### PR TITLE
fix(openai): round-trip reasoning_content for thinking-model tool calls

### DIFF
--- a/internal/agent/content.go
+++ b/internal/agent/content.go
@@ -38,6 +38,13 @@ type ContentBlock struct {
 	// IsError signals that the tool execution failed (type=="tool_result").
 	// The LLM can inspect Result for the error message and recover gracefully.
 	IsError bool `json:"is_error,omitempty"`
+
+	// Reasoning carries a thinking model's reasoning trace that must be echoed
+	// back on the next request (type=="tool_use"). OpenAI thinking models such
+	// as deepseek-v4 return reasoning_content alongside a tool call and reject
+	// the follow-up unless it's resent; the OpenAI adapter stashes it here so it
+	// round-trips through history. Providers that don't need it ignore the field.
+	Reasoning string `json:"reasoning,omitempty"`
 }
 
 // NewTextBlock creates a ContentBlock with Type=="text".

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -156,6 +156,9 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 	if first.Message.Content != "" {
 		blocks = append([]agent.ContentBlock{agent.NewTextBlock(first.Message.Content)}, blocks...)
 	}
+	// Stash the reasoning trace on the tool_use block so it round-trips back to
+	// the API on the follow-up request (required by thinking models).
+	attachReasoning(blocks, first.Message.ReasoningContent)
 
 	return provider.Response{
 		Content:      first.Message.Content,
@@ -223,6 +226,9 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 				case "text":
 					msg.Content = b.Text
 				case "tool_use":
+					if b.Reasoning != "" {
+						msg.ReasoningContent = b.Reasoning
+					}
 					msg.ToolCalls = append(msg.ToolCalls, apiToolCall{
 						ID:   b.ID,
 						Type: "function",
@@ -255,6 +261,23 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 		out = append(out, apiMessage{Role: string(m.Role), Content: m.Content})
 	}
 	return out, nil
+}
+
+// attachReasoning records a thinking model's reasoning trace on the first
+// tool_use block so it survives in history and is re-sent on the follow-up
+// request. No-op when reasoning is empty or there is no tool_use block — which
+// keeps reasoning_content off plain text turns (some reasoning models reject it
+// there).
+func attachReasoning(blocks []agent.ContentBlock, reasoning string) {
+	if reasoning == "" {
+		return
+	}
+	for i := range blocks {
+		if blocks[i].Type == "tool_use" {
+			blocks[i].Reasoning = reasoning
+			return
+		}
+	}
 }
 
 // marshalInput encodes a tool input map back to a compact JSON string.

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -91,6 +91,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 
 	var (
 		contentB   strings.Builder
+		reasoningB strings.Builder
 		result     provider.Response
 		toolStates = map[int]*toolCallState{} // keyed by tool call index
 		toolOrder  []int                      // preserve order
@@ -140,6 +141,9 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 				onChunk(choice.Delta.Content)
 			}
 		}
+		// Reasoning trace from thinking models streams in its own delta field;
+		// accumulate but don't surface as visible text.
+		reasoningB.WriteString(choice.Delta.ReasoningContent)
 		// Accumulate tool call fragments.
 		for _, tc := range choice.Delta.ToolCalls {
 			st, exists := toolStates[tc.Index]
@@ -190,6 +194,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		}
 		blocks = append(blocks, agent.NewToolUseBlock(st.id, st.name, input))
 	}
+	attachReasoning(blocks, reasoningB.String())
 	if len(blocks) > 0 {
 		result.Blocks = blocks
 	}

--- a/internal/provider/openai/tools_test.go
+++ b/internal/provider/openai/tools_test.go
@@ -130,6 +130,89 @@ func TestSend_ToolCall_Response(t *testing.T) {
 	}
 }
 
