### PR TITLE
chore: cut 0.4.0, start 0.5.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased — 0.4.0-dev]
+## [Unreleased — 0.5.0-dev]
+
+_Nothing yet — next milestone work (M8 web server, M9 IM bridge, MCP follow-ups like notifications / Auth Code+PKCE, or further roadmap items) will accumulate here._
+
+## [0.4.0] — 2026-05-28
+
+**MCP client release.** Adds a full Model Context Protocol client — stdio + Streamable HTTP transports, tools/resources/prompts surfaces, and Device Authorization Grant OAuth so spec-compliant remote servers (Lark Project's MCP server is the smoke-test target) work end-to-end without manual token wrangling. Disk format and existing CLI surface stay unchanged from 0.3.0 — drop a `~/.octo/mcp.json` in and you're set.
 
 ### Fixed
 - **Resume without `--tools` no longer produces garbled XML tool calls.** When a tool-enabled session was resumed without re-passing `--tools`, the model saw prior `tool_use` blocks in history but no tools array in the new request, and fell back to emitting tool calls as text (a wall of `<tool_calls><invoke name="terminal"><parameter name="command">…`). `octo chat -c <id>` now pre-loads the session, checks for any `tool_use` block, and auto-enables `--tools` with a one-line notice. Plain (no-tools) sessions resume unchanged.

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ GOFLAGS ?=
 # pollute the reported version. Dev builds say "<next>-dev"; release builds
 # should set VERSION explicitly:
 #
-#   VERSION=0.4.0 make build
+#   VERSION=0.5.0 make build
 #
-VERSION ?= 0.4.0-dev
+VERSION ?= 0.5.0-dev
 COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 LDFLAGS := -X github.com/Leihb/octo-agent/internal/version.Version=$(VERSION) \
            -X github.com/Leihb/octo-agent/internal/version.Commit=$(COMMIT)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@
 package version
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "0.4.0-dev"
+var Version = "0.5.0-dev"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary

Releases the MCP work as **v0.4.0**.

- CHANGELOG: rename `Unreleased — 0.4.0-dev` → `[0.4.0] — 2026-05-28` with a one-paragraph headline; add fresh `Unreleased — 0.5.0-dev` section.
- `internal/version/version.go`: `0.4.0-dev` → `0.5.0-dev`.
- `Makefile`: same bump.

## What's in 0.4.0

| PR | Title |
|---|---|
| #128 | MCP client (stdio + Streamable HTTP, tools/resources/prompts) |
| #129 | MCP OAuth device flow (RFC 9728/8414/7591/8628) |
| #130 | fix: resume without `--tools` garbles output; spinner eats first char |

**Smoke-tested end-to-end** against `https://project.larksuite.com/mcp_server/v1` (Lark Project's MCP server, full OAuth device flow). User-confirmed working alongside skills.

## Compatibility

Disk format unchanged from 0.3.0 — sessions, tasks, memory all upgrade in place. New optional file `~/.octo/mcp.json` enables MCP. Existing 0.3.0 features (readline, short IDs, help, spinner, verbosity, shell completion) untouched.

## Test plan

- [x] `go test -race ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] After CI passes and this merges, tag `v0.4.0` at the merge commit and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)