### PR TITLE
feat(tools): LLM-callable agent tool for sub-agent dispatch

### DIFF
--- a/dev-docs/CATCHUP_PLAN.md
+++ b/dev-docs/CATCHUP_PLAN.md
@@ -8,7 +8,7 @@
 
 | 编号 | 项目 | Issue | 优先级 | 状态 | 估时 |
 |------|------|-------|--------|------|------|
-| P0-1 | LLM 可调度的 `Task`/`Agent` 子代理工具 | [#2](https://github.com/Leihb/octo/issues/2) | P0 | ⬜ todo | 2d |
+| P0-1 | LLM 可调度的 `Task`/`Agent` 子代理工具 | [#2](https://github.com/Leihb/octo/issues/2) | P0 | ✅ 2026-05-25 | 2d |
 | P0-2 | 通用 MCP 客户端（stdio + SSE） | [#3](https://github.com/Leihb/octo/issues/3) | P0 | ⬜ todo | 5d |
 | P0-3 | `settings.yml` 用户可配置 hook | [#4](https://github.com/Leihb/octo/issues/4) | P0 | ⬜ todo | 3d |
 | P0-4 | `max_turns` / `max_cost_usd` 主循环闸门 | [#5](https://github.com/Leihb/octo/issues/5) | P0 | ✅ 2026-05-25 | 1d |
@@ -40,6 +40,8 @@
 - 不允许子代理递归调用 Agent 工具（防爆栈），通过 `forbidden_tools` 默认排除自身。
 
 **验收**：用例 `spec/octo/tools/agent_spec.rb` 跑通"主代理调 Agent 工具开子代理 → 子代理只能用白名单工具 → 返回字符串结果合并回主对话"。
+
+**完成**：2026-05-25。`lib/octo/tools/agent.rb` 通过 `Octo::Agent#fork_subagent` 封装；参数 `description` / `prompt` / `subagent_type?`（P1-1 占位）/ `tools?` 白名单 / `forbidden_tools?` 黑名单 / `model?`（默认 `lite`）；白名单内部转成"全工具集 - 白名单"的黑名单注入到现有 `before_tool_use` hook；默认 `forbidden_tools` 含 `agent` 自身防递归。子代理结束后 token / USD cost 通过私有 `absorb_session_usage` 合并到父代理的 P0-4 累计器，`/cost` 和 `max_cost_usd` 看到的是完整账单。Spec `spec/octo/tools/agent_tool_spec.rb` 17 个 example。
 
 ---
 

--- a/lib/octo.rb
+++ b/lib/octo.rb
@@ -122,6 +122,7 @@ require_relative "octo/tools/redo_task"
 require_relative "octo/tools/list_tasks"
 require_relative "octo/tools/browser"
 require_relative "octo/tools/terminal"
+require_relative "octo/tools/agent"
 require_relative "octo/agent"
 
 require_relative "octo/server/session_registry"

--- a/lib/octo/agent.rb
+++ b/lib/octo/agent.rb
@@ -1442,6 +1442,12 @@ module Octo
             args[:agent] = self
           end
 
+          # Sub-agent tool needs access to fork_subagent and the parent
+          # tool registry (for allowlist→denylist resolution).
+          if call[:name] == "agent"
+            args[:agent] = self
+          end
+
           # Inject working_dir so tools don't rely on Dir.chdir global state
           args[:working_dir] = @working_dir if @working_dir
 
@@ -1687,6 +1693,7 @@ module Octo
       @tool_registry.register(Tools::RedoTask.new)
       @tool_registry.register(Tools::ListTasks.new)
       @tool_registry.register(Tools::Browser.new)
+      @tool_registry.register(Tools::Agent.new)
     end
 
     # Fork a subagent with specified configuration

--- a/lib/octo/tools/agent.rb
+++ b/lib/octo/tools/agent.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+module Octo
+  module Tools
+    # Spawns a forked sub-agent to handle an isolated sub-task.
+    #
+    # This is the LLM-facing entry to Octo's existing fork_subagent
+    # infrastructure: the parent agent describes a task, the sub-agent runs
+    # autonomously against its own copy of history (with optional tool
+    # restrictions and a different model), and returns a summary string.
+    #
+    # Sub-agents inherit:
+    #   - All tool definitions (for prompt-cache reuse)
+    #   - A deep clone of the parent's history
+    #   - The same working_dir, agent profile, and source channel
+    #
+    # Sub-agents do NOT inherit the ability to call this very tool — the
+    # default forbidden_tools includes `agent` itself, blocking infinite
+    # recursion. Callers can extend the denylist but cannot disable the
+    # self-block.
+    class Agent < Base
+      self.tool_name = "agent"
+      self.tool_description = <<~DESC.strip
+        Launch a new sub-agent to handle complex, multi-step tasks in isolation.
+
+        Use this when you need to:
+        - Run independent research that would clutter the main conversation
+        - Parallelize work that can be split into self-contained sub-tasks
+        - Verify code changes with a fresh perspective (no context contamination)
+        - Constrain a sub-task to a smaller toolset (e.g. read-only exploration)
+
+        Brief the sub-agent like a colleague who just walked in: include the goal,
+        what is already known, what's in scope, and what success looks like. The
+        sub-agent cannot ask follow-up questions of the parent — its result
+        comes back as a single tool result string.
+
+        Defaults to the lite model for cost; pass `model: "default"` for primary.
+        Recursion is blocked: a sub-agent cannot itself call `agent`.
+      DESC
+      self.tool_category = "subagent"
+      self.tool_parameters = {
+        type: "object",
+        properties: {
+          description: {
+            type: "string",
+            description: "Short 3-5 word label shown to the user while the sub-agent runs (e.g. 'Audit auth flow')"
+          },
+          prompt: {
+            type: "string",
+            description: "Self-contained task brief for the sub-agent: goal, context, constraints, what success looks like"
+          },
+          subagent_type: {
+            type: "string",
+            description: "Optional preset name from default_agents/ (reserved for P1-1; ignored today)"
+          },
+          tools: {
+            type: "array",
+            items: { type: "string" },
+            description: "Optional allowlist of tool names; all other tools become forbidden in the sub-agent (the `agent` tool itself is always forbidden)"
+          },
+          forbidden_tools: {
+            type: "array",
+            items: { type: "string" },
+            description: "Optional denylist merged with the default `agent` self-block"
+          },
+          model: {
+            type: "string",
+            description: "Model role: `lite` (default, cheap) | `default` (primary) | a configured model name"
+          }
+        },
+        required: %w[description prompt]
+      }
+
+      # Execute the sub-agent task.
+      #
+      # @param description [String] short label for UI
+      # @param prompt [String] task brief delivered as the sub-agent's user turn
+      # @param subagent_type [String, nil] preset name (P1-1 hook; ignored today)
+      # @param tools [Array<String>, nil] allowlist of tool names
+      # @param forbidden_tools [Array<String>, nil] explicit denylist
+      # @param model [String] model role / name (default: "lite")
+      # @param agent [Octo::Agent] injected by the dispatcher
+      # @param working_dir [String, nil] injected by the dispatcher (unused; here for parity)
+      # @return [String, Hash] sub-agent summary on success, error hash on misuse
+      def execute(description:, prompt:, subagent_type: nil, tools: nil,
+                  forbidden_tools: nil, model: "lite", agent: nil, working_dir: nil)
+        _ = working_dir  # accepted but unused — sub-agent inherits parent's working_dir
+        _ = subagent_type  # reserved for P1-1 preset loading
+        return { error: "Agent context is required" } unless agent
+        return { error: "description is required" } if description.to_s.strip.empty?
+        return { error: "prompt is required" } if prompt.to_s.strip.empty?
+
+        effective_forbidden = resolve_forbidden(agent, tools: tools, forbidden_tools: forbidden_tools)
+
+        subagent = agent.fork_subagent(
+          model: model,
+          forbidden_tools: effective_forbidden,
+          system_prompt_suffix: build_subagent_brief(description)
+        )
+
+        agent.ui&.show_info(
+          "Sub-agent start: #{description} [#{subagent.current_model_info&.dig(:model)}]"
+        )
+
+        begin
+          subagent.run(prompt)
+        rescue Octo::AgentInterrupted
+          # Bubble up so the parent loop exits cleanly too.
+          raise
+        end
+
+        summary = agent.send(:generate_subagent_summary, subagent)
+
+        # Roll the sub-agent's token + cost into the parent's session totals
+        # so /cost and max_cost_usd see the full bill for the user request.
+        absorb_session_usage(agent, subagent)
+
+        agent.ui&.show_info("Sub-agent done: #{description} (#{subagent.iterations} iterations)")
+
+        summary
+      end
+
+      # @param args [Hash]
+      # @return [String]
+      def format_call(args)
+        desc = args[:description] || args["description"]
+        "Agent(#{desc})"
+      end
+
+      # @param result [Object]
+      # @return [String]
+      def format_result(result)
+        if result.is_a?(Hash) && result[:error]
+          "Error: #{result[:error]}"
+        elsif result.is_a?(String)
+          first_line = result.lines.first.to_s.strip
+          first_line.length > 120 ? "#{first_line[0..117]}..." : first_line
+        else
+          "Sub-agent finished"
+        end
+      end
+
+      private def resolve_forbidden(agent, tools:, forbidden_tools:)
+        denylist = Array(forbidden_tools).map(&:to_s)
+
+        if tools && !Array(tools).empty?
+          # Allowlist takes precedence: forbid everything not on the list.
+          # Plain Array#include? avoids a Set require on Ruby 2.6 (CI matrix).
+          allow = Array(tools).map(&:to_s)
+          all_names = agent.instance_variable_get(:@tool_registry).all.map(&:name)
+          all_names.each do |name|
+            denylist << name unless allow.include?(name)
+          end
+        end
+
+        # Always block self-recursion.
+        denylist << self.class.tool_name unless denylist.include?(self.class.tool_name)
+        denylist.uniq
+      end
+
+      private def build_subagent_brief(description)
+        <<~BRIEF.strip
+          You have been spawned by the parent agent to handle this sub-task: #{description}
+
+          Work autonomously. You cannot ask follow-up questions of the parent — your
+          response must be self-contained. When you finish (i.e. stop calling tools
+          and produce a final response), your output will be summarized and handed
+          back to the parent as a tool result.
+        BRIEF
+      end
+
+      private def absorb_session_usage(parent, subagent)
+        return unless parent && subagent
+        parent_totals = parent.session_token_totals
+        sub_totals = subagent.session_token_totals
+        parent_totals[:prompt_tokens] += sub_totals[:prompt_tokens]
+        parent_totals[:completion_tokens] += sub_totals[:completion_tokens]
+        parent_totals[:cache_creation_input_tokens] += sub_totals[:cache_creation_input_tokens]
+        parent_totals[:cache_read_input_tokens] += sub_totals[:cache_read_input_tokens]
+        parent.instance_variable_set(
+          :@session_cost_usd,
+          parent.session_cost_usd + subagent.session_cost_usd
+        )
+      end
+    end
+  end
+end

--- a/spec/octo/tools/agent_tool_spec.rb
+++ b/spec/octo/tools/agent_tool_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+RSpec.describe Octo::Tools::Agent do
+  let(:tool) { described_class.new }
+
+  describe "tool metadata" do
+    it "registers under wire name 'agent'" do
+      expect(described_class.tool_name).to eq("agent")
+    end
+
+    it "advertises description, prompt as required parameters" do
+      expect(described_class.tool_parameters[:required]).to match_array(%w[description prompt])
+    end
+
+    it "lives in the subagent category" do
+      expect(described_class.tool_category).to eq("subagent")
+    end
+  end
+
+  describe "#execute argument validation" do
+    it "errors when no agent is injected" do
+      expect(tool.execute(description: "x", prompt: "y")).to eq({ error: "Agent context is required" })
+    end
+
+    it "errors on blank description" do
+      agent = instance_double(Octo::Agent)
+      expect(tool.execute(description: "  ", prompt: "y", agent: agent)).to eq({ error: "description is required" })
+    end
+
+    it "errors on blank prompt" do
+      agent = instance_double(Octo::Agent)
+      expect(tool.execute(description: "x", prompt: "", agent: agent)).to eq({ error: "prompt is required" })
+    end
+  end
+
+  describe "#execute success path" do
+    let(:registry) do
+      reg = Octo::ToolRegistry.new
+      [Octo::Tools::FileReader, Octo::Tools::Grep, Octo::Tools::Write,
+       Octo::Tools::Edit, Octo::Tools::Terminal, described_class].each do |klass|
+        instance = klass == Octo::Tools::Terminal ? klass.new(agent_session_id: "test") : klass.new
+        reg.register(instance)
+      end
+      reg
+    end
+
+    let(:subagent) do
+      sub = instance_double(Octo::Agent,
+        iterations: 4,
+        current_model_info: { model: "claude-haiku-4-5" },
+        session_token_totals: {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0
+        },
+        session_cost_usd: 0.0012
+      )
+      allow(sub).to receive(:run).and_return(status: :success)
+      sub
+    end
+
+    let(:agent) do
+      a = instance_double(Octo::Agent,
+        ui: nil,
+        session_token_totals: {
+          prompt_tokens: 200,
+          completion_tokens: 100,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0
+        },
+        session_cost_usd: 0.005
+      )
+      a.instance_variable_set(:@tool_registry, registry)
+      allow(a).to receive(:instance_variable_get).with(:@tool_registry).and_return(registry)
+      allow(a).to receive(:instance_variable_set)
+      allow(a).to receive(:fork_subagent).and_return(subagent)
+      allow(a).to receive(:send).with(:generate_subagent_summary, subagent).and_return("done!")
+      a
+    end
+
+    it "forks with the lite model and runs the prompt" do
+      expect(agent).to receive(:fork_subagent).with(
+        model: "lite",
+        forbidden_tools: ["agent"],
+        system_prompt_suffix: a_string_including("do research")
+      ).and_return(subagent)
+
+      result = tool.execute(description: "do research", prompt: "explore feature X", agent: agent)
+      expect(result).to eq("done!")
+    end
+
+    it "blocks recursion by default (forbidden_tools includes 'agent')" do
+      captured_forbidden = nil
+      allow(agent).to receive(:fork_subagent) do |**kw|
+        captured_forbidden = kw[:forbidden_tools]
+        subagent
+      end
+
+      tool.execute(description: "x", prompt: "y", agent: agent)
+      expect(captured_forbidden).to include("agent")
+    end
+
+    it "merges caller-provided forbidden_tools with the default self-block" do
+      captured_forbidden = nil
+      allow(agent).to receive(:fork_subagent) do |**kw|
+        captured_forbidden = kw[:forbidden_tools]
+        subagent
+      end
+
+      tool.execute(description: "x", prompt: "y", agent: agent,
+                   forbidden_tools: ["terminal", "edit"])
+      expect(captured_forbidden).to include("agent", "terminal", "edit")
+    end
+
+    it "converts tools allowlist into a denylist of everything else" do
+      captured_forbidden = nil
+      allow(agent).to receive(:fork_subagent) do |**kw|
+        captured_forbidden = kw[:forbidden_tools]
+        subagent
+      end
+
+      tool.execute(description: "x", prompt: "y", agent: agent,
+                   tools: ["file_reader", "grep"])
+      # Should forbid every registered tool except file_reader and grep,
+      # plus the always-on 'agent' self-block.
+      expect(captured_forbidden).to include("write", "edit", "terminal", "agent")
+      expect(captured_forbidden).not_to include("file_reader", "grep")
+    end
+
+    it "absorbs subagent token totals into the parent" do
+      tool.execute(description: "x", prompt: "y", agent: agent)
+      totals = agent.session_token_totals
+      expect(totals[:prompt_tokens]).to eq(300)       # 200 + 100
+      expect(totals[:completion_tokens]).to eq(150)   # 100 + 50
+    end
+
+    it "absorbs subagent USD cost into the parent" do
+      expect(agent).to receive(:instance_variable_set).with(:@session_cost_usd, 0.005 + 0.0012)
+      tool.execute(description: "x", prompt: "y", agent: agent)
+    end
+
+    it "passes a unique model when caller specifies one" do
+      expect(agent).to receive(:fork_subagent).with(
+        hash_including(model: "claude-opus-4-1")
+      ).and_return(subagent)
+
+      tool.execute(description: "x", prompt: "y", agent: agent, model: "claude-opus-4-1")
+    end
+
+    it "lets AgentInterrupted bubble up" do
+      allow(subagent).to receive(:run).and_raise(Octo::AgentInterrupted)
+      expect {
+        tool.execute(description: "x", prompt: "y", agent: agent)
+      }.to raise_error(Octo::AgentInterrupted)
+    end
+  end
+
+  describe "#format_call" do
+    it "renders the description in parens" do
+      expect(tool.format_call(description: "investigate auth")).to eq("Agent(investigate auth)")
+    end
+  end
+
+  describe "#format_result" do
+    it "prefixes errors" do
+      expect(tool.format_result({ error: "nope" })).to eq("Error: nope")
+    end
+
+    it "shows the first line of a string result" do
+      expect(tool.format_result("Done in 4 iterations\nDetails...")).to eq("Done in 4 iterations")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Exposes `Agent#fork_subagent` to the LLM via a new `agent` tool, so the model can spawn sub-agents on its own (parallel research, scoped exploration, verification) instead of relying only on `SkillManager`'s code-path forks.

- `lib/octo/tools/agent.rb` (new) — wire name `agent`, params `description` / `prompt` / `subagent_type?` / `tools?` / `forbidden_tools?` / `model?`. `model` defaults to `lite`.
- Allowlist mode (`tools:`) is implemented by computing `all_tools - tools` and passing that as `forbidden_tools` to the existing hook-based denylist machinery — no parallel allowlist path needed in the agent core.
- Default `forbidden_tools` always includes `agent` itself to block infinite recursion.
- Sub-agent token totals + USD cost absorb into the parent's P0-4 session counters via private `absorb_session_usage`, so `/cost` and `max_cost_usd` see the full bill.
- `Octo::AgentInterrupted` propagates cleanly.
- `dev-docs/CATCHUP_PLAN.md` status row updated (file was moved from `docs/` to `dev-docs/` in fe6b72d as part of GitHub Pages setup; updated the new location).

Closes #2

## Test plan
- [x] `bundle exec rspec spec/octo/tools/agent_tool_spec.rb` — 17 examples (metadata, validation, recursion block, denylist merge, allowlist→denylist, model passthrough, token+cost absorb, interrupt propagation)
- [x] `bundle exec rspec` — 1987/1987 (no regressions)
- [ ] Manual: ask the agent "open a sub-agent to read README.md and summarize it" and confirm the sub-agent runs with `lite` model and result comes back in main conversation
- [ ] Manual: confirm `/cost` after a sub-agent run includes the sub-agent's tokens
- [ ] Manual: confirm a sub-agent calling `agent` again hits the forbidden-tool hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)