### PR TITLE
feat(skills): M7 Skill loader (Claude Code-compatible)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/provider"
 	"github.com/Leihb/octo-agent/internal/provider/anthropic"
 	"github.com/Leihb/octo-agent/internal/provider/openai"
+	"github.com/Leihb/octo-agent/internal/skills"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
@@ -58,6 +59,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	continueIDLong := fs.String("continue", "", "Session ID to resume")
 	noSave := fs.Bool("no-save", false, "Disable auto-save in REPL mode")
 	listSessions := fs.Bool("list-sessions", false, "Print the 10 most recent sessions and exit")
+	listSkills := fs.Bool("list-skills", false, "Print available skills (user + project) and exit")
 	enableTools := fs.Bool("tools", false, "Enable built-in tools (bash) for agentic loop")
 	plain := fs.Bool("plain", false, "Render tool events as one-line ↳ status lines instead of rich diff cards")
 	permMode := fs.String("permission-mode", "interactive", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask)")
@@ -107,6 +109,21 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 0
 	}
 
+	// --list-skills: discover and print, no provider needed.
+	if *listSkills {
+		cwd, _ := os.Getwd()
+		reg := skills.Discover(cwd)
+		if reg.Len() == 0 {
+			fmt.Fprintln(stdout, "No skills found (looked in ~/.octo/skills and ./.octo/skills).")
+			return 0
+		}
+		fmt.Fprintln(stdout, "Available skills (trigger with /<name>):")
+		for _, s := range reg.List() {
+			fmt.Fprintf(stdout, "  /%-16s [%-7s] %s\n", s.Name, s.Source, s.Description)
+		}
+		return 0
+	}
+
 	// Resolve -c / --continue (short wins if both somehow set).
 	resumeID := *continueIDLong
 	if *continueID != "" {
@@ -143,6 +160,13 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	cwd, _ := os.Getwd()
 	env := buildEnvContext(cwd)
 
+	// Discover skills (user + project) once at session start. The manifest goes
+	// into the frozen system prompt (L1); the registry backs the `skill` tool so
+	// it can serve full bodies on demand (L2).
+	skillReg := skills.Discover(cwd)
+	skillsManifest := skills.RenderManifest(skillReg)
+	tools.SetSkills(skillReg)
+
 	if *useSandbox {
 		opts := sandboxOpts{allowNet: *sandboxAllowNet, writeRoots: sandboxWrite, readRoots: sandboxRead}
 		if err := activateSandbox(cwd, opts, stderr); err != nil {
@@ -158,7 +182,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		thinkingBudget: *thinkingBudget,
 		thinkingOut:    stdout,
 	}, resolvedModel)
-	a.System = prompt.Compose(*system, cwd, env)
+	a.System = prompt.Compose(*system, cwd, env, skillsManifest)
 	a.MaxTokens = *maxTokens
 	a.MaxTurns = *maxTurns
 	a.MaxCostUSD = *maxCost
@@ -181,19 +205,20 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			}
 			// Recompose from the session's raw user layer so base/project/env
 			// pick up any changes since the session was created.
