### PR TITLE
chore: drop AWS Bedrock from positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="README.md">English</a> · <a href="README_CN.md">简体中文</a>
 </p>
 
-A functionality-first AI agent, distributed as a single Go binary. Speaks three native API protocols — **Anthropic Messages**, **OpenAI Chat Completions**, **AWS Bedrock** (planned) — and aims for three equal interfaces: **CLI**, **Web**, and **IM**.
+A functionality-first AI agent, distributed as a single Go binary. Speaks two native API protocols — **Anthropic Messages** and **OpenAI Chat Completions** — and works against any compatible third party (DeepSeek, Kimi, Bailian, OpenRouter, vLLM, …). Aims for three equal interfaces: **CLI**, **Web**, and **IM**.
 
 ## Status
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -9,7 +9,7 @@
   <a href="README.md">English</a> · <a href="README_CN.md">简体中文</a>
 </p>
 
-以功能为先的 AI Agent，单一 Go 二进制分发。原生支持三种 API 协议 —— **Anthropic Messages**、**OpenAI Chat Completions**、**AWS Bedrock**（规划中），目标是 **CLI**、**Web**、**IM** 三种平等的交互界面。
+以功能为先的 AI Agent，单一 Go 二进制分发。原生支持两种 API 协议 —— **Anthropic Messages** 和 **OpenAI Chat Completions**，并能对接任何兼容这两种协议的第三方（DeepSeek、Kimi、百炼、OpenRouter、vLLM 等）。目标是 **CLI**、**Web**、**IM** 三种平等的交互界面。
 
 ## 状态
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Octo — a functionality-first AI agent</title>
-  <meta name="description" content="A functionality-first AI agent with three equal interfaces — terminal CLI, web UI, and IM bridges. Speaks Anthropic Messages, OpenAI, and AWS Bedrock natively.">
+  <meta name="description" content="A functionality-first AI agent, distributed as a single Go binary. Speaks Anthropic Messages and OpenAI Chat Completions natively, plus any compatible third party. Three equal interfaces: CLI, web UI, IM.">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ctext y='52' font-size='52'%3E🐙%3C/text%3E%3C/svg%3E">
   <style>
     :root {
@@ -141,8 +141,8 @@
     </section>
 
     <section>
-      <h2>Three native API protocols</h2>
-      <p style="color: var(--muted);">Speaks <strong>Anthropic Messages</strong>, <strong>OpenAI</strong> (Chat Completions + Responses), and <strong>AWS Bedrock</strong> natively — dispatched per-provider, per-model. Any provider that exposes one of these shapes works out of the box.</p>
+      <h2>Two native API protocols</h2>
+      <p style="color: var(--muted);">Speaks <strong>Anthropic Messages</strong> and <strong>OpenAI Chat Completions</strong> natively — dispatched per-provider, per-model. Any service that exposes one of these shapes (DeepSeek, Kimi, Bailian, OpenRouter, vLLM, …) works out of the box.</p>
     </section>
 
     <section>

--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -7,8 +7,8 @@
 // provider streaming aggregators and the tool registry.
 package agent
 
-// Role is the message author role, mirroring the role string used by all three
-// LLM API protocols (Anthropic Messages, OpenAI, Bedrock).
+// Role is the message author role, mirroring the role string used by both
+// supported LLM API protocols (Anthropic Messages, OpenAI Chat Completions).
 type Role string
 
 const (

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -50,7 +50,7 @@ type Response struct {
 }
 
 // Provider is the per-backend abstraction. Implementations are kept under
-// internal/provider/<name>/ (e.g. anthropic, openai, bedrock).
+// internal/provider/<name>/ (e.g. anthropic, openai).
 type Provider interface {
 	// Name returns a stable identifier for the provider, used in logs and
 	// telemetry — e.g. "anthropic-messages", "openai-completions".


### PR DESCRIPTION
## Summary

Stop advertising AWS Bedrock as a supported protocol. The Go rewrite supports **two** native API protocols: Anthropic Messages and OpenAI Chat Completions — plus any compatible third party (DeepSeek, Kimi, Bailian, OpenRouter, vLLM, …).

## Why

- Bedrock requires SigV4 signing, an AWS SDK dependency, and IAM-shaped auth surface that's substantially more complex than bearer tokens. Cost-to-benefit is poor for a community OSS tool.
- Bedrock's Anthropic-on-Bedrock variant is already reachable via the existing Anthropic provider with `ANTHROPIC_BASE_URL` pointed at a compatible proxy.
- No Bedrock code paths existed yet — this is a positioning clarification, not a scope removal.

## Changes

- README.md / README_CN.md — "three protocols" → "two protocols"; explicitly call out compatible-third-party support
- docs/index.html — meta description + landing body section
- internal/provider/provider.go — doc comment listing example impls
- internal/agent/message.go — Role doc comment

## Test plan

- [x] `go test ./...` — green
- [x] grep -rn 'bedrock' across `.md` `.go` `.html` `.yml` `Makefile` — clean
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)