### PR TITLE
feat(c9): consolidate memory via sub-agent (M10-backed)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -200,6 +200,17 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	a.MaxCostUSD = *maxCost
 	a.CompactThreshold = *compactThreshold
 
+	// Build the tool executor up-front (REPL mode only — single-turn mode
+	// doesn't dispatch tools) and register the sub-agent dispatcher BEFORE the
+	// startup memory pass runs. This lets maybeProcessMemory's consolidation
+	// step use a sub-agent (M10, #6) with read-only filesystem tools, falling
+	// back to the side-call path when no Spawner is wired.
+	var toolExecutor tools.DefaultRegistry
+	if isREPL {
+		toolExecutor = tools.NewDefaultRegistry()
+		tools.SetSpawner(newAgentSpawner(a, toolExecutor, tools.DefaultTools))
+	}
+
 	// Boundary memory (REPL only): extract durable facts from the previous
 	// session and consolidate if due, BEFORE rendering this session's injection
 	// so freshly captured facts apply immediately rather than a session later.
@@ -247,14 +258,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			memStore: memStore,
 		}
 		if *enableTools {
-			executor := tools.NewDefaultRegistry()
-			// Register sub-agent dispatch BEFORE asking DefaultTools() for the
-			// catalog, so launch_agent appears in the LLM-facing tool list.
-			// The spawner closes over the parent agent so child token usage
-			// rolls back into a's session counters.
-			tools.SetSpawner(newAgentSpawner(a, executor, tools.DefaultTools))
+			// Spawner is already registered above (before the memory pass) so
+			// launch_agent shows up in DefaultTools here. Reuse the executor
+			// built earlier so the spawner and the REPL share the same read
+			// tracker / mutex-guarded state.
 			cfg.tools = tools.DefaultTools()
-			cfg.executor = executor
+			cfg.executor = toolExecutor
 
 			// Build the permission engine that gates every tool call.
 			cwd, _ := os.Getwd()

--- a/cmd/octo/memory_consolidate_test.go
+++ b/cmd/octo/memory_consolidate_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/memory"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// stubConsolidationSpawner records what the consolidator handed to the sub-
+// agent and replays a canned reply. It's just for the unit-level test —
+// the real spawner is exercised by the M10 integration tests.
+type stubConsolidationSpawner struct {
+	reply string
+	err   error
+
+	called   bool
+	lastReq  tools.SpawnRequest
+	gotPrior bool // prompt mentioned the prior summary
+	gotNotes bool // prompt mentioned the new notes
+}
+
+func (s *stubConsolidationSpawner) Spawn(_ context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
+	s.called = true
+	s.lastReq = req
+	if strings.Contains(req.Prompt, "PRIOR_SUMMARY_MARKER") {
+		s.gotPrior = true
+	}
+	if strings.Contains(req.Prompt, "NEW_NOTES_MARKER") {
+		s.gotNotes = true
+	}
+	if s.err != nil {
+		return tools.SpawnResult{}, s.err
+	}
+	return tools.SpawnResult{Reply: s.reply}, nil
+}
+
+func useConsolidationSpawner(t *testing.T, s tools.Spawner) {
+	t.Helper()
+	tools.SetSpawner(s)
+	t.Cleanup(func() { tools.SetSpawner(nil) })
+}
+
+func TestConsolidateViaSubAgent_HappyPath(t *testing.T) {
+	stub := &stubConsolidationSpawner{reply: "## Consolidated\n- one line\n- two lines"}
+	useConsolidationSpawner(t, stub)
+
+	out := consolidateViaSubAgent(context.Background(), memory.NewStoreAt(t.TempDir()), "PRIOR_SUMMARY_MARKER", "NEW_NOTES_MARKER")
+	if out == "" {
+		t.Fatalf("expected sub-agent path to return text, got empty")
+	}
+	if !strings.Contains(out, "Consolidated") {
+		t.Errorf("unexpected sub-agent output: %q", out)
+	}
+	if !stub.called {
+		t.Error("spawner was never called")
+	}
+	if !stub.gotPrior || !stub.gotNotes {
+		t.Errorf("prompt should embed prior + new notes; gotPrior=%v gotNotes=%v", stub.gotPrior, stub.gotNotes)
+	}
+	if !sliceEquals(stub.lastReq.Tools, consolidationToolAllowlist) {
+		t.Errorf("spawner request should restrict to %v, got %v", consolidationToolAllowlist, stub.lastReq.Tools)
+	}
+}
+
+func TestConsolidateViaSubAgent_NoSpawner(t *testing.T) {
+	tools.SetSpawner(nil)
+	out := consolidateViaSubAgent(context.Background(), memory.NewStoreAt(t.TempDir()), "x", "y")
+	if out != "" {
+		t.Errorf("with no spawner, should return empty (caller falls back to side-call), got %q", out)
+	}
+}
+
+func TestConsolidateViaSubAgent_SpawnerError(t *testing.T) {
+	useConsolidationSpawner(t, &stubConsolidationSpawner{err: errors.New("provider down")})
+	out := consolidateViaSubAgent(context.Background(), memory.NewStoreAt(t.TempDir()), "x", "y")
+	if out != "" {
+		t.Errorf("sub-agent error should be swallowed as empty (caller falls back), got %q", out)
+	}
+}
+
+func TestConsolidateViaSubAgent_StripsCodeFence(t *testing.T) {
+	stub := &stubConsolidationSpawner{
+		reply: "```markdown\n- bullet a\n- bullet b\n```",
+	}
+	useConsolidationSpawner(t, stub)
+
+	out := consolidateViaSubAgent(context.Background(), memory.NewStoreAt(t.TempDir()), "p", "n")
+	if strings.Contains(out, "```") {
+		t.Errorf("code fence should be stripped, got %q", out)
+	}
+	if !strings.Contains(out, "bullet a") {
+		t.Errorf("body lost when stripping fence: %q", out)
+	}
+}
+
+func TestConsolidateViaSubAgent_EmptyReply(t *testing.T) {
+	useConsolidationSpawner(t, &stubConsolidationSpawner{reply: "   "})
+	out := consolidateViaSubAgent(context.Background(), memory.NewStoreAt(t.TempDir()), "p", "n")
+	if out != "" {
+		t.Errorf("empty sub-agent reply should be reported as empty so caller can fall back, got %q", out)
+	}
+}
+
+func TestBuildConsolidationPrompt_ContentShape(t *testing.T) {
+	p := buildConsolidationPrompt("/tmp/mem", "PRIOR", "NEW")
+	for _, want := range []string{
+		"cross-session memory",
+		"/tmp/mem/memory_summary.md",
+		"/tmp/mem/rollout_summaries",
+		"PRIOR",
+		"NEW",
+		"read_file",
+		"protocol marker",
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("prompt missing %q:\n%s", want, p)
+		}
+	}
+}
+
+func TestBuildConsolidationPrompt_HandlesEmptyPriorSummary(t *testing.T) {
+	p := buildConsolidationPrompt("/tmp/mem", "", "NEW")
+	if !strings.Contains(p, "first consolidation pass") {
+		t.Errorf("empty prior summary should be labelled as first pass:\n%s", p)
+	}
+}
+
+func sliceEquals(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/octo/memory_extract.go
+++ b/cmd/octo/memory_extract.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/memory"
+	"github.com/Leihb/octo-agent/internal/tools"
 )
 
 // Consolidation triggers (Phase 1 fallback; the daemon will own these later).
