### PR TITLE
fix(agent): use real provider token counts for context usage gauge

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -427,7 +427,11 @@ func (m *tuiModel) renderStatusBar() string {
 		segs = append(segs, [2]string{"cwd", m.cwd})
 	}
 	if used, window := m.a.ContextUsage(); window > 0 && used > 0 {
-		segs = append(segs, [2]string{"ctx", fmt.Sprintf("%d%%", used*100/window)})
+		pct := used * 100 / window
+		if pct > 100 {
+			pct = 100
+		}
+		segs = append(segs, [2]string{"ctx", fmt.Sprintf("%d%%", pct)})
 	}
 	if m.cfg.permEngine != nil {
 		segs = append(segs, [2]string{"perm", string(m.cfg.permEngine.GetMode())})

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -829,11 +829,11 @@ func (a *Agent) AccrueChildUsage(inputTokens, outputTokens int) {
 }
 
 // ContextUsage reports how full the model's context window is: used is the
-// size of the most recently sent context (the prior turn's input tokens, 0
-// before the first reply), window is the model's approximate context-window
-// size. Lets the TUI status bar render a "ctx N%" gauge. window is always > 0.
+// most recently sent context size in tokens (reported by the provider), and
+// window is the model's approximate context-window size. Lets the TUI status
+// bar render a "ctx N%" gauge. window is always > 0.
 func (a *Agent) ContextUsage() (used, window int) {
-	return estimateMessages(a.History.Snapshot()), contextWindow(a.Model)
+	return a.lastInputTokens, contextWindow(a.Model)
 }
 
 // SessionCacheTokens returns the cumulative cache read/write token counts.


### PR DESCRIPTION
ContextUsage previously used estimateMessages(a.History.Snapshot()), a local character heuristic that consistently under-counted for code-dense content. This led to absurd percentages like 103% while the provider hadn't errored.

Now it returns a.lastInputTokens — the actual input token count reported by the provider on the most recent call. This matches what the API sees and eliminates the estimation drift.

TUI status bar also caps the percentage at 100% as a defensive measure.