### PR TITLE
feat(memoryd): C9 Phase 2 PR1 — daemon core (lifecycle + PID file)

### DIFF
--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -49,6 +49,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return runMemory(args[1:], stdout, stderr)
 	case "task":
 		return runTask(args[1:], stdin, stdout, stderr)
+	case "memoryd":
+		return runMemoryd(args[1:], stdin, stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "octo: unknown command %q\n", args[0])
 		fmt.Fprintln(stderr, "Run `octo help` for available commands.")
@@ -66,6 +68,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  init       Analyze the repo and generate/update .octorules")
 	fmt.Fprintln(w, "  memory     Manage cross-session memory (e.g. `octo memory list`)")
 	fmt.Fprintln(w, "  task       Autonomous task orchestration (M11; `octo task start \"<goal>\"`)")
+	fmt.Fprintln(w, "  memoryd    C9 Phase 2 memory daemon (`octo memoryd start|stop|status`)")
 	fmt.Fprintln(w, "  version    Print the version and exit")
 	fmt.Fprintln(w, "  help       Print this help and exit")
 	fmt.Fprintln(w)

--- a/cmd/octo/memoryd.go
+++ b/cmd/octo/memoryd.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/memoryd"
+)
+
+// runMemoryd handles `octo memoryd <subcommand>`. The C9 Phase 2 daemon
+// (see internal/memoryd) takes over the async extract + consolidate
+// passes the chat path runs at startup; with the daemon alive, chat
+// startup becomes effectively instant and memory work happens in the
+// background. v1 is manual-start only (no launchd / systemd integration);
+// the user runs `octo memoryd start` in a spare terminal or backgrounds
+// it via shell.
+//
+// PR1 (this file) ships start / stop / status. PR2 will plug the actual
+// work into the daemon. PR3 will teach `octo chat` to skip the Phase 1
+// startup path when the daemon is alive.
+func runMemoryd(args []string, _ io.Reader, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		printMemorydUsage(stdout)
+		return 2
+	}
+	switch args[0] {
+	case "start":
+		return runMemorydStart(stdout, stderr)
+	case "stop":
+		return runMemorydStop(stdout, stderr)
+	case "status":
+		return runMemorydStatus(stdout, stderr)
+	case "help", "--help", "-h":
+		printMemorydUsage(stdout)
+		return 0
+	default:
+		fmt.Fprintf(stderr, "octo memoryd: unknown subcommand %q\n", args[0])
+		printMemorydUsage(stderr)
+		return 2
+	}
+}
+
+func printMemorydUsage(w io.Writer) {
+	fmt.Fprintln(w, "octo memoryd — C9 Phase 2 cross-session memory daemon")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Usage: octo memoryd <subcommand>")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Subcommands:")
+	fmt.Fprintln(w, "  start    Run the daemon in the foreground (Ctrl-C / SIGTERM to stop).")
+	fmt.Fprintln(w, "  stop     SIGTERM the running daemon (reads ~/.octo/memoryd.pid).")
+	fmt.Fprintln(w, "  status   Report whether a daemon is running and where its PID file is.")
+}
+
+// runMemorydStart writes the PID file, hooks signal handlers, and runs
+// the daemon loop in the foreground. Returns 0 on graceful shutdown, 1
+// on configuration / setup errors.
+func runMemorydStart(stdout, stderr io.Writer) int {
+	if !memoryd.SupportedOnThisOS() {
+		fmt.Fprintln(stderr, "octo memoryd: not supported on this OS (Windows falls back to Phase 1 startup memory).")
+		return 1
+	}
+
+	pidPath, err := memoryd.ReserveStart()
+	if err != nil {
+		if memoryd.IsAlreadyRunning(err) {
+			fmt.Fprintf(stderr, "octo memoryd: %v\n", err)
+			fmt.Fprintln(stderr, "If you're sure no daemon is alive, remove ~/.octo/memoryd.pid manually.")
+			return 1
+		}
+		fmt.Fprintf(stderr, "octo memoryd: %v\n", err)
+		return 1
+	}
+	// Remove the PID file on exit so the next `start` doesn't refuse.
+	defer func() { _ = memoryd.RemovePIDFile(pidPath) }()
+
+	fmt.Fprintf(stdout, "octo memoryd: started (pid %d, pidfile %s)\n", os.Getpid(), pidPath)
+	fmt.Fprintln(stdout, "Use `octo memoryd stop` from another terminal, or send SIGTERM/SIGINT.")
+
+	ctx, cancel := signalContext(context.Background())
+	defer cancel()
+
+	d := &memoryd.Daemon{Out: stdout}
+	err = d.Run(ctx)
+	// ctx.Canceled is the graceful path (SIGTERM/SIGINT delivered →
+	// signalContext cancelled the ctx → Run returned ctx.Err()).
+	if err != nil && ctx.Err() == nil {
+		fmt.Fprintf(stderr, "octo memoryd: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// runMemorydStop reads the PID file and sends SIGTERM to the recorded
+// PID. Doesn't wait for the process to exit — the daemon's signal
+// handler is responsible for finishing the in-flight tick and cleaning
+// up the PID file. Returns 0 if signal delivery succeeded (or the
+// daemon was already gone), 1 otherwise.
+func runMemorydStop(stdout, stderr io.Writer) int {
+	if !memoryd.SupportedOnThisOS() {
+		fmt.Fprintln(stderr, "octo memoryd: not supported on this OS.")
+		return 1
+	}
+
+	status, err := memoryd.CheckStatus()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo memoryd: %v\n", err)
+		return 1
+	}
+	if status.PID == 0 {
+		fmt.Fprintln(stdout, "octo memoryd: no daemon running (no PID file).")
+		return 0
+	}
+	if !status.Running {
+		fmt.Fprintf(stdout, "octo memoryd: PID %d is not alive; clearing stale pidfile.\n", status.PID)
+		_ = memoryd.RemovePIDFile(status.PIDFile)
+		return 0
+	}
+	proc, err := os.FindProcess(status.PID)
+	if err != nil {
+		fmt.Fprintf(stderr, "octo memoryd: find pid %d: %v\n", status.PID, err)
+		return 1
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		fmt.Fprintf(stderr, "octo memoryd: SIGTERM pid %d: %v\n", status.PID, err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "octo memoryd: sent SIGTERM to pid %d.\n", status.PID)
+	return 0
+}
+
+// runMemorydStatus prints whether a daemon is currently running. Plays
+// the same role as `systemctl status` — informational, never exits with
+// an error just because no daemon is up.
+func runMemorydStatus(stdout, stderr io.Writer) int {
+	status, err := memoryd.CheckStatus()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo memoryd: %v\n", err)
+		return 1
+	}
+	switch {
+	case status.PID == 0:
+		fmt.Fprintln(stdout, "octo memoryd: not running.")
+	case !status.Running:
+		fmt.Fprintf(stdout, "octo memoryd: stale (pidfile %s claims pid %d, not alive).\n", status.PIDFile, status.PID)
+	default:
+		uptime := time.Since(status.StartedAt).Round(time.Second)
+		fmt.Fprintf(stdout, "octo memoryd: running (pid %d, uptime %s, pidfile %s).\n",
+			status.PID, uptime, status.PIDFile)
+	}
+	return 0
+}
+
+// signalContext returns a context that cancels on SIGTERM or SIGINT, so
+// the daemon's Run loop unwinds gracefully when the user runs
+// `octo memoryd stop` (which sends SIGTERM) or Ctrl-C's the foreground
+// process.
+func signalContext(parent context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		select {
+		case <-ch:
+			cancel()
+		case <-ctx.Done():
+		}
+		signal.Stop(ch)
+	}()
+	return ctx, cancel
+}

--- a/cmd/octo/memoryd_test.go
+++ b/cmd/octo/memoryd_test.go
@@ -80,6 +80,9 @@ func TestRunMemorydStatus_StalePIDFile(t *testing.T) {
 }
 
 func TestRunMemorydStatus_AliveDaemon(t *testing.T) {
+	if !memoryd.SupportedOnThisOS() {
+		t.Skip("daemon model not supported on this OS")
+	}
 	fakeHomeForMemoryd(t)
 	pidPath, _ := memoryd.PIDFile()
 	if err := memoryd.WritePIDFile(pidPath, os.Getpid()); err != nil {

--- a/cmd/octo/memoryd_test.go
+++ b/cmd/octo/memoryd_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/memoryd"
+)
+
+// fakeHomeForMemoryd points $HOME at a tempdir so memoryd lifecycle
+// commands write their PID file there.
+func fakeHomeForMemoryd(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	return dir
+}
+
+func TestRunMemoryd_NoArgsShowsUsage(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runMemoryd(nil, nil, &out, &errBuf); code != 2 {
+		t.Errorf("no args exit = %d, want 2", code)
+	}
+	if !strings.Contains(out.String(), "octo memoryd") {
+		t.Errorf("usage should be printed:\n%s", out.String())
+	}
+}
+
+func TestRunMemoryd_UnknownSubcommand(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runMemoryd([]string{"bogus"}, nil, &out, &errBuf); code != 2 {
+		t.Errorf("unknown subcommand exit = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "unknown subcommand") {
+		t.Errorf("expected 'unknown subcommand' notice:\n%s", errBuf.String())
+	}
+}
+
+func TestRunMemoryd_HelpExitsZero(t *testing.T) {
+	for _, arg := range []string{"help", "--help", "-h"} {
+		var out, errBuf bytes.Buffer
+		if code := runMemoryd([]string{arg}, nil, &out, &errBuf); code != 0 {
+			t.Errorf("%s exit = %d, want 0", arg, code)
+		}
+	}
+}
+
+func TestRunMemorydStatus_NoDaemon(t *testing.T) {
+	fakeHomeForMemoryd(t)
+	var out bytes.Buffer
+	if code := runMemoryd([]string{"status"}, nil, &out, &out); code != 0 {
+		t.Errorf("status with no daemon exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "not running") {
+		t.Errorf("status should say 'not running':\n%s", out.String())
+	}
+}
+
+func TestRunMemorydStatus_StalePIDFile(t *testing.T) {
+	dir := fakeHomeForMemoryd(t)
+	// Drop a PID file pointing at a long-dead PID.
+	pidPath := filepath.Join(dir, ".octo", "memoryd.pid")
+	if err := memoryd.WritePIDFile(pidPath, 2_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	if memoryd.IsRunning(2_000_000_000) {
+		t.Skip("PID 2_000_000_000 happens to be alive on this system")
+	}
+	var out bytes.Buffer
+	if code := runMemoryd([]string{"status"}, nil, &out, &out); code != 0 {
+		t.Errorf("status with stale pid exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "stale") {
+		t.Errorf("stale-pid status should be flagged:\n%s", out.String())
+	}
+}
+
+func TestRunMemorydStatus_AliveDaemon(t *testing.T) {
+	fakeHomeForMemoryd(t)
+	pidPath, _ := memoryd.PIDFile()
+	if err := memoryd.WritePIDFile(pidPath, os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if code := runMemoryd([]string{"status"}, nil, &out, &out); code != 0 {
+		t.Errorf("status with alive pid exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "running") {
+		t.Errorf("alive-daemon status should be flagged:\n%s", out.String())
+	}
+}
+
+func TestRunMemorydStop_NoDaemon(t *testing.T) {
+	fakeHomeForMemoryd(t)
+	var out, errBuf bytes.Buffer
+	if !memoryd.SupportedOnThisOS() {
+		t.Skip("memoryd not supported on this OS")
+	}
+	if code := runMemoryd([]string{"stop"}, nil, &out, &errBuf); code != 0 {
+		t.Errorf("stop with no daemon exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "no daemon") {
+		t.Errorf("stop with no daemon should say so:\n%s", out.String())
+	}
+}
+
+func TestRunMemorydStop_StalePIDClearsFile(t *testing.T) {
+	if !memoryd.SupportedOnThisOS() {
+		t.Skip("memoryd not supported on this OS")
+	}
+	fakeHomeForMemoryd(t)
+	pidPath, _ := memoryd.PIDFile()
+	if err := memoryd.WritePIDFile(pidPath, 2_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	if memoryd.IsRunning(2_000_000_000) {
+		t.Skip("PID 2_000_000_000 alive — can't test stale path")
+	}
+	var out bytes.Buffer
+	if code := runMemoryd([]string{"stop"}, nil, &out, &out); code != 0 {
+		t.Errorf("stop with stale pid exit = %d, want 0", code)
+	}
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Errorf("stale PID file should be cleared, got %v", err)
+	}
+}
+
+func TestRunMemorydStart_RefusesIfAlreadyRunning(t *testing.T) {
+	if !memoryd.SupportedOnThisOS() {
+		t.Skip("memoryd not supported on this OS")
+	}
+	fakeHomeForMemoryd(t)
+	// Pretend a daemon is already up (our own PID).
+	pidPath, _ := memoryd.PIDFile()
+	if err := memoryd.WritePIDFile(pidPath, os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	var out, errBuf bytes.Buffer
+	if code := runMemoryd([]string{"start"}, nil, &out, &errBuf); code != 1 {
+		t.Errorf("start with alive daemon exit = %d, want 1; stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "already running") {
+		t.Errorf("start should refuse with 'already running':\n%s", errBuf.String())
+	}
+}

--- a/internal/memoryd/memoryd.go
+++ b/internal/memoryd/memoryd.go
@@ -30,7 +30,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -98,29 +97,25 @@ func RemovePIDFile(path string) error {
 }
 
 // IsRunning probes whether a process with the given PID exists. On Unix
-// this uses `kill -0` (signal 0 = just check, don't deliver). The PID
-// must be >0 (we already validated that in ReadPIDFile).
+// this uses `kill -0` (signal 0 = just check, don't deliver). On Windows
+// it always returns false — the daemon is unsupported there (see
+// SupportedOnThisOS), so the answer is structurally "no daemon", and
+// every code path that consults IsRunning gracefully degrades to the
+// Phase 1 fallback.
 //
-// False positives are possible if the OS recycled the PID to an unrelated
-// process — in that case `octo memoryd start` will detect the conflict
-// when it tries to write its own PID, and `octo memoryd stop` will
-// SIGTERM the unrelated process. Acceptable for v1; a real watchdog
+// False positives are possible on Unix if the OS recycled the PID to an
+// unrelated process — in that case `octo memoryd start` will detect the
+// conflict when it tries to write its own PID, and `octo memoryd stop`
+// will SIGTERM the unrelated process. Acceptable for v1; a real watchdog
 // would verify the binary by reading /proc/<pid>/comm.
+//
+// Implemented per-OS via isRunning so build-tagged behavior is local to
+// supported_*.go.
 func IsRunning(pid int) bool {
 	if pid <= 0 {
 		return false
 	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	// On Unix os.FindProcess never errors — the real check is Signal(0).
-	// On Windows os.FindProcess does check, but Signal isn't reliable, so
-	// daemon mode is unsupported there (see SupportedOnThisOS).
-	if err := proc.Signal(syscall.Signal(0)); err != nil {
-		return false
-	}
-	return true
+	return isRunning(pid)
 }
 
 // Status describes a daemon's lifecycle state for the CLI to render.

--- a/internal/memoryd/memoryd.go
+++ b/internal/memoryd/memoryd.go
@@ -1,0 +1,261 @@
+// Package memoryd is the C9 Phase 2 cross-session memory daemon. It owns
+// the async extraction + consolidation passes that Phase 1 runs at REPL
+// startup, moving them off the user's hot path. When the daemon is
+// offline, the chat path falls back to Phase 1 — memory still works,
+// just synchronously.
+//
+// v1 scope (per c9-memory-design.md §7):
+//   - Manual `octo memoryd start` lifecycle (no auto-spawn).
+//   - Foreground process (the user runs it in a separate terminal or
+//     backgrounds via shell). No fork/setsid daemonization.
+//   - PID file at ~/.octo/memoryd.pid for start/stop/status coordination.
+//   - SIGTERM / SIGINT graceful shutdown (finishes the in-flight tick
+//     before exiting).
+//   - Windows degrades: `octo memoryd start` on Windows refuses with a
+//     clear notice and exits non-zero, mirroring the sandbox's Windows
+//     fail-soft strategy.
+//
+// PR1 (this file) wires the lifecycle plumbing without the actual work
+// loop — Tick is a placeholder that just logs and sleeps. PR2 will
+// implement the extract + consolidate logic against memory.Store +
+// agent.ExtractMemory.
+package memoryd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// DefaultTick is how often the daemon wakes up to check for work. 15s is
+// short enough that a freshly-ended chat session sees its memory extracted
+// promptly, but long enough that idle CPU cost is negligible.
+const DefaultTick = 15 * time.Second
+
+// DefaultIdleThreshold is how long a session must be quiet (no writes)
+// before the daemon considers it eligible for boundary extraction. 15
+// minutes matches the design doc's chosen default.
+const DefaultIdleThreshold = 15 * time.Minute
+
+// PIDFile returns ~/.octo/memoryd.pid. The single-user PID file is
+// sufficient for the v1 manual-start model — there's only ever one
+// memoryd per user.
+func PIDFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", fmt.Errorf("memoryd: cannot resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".octo", "memoryd.pid"), nil
+}
+
+// WritePIDFile atomically writes pid to path. Creates parent dirs as
+// needed. Uses the temp-file + rename pattern so a crash mid-write never
+// leaves a partially-written PID a peer would read as garbage.
+func WritePIDFile(path string, pid int) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strconv.Itoa(pid)), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// ReadPIDFile reads the integer PID from path. Returns the canonical
+// errors so callers can distinguish "no daemon ever started" from
+// "stale/corrupt file" — both mean "no live daemon" but the user-facing
+// status command can phrase them differently.
+func ReadPIDFile(path string) (int, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil {
+		return 0, fmt.Errorf("memoryd: pid file %s is malformed: %w", path, err)
+	}
+	if pid <= 0 {
+		return 0, fmt.Errorf("memoryd: pid file %s has invalid pid %d", path, pid)
+	}
+	return pid, nil
+}
+
+// RemovePIDFile deletes path. Idempotent — a missing file is not an
+// error (cleanup ran twice, e.g. graceful shutdown + defer).
+func RemovePIDFile(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// IsRunning probes whether a process with the given PID exists. On Unix
+// this uses `kill -0` (signal 0 = just check, don't deliver). The PID
+// must be >0 (we already validated that in ReadPIDFile).
+//
+// False positives are possible if the OS recycled the PID to an unrelated
+// process — in that case `octo memoryd start` will detect the conflict
+// when it tries to write its own PID, and `octo memoryd stop` will
+// SIGTERM the unrelated process. Acceptable for v1; a real watchdog
+// would verify the binary by reading /proc/<pid>/comm.
+func IsRunning(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// On Unix os.FindProcess never errors — the real check is Signal(0).
+	// On Windows os.FindProcess does check, but Signal isn't reliable, so
+	// daemon mode is unsupported there (see SupportedOnThisOS).
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		return false
+	}
+	return true
+}
+
+// Status describes a daemon's lifecycle state for the CLI to render.
+type Status struct {
+	PID       int       // 0 when no daemon is running
+	Running   bool      // true when the PID is alive
+	PIDFile   string    // resolved path (always populated for messaging)
+	StartedAt time.Time // file mtime of the PID file (best-effort)
+}
+
+// CheckStatus is the read-side of the lifecycle: look up the PID file,
+// see if it exists, see if the PID is alive. Used by `octo memoryd
+// status` AND by the chat side to decide whether to skip startup
+// extraction (PR3).
+func CheckStatus() (Status, error) {
+	path, err := PIDFile()
+	if err != nil {
+		return Status{}, err
+	}
+	s := Status{PIDFile: path}
+	fi, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil // no PID file → no daemon (not an error)
+		}
+		return s, err
+	}
+	s.StartedAt = fi.ModTime()
+	pid, err := ReadPIDFile(path)
+	if err != nil {
+		return s, err
+	}
+	s.PID = pid
+	s.Running = IsRunning(pid)
+	return s, nil
+}
+
+// Daemon is the long-running worker. v1 holds only the config it'll need
+// for the work loop landing in PR2; this PR's Run is a placeholder that
+// just heartbeats so the lifecycle code (start/stop/status) can be
+// exercised end-to-end.
+type Daemon struct {
+	// Tick is the work-loop period. Zero → DefaultTick.
+	Tick time.Duration
+	// IdleThreshold is how long a session must be quiet before its
+	// memories are eligible for extraction. Zero → DefaultIdleThreshold.
+	IdleThreshold time.Duration
+	// Out receives one heartbeat line per Tick when non-nil. nil silences
+	// the daemon (useful for tests that want to assert only on PID file
+	// state). Production passes os.Stdout.
+	Out io.Writer
+}
+
+// Run starts the work loop. Blocks until ctx is done (typically the CLI
+// hooks a signal-driven context to SIGTERM / SIGINT). The PID file is
+// the caller's responsibility — Run doesn't touch it so tests can
+// exercise the loop without polluting the real ~/.octo/memoryd.pid.
+//
+// PR1 placeholder: each tick writes a heartbeat line. PR2 replaces the
+// inner body with the extract + consolidate work.
+func (d *Daemon) Run(ctx context.Context) error {
+	tick := d.Tick
+	if tick <= 0 {
+		tick = DefaultTick
+	}
+	d.logf("memoryd: started (tick=%s, idle_threshold=%s)\n", tick, d.idleThreshold())
+
+	// First tick fires immediately so the user sees the heartbeat without
+	// waiting a full period. Then subsequent ticks honor the interval.
+	d.doTick()
+	t := time.NewTicker(tick)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.logf("memoryd: stopping (%v)\n", ctx.Err())
+			return ctx.Err()
+		case <-t.C:
+			d.doTick()
+		}
+	}
+}
+
+// doTick is the per-tick work. PR1: just heartbeats. PR2: extract +
+// consolidate.
+func (d *Daemon) doTick() {
+	d.logf("memoryd: tick @ %s\n", time.Now().UTC().Format(time.RFC3339))
+}
+
+func (d *Daemon) idleThreshold() time.Duration {
+	if d.IdleThreshold > 0 {
+		return d.IdleThreshold
+	}
+	return DefaultIdleThreshold
+}
+
+func (d *Daemon) logf(format string, args ...any) {
+	if d.Out == nil {
+		return
+	}
+	fmt.Fprintf(d.Out, format, args...)
+}
+
+// SupportedOnThisOS reports whether the current platform supports the
+// daemon. Windows is unsupported in v1 (see package doc); on those
+// platforms the CLI surface refuses with a clear notice.
+var SupportedOnThisOS = supportedOnThisOS
+
+// errPidFileExists is the sentinel ReserveStart returns when another
+// daemon is already running. CLI maps it to a friendly message.
+var errPidFileExists = errors.New("memoryd: another daemon is already running")
+
+// IsAlreadyRunning reports whether err came from ReserveStart and means
+// "PID file claims a live daemon".
+func IsAlreadyRunning(err error) bool { return errors.Is(err, errPidFileExists) }
+
+// ReserveStart atomically claims the PID file for the current process.
+// If the file already exists AND its PID is alive, returns
+// errPidFileExists (use IsAlreadyRunning to detect). Stale PID files
+// (the recorded PID is dead) are overwritten — convenient for the
+// common case where the daemon crashed without cleanup.
+func ReserveStart() (path string, err error) {
+	path, err = PIDFile()
+	if err != nil {
+		return "", err
+	}
+	if pid, err := ReadPIDFile(path); err == nil {
+		if IsRunning(pid) {
+			return "", fmt.Errorf("%w (pid %d)", errPidFileExists, pid)
+		}
+		// Stale → fall through and overwrite.
+	}
+	if err := WritePIDFile(path, os.Getpid()); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/internal/memoryd/memoryd_test.go
+++ b/internal/memoryd/memoryd_test.go
@@ -93,6 +93,9 @@ func TestRemovePIDFile_IdempotentOnMissing(t *testing.T) {
 // ── IsRunning ────────────────────────────────────────────────────────────
 
 func TestIsRunning_CurrentProcess(t *testing.T) {
+	if !SupportedOnThisOS() {
+		t.Skip("PID probing isn't supported on this OS — IsRunning returns false structurally")
+	}
 	if !IsRunning(os.Getpid()) {
 		t.Error("our own PID should be reported as Running")
 	}
@@ -129,6 +132,9 @@ func TestCheckStatus_NoPIDFileNotAnError(t *testing.T) {
 }
 
 func TestCheckStatus_AlivePID(t *testing.T) {
+	if !SupportedOnThisOS() {
+		t.Skip("daemon model not supported on this OS")
+	}
 	fakeHome(t)
 	path, _ := PIDFile()
 	if err := WritePIDFile(path, os.Getpid()); err != nil {
@@ -185,6 +191,9 @@ func TestReserveStart_FreshHomeSucceeds(t *testing.T) {
 }
 
 func TestReserveStart_AlreadyRunningRefuses(t *testing.T) {
+	if !SupportedOnThisOS() {
+		t.Skip("daemon model not supported on this OS — IsRunning always returns false there, so 'already running' never triggers")
+	}
 	fakeHome(t)
 	path, _ := PIDFile()
 	if err := WritePIDFile(path, os.Getpid()); err != nil {

--- a/internal/memoryd/memoryd_test.go
+++ b/internal/memoryd/memoryd_test.go
@@ -1,0 +1,272 @@
+package memoryd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeHome redirects $HOME to a tempdir for the duration of t. Returns
+// the directory. Lets PID-file helpers use the package's real
+// resolution path while pointing at scratch space.
+func fakeHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	return dir
+}
+
+// ── PID file ─────────────────────────────────────────────────────────────
+
+func TestPIDFile_ResolvesUnderOctoHome(t *testing.T) {
+	dir := fakeHome(t)
+	got, err := PIDFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, ".octo", "memoryd.pid")
+	if got != want {
+		t.Errorf("PIDFile = %q, want %q", got, want)
+	}
+}
+
+func TestWriteAndReadPIDFile_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "memoryd.pid") // exercises mkdir
+	if err := WritePIDFile(path, 12345); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPIDFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 12345 {
+		t.Errorf("ReadPIDFile = %d, want 12345", got)
+	}
+}
+
+func TestWritePIDFile_AtomicNoTempLeak(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "memoryd.pid")
+	if err := WritePIDFile(path, 1); err != nil {
+		t.Fatal(err)
+	}
+	ents, _ := os.ReadDir(dir)
+	for _, e := range ents {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file leaked after WritePIDFile: %s", e.Name())
+		}
+	}
+}
+
+func TestReadPIDFile_MissingErrors(t *testing.T) {
+	if _, err := ReadPIDFile(filepath.Join(t.TempDir(), "absent.pid")); err == nil {
+		t.Error("missing PID file should error")
+	}
+}
+
+func TestReadPIDFile_MalformedErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "memoryd.pid")
+	for _, body := range []string{"", "not-a-number", "0", "-3"} {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReadPIDFile(path); err == nil {
+			t.Errorf("body %q should error", body)
+		}
+	}
+}
+
+func TestRemovePIDFile_IdempotentOnMissing(t *testing.T) {
+	if err := RemovePIDFile(filepath.Join(t.TempDir(), "absent.pid")); err != nil {
+		t.Errorf("removing a missing PID file should be a no-op, got %v", err)
+	}
+}
+
+// ── IsRunning ────────────────────────────────────────────────────────────
+
+func TestIsRunning_CurrentProcess(t *testing.T) {
+	if !IsRunning(os.Getpid()) {
+		t.Error("our own PID should be reported as Running")
+	}
+}
+
+func TestIsRunning_InvalidPIDsFalse(t *testing.T) {
+	for _, pid := range []int{0, -1, -99999} {
+		if IsRunning(pid) {
+			t.Errorf("IsRunning(%d) should be false", pid)
+		}
+	}
+}
+
+func TestIsRunning_VeryHighPIDFalse(t *testing.T) {
+	// 2^31 - 1 is well above any realistic PID range; the OS may
+	// theoretically have it but it's a useful negative signal in
+	// practice.
+	if IsRunning(2_000_000_000) {
+		t.Skip("PID 2_000_000_000 is in use on this system — skipping")
+	}
+}
+
+// ── CheckStatus ──────────────────────────────────────────────────────────
+
+func TestCheckStatus_NoPIDFileNotAnError(t *testing.T) {
+	fakeHome(t)
+	s, err := CheckStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.PID != 0 || s.Running {
+		t.Errorf("no PID file → zero status, got %+v", s)
+	}
+}
+
+func TestCheckStatus_AlivePID(t *testing.T) {
+	fakeHome(t)
+	path, _ := PIDFile()
+	if err := WritePIDFile(path, os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	s, err := CheckStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.Running {
+		t.Errorf("our own PID should be Running, got %+v", s)
+	}
+	if s.StartedAt.IsZero() {
+		t.Error("StartedAt should reflect the PID file mtime")
+	}
+}
+
+func TestCheckStatus_StalePID(t *testing.T) {
+	fakeHome(t)
+	path, _ := PIDFile()
+	// PID 1 always exists on Unix (init), so use a guaranteed-not-running
+	// negative... wait, ReadPIDFile rejects negatives. Use the
+	// "very high PID" heuristic instead.
+	if err := WritePIDFile(path, 2_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	s, err := CheckStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Running {
+		t.Skipf("PID %d happens to be alive on this system — skipping", s.PID)
+	}
+	if s.PID != 2_000_000_000 {
+		t.Errorf("PID = %d, want 2_000_000_000", s.PID)
+	}
+}
+
+// ── ReserveStart ─────────────────────────────────────────────────────────
+
+func TestReserveStart_FreshHomeSucceeds(t *testing.T) {
+	fakeHome(t)
+	path, err := ReserveStart()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("ReserveStart should have created the PID file: %v", err)
+	}
+	pid, _ := ReadPIDFile(path)
+	if pid != os.Getpid() {
+		t.Errorf("PID file = %d, want %d", pid, os.Getpid())
+	}
+}
+
+func TestReserveStart_AlreadyRunningRefuses(t *testing.T) {
+	fakeHome(t)
+	path, _ := PIDFile()
+	if err := WritePIDFile(path, os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ReserveStart()
+	if err == nil {
+		t.Fatal("ReserveStart should refuse when a live daemon's PID is already on file")
+	}
+	if !IsAlreadyRunning(err) {
+		t.Errorf("error should be IsAlreadyRunning, got %v (type %T)", err, err)
+	}
+}
+
+func TestReserveStart_StalePIDOverwritten(t *testing.T) {
+	fakeHome(t)
+	path, _ := PIDFile()
+	if err := WritePIDFile(path, 2_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	if IsRunning(2_000_000_000) {
+		t.Skip("very-high PID happens to be alive — can't simulate stale")
+	}
+	if _, err := ReserveStart(); err != nil {
+		t.Errorf("stale PID file should be overwritten, got %v", err)
+	}
+	pid, _ := ReadPIDFile(path)
+	if pid != os.Getpid() {
+		t.Errorf("stale PID not overwritten: %d, want %d", pid, os.Getpid())
+	}
+}
+
+func TestIsAlreadyRunning_DistinguishesOtherErrors(t *testing.T) {
+	if IsAlreadyRunning(errors.New("unrelated")) {
+		t.Error("IsAlreadyRunning should not match arbitrary errors")
+	}
+}
+
+// ── Daemon.Run lifecycle ────────────────────────────────────────────────
+
+func TestDaemonRun_ExitsOnCtxCancel(t *testing.T) {
+	var out bytes.Buffer
+	d := &Daemon{Tick: 20 * time.Millisecond, Out: &out}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	// Let at least one tick happen then cancel.
+	time.Sleep(40 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Run should return ctx.Err(), got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Daemon did not stop after ctx cancel")
+	}
+	if !strings.Contains(out.String(), "tick") {
+		t.Errorf("expected at least one tick heartbeat:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "stopping") {
+		t.Errorf("shutdown notice missing:\n%s", out.String())
+	}
+}
+
+func TestDaemonRun_HonoursDefaultTick(t *testing.T) {
+	d := &Daemon{Out: nil} // no Out + no Tick → uses defaults; just verify
+	// we can construct + cancel without hangs.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := d.Run(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Run should propagate ctx.Err(), got %v", err)
+	}
+}
+
+// ── Platform support ────────────────────────────────────────────────────
+
+func TestSupportedOnThisOS(t *testing.T) {
+	// On the build target running this test, we just verify the
+	// function compiles + returns something. The platform-specific
+	// assertion lives in the per-OS file.
+	_ = SupportedOnThisOS()
+}

--- a/internal/memoryd/supported_unix.go
+++ b/internal/memoryd/supported_unix.go
@@ -2,7 +2,22 @@
 
 package memoryd
 
+import (
+	"os"
+	"syscall"
+)
+
 // supportedOnThisOS reports whether the daemon model works on this OS.
 // Unix-like systems support the foreground-process + PID-file model
 // memoryd v1 uses (Signal(0) probes, SIGTERM-driven shutdown).
 func supportedOnThisOS() bool { return true }
+
+// isRunning probes the PID via signal 0 (`kill -0`), the standard Unix
+// "is this PID alive?" test that doesn't actually deliver a signal.
+func isRunning(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/internal/memoryd/supported_unix.go
+++ b/internal/memoryd/supported_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package memoryd
+
+// supportedOnThisOS reports whether the daemon model works on this OS.
+// Unix-like systems support the foreground-process + PID-file model
+// memoryd v1 uses (Signal(0) probes, SIGTERM-driven shutdown).
+func supportedOnThisOS() bool { return true }

--- a/internal/memoryd/supported_windows.go
+++ b/internal/memoryd/supported_windows.go
@@ -8,3 +8,10 @@ package memoryd
 // notice; chat-side memory falls back to the Phase 1 startup path on
 // Windows automatically. Matches the sandbox's Windows fail-soft.
 func supportedOnThisOS() bool { return false }
+
+// isRunning is structurally false on Windows — the daemon is
+// unsupported, so "no daemon ever running" is the correct answer for
+// every caller. CheckStatus + ReserveStart degrade accordingly:
+// status reports "stale" for any PID file that exists, ReserveStart
+// happily overwrites whatever's on disk.
+func isRunning(_ int) bool { return false }

--- a/internal/memoryd/supported_windows.go
+++ b/internal/memoryd/supported_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package memoryd
+
+// supportedOnThisOS reports false on Windows. The v1 daemon relies on
+// Signal(0) PID probes + SIGTERM graceful shutdown, neither of which
+// behave reliably on Windows. The CLI surface refuses with a clear
+// notice; chat-side memory falls back to the Phase 1 startup path on
+// Windows automatically. Matches the sandbox's Windows fail-soft.
+func supportedOnThisOS() bool { return false }


### PR DESCRIPTION
## Summary

First slice of **C9 Phase 2** (cross-session memory daemon). Wires the process-lifecycle plumbing — PID file management, start/stop/status subcommands, SIGTERM graceful shutdown — without the actual work yet. PR2 will plug the extract + consolidate loops into `Daemon.doTick`.

### `internal/memoryd/` (new package)

- `PIDFile()` resolves `~/.octo/memoryd.pid`.
- `WritePIDFile` uses the temp-file + rename pattern (atomic on POSIX), so a crash mid-write never leaves a half-written PID. Idempotent `RemovePIDFile`.
- `ReadPIDFile` parses + sanity-checks; malformed / zero / negative PIDs error.
- `IsRunning` probes via `os.FindProcess` + `Signal(0)` — the standard Unix "is this PID alive?" check.
- `CheckStatus` is the read-only side: handles missing pidfile, stale (PID dead) pidfile, and the alive case in one struct.
- `ReserveStart` atomically claims the PID file. Refuses (via `IsAlreadyRunning` sentinel) if a live daemon is already on file; overwrites a stale one.
- `Daemon` struct + `Run` loop. v1 placeholder: each tick logs a heartbeat. Ticker fires immediately so the user sees the first heartbeat without waiting a full period.
- **Build-tagged `SupportedOnThisOS`**: Unix → true, Windows → false (the Signal(0) probe + SIGTERM model doesn't translate). Mirrors the sandbox's Windows fail-soft.

### `cmd/octo/memoryd.go` (new)

```
octo memoryd start    Run the daemon in the foreground (Ctrl-C / SIGTERM to stop).
octo memoryd stop     SIGTERM the running daemon (reads ~/.octo/memoryd.pid).
octo memoryd status   Report whether a daemon is running and where its PID file is.
```

`start` ReserveStarts → hooks SIGTERM/SIGINT → `Daemon.Run` blocks until shutdown → cleanup. Foreground process per design — no fork/setsid. `stop` SIGTERMs the PID (clears stale pidfiles gracefully). `status` prints not-running / stale / running with uptime + pidfile path.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [x] `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
- [x] ~280 lines of tests covering: PID file round-trip + no-temp-leak + missing/malformed-body errors, `IsRunning` for our own PID + invalid PIDs, `CheckStatus` (no-pidfile / alive / stale), `ReserveStart` (fresh / already-running refusal / stale-overwrite), `IsAlreadyRunning` sentinel discrimination, `Daemon.Run` ctx-cancel exit + default tick. CLI tests cover usage / unknown / help, status (all three states), stop (no-daemon + stale clears file), start refuses when already-running. Tests skip cleanly on Windows or when high-PID happens to be alive.

## Up next
- **PR2**: plug `agent.ExtractMemory` + consolidation into `Daemon.doTick`. Provider config from env (same source as chat); refuses to start without an API key.
- **PR3**: chat side detects memoryd via `CheckStatus`, skips the Phase 1 startup memory pass when it's alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)