### PR TITLE
fix(tools): track file reads from terminal tool commands

### DIFF
--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 )
@@ -85,11 +87,17 @@ func (r DefaultRegistry) Execute(ctx context.Context, name string, input map[str
 			// On a successful read OR write, (re)stamp the tracker so the
 			// file is considered "read at its current mtime" — this lets a
 			// write be followed by an edit without a redundant re-read.
-			if err == nil && r.tracker != nil &&
-				(name == "read_file" || name == "write_file" || name == "edit_file") {
-				if path, ok := input["path"].(string); ok {
-					if abs, rerr := resolvePath(path); rerr == nil {
-						r.tracker.RecordRead(abs)
+			if err == nil && r.tracker != nil {
+				switch name {
+				case "read_file", "write_file", "edit_file":
+					if path, ok := input["path"].(string); ok {
+						if abs, rerr := resolvePath(path); rerr == nil {
+							r.tracker.RecordRead(abs)
+						}
+					}
+				case "terminal":
+					if cmd, ok := input["command"].(string); ok {
+						r.recordTerminalReads(cmd)
 					}
 				}
 			}
@@ -97,6 +105,92 @@ func (r DefaultRegistry) Execute(ctx context.Context, name string, input map[str
 		}
 	}
 	return "", fmt.Errorf("unknown tool %q", name)
+}
+
+// recordTerminalReads parses a successful terminal command for common file-
+// reading operations (cat, head, tail, grep, etc.) and records the referenced
+// paths in the read tracker. This closes the gap where `cat file` followed by
+// `write_file file` would wrongly fail with "File has not been read yet".
+//
+// The parser is intentionally lightweight: it tokenises the command string,
+// skips flags and shell metacharacters, and treats any remaining token that
+// resolves to an existing file as a read. It does NOT understand subshells,
+// variable expansion, or complex pipelines — those still require an explicit
+// read_file if the model wants to edit afterwards.
+func (r DefaultRegistry) recordTerminalReads(command string) {
+	// Commands that are known to read files as positional arguments.
+	readCmds := map[string]bool{
+		"cat": true, "head": true, "tail": true, "less": true, "more": true,
+		"grep": true, "rg": true, "awk": true, "sed": true, "wc": true,
+		"sort": true, "uniq": true, "diff": true, "comm": true, "cmp": true,
+		"md5sum": true, "sha256sum": true, "shasum": true, "file": true,
+		"stat": true, "ls": true, "find": true, "readlink": true,
+	}
+
+	tokens := tokenizeCommand(command)
+	if len(tokens) == 0 {
+		return
+	}
+	if !readCmds[tokens[0]] {
+		return
+	}
+
+	for _, tok := range tokens[1:] {
+		if strings.HasPrefix(tok, "-") || strings.HasPrefix(tok, ">") || strings.HasPrefix(tok, "<") {
+			continue // skip flags and redirection operators
+		}
+		if strings.ContainsAny(tok, "|;&$()`") {
+			continue // skip tokens with shell metacharacters
+		}
+		// Try to resolve as a path.  If the file exists, record it.
+		abs, err := resolvePath(tok)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(abs); err == nil {
+			r.tracker.RecordRead(abs)
+		}
+	}
+}
+
+// tokenizeCommand splits a shell command line into whitespace-separated tokens,
+// respecting single and double quotes (no nesting, no escape sequences).
+func tokenizeCommand(s string) []string {
+	var tokens []string
+	var cur strings.Builder
+	var inSingle, inDouble bool
+
+	for _, r := range s {
+		switch r {
+		case '\'':
+			if inDouble {
+				cur.WriteRune(r)
+			} else {
+				inSingle = !inSingle
+			}
+		case '"':
+			if inSingle {
+				cur.WriteRune(r)
+			} else {
+				inDouble = !inDouble
+			}
+		case ' ', '\t':
+			if inSingle || inDouble {
+				cur.WriteRune(r)
+			} else {
+				if cur.Len() > 0 {
+					tokens = append(tokens, cur.String())
+					cur.Reset()
+				}
+			}
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	if cur.Len() > 0 {
+		tokens = append(tokens, cur.String())
+	}
+	return tokens
 }
 
 // DefaultTools returns the slice of ToolDefinitions sent to the LLM when


### PR DESCRIPTION
The read-before-write tracker only recorded reads from the read_file tool. This meant that `cat file` (terminal) followed by `write_file file` would wrongly fail with "File has not been read yet".

- Add `recordTerminalReads` + `tokenizeCommand` to parse common file-reading commands (cat, head, tail, grep, etc.) and record their path arguments.
- Wire it into `DefaultRegistry.Execute` post-execution for successful terminal calls.
- The parser is lightweight: tokenises, skips flags/metacharacters, and only records paths that exist on disk. Complex pipelines still need explicit read_file.