### PR TITLE
fix(config): read permission_mode from config file

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -106,7 +106,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	noTUI := fs.Bool("no-tui", false, "Disable the interactive TUI on a terminal; use the plain line-based REPL (also OCTO_TUI=0)")
 	quietFlag := fs.Bool("quiet", false, "Strip all status chrome (no spinner, no banner, no cache line). Also OCTO_VERBOSITY=quiet.")
 	verboseFlag := fs.Bool("verbose", false, "Print extra context (provider/model/endpoint, always-on cache line). Also OCTO_VERBOSITY=verbose.")
-	permMode := fs.String("permission-mode", "interactive", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask) | auto (allow on ask)")
+	permMode := fs.String("permission-mode", "", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask) | auto (allow on ask). Empty = use `octo config` value, else interactive.")
 	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = auto: 100 interactive, unlimited unattended/--prompt-file)")
 	maxCost := fs.Float64("max-cost", 0, "Stop the session once estimated cost (USD) reaches this; 0 = unlimited")
 	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (~75% of the model's context window), <0 = disabled")
@@ -121,14 +121,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	// Validate --permission-mode up front. Fail closed on a typo rather than
-	// silently falling back to the more-permissive interactive mode — a user
-	// who asked for "strict" and got "interactive" by typo is a security
-	// regression, not a convenience.
-	if *permMode != string(permission.ModeInteractive) && *permMode != string(permission.ModeStrict) && *permMode != string(permission.ModeAutoApprove) {
-		fmt.Fprintf(stderr, "octo chat: invalid --permission-mode %q (want 'interactive', 'strict', or 'auto')\n", *permMode)
-		return 2
-	}
+
 
 	// --list-sessions: print and exit, no provider needed.
 	if *listSessions {
@@ -197,6 +190,22 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "Run `octo config` to rewrite ~/.octo/config.json.")
 		return 1
 	}
+
+	// Resolve permission mode: explicit flag > config file > interactive default.
+	resolvedPermMode := *permMode
+	if resolvedPermMode == "" {
+		resolvedPermMode = cfg.PermissionMode
+	}
+	if resolvedPermMode == "" {
+		resolvedPermMode = string(permission.ModeInteractive)
+	}
+	// Validate up front. Fail closed on a typo rather than silently falling
+	// back to the more-permissive interactive mode.
+	if resolvedPermMode != string(permission.ModeInteractive) && resolvedPermMode != string(permission.ModeStrict) && resolvedPermMode != string(permission.ModeAutoApprove) {
+		fmt.Fprintf(stderr, "octo chat: invalid --permission-mode %q (want 'interactive', 'strict', or 'auto')\n", resolvedPermMode)
+		return 2
+	}
+
 	provName, resolvedModel, ok := resolveProviderModel(*providerName, *model, cfg)
 	if !ok {
 		fmt.Fprintf(stderr, "octo chat: unknown provider %q (use 'anthropic' or 'openai')\n", provName)
@@ -466,7 +475,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 			// Build the permission engine that gates every tool call.
 			cwd, _ := os.Getwd()
-			engine, err := permission.New(permissionConfigPath(), cwd, resolvePermissionMode(*permMode))
+			engine, err := permission.New(permissionConfigPath(), cwd, resolvePermissionMode(resolvedPermMode))
 			if err != nil {
 				fmt.Fprintf(stderr, "octo chat: permission config: %v\n", err)
 				return 1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,9 +21,10 @@ import (
 // missing file (or a missing field) leaves the zero value, and the caller
 // substitutes its built-in default.
 type Config struct {
-	Provider string `json:"provider,omitempty"`
-	Model    string `json:"model,omitempty"`
-	BaseURL  string `json:"base_url,omitempty"`
+	Provider       string `json:"provider,omitempty"`
+	Model          string `json:"model,omitempty"`
+	BaseURL        string `json:"base_url,omitempty"`
+	PermissionMode string `json:"permission_mode,omitempty"`
 	// APIKey, when set, is a plaintext fallback used only if the provider's
 	// env var is empty. Opt-in via `octo config` and stored mode 0600. Prefer
 	// the env var.


### PR DESCRIPTION
The Config struct was missing the PermissionMode field, so `permission_mode` in ~/.octo/config.json was silently ignored. The --permission-mode flag always defaulted to 'interactive', overriding any stored config.

- Add PermissionMode to config.Config with json tag permission_mode.
- Change --permission-mode flag default from 'interactive' to '' (empty means 'not set').
- In chat.go, resolve precedence: explicit flag > config file > 'interactive' fallback.
- Move validation after config.Load so we can validate the resolved value, not just the raw flag.