### PR TITLE
fix(tui): eagerly probe terminal background before bubbletea owns stdin

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/tools"
+	"github.com/Leihb/octo-agent/internal/tui"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -33,6 +34,11 @@ func runTUI(cfg replConfig) int {
 	p := tea.NewProgram(m)
 	sink := &tuiSink{prog: p}
 	m.sink = sink
+
+	// Eagerly probe terminal background colour so lipgloss caches the result
+	// before bubbletea owns stdin. Without this, the OSC 11 response can leak
+	// into the textinput as apparent user input.
+	_ = tui.IsDark()
 
 	// Gate + asker raise their prompts through the same sink, so they render
 	// as modals on this event loop instead of reading stdin (which bubbletea


### PR DESCRIPTION
lipgloss.HasDarkBackground() queries the terminal via OSC 11. If the probe happens after bubbletea starts reading stdin, the terminal's response sequence leaks into the textinput as apparent user input (e.g. "11;rgb:1e1e/1e1e/2e2e\").

Call tui.IsDark() early in runTUI, before p.Run(), so the result is cached and diff card rendering no longer triggers a late probe.