### PR TITLE
feat(memory): C9 Phase 1 part 2 — boundary extraction + startup triggers

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -169,16 +169,14 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	skillsManifest := skills.RenderManifest(skillReg)
 	tools.SetSkills(skillReg)
 
-	// Cross-session memory (C9): the store backs the `remember` tool and renders
-	// this session's memory injection. --no-memory disables both. A store error
+	// Cross-session memory (C9): the store backs the `remember` tool and (below)
+	// renders this session's injection. --no-memory disables both. A store error
 	// (e.g. unresolvable home dir) degrades to no memory rather than failing.
-	var memInjection string
 	var memStore *memory.Store
 	if !*noMemory {
 		if store, err := memory.NewStore(); err == nil {
 			memStore = store
 			tools.SetMemoryStore(store)
-			memInjection, _ = store.RenderInjection()
 		}
 	}
 
@@ -197,11 +195,23 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		thinkingBudget: *thinkingBudget,
 		thinkingOut:    stdout,
 	}, resolvedModel)
-	a.System = prompt.Compose(*system, cwd, env, skillsManifest, memInjection)
 	a.MaxTokens = *maxTokens
 	a.MaxTurns = *maxTurns
 	a.MaxCostUSD = *maxCost
 	a.CompactThreshold = *compactThreshold
+
+	// Boundary memory (REPL only): extract durable facts from the previous
+	// session and consolidate if due, BEFORE rendering this session's injection
+	// so freshly captured facts apply immediately rather than a session later.
+	// Skips the session being resumed. Best-effort — errors don't block startup.
+	if isREPL && memStore != nil {
+		maybeProcessMemory(a, memStore, stdout, resumeID)
+	}
+	var memInjection string
+	if memStore != nil {
+		memInjection, _ = memStore.RenderInjection()
+	}
+	a.System = prompt.Compose(*system, cwd, env, skillsManifest, memInjection)
 
 	// ── REPL mode ────────────────────────────────────────────────────────────
 	if isREPL {

--- a/cmd/octo/memory_extract.go
+++ b/cmd/octo/memory_extract.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/memory"
+)
+
+// Consolidation triggers (Phase 1 fallback; the daemon will own these later).
+const (
+	consolidateMinEntries = 5
+	consolidateMinAge     = 24 * time.Hour
+)
+
+// maybeProcessMemory runs the boundary-extraction + consolidation triggers at
+// session start (the no-daemon fallback path). It extracts durable facts from
+// the most-recent finished session (skipping excludeID, the one we're about to
+// resume), then consolidates if due. Best-effort: any side-call error is
+// swallowed so a memory hiccup never blocks the session.
+func maybeProcessMemory(a *agent.Agent, store *memory.Store, out io.Writer, excludeID string) {
+	if store == nil {
+		return
+	}
+	ctx := context.Background()
+	st := store.LoadState()
+
+	extractPreviousSession(ctx, a, store, out, excludeID, &st)
+	consolidateIfDue(ctx, a, store, &st)
+
+	_ = store.SaveState(st)
+}
+
+func extractPreviousSession(ctx context.Context, a *agent.Agent, store *memory.Store, out io.Writer, excludeID string, st *memory.State) {
+	sessions, err := agent.ListSessions(2)
+	if err != nil {
+		return
+	}
+	for _, sess := range sessions {
+		if sess.ID == excludeID {
+			continue // the session we're resuming — still ongoing
+		}
+		if sess.ID == st.LastExtractedSession || sess.TurnCount() == 0 {
+			return // reached the already-extracted boundary (or nothing to do)
+		}
+		facts, err := a.ExtractMemory(ctx, sess.ToHistory().Snapshot())
+		if err == nil {
+			n := 0
+			for _, f := range facts {
+				if serr := store.Save(memory.Entry{
+					Description: f.Description,
+					Type:        memory.Type(f.Type),
+					Body:        f.Content,
+				}); serr == nil {
+					n++
+				}
+			}
+			if n > 0 {
+				fmt.Fprintf(out, "  ⓘ remembered %d fact(s) from your last session\n", n)
+			}
+		}
+		st.LastExtractedSession = sess.ID
+		return // only the most-recent session, to bound startup cost
+	}
+}
+
+func consolidateIfDue(ctx context.Context, a *agent.Agent, store *memory.Store, st *memory.State) {
+	if !consolidateDue(*st, store) {
+		return
+	}
+	notes, err := store.ExportNotes()
+	if err != nil || notes == "" {
+		return
+	}
+	summary, err := a.ConsolidateMemory(ctx, notes)
+	if err != nil || summary == "" {
+		return
+	}
+	if store.WriteSummary(summary) == nil {
+		st.LastConsolidated = time.Now().Format("2006-01-02")
+	}
+}
+
+func consolidateDue(st memory.State, store *memory.Store) bool {
+	entries, err := store.List()
+	if err != nil || len(entries) < consolidateMinEntries {
+		return false
+	}
+	if st.LastConsolidated == "" {
+		return true
+	}
+	last, err := time.Parse("2006-01-02", st.LastConsolidated)
+	if err != nil {
+		return true
+	}
+	return time.Since(last) >= consolidateMinAge
+}

