### PR TITLE
tui: polish visual design with banner, styled prompt, and status bar

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -194,6 +194,9 @@ type tuiModel struct {
 	// tools suppress their started line, so without this they'd show nothing
 	// until completion.)
 	running *runningTool
+
+	// showBanner is true until the first user input dismisses the welcome banner.
+	showBanner bool
 }
 
 // runningTool is the live indicator state for an in-flight card tool.
@@ -217,13 +220,13 @@ type modalState struct {
 func newTUIModel(cfg replConfig) *tuiModel {
 	ti := textinput.New()
 	ti.Prompt = ""
-	ti.Placeholder = ""
+	ti.Placeholder = "Ask anything…"
 	ti.Focus()
 	// Disable bubbles' built-in up/down (suggestion navigation) so we can use
 	// them for input-history recall instead.
 	ti.KeyMap.NextSuggestion = key.Binding{}
 	ti.KeyMap.PrevSuggestion = key.Binding{}
-	return &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ti: ti, inputHistoryIdx: -1}
+	return &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ti: ti, inputHistoryIdx: -1, showBanner: true}
 }
 
 func (m *tuiModel) Init() tea.Cmd { return textinput.Blink }
@@ -263,7 +266,7 @@ func (m *tuiModel) startTurnEcho(line, echo string) tea.Cmd {
 	// animation ticker for the spinner + elapsed clock.
 	var echoCmd tea.Cmd
 	if echo != "" && !strings.HasPrefix(echo, "<system-reminder>") {
-		echoCmd = tea.Println(promptStyle.Render("> ") + echo)
+		echoCmd = tea.Println(userEchoStyle.Render("❯ ") + echo)
 	}
 	return tea.Batch(echoCmd, tickCmd())
 }

--- a/cmd/octo/tuirepl_p2_test.go
+++ b/cmd/octo/tuirepl_p2_test.go
@@ -32,7 +32,7 @@ func TestRenderInputBox_BorderGating(t *testing.T) {
 	if got := m.renderInputBox(); strings.ContainsAny(got, "╭╮╰╯") {
 		t.Errorf("no border expected at width 0; got:\n%s", got)
 	}
-	if !strings.Contains(m.renderInputBox(), "> ") {
+	if !strings.Contains(m.renderInputBox(), "❯ ") {
 		t.Error("input box should always show the prompt")
 	}
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -16,18 +16,19 @@ import (
 )
 
 var (
-	promptStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)
-	noticeStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	errorStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-	toolErrStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-	queueStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
-	modalStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("13")).Bold(true)
-	hintStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Italic(true)
-	statusStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	promptStyle   = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	noticeStyle   = lipgloss.NewStyle().Foreground(tui.ColMuted)
+	errorStyle    = lipgloss.NewStyle().Foreground(tui.ColDanger)
+	toolErrStyle  = lipgloss.NewStyle().Foreground(tui.ColDanger)
+	queueStyle    = lipgloss.NewStyle().Foreground(tui.ColAccent)
+	modalStyle    = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	hintStyle     = lipgloss.NewStyle().Foreground(tui.ColDimmer).Italic(true)
+	statusStyle   = lipgloss.NewStyle().Foreground(tui.ColMuted)
 	inputBoxStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(tui.ColBorder).
 			Padding(0, 1)
+	userEchoStyle = lipgloss.NewStyle().Foreground(tui.ColUserMsg).Bold(true)
 )
 
 // handleKey routes a keypress by context: a modal grabs all keys; otherwise the
