### PR TITLE
feat(mcp): Model Context Protocol client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased — 0.4.0-dev]
 
-_Nothing yet — next milestone work (M8 web server, M9 IM bridge, or further roadmap items) will accumulate here._
+### Added
+- **MCP client** — `octo chat --tools` now auto-connects to every Model Context Protocol server listed in `~/.octo/mcp.json` (user-global) and `./.octo/mcp.json` (project-local, overrides per name); both stdio (subprocess) and Streamable HTTP transports are supported per MCP spec 2024-11-05. The new `internal/mcp` package is a self-contained client: JSON-RPC 2.0 framing, transport interface with stdio + HTTP implementations, lifecycle handshake, and typed wrappers for tools/list, tools/call, resources/list, resources/read, prompts/list, prompts/get. Each connected server's surface rides alongside octo's built-in tools as `mcp__<server>__<tool>` (matching Claude Code's naming convention so user tooling that grep's tool names keeps working); resources become a synthesized `mcp__<server>__resource_read(uri)` tool and prompts a `mcp__<server>__prompt_get(name, arguments)` tool, gated on the server's advertised capabilities. Config format mirrors Claude Code's `mcpServers` shape (`{command, args, env}` for stdio, `{url, headers}` for HTTP, plus `disabled: true`) so users can copy-paste configs between the two tools. Connect failures degrade — a misconfigured or slow server is logged on stderr and skipped (10s per-server timeout); the session keeps going with the survivors. New `/mcp` REPL slash command lists connected servers + their surface counts + the server-supplied instructions. `octo help mcp` documents the config format, transports, and the v1 omissions (notifications, subscriptions, sampling, roots).
 
 ## [0.3.0] — 2026-05-28
 

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/hooks"
+	"github.com/Leihb/octo-agent/internal/mcp"
 	"github.com/Leihb/octo-agent/internal/memory"
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/prompt"
@@ -23,6 +24,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/skills"
 	"github.com/Leihb/octo-agent/internal/tasks"
 	"github.com/Leihb/octo-agent/internal/tools"
+	"github.com/Leihb/octo-agent/internal/version"
 )
 
 // Provider names accepted by `--provider`.
@@ -251,6 +253,38 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		// (cross-session persistence is M11 territory).
 		tools.SetTaskStore(tasks.New())
 		defer tools.SetTaskStore(nil)
+
+		// MCP servers: load config, connect, register so DefaultTools and
+		// DefaultRegistry pick them up. Best-effort — a misconfigured or
+		// missing server is logged on stderr and the session keeps going.
+		// Tool-disabled chat doesn't load MCP because the agent would never
+		// invoke the tools anyway and we'd be paying subprocess spawn cost
+		// for nothing.
+		if *enableTools {
+			mcpCfg, err := mcp.LoadConfig(cwd)
+			if err != nil {
+				fmt.Fprintf(stderr, "octo chat: mcp config: %v\n", err)
+			} else if len(mcpCfg.Servers) > 0 {
+				mcpReg := mcp.ConnectAll(
+					context.Background(),
+					mcpCfg,
+					mcp.Implementation{Name: "octo", Version: version.Version},
+					stderr,
+				)
+				if mcpReg.Len() > 0 {
+					tools.SetMCPRegistry(mcpReg)
+					defer func() {
+						tools.SetMCPRegistry(nil)
+						mcpReg.Close()
+					}()
+					if mcpReg.Len() == 1 {
+						fmt.Fprintf(stdout, "Connected 1 MCP server.\n")
+					} else {
+						fmt.Fprintf(stdout, "Connected %d MCP servers.\n", mcpReg.Len())
+					}
+				}
+			}
+		}
 	}
 
 	// Boundary memory (REPL only): extract durable facts from the previous

