### PR TITLE
feat(repl): surface tool events as inline status lines

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -93,15 +94,14 @@ func runREPL(cfg replConfig) int {
 			err   error
 		)
 		if len(cfg.tools) > 0 && cfg.executor != nil {
-			// Wrap the new event handler as a text-only printer so REPL
-			// behaviour matches the pre-M5 streaming output exactly.
-			// Tool events are not surfaced in the REPL today; later they
-			// can grow inline cards or status lines.
-			reply, err = a.RunStream(context.Background(), line, cfg.tools, cfg.executor, func(ev agent.AgentEvent) {
-				if ev.Kind == agent.EventTextDelta {
-					fmt.Fprint(cfg.stdout, ev.Text)
-				}
-			})
+			// Tool events become inline status lines so the user can see what
+			// the agent is doing instead of staring at a blank terminal while
+			// a tool runs. Text deltas stream as before. Output is muted on
+			// EventToolDone — the tool's own product (file written, command
+			// stdout, etc.) is conversational state for the LLM, not user-
+			// facing chrome. EventTurnDone is also silent; the trailing
+			// newline below marks the visible turn boundary.
+			reply, err = a.RunStream(context.Background(), line, cfg.tools, cfg.executor, replToolEventHandler(cfg.stdout))
 		} else {
 			reply, err = a.TurnStream(context.Background(), line, func(delta string) {
 				fmt.Fprint(cfg.stdout, delta)
@@ -182,4 +182,104 @@ func printSessions(w io.Writer) error {
 		fmt.Fprintln(w)
 	}
 	return nil
+}
+
+// replToolEventHandler returns an EventHandler that paints tool activity
+// onto the terminal between assistant text streams. Layout:
+//
+//	…assistant text streamed…
+//	↳ terminal: ls -la                                          ← tool_started
+//	↳ terminal ✓ (142ms)                                        ← tool_done
+//	…more assistant text…
+//
+// Status lines start with "↳ " so they're visually distinct from the
+// assistant's reply, and each is on its own line. We also insert a leading
+// newline before the FIRST status line of a turn — without it the marker
+// would butt up against the trailing character of the assistant's
+// "I'll now run terminal..." sentence.
+func replToolEventHandler(stdout io.Writer) func(agent.AgentEvent) {
+	// Per-tool-call start times so EventToolDone can report elapsed.
+	startedAt := make(map[string]time.Time)
+	// Track whether the previous event was a text delta — if so, a tool
+	// status line needs a leading newline to start cleanly.
+	prevWasText := false
+
+	return func(ev agent.AgentEvent) {
+		switch ev.Kind {
+		case agent.EventTextDelta:
+			fmt.Fprint(stdout, ev.Text)
+			prevWasText = true
+
+		case agent.EventToolStarted:
+			if prevWasText {
+				fmt.Fprintln(stdout)
+				prevWasText = false
+			}
+			startedAt[ev.ToolID] = time.Now()
+			fmt.Fprintf(stdout, "↳ %s: %s\n", ev.ToolName, summariseInput(ev.Input))
+
+		case agent.EventToolDone:
+			elapsed := ""
+			if t, ok := startedAt[ev.ToolID]; ok {
+				elapsed = fmt.Sprintf(" (%s)", time.Since(t).Round(time.Millisecond))
+				delete(startedAt, ev.ToolID)
+			}
+			fmt.Fprintf(stdout, "↳ %s ✓%s\n", ev.ToolName, elapsed)
+
+		case agent.EventToolError:
+			elapsed := ""
+			if t, ok := startedAt[ev.ToolID]; ok {
+				elapsed = fmt.Sprintf(" (%s)", time.Since(t).Round(time.Millisecond))
+				delete(startedAt, ev.ToolID)
+			}
+			fmt.Fprintf(stdout, "↳ %s ✗%s — %s\n", ev.ToolName, elapsed, truncate1Line(ev.Err))
+
+			// EventTurnDone is silent — the trailing newline emitted by the
+			// REPL loop after RunStream returns serves as the turn boundary.
+		}
+	}
+}
+
+// summariseInput renders a short single-line description of the tool's input
+// for inline display. Keys are sorted so the line is stable; long values are
+// truncated. The goal is "enough for the user to know which call this is",
+// not full fidelity.
+func summariseInput(input map[string]any) string {
+	if len(input) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(input))
+	for k := range input {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v := fmt.Sprintf("%v", input[k])
+		if len(v) > 60 {
+			v = v[:57] + "..."
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+	}
+	joined := strings.Join(parts, " ")
+	if len(joined) > 120 {
+		joined = joined[:117] + "..."
+	}
+	return joined
+}
+
+// truncate1Line collapses a multi-line error to its first non-empty line and
+// caps total length, so the status row stays single-line.
+func truncate1Line(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if len(line) > 200 {
+			line = line[:197] + "..."
+		}
+		return line
+	}
+	return "(empty error)"
 }

--- a/cmd/octo/repl_test.go
+++ b/cmd/octo/repl_test.go
@@ -197,3 +197,95 @@ func TestREPL_ResumedSessionShowsTurnCount(t *testing.T) {
 		t.Errorf("expected '1 turn' in output:\n%s", out)
 	}
 }
