### PR TITLE
feat(tools): task_manager — task_create / task_update / task_list

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/provider/anthropic"
 	"github.com/Leihb/octo-agent/internal/provider/openai"
 	"github.com/Leihb/octo-agent/internal/skills"
+	"github.com/Leihb/octo-agent/internal/tasks"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
@@ -222,6 +223,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		replScanner = bufio.NewScanner(stdin)
 		tools.SetAsker(newREPLAsker(replScanner, stdout))
 		defer tools.SetAsker(nil)
+
+		// Session-scoped task tracker for the task_create / task_update /
+		// task_list tools + the /tasks REPL command. Lost on exit by design
+		// (cross-session persistence is M11 territory).
+		tools.SetTaskStore(tasks.New())
+		defer tools.SetTaskStore(nil)
 	}
 
 	// Boundary memory (REPL only): extract durable facts from the previous

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -174,6 +174,9 @@ func runREPL(cfg replConfig) int {
 			case "/memory":
 				printMemory(cfg.stdout, cfg.memStore)
 				continue
+			case "/tasks":
+				printTasks(cfg.stdout)
+				continue
 			default:
 				fmt.Fprintf(cfg.stdout, "Unknown command %q. Type /help for a list.\n", cmd)
 				continue
@@ -259,6 +262,7 @@ func printReplHelp(w io.Writer) {
 	fmt.Fprintln(w, "  /sessions   List the 10 most recent sessions")
 	fmt.Fprintln(w, "  /skills     List available skills (trigger one with /<name>)")
 	fmt.Fprintln(w, "  /memory     List what's remembered across sessions")
+	fmt.Fprintln(w, "  /tasks      Show the current session's task list")
 	fmt.Fprintln(w, "  /exit       Save and exit  (also: /quit, Ctrl-C, Ctrl-D)")
 }
 
@@ -309,6 +313,19 @@ func pluralEntries(n int) string {
 		return "y"
 	}
 	return "ies"
+}
+
+// printTasks shows the session-scoped task list, reusing the same formatter
+// the task_list tool returns to the model. Distinct from the LLM-facing
+// rendering only in that this runs at the user's command and goes to stdout
+// directly, never through a tool_result.
+func printTasks(w io.Writer) {
+	store := tools.ActiveTaskStore()
+	if store == nil {
+		fmt.Fprintln(w, "Tasks are disabled for this session.")
+		return
+	}
+	fmt.Fprintln(w, tools.FormatTaskList(store.List()))
 }
 
 // reservedReplCommands are the built-in slash commands; a skill may not shadow

