### PR TITLE
chore: gitignore the local .codegraph/ index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage.html
 
 # Local agent / config
 /.claude/settings.local.json
+.codegraph/


### PR DESCRIPTION
## Summary
`.codegraph/` is a per-clone CodeGraph index (local code-intelligence cache), not source. Add it to `.gitignore` so it can't be committed by accident.

One line, no code impact.