### PR TITLE
feat(prompt): cross-session user memory + @include (C8)

### DIFF
--- a/internal/prompt/memory_test.go
+++ b/internal/prompt/memory_test.go
@@ -1,0 +1,153 @@
+package prompt
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withUserRules points userRulesPath at a temp file containing body, and
+// restores the original afterward.
+func withUserRules(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "octorules.md")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := userRulesPath
+	userRulesPath = func() string { return p }
+	t.Cleanup(func() { userRulesPath = orig })
+}
+
+func TestCompose_UserLayerBetweenEnvAndProject(t *testing.T) {
+	withUserRules(t, "USER_GLOBAL_RULE")
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("PROJECT_RULE"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := Compose("SYSTEM_OVERRIDE", dir, "ENV_BLOCK")
+
+	envIdx := strings.Index(out, "ENV_BLOCK")
+	userIdx := strings.Index(out, "USER_GLOBAL_RULE")
+	projIdx := strings.Index(out, "PROJECT_RULE")
+	sysIdx := strings.Index(out, "SYSTEM_OVERRIDE")
+	for name, idx := range map[string]int{"env": envIdx, "user": userIdx, "proj": projIdx, "sys": sysIdx} {
+		if idx == -1 {
+			t.Fatalf("%s layer missing:\n%s", name, out)
+		}
+	}
+	// base < env < user < project < --system
+	if !(envIdx < userIdx && userIdx < projIdx && projIdx < sysIdx) {
+		t.Errorf("order wrong: env=%d user=%d proj=%d sys=%d", envIdx, userIdx, projIdx, sysIdx)
+	}
+	if !strings.Contains(out, "~/.octo/octorules.md") {
+		t.Error("user layer should be labelled with its source path")
+	}
+}
+
+func TestCompose_NoUserFile_NoUserLayer(t *testing.T) {
+	// Point at a non-existent file.
+	orig := userRulesPath
+	userRulesPath = func() string { return filepath.Join(t.TempDir(), "absent.md") }
+	t.Cleanup(func() { userRulesPath = orig })
+
+	out := Compose("", t.TempDir(), "")
+	if strings.Contains(out, "octorules.md") {
+		t.Errorf("absent user file should add no layer:\n%s", out)
+	}
+	if strings.Contains(out, "---") {
+		t.Errorf("base-only prompt should have no separators:\n%s", out)
+	}
+}
+
+func TestInclude_InlinesRelativeFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "style.md"), []byte("STYLE_FROM_INCLUDE"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	main := filepath.Join(dir, ProjectContextFile)
+	if err := os.WriteFile(main, []byte("top line\n@style.md\nbottom line"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readProjectContext(dir)
+	for _, want := range []string{"top line", "STYLE_FROM_INCLUDE", "bottom line"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in expanded content:\n%s", want, got)
+		}
+	}
+}
+
+func TestInclude_NestedAndDepth(t *testing.T) {
+	dir := t.TempDir()
+	// a → b → c chain (depth 3, under the cap).
+	must := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("c.md", "DEEP_C")
+	must("b.md", "MID_B\n@c.md")
+	must(ProjectContextFile, "TOP_A\n@b.md")
+
+	got := readProjectContext(dir)
+	for _, want := range []string{"TOP_A", "MID_B", "DEEP_C"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("nested include lost %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestInclude_MissingFileLeavesMarker(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("@nope.md"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := readProjectContext(dir)
+	if !strings.Contains(got, "missing include: nope.md") {
+		t.Errorf("missing include should leave a marker, got:\n%s", got)
+	}
+}
+
+func TestInclude_CycleIsBroken(t *testing.T) {
+	dir := t.TempDir()
+	// a includes b, b includes a → cycle.
+	if err := os.WriteFile(filepath.Join(dir, "b.md"), []byte("B_BODY\n@"+ProjectContextFile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("A_BODY\n@b.md"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := readProjectContext(dir)
+	if !strings.Contains(got, "A_BODY") || !strings.Contains(got, "B_BODY") {
+		t.Errorf("both bodies should appear once:\n%s", got)
+	}
+	if !strings.Contains(got, "include cycle") {
+		t.Errorf("cycle back to the root should be marked, got:\n%s", got)
+	}
+}
+
+func TestInclude_DiamondAllowed(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("shared.md", "SHARED")
+	mk("left.md", "@shared.md")
+	mk("right.md", "@shared.md")
+	mk(ProjectContextFile, "@left.md\n@right.md")
+
+	got := readProjectContext(dir)
+	// SHARED reached via two sibling branches (diamond) is allowed, not a cycle.
+	if strings.Contains(got, "include cycle") {
+		t.Errorf("diamond include must not be flagged as a cycle:\n%s", got)
+	}
+	if n := strings.Count(got, "SHARED"); n != 2 {
+		t.Errorf("SHARED should appear twice (once per branch), got %d:\n%s", n, got)
+	}
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -26,26 +26,48 @@ var base string
 // follow (the human-facing counterpart to CLAUDE.md).
 const ProjectContextFile = ".octorules"
 
-// Compose assembles the session system prompt from up to four layers, in
-// order of increasing specificity:
+// maxIncludeDepth caps @include nesting so a deep (or accidentally recursive)
+// chain can't blow the stack or balloon the prompt. Cycles are caught
+// separately; this guards pathological-but-acyclic depth.
+const maxIncludeDepth = 5
+
+// userRulesPath returns the absolute path of the per-user global conventions
+// file (~/.octo/octorules.md) — the cross-project counterpart of the per-repo
+// ProjectContextFile. It's a var so tests can point it at a temp file. Returns
+// "" when the home directory can't be resolved.
+var userRulesPath = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "octorules.md")
+}
+
+// Compose assembles the session system prompt from up to five layers, in order
+// of increasing specificity:
 //
 //  1. base    — embedded octo foundation (always present)
 //  2. env     — environment snapshot (cwd, git, date, OS) the caller renders
-//  3. project — ProjectContextFile in cwd, if present (repo conventions)
-//  4. user    — the --system value, if any (highest-priority override, last)
+//  3. user    — ~/.octo/octorules.md, if present (cross-project user rules)
+//  4. project — ProjectContextFile in cwd, if present (repo conventions)
+//  5. system  — the --system value, if any (highest-priority override, last)
 //
 // Empty layers are skipped. Later layers appear later in the text, which is
-// the conventional way to let more specific instructions take precedence.
+// the conventional way to let more specific instructions take precedence —
+// project rules override the user's global rules, and --system overrides all.
 //
-// env is passed in rather than computed here so this package stays pure (no
-// os/exec, no git). The caller takes a snapshot once at session start; since
-// the composed prompt is frozen for the session, a snapshot is correct and
-// keeps the cached prompt prefix stable across turns.
+// The user and project files may pull in other files with @include directives
+// (see expandIncludes). env is passed in rather than computed here so this
+// package stays pure (no os/exec, no git); the caller snapshots it once at
+// session start, which keeps the cached prompt prefix stable across turns.
 func Compose(userSystem, cwd, env string) string {
 	layers := []string{strings.TrimSpace(base)}
 
 	if e := strings.TrimSpace(env); e != "" {
 		layers = append(layers, e)
+	}
+	if u := readUserContext(); u != "" {
+		layers = append(layers, "# User conventions (~/.octo/octorules.md)\n\n"+u)
 	}
 	if proj := readProjectContext(cwd); proj != "" {
 		layers = append(layers, "# Project conventions ("+ProjectContextFile+")\n\n"+proj)
@@ -57,16 +79,110 @@ func Compose(userSystem, cwd, env string) string {
 	return strings.Join(layers, "\n\n---\n\n")
 }
 
-// readProjectContext returns the trimmed contents of ProjectContextFile in
-// cwd, or "" if it's absent/unreadable/empty. A missing file is not an error
-// — most directories won't have one.
+// readUserContext returns the trimmed, include-expanded contents of the
+// per-user global rules file, or "" if it's absent/unreadable/empty.
+func readUserContext() string {
+	p := userRulesPath()
+	if p == "" {
+		return ""
+	}
+	return readContextFile(p)
+}
+
+// readProjectContext returns the trimmed, include-expanded contents of
+// ProjectContextFile in cwd, or "" if it's absent/unreadable/empty. A missing
+// file is not an error — most directories won't have one.
 func readProjectContext(cwd string) string {
 	if cwd == "" {
 		return ""
 	}
-	b, err := os.ReadFile(filepath.Join(cwd, ProjectContextFile))
+	return readContextFile(filepath.Join(cwd, ProjectContextFile))
+}
+
+// readContextFile reads a context file and expands its @include directives,
+// returning the trimmed result (or "" when the file is absent/unreadable).
+func readContextFile(path string) string {
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(b))
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	// Seed the cycle set with the root file so it can't transitively include
+	// itself.
+	expanded := expandIncludes(string(b), filepath.Dir(abs), 0, map[string]bool{abs: true})
+	return strings.TrimSpace(expanded)
+}
+
+// expandIncludes inlines @include directives. A line whose first non-space
+// character is '@' is an include: the remainder (trimmed) is a file path,
+// resolved as ~/… (home), an absolute path, or relative to baseDir (the
+// directory of the file currently being expanded). The referenced file is
+// read and recursively expanded in place.
+//
+// Failures degrade to an inline HTML comment rather than aborting the prompt:
+//   - unreadable/missing →  <!-- missing include: PATH -->
+//   - already in the ancestor chain (cycle) →  <!-- include cycle: PATH -->
+//   - past maxIncludeDepth →  <!-- include depth exceeded: PATH -->
+//
+// seen tracks the current ancestor chain (added before recursing, removed
+// after) so a diamond include — the same file reached via two sibling
+// branches — is allowed, while a true cycle is not.
+func expandIncludes(content, baseDir string, depth int, seen map[string]bool) string {
+	var out strings.Builder
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) < 2 || trimmed[0] != '@' {
+			out.WriteString(line)
+			out.WriteByte('\n')
+			continue
+		}
+
+		raw := strings.TrimSpace(trimmed[1:])
+		resolved := resolveIncludePath(raw, baseDir)
+		abs, err := filepath.Abs(resolved)
+		if err != nil {
+			abs = resolved
+		}
+
+		switch {
+		case depth+1 > maxIncludeDepth:
+			out.WriteString("<!-- include depth exceeded: " + raw + " -->\n")
+			continue
+		case seen[abs]:
+			out.WriteString("<!-- include cycle: " + raw + " -->\n")
+			continue
+		}
+
+		b, err := os.ReadFile(abs)
+		if err != nil {
+			out.WriteString("<!-- missing include: " + raw + " -->\n")
+			continue
+		}
+
+		seen[abs] = true
+		nested := expandIncludes(string(b), filepath.Dir(abs), depth+1, seen)
+		delete(seen, abs)
+
+		out.WriteString(strings.TrimRight(nested, "\n"))
+		out.WriteByte('\n')
+	}
+	return out.String()
+}
+
+// resolveIncludePath turns an @include target into a filesystem path: ~/… is
+// expanded against the home dir, absolute paths pass through, and everything
+// else is taken relative to baseDir (the including file's directory).
+func resolveIncludePath(raw, baseDir string) string {
+	if raw == "~" || strings.HasPrefix(raw, "~/") {
+		if home, err := os.UserHomeDir(); err == nil && home != "" {
+			return filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(raw, "~"), "/"))
+		}
+	}
+	if filepath.IsAbs(raw) {
+		return raw
+	}
+	return filepath.Join(baseDir, raw)
 }


### PR DESCRIPTION
## Summary
Adds a persistent, **cross-project user rules file** loaded into the system prompt every session — the global counterpart of the per-repo `.octorules`. This is C8 layer-1: a static instruction hierarchy (CLAUDE.md-style), distinct from C9's auto/typed memory.

Composition is now five layers, increasing specificity:
```
base → env → user(~/.octo/octorules.md) → project(.octorules) → --system
```
so project rules override the user's globals, and `--system` overrides everything. Empty layers are skipped.

### `@include`
Both the user and project files (recursively) support includes: a line beginning with `@` inlines another file, resolved as `~/…`, an absolute path, or relative to the including file's directory. Failures degrade to an inline marker instead of aborting the prompt:
- missing/unreadable → `<!-- missing include: PATH -->`
- cycle (file already in the ancestor chain) → `<!-- include cycle: PATH -->`
- past depth cap (5) → `<!-- include depth exceeded: PATH -->`

Cycle detection tracks the *ancestor chain* (added before recursing, removed after), so a **diamond** include — the same file via two sibling branches — is allowed, while a true cycle is broken.

Files load once at session start (frozen prompt), so the provider's system-prefix cache stays stable; edits take effect next session.

## Decisions (agreed up front)
- User file = `~/.octo/octorules.md` (symmetric with project `.octorules`).
- **No managed/org layer** this round (dropped by request; trivially addable later).
- Project stays cwd-only (no parent-dir walk).

## Validation
- **Live (Kimi k2.6)**: a `~/.octo/octorules.md` rule and its `@include`-d file both shaped the reply (two distinct marker tokens appeared).

## Test plan
- [x] user layer sits between env and project; labelled with its source path
- [x] absent user file adds no layer (no stray separators)
- [x] `@include`: relative inline, nested chain, missing-file marker, cycle broken, diamond allowed
- [x] existing layering/skip tests still pass
- [x] `make test` (race), `make vet`, `gofmt` clean

## Note
This is a power-user feature with no in-app discovery yet. Happy to add a short mention to `/help` or `docs/` in a follow-up if you want it surfaced.