### PR TITLE
feat(m11): PR3 — scheduler dispatches subtasks via M10 sub-agents

### DIFF
--- a/cmd/octo/task.go
+++ b/cmd/octo/task.go
@@ -5,10 +5,13 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/prompt"
 	"github.com/Leihb/octo-agent/internal/taskgraph"
+	"github.com/Leihb/octo-agent/internal/tools"
 )
 
 // runTask handles `octo task <subcommand>`. PR2 (this file) wires only
@@ -25,6 +28,8 @@ func runTask(args []string, _ io.Reader, stdout, stderr io.Writer) int {
 	switch args[0] {
 	case "start":
 		return runTaskStart(args[1:], stdout, stderr)
+	case "run":
+		return runTaskRun(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
 		printTaskUsage(stdout)
 		return 0
@@ -42,8 +47,9 @@ func printTaskUsage(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Subcommands:")
 	fmt.Fprintln(w, "  start \"<goal>\"   Decompose a goal into a subtask DAG and persist it")
+	fmt.Fprintln(w, "  run <id>         Execute the planned DAG: dispatch one sub-agent per subtask")
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Coming in later PRs: run, list, status, show, resume, cancel.")
+	fmt.Fprintln(w, "Coming in later PRs: list, status, show, resume, cancel.")
 }
 
 // runTaskStart handles `octo task start "<goal>" [flags]`. It runs the
@@ -168,3 +174,92 @@ func joinInts(in []int) string {
 // planMaxTokens inside agent.PlanTask, but the agent struct still wants
 // a sensible value.
 const defaultMaxTokensForPlanner = 4096
+
+// runTaskRun handles `octo task run <id> [flags]`. It loads the persisted
+// task, wires an M10-backed Executor, hands them to taskgraph.Scheduler,
+// and exits with 0 on success / 1 on failure / 2 on bad args. Mirrors the
+// loop semantics already covered by scheduler_test.go — this is mostly
+// CLI plumbing.
+func runTaskRun(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("task run", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	providerName := fs.String("provider", providerAnthropic, "Provider: anthropic | openai")
+	model := fs.String("model", "", "Model name (defaults to the provider's cheapest reasoning model)")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: octo task run <id> [--provider …] [--model …]")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() < 1 {
+		fmt.Fprintln(stderr, "octo task run: task id is required (try `octo task list` once that lands)")
+		return 2
+	}
+	id := fs.Arg(0)
+
+	resolvedModel := *model
+	if resolvedModel == "" {
+		resolvedModel = defaultModels[*providerName]
+	}
+	if resolvedModel == "" {
+		fmt.Fprintf(stderr, "octo task run: unknown provider %q (use 'anthropic' or 'openai')\n", *providerName)
+		return 2
+	}
+
+	prov, err := buildProvider(*providerName, stderr)
+	if err != nil {
+		return 1
+	}
+
+	// Parent agent acts as the spawner's anchor — it owns the Sender, the
+	// system prompt every sub-agent inherits, and the token counter the
+	// children roll back into. We're not running an interactive loop here,
+	// but the sub_agent.go spawner closure needs an *agent.Agent to attach
+	// to.
+	parent := agent.New(providerSender{
+		p:        prov,
+		cacheKey: newCacheKey(),
+	}, resolvedModel)
+	parent.MaxTokens = defaultMaxTokensForPlanner
+	cwd, _ := os.Getwd()
+	parent.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "")
+
+	executor := tools.NewDefaultRegistry()
+	tools.SetSpawner(newAgentSpawner(parent, executor, tools.DefaultTools))
+	defer tools.SetSpawner(nil)
+
+	store, err := taskgraph.NewStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo task run: %v\n", err)
+		return 1
+	}
+	sch := taskgraph.NewScheduler(store, &spawnerExecutor{}, stdout)
+	if err := sch.Run(context.Background(), id); err != nil {
+		fmt.Fprintf(stderr, "octo task run: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// spawnerExecutor adapts the package-global tools.ActiveSpawner into the
+// taskgraph.Executor interface. Each subtask becomes one launch_agent
+// invocation: the child sees the subtask description as its prompt, has
+// the parent's full tool catalog (minus launch_agent so it can't recurse),
+// and reports back a single final text reply.
+type spawnerExecutor struct{}
+
+func (spawnerExecutor) Execute(ctx context.Context, description string) (string, error) {
+	sp := tools.ActiveSpawner()
+	if sp == nil {
+		return "", fmt.Errorf("task run: no Spawner configured")
+	}
+	res, err := sp.Spawn(ctx, tools.SpawnRequest{
+		Description: oneLine(description),
+		Prompt:      description,
+	})
+	if err != nil {
+		return "", err
+	}
+	return res.Reply, nil
+}

--- a/cmd/octo/task_test.go
+++ b/cmd/octo/task_test.go
@@ -149,6 +149,45 @@ func TestJoinInts(t *testing.T) {
 	}
 }
 
+func TestRunTaskRun_RequiresTaskID(t *testing.T) {
+	withFakeHome(t)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	var out, errBuf bytes.Buffer
+	code := runTask([]string{"run"}, nil, &out, &errBuf)
+	if code != 2 {
+		t.Errorf("missing id exit = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "task id is required") {
+		t.Errorf("expected 'task id is required' note, got:\n%s", errBuf.String())
+	}
+}
+
+func TestRunTaskRun_UnknownTaskID(t *testing.T) {
+	withFakeHome(t)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	var out, errBuf bytes.Buffer
+	code := runTask([]string{"run", "20990101-000000-deadbeef"}, nil, &out, &errBuf)
+	if code != 1 {
+		t.Errorf("unknown id exit = %d, want 1; stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "octo task run") {
+		t.Errorf("error should be tagged with 'octo task run':\n%s", errBuf.String())
+	}
+}
+
+func TestRunTaskRun_MissingAPIKey(t *testing.T) {
+	withFakeHome(t)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	var out, errBuf bytes.Buffer
+	code := runTask([]string{"run", "any-id"}, nil, &out, &errBuf)
+	if code != 1 {
+		t.Errorf("missing key exit = %d, want 1; stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "ANTHROPIC_API_KEY") {
+		t.Errorf("stderr should name the missing env var: %q", errBuf.String())
+	}
+}
+
 // Smoke test that the planner-to-store conversion preserves IDs and the
 // taskgraph layer accepts what the planner emits. Doesn't hit the LLM —
 // it constructs the equivalent subtasks directly and checks they round-

--- a/internal/taskgraph/scheduler.go
+++ b/internal/taskgraph/scheduler.go
@@ -1,0 +1,273 @@
+package taskgraph
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// Executor runs one subtask's description through whatever execution mechanism
+// the caller has wired up (in production: M10's launch_agent / tools.Spawner;
+// in tests: a stub). Kept as a local interface so internal/taskgraph stays
+// free of an internal/tools dependency — cmd/octo adapts the real Spawner
+// into this shape via a tiny shim.
+type Executor interface {
+	// Execute runs one subtask and returns its final reply text. An error
+	// signals the subtask failed and lights the stop-on-fail path. The
+	// context honors caller-level cancellation; implementations should
+	// propagate ctx.Err() promptly.
+	Execute(ctx context.Context, description string) (result string, err error)
+}
+
+// Scheduler walks a Task's DAG, dispatching ready Subtasks through Executor
+// in parallel goroutines, fsync'ing state transitions through Store. One
+// Scheduler runs one Task at a time — there is no global queue here. The
+// CLI constructs a fresh Scheduler per `octo task run <id>`.
+type Scheduler struct {
+	store *Store
+	exec  Executor
+	// stdout receives one progress line per state transition (subtask
+	// Running, Done, Failed, Skipped, and the final task-level summary).
+	// nil silences progress output — useful in tests that want to assert
+	// only on the persisted state.
+	stdout io.Writer
+}
+
+// NewScheduler wires the pieces together. stdout may be nil (silent).
+func NewScheduler(store *Store, exec Executor, stdout io.Writer) *Scheduler {
+	return &Scheduler{store: store, exec: exec, stdout: stdout}
+}
+
+// Run drives the task forward to a terminal state (done, failed, or
+// cancelled). Returns nil on success (TaskDone) and a descriptive error
+// for every other terminal state, so a CLI caller can map the return into
+// an exit code without re-reading the task from disk.
+//
+// The loop pattern per iteration:
+//
+//  1. Reload the task from disk (so a concurrent edit, however unlikely
+//     in v1, doesn't race the in-flight batch).
+//  2. Find every subtask that's Pending AND has all its BlockedBy Done.
+//  3. Mark every ready subtask as Running in one Update (one fsync).
+//  4. Spawn N goroutines, one per ready subtask, each calling exec.Execute.
+//  5. After wg.Wait, apply ALL results in one Update (one fsync). Each
+//     subtask becomes Done (with its result) or Failed (with its error).
+//  6. If any subtask failed: in a final Update, mark every remaining
+//     Pending subtask as Skipped, advance the task to TaskFailed, exit.
+//  7. If no subtask failed and nothing was ready (i.e. step 2 returned
+//     empty), advance the task to TaskDone (if every subtask is Done)
+//     and exit.
+//
+// Two fsyncs per batch (mark-running + apply-results), so a kill -9
+// strands at most one transition per subtask.
+func (s *Scheduler) Run(ctx context.Context, id string) error {
+	if s.exec == nil {
+		return errors.New("scheduler: Executor is required")
+	}
+	// Promote the task to Running before the first batch. Rejects tasks
+	// that are already finished or were cancelled — the CLI's resume path
+	// will explicitly clear cancellation before calling Run.
+	t, err := s.store.Update(id, func(t *Task) error {
+		switch t.Status {
+		case TaskDone:
+			return errors.New("task already done")
+		case TaskCancelled:
+			return errors.New("task was cancelled; resume to retry")
+		}
+		t.Status = TaskRunning
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	s.logf("Running task %s (%d subtasks)\n", t.ID, len(t.Subtasks))
+
+	for {
+		// Reload to see whatever the previous iteration / external
+		// editors may have changed.
+		t, err = s.store.Get(id)
+		if err != nil {
+			return err
+		}
+		ready := readyIDs(t)
+		if len(ready) == 0 {
+			// Nothing else to do. Final status depends on what's left.
+			return s.finalize(id, t)
+		}
+
+		now := time.Now().UTC()
+		_, err = s.store.Update(id, func(t *Task) error {
+			for _, subID := range ready {
+				if sub := t.Find(subID); sub != nil {
+					sub.Status = SubtaskRunning
+					started := now
+					sub.Started = &started
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("scheduler: mark running: %w", err)
+		}
+		for _, subID := range ready {
+			s.logf("▶ #%d running\n", subID)
+		}
+
+		results := s.dispatchBatch(ctx, t, ready)
+
+		_, err = s.store.Update(id, func(t *Task) error {
+			finished := time.Now().UTC()
+			for subID, r := range results {
+				sub := t.Find(subID)
+				if sub == nil {
+					continue
+				}
+				f := finished
+				sub.Finished = &f
+				if r.err != nil {
+					sub.Status = SubtaskFailed
+					sub.Error = r.err.Error()
+				} else {
+					sub.Status = SubtaskDone
+					sub.Result = r.reply
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("scheduler: apply results: %w", err)
+		}
+		anyFailed := false
+		for subID, r := range results {
+			if r.err != nil {
+				anyFailed = true
+				s.logf("✗ #%d failed: %s\n", subID, r.err.Error())
+			} else {
+				s.logf("✓ #%d done\n", subID)
+			}
+		}
+
+		// If the user cancelled mid-batch, prefer "task cancelled" over
+		// "task failed" even if some subtasks returned ctx errors — those
+		// were ctx.Err(), not application failures.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			_, _ = s.store.Update(id, func(t *Task) error {
+				t.Status = TaskCancelled
+				return nil
+			})
+			return ctxErr
+		}
+
+		if anyFailed {
+			return s.markFailed(id)
+		}
+	}
+}
+
+// finalize closes out the task once no more subtasks are ready. Picks
+// between TaskDone (every subtask reached Done) and TaskFailed (something
+// got stranded — shouldn't happen with stop-on-fail wiring but be defensive).
+func (s *Scheduler) finalize(id string, t *Task) error {
+	allDone := true
+	for _, sub := range t.Subtasks {
+		if sub.Status != SubtaskDone {
+			allDone = false
+			break
+		}
+	}
+	final := TaskDone
+	if !allDone {
+		final = TaskFailed
+	}
+	_, err := s.store.Update(id, func(t *Task) error {
+		t.Status = final
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if final == TaskDone {
+		s.logf("Task done.\n")
+		return nil
+	}
+	s.logf("Task finalized as failed (some subtasks not Done).\n")
+	return fmt.Errorf("task %s finished with non-Done subtasks", id)
+}
+
+// markFailed is the stop-on-fail path: every still-Pending subtask becomes
+// Skipped (so resume can tell "tried-and-failed" from "didn't try"), and
+// the task itself moves to Failed.
+func (s *Scheduler) markFailed(id string) error {
+	_, err := s.store.Update(id, func(t *Task) error {
+		for i := range t.Subtasks {
+			if t.Subtasks[i].Status == SubtaskPending {
+				t.Subtasks[i].Status = SubtaskSkipped
+			}
+		}
+		t.Status = TaskFailed
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	s.logf("Task failed (stop-on-fail; remaining subtasks marked skipped).\n")
+	return fmt.Errorf("task %s failed", id)
+}
+
+// subResult bundles one goroutine's outcome.
+type subResult struct {
+	reply string
+	err   error
+}
+
+// dispatchBatch fans out ready subtasks to Executor in parallel and returns
+// a map keyed by subtask ID. The caller persists the results in one Update
+// for a single fsync per batch.
+//
+// Subtasks aren't re-shuffled or sorted here — readyIDs already returns
+// them in DAG-natural (ID-ascending) order.
+func (s *Scheduler) dispatchBatch(ctx context.Context, t *Task, ready []int) map[int]subResult {
+	results := make(map[int]subResult, len(ready))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, subID := range ready {
+		sub := t.Find(subID)
+		if sub == nil {
+			continue
+		}
+		desc := sub.Description
+		wg.Add(1)
+		go func(id int, d string) {
+			defer wg.Done()
+			reply, err := s.exec.Execute(ctx, d)
+			mu.Lock()
+			results[id] = subResult{reply: reply, err: err}
+			mu.Unlock()
+		}(subID, desc)
+	}
+	wg.Wait()
+	return results
+}
+
+// readyIDs walks the task and returns the IDs of every subtask whose
+// dependencies are satisfied. Returned in ascending order so progress
+// logs stay readable.
+func readyIDs(t *Task) []int {
+	var ids []int
+	for _, sub := range t.Subtasks {
+		if sub.Ready(t) {
+			ids = append(ids, sub.ID)
+		}
+	}
+	return ids
+}
+
+func (s *Scheduler) logf(format string, args ...any) {
+	if s.stdout == nil {
+		return
+	}
+	fmt.Fprintf(s.stdout, format, args...)
+}

--- a/internal/taskgraph/scheduler_test.go
+++ b/internal/taskgraph/scheduler_test.go
@@ -1,0 +1,348 @@
+package taskgraph
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeExec runs a function per subtask description. The function decides
+// what to return + how long to take. Used to control concurrency / ordering
+// / failure-injection without spawning real LLM calls.
+type fakeExec struct {
+	fn        func(ctx context.Context, description string) (string, error)
+	callCount int32
+}
+
+func (f *fakeExec) Execute(ctx context.Context, description string) (string, error) {
+	atomic.AddInt32(&f.callCount, 1)
+	if f.fn == nil {
+		return "ok:" + description, nil
+	}
+	return f.fn(ctx, description)
+}
+
+// runWithExec is the standard helper: create a task with the given subtasks
+// in a fresh store, run the scheduler with the given fakeExec, return the
+// final task state + the scheduler's error.
+func runWithExec(t *testing.T, subs []Subtask, exec Executor) (*Task, error, string) {
+	t.Helper()
+	store := NewStoreAt(t.TempDir())
+	created, err := store.Create("test goal", subs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	sch := NewScheduler(store, exec, &buf)
+	runErr := sch.Run(context.Background(), created.ID)
+	final, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return final, runErr, buf.String()
+}
+
+// ── Happy path ───────────────────────────────────────────────────────────
+
+func TestScheduler_LinearDAGCompletes(t *testing.T) {
+	got, err, log := runWithExec(t, []Subtask{
+		{ID: 1, Description: "A", Status: SubtaskPending},
+		{ID: 2, Description: "B", BlockedBy: []int{1}, Status: SubtaskPending},
+		{ID: 3, Description: "C", BlockedBy: []int{2}, Status: SubtaskPending},
+	}, &fakeExec{})
+	if err != nil {
+		t.Fatalf("Run = %v, want nil; log:\n%s", err, log)
+	}
+	if got.Status != TaskDone {
+		t.Errorf("final task status = %q, want %q", got.Status, TaskDone)
+	}
+	for _, sub := range got.Subtasks {
+		if sub.Status != SubtaskDone {
+			t.Errorf("subtask #%d status = %q, want Done", sub.ID, sub.Status)
+		}
+		if sub.Result != "ok:"+sub.Description {
+			t.Errorf("subtask #%d result = %q", sub.ID, sub.Result)
+		}
+		if sub.Started == nil || sub.Finished == nil {
+			t.Errorf("subtask #%d missing Started/Finished timestamps", sub.ID)
+		}
+	}
+}
+
+func TestScheduler_SingleSubtaskCompletes(t *testing.T) {
+	got, err, _ := runWithExec(t, []Subtask{
+		{ID: 1, Description: "only", Status: SubtaskPending},
+	}, &fakeExec{})
+	if err != nil || got.Status != TaskDone {
+		t.Errorf("single-subtask task should succeed: status=%q err=%v", got.Status, err)
+	}
+}
+
+func TestScheduler_LogsProgress(t *testing.T) {
+	_, _, log := runWithExec(t, []Subtask{
+		{ID: 1, Description: "A", Status: SubtaskPending},
+		{ID: 2, Description: "B", BlockedBy: []int{1}, Status: SubtaskPending},
+	}, &fakeExec{})
+	for _, want := range []string{"Running task", "▶ #1", "✓ #1", "▶ #2", "✓ #2", "Task done"} {
+		if !strings.Contains(log, want) {
+			t.Errorf("progress log missing %q:\n%s", want, log)
+		}
+	}
+}
+
+// ── Parallelism ──────────────────────────────────────────────────────────
+
+func TestScheduler_IndependentSubtasksRunConcurrently(t *testing.T) {
+	// Three subtasks with no deps; each blocks on a shared barrier so
+	// they all have to be in-flight at the same time for the test to pass.
+	// If the scheduler dispatched serially, the barrier never opens and
+	// the test times out.
+	var wg sync.WaitGroup
+	wg.Add(3)
+	released := make(chan struct{})
+
+	exec := &fakeExec{fn: func(ctx context.Context, _ string) (string, error) {
+		wg.Done()  // arrival
+		<-released // release only after main test sees all 3 arrived
+		return "", nil
+	}}
+
+	store := NewStoreAt(t.TempDir())
+	created, _ := store.Create("parallel", []Subtask{
+		{ID: 1, Description: "A", Status: SubtaskPending},
+		{ID: 2, Description: "B", Status: SubtaskPending},
+		{ID: 3, Description: "C", Status: SubtaskPending},
+	})
+
+	sch := NewScheduler(store, exec, nil)
+	done := make(chan error, 1)
+	go func() { done <- sch.Run(context.Background(), created.ID) }()
+
+	// Wait for all three to arrive at the barrier.
+	arrived := make(chan struct{})
+	go func() { wg.Wait(); close(arrived) }()
+
+	select {
+	case <-arrived:
+		// Good — three goroutines are simultaneously inside Execute.
+	case <-time.After(2 * time.Second):
+		close(released) // unblock to clean up
+		<-done
+		t.Fatal("independent subtasks did not run concurrently")
+	}
+	close(released)
+	if err := <-done; err != nil {
+		t.Fatalf("Run = %v", err)
+	}
+}
+
+func TestScheduler_DepsForceSerial(t *testing.T) {
+	// 1 → 2 → 3: each must complete before the next starts. We assert that
+	// by recording the relative order of Execute calls.
+	var (
+		mu    sync.Mutex
+		order []string
+	)
+	exec := &fakeExec{fn: func(ctx context.Context, d string) (string, error) {
+		mu.Lock()
+		order = append(order, d)
+		mu.Unlock()
+		return "", nil
+	}}
+
+	got, err, _ := runWithExec(t, []Subtask{
+		{ID: 1, Description: "first", Status: SubtaskPending},
+		{ID: 2, Description: "second", BlockedBy: []int{1}, Status: SubtaskPending},
+		{ID: 3, Description: "third", BlockedBy: []int{2}, Status: SubtaskPending},
+	}, exec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != TaskDone {
+		t.Fatalf("final status = %q", got.Status)
+	}
+	if len(order) != 3 || order[0] != "first" || order[1] != "second" || order[2] != "third" {
+		t.Errorf("execution order = %v, want [first second third]", order)
+	}
+}
+
+// ── Stop on failure ──────────────────────────────────────────────────────
+
+func TestScheduler_FailureStopsAndMarksRemainingSkipped(t *testing.T) {
+	exec := &fakeExec{fn: func(_ context.Context, d string) (string, error) {
+		if d == "B" {
+			return "", errors.New("oops")
+		}
+		return "ok:" + d, nil
+	}}
+
+	got, err, log := runWithExec(t, []Subtask{
+		{ID: 1, Description: "A", Status: SubtaskPending},
+		{ID: 2, Description: "B", BlockedBy: []int{1}, Status: SubtaskPending},
+		{ID: 3, Description: "C", BlockedBy: []int{2}, Status: SubtaskPending},
+	}, exec)
+	if err == nil {
+		t.Fatal("Run should error when a subtask fails")
+	}
+	if got.Status != TaskFailed {
+		t.Errorf("task status after failure = %q, want %q", got.Status, TaskFailed)
+	}
+	if got.Subtasks[0].Status != SubtaskDone {
+		t.Errorf("subtask #1 should be Done: %+v", got.Subtasks[0])
+	}
+	if got.Subtasks[1].Status != SubtaskFailed {
+		t.Errorf("subtask #2 should be Failed: %+v", got.Subtasks[1])
+	}
+	if got.Subtasks[1].Error != "oops" {
+		t.Errorf("subtask #2 error = %q", got.Subtasks[1].Error)
+	}
+	if got.Subtasks[2].Status != SubtaskSkipped {
+		t.Errorf("subtask #3 should be Skipped: %+v", got.Subtasks[2])
+	}
+	if !strings.Contains(log, "✗ #2") {
+		t.Errorf("failure should be logged:\n%s", log)
+	}
+}
+
+func TestScheduler_ParallelFailureSkipsUnrelatedBranch(t *testing.T) {
+	// Two independent branches: 1 and 2 run in parallel. 1 fails. Even
+	// though 2 has nothing to do with 1, the stop-on-fail policy marks
+	// the whole task failed and any later-depending pending subtasks
+	// as skipped. (Here 2 either lands as Done or Failed in the same
+	// batch — both outcomes are valid; what matters is the *task*
+	// terminates as Failed.)
+	exec := &fakeExec{fn: func(_ context.Context, d string) (string, error) {
+		if d == "A" {
+			return "", errors.New("nope")
+		}
+		return "", nil
+	}}
+
+	got, err, _ := runWithExec(t, []Subtask{
+		{ID: 1, Description: "A", Status: SubtaskPending},
+		{ID: 2, Description: "B", Status: SubtaskPending},
+		{ID: 3, Description: "C", BlockedBy: []int{1}, Status: SubtaskPending}, // would have run after A
+	}, exec)
+	if err == nil {
+		t.Fatal("expected failure error")
+	}
+	if got.Status != TaskFailed {
+		t.Errorf("task status = %q", got.Status)
+	}
+	if got.Subtasks[0].Status != SubtaskFailed {
+		t.Errorf("#1 should be Failed: %q", got.Subtasks[0].Status)
+	}
+	if got.Subtasks[2].Status != SubtaskSkipped {
+		t.Errorf("#3 (depended on #1) should be Skipped, got %q", got.Subtasks[2].Status)
+	}
+}
+
+// ── Lifecycle guards ─────────────────────────────────────────────────────
+
+func TestScheduler_RejectsAlreadyDoneTask(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+	t1, _ := store.Create("g", []Subtask{{ID: 1, Description: "x", Status: SubtaskPending}})
+	_, _ = store.Update(t1.ID, func(t *Task) error { t.Status = TaskDone; return nil })
+
+	sch := NewScheduler(store, &fakeExec{}, nil)
+	if err := sch.Run(context.Background(), t1.ID); err == nil {
+		t.Error("running a Done task should error")
+	}
+}
+
+func TestScheduler_RejectsCancelledTask(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+	t1, _ := store.Create("g", []Subtask{{ID: 1, Description: "x", Status: SubtaskPending}})
+	_, _ = store.Update(t1.ID, func(t *Task) error { t.Status = TaskCancelled; return nil })
+
+	sch := NewScheduler(store, &fakeExec{}, nil)
+	if err := sch.Run(context.Background(), t1.ID); err == nil {
+		t.Error("running a cancelled task should error; resume should explicitly clear cancellation first")
+	}
+}
+
+func TestScheduler_NilExecutorErrors(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+	t1, _ := store.Create("g", []Subtask{{ID: 1, Description: "x", Status: SubtaskPending}})
+	sch := NewScheduler(store, nil, nil)
+	if err := sch.Run(context.Background(), t1.ID); err == nil {
+		t.Error("nil Executor should error before any state changes")
+	}
+}
+
+// ── Context cancellation ─────────────────────────────────────────────────
+
+func TestScheduler_ContextCancellation(t *testing.T) {
+	// Sub-agent blocks until ctx is cancelled, then returns ctx.Err().
+	// The scheduler should treat that as cancellation (not a regular
+	// subtask failure) and leave the task marked cancelled.
+	exec := &fakeExec{fn: func(ctx context.Context, _ string) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}}
+
+	store := NewStoreAt(t.TempDir())
+	created, _ := store.Create("g", []Subtask{
+		{ID: 1, Description: "long", Status: SubtaskPending},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sch := NewScheduler(store, exec, nil)
+	done := make(chan error, 1)
+	go func() { done <- sch.Run(ctx, created.ID) }()
+
+	// Cancel after a tick so the sub-agent has started.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	err := <-done
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Run should return context.Canceled, got %v", err)
+	}
+	final, _ := store.Get(created.ID)
+	if final.Status != TaskCancelled {
+		t.Errorf("final task status = %q, want %q", final.Status, TaskCancelled)
+	}
+}
+
+// ── Persistence ──────────────────────────────────────────────────────────
+
+func TestScheduler_PersistsResultsAndErrors(t *testing.T) {
+	exec := &fakeExec{fn: func(_ context.Context, d string) (string, error) {
+		return "reply for " + d, nil
+	}}
+	got, err, _ := runWithExec(t, []Subtask{
+		{ID: 1, Description: "alpha", Status: SubtaskPending},
+		{ID: 2, Description: "beta", BlockedBy: []int{1}, Status: SubtaskPending},
+	}, exec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Subtasks[0].Result != "reply for alpha" {
+		t.Errorf("alpha result = %q", got.Subtasks[0].Result)
+	}
+	if got.Subtasks[1].Result != "reply for beta" {
+		t.Errorf("beta result = %q", got.Subtasks[1].Result)
+	}
+}
+
+// ── readyIDs unit ────────────────────────────────────────────────────────
+
+func TestReadyIDs(t *testing.T) {
+	// 1 done, 2 ready (deps satisfied), 3 still blocked, 4 already running.
+	tk := &Task{Subtasks: []Subtask{
+		{ID: 1, Status: SubtaskDone},
+		{ID: 2, Status: SubtaskPending, BlockedBy: []int{1}},
+		{ID: 3, Status: SubtaskPending, BlockedBy: []int{2}},
+		{ID: 4, Status: SubtaskRunning},
+	}}
+	got := readyIDs(tk)
+	if len(got) != 1 || got[0] != 2 {
+		t.Errorf("readyIDs = %v, want [2]", got)
+	}
+}


### PR DESCRIPTION
## Summary

Third slice of **M11**. `internal/taskgraph.Scheduler` walks the DAG built by PR2 (#111) and drives it to a terminal state via parallel M10 sub-agents — one Spawn per ready subtask, fsync'd state transitions, stop-on-first-failure. `octo task run <id>` wires the CLI to it.

### `internal/taskgraph/scheduler.go`

- **`Executor`** interface (local to the package — keeps `taskgraph` free of an `internal/tools` dependency). `cmd/octo`'s `spawnerExecutor` adapts the real `tools.Spawner` into this shape.
- **`Scheduler.Run`** loop pattern per iteration:
  1. Reload task from disk.
  2. Find ready subtasks (Pending + all `BlockedBy` Done).
  3. Mark batch Running (**one fsync**).
  4. Parallel goroutines, one per ready subtask, each calling `Executor.Execute`.
  5. Apply all results in one Update (**one fsync**). Each subtask becomes Done (with result) or Failed (with error).
  6. Cancellation? → `TaskCancelled` + return `ctx.Err()`. Any failure? → mark remaining Pending as Skipped + `TaskFailed` + return.
- Two fsyncs per batch, so `kill -9` strands at most one subtask transition.
- Rejects Done / Cancelled tasks up front (PR4's resume will explicitly clear cancellation before calling Run again).

### `cmd/octo/task.go`

- `runTaskRun` parses `--provider` / `--model` identically to `start`, loads the task, builds parent agent + executor + Spawner the same way `chat.go` does for the REPL, hands them to Scheduler.
- `spawnerExecutor` adapts `tools.ActiveSpawner` into `taskgraph.Executor` by issuing one `launch_agent` Spawn per subtask. `Description` is one-line-truncated for the progress UI; the full description is the sub-agent's prompt.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [x] `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
- [x] Scheduler tests (~350 lines): happy path (linear / single / progress log), **parallelism** (barrier-based proof of concurrency + dependency forces serial), **stop-on-fail** (mid-DAG + parallel-unrelated-skipped), lifecycle guards (Done / Cancelled / nil-Executor), **context cancellation** (yields `TaskCancelled` + `context.Canceled`), persistence round-trip, `readyIDs` unit.
- [x] CLI tests: missing id → 2, unknown id → 1, missing API key → 1.
- [ ] Live verification: `octo task start "<goal>"` → `octo task run <id>` → DAG completes end-to-end with real sub-agents.

## Up next
- **PR4**: `list / status / show / resume / cancel`; `start` chains into `run` so the one-command flow works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)