### PR TITLE
chore: freeze Ruby implementation, announce Go rewrite

### DIFF
--- a/.octorules
+++ b/.octorules
@@ -1,5 +1,16 @@
 # Octo Project Rules (.octorules)
 
+## ⚠️ STATUS: Ruby implementation FROZEN — Go rewrite incoming
+
+As of `v0.11.2-final-ruby`, the Ruby codebase is feature-frozen. The full
+Ruby source is preserved on the `archive/ruby` branch. Until the Go rewrite
+lands on `main`:
+
+- **Do not add new features to the Ruby code.** Bug fixes for critical regressions are acceptable on `archive/ruby` but should not land on `main`.
+- **Main is in transition** — it currently still contains the Ruby tree but is being rebuilt in Go. New code on `main` should be Go.
+- **Skill format and product behaviour carry over** to Go intact. Markdown skills, the inbox model, ghost-text suggestion, background-task notifications — these are language-independent designs and will be reimplemented as-is.
+- See `dev-docs/CATCHUP_PLAN.md` and the README "🚧 Octo is being rewritten in Go" callout for the wider context.
+
 ## Project Overview
 This is the `octo` Ruby gem - an AI agent with three equal interfaces (CLI, Web UI, IM bridges) for interacting with AI models (Claude, OpenAI, DeepSeek, Bedrock, etc.).
 It speaks three native API protocols — Anthropic Messages, OpenAI (Chat Completions + Responses), and AWS Bedrock — dispatched per-model in `lib/octo/providers.rb`. It provides chat functionality and autonomous AI agent capabilities with tool use.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
   <a href="README.md">English</a> · <a href="README_CN.md">简体中文</a>
 </p>
 
+> ## 🚧 Octo is being rewritten in Go
+>
+> This Ruby implementation is **frozen** as of `v0.11.2-final-ruby`. The full source remains on the [`archive/ruby`](https://github.com/Leihb/octo/tree/archive/ruby) branch and you can still `gem install octo-agent` to use it, but no new features or bug fixes will land on this line.
+>
+> The next-generation Octo is being built in Go to ship as a single binary (zero install dependencies), with native Windows support and the same three-interface, three-protocol design. Track progress on `main` here, or watch the repo for releases. Estimated first Go alpha: 3-4 months.
+
 > This project is a hard fork of [clacky-ai/openclacky](https://github.com/clacky-ai/openclacky). The original MIT copyright is preserved in [LICENSE.txt](LICENSE.txt); modifications are © 2026 Leihb (roy).
 
 A **functionality-first** AI agent with three equal interfaces.

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,6 +10,12 @@
   <a href="README.md">English</a> · <a href="README_CN.md">简体中文</a>
 </p>
 
+> ## 🚧 Octo 正在用 Go 重写
+>
+> 当前 Ruby 实现已**冻结**在 `v0.11.2-final-ruby`。完整源码保留在 [`archive/ruby`](https://github.com/Leihb/octo/tree/archive/ruby) 分支，仍可 `gem install octo-agent` 安装使用，但不再有新功能或修复。
+>
+> 新一代 Octo 用 Go 实现，目标是单二进制零依赖分发、原生 Windows 支持，保持三界面 + 三协议的同样设计。在本仓库 `main` 分支跟踪进度，或 watch 仓库等正式 release。预计 Go alpha 首发：3-4 个月内。
+
 > 本项目硬分叉自 [clacky-ai/openclacky](https://github.com/clacky-ai/openclacky)。上游 MIT 协议及原作者版权完整保留于 [LICENSE.txt](LICENSE.txt)；后续修改 © 2026 Leihb (roy)。
 
 一个**功能优先**的 AI Agent，三种界面一视同仁。


### PR DESCRIPTION
## Summary

Officially freeze the Ruby codebase at `v0.11.2-final-ruby` and announce that `main` is being rebuilt in Go.

## What changed

- **README.md / README_CN.md**: 🚧 migration callout above the fold so anyone landing on the repo sees the notice before Ruby docs.
- **.octorules**: project-wide rule — no new Ruby features on `main` during the rewrite. Bug fixes target `archive/ruby`.

## What stayed

- All Ruby code under `lib/`, `scripts/`, `spec/` is unchanged. The Ruby tree on `main` is still the working reference until Go scaffolding replaces it.
- Tag `v0.11.2-final-ruby` and branch `archive/ruby` both already pushed to remote (created out-of-PR — see commits `3809ffb` and the new refs).

## Why now

The strategic call to rewrite was made after thinking through:
- **1000+ star goal**: needs single-binary distribution + Windows native, both blocked by Ruby ecosystem.
- **PTY gap**: `require "pty"` is POSIX-only; Ruby has no production-grade ConPTY binding. Go via `creack/pty` + `pkg/conpty` solves it.
- **No emotional anchor to Ruby** — Ruby was chosen for metaprogramming convenience, not domain fit.

## Test plan

- [x] Render README locally — callout displays above the fold.
- [x] No code changes, so no test impact.
- [x] CI should pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)