### PR TITLE
feat(tools): ask_user_question — structured clarifying questions in the REPL

### DIFF
--- a/cmd/octo/asker.go
+++ b/cmd/octo/asker.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// replAsker implements tools.Asker by prompting on the REPL's shared
+// stdin/stdout. Same plumbing as cliPermissionGate — both run synchronously
+// inside RunStream, so they share the scanner without racing on it.
+//
+// UX:
+//
+//	[ask_user_question · header]
+//	  Which library should we use?
+//	    1) date-fns
+//	    2) Day.js
+//	    3) Other (free text)
+//	  Select [1-3]: _
+//
+// On multi-select the prompt accepts a comma-separated list ("1,3"). The
+// "Other" tail is always added and lets the user type a free-text answer
+// instead of choosing.
+type replAsker struct {
+	in  *bufio.Scanner // shared with the REPL loop
+	out io.Writer
+}
+
+func newREPLAsker(in *bufio.Scanner, out io.Writer) *replAsker {
+	return &replAsker{in: in, out: out}
+}
+
+// Ask implements tools.Asker.
+func (a *replAsker) Ask(_ context.Context, q tools.AskRequest) (tools.AskResponse, error) {
+	if a.in == nil {
+		return tools.AskResponse{Cancelled: true}, nil
+	}
+
+	a.printQuestion(q)
+
+	raw, ok := a.readLine()
+	if !ok {
+		// EOF or empty submission → treat as cancellation. An empty answer
+		// to a forced-pick prompt isn't a valid selection, and surfacing
+		// "(user cancelled)" to the model gives it a chance to ask again
+		// or pick a default itself.
+		fmt.Fprintln(a.out)
+		return tools.AskResponse{Cancelled: true}, nil
+	}
+
+	choice := strings.TrimSpace(raw)
+	if choice == "" {
+		return tools.AskResponse{Cancelled: true}, nil
+	}
+
+	// "Other" picks the (N+1)th slot — the free-text tail.
+	otherIdx := len(q.Options) + 1
+	indices, parseErr := parseSelection(choice, otherIdx, q.MultiSelect)
+	if parseErr != nil {
+		fmt.Fprintf(a.out, "  (couldn't parse %q, treating as cancellation)\n", choice)
+		return tools.AskResponse{Cancelled: true}, nil
+	}
+
+	var (
+		picks      []string
+		pickedSlot int
+		wantOther  bool
+	)
+	for _, idx := range indices {
+		if idx == otherIdx {
+			wantOther = true
+			continue
+		}
+		if idx < 1 || idx > len(q.Options) {
+			continue // ignore out-of-range; parseSelection already filtered
+		}
+		picks = append(picks, q.Options[idx-1])
+		pickedSlot = idx
+	}
+	_ = pickedSlot
+
+	if wantOther {
+		fmt.Fprint(a.out, "  Other (free text): ")
+		text, ok := a.readLine()
+		if !ok || strings.TrimSpace(text) == "" {
+			return tools.AskResponse{Cancelled: true}, nil
+		}
+		return tools.AskResponse{Custom: strings.TrimSpace(text)}, nil
+	}
+
+	if len(picks) == 0 {
+		return tools.AskResponse{Cancelled: true}, nil
+	}
+	return tools.AskResponse{Choices: picks}, nil
+}
+
+func (a *replAsker) printQuestion(q tools.AskRequest) {
+	header := q.Header
+	if header == "" {
+		header = "question"
+	}
+	fmt.Fprintf(a.out, "\n[ask_user_question · %s]\n", header)
+	fmt.Fprintf(a.out, "  %s\n", q.Question)
+	otherIdx := len(q.Options) + 1
+	for i, opt := range q.Options {
+		fmt.Fprintf(a.out, "    %d) %s\n", i+1, opt)
+	}
+	fmt.Fprintf(a.out, "    %d) Other (free text)\n", otherIdx)
+
+	hint := fmt.Sprintf("[1-%d]", otherIdx)
+	if q.MultiSelect {
+		hint = "[comma-separated, e.g. 1,3]"
+	}
+	fmt.Fprintf(a.out, "  Select %s: ", hint)
+}
+
+func (a *replAsker) readLine() (string, bool) {
+	if !a.in.Scan() {
+		return "", false
+	}
+	return a.in.Text(), true
+}
+
+// parseSelection converts the user's typed answer into a list of 1-based
+// option indices. Empty / non-numeric input returns nil with no error;
+// genuinely malformed input (e.g. mixing numbers and prose) errors so the
+// caller can treat it as cancellation rather than guessing.
+//
+// In single-select mode, only the first index is honored even if the user
+// typed multiple.
+func parseSelection(raw string, maxIdx int, multi bool) ([]int, error) {
+	parts := strings.Split(raw, ",")
+	var out []int
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, fmt.Errorf("not a number: %q", p)
+		}
+		if n < 1 || n > maxIdx {
+			return nil, fmt.Errorf("out of range: %d", n)
+		}
+		out = append(out, n)
+	}
+	if !multi && len(out) > 1 {
+		out = out[:1]
+	}
+	return out, nil
+}

