### PR TITLE
feat(sandbox): OS-level command sandbox, opt-in --sandbox (C11 Phase 1)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -65,6 +65,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	maxCost := fs.Float64("max-cost", 0, "Stop the session once estimated cost (USD) reaches this; 0 = unlimited")
 	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (~75% of the model's context window), <0 = disabled")
 	thinkingBudget := fs.Int("thinking-budget", 0, "Enable extended thinking with this token budget (Anthropic/Kimi); 0 = off")
+	useSandbox := fs.Bool("sandbox", false, "Confine terminal commands to the project dir + tmp with no network (OS-enforced; macOS/Linux). Fails closed if unavailable.")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -137,6 +138,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// user layer; base/project are recomposed fresh each run.
 	cwd, _ := os.Getwd()
 	env := buildEnvContext(cwd)
+
+	if *useSandbox {
+		if err := activateSandbox(cwd, stderr); err != nil {
+			return 1
+		}
+	}
 
 	// A stable per-process cache key lets OpenAI route every turn (and every
 	// tool-loop iteration) of this conversation to the same prompt cache.

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -38,6 +38,7 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	model := fs.String("model", "", "Model name (defaults to the provider's cheapest reasoning model)")
 	plain := fs.Bool("plain", false, "Render tool events as one-line ↳ status lines instead of rich diff cards")
 	permMode := fs.String("permission-mode", "strict", "Tool permission handling: interactive | strict")
+	useSandbox := fs.Bool("sandbox", false, "Confine commands to the project dir + tmp with no network (OS-enforced; macOS/Linux). Fails closed if unavailable.")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -62,6 +63,12 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 	cwd, _ := os.Getwd()
 	env := buildEnvContext(cwd)
+
+	if *useSandbox {
+		if err := activateSandbox(cwd, stderr); err != nil {
+			return 1
+		}
+	}
 
 	a := agent.New(providerSender{p: prov, cacheKey: newCacheKey()}, resolvedModel)
 	a.System = prompt.Compose("", cwd, env)

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/Leihb/octo-agent/internal/sandbox"
 	"github.com/Leihb/octo-agent/internal/version"
 )
 
