### PR TITLE
feat(tui): Ctrl+X cancels the most-recently queued message

### DIFF
--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -59,6 +59,28 @@ func TestTUI_RunningEnterSteers(t *testing.T) {
 	}
 }
 
+func TestTUI_CtrlXUnqueuesMostRecent(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.queue = []pendingItem{{text: "first"}, {text: "second"}}
+
+	// Ctrl+X drops the most-recently queued item.
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlX})
+	if len(m.queue) != 1 || m.queue[0].text != "first" {
+		t.Fatalf("Ctrl+X should drop the last queued item, got %+v", m.queue)
+	}
+	// Repeat clears the rest.
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlX})
+	if len(m.queue) != 0 {
+		t.Fatalf("repeated Ctrl+X should empty the queue, got %+v", m.queue)
+	}
+	// Ctrl+X on an empty queue is a harmless no-op.
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlX})
+	if len(m.queue) != 0 {
+		t.Errorf("Ctrl+X on empty queue should be a no-op")
+	}
+}
+
 func TestTUI_RunningAltEnterQueues(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -57,6 +57,17 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.input = nil
 		return m, nil
 
+	case tea.KeyCtrlX:
+		// Cancel the most-recently queued message. The queue survives Esc
+		// (interrupt only stops the running turn), so this is the way to undo a
+		// mis-queued Alt+Enter; repeat to clear the queue.
+		if n := len(m.queue); n > 0 {
+			dropped := m.queue[n-1].text
+			m.queue = m.queue[:n-1]
+			return m, tea.Println(queueStyle.Render("✕ unqueued: " + dropped))
+		}
+		return m, nil
+
 	case tea.KeyEnter:
 		return m.submit(msg.Alt)
 
@@ -336,6 +347,9 @@ func (m *tuiModel) renderStatusBar() string {
 	hint := "Enter send · /exit quit · Ctrl+D quit"
 	if m.turnRunning {
 		hint = "Enter steer · Alt+Enter queue · Esc interrupt"
+	}
+	if len(m.queue) > 0 {
+		hint += " · Ctrl+X unqueue"
 	}
 	return statusStyle.Render(strings.Join(segs, " · ")) + "\n" + hintStyle.Render(hint)
 }


### PR DESCRIPTION
## Why

Auditing the design docs surfaced a real gap: decision #10 (input-modes design) specified a queue **removal safety valve**, but it was never implemented. Since Esc only stops the running turn and leaves the queue intact (decision #9), a mis-queued `Alt+Enter` message had **no way to be cancelled**.

## What

`Ctrl+X` drops the most-recently queued item (repeat to clear the whole queue); no-op on an empty queue. The status-bar hint shows `Ctrl+X unqueue` whenever the queue is non-empty.

This is the minimal honoring of decision #10's "逐条/全部撤回" — last-item removal is the per-item primitive; repeat = clear all. (A full selectable-cursor UI was over-scoped; this closes the actual gap.)

## Testing

`TestTUI_CtrlXUnqueuesMostRecent`: drops last, repeat empties, no-op on empty. Full `-race` suite, vet, gofmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)