-			a.System = prompt.Compose(sess.System, cwd, env)
+			a.System = prompt.Compose(sess.System, cwd, env, skillsManifest)
 		} else {
 			sess = agent.NewSession(resolvedModel, *system)
 		}
 
 		cfg := replConfig{
-			a:       a,
-			session: sess,
-			noSave:  *noSave,
-			plain:   *plain,
-			stdin:   stdin,
-			stdout:  stdout,
-			stderr:  stderr,
+			a:        a,
+			session:  sess,
+			noSave:   *noSave,
+			plain:    *plain,
+			stdin:    stdin,
+			stdout:   stdout,
+			stderr:   stderr,
+			skillReg: skillReg,
 		}
 		if *enableTools {
 			cfg.tools = tools.DefaultTools()

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -76,7 +76,7 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	a := agent.New(providerSender{p: prov, cacheKey: newCacheKey()}, resolvedModel)
-	a.System = prompt.Compose("", cwd, env)
+	a.System = prompt.Compose("", cwd, env, "") // init is a one-shot task; no skills manifest
 
 	engine, err := permission.New(permissionConfigPath(), cwd, resolvePermissionMode(*permMode))
 	if err != nil {

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/permission"
+	"github.com/Leihb/octo-agent/internal/skills"
 	"github.com/Leihb/octo-agent/internal/tools"
 	"github.com/Leihb/octo-agent/internal/tui"
 )
@@ -31,6 +32,7 @@ type replConfig struct {
 	stderr     io.Writer
 	tools      []agent.ToolDefinition
 	executor   agent.ToolExecutor
+	skillReg   *skills.Registry // discovered skills; backs /skills and /<name>
 }
 
 // runREPL runs the interactive multi-turn loop until the user exits or EOF.
@@ -129,6 +131,12 @@ func runREPL(cfg replConfig) int {
 			}
 			fmt.Fprintln(cfg.stdout, "Analyzing the repository to generate .octorules…")
 			line = initInstruction
+		} else if s, args, ok := skillTrigger(cfg.skillReg, line); ok {
+			// /<name> [args] → inline the skill's instructions and fall through
+			// to a normal turn (same machinery as /init). This saves the round
+			// trip the model would otherwise spend calling the skill tool.
+			fmt.Fprintf(cfg.stdout, "Running skill /%s…\n", s.Name)
+			line = inlineSkill(s.Body, args)
 		} else if strings.HasPrefix(line, "/") {
 			cmd := strings.ToLower(strings.Fields(line)[0])
 			switch cmd {
@@ -149,6 +157,9 @@ func runREPL(cfg replConfig) int {
 				if err := printSessions(cfg.stdout); err != nil {
 					fmt.Fprintf(cfg.stderr, "sessions: %v\n", err)
 				}
+				continue
+			case "/skills":
+				printSkills(cfg.stdout, cfg.skillReg)
 				continue
 			default:
 				fmt.Fprintf(cfg.stdout, "Unknown command %q. Type /help for a list.\n", cmd)
@@ -233,7 +244,56 @@ func printReplHelp(w io.Writer) {
 	fmt.Fprintln(w, "  /cost       Show token usage and estimated cost for this session")
 	fmt.Fprintln(w, "  /save       Save the session now (it also auto-saves after each turn)")
 	fmt.Fprintln(w, "  /sessions   List the 10 most recent sessions")
+	fmt.Fprintln(w, "  /skills     List available skills (trigger one with /<name>)")
 	fmt.Fprintln(w, "  /exit       Save and exit  (also: /quit, Ctrl-C, Ctrl-D)")
+}
+
+// reservedReplCommands are the built-in slash commands; a skill may not shadow
+// one (so /help always means help even if a skill dir is named "help").
+var reservedReplCommands = map[string]bool{
+	"init": true, "exit": true, "quit": true, "help": true,
+	"cost": true, "save": true, "sessions": true, "skills": true,
+}
+
+// skillTrigger reports whether line is a /<name> invocation of a discovered
+// skill (and not a reserved command), returning the skill and any trailing
+// args (the text after the command word).
+func skillTrigger(reg *skills.Registry, line string) (skills.Skill, string, bool) {
+	if reg == nil || !strings.HasPrefix(line, "/") {
+		return skills.Skill{}, "", false
+	}
+	fields := strings.Fields(line)
+	name := strings.TrimPrefix(fields[0], "/")
+	if reservedReplCommands[strings.ToLower(name)] {
+		return skills.Skill{}, "", false
+	}
+	s, ok := reg.Get(name)
+	if !ok {
+		return skills.Skill{}, "", false
+	}
+	args := strings.TrimSpace(strings.TrimPrefix(line, fields[0]))
+	return s, args, true
+}
+
+// inlineSkill builds the turn input for an explicit /<name> trigger: the skill
+// body, optionally followed by the user's trailing arguments.
+func inlineSkill(body, args string) string {
+	if args == "" {
+		return body
+	}
+	return body + "\n\nUser input: " + args
+}
+
+// printSkills lists the discovered skills, or a hint when there are none.
+func printSkills(w io.Writer, reg *skills.Registry) {
+	if reg == nil || reg.Len() == 0 {
+		fmt.Fprintln(w, "No skills found (looked in ~/.octo/skills and ./.octo/skills).")
+		return
+	}
+	fmt.Fprintln(w, "Available skills (trigger with /<name>):")
+	for _, s := range reg.List() {
+		fmt.Fprintf(w, "  /%-16s [%-7s] %s\n", s.Name, s.Source, s.Description)
+	}
 }
 
 func printCost(w io.Writer, a *agent.Agent) {

--- a/cmd/octo/skill_repl_test.go
+++ b/cmd/octo/skill_repl_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/skills"
+)
+
+// skillRegFor builds a project-level skill registry from name→SKILL.md content,
+// with HOME pointed at an empty dir so no real user skills leak in.
+func skillRegFor(t *testing.T, m map[string]string) *skills.Registry {
+	t.Helper()
+	empty := t.TempDir()
+	t.Setenv("HOME", empty)
+	t.Setenv("USERPROFILE", empty)
+
+	cwd := t.TempDir()
+	for name, content := range m {
+		dir := filepath.Join(cwd, ".octo", "skills", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, skills.SkillFile), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return skills.Discover(cwd)
+}
+
+func TestSkillTrigger(t *testing.T) {
+	reg := skillRegFor(t, map[string]string{
+		"greet": "---\ndescription: d\n---\nbody",
+		"help":  "---\ndescription: d\n---\nshadow attempt",
+	})
+
+	if _, _, ok := skillTrigger(nil, "/greet"); ok {
+		t.Error("nil registry should never match")
+	}
+	if _, _, ok := skillTrigger(reg, "greet"); ok {
+		t.Error("non-slash input should not match")
+	}
+	if _, _, ok := skillTrigger(reg, "/help"); ok {
+		t.Error("reserved command /help must not be hijacked by a same-named skill")
+	}
+	if _, _, ok := skillTrigger(reg, "/nope"); ok {
+		t.Error("unknown skill should not match")
+	}
+	s, args, ok := skillTrigger(reg, "/greet")
+	if !ok || s.Name != "greet" || args != "" {
+		t.Errorf("/greet → %q, args=%q, ok=%v", s.Name, args, ok)
+	}
+	s, args, ok = skillTrigger(reg, "/greet  hello world")
+	if !ok || args != "hello world" {
+		t.Errorf("/greet args → args=%q, ok=%v", args, ok)
+	}
+}
+
+func TestInlineSkill(t *testing.T) {
+	if got := inlineSkill("BODY", ""); got != "BODY" {
+		t.Errorf("no args → %q", got)
+	}
+	if got := inlineSkill("BODY", "x"); got != "BODY\n\nUser input: x" {
+		t.Errorf("with args → %q", got)
+	}
+}
+
+func TestREPL_SkillsCommand(t *testing.T) {
+	cfg, stdout, _, stub := makeREPLFixture(t, "/skills\n/exit\n")
+	cfg.skillReg = skillRegFor(t, map[string]string{"greet": "---\ndescription: say hi\n---\nbody"})
+
+	runREPL(cfg)
+	if stub.called != 0 {
+		t.Errorf("/skills should not call the sender, got %d", stub.called)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "/greet") || !strings.Contains(out, "say hi") {
+		t.Errorf("/skills output missing skill:\n%s", out)
+	}
+}
+
+func TestREPL_SkillsCommand_None(t *testing.T) {
+	cfg, stdout, _, _ := makeREPLFixture(t, "/skills\n/exit\n")
+	cfg.skillReg = skillRegFor(t, nil)
+
+	runREPL(cfg)
+	if !strings.Contains(stdout.String(), "No skills found") {
+		t.Errorf("expected 'No skills found':\n%s", stdout.String())
+	}
+}
+
+func TestREPL_SkillTriggerRunsTurn(t *testing.T) {
+	cfg, stdout, stderr, stub := makeREPLFixture(t, "/greet\n/exit\n")
+	cfg.skillReg = skillRegFor(t, map[string]string{"greet": "---\ndescription: d\n---\nSay hello warmly."})
+
+	code := runREPL(cfg)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr: %s", code, stderr.String())
+	}
+	if stub.called != 1 {
+		t.Errorf("/greet should run one turn, sender called %d times", stub.called)
+	}
+	if !strings.Contains(stdout.String(), "Running skill /greet") {
+		t.Errorf("missing skill-run notice:\n%s", stdout.String())
+	}
+}
+
+func TestREPL_UnknownSlashStillUnknown(t *testing.T) {
+	// A /command that is neither reserved nor a skill keeps the old behaviour.
+	cfg, stdout, _, stub := makeREPLFixture(t, "/bogus\n/exit\n")
+	cfg.skillReg = skillRegFor(t, map[string]string{"greet": "---\ndescription: d\n---\nbody"})
+
+	runREPL(cfg)
+	if stub.called != 0 {
+		t.Errorf("unknown command should not call sender, got %d", stub.called)
+	}
+	if !strings.Contains(stdout.String(), "Unknown command") {
+		t.Errorf("expected unknown-command message:\n%s", stdout.String())
+	}
+}

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -13,6 +13,11 @@ You are octo, an AI coding agent that runs in a terminal and operates on the use
 - Some tool calls are gated by a permission policy. A call may be allowed, denied, or require the user's approval. If a call is denied, you'll get a `permission_denied` result explaining why — treat it as a normal outcome: explain the situation to the user or propose a safe alternative, don't retry the same call in a loop.
 - Don't attempt to read credentials (private keys, `.env`, `~/.ssh`, cloud-metadata endpoints) or write secrets into files; these are blocked by policy.
 
+## Skills
+
+- If the system prompt includes an "Available skills" section, each entry is a pre-written instruction set for a specific kind of task. When the user's request matches a skill's one-line description, call the `skill` tool with that name to load its full instructions, then follow them — don't guess the steps from the description alone.
+- Only reach for a skill when the task genuinely matches one; otherwise ignore the list and work normally.
+
 ## Output
 
 - Be concise and direct. Skip filler and preamble.

--- a/internal/prompt/memory_test.go
+++ b/internal/prompt/memory_test.go
@@ -28,7 +28,7 @@ func TestCompose_UserLayerBetweenEnvAndProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out := Compose("SYSTEM_OVERRIDE", dir, "ENV_BLOCK")
+	out := Compose("SYSTEM_OVERRIDE", dir, "ENV_BLOCK", "")
 
 	envIdx := strings.Index(out, "ENV_BLOCK")
 	userIdx := strings.Index(out, "USER_GLOBAL_RULE")
@@ -54,7 +54,7 @@ func TestCompose_NoUserFile_NoUserLayer(t *testing.T) {
 	userRulesPath = func() string { return filepath.Join(t.TempDir(), "absent.md") }
 	t.Cleanup(func() { userRulesPath = orig })
 
-	out := Compose("", t.TempDir(), "")
+	out := Compose("", t.TempDir(), "", "")
 	if strings.Contains(out, "octorules.md") {
 		t.Errorf("absent user file should add no layer:\n%s", out)
 	}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -43,28 +43,37 @@ var userRulesPath = func() string {
 	return filepath.Join(home, ".octo", "octorules.md")
 }
 
-// Compose assembles the session system prompt from up to five layers, in order
+// Compose assembles the session system prompt from up to six layers, in order
 // of increasing specificity:
 //
 //  1. base    — embedded octo foundation (always present)
 //  2. env     — environment snapshot (cwd, git, date, OS) the caller renders
-//  3. user    — ~/.octo/octorules.md, if present (cross-project user rules)
-//  4. project — ProjectContextFile in cwd, if present (repo conventions)
-//  5. system  — the --system value, if any (highest-priority override, last)
+//  3. skills  — the available-skills manifest the caller renders, if any
+//  4. user    — ~/.octo/octorules.md, if present (cross-project user rules)
+//  5. project — ProjectContextFile in cwd, if present (repo conventions)
+//  6. system  — the --system value, if any (highest-priority override, last)
 //
 // Empty layers are skipped. Later layers appear later in the text, which is
 // the conventional way to let more specific instructions take precedence —
 // project rules override the user's global rules, and --system overrides all.
 //
+// skills is the already-rendered manifest (see skills.RenderManifest); it sits
+// near base/env because it's a capability description, not a rule. It is passed
+// in rather than discovered here so this package keeps a one-directional dep
+// (prompt does not import skills) and the prefix stays stable across turns.
+//
 // The user and project files may pull in other files with @include directives
 // (see expandIncludes). env is passed in rather than computed here so this
 // package stays pure (no os/exec, no git); the caller snapshots it once at
 // session start, which keeps the cached prompt prefix stable across turns.
-func Compose(userSystem, cwd, env string) string {
+func Compose(userSystem, cwd, env, skills string) string {
 	layers := []string{strings.TrimSpace(base)}
 
 	if e := strings.TrimSpace(env); e != "" {
 		layers = append(layers, e)
+	}
+	if s := strings.TrimSpace(skills); s != "" {
+		layers = append(layers, s)
 	}
 	if u := readUserContext(); u != "" {
 		layers = append(layers, "# User conventions (~/.octo/octorules.md)\n\n"+u)

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCompose_BaseAlwaysPresent(t *testing.T) {
-	out := Compose("", t.TempDir(), "") // empty user/env, no .octorules
+	out := Compose("", t.TempDir(), "", "") // empty user/env/skills, no .octorules
 	if !strings.Contains(out, "octo") {
 		t.Errorf("composed prompt should contain the base identity:\n%s", out)
 	}
@@ -22,19 +22,20 @@ func TestCompose_LayersInOrder(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("PROJECT_RULE_X"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	out := Compose("USER_RULE_Y", dir, "ENV_BLOCK_Z")
+	out := Compose("USER_RULE_Y", dir, "ENV_BLOCK_Z", "SKILLS_MANIFEST_W")
 
 	baseIdx := strings.Index(out, "octo")
 	envIdx := strings.Index(out, "ENV_BLOCK_Z")
+	skillsIdx := strings.Index(out, "SKILLS_MANIFEST_W")
 	projIdx := strings.Index(out, "PROJECT_RULE_X")
 	userIdx := strings.Index(out, "USER_RULE_Y")
 
-	if baseIdx == -1 || envIdx == -1 || projIdx == -1 || userIdx == -1 {
-		t.Fatalf("all four layers should be present:\n%s", out)
+	if baseIdx == -1 || envIdx == -1 || skillsIdx == -1 || projIdx == -1 || userIdx == -1 {
+		t.Fatalf("all five layers should be present:\n%s", out)
 	}
-	// Order: base < env < project < user.
-	if !(baseIdx < envIdx && envIdx < projIdx && projIdx < userIdx) {
-		t.Errorf("layer order wrong: base=%d env=%d project=%d user=%d", baseIdx, envIdx, projIdx, userIdx)
+	// Order: base < env < skills < project < user.
+	if !(baseIdx < envIdx && envIdx < skillsIdx && skillsIdx < projIdx && projIdx < userIdx) {
+		t.Errorf("layer order wrong: base=%d env=%d skills=%d project=%d user=%d", baseIdx, envIdx, skillsIdx, projIdx, userIdx)
 	}
 	if !strings.Contains(out, ProjectContextFile) {
 		t.Errorf("project layer should be labelled with the source file")
@@ -42,8 +43,8 @@ func TestCompose_LayersInOrder(t *testing.T) {
 }
 
 func TestCompose_SkipsAbsentLayers(t *testing.T) {
-	// No env, no .octorules, no user prompt → just the base, no separators.
-	out := Compose("", t.TempDir(), "")
+	// No env, no skills, no .octorules, no user prompt → just the base, no separators.
+	out := Compose("", t.TempDir(), "", "")
 	if strings.Contains(out, "---") {
 		t.Errorf("single-layer prompt should have no separator:\n%s", out)
 	}

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -1,0 +1,201 @@
+// Package skills discovers Claude Code-compatible skills from disk and exposes
+// them to the agent in two layers: a one-line manifest injected into the
+// session-start system prompt (see RenderManifest), and full SKILL.md bodies
+// loaded on demand through the `skill` tool. This progressive-disclosure split
+// keeps the cached prompt prefix small while still letting the model pull in a
+// skill's full instructions when a task matches.
+//
+// A skill is a directory containing a SKILL.md file with YAML frontmatter:
+//
+//	~/.octo/skills/<name>/SKILL.md      (user-level, cross-project)
+//	<cwd>/.octo/skills/<name>/SKILL.md  (project-level, takes precedence)
+//
+// The directory name is the authoritative trigger name (matching Claude Code);
+// the frontmatter `name` is display-only. The format is identical to
+// ~/.claude/skills/*/SKILL.md, so users can symlink that directory in directly.
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SkillFile is the per-skill instruction file Discover looks for in each skill
+// directory.
+const SkillFile = "SKILL.md"
+
+// Skill is one discovered skill. Body is the SKILL.md content after the
+// frontmatter — the instructions handed to the model on demand.
+type Skill struct {
+	Name        string // directory name; the /<name> trigger
+	Description string // frontmatter description; the L1 manifest + trigger cue
+	Body        string // SKILL.md body after frontmatter
+	Dir         string // absolute path of the skill directory
+	Source      string // "project" | "user" (display only, for --list-skills)
+}
+
+// Registry holds the skills discovered for a session, indexed by name.
+type Registry struct {
+	skills map[string]Skill
+}
+
+// userSkillsRoot returns ~/.octo/skills, or "" when the home dir can't be
+// resolved. It's a var so tests can point discovery at a temp directory.
+var userSkillsRoot = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "skills")
+}
+
+// Discover scans the user-level then project-level skill roots and returns a
+// Registry. Project skills override user skills of the same name (the project
+// root is scanned last, overwriting the map entry). A missing root is not an
+// error — most environments won't have both.
+func Discover(cwd string) *Registry {
+	r := &Registry{skills: make(map[string]Skill)}
+	if root := userSkillsRoot(); root != "" {
+		r.scanRoot(root, "user")
+	}
+	if cwd != "" {
+		r.scanRoot(filepath.Join(cwd, ".octo", "skills"), "project")
+	}
+	return r
+}
+
+// scanRoot reads one skills root: each immediate subdirectory holding a
+// readable, well-formed SKILL.md becomes a Skill. Anything malformed (missing
+// SKILL.md, no frontmatter, missing name/description) is skipped silently —
+// discovery never fails the session over one bad skill.
+func (r *Registry) scanRoot(root, source string) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return // missing/unreadable root: nothing to add
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		dir := filepath.Join(root, name)
+		b, err := os.ReadFile(filepath.Join(dir, SkillFile))
+		if err != nil {
+			continue
+		}
+		desc, body, ok := parse(b)
+		if !ok || desc == "" {
+			continue
+		}
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			abs = dir
+		}
+		r.skills[name] = Skill{
+			Name:        name,
+			Description: desc,
+			Body:        strings.TrimSpace(body),
+			Dir:         abs,
+			Source:      source,
+		}
+	}
+}
+
+// frontmatter is the subset of SKILL.md frontmatter we consume. yaml.v3 ignores
+// every other key (allowed-tools, license, nested metadata blocks, …), which is
+// exactly what Claude Code compatibility needs.
+type frontmatter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+// parse splits a SKILL.md into its frontmatter description and body. It expects
+// the file to open with a `---` line and contain a closing `---` line; the YAML
+// between them is unmarshalled for the description. ok is false when the file
+// has no frontmatter fence or the YAML doesn't parse.
+func parse(b []byte) (desc, body string, ok bool) {
+	front, body, ok := splitFrontmatter(string(b))
+	if !ok {
+		return "", "", false
+	}
+	var fm frontmatter
+	if err := yaml.Unmarshal([]byte(front), &fm); err != nil {
+		return "", "", false
+	}
+	return strings.TrimSpace(fm.Description), body, true
+}
+
+// splitFrontmatter returns the text between the opening and closing `---`
+// fences and everything after the closing fence. ok is false unless the first
+// non-empty content is a `---` line with a matching closing fence.
+func splitFrontmatter(content string) (front, body string, ok bool) {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", "", false
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return strings.Join(lines[1:i], "\n"), strings.Join(lines[i+1:], "\n"), true
+		}
+	}
+	return "", "", false
+}
+
+// Get returns the skill with the given name.
+func (r *Registry) Get(name string) (Skill, bool) {
+	if r == nil {
+		return Skill{}, false
+	}
+	s, ok := r.skills[name]
+	return s, ok
+}
+
+// Len reports how many skills were discovered.
+func (r *Registry) Len() int {
+	if r == nil {
+		return 0
+	}
+	return len(r.skills)
+}
+
+// List returns all discovered skills in a stable order: project skills first,
+// then user skills, each group sorted by name.
+func (r *Registry) List() []Skill {
+	if r == nil {
+		return nil
+	}
+	out := make([]Skill, 0, len(r.skills))
+	for _, s := range r.skills {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Source != out[j].Source {
+			return out[i].Source == "project" // project before user
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// RenderManifest builds the L1 manifest injected into the system prompt: each
+// skill's name and description, plus a note on how to load the full body.
+// Returns "" for a nil/empty registry so the caller can skip the prompt layer.
+func RenderManifest(r *Registry) string {
+	if r.Len() == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("# Available skills\n\n")
+	b.WriteString("When a task matches a skill's description, call the `skill` tool with its " +
+		"name to load the full instructions before acting. Don't guess the instructions " +
+		"from the one-line description. The user can also trigger one directly by typing /<name>.\n\n")
+	for _, s := range r.List() {
+		fmt.Fprintf(&b, "- %s: %s\n", s.Name, s.Description)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,0 +1,174 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSkill creates <root>/<name>/SKILL.md with the given content.
+func writeSkill(t *testing.T, root, name, content string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, SkillFile), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// useUserRoot points userSkillsRoot at dir for the duration of the test.
+func useUserRoot(t *testing.T, dir string) {
+	t.Helper()
+	orig := userSkillsRoot
+	userSkillsRoot = func() string { return dir }
+	t.Cleanup(func() { userSkillsRoot = orig })
+}
+
+func TestDiscover_Empty(t *testing.T) {
+	useUserRoot(t, filepath.Join(t.TempDir(), "nonexistent"))
+	r := Discover(filepath.Join(t.TempDir(), "alsogone"))
+	if r.Len() != 0 {
+		t.Errorf("Len = %d, want 0", r.Len())
+	}
+	if m := RenderManifest(r); m != "" {
+		t.Errorf("RenderManifest = %q, want empty", m)
+	}
+}
+
+func TestDiscover_UserSkill(t *testing.T) {
+	userRoot := t.TempDir()
+	useUserRoot(t, userRoot)
+	writeSkill(t, userRoot, "greet", "---\nname: Greeter\ndescription: Say hello nicely\n---\nBe warm and friendly.")
+
+	r := Discover("")
+	s, ok := r.Get("greet")
+	if !ok {
+		t.Fatal("greet not discovered")
+	}
+	if s.Name != "greet" {
+		t.Errorf("Name = %q, want %q (dir name is authoritative, not frontmatter name)", s.Name, "greet")
+	}
+	if s.Description != "Say hello nicely" {
+		t.Errorf("Description = %q", s.Description)
+	}
+	if s.Body != "Be warm and friendly." {
+		t.Errorf("Body = %q", s.Body)
+	}
+	if s.Source != "user" {
+		t.Errorf("Source = %q, want user", s.Source)
+	}
+}
+
+func TestDiscover_ProjectOverridesUser(t *testing.T) {
+	userRoot := t.TempDir()
+	useUserRoot(t, userRoot)
+	writeSkill(t, userRoot, "deploy", "---\ndescription: user version\n---\nuser body")
+
+	cwd := t.TempDir()
+	writeSkill(t, filepath.Join(cwd, ".octo", "skills"), "deploy", "---\ndescription: project version\n---\nproject body")
+
+	r := Discover(cwd)
+	if r.Len() != 1 {
+		t.Fatalf("Len = %d, want 1 (same name should collapse)", r.Len())
+	}
+	s, _ := r.Get("deploy")
+	if s.Description != "project version" || s.Source != "project" {
+		t.Errorf("project did not override user: %+v", s)
+	}
+}
+
+func TestDiscover_SkipsMalformed(t *testing.T) {
+	userRoot := t.TempDir()
+	useUserRoot(t, userRoot)
+
+	// No SKILL.md.
+	if err := os.MkdirAll(filepath.Join(userRoot, "empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// No frontmatter fence.
+	writeSkill(t, userRoot, "nofence", "just a body, no frontmatter")
+	// Frontmatter but no description.
+	writeSkill(t, userRoot, "nodesc", "---\nname: x\n---\nbody")
+	// A regular file (not a directory) at the root — must be ignored.
+	if err := os.WriteFile(filepath.Join(userRoot, "loose.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// One good skill.
+	writeSkill(t, userRoot, "ok", "---\ndescription: works\n---\nbody")
+
+	r := Discover("")
+	if r.Len() != 1 {
+		t.Fatalf("Len = %d, want 1 (only 'ok' is well-formed)", r.Len())
+	}
+	if _, ok := r.Get("ok"); !ok {
+		t.Error("'ok' should be discovered")
+	}
+}
+
+// TestDiscover_IgnoresNestedMetadata is the Claude Code compatibility guard:
+// CC frontmatter carries a nested `metadata:` block. yaml.v3 must parse the
+// file and ignore the unmapped block rather than choking on it.
+func TestDiscover_IgnoresNestedMetadata(t *testing.T) {
+	userRoot := t.TempDir()
+	useUserRoot(t, userRoot)
+	writeSkill(t, userRoot, "cc", `---
+name: cc-skill
+description: A Claude Code style skill
+allowed-tools: Bash, Read
+metadata:
+  author: someone
+  version: 2
+---
+Do the thing.`)
+
+	r := Discover("")
+	s, ok := r.Get("cc")
+	if !ok {
+		t.Fatal("cc not discovered — nested metadata block likely broke parsing")
+	}
+	if s.Description != "A Claude Code style skill" {
+		t.Errorf("Description = %q", s.Description)
+	}
+	if s.Body != "Do the thing." {
+		t.Errorf("Body = %q", s.Body)
+	}
+}
+
+func TestList_ProjectBeforeUserThenByName(t *testing.T) {
+	userRoot := t.TempDir()
+	useUserRoot(t, userRoot)
+	writeSkill(t, userRoot, "zebra", "---\ndescription: u\n---\nb")
+	writeSkill(t, userRoot, "alpha", "---\ndescription: u\n---\nb")
+
+	cwd := t.TempDir()
+	writeSkill(t, filepath.Join(cwd, ".octo", "skills"), "yak", "---\ndescription: p\n---\nb")
+
+	got := make([]string, 0)
+	for _, s := range Discover(cwd).List() {
+		got = append(got, s.Name)
+	}
+	want := []string{"yak", "alpha", "zebra"} // project first, then user by name
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("List order = %v, want %v", got, want)
+	}
+}
+
+func TestRenderManifest(t *testing.T) {
+	userRoot := t.TempDir()
+	useUserRoot(t, userRoot)
+	writeSkill(t, userRoot, "greet", "---\ndescription: Say hello\n---\nbody")
+
+	m := RenderManifest(Discover(""))
+	if !strings.Contains(m, "# Available skills") {
+		t.Error("manifest missing header")
+	}
+	if !strings.Contains(m, "`skill` tool") {
+		t.Error("manifest should tell the model to use the skill tool")
+	}
+	if !strings.Contains(m, "- greet: Say hello") {
+		t.Errorf("manifest missing skill line:\n%s", m)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -29,6 +29,7 @@ var allTools = []tool{
 	GrepTool{},
 	WebFetchTool{},
 	WebSearchTool{},
+	SkillTool{},
 }
 
 // DefaultRegistry is the agent.ToolExecutor used when `octo chat --tools` is
@@ -84,11 +85,17 @@ func (r DefaultRegistry) Execute(ctx context.Context, name string, input map[str
 }
 
 // DefaultTools returns the slice of ToolDefinitions sent to the LLM when
-// `--tools` is on. Order matches allTools.
+// `--tools` is on. Order matches allTools. The skill tool is withheld unless
+// at least one skill was discovered (SetSkills) — advertising a tool that can
+// only error wastes a slot and confuses the model.
 func DefaultTools() []agent.ToolDefinition {
-	defs := make([]agent.ToolDefinition, len(allTools))
-	for i, t := range allTools {
-		defs[i] = t.Definition()
+	skillsOn := skillsEnabled()
+	defs := make([]agent.ToolDefinition, 0, len(allTools))
+	for _, t := range allTools {
+		if _, isSkill := t.(SkillTool); isSkill && !skillsOn {
+			continue
+		}
+		defs = append(defs, t.Definition())
 	}
 	return defs
 }

--- a/internal/tools/skill.go
+++ b/internal/tools/skill.go
@@ -1,0 +1,64 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/skills"
+)
+
+// activeSkills, when non-nil and non-empty, backs the `skill` tool: it serves
+// SKILL.md bodies on demand (progressive-disclosure L2). Set once at session
+// start via SetSkills; mirrors the package-level activeSandbox/defaultBg.
+var activeSkills *skills.Registry
+
+// SetSkills registers the skills the `skill` tool serves and that DefaultTools
+// uses to decide whether to advertise the tool. cmd/octo calls this at session
+// start. Pass nil (or an empty registry) to disable.
+func SetSkills(r *skills.Registry) { activeSkills = r }
+
+// skillsEnabled reports whether any skill was discovered — the gate for both
+// advertising and dispatching the skill tool.
+func skillsEnabled() bool { return activeSkills != nil && activeSkills.Len() > 0 }
+
+// SkillTool loads a skill's full SKILL.md body on demand. The model calls it
+// after spotting a matching skill in the system-prompt "Available skills"
+// manifest; the body returns as a tool_result, landing in history rather than
+// the frozen system prefix. The zero value reads from the package-level
+// registry set by SetSkills.
+type SkillTool struct{}
+
+func (SkillTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "skill",
+		Description: "Load the full instructions for an available skill by name. Skills are " +
+			"listed in the system prompt under \"Available skills\". Call this with a skill's " +
+			"name to get its step-by-step instructions, then follow them using the other tools.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "string",
+					"description": "The skill name exactly as shown in the Available skills list.",
+				},
+			},
+			"required": []string{"name"},
+		},
+	}
+}
+
+func (SkillTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+	name, _ := input["name"].(string)
+	if name == "" {
+		return "", fmt.Errorf("skill: name is required")
+	}
+	if !skillsEnabled() {
+		return "", fmt.Errorf("skill: no skills are available")
+	}
+	s, ok := activeSkills.Get(name)
+	if !ok {
+		return "", fmt.Errorf("skill: unknown skill %q", name)
+	}
+	return s.Body, nil
+}

--- a/internal/tools/skill_test.go
+++ b/internal/tools/skill_test.go
@@ -1,0 +1,82 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/skills"
+)
+
+// discoverSkills builds a registry from a temp project dir holding the given
+// skill (name → SKILL.md content) and restores the package state after.
+func setSkillsFor(t *testing.T, name, content string) {
+	t.Helper()
+	cwd := t.TempDir()
+	dir := filepath.Join(cwd, ".octo", "skills", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, skills.SkillFile), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	SetSkills(skills.Discover(cwd))
+	t.Cleanup(func() { SetSkills(nil) })
+}
+
+func TestSkillTool_Execute(t *testing.T) {
+	setSkillsFor(t, "greet", "---\ndescription: say hi\n---\nStep 1: be nice.")
+
+	out, err := SkillTool{}.Execute(context.Background(), "skill", map[string]any{"name": "greet"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "Step 1: be nice." {
+		t.Errorf("body = %q", out)
+	}
+}
+
+func TestSkillTool_Errors(t *testing.T) {
+	SetSkills(nil)
+	t.Cleanup(func() { SetSkills(nil) })
+
+	// No name.
+	if _, err := (SkillTool{}).Execute(context.Background(), "skill", map[string]any{}); err == nil {
+		t.Error("expected error for missing name")
+	}
+	// Name given but no skills configured.
+	if _, err := (SkillTool{}).Execute(context.Background(), "skill", map[string]any{"name": "x"}); err == nil || !strings.Contains(err.Error(), "no skills") {
+		t.Errorf("expected 'no skills' error, got %v", err)
+	}
+
+	// Unknown skill when some exist.
+	setSkillsFor(t, "real", "---\ndescription: d\n---\nbody")
+	if _, err := (SkillTool{}).Execute(context.Background(), "skill", map[string]any{"name": "ghost"}); err == nil || !strings.Contains(err.Error(), "unknown skill") {
+		t.Errorf("expected 'unknown skill' error, got %v", err)
+	}
+}
+
+func TestDefaultTools_SkillToolGatedOnRegistry(t *testing.T) {
+	SetSkills(nil)
+	t.Cleanup(func() { SetSkills(nil) })
+
+	has := func() bool {
+		for _, d := range DefaultTools() {
+			if d.Name == "skill" {
+				return true
+			}
+		}
+		return false
+	}
+
+	if has() {
+		t.Error("skill tool should be absent when no skills are discovered")
+	}
+
+	setSkillsFor(t, "x", "---\ndescription: d\n---\nbody")
+	if !has() {
+		t.Error("skill tool should be present once a skill is discovered")
+	}
+}


### PR DESCRIPTION
Implements **M7 — Skill 加载器** per `dev-docs/m7-skills-design.md` (#86).

## What

Progressive-disclosure skills, mirroring Claude Code:
- **L1** — discovered skills' `name + description` go into the session-start, provider-cached system prompt (`prompt.Compose` gains a skills layer: `base→env→skills→user→project→system`).
- **L2** — full SKILL.md body loads on demand via a new `skill` tool, landing in history (not the frozen prefix).

Discovery: `~/.octo/skills/<name>/SKILL.md` (user) + `./.octo/skills/<name>/SKILL.md` (project, wins). Directory name is the authoritative trigger. Frontmatter parsed with `yaml.v3`, so CC's nested `metadata:` block is ignored cleanly — users can symlink `~/.claude/skills/` in directly.

## Surface
- `octo chat --list-skills` — discover + print + exit
- REPL `/skills` — list; `/<name> [args]` — inline the body and run a turn (saves the skill-tool round trip)
- `skill` tool advertised only when ≥1 skill exists

## Scope (per design)
Instruction-only skills. Bundled-script execution, C9 typed memory, and built-in default_skills deferred.

## Tests
`internal/skills` (discovery/override/malformed-skip/CC-metadata/manifest), `internal/tools` (skill tool + gated DefaultTools), `cmd/octo` (trigger/`/skills`/reserved-command shadowing). `make vet`, race tests, `gofmt`, and linux+windows cross-builds all green. Smoke-tested `--list-skills` end-to-end with a CC-style SKILL.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)