### PR TITLE
docs: cover sandbox, init, octorules, and skills in README (EN + CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,20 +56,71 @@ octo chat --provider openai --model gpt-4o-mini "..."
 ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic \
   octo chat --model deepseek-chat "..."
 
-# Enable the terminal tool (LLM can run shell commands)
+# Enable the built-in tools (LLM can run shell commands, read/edit files, search, …)
 octo chat --tools
+
+# Sandbox those commands: confine the terminal tool to the project dir + tmp, no network
+octo chat --tools --sandbox
+
+# Generate a .octorules guide for this repo
+octo init
+
+# List discovered skills
+octo chat --list-skills
+```
+
+## Configuration
+
+Octo composes its system prompt from several optional layers (later overrides earlier):
+
+- `~/.octo/octorules.md` — your global, cross-project rules and preferences.
+- `.octorules` — per-repo conventions, committed with the project. Generate one with `octo init` (or `/init` in the REPL).
+- `--system "..."` — a one-off override for a single run.
+
+Both rule files support `@include path/to/fragment.md` to pull in shared content.
+
+## Skills
+
+Skills are reusable instruction sets in Claude Code's SKILL.md format, discovered from:
+
+- `~/.octo/skills/<name>/SKILL.md` — user-level, across all projects.
+- `.octo/skills/<name>/SKILL.md` — project-level (takes precedence over user-level).
+
+The format is identical to Claude Code's, so you can symlink `~/.claude/skills` to `~/.octo/skills` and reuse what you already have. Each `SKILL.md` is YAML frontmatter plus a markdown body:
+
+```markdown
+---
+name: review
+description: Review the current diff for correctness and style
+---
+Walk the diff hunk by hunk and flag correctness bugs first, then style.
+```
+
+At session start Octo lists each skill's name and description in the system prompt; the model loads a skill's full instructions on demand (via the `skill` tool) when a task matches. You can also trigger one explicitly — `octo chat --list-skills` to see what's discovered, then `/skills` to list and `/<name>` (e.g. `/review`) to run one in the REPL.
+
+## Sandboxing
+
+`--sandbox` confines the `terminal` tool to the project directory plus temp, with no network, enforced by the OS (macOS Seatbelt, Linux Landlock + seccomp). It's off by default and fails closed when the OS mechanism is unavailable.
+
+```bash
+octo chat --tools --sandbox                              # confine, deny network
+octo chat --tools --sandbox --sandbox-allow-net          # allow network
+octo chat --tools --sandbox --sandbox-write ./build      # extra writable dir (repeatable)
+octo chat --tools --sandbox --sandbox-read /opt/data     # extra readable dir (repeatable)
 ```
 
 ## What's implemented
 
-| Milestone | Status | Description |
-|-----------|--------|-------------|
-| M1   | done | Go scaffold (cmd/octo, Makefile, CI matrix Linux/macOS/Windows) |
-| M1.2 | done | Anthropic Messages provider, single-turn `octo chat` |
-| M2   | done | Streaming SSE, OpenAI Chat Completions provider, `--provider` flag |
-| M3   | done | Interactive REPL, session persistence (`~/.octo/sessions/`), `/cost`, `/save`, `/sessions` |
-| M4   | done | Tool calling (agentic loop), `terminal` tool |
-| M5–M10 | planned | See [`dev-docs/go-rewrite-roadmap.md`](dev-docs/go-rewrite-roadmap.md) |
+| Area | Status | Description |
+|------|--------|-------------|
+| Core CLI | done | Single-turn + interactive REPL, streaming, session persistence (`~/.octo/sessions/`), `/cost` `/save` `/sessions` |
+| Providers | done | Anthropic Messages + OpenAI Chat Completions, plus any compatible third party |
+| Tools | done | `terminal` (+ background), file read/write/edit, glob, grep, web fetch/search |
+| Agentic loop | done | Multi-step tool calling, permission gating, history compaction, graceful Ctrl-C |
+| Memory & config | done | `~/.octo/octorules.md`, `.octorules`, `octo init`, `@include` |
+| Skills | done | Claude Code-compatible SKILL.md loader (`--list-skills`, `/skills`, `/<name>`) |
+| Sandbox | done | OS-enforced `--sandbox` (macOS / Linux) |
+| Web UI / IM bridges | planned | See [`dev-docs/go-rewrite-roadmap.md`](dev-docs/go-rewrite-roadmap.md) |
 
 ## Architecture
 
@@ -85,7 +136,9 @@ internal/provider/ Provider interface + concrete implementations
                    ├─ anthropic/   x-api-key, system top-level, content[].text
                    └─ openai/      Bearer auth, system in messages[0]
    ↓
-internal/tools/    ToolExecutor implementations (currently `terminal`)
+internal/tools/    ToolExecutor implementations — terminal (+ background),
+                   file read/write/edit, glob, grep, web fetch/search, skill
+internal/skills/   SKILL.md discovery + system-prompt manifest
 ```
 
 Each provider implements both **buffered** (`Send`) and **streaming** (`SendStream`) variants. The agent layer mirrors with `Sender` / `StreamingSender` / `ToolSender` / `ToolStreamingSender` — interfaces are added incrementally so non-streaming providers still work.

--- a/README_CN.md
+++ b/README_CN.md
@@ -56,20 +56,71 @@ octo chat --provider openai --model gpt-4o-mini "..."
 ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic \
   octo chat --model deepseek-chat "..."
 
-# 启用 terminal 工具（LLM 可执行 shell 命令）
+# 启用内置工具（LLM 可执行 shell 命令、读写改文件、搜索等）
 octo chat --tools
+
+# 沙箱化这些命令：把 terminal 工具限制在项目目录 + 临时目录，禁网络
+octo chat --tools --sandbox
+
+# 为当前仓库生成 .octorules 指南
+octo init
+
+# 列出已发现的 skill
+octo chat --list-skills
+```
+
+## 配置
+
+Octo 的系统提示由若干可选层叠加而成（后者覆盖前者）：
+
+- `~/.octo/octorules.md` —— 你的全局、跨项目规则与偏好。
+- `.octorules` —— 随项目提交的仓库级约定。用 `octo init`（或 REPL 里的 `/init`）生成。
+- `--system "..."` —— 单次运行的一次性覆盖。
+
+两个规则文件都支持 `@include path/to/fragment.md` 来引入共享内容。
+
+## Skills
+
+Skill 是采用 Claude Code SKILL.md 格式的可复用指令集，从以下位置发现：
+
+- `~/.octo/skills/<name>/SKILL.md` —— 用户级，跨所有项目。
+- `.octo/skills/<name>/SKILL.md` —— 项目级（优先于用户级）。
+
+格式与 Claude Code 完全相同，所以你可以把 `~/.claude/skills` 软链到 `~/.octo/skills` 直接复用现有 skill。每个 `SKILL.md` 是 YAML frontmatter 加 markdown 正文：
+
+```markdown
+---
+name: review
+description: Review the current diff for correctness and style
+---
+逐个 hunk 审查 diff，先标正确性 bug，再看风格。
+```
+
+会话启动时 Octo 把每个 skill 的名字和描述列进系统提示；当任务匹配某个 skill 时，模型通过 `skill` 工具按需加载它的完整指令。你也可以显式触发 —— `octo chat --list-skills` 查看已发现的 skill，再在 REPL 里用 `/skills` 列出、`/<name>`（如 `/review`）运行某个。
+
+## 沙箱
+
+`--sandbox` 把 `terminal` 工具限制在项目目录加临时目录、禁网络，由操作系统强制执行（macOS Seatbelt、Linux Landlock + seccomp）。默认关闭；当操作系统机制不可用时 fail-closed（直接拒绝运行）。
+
+```bash
+octo chat --tools --sandbox                              # 限制，禁网络
+octo chat --tools --sandbox --sandbox-allow-net          # 允许网络
+octo chat --tools --sandbox --sandbox-write ./build      # 额外可写目录（可重复）
+octo chat --tools --sandbox --sandbox-read /opt/data     # 额外可读目录（可重复）
 ```
 
 ## 已实现
 
-| 里程碑 | 状态 | 内容 |
-|--------|------|------|
-| M1   | 完成 | Go 脚手架（cmd/octo、Makefile、Linux/macOS/Windows CI 矩阵） |
-| M1.2 | 完成 | Anthropic Messages Provider，单轮 `octo chat` |
-| M2   | 完成 | SSE 流式输出，OpenAI Chat Completions Provider，`--provider` 标志 |
-| M3   | 完成 | 交互式 REPL，Session 持久化（`~/.octo/sessions/`），`/cost`、`/save`、`/sessions` |
-| M4   | 完成 | Tool Calling（agentic loop），`terminal` 工具 |
-| M5–M10 | 规划中 | 见 [`dev-docs/go-rewrite-roadmap.md`](dev-docs/go-rewrite-roadmap.md) |
+| 领域 | 状态 | 内容 |
+|------|------|------|
+| 核心 CLI | 完成 | 单轮 + 交互式 REPL，流式输出，Session 持久化（`~/.octo/sessions/`），`/cost` `/save` `/sessions` |
+| Provider | 完成 | Anthropic Messages + OpenAI Chat Completions，以及任何兼容的第三方 |
+| 工具 | 完成 | `terminal`（含后台），文件读/写/改，glob，grep，web 抓取/搜索 |
+| Agentic loop | 完成 | 多步工具调用，权限门控，历史压缩，优雅 Ctrl-C |
+| 记忆与配置 | 完成 | `~/.octo/octorules.md`、`.octorules`、`octo init`、`@include` |
+| Skills | 完成 | 兼容 Claude Code 的 SKILL.md 加载器（`--list-skills`、`/skills`、`/<name>`） |
+| 沙箱 | 完成 | 操作系统强制的 `--sandbox`（macOS / Linux） |
+| Web UI / IM 桥接 | 规划中 | 见 [`dev-docs/go-rewrite-roadmap.md`](dev-docs/go-rewrite-roadmap.md) |
 
 ## 架构
 
@@ -85,7 +136,9 @@ internal/provider/ Provider 接口 + 具体实现
                    ├─ anthropic/   x-api-key，system 顶级字段，content[].text
                    └─ openai/      Bearer 认证，system 放在 messages[0]
    ↓
-internal/tools/    ToolExecutor 实现（目前只有 `terminal`）
+internal/tools/    ToolExecutor 实现 —— terminal（含后台）、
+                   文件读/写/改、glob、grep、web 抓取/搜索、skill
+internal/skills/   SKILL.md 发现 + 系统提示清单
 ```
 
 每个 Provider 同时实现**缓冲式** (`Send`) 和**流式** (`SendStream`) 变体。Agent 层对应有 `Sender` / `StreamingSender` / `ToolSender` / `ToolStreamingSender` —— 接口分层添加，不支持流式的 Provider 也能跑。


### PR DESCRIPTION
The README documented features only up to `--tools` (M4), and the "What's implemented" table still listed M5–M10 as *planned* — hiding the sandbox, `octo init`, octorules, and skills work that has since landed.

## Changes (README.md + README_CN.md, mirrored)
- **Quick start** — add `--sandbox`, `octo init`, `--list-skills` examples.
- **New sections**:
  - *Configuration* — `~/.octo/octorules.md`, `.octorules`, `octo init`, `@include` layering.
  - *Skills* — Claude Code-compatible SKILL.md discovery (user + project), `--list-skills` / `/skills` / `/<name>`, symlink-`~/.claude/skills` note.
  - *Sandboxing* — `--sandbox` + `--sandbox-allow-net` / `--sandbox-write` / `--sandbox-read`.
- **Status table** — replaced the stale milestone rows with an area-based table reflecting current state.
- **Architecture** — corrected the `internal/tools` line (was "currently terminal") and added `internal/skills`.

Landing page (`docs/index.html`) left as-is — it's a marketing page and already mentions skills.

Docs-only; no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)