### PR TITLE
feat(permission): add --permission-mode auto (allow on ask)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -106,7 +106,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	noTUI := fs.Bool("no-tui", false, "Disable the interactive TUI on a terminal; use the plain line-based REPL (also OCTO_TUI=0)")
 	quietFlag := fs.Bool("quiet", false, "Strip all status chrome (no spinner, no banner, no cache line). Also OCTO_VERBOSITY=quiet.")
 	verboseFlag := fs.Bool("verbose", false, "Print extra context (provider/model/endpoint, always-on cache line). Also OCTO_VERBOSITY=verbose.")
-	permMode := fs.String("permission-mode", "interactive", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask)")
+	permMode := fs.String("permission-mode", "interactive", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask) | auto (allow on ask)")
 	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = auto: 100 interactive, unlimited unattended/--prompt-file)")
 	maxCost := fs.Float64("max-cost", 0, "Stop the session once estimated cost (USD) reaches this; 0 = unlimited")
 	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (~75% of the model's context window), <0 = disabled")
@@ -125,8 +125,8 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// silently falling back to the more-permissive interactive mode — a user
 	// who asked for "strict" and got "interactive" by typo is a security
 	// regression, not a convenience.
-	if *permMode != string(permission.ModeInteractive) && *permMode != string(permission.ModeStrict) {
-		fmt.Fprintf(stderr, "octo chat: invalid --permission-mode %q (want 'interactive' or 'strict')\n", *permMode)
+	if *permMode != string(permission.ModeInteractive) && *permMode != string(permission.ModeStrict) && *permMode != string(permission.ModeAutoApprove) {
+		fmt.Fprintf(stderr, "octo chat: invalid --permission-mode %q (want 'interactive', 'strict', or 'auto')\n", *permMode)
 		return 2
 	}
 

--- a/cmd/octo/completion.go
+++ b/cmd/octo/completion.go
@@ -111,7 +111,7 @@ func chatCandidates(words []string, prev string) []string {
 	case "--provider":
 		return []string{"anthropic", "openai"}
 	case "--permission-mode":
-		return []string{"interactive", "strict"}
+		return []string{"interactive", "strict", "auto"}
 	case "--model", "--system", "--max-tokens", "--max-turns",
 		"--max-cost", "--compact-threshold", "--thinking-budget",
 		"--sandbox-write", "--sandbox-read":
@@ -173,7 +173,7 @@ func initCandidates(prev string) []string {
 	case "--provider":
 		return []string{"anthropic", "openai"}
 	case "--permission-mode":
-		return []string{"interactive", "strict"}
+		return []string{"interactive", "strict", "auto"}
 	}
 	return initFlags
 }
@@ -230,7 +230,7 @@ What it completes:
   - Session IDs after "octo chat -c " — full + short + "last".
   - Task IDs after "octo goal status|show|resume|cancel|run " — full + short + "last".
   - Fixed values for --provider (anthropic|openai) and --permission-mode
-    (interactive|strict).
+    (interactive|strict|auto).
 
 The shell snippet just delegates to the hidden "octo __complete" subcommand;
 the routing logic lives in the binary, so the same snippet keeps working as

--- a/cmd/octo/completion_test.go
+++ b/cmd/octo/completion_test.go
@@ -55,7 +55,7 @@ func TestCompletionCandidates_ProviderValueAfterFlag(t *testing.T) {
 
 func TestCompletionCandidates_PermissionModeAfterFlag(t *testing.T) {
 	got := completionCandidates([]string{"octo", "chat", "--permission-mode", ""})
-	if !sliceEq(got, []string{"interactive", "strict"}) {
+	if !sliceEq(got, []string{"interactive", "strict", "auto"}) {
 		t.Errorf("--permission-mode value completion = %v", got)
 	}
 }

--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -111,7 +111,7 @@ Common flags:
   --no-save                Don't auto-save the session to ~/.octo/sessions
   --no-memory              Disable cross-session memory injection
   --sandbox                OS-enforced confinement for terminal commands (macOS/Linux)
-  --permission-mode <m>    interactive (default; prompts on ask) | strict (denies asks)
+  --permission-mode <m>    interactive (default; prompts on ask) | strict (denies asks) | auto (allows asks)
   --list-sessions          Print recent sessions and exit
   --quiet                  Strip status chrome (spinner, banner, cache line)
   --verbose                Print extra context (provider/model/endpoint, always-on cache line)
@@ -195,7 +195,7 @@ Common flags:
   --model <name>           Override the default model
   --plain                  Terse ↳ status lines instead of rich diff cards
   --sandbox                OS-enforced command confinement (macOS/Linux)
-  --permission-mode <m>    interactive | strict (default)
+  --permission-mode <m>    interactive | strict (default) | auto
 
 Environment:
   ANTHROPIC_API_KEY / OPENAI_API_KEY    Required for the chosen provider.`)

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -37,7 +37,7 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	providerName := fs.String("provider", "", "Provider: anthropic | openai (default from `octo config`, else anthropic)")
 	model := fs.String("model", "", "Model name (defaults to the provider's cheapest reasoning model)")
 	plain := fs.Bool("plain", false, "Render tool events as one-line ↳ status lines instead of rich diff cards")
-	permMode := fs.String("permission-mode", "strict", "Tool permission handling: interactive | strict")
+	permMode := fs.String("permission-mode", "strict", "Tool permission handling: interactive | strict | auto")
 	useSandbox := fs.Bool("sandbox", false, "Confine commands to the project dir + tmp with no network (OS-enforced; macOS/Linux). Fails closed if unavailable.")
 	sandboxAllowNet := fs.Bool("sandbox-allow-net", false, "Under --sandbox, permit network access (default: denied)")
 	var sandboxWrite, sandboxRead stringList
@@ -46,8 +46,8 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if *permMode != string(permission.ModeInteractive) && *permMode != string(permission.ModeStrict) {
-		fmt.Fprintf(stderr, "octo init: invalid --permission-mode %q (want 'interactive' or 'strict')\n", *permMode)
+	if *permMode != string(permission.ModeInteractive) && *permMode != string(permission.ModeStrict) && *permMode != string(permission.ModeAutoApprove) {
+		fmt.Fprintf(stderr, "octo init: invalid --permission-mode %q (want 'interactive', 'strict', or 'auto')\n", *permMode)
 		return 2
 	}
 

--- a/cmd/octo/permission_gate.go
+++ b/cmd/octo/permission_gate.go
@@ -65,8 +65,12 @@ func permissionConfigPath() string {
 // permission.Mode. Unknown values fall back to interactive (the safe,
 // CLI-friendly default) and the caller is expected to have validated.
 func resolvePermissionMode(s string) permission.Mode {
-	if s == string(permission.ModeStrict) {
+	switch s {
+	case string(permission.ModeStrict):
 		return permission.ModeStrict
+	case string(permission.ModeAutoApprove):
+		return permission.ModeAutoApprove
+	default:
+		return permission.ModeInteractive
 	}
-	return permission.ModeInteractive
 }

--- a/cmd/octo/permission_gate_test.go
+++ b/cmd/octo/permission_gate_test.go
@@ -109,12 +109,28 @@ func TestCLIGate_StrictModeNeverPrompts(t *testing.T) {
 	}
 }
 
+func TestCLIGate_AutoApproveModeNeverPrompts(t *testing.T) {
+	// In auto-approve mode the engine collapses ask → allow, so a command
+	// that would normally prompt is allowed without reading stdin.
+	g, out := newGate(t, permission.ModeAutoApprove, "") // no stdin needed
+	ok, reason := g.Check(context.Background(), "terminal", map[string]any{"command": "sudo apt update"})
+	if !ok {
+		t.Errorf("auto mode must allow ask-class commands; reason=%q", reason)
+	}
+	if out.Len() != 0 {
+		t.Errorf("auto mode must not prompt; got %q", out.String())
+	}
+}
+
 func TestResolvePermissionMode(t *testing.T) {
 	if resolvePermissionMode("strict") != permission.ModeStrict {
 		t.Error("strict should map to ModeStrict")
 	}
 	if resolvePermissionMode("interactive") != permission.ModeInteractive {
 		t.Error("interactive should map to ModeInteractive")
+	}
+	if resolvePermissionMode("auto") != permission.ModeAutoApprove {
+		t.Error("auto should map to ModeAutoApprove")
 	}
 	// Unknown falls back to interactive (chat.go validates before this is
 	// reached, but the helper itself defaults safely).

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -53,6 +53,7 @@ type Mode string
 const (
 	ModeInteractive Mode = "interactive"
 	ModeStrict      Mode = "strict"
+	ModeAutoApprove Mode = "auto"
 )
 
 // Rule is one entry in the rule list for a tool. Exactly one of Pattern /
@@ -202,10 +203,20 @@ func (e *Engine) DenialReason(toolName string, input map[string]any) string {
 	return fmt.Sprintf("permission_denied: %s — user declined the interactive prompt.", toolName)
 }
 
-// applyMode collapses Ask → Deny when the engine is in strict mode.
+// applyMode adjusts Ask decisions based on the engine mode:
+//   - ModeStrict:      Ask → Deny
+//   - ModeAutoApprove: Ask → Allow
+//   - ModeInteractive: Ask passes through unchanged
 func (e *Engine) applyMode(d Decision) Decision {
-	if d == Ask && e.mode == ModeStrict {
-		return Deny
+	switch e.mode {
+	case ModeStrict:
+		if d == Ask {
+			return Deny
+		}
+	case ModeAutoApprove:
+		if d == Ask {
+			return Allow
+		}
 	}
 	return d
 }

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -148,6 +148,24 @@ func TestInteractiveMode_PreservesAsk(t *testing.T) {
 	}
 }
 
+func TestAutoApproveMode_TurnsAskIntoAllow(t *testing.T) {
+	e, err := New("", "/work", ModeAutoApprove)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := e.Check("terminal", map[string]any{"command": "rm -rf node_modules"}); got != Allow {
+		t.Errorf("auto ask→allow: got %s, want Allow", got)
+	}
+	// Explicit allows still allow.
+	if got := e.Check("terminal", map[string]any{"command": "ls"}); got != Allow {
+		t.Errorf("auto still allows allow rules: got %s", got)
+	}
+	// Explicit denies still deny.
+	if got := e.Check("terminal", map[string]any{"command": "rm -rf /"}); got != Deny {
+		t.Errorf("auto still denies deny rules: got %s", got)
+	}
+}
+
 // ─── Remember cache ────────────────────────────────────────────────────────
 
 func TestRemember_ShortCircuits(t *testing.T) {


### PR DESCRIPTION
Adds a third permission mode `auto` that converts Ask decisions to Allow, enabling fully unattended agentic runs without interactive prompts.

### Changes
- `permission.ModeAutoApprove` ("auto"): ask → allow
- CLI: `--permission-mode` accepts "auto" in `chat`, `init`, completion
- Help text and shell completion updated
- Tests for engine mode + CLI gate behaviour

### Usage
```
octo chat --permission-mode auto
octo init --permission-mode auto
```