### PR TITLE
feat(cmd): octo init / REPL /init to generate .octorules

### DIFF
--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/permission"
+	"github.com/Leihb/octo-agent/internal/prompt"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// initInstruction is the prompt that drives `.octorules` generation, shared by
+// the `octo init` subcommand and the REPL `/init` command. It tells the agent
+// to investigate the repo with its tools before writing, and to keep the
+// output terse — the file is loaded into the system prompt every session.
+const initInstruction = `Analyze this repository and create (or update) a ` + "`.octorules`" + ` file at its root to help an AI coding agent work here effectively.
+
+Investigate with your tools BEFORE writing:
+- List the top-level layout and the important directories.
+- Read the build/dependency manifests (go.mod, package.json, Makefile, etc.), the README, and any CI config.
+- Determine the language(s), how to build / test / run / lint, and the main entry points.
+- Note conventions that aren't obvious from a single file: architecture, naming, testing approach, branch/PR workflow.
+
+Then write ` + "`.octorules`" + ` with concise, factual content — short sections, real commands and real paths, no marketing or filler. If ` + "`.octorules`" + ` already exists, read it first and improve it rather than discarding useful content. Keep it tight: every line is sent to the model on every turn.`
+
+// runInit handles `octo init [flags]`: a one-shot agentic run that generates
+// or updates the project's .octorules. It mirrors chat's tool setup but is
+// non-interactive and exits when the file is written.
+func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	providerName := fs.String("provider", providerAnthropic, "Provider: anthropic | openai")
+	model := fs.String("model", "", "Model name (defaults to the provider's cheapest reasoning model)")
+	plain := fs.Bool("plain", false, "Render tool events as one-line ↳ status lines instead of rich diff cards")
+	permMode := fs.String("permission-mode", "strict", "Tool permission handling: interactive | strict")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *permMode != string(permission.ModeInteractive) && *permMode != string(permission.ModeStrict) {
+		fmt.Fprintf(stderr, "octo init: invalid --permission-mode %q (want 'interactive' or 'strict')\n", *permMode)
+		return 2
+	}
+
+	resolvedModel := *model
+	if resolvedModel == "" {
+		resolvedModel = defaultModels[*providerName]
+	}
+	if resolvedModel == "" {
+		fmt.Fprintf(stderr, "octo init: unknown provider %q (use 'anthropic' or 'openai')\n", *providerName)
+		return 2
+	}
+
+	prov, err := buildProvider(*providerName, stderr)
+	if err != nil {
+		return 1
+	}
+
+	cwd, _ := os.Getwd()
+	env := buildEnvContext(cwd)
+
+	a := agent.New(providerSender{p: prov, cacheKey: newCacheKey()}, resolvedModel)
+	a.System = prompt.Compose("", cwd, env)
+
+	engine, err := permission.New(permissionConfigPath(), cwd, resolvePermissionMode(*permMode))
+	if err != nil {
+		fmt.Fprintf(stderr, "octo init: permission config: %v\n", err)
+		return 1
+	}
+	a.Gate = &cliPermissionGate{engine: engine, in: bufio.NewScanner(stdin), out: stdout}
+
+	fmt.Fprintln(stdout, "Analyzing the repository to generate .octorules…")
+	handler := replToolEventHandler(stdout, *plain)
+	_, err = a.RunStream(context.Background(), initInstruction, tools.DefaultTools(), tools.NewDefaultRegistry(), handler)
+	tools.KillAllBackground()
+	fmt.Fprintln(stdout)
+	if err != nil {
+		fmt.Fprintf(stderr, "octo init: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -38,6 +38,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 0
 	case "chat":
 		return runChat(args[1:], stdin, stdout, stderr)
+	case "init":
+		return runInit(args[1:], stdin, stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "octo: unknown command %q\n", args[0])
 		fmt.Fprintln(stderr, "Run `octo help` for available commands.")
@@ -51,7 +53,8 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage: octo <command>")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Commands:")
-	fmt.Fprintln(w, "  chat       Send one message to Anthropic and print the reply")
+	fmt.Fprintln(w, "  chat       Start an interactive session (or single-turn with a message)")
+	fmt.Fprintln(w, "  init       Analyze the repo and generate/update .octorules")
 	fmt.Fprintln(w, "  version    Print the version and exit")
 	fmt.Fprintln(w, "  help       Print this help and exit")
 	fmt.Fprintln(w)

--- a/cmd/octo/main_test.go
+++ b/cmd/octo/main_test.go
@@ -35,6 +35,27 @@ func TestRun_Version(t *testing.T) {
 	}
 }
 
