### PR TITLE
fix(docs): correct stale localhost:7070 → localhost:8888 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Octo is a Ruby tool for interacting with AI models. It speaks **Anthropic Messag
 | Feature | Description |
 |---|---|
 | **Interactive CLI** | Start an agent session directly in your terminal |
-| **Web UI** | Full chat interface with multi-session support at `localhost:7070` |
+| **Web UI** | Full chat interface with multi-session support at `localhost:8888` |
 | **IM Integration** | Feishu, WeCom, WeChat, Discord, Telegram — all with full parity |
 | **Skills** | Install, create, and evolve skills in standard Markdown format |
 | **BYOK** | Bring your own API key — any Anthropic / OpenAI / Bedrock-compatible model |
@@ -72,7 +72,7 @@ octo            # start interactive agent in current directory
 ### Web UI
 
 ```bash
-octo server     # default: http://localhost:7070
+octo server     # default: http://localhost:8888
 ```
 
 Options:

--- a/README_CN.md
+++ b/README_CN.md
@@ -33,7 +33,7 @@ Octo 是一个 Ruby 工具，用于与 AI 模型交互。原生支持 **Anthropi
 | 特性 | 说明 |
 |---|---|
 | **交互式 CLI** | 直接在终端启动 Agent 会话 |
-| **Web UI** | 完整的聊天界面，支持多 Session，`localhost:7070` |
+| **Web UI** | 完整的聊天界面，支持多 Session，`localhost:8888` |
 | **IM 集成** | 飞书、企微、微信、Discord、Telegram —— 全部能力对等 |
 | **Skills** | 以标准 Markdown 格式安装、创建和进化技能 |
 | **BYOK** | 自带 API Key —— 任意 Anthropic / OpenAI / Bedrock 协议模型 |
@@ -72,7 +72,7 @@ octo            # 在当前目录启动交互式 Agent
 ### Web UI
 
 ```bash
-octo server     # 默认地址：http://localhost:7070
+octo server     # 默认地址：http://localhost:8888
 ```
 
 选项：

--- a/lib/octo/tools/terminal.rb
+++ b/lib/octo/tools/terminal.rb
@@ -1210,7 +1210,7 @@ module Octo
         log_io   = File.open(log_file, "wb")
 
         # Prevent the child process from inheriting the server's
-        # listening socket (port 7070) which would block hot_restart.
+        # listening socket (default port 8888) which would block hot_restart.
         # PTY.spawn does not support close_others, so we temporarily
         # set close_on_exec on the inherited fd — the kernel closes
         # it in the child after exec while the parent keeps it open.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -533,7 +533,7 @@ show_post_install_info() {
     echo ""
     echo -e "  ${GREEN}Web UI${NC} (recommended):"
     echo "    $cmd server"
-    echo "    Open http://localhost:7070"
+    echo "    Open http://localhost:8888"
     echo ""
     echo -e "  ${GREEN}Terminal${NC}:"
     echo "    $cmd"

--- a/scripts/install_full.sh
+++ b/scripts/install_full.sh
@@ -799,7 +799,7 @@ show_post_install_info() {
     echo -e "    ${YELLOW}source ${SHELL_RC}${NC}"
     echo ""
     echo -e "  ${GREEN}Web UI${NC} (recommended):"
-    echo "    $cmd server  →  http://localhost:7070"
+    echo "    $cmd server  →  http://localhost:8888"
     echo ""
     echo -e "  ${GREEN}Terminal${NC}:"
     echo "    $cmd"


### PR DESCRIPTION
## Summary

5 user-facing references still pointed at `localhost:7070`, the old upstream default. The actual default has been `8888` for a while (`lib/octo/cli.rb:876` — `default: 8888`).

## Changes

- `README.md` / `README_CN.md`: Web UI feature-table row + `octo server` example
- `scripts/install.sh`, `scripts/install_full.sh`: post-install hint
- `lib/octo/tools/terminal.rb`: stale comment about which port the listen socket is on

## Test plan

- [x] `grep -rn 7070` across `*.md`, `*.rb`, `*.sh` — only `spec/fixtures/web_search/baidu.html` (CSS color `#707070`, unrelated)
- [x] Confirmed default port via `cli.rb:876`

🤖 Generated with [Claude Code](https://claude.com/claude-code)