### PR TITLE
feat(skills): default skills shipped in the binary, materialized on first run

### DIFF
--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 
 	"github.com/Leihb/octo-agent/internal/sandbox"
+	"github.com/Leihb/octo-agent/internal/skills"
 	"github.com/Leihb/octo-agent/internal/version"
 )
 
@@ -28,6 +29,13 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		printUsage(stdout)
 		return 0
+	}
+
+	// Materialize the binary's default skills to ~/.octo/skills-default so
+	// they're discoverable like any user skill. Best-effort and a fast no-op
+	// once current; skipped for the internal fast-path commands.
+	if args[0] != "__sandboxed-exec" && args[0] != "__complete" {
+		_ = skills.MaterializeDefaults(version.Version)
 	}
 
 	switch args[0] {
@@ -63,6 +71,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return runMemory(args[1:], stdout, stderr)
 	case "task":
 		return runTask(args[1:], stdin, stdout, stderr)
+	case "skills":
+		return runSkills(args[1:], stdout, stderr)
 	case "completion":
 		return runCompletion(args[1:], stdout, stderr)
 	case "__complete":

--- a/cmd/octo/skills_cmd.go
+++ b/cmd/octo/skills_cmd.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Leihb/octo-agent/internal/skills"
+	"github.com/Leihb/octo-agent/internal/version"
+)
+
+// runSkills handles `octo skills [list|update|path]`. Bare `octo skills`
+// defaults to list. Skills are discovered from three roots (default < user <
+// project); the default set ships embedded in the binary and is materialized to
+// disk on startup (see internal/skills/defaults.go).
+func runSkills(args []string, stdout, stderr io.Writer) int {
+	sub := "list"
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	switch sub {
+	case "list":
+		return skillsList(stdout)
+	case "update":
+		return skillsUpdate(stdout, stderr)
+	case "path":
+		return skillsPath(stdout)
+	default:
+		fmt.Fprintf(stderr, "octo skills: unknown subcommand %q (want list | update | path)\n", sub)
+		return 2
+	}
+}
+
+func skillsList(stdout io.Writer) int {
+	cwd, _ := os.Getwd()
+	reg := skills.Discover(cwd)
+	all := reg.List()
+	if len(all) == 0 {
+		fmt.Fprintln(stdout, "No skills found.")
+		fmt.Fprintln(stdout, "Defaults ship with the binary; add your own under ~/.octo/skills or ./.octo/skills.")
+		return 0
+	}
+	// Group by source for a readable overview: default → user → project.
+	order := map[string]int{"default": 0, "user": 1, "project": 2}
+	sort.SliceStable(all, func(i, j int) bool {
+		if order[all[i].Source] != order[all[j].Source] {
+			return order[all[i].Source] < order[all[j].Source]
+		}
+		return all[i].Name < all[j].Name
+	})
+	fmt.Fprintln(stdout, "Skills (trigger with /<name>; project overrides user overrides default):")
+	for _, s := range all {
+		fmt.Fprintf(stdout, "  /%-18s [%-7s] %s\n", s.Name, s.Source, s.Description)
+	}
+	return 0
+}
+
+func skillsUpdate(stdout, stderr io.Writer) int {
+	if err := skills.UpdateDefaults(version.Version); err != nil {
+		fmt.Fprintf(stderr, "octo skills update: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Default skills refreshed → %s\n", skills.DefaultRoot())
+	return 0
+}
+
+func skillsPath(stdout io.Writer) int {
+	cwd, _ := os.Getwd()
+	fmt.Fprintln(stdout, "Skill roots (lowest → highest precedence):")
+	fmt.Fprintf(stdout, "  default  %s\n", skills.DefaultRoot())
+	fmt.Fprintf(stdout, "  user     %s\n", skills.UserRoot())
+	fmt.Fprintf(stdout, "  project  %s\n", filepath.Join(cwd, ".octo", "skills"))
+	return 0
+}

--- a/dev-docs/default-skills-design.md
+++ b/dev-docs/default-skills-design.md
@@ -1,0 +1,71 @@
+# Default Skills (embed + materialize)
+
+> A curated set of skills ships with the binary and lands on disk on first run,
+> so a fresh `octo` install has useful skills without the user authoring any.
+
+## 1. Goal
+
+After install, a curated skill set (today: `worktree-isolate`) is discoverable,
+listable, and overridable — **offline, version-locked to the binary, and never
+clobbering a user's own skills.**
+
+## 2. Decision: embed, don't download
+
+The default set is embedded in the binary via `//go:embed` and materialized to
+disk on startup — **not** fetched from a remote. Embedding keeps a fresh install
+offline-capable (works for `go install`, air-gapped, CI) and immune to
+supply-chain / network-failure modes. A real download path is reserved for a
+future *optional* community catalog (`octo skills add <name>`), which is a
+separate concern from the built-in defaults.
+
+## 3. Mechanism
+
+- **Source of truth:** `internal/skills/defaults/<name>/SKILL.md`, embedded as
+  `defaultsFS` (`internal/skills/defaults.go`).
+- **Materialize:** `MaterializeDefaults(version)` writes the embedded tree to
+  `~/.octo/skills-default/`, stamped with the binary version in `.octo-version`.
+  It's a fast no-op once the stamp matches; a version bump wipes-and-rewrites the
+  whole dir (stale/renamed skills handled). Called best-effort at startup in
+  `cmd/octo` `run()` (skipped for the `__complete` / `__sandboxed-exec` fast
+  paths); a read-only HOME degrades to "no defaults", never an error.
+- **Dedicated dir:** `~/.octo/skills-default/` is exclusively octo-managed and
+  kept **separate** from `~/.octo/skills/`, so refreshing defaults never touches
+  a user's own skills and needs no per-file provenance tracking.
+
+## 4. Precedence
+
+`Discover` scans lowest-first; `scanRoot` overwrites by name:
+
+```
+default  ~/.octo/skills-default/   (shipped, materialized)
+   ↓ overridden by
+user     ~/.octo/skills/
+   ↓ overridden by
+project  ./.octo/skills/
+```
+
+A user overrides a default skill by dropping a same-named skill in
+`~/.octo/skills/`. `--list-skills` / `octo skills list` tag each with its
+source.
+
+## 5. CLI
+
+```
+octo skills list      # all skills, grouped default → user → project
+octo skills update    # force re-materialize the defaults (ignores the stamp)
+octo skills path      # print the three roots
+```
+
+## 6. Adding a default skill
+
+Drop `internal/skills/defaults/<name>/SKILL.md` (standard SKILL.md frontmatter:
+`name` + `description`). It ships on the next release and materializes on the
+user's next run after upgrade. Keep the set small and high-value — every default
+costs system-prompt manifest space for every user.
+
+## 7. Out of scope
+
+- **Remote / community skills** (`octo skills add`, a catalog) — a separate
+  optional feature; defaults stay embedded.
+- **Per-file user-edit preservation in the default dir** — unnecessary, because
+  users edit in `~/.octo/skills/`, not the octo-managed default dir.

--- a/internal/skills/defaults.go
+++ b/internal/skills/defaults.go
@@ -1,0 +1,98 @@
+package skills
+
+import (
+	"embed"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// defaultsFS holds the skills shipped with the binary. They are the curated
+// set every install gets out of the box; MaterializeDefaults writes them to
+// disk so they're discoverable, listable, and overridable like any other
+// skill. Embedding (rather than downloading) keeps a fresh install offline-
+// capable and version-locked to the binary — no network, no supply chain.
+//
+//go:embed defaults
+var defaultsFS embed.FS
+
+// defaultStampFile records which binary version last materialized the default
+// skills, so MaterializeDefaults can no-op until the version changes.
+const defaultStampFile = ".octo-version"
+
+// defaultSkillsRoot returns ~/.octo/skills-default — a dedicated, octo-managed
+// directory kept separate from ~/.octo/skills so refreshing the defaults never
+// touches a user's own skills. A var so tests can redirect it.
+var defaultSkillsRoot = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "skills-default")
+}
+
+// DefaultRoot is the on-disk location of the materialized default skills
+// (~/.octo/skills-default), exported for `octo skills path`.
+func DefaultRoot() string { return defaultSkillsRoot() }
+
+// UserRoot is the user-level skills directory (~/.octo/skills), exported for
+// `octo skills path`.
+func UserRoot() string { return userSkillsRoot() }
+
+// MaterializeDefaults writes the embedded default skills to the default root
+// when the on-disk version stamp doesn't match version. It's a fast no-op once
+// the install is current (a single stamp read). Best-effort: the caller should
+// ignore the error so a read-only HOME never blocks a session.
+func MaterializeDefaults(version string) error {
+	return materializeDefaults(defaultSkillsRoot(), version, false)
+}
+
+// UpdateDefaults forces a rewrite regardless of the stamp — backs
+// `octo skills update`.
+func UpdateDefaults(version string) error {
+	return materializeDefaults(defaultSkillsRoot(), version, true)
+}
+
+func materializeDefaults(root, version string, force bool) error {
+	if root == "" {
+		return nil
+	}
+	if !force {
+		if b, err := os.ReadFile(filepath.Join(root, defaultStampFile)); err == nil &&
+			strings.TrimSpace(string(b)) == version {
+			return nil // already current
+		}
+	}
+
+	// The default root is exclusively octo-managed (users override in
+	// ~/.octo/skills), so a wholesale wipe-and-rewrite is safe and keeps the
+	// set in lockstep with the binary — stale skills removed, renames handled.
+	if err := os.RemoveAll(root); err != nil {
+		return err
+	}
+	if err := fs.WalkDir(defaultsFS, "defaults", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel := strings.TrimPrefix(p, "defaults/") // e.g. worktree-isolate/SKILL.md
+		target := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		data, err := defaultsFS.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	}); err != nil {
+		return err
+	}
+
+	// Stamp last: if a write above failed mid-way the stamp is absent/stale, so
+	// the next run retries rather than trusting a partial materialization.
+	return os.WriteFile(filepath.Join(root, defaultStampFile), []byte(version), 0o644)
+}

