### PR TITLE
feat(agent): max_turns / max_cost loop budget gates (B1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased — 0.1.0-dev]
 
 ### Changed
+- **Loop budget gates** — the agentic loop's hardcoded 20-iteration cap (which `error`ed out and discarded the turn) is replaced by configurable `Agent.MaxTurns` (default 20) and `Agent.MaxCostUSD` (0 = unlimited), surfaced as `octo chat --max-turns` / `--max-cost`. Hitting either limit now ends the run *gracefully*: history keeps the partial progress and the caller gets a friendly assistant message (`[octo] Stopped: …`) with a sentinel `StopReason` (`max_turns` / `max_cost`) instead of an error. The cost gate checks the running session estimate before each provider call. (Ports Ruby CATCHUP P0-4.)
 - **Unified agentic loop** — `Run` (buffered) and `RunStream` (streaming) previously carried two near-duplicate copies of the tool-dispatch loop, so changes like the permission gate had to be applied in both. They now share a single `runLoop`; `Run` drives it with a buffered send closure and a nil event handler (every event-emit path short-circuits on nil), `RunStream` with a streaming closure and a real handler. Behaviour is unchanged — verified by the existing `Run` and `RunStream` test suites.
 
 ### Added

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -58,6 +58,8 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	enableTools := fs.Bool("tools", false, "Enable built-in tools (bash) for agentic loop")
 	plain := fs.Bool("plain", false, "Render tool events as one-line ↳ status lines instead of rich diff cards")
 	permMode := fs.String("permission-mode", "interactive", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask)")
+	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = default 20)")
+	maxCost := fs.Float64("max-cost", 0, "Stop the session once estimated cost (USD) reaches this; 0 = unlimited")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -133,6 +135,8 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	a := agent.New(providerSender{p: prov}, resolvedModel)
 	a.System = prompt.Compose(*system, cwd)
 	a.MaxTokens = *maxTokens
