### PR TITLE
feat(memory): C9 Phase 1 core — store, remember tool, injection, CLI

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"e346776b-d0e5-4027-bd59-223572cf48fd","pid":50401,"procStart":"Wed May 27 13:16:19 2026","acquiredAt":1779890566556}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"e346776b-d0e5-4027-bd59-223572cf48fd","pid":50401,"procStart":"Wed May 27 13:16:19 2026","acquiredAt":1779890566556}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage.html
 # Local agent / config
 /.claude/settings.local.json
 .codegraph/
+/.claude/scheduled_tasks.lock

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/memory"
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/prompt"
 	"github.com/Leihb/octo-agent/internal/provider"
@@ -61,6 +62,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	listSessions := fs.Bool("list-sessions", false, "Print the 10 most recent sessions and exit")
 	listSkills := fs.Bool("list-skills", false, "Print available skills (user + project) and exit")
 	enableTools := fs.Bool("tools", false, "Enable built-in tools (bash) for agentic loop")
+	noMemory := fs.Bool("no-memory", false, "Disable cross-session memory (the remember tool + memory injection)")
 	plain := fs.Bool("plain", false, "Render tool events as one-line ↳ status lines instead of rich diff cards")
 	permMode := fs.String("permission-mode", "interactive", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask)")
 	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = default 20)")
@@ -167,6 +169,19 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	skillsManifest := skills.RenderManifest(skillReg)
 	tools.SetSkills(skillReg)
 
+	// Cross-session memory (C9): the store backs the `remember` tool and renders
+	// this session's memory injection. --no-memory disables both. A store error
+	// (e.g. unresolvable home dir) degrades to no memory rather than failing.
+	var memInjection string
+	var memStore *memory.Store
+	if !*noMemory {
+		if store, err := memory.NewStore(); err == nil {
+			memStore = store
+			tools.SetMemoryStore(store)
+			memInjection, _ = store.RenderInjection()
+		}
+	}
+
 	if *useSandbox {
 		opts := sandboxOpts{allowNet: *sandboxAllowNet, writeRoots: sandboxWrite, readRoots: sandboxRead}
 		if err := activateSandbox(cwd, opts, stderr); err != nil {
@@ -182,7 +197,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		thinkingBudget: *thinkingBudget,
 		thinkingOut:    stdout,
 	}, resolvedModel)
-	a.System = prompt.Compose(*system, cwd, env, skillsManifest)
+	a.System = prompt.Compose(*system, cwd, env, skillsManifest, memInjection)
 	a.MaxTokens = *maxTokens
 	a.MaxTurns = *maxTurns
 	a.MaxCostUSD = *maxCost
@@ -205,7 +220,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			}
 			// Recompose from the session's raw user layer so base/project/env
 			// pick up any changes since the session was created.
-			a.System = prompt.Compose(sess.System, cwd, env, skillsManifest)
+			a.System = prompt.Compose(sess.System, cwd, env, skillsManifest, memInjection)
 		} else {
 			sess = agent.NewSession(resolvedModel, *system)
 		}
@@ -219,6 +234,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			stdout:   stdout,
 			stderr:   stderr,
 			skillReg: skillReg,
+			memStore: memStore,
 		}
 		if *enableTools {
 			cfg.tools = tools.DefaultTools()

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -76,7 +76,7 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	a := agent.New(providerSender{p: prov, cacheKey: newCacheKey()}, resolvedModel)
-	a.System = prompt.Compose("", cwd, env, "") // init is a one-shot task; no skills manifest
+	a.System = prompt.Compose("", cwd, env, "", "") // init is a one-shot task; no skills/memory
 
 	engine, err := permission.New(permissionConfigPath(), cwd, resolvePermissionMode(*permMode))
 	if err != nil {

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -45,6 +45,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return runChat(args[1:], stdin, stdout, stderr)
 	case "init":
 		return runInit(args[1:], stdin, stdout, stderr)
+	case "memory":
+		return runMemory(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "octo: unknown command %q\n", args[0])
 		fmt.Fprintln(stderr, "Run `octo help` for available commands.")
@@ -60,6 +62,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "Commands:")
 	fmt.Fprintln(w, "  chat       Start an interactive session (or single-turn with a message)")
 	fmt.Fprintln(w, "  init       Analyze the repo and generate/update .octorules")
+	fmt.Fprintln(w, "  memory     Manage cross-session memory (e.g. `octo memory list`)")
 	fmt.Fprintln(w, "  version    Print the version and exit")
 	fmt.Fprintln(w, "  help       Print this help and exit")
 	fmt.Fprintln(w)

--- a/cmd/octo/memory.go
+++ b/cmd/octo/memory.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Leihb/octo-agent/internal/memory"
+)
+
+// runMemory handles `octo memory <subcommand>`. Currently just `list`, which
+// prints the stored cross-session memory entries.
+func runMemory(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] != "list" {
+		fmt.Fprintln(stderr, "Usage: octo memory list")
+		return 2
+	}
+
+	store, err := memory.NewStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo memory: %v\n", err)
+		return 1
+	}
+	entries, err := store.List()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo memory: %v\n", err)
+		return 1
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(stdout, "No memories stored.")
+		return 0
+	}
+	fmt.Fprintln(stdout, "Stored memories:")
+	for _, e := range entries {
+		fmt.Fprintf(stdout, "  %-28s [%-9s] %s\n", e.Name, e.Type, e.Description)
+	}
+	return 0
+}

