### PR TITLE
feat(go): M4 — tool calling and agentic loop

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Leihb/octo/internal/provider"
 	"github.com/Leihb/octo/internal/provider/anthropic"
 	"github.com/Leihb/octo/internal/provider/openai"
+	"github.com/Leihb/octo/internal/tools"
 )
 
 // Provider names accepted by `--provider`.
@@ -52,6 +53,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	continueIDLong := fs.String("continue", "", "Session ID to resume")
 	noSave := fs.Bool("no-save", false, "Disable auto-save in REPL mode")
 	listSessions := fs.Bool("list-sessions", false, "Print the 10 most recent sessions and exit")
+	enableTools := fs.Bool("tools", false, "Enable built-in tools (bash) for agentic loop")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -135,14 +137,19 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			sess = agent.NewSession(resolvedModel, *system)
 		}
 
-		return runREPL(replConfig{
+		cfg := replConfig{
 			a:       a,
 			session: sess,
 			noSave:  *noSave,
 			stdin:   stdin,
 			stdout:  stdout,
 			stderr:  stderr,
-		})
+		}
+		if *enableTools {
+			cfg.tools = tools.DefaultTools()
+			cfg.executor = tools.RegistryWithBash{}
+		}
+		return runREPL(cfg)
 	}
 
 	// ── Single-turn mode (original M2 behaviour) ──────────────────────────────