--- a/cmd/octo/asker_test.go
+++ b/cmd/octo/asker_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// askInput wires a replAsker around the canned stdin string + a buffer for
+// the rendered prompt. Returns the asker and the output buffer so tests
+// can assert both the user answer and the displayed UI.
+func askInput(input string) (*replAsker, *bytes.Buffer) {
+	out := &bytes.Buffer{}
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	return newREPLAsker(scanner, out), out
+}
+
+func TestReplAsker_PrintsQuestionAndOptions(t *testing.T) {
+	a, out := askInput("1\n")
+	_, err := a.Ask(context.Background(), tools.AskRequest{
+		Question: "Which library should we use?",
+		Options:  []string{"date-fns", "Day.js", "Luxon"},
+		Header:   "lib_choice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"[ask_user_question · lib_choice]",
+		"Which library should we use?",
+		"1) date-fns",
+		"2) Day.js",
+		"3) Luxon",
+		"4) Other (free text)", // tail is always added
+		"Select [1-4]:",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prompt missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestReplAsker_SinglePickFirstOption(t *testing.T) {
+	a, _ := askInput("1\n")
+	r, _ := a.Ask(context.Background(), tools.AskRequest{
+		Question: "?",
+		Options:  []string{"alpha", "beta"},
+	})
+	if len(r.Choices) != 1 || r.Choices[0] != "alpha" {
+		t.Errorf("single pick = %+v, want [alpha]", r.Choices)
+	}
+}
+
+func TestReplAsker_MultiSelect(t *testing.T) {
+	a, out := askInput("1,3\n")
+	r, _ := a.Ask(context.Background(), tools.AskRequest{
+		Question:    "?",
+		Options:     []string{"alpha", "beta", "gamma"},
+		MultiSelect: true,
+	})
+	if len(r.Choices) != 2 || r.Choices[0] != "alpha" || r.Choices[1] != "gamma" {
+		t.Errorf("multi-pick = %+v, want [alpha gamma]", r.Choices)
+	}
+	if !strings.Contains(out.String(), "comma-separated") {
+		t.Errorf("multi-select prompt should hint at comma-separated input")
+	}
+}
+
+func TestReplAsker_SingleSelectIgnoresExtraPicks(t *testing.T) {
+	// Even when the user types "1,2", single-select keeps only the first.
+	a, _ := askInput("1,2\n")
+	r, _ := a.Ask(context.Background(), tools.AskRequest{
+		Question: "?",
+		Options:  []string{"alpha", "beta"},
+	})
+	if len(r.Choices) != 1 || r.Choices[0] != "alpha" {
+		t.Errorf("single-select must keep only the first pick, got %+v", r.Choices)
+	}
+}
+
+func TestReplAsker_OtherFreeText(t *testing.T) {
+	// "Other" is the (len(opts)+1)-th slot; after picking it, the asker
+	// prompts again for the free-text follow-up.
+	a, out := askInput("3\nKerberos with constrained delegation\n")
+	r, _ := a.Ask(context.Background(), tools.AskRequest{
+		Question: "?",
+		Options:  []string{"OAuth", "API key"},
+	})
+	if r.Custom != "Kerberos with constrained delegation" {
+		t.Errorf("custom = %q", r.Custom)
+	}
+	if len(r.Choices) != 0 {
+		t.Errorf("custom answer should leave Choices empty, got %+v", r.Choices)
+	}
+	if !strings.Contains(out.String(), "Other (free text):") {
+		t.Errorf("Other follow-up prompt missing in:\n%s", out)
+	}
+}
+
+func TestReplAsker_OtherEmptyFreeText_Cancels(t *testing.T) {
+	a, _ := askInput("3\n\n")
+	r, _ := a.Ask(context.Background(), tools.AskRequest{
+		Question: "?",
+		Options:  []string{"a", "b"},
+	})
+	if !r.Cancelled {
+		t.Errorf("empty Other text should cancel, got %+v", r)
+	}
+}
+
+func TestReplAsker_EmptyInputCancels(t *testing.T) {
+	a, _ := askInput("\n")
+	r, _ := a.Ask(context.Background(), tools.AskRequest{
+		Question: "?",
+		Options:  []string{"a", "b"},
+	})
+	if !r.Cancelled {
+		t.Errorf("empty selection should cancel, got %+v", r)
+	}
+}
+
+func TestReplAsker_EOFCancels(t *testing.T) {
+	// Empty reader → Scan returns false immediately → cancel.
+	a, _ := askInput("")
+	r, _ := a.Ask(context.Background(), tools.AskRequest{
+		Question: "?",
+		Options:  []string{"a", "b"},
+	})
+	if !r.Cancelled {
+		t.Errorf("EOF should cancel, got %+v", r)
+	}
+}
+
+func TestReplAsker_NonNumericCancels(t *testing.T) {
+	// Garbage input → can't parse → cancel (with a friendly inline note).
+	a, out := askInput("yes please\n")
+	r, _ := a.Ask(context.Background(), tools.AskRequest{
+		Question: "?",
+		Options:  []string{"a", "b"},
+	})
+	if !r.Cancelled {
+		t.Errorf("non-numeric input should cancel, got %+v", r)
+	}
+	if !strings.Contains(out.String(), "couldn't parse") {
+		t.Errorf("expected user-facing parse note in:\n%s", out)
+	}
+}
+
+func TestReplAsker_HeaderDefault(t *testing.T) {
+	a, out := askInput("1\n")
+	_, _ = a.Ask(context.Background(), tools.AskRequest{
+		Question: "?",
+		Options:  []string{"a", "b"},
+		// no Header
+	})
+	if !strings.Contains(out.String(), "[ask_user_question · question]") {
+		t.Errorf("missing header should default to 'question':\n%s", out)
+	}
+}
+
+func TestParseSelection(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		max     int
+		multi   bool
+		want    []int
+		wantErr bool
+	}{
+		{"single", "2", 4, false, []int{2}, false},
+		{"multi keeps all", "1,3", 4, true, []int{1, 3}, false},
+		{"single drops extras", "1,3", 4, false, []int{1}, false},
+		{"whitespace tolerated", " 2 , 4 ", 4, true, []int{2, 4}, false},
+		{"out of range errors", "9", 4, false, nil, true},
+		{"non-numeric errors", "abc", 4, false, nil, true},
+		{"empty returns empty", "", 4, false, nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSelection(tc.in, tc.max, tc.multi)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil (%v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if !sliceEqualsInt(got, tc.want) {
+				t.Errorf("parseSelection = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func sliceEqualsInt(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -205,10 +206,22 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// startup memory pass runs. This lets maybeProcessMemory's consolidation
 	// step use a sub-agent (M10, #6) with read-only filesystem tools, falling
 	// back to the side-call path when no Spawner is wired.
-	var toolExecutor tools.DefaultRegistry
+	//
+	// The stdin scanner is built here too so the same instance is shared with
+	// the REPL loop (no double-buffering), the permission gate, and the
+	// asker. Registering the asker NOW also matters for DefaultTools()
+	// gating: the ask_user_question tool only appears when an asker is
+	// registered, and DefaultTools is computed below before runREPL starts.
+	var (
+		toolExecutor tools.DefaultRegistry
+		replScanner  *bufio.Scanner
+	)
 	if isREPL {
 		toolExecutor = tools.NewDefaultRegistry()
 		tools.SetSpawner(newAgentSpawner(a, toolExecutor, tools.DefaultTools))
+		replScanner = bufio.NewScanner(stdin)
+		tools.SetAsker(newREPLAsker(replScanner, stdout))
+		defer tools.SetAsker(nil)
 	}
 
 	// Boundary memory (REPL only): extract durable facts from the previous
@@ -256,6 +269,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			stderr:   stderr,
 			skillReg: skillReg,
 			memStore: memStore,
+			scanner:  replScanner, // shared with the asker / permission gate
 		}
 		if *enableTools {
 			// Spawner is already registered above (before the memory pass) so

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -35,6 +35,11 @@ type replConfig struct {
 	executor   agent.ToolExecutor
 	skillReg   *skills.Registry // discovered skills; backs /skills and /<name>
 	memStore   *memory.Store    // cross-session memory; backs /memory (nil → disabled)
+	// scanner, when non-nil, is the stdin reader to use instead of building
+	// one fresh inside runREPL. Set by cmd/octo when the asker / spawner need
+	// the same scanner the loop will read from (no double-buffering). Tests
+	// that only pass cfg.stdin leave this nil and runREPL builds its own.
+	scanner *bufio.Scanner
 }
 
 // runREPL runs the interactive multi-turn loop until the user exits or EOF.
@@ -60,7 +65,10 @@ func runREPL(cfg replConfig) int {
 	fmt.Fprintln(cfg.stdout, `Type /help for commands, Ctrl-C or /exit to quit.`)
 	fmt.Fprintln(cfg.stdout)
 
-	scanner := bufio.NewScanner(cfg.stdin)
+	scanner := cfg.scanner
+	if scanner == nil {
+		scanner = bufio.NewScanner(cfg.stdin)
+	}
 
 	// Ctrl-C handling: while a turn is running, SIGINT cancels just that turn
 	// (the loop catches context.Canceled, finalizes well-formed history, and

--- a/internal/tools/ask_user_question.go
+++ b/internal/tools/ask_user_question.go
@@ -1,0 +1,164 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// Asker presents a structured question to the user and waits for their
+// answer. Implementations live in cmd/octo (the REPL prompt reader); tests
+// substitute fakes. Like Spawner, this interface stays free of the
+// stdin/terminal mechanics so the tools package doesn't depend on cmd/octo.
+type Asker interface {
+	Ask(ctx context.Context, q AskRequest) (AskResponse, error)
+}
+
+// AskRequest is the structured question, parsed from the tool input.
+type AskRequest struct {
+	// Question is the prompt shown to the user, complete with punctuation.
+	Question string
+
+	// Options are the mutually-exclusive (or, when MultiSelect, jointly
+	// selectable) labels. Empty means "free text answer" (the asker prompts
+	// for an open-ended response with no list).
+	Options []string
+
+	// MultiSelect lets the user pick more than one option. The asker is
+	// responsible for parsing a comma-separated selection and returning all
+	// chosen labels.
+	MultiSelect bool
+
+	// Header is an optional short tag (≤12 chars) shown in the prompt UI.
+	// Helpful when several questions share visual real estate.
+	Header string
+}
+
+// AskResponse is what the user provided. Cancelled is true when the user
+// dismissed the prompt (Ctrl-C, empty enter on a forced-pick, etc.); in
+// that case Choices and Custom are empty.
+type AskResponse struct {
+	// Choices are the labels the user selected from Options. Empty when
+	// the user picked "Other" (then Custom carries their free text) or
+	// when the question had no Options (free text only).
+	Choices []string
+
+	// Custom is the free-text answer for "Other" picks or option-less
+	// questions. Empty for plain selections.
+	Custom string
+
+	// Cancelled reports user dismissal. The tool surfaces this to the LLM
+	// as a non-error result so the model can decide what to do next.
+	Cancelled bool
+}
+
+// activeAsker, when non-nil, backs the ask_user_question tool and gates its
+// advertisement in DefaultTools. Set by the REPL at session start; nil in
+// single-turn / unattended modes, where prompting the user is impossible.
+var activeAsker Asker
+
+// SetAsker registers the asker the ask_user_question tool delegates to.
+// Pass nil to disable (the tool then doesn't appear in DefaultTools).
+func SetAsker(a Asker) { activeAsker = a }
+
+func askerEnabled() bool { return activeAsker != nil }
+
+// AskUserQuestionTool lets the model ask the user a single structured
+// clarifying question. The point isn't to chat with the user — it's to
+// resolve a branch where the model genuinely doesn't have enough
+// information to pick a default and asking via free-form prose would
+// produce a sloppy, hard-to-parse answer.
+//
+// Schema mirrors Claude Code's AskUserQuestion at the surface level but
+// caps at ONE question per call (per the M11-prep design): simpler
+// schema, simpler REPL UX, model fires multiple calls if it needs
+// multiple questions.
+type AskUserQuestionTool struct{}
+
+func (AskUserQuestionTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "ask_user_question",
+		Description: "Ask the user one structured clarifying question and wait for their answer. " +
+			"Use this when you're at a branch where you genuinely lack the information to pick a " +
+			"reasonable default — preferences (\"which library?\"), trade-offs (\"prioritize speed " +
+			"or readability?\"), or scope (\"include the migration too?\"). Don't use it for " +
+			"information you could find in the repo or for questions you should have an opinion " +
+			"on yourself. Options must be 2-4 mutually exclusive labels; if you also pass " +
+			"multi_select=true the user can pick more than one. An \"Other\" tail with a free-text " +
+			"follow-up is always added. Result text is shaped like 'User chose: <label>' or, " +
+			"for Other, 'User chose: Other — <free text>'.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"question": map[string]any{
+					"type":        "string",
+					"description": "The question to ask, complete with punctuation. Should be one sentence; if you need more context, put it in the option labels instead of the question itself.",
+				},
+				"options": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"minItems":    2,
+					"maxItems":    4,
+					"description": "2-4 mutually exclusive labels. Each label should be a complete choice (\"OAuth with PKCE\" not just \"OAuth\"). The asker adds an \"Other (free text)\" tail automatically — don't include one yourself.",
+				},
+				"multi_select": map[string]any{
+					"type":        "boolean",
+					"description": "Set true when the choices are NOT mutually exclusive (e.g. \"which features should we enable?\"). The user can then pick a comma-separated subset.",
+				},
+				"header": map[string]any{
+					"type":        "string",
+					"description": "Optional short tag shown in the prompt UI (≤12 chars). Helps the user track which question is which when you ask several in sequence. Example: 'auth_method', 'scope'.",
+				},
+			},
+			"required": []string{"question", "options"},
+		},
+	}
+}
+
+func (AskUserQuestionTool) Execute(ctx context.Context, _ string, input map[string]any) (string, error) {
+	if !askerEnabled() {
+		return "", fmt.Errorf("ask_user_question: not available in this mode (REPL only)")
+	}
+	question := strings.TrimSpace(stringArg(input, "question"))
+	if question == "" {
+		return "", fmt.Errorf("ask_user_question: question is required")
+	}
+	options := stringSliceArg(input, "options")
+	if len(options) < 2 || len(options) > 4 {
+		return "", fmt.Errorf("ask_user_question: options must have 2-4 entries (got %d)", len(options))
+	}
+	multi, _ := input["multi_select"].(bool)
+	header := strings.TrimSpace(stringArg(input, "header"))
+
+	res, err := activeAsker.Ask(ctx, AskRequest{
+		Question:    question,
+		Options:     options,
+		MultiSelect: multi,
+		Header:      header,
+	})
+	if err != nil {
+		return "", fmt.Errorf("ask_user_question: %w", err)
+	}
+	return formatAskResponse(res), nil
+}
+
+// formatAskResponse turns the asker's structured reply into the text the LLM
+// reads as its tool_result. Three shapes:
+//
+//	cancelled                  → "(user cancelled)"
+//	plain selection(s)         → "User chose: A" or "User chose: A, B"
+//	"Other" with free text     → "User chose: Other — <text>"
+func formatAskResponse(r AskResponse) string {
+	if r.Cancelled {
+		return "(user cancelled)"
+	}
+	if r.Custom != "" && len(r.Choices) == 0 {
+		return "User chose: Other — " + r.Custom
+	}
+	if len(r.Choices) == 0 {
+		return "(user cancelled)" // defensive: no choices and no custom → nothing to report
+	}
+	return "User chose: " + strings.Join(r.Choices, ", ")
+}

--- a/internal/tools/ask_user_question_test.go
+++ b/internal/tools/ask_user_question_test.go
@@ -1,0 +1,234 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// stubAsker records what the tool handed it and replays a canned response.
+type stubAsker struct {
+	resp    AskResponse
+	err     error
+	called  bool
+	lastReq AskRequest
+}
+
+func (s *stubAsker) Ask(_ context.Context, q AskRequest) (AskResponse, error) {
+	s.called = true
+	s.lastReq = q
+	return s.resp, s.err
+}
+
+func useAsker(t *testing.T, a Asker) {
+	t.Helper()
+	SetAsker(a)
+	t.Cleanup(func() { SetAsker(nil) })
+}
+
+func TestAskUserQuestionTool_Schema(t *testing.T) {
+	def := AskUserQuestionTool{}.Definition()
+	if def.Name != "ask_user_question" {
+		t.Errorf("Name = %q", def.Name)
+	}
+	props, _ := def.Parameters["properties"].(map[string]any)
+	for _, want := range []string{"question", "options", "multi_select", "header"} {
+		if _, ok := props[want]; !ok {
+			t.Errorf("schema missing property %q", want)
+		}
+	}
+	required, _ := def.Parameters["required"].([]string)
+	if !sliceContains(required, "question") || !sliceContains(required, "options") {
+		t.Errorf("question + options should be required, got %v", required)
+	}
+}
+
+func TestAskUserQuestionTool_Execute_SingleChoice(t *testing.T) {
+	stub := &stubAsker{resp: AskResponse{Choices: []string{"OAuth"}}}
+	useAsker(t, stub)
+
+	out, err := AskUserQuestionTool{}.Execute(context.Background(), "ask_user_question", map[string]any{
+		"question": "Which auth method?",
+		"options":  []any{"OAuth", "API key", "mTLS"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "User chose: OAuth" {
+		t.Errorf("Execute result = %q", out)
+	}
+	if !stub.called {
+		t.Error("asker was never invoked")
+	}
+	if stub.lastReq.Question != "Which auth method?" {
+		t.Errorf("question not forwarded: %q", stub.lastReq.Question)
+	}
+	if len(stub.lastReq.Options) != 3 {
+		t.Errorf("options not forwarded: %v", stub.lastReq.Options)
+	}
+}
+
+func TestAskUserQuestionTool_Execute_MultiChoice(t *testing.T) {
+	stub := &stubAsker{resp: AskResponse{Choices: []string{"OAuth", "API key"}}}
+	useAsker(t, stub)
+
+	out, err := AskUserQuestionTool{}.Execute(context.Background(), "ask_user_question", map[string]any{
+		"question":     "Which auth methods should we support?",
+		"options":      []any{"OAuth", "API key", "mTLS"},
+		"multi_select": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "User chose: OAuth, API key" {
+		t.Errorf("Execute result = %q", out)
+	}
+	if !stub.lastReq.MultiSelect {
+		t.Error("multi_select flag not forwarded")
+	}
+}
+
+func TestAskUserQuestionTool_Execute_OtherFreeText(t *testing.T) {
+	stub := &stubAsker{resp: AskResponse{Custom: "Kerberos with constrained delegation"}}
+	useAsker(t, stub)
+
+	out, _ := AskUserQuestionTool{}.Execute(context.Background(), "ask_user_question", map[string]any{
+		"question": "Which auth method?",
+		"options":  []any{"OAuth", "API key"},
+	})
+	if !strings.HasPrefix(out, "User chose: Other — ") {
+		t.Errorf("free-text answer should be reported as Other — …, got %q", out)
+	}
+	if !strings.Contains(out, "Kerberos with constrained delegation") {
+		t.Errorf("free-text payload lost: %q", out)
+	}
+}
+
+func TestAskUserQuestionTool_Execute_Cancelled(t *testing.T) {
+	useAsker(t, &stubAsker{resp: AskResponse{Cancelled: true}})
+	out, err := AskUserQuestionTool{}.Execute(context.Background(), "ask_user_question", map[string]any{
+		"question": "Which?",
+		"options":  []any{"a", "b"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "(user cancelled)" {
+		t.Errorf("cancellation = %q, want '(user cancelled)'", out)
+	}
+}
+
+func TestAskUserQuestionTool_Execute_HeaderForwarded(t *testing.T) {
+	stub := &stubAsker{resp: AskResponse{Choices: []string{"a"}}}
+	useAsker(t, stub)
+	_, _ = AskUserQuestionTool{}.Execute(context.Background(), "ask_user_question", map[string]any{
+		"question": "Q?",
+		"options":  []any{"a", "b"},
+		"header":   "auth_method",
+	})
+	if stub.lastReq.Header != "auth_method" {
+		t.Errorf("header not forwarded: %q", stub.lastReq.Header)
+	}
+}
+
+func TestAskUserQuestionTool_Execute_AskerError(t *testing.T) {
+	useAsker(t, &stubAsker{err: errors.New("stdin closed")})
+	_, err := AskUserQuestionTool{}.Execute(context.Background(), "ask_user_question", map[string]any{
+		"question": "Q?",
+		"options":  []any{"a", "b"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "stdin closed") {
+		t.Errorf("asker error should propagate, got %v", err)
+	}
+}
+
+func TestAskUserQuestionTool_Execute_NoAsker(t *testing.T) {
+	SetAsker(nil)
+	_, err := AskUserQuestionTool{}.Execute(context.Background(), "ask_user_question", map[string]any{
+		"question": "Q?",
+		"options":  []any{"a", "b"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not available") {
+		t.Errorf("no asker should error 'not available', got %v", err)
+	}
+}
+
+func TestAskUserQuestionTool_Execute_Validation(t *testing.T) {
+	useAsker(t, &stubAsker{resp: AskResponse{Choices: []string{"a"}}})
+
+	// Missing question.
+	if _, err := (AskUserQuestionTool{}).Execute(context.Background(), "ask_user_question", map[string]any{
+		"options": []any{"a", "b"},
+	}); err == nil || !strings.Contains(err.Error(), "question is required") {
+		t.Errorf("missing question should error, got %v", err)
+	}
+
+	// Too few options.
+	if _, err := (AskUserQuestionTool{}).Execute(context.Background(), "ask_user_question", map[string]any{
+		"question": "Q?",
+		"options":  []any{"only"},
+	}); err == nil || !strings.Contains(err.Error(), "2-4 entries") {
+		t.Errorf("single option should error, got %v", err)
+	}
+
+	// Too many options.
+	if _, err := (AskUserQuestionTool{}).Execute(context.Background(), "ask_user_question", map[string]any{
+		"question": "Q?",
+		"options":  []any{"a", "b", "c", "d", "e"},
+	}); err == nil || !strings.Contains(err.Error(), "2-4 entries") {
+		t.Errorf("5 options should error, got %v", err)
+	}
+}
+
+func TestDefaultTools_AskGatedOnAsker(t *testing.T) {
+	SetAsker(nil)
+	t.Cleanup(func() { SetAsker(nil) })
+
+	has := func() bool {
+		for _, d := range DefaultTools() {
+			if d.Name == "ask_user_question" {
+				return true
+			}
+		}
+		return false
+	}
+
+	if has() {
+		t.Error("ask_user_question should be absent when no asker is configured")
+	}
+	useAsker(t, &stubAsker{})
+	if !has() {
+		t.Error("ask_user_question should appear once an asker is registered")
+	}
+}
+
+func TestFormatAskResponse(t *testing.T) {
+	cases := []struct {
+		name string
+		in   AskResponse
+		want string
+	}{
+		{"cancelled", AskResponse{Cancelled: true}, "(user cancelled)"},
+		{"single", AskResponse{Choices: []string{"OAuth"}}, "User chose: OAuth"},
+		{"multi", AskResponse{Choices: []string{"a", "b"}}, "User chose: a, b"},
+		{"other", AskResponse{Custom: "Kerberos"}, "User chose: Other — Kerberos"},
+		{"empty (defensive)", AskResponse{}, "(user cancelled)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatAskResponse(tc.in); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func sliceContains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -32,6 +32,7 @@ var allTools = []tool{
 	SkillTool{},
 	RememberTool{},
 	LaunchAgentTool{},
+	AskUserQuestionTool{},
 }
 
 // DefaultRegistry is the agent.ToolExecutor used when `octo chat --tools` is
@@ -96,6 +97,7 @@ func DefaultTools() []agent.ToolDefinition {
 	skillsOn := skillsEnabled()
 	memoryOn := memoryEnabled()
 	spawnerOn := spawnerEnabled()
+	askerOn := askerEnabled()
 	defs := make([]agent.ToolDefinition, 0, len(allTools))
 	for _, t := range allTools {
 		if _, isSkill := t.(SkillTool); isSkill && !skillsOn {
@@ -105,6 +107,9 @@ func DefaultTools() []agent.ToolDefinition {
 			continue
 		}
 		if _, isLaunch := t.(LaunchAgentTool); isLaunch && !spawnerOn {
+			continue
+		}
+		if _, isAsk := t.(AskUserQuestionTool); isAsk && !askerOn {
 			continue
 		}
 		defs = append(defs, t.Definition())


### PR DESCRIPTION
## Summary

Adds a tool the model can call when it's at a branch where it genuinely lacks the information to pick a default (which library? which auth method? include the migration?), instead of dumping the question into a free-form reply.

### Surface

```
ask_user_question(
  question:     string,           // required, complete with ?
  options:      [string, …],      // 2-4 mutually exclusive labels
  multi_select: bool,             // true → comma-separated subset allowed
  header:       string,           // optional ≤12-char tag
)
```

### REPL UX

```
[ask_user_question · auth_method]
  Which auth method should we use?
    1) OAuth
    2) API key
    3) mTLS
    4) Other (free text)
  Select [1-4]: _
```

`Other` is always appended as the `(N+1)`-th slot; picking it triggers a free-text follow-up. Tool result text:

| User does | Result text |
|---|---|
| Picks 1 | `User chose: OAuth` |
| Multi-picks 1,2 | `User chose: OAuth, API key` |
| Picks Other + types text | `User chose: Other — <text>` |
| Ctrl-D / empty / garbage | `(user cancelled)` |

### Wiring notes

- `tools.SetAsker` follows the gating pattern of `SetSpawner` / `SetMemoryStore` / `SetSkills` — the tool is dropped from `DefaultTools()` until an Asker is registered, so single-turn mode and unattended scripts don't advertise it.
- Scanner is now built in `chat.go` (before `maybeProcessMemory`) and passed through `replConfig.scanner`, so `SetAsker` can fire **before** `DefaultTools()` is computed. Tests that don't set the scanner field fall back to `runREPL` building its own — existing fixtures unchanged.
- Same shared-scanner plumbing as `cliPermissionGate`: tool dispatch is synchronous inside `RunStream`, so no contention.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [x] `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
- [x] Tool tests: schema, single/multi/Other paths, cancellation, header forwarding, error propagation, no-asker gating, options-count validation.
- [x] REPL asker tests: prompt rendering, single/multi pick, single-select drops extras, Other + free text, Other + empty cancels, empty/EOF cancels, garbage cancels with note, header default.
- [x] `parseSelection` table-driven for ranges, multi-vs-single, whitespace tolerance, error paths.
- [ ] Live verification: model asks a structured question in REPL → numbered list renders → user picks → result lands as `User chose: …` in next tool_result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)