### PR TITLE
feat(cli): show resolved provider/model/endpoint under --verbose

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -202,6 +202,15 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// Verbose: surface the resolved provider / model / endpoint so a
+	// misrouted base URL (e.g. ANTHROPIC_BASE_URL pointed at a third party) is
+	// visible at a glance. To stderr so it never pollutes single-turn stdout;
+	// shown for every path (single-turn, plain REPL, TUI).
+	if resolveVerbosity(*quietFlag, *verboseFlag).verbose() {
+		fmt.Fprintf(stderr, "octo: provider=%s model=%s endpoint=%s\n",
+			provName, resolvedModel, effectiveEndpoint(provName, cfg))
+	}
+
 	// Compose the system prompt once (base + project .octorules + user --system)
 	// and freeze it for the session — recomputing mid-session would bust the
 	// provider's system+tools prompt cache. The session stores only the raw
@@ -492,7 +501,7 @@ func buildProvider(name string, cfg config.Config, stderr io.Writer) (provider.P
 			fmt.Fprintf(stderr, "octo chat: %v\n", err)
 			return nil, err
 		}
-		if baseURL := firstNonEmpty(os.Getenv("ANTHROPIC_BASE_URL"), providerBaseURL(name, cfg)); baseURL != "" {
+		if baseURL := resolveBaseURL(name, cfg); baseURL != "" {
 			client.BaseURL = baseURL
 		}
 		return client, nil
@@ -521,7 +530,7 @@ func buildProvider(name string, cfg config.Config, stderr io.Writer) (provider.P
 			fmt.Fprintf(stderr, "octo chat: %v\n", err)
 			return nil, err
 		}
-		if baseURL := firstNonEmpty(os.Getenv("OPENAI_BASE_URL"), providerBaseURL(name, cfg)); baseURL != "" {
+		if baseURL := resolveBaseURL(name, cfg); baseURL != "" {
 			client.BaseURL = baseURL
 		}
 		return client, nil

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/config"
+	"github.com/Leihb/octo-agent/internal/provider/anthropic"
+	"github.com/Leihb/octo-agent/internal/provider/openai"
 )
 
 // firstNonEmpty returns the first non-empty string, or "" if all are empty.
@@ -47,6 +49,36 @@ func providerBaseURL(provider string, cfg config.Config) string {
 		return cfg.BaseURL
 	}
 	return ""
+}
+
+// resolveBaseURL returns the base-URL override for the provider, env-first
+// (ANTHROPIC_BASE_URL / OPENAI_BASE_URL) then the persisted config. "" means no
+// override — the provider uses its built-in default endpoint. This is the
+// single source of truth shared by buildProvider and the verbose endpoint line.
+func resolveBaseURL(provider string, cfg config.Config) string {
+	switch provider {
+	case providerAnthropic:
+		return firstNonEmpty(os.Getenv("ANTHROPIC_BASE_URL"), providerBaseURL(provider, cfg))
+	case providerOpenAI:
+		return firstNonEmpty(os.Getenv("OPENAI_BASE_URL"), providerBaseURL(provider, cfg))
+	}
+	return ""
+}
+
+// effectiveEndpoint is resolveBaseURL for display: it substitutes the
+// provider's built-in default (marked) when there's no override, so a verbose
+// run always shows the host that will actually be called.
+func effectiveEndpoint(provider string, cfg config.Config) string {
+	if u := resolveBaseURL(provider, cfg); u != "" {
+		return u
+	}
+	switch provider {
+	case providerAnthropic:
+		return anthropic.DefaultBaseURL + " (default)"
+	case providerOpenAI:
+		return openai.DefaultBaseURL + " (default)"
+	}
+	return "(default)"
 }
 
 // runConfig handles `octo config [show|path]` and, with no subcommand, an

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -8,6 +8,39 @@ import (
 	"github.com/Leihb/octo-agent/internal/config"
 )
 
+func TestResolveBaseURL_Precedence(t *testing.T) {
+	// env wins over config.
+	t.Setenv("ANTHROPIC_BASE_URL", "https://api.deepseek.com/anthropic")
+	cfg := config.Config{Provider: providerAnthropic, BaseURL: "https://cfg.example"}
+	if got := resolveBaseURL(providerAnthropic, cfg); got != "https://api.deepseek.com/anthropic" {
+		t.Errorf("env should win, got %q", got)
+	}
+
+	// No env → config (same provider only).
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	if got := resolveBaseURL(providerAnthropic, cfg); got != "https://cfg.example" {
+		t.Errorf("config base URL = %q, want https://cfg.example", got)
+	}
+	// Config base URL must not leak onto a different provider.
+	if got := resolveBaseURL(providerOpenAI, cfg); got != "" {
+		t.Errorf("openai must not inherit anthropic's config base URL, got %q", got)
+	}
+
+	// No override anywhere → effectiveEndpoint shows the marked default.
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	empty := config.Config{}
+	if got := resolveBaseURL(providerAnthropic, empty); got != "" {
+		t.Errorf("no override should be empty, got %q", got)
+	}
+	if got := effectiveEndpoint(providerAnthropic, empty); !strings.Contains(got, "api.anthropic.com") || !strings.Contains(got, "default") {
+		t.Errorf("effectiveEndpoint default = %q, want the marked anthropic default", got)
+	}
+	// Override flows through to effectiveEndpoint verbatim.
+	if got := effectiveEndpoint(providerAnthropic, cfg); got != "https://cfg.example" {
+		t.Errorf("effectiveEndpoint override = %q, want the config URL unmarked", got)
+	}
+}
+
 func TestResolveProviderModel_Precedence(t *testing.T) {
 	cfg := config.Config{Provider: "openai", Model: "cfg-model"}
 	tests := []struct {


### PR DESCRIPTION
## Why

When `ANTHROPIC_BASE_URL` is pointed at a third party (e.g. DeepSeek's `/anthropic` endpoint), there was **no way to confirm the base URL took effect**. `--verbose` advertised "provider/model/endpoint" but the banner only printed the model. Worse, the `anthropic:` error prefix is just the protocol-adapter name (not proof the request hit api.anthropic.com), so a third-party auth rejection read like an Anthropic failure — easy to misdiagnose.

## What

One stderr line, printed for every path (single-turn, plain REPL, TUI) when `--verbose`:

```
octo: provider=anthropic model=claude-haiku-4-5-20251001 endpoint=https://api.deepseek.com/anthropic
```

It surfaces both common base-URL mistakes at a glance: a misrouted endpoint, and a leftover default `claude-*` model that a third party won't accept.

## How

- Extracts `resolveBaseURL` (env-first → config) as the single source of truth, replacing the inline `firstNonEmpty(...)` in both provider branches of `buildProvider` (DRY).
- `effectiveEndpoint` for display — substitutes and marks the provider's built-in default when there's no override.
- Printed to **stderr** so it never pollutes single-turn stdout.

## Testing

- New `TestResolveBaseURL_Precedence`: env > config, no cross-provider leak, default marking.
- Smoke: `ANTHROPIC_BASE_URL=…/anthropic ./octo chat --verbose` prints the line correctly.
- `go test -race ./...`, `go vet`, `gofmt -l` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)