### PR TITLE
feat(memory): stamp memory_summary.md with v1 protocol marker

### DIFF
--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -56,6 +56,16 @@ const (
 	stateFile     = ".state"
 	lockName      = ".lock"
 	archiveSubdir = "archive"
+
+	// summaryMarker is the first line of every memory_summary.md octo writes.
+	// It declares the on-disk protocol version so future readers can detect a
+	// breaking schema change without sniffing the body. Older summaries written
+	// before this marker existed are still accepted (stripSummaryMarker is a
+	// no-op on them); newer schemas will use "octo-memory v2", etc.
+	//
+	// Kept as an HTML comment so the marker renders invisibly when a user opens
+	// the file in a Markdown viewer.
+	summaryMarker = "<!-- octo-memory v1 -->"
 )
 
 // Store is a memory directory (default ~/.octo/memory).
@@ -239,10 +249,8 @@ func (s *Store) rebuildIndex() error {
 // Prefers a consolidated memory_summary.md; falls back to a compact list of
 // entry descriptions. Returns "" when there is nothing to inject.
 func (s *Store) RenderInjection() (string, error) {
-	if b, err := os.ReadFile(filepath.Join(s.dir, summaryFile)); err == nil {
-		if sum := strings.TrimSpace(string(b)); sum != "" {
-			return "# Memory (from past sessions)\n\n" + sum, nil
-		}
+	if sum := s.ReadSummary(); sum != "" {
+		return "# Memory (from past sessions)\n\n" + sum, nil
 	}
 	entries, err := s.List()
 	if err != nil || len(entries) == 0 {
@@ -355,21 +363,39 @@ func (s *Store) SaveState(st State) error {
 }
 
 // WriteSummary writes the consolidated memory summary (the injection source,
-// preferred by RenderInjection over the entry list).
+// preferred by RenderInjection over the entry list). The file is prefixed with
+// summaryMarker so a future reader can detect the on-disk protocol version.
 func (s *Store) WriteSummary(summary string) error {
 	if err := s.ensureDir(); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(s.dir, summaryFile), []byte(strings.TrimSpace(summary)+"\n"), 0o644)
+	body := summaryMarker + "\n" + strings.TrimSpace(summary) + "\n"
+	return os.WriteFile(filepath.Join(s.dir, summaryFile), []byte(body), 0o644)
 }
 
-// ReadSummary returns the current consolidated summary, or "" if none.
+// ReadSummary returns the current consolidated summary (with the protocol
+// marker stripped) or "" if none. Summaries written before the marker existed
+// pass through unchanged — backward compatibility with the PR-#96 era files.
 func (s *Store) ReadSummary() string {
 	b, err := os.ReadFile(filepath.Join(s.dir, summaryFile))
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(b))
+	return stripSummaryMarker(string(b))
+}
+
+// stripSummaryMarker removes the first-line summaryMarker (if present) and
+// returns the trimmed remainder. Markerless inputs pass through (trimmed).
+func stripSummaryMarker(s string) string {
+	s = strings.TrimLeft(s, "\n\r\t ")
+	if !strings.HasPrefix(s, summaryMarker) {
+		return strings.TrimSpace(s)
+	}
+	rest := strings.TrimPrefix(s, summaryMarker)
+	// Drop the line-terminator that followed the marker (if any) so the next
+	// real line isn't glued to it.
+	rest = strings.TrimLeft(rest, "\r\n")
+	return strings.TrimSpace(rest)
 }
 
 // ArchiveAll moves every active entry to archive/, then rebuilds the index.

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -240,6 +240,65 @@ func TestReadSummary(t *testing.T) {
 	}
 }
 
+func TestWriteSummary_StampsV1Marker(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	if err := s.WriteSummary("body content"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(s.dir, summaryFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	if !strings.HasPrefix(got, summaryMarker) {
+		t.Errorf("summary file should start with %q, got:\n%s", summaryMarker, got)
+	}
+	// The body must still be there after the marker line.
+	if !strings.Contains(got, "body content") {
+		t.Errorf("summary body lost:\n%s", got)
+	}
+}
+
+func TestReadSummary_HidesMarkerFromCallers(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	_ = s.WriteSummary("alpha\nbeta")
+	got := s.ReadSummary()
+	if strings.Contains(got, summaryMarker) {
+		t.Errorf("ReadSummary should strip the marker, got: %q", got)
+	}
+	if got != "alpha\nbeta" {
+		t.Errorf("ReadSummary = %q, want %q", got, "alpha\nbeta")
+	}
+}
+
+func TestReadSummary_AcceptsLegacyMarkerless(t *testing.T) {
+	// Summaries written by the PR-#96 era code had no marker. They must still
+	// read cleanly so the upgrade is non-breaking.
+	s := NewStoreAt(t.TempDir())
+	_ = s.ensureDir()
+	if err := os.WriteFile(filepath.Join(s.dir, summaryFile), []byte("legacy body\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.ReadSummary(); got != "legacy body" {
+		t.Errorf("legacy markerless summary should pass through, got %q", got)
+	}
+}
+
+func TestRenderInjection_HidesMarker(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	_ = s.WriteSummary("CONSOLIDATED")
+	out, err := s.RenderInjection()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, summaryMarker) {
+		t.Errorf("injection should not leak the protocol marker:\n%s", out)
+	}
+	if !strings.Contains(out, "CONSOLIDATED") {
+		t.Errorf("injection missing summary body:\n%s", out)
+	}
+}
+
 func TestExportNotes(t *testing.T) {
 	s := NewStoreAt(t.TempDir())
 	if notes, _ := s.ExportNotes(); notes != "" {


### PR DESCRIPTION
## Summary
- WriteSummary now prepends `<!-- octo-memory v1 -->` as the first line of `memory_summary.md` so a future reader can detect the on-disk schema version without sniffing the body. The marker is an HTML comment so it renders invisibly in a Markdown viewer.
- ReadSummary strips the marker on the way out, so RenderInjection / ConsolidateMemory's priorSummary / `/memory` display all see clean content. The marker never leaks into the LLM prompt.
- Backward compatible: legacy markerless summaries (PR-#96 era files) read cleanly.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [x] New tests cover: marker is the first line of the written file, ReadSummary strips it, legacy markerless input passes through, RenderInjection doesn't leak the marker into the LLM-facing block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)