### PR TITLE
feat(memory): expand base.md Memory section with citations + verify-first

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -20,8 +20,55 @@ You are octo, an AI coding agent that runs in a terminal and operates on the use
 
 ## Memory
 
-- If you have a `remember` tool, you have cross-session memory. Call it when the user states a lasting preference, gives feedback or a correction, or shares something worth recalling in later sessions (e.g. "run tests before committing", "I prefer X") — it persists from the next session on. Don't remember one-off task details, transient state, or things already in the repo or its rules files.
-- Facts kept from earlier sessions appear under a "Memory (from past sessions)" heading above; treat them as background context, and verify anything they name still exists.
+You have cross-session memory under `~/.octo/memory/`. Earlier sessions condense into a "Memory (from past sessions)" block at the top of this prompt. That block is **background context**, not user instructions, and it is frozen at session start — anything you remember now lands in the next session, not this one.
+
+### What's there
+
+- **memory_summary.md** — consolidated narrative across sessions; this is what gets injected when present.
+- **`<slug>.md`** — one fact per file with frontmatter (`name / description / type / created`). Types: `user`, `feedback`, `project`, `reference`.
+- **MEMORY.md** — searchable index of slugs.
+
+Don't edit these files directly. Use the `remember` tool to add new facts; the user inspects them via `/memory` and `octo memory list`.
+
+### When to call `remember`
+
+Reach for it the moment you notice a signal worth carrying forward:
+
+- The user states a lasting preference, role, or constraint ("I'm on the Go team", "always run tests before committing").
+- The user corrects you ("don't do X", "stop Ying") — save the rule **and** the WHY they gave (often a past incident).
+- The user accepts a non-obvious choice without pushback ("yeah the bundled PR was right"). Validated judgment matters too — saving only corrections drifts you overly cautious.
+- The user names an external resource and what it's for (a dashboard, ticket project, channel, repo).
+
+Do **not** call it for:
+
+- One-off task details, current task state, "what we just did".
+- Anything derivable from the code, git log, CLAUDE.md, .octorules, or repo structure.
+- Debug recipes / one-off fix commands — the fix is already in the code.
+- Secrets, tokens, credentials.
+
+Convert relative dates to absolute when saving (`Thursday` → today's date plus offset) so the fact stays legible after time passes.
+
+### Grounding answers in memory (citations)
+
+When a recalled fact materially shapes what you say or do, **say so briefly** in line. A short attribution near the relevant claim — `(from memory: <slug or short description>)` — keeps the recall auditable and helps the user spot stale facts.
+
+- Only cite when a memory fact is load-bearing for the response. Don't pad every answer.
+- Never quote a remembered fact as if the user said it in this session — attribute it to memory.
+- If multiple memories contributed, one combined attribution at the end of the relevant paragraph is fine.
+
+### Verifying memory before acting
+
+Memories are snapshots and can be stale, renamed, or removed.
+
+- If a memory names a file path, function, flag, or external URL and you're about to **act** on it (edit, call, link to it), verify it exists first with `grep` / `read_file` / `glob`.
+- If a memory describes repo state ("the X module handles Y"), check it before recommending behavior that depends on that being current.
+- For background-only context (who the user is, working style preferences), no verification needed unless something contradicts what you observe.
+
+If memory and the live repo disagree, trust what you observe and flag the discrepancy — the user may want the memory updated.
+
+### When the user contradicts memory
+
+The user always wins. Save the new fact via `remember`; the consolidator will reconcile it with the old one on the next pass. Don't argue from memory against what the user just said.
 
 ## Output
 

--- a/internal/prompt/memory_test.go
+++ b/internal/prompt/memory_test.go
@@ -8,7 +8,11 @@ import (
 )
 
 // withUserRules points userRulesPath at a temp file containing body, and
-// restores the original afterward.
+// restores the original afterward. It does NOT isolate soulPath/userProfilePath
+// — callers that need a base-only prompt should pair it with useIdentityFiles
+// (identity_test.go) so a real ~/.octo/soul.md or user.md on the dev machine
+// doesn't leak into the test (CI runners have empty homes, so this only bit
+// developers).
 func withUserRules(t *testing.T, body string) {
 	t.Helper()
 	dir := t.TempDir()
@@ -22,6 +26,7 @@ func withUserRules(t *testing.T, body string) {
 }
 
 func TestCompose_UserLayerBetweenEnvAndProject(t *testing.T) {
+	useIdentityFiles(t, "", "") // isolate from real ~/.octo identity files
 	withUserRules(t, "USER_GLOBAL_RULE")
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("PROJECT_RULE"), 0o644); err != nil {
@@ -49,10 +54,9 @@ func TestCompose_UserLayerBetweenEnvAndProject(t *testing.T) {
 }
 
 func TestCompose_NoUserFile_NoUserLayer(t *testing.T) {
-	// Point at a non-existent file.
-	orig := userRulesPath
-	userRulesPath = func() string { return filepath.Join(t.TempDir(), "absent.md") }
-	t.Cleanup(func() { userRulesPath = orig })
+	// useIdentityFiles also clears userRulesPath (sets it to a non-existent
+	// path), so this isolates the test from real ~/.octo/{soul,user,octorules}.
+	useIdentityFiles(t, "", "")
 
 	out := Compose("", t.TempDir(), "", "", "")
 	if strings.Contains(out, "octorules.md") {

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -43,6 +43,9 @@ func TestCompose_LayersInOrder(t *testing.T) {
 }
 
 func TestCompose_SkipsAbsentLayers(t *testing.T) {
+	// Isolate from real ~/.octo/{soul,user,octorules}.md so the test runs the
+	// same on a developer machine and on a fresh CI runner.
+	useIdentityFiles(t, "", "")
 	// No env, no skills, no .octorules, no user prompt → just the base, no separators.
 	out := Compose("", t.TempDir(), "", "", "")
 	if strings.Contains(out, "---") {


### PR DESCRIPTION
## Summary
- Expands `base.md`'s Memory section from 2 bullets to ~55 lines covering: when to call `remember`, inline `(from memory: …)` citations when a recalled fact is load-bearing for the reply, verify-first rule before acting on remembered paths/functions/flags, and "user always wins" when memory contradicts the current turn.
- Borrows the shape of Codex's `read_path.md` but uses inline attribution instead of the heavier `<oai-mem-citation>` XML block — gentler for the conversational REPL.
- Drive-by test fix: three tests in `internal/prompt/` didn't override `soulPath` / `userProfilePath`, so they silently failed locally on dev machines with real `~/.octo/soul.md` or `user.md` (CI runners have empty homes, so the bug was invisible there). Reuse the existing `useIdentityFiles` helper.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [x] All three prompt tests now pass on a machine with real `~/.octo/{soul,user}.md` present.
- [ ] Live verification: next session reply that uses a remembered fact should include a `(from memory: …)` attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)