### PR TITLE
feat(anthropic): extended thinking with tool-call round-trip

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -64,6 +64,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = default 20)")
 	maxCost := fs.Float64("max-cost", 0, "Stop the session once estimated cost (USD) reaches this; 0 = unlimited")
 	compactThreshold := fs.Int("compact-threshold", 0, "Summarize older history once a turn's input exceeds this many tokens; 0 = disabled")
+	thinkingBudget := fs.Int("thinking-budget", 0, "Enable extended thinking with this token budget (Anthropic/Kimi); 0 = off")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -139,7 +140,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 	// A stable per-process cache key lets OpenAI route every turn (and every
 	// tool-loop iteration) of this conversation to the same prompt cache.
-	a := agent.New(providerSender{p: prov, cacheKey: newCacheKey()}, resolvedModel)
+	a := agent.New(providerSender{
+		p:              prov,
+		cacheKey:       newCacheKey(),
+		thinkingBudget: *thinkingBudget,
+		thinkingOut:    stdout,
+	}, resolvedModel)
 	a.System = prompt.Compose(*system, cwd, env)
 	a.MaxTokens = *maxTokens
 	a.MaxTurns = *maxTurns
@@ -282,6 +288,36 @@ type providerSender struct {
 	// constant across a session's turns lets the backend route them to the
 	// same prompt cache. Empty is fine — providers omit the field.
 	cacheKey string
+	// thinkingBudget, when > 0, enables extended thinking (Anthropic) with this
+	// token budget for the reasoning trace.
+	thinkingBudget int
+	// thinkingOut, when non-nil, is where the streamed thinking trace is printed
+	// (dimmed). Nil disables thinking display.
+	thinkingOut io.Writer
+}
+
+// thinkingRenderer returns an OnThinking callback that streams the reasoning
+// trace dimmed, and a close function that ends the dim styling before the
+// visible answer begins. Both are no-ops when thinking display is off.
+func (s providerSender) thinkingRenderer() (onThinking func(string), closeThinking func()) {
+	if s.thinkingOut == nil || s.thinkingBudget <= 0 {
+		return nil, func() {}
+	}
+	var started, closed bool
+	onThinking = func(d string) {
+		if !started {
+			fmt.Fprint(s.thinkingOut, "\x1b[2m\U0001F4AD ")
+			started = true
+		}
+		fmt.Fprint(s.thinkingOut, d)
+	}
+	closeThinking = func() {
+		if started && !closed {
+			fmt.Fprint(s.thinkingOut, "\x1b[0m\n")
+			closed = true
+		}
+	}
+	return onThinking, closeThinking
 }
 
 // newCacheKey returns a random hex token used as the prompt-cache key for one
