### PR TITLE
chore: cut 0.2.0, start 0.3.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased — 0.2.0-dev]
+## [Unreleased — 0.3.0-dev]
+
+_Nothing yet — the next batch of milestone work (M8 web server, M9 IM bridge, or the C9 follow-ups like launchd unit files / MCP client) will accumulate here._
+
+## [0.2.0] — 2026-05-28
+
+Adds **M11** (autonomous task orchestration) and closes **C9 Phase 2 + Phase 3** (the memory daemon and the turn-boundary hook surface for retrieval layers like Hindsight).
 
 ### Added
 - **C9 Phase 2 — memory daemon** (#115, #116, #117) — `octo memoryd start|stop|status` runs a long-lived foreground process that takes over the boundary extraction + consolidation passes the chat path runs at startup. Sessions are scanned each tick (15s default); a session whose mtime hasn't moved in 15 minutes is eligible for extraction, so the daemon never races a still-active chat. One session per tick by design — `SIGTERM` never finds the daemon mid-extract for more than one session's worth of LLM time. Provider config read from env (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OCTO_MEMORYD_PROVIDER` override); refuses to start without a key. Chat side detects the daemon via the PID file and skips the in-process memory pass, so REPL startup is effectively instant when the daemon is alive. Windows fail-soft (daemon refuses; chat keeps its Phase 1 path).

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ GOFLAGS ?=
 # pollute the reported version. Dev builds say "<next>-dev"; release builds
 # should set VERSION explicitly:
 #
-#   VERSION=0.2.0 make build
+#   VERSION=0.3.0 make build
 #
-VERSION ?= 0.2.0-dev
+VERSION ?= 0.3.0-dev
 COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 LDFLAGS := -X github.com/Leihb/octo-agent/internal/version.Version=$(VERSION) \
            -X github.com/Leihb/octo-agent/internal/version.Commit=$(COMMIT)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@
 package version
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "0.2.0-dev"
+var Version = "0.3.0-dev"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary

Tags the second numbered release. 10 PRs landed since the 0.1.0 cut at #109:

- **M11 — autonomous task orchestration** (#110/111/112/113, plus changelog #114): `octo task start "<goal>"` plans a DAG, dispatches one M10 sub-agent per ready node in parallel, fsyncs state, resumes after kill.
- **C9 Phase 2 — memory daemon** (#115/116/117): `octo memoryd start|stop|status` takes the extract + consolidate passes off the chat startup path; chat side detects via PID file and skips the in-process work when the daemon is alive.
- **C9 Phase 3 — turn-boundary hooks + Hindsight integration docs** (#118/119): pre-turn / post-turn hook surface via env vars, same shape as Claude Code's `UserPromptSubmit`; `dev-docs/c9-phase3-hindsight.md` walks through wiring Hindsight (and other retrieval layers).

### Version bumps
- `internal/version/version.go`: `0.2.0-dev` → `0.3.0-dev`
- `Makefile`: `VERSION ?= 0.2.0-dev` → `0.3.0-dev`; comment refreshed.

### CHANGELOG
- `[Unreleased — 0.2.0-dev]` → `[0.2.0] — 2026-05-28` (header + intro paragraph; the 3 entries below it are unchanged).
- Fresh `[Unreleased — 0.3.0-dev]` section at the top.

After merge, push the `v0.2.0` tag to mark the release point.

## Test plan
- [x] `make fmt-check && make vet && go test -race ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)