### PR TITLE
feat(agent): max_turns / max_cost_usd budget gates + /cost slash

### DIFF
--- a/docs/CATCHUP_PLAN.md
+++ b/docs/CATCHUP_PLAN.md
@@ -1,0 +1,241 @@
+# Octo 追赶 Claude Code 计划
+
+> 与 Claude Code（`/Users/roy.lei/Projects/github/claude-code/src`）功能对账后的差距清单与落地路线。
+> 不追求 1:1 复刻——只补战略性缺口，保住 octo 的差异化（三协议 / 三界面 / Skill-first）。
+> 每完成一项更新本文档对应行的状态。
+
+## 状态总览
+
+| 编号 | 项目 | Issue | 优先级 | 状态 | 估时 |
+|------|------|-------|--------|------|------|
+| P0-1 | LLM 可调度的 `Task`/`Agent` 子代理工具 | [#2](https://github.com/Leihb/octo/issues/2) | P0 | ⬜ todo | 2d |
+| P0-2 | 通用 MCP 客户端（stdio + SSE） | [#3](https://github.com/Leihb/octo/issues/3) | P0 | ⬜ todo | 5d |
+| P0-3 | `settings.yml` 用户可配置 hook | [#4](https://github.com/Leihb/octo/issues/4) | P0 | ⬜ todo | 3d |
+| P0-4 | `max_turns` / `max_cost_usd` 主循环闸门 | [#5](https://github.com/Leihb/octo/issues/5) | P0 | ✅ 2026-05-25 | 1d |
+| P1-1 | 内置子代理预设 explore/plan/verification/general-purpose | [#6](https://github.com/Leihb/octo/issues/6) | P1 | ⬜ todo | 2d |
+| P1-2 | 沙箱执行（命令/网络/路径白名单） | [#7](https://github.com/Leihb/octo/issues/7) | P1 | ⬜ todo | 3d |
+| P1-3 | 高价值内置 slash skill：`/commit` `/review` `/diff` `/compact` `/cost` `/doctor` `/resume` `/status` | [#8](https://github.com/Leihb/octo/issues/8) | P1 | ⬜ todo | 5d |
+| P1-4 | `AskUserQuestion` 升级（多选 / 选项描述 / 预览） | [#9](https://github.com/Leihb/octo/issues/9) | P1 | ⬜ todo | 3d |
+| P2-1 | 输出风格 Output Styles（`~/.octo/output_styles/`） | [#10](https://github.com/Leihb/octo/issues/10) | P2 | ⬜ todo | 2d |
+| P2-2 | 微压缩 micro-compact（按 token 预算截断单条 tool result） | [#11](https://github.com/Leihb/octo/issues/11) | P2 | ⬜ todo | 3d |
+| P2-3 | 项目级 / 团队记忆 `.octo/memories/` + 远端同步 | [#12](https://github.com/Leihb/octo/issues/12) | P2 | ⬜ todo | 5d |
+| P2-4 | 启动并行预热（Session/Provider/Skill 扫描并发） | [#13](https://github.com/Leihb/octo/issues/13) | P2 | ⬜ todo | 1d |
+| P2-5 | `/agents` `/skills` `/tasks` `/permissions` 管理面板（CLI 子菜单） | [#14](https://github.com/Leihb/octo/issues/14) | P2 | ⬜ todo | 3d |
+
+状态图例：⬜ todo / 🟡 in progress / ✅ done / 🚫 skipped
+
+---
+
+## P0 — 影响 LLM 行为上限，必须补
+
+### P0-1. LLM 可调度的 `Task`/`Agent` 子代理工具
+
+**现状**：octo 只能通过 `fork_agent: true` 的 skill 触发子代理（`code-explorer` / `persist-memory` / `recall-memory` / `product-help`）。LLM 不能在对话中直接说"开三个子代理并行调研"。
+
+**对标**：claude-code `tools/AgentTool/AgentTool.ts` + `built-in/{explore,plan,general-purpose,verification,claudeCodeGuide,statuslineSetup}.ts`。
+
+**目标**：
+- 新增 `lib/octo/tools/agent.rb`，参数：`description`（短标题）、`prompt`（任务详述）、`subagent_type?`（预设名）、`tools?`/`forbidden_tools?`（白/黑名单）、`model?`（默认 lite）。
+- 封装现有 `Agent#fork_subagent`，复用 marshal-deep-clone + 缓存共享。
+- 不允许子代理递归调用 Agent 工具（防爆栈），通过 `forbidden_tools` 默认排除自身。
+
+**验收**：用例 `spec/octo/tools/agent_spec.rb` 跑通"主代理调 Agent 工具开子代理 → 子代理只能用白名单工具 → 返回字符串结果合并回主对话"。
+
+---
+
+### P0-2. 通用 MCP 客户端
+
+**现状**：仅 `tools/browser.rb` 一处硬编码 chrome-devtools-mcp（stdio JSON-RPC，daemon 由 `server/browser_manager.rb` 管生命周期）。无法接其他 MCP server。
+
+**对标**：claude-code `services/mcp/` 22 文件（`client.ts` / `MCPConnectionManager.tsx` / `InProcessTransport.ts` / `auth.ts` / SSE+stdio 双 transport）。
+
+**目标**：
+- 抽出 `lib/octo/mcp/`：
+  - `client.rb` — JSON-RPC 2.0 双向流
+  - `registry.rb` — server 实例池
+  - `transports/stdio.rb` — spawn 子进程
+  - `transports/sse.rb` — 远端 SSE
+  - `tool_proxy.rb` — 把发现的 MCP tool 注册成 `Octo::Tools::Base` 子类，命名 `mcp__{server}__{tool}`
+- 配置文件 `~/.octo/mcp_servers.yml`：`command`/`args`/`env`/`url`/`disabled`
+- 启动时拉 tools list；连接失败 fail-open 不阻塞主流程
+- `chrome-devtools-mcp` 改造为新框架下的一个 server entry（去重）
+
+**验收**：能挂 `@modelcontextprotocol/server-filesystem` 和 `@modelcontextprotocol/server-github`，LLM 看见 `mcp__filesystem__*` 工具并能调用。
+
+---
+
+### P0-3. `settings.yml` 用户可配置 hook
+
+**现状**：`agent/hook_manager.rb` 提供 7 个事件（`:before_tool_use` / `:after_tool_use` / `:on_tool_error` / `:on_start` / `:on_complete` / `:on_iteration` / `:session_rollback`），但只能编程注入，外部用户改不到。
+
+**对标**：claude-code `schemas/hooks.ts` + `settings.json` 的 `hooks` 段，shell 命令挂事件。
+
+**目标**：
+- `~/.octo/settings.yml` 新增 `hooks` 段：
+  ```yaml
+  hooks:
+    before_tool_use:
+      - matcher: "terminal"
+        command: "echo $OCTO_TOOL_INPUT >> ~/.octo/audit.log"
+    on_complete:
+      - command: "osascript -e 'display notification \"Octo done\"'"
+  ```
+- 主进程在事件触发时把上下文塞 env，同步/异步 spawn shell 命令
+- 非零退出码默认不阻塞；`block: true` 时阻断该工具调用
+- 项目级 `.octo/settings.yml` 覆盖用户级
+
+**验收**：手写 hook 让 `before_tool_use` 拦截 `terminal` 工具的 `rm -rf *` 调用并退出非零，主代理收到阻断消息。
+
+---
+
+### P0-4. `max_turns` / `max_cost_usd` 主循环闸门
+
+**现状**：`agent.rb:385` 主循环只有 `task_truncation_count >= 3` 兜底，没有显式上限。坏的 LLM 可以无限 tool-loop 烧钱。
+
+**对标**：claude-code `query/tokenBudget.ts` + `QueryEngineConfig.maxTurns/maxBudgetUsd`。
+
+**目标**：
+- `Octo::AgentConfig` 新增 `max_turns`（默认 30）和 `max_cost_usd`（默认 nil=无限）
+- 主循环每 iteration 末判断；超出抛 `Octo::TurnLimitExceeded` / `Octo::CostLimitExceeded`，UI 友好退出
+- `/cost` slash 命令显示当前会话累计 token / 估算成本（按 provider 价目表）
+- CLI 标志 `--max-turns` / `--max-cost`
+
+**验收**：用 `--max-turns 3` 跑一个会反复 tool-loop 的 prompt，第 4 轮被截断并返回明确错误消息。
+
+**完成**：2026-05-25。`AgentConfig#max_turns` 默认 30、`#max_cost_usd` 默认 nil；`Agent#enforce_loop_budget!` 每轮 iteration 顶部检查、抛 `Octo::TurnLimitExceeded` / `Octo::CostLimitExceeded`；`accumulate_session_usage!` 复用现有 `Octo::ModelPricing.calculate_cost` 维护 `@session_token_totals` + `@session_cost_usd`；CLI 加 `--max-turns` / `--max-cost`；TTY + JSON 两条交互路径都接 `/cost` slash。
+
+---
+
+## P1 — 命令面和安全面打底
+
+### P1-1. 内置子代理预设
+
+**依赖**：P0-1。
+
+**目标**：`lib/octo/default_agents/` 下增加：
+- `explore/` — 只读工具白名单（`file_reader` / `glob` / `grep` / `terminal` 限 `ls/cat/find`）
+- `plan/` — 仅 thinking，不允许 `write` / `edit` / `terminal`
+- `verification/` — 读 + 跑测试，禁止 `write` / `edit`
+- `general-purpose/` — 全工具，但 `forbidden_tools: [agent]` 防递归
+
+每个含 `agent.yml`（model、forbidden_tools）+ `system_prompt.md`。
+
+**验收**：Agent 工具传 `subagent_type: "explore"` 时自动应用预设。
+
+---
+
+### P1-2. 沙箱执行
+
+**现状**：`tools/security.rb` 二分"安全/不安全"，颗粒粗。
+
+**对标**：claude-code `BashTool` 的 sandbox prompt 段 + `services/policyLimits/`。
+
+**目标**：
+- `~/.octo/sandbox.yml`：
+  ```yaml
+  filesystem:
+    write_allow: ["/tmp/octo-*", "~/Projects"]
+    write_deny: ["**/.git/**", "**/.env"]
+  network:
+    allowed_hosts: ["api.github.com", "*.anthropic.com"]
+  terminal:
+    deny_commands: ["rm -rf /", "dd if=*"]
+  ```
+- `terminal` / `write` / `edit` 工具在执行前查规则；命中白名单跳过 confirm，命中 deny 直接拒绝
+- `confirm_safes` 模式下，规则覆盖默认问询，减少打断
+
+**验收**：`write` 到 `~/Projects/foo.txt` 在 `confirm_safes` 下不问询；`write` 到 `~/.ssh/config` 被拒。
+
+---
+
+### P1-3. 高价值内置 slash skill
+
+**形态**：纯 SKILL.md，不开新工具，全部走现有 `terminal` / `file_reader` / `grep`。
+
+候选清单（按优先级）：
+- `/commit` — git status → diff → 生成 message（参考 CLAUDE.md 的 commit 风格）→ `git commit`
+- `/review` — 仿 claude-code `commands/review.ts`：列改动 → 三路并发子代理（reuse / quality / efficiency）→ 汇总
+- `/diff` — `git diff` 格式化输出
+- `/compact` — 手动触发 `MessageCompressor`
+- `/cost` — 当前会话 token/cost（需 P0-4）
+- `/doctor` — 检查 provider 可达性、配置完整性、磁盘空间
+- `/resume` — 列最近 5 个 session 让用户选（比 `-c` 显式）
+- `/status` — provider/model/mode/cwd 一屏
+
+**验收**：用户在交互模式输入 `/commit`，skill 自动跑完一次提交流程。
+
+---
+
+### P1-4. `AskUserQuestion` 升级
+
+**现状**：`request_user_feedback` 是单问，UI 简单。
+
+**对标**：claude-code `AskUserQuestionTool`（2-4 options，multiSelect，per-option description/preview/notes）。
+
+**目标**：
+- 新增 `Octo::Tools::AskUserQuestion`（与 `request_user_feedback` 并存或替代），参数：`questions[]`，每个含 `question` / `header`（≤12 字符 chip）/ `options[]`（label/description/preview）/ `multiSelect`
+- Web UI `format_result_for_ui` 渲染卡片：左边选项列表、右边 preview（仅单选）
+- IM 适配器降级为编号文本菜单
+- CLI 用 tty-prompt 多选
+
+**验收**：LLM 在歧义点发"实现方式 A vs B vs C"卡片，三界面（CLI/Web/IM）都能正常作答。
+
+---
+
+## P2 — 体验细节，可挑着做
+
+### P2-1. 输出风格 Output Styles
+- `~/.octo/output_styles/<name>.md`（frontmatter `description`）+ `/output-style <name>` 切换
+- 选中后注入到 `SystemPromptBuilder` 末尾
+- 内置三档：`default` / `terse` / `educational`
+
+### P2-2. 微压缩
+- 按 token 预算截断单条 tool result（特别是 `file_reader` 读大文件、`grep` 海量匹配）
+- 不重写整段历史，仅压缩单条 `:content`
+- 对标 `services/compact/microCompact.ts`
+
+### P2-3. 项目级 / 团队记忆
+- 新增 `.octo/memories/`（项目级，可入 git）
+- `SystemPromptBuilder` 分层 merge：built-in < user < project
+- 可选 `octo memory sync` 命令推到远端（CEG 知识库 / GitHub repo）
+
+### P2-4. 启动并行预热
+- `Octo::CLI.start` 入口并发跑：`SessionManager.scan` / `Providers.resolve` / `SkillLoader.scan` / `MemoryUpdater.metadata`
+- 用 `Thread` + `Concurrent::Future`，注意线程安全（`@state_mutex` 等）
+- 仅在测量启动时间 > 1s 时投入
+
+### P2-5. 管理面板 slash 命令
+- `/agents` `/skills` `/tasks` `/permissions` 进入子菜单（CLI 走 tty-prompt，Web UI 跳路由）
+- 多数 `/api` 后端已有，主要是 UX 打包
+
+---
+
+## P3 — 战略上不追
+
+| 项目 | 理由 |
+|------|------|
+| 自己 fork Ink 渲染器 | `ui2` 已够用，TUI 不是瓶颈 |
+| vim mode / voice mode / desktop sprite | 受众小，ROI 低 |
+| IDE 桥接（`bridge/` JWT+trusted-device） | octo 走 IM-first；要 IDE 集成走"octo 当 MCP server"路线更优雅 |
+| 插件 marketplace | 先把 skill 生态做厚；`skill-add` 已支持 zip URL 安装 |
+| `migrations/` 框架 | 量级未到 |
+| `coordinator/` 多代理协调 | 超前需求 |
+| 组织策略限位 `policyLimits` | to-B 需求，先 to-D |
+
+---
+
+## 不要为追赶而冲掉的差异化
+
+1. **三协议原生**（Anthropic Messages / OpenAI Chat+Responses / Bedrock Converse 平等头等公民）——不要让新功能只在 Anthropic 路径跑通。
+2. **三界面平等**（CLI / Web UI / IM）——新工具必带 `format_result_for_ui` 和 IM 文本回退。
+3. **Skill-first 哲学**（`.octorules` 明文）——能用 skill 解决就别新增 Ruby Tool。
+
+---
+
+## 更新规则
+
+每一项对应一个 GitHub issue（见状态表 Issue 列）。完成一项后：
+1. PR / commit message 写 `Closes #<n>` 让 GitHub 自动关 issue
+2. 把状态总览表对应行从 ⬜ 改成 ✅，加完成日期
+3. 在该项小节末尾追加 `**完成**：日期 / commit hash / 关键决策记录`
+4. 如果实施中发现需要拆分，在状态表新增子项（如 `P0-2a` / `P0-2b`）并各建一个 sub-issue 链回母 issue

--- a/lib/octo.rb
+++ b/lib/octo.rb
@@ -141,5 +141,9 @@ module Octo
   class UpstreamTruncatedError < RetryableError; end
   class ToolCallError < AgentError; end  # Raised when tool call fails due to invalid parameters
   class BrowserNotReachableError < AgentError; end  # Chrome/Edge not running or remote debugging disabled
+  # Raised when the agent main loop exceeds the configured turn budget for a single task.
+  class TurnLimitExceeded < AgentError; end
+  # Raised when the agent main loop exceeds the configured cumulative cost budget for the session.
+  class CostLimitExceeded < AgentError; end
   # BrowserManager singleton: Octo::BrowserManager.instance
 end

--- a/lib/octo/agent.rb
+++ b/lib/octo/agent.rb
@@ -45,7 +45,8 @@ module Octo
                 :cache_stats, :ui, :skill_loader, :agent_profile,
                 :status, :error, :updated_at, :source,
                 :latest_latency,  # Hash of latency metrics from the most recent LLM call (see Client#send_messages_with_tools)
-                :reasoning_effort
+                :reasoning_effort,
+                :session_token_totals, :session_cost_usd
     attr_accessor :pinned
 
     REASONING_EFFORTS = %w[low medium high].freeze
@@ -93,6 +94,18 @@ module Octo
       @created_at = Time.now.iso8601
       @total_tasks = 0
       @previous_total_tokens = 0  # Track tokens from previous iteration for delta calculation
+
+      # Session-level cumulative usage. Accumulators are bumped after every
+      # successful LLM response so /cost and the max_cost_usd gate have one
+      # source of truth. Token totals work for all providers; cost is best-
+      # effort and stays at 0.0 when the active model isn't priced.
+      @session_token_totals = {
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0
+      }
+      @session_cost_usd = 0.0
       @latest_latency = nil  # Most recent LLM call's latency metrics (see Client#send_messages_with_tools)
       @reasoning_effort = nil  # Per-session reasoning effort override; nil = provider default
       @ui = ui  # UIController for direct UI interaction
@@ -386,6 +399,12 @@ module Octo
           @iterations += 1
           @hooks.trigger(:on_iteration, @iterations)
 
+          # Budget gates: enforce per-task turn count and session cumulative
+          # cost. Both are configured on AgentConfig. Raising here exits the
+          # loop through the existing rescue path, producing a friendly UI
+          # error and a checkpointed session.
+          enforce_loop_budget!
+
           # Drain any inbox items (queued user messages) since the last
           # iteration. Without this, items sit in the queue until the WHOLE
           # run completes — latency drops from "minutes" to "one LLM turn".
@@ -397,7 +416,10 @@ module Octo
 
           # Think: LLM reasoning with tool support
           response = think
-          @last_token_usage = response[:token_usage] if response && response[:token_usage]
+          if response && response[:token_usage]
+            @last_token_usage = response[:token_usage]
+            accumulate_session_usage!(response[:token_usage])
+          end
 
           # Debug: check for potential infinite loops
           if @config.verbose
@@ -754,6 +776,56 @@ module Octo
     # run loop's "LLM said done — but should we really break?" check.
     private def inbox_pending?
       @state_mutex.synchronize { !@inbox.empty? }
+    end
+
+    # Raise if the current task has exceeded max_turns, or the session has
+    # exceeded max_cost_usd. Called at the top of every loop iteration so the
+    # guard fires BEFORE the next think() (preventing one more billed call).
+    private def enforce_loop_budget!
+      task_turns = @iterations - (@task_start_iterations || 0)
+      max_turns = @config.max_turns
+      if max_turns && max_turns.positive? && task_turns > max_turns
+        raise Octo::TurnLimitExceeded,
+              "Task exceeded max_turns budget (#{task_turns} > #{max_turns}). " \
+              "Adjust with --max-turns or AgentConfig#max_turns."
+      end
+
+      max_cost = @config.max_cost_usd
+      if max_cost && max_cost.positive? && @session_cost_usd >= max_cost
+        raise Octo::CostLimitExceeded,
+              format("Session cost $%.4f exceeded budget $%.4f. " \
+                     "Adjust with --max-cost or AgentConfig#max_cost_usd.",
+                     @session_cost_usd, max_cost)
+      end
+    end
+
+    # Add a single LLM response's usage into the session totals and cost.
+    # Cost rolls forward only when the active model has a known price; for
+    # unpriced models the token totals still update so /cost remains useful.
+    # Delegates pricing to Octo::ModelPricing so all USD math goes through
+    # one source of truth (tiered rates, cache surcharges, normalization).
+    private def accumulate_session_usage!(usage)
+      return unless usage.is_a?(Hash)
+
+      @session_token_totals[:prompt_tokens] += usage[:prompt_tokens].to_i
+      @session_token_totals[:completion_tokens] += usage[:completion_tokens].to_i
+      @session_token_totals[:cache_creation_input_tokens] += usage[:cache_creation_input_tokens].to_i
+      @session_token_totals[:cache_read_input_tokens] += usage[:cache_read_input_tokens].to_i
+
+      result = Octo::ModelPricing.calculate_cost(
+        model: current_model_name_for_pricing,
+        usage: usage
+      )
+      @session_cost_usd += result[:cost] if result && result[:cost]
+    end
+
+    # The model name to consult when pricing the most recent LLM call. Uses
+    # effective_model_name so fallbacks are priced against their actual model,
+    # not the configured primary.
+    private def current_model_name_for_pricing
+      @config.effective_model_name
+    rescue StandardError
+      @config.model_name
     end
 
     # Public: count of pending :user_msg items in the inbox.

--- a/lib/octo/agent_config.rb
+++ b/lib/octo/agent_config.rb
@@ -157,7 +157,8 @@ module Octo
                   :memory_update_enabled, :skill_evolution,
                   :next_message_suggestion_enabled,
                   :max_running_agents, :max_idle_agents,
-                  :default_working_dir
+                  :default_working_dir,
+                  :max_turns, :max_cost_usd
 
     def initialize(options = {})
       @permission_mode = validate_permission_mode(options[:permission_mode])
@@ -203,6 +204,13 @@ module Octo
       @max_idle_agents = options[:max_idle_agents] || 10
 
       @default_working_dir = options[:default_working_dir] || ENV["OCTO_WORKSPACE_DIR"]
+
+      # Loop budget guards. Both opt-in by configuration but max_turns has a
+      # sane default of 30 to catch runaway tool loops; max_cost_usd defaults
+      # to nil (unlimited) because cost gating requires a priced model and we
+      # don't want to surprise users who run on self-hosted endpoints.
+      @max_turns = options.key?(:max_turns) ? options[:max_turns] : 30
+      @max_cost_usd = options[:max_cost_usd]
 
       # Per-session virtual model overlay.
       # When set, #current_model returns a *merged* hash (the resolved @models
@@ -380,6 +388,7 @@ module Octo
       next_message_suggestion_enabled
       skill_evolution max_running_agents max_idle_agents
       default_working_dir
+      max_turns max_cost_usd
     ].freeze
 
     # Serialize the current agent configuration to YAML.
@@ -397,7 +406,9 @@ module Octo
         "skill_evolution" => @skill_evolution,
         "max_running_agents" => @max_running_agents,
         "max_idle_agents" => @max_idle_agents,
-        "default_working_dir" => @default_working_dir
+        "default_working_dir" => @default_working_dir,
+        "max_turns" => @max_turns,
+        "max_cost_usd" => @max_cost_usd
       }
       YAML.dump("settings" => settings, "models" => persistable_models)
     end

--- a/lib/octo/cli.rb
+++ b/lib/octo/cli.rb
@@ -57,6 +57,8 @@ module Octo
     option :image, type: :array, aliases: "-i", desc: "Image file path(s) to attach (alias for --file, kept for compatibility)"
     option :agent, type: :string, default: "coding", desc: "Agent profile to use: coding, general, or any custom profile name (default: coding)"
     option :model, type: :string, desc: "Override the model to use (by name, e.g. gpt-5.3-codex or deepseek-v4-pro). Uses default model if not specified"
+    option :max_turns, type: :numeric, desc: "Per-task turn budget. Aborts the run when the LLM keeps tool-looping past this number (default: 30, 0 disables)."
+    option :max_cost, type: :numeric, desc: "Session USD budget. Aborts the run once cumulative cost exceeds this number (unlimited by default)."
     option :help, type: :boolean, aliases: "-h", desc: "Show this help message"
     def agent
       # Handle help option
@@ -101,6 +103,8 @@ module Octo
       # Update agent config with CLI options
       agent_config.permission_mode = options[:mode].to_sym if options[:mode]
       agent_config.verbose = options[:verbose] if options[:verbose]
+      agent_config.max_turns = options[:max_turns].to_i if options[:max_turns]
+      agent_config.max_cost_usd = options[:max_cost].to_f if options[:max_cost]
 
       # Client factory: produces a fresh Client reflecting the *current*
       # state of agent_config each time it's called. The CLI never holds a
@@ -338,6 +342,26 @@ module Octo
       private def format_number(num)
         return "0" if num.nil? || num == 0
         num.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
+      end
+
+      # Human-readable summary of session token usage and estimated USD cost.
+      # Used by the /cost slash command across UI / JSON / TTY paths.
+      private def format_cost_summary(agent)
+        totals = agent.session_token_totals
+        cost = agent.session_cost_usd
+        model = agent.current_model_info&.dig(:model)
+        priced = !Octo::ModelPricing.normalize_model_name(model.to_s).nil?
+        cost_str = priced ? format("$%.4f", cost) : "n/a (model not in price table)"
+        lines = []
+        lines << "Session usage:"
+        lines << "  prompt tokens     #{format_number(totals[:prompt_tokens])}"
+        lines << "  completion tokens #{format_number(totals[:completion_tokens])}"
+        if totals[:cache_creation_input_tokens].positive? || totals[:cache_read_input_tokens].positive?
+          lines << "  cache write       #{format_number(totals[:cache_creation_input_tokens])}"
+          lines << "  cache read        #{format_number(totals[:cache_read_input_tokens])}"
+        end
+        lines << "  estimated cost    #{cost_str}"
+        lines.join("\n")
       end
 
       # Auto-name a CLI session from the first user message, mirroring server-side logic.
@@ -579,6 +603,9 @@ module Octo
               agent.instance_variable_set(:@ui, json_ui)
               json_ui.emit("info", message: "Session cleared. Starting fresh.")
               next
+            when "/cost"
+              json_ui.emit("info", message: format_cost_summary(agent))
+              next
             end
 
             files = input["files"] || []
@@ -762,6 +789,9 @@ module Octo
           when "/help"
             sleep 0.1
             ui_controller.show_help
+            next
+          when "/cost"
+            ui_controller.show_info(format_cost_summary(agent))
             next
           end
 

--- a/spec/octo/agent_loop_budget_spec.rb
+++ b/spec/octo/agent_loop_budget_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+RSpec.describe Octo::Agent, "loop budget gates" do
+  let(:client) do
+    instance_double(Octo::Client).tap do |c|
+      c.instance_variable_set(:@api_key, "test-api-key")
+    end
+  end
+
+  def build_agent(max_turns: nil, max_cost_usd: nil)
+    config = Octo::AgentConfig.new(
+      permission_mode: :auto_approve,
+      max_turns: max_turns,
+      max_cost_usd: max_cost_usd
+    )
+    config.add_model(
+      model: "claude-sonnet-4-5",
+      api_key: "test-api-key",
+      base_url: "https://api.anthropic.com"
+    )
+    described_class.new(
+      client, config,
+      working_dir: Dir.pwd,
+      ui: nil,
+      profile: "coding",
+      session_id: Octo::SessionManager.generate_id,
+      source: :manual
+    )
+  end
+
+  describe "AgentConfig" do
+    it "defaults max_turns to 30 and max_cost_usd to nil" do
+      cfg = Octo::AgentConfig.new
+      expect(cfg.max_turns).to eq(30)
+      expect(cfg.max_cost_usd).to be_nil
+    end
+
+    it "honors explicit nil max_turns (no limit)" do
+      cfg = Octo::AgentConfig.new(max_turns: nil)
+      expect(cfg.max_turns).to be_nil
+    end
+
+    it "persists max_turns and max_cost_usd through to_yaml" do
+      cfg = Octo::AgentConfig.new(max_turns: 10, max_cost_usd: 2.5)
+      yaml = cfg.to_yaml
+      expect(yaml).to include("max_turns: 10")
+      expect(yaml).to include("max_cost_usd: 2.5")
+    end
+  end
+
+  describe "#accumulate_session_usage!" do
+    it "rolls token counts and USD cost into session totals" do
+      agent = build_agent
+      agent.send(:accumulate_session_usage!, {
+        prompt_tokens: 100_000,
+        completion_tokens: 50_000,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0
+      })
+
+      expect(agent.session_token_totals[:prompt_tokens]).to eq(100_000)
+      expect(agent.session_token_totals[:completion_tokens]).to eq(50_000)
+      # Sonnet 4.5 default tier: $3 input + $15 output per 1M.
+      # 100k @ $3 + 50k @ $15 = $0.30 + $0.75 = $1.05
+      expect(agent.session_cost_usd).to be_within(0.001).of(1.05)
+    end
+
+    it "leaves cost at 0 when the model is not priced" do
+      agent = build_agent
+      allow(agent).to receive(:current_model_name_for_pricing).and_return("self-hosted-llama")
+      agent.send(:accumulate_session_usage!, {
+        prompt_tokens: 1_000_000,
+        completion_tokens: 1_000_000
+      })
+      expect(agent.session_cost_usd).to eq(0.0)
+      expect(agent.session_token_totals[:prompt_tokens]).to eq(1_000_000)
+    end
+  end
+
+  describe "#enforce_loop_budget!" do
+    it "raises TurnLimitExceeded once task turns exceed the budget" do
+      agent = build_agent(max_turns: 3)
+      agent.instance_variable_set(:@task_start_iterations, 0)
+      agent.instance_variable_set(:@iterations, 4)
+      expect {
+        agent.send(:enforce_loop_budget!)
+      }.to raise_error(Octo::TurnLimitExceeded, /max_turns/)
+    end
+
+    it "stays silent when within the turn budget" do
+      agent = build_agent(max_turns: 3)
+      agent.instance_variable_set(:@task_start_iterations, 0)
+      agent.instance_variable_set(:@iterations, 3)
+      expect { agent.send(:enforce_loop_budget!) }.not_to raise_error
+    end
+
+    it "raises CostLimitExceeded once session cost passes the budget" do
+      agent = build_agent(max_cost_usd: 0.10)
+      agent.instance_variable_set(:@session_cost_usd, 0.25)
+      expect {
+        agent.send(:enforce_loop_budget!)
+      }.to raise_error(Octo::CostLimitExceeded, /\$0\.25/)
+    end
+
+    it "does not gate cost when max_cost_usd is unset" do
+      agent = build_agent
+      agent.instance_variable_set(:@session_cost_usd, 99.0)
+      expect { agent.send(:enforce_loop_budget!) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `AgentConfig` gains `max_turns` (default 30) and `max_cost_usd` (default nil); both persist through `to_yaml`.
- `Agent#enforce_loop_budget!` runs at the top of every iteration before `think()`, raising `Octo::TurnLimitExceeded` / `Octo::CostLimitExceeded` through the existing rescue path for friendly UI exit.
- Session usage accumulates in `@session_token_totals` + `@session_cost_usd` via the existing `Octo::ModelPricing.calculate_cost` (one source of truth for cost math).
- CLI: `--max-turns` / `--max-cost` flags on `octo agent`; `/cost` slash command across TTY (ui2) and JSON (--json) interactive paths.
- Adds `docs/CATCHUP_PLAN.md` — the 13-issue Claude Code parity tracker (this is item P0-4).

Closes #5

## Test plan
- [x] `bundle exec rspec spec/octo/agent_loop_budget_spec.rb` — 9 examples
- [x] `bundle exec rspec` — 1969/1970 (one unrelated flaky terminal-concurrency test that passes in isolation)
- [x] `bundle exec ruby bin/octo help agent` shows new flags
- [ ] Manual: launch agent, type `/cost`, confirm token + cost summary
- [ ] Manual: run with `--max-turns 3` against a tool-loop prompt, confirm 4th turn aborts with friendly error

🤖 Generated with [Claude Code](https://claude.com/claude-code)