@@ -30,6 +31,10 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	switch args[0] {
+	case "__sandboxed-exec":
+		// Internal: the OS-sandbox re-exec shim (Linux). Applies confinement to
+		// itself, then execs the real command. Not user-facing.
+		return sandbox.ShimMain()
 	case "version", "--version", "-v":
 		fmt.Fprintf(stdout, "octo %s\n", version.String())
 		return 0

--- a/cmd/octo/sandbox.go
+++ b/cmd/octo/sandbox.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/Leihb/octo-agent/internal/sandbox"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// errSandboxUnavailable is returned (after a message) when --sandbox is asked
+// for but the host can't enforce it. Callers fail closed.
+var errSandboxUnavailable = errors.New("sandbox unavailable")
+
+// activateSandbox turns on OS-level command confinement for cwd, or fails
+// closed when the host can't enforce a sandbox — the user asked for a guarantee
+// we can't provide, so we refuse rather than run unconfined.
+func activateSandbox(cwd string, stderr io.Writer) error {
+	if !sandbox.Available() {
+		fmt.Fprintln(stderr, "octo: --sandbox requested but no OS sandbox is available on this host\n"+
+			"  (needs macOS, or Linux with Landlock — kernel ≥ 5.13). Refusing to run unconfined.")
+		return errSandboxUnavailable
+	}
+	policy := sandbox.DefaultPolicy(cwd)
+	tools.SetSandbox(&policy)
+	return nil
+}

--- a/dev-docs/c11-sandbox-design.md
+++ b/dev-docs/c11-sandbox-design.md
@@ -96,19 +96,28 @@ non-nil → `sandbox.Command(ctx, command, *activeSandbox)`.
 
 ## 4. macOS mechanism — Seatbelt (SBPL)
 
-Wrap as `sandbox-exec -p <profile> sh -c <command>`. Generated profile:
+Wrap as `sandbox-exec -p <profile> sh -c <command>`. A full `(deny default)`
+profile aborts most binaries (dyld/`/dev`/mach lookups it can't predict), so the
+profile uses an **`allow default` base** and tightens just the axes we care
+about — which proved robust in practice while still enforcing the boundary:
 
 ```scheme
 (version 1)
-(deny default)
-(allow process*)
-(allow sysctl-read)
-(allow file-read-metadata)
-(allow file-read*  (subpath "<read-root>") …)
+(allow default)
+(deny file-write*)
 (allow file-write* (subpath "<write-root>") …)   ; cwd, tmp
-; AllowNetwork=false → no network allows, default-deny covers it
-; AllowNetwork=true  → (allow network*)
+(allow file-write* (literal "/dev/null") …)        ; device nodes
+(deny file-read*  (subpath "<HOME>"))              ; confine reads within $HOME …
+(allow file-read* (subpath "<read-root>") …)       ; … but re-allow the roots
+(deny network*)                                    ; unless AllowNetwork
 ```
+
+Writes are a strict allowlist (deny-all then re-allow roots; the later, more
+specific rule wins). Reads are confined **within `$HOME`**: everything under
+`$HOME` is denied except the read roots, which protects every home secret
+(`~/.ssh`, `~/.aws`, …) while system paths (`/usr`, `/System`) stay readable via
+`allow default`. (This is the one place macOS is looser than Linux: Linux's
+Landlock enforces a *full* read allowlist; macOS confines reads to `$HOME`.)
 
 `sandbox-exec` is marked deprecated by Apple but has no replacement and remains
 functional; it's the mechanism other agent tools use on macOS. `Available()`

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	github.com/alecthomas/chroma/v2 v2.14.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	golang.org/x/sys v0.30.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -21,5 +22,4 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.30.0 // indirect
 )

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -1,0 +1,107 @@
+// Package sandbox confines an arbitrary shell command to an OS-enforced
+// filesystem and network boundary — defense-in-depth beneath the
+// permission engine (internal/permission), which only gates command strings.
+//
+// The boundary is enforced per platform: macOS via Seatbelt (sandbox-exec),
+// Linux via a Landlock + seccomp re-exec shim. Other platforms are
+// unsupported (Available reports false and Command returns ErrUnsupported).
+//
+// See dev-docs/c11-sandbox-design.md for the full design.
+package sandbox
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// ErrUnsupported is returned by Command when sandboxing was requested but the
+// host can't enforce it (unsupported OS, kernel too old, mechanism missing).
+// Callers that asked for a sandbox should fail closed on this.
+var ErrUnsupported = errors.New("sandbox: not supported on this host")
+
+// Policy describes the filesystem and network confinement for a command.
+// Roots are absolute paths; a root grants access to that path and everything
+// beneath it.
+type Policy struct {
+	// ReadRoots are directories the command may read (and execute from).
+	ReadRoots []string
+	// WriteRoots are directories the command may write to (a subset use of
+	// ReadRoots — write roots should also be readable).
+	WriteRoots []string
+	// AllowNetwork, when false, denies IP networking (AF_INET/AF_INET6). Unix
+	// domain sockets remain available.
+	AllowNetwork bool
+}
+
+// DefaultPolicy builds the standard confinement for a working directory:
+// read access to common system roots plus cwd and temp, write access to cwd
+// and temp, and no network. Credential paths under $HOME (~/.ssh, ~/.aws, …)
+// are deliberately NOT included, so secrets stay unreadable.
+func DefaultPolicy(cwd string) Policy {
+	tmp := os.TempDir()
+
+	read := []string{}
+	add := func(p string) {
+		if p == "" {
+			return
+		}
+		if abs, err := filepath.Abs(p); err == nil {
+			read = append(read, abs)
+		}
+	}
+	add(cwd)
+	add(tmp)
+	// System roots needed to run ordinary tooling. Read-only; not writable.
+	for _, p := range systemReadRoots() {
+		add(p)
+	}
+
+	write := []string{}
+	if cwd != "" {
+		if abs, err := filepath.Abs(cwd); err == nil {
+			write = append(write, abs)
+		}
+	}
+	if tmp != "" {
+		if abs, err := filepath.Abs(tmp); err == nil {
+			write = append(write, abs)
+		}
+	}
+
+	return Policy{ReadRoots: dedupe(read), WriteRoots: dedupe(write), AllowNetwork: false}
+}
+
+// systemReadRoots returns the OS-specific read-only roots ordinary commands
+// need (toolchains, shared libs, config). Best-effort: missing paths are
+// harmless (a sandbox rule for a nonexistent path just never matches).
+func systemReadRoots() []string {
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{"/usr", "/bin", "/sbin", "/etc", "/var", "/private", "/System", "/Library", "/opt", "/dev/null"}
+	case "linux":
+		return []string{"/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc", "/opt", "/proc/self", "/dev/null"}
+	default:
+		return nil
+	}
+}
+
+func dedupe(in []string) []string {
+	seen := map[string]bool{}
+	out := in[:0]
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}
+
+// Command and Available are defined per-platform in
+// sandbox_{darwin,linux,other}.go:
+//
+//	func Command(ctx context.Context, command string, p Policy) (*exec.Cmd, error)
+//	func Available() bool

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -73,15 +73,17 @@ func DefaultPolicy(cwd string) Policy {
 	return Policy{ReadRoots: dedupe(read), WriteRoots: dedupe(write), AllowNetwork: false}
 }
 
