### PR TITLE
feat: remove cost estimation and --max-cost flag

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -108,7 +108,6 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	verboseFlag := fs.Bool("verbose", false, "Print extra context (provider/model/endpoint, always-on cache line). Also OCTO_VERBOSITY=verbose.")
 	permMode := fs.String("permission-mode", "", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask) | auto (allow on ask). Empty = use `octo config` value, else interactive.")
 	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = auto: 100 interactive, unlimited unattended/--prompt-file)")
-	maxCost := fs.Float64("max-cost", 0, "Stop the session once estimated cost (USD) reaches this; 0 = unlimited")
 	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (~75% of the model's context window), <0 = disabled")
 	thinkingBudget := fs.Int("thinking-budget", 0, "Enable extended thinking with this token budget (Anthropic/Kimi); 0 = off")
 	useSandbox := fs.Bool("sandbox", false, "Confine terminal commands to the project dir + tmp with no network (OS-enforced; macOS/Linux). Fails closed if unavailable.")
@@ -303,7 +302,6 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}, resolvedModel)
 	a.MaxTokens = *maxTokens
 	a.MaxTurns = resolveMaxTurns(*maxTurns, seedPrompt != "", stdinIsTTY(stdin))
-	a.MaxCostUSD = *maxCost
 	a.CompactThreshold = *compactThreshold
 
 	// Build the tool executor up-front (REPL mode only — single-turn mode

