### PR TITLE
feat(repl): readline-backed prompt with history + multiline (UX-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased — 0.3.0-dev]
 
-_Nothing yet — the next batch of milestone work (M8 web server, M9 IM bridge, or the C9 follow-ups like launchd unit files / MCP client) will accumulate here._
+### Added
+- **REPL line editing + history (UX-1)** — `octo chat` now drives the prompt through `chzyer/readline` when stdin is an interactive terminal: up/down arrow recall a persistent history at `~/.octo/history` (override via `OCTO_HISTORY_FILE`), Ctrl-A / Ctrl-E / Ctrl-W and the usual readline editing keys work, and a trailing `\` continues the input onto a `... ` continuation line (bash-style; doubled `\\` is a literal). At an idle prompt Ctrl-C clears the line instead of exiting (use `/exit` or Ctrl-D), matching `bash` / `zsh` convention. The asker (`ask_user_question`) and the permission gate share the same line reader, so the `Other (free text)` and `allow? [y/a/N]` prompts get history + editing too. Non-tty stdin (pipes, tests, `octo chat < input.txt`) keeps the existing scanner path verbatim — no behaviour change there. First of five planned CLI-UX PRs; see `dev-docs/go-rewrite-roadmap.md` for the rest (ID shortcuts, error messages + `octo help`, status feedback + verbosity, shell completion).
 
 ## [0.2.0] — 2026-05-28
 

--- a/cmd/octo/asker.go
+++ b/cmd/octo/asker.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -13,7 +12,7 @@ import (
 
 // replAsker implements tools.Asker by prompting on the REPL's shared
 // stdin/stdout. Same plumbing as cliPermissionGate — both run synchronously
-// inside RunStream, so they share the scanner without racing on it.
+// inside RunStream, so they share the line reader without racing on it.
 //
 // UX:
 //
@@ -28,11 +27,11 @@ import (
 // "Other" tail is always added and lets the user type a free-text answer
 // instead of choosing.
 type replAsker struct {
-	in  *bufio.Scanner // shared with the REPL loop
+	in  lineReader // shared with the REPL loop
 	out io.Writer
 }
 
-func newREPLAsker(in *bufio.Scanner, out io.Writer) *replAsker {
+func newREPLAsker(in lineReader, out io.Writer) *replAsker {
 	return &replAsker{in: in, out: out}
 }
 
@@ -42,9 +41,9 @@ func (a *replAsker) Ask(_ context.Context, q tools.AskRequest) (tools.AskRespons
 		return tools.AskResponse{Cancelled: true}, nil
 	}
 
-	a.printQuestion(q)
+	prompt := a.printQuestion(q)
 
-	raw, ok := a.readLine()
+	raw, ok := a.in.ReadLine(prompt)
 	if !ok {
 		// EOF or empty submission → treat as cancellation. An empty answer
 		// to a forced-pick prompt isn't a valid selection, and surfacing
@@ -86,8 +85,7 @@ func (a *replAsker) Ask(_ context.Context, q tools.AskRequest) (tools.AskRespons
 	_ = pickedSlot
 
 	if wantOther {
-		fmt.Fprint(a.out, "  Other (free text): ")
-		text, ok := a.readLine()
+		text, ok := a.in.ReadLine("  Other (free text): ")
 		if !ok || strings.TrimSpace(text) == "" {
 			return tools.AskResponse{Cancelled: true}, nil
 		}
@@ -100,7 +98,11 @@ func (a *replAsker) Ask(_ context.Context, q tools.AskRequest) (tools.AskRespons
 	return tools.AskResponse{Choices: picks}, nil
 }
 
-func (a *replAsker) printQuestion(q tools.AskRequest) {
+// printQuestion writes the multi-line question card and returns the final
+// inline "Select [...]: " prompt — which is passed to ReadLine so that
+// readline can render it correctly (e.g. preserving line position for
+// history navigation).
+func (a *replAsker) printQuestion(q tools.AskRequest) string {
 	header := q.Header
 	if header == "" {
 		header = "question"
@@ -117,14 +119,7 @@ func (a *replAsker) printQuestion(q tools.AskRequest) {
 	if q.MultiSelect {
 		hint = "[comma-separated, e.g. 1,3]"
 	}
-	fmt.Fprintf(a.out, "  Select %s: ", hint)
-}
-
-func (a *replAsker) readLine() (string, bool) {
-	if !a.in.Scan() {
-		return "", false
-	}
-	return a.in.Text(), true
+	return fmt.Sprintf("  Select %s: ", hint)
 }
 
 // parseSelection converts the user's typed answer into a list of 1-based

--- a/cmd/octo/asker_test.go
+++ b/cmd/octo/asker_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"strings"
@@ -15,8 +14,8 @@ import (
 // can assert both the user answer and the displayed UI.
 func askInput(input string) (*replAsker, *bytes.Buffer) {
 	out := &bytes.Buffer{}
-	scanner := bufio.NewScanner(strings.NewReader(input))
-	return newREPLAsker(scanner, out), out
+	reader := newScannerLineReader(strings.NewReader(input), out)
+	return newREPLAsker(reader, out), out
 }
 
 func TestReplAsker_PrintsQuestionAndOptions(t *testing.T) {

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -209,20 +208,33 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// step use a sub-agent (M10, #6) with read-only filesystem tools, falling
 	// back to the side-call path when no Spawner is wired.
 	//
-	// The stdin scanner is built here too so the same instance is shared with
-	// the REPL loop (no double-buffering), the permission gate, and the
-	// asker. Registering the asker NOW also matters for DefaultTools()
-	// gating: the ask_user_question tool only appears when an asker is
-	// registered, and DefaultTools is computed below before runREPL starts.
+	// The line reader is built here too so the same instance is shared with
+	// the REPL loop, the permission gate, and the asker (no double-buffering
+	// of stdin). On an interactive terminal we use chzyer/readline for
+	// history + line editing; otherwise (tests, pipes) we fall back to a
+	// scanner over stdin. Registering the asker NOW also matters for
+	// DefaultTools() gating: the ask_user_question tool only appears when
+	// an asker is registered, and DefaultTools is computed below before
+	// runREPL starts.
 	var (
 		toolExecutor tools.DefaultRegistry
-		replScanner  *bufio.Scanner
+		replReader   lineReader
 	)
 	if isREPL {
 		toolExecutor = tools.NewDefaultRegistry()
 		tools.SetSpawner(newAgentSpawner(a, toolExecutor, tools.DefaultTools))
-		replScanner = bufio.NewScanner(stdin)
-		tools.SetAsker(newREPLAsker(replScanner, stdout))
+		if stdinIsTTY(stdin) {
+			rl, err := newReadlineReader(defaultHistoryFile())
+			if err != nil {
+				fmt.Fprintf(stderr, "octo chat: line editor unavailable (%v); falling back to plain input\n", err)
+				replReader = newScannerLineReader(stdin, stdout)
+			} else {
+				replReader = rl
+			}
+		} else {
+			replReader = newScannerLineReader(stdin, stdout)
+		}
+		tools.SetAsker(newREPLAsker(replReader, stdout))
 		defer tools.SetAsker(nil)
 
 		// Session-scoped task tracker for the task_create / task_update /
@@ -283,7 +295,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			stderr:   stderr,
 			skillReg: skillReg,
 			memStore: memStore,
-			scanner:  replScanner,         // shared with the asker / permission gate
+			reader:   replReader,          // shared with the asker / permission gate
 			hooks:    hooks.LoadFromEnv(), // C9 Phase 3: external retrieval layer hooks
 		}
 		if *enableTools {

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"flag"
 	"fmt"
@@ -83,7 +82,7 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "octo init: permission config: %v\n", err)
 		return 1
 	}
-	a.Gate = &cliPermissionGate{engine: engine, in: bufio.NewScanner(stdin), out: stdout}
+	a.Gate = &cliPermissionGate{engine: engine, in: newScannerLineReader(stdin, stdout), out: stdout}
 
 	fmt.Fprintln(stdout, "Analyzing the repository to generate .octorules…")
 	handler := replToolEventHandler(stdout, *plain)

--- a/cmd/octo/lineread.go
+++ b/cmd/octo/lineread.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chzyer/readline"
+	"github.com/mattn/go-isatty"
+)
+
+// lineReader is the REPL's input abstraction. Two implementations:
+//
+//   - scannerLineReader  — wraps bufio.Scanner. Used for piped stdin, test
+//     fixtures (strings.Reader), and any non-tty input.
+//   - readlineLineReader — wraps chzyer/readline. Used in interactive
+//     terminals; provides history, line editing, Ctrl-C / Ctrl-D handling.
+//
+// The interface intentionally keeps prompt printing inside the reader so
+// scanner mode and readline mode produce the same stdout sequence (important
+// for tests that assert against stdout). Callers that draw multi-line prompts
+// — the asker's question card — print the body themselves and pass only the
+// final inline prompt ("Select [1-3]: ") to ReadLine.
+type lineReader interface {
+	// ReadLine reads one logical line. prompt, if non-empty, is rendered
+	// just before the cursor; the trailing newline produced by the user
+	// is stripped from the returned string. ok is false on EOF or any
+	// terminal error.
+	ReadLine(prompt string) (line string, ok bool)
+	// Interrupted reports whether the most recent ReadLine ended via
+	// Ctrl-C at the prompt (readline only). Scanner mode never sets it.
+	Interrupted() bool
+	// Close flushes history (readline) and releases the terminal.
+	Close() error
+}
+
+// scannerLineReader is the non-tty fallback. Tests rely on this — they pass
+// stdin as a strings.Reader and expect deterministic stdout including the
+// "you> " prompts.
+type scannerLineReader struct {
+	in  *bufio.Scanner
+	out io.Writer
+}
+
+func newScannerLineReader(in io.Reader, out io.Writer) *scannerLineReader {
+	return &scannerLineReader{in: bufio.NewScanner(in), out: out}
+}
+
+func (s *scannerLineReader) ReadLine(prompt string) (string, bool) {
+	if prompt != "" {
+		fmt.Fprint(s.out, prompt)
+	}
+	if !s.in.Scan() {
+		return "", false
+	}
+	return strings.TrimRight(s.in.Text(), "\r"), true
+}
+
+func (*scannerLineReader) Interrupted() bool { return false }
+func (*scannerLineReader) Close() error      { return nil }
+
+// readlineLineReader is the interactive-tty implementation.
+type readlineLineReader struct {
+	rl          *readline.Instance
+	interrupted bool
+}
+
+func newReadlineReader(historyFile string) (*readlineLineReader, error) {
+	if historyFile != "" {
+		if err := os.MkdirAll(filepath.Dir(historyFile), 0o755); err != nil {
+			// Non-fatal: fall through with history disabled rather than
+			// blowing up the REPL because ~/.octo isn't writable.
+			historyFile = ""
+		}
+	}
+	rl, err := readline.NewEx(&readline.Config{
+		Prompt:                 "you> ",
+		HistoryFile:            historyFile,
+		HistoryLimit:           5000,
+		HistorySearchFold:      true,
+		DisableAutoSaveHistory: false,
+		InterruptPrompt:        "^C",
+		EOFPrompt:              "",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &readlineLineReader{rl: rl}, nil
+}
+
+func (r *readlineLineReader) ReadLine(prompt string) (string, bool) {
+	r.interrupted = false
+	if prompt == "" {
+		// readline always renders *some* prompt; an empty one is fine.
+		r.rl.SetPrompt("")
+	} else {
+		r.rl.SetPrompt(prompt)
+	}
+	line, err := r.rl.Readline()
+	switch {
+	case errors.Is(err, readline.ErrInterrupt):
+		r.interrupted = true
+		return "", false
+	case errors.Is(err, io.EOF):
+		return "", false
+	case err != nil:
+		return "", false
+	}
+	return line, true
+}
+
+func (r *readlineLineReader) Interrupted() bool { return r.interrupted }
+func (r *readlineLineReader) Close() error      { return r.rl.Close() }
+
+// stdinIsTTY reports whether r is an *os.File backed by an interactive
+// terminal. Anything else (pipe, file, strings.Reader) returns false.
+func stdinIsTTY(r io.Reader) bool {
+	f, ok := r.(*os.File)
+	if !ok {
+		return false
+	}
+	return isatty.IsTerminal(f.Fd())
+}
+
+// defaultHistoryFile resolves the path used for persistent REPL history.
+// OCTO_HISTORY_FILE wins so users (and tests) can redirect it. Empty
+// return disables history persistence.
+func defaultHistoryFile() string {
+	if env := os.Getenv("OCTO_HISTORY_FILE"); env != "" {
+		return env
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "history")
+}
+
+// readPromptLine reads one user-facing input line, expanding `\` line
+// continuations into a single multi-line string (joined with "\n"). The
+// continuation prompt is used for any line after the first. Both modes
+// support continuation; in scanner mode a trailing `\` in piped input
+// glues two lines together, which is consistent with bash-style heredocs.
+func readPromptLine(r lineReader, prompt, contPrompt string) (string, bool) {
+	first, ok := r.ReadLine(prompt)
+	if !ok {
+		return "", false
+	}
+	if !endsWithContinuation(first) {
+		return first, true
+	}
+	var sb strings.Builder
+	sb.WriteString(strings.TrimSuffix(first, "\\"))
+	for {
+		next, ok := r.ReadLine(contPrompt)
+		if !ok {
+			// EOF mid-continuation — return what we have so the user's
+			// keystrokes aren't silently discarded.
+			return sb.String(), true
+		}
+		if !endsWithContinuation(next) {
+			sb.WriteString("\n")
+			sb.WriteString(next)
+			return sb.String(), true
+		}
+		sb.WriteString("\n")
+		sb.WriteString(strings.TrimSuffix(next, "\\"))
+	}
+}
+
+// endsWithContinuation is true when the line ends in a single unescaped
+// backslash. A doubled `\\` at the end is treated as a literal backslash,
+// not a continuation marker — same rule bash uses.
+func endsWithContinuation(line string) bool {
+	if !strings.HasSuffix(line, "\\") {
+		return false
+	}
+	// Count trailing backslashes; odd count → continuation.
+	n := 0
+	for i := len(line) - 1; i >= 0 && line[i] == '\\'; i-- {
+		n++
+	}
+	return n%2 == 1
+}

--- a/cmd/octo/lineread_test.go
+++ b/cmd/octo/lineread_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestScannerLineReader_PrintsPrompt(t *testing.T) {
+	var out bytes.Buffer
+	r := newScannerLineReader(strings.NewReader("hi\n"), &out)
+
+	line, ok := r.ReadLine("you> ")
+	if !ok || line != "hi" {
+		t.Fatalf("ReadLine = (%q, %v); want (\"hi\", true)", line, ok)
+	}
+	if got := out.String(); got != "you> " {
+		t.Errorf("prompt = %q; want %q", got, "you> ")
+	}
+}
+
+func TestScannerLineReader_EOFReturnsFalse(t *testing.T) {
+	var out bytes.Buffer
+	r := newScannerLineReader(strings.NewReader(""), &out)
+
+	if _, ok := r.ReadLine(""); ok {
+		t.Errorf("expected EOF on empty input")
+	}
+	if r.Interrupted() {
+		t.Errorf("scanner reader should never report interrupt")
+	}
+}
+
+func TestScannerLineReader_StripsCarriageReturn(t *testing.T) {
+	var out bytes.Buffer
+	r := newScannerLineReader(strings.NewReader("hi\r\n"), &out)
+	line, ok := r.ReadLine("")
+	if !ok || line != "hi" {
+		t.Errorf("ReadLine = (%q, %v); want (\"hi\", true)", line, ok)
+	}
+}
+
+func TestReadPromptLine_SingleLine(t *testing.T) {
+	var out bytes.Buffer
+	r := newScannerLineReader(strings.NewReader("hello\n"), &out)
+
+	got, ok := readPromptLine(r, "you> ", "... ")
+	if !ok || got != "hello" {
+		t.Errorf("got = (%q, %v); want (\"hello\", true)", got, ok)
+	}
+	if !strings.Contains(out.String(), "you> ") {
+		t.Errorf("expected primary prompt; got %q", out.String())
+	}
+	if strings.Contains(out.String(), "... ") {
+		t.Errorf("did not expect continuation prompt on single line; got %q", out.String())
+	}
+}
+
+func TestReadPromptLine_BackslashContinuation(t *testing.T) {
+	var out bytes.Buffer
+	// Two `\`-suffixed lines plus a final unterminated one.
+	in := "first\\\nsecond\\\nthird\n"
+	r := newScannerLineReader(strings.NewReader(in), &out)
+
+	got, ok := readPromptLine(r, "you> ", "... ")
+	if !ok {
+		t.Fatal("ReadPromptLine ok=false")
+	}
+	want := "first\nsecond\nthird"
+	if got != want {
+		t.Errorf("got = %q; want %q", got, want)
+	}
+	prompts := out.String()
+	if !strings.Contains(prompts, "you> ") {
+		t.Errorf("missing primary prompt; got %q", prompts)
+	}
+	if strings.Count(prompts, "... ") != 2 {
+		t.Errorf("expected 2 continuation prompts; got %q", prompts)
+	}
+}
+
+func TestReadPromptLine_DoubleBackslashIsLiteral(t *testing.T) {
+	var out bytes.Buffer
+	// `\\` at end means a literal backslash, not a continuation.
+	r := newScannerLineReader(strings.NewReader("foo\\\\\n"), &out)
+	got, ok := readPromptLine(r, "", "")
+	if !ok || got != "foo\\\\" {
+		t.Errorf("got = (%q, %v); want (\"foo\\\\\\\\\", true)", got, ok)
+	}
+}
+
+func TestReadPromptLine_EOFMidContinuation(t *testing.T) {
+	var out bytes.Buffer
+	r := newScannerLineReader(strings.NewReader("first\\\n"), &out)
+	got, ok := readPromptLine(r, "", "")
+	if !ok {
+		t.Fatal("expected partial line, not EOF")
+	}
+	if got != "first" {
+		t.Errorf("got = %q; want %q", got, "first")
+	}
+}
+
+func TestEndsWithContinuation(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"foo", false},
+		{"foo\\", true},
+		{"foo\\\\", false},
+		{"foo\\\\\\", true},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := endsWithContinuation(tc.in); got != tc.want {
+			t.Errorf("endsWithContinuation(%q) = %v; want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cmd/octo/permission_gate.go
+++ b/cmd/octo/permission_gate.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -20,7 +19,7 @@ import (
 // path is never reached — Check just returns the denial with its reason.
 type cliPermissionGate struct {
 	engine *permission.Engine
-	in     *bufio.Scanner // shared with the REPL loop; reads one line per prompt
+	in     lineReader // shared with the REPL loop; reads one line per prompt
 	out    io.Writer
 }
 
@@ -45,11 +44,12 @@ func (g *cliPermissionGate) Check(_ context.Context, name string, input map[stri
 func (g *cliPermissionGate) prompt(name string, input map[string]any) (bool, string) {
 	fmt.Fprintf(g.out, "\n⚠ permission: %s wants to run\n", name)
 	fmt.Fprintf(g.out, "    %s\n", summariseInput(input))
-	fmt.Fprint(g.out, "  allow? [y]es / [a]lways this session / [N]o: ")
 
 	answer := ""
-	if g.in != nil && g.in.Scan() {
-		answer = strings.ToLower(strings.TrimSpace(g.in.Text()))
+	if g.in != nil {
+		if raw, ok := g.in.ReadLine("  allow? [y]es / [a]lways this session / [N]o: "); ok {
+			answer = strings.ToLower(strings.TrimSpace(raw))
+		}
 	}
 
 	switch answer {

--- a/cmd/octo/permission_gate_test.go
+++ b/cmd/octo/permission_gate_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"strings"
@@ -19,7 +18,7 @@ func newGate(t *testing.T, mode permission.Mode, stdin string) (*cliPermissionGa
 	var out bytes.Buffer
 	g := &cliPermissionGate{
 		engine: eng,
-		in:     bufio.NewScanner(strings.NewReader(stdin)),
+		in:     newScannerLineReader(strings.NewReader(stdin), &out),
 		out:    &out,
 	}
 	return g, &out

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -37,11 +36,12 @@ type replConfig struct {
 	skillReg   *skills.Registry // discovered skills; backs /skills and /<name>
 	memStore   *memory.Store    // cross-session memory; backs /memory (nil → disabled)
 	hooks      *hooks.Runner    // C9 Phase 3 pre/post-turn hooks; nil-safe via Configured()
-	// scanner, when non-nil, is the stdin reader to use instead of building
-	// one fresh inside runREPL. Set by cmd/octo when the asker / spawner need
-	// the same scanner the loop will read from (no double-buffering). Tests
-	// that only pass cfg.stdin leave this nil and runREPL builds its own.
-	scanner *bufio.Scanner
+	// reader, when non-nil, is the line reader to use instead of building
+	// one fresh inside runREPL. Set by cmd/octo so the same instance is
+	// shared with the permission gate and the ask_user_question asker.
+	// Tests that only pass cfg.stdin leave this nil; runREPL builds a
+	// scanner-backed reader over stdin for them.
+	reader lineReader
 }
 
 // runREPL runs the interactive multi-turn loop until the user exits or EOF.
@@ -67,15 +67,18 @@ func runREPL(cfg replConfig) int {
 	fmt.Fprintln(cfg.stdout, `Type /help for commands, Ctrl-C or /exit to quit.`)
 	fmt.Fprintln(cfg.stdout)
 
-	scanner := cfg.scanner
-	if scanner == nil {
-		scanner = bufio.NewScanner(cfg.stdin)
+	reader := cfg.reader
+	if reader == nil {
+		reader = newScannerLineReader(cfg.stdin, cfg.stdout)
 	}
+	defer reader.Close()
 
 	// Ctrl-C handling: while a turn is running, SIGINT cancels just that turn
 	// (the loop catches context.Canceled, finalizes well-formed history, and
 	// returns to the prompt). At an idle prompt — no turn in flight — SIGINT
-	// exits cleanly, preserving the documented "Ctrl-C to quit" behaviour.
+	// behaviour depends on the reader: readline catches it and returns
+	// ErrInterrupt (we just re-prompt), while scanner mode falls through to
+	// the signal handler which saves and exits.
 	var (
 		turnMu     sync.Mutex
 		turnCancel context.CancelFunc
@@ -97,39 +100,49 @@ func runREPL(cfg replConfig) int {
 				c() // interrupt the in-flight turn; the loop returns to prompt
 				continue
 			}
-			// Idle prompt: save what we have and exit cleanly. os.Exit skips the
-			// deferred cleanup below, so do it explicitly here.
-			fmt.Fprintln(cfg.stdout, "\n^C")
-			if !cfg.noSave {
-				sess.SyncFrom(a.History)
-				_ = sess.Save()
+			// Idle prompt with the scanner reader (no built-in SIGINT
+			// handling): save and exit. The readline reader catches Ctrl-C
+			// itself (returns ErrInterrupt), so this branch never fires in
+			// interactive mode — its loop just re-prompts on the next pass.
+			if _, ok := reader.(*scannerLineReader); ok {
+				fmt.Fprintln(cfg.stdout, "\n^C")
+				if !cfg.noSave {
+					sess.SyncFrom(a.History)
+					_ = sess.Save()
+				}
+				tools.KillAllBackground()
+				os.Exit(0)
 			}
-			tools.KillAllBackground()
-			os.Exit(0)
 		}
 	}()
 
-	// Permission gating shares the REPL scanner so an interactive "ask"
-	// prompt reads from the same stdin buffer the loop uses. Tool dispatch
-	// runs synchronously inside RunStream (which blocks this loop), so there
-	// is no concurrent access to the scanner.
+	// Permission gating shares the REPL line reader so an interactive "ask"
+	// prompt reads from the same stdin the loop uses. Tool dispatch runs
+	// synchronously inside RunStream (which blocks this loop), so there is
+	// no concurrent access to the reader.
 	if cfg.permEngine != nil {
 		a.Gate = &cliPermissionGate{
 			engine: cfg.permEngine,
-			in:     scanner,
+			in:     reader,
 			out:    cfg.stdout,
 		}
 	}
 
 	for {
-		fmt.Fprint(cfg.stdout, "you> ")
-
-		if !scanner.Scan() {
+		raw, ok := readPromptLine(reader, "you> ", "... ")
+		if !ok {
+			if reader.Interrupted() {
+				// Ctrl-C at an idle prompt under readline: just re-loop so
+				// the user can keep typing. Matches the convention in
+				// bash/zsh — Ctrl-C clears the current line but doesn't
+				// exit the shell.
+				continue
+			}
 			// EOF (Ctrl-D) or read error.
 			fmt.Fprintln(cfg.stdout)
 			break
 		}
-		line := strings.TrimSpace(scanner.Text())
+		line := strings.TrimSpace(raw)
 		if line == "" {
 			continue
 		}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.22
 require (
 	github.com/alecthomas/chroma/v2 v2.14.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/chzyer/readline v1.5.1
+	github.com/mattn/go-isatty v0.0.20
 	golang.org/x/sys v0.30.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -17,7 +19,6 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,12 @@ github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd h1:vy0G
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd/go.mod h1:xe0nKWGd3eJgtqZRaN9RjMtK7xUYchjzPr7q6kcvCCs=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
+github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
+github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
+github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
+github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
+github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
+github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -35,6 +41,7 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
## Summary

First of five planned CLI-UX PRs. Replaces the bare `bufio.Scanner` read in `octo chat`'s REPL loop with a [chzyer/readline](https://github.com/chzyer/readline)-backed prompt whenever stdin is an interactive terminal, and threads the new line reader through the permission gate and the `ask_user_question` asker so all three prompt sites get the same ergonomics.

### What you get when stdin is a tty
- **Persistent history** at `~/.octo/history` (override with `OCTO_HISTORY_FILE`), with up/down recall across sessions.
- **Full readline editing**: Ctrl-A / Ctrl-E / Ctrl-W, arrow keys for in-line cursor movement, etc.
- **Multiline input** via trailing `\` continuation. Subsequent lines come in under a `...` prompt and are joined with `\n`. Doubled `\\` at end of line is a literal backslash (same rule bash uses).
- **Idle-prompt Ctrl-C** clears the current line instead of exiting (matches bash / zsh). `/exit` or Ctrl-D still exits cleanly.
- **In-turn Ctrl-C** still cancels just the current turn — unchanged from before.

### Design

New `cmd/octo/lineread.go` introduces a small `lineReader` interface with two implementations:

| Mode | Backing | Used when |
|------|---------|-----------|
| `scannerLineReader` | `bufio.Scanner` over stdin | Pipes, redirected files, test fixtures (`strings.Reader`) — anything where `isatty.IsTerminal` returns false |
| `readlineLineReader` | `*readline.Instance` | Interactive terminal |

The REPL builds whichever reader applies once in `cmd/octo/chat.go` and hands it to `runREPL`, the permission gate, and the asker. Tool dispatch is synchronous inside `RunStream`, so the three sites never race on stdin.

`readPromptLine()` adds the `\`-continuation loop on top of the interface; both reader implementations get it for free.

### Backwards compatibility

- Test fixtures that pipe stdin via `strings.NewReader` keep the existing scanner path verbatim. `repl_test.go` / `asker_test.go` / `permission_gate_test.go` only changed where they construct a reader (one-line swap to `newScannerLineReader`), not their assertions.
- Permission gate API gained one indirection (`lineReader` instead of `*bufio.Scanner`) but its existing prompt-line shape is unchanged.

### Out of scope (follow-ups)
- ID shortcuts (`-c last`, fuzzy prefix matching) — UX-2
- Error messages + `octo help <cmd>` — UX-3
- Status feedback + verbosity flags — UX-4
- Shell completion — UX-5

## Test plan

- [x] `go test -race ./...` — all packages green, including new `lineread_test.go` covering single-line, `\`-continuation, double-`\\`, mid-continuation EOF, carriage-return stripping.
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `make build` produces a working binary
- [ ] Manual smoke in a real terminal: history persists across two `octo chat` runs, multiline `\` works, Ctrl-C at idle reprompts, Ctrl-C in a turn cancels the turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)