### PR TITLE
fix(stream): parse SSE without trailing space and read delta cache usage

### DIFF
--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -113,11 +113,14 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		// SSE frames: "data: <json>" lines, separated by blank lines.
-		if !strings.HasPrefix(line, "data: ") {
+		// SSE frames: "data:<json>" lines, separated by blank lines. Per the
+		// SSE spec the single space after "data:" is optional — Anthropic
+		// sends "data: {...}" but some compatible backends (Kimi) send
+		// "data:{...}". Strip the prefix and at most one leading space.
+		if !strings.HasPrefix(line, "data:") {
 			continue
 		}
-		data := strings.TrimPrefix(line, "data: ")
+		data := strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " ")
 		if data == "" {
 			continue
 		}
@@ -188,6 +191,20 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 			// final message_delta carries the authoritative total.
 			if ev.Usage != nil {
 				result.OutputTokens = ev.Usage.OutputTokens
+				// Anthropic reports cache accounting in message_start, but some
+				// compatible backends (Kimi) only report it in the final
+				// message_delta. Take non-zero cache values here so we don't
+				// miss those hits; the >0 guard avoids clobbering message_start's
+				// counts with a trailing zero. A cache_read here also means this
+				// backend sent full final accounting, so adopt its input_tokens
+				// (the non-cached remainder) too.
+				if ev.Usage.CacheReadInputTokens > 0 {
+					result.CacheReadTokens = ev.Usage.CacheReadInputTokens
+					result.InputTokens = ev.Usage.InputTokens
+				}
+				if ev.Usage.CacheCreationInputTokens > 0 {
+					result.CacheWriteTokens = ev.Usage.CacheCreationInputTokens
+				}
 			}
 
 		case "error":

--- a/internal/provider/anthropic/stream_test.go
+++ b/internal/provider/anthropic/stream_test.go
@@ -191,6 +191,60 @@ func TestSendStream_NonTextDeltasIgnored(t *testing.T) {
 	}
 }
 
+// kimiStream mimics Kimi's Anthropic-compatible SSE: the single space after
+// "data:" is omitted (valid per the SSE spec), and cache accounting lands in
+// the final message_delta rather than in message_start.
+const kimiStream = "" +
+	`event:message_start` + "\n" +
+	`data:{"type":"message_start","message":{"id":"m","model":"kimi-for-coding","usage":{"input_tokens":1988,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}` + "\n\n" +
+	`event:content_block_start` + "\n" +
+	`data:{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
+	`event:content_block_delta` + "\n" +
+	`data:{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"cached"}}` + "\n\n" +
+	`event:content_block_stop` + "\n" +
+	`data:{"type":"content_block_stop","index":0}` + "\n\n" +
+	`event:message_delta` + "\n" +
+	`data:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":0,"output_tokens":3,"cache_read_input_tokens":1988,"cache_creation_input_tokens":0}}` + "\n\n" +
+	`event:message_stop` + "\n" +
+	`data:{"type":"message_stop"}` + "\n\n"
+
+// TestSendStream_KimiNoSpaceAndDeltaCache guards two compatible-backend quirks:
+// SSE "data:" lines without a trailing space must still be parsed, and cache
+// accounting reported only in message_delta must be picked up.
+func TestSendStream_KimiNoSpaceAndDeltaCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, kimiStream)
+	}))
+	defer srv.Close()
+
+	c, err := New("test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.BaseURL = srv.URL
+
+	resp, err := c.SendStream(context.Background(), provider.Request{
+		Model:    "k2.6",
+		Messages: []agent.Message{agent.NewUserMessage("hi")},
+	}, provider.StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("SendStream: %v", err)
+	}
+
+	if resp.Content != "cached" {
+		t.Errorf("Content = %q, want 'cached' (no-space data: lines must parse)", resp.Content)
+	}
+	if resp.CacheReadTokens != 1988 {
+		t.Errorf("CacheReadTokens = %d, want 1988 (message_delta cache must be captured)", resp.CacheReadTokens)
+	}
+	// message_delta carries the non-cached remainder; on a full cache hit it's 0.
+	if resp.InputTokens != 0 {
+		t.Errorf("InputTokens = %d, want 0", resp.InputTokens)
+	}
+}
+
 // Compile-time assertion: *Client implements provider.StreamingProvider in the
 // test package too, in case future refactors split the file layout.
 var _ provider.StreamingProvider = (*Client)(nil)

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -101,10 +101,13 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "data: ") {
+		// Per the SSE spec the single space after "data:" is optional. OpenAI
+		// and DeepSeek send "data: {...}" but some compatible backends omit
+		// the space; strip the prefix and at most one leading space.
+		if !strings.HasPrefix(line, "data:") {
 			continue
 		}
-		data := strings.TrimPrefix(line, "data: ")
+		data := strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " ")
 		if data == "" {
 			continue
 		}


### PR DESCRIPTION
## Summary
Two streaming bugs surfaced while validating prompt caching against Kimi's Anthropic-compatible endpoint (`api.kimi.com/coding`):

- **Empty replies / HTTP 400.** SSE data lines were matched as `"data: "` (trailing space). The space is optional per the SSE spec; Kimi sends `data:{...}`, so every event was skipped → empty assistant reply → the next turn hit `HTTP 400: assistant must not be empty`. Now strip the prefix and at most one leading space, in both the anthropic and openai stream parsers. DeepSeek worked only because it happens to send the space.
- **Missing cache counts in streaming.** Kimi reports cache accounting only in the final `message_delta`, not in `message_start` (which stays 0). The aggregator read cache solely from `message_start`, so streamed Kimi turns showed zero cache. Now pick up non-zero `cache_read`/`cache_creation` (and the non-cached input remainder) from `message_delta` without clobbering standard Anthropic's `message_start` values. The buffered `Send` path was already correct.

## Validation (live, streaming, turn 2)
| Protocol | Backend | Result |
|---|---|---|
| Anthropic | Kimi k2.6 | `cache: 1536 read` |
| OpenAI | DeepSeek v4-flash | `cache: 1536 read` |

## Test plan
- [x] New regression test `TestSendStream_KimiNoSpaceAndDeltaCache` (no-space `data:` + delta-only cache)
- [x] `make test` (race), `make vet`, `gofmt` clean
- [x] Existing spaced-`data: ` streams still parse (backward-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)