### PR TITLE
feat(tui): show idle hint once in Banner instead of persistent status bar

### DIFF
--- a/cmd/octo/tuirepl_p2_test.go
+++ b/cmd/octo/tuirepl_p2_test.go
@@ -12,9 +12,9 @@ func TestRenderStatusBar_ShowsModelAndHint(t *testing.T) {
 	if !strings.Contains(out, "m") {
 		t.Errorf("status bar should include the model; got:\n%s", out)
 	}
-	// Idle hint.
-	if !strings.Contains(out, "Enter send") {
-		t.Errorf("idle status bar should show the send hint; got:\n%s", out)
+	// Idle: no persistent hint (the startup hint is shown once in the Banner).
+	if strings.Contains(out, "Enter send") {
+		t.Errorf("idle status bar should NOT show a persistent send hint; got:\n%s", out)
 	}
 	// Running hint switches.
 	m.turnRunning = true

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -436,12 +436,12 @@ func (m *tuiModel) renderStatusBar() string {
 		segs = append(segs, [2]string{"elapsed", time.Since(m.turnStart).Round(time.Second).String()})
 	}
 
-	hint := "Enter send · /exit quit · Ctrl+D quit"
+	var hint string
 	if m.turnRunning {
 		hint = "Enter steer · Alt+Enter queue · Esc interrupt"
-	}
-	if len(m.queue) > 0 {
-		hint += " · Ctrl+X unqueue"
+		if len(m.queue) > 0 {
+			hint += " · Ctrl+X unqueue"
+		}
 	}
 	return tui.StatusBar(segs, hint, m.width)
 }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -109,6 +109,8 @@ func Banner(version, model, cwd string, width int) string {
 
 	sep := strings.Repeat("─", width)
 	b.WriteString(bannerSepStyle.Render(sep))
+	b.WriteByte('\n')
+	b.WriteString(bannerSubStyle.Render("Enter send · /exit quit · Ctrl+D quit"))
 	return b.String()
 }
 

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -47,7 +47,7 @@ func TestChromaStyle_LightDark(t *testing.T) {
 
 func TestBanner_ContainsTitleAndInfo(t *testing.T) {
 	out := Banner("v1.0", "claude", "~/proj", 40)
-	for _, want := range []string{"octo chat", "claude", "~/proj", "──"} {
+	for _, want := range []string{"octo chat", "claude", "~/proj", "──", "Enter send"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("Banner missing %q in:\n%s", want, out)
 		}


### PR DESCRIPTION
The 'Enter send · /exit quit · Ctrl+D quit' hint was permanently rendered at the bottom of the screen. This PR moves it to the welcome Banner so it appears once at startup and disappears after the first input, keeping the bottom status bar clean during the session.