### PR TITLE
docs: Go rewrite roadmap M5–M10

### DIFF
--- a/dev-docs/go-rewrite-roadmap.md
+++ b/dev-docs/go-rewrite-roadmap.md
@@ -119,26 +119,64 @@ REPL 兼容层：`repl.go` 把 `EventHandler` 包装为只打印 `EventTextDelta
 | `glob` | 文件模式匹配，按 mtime 排序 | 返回路径列表 |
 | `grep` | ripgrep 封装，content/files/count 三模式 | 支持 -A/-B/-C context |
 | `web_fetch` | HTTP GET 转 Markdown | Jina reader 代理（`r.jina.ai/`） |
-| `web_search` | 网络搜索 | **Brave Search API**（默认），可选 Tavily / Serper |
+| `web_search` | 网络搜索 | 默认零 key 直抓 HTML（DDG + Bing 兜底），可选付费 API |
 
 ### web_search 实现
 
-> **背景**：Bing Search API 已于 2025-08 停服，roadmap 旧版指向它要换。
+**设计哲学**（沿用 Ruby 版 `lib/octo/tools/web_search.rb` 的踩坑经验）：
+- **零启动成本是默认值** —— 开源用户拉下来即可用，不强制注册 key
+- 付费 API 是 _可选升级_，env 设了就优先用，不设也能跑
 
-候选搜索后端按优先级：
+**后端优先级（运行时按这个顺序尝试）：**
 
-| 后端 | 端点 | 免费额度 | 认证 env |
-|------|------|----------|----------|
-| **Brave Search**（默认） | `https://api.search.brave.com/res/v1/web/search` | 2000 次/月，独立索引 | `BRAVE_SEARCH_API_KEY` |
-| Tavily（AI agent 专用） | `https://api.tavily.com/search` | 1000 次/月，带 LLM 摘要 | `TAVILY_API_KEY` |
-| Serper.dev（Google 代理） | `https://google.serper.dev/search` | 2500 免费试用 | `SERPER_API_KEY` |
+| 优先级 | 后端 | 触发条件 | 备注 |
+|--------|------|----------|------|
+| 1 | Brave Search API | `BRAVE_SEARCH_API_KEY` 已设 | 独立索引，2000 次/月免费 |
+| 2 | Tavily API | `TAVILY_API_KEY` 已设 | AI agent 专用，自带 LLM 摘要 |
+| 3 | Serper.dev | `SERPER_API_KEY` 已设 | Google 代理，2500 次免费试用 |
+| 4 | **DuckDuckGo HTML**（默认兜底）| 无条件 | `html.duckduckgo.com/html/?q=` |
+| 5 | **Bing HTML**（最后兜底）| 无条件 | `cn.bing.com/search`（国内直连） |
+
+> Bing Search **API** 已于 2025-08 停服。Bing HTML 抓取通道仍可用，但不是同一个东西。
+
+### HTML 抓取通道的实战细节（从 Ruby 版搬过来，全是踩过的坑）
 
 ```go
 // internal/tools/web_search.go
-// 实际后端按 env var 优先级：BRAVE > TAVILY > SERPER
-// 都未设置时返回明确错误，不 panic
-// 响应归一化为 [{title, url, snippet}]，默认 top 5
+// 关键约定：
+// 1. 5 个真实浏览器 UA 轮播（Mac/Windows/Linux × Chrome 122/124）
+// 2. 完整 browser header 集：Sec-Fetch-Dest=document / Mode=navigate /
+//    Site=none / Upgrade-Insecure-Requests=1 / Accept-Language=zh-CN,zh;q=0.9,en;q=0.8
+// 3. *不设* Accept-Encoding —— 一旦发 gzip，Bing 会返回 ~39KB 的 JS-only
+//    骨架页而不是 ~120KB 的真 HTML。这是 Ruby 版花了好一阵才定位的坑。
+// 4. cn.bing.com 在非中国 IP 上会 302 到 www.bing.com，必须跟 redirect
+//    （最多 2 跳）。
+// 5. Bing 的真实链接藏在 bing.com/ck/a?...&u=a1<URL-safe base64>&ntb=1
+//    解码：去掉 "a1" 前缀 → base64 URL-safe decode → 真实 URL
+//    decode 失败时直接返回原 URL，不要让一条坏链接打掉整次搜索。
+// 6. DuckDuckGo 单次失败后冷却 10 分钟，期间跳过它直接走 Bing。
+// 7. 超时：read 8s / open 5s。搜索是同步阻塞，agent 等不起。
 ```