@@ -276,6 +283,7 @@ func (s providerSender) StreamMessages(
 func replyFromResponse(resp provider.Response) agent.Reply {
 	return agent.Reply{
 		Content:      resp.Content,
+		Blocks:       resp.Blocks,
 		Model:        resp.Model,
 		StopReason:   resp.StopReason,
 		InputTokens:  resp.InputTokens,
@@ -283,8 +291,76 @@ func replyFromResponse(resp provider.Response) agent.Reply {
 	}
 }
 
-// Compile-time assertions: providerSender satisfies both agent interfaces.
+// SendMessagesWithTools implements agent.ToolSender. It passes the tool
+// definitions to the provider via provider.Request.Tools and returns the full
+// content-block list (including tool_use blocks) in the Reply.
+func (s providerSender) SendMessagesWithTools(
+	ctx context.Context,
+	model, system string,
+	msgs []agent.Message,
+	maxTokens int,
+	tools []agent.ToolDefinition,
+) (agent.Reply, error) {
+	if s.p == nil {
+		return agent.Reply{}, errors.New("providerSender: provider is nil")
+	}
+	resp, err := s.p.Send(ctx, provider.Request{
+		Model:        model,
+		SystemPrompt: system,
+		Messages:     msgs,
+		MaxTokens:    maxTokens,
+		Tools:        tools,
+	})
+	if err != nil {
+		return agent.Reply{}, err
+	}
+	return replyFromResponse(resp), nil
+}
+
+// StreamMessagesWithTools implements agent.ToolStreamingSender. It passes
+// tools to the provider and streams text deltas via onChunk; tool_use blocks
+// are accumulated and returned in Reply.Blocks at the end of the stream.
+func (s providerSender) StreamMessagesWithTools(
+	ctx context.Context,
+	model, system string,
+	msgs []agent.Message,
+	maxTokens int,
+	tools []agent.ToolDefinition,
+	onChunk func(string),
+) (agent.Reply, error) {
+	if s.p == nil {
+		return agent.Reply{}, errors.New("providerSender: provider is nil")
+	}
+	req := provider.Request{
+		Model:        model,
+		SystemPrompt: system,
+		Messages:     msgs,
+		MaxTokens:    maxTokens,
+		Tools:        tools,
+	}
+	if sp, ok := s.p.(provider.StreamingProvider); ok {
+		resp, err := sp.SendStream(ctx, req, onChunk)
+		if err != nil {
+			return agent.Reply{}, err
+		}
+		return replyFromResponse(resp), nil
+	}
+
+	// Buffered fallback.
+	resp, err := s.p.Send(ctx, req)
+	if err != nil {
+		return agent.Reply{}, err
+	}
+	if onChunk != nil && resp.Content != "" {
+		onChunk(resp.Content)
+	}
+	return replyFromResponse(resp), nil
+}
+
+// Compile-time assertions: providerSender satisfies all agent sender interfaces.
 var (
-	_ agent.Sender          = providerSender{}
-	_ agent.StreamingSender = providerSender{}
+	_ agent.Sender               = providerSender{}
+	_ agent.StreamingSender      = providerSender{}
+	_ agent.ToolSender           = providerSender{}
+	_ agent.ToolStreamingSender  = providerSender{}
 )

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -359,8 +359,8 @@ func (s providerSender) StreamMessagesWithTools(
 
 // Compile-time assertions: providerSender satisfies all agent sender interfaces.
 var (
-	_ agent.Sender               = providerSender{}
-	_ agent.StreamingSender      = providerSender{}
-	_ agent.ToolSender           = providerSender{}
-	_ agent.ToolStreamingSender  = providerSender{}
+	_ agent.Sender              = providerSender{}
+	_ agent.StreamingSender     = providerSender{}
+	_ agent.ToolSender          = providerSender{}
+	_ agent.ToolStreamingSender = providerSender{}
 )

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -13,12 +13,14 @@ import (
 
 // replConfig holds everything runREPL needs.
 type replConfig struct {
-	a       *agent.Agent
-	session *agent.Session
-	noSave  bool
-	stdin   io.Reader
-	stdout  io.Writer
-	stderr  io.Writer
+	a        *agent.Agent
+	session  *agent.Session
+	noSave   bool
+	stdin    io.Reader
+	stdout   io.Writer
+	stderr   io.Writer
+	tools    []agent.ToolDefinition
+	executor agent.ToolExecutor
 }
 
 // runREPL runs the interactive multi-turn loop until the user exits or EOF.
@@ -84,11 +86,21 @@ func runREPL(cfg replConfig) int {
 			break
 		}
 
-		// Regular message — streaming turn.
+		// Regular message — streaming turn (or agentic loop when tools enabled).
 		startedAt := time.Now()
-		reply, err := a.TurnStream(context.Background(), line, func(delta string) {
-			fmt.Fprint(cfg.stdout, delta)
-		})
+		var (
+			reply agent.Reply
+			err   error
+		)
+		if len(cfg.tools) > 0 && cfg.executor != nil {
+			reply, err = a.RunStream(context.Background(), line, cfg.tools, cfg.executor, func(delta string) {
+				fmt.Fprint(cfg.stdout, delta)
+			})
+		} else {
+			reply, err = a.TurnStream(context.Background(), line, func(delta string) {
+				fmt.Fprint(cfg.stdout, delta)
+			})
+		}
 		if err != nil {
 			fmt.Fprintf(cfg.stderr, "\nerror: %v\n", err)
 			continue

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // Sender is the minimal slice of provider.Provider the Agent depends on:
@@ -37,12 +38,46 @@ type StreamingSender interface {
 	) (Reply, error)
 }
 
+// ToolSender extends Sender with a tool-aware variant that carries tool
+// definitions alongside the messages. Implementations return the full
+// content-block list (including tool_use blocks) in Reply.Blocks.
+type ToolSender interface {
+	Sender
+	SendMessagesWithTools(
+		ctx context.Context,
+		model, system string,
+		messages []Message,
+		maxTokens int,
+		tools []ToolDefinition,
+	) (Reply, error)
+}
+
+// ToolStreamingSender extends ToolSender and StreamingSender with a streaming
+// tool-aware variant. Implementations stream text deltas via onChunk and
+// accumulate tool_use blocks; the final Reply carries Blocks for dispatch.
+type ToolStreamingSender interface {
+	ToolSender
+	StreamMessagesWithTools(
+		ctx context.Context,
+		model, system string,
+		messages []Message,
+		maxTokens int,
+		tools []ToolDefinition,
+		onChunk func(textDelta string),
+	) (Reply, error)
+}
+
 // Reply is the agent-level view of a provider response. It deliberately
 // mirrors provider.Response field-for-field (same names, same types) but
 // lives in this package so users of the agent API don't have to import
 // provider.
+//
+// Blocks is populated when the provider returns content blocks — in
+// particular when stop_reason=="tool_use", Blocks will contain the
+// tool_use blocks that the agentic loop should dispatch.
 type Reply struct {
 	Content      string
+	Blocks       []ContentBlock
 	Model        string
 	StopReason   string
 	InputTokens  int
@@ -159,6 +194,202 @@ func (a *Agent) TurnStream(
 	a.sessionInputTokens += reply.InputTokens
 	a.sessionOutputTokens += reply.OutputTokens
 	return reply, nil
+}
+
+// maxToolIterations is the safety cap on the agentic loop. If the model
+// requests more tool calls than this in a single Run, we bail out with an
+// error rather than looping forever.
+const maxToolIterations = 20
+
+// Run is the agentic loop. It appends the user message to history then
+// repeatedly calls the provider until the model reaches end_turn (no more
+// tool calls) or the iteration cap is hit.
+//
+// If tools is nil or executor is nil, Run is equivalent to Turn (single-turn,
+// no tool dispatch).
+func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinition, executor ToolExecutor) (Reply, error) {
+	if a.Sender == nil {
+		return Reply{}, fmt.Errorf("agent: no Sender configured")
+	}
+	if a.Model == "" {
+		return Reply{}, fmt.Errorf("agent: Model is required")
+	}
+	if userInput == "" {
+		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
+	}
+
+	// No tools → plain Turn.
+	if len(tools) == 0 || executor == nil {
+		return a.Turn(ctx, userInput)
+	}
+
+	ts, ok := a.Sender.(ToolSender)
+	if !ok {
+		// Sender doesn't support tools; fall back to Turn.
+		return a.Turn(ctx, userInput)
+	}
+
+	a.History.Append(NewUserMessage(userInput))
+
+	for i := 0; i < maxToolIterations; i++ {
+		reply, err := ts.SendMessagesWithTools(ctx, a.Model, a.System, a.History.Snapshot(), a.MaxTokens, tools)
+		if err != nil {
+			if i == 0 {
+				a.History.popLast()
+			}
+			return Reply{}, fmt.Errorf("agent: run[%d]: %w", i, err)
+		}
+		a.sessionInputTokens += reply.InputTokens
+		a.sessionOutputTokens += reply.OutputTokens
+
+		if reply.StopReason == "tool_use" {
+			// Append assistant message with tool_use blocks, then dispatch.
+			a.History.Append(NewToolUseMessage(reply.Blocks))
+
+			resultBlocks, err := dispatchTools(ctx, executor, reply.Blocks)
+			if err != nil {
+				return Reply{}, fmt.Errorf("agent: dispatch tools[%d]: %w", i, err)
+			}
+			a.History.Append(NewToolResultMessage(resultBlocks))
+			continue
+		}
+
+		// end_turn (or other stop reason): done.
+		// Use text content from reply; if Content is empty but Blocks has text, reconstruct.
+		content := reply.Content
+		if content == "" {
+			content = textFromBlocks(reply.Blocks)
+		}
+		a.History.Append(NewAssistantMessage(content))
+		reply.Content = content
+		return reply, nil
+	}
+
+	return Reply{}, fmt.Errorf("agent: exceeded max tool iterations (%d)", maxToolIterations)
+}
+
+// RunStream is the streaming agentic loop. Behaves like Run but streams text
+// deltas to onChunk as they arrive from the provider.
+//
+// If tools is nil or executor is nil, RunStream is equivalent to TurnStream.
+func (a *Agent) RunStream(
+	ctx context.Context,
+	userInput string,
+	tools []ToolDefinition,
+	executor ToolExecutor,
+	onChunk func(string),
+) (Reply, error) {
+	if a.Sender == nil {
+		return Reply{}, fmt.Errorf("agent: no Sender configured")
+	}
+	if a.Model == "" {
+		return Reply{}, fmt.Errorf("agent: Model is required")
+	}
+	if userInput == "" {
+		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
+	}
+
+	// No tools → plain TurnStream.
+	if len(tools) == 0 || executor == nil {
+		return a.TurnStream(ctx, userInput, onChunk)
+	}
+
+	// Try ToolStreamingSender first, then fall back to ToolSender (buffered).
+	if tss, ok := a.Sender.(ToolStreamingSender); ok {
+		return a.runStreamLoop(ctx, userInput, tools, executor, onChunk,
+			func(ctx context.Context, msgs []Message) (Reply, error) {
+				return tss.StreamMessagesWithTools(ctx, a.Model, a.System, msgs, a.MaxTokens, tools, onChunk)
+			})
+	}
+	if ts, ok := a.Sender.(ToolSender); ok {
+		return a.runStreamLoop(ctx, userInput, tools, executor, onChunk,
+			func(ctx context.Context, msgs []Message) (Reply, error) {
+				reply, err := ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, a.MaxTokens, tools)
+				if err == nil && onChunk != nil && reply.Content != "" {
+					onChunk(reply.Content)
+				}
+				return reply, err
+			})
+	}
+
+	// Neither interface available → plain TurnStream.
+	return a.TurnStream(ctx, userInput, onChunk)
+}
+
+// runStreamLoop is the shared inner loop for RunStream. The send function
+// encapsulates the provider call (streaming or buffered).
+func (a *Agent) runStreamLoop(
+	ctx context.Context,
+	userInput string,
+	tools []ToolDefinition,
+	executor ToolExecutor,
+	_ func(string), // onChunk already closed over by send
+	send func(ctx context.Context, msgs []Message) (Reply, error),
+) (Reply, error) {
+	a.History.Append(NewUserMessage(userInput))
+
+	for i := 0; i < maxToolIterations; i++ {
+		reply, err := send(ctx, a.History.Snapshot())
+		if err != nil {
+			if i == 0 {
+				a.History.popLast()
+			}
+			return Reply{}, fmt.Errorf("agent: run-stream[%d]: %w", i, err)
+		}
+		a.sessionInputTokens += reply.InputTokens
+		a.sessionOutputTokens += reply.OutputTokens
+
+		if reply.StopReason == "tool_use" {
+			a.History.Append(NewToolUseMessage(reply.Blocks))
+
+			resultBlocks, err := dispatchTools(ctx, executor, reply.Blocks)
+			if err != nil {
+				return Reply{}, fmt.Errorf("agent: dispatch tools[%d]: %w", i, err)
+			}
+			a.History.Append(NewToolResultMessage(resultBlocks))
+			continue
+		}
+
+		content := reply.Content
+		if content == "" {
+			content = textFromBlocks(reply.Blocks)
+		}
+		a.History.Append(NewAssistantMessage(content))
+		reply.Content = content
+		return reply, nil
+	}
+
+	return Reply{}, fmt.Errorf("agent: exceeded max tool iterations (%d)", maxToolIterations)
+}
+
+// dispatchTools calls executor.Execute for every tool_use block in blocks,
+// returning the corresponding tool_result blocks. Errors from Execute are
+// returned as tool_result blocks with IsError=true so the model can recover.
+func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentBlock) ([]ContentBlock, error) {
+	var results []ContentBlock
+	for _, b := range blocks {
+		if b.Type != "tool_use" {
+			continue
+		}
+		output, execErr := executor.Execute(ctx, b.Name, b.Input)
+		if execErr != nil {
+			results = append(results, NewToolResultBlock(b.ID, execErr.Error(), true))
+		} else {
+			results = append(results, NewToolResultBlock(b.ID, output, false))
+		}
+	}
+	return results, nil
+}
+
+// textFromBlocks joins text from all "text" content blocks.
+func textFromBlocks(blocks []ContentBlock) string {
+	var sb strings.Builder
+	for _, b := range blocks {
+		if b.Type == "text" {
+			sb.WriteString(b.Text)
+		}
+	}
+	return sb.String()
 }
 
 // SessionTokens returns the cumulative input and output token counts for all

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -227,5 +228,189 @@ func TestAgent_TurnStream_Error_RestoresHistory(t *testing.T) {
 	}
 	if n := a.History.Len(); n != 0 {
 		t.Errorf("History.Len = %d after failed TurnStream, want 0", n)
+	}
+}
+
+// ─── Run() agentic loop tests ─────────────────────────────────────────────
+
+// fakeToolSender implements both Sender and ToolSender. On each call it pops
+// the next reply from the replies slice so callers can script multi-turn
+// sequences.
+type fakeToolSender struct {
+	replies []Reply
+	calls   int
+}
+
+func (f *fakeToolSender) SendMessages(_ context.Context, _, _ string, _ []Message, _ int) (Reply, error) {
+	return f.nextReply()
+}
+
+func (f *fakeToolSender) SendMessagesWithTools(_ context.Context, _, _ string, _ []Message, _ int, _ []ToolDefinition) (Reply, error) {
+	return f.nextReply()
+}
+
+func (f *fakeToolSender) nextReply() (Reply, error) {
+	if f.calls >= len(f.replies) {
+		return Reply{}, fmt.Errorf("fakeToolSender: no more replies (call %d)", f.calls)
+	}
+	r := f.replies[f.calls]
+	f.calls++
+	return r, nil
+}
+
+// fakeExecutor implements ToolExecutor, returning canned results keyed by name.
+type fakeExecutor struct {
+	results map[string]string
+	called  []string
+}
+
+func (f *fakeExecutor) Execute(_ context.Context, name string, _ map[string]any) (string, error) {
+	f.called = append(f.called, name)
+	if f.results != nil {
+		if v, ok := f.results[name]; ok {
+			return v, nil
+		}
+	}
+	return "ok", nil
+}
+
+func TestAgent_Run_NoTools_FallsBackToTurn(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{{Content: "plain reply", StopReason: "end_turn"}},
+	}
+	a := New(send, "m")
+
+	reply, err := a.Run(context.Background(), "hello", nil, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.Content != "plain reply" {
+		t.Errorf("Content = %q", reply.Content)
+	}
+}
+
+func TestAgent_Run_ToolUse_ThenEndTurn(t *testing.T) {
+	// Round 1: model returns tool_use
+	// Round 2: model returns end_turn with final answer
+	send := &fakeToolSender{
+		replies: []Reply{
+			{
+				StopReason: "tool_use",
+				Blocks: []ContentBlock{
+					NewToolUseBlock("call-1", "bash", map[string]any{"command": "echo hi"}),
+				},
+			},
+			{
+				Content:    "The output was: hi",
+				StopReason: "end_turn",
+			},
+		},
+	}
+	exec := &fakeExecutor{results: map[string]string{"bash": "hi"}}
+
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "bash", Description: "run shell"}}
+
+	reply, err := a.Run(context.Background(), "run echo hi", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.Content != "The output was: hi" {
+		t.Errorf("Content = %q", reply.Content)
+	}
+	if reply.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q", reply.StopReason)
+	}
+
+	// Executor was called once with "bash".
+	if len(exec.called) != 1 || exec.called[0] != "bash" {
+		t.Errorf("executor called = %v", exec.called)
+	}
+
+	// History should be: user, assistant(tool_use), user(tool_result), assistant(final)
+	snap := a.History.Snapshot()
+	if len(snap) != 4 {
+		t.Fatalf("History len = %d, want 4 (%v)", len(snap), snap)
+	}
+	if snap[0].Role != RoleUser {
+		t.Errorf("snap[0] role = %q", snap[0].Role)
+	}
+	if snap[1].Role != RoleAssistant || len(snap[1].Blocks) == 0 {
+		t.Errorf("snap[1] should be assistant with blocks: %+v", snap[1])
+	}
+	if snap[2].Role != RoleUser || len(snap[2].Blocks) == 0 {
+		t.Errorf("snap[2] should be user with tool results: %+v", snap[2])
+	}
+	if snap[3].Role != RoleAssistant || snap[3].Content != "The output was: hi" {
+		t.Errorf("snap[3] = %+v", snap[3])
+	}
+}
+
+func TestAgent_Run_MultipleToolCalls(t *testing.T) {
+	// Round 1: two tool calls in one response
+	// Round 2: end_turn
+	send := &fakeToolSender{
+		replies: []Reply{
+			{
+				StopReason: "tool_use",
+				Blocks: []ContentBlock{
+					NewToolUseBlock("c1", "bash", map[string]any{"command": "echo a"}),
+					NewToolUseBlock("c2", "bash", map[string]any{"command": "echo b"}),
+				},
+			},
+			{Content: "done", StopReason: "end_turn"},
+		},
+	}
+	exec := &fakeExecutor{}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "bash"}}
+
+	_, err := a.Run(context.Background(), "go", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Both tool calls executed.
+	if len(exec.called) != 2 {
+		t.Errorf("executor called %d times, want 2", len(exec.called))
+	}
+}
+
+func TestAgent_Run_ExceedsMaxIterations(t *testing.T) {
+	// Every reply is tool_use — loop should hit the cap.
+	replies := make([]Reply, maxToolIterations+5)
+	for i := range replies {
+		replies[i] = Reply{
+			StopReason: "tool_use",
+			Blocks:     []ContentBlock{NewToolUseBlock("c", "bash", nil)},
+		}
+	}
+	send := &fakeToolSender{replies: replies}
+	exec := &fakeExecutor{}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "bash"}}
+
+	_, err := a.Run(context.Background(), "go", defs, exec)
+	if err == nil {
+		t.Fatal("expected error when max iterations exceeded")
+	}
+}
+
+func TestAgent_Run_SenderWithoutToolSupport_FallsBackToTurn(t *testing.T) {
+	// A plain fakeSender (no ToolSender) should just do a single Turn.
+	send := &fakeSender{reply: Reply{Content: "plain", StopReason: "end_turn"}}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "bash"}}
+	exec := &fakeExecutor{}
+
+	reply, err := a.Run(context.Background(), "hi", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.Content != "plain" {
+		t.Errorf("Content = %q", reply.Content)
+	}
+	// Executor should NOT have been called.
+	if len(exec.called) != 0 {
+		t.Errorf("executor should not be called when sender has no ToolSender support")
 	}
 }