--- a/internal/skills/defaults/worktree-isolate/SKILL.md
+++ b/internal/skills/defaults/worktree-isolate/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: worktree-isolate
+description: Do risky or experimental work in an isolated git worktree, then merge or discard. Use when the user wants changes tried in isolation ("试在 worktree 里改", "隔离环境跑一下", "worktree 隔离", "在临时分支上做"), or before a large/uncertain edit that shouldn't touch the main checkout. Trailing text is the task to perform in the worktree.
+---
+
+# Work in an isolated git worktree
+
+Create a throwaway git worktree on a new branch, do all the work there, verify, then either merge it back or remove it. octo has **no session-level working directory** — so the one rule that makes this work is: **address the worktree by absolute path in every tool call.**
+
+## ⚠️ The absolute-path rule (octo-specific — read first)
+
+octo's `terminal` runs each command in a **fresh shell** in the **process's launch directory**; a `cd` does **not** carry to the next `terminal` call, and `read_file` / `edit_file` / `write_file` resolve relative paths against that same fixed directory. There is no "the session is now inside the worktree" mode.
+
+Therefore, after creating the worktree:
+
+- **Shell:** use `git -C "$WT" …` and absolute paths, or chain everything inside ONE command: `cd "$WT" && go build ./... && go test ./...`. Never split `cd "$WT"` from the work into separate `terminal` calls.
+- **Files:** always pass the worktree's **absolute path** to read_file / edit_file / write_file (e.g. `$WT/internal/foo.go`), never a bare relative path.
+
+Resolve `$WT` to a real absolute path once and reuse it verbatim.
+
+## Steps
+
+1. **Locate the repo and base.**
+   - `terminal: git rev-parse --show-toplevel` → this is `$REPO` (absolute).
+   - Note the current branch (`git -C "$REPO" rev-parse --abbrev-ref HEAD`); the new branch will fork from current HEAD unless the user says otherwise.
+
+2. **Pick a name and path.** Slugify the task into `<slug>`. Use:
+   - worktree dir: `$WT = $REPO/.worktrees/<slug>`
+   - branch: `wt/<slug>`
+   - Make sure `.worktrees/` is ignored: if `git -C "$REPO" check-ignore .worktrees` prints nothing, append `/.worktrees/` to `$REPO/.gitignore` first.
+
+3. **Create the worktree.**
+   ```
+   git -C "$REPO" worktree add "$WT" -b "wt/<slug>"
+   ```
+   If the branch already exists, drop `-b` and pass the branch name as a third arg, or pick a fresh slug.
+
+4. **Do the task in `$WT`** — following the absolute-path rule above. Build and run the project's tests inside `$WT` to verify (e.g. `cd "$WT" && <project test command>`), not in the main checkout.
+
+5. **Finish — ask the user which, unless they already said:**
+   - **Keep / merge:** leave the branch for a PR, or `git -C "$REPO" merge wt/<slug>` if they want it folded in. Report the branch name and the diff summary.
+   - **Discard:** `git -C "$REPO" worktree remove --force "$WT"` and `git -C "$REPO" branch -D wt/<slug>`.
+
+## Notes
+
+- Don't `os.Chdir` / don't expect a persistent cwd — that's exactly what this skill routes around.
+- A worktree shares the repo's object store; creating/removing it is cheap and never touches the main working tree.
+- If anything fails mid-way, surface it and leave the worktree in place (so the user can inspect) rather than silently removing it.

