### PR TITLE
feat(tools): auto-restart timed-out sync commands as background

### DIFF
--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -170,6 +171,61 @@ func TestKillShellTool(t *testing.T) {
 	if _, err := killTool.Execute(context.Background(), "kill_shell", map[string]any{"id": "bg_nope"}); err == nil {
 		t.Error("kill_shell on unknown id should error")
 	}
+}
+
+// TestTerminalTool_TimeoutPromotesToBackground verifies that a synchronous
+// command which exceeds TerminalTimeout is killed and automatically restarted
+// as a background process. The agent receives partial output plus a bg id.
+func TestTerminalTool_TimeoutPromotesToBackground(t *testing.T) {
+	// Use a very short timeout so the test doesn't take 30 s.
+	oldTimeout := TerminalTimeout
+	TerminalTimeout = 200 * time.Millisecond
+	defer func() { TerminalTimeout = oldTimeout }()
+
+	m := NewBackgroundManager()
+	term := TerminalTool{mgr: m}
+
+	// Use `go env` (fast, cross-platform) piped to a long sleep.  On POSIX
+	// `sleep` is available; on Windows we use `Start-Sleep` via PowerShell.
+	cmd := "echo partial && sleep 1"
+	if runtime.GOOS == "windows" {
+		cmd = "Write-Output partial; Start-Sleep -Seconds 1"
+	}
+	res, err := term.Execute(context.Background(), "terminal", map[string]any{
+		"command": cmd,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Should contain the partial output.
+	if !strings.Contains(res.Text, "partial") {
+		t.Errorf("result should contain partial output, got: %q", res.Text)
+	}
+	// Should mention the timeout and background promotion.
+	if !strings.Contains(res.Text, "timeout") {
+		t.Errorf("result should mention timeout, got: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "bg_1") {
+		t.Errorf("result should mention bg id, got: %q", res.Text)
+	}
+	// Should contain the anti-polling instruction.
+	if !strings.Contains(res.Text, "DO NOT poll") {
+		t.Errorf("result should warn against polling, got: %q", res.Text)
+	}
+
+	// The background process should eventually finish (sleep 0.5 + margin).
+	// Use a longer deadline than the default waitFor because CI under -race
+	// can be very slow.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		_, s, _ := m.Read("bg_1")
+		if strings.HasPrefix(s, "exited") {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for background process to exit")
 }
 
 func TestTerminalOutputTool_ReadOnly(t *testing.T) {

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -177,15 +177,17 @@ func TestKillShellTool(t *testing.T) {
 // command which exceeds TerminalTimeout is killed and automatically restarted
 // as a background process. The agent receives partial output plus a bg id.
 func TestTerminalTool_TimeoutPromotesToBackground(t *testing.T) {
-	// Use a very short timeout so the test doesn't take 30 s.
+	// Use a short timeout so the test doesn't take 30 s.  500 ms is enough
+	// for POSIX `sh` and Windows PowerShell to start and emit a line, while
+	// keeping the test fast.
 	oldTimeout := TerminalTimeout
-	TerminalTimeout = 200 * time.Millisecond
+	TerminalTimeout = 500 * time.Millisecond
 	defer func() { TerminalTimeout = oldTimeout }()
 
 	m := NewBackgroundManager()
 	term := TerminalTool{mgr: m}
 
-	// Use `go env` (fast, cross-platform) piped to a long sleep.  On POSIX
+	// Use `echo` (fast, cross-platform) piped to a long sleep.  On POSIX
 	// `sleep` is available; on Windows we use `Start-Sleep` via PowerShell.
 	cmd := "echo partial && sleep 1"
 	if runtime.GOOS == "windows" {

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -14,8 +14,9 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 )
 
-// TerminalTimeout is the maximum time a single terminal command may run.
-const TerminalTimeout = 30 * time.Second
+// TerminalTimeout is the maximum time a single terminal command may run
+// synchronously before it is automatically promoted to a background process.
+var TerminalTimeout = 30 * time.Second
 
 // TerminalTool is an agent.ToolExecutor that runs shell commands through the
 // system shell (`sh -c` on macOS/Linux, PowerShell on Windows; see
@@ -84,6 +85,11 @@ func (t TerminalTool) Execute(ctx context.Context, name string, input map[string
 // Scanner buffer cap is 1 MiB per line — commands that emit a single 10MB-
 // long line will get their final line truncated, but the more usual case of
 // many short lines is unaffected.
+//
+// Timeout promotion: if the command exceeds TerminalTimeout (30 s) it is
+// killed and automatically restarted as a background process so the work is
+// not lost. The caller receives the output produced so far plus a background
+// id and a clear instruction to wait for the completion notification.
 func (t TerminalTool) ExecuteStream(
 	ctx context.Context,
 	_ string,
@@ -108,10 +114,18 @@ func (t TerminalTool) ExecuteStream(
 		return agent.ToolResult{Text: fmt.Sprintf("Started background process %s.\n\nDO NOT poll terminal_output. The system will automatically notify you when this process finishes, carrying its full output. You can continue with other tasks while it runs.", id)}, nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, TerminalTimeout)
-	defer cancel()
+	// Synchronous path: run with a timeout. If the command exceeds the timeout
+	// it is killed and automatically restarted as a background process so the
+	// work is not lost. The agent receives the partial output plus a bg id.
+	//
+	// We use a manual timer instead of context.WithTimeout because
+	// exec.CommandContext kills the process on timeout and returns "signal:
+	// killed" rather than context.DeadlineExceeded, making it impossible to
+	// distinguish timeout from user interrupt.
+	cmdCtx, cmdCancel := context.WithCancel(context.Background())
+	defer cmdCancel()
 
-	cmd, err := shellCommand(ctx, command)
+	cmd, err := shellCommand(cmdCtx, command)
 	if err != nil {
 		return agent.ToolResult{Text: ""}, err
 	}
@@ -151,30 +165,63 @@ func (t TerminalTool) ExecuteStream(
 		// the rest. The Wait() error below is the canonical signal.
 	}()
 
-	// Kill the subprocess (and any children it spawned) when the context is
-	// cancelled (e.g. user pressed Esc in the TUI). Without this, cmd.Wait()
-	// blocks until the child exits on its own, so an interactive command like
-	// `gh pr checks --watch` appears to ignore the interrupt.
+	// Kill the subprocess when the USER cancels the turn (Esc / Ctrl-C).
+	// The timeout is handled separately below.
+	// context.Background() (used in some tests) returns a nil Done channel;
+	// reading from a nil channel blocks forever, so we guard against it.
 	go func() {
-		<-ctx.Done()
-		if cmd.Process != nil {
-			_ = killProcessGroup(cmd.Process)
+		if done := ctx.Done(); done != nil {
+			<-done
+			cmdCancel()
+			if cmd.Process != nil {
+				_ = killProcessGroup(cmd.Process)
+			}
 		}
 	}()
 
-	waitErr := cmd.Wait()
-	_ = pw.Close() // unblocks the scanner's Read by EOF
-	<-readDone     // ensure goroutine has flushed before reading `out`
+	// Wait for the command to finish, but cap the wait at TerminalTimeout.
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- cmd.Wait()
+		_ = pw.Close() // unblocks the scanner's Read by EOF
+	}()
+
+	var (
+		timedOut bool
+		waitRes  error
+	)
+	select {
+	case waitRes = <-waitErr:
+	case <-time.After(TerminalTimeout):
+		timedOut = true
+		cmdCancel()
+		if cmd.Process != nil {
+			_ = killProcessGroup(cmd.Process)
+		}
+		waitRes = <-waitErr // drain the channel
+	}
+	<-readDone // ensure goroutine has flushed before reading `out`
 
 	body := strings.TrimRight(out.String(), "\n")
 	// Tabs confuse the TUI's cursor-position math (bubbletea can't predict
 	// where a tab stop lands). Replace them with spaces so inline rendering
 	// stays aligned with the terminal's actual cursor.
 	body = strings.ReplaceAll(body, "\t", "    ")
-	if waitErr != nil {
+
+	// If the command timed out, restart it as a background process so the
+	// work is not lost. The agent gets the partial output plus a bg id.
+	if timedOut {
+		id, err := t.manager().Start(command)
+		if err != nil {
+			return agent.ToolResult{Text: body + "\n[timeout: command exceeded " + TerminalTimeout.String() + "]"}, nil
+		}
+		return agent.ToolResult{Text: fmt.Sprintf("%s\n\n[timeout: command exceeded %s and was restarted as background process %s]\n\nDO NOT poll terminal_output. The system will automatically notify you when this process finishes, carrying its full output. You can continue with other tasks while it runs.", body, TerminalTimeout, id)}, nil
+	}
+
+	if waitRes != nil {
 		// Match the original Execute contract: non-zero exit is surfaced as
 		// result text, not as a Go error, so the LLM can read and adapt.
-		return agent.ToolResult{Text: body + "\n[exit: " + waitErr.Error() + "]"}, nil
+		return agent.ToolResult{Text: body + "\n[exit: " + waitRes.Error() + "]"}, nil
 	}
 	return agent.ToolResult{Text: body}, nil
 }


### PR DESCRIPTION
When a synchronous terminal command exceeds the 30s timeout, instead of returning a killed error, it is automatically restarted as a background process. The agent receives partial output + bg id + anti-polling instruction, so no work is lost.