--- a/internal/agent/content.go
+++ b/internal/agent/content.go
@@ -1,0 +1,70 @@
+package agent
+
+// ContentBlock is a single element of a multi-part message. It unifies the
+// three roles a block can play in an LLM conversation:
+//
+//   - "text"        — plain assistant or user text
+//   - "tool_use"    — the model requesting a tool call (assistant turn)
+//   - "tool_result" — the result of a tool call (user turn)
+//
+// The zero value is not valid; use the New*Block helpers instead.
+type ContentBlock struct {
+	// Type distinguishes the block variant: "text", "tool_use", "tool_result".
+	Type string `json:"type"`
+
+	// Text is the text payload (type=="text").
+	Text string `json:"text,omitempty"`
+
+	// ID is the unique call identifier supplied by the model (type=="tool_use").
+	// ToolUseID on a tool_result block must match the ID of the corresponding
+	// tool_use block.
+	ID string `json:"id,omitempty"`
+
+	// Name is the tool name the model wants to invoke (type=="tool_use").
+	Name string `json:"name,omitempty"`
+
+	// Input is the parsed argument map the model passes to the tool
+	// (type=="tool_use"). Keys and value types are defined by the tool's
+	// JSON Schema Parameters.
+	Input map[string]any `json:"input,omitempty"`
+
+	// ToolUseID links this result back to its originating tool_use block
+	// (type=="tool_result"). Must equal the ID field of the paired block.
+	ToolUseID string `json:"tool_use_id,omitempty"`
+
+	// Result is the textual output of the tool execution (type=="tool_result").
+	Result string `json:"result,omitempty"`
+
+	// IsError signals that the tool execution failed (type=="tool_result").
+	// The LLM can inspect Result for the error message and recover gracefully.
+	IsError bool `json:"is_error,omitempty"`
+}
+
+// NewTextBlock creates a ContentBlock with Type=="text".
+func NewTextBlock(text string) ContentBlock {
+	return ContentBlock{Type: "text", Text: text}
+}
+
+// NewToolUseBlock creates a ContentBlock with Type=="tool_use".
+// id must be unique within the conversation turn (supplied by the LLM).
+func NewToolUseBlock(id, name string, input map[string]any) ContentBlock {
+	return ContentBlock{
+		Type:  "tool_use",
+		ID:    id,
+		Name:  name,
+		Input: input,
+	}
+}
+
+// NewToolResultBlock creates a ContentBlock with Type=="tool_result".
+// toolUseID must match the ID of the corresponding tool_use block.
+// isError should be true when the tool execution failed; result carries the
+// error message in that case.
+func NewToolResultBlock(toolUseID, result string, isError bool) ContentBlock {
+	return ContentBlock{
+		Type:      "tool_result",
+		ToolUseID: toolUseID,
+		Result:    result,
+		IsError:   isError,
+	}
+}

--- a/internal/agent/content_test.go
+++ b/internal/agent/content_test.go
@@ -1,0 +1,110 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNewTextBlock(t *testing.T) {
+	b := NewTextBlock("hello world")
+	if b.Type != "text" {
+		t.Errorf("Type = %q, want %q", b.Type, "text")
+	}
+	if b.Text != "hello world" {
+		t.Errorf("Text = %q, want %q", b.Text, "hello world")
+	}
+	// other fields must be zero
+	if b.ID != "" || b.Name != "" || b.ToolUseID != "" || b.Result != "" || b.IsError {
+		t.Errorf("unexpected non-zero fields in text block: %+v", b)
+	}
+}
+
+func TestNewToolUseBlock(t *testing.T) {
+	input := map[string]any{"command": "echo hi"}
+	b := NewToolUseBlock("call-1", "bash", input)
+	if b.Type != "tool_use" {
+		t.Errorf("Type = %q, want %q", b.Type, "tool_use")
+	}
+	if b.ID != "call-1" {
+		t.Errorf("ID = %q, want %q", b.ID, "call-1")
+	}
+	if b.Name != "bash" {
+		t.Errorf("Name = %q, want %q", b.Name, "bash")
+	}
+	if b.Input["command"] != "echo hi" {
+		t.Errorf("Input = %v", b.Input)
+	}
+}
+
+func TestNewToolResultBlock(t *testing.T) {
+	b := NewToolResultBlock("call-1", "hi\n", false)
+	if b.Type != "tool_result" {
+		t.Errorf("Type = %q, want %q", b.Type, "tool_result")
+	}
+	if b.ToolUseID != "call-1" {
+		t.Errorf("ToolUseID = %q, want %q", b.ToolUseID, "call-1")
+	}
+	if b.Result != "hi\n" {
+		t.Errorf("Result = %q", b.Result)
+	}
+	if b.IsError {
+		t.Error("IsError should be false")
+	}
+}
+
+func TestNewToolResultBlock_Error(t *testing.T) {
+	b := NewToolResultBlock("call-1", "command not found", true)
+	if !b.IsError {
+		t.Error("IsError should be true")
+	}
+	if b.Result != "command not found" {
+		t.Errorf("Result = %q", b.Result)
+	}
+}
+
+func TestContentBlock_JSONRoundtrip(t *testing.T) {
+	blocks := []ContentBlock{
+		NewTextBlock("some text"),
+		NewToolUseBlock("id-1", "bash", map[string]any{"command": "ls"}),
+		NewToolResultBlock("id-1", "file1.go\nfile2.go", false),
+	}
+
+	data, err := json.Marshal(blocks)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded []ContentBlock
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(decoded) != 3 {
+		t.Fatalf("len = %d, want 3", len(decoded))
+	}
+	if decoded[0].Type != "text" || decoded[0].Text != "some text" {
+		t.Errorf("block[0] = %+v", decoded[0])
+	}
+	if decoded[1].Type != "tool_use" || decoded[1].ID != "id-1" || decoded[1].Name != "bash" {
+		t.Errorf("block[1] = %+v", decoded[1])
+	}
+	if decoded[2].Type != "tool_result" || decoded[2].ToolUseID != "id-1" || decoded[2].Result != "file1.go\nfile2.go" {
+		t.Errorf("block[2] = %+v", decoded[2])
+	}
+}
+
+func TestContentBlock_OmitEmptyFields(t *testing.T) {
+	b := NewTextBlock("hi")
+	data, err := json.Marshal(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	// id, name, tool_use_id, result, input, is_error should not appear
+	for _, field := range []string{`"id"`, `"name"`, `"tool_use_id"`, `"result"`, `"input"`, `"is_error"`} {
+		if strings.Contains(s, field) {
+			t.Errorf("field %s should be omitted but found in: %s", field, s)
+		}
+	}
+}

--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -17,12 +17,17 @@ const (
 	RoleAssistant Role = "assistant"
 )
 
-// Message is a single turn in the conversation. Content is plain text for now;
-// when M2 adds tool calls and image attachments this expands into a richer
-// content-block type, but the wire-level shape stays compatible.
+// Message is a single turn in the conversation.
+//
+// Content carries plain text for simple turns. Blocks carries the richer
+// multi-part form used when the assistant performs tool calls or when the user
+// returns tool results. When both fields are set the provider adapter should
+// prefer Blocks; when only Content is set the adapter encodes it as a single
+// text block.
 type Message struct {
-	Role    Role   `json:"role"`
-	Content string `json:"content"`
+	Role    Role           `json:"role"`
+	Content string         `json:"content,omitempty"`
+	Blocks  []ContentBlock `json:"blocks,omitempty"`
 }
 
 // NewUserMessage constructs a Message with RoleUser.
@@ -42,4 +47,20 @@ func NewAssistantMessage(content string) Message {
 // adapter is responsible for that translation.
 func NewSystemMessage(content string) Message {
 	return Message{Role: RoleSystem, Content: content}
+}
+
+// NewToolUseMessage constructs an assistant Message whose content is a slice
+// of blocks that may include tool_use blocks. The blocks slice typically
+// contains one or more tool_use blocks (and optionally a preceding text block
+// with the model's reasoning).
+func NewToolUseMessage(blocks []ContentBlock) Message {
+	return Message{Role: RoleAssistant, Blocks: blocks}
+}
+
+// NewToolResultMessage constructs a user Message that carries tool execution
+// results back to the model. Each element of results must be a tool_result
+// block whose ToolUseID matches a tool_use block in the preceding assistant
+// message.
+func NewToolResultMessage(results []ContentBlock) Message {
+	return Message{Role: RoleUser, Blocks: results}
 }

--- a/internal/agent/tool.go
+++ b/internal/agent/tool.go
@@ -1,0 +1,19 @@
+package agent
+
+import "context"
+
+// ToolDefinition describes a tool the LLM may invoke. The Parameters field
+// must be a valid JSON Schema "object" definition; most tools only need
+// "type", "properties", and "required".
+type ToolDefinition struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters"` // JSON Schema object
+}
+
+// ToolExecutor dispatches tool calls on behalf of the agentic loop. Each
+// implementation maps a tool name to a function; unknown names should return
+// an error so the LLM sees a clean error result rather than a panic.
+type ToolExecutor interface {
+	Execute(ctx context.Context, name string, input map[string]any) (string, error)
+}

--- a/internal/agent/tool_test.go
+++ b/internal/agent/tool_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestToolDefinition_Fields(t *testing.T) {
+	def := ToolDefinition{
+		Name:        "bash",
+		Description: "Run a shell command",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"command": map[string]any{
+					"type": "string",
+				},
+			},
+			"required": []string{"command"},
+		},
+	}
+
+	if def.Name != "bash" {
+		t.Errorf("Name = %q", def.Name)
+	}
+	if def.Description != "Run a shell command" {
+		t.Errorf("Description = %q", def.Description)
+	}
+	if def.Parameters["type"] != "object" {
+		t.Errorf("Parameters[type] = %v", def.Parameters["type"])
+	}
+}
+
+func TestToolDefinition_JSONRoundtrip(t *testing.T) {
+	def := ToolDefinition{
+		Name:        "echo",
+		Description: "Echo input",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+			"required":   []string{},
+		},
+	}
+
+	data, err := json.Marshal(def)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded ToolDefinition
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Name != def.Name {
+		t.Errorf("Name = %q, want %q", decoded.Name, def.Name)
+	}
+	if decoded.Description != def.Description {
+		t.Errorf("Description = %q", decoded.Description)
+	}
+}

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -78,11 +78,17 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		return provider.Response{}, errors.New("anthropic: at least one message is required")
 	}
 
+	msgs, err := toAPIMessages(req.Messages)
+	if err != nil {
+		return provider.Response{}, fmt.Errorf("anthropic: serialize messages: %w", err)
+	}
+
 	body := apiRequest{
 		Model:     req.Model,
 		MaxTokens: req.MaxTokens,
 		System:    req.SystemPrompt,
-		Messages:  toAPIMessages(req.Messages),
+		Messages:  msgs,
+		Tools:     toAPITools(req.Tools),
 	}
 	if body.MaxTokens <= 0 {
 		body.MaxTokens = DefaultMaxTokens
@@ -137,8 +143,10 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		return provider.Response{}, fmt.Errorf("anthropic: decode response: %w", err)
 	}
 
