### PR TITLE
feat(tui): status bar + bordered input box (P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased — 0.5.0-dev]
 
 ### Added
+- **TUI status bar + bordered input box (TUI UX upgrade, P2).** The interactive TUI's input line is now a rounded-border box sized to the terminal width, with a status bar beneath it showing the model, home-abbreviated working directory, context-window usage (`ctx N%`), estimated session cost (`$…`), permission mode, and per-turn elapsed time; the contextual key hint moved onto a dim line below. New `Agent.ContextUsage()` exposes the context gauge (last-sent tokens / model window). Borderless fallback before the first window-size message or on a very narrow terminal.
 - **TUI tool cards (TUI UX upgrade, P1).** The interactive bubbletea TUI now renders tool activity as rich cards instead of one-line `↳ tool ✓` status: `edit_file` shows a chroma-highlighted diff card (the `internal/tui` renderer that previously only ran in the non-TTY fallback view), and `terminal` / `grep` / `glob` / `read_file` / `web_fetch` / `web_search` show an output-preview card (`● Verb(target)` header above the output behind a `│` gutter, capped with a "N more lines" marker). A new `internal/tui` theme skeleton centralises the palette. First of the phased TUI upgrade in `dev-docs/tui-ux-upgrade-design.md` (P2 status bar + bordered input, P3 rich spinner, P4 glamour markdown, P5 panels follow).
 
 ### Changed

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/tools"
@@ -149,6 +150,12 @@ type tuiModel struct {
 
 	width int
 	quit  bool
+
+	// cwd is the home-abbreviated working directory shown in the status bar
+	// (computed once — it doesn't change during a session).
+	cwd string
+	// turnStart timestamps the current turn so the status bar can show elapsed.
+	turnStart time.Time
 }
 
 // modalState renders a permission / question prompt and collects the answer.
@@ -163,7 +170,7 @@ type modalState struct {
 }
 
 func newTUIModel(cfg replConfig) *tuiModel {
-	return &tuiModel{cfg: cfg, a: cfg.a}
+	return &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir())}
 }
 
 func (m *tuiModel) Init() tea.Cmd { return nil }
@@ -174,6 +181,7 @@ func (m *tuiModel) Init() tea.Cmd { return nil }
 func (m *tuiModel) startTurn(line string) tea.Cmd {
 	m.turnRunning = true
 	m.streaming = false
+	m.turnStart = time.Now()
 	m.partial.Reset()
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancelTurn = cancel

--- a/cmd/octo/tuirepl_p2_test.go
+++ b/cmd/octo/tuirepl_p2_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderStatusBar_ShowsModelAndHint(t *testing.T) {
+	m := newTestModel() // agent model name is "m"
+	out := m.renderStatusBar()
+	if !strings.Contains(out, "m") {
+		t.Errorf("status bar should include the model; got:\n%s", out)
+	}
+	// Idle hint.
+	if !strings.Contains(out, "Enter send") {
+		t.Errorf("idle status bar should show the send hint; got:\n%s", out)
+	}
+	// Running hint switches.
+	m.turnRunning = true
+	if got := m.renderStatusBar(); !strings.Contains(got, "interrupt") {
+		t.Errorf("running status bar should show the interrupt hint; got:\n%s", got)
+	}
+}
+
+func TestRenderInputBox_BorderGating(t *testing.T) {
+	m := newTestModel()
+	typeRunes(m, "hi")
+
+	// Width 0 (pre-WindowSizeMsg): borderless, just the content.
+	m.width = 0
+	if got := m.renderInputBox(); strings.ContainsAny(got, "╭╮╰╯") {
+		t.Errorf("no border expected at width 0; got:\n%s", got)
+	}
+	if !strings.Contains(m.renderInputBox(), "you>") {
+		t.Error("input box should always show the prompt")
+	}
+
+	// A real width draws the rounded border.
+	m.width = 60
+	if got := m.renderInputBox(); !strings.ContainsAny(got, "╭╮╰╯") {
+		t.Errorf("expected a rounded border at width 60; got:\n%s", got)
+	}
+}
+
+func TestAbbreviateHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	if got := abbreviateHome(home); got != "~" {
+		t.Errorf("abbreviateHome(home) = %q, want ~", got)
+	}
+	sub := filepath.Join(home, "proj", "octo")
+	if got := abbreviateHome(sub); got != "~"+string(filepath.Separator)+filepath.Join("proj", "octo") {
+		t.Errorf("abbreviateHome(sub) = %q, want ~/proj/octo", got)
+	}
+	if got := abbreviateHome("/etc/hosts"); got != "/etc/hosts" {
+		t.Errorf("abbreviateHome outside home should be unchanged; got %q", got)
+	}
+	if got := abbreviateHome(""); got != "" {
+		t.Errorf("abbreviateHome(\"\") = %q, want empty", got)
+	}
+}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	tea "github.com/charmbracelet/bubbletea"
@@ -10,13 +12,18 @@ import (
 )
 
 var (
-	promptStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)
-	noticeStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	errorStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-	toolErrStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-	queueStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
-	modalStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("13")).Bold(true)
-	hintStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Italic(true)
+	promptStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)
+	noticeStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	errorStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+	toolErrStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+	queueStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
+	modalStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("13")).Bold(true)
+	hintStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Italic(true)
+	statusStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	inputBoxStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("8")).
+			Padding(0, 1)
 )
 
 // handleKey routes a keypress by context: a modal grabs all keys; otherwise the
