### PR TITLE
feat(tools): read_file image support for multimodal models

### DIFF
--- a/cmd/octo/repl_test.go
+++ b/cmd/octo/repl_test.go
@@ -572,6 +572,6 @@ func TestREPL_MemoryNudge_AbsentWhenToolsOff(t *testing.T) {
 // that need cfg.tools to be non-empty but don't actually invoke any tools.
 type dummyExecutor struct{}
 
-func (dummyExecutor) Execute(_ context.Context, name string, _ map[string]any) (string, error) {
-	return "ok:" + name, nil
+func (dummyExecutor) Execute(_ context.Context, name string, _ map[string]any) (agent.ToolResult, error) {
+	return agent.ToolResult{Text: "ok:" + name}, nil
 }

--- a/cmd/octo/sub_agent_test.go
+++ b/cmd/octo/sub_agent_test.go
@@ -41,8 +41,8 @@ func (s *subAgentSender) SendMessages(_ context.Context, model, system string, m
 // never produces tool_use blocks (so Execute is never invoked).
 type nilExecutor struct{}
 
-func (nilExecutor) Execute(_ context.Context, _ string, _ map[string]any) (string, error) {
-	return "", nil
+func (nilExecutor) Execute(_ context.Context, _ string, _ map[string]any) (agent.ToolResult, error) {
+	return agent.ToolResult{Text: ""}, nil
 }
 
 func TestAgentSpawner_RunsChildAndRollsTokensIntoParent(t *testing.T) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -707,36 +707,39 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 		calls = append(calls, c)
 	}
 
-	results := make([]ContentBlock, len(calls))
+	// Pass 2 — execute. Each tool may return multiple blocks (e.g. tool_result +
+	// image), so we collect per-tool slices and flatten at the end.
+	var resultSlices [][]ContentBlock
 
-	// Pass 2 — execute.
 	if canParallelize(calls) {
 		var wg sync.WaitGroup
+		resultSlices = make([][]ContentBlock, len(calls))
 		for i := range calls {
 			if calls[i].denyReason != "" {
-				results[i] = NewToolResultBlock(calls[i].block.ID, calls[i].denyReason, true)
+				resultSlices[i] = []ContentBlock{NewToolResultBlock(calls[i].block.ID, calls[i].denyReason, true)}
 				continue
 			}
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
-				out, err := executor.Execute(ctx, calls[i].block.Name, calls[i].block.Input)
-				results[i] = toolResultBlock(calls[i].block.ID, out, err)
+				res, err := executor.Execute(ctx, calls[i].block.Name, calls[i].block.Input)
+				resultSlices[i] = toolResultBlocks(calls[i].block.ID, res, err)
 			}(i)
 		}
 		wg.Wait()
-		return results, nil
+		return flattenResults(resultSlices), nil
 	}
 
 	streaming, hasStreaming := executor.(StreamingToolExecutor)
+	resultSlices = make([][]ContentBlock, len(calls))
 	for i := range calls {
 		b := calls[i].block
 		if calls[i].denyReason != "" {
-			results[i] = NewToolResultBlock(b.ID, calls[i].denyReason, true)
+			resultSlices[i] = []ContentBlock{NewToolResultBlock(b.ID, calls[i].denyReason, true)}
 			continue
 		}
 		var (
-			output  string
+			res     ToolResult
 			execErr error
 		)
 		if hasStreaming && handler != nil {
@@ -747,13 +750,13 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 				}
 				handler(AgentEvent{Kind: EventToolProgress, ToolID: toolID, ToolName: toolName, Chunk: chunk})
 			}
-			output, execErr = streaming.ExecuteStream(ctx, b.Name, b.Input, progress)
+			res, execErr = streaming.ExecuteStream(ctx, b.Name, b.Input, progress)
 		} else {
-			output, execErr = executor.Execute(ctx, b.Name, b.Input)
+			res, execErr = executor.Execute(ctx, b.Name, b.Input)
 		}
-		results[i] = toolResultBlock(b.ID, output, execErr)
+		resultSlices[i] = toolResultBlocks(b.ID, res, execErr)
 	}
-	return results, nil
+	return flattenResults(resultSlices), nil
 }
 
 // canParallelize reports whether a batch can run concurrently: more than one
@@ -772,15 +775,30 @@ func canParallelize(calls []toolCall) bool {
 	return executable > 1
 }
 
-// toolResultBlock builds a tool_result, mapping an execution error onto an
-// IsError result carrying the error text. Both success output and error text
-// pass through microCompact so a single oversized result can't dominate the
-// context window.
-func toolResultBlock(id, output string, err error) ContentBlock {
+// toolResultBlocks builds a slice of content blocks from a ToolResult.
+// The first element is always the tool_result block; any additional blocks
+// (e.g. images) from the result are appended after it.
+func toolResultBlocks(id string, result ToolResult, err error) []ContentBlock {
 	if err != nil {
-		return NewToolResultBlock(id, microCompact(err.Error()), true)
+		return []ContentBlock{NewToolResultBlock(id, microCompact(err.Error()), true)}
 	}
-	return NewToolResultBlock(id, microCompact(output), false)
+	blocks := make([]ContentBlock, 0, 1+len(result.Blocks))
+	blocks = append(blocks, NewToolResultBlock(id, microCompact(result.Text), false))
+	blocks = append(blocks, result.Blocks...)
+	return blocks
+}
+
+// flattenResults collapses a per-tool slice-of-slices into a single flat slice.
+func flattenResults(slices [][]ContentBlock) []ContentBlock {
+	var total int
+	for _, s := range slices {
+		total += len(s)
+	}
+	out := make([]ContentBlock, 0, total)
+	for _, s := range slices {
+		out = append(out, s...)
+	}
+	return out
 }
 
 // textFromBlocks joins text from all "text" content blocks.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -265,14 +265,14 @@ type fakeExecutor struct {
 	called  []string
 }
 
