### PR TITLE
feat(go): M1 scaffolding — go.mod, cmd/octo entrypoint, Go CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,49 @@
+name: Go
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Run a fresh job per push to the same branch and cancel any in-flight one,
+# saves CI minutes during rapid iteration.
+concurrency:
+  group: go-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Go ${{ matrix.go }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ['1.22', '1.23']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+          cache: true
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: gofmt
+        if: matrix.os != 'windows-latest'
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::gofmt found unformatted files:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: go build
+        run: go build ./...
+
+      - name: go test
+        run: go test -race ./...

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,11 @@ openclacky/
 /checksums.yaml.gz
 /data.tar.gz
 /metadata.gz
+
+# Go build artefacts
+/octo
+/octo.exe
+/dist/
+*.test
+coverage.out
+coverage.html

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -1,0 +1,55 @@
+// Command octo is the Go implementation of the Octo AI agent.
+//
+// At this scaffolding stage the binary only resolves the version subcommand;
+// the agent loop, providers, tools, skills, web server, and IM bridges all
+// land in subsequent milestones (M1..M5). See dev-docs/CATCHUP_PLAN.md and
+// the README "🚧 Octo is being rewritten in Go" callout for the migration
+// plan.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Leihb/octo/internal/version"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run is the testable entry point. Splitting it out keeps main thin and
+// lets the test harness drive the CLI without spawning a subprocess.
+func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		printUsage(stdout)
+		return 0
+	}
+
+	switch args[0] {
+	case "version", "--version", "-v":
+		fmt.Fprintf(stdout, "octo %s\n", version.String())
+		return 0
+	case "help", "--help", "-h":
+		printUsage(stdout)
+		return 0
+	default:
+		fmt.Fprintf(stderr, "octo: unknown command %q (the Go rewrite is in early scaffolding — only `version` is wired up)\n", args[0])
+		fmt.Fprintln(stderr, "Run `octo help` for available commands.")
+		return 2
+	}
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprintln(w, "octo — a functionality-first AI agent (Go rewrite in progress)")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Usage: octo <command>")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Commands:")
+	fmt.Fprintln(w, "  version    Print the version and exit")
+	fmt.Fprintln(w, "  help       Print this help and exit")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "More commands will land as the rewrite progresses. The Ruby")
+	fmt.Fprintln(w, "implementation lives on the archive/ruby branch in the meantime.")
+}

--- a/cmd/octo/main_test.go
+++ b/cmd/octo/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRun_NoArgs_PrintsUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "Usage: octo") {
+		t.Errorf("stdout missing usage banner; got: %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr should be empty; got: %q", stderr.String())
+	}
+}
+
+func TestRun_Version(t *testing.T) {
+	for _, arg := range []string{"version", "--version", "-v"} {
+		t.Run(arg, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run([]string{arg}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit code = %d, want 0", code)
+			}
+			if !strings.HasPrefix(stdout.String(), "octo ") {
+				t.Errorf("stdout should start with 'octo '; got: %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestRun_UnknownCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"bogus"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "unknown command") {
+		t.Errorf("stderr should mention 'unknown command'; got: %q", stderr.String())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Leihb/octo
+
+go 1.22

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,26 @@
+// Package version holds the build-time version metadata for the octo binary.
+//
+// The default values here describe an unreleased local build. Production
+// binaries set Version and Commit via -ldflags at build time:
+//
+//	go build -ldflags "-X github.com/Leihb/octo/internal/version.Version=0.12.0 -X github.com/Leihb/octo/internal/version.Commit=$(git rev-parse --short HEAD)" ./cmd/octo
+package version
+
+// Version is the SemVer string for this build. Overridden via -ldflags.
+//
+// 0.12.0-dev is the placeholder for the in-progress Go rewrite of Octo —
+// the Ruby line ended at v0.11.2-final-ruby.
+var Version = "0.12.0-dev"
+
+// Commit is the short git SHA for this build. Overridden via -ldflags.
+// Empty in local `go build` invocations.
+var Commit = ""
+
+// String renders a human-friendly version line, e.g. "0.12.0-dev (abc1234)".
+// The commit suffix is omitted when Commit is empty.
+func String() string {
+	if Commit == "" {
+		return Version
+	}
+	return Version + " (" + Commit + ")"
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,29 @@
+package version
+
+import "testing"
+
+func TestString_WithoutCommit(t *testing.T) {
+	t.Cleanup(saveAndRestore(&Version, &Commit))
+	Version = "1.2.3"
+	Commit = ""
+	if got, want := String(), "1.2.3"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestString_WithCommit(t *testing.T) {
+	t.Cleanup(saveAndRestore(&Version, &Commit))
+	Version = "1.2.3"
+	Commit = "abc1234"
+	if got, want := String(), "1.2.3 (abc1234)"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func saveAndRestore(version, commit *string) func() {
+	origV, origC := *version, *commit
+	return func() {
+		*version = origV
+		*commit = origC
+	}
+}


### PR DESCRIPTION
## Summary

First commit of the Go rewrite. Lays down the Go module, a minimal `cmd/octo` entrypoint that wires up `version` and `help`, and a Go CI matrix. Coexists with the frozen Ruby tree on `main`.

## Why coexistence (Ruby + Go on main)

The original plan was either "wipe Ruby in one shot" or "Go alongside Ruby for the transition". Going with the latter:

- Existing Ruby CI (`.github/workflows/main.yml`) keeps running, so branch protection's required Ruby checks are unaffected.
- New Go CI runs in parallel.
- When Go reaches feature parity, a follow-up PR will remove the Ruby tree and the Ruby CI in one go and swap the required checks.

## Files

| File | Purpose |
|---|---|
| `go.mod` | `module github.com/Leihb/octo`, `go 1.22` |
| `cmd/octo/main.go` | CLI entrypoint. Only `version`/`--version`/`-v` and `help`/`--help`/`-h` are wired up. Anything else exits 2 with a "not yet implemented" message. |
| `cmd/octo/main_test.go` | Covers no-args, version flags, unknown command exit code. |
| `internal/version/version.go` | `Version` and `Commit` vars, both overridable via `-ldflags` at build time. `String()` renders the user-facing line. |
| `internal/version/version_test.go` | Unit tests for `String()` shape. |
| `.github/workflows/go.yml` | Go matrix: 1.22 × {linux, macos, windows}, 1.23 × {linux, macos, windows}. Runs `go vet`, `gofmt -l`, `go build`, `go test -race`. |
| `.gitignore` | Adds `/octo`, `/octo.exe`, `/dist/`, `*.test`, `coverage.out`, `coverage.html`. |

Total: 7 files, +217 lines.

## What runs

```
$ go build ./cmd/octo && ./octo version
octo 0.12.0-dev

$ ./octo help
octo — a functionality-first AI agent (Go rewrite in progress)
…

$ ./octo bogus            # exit 2
octo: unknown command "bogus" (the Go rewrite is in early scaffolding — only `version` is wired up)
Run `octo help` for available commands.
```

Local: `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .` all pass on macOS arm64 with Go 1.24.6.

## Test plan

- [x] Local build + test pass
- [x] `gofmt` clean
- [x] `go vet` clean
- [ ] CI: Go 1.22 × {ubuntu, macos, windows} — pending
- [ ] CI: Go 1.23 × {ubuntu, macos, windows} — pending
- [ ] CI: existing Ruby matrix still green (sanity check that adding Go files didn't break the Ruby tree) — pending

## Out of scope

- Replacing the Ruby tree. That's a later PR once Go reaches parity.
- Agent core, providers, tools, skills, web server, IM bridges. M1 is just the scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)