### PR TITLE
fix(tui): real-time glamour render for streaming partial text

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -347,8 +347,9 @@ func (m *tuiModel) View() string {
 	}
 
 	// Live partial assistant line (committed lines already scrolled up).
+	// Render through glamour so wrapping stays consistent with committed blocks.
 	if p := m.partial.String(); p != "" {
-		b.WriteString(p)
+		b.WriteString(m.md.render(p, m.width))
 		b.WriteByte('\n')
 	}
 	// Animated activity indicator: a running card-tool, else the "thinking"


### PR DESCRIPTION
Render the live partial assistant text through glamour in View() so wrapping stays consistent with committed blocks. Previously partial text was shown raw, causing a visible jump when the buffer was flushed and glamour-rendered.