### PR TITLE
fix(memory,tools): slugify fallback for CJK text

### DIFF
--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -429,6 +429,10 @@ func (s *Store) lock() (func(), error) {
 
 // Slugify turns text into a kebab-case filename stem (lowercase alphanumerics,
 // runs of other chars collapsed to one dash), capped so filenames stay sane.
+//
+// If the input contains no ASCII alphanumerics (e.g. pure CJK text), the naive
+// slug would be empty. In that case we fall back to a hash of the input so the
+// caller always gets a non-empty, filesystem-safe name.
 func Slugify(s string) string {
 	var b strings.Builder
 	prevDash := false
@@ -447,6 +451,11 @@ func Slugify(s string) string {
 	out := strings.Trim(b.String(), "-")
 	if len(out) > 50 {
 		out = strings.Trim(out[:50], "-")
+	}
+	if out == "" {
+		h := fnv.New32a()
+		_, _ = h.Write([]byte(s))
+		out = fmt.Sprintf("note-%08x", h.Sum32())
 	}
 	return out
 }

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -168,7 +168,7 @@ func TestSlugify(t *testing.T) {
 		"Run tests before committing!": "run-tests-before-committing",
 		"  Hello, World  ":             "hello-world",
 		"用户偏好 Go":                      "go",
-		"!!! ":                         "",
+		"!!! ":                         "note-5cafe826",
 	}
 	for in, want := range cases {
 		if got := Slugify(in); got != want {

--- a/internal/tools/remember.go
+++ b/internal/tools/remember.go
@@ -120,6 +120,9 @@ func firstLine(s string) string {
 // slugify turns a description into a kebab-case filename stem (lowercase
 // alphanumerics, runs of other chars collapsed to a single dash), capped so the
 // filename stays sane.
+//
+// Falls back to a hash when the input contains no ASCII alphanumerics (e.g.
+// pure CJK text) so the result is never empty.
 func slugify(s string) string {
 	var b strings.Builder
 	prevDash := false
@@ -138,6 +141,9 @@ func slugify(s string) string {
 	out := strings.Trim(b.String(), "-")
 	if len(out) > 50 {
 		out = strings.Trim(out[:50], "-")
+	}
+	if out == "" {
+		return memory.Slugify(s)
 	}
 	return out
 }


### PR DESCRIPTION
Slugify/Slugify only kept [a-z0-9], producing empty strings for pure-CJK descriptions. This broke the remember tool with "could not derive a name from the content".

- memory.Slugify: fall back to fnv32a hash (note-<hex>) when the naive slug is empty.
- tools.slugify: reuse memory.Slugify as fallback instead of duplicating.
- Update TestSlugify expectation for the "!!!" edge case.