### PR TITLE
fix(agent): prevent empty assistant messages that Anthropic rejects

### DIFF
--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -36,7 +36,12 @@ func NewUserMessage(content string) Message {
 }
 
 // NewAssistantMessage constructs a Message with RoleAssistant.
+// If content is empty, it falls back to a non-empty placeholder so the
+// message is valid for providers (Anthropic rejects empty assistant content).
 func NewAssistantMessage(content string) Message {
+	if content == "" {
+		content = "[no content]"
+	}
 	return Message{Role: RoleAssistant, Content: content}
 }
 


### PR DESCRIPTION
Anthropic returns HTTP 400 when an assistant message has empty content. NewAssistantMessage now falls back to [no content] when content is empty, covering all append sites (Turn, TurnStream, runLoop).