+
+### 归一化输出
+
+```go
+type Result struct {
+    Title    string
+    URL      string
+    Snippet  string
+}
+
+type Response struct {
+    Query    string
+    Results  []Result
+    Count    int
+    Provider string  // 实际用了哪个后端，"brave" / "bing" / "ddg" / ...
+    Error    string  // 失败时填，永远不 panic / 不 return Go error 出工具边界
+}
+```
+
+`Provider` 字段把"实际走了哪条路"暴露给 agent，避免 LLM 拿着零结果以为是搜索结果为零（而其实是后端全挂）。
 
 ### 目录结构
 
@@ -158,8 +196,9 @@ internal/tools/
 ### 验收
 
 - `octo chat --tools` 下 LLM 能读/写/编辑当前目录文件
-- `web_search "Go generics tutorial"` 返回 5 条结果
-- 所有搜索 env 未设时工具返回明确错误，不 panic
+- `web_search "Go generics tutorial"` 默认无任何 env 设置即可返回 5 条结果（走 DDG / Bing HTML）
+- 设置 `BRAVE_SEARCH_API_KEY` 后再跑同一查询，`Provider` 字段切到 `"brave"`
+- 所有后端全挂时返回 `Error` 字段非空、`Results` 为空，绝不 panic
 
 ---
 