--- a/cmd/octo/tasks_repl_test.go
+++ b/cmd/octo/tasks_repl_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/tasks"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+func TestPrintTasks_Disabled(t *testing.T) {
+	tools.SetTaskStore(nil)
+	t.Cleanup(func() { tools.SetTaskStore(nil) })
+
+	var buf bytes.Buffer
+	printTasks(&buf)
+	if !strings.Contains(buf.String(), "disabled") {
+		t.Errorf("expected 'disabled' notice when no store, got:\n%s", buf.String())
+	}
+}
+
+func TestPrintTasks_Empty(t *testing.T) {
+	tools.SetTaskStore(tasks.New())
+	t.Cleanup(func() { tools.SetTaskStore(nil) })
+
+	var buf bytes.Buffer
+	printTasks(&buf)
+	if !strings.Contains(buf.String(), "No tasks yet") {
+		t.Errorf("expected empty-list message, got:\n%s", buf.String())
+	}
+}
+
+func TestPrintTasks_RendersList(t *testing.T) {
+	store := tasks.New()
+	id, _ := store.Create("Refactor cache", "", "")
+	inProg := tasks.InProgress
+	_, _ = store.Update(id, tasks.UpdateField{Status: &inProg})
+	store.Create("Add tests", "", "")
+
+	tools.SetTaskStore(store)
+	t.Cleanup(func() { tools.SetTaskStore(nil) })
+
+	var buf bytes.Buffer
+	printTasks(&buf)
+	out := buf.String()
+	for _, want := range []string{"Refactor cache", "Add tests", "▶", "○"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestREPL_TasksCommand(t *testing.T) {
+	cfg, stdout, _, stub := makeREPLFixture(t, "/tasks\n/exit\n")
+	store := tasks.New()
+	store.Create("Test task", "", "")
+	tools.SetTaskStore(store)
+	t.Cleanup(func() { tools.SetTaskStore(nil) })
+
+	runREPL(cfg)
+	if stub.called != 0 {
+		t.Errorf("/tasks should not call the sender, got %d", stub.called)
+	}
+	if !strings.Contains(stdout.String(), "Test task") {
+		t.Errorf("/tasks output missing the task:\n%s", stdout.String())
+	}
+}

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -1,0 +1,235 @@
+// Package tasks implements a session-scoped task tracker. The agent's
+// task_manager tool group (task_create / task_update / task_list) backs onto
+// this Store so the model can break work down into discrete steps and surface
+// progress to the user.
+//
+// Phase 1 is intentionally in-memory only — tasks vanish when the REPL exits.
+// Cross-session persistence is M11 territory (`octo task` CLI + JSON files
+// under ~/.octo/tasks/) and is deliberately out of scope here.
+package tasks
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Status is the lifecycle marker of a task. The model drives transitions:
+// new tasks land as Pending; the model marks them InProgress when it starts
+// and Completed when finished. Deleted is the soft-delete sentinel — calls
+// to List skip it, but the task isn't actually removed (so a stale ID won't
+// silently re-bind to a different task later).
+type Status string
+
+const (
+	Pending    Status = "pending"
+	InProgress Status = "in_progress"
+	Completed  Status = "completed"
+	Deleted    Status = "deleted"
+)
+
+// validStatus reports whether s is a known status value. Unknown strings from
+// the LLM are rejected so the store doesn't accumulate junk values that
+// won't survive a future schema check.
+func validStatus(s Status) bool {
+	switch s {
+	case Pending, InProgress, Completed, Deleted:
+		return true
+	}
+	return false
+}
+
+// Task is one tracked work item. ID is assigned by the store on Create and
+// never reused — even after Delete, the slot stays so a stale ID surfaces as
+// "deleted" rather than silently re-binding.
+type Task struct {
+	ID          int       // 1-based, monotonic per store
+	Subject     string    // short imperative title ("Migrate auth middleware")
+	Description string    // longer detail / acceptance criteria (optional)
+	Status      Status    // see consts above
+	ActiveForm  string    // present continuous form ("Migrating auth middleware") for spinner UI
+	Created     time.Time // first Create
+	Updated     time.Time // last Update or Create
+}
+
+// Store is the session-scoped task list. Methods are safe for concurrent use
+// — the tools and the REPL's /tasks command may dispatch through it at the
+// same time (parallel sub-agent calls share the parent's store; the REPL
+// loop runs synchronously w.r.t. tool dispatch, but defensively guarding is
+// cheap and prevents future surprises).
+type Store struct {
+	mu    sync.Mutex
+	next  int
+	tasks []Task // dense slice; index irrelevant for users (lookups by ID)
+}
+
+// New returns an empty Store with the next-ID counter at 1.
+func New() *Store {
+	return &Store{next: 1}
+}
+
+// Create adds a new task. Subject is required; description and activeForm
+// are optional. Returns the assigned ID.
+func (s *Store) Create(subject, description, activeForm string) (int, error) {
+	subject = strings.TrimSpace(subject)
+	if subject == "" {
+		return 0, fmt.Errorf("task: subject is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now().UTC()
+	t := Task{
+		ID:          s.next,
+		Subject:     subject,
+		Description: strings.TrimSpace(description),
+		Status:      Pending,
+		ActiveForm:  strings.TrimSpace(activeForm),
+		Created:     now,
+		Updated:     now,
+	}
+	s.next++
+	s.tasks = append(s.tasks, t)
+	return t.ID, nil
+}
+
+// Update mutates an existing task. Only fields whose UpdateField pointer is
+// non-nil are touched, so callers can change just the status without
+// supplying the subject etc. Status must be a known value when provided.
+type UpdateField struct {
+	Status      *Status
+	Subject     *string
+	Description *string
+	ActiveForm  *string
+}
+
+// Update applies u to the task with the given ID. Returns the updated task
+// (copy, not pointer — Store owns the canonical record) or an error if the
+// task doesn't exist or u carries an invalid status.
+func (s *Store) Update(id int, u UpdateField) (Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := s.indexLocked(id)
+	if idx < 0 {
+		return Task{}, fmt.Errorf("task: no task with id %d", id)
+	}
+	if u.Status != nil && !validStatus(*u.Status) {
+		return Task{}, fmt.Errorf("task: invalid status %q (want pending|in_progress|completed|deleted)", *u.Status)
+	}
+	t := &s.tasks[idx]
+	if u.Status != nil {
+		t.Status = *u.Status
+	}
+	if u.Subject != nil {
+		subj := strings.TrimSpace(*u.Subject)
+		if subj == "" {
+			return Task{}, fmt.Errorf("task: subject cannot be cleared to empty")
+		}
+		t.Subject = subj
+	}
+	if u.Description != nil {
+		t.Description = strings.TrimSpace(*u.Description)
+	}
+	if u.ActiveForm != nil {
+		t.ActiveForm = strings.TrimSpace(*u.ActiveForm)
+	}
+	t.Updated = time.Now().UTC()
+	return *t, nil
+}
+
+// Get returns the task with the given ID (including deleted ones, so a
+// stale ID can be diagnosed). The second return is false if the ID was
+// never assigned.
+func (s *Store) Get(id int) (Task, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := s.indexLocked(id)
+	if idx < 0 {
+		return Task{}, false
+	}
+	return s.tasks[idx], true
+}
+
+// List returns every non-deleted task in display order: in-progress first
+// (most pressing), then pending (next up), then completed (done, kept
+// visible for context). Within each bucket, ordered by ID ascending.
+func (s *Store) List() []Task {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Task, 0, len(s.tasks))
+	for _, t := range s.tasks {
+		if t.Status == Deleted {
+			continue
+		}
+		out = append(out, t)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		oi, oj := statusOrder(out[i].Status), statusOrder(out[j].Status)
+		if oi != oj {
+			return oi < oj
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// indexLocked finds the slice index of the task with the given ID. -1 means
+// not found. Caller MUST hold s.mu.
+func (s *Store) indexLocked(id int) int {
+	for i, t := range s.tasks {
+		if t.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// statusOrder ranks statuses for the display sort. Smaller = shown earlier.
+func statusOrder(s Status) int {
+	switch s {
+	case InProgress:
+		return 0
+	case Pending:
+		return 1
+	case Completed:
+		return 2
+	}
+	return 3
+}
+
+// Summary returns a one-line count of tasks by status — used for the REPL
+// status line printed after each task tool call:
+//
+//	"3 in progress, 2 pending, 5 done"
+//
+// Buckets with zero are omitted. Returns "" when there are no tasks.
+func (s *Store) Summary() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var inProg, pending, done int
+	for _, t := range s.tasks {
+		switch t.Status {
+		case InProgress:
+			inProg++
+		case Pending:
+			pending++
+		case Completed:
+			done++
+		}
+	}
+	if inProg+pending+done == 0 {
+		return ""
+	}
+	var parts []string
+	if inProg > 0 {
+		parts = append(parts, fmt.Sprintf("%d in progress", inProg))
+	}
+	if pending > 0 {
+		parts = append(parts, fmt.Sprintf("%d pending", pending))
+	}
+	if done > 0 {
+		parts = append(parts, fmt.Sprintf("%d done", done))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -1,0 +1,182 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStore_CreateAndGet(t *testing.T) {
+	s := New()
+	id, err := s.Create("Migrate auth middleware", "Replace legacy session check with new module", "Migrating auth middleware")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != 1 {
+		t.Errorf("first ID = %d, want 1", id)
+	}
+	got, ok := s.Get(id)
+	if !ok {
+		t.Fatal("created task not gettable")
+	}
+	if got.Subject != "Migrate auth middleware" {
+		t.Errorf("Subject = %q", got.Subject)
+	}
+	if got.Status != Pending {
+		t.Errorf("new task should be Pending, got %q", got.Status)
+	}
+	if got.Created.IsZero() || got.Updated.IsZero() {
+		t.Error("Created / Updated timestamps should be set")
+	}
+}
+
+func TestStore_CreateRequiresSubject(t *testing.T) {
+	s := New()
+	if _, err := s.Create("", "", ""); err == nil {
+		t.Error("empty subject should error")
+	}
+	if _, err := s.Create("   ", "", ""); err == nil {
+		t.Error("whitespace-only subject should error")
+	}
+}
+
+func TestStore_MonotonicIDs(t *testing.T) {
+	s := New()
+	for i := 1; i <= 5; i++ {
+		id, _ := s.Create("t", "", "")
+		if id != i {
+			t.Errorf("Create #%d returned ID %d", i, id)
+		}
+	}
+}
+
+func TestStore_UpdateStatus(t *testing.T) {
+	s := New()
+	id, _ := s.Create("task", "", "")
+	inProg := InProgress
+	got, err := s.Update(id, UpdateField{Status: &inProg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != InProgress {
+		t.Errorf("Update Status = %q, want %q", got.Status, InProgress)
+	}
+}
+
+func TestStore_UpdateRejectsInvalidStatus(t *testing.T) {
+	s := New()
+	id, _ := s.Create("task", "", "")
+	bogus := Status("bogus")
+	if _, err := s.Update(id, UpdateField{Status: &bogus}); err == nil {
+		t.Error("invalid status should error")
+	}
+}
+
+func TestStore_UpdateUnknownID(t *testing.T) {
+	s := New()
+	inProg := InProgress
+	if _, err := s.Update(999, UpdateField{Status: &inProg}); err == nil {
+		t.Error("unknown ID should error")
+	}
+}
+
+func TestStore_UpdatePartialFieldsLeavesOthersAlone(t *testing.T) {
+	s := New()
+	id, _ := s.Create("orig subject", "orig desc", "orig active")
+
+	newSubject := "new subject"
+	got, _ := s.Update(id, UpdateField{Subject: &newSubject})
+	if got.Subject != "new subject" {
+		t.Errorf("Subject not updated: %q", got.Subject)
+	}
+	if got.Description != "orig desc" || got.ActiveForm != "orig active" {
+		t.Errorf("untouched fields wiped: %+v", got)
+	}
+	if got.Status != Pending {
+		t.Errorf("status should be unchanged: %q", got.Status)
+	}
+}
+
+func TestStore_UpdateSubjectCannotBeEmpty(t *testing.T) {
+	s := New()
+	id, _ := s.Create("orig", "", "")
+	empty := ""
+	if _, err := s.Update(id, UpdateField{Subject: &empty}); err == nil {
+		t.Error("clearing subject should error")
+	}
+}
+
+func TestStore_ListSortsByStatusThenID(t *testing.T) {
+	s := New()
+	id1, _ := s.Create("a", "", "") // pending
+	id2, _ := s.Create("b", "", "") // pending → completed
+	id3, _ := s.Create("c", "", "") // pending → in_progress
+	id4, _ := s.Create("d", "", "") // deleted (hidden)
+
+	completed := Completed
+	inProg := InProgress
+	deleted := Deleted
+	_, _ = s.Update(id2, UpdateField{Status: &completed})
+	_, _ = s.Update(id3, UpdateField{Status: &inProg})
+	_, _ = s.Update(id4, UpdateField{Status: &deleted})
+
+	got := s.List()
+	if len(got) != 3 {
+		t.Fatalf("List should hide deleted; got %d entries", len(got))
+	}
+	// Expected order: in_progress (id3) → pending (id1) → completed (id2)
+	if got[0].ID != id3 || got[1].ID != id1 || got[2].ID != id2 {
+		t.Errorf("List order = %d,%d,%d, want %d,%d,%d",
+			got[0].ID, got[1].ID, got[2].ID, id3, id1, id2)
+	}
+}
+
+func TestStore_GetDeletedSurfacesIt(t *testing.T) {
+	// Deleted tasks are kept (slot not reused) so a stale ID surfaces as
+	// "deleted" rather than silently re-binding.
+	s := New()
+	id, _ := s.Create("t", "", "")
+	del := Deleted
+	_, _ = s.Update(id, UpdateField{Status: &del})
+
+	got, ok := s.Get(id)
+	if !ok {
+		t.Fatal("deleted task should still be Get-able")
+	}
+	if got.Status != Deleted {
+		t.Errorf("status = %q, want deleted", got.Status)
+	}
+}
+
+func TestStore_Summary(t *testing.T) {
+	s := New()
+	if got := s.Summary(); got != "" {
+		t.Errorf("empty store summary = %q, want empty", got)
+	}
+
+	id1, _ := s.Create("a", "", "")
+	id2, _ := s.Create("b", "", "")
+	_, _ = s.Create("c", "", "")
+	inProg := InProgress
+	done := Completed
+	_, _ = s.Update(id1, UpdateField{Status: &inProg})
+	_, _ = s.Update(id2, UpdateField{Status: &done})
+
+	got := s.Summary()
+	for _, want := range []string{"1 in progress", "1 pending", "1 done"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Summary missing %q: %q", want, got)
+		}
+	}
+}
+
+func TestStore_SummaryOmitsZeroBuckets(t *testing.T) {
+	s := New()
+	_, _ = s.Create("only", "", "")
+	got := s.Summary()
+	if !strings.Contains(got, "1 pending") {
+		t.Errorf("Summary = %q", got)
+	}
+	if strings.Contains(got, "0 ") {
+		t.Errorf("Summary should omit zero buckets: %q", got)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -33,6 +33,9 @@ var allTools = []tool{
 	RememberTool{},
 	LaunchAgentTool{},
 	AskUserQuestionTool{},
+	TaskCreateTool{},
+	TaskUpdateTool{},
+	TaskListTool{},
 }
 
 // DefaultRegistry is the agent.ToolExecutor used when `octo chat --tools` is
@@ -98,6 +101,7 @@ func DefaultTools() []agent.ToolDefinition {
 	memoryOn := memoryEnabled()
 	spawnerOn := spawnerEnabled()
 	askerOn := askerEnabled()
+	tasksOn := tasksEnabled()
 	defs := make([]agent.ToolDefinition, 0, len(allTools))
 	for _, t := range allTools {
 		if _, isSkill := t.(SkillTool); isSkill && !skillsOn {
@@ -110,6 +114,15 @@ func DefaultTools() []agent.ToolDefinition {
 			continue
 		}
 		if _, isAsk := t.(AskUserQuestionTool); isAsk && !askerOn {
+			continue
+		}
+		if _, isTaskCreate := t.(TaskCreateTool); isTaskCreate && !tasksOn {
+			continue
+		}
+		if _, isTaskUpdate := t.(TaskUpdateTool); isTaskUpdate && !tasksOn {
+			continue
+		}
+		if _, isTaskList := t.(TaskListTool); isTaskList && !tasksOn {
 			continue
 		}
 		defs = append(defs, t.Definition())

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -1,0 +1,266 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tasks"
+)
+
+// TaskStore is the surface the task_* tools use to talk to the underlying
+// store. internal/tasks.Store satisfies this directly; tests can substitute
+// fakes without dragging in the tasks package.
+type TaskStore interface {
+	Create(subject, description, activeForm string) (int, error)
+	Update(id int, u tasks.UpdateField) (tasks.Task, error)
+	List() []tasks.Task
+	Get(id int) (tasks.Task, bool)
+	Summary() string
+}
+
+// activeTasks, when non-nil, backs the task_* tools and gates their
+// advertisement in DefaultTools. Set by cmd/octo at REPL start with a fresh
+// per-session Store. Nil → task_create / task_update / task_list don't
+// appear in the catalog (single-turn mode and unattended runs).
+var activeTasks TaskStore
+
+// SetTaskStore registers the store the task_* tools delegate to. Pass nil to
+// disable; the three tools then drop out of DefaultTools.
+func SetTaskStore(s TaskStore) { activeTasks = s }
+
+// ActiveTaskStore returns the currently registered store, or nil. Used by
+// cmd/octo's /tasks REPL command (and the post-tool summary line) without
+// going through a LLM-driven tool call.
+func ActiveTaskStore() TaskStore { return activeTasks }
+
+func tasksEnabled() bool { return activeTasks != nil }
+
+// ============================================================================
+// task_create
+// ============================================================================
+
+// TaskCreateTool adds a new pending task to the session's task list.
+//
+// Tool name: task_create.
+type TaskCreateTool struct{}
+
+func (TaskCreateTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "task_create",
+		Description: "Add a new task to the session's task list. Use when you're breaking " +
+			"down work into discrete, trackable steps the user can see. Each task lands as " +
+			"`pending`; mark it `in_progress` via task_update when you start, `completed` when " +
+			"done. Use sparingly — single trivial commands don't need a task. Returns the " +
+			"assigned numeric ID.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"subject": map[string]any{
+					"type":        "string",
+					"description": "Short imperative title (3-10 words). Example: 'Migrate auth middleware'.",
+				},
+				"description": map[string]any{
+					"type":        "string",
+					"description": "Optional longer detail / acceptance criteria. Use when the subject alone isn't enough to know when the task is done.",
+				},
+				"active_form": map[string]any{
+					"type":        "string",
+					"description": "Optional present-continuous form for the spinner UI (e.g. 'Migrating auth middleware'). Defaults to the subject if omitted.",
+				},
+			},
+			"required": []string{"subject"},
+		},
+	}
+}
+
+func (TaskCreateTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+	if !tasksEnabled() {
+		return "", fmt.Errorf("task_create: task tracking is not configured for this session")
+	}
+	subject := strings.TrimSpace(stringArg(input, "subject"))
+	if subject == "" {
+		return "", fmt.Errorf("task_create: subject is required")
+	}
+	id, err := activeTasks.Create(
+		subject,
+		stringArg(input, "description"),
+		stringArg(input, "active_form"),
+	)
+	if err != nil {
+		return "", fmt.Errorf("task_create: %w", err)
+	}
+	return fmt.Sprintf("Created task #%d: %s", id, subject), nil
+}
+
+// ============================================================================
+// task_update
+// ============================================================================
+
+// TaskUpdateTool mutates an existing task. Most commonly the model uses it to
+// move tasks through the pending → in_progress → completed lifecycle.
+//
+// Tool name: task_update.
+type TaskUpdateTool struct{}
+
+func (TaskUpdateTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "task_update",
+		Description: "Update an existing task. Most common use: shift status as work progresses " +
+			"(`pending` → `in_progress` when you start a step, `in_progress` → `completed` when " +
+			"you finish). Can also rewrite subject / description / active_form if the scope of " +
+			"the task changes. Set status to `deleted` to drop a task that was misclassified or " +
+			"no longer applies. Only the fields you provide are touched.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"task_id": map[string]any{
+					"type":        "integer",
+					"description": "The numeric ID returned by task_create.",
+				},
+				"status": map[string]any{
+					"type":        "string",
+					"enum":        []string{"pending", "in_progress", "completed", "deleted"},
+					"description": "New status. `deleted` removes the task from /tasks views but the ID stays reserved (so stale references surface clearly).",
+				},
+				"subject": map[string]any{
+					"type":        "string",
+					"description": "Optional rewrite of the imperative title.",
+				},
+				"description": map[string]any{
+					"type":        "string",
+					"description": "Optional rewrite of the longer detail.",
+				},
+				"active_form": map[string]any{
+					"type":        "string",
+					"description": "Optional rewrite of the present-continuous form.",
+				},
+			},
+			"required": []string{"task_id"},
+		},
+	}
+}
+
+func (TaskUpdateTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+	if !tasksEnabled() {
+		return "", fmt.Errorf("task_update: task tracking is not configured for this session")
+	}
+	id := intArg(input, "task_id", 0)
+	if id <= 0 {
+		return "", fmt.Errorf("task_update: task_id is required (positive integer)")
+	}
+
+	var u tasks.UpdateField
+	if s := strings.TrimSpace(stringArg(input, "status")); s != "" {
+		st := tasks.Status(s)
+		u.Status = &st
+	}
+	if raw, present := input["subject"]; present {
+		if s, ok := raw.(string); ok {
+			u.Subject = &s
+		}
+	}
+	if raw, present := input["description"]; present {
+		if s, ok := raw.(string); ok {
+			u.Description = &s
+		}
+	}
+	if raw, present := input["active_form"]; present {
+		if s, ok := raw.(string); ok {
+			u.ActiveForm = &s
+		}
+	}
+
+	if u.Status == nil && u.Subject == nil && u.Description == nil && u.ActiveForm == nil {
+		return "", fmt.Errorf("task_update: nothing to update (provide status, subject, description, or active_form)")
+	}
+
+	got, err := activeTasks.Update(id, u)
+	if err != nil {
+		return "", fmt.Errorf("task_update: %w", err)
+	}
+	return fmt.Sprintf("Updated task #%d (%s): %s", got.ID, got.Status, got.Subject), nil
+}
+
+// ============================================================================
+// task_list
+// ============================================================================
+
+// TaskListTool returns the current task list, grouped by status.
+//
+// Tool name: task_list.
+type TaskListTool struct{}
+
+func (TaskListTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "task_list",
+		Description: "Show the current session's task list, grouped by status (in-progress, " +
+			"pending, completed; deleted tasks hidden). Use this to check progress or remind " +
+			"yourself which tasks are still open before starting new work.",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+	}
+}
+
+func (TaskListTool) Execute(_ context.Context, _ string, _ map[string]any) (string, error) {
+	if !tasksEnabled() {
+		return "", fmt.Errorf("task_list: task tracking is not configured for this session")
+	}
+	return FormatTaskList(activeTasks.List()), nil
+}
+
+// FormatTaskList renders a slice of tasks for display. Used both by the
+// task_list tool's Execute and by the REPL's /tasks slash command.
+//
+// Layout: a one-line header followed by one row per task, status-prefixed
+// so the user can scan at a glance:
+//
+//	Tasks: 1 in progress, 2 pending
+//	  ▶ #3  Migrating auth middleware
+//	  ○ #1  Add migration test
+//	  ○ #4  Update README
+func FormatTaskList(items []tasks.Task) string {
+	if len(items) == 0 {
+		return "No tasks yet."
+	}
+	var b strings.Builder
+	b.WriteString("Tasks:\n")
+	for _, t := range items {
+		marker := statusMarker(t.Status)
+		title := t.Subject
+		if t.Status == tasks.InProgress && t.ActiveForm != "" {
+			title = t.ActiveForm // surface the spinner-friendly form when in flight
+		}
+		fmt.Fprintf(&b, "  %s #%-3d %s\n", marker, t.ID, title)
+		if t.Description != "" {
+			for _, line := range strings.Split(t.Description, "\n") {
+				fmt.Fprintf(&b, "       %s\n", line)
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// statusMarker returns the one-rune glyph used in FormatTaskList. Chosen to
+// be visually distinct in a monospace terminal:
+//
+//	▶ in progress (filled triangle = "now")
+//	○ pending     (empty circle    = "open")
+//	✓ completed   (check           = "done")
+//	· anything else (deleted shouldn't appear, but be defensive)
+func statusMarker(s tasks.Status) string {
+	switch s {
+	case tasks.InProgress:
+		return "▶"
+	case tasks.Pending:
+		return "○"
+	case tasks.Completed:
+		return "✓"
+	}
+	return "·"
+}
+
+// (intArg is shared with read_file.go — package-wide helper.)

--- a/internal/tools/tasks_test.go
+++ b/internal/tools/tasks_test.go
@@ -1,0 +1,292 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/tasks"
+)
+
+func useTaskStore(t *testing.T) *tasks.Store {
+	t.Helper()
+	s := tasks.New()
+	SetTaskStore(s)
+	t.Cleanup(func() { SetTaskStore(nil) })
+	return s
+}
+
+// ── task_create ──────────────────────────────────────────────────────────
+
+func TestTaskCreateTool_Schema(t *testing.T) {
+	def := TaskCreateTool{}.Definition()
+	if def.Name != "task_create" {
+		t.Errorf("Name = %q", def.Name)
+	}
+	props, _ := def.Parameters["properties"].(map[string]any)
+	for _, want := range []string{"subject", "description", "active_form"} {
+		if _, ok := props[want]; !ok {
+			t.Errorf("schema missing property %q", want)
+		}
+	}
+	required, _ := def.Parameters["required"].([]string)
+	if !sliceContains(required, "subject") {
+		t.Errorf("subject should be required, got %v", required)
+	}
+}
+
+func TestTaskCreateTool_Execute(t *testing.T) {
+	store := useTaskStore(t)
+	out, err := TaskCreateTool{}.Execute(context.Background(), "task_create", map[string]any{
+		"subject":     "Migrate auth middleware",
+		"description": "Replace legacy session check",
+		"active_form": "Migrating auth middleware",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "Created task #1") || !strings.Contains(out, "Migrate auth middleware") {
+		t.Errorf("Execute = %q", out)
+	}
+	got := store.List()
+	if len(got) != 1 || got[0].Subject != "Migrate auth middleware" {
+		t.Errorf("store state after Create = %+v", got)
+	}
+}
+
+func TestTaskCreateTool_Execute_RequiresSubject(t *testing.T) {
+	useTaskStore(t)
+	if _, err := (TaskCreateTool{}).Execute(context.Background(), "task_create", map[string]any{
+		"description": "Something",
+	}); err == nil || !strings.Contains(err.Error(), "subject is required") {
+		t.Errorf("missing subject should error, got %v", err)
+	}
+}
+
+func TestTaskCreateTool_Execute_NoStore(t *testing.T) {
+	SetTaskStore(nil)
+	if _, err := (TaskCreateTool{}).Execute(context.Background(), "task_create", map[string]any{
+		"subject": "x",
+	}); err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("no store should error 'not configured', got %v", err)
+	}
+}
+
+// ── task_update ──────────────────────────────────────────────────────────
+
+func TestTaskUpdateTool_Schema(t *testing.T) {
+	def := TaskUpdateTool{}.Definition()
+	if def.Name != "task_update" {
+		t.Errorf("Name = %q", def.Name)
+	}
+	required, _ := def.Parameters["required"].([]string)
+	if !sliceContains(required, "task_id") {
+		t.Errorf("task_id should be required, got %v", required)
+	}
+}
+
+func TestTaskUpdateTool_Execute_StatusChange(t *testing.T) {
+	store := useTaskStore(t)
+	id, _ := store.Create("task", "", "")
+
+	out, err := TaskUpdateTool{}.Execute(context.Background(), "task_update", map[string]any{
+		"task_id": float64(id), // JSON shape
+		"status":  "in_progress",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "in_progress") {
+		t.Errorf("Execute = %q", out)
+	}
+	got, _ := store.Get(id)
+	if got.Status != tasks.InProgress {
+		t.Errorf("status not updated: %q", got.Status)
+	}
+}
+
+func TestTaskUpdateTool_Execute_PartialUpdate(t *testing.T) {
+	store := useTaskStore(t)
+	id, _ := store.Create("orig", "orig desc", "")
+
+	_, err := TaskUpdateTool{}.Execute(context.Background(), "task_update", map[string]any{
+		"task_id": float64(id),
+		"subject": "new subject",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := store.Get(id)
+	if got.Subject != "new subject" {
+		t.Errorf("Subject = %q", got.Subject)
+	}
+	if got.Description != "orig desc" {
+		t.Errorf("Description should be untouched: %q", got.Description)
+	}
+}
+
+func TestTaskUpdateTool_Execute_RejectsNoFields(t *testing.T) {
+	store := useTaskStore(t)
+	id, _ := store.Create("task", "", "")
+	if _, err := (TaskUpdateTool{}).Execute(context.Background(), "task_update", map[string]any{
+		"task_id": float64(id),
+	}); err == nil || !strings.Contains(err.Error(), "nothing to update") {
+		t.Errorf("expected 'nothing to update' error, got %v", err)
+	}
+}
+
+func TestTaskUpdateTool_Execute_InvalidStatus(t *testing.T) {
+	store := useTaskStore(t)
+	id, _ := store.Create("task", "", "")
+	_, err := TaskUpdateTool{}.Execute(context.Background(), "task_update", map[string]any{
+		"task_id": float64(id),
+		"status":  "bogus",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid status") {
+		t.Errorf("invalid status should error, got %v", err)
+	}
+}
+
+func TestTaskUpdateTool_Execute_UnknownTaskID(t *testing.T) {
+	useTaskStore(t)
+	_, err := TaskUpdateTool{}.Execute(context.Background(), "task_update", map[string]any{
+		"task_id": float64(999),
+		"status":  "completed",
+	})
+	if err == nil || !strings.Contains(err.Error(), "no task with id") {
+		t.Errorf("unknown ID should error, got %v", err)
+	}
+}
+
+func TestTaskUpdateTool_Execute_RequiresPositiveID(t *testing.T) {
+	useTaskStore(t)
+	for _, in := range []map[string]any{
+		{},                       // missing
+		{"task_id": float64(0)},  // zero
+		{"task_id": float64(-3)}, // negative
+	} {
+		in["status"] = "completed"
+		if _, err := (TaskUpdateTool{}).Execute(context.Background(), "task_update", in); err == nil {
+			t.Errorf("input %+v should error", in)
+		}
+	}
+}
+
+// ── task_list ────────────────────────────────────────────────────────────
+
+func TestTaskListTool_Execute_Empty(t *testing.T) {
+	useTaskStore(t)
+	out, err := TaskListTool{}.Execute(context.Background(), "task_list", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "No tasks yet." {
+		t.Errorf("empty list = %q", out)
+	}
+}
+
+func TestTaskListTool_Execute_GroupsByStatus(t *testing.T) {
+	store := useTaskStore(t)
+	id1, _ := store.Create("first", "", "")
+	id2, _ := store.Create("second", "", "")
+	store.Create("third", "", "")
+
+	inProg := tasks.InProgress
+	done := tasks.Completed
+	_, _ = store.Update(id1, tasks.UpdateField{Status: &inProg})
+	_, _ = store.Update(id2, tasks.UpdateField{Status: &done})
+
+	out, err := TaskListTool{}.Execute(context.Background(), "task_list", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"▶", "○", "✓", "first", "second", "third"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	// In-progress (id1) should appear before pending (id3) which should
+	// appear before completed (id2) in the rendered text.
+	inProgPos := strings.Index(out, "first")
+	pendPos := strings.Index(out, "third")
+	donePos := strings.Index(out, "second")
+	if !(inProgPos < pendPos && pendPos < donePos) {
+		t.Errorf("status order wrong (in_prog<pending<done): %d<%d<%d", inProgPos, pendPos, donePos)
+	}
+}
+
+func TestTaskListTool_Execute_UsesActiveFormForInProgress(t *testing.T) {
+	store := useTaskStore(t)
+	id, _ := store.Create("Migrate auth middleware", "", "Migrating auth middleware")
+	inProg := tasks.InProgress
+	_, _ = store.Update(id, tasks.UpdateField{Status: &inProg})
+
+	out, _ := TaskListTool{}.Execute(context.Background(), "task_list", nil)
+	if !strings.Contains(out, "Migrating auth middleware") {
+		t.Errorf("in-progress should use ActiveForm, got:\n%s", out)
+	}
+}
+
+// ── gating ───────────────────────────────────────────────────────────────
+
+func TestDefaultTools_TaskToolsGatedOnStore(t *testing.T) {
+	SetTaskStore(nil)
+	t.Cleanup(func() { SetTaskStore(nil) })
+
+	taskNames := func() []string {
+		var got []string
+		for _, d := range DefaultTools() {
+			if strings.HasPrefix(d.Name, "task_") {
+				got = append(got, d.Name)
+			}
+		}
+		return got
+	}
+
+	if got := taskNames(); len(got) != 0 {
+		t.Errorf("task_* tools should be absent without a store, got %v", got)
+	}
+	useTaskStore(t)
+	got := taskNames()
+	for _, want := range []string{"task_create", "task_update", "task_list"} {
+		if !sliceContains(got, want) {
+			t.Errorf("expected %q in DefaultTools, got %v", want, got)
+		}
+	}
+}
+
+func TestActiveTaskStore_Roundtrip(t *testing.T) {
+	if ActiveTaskStore() != nil {
+		// Defensive: tests in this package set/clear the store; another test
+		// might have left it set. Reset.
+		SetTaskStore(nil)
+	}
+	if ActiveTaskStore() != nil {
+		t.Fatal("ActiveTaskStore should be nil when none is set")
+	}
+	s := tasks.New()
+	SetTaskStore(s)
+	defer SetTaskStore(nil)
+	if got := ActiveTaskStore(); got == nil {
+		t.Error("ActiveTaskStore should return the registered store")
+	}
+}
+
+// ── formatter ────────────────────────────────────────────────────────────
+
+func TestFormatTaskList_DescriptionIndented(t *testing.T) {
+	id := 7
+	out := FormatTaskList([]tasks.Task{{
+		ID:          id,
+		Subject:     "Refactor X",
+		Description: "First line\nSecond line",
+		Status:      tasks.Pending,
+	}})
+	if !strings.Contains(out, "Refactor X") || !strings.Contains(out, "#7") {
+		t.Errorf("subject line missing:\n%s", out)
+	}
+	// Description lines should be indented further than the row.
+	if !strings.Contains(out, "       First line") || !strings.Contains(out, "       Second line") {
+		t.Errorf("description not indented:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a three-tool group letting the model break work into discrete trackable steps and surface progress to the user — analogous to Claude Code's `TaskCreate` / `TaskUpdate` / `TaskList`. Session-scoped (in-memory) per the design vote; cross-session persistence is M11 territory.

### Tool surface

```
task_create(subject, description?, active_form?)        → "Created task #N: <subject>"
task_update(task_id, status?, subject?, description?,
            active_form?)                               → "Updated task #N (<status>): <subject>"
task_list()                                             → multi-line list, grouped by status
```

`task_update` honors only-provided-fields semantics — change status alone without resupplying everything. Status enum: `pending | in_progress | completed | deleted`.

### REPL UX

```
Tasks:
  ▶ #3   Migrating auth middleware
  ○ #1   Add migration test
  ○ #4   Update README
  ✓ #2   Spec out the new schema
```

In-progress rows show `active_form` (e.g. "Migrating…") instead of the subject so the row reads like a spinner label. Deleted tasks are hidden; their IDs stay reserved so a stale reference surfaces as "deleted" rather than silently re-binding.

New `/tasks` slash command renders the same list via the same `FormatTaskList` helper the LLM-facing `task_list` returns — no drift between user-facing and model-facing rendering.

### Wiring

- `internal/tasks` — pure-data Store (mutex-guarded, monotonic IDs).
- `internal/tools/tasks.go` — `TaskStore` interface + 3 tools + `SetTaskStore` gating (same pattern as `SetAsker` / `SetSpawner`).
- `cmd/octo/chat.go` — `SetTaskStore(tasks.New())` at REPL start, deferred cleanup so a follow-up non-REPL run can't see a stale store.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [x] `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
- [x] `internal/tasks` (~180 lines): Create round-trip, monotonic IDs, status updates, invalid-status rejection, partial updates, empty-subject rejection, deleted-but-Get-able, List sort order, Summary buckets.
- [x] `internal/tools` (~290 lines): schemas, Execute happy paths, partial updates, gating, invalid status / unknown ID / positive-ID validation, task_list grouping, active_form for in-progress rows, formatter indentation.
- [x] `cmd/octo` (~70 lines): printTasks disabled / empty / populated, `/tasks` slash command in the REPL fixture.
- [ ] Live verification: model breaks down a multi-step request into 3-4 tasks → `/tasks` shows them grouped → marks in-progress → completes → /tasks renders accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)