### PR TITLE
feat(prompt): identity files (soul.md / user.md) injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ octo chat --list-skills
 
 Octo composes its system prompt from several optional layers (later overrides earlier):
 
+- `~/.octo/soul.md` — agent identity & behavior, an openclaw/hermes-style persona.
+- `~/.octo/user.md` — who you are; a profile injected into every session.
 - `~/.octo/octorules.md` — your global, cross-project rules and preferences.
 - `.octorules` — per-repo conventions, committed with the project. Generate one with `octo init` (or `/init` in the REPL).
 - `--system "..."` — a one-off override for a single run.
 
-Both rule files support `@include path/to/fragment.md` to pull in shared content.
+The identity and rule files support `@include path/to/fragment.md` to pull in shared content.
 
 ## Skills
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -73,11 +73,13 @@ octo chat --list-skills
 
 Octo 的系统提示由若干可选层叠加而成（后者覆盖前者）：
 
+- `~/.octo/soul.md` —— agent 的身份与行为规范（openclaw/hermes 式 persona）。
+- `~/.octo/user.md` —— 你是谁；每次会话都会注入的个人画像。
 - `~/.octo/octorules.md` —— 你的全局、跨项目规则与偏好。
 - `.octorules` —— 随项目提交的仓库级约定。用 `octo init`（或 REPL 里的 `/init`）生成。
 - `--system "..."` —— 单次运行的一次性覆盖。
 
-两个规则文件都支持 `@include path/to/fragment.md` 来引入共享内容。
+身份文件与规则文件都支持 `@include path/to/fragment.md` 来引入共享内容。
 
 ## Skills
 