--- a/dev-docs/go-rewrite-roadmap.md
+++ b/dev-docs/go-rewrite-roadmap.md
@@ -1,0 +1,404 @@
+# Octo Go Rewrite — Roadmap M5–M10
+
+> 本文档记录 octo Go 重写版本的架构决策和里程碑计划。
+> M1–M4 已完成（单轮对话 → 流式 → REPL + Session → Tool Calling）。
+> 目标：三界面平等（CLI / Web / IM）、100% 兼容 Claude Code Skill 格式、竞品级 agent harness。
+
+---
+
+## 已完成里程碑（M1–M4）
+
+| 里程碑 | 内容 | PR |
+|--------|------|-----|
+| M1   | Go 脚手架（go.mod / cmd/octo / CI 矩阵 / Makefile）                 | #28 |
+| M1.2 | `octo chat` 单轮 CLI，Anthropic Provider                            | #30 |
+| M2   | 流式输出（`--stream`），OpenAI Provider，`--provider` / `--model`   | #32 / #34 |
+| M3   | 交互式 REPL，Session 持久化（`~/.octo/sessions/`），`-c` 续话       | #36 |
+| M4   | Tool Calling 核心（agentic loop + bash tool），四接口 Sender         | #38 |
+
+---
+
+## 架构决策（M1–M4 形成的约定）
+
+### Sender 接口层级
+
+```
+Sender                    — 基础：SendMessages
+  StreamingSender         — + StreamMessages(onChunk)
+    ToolSender            — + SendMessagesWithTools
+      ToolStreamingSender — + StreamMessagesWithTools(tools, onChunk)
+```
+
+`providerSender`（cmd/octo/chat.go）同时实现全部四个接口，通过 type-assert 按能力降级。
+
+### ContentBlock 联合类型
+
+`internal/agent/content.go` 中的 `ContentBlock` 是 text / tool_use / tool_result 的统一载体。
+Message.Blocks 为 nil 时使用 Message.Content（字符串），向后兼容旧 Session JSON。
+
+### Provider 归一化
+
+- OpenAI `finish_reason: "tool_calls"` → 归一化为 `"tool_use"`
+- OpenAI tool result 序列化为独立 `role:"tool"` 消息（Wire 格式差异，agent 层不感知）
+- Anthropic `apiMessage.Content` 为 `json.RawMessage`，兼容 string 和 block array
+
+---
+
+## M5 — AgentEvent 流式事件重构
+
+**问题**：当前 `onChunk func(string)` 只传文本 delta，工具调用过程（开始/结束/报错）对
+Web UI 和 IM 完全不透明。
+
+**目标**：把流式通道从 `func(string)` 升级为结构化事件流，不破坏现有 REPL 行为。
+
+### 事件类型
+
+```go
+// internal/agent/event.go
+type EventKind string
+
+const (
+    EventTextDelta   EventKind = "text_delta"
+    EventToolStarted EventKind = "tool_started"
+    EventToolDone    EventKind = "tool_done"
+    EventToolError   EventKind = "tool_error"
+    EventTurnDone    EventKind = "turn_done"
+)
+
+type AgentEvent struct {
+    Kind    EventKind
+    // text_delta
+    Text    string
+    // tool_*
+    ToolID  string
+    ToolName string
+    Input   map[string]any // tool_started
+    Output  string         // tool_done
+    Err     string         // tool_error
+    // turn_done
+    Reply   *Reply
+}
+
+type EventHandler func(AgentEvent)
+```
+
+### 接口变更
+
+```go
+// RunStream 签名升级
+func (a *Agent) RunStream(
+    ctx context.Context,
+    userInput string,
+    tools []ToolDefinition,
+    executor ToolExecutor,
+    handler EventHandler,   // 替换 onChunk func(string)
+) (Reply, error)
+```
+
+REPL 兼容层：`repl.go` 把 `EventHandler` 包装为只打印 `EventTextDelta.Text`，不影响现有体验。
+
+### 验收
+
+- `EventToolStarted` 在调用工具前 fire，携带工具名和 input
+- `EventToolDone` 在工具返回后 fire，携带 output（截断到 512 bytes 用于展示）
+- REPL 行为与 M4 完全一致（事件处理器只打文本 delta）
+
+---
+
+## M6 — 核心工具集
+
+**目标**：补齐 Claude Code 级别的文件系统 + 网络工具，达到自举能力（能改自己的代码）。
+
+### 工具清单
+
+| 工具名 | 功能 | 关键约束 |
+|--------|------|----------|
+| `read_file` | 读文件内容，支持 offset/limit（行号） | 单次最多 2000 行 |
+| `write_file` | 写/覆盖文件 | 先读再写，防意外覆盖 |
+| `edit_file` | old_string → new_string 精确替换 | 必须唯一匹配；replace_all 模式 |
+| `glob` | 文件模式匹配，按 mtime 排序 | 返回路径列表 |
+| `grep` | ripgrep 封装，content/files/count 三模式 | 支持 -A/-B/-C context |
+| `web_fetch` | HTTP GET 转 Markdown | Jina reader 代理（`r.jina.ai/`） |
+| `web_search` | 网络搜索 | **Brave Search API**（默认），可选 Tavily / Serper |
+
+### web_search 实现
+
+> **背景**：Bing Search API 已于 2025-08 停服，roadmap 旧版指向它要换。
+
+候选搜索后端按优先级：
+
+| 后端 | 端点 | 免费额度 | 认证 env |
+|------|------|----------|----------|
+| **Brave Search**（默认） | `https://api.search.brave.com/res/v1/web/search` | 2000 次/月，独立索引 | `BRAVE_SEARCH_API_KEY` |
+| Tavily（AI agent 专用） | `https://api.tavily.com/search` | 1000 次/月，带 LLM 摘要 | `TAVILY_API_KEY` |
+| Serper.dev（Google 代理） | `https://google.serper.dev/search` | 2500 免费试用 | `SERPER_API_KEY` |
+
+```go
+// internal/tools/web_search.go
+// 实际后端按 env var 优先级：BRAVE > TAVILY > SERPER
+// 都未设置时返回明确错误，不 panic
+// 响应归一化为 [{title, url, snippet}]，默认 top 5
+```
+
+### 目录结构
+
+```
+internal/tools/
+  bash.go        (M4, 已有)
+  read_file.go
+  write_file.go
+  edit_file.go
+  glob.go
+  grep.go
+  web_fetch.go
+  web_search.go
+  registry.go    (DefaultTools() 返回所有工具列表)
+```
+
+### 验收
+
+- `octo chat --tools` 下 LLM 能读/写/编辑当前目录文件
+- `web_search "Go generics tutorial"` 返回 5 条结果
+- 所有搜索 env 未设时工具返回明确错误，不 panic
+
+---
+
+## M7 — Skill 加载器（100% Claude Code 兼容）
+
+**目标**：实现与 Claude Code `/` 斜杠命令完全兼容的 Skill 系统。
+用户的 `~/.claude/skills/` 目录下的 skill 可以直接在 octo 里使用。
+
+### Skill 格式（沿用 Claude Code 标准）
+
+```
+~/.octo/skills/<name>/
+  SKILL.md       # frontmatter + 指令正文
+```
+
+SKILL.md frontmatter（YAML）：
+```yaml
+---
+name: my-skill
+description: 一句话描述，触发检测用
+triggers:
+  - /my-skill
+  - keyword1
+  - keyword2
+---
+# Skill 指令正文（注入 system prompt）
+...
+```
+
+### 加载流程
+
+```
+用户输入 "/foo arg1 arg2"
+  │
+  ├─ SkillLoader.Match("/foo") → 找到 skill
+  │     读取 SKILL.md → 注入 system prompt
+  │     args 作为首条 user 消息
+  │     启动新 RunStream（可带 M6 工具）
+  │
+  └─ 未命中 → 普通 REPL 消息
+```
+
+### 兼容性要求
+
+- SKILL.md 格式与 `~/.claude/skills/*/SKILL.md` 完全相同
+- 用户可把 `~/.claude/skills/` 软链到 `~/.octo/skills/` 直接复用
+- 搜索顺序：`~/.octo/skills/` → `~/.octo/default_skills/`（内置）
+
+### 内置 Skill 候选
+
+| Skill | 功能 |
+|-------|------|
+| `/help` | 列出可用 skill 和工具 |
+| `/cost` | 当前会话 token 和估算费用 |
+| `/sessions` | 最近 10 个 session |
+| `/compact` | 触发对话压缩（M7.5 再做） |
+
+### 验收
+
+- `~/.octo/skills/hello/SKILL.md` 定义后，REPL 输入 `/hello` 触发
+- `--list-skills` 标志列出所有可用 skill
+- 与 Claude Code 同格式 SKILL.md 能直接使用（不修改）
+
+---
+
+## M8 — Web Server + Agent Dashboard
+
+**目标**：HTTP server 提供 REST + SSE 接口，配套 Web UI 展示 agent 执行过程。
+
+### API 设计
+
+```
+POST /api/chat           # 创建新对话（返回 session_id）
+POST /api/chat/:id/turn  # 发送消息（SSE 流式响应）
+GET  /api/sessions       # 列出历史 session
+GET  /api/sessions/:id   # 获取 session 详情
+GET  /api/tools          # 列出可用工具
+GET  /api/skills         # 列出可用 skill
+```
+
+### SSE 事件格式（对应 M5 AgentEvent）
+
+```
+data: {"kind":"text_delta","text":"Hello"}
+data: {"kind":"tool_started","tool_name":"bash","input":{"command":"ls"}}
+data: {"kind":"tool_done","tool_name":"bash","output":"file1\nfile2"}
+data: {"kind":"turn_done","reply":{"content":"...","input_tokens":100}}
+```
+
+### Web UI 功能（Agent Dashboard）
+
+- 对话界面：左侧 session 列表，右侧消息流
+- Tool 调用可视化：工具名 + input/output 可折叠卡片
+- Token/Cost 实时显示（对接 M5 EventTurnDone）
+- Skill 触发记录
+
+### 技术选型
+
+- HTTP server：Go 标准库 `net/http`（不引入框架）
+- 前端：单文件 HTML + Alpine.js + SSE EventSource（不引入构建工具）
+- 打包：`go:embed` 嵌入静态文件，单 binary 发布
+
+### 验收
+
+- `octo serve` 启动 HTTP server（默认 :8080）
+- 浏览器打开 `localhost:8080` 能对话，能看到 tool 调用过程
+- Agent Dashboard 显示实时 token 消耗
+
+---
+
+## M9 — WeChat iLink Bridge
+
+**技术背景**（协议于 2026-03 开放）：
+
+| 属性 | 值 |
+|------|-----|
+| 官方名称 | 微信 iLink Bot（隶属于 Tencent **OpenClaw** 多渠道 agent 网关项目） |
+| 官方插件 | npm `@tencent-weixin/openclaw-weixin`（Tencent 官方发布，Node 实现） |
+| API host | `https://ilinkai.weixin.qq.com` |
+| 接入协议 | HTTP Long Polling |
+| 关键端点 | `GET /get_bot_qrcode` · `GET /get_qrcode_status` · `POST /getupdates` · `POST /sendmessage` · `POST /sendtyping` · `POST /getuploadurl` |
+| 媒体 CDN | `https://novac2c.cdn.weixin.qq.com/c2c`（`/upload`、`/download`） |
+| 认证 | 扫码 QR → `bot_token`，请求头 `Authorization: Bearer <token>` + `AuthorizationType: ilink_bot_token` |
+| 消息类型 | 文本 / 图片 / 语音 / 文件 / 视频 |
+| 群聊支持 | ⚠️ 官方文档未明确说明，待实测确认（保守按"仅 1:1 私聊"实现，后续再扩展） |
+
+**设计决策**：依赖第三方 Go SDK [`corespeed-io/wechatbot/golang`](https://github.com/corespeed-io/wechatbot)（436⭐，MIT，多语言 SDK 互验，自带文档站 [wechatbot.dev](https://www.wechatbot.dev/zh/protocol)）。理由：
+- 协议反向工程已完成且有 Node/Python/Go/Rust 四语言互证
+- 我们要的能力（扫码、收发文本、媒体）SDK 都已封装好
+- 不引入 Node/Python runtime，仍是纯 Go 依赖
+- 备选：[`SpellingDragon/wechat-robot-go`](https://github.com/SpellingDragon/wechat-robot-go)（22⭐，更轻量）作为兜底，若 corespeed-io 出现 license 或维护问题再切换
+
+### 架构
+
+```
+corespeed-io/wechatbot/golang
+  ├─ bot.Login(ctx)               // 扫码登录
+  └─ bot.OnMessage(handler)       // 注册消息回调
+        ↓
+Message Router (octo 自己写)
+  │  映射 IncomingMessage.UserID → Session (per-user 对话历史)
+  ↓
+Agent.RunStream(ctx, text, tools, executor, handler)
+  │  M5 EventHandler
+  │  文本 delta 累积
+  ↓
+bot.Reply(ctx, msg, replyText)    // SDK 内部 POST /sendmessage
+```
+
+### 配置
+
+```yaml
+# ~/.octo/config.yml
+wechat:
+  enabled: true
+  bot_token: "xxx"          # 扫码后写入
+  max_session_idle: "30m"   # 空闲超时清理 session
+```
+
+### 命令
+
+```
+octo wechat login    # 展示 QR 码，扫码后保存 bot_token
+octo wechat start    # 启动 long poll 守护进程
+octo wechat status   # 查看连接状态
+```
+
+### 验收
+
+- `octo wechat login` 展示 QR，扫码后控制台确认"已登录"
+- 给 Bot 发文字消息，收到 AI 回复
+- 每个微信用户维护独立 session（对话历史隔离）
+- 发送消息 / 收到回复全程不需要在电脑前操作
+- 群聊场景：先实测 SDK 是否能接收群消息事件，再决定是否开启群聊支持
+
+---
+
+## M10 — Sub-Agent Tool
+
+**目标**：LLM 在对话中可以调度子代理并行执行任务，与 Claude Code `Agent` 工具对标。
+
+### 工具定义
+
+```go
+// internal/tools/agent.go
+// Tool name: "launch_agent"
+// Parameters:
+//   description: string   -- 短标题（日志展示用）
+//   prompt:      string   -- 子代理任务描述
+//   tools:       []string -- 允许的工具名列表（nil = 继承父代理）
+//   model:       string   -- 模型（默认 haiku/gpt-4o-mini）
+```
+
+### 并行执行
+
+- 父代理一次 `tool_use` 可包含多个 `launch_agent` 调用
+- 每个子代理在独立 goroutine 中跑，共享同一 Provider（不开新连接）
+- 子代理不能递归调用 `launch_agent`（`forbidden_tools` 自动注入）
+- 所有子代理完成后，结果作为 tool_result 批量返回给父代理
+
+### 验收
+
+- 父代理说"并行调研 A 和 B"→ 两个子代理同时跑 → 结果合并回复
+- 子代理调用 `launch_agent` 被拒绝（递归防护）
+- token 计数合并到父 session（`/cost` 显示总账单）
+
+---
+
+## 里程碑时序
+
+```
+M5 AgentEvent     ←── 基础，影响所有后续
+  │
+  ├── M6 Core Tools  ←── M7/M9 依赖工具能力
+  │     │
+  │     ├── M7 Skill Loader  ←── Claude Code 兼容层
+  │     │
+  │     └── M8 Web Server    ←── 可并行 M7
+  │
+  └── M9 WeChat iLink  ←── M6 工具 optional，M5 必须
+        │
+        └── M10 Sub-Agent  ←── 最后做，需要整体稳定
+```
+
+---
+
+## 差异化原则（不为追赶而丢失）
+
+1. **单 binary，无安装依赖** — 所有功能打进一个 Go binary，不依赖 Node/Ruby/Python runtime
+2. **三界面平等** — CLI / Web / WeChat 是同等头等公民，不是"CLI 主，其他适配"
+3. **Skill-first** — 优先用 SKILL.md 扩展能力，工具数量保持最小化
+4. **100% Claude Code Skill 兼容** — 用户的 `~/.claude/skills/` 可直接在 octo 使用
+5. **隐私优先** — 对话历史默认只存本地（`~/.octo/sessions/`），不上传任何云端
+
+---
+
+## 更新规则
+
+每完成一个里程碑：
+1. 在状态表（如建立）对应行更新 ✅ + PR 号
+2. 在该节末尾追加 `**完成**：日期 / PR#xx / 关键决策`
+3. 有架构变更时更新本文档对应节


### PR DESCRIPTION
## Summary

Captures the post-M4 plan in `dev-docs/go-rewrite-roadmap.md`:

- **M5** — AgentEvent structured event stream (replaces opaque `onChunk func(string)` so Web UI / IM can see tool calls)
- **M6** — Core file + web tools (read/write/edit/glob/grep/web_fetch/web_search)
- **M7** — Claude Code-compatible skill loader (read `~/.octo/skills/*/SKILL.md`)
- **M8** — Web server + agent dashboard (REST + SSE, `go:embed` single binary)
- **M9** — WeChat iLink bridge (depends on third-party SDK `corespeed-io/wechatbot/golang`)
- **M10** — Sub-agent tool (parallel `launch_agent` with recursion guard)

## Verifications done before committing

The roadmap's external claims were checked, not just written from memory:

- **iLink protocol is real**: Tencent `@tencent-weixin/openclaw-weixin` npm package, author "Tencent", published by `pumpkinxing@tencent.com`. API host `ilinkai.weixin.qq.com` confirmed live (returns 404 only on the bare root — it's an API host, not a website).
- **Endpoint paths corrected**: `/getupdates`, `/sendmessage` (no `/ilink/bot/` prefix as the doc originally claimed).
- **SDK choice**: `corespeed-io/wechatbot/golang` (436⭐, MIT, multi-language SDKs cross-validate the protocol), with `SpellingDragon/wechat-robot-go` (22⭐) as a backup.
- **Bing Search API retired Aug 2025**: M6 default backend swapped from Bing API to DuckDuckGo + Bing **HTML scraping** (matching Ruby version `lib/octo/tools/web_search.rb` on `archive/ruby`). Paid APIs (Brave / Tavily / Serper) become opt-in upgrades via env vars.
- **Ruby implementation cross-referenced**: the Bing `ck/a` base64-decoding logic, the "don't send Accept-Encoding" gotcha, the DDG cooldown, the 5-UA rotation — all are real lessons from the Ruby code, documented in the roadmap so the Go reimplementation inherits them.

## Why this is doc-only

This PR ships zero code. It exists to capture the plan + verified facts before starting M5, so the implementation work can reference a stable design document. M5 will be the first PR that closes against this roadmap.

## Test plan

- [x] doc-only diff (no `internal/`, no `cmd/`)
- [x] verified all external claims (npm publisher, GitHub repos, API host liveness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)