### PR TITLE
docs: refine remaining design specs to current state

### DIFF
--- a/dev-docs/c11-sandbox-design.md
+++ b/dev-docs/c11-sandbox-design.md
@@ -1,63 +1,50 @@
-# C11 — OS-level command sandbox (design)
+# OS-level command sandbox
 
-Status: design agreed 2026-05-27. Implements roadmap item **C11** (= M6.5 P1-2).
+An opt-in `--sandbox` confines the `terminal` tool's commands at the OS layer:
+even a permission-allowed command can't write/read outside an allowed set of
+roots or open a network connection. Defense-in-depth under the permission
+engine — not an absolute boundary against kernel exploits.
 
 ## 1. Threat model & goals
 
-The permission engine (`internal/permission`) gates the `terminal` tool at the
-**policy layer** — allow/deny/ask on the command *string* (substring + glob
-rules). That is bypassable: `python -c '…'`, `bash -c '…'`, a novel binary, or
-any command whose dangerous effect isn't captured by a substring rule can slip
-through an `allow`.
+The permission engine (`internal/permission`) gates `terminal` at the **policy
+layer** — allow/deny/ask on the command *string* (substring + glob rules). That
+is bypassable: `python -c '…'`, `bash -c '…'`, a novel binary, or any command
+whose dangerous effect isn't captured by a substring rule can slip through an
+`allow`.
 
-**Threat.** An LLM-issued or prompt-injected command that the permission engine
-allows (or that evades its rules) does one of:
-- writes/deletes files **outside the project** (e.g. `~`, `/etc`),
-- reads **secrets** (`~/.ssh`, `~/.aws`, `~/.config`),
-- **exfiltrates** data over the network.
+**Threat.** An LLM-issued or prompt-injected command the engine allows (or that
+evades its rules) writes/deletes files outside the project (`~`, `/etc`), reads
+secrets (`~/.ssh`, `~/.aws`, `~/.config`), or exfiltrates over the network.
 
-**Goal.** Even an *allowed* command cannot, as enforced by the OS (not by string
-matching):
-- write outside an allowed set of roots,
-- read outside an allowed set of roots,
-- open an IP-network connection (deny by default; allowlist later).
+**Goal.** As enforced by the OS (not string matching), even an *allowed* command
+cannot write outside an allowed root set, read outside an allowed root set, or
+open an IP-network connection (deny by default).
 
-This is **defense-in-depth**, layered under the permission engine — not an
-absolute boundary against kernel exploits.
+**Non-goals.** Full container isolation, complete syscall filtering, defeating
+local privilege escalation. The boundary is the arbitrary-command surface: the
+`terminal` tool (foreground + background).
 
