### PR TITLE
fix(tui): also eagerly probe termenv background before bubbletea owns stdin

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/muesli/termenv"
 )
 
 // runTUI is the interactive bubbletea REPL: the TTY counterpart to runREPL's
@@ -35,10 +36,12 @@ func runTUI(cfg replConfig) int {
 	sink := &tuiSink{prog: p}
 	m.sink = sink
 
-	// Eagerly probe terminal background colour so lipgloss caches the result
-	// before bubbletea owns stdin. Without this, the OSC 11 response can leak
-	// into the textinput as apparent user input.
+	// Eagerly probe terminal background colour so lipgloss / termenv cache the
+	// result before bubbletea owns stdin. Both libraries send OSC 11 queries;
+	// without eager probing the terminal's response leaks into the textinput as
+	// apparent user input (e.g. "11;rgb:1e1e/1e1e/2e2e\\").
 	_ = tui.IsDark()
+	_ = termenv.HasDarkBackground()
 
 	// Gate + asker raise their prompts through the same sink, so they render
 	// as modals on this event loop instead of reading stdin (which bubbletea


### PR DESCRIPTION
lipgloss and termenv each maintain their own Output instance with separate sync.Once caches for background-color probing. The previous fix only called tui.IsDark() (lipgloss), but glamour.WithAutoStyle() uses termenv.HasDarkBackground() via its own global Output — so the OSC 11 query still leaked into bubbletea's stdin on the first markdown render.

Call both probes early in runTUI, before p.Run(), so both caches are warmed and no late query can interleave with user input.