### PR TITLE
feat(tools): resumable sub-agents via send_message

### DIFF
--- a/cmd/octo/memory_consolidate_test.go
+++ b/cmd/octo/memory_consolidate_test.go
@@ -38,6 +38,12 @@ func (s *stubConsolidationSpawner) Spawn(_ context.Context, req tools.SpawnReque
 	return tools.SpawnResult{Reply: s.reply}, nil
 }
 
+// Continue is unused by the consolidator (it only ever calls Spawn) but is
+// required to satisfy tools.Spawner.
+func (s *stubConsolidationSpawner) Continue(_ context.Context, _, _ string) (tools.SpawnResult, error) {
+	return tools.SpawnResult{}, nil
+}
+
 func useConsolidationSpawner(t *testing.T, s tools.Spawner) {
 	t.Helper()
 	tools.SetSpawner(s)

--- a/cmd/octo/sub_agent.go
+++ b/cmd/octo/sub_agent.go
@@ -2,6 +2,11 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/tools"
@@ -23,18 +28,31 @@ type agentSpawner struct {
 	parent   *agent.Agent
 	executor agent.ToolExecutor
 	toolsFn  func() []agent.ToolDefinition
+	// reg keeps spawned children alive after Spawn returns so a later
+	// send_message (tools.Spawner.Continue) can re-run them with their history
+	// intact. In-memory and session-scoped: it lives as long as this spawner
+	// (one per REPL session), and a fresh process starts empty.
+	reg *childRegistry
 }
 
 func newAgentSpawner(parent *agent.Agent, executor agent.ToolExecutor, toolsFn func() []agent.ToolDefinition) *agentSpawner {
-	return &agentSpawner{parent: parent, executor: executor, toolsFn: toolsFn}
+	return &agentSpawner{
+		parent:   parent,
+		executor: executor,
+		toolsFn:  toolsFn,
+		reg:      newChildRegistry(),
+	}
 }
 
 // childMaxTurns caps the sub-agent's tool loop. Smaller than the parent's
 // default — sub-agents are meant for focused sub-tasks, not free-form work,
-// and a runaway child can otherwise burn through budget unnoticed.
+// and a runaway child can otherwise burn through budget unnoticed. Each
+// Continue (send_message) re-arms this budget for the next round.
 const childMaxTurns = 12
 
-// Spawn implements tools.Spawner.
+// Spawn implements tools.Spawner. It builds an isolated child, registers it so
+// a later send_message can continue it, runs the first prompt, and returns the
+// child's id alongside its reply.
 func (s *agentSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
 	childTools := filterChildTools(s.toolsFn(), req.Tools)
 
@@ -54,28 +72,70 @@ func (s *agentSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools
 	// should still constrain the child.
 	child.MaxCostUSD = s.parent.MaxCostUSD
 
-	// Mark the context so the launch_agent tool refuses recursive calls
-	// even if a hallucinating model bypasses the empty-tools filter below.
-	childCtx := tools.WithSubAgentMarker(ctx)
+	lc := &liveChild{agent: child, tools: childTools, executor: s.executor}
+	id := s.reg.put(lc)
 
-	reply, err := child.Run(childCtx, req.Prompt, childTools, s.executor)
+	reply, in, out, err := s.runChild(ctx, lc, req.Prompt)
 	if err != nil {
 		return tools.SpawnResult{}, err
 	}
-
-	in, out := child.SessionTokens()
-	s.parent.AccrueChildUsage(in, out)
-
 	return tools.SpawnResult{
-		Reply:        reply.Content,
+		AgentID:      id,
+		Reply:        reply,
 		InputTokens:  in,
 		OutputTokens: out,
 	}, nil
 }
 
-// filterChildTools drops launch_agent (no recursion) and, when allowed is
-// non-empty, intersects with that allowlist so the parent can hand the child
-// a restricted toolbelt (e.g. read-only research).
+// Continue implements tools.Spawner. It re-runs a still-alive child with a new
+// message. An unknown / evicted id returns an error whose text steers the model
+// to launch a fresh sub-agent.
+func (s *agentSpawner) Continue(ctx context.Context, agentID, message string) (tools.SpawnResult, error) {
+	lc, ok := s.reg.get(agentID)
+	if !ok {
+		return tools.SpawnResult{}, fmt.Errorf(
+			"agent %s is no longer alive (idle-expired or evicted); launch a fresh sub-agent instead", agentID)
+	}
+	reply, in, out, err := s.runChild(ctx, lc, message)
+	if err != nil {
+		return tools.SpawnResult{}, err
+	}
+	return tools.SpawnResult{
+		AgentID:      agentID,
+		Reply:        reply,
+		InputTokens:  in,
+		OutputTokens: out,
+	}, nil
+}
+
+// runChild is the shared body of Spawn and Continue. It serializes calls to a
+// single child (a child's history can't take two interleaved turns), re-stamps
+// the sub-agent context marker so the child can't recurse, and accrues only the
+// token delta for this round into the parent (SessionTokens is cumulative, so
+// re-accruing the total would double-count earlier rounds). The returned (in,
+// out) are this round's delta.
+func (s *agentSpawner) runChild(ctx context.Context, lc *liveChild, prompt string) (reply string, in, out int, err error) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+
+	childCtx := tools.WithSubAgentMarker(ctx)
+	r, err := lc.agent.Run(childCtx, prompt, lc.tools, lc.executor)
+	if err != nil {
+		return "", 0, 0, err
+	}
+
+	totIn, totOut := lc.agent.SessionTokens()
+	in, out = totIn-lc.accruedIn, totOut-lc.accruedOut
+	lc.accruedIn, lc.accruedOut = totIn, totOut
+	s.parent.AccrueChildUsage(in, out)
+
+	return r.Content, in, out, nil
+}
+
+// filterChildTools drops launch_agent and send_message (a sub-agent can
+// neither spawn nor wake another sub-agent — those stay top-level-only) and,
+// when allowed is non-empty, intersects with that allowlist so the parent can
+// hand the child a restricted toolbelt (e.g. read-only research).
 func filterChildTools(parent []agent.ToolDefinition, allowed []string) []agent.ToolDefinition {
 	var allowSet map[string]bool
 	if len(allowed) > 0 {
@@ -86,7 +146,7 @@ func filterChildTools(parent []agent.ToolDefinition, allowed []string) []agent.T
 	}
 	out := make([]agent.ToolDefinition, 0, len(parent))
 	for _, td := range parent {
-		if td.Name == "launch_agent" {
+		if td.Name == "launch_agent" || td.Name == "send_message" {
 			continue
 		}
 		if allowSet != nil && !allowSet[td.Name] {
@@ -95,4 +155,119 @@ func filterChildTools(parent []agent.ToolDefinition, allowed []string) []agent.T
 		out = append(out, td)
 	}
 	return out
+}
+
+// Live-child registry — keeps spawned sub-agents addressable for send_message.
+
+const (
+	// maxLiveChildren caps how many sub-agents stay resumable at once. Beyond
+	// this the least-recently-used is evicted (its history is dropped; a
+	// send_message to it then fails and the model relaunches).
+	maxLiveChildren = 8
+	// childIdleTTL evicts a sub-agent that hasn't been touched in this long,
+	// so abandoned children don't pin their histories in memory for the whole
+	// session.
+	childIdleTTL = 30 * time.Minute
+)
+
+// liveChild is one resumable sub-agent: its Agent (history accumulates across
+// Run calls), the toolbelt + executor it was spawned with (a Continue reuses
+// them), and the bookkeeping for serialization, eviction, and delta-accounting.
+type liveChild struct {
+	agent    *agent.Agent
+	tools    []agent.ToolDefinition
+	executor agent.ToolExecutor
+
+	mu sync.Mutex // serializes runChild on this child
+
+	// accruedIn/accruedOut track how much of the child's cumulative
+	// SessionTokens has already been folded into the parent, so each round
+	// accrues only its delta.
+	accruedIn  int
+	accruedOut int
+
+	lastUsed time.Time // for TTL eviction
+	seq      uint64    // monotonic touch order, for LRU eviction (clock-independent)
+}
+
+// childRegistry holds the live children for one spawner (one REPL session).
+// Purely in-memory: nothing is persisted, and the map is dropped when the
+// spawner goes away with the session.
+type childRegistry struct {
+	mu     sync.Mutex
+	m      map[string]*liveChild
+	seqCtr uint64
+	now    func() time.Time // injectable for tests
+}
+
+func newChildRegistry() *childRegistry {
+	return &childRegistry{m: make(map[string]*liveChild), now: time.Now}
+}
+
+// put registers a child under a fresh id and returns it. Eviction runs after
+// insertion so the cap holds even counting the new entry; the just-added child
+// is the most-recently-used, so LRU never evicts it.
+func (r *childRegistry) put(lc *liveChild) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	id := r.freshIDLocked()
+	r.touchLocked(lc)
+	r.m[id] = lc
+	r.evictLocked()
+	return id
+}
+
+// get returns the child for id (refreshing its LRU/TTL standing) or (nil,
+// false) if it's unknown or already evicted.
+func (r *childRegistry) get(id string) (*liveChild, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.evictLocked()
+	lc, ok := r.m[id]
+	if ok {
+		r.touchLocked(lc)
+	}
+	return lc, ok
+}
+
+// touchLocked stamps a child as most-recently-used. Caller holds r.mu.
+func (r *childRegistry) touchLocked(lc *liveChild) {
+	r.seqCtr++
+	lc.seq = r.seqCtr
+	lc.lastUsed = r.now()
+}
+
+// evictLocked drops TTL-expired children, then trims to maxLiveChildren by
+// least-recently-used. Caller holds r.mu.
+func (r *childRegistry) evictLocked() {
+	now := r.now()
+	for id, lc := range r.m {
+		if now.Sub(lc.lastUsed) > childIdleTTL {
+			delete(r.m, id)
+		}
+	}
+	for len(r.m) > maxLiveChildren {
+		var oldestID string
+		var oldestSeq uint64
+		first := true
+		for id, lc := range r.m {
+			if first || lc.seq < oldestSeq {
+				oldestID, oldestSeq, first = id, lc.seq, false
+			}
+		}
+		delete(r.m, oldestID)
+	}
+}
+
+// freshIDLocked returns an 8-hex-char id not currently in use. Same shape as
+// agent.Session / taskgraph short ids. Caller holds r.mu.
+func (r *childRegistry) freshIDLocked() string {
+	for {
+		var b [4]byte
+		_, _ = rand.Read(b[:]) // crypto/rand.Read effectively never fails
+		id := hex.EncodeToString(b[:])
+		if _, taken := r.m[id]; !taken {
+			return id
+		}
+	}
 }

--- a/cmd/octo/sub_agent_test.go
+++ b/cmd/octo/sub_agent_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/tools"
@@ -144,6 +146,172 @@ func TestAgentSpawner_ModelOverride(t *testing.T) {
 	}
 	if send.lastModel != "claude-haiku-4-5" {
 		t.Errorf("model override ignored: child ran with %q", send.lastModel)
+	}
+}
+
+func TestAgentSpawner_SpawnReturnsIDAndContinueResumesSameChild(t *testing.T) {
+	send := &subAgentSender{reply: "round one", inputTokens: 200, outputTokens: 80}
+	parent := agent.New(send, "parent-model")
+	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+
+	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{Description: "x", Prompt: "first task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.AgentID == "" {
+		t.Fatal("Spawn should return a non-empty AgentID")
+	}
+	// First Run sent a single-message history.
+	if got := len(send.lastMessages); got != 1 {
+		t.Fatalf("after Spawn, child saw %d messages, want 1", got)
+	}
+
+	send.reply = "round two"
+	res2, err := sp.Continue(context.Background(), res.AgentID, "second task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res2.Reply != "round two" {
+		t.Errorf("Continue reply = %q", res2.Reply)
+	}
+	// Continuation carries history: [user1, assistant1, user2] = 3 messages.
+	if got := len(send.lastMessages); got != 3 {
+		t.Errorf("after Continue, child saw %d messages, want 3 (history carried over)", got)
+	}
+}
+
+func TestAgentSpawner_ContinueAccruesOnlyDeltaTokens(t *testing.T) {
+	send := &subAgentSender{reply: "ok", inputTokens: 200, outputTokens: 80}
+	parent := agent.New(send, "parent-model")
+	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+
+	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{Description: "x", Prompt: "go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.InputTokens != 200 || res.OutputTokens != 80 {
+		t.Errorf("Spawn delta tokens = (%d,%d), want (200,80)", res.InputTokens, res.OutputTokens)
+	}
+
+	res2, err := sp.Continue(context.Background(), res.AgentID, "again")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The child's cumulative SessionTokens is now (400,160); Continue must
+	// report and accrue only this round's delta (200,80), not the cumulative.
+	if res2.InputTokens != 200 || res2.OutputTokens != 80 {
+		t.Errorf("Continue delta tokens = (%d,%d), want (200,80)", res2.InputTokens, res2.OutputTokens)
+	}
+	in, out := parent.SessionTokens()
+	if in != 400 || out != 160 {
+		t.Errorf("parent session tokens = (%d,%d), want (400,160) — double-counting bug if 600/240", in, out)
+	}
+}
+
+func TestAgentSpawner_ContinueUnknownID(t *testing.T) {
+	send := &subAgentSender{reply: "ok"}
+	parent := agent.New(send, "parent-model")
+	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+
+	_, err := sp.Continue(context.Background(), "nope", "hi")
+	if err == nil || !strings.Contains(err.Error(), "no longer alive") {
+		t.Errorf("expected 'no longer alive' error for unknown id, got %v", err)
+	}
+}
+
+func TestAgentSpawner_ConcurrentContinueSerialized(t *testing.T) {
+	send := &subAgentSender{reply: "ok", inputTokens: 10, outputTokens: 5}
+	parent := agent.New(send, "parent-model")
+	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+
+	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{Description: "x", Prompt: "go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 10
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := sp.Continue(context.Background(), res.AgentID, "more"); err != nil {
+				t.Errorf("Continue: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// per-child mutex serializes the runs, so the cumulative total is exact:
+	// 1 Spawn + n Continue rounds. (Run under -race to catch History races.)
+	in, out := parent.SessionTokens()
+	if in != (n+1)*10 || out != (n+1)*5 {
+		t.Errorf("parent tokens = (%d,%d), want (%d,%d)", in, out, (n+1)*10, (n+1)*5)
+	}
+}
+
+func TestFilterChildTools_DropsSendMessage(t *testing.T) {
+	parentTools := []agent.ToolDefinition{
+		{Name: "read_file"},
+		{Name: "launch_agent"},
+		{Name: "send_message"},
+	}
+	got := filterChildTools(parentTools, nil)
+	for _, td := range got {
+		if td.Name == "send_message" || td.Name == "launch_agent" {
+			t.Errorf("child toolbelt must not contain %q", td.Name)
+		}
+	}
+	if len(got) != 1 || got[0].Name != "read_file" {
+		t.Errorf("expected only read_file to survive, got %+v", got)
+	}
+}
+
+func TestChildRegistry_LRUEviction(t *testing.T) {
+	reg := newChildRegistry()
+	ids := make([]string, 0, maxLiveChildren+1)
+	for i := 0; i < maxLiveChildren+1; i++ {
+		ids = append(ids, reg.put(&liveChild{}))
+	}
+	if _, ok := reg.get(ids[0]); ok {
+		t.Error("the least-recently-used child should have been evicted")
+	}
+	if _, ok := reg.get(ids[len(ids)-1]); !ok {
+		t.Error("the most-recently-added child should still be alive")
+	}
+	if len(reg.m) != maxLiveChildren {
+		t.Errorf("registry size = %d, want %d", len(reg.m), maxLiveChildren)
+	}
+}
+
+func TestChildRegistry_LRUKeepsRecentlyUsed(t *testing.T) {
+	reg := newChildRegistry()
+	first := reg.put(&liveChild{})
+	for i := 0; i < maxLiveChildren-1; i++ {
+		reg.put(&liveChild{})
+	}
+	// Touch `first` so it's no longer the LRU victim, then overflow by one.
+	if _, ok := reg.get(first); !ok {
+		t.Fatal("first should still be alive before overflow")
+	}
+	reg.put(&liveChild{}) // overflow → evicts the now-oldest, not `first`
+	if _, ok := reg.get(first); !ok {
+		t.Error("a recently-touched child must survive LRU eviction")
+	}
+}
+
+func TestChildRegistry_TTLEviction(t *testing.T) {
+	now := time.Now()
+	reg := newChildRegistry()
+	reg.now = func() time.Time { return now }
+
+	id := reg.put(&liveChild{})
+	if _, ok := reg.get(id); !ok {
+		t.Fatal("child should be alive immediately after put")
+	}
+	now = now.Add(childIdleTTL + time.Minute)
+	if _, ok := reg.get(id); ok {
+		t.Error("child should be evicted after idle TTL")
 	}
 }
 

--- a/dev-docs/resumable-subagent-design.md
+++ b/dev-docs/resumable-subagent-design.md
@@ -1,0 +1,290 @@
+# 可续话 Sub-Agent 设计（send_message）
+
+## 背景与目标
+
+octo 当前的 sub-agent 是一次性的：父 agent 通过 `launch_agent` 工具起一个子 agent，子 agent 跑完返回一段 final text，然后被丢弃。子 agent 没有可寻址的句柄，父 agent 无法在它完成首个任务后再唤醒它继续对话。
+
+本设计新增一个 `send_message` 工具，让**顶层父 agent** 在 `launch_agent` 起的子 agent 完成首个任务后，还能带着完整上下文再次唤醒它继续干活——对标 Claude Code 的 `Agent` + `SendMessage` 续话模型，而非现在的 Codex 式 fire-and-forget。
+
+### Scope
+
+| 项 | 决定 |
+|---|---|
+| 保活范围 | **in-memory only**，registry 生命周期 = 一个 REPL 会话，不跨进程持久化 |
+| 影响面 | **只动 `launch_agent` 这条线**，taskgraph（`octo task`）的 `spawnerExecutor` 不改 |
+| 谁能续话 | **只有顶层父 agent**；子 agent 拿不到 `send_message`（与现有「子 agent 不能 spawn」对称） |
+| 驱逐策略 | LRU 上限 8 个 + 30 分钟空闲 TTL |
+| close 工具 | 不做，只靠 LRU/TTL 自动回收 |
+
+## 关键前提：agent 核心层零改动
+
+`internal/agent/` 不需要任何改动。`Agent.Run` 本身就是续话友好的——`runLoop` 把用户输入追加进**同一个** `a.History`，而非重置：
+
+```go
+// internal/agent/agent.go:411
+a.History.Append(NewUserMessage(userInput))
+```
+
+`History` 是 goroutine-safe 的消息日志（`internal/agent/history.go`，`popLast` 等操作持 `h.mu`）。每次 `Run` 还重新发一份 `MaxTurns` 预算（`turnLimit`，`agent.go:536`）。
+
+因此「子 agent 完成后续话」在 agent 层是天然支持的：**只要还持有那个 `child *agent.Agent`，再 `child.Run(ctx, 后续消息, tools, exec)` 一次，它就接着上一轮聊**。当前做不到，唯一原因是上层把 child 用完即弃。
+
+## 当前实现的相关事实
+
+| 事实 | 位置 |
+|---|---|
+| `agentSpawner.Spawn` 把 child 建成局部变量，`Run` 完即返回 `SpawnResult` 后被 GC | `cmd/octo/sub_agent.go:38-74` |
+| child 构造：共享 parent 的 `Sender` / `System` / `MaxTokens` / `Gate` / `MaxCostUSD`，`MaxTurns` 设为 `childMaxTurns = 12` | `cmd/octo/sub_agent.go:35,46-55` |
+| `SpawnResult` 字段：`Reply` / `InputTokens` / `OutputTokens`，**无 ID** | `internal/tools/launch_agent.go:44-48` |
+| `Spawner` 接口只有 `Spawn(ctx, req) (SpawnResult, error)` | `internal/tools/launch_agent.go:17-19` |
+| `SpawnRequest` 字段：`Description` / `Prompt` / `Tools` / `Model` | `internal/tools/launch_agent.go:21-39` |
+| token 计费：`Spawn` 取 `child.SessionTokens()`（**累计值**）后 `parent.AccrueChildUsage(in, out)` | `cmd/octo/sub_agent.go:66`、`internal/agent/agent.go:776,785` |
+| `filterChildTools` 给子 agent 过滤工具时丢弃 `launch_agent`（防递归） | `cmd/octo/sub_agent.go:79-98` |
+| 递归防护：`WithSubAgentMarker(ctx)` 打标，`IsSubAgent(ctx)` 检测，`launch_agent` Execute 据此拒绝嵌套 | `internal/tools/launch_agent.go:78-87,138-143` |
+| `DefaultTools` 对 `LaunchAgentTool` 按 `spawnerEnabled()` 门控 | `internal/tools/registry.go:121-123`、`internal/tools/launch_agent.go:66` |
+| `launch_agent` 在 `readOnlyTools` 里为 `true`，允许一个 tool_use batch 并行起多个子 agent | `internal/agent/agent.go:625-632` |
+| spawner 会话级接线：`SetSpawner(newAgentSpawner(a, …))` 每会话一次 | `cmd/octo/chat.go:329` |
+
+## 方案设计
+
+改动集中在 `cmd/octo/sub_agent.go`（新增 registry + 改造 `agentSpawner`）和一个新工具文件，外加 `internal/tools/launch_agent.go` 的接口与 `SpawnResult` 扩展。`internal/agent/` 只读不改。
+
+### 1. SpawnResult 加 AgentID，Spawner 加 Continue
+
+`internal/tools/launch_agent.go`：
+
+```go
+type SpawnResult struct {
+	AgentID      string // 可寻址句柄；send_message 用它定位 child。Spawn 必填
+	Reply        string
+	InputTokens  int
+	OutputTokens int
+}
+
+type Spawner interface {
+	Spawn(ctx context.Context, req SpawnRequest) (SpawnResult, error)
+	// Continue 用 message 续跑一个仍存活的 child，返回它这一轮的新 reply。
+	// agentID 未知或已被驱逐时返回错误，错误文案提示模型重新 launch_agent。
+	Continue(ctx context.Context, agentID, message string) (SpawnResult, error)
+}
+```
+
+taskgraph 的 `spawnerExecutor`（`cmd/octo/task.go:573`）只调 `Spawn`，加 `Continue` 不影响它。
+
+### 2. childRegistry + liveChild（in-memory，session-scoped）
+
+新增到 `cmd/octo/sub_agent.go`。registry 作为 `agentSpawner` 的字段，生命周期随 spawner（一个 REPL 会话）。
+
+```go
+type liveChild struct {
+	agent       *agent.Agent          // 保活的 child，History 持续累积
+	tools       []agent.ToolDefinition // 该 child 当初过滤后的 toolbelt（续话沿用）
+	executor    agent.ToolExecutor
+	mu          sync.Mutex            // 串行化对同一 child 的调用（坑①）
+	lastUsed    time.Time             // LRU + TTL 依据
+	lastAccrued struct{ in, out int } // 已计入 parent 的累计 token（坑②）
+}
+
+type childRegistry struct {
+	mu  sync.Mutex
+	m   map[string]*liveChild
+	now func() time.Time // 注入便于测试
+}
+
+const (
+	maxLiveChildren = 8                // LRU 上限
+	childIdleTTL    = 30 * time.Minute // 空闲驱逐
+)
+```
+
+registry 行为：
+
+- **put(child, tools, exec) → id**：生成 8 位 hex id（与 `agent.Session.ShortID` / `taskgraph.shortTaskID` 同风格），写入 map，置 `lastUsed = now`。put 前先 `evict()`。
+- **get(id) → \*liveChild, ok**：命中则刷新 `lastUsed`。先 `evict()` 再查，使过期项查不到。
+- **evict()**（持 registry.mu）：先删 `now - lastUsed > childIdleTTL` 的项；再若 `len(m) > maxLiveChildren`，按 `lastUsed` 升序删到 8 个。被删项不需要额外清理（无文件、无连接，GC 即回收）。
+
+### 3. agentSpawner 改造
+
+`Spawn` 跑完**不丢弃 child**，而是入 registry 并把 id 回填到 `SpawnResult.AgentID`；新增 `Continue`：
+
+```go
+func (s *agentSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
+	childTools := filterChildTools(s.toolsFn(), req.Tools)
+	model := req.Model
+	if model == "" {
+		model = s.parent.Model
+	}
+	child := agent.New(s.parent.Sender, model)
+	child.System = s.parent.System
+	child.MaxTokens = s.parent.MaxTokens
+	child.Gate = s.parent.Gate
+	child.MaxTurns = childMaxTurns
+	child.MaxCostUSD = s.parent.MaxCostUSD
+
+	lc := &liveChild{agent: child, tools: childTools, executor: s.executor}
+	id := s.reg.put(lc) // 先登记，拿到 id
+
+	reply, err := s.runChild(ctx, lc, req.Prompt)
+	if err != nil {
+		return tools.SpawnResult{}, err
+	}
+	return tools.SpawnResult{AgentID: id, Reply: reply, /* 本轮增量 token */}, nil
+}
+
+func (s *agentSpawner) Continue(ctx context.Context, agentID, message string) (tools.SpawnResult, error) {
+	lc, ok := s.reg.get(agentID)
+	if !ok {
+		return tools.SpawnResult{}, fmt.Errorf(
+			"agent %s is no longer alive (idle-expired or evicted); launch a fresh sub-agent instead", agentID)
+	}
+	reply, err := s.runChild(ctx, lc, message)
+	if err != nil {
+		return tools.SpawnResult{}, err
+	}
+	return tools.SpawnResult{AgentID: agentID, Reply: reply}, nil
+}
+```
+
+`runChild` 是 `Spawn` / `Continue` 共用的核心，负责**串行锁 + 递归 marker + 增量计费**：
+
+```go
+func (s *agentSpawner) runChild(ctx context.Context, lc *liveChild, prompt string) (string, error) {
+	lc.mu.Lock()          // 坑①：串行化对同一 child 的调用
+	defer lc.mu.Unlock()
+
+	childCtx := tools.WithSubAgentMarker(ctx) // 坑④：续话仍要打标防递归
+	reply, err := lc.agent.Run(childCtx, prompt, lc.tools, lc.executor)
+	if err != nil {
+		return "", err
+	}
+
+	// 坑②：SessionTokens 是累计值，只 accrue 自上次以来的增量
+	in, out := lc.agent.SessionTokens()
+	s.parent.AccrueChildUsage(in-lc.lastAccrued.in, out-lc.lastAccrued.out)
+	lc.lastAccrued.in, lc.lastAccrued.out = in, out
+
+	return reply.Content, nil
+}
+```
+
+### 4. send_message 工具
+
+新增 `internal/tools/send_message.go`，与 `launch_agent` 同样按 `spawnerEnabled()` 门控（在 `registry.go` 的 `DefaultTools` 里加一条 `SendMessageTool` 的 spawner 门控分支，紧挨现有 `LaunchAgentTool` 分支 `registry.go:121-123`）。
+
+工具 schema：
+
+```
+name: send_message
+description: 续跑一个之前用 launch_agent 起的、仍存活的 sub-agent，带上一段新消息，
+            返回它这一轮的新回复。子 agent 记得它之前做的所有事。当一个子任务需要
+            多轮往返、或要基于前一轮结果追加指令时使用。如果返回 "no longer alive"，
+            改用 launch_agent 重新起一个。
+parameters:
+  agent_id (string, required): launch_agent 返回里的 agent id
+  message  (string, required): 发给该 sub-agent 的新消息（它看不到本对话，消息要自包含）
+```
+
+Execute：与 `launch_agent` 同样先查 `spawnerEnabled()`、`IsSubAgent(ctx)`（子 agent 调用直接拒绝），再 `ActiveSpawner().Continue(ctx, agentID, message)`，空 reply 时返回 `(sub-agent <id> produced no reply)`（沿用 `launch_agent.go:167-172` 的处理）。
+
+`send_message` **不进 `readOnlyTools`**（`agent.go:625`）。原因见坑①：若进了并行集合，模型一个 batch 里对同一 id 发两条会并发 `Run` 同一 child；不进则该工具整批串行执行，从调度层就避免了并发同一 child。per-child mutex 是第二层兜底。
+
+### 5. 透出 AgentID 给父模型
+
+`launch_agent` 的 Execute（`internal/tools/launch_agent.go:162-174`）返回文本前面带上 id，否则模型不知道往哪发：
+
+```
+[agent a3f9c2b1] <child reply>
+```
+
+`send_message` 的返回同样带 `[agent <id>] ` 前缀，保持模型对「同一个子 agent」的指代一致。
+
+### 6. 强制「只有顶层父 agent 能用」（决策3）
+
+`filterChildTools`（`cmd/octo/sub_agent.go:79-98`）当前丢弃 `launch_agent`，扩展为**同时丢弃 `send_message`**：
+
+```go
+if td.Name == "launch_agent" || td.Name == "send_message" {
+	continue
+}
+```
+
+子 agent 的 toolbelt 里没有 `send_message`，结构上保证它不能唤醒别的 child；`IsSubAgent(ctx)` 检查是第二层兜底（防模型幻觉出一个不在 schema 里的工具调用）。这与现有「子 agent 不能 spawn」完全对称。
+
+## 四个坑的处理小结
+
+| # | 坑 | 处理 |
+|---|---|---|
+| ① | 同一 child 并发 Run 破坏 History 交替 | `send_message` 不进 `readOnlyTools`（整批串行）+ `liveChild.mu` 串行化 |
+| ② | `SessionTokens` 累计值被多轮重复 accrue 双计 | `liveChild.lastAccrued` 记上次累计，每轮只 accrue 增量 |
+| ③ | 保活 child 连着 History 泄漏内存 | LRU 8 + 30min TTL，put/get 前 `evict()`；registry 随 spawner（会话）销毁 |
+| ④ | 续话漏打递归 marker | `runChild` 统一 `WithSubAgentMarker(ctx)`，`Spawn` / `Continue` 共用 |
+
+## 时序图
+
+```mermaid
+sequenceDiagram
+    participant M as 父模型 (LLM)
+    participant LA as launch_agent
+    participant SP as agentSpawner
+    participant REG as childRegistry
+    participant C as child Agent
+
+    M->>LA: tool_use launch_agent(prompt)
+    LA->>SP: Spawn(req)
+    SP->>C: agent.New + 配置
+    SP->>REG: put(child) → id=a3f9
+    SP->>C: runChild: Run(prompt) [lock a3f9]
+    C-->>SP: reply1 (+token 增量)
+    SP-->>LA: SpawnResult{AgentID:a3f9, reply1}
+    LA-->>M: "[agent a3f9] reply1"
+
+    Note over M: 父 agent 决定追加指令
+
+    M->>SP: tool_use send_message(a3f9, msg2)
+    SP->>REG: get(a3f9) → 命中, 刷新 lastUsed
+    SP->>C: runChild: Run(msg2) [lock a3f9]
+    Note over C: History 续上 reply1 之后
+    C-->>SP: reply2 (+token 增量)
+    SP-->>M: "[agent a3f9] reply2"
+
+    Note over REG: 30min 空闲 / 超 8 个 → evict 回收
+    M->>SP: send_message(a3f9, msg3) 若已驱逐
+    SP->>REG: get(a3f9) → miss
+    SP-->>M: error "no longer alive; launch fresh"
+```
+
+## 测试计划
+
+放在 `cmd/octo/sub_agent_test.go`（扩展现有）和新增 `internal/tools/send_message_test.go`，沿用 stdlib + 现有 fake Sender/Spawner，无真实网络。
+
+| 用例 | 断言 |
+|---|---|
+| Spawn 后 Continue 续话 | child History 累积；reply2 能看到 reply1 的上下文（用 fake Sender 回显历史长度验证） |
+| token 不双计 | 两轮后 `parent.SessionTokens` == 两轮增量之和，而非 累计×2 |
+| 并发 send_message 同一 id | per-child mutex 串行执行，无 data race（`-race` 下跑）；History 交替合法 |
+| 未知 / 已驱逐 id | `Continue` 返回 "no longer alive" 错误 |
+| LRU 驱逐 | put 第 9 个后最久未用的被删，`get` 旧 id miss |
+| TTL 驱逐 | 注入 `now` 推进 31min，`get` miss |
+| 子 agent 拿不到 send_message | `filterChildTools` 输出不含 `send_message` 和 `launch_agent` |
+| 子 agent 调 send_message 被拒 | `IsSubAgent(ctx)` 为真时 Execute 返回错误 |
+| spawner 未配置 | `send_message` 不在 `DefaultTools`，Execute 报 "not configured" |
+
+## 兼容性
+
+- **现有 `launch_agent` 行为**：不变。父模型不调 `send_message` 时，Spawn 的唯一新增副作用是把 child 留在 registry 里（最终被 LRU/TTL 回收），返回文本多了 `[agent <id>] ` 前缀。
+- **taskgraph（`octo task`）**：不涉及。`spawnerExecutor` 只调 `Spawn`；其 spawner 的 registry 没人调 `Continue`，留存的 child 随该次 `octo task run` 进程退出一并释放。`octo task` 是前台一次性进程，不存在跨会话泄漏。
+- **session JSON 持久化**：不涉及。registry 是纯 in-memory，不写盘、不进 session 文件；进程退出即清空（决策1：不跨进程持久化）。
+- **provider / wire 格式**：不涉及。child 复用 parent 的 `Sender`，续话只是对同一 `Sender` 多发几轮，与单 agent 多轮对话走同一路径。
+- **权限门控**：不涉及新增。`send_message` 复用 `spawnerEnabled()` 门控；child 的 `Gate` 继承自 parent（`sub_agent.go:49`），续话沿用同一 Gate。
+
+## 回滚
+
+代码与数据可独立回滚——本特性无数据层改动（纯 in-memory）。回滚 = revert 代码：移除 `send_message` 工具后它从 `DefaultTools` 消失，模型不再看到该工具；`SpawnResult.AgentID` 和 `Spawner.Continue` 即便保留也无副作用（Spawn 路径与回滚前等价，唯一区别是 child 多停留在 registry 直到 GC）。无需数据迁移。
+
+## 不做的事（明确排除）
+
+- 不做跨进程 / 跨会话持久化续话（决策1）。需要时另设计：序列化 child History（可复用 `internal/agent/session.go` 机制）。
+- 不改 taskgraph 让 subtask 之间续话（决策2）。DAG 仍靠 `Subtask.Result` 文本传递。
+- 不给子 agent `send_message`（决策3）。
+- 不做 `close_agent` 显式释放工具，只靠 LRU/TTL 自动回收。
+- 不做 child 的事件流透出（与现状一致：父只拿 final string，不订阅 child 的 AgentEvent）。

--- a/internal/tools/launch_agent.go
+++ b/internal/tools/launch_agent.go
@@ -16,6 +16,14 @@ import (
 // implementation MUST be safe for concurrent invocation on distinct requests.
 type Spawner interface {
 	Spawn(ctx context.Context, req SpawnRequest) (SpawnResult, error)
+	// Continue re-runs a still-alive sub-agent (one a prior Spawn kept in the
+	// implementation's live registry) with a new message and returns its next
+	// reply. The sub-agent's prior history carries over. An unknown or
+	// already-evicted agentID returns an error whose text tells the model to
+	// launch a fresh sub-agent instead. Concurrent Continue calls on the SAME
+	// agentID must be serialized by the implementation — a sub-agent's history
+	// can't take two interleaved turns.
+	Continue(ctx context.Context, agentID, message string) (SpawnResult, error)
 }
 
 // SpawnRequest is the LLM-supplied launch_agent payload, parsed.
@@ -42,6 +50,12 @@ type SpawnRequest struct {
 // parent can roll it into the session total (the same way /cost displays one
 // number even when sub-agents fired side calls).
 type SpawnResult struct {
+	// AgentID addresses the sub-agent for a later send_message. Spawn returns
+	// a non-empty id when the implementation keeps the child alive; the
+	// launch_agent tool surfaces it to the model in an "[agent <id>]" tag.
+	// Empty when the implementation doesn't support continuation (e.g. test
+	// stubs) — the tag is then omitted.
+	AgentID      string
 	Reply        string
 	InputTokens  int
 	OutputTokens int
@@ -170,7 +184,7 @@ func (LaunchAgentTool) Execute(ctx context.Context, _ string, input map[string]a
 		// guess.
 		return "(sub-agent " + desc + " produced no reply)", nil
 	}
-	return reply, nil
+	return withAgentTag(res.AgentID, reply), nil
 }
 
 // stringSliceArg pulls an []string argument tolerating absence and the JSON

--- a/internal/tools/launch_agent_test.go
+++ b/internal/tools/launch_agent_test.go
@@ -20,6 +20,12 @@ type stubSpawner struct {
 	delay    time.Duration // optional sleep so two concurrent calls actually overlap
 	err      error
 	spawnCnt int32
+
+	// Continue support.
+	continueReply SpawnResult
+	continueErr   error
+	contAgentID   string
+	contMessage   string
 }
 
 func (s *stubSpawner) Spawn(_ context.Context, req SpawnRequest) (SpawnResult, error) {
@@ -40,6 +46,17 @@ func (s *stubSpawner) Spawn(_ context.Context, req SpawnRequest) (SpawnResult, e
 		return s.replies[len(s.calls)-1], nil
 	}
 	return s.replies[len(s.replies)-1], nil
+}
+
+func (s *stubSpawner) Continue(_ context.Context, agentID, message string) (SpawnResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.contAgentID = agentID
+	s.contMessage = message
+	if s.continueErr != nil {
+		return SpawnResult{}, s.continueErr
+	}
+	return s.continueReply, nil
 }
 
 func useSpawner(t *testing.T, s Spawner) {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -33,6 +33,7 @@ var allTools = []tool{
 	SkillTool{},
 	RememberTool{},
 	LaunchAgentTool{},
+	SendMessageTool{},
 	AskUserQuestionTool{},
 	TaskCreateTool{},
 	TaskUpdateTool{},
@@ -119,6 +120,9 @@ func DefaultTools() []agent.ToolDefinition {
 			continue
 		}
 		if _, isLaunch := t.(LaunchAgentTool); isLaunch && !spawnerOn {
+			continue
+		}
+		if _, isSend := t.(SendMessageTool); isSend && !spawnerOn {
 			continue
 		}
 		if _, isAsk := t.(AskUserQuestionTool); isAsk && !askerOn {

--- a/internal/tools/send_message.go
+++ b/internal/tools/send_message.go
@@ -1,0 +1,83 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// SendMessageTool continues a sub-agent previously started with launch_agent,
+// sending it a new message and returning its next reply. Only the top-level
+// parent agent gets this tool — the Spawner filters it out of every child's
+// toolbelt (same rule as launch_agent), so a sub-agent can't message another.
+type SendMessageTool struct{}
+
+func (SendMessageTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "send_message",
+		Description: "Continue a sub-agent you previously started with launch_agent by sending " +
+			"it a new message, and get its next reply. The sub-agent remembers everything it did " +
+			"before — use this when a delegated sub-task needs multiple rounds, or to give a " +
+			"follow-up instruction based on the sub-agent's earlier reply (instead of launching a " +
+			"fresh one that starts from scratch). The agent_id comes from the launch_agent result " +
+			"(the value in its '[agent <id>]' tag). If the reply says the agent is no longer alive, " +
+			"start a new one with launch_agent.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"agent_id": map[string]any{
+					"type":        "string",
+					"description": "Id of the sub-agent to continue, as returned by launch_agent (the value in its '[agent <id>]' tag).",
+				},
+				"message": map[string]any{
+					"type":        "string",
+					"description": "The new message for the sub-agent. It can't see this conversation, so keep it self-contained.",
+				},
+			},
+			"required": []string{"agent_id", "message"},
+		},
+	}
+}
+
+func (SendMessageTool) Execute(ctx context.Context, _ string, input map[string]any) (string, error) {
+	if !spawnerEnabled() {
+		return "", fmt.Errorf("send_message: sub-agent dispatch is not configured for this session")
+	}
+	if IsSubAgent(ctx) {
+		// Symmetric with launch_agent's recursion guard: a sub-agent must not
+		// be able to wake another sub-agent. Defense in depth on top of the
+		// Spawner dropping send_message from every child's tool list.
+		return "", fmt.Errorf("send_message: a sub-agent cannot message another sub-agent")
+	}
+
+	agentID := strings.TrimSpace(stringArg(input, "agent_id"))
+	message := strings.TrimSpace(stringArg(input, "message"))
+	if agentID == "" {
+		return "", fmt.Errorf("send_message: agent_id is required")
+	}
+	if message == "" {
+		return "", fmt.Errorf("send_message: message is required")
+	}
+
+	res, err := activeSpawner.Continue(ctx, agentID, message)
+	if err != nil {
+		return "", fmt.Errorf("send_message: %w", err)
+	}
+	reply := strings.TrimSpace(res.Reply)
+	if reply == "" {
+		return "(sub-agent " + agentID + " produced no reply)", nil
+	}
+	return withAgentTag(res.AgentID, reply), nil
+}
+
+// withAgentTag prefixes a sub-agent reply with "[agent <id>] " so the parent
+// model has a stable handle to address in a follow-up send_message. An empty
+// id (continuation unsupported) yields the bare reply unchanged.
+func withAgentTag(id, reply string) string {
+	if id == "" {
+		return reply
+	}
+	return "[agent " + id + "] " + reply
+}

--- a/internal/tools/send_message_test.go
+++ b/internal/tools/send_message_test.go
@@ -1,0 +1,148 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSendMessageTool_Schema(t *testing.T) {
+	def := SendMessageTool{}.Definition()
+	if def.Name != "send_message" {
+		t.Errorf("Name = %q", def.Name)
+	}
+	props, _ := def.Parameters["properties"].(map[string]any)
+	for _, want := range []string{"agent_id", "message"} {
+		if _, ok := props[want]; !ok {
+			t.Errorf("schema missing property %q", want)
+		}
+	}
+	required, _ := def.Parameters["required"].([]string)
+	if !containsString(required, "agent_id") || !containsString(required, "message") {
+		t.Errorf("agent_id and message should be required, got %v", required)
+	}
+}
+
+func TestSendMessageTool_ContinuesAndTagsReply(t *testing.T) {
+	stub := &stubSpawner{continueReply: SpawnResult{AgentID: "a1b2c3d4", Reply: "next round done"}}
+	useSpawner(t, stub)
+
+	out, err := SendMessageTool{}.Execute(context.Background(), "send_message", map[string]any{
+		"agent_id": "a1b2c3d4",
+		"message":  "now do the second half",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "[agent a1b2c3d4] next round done" {
+		t.Errorf("Execute returned %q, want tagged reply", out)
+	}
+	if stub.contAgentID != "a1b2c3d4" || stub.contMessage != "now do the second half" {
+		t.Errorf("Continue got (%q,%q)", stub.contAgentID, stub.contMessage)
+	}
+}
+
+func TestSendMessageTool_EmptyReplySurfaced(t *testing.T) {
+	useSpawner(t, &stubSpawner{continueReply: SpawnResult{AgentID: "id", Reply: "  "}})
+	out, err := SendMessageTool{}.Execute(context.Background(), "send_message", map[string]any{
+		"agent_id": "id",
+		"message":  "ping",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "produced no reply") {
+		t.Errorf("empty reply should be surfaced, got %q", out)
+	}
+}
+
+func TestSendMessageTool_RequiredArgs(t *testing.T) {
+	useSpawner(t, &stubSpawner{})
+	cases := []struct {
+		name  string
+		input map[string]any
+		want  string
+	}{
+		{"no agent_id", map[string]any{"message": "x"}, "agent_id is required"},
+		{"no message", map[string]any{"agent_id": "id"}, "message is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := SendMessageTool{}.Execute(context.Background(), "send_message", tc.input)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("want %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestSendMessageTool_RecursionRefused(t *testing.T) {
+	useSpawner(t, &stubSpawner{continueReply: SpawnResult{AgentID: "id", Reply: "would have worked"}})
+	ctx := WithSubAgentMarker(context.Background())
+	_, err := SendMessageTool{}.Execute(ctx, "send_message", map[string]any{
+		"agent_id": "id",
+		"message":  "wake up",
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot message another sub-agent") {
+		t.Errorf("expected recursion refusal, got %v", err)
+	}
+}
+
+func TestSendMessageTool_NoSpawnerConfigured(t *testing.T) {
+	SetSpawner(nil)
+	_, err := SendMessageTool{}.Execute(context.Background(), "send_message", map[string]any{
+		"agent_id": "id",
+		"message":  "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("expected 'not configured' error, got %v", err)
+	}
+}
+
+func TestSendMessageTool_ContinueErrorPropagates(t *testing.T) {
+	useSpawner(t, &stubSpawner{continueErr: errors.New("no longer alive")})
+	_, err := SendMessageTool{}.Execute(context.Background(), "send_message", map[string]any{
+		"agent_id": "stale",
+		"message":  "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "no longer alive") {
+		t.Errorf("expected propagated continue error, got %v", err)
+	}
+}
+
+func TestDefaultTools_SendMessageGatedOnSpawner(t *testing.T) {
+	SetSpawner(nil)
+	t.Cleanup(func() { SetSpawner(nil) })
+
+	has := func() bool {
+		for _, d := range DefaultTools() {
+			if d.Name == "send_message" {
+				return true
+			}
+		}
+		return false
+	}
+
+	if has() {
+		t.Error("send_message should be absent when no spawner is configured")
+	}
+	useSpawner(t, &stubSpawner{})
+	if !has() {
+		t.Error("send_message should be present once a spawner is registered")
+	}
+}
+
+func TestLaunchAgentTool_TagsReplyWithAgentID(t *testing.T) {
+	useSpawner(t, &stubSpawner{replies: []SpawnResult{{AgentID: "deadbeef", Reply: "the finding"}}})
+	out, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+		"description": "Investigate",
+		"prompt":      "look into X",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "[agent deadbeef] the finding" {
+		t.Errorf("launch_agent reply should carry the agent tag, got %q", out)
+	}
+}


### PR DESCRIPTION
## What

Sub-agents launched with `launch_agent` were fire-and-forget — the child ran to completion, returned a final string, and was discarded with no handle to re-address. This adds a **`send_message`** tool so the **top-level parent agent** can wake a still-alive sub-agent and continue its conversation with full history (Claude-Code-style `Agent` + `SendMessage`, rather than the current Codex-style one-shot).

## Why it's small

`internal/agent/` needs **zero changes** — `agent.Run` already appends to the same `History`, so a kept-alive child naturally continues when `Run` is called again. The only missing pieces were keeping the child alive and addressing it.

## Changes

- **`childRegistry`** (`cmd/octo/sub_agent.go`): in-memory, session-scoped map of live children, **LRU-capped at 8 + 30min idle TTL**. Purely in-process; nothing persisted.
- **`SpawnResult.AgentID` + `Spawner.Continue`**: `Spawn` registers the child and returns its id; `Continue` re-runs it by id.
- **`send_message` tool** (`internal/tools/send_message.go`): gated on the spawner like `launch_agent`, refuses calls from inside a sub-agent, and is filtered out of every child's toolbelt — so only the top-level parent can use it (symmetric with "sub-agents can't spawn").
- `launch_agent` / `send_message` replies carry an `[agent <id>]` tag so the model has a stable handle.

## Pitfalls handled

| # | Pitfall | Fix |
|---|---|---|
| ① | Concurrent `Continue` on one child corrupts its history | per-child mutex serializes `runChild`; `send_message` kept out of the read-only parallel set |
| ② | `SessionTokens` is cumulative → double-counting | accrue per-round **delta** into the parent |
| ③ | Live children leak memory | LRU 8 + 30min TTL; registry dies with the session |
| ④ | Continuation skips recursion guard | `runChild` re-stamps `WithSubAgentMarker` |

## Scope (confirmed decisions)

- **in-memory only** — no cross-process persistence
- **taskgraph untouched** — its `spawnerExecutor` only calls `Spawn`
- **top-level parent only** — children can't `send_message`

## Tests

~17 new cases: continuation carries history, per-round delta (no double-count), unknown/evicted id, LRU + TTL eviction, concurrent-Continue serialization (under `-race`), children can't see `send_message`, spawner gating.

`gofmt` clean · `go vet` clean · `go test -race ./...` green across all 20 packages.

Design: `dev-docs/resumable-subagent-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)