+	blocks := fromAPIContentBlocks(apiResp.Content)
 	return provider.Response{
 		Content:      joinTextBlocks(apiResp.Content),
+		Blocks:       blocks,
 		Model:        apiResp.Model,
 		StopReason:   apiResp.StopReason,
 		InputTokens:  apiResp.Usage.InputTokens,
@@ -156,24 +164,113 @@ func (c *Client) endpointURL() string {
 	return strings.TrimRight(base, "/") + MessagesPath
 }
 
+// toAPITools converts []agent.ToolDefinition to []apiTool.
+// Anthropic uses "input_schema" where the agent layer uses "parameters".
+func toAPITools(defs []agent.ToolDefinition) []apiTool {
+	if len(defs) == 0 {
+		return nil
+	}
+	out := make([]apiTool, len(defs))
+	for i, d := range defs {
+		out[i] = apiTool{
+			Name:        d.Name,
+			Description: d.Description,
+			InputSchema: d.Parameters,
+		}
+	}
+	return out
+}
+
 // toAPIMessages converts agent.Message slice into the Anthropic wire format.
 // The system role is filtered out here because Anthropic carries it as a
 // top-level Request.SystemPrompt — sending role:"system" inside the
 // messages array would 400.
-func toAPIMessages(in []agent.Message) []apiMessage {
+//
+// Messages with Blocks are serialized as a []apiContentBlock JSON array;
+// plain-text messages are serialized as a JSON string for compatibility.
+func toAPIMessages(in []agent.Message) ([]apiMessage, error) {
 	out := make([]apiMessage, 0, len(in))
 	for _, m := range in {
 		if m.Role == agent.RoleSystem {
 			continue
 		}
-		out = append(out, apiMessage{Role: string(m.Role), Content: m.Content})
+
+		if len(m.Blocks) > 0 {
+			// Serialize as a content-block array.
+			blocks, err := marshalBlocks(m.Blocks)
+			if err != nil {
+				return nil, err
+			}
+			raw, err := json.Marshal(blocks)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, apiMessage{Role: string(m.Role), Content: raw})
+		} else {
+			// Plain string content.
+			raw, err := json.Marshal(m.Content)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, apiMessage{Role: string(m.Role), Content: raw})
+		}
+	}
+	return out, nil
+}
+
+// marshalBlocks converts agent.ContentBlock slice to []apiContentBlock.
+// tool_result blocks are serialized with a nested "content" string field
+// per the Anthropic wire format.
+func marshalBlocks(blocks []agent.ContentBlock) ([]map[string]any, error) {
+	out := make([]map[string]any, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			out = append(out, map[string]any{
+				"type": "text",
+				"text": b.Text,
+			})
+		case "tool_use":
+			m := map[string]any{
+				"type":  "tool_use",
+				"id":    b.ID,
+				"name":  b.Name,
+				"input": b.Input,
+			}
+			out = append(out, m)
+		case "tool_result":
+			m := map[string]any{
+				"type":        "tool_result",
+				"tool_use_id": b.ToolUseID,
+				"content":     b.Result,
+			}
+			if b.IsError {
+				m["is_error"] = true
+			}
+			out = append(out, m)
+		default:
+			return nil, fmt.Errorf("anthropic: unknown block type %q", b.Type)
+		}
+	}
+	return out, nil
+}
+
+// fromAPIContentBlocks converts the response content blocks to agent.ContentBlock.
+func fromAPIContentBlocks(blocks []apiContentBlock) []agent.ContentBlock {
+	out := make([]agent.ContentBlock, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			out = append(out, agent.NewTextBlock(b.Text))
+		case "tool_use":
+			out = append(out, agent.NewToolUseBlock(b.ID, b.Name, b.Input))
+		}
 	}
 	return out
 }
 
 // joinTextBlocks concatenates the text from every "text" content block.
