### PR TITLE
docs: record sandbox default-on as not pursued (kept opt-in)

### DIFF
--- a/dev-docs/c11-sandbox-design.md
+++ b/dev-docs/c11-sandbox-design.md
@@ -188,10 +188,13 @@ default-off means normal use is unaffected. Revisit later if needed.
   toggle** (`--sandbox-allow-net`), which covers the practical safety need
   ("this task needs the network: on; otherwise off"). Revisit only if a concrete
   per-host requirement appears.
-- **Default-on:** deferred. Without a network allowlist, flipping `--sandbox`
+- **Default-on: not pursued (decided 2026-05-27).** Flipping `--sandbox`
   default-on would break every network-needing command (`go mod download`,
-  `git fetch`, …). Kept opt-in; the permission engine + strict mode remain the
-  always-on backstop.
+  `git fetch`, …), because the network story is an all-or-nothing toggle, not a
+  per-host allowlist. The sandbox stays **opt-in** — `--sandbox` on demand; the
+  permission engine + strict mode remain the always-on backstop. Not revisited
+  unless a fine-grained network boundary appears that would make a safe default
+  viable.
 
 ## 9. Testing
 

--- a/dev-docs/competitive-parity-roadmap.md
+++ b/dev-docs/competitive-parity-roadmap.md
@@ -25,7 +25,7 @@ A+B 加固（#60–#65）之后，对标项基本落地完毕：
 
 附带落地：provider 流式/缓存修复(#72)、DeepSeek reasoning_content(#73)、Anthropic extended thinking(#74)、`octo init` / `/init`(#80)。
 
-**剩余**：C9（并入 M7）；沙箱默认开（待网络故事成熟后再议）。C11 网络故事 = `--sandbox-allow-net` 的 on/off 开关,主机白名单经评估后放弃。
+**剩余**：C9（并入 M7；Skill 加载器已落地 #87，typed memory 待单独一轮）。沙箱默认开**已决定不做**（2026-05-27）—— 保持 opt-in，按需 `--sandbox`，理由见 [`c11-sandbox-design.md`](c11-sandbox-design.md) §8。C11 网络故事 = `--sandbox-allow-net` 的 on/off 开关,主机白名单经评估后放弃。
 
 ---
 


### PR DESCRIPTION
Per user decision (2026-05-27): **`--sandbox` stays opt-in, default off.** Sandbox default-on is *not pursued*.

Rationale: without a per-host network boundary (infeasible at the OS layer — Linux seccomp can't see `connect()` destinations, macOS SBPL is IP-only), flipping default-on would break every network-needing command (`go mod download`, `git fetch`, …). The permission engine + strict mode already provide an always-on backstop.

## Changes
- `c11-sandbox-design.md` §8 — "Default-on: deferred" → "not pursued (decided 2026-05-27)".
- `competitive-parity-roadmap.md` — remaining-work note updated so default-on isn't re-surfaced as a TODO.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)