### PR TITLE
feat(agent): default-on history compaction with window-relative threshold (C6)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -63,7 +63,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	permMode := fs.String("permission-mode", "interactive", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask)")
 	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = default 20)")
 	maxCost := fs.Float64("max-cost", 0, "Stop the session once estimated cost (USD) reaches this; 0 = unlimited")
-	compactThreshold := fs.Int("compact-threshold", 0, "Summarize older history once a turn's input exceeds this many tokens; 0 = disabled")
+	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (~75% of the model's context window), <0 = disabled")
 	thinkingBudget := fs.Int("thinking-budget", 0, "Enable extended thinking with this token budget (Anthropic/Kimi); 0 = off")
 
 	if err := fs.Parse(args); err != nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -122,9 +122,11 @@ type Agent struct {
 	// provider call with StopReason "max_cost".
 	MaxCostUSD float64
 
-	// CompactThreshold triggers history compaction: when the most recent
-	// context sent (lastInputTokens) exceeds this, the next Run/RunStream
-	// summarizes the older turns before continuing. 0 disables compaction.
+	// CompactThreshold controls history compaction: when the most recent
+	// context sent (lastInputTokens) crosses the effective trigger, the next
+	// Run/RunStream summarizes the older turns before continuing. Semantics:
+	// <0 disables; ==0 auto (a fraction of the model's context window, the
+	// default); >0 is an explicit token count. See compactTriggerTokens.
 	CompactThreshold int
 
 	// Cumulative token counts for this session (all turns combined).

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -3,11 +3,52 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // compactKeepTurns is how many of the most recent user turns runLoop keeps
 // verbatim when it compacts; everything older is folded into one summary.
 const compactKeepTurns = 4
+
+// compactThresholdFraction is the share of the model's context window at which
+// auto-compaction (CompactThreshold == 0) triggers, leaving headroom for the
+// kept tail, the summary side-call, and the next turn's output.
+const compactThresholdFraction = 0.75
+
+// defaultContextWindow is the conservative fallback window (in tokens) for
+// models not named in contextWindow. Under-estimating only makes us compact
+// slightly earlier — never overflow — so unknown models stay safe.
+const defaultContextWindow = 128_000
+
+// contextWindow returns the approximate context-window size (in tokens) for a
+// model. Values are deliberately conservative; matched case-insensitively by
+// substring so dated/aliased names ("claude-haiku-4-5-2025…") still resolve.
+// Raise a model's entry when a larger window is confirmed.
+func contextWindow(model string) int {
+	switch {
+	case strings.Contains(strings.ToLower(model), "claude"):
+		return 200_000
+	default:
+		return defaultContextWindow
+	}
+}
+
+// compactTriggerTokens resolves the effective auto-compaction trigger from
+// CompactThreshold:
+//
+//	< 0  → disabled (0)
+//	== 0 → auto: a fraction of the model's context window
+//	> 0  → that explicit token count
+func (a *Agent) compactTriggerTokens() int {
+	switch {
+	case a.CompactThreshold < 0:
+		return 0
+	case a.CompactThreshold == 0:
+		return int(float64(contextWindow(a.Model)) * compactThresholdFraction)
+	default:
+		return a.CompactThreshold
+	}
+}
 
 // summarizeMaxTokens caps the summary length. A summary is meant to be a
 // compact carry-forward of decisions/paths/open tasks, not a transcript.
@@ -46,7 +87,8 @@ What was just completed, and the immediate next action if the task is unfinished
 // means the summarization side-call failed (the caller logs and proceeds with
 // uncompacted history rather than aborting the turn).
 func (a *Agent) maybeCompact(ctx context.Context) error {
-	if a.CompactThreshold <= 0 || a.lastInputTokens < a.CompactThreshold {
+	trigger := a.compactTriggerTokens()
+	if trigger <= 0 || a.lastInputTokens < trigger {
 		return nil
 	}
 

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -63,6 +63,54 @@ func TestSafeSplitIndex(t *testing.T) {
 	})
 }
 
+func TestContextWindow(t *testing.T) {
+	if got := contextWindow("claude-haiku-4-5-20251001"); got != 200_000 {
+		t.Errorf("claude window = %d, want 200000", got)
+	}
+	if got := contextWindow("k2.6"); got != defaultContextWindow {
+		t.Errorf("unknown model window = %d, want %d (conservative default)", got, defaultContextWindow)
+	}
+}
+
+func TestCompactTriggerTokens(t *testing.T) {
+	a := New(&summarizeFake{}, "k2.6") // unknown model → default window
+
+	a.CompactThreshold = -1
+	if got := a.compactTriggerTokens(); got != 0 {
+		t.Errorf("disabled trigger = %d, want 0", got)
+	}
+
+	a.CompactThreshold = 0 // auto
+	want := int(float64(defaultContextWindow) * compactThresholdFraction)
+	if got := a.compactTriggerTokens(); got != want {
+		t.Errorf("auto trigger = %d, want %d", got, want)
+	}
+
+	a.CompactThreshold = 4242 // explicit
+	if got := a.compactTriggerTokens(); got != 4242 {
+		t.Errorf("explicit trigger = %d, want 4242", got)
+	}
+}
+
+// TestMaybeCompact_AutoDefaultTriggers proves the C6 flip: with CompactThreshold
+// left at 0, a context past the window-relative trigger compacts automatically.
+func TestMaybeCompact_AutoDefaultTriggers(t *testing.T) {
+	f := &summarizeFake{summary: "S"}
+	a := New(f, "k2.6") // CompactThreshold defaults to 0 (auto)
+	for i := 0; i < 6; i++ {
+		a.History.Append(NewUserMessage(fmt.Sprintf("u%d", i)))
+		a.History.Append(NewAssistantMessage(fmt.Sprintf("a%d", i)))
+	}
+	// Just over the auto trigger (0.75 * default window).
+	a.lastInputTokens = int(float64(defaultContextWindow)*compactThresholdFraction) + 1
+	if err := a.maybeCompact(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if f.calls != 1 {
+		t.Errorf("auto default should compact once; calls=%d", f.calls)
+	}
+}
+
 func TestMaybeCompact_DisabledOrBelowThreshold(t *testing.T) {
 	f := &summarizeFake{summary: "S"}
 	a := New(f, "m")
@@ -71,7 +119,8 @@ func TestMaybeCompact_DisabledOrBelowThreshold(t *testing.T) {
 		a.History.Append(NewAssistantMessage(fmt.Sprintf("a%d", i)))
 	}
 
-	// Disabled (threshold 0).
+	// Disabled (negative threshold) — even a huge context must not compact.
+	a.CompactThreshold = -1
 	a.lastInputTokens = 999999
 	if err := a.maybeCompact(context.Background()); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
Compaction was opt-in — `--compact-threshold` defaulted to `0` = disabled — so long sessions could silently grow until the backend rejected the context. This flips it **on by default**, now that the structured 5-section summary (C3) is validated against a real model.

`CompactThreshold` semantics:
- `< 0` → disabled
- `== 0` → **auto**: a fraction (~75%) of the model's context window — the new default
- `> 0` → explicit token count

`contextWindow(model)` is deliberately conservative: `claude` → 200k, everything else → a 128k default. Under-estimating only compacts slightly early; it never overflows. `--compact-threshold` help updated; pass a negative value to disable.

## Validation — summary quality on a real model (the C6 blocker)
Forced a real compaction on **Kimi k2.6** (low threshold, multi-turn, tools) and inspected the saved session. The generated `[Earlier conversation summary]` was high quality: exact 5-section structure, real paths + line numbers (`runLoop` lines 379-460, `dispatchTools` 575-641), accurate architecture notes, no hallucination — and the folded-in early turns were still correctly recalled on the next turn.

## Test plan
- [x] `TestContextWindow` — claude 200k, unknown → conservative default
- [x] `TestCompactTriggerTokens` — disabled / auto / explicit resolution
- [x] `TestMaybeCompact_AutoDefaultTriggers` — `CompactThreshold==0` now compacts past the window-relative trigger
- [x] Updated `TestMaybeCompact_DisabledOrBelowThreshold` to use `-1` for explicit disable
- [x] `make test` (race), `make vet`, `gofmt` clean