### PR TITLE
feat(sandbox): configurable policy — extra roots + network toggle (C11 Phase 3)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -66,6 +66,10 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (~75% of the model's context window), <0 = disabled")
 	thinkingBudget := fs.Int("thinking-budget", 0, "Enable extended thinking with this token budget (Anthropic/Kimi); 0 = off")
 	useSandbox := fs.Bool("sandbox", false, "Confine terminal commands to the project dir + tmp with no network (OS-enforced; macOS/Linux). Fails closed if unavailable.")
+	sandboxAllowNet := fs.Bool("sandbox-allow-net", false, "Under --sandbox, permit network access (default: denied)")
+	var sandboxWrite, sandboxRead stringList
+	fs.Var(&sandboxWrite, "sandbox-write", "Under --sandbox, an extra writable directory (repeatable)")
+	fs.Var(&sandboxRead, "sandbox-read", "Under --sandbox, an extra read-only directory (repeatable)")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -140,7 +144,8 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	env := buildEnvContext(cwd)
 
 	if *useSandbox {
-		if err := activateSandbox(cwd, stderr); err != nil {
+		opts := sandboxOpts{allowNet: *sandboxAllowNet, writeRoots: sandboxWrite, readRoots: sandboxRead}
+		if err := activateSandbox(cwd, opts, stderr); err != nil {
 			return 1
 		}
 	}

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -39,6 +39,10 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	plain := fs.Bool("plain", false, "Render tool events as one-line ↳ status lines instead of rich diff cards")
 	permMode := fs.String("permission-mode", "strict", "Tool permission handling: interactive | strict")
 	useSandbox := fs.Bool("sandbox", false, "Confine commands to the project dir + tmp with no network (OS-enforced; macOS/Linux). Fails closed if unavailable.")
+	sandboxAllowNet := fs.Bool("sandbox-allow-net", false, "Under --sandbox, permit network access (default: denied)")
+	var sandboxWrite, sandboxRead stringList
+	fs.Var(&sandboxWrite, "sandbox-write", "Under --sandbox, an extra writable directory (repeatable)")
+	fs.Var(&sandboxRead, "sandbox-read", "Under --sandbox, an extra read-only directory (repeatable)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -65,7 +69,8 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	env := buildEnvContext(cwd)
 
 	if *useSandbox {
-		if err := activateSandbox(cwd, stderr); err != nil {
+		opts := sandboxOpts{allowNet: *sandboxAllowNet, writeRoots: sandboxWrite, readRoots: sandboxRead}
+		if err := activateSandbox(cwd, opts, stderr); err != nil {
 			return 1
 		}
 	}

--- a/cmd/octo/sandbox.go
+++ b/cmd/octo/sandbox.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 
 	"github.com/Leihb/octo-agent/internal/sandbox"
 	"github.com/Leihb/octo-agent/internal/tools"
@@ -13,16 +15,45 @@ import (
 // for but the host can't enforce it. Callers fail closed.
 var errSandboxUnavailable = errors.New("sandbox unavailable")
 
-// activateSandbox turns on OS-level command confinement for cwd, or fails
-// closed when the host can't enforce a sandbox — the user asked for a guarantee
-// we can't provide, so we refuse rather than run unconfined.
-func activateSandbox(cwd string, stderr io.Writer) error {
+// stringList is a repeatable string flag: each --flag value appends one entry.
+type stringList []string
+
+func (s *stringList) String() string { return strings.Join(*s, ",") }
+func (s *stringList) Set(v string) error {
+	*s = append(*s, v)
+	return nil
+}
+
+// sandboxOpts carries the user's --sandbox-* tuning on top of the default
+// policy.
+type sandboxOpts struct {
+	allowNet   bool
+	writeRoots []string // extra writable (and thus readable) dirs
+	readRoots  []string // extra read-only dirs
+}
+
+// activateSandbox turns on OS-level command confinement for cwd, extended by
+// opts, or fails closed when the host can't enforce a sandbox — the user asked
+// for a guarantee we can't provide, so we refuse rather than run unconfined.
+func activateSandbox(cwd string, opts sandboxOpts, stderr io.Writer) error {
 	if !sandbox.Available() {
 		fmt.Fprintln(stderr, "octo: --sandbox requested but no OS sandbox is available on this host\n"+
 			"  (needs macOS, or Linux with Landlock — kernel ≥ 5.13). Refusing to run unconfined.")
 		return errSandboxUnavailable
 	}
-	policy := sandbox.DefaultPolicy(cwd)
-	tools.SetSandbox(&policy)
+	p := sandbox.DefaultPolicy(cwd)
+	p.AllowNetwork = opts.allowNet
+	for _, d := range opts.writeRoots {
+		if abs, err := filepath.Abs(d); err == nil {
+			p.WriteRoots = append(p.WriteRoots, abs)
+			p.ReadRoots = append(p.ReadRoots, abs) // writable implies readable
+		}
+	}
+	for _, d := range opts.readRoots {
+		if abs, err := filepath.Abs(d); err == nil {
+			p.ReadRoots = append(p.ReadRoots, abs)
+		}
+	}
+	tools.SetSandbox(&p)
 	return nil
 }

--- a/cmd/octo/sandbox_test.go
+++ b/cmd/octo/sandbox_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func TestStringList_Repeatable(t *testing.T) {
+	var s stringList
+	for _, v := range []string{"/a", "/b", "/c"} {
+		if err := s.Set(v); err != nil {
+			t.Fatalf("Set(%q): %v", v, err)
+		}
+	}
+	if len(s) != 3 || s[0] != "/a" || s[2] != "/c" {
+		t.Errorf("stringList = %v, want [/a /b /c]", s)
+	}
+	if got := s.String(); got != "/a,/b,/c" {
+		t.Errorf("String() = %q, want /a,/b,/c", got)
+	}
+}

--- a/internal/sandbox/sandbox_darwin_test.go
+++ b/internal/sandbox/sandbox_darwin_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -19,6 +20,29 @@ func run(t *testing.T, cwd, command string, p Policy) error {
 	out, runErr := cmd.CombinedOutput()
 	t.Logf("command %q → err=%v out=%s", command, runErr, out)
 	return runErr
+}
+
+func TestBuildProfile_NetworkToggle(t *testing.T) {
+	if got := buildProfile(Policy{}); !strings.Contains(got, "(deny network*)") {
+		t.Errorf("AllowNetwork=false profile should deny network:\n%s", got)
+	}
+	if got := buildProfile(Policy{AllowNetwork: true}); strings.Contains(got, "(deny network*)") {
+		t.Errorf("AllowNetwork=true profile should NOT deny network:\n%s", got)
+	}
+}
+
+func TestBuildProfile_IncludesConfiguredRoots(t *testing.T) {
+	p := Policy{
+		WriteRoots: []string{"/srv/extra-write"},
+		ReadRoots:  []string{"/srv/extra-read"},
+	}
+	got := buildProfile(p)
+	if !strings.Contains(got, "/srv/extra-write") {
+		t.Errorf("profile should grant the configured write root:\n%s", got)
+	}
+	if !strings.Contains(got, "/srv/extra-read") {
+		t.Errorf("profile should grant the configured read root:\n%s", got)
+	}
 }
 
 func TestSandbox_FilesystemBoundary(t *testing.T) {


### PR DESCRIPTION
## Summary
C11 **Phase 3** (configurable policy). Adds to `octo chat` and `octo init`:
- `--sandbox-allow-net` — permit network under `--sandbox` (default: denied).
- `--sandbox-write <dir>` (repeatable) — an extra writable (and readable) root.
- `--sandbox-read <dir>` (repeatable) — an extra read-only root.

These extend `sandbox.DefaultPolicy(cwd)` and are enforced by the existing OS sandbox layer (macOS SBPL / Linux Landlock+seccomp).

**Default-on deliberately not flipped:** without the Phase 2 network *host* allowlist, default-on would break every network-needing command (`go mod download`, `git fetch`, …). `--sandbox` stays opt-in; revisit default-on once Phase 2 exists.

## Validation
- **macOS** unit tests: `buildProfile` includes/omits `(deny network*)` per the toggle; configured read/write roots appear in the profile.
- **Linux** (Landlock container, kernel 6.8): with `AllowNetwork=true`, `socket(AF_INET)` opens (no seccomp filter); an extra write root is writable.
- `--sandbox-write/-read` are repeatable via a small `stringList` flag (unit-tested).
- `make test` (race), `make vet`, cross-builds (linux/windows/darwin), `gofmt` all clean.

## Remaining (per design doc §8)
- Phase 2: network **host** allowlist (needs a local proxy approach — larger).
- Default-on rollout (after Phase 2).