### PR TITLE
docs(site): lead install with prebuilt binaries; mention octo config + MCP

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -118,8 +118,11 @@
 
     <section class="install">
       <h2>Install</h2>
+      <p style="color: var(--muted); font-size: 0.9rem; margin-top: 0;">Download a prebuilt binary for macOS / Linux / Windows (amd64 + arm64) — no Go toolchain needed:</p>
+      <pre><code><a href="https://github.com/Leihb/octo-agent/releases/latest" style="color: inherit;">github.com/Leihb/octo-agent/releases/latest</a></code></pre>
+      <p style="color: var(--muted); font-size: 0.9rem;">Or, with Go ≥ 1.22:</p>
       <pre><code>go install github.com/Leihb/octo-agent/cmd/octo@latest</code></pre>
-      <p style="color: var(--muted); font-size: 0.9rem;">Requires Go ≥ 1.22. Single binary, no runtime dependencies. Run <code class="inline">octo chat</code> for the CLI; Web UI and IM bridges land in later milestones.</p>
+      <p style="color: var(--muted); font-size: 0.9rem;">Single binary, no runtime dependencies. Run <code class="inline">octo config</code> once to set your provider/key, then <code class="inline">octo chat</code>. Web UI and IM bridges land in later milestones.</p>
     </section>
 
     <section>
@@ -127,7 +130,7 @@
       <div class="grid">
         <div class="card">
           <h3>Terminal</h3>
-          <p>First-class CLI. Streaming, tool calls, sessions, skills.</p>
+          <p>First-class CLI. Streaming, tool calls, sessions, skills, MCP.</p>
         </div>
         <div class="card">
           <h3>Web UI</h3>


### PR DESCRIPTION
"推给别人用"剩余三块之二：**文档/官网**。

## Why

octo-agent.dev 落地页的 Install 段只给了 `go install`，但发布自动化（#142）已经产出预编译二进制了。落地页应与 README 一致，预编译优先 —— 非 Go 用户无需工具链即可上手。

## What

- Install 段改为**预编译二进制优先**（链到 releases/latest），`go install` 作为备选。
- 首次上手指引补一句 `octo config` → `octo chat`（配合 #143）。
- Terminal 能力卡片补上 **MCP**。

## Scope

刻意只动落地页：项目详细文档在 README，站点是单页 landing。不硬造多页文档站（够用就好）。无 Go 改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)