@@ -125,6 +126,7 @@ func (m *tuiModel) submit(alt bool) (tea.Model, tea.Cmd) {
 	if text == "" {
 		return m, nil
 	}
+	m.showBanner = false // dismiss welcome banner on first input
 	m.ti.Reset()
 	m.inputHistoryIdx = -1
 	// Save to history for ↑/↓ recall (dedup consecutive identical lines).
@@ -343,6 +345,12 @@ func (m *tuiModel) View() string {
 
 	var b strings.Builder
 
+	// Welcome banner shown on first launch until the user starts typing.
+	if m.showBanner {
+		b.WriteString(tui.Banner("", m.a.Model, m.cwd, m.width))
+		b.WriteByte('\n')
+	}
+
 	// Live partial assistant line (committed lines already scrolled up).
 	if p := m.partial.String(); p != "" {
 		b.WriteString(p)
@@ -414,7 +422,7 @@ func (m *tuiModel) spinnerLine(label string, since time.Time) string {
 // sized to the terminal width. Falls back to a borderless line before the
 // first WindowSizeMsg (width 0) or on a very narrow terminal.
 func (m *tuiModel) renderInputBox() string {
-	content := promptStyle.Render("> ") + m.ti.View()
+	content := promptStyle.Render("❯ ") + m.ti.View()
 	if m.width <= 6 {
 		return content
 	}
@@ -424,21 +432,22 @@ func (m *tuiModel) renderInputBox() string {
 // renderStatusBar renders the model / cwd / context% / cost / permission /
 // elapsed segments, with the contextual key hint on a dim line below.
 func (m *tuiModel) renderStatusBar() string {
-	segs := []string{m.a.Model}
+	var segs [][2]string
+	segs = append(segs, [2]string{"model", m.a.Model})
 	if m.cwd != "" {
-		segs = append(segs, m.cwd)
+		segs = append(segs, [2]string{"cwd", m.cwd})
 	}
 	if used, window := m.a.ContextUsage(); window > 0 && used > 0 {
-		segs = append(segs, fmt.Sprintf("ctx %d%%", used*100/window))
+		segs = append(segs, [2]string{"ctx", fmt.Sprintf("%d%%", used*100/window)})
 	}
 	if c := m.a.SessionCostUSD(); c > 0 {
-		segs = append(segs, fmt.Sprintf("$%.4f", c))
+		segs = append(segs, [2]string{"cost", fmt.Sprintf("$%.4f", c)})
 	}
 	if m.cfg.permEngine != nil {
-		segs = append(segs, string(m.cfg.permEngine.GetMode()))
+		segs = append(segs, [2]string{"perm", string(m.cfg.permEngine.GetMode())})
 	}
 	if m.turnRunning && !m.turnStart.IsZero() {
-		segs = append(segs, time.Since(m.turnStart).Round(time.Second).String())
+		segs = append(segs, [2]string{"elapsed", time.Since(m.turnStart).Round(time.Second).String()})
 	}
 
 	hint := "Enter send · /exit quit · Ctrl+D quit"
@@ -448,7 +457,7 @@ func (m *tuiModel) renderStatusBar() string {
 	if len(m.queue) > 0 {
 		hint += " · Ctrl+X unqueue"
 	}
-	return statusStyle.Render(strings.Join(segs, " · ")) + "\n" + hintStyle.Render(hint)
+	return tui.StatusBar(segs, hint, m.width)
 }
 
 // workingDir returns the current directory, or "" if it can't be determined.

--- a/commit-msg.txt
+++ b/commit-msg.txt
@@ -1,0 +1,12 @@
+tui: polish visual design with banner, styled prompt, and status bar
+
+- Add welcome banner (◆ octo chat) shown on startup, dismissed on first input
+- Replace plain "> " prompt with purple "❯ " using brand colour
+- Add input placeholder "Ask anything…"
+- Style user message echoes with blue tint (ColUserMsg)
+- Redesign status bar with top separator line and styled segments:
+  - model: muted purple bold
+  - cost: green accent
+  - elapsed: muted
+- Add new brand colours to theme: ColBrand, ColBrandDim, ColUserMsg, ColAssistant
+- Add Banner() and StatusBar() helpers to internal/tui with tests

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,6 +1,10 @@
 package tui
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
 
 // Palette — adaptive so cards, panels, and chrome read on both light and dark
 // terminals. Values follow GitHub's light/dark themes; lipgloss resolves the
@@ -12,6 +16,12 @@ var (
 	ColDim    = lipgloss.AdaptiveColor{Light: "#6E7781", Dark: "#6E7681"} // gutters, line numbers
 	ColDimmer = lipgloss.AdaptiveColor{Light: "#AFB8C1", Dark: "#484F58"} // dimmest (unchanged line nos)
 	ColBorder = lipgloss.AdaptiveColor{Light: "#D0D7DE", Dark: "#30363D"} // panel / input-box border
+
+	// Brand colours for the TUI chrome (banner, prompt, status bar).
+	ColBrand     = lipgloss.AdaptiveColor{Light: "#6F42C1", Dark: "#A371F7"} // purple — octo brand
+	ColBrandDim  = lipgloss.AdaptiveColor{Light: "#B4A7D6", Dark: "#6E5494"} // muted purple
+	ColUserMsg   = lipgloss.AdaptiveColor{Light: "#0969DA", Dark: "#58A6FF"} // blue — user messages
+	ColAssistant = lipgloss.AdaptiveColor{Light: "#1A7F37", Dark: "#3FB950"} // green — assistant
 )
 
 // IsDark reports whether the terminal has a dark background. The raw-ANSI diff
@@ -41,4 +51,89 @@ func Panel(title, body string) string {
 // — for content that supplies its own heading (e.g. a modal prompt).
 func Box(content string) string {
 	return panelBorder.Render(content)
+}
+
+// ── Banner ─────────────────────────────────────────────────────────────────
+
+var (
+	bannerStyle = lipgloss.NewStyle().
+			Foreground(ColBrand).
+			Bold(true)
+	bannerSubStyle = lipgloss.NewStyle().
+			Foreground(ColMuted)
+	bannerSepStyle = lipgloss.NewStyle().
+			Foreground(ColBorder)
+)
+
+// Banner renders the octo chat welcome header. Width caps the separator line.
+func Banner(version, model, cwd string, width int) string {
+	if width < 20 {
+		width = 20
+	}
+	var b strings.Builder
+	b.WriteString(bannerStyle.Render("◆ octo chat"))
+	if version != "" {
+		b.WriteString(bannerSubStyle.Render("  " + version))
+	}
+	b.WriteByte('\n')
+
+	info := model
+	if cwd != "" {
+		if info != "" {
+			info += " · "
+		}
+		info += cwd
+	}
+	if info != "" {
+		b.WriteString(bannerSubStyle.Render(info))
+		b.WriteByte('\n')
+	}
+
+	sep := strings.Repeat("─", width)
+	b.WriteString(bannerSepStyle.Render(sep))
+	return b.String()
+}
+
+// ── Status bar ─────────────────────────────────────────────────────────────
+
+var (
+	statusSegStyle   = lipgloss.NewStyle().Foreground(ColMuted)
+	statusHintStyle  = lipgloss.NewStyle().Foreground(ColDimmer).Italic(true)
+	statusBarStyle   = lipgloss.NewStyle().Foreground(ColBorder)
+	statusModelStyle = lipgloss.NewStyle().Foreground(ColBrandDim).Bold(true)
+	statusCostStyle  = lipgloss.NewStyle().Foreground(ColAccent)
+	statusTimeStyle  = lipgloss.NewStyle().Foreground(ColMuted)
+)
+
+// StatusBar renders the bottom status line with styled segments.
+// Each segment is a [label, value] pair; the hint is shown on a second line.
+func StatusBar(segments [][2]string, hint string, width int) string {
+	var b strings.Builder
+	if width > 3 {
+		b.WriteString(statusBarStyle.Render(strings.Repeat("─", width)))
+		b.WriteByte('\n')
+	}
+	for i, seg := range segments {
+		if i > 0 {
+			b.WriteString(statusSegStyle.Render(" · "))
+		}
+		label, value := seg[0], seg[1]
+		var rendered string
+		switch label {
+		case "model":
+			rendered = statusModelStyle.Render(value)
+		case "cost":
+			rendered = statusCostStyle.Render(value)
+		case "elapsed":
+			rendered = statusTimeStyle.Render(value)
+		default:
+			rendered = statusSegStyle.Render(value)
+		}
+		b.WriteString(rendered)
+	}
+	if hint != "" {
+		b.WriteByte('\n')
+		b.WriteString(statusHintStyle.Render(hint))
+	}
+	return b.String()
 }

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -44,3 +44,36 @@ func TestChromaStyle_LightDark(t *testing.T) {
 		t.Errorf("chromaStyle: dark=%q light=%q", chromaStyle(true), chromaStyle(false))
 	}
 }
+
+func TestBanner_ContainsTitleAndInfo(t *testing.T) {
+	out := Banner("v1.0", "claude", "~/proj", 40)
+	for _, want := range []string{"octo chat", "claude", "~/proj", "──"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Banner missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestBanner_MinWidth(t *testing.T) {
+	out := Banner("", "", "", 5)
+	if !strings.Contains(out, "octo chat") {
+		t.Errorf("Banner should still render at tiny width; got:\n%s", out)
+	}
+}
+
+func TestStatusBar_SegmentsAndHint(t *testing.T) {
+	segs := [][2]string{{"model", "gpt-4"}, {"cost", "$0.01"}}
+	out := StatusBar(segs, "Enter send", 30)
+	for _, want := range []string{"gpt-4", "$0.01", "Enter send", "──"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("StatusBar missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestStatusBar_ZeroWidth(t *testing.T) {
+	out := StatusBar(nil, "hint", 0)
+	if !strings.Contains(out, "hint") {
+		t.Errorf("StatusBar should still render hint at width 0; got:\n%s", out)
+	}
+}


### PR DESCRIPTION
Improve the octo chat TUI appearance with better visual hierarchy and brand styling.

## Changes

- **Welcome banner** — ◆ octo chat header shown on startup with model and cwd info, dismissed on first input
- **Styled prompt** — Purple ❯ replaces plain >, with "Ask anything…" placeholder
- **User message styling** — Blue-tinted echo for user messages in scrollback
- **Redesigned status bar** — Top separator line (─) with styled segments:
  - model: muted purple bold
  - cost: green accent  
  - elapsed: muted grey
- **New theme colours** — ColBrand, ColBrandDim, ColUserMsg, ColAssistant in internal/tui
- **New helpers** — Banner() and StatusBar() with tests

## Screenshots

Before: plain > prompt, flat grey status bar, no welcome header
After: branded prompt with border, separator-line status bar, welcome banner

All existing tests pass.