@@ -245,19 +252,74 @@ func (m *tuiModel) View() string {
 		}
 	}
 
-	// Input line.
-	b.WriteString(promptStyle.Render("you> "))
-	b.WriteString(string(m.input))
-	b.WriteString("▏")
-
-	// Context hint.
+	// Bordered input box + status bar.
+	b.WriteString(m.renderInputBox())
 	b.WriteByte('\n')
-	if m.turnRunning {
-		b.WriteString(hintStyle.Render("Enter steer · Alt+Enter queue · Esc interrupt"))
-	} else {
-		b.WriteString(hintStyle.Render("Enter send · /exit quit · Ctrl+D quit"))
-	}
+	b.WriteString(m.renderStatusBar())
 	return b.String()
+}
+
+// renderInputBox draws the prompt + current input inside a rounded border,
+// sized to the terminal width. Falls back to a borderless line before the
+// first WindowSizeMsg (width 0) or on a very narrow terminal.
+func (m *tuiModel) renderInputBox() string {
+	content := promptStyle.Render("you> ") + string(m.input) + "▏"
+	if m.width <= 6 {
+		return content
+	}
+	return inputBoxStyle.Width(m.width - 4).Render(content) // -2 border, -2 padding
+}
+
+// renderStatusBar renders the model / cwd / context% / cost / permission /
+// elapsed segments, with the contextual key hint on a dim line below.
+func (m *tuiModel) renderStatusBar() string {
+	segs := []string{m.a.Model}
+	if m.cwd != "" {
+		segs = append(segs, m.cwd)
+	}
+	if used, window := m.a.ContextUsage(); window > 0 && used > 0 {
+		segs = append(segs, fmt.Sprintf("ctx %d%%", used*100/window))
+	}
+	if c := m.a.SessionCostUSD(); c > 0 {
+		segs = append(segs, fmt.Sprintf("$%.4f", c))
+	}
+	if m.cfg.permEngine != nil {
+		segs = append(segs, string(m.cfg.permEngine.GetMode()))
+	}
+	if m.turnRunning && !m.turnStart.IsZero() {
+		segs = append(segs, time.Since(m.turnStart).Round(time.Second).String())
+	}
+
+	hint := "Enter send · /exit quit · Ctrl+D quit"
+	if m.turnRunning {
+		hint = "Enter steer · Alt+Enter queue · Esc interrupt"
+	}
+	return statusStyle.Render(strings.Join(segs, " · ")) + "\n" + hintStyle.Render(hint)
+}
+
+// workingDir returns the current directory, or "" if it can't be determined.
+func workingDir() string {
+	d, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return d
+}
+
+// abbreviateHome replaces the user's home-dir prefix with "~".
+func abbreviateHome(path string) string {
+	if path == "" {
+		return ""
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if path == home {
+			return "~"
+		}
+		if strings.HasPrefix(path, home+string(os.PathSeparator)) {
+			return "~" + path[len(home):]
+		}
+	}
+	return path
 }
 
 func (m *tuiModel) modalView() string {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -787,6 +787,14 @@ func (a *Agent) AccrueChildUsage(inputTokens, outputTokens int) {
 	a.sessionOutputTokens += outputTokens
 }
 
+// ContextUsage reports how full the model's context window is: used is the
+// size of the most recently sent context (the prior turn's input tokens, 0
+// before the first reply), window is the model's approximate context-window
+// size. Lets the TUI status bar render a "ctx N%" gauge. window is always > 0.
+func (a *Agent) ContextUsage() (used, window int) {
+	return a.lastInputTokens, contextWindow(a.Model)
+}
+
 // SessionCacheTokens returns the cumulative cache read/write token counts.
 // Read is input served from cache (cheap); write is input written into the
 // cache (Anthropic only). Both zero when the backend reports no cache info.


### PR DESCRIPTION
TUI UX 升级 **P2**（`dev-docs/tui-ux-upgrade-design.md`）。

## 改动

- **边框输入框**：`you>` 输入行改成圆角边框框，按终端宽度自适应（width 0 / 极窄时降级无边框）。
- **状态栏**（输入框下方）：`model · ~/cwd · ctx N% · $cost · 权限模式 · 计时`；键位提示挪到下方 dim 行。
- **`Agent.ContextUsage()`**（新导出）：返回 `(lastInputTokens, contextWindow(model))`，供状态栏算 ctx%。

数据源复用现有：`SessionCostUSD()` / `permEngine.GetMode()` / 新的 `ContextUsage()`；cwd 用 `abbreviateHome` 缩成 `~/…`，计时从 turnStart 算（流式事件期间随重绘更新；连续跳动留给 P3 的 ticker）。

## 测试

`make test`（`-race`）/ `vet` / `fmt-check` 全绿。新增：状态栏含 model 且 running 时切到 interrupt 提示；输入框边框按宽度 gating；`abbreviateHome`。

## 分期

P1 ✅ → **P2（本 PR）** → P3 富 spinner（计时跳动 + 轮转词）→ P4 glamour markdown → P5 面板化+主题收口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)