-**Non-goals (this milestone).** Full container isolation, complete syscall
-filtering, defeating local privilege escalation, sandboxing our own controlled
-read-only helpers (`grep`'s `rg`). The boundary we care about is the
-arbitrary-command surface: the `terminal` tool (foreground + background).
+The sandbox is **opt-in** (`--sandbox`, default off); the permission engine +
+strict mode are the always-on backstop. It is not default-on because the network
+story is an all-or-nothing toggle (§5), so a default sandbox would break every
+network-needing command (`go mod download`, `git fetch`).
 
-## 2. Decisions (agreed)
+## 2. Integration point & abstraction
 
-- **Rollout: opt-in.** A `--sandbox` flag, default **off**. The existing strict
-  permission mode remains the backstop. Flip to default-on in a later phase once
-  proven. Does not block other work.
-- **Linux mechanism: Landlock re-exec shim** (no external dependency, fits the
-  single-binary ethos; kernel ≥ 5.13). `bwrap` is *not* a dependency.
-- **Phase 1 scope: filesystem boundary AND network deny together** (not FS only).
-
-## 3. Integration point & abstraction
-
-Two call sites build the arbitrary command today, both
-`exec.CommandContext(ctx, "sh", "-c", command)`:
-- `internal/tools/terminal.go` (foreground)
-- `internal/tools/background.go` (background)
-
-Both route through a new package:
+Both command sites — `internal/tools/terminal.go` (foreground) and
+`internal/tools/background.go` (background) — build `sh -c command` and route
+through `internal/sandbox`:
 
 ```go
-// internal/sandbox
 type Policy struct {
-    ReadRoots    []string // absolute roots readable (incl. system: /usr /bin /lib /etc, cwd, tmp)
+    ReadRoots    []string // absolute roots readable (cwd, tmp, OS system roots)
     WriteRoots   []string // absolute roots writable (cwd, $TMPDIR)
     AllowNetwork bool     // false → deny IP networking
 }
 
-// Command wraps `sh -c command` so it runs confined to p. Returns an error
-// when sandboxing was requested but is unavailable on this host (see §6).
+// Command wraps `sh -c command` so it runs confined to p. Errors when
+// sandboxing was requested but is unavailable on this host (see §6).
 func Command(ctx context.Context, command string, p Policy) (*exec.Cmd, error)
 
 // Available reports whether this OS/kernel can enforce a sandbox.
@@ -68,21 +55,19 @@ func DefaultPolicy(cwd string) Policy
 ```
 
 `DefaultPolicy(cwd)`:
-- ReadRoots: `cwd`, `$TMPDIR`/`/tmp`, and read-only system roots
-  (`/usr`, `/bin`, `/lib`, `/lib64`, `/etc`, `/opt`, `/System` on macOS, the Go
-  toolchain dir). Generous on read so normal tooling works; the credential
-  paths are excluded so secrets stay unreadable.
-- WriteRoots: `cwd`, `$TMPDIR`/`/tmp`.
-- AllowNetwork: false.
 
-Explicitly **outside** ReadRoots: `~/.ssh`, `~/.aws`, `~/.config`, `~` in
-general (only cwd + tmp are reachable under the home tree).
+- **ReadRoots**: `cwd`, `$TMPDIR`/`/tmp`, and OS-specific read-only system roots
+  (`systemReadRoots()` — `/usr /bin /lib /etc …` plus per-OS additions:
+  `/sbin /var /private /Library` on darwin, `/sbin /proc` on linux). Generous on
+  read so normal tooling works; credential paths stay excluded.
+- **WriteRoots**: `cwd`, `$TMPDIR`/`/tmp`.
+- **AllowNetwork**: false.
 
-### Plumbing the policy to the tools
+Explicitly outside ReadRoots: `~/.ssh`, `~/.aws`, `~/.config`, `~` in general
+(only cwd + tmp are reachable under the home tree).
 
-`TerminalTool` and `BackgroundManager` are stateless values in `allTools`, so —
-mirroring the existing `defaultBg` pattern — the active policy lives as a
-package-level value in `internal/tools`, set once at startup:
+`TerminalTool` and `BackgroundManager` are stateless values, so the active policy
+lives package-level (mirroring `defaultBg`), set once at startup:
 
 ```go
 // internal/tools
@@ -91,15 +76,15 @@ func SetSandbox(p *sandbox.Policy) { activeSandbox = p }
 ```
 
 `cmd/octo` calls `tools.SetSandbox(&policy)` when `--sandbox` is passed. Both
-exec sites consult `activeSandbox`: nil → today's plain `exec.CommandContext`;
-non-nil → `sandbox.Command(ctx, command, *activeSandbox)`.
+exec sites consult `activeSandbox`: nil → plain `exec.CommandContext`; non-nil →
+`sandbox.Command(ctx, command, *activeSandbox)`.
 
-## 4. macOS mechanism — Seatbelt (SBPL)
+## 3. macOS mechanism — Seatbelt (SBPL)
 
 Wrap as `sandbox-exec -p <profile> sh -c <command>`. A full `(deny default)`
-profile aborts most binaries (dyld/`/dev`/mach lookups it can't predict), so the
-profile uses an **`allow default` base** and tightens just the axes we care
-about — which proved robust in practice while still enforcing the boundary:
+profile aborts most binaries (dyld / `/dev` / mach lookups it can't predict), so
+the profile uses an **`allow default` base** and tightens just the axes we care
+about:
 
 ```scheme
 (version 1)
@@ -114,115 +99,91 @@ about — which proved robust in practice while still enforcing the boundary:
 
 Writes are a strict allowlist (deny-all then re-allow roots; the later, more
 specific rule wins). Reads are confined **within `$HOME`**: everything under
-`$HOME` is denied except the read roots, which protects every home secret
-(`~/.ssh`, `~/.aws`, …) while system paths (`/usr`, `/System`) stay readable via
-`allow default`. (This is the one place macOS is looser than Linux: Linux's
-Landlock enforces a *full* read allowlist; macOS confines reads to `$HOME`.)
+`$HOME` is denied except the read roots, protecting every home secret while
+system paths (`/usr`, `/System`) stay readable via `allow default`. This is the
+one place macOS is looser than Linux: Linux's Landlock enforces a *full* read
+allowlist; macOS confines reads to `$HOME`.
 
-`sandbox-exec` is marked deprecated by Apple but has no replacement and remains
-functional; it's the mechanism other agent tools use on macOS. `Available()`
-checks the binary exists.
+`sandbox-exec` is Apple-deprecated but has no replacement and remains functional;
+it's the mechanism other agent tools use on macOS. `Available()` checks the
+binary exists.
 
-## 5. Linux mechanism — Landlock + seccomp re-exec shim
+## 4. Linux mechanism — Landlock + seccomp re-exec shim
 
-Landlock and seccomp must be applied to the **child** *after* fork and *before*
-exec — Go's `os/exec` gives no hook there. Standard solution: a **self re-exec
-shim**.
+Landlock and seccomp must apply to the **child** after fork and before exec —
+`os/exec` gives no hook there, so octo re-execs itself: the hidden subcommand
+`octo __sandboxed-exec` (`sandbox.ShimMain`, dispatched in `cmd/octo/main.go`) receives
+the policy and the real command, and before running anything else:
 
-- A hidden subcommand, `octo __sandboxed-exec`, receives the policy (JSON via an
-  env var or a fd) and the real command.
-- In that child, before running anything else, it:
-  1. applies a **Landlock** ruleset (`github.com/landlock-lsm/go-landlock`,
-     pure Go) granting read/read-exec on ReadRoots and read-write on WriteRoots;
-  2. if `AllowNetwork=false`, installs a minimal **seccomp** BPF filter (pure
-     Go via `golang.org/x/sys/unix` `prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER)`,
-     no cgo) that **denies `socket(2)` for `AF_INET`/`AF_INET6`** (filtering on
-     the domain arg) while allowing `AF_UNIX`;
-  3. `syscall.Exec`s `sh -c command`.
+1. applies a **Landlock** ruleset granting read/read-exec on ReadRoots and
+   read-write on WriteRoots — via **raw Landlock syscalls on
+   `golang.org/x/sys/unix`** (`SYS_LANDLOCK_CREATE_RULESET` / `ADD_RULE` /
+   `RESTRICT_SELF`); no third-party library, no cgo;
+2. if `AllowNetwork=false`, installs a minimal **seccomp** BPF filter (also via
+   `x/sys/unix` `prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER)`) that denies
+   `socket(2)` for `AF_INET`/`AF_INET6` (filtering on the domain arg) while
+   allowing `AF_UNIX`;
+3. `syscall.Exec`s `sh -c command`.
 
-`sandbox.Command` on Linux therefore returns
-`exec.Command(self, "__sandboxed-exec", …)` where `self = os.Executable()`.
+So `sandbox.Command` on Linux returns `exec.Command(self, "__sandboxed-exec", …)`
+with `self = os.Executable()`. `Available()` probes Landlock via
+`LANDLOCK_CREATE_RULESET_VERSION` (ABI ≥ 1 → supported; ENOSYS/EOPNOTSUPP →
+kernel < 5.13 or Landlock disabled).
 
-`Available()` on Linux probes Landlock support (attempt to create a ruleset;
-ENOSYS/EOPNOTSUPP → unavailable, i.e. kernel < 5.13 or Landlock disabled).
+Notes:
 
-Notes / risks:
 - Network deny via seccomp socket-domain filtering is unprivileged and portable;
-  a network *namespace* would need a user namespace (often restricted), so
-  seccomp is the primary route. DNS is also blocked (it needs `AF_INET`), which
-  is the intended outcome under `AllowNetwork=false`.
-- seccomp can inspect scalar syscall args (domain) but not memory; filtering on
+  a network *namespace* would need a user namespace (often restricted). DNS is
+  also blocked (needs `AF_INET`), the intended outcome under `AllowNetwork=false`.
+- seccomp inspects scalar syscall args (domain) but not memory; filtering on
   `socket`'s domain is sufficient and pointer-safe.
-- Landlock is path-based and unprivileged; no namespaces required.
+- Landlock is path-based and unprivileged; no namespaces required. A known gap:
+  32-bit/compat syscalls can bypass a seccomp filter written for the native ABI.
 
-## 6. Availability & fallback
+## 5. Network: all-or-nothing
 
-`Available()==false` (kernel < 5.13, Landlock off, `sandbox-exec` missing,
-Windows):
-- **`--sandbox` explicitly requested → fail-closed**: refuse to run `terminal`,
-  with a clear message (the user asked for a guarantee we can't provide).
-- **`--sandbox=auto` (future) → warn once, fall back** to permission-engine-only.
+The network story is the `--sandbox-allow-net` toggle, not a per-host allowlist.
+Per-host filtering isn't feasible as a hard OS boundary: Linux seccomp can't
+inspect `connect()`'s destination (sockaddr is a pointer), and macOS SBPL filters
+by IP/port, not hostname. The only routes are a local HTTP(S) proxy (a *soft*
+allowlist, bypassable by raw-socket tools) or a network-namespace + NAT setup
+(heavy, needs user namespaces, still IP-only on macOS). The toggle covers the
+practical need: "this task needs the network: on; otherwise off."
 
-## 7. Windows
+## 6. Availability, fallback, Windows
 
-No lightweight equivalent (Job Objects / AppContainer are heavyweight and
-awkward). Phase 1: **unsupported** — `--sandbox` on Windows errors at startup;
-default-off means normal use is unaffected. Revisit later if needed.
+`--sandbox` with `Available()==false` (kernel < 5.13, Landlock off, `sandbox-exec`
+missing, Windows) **fails closed**: refuse to run `terminal` with a clear message
+— the user asked for a guarantee we can't provide.
 
-## 8. Phasing
+Windows has no lightweight equivalent (Job Objects / AppContainer are heavyweight
+and awkward): `--sandbox` errors at startup. Default-off means normal use is
+unaffected.
 
-- **Phase 1 (done, #82):** `internal/sandbox` abstraction + both exec sites
-  + **FS read/write roots + network deny**, on macOS (SBPL) and Linux
-  (landlock+seccomp shim); `--sandbox` flag on `octo chat` and `octo init`;
-  `Available()` probe + fail-closed; Windows unsupported.
-- **Phase 3 (done, #84):** configurable policy — `--sandbox-allow-net`,
-  `--sandbox-write <dir>`, `--sandbox-read <dir>` extend the default policy.
-- **Phase 2 — network host allowlist: dropped (decided 2026-05-27).**
-  Per-host network filtering is not feasible as a hard boundary at the OS layer:
-  Linux seccomp can't inspect `connect()`'s destination (sockaddr is a pointer),
-  and macOS SBPL filters by IP/port, not hostname. The only routes are a local
-  HTTP(S) **proxy** (a *soft* allowlist — bypassable by raw-socket tools, only
-  honored by proxy-aware tools) or a network-namespace + slirp/NAT setup (heavy,
-  needs user namespaces, still IP-only on macOS). Cost/value and the weak
-  guarantee don't justify it. **The network story is the deny-all / allow-all
-  toggle** (`--sandbox-allow-net`), which covers the practical safety need
-  ("this task needs the network: on; otherwise off"). Revisit only if a concrete
-  per-host requirement appears.
-- **Default-on: not pursued (decided 2026-05-27).** Flipping `--sandbox`
-  default-on would break every network-needing command (`go mod download`,
-  `git fetch`, …), because the network story is an all-or-nothing toggle, not a
-  per-host allowlist. The sandbox stays **opt-in** — `--sandbox` on demand; the
-  permission engine + strict mode remain the always-on backstop. Not revisited
-  unless a fine-grained network boundary appears that would make a safe default
-  viable.
+## 7. CLI
+
+`--sandbox` plus the policy extenders, on both `octo chat` and `octo init`:
+
+- `--sandbox-allow-net` — permit IP networking.
+- `--sandbox-write <dir>` — add a writable root (repeatable).
+- `--sandbox-read <dir>` — add a readable root (repeatable).
+
+## 8. Dependencies
+
+No third-party sandbox library. Landlock and the seccomp filter are hand-rolled
+on `golang.org/x/sys/unix` (already a dependency); macOS shells out to the
+system `sandbox-exec`. The single-binary ethos holds.
 
 ## 9. Testing
 
-OS-specific and not fully coverable in one CI runner. Plan:
+OS-specific, not fully coverable in one CI runner:
+
 - `//go:build darwin` / `linux` / `other` split implementations; a portable
   `Available()`-gated path.
-- Capability-gated integration tests that run **only** where the mechanism
-  works (skip otherwise): assert "write a file **inside** cwd succeeds", "write
-  **outside** cwd (e.g. `$HOME/x`) fails", "read `~/.ssh/known_hosts` fails",
-  and (network) "`curl`/a TCP connect fails" under `AllowNetwork=false`.
-- Windows / old-kernel: test the **fail-closed** branch (Available()==false →
+- Capability-gated integration tests that run only where the mechanism works:
+  "write inside cwd succeeds", "write outside cwd (`$HOME/x`) fails", "read
+  `~/.ssh/known_hosts` fails", and "a TCP connect fails" under `AllowNetwork=false`.
+- Windows / old-kernel: the **fail-closed** branch (`Available()==false` →
   `Command` errors / startup refuses).
 - The re-exec shim is exercised by spawning the test binary's own
   `__sandboxed-exec` path.
-
-## 10. New dependencies
-
-- `github.com/landlock-lsm/go-landlock` (pure Go, Linux only via build tags).
-- seccomp filter hand-rolled on `golang.org/x/sys/unix` (no cgo).
-- macOS/Windows pull in neither (build-tagged out).
-
-## 11. Task breakdown (Phase 1)
-
-1. `internal/sandbox`: `Policy`, `DefaultPolicy`, `Command`, `Available` + the
-   build-tagged darwin/linux/other files.
-2. macOS SBPL profile generator + `sandbox-exec` wrapper.
-3. Linux landlock+seccomp + the `octo __sandboxed-exec` hidden subcommand.
-4. `tools.SetSandbox` + both exec sites consult `activeSandbox`.
-5. `--sandbox` flag on `chat` and `init`; build `DefaultPolicy(cwd)`; call
-   `SetSandbox`; fail-closed when unavailable.
-6. Tests (capability-gated integration + fail-closed unit).

--- a/dev-docs/c9-phase3-hindsight.md
+++ b/dev-docs/c9-phase3-hindsight.md
@@ -1,15 +1,15 @@
-# C9 Phase 3 — Hindsight (and other retrieval layers) integration
+# 检索层接入 — Hindsight(及其他检索层)
 
-> 设计依据：`c9-memory-design.md` §8。PR #118 落地了 hook 机制；本文是
-> "怎么把 Hindsight（或任何检索层）接进来" 的实操手册。
+> 设计依据：`c9-memory-design.md` §6（检索经 hook 出核心）。本文是"怎么把 Hindsight
+> （或任何检索层）接进来"的实操手册。
 
-C9 Phase 1+2 给了 octo **typed 写入 + 整合 + summary 注入**，但没有
-**检索**。设计上检索就不进 harness 核心——它经 Phase 3 的 hook 插件机制叠加，
+C9 typed memory 给了 octo **typed 写入 + 整合 + summary 注入**，但没有
+**检索**。设计上检索就不进 harness 核心——它经 hook 插件机制叠加，
 不装 Hindsight 仍能用 typed memory，装了多一路召回。
 
 ## 1. Hook surface 简要
 
-PR #118 在 REPL 的每一 turn 边界各暴露一个 hook：
+REPL 在每一 turn 边界各暴露一个 hook：
 
 | Hook | 触发 | 输入 (stdin) | 输出 (stdout) | 作用 |
 |---|---|---|---|---|
@@ -116,7 +116,7 @@ export OCTO_HOOK_TIMEOUT=2s
                        │  2. InjectContext()                  │
                        │     <user input>                     │
                        │     ---                              │
-                       │     Additional context (from hook):  │
+                       │     Additional context (from pre-turn hook):
                        │     <recall result>                  │
                        │                                      │
                        │  3. RunStream(turnInput, …)          │
@@ -131,7 +131,7 @@ export OCTO_HOOK_TIMEOUT=2s
                        └─────────────────────────────────────┘
 ```
 
-C9 Phase 1+2 的 `memory_summary.md` injection 仍然走 `prompt.Compose`
+C9 的 `memory_summary.md` injection 仍然走 `prompt.Compose`
 （system prompt 冻结 prefix）；hook 注入是 **per-turn 用户消息附加**，
 两者正交。Hindsight 召回的内容只影响当前 turn，不进 system prompt
 缓存——所以 cache key 不动，prompt 缓存仍有效。
@@ -142,8 +142,8 @@ C9 Phase 1+2 的 `memory_summary.md` injection 仍然走 `prompt.Compose`
   指向一个 wrapper script，wrapper 里 `tee /tmp/hook-stdin > /dev/null` 抓输入。
 - **hook 错误**：octo 在 stderr 打 `↳ pre-turn hook: <err>`（含 stderr tail，
   截断到 200 字符）。timeout 会显示成 `timed out after 2s`。
-- **hook 把 turn 拖慢了**：调小 `OCTO_HOOK_TIMEOUT`（最低 1s）；或在
-  pre 脚本里加 fail-fast 短路。
+- **hook 把 turn 拖慢了**：调小 `OCTO_HOOK_TIMEOUT`（任何 >0 的时长都接受，如 `500ms`；
+  上限 30s）；或在 pre 脚本里加 fail-fast 短路。
 - **Hindsight 不在线**：脚本里 `|| true` 让 recall 失败时返空 stdout，
   octo 当无召回处理，turn 正常推进。
 
@@ -161,14 +161,11 @@ Hook 是协议无关的——任何能 shell 调的检索层都能接：
 约束就两条：1) 在 timeout 内返回；2) stdout 是给模型看的纯文本或
 `{additional_context: ...}` JSON。
 
-## 7. MCP client 路径（未排期）
+## 7. MCP client 路径(备选)
 
-c9-memory-design.md §8 留了另一条路：让 octo 实现 MCP client，直接调
-Hindsight 的 `agent_knowledge_*` tools。优点是协议化、能复用其他 MCP
-server；代价是 MCP client 本身是更大的独立工作。
-
-当前 hook 路径已经够用——如果未来有强需求（比如同时接多个 MCP server），
-再做 client。这俩不冲突：可以并存，配置文件里指定每个 turn 走哪条路。
+另一条路:让 octo 经 MCP client 直接调 Hindsight 的 `agent_knowledge_*` tools。优点是
+协议化、能复用其他 MCP server;代价是 MCP client 是更大的独立工作。hook 路径已够用,两者
+不冲突、可并存(配置指定每个 turn 走哪条)。
 
 ## 8. 不做（boundary）
 
@@ -178,13 +175,5 @@ server；代价是 MCP client 本身是更大的独立工作。
   turn-level context。两者目的不同，存储不同，调用时机不同。
 - **Hindsight 失败不影响 typed memory**。即使 hook 超时 / 失败，
   `remember` 还在工作，下次 session 启动还会 inject summary。
-- **不替换原生路径**。Phase 3 是叠加层。`OCTO_HOOK_PRE_TURN` 不设
-  → 走纯原生路径（`remember` + 启动整合）。
-
-## 9. Roadmap
-
-- ✅ Hook 机制（PR #118）
-- ✅ 本文档（PR #119）
-- ⏳ 真实 Hindsight 实例跑通端到端（依赖用户本地装 Hindsight）
-- ⏳ 可选：layered config (`~/.octo/hooks.yml`) 取代纯 env vars。
-- ⏳ 可选：MCP client（另开 milestone）
+- **不替换原生路径**。检索是叠加层。`OCTO_HOOK_PRE_TURN` 不设 → 走纯原生路径
+  （`remember` + 启动整合）。

--- a/dev-docs/identity-files-design.md
+++ b/dev-docs/identity-files-design.md
@@ -12,13 +12,10 @@
 - `~/.octo/soul.md` —— agent 的身份、人格、行为规范。
 - `~/.octo/user.md` —— 用户的个人信息 / 画像。
 
-本轮范围（已与用户对齐）：
+用户手写这两个文件,会话启动时注入冻结的 system prompt prefix。仅用户级
+(`~/.octo/`,跨项目),符合 openclaw/hermes 的身份范式。纯 Compose 注入层,独立于 C9。
 
-- ✅ **手写 + 启动注入**：用户手写这两个文件，会话启动时注入冻结的 system prompt prefix。
-- ✅ **仅用户级**（`~/.octo/`，跨项目）—— 符合 openclaw/hermes 的身份范式。
-- ✅ **纯 Compose 注入层**，很轻；独立于 C9，可单独先做。
-- ❌ **项目级 soul/user**（不同 repo 不同 persona）—— 后续再议。
-- ❌ **管理/编辑 skill** —— 后续用 M7 skill loader 做（见 §7），不在本轮。
+范围外:项目级 soul/user(不同 repo 不同 persona);管理/编辑 skill(可用 skill loader 做,见 §7)。
 
 ## 2. 与现有来源的分工
 
@@ -63,8 +60,8 @@ persona 与行为风格，但**不应覆盖** base 的硬规范（read-before-wr
 - 这是**软约束**：注入顺序让 soul 在 base 之后，LLM 倾向后文优先，所以 persona 层 soul
   说了算；但 base 的安全规范靠其措辞 + 用户不在 soul 里写「忽略安全规范」来维持，不做技术
   强制。
-- 若日后需要硬保证，再把 base 拆成「persona 段（soul 前）+ 不可覆盖的安全段（最末）」。
-  本轮不做（过度设计）。
+- 若日后需要硬保证，再把 base 拆成「persona 段（soul 前）+ 不可覆盖的安全段（最末）」——
+  当前不做(过度设计)。
 
 ## 6. 与 C9 的协调
 
@@ -75,29 +72,12 @@ persona 与行为风格，但**不应覆盖** base 的硬规范（read-before-wr
 - 注入顺序里 `user.md` 紧跟 `memory`，二者相邻，便于模型把"手写画像 + 自动观察"作为一组
   用户上下文理解。
 
-## 7. 后续：管理/编辑 skill（不在本轮）
+## 7. 管理/编辑 skill(后续)
 
-用刚落地的 M7 skill loader 做一个 skill（如 `/identity`）帮用户查看/编辑 soul.md 与
-user.md——交互式补全字段、校验、给模板。本轮只做手写 + 注入；skill 作为独立后续。
+可用 skill loader 做一个 skill(如 `/identity`)帮用户查看/编辑 soul.md 与 user.md——交互式
+补全字段、校验、给模板。当前只做手写 + 注入。
 
-## 8. 决策记录
-
-- **D1（独立于 C9）**：手写第一层 vs 自动第二层，概念分离；纯 Compose 注入，可单独交付。
-- **D2（仅用户级）**：`~/.octo/`，跨项目；项目级 persona 留后续。
-- **D3（soul 补充非覆盖）**：base 的工具/安全规范保留；soul 在 base 后重塑 persona，软约束。
-- **D4（prompt 包内直读，不加 Compose 参数）**：与 octorules 同模式；缺失跳过。
-- **D5（编辑 skill 留后续）**：用 M7 loader 做，不在本轮。
-
-## 9. 切片
-
-1. prompt 包：`soulPath` / `userProfilePath` var + `readSoul` / `readUserProfile` +
-   `Compose` 插入 soul（base 后）、user.md（memory 后、规则前）两层。+ 测试。
-2. 文档：README 加一节（`~/.octo/soul.md` / `user.md` 是什么、注入顺序、与 octorules
-   分工）。
-
-`make vet && make test`（race）+ gofmt；跨 OS `GOOS=linux/windows go build ./...`。
-
-## 10. 测试（stdlib，无外部框架）
+## 8. 测试(stdlib,无外部框架)
 
 - `prompt`：soul 在 base 之后、user.md 在 memory/skills 之后且在 octorules 之前的顺序；
   两文件缺失各自跳过、不留空分隔；与 octorules 共存时层次正确。

--- a/dev-docs/m7-skills-design.md
+++ b/dev-docs/m7-skills-design.md
@@ -1,115 +1,93 @@
-# M7 — Skill 加载器（design）
+# Skills — 加载器与默认集
 
-> 路线图源：`go-rewrite-roadmap.md` §M7、`competitive-parity-roadmap.md` C9（C9
-> 已并入 M7 track，但**本轮不实现** typed memory，只做 Skills）。
+用户在 `.octo/skills/` 下放 **Claude Code 格式**的 SKILL.md,octo 会话里发现它们、按需把
+指令喂给模型,并支持 `/<name>` 显式触发。一组精选 skill 嵌在二进制里、安装即用。
 
-## 1. 目标与范围
+100% 兼容 Claude Code 格式是硬约束:把 `~/.claude/skills/` 软链到 `~/.octo/skills/` 应能
+直接复用,无需改任何 SKILL.md。
 
-让用户在 `~/.octo/skills/` 和项目 `.octo/skills/` 下放置 **Claude Code 格式**的
-SKILL.md，octo 在会话里发现它们、按需把指令喂给模型，并支持 `/<name>` 显式触发。
+skill 是**纯指令**:正文是给模型的 markdown,模型读后用现有工具(`terminal` / `read_file`
+/ `edit_file` …)执行。loader 不执行 skill 目录里的脚本——frontmatter 的 `allowed-tools`
+等字段解析但不强制(模型仍可经 `terminal` 自行运行那些脚本,但那是模型的工具调用)。
 
-**100% 兼容 Claude Code skill 格式**是硬目标：用户应能把现有
-`~/.claude/skills/` 软链到 `~/.octo/skills/` 直接复用，无需改动任何 SKILL.md。
-
-本轮范围（已与用户对齐）：
-
-- ✅ **指令型 skill**：skill = 纯 SKILL.md，正文是给模型的 markdown 指令。模型读到
-  指令后用**现有工具**执行。
-- ✅ **两级来源**：用户级 `~/.octo/skills/` + 项目级 `<cwd>/.octo/skills/`，项目优先。
-- ✅ **渐进式披露**：清单进 system prompt，正文经 `skill` 工具按需加载。
-- ✅ **显式触发** `/<name>`、`--list-skills`、REPL `/skills`。
-- ❌ **bundled 可执行脚本**：skill 目录里的脚本不由 loader 执行（frontmatter 的
-  `allowed-tools` 等字段解析但不强制）。模型仍可经 `terminal` 自行运行 skill 目录里
-  的脚本——但那是模型的工具调用，不是 loader 的职责。
-- ❌ **C9 typed cross-session memory**：单独一轮。
-- ❌ **内置 default_skills**：留待 future（roadmap 的 `~/.octo/default_skills/`）。
-
-## 2. Skill 格式（Claude Code 兼容）
+## 1. SKILL.md 格式
 
 ```
 <root>/skills/<name>/
   SKILL.md          # YAML frontmatter + markdown 正文
-  (其它文件)         # 模板/脚本/参考——loader 不解释，正文可引用让模型 read_file
+  (其它文件)         # 模板/脚本/参考——loader 不解释,正文可引用让模型 read_file
 ```
-
-SKILL.md：
 
 ```markdown
 ---
 name: my-skill
-description: 一句话说明「何时该用这个 skill」——这是模型自主触发的唯一依据
+description: 一句话说明「何时该用这个 skill」——模型自主触发的唯一依据
 ---
 
 # 指令正文
 
-按需写给模型的步骤、约束、示例。可以引用同目录文件
-（让模型用 read_file 打开），可以要求模型用 terminal 跑命令。
+写给模型的步骤、约束、示例。可引用同目录文件(让模型 read_file),可要模型用 terminal 跑命令。
 ```
 
-解析规则（兼容优先，宽容为主）：
+解析规则(兼容优先、宽容为主):
 
-- **必需**：`name`、`description`。缺任一 → 跳过该 skill，向 stderr 记一行告警，不中断。
-- **宽容忽略**：`allowed-tools`、`license`、`metadata` 等 CC 字段一律解析不报错、不强制
-  ——保证 `~/.claude/skills/` 的 skill 原样可用。
-- **name 一致性**：以**目录名**为权威 skill 名（CC 行为）；frontmatter 的 `name`
-  仅作展示。`/<目录名>` 触发。
+- **必需** `name`、`description`,缺任一则跳过该 skill,向 stderr 记一行告警、不中断。
+- **目录名是权威 skill 名**(CC 行为);frontmatter 的 `name` 仅作展示。`/<目录名>` 触发。
+- 其余 CC 字段(`allowed-tools`、`license`、嵌套 `metadata:` 块)一律解析不报错、不强制。
+- frontmatter 用 `gopkg.in/yaml.v3` 解析到只含 `Name`/`Description` 的 struct,其余字段
+  自动忽略——这是处理 CC 嵌套 `metadata:` 块的正确方式(手写「顶层 key:value」会解坏它)。
 
-frontmatter 用 `gopkg.in/yaml.v3`（已是 go.mod 直接依赖，零新增成本）解析为 struct：
-切出首尾 `---` 之间的块，`yaml.Unmarshal` 到 `struct{ Name, Description string }`。
-未映射字段（`allowed-tools`、嵌套的 `metadata:` 块等）被自动忽略——这正是处理
-CC frontmatter 的正确方式：CC 的 `metadata:` 是**嵌套块**，手写"顶层 key:value"解析
-会解坏它，违反 100% 兼容目标。
+## 2. 三层发现与优先级
 
-## 3. 发现与来源层级
+`internal/skills` 的 `Discover(cwd)` 扫三个 root,**后扫覆盖同名**:
 
-新包 `internal/skills/`：
+```
+default   ~/.octo/skills-default/   随二进制 ship、首次运行落地(见 §4)
+   ↓ 被覆盖
+user      ~/.octo/skills/           跨项目,用户级
+   ↓ 被覆盖
+project   <cwd>/.octo/skills/        项目级,最高优先
+```
+
+任一 root 缺失都不是错误。用户覆盖某个默认 skill,只要在 `~/.octo/skills/` 放同名目录。
 
 ```go
 type Skill struct {
-    Name        string // 目录名（触发名）
-    Description string // frontmatter description（L1 清单 + 触发依据）
+    Name        string // 目录名(触发名)
+    Description string // frontmatter description(L1 清单 + 触发依据)
     Body        string // SKILL.md frontmatter 之后的正文
-    Dir         string // skill 目录绝对路径（正文引用相对文件时的基准）
-    Source      string // "project" | "user"，仅用于 --list-skills 展示
+    Dir         string // skill 目录绝对路径(正文引用相对文件时的基准)
+    Source      string // "default" | "user" | "project",用于 list 展示
 }
 
 type Registry struct{ skills map[string]Skill } // 按 name 索引
 
-// Discover 扫描项目级 + 用户级目录，项目级同名覆盖用户级。
-// 任一目录缺失都不是错误（多数环境不会两个都有）。
 func Discover(cwd string) *Registry
-
 func (r *Registry) Get(name string) (Skill, bool)
-func (r *Registry) List() []Skill   // 排序稳定，project 在前
+func (r *Registry) List() []Skill
 func (r *Registry) Len() int
 ```
 
-来源顺序（后者覆盖前者，所以项目级最后扫）：
+## 3. 渐进式披露——两个集成点
 
-1. `~/.octo/skills/*/SKILL.md` — 跨项目，用户级
-2. `<cwd>/.octo/skills/*/SKILL.md` — 项目级，优先
+完整正文不进 system prompt(`Compose` 的 prefix 被 provider 缓存、session-start 冻结;
+mid-session 重注入会失效缓存,全量注入又吃满上下文)。所以分两级,与真实 Claude Code 的
+Skill 工具一致:
 
-> roadmap 原列的 `~/.octo/default_skills/`（内置）本轮不做；将来作为最低优先级的
-> 第 0 层加入即可，不影响这里的接口。
+### L1:清单进 system prompt(session start,冻结)
 
-## 4. 渐进式披露——两个集成点
+只把**清单**(每个 skill 的 name + description)放进 system。渲染逻辑在
+`internal/skills.RenderManifest(r)`(不放 prompt 包,保持 prompt 不依赖 skills)。caller
+(chat.go)session start 调 `Discover` → `RenderManifest` → 传入 `Compose` 的 skills 层。
+resume 路径同样重新发现 skills——清单随当前磁盘状态重算,不随会话固化。
 
-这是与 roadmap 早期草图（"读取 SKILL.md → 注入 system prompt"）的**关键偏离**，理由见 §8 D1。
+清单层在 Compose 里的位置(skills 是能力说明,紧跟 base/env、在用户身份与规则之前):
 
-### L1：清单进 system prompt（session start，冻结）
+```
+base → soul → env → skills → memory → user.md → octorules(user) → octorules(project) → --system
+```
 
-`internal/prompt/Compose` 的 prefix 被 provider 缓存、且**必须 session-start 冻结**
-（见 `prompt.go` 包注释）。所以只把**清单**（每个 skill 的 name + description，几十字）
-放进 system，正文不放。
-
-- `Compose` 新增一个参数 `skills string`（已渲染好的清单文本），空串则跳过该层。
-- 渲染逻辑放在 `internal/skills`（`RenderManifest(r *Registry) string`），**不**放
-  prompt 包——保持 prompt 包不依赖 skills 包（单向依赖）。caller（chat.go）在 session
-  start 调 `skills.Discover` → `RenderManifest` → 传入 `Compose`。
-- 层位置：`base → env → **skills 清单** → user octorules → project .octorules → --system`。
-  清单是"能力说明"，性质近工具说明，紧跟 base/env、在用户规则之前。
-
-清单文本形如：
+清单文本形如:
 
 ```
 # Available skills
@@ -119,126 +97,60 @@ to load the full instructions before acting. The user can also trigger one
 directly by typing /<name>.
 
 - code-review: Review the current diff for correctness and cleanups.
-- deploy: Push a service branch to a Klook test env via Lark bot.
+- worktree-isolate: Do risky work in an isolated git worktree.
 ```
 
-Resume 路径（chat.go:184 的 `prompt.Compose(sess.System, cwd, env)`）同样要带上当前
-发现的 skills——skill 清单随当前磁盘状态重算，不随会话固化。
+### L2:正文经 `skill` 工具加载(按需,进 history)
 
-### L2：正文经 `skill` 工具加载（按需，进 history）
+`internal/tools/skill.go` 的 `SkillTool`:`Definition` 名为 `skill`、参数 `{name}`;
+`Execute` 返回该 skill 的 Body 作 **tool_result 进 history**——位于缓存 prefix 之后,不污染
+冻结的 system,且天然纳入压缩 / 会话持久化。
 
-`internal/tools/skill.go`：
+registry 经包级 `tools.SetSkills(*skills.Registry)` 注入,`SkillTool{}` 零值从单例取数
+(同 `TerminalTool` 的 `defaultBg`)。`DefaultTools()` **仅在发现 ≥1 skill 时** append
+skill 工具——没有 skill 时模型不该看到空工具。
 
-```go
-type SkillTool struct{} // 零值；经包级 registry 取数（见下）
-
-func (SkillTool) Definition() agent.ToolDefinition // name="skill", 参数 {name: string}
-func (SkillTool) Execute(ctx, _, input) (string, error) // 返回该 skill 的 Body
-```
-
-- 工具返回 SKILL.md 正文，作为 **tool_result 进 history**——位于缓存 prefix 之后，
-  不污染冻结的 system，且天然纳入压缩/会话持久化。
-- registry 注入沿用 `sandbox.go` 的 `SetSandbox` 模式：包级
-  `tools.SetSkills(*skills.Registry)`，`SkillTool{}` 零值从包级单例取数。与
-  `TerminalTool` 的 `defaultBg` 一致。
-- **仅在发现 ≥1 skill 时暴露**：`DefaultTools()` 末尾在 registry 非空时 append
-  skill 工具定义——没有 skill 时模型不该看到一个空工具。`allTools` 静态列表保持不变。
-
-### 一次 skill 使用的时序
+一次 skill 使用的时序:
 
 ```
 session start
-  skills.Discover(cwd) → Registry
-  tools.SetSkills(reg)
-  manifest = skills.RenderManifest(reg)
-  a.System = prompt.Compose(--system, cwd, env, manifest)   // L1
-  DefaultTools() 含 skill 工具（reg 非空）
-
+  skills.Discover(cwd) → Registry;tools.SetSkills(reg)
+  manifest = RenderManifest(reg);a.System = Compose(..., manifest, ...)   // L1
+  DefaultTools() 含 skill 工具(reg 非空)
 turn
-  模型看到清单，判断 description 匹配 → 调 skill{name:"code-review"}   // L2
-  tool_result = SKILL.md 正文 → 进 history
-  模型据正文用 read_file/terminal/edit_file 执行
+  模型据清单 description 匹配 → 调 skill{name:"code-review"}              // L2
+  tool_result = SKILL.md 正文 → 进 history → 模型据正文用工具执行
 ```
 
-## 5. 显式触发 `/<name>`
+## 4. 默认集(嵌入 + 首次落地)
 
-`repl.go` 现有 slash 派发是硬编码 switch（`/help`、`/cost`…），`/init` 是特例：改写
-`line` 为 `initInstruction` 后 fall through 到 turn machinery。
+随二进制 ship 一组精选 skill,安装即用,详见 `default-skills-design.md`。要点:
 
-`/<name>` 复用同一模式：在 switch 的 `default` 分支（"Unknown command"之前）先查 skill
-registry：
+- 源在 `internal/skills/defaults/<name>/SKILL.md`,`//go:embed` 烤进二进制。
+- 启动时 `MaterializeDefaults(version)` 把它们写到 `~/.octo/skills-default/`,版本戳 no-op,
+  版本升级整目录重写。独立目录,刷新不碰用户 skill。
+- 嵌入(非远程下载)→ 离线可用、版本锁定二进制。
 
-- 命中 `/foo [args]` → `line = skill.Body`（args 非空则追加为 `\n\n用户附加输入：<args>`），
-  fall through 到 turn——**直接把正文喂给模型，省掉一次 skill 工具往返**。
-- 未命中 → 保持现有 `Unknown command %q` 行为。
+## 5. 显式触发与 CLI
 
-两条路（模型自主调 skill 工具 / 用户 `/foo` inline）最终都把正文交给模型，语义一致。
+- **`/<name> [args]`**(REPL):命中 skill registry 则 `line = skill.Body`(args 非空追加为
+  用户附加输入)、fall through 到 turn——直接把正文喂模型,省一次 skill 工具往返。与模型
+  自主调 skill 工具并存,语义一致。未命中保持 `Unknown command`。
+- **`octo skills list|update|path`**:`list` 按来源(default → user → project)列出;
+  `update` 强制重新落地默认集;`path` 打印三个 root。
+- **`octo chat --list-skills`**:发现并打印后退出,不需 provider/key。
+- **REPL `/skills`**:列出本会话可用 skill。
 
-## 6. CLI / REPL 表面
+`base.md` 有一小节教模型:看到 system 里的 "Available skills" 清单后,当且仅当任务匹配某条
+description 时,先调 `skill` 工具加载完整指令再行动,不要凭一句描述揣测正文。
 
-- **`octo chat --list-skills`**：发现并打印（name、source、description 一行一个）后退出，
-  不需要 provider/key。与 `--list-sessions` 同形。
-- **REPL `/skills`**：列出本会话可用 skill；`printReplHelp` 增一行。
-- **`/help`**：保持，但补一句"`/<skill>` 运行某个 skill"。
+## 6. 测试(stdlib,无外部框架)
 
-## 7. base prompt 增补
-
-`internal/prompt/base.md` 增一小节，告诉模型 skill 机制怎么用：看到 system 里的
-"Available skills"清单后，**当且仅当**任务匹配某条 description 时，先调 `skill` 工具
-加载完整指令再行动；不要凭清单里的一句话描述就揣测正文。无 skill 时该节不出现
-（清单层为空），所以这段文字要在"若有 skills 清单"的语气下写，避免无 skill 时显得突兀。
-
-## 8. 决策记录
-
-- **D1（渐进式披露，非全量注入）**：roadmap 早期写"读取 SKILL.md → 注入 system
-  prompt"。本设计改为 L1 清单进 system + L2 正文进 history（经 skill 工具）。理由：
-  (a) `Compose` 的 prefix 被 provider 缓存且 session-start 冻结，mid-session 重注入会
-  对每个后续 turn 失效缓存；(b) 全量注入所有 skill 正文会无谓吃满上下文。这也正是真实
-  Claude Code 的做法（Skill 工具），所以"参考 CC"在此与 cache 约束一致，不冲突。
-- **D2（仅指令型）**：不执行 bundled 脚本；`allowed-tools` 等字段解析但不强制。保证
-  CC 格式兼容的同时，把权限模型/沙箱交互留在范围外。
-- **D3（两级来源，项目优先）**：用户级 + 项目级，无内置 default_skills（future）。
-- **D4（skill 工具按需暴露）**：发现 0 个 skill 时不注入清单层、不暴露 skill 工具。
-- **D5（`/name` inline）**：显式触发直接 inline 正文，省一次工具往返；与模型自主调
-  skill 工具并存。
-- **D6（目录名为权威触发名）**：与 CC 一致；frontmatter `name` 仅展示。
-- **D7（用 yaml.v3 解析 frontmatter）**：`gopkg.in/yaml.v3` 已是 go.mod 直接依赖，
-  零新增成本；且能正确跳过 CC 的嵌套 `metadata:` 块——手写"顶层 key:value"解析会解坏
-  它，违反 100% CC 兼容。Unmarshal 到只含 `Name`/`Description` 的 struct，其余字段忽略。
-
-## 9. 测试（stdlib + httptest，无外部框架）
-
-- `internal/skills`：
-  - `Discover`：临时目录构造两级来源；验证项目覆盖用户、缺失目录不报错、坏/缺
-    frontmatter 被跳过且不中断、目录名作 name。
-  - `RenderManifest`：稳定有序输出；空 registry → 空串。
-- `internal/tools`：
-  - `SkillTool.Execute`：命中返回正文、未命中报错。
-  - `DefaultTools`：`SetSkills` 空/非空时 skill 工具的有无。
-- `cmd/octo`：
-  - `repl` slash：`/foo` 命中 inline、未命中 Unknown command、`/skills` 输出。
-  - `--list-skills` 输出与退出码。
-  - `Compose` 第四参数（manifest）的层位置。
-
-## 10. 任务拆分
-
-垂直切，依赖序：
-
-1. **`internal/skills` 包**：`Skill`/`Registry`/`Discover`/`Get`/`List`/`RenderManifest`
-   + frontmatter 解析 + 测试。（无下游依赖，先落）
-2. **`Compose` 扩参**：加 `skills string` 层 + 测试；更新 chat.go 两处调用点
-   （新建会话 + resume）。
-3. **`skill` 工具 + `SetSkills`**：`internal/tools/skill.go` + `DefaultTools` 按需 append
-   + 测试。
-4. **CLI/REPL 表面**：`--list-skills`、`/skills`、`/<name>` 派发、chat.go session-start
-   接线（Discover → SetSkills → manifest）+ 测试。
-5. **base.md 增补** + 文档（docs/ 用户向，可并入或留到文档轮）。
-
-每步 `make vet && make test`（race）+ gofmt；跨 OS `GOOS=linux/windows go build ./...`。
-
-## 11. 不做 / 未来
-
-- C9 typed cross-session memory（独立轮）。
-- 内置 default_skills 第 0 层。
-- bundled 脚本执行 / `allowed-tools` 强制（需先有沙箱-权限的 skill 交互模型）。
-- Web/IM 界面的 skill 列举端点（roadmap §M8 `GET /api/skills`）。
+- `internal/skills`:`Discover` 三层覆盖(project > user > default)、缺失目录不报错、坏/缺
+  frontmatter 跳过、目录名作 name;`RenderManifest` 稳定有序、空 registry → 空串;
+  `MaterializeDefaults` 写嵌入 + 版本戳、同版本 no-op、版本变重写;默认 skill 被同名 user
+  skill 覆盖。
+- `internal/tools`:`SkillTool.Execute` 命中返回正文 / 未命中报错;`DefaultTools` 按 registry
+  空非空决定 skill 工具有无。
+- `cmd/octo`:`/<name>` 命中 inline / 未命中 Unknown command / `/skills` 输出;`--list-skills`
+  与退出码;`Compose` 的 skills 层位置;`octo skills` 子命令。

--- a/dev-docs/tui-input-modes-design.md
+++ b/dev-docs/tui-input-modes-design.md
@@ -1,269 +1,165 @@
-# TUI 输入模式 — Queue / Steer / Interrupt（design）
+# TUI 输入模式 — Queue / Steer / Interrupt
 
-> 给交互式 REPL 引入「回合运行时也能输入」的能力：排队（queue）、中途引导（steer）、打断（interrupt）。
-> 实现手段是把交互式 TTY 路径迁到 bubbletea 事件循环，非-TTY 保留纯文本路径。
+> 交互式 REPL 在回合运行时也能输入:排队(queue)、中途引导(steer)、打断(interrupt)。
+> 交互式 TTY 走 bubbletea 事件循环,非-TTY 与 `--no-tui` 走纯文本路径。
 
----
+## 1. 目标
 
-## 1. 目标与范围
+REPL 主循环不再是「读一行 → 阻塞跑完回合 → 再读一行」。回合运行时:
 
-### 解决的问题
+- **Steer**(裸 Enter):键入的话注入**正在跑的回合**,在下一个工具批次边界生效,引导
+  agent 改方向而不打断它。
+- **Queue**(Alt+Enter):键入的话排队,当前回合完整结束后作为新回合自动执行。
+- **Interrupt**(Esc,无模态时):停掉当前在途回合;队列保留。
 
-当前 REPL 主循环是**单 goroutine 同步阻塞**的：读一行 → `RunStream` 跑完整个 agentic 回合（全程阻塞）→ 再读下一行（`cmd/octo/repl.go:146` 的 for 循环，回合在 `:271`）。回合运行期间没人读 stdin，用户键入的字符只是停在终端缓冲里，等回合结束才被当作**下一条 prompt** 读走。
+## 2. 架构
 
-后果：用户在 agent 忙的时候**完全无法表达意图**——既不能排队下一件事，也不能在 agent 跑歪时中途纠偏。唯一能影响在途回合的手段是 Ctrl-C（`repl.go:109-132` 的信号 goroutine 取消 `turnCtx`），即已有的 interrupt。
-
-### 目标
-
-在交互式 TTY 上，回合运行时用户可以：
-
-- **Steer**（裸 Enter）：键入的话注入到**正在跑的回合**，在下一个工具批次边界生效，引导 agent 改变方向而不打断它。
-- **Queue**（Alt+Enter）：键入的话排进队列，当前回合**完整结束后**作为新回合自动执行。
-- **Interrupt**（Esc，无模态时）：停掉当前在途回合（保留已有的 Ctrl-C 语义并对齐到 Esc）。
-
-### 范围内
-
-- 交互式 TTY 的 REPL 渲染层迁到 bubbletea。
-- 抽出与渲染解耦的 **turn-core**，TTY 视图与非-TTY 纯文本视图共享。
-- permission gate / `ask_user_question` 改为 channel 请求-响应 + TUI 模态。
-- pending 缓冲（queue/steer 共用）、常驻队列区 UI。
-- `mswe-eval` 的 piped-REPL 驱动（最终评估为无需改动，见 §8）。
-- `--no-tui` 兼容性回退。
-
-### 范围外（见 §11）
-
-Web/IM 端的等价能力、pending 缓冲持久化、队列消息的富文本编辑、steer 的「立即打断重发」语义。
-
----
-
-## 2. 决策记录（grill 已定）
-
-| # | 决策 | 选择 | 理由 |
-|---|---|---|---|
-| 1 | 行为选择方式 | 单输入框、按键决定 | 三种行为在一个框里靠键区分，不引入有状态模式；对齐 Claude Code |
-| 2 | Steer 生效时机 | 下一个工具批次边界注入 | 不浪费在途工作；「手头这步做完听我一句再继续」 |
-| 3 | Steer 注入机制 | 文本作为额外 text block 并入尾部 `tool_result` 消息 | Messages API 官方支持的多-block 形态，不破 user/assistant 交替不变量 |
-| 4 | 终端输入层 | 全面上 bubbletea | line-based readline 无法在流式输出时后台读键；长期最稳，且已在 charmbracelet 生态（lipgloss） |
-| 5 | TTY/非-TTY 共存 | `stdinIsTTY()` 分流 + 共享 turn-core + 双视图；顺带迁 mswe-eval | bubbletea 需 TTY；piped/测试/CI 必须保留纯文本路径 |
-| 6 | gate / asker | channel 请求-响应 + TUI 模态，共用一套；模态 Esc = 取消单个工具、回合继续 | bubbletea 处理「后台工作需用户输入」的标准范式 |
-| 7 | 键位 | 裸 **Enter = steer**、**Alt+Enter = queue**；Esc 上下文相关 | 默认即时引导；Alt+Enter 可靠（Ctrl/Shift+Enter 终端不可靠） |
-| 8 | Steer 无边界可注入 | 自动降级为 queue | 消息永不丢；queue/steer 共享一个 pending 缓冲，仅消费时机不同 |
-| 9 | Esc 打断与 pending | Esc 只停当前回合，pending 保留作后续回合 | interrupt 收窄到在途回合，队列独立生命周期 |
-| 10 | 队列可见性 | 常驻队列区 + 逐条/全部撤回 | 配套 #9 的「pending 存活」，提供撤回安全阀 |
-| 11 | 落地策略 | 单个大 PR | 用户选择；已知风险：review 难、难二分 |
-| 12 | 回退 | 保留 `--no-tui` 强制走纯文本路径 | 兼容性兜底（dumb terminal/SSH/tmux/伪 TTY/屏幕阅读器），边际成本近零 |
-
----
-
-## 3. 架构总览
+bubbletea 的事件循环占主 goroutine,agent loop 移到后台 goroutine;两者经 `tea.Msg`
+(事件出)和 channel(请求-响应)通信。渲染与编排解耦,TTY 与纯文本两视图共享一个 turn-core:
 
 ```
                     ┌─────────────────────────────────────────┐
                     │            cmd/octo (CLI 层)              │
-                    │                                           │
    stdinIsTTY()?    │   ┌──────────────┐    ┌───────────────┐  │
-   ───────┬─────────┼──▶│  TTY 视图     │    │ headless 视图  │◀─┼── 非-TTY
-          │         │   │ (bubbletea)  │    │ (纯文本/scanner)│  │   --no-tui
+   ───────┬─────────┼──▶│  TTY 视图     │    │ headless 视图  │◀─┼── 非-TTY / --no-tui
+          │         │   │ (bubbletea)  │    │ (纯文本/scanner)│  │
           │         │   └──────┬───────┘    └───────┬───────┘  │
           │         │          │  实现 ViewSink      │          │
           │         │          └─────────┬──────────┘          │
           │         │              ┌─────▼──────┐              │
-          │         │              │  turn-core  │  ← 抽出的共享核心
-          │         │              │ (无渲染依赖) │              │
+          │         │              │  turn-core  │ (无渲染依赖)  │
           │         │              └─────┬──────┘              │
           └─────────┴────────────────────┼──────────────────────┘
                                           │ AgentEvent / 请求-响应
                           ┌───────────────▼────────────────┐
-                          │     internal/agent (后台 goroutine) │
-                          │  RunStream → runLoop（注入点在此） │
+                          │ internal/agent (后台 goroutine)  │
+                          │  RunStream → runLoop(注入点在此) │
                           └────────────────────────────────┘
 ```
 
-三层关键变化：
+三个关键件:
 
-1. **turn-core**（新）：把现有 `runREPL` 里与渲染无关的回合编排逻辑（pre/post hook、auto-save、cost gate、memory nudge、turnCtx 生命周期）抽成一个不依赖具体渲染的核心，对外暴露一个 `ViewSink` 接口（事件出、请求-响应进）。TTY 视图和 headless 视图都驱动它。
+1. **turn-core**(`cmd/octo/turncore.go`):`runREPL` 里与渲染无关的回合编排(memory nudge
+   + live-delta、pre/post hook、auto-save、turnCtx 生命周期)抽进 `runTurn`,对外只认
+   `ViewSink` 接口。TTY 视图(`tuiSink`)和纯文本视图(`plainView`)都驱动它。
+2. **agent loop 在后台 goroutine**:`tuiSink` 把 `AgentEvent` 包成 `tea.Msg` 投给 Model,
+   并经 channel 接收 steer/queue/interrupt 信号。
+3. **pending 缓冲 + 注入点**:steer 经 `Agent.Steer`,`runLoop` 在工具批次边界 drain 并入
+   tool_result;回合自然结束时若仍有 pending 则作为下一回合启动(queue / steer 降级)。
 
-2. **agent loop 移到后台 goroutine**：bubbletea 的 `tea.Program` 在主 goroutine 跑事件循环，agent 必须在 goroutine 里跑，通过 `tea.Msg` 把 `AgentEvent` 投递给 Model，通过 channel 接收 steer/queue/interrupt 信号。
-
-3. **pending 缓冲 + 注入点**：queue/steer 共用一个线程安全的 pending 缓冲；`runLoop` 在每个工具批次边界 drain 它（steer 生效），回合自然结束时若仍有内容则作为下一个回合启动（queue / steer 降级）。
-
----
-
-## 4. turn-core 抽象
-
-现状：`runREPL`（`cmd/octo/repl.go:50`）把回合编排和终端渲染**糅在一起**——`replToolEventHandler`（`cmd/octo/repl.go:590`）直接 `fmt.Fprint` 到 stdout。要双视图共享，必须先解耦。
-
-### ViewSink 接口（草案）
+## 3. turn-core / ViewSink
 
 ```go
-// turn-core 通过 ViewSink 与渲染层通信，自身不知道是 bubbletea 还是纯文本。
 type ViewSink interface {
-    // 流式事件出口（替代当前直接 Fprint 的 replToolEventHandler）。
-    Emit(ev agent.AgentEvent)
-
-    // agent 需要用户给一个结构化答复时调用，阻塞直到 ViewSink 回填。
-    // permission gate 与 ask_user_question 共用此通道（决策 #6）。
-    Ask(ctx context.Context, req UserPrompt) (UserResponse, error)
-
-    // 回合开始/结束的钩子，供视图清理输入区、刷新队列等。
+    userPrompter // Ask(ctx, UserPrompt) (UserResponse, error)
     TurnStarted()
-    TurnEnded(reply agent.Reply, err error)
+    Emit(ev agent.AgentEvent)               // 流式事件出口
+    TurnEnded(reply agent.Reply, err error) // 渲染 cache/^C/error
+    Notice(msg string)                       // 带外消息(hook 失败等)
 }
 ```
 
-- **TTY 视图**：`Emit` → 把事件包成 `tea.Msg` 投给 Program；`Ask` → 发模态请求、阻塞等 Model 回填。
-- **headless 视图**：`Emit` → 复用现有 `replToolEventHandler` 的纯文本逻辑；`Ask` → 复用现有 `cliPermissionGate` 从 stdin 读。
+- **`plainView`**:`Emit` 复用纯文本的工具事件渲染;`Ask` 从 stdin 读(行为同重构前)。backs
+  非-TTY 路径与 `--no-tui`。
+- **`tuiSink`**:`Emit` → `tea.Msg`;`Ask` → 发模态请求、阻塞等 Model 回填。
 
-turn-core 保留的现有逻辑（从 `runREPL` 平移，不改行为）：pre-turn hook（`repl.go:242-248`）、memory nudge（`repl.go:239-241`）、post-turn hook（`repl.go:290-294`）、auto-save（`repl.go:325-331`）、cost/turn 上限（已在 `runLoop`）、`turnCtx` 的创建与取消（`repl.go:224-283`）。
+`runTurn` 把回合编排集中在一处:memory nudge + 跨会话 live-delta、pre/post hook,然后
+`a.RunStream(ctx, …, sink.Emit)`,返回的 reply/err 交 `sink.TurnEnded`。caller 仍管输入读取、
+slash 命令、turnCtx、save/loop 决策。
 
----
+## 4. steer 注入与降级
 
-## 5. agent loop 的并发改造与注入点
-
-`internal/agent/runLoop`（`internal/agent/agent.go:386`）是唯一的 agentic 循环。改造点有二：
-
-### 5.1 steer 注入点（决策 #2/#3）
-
-循环每次迭代在工具批次后是 `append(tool_use, assistant)` → `append(tool_result, user)` → `continue`（`agent.go:434-455`）。因此循环顶看到的 history 在多步 loop 中**必然以 `user(tool_result)` 结尾**——这正是 steer 要落脚的地方。
-
-注入方式（决策 #3）：在 `append(NewToolResultMessage(...))` 之前 drain 一次 pending 缓冲；若有 steer 内容，把它作为**额外的 text block 拼进 tool_result 消息的 blocks**，而不是新起一条 user 消息（避免连续两条 user role 破坏交替不变量）。
+`runLoop` 每次工具批次后 history 以 `user(tool_result)` 结尾——这是 steer 唯一能落脚的地方。
+在 append tool_result 之前 drain steer,把文本作为**额外 text block 并进同一条 tool_result
+消息**(而非新起一条 user 消息,否则连续两条 user role 破坏交替不变量;多-block 的
+`[tool_result…, text]` user 消息是 Messages API 官方形态):
 
 ```go
-// runLoop 内，构造 tool_result 消息时：
 resultBlocks := /* dispatchTools 产出 */
 if steer := a.drainSteer(); steer != "" {
-    resultBlocks = append(resultBlocks, TextBlock(steer))  // 并入同一条 user 消息
+    resultBlocks = append(resultBlocks, NewTextBlock(steer))
 }
 a.History.Append(NewToolResultMessage(resultBlocks))
 ```
 
-- pending 缓冲由 cmd/octo 经一个 channel 或 `Agent` 上的线程安全方法注入；`runLoop` 在自己的 goroutine 里 drain，**无数据竞争**（`History` 本身也有 `sync.RWMutex` 兜底，见 `internal/agent/history.go`）。
-- **降级（决策 #8）**：若回合走到终止（模型不再 tool_use，`agent.go:458-468`）时 pending 仍有内容，turn-core 在 `TurnEnded` 后把它作为下一个回合的 userInput 启动 —— 这就是 queue / steer-无边界 的统一兜底。
+`Agent.Steer` 从 UI goroutine 写、`runLoop` 在自己 goroutine drain,无数据竞争(History 也有
+`sync.RWMutex` 兜底)。OpenAI 适配器把这条 user 消息的 tool_result 拆成 `role:"tool"` 消息、
+text block 作随后的 `role:"user"` 消息(对齐 Anthropic 的多-block 形态)。
 
-### 5.2 interrupt（决策 #9）
+**降级**:回合走到终止(模型不再 tool_use)时若仍有 pending steer,turn-core 在回合结束后把
+它作为下一回合启动——这就是 steer-无边界 / queue 的统一兜底。
 
-沿用现有机制：每回合独立 `turnCtx`，Esc（无模态）调用 `turnCancel()`，`runLoop` 在迭代边界检测 `ctx.Err()` 并走 `finishInterrupted`（`internal/agent/agent.go:492`）把 history 收尾成 well-formed。
+## 5. interrupt
 
-**关键差异**：Esc 只取消 `turnCtx`，**不动 pending 缓冲**——pending 消息存活，turn-core 在 interrupt 收尾后照常消费它们作为后续回合。
+每回合独立 `turnCtx`。Esc(无模态)取消它,`runLoop` 在迭代边界检测 `ctx.Err()` 走
+`finishInterrupted` 把 history 收尾成 well-formed。**Esc 只取消 turnCtx,不动 pending**——
+pending 存活,turn-core 收尾后照常消费为后续回合。
 
----
+## 6. permission gate / ask_user_question
 
-## 6. permission gate / ask_user_question（决策 #6）
-
-现状：`cliPermissionGate`（接到 `a.Gate`，`repl.go:138-144`）和 asker 在 `RunStream` 内部**同步**从共享 reader 读 stdin。bubbletea 接管后 stdin 归事件循环独占，且 agent 在后台 goroutine，必须改成跨 goroutine 的请求-响应。
+bubbletea 接管 stdin、agent 又在后台 goroutine,所以审批/提问改成跨 goroutine 的请求-响应,
+经 `ViewSink.Ask`(gate 与 asker 共用):
 
 ```
 agent goroutine                     bubbletea 主 goroutine
-─────────────                       ──────────────────────
-gate.Ask(req)                       Update: 收到 UserPrompt
-  └─ send req → ViewSink.Ask        └─ 进入模态状态，View 渲染选项卡
-       (阻塞在 respCh)               用户按键选择 / Esc
-                                     └─ 写 respCh ← UserResponse
-  ←── 解除阻塞，继续 dispatch
+gate.Ask(req) ── 发 UserPrompt ──▶  Update: 进模态,View 渲染选项
+     (阻塞在 respCh)                 用户选择 / Esc → 写 respCh
+     ◀── 解除阻塞,继续 dispatch
 ```
 
-- gate 与 asker **共用** `ViewSink.Ask` 这一通道（两者本质都是「agent 暂停、等一个结构化答复」）。
-- **模态 Esc = 取消这一个工具**（决策 #6）：`Ask` 返回一个「拒绝/取消」响应，`dispatchTools` 据此合成 `is_error` 的 tool_result，回合继续。这与「无模态 Esc = interrupt 整个回合」靠**有无模态**的上下文区分，不冲突。
-- headless 视图的 `Ask` 退回现有 stdin 读法，行为不变。
+`UserPrompt`/`UserResponse`/`userPrompter` 在 `cmd/octo/prompt.go`。**模态 Esc = 取消这一个
+工具**(`Ask` 返回取消,`dispatchTools` 合成 is_error tool_result,回合继续),与「无模态
+Esc = interrupt 整回合」靠有无模态区分。纯文本视图的 `Ask` 退回 stdin 读法。
 
----
+问答模态首版:选中 "Other(自由文本)" 视作取消(模型可重问或自取默认);纯文本路径仍支持
+Other 自由文本输入。
 
-## 7. 键位与 UX（决策 #7/#9/#10）
+## 7. 键位
 
-| 键 | idle（无回合） | 回合运行中（无模态） | 模态打开时 |
+| 键 | idle(无回合) | 回合运行中(无模态) | 模态打开时 |
 |---|---|---|---|
-| 裸 **Enter** | 提交，开新回合 | **steer**：注入 pending，下一边界生效（无边界→降级 queue） | 确认当前选项 |
-| **Alt+Enter** | （同 Enter） | **queue**：排进 pending，回合结束后作新回合 | — |
-| **Esc** | 清空当前输入行 | **interrupt**：停当前回合，pending 保留 | **取消单个工具**，回合继续 |
-| **Ctrl-C** | 保存并退出 | interrupt（同 Esc）；连按可退出 | 取消工具 |
-| **Ctrl-D** | EOF 退出 | — | — |
+| 裸 **Enter** | 提交,开新回合 | **steer**:注入 pending,下一边界生效(无边界→降级 queue) | 确认当前选项 |
+| **Alt+Enter** | (同 Enter) | **queue**:排队,回合结束后作新回合 | — |
+| **Ctrl+X** | — | **撤回**最近排队项(连按清空) | — |
+| **Esc** | 清空当前输入行 | **interrupt**:停当前回合,pending 保留 | **取消单个工具**,回合继续 |
+| **Ctrl+C** | 保存并退出 | interrupt | 取消工具 |
+| **Ctrl+D** | 退出 | — | — |
 
-修饰键选择：**Alt+Enter**（raw mode 下是 `ESC`+`CR`，bubbletea 可靠检测），不用 Ctrl+Enter / Shift+Enter（终端普遍发与 Enter 相同的码）。
+`Alt+Enter` 在 raw mode 下是 `ESC`+`CR`、bubbletea 可靠检测;不用 Ctrl+Enter / Shift+Enter
+(终端普遍发与 Enter 相同的码)。`Ctrl+X` 是队列撤回安全阀——因为 Esc 只停回合、不清队列,
+排错的 queue 靠它取消。
 
-### 常驻队列区（决策 #10）
+常驻队列区列出所有 pending、显示消费顺序;状态行在队列非空时提示 `Ctrl+X unqueue`。pending
+为会话内瞬态,不持久化。
 
-```
-┌─ 对话区（流式输出 + 工具事件 + card）──────────────┐
-│ …assistant text…                                   │
-│ ↳ terminal: go test ./...                          │
-│ …                                                  │
-├─ 队列 (2) ─────────────────────────────────────────┤
-│  1. [queue] 跑一下 lint                            │
-│  2. [steer] 顺便把错误分支也覆盖到                  │  ← Ctrl-X 删选中 / Ctrl-Shift-X 清空
-├─ 输入区 ───────────────────────────────────────────┤
-│ you> _                                             │
-└────────────────────────────────────────────────────┘
-```
-
-- 队列区列出所有 pending，标注 `[queue]`/`[steer]`，显示消费顺序。
-- 撤回：删最后一条 / 选中删 / 清空（具体键位 tech-design 细化）。
-- pending 为**会话内瞬态**，不持久化——丢了可重打（见 §11）。
-
----
-
-## 8. TTY / 非-TTY 分流与 mswe-eval（决策 #5/#12）
+## 8. TTY / 非-TTY 分流
 
 ```go
-// cmd/octo 选择视图：
-switch {
-case forceNoTUI:                 // --no-tui / OCTO_TUI=0
-    view = newPlainView(...)     // 复用现有纯文本渲染
-case stdinIsTTY(os.Stdin):       // lineread.go:121
-    view = newTUIView(...)       // bubbletea
-default:                         // 管道 / 测试 / CI
-    view = newPlainView(...)
-}
-runTurnCore(turnCore, view)      // 同一 core，不同 sink
+useTUI := isREPL && stdinIsTTY(stdin) && !*noTUI && !tuiDisabledByEnv() && seedPrompt == ""
 ```
 
-- **headless 路径必然保留**（mswe-eval、测试用 `strings.Reader`、`octo chat "msg"` 单发、管道）。`--no-tui` 只是让 TTY 也强制走它，兼容性兜底。
-- **mswe-eval（最终：不迁移）**：它靠「piped stdin 驱动 REPL」（`cmd/mswe-eval/main.go` 的 `runStdin`，喂 `octoPrompt+"\n"` + EOF）。最初担心这条路会被 TUI 取代而脆弱，计划改成专用 headless 入口。落地时发现**没必要**：`useTUI = isREPL && stdinIsTTY && !--no-tui`，管道 stdin 的 `stdinIsTTY` 恒为 false，必然路由到 plain `runREPL`（scanner + plainView），bubbletea 永不激活。plain path 现在是一等公民且经测试,piped-REPL 契约完整保留。再加一个 `--headless` flag 属于 YAGNI,故不做。
+为真 → `runTUI`(bubbletea);否则 → `runREPL`(scanner + `plainView`)。`--no-tui` /
+`OCTO_TUI=0` 强制纯文本(dumb terminal / SSH / tmux / 屏幕阅读器兜底);`--prompt-file`
+(`seedPrompt`)的非交互单发也走纯文本。
 
----
+**非-TTY 必然走纯文本**:管道 stdin 的 `stdinIsTTY` 恒 false,所以 `mswe-eval`(piped-REPL
+驱动)、测试(`strings.Reader`)、CI 都走 `runREPL`,bubbletea 永不激活——piped-REPL 契约
+天然保留,无需专用 headless 入口。
 
-## 9. 测试（stdlib + httptest，无外部框架）
+## 9. 依赖
 
-- **turn-core**：用一个 mock `ViewSink` 断言事件序列、`Ask` 请求-响应、pending 消费时机；不依赖终端。这是双视图共享逻辑的主战场。
-- **pending/注入**：构造一个会产 tool_use 的 mock Sender，断言 steer 文本被并进 tool_result 消息的 blocks（不产生连续两条 user role）；断言无边界时降级为后续回合。
-- **interrupt 与 pending 存活**：cancel `turnCtx`，断言当前回合走 `finishInterrupted` 且 pending 仍被后续消费。
-- **headless 路径回归**：现有 scanner-based REPL 测试（`strings.Reader` 喂 stdin、断言 stdout 序列）继续绿，保证 `--no-tui` / 非-TTY 行为不变。
-- **bubbletea 视图**：用 `teatest`（charmbracelet 官方测试工具）驱动 Model，断言键位映射与模态状态机；不接真实 TTY。
-- **gate/asker 请求-响应**：mock ViewSink 验证模态 Esc → 单工具取消 → 回合继续。
+- `github.com/charmbracelet/bubbletea` — 事件循环。
+- 已有:`lipgloss`(渲染)、`go-isatty`(TTY 探测)、`chzyer/readline`(纯文本路径的 idle 行编辑)。
 
----
+输入行手写(逐 rune + backspace),**不依赖** `bubbles`;Model 逻辑经 `Update` 直接单测,
+**不依赖** `teatest`。
 
-## 10. 新增依赖
+## 10. 测试(stdlib,无外部框架)
 
-- `github.com/charmbracelet/bubbletea` — TUI 事件循环。
-- `github.com/charmbracelet/bubbles`（可选）— 现成的 textinput/viewport 组件。
-- `github.com/charmbracelet/x/exp/teatest`（test-only）— Model 测试。
-- 已有：`lipgloss`（渲染）、`go-isatty`（TTY 探测）。`chzyer/readline` 在 `--no-tui`/headless 仍保留，或评估能否退场（idle 行编辑由 bubbletea textinput 接管后）。
-
----
-
-## 11. 任务拆分（单 PR，决策 #11）
-
-单 PR 落地，内部按以下顺序构建（实际落地状态标注于后）：
-
-1. ✅ **抽 turn-core**（`cmd/octo/turncore.go`）：`runREPL` 的回合编排与渲染解耦，定义 `ViewSink`，`plainView` 等价适配。零行为变更，既有测试全绿。
-2. ✅ **agent loop 注入点**（`internal/agent/steer.go` + `runLoop`）：`Agent.Steer`/`DrainSteer`/`HasPendingSteer`；steer 在工具批次边界并入尾部 tool_result；回合末降级。同时修了 OpenAI 适配器丢弃 text block 的 bug。
-3. ✅ **gate/asker 请求-响应化**（`cmd/octo/prompt.go`）：`UserPrompt`/`UserResponse`/`userPrompter`，折入 `ViewSink.Ask`；plainView.Ask 保留 stdin 行为不变。
-4. ✅ **bubbletea TTY 视图**（`cmd/octo/tuirepl.go` + `tuirepl_view.go`）：`runTUI` + `tuiModel` + `tuiSink`；键位（§7）；`AgentEvent`→`tea.Msg`；queue 面板 + 模态。Model 逻辑经 Update 单测覆盖（无需 TTY）。
-5. ✅ **分流与 flag**（`chat.go`）：`stdinIsTTY` 分流 + `--no-tui` / `OCTO_TUI=0`。
-6. ⏭️ **mswe-eval**：**未做，刻意保留 piped-REPL 驱动**（见 §8）。非-TTY stdin 已干净路由到 plain `runREPL`，契约完整保留；专用 headless 入口是可选 hardening，按 YAGNI 不引入额外表面。
-7. ✅ **测试**（§9）：turn-core 经既有 REPL 测试覆盖；steer/注入/适配器/TUI-Model 各有单测。
-
-> ⚠️ 单 PR 风险（已知并接受）：diff 大、review 困难、出问题难二分。缓解：上述步骤各自 commit 清晰、turn-core 步骤保持既有测试绿作为「未回归」基线。
->
-> ⚠️ **未做交互式真终端验证**：bubbletea 的渲染/键位在真实 TTY 上的手感（光标、换行、resize、Alt+Enter 检测）需人工在真终端冒烟；Model 逻辑已单测，但渲染层无法在 headless CI 中验证。`--no-tui` 是兼容兜底。
-
----
-
-## 12. 不做 / 未来
-
-- **pending 持久化**：typed-ahead 是瞬态输入，会话退出/崩溃即丢，不写盘。
-- **steer 的「立即打断重发」语义**（grill Q2·B）：明确否决——与 interrupt 区分度太低。steer 一律走「下一边界注入」。
-- **队列消息的富文本编辑**（grill Q10·C 的回填编辑）：首版只做删除/清空，不做回填到输入区再编辑。
-- **模态里的 "Other（自由文本）"**：TUI 问答模态首版选中 "Other" 视作取消（模型可重问或自取默认）——内联自由文本输入框留待后续。plain 路径仍支持 Other 自由文本。
-- **Web / IM 端的 queue/steer/interrupt**：本设计只覆盖 CLI TTY；Web/IM 各有自己的输入模型，另案。
-- **多回合并行**：始终一次一个在途回合，pending 串行消费。
+- **turn-core**:mock `ViewSink` 断言事件序列、`Ask` 请求-响应、pending 消费时机。
+- **steer/注入**:mock Sender 产 tool_use,断言 steer 并进 tool_result 的 blocks(不产生连续
+  两条 user role)、无边界时降级;两个 provider 适配器的 wire 形态。
+- **interrupt**:cancel `turnCtx`,断言走 `finishInterrupted` 且 pending 存活、后续被消费。
+- **TUI Model**:经 `Update` 断言键位映射(Enter=steer/Alt+Enter=queue/Ctrl+X=unqueue/Esc)、
+  queue 入队与出队、降级、模态状态机、文本缓冲——无需真 TTY。
+- **纯文本路径回归**:既有 scanner-based REPL 测试继续绿,保证 `--no-tui` / 非-TTY 不变。


### PR DESCRIPTION
Follow-up to the C9 memory refine (#169) and the doc audit. Strips process narrative and fixes drift across five design docs — current-state-only, verified against code.

| Doc | Action |
|---|---|
| **m7-skills** | Rewritten. Documents the shipped **default-skills tier** (default → user → project, embedded + materialized to `~/.octo/skills-default`) + the `octo skills list/update/path` subcommand the doc previously said were "future/不做"; fixes the `Source` enum. Drops scope checkmarks / decision record / task split. |
| **c11-sandbox** | Rewritten. Fixes the **wrong Landlock claim** (raw syscalls via `golang.org/x/sys/unix`, no `go-landlock` dependency), corrects `Available()` probe + system-read-roots, drops Phasing/Decisions/task-breakdown scaffolding + speculative `--sandbox=auto`. |
| **tui-input-modes** | Rewritten. `Ctrl+X` unqueue now real (#170); corrects the `useTUI` formula (`+tuiDisabledByEnv +seedPrompt`) and deps list (no `bubbles`/`teatest`). Drops decision table / task split / backlog / reversal narrative. |
| **identity-files** | Zero drift — trims scope checkmarks, decision record, slice list, "本轮" framing. |
| **c9-phase3-hindsight** | Drops Roadmap section + PR refs; fixes the fabricated "最低 1s" timeout floor and a stale diagram label. |

Net **-262 lines**. `/lint-design` clean on all five (file refs verified). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)