### PR TITLE
feat(memory): incremental consolidate + archive consolidated entries

### DIFF
--- a/cmd/octo/memory.go
+++ b/cmd/octo/memory.go
@@ -3,16 +3,24 @@ package main
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/Leihb/octo-agent/internal/memory"
 )
 
-// runMemory handles `octo memory <subcommand>`. Currently just `list`, which
-// prints the stored cross-session memory entries.
+// runMemory handles `octo memory <subcommand>`. Currently `list` (active
+// entries + consolidated summary) and `list --archive` (entries already folded
+// into the summary, kept as authoritative sources).
 func runMemory(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] != "list" {
-		fmt.Fprintln(stderr, "Usage: octo memory list")
+		fmt.Fprintln(stderr, "Usage: octo memory list [--archive]")
 		return 2
+	}
+	showArchive := false
+	for _, a := range args[1:] {
+		if a == "--archive" {
+			showArchive = true
+		}
 	}
 
 	store, err := memory.NewStore()
@@ -20,18 +28,45 @@ func runMemory(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "octo memory: %v\n", err)
 		return 1
 	}
-	entries, err := store.List()
+
+	var (
+		entries []memory.Entry
+		header  string
+	)
+	if showArchive {
+		entries, err = store.ListArchived()
+		header = "Archived memories:"
+	} else {
+		entries, err = store.List()
+		header = "Stored memories:"
+	}
 	if err != nil {
 		fmt.Fprintf(stderr, "octo memory: %v\n", err)
 		return 1
 	}
