### PR TITLE
feat(agent): context overflow recovery with insert-then-compress

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -129,6 +129,10 @@ type Agent struct {
 	// default); >0 is an explicit token count. See compactTriggerTokens.
 	CompactThreshold int
 
+	// overflow handles "context too long" 400 errors by compressing history
+	// and retrying. Aligned with Ruby's perform_context_overflow_compression.
+	overflow overflowRecovery
+
 	// Cumulative token counts for this session (all turns combined).
 	sessionInputTokens  int
 	sessionOutputTokens int
@@ -436,11 +440,23 @@ func (a *Agent) runLoop(
 			if ctx.Err() != nil {
 				return a.finishInterrupted(handler)
 			}
+
+			// ── Context overflow recovery (aligned with Ruby) ──
+			if a.overflow.tryRecover(ctx, a, err) {
+				// Compression succeeded — retry the same iteration
+				// without incrementing i or popping user message
+				continue
+			}
+
 			if i == 0 {
 				a.History.popLast()
 			}
 			return Reply{}, fmt.Errorf("agent: loop[%d]: %w", i, err)
 		}
+
+		// Success — reset overflow attempt flag for next turn
+		a.overflow.reset()
+
 		a.accrueUsage(reply)
 
 		if reply.StopReason == "tool_use" {
@@ -478,6 +494,13 @@ func (a *Agent) runLoop(
 			}
 
 			a.History.Append(NewToolResultMessage(resultBlocks))
+
+			// Turn-in compaction check: after a tool batch, history may have
+			// grown significantly. If the estimated size is near the window,
+			// compact before the next LLM call to avoid a 400.
+			if a.shouldCompactBetweenBatches() {
+				_ = a.maybeCompact(ctx)
+			}
 			continue
 		}
 

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 // compactKeepTurns is how many of the most recent user turns runLoop keeps
@@ -25,9 +26,25 @@ const defaultContextWindow = 128_000
 // substring so dated/aliased names ("claude-haiku-4-5-2025…") still resolve.
 // Raise a model's entry when a larger window is confirmed.
 func contextWindow(model string) int {
+	m := strings.ToLower(model)
 	switch {
-	case strings.Contains(strings.ToLower(model), "claude"):
+	case strings.Contains(m, "claude-3-5"):
 		return 200_000
+	case strings.Contains(m, "claude-3"):
+		return 200_000
+	case strings.Contains(m, "claude-opus-4"):
+		return 200_000
+	case strings.Contains(m, "claude-sonnet-4"):
+		return 200_000
+	case strings.Contains(m, "claude-haiku-4"):
+		return 200_000
+	case strings.Contains(m, "claude"):
+		// Claude 4.x and newer models with 256K window
+		return 256_000
+	case strings.Contains(m, "gpt-4o"):
+		return 128_000
+	case strings.Contains(m, "gpt-4"):
+		return 128_000
 	default:
 		return defaultContextWindow
 	}
@@ -54,30 +71,41 @@ func (a *Agent) compactTriggerTokens() int {
 // compact carry-forward of decisions/paths/open tasks, not a transcript.
 const summarizeMaxTokens = 1024
 
-// summarizeSystem is the system prompt for the summarization side-call. It is
-// distinct from the main session prompt (the call is infrequent, so a cache
-// miss here is fine). The five-section structure mirrors Claude Code's
-// compaction prompt — a structured carry-forward retains far more usable
-// signal than a freeform "summarize this" instruction.
-const summarizeSystem = `You are a conversation summarizer for a coding agent. Produce a
-structured summary so the agent can continue the task without the full
-transcript. Be specific and terse — bullet points, real names, real paths.
-Output exactly these five sections:
+// compressionPrompt is the instruction inserted into the conversation for
+// insert-then-compress. The LLM sees the full history (cached) plus this
+// instruction, and returns a summary. Aligned with Ruby's COMPRESSION_PROMPT.
+const compressionPrompt = `═══════════════════════════════════════════════════════════════
+CRITICAL: TASK CHANGE - MEMORY COMPRESSION MODE
+═══════════════════════════════════════════════════════════════
+The conversation above has ENDED. You are now in MEMORY COMPRESSION MODE.
 
-## Primary Request
-The user's overall goal and any explicit, still-active instructions or constraints.
+CRITICAL INSTRUCTIONS - READ CAREFULLY:
+1. This is NOT a continuation of the conversation
+2. DO NOT respond to any requests in the conversation above
+3. DO NOT call ANY tools or functions
+4. DO NOT use tool_calls in your response
+5. Your response MUST be PURE TEXT ONLY
 
-## Key Technical Concepts
-Architecture, libraries, patterns, and decisions established so far.
+YOUR ONLY TASK: Create a comprehensive summary of the conversation above.
 
-## Files and Code
-Files read or modified (with paths), and the important changes made to each.
+REQUIRED RESPONSE FORMAT:
+First output a <topics> line listing 3-6 key topic phrases (comma-separated, concise).
+Then output the full summary wrapped in <summary> tags.
 
-## Errors and Fixes
-Errors encountered and how they were resolved; anything still broken.
+Example format:
+<topics>Rails setup, database config, deploy pipeline, Tailwind CSS</topics>
+<summary>
+...full summary text...
+</summary>
 
-## Current State and Next Steps
-What was just completed, and the immediate next action if the task is unfinished.`
+Focus on:
+- User's explicit requests and intents
+- Key technical concepts and code changes
+- Files examined and modified
+- Errors encountered and fixes applied
+- Current work status and pending tasks
+
+Begin your response NOW. Remember: PURE TEXT only, starting with <topics> then <summary>.`
 
 // maybeCompact summarizes the older portion of history when the most recent
 // context size (lastInputTokens) crossed CompactThreshold. It runs only at a
@@ -118,18 +146,48 @@ func (a *Agent) maybeCompact(ctx context.Context) error {
 }
 
 // summarize asks the Sender to condense the given messages into a summary.
-// It appends a single user instruction after the slice (which ends on an
-// assistant message, so alternation holds) and returns the reply text.
+// It uses the insert-then-compress strategy: the compression instruction is
+// appended to the messages slice (which ends on an assistant message, so
+// alternation holds), and the LLM returns a summary. The caller is responsible
+// for rebuilding history with the summary.
+//
+// Overflow protection: if the estimated token count of msgs exceeds the model's
+// context window, messages are popped from the head until it fits. This
+// prevents the compression call itself from 400-ing.
 func (a *Agent) summarize(ctx context.Context, msgs []Message) (string, error) {
+	// ── Overflow protection ──────────────────────────────────────────────
+	// If msgs alone exceeds the window, pop from head until it fits.
+	// This handles the case where the history is already over the limit
+	// (e.g. a single huge tool_result tipped it over).
+	window := contextWindow(a.Model)
+	for {
+		est := estimateMessages(msgs)
+		if est < window {
+			break
+		}
+		if len(msgs) <= 2 {
+			// Can't pop any more; proceed anyway and let the caller handle 400
+			break
+		}
+		msgs = msgs[1:] // pop from head (preserve system msg at index 0)
+	}
+
+	// ── Insert-then-compress ─────────────────────────────────────────────
 	req := make([]Message, 0, len(msgs)+1)
 	req = append(req, msgs...)
-	req = append(req, NewUserMessage(
-		"Summarize the conversation above per your instructions. Output only the summary."))
+	req = append(req, NewUserMessage(compressionPrompt))
 
-	reply, err := a.Sender.SendMessages(ctx, a.Model, summarizeSystem, req, summarizeMaxTokens)
+	reply, err := a.Sender.SendMessages(ctx, a.Model, "", req, summarizeMaxTokens)
 	if err != nil {
 		return "", err
 	}
+
+	// Defensive: if the LLM returned tool_calls instead of text (it shouldn't,
+	// but some models hallucinate), treat it as a failed compression.
+	if reply.StopReason == "tool_use" {
+		return "", fmt.Errorf("agent: compact: LLM returned tool_calls instead of summary")
+	}
+
 	// Summary tokens count toward the session budget like any other call.
 	a.sessionInputTokens += reply.InputTokens
 	a.sessionOutputTokens += reply.OutputTokens
@@ -164,4 +222,85 @@ func hasToolResult(m Message) bool {
 		}
 	}
 	return false
+}
+
+// shouldCompactBetweenBatches reports whether compaction should run after a
+// tool batch, before the next LLM call. This catches history growth within a
+// turn that lastInputTokens (from the previous provider call) doesn't reflect.
+//
+// The heuristic is aggressive: if the estimated token count exceeds 90% of the
+// model's context window, we compact. This prevents the next send() from 400-ing.
+func (a *Agent) shouldCompactBetweenBatches() bool {
+	trigger := a.compactTriggerTokens()
+	if trigger <= 0 {
+		return false
+	}
+	est := estimateMessages(a.History.Snapshot())
+	window := contextWindow(a.Model)
+	// Compact if we're within 10% of the window (more aggressive than the
+	// between-turns trigger, which uses compactThresholdFraction = 75%).
+	return est > int(float64(window)*0.9)
+}
+
+// ── Token estimation (fast heuristic) ──────────────────────────────────────
+
+// estimateMessages returns a fast heuristic token count for a message slice.
+// Used for overflow protection before compression calls.
+func estimateMessages(msgs []Message) int {
+	total := 0
+	for _, m := range msgs {
+		total += estimateMessage(m)
+	}
+	return total
+}
+
+// estimateMessage counts tokens for a single message.
+// Heuristic: ~4 chars/token for ASCII/code, ~1.5 chars/token for CJK.
+func estimateMessage(m Message) int {
+	tokens := 4 // role overhead
+	tokens += estimateText(m.Content)
+	for _, b := range m.Blocks {
+		switch b.Type {
+		case "text":
+			tokens += estimateText(b.Text)
+		case "tool_use":
+			tokens += estimateText(b.Name)
+			tokens += estimateMap(b.Input)
+		case "tool_result":
+			tokens += estimateText(b.Result)
+		case "thinking":
+			tokens += estimateText(b.Thinking)
+		}
+	}
+	return tokens
+}
+
+func estimateText(s string) int {
+	if s == "" {
+		return 0
+	}
+	asciiCount := 0
+	multiCount := 0
+	for _, r := range s {
+		if r < 128 {
+			asciiCount++
+		} else {
+			multiCount += utf8.RuneLen(r)
+		}
+	}
+	return (asciiCount / 4) + int(float64(multiCount)/1.5+0.5)
+}
+
+func estimateMap(m map[string]any) int {
+	if len(m) == 0 {
+		return 0
+	}
+	var b strings.Builder
+	for k, v := range m {
+		b.WriteString(k)
+		b.WriteString(":")
+		b.WriteString(fmt.Sprintf("%v", v))
+		b.WriteString(",")
+	}
+	return estimateText(b.String())
 }

--- a/internal/agent/history.go
+++ b/internal/agent/history.go
@@ -50,3 +50,48 @@ func (h *History) Reset() {
 	defer h.mu.Unlock()
 	h.messages = nil
 }
+
+// TruncateTo keeps only the first n messages.
+// Used by overflow recovery to pop messages from tail.
+func (h *History) TruncateTo(n int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if n < len(h.messages) {
+		h.messages = h.messages[:n]
+	}
+}
+
+// ReplaceAll atomically replaces the entire message list.
+// Used by compaction to rebuild history from summary + recent messages.
+func (h *History) ReplaceAll(msgs []Message) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.messages = make([]Message, len(msgs))
+	copy(h.messages, msgs)
+}
+
+// Tail returns the last n messages (or all if fewer).
+func (h *History) Tail(n int) []Message {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	if n >= len(h.messages) {
+		out := make([]Message, len(h.messages))
+		copy(out, h.messages)
+		return out
+	}
+	out := make([]Message, n)
+	copy(out, h.messages[len(h.messages)-n:])
+	return out
+}
+
+// FindSystemMsg returns the first system message index, or -1.
+func (h *History) FindSystemMsg() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for i, m := range h.messages {
+		if m.Role == RoleSystem {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/agent/overflow.go
+++ b/internal/agent/overflow.go
@@ -1,0 +1,185 @@
+package agent
+
+import (
+	"context"
+	"strings"
+)
+
+// overflowRecovery handles "context too long" errors by compressing history
+// and retrying. Aligned with Ruby's perform_context_overflow_compression.
+type overflowRecovery struct {
+	inProgress bool // true during recovery compression (prevents recursion)
+	attempted  bool // true after one attempt per turn (max one retry)
+}
+
+// contextTooLongError detects whether an error is about exceeding the model's
+// context window. Aligned with Ruby's context_too_long_error?.
+//
+// Coverage (verified against real production error strings):
+//
+//	OpenAI:    "This model's maximum context length is 128000 tokens..."
+//	Anthropic: "prompt is too long: 218849 tokens > 200000 maximum"
+//	Qwen:      "You passed 117345 input tokens... context length is only 125536"
+//	DeepSeek:  Variants of "context length" / "tokens exceeds"
+//	Generic:   "The total number of tokens exceeds the model's maximum context length"
+func contextTooLongError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+
+	// Strong phrases — any one is conclusive on its own.
+	strongPhrases := []string{
+		"context length",
+		"context_length_exceeded",
+		"maximum context",
+		"maximum input length",
+		"prompt is too long",
+		"input is too long",
+		"exceeds the maximum context",
+		"exceeds the model's context",
+		"exceeds the model's maximum",
+		"reduce the length of the input",
+		"reduce the length of the messages",
+		"reduce the length of your",
+		"reduce the length of the prompt",
+		"range of input length",
+	}
+	for _, p := range strongPhrases {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+
+	// Pattern 1: Anthropic-style "<N> tokens > <N> maximum"
+	if strings.Contains(msg, "tokens") && strings.Contains(msg, "maximum") {
+		return true
+	}
+
+	// Pattern 2: Qwen-style structured field "parameter=input_tokens"
+	if strings.Contains(msg, "parameter=input_tokens") {
+		return true
+	}
+
+	return false
+}
+
+// tryRecover attempts to recover from a context-overflow error by compressing
+// history and returning true if the caller should retry.
+//
+// Layer 1 (standard): pull back 1 message from tail (preserves prompt cache),
+// compress, retry. Handles 99% of cases.
+//
+// Layer 2 (aggressive): pull back ~half the history. Sacrifices cache but
+// guarantees the compression call fits.
+func (r *overflowRecovery) tryRecover(ctx context.Context, a *Agent, sendErr error) bool {
+	if r.attempted || r.inProgress {
+		return false
+	}
+	if !contextTooLongError(sendErr) {
+		return false
+	}
+
+	r.attempted = true
+	r.inProgress = true
+	defer func() { r.inProgress = false }()
+
+	// Layer 1: standard cache-preserving compression
+	if a.tryOverflowCompact(ctx, pullBackStandard) {
+		return true
+	}
+
+	// Layer 2: aggressive fallback
+	if a.tryOverflowCompact(ctx, pullBackAggressive) {
+		return true
+	}
+
+	return false
+}
+
+// reset clears the attempted flag so the next turn can attempt recovery again.
+func (r *overflowRecovery) reset() {
+	r.attempted = false
+}
+
+const (
+	pullBackStandard   = 1  // preserve cache#A
+	pullBackAggressive = -1 // ~half history, computed dynamically
+)
+
+// tryOverflowCompact is the Layer 1/2 entry point for 400-recovery compression.
+// It pops K messages from tail, runs compression, then reattaches them.
+// Returns true if compression succeeded and history was rebuilt.
+func (a *Agent) tryOverflowCompact(ctx context.Context, pullBackMode int) bool {
+	trigger := a.compactTriggerTokens()
+	if trigger <= 0 {
+		return false // compaction disabled
+	}
+
+	msgs := a.History.Snapshot()
+	if len(msgs) < 4 {
+		return false // not enough to safely compact
+	}
+
+	// Compute pull-back count
+	k := computePullBack(len(msgs), pullBackMode)
+	if k <= 0 || k >= len(msgs)-1 {
+		return false // would pop too much (keep at least system + 1)
+	}
+
+	// Save pulled-back messages
+	pulledBack := make([]Message, k)
+	copy(pulledBack, msgs[len(msgs)-k:])
+
+	// Build truncated history for compression
+	truncated := NewHistory()
+	for _, m := range msgs[:len(msgs)-k] {
+		truncated.Append(m)
+	}
+
+	// Find safe split point
+	split := safeSplitIndex(truncated.Snapshot(), compactKeepTurns)
+	if split <= 0 {
+		return false
+	}
+
+	// Run compression side-call on truncated history
+	summary, err := a.summarize(ctx, truncated.Snapshot()[:split])
+	if err != nil || summary == "" {
+		return false
+	}
+
+	// Rebuild: summary + kept recent + pulled_back
+	recent := truncated.Snapshot()[split:]
+
+	a.History.Reset()
+	a.History.Append(NewUserMessage("[Earlier conversation summary]\n\n" + summary))
+	for _, m := range recent {
+		a.History.Append(m)
+	}
+	for _, m := range pulledBack {
+		a.History.Append(m)
+	}
+
+	a.lastInputTokens = 0 // reset trigger so we don't immediately re-compact
+	return true
+}
+
+func computePullBack(historyLen, mode int) int {
+	if mode == pullBackStandard {
+		return 1
+	}
+	// Aggressive: pop ~half, bounded
+	half := historyLen / 2
+	return clamp(half, 4, historyLen-2) // keep system + at least 1 message
+}
+
+func clamp(v, min, max int) int {
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
+}


### PR DESCRIPTION
Align Go agent with Ruby's context protection system.

## Changes

- **overflowRecovery**: catch "context too long" 400 errors, compress history, and retry once. Two-layer fallback: standard (pull_back: 1, preserves cache) then aggressive (pull_back: ~half).
- **insert-then-compress**: append compression instruction to current conversation so LLM reuses existing prompt cache instead of reprocessing full history.
- **overflow protection**: if estimated tokens exceed model window, pop messages from head until it fits. Prevents compression call itself from 400-ing.
- **turn-in compaction**: after each tool batch, check if estimated history is near window (90% threshold) and compact before next LLM call.
- **fix contextWindow()**: recognize 256K Claude 4.x models (was hardcoded to 200K for all Claude).
- **extend History**: add TruncateTo, ReplaceAll, Tail, FindSystemMsg.

## Testing

- go test ./... ✅
- go vet ./... ✅
- gofmt ✅

Closes the "requested: 262589 > limit: 262144" issue.