### PR TITLE
feat(tools): native PowerShell for the terminal tool on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Four-layer stack with one-directional dependencies:
    Provider wire quirks are encapsulated here — the agent layer never branches on protocol.
 
 4. **Tools (`internal/tools/`)** — concrete `ToolExecutor` implementations.
-   - `terminal.go` — current canonical example. Tool name `terminal` rather than `bash` because the implementation shells out via `sh -c`, not `/bin/bash`.
+   - `terminal.go` — current canonical example. Tool name `terminal` rather than `bash` because the implementation shells out via the platform shell — `sh -c` on macOS/Linux, PowerShell (`pwsh`, else `powershell`) on Windows — not a hard `/bin/bash` dependency. The shell is selected in one place: `shellCommand` in `sandbox.go`. The model is told which shell it's on via the environment context (`cmd/octo/envcontext.go`).
    - `DefaultRegistry` dispatches by tool name. `DefaultTools()` returns the set sent to the LLM when `--tools` is on.
 
 ## Conventions

--- a/cmd/octo/envcontext.go
+++ b/cmd/octo/envcontext.go
@@ -31,6 +31,16 @@ func buildEnvContext(cwd string) string {
 	}
 	fmt.Fprintf(&b, "- Today's date: %s\n", time.Now().Format("2006-01-02"))
 	fmt.Fprintf(&b, "- OS/arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	if runtime.GOOS == "windows" {
+		// The `terminal` tool runs commands through PowerShell here, not POSIX
+		// sh — steer the model away from emitting `ls`/`grep`/`rm -rf`/`&&`-on-
+		// cmd and toward PowerShell. The cross-platform built-in tools are the
+		// better default regardless.
+		b.WriteString("- Shell: PowerShell. Use PowerShell syntax and cmdlets " +
+			"(Get-ChildItem, Get-Content, Select-String, Remove-Item, $env:VAR), not POSIX sh. " +
+			"Chain commands with `;` rather than `&&` (Windows PowerShell 5.1 lacks `&&`). " +
+			"Prefer the built-in read_file / glob / grep tools over shelling out — they're identical across platforms.\n")
+	}
 	return b.String()
 }
 

--- a/internal/permission/defaults.yml
+++ b/internal/permission/defaults.yml
@@ -30,6 +30,19 @@ terminal:
   # steering the model to edit_file (defence in depth for permissive configs).
   - deny:  { pattern: "sed -i" }
   - deny:  { pattern: "sed --in-place" }
+  # Windows / PowerShell dangers. Matching is case-sensitive substring and
+  # PowerShell is case-insensitive with aliases, so these catch the canonical
+  # forms an LLM typically emits — anything missed still falls through to the
+  # implicit `ask` (prompt in interactive, deny in strict), never auto-run.
+  # (`rm -rf` above already covers the PowerShell `rm` alias.)
+  - deny:  { pattern: "Remove-Item -Recurse -Force" }
+  - deny:  { pattern: "Remove-Item -Force -Recurse" }
+  - deny:  { pattern: "Format-Volume" }
+  - ask:   { pattern: "Invoke-Expression" }        # arbitrary code (alias: iex)
+  - ask:   { pattern: "Invoke-WebRequest" }        # download / exfiltrate (alias: iwr)
+  - ask:   { pattern: "Invoke-RestMethod" }        # alias: irm
+  - ask:   { pattern: "Set-ExecutionPolicy" }
+  - ask:   { pattern: "Start-Process" }            # can launch arbitrary binaries
   # Sensitive-path access — must precede the safe-verb allows below, otherwise
   # `cat /etc/passwd` would match `allow: cat ` and slip through. Substring
   # matches are intentionally specific to avoid false positives.

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"context"
 	"os/exec"
+	"runtime"
+	"sync"
 
 	"github.com/Leihb/octo-agent/internal/sandbox"
 )
@@ -19,9 +21,28 @@ func SetSandbox(p *sandbox.Policy) { activeSandbox = p }
 // shellCommand builds the *exec.Cmd that runs `command` via the shell, wrapped
 // in the active sandbox when one is set. Both TerminalTool and the background
 // manager route through here so confinement is uniform.