@@ -90,10 +92,21 @@ func consolidateIfDue(ctx context.Context, a *agent.Agent, store *memory.Store, 
 		return // no new active entries — nothing to fold in
 	}
 	priorSummary := store.ReadSummary()
-	summary, err := a.ConsolidateMemory(ctx, priorSummary, newNotes)
-	if err != nil || summary == "" {
-		return
+
+	// Prefer the sub-agent path (#6) when a Spawner is registered: a child
+	// agent runs in its own context with read-only filesystem tools, can
+	// grep / read_file across the memory dir to look at the actual entry
+	// files and rollout summaries, and returns the new summary text. Falls
+	// back to the side-call (priorSummary + newNotes only, no tools) when no
+	// Spawner is wired or the sub-agent declines.
+	summary := consolidateViaSubAgent(ctx, store, priorSummary, newNotes)
+	if summary == "" {
+		summary, err = a.ConsolidateMemory(ctx, priorSummary, newNotes)
+		if err != nil || summary == "" {
+			return
+		}
 	}
+
 	if err := store.WriteSummary(summary); err != nil {
 		return
 	}
@@ -105,12 +118,86 @@ func consolidateIfDue(ctx context.Context, a *agent.Agent, store *memory.Store, 
 		return
 	}
 	st.LastConsolidated = time.Now().Format("2006-01-02")
-	// Record the new git baseline so the future sub-agent consolidator (#6)
-	// knows what point we've folded up to. HeadSHA returns "" when git is off,
-	// which is fine — it just leaves the field empty.
+	// Record the new git baseline so the next consolidation can diff against
+	// it. HeadSHA returns "" when git is off, which is fine — it just leaves
+	// the field empty.
 	if sha, err := store.HeadSHA(); err == nil && sha != "" {
 		st.LastConsolidatedSHA = sha
 	}
+}
+
+// consolidationToolAllowlist restricts the consolidator sub-agent to read-only
+// research. It must not have write_file / edit_file (the parent calls
+// Store.WriteSummary, which adds the v1 marker and commits via git), terminal
+// (out of scope), remember (would mutate memory mid-consolidation), or
+// launch_agent (recursion is filtered out by the spawner anyway, listing it
+// explicitly is defense in depth).
+var consolidationToolAllowlist = []string{"read_file", "grep", "glob"}
+
+// consolidateViaSubAgent runs the consolidation pass as a sub-agent with
+// read-only filesystem tools. Returns the new summary text on success or ""
+// when no spawner is configured / the sub-agent errored / the sub-agent
+// returned nothing. The empty case is non-fatal — caller falls back to the
+// side-call.
+//
+// The sub-agent's win over the side-call: it can grep through rollout_summaries
+// for context that didn't make it into newNotes, read the actual <slug>.md
+// frontmatter, and check MEMORY.md for cross-references — autonomously, in its
+// own context window.
+func consolidateViaSubAgent(ctx context.Context, store *memory.Store, priorSummary, newNotes string) string {
+	spawner := tools.ActiveSpawner()
+	if spawner == nil {
+		return ""
+	}
+
+	res, err := spawner.Spawn(ctx, tools.SpawnRequest{
+		Description: "Consolidate cross-session memory",
+		Prompt:      buildConsolidationPrompt(store.Dir(), priorSummary, newNotes),
+		Tools:       consolidationToolAllowlist,
+	})
+	if err != nil {
+		return ""
+	}
+	out := strings.TrimSpace(res.Reply)
+	// Strip a leading code fence the sub-agent might wrap the summary in.
+	if strings.HasPrefix(out, "```") {
+		if nl := strings.IndexByte(out, '\n'); nl >= 0 {
+			out = out[nl+1:]
+		}
+		if idx := strings.LastIndex(out, "```"); idx >= 0 {
+			out = out[:idx]
+		}
+		out = strings.TrimSpace(out)
+	}
+	return out
+}
+
+// buildConsolidationPrompt assembles the sub-agent's instructions. The prompt
+// is self-contained: the sub-agent doesn't see the parent's conversation, so
+// the current summary, the new notes, and pointers to the on-disk memory dir
+// must all be inline here.
+func buildConsolidationPrompt(memDir, priorSummary, newNotes string) string {
+	var b strings.Builder
+	b.WriteString("You are consolidating cross-session memory for the octo coding agent.\n\n")
+	b.WriteString("Memory layout (read-only access via read_file / grep / glob):\n")
+	if memDir != "" {
+		b.WriteString("- Root: " + memDir + "\n")
+		b.WriteString("- " + memDir + "/MEMORY.md (index of slugs)\n")
+		b.WriteString("- " + memDir + "/<slug>.md (one fact per file, with frontmatter)\n")
+		b.WriteString("- " + memDir + "/rollout_summaries/<timestamp>-<slug>.md (per-session narratives)\n")
+		b.WriteString("- " + memDir + "/memory_summary.md (the file you're updating; current contents below)\n")
+	}
+	b.WriteString("\nCurrent consolidated summary (may be empty on first pass):\n\n")
+	if priorSummary != "" {
+		b.WriteString(priorSummary)
+	} else {
+		b.WriteString("(empty — this is the first consolidation pass)")
+	}
+	b.WriteString("\n\nNew memory entries since the last consolidation (the index digest):\n\n")
+	b.WriteString(newNotes)
+	b.WriteString("\n\nYour task: produce the UPDATED consolidated summary. Fold the new entries into the current summary, dedupe, drop anything stale or trivial, and keep load-bearing facts. Be terse — bullet points, grouped loosely by kind (who the user is, how they like to work, ongoing project context, useful references). If you need more context than the digest gives you (a specific quote, the rationale behind a feedback fact, a related rollout summary), use read_file / grep / glob to look at the actual files.\n\n")
+	b.WriteString("Output ONLY the new summary text. No preamble, no code fences, no commentary about what you changed. The parent will write your output to memory_summary.md (it adds the protocol marker automatically — you don't need to).\n")
+	return b.String()
 }
 
 func consolidateDue(st memory.State, store *memory.Store) bool {

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -102,6 +102,11 @@ func NewStore() (*Store, error) {
 // Git is NOT enabled by default here — chain .EnableGit() if you need it.
 func NewStoreAt(dir string) *Store { return &Store{dir: dir} }
 
+// Dir returns the on-disk root of this store. Useful when an external caller
+// (the sub-agent consolidator) needs to tell the LLM where the memory files
+// live so it can read them with the filesystem tools.
+func (s *Store) Dir() string { return s.dir }
+
 // EnableGit flips the auto-commit behavior on. Subsequent Save / WriteSummary
 // / DropConsolidated calls will lazily `git init` the dir (if needed) and
 // commit each change. Returns the receiver for fluent construction.

--- a/internal/tools/launch_agent.go
+++ b/internal/tools/launch_agent.go
@@ -57,6 +57,12 @@ var activeSpawner Spawner
 // nil to disable (the tool then doesn't appear in DefaultTools).
 func SetSpawner(s Spawner) { activeSpawner = s }
 
+// ActiveSpawner returns the currently registered Spawner, or nil if none.
+// Used by callers outside the tools package (cmd/octo's memory consolidator)
+// to spawn a sub-agent without going through a LLM-driven tool call. May
+// return nil — caller is responsible for the fallback path.
+func ActiveSpawner() Spawner { return activeSpawner }
+
 func spawnerEnabled() bool { return activeSpawner != nil }
 
 // subAgentCtxKey marks a context as belonging to a sub-agent's run. The


### PR DESCRIPTION
## Summary

Closes the **#6** item from the post-session-2 ROI list (`dev-docs/c9-memory-design.md` Appendix A.7) and the M10-dependent slot in §10. Memory consolidation now prefers spawning a sub-agent (via the M10 `Spawner` from PR #104) over the single-shot side-call when one is registered, falling back to the side-call otherwise.

### What the sub-agent path adds over the side-call

- **Isolated context with its own loop** — the sub-agent can `grep` through `rollout_summaries/`, `read_file` individual `<slug>.md` files, check `MEMORY.md` cross-references, autonomously gathering whatever context it needs beyond the digest the side-call sees.
- **Read-only allowlist**: `["read_file", "grep", "glob"]`. No `write_file` (parent calls `Store.WriteSummary` so v1 marker + git commit happen in one place), no `terminal`, no `remember`, no `launch_agent`.

### Wiring

- `cmd/octo/chat.go`: tool executor + `tools.SetSpawner` moved up before `maybeProcessMemory` so the Spawner lives for the whole REPL session, not just the `--tools` branch. Single-turn mode unchanged.
- `cmd/octo/memory_extract.go`: new `consolidateViaSubAgent` + `buildConsolidationPrompt`. The prompt is self-contained (sub-agent doesn't see the parent's conversation): current summary, new notes, memory-dir layout, and pointers to the read-only filesystem tools are all inline.
- `consolidateIfDue` tries the sub-agent first; an empty / errored result falls through to the existing `ConsolidateMemory` side-call, preserving semantics.
- Code-fence strip on the sub-agent's reply — models occasionally wrap the output in ```markdown despite the instruction.
- `memory.Store.Dir()` and `tools.ActiveSpawner()` getters added.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [x] `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
- [x] New tests: happy path, no-spawner fallback, spawner-error fallback, code-fence strip, empty-reply fallback, prompt content shape.
- [ ] Live verification: next consolidation pass (after 24h + 5 new entries) should show the sub-agent reading files via `read_file`/`grep` in addition to the consolidation completing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)