### PR TITLE
feat(cli): ANTHROPIC_MODEL / OPENAI_MODEL env override for the model

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -68,7 +68,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("chat", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	providerName := fs.String("provider", "", "Provider: anthropic | openai (default from `octo config`, else anthropic)")
-	model := fs.String("model", "", "Model name (defaults to the provider's cheapest reasoning model)")
+	model := fs.String("model", "", "Model name (else ANTHROPIC_MODEL/OPENAI_MODEL env, then `octo config`, then the provider's cheapest reasoning model)")
 	system := fs.String("system", "", "System prompt (optional)")
 	maxTokens := fs.Int("max-tokens", 0, "max_tokens for the response (0 = provider default)")
 	stream := fs.Bool("stream", true, "Stream the reply (chunks printed as they arrive); --stream=false buffers")

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -21,14 +21,22 @@ func firstNonEmpty(vals ...string) string {
 	return ""
 }
 
-// resolveProviderModel applies precedence flag > config file > built-in default
-// to the provider and model. An empty flagProvider/flagModel means "not set on
-// the CLI". ok is false when the resolved provider has no known default model
-// (i.e. an unknown provider with no explicit model) — the caller prints an
-// error and exits.
+// resolveProviderModel applies precedence flag > env > config file > built-in
+// default to the provider and model. An empty flagProvider/flagModel means "not
+// set on the CLI". ok is false when the resolved provider has no known default
+// model (i.e. an unknown provider with no explicit model) — the caller prints
+// an error and exits.
 func resolveProviderModel(flagProvider, flagModel string, cfg config.Config) (provider, model string, ok bool) {
 	provider = firstNonEmpty(flagProvider, cfg.Provider, providerAnthropic)
+	// Precedence: --model flag > env (ANTHROPIC_MODEL / OPENAI_MODEL) > config
+	// (same-provider only) > built-in default. The env tier mirrors how the
+	// base URL and key resolve env-first, so a third-party Claude-/OpenAI-
+	// compatible endpoint can be configured entirely through env vars (e.g.
+	// ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY + ANTHROPIC_MODEL).
 	model = flagModel
+	if model == "" {
+		model = modelFromEnv(provider)
+	}
 	// The config's model is specific to the config's provider — only honor it
 	// when the resolved provider matches, so `--provider <other>` doesn't carry
 	// one vendor's model onto another.
@@ -47,6 +55,19 @@ func resolveProviderModel(flagProvider, flagModel string, cfg config.Config) (pr
 func providerBaseURL(provider string, cfg config.Config) string {
 	if cfg.Provider == provider {
 		return cfg.BaseURL
+	}
+	return ""
+}
+
+// modelFromEnv returns the per-provider model env override, or "" if unset.
+// Named to match the BASE_URL / API_KEY env vars so a third-party endpoint can
+// be configured purely through the environment.
+func modelFromEnv(provider string) string {
+	switch provider {
+	case providerAnthropic:
+		return os.Getenv("ANTHROPIC_MODEL")
+	case providerOpenAI:
+		return os.Getenv("OPENAI_MODEL")
 	}
 	return ""
 }

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -41,7 +41,34 @@ func TestResolveBaseURL_Precedence(t *testing.T) {
 	}
 }
 
+func TestResolveProviderModel_ModelEnv(t *testing.T) {
+	// env beats config + default, but the --model flag still beats env.
+	t.Setenv("ANTHROPIC_MODEL", "claude-from-env")
+	t.Setenv("OPENAI_MODEL", "")
+	cfg := config.Config{Provider: providerAnthropic, Model: "cfg-model"}
+
+	if _, m, _ := resolveProviderModel("", "", cfg); m != "claude-from-env" {
+		t.Errorf("env should beat config, got %q", m)
+	}
+	if _, m, _ := resolveProviderModel("", "flag-model", cfg); m != "flag-model" {
+		t.Errorf("--model flag should beat env, got %q", m)
+	}
+	// The model env is per-provider: ANTHROPIC_MODEL must not leak onto openai.
+	if _, m, _ := resolveProviderModel(providerOpenAI, "", config.Config{}); m != "gpt-4o-mini" {
+		t.Errorf("ANTHROPIC_MODEL must not affect openai, got %q (want default)", m)
+	}
+	// OPENAI_MODEL drives the openai default slot.
+	t.Setenv("OPENAI_MODEL", "deepseek-chat")
+	if _, m, _ := resolveProviderModel(providerOpenAI, "", config.Config{}); m != "deepseek-chat" {
+		t.Errorf("OPENAI_MODEL = %q, want deepseek-chat", m)
+	}
+}
+
 func TestResolveProviderModel_Precedence(t *testing.T) {
+	// Isolate from any model env vars in the host so the flag/config/default
+	// cases below are deterministic.
+	t.Setenv("ANTHROPIC_MODEL", "")
+	t.Setenv("OPENAI_MODEL", "")
 	cfg := config.Config{Provider: "openai", Model: "cfg-model"}
 	tests := []struct {
 		name              string


### PR DESCRIPTION
## Why

`ANTHROPIC_BASE_URL` and `ANTHROPIC_API_KEY` resolve env-first, but the **model had no env tier** — only `--model`, `octo config`, and the built-in default. So a third-party Claude-compatible setup (e.g. DeepSeek's `/anthropic` endpoint) couldn't be driven purely by env vars: users kept landing on the default `claude-*` model, which the vendor rejects.

## What

Per-provider model env override, slotted into the existing precedence:

```
--model flag  >  ANTHROPIC_MODEL / OPENAI_MODEL  >  octo config (same provider)  >  built-in default
```

Now the full third-party setup lives entirely in the environment — no flags:

```bash
export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic
export ANTHROPIC_API_KEY=<deepseek key>
export ANTHROPIC_MODEL=deepseek-chat
octo chat
```

Per-provider (not a single `OCTO_MODEL`) to match the `BASE_URL`/`API_KEY` naming and avoid one vendor's model leaking onto another.

## How

- `modelFromEnv(provider)` next to `resolveBaseURL` — shared by all five `resolveProviderModel` call sites.
- `--model` help text updated to spell out the chain.

## Testing

- `TestResolveProviderModel_ModelEnv`: env beats config+default, `--model` still beats env, no cross-provider leak.
- Existing precedence test isolated from host env.
- Smoke: `ANTHROPIC_MODEL=deepseek-chat octo chat --verbose` → `model=deepseek-chat`.
- `go test -race ./...`, `go vet`, `gofmt -l` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)