### PR TITLE
feat(memory): git baseline replaces archive/ subdir

### DIFF
--- a/cmd/octo/memory_extract.go
+++ b/cmd/octo/memory_extract.go
@@ -91,6 +91,12 @@ func consolidateIfDue(ctx context.Context, a *agent.Agent, store *memory.Store, 
 		return
 	}
 	st.LastConsolidated = time.Now().Format("2006-01-02")
+	// Record the new git baseline so the future sub-agent consolidator (#6)
+	// knows what point we've folded up to. HeadSHA returns "" when git is off,
+	// which is fine — it just leaves the field empty.
+	if sha, err := store.HeadSHA(); err == nil && sha != "" {
+		st.LastConsolidatedSHA = sha
+	}
 }
 
 func consolidateDue(st memory.State, store *memory.Store) bool {

--- a/internal/memory/git.go
+++ b/internal/memory/git.go
@@ -1,0 +1,206 @@
+package memory
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// gitAuthorEmail / gitAuthorName are the committer identity used for octo's
+// auto-commits. Local-repo config so we don't perturb the user's global
+// .gitconfig.
+const (
+	gitAuthorEmail = "memory@octo.local"
+	gitAuthorName  = "octo memory"
+)
+
+// gitAvailableOnce caches the result of "is `git` on PATH?". Looked up once
+// per process — the answer doesn't change at runtime.
+var (
+	gitAvailableOnce sync.Once
+	gitAvailableVal  bool
+)
+
+// gitAvailable reports whether `git` is on PATH. Cached. When false, Store
+// methods that would have committed silently skip — memory still works, just
+// without an audit trail.
+func gitAvailable() bool {
+	gitAvailableOnce.Do(func() {
+		_, err := exec.LookPath("git")
+		gitAvailableVal = err == nil
+	})
+	return gitAvailableVal
+}
+
+// isGitRepo returns true if dir/.git exists (file or directory; submodule-style
+// .git files count too).
+func isGitRepo(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, ".git"))
+	return err == nil
+}
+
+// runGit runs `git <args...>` inside dir, returning trimmed stdout and a
+// wrapped error that includes stderr when the command fails.
+func runGit(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	// Make output deterministic across user environments / locales.
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"LC_ALL=C",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(ee.Stderr)))
+		}
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return strings.TrimRight(string(out), "\n"), nil
+}
+
+// gitInit initializes dir as a git repo (idempotent) and sets local
+// user.email / user.name so commits don't depend on the user's global config.
+// Initial branch is `main` to match the project default.
+func gitInit(dir string) error {
+	if !gitAvailable() {
+		return errInternalGitMissing
+	}
+	if isGitRepo(dir) {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	// -b main is supported from git 2.28+. Fall back to `git init` + a branch
+	// rename if it errors (older runners).
+	if _, err := runGit(dir, "init", "-b", "main"); err != nil {
+		if _, err2 := runGit(dir, "init"); err2 != nil {
+			return err2
+		}
+		_, _ = runGit(dir, "symbolic-ref", "HEAD", "refs/heads/main")
+	}
+	if _, err := runGit(dir, "config", "user.email", gitAuthorEmail); err != nil {
+		return err
+	}
+	if _, err := runGit(dir, "config", "user.name", gitAuthorName); err != nil {
+		return err
+	}
+	// Drop a .gitignore so runtime / transient files (the cross-process lock,
+	// the per-session state file) don't pollute the audit trail. The user-
+	// facing memory artifacts (entries, MEMORY.md, memory_summary.md) stay
+	// tracked.
+	gi := []byte(".lock\n.state\n")
+	_ = os.WriteFile(filepath.Join(dir, ".gitignore"), gi, 0o644)
+	return nil
+}
+
+// gitHead returns the current HEAD SHA, or "" if the repo has no commits yet
+// (the typical state right after gitInit).
+func gitHead(dir string) (string, error) {
+	out, err := runGit(dir, "rev-parse", "HEAD")
+	if err != nil {
+		// "fatal: ambiguous argument 'HEAD'" means no commits yet — not an error
+		// for our purposes.
+		if strings.Contains(err.Error(), "unknown revision") || strings.Contains(err.Error(), "ambiguous argument") {
+			return "", nil
+		}
+		return "", err
+	}
+	return out, nil
+}
+
+// gitCommit stages every change under dir and commits with the given message.
+// Returns the new HEAD SHA, or "" with no error if the working tree was clean
+// (nothing to commit is a normal no-op, not a failure).
+func gitCommit(dir, message string) (string, error) {
+	if !gitAvailable() || !isGitRepo(dir) {
+		return "", nil
+	}
+	if _, err := runGit(dir, "add", "-A"); err != nil {
+		return "", err
+	}
+	// `--allow-empty=false` is the default but be explicit. If nothing is
+	// staged after `add -A`, the commit errors with "nothing to commit" — we
+	// treat that as a no-op.
+	if _, err := runGit(dir, "commit", "-m", message); err != nil {
+		if strings.Contains(err.Error(), "nothing to commit") || strings.Contains(err.Error(), "no changes added") {
+			return "", nil
+		}
+		return "", err
+	}
+	return gitHead(dir)
+}
+
+// gitListAllPaths returns the union of every distinct path that has ever
+// appeared in the history under dir (including paths that are currently
+// deleted). Used by ListArchived to discover entries removed by past
+// consolidate-drop commits.
+func gitListAllPaths(dir string) ([]string, error) {
+	if !gitAvailable() || !isGitRepo(dir) {
+		return nil, nil
+	}
+	out, err := runGit(dir, "log", "--all", "--pretty=format:", "--name-only")
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var paths []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || seen[line] {
+			continue
+		}
+		seen[line] = true
+		paths = append(paths, line)
+	}
+	return paths, nil
+}
+
+// gitLastTouching returns the SHA of the most recent commit that modified
+// path, or "" if no commit ever touched it.
+func gitLastTouching(dir, path string) (string, error) {
+	if !gitAvailable() || !isGitRepo(dir) {
+		return "", nil
+	}
+	out, err := runGit(dir, "log", "-1", "--pretty=format:%H", "--", path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// gitShow returns the contents of path at ref. Used to recover the content of
+// a file that no longer exists in the working tree.
+func gitShow(dir, ref, path string) (string, error) {
+	if !gitAvailable() || !isGitRepo(dir) {
+		return "", errInternalGitMissing
+	}
+	return runGit(dir, "show", ref+":"+path)
+}
+
+// gitDiff returns the unified diff between two refs (or between a ref and the
+// working tree if head is empty). Used by the future sub-agent consolidator
+// (#6) to see what changed since the last consolidation baseline.
+func gitDiff(dir, base, head string) (string, error) {
+	if !gitAvailable() || !isGitRepo(dir) {
+		return "", errInternalGitMissing
+	}
+	args := []string{"diff"}
+	if head == "" {
+		args = append(args, base)
+	} else {
+		args = append(args, base+".."+head)
+	}
+	return runGit(dir, args...)
+}
+
+// errInternalGitMissing is returned by helpers that require git when it isn't
+// available or the dir isn't a repo. Callers higher up convert it to a no-op
+// (e.g. ListArchived returns nil, nil rather than surfacing this).
+var errInternalGitMissing = errors.New("memory: git unavailable")

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -51,11 +51,10 @@ type Entry struct {
 }
 
 const (
-	indexFile     = "MEMORY.md"
-	summaryFile   = "memory_summary.md"
-	stateFile     = ".state"
-	lockName      = ".lock"
-	archiveSubdir = "archive"
+	indexFile   = "MEMORY.md"
+	summaryFile = "memory_summary.md"
+	stateFile   = ".state"
+	lockName    = ".lock"
 
 	// summaryMarker is the first line of every memory_summary.md octo writes.
 	// It declares the on-disk protocol version so future readers can detect a
@@ -68,8 +67,15 @@ const (
 	summaryMarker = "<!-- octo-memory v1 -->"
 )
 
-// Store is a memory directory (default ~/.octo/memory).
-type Store struct{ dir string }
+// Store is a memory directory (default ~/.octo/memory). When gitEnabled, every
+// successful Save / WriteSummary / DropConsolidated call auto-commits inside
+// the directory so the entire memory history is rollback-safe and inspectable
+// via `git log`. Replaces the older `archive/` subdir approach: deleted
+// entries live in git history rather than a parallel folder.
+type Store struct {
+	dir        string
+	gitEnabled bool
+}
 
 // DefaultDir resolves ~/.octo/memory.
 func DefaultDir() (string, error) {
@@ -80,17 +86,49 @@ func DefaultDir() (string, error) {
 	return filepath.Join(home, ".octo", "memory"), nil
 }
 
-// NewStore returns a Store rooted at the default directory.
+// NewStore returns a Store rooted at the default directory with git baseline
+// enabled. Use NewStoreAt for tests / custom locations where you don't want
+// every operation to shell out to git.
 func NewStore() (*Store, error) {
 	dir, err := DefaultDir()
 	if err != nil {
 		return nil, err
 	}
-	return &Store{dir: dir}, nil
+	return (&Store{dir: dir}).EnableGit(), nil
 }
 
 // NewStoreAt returns a Store rooted at dir (for tests / custom locations).
+// Git is NOT enabled by default here — chain .EnableGit() if you need it.
 func NewStoreAt(dir string) *Store { return &Store{dir: dir} }
+
+// EnableGit flips the auto-commit behavior on. Subsequent Save / WriteSummary
+// / DropConsolidated calls will lazily `git init` the dir (if needed) and
+// commit each change. Returns the receiver for fluent construction.
+func (s *Store) EnableGit() *Store {
+	s.gitEnabled = true
+	return s
+}
+
+// GitEnabled reports whether auto-commit is active.
+func (s *Store) GitEnabled() bool { return s.gitEnabled }
+
+// maybeCommit is the unified entry point for the auto-commit behavior: it
+// lazily initializes the repo on first use, then stages+commits with message.
+// Silently no-ops when git is disabled, git is not on PATH, or the working
+// tree is clean — none of those should fail a memory write.
+func (s *Store) maybeCommit(message string) {
+	if !s.gitEnabled || !gitAvailable() {
+		return
+	}
+	if !isGitRepo(s.dir) {
+		// Lazy init — first write triggers it. Swallow errors: a missing repo
+		// shouldn't break the memory write.
+		if err := gitInit(s.dir); err != nil {
+			return
+		}
+	}
+	_, _ = gitCommit(s.dir, message)
+}
 
 func today() string { return time.Now().Format("2006-01-02") }
 
@@ -135,7 +173,11 @@ func (s *Store) Save(e Entry) error {
 	if err := s.writeEntry(e); err != nil {
 		return err
 	}
-	return s.rebuildIndex()
+	if err := s.rebuildIndex(); err != nil {
+		return err
+	}
+	s.maybeCommit("remember: " + e.Name)
+	return nil
 }
 
 func (s *Store) writeEntry(e Entry) error {
@@ -334,9 +376,14 @@ func Slugify(s string) string {
 
 // State tracks what the boundary-extraction/consolidation triggers have already
 // done, so startup doesn't re-extract the same session or over-consolidate.
+//
+// LastConsolidatedSHA is the git baseline recorded after a successful
+// consolidation: the future sub-agent consolidator (#6) diffs against this to
+// see what's new. Empty until the first git-backed consolidation lands.
 type State struct {
 	LastExtractedSession string `json:"last_extracted_session"`
 	LastConsolidated     string `json:"last_consolidated"` // YYYY-MM-DD
+	LastConsolidatedSHA  string `json:"last_consolidated_sha,omitempty"`
 }
 
 // LoadState reads .state; a missing/unreadable file yields a zero State.
@@ -365,13 +412,50 @@ func (s *Store) SaveState(st State) error {
 // WriteSummary writes the consolidated memory summary (the injection source,
 // preferred by RenderInjection over the entry list). The file is prefixed with
 // summaryMarker so a future reader can detect the on-disk protocol version.
+// When git is enabled the write is auto-committed; the new commit's SHA is
+// what the caller should record as the consolidation baseline (HeadSHA).
 func (s *Store) WriteSummary(summary string) error {
 	if err := s.ensureDir(); err != nil {
 		return err
 	}
 	body := summaryMarker + "\n" + strings.TrimSpace(summary) + "\n"
-	return os.WriteFile(filepath.Join(s.dir, summaryFile), []byte(body), 0o644)
+	if err := os.WriteFile(filepath.Join(s.dir, summaryFile), []byte(body), 0o644); err != nil {
+		return err
+	}
+	s.maybeCommit("consolidate: write summary")
+	return nil
 }
+
+// HeadSHA returns the current git HEAD SHA for the store, or "" when git is
+// disabled, unavailable, or the repo has no commits yet. Useful as a baseline
+// for the future sub-agent consolidator (#6) to ask "what changed since this
+// commit?" via WorkspaceDiff.
+func (s *Store) HeadSHA() (string, error) {
+	if !s.gitEnabled || !gitAvailable() || !isGitRepo(s.dir) {
+		return "", nil
+	}
+	return gitHead(s.dir)
+}
+
+// WorkspaceDiff returns the unified diff between baseSHA and the current
+// working tree HEAD. baseSHA empty means "diff against the empty tree" — i.e.
+// every file currently committed. Used by the future sub-agent consolidator
+// to see what's new since the last consolidation. Returns "" if git is off.
+func (s *Store) WorkspaceDiff(baseSHA string) (string, error) {
+	if !s.gitEnabled || !gitAvailable() || !isGitRepo(s.dir) {
+		return "", nil
+	}
+	if baseSHA == "" {
+		// The empty-tree SHA is the same in every git repo; using it lets the
+		// caller treat "no baseline yet" the same as "diff since beginning".
+		baseSHA = emptyTreeSHA
+	}
+	return gitDiff(s.dir, baseSHA, "")
+}
+
+// emptyTreeSHA is git's hard-coded SHA for the empty tree object, which lets
+// us diff "from the beginning" without special-casing a missing baseline.
+const emptyTreeSHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 // ReadSummary returns the current consolidated summary (with the protocol
 // marker stripped) or "" if none. Summaries written before the marker existed
@@ -398,10 +482,17 @@ func stripSummaryMarker(s string) string {
 	return strings.TrimSpace(rest)
 }
 
-// ArchiveAll moves every active entry to archive/, then rebuilds the index.
-// Use after a successful consolidation: the entries are preserved as
-// authoritative sources (in archive/) but no longer feed the consolidation or
-// the injection fallback, so neither grows unbounded.
+// ArchiveAll deletes every active entry from the working tree, rebuilds the
+// index, and commits the deletion ("consolidate: drop N entries"). Use after
+// a successful consolidation: the entries are preserved in git history as
+// authoritative sources, but no longer feed the next consolidation's input
+// or the injection fallback, so neither grows unbounded.
+//
+// Replaces the older `archive/` subdir approach. The name is kept so callers
+// (consolidateIfDue) don't have to change; the semantics are now "drop from
+// the working tree, keep in git". When git is disabled this still deletes the
+// files but loses the audit trail — callers should always EnableGit in
+// production.
 func (s *Store) ArchiveAll() error {
 	unlock, err := s.lock()
 	if err != nil {
@@ -415,61 +506,87 @@ func (s *Store) ArchiveAll() error {
 	if len(entries) == 0 {
 		return nil
 	}
-	archiveDir := filepath.Join(s.dir, archiveSubdir)
-	if err := os.MkdirAll(archiveDir, 0o755); err != nil {
-		return err
-	}
 	for _, e := range entries {
-		src := filepath.Join(s.dir, e.Name+".md")
-		dst := filepath.Join(archiveDir, e.Name+".md")
-		// If an archived file with the same name already exists, overwrite —
-		// the active version is more recent.
-		_ = os.Remove(dst)
-		if err := os.Rename(src, dst); err != nil {
+		if err := os.Remove(filepath.Join(s.dir, e.Name+".md")); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 	}
-	return s.rebuildIndex()
+	if err := s.rebuildIndex(); err != nil {
+		return err
+	}
+	s.maybeCommit(fmt.Sprintf("consolidate: drop %d entries folded into summary", len(entries)))
+	return nil
 }
 
-// ListArchived returns all archived entries, sorted by name. Archived entries
-// remain queryable as authoritative sources but do not feed the consolidation
-// or injection paths.
+// ListArchived recovers entries that were folded into a past consolidation
+// (and thus removed from the working tree) by walking git history. Returns
+// nil,nil when git is unavailable or the dir isn't a repo — the older
+// `archive/` subdir is gone, and without git there's no archive to list.
+//
+// Strategy: enumerate every path that has ever appeared in the history, drop
+// the ones currently in the working tree (those are active, not archived),
+// and for each remaining path recover content from the most recent commit
+// that contained it. A slug deleted, re-added, then re-deleted recovers the
+// latest content. Dedup by entry Name.
 func (s *Store) ListArchived() ([]Entry, error) {
-	archiveDir := filepath.Join(s.dir, archiveSubdir)
-	ents, err := os.ReadDir(archiveDir)
+	if !s.gitEnabled || !gitAvailable() || !isGitRepo(s.dir) {
+		return nil, nil
+	}
+	paths, err := gitListAllPaths(s.dir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
 		return nil, err
 	}
-	var out []Entry
-	for _, de := range ents {
-		name := de.Name()
-		if de.IsDir() || !strings.HasSuffix(name, ".md") {
+	seen := map[string]Entry{}
+	for _, p := range paths {
+		// Only top-level <slug>.md files are entries.
+		if strings.Contains(p, "/") || !strings.HasSuffix(p, ".md") {
 			continue
 		}
-		e, ok, err := s.readArchived(name)
-		if err != nil {
-			return nil, err
+		if p == indexFile || p == summaryFile {
+			continue
 		}
-		if ok {
-			out = append(out, e)
+		// Skip files currently in the working tree.
+		if _, err := os.Stat(filepath.Join(s.dir, p)); err == nil {
+			continue
 		}
+		e, ok, err := s.recoverArchivedEntry(p)
+		if err != nil || !ok {
+			continue
+		}
+		seen[e.Name] = e
+	}
+	out := make([]Entry, 0, len(seen))
+	for _, e := range seen {
+		out = append(out, e)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
 }
 
-func (s *Store) readArchived(file string) (Entry, bool, error) {
-	b, err := os.ReadFile(filepath.Join(s.dir, archiveSubdir, file))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return Entry{}, false, nil
-		}
+// recoverArchivedEntry pulls the latest content of path from git: the commit
+// that most recently touched it is either the deletion itself (content lives
+// at parent) or an add/modify (content lives at that commit). Try the touching
+// commit first; on failure, try its parent.
+func (s *Store) recoverArchivedEntry(path string) (Entry, bool, error) {
+	sha, err := gitLastTouching(s.dir, path)
+	if err != nil || sha == "" {
 		return Entry{}, false, err
 	}
+	content, err := gitShow(s.dir, sha, path)
+	if err != nil {
+		// Latest touch deleted the file → recover from its parent.
+		content, err = gitShow(s.dir, sha+"^", path)
+		if err != nil {
+			return Entry{}, false, nil
+		}
+	}
+	return parseEntryFromBytes(path, []byte(content))
+}
+
+// parseEntryFromBytes parses an entry file's bytes into an Entry. Mirrors
+// readEntry's logic but works from a byte slice (used to materialize entries
+// recovered from git history). Malformed input yields ok=false with no error.
+func parseEntryFromBytes(file string, b []byte) (Entry, bool, error) {
 	front, body, ok := splitFrontmatter(string(b))
 	if !ok {
 		return Entry{}, false, nil
@@ -480,7 +597,7 @@ func (s *Store) readArchived(file string) (Entry, bool, error) {
 	}
 	name := fm.Name
 	if name == "" {
-		name = strings.TrimSuffix(file, ".md")
+		name = strings.TrimSuffix(filepath.Base(file), ".md")
 	}
 	t := Type(fm.Type)
 	if !validType(t) {

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -172,8 +172,19 @@ func TestWriteSummary_PreferredByInjection(t *testing.T) {
 	}
 }
 
-func TestArchiveAll_MovesEntriesAndRebuildsIndex(t *testing.T) {
-	s := NewStoreAt(t.TempDir())
+// requireGit skips the test when `git` isn't on PATH. The git-baseline path
+// (auto-commit, ListArchived, HeadSHA, WorkspaceDiff) all degrade to no-ops
+// without git; tests for those paths can't meaningfully run without it.
+func requireGit(t *testing.T) {
+	t.Helper()
+	if !gitAvailable() {
+		t.Skip("git not on PATH — skipping git-baseline test")
+	}
+}
+
+func TestArchiveAll_DropsEntriesAndRebuildsIndex(t *testing.T) {
+	requireGit(t)
+	s := NewStoreAt(t.TempDir()).EnableGit()
 	_ = s.Save(Entry{Description: "first", Type: TypeUser})
 	_ = s.Save(Entry{Description: "second", Type: TypeFeedback})
 
@@ -184,13 +195,13 @@ func TestArchiveAll_MovesEntriesAndRebuildsIndex(t *testing.T) {
 	if active, _ := s.List(); len(active) != 0 {
 		t.Errorf("after ArchiveAll, List should be empty: %+v", active)
 	}
-	// Archived list contains both.
+	// Archived list (recovered via git log) contains both.
 	archived, err := s.ListArchived()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(archived) != 2 {
-		t.Fatalf("expected 2 archived entries, got %d", len(archived))
+		t.Fatalf("expected 2 archived entries, got %d: %+v", len(archived), archived)
 	}
 	// Index was rebuilt (and now empty).
 	b, err := os.ReadFile(filepath.Join(s.dir, indexFile))
@@ -203,7 +214,8 @@ func TestArchiveAll_MovesEntriesAndRebuildsIndex(t *testing.T) {
 }
 
 func TestArchiveAll_PreservesArchivedContent(t *testing.T) {
-	s := NewStoreAt(t.TempDir())
+	requireGit(t)
+	s := NewStoreAt(t.TempDir()).EnableGit()
 	_ = s.Save(Entry{Description: "a fact", Type: TypeProject, Body: "the body"})
 	_ = s.ArchiveAll()
 
@@ -213,8 +225,9 @@ func TestArchiveAll_PreservesArchivedContent(t *testing.T) {
 	}
 }
 
-func TestArchiveAll_OverwritesPriorArchive(t *testing.T) {
-	s := NewStoreAt(t.TempDir())
+func TestArchiveAll_KeepsLatestVersionAcrossRounds(t *testing.T) {
+	requireGit(t)
+	s := NewStoreAt(t.TempDir()).EnableGit()
 	// First round: save and archive.
 	_ = s.Save(Entry{Name: "n", Description: "v1", Type: TypeUser})
 	_ = s.ArchiveAll()
@@ -226,6 +239,74 @@ func TestArchiveAll_OverwritesPriorArchive(t *testing.T) {
 	archived, _ := s.ListArchived()
 	if len(archived) != 1 || archived[0].Description != "v2" {
 		t.Errorf("archive should keep the latest version, got %+v", archived)
+	}
+}
+
+func TestSave_AutoCommitsWhenGitEnabled(t *testing.T) {
+	requireGit(t)
+	s := NewStoreAt(t.TempDir()).EnableGit()
+	_ = s.Save(Entry{Description: "first fact", Type: TypeUser})
+
+	if !isGitRepo(s.dir) {
+		t.Fatalf("Save should lazily init a git repo when git is enabled")
+	}
+	sha, err := s.HeadSHA()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sha == "" {
+		t.Errorf("HeadSHA should be non-empty after a successful Save+commit")
+	}
+}
+
+func TestSave_NoGitWhenDisabled(t *testing.T) {
+	// Default NewStoreAt has git off — Save should not create .git/.
+	s := NewStoreAt(t.TempDir())
+	_ = s.Save(Entry{Description: "first fact", Type: TypeUser})
+	if isGitRepo(s.dir) {
+		t.Errorf("Save should NOT create .git/ when git is disabled")
+	}
+}
+
+func TestWorkspaceDiff_ReportsNewEntriesSinceBaseline(t *testing.T) {
+	requireGit(t)
+	s := NewStoreAt(t.TempDir()).EnableGit()
+	_ = s.Save(Entry{Description: "before baseline", Type: TypeUser})
+	base, _ := s.HeadSHA()
+	if base == "" {
+		t.Fatal("baseline SHA must be set after a save")
+	}
+
+	_ = s.Save(Entry{Description: "after baseline", Type: TypeFeedback})
+
+	diff, err := s.WorkspaceDiff(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The diff must record that after-baseline.md was added (a "new file mode"
+	// or "+++ b/after-baseline.md" line) but must NOT report before-baseline.md
+	// as newly added — it was already in the baseline.
+	if !strings.Contains(diff, "+++ b/after-baseline.md") {
+		t.Errorf("WorkspaceDiff should record the new file added since the baseline:\n%s", diff)
+	}
+	if strings.Contains(diff, "+++ b/before-baseline.md") {
+		t.Errorf("WorkspaceDiff should NOT record the baseline file as new:\n%s", diff)
+	}
+}
+
+func TestListArchived_EmptyWithoutGit(t *testing.T) {
+	// Without git enabled, ListArchived returns nil — the older archive/
+	// subdir no longer exists and there's no history to walk.
+	s := NewStoreAt(t.TempDir())
+	_ = s.Save(Entry{Description: "x", Type: TypeUser})
+	_ = s.ArchiveAll()
+
+	got, err := s.ListArchived()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("ListArchived without git should be nil, got %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

The PR-#96 `archive/` subdir was a parallel folder we hand-rolled to keep consolidated entries around. It worked but duplicated what git does natively. Codex's Phase 1 design (Appendix A) treats the memory dir as a git repo and lets history do the archiving — this PR moves us to that model.

### What's in this change

- **`internal/memory/git.go` (new)**: tiny helpers wrapping `git init` / commit / log / show / diff. All best-effort: if `git` isn't on PATH or the dir isn't a repo, the helpers degrade to no-ops so a memory write never fails because of a git hiccup.
- **`Store` gains `EnableGit()`**. `NewStore()` enables it; `NewStoreAt(dir)` defaults to off so unit tests don't shell out to git per `Save`. Tests that need the git path enable it explicitly and skip when git is missing.
- **`Save` and `WriteSummary` auto-commit on success** (`remember: <slug>`, `consolidate: write summary`). First `Save` lazily `git init`s the dir, configures local `user.email`/`user.name`, and drops a `.gitignore` that excludes `.lock` and `.state`.
- **`ArchiveAll`** no longer moves files to `archive/`. It deletes them from the working tree, rebuilds the index, and commits (`consolidate: drop N entries folded into summary`). The entries live in git history.
- **`ListArchived`** walks git history: every path ever committed, minus those currently in the working tree, recovered from the most recent commit that contained them. A slug deleted, re-added, then re-deleted recovers the latest content.
- **`HeadSHA()` and `WorkspaceDiff(base)`** expose the baseline machinery #6 (sub-agent consolidator) will use.
- **`State.LastConsolidatedSHA`** is populated by `consolidateIfDue` after a successful `WriteSummary` commit.

### Backward compatibility

A user's existing `~/.octo/memory/` becomes a git repo on first write under the new code. Existing `archive/` subdirs are ignored (`List`/`ListArchived` skip subdirs), so the migration is silent and non-destructive. `ListArchived` without git enabled returns nil rather than scanning the old archive folder — a clean break since the design is now git-first.

## Test plan

- [x] `make fmt-check && make vet && go test -race ./...`
- [x] `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
- [x] New tests cover: lazy git init on first `Save`, `HeadSHA` non-empty after commit, `WorkspaceDiff` shows only changes after the baseline, `ListArchived` recovers entries from history (including the "delete → re-add → delete" case), `ListArchived` returns nil when git is disabled.
- [ ] Live verification: after a real consolidation, `cd ~/.octo/memory && git log --oneline` should show `remember: …` and `consolidate: …` commits, and `octo memory list --archive` should still display the folded entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)