### PR TITLE
feat(memory): turn-boundary nudge so the agent actually uses `remember`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased — 0.5.0-dev]
 
-_Nothing yet — next milestone work (M8 web server, M9 IM bridge, MCP follow-ups like notifications / Auth Code+PKCE, or further roadmap items) will accumulate here._
+### Added
+- **Turn-boundary memory nudge** — appended to each user message (wrapped in a `<system-reminder>` block) when cross-session memory + tools are both on. The nudge reminds the model to scan the message it just received for the four signals base.md already documents (preference / correction with WHY / validated approach / external resource) and call `remember` if any matches. Without this, the in-session `remember` tool was being skipped almost universally — base.md's instructions are near the top of a long system prompt, far from the actual decision point, and the default action (do nothing) is free. Concrete case the nudge addresses: user pushes back with "不用，这个不算 bug，确实承诺只应该考虑 agent 给出的" (a domain rule worth saving as feedback), the agent acknowledges and moves on, the rule is forgotten next session. The nudge gates on `len(cfg.tools) > 0` because reminding the model to call a tool it doesn't have is pointless.
 
 ## [0.4.0] — 2026-05-28
 

--- a/cmd/octo/memory_nudge.go
+++ b/cmd/octo/memory_nudge.go
@@ -1,0 +1,52 @@
+package main
+
+import "strings"
+
+// memoryNudge is the per-turn system-reminder appended to the user's
+// message when cross-session memory is enabled AND tools are on (so the
+// `remember` tool is actually callable).
+//
+// # Why this exists
+//
+// The "when to call remember" guidance in base.md is correct but lives
+// near the top of a long system prompt, before the tool list and before
+// the conversation. By the time the model is composing its reply, that
+// section is far away in the attention window — and the default action
+// (do nothing) is free, so memorable signals slip through routinely.
+// Concrete case: user pushes back with a domain rule ("不用，承诺只考虑
+// agent 给出的"), agent acknowledges and moves on, the rule is forgotten
+// next session.
+//
+// The fix is the same one Claude Code uses: tag a small reminder onto
+// the user message at the precise decision point. Empirically, models
+// follow tool-call instructions much more reliably when the directive
+// is in-context at the relevant turn, not buried in the system prompt.
+//
+// The reminder explicitly tells the model the user can't see it, and to
+// skip silently when nothing qualifies — so it doesn't pad every reply
+// with "I noted that as memory."
+const memoryNudge = "" +
+	"<system-reminder>\n" +
+	"Memory hygiene check (this reminder is auto-injected; the user does not see it):\n" +
+	"\n" +
+	"Scan the user message above for durable signals worth saving to cross-session memory via the `remember` tool:\n" +
+	"  (a) preference, role, or constraint they state (\"I'm on the Go team\", \"always run tests first\")\n" +
+	"  (b) correction / pushback — save the rule AND the WHY they gave (often a past incident or domain rule)\n" +
+	"  (c) acceptance of a non-obvious choice without complaint (validated judgement matters too)\n" +
+	"  (d) external resource they pointed at + what it's for (a dashboard, ticket project, channel)\n" +
+	"\n" +
+	"If you find one, call `remember` (in parallel with your text reply is fine — they're independent). " +
+	"If nothing qualifies, skip silently. Do NOT mention this check in your reply. " +
+	"Do NOT call `remember` for one-off task details, code/repo facts derivable from grep, or anything already in CLAUDE.md / .octorules.\n" +
+	"</system-reminder>"
+
+// appendMemoryNudge tacks the nudge onto the end of the user's message,
+// with a blank line separator. Idempotent in spirit — the nudge text is
+// a constant, so even if some upstream layer accidentally re-appended it
+// the model would treat the duplicate as the same instruction.
+func appendMemoryNudge(userInput string) string {
+	if strings.TrimSpace(userInput) == "" {
+		return userInput
+	}
+	return userInput + "\n\n" + memoryNudge
+}

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -230,12 +230,21 @@ func runREPL(cfg replConfig) int {
 		// are logged but never block the turn — the user still gets
 		// their reply.
 		turnInput := line
+		// Memory-hygiene nudge: appended to the user message when both
+		// cross-session memory and the `remember` tool are active, so
+		// the model is reminded to scan for durable signals at the
+		// precise decision point. Gated on tools being on because the
+		// nudge is asking the model to call a tool — pointless to ask
+		// when no tools are advertised.
+		if cfg.memStore != nil && len(cfg.tools) > 0 {
+			turnInput = appendMemoryNudge(turnInput)
+		}
 		if cfg.hooks.Configured() {
 			extra, herr := cfg.hooks.Pre(turnCtx, line)
 			if herr != nil {
 				fmt.Fprintf(cfg.stderr, "↳ pre-turn hook: %v\n", herr)
 			}
-			turnInput = hooks.InjectContext(line, extra)
+			turnInput = hooks.InjectContext(turnInput, extra)
 		}
 
 		var (

--- a/cmd/octo/repl_test.go
+++ b/cmd/octo/repl_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/memory"
 )
 
 // stubSender is a deterministic Sender for REPL tests — returns a fixed reply
@@ -478,4 +479,132 @@ func TestREPL_VerboseMode_PrintsModelAndHints(t *testing.T) {
 	if !strings.Contains(out, "model: test-model") {
 		t.Errorf("verbose mode should print model line; got:\n%s", out)
 	}
+}
+
+// capturingSender records the messages each Send call received, so tests
+// can inspect what was actually sent over the wire (e.g., whether the
+// memory-nudge reminder was appended to the user input).
+type capturingSender struct {
+	stubSender
+	lastMessages []agent.Message
+}
+
+func (c *capturingSender) SendMessages(ctx context.Context, sys, model string, msgs []agent.Message, maxTokens int) (agent.Reply, error) {
+	c.lastMessages = msgs
+	return c.stubSender.SendMessages(ctx, sys, model, msgs, maxTokens)
+}
+
+func (c *capturingSender) StreamMessages(ctx context.Context, sys, model string, msgs []agent.Message, maxTokens int, onChunk func(string)) (agent.Reply, error) {
+	c.lastMessages = msgs
+	return c.stubSender.StreamMessages(ctx, sys, model, msgs, maxTokens, onChunk)
+}
+
+// lastUserContent returns the textual Content of the last user message
+// sent — that's where the memory-nudge reminder lands when active.
+func (c *capturingSender) lastUserContent() string {
+	for i := len(c.lastMessages) - 1; i >= 0; i-- {
+		if c.lastMessages[i].Role == agent.RoleUser {
+			return c.lastMessages[i].Content
+		}
+	}
+	return ""
+}
+
+func TestREPL_MemoryNudge_AppendedWhenMemoryAndToolsActive(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	cap := &capturingSender{stubSender: stubSender{reply: "ok"}}
+	a := agent.New(cap, "test-model")
+
+	// Active memory store + a non-empty tools list = nudge should fire.
+	store := memory.NewStoreAt(t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	cfg := replConfig{
+		a:        a,
+		session:  agent.NewSession("test-model", ""),
+		stdin:    strings.NewReader("hi\n/exit\n"),
+		stdout:   &stdout,
+		stderr:   &stderr,
+		memStore: store,
+		// A dummy tool def is enough to satisfy `len(cfg.tools) > 0`.
+		tools:    []agent.ToolDefinition{{Name: "dummy", Description: "x", Parameters: map[string]any{"type": "object"}}},
+		executor: dummyExecutor{},
+	}
+	if code := runREPL(cfg); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+	got := cap.lastUserContent()
+	if !strings.Contains(got, "Memory hygiene check") {
+		t.Errorf("expected nudge in user message, got:\n%s", got)
+	}
+	if !strings.Contains(got, "hi") {
+		t.Errorf("user input lost from message body:\n%s", got)
+	}
+}
+
+func TestREPL_MemoryNudge_AbsentWhenMemoryDisabled(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	cap := &capturingSender{stubSender: stubSender{reply: "ok"}}
+	a := agent.New(cap, "test-model")
+
+	var stdout, stderr bytes.Buffer
+	cfg := replConfig{
+		a:        a,
+		session:  agent.NewSession("test-model", ""),
+		stdin:    strings.NewReader("hi\n/exit\n"),
+		stdout:   &stdout,
+		stderr:   &stderr,
+		memStore: nil, // ← memory off
+		tools:    []agent.ToolDefinition{{Name: "dummy", Description: "x", Parameters: map[string]any{"type": "object"}}},
+		executor: dummyExecutor{},
+	}
+	if code := runREPL(cfg); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if got := cap.lastUserContent(); strings.Contains(got, "Memory hygiene check") {
+		t.Errorf("nudge should be absent when memory is off; got:\n%s", got)
+	}
+}
+
+func TestREPL_MemoryNudge_AbsentWhenToolsOff(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	cap := &capturingSender{stubSender: stubSender{reply: "ok"}}
+	a := agent.New(cap, "test-model")
+
+	store := memory.NewStoreAt(t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	cfg := replConfig{
+		a:        a,
+		session:  agent.NewSession("test-model", ""),
+		stdin:    strings.NewReader("hi\n/exit\n"),
+		stdout:   &stdout,
+		stderr:   &stderr,
+		memStore: store,
+		// tools empty: the remember tool can't be called, so the nudge
+		// is pointless and should be omitted.
+	}
+	if code := runREPL(cfg); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if got := cap.lastUserContent(); strings.Contains(got, "Memory hygiene check") {
+		t.Errorf("nudge should be absent when no tools are advertised; got:\n%s", got)
+	}
+}
+
+// dummyExecutor satisfies the agent.ToolExecutor interface for tests
+// that need cfg.tools to be non-empty but don't actually invoke any tools.
+type dummyExecutor struct{}
+
+func (dummyExecutor) Execute(_ context.Context, name string, _ map[string]any) (string, error) {
+	return "ok:" + name, nil
 }


### PR DESCRIPTION
## Summary

Fix for a real-world failure of the memory system: the in-session \`remember\` tool was being skipped almost universally, even when the user gave textbook feedback-with-WHY.

**The example that drove this** (session 20260528-193557-7b860e0b.jsonl):

\`\`\`
user> 不用，这个不算bug，确实承诺只应该考虑agent给出的
\`\`\`

This is a domain rule about the klook-ceg-aiassistant codebase (the \`promises\` field only includes agent commitments, merchant/customer deadlines belong elsewhere) — exactly the kind of thing that should land in cross-session memory under \`type=feedback\` with the WHY recorded. base.md documents the four trigger categories. The \`remember\` tool was available. The agent still skipped the call.

## Why base.md alone isn't enough

The \"when to call remember\" guidance sits near the top of a long system prompt — before tools, before conversation history. By the time the model composes its reply, that section is far from the active attention window. The default action (do nothing) is free. Even with explicit instructions, the model needs a forcing function at the decision point.

## Fix

Append a small \`<system-reminder>\` block to each user message that restates the four signals and tells the model to act now or skip silently:

\`\`\`
<system-reminder>
Memory hygiene check (this reminder is auto-injected; the user does not see it):

Scan the user message above for durable signals worth saving to cross-session memory via the \`remember\` tool:
  (a) preference, role, or constraint they state (\"I'm on the Go team\", \"always run tests first\")
  (b) correction / pushback — save the rule AND the WHY they gave (often a past incident or domain rule)
  (c) acceptance of a non-obvious choice without complaint (validated judgement matters too)
  (d) external resource they pointed at + what it's for (a dashboard, ticket project, channel)

If you find one, call \`remember\` (in parallel with your text reply is fine — they're independent). If nothing qualifies, skip silently. Do NOT mention this check in your reply. Do NOT call \`remember\` for one-off task details, code/repo facts derivable from grep, or anything already in CLAUDE.md / .octorules.
</system-reminder>
\`\`\`

Mirrors Claude Code's reminder pattern that already works in practice.

## Gating

- \`cfg.memStore != nil\` — memory is enabled this session.
- \`len(cfg.tools) > 0\` — the \`remember\` tool can actually be called. Pointless to ask otherwise.

The C9 Phase 3 pre-turn hook injection runs AFTER the nudge so external retrieval context still lands at the very end of the user message.

## Files

| File | What |
|------|------|
| \`cmd/octo/memory_nudge.go\` (new) | The nudge string + \`appendMemoryNudge()\` |
| \`cmd/octo/repl.go\` | Inject before the optional Phase 3 hook |
| \`cmd/octo/repl_test.go\` | \`capturingSender\` records messages; three tests |

## Test plan

- [x] \`go test -race ./...\` clean
- [x] Three new tests: (a) nudge appended when memory + tools active, (b) absent when memory off, (c) absent when tools empty
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l .\` clean
- [ ] **Manual smoke**: resume the failing session above, give a similar feedback message, observe \`remember\` getting called

🤖 Generated with [Claude Code](https://claude.com/claude-code)