+func TestRun_Usage_ListsInit(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	run(nil, strings.NewReader(""), &stdout, &stderr)
+	if !strings.Contains(stdout.String(), "init") {
+		t.Errorf("usage should list the init command; got: %q", stdout.String())
+	}
+}
+
+func TestRunInit_InvalidPermissionMode(t *testing.T) {
+	// Validation happens before any provider/network work, so this is
+	// deterministic and offline.
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"init", "--permission-mode", "bogus"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "permission-mode") {
+		t.Errorf("stderr should explain the bad permission-mode; got: %q", stderr.String())
+	}
+}
+
 func TestRun_UnknownCommand(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"bogus"}, strings.NewReader(""), &stdout, &stderr)

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -120,8 +120,16 @@ func runREPL(cfg replConfig) int {
 			continue
 		}
 
-		// Slash commands.
-		if strings.HasPrefix(line, "/") {
+		// /init runs the .octorules generator as a normal tool-enabled turn —
+		// swap in the init prompt and fall through to the turn machinery.
+		if line == "/init" {
+			if len(cfg.tools) == 0 || cfg.executor == nil {
+				fmt.Fprintln(cfg.stdout, "/init needs tools — restart with: octo chat --tools")
+				continue
+			}
+			fmt.Fprintln(cfg.stdout, "Analyzing the repository to generate .octorules…")
+			line = initInstruction
+		} else if strings.HasPrefix(line, "/") {
 			cmd := strings.ToLower(strings.Fields(line)[0])
 			switch cmd {
 			case "/exit", "/quit":
@@ -221,6 +229,7 @@ func runREPL(cfg replConfig) int {
 func printReplHelp(w io.Writer) {
 	fmt.Fprintln(w, "Commands:")
 	fmt.Fprintln(w, "  /help       Show this message")
+	fmt.Fprintln(w, "  /init       Analyze the repo and generate/update .octorules (needs --tools)")
 	fmt.Fprintln(w, "  /cost       Show token usage and estimated cost for this session")
 	fmt.Fprintln(w, "  /save       Save the session now (it also auto-saves after each turn)")
 	fmt.Fprintln(w, "  /sessions   List the 10 most recent sessions")


### PR DESCRIPTION
## Summary
Answers "is there a command to auto-generate `.octorules`?" — there wasn't; now there is, in two forms (Claude Code `/init`-style).

A shared init prompt drives the existing agentic loop: the agent inspects the repo with its tools (`ls`/`glob`/`grep`/`read_file`), then writes a concise, factual `.octorules` via `write_file`.

- **`octo init`** — one-shot subcommand. Non-interactive; defaults to **strict** permission mode (writing `$CWD/.octorules` and the read-only tools are already default-allowed, so it runs without prompts). Flags: `--provider`, `--model`, `--permission-mode`, `--plain`.
- **REPL `/init`** — runs the same prompt as a normal tool-enabled turn, so it gets streaming, the inline tool-event UI, and Ctrl-C interrupt for free. Requires `--tools`; otherwise it tells you to restart with it.

If `.octorules` already exists, the prompt tells the agent to read it first and improve it (read-before-write is enforced regardless). `octo help` and `/help` both list it.

## Validation
- **Live (Kimi k2.6)**: `octo init` in a sample Go repo (go.mod + cmd/ + internal/ + Makefile + README) explored it (ls, glob for manifests, read go.mod/Makefile/README) and wrote an accurate `.octorules` — real module path, real layout (`cmd/widget/main.go`, `internal/store/`), real commands (`make build`, `go test ./...`), sensible conventions. A `find` command was denied under strict mode; the agent adapted to `glob` and still succeeded.

## Test plan
- [x] usage lists `init`
- [x] `octo init --permission-mode bogus` → exit 2 (offline validation)
- [x] existing cmd tests still pass
- [x] `make test` (race), `make vet`, `gofmt` clean

## Note
Independent of the open C8 PR (#79) — this writes the project `.octorules`, which predates C8. No overlap.