+	a.MaxTurns = *maxTurns
+	a.MaxCostUSD = *maxCost
 
 	// ── REPL mode ────────────────────────────────────────────────────────────
 	if isREPL {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -106,10 +106,28 @@ type Agent struct {
 	// Gate means no gating — all tool calls run (the pre-M6.5 behaviour).
 	Gate PermissionGate
 
+	// MaxTurns caps the number of provider round-trips in a single Run/
+	// RunStream. <= 0 uses defaultMaxTurns. Hitting the cap ends the run
+	// with a friendly budget reply (StopReason "max_turns"), not an error.
+	MaxTurns int
+
+	// MaxCostUSD caps cumulative session spend. 0 = unlimited. When the
+	// running estimate reaches the cap the loop stops before the next
+	// provider call with StopReason "max_cost".
+	MaxCostUSD float64
+
 	// Cumulative token counts for this session (all turns combined).
 	sessionInputTokens  int
 	sessionOutputTokens int
 }
+
+// StopReason sentinels set on the Reply when a loop budget is exhausted.
+// They are NOT provider stop reasons — the agent synthesises them so callers
+// can distinguish "the model finished" from "we cut it off".
+const (
+	StopReasonMaxTurns = "max_turns"
+	StopReasonMaxCost  = "max_cost"
+)
 
 // New constructs an Agent with a fresh History.
 //
@@ -209,10 +227,10 @@ func (a *Agent) TurnStream(
 	return reply, nil
 }
 
-// maxToolIterations is the safety cap on the agentic loop. If the model
-// requests more tool calls than this in a single Run, we bail out with an
-// error rather than looping forever.
-const maxToolIterations = 20
+// defaultMaxTurns is the fallback per-Run loop cap when Agent.MaxTurns is
+// unset (<= 0). A "turn" here is one provider round-trip inside the agentic
+// loop; the cap stops a misbehaving model from looping on tools forever.
+const defaultMaxTurns = 20
 
 // Run is the agentic loop: it appends the user message to history then
 // repeatedly calls the provider until the model reaches end_turn (no more
@@ -353,7 +371,17 @@ func (a *Agent) runLoop(
 ) (Reply, error) {
 	a.History.Append(NewUserMessage(userInput))
 
-	for i := 0; i < maxToolIterations; i++ {
+	limit := a.turnLimit()
+	for i := 0; i < limit; i++ {
+		// Cost gate: checked before each provider call. Cost is only known
+		// after a response, so the worst case is one call that tips over the
+		// budget; we stop before the next.
+		if a.MaxCostUSD > 0 && a.SessionCostUSD() >= a.MaxCostUSD {
+			return a.budgetStop(handler, StopReasonMaxCost, fmt.Sprintf(
+				"[octo] Stopped: session cost budget ($%.4f) reached. The task may be "+
+					"incomplete — raise --max-cost or start a new session to continue.", a.MaxCostUSD))
+		}
+
 		reply, err := send(ctx, a.History.Snapshot())
 		if err != nil {
 			if i == 0 {
@@ -402,7 +430,36 @@ func (a *Agent) runLoop(
 		return reply, nil
 	}
 
-	return Reply{}, fmt.Errorf("agent: exceeded max tool iterations (%d)", maxToolIterations)
+	// Loop cap reached while the model still wanted to keep going. End the
+	// run gracefully rather than erroring — the history holds the partial
+	// progress and the caller gets a clear, non-fatal explanation.
+	return a.budgetStop(handler, StopReasonMaxTurns, fmt.Sprintf(
+		"[octo] Stopped: reached the max-turns limit (%d). The task may be incomplete — "+
+			"raise --max-turns or send another message to continue.", limit))
+}
+
+// turnLimit resolves the per-Run loop cap, applying the default when unset.
+func (a *Agent) turnLimit() int {
+	if a.MaxTurns > 0 {
+		return a.MaxTurns
+	}
+	return defaultMaxTurns
+}
+
+// budgetStop ends a run that hit a loop budget (turns or cost). It appends a
+// synthetic assistant message so history stays well-formed, surfaces the
+// message as a text delta + turn_done event (so streaming callers render it
+// like normal reply text), and returns a Reply carrying the budget StopReason
+// — never an error, so the partial progress isn't discarded.
+func (a *Agent) budgetStop(handler EventHandler, reason, msg string) (Reply, error) {
+	a.History.Append(NewAssistantMessage(msg))
+	reply := Reply{Content: msg, StopReason: reason}
+	if handler != nil {
+		handler(AgentEvent{Kind: EventTextDelta, Text: msg})
+		r := reply
+		handler(AgentEvent{Kind: EventTurnDone, Reply: &r})
+	}
+	return reply, nil
 }
 
 // emitToolStartedEvents fires one EventToolStarted per tool_use block.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -376,9 +376,10 @@ func TestAgent_Run_MultipleToolCalls(t *testing.T) {
 	}
 }
 
-func TestAgent_Run_ExceedsMaxIterations(t *testing.T) {
-	// Every reply is tool_use — loop should hit the cap.
-	replies := make([]Reply, maxToolIterations+5)
+func TestAgent_Run_ExceedsMaxTurns_FriendlyStop(t *testing.T) {
+	// Every reply is tool_use — loop hits the cap. Hitting it must NOT error;
+	// it returns a friendly reply with StopReason "max_turns".
+	replies := make([]Reply, defaultMaxTurns+5)
 	for i := range replies {
 		replies[i] = Reply{
 			StopReason: "tool_use",
@@ -390,9 +391,72 @@ func TestAgent_Run_ExceedsMaxIterations(t *testing.T) {
 	a := New(send, "m")
 	defs := []ToolDefinition{{Name: "bash"}}
 
-	_, err := a.Run(context.Background(), "go", defs, exec)
-	if err == nil {
-		t.Fatal("expected error when max iterations exceeded")
+	reply, err := a.Run(context.Background(), "go", defs, exec)
+	if err != nil {
+		t.Fatalf("hitting the cap should not error, got %v", err)
+	}
+	if reply.StopReason != StopReasonMaxTurns {
+		t.Errorf("StopReason = %q, want %q", reply.StopReason, StopReasonMaxTurns)
+	}
+	if !strings.Contains(reply.Content, "max-turns") {
+		t.Errorf("reply should explain the limit, got %q", reply.Content)
+	}
+}
+
+func TestAgent_Run_CustomMaxTurns(t *testing.T) {
+	// MaxTurns=2 → exactly 2 provider calls, then a friendly stop.
+	replies := make([]Reply, 10)
+	for i := range replies {
+		replies[i] = Reply{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c", "bash", nil)}}
+	}
+	send := &fakeToolSender{replies: replies}
+	exec := &fakeExecutor{}
+	a := New(send, "m")
+	a.MaxTurns = 2
+	defs := []ToolDefinition{{Name: "bash"}}
+
+	reply, err := a.Run(context.Background(), "go", defs, exec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply.StopReason != StopReasonMaxTurns {
+		t.Errorf("StopReason = %q, want max_turns", reply.StopReason)
+	}
+	if send.calls != 2 {
+		t.Errorf("provider calls = %d, want 2 (MaxTurns)", send.calls)
+	}
+}
+
+func TestAgent_Run_MaxCostStops(t *testing.T) {
+	// First reply reports tokens that push session cost over the budget; the
+	// loop must stop before the second provider call.
+	send := &fakeToolSender{
+		replies: []Reply{
+			{
+				StopReason:   "tool_use",
+				Blocks:       []ContentBlock{NewToolUseBlock("c", "bash", nil)},
+				InputTokens:  1_000_000, // ~$3 at default sonnet input pricing
+				OutputTokens: 0,
+			},
+			{Content: "should not be reached", StopReason: "end_turn"},
+		},
+	}
+	exec := &fakeExecutor{}
+	a := New(send, "claude-sonnet-4-6")
+	a.MaxCostUSD = 0.50 // well under the first call's ~$3
+	defs := []ToolDefinition{{Name: "bash"}}
+
+	reply, err := a.Run(context.Background(), "go", defs, exec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply.StopReason != StopReasonMaxCost {
+		t.Errorf("StopReason = %q, want max_cost", reply.StopReason)
+	}
+	// One provider call happened (cost only known after it); the second was
+	// gated out.
+	if send.calls != 1 {
+		t.Errorf("provider calls = %d, want 1 (stopped on cost before 2nd)", send.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary
Review §1 + Ruby CATCHUP P0-4. Replaces the hardcoded 20-iteration cap (which `error`ed and discarded the turn) with configurable budgets.

- `Agent.MaxTurns` (default 20) + `Agent.MaxCostUSD` (0 = unlimited), surfaced as `octo chat --max-turns` / `--max-cost`.
- **Graceful stop, not error.** Hitting either limit appends a synthetic assistant message (`[octo] Stopped: …`), keeps history well-formed, surfaces it as a text-delta + turn_done event (streaming callers render it like normal reply text), and returns a `Reply` with a sentinel `StopReason` (`max_turns` / `max_cost`). Partial progress is preserved; the user can send another message to continue.
- Cost gate checks the running session estimate **before** each provider call — cost is only known post-response, so the worst case is one call that tips over the budget, then we stop before the next.

## Test plan
- [x] `go test -race ./...` clean; `gofmt` / `vet` clean
- [x] max-turns: hitting cap returns friendly reply (no error) with `StopReason=max_turns`; custom `MaxTurns=2` → exactly 2 provider calls
- [x] max-cost: a first call that exceeds the budget stops the loop before the 2nd call with `StopReason=max_cost`
- [x] existing loop/gate/multi-tool suites still pass through the gated loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)