### PR TITLE
refactor(agent): unify Run and RunStream into one runLoop (B2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased — 0.1.0-dev]
 
+### Changed
+- **Unified agentic loop** — `Run` (buffered) and `RunStream` (streaming) previously carried two near-duplicate copies of the tool-dispatch loop, so changes like the permission gate had to be applied in both. They now share a single `runLoop`; `Run` drives it with a buffered send closure and a nil event handler (every event-emit path short-circuits on nil), `RunStream` with a streaming closure and a real handler. Behaviour is unchanged — verified by the existing `Run` and `RunStream` test suites.
+
 ### Added
 - **System prompt composition** — new `internal/prompt` package assembles the session system prompt from three layers in order of specificity: an embedded base prompt (octo identity + tool-use / permission / read-before-write norms) < the repo's `.octorules` (if present in cwd) < the `--system` flag. Composed once per session and frozen (recomputing mid-session would bust the provider prompt cache). Previously the default system prompt was empty — the agent got tool schemas but zero behavioral guidance.
 - **Anthropic prompt caching** — requests now place a `cache_control: ephemeral` breakpoint on the system block, which (per the tools → system → messages prefix order) caches the entire stable system+tools prefix that was previously re-sent at full price every agentic-loop iteration. Falls back to marking the last tool when there's no system prompt. Cuts input-token cost on the cached prefix by ~90% on multi-tool turns. (History-prefix caching pairs with the upcoming compaction work.)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -214,9 +214,11 @@ func (a *Agent) TurnStream(
 // error rather than looping forever.
 const maxToolIterations = 20
 
-// Run is the agentic loop. It appends the user message to history then
+// Run is the agentic loop: it appends the user message to history then
 // repeatedly calls the provider until the model reaches end_turn (no more
-// tool calls) or the iteration cap is hit.
+// tool calls) or the iteration cap is hit. Run is the buffered, no-event
+// counterpart of RunStream — both drive the same runLoop, Run with a nil
+// handler so no AgentEvents are emitted.
 //
 // If tools is nil or executor is nil, Run is equivalent to Turn (single-turn,
 // no tool dispatch).
@@ -231,57 +233,21 @@ func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinitio
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
 
-	// No tools → plain Turn.
+	// No tools (or a Sender that can't do tools) → plain Turn.
 	if len(tools) == 0 || executor == nil {
 		return a.Turn(ctx, userInput)
 	}
-
 	ts, ok := a.Sender.(ToolSender)
 	if !ok {
-		// Sender doesn't support tools; fall back to Turn.
 		return a.Turn(ctx, userInput)
 	}
 
-	a.History.Append(NewUserMessage(userInput))
-
-	for i := 0; i < maxToolIterations; i++ {
-		reply, err := ts.SendMessagesWithTools(ctx, a.Model, a.System, a.History.Snapshot(), a.MaxTokens, tools)
-		if err != nil {
-			if i == 0 {
-				a.History.popLast()
-			}
-			return Reply{}, fmt.Errorf("agent: run[%d]: %w", i, err)
-		}
-		a.sessionInputTokens += reply.InputTokens
-		a.sessionOutputTokens += reply.OutputTokens
-
-		if reply.StopReason == "tool_use" {
-			// Append assistant message with tool_use blocks, then dispatch.
-			a.History.Append(NewToolUseMessage(reply.Blocks))
-
-			// Run.runner doesn't carry a handler — progress events would
-			// have nowhere to go. Pass nil; dispatchTools degrades to the
-			// non-streaming path automatically.
-			resultBlocks, err := dispatchTools(ctx, executor, reply.Blocks, nil, a.Gate)
-			if err != nil {
-				return Reply{}, fmt.Errorf("agent: dispatch tools[%d]: %w", i, err)
-			}
-			a.History.Append(NewToolResultMessage(resultBlocks))
-			continue
-		}
-
-		// end_turn (or other stop reason): done.
-		// Use text content from reply; if Content is empty but Blocks has text, reconstruct.
-		content := reply.Content
-		if content == "" {
-			content = textFromBlocks(reply.Blocks)
-		}
-		a.History.Append(NewAssistantMessage(content))
-		reply.Content = content
-		return reply, nil
-	}
-
-	return Reply{}, fmt.Errorf("agent: exceeded max tool iterations (%d)", maxToolIterations)
+	// Buffered send + nil handler: runLoop runs the same dispatch/history
+	// machinery as the streaming path but emits no events.
+	return a.runLoop(ctx, userInput, tools, executor, nil,
+		func(ctx context.Context, msgs []Message) (Reply, error) {
+			return ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, a.MaxTokens, tools)
+		})
 }
 
 // RunStream is the streaming agentic loop. Behaves like Run but emits
