### PR TITLE
feat(eval): Multi-SWE-bench (Go) eval harness scaffold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@
 #   make fmt-check  fail if anything would be reformatted
 #   make tidy       go mod tidy
 #   make clean      remove build artefacts
+#
+# Multi-SWE-bench eval (manual; needs a model key + Docker + Python, NOT in CI):
+#   make eval-mswe-build                build the ./mswe-eval tool
+#   make eval-mswe-inspect DATASET=...  confirm the dataset schema
+#   make eval-mswe DATASET=...          generate patches with octo, then judge
+# See dev-docs/mswe-eval.md.
 
 GOTAGS ?=
 GOFLAGS ?=
@@ -29,7 +35,8 @@ COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 LDFLAGS := -X github.com/Leihb/octo-agent/internal/version.Version=$(VERSION) \
            -X github.com/Leihb/octo-agent/internal/version.Commit=$(COMMIT)
 
-.PHONY: all build install test cover vet fmt fmt-check tidy clean
+.PHONY: all build install test cover vet fmt fmt-check tidy clean \
+        eval-mswe-build eval-mswe-inspect eval-mswe
 
 all: test
 
@@ -65,5 +72,20 @@ tidy:
 	go mod tidy
 
 clean:
-	rm -f octo octo.exe coverage.out coverage.html
+	rm -f octo octo.exe mswe-eval coverage.out coverage.html
 	rm -rf dist/
+
+# ── Multi-SWE-bench eval (manual; see dev-docs/mswe-eval.md) ────────────────
+# DATASET must point at a Go-filtered Multi-SWE-bench JSONL. LIMIT caps the
+# instance count. These call a real model and (for judging) Docker + Python —
+# never run them in CI.
+LIMIT  ?= 5
+
+eval-mswe-build:
+	go build $(GOFLAGS) -o mswe-eval ./cmd/mswe-eval
+
+eval-mswe-inspect: eval-mswe-build build
+	./mswe-eval inspect --dataset '$(DATASET)' --limit $(LIMIT)
+
+eval-mswe: eval-mswe-build build
+	./mswe-eval run --dataset '$(DATASET)' --limit $(LIMIT) --octo ./octo --out predictions.jsonl

