### PR TITLE
chore(go): M1 finish — Makefile, CHANGELOG entry, READMEs, CONTRIBUTING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This project is a hard fork of [clacky-ai/openclacky](https://github.com/clacky-ai/openclacky) at upstream **1.1.6**, renumbered as **0.10.0** in this fork's own SemVer line. Only changes made in this fork (0.11.x and later) are tracked here. For history prior to the fork, see the upstream repository.
 
+## [Unreleased — 0.12.0-dev] — Go rewrite in progress
+
+Octo is being rewritten in Go. The Ruby line ended at `v0.11.2-final-ruby` (preserved on the `archive/ruby` branch); from here, `main` mixes the frozen Ruby tree with the in-progress Go tree until Go reaches feature parity.
+
+### Added
+- **Go module scaffolding** — `go.mod` at module path `github.com/Leihb/octo`, `cmd/octo/main.go` entrypoint wiring up `version`/`help`, `internal/version` with `-ldflags`-overridable `Version` and `Commit` variables (PR #28).
+- **Go CI matrix** — `.github/workflows/go.yml` runs `go vet`, `gofmt -l`, `go build`, `go test -race` against Go 1.22 and 1.23 on Linux, macOS, and Windows — including the first proof that the Go tree builds and tests on native Windows.
+- **Makefile** — `make build / test / cover / vet / fmt / fmt-check / tidy / install / clean` targets. `VERSION` and `COMMIT` are injected at build time via `-ldflags`; release builds set `VERSION` explicitly (e.g. `VERSION=0.12.0 make build`).
+
+### Changed
+- **Ruby implementation frozen** at `v0.11.2-final-ruby` (PR #27). README / README_CN now carry a 🚧 callout above the fold. `.octorules` instructs future contributors to keep new Ruby features off `main`.
+- **Tag `v0.11.2-final-ruby`** added on top of `v0.11.2`, and **branch `archive/ruby`** created pointing at the same commit — the canonical access points for the Ruby line going forward.
+
+### Removed
+- Nothing yet. The Ruby tree under `lib/`, `scripts/`, `spec/` stays on `main` until the Go rewrite reaches parity. A future PR will excise it in one step alongside the Ruby CI workflow.
+
 ## [0.11.2] - 2026-05-25
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ PR description.
 
 - Pull the latest `main` (`git pull --ff-only origin main`) and create a topic branch off it. Use a descriptive name with a type prefix: `fix/...`, `feat/...`, `chore/...`, `docs/...`.
 - Commit on the topic branch only. Push the branch to `origin` and open a PR against `main`.
-- CI must be **green on all three Ruby versions** in the matrix (4.0, 3.3.5, 2.6) before the PR can merge.
+- CI must be **green on all three Ruby versions** in the matrix (4.0, 3.3.5, 2.6) AND on the **Go matrix** (1.22 / 1.23 × Linux / macOS / Windows) before the PR can merge.
 - Your branch must be **up to date with `main`** before merging — rebase or merge the latest `main` in if it has moved.
 - Force-pushes to `main` and deletion of `main` are blocked at the GitHub level.
 
@@ -93,6 +93,39 @@ git switch -c fix/your-change           # rename current HEAD to a topic branch
 git switch main && git reset --hard origin/main   # restore main to upstream
 git switch fix/your-change              # back on the topic branch, push from here
 ```
+
+---
+
+## 5. Go development (work-in-progress)
+
+`main` is currently in transition: the Ruby tree under `lib/`, `scripts/`, `spec/` is frozen, and a Go rewrite is growing alongside it under `cmd/` and `internal/`. New non-bugfix work should target the Go side.
+
+Setup:
+
+```sh
+# Need Go 1.22+
+go version
+
+# Run the standard checks the CI runs:
+make fmt-check    # fail if anything would be reformatted by `gofmt`
+make vet          # go vet ./...
+make test         # go test -race ./...
+make build        # produces ./octo with version metadata baked in
+```
+
+Project layout:
+
+- `cmd/octo/`              binary entrypoint
+- `internal/version/`      build-time version metadata (overridden via `-ldflags` for releases)
+- `internal/agent/`        agent core (M2)
+- `internal/provider/`     LLM provider clients (M2)
+- `internal/tools/`        built-in tools (M2)
+- `internal/skills/`       skill loader (M3)
+- `internal/server/`       HTTP + WebSocket server for the Web UI (M3)
+
+`gofmt` and `go vet` cleanliness are mandatory. `golangci-lint` is not yet wired up but PRs are welcome to follow [Effective Go](https://go.dev/doc/effective_go) and the [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments) guide.
+
+Ruby fixes (only critical regressions) should target the `archive/ruby` branch directly, not `main`.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+# Octo — Go build & test orchestration
+#
+# Usage:
+#   make            same as `make test`
+#   make build      build the octo binary at repo root (./octo)
+#   make install    install to $GOPATH/bin
+#   make test       go test -race ./...
+#   make cover      generate coverage.out + coverage.html
+#   make vet        go vet ./...
+#   make fmt        gofmt -w on the tree
+#   make fmt-check  fail if anything would be reformatted
+#   make tidy       go mod tidy
+#   make clean      remove build artefacts
+
+GOTAGS ?=
+GOFLAGS ?=
+
+# Inject version + commit at build time so `octo version` reports a real SHA.
+#
+# Auto-detection via `git describe` is intentionally avoided here because the
+# repo still carries Ruby-era tags (v0.11.2, v0.11.2-final-ruby) that would
+# pollute the reported version. Dev builds always say "0.12.0-dev". Release
+# builds should set VERSION explicitly:
+#
+#   VERSION=0.12.0 make build
+#
+VERSION ?= 0.12.0-dev
+COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+LDFLAGS := -X github.com/Leihb/octo/internal/version.Version=$(VERSION) \
+           -X github.com/Leihb/octo/internal/version.Commit=$(COMMIT)
+
+.PHONY: all build install test cover vet fmt fmt-check tidy clean
+
+all: test
+
+build:
+	go build $(GOFLAGS) -tags='$(GOTAGS)' -ldflags='$(LDFLAGS)' -o octo ./cmd/octo
+
+install:
+	go install $(GOFLAGS) -tags='$(GOTAGS)' -ldflags='$(LDFLAGS)' ./cmd/octo
+
+test:
+	go test -race $(GOFLAGS) -tags='$(GOTAGS)' ./...
+
+cover:
+	go test $(GOFLAGS) -tags='$(GOTAGS)' -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out -o coverage.html
+	@echo "Open coverage.html in a browser to see line coverage."
+
+vet:
+	go vet ./...
+
+fmt:
+	gofmt -w .
+
+fmt-check:
+	@unformatted=$$(gofmt -l .); \
+	if [ -n "$$unformatted" ]; then \
+		echo "gofmt found unformatted files:"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
+
+tidy:
+	go mod tidy
+
+clean:
+	rm -f octo octo.exe coverage.out coverage.html
+	rm -rf dist/

--- a/README.md
+++ b/README.md
@@ -47,7 +47,20 @@ Octo is a Ruby tool for interacting with AI models. It speaks **Anthropic Messag
 
 ## Installation
 
-### RubyGem
+### Building the in-progress Go version (from source)
+
+The Go rewrite is just scaffolding right now — only `octo version` and `octo help` are wired up — but the binary builds and the CI matrix already covers Linux, macOS, and Windows.
+
+```bash
+git clone https://github.com/Leihb/octo.git
+cd octo
+make build      # produces ./octo
+./octo version
+```
+
+`make install` puts the binary on `$GOPATH/bin`. Requires Go 1.22+.
+
+### RubyGem (frozen Ruby line)
 
 Requires Ruby >= 3.1.0
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -47,7 +47,20 @@ Octo 是一个 Ruby 工具，用于与 AI 模型交互。原生支持 **Anthropi
 
 ## 安装
 
-### RubyGem
+### 从源码构建 Go 版本（开发中）
+
+Go 重写目前只是脚手架——只通了 `octo version` 和 `octo help`——但二进制能构建，CI 已覆盖 Linux / macOS / Windows。
+
+```bash
+git clone https://github.com/Leihb/octo.git
+cd octo
+make build      # 生成 ./octo
+./octo version
+```
+
+`make install` 把二进制放到 `$GOPATH/bin`。需要 Go 1.22+。
+
+### RubyGem（冻结状态）
 
 需要 Ruby >= 3.1.0
 


### PR DESCRIPTION
## Summary

Wraps up M1 scaffolding (PR #28) with the developer-facing surface a Go contributor expects to find on first checkout: a `Makefile`, a CHANGELOG entry, "Building the Go version" sections in both READMEs, and a Go-development section in CONTRIBUTING.md.

## Changes

| File | What |
|---|---|
| `Makefile` (new) | `build / install / test / cover / vet / fmt / fmt-check / tidy / clean`. `VERSION ?= 0.12.0-dev`, overridable for releases (`VERSION=0.12.0 make build`). Auto-detection from git tags is intentionally avoided so Ruby-era tags (`v0.11.2`, `v0.11.2-final-ruby`) don't leak into Go dev builds. |
| `CHANGELOG.md` | `[Unreleased — 0.12.0-dev]` section on top summarising the scaffold + freeze work that landed today. |
| `README.md` / `README_CN.md` | "Building the in-progress Go version (from source)" section above the existing RubyGem instructions, which are relabelled "frozen Ruby line". |
| `CONTRIBUTING.md` | New "Go development (work-in-progress)" section: project layout (`cmd/`, `internal/{version,agent,provider,tools,skills,server}`), `make` targets that mirror CI, and the convention that Ruby fixes target `archive/ruby` instead of `main`. Existing branch-merge rules updated to mention the Go CI matrix as a required check. |

## Test plan

- [x] `make fmt-check` clean
- [x] `make vet` clean
- [x] `make test` green
- [x] `make build` produces `./octo`; `./octo version` prints `octo 0.12.0-dev (<sha>)`
- [x] `VERSION=0.12.0 make build` → `./octo version` prints `octo 0.12.0 (<sha>)`

## Out of scope

- goreleaser config — too early; we don't have releasable content yet.
- golangci-lint — too early; `go vet` + `gofmt` is enough for the scaffold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)