### PR TITLE
feat(m11): PR4 — list / status / show / resume / cancel + start chains run

### DIFF
--- a/cmd/octo/task.go
+++ b/cmd/octo/task.go
@@ -30,6 +30,16 @@ func runTask(args []string, _ io.Reader, stdout, stderr io.Writer) int {
 		return runTaskStart(args[1:], stdout, stderr)
 	case "run":
 		return runTaskRun(args[1:], stdout, stderr)
+	case "list", "ls":
+		return runTaskList(args[1:], stdout, stderr)
+	case "status":
+		return runTaskStatus(args[1:], stdout, stderr)
+	case "show":
+		return runTaskShow(args[1:], stdout, stderr)
+	case "resume":
+		return runTaskResume(args[1:], stdout, stderr)
+	case "cancel":
+		return runTaskCancel(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
 		printTaskUsage(stdout)
 		return 0
@@ -46,10 +56,13 @@ func printTaskUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage: octo task <subcommand> [args...]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Subcommands:")
-	fmt.Fprintln(w, "  start \"<goal>\"   Decompose a goal into a subtask DAG and persist it")
-	fmt.Fprintln(w, "  run <id>         Execute the planned DAG: dispatch one sub-agent per subtask")
-	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Coming in later PRs: list, status, show, resume, cancel.")
+	fmt.Fprintln(w, "  start \"<goal>\" [--plan-only]   Plan + run a goal end-to-end (or just plan).")
+	fmt.Fprintln(w, "  run <id>                       Execute a previously planned task.")
+	fmt.Fprintln(w, "  list                           List every task, newest first.")
+	fmt.Fprintln(w, "  status <id>                    Show one task's DAG state (status per subtask).")
+	fmt.Fprintln(w, "  show <id> <subtask-id>         Show one subtask's full result / error / timing.")
+	fmt.Fprintln(w, "  resume <id>                    Re-run failed / skipped / cancelled subtasks.")
+	fmt.Fprintln(w, "  cancel <id>                    Mark a task cancelled (any in-flight `run` honors ctx separately).")
 }
 
 // runTaskStart handles `octo task start "<goal>" [flags]`. It runs the
@@ -62,8 +75,9 @@ func runTaskStart(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	providerName := fs.String("provider", providerAnthropic, "Provider: anthropic | openai")
 	model := fs.String("model", "", "Model name (defaults to the provider's cheapest reasoning model)")
+	planOnly := fs.Bool("plan-only", false, "Plan the DAG and exit — don't run subtasks yet (use `octo task run <id>` later)")
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "Usage: octo task start \"<goal>\" [--provider …] [--model …]")
+		fmt.Fprintln(stderr, "Usage: octo task start \"<goal>\" [--provider …] [--model …] [--plan-only]")
 		fs.PrintDefaults()
 	}
 	if err := fs.Parse(args); err != nil {
@@ -95,6 +109,8 @@ func runTaskStart(args []string, stdout, stderr io.Writer) int {
 		cacheKey: newCacheKey(),
 	}, resolvedModel)
 	a.MaxTokens = defaultMaxTokensForPlanner
+	cwd, _ := os.Getwd()
+	a.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "")
 
 	fmt.Fprintf(stdout, "Planning…  goal: %s\n", oneLine(goal))
 	res, err := a.PlanTask(context.Background(), goal)
@@ -131,7 +147,24 @@ func runTaskStart(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "Created task %s\n\n", task.ID)
 	printPlannedDAG(stdout, task)
 	fmt.Fprintln(stdout)