--- a/cmd/octo/memory_test.go
+++ b/cmd/octo/memory_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/memory"
+)
+
+func TestRunMemory_List(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	var out bytes.Buffer
+	if code := runMemory([]string{"list"}, &out, &out); code != 0 {
+		t.Fatalf("empty list exit = %d", code)
+	}
+	if !strings.Contains(out.String(), "No memories") {
+		t.Errorf("empty store should say so:\n%s", out.String())
+	}
+
+	store, err := memory.NewStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(memory.Entry{Name: "n", Description: "prefers Go", Type: memory.TypeUser}); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	runMemory([]string{"list"}, &out, &out)
+	if !strings.Contains(out.String(), "prefers Go") {
+		t.Errorf("list should show the entry:\n%s", out.String())
+	}
+}
+
+func TestRunMemory_BadSubcommand(t *testing.T) {
+	var out bytes.Buffer
+	if code := runMemory([]string{"bogus"}, &out, &out); code != 2 {
+		t.Errorf("bad subcommand exit = %d, want 2", code)
+	}
+	if code := runMemory(nil, &out, &out); code != 2 {
+		t.Errorf("no subcommand exit = %d, want 2", code)
+	}
+}
+
+func TestREPL_MemoryCommand(t *testing.T) {
+	cfg, stdout, _, stub := makeREPLFixture(t, "/memory\n/exit\n")
+	store := memory.NewStoreAt(t.TempDir())
+	if err := store.Save(memory.Entry{Name: "n", Description: "remembered thing", Type: memory.TypeFeedback}); err != nil {
+		t.Fatal(err)
+	}
+	cfg.memStore = store
+
+	runREPL(cfg)
+	if stub.called != 0 {
+		t.Errorf("/memory should not call the sender, got %d", stub.called)
+	}
+	if !strings.Contains(stdout.String(), "remembered thing") {
+		t.Errorf("/memory output missing entry:\n%s", stdout.String())
+	}
+}
+
+func TestREPL_MemoryDisabled(t *testing.T) {
+	cfg, stdout, _, _ := makeREPLFixture(t, "/memory\n/exit\n")
+	// memStore left nil → memory disabled
+	runREPL(cfg)
+	if !strings.Contains(stdout.String(), "disabled") {
+		t.Errorf("expected disabled notice:\n%s", stdout.String())
+	}
+}

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/memory"
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/skills"
 	"github.com/Leihb/octo-agent/internal/tools"
@@ -33,6 +34,7 @@ type replConfig struct {
 	tools      []agent.ToolDefinition
 	executor   agent.ToolExecutor
 	skillReg   *skills.Registry // discovered skills; backs /skills and /<name>
+	memStore   *memory.Store    // cross-session memory; backs /memory (nil → disabled)
 }
 
 // runREPL runs the interactive multi-turn loop until the user exits or EOF.
