### PR TITLE
feat(tui): display steer messages at drain time, not at input time

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -407,6 +407,13 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) tea.Cmd {
 			return m.commitToolLine(renderToolCard(ev.ToolName, input, firstNonEmpty(ev.Output, ev.Err), true))
 		}
 		return m.commitToolLine(toolErrStyle.Render(fmt.Sprintf("↳ %s ✗ — %s", ev.ToolName, truncate1Line(ev.Err))))
+
+	case agent.EventSteerInjected:
+		// Steer text is displayed at the exact moment it enters history,
+		// after the tool_result it was folded into. This preserves
+		// chronological order — the user sees their steer where the model
+		// actually receives it, not prematurely when they typed it.
+		return tea.Println(userEchoStyle.Render("> ") + ev.Text)
 	}
 	return nil
 }

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -144,8 +144,11 @@ func (m *tuiModel) submit(alt bool) (tea.Model, tea.Cmd) {
 		return m, tea.Println(queueStyle.Render("＋ queued: " + text))
 	}
 	// Steer: fold into the running turn at the next tool-batch boundary.
+	// No immediate UI echo — the steer text is displayed later via
+	// EventSteerInjected when it is actually drained into the tool_result,
+	// preserving chronological order.
 	m.a.Steer(text)
-	return m, tea.Println(queueStyle.Render("→ steering: " + text))
+	return m, nil
 }
 
 // dispatchSlash handles a leading-"/" line when the session is idle.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -481,6 +481,9 @@ func (a *Agent) runLoop(
 			// messages in a row.
 			if steer := a.drainSteer(); steer != "" {
 				resultBlocks = append(resultBlocks, NewTextBlock(steer))
+				if handler != nil {
+					handler(AgentEvent{Kind: EventSteerInjected, Text: steer})
+				}
 			}
 
 			a.History.Append(NewToolResultMessage(resultBlocks))

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -50,6 +50,13 @@ const (
 	// after the assistant's final reply is committed to history. Reply
 	// carries the aggregated final Reply.
 	EventTurnDone EventKind = "turn_done"
+
+	// EventSteerInjected fires when a steer message is drained from the
+	// pending buffer and folded into the current tool_result. Text carries
+	// the steer content. This lets the UI display the steer at the exact
+	// moment it enters the conversation history, preserving chronological
+	// order rather than showing it prematurely when the user typed it.
+	EventSteerInjected EventKind = "steer_injected"
 )
 
 // EventToolOutputCap is the maximum length of the Output field emitted on
@@ -71,6 +78,7 @@ const EventToolOutputCap = 512
 //   - EventToolDone:       ToolID, ToolName, Output
 //   - EventToolError:      ToolID, ToolName, Output (may be empty), Err
 //   - EventTurnDone:       Reply
+//   - EventSteerInjected:  Text
 //
 // JSON tags are included so HTTP/SSE transports (M8 web server) can
 // marshal events directly without an intermediate type.


### PR DESCRIPTION
Previously, steer messages were immediately echoed as '→ steering: text' when the user pressed Enter. This was misleading because the steer was not yet in history — it was only queued until the next tool-batch boundary.

Now:
- Remove the premature '→ steering' echo from submit().
- Add EventSteerInjected, fired when the steer is actually drained and folded into the tool_result message.
- The TUI prints the steer text via userEchoStyle at the exact moment it enters the conversation, preserving chronological order.