### PR TITLE
feat(go,anthropic): support ANTHROPIC_BASE_URL for compatible third parties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Octo is being rewritten in Go. The Ruby line ended at `v0.11.2-final-ruby` (pres
 - **Go module scaffolding** — `go.mod` at module path `github.com/Leihb/octo`, `cmd/octo/main.go` entrypoint wiring up `version`/`help`, `internal/version` with `-ldflags`-overridable `Version` and `Commit` variables (PR #28).
 - **Go CI matrix** — `.github/workflows/go.yml` runs `go vet`, `gofmt -l`, `go build`, `go test -race` against Go 1.22 and 1.23 on Linux, macOS, and Windows — including the first proof that the Go tree builds and tests on native Windows.
 - **Makefile** — `make build / test / cover / vet / fmt / fmt-check / tidy / install / clean` targets. `VERSION` and `COMMIT` are injected at build time via `-ldflags`; release builds set `VERSION` explicitly (e.g. `VERSION=0.12.0 make build`).
+- **`octo chat` subcommand** — single-turn Anthropic Messages call via `internal/agent` + `internal/provider/anthropic`. Reads `ANTHROPIC_API_KEY` from env. Flags: `--model`, `--system`, `--max-tokens` (PR #30).
+- **`ANTHROPIC_BASE_URL` env var** — same name the official Anthropic SDK uses. Lets `octo chat` target any Anthropic-protocol-compatible third party (DeepSeek `https://api.deepseek.com/anthropic`, Kimi K2 `https://api.moonshot.cn/anthropic`, OpenRouter Anthropic-shim, etc.) without code changes.
 
 ### Changed
 - **Ruby implementation frozen** at `v0.11.2-final-ruby` (PR #27). README / README_CN now carry a 🚧 callout above the fold. `.octorules` instructs future contributors to keep new Ruby features off `main`.

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -52,6 +52,13 @@ func runChat(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "octo chat: %v\n", err)
 		return 1
 	}
+	// Honour ANTHROPIC_BASE_URL (same env name the official Anthropic SDK uses)
+	// so the same `octo chat` invocation can target an Anthropic-compatible
+	// third party — e.g. DeepSeek at https://api.deepseek.com/anthropic.
+	// Without the env var the client uses anthropic.DefaultBaseURL.
+	if baseURL := os.Getenv("ANTHROPIC_BASE_URL"); baseURL != "" {
+		client.BaseURL = baseURL
+	}
 
 	a := agent.New(providerSender{p: client}, *model)
 	a.System = *system

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -37,6 +37,37 @@ func TestRunChat_MissingAPIKey(t *testing.T) {
 	}
 }
 
+func TestRunChat_HonoursAnthropicBaseURL(t *testing.T) {
+	// Stand up a fake Anthropic-compatible endpoint and verify runChat
+	// actually POSTs there when ANTHROPIC_BASE_URL is set. Same shape the
+	// user will use with DeepSeek / Kimi / OpenRouter-Anthropic-shim.
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{
+			"id":"m","type":"message","role":"assistant","model":"x",
+			"content":[{"type":"text","text":"hi"}],
+			"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}
+		}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("ANTHROPIC_API_KEY", "k")
+	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
+
+	var stdout, stderr bytes.Buffer
+	code := runChat([]string{"--model", "x", "hello"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "hi") {
+		t.Errorf("stdout should contain reply; got: %q", stdout.String())
+	}
+	if gotPath != "/v1/messages" {
+		t.Errorf("path = %q, want /v1/messages", gotPath)
+	}
+}
+
 func TestRunChat_EndToEnd(t *testing.T) {
 	// httptest server impersonating Anthropic — proves the full chain
 	// (cmd → adapter → provider → HTTP) is wired correctly.

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -15,9 +15,15 @@ import (
 	"github.com/Leihb/octo/internal/provider"
 )
 
-// DefaultEndpoint is the Anthropic Messages API endpoint. Tests override it
-// via Client.Endpoint; production should leave it as the default.
-const DefaultEndpoint = "https://api.anthropic.com/v1/messages"
+// DefaultBaseURL is Anthropic's API base. The actual Messages endpoint is
+// BaseURL + "/v1/messages". Override Client.BaseURL when pointing at an
+// Anthropic-compatible third-party (DeepSeek, Kimi, OpenRouter's Anthropic
+// shim, …) — for example DeepSeek exposes the protocol at
+// `https://api.deepseek.com/anthropic`.
+const DefaultBaseURL = "https://api.anthropic.com"
+
+// MessagesPath is the path appended to BaseURL for every send.
+const MessagesPath = "/v1/messages"
 
 // DefaultAPIVersion is the value sent as the `anthropic-version` header.
 // Pinned to the GA version used by the Messages API since 2023-06-01; bump
@@ -28,11 +34,16 @@ const DefaultAPIVersion = "2023-06-01"
 // 4096 is generous for chat-style replies and well below the model ceilings.
 const DefaultMaxTokens = 4096
 
-// Client talks to Anthropic's Messages API. Construct via New(); zero values
-// are not valid because APIKey is required.
+// Client talks to an Anthropic-compatible Messages API. Construct via New();
+// zero values are not valid because APIKey is required.
+//
+// BaseURL is the host + protocol-prefix only (no /v1/messages suffix); the
+// client appends MessagesPath itself. This makes pointing at compatible
+// endpoints painless — set `BaseURL = "https://api.deepseek.com/anthropic"`
+// and the rest works unchanged.
 type Client struct {
 	APIKey     string
-	Endpoint   string       // optional override; defaults to DefaultEndpoint
+	BaseURL    string       // optional override; defaults to DefaultBaseURL
 	APIVersion string       // optional override; defaults to DefaultAPIVersion
 	HTTPClient *http.Client // optional; defaults to http.Client with a 60s timeout
 }
@@ -46,7 +57,7 @@ func New(apiKey string) (*Client, error) {
 	}
 	return &Client{
 		APIKey:     apiKey,
-		Endpoint:   DefaultEndpoint,
+		BaseURL:    DefaultBaseURL,
 		APIVersion: DefaultAPIVersion,
 		HTTPClient: &http.Client{Timeout: 60 * time.Second},
 	}, nil
@@ -82,11 +93,7 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		return provider.Response{}, fmt.Errorf("anthropic: marshal request: %w", err)
 	}
 
-	endpoint := c.Endpoint
-	if endpoint == "" {
-		endpoint = DefaultEndpoint
-	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpointURL(), bytes.NewReader(payload))
 	if err != nil {
 		return provider.Response{}, fmt.Errorf("anthropic: build request: %w", err)
 	}
@@ -137,6 +144,16 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		InputTokens:  apiResp.Usage.InputTokens,
 		OutputTokens: apiResp.Usage.OutputTokens,
 	}, nil
+}
+
+// endpointURL returns BaseURL + MessagesPath, applying defaults and trimming
+// any trailing slash on BaseURL so the join is exactly one slash.
+func (c *Client) endpointURL() string {
+	base := c.BaseURL
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	return strings.TrimRight(base, "/") + MessagesPath
 }
 
 // toAPIMessages converts agent.Message slice into the Anthropic wire format.

--- a/internal/provider/anthropic/client_test.go
+++ b/internal/provider/anthropic/client_test.go
@@ -74,7 +74,7 @@ func TestSend_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Endpoint = srv.URL
+	c.BaseURL = srv.URL
 
 	resp, err := c.Send(context.Background(), provider.Request{
 		Model:        "claude-haiku-4-5-20251001",
@@ -116,7 +116,7 @@ func TestSend_SystemMessageStripped(t *testing.T) {
 	defer srv.Close()
 
 	c, _ := New("k")
-	c.Endpoint = srv.URL
+	c.BaseURL = srv.URL
 
 	_, err := c.Send(context.Background(), provider.Request{
 		Model: "claude-haiku-4-5-20251001",
@@ -141,7 +141,7 @@ func TestSend_HTTPError_Wrapped(t *testing.T) {
 	defer srv.Close()
 
 	c, _ := New("k")
-	c.Endpoint = srv.URL
+	c.BaseURL = srv.URL
 
 	_, err := c.Send(context.Background(), provider.Request{
 		Model:    "x",
@@ -160,7 +160,7 @@ func TestSend_HTTPError_Wrapped(t *testing.T) {
 
 func TestSend_ValidatesRequest(t *testing.T) {
 	c, _ := New("k")
-	c.Endpoint = "http://invalid"
+	c.BaseURL = "http://invalid"
 
 	if _, err := c.Send(context.Background(), provider.Request{}); err == nil {
 		t.Error("empty request should error")
@@ -182,7 +182,7 @@ func TestSend_DefaultMaxTokens(t *testing.T) {
 	defer srv.Close()
 
 	c, _ := New("k")
-	c.Endpoint = srv.URL
+	c.BaseURL = srv.URL
 
 	_, err := c.Send(context.Background(), provider.Request{
 		Model:    "x",
@@ -194,6 +194,47 @@ func TestSend_DefaultMaxTokens(t *testing.T) {
 	}
 	if capturedMaxTokens != DefaultMaxTokens {
 		t.Errorf("MaxTokens = %d, want default %d", capturedMaxTokens, DefaultMaxTokens)
+	}
+}
+
+func TestSend_AppendsMessagesPath(t *testing.T) {
+	// Verify the client always POSTs to BaseURL + "/v1/messages", regardless
+	// of whether the caller's BaseURL has a trailing slash. This is the
+	// guarantee that makes pointing at Anthropic-compatible third parties
+	// (e.g. DeepSeek at https://api.deepseek.com/anthropic) work transparently.
+	cases := []struct {
+		name string
+		base string
+	}{
+		{"no trailing slash", ""}, // populated below with srv.URL
+		{"trailing slash", ""},
+	}
+	for i, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				_, _ = w.Write([]byte(`{"id":"m","type":"message","role":"assistant","model":"x","content":[],"stop_reason":"end_turn","usage":{"input_tokens":0,"output_tokens":0}}`))
+			}))
+			defer srv.Close()
+
+			cl, _ := New("k")
+			cl.BaseURL = srv.URL
+			if i == 1 {
+				cl.BaseURL = srv.URL + "/"
+			}
+
+			_, err := cl.Send(context.Background(), provider.Request{
+				Model:    "x",
+				Messages: []agent.Message{agent.NewUserMessage("hi")},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotPath != "/v1/messages" {
+				t.Errorf("path = %q, want /v1/messages", gotPath)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Lets `octo chat` target any Anthropic-protocol-compatible backend (DeepSeek, Kimi K2, OpenRouter's Anthropic shim, …) without code changes, by honouring the standard `ANTHROPIC_BASE_URL` env var.

```sh
export ANTHROPIC_API_KEY=sk-<deepseek-key>
export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic
./octo chat --model deepseek-chat "explain PTY in one paragraph"
```

## Changes

| File | What |
|---|---|
| `internal/provider/anthropic/client.go` | Rename `Client.Endpoint` → `Client.BaseURL`. New const `MessagesPath = "/v1/messages"`. New unexported `Client.endpointURL()` does `strings.TrimRight(base, "/") + MessagesPath`, so trailing-slash variants of BaseURL are tolerated. `DefaultEndpoint` const becomes `DefaultBaseURL = "https://api.anthropic.com"`. |
| `internal/provider/anthropic/client_test.go` | Update all existing `c.Endpoint = srv.URL` to `c.BaseURL = srv.URL`. Add `TestSend_AppendsMessagesPath` covering both trailing- and non-trailing-slash inputs and asserting `r.URL.Path == "/v1/messages"`. |
| `cmd/octo/chat.go` | After constructing the client, read `ANTHROPIC_BASE_URL` from env and apply it to `client.BaseURL` when non-empty. Comment names the env var explicitly so future readers know it matches the official SDK convention. |
| `cmd/octo/chat_test.go` | New `TestRunChat_HonoursAnthropicBaseURL` stands up `httptest.NewServer`, exports the env var, runs `runChat`, and asserts the request hit the fake server with path `/v1/messages` and that the reply was printed to stdout. |
| `CHANGELOG.md` | Add "ANTHROPIC_BASE_URL env var" bullet under the [Unreleased — 0.12.0-dev] Added section. |

## Why `ANTHROPIC_BASE_URL` specifically

That's the env name the official Anthropic Python and TypeScript SDKs use. Sticking to the convention means anyone who's used Anthropic SDKs already knows how to point `octo chat` somewhere else.

## Test plan

- [x] `make fmt-check` clean
- [x] `make vet` clean
- [x] `make test -race` green
- [x] Smoke-tested: `ANTHROPIC_BASE_URL=http://127.0.0.1:9999 ./octo chat …` actually routes to the local server (got 501 from `python3 -m http.server`, confirming the request didn't go to Anthropic).
- [ ] Live DeepSeek test — manual, pending user with a DeepSeek key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)