--- a/internal/agent/extract.go
+++ b/internal/agent/extract.go
@@ -1,0 +1,157 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// extractMaxTokens caps the memory-extraction side-call. Like the compaction
+// summary, an extraction is a short structured carry-forward, not a transcript.
+const extractMaxTokens = 1024
+
+// extractSystem instructs the extraction side-call to mine a finished
+// conversation for durable, cross-session facts and emit them as JSON. It is
+// the boundary counterpart to the immediate `remember` tool: remember catches
+// explicit signals mid-session, this sweeps for what the model didn't record.
+const extractSystem = `You extract durable, cross-session memories from a coding agent's finished
+conversation. Output ONLY a JSON array; each element:
+
+  {"type": "user|feedback|project|reference", "description": "<one line>", "content": "<the fact>"}
+
+Record ONLY load-bearing facts worth recalling in FUTURE sessions:
+- user: who the user is; durable preferences.
+- feedback: how to work — corrections and confirmed approaches (say why).
+- project: ongoing goals/constraints not derivable from the code or git history.
+- reference: pointers to external resources (URLs, dashboards, tickets).
+
+Do NOT record: one-off task details, things already in the repo / CLAUDE.md,
+transient state, or anything likely to change next session. Quality over
+quantity — most turns yield nothing. If nothing qualifies, output exactly [].
+No prose, no code fences around the array unless you must — just the JSON.`
+
+// consolidateSystem instructs the consolidation side-call to fold the current
+// memory notes into a compact summary (dedupe, drop stale, keep load-bearing).
+const consolidateSystem = `You consolidate a coding agent's cross-session memory notes into a compact
+summary for injection into future sessions. Merge duplicates, drop anything
+stale or trivial, and keep the load-bearing facts. Be terse — bullet points,
+grouped loosely by kind (who the user is, how they like to work, ongoing
+project context, useful references). Output only the summary text.`
+
+// MemoryFact is one extracted fact (the JSON shape the extraction side-call
+// returns). type maps to memory.Type at the call site.
+type MemoryFact struct {
+	Type        string `json:"type"`
+	Description string `json:"description"`
+	Content     string `json:"content"`
+}
+
+// ExtractMemory runs the extraction side-call over msgs (a finished session's
+// messages) and returns the durable facts found. It does not write anything —
+// the caller persists the facts. A nil slice means "nothing worth keeping".
+func (a *Agent) ExtractMemory(ctx context.Context, msgs []Message) ([]MemoryFact, error) {
+	if a.Sender == nil {
+		return nil, fmt.Errorf("agent: no Sender configured")
+	}
+	if len(msgs) == 0 {
+		return nil, nil
+	}
+	req := make([]Message, 0, len(msgs)+1)
+	req = append(req, msgs...)
+	req = append(req, NewUserMessage(
+		"Extract durable memories from the conversation above per your instructions. Output only the JSON array."))
+
+	reply, err := a.Sender.SendMessages(ctx, a.Model, extractSystem, req, extractMaxTokens)
+	if err != nil {
+		return nil, err
+	}
+	a.sessionInputTokens += reply.InputTokens
+	a.sessionOutputTokens += reply.OutputTokens
+	return parseFacts(reply.Content)
+}
+
+// ConsolidateMemory runs the consolidation side-call over the rendered current
+// notes and returns the consolidated summary text.
+func (a *Agent) ConsolidateMemory(ctx context.Context, notes string) (string, error) {
+	if a.Sender == nil {
+		return "", fmt.Errorf("agent: no Sender configured")
+	}
+	if strings.TrimSpace(notes) == "" {
+		return "", nil
+	}
+	req := []Message{NewUserMessage("Current memory notes:\n\n" + notes + "\n\nConsolidate per your instructions.")}
+	reply, err := a.Sender.SendMessages(ctx, a.Model, consolidateSystem, req, extractMaxTokens)
+	if err != nil {
+		return "", err
+	}
+	a.sessionInputTokens += reply.InputTokens
+	a.sessionOutputTokens += reply.OutputTokens
+	return strings.TrimSpace(reply.Content), nil
+}
+
+// parseFacts extracts the JSON array from a side-call reply (tolerating a code
+// fence or surrounding prose) and normalizes each fact. A reply with no array
+// yields nil, nil — "nothing to record" is not an error.
+func parseFacts(s string) ([]MemoryFact, error) {
+	s = strings.TrimSpace(stripCodeFence(s))
+	i := strings.Index(s, "[")
+	j := strings.LastIndex(s, "]")
+	if i < 0 || j < 0 || j < i {
+		return nil, nil
+	}
+	var facts []MemoryFact
+	if err := json.Unmarshal([]byte(s[i:j+1]), &facts); err != nil {
+		return nil, fmt.Errorf("agent: parse memory facts: %w", err)
+	}
+	out := make([]MemoryFact, 0, len(facts))
+	for _, f := range facts {
+		f.Content = strings.TrimSpace(f.Content)
+		f.Description = strings.TrimSpace(f.Description)
+		if f.Content == "" && f.Description == "" {
+			continue
+		}
+		if f.Content == "" {
+			f.Content = f.Description
+		}
+		if f.Description == "" {
+			f.Description = firstLineOf(f.Content)
+		}
+		out = append(out, f)
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// stripCodeFence removes a leading ```… fence and trailing ``` if present, so a
+// fenced JSON block parses.
+func stripCodeFence(s string) string {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "```") {
+		return s
+	}
+	if nl := strings.IndexByte(s, '\n'); nl >= 0 {
+		s = s[nl+1:] // drop the ```lang line
+	}
+	if idx := strings.LastIndex(s, "```"); idx >= 0 {
+		s = s[:idx]
+	}
+	return strings.TrimSpace(s)
+}
+
+// firstLineOf returns the first non-empty line, capped, for a fallback description.
+func firstLineOf(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if len(line) > 80 {
+			line = strings.TrimSpace(line[:80])
+		}
+		return line
+	}
+	return ""
+}