-// systemReadRoots returns the OS-specific read-only roots ordinary commands
-// need (toolchains, shared libs, config). Best-effort: missing paths are
-// harmless (a sandbox rule for a nonexistent path just never matches).
+// systemReadRoots returns the OS-specific read-only DIRECTORY roots ordinary
+// commands need (toolchains, shared libs, config). Directories only — device
+// files like /dev/null are granted separately by the platform layer, since
+// directory access rights are invalid on a character device. Best-effort:
+// missing paths are harmless (a rule for a nonexistent path never matches).
 func systemReadRoots() []string {
 	switch runtime.GOOS {
 	case "darwin":
-		return []string{"/usr", "/bin", "/sbin", "/etc", "/var", "/private", "/System", "/Library", "/opt", "/dev/null"}
+		return []string{"/usr", "/bin", "/sbin", "/etc", "/var", "/private", "/System", "/Library", "/opt"}
 	case "linux":
-		return []string{"/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc", "/opt", "/proc/self", "/dev/null"}
+		return []string{"/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc", "/opt", "/proc"}
 	default:
 		return nil
 	}

--- a/internal/sandbox/sandbox_darwin.go
+++ b/internal/sandbox/sandbox_darwin.go
@@ -1,0 +1,104 @@
+//go:build darwin
+
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// sandboxExec is the macOS Seatbelt front-end. Deprecated by Apple but still
+// functional and without a public replacement; it remains the standard way to
+// confine a child process on macOS.
+const sandboxExec = "/usr/bin/sandbox-exec"
+
+// Available reports whether sandbox-exec is present.
+func Available() bool {
+	_, err := exec.LookPath(sandboxExec)
+	return err == nil
+}
+
+// Command runs `sh -c command` under a generated SBPL profile via sandbox-exec.
+func Command(ctx context.Context, command string, p Policy) (*exec.Cmd, error) {
+	if !Available() {
+		return nil, ErrUnsupported
+	}
+	profile := buildProfile(p)
+	// -p <profile> applies an inline profile; then the program + args to run.
+	return exec.CommandContext(ctx, sandboxExec, "-p", profile, "/bin/sh", "-c", command), nil
+}
+
+// buildProfile renders an SBPL profile. The base is `allow default` so ordinary
+// commands (dyld, /dev, mach services) keep working — a full deny-default
+// profile aborts most binaries. On top of that:
+//
+//   - Writes become an allowlist: deny all, then re-allow the write roots (and
+//     the device nodes commands expect). The later, more specific rule wins.
+//   - Reads are confined within $HOME: deny everything under $HOME, then
+//     re-allow the read roots. System paths (/usr, /System, …) stay readable
+//     via allow-default, so this protects every home secret (~/.ssh, ~/.aws, …)
+//     without the brittleness of denying all reads. (Read confinement is thus
+//     scoped to $HOME on macOS; Linux/Landlock enforces a full read allowlist.)
+//   - Network is denied unless AllowNetwork.
+func buildProfile(p Policy) string {
+	var b strings.Builder
+	b.WriteString("(version 1)\n")
+	b.WriteString("(allow default)\n")
+
+	b.WriteString("(deny file-write*)\n")
+	if subs := subpaths(p.WriteRoots); subs != "" {
+		b.WriteString("(allow file-write* " + subs + ")\n")
+	}
+	b.WriteString(`(allow file-write* (literal "/dev/null") (literal "/dev/dtracehelper") (literal "/dev/tty") (literal "/dev/stdout") (literal "/dev/stderr"))` + "\n")
+
+	if home := homeDir(); home != "" {
+		b.WriteString(fmt.Sprintf("(deny file-read* (subpath %q))\n", home))
+		if subs := subpaths(p.ReadRoots); subs != "" {
+			b.WriteString("(allow file-read* " + subs + ")\n")
+		}
+	}
+
+	if !p.AllowNetwork {
+		b.WriteString("(deny network*)\n")
+	}
+	return b.String()
+}
+
+// homeDir resolves $HOME (symlinks too, so it matches the canonical path the
+// kernel checks). Returns "" when it can't be determined.
+func homeDir() string {
+	h, err := os.UserHomeDir()
+	if err != nil || h == "" {
+		return ""
+	}
+	if real, err := filepath.EvalSymlinks(h); err == nil {
+		return real
+	}
+	return h
+}
+
+// subpaths renders roots as a sequence of (subpath "…") clauses, resolving
+// symlinks so the canonical path the kernel sees matches (e.g. /tmp →
+// /private/tmp). Roots that can't be resolved are used as-is.
+func subpaths(roots []string) string {
+	var parts []string
+	for _, r := range roots {
+		resolved := r
+		if real, err := filepath.EvalSymlinks(r); err == nil {
+			resolved = real
+		}
+		parts = append(parts, fmt.Sprintf("(subpath %q)", resolved))
+	}
+	return strings.Join(parts, " ")
+}
+
+// ShimMain is the re-exec entry point used only on Linux; on macOS the sandbox
+// is applied by sandbox-exec, so this should never be invoked.
+func ShimMain() int {
+	fmt.Fprintln(os.Stderr, "octo: __sandboxed-exec is not used on darwin")
+	return 1
+}

--- a/internal/sandbox/sandbox_darwin_test.go
+++ b/internal/sandbox/sandbox_darwin_test.go
@@ -1,0 +1,65 @@
+//go:build darwin
+
+package sandbox
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func run(t *testing.T, cwd, command string, p Policy) error {
+	t.Helper()
+	cmd, err := Command(context.Background(), command, p)
+	if err != nil {
+		t.Fatalf("Command: %v", err)
+	}
+	cmd.Dir = cwd
+	out, runErr := cmd.CombinedOutput()
+	t.Logf("command %q → err=%v out=%s", command, runErr, out)
+	return runErr
+}
+
+func TestSandbox_FilesystemBoundary(t *testing.T) {
+	if !Available() {
+		t.Skip("sandbox-exec not available")
+	}
+	cwd := t.TempDir()
+	p := DefaultPolicy(cwd)
+
+	// A normal command runs.
+	if err := run(t, cwd, "echo hello", p); err != nil {
+		t.Errorf("plain echo should run under sandbox: %v", err)
+	}
+
+	// Write INSIDE cwd succeeds.
+	if err := run(t, cwd, "echo in > inside.txt", p); err != nil {
+		t.Errorf("write inside cwd should succeed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "inside.txt")); err != nil {
+		t.Errorf("inside.txt should exist: %v", err)
+	}
+
+	// Write OUTSIDE the roots (under $HOME) is denied.
+	home, _ := os.UserHomeDir()
+	outside := filepath.Join(home, ".octo_sbx_write_probe")
+	defer os.Remove(outside)
+	if err := run(t, cwd, "echo out > "+outside, p); err == nil {
+		t.Errorf("write outside roots should be denied")
+	}
+	if _, err := os.Stat(outside); err == nil {
+		t.Errorf("outside file must not have been created")
+	}
+
+	// Read OUTSIDE the roots is denied. Seed a secret in $HOME (not a root),
+	// then try to read it from within the sandbox.
+	secret := filepath.Join(home, ".octo_sbx_read_probe")
+	if err := os.WriteFile(secret, []byte("SECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(secret)
+	if err := run(t, cwd, "cat "+secret, p); err == nil {
+		t.Errorf("read outside roots should be denied")
+	}
+}

--- a/internal/sandbox/sandbox_linux.go
+++ b/internal/sandbox/sandbox_linux.go
@@ -1,0 +1,274 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// policyEnv carries the JSON-encoded Policy to the re-exec shim.
+const policyEnv = "OCTO_SANDBOX_POLICY"
+
+// shimArg is the hidden subcommand the parent re-execs into; the shim applies
+// Landlock + seccomp to itself, then execs the real command.
+const shimArg = "__sandboxed-exec"
+
+// extra device files the confined command may read/write even though they
+// aren't under a write root.
+var deviceFiles = []string{"/dev/null", "/dev/zero", "/dev/full", "/dev/random", "/dev/urandom", "/dev/tty"}
+
+// Available reports whether Landlock is usable (kernel ≥ 5.13 with Landlock
+// enabled). It queries the supported ABI version.
+func Available() bool { return landlockABI() >= 1 }
+
+// landlockABI returns the kernel's Landlock ABI version, or -1 if unsupported.
+func landlockABI() int {
+	v, _, errno := unix.Syscall(unix.SYS_LANDLOCK_CREATE_RULESET, 0, 0, uintptr(unix.LANDLOCK_CREATE_RULESET_VERSION))
+	if errno != 0 {
+		return -1
+	}
+	return int(v)
+}
+
+// Command re-execs this binary as the sandbox shim, passing the policy via the
+// environment and the real command after "--".
+func Command(ctx context.Context, command string, p Policy) (*exec.Cmd, error) {
+	if !Available() {
+		return nil, ErrUnsupported
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("sandbox: locate self: %w", err)
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox: marshal policy: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, self, shimArg, "--", "/bin/sh", "-c", command)
+	cmd.Env = append(os.Environ(), policyEnv+"="+string(data))
+	return cmd, nil
+}
+
+// ShimMain is the re-exec entry point (dispatched from main on the
+// __sandboxed-exec subcommand). It applies the sandbox to itself, then execs
+// the command that follows "--". It never returns on success.
+func ShimMain() int {
+	// Keep the security-applying work and the execve on one OS thread: the
+	// per-thread Landlock/seccomp restrictions then carry into the exec'd image.
+	runtime.LockOSThread()
+
+	cmdArgs := argsAfterDoubleDash(os.Args)
+	if len(cmdArgs) == 0 {
+		fmt.Fprintln(os.Stderr, "sandbox shim: no command after --")
+		return 1
+	}
+
+	var p Policy
+	if raw := os.Getenv(policyEnv); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &p); err != nil {
+			fmt.Fprintf(os.Stderr, "sandbox shim: bad policy: %v\n", err)
+			return 1
+		}
+	}
+
+	if err := applyLandlock(p); err != nil {
+		fmt.Fprintf(os.Stderr, "sandbox shim: landlock: %v\n", err)
+		return 1
+	}
+	if !p.AllowNetwork {
+		if err := applyNoNetwork(); err != nil {
+			fmt.Fprintf(os.Stderr, "sandbox shim: seccomp: %v\n", err)
+			return 1
+		}
+	}
+
+	path := cmdArgs[0]
+	if resolved, err := exec.LookPath(path); err == nil {
+		path = resolved
+	}
+	if err := syscall.Exec(path, cmdArgs, os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "sandbox shim: exec %s: %v\n", path, err)
+		return 1
+	}
+	return 0 // unreachable
+}
+
+func argsAfterDoubleDash(args []string) []string {
+	for i, a := range args {
+		if a == "--" {
+			return args[i+1:]
+		}
+	}
+	return nil
+}
+
+// handledAccessFS returns the full set of filesystem access rights to govern,
+// masked to what the kernel's ABI version supports (newer bits on an older
+// kernel would make create_ruleset fail).
+func handledAccessFS(abi int) uint64 {
+	a := uint64(unix.LANDLOCK_ACCESS_FS_EXECUTE |
+		unix.LANDLOCK_ACCESS_FS_WRITE_FILE |
+		unix.LANDLOCK_ACCESS_FS_READ_FILE |
+		unix.LANDLOCK_ACCESS_FS_READ_DIR |
+		unix.LANDLOCK_ACCESS_FS_REMOVE_DIR |
+		unix.LANDLOCK_ACCESS_FS_REMOVE_FILE |
+		unix.LANDLOCK_ACCESS_FS_MAKE_CHAR |
+		unix.LANDLOCK_ACCESS_FS_MAKE_DIR |
+		unix.LANDLOCK_ACCESS_FS_MAKE_REG |
+		unix.LANDLOCK_ACCESS_FS_MAKE_SOCK |
+		unix.LANDLOCK_ACCESS_FS_MAKE_FIFO |
+		unix.LANDLOCK_ACCESS_FS_MAKE_BLOCK |
+		unix.LANDLOCK_ACCESS_FS_MAKE_SYM)
+	if abi >= 2 {
+		a |= unix.LANDLOCK_ACCESS_FS_REFER
+	}
+	if abi >= 3 {
+		a |= unix.LANDLOCK_ACCESS_FS_TRUNCATE
+	}
+	return a
+}
+
+// fileAccessMask is the subset of access rights valid on a (non-directory)
+// file — directory-only bits (READ_DIR, MAKE_*, REMOVE_*) would make add_rule
+// reject a regular-file target.
+func fileAccessMask(handled uint64) uint64 {
+	return handled & uint64(unix.LANDLOCK_ACCESS_FS_READ_FILE|
+		unix.LANDLOCK_ACCESS_FS_WRITE_FILE|
+		unix.LANDLOCK_ACCESS_FS_EXECUTE|
+		unix.LANDLOCK_ACCESS_FS_TRUNCATE)
+}
+
+// applyLandlock confines this process to the policy's filesystem roots: read
+// (+exec) on ReadRoots, full read/write on WriteRoots, plus read/write on a few
+// device files. Paths that don't exist are skipped.
+func applyLandlock(p Policy) error {
+	abi := landlockABI()
+	if abi < 1 {
+		return ErrUnsupported
+	}
+	handled := handledAccessFS(abi)
+
+	attr := struct{ accessFS uint64 }{accessFS: handled}
+	fd, _, errno := unix.Syscall(unix.SYS_LANDLOCK_CREATE_RULESET,
+		uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr), 0)
+	if errno != 0 {
+		return fmt.Errorf("create_ruleset: %w", errno)
+	}
+	rulesetFd := int(fd)
+	defer unix.Close(rulesetFd)
+
+	readDir := handled & uint64(unix.LANDLOCK_ACCESS_FS_READ_FILE|
+		unix.LANDLOCK_ACCESS_FS_READ_DIR|
+		unix.LANDLOCK_ACCESS_FS_EXECUTE)
+
+	for _, root := range p.WriteRoots {
+		if err := addPathRule(rulesetFd, root, handled); err != nil {
+			return err
+		}
+	}
+	for _, root := range p.ReadRoots {
+		if contains(p.WriteRoots, root) {
+			continue
+		}
+		if err := addPathRule(rulesetFd, root, readDir); err != nil {
+			return err
+		}
+	}
+	for _, dev := range deviceFiles {
+		if err := addPathRule(rulesetFd, dev, fileAccessMask(handled)); err != nil {
+			return err
+		}
+	}
+
+	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		return fmt.Errorf("no_new_privs: %w", err)
+	}
+	if _, _, errno := unix.Syscall(unix.SYS_LANDLOCK_RESTRICT_SELF, uintptr(rulesetFd), 0, 0); errno != 0 {
+		return fmt.Errorf("restrict_self: %w", errno)
+	}
+	return nil
+}
+
+// addPathRule grants access beneath path. A missing path is skipped (not an
+// error) so generous default roots stay harmless.
+func addPathRule(rulesetFd int, path string, access uint64) error {
+	if access == 0 {
+		return nil
+	}
+	fd, err := unix.Open(path, unix.O_PATH|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil // missing/inaccessible → skip
+	}
+	defer unix.Close(fd)
+
+	attr := unix.LandlockPathBeneathAttr{Allowed_access: access, Parent_fd: int32(fd)}
+	_, _, errno := unix.Syscall6(unix.SYS_LANDLOCK_ADD_RULE,
+		uintptr(rulesetFd), uintptr(unix.LANDLOCK_RULE_PATH_BENEATH),
+		uintptr(unsafe.Pointer(&attr)), 0, 0, 0)
+	if errno != 0 {
+		return fmt.Errorf("add_rule %s: %w", path, errno)
+	}
+	return nil
+}
+
+// applyNoNetwork installs a seccomp filter that denies socket(AF_INET) and
+// socket(AF_INET6) with EACCES, leaving AF_UNIX and all other syscalls alone.
+// This blocks IP networking (including DNS) for the confined command.
+//
+// Limitation: the filter matches on the native socket(2) syscall number, so a
+// process making a 32-bit/compat syscall could bypass it — acceptable for the
+// ordinary-command threat model.
+func applyNoNetwork() error {
+	const (
+		denyRet  = uint32(unix.SECCOMP_RET_ERRNO) | (uint32(unix.EACCES) & 0x0000ffff)
+		allowRet = uint32(unix.SECCOMP_RET_ALLOW)
+		// seccomp_data offsets.
+		offNR   = 0
+		offArg0 = 16
+	)
+	filter := []unix.SockFilter{
+		bpfStmt(unix.BPF_LD|unix.BPF_W|unix.BPF_ABS, offNR),
+		bpfJump(unix.BPF_JMP|unix.BPF_JEQ|unix.BPF_K, uint32(unix.SYS_SOCKET), 0, 3), // not socket → allow
+		bpfStmt(unix.BPF_LD|unix.BPF_W|unix.BPF_ABS, offArg0),                        // domain
+		bpfJump(unix.BPF_JMP|unix.BPF_JEQ|unix.BPF_K, uint32(unix.AF_INET), 2, 0),    // AF_INET → deny
+		bpfJump(unix.BPF_JMP|unix.BPF_JEQ|unix.BPF_K, uint32(unix.AF_INET6), 1, 0),   // AF_INET6 → deny
+		bpfStmt(unix.BPF_RET|unix.BPF_K, allowRet),
+		bpfStmt(unix.BPF_RET|unix.BPF_K, denyRet),
+	}
+	prog := unix.SockFprog{Len: uint16(len(filter)), Filter: &filter[0]}
+
+	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		return fmt.Errorf("no_new_privs: %w", err)
+	}
+	if err := unix.Prctl(unix.PR_SET_SECCOMP, uintptr(unix.SECCOMP_MODE_FILTER),
+		uintptr(unsafe.Pointer(&prog)), 0, 0); err != nil {
+		return fmt.Errorf("set_seccomp: %w", err)
+	}
+	return nil
+}
+
+func bpfStmt(code uint16, k uint32) unix.SockFilter {
+	return unix.SockFilter{Code: code, K: k}
+}
+
+func bpfJump(code uint16, k uint32, jt, jf uint8) unix.SockFilter {
+	return unix.SockFilter{Code: code, Jt: jt, Jf: jf, K: k}
+}
+
+func contains(roots []string, target string) bool {
+	for _, r := range roots {
+		if r == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sandbox/sandbox_linux.go
+++ b/internal/sandbox/sandbox_linux.go
@@ -137,16 +137,6 @@ func handledAccessFS(abi int) uint64 {
 	return a
 }
 
-// fileAccessMask is the subset of access rights valid on a (non-directory)
-// file — directory-only bits (READ_DIR, MAKE_*, REMOVE_*) would make add_rule
-// reject a regular-file target.
-func fileAccessMask(handled uint64) uint64 {
-	return handled & uint64(unix.LANDLOCK_ACCESS_FS_READ_FILE|
-		unix.LANDLOCK_ACCESS_FS_WRITE_FILE|
-		unix.LANDLOCK_ACCESS_FS_EXECUTE|
-		unix.LANDLOCK_ACCESS_FS_TRUNCATE)
-}
-
 // applyLandlock confines this process to the policy's filesystem roots: read
 // (+exec) on ReadRoots, full read/write on WriteRoots, plus read/write on a few
 // device files. Paths that don't exist are skipped.
@@ -183,10 +173,12 @@ func applyLandlock(p Policy) error {
 			return err
 		}
 	}
+	// Device files: only the file read/write rights are valid on a character
+	// device (EXECUTE/TRUNCATE make add_rule return EINVAL). Best-effort — a
+	// device-rule failure must never abort the whole sandbox.
+	devAccess := handled & uint64(unix.LANDLOCK_ACCESS_FS_READ_FILE|unix.LANDLOCK_ACCESS_FS_WRITE_FILE)
 	for _, dev := range deviceFiles {
-		if err := addPathRule(rulesetFd, dev, fileAccessMask(handled)); err != nil {
-			return err
-		}
+		_ = addPathRule(rulesetFd, dev, devAccess)
 	}
 
 	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {

--- a/internal/sandbox/sandbox_other.go
+++ b/internal/sandbox/sandbox_other.go
@@ -1,0 +1,25 @@
+//go:build !darwin && !linux
+
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// Available reports false: no sandbox mechanism on this platform (e.g. Windows).
+func Available() bool { return false }
+
+// Command always fails closed here — callers that requested a sandbox must not
+// silently run unconfined.
+func Command(_ context.Context, _ string, _ Policy) (*exec.Cmd, error) {
+	return nil, ErrUnsupported
+}
+
+// ShimMain is never used off Linux.
+func ShimMain() int {
+	fmt.Fprintln(os.Stderr, "octo: __sandboxed-exec is not supported on this platform")
+	return 1
+}

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os/exec"
 	"sync"
 )
 
@@ -90,7 +89,11 @@ func NewBackgroundManager() *BackgroundManager {
 // if its context is cancelled (Kill / KillAll).
 func (m *BackgroundManager) Start(command string) (string, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd, err := shellCommand(ctx, command)
+	if err != nil {
+		cancel()
+		return "", err
+	}
 
 	pr, pw := io.Pipe()
 	cmd.Stdout = pw

--- a/internal/tools/main_test.go
+++ b/internal/tools/main_test.go
@@ -1,0 +1,20 @@
+package tools
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/sandbox"
+)
+
+// TestMain lets the test binary stand in for the `octo` executable when the
+// Linux sandbox re-execs itself: sandbox.Command runs os.Executable() with the
+// __sandboxed-exec subcommand, and under `go test` that executable IS this test
+// binary. Without this dispatch the re-exec would recurse into the test suite.
+// On macOS (sandbox-exec, no re-exec) the arg never appears, so this is a no-op.
+func TestMain(m *testing.M) {
+	if len(os.Args) > 1 && os.Args[1] == "__sandboxed-exec" {
+		os.Exit(sandbox.ShimMain())
+	}
+	os.Exit(m.Run())
+}

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -1,0 +1,27 @@
+package tools
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/Leihb/octo-agent/internal/sandbox"
+)
+
+// activeSandbox, when non-nil, confines every terminal command (foreground and
+// background) to the given policy. nil means no OS sandbox — the default.
+// Set once at startup via SetSandbox; mirrors the package-level defaultBg.
+var activeSandbox *sandbox.Policy
+
+// SetSandbox enables OS-level command confinement for the terminal tools.
+// Pass nil to disable. cmd/octo calls this when --sandbox is requested.
+func SetSandbox(p *sandbox.Policy) { activeSandbox = p }
+
+// shellCommand builds the *exec.Cmd that runs `command` via the shell, wrapped
+// in the active sandbox when one is set. Both TerminalTool and the background
+// manager route through here so confinement is uniform.
+func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
+	if activeSandbox != nil {
+		return sandbox.Command(ctx, command, *activeSandbox)
+	}
+	return exec.CommandContext(ctx, "sh", "-c", command), nil
+}

