### PR TITLE
fix(agent): ContextUsage estimates from History, not lastInputTokens

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -828,7 +828,7 @@ func (a *Agent) AccrueChildUsage(inputTokens, outputTokens int) {
 // before the first reply), window is the model's approximate context-window
 // size. Lets the TUI status bar render a "ctx N%" gauge. window is always > 0.
 func (a *Agent) ContextUsage() (used, window int) {
-	return a.lastInputTokens, contextWindow(a.Model)
+	return estimateMessages(a.History.Snapshot()), contextWindow(a.Model)
 }
 
 // SessionCacheTokens returns the cumulative cache read/write token counts.


### PR DESCRIPTION
Fix ctx% always showing 0% by using estimateMessages() on the full History snapshot instead of lastInputTokens (which only reflects the last provider call's input size).