### PR TITLE
fix(agent): collision-proof session IDs (B3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased — 0.1.0-dev]
 
+### Fixed
+- **Session ID collisions** — session IDs were `YYYYMMDD-HHMMSS` (second precision), so two sessions started in the same second silently overwrote each other's save file. IDs now carry a 4-hex-char random suffix (`YYYYMMDD-HHMMSS-xxxx`), keeping them sortable/readable while removing the collision.
+
 ### Changed
 - **Loop budget gates** — the agentic loop's hardcoded 20-iteration cap (which `error`ed out and discarded the turn) is replaced by configurable `Agent.MaxTurns` (default 20) and `Agent.MaxCostUSD` (0 = unlimited), surfaced as `octo chat --max-turns` / `--max-cost`. Hitting either limit now ends the run *gracefully*: history keeps the partial progress and the caller gets a friendly assistant message (`[octo] Stopped: …`) with a sentinel `StopReason` (`max_turns` / `max_cost`) instead of an error. The cost gate checks the running session estimate before each provider call. (Ports Ruby CATCHUP P0-4.)
 - **Unified agentic loop** — `Run` (buffered) and `RunStream` (streaming) previously carried two near-duplicate copies of the tool-dispatch loop, so changes like the permission gate had to be applied in both. They now share a single `runLoop`; `Run` drives it with a buffered send closure and a nil event handler (every event-emit path short-circuits on nil), `RunStream` with a streaming closure and a real handler. Behaviour is unchanged — verified by the existing `Run` and `RunStream` test suites.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -21,18 +23,31 @@ type Session struct {
 	Messages  []Message `json:"messages"`
 }
 
-// NewSession creates a Session with an ID derived from the current time.
-// Format: YYYYMMDD-HHMMSS (no external uniqueness dependency; two sessions
-// started in the same second get the same ID — acceptable for interactive use).
+// NewSession creates a Session with an ID derived from the current time plus
+// a short random suffix: YYYYMMDD-HHMMSS-xxxx. The timestamp keeps IDs
+// roughly sortable and human-readable; the suffix removes the same-second
+// collision that would otherwise let two sessions overwrite each other's
+// file (e.g. two quick `octo chat` launches, or anything non-interactive).
 func NewSession(model, system string) *Session {
 	now := time.Now()
 	return &Session{
-		ID:        now.Format("20060102-150405"),
+		ID:        now.Format("20060102-150405") + "-" + randomSuffix(now),
 		CreatedAt: now,
 		UpdatedAt: now,
 		Model:     model,
 		System:    system,
 	}
+}
+
+// randomSuffix returns 4 hex chars from crypto/rand. If the system RNG is
+// somehow unavailable it falls back to the sub-second nanosecond fraction,
+// which still disambiguates same-second IDs from a single process.
+func randomSuffix(now time.Time) string {
+	var b [2]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%04x", now.Nanosecond()&0xffff)
+	}
+	return hex.EncodeToString(b[:])
 }
 
 // TurnCount returns the number of complete user+assistant turn pairs.

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -36,12 +36,25 @@ func TestNewSession(t *testing.T) {
 
 func TestSessionIDFormat(t *testing.T) {
 	s := NewSession("m", "")
-	// YYYYMMDD-HHMMSS — 15 chars
-	if len(s.ID) != 15 {
-		t.Errorf("ID len = %d, want 15 (got %q)", len(s.ID), s.ID)
+	// YYYYMMDD-HHMMSS-xxxx — 20 chars (15 timestamp + '-' + 4 hex suffix).
+	if len(s.ID) != 20 {
+		t.Errorf("ID len = %d, want 20 (got %q)", len(s.ID), s.ID)
 	}
-	if s.ID[8] != '-' {
-		t.Errorf("ID[8] = %q, want '-' (got %q)", s.ID[8], s.ID)
+	if s.ID[8] != '-' || s.ID[15] != '-' {
+		t.Errorf("ID separators wrong: %q", s.ID)
+	}
+}
+
+func TestSessionID_NoCollisionSameSecond(t *testing.T) {
+	// Two sessions created back-to-back (same second) must get distinct IDs,
+	// so their save files don't clobber each other.
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		id := NewSession("m", "").ID
+		if seen[id] {
+			t.Fatalf("duplicate session ID within the same second: %q", id)
+		}
+		seen[id] = true
 	}
 }
 


### PR DESCRIPTION
## Summary
Review §3 data-loss bug. Session IDs were `YYYYMMDD-HHMMSS` (second precision), so two sessions started in the same second produced the same ID and **silently overwrote each other's save file** — trips the moment anything launches octo non-interactively or twice quickly.

- IDs now append a 4-hex-char `crypto/rand` suffix: `YYYYMMDD-HHMMSS-xxxx`. Falls back to the nanosecond fraction if the system RNG is somehow unavailable.
- Still sortable/readable; resume-by-id and `--list-sessions` unaffected.

## Test plan
- [x] `go test -race ./...` clean; `gofmt` / `vet` clean
- [x] ID format test updated to 20 chars with separators at [8] and [15]
- [x] new test: 100 back-to-back `NewSession` calls (same second) all get distinct IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)