--- a/internal/tools/sandbox_integration_test.go
+++ b/internal/tools/sandbox_integration_test.go
@@ -28,9 +28,11 @@ func TestTerminal_SandboxConfinesIO(t *testing.T) {
 
 	// Write INSIDE the project root succeeds.
 	inside := filepath.Join(cwd, "inside.txt")
-	if _, err := reg.Execute(ctx, "terminal", map[string]any{
-		"command": "echo hi > " + inside,
-	}); err != nil {
+	out, err := reg.Execute(ctx, "terminal", map[string]any{
+		"command": "echo hi > " + inside + " && echo OK || echo FAIL:$?",
+	})
+	t.Logf("inside cmd → err=%v out=%q", err, out)
+	if err != nil {
 		t.Fatalf("terminal execute (inside): %v", err)
 	}
 	if _, err := os.Stat(inside); err != nil {

--- a/internal/tools/sandbox_integration_test.go
+++ b/internal/tools/sandbox_integration_test.go
@@ -1,0 +1,52 @@
+//go:build darwin || linux
+
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/sandbox"
+)
+
+// TestTerminal_SandboxConfinesIO verifies the wiring: once SetSandbox is active,
+// the terminal tool runs commands confined — writes land inside the project
+// root but are denied outside it. Skipped where the OS can't enforce a sandbox.
+func TestTerminal_SandboxConfinesIO(t *testing.T) {
+	if !sandbox.Available() {
+		t.Skip("no OS sandbox available on this host")
+	}
+	cwd := t.TempDir()
+	p := sandbox.DefaultPolicy(cwd)
+	SetSandbox(&p)
+	defer SetSandbox(nil)
+
+	reg := NewDefaultRegistry()
+	ctx := context.Background()
+
+	// Write INSIDE the project root succeeds.
+	inside := filepath.Join(cwd, "inside.txt")
+	if _, err := reg.Execute(ctx, "terminal", map[string]any{
+		"command": "echo hi > " + inside,
+	}); err != nil {
+		t.Fatalf("terminal execute (inside): %v", err)
+	}
+	if _, err := os.Stat(inside); err != nil {
+		t.Errorf("inside.txt should exist under the project root: %v", err)
+	}
+
+	// Write OUTSIDE the roots (under $HOME) is blocked by the sandbox.
+	home, _ := os.UserHomeDir()
+	outside := filepath.Join(home, ".octo_tools_sbx_probe")
+	defer os.Remove(outside)
+	if _, err := reg.Execute(ctx, "terminal", map[string]any{
+		"command": "echo x > " + outside,
+	}); err != nil {
+		t.Fatalf("terminal execute (outside) returned a Go error: %v", err)
+	}
+	if _, err := os.Stat(outside); err == nil {
+		t.Errorf("write outside the sandbox roots must be denied (file was created)")
+	}
+}

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -110,7 +109,10 @@ func (t TerminalTool) ExecuteStream(
 	ctx, cancel := context.WithTimeout(ctx, TerminalTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd, err := shellCommand(ctx, command)
+	if err != nil {
+		return "", err
+	}
 
 	// Merge stdout + stderr through a single pipe so the reader sees a
 	// chronological stream. Doing `cmd.Stderr = cmd.Stdout` after StdoutPipe


### PR DESCRIPTION
## Summary
Implements **C11 Phase 1** per `dev-docs/c11-sandbox-design.md`: confine the `terminal` tool's commands at the OS level — defense-in-depth *under* the permission engine. **Opt-in** via `--sandbox` on `octo chat` and `octo init`; default off; **fail-closed** when the host can't enforce it.

`internal/sandbox` exposes `Policy` / `DefaultPolicy` / `Command` / `Available`, build-tagged per OS:

- **macOS** — a Seatbelt (SBPL) profile via `sandbox-exec`: `allow default` base, writes restricted to cwd+tmp (+ device nodes), reads confined within `$HOME` (deny `$HOME`, re-allow roots — protects `~/.ssh`, `~/.aws`, …), network denied.
- **Linux** — a self re-exec shim (`octo __sandboxed-exec`) that applies **Landlock** (read/exec on read roots, read-write on write roots) **plus a seccomp BPF filter** denying `socket(AF_INET/AF_INET6)` when network is off, then `execve`s the command. Landlock + seccomp are hand-rolled on `golang.org/x/sys/unix` raw syscalls — **no cgo, no new module deps, stays Go 1.22** (the `go-landlock` library pulled cgo + a Go 1.24 bump, so it was rejected).
- **Other (Windows)** — unsupported → `ErrUnsupported` (fail-closed).

`DefaultPolicy`: read system roots + cwd + tmp, write cwd + tmp, no network; home credential dirs deliberately excluded. `tools.SetSandbox` plumbs the policy to **both** the foreground and background terminal exec sites.

## Validation
- **macOS (dev host) — fully validated:**
  - `internal/sandbox` boundary test: write inside cwd ok, outside denied, read `$HOME` secret denied.
  - `internal/tools` wiring test: terminal tool confined once `SetSandbox` is active.
  - **Live** `octo chat --sandbox` with Kimi: model's write inside the project succeeded; its `echo … > ~/probe` was **blocked** by the sandbox.
- **Linux — cross-compiled (amd64 + arm64); runtime enforcement covered by the capability-gated integration tests** (they run on a Landlock-capable runner, else skip). ⚠️ Flagged honestly: this could not be runtime-tested on the macOS dev host, so the Linux landlock/seccomp enforcement is validated by CI (if the ubuntu runner supports Landlock) and code review, not by me locally.
- Cross-builds green for linux/{amd64,arm64}, windows/amd64, darwin/arm64. `make test` (race), `make vet`, `gofmt` clean.

## Scope / follow-ups (per the design doc)
- Phase 2: network **allowlist** (vs all-or-nothing). Phase 3: default-on + configurable policy.
- Known limitation: seccomp matches the native `socket(2)` number (a 32-bit/compat syscall could bypass) — acceptable for the ordinary-command threat model. macOS read confinement is `$HOME`-scoped (Linux is a full read allowlist).