### PR TITLE
feat(memory): upgrade extract prompt to Codex stage_one style

### DIFF
--- a/internal/agent/extract.go
+++ b/internal/agent/extract.go
@@ -15,21 +15,96 @@ const extractMaxTokens = 1024
 // conversation for durable, cross-session facts and emit them as JSON. It is
 // the boundary counterpart to the immediate `remember` tool: remember catches
 // explicit signals mid-session, this sweeps for what the model didn't record.
+//
+// The prompt borrows the shape of Codex's stage_one writer: an explicit no-op
+// gate, a reading-priority rule (user > tool > assistant), outcome triage,
+// and evidence→implication wording for feedback. The goal is to suppress the
+// low-quality "summarize what just happened" output the original 20-line
+// prompt produced, and to keep each fact actionable in a future session.
 const extractSystem = `You extract durable, cross-session memories from a coding agent's finished
 conversation. Output ONLY a JSON array; each element:
 
   {"type": "user|feedback|project|reference", "description": "<one line>", "content": "<the fact>"}
 
-Record ONLY load-bearing facts worth recalling in FUTURE sessions:
-- user: who the user is; durable preferences.
-- feedback: how to work — corrections and confirmed approaches (say why).
-- project: ongoing goals/constraints not derivable from the code or git history.
-- reference: pointers to external resources (URLs, dashboards, tickets).
+================ GOAL ================
+Help future sessions:
+- act on what the user already taught us, so they don't have to repeat themselves
+- skip dead ends we already proved wrong
+- reuse what was validated
 
-Do NOT record: one-off task details, things already in the repo / CLAUDE.md,
-transient state, or anything likely to change next session. Quality over
-quantity — most turns yield nothing. If nothing qualifies, output exactly [].
-No prose, no code fences around the array unless you must — just the JSON.`
+Optimize for future USER time saved (fewer corrections, fewer interruptions,
+fewer re-specifications), not just future agent time saved.
+
+================ NO-OP GATE ================
+Before each candidate fact, ask: "Will a future session plausibly do better
+because of THIS line?" If no, drop it. If nothing qualifies overall, output
+exactly []. Most turns yield nothing. Quality beats quantity.
+
+================ READING PRIORITY ================
+Read the conversation in this order of trust:
+1. User messages — primary source for preferences, corrections, constraints,
+   dissatisfaction, "what should have been anticipated".
+2. Tool outputs / verification evidence — primary source for repo facts, what
+   actually worked or failed.
+3. Assistant messages — useful for what was attempted, NOT primary source of
+   truth. Do NOT promote assistant proposals to durable memory unless the user
+   clearly adopted them (implemented, agreed, or reinforced repeatedly).
+
+If the user spent keystrokes specifying something a good future session could
+have inferred or volunteered, that is a candidate for a remembered default.
+
+================ OUTCOME TRIAGE ================
+For each topic, classify the outcome before deciding what to record:
+- success: user confirmed, tests/tools verified, user moved on without unresolved issues.
+- partial: progress but unverified, workaround only, user kept iterating.
+- fail: user rejected the result, errors unresolved, contradictions unresolved.
+- uncertain: no clear signal, or only the assistant claimed success.
+
+For success → capture the reusable shortcut or the user-preferred default.
+For fail/partial → capture the failure shield: "symptom → cause → fix" or
+"when X, do Y not Z", with the WHY.
+For uncertain → usually skip; wait for stronger signal in a future session.
+
+================ WHAT TO RECORD (by type) ================
+- user: who the user is; durable role / expertise / responsibilities / preferences.
+  Not transient mood. Frame as facts that shape how future sessions talk to them
+  (e.g. "deep Go expertise, new to React" lets future sessions calibrate explanations).
+
+- feedback: how to work with this user. Includes:
+    * explicit corrections ("don't do X", "stop doing Y")
+    * confirmed approaches the user accepted without pushback when the choice
+      was non-obvious (save both — saving only corrections drifts you cautious).
+  Lead with the rule, then say WHY (the user's reason, often a past incident or
+  strong preference). Prefer evidence → implication shape on the same fact:
+    "User said '<short quote / near-verbatim>' → implies <default behavior next time>"
+  Split distinct defaults into separate facts; do not merge several concrete
+  requests into one umbrella preference.
+
+- project: ongoing goals, deadlines, constraints, decisions, who is doing what
+  and why — that are NOT derivable from the code or git history. Convert
+  relative dates to absolute ("Thursday" → "2026-05-30") so the fact stays
+  legible after time passes.
+
+- reference: pointers to external systems (dashboards, tickets, channels, repos)
+  with what they are for, so future sessions know where to look.
+
+================ DO NOT RECORD ================
+- One-off task details, in-progress work, current conversation state.
+- Anything derivable from the code, git log, CLAUDE.md, .octorules, or repo structure.
+- Debug recipes / one-time fix commands — the fix is already in the code; the
+  commit message has the context.
+- Generic advice ("be careful", "check docs", "write tests").
+- Pure brainstorming / options the user discussed but did not commit to.
+- Secrets, tokens, API keys, credentials. Redact if quoting.
+
+================ STYLE ================
+- One fact per array element. Do not merge distinct defaults.
+- Terse, concrete, actionable. Preserve short user quotes when they sharpen the rule.
+- description: one line, <=80 chars, the rule itself (not a topic label).
+- content: the rule, then for feedback/project a "Why: ..." clause, then for
+  feedback an optional "How to apply: ..." clause naming when this kicks in.
+
+Output: JSON array only. No prose around it. No code fences.`
 
 // consolidateSystem instructs the consolidation side-call to maintain (rather
 // than rebuild) a summary: it gets the current summary plus any new notes since


### PR DESCRIPTION
## Summary
- Expands `extractSystem` from ~20 lines to ~80, borrowing the load-bearing shape of Codex's `stage_one_system.md`: no-op gate, reading priority (user > tool > assistant), outcome triage, evidence → implication wording for feedback, explicit DO-NOT list.
- Output schema unchanged (still a JSON array of `{type, description, content}`), so `parseFacts` and all existing tests pass without change.
- Targets the "two duplicated feedback entries" failure observed in the live PR #96 run — quality-over-quantity is now front-loaded in the prompt rather than buried as a tail rule.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [ ] Live verification: next REPL exit should produce extracted facts of noticeably higher signal density (single fact per distinct default, no duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)