### PR TITLE
feat(tools): stronger 'wait for notification' message on background launch

### DIFF
--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -105,7 +105,7 @@ func (t TerminalTool) ExecuteStream(
 		if err != nil {
 			return agent.ToolResult{Text: ""}, err
 		}
-		return agent.ToolResult{Text: fmt.Sprintf("Started background process %s.\nRead its output with the terminal_output tool (id: %q).", id, id)}, nil
+		return agent.ToolResult{Text: fmt.Sprintf("Started background process %s.\n\nDO NOT poll terminal_output. The system will automatically notify you when this process finishes, carrying its full output. You can continue with other tasks while it runs.", id)}, nil
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, TerminalTimeout)


### PR DESCRIPTION
Replace the old 'Read its output with terminal_output' wording with an explicit DO NOT poll instruction, so the agent knows the system will automatically notify it when the background process finishes.