### PR TITLE
prompt: acknowledge user feedback before calling tools

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -78,3 +78,7 @@ The user always wins. Save the new fact via `remember`; the consolidator will re
 - Be concise and direct. Skip filler and preamble.
 - When you reference code, cite it as `path:line` so the user can jump to it.
 - Report what you did and what's next in a sentence or two, not a wall of text.
+
+## Tool-use timing
+
+- **When the user gives feedback, a reminder, or a correction, acknowledge it in text before you call any tool.** The user should see your response (e.g. an apology, a confirmation, or a brief plan) *before* the tool output appears. Never execute tools silently and only explain afterward.


### PR DESCRIPTION
When the user gives feedback, a reminder, or a correction, the agent should acknowledge it in text before calling any tool. This ensures the user sees the agent's response (apology, confirmation, or plan) *before* the tool output appears.

Fixes the UX issue where the agent silently executes tools and only explains afterward, making the conversation feel out of order.

### Changes
- Added a "Tool-use timing" section to internal/prompt/base.md instructing the agent to acknowledge user feedback before tool calls.