-func (f *fakeExecutor) Execute(_ context.Context, name string, _ map[string]any) (string, error) {
+func (f *fakeExecutor) Execute(_ context.Context, name string, _ map[string]any) (ToolResult, error) {
 	f.called = append(f.called, name)
 	if f.results != nil {
 		if v, ok := f.results[name]; ok {
-			return v, nil
+			return ToolResult{Text: v}, nil
 		}
 	}
-	return "ok", nil
+	return ToolResult{Text: "ok"}, nil
 }
 
 func TestAgent_Run_NoTools_FallsBackToTurn(t *testing.T) {
@@ -488,8 +488,8 @@ type failingExecutor struct {
 	err error
 }
 
-func (f *failingExecutor) Execute(_ context.Context, _ string, _ map[string]any) (string, error) {
-	return "", f.err
+func (f *failingExecutor) Execute(_ context.Context, _ string, _ map[string]any) (ToolResult, error) {
+	return ToolResult{}, f.err
 }
 
 func TestAgent_RunStream_NoTools_EmitsTextDeltaAndTurnDone(t *testing.T) {
@@ -690,17 +690,17 @@ type streamingFakeExecutor struct {
 	called  []string
 }
 
-func (f *streamingFakeExecutor) Execute(_ context.Context, name string, _ map[string]any) (string, error) {
+func (f *streamingFakeExecutor) Execute(_ context.Context, name string, _ map[string]any) (ToolResult, error) {
 	f.called = append(f.called, name)
 	if v, ok := f.results[name]; ok {
-		return v, nil
+		return ToolResult{Text: v}, nil
 	}
-	return "ok", nil
+	return ToolResult{Text: "ok"}, nil
 }
 
 func (f *streamingFakeExecutor) ExecuteStream(
 	_ context.Context, name string, _ map[string]any, progress func(string),
-) (string, error) {
+) (ToolResult, error) {
 	f.called = append(f.called, name)
 	for _, c := range f.chunks {
 		if progress != nil {
@@ -708,9 +708,9 @@ func (f *streamingFakeExecutor) ExecuteStream(
 		}
 	}
 	if v, ok := f.results[name]; ok {
-		return v, nil
+		return ToolResult{Text: v}, nil
 	}
-	return "ok", nil
+	return ToolResult{Text: "ok"}, nil
 }
 
 func TestAgent_RunStream_StreamingExecutor_EmitsProgress(t *testing.T) {

--- a/internal/agent/content.go
+++ b/internal/agent/content.go
@@ -7,11 +7,12 @@ package agent
 //   - "tool_use"    — the model requesting a tool call (assistant turn)
 //   - "tool_result" — the result of a tool call (user turn)
 //   - "thinking"    — a reasoning model's extended-thinking trace (assistant turn)
+//   - "image"       — an image for multimodal model consumption (user turn)
 //
 // The zero value is not valid; use the New*Block helpers instead.
 type ContentBlock struct {
 	// Type distinguishes the block variant: "text", "tool_use", "tool_result",
-	// "thinking".
+	// "thinking", "image".
 	Type string `json:"type"`
 
 	// Text is the text payload (type=="text").
@@ -57,6 +58,18 @@ type ContentBlock struct {
 	// unless it's resent; the OpenAI adapter stashes it here so it round-trips
 	// through history. Providers that don't need it ignore the field.
 	Reasoning string `json:"reasoning,omitempty"`
+
+	// Image carries vision-model image data (type=="image"). Used when a tool
+	// result includes an image that should be rendered by a multimodal model
+	// (Claude, GPT-4o, Kimi k2.6, etc.). The provider adapter serialises it to
+	// the vendor-specific wire format (Anthropic base64 source, OpenAI data URL).
+	Image *ImageData `json:"-"`
+}
+
+// ImageData holds raw image bytes and their MIME type for multimodal uploads.
+type ImageData struct {
+	MIMEType string // e.g. "image/jpeg", "image/png"
+	Data     []byte // raw file bytes
 }
 
 // NewTextBlock creates a ContentBlock with Type=="text".
@@ -95,5 +108,15 @@ func NewToolResultBlock(toolUseID, result string, isError bool) ContentBlock {
 		ToolUseID: toolUseID,
 		Result:    result,
 		IsError:   isError,
+	}
+}
+
+// NewImageBlock creates a ContentBlock with Type=="image" for multimodal
+// model consumption. The provider adapter is responsible for converting this
+// to the vendor-specific wire format.
+func NewImageBlock(mimeType string, data []byte) ContentBlock {
+	return ContentBlock{
+		Type:  "image",
+		Image: &ImageData{MIMEType: mimeType, Data: data},
 	}
 }

--- a/internal/agent/dispatch_test.go
+++ b/internal/agent/dispatch_test.go
@@ -63,13 +63,13 @@ type barrierExec struct {
 	order []string
 }
 
-func (b *barrierExec) Execute(_ context.Context, name string, _ map[string]any) (string, error) {
+func (b *barrierExec) Execute(_ context.Context, name string, _ map[string]any) (ToolResult, error) {
 	b.mu.Lock()
 	b.order = append(b.order, name)
 	b.mu.Unlock()
 	b.wg.Done() // arrived
 	b.wg.Wait() // release only once everyone has arrived → requires concurrency
-	return "ok:" + name, nil
+	return ToolResult{Text: "ok:" + name}, nil
 }
 
 func TestDispatchTools_ParallelReadOnly(t *testing.T) {
@@ -110,11 +110,11 @@ type countingExec struct {
 	called []string
 }
 
-func (c *countingExec) Execute(_ context.Context, name string, _ map[string]any) (string, error) {
+func (c *countingExec) Execute(_ context.Context, name string, _ map[string]any) (ToolResult, error) {
 	c.mu.Lock()
 	c.called = append(c.called, name)
 	c.mu.Unlock()
-	return "ok:" + name, nil
+	return ToolResult{Text: "ok:" + name}, nil
 }
 
 func TestDispatchTools_MixedBatchSerialCorrect(t *testing.T) {

--- a/internal/agent/interrupt_test.go
+++ b/internal/agent/interrupt_test.go
@@ -96,9 +96,9 @@ func (s *toolThenCancelSender) SendMessagesWithTools(_ context.Context, _, _ str
 
 type cancelOnExecExecutor struct{ cancel context.CancelFunc }
 
-func (e cancelOnExecExecutor) Execute(ctx context.Context, _ string, _ map[string]any) (string, error) {
+func (e cancelOnExecExecutor) Execute(ctx context.Context, _ string, _ map[string]any) (ToolResult, error) {
 	e.cancel() // Ctrl-C arrives while the tool runs
-	return "", ctx.Err()
+	return ToolResult{}, ctx.Err()
 }
 
 func TestRun_InterruptDuringToolDispatch(t *testing.T) {

--- a/internal/agent/microcompact_test.go
+++ b/internal/agent/microcompact_test.go
@@ -56,8 +56,8 @@ func TestTruncateMiddle_ValidUTF8AtBoundary(t *testing.T) {
 // hugeExec returns a tool output far larger than the cap.
 type hugeExec struct{}
 
-func (hugeExec) Execute(_ context.Context, _ string, _ map[string]any) (string, error) {
-	return strings.Repeat("A", ToolResultMaxBytes*3), nil
+func (hugeExec) Execute(_ context.Context, _ string, _ map[string]any) (ToolResult, error) {
+	return ToolResult{Text: strings.Repeat("A", ToolResultMaxBytes*3)}, nil
 }
 
 func TestDispatchTools_TruncatesOversizedResult(t *testing.T) {

--- a/internal/agent/steer_test.go
+++ b/internal/agent/steer_test.go
@@ -163,10 +163,10 @@ type steeringExecutor struct {
 	fired bool
 }
 
-func (e *steeringExecutor) Execute(_ context.Context, _ string, _ map[string]any) (string, error) {
+func (e *steeringExecutor) Execute(_ context.Context, _ string, _ map[string]any) (ToolResult, error) {
 	if !e.fired {
 		e.a.Steer(e.steer)
 		e.fired = true
 	}
-	return "ok", nil
+	return ToolResult{Text: "ok"}, nil
 }

--- a/internal/agent/tool.go
+++ b/internal/agent/tool.go
@@ -11,11 +11,21 @@ type ToolDefinition struct {
 	Parameters  map[string]any `json:"parameters"` // JSON Schema object
 }
 
+// ToolResult is the return value from a tool execution. Text is the required
+// textual summary (shown in the UI and sent to the model as the primary
+// result). Blocks holds optional rich content — images for multimodal models,
+// structured data, etc. — that the provider adapter serialises into the
+// vendor-specific wire format.
+type ToolResult struct {
+	Text   string         // required textual summary
+	Blocks []ContentBlock // optional rich content (images, etc.)
+}
+
 // ToolExecutor dispatches tool calls on behalf of the agentic loop. Each
 // implementation maps a tool name to a function; unknown names should return
 // an error so the LLM sees a clean error result rather than a panic.
 type ToolExecutor interface {
-	Execute(ctx context.Context, name string, input map[string]any) (string, error)
+	Execute(ctx context.Context, name string, input map[string]any) (ToolResult, error)
 }
 
 // PermissionGate decides whether a tool call may proceed. The agent loop
@@ -46,8 +56,8 @@ type PermissionGate interface {
 // Otherwise the loop falls back to Execute.
 //
 // progress may be nil; implementations should treat a nil progress callback
-// as equivalent to non-streaming Execute. The (string, error) return is the
-// FULL aggregated output (same contract as Execute) — progress chunks are
+// as equivalent to non-streaming Execute. The (ToolResult, error) return is
+// the FULL aggregated result (same contract as Execute) — progress chunks are
 // for UI/observability only.
 type StreamingToolExecutor interface {
 	ToolExecutor
@@ -56,5 +66,5 @@ type StreamingToolExecutor interface {
 		name string,
 		input map[string]any,
 		progress func(chunk string),
-	) (string, error)
+	) (ToolResult, error)
 }

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -384,11 +385,29 @@ func marshalBlocks(blocks []agent.ContentBlock) ([]map[string]any, error) {
 				m["is_error"] = true
 			}
 			out = append(out, m)
+		case "image":
+			// Anthropic image block: base64-encoded data with source type.
+			if b.Image == nil {
+				return nil, fmt.Errorf("anthropic: image block missing Image data")
+			}
+			out = append(out, map[string]any{
+				"type": "image",
+				"source": map[string]any{
+					"type":       "base64",
+					"media_type": b.Image.MIMEType,
+					"data":       encodeBase64(b.Image.Data),
+				},
+			})
 		default:
 			return nil, fmt.Errorf("anthropic: unknown block type %q", b.Type)
 		}
 	}
 	return out, nil
+}
+
+// encodeBase64 returns a standard base64 string.
+func encodeBase64(data []byte) string {
+	return base64.StdEncoding.EncodeToString(data)
 }
 
 // fromAPIContentBlocks converts the response content blocks to agent.ContentBlock.

--- a/internal/provider/anthropic/tools_test.go
+++ b/internal/provider/anthropic/tools_test.go
@@ -269,6 +269,78 @@ func TestSend_ToolResultWithSteerText(t *testing.T) {
 	}
 }
 
+// TestSend_ImageBlock_WireFormat verifies that an image content block is
+// serialized as an Anthropic image source block with base64 data.
+func TestSend_ImageBlock_WireFormat(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"m","type":"message","role":"assistant","model":"x","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	msgs := []agent.Message{
+		agent.NewUserMessage("describe this"),
+		agent.NewToolUseMessage([]agent.ContentBlock{
+			agent.NewToolUseBlock("call-1", "read_file", map[string]any{"path": "/tmp/img.png"}),
+		}),
+		agent.NewToolResultMessage([]agent.ContentBlock{
+			agent.NewToolResultBlock("call-1", "Image: /tmp/img.png (image/png, 12 B)", false),
+			agent.NewImageBlock("image/png", []byte{0x89, 0x50}),
+		}),
+	}
+
+	_, err := c.Send(context.Background(), provider.Request{Model: "x", Messages: msgs})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var wireReq struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(capturedBody, &wireReq); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// user, assistant(tool_use), user(tool_result + image)
+	if len(wireReq.Messages) != 3 {
+		t.Fatalf("messages len = %d, want 3: %s", len(wireReq.Messages), capturedBody)
+	}
+
+	var userContent []map[string]any
+	if err := json.Unmarshal(wireReq.Messages[2].Content, &userContent); err != nil {
+		t.Fatalf("decode user content: %v", err)
+	}
+	if len(userContent) != 2 {
+		t.Fatalf("user content blocks = %d, want 2 (tool_result + image): %v", len(userContent), userContent)
+	}
+	if userContent[0]["type"] != "tool_result" {
+		t.Errorf("blocks[0].type = %v, want tool_result", userContent[0]["type"])
+	}
+	if userContent[1]["type"] != "image" {
+		t.Errorf("blocks[1].type = %v, want image", userContent[1]["type"])
+	}
+	src, ok := userContent[1]["source"].(map[string]any)
+	if !ok {
+		t.Fatalf("image source missing or wrong type")
+	}
+	if src["type"] != "base64" {
+		t.Errorf("source.type = %v, want base64", src["type"])
+	}
+	if src["media_type"] != "image/png" {
+		t.Errorf("source.media_type = %v, want image/png", src["media_type"])
+	}
+	if src["data"] != "iVA=" { // base64 of {0x89, 0x50}
+		t.Errorf("source.data = %v, want iVA=", src["data"])
+	}
+}
+
 // TestSendStream_ToolUse verifies that tool_use blocks emitted during a stream
 // are accumulated and returned in resp.Blocks, and that input_json_delta
 // fragments are correctly assembled into the final Input map.

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -291,8 +292,12 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 		// §5) can't ride on a role="tool" message, so it's emitted as a separate
 		// role="user" message AFTER the tool outputs, which is the OpenAI-shaped
 		// equivalent of Anthropic's [tool_result…, text] user message.
+		//
+		// Image blocks are folded into the user message as content parts (OpenAI
+		// vision format: [{type:"text",text:"..."},{type:"image_url",image_url:{url:"data:..."}}]).
 		if m.Role == agent.RoleUser && len(m.Blocks) > 0 {
 			var steerText strings.Builder
+			var contentParts []apiContentPart
 			for _, b := range m.Blocks {
 				switch b.Type {
 				case "tool_result":
@@ -306,10 +311,29 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 						steerText.WriteString("\n\n")
 					}
 					steerText.WriteString(b.Text)
+				case "image":
+					if b.Image != nil {
+						dataURL := fmt.Sprintf("data:%s;base64,%s", b.Image.MIMEType, base64.StdEncoding.EncodeToString(b.Image.Data))
+						contentParts = append(contentParts, apiContentPart{
+							Type: "image_url",
+							ImageURL: &struct {
+								URL string `json:"url"`
+							}{URL: dataURL},
+						})
+					}
 				}
 			}
 			if steerText.Len() > 0 {
-				out = append(out, apiMessage{Role: "user", Content: steerText.String()})
+				contentParts = append([]apiContentPart{{Type: "text", Text: steerText.String()}}, contentParts...)
+			}
+			if len(contentParts) > 0 {
+				// Use array format only when images are present; otherwise stick to
+				// plain string content for compatibility with tests and simpler wire.
+				if len(contentParts) == 1 && contentParts[0].Type == "text" {
+					out = append(out, apiMessage{Role: "user", Content: contentParts[0].Text})
+				} else {
+					out = append(out, apiMessage{Role: "user", ContentParts: contentParts})
+				}
 			}
 			continue
 		}

--- a/internal/provider/openai/tools_test.go
+++ b/internal/provider/openai/tools_test.go
@@ -331,6 +331,80 @@ func TestSend_ToolResultWithSteerText_WireFormat(t *testing.T) {
 	}
 }
 
+// TestSend_ImageBlock_WireFormat verifies that an image content block is
+// serialized as an OpenAI vision content array with a data URL.
+//
+// OpenAI protocol: tool_result blocks become role="tool" messages, while
+// image blocks ride on a separate role="user" message with a content array.
+func TestSend_ImageBlock_WireFormat(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"x","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	msgs := []agent.Message{
+		agent.NewUserMessage("describe this"),
+		agent.NewToolUseMessage([]agent.ContentBlock{
+			agent.NewToolUseBlock("call-1", "read_file", map[string]any{"path": "/tmp/img.png"}),
+		}),
+		agent.NewToolResultMessage([]agent.ContentBlock{
+			agent.NewToolResultBlock("call-1", "Image: /tmp/img.png (image/png, 12 B)", false),
+			agent.NewImageBlock("image/png", []byte{0x89, 0x50}),
+		}),
+	}
+
+	_, err := c.Send(context.Background(), provider.Request{Model: "x", Messages: msgs})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var wireReq struct {
+		Messages []struct {
+			Role       string `json:"role"`
+			Content    any    `json:"content"`
+			ToolCallID string `json:"tool_call_id"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(capturedBody, &wireReq); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// user, assistant(tool_call), tool(result), user(image)
+	if len(wireReq.Messages) != 4 {
+		t.Fatalf("messages len = %d, want 4: %s", len(wireReq.Messages), capturedBody)
+	}
+	// msg[2] = tool result
+	if wireReq.Messages[2].Role != "tool" || wireReq.Messages[2].ToolCallID != "call-1" {
+		t.Errorf("msg[2] = %+v, want tool/call-1", wireReq.Messages[2])
+	}
+	// msg[3] = user message carrying the image block
+	if wireReq.Messages[3].Role != "user" {
+		t.Errorf("msg[3].role = %q, want user", wireReq.Messages[3].Role)
+	}
+	// Content should be an array with an image_url part.
+	parts, ok := wireReq.Messages[3].Content.([]any)
+	if !ok {
+		t.Fatalf("msg[3].content = %T, want []any", wireReq.Messages[3].Content)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("content parts len = %d, want 1", len(parts))
+	}
+	first, _ := parts[0].(map[string]any)
+	if first["type"] != "image_url" {
+		t.Errorf("parts[0].type = %v, want image_url", first["type"])
+	}
+	imgURL, _ := first["image_url"].(map[string]any)
+	url, _ := imgURL["url"].(string)
+	if !strings.HasPrefix(url, "data:image/png;base64,") {
+		t.Errorf("image_url.url prefix wrong: %q", url)
+	}
+}
+
 // TestSend_NoTools_FieldAbsent ensures we don't send a "tools" key at all
 // when no tools are defined (some OpenAI-compatible servers reject the field
 // even when empty).

--- a/internal/provider/openai/types.go
+++ b/internal/provider/openai/types.go
@@ -8,6 +8,11 @@
 // pointing Client.BaseURL at the alternative host.
 package openai
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // apiFunction describes the callable function part of a tool.
 type apiFunction struct {
 	Name        string         `json:"name"`
@@ -38,15 +43,81 @@ type apiRequest struct {
 // For plain turns Content is a string. For assistant turns with tool calls
 // ToolCalls is populated and Content may be empty. For tool result turns
 // Role is "tool" and ToolCallID identifies which call is being answered.
+//
+// When image blocks are present, ContentParts carries the array of text/image
+// content items and Content is left empty. The JSON serialization uses
+// "content" for both shapes (string or array) via custom MarshalJSON/UnmarshalJSON.
 type apiMessage struct {
 	Role       string        `json:"role"`
-	Content    string        `json:"content,omitempty"`
+	Content    string        `json:"-"`
 	ToolCalls  []apiToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string        `json:"tool_call_id,omitempty"`
 	// ReasoningContent is the thinking trace returned by reasoning models
 	// (deepseek-v4 etc.). It must be echoed back on the assistant message that
 	// carries tool_calls, or the next request is rejected; omitted otherwise.
 	ReasoningContent string `json:"reasoning_content,omitempty"`
+	// ContentParts is the array form of content used for vision/multimodal
+	// messages. When non-empty it overrides Content in JSON serialization.
+	ContentParts []apiContentPart `json:"-"`
+}
+
+// apiContentPart is one element of a multimodal content array.
+type apiContentPart struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	ImageURL *struct {
+		URL string `json:"url"`
+	} `json:"image_url,omitempty"`
+}
+
+// MarshalJSON emits Content as a string when ContentParts is empty, or as
+// an array when ContentParts is populated. This matches the OpenAI wire
+// format where "content" can be either shape.
+func (m apiMessage) MarshalJSON() ([]byte, error) {
+	type alias apiMessage // prevent recursion
+	raw := struct {
+		alias
+		Content any `json:"content,omitempty"`
+	}{
+		alias: alias(m),
+	}
+	if len(m.ContentParts) > 0 {
+		raw.Content = m.ContentParts
+	} else {
+		raw.Content = m.Content
+	}
+	return json.Marshal(raw)
+}
+
+// UnmarshalJSON reads "content" as either a string or an array of content
+// parts, populating Content or ContentParts accordingly.
+func (m *apiMessage) UnmarshalJSON(data []byte) error {
+	type alias apiMessage
+	var raw struct {
+		alias
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*m = apiMessage(raw.alias)
+
+	if len(raw.Content) == 0 || string(raw.Content) == "null" {
+		return nil
+	}
+	// Try string first.
+	var s string
+	if err := json.Unmarshal(raw.Content, &s); err == nil {
+		m.Content = s
+		return nil
+	}
+	// Fall back to array of content parts.
+	var parts []apiContentPart
+	if err := json.Unmarshal(raw.Content, &parts); err == nil {
+		m.ContentParts = parts
+		return nil
+	}
+	return fmt.Errorf("apiMessage.content: unsupported type: %s", string(raw.Content))
 }
 
 // apiToolCall is one element of apiMessage.ToolCalls (assistant turns).

--- a/internal/tools/ask_user_question.go
+++ b/internal/tools/ask_user_question.go
@@ -117,17 +117,17 @@ func (AskUserQuestionTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (AskUserQuestionTool) Execute(ctx context.Context, _ string, input map[string]any) (string, error) {
+func (AskUserQuestionTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	if !askerEnabled() {
-		return "", fmt.Errorf("ask_user_question: not available in this mode (REPL only)")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("ask_user_question: not available in this mode (REPL only)")
 	}
 	question := strings.TrimSpace(stringArg(input, "question"))
 	if question == "" {
-		return "", fmt.Errorf("ask_user_question: question is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("ask_user_question: question is required")
 	}
 	options := stringSliceArg(input, "options")
 	if len(options) < 2 || len(options) > 4 {
-		return "", fmt.Errorf("ask_user_question: options must have 2-4 entries (got %d)", len(options))
+		return agent.ToolResult{Text: ""}, fmt.Errorf("ask_user_question: options must have 2-4 entries (got %d)", len(options))
 	}
 	multi, _ := input["multi_select"].(bool)
 	header := strings.TrimSpace(stringArg(input, "header"))
@@ -139,9 +139,9 @@ func (AskUserQuestionTool) Execute(ctx context.Context, _ string, input map[stri
 		Header:      header,
 	})
 	if err != nil {
-		return "", fmt.Errorf("ask_user_question: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("ask_user_question: %w", err)
 	}
-	return formatAskResponse(res), nil
+	return agent.ToolResult{Text: formatAskResponse(res)}, nil
 }
 
 // formatAskResponse turns the asker's structured reply into the text the LLM

--- a/internal/tools/ask_user_question_test.go
+++ b/internal/tools/ask_user_question_test.go
@@ -55,8 +55,8 @@ func TestAskUserQuestionTool_Execute_SingleChoice(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "User chose: OAuth" {
-		t.Errorf("Execute result = %q", out)
+	if out.Text != "User chose: OAuth" {
+		t.Errorf("Execute result = %q", out.Text)
 	}
 	if !stub.called {
 		t.Error("asker was never invoked")
@@ -81,8 +81,8 @@ func TestAskUserQuestionTool_Execute_MultiChoice(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "User chose: OAuth, API key" {
-		t.Errorf("Execute result = %q", out)
+	if out.Text != "User chose: OAuth, API key" {
+		t.Errorf("Execute result = %q", out.Text)
 	}
 	if !stub.lastReq.MultiSelect {
 		t.Error("multi_select flag not forwarded")
@@ -97,11 +97,11 @@ func TestAskUserQuestionTool_Execute_OtherFreeText(t *testing.T) {
 		"question": "Which auth method?",
 		"options":  []any{"OAuth", "API key"},
 	})
-	if !strings.HasPrefix(out, "User chose: Other — ") {
-		t.Errorf("free-text answer should be reported as Other — …, got %q", out)
+	if !strings.HasPrefix(out.Text, "User chose: Other — ") {
+		t.Errorf("free-text answer should be reported as Other — …, got %q", out.Text)
 	}
-	if !strings.Contains(out, "Kerberos with constrained delegation") {
-		t.Errorf("free-text payload lost: %q", out)
+	if !strings.Contains(out.Text, "Kerberos with constrained delegation") {
+		t.Errorf("free-text payload lost: %q", out.Text)
 	}
 }
 
@@ -114,8 +114,8 @@ func TestAskUserQuestionTool_Execute_Cancelled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "(user cancelled)" {
-		t.Errorf("cancellation = %q, want '(user cancelled)'", out)
+	if out.Text != "(user cancelled)" {
+		t.Errorf("cancellation = %q, want '(user cancelled)'", out.Text)
 	}
 }
 

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -93,15 +93,15 @@ func TestBackgroundManager_Kill(t *testing.T) {
 func TestTerminalTool_BackgroundLaunch(t *testing.T) {
 	m := NewBackgroundManager()
 	tool := TerminalTool{mgr: m}
-	res, err := tool.Execute(context.Background(), "terminal", map[string]any{
+	resTool, err := tool.Execute(context.Background(), "terminal", map[string]any{
 		"command":    "echo hi",
 		"background": true,
 	})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(res, "bg_1") {
-		t.Errorf("result = %q, want it to mention the bg id", res)
+	if !strings.Contains(resTool.Text, "bg_1") {
+		t.Errorf("result = %q, want it to mention the bg id", resTool.Text)
 	}
 	// The terminal guard (e.g. in-place sed) still applies to background launches.
 	if _, err := tool.Execute(context.Background(), "terminal", map[string]any{
@@ -126,11 +126,11 @@ func TestTerminalOutputTool(t *testing.T) {
 
 	var res string
 	waitFor(t, "terminal_output to show exit", func() bool {
-		r, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_1"})
+		rTool, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_1"})
 		if err != nil {
 			t.Fatalf("terminal_output: %v", err)
 		}
-		res += r
+		res += rTool.Text
 		return strings.Contains(res, "exited")
 	})
 	if !strings.Contains(res, "from-bg") {
@@ -158,12 +158,12 @@ func TestKillShellTool(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("launch: %v", err)
 	}
-	res, err := killTool.Execute(context.Background(), "kill_shell", map[string]any{"id": "bg_1"})
+	resKill, err := killTool.Execute(context.Background(), "kill_shell", map[string]any{"id": "bg_1"})
 	if err != nil {
 		t.Fatalf("kill_shell: %v", err)
 	}
-	if !strings.Contains(res, "killed") {
-		t.Errorf("result = %q, want it to note the kill", res)
+	if !strings.Contains(resKill.Text, "killed") {
+		t.Errorf("result = %q, want it to note the kill", resKill.Text)
 	}
 
 	// Unknown id is an error.
@@ -185,15 +185,15 @@ func TestTerminalOutputTool_ReadOnly(t *testing.T) {
 	}
 	// terminal_output no longer kills: a "kill" key is ignored and the process
 	// keeps running.
-	res, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{
+	resOut, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{
 		"id":   "bg_1",
 		"kill": true, // ignored
 	})
 	if err != nil {
 		t.Fatalf("terminal_output: %v", err)
 	}
-	if strings.Contains(res, "killed") {
-		t.Errorf("terminal_output must not kill, got %q", res)
+	if strings.Contains(resOut.Text, "killed") {
+		t.Errorf("terminal_output must not kill, got %q", resOut.Text)
 	}
 	if _, status, _ := m.Read("bg_1"); status != "running" {
 		t.Errorf("process should still be running after terminal_output, status=%q", status)

--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -46,35 +46,35 @@ func (EditFileTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (EditFileTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+func (EditFileTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	path, _ := input["path"].(string)
 	if strings.TrimSpace(path) == "" {
-		return "", fmt.Errorf("edit_file: path is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: path is required")
 	}
 	oldStr, ok1 := input["old_string"].(string)
 	newStr, ok2 := input["new_string"].(string)
 	if !ok1 {
-		return "", fmt.Errorf("edit_file: old_string is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: old_string is required")
 	}
 	if !ok2 {
-		return "", fmt.Errorf("edit_file: new_string is required (use empty string to delete)")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: new_string is required (use empty string to delete)")
 	}
 	if oldStr == "" {
-		return "", fmt.Errorf("edit_file: old_string must be non-empty")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: old_string must be non-empty")
 	}
 	if oldStr == newStr {
-		return "", fmt.Errorf("edit_file: old_string and new_string are identical — nothing to do")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: old_string and new_string are identical — nothing to do")
 	}
 	replaceAll, _ := input["replace_all"].(bool)
 
 	abs, err := resolvePath(path)
 	if err != nil {
-		return "", err
+		return agent.ToolResult{Text: ""}, err
 	}
 
 	data, err := os.ReadFile(abs)
 	if err != nil {
-		return "", fmt.Errorf("edit_file: read %q: %w", path, err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: read %q: %w", path, err)
 	}
 	body := string(data)
 
@@ -96,10 +96,10 @@ func (EditFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 
 	count := strings.Count(bodyForMatch, oldForMatch)
 	if count == 0 {
-		return "", fmt.Errorf("edit_file: old_string not found in %s", path)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: old_string not found in %s", path)
 	}
 	if count > 1 && !replaceAll {
-		return "", fmt.Errorf(
+		return agent.ToolResult{Text: ""}, fmt.Errorf(
 			"edit_file: old_string matches %d times — either include more context to make it unique, or set replace_all=true",
 			count,
 		)
@@ -116,11 +116,11 @@ func (EditFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 	}
 
 	if err := os.WriteFile(abs, []byte(updated), 0o644); err != nil {
-		return "", fmt.Errorf("edit_file: write %q: %w", path, err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: write %q: %w", path, err)
 	}
 
 	if replaceAll {
-		return fmt.Sprintf("Replaced %d occurrence(s) in %s", count, abs), nil
+		return agent.ToolResult{Text: fmt.Sprintf("Replaced %d occurrence(s) in %s", count, abs)}, nil
 	}
-	return fmt.Sprintf("Replaced 1 occurrence in %s", abs), nil
+	return agent.ToolResult{Text: fmt.Sprintf("Replaced 1 occurrence in %s", abs)}, nil
 }

--- a/internal/tools/edit_file_test.go
+++ b/internal/tools/edit_file_test.go
@@ -20,8 +20,8 @@ func TestEditFile_UniqueReplacement(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "Replaced 1 occurrence") {
-		t.Errorf("status = %q", out)
+	if !strings.Contains(out.Text, "Replaced 1 occurrence") {
+		t.Errorf("status = %q", out.Text)
 	}
 	if !strings.Contains(readTestFile(t, path), `"hi there"`) {
 		t.Error("replacement did not land in file")
@@ -61,8 +61,8 @@ func TestEditFile_ReplaceAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "Replaced 3 occurrence(s)") {
-		t.Errorf("status = %q", out)
+	if !strings.Contains(out.Text, "Replaced 3 occurrence(s)") {
+		t.Errorf("status = %q", out.Text)
 	}
 	if got := readTestFile(t, path); got != "baz\nbaz\nbar\nbaz\n" {
 		t.Errorf("file = %q", got)
@@ -159,8 +159,8 @@ func TestEditFile_CRLFNormalization_MatchAndPreserve(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "Replaced 1 occurrence") {
-		t.Errorf("status = %q", out)
+	if !strings.Contains(out.Text, "Replaced 1 occurrence") {
+		t.Errorf("status = %q", out.Text)
 	}
 	got := readTestFile(t, path)
 	want := "line one\r\nLINE TWO\r\nline three\r\n"

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -53,10 +53,10 @@ func (GlobTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (GlobTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+func (GlobTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	pattern, _ := input["pattern"].(string)
 	if strings.TrimSpace(pattern) == "" {
-		return "", fmt.Errorf("glob: pattern is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("glob: pattern is required")
 	}
 
 	root := "."
@@ -65,7 +65,7 @@ func (GlobTool) Execute(_ context.Context, _ string, input map[string]any) (stri
 	}
 	absRoot, err := resolvePath(root)
 	if err != nil {
-		return "", err
+		return agent.ToolResult{Text: ""}, err
 	}
 
 	type match struct {
@@ -111,7 +111,7 @@ func (GlobTool) Execute(_ context.Context, _ string, input map[string]any) (stri
 		return nil
 	})
 	if err != nil {
-		return "", fmt.Errorf("glob: walk %q: %w", root, err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("glob: walk %q: %w", root, err)
 	}
 
 	sort.Slice(matches, func(i, j int) bool { return matches[i].mtime > matches[j].mtime })
@@ -129,12 +129,12 @@ func (GlobTool) Execute(_ context.Context, _ string, input map[string]any) (stri
 		out.WriteByte('\n')
 	}
 	if out.Len() == 0 {
-		return fmt.Sprintf("(no matches for %q under %s)", pattern, absRoot), nil
+		return agent.ToolResult{Text: fmt.Sprintf("(no matches for %q under %s)", pattern, absRoot)}, nil
 	}
 	if truncated {
 		fmt.Fprintf(&out, "\n[truncated to first %d of %d matches]\n", GlobMaxResults, totalMatches)
 	}
-	return out.String(), nil
+	return agent.ToolResult{Text: out.String()}, nil
 }
 
 // globMatch matches a pattern against a relative path, supporting `**`

--- a/internal/tools/glob_test.go
+++ b/internal/tools/glob_test.go
@@ -21,11 +21,11 @@ func TestGlob_FlatStarPattern(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "a.go") || !strings.Contains(out, "b.go") {
-		t.Errorf("expected a.go and b.go in output:\n%s", out)
+	if !strings.Contains(out.Text, "a.go") || !strings.Contains(out.Text, "b.go") {
+		t.Errorf("expected a.go and b.go in output:\n%s", out.Text)
 	}
-	if strings.Contains(out, "c.txt") {
-		t.Errorf(".txt should not match *.go:\n%s", out)
+	if strings.Contains(out.Text, "c.txt") {
+		t.Errorf(".txt should not match *.go:\n%s", out.Text)
 	}
 }
 
@@ -44,11 +44,11 @@ func TestGlob_DoubleStarRecursive(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	for _, want := range []string{"top.go", "mid.go", "leaf.go"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("expected %s in output:\n%s", want, out)
+		if !strings.Contains(out.Text, want) {
+			t.Errorf("expected %s in output:\n%s", want, out.Text)
 		}
 	}
-	if strings.Contains(out, "other.txt") {
+	if strings.Contains(out.Text, "other.txt") {
 		t.Errorf("other.txt should not match")
 	}
 }
@@ -70,10 +70,10 @@ func TestGlob_SortedByMtimeDescending(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	// newer.txt should appear before older.txt in the output.
-	idxNew := strings.Index(out, "newer.txt")
-	idxOld := strings.Index(out, "older.txt")
+	idxNew := strings.Index(out.Text, "newer.txt")
+	idxOld := strings.Index(out.Text, "older.txt")
 	if idxNew < 0 || idxOld < 0 || idxNew > idxOld {
-		t.Errorf("expected newer.txt before older.txt:\n%s", out)
+		t.Errorf("expected newer.txt before older.txt:\n%s", out.Text)
 	}
 }
 
@@ -90,11 +90,11 @@ func TestGlob_SkipsGitAndNodeModules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "real.go") {
-		t.Errorf("real.go missing:\n%s", out)
+	if !strings.Contains(out.Text, "real.go") {
+		t.Errorf("real.go missing:\n%s", out.Text)
 	}
-	if strings.Contains(out, ".git/") || strings.Contains(out, "node_modules/") {
-		t.Errorf("noise directories should be skipped:\n%s", out)
+	if strings.Contains(out.Text, ".git/") || strings.Contains(out.Text, "node_modules/") {
+		t.Errorf("noise directories should be skipped:\n%s", out.Text)
 	}
 }
 
@@ -107,8 +107,8 @@ func TestGlob_NoMatches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "no matches") {
-		t.Errorf("expected 'no matches' message: %q", out)
+	if !strings.Contains(out.Text, "no matches") {
+		t.Errorf("expected 'no matches' message: %q", out.Text)
 	}
 }
 

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -71,9 +71,9 @@ func (GrepTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (string, error) {
+func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	if _, err := exec.LookPath("rg"); err != nil {
-		return "", fmt.Errorf(
+		return agent.ToolResult{Text: ""}, fmt.Errorf(
 			"grep: ripgrep (`rg`) is not installed or not on PATH. " +
 				"Install it from https://github.com/BurntSushi/ripgrep",
 		)
@@ -81,7 +81,7 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (st
 
 	pattern, _ := input["pattern"].(string)
 	if strings.TrimSpace(pattern) == "" {
-		return "", fmt.Errorf("grep: pattern is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("grep: pattern is required")
 	}
 
 	mode, _ := input["mode"].(string)
@@ -102,7 +102,7 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (st
 	case "count":
 		args = append(args, "--count-matches")
 	default:
-		return "", fmt.Errorf("grep: unknown mode %q (use content | files_with_matches | count)", mode)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("grep: unknown mode %q (use content | files_with_matches | count)", mode)
 	}
 
 	if ci, _ := input["case_insensitive"].(bool); ci {
@@ -129,7 +129,7 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (st
 	if p, _ := input["path"].(string); p != "" {
 		abs, err := resolvePath(p)
 		if err != nil {
-			return "", err
+			return agent.ToolResult{Text: ""}, err
 		}
 		args = append(args, abs)
 	}
@@ -140,12 +140,12 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (st
 		// the LLM's perspective — surface it as a normal result.
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
-			return "(no matches)", nil
+			return agent.ToolResult{Text: "(no matches)"}, nil
 		}
-		return "", fmt.Errorf("grep: rg failed: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("grep: rg failed: %w", err)
 	}
 	if len(out) == 0 {
-		return "(no matches)", nil
+		return agent.ToolResult{Text: "(no matches)"}, nil
 	}
-	return strings.TrimRight(string(out), "\n"), nil
+	return agent.ToolResult{Text: strings.TrimRight(string(out), "\n")}, nil
 }

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -31,8 +31,8 @@ func TestGrep_ContentMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "func Hello") || !strings.Contains(out, "func World") {
-		t.Errorf("expected both functions in output:\n%s", out)
+	if !strings.Contains(out.Text, "func Hello") || !strings.Contains(out.Text, "func World") {
+		t.Errorf("expected both functions in output:\n%s", out.Text)
 	}
 }
 
@@ -50,11 +50,11 @@ func TestGrep_FilesWithMatches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "a.txt") {
-		t.Errorf("expected a.txt in output:\n%s", out)
+	if !strings.Contains(out.Text, "a.txt") {
+		t.Errorf("expected a.txt in output:\n%s", out.Text)
 	}
-	if strings.Contains(out, "b.txt") {
-		t.Errorf("b.txt has no match — shouldn't appear:\n%s", out)
+	if strings.Contains(out.Text, "b.txt") {
+		t.Errorf("b.txt has no match — shouldn't appear:\n%s", out.Text)
 	}
 }
 
@@ -70,8 +70,8 @@ func TestGrep_NoMatches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute should not error on zero matches: %v", err)
 	}
-	if !strings.Contains(out, "no matches") {
-		t.Errorf("expected 'no matches' message: %q", out)
+	if !strings.Contains(out.Text, "no matches") {
+		t.Errorf("expected 'no matches' message: %q", out.Text)
 	}
 }
 
@@ -88,8 +88,8 @@ func TestGrep_CaseInsensitive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "HELLO") {
-		t.Errorf("case-insensitive should match: %q", out)
+	if !strings.Contains(out.Text, "HELLO") {
+		t.Errorf("case-insensitive should match: %q", out.Text)
 	}
 }
 
@@ -107,11 +107,11 @@ func TestGrep_IncludeGlob(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "a.go") {
-		t.Errorf("a.go should match:\n%s", out)
+	if !strings.Contains(out.Text, "a.go") {
+		t.Errorf("a.go should match:\n%s", out.Text)
 	}
-	if strings.Contains(out, "b.txt") {
-		t.Errorf("b.txt should be excluded by include glob:\n%s", out)
+	if strings.Contains(out.Text, "b.txt") {
+		t.Errorf("b.txt should be excluded by include glob:\n%s", out.Text)
 	}
 }
 
@@ -151,14 +151,14 @@ func TestGrep_TruncatesLongMatchingLines(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	// The literal long run of 'a' must NOT appear in output.
-	if strings.Contains(out, strings.Repeat("a", 200)) {
-		sample := out
+	if strings.Contains(out.Text, strings.Repeat("a", 200)) {
+		sample := out.Text
 		if len(sample) > 200 {
 			sample = sample[:200]
 		}
 		t.Errorf("long line leaked through; head of output:\n%s", sample)
 	}
-	if !strings.Contains(out, "Omitted long matching line") {
-		t.Errorf("expected omission marker; output:\n%s", out)
+	if !strings.Contains(out.Text, "Omitted long matching line") {
+		t.Errorf("expected omission marker; output:\n%s", out.Text)
 	}
 }

--- a/internal/tools/launch_agent.go
+++ b/internal/tools/launch_agent.go
@@ -145,21 +145,21 @@ func (LaunchAgentTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (LaunchAgentTool) Execute(ctx context.Context, _ string, input map[string]any) (string, error) {
+func (LaunchAgentTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	if !spawnerEnabled() {
-		return "", fmt.Errorf("launch_agent: sub-agent dispatch is not configured for this session")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("launch_agent: sub-agent dispatch is not configured for this session")
 	}
 	if IsSubAgent(ctx) {
 		// Defense in depth — the Spawner is supposed to filter launch_agent
 		// out of a child's tool list, but a hallucinated tool call would
 		// otherwise still execute through the shared registry.
-		return "", fmt.Errorf("launch_agent: a sub-agent cannot spawn another sub-agent")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("launch_agent: a sub-agent cannot spawn another sub-agent")
 	}
 
 	desc := strings.TrimSpace(stringArg(input, "description"))
 	prompt := strings.TrimSpace(stringArg(input, "prompt"))
 	if prompt == "" {
-		return "", fmt.Errorf("launch_agent: prompt is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("launch_agent: prompt is required")
 	}
 	if desc == "" {
 		// Falling back to a truncated prompt is friendlier than an error —
@@ -175,16 +175,16 @@ func (LaunchAgentTool) Execute(ctx context.Context, _ string, input map[string]a
 	}
 	res, err := activeSpawner.Spawn(ctx, req)
 	if err != nil {
-		return "", fmt.Errorf("launch_agent: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("launch_agent: %w", err)
 	}
 	reply := strings.TrimSpace(res.Reply)
 	if reply == "" {
 		// A sub-agent that ended with no final text isn't fatal — it just
 		// has nothing to say. Surface that explicitly so the parent doesn't
 		// guess.
-		return "(sub-agent " + desc + " produced no reply)", nil
+		return agent.ToolResult{Text: "(sub-agent " + desc + " produced no reply)"}, nil
 	}
-	return withAgentTag(res.AgentID, reply), nil
+	return agent.ToolResult{Text: withAgentTag(res.AgentID, reply)}, nil
 }
 
 // stringSliceArg pulls an []string argument tolerating absence and the JSON

--- a/internal/tools/launch_agent_test.go
+++ b/internal/tools/launch_agent_test.go
@@ -94,8 +94,8 @@ func TestLaunchAgentTool_Execute(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "sub-agent finding" {
-		t.Errorf("Execute returned %q, want %q", out, "sub-agent finding")
+	if out.Text != "sub-agent finding" {
+		t.Errorf("Execute returned %q, want %q", out.Text, "sub-agent finding")
 	}
 }
 
@@ -184,8 +184,8 @@ func TestLaunchAgentTool_EmptyReplySurfacedExplicitly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, "produced no reply") {
-		t.Errorf("empty reply should be surfaced explicitly, got %q", out)
+	if !strings.Contains(out.Text, "produced no reply") {
+		t.Errorf("empty reply should be surfaced explicitly, got %q", out.Text)
 	}
 }
 

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -11,38 +11,63 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 )
 
+// imageExtensions maps file extensions to their MIME types for images
+// that multimodal models can consume.
+var imageExtensions = map[string]string{
+	".png":  "image/png",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif":  "image/gif",
+	".bmp":  "image/bmp",
+	".webp": "image/webp",
+	".ico":  "image/x-icon",
+	".tiff": "image/tiff",
+	".heic": "image/heic",
+}
+
 // ReadFileMaxLines caps how many lines a single read_file call returns.
 // Past this, the caller must paginate via offset/limit. Matches the cap
 // Claude Code's Read tool uses (helps keep LLM context sane).
 const ReadFileMaxLines = 2000
 
+// ReadFileImageMaxBytes is the maximum image file size read_file will
+// embed for multimodal models. Past this the user gets an error suggesting
+// they resize or compress the image.
+const ReadFileImageMaxBytes = 5 * 1024 * 1024 // 5 MB
+
 // ReadFileTool reads a UTF-8 text file, optionally a window of it, and
 // returns its content with each line prefixed by its 1-based line number
 // (the `cat -n` format the LLM is already familiar with).
+//
+// For image files (.png, .jpg, .jpeg, .gif, .webp, .bmp, .tiff, .heic, .ico)
+// the tool reads the raw bytes and returns them as an image content block
+// for multimodal model consumption alongside a short text description.
 type ReadFileTool struct{}
 
 func (ReadFileTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name: "read_file",
-		Description: "Read a UTF-8 text file and return its content with cat -n-style " +
+		Description: "Read a UTF-8 text file and return its content with cat-n-style " +
 			"line numbers. Up to 2000 lines per call — use offset/limit to paginate. " +
 			"Absolute paths are preferred; relative paths resolve against the current " +
 			"working directory. Refuses binary extensions (executables, archives, " +
-			"images, PDFs, DBs) and blocking device files (/dev/random, /dev/tty etc).",
+			"PDFs, DBs) and blocking device files (/dev/random, /dev/tty etc). " +
+			"Image files (.png, .jpg, .jpeg, .gif, .webp, .bmp, .tiff, .heic, .ico) " +
+			"are returned as image content for multimodal model consumption.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"path": map[string]any{
 					"type":        "string",
-					"description": "File path (absolute preferred).",
+					"description": "File path (absolute preferred). Image files are supported for multimodal models.",
 				},
 				"offset": map[string]any{
 					"type":        "integer",
-					"description": "1-based line number to start from. Defaults to 1 (beginning of file).",
+					"description": "1-based line number to start from. Defaults to 1 (beginning of file). Only applies to text files.",
 				},
 				"limit": map[string]any{
 					"type":        "integer",
-					"description": "Maximum lines to return. Defaults to 2000.",
+					"description": "Maximum lines to return. Defaults to 2000. Only applies to text files.",
 				},
 			},
 			"required": []string{"path"},
@@ -50,35 +75,38 @@ func (ReadFileTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	path, _ := input["path"].(string)
 	if strings.TrimSpace(path) == "" {
-		return "", fmt.Errorf("read_file: path is required")
+		return agent.ToolResult{}, fmt.Errorf("read_file: path is required")
 	}
 	// Refuse UNC / network paths (\\server\share, //server/share) before
 	// resolving. On Windows these trigger an SMB connection that can leak
 	// NTLM credentials to an attacker-controlled host; nowhere does a
 	// legitimate read need one.
 	if isUNCPath(path) {
-		return "", fmt.Errorf("read_file: refusing network/UNC path %q — it could leak credentials to a remote host", path)
+		return agent.ToolResult{}, fmt.Errorf("read_file: refusing network/UNC path %q — it could leak credentials to a remote host", path)
 	}
 	abs, err := resolvePath(path)
 	if err != nil {
-		return "", err
-	}
-
-	// Refuse binaries by extension. Cheaper than mime-sniffing and stops
-	// the LLM from blowing its context on a multi-MB .exe / .png. PDFs and
-	// images would need separate tooling (image embedding, PDF text
-	// extraction) — out of scope for read_file.
-	if reason := isLikelyBinaryPath(abs); reason != "" {
-		return "", fmt.Errorf("read_file: refusing to read %s — %s", path, reason)
+		return agent.ToolResult{}, err
 	}
 
 	// Refuse device files that would block forever or generate infinite
 	// output. /dev/null is permitted because it just returns EOF immediately.
 	if isBlockedDevicePath(abs) {
-		return "", fmt.Errorf("read_file: refusing to read %s — device file would block or stream indefinitely", path)
+		return agent.ToolResult{}, fmt.Errorf("read_file: refusing to read %s — device file would block or stream indefinitely", path)
+	}
+
+	// Check for image files first — multimodal models can consume them.
+	if mimeType := imageMIMEType(abs); mimeType != "" {
+		return readImageFile(abs, path, mimeType)
+	}
+
+	// Refuse non-image binaries by extension. Cheaper than mime-sniffing
+	// and stops the LLM from blowing its context on a multi-MB .exe.
+	if reason := isLikelyBinaryPath(abs); reason != "" {
+		return agent.ToolResult{}, fmt.Errorf("read_file: refusing to read %s — %s", path, reason)
 	}
 
 	offset := intArg(input, "offset", 1)
@@ -92,7 +120,7 @@ func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 
 	f, err := os.Open(abs)
 	if err != nil {
-		return "", fmt.Errorf("read_file: open %q: %w", path, err)
+		return agent.ToolResult{}, fmt.Errorf("read_file: open %q: %w", path, err)
 	}
 	defer f.Close()
 
@@ -121,16 +149,64 @@ func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 		returned++
 	}
 	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("read_file: scan %q: %w", path, err)
+		return agent.ToolResult{}, fmt.Errorf("read_file: scan %q: %w", path, err)
 	}
 
 	if returned == 0 && lineNum > 0 {
-		return "", fmt.Errorf("read_file: offset %d is past end of file (only %d lines)", offset, lineNum)
+		return agent.ToolResult{}, fmt.Errorf("read_file: offset %d is past end of file (only %d lines)", offset, lineNum)
 	}
 	if returned == 0 {
-		return "(empty file)", nil
+		return agent.ToolResult{Text: "(empty file)"}, nil
 	}
-	return out.String(), nil
+	return agent.ToolResult{Text: out.String()}, nil
+}
+
+// imageMIMEType returns the MIME type for known image extensions, or "".
+func imageMIMEType(absPath string) string {
+	ext := strings.ToLower(filepath.Ext(absPath))
+	return imageExtensions[ext]
+}
+
+// readImageFile reads an image file and returns a ToolResult with both a
+// text description and an image content block for multimodal models.
+func readImageFile(absPath, displayPath, mimeType string) (agent.ToolResult, error) {
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return agent.ToolResult{}, fmt.Errorf("read_file: stat %q: %w", displayPath, err)
+	}
+	if info.Size() > ReadFileImageMaxBytes {
+		return agent.ToolResult{}, fmt.Errorf(
+			"read_file: image %s is %s — exceeds %s limit. Resize or compress before reading.",
+			displayPath, formatBytes(info.Size()), formatBytes(ReadFileImageMaxBytes),
+		)
+	}
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return agent.ToolResult{}, fmt.Errorf("read_file: read %q: %w", displayPath, err)
+	}
+
+	desc := fmt.Sprintf("Image: %s (%s, %s)", displayPath, mimeType, formatBytes(info.Size()))
+	return agent.ToolResult{
+		Text:   desc,
+		Blocks: []agent.ContentBlock{agent.NewImageBlock(mimeType, data)},
+	}, nil
+}
+
+// formatBytes renders a byte count in human-readable form.
+func formatBytes(n int64) string {
+	const (
+		KB = 1024
+		MB = 1024 * KB
+	)
+	switch {
+	case n >= MB:
+		return fmt.Sprintf("%.1f MB", float64(n)/MB)
+	case n >= KB:
+		return fmt.Sprintf("%.1f KB", float64(n)/KB)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }
 
 // isUNCPath reports whether path is a UNC / network path. Both the Windows
@@ -176,11 +252,10 @@ func intArg(input map[string]any, key string, dflt int) int {
 
 // binaryExtensions is the set of file extensions read_file refuses outright.
 // The list focuses on formats that are almost never useful as text in an
-// LLM context (executables, archives, media, compiled artefacts). PDFs and
-// images are *also* binary but excluded from this map — they're plausibly
-// useful via separate extraction tools we may add later, and the user-facing
-// error message becomes more accurate ("use a PDF tool") than the generic
-// "binary file" wording. For now those still hit this list as a catch-all.
+// LLM context (executables, archives, audio/video, compiled artefacts).
+// Images (.png, .jpg, etc.) are handled separately via imageExtensions —
+// they're returned as image content blocks for multimodal models.
+// PDFs remain refused because they need separate text extraction tooling.
 var binaryExtensions = map[string]string{
 	// Executables / libraries
 	".exe": "Windows executable", ".dll": "Windows library",
@@ -193,10 +268,6 @@ var binaryExtensions = map[string]string{
 	".zip": "ZIP archive", ".tar": "tar archive", ".gz": "gzip archive",
 	".bz2": "bzip2 archive", ".xz": "xz archive", ".7z": "7-zip archive",
 	".rar": "RAR archive",
-	// Images
-	".png": "PNG image", ".jpg": "JPEG image", ".jpeg": "JPEG image",
-	".gif": "GIF image", ".bmp": "BMP image", ".webp": "WebP image",
-	".ico": "icon", ".tiff": "TIFF image", ".heic": "HEIC image",
 	// Audio / video
 	".mp3": "MP3 audio", ".mp4": "MP4 video", ".mov": "video",
 	".avi": "video", ".mkv": "video", ".webm": "video",

--- a/internal/tools/read_file_test.go
+++ b/internal/tools/read_file_test.go
@@ -18,8 +18,8 @@ func TestReadFile_HappyPath(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	for _, want := range []string{"     1\tline1", "     2\tline2", "     3\tline3"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("output missing %q\n%s", want, out)
+		if !strings.Contains(out.Text, want) {
+			t.Errorf("output missing %q\n%s", want, out.Text)
 		}
 	}
 }
@@ -43,11 +43,11 @@ func TestReadFile_OffsetAndLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "     3\tline3") || !strings.Contains(out, "     4\tline4") {
-		t.Errorf("offset/limit slice wrong:\n%s", out)
+	if !strings.Contains(out.Text, "     3\tline3") || !strings.Contains(out.Text, "     4\tline4") {
+		t.Errorf("offset/limit slice wrong:\n%s", out.Text)
 	}
-	if strings.Contains(out, "     2\tline2") || strings.Contains(out, "     5\tline5") {
-		t.Errorf("offset/limit returned unwanted lines:\n%s", out)
+	if strings.Contains(out.Text, "     2\tline2") || strings.Contains(out.Text, "     5\tline5") {
+		t.Errorf("offset/limit returned unwanted lines:\n%s", out.Text)
 	}
 }
 
@@ -83,8 +83,8 @@ func TestReadFile_EmptyFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "empty") {
-		t.Errorf("expected empty-file marker, got %q", out)
+	if !strings.Contains(out.Text, "empty") {
+		t.Errorf("expected empty-file marker, got %q", out.Text)
 	}
 }
 
@@ -104,7 +104,6 @@ func TestReadFile_RejectsBinaryExtensions(t *testing.T) {
 	}{
 		{"exe", ".exe", "Windows executable"},
 		{"zip", ".zip", "ZIP archive"},
-		{"png", ".png", "PNG image"},
 		{"pdf", ".pdf", "PDF document"},
 		{"sqlite", ".sqlite", "SQLite database"},
 	}
@@ -120,6 +119,46 @@ func TestReadFile_RejectsBinaryExtensions(t *testing.T) {
 				t.Errorf("error should mention %q; got: %v", c.wantSub, err)
 			}
 		})
+	}
+}
+
+func TestReadFile_ReadsImage(t *testing.T) {
+	// A valid PNG header: 89 50 4E 47 0D 0A 1A 0A
+	pngHeader := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.png")
+	if err := os.WriteFile(path, pngHeader, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ReadFileTool{}.Execute(context.Background(), "read_file", map[string]any{"path": path})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res.Text, "image/png") {
+		t.Errorf("expected image description with MIME type, got: %q", res.Text)
+	}
+	if len(res.Blocks) != 1 || res.Blocks[0].Type != "image" {
+		t.Errorf("expected 1 image block, got %+v", res.Blocks)
+	}
+	if res.Blocks[0].Image == nil || res.Blocks[0].Image.MIMEType != "image/png" {
+		t.Errorf("image block MIME type wrong: %+v", res.Blocks[0].Image)
+	}
+}
+
+func TestReadFile_ImageTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.png")
+	// Write a file larger than ReadFileImageMaxBytes
+	big := make([]byte, ReadFileImageMaxBytes+1)
+	big[0] = 0x89 // PNG magic byte so it passes the extension check
+	if err := os.WriteFile(path, big, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ReadFileTool{}.Execute(context.Background(), "read_file", map[string]any{"path": path})
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected size-limit error, got: %v", err)
 	}
 }
 
@@ -168,8 +207,8 @@ func TestReadFile_AllowsDevNull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("/dev/null should be readable (returns EOF): %v", err)
 	}
-	if !strings.Contains(out, "empty") {
-		t.Errorf("expected empty-file marker, got %q", out)
+	if !strings.Contains(out.Text, "empty") {
+		t.Errorf("expected empty-file marker, got %q", out.Text)
 	}
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -13,7 +13,7 @@ import (
 // interface is private so adding methods later doesn't break consumers.
 type tool interface {
 	Definition() agent.ToolDefinition
-	Execute(ctx context.Context, name string, input map[string]any) (string, error)
+	Execute(ctx context.Context, name string, input map[string]any) (agent.ToolResult, error)
 }
 
 // allTools is the canonical, ordered list of built-in tools shipped with
@@ -60,12 +60,12 @@ func NewDefaultRegistry() DefaultRegistry {
 }
 
 // Execute implements agent.ToolExecutor.
-func (r DefaultRegistry) Execute(ctx context.Context, name string, input map[string]any) (string, error) {
+func (r DefaultRegistry) Execute(ctx context.Context, name string, input map[string]any) (agent.ToolResult, error) {
 	// MCP tools land here too — route them first so an "mcp__…" name
 	// never falls through to the unknown-tool path. executeMCP returns
 	// ok=false when the name isn't ours, then dispatch continues below.
 	if out, ok, err := executeMCP(ctx, name, input); ok {
-		return out, err
+		return agent.ToolResult{Text: out}, err
 	}
 
 	// Read-before-write pre-check (skipped when no tracker is configured).
@@ -73,7 +73,7 @@ func (r DefaultRegistry) Execute(ctx context.Context, name string, input map[str
 		if path, ok := input["path"].(string); ok {
 			if abs, err := resolvePath(path); err == nil {
 				if cerr := r.tracker.CheckWritable(abs); cerr != nil {
-					return "", cerr
+					return agent.ToolResult{}, cerr
 				}
 			}
 		}
@@ -96,7 +96,7 @@ func (r DefaultRegistry) Execute(ctx context.Context, name string, input map[str
 			return out, err
 		}
 	}
-	return "", fmt.Errorf("unknown tool %q", name)
+	return agent.ToolResult{Text: ""}, fmt.Errorf("unknown tool %q", name)
 }
 
 // DefaultTools returns the slice of ToolDefinitions sent to the LLM when

--- a/internal/tools/remember.go
+++ b/internal/tools/remember.go
@@ -57,13 +57,13 @@ func (RememberTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (RememberTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+func (RememberTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	content := strings.TrimSpace(stringArg(input, "content"))
 	if content == "" {
-		return "", fmt.Errorf("remember: content is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("remember: content is required")
 	}
 	if !memoryEnabled() {
-		return "", fmt.Errorf("remember: memory is disabled for this session")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("remember: memory is disabled for this session")
 	}
 	desc := strings.TrimSpace(stringArg(input, "description"))
 	if desc == "" {
@@ -78,12 +78,12 @@ func (RememberTool) Execute(_ context.Context, _ string, input map[string]any) (
 		Body:        content,
 	}
 	if e.Name == "" {
-		return "", fmt.Errorf("remember: could not derive a name from the content")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("remember: could not derive a name from the content")
 	}
 	if err := activeMemory.Save(e); err != nil {
-		return "", fmt.Errorf("remember: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("remember: %w", err)
 	}
-	return "Remembered (" + string(normalizeType(e.Type)) + "): " + desc, nil
+	return agent.ToolResult{Text: "Remembered (" + string(normalizeType(e.Type)) + "): " + desc}, nil
 }
 
 // normalizeType mirrors the store's defaulting so the confirmation message

--- a/internal/tools/remember_test.go
+++ b/internal/tools/remember_test.go
@@ -26,8 +26,8 @@ func TestRememberTool_Execute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "feedback") {
-		t.Errorf("confirmation should report the type: %q", out)
+	if !strings.Contains(out.Text, "feedback") {
+		t.Errorf("confirmation should report the type: %q", out.Text)
 	}
 
 	entries, _ := store.List()

--- a/internal/tools/sandbox_integration_test.go
+++ b/internal/tools/sandbox_integration_test.go
@@ -31,7 +31,7 @@ func TestTerminal_SandboxConfinesIO(t *testing.T) {
 	out, err := reg.Execute(ctx, "terminal", map[string]any{
 		"command": "echo hi > " + inside + " && echo OK || echo FAIL:$?",
 	})
-	t.Logf("inside cmd → err=%v out=%q", err, out)
+	t.Logf("inside cmd → err=%v out=%q", err, out.Text)
 	if err != nil {
 		t.Fatalf("terminal execute (inside): %v", err)
 	}

--- a/internal/tools/send_message.go
+++ b/internal/tools/send_message.go
@@ -41,35 +41,35 @@ func (SendMessageTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (SendMessageTool) Execute(ctx context.Context, _ string, input map[string]any) (string, error) {
+func (SendMessageTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	if !spawnerEnabled() {
-		return "", fmt.Errorf("send_message: sub-agent dispatch is not configured for this session")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("send_message: sub-agent dispatch is not configured for this session")
 	}
 	if IsSubAgent(ctx) {
 		// Symmetric with launch_agent's recursion guard: a sub-agent must not
 		// be able to wake another sub-agent. Defense in depth on top of the
 		// Spawner dropping send_message from every child's tool list.
-		return "", fmt.Errorf("send_message: a sub-agent cannot message another sub-agent")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("send_message: a sub-agent cannot message another sub-agent")
 	}
 
 	agentID := strings.TrimSpace(stringArg(input, "agent_id"))
 	message := strings.TrimSpace(stringArg(input, "message"))
 	if agentID == "" {
-		return "", fmt.Errorf("send_message: agent_id is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("send_message: agent_id is required")
 	}
 	if message == "" {
-		return "", fmt.Errorf("send_message: message is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("send_message: message is required")
 	}
 
 	res, err := activeSpawner.Continue(ctx, agentID, message)
 	if err != nil {
-		return "", fmt.Errorf("send_message: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("send_message: %w", err)
 	}
 	reply := strings.TrimSpace(res.Reply)
 	if reply == "" {
-		return "(sub-agent " + agentID + " produced no reply)", nil
+		return agent.ToolResult{Text: "(sub-agent " + agentID + " produced no reply)"}, nil
 	}
-	return withAgentTag(res.AgentID, reply), nil
+	return agent.ToolResult{Text: withAgentTag(res.AgentID, reply)}, nil
 }
 
 // withAgentTag prefixes a sub-agent reply with "[agent <id>] " so the parent

--- a/internal/tools/send_message_test.go
+++ b/internal/tools/send_message_test.go
@@ -35,8 +35,8 @@ func TestSendMessageTool_ContinuesAndTagsReply(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "[agent a1b2c3d4] next round done" {
-		t.Errorf("Execute returned %q, want tagged reply", out)
+	if out.Text != "[agent a1b2c3d4] next round done" {
+		t.Errorf("Execute returned %q, want tagged reply", out.Text)
 	}
 	if stub.contAgentID != "a1b2c3d4" || stub.contMessage != "now do the second half" {
 		t.Errorf("Continue got (%q,%q)", stub.contAgentID, stub.contMessage)
@@ -52,8 +52,8 @@ func TestSendMessageTool_EmptyReplySurfaced(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, "produced no reply") {
-		t.Errorf("empty reply should be surfaced, got %q", out)
+	if !strings.Contains(out.Text, "produced no reply") {
+		t.Errorf("empty reply should be surfaced, got %q", out.Text)
 	}
 }
 
@@ -142,7 +142,7 @@ func TestLaunchAgentTool_TagsReplyWithAgentID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "[agent deadbeef] the finding" {
-		t.Errorf("launch_agent reply should carry the agent tag, got %q", out)
+	if out.Text != "[agent deadbeef] the finding" {
+		t.Errorf("launch_agent reply should carry the agent tag, got %q", out.Text)
 	}
 }

--- a/internal/tools/skill.go
+++ b/internal/tools/skill.go
@@ -48,17 +48,17 @@ func (SkillTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (SkillTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+func (SkillTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	name, _ := input["name"].(string)
 	if name == "" {
-		return "", fmt.Errorf("skill: name is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("skill: name is required")
 	}
 	if !skillsEnabled() {
-		return "", fmt.Errorf("skill: no skills are available")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("skill: no skills are available")
 	}
 	s, ok := activeSkills.Get(name)
 	if !ok {
-		return "", fmt.Errorf("skill: unknown skill %q", name)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("skill: unknown skill %q", name)
 	}
-	return s.Body, nil
+	return agent.ToolResult{Text: s.Body}, nil
 }

--- a/internal/tools/skill_test.go
+++ b/internal/tools/skill_test.go
@@ -33,8 +33,8 @@ func TestSkillTool_Execute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if out != "Step 1: be nice." {
-		t.Errorf("body = %q", out)
+	if out.Text != "Step 1: be nice." {
+		t.Errorf("body = %q", out.Text)
 	}
 }
 

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -75,13 +75,13 @@ func (TaskCreateTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (TaskCreateTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+func (TaskCreateTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	if !tasksEnabled() {
-		return "", fmt.Errorf("task_create: task tracking is not configured for this session")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("task_create: task tracking is not configured for this session")
 	}
 	subject := strings.TrimSpace(stringArg(input, "subject"))
 	if subject == "" {
-		return "", fmt.Errorf("task_create: subject is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("task_create: subject is required")
 	}
 	id, err := activeTasks.Create(
 		subject,
@@ -89,9 +89,9 @@ func (TaskCreateTool) Execute(_ context.Context, _ string, input map[string]any)
 		stringArg(input, "active_form"),
 	)
 	if err != nil {
-		return "", fmt.Errorf("task_create: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("task_create: %w", err)
 	}
-	return fmt.Sprintf("Created task #%d: %s", id, subject), nil
+	return agent.ToolResult{Text: fmt.Sprintf("Created task #%d: %s", id, subject)}, nil
 }
 
 // ============================================================================
@@ -142,13 +142,13 @@ func (TaskUpdateTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (TaskUpdateTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+func (TaskUpdateTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	if !tasksEnabled() {
-		return "", fmt.Errorf("task_update: task tracking is not configured for this session")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("task_update: task tracking is not configured for this session")
 	}
 	id := intArg(input, "task_id", 0)
 	if id <= 0 {
-		return "", fmt.Errorf("task_update: task_id is required (positive integer)")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("task_update: task_id is required (positive integer)")
 	}
 
 	var u tasks.UpdateField
@@ -173,14 +173,14 @@ func (TaskUpdateTool) Execute(_ context.Context, _ string, input map[string]any)
 	}
 
 	if u.Status == nil && u.Subject == nil && u.Description == nil && u.ActiveForm == nil {
-		return "", fmt.Errorf("task_update: nothing to update (provide status, subject, description, or active_form)")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("task_update: nothing to update (provide status, subject, description, or active_form)")
 	}
 
 	got, err := activeTasks.Update(id, u)
 	if err != nil {
-		return "", fmt.Errorf("task_update: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("task_update: %w", err)
 	}
-	return fmt.Sprintf("Updated task #%d (%s): %s", got.ID, got.Status, got.Subject), nil
+	return agent.ToolResult{Text: fmt.Sprintf("Updated task #%d (%s): %s", got.ID, got.Status, got.Subject)}, nil
 }
 
 // ============================================================================
@@ -205,11 +205,11 @@ func (TaskListTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (TaskListTool) Execute(_ context.Context, _ string, _ map[string]any) (string, error) {
+func (TaskListTool) Execute(_ context.Context, _ string, _ map[string]any) (agent.ToolResult, error) {
 	if !tasksEnabled() {
-		return "", fmt.Errorf("task_list: task tracking is not configured for this session")
+		return agent.ToolResult{}, fmt.Errorf("task_list: task tracking is not configured for this session")
 	}
-	return FormatTaskList(activeTasks.List()), nil
+	return agent.ToolResult{Text: FormatTaskList(activeTasks.List())}, nil
 }
 
 // FormatTaskList renders a slice of tasks for display. Used both by the

--- a/internal/tools/tasks_test.go
+++ b/internal/tools/tasks_test.go
@@ -45,8 +45,8 @@ func TestTaskCreateTool_Execute(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, "Created task #1") || !strings.Contains(out, "Migrate auth middleware") {
-		t.Errorf("Execute = %q", out)
+	if !strings.Contains(out.Text, "Created task #1") || !strings.Contains(out.Text, "Migrate auth middleware") {
+		t.Errorf("Execute = %q", out.Text)
 	}
 	got := store.List()
 	if len(got) != 1 || got[0].Subject != "Migrate auth middleware" {
@@ -96,8 +96,8 @@ func TestTaskUpdateTool_Execute_StatusChange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, "in_progress") {
-		t.Errorf("Execute = %q", out)
+	if !strings.Contains(out.Text, "in_progress") {
+		t.Errorf("Execute = %q", out.Text)
 	}
 	got, _ := store.Get(id)
 	if got.Status != tasks.InProgress {
@@ -180,8 +180,8 @@ func TestTaskListTool_Execute_Empty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "No tasks yet." {
-		t.Errorf("empty list = %q", out)
+	if out.Text != "No tasks yet." {
+		t.Errorf("empty list = %q", out.Text)
 	}
 }
 
@@ -201,15 +201,15 @@ func TestTaskListTool_Execute_GroupsByStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, want := range []string{"▶", "○", "✓", "first", "second", "third"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("output missing %q:\n%s", want, out)
+		if !strings.Contains(out.Text, want) {
+			t.Errorf("output missing %q:\n%s", want, out.Text)
 		}
 	}
 	// In-progress (id1) should appear before pending (id3) which should
 	// appear before completed (id2) in the rendered text.
-	inProgPos := strings.Index(out, "first")
-	pendPos := strings.Index(out, "third")
-	donePos := strings.Index(out, "second")
+	inProgPos := strings.Index(out.Text, "first")
+	pendPos := strings.Index(out.Text, "third")
+	donePos := strings.Index(out.Text, "second")
 	if !(inProgPos < pendPos && pendPos < donePos) {
 		t.Errorf("status order wrong (in_prog<pending<done): %d<%d<%d", inProgPos, pendPos, donePos)
 	}
@@ -222,8 +222,8 @@ func TestTaskListTool_Execute_UsesActiveFormForInProgress(t *testing.T) {
 	_, _ = store.Update(id, tasks.UpdateField{Status: &inProg})
 
 	out, _ := TaskListTool{}.Execute(context.Background(), "task_list", nil)
-	if !strings.Contains(out, "Migrating auth middleware") {
-		t.Errorf("in-progress should use ActiveForm, got:\n%s", out)
+	if !strings.Contains(out.Text, "Migrating auth middleware") {
+		t.Errorf("in-progress should use ActiveForm, got:\n%s", out.Text)
 	}
 }
 

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -71,7 +71,7 @@ func (TerminalTool) Definition() agent.ToolDefinition {
 // Internally this delegates to ExecuteStream with a nil progress callback so
 // both code paths share the same exec/scanner pipeline — only the streaming
 // behavior changes.
-func (t TerminalTool) Execute(ctx context.Context, name string, input map[string]any) (string, error) {
+func (t TerminalTool) Execute(ctx context.Context, name string, input map[string]any) (agent.ToolResult, error) {
 	return t.ExecuteStream(ctx, name, input, nil)
 }
 
@@ -89,13 +89,13 @@ func (t TerminalTool) ExecuteStream(
 	_ string,
 	input map[string]any,
 	progress func(chunk string),
-) (string, error) {
+) (agent.ToolResult, error) {
 	command, _ := input["command"].(string)
 	if command == "" {
-		return "", fmt.Errorf("terminal: command is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal: command is required")
 	}
 	if err := guardCommand(command); err != nil {
-		return "", err
+		return agent.ToolResult{Text: ""}, err
 	}
 
 	// Background launch: detach, no timeout, return the id immediately. The
@@ -103,9 +103,9 @@ func (t TerminalTool) ExecuteStream(
 	if bg, _ := input["background"].(bool); bg {
 		id, err := t.manager().Start(command)
 		if err != nil {
-			return "", err
+			return agent.ToolResult{Text: ""}, err
 		}
-		return fmt.Sprintf("Started background process %s.\nRead its output with the terminal_output tool (id: %q).", id, id), nil
+		return agent.ToolResult{Text: fmt.Sprintf("Started background process %s.\nRead its output with the terminal_output tool (id: %q).", id, id)}, nil
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, TerminalTimeout)
@@ -113,7 +113,7 @@ func (t TerminalTool) ExecuteStream(
 
 	cmd, err := shellCommand(ctx, command)
 	if err != nil {
-		return "", err
+		return agent.ToolResult{Text: ""}, err
 	}
 
 	// Merge stdout + stderr through a single pipe so the reader sees a
@@ -125,7 +125,7 @@ func (t TerminalTool) ExecuteStream(
 
 	if err := cmd.Start(); err != nil {
 		_ = pw.Close()
-		return "", fmt.Errorf("terminal: start: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal: start: %w", err)
 	}
 
 	// Reader goroutine forwards each line to progress and accumulates the
@@ -170,9 +170,9 @@ func (t TerminalTool) ExecuteStream(
 	if waitErr != nil {
 		// Match the original Execute contract: non-zero exit is surfaced as
 		// result text, not as a Go error, so the LLM can read and adapt.
-		return body + "\n[exit: " + waitErr.Error() + "]", nil
+		return agent.ToolResult{Text: body + "\n[exit: " + waitErr.Error() + "]"}, nil
 	}
-	return body, nil
+	return agent.ToolResult{Text: body}, nil
 }
 
 // TerminalOutputTool reads new output (and status) from a background process
@@ -208,20 +208,20 @@ func (TerminalOutputTool) Definition() agent.ToolDefinition {
 
 // Execute returns the new output plus a status line. Read-only — it never
 // terminates the process (that's kill_shell).
-func (t TerminalOutputTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+func (t TerminalOutputTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	id, _ := input["id"].(string)
 	if id == "" {
-		return "", fmt.Errorf("terminal_output: id is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: id is required")
 	}
 	out, status, found := t.manager().Read(id)
 	if !found {
-		return "", fmt.Errorf("terminal_output: no background process %q", id)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: no background process %q", id)
 	}
 	header := "[status: " + status + "]"
 	if out == "" {
-		return header + "\n(no new output)", nil
+		return agent.ToolResult{Text: header + "\n(no new output)"}, nil
 	}
-	return header + "\n" + out, nil
+	return agent.ToolResult{Text: header + "\n" + out}, nil
 }
 
 // KillShellTool terminates a background process started by TerminalTool with
@@ -258,14 +258,14 @@ func (KillShellTool) Definition() agent.ToolDefinition {
 // Execute kills the process, then returns its final remaining output. An
 // unknown id is an error (Kill reports it); an already-exited process is a
 // no-op kill and still returns its last output.
-func (t KillShellTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+func (t KillShellTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	id, _ := input["id"].(string)
 	if id == "" {
-		return "", fmt.Errorf("kill_shell: id is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("kill_shell: id is required")
 	}
 	mgr := t.manager()
 	if !mgr.Kill(id) {
-		return "", fmt.Errorf("kill_shell: no background process %q", id)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("kill_shell: no background process %q", id)
 	}
 	// Give the process a moment to flush and the waiter to record exit.
 	time.Sleep(50 * time.Millisecond)
@@ -273,7 +273,7 @@ func (t KillShellTool) Execute(_ context.Context, _ string, input map[string]any
 	out, status, _ := mgr.Read(id) // found guaranteed: Kill succeeded
 	header := "[killed] [status: " + status + "]"
 	if out == "" {
-		return header + "\n(no new output)", nil
+		return agent.ToolResult{Text: header + "\n(no new output)"}, nil
 	}
-	return header + "\n" + out, nil
+	return agent.ToolResult{Text: header + "\n" + out}, nil
 }

--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -43,8 +43,8 @@ func TestTerminalTool_Execute_Echo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if strings.TrimSpace(result) != "hello" {
-		t.Errorf("result = %q, want 'hello'", result)
+	if strings.TrimSpace(result.Text) != "hello" {
+		t.Errorf("result = %q, want 'hello'", result.Text)
 	}
 }
 
@@ -55,8 +55,8 @@ func TestTerminalTool_Execute_Multiline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(result, "line1") || !strings.Contains(result, "line2") {
-		t.Errorf("result = %q, want line1 and line2", result)
+	if !strings.Contains(result.Text, "line1") || !strings.Contains(result.Text, "line2") {
+		t.Errorf("result = %q, want line1 and line2", result.Text)
 	}
 }
 
@@ -70,11 +70,11 @@ func TestTerminalTool_Execute_NonZeroExit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute should not return a Go error for non-zero exit: %v", err)
 	}
-	if !strings.Contains(result, "oops") {
-		t.Errorf("result should contain stdout: %q", result)
+	if !strings.Contains(result.Text, "oops") {
+		t.Errorf("result should contain stdout: %q", result.Text)
 	}
-	if !strings.Contains(result, "[exit:") {
-		t.Errorf("result should contain [exit:...]: %q", result)
+	if !strings.Contains(result.Text, "[exit:") {
+		t.Errorf("result should contain [exit:...]: %q", result.Text)
 	}
 }
 
@@ -103,8 +103,8 @@ func TestDefaultRegistry_Execute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute terminal: %v", err)
 	}
-	if strings.TrimSpace(result) != "registry" {
-		t.Errorf("result = %q", result)
+	if strings.TrimSpace(result.Text) != "registry" {
+		t.Errorf("result = %q", result.Text)
 	}
 }
 
@@ -132,8 +132,8 @@ func TestTerminalTool_ExecuteStream_LineByLine(t *testing.T) {
 			t.Errorf("got[%d] = %q, want %q", i, got[i], want)
 		}
 	}
-	if result != "line1\nline2\nline3" {
-		t.Errorf("aggregated result = %q", result)
+	if result.Text != "line1\nline2\nline3" {
+		t.Errorf("aggregated result = %q", result.Text)
 	}
 }
 
@@ -164,8 +164,8 @@ func TestTerminalTool_ExecuteStream_NilProgressIsExecute(t *testing.T) {
 		map[string]any{"command": "echo hi"}, func(string) {})
 	execResult, _ := TerminalTool{}.Execute(context.Background(), "terminal",
 		map[string]any{"command": "echo hi"})
-	if streamResult != execResult {
-		t.Errorf("stream=%q exec=%q — should match", streamResult, execResult)
+	if streamResult.Text != execResult.Text {
+		t.Errorf("stream=%q exec=%q — should match", streamResult.Text, execResult.Text)
 	}
 }
 
@@ -177,11 +177,11 @@ func TestTerminalTool_ExecuteStream_NonZeroExitPreservesContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("non-zero exit should NOT be a Go error: %v", err)
 	}
-	if !strings.Contains(result, "before-fail") {
-		t.Errorf("output should include pre-exit stdout: %q", result)
+	if !strings.Contains(result.Text, "before-fail") {
+		t.Errorf("output should include pre-exit stdout: %q", result.Text)
 	}
-	if !strings.Contains(result, "[exit:") {
-		t.Errorf("output should include exit annotation: %q", result)
+	if !strings.Contains(result.Text, "[exit:") {
+		t.Errorf("output should include exit annotation: %q", result.Text)
 	}
 }
 
@@ -208,8 +208,8 @@ func TestTerminalTool_ContextCancel_KillsChild(t *testing.T) {
 		t.Fatalf("Execute should not error on cancellation: %v", err)
 	}
 	// The result should mention the signal/kill, not a clean exit.
-	if !strings.Contains(result, "[exit:") {
-		t.Errorf("result should contain [exit:...] after kill; got: %q", result)
+	if !strings.Contains(result.Text, "[exit:") {
+		t.Errorf("result should contain [exit:...] after kill; got: %q", result.Text)
 	}
 	// Must finish well before 30s — the cancellation killed it.
 	if elapsed > 2*time.Second {

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -53,17 +53,17 @@ func (WebFetchTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any) (string, error) {
+func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	raw, _ := input["url"].(string)
 	if strings.TrimSpace(raw) == "" {
-		return "", fmt.Errorf("web_fetch: url is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: url is required")
 	}
 	u, err := url.Parse(raw)
 	if err != nil {
-		return "", fmt.Errorf("web_fetch: parse url: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: parse url: %w", err)
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
-		return "", fmt.Errorf("web_fetch: only http/https URLs are allowed (got %q)", u.Scheme)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: only http/https URLs are allowed (got %q)", u.Scheme)
 	}
 
 	// Jina's contract is literal string concatenation: r.jina.ai/<rest>.
@@ -78,7 +78,7 @@ func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jinaURL, nil)
 	if err != nil {
-		return "", fmt.Errorf("web_fetch: build request: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: build request: %w", err)
 	}
 	req.Header.Set("Accept", "text/markdown,text/plain,*/*")
 	// Identify ourselves so Jina can reach us about issues.
@@ -86,18 +86,18 @@ func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any)
 
 	resp, err := webFetchHTTPClient().Do(req)
 	if err != nil {
-		return "", fmt.Errorf("web_fetch: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return "", fmt.Errorf("web_fetch: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, WebFetchMaxBytes+1))
 	if err != nil {
-		return "", fmt.Errorf("web_fetch: read body: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: read body: %w", err)
 	}
 	truncated := false
 	if len(body) > WebFetchMaxBytes {
@@ -109,7 +109,7 @@ func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any)
 	if truncated {
 		out += "\n\n…[truncated at " + strconv.Itoa(WebFetchMaxBytes) + " bytes]"
 	}
-	return out, nil
+	return agent.ToolResult{Text: out}, nil
 }
 
 // webHTTPClient is the shared http.Client used by the network backends of

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -57,8 +57,8 @@ func TestWebFetch_AgainstHTTPTest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "Hello") || !strings.Contains(out, "markdown") {
-		t.Errorf("unexpected body: %q", out)
+	if !strings.Contains(out.Text, "Hello") || !strings.Contains(out.Text, "markdown") {
+		t.Errorf("unexpected body: %q", out.Text)
 	}
 }
 
@@ -84,12 +84,12 @@ func TestWebFetch_RefusesCrossHostRedirect(t *testing.T) {
 		"url": "https://example.com/x",
 	})
 	if err == nil {
-		t.Fatalf("expected cross-host redirect to be refused; got body %q", out)
+		t.Fatalf("expected cross-host redirect to be refused; got body %q", out.Text)
 	}
 	if !strings.Contains(err.Error(), "cross-host redirect") {
 		t.Errorf("error should mention cross-host redirect, got %v", err)
 	}
-	if strings.Contains(out, "secret internal content") {
+	if strings.Contains(out.Text, "secret internal content") {
 		t.Errorf("must not have followed the redirect to the destination")
 	}
 }
@@ -116,8 +116,8 @@ func TestWebFetch_FollowsSameHostRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("same-host redirect should be followed: %v", err)
 	}
-	if !strings.Contains(out, "arrived") {
-		t.Errorf("expected to reach the same-host redirect target, got %q", out)
+	if !strings.Contains(out.Text, "arrived") {
+		t.Errorf("expected to reach the same-host redirect target, got %q", out.Text)
 	}
 }
 
@@ -157,8 +157,8 @@ func TestWebFetch_Truncates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "truncated") {
-		t.Errorf("expected truncation marker, got tail: %q", out[max(0, len(out)-100):])
+	if !strings.Contains(out.Text, "truncated") {
+		t.Errorf("expected truncation marker, got tail: %q", out.Text[max(0, len(out.Text)-100):])
 	}
 }
 

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -94,10 +94,10 @@ func (WebSearchTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (WebSearchTool) Execute(ctx context.Context, _ string, input map[string]any) (string, error) {
+func (WebSearchTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	query, _ := input["query"].(string)
 	if strings.TrimSpace(query) == "" {
-		return "", fmt.Errorf("web_search: query is required")
+		return agent.ToolResult{}, fmt.Errorf("web_search: query is required")
 	}
 	max := intArg(input, "max_results", WebSearchDefaultMax)
 	if max < 1 {
@@ -171,9 +171,9 @@ func (WebSearchTool) Execute(ctx context.Context, _ string, input map[string]any
 
 	body, err := json.MarshalIndent(response, "", "  ")
 	if err != nil {
-		return "", fmt.Errorf("web_search: marshal: %w", err)
+		return agent.ToolResult{}, fmt.Errorf("web_search: marshal: %w", err)
 	}
-	return string(body), nil
+	return agent.ToolResult{Text: string(body)}, nil
 }
 
 // ───────────────────── paid API backends ─────────────────────

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -63,8 +63,8 @@ func TestWebSearch_BravePreferred(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	var resp WebSearchResponse
-	if err := json.Unmarshal([]byte(out), &resp); err != nil {
-		t.Fatalf("output isn't valid JSON: %v\n%s", err, out)
+	if err := json.Unmarshal([]byte(out.Text), &resp); err != nil {
+		t.Fatalf("output isn't valid JSON: %v\n%s", err, out.Text)
 	}
 	if resp.Provider != "brave" {
 		t.Errorf("Provider = %q, want 'brave'", resp.Provider)
@@ -91,7 +91,7 @@ func TestWebSearch_TavilyWhenBraveAbsent(t *testing.T) {
 
 	out, _ := WebSearchTool{}.Execute(context.Background(), "web_search", map[string]any{"query": "x"})
 	var resp WebSearchResponse
-	_ = json.Unmarshal([]byte(out), &resp)
+	_ = json.Unmarshal([]byte(out.Text), &resp)
 	if resp.Provider != "tavily" || len(resp.Results) != 1 || resp.Results[0].URL != "https://t1" {
 		t.Errorf("unexpected: %+v", resp)
 	}
@@ -113,7 +113,7 @@ func TestWebSearch_SerperWhenOnlySerperSet(t *testing.T) {
 
 	out, _ := WebSearchTool{}.Execute(context.Background(), "web_search", map[string]any{"query": "x"})
 	var resp WebSearchResponse
-	_ = json.Unmarshal([]byte(out), &resp)
+	_ = json.Unmarshal([]byte(out.Text), &resp)
 	if resp.Provider != "serper" || resp.Results[0].URL != "https://s1" {
 		t.Errorf("unexpected: %+v", resp)
 	}
@@ -141,8 +141,8 @@ func TestWebSearch_FallsBackToDDG(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	var resp WebSearchResponse
-	if err := json.Unmarshal([]byte(out), &resp); err != nil {
-		t.Fatalf("decode: %v\n%s", err, out)
+	if err := json.Unmarshal([]byte(out.Text), &resp); err != nil {
+		t.Fatalf("decode: %v\n%s", err, out.Text)
 	}
 	if resp.Provider != "duckduckgo" {
 		t.Errorf("Provider = %q, want 'duckduckgo'", resp.Provider)
@@ -184,7 +184,7 @@ func TestWebSearch_FallsBackToBing_WhenDDGReturnsZero(t *testing.T) {
 
 	out, _ := WebSearchTool{}.Execute(context.Background(), "web_search", map[string]any{"query": "x"})
 	var resp WebSearchResponse
-	_ = json.Unmarshal([]byte(out), &resp)
+	_ = json.Unmarshal([]byte(out.Text), &resp)
 	if resp.Provider != "bing" {
 		t.Errorf("Provider = %q, want 'bing'", resp.Provider)
 	}
@@ -209,9 +209,9 @@ func TestWebSearch_AllBackendsFail(t *testing.T) {
 		t.Fatalf("tool should not return Go error: %v", err)
 	}
 	var resp WebSearchResponse
-	_ = json.Unmarshal([]byte(out), &resp)
+	_ = json.Unmarshal([]byte(out.Text), &resp)
 	if resp.Error == "" {
-		t.Errorf("expected Error field set, got: %s", out)
+		t.Errorf("expected Error field set, got: %s", out.Text)
 	}
 	if resp.Count != 0 {
 		t.Errorf("expected zero results, got %d", resp.Count)
@@ -247,7 +247,7 @@ func TestWebSearch_RespectsMaxResults(t *testing.T) {
 		"max_results": 2,
 	})
 	var resp WebSearchResponse
-	_ = json.Unmarshal([]byte(out), &resp)
+	_ = json.Unmarshal([]byte(out.Text), &resp)
 	if len(resp.Results) != 2 {
 		t.Errorf("want 2 results, got %d", len(resp.Results))
 	}

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -38,36 +38,36 @@ func (WriteFileTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (WriteFileTool) Execute(_ context.Context, _ string, input map[string]any) (string, error) {
+func (WriteFileTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	path, _ := input["path"].(string)
 	if strings.TrimSpace(path) == "" {
-		return "", fmt.Errorf("write_file: path is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("write_file: path is required")
 	}
 	content, ok := input["content"].(string)
 	if !ok {
 		// Distinguish "not provided" from "empty string". JSON null → not a string.
-		return "", fmt.Errorf("write_file: content is required (string)")
+		return agent.ToolResult{Text: ""}, fmt.Errorf("write_file: content is required (string)")
 	}
 	if secret := scanForSecrets(content); secret != "" {
-		return "", fmt.Errorf("write_file: refusing to write content that contains a %s. "+
+		return agent.ToolResult{Text: ""}, fmt.Errorf("write_file: refusing to write content that contains a %s. "+
 			"If this is genuinely intended (e.g. a test fixture), remove the live-credential "+
 			"shape or create the file outside the agent.", secret)
 	}
 	abs, err := resolvePath(path)
 	if err != nil {
-		return "", err
+		return agent.ToolResult{Text: ""}, err
 	}
 
 	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
-		return "", fmt.Errorf("write_file: mkdir parent: %w", err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("write_file: mkdir parent: %w", err)
 	}
 	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
-		return "", fmt.Errorf("write_file: write %q: %w", path, err)
+		return agent.ToolResult{Text: ""}, fmt.Errorf("write_file: write %q: %w", path, err)
 	}
 
 	lineCount := strings.Count(content, "\n")
 	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
 		lineCount++
 	}
-	return fmt.Sprintf("Wrote %d bytes (%d lines) to %s", len(content), lineCount, abs), nil
+	return agent.ToolResult{Text: fmt.Sprintf("Wrote %d bytes (%d lines) to %s", len(content), lineCount, abs)}, nil
 }

--- a/internal/tools/write_file_test.go
+++ b/internal/tools/write_file_test.go
@@ -19,8 +19,8 @@ func TestWriteFile_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, "12 bytes") || !strings.Contains(out, "2 lines") {
-		t.Errorf("status message wrong: %q", out)
+	if !strings.Contains(out.Text, "12 bytes") || !strings.Contains(out.Text, "2 lines") {
+		t.Errorf("status message wrong: %q", out.Text)
 	}
 	if got := readTestFile(t, path); got != "hello\nworld\n" {
 		t.Errorf("file content = %q", got)


### PR DESCRIPTION
## Summary

Replace `ToolExecutor.Execute` string return with `agent.ToolResult`, enabling tools to return rich content blocks (images) alongside text.

## Changes

### Core types
- `agent.ToolResult`: `{Text string, Blocks []ContentBlock}`
- `ContentBlock` gains `Type=="image"` with `ImageData {MIMEType, Data}`
- `dispatchTools`: flattens per-tool block slices into history

### read_file image support
- Detects image extensions: `png`, `jpg`, `jpeg`, `gif`, `webp`, `bmp`, `tiff`, `heic`, `ico`
- Reads raw bytes, returns `ToolResult{Text: description, Blocks: [image block]}`
- Size limit: 5MB (configurable via `ReadFileImageMaxBytes`)
- Image extensions removed from binary-refusal list

### Provider adapters
- **Anthropic**: image block → `{type: "image", source: {type: "base64", media_type, data}}`
- **OpenAI**: image block → `{type: "image_url", image_url: {url: "data:...;base64,..."}}` in content array

### Tool migration
All 20+ tools updated to return `agent.ToolResult{Text: ...}` instead of plain string.

### Tests
- `TestReadFile_ReadsImage` – validates image block creation
- `TestReadFile_ImageTooLarge` – validates 5MB size limit
- `TestSend_ImageBlock_WireFormat` – Anthropic & OpenAI serialization
- All existing tests updated and passing (`go test -race ./...`)

## Backward compatibility
No breaking changes to CLI or public API. The wire-format changes are internal to provider adapters.