### PR TITLE
feat(provider): retry transient API failures with backoff + Retry-After

### DIFF
--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/provider"
+	"github.com/Leihb/octo-agent/internal/provider/retry"
 )
 
 // DefaultBaseURL is Anthropic's API base. The actual Messages endpoint is
@@ -46,6 +47,16 @@ type Client struct {
 	BaseURL    string       // optional override; defaults to DefaultBaseURL
 	APIVersion string       // optional override; defaults to DefaultAPIVersion
 	HTTPClient *http.Client // optional; defaults to http.Client with a 60s timeout
+	Retry      retry.Policy // optional; zero value falls back to retry.Default()
+}
+
+// policy returns the configured retry policy, or the package default when the
+// caller left Client.Retry zero.
+func (c *Client) policy() retry.Policy {
+	if c.Retry.MaxAttempts > 0 {
+		return c.Retry
+	}
+	return retry.Default()
 }
 
 // New constructs a Client with the given API key and the standard defaults.
@@ -99,61 +110,66 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		return provider.Response{}, fmt.Errorf("anthropic: marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpointURL(), bytes.NewReader(payload))
-	if err != nil {
-		return provider.Response{}, fmt.Errorf("anthropic: build request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("x-api-key", c.APIKey)
-	apiVer := c.APIVersion
-	if apiVer == "" {
-		apiVer = DefaultAPIVersion
-	}
-	httpReq.Header.Set("anthropic-version", apiVer)
-
 	httpClient := c.HTTPClient
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
 
-	resp, err := httpClient.Do(httpReq)
-	if err != nil {
-		return provider.Response{}, fmt.Errorf("anthropic: send: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return provider.Response{}, fmt.Errorf("anthropic: read response: %w", err)
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		var apiErr apiError
-		if jerr := json.Unmarshal(respBody, &apiErr); jerr == nil && apiErr.Error.Message != "" {
-			return provider.Response{}, fmt.Errorf(
-				"anthropic: HTTP %d (%s): %s",
-				resp.StatusCode, apiErr.Error.Type, apiErr.Error.Message,
-			)
+	// Retry the request on transient failures (429/5xx/529/network). The
+	// payload is fixed across attempts; each attempt gets a fresh body reader.
+	return retry.Do(ctx, c.policy(), func(ctx context.Context) (provider.Response, retry.Decision, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpointURL(), bytes.NewReader(payload))
+		if err != nil {
+			return provider.Response{}, retry.Decision{}, fmt.Errorf("anthropic: build request: %w", err)
 		}
-		return provider.Response{}, fmt.Errorf("anthropic: HTTP %d: %s", resp.StatusCode, string(respBody))
-	}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("x-api-key", c.APIKey)
+		apiVer := c.APIVersion
+		if apiVer == "" {
+			apiVer = DefaultAPIVersion
+		}
+		httpReq.Header.Set("anthropic-version", apiVer)
 
-	var apiResp apiResponse
-	if err := json.Unmarshal(respBody, &apiResp); err != nil {
-		return provider.Response{}, fmt.Errorf("anthropic: decode response: %w", err)
-	}
+		resp, err := httpClient.Do(httpReq)
+		if err != nil {
+			return provider.Response{}, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("anthropic: send: %w", err)
+		}
+		defer resp.Body.Close()
 
-	blocks := fromAPIContentBlocks(apiResp.Content)
-	return provider.Response{
-		Content:          joinTextBlocks(apiResp.Content),
-		Blocks:           blocks,
-		Model:            apiResp.Model,
-		StopReason:       apiResp.StopReason,
-		InputTokens:      apiResp.Usage.InputTokens,
-		OutputTokens:     apiResp.Usage.OutputTokens,
-		CacheReadTokens:  apiResp.Usage.CacheReadInputTokens,
-		CacheWriteTokens: apiResp.Usage.CacheCreationInputTokens,
-	}, nil
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return provider.Response{}, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("anthropic: read response: %w", err)
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			dec := retry.Decision{Retry: retry.RetryableStatus(resp.StatusCode), RetryAfter: retry.RetryAfterHeader(resp.Header)}
+			var apiErr apiError
+			if jerr := json.Unmarshal(respBody, &apiErr); jerr == nil && apiErr.Error.Message != "" {
+				return provider.Response{}, dec, fmt.Errorf(
+					"anthropic: HTTP %d (%s): %s",
+					resp.StatusCode, apiErr.Error.Type, apiErr.Error.Message,
+				)
+			}
+			return provider.Response{}, dec, fmt.Errorf("anthropic: HTTP %d: %s", resp.StatusCode, string(respBody))
+		}
+
+		var apiResp apiResponse
+		if err := json.Unmarshal(respBody, &apiResp); err != nil {
+			return provider.Response{}, retry.Decision{}, fmt.Errorf("anthropic: decode response: %w", err)
+		}
+
+		blocks := fromAPIContentBlocks(apiResp.Content)
+		return provider.Response{
+			Content:          joinTextBlocks(apiResp.Content),
+			Blocks:           blocks,
+			Model:            apiResp.Model,
+			StopReason:       apiResp.StopReason,
+			InputTokens:      apiResp.Usage.InputTokens,
+			OutputTokens:     apiResp.Usage.OutputTokens,
+			CacheReadTokens:  apiResp.Usage.CacheReadInputTokens,
+			CacheWriteTokens: apiResp.Usage.CacheCreationInputTokens,
+		}, retry.Decision{}, nil
+	})
 }
 
 // endpointURL returns BaseURL + MessagesPath, applying defaults and trimming

--- a/internal/provider/anthropic/client_test.go
+++ b/internal/provider/anthropic/client_test.go
@@ -7,10 +7,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/provider"
+	"github.com/Leihb/octo-agent/internal/provider/retry"
 )
 
 func TestNew_EmptyKeyRejected(t *testing.T) {
@@ -283,5 +286,65 @@ func TestSend_ParsesCacheUsage(t *testing.T) {
 	}
 	if resp.CacheReadTokens != 3400 {
 		t.Errorf("CacheReadTokens = %d, want 3400 (cache_read_input_tokens)", resp.CacheReadTokens)
+	}
+}
+
+func TestSend_RetriesTransientThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			// First attempt: transient 503 with a Retry-After the policy caps.
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":{"type":"overloaded_error","message":"try again"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"m","type":"message","role":"assistant","model":"x",
+			"content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn",
+			"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	c.Retry = retry.Policy{MaxAttempts: 4, BaseDelay: time.Millisecond, MaxDelay: 5 * time.Millisecond}
+
+	resp, err := c.Send(context.Background(), provider.Request{
+		Model:    "x",
+		Messages: []agent.Message{agent.NewUserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Errorf("content = %q, want ok", resp.Content)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("expected 2 HTTP attempts (1 retry), got %d", got)
+	}
+}
+
+func TestSend_DoesNotRetryClientError(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest) // 400: not retryable
+		_, _ = w.Write([]byte(`{"error":{"type":"invalid_request_error","message":"bad"}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	c.Retry = retry.Policy{MaxAttempts: 4, BaseDelay: time.Millisecond, MaxDelay: time.Millisecond}
+
+	if _, err := c.Send(context.Background(), provider.Request{
+		Model:    "x",
+		Messages: []agent.Message{agent.NewUserMessage("hi")},
+	}); err == nil {
+		t.Fatal("expected error for 400")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("400 should not be retried; attempts=%d", got)
 	}
 }

--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/provider"
+	"github.com/Leihb/octo-agent/internal/provider/retry"
 )
 
 // blockAccumulator holds in-progress state for a single content block while
@@ -70,36 +71,46 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		return provider.Response{}, fmt.Errorf("anthropic: marshal stream request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpointURL(), bytes.NewReader(payload))
-	if err != nil {
-		return provider.Response{}, fmt.Errorf("anthropic: build stream request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "text/event-stream")
-	httpReq.Header.Set("x-api-key", c.APIKey)
-	apiVer := c.APIVersion
-	if apiVer == "" {
-		apiVer = DefaultAPIVersion
-	}
-	httpReq.Header.Set("anthropic-version", apiVer)
+	// Retry only request establishment (build → send → status check). Once the
+	// body below starts streaming we can't retry without duplicating emitted
+	// tokens. On success the attempt returns the open response for scanning.
+	resp, err := retry.Do(ctx, c.policy(), func(ctx context.Context) (*http.Response, retry.Decision, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpointURL(), bytes.NewReader(payload))
+		if err != nil {
+			return nil, retry.Decision{}, fmt.Errorf("anthropic: build stream request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Accept", "text/event-stream")
+		httpReq.Header.Set("x-api-key", c.APIKey)
+		apiVer := c.APIVersion
+		if apiVer == "" {
+			apiVer = DefaultAPIVersion
+		}
+		httpReq.Header.Set("anthropic-version", apiVer)
 
-	resp, err := c.streamingHTTPClient().Do(httpReq)
+		resp, err := c.streamingHTTPClient().Do(httpReq)
+		if err != nil {
+			return nil, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("anthropic: send stream: %w", err)
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			respBody, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			dec := retry.Decision{Retry: retry.RetryableStatus(resp.StatusCode), RetryAfter: retry.RetryAfterHeader(resp.Header)}
+			var apiErr apiError
+			if jerr := json.Unmarshal(respBody, &apiErr); jerr == nil && apiErr.Error.Message != "" {
+				return nil, dec, fmt.Errorf(
+					"anthropic: HTTP %d (%s): %s",
+					resp.StatusCode, apiErr.Error.Type, apiErr.Error.Message,
+				)
+			}
+			return nil, dec, fmt.Errorf("anthropic: HTTP %d: %s", resp.StatusCode, string(respBody))
+		}
+		return resp, retry.Decision{}, nil
+	})
 	if err != nil {
-		return provider.Response{}, fmt.Errorf("anthropic: send stream: %w", err)
+		return provider.Response{}, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		respBody, _ := io.ReadAll(resp.Body)
-		var apiErr apiError
-		if jerr := json.Unmarshal(respBody, &apiErr); jerr == nil && apiErr.Error.Message != "" {
-			return provider.Response{}, fmt.Errorf(
-				"anthropic: HTTP %d (%s): %s",
-				resp.StatusCode, apiErr.Error.Type, apiErr.Error.Message,
-			)
-		}
-		return provider.Response{}, fmt.Errorf("anthropic: HTTP %d: %s", resp.StatusCode, string(respBody))
-	}
 
 	var (
 		result     provider.Response

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/provider"
+	"github.com/Leihb/octo-agent/internal/provider/retry"
 )
 
 // DefaultBaseURL is OpenAI's API host. The actual Chat Completions endpoint
@@ -41,6 +42,16 @@ type Client struct {
 	APIKey     string
 	BaseURL    string       // optional override; defaults to DefaultBaseURL
 	HTTPClient *http.Client // optional; defaults to http.Client with a 60s timeout
+	Retry      retry.Policy // optional; zero value falls back to retry.Default()
+}
+
+// policy returns the configured retry policy, or the package default when the
+// caller left Client.Retry zero.
+func (c *Client) policy() retry.Policy {
+	if c.Retry.MaxAttempts > 0 {
+		return c.Retry
+	}
+	return retry.Default()
 }
 
 // New constructs a Client with the given API key and the standard defaults.
@@ -93,38 +104,47 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		return provider.Response{}, fmt.Errorf("openai: marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpointURL(), bytes.NewReader(payload))
-	if err != nil {
-		return provider.Response{}, fmt.Errorf("openai: build request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
-
 	httpClient := c.HTTPClient
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
 
-	resp, err := httpClient.Do(httpReq)
-	if err != nil {
-		return provider.Response{}, fmt.Errorf("openai: send: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return provider.Response{}, fmt.Errorf("openai: read response: %w", err)
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		var apiErr apiError
-		if jerr := json.Unmarshal(respBody, &apiErr); jerr == nil && apiErr.Error.Message != "" {
-			return provider.Response{}, fmt.Errorf(
-				"openai: HTTP %d (%s): %s",
-				resp.StatusCode, apiErr.Error.Type, apiErr.Error.Message,
-			)
+	// Retry request establishment + body read on transient failures; parse the
+	// (fixed) response body below. Each attempt gets a fresh body reader.
+	respBody, err := retry.Do(ctx, c.policy(), func(ctx context.Context) ([]byte, retry.Decision, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpointURL(), bytes.NewReader(payload))
+		if err != nil {
+			return nil, retry.Decision{}, fmt.Errorf("openai: build request: %w", err)
 		}
-		return provider.Response{}, fmt.Errorf("openai: HTTP %d: %s", resp.StatusCode, string(respBody))
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
+
+		resp, err := httpClient.Do(httpReq)
+		if err != nil {
+			return nil, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("openai: send: %w", err)
+		}
+		defer resp.Body.Close()
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("openai: read response: %w", err)
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			dec := retry.Decision{Retry: retry.RetryableStatus(resp.StatusCode), RetryAfter: retry.RetryAfterHeader(resp.Header)}
+			var apiErr apiError
+			if jerr := json.Unmarshal(respBody, &apiErr); jerr == nil && apiErr.Error.Message != "" {
+				return nil, dec, fmt.Errorf(
+					"openai: HTTP %d (%s): %s",
+					resp.StatusCode, apiErr.Error.Type, apiErr.Error.Message,
+				)
+			}
+			return nil, dec, fmt.Errorf("openai: HTTP %d: %s", resp.StatusCode, string(respBody))
+		}
+		return respBody, retry.Decision{}, nil
+	})
+	if err != nil {
+		return provider.Response{}, err
 	}
 
 	var apiResp apiResponse

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/provider"
+	"github.com/Leihb/octo-agent/internal/provider/retry"
 )
 
 // toolCallState accumulates streaming fragments for one tool call.
@@ -63,31 +64,41 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		return provider.Response{}, fmt.Errorf("openai: marshal stream request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpointURL(), bytes.NewReader(payload))
-	if err != nil {
-		return provider.Response{}, fmt.Errorf("openai: build stream request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "text/event-stream")
-	httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
+	// Retry only request establishment (build → send → status check). Once the
+	// body below starts streaming we can't retry without duplicating emitted
+	// tokens. On success the attempt returns the open response for scanning.
+	resp, err := retry.Do(ctx, c.policy(), func(ctx context.Context) (*http.Response, retry.Decision, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpointURL(), bytes.NewReader(payload))
+		if err != nil {
+			return nil, retry.Decision{}, fmt.Errorf("openai: build stream request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Accept", "text/event-stream")
+		httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
 
-	resp, err := c.streamingHTTPClient().Do(httpReq)
+		resp, err := c.streamingHTTPClient().Do(httpReq)
+		if err != nil {
+			return nil, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("openai: send stream: %w", err)
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			respBody, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			dec := retry.Decision{Retry: retry.RetryableStatus(resp.StatusCode), RetryAfter: retry.RetryAfterHeader(resp.Header)}
+			var apiErr apiError
+			if jerr := json.Unmarshal(respBody, &apiErr); jerr == nil && apiErr.Error.Message != "" {
+				return nil, dec, fmt.Errorf(
+					"openai: HTTP %d (%s): %s",
+					resp.StatusCode, apiErr.Error.Type, apiErr.Error.Message,
+				)
+			}
+			return nil, dec, fmt.Errorf("openai: HTTP %d: %s", resp.StatusCode, string(respBody))
+		}
+		return resp, retry.Decision{}, nil
+	})
 	if err != nil {
-		return provider.Response{}, fmt.Errorf("openai: send stream: %w", err)
+		return provider.Response{}, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		respBody, _ := io.ReadAll(resp.Body)
-		var apiErr apiError
-		if jerr := json.Unmarshal(respBody, &apiErr); jerr == nil && apiErr.Error.Message != "" {
-			return provider.Response{}, fmt.Errorf(
-				"openai: HTTP %d (%s): %s",
-				resp.StatusCode, apiErr.Error.Type, apiErr.Error.Message,
-			)
-		}
-		return provider.Response{}, fmt.Errorf("openai: HTTP %d: %s", resp.StatusCode, string(respBody))
-	}
 
 	var (
 		contentB   strings.Builder

--- a/internal/provider/retry/retry.go
+++ b/internal/provider/retry/retry.go
@@ -1,0 +1,153 @@
+// Package retry adds bounded exponential-backoff retries to provider HTTP
+// calls for transient failures — request timeouts, rate limits (429), the 5xx
+// family, Anthropic's 529 "overloaded", and transient network errors — while
+// honoring a server-supplied Retry-After header. The anthropic and openai
+// clients route their request-establishment phase through Do.
+//
+// Streaming retries cover only request establishment (build → send → status
+// check); once the response body starts streaming, a mid-stream failure is not
+// retried (it would duplicate already-emitted tokens).
+package retry
+
+import (
+	"context"
+	"errors"
+	"math"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Policy bounds the retry loop.
+type Policy struct {
+	MaxAttempts int           // total attempts including the first
+	BaseDelay   time.Duration // first backoff step
+	MaxDelay    time.Duration // cap on any single wait (also caps Retry-After)
+}
+
+// Default is the standard provider policy: 4 attempts with ~0.5s→1s→2s of
+// jittered backoff between them, no single wait longer than 30s.
+func Default() Policy {
+	return Policy{MaxAttempts: 4, BaseDelay: 500 * time.Millisecond, MaxDelay: 30 * time.Second}
+}
+
+// Decision tells Do whether the just-returned error is worth retrying and, if
+// the server supplied one, how long to wait before doing so (which overrides
+// the computed backoff).
+type Decision struct {
+	Retry      bool
+	RetryAfter time.Duration
+}
+
+// Do runs attempt up to p.MaxAttempts times. It retries only while attempt
+// returns a non-nil error AND Decision.Retry is true AND attempts remain AND
+// ctx is still live. Between tries it waits Decision.RetryAfter (capped at
+// MaxDelay) or, when that's zero, an exponential backoff with full jitter.
+// Returns the final attempt's (result, error) regardless of outcome.
+func Do[T any](ctx context.Context, p Policy, attempt func(context.Context) (T, Decision, error)) (T, error) {
+	if p.MaxAttempts < 1 {
+		p.MaxAttempts = 1
+	}
+	var (
+		result T
+		dec    Decision
+		err    error
+	)
+	for i := 1; ; i++ {
+		result, dec, err = attempt(ctx)
+		if err == nil || !dec.Retry || i >= p.MaxAttempts {
+			return result, err
+		}
+		wait := dec.RetryAfter
+		if wait <= 0 {
+			wait = backoff(p, i)
+		}
+		if wait > p.MaxDelay {
+			wait = p.MaxDelay
+		}
+		if serr := sleep(ctx, wait); serr != nil {
+			return result, err // ctx cancelled mid-wait: surface the attempt's error
+		}
+	}
+}
+
+// backoff returns BaseDelay * 2^(attempt-1), capped at MaxDelay, with full
+// jitter applied (a uniform random value in [0, that]).
+func backoff(p Policy, attempt int) time.Duration {
+	d := float64(p.BaseDelay) * math.Pow(2, float64(attempt-1))
+	if d > float64(p.MaxDelay) {
+		d = float64(p.MaxDelay)
+	}
+	return time.Duration(rand.Int63n(int64(d) + 1))
+}
+
+func sleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// RetryableStatus reports whether an HTTP status code is a transient failure
+// worth retrying.
+func RetryableStatus(code int) bool {
+	switch code {
+	case http.StatusRequestTimeout, // 408
+		http.StatusTooManyRequests,     // 429
+		http.StatusInternalServerError, // 500
+		http.StatusBadGateway,          // 502
+		http.StatusServiceUnavailable,  // 503
+		http.StatusGatewayTimeout,      // 504
+		529:                            // Anthropic "overloaded" (no stdlib const)
+		return true
+	}
+	return false
+}
+
+// RetryableErr reports whether a transport-level error from http.Client.Do is
+// worth retrying: true for transient network failures, false when there's no
+// error or the context was cancelled / timed out (a user abort or deadline,
+// not a transient blip).
+func RetryableErr(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if ctx.Err() != nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return true
+}
+
+// RetryAfterHeader parses a Retry-After header value (delay-seconds or an
+// HTTP-date) into a duration. Returns 0 when the header is absent, malformed,
+// or in the past.
+func RetryAfterHeader(h http.Header) time.Duration {
+	v := strings.TrimSpace(h.Get("Retry-After"))
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}

--- a/internal/provider/retry/retry_test.go
+++ b/internal/provider/retry/retry_test.go
@@ -1,0 +1,125 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func fast() Policy {
+	return Policy{MaxAttempts: 4, BaseDelay: time.Millisecond, MaxDelay: 5 * time.Millisecond}
+}
+
+func TestDo_RetriesThenSucceeds(t *testing.T) {
+	calls := 0
+	got, err := Do(context.Background(), fast(), func(context.Context) (int, Decision, error) {
+		calls++
+		if calls < 3 {
+			return 0, Decision{Retry: true}, errors.New("boom")
+		}
+		return 42, Decision{}, nil
+	})
+	if err != nil || got != 42 {
+		t.Fatalf("got %d err %v, want 42 nil", got, err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 attempts, got %d", calls)
+	}
+}
+
+func TestDo_StopsOnNonRetryable(t *testing.T) {
+	calls := 0
+	_, err := Do(context.Background(), fast(), func(context.Context) (int, Decision, error) {
+		calls++
+		return 0, Decision{Retry: false}, errors.New("nope")
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Errorf("non-retryable should not retry; calls=%d", calls)
+	}
+}
+
+func TestDo_ExhaustsAttempts(t *testing.T) {
+	calls := 0
+	_, err := Do(context.Background(), fast(), func(context.Context) (int, Decision, error) {
+		calls++
+		return 0, Decision{Retry: true}, errors.New("always")
+	})
+	if err == nil {
+		t.Fatal("expected error after exhaustion")
+	}
+	if calls != 4 {
+		t.Errorf("expected 4 attempts, got %d", calls)
+	}
+}
+
+func TestDo_ContextCancellationAbortsWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	// A huge backoff would hang for an hour if the wait ignored ctx; cancelling
+	// during the first attempt must abort the wait and surface that attempt's error.
+	_, err := Do(ctx, Policy{MaxAttempts: 5, BaseDelay: time.Hour, MaxDelay: time.Hour}, func(context.Context) (int, Decision, error) {
+		calls++
+		cancel()
+		return 0, Decision{Retry: true}, errors.New("boom")
+	})
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("want the attempt error 'boom', got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("cancellation should stop after the first attempt, got %d", calls)
+	}
+}
+
+func TestRetryableStatus(t *testing.T) {
+	for _, c := range []int{408, 429, 500, 502, 503, 504, 529} {
+		if !RetryableStatus(c) {
+			t.Errorf("%d should be retryable", c)
+		}
+	}
+	for _, c := range []int{200, 201, 400, 401, 403, 404, 422} {
+		if RetryableStatus(c) {
+			t.Errorf("%d should NOT be retryable", c)
+		}
+	}
+}
+
+func TestRetryAfterHeader(t *testing.T) {
+	h := http.Header{}
+	if d := RetryAfterHeader(h); d != 0 {
+		t.Errorf("absent → 0, got %v", d)
+	}
+	h.Set("Retry-After", "3")
+	if d := RetryAfterHeader(h); d != 3*time.Second {
+		t.Errorf("seconds parse = %v, want 3s", d)
+	}
+	h.Set("Retry-After", "0")
+	if d := RetryAfterHeader(h); d != 0 {
+		t.Errorf("zero seconds → 0, got %v", d)
+	}
+	h.Set("Retry-After", "not-a-number")
+	if d := RetryAfterHeader(h); d != 0 {
+		t.Errorf("garbage → 0, got %v", d)
+	}
+}
+
+func TestRetryableErr(t *testing.T) {
+	if RetryableErr(context.Background(), nil) {
+		t.Error("nil err is not retryable")
+	}
+	if !RetryableErr(context.Background(), errors.New("connection reset")) {
+		t.Error("transient transport error should be retryable")
+	}
+	if RetryableErr(context.Background(), context.Canceled) {
+		t.Error("context.Canceled should not be retryable")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if RetryableErr(ctx, errors.New("anything")) {
+		t.Error("cancelled context → not retryable")
+	}
+}


### PR DESCRIPTION
Production-readiness Tier 1, item 2.

## Problem
Both providers did a single `httpClient.Do` with no retry. A transient **429 / 5xx / 529 (Anthropic overloaded) / network blip** failed the whole turn — and inside a long agentic loop, the whole run. That's the most common real-world failure mode and it was unhandled.

## Change
New `internal/provider/retry` package and wiring into both clients.

**`retry.Do[T](ctx, policy, attempt)`** — generic, bounded retry loop. Retries only when the attempt returns an error **and** marks it retryable **and** attempts remain **and** ctx is still live. Waits are **ctx-aware** (Ctrl-C / deadline aborts the wait immediately).

- **Default policy**: 4 attempts, 500ms base, 30s cap → ~0.5s → 1s → 2s of jittered (full-jitter) backoff.
- **Classifiers**: `RetryableStatus` (408/429/500/502/503/504/529), `RetryableErr` (transient transport errors, but **not** context cancellation), `RetryAfterHeader` (delay-seconds or HTTP-date, capped at MaxDelay — a server Retry-After overrides the computed backoff).

**Wiring**: a `Client.Retry` policy field on both clients (zero value → `retry.Default()`, so existing callers get retries for free; tests inject a fast policy).
- `Send` (buffered): retries the full request/response.
- `SendStream`: retries **only request establishment** (build → send → status check). Once the body starts streaming, a mid-stream failure is **not** retried — that would duplicate already-emitted tokens. Documented as a deliberate boundary.

## Tests
- `retry` package: retry-then-succeed, stop-on-non-retryable, exhaust-attempts, **ctx-cancel-aborts-wait** (huge backoff + cancel → returns immediately), and all three classifiers.
- anthropic provider via httptest: **503-then-200** asserts exactly one retry + success; **400** asserts no retry.

## Verification
`gofmt -l .` clean · `go vet ./...` clean · `go test -race ./...` all pass.

## Not in scope
- Mid-stream resync (would need response replay/idempotency).
- Adaptive/circuit-breaker behavior across calls — out of scope for this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)