--- a/internal/skills/defaults_test.go
+++ b/internal/skills/defaults_test.go
@@ -1,0 +1,114 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain neutralizes the default-skills root for the whole package so tests
+// never read the real ~/.octo/skills-default (which an installed binary
+// populates). Tests that exercise defaults opt in via useDefaultRoot.
+func TestMain(m *testing.M) {
+	tmp, _ := os.MkdirTemp("", "octo-skills-default-empty")
+	defaultSkillsRoot = func() string { return tmp }
+	code := m.Run()
+	if tmp != "" {
+		_ = os.RemoveAll(tmp)
+	}
+	os.Exit(code)
+}
+
+// useDefaultRoot points defaultSkillsRoot at dir for the test's duration.
+func useDefaultRoot(t *testing.T, dir string) {
+	t.Helper()
+	orig := defaultSkillsRoot
+	defaultSkillsRoot = func() string { return dir }
+	t.Cleanup(func() { defaultSkillsRoot = orig })
+}
+
+func TestMaterializeDefaults_WritesEmbeddedAndStamps(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "skills-default")
+	useDefaultRoot(t, root)
+
+	if err := MaterializeDefaults("v1"); err != nil {
+		t.Fatalf("MaterializeDefaults: %v", err)
+	}
+	// The shipped worktree-isolate skill must land on disk.
+	if _, err := os.Stat(filepath.Join(root, "worktree-isolate", "SKILL.md")); err != nil {
+		t.Fatalf("expected worktree-isolate/SKILL.md materialized: %v", err)
+	}
+	// Stamp records the version.
+	b, err := os.ReadFile(filepath.Join(root, defaultStampFile))
+	if err != nil || string(b) != "v1" {
+		t.Fatalf("stamp = %q, %v; want v1", string(b), err)
+	}
+}
+
+func TestMaterializeDefaults_NoOpWhenCurrent(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "skills-default")
+	useDefaultRoot(t, root)
+	if err := MaterializeDefaults("v1"); err != nil {
+		t.Fatal(err)
+	}
+	// Drop a sentinel; a no-op (same version) must not wipe the dir.
+	sentinel := filepath.Join(root, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := MaterializeDefaults("v1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("same-version call should be a no-op, but the dir was rewritten")
+	}
+
+	// A version bump (or UpdateDefaults force) re-materializes, wiping stale files.
+	if err := MaterializeDefaults("v2"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Errorf("version bump should wipe-and-rewrite the default root")
+	}
+}
+
+func TestDiscover_DefaultSkillSurfacesAndIsOverridable(t *testing.T) {
+	defaultRoot := filepath.Join(t.TempDir(), "skills-default")
+	useDefaultRoot(t, defaultRoot)
+	if err := MaterializeDefaults("v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	userRoot := t.TempDir()
+	useUserRoot(t, userRoot)
+
+	// Default-only: worktree-isolate is discovered with source "default".
+	reg := Discover("")
+	s, ok := reg.Get("worktree-isolate")
+	if !ok {
+		t.Fatal("default worktree-isolate not discovered")
+	}
+	if s.Source != "default" {
+		t.Errorf("source = %q, want default", s.Source)
+	}
+
+	// A user skill of the same name overrides the default.
+	dir := filepath.Join(userRoot, "worktree-isolate")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(dir, "SKILL.md"), "---\nname: worktree-isolate\ndescription: my override\n---\nbody")
+
+	reg = Discover("")
+	s, _ = reg.Get("worktree-isolate")
+	if s.Source != "user" || s.Description != "my override" {
+		t.Errorf("user skill should override default, got source=%q desc=%q", s.Source, s.Description)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -60,6 +60,13 @@ var userSkillsRoot = func() string {
 // error — most environments won't have both.
 func Discover(cwd string) *Registry {
 	r := &Registry{skills: make(map[string]Skill)}
+	// Lowest precedence first; scanRoot overwrites by name, so user then
+	// project win. Default skills (shipped with the binary, materialized to
+	// ~/.octo/skills-default) are the floor — a user overrides one by dropping
+	// a same-named skill in ~/.octo/skills.
+	if root := defaultSkillsRoot(); root != "" {
+		r.scanRoot(root, "default")
+	}
 	if root := userSkillsRoot(); root != "" {
 		r.scanRoot(root, "user")
 	}


### PR DESCRIPTION
## Why

A fresh `octo` install had **no skills** unless the user wrote them. This ships a curated default set (today: `worktree-isolate`) that lands on disk on first run — discoverable, listable, and overridable like any user skill.

## Decision: embed, not download

Defaults are **embedded in the binary** (`//go:embed`) and materialized to disk on startup — not fetched from a remote. Embedding keeps a fresh install **offline-capable** (`go install`, air-gapped, CI) and immune to network/supply-chain failure. A real download path is reserved for a future *optional* community catalog (`octo skills add`), separate from built-in defaults.

## Mechanism

- Source: `internal/skills/defaults/<name>/SKILL.md`, embedded as `defaultsFS`.
- `MaterializeDefaults(version)` writes the tree to a dedicated, octo-managed `~/.octo/skills-default/`, stamped with the binary version. Fast no-op once current; a version bump wipe-and-rewrites (handles stale/renamed skills). Best-effort at startup; read-only HOME → no defaults, never an error.
- **Separate dir** from `~/.octo/skills/`, so refreshing defaults never touches a user's own skills (no per-file provenance).
- `Discover` scans `default → user → project` (lowest first, later wins) → a user overrides a default by dropping a same-named skill in `~/.octo/skills/`.

## CLI

```
octo skills list     # grouped default → user → project (with source tags)
octo skills update   # force re-materialize defaults
octo skills path     # the three roots
```

## First default skill

`worktree-isolate` — the "work in an isolated git worktree via absolute paths" workflow (routes around octo's lack of a session-level cwd).

## Testing

- materialize writes embedded skill + stamp; same-version no-op vs version-bump rewrite; default discovered with source `default` and overridden by a same-named user skill.
- Package `TestMain` neutralizes the default root so existing skills tests don't read the real `~/.octo`.
- `go test -race ./...`, `go vet`, `gofmt -l` — all green. Smoke-tested `list` / `path` / `update` + first-run materialization end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)