+// TestReasoningContent_RoundTrips verifies the thinking-model contract used by
+// deepseek-v4: reasoning_content returned alongside a tool call is captured
+// onto the tool_use block, then re-emitted on the follow-up assistant message
+// (which carries tool_calls) — but never on a plain text turn.
+func TestReasoningContent_RoundTrips(t *testing.T) {
+	// 1. A tool-call response carrying reasoning_content lands on the block.
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"id":"x","object":"chat.completion","model":"deepseek-v4-flash",
+			"choices":[{"index":0,"finish_reason":"tool_calls","message":{
+				"role":"assistant","content":"","reasoning_content":"I should read the file.",
+				"tool_calls":[{"id":"call-1","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"go.mod\"}"}}]
+			}}],
+			"usage":{"prompt_tokens":5,"completion_tokens":15,"total_tokens":20}
+		}`))
+	}))
+	defer srv1.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv1.URL
+	resp, err := c.Send(context.Background(), provider.Request{
+		Model:    "deepseek-v4-flash",
+		Messages: []agent.Message{agent.NewUserMessage("read go.mod")},
+		Tools:    []agent.ToolDefinition{{Name: "read_file"}},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(resp.Blocks) != 1 || resp.Blocks[0].Type != "tool_use" {
+		t.Fatalf("Blocks = %+v, want one tool_use", resp.Blocks)
+	}
+	if resp.Blocks[0].Reasoning != "I should read the file." {
+		t.Fatalf("Reasoning = %q, want it captured onto the tool_use block", resp.Blocks[0].Reasoning)
+	}
+
+	// 2. On the follow-up, the assistant tool-call message re-emits
+	//    reasoning_content; the plain assistant turn must not.
+	var capturedBody []byte
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"x","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv2.Close()
+
+	c.BaseURL = srv2.URL
+	_, err = c.Send(context.Background(), provider.Request{
+		Model: "deepseek-v4-flash",
+		Messages: []agent.Message{
+			agent.NewUserMessage("read go.mod"),
+			agent.NewAssistantMessage("an earlier plain reply"),
+			agent.NewToolUseMessage(resp.Blocks),
+			agent.NewToolResultMessage([]agent.ContentBlock{agent.NewToolResultBlock("call-1", "module github.com/Leihb/octo-agent", false)}),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Send 2: %v", err)
+	}
+
+	var wire struct {
+		Messages []struct {
+			Role             string `json:"role"`
+			ReasoningContent string `json:"reasoning_content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(capturedBody, &wire); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var toolCallReasoning string
+	for _, m := range wire.Messages {
+		if m.Role == "assistant" && m.ReasoningContent != "" {
+			toolCallReasoning = m.ReasoningContent
+		}
+	}
+	if toolCallReasoning != "I should read the file." {
+		t.Errorf("tool-call assistant reasoning_content = %q, want it re-emitted", toolCallReasoning)
+	}
+	// The plain assistant turn ("an earlier plain reply") must carry no
+	// reasoning_content — guard against blanket emission that would break R1.
+	if strings.Count(string(capturedBody), `"reasoning_content"`) != 1 {
+		t.Errorf("reasoning_content should appear exactly once (tool-call turn only): %s", capturedBody)
+	}
+}
+
 // TestSend_ToolResultMessages_WireFormat verifies that tool_result blocks are
 // serialized as individual role="tool" messages (OpenAI format).
 func TestSend_ToolResultMessages_WireFormat(t *testing.T) {

--- a/internal/provider/openai/types.go
+++ b/internal/provider/openai/types.go
@@ -43,6 +43,10 @@ type apiMessage struct {
 	Content    string        `json:"content,omitempty"`
 	ToolCalls  []apiToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string        `json:"tool_call_id,omitempty"`
+	// ReasoningContent is the thinking trace returned by reasoning models
+	// (deepseek-v4 etc.). It must be echoed back on the assistant message that
+	// carries tool_calls, or the next request is rejected; omitted otherwise.
+	ReasoningContent string `json:"reasoning_content,omitempty"`
 }
 
 // apiToolCall is one element of apiMessage.ToolCalls (assistant turns).
@@ -141,9 +145,10 @@ type streamChoice struct {
 // streamDelta carries the incremental fields of an assistant message.
 // ToolCalls carries incremental tool call fragments (index-keyed).
 type streamDelta struct {
-	Role      string                `json:"role,omitempty"`
-	Content   string                `json:"content,omitempty"`
-	ToolCalls []streamToolCallDelta `json:"tool_calls,omitempty"`
+	Role             string                `json:"role,omitempty"`
+	Content          string                `json:"content,omitempty"`
+	ReasoningContent string                `json:"reasoning_content,omitempty"`
+	ToolCalls        []streamToolCallDelta `json:"tool_calls,omitempty"`
 }
 
 // streamToolCallDelta is one incremental fragment of a tool call in a stream


### PR DESCRIPTION
## Summary
DeepSeek tool calling was fully broken in the OpenAI adapter. `deepseek-v4` (thinking mode) returns `reasoning_content` alongside a tool call:
```json
"message": { "content": "", "reasoning_content": "Let me read go.mod...", "tool_calls": [...] }
```
and rejects the follow-up request (the one sending the tool result back) unless that `reasoning_content` is echoed on the assistant tool-call message — otherwise `HTTP 400: reasoning_content in the thinking mode must be passed back`. Our adapter captured neither on receive nor re-emitted on send, so every DeepSeek tool call died on the second round-trip.

## Fix
- New `agent.ContentBlock.Reasoning` field carries the trace through history (provider-agnostic; non-OpenAI providers ignore it).
- OpenAI adapter captures `reasoning_content` (buffered `Send` + streaming `SendStream`) onto the first `tool_use` block, and re-emits it in `toAPIMessages`.
- **Scoped to assistant turns that carry `tool_calls`** — plain text turns never send `reasoning_content`, which keeps `deepseek-reasoner` (R1) working, since R1 rejects echoed `reasoning_content`.

## Validation (live, DeepSeek v4-flash, agentic loop)
- Single tool call: `read_file go.mod` → correct module path.
- Parallel tool calls: `glob` + `read_file` in one turn → correct answer, loop completes.
- Caching still works through the loop (`cache: 2944 read`).

## Test plan
- [x] New round-trip regression test `TestReasoningContent_RoundTrips` — capture onto block, re-emit on tool-call turn, and assert it appears **exactly once** (not on the plain assistant turn → R1-safe)
- [x] `make test` (race), `make vet`, `gofmt` clean