### PR TITLE
feat(m10): launch_agent sub-agent tool

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -247,8 +247,14 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			memStore: memStore,
 		}
 		if *enableTools {
+			executor := tools.NewDefaultRegistry()
+			// Register sub-agent dispatch BEFORE asking DefaultTools() for the
+			// catalog, so launch_agent appears in the LLM-facing tool list.
+			// The spawner closes over the parent agent so child token usage
+			// rolls back into a's session counters.
+			tools.SetSpawner(newAgentSpawner(a, executor, tools.DefaultTools))
 			cfg.tools = tools.DefaultTools()
-			cfg.executor = tools.NewDefaultRegistry()
+			cfg.executor = executor
 
 			// Build the permission engine that gates every tool call.
 			cwd, _ := os.Getwd()

--- a/cmd/octo/sub_agent.go
+++ b/cmd/octo/sub_agent.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// agentSpawner implements tools.Spawner by building a child agent on each
+// launch_agent call. The child shares the parent's Sender (one provider
+// connection) and System (same harness identity), but runs in isolation:
+// fresh History, no visibility into the parent's conversation, its own
+// loop budget. The final child reply text is returned to the parent as the
+// launch_agent tool_result; the child's token usage is rolled into the
+// parent's session totals so /cost reports one consolidated number.
+//
+// toolsFn is a deferred lookup of the LLM-facing tool catalog (DefaultTools).
+// Resolving it on each Spawn — rather than capturing a slice at construction
+// — lets cmd/octo set up the spawner before computing the tool list, since
+// SetSpawner has to run first for launch_agent to appear in DefaultTools().
+type agentSpawner struct {
+	parent   *agent.Agent
+	executor agent.ToolExecutor
+	toolsFn  func() []agent.ToolDefinition
+}
+
+func newAgentSpawner(parent *agent.Agent, executor agent.ToolExecutor, toolsFn func() []agent.ToolDefinition) *agentSpawner {
+	return &agentSpawner{parent: parent, executor: executor, toolsFn: toolsFn}
+}
+
+// childMaxTurns caps the sub-agent's tool loop. Smaller than the parent's
+// default — sub-agents are meant for focused sub-tasks, not free-form work,
+// and a runaway child can otherwise burn through budget unnoticed.
+const childMaxTurns = 12
+
+// Spawn implements tools.Spawner.
+func (s *agentSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
+	childTools := filterChildTools(s.toolsFn(), req.Tools)
+
+	model := req.Model
+	if model == "" {
+		model = s.parent.Model
+	}
+
+	child := agent.New(s.parent.Sender, model)
+	child.System = s.parent.System // share harness identity (base + soul + env + skills + memory + …)
+	child.MaxTokens = s.parent.MaxTokens
+	child.Gate = s.parent.Gate
+	child.MaxTurns = childMaxTurns
+	// Inherit the parent's hard cost ceiling — the child's spend is rolled
+	// back into the parent below, but the per-loop check inside the child
+	// uses its own counter, so a budget the user already set on the parent
+	// should still constrain the child.
+	child.MaxCostUSD = s.parent.MaxCostUSD
+
+	// Mark the context so the launch_agent tool refuses recursive calls
+	// even if a hallucinating model bypasses the empty-tools filter below.
+	childCtx := tools.WithSubAgentMarker(ctx)
+
+	reply, err := child.Run(childCtx, req.Prompt, childTools, s.executor)
+	if err != nil {
+		return tools.SpawnResult{}, err
+	}
+
+	in, out := child.SessionTokens()
+	s.parent.AccrueChildUsage(in, out)
+
+	return tools.SpawnResult{
+		Reply:        reply.Content,
+		InputTokens:  in,
+		OutputTokens: out,
+	}, nil
+}
+
+// filterChildTools drops launch_agent (no recursion) and, when allowed is
+// non-empty, intersects with that allowlist so the parent can hand the child
+// a restricted toolbelt (e.g. read-only research).
+func filterChildTools(parent []agent.ToolDefinition, allowed []string) []agent.ToolDefinition {
+	var allowSet map[string]bool
+	if len(allowed) > 0 {
+		allowSet = make(map[string]bool, len(allowed))
+		for _, a := range allowed {
+			allowSet[a] = true
+		}
+	}
+	out := make([]agent.ToolDefinition, 0, len(parent))
+	for _, td := range parent {
+		if td.Name == "launch_agent" {
+			continue
+		}
+		if allowSet != nil && !allowSet[td.Name] {
+			continue
+		}
+		out = append(out, td)
+	}
+	return out
+}

--- a/cmd/octo/sub_agent_test.go
+++ b/cmd/octo/sub_agent_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// subAgentSender returns a canned reply and counts how often it's been called.
+// The reply has no tool_use blocks so the child's Run terminates after one
+// turn — that's all we need to exercise the spawner glue.
+type subAgentSender struct {
+	reply        string
+	inputTokens  int
+	outputTokens int
+	calls        int32
+	lastSystem   string
+	lastModel    string
+	lastMessages []agent.Message
+}
+
+func (s *subAgentSender) SendMessages(_ context.Context, model, system string, msgs []agent.Message, _ int) (agent.Reply, error) {
+	atomic.AddInt32(&s.calls, 1)
+	s.lastSystem = system
+	s.lastModel = model
+	s.lastMessages = msgs
+	return agent.Reply{
+		Content:      s.reply,
+		InputTokens:  s.inputTokens,
+		OutputTokens: s.outputTokens,
+	}, nil
+}
+
+// nilExecutor exists so child Run can be called even though our stub Sender
+// never produces tool_use blocks (so Execute is never invoked).
+type nilExecutor struct{}
+
+func (nilExecutor) Execute(_ context.Context, _ string, _ map[string]any) (string, error) {
+	return "", nil
+}
+
+func TestAgentSpawner_RunsChildAndRollsTokensIntoParent(t *testing.T) {
+	send := &subAgentSender{reply: "sub-agent answer", inputTokens: 200, outputTokens: 80}
+	parent := agent.New(send, "parent-model")
+	parent.System = "PARENT SYSTEM"
+	parent.MaxTokens = 4096
+
+	parentTools := []agent.ToolDefinition{
+		{Name: "read_file"},
+		{Name: "grep"},
+		{Name: "launch_agent"},
+	}
+	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return parentTools })
+
+	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{
+		Description: "Investigate",
+		Prompt:      "What is in the cache module?",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Reply != "sub-agent answer" {
+		t.Errorf("Reply = %q", res.Reply)
+	}
+	if res.InputTokens != 200 || res.OutputTokens != 80 {
+		t.Errorf("token usage in result = (%d,%d)", res.InputTokens, res.OutputTokens)
+	}
+
+	// Tokens must roll back into the parent's session totals.
+	in, out := parent.SessionTokens()
+	if in != 200 || out != 80 {
+		t.Errorf("parent session tokens = (%d,%d), want (200,80)", in, out)
+	}
+
+	// Child must have inherited the parent's system + model fallback.
+	if send.lastSystem != "PARENT SYSTEM" {
+		t.Errorf("child system = %q, want parent's", send.lastSystem)
+	}
+	if send.lastModel != "parent-model" {
+		t.Errorf("child model = %q, want parent's default", send.lastModel)
+	}
+}
+
+func TestAgentSpawner_AppliesToolAllowlist(t *testing.T) {
+	send := &subAgentSender{reply: "ok"}
+	parent := agent.New(send, "parent-model")
+	parentTools := []agent.ToolDefinition{
+		{Name: "read_file"},
+		{Name: "grep"},
+		{Name: "terminal"},
+		{Name: "launch_agent"},
+	}
+	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return parentTools })
+
+	// Allowlist restricts to read_file + grep. launch_agent always excluded.
+	got := filterChildTools(parentTools, []string{"read_file", "grep"})
+	if len(got) != 2 {
+		t.Fatalf("filtered tools len = %d, want 2: %+v", len(got), got)
+	}
+	names := []string{got[0].Name, got[1].Name}
+	if !strings.Contains(strings.Join(names, ","), "read_file") || !strings.Contains(strings.Join(names, ","), "grep") {
+		t.Errorf("allowlist not applied: %v", names)
+	}
+
+	// No allowlist → all parent tools minus launch_agent.
+	got = filterChildTools(parentTools, nil)
+	if len(got) != 3 {
+		t.Errorf("nil allowlist should keep all non-launch_agent tools: %+v", got)
+	}
+	for _, td := range got {
+		if td.Name == "launch_agent" {
+			t.Errorf("launch_agent must always be filtered out (no recursion)")
+		}
+	}
+
+	// Spawning should run with the inferred childTools (no error path here —
+	// we just verify the spawner doesn't choke when an allowlist is present).
+	_, err := sp.Spawn(context.Background(), tools.SpawnRequest{
+		Description: "x",
+		Prompt:      "y",
+		Tools:       []string{"read_file"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAgentSpawner_ModelOverride(t *testing.T) {
+	send := &subAgentSender{reply: "ok"}
+	parent := agent.New(send, "parent-model")
+	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+
+	_, err := sp.Spawn(context.Background(), tools.SpawnRequest{
+		Description: "x",
+		Prompt:      "y",
+		Model:       "claude-haiku-4-5",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if send.lastModel != "claude-haiku-4-5" {
+		t.Errorf("model override ignored: child ran with %q", send.lastModel)
+	}
+}
+
+func TestAgentSpawner_MarksContextSoRecursionRefused(t *testing.T) {
+	send := &subAgentSender{reply: "ok"}
+	parent := agent.New(send, "parent-model")
+	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+
+	// Wire SpawnRequest into a real launch_agent tool that checks the sub-agent
+	// context flag. After Spawn returns, the OUTER context shouldn't be marked
+	// (only descendants of the spawn call are), but inside Spawn the child's
+	// Run sees the marked context. We can't reach that from the outside cleanly,
+	// so verify behavior by stubbing the spawner and asserting it would refuse
+	// a recursive launch_agent call.
+	tools.SetSpawner(sp)
+	t.Cleanup(func() { tools.SetSpawner(nil) })
+
+	// Simulating a launch_agent execution from inside a sub-agent's ctx:
+	ctx := tools.WithSubAgentMarker(context.Background())
+	_, err := (tools.LaunchAgentTool{}).Execute(ctx, "launch_agent", map[string]any{
+		"description": "nested",
+		"prompt":      "recurse",
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot spawn") {
+		t.Errorf("recursive launch_agent should be refused, got %v", err)
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -586,16 +586,26 @@ func emitToolResultEvents(handler EventHandler, useBlocks, resultBlocks []Conten
 	}
 }
 
-// readOnlyTools are the built-in tools with no local side effects. A batch
+// readOnlyTools are the built-in tools safe for concurrent dispatch. A batch
 // composed entirely of these can be executed concurrently (see dispatchTools).
 // Conservative by design: anything that writes, edits, or shells out is absent,
 // so adding a new mutating tool can never accidentally be parallelised.
+//
+// launch_agent is included even though a sub-agent can itself write/edit. The
+// parallelism here is *between* sub-agents — two simultaneous launch_agent
+// calls share only the LLM transport (Sender, safe for concurrent use) and
+// the executor (DefaultRegistry's only shared state is mutex-guarded). The
+// parent prompt is responsible for ensuring the sub-agents don't conflict on
+// shared filesystem targets, the same way the user is responsible when they
+// run two terminals at once. The point of including it is to let the model
+// fire "investigate A and B in parallel" as one batch — Codex/CC's pattern.
 var readOnlyTools = map[string]bool{
-	"read_file":  true,
-	"glob":       true,
-	"grep":       true,
-	"web_fetch":  true,
-	"web_search": true,
+	"read_file":    true,
+	"glob":         true,
+	"grep":         true,
+	"web_fetch":    true,
+	"web_search":   true,
+	"launch_agent": true,
 }
 
 // toolCall pairs a tool_use block with the gate's verdict.
@@ -742,6 +752,16 @@ func (a *Agent) accrueUsage(reply Reply) {
 // turns made so far in this Agent's lifetime.
 func (a *Agent) SessionTokens() (inputTokens, outputTokens int) {
 	return a.sessionInputTokens, a.sessionOutputTokens
+}
+
+// AccrueChildUsage folds tokens spent by a spawned sub-agent into this
+// agent's session totals, so /cost and SessionTokens still report one
+// consolidated number even when the LLM used launch_agent. cache totals are
+// left untouched — the child runs against the same provider but reports its
+// own cache hits internally; the parent only sees the bottom-line counts here.
+func (a *Agent) AccrueChildUsage(inputTokens, outputTokens int) {
+	a.sessionInputTokens += inputTokens
+	a.sessionOutputTokens += outputTokens
 }
 
 // SessionCacheTokens returns the cumulative cache read/write token counts.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1078,3 +1078,13 @@ func TestAgent_RunStream_GateDenies_EmitsErrorEvent(t *testing.T) {
 		t.Errorf("expected EventToolError carrying the denial reason")
 	}
 }
+
+func TestAccrueChildUsage_FoldsIntoSessionTotals(t *testing.T) {
+	a := New(nil, "m")
+	a.AccrueChildUsage(100, 50)
+	a.AccrueChildUsage(200, 75)
+	in, out := a.SessionTokens()
+	if in != 300 || out != 125 {
+		t.Errorf("SessionTokens after two AccrueChildUsage = (%d,%d), want (300,125)", in, out)
+	}
+}

--- a/internal/agent/dispatch_test.go
+++ b/internal/agent/dispatch_test.go
@@ -32,6 +32,20 @@ func TestCanParallelize(t *testing.T) {
 			[]toolCall{{block: NewToolUseBlock("a", "write_file", nil), denyReason: "no"}, ro("grep"), ro("glob")},
 			true,
 		},
+		{
+			// launch_agent is in the parallel-safe set even though sub-agents can
+			// have side effects — the LLM is supposed to fan out unrelated
+			// research/sub-tasks via this tool, and the dispatcher running them
+			// concurrently is the whole point. See readOnlyTools' comment.
+			"two launch_agent calls → parallel",
+			[]toolCall{ro("launch_agent"), ro("launch_agent")},
+			true,
+		},
+		{
+			"launch_agent + read_file → parallel",
+			[]toolCall{ro("launch_agent"), ro("read_file")},
+			true,
+		},
 	}
 	for _, tc := range cases {
 		if got := canParallelize(tc.calls); got != tc.want {

--- a/internal/tools/launch_agent.go
+++ b/internal/tools/launch_agent.go
@@ -1,0 +1,190 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// Spawner runs one sub-agent task to completion and returns the final reply.
+// Implementations live outside the tools package (cmd/octo wires the real one,
+// tests substitute fakes) so this package stays free of agent-construction
+// concerns. Multiple Spawner calls may run concurrently from one parent
+// tool_use batch (see parallel dispatch in agent.dispatchTools), so the
+// implementation MUST be safe for concurrent invocation on distinct requests.
+type Spawner interface {
+	Spawn(ctx context.Context, req SpawnRequest) (SpawnResult, error)
+}
+
+// SpawnRequest is the LLM-supplied launch_agent payload, parsed.
+type SpawnRequest struct {
+	// Description is a short human-readable label for logging / progress UI.
+	// Not load-bearing for the LLM — the actual task is in Prompt.
+	Description string
+
+	// Prompt is the sub-agent's user message. It carries the task.
+	Prompt string
+
+	// Tools, when non-empty, restricts the child to this subset of the
+	// parent's tool list. nil/empty means "inherit all of parent's tools
+	// except launch_agent itself" — the spawn implementation handles the
+	// recursion filter, not the tool.
+	Tools []string
+
+	// Model, when non-empty, overrides the parent's model for this child.
+	// Empty means "use the parent's default" — typically the same model.
+	Model string
+}
+
+// SpawnResult is the sub-agent's final output, plus its token usage so the
+// parent can roll it into the session total (the same way /cost displays one
+// number even when sub-agents fired side calls).
+type SpawnResult struct {
+	Reply        string
+	InputTokens  int
+	OutputTokens int
+}
+
+// activeSpawner, when non-nil, backs the launch_agent tool and gates its
+// advertisement in DefaultTools. Set once at session start via SetSpawner.
+// Nil disables sub-agent dispatch — the tool stays out of the LLM-facing
+// schema and Execute errors. Mirrors activeMemory / activeSkills.
+var activeSpawner Spawner
+
+// SetSpawner registers the function the launch_agent tool delegates to. Pass
+// nil to disable (the tool then doesn't appear in DefaultTools).
+func SetSpawner(s Spawner) { activeSpawner = s }
+
+func spawnerEnabled() bool { return activeSpawner != nil }
+
+// subAgentCtxKey marks a context as belonging to a sub-agent's run. The
+// launch_agent tool checks for it to refuse recursive nesting (a sub-agent
+// trying to spawn another sub-agent), defense-in-depth on top of the
+// "drop launch_agent from the child's tool list" filter the Spawner applies.
+type subAgentCtxKeyType struct{}
+
+var subAgentCtxKey = subAgentCtxKeyType{}
+
+// WithSubAgentMarker stamps ctx so descendants are detectable as sub-agent
+// work. The Spawner implementation calls this when invoking the child loop.
+func WithSubAgentMarker(ctx context.Context) context.Context {
+	return context.WithValue(ctx, subAgentCtxKey, true)
+}
+
+// IsSubAgent reports whether ctx is currently inside a sub-agent's run. Used
+// by the launch_agent tool to refuse recursion.
+func IsSubAgent(ctx context.Context) bool {
+	v, _ := ctx.Value(subAgentCtxKey).(bool)
+	return v
+}
+
+// LaunchAgentTool spawns a child agent that handles a single prompt in
+// isolation and returns its final reply. Mapped to the LLM as "launch_agent"
+// — name borrowed from Claude Code's `Agent` tool but the surface is closer
+// to Codex's sub-agent (no event stream surfaced to the parent, just a
+// final string).
+type LaunchAgentTool struct{}
+
+func (LaunchAgentTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "launch_agent",
+		Description: "Spawn an autonomous sub-agent to handle a focused sub-task and " +
+			"return its final answer. Use when you need parallel investigation (research two " +
+			"unrelated areas in one tool_use), when you want a fresh context window for an " +
+			"isolated sub-problem (the sub-agent doesn't see this conversation), or when the " +
+			"sub-task is well-defined enough to delegate without back-and-forth. The sub-agent " +
+			"has the same tools as you (minus launch_agent itself — no recursion) and reports " +
+			"a single text reply when done. Multiple launch_agent calls in one tool_use batch " +
+			"run in parallel. Don't use for tasks that need ongoing user steering or that " +
+			"depend on what's in this conversation.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"description": map[string]any{
+					"type":        "string",
+					"description": "Short human-readable label for this sub-agent (3-7 words). Shown in progress UI; doesn't shape behavior. Example: 'Investigate auth middleware'.",
+				},
+				"prompt": map[string]any{
+					"type":        "string",
+					"description": "The task for the sub-agent. Self-contained: include all context the sub-agent needs (file paths, constraints, deliverable) since it can't see this conversation. State the expected output shape (a summary, a list, a YES/NO).",
+				},
+				"tools": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Optional tool-name allowlist for the sub-agent. Omit or pass empty to inherit your tools (minus launch_agent). Useful to harden a research sub-agent to read-only (e.g. ['read_file','grep','glob']).",
+				},
+				"model": map[string]any{
+					"type":        "string",
+					"description": "Optional model override. Defaults to a cheaper model than the parent when supported, otherwise reuses the parent's model.",
+				},
+			},
+			"required": []string{"description", "prompt"},
+		},
+	}
+}
+
+func (LaunchAgentTool) Execute(ctx context.Context, _ string, input map[string]any) (string, error) {
+	if !spawnerEnabled() {
+		return "", fmt.Errorf("launch_agent: sub-agent dispatch is not configured for this session")
+	}
+	if IsSubAgent(ctx) {
+		// Defense in depth — the Spawner is supposed to filter launch_agent
+		// out of a child's tool list, but a hallucinated tool call would
+		// otherwise still execute through the shared registry.
+		return "", fmt.Errorf("launch_agent: a sub-agent cannot spawn another sub-agent")
+	}
+
+	desc := strings.TrimSpace(stringArg(input, "description"))
+	prompt := strings.TrimSpace(stringArg(input, "prompt"))
+	if prompt == "" {
+		return "", fmt.Errorf("launch_agent: prompt is required")
+	}
+	if desc == "" {
+		// Falling back to a truncated prompt is friendlier than an error —
+		// the LLM may forget the optional-feeling label sometimes.
+		desc = firstLine(prompt)
+	}
+
+	req := SpawnRequest{
+		Description: desc,
+		Prompt:      prompt,
+		Tools:       stringSliceArg(input, "tools"),
+		Model:       strings.TrimSpace(stringArg(input, "model")),
+	}
+	res, err := activeSpawner.Spawn(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("launch_agent: %w", err)
+	}
+	reply := strings.TrimSpace(res.Reply)
+	if reply == "" {
+		// A sub-agent that ended with no final text isn't fatal — it just
+		// has nothing to say. Surface that explicitly so the parent doesn't
+		// guess.
+		return "(sub-agent " + desc + " produced no reply)", nil
+	}
+	return reply, nil
+}
+
+// stringSliceArg pulls an []string argument tolerating absence and the JSON
+// pattern where everything comes through as []any.
+func stringSliceArg(input map[string]any, key string) []string {
+	raw, ok := input[key]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, x := range v {
+			if s, ok := x.(string); ok && strings.TrimSpace(s) != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}

--- a/internal/tools/launch_agent_test.go
+++ b/internal/tools/launch_agent_test.go
@@ -1,0 +1,253 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stubSpawner records the requests it received and replays canned responses
+// in order (or repeats the last entry). Concurrent-safe so the parallel
+// dispatch test can fan out multiple Spawn calls.
+type stubSpawner struct {
+	mu       sync.Mutex
+	replies  []SpawnResult
+	calls    []SpawnRequest
+	delay    time.Duration // optional sleep so two concurrent calls actually overlap
+	err      error
+	spawnCnt int32
+}
+
+func (s *stubSpawner) Spawn(_ context.Context, req SpawnRequest) (SpawnResult, error) {
+	atomic.AddInt32(&s.spawnCnt, 1)
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	if s.err != nil {
+		return SpawnResult{}, s.err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, req)
+	if len(s.replies) == 0 {
+		return SpawnResult{}, nil
+	}
+	if len(s.calls) <= len(s.replies) {
+		return s.replies[len(s.calls)-1], nil
+	}
+	return s.replies[len(s.replies)-1], nil
+}
+
+func useSpawner(t *testing.T, s Spawner) {
+	t.Helper()
+	SetSpawner(s)
+	t.Cleanup(func() { SetSpawner(nil) })
+}
+
+func TestLaunchAgentTool_Schema(t *testing.T) {
+	def := LaunchAgentTool{}.Definition()
+	if def.Name != "launch_agent" {
+		t.Errorf("Name = %q", def.Name)
+	}
+	props, _ := def.Parameters["properties"].(map[string]any)
+	for _, want := range []string{"description", "prompt", "tools", "model"} {
+		if _, ok := props[want]; !ok {
+			t.Errorf("schema missing property %q", want)
+		}
+	}
+	required, _ := def.Parameters["required"].([]string)
+	if !containsString(required, "description") || !containsString(required, "prompt") {
+		t.Errorf("description and prompt should be required, got %v", required)
+	}
+}
+
+func TestLaunchAgentTool_Execute(t *testing.T) {
+	useSpawner(t, &stubSpawner{
+		replies: []SpawnResult{{Reply: "sub-agent finding", InputTokens: 100, OutputTokens: 50}},
+	})
+
+	out, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+		"description": "Investigate X",
+		"prompt":      "Find every reference to FooBar.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "sub-agent finding" {
+		t.Errorf("Execute returned %q, want %q", out, "sub-agent finding")
+	}
+}
+
+func TestLaunchAgentTool_PassesArgsThroughToSpawner(t *testing.T) {
+	stub := &stubSpawner{replies: []SpawnResult{{Reply: "ok"}}}
+	useSpawner(t, stub)
+
+	_, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+		"description": "Audit",
+		"prompt":      "Run a security audit.",
+		"tools":       []any{"read_file", "grep"},
+		"model":       "claude-haiku-4-5",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stub.calls) != 1 {
+		t.Fatalf("expected 1 spawner call, got %d", len(stub.calls))
+	}
+	got := stub.calls[0]
+	if got.Description != "Audit" || got.Prompt != "Run a security audit." || got.Model != "claude-haiku-4-5" {
+		t.Errorf("spawner request mismatch: %+v", got)
+	}
+	if len(got.Tools) != 2 || got.Tools[0] != "read_file" || got.Tools[1] != "grep" {
+		t.Errorf("tools allowlist not forwarded: %v", got.Tools)
+	}
+}
+
+func TestLaunchAgentTool_DescriptionDefaultsFromPrompt(t *testing.T) {
+	stub := &stubSpawner{replies: []SpawnResult{{Reply: "ok"}}}
+	useSpawner(t, stub)
+
+	_, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+		"prompt": "Examine the cache invalidation logic.\nReport back.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stub.calls[0].Description == "" {
+		t.Error("missing description should fall back to first prompt line")
+	}
+}
+
+func TestLaunchAgentTool_RecursionRefused(t *testing.T) {
+	useSpawner(t, &stubSpawner{replies: []SpawnResult{{Reply: "would have worked"}}})
+
+	// Mark the context as already inside a sub-agent.
+	ctx := WithSubAgentMarker(context.Background())
+	_, err := LaunchAgentTool{}.Execute(ctx, "launch_agent", map[string]any{
+		"description": "x",
+		"prompt":      "y",
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot spawn") {
+		t.Errorf("expected recursion refusal, got %v", err)
+	}
+}
+
+func TestLaunchAgentTool_NoSpawnerConfigured(t *testing.T) {
+	SetSpawner(nil)
+	_, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+		"description": "x",
+		"prompt":      "y",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("expected 'not configured' error, got %v", err)
+	}
+}
+
+func TestLaunchAgentTool_PromptRequired(t *testing.T) {
+	useSpawner(t, &stubSpawner{})
+	_, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+		"description": "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "prompt is required") {
+		t.Errorf("expected 'prompt is required' error, got %v", err)
+	}
+}
+
+func TestLaunchAgentTool_EmptyReplySurfacedExplicitly(t *testing.T) {
+	useSpawner(t, &stubSpawner{replies: []SpawnResult{{Reply: "   "}}})
+
+	out, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+		"description": "silent run",
+		"prompt":      "do nothing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "produced no reply") {
+		t.Errorf("empty reply should be surfaced explicitly, got %q", out)
+	}
+}
+
+func TestLaunchAgentTool_SpawnerErrorPropagates(t *testing.T) {
+	useSpawner(t, &stubSpawner{err: errors.New("provider unreachable")})
+	_, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+		"description": "x",
+		"prompt":      "y",
+	})
+	if err == nil || !strings.Contains(err.Error(), "provider unreachable") {
+		t.Errorf("expected propagated spawner error, got %v", err)
+	}
+}
+
+func TestDefaultTools_LaunchAgentGatedOnSpawner(t *testing.T) {
+	SetSpawner(nil)
+	t.Cleanup(func() { SetSpawner(nil) })
+
+	has := func() bool {
+		for _, d := range DefaultTools() {
+			if d.Name == "launch_agent" {
+				return true
+			}
+		}
+		return false
+	}
+
+	if has() {
+		t.Error("launch_agent should be absent when no spawner is configured")
+	}
+	useSpawner(t, &stubSpawner{})
+	if !has() {
+		t.Error("launch_agent should be present once a spawner is registered")
+	}
+}
+
+func TestStringSliceArg(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want []string
+	}{
+		{"missing", nil, nil},
+		{"strings slice", []string{"a", "b"}, []string{"a", "b"}},
+		{"any slice", []any{"a", "b"}, []string{"a", "b"}},
+		{"any slice with junk", []any{"a", 42, "", "b"}, []string{"a", "b"}},
+		{"wrong type", "not-a-slice", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := map[string]any{}
+			if tc.in != nil {
+				input["k"] = tc.in
+			}
+			got := stringSliceArg(input, "k")
+			if !sameStrings(got, tc.want) {
+				t.Errorf("stringSliceArg = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -31,6 +31,7 @@ var allTools = []tool{
 	WebSearchTool{},
 	SkillTool{},
 	RememberTool{},
+	LaunchAgentTool{},
 }
 
 // DefaultRegistry is the agent.ToolExecutor used when `octo chat --tools` is
@@ -86,19 +87,24 @@ func (r DefaultRegistry) Execute(ctx context.Context, name string, input map[str
 }
 
 // DefaultTools returns the slice of ToolDefinitions sent to the LLM when
-// `--tools` is on. Order matches allTools. The skill tool is withheld unless a
-// skill was discovered (SetSkills), and the remember tool unless memory is
-// enabled (SetMemoryStore) — advertising a tool that can only error wastes a
-// slot and confuses the model.
+// `--tools` is on. Order matches allTools. Each capability-gated tool is
+// withheld unless the corresponding registration call has been made —
+// SkillTool needs SetSkills, RememberTool needs SetMemoryStore, LaunchAgentTool
+// needs SetSpawner. Advertising a tool that can only error wastes a slot and
+// confuses the model.
 func DefaultTools() []agent.ToolDefinition {
 	skillsOn := skillsEnabled()
 	memoryOn := memoryEnabled()
+	spawnerOn := spawnerEnabled()
 	defs := make([]agent.ToolDefinition, 0, len(allTools))
 	for _, t := range allTools {
 		if _, isSkill := t.(SkillTool); isSkill && !skillsOn {
 			continue
 		}
 		if _, isRemember := t.(RememberTool); isRemember && !memoryOn {
+			continue
+		}
+		if _, isLaunch := t.(LaunchAgentTool); isLaunch && !spawnerOn {
 			continue
 		}
 		defs = append(defs, t.Definition())


### PR DESCRIPTION
## Summary

Implements **M10 — Sub-Agent Tool** from the Go-rewrite roadmap. Adds a `launch_agent` tool letting the model spawn focused sub-agents that run in isolation and report a single final reply. Unblocks #6 (consolidation via sub-agent) and the future M11 (autonomous task orchestration).

### Surface

- `internal/tools/launch_agent.go` — `Spawner` interface + `LaunchAgentTool`. Spawner implementations live outside the tools package (`cmd/octo` wires the real one; tests use fakes) so this package stays free of agent-construction concerns. Same `SetSpawner` gating pattern as `SetMemoryStore` / `SetSkills` — the tool is hidden from the LLM catalog until a spawner is registered.
- `cmd/octo/sub_agent.go` — `agentSpawner` builds a child `agent.Agent` on each call, sharing the parent's `Sender` (one provider connection) and `System` (same harness identity). Child runs in isolation: fresh `History`, capped at 12 turns so a runaway can't burn budget unnoticed. Token usage rolls back into the parent via `Agent.AccrueChildUsage`.
- `internal/agent/agent.go` — `AccrueChildUsage(in, out int)` (public method), and `launch_agent` added to the parallel-safe `readOnlyTools` set so two `launch_agent` calls in one `tool_use` batch fan out concurrently. Comment on the set updated to explain why a tool that can write through a sub-agent still belongs there.

### Recursion guard (defense in depth)

- `filterChildTools` always drops `launch_agent` from the child's tool list.
- The child's `ctx` is stamped via `tools.WithSubAgentMarker`; `LaunchAgentTool.Execute` refuses to spawn if `IsSubAgent(ctx)` is true. Catches the hallucinated-tool-name case.

### Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [x] `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
- New tests cover: schema shape, Execute happy path / arg forwarding / description fallback / empty reply / errors / gating / recursion refusal; `canParallelize` for `launch_agent × N` and `launch_agent + read_file`; spawner inherits parent's System / Model with override; tool allowlist applied and `launch_agent` always filtered; child tokens rolled into parent.
- [ ] Live verification: parent says "research X and Y in parallel" → two sub-agents spawn concurrently → both replies arrive as tool_results in one turn → `/cost` reports one consolidated total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)