-// Non-text blocks (tool_use in M2+) are skipped here; the agent loop reads
-// them out of the raw apiResponse in later milestones.
+// Non-text blocks (tool_use) are skipped.
 func joinTextBlocks(blocks []apiContentBlock) string {
 	var b strings.Builder
 	for _, blk := range blocks {

--- a/internal/provider/anthropic/client_test.go
+++ b/internal/provider/anthropic/client_test.go
@@ -49,8 +49,8 @@ func TestSend_Success(t *testing.T) {
 		if len(req.Messages) != 1 {
 			t.Fatalf("messages len = %d, want 1", len(req.Messages))
 		}
-		if req.Messages[0].Role != "user" || req.Messages[0].Content != "hello" {
-			t.Errorf("first message = %+v, want {user, hello}", req.Messages[0])
+		if req.Messages[0].Role != "user" || string(req.Messages[0].Content) != `"hello"` {
+			t.Errorf("first message = %+v, want {user, \"hello\"}", req.Messages[0])
 		}
 
 		// Response

--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -11,15 +11,28 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Leihb/octo/internal/agent"
 	"github.com/Leihb/octo/internal/provider"
 )
+
+// blockAccumulator holds in-progress state for a single content block while
+// the SSE stream is open. Text blocks accumulate their text delta-by-delta;
+// tool_use blocks accumulate input_json_delta fragments that are JSON-parsed
+// once the stream for that block closes (content_block_stop).
+type blockAccumulator struct {
+	blockType string
+	text      strings.Builder
+	id        string
+	name      string
+	inputJSON strings.Builder
+}
 
 // SendStream implements provider.StreamingProvider against Anthropic's
 // Messages API with `stream: true`.
 //
 // Each text delta (content_block_delta of type text_delta) is forwarded to
-// onChunk synchronously. The aggregated Content, Model, StopReason, and
-// token usage are returned in the final Response.
+// onChunk synchronously. The aggregated Content, Blocks, Model, StopReason,
+// and token usage are returned in the final Response.
 //
 // Cancellation is via ctx; no HTTP-level timeout is set, because streaming
 // responses can legitimately run for minutes.
@@ -31,12 +44,18 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, onChunk f
 		return provider.Response{}, errors.New("anthropic: at least one message is required")
 	}
 
+	msgs, err := toAPIMessages(req.Messages)
+	if err != nil {
+		return provider.Response{}, fmt.Errorf("anthropic: serialize messages: %w", err)
+	}
+
 	body := apiRequest{
 		Model:     req.Model,
 		MaxTokens: req.MaxTokens,
 		System:    req.SystemPrompt,
-		Messages:  toAPIMessages(req.Messages),
+		Messages:  msgs,
 		Stream:    true,
+		Tools:     toAPITools(req.Tools),
 	}
 	if body.MaxTokens <= 0 {
 		body.MaxTokens = DefaultMaxTokens
@@ -79,8 +98,10 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, onChunk f
 	}
 
 	var (
-		contentB strings.Builder
-		result   provider.Response
+		result     provider.Response
+		accByIndex = map[int]*blockAccumulator{}
+		// ordered list of block indices to preserve emission order
+		blockOrder []int
 	)
 
 	scanner := bufio.NewScanner(resp.Body)
@@ -91,9 +112,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, onChunk f
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		// SSE frames: "data: <json>" lines, separated by blank lines, with
-		// optional "event: <type>" markers we ignore (the JSON payload
-		// always carries its own `type` field).
+		// SSE frames: "data: <json>" lines, separated by blank lines.
 		if !strings.HasPrefix(line, "data: ") {
 			continue
 		}
@@ -114,13 +133,40 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, onChunk f
 				result.InputTokens = ev.Message.Usage.InputTokens
 				result.OutputTokens = ev.Message.Usage.OutputTokens
 			}
+
+		case "content_block_start":
+			acc := &blockAccumulator{}
+			if ev.ContentBlock != nil {
+				acc.blockType = ev.ContentBlock.Type
+				acc.id = ev.ContentBlock.ID
+				acc.name = ev.ContentBlock.Name
+			}
+			accByIndex[ev.Index] = acc
+			blockOrder = append(blockOrder, ev.Index)
+
 		case "content_block_delta":
-			if ev.Delta != nil && ev.Delta.Type == "text_delta" && ev.Delta.Text != "" {
-				contentB.WriteString(ev.Delta.Text)
-				if onChunk != nil {
+			acc, ok := accByIndex[ev.Index]
+			if !ok {
+				// No content_block_start for this index — auto-create a text
+				// accumulator so we don't lose text deltas from providers that
+				// omit the start event.
+				acc = &blockAccumulator{blockType: "text"}
+				accByIndex[ev.Index] = acc
+				blockOrder = append(blockOrder, ev.Index)
+			}
+			if ev.Delta == nil {
+				break
+			}
+			switch ev.Delta.Type {
+			case "text_delta":
+				acc.text.WriteString(ev.Delta.Text)
+				if onChunk != nil && ev.Delta.Text != "" {
 					onChunk(ev.Delta.Text)
 				}
+			case "input_json_delta":
+				acc.inputJSON.WriteString(ev.Delta.PartialJSON)
 			}
+
 		case "message_delta":
 			if ev.Delta != nil && ev.Delta.StopReason != "" {
 				result.StopReason = ev.Delta.StopReason
@@ -130,9 +176,8 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, onChunk f
 			if ev.Usage != nil {
 				result.OutputTokens = ev.Usage.OutputTokens
 			}
+
 		case "error":
-			// Server-side errors mid-stream are surfaced as `event: error`.
-			// The payload reuses apiError shape.
 			var apiErr apiError
 			_ = json.Unmarshal([]byte(data), &apiErr)
 			return result, fmt.Errorf("anthropic: stream error: %s", apiErr.Error.Message)
@@ -142,7 +187,30 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, onChunk f
 		return result, fmt.Errorf("anthropic: stream read: %w", err)
 	}
 
-	result.Content = contentB.String()
+	// Build the final block list in order.
+	var textB strings.Builder
+	blocks := make([]agent.ContentBlock, 0, len(blockOrder))
+	for _, idx := range blockOrder {
+		acc, ok := accByIndex[idx]
+		if !ok {
+			continue
+		}
+		switch acc.blockType {
+		case "text":
+			t := acc.text.String()
+			textB.WriteString(t)
+			blocks = append(blocks, agent.NewTextBlock(t))
+		case "tool_use":
+			var input map[string]any
+			if s := acc.inputJSON.String(); s != "" {
+				_ = json.Unmarshal([]byte(s), &input)
+			}
+			blocks = append(blocks, agent.NewToolUseBlock(acc.id, acc.name, input))
+		}
+	}
+
+	result.Content = textB.String()
+	result.Blocks = blocks
 	return result, nil
 }
 

--- a/internal/provider/anthropic/tools_test.go
+++ b/internal/provider/anthropic/tools_test.go
@@ -1,0 +1,298 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo/internal/agent"
+	"github.com/Leihb/octo/internal/provider"
+)
+
+// TestSend_ToolDefinitions_WireFormat verifies that ToolDefinition slices are
+// translated into Anthropic's `tools` wire format (using "input_schema" rather
+// than "parameters").
+func TestSend_ToolDefinitions_WireFormat(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		// Return a minimal valid response so the client doesn't error.
+		_, _ = w.Write([]byte(`{"id":"m","type":"message","role":"assistant","model":"x","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	_, err := c.Send(context.Background(), provider.Request{
+		Model:    "x",
+		Messages: []agent.Message{agent.NewUserMessage("hi")},
+		Tools: []agent.ToolDefinition{
+			{
+				Name:        "bash",
+				Description: "Run shell command",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"command": map[string]any{"type": "string"},
+					},
+					"required": []string{"command"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var wireReq struct {
+		Tools []struct {
+			Name        string         `json:"name"`
+			Description string         `json:"description"`
+			InputSchema map[string]any `json:"input_schema"`
+			Parameters  map[string]any `json:"parameters"` // should NOT be present
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(capturedBody, &wireReq); err != nil {
+		t.Fatalf("decode wire body: %v", err)
+	}
+	if len(wireReq.Tools) != 1 {
+		t.Fatalf("tools len = %d, want 1", len(wireReq.Tools))
+	}
+	tool := wireReq.Tools[0]
+	if tool.Name != "bash" {
+		t.Errorf("tool.name = %q, want bash", tool.Name)
+	}
+	if tool.InputSchema == nil {
+		t.Error("tool.input_schema should be set")
+	}
+	if tool.Parameters != nil {
+		t.Error("tool.parameters should NOT be present (Anthropic uses input_schema)")
+	}
+}
+
+// TestSend_ToolUse_Response verifies that tool_use content blocks in the
+// response are converted to agent.ContentBlock correctly.
+func TestSend_ToolUse_Response(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"id": "msg_01",
+			"type": "message",
+			"role": "assistant",
+			"model": "x",
+			"content": [
+				{"type":"text","text":"Let me run that."},
+				{"type":"tool_use","id":"call-1","name":"bash","input":{"command":"echo hi"}}
+			],
+			"stop_reason": "tool_use",
+			"usage": {"input_tokens":10,"output_tokens":20}
+		}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	resp, err := c.Send(context.Background(), provider.Request{
+		Model:    "x",
+		Messages: []agent.Message{agent.NewUserMessage("run echo hi")},
+		Tools:    []agent.ToolDefinition{{Name: "bash"}},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if resp.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use", resp.StopReason)
+	}
+	if resp.Content != "Let me run that." {
+		t.Errorf("Content = %q", resp.Content)
+	}
+	if len(resp.Blocks) != 2 {
+		t.Fatalf("Blocks len = %d, want 2", len(resp.Blocks))
+	}
+	textBlock := resp.Blocks[0]
+	if textBlock.Type != "text" || textBlock.Text != "Let me run that." {
+		t.Errorf("Blocks[0] = %+v", textBlock)
+	}
+	toolBlock := resp.Blocks[1]
+	if toolBlock.Type != "tool_use" {
+		t.Errorf("Blocks[1].Type = %q, want tool_use", toolBlock.Type)
+	}
+	if toolBlock.ID != "call-1" || toolBlock.Name != "bash" {
+		t.Errorf("Blocks[1] = %+v", toolBlock)
+	}
+	if toolBlock.Input["command"] != "echo hi" {
+		t.Errorf("Blocks[1].Input = %v", toolBlock.Input)
+	}
+}
+
+// TestSend_ToolResultMessage verifies that an agent message containing
+// tool_result blocks is serialized correctly (Anthropic format: role=user,
+// content=[{type:tool_result, ...}]).
+func TestSend_ToolResultMessage(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"m","type":"message","role":"assistant","model":"x","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	msgs := []agent.Message{
+		agent.NewUserMessage("run echo hi"),
+		agent.NewToolUseMessage([]agent.ContentBlock{
+			agent.NewToolUseBlock("call-1", "bash", map[string]any{"command": "echo hi"}),
+		}),
+		agent.NewToolResultMessage([]agent.ContentBlock{
+			agent.NewToolResultBlock("call-1", "hi", false),
+		}),
+	}
+
+	_, err := c.Send(context.Background(), provider.Request{
+		Model:    "x",
+		Messages: msgs,
+		Tools:    []agent.ToolDefinition{{Name: "bash"}},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var wireReq struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(capturedBody, &wireReq); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Should be 3 messages: user text, assistant(tool_use), user(tool_result)
+	if len(wireReq.Messages) != 3 {
+		t.Fatalf("messages len = %d, want 3", len(wireReq.Messages))
+	}
+
+	// Message 1: user text (plain string)
+	if wireReq.Messages[0].Role != "user" {
+		t.Errorf("messages[0].role = %q", wireReq.Messages[0].Role)
+	}
+
+	// Message 2: assistant with tool_use blocks
+	if wireReq.Messages[1].Role != "assistant" {
+		t.Errorf("messages[1].role = %q", wireReq.Messages[1].Role)
+	}
+	var assistantContent []map[string]any
+	if err := json.Unmarshal(wireReq.Messages[1].Content, &assistantContent); err != nil {
+		t.Fatalf("decode assistant content: %v", err)
+	}
+	if len(assistantContent) != 1 || assistantContent[0]["type"] != "tool_use" {
+		t.Errorf("assistant content = %v", assistantContent)
+	}
+
+	// Message 3: user with tool_result blocks
+	if wireReq.Messages[2].Role != "user" {
+		t.Errorf("messages[2].role = %q", wireReq.Messages[2].Role)
+	}
+	var userContent []map[string]any
+	if err := json.Unmarshal(wireReq.Messages[2].Content, &userContent); err != nil {
+		t.Fatalf("decode user content: %v", err)
+	}
+	if len(userContent) != 1 || userContent[0]["type"] != "tool_result" {
+		t.Errorf("user content = %v", userContent)
+	}
+	if userContent[0]["tool_use_id"] != "call-1" {
+		t.Errorf("tool_use_id = %v", userContent[0]["tool_use_id"])
+	}
+}
+
+// TestSendStream_ToolUse verifies that tool_use blocks emitted during a stream
+// are accumulated and returned in resp.Blocks, and that input_json_delta
+// fragments are correctly assembled into the final Input map.
+func TestSendStream_ToolUse(t *testing.T) {
+	// Anthropic stream with one text block and one tool_use block.
+	toolStream := "" +
+		`data: {"type":"message_start","message":{"id":"m","model":"x","usage":{"input_tokens":10,"output_tokens":0}}}` + "\n\n" +
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","id":"","name":""}}` + "\n\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Thinking..."}}` + "\n\n" +
+		`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"call-99","name":"bash"}}` + "\n\n" +
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"command\":"}}` + "\n\n" +
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"echo test\"}"}}` + "\n\n" +
+		`data: {"type":"content_block_stop","index":1}` + "\n\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input_tokens":0,"output_tokens":15}}` + "\n\n" +
+		`data: {"type":"message_stop"}` + "\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, toolStream)
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	var textChunks []string
+	resp, err := c.SendStream(context.Background(), provider.Request{
+		Model:    "x",
+		Messages: []agent.Message{agent.NewUserMessage("run echo test")},
+		Tools:    []agent.ToolDefinition{{Name: "bash"}},
+	}, func(d string) { textChunks = append(textChunks, d) })
+	if err != nil {
+		t.Fatalf("SendStream: %v", err)
+	}
+
+	if resp.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use", resp.StopReason)
+	}
+	if resp.Content != "Thinking..." {
+		t.Errorf("Content = %q", resp.Content)
+	}
+	if len(textChunks) != 1 || textChunks[0] != "Thinking..." {
+		t.Errorf("textChunks = %v", textChunks)
+	}
+	if len(resp.Blocks) != 2 {
+		t.Fatalf("Blocks len = %d, want 2", len(resp.Blocks))
+	}
+	if resp.Blocks[0].Type != "text" || resp.Blocks[0].Text != "Thinking..." {
+		t.Errorf("Blocks[0] = %+v", resp.Blocks[0])
+	}
+	toolBlock := resp.Blocks[1]
+	if toolBlock.Type != "tool_use" || toolBlock.ID != "call-99" || toolBlock.Name != "bash" {
+		t.Errorf("Blocks[1] = %+v", toolBlock)
+	}
+	if toolBlock.Input["command"] != "echo test" {
+		t.Errorf("Blocks[1].Input = %v", toolBlock.Input)
+	}
+}
+
+// Ensure tools field is absent from wire request when no tools are specified.
+func TestSend_NoTools_FieldAbsent(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"m","type":"message","role":"assistant","model":"x","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	_, err := c.Send(context.Background(), provider.Request{
+		Model:    "x",
+		Messages: []agent.Message{agent.NewUserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(string(capturedBody), `"tools"`) {
+		t.Errorf("tools field should be absent when no tools: %s", capturedBody)
+	}
+}

--- a/internal/provider/anthropic/types.go
+++ b/internal/provider/anthropic/types.go
@@ -4,25 +4,35 @@
 // API reference: https://docs.anthropic.com/en/api/messages
 package anthropic
 
+import "encoding/json"
+
+// apiTool describes one tool the model may invoke, in the Anthropic wire format.
+// Note: Anthropic uses "input_schema" where the agent layer uses "parameters".
+type apiTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"input_schema"`
+}
+
 // apiRequest is the wire-level JSON body of POST /v1/messages.
-//
-// Tool definitions and request metadata arrive in later milestones.
 type apiRequest struct {
 	Model     string       `json:"model"`
 	MaxTokens int          `json:"max_tokens"`
 	System    string       `json:"system,omitempty"`
 	Messages  []apiMessage `json:"messages"`
 	Stream    bool         `json:"stream,omitempty"`
+	Tools     []apiTool    `json:"tools,omitempty"`
 }
 
 // apiMessage is one element of apiRequest.Messages.
 //
-// Anthropic accepts either a plain string Content or a slice of content blocks
-// (text, image, tool_use, tool_result). M1.2 always sends strings; the
-// adapter converts agent.Message → apiMessage one-to-one.
+// Anthropic accepts Content either as a plain string or as a slice of content
+// blocks (text, tool_use, tool_result). We use json.RawMessage to handle both
+// shapes when marshalling outgoing messages and when parsing is not needed
+// (we control what we write).
 type apiMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
 }
 
 // apiResponse is the wire-level JSON body of a successful 200 response.
@@ -36,12 +46,15 @@ type apiResponse struct {
 	Usage      apiUsageBlock     `json:"usage"`
 }
 
-// apiContentBlock is a single element of apiResponse.Content. M1.2 only
-// reads text blocks; tool_use blocks are returned in later milestones once
-// the tool layer can dispatch them.
+// apiContentBlock is a single element of apiResponse.Content.
+// For type=="text" only Text is populated; for type=="tool_use" ID, Name, and
+// Input are populated.
 type apiContentBlock struct {
-	Type string `json:"type"`           // "text" or "tool_use" in M2+
-	Text string `json:"text,omitempty"` // populated when Type == "text"
+	Type  string         `json:"type"`
+	Text  string         `json:"text,omitempty"`
+	ID    string         `json:"id,omitempty"`   // tool_use
+	Name  string         `json:"name,omitempty"` // tool_use
+	Input map[string]any `json:"input,omitempty"`
 }
 
 // apiUsageBlock is the token-count block Anthropic returns on every message.
@@ -66,16 +79,23 @@ type apiError struct {
 // content_block_stop, message_delta, message_stop, ping, and error events.
 // We only act on a subset; the rest is ignored.
 type streamEvent struct {
-	Type    string         `json:"type"`
-	Index   int            `json:"index,omitempty"`   // content_block_*
-	Message *streamMessage `json:"message,omitempty"` // message_start
-	Delta   *streamDelta   `json:"delta,omitempty"`   // content_block_delta, message_delta
-	Usage   *apiUsageBlock `json:"usage,omitempty"`   // message_delta
+	Type         string               `json:"type"`
+	Index        int                  `json:"index,omitempty"`        // content_block_*
+	Message      *streamMessage       `json:"message,omitempty"`      // message_start
+	Delta        *streamDelta         `json:"delta,omitempty"`        // content_block_delta, message_delta
+	Usage        *apiUsageBlock       `json:"usage,omitempty"`        // message_delta
+	ContentBlock *streamContentBlock  `json:"content_block,omitempty"` // content_block_start
+}
+
+// streamContentBlock is the block metadata emitted with content_block_start.
+// For text blocks only Type is set; for tool_use blocks ID and Name are also set.
+type streamContentBlock struct {
+	Type string `json:"type"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // streamMessage is the abridged message snapshot inside a message_start event.
-// Only fields we currently read are kept; the rest of the JSON is allowed
-// to flow past untouched.
 type streamMessage struct {
 	ID    string        `json:"id,omitempty"`
 	Model string        `json:"model,omitempty"`
@@ -84,10 +104,12 @@ type streamMessage struct {
 
 // streamDelta is the per-delta payload inside content_block_delta and
 // message_delta events.
-//   - content_block_delta: Type=="text_delta", Text holds the new bytes
-//   - message_delta:        StopReason set when the model stops
+//   - content_block_delta/text_delta:       Type=="text_delta",       Text holds the new bytes
+//   - content_block_delta/input_json_delta: Type=="input_json_delta", PartialJSON accumulates tool input
+//   - message_delta:                        StopReason set when the model stops
 type streamDelta struct {
-	Type       string `json:"type,omitempty"`
-	Text       string `json:"text,omitempty"`
-	StopReason string `json:"stop_reason,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Text        string `json:"text,omitempty"`
+	PartialJSON string `json:"partial_json,omitempty"`
+	StopReason  string `json:"stop_reason,omitempty"`
 }

--- a/internal/provider/anthropic/types.go
+++ b/internal/provider/anthropic/types.go
@@ -79,12 +79,12 @@ type apiError struct {
 // content_block_stop, message_delta, message_stop, ping, and error events.
 // We only act on a subset; the rest is ignored.
 type streamEvent struct {
-	Type         string               `json:"type"`
-	Index        int                  `json:"index,omitempty"`        // content_block_*
-	Message      *streamMessage       `json:"message,omitempty"`      // message_start
-	Delta        *streamDelta         `json:"delta,omitempty"`        // content_block_delta, message_delta
-	Usage        *apiUsageBlock       `json:"usage,omitempty"`        // message_delta
-	ContentBlock *streamContentBlock  `json:"content_block,omitempty"` // content_block_start
+	Type         string              `json:"type"`
+	Index        int                 `json:"index,omitempty"`         // content_block_*
+	Message      *streamMessage      `json:"message,omitempty"`       // message_start
+	Delta        *streamDelta        `json:"delta,omitempty"`         // content_block_delta, message_delta
+	Usage        *apiUsageBlock      `json:"usage,omitempty"`         // message_delta
+	ContentBlock *streamContentBlock `json:"content_block,omitempty"` // content_block_start
 }
 
 // streamContentBlock is the block metadata emitted with content_block_start.

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -72,10 +72,16 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		return provider.Response{}, errors.New("openai: at least one message is required")
 	}
 
+	msgs, err := toAPIMessages(req.SystemPrompt, req.Messages)
+	if err != nil {
+		return provider.Response{}, fmt.Errorf("openai: serialize messages: %w", err)
+	}
+
 	body := apiRequest{
 		Model:     req.Model,
 		MaxTokens: req.MaxTokens,
-		Messages:  toAPIMessages(req.SystemPrompt, req.Messages),
+		Messages:  msgs,
+		Tools:     toAPITools(req.Tools),
 	}
 	if body.MaxTokens <= 0 {
 		body.MaxTokens = DefaultMaxTokens
@@ -130,10 +136,31 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 	}
 	first := apiResp.Choices[0]
 
+	// Convert tool calls to agent.ContentBlock.
+	var blocks []agent.ContentBlock
+	var stopReason = first.FinishReason
+	if len(first.Message.ToolCalls) > 0 {
+		for _, tc := range first.Message.ToolCalls {
+			var input map[string]any
+			if tc.Function.Arguments != "" {
+				_ = json.Unmarshal([]byte(tc.Function.Arguments), &input)
+			}
+			blocks = append(blocks, agent.NewToolUseBlock(tc.ID, tc.Function.Name, input))
+		}
+		// Normalize finish_reason to Anthropic's naming.
+		if stopReason == "tool_calls" {
+			stopReason = "tool_use"
+		}
+	}
+	if first.Message.Content != "" {
+		blocks = append([]agent.ContentBlock{agent.NewTextBlock(first.Message.Content)}, blocks...)
+	}
+
 	return provider.Response{
 		Content:      first.Message.Content,
+		Blocks:       blocks,
 		Model:        apiResp.Model,
-		StopReason:   first.FinishReason,
+		StopReason:   stopReason,
 		InputTokens:  apiResp.Usage.PromptTokens,
 		OutputTokens: apiResp.Usage.CompletionTokens,
 	}, nil
@@ -149,14 +176,33 @@ func (c *Client) endpointURL() string {
 	return strings.TrimRight(base, "/") + ChatCompletionsPath
 }
 
+// toAPITools converts []agent.ToolDefinition to []apiTool (function format).
+func toAPITools(defs []agent.ToolDefinition) []apiTool {
+	if len(defs) == 0 {
+		return nil
+	}
+	out := make([]apiTool, len(defs))
+	for i, d := range defs {
+		out[i] = apiTool{
+			Type: "function",
+			Function: apiFunction{
+				Name:        d.Name,
+				Description: d.Description,
+				Parameters:  d.Parameters,
+			},
+		}
+	}
+	return out
+}
+
 // toAPIMessages converts agent.Message slice into the OpenAI wire format.
 //
 // OpenAI carries the system prompt as the FIRST element of the messages
-// array with role:"system" — the opposite direction from Anthropic, which
-// uses a separate top-level field. If a non-empty systemPrompt is passed we
-// prepend it; any role:"system" entries already in `in` are dropped so the
-// agent's SystemPrompt is the single source of truth.
-func toAPIMessages(systemPrompt string, in []agent.Message) []apiMessage {
+// array with role:"system". Tool result messages in agent History have
+// role=user + Blocks containing tool_result blocks — these are exploded into
+// individual role="tool" messages (one per result) because that's what the
+// OpenAI protocol expects.
+func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error) {
 	out := make([]apiMessage, 0, len(in)+1)
 	if strings.TrimSpace(systemPrompt) != "" {
 		out = append(out, apiMessage{Role: "system", Content: systemPrompt})
@@ -165,7 +211,58 @@ func toAPIMessages(systemPrompt string, in []agent.Message) []apiMessage {
 		if m.Role == agent.RoleSystem {
 			continue
 		}
+
+		// Assistant message with tool calls.
+		if m.Role == agent.RoleAssistant && len(m.Blocks) > 0 {
+			msg := apiMessage{Role: "assistant"}
+			for _, b := range m.Blocks {
+				switch b.Type {
+				case "text":
+					msg.Content = b.Text
+				case "tool_use":
+					msg.ToolCalls = append(msg.ToolCalls, apiToolCall{
+						ID:   b.ID,
+						Type: "function",
+						Function: apiToolCallFunction{
+							Name:      b.Name,
+							Arguments: marshalInput(b.Input),
+						},
+					})
+				}
+			}
+			out = append(out, msg)
+			continue
+		}
+
+		// User message with tool results — explode into individual role="tool" messages.
+		if m.Role == agent.RoleUser && len(m.Blocks) > 0 {
+			for _, b := range m.Blocks {
+				if b.Type == "tool_result" {
+					out = append(out, apiMessage{
+						Role:       "tool",
+						Content:    b.Result,
+						ToolCallID: b.ToolUseID,
+					})
+				}
+			}
+			continue
+		}
+
+		// Plain text message.
 		out = append(out, apiMessage{Role: string(m.Role), Content: m.Content})
 	}
-	return out
+	return out, nil
+}
+
+// marshalInput encodes a tool input map back to a compact JSON string.
+// Returns "{}" on nil/empty input so the wire value is always valid JSON.
+func marshalInput(input map[string]any) string {
+	if len(input) == 0 {
+		return "{}"
+	}
+	b, err := json.Marshal(input)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
 }

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -11,15 +11,23 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Leihb/octo/internal/agent"
 	"github.com/Leihb/octo/internal/provider"
 )
+
+// toolCallState accumulates streaming fragments for one tool call.
+type toolCallState struct {
+	id   string
+	name string
+	args strings.Builder
+}
 
 // SendStream implements provider.StreamingProvider against OpenAI's
 // Chat Completions API with `stream: true`.
 //
 // Each non-empty content delta is forwarded to onChunk synchronously. The
-// aggregated Content, Model, and FinishReason are returned in the final
-// Response. InputTokens / OutputTokens are typically zero on streaming
+// aggregated Content, Blocks, Model, and FinishReason are returned in the
+// final Response. InputTokens / OutputTokens are typically zero on streaming
 // responses because we don't send `stream_options.include_usage=true` —
 // some third-party OpenAI-compatible servers reject it, and the cost of
 // missing usage on a single turn is much smaller than losing compatibility.
@@ -31,11 +39,17 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, onChunk f
 		return provider.Response{}, errors.New("openai: at least one message is required")
 	}
 
+	msgs, err := toAPIMessages(req.SystemPrompt, req.Messages)
+	if err != nil {
+		return provider.Response{}, fmt.Errorf("openai: serialize messages: %w", err)
+	}
+
 	body := apiRequest{
 		Model:     req.Model,
 		MaxTokens: req.MaxTokens,
-		Messages:  toAPIMessages(req.SystemPrompt, req.Messages),
+		Messages:  msgs,
 		Stream:    true,
+		Tools:     toAPITools(req.Tools),
 	}
 	if body.MaxTokens <= 0 {
 		body.MaxTokens = DefaultMaxTokens
@@ -73,8 +87,10 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, onChunk f
 	}
 
 	var (
-		contentB strings.Builder
-		result   provider.Response
+		contentB   strings.Builder
+		result     provider.Response
+		toolStates = map[int]*toolCallState{} // keyed by tool call index
+		toolOrder  []int                      // preserve order
 	)
 
 	scanner := bufio.NewScanner(resp.Body)
@@ -117,8 +133,28 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, onChunk f
 				onChunk(choice.Delta.Content)
 			}
 		}
+		// Accumulate tool call fragments.
+		for _, tc := range choice.Delta.ToolCalls {
+			st, exists := toolStates[tc.Index]
+			if !exists {
+				st = &toolCallState{}
+				toolStates[tc.Index] = st
+				toolOrder = append(toolOrder, tc.Index)
+			}
+			if tc.ID != "" {
+				st.id = tc.ID
+			}
+			if tc.Function.Name != "" {
+				st.name = tc.Function.Name
+			}
+			st.args.WriteString(tc.Function.Arguments)
+		}
 		if choice.FinishReason != "" {
-			result.StopReason = choice.FinishReason
+			stopReason := choice.FinishReason
+			if stopReason == "tool_calls" {
+				stopReason = "tool_use"
+			}
+			result.StopReason = stopReason
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -126,6 +162,24 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, onChunk f
 	}
 
 	result.Content = contentB.String()
+
+	// Build final block list: text first (if any), then tool_use blocks.
+	var blocks []agent.ContentBlock
+	if result.Content != "" {
+		blocks = append(blocks, agent.NewTextBlock(result.Content))
+	}
+	for _, idx := range toolOrder {
+		st := toolStates[idx]
+		var input map[string]any
+		if s := st.args.String(); s != "" {
+			_ = json.Unmarshal([]byte(s), &input)
+		}
+		blocks = append(blocks, agent.NewToolUseBlock(st.id, st.name, input))
+	}
+	if len(blocks) > 0 {
+		result.Blocks = blocks
+	}
+
 	return result, nil
 }
 

--- a/internal/provider/openai/tools_test.go
+++ b/internal/provider/openai/tools_test.go
@@ -1,0 +1,264 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo/internal/agent"
+	"github.com/Leihb/octo/internal/provider"
+)
+
+// TestSend_ToolDefinitions_WireFormat verifies that ToolDefinition slices are
+// converted to OpenAI's function-tool wire format.
+func TestSend_ToolDefinitions_WireFormat(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"x","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	_, err := c.Send(context.Background(), provider.Request{
+		Model:    "x",
+		Messages: []agent.Message{agent.NewUserMessage("hi")},
+		Tools: []agent.ToolDefinition{
+			{
+				Name:        "bash",
+				Description: "Run shell",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"command": map[string]any{"type": "string"},
+					},
+					"required": []string{"command"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wireReq struct {
+		Tools []struct {
+			Type     string `json:"type"`
+			Function struct {
+				Name        string         `json:"name"`
+				Description string         `json:"description"`
+				Parameters  map[string]any `json:"parameters"`
+			} `json:"function"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(capturedBody, &wireReq); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(wireReq.Tools) != 1 {
+		t.Fatalf("tools len = %d, want 1", len(wireReq.Tools))
+	}
+	tool := wireReq.Tools[0]
+	if tool.Type != "function" {
+		t.Errorf("tool.type = %q, want function", tool.Type)
+	}
+	if tool.Function.Name != "bash" {
+		t.Errorf("function.name = %q", tool.Function.Name)
+	}
+	if tool.Function.Parameters["type"] != "object" {
+		t.Errorf("function.parameters.type = %v", tool.Function.Parameters["type"])
+	}
+}
+
+// TestSend_ToolCall_Response verifies that a response with tool_calls is
+// converted to agent.ContentBlock(tool_use) and StopReason normalised.
+func TestSend_ToolCall_Response(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"id":"x","object":"chat.completion","model":"gpt-4o",
+			"choices":[{
+				"index":0,
+				"message":{
+					"role":"assistant",
+					"content":null,
+					"tool_calls":[{
+						"id":"call-42",
+						"type":"function",
+						"function":{"name":"bash","arguments":"{\"command\":\"echo hello\"}"}
+					}]
+				},
+				"finish_reason":"tool_calls"
+			}],
+			"usage":{"prompt_tokens":5,"completion_tokens":15,"total_tokens":20}
+		}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	resp, err := c.Send(context.Background(), provider.Request{
+		Model:    "gpt-4o",
+		Messages: []agent.Message{agent.NewUserMessage("echo hello")},
+		Tools:    []agent.ToolDefinition{{Name: "bash"}},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	// finish_reason:"tool_calls" → "tool_use"
+	if resp.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use", resp.StopReason)
+	}
+	if len(resp.Blocks) != 1 {
+		t.Fatalf("Blocks len = %d, want 1", len(resp.Blocks))
+	}
+	b := resp.Blocks[0]
+	if b.Type != "tool_use" {
+		t.Errorf("Blocks[0].Type = %q", b.Type)
+	}
+	if b.ID != "call-42" || b.Name != "bash" {
+		t.Errorf("Blocks[0] = %+v", b)
+	}
+	if b.Input["command"] != "echo hello" {
+		t.Errorf("Blocks[0].Input = %v", b.Input)
+	}
+}
+
+// TestSend_ToolResultMessages_WireFormat verifies that tool_result blocks are
+// serialized as individual role="tool" messages (OpenAI format).
+func TestSend_ToolResultMessages_WireFormat(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"x","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	msgs := []agent.Message{
+		agent.NewUserMessage("run echo hi"),
+		agent.NewToolUseMessage([]agent.ContentBlock{
+			agent.NewToolUseBlock("call-1", "bash", map[string]any{"command": "echo hi"}),
+		}),
+		agent.NewToolResultMessage([]agent.ContentBlock{
+			agent.NewToolResultBlock("call-1", "hi", false),
+		}),
+	}
+
+	_, err := c.Send(context.Background(), provider.Request{
+		Model:    "x",
+		Messages: msgs,
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var wireReq struct {
+		Messages []struct {
+			Role       string `json:"role"`
+			Content    string `json:"content"`
+			ToolCallID string `json:"tool_call_id"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(capturedBody, &wireReq); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// user, assistant(tool_call), tool(result)
+	if len(wireReq.Messages) != 3 {
+		t.Fatalf("messages len = %d, want 3: %s", len(wireReq.Messages), capturedBody)
+	}
+	if wireReq.Messages[0].Role != "user" {
+		t.Errorf("msg[0].role = %q", wireReq.Messages[0].Role)
+	}
+	if wireReq.Messages[1].Role != "assistant" {
+		t.Errorf("msg[1].role = %q", wireReq.Messages[1].Role)
+	}
+	if wireReq.Messages[2].Role != "tool" {
+		t.Errorf("msg[2].role = %q, want tool", wireReq.Messages[2].Role)
+	}
+	if wireReq.Messages[2].ToolCallID != "call-1" {
+		t.Errorf("msg[2].tool_call_id = %q", wireReq.Messages[2].ToolCallID)
+	}
+	if wireReq.Messages[2].Content != "hi" {
+		t.Errorf("msg[2].content = %q", wireReq.Messages[2].Content)
+	}
+}
+
+// TestSend_NoTools_FieldAbsent ensures we don't send a "tools" key at all
+// when no tools are defined (some OpenAI-compatible servers reject the field
+// even when empty).
+func TestSend_NoTools_FieldAbsent(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"x","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	_, err := c.Send(context.Background(), provider.Request{
+		Model:    "x",
+		Messages: []agent.Message{agent.NewUserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(capturedBody), `"tools"`) {
+		t.Errorf("tools field should be absent: %s", capturedBody)
+	}
+}
+
+// TestSendStream_ToolCalls_Accumulated verifies that streaming tool_calls
+// fragments are assembled into the correct Blocks at stream end.
+func TestSendStream_ToolCalls_Accumulated(t *testing.T) {
+	// Simulated OpenAI stream with a tool_calls delta.
+	toolStream := "" +
+		`data: {"id":"x","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}` + "\n\n" +
+		`data: {"id":"x","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call-7","type":"function","function":{"name":"bash","arguments":""}}]},"finish_reason":null}]}` + "\n\n" +
+		`data: {"id":"x","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"command\":"}}]},"finish_reason":null}]}` + "\n\n" +
+		`data: {"id":"x","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"ls\"}"}}]},"finish_reason":null}]}` + "\n\n" +
+		`data: {"id":"x","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n" +
+		"data: [DONE]\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, toolStream)
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	resp, err := c.SendStream(context.Background(), provider.Request{
+		Model:    "gpt-4o",
+		Messages: []agent.Message{agent.NewUserMessage("list files")},
+		Tools:    []agent.ToolDefinition{{Name: "bash"}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("SendStream: %v", err)
+	}
+
+	if resp.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use", resp.StopReason)
+	}
+	if len(resp.Blocks) != 1 {
+		t.Fatalf("Blocks len = %d, want 1", len(resp.Blocks))
+	}
+	b := resp.Blocks[0]
+	if b.Type != "tool_use" || b.ID != "call-7" || b.Name != "bash" {
+		t.Errorf("Blocks[0] = %+v", b)
+	}
+	if b.Input["command"] != "ls" {
+		t.Errorf("Blocks[0].Input = %v", b.Input)
+	}
+}

--- a/internal/provider/openai/types.go
+++ b/internal/provider/openai/types.go
@@ -8,28 +8,51 @@
 // pointing Client.BaseURL at the alternative host.
 package openai
 
+// apiFunction describes the callable function part of a tool.
+type apiFunction struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters"`
+}
+
+// apiTool wraps an apiFunction with a type discriminator (always "function").
+type apiTool struct {
+	Type     string      `json:"type"` // "function"
+	Function apiFunction `json:"function"`
+}
+
 // apiRequest is the wire-level JSON body of POST /v1/chat/completions.
-//
-// Only the fields M2 needs are wired up. Tool calls, response_format, and
-// reasoning_effort arrive in later milestones. `stream_options` is
-// deliberately omitted — OpenAI itself accepts it (to request a final
-// `usage` chunk) but third-party clones diverge in support, and we don't
-// want to gate compatibility on a non-essential field.
 type apiRequest struct {
 	Model     string       `json:"model"`
 	Messages  []apiMessage `json:"messages"`
 	MaxTokens int          `json:"max_tokens,omitempty"`
 	Stream    bool         `json:"stream,omitempty"`
+	Tools     []apiTool    `json:"tools,omitempty"`
 }
 
 // apiMessage is one element of apiRequest.Messages.
 //
-// OpenAI accepts Content either as a plain string or as an array of content
-// parts (for vision). M2 always sends strings; image attachments arrive in
-// a later milestone alongside the tool-use work.
+// For plain turns Content is a string. For assistant turns with tool calls
+// ToolCalls is populated and Content may be empty. For tool result turns
+// Role is "tool" and ToolCallID identifies which call is being answered.
 type apiMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role       string        `json:"role"`
+	Content    string        `json:"content,omitempty"`
+	ToolCalls  []apiToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string        `json:"tool_call_id,omitempty"`
+}
+
+// apiToolCall is one element of apiMessage.ToolCalls (assistant turns).
+type apiToolCall struct {
+	ID       string              `json:"id"`
+	Type     string              `json:"type"` // "function"
+	Function apiToolCallFunction `json:"function"`
+}
+
+// apiToolCallFunction carries the name and JSON-encoded arguments.
+type apiToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // JSON string, needs json.Unmarshal to a map
 }
 
 // apiResponse is the wire-level JSON body of a successful 200 response.
@@ -41,7 +64,7 @@ type apiResponse struct {
 	Usage   apiUsage    `json:"usage"`
 }
 
-// apiChoice is one element of apiResponse.Choices. M2 always reads the first.
+// apiChoice is one element of apiResponse.Choices.
 type apiChoice struct {
 	Index        int        `json:"index"`
 	Message      apiMessage `json:"message"`
@@ -91,8 +114,25 @@ type streamChoice struct {
 }
 
 // streamDelta carries the incremental fields of an assistant message.
-// Only `content` is consumed in M2; tool_calls land in a later milestone.
+// ToolCalls carries incremental tool call fragments (index-keyed).
 type streamDelta struct {
-	Role    string `json:"role,omitempty"`
-	Content string `json:"content,omitempty"`
+	Role      string                `json:"role,omitempty"`
+	Content   string                `json:"content,omitempty"`
+	ToolCalls []streamToolCallDelta `json:"tool_calls,omitempty"`
+}
+
+// streamToolCallDelta is one incremental fragment of a tool call in a stream
+// chunk. Fragments for the same call share the same Index; ID and Type are
+// only present in the first fragment.
+type streamToolCallDelta struct {
+	Index    int                 `json:"index"`
+	ID       string              `json:"id,omitempty"`
+	Type     string              `json:"type,omitempty"` // "function"
+	Function streamFunctionDelta `json:"function"`
+}
+
+// streamFunctionDelta carries incremental name and arguments fragments.
+type streamFunctionDelta struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -20,20 +20,31 @@ import (
 // SystemPrompt is carried out of band rather than as a Message because
 // Anthropic's API treats it as a top-level field; OpenAI providers convert
 // it back into a leading role:"system" message in their adapter.
+//
+// Tools, when non-empty, declares the tools the model may invoke. Providers
+// that don't support tool calling should ignore this field (the model will
+// simply never emit tool_use blocks).
 type Request struct {
 	Model        string
 	SystemPrompt string
 	Messages     []agent.Message
 	MaxTokens    int
+	Tools        []agent.ToolDefinition
 }
 
-// Response is the assistant reply produced by Send. Content is plain text in
-// M1.2 — when M2 adds tool calls the type expands to carry a slice of content
-// blocks, with Content remaining as a convenience join for the text portion.
+// Response is the assistant reply produced by Send.
+//
+// Content is the concatenated text from all text blocks — a convenience join
+// for callers that only care about the prose portion of the reply.
+//
+// Blocks holds the full list of content blocks in the order the model emitted
+// them. This includes both text and tool_use blocks; callers that drive an
+// agentic loop should inspect Blocks to find tool_use blocks and dispatch them.
 type Response struct {
 	Content      string
-	Model        string // echoed by the API; useful when "claude-3-5-sonnet-latest" resolves to a dated name
-	StopReason   string // e.g. "end_turn", "max_tokens", "stop_sequence"
+	Blocks       []agent.ContentBlock // full content-block list (text + tool_use)
+	Model        string               // echoed by the API; useful when "claude-3-5-sonnet-latest" resolves to a dated name
+	StopReason   string               // "end_turn" | "tool_use" | "max_tokens" | "stop_sequence"
 	InputTokens  int
 	OutputTokens int
 }

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -1,0 +1,84 @@
+// Package tools provides built-in tool implementations for the octo agentic
+// loop. Each tool implements agent.ToolExecutor and exposes a Definition()
+// method that returns the agent.ToolDefinition the LLM sees.
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/Leihb/octo/internal/agent"
+)
+
+// BashTimeout is the maximum time a single bash command may run.
+const BashTimeout = 30 * time.Second
+
+// BashTool is an agent.ToolExecutor that runs shell commands via `sh -c`.
+// Stdout and stderr are combined and returned as the tool result. Non-zero
+// exit codes are reported as extra metadata in the result text rather than
+// as a tool error, so the LLM can see the failure output and adapt.
+type BashTool struct{}
+
+// Definition returns the agent.ToolDefinition the LLM receives in the tools
+// list. The JSON Schema describes a single required "command" string parameter.
+func (BashTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name:        "bash",
+		Description: "Run a bash/shell command and return stdout+stderr. Use for file operations, running programs, searching code, etc.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"command": map[string]any{
+					"type":        "string",
+					"description": "The shell command to execute",
+				},
+			},
+			"required": []string{"command"},
+		},
+	}
+}
+
+// Execute runs the command and returns combined output. A non-zero exit code
+// is appended to the output as `[exit: <error>]` rather than being surfaced
+// as an error, giving the LLM visibility into what went wrong.
+func (BashTool) Execute(ctx context.Context, _ string, input map[string]any) (string, error) {
+	command, _ := input["command"].(string)
+	if command == "" {
+		return "", fmt.Errorf("bash: command is required")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, BashTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// Surface as result text (not a tool-level error) so the LLM sees it.
+		return strings.TrimSpace(string(out)) + "\n[exit: " + err.Error() + "]", nil
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// RegistryWithBash is a simple ToolExecutor registry that contains only
+// BashTool. It is the default executor used when --tools is enabled.
+type RegistryWithBash struct{}
+
+// Execute dispatches to BashTool for "bash" and returns an error for unknown
+// tools so the LLM receives a clean error result.
+func (RegistryWithBash) Execute(ctx context.Context, name string, input map[string]any) (string, error) {
+	switch name {
+	case "bash":
+		return BashTool{}.Execute(ctx, name, input)
+	default:
+		return "", fmt.Errorf("unknown tool %q", name)
+	}
+}
+
+// DefaultTools returns the set of tool definitions that are active when
+// --tools is enabled. Currently this is just the bash tool.
+func DefaultTools() []agent.ToolDefinition {
+	return []agent.ToolDefinition{BashTool{}.Definition()}
+}

--- a/internal/tools/bash_test.go
+++ b/internal/tools/bash_test.go
@@ -1,0 +1,126 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestBashTool_Definition(t *testing.T) {
+	def := BashTool{}.Definition()
+	if def.Name != "bash" {
+		t.Errorf("Name = %q, want bash", def.Name)
+	}
+	if def.Description == "" {
+		t.Error("Description should not be empty")
+	}
+	if def.Parameters["type"] != "object" {
+		t.Errorf("Parameters.type = %v", def.Parameters["type"])
+	}
+	props, ok := def.Parameters["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("Parameters.properties is not a map")
+	}
+	if _, ok := props["command"]; !ok {
+		t.Error("Parameters.properties.command should exist")
+	}
+	req, ok := def.Parameters["required"].([]string)
+	if !ok {
+		t.Fatal("Parameters.required is not []string")
+	}
+	if len(req) != 1 || req[0] != "command" {
+		t.Errorf("required = %v, want [command]", req)
+	}
+}
+
+func TestBashTool_Execute_Echo(t *testing.T) {
+	result, err := BashTool{}.Execute(context.Background(), "bash", map[string]any{
+		"command": "echo hello",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.TrimSpace(result) != "hello" {
+		t.Errorf("result = %q, want 'hello'", result)
+	}
+}
+
+func TestBashTool_Execute_Multiline(t *testing.T) {
+	result, err := BashTool{}.Execute(context.Background(), "bash", map[string]any{
+		"command": "echo line1 && echo line2",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(result, "line1") || !strings.Contains(result, "line2") {
+		t.Errorf("result = %q, want line1 and line2", result)
+	}
+}
+
+func TestBashTool_Execute_NonZeroExit(t *testing.T) {
+	// A failing command should return output + exit info as result text,
+	// NOT as a Go error, so the LLM can read it.
+	result, err := BashTool{}.Execute(context.Background(), "bash", map[string]any{
+		"command": "sh -c 'echo oops; exit 1'",
+	})
+	if err != nil {
+		t.Fatalf("Execute should not return a Go error for non-zero exit: %v", err)
+	}
+	if !strings.Contains(result, "oops") {
+		t.Errorf("result should contain stdout: %q", result)
+	}
+	if !strings.Contains(result, "[exit:") {
+		t.Errorf("result should contain [exit:...]: %q", result)
+	}
+}
+
+func TestBashTool_Execute_EmptyCommand(t *testing.T) {
+	_, err := BashTool{}.Execute(context.Background(), "bash", map[string]any{
+		"command": "",
+	})
+	if err == nil {
+		t.Error("empty command should return error")
+	}
+}
+
+func TestBashTool_Execute_NoCommandKey(t *testing.T) {
+	_, err := BashTool{}.Execute(context.Background(), "bash", map[string]any{})
+	if err == nil {
+		t.Error("missing command key should return error")
+	}
+}
+
+func TestRegistryWithBash_Execute(t *testing.T) {
+	r := RegistryWithBash{}
+
+	result, err := r.Execute(context.Background(), "bash", map[string]any{
+		"command": "echo registry",
+	})
+	if err != nil {
+		t.Fatalf("Execute bash: %v", err)
+	}
+	if strings.TrimSpace(result) != "registry" {
+		t.Errorf("result = %q", result)
+	}
+}
+
+func TestRegistryWithBash_Execute_UnknownTool(t *testing.T) {
+	r := RegistryWithBash{}
+	_, err := r.Execute(context.Background(), "unknown_tool", nil)
+	if err == nil {
+		t.Error("unknown tool should return error")
+	}
+	if !strings.Contains(err.Error(), "unknown tool") {
+		t.Errorf("error = %q, should mention unknown tool", err)
+	}
+}
+
+func TestDefaultTools(t *testing.T) {
+	defs := DefaultTools()
+	if len(defs) != 1 {
+		t.Fatalf("len = %d, want 1", len(defs))
+	}
+	if defs[0].Name != "bash" {
+		t.Errorf("Name = %q, want bash", defs[0].Name)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements the full tool-calling pipeline for both Anthropic and OpenAI providers, plus an agentic `Run`/`RunStream` loop that automatically dispatches tool calls until the model reaches `end_turn`
- Adds `internal/tools` with `BashTool` + `RegistryWithBash` and wires a `--tools` flag into the REPL

## Key changes

**New types (agent layer)**
- `ContentBlock` — unified `text`/`tool_use`/`tool_result` block with helpers
- `ToolDefinition` / `ToolExecutor` — provider-agnostic tool contract
- `Message.Blocks` — multi-part content alongside the existing `Content` string
- `ToolSender` / `ToolStreamingSender` interfaces on the `Sender` hierarchy

**Agentic loop**
- `Agent.Run` — buffered loop up to 20 iterations; appends tool-use and tool-result turns; falls back to `Turn` when no tools/executor provided
- `Agent.RunStream` — same loop with streaming text deltas via `onChunk`

**Anthropic provider**
- `apiRequest.Tools` → `input_schema` wire format (not `parameters`)
- `apiMessage.Content` changed to `json.RawMessage` to support both string and `[]block` shapes
- Stream: new `blockAccumulator` per content-block index; `input_json_delta` fragments assembled into `map[string]any` at stream end

**OpenAI provider**
- `apiTool` with `type:"function"` wrapper
- `tool_calls` streaming: delta accumulation keyed by index
- `finish_reason:"tool_calls"` normalized to `"tool_use"`
- Tool-result messages exploded into individual `role:"tool"` messages (OpenAI wire requirement)

**CLI**
- `octo chat --tools` enables the bash tool in REPL mode

## Test plan

- [x] `go test ./...` — all 60+ tests pass (new + existing)
- [x] `internal/agent`: Run loop tests — tool_use → end_turn round-trip, multiple calls, max-iterations cap, sender fallback
- [x] `internal/provider/anthropic`: wire format for tools request, tool_use response, tool_result serialization, streaming tool_use accumulation
- [x] `internal/provider/openai`: same coverage + tool_calls streaming delta assembly
- [x] `internal/tools`: BashTool echo, multiline, non-zero exit, empty command, registry dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)