### PR TITLE
fix(tui): stop glamour WithAutoStyle from leaking OSC 11 response into input

### DIFF
--- a/cmd/octo/markdown.go
+++ b/cmd/octo/markdown.go
@@ -12,6 +12,7 @@ import (
 // formatting glitch.
 type markdownRenderer struct {
 	width int
+	style string // "dark" or "light"; empty defaults to dark
 	r     *glamour.TermRenderer
 }
 
@@ -26,7 +27,11 @@ func (m *markdownRenderer) render(src string, width int) string {
 		w = 80
 	}
 	if m.r == nil || m.width != w {
-		r, err := glamour.NewTermRenderer(glamour.WithAutoStyle(), glamour.WithWordWrap(w))
+		style := m.style
+		if style == "" {
+			style = "dark"
+		}
+		r, err := glamour.NewTermRenderer(glamour.WithStandardStyle(style), glamour.WithWordWrap(w))
 		if err != nil {
 			return strings.TrimRight(src, "\n")
 		}

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -35,15 +35,15 @@ func runTUI(cfg replConfig) int {
 	sink := &tuiSink{prog: p}
 	m.sink = sink
 
-	// Eagerly probe terminal background colour so lipgloss caches the result
-	// before bubbletea owns stdin. lipgloss.AdaptiveColor and termenv both
-	// send OSC 11 queries; without eager probing the terminal's response leaks
-	// into the textinput as apparent user input (e.g. "11;rgb:1e1e/1e1e/2e2e\\").
+	// Eagerly probe terminal background colour before bubbletea owns stdin.
+	// lipgloss.AdaptiveColor sends an OSC 11 query on first use; if that
+	// happens after p.Run() the terminal's response (e.g. "11;rgb:1e1e/1e1e/2e2e\\")
+	// leaks into bubbletea's input reader and shows up as apparent user input.
 	//
-	// Only probe through lipgloss — it wraps termenv.DefaultOutput() and guards
-	// the query with sync.Once. Calling termenv.HasDarkBackground() directly
-	// would bypass that cache and fire a second query, whose response can race
-	// with bubbletea's input reader.
+	// tui.IsDark() guards the probe with sync.Once, so calling it here warms
+	// the cache. The result is also passed to markdownRenderer so glamour can
+	// use an explicit dark/light style instead of WithAutoStyle(), which would
+	// fire its own (uncached) termenv query later.
 	_ = tui.IsDark()
 
 	// Gate + asker raise their prompts through the same sink, so they render
@@ -229,7 +229,11 @@ func newTUIModel(cfg replConfig) *tuiModel {
 	// them for input-history recall instead.
 	ti.KeyMap.NextSuggestion = key.Binding{}
 	ti.KeyMap.PrevSuggestion = key.Binding{}
-	return &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ti: ti, inputHistoryIdx: -1, showBanner: true}
+	style := "dark"
+	if !tui.IsDark() {
+		style = "light"
+	}
+	return &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ti: ti, inputHistoryIdx: -1, showBanner: true, md: markdownRenderer{style: style}}
 }
 
 func (m *tuiModel) Init() tea.Cmd { return textinput.Blink }


### PR DESCRIPTION
Previous fixes (#190, #192, #196) tried to eager-probe and cache the terminal background colour before bubbletea took over stdin, but the leak kept happening because the real culprit was <code>glamour.WithAutoStyle()</code>.

glamour.WithAutoStyle() calls <code>termenv.HasDarkBackground()</code> internally, using <code>termenv.DefaultOutput()</code> which defaults to <code>cache=false</code>. This means every glamour renderer creation re-queries the terminal via OSC 11. When markdownRenderer lazily creates its first renderer mid-turn (after p.Run() has started), the terminal response races with bubbletea's input reader and shows up as apparent user input (e.g. <code>1;rgb:1e1e/1e1e/2e2e\</code>).

**Fix**: pass the already-cached <code>tui.IsDark()</code> result explicitly to markdownRenderer, which uses <code>glamour.WithStandardStyle("dark"/"light")</code> instead of WithAutoStyle(). This eliminates glamour's uncached termenv query entirely.