### PR TITLE
feat(prompt,anthropic): system prompt composition + prompt caching (A1+A2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased — 0.1.0-dev]
 
 ### Added
+- **System prompt composition** — new `internal/prompt` package assembles the session system prompt from three layers in order of specificity: an embedded base prompt (octo identity + tool-use / permission / read-before-write norms) < the repo's `.octorules` (if present in cwd) < the `--system` flag. Composed once per session and frozen (recomputing mid-session would bust the provider prompt cache). Previously the default system prompt was empty — the agent got tool schemas but zero behavioral guidance.
+- **Anthropic prompt caching** — requests now place a `cache_control: ephemeral` breakpoint on the system block, which (per the tools → system → messages prefix order) caches the entire stable system+tools prefix that was previously re-sent at full price every agentic-loop iteration. Falls back to marking the last tool when there's no system prompt. Cuts input-token cost on the cached prefix by ~90% on multi-tool turns. (History-prefix caching pairs with the upcoming compaction work.)
 - **Go module scaffold** at `github.com/Leihb/octo-agent` (`cmd/octo` entry, `internal/{agent,provider,tools,version}`, Makefile, Go 1.22 CI matrix on Linux / macOS / Windows).
 - **`octo chat` CLI** — single-turn and interactive REPL modes. Streams by default; `--stream=false` opts back into buffered output.
 - **Anthropic Messages provider** — `x-api-key` auth, `anthropic-version` header, `content[].text` block parsing. `ANTHROPIC_BASE_URL` env override targets compatible third parties (DeepSeek, Kimi, OpenRouter Anthropic shim, etc.).

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/permission"
+	"github.com/Leihb/octo-agent/internal/prompt"
 	"github.com/Leihb/octo-agent/internal/provider"
 	"github.com/Leihb/octo-agent/internal/provider/anthropic"
 	"github.com/Leihb/octo-agent/internal/provider/openai"
@@ -123,8 +124,14 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// Compose the system prompt once (base + project .octorules + user --system)
+	// and freeze it for the session — recomputing mid-session would bust the
+	// provider's system+tools prompt cache. The session stores only the raw
+	// user layer; base/project are recomposed fresh each run.
+	cwd, _ := os.Getwd()
+
 	a := agent.New(providerSender{p: prov}, resolvedModel)
-	a.System = *system
+	a.System = prompt.Compose(*system, cwd)
 	a.MaxTokens = *maxTokens
 
 	// ── REPL mode ────────────────────────────────────────────────────────────
@@ -142,9 +149,9 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			if sess.Model != "" {
 				a.Model = sess.Model
 			}
