### PR TITLE
feat(go): M5 — AgentEvent structured event stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`terminal` tool** — first concrete tool; runs `sh -c <command>` with a 30s timeout, returns combined stdout+stderr, surfaces non-zero exits as `[exit: ...]` annotations rather than Go errors so the LLM can read and adapt.
 - **Session persistence** — JSON sessions under `~/.octo/sessions/<YYYYMMDD-HHMMSS>.json`, resume via `octo chat -c <id>`, list via `--list-sessions`, opt out with `--no-save`.
 - **REPL slash commands** — `/help`, `/cost` (token + USD estimate, per-model pricing), `/save`, `/sessions`, `/exit`, `/quit`.
+- **M5 — AgentEvent structured event stream** — `Agent.RunStream` now takes an `EventHandler` instead of `onChunk func(string)`. Events: `text_delta`, `tool_started`, `tool_done`, `tool_error`, `turn_done` (carries final `Reply`). Tool events identify the call by `ToolID` + `ToolName` + `Input`; `Output` is truncated to 512 bytes for previews while the agent's own conversation history keeps the full result. The REPL wraps the handler as a text-only printer so its behaviour is unchanged. Foundation for Web UI / IM tool-call visualization in M8 / M9.
 
 ### Notes
 - The Ruby implementation under `lib/`, `spec/`, `bin/octo`, `Gemfile`, `Rakefile`, `octo-agent.gemspec`, `.rubocop.yml`, `Dockerfile` (Ruby base image), `homebrew/octo-agent.rb`, `scripts/`, `benchmark/`, `sig/`, and `POSITIONING.md` (Ruby-era) has been removed from `main`. The frozen Ruby tree remains accessible at `archive/ruby`.

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -93,8 +93,14 @@ func runREPL(cfg replConfig) int {
 			err   error
 		)
 		if len(cfg.tools) > 0 && cfg.executor != nil {
-			reply, err = a.RunStream(context.Background(), line, cfg.tools, cfg.executor, func(delta string) {
-				fmt.Fprint(cfg.stdout, delta)
+			// Wrap the new event handler as a text-only printer so REPL
+			// behaviour matches the pre-M5 streaming output exactly.
+			// Tool events are not surfaced in the REPL today; later they
+			// can grow inline cards or status lines.
+			reply, err = a.RunStream(context.Background(), line, cfg.tools, cfg.executor, func(ev agent.AgentEvent) {
+				if ev.Kind == agent.EventTextDelta {
+					fmt.Fprint(cfg.stdout, ev.Text)
+				}
 			})
 		} else {
 			reply, err = a.TurnStream(context.Background(), line, func(delta string) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -268,16 +268,19 @@ func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinitio
 	return Reply{}, fmt.Errorf("agent: exceeded max tool iterations (%d)", maxToolIterations)
 }
 
-// RunStream is the streaming agentic loop. Behaves like Run but streams text
-// deltas to onChunk as they arrive from the provider.
+// RunStream is the streaming agentic loop. Behaves like Run but emits
+// structured AgentEvents to handler as work progresses — text deltas, tool
+// start/done/error, and a final EventTurnDone carrying the aggregated Reply.
 //
-// If tools is nil or executor is nil, RunStream is equivalent to TurnStream.
+// If tools is nil or executor is nil, RunStream falls back to TurnStream and
+// adapts text deltas into EventTextDelta events. handler may be nil, in
+// which case events are discarded but the run completes normally.
 func (a *Agent) RunStream(
 	ctx context.Context,
 	userInput string,
 	tools []ToolDefinition,
 	executor ToolExecutor,
-	onChunk func(string),
+	handler EventHandler,
 ) (Reply, error) {
 	if a.Sender == nil {
 		return Reply{}, fmt.Errorf("agent: no Sender configured")
@@ -289,41 +292,65 @@ func (a *Agent) RunStream(
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
 
-	// No tools → plain TurnStream.
+	// onChunk adapts text deltas from provider streams into EventTextDelta
+	// events. Nil-safe; empty deltas are silently dropped.
+	onChunk := func(delta string) {
+		if handler == nil || delta == "" {
+			return
+		}
+		handler(AgentEvent{Kind: EventTextDelta, Text: delta})
+	}
+
+	// No tools → plain TurnStream with the event-adapting onChunk. The
+	// terminal EventTurnDone is fired here so the caller's contract is
+	// identical regardless of whether tools were used.
 	if len(tools) == 0 || executor == nil {
-		return a.TurnStream(ctx, userInput, onChunk)
+		reply, err := a.TurnStream(ctx, userInput, onChunk)
+		if err == nil && handler != nil {
+			r := reply
+			handler(AgentEvent{Kind: EventTurnDone, Reply: &r})
+		}
+		return reply, err
 	}
 
 	// Try ToolStreamingSender first, then fall back to ToolSender (buffered).
 	if tss, ok := a.Sender.(ToolStreamingSender); ok {
-		return a.runStreamLoop(ctx, userInput, tools, executor, onChunk,
+		return a.runStreamLoop(ctx, userInput, tools, executor, handler,
 			func(ctx context.Context, msgs []Message) (Reply, error) {
 				return tss.StreamMessagesWithTools(ctx, a.Model, a.System, msgs, a.MaxTokens, tools, onChunk)
 			})
 	}
 	if ts, ok := a.Sender.(ToolSender); ok {
-		return a.runStreamLoop(ctx, userInput, tools, executor, onChunk,
+		return a.runStreamLoop(ctx, userInput, tools, executor, handler,
 			func(ctx context.Context, msgs []Message) (Reply, error) {
 				reply, err := ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, a.MaxTokens, tools)
-				if err == nil && onChunk != nil && reply.Content != "" {
+				if err == nil && reply.Content != "" {
 					onChunk(reply.Content)
 				}
 				return reply, err
 			})
 	}
 
-	// Neither interface available → plain TurnStream.
-	return a.TurnStream(ctx, userInput, onChunk)
+	// Neither tool-aware interface available → plain TurnStream with the
+	// event-adapting onChunk. EventTurnDone fires on success.
+	reply, err := a.TurnStream(ctx, userInput, onChunk)
+	if err == nil && handler != nil {
+		r := reply
+		handler(AgentEvent{Kind: EventTurnDone, Reply: &r})
+	}
+	return reply, err
 }
 
 // runStreamLoop is the shared inner loop for RunStream. The send function
-// encapsulates the provider call (streaming or buffered).
+// encapsulates the provider call (streaming or buffered) and is responsible
+// for surfacing text deltas itself; this loop is only responsible for tool
+// dispatch and tool-level events.
 func (a *Agent) runStreamLoop(
 	ctx context.Context,
 	userInput string,
 	tools []ToolDefinition,
 	executor ToolExecutor,
-	_ func(string), // onChunk already closed over by send
+	handler EventHandler,
 	send func(ctx context.Context, msgs []Message) (Reply, error),
 ) (Reply, error) {
 	a.History.Append(NewUserMessage(userInput))
@@ -342,10 +369,21 @@ func (a *Agent) runStreamLoop(
 		if reply.StopReason == "tool_use" {
 			a.History.Append(NewToolUseMessage(reply.Blocks))
 
+			// Emit EventToolStarted before dispatch so observers see the
+			// "thinking → tool call" boundary even if the tool blocks.
+			emitToolStartedEvents(handler, reply.Blocks)
+
 			resultBlocks, err := dispatchTools(ctx, executor, reply.Blocks)
 			if err != nil {
 				return Reply{}, fmt.Errorf("agent: dispatch tools[%d]: %w", i, err)
 			}
+
+			// Emit EventToolDone / EventToolError per result, pairing
+			// each result with the originating tool_use block so ToolName
+			// can be carried through (tool_result blocks don't carry it
+			// themselves).
+			emitToolResultEvents(handler, reply.Blocks, resultBlocks)
+
 			a.History.Append(NewToolResultMessage(resultBlocks))
 			continue
 		}
@@ -356,10 +394,67 @@ func (a *Agent) runStreamLoop(
 		}
 		a.History.Append(NewAssistantMessage(content))
 		reply.Content = content
+		if handler != nil {
+			r := reply
+			handler(AgentEvent{Kind: EventTurnDone, Reply: &r})
+		}
 		return reply, nil
 	}
 
 	return Reply{}, fmt.Errorf("agent: exceeded max tool iterations (%d)", maxToolIterations)
+}
+
+// emitToolStartedEvents fires one EventToolStarted per tool_use block.
+// handler may be nil — the loop short-circuits cleanly.
+func emitToolStartedEvents(handler EventHandler, useBlocks []ContentBlock) {
+	if handler == nil {
+		return
+	}
+	for _, b := range useBlocks {
+		if b.Type != "tool_use" {
+			continue
+		}
+		handler(AgentEvent{
+			Kind:     EventToolStarted,
+			ToolID:   b.ID,
+			ToolName: b.Name,
+			Input:    b.Input,
+		})
+	}
+}
+
+// emitToolResultEvents pairs each tool_result with the originating tool_use
+// (matched on ID) so ToolName flows through to the EventDone / EventError
+// payload. tool_result blocks don't carry the tool name themselves — this
+// pairing is required to keep events fully self-describing for UI consumers.
+func emitToolResultEvents(handler EventHandler, useBlocks, resultBlocks []ContentBlock) {
+	if handler == nil {
+		return
+	}
+	// Build an id→name index once.
+	nameByID := make(map[string]string, len(useBlocks))
+	for _, b := range useBlocks {
+		if b.Type == "tool_use" {
+			nameByID[b.ID] = b.Name
+		}
+	}
+	for _, r := range resultBlocks {
+		if r.Type != "tool_result" {
+			continue
+		}
+		ev := AgentEvent{
+			ToolID:   r.ToolUseID,
+			ToolName: nameByID[r.ToolUseID],
+			Output:   truncateOutput(r.Result),
+		}
+		if r.IsError {
+			ev.Kind = EventToolError
+			ev.Err = r.Result // full untruncated error message in Err
+		} else {
+			ev.Kind = EventToolDone
+		}
+		handler(ev)
+	}
 }
 
 // dispatchTools calls executor.Execute for every tool_use block in blocks,

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -412,5 +413,205 @@ func TestAgent_Run_SenderWithoutToolSupport_FallsBackToTurn(t *testing.T) {
 	// Executor should NOT have been called.
 	if len(exec.called) != 0 {
 		t.Errorf("executor should not be called when sender has no ToolSender support")
+	}
+}
+
+// ─── RunStream() + AgentEvent tests ────────────────────────────────────────
+
+// failingExecutor returns an error from Execute, which the agent loop turns
+// into a tool_result block with IsError=true.
+type failingExecutor struct {
+	err error
+}
+
+func (f *failingExecutor) Execute(_ context.Context, _ string, _ map[string]any) (string, error) {
+	return "", f.err
+}
+
+func TestAgent_RunStream_NoTools_EmitsTextDeltaAndTurnDone(t *testing.T) {
+	// Without tools, RunStream falls back through TurnStream. With a plain
+	// Sender (no streaming variant), TurnStream synthesises a single
+	// onChunk call with the full content. That should surface as exactly
+	// one EventTextDelta + one EventTurnDone.
+	send := &fakeSender{reply: Reply{Content: "hello world", StopReason: "end_turn"}}
+	a := New(send, "m")
+
+	var events []AgentEvent
+	reply, err := a.RunStream(context.Background(), "hi", nil, nil, func(ev AgentEvent) {
+		events = append(events, ev)
+	})
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+	if reply.Content != "hello world" {
+		t.Errorf("reply.Content = %q", reply.Content)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2 (TextDelta + TurnDone), got %+v", len(events), events)
+	}
+	if events[0].Kind != EventTextDelta || events[0].Text != "hello world" {
+		t.Errorf("events[0] = %+v", events[0])
+	}
+	if events[1].Kind != EventTurnDone || events[1].Reply == nil || events[1].Reply.Content != "hello world" {
+		t.Errorf("events[1] = %+v", events[1])
+	}
+}
+
+func TestAgent_RunStream_ToolUse_EmitsStartedAndDone(t *testing.T) {
+	// Two-round conversation: tool_use → end_turn.
+	send := &fakeToolSender{
+		replies: []Reply{
+			{
+				StopReason: "tool_use",
+				Blocks: []ContentBlock{
+					NewToolUseBlock("call-1", "terminal", map[string]any{"command": "echo hi"}),
+				},
+			},
+			{Content: "The output was: hi", StopReason: "end_turn"},
+		},
+	}
+	exec := &fakeExecutor{results: map[string]string{"terminal": "hi"}}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "terminal"}}
+
+	var events []AgentEvent
+	reply, err := a.RunStream(context.Background(), "run echo", defs, exec, func(ev AgentEvent) {
+		events = append(events, ev)
+	})
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+	if reply.Content != "The output was: hi" {
+		t.Errorf("reply.Content = %q", reply.Content)
+	}
+
+	// Expect (in order):
+	// 1. EventToolStarted for call-1
+	// 2. EventToolDone for call-1
+	// 3. EventTextDelta with "The output was: hi" (round-2 buffered onChunk)
+	// 4. EventTurnDone with the final Reply
+	if len(events) < 4 {
+		t.Fatalf("events = %d, want >=4, got %+v", len(events), events)
+	}
+
+	if events[0].Kind != EventToolStarted {
+		t.Errorf("events[0].Kind = %q, want tool_started", events[0].Kind)
+	}
+	if events[0].ToolID != "call-1" || events[0].ToolName != "terminal" {
+		t.Errorf("events[0] tool id/name = %q/%q", events[0].ToolID, events[0].ToolName)
+	}
+	if got := events[0].Input["command"]; got != "echo hi" {
+		t.Errorf("events[0].Input.command = %v", got)
+	}
+
+	if events[1].Kind != EventToolDone {
+		t.Errorf("events[1].Kind = %q, want tool_done", events[1].Kind)
+	}
+	if events[1].ToolID != "call-1" || events[1].ToolName != "terminal" {
+		t.Errorf("events[1] tool id/name = %q/%q", events[1].ToolID, events[1].ToolName)
+	}
+	if events[1].Output != "hi" {
+		t.Errorf("events[1].Output = %q, want 'hi'", events[1].Output)
+	}
+
+	// Last event must be EventTurnDone.
+	last := events[len(events)-1]
+	if last.Kind != EventTurnDone || last.Reply == nil {
+		t.Errorf("last event = %+v, want EventTurnDone with Reply set", last)
+	}
+}
+
+func TestAgent_RunStream_ToolError_EmitsErrorEvent(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{
+			{
+				StopReason: "tool_use",
+				Blocks: []ContentBlock{
+					NewToolUseBlock("call-1", "terminal", nil),
+				},
+			},
+			{Content: "I see the error", StopReason: "end_turn"},
+		},
+	}
+	exec := &failingExecutor{err: fmt.Errorf("command not found")}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "terminal"}}
+
+	var events []AgentEvent
+	_, err := a.RunStream(context.Background(), "run", defs, exec, func(ev AgentEvent) {
+		events = append(events, ev)
+	})
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+
+	// First should be tool_started, second tool_error.
+	if len(events) < 2 {
+		t.Fatalf("events = %d, want >=2", len(events))
+	}
+	if events[0].Kind != EventToolStarted {
+		t.Errorf("events[0] = %+v", events[0])
+	}
+	if events[1].Kind != EventToolError {
+		t.Errorf("events[1] = %+v, want tool_error", events[1])
+	}
+	if events[1].Err != "command not found" {
+		t.Errorf("events[1].Err = %q", events[1].Err)
+	}
+}
+
+func TestAgent_RunStream_NilHandlerTolerated(t *testing.T) {
+	// nil handler must be safe — events are dropped, the run still completes.
+	send := &fakeToolSender{
+		replies: []Reply{
+			{
+				StopReason: "tool_use",
+				Blocks:     []ContentBlock{NewToolUseBlock("c1", "terminal", nil)},
+			},
+			{Content: "ok", StopReason: "end_turn"},
+		},
+	}
+	exec := &fakeExecutor{}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "terminal"}}
+
+	reply, err := a.RunStream(context.Background(), "go", defs, exec, nil)
+	if err != nil {
+		t.Fatalf("RunStream(nil handler): %v", err)
+	}
+	if reply.Content != "ok" {
+		t.Errorf("reply.Content = %q", reply.Content)
+	}
+}
+
+func TestAgent_RunStream_TruncatesLongToolOutput(t *testing.T) {
+	long := strings.Repeat("x", EventToolOutputCap+200)
+	send := &fakeToolSender{
+		replies: []Reply{
+			{
+				StopReason: "tool_use",
+				Blocks:     []ContentBlock{NewToolUseBlock("c1", "terminal", nil)},
+			},
+			{Content: "done", StopReason: "end_turn"},
+		},
+	}
+	exec := &fakeExecutor{results: map[string]string{"terminal": long}}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "terminal"}}
+
+	var seen AgentEvent
+	_, err := a.RunStream(context.Background(), "go", defs, exec, func(ev AgentEvent) {
+		if ev.Kind == EventToolDone {
+			seen = ev
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(seen.Output) > EventToolOutputCap+len("…[truncated]") {
+		t.Errorf("Output not truncated: len=%d", len(seen.Output))
+	}
+	if !strings.HasSuffix(seen.Output, "…[truncated]") {
+		t.Errorf("Output should be marked truncated: %q", seen.Output[:50])
 	}
 }

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -1,0 +1,79 @@
+package agent
+
+// EventKind tags an AgentEvent by what happened.
+type EventKind string
+
+const (
+	// EventTextDelta carries one piece of the assistant's text reply, as it
+	// arrives off the provider stream. Multiple deltas concatenate to form
+	// the full reply text.
+	EventTextDelta EventKind = "text_delta"
+
+	// EventToolStarted fires immediately before a tool is dispatched.
+	// ToolID / ToolName / Input identify the call.
+	EventToolStarted EventKind = "tool_started"
+
+	// EventToolDone fires after a successful tool execution.
+	// Output carries the tool's combined stdout/stderr text (truncated to
+	// EventToolOutputCap if longer).
+	EventToolDone EventKind = "tool_done"
+
+	// EventToolError fires when the tool executor reports an error result
+	// (IsError=true on the underlying ToolResultBlock). Err carries the
+	// failure message; Output may still contain partial stdout from the
+	// failing process.
+	EventToolError EventKind = "tool_error"
+
+	// EventTurnDone fires once at the end of a successful Run/RunStream,
+	// after the assistant's final reply is committed to history. Reply
+	// carries the aggregated final Reply.
+	EventTurnDone EventKind = "turn_done"
+)
+
+// EventToolOutputCap is the maximum length of the Output field emitted on
+// EventToolDone / EventToolError. The agent loop never truncates the actual
+// tool result going back into the conversation — this cap only applies to
+// what's surfaced to event observers (Web UI cards, IM previews), where a
+// 100KB shell dump would be useless noise.
+const EventToolOutputCap = 512
+
+// AgentEvent is the union shape carried over the EventHandler callback.
+//
+// All fields are populated only for the EventKinds that need them; the rest
+// stay at zero values. The contract for each kind:
+//
+//   - EventTextDelta:   Text
+//   - EventToolStarted: ToolID, ToolName, Input
+//   - EventToolDone:    ToolID, ToolName, Output
+//   - EventToolError:   ToolID, ToolName, Output (may be empty), Err
+//   - EventTurnDone:    Reply
+//
+// JSON tags are included so HTTP/SSE transports (M8 web server) can
+// marshal events directly without an intermediate type.
+type AgentEvent struct {
+	Kind     EventKind      `json:"kind"`
+	Text     string         `json:"text,omitempty"`
+	ToolID   string         `json:"tool_id,omitempty"`
+	ToolName string         `json:"tool_name,omitempty"`
+	Input    map[string]any `json:"input,omitempty"`
+	Output   string         `json:"output,omitempty"`
+	Err      string         `json:"err,omitempty"`
+	Reply    *Reply         `json:"reply,omitempty"`
+}
+
+// EventHandler is the callback type passed into Agent.RunStream. The handler
+// is invoked synchronously from the agent loop — if it blocks, the loop
+// blocks. Implementations that need async fan-out (e.g. SSE to multiple
+// clients) should buffer into a channel and return immediately.
+type EventHandler func(AgentEvent)
+
+// truncateOutput is the helper used by the agent loop before placing tool
+// output into an AgentEvent. Keeping it here rather than in agent.go puts
+// the size policy next to the cap constant.
+func truncateOutput(s string) string {
+	if len(s) <= EventToolOutputCap {
+		return s
+	}
+	// Add a clear marker so consumers know they only got a slice.
+	return s[:EventToolOutputCap] + "…[truncated]"
+}


### PR DESCRIPTION
## Summary

Replace `Agent.RunStream`'s `onChunk func(string)` callback with a typed `AgentEvent` stream. Web UI and IM consumers can now observe the full agent execution — tool starts, tool results, errors, final reply — not just text deltas.

## Events

| Kind | Fired when | Payload |
|------|-----------|---------|
| `text_delta`   | text chunk arrives from provider | `Text` |
| `tool_started` | before each tool dispatch | `ToolID`, `ToolName`, `Input` |
| `tool_done`    | successful tool result | `ToolID`, `ToolName`, `Output` |
| `tool_error`   | tool result with `IsError=true` | `ToolID`, `ToolName`, `Output`, `Err` |
| `turn_done`    | end of run | `Reply` |

`AgentEvent` is a single flat struct (chosen over the payload-interface variant) with JSON tags so the M8 web server can SSE-marshal directly.

`Output` on tool events is truncated to **512 bytes** (`EventToolOutputCap`) with a `…[truncated]` marker — UI/IM presentation concern only; the agent's conversation history keeps the full result.

## REPL behaviour

Unchanged. `cmd/octo/repl.go` wraps the new `EventHandler` as a text-only printer (`if ev.Kind == EventTextDelta { fprint(ev.Text) }`). Tool events are not surfaced in the REPL today; later milestones can grow inline cards.

## Scope

- `TurnStream` signature unchanged
- Only `RunStream`'s callback type changed; nothing outside `cmd/octo` calls `RunStream`, so blast radius is contained

## Test plan

- [x] `go test -race ./...` — green (5 new tests covering text+turn, tool started+done, tool error, nil handler, output truncation)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean

## Why this lands now

It's the foundation for the next two roadmap items: **M8 Web Server agent dashboard** and **M9 WeChat iLink bridge**. Both need to render tool calls as discrete UI elements, which the previous text-only callback didn't support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)