--- a/cmd/octo/completion.go
+++ b/cmd/octo/completion.go
@@ -91,7 +91,7 @@ func completionCandidates(words []string) []string {
 	case "help":
 		// `octo help <TAB>` → list of help targets.
 		if len(words) == 3 {
-			return []string{"chat", "task", "memory", "init", "memoryd"}
+			return []string{"chat", "task", "memory", "init", "memoryd", "completion", "mcp"}
 		}
 	case "completion":
 		if len(words) == 3 {

--- a/cmd/octo/completion_test.go
+++ b/cmd/octo/completion_test.go
@@ -108,8 +108,9 @@ func TestCompletionCandidates_TaskIDsAfterVerbs(t *testing.T) {
 
 func TestCompletionCandidates_HelpTargets(t *testing.T) {
 	got := completionCandidates([]string{"octo", "help", ""})
-	if !sliceEq(got, []string{"chat", "task", "memory", "init", "memoryd"}) {
-		t.Errorf("help target completion = %v", got)
+	want := []string{"chat", "task", "memory", "init", "memoryd", "completion", "mcp"}
+	if !sliceEq(got, want) {
+		t.Errorf("help target completion = %v, want %v", got, want)
 	}
 }
 

--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -24,10 +24,57 @@ func printCommandHelp(name string, w io.Writer) bool {
 		memorydHelp(w)
 	case "completion":
 		completionHelp(w)
+	case "mcp":
+		mcpHelp(w)
 	default:
 		return false
 	}
 	return true
+}
+
+func mcpHelp(w io.Writer) {
+	fmt.Fprintln(w, `octo mcp — Model Context Protocol client. With `+"`"+`--tools`+"`"+` on, every server
+listed in mcp.json gets connected at session start; its tools, resources, and
+prompts ride alongside octo's built-in tools.
+
+Configuration:
+  ~/.octo/mcp.json                 user-global config (always loaded)
+  ./.octo/mcp.json                 project-local config (overrides user-global per name)
+
+mcp.json format (mirrors Claude Code):
+  {
+    "mcpServers": {
+      "filesystem": {
+        "command": "npx",
+        "args":    ["-y", "@modelcontextprotocol/server-filesystem", "/some/path"],
+        "env":     {"FOO": "bar"}
+      },
+      "remote-api": {
+        "url":     "https://example.com/mcp",
+        "headers": {"Authorization": "Bearer abc..."}
+      }
+    }
+  }
+
+A server entry must set EITHER `+"`"+`command`+"`"+` (stdio transport — spawn a subprocess)
+OR `+"`"+`url`+"`"+` (Streamable HTTP transport). `+"`"+`disabled: true`+"`"+` skips an entry without
+removing it.
+
+Tool naming in the agent's tool list:
+  mcp__<server>__<tool>            one entry per advertised tool
+  mcp__<server>__resource_read     synthesized when server supports resources/*
+  mcp__<server>__prompt_get        synthesized when server supports prompts/*
+
+Examples:
+  octo chat --tools                # auto-connect every configured server
+  /mcp                             # REPL: list connected servers + surface counts
+
+Failure handling — a server that won't start, fails initialize, or times out
+during the handshake is logged on stderr and skipped. The session keeps going
+with the survivors. The connect timeout is 10s per server.
+
+What's not yet implemented (v1): server-initiated notifications, resource
+subscriptions, sampling (server → client LLM calls), roots.`)
 }
 
 func chatHelp(w io.Writer) {

--- a/cmd/octo/main_test.go
+++ b/cmd/octo/main_test.go
@@ -77,6 +77,8 @@ func TestRun_HelpWithSubcommand_PrintsRichHelp(t *testing.T) {
 		{"memory", []string{"octo memory", "octo memory list"}},
 		{"init", []string{"octo init", ".octorules"}},
 		{"memoryd", []string{"octo memoryd", "PID file", "octo memoryd start"}},
+		{"mcp", []string{"octo mcp", "mcp.json", "mcp__"}},
+		{"completion", []string{"octo completion", "shell-completion"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.cmd, func(t *testing.T) {

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -207,6 +207,9 @@ func runREPL(cfg replConfig) int {
 			case "/tasks":
 				printTasks(cfg.stdout)
 				continue
+			case "/mcp":
+				printMCP(cfg.stdout)
+				continue
 			default:
 				fmt.Fprintf(cfg.stdout, "Unknown command %q. Type /help for a list.\n", cmd)
 				continue
@@ -344,6 +347,7 @@ func printReplHelp(w io.Writer) {
 	fmt.Fprintln(w, "  /skills     List available skills (trigger one with /<name>)")
 	fmt.Fprintln(w, "  /memory     List what's remembered across sessions")
 	fmt.Fprintln(w, "  /tasks      Show the current session's task list")
+	fmt.Fprintln(w, "  /mcp        Show connected MCP servers and their surfaces")
 	fmt.Fprintln(w, "  /exit       Save and exit  (also: /quit, Ctrl-C, Ctrl-D)")
 }
 
@@ -396,6 +400,48 @@ func pluralEntries(n int) string {
 	return "ies"
 }
 
+// printMCP lists the connected MCP servers and the surface they advertised
+// (tool count + resource count + prompt count, plus the server-supplied
+// instructions if non-empty). Drives the /mcp REPL command.
+func printMCP(w io.Writer) {
+	reg := tools.ActiveMCPRegistry()
+	if reg == nil || reg.Len() == 0 {
+		fmt.Fprintln(w, "No MCP servers connected.")
+		fmt.Fprintln(w, "Configure one at ~/.octo/mcp.json (run `octo help mcp` for the format).")
+		return
+	}
+	conns := reg.Connections()
+	if len(conns) == 1 {
+		fmt.Fprintln(w, "1 MCP server connected:")
+	} else {
+		fmt.Fprintf(w, "%d MCP servers connected:\n", len(conns))
+	}
+	for _, c := range conns {
+		info := c.Client.ServerInfo()
+		nameVer := info.Name
+		if info.Version != "" {
+			nameVer = fmt.Sprintf("%s %s", info.Name, info.Version)
+		}
+		fmt.Fprintf(w, "  %s (%s): %d tool%s, %d resource%s, %d prompt%s\n",
+			c.Name, nameVer,
+			len(c.Tools), pluralS(len(c.Tools)),
+			len(c.Resources), pluralS(len(c.Resources)),
+			len(c.Prompts), pluralS(len(c.Prompts)))
+		if instr := c.Client.Instructions(); instr != "" {
+			for _, line := range strings.Split(instr, "\n") {
+				fmt.Fprintf(w, "      %s\n", line)
+			}
+		}
+	}
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
 // printTasks shows the session-scoped task list, reusing the same formatter
 // the task_list tool returns to the model. Distinct from the LLM-facing
 // rendering only in that this runs at the user's command and goes to stdout
@@ -414,6 +460,7 @@ func printTasks(w io.Writer) {
 var reservedReplCommands = map[string]bool{
 	"init": true, "exit": true, "quit": true, "help": true,
 	"cost": true, "save": true, "sessions": true, "skills": true,
+	"memory": true, "tasks": true, "mcp": true,
 }
 
 // skillTrigger reports whether line is a /<name> invocation of a discovered

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1,0 +1,314 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"sync/atomic"
+)
+
+// Client is a single MCP server connection: one transport, one initialize
+// handshake, request/response dispatch by ID. It's safe for concurrent
+// callers — Call serialises through the transport via sendMu, and the
+// receive loop demultiplexes responses on a per-request channel.
+//
+// Lifecycle:
+//
+//	Initialize  →  ListTools / CallTool / ListResources / ... (any order, concurrent OK)  →  Close
+//
+// The receive goroutine is started in Initialize and stops when the
+// transport hits EOF or Close is called. Pending callers waiting on a
+// response see their channel closed with an error in that case.
+type Client struct {
+	transport Transport
+	info      Implementation
+	// caps is populated after Initialize so callers can branch on which
+	// surfaces the server actually advertised. Tools/Resources/Prompts are
+	// pointers in the spec; nil means "not supported".
+	caps         ServerCapabilities
+	serverInfo   Implementation
+	instructions string
+
+	nextID atomic.Uint64
+
+	// pending tracks in-flight requests. The map is keyed by the request
+	// ID we issued (as a string for json.RawMessage compatibility) and
+	// holds the response channel the caller is blocked on.
+	pendingMu sync.Mutex
+	pending   map[string]chan *Message
+
+	// sendMu is the transport's write lock. Stdio transport already
+	// serialises but the contract is per-Client, so we hold it explicitly
+	// at the Call call site.
+	sendMu sync.Mutex
+
+	rxDone chan struct{} // closed when the receive loop exits
+	closed atomic.Bool
+}
+
+// NewClient builds a Client around an already-Open transport. The caller
+// owns transport lifetime up to Initialize; after Initialize succeeds the
+// Client owns it and Close will tear it down.
+func NewClient(t Transport, info Implementation) *Client {
+	return &Client{
+		transport: t,
+		info:      info,
+		pending:   make(map[string]chan *Message),
+		rxDone:    make(chan struct{}),
+	}
+}
+
+// Initialize performs the MCP handshake: send the initialize request,
+// receive the result, then send the initialized notification. Starts the
+// background receive loop on the way in so the response to initialize is
+// demuxed normally.
+func (c *Client) Initialize(ctx context.Context) error {
+	// Kick off the receive loop BEFORE issuing the first request so the
+	// response can be matched. If the loop fails to start the goroutine
+	// would still observe ctx cancellation, but starting it ahead removes
+	// a race where Send finishes and the response arrives before we set
+	// up the demuxer.
+	go c.receiveLoop()
+
+	params := InitializeParams{
+		ProtocolVersion: ProtocolVersion,
+		Capabilities:    ClientCapabilities{},
+		ClientInfo:      c.info,
+	}
+	var result InitializeResult
+	if err := c.Call(ctx, MethodInitialize, params, &result); err != nil {
+		return fmt.Errorf("mcp: initialize: %w", err)
+	}
+	c.caps = result.Capabilities
+	c.serverInfo = result.ServerInfo
+	c.instructions = result.Instructions
+
+	// notifications/initialized lets the server know we're done handshaking
+	// and ready for normal traffic. Fire-and-forget — the server doesn't
+	// reply, and a transport error here surfaces on the next real call.
+	if err := c.Notify(ctx, MethodInitialized, nil); err != nil {
+		return fmt.Errorf("mcp: send initialized: %w", err)
+	}
+	return nil
+}
+
+// ServerInfo returns the {name, version} the server advertised in its
+// initialize response. Useful for /mcp output.
+func (c *Client) ServerInfo() Implementation { return c.serverInfo }
+
+// Capabilities returns the server's advertised capabilities so callers can
+// avoid calling tools/list against a server that doesn't support tools.
+func (c *Client) Capabilities() ServerCapabilities { return c.caps }
+
+// Instructions returns the optional human-readable instructions the server
+// included in its initialize response. Some servers use this to tell the
+// agent how their tools should be used.
+func (c *Client) Instructions() string { return c.instructions }
+
+// Call issues a request and blocks for the matched response. params is
+// json-marshalled; result, if non-nil, is unmarshalled from the response's
+// result field. RPC errors (server-returned) become a typed error caller
+// can inspect.
+func (c *Client) Call(ctx context.Context, method string, params, result any) error {
+	if c.closed.Load() {
+		return errors.New("mcp: client closed")
+	}
+	id := c.nextID.Add(1)
+	idBytes := []byte(strconv.FormatUint(id, 10))
+	idKey := string(idBytes)
+
+	// Register the pending channel BEFORE sending so a fast response can't
+	// arrive before the demuxer knows where to deliver it.
+	ch := make(chan *Message, 1)
+	c.pendingMu.Lock()
+	c.pending[idKey] = ch
+	c.pendingMu.Unlock()
+	defer c.removePending(idKey)
+
+	msg := &Message{
+		JSONRPC: "2.0",
+		ID:      idBytes,
+		Method:  method,
+	}
+	if params != nil {
+		p, err := json.Marshal(params)
+		if err != nil {
+			return fmt.Errorf("mcp: marshal params: %w", err)
+		}
+		msg.Params = p
+	}
+
+	c.sendMu.Lock()
+	err := c.transport.Send(ctx, msg)
+	c.sendMu.Unlock()
+	if err != nil {
+		return err
+	}
+
+	select {
+	case resp := <-ch:
+		if resp == nil {
+			return errors.New("mcp: connection closed")
+		}
+		if resp.Error != nil {
+			return resp.Error
+		}
+		if result != nil && len(resp.Result) > 0 {
+			if err := json.Unmarshal(resp.Result, result); err != nil {
+				return fmt.Errorf("mcp: unmarshal result: %w", err)
+			}
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Notify sends a one-way notification — no id, no response. params may be
+// nil for parameterless notifications (e.g., notifications/initialized).
+func (c *Client) Notify(ctx context.Context, method string, params any) error {
+	if c.closed.Load() {
+		return errors.New("mcp: client closed")
+	}
+	msg := &Message{JSONRPC: "2.0", Method: method}
+	if params != nil {
+		p, err := json.Marshal(params)
+		if err != nil {
+			return fmt.Errorf("mcp: marshal notify params: %w", err)
+		}
+		msg.Params = p
+	}
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+	return c.transport.Send(ctx, msg)
+}
+
+// receiveLoop runs for the life of the Client, pulling frames off the
+// transport and dispatching responses to the matching pending channel.
+// Notifications from the server are silently dropped — v1 doesn't react to
+// list_changed / progress / log messages.
+func (c *Client) receiveLoop() {
+	defer close(c.rxDone)
+	ctx := context.Background()
+	for {
+		msg, err := c.transport.Receive(ctx)
+		if err != nil {
+			c.abortPending(err)
+			return
+		}
+		if msg.IsResponse() {
+			c.deliverResponse(msg)
+			continue
+		}
+		// Server-initiated request or notification: ignore for v1. A
+		// future revision can add a handler hook here.
+	}
+}
+
+func (c *Client) deliverResponse(m *Message) {
+	c.pendingMu.Lock()
+	ch, ok := c.pending[string(m.ID)]
+	delete(c.pending, string(m.ID))
+	c.pendingMu.Unlock()
+	if !ok {
+		return // unknown id — server bug or late delivery after timeout
+	}
+	ch <- m
+}
+
+func (c *Client) removePending(id string) {
+	c.pendingMu.Lock()
+	if ch, ok := c.pending[id]; ok {
+		delete(c.pending, id)
+		close(ch)
+	}
+	c.pendingMu.Unlock()
+}
+
+func (c *Client) abortPending(_ error) {
+	c.pendingMu.Lock()
+	for id, ch := range c.pending {
+		close(ch)
+		delete(c.pending, id)
+	}
+	c.pendingMu.Unlock()
+}
+
+// Close tears the transport down and unblocks any pending Call(). Safe to
+// call multiple times.
+func (c *Client) Close() error {
+	if !c.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	err := c.transport.Close()
+	// Wait briefly for the receive loop to notice — best-effort. If the
+	// transport's Close didn't unblock Receive (rare), we don't hang here.
+	select {
+	case <-c.rxDone:
+	default:
+	}
+	c.abortPending(nil)
+	return err
+}
+
+// ── Typed convenience wrappers ───────────────────────────────────────────
+
+func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
+	if c.caps.Tools == nil {
+		return nil, nil
+	}
+	var r ListToolsResult
+	if err := c.Call(ctx, MethodToolsList, struct{}{}, &r); err != nil {
+		return nil, err
+	}
+	return r.Tools, nil
+}
+
+func (c *Client) CallTool(ctx context.Context, name string, args map[string]any) (*CallToolResult, error) {
+	var r CallToolResult
+	if err := c.Call(ctx, MethodToolsCall, CallToolParams{Name: name, Arguments: args}, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func (c *Client) ListResources(ctx context.Context) ([]Resource, error) {
+	if c.caps.Resources == nil {
+		return nil, nil
+	}
+	var r ListResourcesResult
+	if err := c.Call(ctx, MethodResourcesList, struct{}{}, &r); err != nil {
+		return nil, err
+	}
+	return r.Resources, nil
+}
+
+func (c *Client) ReadResource(ctx context.Context, uri string) ([]ResourceContent, error) {
+	var r ReadResourceResult
+	if err := c.Call(ctx, MethodResourcesRead, ReadResourceParams{URI: uri}, &r); err != nil {
+		return nil, err
+	}
+	return r.Contents, nil
+}
+
+func (c *Client) ListPrompts(ctx context.Context) ([]Prompt, error) {
+	if c.caps.Prompts == nil {
+		return nil, nil
+	}
+	var r ListPromptsResult
+	if err := c.Call(ctx, MethodPromptsList, struct{}{}, &r); err != nil {
+		return nil, err
+	}
+	return r.Prompts, nil
+}
+
+func (c *Client) GetPrompt(ctx context.Context, name string, args map[string]string) (*GetPromptResult, error) {
+	var r GetPromptResult
+	if err := c.Call(ctx, MethodPromptsGet, GetPromptParams{Name: name, Arguments: args}, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -1,0 +1,358 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// mockTransport is a paired-channel transport for unit tests. The mock
+// server runs in a goroutine, reading inbound frames off the in channel and
+// pushing replies / notifications to the out channel.
+type mockTransport struct {
+	out    chan *Message
+	in     chan *Message
+	closed atomic.Bool
+}
+
+func newMockTransport() *mockTransport {
+	return &mockTransport{
+		out: make(chan *Message, 16),
+		in:  make(chan *Message, 16),
+	}
+}
+
+func (m *mockTransport) Send(ctx context.Context, msg *Message) error {
+	if m.closed.Load() {
+		return errors.New("closed")
+	}
+	select {
+	case m.in <- msg:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (m *mockTransport) Receive(ctx context.Context) (*Message, error) {
+	select {
+	case msg, ok := <-m.out:
+		if !ok {
+			return nil, io.EOF
+		}
+		return msg, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (m *mockTransport) Close() error {
+	if !m.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	close(m.out)
+	return nil
+}
+
+// mockServer is the goroutine driving mockTransport from the server side.
+// It mirrors a real MCP server: handles initialize + lists + tool calls
+// with canned responses. The optional handlers map lets tests override per-
+// method behaviour.
+type mockServer struct {
+	t        *testing.T
+	tx       *mockTransport
+	caps     ServerCapabilities
+	tools    []Tool
+	resmap   map[string][]ResourceContent
+	promap   map[string]GetPromptResult
+	wg       sync.WaitGroup
+	stopped  chan struct{}
+	stopOnce sync.Once
+}
+
+func newMockServer(t *testing.T) *mockServer {
+	return &mockServer{
+		t:       t,
+		tx:      newMockTransport(),
+		stopped: make(chan struct{}),
+		// Default: all surfaces enabled. Tests can override before start.
+		caps: ServerCapabilities{
+			Tools:     &ToolsCapability{},
+			Resources: &ResourcesCapability{},
+			Prompts:   &PromptsCapability{},
+		},
+	}
+}
+
+// reply sends a success response for the given request id and result.
+func (s *mockServer) reply(id json.RawMessage, result any) {
+	b, _ := json.Marshal(result)
+	s.tx.out <- &Message{JSONRPC: "2.0", ID: id, Result: b}
+}
+
+func (s *mockServer) replyError(id json.RawMessage, code int, msg string) {
+	s.tx.out <- &Message{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &RPCError{Code: code, Message: msg},
+	}
+}
+
+func (s *mockServer) start() {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for {
+			select {
+			case <-s.stopped:
+				return
+			case req, ok := <-s.tx.in:
+				if !ok {
+					return
+				}
+				if req.IsNotification() {
+					continue // ignore notifications/initialized etc.
+				}
+				switch req.Method {
+				case MethodInitialize:
+					s.reply(req.ID, InitializeResult{
+						ProtocolVersion: ProtocolVersion,
+						Capabilities:    s.caps,
+						ServerInfo:      Implementation{Name: "mockserver", Version: "0.0.1"},
+						Instructions:    "use the echo tool",
+					})
+				case MethodToolsList:
+					s.reply(req.ID, ListToolsResult{Tools: s.tools})
+				case MethodToolsCall:
+					var p CallToolParams
+					_ = json.Unmarshal(req.Params, &p)
+					s.reply(req.ID, CallToolResult{
+						Content: []Content{{Type: "text", Text: "echo:" + p.Name}},
+					})
+				case MethodResourcesList:
+					var rs []Resource
+					for uri := range s.resmap {
+						rs = append(rs, Resource{URI: uri, Name: uri})
+					}
+					s.reply(req.ID, ListResourcesResult{Resources: rs})
+				case MethodResourcesRead:
+					var p ReadResourceParams
+					_ = json.Unmarshal(req.Params, &p)
+					contents, ok := s.resmap[p.URI]
+					if !ok {
+						s.replyError(req.ID, -32602, "no such resource")
+						continue
+					}
+					s.reply(req.ID, ReadResourceResult{Contents: contents})
+				case MethodPromptsList:
+					var ps []Prompt
+					for name := range s.promap {
+						ps = append(ps, Prompt{Name: name})
+					}
+					s.reply(req.ID, ListPromptsResult{Prompts: ps})
+				case MethodPromptsGet:
+					var p GetPromptParams
+					_ = json.Unmarshal(req.Params, &p)
+					r, ok := s.promap[p.Name]
+					if !ok {
+						s.replyError(req.ID, -32602, "no such prompt")
+						continue
+					}
+					s.reply(req.ID, r)
+				default:
+					s.replyError(req.ID, -32601, "method not found: "+req.Method)
+				}
+			}
+		}
+	}()
+}
+
+func (s *mockServer) stop() {
+	s.stopOnce.Do(func() {
+		close(s.stopped)
+		_ = s.tx.Close()
+	})
+	s.wg.Wait()
+}
+
+func TestClient_InitializeRoundtrip(t *testing.T) {
+	srv := newMockServer(t)
+	srv.start()
+	defer srv.stop()
+
+	c := NewClient(srv.tx, Implementation{Name: "test", Version: "0.1"})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if got := c.ServerInfo().Name; got != "mockserver" {
+		t.Errorf("ServerInfo.Name = %q", got)
+	}
+	if c.Capabilities().Tools == nil {
+		t.Error("expected Tools capability")
+	}
+	if c.Instructions() != "use the echo tool" {
+		t.Errorf("Instructions = %q", c.Instructions())
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClient_ListAndCallTool(t *testing.T) {
+	srv := newMockServer(t)
+	srv.tools = []Tool{
+		{Name: "echo", Description: "echoes back", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	srv.start()
+	defer srv.stop()
+
+	c := NewClient(srv.tx, Implementation{Name: "test", Version: "0.1"})
+	ctx := context.Background()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	tools, err := c.ListTools(ctx)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "echo" {
+		t.Fatalf("ListTools = %v", tools)
+	}
+	res, err := c.CallTool(ctx, "echo", map[string]any{"x": 1})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if len(res.Content) != 1 || res.Content[0].Text != "echo:echo" {
+		t.Errorf("CallTool result = %+v", res)
+	}
+}
+
+func TestClient_ReadResource(t *testing.T) {
+	srv := newMockServer(t)
+	srv.resmap = map[string][]ResourceContent{
+		"file:///etc/hosts": {
+			{URI: "file:///etc/hosts", MIMEType: "text/plain", Text: "127.0.0.1 localhost"},
+		},
+	}
+	srv.start()
+	defer srv.stop()
+
+	c := NewClient(srv.tx, Implementation{Name: "test", Version: "0.1"})
+	ctx := context.Background()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	resources, err := c.ListResources(ctx)
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("ListResources = %v", resources)
+	}
+	contents, err := c.ReadResource(ctx, "file:///etc/hosts")
+	if err != nil {
+		t.Fatalf("ReadResource: %v", err)
+	}
+	if len(contents) != 1 || contents[0].Text != "127.0.0.1 localhost" {
+		t.Errorf("ReadResource = %+v", contents)
+	}
+}
+
+func TestClient_GetPrompt(t *testing.T) {
+	srv := newMockServer(t)
+	srv.promap = map[string]GetPromptResult{
+		"summarise": {
+			Description: "summarise a text",
+			Messages: []PromptMessage{
+				{Role: "user", Content: Content{Type: "text", Text: "Please summarise."}},
+			},
+		},
+	}
+	srv.start()
+	defer srv.stop()
+
+	c := NewClient(srv.tx, Implementation{Name: "test", Version: "0.1"})
+	ctx := context.Background()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	prompts, err := c.ListPrompts(ctx)
+	if err != nil {
+		t.Fatalf("ListPrompts: %v", err)
+	}
+	if len(prompts) != 1 {
+		t.Fatalf("ListPrompts = %v", prompts)
+	}
+	r, err := c.GetPrompt(ctx, "summarise", nil)
+	if err != nil {
+		t.Fatalf("GetPrompt: %v", err)
+	}
+	if r.Description != "summarise a text" {
+		t.Errorf("Description = %q", r.Description)
+	}
+}
+
+func TestClient_RPCErrorPropagates(t *testing.T) {
+	srv := newMockServer(t)
+	srv.start()
+	defer srv.stop()
+
+	c := NewClient(srv.tx, Implementation{Name: "test", Version: "0.1"})
+	ctx := context.Background()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	// Unknown resource → server replies with code -32602.
+	_, err := c.ReadResource(ctx, "file:///does-not-exist")
+	if err == nil {
+		t.Fatal("expected RPC error")
+	}
+	var rpcErr *RPCError
+	if !errors.As(err, &rpcErr) {
+		t.Errorf("expected *RPCError, got %T", err)
+	}
+}
+
+func TestClient_CallAfterCloseFails(t *testing.T) {
+	srv := newMockServer(t)
+	srv.start()
+	defer srv.stop()
+
+	c := NewClient(srv.tx, Implementation{Name: "test", Version: "0.1"})
+	if err := c.Initialize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	c.Close()
+	if _, err := c.ListTools(context.Background()); err == nil {
+		t.Error("expected error after Close")
+	}
+}
+
+func TestClient_ContextCancellation(t *testing.T) {
+	srv := newMockServer(t)
+	srv.start()
+	defer srv.stop()
+
+	c := NewClient(srv.tx, Implementation{Name: "test", Version: "0.1"})
+	if err := c.Initialize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drain the server briefly so the next call sees the cancellation, not
+	// a normal reply.
+	srv.stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := c.ListTools(ctx)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -1,0 +1,152 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Config is the parsed view of one mcp.json file. The wire format mirrors
+// Claude Code so users can copy-paste configs between the two:
+//
+//	{
+//	  "mcpServers": {
+//	    "filesystem": {
+//	      "command": "npx",
+//	      "args":    ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+//	      "env":     {"FOO": "bar"}
+//	    },
+//	    "remote-api": {
+//	      "url":     "https://example.com/mcp",
+//	      "headers": {"Authorization": "Bearer ..."}
+//	    }
+//	  }
+//	}
+//
+// A server entry is classified as stdio if Command is non-empty, HTTP if
+// URL is non-empty. Both set is an error.
+type Config struct {
+	Servers map[string]ServerEntry `json:"mcpServers"`
+}
+
+// ServerEntry is the union of stdio + HTTP shapes. The transport-specific
+// fields are mutually exclusive — Validate enforces it.
+type ServerEntry struct {
+	// stdio fields
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+
+	// HTTP fields
+	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+
+	// Optional: disable a server without removing it from config.
+	Disabled bool `json:"disabled,omitempty"`
+}
+
+// Kind reports which transport this entry uses. Returns "" when neither
+// (caller treats it as an invalid entry and skips it).
+func (e ServerEntry) Kind() string {
+	if e.Command != "" {
+		return "stdio"
+	}
+	if e.URL != "" {
+		return "http"
+	}
+	return ""
+}
+
+// Validate enforces the union invariant — exactly one of Command/URL set —
+// and surfaces a usable error message identifying the offender. Called by
+// Load before returning so callers get pre-validated entries.
+func (e ServerEntry) Validate(name string) error {
+	if e.Command == "" && e.URL == "" {
+		return fmt.Errorf("mcp server %q: must set either 'command' (stdio) or 'url' (http)", name)
+	}
+	if e.Command != "" && e.URL != "" {
+		return fmt.Errorf("mcp server %q: cannot set both 'command' and 'url'", name)
+	}
+	return nil
+}
+
+// LoadConfig reads + merges the user-global config and the project-local
+// config, returning the merged result.
+//
+//   - User-global lives at ~/.octo/mcp.json. Always loaded if present.
+//   - Project-local lives at <projectDir>/.octo/mcp.json. Loaded when
+//     projectDir is non-empty AND the file exists.
+//
+// Merge rule: project-local entries OVERRIDE user-global entries with the
+// same name. This matches the skills layer's same-name precedence so
+// users can keep a shared user-global config and tweak per-project.
+//
+// Disabled entries are filtered out at load time. Missing files are not an
+// error — they produce a zero-server config.
+func LoadConfig(projectDir string) (*Config, error) {
+	merged := &Config{Servers: map[string]ServerEntry{}}
+
+	// 1. User-global.
+	if home, err := os.UserHomeDir(); err == nil {
+		userPath := filepath.Join(home, ".octo", "mcp.json")
+		if cfg, err := readConfigFile(userPath); err != nil {
+			return nil, err
+		} else if cfg != nil {
+			for name, e := range cfg.Servers {
+				merged.Servers[name] = e
+			}
+		}
+	}
+
+	// 2. Project-local (overrides user-global on name collision).
+	if projectDir != "" {
+		projPath := filepath.Join(projectDir, ".octo", "mcp.json")
+		if cfg, err := readConfigFile(projPath); err != nil {
+			return nil, err
+		} else if cfg != nil {
+			for name, e := range cfg.Servers {
+				merged.Servers[name] = e
+			}
+		}
+	}
+
+	// 3. Filter disabled + validate the rest.
+	for name, e := range merged.Servers {
+		if e.Disabled {
+			delete(merged.Servers, name)
+			continue
+		}
+		if err := e.Validate(name); err != nil {
+			return nil, err
+		}
+	}
+	return merged, nil
+}
+
+// ServerNames returns the configured server names in stable sorted order,
+// useful for deterministic /mcp output.
+func (c *Config) ServerNames() []string {
+	names := make([]string, 0, len(c.Servers))
+	for n := range c.Servers {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func readConfigFile(path string) (*Config, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("mcp: read %s: %w", path, err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return nil, fmt.Errorf("mcp: parse %s: %w", path, err)
+	}
+	return &cfg, nil
+}

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -1,0 +1,146 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestLoadConfig_MissingFilesIsZero(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.Servers) != 0 {
+		t.Errorf("expected empty config, got %d servers", len(cfg.Servers))
+	}
+}
+
+func TestLoadConfig_UserGlobalOnly(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	writeFile(t, filepath.Join(tmp, ".octo", "mcp.json"), `{
+        "mcpServers": {
+          "fs": {"command": "npx", "args": ["-y", "server-filesystem"]}
+        }
+    }`)
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got := cfg.Servers["fs"].Command; got != "npx" {
+		t.Errorf("fs.Command = %q", got)
+	}
+	if got := cfg.Servers["fs"].Kind(); got != "stdio" {
+		t.Errorf("fs.Kind() = %q, want stdio", got)
+	}
+}
+
+func TestLoadConfig_ProjectOverridesUserGlobal(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	writeFile(t, filepath.Join(tmp, ".octo", "mcp.json"), `{
+        "mcpServers": {
+          "fs": {"command": "global-fs"}
+        }
+    }`)
+	proj := t.TempDir()
+	writeFile(t, filepath.Join(proj, ".octo", "mcp.json"), `{
+        "mcpServers": {
+          "fs":     {"command": "project-fs"},
+          "github": {"url": "https://gh.example/mcp"}
+        }
+    }`)
+	cfg, err := LoadConfig(proj)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	// "fs" overridden by project entry.
+	if got := cfg.Servers["fs"].Command; got != "project-fs" {
+		t.Errorf("expected project override, got %q", got)
+	}
+	// "github" comes from project only.
+	if got := cfg.Servers["github"].URL; got != "https://gh.example/mcp" {
+		t.Errorf("github.URL = %q", got)
+	}
+	if got := cfg.Servers["github"].Kind(); got != "http" {
+		t.Errorf("github.Kind() = %q, want http", got)
+	}
+}
+
+func TestLoadConfig_DisabledIsSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	writeFile(t, filepath.Join(tmp, ".octo", "mcp.json"), `{
+        "mcpServers": {
+          "off": {"command": "x", "disabled": true},
+          "on":  {"command": "y"}
+        }
+    }`)
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if _, ok := cfg.Servers["off"]; ok {
+		t.Error("disabled entry should be filtered out")
+	}
+	if _, ok := cfg.Servers["on"]; !ok {
+		t.Error("non-disabled entry missing")
+	}
+}
+
+func TestLoadConfig_ValidationRejectsBothTransports(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	writeFile(t, filepath.Join(tmp, ".octo", "mcp.json"), `{
+        "mcpServers": {
+          "bad": {"command": "x", "url": "https://example.com/mcp"}
+        }
+    }`)
+	if _, err := LoadConfig(""); err == nil {
+		t.Fatal("expected validation error for entry with both command and url")
+	}
+}
+
+func TestLoadConfig_ValidationRejectsNeither(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	writeFile(t, filepath.Join(tmp, ".octo", "mcp.json"), `{
+        "mcpServers": {
+          "bad": {"env": {"X": "y"}}
+        }
+    }`)
+	if _, err := LoadConfig(""); err == nil {
+		t.Fatal("expected validation error for entry with neither command nor url")
+	}
+}
+
+func TestConfig_ServerNames_Sorted(t *testing.T) {
+	c := &Config{Servers: map[string]ServerEntry{
+		"z": {Command: "a"},
+		"a": {Command: "a"},
+		"m": {Command: "a"},
+	}}
+	names := c.ServerNames()
+	if names[0] != "a" || names[1] != "m" || names[2] != "z" {
+		t.Errorf("expected sorted names, got %v", names)
+	}
+}

--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -1,0 +1,188 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+)
+
+// HTTPTransport speaks JSON-RPC 2.0 over a single HTTP endpoint, per the
+// MCP "Streamable HTTP" transport in spec 2024-11-05.
+//
+// What we implement
+//   - POST one JSON-RPC frame per request, body Content-Type application/json.
+//   - Each response body holds exactly one JSON-RPC frame (the response to
+//     the request we just sent). We treat that as a synchronous RPC.
+//   - The server-issued Mcp-Session-Id header is captured on the first
+//     response and echoed on every subsequent request, so the server can
+//     resume per-client state.
+//
+// What we don't implement (v1 omission)
+//   - The SSE upgrade path (server responding with text/event-stream and
+//     streaming multiple frames). Almost no server requires it for the
+//     tools/list / tools/call request-response flow we care about.
+//   - The optional GET endpoint for server-initiated notifications.
+//   - Bidirectional concurrent sends. The client serialises one request at
+//     a time anyway.
+//
+// Receive is wired through an in-memory channel: each Send queues the
+// parsed response, Receive pops the next one. This keeps the same
+// "Send / Receive interleaved" interface stdio uses, so the client logic
+// is transport-agnostic.
+type HTTPTransport struct {
+	url     string
+	headers map[string]string
+	hc      *http.Client
+
+	// Session id is empty until the first server response sets it via
+	// Mcp-Session-Id. Subsequent requests echo it back.
+	sessionMu sync.Mutex
+	sessionID string
+
+	// inbox queues the response of each Send so Receive can hand it back.
+	// Buffered so a Send never blocks (paired with one Receive per Send,
+	// the channel never grows unboundedly).
+	inbox  chan *Message
+	closed atomic.Bool
+}
+
+// HTTPConfig is the configuration end-users pass via mcp.json — URL plus
+// optional static headers (Authorization, custom auth, etc.). Headers
+// values are sent verbatim; we don't expand env-var placeholders here, that
+// happens in the config layer before we land on this struct.
+type HTTPConfig struct {
+	URL     string
+	Headers map[string]string
+}
+
+// NewHTTPTransport builds an HTTPTransport ready to Send / Receive.
+// No network I/O happens until the first Send.
+func NewHTTPTransport(cfg HTTPConfig) (*HTTPTransport, error) {
+	if cfg.URL == "" {
+		return nil, errors.New("mcp: http transport: empty URL")
+	}
+	return &HTTPTransport{
+		url:     cfg.URL,
+		headers: cfg.Headers,
+		hc:      &http.Client{},
+		// 16 is generous — the synchronous Send/Receive pattern only ever
+		// has one outstanding response, but headroom protects against any
+		// pipelining we might add later.
+		inbox: make(chan *Message, 16),
+	}, nil
+}
+
+// Send POSTs msg to the configured URL and queues the response for the
+// next Receive call. Honors the documented Send-then-Receive pairing — one
+// Send does exactly one HTTP round-trip and yields exactly one frame.
+func (t *HTTPTransport) Send(ctx context.Context, msg *Message) error {
+	if t.closed.Load() {
+		return errors.New("mcp: http transport: closed")
+	}
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("mcp: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("mcp: request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// MCP spec: clients MUST include Accept with both JSON and SSE so the
+	// server can pick. We hand-pick the order so a server that supports
+	// both prefers plain JSON (which we know how to decode synchronously).
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	for k, v := range t.headers {
+		req.Header.Set(k, v)
+	}
+	t.sessionMu.Lock()
+	if t.sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", t.sessionID)
+	}
+	t.sessionMu.Unlock()
+
+	resp, err := t.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("mcp: do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Capture session id on first response (and tolerate the server
+	// rotating it on subsequent calls — spec lets them).
+	if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
+		t.sessionMu.Lock()
+		t.sessionID = sid
+		t.sessionMu.Unlock()
+	}
+
+	if resp.StatusCode == http.StatusNoContent {
+		// 204: server accepted a notification. No body to parse, no inbox
+		// queue — the client doesn't expect a response for notifications.
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("mcp: http %d: %s", resp.StatusCode, bytes.TrimSpace(b))
+	}
+
+	// We only handle plain-JSON responses for v1. If the server insists on
+	// text/event-stream we surface a clear error rather than silently
+	// hanging — the user can pick a different server or file an issue.
+	ct := resp.Header.Get("Content-Type")
+	if ct != "" && !isJSONContentType(ct) {
+		return fmt.Errorf("mcp: http: unsupported response Content-Type %q (v1 needs application/json)", ct)
+	}
+
+	var m Message
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return fmt.Errorf("mcp: decode response: %w", err)
+	}
+	select {
+	case t.inbox <- &m:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}
+
+// Receive blocks for the next queued response. The pairing with Send is
+// strict: one Send produces one inbox entry, one Receive consumes it.
+func (t *HTTPTransport) Receive(ctx context.Context) (*Message, error) {
+	select {
+	case m, ok := <-t.inbox:
+		if !ok {
+			return nil, io.EOF
+		}
+		return m, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Close tears the transport down. Idempotent. After Close, any pending
+// Receive caller is unblocked with io.EOF; further Sends return an error.
+func (t *HTTPTransport) Close() error {
+	if !t.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	close(t.inbox)
+	return nil
+}
+
+// isJSONContentType reports whether ct (a Content-Type header value)
+// indicates a JSON-RPC body. Tolerant of the "; charset=utf-8" suffix and
+// the legacy "application/json-rpc" alias some servers use.
+func isJSONContentType(ct string) bool {
+	for _, prefix := range []string{"application/json", "application/json-rpc"} {
+		if len(ct) >= len(prefix) && ct[:len(prefix)] == prefix {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/http_test.go
+++ b/internal/mcp/http_test.go
@@ -1,0 +1,139 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHTTPTransport_RoundtripWithSessionHeader(t *testing.T) {
+	// Server echoes back a canned "result". On the first request it also
+	// sets Mcp-Session-Id; subsequent requests must echo it back.
+	var seenSession string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var in Message
+		_ = json.Unmarshal(body, &in)
+
+		// Record / verify the session id round-trip.
+		if seenSession == "" {
+			w.Header().Set("Mcp-Session-Id", "session-42")
+			seenSession = "session-42"
+		} else if got := r.Header.Get("Mcp-Session-Id"); got != seenSession {
+			t.Errorf("expected session header %q, got %q", seenSession, got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Reply matches the request id.
+		_ = json.NewEncoder(w).Encode(Message{
+			JSONRPC: "2.0",
+			ID:      in.ID,
+			Result:  json.RawMessage(`{"ok":true}`),
+		})
+	}))
+	defer srv.Close()
+
+	tx, err := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// First request — server should set the session id.
+	req1 := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+	if err := tx.Send(ctx, req1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Receive(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second request — client should echo session id; the server above
+	// asserts on a mismatch.
+	req2 := &Message{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/list"}
+	if err := tx.Send(ctx, req2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Receive(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHTTPTransport_ErrorStatusSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("kaboom"))
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+	req := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+	err := tx.Send(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for non-2xx response")
+	}
+}
+
+func TestHTTPTransport_HeadersPassedThrough(t *testing.T) {
+	var seenAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Message{
+			JSONRPC: "2.0",
+			ID:      json.RawMessage(`1`),
+			Result:  json.RawMessage(`{}`),
+		})
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{
+		URL:     srv.URL,
+		Headers: map[string]string{"Authorization": "Bearer abc"},
+	})
+	defer tx.Close()
+
+	req := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+	if err := tx.Send(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Receive(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if seenAuth != "Bearer abc" {
+		t.Errorf("Authorization header = %q, want Bearer abc", seenAuth)
+	}
+}
+
+func TestHTTPTransport_NotificationGet204(t *testing.T) {
+	// Server returns 204 No Content — this is the path for an accepted
+	// notification (no body to parse).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	tx, _ := NewHTTPTransport(HTTPConfig{URL: srv.URL})
+	defer tx.Close()
+
+	notif := &Message{JSONRPC: "2.0", Method: "notifications/initialized"}
+	if err := tx.Send(context.Background(), notif); err != nil {
+		t.Errorf("notification Send returned error: %v", err)
+	}
+}
+
+func TestNewHTTPTransport_EmptyURLRejected(t *testing.T) {
+	_, err := NewHTTPTransport(HTTPConfig{})
+	if err == nil {
+		t.Error("expected error for empty URL")
+	}
+}

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -1,0 +1,265 @@
+// Package mcp implements a Model Context Protocol client for octo. It speaks
+// MCP spec version 2024-11-05 over either stdio (subprocess) or Streamable
+// HTTP transports, and exposes the tools / resources / prompts surfaces a
+// server can advertise.
+//
+// What this package does NOT cover (deliberately, for v1):
+//   - server-initiated notifications (list_changed, progress, log) — connect,
+//     list once, call;
+//   - resource subscriptions;
+//   - sampling (server asking client to call the LLM);
+//   - roots (client advertising filesystem roots to the server).
+//
+// The package is pure protocol + transport — adapting an MCP server's surface
+// into octo's tool layer is done in cmd/octo so this package stays free of
+// any agent / tool dependencies.
+package mcp
+
+import (
+	"encoding/json"
+)
+
+// ProtocolVersion is the MCP spec revision this client implements. Sent in
+// the initialize request; the server is expected to echo it back (or a
+// compatible newer/older version it can downgrade to). We don't currently
+// negotiate — if the server returns a different version we accept it and
+// hope for the best.
+const ProtocolVersion = "2024-11-05"
+
+// ── JSON-RPC 2.0 frame ───────────────────────────────────────────────────
+//
+// A single Message struct covers all three frame shapes — request,
+// notification, response — because the wire format is the same and Go's
+// optional-field encoding (omitempty + nil pointers / empty slices) lets us
+// distinguish them at marshal time. Sentinel helpers IsRequest /
+// IsNotification / IsResponse classify a decoded message at read time.
+//
+// ID is held as json.RawMessage because the JSON-RPC spec permits numbers,
+// strings, or null. We always issue numeric IDs ourselves, but a strict
+// server might echo back the literal we sent (e.g. "1" vs 1) and matching
+// on the byte representation keeps us tolerant.
+
+type Message struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// RPCError is the standard JSON-RPC 2.0 error object. Code follows the spec
+// reserved ranges: -32700 parse, -32600 invalid request, -32601 method not
+// found, -32602 invalid params, -32603 internal, -32000..-32099 server.
+// MCP-specific codes (if any) ride in the same field.
+type RPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *RPCError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+// IsRequest reports whether the message is a request (method set, id set).
+func (m *Message) IsRequest() bool { return m.Method != "" && len(m.ID) > 0 }
+
+// IsNotification reports whether the message is a notification (method set,
+// no id). Servers send these when they don't expect a response (e.g.
+// notifications/initialized from the client, or notifications/progress from
+// the server).
+func (m *Message) IsNotification() bool { return m.Method != "" && len(m.ID) == 0 }
+
+// IsResponse reports whether the message is a response — either result or
+// error, never both, always with an id.
+func (m *Message) IsResponse() bool { return m.Method == "" && len(m.ID) > 0 }
+
+// ── MCP method names ─────────────────────────────────────────────────────
+
+const (
+	MethodInitialize    = "initialize"
+	MethodInitialized   = "notifications/initialized"
+	MethodToolsList     = "tools/list"
+	MethodToolsCall     = "tools/call"
+	MethodResourcesList = "resources/list"
+	MethodResourcesRead = "resources/read"
+	MethodPromptsList   = "prompts/list"
+	MethodPromptsGet    = "prompts/get"
+	MethodShutdown      = "shutdown"
+)
+
+// ── initialize handshake ─────────────────────────────────────────────────
+
+// InitializeParams is the payload of the client → server initialize request.
+// We advertise an empty capabilities object because v1 doesn't implement
+// sampling or roots — both are server → client features. ClientInfo is just
+// nameplate metadata the server may log.
+type InitializeParams struct {
+	ProtocolVersion string             `json:"protocolVersion"`
+	Capabilities    ClientCapabilities `json:"capabilities"`
+	ClientInfo      Implementation     `json:"clientInfo"`
+}
+
+type ClientCapabilities struct {
+	// Future: Roots, Sampling. Left empty for v1.
+	Experimental map[string]any `json:"experimental,omitempty"`
+}
+
+type Implementation struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// InitializeResult comes back from the server. ServerInfo is informational
+// (we log it in /mcp output). Capabilities tells us which surfaces the
+// server actually supports — we use those flags to decide whether to call
+// tools/list / resources/list / prompts/list at connect time.
+type InitializeResult struct {
+	ProtocolVersion string             `json:"protocolVersion"`
+	Capabilities    ServerCapabilities `json:"capabilities"`
+	ServerInfo      Implementation     `json:"serverInfo"`
+	Instructions    string             `json:"instructions,omitempty"`
+}
+
+type ServerCapabilities struct {
+	Tools     *ToolsCapability     `json:"tools,omitempty"`
+	Resources *ResourcesCapability `json:"resources,omitempty"`
+	Prompts   *PromptsCapability   `json:"prompts,omitempty"`
+	Logging   *struct{}            `json:"logging,omitempty"`
+}
+
+type ToolsCapability struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+type ResourcesCapability struct {
+	Subscribe   bool `json:"subscribe,omitempty"`
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+type PromptsCapability struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+// ── tools ────────────────────────────────────────────────────────────────
+
+type Tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"inputSchema,omitempty"`
+}
+
+type ListToolsResult struct {
+	Tools      []Tool `json:"tools"`
+	NextCursor string `json:"nextCursor,omitempty"`
+}
+
+type CallToolParams struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments,omitempty"`
+}
+
+// CallToolResult carries the tool's output as a list of content blocks,
+// matching the agent's existing multi-content shape. IsError signals that
+// the server ran the tool but it failed — distinct from an RPC error,
+// which means the call itself didn't reach the tool.
+type CallToolResult struct {
+	Content []Content `json:"content"`
+	IsError bool      `json:"isError,omitempty"`
+}
+
+// Content covers the four block types MCP defines: text, image, audio, and
+// embedded resource. Only Type and the type-specific fields are populated
+// per block; the other fields stay zero.
+type Content struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	Data     string `json:"data,omitempty"`     // base64; image/audio
+	MIMEType string `json:"mimeType,omitempty"` // image/audio/resource
+	// Embedded resource shape (type == "resource"): the nested Resource holds
+	// uri + name + mimeType + text/blob.
+	Resource *EmbeddedResource `json:"resource,omitempty"`
+}
+
+type EmbeddedResource struct {
+	URI      string `json:"uri"`
+	Name     string `json:"name,omitempty"`
+	MIMEType string `json:"mimeType,omitempty"`
+	Text     string `json:"text,omitempty"`
+	Blob     string `json:"blob,omitempty"`
+}
+
+// ── resources ────────────────────────────────────────────────────────────
+
+type Resource struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	MIMEType    string `json:"mimeType,omitempty"`
+}
+
+type ListResourcesResult struct {
+	Resources  []Resource `json:"resources"`
+	NextCursor string     `json:"nextCursor,omitempty"`
+}
+
+type ReadResourceParams struct {
+	URI string `json:"uri"`
+}
+
+type ReadResourceResult struct {
+	Contents []ResourceContent `json:"contents"`
+}
+
+// ResourceContent is a single chunk of a resource read. The server returns
+// at least one — for a plain file it's typically one Text chunk; for a
+// multi-part resource it can be several. Text and Blob are mutually
+// exclusive (blob is base64-encoded binary).
+type ResourceContent struct {
+	URI      string `json:"uri"`
+	MIMEType string `json:"mimeType,omitempty"`
+	Text     string `json:"text,omitempty"`
+	Blob     string `json:"blob,omitempty"`
+}
+
+// ── prompts ──────────────────────────────────────────────────────────────
+
+type Prompt struct {
+	Name        string           `json:"name"`
+	Description string           `json:"description,omitempty"`
+	Arguments   []PromptArgument `json:"arguments,omitempty"`
+}
+
+type PromptArgument struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+}
+
+type ListPromptsResult struct {
+	Prompts    []Prompt `json:"prompts"`
+	NextCursor string   `json:"nextCursor,omitempty"`
+}
+
+type GetPromptParams struct {
+	Name      string            `json:"name"`
+	Arguments map[string]string `json:"arguments,omitempty"`
+}
+
+// GetPromptResult is the materialised prompt — a list of role-tagged messages
+// the server expanded from its template. The user-facing tool drops them
+// into the conversation; the role distinction (user / assistant) matters
+// for chains-of-thought prompts.
+type GetPromptResult struct {
+	Description string          `json:"description,omitempty"`
+	Messages    []PromptMessage `json:"messages"`
+}
+
+type PromptMessage struct {
+	Role    string  `json:"role"`
+	Content Content `json:"content"`
+}

--- a/internal/mcp/protocol_test.go
+++ b/internal/mcp/protocol_test.go
@@ -1,0 +1,79 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMessage_IsRequest(t *testing.T) {
+	m := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+	if !m.IsRequest() {
+		t.Error("expected IsRequest=true")
+	}
+	if m.IsNotification() {
+		t.Error("expected IsNotification=false")
+	}
+	if m.IsResponse() {
+		t.Error("expected IsResponse=false")
+	}
+}
+
+func TestMessage_IsNotification(t *testing.T) {
+	m := &Message{JSONRPC: "2.0", Method: "notifications/initialized"}
+	if !m.IsNotification() {
+		t.Error("expected IsNotification=true")
+	}
+	if m.IsRequest() {
+		t.Error("expected IsRequest=false")
+	}
+	if m.IsResponse() {
+		t.Error("expected IsResponse=false")
+	}
+}
+
+func TestMessage_IsResponse(t *testing.T) {
+	m := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Result: json.RawMessage(`{}`)}
+	if !m.IsResponse() {
+		t.Error("expected IsResponse=true")
+	}
+	if m.IsRequest() {
+		t.Error("expected IsRequest=false")
+	}
+}
+
+func TestMessage_MarshalShape(t *testing.T) {
+	// Request: id + method present, result/error/params optional.
+	m := &Message{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`5`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"echo"}`),
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"echo"}}`
+	if string(b) != want {
+		t.Errorf("marshal:\n  got  %s\n  want %s", b, want)
+	}
+}
+
+func TestRPCError_ErrorReturnsMessage(t *testing.T) {
+	e := &RPCError{Code: -32601, Message: "Method not found"}
+	if e.Error() != "Method not found" {
+		t.Errorf("Error() = %q", e.Error())
+	}
+	var nilErr *RPCError
+	if nilErr.Error() != "" {
+		t.Errorf("nil RPCError.Error() should be empty")
+	}
+}
+
+func TestProtocolVersion_IsSpecRevision(t *testing.T) {
+	// Sanity guard against accidental version bumps. If we ever upgrade
+	// this string the test should flag the change so it's intentional.
+	if ProtocolVersion != "2024-11-05" {
+		t.Errorf("ProtocolVersion = %q, expected the documented 2024-11-05 spec", ProtocolVersion)
+	}
+}

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -1,0 +1,166 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Registry owns the live MCP client connections for a session. Built once
+// at startup from a Config; tears all clients down on Close. Failures to
+// connect or initialize one server degrade — the server is skipped, its
+// error logged to stderr, and the registry keeps the survivors.
+//
+// This separation (Registry here vs. tool-adapter in cmd/octo) lets the
+// internal/mcp package stay free of any agent / tool dependencies.
+type Registry struct {
+	mu     sync.RWMutex
+	conns  map[string]*Connection // server name → live client
+	closed bool
+}
+
+// Connection is the per-server bundle of state the adapters need: the
+// client itself plus the pre-fetched tools/resources/prompts lists so the
+// agent loop doesn't re-list on every turn.
+type Connection struct {
+	Name      string
+	Client    *Client
+	Tools     []Tool
+	Resources []Resource
+	Prompts   []Prompt
+}
+
+// ConnectAll spins up one client per configured server, runs the
+// initialize handshake, and pre-fetches the surface lists. Failures are
+// reported via the warn writer (typically os.Stderr) and the server is
+// simply omitted — the user sees the error but the session still starts.
+//
+// The handshake + initial lists run with a per-server timeout so a single
+// hung server can't stall startup. Servers are connected sequentially to
+// keep startup logs readable; the connect cost is dominated by subprocess
+// spawn and a single round-trip, so v1 doesn't need parallelism.
+func ConnectAll(ctx context.Context, cfg *Config, info Implementation, warn io.Writer) *Registry {
+	r := &Registry{conns: map[string]*Connection{}}
+	if cfg == nil {
+		return r
+	}
+	for _, name := range cfg.ServerNames() {
+		entry := cfg.Servers[name]
+		conn, err := connectOne(ctx, name, entry, info)
+		if err != nil {
+			if warn != nil {
+				fmt.Fprintf(warn, "mcp: server %q skipped: %v\n", name, err)
+			}
+			continue
+		}
+		r.conns[name] = conn
+	}
+	return r
+}
+
+func connectOne(ctx context.Context, name string, entry ServerEntry, info Implementation) (*Connection, error) {
+	// 10s is generous for subprocess spawn + handshake but bounded enough
+	// that a misconfigured server doesn't keep a fresh chat blocked.
+	connectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	var transport Transport
+	switch entry.Kind() {
+	case "stdio":
+		t, err := NewStdioTransport(connectCtx, StdioConfig{
+			Command: entry.Command,
+			Args:    entry.Args,
+			Env:     entry.Env,
+		})
+		if err != nil {
+			return nil, err
+		}
+		transport = t
+	case "http":
+		t, err := NewHTTPTransport(HTTPConfig{
+			URL:     entry.URL,
+			Headers: entry.Headers,
+		})
+		if err != nil {
+			return nil, err
+		}
+		transport = t
+	default:
+		return nil, fmt.Errorf("invalid transport for server %q", name)
+	}
+
+	client := NewClient(transport, info)
+	if err := client.Initialize(connectCtx); err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+
+	conn := &Connection{Name: name, Client: client}
+	// Pre-fetch surface listings so per-turn calls don't pay an RPC just
+	// to enumerate. We tolerate per-surface failures — a server with
+	// broken resources/list still gets its tools/list cached.
+	if tools, err := client.ListTools(connectCtx); err == nil {
+		conn.Tools = tools
+	}
+	if resources, err := client.ListResources(connectCtx); err == nil {
+		conn.Resources = resources
+	}
+	if prompts, err := client.ListPrompts(connectCtx); err == nil {
+		conn.Prompts = prompts
+	}
+	return conn, nil
+}
+
+// Connections returns the live connections in stable order so /mcp output
+// is deterministic.
+func (r *Registry) Connections() []*Connection {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*Connection, 0, len(r.conns))
+	for _, name := range sortedKeys(r.conns) {
+		out = append(out, r.conns[name])
+	}
+	return out
+}
+
+// Get returns the named connection, or nil if no such server is live.
+func (r *Registry) Get(name string) *Connection {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.conns[name]
+}
+
+// Len reports how many servers connected successfully — useful for the
+// "Connected N MCP servers" startup line.
+func (r *Registry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.conns)
+}
+
+// Close tears every connection down. Idempotent. Errors per server are
+// dropped — Close is end-of-life and the user can't do anything with the
+// errors anyway.
+func (r *Registry) Close() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return
+	}
+	r.closed = true
+	for _, c := range r.conns {
+		_ = c.Client.Close()
+	}
+}
+
+func sortedKeys(m map[string]*Connection) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -1,0 +1,155 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+)
+
+// StdioTransport speaks JSON-RPC 2.0 over a subprocess's stdin/stdout. One
+// JSON object per line, UTF-8, no chunking. The subprocess inherits stderr
+// from the parent so its logs reach the user (and don't fill an unbounded
+// pipe). The transport owns the *exec.Cmd lifecycle: Start runs it, Close
+// closes stdin (signalling EOF to the child) and Wait()s for exit.
+type StdioTransport struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	dec    *json.Decoder
+
+	closeMu sync.Mutex
+	closed  atomic.Bool
+
+	// sendMu serialises writes so concurrent Send calls don't interleave
+	// JSON bytes on stdin.
+	sendMu sync.Mutex
+}
+
+// StdioConfig is the wire-format-agnostic spawn config. Env overrides extend
+// (not replace) the parent's environment so PATH / HOME stay available to
+// the child by default.
+type StdioConfig struct {
+	Command string
+	Args    []string
+	Env     map[string]string
+}
+
+// NewStdioTransport spawns the configured subprocess and wires its stdin /
+// stdout to a line-delimited JSON-RPC pipe. stderr is inherited so the
+// child's diagnostic logs appear directly under the parent's stderr.
+//
+// The returned transport is already running — Close will signal shutdown
+// by closing stdin (the conventional MCP "I'm done, please exit") and then
+// Wait()ing for exit so resources are released.
+func NewStdioTransport(ctx context.Context, cfg StdioConfig) (*StdioTransport, error) {
+	if cfg.Command == "" {
+		return nil, errors.New("mcp: stdio transport: empty command")
+	}
+	cmd := exec.CommandContext(ctx, cfg.Command, cfg.Args...)
+	// Inherit env + add/override the configured entries. Building a fresh
+	// slice keeps os.Environ() intact for the parent.
+	if len(cfg.Env) > 0 {
+		env := os.Environ()
+		for k, v := range cfg.Env {
+			env = append(env, k+"="+v)
+		}
+		cmd.Env = env
+	}
+	cmd.Stderr = os.Stderr // child's logs flow through to user terminal
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("mcp: start %s: %w", cfg.Command, err)
+	}
+
+	t := &StdioTransport{
+		cmd:    cmd,
+		stdin:  stdin,
+		stdout: stdout,
+		// bufio.Reader on stdout lets us read line-by-line; json.Decoder
+		// accepts a reader and tokenises whitespace-separated JSON values.
+		// Using a Decoder over a raw scanner lets us hand back nested
+		// objects without re-marshalling.
+		dec: json.NewDecoder(bufio.NewReaderSize(stdout, 64*1024)),
+	}
+	return t, nil
+}
+
+// Send writes msg as one line of JSON to the subprocess stdin. Concurrent
+// callers are serialised via sendMu so frames don't interleave.
+func (t *StdioTransport) Send(ctx context.Context, msg *Message) error {
+	if t.closed.Load() {
+		return errors.New("mcp: stdio transport: closed")
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("mcp: marshal: %w", err)
+	}
+	t.sendMu.Lock()
+	defer t.sendMu.Unlock()
+	// We append a newline so older MCP servers that read line-by-line (and
+	// many community implementations do) see a clean delimiter; newer
+	// JSON-aware decoders don't care either way.
+	b = append(b, '\n')
+	if _, err := t.stdin.Write(b); err != nil {
+		return fmt.Errorf("mcp: write: %w", err)
+	}
+	return nil
+}
+
+// Receive blocks for the next JSON object on stdout. The Decoder skips
+// whitespace between objects, so the wire format can be either one-object-
+// per-line or stream-with-no-delimiters — both work.
+//
+// Context cancellation is handled in two layers: (1) if ctx is already done
+// we return immediately; (2) cancelling ctx after Receive has blocked has
+// no direct hook (Decoder doesn't take ctx), so the canonical interrupt is
+// Close, which closes stdout and surfaces here as io.EOF.
+func (t *StdioTransport) Receive(ctx context.Context) (*Message, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if t.closed.Load() {
+		return nil, io.EOF
+	}
+	var m Message
+	if err := t.dec.Decode(&m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// Close shuts the subprocess down. The order matters: close stdin first so
+// the child sees EOF and can exit on its own (the polite shutdown signal
+// MCP servers expect), then Wait so process resources are reclaimed.
+// Idempotent — repeat calls return nil.
+func (t *StdioTransport) Close() error {
+	t.closeMu.Lock()
+	defer t.closeMu.Unlock()
+	if !t.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	// stdin.Close() can race with the Send path; we hold closeMu but Send
+	// only checks closed atomically before acquiring sendMu. The window is
+	// tiny and a failed write surfaces as an error to the caller — fine.
+	_ = t.stdin.Close()
+	_ = t.stdout.Close()
+	// Wait is best-effort: if the child is being killed by ctx (via
+	// CommandContext) it might already be reaped.
+	_ = t.cmd.Wait()
+	return nil
+}

--- a/internal/mcp/stdio_test.go
+++ b/internal/mcp/stdio_test.go
@@ -1,0 +1,131 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestHelperProcess is the standard Go pattern for a self-spawning subprocess
+// fixture: the test binary re-execs itself with GO_HELPER_PROCESS=1 and
+// behaves like a mini MCP server in that mode. Lets us exercise the stdio
+// transport end-to-end without shipping a separate binary or shell script.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+	dec := json.NewDecoder(bufio.NewReader(os.Stdin))
+	enc := json.NewEncoder(os.Stdout)
+	for {
+		var req Message
+		if err := dec.Decode(&req); err != nil {
+			return
+		}
+		if req.IsNotification() {
+			continue
+		}
+		switch req.Method {
+		case MethodInitialize:
+			result := InitializeResult{
+				ProtocolVersion: ProtocolVersion,
+				Capabilities:    ServerCapabilities{Tools: &ToolsCapability{}},
+				ServerInfo:      Implementation{Name: "helper", Version: "0.1"},
+			}
+			b, _ := json.Marshal(result)
+			_ = enc.Encode(Message{JSONRPC: "2.0", ID: req.ID, Result: b})
+		case MethodToolsList:
+			result := ListToolsResult{Tools: []Tool{
+				{Name: "ping", Description: "responds pong"},
+			}}
+			b, _ := json.Marshal(result)
+			_ = enc.Encode(Message{JSONRPC: "2.0", ID: req.ID, Result: b})
+		case MethodToolsCall:
+			result := CallToolResult{
+				Content: []Content{{Type: "text", Text: "pong"}},
+			}
+			b, _ := json.Marshal(result)
+			_ = enc.Encode(Message{JSONRPC: "2.0", ID: req.ID, Result: b})
+		default:
+			b, _ := json.Marshal(&RPCError{Code: -32601, Message: "not implemented"})
+			_ = enc.Encode(Message{
+				JSONRPC: "2.0", ID: req.ID,
+				Error: &RPCError{Code: -32601, Message: "not implemented", Data: b},
+			})
+		}
+	}
+}
+
+// helperCommand returns the StdioConfig that re-execs THIS test binary in
+// helper-process mode. The "-test.run=TestHelperProcess" arg matches Go's
+// convention; the GO_HELPER_PROCESS=1 env flag switches it from "run the
+// real test" to "act as the helper".
+func helperCommand() StdioConfig {
+	return StdioConfig{
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess"},
+		Env:     map[string]string{"GO_HELPER_PROCESS": "1"},
+	}
+}
+
+func TestStdioTransport_SubprocessRoundtrip(t *testing.T) {
+	// Sanity: refuse to run if the helper isn't reachable through os.Args[0].
+	if _, err := exec.LookPath(os.Args[0]); err != nil {
+		t.Skip("self-binary not found; running outside a test binary")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tx, err := NewStdioTransport(ctx, helperCommand())
+	if err != nil {
+		t.Fatalf("NewStdioTransport: %v", err)
+	}
+	defer tx.Close()
+
+	c := NewClient(tx, Implementation{Name: "octo-test", Version: "0.1"})
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if name := c.ServerInfo().Name; name != "helper" {
+		t.Errorf("ServerInfo.Name = %q, want helper", name)
+	}
+	tools, err := c.ListTools(ctx)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "ping" {
+		t.Fatalf("ListTools = %v", tools)
+	}
+	res, err := c.CallTool(ctx, "ping", nil)
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if len(res.Content) != 1 || res.Content[0].Text != "pong" {
+		t.Errorf("CallTool result = %+v", res)
+	}
+	if err := c.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+func TestStdioTransport_EmptyCommandRejected(t *testing.T) {
+	_, err := NewStdioTransport(context.Background(), StdioConfig{})
+	if err == nil {
+		t.Error("expected error for empty command")
+	}
+}
+
+func TestStdioTransport_BadCommandSurfaces(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	// Random unlikely-to-exist command
+	cfg := StdioConfig{Command: fmt.Sprintf("octo-this-binary-does-not-exist-%d", time.Now().UnixNano())}
+	if _, err := NewStdioTransport(ctx, cfg); err == nil {
+		t.Error("expected error for non-existent command")
+	}
+}

--- a/internal/mcp/transport.go
+++ b/internal/mcp/transport.go
@@ -1,0 +1,22 @@
+package mcp
+
+import "context"
+
+// Transport is the framed-message connection an MCP client speaks over.
+// Two impls today: stdio (subprocess pipes) and Streamable HTTP. Send is
+// fire-and-forget — the client matches responses to requests by ID, not by
+// Send/Receive ordering. Receive blocks until either a frame arrives or ctx
+// is done; transports must honor ctx cancellation promptly so a stalled
+// remote can be torn down on /exit.
+type Transport interface {
+	// Send writes one JSON-RPC frame. Implementations serialise it; the
+	// caller hands over an already-encoded Message.
+	Send(ctx context.Context, msg *Message) error
+	// Receive blocks until the next frame arrives. Returns (nil, io.EOF) on
+	// a clean close. Recoverable parse errors are returned as a non-nil
+	// error; callers may retry, but in practice we tear the transport down.
+	Receive(ctx context.Context) (*Message, error)
+	// Close releases the transport. After Close, Send / Receive return an
+	// error. Idempotent.
+	Close() error
+}

--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -1,0 +1,363 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/mcp"
+)
+
+// MCP integration. The tools package exposes one global *mcp.Registry that
+// cmd/octo populates at session start; DefaultRegistry.Execute branches on
+// the "mcp__" tool-name prefix to dispatch through the registry, and
+// DefaultTools synthesises ToolDefinitions for every MCP surface so they
+// ride alongside the built-ins in the model's tool list.
+//
+// Naming: tool names are "mcp__<server>__<tool>". The double-underscore
+// separator avoids the LLM-side restriction that tool names match
+// ^[a-zA-Z0-9_-]+$ (no dots, slashes, or colons) while still being
+// unambiguous to parse. Mirrors Claude Code's convention.
+//
+// Synthetic per-server tools:
+//   - mcp__<server>__resource_read  — fetches one resource by URI.
+//   - mcp__<server>__prompt_get     — materialises one named prompt.
+//
+// Only synthesized when the server's capabilities advertised the surface
+// — a tools-only server gets just its tools.
+
+var (
+	mcpRegistryMu sync.RWMutex
+	mcpRegistry   *mcp.Registry
+)
+
+// SetMCPRegistry installs the active registry for this session. Passing
+// nil clears it (used by defer in cmd/octo so the next session starts
+// clean). Idempotent.
+func SetMCPRegistry(r *mcp.Registry) {
+	mcpRegistryMu.Lock()
+	mcpRegistry = r
+	mcpRegistryMu.Unlock()
+}
+
+// ActiveMCPRegistry returns the registered registry or nil if MCP is off.
+func ActiveMCPRegistry() *mcp.Registry {
+	mcpRegistryMu.RLock()
+	defer mcpRegistryMu.RUnlock()
+	return mcpRegistry
+}
+
+// mcpEnabled is the DefaultTools gating function — true when SetMCPRegistry
+// has been called with a non-nil registry AND that registry has at least
+// one live connection.
+func mcpEnabled() bool {
+	r := ActiveMCPRegistry()
+	return r != nil && r.Len() > 0
+}
+
+// mcpToolDefs synthesises one ToolDefinition per MCP surface for every live
+// connection. Called from DefaultTools at session start; returns empty if
+// MCP is off so the caller can splice it in unconditionally.
+func mcpToolDefs() []agent.ToolDefinition {
+	reg := ActiveMCPRegistry()
+	if reg == nil {
+		return nil
+	}
+	var defs []agent.ToolDefinition
+	for _, conn := range reg.Connections() {
+		// Server tools: one definition per advertised tool. The MCP tool's
+		// inputSchema is already a JSON Schema object, so we pass it through
+		// verbatim into Parameters.
+		for _, t := range conn.Tools {
+			defs = append(defs, agent.ToolDefinition{
+				Name:        mcpToolName(conn.Name, t.Name),
+				Description: fmt.Sprintf("[mcp:%s] %s", conn.Name, t.Description),
+				Parameters:  decodeSchema(t.InputSchema),
+			})
+		}
+		// Synthetic resource_read: present when the server advertises
+		// resources/* capability at all (some servers expose resources via
+		// templates without prepopulating the list).
+		if conn.Client.Capabilities().Resources != nil {
+			defs = append(defs, agent.ToolDefinition{
+				Name:        mcpToolName(conn.Name, "resource_read"),
+				Description: fmt.Sprintf("[mcp:%s] Read an MCP resource by URI. Available resources: %s", conn.Name, joinResourceURIs(conn.Resources)),
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"uri": map[string]any{
+							"type":        "string",
+							"description": "The resource URI to read (see the description for what this server advertises).",
+						},
+					},
+					"required": []string{"uri"},
+				},
+			})
+		}
+		// Synthetic prompt_get: same gating, present whenever the server
+		// advertises prompts/*.
+		if conn.Client.Capabilities().Prompts != nil {
+			defs = append(defs, agent.ToolDefinition{
+				Name:        mcpToolName(conn.Name, "prompt_get"),
+				Description: fmt.Sprintf("[mcp:%s] Materialise an MCP prompt template. Available prompts: %s", conn.Name, joinPromptNames(conn.Prompts)),
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{
+							"type":        "string",
+							"description": "Prompt name from the available list.",
+						},
+						"arguments": map[string]any{
+							"type":                 "object",
+							"description":          "Key-value arguments for the prompt template (string keys, string values).",
+							"additionalProperties": map[string]any{"type": "string"},
+						},
+					},
+					"required": []string{"name"},
+				},
+			})
+		}
+	}
+	return defs
+}
+
+// executeMCP dispatches an "mcp__…" tool call through the registry.
+// Returns ok=false when the name isn't an MCP tool so the caller can fall
+// through to its normal dispatch. Errors from the underlying client are
+// propagated as-is so the agent loop sees the same error surface it would
+// for any other tool.
+func executeMCP(ctx context.Context, name string, input map[string]any) (out string, ok bool, err error) {
+	if !strings.HasPrefix(name, "mcp__") {
+		return "", false, nil
+	}
+	server, tool, ok2 := parseMCPName(name)
+	if !ok2 {
+		return "", true, fmt.Errorf("mcp: malformed tool name %q (want mcp__<server>__<tool>)", name)
+	}
+	reg := ActiveMCPRegistry()
+	if reg == nil {
+		return "", true, fmt.Errorf("mcp: no registry registered")
+	}
+	conn := reg.Get(server)
+	if conn == nil {
+		return "", true, fmt.Errorf("mcp: server %q is not connected", server)
+	}
+
+	switch tool {
+	case "resource_read":
+		uri, _ := input["uri"].(string)
+		if uri == "" {
+			return "", true, fmt.Errorf("mcp: resource_read needs uri")
+		}
+		contents, err := conn.Client.ReadResource(ctx, uri)
+		if err != nil {
+			return "", true, err
+		}
+		return formatResourceContents(contents), true, nil
+
+	case "prompt_get":
+		promptName, _ := input["name"].(string)
+		if promptName == "" {
+			return "", true, fmt.Errorf("mcp: prompt_get needs name")
+		}
+		argMap := convertStringMap(input["arguments"])
+		result, err := conn.Client.GetPrompt(ctx, promptName, argMap)
+		if err != nil {
+			return "", true, err
+		}
+		return formatPromptResult(result), true, nil
+
+	default:
+		result, err := conn.Client.CallTool(ctx, tool, input)
+		if err != nil {
+			return "", true, err
+		}
+		out := formatToolResult(result)
+		if result.IsError {
+			// The tool ran but reported an error in-band. Surface it as a
+			// Go error so the agent loop tags the tool_result IsError too —
+			// matches the contract built-in tools use.
+			return out, true, fmt.Errorf("mcp tool error: %s", out)
+		}
+		return out, true, nil
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+func mcpToolName(server, tool string) string {
+	return "mcp__" + sanitizeMCPName(server) + "__" + sanitizeMCPName(tool)
+}
+
+// sanitizeMCPName conforms a string to the LLM tool-name regex
+// ^[a-zA-Z0-9_-]+$. The MCP spec doesn't constrain server/tool names, so we
+// strip what an LLM provider would otherwise reject. Replaces forbidden
+// runes with underscores; collapses consecutive replacements.
+func sanitizeMCPName(s string) string {
+	var b strings.Builder
+	prevReplaced := false
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-':
+			b.WriteRune(r)
+			prevReplaced = false
+		default:
+			if !prevReplaced {
+				b.WriteByte('_')
+				prevReplaced = true
+			}
+		}
+	}
+	return b.String()
+}
+
+// parseMCPName splits "mcp__<server>__<tool>" into its components. Returns
+// ok=false on a malformed name. The tool segment may itself contain "__"
+// (we use SplitN to keep it intact).
+//
+// Strict on the prefix: callers shouldn't rely on TrimPrefix's silent no-op
+// when the prefix doesn't match — that would let "not-mcp__a__b" through.
+func parseMCPName(name string) (server, tool string, ok bool) {
+	if !strings.HasPrefix(name, "mcp__") {
+		return "", "", false
+	}
+	rest := name[len("mcp__"):]
+	parts := strings.SplitN(rest, "__", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// decodeSchema turns the MCP tool's raw JSON Schema into the map[string]any
+// shape agent.ToolDefinition.Parameters wants. Falls back to an empty
+// "object" schema on parse failure so the LLM still sees a valid (if
+// unhelpful) tool definition.
+func decodeSchema(raw json.RawMessage) map[string]any {
+	if len(raw) == 0 {
+		return map[string]any{"type": "object"}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return map[string]any{"type": "object"}
+	}
+	return out
+}
+
+func joinResourceURIs(rs []mcp.Resource) string {
+	if len(rs) == 0 {
+		return "(none pre-listed; check with the server's templates)"
+	}
+	uris := make([]string, 0, len(rs))
+	for _, r := range rs {
+		uris = append(uris, r.URI)
+	}
+	if len(uris) > 8 {
+		uris = append(uris[:8], "…")
+	}
+	return strings.Join(uris, ", ")
+}
+
+func joinPromptNames(ps []mcp.Prompt) string {
+	if len(ps) == 0 {
+		return "(none pre-listed)"
+	}
+	names := make([]string, 0, len(ps))
+	for _, p := range ps {
+		names = append(names, p.Name)
+	}
+	if len(names) > 8 {
+		names = append(names[:8], "…")
+	}
+	return strings.Join(names, ", ")
+}
+
+// formatToolResult flattens an MCP tool result's content blocks into a
+// single string for the agent's text-content tool_result. Non-text blocks
+// are summarised so the agent at least knows what came back.
+func formatToolResult(r *mcp.CallToolResult) string {
+	if r == nil {
+		return ""
+	}
+	var b strings.Builder
+	for i, c := range r.Content {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		switch c.Type {
+		case "text":
+			b.WriteString(c.Text)
+		case "image":
+			fmt.Fprintf(&b, "[image: %s, %d bytes]", c.MIMEType, len(c.Data))
+		case "audio":
+			fmt.Fprintf(&b, "[audio: %s, %d bytes]", c.MIMEType, len(c.Data))
+		case "resource":
+			if c.Resource != nil {
+				if c.Resource.Text != "" {
+					fmt.Fprintf(&b, "[resource %s]\n%s", c.Resource.URI, c.Resource.Text)
+				} else {
+					fmt.Fprintf(&b, "[resource %s: %s, blob len=%d]", c.Resource.URI, c.Resource.MIMEType, len(c.Resource.Blob))
+				}
+			}
+		default:
+			fmt.Fprintf(&b, "[unknown content type %q]", c.Type)
+		}
+	}
+	return b.String()
+}
+
+func formatResourceContents(cs []mcp.ResourceContent) string {
+	var b strings.Builder
+	for i, c := range cs {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		if c.Text != "" {
+			fmt.Fprintf(&b, "[resource %s]\n%s", c.URI, c.Text)
+		} else {
+			fmt.Fprintf(&b, "[resource %s: %s, blob len=%d]", c.URI, c.MIMEType, len(c.Blob))
+		}
+	}
+	return b.String()
+}
+
+func formatPromptResult(r *mcp.GetPromptResult) string {
+	if r == nil {
+		return ""
+	}
+	var b strings.Builder
+	if r.Description != "" {
+		fmt.Fprintf(&b, "Description: %s\n\n", r.Description)
+	}
+	for i, m := range r.Messages {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		fmt.Fprintf(&b, "[%s]\n", m.Role)
+		switch m.Content.Type {
+		case "text":
+			b.WriteString(m.Content.Text)
+		default:
+			fmt.Fprintf(&b, "(non-text content: %s)", m.Content.Type)
+		}
+	}
+	return b.String()
+}
+
+// convertStringMap normalises the "arguments" field of prompt_get to
+// map[string]string. The agent passes arguments as map[string]any so we
+// stringify each value (which is what the prompt template expects anyway).
+func convertStringMap(v any) map[string]string {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, val := range m {
+		out[k] = fmt.Sprintf("%v", val)
+	}
+	return out
+}

--- a/internal/tools/mcp_test.go
+++ b/internal/tools/mcp_test.go
@@ -1,0 +1,112 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/mcp"
+)
+
+func TestMCPToolName_HappyPath(t *testing.T) {
+	got := mcpToolName("filesystem", "read_file")
+	if got != "mcp__filesystem__read_file" {
+		t.Errorf("mcpToolName = %q", got)
+	}
+}
+
+func TestSanitizeMCPName_StripsForbidden(t *testing.T) {
+	cases := map[string]string{
+		"simple":            "simple",
+		"with-dash":         "with-dash",
+		"with_underscore":   "with_underscore",
+		"with.dot":          "with_dot",       // dot replaced
+		"with:colon":        "with_colon",     // colon replaced
+		"with space":        "with_space",     // space replaced
+		"with/slash":        "with_slash",     // slash replaced
+		"chars!@#$multiple": "chars_multiple", // consecutive forbidden collapse to one _
+		"valid42":           "valid42",
+	}
+	for in, want := range cases {
+		if got := sanitizeMCPName(in); got != want {
+			t.Errorf("sanitizeMCPName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseMCPName_RoundTrip(t *testing.T) {
+	server, tool, ok := parseMCPName("mcp__filesystem__read_file")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if server != "filesystem" || tool != "read_file" {
+		t.Errorf("got (%q, %q)", server, tool)
+	}
+}
+
+func TestParseMCPName_ToolWithUnderscores(t *testing.T) {
+	// SplitN(s, "__", 2) preserves further "__" inside the tool segment.
+	server, tool, ok := parseMCPName("mcp__github__list__issues")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if server != "github" || tool != "list__issues" {
+		t.Errorf("got (%q, %q)", server, tool)
+	}
+}
+
+func TestParseMCPName_RejectsMalformed(t *testing.T) {
+	for _, bad := range []string{
+		"mcp__only-server",    // missing tool segment
+		"mcp____empty-server", // empty server  (SplitN gives ["", "empty-server"], parts[0]==""→ok=false)
+		"not-mcp__a__b",       // wrong prefix
+		"",
+	} {
+		if _, _, ok := parseMCPName(bad); ok {
+			t.Errorf("parseMCPName(%q) ok=true, want false", bad)
+		}
+	}
+}
+
+func TestFormatToolResult_MixedContent(t *testing.T) {
+	r := &mcp.CallToolResult{Content: []mcp.Content{
+		{Type: "text", Text: "first"},
+		{Type: "image", MIMEType: "image/png", Data: "<base64 …>"},
+		{Type: "resource", Resource: &mcp.EmbeddedResource{
+			URI: "file:///x", MIMEType: "text/plain", Text: "embedded",
+		}},
+	}}
+	out := formatToolResult(r)
+	for _, want := range []string{
+		"first",
+		"[image: image/png",
+		"[resource file:///x]",
+		"embedded",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestMCPEnabledGate(t *testing.T) {
+	// Before any registration the gate is off so DefaultTools won't
+	// advertise MCP surfaces.
+	SetMCPRegistry(nil)
+	if mcpEnabled() {
+		t.Error("expected mcpEnabled=false with no registry")
+	}
+	// Empty registry: still disabled — Len() == 0.
+	SetMCPRegistry(&mcp.Registry{})
+	if mcpEnabled() {
+		t.Error("expected mcpEnabled=false with empty registry")
+	}
+	SetMCPRegistry(nil) // clean up for other tests
+}
+
+func TestMCPToolDefs_NilRegistryYieldsNone(t *testing.T) {
+	SetMCPRegistry(nil)
+	defer SetMCPRegistry(nil)
+	if defs := mcpToolDefs(); len(defs) != 0 {
+		t.Errorf("expected empty defs with no registry, got %d", len(defs))
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -59,6 +59,13 @@ func NewDefaultRegistry() DefaultRegistry {
 
 // Execute implements agent.ToolExecutor.
 func (r DefaultRegistry) Execute(ctx context.Context, name string, input map[string]any) (string, error) {
+	// MCP tools land here too — route them first so an "mcp__…" name
+	// never falls through to the unknown-tool path. executeMCP returns
+	// ok=false when the name isn't ours, then dispatch continues below.
+	if out, ok, err := executeMCP(ctx, name, input); ok {
+		return out, err
+	}
+
 	// Read-before-write pre-check (skipped when no tracker is configured).
 	if r.tracker != nil && (name == "write_file" || name == "edit_file") {
 		if path, ok := input["path"].(string); ok {
@@ -127,5 +134,9 @@ func DefaultTools() []agent.ToolDefinition {
 		}
 		defs = append(defs, t.Definition())
 	}
+	// MCP-advertised surfaces ride alongside built-ins, gated on a non-nil
+	// registry registered via SetMCPRegistry. Synthesised per-connection so
+	// each server's tools/resources/prompts surface together.
+	defs = append(defs, mcpToolDefs()...)
 	return defs
 }


### PR DESCRIPTION
## Summary

Self-contained MCP client. Supports both stdio (subprocess) and Streamable HTTP transports per [MCP spec 2024-11-05](https://modelcontextprotocol.io/), and the full v1 surface (tools / resources / prompts).

\`octo chat --tools\` auto-connects every server in mcp.json. Each server's surface rides alongside the built-ins as \`mcp__<server>__<tool>\`.

## Highlights

**\`internal/mcp\` (new package)** — pure protocol + transport, zero dependency on the agent / tool layers:

| File | What it does |
|------|--------------|
| \`protocol.go\` | JSON-RPC 2.0 frame + typed MCP message shapes for every supported method |
| \`transport.go\` | \`Transport\` interface (\`Send\` / \`Receive\` / \`Close\`) |
| \`stdio.go\` | Subprocess transport; line-delimited JSON-RPC, inherits stderr |
| \`http.go\` | Streamable HTTP transport with \`Mcp-Session-Id\` round-trip |
| \`client.go\` | Lifecycle, RPC dispatch by ID, typed method wrappers |
| \`config.go\` | mcp.json loader; user-global + project-local merge; \`disabled\` filter |
| \`registry.go\` | Connect all + pre-fetch surfaces; failures degrade with stderr log |

**\`internal/tools/mcp.go\`** — thin adapter that turns each connected server's surfaces into \`agent.ToolDefinition\`s and routes \`mcp__…\` dispatch through the registry. Synthesises one \`resource_read\` and one \`prompt_get\` tool per server when the capability is advertised.

**\`cmd/octo\`** integration:
- \`chat.go\` loads mcp.json, calls \`ConnectAll\`, registers the registry, defers teardown.
- \`repl.go\` adds the \`/mcp\` slash command with server name, version, surface counts, and instructions.
- \`help.go\` adds \`octo help mcp\` covering config format, transports, naming convention, and v1 omissions.

## Config example

\`\`\`json
{
  \"mcpServers\": {
    \"filesystem\": {
      \"command\": \"npx\",
      \"args\":    [\"-y\", \"@modelcontextprotocol/server-filesystem\", \"/some/path\"]
    },
    \"github\": {
      \"url\":     \"https://github-mcp.example.com/mcp\",
      \"headers\": {\"Authorization\": \"Bearer ghp_...\"}
    },
    \"work-in-progress\": {
      \"command\": \"node\",
      \"args\":    [\"./local-server.js\"],
      \"disabled\": true
    }
  }
}
\`\`\`

## Naming

\`mcp__<server>__<tool>\` — matches Claude Code's convention so users keep one mental model. Double-underscore separator avoids the LLM-side restriction that tool names match \`^[a-zA-Z0-9_-]+$\` (no colons or dots).

## Not implemented in v1 (deliberate)

- Server-initiated notifications (list_changed, progress, log).
- Resource subscriptions.
- Sampling (server asking the client to call its LLM).
- Roots (client filesystem roots advertised back to the server).

Each is its own integration point and would more than double the PR size. They can land incrementally once we have real demand.

## Test plan

- [x] \`go test -race ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`internal/mcp\`: 20+ tests covering protocol classification + marshalling, config precedence/validation/disabled, HTTP transport with session header round-trip + header passthrough + 204 notifications + error status, stdio transport end-to-end via self-exec helper-process pattern, client initialize handshake, list/call tools, read resources, get prompts, RPC error propagation, post-Close errors, context cancellation
- [x] \`internal/tools\`: \`sanitize\` / \`parseMCPName\` / content formatters covered; \`mcpToolDefs\` gate verified
- [ ] Manual smoke against a real MCP server (filesystem) deferred until the binary is on a machine that can \`npx\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)