-	fmt.Fprintln(stdout, "Next: `octo task run "+task.ID+"` (coming in PR3) — for now the DAG is on disk and resumable.")
+
+	if *planOnly {
+		fmt.Fprintln(stdout, "Plan-only mode. Run with: octo task run "+task.ID)
+		return 0
+	}
+
+	// Chain into the scheduler reusing the agent + provider we already
+	// built — avoids a second provider handshake.
+	fmt.Fprintln(stdout, "Running…")
+	executor := tools.NewDefaultRegistry()
+	tools.SetSpawner(newAgentSpawner(a, executor, tools.DefaultTools))
+	defer tools.SetSpawner(nil)
+
+	sch := taskgraph.NewScheduler(store, &spawnerExecutor{}, stdout)
+	if err := sch.Run(context.Background(), task.ID); err != nil {
+		fmt.Fprintf(stderr, "octo task start: %v\n", err)
+		return 1
+	}
 	return 0
 }
 
@@ -239,6 +272,254 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "octo task run: %v\n", err)
 		return 1
 	}
+	return 0
+}
+
+// runTaskList prints every task on disk, newest first, in a compact table.
+func runTaskList(_ []string, stdout, stderr io.Writer) int {
+	store, err := taskgraph.NewStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo task list: %v\n", err)
+		return 1
+	}
+	tasks, err := store.List()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo task list: %v\n", err)
+		return 1
+	}
+	if len(tasks) == 0 {
+		fmt.Fprintln(stdout, "No tasks yet. Try `octo task start \"<goal>\"`.")
+		return 0
+	}
+	for _, t := range tasks {
+		fmt.Fprintf(stdout, "%s  %-9s  %s\n", t.ID, t.Status, oneLine(t.Goal))
+	}
+	return 0
+}
+
+// runTaskStatus prints one task's full DAG state — every subtask with its
+// status, dependencies, and one-line result snippet for completed work.
+func runTaskStatus(args []string, stdout, stderr io.Writer) int {
+	if len(args) < 1 {
+		fmt.Fprintln(stderr, "Usage: octo task status <id>")
+		return 2
+	}
+	store, err := taskgraph.NewStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo task status: %v\n", err)
+		return 1
+	}
+	t, err := store.Get(args[0])
+	if err != nil {
+		fmt.Fprintf(stderr, "octo task status: %v\n", err)
+		return 1
+	}
+	printTaskStatus(stdout, t)
+	return 0
+}
+
+// printTaskStatus is the formatter shared between `octo task status` and
+// the no-args summary `start` and `run` might print on completion later.
+func printTaskStatus(w io.Writer, t *taskgraph.Task) {
+	fmt.Fprintf(w, "Task %s — %s\n", t.ID, t.Status)
+	fmt.Fprintf(w, "Goal: %s\n\n", t.Goal)
+	for _, sub := range t.Subtasks {
+		fmt.Fprintf(w, "  %s #%-2d %s\n", subtaskGlyph(sub.Status), sub.ID, sub.Description)
+		if len(sub.BlockedBy) > 0 {
+			fmt.Fprintf(w, "      ↳ blocked_by: %s\n", joinInts(sub.BlockedBy))
+		}
+		if sub.Status == taskgraph.SubtaskFailed && sub.Error != "" {
+			fmt.Fprintf(w, "      ✗ %s\n", oneLine(sub.Error))
+		}
+		if sub.Status == taskgraph.SubtaskDone && sub.Result != "" {
+			fmt.Fprintf(w, "      ↳ %s\n", oneLine(sub.Result))
+		}
+	}
+}
+
+// subtaskGlyph returns the same single-rune markers task_manager uses, so
+// the visual language is consistent across the two task layers.
+func subtaskGlyph(s taskgraph.SubtaskStatus) string {
+	switch s {
+	case taskgraph.SubtaskRunning:
+		return "▶"
+	case taskgraph.SubtaskPending:
+		return "○"
+	case taskgraph.SubtaskDone:
+		return "✓"
+	case taskgraph.SubtaskFailed:
+		return "✗"
+	case taskgraph.SubtaskSkipped:
+		return "⊘"
+	}
+	return "·"
+}
+
+// runTaskShow prints one subtask's full result / error / timestamps —
+// useful when `octo task status` shows a Failed or interesting Done node
+// and the user wants the verbatim payload.
+func runTaskShow(args []string, stdout, stderr io.Writer) int {
+	if len(args) < 2 {
+		fmt.Fprintln(stderr, "Usage: octo task show <id> <subtask-id>")
+		return 2
+	}
+	subID := 0
+	if _, err := fmt.Sscanf(args[1], "%d", &subID); err != nil || subID < 1 {
+		fmt.Fprintf(stderr, "octo task show: invalid subtask-id %q (want a positive integer)\n", args[1])
+		return 2
+	}
+	store, err := taskgraph.NewStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo task show: %v\n", err)
+		return 1
+	}
+	t, err := store.Get(args[0])
+	if err != nil {
+		fmt.Fprintf(stderr, "octo task show: %v\n", err)
+		return 1
+	}
+	sub := t.Find(subID)
+	if sub == nil {
+		fmt.Fprintf(stderr, "octo task show: no subtask #%d in task %s\n", subID, args[0])
+		return 1
+	}
+	fmt.Fprintf(stdout, "Task %s · subtask #%d (%s)\n", t.ID, sub.ID, sub.Status)
+	fmt.Fprintf(stdout, "Description:\n  %s\n\n", sub.Description)
+	if len(sub.BlockedBy) > 0 {
+		fmt.Fprintf(stdout, "Blocked by: %s\n", joinInts(sub.BlockedBy))
+	}
+	if sub.Started != nil {
+		fmt.Fprintf(stdout, "Started:  %s\n", sub.Started.Format("2006-01-02 15:04:05 UTC"))
+	}
+	if sub.Finished != nil {
+		fmt.Fprintf(stdout, "Finished: %s\n", sub.Finished.Format("2006-01-02 15:04:05 UTC"))
+		if sub.Started != nil {
+			fmt.Fprintf(stdout, "Duration: %s\n", sub.Finished.Sub(*sub.Started).Round(100_000_000)) // 0.1s precision
+		}
+	}
+	if sub.Error != "" {
+		fmt.Fprintf(stdout, "\nError:\n%s\n", sub.Error)
+	}
+	if sub.Result != "" {
+		fmt.Fprintf(stdout, "\nResult:\n%s\n", sub.Result)
+	}
+	return 0
+}
+
+// runTaskResume re-runs a stalled task. Resets Failed / Skipped /
+// Cancelled subtasks back to Pending so the scheduler picks them up; the
+// task itself moves Failed/Cancelled → Pending. Done subtasks (and their
+// results) are preserved.
+func runTaskResume(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("task resume", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	providerName := fs.String("provider", providerAnthropic, "Provider: anthropic | openai")
+	model := fs.String("model", "", "Model name (defaults to the provider's cheapest reasoning model)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() < 1 {
+		fmt.Fprintln(stderr, "Usage: octo task resume <id>")
+		return 2
+	}
+	id := fs.Arg(0)
+
+	store, err := taskgraph.NewStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo task resume: %v\n", err)
+		return 1
+	}
+
+	t, err := store.Update(id, func(t *taskgraph.Task) error {
+		if t.Status == taskgraph.TaskDone {
+			return fmt.Errorf("task %s is already done — nothing to resume", t.ID)
+		}
+		for i := range t.Subtasks {
+			switch t.Subtasks[i].Status {
+			case taskgraph.SubtaskFailed, taskgraph.SubtaskSkipped:
+				t.Subtasks[i].Status = taskgraph.SubtaskPending
+				t.Subtasks[i].Error = ""
+				t.Subtasks[i].Started = nil
+				t.Subtasks[i].Finished = nil
+			}
+		}
+		t.Status = taskgraph.TaskPending
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "octo task resume: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Resumed task %s — re-running pending subtasks…\n", t.ID)
+
+	// Then drive Scheduler.Run the same way `run` does.
+	return resumeAndRun(t, *providerName, *model, stdout, stderr)
+}
+
+// resumeAndRun is the shared "build provider+spawner, hand to Scheduler"
+// path used by resume (and potentially by future commands). Returns the
+// CLI exit code.
+func resumeAndRun(t *taskgraph.Task, providerName, model string, stdout, stderr io.Writer) int {
+	resolvedModel := model
+	if resolvedModel == "" {
+		resolvedModel = defaultModels[providerName]
+	}
+	if resolvedModel == "" {
+		fmt.Fprintf(stderr, "unknown provider %q (use 'anthropic' or 'openai')\n", providerName)
+		return 2
+	}
+	prov, err := buildProvider(providerName, stderr)
+	if err != nil {
+		return 1
+	}
+	parent := agent.New(providerSender{p: prov, cacheKey: newCacheKey()}, resolvedModel)
+	parent.MaxTokens = defaultMaxTokensForPlanner
+	cwd, _ := os.Getwd()
+	parent.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "")
+
+	executor := tools.NewDefaultRegistry()
+	tools.SetSpawner(newAgentSpawner(parent, executor, tools.DefaultTools))
+	defer tools.SetSpawner(nil)
+
+	store, err := taskgraph.NewStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	sch := taskgraph.NewScheduler(store, &spawnerExecutor{}, stdout)
+	if err := sch.Run(context.Background(), t.ID); err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// runTaskCancel marks a task Cancelled. Does NOT signal a concurrently-
+// running scheduler — in v1 the scheduler is foreground-only, so cancel
+// is mostly useful for tasks the user abandoned (Ctrl-C'd) so they don't
+// get accidentally resumed.
+func runTaskCancel(args []string, stdout, stderr io.Writer) int {
+	if len(args) < 1 {
+		fmt.Fprintln(stderr, "Usage: octo task cancel <id>")
+		return 2
+	}
+	store, err := taskgraph.NewStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo task cancel: %v\n", err)
+		return 1
+	}
+	t, err := store.Update(args[0], func(t *taskgraph.Task) error {
+		if t.Status == taskgraph.TaskDone {
+			return fmt.Errorf("task %s is done — nothing to cancel", t.ID)
+		}
+		t.Status = taskgraph.TaskCancelled
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "octo task cancel: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Cancelled task %s.\n", t.ID)
 	return 0
 }
 

--- a/cmd/octo/task_test.go
+++ b/cmd/octo/task_test.go
@@ -188,6 +188,269 @@ func TestRunTaskRun_MissingAPIKey(t *testing.T) {
 	}
 }
 