@@ -344,13 +310,13 @@ func (a *Agent) RunStream(
 
 	// Try ToolStreamingSender first, then fall back to ToolSender (buffered).
 	if tss, ok := a.Sender.(ToolStreamingSender); ok {
-		return a.runStreamLoop(ctx, userInput, tools, executor, handler,
+		return a.runLoop(ctx, userInput, tools, executor, handler,
 			func(ctx context.Context, msgs []Message) (Reply, error) {
 				return tss.StreamMessagesWithTools(ctx, a.Model, a.System, msgs, a.MaxTokens, tools, onChunk, onToolDelta)
 			})
 	}
 	if ts, ok := a.Sender.(ToolSender); ok {
-		return a.runStreamLoop(ctx, userInput, tools, executor, handler,
+		return a.runLoop(ctx, userInput, tools, executor, handler,
 			func(ctx context.Context, msgs []Message) (Reply, error) {
 				reply, err := ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, a.MaxTokens, tools)
 				if err == nil && reply.Content != "" {
@@ -370,11 +336,14 @@ func (a *Agent) RunStream(
 	return reply, err
 }
 
-// runStreamLoop is the shared inner loop for RunStream. The send function
-// encapsulates the provider call (streaming or buffered) and is responsible
-// for surfacing text deltas itself; this loop is only responsible for tool
-// dispatch and tool-level events.
-func (a *Agent) runStreamLoop(
+// runLoop is the single agentic loop shared by Run and RunStream. The send
+// function encapsulates the provider call (streaming or buffered) and is
+// responsible for surfacing text deltas itself; this loop owns tool dispatch,
+// history bookkeeping, and tool-level event emission.
+//
+// handler may be nil (the Run path): every emit* helper and the dispatch
+// progress path short-circuit on nil, so no events fire.
+func (a *Agent) runLoop(
 	ctx context.Context,
 	userInput string,
 	tools []ToolDefinition,
@@ -390,7 +359,7 @@ func (a *Agent) runStreamLoop(
 			if i == 0 {
 				a.History.popLast()
 			}
-			return Reply{}, fmt.Errorf("agent: run-stream[%d]: %w", i, err)
+			return Reply{}, fmt.Errorf("agent: loop[%d]: %w", i, err)
 		}
 		a.sessionInputTokens += reply.InputTokens
 		a.sessionOutputTokens += reply.OutputTokens


### PR DESCRIPTION
## Summary
Review §1 cleanup. `Run` (buffered) and `runStreamLoop` (streaming) carried two near-duplicate copies of the agentic tool-dispatch loop — an active divergence hazard (the M6.5 permission gate had to be added to both by hand).

- Collapsed into a single `runLoop`. `Run` delegates with a buffered send closure + **nil** `EventHandler`; `RunStream` with a streaming closure + a real handler.
- Safe because every event path already no-ops on a nil handler: `emitToolStartedEvents` / `emitToolResultEvents` return early, `dispatchTools` takes the non-streaming `Execute` path, and the `turn_done` emit is guarded by `if handler != nil`.
- Net −28 lines; the old `Run` loop body is gone.

## Behaviour
Unchanged. The error-wrap prefix for the buffered path changes (`agent: run[i]` → `agent: loop[i]`); no test asserts on it.

## Test plan
- [x] `go test -race ./...` clean; `gofmt -l .` / `go vet ./...` clean
- [x] Existing suites exercise the unified loop via both entry points: `Run` (gate deny/allow, multi-tool, max-iterations, no-tools fallback) and `RunStream` (started/done/error events, progress, input-delta, turn_done, nil handler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)