### PR TITLE
fix(tools): replace tabs with spaces to prevent TUI cursor corruption

### DIFF
--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -144,7 +145,10 @@ func (m *BackgroundManager) Start(command string) (string, error) {
 		scanner := bufio.NewScanner(pr)
 		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 		for scanner.Scan() {
-			p.append(append(scanner.Bytes(), '\n')) // Bytes() reused next Scan; append copies
+			line := scanner.Bytes()
+			// Tabs break the TUI's cursor-position math; replace with spaces.
+			line = bytes.ReplaceAll(line, []byte{'\t'}, []byte("    "))
+			p.append(append(line, '\n')) // append copies
 		}
 	}()
 	// Waiter: record exit, unblock the reader via EOF, then fire the onExit

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -198,4 +198,9 @@ func TestTerminalOutputTool_ReadOnly(t *testing.T) {
 	if _, status, _ := m.Read("bg_1"); status != "running" {
 		t.Errorf("process should still be running after terminal_output, status=%q", status)
 	}
+	// When the process is running and there is no new output, the result must
+	// contain a strong anti-polling warning.
+	if !strings.Contains(resOut.Text, "STOP POLLING") {
+		t.Errorf("terminal_output on running process with no new output should warn against polling, got %q", resOut.Text)
+	}
 }

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -167,6 +167,10 @@ func (t TerminalTool) ExecuteStream(
 	<-readDone     // ensure goroutine has flushed before reading `out`
 
 	body := strings.TrimRight(out.String(), "\n")
+	// Tabs confuse the TUI's cursor-position math (bubbletea can't predict
+	// where a tab stop lands). Replace them with spaces so inline rendering
+	// stays aligned with the terminal's actual cursor.
+	body = strings.ReplaceAll(body, "\t", "    ")
 	if waitErr != nil {
 		// Match the original Execute contract: non-zero exit is surfaced as
 		// result text, not as a Go error, so the LLM can read and adapt.
@@ -219,6 +223,9 @@ func (t TerminalOutputTool) Execute(_ context.Context, _ string, input map[strin
 	}
 	header := "[status: " + status + "]"
 	if out == "" {
+		if status == "running" {
+			return agent.ToolResult{Text: header + "\n(no new output)\n\nSTOP POLLING. The system will automatically notify you when this background process finishes. Do NOT call terminal_output again unless you need to check progress mid-run."}, nil
+		}
 		return agent.ToolResult{Text: header + "\n(no new output)"}, nil
 	}
 	return agent.ToolResult{Text: header + "\n" + out}, nil


### PR DESCRIPTION
Shell commands like `gh pr checks` emit tab characters to align columns. In the inline TUI, bubbletea cannot predict tab-stop positions, so its cursor math drifts and status-bar content (cost, elapsed time, etc.) leaks into tool-output lines.

Replace \t with 4 spaces in both synchronous and background command output paths.