--- a/internal/agent/extract_test.go
+++ b/internal/agent/extract_test.go
@@ -1,0 +1,122 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// stubExtractSender returns a canned reply for both extract and consolidate
+// side-calls. It captures the system prompt so tests can assert which side-call
+// fired.
+type stubExtractSender struct {
+	reply        string
+	err          error
+	lastSystem   string
+	lastMessages []Message
+}
+
+func (s *stubExtractSender) SendMessages(_ context.Context, _, system string, msgs []Message, _ int) (Reply, error) {
+	s.lastSystem = system
+	s.lastMessages = msgs
+	if s.err != nil {
+		return Reply{}, s.err
+	}
+	return Reply{Content: s.reply, InputTokens: 10, OutputTokens: 20}, nil
+}
+
+func (s *stubExtractSender) StreamMessages(_ context.Context, _, _ string, _ []Message, _ int, _ func(string)) (Reply, error) {
+	return s.SendMessages(context.Background(), "", "", nil, 0)
+}
+
+func TestParseFacts(t *testing.T) {
+	good := `[{"type":"user","description":"prefers Go","content":"User likes Go."},{"type":"feedback","description":"run tests first","content":"Always run tests before committing."}]`
+	facts, err := parseFacts(good)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(facts) != 2 || facts[0].Type != "user" || facts[1].Description != "run tests first" {
+		t.Errorf("parseFacts wrong: %+v", facts)
+	}
+}
+
+func TestParseFacts_FencedAndPreamble(t *testing.T) {
+	fenced := "```json\n[{\"type\":\"user\",\"description\":\"d\",\"content\":\"c\"}]\n```"
+	facts, _ := parseFacts(fenced)
+	if len(facts) != 1 {
+		t.Errorf("fenced should parse one fact: %+v", facts)
+	}
+	withPreamble := "Here you go:\n[{\"type\":\"user\",\"description\":\"d\",\"content\":\"c\"}]"
+	facts, _ = parseFacts(withPreamble)
+	if len(facts) != 1 {
+		t.Errorf("preamble should not block parsing: %+v", facts)
+	}
+}
+
+func TestParseFacts_EmptyAndMissingArray(t *testing.T) {
+	if facts, err := parseFacts("[]"); err != nil || facts != nil {
+		t.Errorf("[] should yield nil,nil; got %v,%v", facts, err)
+	}
+	if facts, err := parseFacts("nothing interesting"); err != nil || facts != nil {
+		t.Errorf("no array should yield nil,nil; got %v,%v", facts, err)
+	}
+}
+
+func TestParseFacts_DescriptionFromContent(t *testing.T) {
+	in := `[{"type":"user","content":"User prefers Go.\nDetails follow."}]`
+	facts, _ := parseFacts(in)
+	if len(facts) != 1 || facts[0].Description != "User prefers Go." {
+		t.Errorf("description should default to first line of content: %+v", facts)
+	}
+}
+
+func TestExtractMemory(t *testing.T) {
+	s := &stubExtractSender{reply: `[{"type":"feedback","description":"run tests first","content":"Always run tests before committing."}]`}
+	a := New(s, "test-model")
+	msgs := []Message{NewUserMessage("test")}
+
+	facts, err := a.ExtractMemory(context.Background(), msgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(facts) != 1 || facts[0].Description != "run tests first" {
+		t.Errorf("ExtractMemory: %+v", facts)
+	}
+	if !strings.Contains(s.lastSystem, "JSON array") {
+		t.Errorf("ExtractMemory should use the extract system prompt, got %q", s.lastSystem)
+	}
+}
+
+func TestExtractMemory_NoMessages(t *testing.T) {
+	a := New(&stubExtractSender{}, "test-model")
+	facts, err := a.ExtractMemory(context.Background(), nil)
+	if err != nil || facts != nil {
+		t.Errorf("no messages → nil,nil; got %v,%v", facts, err)
+	}
+}
+
+func TestExtractMemory_SenderError(t *testing.T) {
+	s := &stubExtractSender{err: errors.New("boom")}
+	a := New(s, "test-model")
+	if _, err := a.ExtractMemory(context.Background(), []Message{NewUserMessage("x")}); err == nil {
+		t.Error("expected error to propagate")
+	}
+}
+
+func TestConsolidateMemory(t *testing.T) {
+	s := &stubExtractSender{reply: "Consolidated summary."}
+	a := New(s, "test-model")
+	out, err := a.ConsolidateMemory(context.Background(), "- [user] prefers Go")
+	if err != nil || out != "Consolidated summary." {
+		t.Errorf("ConsolidateMemory out=%q err=%v", out, err)
+	}
+	if !strings.Contains(s.lastSystem, "consolidate") {
+		t.Errorf("should use consolidate system prompt, got %q", s.lastSystem)
+	}
+	// Empty notes → empty summary, no call.
+	out, _ = a.ConsolidateMemory(context.Background(), "")
+	if out != "" {
+		t.Errorf("empty notes should return empty, got %q", out)
+	}
+}

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -10,6 +10,7 @@
 package memory
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -52,6 +53,7 @@ type Entry struct {
 const (
 	indexFile   = "MEMORY.md"
 	summaryFile = "memory_summary.md"
+	stateFile   = ".state"
 	lockName    = ".lock"
 )
 
@@ -96,8 +98,14 @@ type frontmatter struct {
 // store lock. Name and Description are required; an unknown Type normalizes to
 // reference; Created is set on first write, LastVerified always refreshed.
 func (s *Store) Save(e Entry) error {
-	if strings.TrimSpace(e.Name) == "" || strings.TrimSpace(e.Description) == "" {
-		return fmt.Errorf("memory: Name and Description are required")
+	if strings.TrimSpace(e.Description) == "" {
+		return fmt.Errorf("memory: Description is required")
+	}
+	if strings.TrimSpace(e.Name) == "" {
+		e.Name = Slugify(e.Description)
+	}
+	if e.Name == "" {
+		return fmt.Errorf("memory: could not derive a name from the description")
 	}
 	if !validType(e.Type) {
 		e.Type = TypeReference
@@ -289,4 +297,86 @@ func (s *Store) lock() (func(), error) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
+}
+
+// Slugify turns text into a kebab-case filename stem (lowercase alphanumerics,
+// runs of other chars collapsed to one dash), capped so filenames stay sane.
+func Slugify(s string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if len(out) > 50 {
+		out = strings.Trim(out[:50], "-")
+	}
+	return out
+}
+
+// State tracks what the boundary-extraction/consolidation triggers have already
+// done, so startup doesn't re-extract the same session or over-consolidate.
+type State struct {
+	LastExtractedSession string `json:"last_extracted_session"`
+	LastConsolidated     string `json:"last_consolidated"` // YYYY-MM-DD
+}
+
+// LoadState reads .state; a missing/unreadable file yields a zero State.
+func (s *Store) LoadState() State {
+	var st State
+	b, err := os.ReadFile(filepath.Join(s.dir, stateFile))
+	if err != nil {
+		return st
+	}
+	_ = json.Unmarshal(b, &st)
+	return st
+}
+
+// SaveState writes .state.
+func (s *Store) SaveState(st State) error {
+	if err := s.ensureDir(); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(s.dir, stateFile), b, 0o644)
+}
+
+// WriteSummary writes the consolidated memory summary (the injection source,
+// preferred by RenderInjection over the entry list).
+func (s *Store) WriteSummary(summary string) error {
+	if err := s.ensureDir(); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(s.dir, summaryFile), []byte(strings.TrimSpace(summary)+"\n"), 0o644)
+}
+
+// ExportNotes renders all entries as plain text for the consolidation
+// side-call (name, type, description, body per entry).
+func (s *Store) ExportNotes() (string, error) {
+	entries, err := s.List()
+	if err != nil || len(entries) == 0 {
+		return "", err
+	}
+	var b strings.Builder
+	for _, e := range entries {
+		fmt.Fprintf(&b, "- [%s] %s\n", e.Type, e.Description)
+		if e.Body != "" {
+			for _, line := range strings.Split(e.Body, "\n") {
+				fmt.Fprintf(&b, "  %s\n", line)
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "\n"), nil
 }

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -36,16 +36,6 @@ func TestSave_GetRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSave_RequiresNameAndDescription(t *testing.T) {
-	s := NewStoreAt(t.TempDir())
-	if err := s.Save(Entry{Description: "x"}); err == nil {
-		t.Error("expected error for missing Name")
-	}
-	if err := s.Save(Entry{Name: "x"}); err == nil {
-		t.Error("expected error for missing Description")
-	}
-}
-
 func TestSave_UnknownTypeDefaultsReference(t *testing.T) {
 	s := NewStoreAt(t.TempDir())
 	if err := s.Save(Entry{Name: "n", Description: "d", Type: "bogus"}); err != nil {
@@ -120,6 +110,77 @@ func TestRenderInjection(t *testing.T) {
 	out, _ = s.RenderInjection()
 	if !strings.Contains(out, "CONSOLIDATED SUMMARY") || strings.Contains(out, "prefers Go") {
 		t.Errorf("summary should take precedence over entry list:\n%s", out)
+	}
+}
+
+func TestSave_AutoSlugFromDescription(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	if err := s.Save(Entry{Description: "Run tests before committing!", Type: TypeFeedback}); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := s.List()
+	if len(entries) != 1 || entries[0].Name != "run-tests-before-committing" {
+		t.Errorf("Save should auto-slug from description, got %+v", entries)
+	}
+}
+
+func TestSave_RequiresDescription(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	if err := s.Save(Entry{Type: TypeUser}); err == nil {
+		t.Error("expected error for missing description (no source for auto-slug)")
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	cases := map[string]string{
+		"Run tests before committing!": "run-tests-before-committing",
+		"  Hello, World  ":             "hello-world",
+		"用户偏好 Go":                      "go",
+		"!!! ":                         "",
+	}
+	for in, want := range cases {
+		if got := Slugify(in); got != want {
+			t.Errorf("Slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestState_RoundTrip(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	if st := s.LoadState(); st.LastExtractedSession != "" || st.LastConsolidated != "" {
+		t.Errorf("missing state should be zero: %+v", st)
+	}
+	in := State{LastExtractedSession: "sess-123", LastConsolidated: "2026-05-28"}
+	if err := s.SaveState(in); err != nil {
+		t.Fatal(err)
+	}
+	got := s.LoadState()
+	if got != in {
+		t.Errorf("State round-trip: %+v, want %+v", got, in)
+	}
+}
+
+func TestWriteSummary_PreferredByInjection(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	_ = s.Save(Entry{Description: "prefers Go", Type: TypeUser})
+	if err := s.WriteSummary("CONSOLIDATED"); err != nil {
+		t.Fatal(err)
+	}
+	out, _ := s.RenderInjection()
+	if !strings.Contains(out, "CONSOLIDATED") || strings.Contains(out, "prefers Go") {
+		t.Errorf("WriteSummary should be preferred over entries:\n%s", out)
+	}
+}
+
+func TestExportNotes(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	if notes, _ := s.ExportNotes(); notes != "" {
+		t.Errorf("empty store ExportNotes = %q, want empty", notes)
+	}
+	_ = s.Save(Entry{Description: "prefers Go", Type: TypeUser, Body: "User said so."})
+	notes, _ := s.ExportNotes()
+	if !strings.Contains(notes, "[user] prefers Go") || !strings.Contains(notes, "User said so") {
+		t.Errorf("ExportNotes missing pieces:\n%s", notes)
 	}
 }
 


### PR DESCRIPTION
Second half of C9 Phase 1 (#93 was core). Implements the boundary-extraction path from `dev-docs/c9-memory-design.md` §4b–§5, in the no-daemon fallback shape: triggers run at session start before rendering the injection, so freshly captured facts apply to **this** session rather than slipping by a session.

## What
- **`internal/agent/extract.go`** — `ExtractMemory` and `ConsolidateMemory` side-calls, same shape as compaction's `summarize` (own system prompt, capped budget, tokens charged to the session). The extract prompt asks for a JSON array of `{type, description, content}`; the parser tolerates code fences and preamble.
- **`internal/memory`** — `Save` auto-slugs from `Description` when `Name` is empty; `Slugify` exported; `State` (`.state`: `LastExtractedSession`, `LastConsolidated`) with `LoadState`/`SaveState`; `WriteSummary` (writes `memory_summary.md`, preferred by `RenderInjection`); `ExportNotes` formats entries for the consolidation prompt.
- **`cmd/octo`** — `maybeProcessMemory` drives both triggers:
  - extract the most-recent unextracted session (skip the one being resumed)
  - consolidate when entries ≥ 5 and last consolidation older than 24h
  - best-effort: a memory error never blocks startup
- **`chat.go`** — hoist agent construction; call `maybeProcessMemory` **before** rendering the memory injection in REPL mode, so just-captured facts make it into this session's prompt.

## Tests
- `internal/agent`: `parseFacts` (good / fenced / preamble / empty / fallback description), `ExtractMemory` (sender invocation, system prompt, no-message, error propagation), `ConsolidateMemory`.
- `internal/memory`: auto-slug, `Slugify`, state round-trip, summary preference, `ExportNotes`.
- `make vet`, race tests, gofmt, linux+windows cross-builds all green.

## What this completes
C9 Phase 1 is now done (native, no daemon): immediate `remember` + boundary extraction + consolidation + typed store + summary injection. Phase 2 (resident `octo memoryd`) and Phase 3 (plugin + Hindsight) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)