### PR TITLE
feat(c9): Phase 2 PR3 — chat skips startup memory pass when daemon is alive

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -235,7 +235,13 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// session and consolidate if due, BEFORE rendering this session's injection
 	// so freshly captured facts apply immediately rather than a session later.
 	// Skips the session being resumed. Best-effort — errors don't block startup.
-	if isREPL && memStore != nil {
+	//
+	// C9 Phase 2 coordination: if the memory daemon is alive, IT owns the
+	// extract + consolidate cadence — chat startup skips this hot-path work
+	// so the user sees an instant prompt. The daemon will catch up the just-
+	// ended previous session ~15 min later (the idle threshold), so the next
+	// fresh chat session inherits its memory naturally.
+	if isREPL && memStore != nil && !memorydAlive() {
 		maybeProcessMemory(a, memStore, stdout, resumeID)
 	}
 	var memInjection string

--- a/cmd/octo/memoryd_work.go
+++ b/cmd/octo/memoryd_work.go
@@ -139,3 +139,20 @@ func extractIdleSession(ctx context.Context, a *agent.Agent, store *memory.Store
 // window to walk back through them. 20 is generous without making
 // the per-tick filesystem scan expensive.
 const memorydSessionsWindow = 20
+
+// memorydAlive reports whether the memory daemon is currently running.
+// Used by chat startup to skip the Phase 1 in-process extract +
+// consolidate path when the daemon owns that work.
+//
+// Defensively false: any error (no PID file, malformed PID, dead PID,
+// platform without daemon support) returns false, so chat keeps doing
+// Phase 1 work and memory still ends up populated. The worst case is
+// a one-time double-extract if both paths fire — Phase 1's
+// LastExtractedSession cursor catches the second pass and no-ops it.
+var memorydAlive = func() bool {
+	status, err := memoryd.CheckStatus()
+	if err != nil {
+		return false
+	}
+	return status.Running
+}

--- a/cmd/octo/memoryd_work_test.go
+++ b/cmd/octo/memoryd_work_test.go
@@ -187,6 +187,46 @@ func TestExtractIdleSession_StopsAtCursor(t *testing.T) {
 	}
 }
 
+// ── memorydAlive (chat-side coordination) ──────────────────────────────
+
+func TestMemorydAlive_NoPIDFile(t *testing.T) {
+	fakeHomeForMemoryd(t)
+	if memorydAlive() {
+		t.Error("memorydAlive should be false when no PID file exists")
+	}
+}
+
+func TestMemorydAlive_StalePIDFile(t *testing.T) {
+	if !memoryd.SupportedOnThisOS() {
+		t.Skip("daemon model not supported on this OS")
+	}
+	fakeHomeForMemoryd(t)
+	pidPath, _ := memoryd.PIDFile()
+	if err := memoryd.WritePIDFile(pidPath, 2_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	if memoryd.IsRunning(2_000_000_000) {
+		t.Skip("PID 2_000_000_000 happens to be alive on this host")
+	}
+	if memorydAlive() {
+		t.Error("memorydAlive should be false for a stale PID")
+	}
+}
+
+func TestMemorydAlive_AlivePID(t *testing.T) {
+	if !memoryd.SupportedOnThisOS() {
+		t.Skip("daemon model not supported on this OS")
+	}
+	fakeHomeForMemoryd(t)
+	pidPath, _ := memoryd.PIDFile()
+	if err := memoryd.WritePIDFile(pidPath, os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	if !memorydAlive() {
+		t.Error("memorydAlive should be true when the recorded PID is alive (our own)")
+	}
+}
+
 // writeFakeSession creates a session JSONL file under
 // ~/.octo/sessions/ with the given mtime and a single user/assistant
 // turn so TurnCount > 0. Returns the session id.


### PR DESCRIPTION
## Summary

Third slice of **C9 Phase 2**. With `memoryd` running, chat startup becomes the fast path: no extract side-call, no consolidate side-call, no LLM round-trip before the user sees the prompt. The daemon catches up the just-ended previous session ~15 minutes later (the idle threshold), so the next fresh chat inherits its memory naturally.

### Files

- **`cmd/octo/chat.go`** — `maybeProcessMemory` now gated on `!memorydAlive()`. Other preconditions (`isREPL` + `memStore != nil`) unchanged.
- **`cmd/octo/memoryd_work.go`** — `memorydAlive` is a package-var-of-func so it can be stubbed. Defensively `false`: any error from `CheckStatus` returns false (no PID file, malformed PID, dead PID, unsupported OS). Worst case is a one-time double-extract if both paths fire — Phase 1's `LastExtractedSession` cursor catches the second pass and no-ops it.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`
- [x] `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
- [x] Tests cover `memorydAlive` (no PID file → false / stale PID → false / alive PID → true). All gated on `SupportedOnThisOS` so Windows skips cleanly.
- [ ] Live verification: `octo memoryd start` in terminal A → `octo chat` in terminal B → chat banner appears instantly (no "extracted N facts from your last session" line); kill the daemon and start chat again → the startup extract path runs as before.

## C9 Phase 2 milestone summary

Three PRs, all merged:
- **#115** — daemon core (PID file, lifecycle, start/stop/status)
- **#116** — extract + consolidate work loop
- **#117 (this)** — chat-side coordination

Roadmap acceptance from `dev-docs/c9-memory-design.md` §7:
- [x] Manual `octo memoryd start` lifecycle
- [x] PID file + SIGTERM graceful shutdown
- [x] Sessions-mtime idle detection (15min default)
- [x] flock coordination already in place from Phase 1
- [x] Windows fail-soft (chat falls back automatically)
- [ ] launchd / systemd unit files — deferred (per design doc's "MVP 手动 octo memoryd start" decision)

## Up next: C9 Phase 3
- **PR4**: pre-turn / post-turn hook mechanism (the CC-style surface Hindsight will plug into).
- **PR5**: Hindsight integration docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)