--- a/cmd/mswe-eval/main.go
+++ b/cmd/mswe-eval/main.go
@@ -1,0 +1,339 @@
+// Command mswe-eval runs the octo side of the Multi-SWE-bench evaluation: it
+// drives octo over a slice of Go instances to produce patches, then hands them
+// to the official Python+Docker judge.
+//
+// This tool is NOT part of the octo binary and never runs in CI — it needs a
+// real model key, network, and (for `judge`) Docker + the multi_swe_bench
+// Python package. See dev-docs/mswe-eval.md.
+//
+// Subcommands:
+//
+//	inspect   Print the schema (keys + scalars) of the first N dataset records,
+//	          to confirm field names before a real run.
+//	generate  Clone each repo at its base commit, drive octo to fix the issue,
+//	          and write predictions.jsonl (one {org,repo,number,fix_patch}/line).
+//	judge     Write the harness config, invoke run_evaluation, parse the report.
+//	run       generate then judge.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/mswe"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	var err error
+	switch os.Args[1] {
+	case "inspect":
+		err = runInspect(os.Args[2:])
+	case "generate":
+		err = runGenerate(os.Args[2:])
+	case "judge":
+		err = runJudge(os.Args[2:])
+	case "run":
+		if err = runGenerate(os.Args[2:]); err == nil {
+			err = runJudge(os.Args[2:])
+		}
+	default:
+		usage()
+		os.Exit(2)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mswe-eval: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: mswe-eval <inspect|generate|judge|run> [flags]")
+	fmt.Fprintln(os.Stderr, "see dev-docs/mswe-eval.md")
+}
+
+// ── inspect ────────────────────────────────────────────────────────────────
+
+func runInspect(args []string) error {
+	fs := flag.NewFlagSet("inspect", flag.ContinueOnError)
+	dataset := fs.String("dataset", "", "path to the Multi-SWE-bench JSONL dataset")
+	lang := fs.String("lang", "go", "language filter ('' = all)")
+	limit := fs.Int("limit", 1, "number of records to inspect")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	insts, err := loadDataset(*dataset, *lang, *limit)
+	if err != nil {
+		return err
+	}
+	for i, inst := range insts {
+		fmt.Printf("── record %d ── %s [%s]\n", i, inst.ID(), inst.Language())
+		fmt.Printf("  keys: %s\n", strings.Join(inst.Keys(), ", "))
+		fmt.Printf("  base_commit: %q\n", inst.BaseCommit())
+		fmt.Printf("  clone_url:   %s\n", inst.CloneURL())
+		ps := inst.ProblemStatement()
+		if len(ps) > 200 {
+			ps = ps[:200] + "…"
+		}
+		fmt.Printf("  problem (preview): %s\n", strings.ReplaceAll(ps, "\n", " "))
+	}
+	if len(insts) == 0 {
+		fmt.Println("(no records matched — check --dataset path and --lang)")
+	}
+	return nil
+}
+
+// ── generate ───────────────────────────────────────────────────────────────
+
+func runGenerate(args []string) error {
+	fs := flag.NewFlagSet("generate", flag.ContinueOnError)
+	dataset := fs.String("dataset", "", "path to the Multi-SWE-bench JSONL dataset")
+	lang := fs.String("lang", "go", "language filter")
+	limit := fs.Int("limit", 5, "max instances to run")
+	octoBin := fs.String("octo", "./octo", "path to the octo binary")
+	out := fs.String("out", "predictions.jsonl", "output predictions file (JSONL)")
+	workdir := fs.String("workdir", filepath.Join(os.TempDir(), "mswe-eval"), "scratch dir for clones + octo HOME")
+	model := fs.String("model", "", "model passed to octo (empty = octo default)")
+	provider := fs.String("provider", "", "provider passed to octo (empty = octo default)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	insts, err := loadDataset(*dataset, *lang, *limit)
+	if err != nil {
+		return err
+	}
+	if len(insts) == 0 {
+		return fmt.Errorf("no %s instances found in %s", *lang, *dataset)
+	}
+	octoAbs, err := filepath.Abs(*octoBin)
+	if err != nil {
+		return err
+	}
+
+	// Isolated HOME so octo's ~/.octo (sessions, memory, permissions) doesn't
+	// touch the user's, and so a permissive permissions file lets the agent run
+	// tools non-interactively in the throwaway clone.
+	evalHome := filepath.Join(*workdir, "home")
+	if err := writeEvalPermissions(evalHome); err != nil {
+		return err
+	}
+
+	var preds []mswe.Prediction
+	for i, inst := range insts {
+		fmt.Printf("[%d/%d] %s — clone + run octo…\n", i+1, len(insts), inst.ID())
+		patch, err := generateOne(inst, octoAbs, evalHome, *workdir, *model, *provider)
+		if err != nil {
+			fmt.Printf("        ! skipped: %v\n", err)
+			continue
+		}
+		if strings.TrimSpace(patch) == "" {
+			fmt.Printf("        ! empty patch (octo made no source changes) — recording anyway\n")
+		}
+		preds = append(preds, mswe.Prediction{
+			Org: inst.Org(), Repo: inst.Repo(), Number: inst.Number(), FixPatch: patch,
+		})
+	}
+
+	f, err := os.Create(*out)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := mswe.WritePredictions(f, preds); err != nil {
+		return err
+	}
+	fmt.Printf("wrote %d prediction(s) → %s\n", len(preds), *out)
+	return nil
+}
+
+// generateOne clones the instance's repo at its base commit, drives octo to
+// resolve the issue, and returns the test-scoped diff.
+func generateOne(inst mswe.Instance, octoBin, evalHome, workdir, model, provider string) (string, error) {
+	if inst.BaseCommit() == "" {
+		return "", fmt.Errorf("no base commit (run `inspect` to confirm the field name)")
+	}
+	repoDir := filepath.Join(workdir, "repos", fmt.Sprintf("%s__%s__%d", inst.Org(), inst.Repo(), inst.Number()))
+	_ = os.RemoveAll(repoDir)
+	if err := os.MkdirAll(filepath.Dir(repoDir), 0o755); err != nil {
+		return "", err
+	}
+
+	if out, err := run("", nil, "git", "clone", "--quiet", inst.CloneURL(), repoDir); err != nil {
+		return "", fmt.Errorf("clone: %v (%s)", err, truncate(out, 200))
+	}
+	if out, err := run(repoDir, nil, "git", "checkout", "--quiet", inst.BaseCommit()); err != nil {
+		return "", fmt.Errorf("checkout %s: %v (%s)", inst.BaseCommit(), err, truncate(out, 200))
+	}
+
+	// Drive octo headless: single-turn agentic loop, strict perms (the eval
+	// HOME's permissive permissions.yml allows the tools), session save off.
+	env := append(os.Environ(), "HOME="+evalHome)
+	octoArgs := []string{"chat", "--tools", "--permission-mode", "strict", "--no-save", "--quiet"}
+	if model != "" {
+		octoArgs = append(octoArgs, "--model", model)
+	}
+	if provider != "" {
+		octoArgs = append(octoArgs, "--provider", provider)
+	}
+	octoArgs = append(octoArgs, octoPrompt(inst))
+	if out, err := run(repoDir, env, octoBin, octoArgs...); err != nil {
+		return "", fmt.Errorf("octo run: %v (%s)", err, truncate(out, 300))
+	}
+
+	// Capture every change (incl. new/deleted files), then drop test files.
+	if out, err := run(repoDir, nil, "git", "add", "-A"); err != nil {
+		return "", fmt.Errorf("git add: %v (%s)", err, truncate(out, 200))
+	}
+	diff, err := run(repoDir, nil, "git", "diff", "--cached")
+	if err != nil {
+		return "", fmt.Errorf("git diff: %v", err)
+	}
+	return mswe.ScopeFixPatch(diff), nil
+}
+
+func octoPrompt(inst mswe.Instance) string {
+	return "You are working in the " + inst.Org() + "/" + inst.Repo() + " repository. " +
+		"Resolve the following issue by editing the SOURCE code only — do NOT add or modify any test files (*_test.go). " +
+		"When done, make sure the package still builds (`go build ./...`).\n\n" +
+		"--- ISSUE ---\n" + inst.ProblemStatement()
+}
+
+// writeEvalPermissions drops a permissive permissions.yml into the eval HOME so
+// octo runs its tools without interactive prompts inside the throwaway clone.
+func writeEvalPermissions(evalHome string) error {
+	dir := filepath.Join(evalHome, ".octo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	const perms = `# Generated by mswe-eval — allow tools non-interactively in the eval sandbox.
+terminal:
+  - allow: { pattern: "" }
+write_file:
+  - allow: { path: ["**"] }
+edit_file:
+  - allow: { path: ["**"] }
+read_file:
+  - allow: { path: ["**"] }
+`
+	return os.WriteFile(filepath.Join(dir, "permissions.yml"), []byte(perms), 0o644)
+}
+
+// ── judge ──────────────────────────────────────────────────────────────────
+
+func runJudge(args []string) error {
+	fs := flag.NewFlagSet("judge", flag.ContinueOnError)
+	dataset := fs.String("dataset", "", "path to the Multi-SWE-bench JSONL dataset")
+	predictions := fs.String("predictions", "predictions.jsonl", "predictions JSONL from `generate`")
+	workdir := fs.String("workdir", filepath.Join(os.TempDir(), "mswe-eval"), "scratch dir for the harness")
+	python := fs.String("python", "python3", "python interpreter with multi_swe_bench installed")
+	// generate-only flags tolerated so `run` can share one flag set.
+	_ = fs.String("octo", "", "")
+	_ = fs.String("out", "", "")
+	_ = fs.String("lang", "", "")
+	_ = fs.Int("limit", 0, "")
+	_ = fs.String("model", "", "")
+	_ = fs.String("provider", "", "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *dataset == "" {
+		return fmt.Errorf("judge: --dataset is required")
+	}
+	outputDir := filepath.Join(*workdir, "judge-out")
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return err
+	}
+
+	datasetAbs, _ := filepath.Abs(*dataset)
+	predAbs, _ := filepath.Abs(*predictions)
+	cfg := mswe.NewHarnessConfig(*workdir, datasetAbs, predAbs, outputDir)
+	cfgPath := filepath.Join(outputDir, "config.json")
+	cf, err := os.Create(cfgPath)
+	if err != nil {
+		return err
+	}
+	if err := cfg.Write(cf); err != nil {
+		cf.Close()
+		return err
+	}
+	cf.Close()
+
+	fmt.Printf("running judge: %s -m multi_swe_bench.harness.run_evaluation --config %s\n", *python, cfgPath)
+	cmd := exec.Command(*python, "-m", "multi_swe_bench.harness.run_evaluation", "--config", cfgPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run_evaluation: %w (is multi_swe_bench installed + Docker running?)", err)
+	}
+
+	reportPath, err := findReport(outputDir)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		return err
+	}
+	sum, err := mswe.ParseReport(data)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("\n=== Multi-SWE-bench (Go) ===\nresolved %d / %d  (unresolved %d)\nreport: %s\n",
+		sum.Resolved, sum.Total, sum.Unresolved, reportPath)
+	return nil
+}
+
+// findReport locates final_report.json beneath dir (the harness may nest it in
+// a run-specific subdirectory).
+func findReport(dir string) (string, error) {
+	var found string
+	_ = filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err == nil && info != nil && !info.IsDir() && filepath.Base(p) == "final_report.json" {
+			found = p
+		}
+		return nil
+	})
+	if found == "" {
+		return "", fmt.Errorf("final_report.json not found under %s — check the harness output above", dir)
+	}
+	return found, nil
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+func loadDataset(path, lang string, limit int) ([]mswe.Instance, error) {
+	if path == "" {
+		return nil, fmt.Errorf("--dataset is required (see dev-docs/mswe-eval.md for how to obtain the Go JSONL)")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return mswe.LoadInstances(f, lang, limit)
+}
+
+// run executes name+args in dir (cwd if "") with env (inherited if nil) and
+// returns combined output.
+func run(dir string, env []string, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func truncate(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) > n {
+		return s[:n] + "…"
+	}
+	return s
+}

--- a/dev-docs/mswe-eval.md
+++ b/dev-docs/mswe-eval.md
@@ -1,0 +1,105 @@
+# Multi-SWE-bench eval harness
+
+Measures octo's task-completion quality on a small slice of **Multi-SWE-bench**
+(Go subset) — real GitHub issues in real repos, judged by hidden tests. This is
+the Tier-1 "eval / regression" capability: it's how you tell whether a prompt,
+tool, or model change made octo *better or worse* at actually fixing issues.
+
+## Why it's not in CI
+
+A real eval **must** use the real model (it measures whether the fix works) and
+the official judge needs **Docker** + the `multi_swe_bench` Python package +
+network (clone repos, pull images). None of that belongs in `go test` (the
+project rule: no live network in CI). So this is a **manual / periodic** run.
+
+The Go code that's part of CI is only the pure logic in `internal/mswe`
+(dataset parsing, prediction writing, patch scoping, config, report parsing) —
+fully unit-tested. The orchestration in `cmd/mswe-eval` is exercised by the
+real run below.
+
+## Architecture (two stages)
+
+```
+mswe-eval generate  (our Go tool, drives octo)
+  for each Go instance:
+    git clone <repo> ; git checkout <base_commit>
+    octo chat --tools --permission-mode strict --no-save "<issue>"
+    git add -A ; git diff --cached ; strip *_test.go hunks
+  → predictions.jsonl   {org, repo, number, fix_patch}
+
+mswe-eval judge  (invokes the official harness)
+  → config.json {patch_files, dataset_files, output_dir, ...}
+  → python -m multi_swe_bench.harness.run_evaluation --config config.json
+       (builds a Docker env per instance, applies fix_patch + hidden tests, runs)
+  → final_report.json → resolved / total
+```
+
+octo only ever produces the source patch; the official harness owns the
+Docker-based judging. octo runs with an **isolated `HOME`** (a throwaway
+`<workdir>/home`) so eval sessions/memory don't touch your real `~/.octo`, and a
+permissive `permissions.yml` there lets it run tools without prompts in the
+disposable clone.
+
+## Prerequisites
+
+- A model key in the environment (e.g. `ANTHROPIC_API_KEY` + `ANTHROPIC_BASE_URL`
+  for a Kimi/Anthropic-compatible endpoint). `generate` passes the environment
+  through to octo.
+- `git`, network access (clone repos).
+- For `judge`: **Docker running**, `python3`, and `pip install multi_swe_bench`.
+
+## Get the Go dataset slice
+
+The dataset lives on HuggingFace as raw JSONL: `ByteDance-Seed/Multi-SWE-bench`
+(or the smaller `…_mini` / `…-flash`). Download it and keep only Go records, e.g.
+
+```bash
+huggingface-cli download ByteDance-Seed/Multi-SWE-bench --repo-type dataset --local-dir mswe-data
+# then filter to Go (field name confirmed by `inspect`, usually "language":"go")
+# into a single file, e.g. mswe-data/go.jsonl
+```
+
+`--dataset` (our tool) and `dataset_files` (the harness config) both point at
+this same Go JSONL.
+
+## Run it
+
+```bash
+# 0. Confirm the real schema FIRST — the dataset is raw JSONL and field names
+#    can drift by release. Check that base_commit + problem appear non-empty.
+make eval-mswe-inspect DATASET=mswe-data/go.jsonl LIMIT=1
+
+# 1. Full run: generate patches with octo, then judge (5 instances by default).
+make eval-mswe DATASET=mswe-data/go.jsonl LIMIT=5
+```
+
+Or drive the stages directly:
+
+```bash
+./mswe-eval generate --dataset mswe-data/go.jsonl --limit 5 --octo ./octo --out predictions.jsonl
+./mswe-eval judge    --dataset mswe-data/go.jsonl --predictions predictions.jsonl
+```
+
+## Confirm on the first run (build-time unknowns)
+
+The scaffold is tolerant but a few things can only be pinned against the real
+data / installed harness. Check these on the first run and adjust if needed:
+
+1. **Record field names** — `inspect` prints each record's keys. The accessors
+   in `internal/mswe/instance.go` try `base_commit`/`base.sha` and
+   `problem_statement`/`resolved_issues`; if `inspect` shows different names,
+   extend those accessors.
+2. **Harness config keys** — `internal/mswe/config.go` writes the documented
+   keys (`patch_files`, `dataset_files`, `output_dir`, worker counts). If your
+   `multi_swe_bench` version wants more/different keys, the run will say so;
+   update `HarnessConfig`.
+3. **Report path/shape** — `judge` searches for `final_report.json` under the
+   output dir and `ParseReport` accepts either ID-lists or counts for
+   `resolved_instances`/`unresolved_instances`. Adjust if the real report
+   differs.
+
+## Cost & scale
+
+Each instance is one full octo agentic run (cheap on Kimi) plus one Docker
+build + test run (slow, heavy). Start at `LIMIT=5`, grow once the pipeline is
+proven. Expect the first run to be dominated by Docker image builds.

--- a/internal/mswe/config.go
+++ b/internal/mswe/config.go
@@ -1,0 +1,53 @@
+package mswe
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// HarnessConfig is the config.json passed to
+// `python -m multi_swe_bench.harness.run_evaluation --config <file>`. It points
+// the judge at the dataset records and our predictions, and at scratch/output
+// dirs for the per-instance Docker builds and the final report.
+//
+// Field names mirror the harness's documented config keys. The harness may
+// accept or require additional keys depending on its release; this covers the
+// documented set and leaves the rest at the harness defaults. Confirm against
+// the installed multi_swe_bench version on the first run.
+type HarnessConfig struct {
+	Mode                  string   `json:"mode"`
+	Workdir               string   `json:"workdir"`
+	PatchFiles            []string `json:"patch_files"`
+	DatasetFiles          []string `json:"dataset_files"`
+	OutputDir             string   `json:"output_dir"`
+	ForceBuild            bool     `json:"force_build"`
+	MaxWorkersBuildImage  int      `json:"max_workers_build_image"`
+	MaxWorkersRunInstance int      `json:"max_workers_run_instance"`
+}
+
+// NewHarnessConfig builds a config with conservative defaults: serial Docker
+// builds and runs (workers=1) so a small first run is easy to follow and
+// doesn't thrash the machine.
+func NewHarnessConfig(workdir, datasetFile, predictionsFile, outputDir string) HarnessConfig {
+	return HarnessConfig{
+		Mode:                  "evaluation",
+		Workdir:               workdir,
+		PatchFiles:            []string{predictionsFile},
+		DatasetFiles:          []string{datasetFile},
+		OutputDir:             outputDir,
+		ForceBuild:            false,
+		MaxWorkersBuildImage:  1,
+		MaxWorkersRunInstance: 1,
+	}
+}
+
+// Write emits the config as indented JSON.
+func (c HarnessConfig) Write(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(c); err != nil {
+		return fmt.Errorf("mswe: write harness config: %w", err)
+	}
+	return nil
+}

--- a/internal/mswe/instance.go
+++ b/internal/mswe/instance.go
@@ -1,0 +1,155 @@
+// Package mswe holds the pure, testable pieces of the Multi-SWE-bench eval
+// harness: dataset parsing, prediction writing, fix-patch scoping, harness
+// config generation, and report parsing. The shell-out orchestration (clone a
+// repo, drive octo, invoke the Python+docker judge) lives in cmd/mswe-eval.
+//
+// Multi-SWE-bench ships as raw JSONL and the exact record field names can drift
+// by release, so dataset access goes through tolerant accessors with fallbacks
+// rather than a rigid struct. Confirm the real names with `mswe-eval inspect`
+// before trusting a full run.
+package mswe
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// Instance is one benchmark record, kept as the raw decoded object so accessors
+// can tolerate schema variation and `inspect` can enumerate every key.
+type Instance struct {
+	raw map[string]any
+}
+
+// LoadInstances reads newline-delimited JSON records, optionally filtered to a
+// language (case-insensitive; "" = no filter) and capped at limit (<=0 = all).
+func LoadInstances(r io.Reader, language string, limit int) ([]Instance, error) {
+	sc := bufio.NewScanner(r)
+	// Records carry full patches; allow large lines (up to 16 MiB).
+	sc.Buffer(make([]byte, 64*1024), 16*1024*1024)
+
+	var out []Instance
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			return nil, fmt.Errorf("mswe: parse record: %w", err)
+		}
+		inst := Instance{raw: m}
+		if language != "" && !strings.EqualFold(inst.Language(), language) {
+			continue
+		}
+		out = append(out, inst)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("mswe: read dataset: %w", err)
+	}
+	return out, nil
+}
+
+// Keys returns the record's top-level field names, sorted — used by `inspect`
+// to confirm the real schema against this package's accessors.
+func (i Instance) Keys() []string {
+	ks := make([]string, 0, len(i.raw))
+	for k := range i.raw {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
+// Raw exposes the underlying decoded object (for inspect to print scalars).
+func (i Instance) Raw() map[string]any { return i.raw }
+
+func (i Instance) Org() string      { return str(i.raw, "org") }
+func (i Instance) Repo() string     { return str(i.raw, "repo") }
+func (i Instance) Number() int      { return num(i.raw, "number", "pull_number", "pr") }
+func (i Instance) Language() string { return str(i.raw, "language", "lang") }
+
+// ID is a human-readable instance identifier (org/repo#number).
+func (i Instance) ID() string {
+	return fmt.Sprintf("%s/%s#%d", i.Org(), i.Repo(), i.Number())
+}
+
+// CloneURL is the GitHub URL the runner clones to set up the working tree.
+func (i Instance) CloneURL() string {
+	return fmt.Sprintf("https://github.com/%s/%s.git", i.Org(), i.Repo())
+}
+
+// BaseCommit is the SHA the repo is checked out at before octo runs. Tries a
+// flat "base_commit" first, then a nested base.sha (SWE-bench-style records).
+func (i Instance) BaseCommit() string {
+	if s := str(i.raw, "base_commit", "base_sha"); s != "" {
+		return s
+	}
+	if b, ok := i.raw["base"].(map[string]any); ok {
+		return str(b, "sha", "commit")
+	}
+	return ""
+}
+
+// ProblemStatement is the issue/PR text given to octo as the task. Tries the
+// common flat fields, then falls back to concatenating resolved_issues titles
+// and bodies.
+func (i Instance) ProblemStatement() string {
+	if s := str(i.raw, "problem_statement", "problem", "issue"); s != "" {
+		return s
+	}
+	var b strings.Builder
+	if issues, ok := i.raw["resolved_issues"].([]any); ok {
+		for _, it := range issues {
+			m, ok := it.(map[string]any)
+			if !ok {
+				continue
+			}
+			if t := str(m, "title"); t != "" {
+				b.WriteString(t)
+				b.WriteString("\n\n")
+			}
+			if body := str(m, "body"); body != "" {
+				b.WriteString(body)
+				b.WriteString("\n\n")
+			}
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// str returns the first key present as a non-empty string.
+func str(m map[string]any, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := m[k]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// num returns the first key present as an int (JSON numbers decode to float64).
+func num(m map[string]any, keys ...string) int {
+	for _, k := range keys {
+		switch v := m[k].(type) {
+		case float64:
+			return int(v)
+		case int:
+			return v
+		case string:
+			var n int
+			if _, err := fmt.Sscanf(v, "%d", &n); err == nil {
+				return n
+			}
+		}
+	}
+	return 0
+}

--- a/internal/mswe/mswe_test.go
+++ b/internal/mswe/mswe_test.go
@@ -1,0 +1,133 @@
+package mswe
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestLoadInstances_FilterAndLimit(t *testing.T) {
+	data := strings.Join([]string{
+		`{"org":"a","repo":"r1","number":1,"language":"Go"}`,
+		`{"org":"b","repo":"r2","number":2,"language":"Rust"}`,
+		`{"org":"c","repo":"r3","number":3,"language":"go"}`,
+		``, // blank line ignored
+		`{"org":"d","repo":"r4","number":4,"language":"Go"}`,
+	}, "\n")
+
+	got, err := LoadInstances(strings.NewReader(data), "go", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("limit not honored: got %d", len(got))
+	}
+	if got[0].ID() != "a/r1#1" || got[1].ID() != "c/r3#3" {
+		t.Errorf("Go filter (case-insensitive) wrong: %s, %s", got[0].ID(), got[1].ID())
+	}
+}
+
+func TestInstance_BaseCommit_FlatAndNested(t *testing.T) {
+	flat, _ := LoadInstances(strings.NewReader(`{"base_commit":"abc123"}`), "", 0)
+	if flat[0].BaseCommit() != "abc123" {
+		t.Errorf("flat base_commit = %q", flat[0].BaseCommit())
+	}
+	nested, _ := LoadInstances(strings.NewReader(`{"base":{"sha":"def456"}}`), "", 0)
+	if nested[0].BaseCommit() != "def456" {
+		t.Errorf("nested base.sha = %q", nested[0].BaseCommit())
+	}
+}
+
+func TestInstance_ProblemStatement_FlatAndResolvedIssues(t *testing.T) {
+	flat, _ := LoadInstances(strings.NewReader(`{"problem_statement":"fix the bug"}`), "", 0)
+	if flat[0].ProblemStatement() != "fix the bug" {
+		t.Errorf("flat problem = %q", flat[0].ProblemStatement())
+	}
+	fallback, _ := LoadInstances(strings.NewReader(
+		`{"resolved_issues":[{"title":"Crash on nil","body":"It panics when x is nil."}]}`), "", 0)
+	ps := fallback[0].ProblemStatement()
+	if !strings.Contains(ps, "Crash on nil") || !strings.Contains(ps, "panics when x is nil") {
+		t.Errorf("resolved_issues fallback lost content: %q", ps)
+	}
+}
+
+func TestInstance_CloneURL(t *testing.T) {
+	got, _ := LoadInstances(strings.NewReader(`{"org":"golang","repo":"go","number":7}`), "", 0)
+	if u := got[0].CloneURL(); u != "https://github.com/golang/go.git" {
+		t.Errorf("CloneURL = %q", u)
+	}
+}
+
+func TestScopeFixPatch_StripsTestFiles(t *testing.T) {
+	diff := "diff --git a/foo.go b/foo.go\n" +
+		"--- a/foo.go\n+++ b/foo.go\n@@ -1 +1 @@\n-old\n+new\n" +
+		"diff --git a/foo_test.go b/foo_test.go\n" +
+		"--- a/foo_test.go\n+++ b/foo_test.go\n@@ -1 +1 @@\n-oldtest\n+newtest\n"
+
+	got := ScopeFixPatch(diff)
+	if !strings.Contains(got, "a/foo.go") || !strings.Contains(got, "+new") {
+		t.Errorf("source change dropped:\n%s", got)
+	}
+	if strings.Contains(got, "foo_test.go") || strings.Contains(got, "newtest") {
+		t.Errorf("test-file change should be stripped:\n%s", got)
+	}
+}
+
+func TestScopeFixPatch_KeepsAllWhenNoTests(t *testing.T) {
+	diff := "diff --git a/a.go b/a.go\n@@ -1 +1 @@\n-x\n+y\n"
+	if got := ScopeFixPatch(diff); got != diff {
+		t.Errorf("non-test diff should pass through unchanged:\n%s", got)
+	}
+}
+
+func TestWritePredictions_JSONL(t *testing.T) {
+	var b bytes.Buffer
+	err := WritePredictions(&b, []Prediction{
+		{Org: "a", Repo: "r", Number: 1, FixPatch: "diff1"},
+		{Org: "b", Repo: "s", Number: 2, FixPatch: "diff2"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(b.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 JSONL lines, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], `"fix_patch":"diff1"`) || !strings.Contains(lines[0], `"number":1`) {
+		t.Errorf("line 0 wrong: %s", lines[0])
+	}
+}
+
+func TestParseReport_ListAndCountShapes(t *testing.T) {
+	list := []byte(`{"resolved_instances":["a/r#1","b/s#2"],"unresolved_instances":["c/t#3"]}`)
+	s, err := ParseReport(list)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Resolved != 2 || s.Unresolved != 1 || s.Total != 3 {
+		t.Errorf("list shape: %+v", s)
+	}
+
+	counts := []byte(`{"resolved":5,"unresolved":3,"total":8}`)
+	s, err = ParseReport(counts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Resolved != 5 || s.Unresolved != 3 || s.Total != 8 {
+		t.Errorf("count shape: %+v", s)
+	}
+}
+
+func TestHarnessConfig_Write(t *testing.T) {
+	var b bytes.Buffer
+	c := NewHarnessConfig("/work", "/data/go.jsonl", "/out/predictions.jsonl", "/out")
+	if err := c.Write(&b); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	for _, want := range []string{`"patch_files"`, `"/out/predictions.jsonl"`, `"dataset_files"`, `"/data/go.jsonl"`, `"max_workers_run_instance": 1`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("config missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/mswe/patch.go
+++ b/internal/mswe/patch.go
@@ -1,0 +1,69 @@
+package mswe
+
+import "strings"
+
+// ScopeFixPatch strips test-file sections from a `git diff`, leaving only the
+// source changes. The Multi-SWE-bench harness applies the dataset's own hidden
+// test patch on top of the model's fix_patch, so a model patch that also
+// touched tests would conflict with — or worse, defeat — the hidden tests.
+//
+// The input is unified diff output where each file section starts with a
+// `diff --git a/<path> b/<path>` header. Sections whose path is a Go test file
+// (*_test.go) are dropped; the rest are rejoined unchanged.
+func ScopeFixPatch(diff string) string {
+	sections := splitDiffSections(diff)
+	var kept []string
+	for _, s := range sections {
+		if isGoTestFile(diffSectionPath(s)) {
+			continue
+		}
+		kept = append(kept, s)
+	}
+	return strings.Join(kept, "")
+}
+
+// splitDiffSections breaks a unified diff into per-file sections, each starting
+// at a `diff --git ` line and including everything up to the next one.
+func splitDiffSections(diff string) []string {
+	lines := strings.SplitAfter(diff, "\n")
+	var sections []string
+	var cur strings.Builder
+	flush := func() {
+		if cur.Len() > 0 {
+			sections = append(sections, cur.String())
+			cur.Reset()
+		}
+	}
+	for _, ln := range lines {
+		if strings.HasPrefix(ln, "diff --git ") {
+			flush()
+		}
+		cur.WriteString(ln)
+	}
+	flush()
+	return sections
+}
+
+// diffSectionPath extracts the b/ path from a section's `diff --git a/x b/y`
+// header. Returns "" when the header is missing or malformed.
+func diffSectionPath(section string) string {
+	nl := strings.IndexByte(section, '\n')
+	header := section
+	if nl >= 0 {
+		header = section[:nl]
+	}
+	if !strings.HasPrefix(header, "diff --git ") {
+		return ""
+	}
+	fields := strings.Fields(strings.TrimPrefix(header, "diff --git "))
+	if len(fields) != 2 {
+		return ""
+	}
+	return strings.TrimPrefix(fields[1], "b/")
+}
+
+// isGoTestFile reports whether path is a Go test file. (The eval is Go-only;
+// extend this set if the dataset language scope widens.)
+func isGoTestFile(path string) bool {
+	return strings.HasSuffix(path, "_test.go")
+}

--- a/internal/mswe/prediction.go
+++ b/internal/mswe/prediction.go
@@ -1,0 +1,28 @@
+package mswe
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Prediction is one line of the predictions file the Multi-SWE-bench harness
+// consumes: the instance identity plus the model-produced diff.
+type Prediction struct {
+	Org      string `json:"org"`
+	Repo     string `json:"repo"`
+	Number   int    `json:"number"`
+	FixPatch string `json:"fix_patch"`
+}
+
+// WritePredictions emits one JSON object per line (JSONL), the format
+// run_evaluation expects for patch_files.
+func WritePredictions(w io.Writer, preds []Prediction) error {
+	enc := json.NewEncoder(w)
+	for _, p := range preds {
+		if err := enc.Encode(p); err != nil {
+			return fmt.Errorf("mswe: encode prediction %s/%s#%d: %w", p.Org, p.Repo, p.Number, err)
+		}
+	}
+	return nil
+}

--- a/internal/mswe/report.go
+++ b/internal/mswe/report.go
@@ -1,0 +1,50 @@
+package mswe
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Summary is the headline result parsed from the harness's final_report.json.
+type Summary struct {
+	Resolved   int
+	Unresolved int
+	Total      int
+}
+
+// ParseReport reads final_report.json and extracts resolved/unresolved counts.
+// It tolerates the two shapes the harness might use for each field — a list of
+// instance IDs or a bare count — so it survives minor format differences.
+func ParseReport(data []byte) (Summary, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return Summary{}, fmt.Errorf("mswe: parse report: %w", err)
+	}
+	res := countField(raw, "resolved_instances", "resolved")
+	unres := countField(raw, "unresolved_instances", "unresolved")
+	total := countField(raw, "total_instances", "total")
+	if total == 0 {
+		total = res + unres
+	}
+	return Summary{Resolved: res, Unresolved: unres, Total: total}, nil
+}
+
+// countField returns the count for the first present key, treating a JSON array
+// as its length and a JSON number as its value.
+func countField(raw map[string]json.RawMessage, keys ...string) int {
+	for _, k := range keys {
+		v, ok := raw[k]
+		if !ok {
+			continue
+		}
+		var list []json.RawMessage
+		if err := json.Unmarshal(v, &list); err == nil {
+			return len(list)
+		}
+		var n int
+		if err := json.Unmarshal(v, &n); err == nil {
+			return n
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
Tier-1 **eval / regression** capability — the biggest gap from the production-readiness review. Measures octo's *task-completion quality* on a small slice of Multi-SWE-bench (Go): real GitHub issues in real repos, judged by hidden tests.

## Design: octo produces patches, the official harness judges

octo never reimplements the Docker-based judging (the heavy, error-prone part) — it just produces a source patch per instance; the official `multi_swe_bench` Python+Docker harness does the rest.

```
generate (our Go tool):  clone repo@base_commit → octo --tools (strict perms,
                         isolated HOME) → git diff → strip *_test.go
                         → predictions.jsonl {org,repo,number,fix_patch}
judge   (their harness): config.json → run_evaluation → builds a Docker env per
                         instance, applies fix_patch + hidden tests
                         → final_report.json → resolved / total
```

octo runs with an **isolated `HOME`** so eval sessions/memory don't touch your `~/.octo`, plus a permissive `permissions.yml` there so it runs tools without prompts in the throwaway clone.

## What's in CI vs not

- **In CI (unit-tested):** `internal/mswe` — dataset parsing, prediction writing, fix-patch test-scoping, harness-config generation, report parsing. All pure, all tested.
- **Not in CI:** the actual eval. It needs a real model key + Docker + `pip install multi_swe_bench` + network — none of which belong in `go test`. CI only proves the pure logic + that everything builds. **The first live run is manual** and yours.

## Tolerant by design (schema confirmed at first run)

Multi-SWE-bench ships as raw JSONL whose record field names can drift by release (the HF parquet auto-convert even fails on a struct field). So dataset access uses fallback accessors (`base_commit` / `base.sha`; `problem_statement` / `resolved_issues`), and `mswe-eval inspect` prints the real keys to confirm. `dev-docs/mswe-eval.md` has a "confirm on the first run" checklist for the three build-time unknowns: record field names, harness config keys, report path/shape.

## Files

- `internal/mswe/` — instance / prediction / patch / config / report (+ tests)
- `cmd/mswe-eval/` — `inspect | generate | judge | run`
- `Makefile` — `eval-mswe-build` / `eval-mswe-inspect` / `eval-mswe`
- `dev-docs/mswe-eval.md` — prerequisites, dataset acquisition, run instructions, first-run checklist, cost notes

## Verification

`gofmt -l .` clean · `go vet ./...` clean · `go test -race ./...` all pass · both binaries build. Smoke-tested `inspect` against a synthetic record (nested `base.sha` + `resolved_issues` fallback + language filter all resolve correctly).

## Next (after merge)

You run `make eval-mswe-inspect DATASET=…` to confirm the schema, then `make eval-mswe DATASET=… LIMIT=5` for the first real signal. We adjust accessors/config/report parsing if the first run surfaces field-name drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)