+
+// ─── replToolEventHandler tests ─────────────────────────────────────────────
+
+func TestREPLToolEventHandler_TextOnly(t *testing.T) {
+	var buf bytes.Buffer
+	h := replToolEventHandler(&buf)
+	h(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "hello"})
+	h(agent.AgentEvent{Kind: agent.EventTextDelta, Text: " world"})
+	if got := buf.String(); got != "hello world" {
+		t.Errorf("text deltas = %q, want 'hello world'", got)
+	}
+}
+
+func TestREPLToolEventHandler_ToolStartedAndDone(t *testing.T) {
+	var buf bytes.Buffer
+	h := replToolEventHandler(&buf)
+	h(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "Running now..."})
+	h(agent.AgentEvent{
+		Kind: agent.EventToolStarted, ToolID: "c1", ToolName: "terminal",
+		Input: map[string]any{"command": "ls"},
+	})
+	h(agent.AgentEvent{
+		Kind: agent.EventToolDone, ToolID: "c1", ToolName: "terminal",
+	})
+	out := buf.String()
+	if !strings.Contains(out, "↳ terminal: command=ls") {
+		t.Errorf("missing started line:\n%s", out)
+	}
+	if !strings.Contains(out, "↳ terminal ✓") {
+		t.Errorf("missing done line:\n%s", out)
+	}
+	// "Running now..." should be followed by a newline before the ↳ line —
+	// without it the status arrow would butt up against the dot.
+	if !strings.Contains(out, "Running now...\n↳") {
+		t.Errorf("expected newline between text and ↳:\n%q", out)
+	}
+}
+
+func TestREPLToolEventHandler_ToolError(t *testing.T) {
+	var buf bytes.Buffer
+	h := replToolEventHandler(&buf)
+	h(agent.AgentEvent{
+		Kind: agent.EventToolStarted, ToolID: "c1", ToolName: "write_file",
+		Input: map[string]any{"path": "/etc/passwd"},
+	})
+	h(agent.AgentEvent{
+		Kind: agent.EventToolError, ToolID: "c1", ToolName: "write_file",
+		Err: "permission denied",
+	})
+	out := buf.String()
+	if !strings.Contains(out, "↳ write_file ✗") {
+		t.Errorf("missing error marker:\n%s", out)
+	}
+	if !strings.Contains(out, "permission denied") {
+		t.Errorf("error message not shown:\n%s", out)
+	}
+}
+
+func TestREPLToolEventHandler_TurnDoneSilent(t *testing.T) {
+	// EventTurnDone is intentionally not rendered — the REPL loop appends
+	// its own trailing newline. This test locks that in so a well-meaning
+	// future change doesn't accidentally double-print.
+	var buf bytes.Buffer
+	h := replToolEventHandler(&buf)
+	reply := agent.Reply{Content: "all done"}
+	h(agent.AgentEvent{Kind: agent.EventTurnDone, Reply: &reply})
+	if buf.Len() != 0 {
+		t.Errorf("EventTurnDone should be silent; got %q", buf.String())
+	}
+}
+
+func TestSummariseInput_TruncatesLongValues(t *testing.T) {
+	got := summariseInput(map[string]any{
+		"path":    "short",
+		"content": strings.Repeat("X", 200),
+	})
+	// Long value should be truncated with ellipsis.
+	if !strings.Contains(got, "...") {
+		t.Errorf("expected truncation marker, got %q", got)
+	}
+	// Output line itself capped at 120 chars.
+	if len(got) > 120 {
+		t.Errorf("line not capped: len=%d, got %q", len(got), got)
+	}
+}
+
+func TestTruncate1Line_CollapsesMultiline(t *testing.T) {
+	got := truncate1Line("\n\nfirst real line\nsecond line that gets dropped")
+	if got != "first real line" {
+		t.Errorf("truncate1Line = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

When `--tools` is on, the REPL now prints the tool boundary inline so the user isn't staring at a blank terminal while a tool runs.

**Before** (M5 events were fired but the REPL handler dropped them):
```
you> rename main to App and run the tests
I'll rename it and run tests.
[ ~3s blank terminal ]
Renamed and tests pass.
```

**After**:
```
you> rename main to App and run the tests
I'll rename it and run tests.
↳ edit_file: old_string=main new_string=App path=/Users/.../main.go
↳ edit_file ✓ (4ms)
↳ terminal: command=go test ./...
↳ terminal ✓ (2.1s)
Renamed and tests pass.
```

## Behaviour

| Event | Rendered as |
|---|---|
| `text_delta` | streams to stdout as before |
| `tool_started` | `↳ <name>: <key=value ...>` |
| `tool_done` | `↳ <name> ✓ (<elapsed>)` |
| `tool_error` | `↳ <name> ✗ (<elapsed>) — <first error line>` |
| `turn_done` | silent (REPL loop already emits trailing newline) |

Tool **products** (stdout of `terminal`, contents of `read_file`, …) remain off-screen — that's conversational state for the LLM, not user-facing chrome. Adding a separate `--show-tool-output` flag is a future call.

## Implementation

- `replToolEventHandler(stdout)` returns a closure with per-turn state (start-time map, prevWasText flag for leading-newline insertion).
- `summariseInput` renders sorted `key=value` pairs, cap 120 chars line / 60 chars per value.
- `truncate1Line` collapses multi-line errors to first non-empty line, cap 200 chars.

## Test plan

- [x] `go test -race ./...` green (6 new tests)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] Tests cover: text-only, started+done sequence, error rendering, turn-done silence, summary truncation, multi-line error collapse

## Next in this series

This is PR 1 of 3 — the user-visible REPL change. Follow-ups:
- **PR 2**: `ToolExecutor` gets a progress callback + `terminal` streams stdout/stderr line-by-line
- **PR 3**: `EventToolInputDelta` — surface the LLM's tool-call JSON as it streams in

🤖 Generated with [Claude Code](https://claude.com/claude-code)