### PR TITLE
feat(memoryd): C9 Phase 2 PR2 — extract + consolidate work loop

### DIFF
--- a/cmd/octo/memoryd.go
+++ b/cmd/octo/memoryd.go
@@ -65,6 +65,16 @@ func runMemorydStart(stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// Build the work function BEFORE claiming the PID file so a config
+	// error (missing API key) fails fast and doesn't leave a stale
+	// "started then exited" pidfile to confuse the next start.
+	idleThreshold := memoryd.DefaultIdleThreshold
+	work, err := buildMemorydWork(stderr, idleThreshold)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
 	pidPath, err := memoryd.ReserveStart()
 	if err != nil {
 		if memoryd.IsAlreadyRunning(err) {
@@ -84,7 +94,7 @@ func runMemorydStart(stdout, stderr io.Writer) int {
 	ctx, cancel := signalContext(context.Background())
 	defer cancel()
 
-	d := &memoryd.Daemon{Out: stdout}
+	d := &memoryd.Daemon{Out: stdout, IdleThreshold: idleThreshold, Work: work}
 	err = d.Run(ctx)
 	// ctx.Canceled is the graceful path (SIGTERM/SIGINT delivered →
 	// signalContext cancelled the ctx → Run returned ctx.Err()).

--- a/cmd/octo/memoryd_test.go
+++ b/cmd/octo/memoryd_test.go
@@ -137,6 +137,10 @@ func TestRunMemorydStart_RefusesIfAlreadyRunning(t *testing.T) {
 		t.Skip("memoryd not supported on this OS")
 	}
 	fakeHomeForMemoryd(t)
+	// Provider check runs first; satisfy it so we reach the PID-file
+	// check this test actually cares about.
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	t.Setenv("OPENAI_API_KEY", "")
 	// Pretend a daemon is already up (our own PID).
 	pidPath, _ := memoryd.PIDFile()
 	if err := memoryd.WritePIDFile(pidPath, os.Getpid()); err != nil {
@@ -148,5 +152,27 @@ func TestRunMemorydStart_RefusesIfAlreadyRunning(t *testing.T) {
 	}
 	if !strings.Contains(errBuf.String(), "already running") {
 		t.Errorf("start should refuse with 'already running':\n%s", errBuf.String())
+	}
+}
+
+func TestRunMemorydStart_RefusesWithoutAPIKey(t *testing.T) {
+	if !memoryd.SupportedOnThisOS() {
+		t.Skip("memoryd not supported on this OS")
+	}
+	fakeHomeForMemoryd(t)
+	t.Setenv("OCTO_MEMORYD_PROVIDER", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	var out, errBuf bytes.Buffer
+	if code := runMemoryd([]string{"start"}, nil, &out, &errBuf); code != 1 {
+		t.Errorf("start without keys exit = %d, want 1; stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "ANTHROPIC_API_KEY") {
+		t.Errorf("start should name the missing env var:\n%s", errBuf.String())
+	}
+	// Critically: no PID file should have been written.
+	pidPath, _ := memoryd.PIDFile()
+	if _, err := os.Stat(pidPath); err == nil {
+		t.Errorf("PID file should NOT exist after a config-error refusal")
 	}
 }

--- a/cmd/octo/memoryd_work.go
+++ b/cmd/octo/memoryd_work.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/memory"
+	"github.com/Leihb/octo-agent/internal/memoryd"
+)
+
+// buildMemorydWork assembles the daemon's per-tick work function: build
+// a provider from the environment (refusing if neither key is set),
+// stand up an agent + memory store, and return a closure that on each
+// tick extracts from one idle session + runs consolidateIfDue.
+//
+// The function is built ONCE, before the daemon's signal handler is
+// wired, so a missing-key error fails fast with a clear message
+// rather than after the user has already seen "started".
+func buildMemorydWork(stderr io.Writer, idleThreshold time.Duration) (memoryd.WorkFn, error) {
+	provName := pickMemorydProvider()
+	if provName == "" {
+		return nil, errors.New("octo memoryd: set ANTHROPIC_API_KEY or OPENAI_API_KEY before starting (no chat-side provider config to inherit)")
+	}
+	prov, err := buildProvider(provName, stderr)
+	if err != nil {
+		return nil, err
+	}
+	modelName := defaultModels[provName]
+
+	store, err := memory.NewStore()
+	if err != nil {
+		return nil, fmt.Errorf("octo memoryd: memory store: %w", err)
+	}
+
+	a := agent.New(providerSender{p: prov, cacheKey: newCacheKey()}, modelName)
+	a.MaxTokens = 4096
+
+	return func(ctx context.Context) error {
+		st := store.LoadState()
+		extractIdleSession(ctx, a, store, stderr, idleThreshold, &st)
+		consolidateIfDue(ctx, a, store, &st)
+		return store.SaveState(st)
+	}, nil
+}
+
+// pickMemorydProvider chooses which provider the daemon should use,
+// based on which credential is present in the environment. An explicit
+// OCTO_MEMORYD_PROVIDER env var wins when set (lets the user pin to a
+// specific backend even when both keys are present, e.g. running
+// chat against Anthropic but memoryd against a cheaper OpenAI model).
+// Returns "" when no usable provider is configured.
+func pickMemorydProvider() string {
+	if v := os.Getenv("OCTO_MEMORYD_PROVIDER"); v != "" {
+		return v
+	}
+	if os.Getenv("ANTHROPIC_API_KEY") != "" {
+		return providerAnthropic
+	}
+	if os.Getenv("OPENAI_API_KEY") != "" {
+		return providerOpenAI
+	}
+	return ""
+}
+
+// extractIdleSession finds the newest session that is (a) quiet for at
+// least idleThreshold and (b) not yet extracted, and runs the extract
+// pass against it. Only ONE session per tick by design — the next tick
+// catches up on the rest, and keeping the per-tick work small means
+// SIGTERM never finds the daemon mid-extract for too long.
+//
+// "Quiet" means the session file's mtime is older than now - threshold.
+// The chat path mutates the session file on every turn (append-only
+// JSONL), so a recent mtime is a strong signal that a human or another
+// agent is still typing — the daemon defers extraction so a still-live
+// session's transcript doesn't get extracted mid-flight.
+func extractIdleSession(ctx context.Context, a *agent.Agent, store *memory.Store, stderr io.Writer, idleThreshold time.Duration, st *memory.State) {
+	sessions, err := agent.ListSessions(memorydSessionsWindow)
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	for _, sess := range sessions {
+		// Hit the boundary: this session and everything older are already
+		// extracted (the cursor advances monotonically per session
+		// timestamp, so anything before LastExtractedSession is done).
+		if sess.ID == st.LastExtractedSession {
+			return
+		}
+		if sess.TurnCount() == 0 {
+			continue
+		}
+		mtime, err := agent.SessionMTime(sess.ID)
+		if err != nil {
+			continue
+		}
+		if now.Sub(mtime) < idleThreshold {
+			continue // still active — defer
+		}
+
+		// Eligible — extract.
+		res, err := a.ExtractMemory(ctx, sess.ToHistory().Snapshot())
+		if err != nil {
+			fmt.Fprintf(stderr, "octo memoryd: extract %s: %v\n", sess.ID, err)
+			return
+		}
+		n := 0
+		for _, f := range res.Facts {
+			if serr := store.Save(memory.Entry{
+				Description: f.Description,
+				Type:        memory.Type(f.Type),
+				Body:        f.Content,
+			}); serr == nil {
+				n++
+			}
+		}
+		slug := res.Slug
+		if slug == "" {
+			slug = sess.ID
+		}
+		_ = store.SaveRolloutSummary(slug, res.Summary)
+		st.LastExtractedSession = sess.ID
+
+		if n > 0 || res.Summary != "" {
+			fmt.Fprintf(stderr, "octo memoryd: extracted %d fact(s) from %s\n", n, sess.ID)
+		}
+		return // one session per tick
+	}
+}
+
+// memorydSessionsWindow caps how far back the daemon looks for un-
+// extracted sessions per tick. Larger than the chat-side window (which
+// is 2) because the daemon is the catch-up path: if a user started
+// many sessions while the daemon was off, the daemon needs a fatter
+// window to walk back through them. 20 is generous without making
+// the per-tick filesystem scan expensive.
+const memorydSessionsWindow = 20

--- a/cmd/octo/memoryd_work_test.go
+++ b/cmd/octo/memoryd_work_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/memory"
+	"github.com/Leihb/octo-agent/internal/memoryd"
+)
+
+// ── pickMemorydProvider ─────────────────────────────────────────────────
+
+func TestPickMemorydProvider_AnthropicOnly(t *testing.T) {
+	t.Setenv("OCTO_MEMORYD_PROVIDER", "")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	t.Setenv("OPENAI_API_KEY", "")
+	if got := pickMemorydProvider(); got != providerAnthropic {
+		t.Errorf("Anthropic only → %q, want %q", got, providerAnthropic)
+	}
+}
+
+func TestPickMemorydProvider_OpenAIOnly(t *testing.T) {
+	t.Setenv("OCTO_MEMORYD_PROVIDER", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	if got := pickMemorydProvider(); got != providerOpenAI {
+		t.Errorf("OpenAI only → %q, want %q", got, providerOpenAI)
+	}
+}
+
+func TestPickMemorydProvider_AnthropicWinsWhenBothSet(t *testing.T) {
+	t.Setenv("OCTO_MEMORYD_PROVIDER", "")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-anth")
+	t.Setenv("OPENAI_API_KEY", "sk-oai")
+	if got := pickMemorydProvider(); got != providerAnthropic {
+		t.Errorf("both set → Anthropic wins (alphabetical preference); got %q", got)
+	}
+}
+
+func TestPickMemorydProvider_ExplicitOverride(t *testing.T) {
+	t.Setenv("OCTO_MEMORYD_PROVIDER", providerOpenAI)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-anth") // would normally win
+	t.Setenv("OPENAI_API_KEY", "sk-oai")
+	if got := pickMemorydProvider(); got != providerOpenAI {
+		t.Errorf("explicit override should beat both keys; got %q", got)
+	}
+}
+
+func TestPickMemorydProvider_NeitherKeySet(t *testing.T) {
+	t.Setenv("OCTO_MEMORYD_PROVIDER", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	if got := pickMemorydProvider(); got != "" {
+		t.Errorf("no keys → empty; got %q", got)
+	}
+}
+
+// ── buildMemorydWork ────────────────────────────────────────────────────
+
+func TestBuildMemorydWork_RefusesWithoutKeys(t *testing.T) {
+	t.Setenv("OCTO_MEMORYD_PROVIDER", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	fakeHomeForMemoryd(t)
+
+	var errBuf bytes.Buffer
+	work, err := buildMemorydWork(&errBuf, memoryd.DefaultIdleThreshold)
+	if err == nil {
+		t.Fatal("buildMemorydWork should refuse without API keys")
+	}
+	if !strings.Contains(err.Error(), "ANTHROPIC_API_KEY") {
+		t.Errorf("error should name the missing env var: %v", err)
+	}
+	if work != nil {
+		t.Error("WorkFn should be nil when buildMemorydWork errors")
+	}
+}
+
+// ── Daemon.Work plumbing ────────────────────────────────────────────────
+
+func TestDaemon_WorkCalledEachTick(t *testing.T) {
+	var called int
+	work := memoryd.WorkFn(func(_ context.Context) error {
+		called++
+		return nil
+	})
+	d := &memoryd.Daemon{Tick: 20 * time.Millisecond, Work: work}
+	ctx, cancel := context.WithTimeout(context.Background(), 70*time.Millisecond)
+	defer cancel()
+	_ = d.Run(ctx)
+	if called < 2 {
+		t.Errorf("expected ≥2 work calls in 70ms with 20ms tick, got %d", called)
+	}
+}
+
+func TestDaemon_WorkErrorLoggedNotFatal(t *testing.T) {
+	work := memoryd.WorkFn(func(_ context.Context) error {
+		return errFake
+	})
+	var out bytes.Buffer
+	d := &memoryd.Daemon{Tick: 20 * time.Millisecond, Work: work, Out: &out}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_ = d.Run(ctx)
+	if !strings.Contains(out.String(), "tick error: fake error") {
+		t.Errorf("tick error should be logged:\n%s", out.String())
+	}
+}
+
+var errFake = &fakeErr{}
+
+type fakeErr struct{}
+
+func (e *fakeErr) Error() string { return "fake error" }
+
+// ── extractIdleSession ──────────────────────────────────────────────────
+
+// memorydStubSender returns a canned ExtractMemory reply (three-piece
+// object) so extractIdleSession has something to persist.
+type memorydStubSender struct{ reply string }
+
+func (s *memorydStubSender) SendMessages(_ context.Context, _, _ string, _ []agent.Message, _ int) (agent.Reply, error) {
+	return agent.Reply{Content: s.reply, InputTokens: 1, OutputTokens: 1}, nil
+}
+
+func TestExtractIdleSession_SkipsActiveSession(t *testing.T) {
+	dir := fakeHomeForMemoryd(t)
+	// Make a session whose mtime is now (active — within threshold).
+	id := writeFakeSession(t, dir, time.Now())
+
+	store := memory.NewStoreAt(filepath.Join(dir, ".octo", "memory"))
+	a := agent.New(&memorydStubSender{reply: `{"facts":[]}`}, "test-model")
+	st := memory.State{}
+	var stderr bytes.Buffer
+	extractIdleSession(context.Background(), a, store, &stderr, time.Hour, &st)
+
+	if st.LastExtractedSession == id {
+		t.Errorf("active session should NOT have been extracted, got cursor=%s", st.LastExtractedSession)
+	}
+}
+
+func TestExtractIdleSession_ExtractsQuietSession(t *testing.T) {
+	dir := fakeHomeForMemoryd(t)
+	// Make a session whose mtime is 2 hours ago (well past threshold).
+	id := writeFakeSession(t, dir, time.Now().Add(-2*time.Hour))
+
+	store := memory.NewStoreAt(filepath.Join(dir, ".octo", "memory"))
+	reply := `{"rollout_slug":"x","rollout_summary":"# done","facts":[{"type":"user","description":"d","content":"c"}]}`
+	a := agent.New(&memorydStubSender{reply: reply}, "test-model")
+	st := memory.State{}
+	var stderr bytes.Buffer
+	extractIdleSession(context.Background(), a, store, &stderr, time.Hour, &st)
+
+	if st.LastExtractedSession != id {
+		t.Errorf("quiet session should have been extracted; cursor=%s want %s", st.LastExtractedSession, id)
+	}
+	entries, _ := store.List()
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry persisted, got %d", len(entries))
+	}
+}
+
+func TestExtractIdleSession_StopsAtCursor(t *testing.T) {
+	dir := fakeHomeForMemoryd(t)
+	id1 := writeFakeSession(t, dir, time.Now().Add(-2*time.Hour))
+
+	store := memory.NewStoreAt(filepath.Join(dir, ".octo", "memory"))
+	// Cursor already at id1 → extractIdleSession returns without doing
+	// anything.
+	st := memory.State{LastExtractedSession: id1}
+	a := agent.New(&memorydStubSender{reply: `{"facts":[]}`}, "test-model")
+	var stderr bytes.Buffer
+	extractIdleSession(context.Background(), a, store, &stderr, time.Hour, &st)
+
+	if st.LastExtractedSession != id1 {
+		t.Errorf("cursor should be unchanged when nothing new; got %s", st.LastExtractedSession)
+	}
+	entries, _ := store.List()
+	if len(entries) != 0 {
+		t.Errorf("no entries should be persisted; got %d", len(entries))
+	}
+}
+
+// writeFakeSession creates a session JSONL file under
+// ~/.octo/sessions/ with the given mtime and a single user/assistant
+// turn so TurnCount > 0. Returns the session id.
+func writeFakeSession(t *testing.T, home string, mtime time.Time) string {
+	t.Helper()
+	sess := agent.NewSession("test-model", "")
+	h := agent.NewHistory()
+	h.Append(agent.NewUserMessage("hi"))
+	h.Append(agent.NewAssistantMessage("hello"))
+	sess.SyncFrom(h)
+	if err := sess.Save(); err != nil {
+		t.Fatal(err)
+	}
+	// Locate the session file and chtime it.
+	sessDir := filepath.Join(home, ".octo", "sessions")
+	matches, err := filepath.Glob(filepath.Join(sessDir, sess.ID+"*.jsonl"))
+	if err != nil || len(matches) == 0 {
+		t.Fatalf("session file not found under %s", sessDir)
+	}
+	if err := os.Chtimes(matches[0], mtime, mtime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	return sess.ID
+}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -239,6 +239,23 @@ func resolveSessionPath(id string) (string, error) {
 	return filepath.Join(dir, id+".jsonl"), nil
 }
 
+// SessionMTime returns the file mtime of the session whose id is given.
+// Used by the C9 Phase 2 memory daemon to gate "is this session quiet
+// long enough to safely run boundary extraction" — the chat path
+// updates the session file on every turn, so a recent mtime means the
+// user is still actively chatting and the daemon should defer.
+func SessionMTime(id string) (time.Time, error) {
+	p, err := resolveSessionPath(id)
+	if err != nil {
+		return time.Time{}, err
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return info.ModTime(), nil
+}
+
 // ListSessions returns up to n most-recently-modified sessions from
 // ~/.octo/sessions/, newest first (by file mtime).
 func ListSessions(n int) ([]*Session, error) {

--- a/internal/memoryd/memoryd.go
+++ b/internal/memoryd/memoryd.go
@@ -153,20 +153,42 @@ func CheckStatus() (Status, error) {
 	return s, nil
 }
 
-// Daemon is the long-running worker. v1 holds only the config it'll need
-// for the work loop landing in PR2; this PR's Run is a placeholder that
-// just heartbeats so the lifecycle code (start/stop/status) can be
-// exercised end-to-end.
+// WorkFn is the per-tick callback the Daemon invokes. Implementations
+// live outside this package (cmd/octo wires the real one against
+// internal/agent + internal/memory) so memoryd stays free of agent /
+// memory / tools dependencies — same dependency discipline as the M11
+// scheduler's Executor interface.
+//
+// A WorkFn should be short-lived per call (one tick should complete in
+// well under the daemon's tick interval). The daemon doesn't enforce a
+// timeout; the ctx the work receives is the daemon's lifecycle ctx, so
+// a SIGTERM / SIGINT propagates and the work should honor it promptly.
+//
+// Errors are logged via Daemon.Out but don't stop the loop — a
+// transient extract failure shouldn't take down the daemon for the
+// rest of the session.
+type WorkFn func(ctx context.Context) error
+
+// Daemon is the long-running worker. The lifecycle (PID file, signal
+// handler, tick loop) lives here; the actual work — extracting memories
+// from finished sessions, consolidating when due — comes in via Work.
 type Daemon struct {
 	// Tick is the work-loop period. Zero → DefaultTick.
 	Tick time.Duration
 	// IdleThreshold is how long a session must be quiet before its
 	// memories are eligible for extraction. Zero → DefaultIdleThreshold.
+	// Pass-through value — the daemon doesn't consume it directly, but
+	// it's the natural place to keep the config so WorkFn can read it
+	// via the surrounding closure if needed.
 	IdleThreshold time.Duration
-	// Out receives one heartbeat line per Tick when non-nil. nil silences
-	// the daemon (useful for tests that want to assert only on PID file
-	// state). Production passes os.Stdout.
+	// Out receives lifecycle + heartbeat lines (start, stop, tick errors)
+	// when non-nil. nil silences the daemon (useful for tests).
 	Out io.Writer
+	// Work is the per-tick callback. If nil, the daemon emits a heartbeat
+	// only — useful for the PR1-era smoke tests that just exercise the
+	// lifecycle. cmd/octo wires the real extract + consolidate function
+	// in production.
+	Work WorkFn
 }
 
 // Run starts the work loop. Blocks until ctx is done (typically the CLI
@@ -174,8 +196,9 @@ type Daemon struct {
 // the caller's responsibility — Run doesn't touch it so tests can
 // exercise the loop without polluting the real ~/.octo/memoryd.pid.
 //
-// PR1 placeholder: each tick writes a heartbeat line. PR2 replaces the
-// inner body with the extract + consolidate work.
+// The first tick fires immediately so a freshly-started daemon catches
+// up on any quiet-and-unextracted sessions without making the user wait
+// a full Tick interval.
 func (d *Daemon) Run(ctx context.Context) error {
 	tick := d.Tick
 	if tick <= 0 {
@@ -183,9 +206,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 	d.logf("memoryd: started (tick=%s, idle_threshold=%s)\n", tick, d.idleThreshold())
 
-	// First tick fires immediately so the user sees the heartbeat without
-	// waiting a full period. Then subsequent ticks honor the interval.
-	d.doTick()
+	d.doTick(ctx)
 	t := time.NewTicker(tick)
 	defer t.Stop()
 
@@ -195,15 +216,22 @@ func (d *Daemon) Run(ctx context.Context) error {
 			d.logf("memoryd: stopping (%v)\n", ctx.Err())
 			return ctx.Err()
 		case <-t.C:
-			d.doTick()
+			d.doTick(ctx)
 		}
 	}
 }
 
-// doTick is the per-tick work. PR1: just heartbeats. PR2: extract +
-// consolidate.
-func (d *Daemon) doTick() {
-	d.logf("memoryd: tick @ %s\n", time.Now().UTC().Format(time.RFC3339))
+// doTick runs one cycle. When Work is nil, just emits a heartbeat (the
+// pre-PR2 behavior, kept for the lifecycle smoke tests). When Work is
+// set, dispatches to it and logs any non-nil error without aborting.
+func (d *Daemon) doTick(ctx context.Context) {
+	if d.Work == nil {
+		d.logf("memoryd: tick @ %s\n", time.Now().UTC().Format(time.RFC3339))
+		return
+	}
+	if err := d.Work(ctx); err != nil && ctx.Err() == nil {
+		d.logf("memoryd: tick error: %v\n", err)
+	}
 }
 
 func (d *Daemon) idleThreshold() time.Duration {


### PR DESCRIPTION
## Summary

Plugs the real C9 work into the daemon. Each tick:
1. Picks one idle session (mtime older than the configured threshold, default 15 min) that hasn't been extracted yet.
2. Runs `agent.ExtractMemory`; persists facts + rollout summary via `memory.Store`; advances `state.LastExtractedSession`.
3. Checks `consolidateIfDue` and runs the consolidate side-call if it fires (same orchestrator Phase 1 / chat-startup uses).

**One session per tick by design**: SIGTERM never finds the daemon mid-extract for more than one session's worth of LLM time, so shutdown stays prompt. The 20-session lookback in `extractIdleSession` catches up by the second or third tick even after a long offline period.

### Files

- **`internal/memoryd/memoryd.go`** — adds `WorkFn` type + `Daemon.Work` field. Same dependency-discipline trick as M11's `Executor`: the callback lives outside the package so `internal/memoryd` stays free of `agent`/`memory`/`tools` deps. Nil Work falls back to the PR1 heartbeat (preserved for the lifecycle smoke tests). Errors from Work are logged via `Out` but don't abort the loop.
- **`internal/agent/session.go`** — `SessionMTime(id)` helper.
- **`cmd/octo/memoryd_work.go` (new)** — `buildMemorydWork` (builds provider from env or refuses), `pickMemorydProvider` (env-driven with `OCTO_MEMORYD_PROVIDER` override; Anthropic wins when both keys present), `extractIdleSession` (skips empty / still-active / already-extracted; extracts first eligible).
- **`cmd/octo/memoryd.go`** — `runMemorydStart` builds the work function **before** `ReserveStart`, so a missing-key error fails fast and doesn't leave a stale "started then exited" pidfile.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [x] `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
- [x] ~270 lines of new tests cover: `pickMemorydProvider` env matrix (Anthropic-only / OpenAI-only / both / explicit override / neither), `buildMemorydWork` refusal without keys, `Daemon.Work` plumbing (callback fires multiple times; errors logged not fatal), `extractIdleSession` e2e (skip-active / extract-quiet / stop-at-cursor with controlled-mtime fake session files), CLI fail-fast (no-API-key refusal doesn't leave a PID file).
- [ ] Live verification: `ANTHROPIC_API_KEY=… octo memoryd start` in one terminal, `octo chat` in another → end first chat → wait `>15min` → check `~/.octo/memory/` populates without a chat restart.

## Up next
- **PR3**: chat-side detects memoryd via `CheckStatus` and skips the Phase 1 startup memory pass when it's alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)