### PR TITLE
fix(agent): inject project context into planner user message

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -300,6 +300,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		thinkingBudget: *thinkingBudget,
 		thinkingOut:    stdout,
 	}, resolvedModel)
+	a.CWD = cwd
 	a.MaxTokens = *maxTokens
 	a.MaxTurns = resolveMaxTurns(*maxTurns, seedPrompt != "", stdinIsTTY(stdin))
 	a.CompactThreshold = *compactThreshold

--- a/cmd/octo/task.go
+++ b/cmd/octo/task.go
@@ -113,6 +113,7 @@ func runTaskStart(args []string, stdout, stderr io.Writer) int {
 	}, resolvedModel)
 	a.MaxTokens = defaultMaxTokensForPlanner
 	cwd, _ := os.Getwd()
+	a.CWD = cwd
 	a.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "")
 
 	fmt.Fprintf(stdout, "Planning…  goal: %s\n", oneLine(goal))
@@ -261,6 +262,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 	}, resolvedModel)
 	parent.MaxTokens = defaultMaxTokensForPlanner
 	cwd, _ := os.Getwd()
+	parent.CWD = cwd
 	parent.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "")
 
 	executor := tools.NewDefaultRegistry()
@@ -515,6 +517,7 @@ func resumeAndRun(t *taskgraph.Task, flagProvider, flagModel string, cfg config.
 	parent := agent.New(providerSender{p: prov, cacheKey: newCacheKey()}, resolvedModel)
 	parent.MaxTokens = defaultMaxTokensForPlanner
 	cwd, _ := os.Getwd()
+	parent.CWD = cwd
 	parent.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "")
 
 	executor := tools.NewDefaultRegistry()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -108,6 +108,11 @@ type Agent struct {
 	History   *History
 	Sender    Sender
 
+	// CWD is the working directory used to resolve project context (e.g.
+	// .octorules) for the planner. Callers should set this to the repo root
+	// before invoking PlanTask.
+	CWD string
+
 	// Gate, when non-nil, vets every tool call before execution. A nil
 	// Gate means no gating — all tool calls run (the pre-M6.5 behaviour).
 	Gate PermissionGate

--- a/internal/agent/plan.go
+++ b/internal/agent/plan.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -82,6 +84,16 @@ type PlannedSubtask struct {
 	BlockedBy   []int  `json:"blocked_by,omitempty"`
 }
 
+// maxProjectContextChars caps the project context injected into the planner
+// user message. The planner is a side-call with a tight token budget; we
+// truncate aggressively rather than risk pushing the context over the limit.
+const maxProjectContextChars = 4000
+
+// projectContextFile is the per-repo conventions file the planner reads to
+// understand what kind of project it is planning for. Kept as a constant so
+// it matches prompt.ProjectContextFile without importing prompt.
+const projectContextFile = ".octorules"
+
 // PlanTask runs the planner side-call over goal and returns the resulting
 // subtask DAG. It does not write anything to disk — the caller persists
 // via internal/taskgraph.
@@ -98,7 +110,15 @@ func (a *Agent) PlanTask(ctx context.Context, goal string) (PlanResult, error) {
 		return PlanResult{}, fmt.Errorf("agent: goal is required")
 	}
 
-	req := []Message{NewUserMessage("Goal:\n\n" + goal + "\n\nPlan the subtask DAG per your instructions. Output only the JSON object.")}
+	ctxText := readProjectContext(a.CWD)
+	var userMsg string
+	if ctxText != "" {
+		userMsg = "Project context:\n" + ctxText + "\n\nGoal:\n\n" + goal + "\n\nPlan the subtask DAG per your instructions. Output only the JSON object."
+	} else {
+		userMsg = "Goal:\n\n" + goal + "\n\nPlan the subtask DAG per your instructions. Output only the JSON object."
+	}
+
+	req := []Message{NewUserMessage(userMsg)}
 	reply, err := a.Sender.SendMessages(ctx, a.Model, planSystem, req, planMaxTokens)
 	if err != nil {
 		return PlanResult{}, err
@@ -106,6 +126,30 @@ func (a *Agent) PlanTask(ctx context.Context, goal string) (PlanResult, error) {
 	a.sessionInputTokens += reply.InputTokens
 	a.sessionOutputTokens += reply.OutputTokens
 	return parsePlan(reply.Content)
+}
+
+// readProjectContext returns the trimmed contents of .octorules in cwd, or
+// the current working directory if cwd is empty. The result is truncated to
+// maxProjectContextChars to stay within the planner's token budget. Returns
+// "" when the file is absent, unreadable, or empty.
+func readProjectContext(cwd string) string {
+	dir := cwd
+	if dir == "" {
+		var err error
+		dir, err = os.Getwd()
+		if err != nil {
+			return ""
+		}
+	}
+	b, err := os.ReadFile(filepath.Join(dir, projectContextFile))
+	if err != nil {
+		return ""
+	}
+	s := strings.TrimSpace(string(b))
+	if len(s) > maxProjectContextChars {
+		s = s[:maxProjectContextChars] + "\n... [truncated]"
+	}
+	return s
 }
 
 // parsePlan extracts the JSON object from the planner's reply (tolerating

--- a/internal/agent/plan_test.go
+++ b/internal/agent/plan_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -141,5 +143,53 @@ func TestPlanTask_TokenUsageAccrued(t *testing.T) {
 	in, out := a.SessionTokens()
 	if in == 0 || out == 0 {
 		t.Errorf("PlanTask should accrue token usage, got (%d,%d)", in, out)
+	}
+}
+
+func TestReadProjectContext_MissingFile(t *testing.T) {
+	if got := readProjectContext(t.TempDir()); got != "" {
+		t.Errorf("missing file should yield empty, got %q", got)
+	}
+}
+
+func TestReadProjectContext_ReadsAndTruncates(t *testing.T) {
+	dir := t.TempDir()
+	content := strings.Repeat("a", maxProjectContextChars+100)
+	if err := os.WriteFile(filepath.Join(dir, projectContextFile), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := readProjectContext(dir)
+	if !strings.HasPrefix(got, strings.Repeat("a", maxProjectContextChars)) {
+		t.Error("expected prefix of repeated 'a' chars")
+	}
+	if !strings.HasSuffix(got, "\n... [truncated]") {
+		t.Errorf("expected truncation suffix, got suffix %q", got[len(got)-20:])
+	}
+}
+
+func TestPlanTask_IncludesProjectContext(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, projectContextFile), []byte("This is a Go CLI project."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := &stubExtractSender{reply: `{"subtasks":[{"description":"step one"}]}`}
+	a := New(s, "test-model")
+	a.CWD = dir
+	_, err := a.PlanTask(context.Background(), "Add feature X")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.lastMessages) == 0 {
+		t.Fatal("expected a user message")
+	}
+	msg := s.lastMessages[0].Content
+	if !strings.Contains(msg, "Project context:") {
+		t.Errorf("user message should contain 'Project context:', got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "This is a Go CLI project.") {
+		t.Errorf("user message should contain project context text, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Add feature X") {
+		t.Errorf("user message should still contain the goal, got:\n%s", msg)
 	}
 }


### PR DESCRIPTION
PlanTask previously sent only the raw goal text to the planner, causing it to hallucinate generic plans unrelated to the actual project (e.g. Python/Flask e-commerce for a Go CLI tool).

Now it reads  from  and injects it into the planner's user message so the model knows what kind of project it is planning for. Includes truncation (4000 char cap) and tests.

Closes #207 (follow-up).