--- a/internal/prompt/identity_test.go
+++ b/internal/prompt/identity_test.go
@@ -1,0 +1,82 @@
+package prompt
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// useIdentityFiles points soulPath/userProfilePath at temp files (written when
+// content is non-empty, otherwise an absent path) and clears userRulesPath,
+// isolating the test from any real ~/.octo files.
+func useIdentityFiles(t *testing.T, soul, profile string) {
+	t.Helper()
+	dir := t.TempDir()
+	origSoul, origProfile, origRules := soulPath, userProfilePath, userRulesPath
+	t.Cleanup(func() { soulPath, userProfilePath, userRulesPath = origSoul, origProfile, origRules })
+
+	userRulesPath = func() string { return filepath.Join(dir, "absent-octorules.md") }
+
+	write := func(name, content string) func() string {
+		if content == "" {
+			return func() string { return filepath.Join(dir, "absent-"+name) }
+		}
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return func() string { return p }
+	}
+	soulPath = write("soul.md", soul)
+	userProfilePath = write("user.md", profile)
+}
+
+func TestCompose_IdentityLayers(t *testing.T) {
+	useIdentityFiles(t, "SOUL_PERSONA", "USER_PROFILE_X")
+	out := Compose("", t.TempDir(), "ENV_Z", "SKILLS_M")
+
+	baseIdx := strings.Index(out, "octo")
+	soulIdx := strings.Index(out, "SOUL_PERSONA")
+	envIdx := strings.Index(out, "ENV_Z")
+	skillsIdx := strings.Index(out, "SKILLS_M")
+	profileIdx := strings.Index(out, "USER_PROFILE_X")
+
+	for name, idx := range map[string]int{"soul": soulIdx, "env": envIdx, "skills": skillsIdx, "profile": profileIdx} {
+		if idx == -1 {
+			t.Fatalf("%s layer missing:\n%s", name, out)
+		}
+	}
+	// base < soul < env < skills < profile
+	if !(baseIdx < soulIdx && soulIdx < envIdx && envIdx < skillsIdx && skillsIdx < profileIdx) {
+		t.Errorf("order wrong: base=%d soul=%d env=%d skills=%d profile=%d", baseIdx, soulIdx, envIdx, skillsIdx, profileIdx)
+	}
+	if !strings.Contains(out, "~/.octo/soul.md") || !strings.Contains(out, "~/.octo/user.md") {
+		t.Error("identity layers should be labelled with their source paths")
+	}
+}
+
+func TestCompose_IdentityAbsentSkipped(t *testing.T) {
+	useIdentityFiles(t, "", "") // neither file present
+	out := Compose("", t.TempDir(), "", "")
+	if strings.Contains(out, "soul.md") || strings.Contains(out, "user.md") {
+		t.Errorf("absent identity files should add no layer:\n%s", out)
+	}
+	if strings.Contains(out, "---") {
+		t.Errorf("base-only prompt should have no separator:\n%s", out)
+	}
+}
+
+func TestCompose_ProfileBeforeRules(t *testing.T) {
+	useIdentityFiles(t, "", "USER_PROFILE_X")
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("PROJECT_RULE"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := Compose("", dir, "", "")
+	profileIdx := strings.Index(out, "USER_PROFILE_X")
+	projIdx := strings.Index(out, "PROJECT_RULE")
+	if profileIdx == -1 || projIdx == -1 || profileIdx >= projIdx {
+		t.Errorf("profile should precede project rules: profile=%d proj=%d\n%s", profileIdx, projIdx, out)
+	}
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -43,24 +43,28 @@ var userRulesPath = func() string {
 	return filepath.Join(home, ".octo", "octorules.md")
 }
 
-// Compose assembles the session system prompt from up to six layers, in order
-// of increasing specificity:
+// Compose assembles the session system prompt from up to eight layers, in
+// order of increasing specificity:
 //
 //  1. base    — embedded octo foundation (always present)
-//  2. env     — environment snapshot (cwd, git, date, OS) the caller renders
-//  3. skills  — the available-skills manifest the caller renders, if any
-//  4. user    — ~/.octo/octorules.md, if present (cross-project user rules)
-//  5. project — ProjectContextFile in cwd, if present (repo conventions)
-//  6. system  — the --system value, if any (highest-priority override, last)
+//  2. soul    — ~/.octo/soul.md, if present (agent identity & behavior)
+//  3. env     — environment snapshot (cwd, git, date, OS) the caller renders
+//  4. skills  — the available-skills manifest the caller renders, if any
+//  5. profile — ~/.octo/user.md, if present (who the user is)
+//  6. user    — ~/.octo/octorules.md, if present (cross-project user rules)
+//  7. project — ProjectContextFile in cwd, if present (repo conventions)
+//  8. system  — the --system value, if any (highest-priority override, last)
 //
 // Empty layers are skipped. Later layers appear later in the text, which is
 // the conventional way to let more specific instructions take precedence —
 // project rules override the user's global rules, and --system overrides all.
 //
-// skills is the already-rendered manifest (see skills.RenderManifest); it sits
-// near base/env because it's a capability description, not a rule. It is passed
-// in rather than discovered here so this package keeps a one-directional dep
-// (prompt does not import skills) and the prefix stays stable across turns.
+// soul sits right after base: it reshapes persona/behavior, but base's tool
+// and safety norms still precede it. skills is the already-rendered manifest
+// (see skills.RenderManifest), passed in rather than discovered here so this
+// package keeps a one-directional dep (prompt does not import skills) and the
+// prefix stays stable across turns. soul/profile/user/project are read here
+// (single files), like octorules.
 //
 // The user and project files may pull in other files with @include directives
 // (see expandIncludes). env is passed in rather than computed here so this
@@ -69,11 +73,17 @@ var userRulesPath = func() string {
 func Compose(userSystem, cwd, env, skills string) string {
 	layers := []string{strings.TrimSpace(base)}
 
+	if s := readSoul(); s != "" {
+		layers = append(layers, "# Agent identity (~/.octo/soul.md)\n\n"+s)
+	}
 	if e := strings.TrimSpace(env); e != "" {
 		layers = append(layers, e)
 	}
 	if s := strings.TrimSpace(skills); s != "" {
 		layers = append(layers, s)
+	}
+	if p := readUserProfile(); p != "" {
+		layers = append(layers, "# User profile (~/.octo/user.md)\n\n"+p)
 	}
 	if u := readUserContext(); u != "" {
 		layers = append(layers, "# User conventions (~/.octo/octorules.md)\n\n"+u)
@@ -86,6 +96,44 @@ func Compose(userSystem, cwd, env, skills string) string {
 	}
 
 	return strings.Join(layers, "\n\n---\n\n")
+}
+
+// soulPath and userProfilePath return the per-user identity files
+// (~/.octo/soul.md, ~/.octo/user.md), or "" when the home dir can't be
+// resolved. They're vars so tests can point them at temp files, mirroring
+// userRulesPath.
+var soulPath = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "soul.md")
+}
+
+var userProfilePath = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "user.md")
+}
+
+// readSoul returns the trimmed, include-expanded contents of ~/.octo/soul.md
+// (agent identity & behavior), or "" if it's absent/unreadable/empty.
+func readSoul() string {
+	if p := soulPath(); p != "" {
+		return readContextFile(p)
+	}
+	return ""
+}
+
+// readUserProfile returns the trimmed, include-expanded contents of
+// ~/.octo/user.md (who the user is), or "" if it's absent/unreadable/empty.
+func readUserProfile() string {
+	if p := userProfilePath(); p != "" {
+		return readContextFile(p)
+	}
+	return ""
 }
 
 // readUserContext returns the trimmed, include-expanded contents of the


### PR DESCRIPTION
Implements `dev-docs/identity-files-design.md` (#91).

## What
- `~/.octo/soul.md` (agent identity & behavior) injected right after `base`.
- `~/.octo/user.md` (user profile) injected before the octorules layers.
- Read inside the prompt package like octorules — include-expanded, absent = skipped — so **no Compose signature change**.

Injection order is now:
`base → soul → env → skills → profile → octorules(user) → project → system`
(C9's memory layer will slot between skills and profile when it lands.)

soul follows base so it reshapes persona while base's tool/safety norms still precede it (supplement, not override).

## Tests
`internal/prompt`: layer order (base<soul<env<skills<profile), both files absent → skipped (no stray separator), profile precedes rules. `make vet`, race tests, gofmt, linux+windows cross-builds all green.

README (EN + CN) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)