@@ -300,11 +336,12 @@ func (s providerSender) SendMessages(ctx context.Context, model, system string, 
 		return agent.Reply{}, errors.New("providerSender: provider is nil")
 	}
 	resp, err := s.p.Send(ctx, provider.Request{
-		Model:        model,
-		SystemPrompt: system,
-		Messages:     msgs,
-		MaxTokens:    maxTokens,
-		CacheKey:     s.cacheKey,
+		Model:          model,
+		SystemPrompt:   system,
+		Messages:       msgs,
+		MaxTokens:      maxTokens,
+		CacheKey:       s.cacheKey,
+		ThinkingBudget: s.thinkingBudget,
 	})
 	if err != nil {
 		return agent.Reply{}, err
@@ -329,15 +366,25 @@ func (s providerSender) StreamMessages(
 		return agent.Reply{}, errors.New("providerSender: provider is nil")
 	}
 	req := provider.Request{
-		Model:        model,
-		SystemPrompt: system,
-		Messages:     msgs,
-		MaxTokens:    maxTokens,
-		CacheKey:     s.cacheKey,
+		Model:          model,
+		SystemPrompt:   system,
+		Messages:       msgs,
+		MaxTokens:      maxTokens,
+		CacheKey:       s.cacheKey,
+		ThinkingBudget: s.thinkingBudget,
 	}
 	if sp, ok := s.p.(provider.StreamingProvider); ok {
-		// Text-only path: no tool deltas applicable.
-		resp, err := sp.SendStream(ctx, req, provider.StreamCallbacks{OnText: onChunk})
+		onThinking, closeThinking := s.thinkingRenderer()
+		resp, err := sp.SendStream(ctx, req, provider.StreamCallbacks{
+			OnText: func(d string) {
+				closeThinking()
+				if onChunk != nil {
+					onChunk(d)
+				}
+			},
+			OnThinking: onThinking,
+		})
+		closeThinking()
 		if err != nil {
 			return agent.Reply{}, err
 		}
@@ -381,12 +428,13 @@ func (s providerSender) SendMessagesWithTools(
 		return agent.Reply{}, errors.New("providerSender: provider is nil")
 	}
 	resp, err := s.p.Send(ctx, provider.Request{
-		Model:        model,
-		SystemPrompt: system,
-		Messages:     msgs,
-		MaxTokens:    maxTokens,
-		CacheKey:     s.cacheKey,
-		Tools:        tools,
+		Model:          model,
+		SystemPrompt:   system,
+		Messages:       msgs,
+		MaxTokens:      maxTokens,
+		CacheKey:       s.cacheKey,
+		Tools:          tools,
+		ThinkingBudget: s.thinkingBudget,
 	})
 	if err != nil {
 		return agent.Reply{}, err
@@ -410,22 +458,36 @@ func (s providerSender) StreamMessagesWithTools(
 		return agent.Reply{}, errors.New("providerSender: provider is nil")
 	}
 	req := provider.Request{
-		Model:        model,
-		SystemPrompt: system,
-		Messages:     msgs,
-		MaxTokens:    maxTokens,
-		CacheKey:     s.cacheKey,
-		Tools:        tools,
+		Model:          model,
+		SystemPrompt:   system,
+		Messages:       msgs,
+		MaxTokens:      maxTokens,
+		CacheKey:       s.cacheKey,
+		Tools:          tools,
+		ThinkingBudget: s.thinkingBudget,
 	}
 	if sp, ok := s.p.(provider.StreamingProvider); ok {
-		// Both callbacks are forwarded. provider.StreamCallbacks is a
-		// per-event union — text deltas and tool-input deltas can
-		// interleave on the wire (the Anthropic stream actually does that
-		// when the LLM mixes prose with tool calls).
+		// Callbacks are forwarded. provider.StreamCallbacks is a per-event
+		// union — thinking streams first, then text deltas and tool-input
+		// deltas can interleave. closeThinking ends the dimmed trace before
+		// the first visible token of either kind.
+		onThinking, closeThinking := s.thinkingRenderer()
 		resp, err := sp.SendStream(ctx, req, provider.StreamCallbacks{
-			OnText:      onChunk,
-			OnToolDelta: onToolDelta,
+			OnText: func(d string) {
+				closeThinking()
+				if onChunk != nil {
+					onChunk(d)
+				}
+			},
+			OnToolDelta: func(id, name, j string) {
+				closeThinking()
+				if onToolDelta != nil {
+					onToolDelta(id, name, j)
+				}
+			},
+			OnThinking: onThinking,
 		})
+		closeThinking()
 		if err != nil {
 			return agent.Reply{}, err
 		}

--- a/internal/agent/content.go
+++ b/internal/agent/content.go
@@ -1,15 +1,17 @@
 package agent
 
 // ContentBlock is a single element of a multi-part message. It unifies the
-// three roles a block can play in an LLM conversation:
+// roles a block can play in an LLM conversation:
 //
 //   - "text"        — plain assistant or user text
 //   - "tool_use"    — the model requesting a tool call (assistant turn)
 //   - "tool_result" — the result of a tool call (user turn)
+//   - "thinking"    — a reasoning model's extended-thinking trace (assistant turn)
 //
 // The zero value is not valid; use the New*Block helpers instead.
 type ContentBlock struct {
-	// Type distinguishes the block variant: "text", "tool_use", "tool_result".
+	// Type distinguishes the block variant: "text", "tool_use", "tool_result",
+	// "thinking".
 	Type string `json:"type"`
 
 	// Text is the text payload (type=="text").
@@ -38,6 +40,16 @@ type ContentBlock struct {
 	// IsError signals that the tool execution failed (type=="tool_result").
 	// The LLM can inspect Result for the error message and recover gracefully.
 	IsError bool `json:"is_error,omitempty"`
+
+	// Thinking is the reasoning trace text (type=="thinking"). Reasoning models
+	// such as Claude and Kimi k2.6 return it as a first-class content block that
+	// must be preserved and replayed on subsequent requests when tool use is in
+	// play, or the API rejects the follow-up.
+	Thinking string `json:"thinking,omitempty"`
+
+	// Signature authenticates a thinking block (type=="thinking"). It must be
+	// sent back verbatim alongside the thinking text on the next request.
+	Signature string `json:"signature,omitempty"`
 }
 
 // NewTextBlock creates a ContentBlock with Type=="text".
@@ -53,6 +65,16 @@ func NewToolUseBlock(id, name string, input map[string]any) ContentBlock {
 		ID:    id,
 		Name:  name,
 		Input: input,
+	}
+}
+
+// NewThinkingBlock creates a ContentBlock with Type=="thinking". The signature
+// authenticates the trace and must be preserved for the round-trip.
+func NewThinkingBlock(thinking, signature string) ContentBlock {
+	return ContentBlock{
+		Type:      "thinking",
+		Thinking:  thinking,
+		Signature: signature,
 	}
 }
 

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -92,6 +92,7 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 	if body.MaxTokens <= 0 {
 		body.MaxTokens = DefaultMaxTokens
 	}
+	applyThinking(&body, req.ThinkingBudget)
 
 	payload, err := json.Marshal(body)
 	if err != nil {
@@ -240,6 +241,19 @@ func markMessageCacheable(m apiMessage) apiMessage {
 	return m
 }
 
+// applyThinking enables extended thinking on the request when budget > 0.
+// Anthropic requires max_tokens to exceed budget_tokens, so it bumps
+// max_tokens to leave room for the answer on top of the reasoning budget.
+func applyThinking(body *apiRequest, budget int) {
+	if budget <= 0 {
+		return
+	}
+	body.Thinking = &apiThinking{Type: "enabled", BudgetTokens: budget}
+	if body.MaxTokens <= budget {
+		body.MaxTokens = budget + DefaultMaxTokens
+	}
+}
+
 // toAPITools converts []agent.ToolDefinition to []apiTool.
 // Anthropic uses "input_schema" where the agent layer uses "parameters".
 func toAPITools(defs []agent.ToolDefinition) []apiTool {
@@ -306,6 +320,14 @@ func marshalBlocks(blocks []agent.ContentBlock) ([]map[string]any, error) {
 				"type": "text",
 				"text": b.Text,
 			})
+		case "thinking":
+			// Replayed verbatim with its signature; required before tool_use
+			// when thinking is enabled, or the API rejects the request.
+			out = append(out, map[string]any{
+				"type":      "thinking",
+				"thinking":  b.Thinking,
+				"signature": b.Signature,
+			})
 		case "tool_use":
 			m := map[string]any{
 				"type":  "tool_use",
@@ -340,6 +362,8 @@ func fromAPIContentBlocks(blocks []apiContentBlock) []agent.ContentBlock {
 			out = append(out, agent.NewTextBlock(b.Text))
 		case "tool_use":
 			out = append(out, agent.NewToolUseBlock(b.ID, b.Name, b.Input))
+		case "thinking":
+			out = append(out, agent.NewThinkingBlock(b.Thinking, b.Signature))
 		}
 	}
 	return out

--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -25,6 +25,7 @@ type blockAccumulator struct {
 	id        string
 	name      string
 	inputJSON strings.Builder
+	signature strings.Builder // thinking blocks
 }
 
 // SendStream implements provider.StreamingProvider against Anthropic's
@@ -39,6 +40,7 @@ type blockAccumulator struct {
 func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provider.StreamCallbacks) (provider.Response, error) {
 	onChunk := cb.OnText
 	onToolDelta := cb.OnToolDelta
+	onThinking := cb.OnThinking
 	if req.Model == "" {
 		return provider.Response{}, errors.New("anthropic: req.Model is required")
 	}
@@ -61,6 +63,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 	if body.MaxTokens <= 0 {
 		body.MaxTokens = DefaultMaxTokens
 	}
+	applyThinking(&body, req.ThinkingBudget)
 
 	payload, err := json.Marshal(body)
 	if err != nil {
@@ -170,6 +173,13 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 				if onChunk != nil && ev.Delta.Text != "" {
 					onChunk(ev.Delta.Text)
 				}
+			case "thinking_delta":
+				acc.text.WriteString(ev.Delta.Thinking)
+				if onThinking != nil && ev.Delta.Thinking != "" {
+					onThinking(ev.Delta.Thinking)
+				}
+			case "signature_delta":
+				acc.signature.WriteString(ev.Delta.Signature)
 			case "input_json_delta":
 				acc.inputJSON.WriteString(ev.Delta.PartialJSON)
 				// Stream the JSON fragment to the caller; the
@@ -230,6 +240,11 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 			t := acc.text.String()
 			textB.WriteString(t)
 			blocks = append(blocks, agent.NewTextBlock(t))
+		case "thinking":
+			// Thinking text accumulates in acc.text; keep it out of the visible
+			// answer (textB) but preserve the block + signature for the
+			// tool-call round-trip.
+			blocks = append(blocks, agent.NewThinkingBlock(acc.text.String(), acc.signature.String()))
 		case "tool_use":
 			var input map[string]any
 			if s := acc.inputJSON.String(); s != "" {

--- a/internal/provider/anthropic/thinking_test.go
+++ b/internal/provider/anthropic/thinking_test.go
@@ -1,0 +1,152 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/provider"
+)
+
+// thinkingStream mimics an extended-thinking SSE response: a thinking block
+// (text via thinking_delta, signature via signature_delta) followed by a
+// tool_use block — the shape Kimi/Claude emit when thinking + tools are on.
+const thinkingStream = "" +
+	`data: {"type":"message_start","message":{"id":"m","model":"k2.6","usage":{"input_tokens":10,"output_tokens":0}}}` + "\n\n" +
+	`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}` + "\n\n" +
+	`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me "}}` + "\n\n" +
+	`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"check."}}` + "\n\n" +
+	`data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"SIG123"}}` + "\n\n" +
+	`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+	`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"call-1","name":"read_file"}}` + "\n\n" +
+	`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"go.mod\"}"}}` + "\n\n" +
+	`data: {"type":"content_block_stop","index":1}` + "\n\n" +
+	`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input_tokens":0,"output_tokens":12}}` + "\n\n"
+
+// TestSendStream_Thinking captures the thinking block (text + signature) and
+// fires OnThinking, while keeping the trace out of the visible answer text, and
+// verifies the request enabled thinking with a bumped max_tokens.
+func TestSendStream_Thinking(t *testing.T) {
+	var body apiRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, thinkingStream)
+	}))
+	defer srv.Close()
+
+	c, _ := New("test-key")
+	c.BaseURL = srv.URL
+
+	var thoughts []string
+	resp, err := c.SendStream(context.Background(), provider.Request{
+		Model:          "k2.6",
+		Messages:       []agent.Message{agent.NewUserMessage("read go.mod")},
+		MaxTokens:      100, // below budget on purpose; applyThinking must bump it
+		ThinkingBudget: 1024,
+		Tools:          []agent.ToolDefinition{{Name: "read_file"}},
+	}, provider.StreamCallbacks{OnThinking: func(d string) { thoughts = append(thoughts, d) }})
+	if err != nil {
+		t.Fatalf("SendStream: %v", err)
+	}
+
+	// Request must have enabled thinking and bumped max_tokens above the budget.
+	if body.Thinking == nil || body.Thinking.Type != "enabled" || body.Thinking.BudgetTokens != 1024 {
+		t.Fatalf("request thinking = %+v, want enabled/1024", body.Thinking)
+	}
+	if body.MaxTokens <= 1024 {
+		t.Errorf("MaxTokens = %d, want > budget 1024", body.MaxTokens)
+	}
+
+	// OnThinking fired per thinking_delta, in order.
+	if got := strings.Join(thoughts, ""); got != "Let me check." {
+		t.Errorf("thinking deltas = %q, want 'Let me check.'", got)
+	}
+	// Thinking text must NOT leak into the visible answer.
+	if resp.Content != "" {
+		t.Errorf("Content = %q, want empty (thinking is not answer text)", resp.Content)
+	}
+	// Blocks: thinking (with signature) then tool_use, in order.
+	if len(resp.Blocks) != 2 {
+		t.Fatalf("Blocks len = %d, want 2: %+v", len(resp.Blocks), resp.Blocks)
+	}
+	if resp.Blocks[0].Type != "thinking" || resp.Blocks[0].Thinking != "Let me check." || resp.Blocks[0].Signature != "SIG123" {
+		t.Errorf("Blocks[0] = %+v, want thinking with signature", resp.Blocks[0])
+	}
+	if resp.Blocks[1].Type != "tool_use" {
+		t.Errorf("Blocks[1].Type = %q, want tool_use", resp.Blocks[1].Type)
+	}
+}
+
+// TestSend_ThinkingBlock_RoundTrips verifies a thinking block in history is
+// re-serialized to the wire with its signature, ahead of the tool_use block —
+// the contract the API enforces for thinking + tools.
+func TestSend_ThinkingBlock_RoundTrips(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"x","type":"message","role":"assistant","model":"k2.6","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("test-key")
+	c.BaseURL = srv.URL
+
+	msgs := []agent.Message{
+		agent.NewUserMessage("read go.mod"),
+		agent.NewToolUseMessage([]agent.ContentBlock{
+			agent.NewThinkingBlock("Let me check.", "SIG123"),
+			agent.NewToolUseBlock("call-1", "read_file", map[string]any{"path": "go.mod"}),
+		}),
+		agent.NewToolResultMessage([]agent.ContentBlock{
+			agent.NewToolResultBlock("call-1", "module github.com/Leihb/octo-agent", false),
+		}),
+	}
+	if _, err := c.Send(context.Background(), provider.Request{Model: "k2.6", Messages: msgs}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	// Content shape varies per message (string for plain turns, array for
+	// block turns), so decode it lazily as RawMessage.
+	var wire struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(capturedBody, &wire); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var found bool
+	for _, m := range wire.Messages {
+		if m.Role != "assistant" {
+			continue
+		}
+		var blocks []struct {
+			Type      string `json:"type"`
+			Thinking  string `json:"thinking"`
+			Signature string `json:"signature"`
+		}
+		if err := json.Unmarshal(m.Content, &blocks); err != nil {
+			t.Fatalf("assistant content not an array: %v (%s)", err, m.Content)
+		}
+		found = true
+		if len(blocks) == 0 || blocks[0].Type != "thinking" || blocks[0].Thinking != "Let me check." || blocks[0].Signature != "SIG123" {
+			t.Errorf("assistant block[0] = %+v, want thinking with signature", blocks)
+		}
+		if len(blocks) < 2 || blocks[1].Type != "tool_use" {
+			t.Errorf("thinking block must precede tool_use; got %+v", blocks)
+		}
+	}
+	if !found {
+		t.Fatalf("no assistant message in wire body: %s", capturedBody)
+	}
+}

--- a/internal/provider/anthropic/types.go
+++ b/internal/provider/anthropic/types.go
@@ -46,6 +46,14 @@ type apiRequest struct {
 	Messages  []apiMessage `json:"messages"`
 	Stream    bool         `json:"stream,omitempty"`
 	Tools     []apiTool    `json:"tools,omitempty"`
+	Thinking  *apiThinking `json:"thinking,omitempty"`
+}
+
+// apiThinking enables extended thinking. Type is "enabled"; BudgetTokens caps
+// the reasoning trace and must be less than the request's max_tokens.
+type apiThinking struct {
+	Type         string `json:"type"` // "enabled"
+	BudgetTokens int    `json:"budget_tokens"`
 }
 
 // apiMessage is one element of apiRequest.Messages.
@@ -74,11 +82,13 @@ type apiResponse struct {
 // For type=="text" only Text is populated; for type=="tool_use" ID, Name, and
 // Input are populated.
 type apiContentBlock struct {
-	Type  string         `json:"type"`
-	Text  string         `json:"text,omitempty"`
-	ID    string         `json:"id,omitempty"`   // tool_use
-	Name  string         `json:"name,omitempty"` // tool_use
-	Input map[string]any `json:"input,omitempty"`
+	Type      string         `json:"type"`
+	Text      string         `json:"text,omitempty"`
+	ID        string         `json:"id,omitempty"`   // tool_use
+	Name      string         `json:"name,omitempty"` // tool_use
+	Input     map[string]any `json:"input,omitempty"`
+	Thinking  string         `json:"thinking,omitempty"`  // thinking
+	Signature string         `json:"signature,omitempty"` // thinking
 }
 
 // apiUsageBlock is the token-count block Anthropic returns on every message.
@@ -125,6 +135,10 @@ type streamContentBlock struct {
 	Name string `json:"name,omitempty"`
 }
 
+// Note: thinking blocks stream their text via content_block_delta
+// (thinking_delta) and their signature via signature_delta; the
+// content_block_start carries only Type=="thinking".
+
 // streamMessage is the abridged message snapshot inside a message_start event.
 type streamMessage struct {
 	ID    string        `json:"id,omitempty"`
@@ -142,4 +156,7 @@ type streamDelta struct {
 	Text        string `json:"text,omitempty"`
 	PartialJSON string `json:"partial_json,omitempty"`
 	StopReason  string `json:"stop_reason,omitempty"`
+	// thinking_delta carries Thinking; signature_delta carries Signature.
+	Thinking  string `json:"thinking,omitempty"`
+	Signature string `json:"signature,omitempty"`
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -36,6 +36,11 @@ type Request struct {
 	// forward it; others (Anthropic, which uses inline cache_control
 	// breakpoints) ignore it. Empty means "no hint".
 	CacheKey string
+
+	// ThinkingBudget, when > 0, enables extended thinking and sets the token
+	// budget for the reasoning trace. Only the Anthropic provider honors it
+	// (Claude / Kimi k2.6 via the thinking request field); others ignore it.
+	ThinkingBudget int
 }
 
 // Response is the assistant reply produced by Send.
@@ -90,6 +95,12 @@ type StreamCallbacks struct {
 	// fragments concatenate to form the final JSON object. toolID and
 	// toolName identify the tool call (both known once the block starts).
 	OnToolDelta func(toolID, toolName, partialJSON string)
+
+	// OnThinking is invoked for each fragment of a reasoning model's
+	// extended-thinking trace (Anthropic thinking_delta). Fragments concatenate
+	// to form the full trace. Fires before any OnText/OnToolDelta for the turn,
+	// since the thinking block streams first. Nil-safe.
+	OnThinking func(thinkingDelta string)
 }
 
 // StreamingProvider extends Provider with the ability to stream the


### PR DESCRIPTION
## Summary
Adds extended-thinking support to the Anthropic provider (Claude / Kimi k2.6 via the `thinking` request field). Reasoning models return a `thinking` content block carrying a `signature`, and **reject any follow-up tool-call request unless that block — signature included — is replayed** (`400: thinking is enabled but reasoning_content is missing in assistant tool call message`). We now parse, preserve, and re-emit it so the agentic loop completes.

- `provider.Request.ThinkingBudget` enables thinking when `> 0`; `provider.StreamCallbacks` gains `OnThinking` for the streamed trace.
- `agent.ContentBlock` gains a `"thinking"` variant (text + signature) that round-trips through history and serialization (other providers ignore it).
- Anthropic adapter sends the `thinking` param (bumping `max_tokens` above the budget, as the API requires), parses thinking blocks in **both** buffered and streaming paths (`thinking_delta` / `signature_delta`), and replays them **ahead of** `tool_use`.
- CLI: `--thinking-budget` flag. The trace streams **dimmed** and is closed before the visible answer; thinking text is kept out of the answer `Content`.

## Validation (live, Kimi k2.6)
- Thinking single-turn: dimmed trace renders, then the answer.
- **Thinking + tool calling**: full loop completes — the thinking block + signature round-trips across the tool result (no 400), each loop iteration shows its trace, prompt caching intact (`cache: 2048 read`).
- Confirmed via raw API that omitting the thinking block yields the documented 400; replaying it succeeds.

## Test plan
- [x] `TestSendStream_Thinking` — captures thinking text + signature, fires `OnThinking`, keeps trace out of answer, asserts request enabled thinking + bumped `max_tokens`
- [x] `TestSend_ThinkingBlock_RoundTrips` — a thinking block in history re-serializes to the wire with its signature, ahead of `tool_use`
- [x] `make test` (race), `make vet`, `gofmt` clean

## Notes
- Branched off `main`; independent of the open DeepSeek reasoning-content PR (#73). Both add a field to `agent.ContentBlock` — whichever merges second may need a trivial rebase.