### PR TITLE
fix(eval): ScopeFixPatch drops build artifacts (*.test) + binary diff sections

### DIFF
--- a/internal/mswe/mswe_test.go
+++ b/internal/mswe/mswe_test.go
@@ -80,6 +80,33 @@ func TestScopeFixPatch_KeepsAllWhenNoTests(t *testing.T) {
 	}
 }
 
+func TestScopeFixPatch_StripsBuildArtifacts(t *testing.T) {
+	// `go test` can leave a compiled <pkg>.test binary that `git add -A` sweeps
+	// in; it must not reach the fix patch.
+	diff := "diff --git a/pkg/cmd/api/api.go b/pkg/cmd/api/api.go\n--- a/pkg/cmd/api/api.go\n+++ b/pkg/cmd/api/api.go\n@@ -1 +1 @@\n-old\n+new\n" +
+		"diff --git a/api.test b/api.test\nnew file mode 100755\nindex 0000000..abc1234\nBinary files /dev/null and b/api.test differ\n"
+	got := ScopeFixPatch(diff)
+	if !strings.Contains(got, "a/pkg/cmd/api/api.go") || !strings.Contains(got, "+new") {
+		t.Errorf("source change dropped:\n%s", got)
+	}
+	if strings.Contains(got, "api.test") {
+		t.Errorf(".test build artifact should be stripped:\n%s", got)
+	}
+}
+
+func TestScopeFixPatch_StripsBinarySection(t *testing.T) {
+	// A binary-file diff (no textual hunks) is never part of a source fix.
+	diff := "diff --git a/main.go b/main.go\n@@ -1 +1 @@\n-x\n+y\n" +
+		"diff --git a/bin/tool b/bin/tool\nindex 1111111..2222222 100755\nBinary files a/bin/tool and b/bin/tool differ\n"
+	got := ScopeFixPatch(diff)
+	if !strings.Contains(got, "a/main.go") {
+		t.Errorf("source dropped:\n%s", got)
+	}
+	if strings.Contains(got, "bin/tool") {
+		t.Errorf("binary section should be stripped:\n%s", got)
+	}
+}
+
 func TestWritePredictions_JSONL(t *testing.T) {
 	var b bytes.Buffer
 	err := WritePredictions(&b, []Prediction{

--- a/internal/mswe/patch.go
+++ b/internal/mswe/patch.go
@@ -2,19 +2,22 @@ package mswe
 
 import "strings"
 
-// ScopeFixPatch strips test-file sections from a `git diff`, leaving only the
-// source changes. The Multi-SWE-bench harness applies the dataset's own hidden
-// test patch on top of the model's fix_patch, so a model patch that also
-// touched tests would conflict with — or worse, defeat — the hidden tests.
+// ScopeFixPatch trims a `git diff` down to the source changes the harness
+// should apply, dropping:
+//   - test files (*_test.go) — the harness applies the dataset's own hidden
+//     test patch on top, so a model patch touching tests would conflict with,
+//     or defeat, the hidden tests;
+//   - build artifacts (e.g. Go test binaries, *.test) that `git add -A` may
+//     sweep in after octo runs `go test`/`go build`;
+//   - binary-file sections (a source fix is never a binary blob).
 //
 // The input is unified diff output where each file section starts with a
-// `diff --git a/<path> b/<path>` header. Sections whose path is a Go test file
-// (*_test.go) are dropped; the rest are rejoined unchanged.
+// `diff --git a/<path> b/<path>` header; surviving sections are rejoined as-is.
 func ScopeFixPatch(diff string) string {
 	sections := splitDiffSections(diff)
 	var kept []string
 	for _, s := range sections {
-		if isGoTestFile(diffSectionPath(s)) {
+		if isExcludedFile(diffSectionPath(s)) || isBinarySection(s) {
 			continue
 		}
 		kept = append(kept, s)
@@ -62,8 +65,18 @@ func diffSectionPath(section string) string {
 	return strings.TrimPrefix(fields[1], "b/")
 }
 
-// isGoTestFile reports whether path is a Go test file. (The eval is Go-only;
-// extend this set if the dataset language scope widens.)
-func isGoTestFile(path string) bool {
-	return strings.HasSuffix(path, "_test.go")
+// isExcludedFile reports whether a diff section's file should be dropped from
+// the fix patch: Go test files (the harness supplies the hidden tests) and Go
+// test binaries (build artifacts swept in by `git add -A`). (The eval is
+// Go-only; extend this set if the dataset language scope widens.)
+func isExcludedFile(path string) bool {
+	return strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".test")
+}
+
+// isBinarySection reports whether a diff section is a binary-file change (git
+// emits "Binary files … differ" or a "GIT binary patch" block) rather than a
+// textual source edit. Compiled artifacts have no place in a source fix patch.
+func isBinarySection(section string) bool {
+	return strings.Contains(section, "\nBinary files ") ||
+		strings.Contains(section, "\nGIT binary patch\n")
 }


### PR DESCRIPTION
A baseline run produced a `fix_patch` containing a compiled `api.test` binary — octo ran `go test`, the untracked `<pkg>.test` binary got swept in by `git add -A`, and `ScopeFixPatch` only stripped `*_test.go`. (It didn't break the judge that time, but it's wrong and could.)

Extend `ScopeFixPatch` to also drop:
- `*.test` (Go test binaries), alongside `*_test.go`
- binary-file diff sections (`Binary files … differ` / `GIT binary patch`)

New unit tests cover both. `go test ./internal/mswe/` / `go vet` / `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)