### PR TITLE
feat(agent,repl): graceful Ctrl-C interrupt (C10)

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -3,10 +3,14 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
@@ -53,6 +57,43 @@ func runREPL(cfg replConfig) int {
 	fmt.Fprintln(cfg.stdout)
 
 	scanner := bufio.NewScanner(cfg.stdin)
+
+	// Ctrl-C handling: while a turn is running, SIGINT cancels just that turn
+	// (the loop catches context.Canceled, finalizes well-formed history, and
+	// returns to the prompt). At an idle prompt — no turn in flight — SIGINT
+	// exits cleanly, preserving the documented "Ctrl-C to quit" behaviour.
+	var (
+		turnMu     sync.Mutex
+		turnCancel context.CancelFunc
+	)
+	setTurnCancel := func(c context.CancelFunc) {
+		turnMu.Lock()
+		turnCancel = c
+		turnMu.Unlock()
+	}
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+	go func() {
+		for range sigCh {
+			turnMu.Lock()
+			c := turnCancel
+			turnMu.Unlock()
+			if c != nil {
+				c() // interrupt the in-flight turn; the loop returns to prompt
+				continue
+			}
+			// Idle prompt: save what we have and exit cleanly. os.Exit skips the
+			// deferred cleanup below, so do it explicitly here.
+			fmt.Fprintln(cfg.stdout, "\n^C")
+			if !cfg.noSave {
+				sess.SyncFrom(a.History)
+				_ = sess.Save()
+			}
+			tools.KillAllBackground()
+			os.Exit(0)
+		}
+	}()
 
 	// Permission gating shares the REPL scanner so an interactive "ask"
 	// prompt reads from the same stdin buffer the loop uses. Tool dispatch
@@ -110,7 +151,10 @@ func runREPL(cfg replConfig) int {
 		}
 
 		// Regular message — streaming turn (or agentic loop when tools enabled).
-		startedAt := time.Now()
+		// Each turn gets its own cancellable context so SIGINT can interrupt
+		// just this turn without tearing down the session.
+		turnCtx, cancelTurn := context.WithCancel(context.Background())
+		setTurnCancel(cancelTurn)
 		var (
 			reply agent.Reply
 			err   error
@@ -123,25 +167,35 @@ func runREPL(cfg replConfig) int {
 			// stdout, etc.) is conversational state for the LLM, not user-
 			// facing chrome. EventTurnDone is also silent; the trailing
 			// newline below marks the visible turn boundary.
-			reply, err = a.RunStream(context.Background(), line, cfg.tools, cfg.executor, replToolEventHandler(cfg.stdout, cfg.plain))
+			reply, err = a.RunStream(turnCtx, line, cfg.tools, cfg.executor, replToolEventHandler(cfg.stdout, cfg.plain))
 		} else {
-			reply, err = a.TurnStream(context.Background(), line, func(delta string) {
+			reply, err = a.TurnStream(turnCtx, line, func(delta string) {
 				fmt.Fprint(cfg.stdout, delta)
 			})
 		}
-		if err != nil {
+		setTurnCancel(nil)
+		cancelTurn()
+
+		switch {
+		case errors.Is(err, context.Canceled):
+			// Ctrl-C: the agent already finalized history into a well-formed
+			// state. Acknowledge and fall through to auto-save so the next turn
+			// continues cleanly.
+			fmt.Fprintln(cfg.stdout, "\n^C interrupted")
+		case err != nil:
 			fmt.Fprintf(cfg.stderr, "\nerror: %v\n", err)
 			continue
-		}
-		_ = startedAt
-		fmt.Fprintln(cfg.stdout) // newline after streamed reply
-		// Surface cache activity per turn so the win is visible (and tunable).
-		if reply.CacheReadTokens > 0 || reply.CacheWriteTokens > 0 {
-			fmt.Fprintf(cfg.stdout, "  ⓘ cache: %d read, %d write (in %d / out %d)\n",
-				reply.CacheReadTokens, reply.CacheWriteTokens, reply.InputTokens, reply.OutputTokens)
+		default:
+			fmt.Fprintln(cfg.stdout) // newline after streamed reply
+			// Surface cache activity per turn so the win is visible (and tunable).
+			if reply.CacheReadTokens > 0 || reply.CacheWriteTokens > 0 {
+				fmt.Fprintf(cfg.stdout, "  ⓘ cache: %d read, %d write (in %d / out %d)\n",
+					reply.CacheReadTokens, reply.CacheWriteTokens, reply.InputTokens, reply.OutputTokens)
+			}
 		}
 
-		// Auto-save after every turn unless opted out.
+		// Auto-save after every turn (including interrupted ones — history is
+		// well-formed) unless opted out.
 		if !cfg.noSave {
 			sess.SyncFrom(a.History)
 			if err := sess.Save(); err != nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -144,9 +144,14 @@ type Agent struct {
 // They are NOT provider stop reasons — the agent synthesises them so callers
 // can distinguish "the model finished" from "we cut it off".
 const (
-	StopReasonMaxTurns = "max_turns"
-	StopReasonMaxCost  = "max_cost"
+	StopReasonMaxTurns    = "max_turns"
+	StopReasonMaxCost     = "max_cost"
+	StopReasonInterrupted = "interrupted"
 )
+
+// interruptNote caps an interrupted turn as an assistant message so history
+// keeps the user/assistant alternation the next turn depends on.
+const interruptNote = "[Interrupted by user.]"
 
 // New constructs an Agent with a fresh History.
 //
@@ -397,6 +402,11 @@ func (a *Agent) runLoop(
 
 	limit := a.turnLimit()
 	for i := 0; i < limit; i++ {
+		// Interrupt (Ctrl-C) between iterations — e.g. right after a tool batch.
+		if ctx.Err() != nil {
+			return a.finishInterrupted(handler)
+		}
+
 		// Cost gate: checked before each provider call. Cost is only known
 		// after a response, so the worst case is one call that tips over the
 		// budget; we stop before the next.
@@ -408,6 +418,11 @@ func (a *Agent) runLoop(
 
 		reply, err := send(ctx, a.History.Snapshot())
 		if err != nil {
+			// Interrupt during the provider call: finalize cleanly rather than
+			// surfacing context.Canceled as a turn error.
+			if ctx.Err() != nil {
+				return a.finishInterrupted(handler)
+			}
 			if i == 0 {
 				a.History.popLast()
 			}
@@ -459,6 +474,39 @@ func (a *Agent) runLoop(
 	return a.budgetStop(handler, StopReasonMaxTurns, fmt.Sprintf(
 		"[octo] Stopped: reached the max-turns limit (%d). The task may be incomplete — "+
 			"raise --max-turns or send another message to continue.", limit))
+}
+
+// finishInterrupted finalizes a turn cut short by context cancellation
+// (Ctrl-C) so the history stays well-formed for the next turn, then returns
+// context.Canceled so the caller can recognise the interrupt. It restores the
+// user/assistant alternation invariant:
+//
+//   - last message is the unanswered user input → drop it (turn never happened)
+//   - last message is a tool_result (user role) → cap with an assistant note,
+//     so the next user turn doesn't produce two user messages in a row
+//   - last message is already an assistant turn → nothing to do
+//
+// The synthesized tool_result blocks for interrupted tool calls are produced
+// by dispatchTools itself (cancelled executions become is_error results), so
+// every tool_use already has a matching tool_result by the time we get here.
+func (a *Agent) finishInterrupted(handler EventHandler) (Reply, error) {
+	msgs := a.History.Snapshot()
+	if n := len(msgs); n > 0 {
+		last := msgs[n-1]
+		if last.Role == RoleUser {
+			if hasToolResult(last) {
+				a.History.Append(NewAssistantMessage(interruptNote))
+			} else {
+				a.History.popLast()
+			}
+		}
+	}
+	reply := Reply{Content: interruptNote, StopReason: StopReasonInterrupted}
+	if handler != nil {
+		r := reply
+		handler(AgentEvent{Kind: EventTurnDone, Reply: &r})
+	}
+	return reply, context.Canceled
 }
 
 // turnLimit resolves the per-Run loop cap, applying the default when unset.

--- a/internal/agent/interrupt_test.go
+++ b/internal/agent/interrupt_test.go
@@ -1,0 +1,132 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestFinishInterrupted_HistoryShapes covers the three history end-states the
+// helper must normalize so the next turn keeps user/assistant alternation.
+func TestFinishInterrupted_HistoryShapes(t *testing.T) {
+	t.Run("unanswered user input is dropped", func(t *testing.T) {
+		a := New(&summarizeFake{}, "m")
+		a.History.Append(NewUserMessage("hi"))
+		_, err := a.finishInterrupted(nil)
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("err = %v, want context.Canceled", err)
+		}
+		if a.History.Len() != 0 {
+			t.Errorf("history len = %d, want 0 (unanswered input dropped)", a.History.Len())
+		}
+	})
+
+	t.Run("trailing tool_result is capped with an assistant note", func(t *testing.T) {
+		a := New(&summarizeFake{}, "m")
+		a.History.Append(NewUserMessage("read it"))
+		a.History.Append(NewToolUseMessage([]ContentBlock{NewToolUseBlock("c1", "read_file", nil)}))
+		a.History.Append(NewToolResultMessage([]ContentBlock{NewToolResultBlock("c1", "ctx canceled", true)}))
+		_, err := a.finishInterrupted(nil)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+		msgs := a.History.Snapshot()
+		if len(msgs) != 4 {
+			t.Fatalf("history len = %d, want 4", len(msgs))
+		}
+		if last := msgs[3]; last.Role != RoleAssistant || last.Content != interruptNote {
+			t.Errorf("last msg = %+v, want assistant interrupt note", last)
+		}
+	})
+
+	t.Run("history already ending on assistant is untouched", func(t *testing.T) {
+		a := New(&summarizeFake{}, "m")
+		a.History.Append(NewUserMessage("hi"))
+		a.History.Append(NewAssistantMessage("hello"))
+		_, _ = a.finishInterrupted(nil)
+		if a.History.Len() != 2 {
+			t.Errorf("history len = %d, want 2 (unchanged)", a.History.Len())
+		}
+	})
+}
+
+// cancelOnSendSender cancels the supplied context the first time it is asked to
+// produce a reply, simulating Ctrl-C arriving during the provider call.
+type cancelOnSendSender struct {
+	cancel context.CancelFunc
+}
+
+func (s *cancelOnSendSender) SendMessages(ctx context.Context, _, _ string, _ []Message, _ int) (Reply, error) {
+	s.cancel()
+	return Reply{}, ctx.Err()
+}
+
+// TestRun_InterruptDuringFirstCall verifies an interrupt on the very first
+// model call returns context.Canceled and leaves history empty (the unanswered
+// user turn is dropped).
+func TestRun_InterruptDuringFirstCall(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	a := New(&cancelOnSendSender{cancel: cancel}, "m")
+
+	_, err := a.Turn(ctx, "hi")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if a.History.Len() != 0 {
+		t.Errorf("history len = %d, want 0", a.History.Len())
+	}
+}
+
+// toolThenCancelSender returns a tool_use on the first call; the executor
+// cancels the context during dispatch, so the loop must still produce a
+// well-formed history (assistant tool_use + tool_result + interrupt note).
+type toolThenCancelSender struct{ calls int }
+
+func (s *toolThenCancelSender) SendMessages(_ context.Context, _, _ string, _ []Message, _ int) (Reply, error) {
+	return Reply{}, nil // unused (tool path goes through SendMessagesWithTools)
+}
+
+func (s *toolThenCancelSender) SendMessagesWithTools(_ context.Context, _, _ string, _ []Message, _ int, _ []ToolDefinition) (Reply, error) {
+	s.calls++
+	return Reply{
+		StopReason: "tool_use",
+		Blocks:     []ContentBlock{NewToolUseBlock("c1", "do", map[string]any{})},
+	}, nil
+}
+
+type cancelOnExecExecutor struct{ cancel context.CancelFunc }
+
+func (e cancelOnExecExecutor) Execute(ctx context.Context, _ string, _ map[string]any) (string, error) {
+	e.cancel() // Ctrl-C arrives while the tool runs
+	return "", ctx.Err()
+}
+
+func TestRun_InterruptDuringToolDispatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	a := New(&toolThenCancelSender{}, "m")
+	tools := []ToolDefinition{{Name: "do"}}
+
+	_, err := a.Run(ctx, "go", tools, cancelOnExecExecutor{cancel: cancel})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+
+	// History must be well-formed: user, assistant(tool_use), user(tool_result),
+	// assistant(interrupt note) — alternation preserved for the next turn.
+	msgs := a.History.Snapshot()
+	if len(msgs) != 4 {
+		t.Fatalf("history len = %d, want 4: %+v", len(msgs), msgs)
+	}
+	wantRoles := []Role{RoleUser, RoleAssistant, RoleUser, RoleAssistant}
+	for i, want := range wantRoles {
+		if msgs[i].Role != want {
+			t.Errorf("msg[%d].Role = %q, want %q", i, msgs[i].Role, want)
+		}
+	}
+	if !hasToolResult(msgs[2]) {
+		t.Errorf("msg[2] should carry the synthesized tool_result")
+	}
+	if msgs[3].Content != interruptNote {
+		t.Errorf("msg[3] = %q, want interrupt note", msgs[3].Content)
+	}
+}


### PR DESCRIPTION
## Summary
Ctrl-C used to kill the whole process. Now, in the REPL:
- **SIGINT during a turn** cancels just that turn and returns to the prompt — the session keeps running.
- **SIGINT at an idle prompt** exits cleanly (documented "Ctrl-C to quit" behaviour preserved).

The hard part is keeping history **well-formed** so the next turn doesn't violate provider user/assistant alternation. `runLoop` checks `ctx` between iterations and after a failed provider call, routing cancellation through `finishInterrupted`, which:
- drops an unanswered user message (the turn never produced a reply), or
- caps a trailing `tool_result` (user-role) with an assistant note, so the next user turn doesn't create two user messages in a row.

Interrupted tool calls already become `is_error` tool_results in `dispatchTools`, so every `tool_use` keeps a matching `tool_result`.

The REPL wires a **per-turn cancellable context** to a SIGINT handler (turn in flight → cancel; idle → save + reap background processes + exit), recognizes `context.Canceled` as a clean interrupt, prints `^C interrupted`, and auto-saves the well-formed history.

## Validation
- **Live (Kimi k2.6, via FIFO + `kill -INT` mid-stream)**: turn 1 was streaming an essay → SIGINT → `^C interrupted`, **process survived** (final exit 0, not killed) → next turn returned `FOLLOWUP-OK` (proves history stayed well-formed) → clean `/exit`.

## Test plan
- [x] `TestFinishInterrupted_HistoryShapes` — drop unanswered input / cap trailing tool_result with assistant note / leave assistant-ending history untouched
- [x] `TestRun_InterruptDuringFirstCall` — interrupt on first model call → context.Canceled, history emptied
- [x] `TestRun_InterruptDuringToolDispatch` — interrupt while a tool runs → well-formed `user, assistant(tool_use), user(tool_result), assistant(note)`
- [x] `make test` (race), `make vet`, `gofmt` clean

## Known limitation
An interrupt that arrives while an interactive permission y/n prompt is blocking on stdin only takes effect after the prompt is answered (strict mode has no prompts, so it's unaffected). Noted for a future pass.