### PR TITLE
docs: identity files (soul.md / user.md) design

### DIFF
--- a/dev-docs/identity-files-design.md
+++ b/dev-docs/identity-files-design.md
@@ -1,0 +1,103 @@
+# 身份文件（soul.md / user.md）design
+
+> openclaw / hermes 式的 persona 配置：`soul.md`（agent 身份与行为规范）+ `user.md`
+> （用户个人信息）。手写、会话启动注入 system prompt。独立于 C9 auto-memory
+> （`c9-memory-design.md`）——这是手写的**第一层**，C9 是自动的第二层。
+
+## 1. 目标与范围
+
+给 octo 一对用户级身份文件，让用户用 openclaw/hermes 的范式定义「这个 agent 是谁、为谁
+服务」：
+
+- `~/.octo/soul.md` —— agent 的身份、人格、行为规范。
+- `~/.octo/user.md` —— 用户的个人信息 / 画像。
+
+本轮范围（已与用户对齐）：
+
+- ✅ **手写 + 启动注入**：用户手写这两个文件，会话启动时注入冻结的 system prompt prefix。
+- ✅ **仅用户级**（`~/.octo/`，跨项目）—— 符合 openclaw/hermes 的身份范式。
+- ✅ **纯 Compose 注入层**，很轻；独立于 C9，可单独先做。
+- ❌ **项目级 soul/user**（不同 repo 不同 persona）—— 后续再议。
+- ❌ **管理/编辑 skill** —— 后续用 M7 skill loader 做（见 §7），不在本轮。
+
+## 2. 与现有来源的分工
+
+| 来源 | 回答 | 谁写 | 注入层 |
+|---|---|---|---|
+| **soul.md** | agent **是谁**、人格、行为规范 | 用户手写 | base 之后 |
+| **user.md** | 用户**是谁**、个人信息 | 用户手写 | memory 之后、规则之前 |
+| `~/.octo/octorules.md` / `.octorules` | **怎么工作**（全局 / 项目规则） | 用户手写 / `octo init` | user / project 规则层 |
+| C9 auto-memory | 会话中**自动观察**到的偏好/事实 | agent 自动 | memory 层 |
+
+维度不同，共存不冗余：soul=agent 身份，user=用户身份，octorules=工作规则，C9=自动记忆。
+
+## 3. 文件格式与位置
+
+- `~/.octo/soul.md`、`~/.octo/user.md`，自由 markdown，无强制 frontmatter。
+- 缺失即跳过（像 `.octorules`，多数情况只有部分文件存在，不是错误）。
+- 路径用 `os.UserHomeDir()` + `~/.octo/`，与 octorules / sessions / memory 同根。
+
+## 4. 注入（prompt.Compose）
+
+soul.md / user.md 由 **prompt 包内直读**（与 octorules 的 `userRulesPath` 同模式），
+不新增 Compose 参数——签名已含 skills、C9 还要加 memory，单文件直读放包内更干净。
+
+完整注入顺序（身份层 + 现有层 + C9 memory）：
+
+```
+base → soul → env → skills → memory → user.md → octorules(user) → octorules(project) → --system
+```
+
+- **soul 紧跟 base**：先确立 octo 是谁（base），再让 soul 重塑 persona / 行为风格。
+- **user.md 在 memory 之后、规则之前**：用户画像，先于工作规则。
+- 空层跳过；各层之间维持现有 `\n\n---\n\n` 分隔。
+- 实现：prompt 包加 `soulPath` / `userProfilePath`（var，便于测试覆盖）+ `readSoul` /
+  `readUserProfile`，在 `Compose` 内对应位置插入。
+
+## 5. soul 与 base 的关系（补充，非覆盖）
+
+`base.md`（内嵌的 octo identity + 工具/权限/安全规范）始终在 soul 之前。soul **补充**
+persona 与行为风格，但**不应覆盖** base 的硬规范（read-before-write、权限门控、`edit_file`
+而非 `sed -i` 等）。
+
+- 这是**软约束**：注入顺序让 soul 在 base 之后，LLM 倾向后文优先，所以 persona 层 soul
+  说了算；但 base 的安全规范靠其措辞 + 用户不在 soul 里写「忽略安全规范」来维持，不做技术
+  强制。
+- 若日后需要硬保证，再把 base 拆成「persona 段（soul 前）+ 不可覆盖的安全段（最末）」。
+  本轮不做（过度设计）。
+
+## 6. 与 C9 的协调
+
+- `user.md` 是用户**手写的稳定画像**（名字、角色、长期偏好）；C9 的 user-type auto-memory
+  是 agent **自动提取的增长部分**。两者都注入，互补。
+- 避免冗余：C9 的提取 prompt（`c9-memory-design.md` §4b）应说明「不重复 user.md 已有的
+  事实」。
+- 注入顺序里 `user.md` 紧跟 `memory`，二者相邻，便于模型把"手写画像 + 自动观察"作为一组
+  用户上下文理解。
+
+## 7. 后续：管理/编辑 skill（不在本轮）
+
+用刚落地的 M7 skill loader 做一个 skill（如 `/identity`）帮用户查看/编辑 soul.md 与
+user.md——交互式补全字段、校验、给模板。本轮只做手写 + 注入；skill 作为独立后续。
+
+## 8. 决策记录
+
+- **D1（独立于 C9）**：手写第一层 vs 自动第二层，概念分离；纯 Compose 注入，可单独交付。
+- **D2（仅用户级）**：`~/.octo/`，跨项目；项目级 persona 留后续。
+- **D3（soul 补充非覆盖）**：base 的工具/安全规范保留；soul 在 base 后重塑 persona，软约束。
+- **D4（prompt 包内直读，不加 Compose 参数）**：与 octorules 同模式；缺失跳过。
+- **D5（编辑 skill 留后续）**：用 M7 loader 做，不在本轮。
+
+## 9. 切片
+
+1. prompt 包：`soulPath` / `userProfilePath` var + `readSoul` / `readUserProfile` +
+   `Compose` 插入 soul（base 后）、user.md（memory 后、规则前）两层。+ 测试。
+2. 文档：README 加一节（`~/.octo/soul.md` / `user.md` 是什么、注入顺序、与 octorules
+   分工）。
+
+`make vet && make test`（race）+ gofmt；跨 OS `GOOS=linux/windows go build ./...`。
+
+## 10. 测试（stdlib，无外部框架）
+
+- `prompt`：soul 在 base 之后、user.md 在 memory/skills 之后且在 octorules 之前的顺序；
+  两文件缺失各自跳过、不留空分隔；与 octorules 共存时层次正确。


### PR DESCRIPTION
openclaw/hermes-style persona config, separate from C9 (#90): hand-written identity files injected at session start.

## What
- `~/.octo/soul.md` — agent identity + behavior norms
- `~/.octo/user.md` — user profile
- Hand-written this round; injected into the frozen system prompt. A management/edit skill (built on the M7 loader) comes later.
- **User-level only**, separate small feature (pure Compose injection layer).

## Layering
This is the hand-written **first layer** (like CLAUDE.md), distinct from C9 auto-memory (the automatic second layer). Full injection order:

`base → soul → env → skills → memory → user.md → octorules(user) → octorules(project) → --system`

- `soul` follows `base` (reshape persona, but base's tool/safety norms stay — soul supplements, doesn't override).
- `user.md` sits next to the C9 memory layer (hand-written profile vs auto-extracted facts; extraction prompt avoids duplicating user.md).
- soul.md / user.md are read inside the prompt package (like octorules), no new Compose params.

## Scope
Manual write + injection only. Project-level personas and the management skill are deferred.

Docs-only; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)