### PR TITLE
chore: cut 0.3.0, start 0.4.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased — 0.3.0-dev]
+## [Unreleased — 0.4.0-dev]
+
+_Nothing yet — next milestone work (M8 web server, M9 IM bridge, or further roadmap items) will accumulate here._
+
+## [0.3.0] — 2026-05-28
+
+CLI usability sweep — five PRs improving the `octo chat` / `octo task` surface without touching the underlying agent loop. The headline change is that interactive sessions feel like a modern CLI: readline-edited prompt with history, 8-character short IDs everywhere a 23-character ID used to be, `octo help <command>` pages with copy-paste examples, a `thinking…` spinner during pauses, `--quiet` / `--verbose` knobs, and TAB completion for bash / zsh / fish that knows your sessions and tasks.
 
 ### Added
 - **Shell completion for bash / zsh / fish (UX-5)** — new `octo completion bash|zsh|fish` prints a tiny per-shell snippet the user sources from their rc file (`source <(octo completion bash)`, or persist with `octo completion zsh > "${fpath[1]}/_octo"`, or `octo completion fish > ~/.config/fish/completions/octo.fish`). The snippet delegates each TAB to a hidden `octo __complete <command-line-so-far>` subcommand so all routing lives in one Go function — three shell scripts stay near-identical and don't drift as new flags land. Static completion covers top-level subcommands, `task` / `memory` / `memoryd` / `help` / `completion` subcommands, `--provider` (anthropic|openai), and `--permission-mode` (interactive|strict). **Dynamic completion** reads the live filesystem: TAB after `octo chat -c ` lists `last` + the short + full IDs of the 50 most recent sessions; TAB after `octo task status|show|resume|cancel|run ` does the same for tasks. `octo help completion` documents installation per shell.

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ GOFLAGS ?=
 # pollute the reported version. Dev builds say "<next>-dev"; release builds
 # should set VERSION explicitly:
 #
-#   VERSION=0.3.0 make build
+#   VERSION=0.4.0 make build
 #
-VERSION ?= 0.3.0-dev
+VERSION ?= 0.4.0-dev
 COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 LDFLAGS := -X github.com/Leihb/octo-agent/internal/version.Version=$(VERSION) \
            -X github.com/Leihb/octo-agent/internal/version.Commit=$(COMMIT)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@
 package version
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "0.3.0-dev"
+var Version = "0.4.0-dev"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary

Releases the five UX PRs as **v0.3.0**.

- CHANGELOG: rename `Unreleased — 0.3.0-dev` to `[0.3.0] — 2026-05-28` with a one-paragraph headline; add fresh `Unreleased — 0.4.0-dev` section.
- `internal/version/version.go`: `0.3.0-dev` → `0.4.0-dev`.
- `Makefile`: same bump, and the example release-build comment.

### What's in 0.3.0

| PR | Title |
|---|---|
| #121 | UX-1 readline + history + multiline |
| #123 | UX-2 short IDs + `last`/substring resolver |
| #124 | UX-3 `octo help <cmd>` + actionable errors |
| #125 | UX-4 spinner + `--quiet`/`--verbose` |
| #126 | UX-5 shell completion (bash/zsh/fish) with dynamic IDs |

### Compatibility

Zero backend changes. Session JSON, task graph schema, memory layout, provider wire protocols, and the agent loop are all identical to 0.2.0. Upgrade-in-place; no migration needed.

## Test plan

- [x] `go test -race ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] After CI passes and this merges, tag `v0.3.0` at the merge commit and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)