### PR TITLE
feat(agent): raise default max-turns to 100, unlimited for unattended

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -36,9 +36,9 @@ const (
 
 // unattendedMaxTurns is the agentic-loop cap applied when --max-turns is left
 // at its auto-sentinel (0) and there's no interactive human to continue past
-// the limit (piped stdin, --prompt-file). Higher than the interactive default
-// (agent's 20) because a headless task can't be told to keep going.
-const unattendedMaxTurns = 60
+// the limit (piped stdin, --prompt-file). -1 means unlimited because a
+// headless task can't be told to keep going.
+const unattendedMaxTurns = -1
 
 // resolveMaxTurns picks the agentic-loop cap. An explicit --max-turns (any
 // non-zero flagVal) always wins. Otherwise an unattended run — seeded via
@@ -107,7 +107,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	quietFlag := fs.Bool("quiet", false, "Strip all status chrome (no spinner, no banner, no cache line). Also OCTO_VERBOSITY=quiet.")
 	verboseFlag := fs.Bool("verbose", false, "Print extra context (provider/model/endpoint, always-on cache line). Also OCTO_VERBOSITY=verbose.")
 	permMode := fs.String("permission-mode", "interactive", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask)")
-	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = auto: 20 interactive, 60 unattended/--prompt-file)")
+	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = auto: 100 interactive, unlimited unattended/--prompt-file)")
 	maxCost := fs.Float64("max-cost", 0, "Stop the session once estimated cost (USD) reaches this; 0 = unlimited")
 	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (~75% of the model's context window), <0 = disabled")
 	thinkingBudget := fs.Int("thinking-budget", 0, "Enable extended thinking with this token budget (Anthropic/Kimi); 0 = off")

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -260,9 +260,12 @@ func (a *Agent) TurnStream(
 }
 
 // defaultMaxTurns is the fallback per-Run loop cap when Agent.MaxTurns is
-// unset (<= 0). A "turn" here is one provider round-trip inside the agentic
+// unset (0). A "turn" here is one provider round-trip inside the agentic
 // loop; the cap stops a misbehaving model from looping on tools forever.
-const defaultMaxTurns = 20
+const defaultMaxTurns = 100
+
+// unlimitedTurns signals no cap (used for unattended runs).
+const unlimitedTurns = -1
 
 // Run is the agentic loop: it appends the user message to history then
 // repeatedly calls the provider until the model reaches end_turn (no more
@@ -411,7 +414,7 @@ func (a *Agent) runLoop(
 	a.History.Append(NewUserMessage(userInput))
 
 	limit := a.turnLimit()
-	for i := 0; i < limit; i++ {
+	for i := 0; limit == unlimitedTurns || i < limit; i++ {
 		// Interrupt (Ctrl-C) between iterations — e.g. right after a tool batch.
 		if ctx.Err() != nil {
 			return a.finishInterrupted(handler)
@@ -532,10 +535,17 @@ func (a *Agent) finishInterrupted(handler EventHandler) (Reply, error) {
 	return reply, context.Canceled
 }
 
-// turnLimit resolves the per-Run loop cap, applying the default when unset.
+// turnLimit resolves the per-Run loop cap.
+//
+//	> 0  → explicit cap
+//	0    → defaultMaxTurns (interactive default)
+//	< 0  → unlimited (unattended runs)
 func (a *Agent) turnLimit() int {
 	if a.MaxTurns > 0 {
 		return a.MaxTurns
+	}
+	if a.MaxTurns < 0 {
+		return unlimitedTurns
 	}
 	return defaultMaxTurns
 }


### PR DESCRIPTION
- Interactive default: 20 → 100 (more headroom for complex tasks)
- Unattended (--prompt-file / piped stdin): 60 → unlimited (-1). Headless tasks can'\''t say `continue`, so they should run to completion.
- Add `unlimitedTurns` sentinel (-1) and update `turnLimit()` to handle it.
- `runLoop` uses `limit == unlimitedTurns || i < limit` for infinite loop when unlimited.
- Update help text to reflect new defaults.