### PR TITLE
docs: record C11 Phase 2 (network host allowlist) as dropped

### DIFF
--- a/dev-docs/c11-sandbox-design.md
+++ b/dev-docs/c11-sandbox-design.md
@@ -171,14 +171,27 @@ default-off means normal use is unaffected. Revisit later if needed.
 
 ## 8. Phasing
 
-- **Phase 1 (this milestone):** `internal/sandbox` abstraction + both exec sites
+- **Phase 1 (done, #82):** `internal/sandbox` abstraction + both exec sites
   + **FS read/write roots + network deny**, on macOS (SBPL) and Linux
   (landlock+seccomp shim); `--sandbox` flag on `octo chat` and `octo init`;
   `Available()` probe + fail-closed; Windows unsupported.
-- **Phase 2:** network **allowlist** (specific hosts) rather than all-or-nothing
-  — SBPL host rules / seccomp+resolver or a proxy.
-- **Phase 3:** default-on + configurable policy (e.g. a `sandbox:` block read
-  near `.octorules`, extra roots, per-project network allowlist).
+- **Phase 3 (done, #84):** configurable policy — `--sandbox-allow-net`,
+  `--sandbox-write <dir>`, `--sandbox-read <dir>` extend the default policy.
+- **Phase 2 — network host allowlist: dropped (decided 2026-05-27).**
+  Per-host network filtering is not feasible as a hard boundary at the OS layer:
+  Linux seccomp can't inspect `connect()`'s destination (sockaddr is a pointer),
+  and macOS SBPL filters by IP/port, not hostname. The only routes are a local
+  HTTP(S) **proxy** (a *soft* allowlist — bypassable by raw-socket tools, only
+  honored by proxy-aware tools) or a network-namespace + slirp/NAT setup (heavy,
+  needs user namespaces, still IP-only on macOS). Cost/value and the weak
+  guarantee don't justify it. **The network story is the deny-all / allow-all
+  toggle** (`--sandbox-allow-net`), which covers the practical safety need
+  ("this task needs the network: on; otherwise off"). Revisit only if a concrete
+  per-host requirement appears.
+- **Default-on:** deferred. Without a network allowlist, flipping `--sandbox`
+  default-on would break every network-needing command (`go mod download`,
+  `git fetch`, …). Kept opt-in; the permission engine + strict mode remain the
+  always-on backstop.
 
 ## 9. Testing
 

--- a/dev-docs/competitive-parity-roadmap.md
+++ b/dev-docs/competitive-parity-roadmap.md
@@ -20,12 +20,12 @@ A+B 加固（#60–#65）之后，对标项基本落地完毕：
 | C8 | 跨会话记忆 · 第一层（`~/.octo/octorules.md` + `@include`） | ✅ #79 |
 | C9 | 跨会话记忆 · 第二层（类型化记忆） | ⏸ 推迟，与 M7 Skill 合并规划 |
 | C10 | 优雅中断（Ctrl-C） | ✅ #77 |
-| C11 | OS 级命令沙箱 | ✅ Phase 1 #82（设计 #81）；Phase 2/3 待做 |
+| C11 | OS 级命令沙箱 | ✅ Phase 1 #82（设计 #81）+ Phase 3 可配置 #84；Phase 2 主机白名单已放弃（见 `c11-sandbox-design.md` §8）|
 | C12 | 后台/并发命令执行（`terminal background` + `terminal_output`） | ✅ #76 |
 
 附带落地：provider 流式/缓存修复(#72)、DeepSeek reasoning_content(#73)、Anthropic extended thinking(#74)、`octo init` / `/init`(#80)。
 
-**剩余**：C9（并入 M7）、沙箱 C11 Phase 2（网络白名单）+ Phase 3（默认开 + 可配策略，见 `c11-sandbox-design.md` §8）。
+**剩余**：C9（并入 M7）；沙箱默认开（待网络故事成熟后再议）。C11 网络故事 = `--sandbox-allow-net` 的 on/off 开关,主机白名单经评估后放弃。
 
 ---
 


### PR DESCRIPTION
## Summary
Records the decision (2026-05-27) to **not** build a per-host network allowlist for the sandbox.

Per-host network filtering isn't feasible as a hard OS-layer boundary:
- **Linux seccomp** can't inspect `connect()`'s destination (sockaddr is a pointer).
- **macOS SBPL** filters by IP/port, not hostname.
- A local **HTTP(S) proxy** allowlist is a *soft* boundary — bypassable by raw-socket tools, only honored by proxy-aware tools.
- A **netns + slirp/NAT** hard boundary is heavy, needs user namespaces, and is still IP-only on macOS.

Cost/value doesn't justify it. The **network story is the deny-all / allow-all toggle** (`--sandbox-allow-net`, shipped in Phase 3), which covers the practical need. Default-on stays deferred (would break network-needing commands).

Updates `c11-sandbox-design.md` §8 and the roadmap status line. Docs-only.

## Sandbox status after this
- Phase 1 (#82): FS confinement + network deny.
- Phase 3 (#84): configurable roots + network toggle.
- Phase 2: **dropped** (this PR).
- Default-on: deferred.