### PR TITLE
fix(terminal): kill subprocess when context is cancelled

### DIFF
--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -28,12 +28,18 @@ func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 	if activeSandbox != nil {
 		return sandbox.Command(ctx, command, *activeSandbox)
 	}
+	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
 		// -NoProfile: reproducible env (don't run the user's $PROFILE).
 		// -NonInteractive: never block on a PowerShell prompt mid-command.
-		return exec.CommandContext(ctx, resolvePowerShell(), "-NoProfile", "-NonInteractive", "-Command", command), nil
+		cmd = exec.CommandContext(ctx, resolvePowerShell(), "-NoProfile", "-NonInteractive", "-Command", command)
+	} else {
+		cmd = exec.CommandContext(ctx, "sh", "-c", command)
 	}
-	return exec.CommandContext(ctx, "sh", "-c", command), nil
+	if attr := setProcessGroupOpts(); attr != nil {
+		cmd.SysProcAttr = attr
+	}
+	return cmd, nil
 }
 
 // resolvePowerShell picks the Windows shell once: PowerShell 7+ (`pwsh`) when

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -151,6 +151,17 @@ func (t TerminalTool) ExecuteStream(
 		// the rest. The Wait() error below is the canonical signal.
 	}()
 
+	// Kill the subprocess (and any children it spawned) when the context is
+	// cancelled (e.g. user pressed Esc in the TUI). Without this, cmd.Wait()
+	// blocks until the child exits on its own, so an interactive command like
+	// `gh pr checks --watch` appears to ignore the interrupt.
+	go func() {
+		<-ctx.Done()
+		if cmd.Process != nil {
+			_ = killProcessGroup(cmd.Process)
+		}
+	}()
+
 	waitErr := cmd.Wait()
 	_ = pw.Close() // unblocks the scanner's Read by EOF
 	<-readDone     // ensure goroutine has flushed before reading `out`

--- a/internal/tools/terminal_kill.go
+++ b/internal/tools/terminal_kill.go
@@ -1,0 +1,21 @@
+//go:build darwin || linux
+
+package tools
+
+import (
+	"os"
+	"syscall"
+)
+
+// setProcessGroupOpts sets SysProcAttr so the child becomes a new process
+// group leader. This lets killProcessGroup send a signal to the entire
+// group (the shell and any processes it spawns).
+func setProcessGroupOpts() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessGroup kills the process group rooted at p.
+// On POSIX it sends SIGKILL to -Pid (the whole group).
+func killProcessGroup(p *os.Process) error {
+	return syscall.Kill(-p.Pid, syscall.SIGKILL)
+}

--- a/internal/tools/terminal_kill_windows.go
+++ b/internal/tools/terminal_kill_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package tools
+
+import (
+	"os"
+	"syscall"
+)
+
+// setProcessGroupOpts is a no-op on Windows.
+func setProcessGroupOpts() *syscall.SysProcAttr { return nil }
+
+// killProcessGroup kills the process on Windows.
+// Windows doesn't have POSIX process groups in the same way, so we fall back
+// to killing just the top-level process.
+func killProcessGroup(p *os.Process) error {
+	return p.Kill()
+}

--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 )
@@ -181,6 +182,38 @@ func TestTerminalTool_ExecuteStream_NonZeroExitPreservesContract(t *testing.T) {
 	}
 	if !strings.Contains(result, "[exit:") {
 		t.Errorf("output should include exit annotation: %q", result)
+	}
+}
+
+func TestTerminalTool_ContextCancel_KillsChild(t *testing.T) {
+	// When the context is cancelled mid-run (e.g. user pressed Esc in the TUI),
+	// the subprocess must be killed rather than left running.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start a long-running command that would sleep for 30s.
+	go func() {
+		// Cancel after a short delay so the test doesn't hang forever if the
+		// fix is broken.
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	result, err := TerminalTool{}.Execute(ctx, "terminal", map[string]any{
+		"command": "sleep 30",
+	})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Execute should not error on cancellation: %v", err)
+	}
+	// The result should mention the signal/kill, not a clean exit.
+	if !strings.Contains(result, "[exit:") {
+		t.Errorf("result should contain [exit:...] after kill; got: %q", result)
+	}
+	// Must finish well before 30s — the cancellation killed it.
+	if elapsed > 2*time.Second {
+		t.Errorf("took %s — context cancellation did not kill the child promptly", elapsed)
 	}
 }
 


### PR DESCRIPTION
Previously, when a user pressed Esc in the TUI to interrupt a running turn, the terminal tool's subprocess (e.g. ) continued running because cmd.Wait() blocked until the child exited naturally. The context cancellation only prevented new processes from starting, but did not kill already-running ones.

The fix adds a goroutine that listens on ctx.Done() and calls Process.Kill() on the subprocess when the context is cancelled. This ensures that user interrupts are immediately effective, even for long-running or interactive commands.

Added TestTerminalTool_ContextCancel_KillsChild to verify the child is terminated promptly (within 2s of cancellation, vs. the 30s sleep).