### PR TITLE
fix(tui): fall through to normal turn for unrecognised slash commands

### DIFF
--- a/cmd/octo/tuirepl_slash_test.go
+++ b/cmd/octo/tuirepl_slash_test.go
@@ -35,14 +35,16 @@ func TestTUI_SlashInfoCommandsDontStartTurn(t *testing.T) {
 	}
 }
 
-func TestTUI_SlashUnknownDoesNotStartTurn(t *testing.T) {
+func TestTUI_SlashUnknownFallsThroughToTurn(t *testing.T) {
+	// Unrecognised /-prefixed input is treated as ordinary user text (paths,
+	// regexes, etc.) matching the plain REPL behaviour.
 	m := newTestModel()
 	_, cmd := m.dispatchSlash("/bogus")
-	if m.turnRunning {
-		t.Error("unknown command must not start a turn")
+	if !m.turnRunning {
+		t.Error("unknown slash should start a turn like normal text")
 	}
 	if cmd == nil {
-		t.Error("unknown command should return a notice Cmd")
+		t.Error("expected a start-turn Cmd")
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -151,11 +151,10 @@ func (m *tuiModel) submit(alt bool) (tea.Model, tea.Cmd) {
 	return m, tea.Println(queueStyle.Render("→ steering: " + text))
 }
 
-// dispatchSlash handles a leading-"/" line when the session is idle. It mirrors
-// the command set the plain REPL used to own. Commands fall into three shapes:
-// fall-through (/init, /<skill>) expand to a prompt and run as a turn;
-// info commands render synchronously into the scrollback; /goal drives the
-// task-DAG flow (see tuirepl_goal.go).
+// dispatchSlash handles a leading-"/" line when the session is idle.
+// Recognised commands are dispatched immediately; anything else falls through
+// to startTurn as ordinary user text (paths, regexes, etc.) matching the plain
+// REPL behaviour.
 func (m *tuiModel) dispatchSlash(text string) (tea.Model, tea.Cmd) {
 	cfg := m.cfg
 
@@ -208,7 +207,9 @@ func (m *tuiModel) dispatchSlash(text string) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Println(strings.TrimRight(b.String(), "\n"))
 	default:
-		return m, tea.Println(noticeStyle.Render(fmt.Sprintf("Unknown command %q. Type /help for a list.", cmd)))
+		// Not a recognised command — treat it as ordinary user text so
+		// paths, regexes, and other /-prefixed messages reach the model.
+		return m, m.startTurn(text)
 	}
 }
 


### PR DESCRIPTION
Previously any /-prefixed input that wasn't a known command produced an "Unknown command" error. This broke legitimate user text like file paths (/usr/bin) or regexes (/pattern/).

Now the TUI matches the plain REPL behaviour: recognised commands are dispatched, everything else falls through to startTurn as ordinary user message text.