### PR TITLE
feat(memory): three-piece per-rollout artifacts (slug + summary + facts)

### DIFF
--- a/cmd/octo/memory_extract.go
+++ b/cmd/octo/memory_extract.go
@@ -46,10 +46,10 @@ func extractPreviousSession(ctx context.Context, a *agent.Agent, store *memory.S
 		if sess.ID == st.LastExtractedSession || sess.TurnCount() == 0 {
 			return // reached the already-extracted boundary (or nothing to do)
 		}
-		facts, err := a.ExtractMemory(ctx, sess.ToHistory().Snapshot())
+		res, err := a.ExtractMemory(ctx, sess.ToHistory().Snapshot())
 		if err == nil {
 			n := 0
-			for _, f := range facts {
+			for _, f := range res.Facts {
 				if serr := store.Save(memory.Entry{
 					Description: f.Description,
 					Type:        memory.Type(f.Type),
@@ -58,8 +58,22 @@ func extractPreviousSession(ctx context.Context, a *agent.Agent, store *memory.S
 					n++
 				}
 			}
-			if n > 0 {
-				fmt.Fprintf(out, "  ⓘ remembered %d fact(s) from your last session\n", n)
+			// Persist the per-rollout narrative reference. Fall back to the
+			// session id as the slug when the model returned "" (no-op
+			// extractions return empty here and SaveRolloutSummary skips them
+			// anyway).
+			slug := res.Slug
+			if slug == "" {
+				slug = sess.ID
+			}
+			_ = store.SaveRolloutSummary(slug, res.Summary)
+
+			if n > 0 || res.Summary != "" {
+				suffix := ""
+				if res.Summary != "" {
+					suffix = " (+ rollout summary)"
+				}
+				fmt.Fprintf(out, "  ⓘ remembered %d fact(s) from your last session%s\n", n, suffix)
 			}
 		}
 		st.LastExtractedSession = sess.ID

--- a/internal/agent/extract.go
+++ b/internal/agent/extract.go
@@ -7,24 +7,34 @@ import (
 	"strings"
 )
 
-// extractMaxTokens caps the memory-extraction side-call. Like the compaction
-// summary, an extraction is a short structured carry-forward, not a transcript.
-const extractMaxTokens = 1024
+// extractMaxTokens caps the memory-extraction side-call. The cap covers all
+// three artifacts the side-call produces in one shot (slug + summary + facts),
+// so it's larger than a fact-only extraction would need.
+const extractMaxTokens = 4096
 
 // extractSystem instructs the extraction side-call to mine a finished
-// conversation for durable, cross-session facts and emit them as JSON. It is
-// the boundary counterpart to the immediate `remember` tool: remember catches
-// explicit signals mid-session, this sweeps for what the model didn't record.
+// conversation for three artifacts:
+//
+//   - facts: typed durable memories (the entries injected into future prompts)
+//   - rollout_summary: a narrative reference of what this session was about
+//   - rollout_slug: a filesystem-safe handle naming this session
+//
+// It's the boundary counterpart to the immediate `remember` tool: remember
+// catches explicit signals mid-session, this sweeps for what the model didn't
+// record AND produces the per-rollout reference doc Codex calls
+// `rollout_summaries/<…>.md`.
 //
 // The prompt borrows the shape of Codex's stage_one writer: an explicit no-op
 // gate, a reading-priority rule (user > tool > assistant), outcome triage,
-// and evidence→implication wording for feedback. The goal is to suppress the
-// low-quality "summarize what just happened" output the original 20-line
-// prompt produced, and to keep each fact actionable in a future session.
+// and evidence→implication wording for feedback.
 const extractSystem = `You extract durable, cross-session memories from a coding agent's finished
-conversation. Output ONLY a JSON array; each element:
+conversation. Output ONE JSON object with three top-level fields:
 
-  {"type": "user|feedback|project|reference", "description": "<one line>", "content": "<the fact>"}
+  {
+    "rollout_slug":    "<short kebab-case handle for this session, <= 60 chars>",
+    "rollout_summary": "<narrative reference doc, see format below>",
+    "facts":           [ { "type": "user|feedback|project|reference", "description": "<one line>", "content": "<the fact>" }, ... ]
+  }
 
 ================ GOAL ================
 Help future sessions:
@@ -37,8 +47,15 @@ fewer re-specifications), not just future agent time saved.
 
 ================ NO-OP GATE ================
 Before each candidate fact, ask: "Will a future session plausibly do better
-because of THIS line?" If no, drop it. If nothing qualifies overall, output
-exactly []. Most turns yield nothing. Quality beats quantity.
+because of THIS line?" If no, drop it.
+
+If the whole session has nothing worth carrying — random one-off questions,
+quick fixes already in the code, brainstorming with no adopted conclusion —
+return the all-empty form exactly:
+
+  {"rollout_slug": "", "rollout_summary": "", "facts": []}
+
+Most turns yield nothing. Quality beats quantity. Empty is correct, not lazy.
 
 ================ READING PRIORITY ================
 Read the conversation in this order of trust:
@@ -97,14 +114,56 @@ For uncertain → usually skip; wait for stronger signal in a future session.
 - Pure brainstorming / options the user discussed but did not commit to.
 - Secrets, tokens, API keys, credentials. Redact if quoting.
 
-================ STYLE ================
+================ FACTS STYLE ================
 - One fact per array element. Do not merge distinct defaults.
 - Terse, concrete, actionable. Preserve short user quotes when they sharpen the rule.
 - description: one line, <=80 chars, the rule itself (not a topic label).
 - content: the rule, then for feedback/project a "Why: ..." clause, then for
   feedback an optional "How to apply: ..." clause naming when this kicks in.
 
-Output: JSON array only. No prose around it. No code fences.`
+================ rollout_slug ================
+A filesystem-safe, lowercase, hyphen-separated handle naming THIS session.
+Examples: "tune-extract-prompt", "fix-bing-search-encoding", "design-m11".
+Cap at 60 chars. Avoid generic slugs ("debug", "fix", "task") — be specific
+enough that a future search lands on the right session. If you can't pick a
+specific name, use "".
+
+================ rollout_summary ================
+A narrative reference doc future sessions can grep when they ask "did we do
+anything in this area before?". It is NOT auto-injected into the next session
+(the consolidated memory_summary is) — these summaries live on disk for
+on-demand reading, so they can be detailed.
+
+Length: as much as the session deserves. Single-task sessions: ~30-80 lines.
+Multi-task sessions: longer, one section per task. Use Markdown.
+
+Suggested structure (omit sections that are empty):
+
+  # <one-sentence summary of the session>
+
+  Rollout context: <what the user wanted, environment, constraints>
+
+  ## Task <n>: <task name>
+
+  Outcome: <success|partial|fail|uncertain>
+
+  Preference signals:
+  - when <situation>, the user said "<short quote>" → implies <default for next time>
+
+  Key steps: <only steps that produced a durable result>
+
+  Failures and how to do differently: <what failed, what worked instead, why>
+
+  Reusable knowledge: <validated repo facts, high-leverage shortcuts>
+
+  References: <file paths, commands, error strings worth preserving verbatim>
+
+For fail / partial / uncertain outcomes: emphasize what didn't work, the pivot
+that did, and the prevention rule.
+
+================ OUTPUT ================
+ONE JSON object only. No prose, no code fences. Honor the no-op gate — the
+all-empty form is correct when there's nothing durable to carry.`
 
 // consolidateSystem instructs the consolidation side-call to maintain (rather
 // than rebuild) a summary: it gets the current summary plus any new notes since
@@ -126,28 +185,42 @@ type MemoryFact struct {
 	Content     string `json:"content"`
 }
 
+// ExtractResult is the three-piece artifact a session-end extraction produces:
+// a typed-facts array (the durable memory entries), a narrative rollout
+// summary (the on-disk reference doc), and a slug (the filename handle).
+//
+// Any field can be empty. An all-empty result means the no-op gate fired and
+// the session had nothing worth carrying forward.
+type ExtractResult struct {
+	Slug    string       `json:"rollout_slug"`
+	Summary string       `json:"rollout_summary"`
+	Facts   []MemoryFact `json:"facts"`
+}
+
 // ExtractMemory runs the extraction side-call over msgs (a finished session's
-// messages) and returns the durable facts found. It does not write anything —
-// the caller persists the facts. A nil slice means "nothing worth keeping".
-func (a *Agent) ExtractMemory(ctx context.Context, msgs []Message) ([]MemoryFact, error) {
+// messages) and returns the three-piece result. It does not write anything —
+// the caller persists each piece (entries via the memory Store, the rollout
+// summary via Store.SaveRolloutSummary). A zero ExtractResult means "nothing
+// worth keeping".
+func (a *Agent) ExtractMemory(ctx context.Context, msgs []Message) (ExtractResult, error) {
 	if a.Sender == nil {
-		return nil, fmt.Errorf("agent: no Sender configured")
+		return ExtractResult{}, fmt.Errorf("agent: no Sender configured")
 	}
 	if len(msgs) == 0 {
-		return nil, nil
+		return ExtractResult{}, nil
 	}
 	req := make([]Message, 0, len(msgs)+1)
 	req = append(req, msgs...)
 	req = append(req, NewUserMessage(
-		"Extract durable memories from the conversation above per your instructions. Output only the JSON array."))
+		"Extract durable memories from the conversation above per your instructions. Output only the JSON object."))
 
 	reply, err := a.Sender.SendMessages(ctx, a.Model, extractSystem, req, extractMaxTokens)
 	if err != nil {
-		return nil, err
+		return ExtractResult{}, err
 	}
 	a.sessionInputTokens += reply.InputTokens
 	a.sessionOutputTokens += reply.OutputTokens
-	return parseFacts(reply.Content)
+	return parseExtractResult(reply.Content)
 }
 
 // ConsolidateMemory runs the (incremental) consolidation side-call: it folds
@@ -187,22 +260,79 @@ func (a *Agent) ConsolidateMemory(ctx context.Context, priorSummary, newNotes st
 	return strings.TrimSpace(reply.Content), nil
 }
 
-// parseFacts extracts the JSON array from a side-call reply (tolerating a code
-// fence or surrounding prose) and normalizes each fact. A reply with no array
-// yields nil, nil — "nothing to record" is not an error.
-func parseFacts(s string) ([]MemoryFact, error) {
+// parseExtractResult parses the side-call reply into an ExtractResult,
+// tolerating a code fence or surrounding prose. The model is supposed to emit
+// a single JSON object with rollout_slug / rollout_summary / facts; for safety
+// we also accept a bare array (old shape from before this PR) and treat it as
+// a facts-only result with empty slug/summary. An empty / unparseable reply
+// yields a zero ExtractResult with no error — "nothing to record" is normal.
+func parseExtractResult(s string) (ExtractResult, error) {
 	s = strings.TrimSpace(stripCodeFence(s))
-	i := strings.Index(s, "[")
-	j := strings.LastIndex(s, "]")
+	if s == "" {
+		return ExtractResult{}, nil
+	}
+
+	// Decide which top-level shape we're looking at by the first significant
+	// JSON character. An object inside an array (legacy array shape) must NOT
+	// be confused with the new top-level object — we'd lose the facts.
+	first, _ := firstJSONChar(s)
+
+	if first == '{' {
+		if obj := sliceBetween(s, '{', '}'); obj != "" {
+			var r ExtractResult
+			if err := json.Unmarshal([]byte(obj), &r); err == nil {
+				r.Slug = sanitizeSlug(r.Slug)
+				r.Summary = strings.TrimSpace(r.Summary)
+				r.Facts = normalizeFacts(r.Facts)
+				return r, nil
+			}
+		}
+	}
+
+	if first == '[' {
+		if arr := sliceBetween(s, '[', ']'); arr != "" {
+			var facts []MemoryFact
+			if err := json.Unmarshal([]byte(arr), &facts); err == nil {
+				return ExtractResult{Facts: normalizeFacts(facts)}, nil
+			}
+		}
+	}
+
+	return ExtractResult{}, nil
+}
+
+// firstJSONChar returns the first '{' or '[' byte in s, scanning past
+// surrounding prose. Used to choose between object/array parse paths so an
+// array of objects isn't misread as a bare object.
+func firstJSONChar(s string) (byte, bool) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '{' || s[i] == '[' {
+			return s[i], true
+		}
+	}
+	return 0, false
+}
+
+// sliceBetween returns the substring from the first open rune to the last
+// close rune (inclusive), or "" if either is missing. Used to forgive a model
+// that wraps the JSON in surrounding prose.
+func sliceBetween(s string, open, close byte) string {
+	i := strings.IndexByte(s, open)
+	j := strings.LastIndexByte(s, close)
 	if i < 0 || j < 0 || j < i {
-		return nil, nil
+		return ""
 	}
-	var facts []MemoryFact
-	if err := json.Unmarshal([]byte(s[i:j+1]), &facts); err != nil {
-		return nil, fmt.Errorf("agent: parse memory facts: %w", err)
+	return s[i : j+1]
+}
+
+// normalizeFacts trims whitespace, fills missing description from content's
+// first line (and vice versa), and drops entries that are empty after that.
+func normalizeFacts(in []MemoryFact) []MemoryFact {
+	if len(in) == 0 {
+		return nil
 	}
-	out := make([]MemoryFact, 0, len(facts))
-	for _, f := range facts {
+	out := make([]MemoryFact, 0, len(in))
+	for _, f := range in {
 		f.Content = strings.TrimSpace(f.Content)
 		f.Description = strings.TrimSpace(f.Description)
 		if f.Content == "" && f.Description == "" {
@@ -217,9 +347,38 @@ func parseFacts(s string) ([]MemoryFact, error) {
 		out = append(out, f)
 	}
 	if len(out) == 0 {
-		return nil, nil
+		return nil
 	}
-	return out, nil
+	return out
+}
+
+// sanitizeSlug folds an LLM-supplied slug to the same kebab-case shape we use
+// elsewhere and caps the length. Empty → empty (the caller falls back to the
+// session id or a default).
+func sanitizeSlug(s string) string {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	prevDash := false
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if len(out) > 60 {
+		out = strings.Trim(out[:60], "-")
+	}
+	return out
 }
 
 // stripCodeFence removes a leading ```… fence and trailing ``` if present, so a

--- a/internal/agent/extract_test.go
+++ b/internal/agent/extract_test.go
@@ -30,69 +30,118 @@ func (s *stubExtractSender) StreamMessages(_ context.Context, _, _ string, _ []M
 	return s.SendMessages(context.Background(), "", "", nil, 0)
 }
 
-func TestParseFacts(t *testing.T) {
-	good := `[{"type":"user","description":"prefers Go","content":"User likes Go."},{"type":"feedback","description":"run tests first","content":"Always run tests before committing."}]`
-	facts, err := parseFacts(good)
+func TestParseExtractResult_Object(t *testing.T) {
+	good := `{
+	  "rollout_slug": "tune-extract-prompt",
+	  "rollout_summary": "# tuned the extract prompt\n\nDetails…",
+	  "facts": [
+	    {"type":"user","description":"prefers Go","content":"User likes Go."},
+	    {"type":"feedback","description":"run tests first","content":"Always run tests before committing."}
+	  ]
+	}`
+	r, err := parseExtractResult(good)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if len(facts) != 2 || facts[0].Type != "user" || facts[1].Description != "run tests first" {
-		t.Errorf("parseFacts wrong: %+v", facts)
+	if r.Slug != "tune-extract-prompt" {
+		t.Errorf("slug = %q", r.Slug)
+	}
+	if !strings.Contains(r.Summary, "tuned the extract prompt") {
+		t.Errorf("summary lost: %q", r.Summary)
+	}
+	if len(r.Facts) != 2 || r.Facts[1].Description != "run tests first" {
+		t.Errorf("facts wrong: %+v", r.Facts)
 	}
 }
 
-func TestParseFacts_FencedAndPreamble(t *testing.T) {
-	fenced := "```json\n[{\"type\":\"user\",\"description\":\"d\",\"content\":\"c\"}]\n```"
-	facts, _ := parseFacts(fenced)
-	if len(facts) != 1 {
-		t.Errorf("fenced should parse one fact: %+v", facts)
+func TestParseExtractResult_FencedAndPreamble(t *testing.T) {
+	fenced := "```json\n{\"rollout_slug\":\"x\",\"rollout_summary\":\"\",\"facts\":[{\"type\":\"user\",\"description\":\"d\",\"content\":\"c\"}]}\n```"
+	r, _ := parseExtractResult(fenced)
+	if len(r.Facts) != 1 || r.Slug != "x" {
+		t.Errorf("fenced object should parse: %+v", r)
 	}
-	withPreamble := "Here you go:\n[{\"type\":\"user\",\"description\":\"d\",\"content\":\"c\"}]"
-	facts, _ = parseFacts(withPreamble)
-	if len(facts) != 1 {
-		t.Errorf("preamble should not block parsing: %+v", facts)
-	}
-}
-
-func TestParseFacts_EmptyAndMissingArray(t *testing.T) {
-	if facts, err := parseFacts("[]"); err != nil || facts != nil {
-		t.Errorf("[] should yield nil,nil; got %v,%v", facts, err)
-	}
-	if facts, err := parseFacts("nothing interesting"); err != nil || facts != nil {
-		t.Errorf("no array should yield nil,nil; got %v,%v", facts, err)
+	withPreamble := "Here you go:\n{\"rollout_slug\":\"y\",\"rollout_summary\":\"\",\"facts\":[{\"type\":\"user\",\"description\":\"d\",\"content\":\"c\"}]}"
+	r, _ = parseExtractResult(withPreamble)
+	if len(r.Facts) != 1 || r.Slug != "y" {
+		t.Errorf("preamble should not block parsing: %+v", r)
 	}
 }
 
-func TestParseFacts_DescriptionFromContent(t *testing.T) {
-	in := `[{"type":"user","content":"User prefers Go.\nDetails follow."}]`
-	facts, _ := parseFacts(in)
-	if len(facts) != 1 || facts[0].Description != "User prefers Go." {
-		t.Errorf("description should default to first line of content: %+v", facts)
+func TestParseExtractResult_EmptyAndNoop(t *testing.T) {
+	if r, err := parseExtractResult(`{"rollout_slug":"","rollout_summary":"","facts":[]}`); err != nil || r.Slug != "" || r.Summary != "" || r.Facts != nil {
+		t.Errorf("no-op object → zero result; got %+v, %v", r, err)
+	}
+	if r, err := parseExtractResult("nothing interesting"); err != nil || r.Slug != "" || r.Facts != nil {
+		t.Errorf("no JSON → zero result; got %+v, %v", r, err)
+	}
+}
+
+func TestParseExtractResult_AcceptsLegacyArray(t *testing.T) {
+	// Defensive: a model that ignored the new schema and returned a bare array
+	// (the pre-this-PR shape) should still yield usable facts. Slug/summary
+	// stay empty in that case.
+	legacy := `[{"type":"feedback","description":"run tests first","content":"…"}]`
+	r, err := parseExtractResult(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Slug != "" || r.Summary != "" {
+		t.Errorf("legacy array should leave slug/summary empty, got %+v", r)
+	}
+	if len(r.Facts) != 1 || r.Facts[0].Description != "run tests first" {
+		t.Errorf("legacy array should still yield facts: %+v", r.Facts)
+	}
+}
+
+func TestParseExtractResult_DescriptionFromContent(t *testing.T) {
+	in := `{"rollout_slug":"","rollout_summary":"","facts":[{"type":"user","content":"User prefers Go.\nDetails follow."}]}`
+	r, _ := parseExtractResult(in)
+	if len(r.Facts) != 1 || r.Facts[0].Description != "User prefers Go." {
+		t.Errorf("description should default to first line of content: %+v", r.Facts)
+	}
+}
+
+func TestSanitizeSlug(t *testing.T) {
+	cases := map[string]string{
+		"Tune Extract Prompt":           "tune-extract-prompt",
+		"  fix Bing-encoding  ":         "fix-bing-encoding",
+		"___debug___":                   "debug",
+		"":                              "",
+		"非英文 slug fallback":             "slug-fallback",
+		strings.Repeat("very-long-", 8): "very-long-very-long-very-long-very-long-very-long-very-long",
+	}
+	for in, want := range cases {
+		if got := sanitizeSlug(in); got != want {
+			t.Errorf("sanitizeSlug(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 
 func TestExtractMemory(t *testing.T) {
-	s := &stubExtractSender{reply: `[{"type":"feedback","description":"run tests first","content":"Always run tests before committing."}]`}
+	s := &stubExtractSender{reply: `{"rollout_slug":"tune","rollout_summary":"# tune\n","facts":[{"type":"feedback","description":"run tests first","content":"Always run tests before committing."}]}`}
 	a := New(s, "test-model")
 	msgs := []Message{NewUserMessage("test")}
 
-	facts, err := a.ExtractMemory(context.Background(), msgs)
+	r, err := a.ExtractMemory(context.Background(), msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(facts) != 1 || facts[0].Description != "run tests first" {
-		t.Errorf("ExtractMemory: %+v", facts)
+	if r.Slug != "tune" || !strings.Contains(r.Summary, "tune") {
+		t.Errorf("ExtractMemory slug/summary: %+v", r)
 	}
-	if !strings.Contains(s.lastSystem, "JSON array") {
+	if len(r.Facts) != 1 || r.Facts[0].Description != "run tests first" {
+		t.Errorf("ExtractMemory facts: %+v", r.Facts)
+	}
+	if !strings.Contains(s.lastSystem, "JSON object") {
 		t.Errorf("ExtractMemory should use the extract system prompt, got %q", s.lastSystem)
 	}
 }
 
 func TestExtractMemory_NoMessages(t *testing.T) {
 	a := New(&stubExtractSender{}, "test-model")
-	facts, err := a.ExtractMemory(context.Background(), nil)
-	if err != nil || facts != nil {
-		t.Errorf("no messages → nil,nil; got %v,%v", facts, err)
+	r, err := a.ExtractMemory(context.Background(), nil)
+	if err != nil || r.Slug != "" || r.Summary != "" || r.Facts != nil {
+		t.Errorf("no messages → zero result; got %+v, %v", r, err)
 	}
 }
 

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -51,10 +51,11 @@ type Entry struct {
 }
 
 const (
-	indexFile   = "MEMORY.md"
-	summaryFile = "memory_summary.md"
-	stateFile   = ".state"
-	lockName    = ".lock"
+	indexFile           = "MEMORY.md"
+	summaryFile         = "memory_summary.md"
+	stateFile           = ".state"
+	lockName            = ".lock"
+	rolloutSummariesDir = "rollout_summaries"
 
 	// summaryMarker is the first line of every memory_summary.md octo writes.
 	// It declares the on-disk protocol version so future readers can detect a
@@ -424,6 +425,90 @@ func (s *Store) WriteSummary(summary string) error {
 	}
 	s.maybeCommit("consolidate: write summary")
 	return nil
+}
+
+// RolloutSummary is one entry in rollout_summaries/ — the per-session
+// narrative reference doc (the "what happened this session" artifact).
+type RolloutSummary struct {
+	Filename string // <timestamp>-<slug>.md, relative to rollout_summaries/
+	Slug     string
+	Created  string // YYYY-MM-DD-HHMMSS, from the filename prefix
+	Body     string
+}
+
+// SaveRolloutSummary writes a per-session narrative reference to
+// rollout_summaries/<timestamp>-<slug>.md. Empty body or slug is a no-op
+// (the extraction's no-op gate routinely returns empty). When git is
+// enabled the write is auto-committed.
+//
+// The timestamp prefix keeps rollout summaries chronologically sortable on
+// disk; the slug makes them identifiable.
+func (s *Store) SaveRolloutSummary(slug, body string) error {
+	slug = strings.TrimSpace(slug)
+	body = strings.TrimSpace(body)
+	if slug == "" || body == "" {
+		return nil
+	}
+	if err := s.ensureDir(); err != nil {
+		return err
+	}
+	dir := filepath.Join(s.dir, rolloutSummariesDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	stamp := time.Now().UTC().Format("20060102-150405")
+	name := stamp + "-" + Slugify(slug) + ".md"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body+"\n"), 0o644); err != nil {
+		return err
+	}
+	s.maybeCommit("rollout-summary: " + Slugify(slug))
+	return nil
+}
+
+// ListRolloutSummaries returns every per-rollout summary, sorted by filename
+// (which sorts chronologically because of the timestamp prefix). A missing
+// directory yields nil,nil — no rollouts recorded yet.
+func (s *Store) ListRolloutSummaries() ([]RolloutSummary, error) {
+	dir := filepath.Join(s.dir, rolloutSummariesDir)
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []RolloutSummary
+	for _, de := range ents {
+		name := de.Name()
+		if de.IsDir() || !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		stem := strings.TrimSuffix(name, ".md")
+		stamp, slug := splitRolloutFilename(stem)
+		out = append(out, RolloutSummary{
+			Filename: name,
+			Slug:     slug,
+			Created:  stamp,
+			Body:     strings.TrimSpace(string(b)),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Filename < out[j].Filename })
+	return out, nil
+}
+
+// splitRolloutFilename splits "<YYYYMMDD-HHMMSS>-<slug>" into the two halves.
+// The stamp prefix is 15 chars + a dash; anything after is the slug. If the
+// shape doesn't match, the whole stem is treated as the slug with no stamp.
+func splitRolloutFilename(stem string) (stamp, slug string) {
+	// Expected prefix: 8 digits, dash, 6 digits, dash → "YYYYMMDD-HHMMSS-".
+	if len(stem) < 16 || stem[8] != '-' || stem[15] != '-' {
+		return "", stem
+	}
+	return stem[:15], stem[16:]
 }
 
 // HeadSHA returns the current git HEAD SHA for the store, or "" when git is

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -380,6 +380,56 @@ func TestRenderInjection_HidesMarker(t *testing.T) {
 	}
 }
 
+func TestSaveRolloutSummary_WritesAndLists(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	if err := s.SaveRolloutSummary("tune-extract", "# tuned the extract prompt\n\ndetails…"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.ListRolloutSummaries()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 rollout summary, got %d", len(got))
+	}
+	if got[0].Slug != "tune-extract" {
+		t.Errorf("slug = %q, want %q", got[0].Slug, "tune-extract")
+	}
+	if !strings.Contains(got[0].Body, "tuned the extract prompt") {
+		t.Errorf("body lost: %q", got[0].Body)
+	}
+	// Filename should have the timestamp prefix so on-disk ordering is chronological.
+	if !strings.HasSuffix(got[0].Filename, "-tune-extract.md") {
+		t.Errorf("filename = %q, expected to end with -tune-extract.md", got[0].Filename)
+	}
+}
+
+func TestSaveRolloutSummary_NoOpOnEmpty(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	if err := s.SaveRolloutSummary("", "body"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveRolloutSummary("slug", ""); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.ListRolloutSummaries()
+	if len(got) != 0 {
+		t.Errorf("empty slug or body should be a no-op, got %+v", got)
+	}
+}
+
+func TestSaveRolloutSummary_CommitsWhenGitEnabled(t *testing.T) {
+	requireGit(t)
+	s := NewStoreAt(t.TempDir()).EnableGit()
+	if err := s.SaveRolloutSummary("first-rollout", "body"); err != nil {
+		t.Fatal(err)
+	}
+	sha, _ := s.HeadSHA()
+	if sha == "" {
+		t.Errorf("HeadSHA should be non-empty after a rollout-summary commit")
+	}
+}
+
 func TestExportNotes(t *testing.T) {
 	s := NewStoreAt(t.TempDir())
 	if notes, _ := s.ExportNotes(); notes != "" {

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -27,6 +27,9 @@ You have cross-session memory under `~/.octo/memory/`. Earlier sessions condense
 - **memory_summary.md** — consolidated narrative across sessions; this is what gets injected when present.
 - **`<slug>.md`** — one fact per file with frontmatter (`name / description / type / created`). Types: `user`, `feedback`, `project`, `reference`.
 - **MEMORY.md** — searchable index of slugs.
+- **rollout_summaries/`<timestamp>-<slug>.md`** — per-session narrative references the previous session wrote at exit. NOT auto-injected: grep / read on demand when the user asks "have we worked on X before?", to recover the full context of a past session, or when the consolidated summary is too terse for the question.
+
+The whole directory is a git repo: `cd ~/.octo/memory && git log` shows every change, and the archive of consolidated entries lives in history rather than a sibling folder.
 
 Don't edit these files directly. Use the `remember` tool to add new facts; the user inspects them via `/memory` and `octo memory list`.
 


### PR DESCRIPTION
## Summary

`ExtractMemory` used to return a `[]MemoryFact` — typed entries only. Codex's stage_one (per Appendix A) produces three artifacts per finished session: typed facts, a narrative rollout summary, and a slug. This PR adds the other two while keeping the no-op gate / outcome triage / reading priority from PR #98 intact.

### Wire-level changes

- `agent.ExtractResult { Slug, Summary, Facts }`. `ExtractMemory` returns this in place of a bare slice.
- The `extractSystem` prompt now asks for a single JSON object `{rollout_slug, rollout_summary, facts}`. The no-op case is all-empty fields. The `rollout_summary` format follows Codex's task-first layout (Outcome / Preference signals / Key steps / Failures / Reusable knowledge / References).
- `parseExtractResult` dispatches on the first JSON char so a legacy bare-array reply still parses as facts-only — robust against a model that ignores the new schema.
- `sanitizeSlug` folds the slug to kebab-case + 60-char cap.
- `extractMaxTokens` bumped 1024 → 4096 since one call now produces a narrative too.

### Storage

- `memory.Store.SaveRolloutSummary(slug, body)` writes to `rollout_summaries/<YYYYMMDD-HHMMSS>-<slug>.md`, no-ops on empty inputs, auto-commits via the git baseline from PR #101.
- `ListRolloutSummaries` enumerates them sorted chronologically.
- `base.md` lists `rollout_summaries/` as an **on-demand** reference — not auto-injected — so the agent knows it can grep them when the consolidated summary is too terse.

`extractPreviousSession` at session start now persists all three pieces and falls back to the session id as slug when the model returned `""`.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [x] `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
- [x] New tests cover: object parse, fenced+preamble tolerance, no-op all-empty form, legacy-array fallback, description-from-content fill, slug sanitisation, `SaveRolloutSummary` round-trip + git auto-commit.
- [ ] Live verification: next session exit should produce `~/.octo/memory/rollout_summaries/<stamp>-<slug>.md` AND the per-fact entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)