-	if len(entries) == 0 {
+
+	switch {
+	case len(entries) == 0 && showArchive:
+		fmt.Fprintln(stdout, "No archived memories.")
+	case len(entries) == 0:
 		fmt.Fprintln(stdout, "No memories stored.")
-		return 0
+	default:
+		fmt.Fprintln(stdout, header)
+		for _, e := range entries {
+			fmt.Fprintf(stdout, "  %-28s [%-9s] %s\n", e.Name, e.Type, e.Description)
+		}
 	}
-	fmt.Fprintln(stdout, "Stored memories:")
-	for _, e := range entries {
-		fmt.Fprintf(stdout, "  %-28s [%-9s] %s\n", e.Name, e.Type, e.Description)
+
+	// In the non-archive view, also show the consolidated summary (the actual
+	// injection source) so users can see consolidation happened — otherwise it
+	// generates memory_summary.md silently.
+	if !showArchive {
+		if sum := store.ReadSummary(); sum != "" {
+			fmt.Fprintln(stdout, "\nConsolidated summary (injected next session):")
+			for _, line := range strings.Split(sum, "\n") {
+				fmt.Fprintf(stdout, "  %s\n", line)
+			}
+		}
 	}
 	return 0
 }

--- a/cmd/octo/memory_extract.go
+++ b/cmd/octo/memory_extract.go
@@ -71,17 +71,26 @@ func consolidateIfDue(ctx context.Context, a *agent.Agent, store *memory.Store, 
 	if !consolidateDue(*st, store) {
 		return
 	}
-	notes, err := store.ExportNotes()
-	if err != nil || notes == "" {
-		return
+	newNotes, err := store.ExportNotes()
+	if err != nil || newNotes == "" {
+		return // no new active entries — nothing to fold in
 	}
-	summary, err := a.ConsolidateMemory(ctx, notes)
+	priorSummary := store.ReadSummary()
+	summary, err := a.ConsolidateMemory(ctx, priorSummary, newNotes)
 	if err != nil || summary == "" {
 		return
 	}
-	if store.WriteSummary(summary) == nil {
-		st.LastConsolidated = time.Now().Format("2006-01-02")
+	if err := store.WriteSummary(summary); err != nil {
+		return
 	}
+	// Archive the active entries that were just folded into the summary, so
+	// neither the next consolidation's input nor the injection fallback grows
+	// unbounded. A failure here leaves them active and they'll be re-folded
+	// next time — idempotent (same facts in, same summary out).
+	if err := store.ArchiveAll(); err != nil {
+		return
+	}
+	st.LastConsolidated = time.Now().Format("2006-01-02")
 }
 
 func consolidateDue(st memory.State, store *memory.Store) bool {

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -254,26 +254,53 @@ func printReplHelp(w io.Writer) {
 	fmt.Fprintln(w, "  /exit       Save and exit  (also: /quit, Ctrl-C, Ctrl-D)")
 }
 
-// printMemory lists the cross-session memory entries, or a hint when memory is
-// off / empty.
+// printMemory shows what cross-session memory looks like: active entries
+// (not yet consolidated), the consolidated summary (the actual injection
+// source), and a pointer to the archive. Off / empty states are reported.
 func printMemory(w io.Writer, store *memory.Store) {
 	if store == nil {
 		fmt.Fprintln(w, "Memory is disabled for this session (--no-memory).")
 		return
 	}
-	entries, err := store.List()
+	active, err := store.List()
 	if err != nil {
 		fmt.Fprintf(w, "memory: %v\n", err)
 		return
 	}
-	if len(entries) == 0 {
+	archived, _ := store.ListArchived()
+	summary := store.ReadSummary()
+
+	if len(active) == 0 && summary == "" && len(archived) == 0 {
 		fmt.Fprintln(w, "Nothing remembered yet.")
 		return
 	}
-	fmt.Fprintln(w, "Remembered across sessions:")
-	for _, e := range entries {
-		fmt.Fprintf(w, "  [%-9s] %s\n", e.Type, e.Description)
+
+	if len(active) > 0 {
+		fmt.Fprintln(w, "Active entries (not yet consolidated):")
+		for _, e := range active {
+			fmt.Fprintf(w, "  [%-9s] %s\n", e.Type, e.Description)
+		}
 	}
+	if summary != "" {
+		if len(active) > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, "Consolidated summary (injected next session):")
+		for _, line := range strings.Split(summary, "\n") {
+			fmt.Fprintf(w, "  %s\n", line)
+		}
+	}
+	if len(archived) > 0 {
+		fmt.Fprintf(w, "\n(%d archived entr%s — `octo memory list --archive` to view)\n",
+			len(archived), pluralEntries(len(archived)))
+	}
+}
+
+func pluralEntries(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
 }
 
 // reservedReplCommands are the built-in slash commands; a skill may not shadow

--- a/internal/agent/extract.go
+++ b/internal/agent/extract.go
@@ -31,13 +31,17 @@ transient state, or anything likely to change next session. Quality over
 quantity — most turns yield nothing. If nothing qualifies, output exactly [].
 No prose, no code fences around the array unless you must — just the JSON.`
 
-// consolidateSystem instructs the consolidation side-call to fold the current
-// memory notes into a compact summary (dedupe, drop stale, keep load-bearing).
-const consolidateSystem = `You consolidate a coding agent's cross-session memory notes into a compact
-summary for injection into future sessions. Merge duplicates, drop anything
+// consolidateSystem instructs the consolidation side-call to maintain (rather
+// than rebuild) a summary: it gets the current summary plus any new notes since
+// the last pass and emits the updated summary. This keeps the input bounded as
+// the memory store grows.
+const consolidateSystem = `You maintain a coding agent's cross-session memory summary. You will receive
+the current consolidated summary (which may be empty on the first pass) and
+any new memory notes added since the last consolidation. Produce the UPDATED
+summary: fold the new notes into the existing summary, dedupe, drop anything
 stale or trivial, and keep the load-bearing facts. Be terse — bullet points,
 grouped loosely by kind (who the user is, how they like to work, ongoing
-project context, useful references). Output only the summary text.`
+project context, useful references). Output only the updated summary text.`
 
 // MemoryFact is one extracted fact (the JSON shape the extraction side-call
 // returns). type maps to memory.Type at the call site.
@@ -71,16 +75,34 @@ func (a *Agent) ExtractMemory(ctx context.Context, msgs []Message) ([]MemoryFact
 	return parseFacts(reply.Content)
 }
 
-// ConsolidateMemory runs the consolidation side-call over the rendered current
-// notes and returns the consolidated summary text.
-func (a *Agent) ConsolidateMemory(ctx context.Context, notes string) (string, error) {
+// ConsolidateMemory runs the (incremental) consolidation side-call: it folds
+// newNotes into priorSummary and returns the updated summary. Either argument
+// may be empty — empty priorSummary means "first pass"; empty newNotes means
+// "no new material" and the call short-circuits.
+func (a *Agent) ConsolidateMemory(ctx context.Context, priorSummary, newNotes string) (string, error) {
 	if a.Sender == nil {
 		return "", fmt.Errorf("agent: no Sender configured")
 	}
-	if strings.TrimSpace(notes) == "" {
+	priorSummary = strings.TrimSpace(priorSummary)
+	newNotes = strings.TrimSpace(newNotes)
+	if priorSummary == "" && newNotes == "" {
 		return "", nil
 	}
-	req := []Message{NewUserMessage("Current memory notes:\n\n" + notes + "\n\nConsolidate per your instructions.")}
+
+	var prompt strings.Builder
+	if priorSummary != "" {
+		prompt.WriteString("Current consolidated summary:\n\n")
+		prompt.WriteString(priorSummary)
+		prompt.WriteString("\n\n")
+	}
+	if newNotes != "" {
+		prompt.WriteString("New memory notes since last consolidation:\n\n")
+		prompt.WriteString(newNotes)
+		prompt.WriteString("\n\n")
+	}
+	prompt.WriteString("Produce the updated consolidated summary per your instructions.")
+
+	req := []Message{NewUserMessage(prompt.String())}
 	reply, err := a.Sender.SendMessages(ctx, a.Model, consolidateSystem, req, extractMaxTokens)
 	if err != nil {
 		return "", err

--- a/internal/agent/extract_test.go
+++ b/internal/agent/extract_test.go
@@ -107,16 +107,32 @@ func TestExtractMemory_SenderError(t *testing.T) {
 func TestConsolidateMemory(t *testing.T) {
 	s := &stubExtractSender{reply: "Consolidated summary."}
 	a := New(s, "test-model")
-	out, err := a.ConsolidateMemory(context.Background(), "- [user] prefers Go")
+	out, err := a.ConsolidateMemory(context.Background(), "", "- [user] prefers Go")
 	if err != nil || out != "Consolidated summary." {
 		t.Errorf("ConsolidateMemory out=%q err=%v", out, err)
 	}
-	if !strings.Contains(s.lastSystem, "consolidate") {
+	if !strings.Contains(s.lastSystem, "summary") {
 		t.Errorf("should use consolidate system prompt, got %q", s.lastSystem)
 	}
-	// Empty notes → empty summary, no call.
-	out, _ = a.ConsolidateMemory(context.Background(), "")
-	if out != "" {
-		t.Errorf("empty notes should return empty, got %q", out)
+	// Both arguments empty → short-circuit to empty, no call.
+	s.lastMessages = nil
+	out, _ = a.ConsolidateMemory(context.Background(), "", "")
+	if out != "" || s.lastMessages != nil {
+		t.Errorf("empty inputs should short-circuit; out=%q msgs=%v", out, s.lastMessages)
+	}
+}
+
+func TestConsolidateMemory_IncrementalPrompt(t *testing.T) {
+	s := &stubExtractSender{reply: "merged"}
+	a := New(s, "test-model")
+	if _, err := a.ConsolidateMemory(context.Background(), "PRIOR_SUMMARY_XYZ", "NEW_NOTE_ABC"); err != nil {
+		t.Fatal(err)
+	}
+	if len(s.lastMessages) == 0 {
+		t.Fatal("expected a SendMessages call")
+	}
+	prompt := s.lastMessages[0].Content
+	if !strings.Contains(prompt, "PRIOR_SUMMARY_XYZ") || !strings.Contains(prompt, "NEW_NOTE_ABC") {
+		t.Errorf("prompt should carry both prior summary and new notes:\n%s", prompt)
 	}
 }

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -51,10 +51,11 @@ type Entry struct {
 }
 
 const (
-	indexFile   = "MEMORY.md"
-	summaryFile = "memory_summary.md"
-	stateFile   = ".state"
-	lockName    = ".lock"
+	indexFile     = "MEMORY.md"
+	summaryFile   = "memory_summary.md"
+	stateFile     = ".state"
+	lockName      = ".lock"
+	archiveSubdir = "archive"
 )
 
 // Store is a memory directory (default ~/.octo/memory).
@@ -362,8 +363,115 @@ func (s *Store) WriteSummary(summary string) error {
 	return os.WriteFile(filepath.Join(s.dir, summaryFile), []byte(strings.TrimSpace(summary)+"\n"), 0o644)
 }
 
-// ExportNotes renders all entries as plain text for the consolidation
-// side-call (name, type, description, body per entry).
+// ReadSummary returns the current consolidated summary, or "" if none.
+func (s *Store) ReadSummary() string {
+	b, err := os.ReadFile(filepath.Join(s.dir, summaryFile))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// ArchiveAll moves every active entry to archive/, then rebuilds the index.
+// Use after a successful consolidation: the entries are preserved as
+// authoritative sources (in archive/) but no longer feed the consolidation or
+// the injection fallback, so neither grows unbounded.
+func (s *Store) ArchiveAll() error {
+	unlock, err := s.lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	entries, err := s.List()
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	archiveDir := filepath.Join(s.dir, archiveSubdir)
+	if err := os.MkdirAll(archiveDir, 0o755); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		src := filepath.Join(s.dir, e.Name+".md")
+		dst := filepath.Join(archiveDir, e.Name+".md")
+		// If an archived file with the same name already exists, overwrite —
+		// the active version is more recent.
+		_ = os.Remove(dst)
+		if err := os.Rename(src, dst); err != nil {
+			return err
+		}
+	}
+	return s.rebuildIndex()
+}
+
+// ListArchived returns all archived entries, sorted by name. Archived entries
+// remain queryable as authoritative sources but do not feed the consolidation
+// or injection paths.
+func (s *Store) ListArchived() ([]Entry, error) {
+	archiveDir := filepath.Join(s.dir, archiveSubdir)
+	ents, err := os.ReadDir(archiveDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []Entry
+	for _, de := range ents {
+		name := de.Name()
+		if de.IsDir() || !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		e, ok, err := s.readArchived(name)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			out = append(out, e)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func (s *Store) readArchived(file string) (Entry, bool, error) {
+	b, err := os.ReadFile(filepath.Join(s.dir, archiveSubdir, file))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Entry{}, false, nil
+		}
+		return Entry{}, false, err
+	}
+	front, body, ok := splitFrontmatter(string(b))
+	if !ok {
+		return Entry{}, false, nil
+	}
+	var fm frontmatter
+	if err := yaml.Unmarshal([]byte(front), &fm); err != nil {
+		return Entry{}, false, nil
+	}
+	name := fm.Name
+	if name == "" {
+		name = strings.TrimSuffix(file, ".md")
+	}
+	t := Type(fm.Type)
+	if !validType(t) {
+		t = TypeReference
+	}
+	return Entry{
+		Name:         name,
+		Description:  strings.TrimSpace(fm.Description),
+		Type:         t,
+		Created:      fm.Created,
+		LastVerified: fm.LastVerified,
+		Body:         strings.TrimSpace(body),
+	}, true, nil
+}
+
+// ExportNotes renders all (active, non-archived) entries as plain text for the
+// consolidation side-call (name, type, description, body per entry).
 func (s *Store) ExportNotes() (string, error) {
 	entries, err := s.List()
 	if err != nil || len(entries) == 0 {

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -172,6 +172,74 @@ func TestWriteSummary_PreferredByInjection(t *testing.T) {
 	}
 }
 
+func TestArchiveAll_MovesEntriesAndRebuildsIndex(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	_ = s.Save(Entry{Description: "first", Type: TypeUser})
+	_ = s.Save(Entry{Description: "second", Type: TypeFeedback})
+
+	if err := s.ArchiveAll(); err != nil {
+		t.Fatal(err)
+	}
+	// Active list is now empty.
+	if active, _ := s.List(); len(active) != 0 {
+		t.Errorf("after ArchiveAll, List should be empty: %+v", active)
+	}
+	// Archived list contains both.
+	archived, err := s.ListArchived()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(archived) != 2 {
+		t.Fatalf("expected 2 archived entries, got %d", len(archived))
+	}
+	// Index was rebuilt (and now empty).
+	b, err := os.ReadFile(filepath.Join(s.dir, indexFile))
+	if err != nil {
+		t.Fatalf("index missing after archive: %v", err)
+	}
+	if strings.Contains(string(b), "first") || strings.Contains(string(b), "second") {
+		t.Errorf("index should not list archived entries:\n%s", string(b))
+	}
+}
+
+func TestArchiveAll_PreservesArchivedContent(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	_ = s.Save(Entry{Description: "a fact", Type: TypeProject, Body: "the body"})
+	_ = s.ArchiveAll()
+
+	archived, _ := s.ListArchived()
+	if len(archived) != 1 || archived[0].Body != "the body" || archived[0].Description != "a fact" {
+		t.Errorf("archived entry lost content: %+v", archived)
+	}
+}
+
+func TestArchiveAll_OverwritesPriorArchive(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	// First round: save and archive.
+	_ = s.Save(Entry{Name: "n", Description: "v1", Type: TypeUser})
+	_ = s.ArchiveAll()
+	// Second round: same name, new content — Save then Archive again.
+	_ = s.Save(Entry{Name: "n", Description: "v2", Type: TypeUser})
+	if err := s.ArchiveAll(); err != nil {
+		t.Fatal(err)
+	}
+	archived, _ := s.ListArchived()
+	if len(archived) != 1 || archived[0].Description != "v2" {
+		t.Errorf("archive should keep the latest version, got %+v", archived)
+	}
+}
+
+func TestReadSummary(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	if got := s.ReadSummary(); got != "" {
+		t.Errorf("missing summary = %q, want empty", got)
+	}
+	_ = s.WriteSummary("hello world")
+	if got := s.ReadSummary(); got != "hello world" {
+		t.Errorf("ReadSummary = %q, want %q", got, "hello world")
+	}
+}
+
 func TestExportNotes(t *testing.T) {
 	s := NewStoreAt(t.TempDir())
 	if notes, _ := s.ExportNotes(); notes != "" {


### PR DESCRIPTION
Addresses the long-term token-growth gap in C9 Phase 1 you flagged: active entries kept accumulating, so each consolidation re-ingested the entire history and grew without bound.

## What changes

- **Incremental `ConsolidateMemory`** — signature now `(priorSummary, newNotes)`. The system prompt asks the LLM to **fold new notes into the existing summary**, not re-consolidate from scratch. Empty inputs short-circuit.
- **Archive after consolidation** — `memory.Store.ArchiveAll` moves the active entries to `~/.octo/memory/archive/` once the new summary is written. Archived entries remain queryable as authoritative sources but no longer feed:
  - the next consolidation's input (only new active entries do)
  - the injection fallback (only active entries do; archive is invisible)
- **UX so consolidation is visible** —
  - REPL `/memory` shows active entries + the consolidated summary (the actual injection source) + a pointer to the archive
  - `octo memory list` mirrors that; `octo memory list --archive` views the archive

Net effect each round: input ≈ prior summary (~1KB) + N new entries; output ≈ updated summary. Bounded forever.

## Tests
- `agent`: `ConsolidateMemory` incremental prompt carries both prior + new; empty-inputs short-circuit (no call).
- `memory`: `ArchiveAll` moves entries / rebuilds the index / preserves archived content / overwrites prior archived versions with the same name; `ReadSummary` round-trip.
- `make vet`, race tests, gofmt, linux+windows cross-builds all green.

## Compat
- Existing `~/.octo/memory/` directories keep working: the archive subdir is created on first archive, missing-archive is treated as empty everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)