### PR TITLE
prompt: replace "you>" with ">"

### DIFF
--- a/cmd/octo/lineread.go
+++ b/cmd/octo/lineread.go
@@ -59,7 +59,7 @@ type lineReader interface {
 
 // scannerLineReader is the non-tty fallback. Tests rely on this — they pass
 // stdin as a strings.Reader and expect deterministic stdout including the
-// "you> " prompts.
+// "> " prompts.
 type scannerLineReader struct {
 	mu  sync.Mutex
 	in  *bufio.Scanner
@@ -123,7 +123,7 @@ func newReadlineReader(historyFile string) (*readlineLineReader, error) {
 		}
 	}
 	rl, err := readline.NewEx(&readline.Config{
-		Prompt:                 "you> ",
+		Prompt:                 "> ",
 		HistoryFile:            historyFile,
 		HistoryLimit:           5000,
 		HistorySearchFold:      true,

--- a/cmd/octo/lineread_test.go
+++ b/cmd/octo/lineread_test.go
@@ -10,12 +10,12 @@ func TestScannerLineReader_PrintsPrompt(t *testing.T) {
 	var out bytes.Buffer
 	r := newScannerLineReader(strings.NewReader("hi\n"), &out)
 
-	line, ok := r.ReadLine("you> ")
+	line, ok := r.ReadLine("> ")
 	if !ok || line != "hi" {
 		t.Fatalf("ReadLine = (%q, %v); want (\"hi\", true)", line, ok)
 	}
-	if got := out.String(); got != "you> " {
-		t.Errorf("prompt = %q; want %q", got, "you> ")
+	if got := out.String(); got != "> " {
+		t.Errorf("prompt = %q; want %q", got, "> ")
 	}
 }
 
@@ -48,12 +48,12 @@ func TestSeededLineReader_SeedThenDelegates(t *testing.T) {
 	inner := newScannerLineReader(strings.NewReader("next\n"), &out)
 	r := &seededLineReader{seed: seed, inner: inner}
 
-	got, ok := r.ReadLine("you> ")
+	got, ok := r.ReadLine("> ")
 	if !ok || got != seed {
 		t.Fatalf("first ReadLine = (%q, %v); want the full multi-line seed", got, ok)
 	}
 	// Second call delegates to the inner scanner.
-	got, ok = r.ReadLine("you> ")
+	got, ok = r.ReadLine("> ")
 	if !ok || got != "next" {
 		t.Fatalf("second ReadLine = (%q, %v); want (\"next\", true) from inner", got, ok)
 	}
@@ -67,11 +67,11 @@ func TestReadPromptLine_SingleLine(t *testing.T) {
 	var out bytes.Buffer
 	r := newScannerLineReader(strings.NewReader("hello\n"), &out)
 
-	got, ok := readPromptLine(r, "you> ", "... ")
+	got, ok := readPromptLine(r, "> ", "... ")
 	if !ok || got != "hello" {
 		t.Errorf("got = (%q, %v); want (\"hello\", true)", got, ok)
 	}
-	if !strings.Contains(out.String(), "you> ") {
+	if !strings.Contains(out.String(), "> ") {
 		t.Errorf("expected primary prompt; got %q", out.String())
 	}
 	if strings.Contains(out.String(), "... ") {
@@ -85,7 +85,7 @@ func TestReadPromptLine_BackslashContinuation(t *testing.T) {
 	in := "first\\\nsecond\\\nthird\n"
 	r := newScannerLineReader(strings.NewReader(in), &out)
 
-	got, ok := readPromptLine(r, "you> ", "... ")
+	got, ok := readPromptLine(r, "> ", "... ")
 	if !ok {
 		t.Fatal("ReadPromptLine ok=false")
 	}
@@ -94,7 +94,7 @@ func TestReadPromptLine_BackslashContinuation(t *testing.T) {
 		t.Errorf("got = %q; want %q", got, want)
 	}
 	prompts := out.String()
-	if !strings.Contains(prompts, "you> ") {
+	if !strings.Contains(prompts, "> ") {
 		t.Errorf("missing primary prompt; got %q", prompts)
 	}
 	if strings.Count(prompts, "... ") != 2 {

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -263,7 +263,7 @@ func (m *tuiModel) startTurnEcho(line, echo string) tea.Cmd {
 	// animation ticker for the spinner + elapsed clock.
 	var echoCmd tea.Cmd
 	if echo != "" && !strings.HasPrefix(echo, "<system-reminder>") {
-		echoCmd = tea.Println(promptStyle.Render("you> ") + echo)
+		echoCmd = tea.Println(promptStyle.Render("> ") + echo)
 	}
 	return tea.Batch(echoCmd, tickCmd())
 }

--- a/cmd/octo/tuirepl_goal.go
+++ b/cmd/octo/tuirepl_goal.go
@@ -105,7 +105,7 @@ func (m *tuiModel) startGoalPlan(goal string) tea.Cmd {
 		prog.Send(goalPlannedMsg{task: task, err: err})
 	}()
 	return tea.Batch(
-		tea.Println(promptStyle.Render("you> ")+"/goal "+goal),
+		tea.Println(promptStyle.Render("> ")+"/goal "+goal),
 		tea.Println(noticeStyle.Render("Planning…")),
 		tickCmd(),
 	)

--- a/cmd/octo/tuirepl_p2_test.go
+++ b/cmd/octo/tuirepl_p2_test.go
@@ -32,7 +32,7 @@ func TestRenderInputBox_BorderGating(t *testing.T) {
 	if got := m.renderInputBox(); strings.ContainsAny(got, "╭╮╰╯") {
 		t.Errorf("no border expected at width 0; got:\n%s", got)
 	}
-	if !strings.Contains(m.renderInputBox(), "you>") {
+	if !strings.Contains(m.renderInputBox(), "> ") {
 		t.Error("input box should always show the prompt")
 	}
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -414,7 +414,7 @@ func (m *tuiModel) spinnerLine(label string, since time.Time) string {
 // sized to the terminal width. Falls back to a borderless line before the
 // first WindowSizeMsg (width 0) or on a very narrow terminal.
 func (m *tuiModel) renderInputBox() string {
-	content := promptStyle.Render("you> ") + m.ti.View()
+	content := promptStyle.Render("> ") + m.ti.View()
 	if m.width <= 6 {
 		return content
 	}


### PR DESCRIPTION
Replaces the "you>" prompt with a simple ">" across the TUI and plain REPL.