@@ -161,6 +163,9 @@ func runREPL(cfg replConfig) int {
 			case "/skills":
 				printSkills(cfg.stdout, cfg.skillReg)
 				continue
+			case "/memory":
+				printMemory(cfg.stdout, cfg.memStore)
+				continue
 			default:
 				fmt.Fprintf(cfg.stdout, "Unknown command %q. Type /help for a list.\n", cmd)
 				continue
@@ -245,7 +250,30 @@ func printReplHelp(w io.Writer) {
 	fmt.Fprintln(w, "  /save       Save the session now (it also auto-saves after each turn)")
 	fmt.Fprintln(w, "  /sessions   List the 10 most recent sessions")
 	fmt.Fprintln(w, "  /skills     List available skills (trigger one with /<name>)")
+	fmt.Fprintln(w, "  /memory     List what's remembered across sessions")
 	fmt.Fprintln(w, "  /exit       Save and exit  (also: /quit, Ctrl-C, Ctrl-D)")
+}
+
+// printMemory lists the cross-session memory entries, or a hint when memory is
+// off / empty.
+func printMemory(w io.Writer, store *memory.Store) {
+	if store == nil {
+		fmt.Fprintln(w, "Memory is disabled for this session (--no-memory).")
+		return
+	}
+	entries, err := store.List()
+	if err != nil {
+		fmt.Fprintf(w, "memory: %v\n", err)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "Nothing remembered yet.")
+		return
+	}
+	fmt.Fprintln(w, "Remembered across sessions:")
+	for _, e := range entries {
+		fmt.Fprintf(w, "  [%-9s] %s\n", e.Type, e.Description)
+	}
 }
 
 // reservedReplCommands are the built-in slash commands; a skill may not shadow

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -1,0 +1,292 @@
+// Package memory implements octo's cross-session auto-memory (C9, Phase 1):
+// typed, one-file-per-fact storage under ~/.octo/memory, a MEMORY.md index, and
+// an injection renderer. Facts land here two ways — immediately via the
+// remember tool, and (later) via boundary extraction — and the rendered summary
+// is injected into the next session's system prompt.
+//
+// This is the native, self-sufficient layer: no daemon, no retrieval. A
+// consolidation pass (and the Phase 2 daemon) may later produce memory_summary.md;
+// until then RenderInjection falls back to the entry index.
+package memory
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Type is the semantic category of a memory entry (mirrors Claude Code's
+// frontmatter classes). Unknown values normalize to TypeReference.
+type Type string
+
+const (
+	TypeUser      Type = "user"      // who the user is / preferences
+	TypeFeedback  Type = "feedback"  // how to work — corrections & confirmed approaches
+	TypeProject   Type = "project"   // ongoing work / constraints not in code or git
+	TypeReference Type = "reference" // pointers to external resources
+)
+
+func validType(t Type) bool {
+	switch t {
+	case TypeUser, TypeFeedback, TypeProject, TypeReference:
+		return true
+	}
+	return false
+}
+
+// Entry is one stored fact: a <name>.md file with frontmatter plus body.
+type Entry struct {
+	Name         string // kebab-slug; the filename stem
+	Description  string // one-line summary (index + relevance)
+	Type         Type
+	Created      string // YYYY-MM-DD
+	LastVerified string // YYYY-MM-DD
+	Body         string
+}
+
+const (
+	indexFile   = "MEMORY.md"
+	summaryFile = "memory_summary.md"
+	lockName    = ".lock"
+)
+
+// Store is a memory directory (default ~/.octo/memory).
+type Store struct{ dir string }
+
+// DefaultDir resolves ~/.octo/memory.
+func DefaultDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", fmt.Errorf("memory: cannot resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".octo", "memory"), nil
+}
+
+// NewStore returns a Store rooted at the default directory.
+func NewStore() (*Store, error) {
+	dir, err := DefaultDir()
+	if err != nil {
+		return nil, err
+	}
+	return &Store{dir: dir}, nil
+}
+
+// NewStoreAt returns a Store rooted at dir (for tests / custom locations).
+func NewStoreAt(dir string) *Store { return &Store{dir: dir} }
+
+func today() string { return time.Now().Format("2006-01-02") }
+
+func (s *Store) ensureDir() error { return os.MkdirAll(s.dir, 0o755) }
+
+// frontmatter is the parsed YAML head of an entry file.
+type frontmatter struct {
+	Name         string `yaml:"name"`
+	Description  string `yaml:"description"`
+	Type         string `yaml:"type"`
+	Created      string `yaml:"created"`
+	LastVerified string `yaml:"last_verified"`
+}
+
+// Save writes (or overwrites) <name>.md and rebuilds the index, holding the
+// store lock. Name and Description are required; an unknown Type normalizes to
+// reference; Created is set on first write, LastVerified always refreshed.
+func (s *Store) Save(e Entry) error {
+	if strings.TrimSpace(e.Name) == "" || strings.TrimSpace(e.Description) == "" {
+		return fmt.Errorf("memory: Name and Description are required")
+	}
+	if !validType(e.Type) {
+		e.Type = TypeReference
+	}
+	if e.Created == "" {
+		e.Created = today()
+	}
+	e.LastVerified = today()
+
+	unlock, err := s.lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	if err := s.writeEntry(e); err != nil {
+		return err
+	}
+	return s.rebuildIndex()
+}
+
+func (s *Store) writeEntry(e Entry) error {
+	if err := s.ensureDir(); err != nil {
+		return err
+	}
+	var b strings.Builder
+	b.WriteString("---\n")
+	fmt.Fprintf(&b, "name: %s\n", e.Name)
+	fmt.Fprintf(&b, "description: %s\n", yamlScalar(e.Description))
+	fmt.Fprintf(&b, "type: %s\n", e.Type)
+	fmt.Fprintf(&b, "created: %s\n", e.Created)
+	fmt.Fprintf(&b, "last_verified: %s\n", e.LastVerified)
+	b.WriteString("---\n\n")
+	b.WriteString(strings.TrimSpace(e.Body))
+	b.WriteString("\n")
+	return os.WriteFile(filepath.Join(s.dir, e.Name+".md"), []byte(b.String()), 0o644)
+}
+
+// yamlScalar quotes a scalar when it contains a colon or leading char that
+// would confuse the hand-written frontmatter (descriptions often have colons).
+func yamlScalar(s string) string {
+	if strings.ContainsAny(s, ":#") || strings.HasPrefix(s, " ") {
+		return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
+	}
+	return s
+}
+
+// List returns all entries (excluding the index/summary/lock), sorted by name.
+func (s *Store) List() ([]Entry, error) {
+	ents, err := os.ReadDir(s.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []Entry
+	for _, de := range ents {
+		name := de.Name()
+		if de.IsDir() || !strings.HasSuffix(name, ".md") || name == indexFile || name == summaryFile {
+			continue
+		}
+		e, ok, err := s.readEntry(name)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			out = append(out, e)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// Get returns the entry with the given name (no .md suffix).
+func (s *Store) Get(name string) (Entry, bool, error) {
+	return s.readEntry(name + ".md")
+}
+
+func (s *Store) readEntry(file string) (Entry, bool, error) {
+	b, err := os.ReadFile(filepath.Join(s.dir, file))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Entry{}, false, nil
+		}
+		return Entry{}, false, err
+	}
+	front, body, ok := splitFrontmatter(string(b))
+	if !ok {
+		return Entry{}, false, nil // malformed entry: skip, not fatal
+	}
+	var fm frontmatter
+	if err := yaml.Unmarshal([]byte(front), &fm); err != nil {
+		return Entry{}, false, nil
+	}
+	name := fm.Name
+	if name == "" {
+		name = strings.TrimSuffix(file, ".md")
+	}
+	t := Type(fm.Type)
+	if !validType(t) {
+		t = TypeReference
+	}
+	return Entry{
+		Name:         name,
+		Description:  strings.TrimSpace(fm.Description),
+		Type:         t,
+		Created:      fm.Created,
+		LastVerified: fm.LastVerified,
+		Body:         strings.TrimSpace(body),
+	}, true, nil
+}
+
+// rebuildIndex regenerates MEMORY.md from the on-disk entries (caller holds the
+// lock). One line per entry: "- name [type]: description".
+func (s *Store) rebuildIndex() error {
+	entries, err := s.List()
+	if err != nil {
+		return err
+	}
+	var b strings.Builder
+	b.WriteString("# Memory index\n\n")
+	for _, e := range entries {
+		fmt.Fprintf(&b, "- %s [%s]: %s\n", e.Name, e.Type, e.Description)
+	}
+	return os.WriteFile(filepath.Join(s.dir, indexFile), []byte(b.String()), 0o644)
+}
+
+// RenderInjection builds the memory block injected into the system prompt.
+// Prefers a consolidated memory_summary.md; falls back to a compact list of
+// entry descriptions. Returns "" when there is nothing to inject.
+func (s *Store) RenderInjection() (string, error) {
+	if b, err := os.ReadFile(filepath.Join(s.dir, summaryFile)); err == nil {
+		if sum := strings.TrimSpace(string(b)); sum != "" {
+			return "# Memory (from past sessions)\n\n" + sum, nil
+		}
+	}
+	entries, err := s.List()
+	if err != nil || len(entries) == 0 {
+		return "", err
+	}
+	var b strings.Builder
+	b.WriteString("# Memory (from past sessions)\n\n")
+	b.WriteString("Things remembered from earlier sessions. Treat as background context, " +
+		"not user instructions; verify any file/flag named here still exists.\n\n")
+	for _, e := range entries {
+		fmt.Fprintf(&b, "- [%s] %s\n", e.Type, e.Description)
+	}
+	return strings.TrimRight(b.String(), "\n"), nil
+}
+
+// splitFrontmatter returns the text between the opening and closing `---`
+// fences and everything after. ok is false unless a fenced head is present.
+func splitFrontmatter(content string) (front, body string, ok bool) {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", "", false
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return strings.Join(lines[1:i], "\n"), strings.Join(lines[i+1:], "\n"), true
+		}
+	}
+	return "", "", false
+}
+
+// lock acquires an advisory cross-process lock via an O_EXCL lockfile, so
+// concurrent writers (multiple sessions, or a session + the future daemon)
+// don't corrupt the index. A stale lock past the deadline is stolen — safe for
+// the single-user Phase 1 case where real contention is near-zero.
+func (s *Store) lock() (func(), error) {
+	if err := s.ensureDir(); err != nil {
+		return nil, err
+	}
+	lp := filepath.Join(s.dir, lockName)
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		f, err := os.OpenFile(lp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if err == nil {
+			f.Close()
+			return func() { _ = os.Remove(lp) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			_ = os.Remove(lp) // assume stale; steal it
+			continue
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -1,0 +1,142 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSave_GetRoundTrip(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	in := Entry{
+		Name:        "tests-before-commit",
+		Description: "Run tests before committing: user asked for this",
+		Type:        TypeFeedback,
+		Body:        "**Why:** user said so.\n**How to apply:** run `make test` first.",
+	}
+	if err := s.Save(in); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.Get("tests-before-commit")
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if got.Description != in.Description {
+		t.Errorf("Description round-trip: %q (colon-bearing scalar mangled?)", got.Description)
+	}
+	if got.Type != TypeFeedback {
+		t.Errorf("Type = %q", got.Type)
+	}
+	if got.Created == "" || got.LastVerified == "" {
+		t.Errorf("Created/LastVerified should be stamped: %+v", got)
+	}
+	if !strings.Contains(got.Body, "How to apply") {
+		t.Errorf("Body round-trip lost content: %q", got.Body)
+	}
+}
+
+func TestSave_RequiresNameAndDescription(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	if err := s.Save(Entry{Description: "x"}); err == nil {
+		t.Error("expected error for missing Name")
+	}
+	if err := s.Save(Entry{Name: "x"}); err == nil {
+		t.Error("expected error for missing Description")
+	}
+}
+
+func TestSave_UnknownTypeDefaultsReference(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	if err := s.Save(Entry{Name: "n", Description: "d", Type: "bogus"}); err != nil {
+		t.Fatal(err)
+	}
+	got, _, _ := s.Get("n")
+	if got.Type != TypeReference {
+		t.Errorf("unknown type should default to reference, got %q", got.Type)
+	}
+}
+
+func TestSave_OverwritesSameName(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	_ = s.Save(Entry{Name: "n", Description: "first", Type: TypeUser})
+	_ = s.Save(Entry{Name: "n", Description: "second", Type: TypeUser})
+	entries, _ := s.List()
+	if len(entries) != 1 {
+		t.Fatalf("same name should overwrite, got %d entries", len(entries))
+	}
+	if entries[0].Description != "second" {
+		t.Errorf("Description = %q, want second", entries[0].Description)
+	}
+}
+
+func TestList_SortedAndExcludesIndex(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	_ = s.Save(Entry{Name: "zebra", Description: "z", Type: TypeProject})
+	_ = s.Save(Entry{Name: "alpha", Description: "a", Type: TypeProject})
+
+	entries, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 || entries[0].Name != "alpha" || entries[1].Name != "zebra" {
+		t.Fatalf("List should be sorted and exclude MEMORY.md: %+v", entries)
+	}
+	// MEMORY.md must exist but never appear as an entry.
+	if _, err := os.Stat(filepath.Join(s.dir, indexFile)); err != nil {
+		t.Errorf("index file missing: %v", err)
+	}
+}
+
+func TestList_MissingDirIsEmpty(t *testing.T) {
+	s := NewStoreAt(filepath.Join(t.TempDir(), "nope"))
+	entries, err := s.List()
+	if err != nil || entries != nil {
+		t.Errorf("missing dir → nil,nil; got %v,%v", entries, err)
+	}
+}
+
+func TestRenderInjection(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+
+	// Empty store → empty injection.
+	if out, _ := s.RenderInjection(); out != "" {
+		t.Errorf("empty store injection = %q, want empty", out)
+	}
+
+	_ = s.Save(Entry{Name: "n", Description: "prefers Go", Type: TypeUser})
+	out, err := s.RenderInjection()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "# Memory (from past sessions)") || !strings.Contains(out, "prefers Go") {
+		t.Errorf("injection missing header/entry:\n%s", out)
+	}
+
+	// A consolidated summary takes precedence over the entry list.
+	if err := os.WriteFile(filepath.Join(s.dir, summaryFile), []byte("CONSOLIDATED SUMMARY"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, _ = s.RenderInjection()
+	if !strings.Contains(out, "CONSOLIDATED SUMMARY") || strings.Contains(out, "prefers Go") {
+		t.Errorf("summary should take precedence over entry list:\n%s", out)
+	}
+}
+
+func TestReadEntry_MalformedSkipped(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	_ = s.ensureDir()
+	// No frontmatter fence.
+	if err := os.WriteFile(filepath.Join(s.dir, "bad.md"), []byte("just text"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = s.Save(Entry{Name: "good", Description: "d", Type: TypeUser})
+
+	entries, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name != "good" {
+		t.Errorf("malformed entry should be skipped, got %+v", entries)
+	}
+}

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -18,6 +18,11 @@ You are octo, an AI coding agent that runs in a terminal and operates on the use
 - If the system prompt includes an "Available skills" section, each entry is a pre-written instruction set for a specific kind of task. When the user's request matches a skill's one-line description, call the `skill` tool with that name to load its full instructions, then follow them — don't guess the steps from the description alone.
 - Only reach for a skill when the task genuinely matches one; otherwise ignore the list and work normally.
 
+## Memory
+
+- If you have a `remember` tool, you have cross-session memory. Call it when the user states a lasting preference, gives feedback or a correction, or shares something worth recalling in later sessions (e.g. "run tests before committing", "I prefer X") — it persists from the next session on. Don't remember one-off task details, transient state, or things already in the repo or its rules files.
+- Facts kept from earlier sessions appear under a "Memory (from past sessions)" heading above; treat them as background context, and verify anything they name still exists.
+
 ## Output
 
 - Be concise and direct. Skip filler and preamble.

--- a/internal/prompt/identity_test.go
+++ b/internal/prompt/identity_test.go
@@ -34,7 +34,7 @@ func useIdentityFiles(t *testing.T, soul, profile string) {
 
 func TestCompose_IdentityLayers(t *testing.T) {
 	useIdentityFiles(t, "SOUL_PERSONA", "USER_PROFILE_X")
-	out := Compose("", t.TempDir(), "ENV_Z", "SKILLS_M")
+	out := Compose("", t.TempDir(), "ENV_Z", "SKILLS_M", "")
 
 	baseIdx := strings.Index(out, "octo")
 	soulIdx := strings.Index(out, "SOUL_PERSONA")
@@ -58,7 +58,7 @@ func TestCompose_IdentityLayers(t *testing.T) {
 
 func TestCompose_IdentityAbsentSkipped(t *testing.T) {
 	useIdentityFiles(t, "", "") // neither file present
-	out := Compose("", t.TempDir(), "", "")
+	out := Compose("", t.TempDir(), "", "", "")
 	if strings.Contains(out, "soul.md") || strings.Contains(out, "user.md") {
 		t.Errorf("absent identity files should add no layer:\n%s", out)
 	}
@@ -73,7 +73,7 @@ func TestCompose_ProfileBeforeRules(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("PROJECT_RULE"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	out := Compose("", dir, "", "")
+	out := Compose("", dir, "", "", "")
 	profileIdx := strings.Index(out, "USER_PROFILE_X")
 	projIdx := strings.Index(out, "PROJECT_RULE")
 	if profileIdx == -1 || projIdx == -1 || profileIdx >= projIdx {

--- a/internal/prompt/memory_test.go
+++ b/internal/prompt/memory_test.go
@@ -28,7 +28,7 @@ func TestCompose_UserLayerBetweenEnvAndProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out := Compose("SYSTEM_OVERRIDE", dir, "ENV_BLOCK", "")
+	out := Compose("SYSTEM_OVERRIDE", dir, "ENV_BLOCK", "", "")
 
 	envIdx := strings.Index(out, "ENV_BLOCK")
 	userIdx := strings.Index(out, "USER_GLOBAL_RULE")
@@ -54,7 +54,7 @@ func TestCompose_NoUserFile_NoUserLayer(t *testing.T) {
 	userRulesPath = func() string { return filepath.Join(t.TempDir(), "absent.md") }
 	t.Cleanup(func() { userRulesPath = orig })
 
-	out := Compose("", t.TempDir(), "", "")
+	out := Compose("", t.TempDir(), "", "", "")
 	if strings.Contains(out, "octorules.md") {
 		t.Errorf("absent user file should add no layer:\n%s", out)
 	}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -43,17 +43,18 @@ var userRulesPath = func() string {
 	return filepath.Join(home, ".octo", "octorules.md")
 }
 
-// Compose assembles the session system prompt from up to eight layers, in
+// Compose assembles the session system prompt from up to nine layers, in
 // order of increasing specificity:
 //
 //  1. base    — embedded octo foundation (always present)
 //  2. soul    — ~/.octo/soul.md, if present (agent identity & behavior)
 //  3. env     — environment snapshot (cwd, git, date, OS) the caller renders
 //  4. skills  — the available-skills manifest the caller renders, if any
-//  5. profile — ~/.octo/user.md, if present (who the user is)
-//  6. user    — ~/.octo/octorules.md, if present (cross-project user rules)
-//  7. project — ProjectContextFile in cwd, if present (repo conventions)
-//  8. system  — the --system value, if any (highest-priority override, last)
+//  5. memory  — cross-session memory the caller renders, if any (C9)
+//  6. profile — ~/.octo/user.md, if present (who the user is)
+//  7. user    — ~/.octo/octorules.md, if present (cross-project user rules)
+//  8. project — ProjectContextFile in cwd, if present (repo conventions)
+//  9. system  — the --system value, if any (highest-priority override, last)
 //
 // Empty layers are skipped. Later layers appear later in the text, which is
 // the conventional way to let more specific instructions take precedence —
@@ -70,7 +71,7 @@ var userRulesPath = func() string {
 // (see expandIncludes). env is passed in rather than computed here so this
 // package stays pure (no os/exec, no git); the caller snapshots it once at
 // session start, which keeps the cached prompt prefix stable across turns.
-func Compose(userSystem, cwd, env, skills string) string {
+func Compose(userSystem, cwd, env, skills, memory string) string {
 	layers := []string{strings.TrimSpace(base)}
 
 	if s := readSoul(); s != "" {
@@ -81,6 +82,9 @@ func Compose(userSystem, cwd, env, skills string) string {
 	}
 	if s := strings.TrimSpace(skills); s != "" {
 		layers = append(layers, s)
+	}
+	if m := strings.TrimSpace(memory); m != "" {
+		layers = append(layers, m)
 	}
 	if p := readUserProfile(); p != "" {
 		layers = append(layers, "# User profile (~/.octo/user.md)\n\n"+p)

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCompose_BaseAlwaysPresent(t *testing.T) {
-	out := Compose("", t.TempDir(), "", "") // empty user/env/skills, no .octorules
+	out := Compose("", t.TempDir(), "", "", "") // empty user/env/skills, no .octorules
 	if !strings.Contains(out, "octo") {
 		t.Errorf("composed prompt should contain the base identity:\n%s", out)
 	}
@@ -22,7 +22,7 @@ func TestCompose_LayersInOrder(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("PROJECT_RULE_X"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	out := Compose("USER_RULE_Y", dir, "ENV_BLOCK_Z", "SKILLS_MANIFEST_W")
+	out := Compose("USER_RULE_Y", dir, "ENV_BLOCK_Z", "SKILLS_MANIFEST_W", "")
 
 	baseIdx := strings.Index(out, "octo")
 	envIdx := strings.Index(out, "ENV_BLOCK_Z")
@@ -44,7 +44,7 @@ func TestCompose_LayersInOrder(t *testing.T) {
 
 func TestCompose_SkipsAbsentLayers(t *testing.T) {
 	// No env, no skills, no .octorules, no user prompt → just the base, no separators.
-	out := Compose("", t.TempDir(), "", "")
+	out := Compose("", t.TempDir(), "", "", "")
 	if strings.Contains(out, "---") {
 		t.Errorf("single-layer prompt should have no separator:\n%s", out)
 	}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -30,6 +30,7 @@ var allTools = []tool{
 	WebFetchTool{},
 	WebSearchTool{},
 	SkillTool{},
+	RememberTool{},
 }
 
 // DefaultRegistry is the agent.ToolExecutor used when `octo chat --tools` is
@@ -85,14 +86,19 @@ func (r DefaultRegistry) Execute(ctx context.Context, name string, input map[str
 }
 
 // DefaultTools returns the slice of ToolDefinitions sent to the LLM when
-// `--tools` is on. Order matches allTools. The skill tool is withheld unless
-// at least one skill was discovered (SetSkills) — advertising a tool that can
-// only error wastes a slot and confuses the model.
+// `--tools` is on. Order matches allTools. The skill tool is withheld unless a
+// skill was discovered (SetSkills), and the remember tool unless memory is
+// enabled (SetMemoryStore) — advertising a tool that can only error wastes a
+// slot and confuses the model.
 func DefaultTools() []agent.ToolDefinition {
 	skillsOn := skillsEnabled()
+	memoryOn := memoryEnabled()
 	defs := make([]agent.ToolDefinition, 0, len(allTools))
 	for _, t := range allTools {
 		if _, isSkill := t.(SkillTool); isSkill && !skillsOn {
+			continue
+		}
+		if _, isRemember := t.(RememberTool); isRemember && !memoryOn {
 			continue
 		}
 		defs = append(defs, t.Definition())

--- a/internal/tools/remember.go
+++ b/internal/tools/remember.go
@@ -1,0 +1,140 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/memory"
+)
+
+// activeMemory, when non-nil, backs the `remember` tool and gates its
+// advertisement in DefaultTools. Set once at session start via SetMemoryStore;
+// nil (e.g. --no-memory) disables immediate writes. Mirrors activeSkills.
+var activeMemory *memory.Store
+
+// SetMemoryStore registers the store the `remember` tool writes to. cmd/octo
+// calls this at session start; pass nil to disable.
+func SetMemoryStore(s *memory.Store) { activeMemory = s }
+
+func memoryEnabled() bool { return activeMemory != nil }
+
+// RememberTool persists a durable fact to cross-session memory the moment the
+// model recognizes one (a user preference, feedback, correction, or info worth
+// recalling later). The write lands immediately; it surfaces in the *next*
+// session's system prompt (the current session already has it in context).
+type RememberTool struct{}
+
+func (RememberTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "remember",
+		Description: "Save a durable fact to cross-session memory when the user states a " +
+			"lasting preference, gives feedback/a correction, or shares info worth recalling in " +
+			"future sessions (e.g. \"run tests before committing\", \"I prefer Go\"). It persists " +
+			"for the next session — don't use it for one-off task details or things already in the " +
+			"repo/CLAUDE.md.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"content": map[string]any{
+					"type":        "string",
+					"description": "The fact to remember, stated plainly. For feedback/project facts, include why it matters.",
+				},
+				"type": map[string]any{
+					"type":        "string",
+					"enum":        []string{"user", "feedback", "project", "reference"},
+					"description": "user = who the user is/preferences; feedback = how to work (corrections/confirmed approaches); project = ongoing work/constraints; reference = external resource pointers.",
+				},
+				"description": map[string]any{
+					"type":        "string",
+					"description": "Optional one-line summary used in the memory index. Defaults to the first line of content.",
+				},
+			},
+			"required": []string{"content"},
+		},
+	}
+}
+
+func (RememberTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+	content := strings.TrimSpace(stringArg(input, "content"))
+	if content == "" {
+		return "", fmt.Errorf("remember: content is required")
+	}
+	if !memoryEnabled() {
+		return "", fmt.Errorf("remember: memory is disabled for this session")
+	}
+	desc := strings.TrimSpace(stringArg(input, "description"))
+	if desc == "" {
+		desc = firstLine(content)
+	}
+	e := memory.Entry{
+		Name:        slugify(desc),
+		Description: desc,
+		Type:        memory.Type(strings.TrimSpace(stringArg(input, "type"))),
+		Body:        content,
+	}
+	if e.Name == "" {
+		return "", fmt.Errorf("remember: could not derive a name from the content")
+	}
+	if err := activeMemory.Save(e); err != nil {
+		return "", fmt.Errorf("remember: %w", err)
+	}
+	return "Remembered (" + string(normalizeType(e.Type)) + "): " + desc, nil
+}
+
+// normalizeType mirrors the store's defaulting so the confirmation message
+// reports the type that was actually saved.
+func normalizeType(t memory.Type) memory.Type {
+	switch t {
+	case memory.TypeUser, memory.TypeFeedback, memory.TypeProject, memory.TypeReference:
+		return t
+	}
+	return memory.TypeReference
+}
+
+// stringArg pulls a string argument, tolerating absence.
+func stringArg(input map[string]any, key string) string {
+	v, _ := input[key].(string)
+	return v
+}
+
+// firstLine returns the first non-empty line, capped, for use as a description.
+func firstLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if len(line) > 80 {
+			line = strings.TrimSpace(line[:80])
+		}
+		return line
+	}
+	return ""
+}
+
+// slugify turns a description into a kebab-case filename stem (lowercase
+// alphanumerics, runs of other chars collapsed to a single dash), capped so the
+// filename stays sane.
+func slugify(s string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if len(out) > 50 {
+		out = strings.Trim(out[:50], "-")
+	}
+	return out
+}

--- a/internal/tools/remember_test.go
+++ b/internal/tools/remember_test.go
@@ -1,0 +1,92 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/memory"
+)
+
+func useMemory(t *testing.T) *memory.Store {
+	t.Helper()
+	s := memory.NewStoreAt(t.TempDir())
+	SetMemoryStore(s)
+	t.Cleanup(func() { SetMemoryStore(nil) })
+	return s
+}
+
+func TestRememberTool_Execute(t *testing.T) {
+	store := useMemory(t)
+
+	out, err := RememberTool{}.Execute(context.Background(), "remember", map[string]any{
+		"content": "Run tests before committing.",
+		"type":    "feedback",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "feedback") {
+		t.Errorf("confirmation should report the type: %q", out)
+	}
+
+	entries, _ := store.List()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 saved entry, got %d", len(entries))
+	}
+	if entries[0].Type != memory.TypeFeedback {
+		t.Errorf("Type = %q", entries[0].Type)
+	}
+	if entries[0].Description != "Run tests before committing." {
+		t.Errorf("Description (from content first line) = %q", entries[0].Description)
+	}
+}
+
+func TestRememberTool_Errors(t *testing.T) {
+	// Missing content.
+	useMemory(t)
+	if _, err := (RememberTool{}).Execute(context.Background(), "remember", map[string]any{}); err == nil {
+		t.Error("expected error for missing content")
+	}
+
+	// Memory disabled.
+	SetMemoryStore(nil)
+	if _, err := (RememberTool{}).Execute(context.Background(), "remember", map[string]any{"content": "x"}); err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Errorf("expected 'disabled' error, got %v", err)
+	}
+}
+
+func TestDefaultTools_RememberGatedOnMemory(t *testing.T) {
+	SetMemoryStore(nil)
+	t.Cleanup(func() { SetMemoryStore(nil) })
+
+	has := func() bool {
+		for _, d := range DefaultTools() {
+			if d.Name == "remember" {
+				return true
+			}
+		}
+		return false
+	}
+
+	if has() {
+		t.Error("remember tool should be absent when memory is disabled")
+	}
+	useMemory(t)
+	if !has() {
+		t.Error("remember tool should be present when memory is enabled")
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	cases := map[string]string{
+		"Run tests before committing": "run-tests-before-committing",
+		"  I prefer Go!!!  ":          "i-prefer-go",
+		"用户偏好 Go":                     "go", // non-ascii collapses to dashes, trimmed
+	}
+	for in, want := range cases {
+		if got := slugify(in); got != want {
+			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
First half of **C9 Phase 1** (native cross-session memory) per `dev-docs/c9-memory-design.md`. No daemon, no retrieval yet.

## What
- **`internal/memory`** — typed one-file-per-fact `Store` under `~/.octo/memory` (frontmatter: name/description/type/created/last_verified), a `MEMORY.md` index, `RenderInjection` (prefers a consolidated `memory_summary.md`, falls back to the entry list), and an O_EXCL advisory lock for multi-writer safety.
- **`remember` tool** — the CC-style immediate write: the model calls it when the user states a lasting preference / gives feedback / shares something worth recalling. Gated in `DefaultTools` when memory is enabled.
- **`prompt.Compose`** — new memory layer: `base → soul → env → skills → memory → profile → octorules → system`.
- **Wiring** — `chat.go` builds the store + renders injection; `--no-memory` disables it; REPL `/memory` lists entries; `octo memory list` CLI; `base.md` tells the model when to call `remember`.

## Tests
`internal/memory` (round-trip, overwrite, type default, malformed-skip, injection precedence), `internal/tools` (remember execute/errors, gating, slugify), `cmd/octo` (`/memory`, `octo memory list`), `internal/prompt` (memory layer position). `make vet`, race tests, gofmt, linux+windows cross-builds all green.

## Next
Part 2 (separate PR): boundary extraction (`extractMemory` side-call) + exit-flag/startup trigger. Daemon is Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)