### PR TITLE
feat(tools): background command execution + terminal_output (C12)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -200,6 +200,8 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	// ── Single-turn mode (original M2 behaviour) ──────────────────────────────
+	// Reap any background processes the turn spawned (REPL handles its own).
+	defer tools.KillAllBackground()
 	if *stream {
 		reply, err := a.TurnStream(context.Background(), userInput, func(d string) {
 			fmt.Fprint(stdout, d)

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/permission"
+	"github.com/Leihb/octo-agent/internal/tools"
 	"github.com/Leihb/octo-agent/internal/tui"
 )
 
@@ -33,6 +34,10 @@ type replConfig struct {
 func runREPL(cfg replConfig) int {
 	a := cfg.a
 	sess := cfg.session
+
+	// Kill any background processes (terminal background:true) on exit so none
+	// outlive the session.
+	defer tools.KillAllBackground()
 
 	turns := sess.TurnCount()
 	if turns > 0 {

--- a/dev-docs/competitive-parity-roadmap.md
+++ b/dev-docs/competitive-parity-roadmap.md
@@ -58,6 +58,7 @@ system prompt。
 | # | 项 | 谁有 | 成本 | 说明 |
 |---|----|------|------|------|
 | C10 | 优雅中断（Ctrl-C） | 两家 | 1.5d | REPL 捕获中断 → 取消 ctx → 给在途/未执行工具合成 tool_result（历史保持 well-formed）→ 干净返回。 |
+| C12 | 后台/并发命令执行 | 两家 | 1.5d | `terminal` 加 `background` 参数：脱离 30s 超时、不阻塞，返回后台进程 id；新增 `terminal_output` 工具读取输出+状态（类比 CC `BashOutput`）。后台进程天然并发，绕开只读并行闸门。会话退出杀掉所有后台进程。 |
 
 > 错误恢复链（模型 fallback / output-token 升级 / prompt 超长自动压缩）优先级低、CC 专属，延后。
 

--- a/internal/permission/defaults.yml
+++ b/internal/permission/defaults.yml
@@ -75,6 +75,12 @@ read_file:
   - deny:  { path: ["**/.ssh/id_*", "**/id_rsa*", "**/id_ed25519*", "**/id_ecdsa*", "**/.env", "**/.env.*"] }
   - allow: { path: ["**"] }
 
+# terminal_output reads (and optionally kills) background processes started by
+# this same session via `terminal` background:true — low risk, so allow without
+# prompting. The launching `terminal` call is already gated above.
+terminal_output:
+  - allow: { pattern: "" }
+
 # Pattern-free tools default to allow — they don't have a meaningful
 # axis to gate on, and asking on every glob/grep would be unusable.
 glob:

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -1,0 +1,172 @@
+package tools
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+)
+
+// maxBgOutputBytes caps how much output is retained per background process.
+// Beyond this we keep only the most recent bytes (a long-running server's tail
+// is what matters); Read reports when earlier output was dropped.
+const maxBgOutputBytes = 1 << 20 // 1 MiB
+
+// bgProcess tracks one detached command launched via BackgroundManager.
+type bgProcess struct {
+	id      string
+	command string
+	cancel  context.CancelFunc
+
+	mu       sync.Mutex
+	buf      []byte // most recent <= maxBgOutputBytes of combined stdout+stderr
+	produced int64  // total bytes ever written to the logical stream
+	readOff  int64  // absolute offset already returned by Read
+	done     bool
+	exitErr  error
+}
+
+func (p *bgProcess) append(b []byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.produced += int64(len(b))
+	p.buf = append(p.buf, b...)
+	if len(p.buf) > maxBgOutputBytes {
+		p.buf = p.buf[len(p.buf)-maxBgOutputBytes:]
+	}
+}
+
+func (p *bgProcess) finish(err error) {
+	p.mu.Lock()
+	p.done = true
+	p.exitErr = err
+	p.mu.Unlock()
+}
+
+// readNew returns output produced since the last Read and the current status,
+// advancing the read cursor. When retained output was dropped (buffer cap), the
+// returned text is prefixed with a truncation marker.
+func (p *bgProcess) readNew() (string, string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	bufStart := p.produced - int64(len(p.buf)) // absolute offset of buf[0]
+	var out []byte
+	if p.readOff < bufStart {
+		out = append(out, "[... earlier output truncated ...]\n"...)
+		p.readOff = bufStart
+	}
+	out = append(out, p.buf[p.readOff-bufStart:]...)
+	p.readOff = p.produced
+
+	status := "running"
+	if p.done {
+		if p.exitErr != nil {
+			status = "exited: " + p.exitErr.Error()
+		} else {
+			status = "exited: 0"
+		}
+	}
+	return string(out), status
+}
+
+// BackgroundManager owns the set of detached background processes for a
+// session. Methods are safe for concurrent use.
+type BackgroundManager struct {
+	mu    sync.Mutex
+	procs map[string]*bgProcess
+	seq   int
+}
+
+// NewBackgroundManager returns an empty manager.
+func NewBackgroundManager() *BackgroundManager {
+	return &BackgroundManager{procs: map[string]*bgProcess{}}
+}
+
+// Start launches command detached (via `sh -c`), with no timeout, and returns
+// its background id. Output streams into a capped buffer; the process is killed
+// if its context is cancelled (Kill / KillAll).
+func (m *BackgroundManager) Start(command string) (string, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+
+	pr, pw := io.Pipe()
+	cmd.Stdout = pw
+	cmd.Stderr = pw
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		_ = pw.Close()
+		return "", fmt.Errorf("terminal: start background: %w", err)
+	}
+
+	m.mu.Lock()
+	m.seq++
+	id := fmt.Sprintf("bg_%d", m.seq)
+	p := &bgProcess{id: id, command: command, cancel: cancel}
+	m.procs[id] = p
+	m.mu.Unlock()
+
+	// Reader: forward combined output into the capped buffer.
+	go func() {
+		scanner := bufio.NewScanner(pr)
+		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			p.append(append(scanner.Bytes(), '\n')) // Bytes() reused next Scan; append copies
+		}
+	}()
+	// Waiter: record exit and unblock the reader via EOF.
+	go func() {
+		err := cmd.Wait()
+		_ = pw.Close()
+		p.finish(err)
+	}()
+
+	return id, nil
+}
+
+// Read returns output produced since the last call for id, plus a status
+// string. found is false when id is unknown.
+func (m *BackgroundManager) Read(id string) (output, status string, found bool) {
+	m.mu.Lock()
+	p := m.procs[id]
+	m.mu.Unlock()
+	if p == nil {
+		return "", "", false
+	}
+	out, st := p.readNew()
+	return out, st, true
+}
+
+// Kill terminates the process for id. Returns false when id is unknown.
+func (m *BackgroundManager) Kill(id string) bool {
+	m.mu.Lock()
+	p := m.procs[id]
+	m.mu.Unlock()
+	if p == nil {
+		return false
+	}
+	p.cancel()
+	return true
+}
+
+// KillAll terminates every tracked process. Called on session shutdown so no
+// background command is orphaned.
+func (m *BackgroundManager) KillAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, p := range m.procs {
+		p.cancel()
+	}
+}
+
+// defaultBg is the process-wide manager used by the built-in tools when no
+// manager is injected. A single-process CLI shares one set of background
+// processes across the session.
+var defaultBg = NewBackgroundManager()
+
+// KillAllBackground terminates all background processes started via the default
+// manager. Wire it into session/REPL shutdown to avoid orphans.
+func KillAllBackground() { defaultBg.KillAll() }

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -1,0 +1,171 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// waitFor polls fn until it returns true or the deadline passes.
+func waitFor(t *testing.T, what string, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func TestBackgroundManager_RunsAndReportsExit(t *testing.T) {
+	m := NewBackgroundManager()
+	id, err := m.Start("echo hello")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	var out, status string
+	waitFor(t, "process to exit", func() bool {
+		var found bool
+		o, s, f := m.Read(id)
+		found = f
+		if o != "" {
+			out += o // accumulate across reads (cursor advances)
+		}
+		status = s
+		return found && strings.HasPrefix(s, "exited")
+	})
+
+	if !strings.Contains(out, "hello") {
+		t.Errorf("output = %q, want it to contain 'hello'", out)
+	}
+	if status != "exited: 0" {
+		t.Errorf("status = %q, want 'exited: 0'", status)
+	}
+}
+
+func TestBackgroundManager_IncrementalRead(t *testing.T) {
+	m := NewBackgroundManager()
+	id, err := m.Start("echo one; sleep 0.3; echo two")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// First chunk: "one" before "two" is emitted.
+	waitFor(t, "first line", func() bool {
+		o, _, _ := m.Read(id)
+		return strings.Contains(o, "one")
+	})
+	// A read right after consuming "one" should not re-return it.
+	o, _, _ := m.Read(id)
+	if strings.Contains(o, "one") {
+		t.Errorf("second read re-returned old output: %q", o)
+	}
+	// Eventually "two" arrives as new output.
+	waitFor(t, "second line", func() bool {
+		o, _, _ := m.Read(id)
+		return strings.Contains(o, "two")
+	})
+}
+
+func TestBackgroundManager_Kill(t *testing.T) {
+	m := NewBackgroundManager()
+	id, err := m.Start("sleep 30")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !m.Kill(id) {
+		t.Fatal("Kill returned false for a live process")
+	}
+	waitFor(t, "killed process to report exit", func() bool {
+		_, s, _ := m.Read(id)
+		return strings.HasPrefix(s, "exited")
+	})
+
+	if m.Kill("bg_does_not_exist") {
+		t.Error("Kill of unknown id should return false")
+	}
+}
+
+func TestTerminalTool_BackgroundLaunch(t *testing.T) {
+	m := NewBackgroundManager()
+	tool := TerminalTool{mgr: m}
+	res, err := tool.Execute(context.Background(), "terminal", map[string]any{
+		"command":    "echo hi",
+		"background": true,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res, "bg_1") {
+		t.Errorf("result = %q, want it to mention the bg id", res)
+	}
+	// The terminal guard (e.g. in-place sed) still applies to background launches.
+	if _, err := tool.Execute(context.Background(), "terminal", map[string]any{
+		"command":    "sed -i 's/a/b/' file.txt",
+		"background": true,
+	}); err == nil {
+		t.Error("guarded command should be refused even in background mode")
+	}
+}
+
+func TestTerminalOutputTool(t *testing.T) {
+	m := NewBackgroundManager()
+	term := TerminalTool{mgr: m}
+	outTool := TerminalOutputTool{mgr: m}
+
+	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
+		"command":    "echo from-bg",
+		"background": true,
+	}); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+
+	var res string
+	waitFor(t, "terminal_output to show exit", func() bool {
+		r, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_1"})
+		if err != nil {
+			t.Fatalf("terminal_output: %v", err)
+		}
+		res += r
+		return strings.Contains(res, "exited")
+	})
+	if !strings.Contains(res, "from-bg") {
+		t.Errorf("terminal_output = %q, want it to contain 'from-bg'", res)
+	}
+
+	// Unknown id is an error.
+	if _, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_99"}); err == nil {
+		t.Error("terminal_output of unknown id should error")
+	}
+	// Missing id is an error.
+	if _, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{}); err == nil {
+		t.Error("terminal_output without id should error")
+	}
+}
+
+func TestTerminalOutputTool_Kill(t *testing.T) {
+	m := NewBackgroundManager()
+	term := TerminalTool{mgr: m}
+	outTool := TerminalOutputTool{mgr: m}
+
+	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
+		"command":    "sleep 30",
+		"background": true,
+	}); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	res, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{
+		"id":   "bg_1",
+		"kill": true,
+	})
+	if err != nil {
+		t.Fatalf("kill via terminal_output: %v", err)
+	}
+	if !strings.Contains(res, "killed") {
+		t.Errorf("result = %q, want it to note the kill", res)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -21,6 +21,7 @@ type tool interface {
 // scan and the DefaultTools() listing both pick it up automatically.
 var allTools = []tool{
 	TerminalTool{},
+	TerminalOutputTool{},
 	ReadFileTool{},
 	WriteFileTool{},
 	EditFileTool{},

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -26,20 +26,36 @@ const TerminalTimeout = 30 * time.Second
 // The LLM-facing tool name is "terminal" — calling it "bash" would imply a
 // hard /bin/bash dependency, but the executor actually shells out via
 // `sh -c`.
-type TerminalTool struct{}
+//
+// mgr, when non-nil, is the BackgroundManager used for background:true
+// launches; nil falls back to the process-wide default manager. The field
+// exists so tests can inject an isolated manager.
+type TerminalTool struct{ mgr *BackgroundManager }
+
+func (t TerminalTool) manager() *BackgroundManager {
+	if t.mgr != nil {
+		return t.mgr
+	}
+	return defaultBg
+}
 
 // Definition returns the agent.ToolDefinition the LLM receives in the tools
-// list. The JSON Schema describes a single required "command" string parameter.
+// list. The JSON Schema describes a required "command" string and an optional
+// "background" flag.
 func (TerminalTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name:        "terminal",
-		Description: "Run a shell command (via `sh -c`) and return stdout+stderr. Use for file operations, running programs, searching code, etc.",
+		Description: "Run a shell command (via `sh -c`) and return stdout+stderr. Use for file operations, running programs, searching code, etc. Set background:true for long-running commands (servers, watchers): it returns immediately with a process id (no 30s timeout, non-blocking); read its output later with the terminal_output tool.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"command": map[string]any{
 					"type":        "string",
 					"description": "The shell command to execute",
+				},
+				"background": map[string]any{
+					"type":        "boolean",
+					"description": "Run detached in the background (no timeout, non-blocking). Returns a process id; use terminal_output to read its output.",
 				},
 			},
 			"required": []string{"command"},
@@ -67,7 +83,7 @@ func (t TerminalTool) Execute(ctx context.Context, name string, input map[string
 // Scanner buffer cap is 1 MiB per line — commands that emit a single 10MB-
 // long line will get their final line truncated, but the more usual case of
 // many short lines is unaffected.
-func (TerminalTool) ExecuteStream(
+func (t TerminalTool) ExecuteStream(
 	ctx context.Context,
 	_ string,
 	input map[string]any,
@@ -79,6 +95,16 @@ func (TerminalTool) ExecuteStream(
 	}
 	if err := guardCommand(command); err != nil {
 		return "", err
+	}
+
+	// Background launch: detach, no timeout, return the id immediately. The
+	// guard above still applies, so dangerous commands are blocked either way.
+	if bg, _ := input["background"].(bool); bg {
+		id, err := t.manager().Start(command)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Started background process %s.\nRead its output with the terminal_output tool (id: %q).", id, id), nil
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, TerminalTimeout)
@@ -132,4 +158,68 @@ func (TerminalTool) ExecuteStream(
 		return body + "\n[exit: " + waitErr.Error() + "]", nil
 	}
 	return body, nil
+}
+
+// TerminalOutputTool reads new output (and status) from a background process
+// started by TerminalTool with background:true — the counterpart that makes
+// detached commands useful. It can also kill the process.
+type TerminalOutputTool struct{ mgr *BackgroundManager }
+
+func (t TerminalOutputTool) manager() *BackgroundManager {
+	if t.mgr != nil {
+		return t.mgr
+	}
+	return defaultBg
+}
+
+// Definition describes the required "id" and an optional "kill" flag.
+func (TerminalOutputTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name:        "terminal_output",
+		Description: "Read output produced since the last check from a background process (the id returned by terminal with background:true), along with its status (running / exited). Set kill:true to terminate it.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"id": map[string]any{
+					"type":        "string",
+					"description": "The background process id (e.g. \"bg_1\").",
+				},
+				"kill": map[string]any{
+					"type":        "boolean",
+					"description": "Terminate the process after reading its remaining output.",
+				},
+			},
+			"required": []string{"id"},
+		},
+	}
+}
+
+// Execute returns the new output plus a status line; with kill:true it
+// terminates the process first so the final output is included.
+func (t TerminalOutputTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+	id, _ := input["id"].(string)
+	if id == "" {
+		return "", fmt.Errorf("terminal_output: id is required")
+	}
+	mgr := t.manager()
+
+	var killed bool
+	if kill, _ := input["kill"].(bool); kill {
+		killed = mgr.Kill(id)
+		// Give the process a moment to flush and the waiter to record exit.
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	out, status, found := mgr.Read(id)
+	if !found {
+		return "", fmt.Errorf("terminal_output: no background process %q", id)
+	}
+	header := "[status: " + status + "]"
+	if killed {
+		header = "[killed] " + header
+	}
+	if out == "" {
+		return header + "\n(no new output)", nil
+	}
+	return header + "\n" + out, nil
 }


### PR DESCRIPTION
## Summary
The `terminal` tool was synchronous with a hard 30s timeout, so long-running commands (dev servers, watchers, test runners) couldn't run, and a batch containing `terminal` was always serialized. This adds background execution.

- **`terminal` gains an optional `background` flag**: launches detached via a shared `BackgroundManager` (no timeout, non-blocking) and returns a process id immediately. Output streams into a capped ~1MiB buffer; the command guard (`sed -i` etc.) still applies.
- **New `terminal_output` tool**: reads output produced since the last check (per-id cursor; truncation marker when the cap drops old bytes) plus status (`running` / `exited:code`), and can `kill` the process. Default-allowed in the permission rules — it only reads/kills *this session's own* background processes.
- **Concurrency**: background processes run concurrently by construction, sidestepping the read-only parallel-dispatch gate (which intentionally serializes mutating tools). This answers the original question — multiple long commands can now run at once via background mode.
- **Lifecycle**: `KillAllBackground()` is wired into REPL (`defer`) and single-turn shutdown, so no background process is orphaned.

Roadmap: added as **C12**.

## Validation
- **Live (Kimi k2.6)**: model launched `for i in 1 2 3; do echo "tick $i"; sleep 1; done` with `background:true` → `bg_1`, then read `tick 1 / tick 2 / tick 3` via `terminal_output`. (Surfaced + fixed a permission gap: `terminal_output` now default-allowed, else strict mode denied it.)

## Test plan
- [x] `BackgroundManager`: runs + reports exit status; incremental cursor read (no re-returning consumed output); `Kill` + unknown-id handling
- [x] `terminal` background launch returns an id; guard still applies in background mode
- [x] `terminal_output`: reads output + status; `kill:true`; unknown/missing id errors
- [x] `make test` (race), `make vet`, `gofmt` clean

## Notes
- Output retention is capped at ~1MiB per process (keeps the recent tail; reports truncation). A process registry lives for the session and is reaped on exit.