### PR TITLE
feat(tui): Shift+Tab cycles permission mode

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/tools"
 	"github.com/Leihb/octo-agent/internal/tui"
 	tea "github.com/charmbracelet/bubbletea"
@@ -67,6 +68,23 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			dropped := m.queue[n-1].text
 			m.queue = m.queue[:n-1]
 			return m, tea.Println(queueStyle.Render("✕ unqueued: " + dropped))
+		}
+		return m, nil
+
+	case tea.KeyShiftTab:
+		// Cycle permission mode: interactive → strict → auto → interactive.
+		if m.cfg.permEngine != nil {
+			var next permission.Mode
+			switch m.cfg.permEngine.GetMode() {
+			case permission.ModeInteractive:
+				next = permission.ModeStrict
+			case permission.ModeStrict:
+				next = permission.ModeAutoApprove
+			default:
+				next = permission.ModeInteractive
+			}
+			m.cfg.permEngine.SetMode(next)
+			return m, tea.Println(noticeStyle.Render("Permission mode: " + string(next)))
 		}
 		return m, nil
 

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -187,6 +187,9 @@ func (e *Engine) Remember(toolName string, input map[string]any, decision Decisi
 // on it, e.g. to decide whether to prompt the user).
 func (e *Engine) GetMode() Mode { return e.mode }
 
+// SetMode changes the engine's mode at runtime (e.g. TUI shortcut).
+func (e *Engine) SetMode(mode Mode) { e.mode = mode }
+
 // DenialReason returns a human-readable explanation for why a tool call
 // was denied. Useful for surfacing to the LLM so it knows the failure
 // was a policy denial, not a tool malfunction.


### PR DESCRIPTION
Add a runtime shortcut to switch permission mode without restarting: Shift+Tab cycles interactive → strict → auto → interactive.

- permission.Engine: add SetMode so the mode can be changed at runtime.
- tuirepl_view.go: handle tea.KeyShiftTab in handleKey, cycle the mode, and print a notice so the user sees the change.