+//
+// Shell by platform: POSIX `sh -c` on macOS/Linux; PowerShell on Windows (the
+// OS sandbox is macOS/Linux-only, so the Windows branch is never sandboxed).
 func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 	if activeSandbox != nil {
 		return sandbox.Command(ctx, command, *activeSandbox)
 	}
+	if runtime.GOOS == "windows" {
+		// -NoProfile: reproducible env (don't run the user's $PROFILE).
+		// -NonInteractive: never block on a PowerShell prompt mid-command.
+		return exec.CommandContext(ctx, resolvePowerShell(), "-NoProfile", "-NonInteractive", "-Command", command), nil
+	}
 	return exec.CommandContext(ctx, "sh", "-c", command), nil
 }
+
+// resolvePowerShell picks the Windows shell once: PowerShell 7+ (`pwsh`) when
+// present — it's the modern, cross-platform build and supports `&&`/`||`
+// pipeline chaining — else Windows PowerShell 5.1 (`powershell`), which ships
+// with every supported Windows and is always available as the fallback.
+var resolvePowerShell = sync.OnceValue(func() string {
+	if path, err := exec.LookPath("pwsh"); err == nil {
+		return path
+	}
+	return "powershell"
+})

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -1,0 +1,33 @@
+package tools
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestShellCommand_PlatformShell verifies shellCommand picks the right shell
+// per OS: POSIX `sh -c` on macOS/Linux, PowerShell `-Command` on Windows.
+func TestShellCommand_PlatformShell(t *testing.T) {
+	cmd, err := shellCommand(context.Background(), "echo hi")
+	if err != nil {
+		t.Fatalf("shellCommand: %v", err)
+	}
+	args := cmd.Args
+	if runtime.GOOS == "windows" {
+		// pwsh/powershell ... -Command "echo hi"
+		if len(args) < 2 || args[len(args)-2] != "-Command" || args[len(args)-1] != "echo hi" {
+			t.Errorf("windows shell should end with -Command \"echo hi\", got %v", args)
+		}
+		base := strings.ToLower(filepath.Base(args[0]))
+		if !strings.Contains(base, "pwsh") && !strings.Contains(base, "powershell") {
+			t.Errorf("windows shell should be pwsh/powershell, got %q", args[0])
+		}
+	} else {
+		if len(args) != 3 || args[0] != "sh" || args[1] != "-c" || args[2] != "echo hi" {
+			t.Errorf("posix shell should be [sh -c \"echo hi\"], got %v", args)
+		}
+	}
+}

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -17,14 +17,16 @@ import (
 // TerminalTimeout is the maximum time a single terminal command may run.
 const TerminalTimeout = 30 * time.Second
 
-// TerminalTool is an agent.ToolExecutor that runs shell commands via `sh -c`.
-// Stdout and stderr are combined and returned as the tool result. Non-zero
-// exit codes are reported as extra metadata in the result text rather than
-// as a tool error, so the LLM can see the failure output and adapt.
+// TerminalTool is an agent.ToolExecutor that runs shell commands through the
+// system shell (`sh -c` on macOS/Linux, PowerShell on Windows; see
+// shellCommand). Stdout and stderr are combined and returned as the tool
+// result. Non-zero exit codes are reported as extra metadata in the result
+// text rather than as a tool error, so the LLM can see the failure output and
+// adapt.
 //
 // The LLM-facing tool name is "terminal" — calling it "bash" would imply a
-// hard /bin/bash dependency, but the executor actually shells out via
-// `sh -c`.
+// hard /bin/bash dependency, but the executor shells out via the platform
+// shell (the model is told which one via the environment context).
 //
 // mgr, when non-nil, is the BackgroundManager used for background:true
 // launches; nil falls back to the process-wide default manager. The field
@@ -44,7 +46,7 @@ func (t TerminalTool) manager() *BackgroundManager {
 func (TerminalTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name:        "terminal",
-		Description: "Run a shell command (via `sh -c`) and return stdout+stderr. Use for file operations, running programs, searching code, etc. Set background:true for long-running commands (servers, watchers): it returns immediately with a process id (no 30s timeout, non-blocking); read its output later with the terminal_output tool.",
+		Description: "Run a shell command in the system shell (POSIX sh on macOS/Linux, PowerShell on Windows — see the Shell line in the environment context) and return stdout+stderr. Use for file operations, running programs, searching code, etc. Set background:true for long-running commands (servers, watchers): it returns immediately with a process id (no 30s timeout, non-blocking); read its output later with the terminal_output tool.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -61,9 +61,10 @@ func TestTerminalTool_Execute_Multiline(t *testing.T) {
 
 func TestTerminalTool_Execute_NonZeroExit(t *testing.T) {
 	// A failing command should return output + exit info as result text,
-	// NOT as a Go error, so the LLM can read it.
+	// NOT as a Go error, so the LLM can read it. `echo …; exit 1` is valid in
+	// both POSIX sh and PowerShell, so this stays platform-agnostic.
 	result, err := TerminalTool{}.Execute(context.Background(), "terminal", map[string]any{
-		"command": "sh -c 'echo oops; exit 1'",
+		"command": "echo oops; exit 1",
 	})
 	if err != nil {
 		t.Fatalf("Execute should not return a Go error for non-zero exit: %v", err)


### PR DESCRIPTION
Production-readiness Tier 1, item 3: decide + fix the Windows strategy.

## Problem
`terminal` (and background commands) shelled out via `sh -c` on every platform. On Windows that only works if a POSIX `sh` is on PATH (git-bash / WSL) — true on the GitHub windows-latest runner and on dev machines with git, but **silently broken on a bare Windows box**. CI was green only because the runner has git's `sh.exe`.

## Decision
Go **native PowerShell**, not cmd.exe (cmd can't reliably chain with `&&` and offers nothing for the agent's command style).

## Change
- **One chokepoint** — `shellCommand` in `internal/tools/sandbox.go`: POSIX `sh -c` on macOS/Linux; on Windows, **prefer `pwsh`** (PowerShell 7+, cross-platform, supports `&&`/`||`), **fall back to `powershell`** (Windows PowerShell 5.1, always present). Flags: `-NoProfile -NonInteractive -Command`. (The OS sandbox is macOS/Linux-only, so the Windows branch is never sandboxed — unchanged.)
- **Model dialect awareness** — `envcontext.go` adds a `Shell: PowerShell` line on Windows: use cmdlets (`Get-ChildItem`, `Select-String`, `Remove-Item`…), chain with `;` not `&&` (5.1 lacks it), and prefer the cross-platform built-in read/glob/grep tools.
- **Safety parity** — Windows danger rules in the default permission set: `Remove-Item -Recurse -Force` / `Format-Volume` → **deny**; `Invoke-Expression` / `Invoke-WebRequest` / `Invoke-RestMethod` / `Set-ExecutionPolicy` / `Start-Process` → **ask**. Matching is case-sensitive substring while PowerShell is case-insensitive with aliases, so these catch the canonical LLM-emitted forms; anything missed still falls through to the implicit `ask` (prompt in interactive, deny in strict — never auto-run).
- Docs: `terminal` tool description + `CLAUDE.md` updated to "platform shell" instead of hardcoded `sh -c`.

## Tests
- New GOOS-aware `shellCommand` selection test (asserts pwsh/powershell on Windows, `sh -c` elsewhere).
- The non-zero-exit terminal test now uses `echo oops; exit 1` (valid in both sh and PowerShell).
- The **Windows execution path** (real PowerShell) is exercised by the windows-latest CI job — I can't run it locally (macOS).

## Out of scope
- Full Unix→PowerShell command translation: not attempted. The model is told the dialect and generates PowerShell directly.
- This is the terminal-shell gap only; the built-in read/write/edit/glob/grep tools were already Go-native and cross-platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)