### PR TITLE
feat(tools): strong anti-polling warning in terminal_output

### DIFF
--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -198,4 +198,9 @@ func TestTerminalOutputTool_ReadOnly(t *testing.T) {
 	if _, status, _ := m.Read("bg_1"); status != "running" {
 		t.Errorf("process should still be running after terminal_output, status=%q", status)
 	}
+	// When the process is running and there is no new output, the result must
+	// contain a strong anti-polling warning.
+	if !strings.Contains(resOut.Text, "STOP POLLING") {
+		t.Errorf("terminal_output on running process with no new output should warn against polling, got %q", resOut.Text)
+	}
 }

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -219,6 +219,9 @@ func (t TerminalOutputTool) Execute(_ context.Context, _ string, input map[strin
 	}
 	header := "[status: " + status + "]"
 	if out == "" {
+		if status == "running" {
+			return agent.ToolResult{Text: header + "\n(no new output)\n\nSTOP POLLING. The system will automatically notify you when this background process finishes. Do NOT call terminal_output again unless you need to check progress mid-run."}, nil
+		}
 		return agent.ToolResult{Text: header + "\n(no new output)"}, nil
 	}
 	return agent.ToolResult{Text: header + "\n" + out}, nil


### PR DESCRIPTION
When `terminal_output` is called on a running background process with no new output, return an explicit `STOP POLLING` warning instead of the weak '(no new output)' message. This prevents the agent from wasting tokens on repeated polling — the system already notifies it when the process finishes.