+// ── list / status / show / resume / cancel ──────────────────────────────
+
+// seedTask creates one task in the fake-home store and returns it. Helper
+// for the inspection-command tests.
+func seedTask(t *testing.T) *taskgraph.Task {
+	t.Helper()
+	store, err := taskgraph.NewStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tk, err := store.Create("test goal", []taskgraph.Subtask{
+		{ID: 1, Description: "do A", Status: taskgraph.SubtaskPending},
+		{ID: 2, Description: "do B", BlockedBy: []int{1}, Status: taskgraph.SubtaskPending},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tk
+}
+
+func TestRunTaskList_EmptyShowsNotice(t *testing.T) {
+	withFakeHome(t)
+	var out, errBuf bytes.Buffer
+	if code := runTask([]string{"list"}, nil, &out, &errBuf); code != 0 {
+		t.Errorf("empty list exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "No tasks yet") {
+		t.Errorf("empty list should print notice:\n%s", out.String())
+	}
+}
+
+func TestRunTaskList_LsAlias(t *testing.T) {
+	// `ls` is the alias for `list` (vim users / unix muscle memory).
+	withFakeHome(t)
+	var out bytes.Buffer
+	if code := runTask([]string{"ls"}, nil, &out, &out); code != 0 {
+		t.Errorf("ls alias exit = %d, want 0", code)
+	}
+}
+
+func TestRunTaskList_ShowsAllTasks(t *testing.T) {
+	withFakeHome(t)
+	t1 := seedTask(t)
+	t2 := seedTask(t)
+
+	var out bytes.Buffer
+	if code := runTask([]string{"list"}, nil, &out, &out); code != 0 {
+		t.Fatalf("list exit = %d", code)
+	}
+	got := out.String()
+	// Ordering is descending-by-ID (proved at the store layer in
+	// internal/taskgraph; here we just confirm the CLI passes everything
+	// through with status + goal columns).
+	for _, want := range []string{t1.ID, t2.ID, "pending", "test goal"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("list output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunTaskStatus_RequiresID(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runTask([]string{"status"}, nil, &out, &errBuf); code != 2 {
+		t.Errorf("missing id exit = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "octo task status <id>") {
+		t.Errorf("missing-id error should print usage, got:\n%s", errBuf.String())
+	}
+}
+
+func TestRunTaskStatus_UnknownIDErrors(t *testing.T) {
+	withFakeHome(t)
+	var out, errBuf bytes.Buffer
+	if code := runTask([]string{"status", "missing"}, nil, &out, &errBuf); code != 1 {
+		t.Errorf("unknown id exit = %d, want 1; stderr=%q", code, errBuf.String())
+	}
+}
+
+func TestRunTaskStatus_RendersDAG(t *testing.T) {
+	withFakeHome(t)
+	tk := seedTask(t)
+
+	var out bytes.Buffer
+	if code := runTask([]string{"status", tk.ID}, nil, &out, &out); code != 0 {
+		t.Fatalf("status exit = %d", code)
+	}
+	for _, want := range []string{"Task " + tk.ID, "Goal: test goal", "○ #1", "○ #2", "blocked_by: #1"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("status output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRunTaskShow_RequiresIDAndSubID(t *testing.T) {
+	withFakeHome(t)
+	var out, errBuf bytes.Buffer
+	if code := runTask([]string{"show"}, nil, &out, &errBuf); code != 2 {
+		t.Error("missing id should exit 2")
+	}
+	if code := runTask([]string{"show", "abc"}, nil, &out, &errBuf); code != 2 {
+		t.Error("missing subtask-id should exit 2")
+	}
+}
+
+func TestRunTaskShow_RejectsNonIntSubID(t *testing.T) {
+	withFakeHome(t)
+	var out, errBuf bytes.Buffer
+	if code := runTask([]string{"show", "abc", "two"}, nil, &out, &errBuf); code != 2 {
+		t.Errorf("non-int subtask-id exit = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "invalid subtask-id") {
+		t.Errorf("expected 'invalid subtask-id' note, got:\n%s", errBuf.String())
+	}
+}
+
+func TestRunTaskShow_UnknownSubtaskErrors(t *testing.T) {
+	withFakeHome(t)
+	tk := seedTask(t)
+	var out, errBuf bytes.Buffer
+	if code := runTask([]string{"show", tk.ID, "99"}, nil, &out, &errBuf); code != 1 {
+		t.Errorf("unknown subtask-id exit = %d, want 1", code)
+	}
+}
+
+func TestRunTaskShow_RendersFullSubtask(t *testing.T) {
+	withFakeHome(t)
+	tk := seedTask(t)
+
+	// Mark subtask 1 Done with a result so the formatter has content
+	// to render.
+	store, _ := taskgraph.NewStore()
+	_, _ = store.Update(tk.ID, func(t *taskgraph.Task) error {
+		s := t.Find(1)
+		s.Status = taskgraph.SubtaskDone
+		s.Result = "found the cache layer"
+		return nil
+	})
+
+	var out bytes.Buffer
+	if code := runTask([]string{"show", tk.ID, "1"}, nil, &out, &out); code != 0 {
+		t.Fatalf("show exit = %d", code)
+	}
+	for _, want := range []string{"subtask #1", "done", "do A", "found the cache layer"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("show output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRunTaskCancel_RequiresID(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runTask([]string{"cancel"}, nil, &out, &errBuf); code != 2 {
+		t.Errorf("missing id exit = %d, want 2", code)
+	}
+}
+
+func TestRunTaskCancel_MarksTaskCancelled(t *testing.T) {
+	withFakeHome(t)
+	tk := seedTask(t)
+	var out bytes.Buffer
+	if code := runTask([]string{"cancel", tk.ID}, nil, &out, &out); code != 0 {
+		t.Fatalf("cancel exit = %d", code)
+	}
+	store, _ := taskgraph.NewStore()
+	got, _ := store.Get(tk.ID)
+	if got.Status != taskgraph.TaskCancelled {
+		t.Errorf("task status after cancel = %q, want %q", got.Status, taskgraph.TaskCancelled)
+	}
+}
+
+func TestRunTaskCancel_RefusesDoneTask(t *testing.T) {
+	withFakeHome(t)
+	tk := seedTask(t)
+	store, _ := taskgraph.NewStore()
+	_, _ = store.Update(tk.ID, func(t *taskgraph.Task) error {
+		t.Status = taskgraph.TaskDone
+		return nil
+	})
+	var out, errBuf bytes.Buffer
+	if code := runTask([]string{"cancel", tk.ID}, nil, &out, &errBuf); code != 1 {
+		t.Errorf("cancel on done exit = %d, want 1", code)
+	}
+}
+
+func TestRunTaskResume_RequiresID(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runTask([]string{"resume"}, nil, &out, &errBuf); code != 2 {
+		t.Errorf("missing id exit = %d, want 2", code)
+	}
+}
+
+func TestRunTaskResume_ResetsFailedAndSkippedToPending(t *testing.T) {
+	// Resume mutates state but then tries to actually re-run via the LLM —
+	// we don't want to call the real provider in unit tests. So we set up
+	// the task, run resume (which will fail at the provider build step
+	// because there's no API key), and verify the state reset still happened
+	// before the failure.
+	withFakeHome(t)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	tk := seedTask(t)
+
+	store, _ := taskgraph.NewStore()
+	_, _ = store.Update(tk.ID, func(t *taskgraph.Task) error {
+		t.Status = taskgraph.TaskFailed
+		t.Subtasks[0].Status = taskgraph.SubtaskFailed
+		t.Subtasks[0].Error = "old error"
+		t.Subtasks[1].Status = taskgraph.SubtaskSkipped
+		return nil
+	})
+
+	var out, errBuf bytes.Buffer
+	// We expect exit 1 (provider build will fail), but the state mutation
+	// happens FIRST so it must persist.
+	runTask([]string{"resume", tk.ID}, nil, &out, &errBuf)
+
+	got, _ := store.Get(tk.ID)
+	if got.Status != taskgraph.TaskPending {
+		t.Errorf("task status after resume = %q, want %q", got.Status, taskgraph.TaskPending)
+	}
+	if got.Subtasks[0].Status != taskgraph.SubtaskPending {
+		t.Errorf("failed subtask not reset: %q", got.Subtasks[0].Status)
+	}
+	if got.Subtasks[0].Error != "" {
+		t.Errorf("failed subtask error not cleared: %q", got.Subtasks[0].Error)
+	}
+	if got.Subtasks[1].Status != taskgraph.SubtaskPending {
+		t.Errorf("skipped subtask not reset: %q", got.Subtasks[1].Status)
+	}
+}
+
+func TestRunTaskResume_RejectsDoneTask(t *testing.T) {
+	withFakeHome(t)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	tk := seedTask(t)
+
+	store, _ := taskgraph.NewStore()
+	_, _ = store.Update(tk.ID, func(t *taskgraph.Task) error {
+		t.Status = taskgraph.TaskDone
+		return nil
+	})
+
+	var out, errBuf bytes.Buffer
+	if code := runTask([]string{"resume", tk.ID}, nil, &out, &errBuf); code != 1 {
+		t.Errorf("resume on done task exit = %d, want 1; stderr=%q", code, errBuf.String())
+	}
+}
+
+func TestSubtaskGlyph(t *testing.T) {
+	cases := map[taskgraph.SubtaskStatus]string{
+		taskgraph.SubtaskRunning:         "▶",
+		taskgraph.SubtaskPending:         "○",
+		taskgraph.SubtaskDone:            "✓",
+		taskgraph.SubtaskFailed:          "✗",
+		taskgraph.SubtaskSkipped:         "⊘",
+		taskgraph.SubtaskStatus("bogus"): "·",
+	}
+	for in, want := range cases {
+		if got := subtaskGlyph(in); got != want {
+			t.Errorf("subtaskGlyph(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 // Smoke test that the planner-to-store conversion preserves IDs and the
 // taskgraph layer accepts what the planner emits. Doesn't hit the LLM —
 // it constructs the equivalent subtasks directly and checks they round-


### PR DESCRIPTION
## Summary

Final slice of **M11**. Completes the CLI surface so the plan-and-run workflow is one command end-to-end and the user can inspect, resume, or cancel a task without poking at JSON files directly.

### `octo task start "<goal>"` now chains into the scheduler

By default `start` plans + runs in one invocation. `--plan-only` keeps the old "stop after persisting" behaviour for users who want to eyeball the DAG before running.

### New subcommands

| Command | What it does |
|---|---|
| `octo task list` (alias `ls`) | Newest-first table: `id / status / goal preview`. |
| `octo task status <id>` | Full DAG state with per-subtask glyphs (`▶ ○ ✓ ✗ ⊘`), `blocked_by` lines, one-line result or error snippets for completed nodes. |
| `octo task show <id> <subtask-id>` | One subtask's full `Description / Started / Finished / Duration / Error / Result` when `status`'s one-line snippets aren't enough. |
| `octo task resume <id>` | Resets `Failed` and `Skipped` subtasks → `Pending` (clears their error + timestamps), task → `Pending`, then runs `Scheduler.Run` again. `Done` subtasks keep their results. |
| `octo task cancel <id>` | Marks task `Cancelled`. Foreground-only in v1, so this is mainly cleanup after a Ctrl-C'd run so `resume` doesn't accidentally re-pick it up. Refuses `Done` tasks. |

### Visual consistency

`subtaskGlyph` mirrors the `task_manager` renderer (PR #108) so the visual language for "task progress" is consistent across the in-session todo list and the autonomous DAG view.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [x] `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
- [x] ~280 lines of new CLI tests cover: list (empty + alias + populated), status (missing/unknown id + render), show (arg validation + non-int subtask + unknown + full render), cancel (missing id + happy path + refuse done), resume (missing id + state reset verified post-error + refuse done), `subtaskGlyph` table.

## M11 milestone summary

Four PRs, all merged:
- **#110** — internal/taskgraph data layer (Task + Subtask + Store + fsync persistence)
- **#111** — planner side-call + `octo task start "<goal>"`
- **#112** — scheduler dispatching subtasks via M10 sub-agents
- **#113 (this)** — list/status/show/resume/cancel + start→run chaining

Acceptance criteria from `dev-docs/go-rewrite-roadmap.md` §M11:
- [x] `octo task start "..."` → auto-decompose + execute + persist
- [x] `octo task status <id>` accurately reflects DAG state, independent of conversation history
- [ ] Resumable after `kill -9` (mechanism is in place — fsync per state change + resume command — needs a live test)
- [ ] Survives long-context decay (architecturally true by construction — the harness never sends conversation history to an evaluator — but worth a real long-running task to confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)