-			if sess.System != "" {
-				a.System = sess.System
-			}
+			// Recompose from the session's raw user layer so base/project
+			// pick up any changes since the session was created.
+			a.System = prompt.Compose(sess.System, cwd)
 		} else {
 			sess = agent.NewSession(resolvedModel, *system)
 		}

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -1,0 +1,20 @@
+You are octo, an AI coding agent that runs in a terminal and operates on the user's real machine through tools.
+
+## How to work
+
+- Prefer the dedicated file tools over shelling out: `read_file`, `write_file`, `edit_file`, `glob`, `grep`. Reserve `terminal` for things only a shell can do (running builds/tests, git, process management).
+- Read a file before you edit or overwrite it. `edit_file` and `write_file` require that the file was read this session; if you haven't read it, read it first.
+- Use `edit_file` for partial changes, never `sed -i` or an in-place shell edit — those bypass the diff and safety checks and will be refused.
+- Make the smallest change that satisfies the request. Don't refactor, reformat, or "improve" code that wasn't part of the task.
+- When you search, prefer `grep`/`glob` over reading whole directories.
+
+## Tools and permissions
+
+- Some tool calls are gated by a permission policy. A call may be allowed, denied, or require the user's approval. If a call is denied, you'll get a `permission_denied` result explaining why — treat it as a normal outcome: explain the situation to the user or propose a safe alternative, don't retry the same call in a loop.
+- Don't attempt to read credentials (private keys, `.env`, `~/.ssh`, cloud-metadata endpoints) or write secrets into files; these are blocked by policy.
+
+## Output
+
+- Be concise and direct. Skip filler and preamble.
+- When you reference code, cite it as `path:line` so the user can jump to it.
+- Report what you did and what's next in a sentence or two, not a wall of text.

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,0 +1,63 @@
+// Package prompt assembles the agent's system prompt from layered sources.
+//
+// The composed prompt is meant to be built ONCE per session and frozen: the
+// provider caches the system+tools prefix (see internal/provider/anthropic),
+// and recomputing the prompt mid-session would invalidate that cache for
+// every subsequent turn. Compose at session start, set it on Agent.System,
+// and don't touch it again.
+package prompt
+
+import (
+	_ "embed"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// base is the built-in foundation prompt: octo's identity plus the
+// tool-use, permission, and read-before-write norms. Embedded so it ships
+// in the single binary.
+//
+//go:embed base.md
+var base string
+
+// ProjectContextFile is the per-repo conventions file Compose looks for in
+// the working directory. It carries project-specific rules the agent should
+// follow (the human-facing counterpart to CLAUDE.md).
+const ProjectContextFile = ".octorules"
+
+// Compose assembles the session system prompt from up to three layers, in
+// order of increasing specificity:
+//
+//  1. base    — embedded octo foundation (always present)
+//  2. project — ProjectContextFile in cwd, if present (repo conventions)
+//  3. user    — the --system value, if any (highest-priority override, last)
+//
+// Empty layers are skipped. Later layers appear later in the text, which is
+// the conventional way to let more specific instructions take precedence.
+func Compose(userSystem, cwd string) string {
+	layers := []string{strings.TrimSpace(base)}
+
+	if proj := readProjectContext(cwd); proj != "" {
+		layers = append(layers, "# Project conventions ("+ProjectContextFile+")\n\n"+proj)
+	}
+	if u := strings.TrimSpace(userSystem); u != "" {
+		layers = append(layers, u)
+	}
+
+	return strings.Join(layers, "\n\n---\n\n")
+}
+
+// readProjectContext returns the trimmed contents of ProjectContextFile in
+// cwd, or "" if it's absent/unreadable/empty. A missing file is not an error
+// — most directories won't have one.
+func readProjectContext(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+	b, err := os.ReadFile(filepath.Join(cwd, ProjectContextFile))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1,0 +1,58 @@
+package prompt
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCompose_BaseAlwaysPresent(t *testing.T) {
+	out := Compose("", t.TempDir()) // empty user, no .octorules
+	if !strings.Contains(out, "octo") {
+		t.Errorf("composed prompt should contain the base identity:\n%s", out)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Error("base layer must never be empty")
+	}
+}
+
+func TestCompose_LayersInOrder(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("PROJECT_RULE_X"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := Compose("USER_RULE_Y", dir)
+
+	baseIdx := strings.Index(out, "octo")
+	projIdx := strings.Index(out, "PROJECT_RULE_X")
+	userIdx := strings.Index(out, "USER_RULE_Y")
+
+	if baseIdx == -1 || projIdx == -1 || userIdx == -1 {
+		t.Fatalf("all three layers should be present:\n%s", out)
+	}
+	// Order: base < project < user.
+	if !(baseIdx < projIdx && projIdx < userIdx) {
+		t.Errorf("layer order wrong: base=%d project=%d user=%d", baseIdx, projIdx, userIdx)
+	}
+	if !strings.Contains(out, ProjectContextFile) {
+		t.Errorf("project layer should be labelled with the source file")
+	}
+}
+
+func TestCompose_SkipsAbsentLayers(t *testing.T) {
+	// No .octorules, no user prompt → just the base, no stray separators.
+	out := Compose("", t.TempDir())
+	if strings.Contains(out, "---") {
+		t.Errorf("single-layer prompt should have no separator:\n%s", out)
+	}
+}
+
+func TestReadProjectContext_MissingFileIsEmpty(t *testing.T) {
+	if got := readProjectContext(t.TempDir()); got != "" {
+		t.Errorf("missing .octorules should yield empty, got %q", got)
+	}
+	if got := readProjectContext(""); got != "" {
+		t.Errorf("empty cwd should yield empty, got %q", got)
+	}
+}

--- a/internal/provider/anthropic/cache_test.go
+++ b/internal/provider/anthropic/cache_test.go
@@ -1,0 +1,55 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+func TestCacheableRequest_SystemBreakpoint(t *testing.T) {
+	var body apiRequest
+	tools := toAPITools([]agent.ToolDefinition{{Name: "t1"}, {Name: "t2"}})
+	cacheableRequest(&body, "you are octo", tools)
+
+	sysJSON, _ := json.Marshal(body.System)
+	if !strings.Contains(string(sysJSON), `"ephemeral"`) {
+		t.Errorf("system should carry an ephemeral breakpoint: %s", sysJSON)
+	}
+	// With a system prompt anchoring the breakpoint, tools must NOT be marked
+	// (the system breakpoint already caches tools+system).
+	for i, tl := range body.Tools {
+		if tl.CacheControl != nil {
+			t.Errorf("tool[%d] should not be marked when system carries the breakpoint", i)
+		}
+	}
+}
+
+func TestCacheableRequest_ToolFallbackWhenNoSystem(t *testing.T) {
+	var body apiRequest
+	tools := toAPITools([]agent.ToolDefinition{{Name: "t1"}, {Name: "t2"}})
+	cacheableRequest(&body, "", tools)
+
+	if body.System != nil {
+		t.Errorf("empty system should serialize as nil/omitted, got %v", body.System)
+	}
+	// Last tool gets the breakpoint so the tools array still caches.
+	if body.Tools[len(body.Tools)-1].CacheControl == nil {
+		t.Errorf("last tool should carry the fallback breakpoint")
+	}
+	if body.Tools[0].CacheControl != nil {
+		t.Errorf("only the last tool should be marked, not the first")
+	}
+}
+
+func TestCacheableRequest_NoSystemNoTools(t *testing.T) {
+	var body apiRequest
+	cacheableRequest(&body, "", nil)
+	if body.System != nil {
+		t.Errorf("system should be nil")
+	}
+	if body.Tools != nil {
+		t.Errorf("tools should be nil")
+	}
+}

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -86,10 +86,9 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 	body := apiRequest{
 		Model:     req.Model,
 		MaxTokens: req.MaxTokens,
-		System:    req.SystemPrompt,
 		Messages:  msgs,
-		Tools:     toAPITools(req.Tools),
 	}
+	cacheableRequest(&body, req.SystemPrompt, toAPITools(req.Tools))
 	if body.MaxTokens <= 0 {
 		body.MaxTokens = DefaultMaxTokens
 	}
@@ -162,6 +161,40 @@ func (c *Client) endpointURL() string {
 		base = DefaultBaseURL
 	}
 	return strings.TrimRight(base, "/") + MessagesPath
+}
+
+// buildSystem returns the value for the request's `system` field, placing a
+// cache breakpoint on it when non-empty. Because the cache prefix order is
+// tools → system → messages, a breakpoint on the system block also caches the
+// (stable, every-turn-identical) tools array that precedes it — capturing the
+// bulk of the per-turn input-token cost of an agentic loop. Returns nil for an
+// empty prompt so the field is omitted.
+func buildSystem(prompt string) any {
+	if prompt == "" {
+		return nil
+	}
+	return []apiSystemBlock{{Type: "text", Text: prompt, CacheControl: ephemeral}}
+}
+
+// markToolsCacheable puts a cache breakpoint on the LAST tool so the tools
+// array is cached even with no system prompt to anchor on. No-op when there
+// are no tools.
+func markToolsCacheable(tools []apiTool) []apiTool {
+	if len(tools) > 0 {
+		tools[len(tools)-1].CacheControl = ephemeral
+	}
+	return tools
+}
+
+// cacheableRequest sets body.System and body.Tools with cache breakpoints
+// placed appropriately for the given prompt/tools. Shared by Send and
+// SendStream so both paths cache identically.
+func cacheableRequest(body *apiRequest, systemPrompt string, tools []apiTool) {
+	body.System = buildSystem(systemPrompt)
+	if body.System == nil {
+		tools = markToolsCacheable(tools) // no system block to anchor on
+	}
+	body.Tools = tools
 }
 
 // toAPITools converts []agent.ToolDefinition to []apiTool.

--- a/internal/provider/anthropic/client_test.go
+++ b/internal/provider/anthropic/client_test.go
@@ -43,8 +43,14 @@ func TestSend_Success(t *testing.T) {
 		if req.Model != "claude-haiku-4-5-20251001" {
 			t.Errorf("model = %q, want claude-haiku-4-5-20251001", req.Model)
 		}
-		if req.System != "you are octo" {
-			t.Errorf("system = %q, want 'you are octo'", req.System)
+		// System is now sent in the cacheable array form: a single text block
+		// carrying the prompt plus an ephemeral cache_control breakpoint.
+		sysJSON, _ := json.Marshal(req.System)
+		if !strings.Contains(string(sysJSON), `"you are octo"`) {
+			t.Errorf("system missing prompt text: %s", sysJSON)
+		}
+		if !strings.Contains(string(sysJSON), `"ephemeral"`) {
+			t.Errorf("system missing cache_control breakpoint: %s", sysJSON)
 		}
 		if len(req.Messages) != 1 {
 			t.Fatalf("messages len = %d, want 1", len(req.Messages))

--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -54,11 +54,10 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 	body := apiRequest{
 		Model:     req.Model,
 		MaxTokens: req.MaxTokens,
-		System:    req.SystemPrompt,
 		Messages:  msgs,
 		Stream:    true,
-		Tools:     toAPITools(req.Tools),
 	}
+	cacheableRequest(&body, req.SystemPrompt, toAPITools(req.Tools))
 	if body.MaxTokens <= 0 {
 		body.MaxTokens = DefaultMaxTokens
 	}

--- a/internal/provider/anthropic/types.go
+++ b/internal/provider/anthropic/types.go
@@ -6,19 +6,43 @@ package anthropic
 
 import "encoding/json"
 
+// cacheControl marks a prompt-cache breakpoint. Anthropic caches the entire
+// prefix up to and including the block carrying this marker and reuses it on
+// later requests sharing that prefix (billed at the cheaper cached rate).
+// Only "ephemeral" exists today.
+type cacheControl struct {
+	Type string `json:"type"` // "ephemeral"
+}
+
+// ephemeral is the shared marker; it's immutable so sharing the pointer is safe.
+var ephemeral = &cacheControl{Type: "ephemeral"}
+
+// apiSystemBlock is one element of the array form of the `system` field.
+// Anthropic accepts `system` as a plain string OR an array of text blocks;
+// only the array form can carry a cache_control marker.
+type apiSystemBlock struct {
+	Type         string        `json:"type"` // always "text"
+	Text         string        `json:"text"`
+	CacheControl *cacheControl `json:"cache_control,omitempty"`
+}
+
 // apiTool describes one tool the model may invoke, in the Anthropic wire format.
 // Note: Anthropic uses "input_schema" where the agent layer uses "parameters".
 type apiTool struct {
-	Name        string         `json:"name"`
-	Description string         `json:"description"`
-	InputSchema map[string]any `json:"input_schema"`
+	Name         string         `json:"name"`
+	Description  string         `json:"description"`
+	InputSchema  map[string]any `json:"input_schema"`
+	CacheControl *cacheControl  `json:"cache_control,omitempty"`
 }
 
 // apiRequest is the wire-level JSON body of POST /v1/messages.
+//
+// System is `any` so it serializes as either a plain string or a
+// []apiSystemBlock carrying a cache breakpoint; omitempty drops it when nil.
 type apiRequest struct {
 	Model     string       `json:"model"`
 	MaxTokens int          `json:"max_tokens"`
-	System    string       `json:"system,omitempty"`
+	System    any          `json:"system,omitempty"`
 	Messages  []apiMessage `json:"messages"`
 	Stream    bool         `json:"stream,omitempty"`
 	Tools     []apiTool    `json:"tools,omitempty"`


### PR DESCRIPTION
## Summary
First step of the core-hardening track (review §4 + §5). Two coupled changes in one PR.

### A1 — System prompt composition (`internal/prompt`)
- Layers the system prompt in order of specificity: **embedded base** (octo identity + tool-use / permission / read-before-write norms) < **`.octorules`** in cwd < **`--system`** flag. Empty layers skipped.
- **Composed once per session and frozen** — recomputing mid-session would bust the prompt cache. The session stores only the raw user layer, so base/project recompose fresh each run (small session files, picks up `.octorules` changes).
- Fixes the review's #1-priority gap: the default system prompt was **empty**, so the model got tool schemas but zero behavioral guidance and no awareness of the M6.5 permission layer.

### A2 — Anthropic prompt caching
- Places a `cache_control: ephemeral` breakpoint on the system block. Since the cache prefix order is **tools → system → messages**, this caches the entire stable system+tools prefix that was previously re-sent at full price on every agentic-loop iteration (~90% input-cost cut on multi-tool turns).
- Falls back to marking the last tool when there's no system prompt. `Send` and `SendStream` share one `cacheableRequest` helper.
- History-prefix (double-marker) caching is **deferred** to pair with the compaction PR (A3), where history handling is reworked anyway.

## Design note
Layer order is base < project < user (`--system` wins), which is more intuitive for a CLI flag than the Ruby version's base < user < project. Documented in `prompt.go`.

## Test plan
- [x] `go test -race ./...` clean; `gofmt -l .` clean; `go vet ./...` clean
- [x] prompt: base always present, three-layer ordering, absent-layer skipping, missing `.octorules` = empty
- [x] anthropic: system breakpoint set + tools unmarked when system present; tool-fallback breakpoint when no system; nil/nil when neither; existing Send/stream tests updated for the array-form system field
- [ ] Manual: real Anthropic key, confirm `usage.cache_creation_input_tokens` on turn 1 and `cache_read_input_tokens` on turn 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)