### PR TITLE
fix(config): prompt for API key when switching provider in wizard

### DIFF
--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -231,7 +231,15 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 	if provider == providerOpenAI {
 		envVar = "OPENAI_API_KEY"
 	}
-	if os.Getenv(envVar) == "" && existing.APIKey == "" {
+	// Prompt for key when env is empty AND (no stored key OR switching provider —
+	// a key stored for a different provider doesn't help the new one).
+	needsKeyPrompt := os.Getenv(envVar) == "" &&
+		(existing.APIKey == "" || existing.Provider != provider)
+	if !needsKeyPrompt {
+		// Preserve the existing key when staying on the same provider and not
+		// explicitly re-prompting.
+		out.APIKey = existing.APIKey
+	} else {
 		ans := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
 			"Store the API key in this file? Not recommended — prefer "+envVar+" (y/N)", "n")))
 		if ans == "y" || ans == "yes" {

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -164,6 +164,40 @@ func TestRunConfig_Show_ReportsSourcesNotKey(t *testing.T) {
 	}
 }
 
+func TestRunConfig_Wizard_SwitchesProviderAndPromptsForKey(t *testing.T) {
+	// When the stored config targets one provider and the user switches to
+	// another, the wizard must prompt for an API key for the NEW provider —
+	// the old provider's key is useless for the new one.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+
+	// Start with an anthropic config that has a stored key.
+	if err := (config.Config{Provider: "anthropic", APIKey: "old-anthropic-key"}).Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Answers: provider=openai, model=(default), base_url=(blank), store_key=y, key=new-openai-key.
+	in := strings.NewReader("openai\n\n\ny\nnew-openai-key\n")
+	var stdout, stderr bytes.Buffer
+	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+
+	got, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load after wizard: %v", err)
+	}
+	if got.Provider != "openai" {
+		t.Errorf("provider = %q, want openai", got.Provider)
+	}
+	if got.APIKey != "new-openai-key" {
+		t.Errorf("APIKey = %q, want new-openai-key", got.APIKey)
+	}
+}
+
 func TestRunConfig_UnknownSubcommand(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	if code := runConfig([]string{"frobnicate"}, strings.NewReader(""), &stdout, &stderr); code != 2 {


### PR DESCRIPTION
Previously, the config wizard only prompted for an API key when no key was stored at all. If a user had a key stored for provider A and then switched to provider B, the wizard silently skipped the key prompt, leaving the new provider without a usable key.

The fix changes the prompt condition to also trigger when the user switches providers — a key stored for a different provider is useless for the new one.

Added TestRunConfig_Wizard_SwitchesProviderAndPromptsForKey to cover this scenario.