--- a/cmd/octo/completion.go
+++ b/cmd/octo/completion.go
@@ -113,7 +113,7 @@ func chatCandidates(words []string, prev string) []string {
 	case "--permission-mode":
 		return []string{"interactive", "strict", "auto"}
 	case "--model", "--system", "--max-tokens", "--max-turns",
-		"--max-cost", "--compact-threshold", "--thinking-budget",
+		"--compact-threshold", "--thinking-budget",
 		"--sandbox-write", "--sandbox-read":
 		// These take freeform values; nothing useful to suggest.
 		return nil

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -341,7 +341,6 @@ func printTuiHelp(w io.Writer) {
 	fmt.Fprintln(w, "Commands:")
 	fmt.Fprintln(w, "  /help       Show this message")
 	fmt.Fprintln(w, "  /init       Analyze the repo and generate/update .octorules (needs --tools)")
-	fmt.Fprintln(w, "  /cost       Show token usage and estimated cost for this session")
 	fmt.Fprintln(w, "  /save       Save the session now (it also auto-saves after each turn)")
 	fmt.Fprintln(w, "  /sessions   List the 10 most recent sessions")
 	fmt.Fprintln(w, "  /skills     List available skills (trigger one with /<name>)")
@@ -450,7 +449,7 @@ func pluralS(n int) string {
 // one (so /help always means help even if a skill dir is named "help").
 var reservedReplCommands = map[string]bool{
 	"init": true, "exit": true, "quit": true, "help": true,
-	"cost": true, "save": true, "sessions": true, "skills": true,
+	"save": true, "sessions": true, "skills": true,
 	"memory": true, "mcp": true, "goal": true,
 }
 
@@ -492,15 +491,6 @@ func printSkills(w io.Writer, reg *skills.Registry) {
 	fmt.Fprintln(w, "Available skills (trigger with /<name>):")
 	for _, s := range reg.List() {
 		fmt.Fprintf(w, "  /%-16s [%-7s] %s\n", s.Name, s.Source, s.Description)
-	}
-}
-
-func printCost(w io.Writer, a *agent.Agent) {
-	in, out := a.SessionTokens()
-	cost := a.SessionCostUSD()
-	fmt.Fprintf(w, "Tokens: %d in / %d out  |  est. $%.6f\n", in, out, cost)
-	if read, write := a.SessionCacheTokens(); read > 0 || write > 0 {
-		fmt.Fprintf(w, "Cache:  %d read / %d write\n", read, write)
 	}
 }
 

--- a/cmd/octo/sub_agent.go
+++ b/cmd/octo/sub_agent.go
@@ -66,11 +66,6 @@ func (s *agentSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools
 	child.MaxTokens = s.parent.MaxTokens
 	child.Gate = s.parent.Gate
 	child.MaxTurns = childMaxTurns
-	// Inherit the parent's hard cost ceiling — the child's spend is rolled
-	// back into the parent below, but the per-loop check inside the child
-	// uses its own counter, so a budget the user already set on the parent
-	// should still constrain the child.
-	child.MaxCostUSD = s.parent.MaxCostUSD
 
 	lc := &liveChild{agent: child, tools: childTools, executor: s.executor}
 	id := s.reg.put(lc)

--- a/cmd/octo/tuirepl_slash_test.go
+++ b/cmd/octo/tuirepl_slash_test.go
@@ -23,7 +23,7 @@ func TestTUI_SlashExitQuits(t *testing.T) {
 
 func TestTUI_SlashInfoCommandsDontStartTurn(t *testing.T) {
 	// Info commands render synchronously and must not occupy the session.
-	for _, cmd := range []string{"/help", "/cost", "/skills", "/memory", "/mcp"} {
+	for _, cmd := range []string{"/help", "/skills", "/memory", "/mcp"} {
 		m := newTestModel()
 		_, cmdFn := m.dispatchSlash(cmd)
 		if m.turnRunning {

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -180,13 +180,11 @@ func (m *tuiModel) dispatchSlash(text string) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case "/goal":
 		return m.dispatchGoal(strings.TrimSpace(strings.TrimPrefix(text, first)))
-	case "/help", "/cost", "/save", "/sessions", "/skills", "/memory", "/mcp":
+	case "/help", "/save", "/sessions", "/skills", "/memory", "/mcp":
 		var b bytes.Buffer
 		switch cmd {
 		case "/help":
 			printTuiHelp(&b)
-		case "/cost":
-			printCost(&b, m.a)
 		case "/save":
 			if err := saveSession(&b, cfg.session, m.a); err != nil {
 				fmt.Fprintf(&b, "save: %v\n", err)
@@ -420,9 +418,9 @@ func (m *tuiModel) renderInputBox() string {
 	return promptStyle.Render("> ") + m.ti.View()
 }
 
-// renderStatusBar renders the model / cwd / context% / cost / permission /
-// elapsed segments, with a separator line above and the contextual key hint
-// below (Claude Code style).
+// renderStatusBar renders the cwd / context% / permission / elapsed segments,
+// with a separator line above and the contextual key hint below (Claude Code
+// style).
 func (m *tuiModel) renderStatusBar() string {
 	var segs [][2]string
 	if m.cwd != "" {
@@ -430,9 +428,6 @@ func (m *tuiModel) renderStatusBar() string {
 	}
 	if used, window := m.a.ContextUsage(); window > 0 && used > 0 {
 		segs = append(segs, [2]string{"ctx", fmt.Sprintf("%d%%", used*100/window)})
-	}
-	if c := m.a.SessionCostUSD(); c > 0 {
-		segs = append(segs, [2]string{"cost", fmt.Sprintf("$%.4f", c)})
 	}
 	if m.cfg.permEngine != nil {
 		segs = append(segs, [2]string{"perm", string(m.cfg.permEngine.GetMode())})

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -117,11 +117,6 @@ type Agent struct {
 	// with a friendly budget reply (StopReason "max_turns"), not an error.
 	MaxTurns int
 
-	// MaxCostUSD caps cumulative session spend. 0 = unlimited. When the
-	// running estimate reaches the cap the loop stops before the next
-	// provider call with StopReason "max_cost".
-	MaxCostUSD float64
-
 	// CompactThreshold controls history compaction: when the most recent
 	// context sent (lastInputTokens) crosses the effective trigger, the next
 	// Run/RunStream summarizes the older turns before continuing. Semantics:
@@ -159,7 +154,6 @@ type Agent struct {
 // can distinguish "the model finished" from "we cut it off".
 const (
 	StopReasonMaxTurns    = "max_turns"
-	StopReasonMaxCost     = "max_cost"
 	StopReasonInterrupted = "interrupted"
 )
 
@@ -422,15 +416,6 @@ func (a *Agent) runLoop(
 		// Interrupt (Ctrl-C) between iterations — e.g. right after a tool batch.
 		if ctx.Err() != nil {
 			return a.finishInterrupted(handler)
-		}
-
-		// Cost gate: checked before each provider call. Cost is only known
-		// after a response, so the worst case is one call that tips over the
-		// budget; we stop before the next.
-		if a.MaxCostUSD > 0 && a.SessionCostUSD() >= a.MaxCostUSD {
-			return a.budgetStop(handler, StopReasonMaxCost, fmt.Sprintf(
-				"[octo] Stopped: session cost budget ($%.4f) reached. The task may be "+
-					"incomplete — raise --max-cost or start a new session to continue.", a.MaxCostUSD))
 		}
 
 		reply, err := send(ctx, a.History.Snapshot())
@@ -857,41 +842,6 @@ func (a *Agent) SessionCacheTokens() (readTokens, writeTokens int) {
 // Pricing is based on publicly listed rates as of May 2026 and is best-effort
 // — it uses a prefix match on the model name and falls back to a conservative
 // mid-tier estimate for unknown models.
-func (a *Agent) SessionCostUSD() float64 {
-	in, out := float64(a.sessionInputTokens), float64(a.sessionOutputTokens)
-	inPrice, outPrice := modelPricePerMillion(a.Model)
-	return (in/1_000_000)*inPrice + (out/1_000_000)*outPrice
-}
-
-// modelPricePerMillion returns (inputPricePerMillion, outputPricePerMillion)
-// in USD for the given model name. Prices are approximate and may be stale.
-func modelPricePerMillion(model string) (float64, float64) {
-	switch {
-	// Anthropic Claude 4.x Haiku — cheapest tier
-	case hasPrefix(model, "claude-haiku"):
-		return 0.80, 4.00
-	// Anthropic Claude 4.x Sonnet
-	case hasPrefix(model, "claude-sonnet"):
-		return 3.00, 15.00
-	// Anthropic Claude 4.x Opus
-	case hasPrefix(model, "claude-opus"):
-		return 15.00, 75.00
-	// OpenAI GPT-4o mini
-	case hasPrefix(model, "gpt-4o-mini"):
-		return 0.15, 0.60
-	// OpenAI GPT-4o
-	case hasPrefix(model, "gpt-4o"):
-		return 2.50, 10.00
-	// Unknown — conservative mid-tier estimate
-	default:
-		return 3.00, 15.00
-	}
-}
-
-func hasPrefix(s, prefix string) bool {
-	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
-}
-
 // popLast is an internal helper used by Turn to undo the user-message append
 // when the Sender call fails. Exported users should not need this.
 func (h *History) popLast() {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -427,39 +427,6 @@ func TestAgent_Run_CustomMaxTurns(t *testing.T) {
 	}
 }
 
-func TestAgent_Run_MaxCostStops(t *testing.T) {
-	// First reply reports tokens that push session cost over the budget; the
-	// loop must stop before the second provider call.
-	send := &fakeToolSender{
-		replies: []Reply{
-			{
-				StopReason:   "tool_use",
-				Blocks:       []ContentBlock{NewToolUseBlock("c", "bash", nil)},
-				InputTokens:  1_000_000, // ~$3 at default sonnet input pricing
-				OutputTokens: 0,
-			},
-			{Content: "should not be reached", StopReason: "end_turn"},
-		},
-	}
-	exec := &fakeExecutor{}
-	a := New(send, "claude-sonnet-4-6")
-	a.MaxCostUSD = 0.50 // well under the first call's ~$3
-	defs := []ToolDefinition{{Name: "bash"}}
-
-	reply, err := a.Run(context.Background(), "go", defs, exec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reply.StopReason != StopReasonMaxCost {
-		t.Errorf("StopReason = %q, want max_cost", reply.StopReason)
-	}
-	// One provider call happened (cost only known after it); the second was
-	// gated out.
-	if send.calls != 1 {
-		t.Errorf("provider calls = %d, want 1 (stopped on cost before 2nd)", send.calls)
-	}
-}
-
 func TestAgent_Run_SenderWithoutToolSupport_FallsBackToTurn(t *testing.T) {
 	// A plain fakeSender (no ToolSender) should just do a single Turn.
 	send := &fakeSender{reply: Reply{Content: "plain", StopReason: "end_turn"}}

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -119,7 +119,6 @@ var (
 	statusHintStyle  = lipgloss.NewStyle().Foreground(ColDimmer).Italic(true)
 	statusBarStyle   = lipgloss.NewStyle().Foreground(ColBorder)
 	statusModelStyle = lipgloss.NewStyle().Foreground(ColBrandDim).Bold(true)
-	statusCostStyle  = lipgloss.NewStyle().Foreground(ColAccent)
 	statusTimeStyle  = lipgloss.NewStyle().Foreground(ColMuted)
 )
 
@@ -140,8 +139,6 @@ func StatusBar(segments [][2]string, hint string, width int) string {
 		switch label {
 		case "model":
 			rendered = statusModelStyle.Render(value)
-		case "cost":
-			rendered = statusCostStyle.Render(value)
 		case "elapsed":
 			rendered = statusTimeStyle.Render(value)
 		default:


### PR DESCRIPTION
Remove all cost-related code since users on subscription plans (e.g. Kimi Coding Plan) don't need token-based cost estimates.