### PR TITLE
fix(eval): make the Multi-SWE-bench harness actually run (validated resolved 1/1)

### DIFF
--- a/cmd/mswe-eval/Dockerfile.judge
+++ b/cmd/mswe-eval/Dockerfile.judge
@@ -1,0 +1,21 @@
+# Judge image for `mswe-eval judge --docker`.
+#
+# The Multi-SWE-bench harness can't be imported on a case-insensitive
+# filesystem (macOS/Windows) — its repo-config package has colliding
+# Qiskit/qiskit modules. Running the harness inside this Linux (case-sensitive)
+# image sidesteps that. The harness talks to the HOST Docker daemon via the
+# mounted /var/run/docker.sock to build + run the per-instance containers, so
+# this image needs only Python + git + the harness itself.
+FROM python:3.12-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# The harness git-resets repos cloned onto a host-mounted volume; those are
+# owned by the host user (uid 501) while git here runs as root, which trips
+# git's "dubious ownership" guard. Trust everything — this is a throwaway
+# eval container.
+RUN git config --system --add safe.directory '*'
+
+RUN pip install --no-cache-dir multi-swe-bench

--- a/cmd/mswe-eval/main.go
+++ b/cmd/mswe-eval/main.go
@@ -17,15 +17,70 @@
 package main
 
 import (
+	_ "embed"
 	"flag"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/mswe"
 )
+
+// judgeDockerfile builds the Linux image the harness runs in under --docker
+// mode (it can't import on a case-insensitive macOS/Windows filesystem).
+//
+//go:embed Dockerfile.judge
+var judgeDockerfile string
+
+const judgeImage = "octo-mswe-judge"
+
+// ensureJudgeImage builds judgeImage from the embedded Dockerfile if it isn't
+// already present locally.
+func ensureJudgeImage() error {
+	if err := exec.Command("docker", "image", "inspect", judgeImage).Run(); err == nil {
+		return nil
+	}
+	fmt.Printf("building judge image %s (one-time)…\n", judgeImage)
+	cmd := exec.Command("docker", "build", "-t", judgeImage, "-")
+	cmd.Stdin = strings.NewReader(judgeDockerfile)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("build judge image: %w", err)
+	}
+	return nil
+}
+
+// resolve returns p as an absolute, symlink-resolved path (best effort), so
+// host paths and in-container bind-mount paths line up byte-for-byte.
+func resolve(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		abs = p
+	}
+	if real, err := filepath.EvalSymlinks(abs); err == nil {
+		return real
+	}
+	return abs
+}
+
+// uniqueDirs returns the distinct non-empty entries (host dirs to bind-mount at
+// identical paths in the judge container, so paths the harness hands to the
+// host Docker daemon resolve correctly).
+func uniqueDirs(paths ...string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, p := range paths {
+		if p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	return out
+}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -242,7 +297,8 @@ func runJudge(args []string) error {
 	dataset := fs.String("dataset", "", "path to the Multi-SWE-bench JSONL dataset")
 	predictions := fs.String("predictions", "predictions.jsonl", "predictions JSONL from `generate`")
 	workdir := fs.String("workdir", filepath.Join(os.TempDir(), "mswe-eval"), "scratch dir for the harness")
-	python := fs.String("python", "python3", "python interpreter with multi_swe_bench installed")
+	python := fs.String("python", "python3", "python interpreter with multi_swe_bench installed (native mode)")
+	dockerMode := fs.Bool("docker", runtime.GOOS != "linux", "run the harness in a Linux container via the host Docker daemon — required on macOS/Windows, where the harness can't import")
 	// generate-only flags tolerated so `run` can share one flag set.
 	_ = fs.String("octo", "", "")
 	_ = fs.String("out", "", "")
@@ -256,14 +312,24 @@ func runJudge(args []string) error {
 	if *dataset == "" {
 		return fmt.Errorf("judge: --dataset is required")
 	}
-	outputDir := filepath.Join(*workdir, "judge-out")
+	if err := os.MkdirAll(*workdir, 0o755); err != nil {
+		return err
+	}
+	// Resolve symlinks on every path the config + Docker mounts reference, so a
+	// container's same-path bind mount agrees with the host (macOS /tmp →
+	// /private/tmp would otherwise make the harness fail to find its config).
+	wd := resolve(*workdir)
+	outputDir := filepath.Join(wd, "judge-out")
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return err
 	}
-
-	datasetAbs, _ := filepath.Abs(*dataset)
-	predAbs, _ := filepath.Abs(*predictions)
-	cfg := mswe.NewHarnessConfig(*workdir, datasetAbs, predAbs, outputDir)
+	// The harness validates that repo_dir already exists (it clones into it).
+	if err := os.MkdirAll(filepath.Join(wd, "repos"), 0o755); err != nil {
+		return err
+	}
+	datasetAbs := resolve(*dataset)
+	predAbs := resolve(*predictions)
+	cfg := mswe.NewHarnessConfig(wd, datasetAbs, predAbs, outputDir)
 	cfgPath := filepath.Join(outputDir, "config.json")
 	cf, err := os.Create(cfgPath)
 	if err != nil {
@@ -275,12 +341,31 @@ func runJudge(args []string) error {
 	}
 	cf.Close()
 
-	fmt.Printf("running judge: %s -m multi_swe_bench.harness.run_evaluation --config %s\n", *python, cfgPath)
-	cmd := exec.Command(*python, "-m", "multi_swe_bench.harness.run_evaluation", "--config", cfgPath)
+	var cmd *exec.Cmd
+	if *dockerMode {
+		if err := ensureJudgeImage(); err != nil {
+			return err
+		}
+		// Mount the host Docker socket (so the harness drives the host daemon to
+		// build/run per-instance containers) and every host dir the config
+		// references AT THE SAME PATH, so the paths the harness passes to
+		// `docker run -v` resolve identically on the host.
+		dargs := []string{"run", "--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock"}
+		for _, d := range uniqueDirs(wd, filepath.Dir(datasetAbs), filepath.Dir(predAbs)) {
+			dargs = append(dargs, "-v", d+":"+d)
+		}
+		dargs = append(dargs, "-w", wd, judgeImage,
+			"python", "-m", "multi_swe_bench.harness.run_evaluation", "--config", cfgPath)
+		fmt.Printf("running judge in container %s (host daemon via socket)\n", judgeImage)
+		cmd = exec.Command("docker", dargs...)
+	} else {
+		fmt.Printf("running judge: %s -m multi_swe_bench.harness.run_evaluation --config %s\n", *python, cfgPath)
+		cmd = exec.Command(*python, "-m", "multi_swe_bench.harness.run_evaluation", "--config", cfgPath)
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("run_evaluation: %w (is multi_swe_bench installed + Docker running?)", err)
+		return fmt.Errorf("run_evaluation: %w (Docker running? on macOS/Windows use --docker)", err)
 	}
 
 	reportPath, err := findReport(outputDir)

--- a/cmd/mswe-eval/main.go
+++ b/cmd/mswe-eval/main.go
@@ -172,19 +172,29 @@ func generateOne(inst mswe.Instance, octoBin, evalHome, workdir, model, provider
 		return "", fmt.Errorf("checkout %s: %v (%s)", inst.BaseCommit(), err, truncate(out, 200))
 	}
 
-	// Drive octo headless: single-turn agentic loop, strict perms (the eval
-	// HOME's permissive permissions.yml allows the tools), session save off.
+	// Drive octo through REPL mode (prompt piped on stdin, EOF ends it). The
+	// agentic tool-execution loop only runs in REPL mode — a single-turn
+	// `octo chat "msg"` does one model round-trip WITHOUT executing tools, so it
+	// would never edit files. Strict perms + the eval HOME's permissive
+	// permissions.yml let tools run without prompts; --no-save keeps the
+	// throwaway session out of history.
 	env := append(os.Environ(), "HOME="+evalHome)
-	octoArgs := []string{"chat", "--tools", "--permission-mode", "strict", "--no-save", "--quiet"}
+	octoArgs := []string{"chat", "--tools", "--permission-mode", "strict", "--no-save", "--plain"}
 	if model != "" {
 		octoArgs = append(octoArgs, "--model", model)
 	}
 	if provider != "" {
 		octoArgs = append(octoArgs, "--provider", provider)
 	}
-	octoArgs = append(octoArgs, octoPrompt(inst))
-	if out, err := run(repoDir, env, octoBin, octoArgs...); err != nil {
-		return "", fmt.Errorf("octo run: %v (%s)", err, truncate(out, 300))
+	octoOut, oerr := runStdin(repoDir, env, octoPrompt(inst)+"\n", octoBin, octoArgs...)
+	// Persist octo's transcript for debugging OUTSIDE the repo, so `git add -A`
+	// below doesn't sweep it into the patch. A non-zero exit isn't fatal — octo
+	// may exit non-zero yet still have made useful edits, which the diff captures.
+	logDir := filepath.Join(workdir, "logs")
+	_ = os.MkdirAll(logDir, 0o755)
+	_ = os.WriteFile(filepath.Join(logDir, fmt.Sprintf("%s__%s__%d.log", inst.Org(), inst.Repo(), inst.Number())), []byte(octoOut), 0o644)
+	if oerr != nil {
+		fmt.Printf("        (octo exited %v; capturing whatever it changed)\n", oerr)
 	}
 
 	// Capture every change (incl. new/deleted files), then drop test files.
@@ -326,6 +336,17 @@ func run(dir string, env []string, name string, args ...string) (string, error) 
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// runStdin is like run but feeds stdin to the process — used to drive octo's
+// REPL (the prompt on stdin, EOF ending the session).
+func runStdin(dir string, env []string, stdin, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.Stdin = strings.NewReader(stdin)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }

--- a/cmd/mswe-eval/main.go
+++ b/cmd/mswe-eval/main.go
@@ -64,7 +64,7 @@ func usage() {
 func runInspect(args []string) error {
 	fs := flag.NewFlagSet("inspect", flag.ContinueOnError)
 	dataset := fs.String("dataset", "", "path to the Multi-SWE-bench JSONL dataset")
-	lang := fs.String("lang", "go", "language filter ('' = all)")
+	lang := fs.String("lang", "", "language filter (''=all; the dataset ships pre-split per language, so usually leave empty)")
 	limit := fs.Int("limit", 1, "number of records to inspect")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -95,7 +95,7 @@ func runInspect(args []string) error {
 func runGenerate(args []string) error {
 	fs := flag.NewFlagSet("generate", flag.ContinueOnError)
 	dataset := fs.String("dataset", "", "path to the Multi-SWE-bench JSONL dataset")
-	lang := fs.String("lang", "go", "language filter")
+	lang := fs.String("lang", "", "language filter (''=all; dataset ships pre-split per language)")
 	limit := fs.Int("limit", 5, "max instances to run")
 	octoBin := fs.String("octo", "./octo", "path to the octo binary")
 	out := fs.String("out", "predictions.jsonl", "output predictions file (JSONL)")

--- a/dev-docs/mswe-eval.md
+++ b/dev-docs/mswe-eval.md
@@ -46,7 +46,10 @@ disposable clone.
   for a Kimi/Anthropic-compatible endpoint). `generate` passes the environment
   through to octo.
 - `git`, network access (clone repos).
-- For `judge`: **Docker running**, `python3`, and `pip install multi_swe_bench`.
+- For `judge`: **Docker running**. In the default `--docker` mode (auto off
+  Linux) the harness lives in the auto-built `octo-mswe-judge` image, so no
+  native Python/`multi_swe_bench` install is needed. Native mode (`--docker=false`,
+  Linux only) instead needs `python3` + `pip install multi-swe-bench`.
 
 ## Get the Go dataset slice
 
@@ -54,52 +57,62 @@ The dataset lives on HuggingFace as raw JSONL: `ByteDance-Seed/Multi-SWE-bench`
 (or the smaller `…_mini` / `…-flash`). Download it and keep only Go records, e.g.
 
 ```bash
-huggingface-cli download ByteDance-Seed/Multi-SWE-bench --repo-type dataset --local-dir mswe-data
-# then filter to Go (field name confirmed by `inspect`, usually "language":"go")
-# into a single file, e.g. mswe-data/go.jsonl
+huggingface-cli download ByteDance-Seed/Multi-SWE-bench --repo-type dataset --local-dir ~/mswe-data
+```
+
+The data ships **pre-split per language** as `go/<org>__<repo>_dataset.jsonl`
+(no per-record `language` field), so combine the Go files into one:
+
+```bash
+cat ~/mswe-data/go/*.jsonl > ~/mswe-data/go-all.jsonl
 ```
 
 `--dataset` (our tool) and `dataset_files` (the harness config) both point at
-this same Go JSONL.
+this Go JSONL. A record carries `org`, `repo`, `number`, nested `base.sha`,
+`resolved_issues`, `test_patch`, and `f2p_tests`/`p2p_tests`/`s2p_tests`.
+
+> **macOS/Windows:** put the working directory **under your home dir** — Docker
+> Desktop shares `/Users` but not `/private/tmp`, and the judge bind-mounts the
+> workdir into the container at the same path. Pass `--workdir ~/mswe-work`.
 
 ## Run it
 
 ```bash
-# 0. Confirm the real schema FIRST — the dataset is raw JSONL and field names
-#    can drift by release. Check that base_commit + problem appear non-empty.
-make eval-mswe-inspect DATASET=mswe-data/go.jsonl LIMIT=1
+# 0. Confirm the schema (base_commit + problem come out non-empty).
+./mswe-eval inspect --dataset ~/mswe-data/go-all.jsonl --limit 1
 
-# 1. Full run: generate patches with octo, then judge (5 instances by default).
-make eval-mswe DATASET=mswe-data/go.jsonl LIMIT=5
+# 1. Generate patches with octo (real model key in the env), then judge.
+ANTHROPIC_API_KEY=… ANTHROPIC_BASE_URL=… \
+  ./mswe-eval generate --dataset ~/mswe-data/go-all.jsonl --limit 5 \
+    --octo ./octo --model <model> --provider anthropic \
+    --out ~/mswe-work/predictions.jsonl --workdir ~/mswe-work
+./mswe-eval judge --dataset ~/mswe-data/go-all.jsonl \
+    --predictions ~/mswe-work/predictions.jsonl --workdir ~/mswe-work
 ```
 
-Or drive the stages directly:
+`judge` runs the harness in a **Linux container** (`--docker`, auto-enabled off
+Linux) because the harness can't import on a case-insensitive filesystem. It
+auto-builds the `octo-mswe-judge` image (Python + harness) on first use and
+drives the host Docker daemon via the mounted socket to build + test each
+instance. To bound a first run to one instance, point `--dataset` at a
+one-record JSONL.
 
-```bash
-./mswe-eval generate --dataset mswe-data/go.jsonl --limit 5 --octo ./octo --out predictions.jsonl
-./mswe-eval judge    --dataset mswe-data/go.jsonl --predictions predictions.jsonl
-```
+## Validated end-to-end (2026-05-29)
 
-## Confirm on the first run (build-time unknowns)
-
-The scaffold is tolerant but a few things can only be pinned against the real
-data / installed harness. Check these on the first run and adjust if needed:
-
-1. **Record field names** — `inspect` prints each record's keys. The accessors
-   in `internal/mswe/instance.go` try `base_commit`/`base.sha` and
-   `problem_statement`/`resolved_issues`; if `inspect` shows different names,
-   extend those accessors.
-2. **Harness config keys** — `internal/mswe/config.go` writes the documented
-   keys (`patch_files`, `dataset_files`, `output_dir`, worker counts). If your
-   `multi_swe_bench` version wants more/different keys, the run will say so;
-   update `HarnessConfig`.
-3. **Report path/shape** — `judge` searches for `final_report.json` under the
-   output dir and `ParseReport` accepts either ID-lists or counts for
-   `resolved_instances`/`unresolved_instances`. Adjust if the real report
-   differs.
+Confirmed against `multi_swe_bench 1.1.2` + the real Go data: octo resolved
+**cli/cli#10388** ("`gh api` HEAD request → unexpected end of JSON input") with
+a 5-line fix to `pkg/cmd/api/api.go`, and the harness scored it **resolved 1/1**
+against the hidden tests. The macOS-specific gotchas that the `--docker` path
+handles: case-insensitive import failure (→ Linux container), no daemon in the
+container (→ mount `/var/run/docker.sock`), `/tmp`→`/private/tmp` symlink and
+`/private/tmp` not being Docker-shared (→ home workdir + symlink-resolved
+same-path mounts), git "dubious ownership" on host-owned clones (→
+`safe.directory '*'` in the image), and the harness requiring `repo_dir` to
+pre-exist (→ created before invoking).
 
 ## Cost & scale
 
-Each instance is one full octo agentic run (cheap on Kimi) plus one Docker
-build + test run (slow, heavy). Start at `LIMIT=5`, grow once the pipeline is
-proven. Expect the first run to be dominated by Docker image builds.
+Each instance is one full octo agentic run (cheap on Kimi) plus a Docker image
+build + test run — the latter dominates (the cli/cli base image took ~4 min to
+build the first time). Images are cached, so re-runs of the same repo are much
+faster. Start at `LIMIT=5`, grow once you've got a baseline.

--- a/internal/mswe/config.go
+++ b/internal/mswe/config.go
@@ -4,41 +4,66 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path/filepath"
 )
 
 // HarnessConfig is the config.json passed to
-// `python -m multi_swe_bench.harness.run_evaluation --config <file>`. It points
-// the judge at the dataset records and our predictions, and at scratch/output
-// dirs for the per-instance Docker builds and the final report.
+// `python -m multi_swe_bench.harness.run_evaluation --config <file>`.
 //
-// Field names mirror the harness's documented config keys. The harness may
-// accept or require additional keys depending on its release; this covers the
-// documented set and leaves the rest at the harness defaults. Confirm against
-// the installed multi_swe_bench version on the first run.
+// The field set mirrors the harness's CliArgs dataclass (verified against
+// multi_swe_bench 1.1.2). It's loaded via dataclass_json/marshmallow, which
+// rejects unknown keys and requires every non-defaulted field — so we emit the
+// full set explicitly. Optional fields we don't use (specifics, skips,
+// global_env) are nil → JSON null.
 type HarnessConfig struct {
-	Mode                  string   `json:"mode"`
 	Workdir               string   `json:"workdir"`
 	PatchFiles            []string `json:"patch_files"`
 	DatasetFiles          []string `json:"dataset_files"`
-	OutputDir             string   `json:"output_dir"`
 	ForceBuild            bool     `json:"force_build"`
+	OutputDir             string   `json:"output_dir"`
+	Specifics             []string `json:"specifics"`
+	Skips                 []string `json:"skips"`
+	RepoDir               string   `json:"repo_dir"`
+	NeedClone             bool     `json:"need_clone"`
+	GlobalEnv             []string `json:"global_env"`
+	ClearEnv              bool     `json:"clear_env"`
+	StopOnError           bool     `json:"stop_on_error"`
+	MaxWorkers            int      `json:"max_workers"`
 	MaxWorkersBuildImage  int      `json:"max_workers_build_image"`
 	MaxWorkersRunInstance int      `json:"max_workers_run_instance"`
+	FixPatchRunCmd        string   `json:"fix_patch_run_cmd"`
+	LogDir                string   `json:"log_dir"`
+	LogLevel              string   `json:"log_level"`
+	LogToConsole          bool     `json:"log_to_console"`
+	HumanMode             bool     `json:"human_mode"`
 }
 
-// NewHarnessConfig builds a config with conservative defaults: serial Docker
-// builds and runs (workers=1) so a small first run is easy to follow and
-// doesn't thrash the machine.
+// NewHarnessConfig builds a config with conservative defaults for a small first
+// run: the harness clones repos itself (need_clone) into repo_dir, builds and
+// runs serially (workers=1) so progress is easy to follow, and does not abort
+// the whole batch on a single instance error (stop_on_error=false).
 func NewHarnessConfig(workdir, datasetFile, predictionsFile, outputDir string) HarnessConfig {
 	return HarnessConfig{
-		Mode:                  "evaluation",
 		Workdir:               workdir,
 		PatchFiles:            []string{predictionsFile},
 		DatasetFiles:          []string{datasetFile},
-		OutputDir:             outputDir,
 		ForceBuild:            false,
+		OutputDir:             outputDir,
+		Specifics:             nil,
+		Skips:                 nil,
+		RepoDir:               filepath.Join(workdir, "repos"),
+		NeedClone:             true,
+		GlobalEnv:             nil,
+		ClearEnv:              true,
+		StopOnError:           false,
+		MaxWorkers:            1,
 		MaxWorkersBuildImage:  1,
 		MaxWorkersRunInstance: 1,
+		FixPatchRunCmd:        "",
+		LogDir:                filepath.Join(outputDir, "logs"),
+		LogLevel:              "INFO",
+		LogToConsole:          true,
+		HumanMode:             true,
 	}
 }
 

--- a/internal/mswe/mswe_test.go
+++ b/internal/mswe/mswe_test.go
@@ -125,9 +125,21 @@ func TestHarnessConfig_Write(t *testing.T) {
 		t.Fatal(err)
 	}
 	out := b.String()
-	for _, want := range []string{`"patch_files"`, `"/out/predictions.jsonl"`, `"dataset_files"`, `"/data/go.jsonl"`, `"max_workers_run_instance": 1`} {
+	// The harness's marshmallow loader requires every non-defaulted CliArgs
+	// field; assert the full set is emitted (a missing one fails the real run).
+	for _, want := range []string{
+		`"patch_files"`, `"/out/predictions.jsonl"`,
+		`"dataset_files"`, `"/data/go.jsonl"`,
+		`"repo_dir"`, `"need_clone"`, `"clear_env"`, `"stop_on_error"`,
+		`"max_workers"`, `"max_workers_build_image"`, `"max_workers_run_instance": 1`,
+		`"fix_patch_run_cmd"`, `"log_dir"`, `"log_level"`, `"log_to_console"`, `"human_mode"`,
+	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("config missing %q:\n%s", want, out)
 		}
+	}
+	// `mode` is NOT a CliArgs field — marshmallow rejects unknown keys.
+	if strings.Contains(out, `"mode"`) {
+		t.Errorf("config should not emit a 'mode' key (harness rejects unknown fields):\n%s", out)
 	}
 }


### PR DESCRIPTION
Follow-up to the eval scaffold (#139): the first real run surfaced a chain of issues the scaffold couldn't have anticipated. With these fixes the full **generate → judge** pipeline runs end-to-end, and octo resolved a real Multi-SWE-bench Go instance under the hidden tests.

## 🎯 Result
octo resolved **cli/cli#10388** ("`gh api` HEAD request → unexpected end of JSON input") with a 5-line fix to `pkg/cmd/api/api.go` (skip `parseErrorResponse` on HEAD requests, which have no body). The official harness scored it **resolved 1/1**.

## Fixes (each a real first-run finding)

**Generate (octo side):**
- **config schema was wrong** — emitted a bogus `mode` key (marshmallow rejects unknown fields) and omitted required `CliArgs` fields. Rewrote to the exact 19-field schema of `multi_swe_bench 1.1.2`.
- **`--lang go` filtered everything** — the data ships pre-split per language (`go/<repo>_dataset.jsonl`) with no per-record `language` field. Default to no filter.
- **single-turn `octo chat "msg"` doesn't run the tool loop** — it does one model round-trip; the agentic loop is REPL-only. Drive octo via REPL (prompt on stdin). Confirmed octo then explores, edits, and `go build`s.
- **debug log polluted the patch** — written inside the repo, so `git add -A` swept it in. Write it under `workdir/logs/`.

**Judge (harness side) — `--docker` mode (auto off Linux):**
The harness can't import on a case-insensitive filesystem (colliding `Qiskit`/`qiskit`), so it runs in a small Linux image (`octo-mswe-judge`, auto-built) driving the host Docker daemon via the mounted socket. Plus the macOS path/permission gotchas: `/tmp`→`/private/tmp` symlink + same-path mounts (resolve symlinks), `/private/tmp` not Docker-shared (home workdir), git "dubious ownership" on host-owned clones (`safe.directory '*'`), and `repo_dir` must pre-exist (created before invoking).

The tolerant dataset accessors needed **no change** — nested `base.sha` and the `resolved_issues` problem-statement fallback both read the real records correctly.

## Verification
`gofmt` / `go vet ./...` / `go test -race ./...` clean. The eval itself is manual (real model + Docker + network) and never runs in CI — CI validates the pure `internal/mswe` logic + that everything builds. `dev-docs/mswe-eval.md` updated with the `--docker` workflow, home-workdir requirement, and the validated result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)