### PR TITLE
feat(subagent): async launch_agent, send_message, agent_status, kill_agent

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -323,6 +323,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		toolExecutor tools.DefaultRegistry
 		replReader   lineReader
 		replView     ViewSink
+		subAgentMgr  *tools.SubAgentManager
 	)
 	// useTUI: an interactive terminal drives the bubbletea TUI unless the user
 	// (or OCTO_TUI=0) opted out. Piped / redirected stdin always uses the plain
@@ -332,7 +333,9 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	useTUI := isREPL && stdinIsTTY(stdin) && !*noTUI && !tuiDisabledByEnv() && seedPrompt == ""
 	if isREPL {
 		toolExecutor = tools.NewDefaultRegistry()
-		tools.SetSpawner(newAgentSpawner(a, toolExecutor, tools.DefaultTools))
+		spawner := newAgentSpawner(a, toolExecutor, tools.DefaultTools)
+		tools.SetSpawner(spawner)
+		subAgentMgr = tools.NewSubAgentManager(spawner)
 		if useTUI {
 			// bubbletea owns stdin and renders its own input; the asker and gate
 			// are wired to the TUI sink inside runTUI. No readline reader or
@@ -469,6 +472,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			// tracker / mutex-guarded state.
 			cfg.tools = tools.DefaultTools()
 			cfg.executor = toolExecutor
+			cfg.subAgentMgr = subAgentMgr
 
 			// Build the permission engine that gates every tool call.
 			cwd, _ := os.Getwd()

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -22,21 +22,22 @@ import (
 
 // replConfig holds everything runREPL needs.
 type replConfig struct {
-	a          *agent.Agent
-	session    *agent.Session
-	noSave     bool
-	plain      bool               // true → fall back to terse ↳ status lines for all tool events
-	verbosity  verbosity          // quiet | normal | verbose; controls spinner + chrome
-	permEngine *permission.Engine // nil → no tool-permission gating
-	stdin      io.Reader
-	stdout     io.Writer
-	stderr     io.Writer
-	tools      []agent.ToolDefinition
-	executor   agent.ToolExecutor
-	skillReg   *skills.Registry // discovered skills; backs /skills and /<name>
-	memStore   *memory.Store    // cross-session memory; backs /memory (nil → disabled)
-	memRefresh *memoryRefresher // live cross-session memory delta; nil → disabled
-	hooks      *hooks.Runner    // C9 Phase 3 pre/post-turn hooks; nil-safe via Configured()
+	a           *agent.Agent
+	session     *agent.Session
+	noSave      bool
+	plain       bool               // true → fall back to terse ↳ status lines for all tool events
+	verbosity   verbosity          // quiet | normal | verbose; controls spinner + chrome
+	permEngine  *permission.Engine // nil → no tool-permission gating
+	stdin       io.Reader
+	stdout      io.Writer
+	stderr      io.Writer
+	tools       []agent.ToolDefinition
+	executor    agent.ToolExecutor
+	subAgentMgr *tools.SubAgentManager // nil → sub-agent tools disabled
+	skillReg    *skills.Registry       // discovered skills; backs /skills and /<name>
+	memStore    *memory.Store          // cross-session memory; backs /memory (nil → disabled)
+	memRefresh  *memoryRefresher       // live cross-session memory delta; nil → disabled
+	hooks       *hooks.Runner          // C9 Phase 3 pre/post-turn hooks; nil-safe via Configured()
 	// reader, when non-nil, is the line reader to use instead of building
 	// one fresh inside runREPL. Set by cmd/octo so the same instance is
 	// shared with the permission gate and the ask_user_question asker.
@@ -68,6 +69,21 @@ func runREPL(cfg replConfig) int {
 	// Kill any background processes (terminal background:true) on exit so none
 	// outlive the session.
 	defer tools.KillAllBackground()
+
+	// Sub-agent manager: wire the onExit hook so completion notifications ride
+	// the same steer path as background-process notices. Register the manager
+	// globally so the built-in tools pick it up without per-instance injection.
+	if cfg.subAgentMgr != nil {
+		tools.SetDefaultSubAgentManager(cfg.subAgentMgr)
+		cfg.subAgentMgr.SetOnExit(func(ev tools.SubAgentNotification) {
+			a.Steer(formatSubAgentNote(ev))
+		})
+		defer func() {
+			cfg.subAgentMgr.SetOnExit(nil)
+			tools.SetDefaultSubAgentManager(nil)
+			cfg.subAgentMgr.KillAll()
+		}()
+	}
 
 	// Background-completion notice: inject into the conversation via Steer so
 	// the model is told when a detached command finishes (drained at the next

--- a/cmd/octo/subagent_notify.go
+++ b/cmd/octo/subagent_notify.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// formatSubAgentNote renders a sub-agent completion notification as a
+// <system-reminder> block. It rides the existing steer path (Agent.Steer →
+// folded into the next tool_result, or prepended to the next turn — see
+// turncore.go), so the model reads it as an environment event rather than
+// user speech.
+func formatSubAgentNote(ev tools.SubAgentNotification) string {
+	var b strings.Builder
+	b.WriteString("<system-reminder>\n")
+	switch ev.Kind {
+	case "spawn_done":
+		fmt.Fprintf(&b, "Sub-agent %s (%s) has completed.", ev.AgentID, ev.Description)
+	case "message_reply":
+		fmt.Fprintf(&b, "Sub-agent %s (%s) has replied to your message.", ev.AgentID, ev.Description)
+	default:
+		fmt.Fprintf(&b, "Sub-agent %s (%s) update: %s", ev.AgentID, ev.Description, ev.Kind)
+	}
+	if ev.Result != "" {
+		b.WriteString("\nResult:\n")
+		b.WriteString(ev.Result)
+	}
+	if ev.InputTokens > 0 || ev.OutputTokens > 0 {
+		fmt.Fprintf(&b, "\n[usage] in %d / out %d", ev.InputTokens, ev.OutputTokens)
+	}
+	b.WriteString("\n</system-reminder>")
+	return b.String()
+}

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -54,6 +54,22 @@ func runTUI(cfg replConfig) int {
 	}
 	tools.SetAsker(newREPLAsker(sink))
 
+	// Sub-agent manager: wire the onExit hook so completion notifications ride
+	// the same steer path as background-process notices, and send a TUI msg
+	// for scrollback display.
+	if cfg.subAgentMgr != nil {
+		tools.SetDefaultSubAgentManager(cfg.subAgentMgr)
+		cfg.subAgentMgr.SetOnExit(func(ev tools.SubAgentNotification) {
+			cfg.a.Steer(formatSubAgentNote(ev))
+			p.Send(subAgentNoteMsg{ev})
+		})
+		defer func() {
+			cfg.subAgentMgr.SetOnExit(nil)
+			tools.SetDefaultSubAgentManager(nil)
+			cfg.subAgentMgr.KillAll()
+		}()
+	}
+
 	// Background-process completion notifications. Fired from a process's
 	// waiter goroutine, so each path is goroutine-safe: Steer is mutex-guarded
 	// (folds the notice into the next tool-batch boundary or turn), and
@@ -92,8 +108,9 @@ type turnEndedMsg struct {
 }
 type turnFinishedMsg struct{ err error } // the turn goroutine returned
 type noticeMsg struct{ text string }
-type bgExitMsg struct{ e tools.BgExit } // a background process finished (async)
-type tickMsg struct{}                   // animation tick while a turn runs
+type bgExitMsg struct{ e tools.BgExit }                      // a background process finished (async)
+type subAgentNoteMsg struct{ ev tools.SubAgentNotification } // a sub-agent completed (async)
+type tickMsg struct{}                                        // animation tick while a turn runs
 type askMsg struct {
 	prompt UserPrompt
 	resp   chan UserResponse
@@ -313,6 +330,17 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// mid-turn — it's just another committed line.
 		return m, tea.Println(noticeStyle.Render(fmt.Sprintf(
 			"↳ %s (%s) %s", msg.e.ID, truncate1Line(msg.e.Command), msg.e.Status)))
+
+	case subAgentNoteMsg:
+		// Async sub-agent completion: show a one-line scrollback notice (the
+		// full result rode into the conversation via Steer). Safe to print
+		// mid-turn.
+		label := "completed"
+		if msg.ev.Kind == "message_reply" {
+			label = "replied"
+		}
+		return m, tea.Println(noticeStyle.Render(fmt.Sprintf(
+			"↳ sub-agent %s (%s) %s", msg.ev.AgentID, truncate1Line(msg.ev.Description), label)))
 
 	case turnEndedMsg:
 		// Flush any trailing assistant block (markdown-rendered); then render

--- a/dev-docs/async-subagent-design.md
+++ b/dev-docs/async-subagent-design.md
@@ -1,0 +1,426 @@
+# Async Sub-Agent Design
+
+## Status
+
+Draft — pending implementation (M10+).
+
+## Problem
+
+The current `launch_agent` tool is **synchronous**: the parent agent blocks until the sub-agent completes and returns its final reply in the tool result. This means:
+
+1. The parent cannot do other work while the sub-agent runs.
+2. The user cannot interact with the parent until the sub-agent finishes.
+3. Parallel sub-agent calls in one batch still block the parent on the slowest one.
+
+We want sub-agents to run **asynchronously** — fire-and-forget, with results delivered via notification when ready.
+
+## Goals
+
+- `launch_agent` starts a sub-agent and returns immediately with an `agent_id`.
+- `send_message` sends a message to a sub-agent and returns immediately.
+- Sub-agent results/replies are delivered asynchronously via a notification mechanism.
+- The parent agent can continue processing user input or run other tools while sub-agents work.
+- Design reuses the proven `BackgroundManager` pattern from the `terminal` tool.
+
+## Non-Goals
+
+- Sub-agents spawning sub-agents (recursion stays forbidden).
+- Persistent sub-agents across sessions (sub-agents live only within the current session).
+- Bidirectional streaming between parent and sub-agent (notifications are one-shot, not streams).
+
+## Design
+
+### Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Parent Agent (REPL session)                                │
+│                                                             │
+│  launch_agent ──► SubAgentManager.Start() ──► agent_1      │
+│       │                           │                         │
+│       │                    [goroutine]                      │
+│       │                           │                         │
+│       │                      spawner.Spawn()                │
+│       │                           │                         │
+│       │                      [sub-agent runs]               │
+│       │                           │                         │
+│       │                      onExit(notification)           │
+│       │                           │                         │
+│       │                           ▼                         │
+│       └───────────────────► injected into conversation      │
+│                                                             │
+│  send_message ──► SubAgentManager.Send() ──► agent_1       │
+│       │                           │                         │
+│       │                    [goroutine]                      │
+│       │                           │                         │
+│       │                      spawner.Continue()             │
+│       │                           │                         │
+│       │                      [sub-agent replies]            │
+│       │                           │                         │
+│       │                      onExit(notification)           │
+│       │                           │                         │
+│       │                           ▼                         │
+│       └───────────────────► injected into conversation      │
+│                                                             │
+│  agent_status(agent_1) ──► query state/result (optional)   │
+│  kill_agent(agent_1)     ──► terminate                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### SubAgentManager
+
+Analogous to `BackgroundManager` (`internal/tools/background.go`), but for sub-agents instead of shell processes.
+
+```go
+package tools
+
+// SubAgentNotification is delivered to the onExit hook when a sub-agent
+// finishes a task or replies to a message.
+type SubAgentNotification struct {
+    AgentID      string // e.g. "agent_1"
+    Description  string // human-readable label from launch_agent
+    Kind         string // "spawn_done" | "message_reply"
+    Result       string // final reply text
+    InputTokens  int
+    OutputTokens int
+}
+
+// SubAgentManager owns the set of async sub-agents for a session.
+type SubAgentManager struct {
+    mu     sync.Mutex
+    agents map[string]*asyncSubAgent
+    seq    int
+    spawner Spawner
+    onExit func(SubAgentNotification)
+}
+
+type asyncSubAgent struct {
+    id          string
+    description string
+    cancel      context.CancelFunc
+    start       time.Time
+
+    mu       sync.Mutex
+    busy     bool        // true while processing a Spawn or Continue
+    result   string      // latest result
+    done     bool        // true if the sub-agent has exited
+    exitErr  error
+    inputTokens  int
+    outputTokens int
+}
+```
+
+Key methods:
+
+```go
+// Start creates a new sub-agent and runs it asynchronously.
+// Returns the agent_id immediately; result arrives via onExit.
+func (m *SubAgentManager) Start(req SpawnRequest) (string, error)
+
+// Send sends a message to an existing sub-agent asynchronously.
+// Returns immediately; reply arrives via onExit.
+func (m *SubAgentManager) Send(agentID, message string) error
+
+// Read returns the latest result/status for an agent.
+func (m *SubAgentManager) Read(id string) (result, status string, found bool)
+
+// Kill terminates a sub-agent.
+func (m *SubAgentManager) Kill(id string) bool
+
+// ListRunning returns agents that haven't exited yet.
+func (m *SubAgentManager) ListRunning() []SubAgentInfo
+```
+
+### Tool Changes
+
+#### `launch_agent` — always async
+
+Remove the synchronous path. `Execute` always calls `mgr.Start()` and returns immediately.
+
+```go
+func (LaunchAgentTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+    // ... validation ...
+    id, err := mgr.Start(SpawnRequest{...})
+    if err != nil { return ..., err }
+    return agent.ToolResult{
+        Text: fmt.Sprintf("Started sub-agent %s. You will be notified when it completes.", id),
+    }, nil
+}
+```
+
+LLM-facing description:
+
+```
+Spawn an autonomous sub-agent to handle a focused sub-task.
+The sub-agent starts immediately and runs in the background.
+You will receive its result via a system notification when it completes.
+While the sub-agent runs, you can continue with other tasks.
+```
+
+#### `send_message` — always async
+
+Same pattern: send and forget, reply arrives via notification.
+
+```go
+func (SendMessageTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+    // ... validation ...
+    err := mgr.Send(agentID, message)
+    if err != nil { return ..., err }
+    return agent.ToolResult{
+        Text: fmt.Sprintf("Message sent to %s. You will be notified when it replies.", agentID),
+    }, nil
+}
+```
+
+LLM-facing description:
+
+```
+Send a message to a sub-agent you previously started with launch_agent.
+The message is delivered asynchronously; you will receive the reply via
+a system notification when the sub-agent responds.
+```
+
+#### `agent_status` — new tool
+
+Query the state of an async sub-agent. Optional — LLM should not poll.
+
+```go
+type AgentStatusTool struct{}
+
+func (AgentStatusTool) Definition() agent.ToolDefinition {
+    return agent.ToolDefinition{
+        Name: "agent_status",
+        Description: "Read the current status and latest result from a sub-agent. " +
+            "You do NOT need to poll this tool. Sub-agent results are delivered " +
+            "automatically via notification when ready. Only use this if you need " +
+            "to check progress mid-run or if the user explicitly asks.",
+        Parameters: map[string]any{
+            "type": "object",
+            "properties": map[string]any{
+                "agent_id": map[string]any{
+                    "type":        "string",
+                    "description": "The sub-agent id (e.g. \"agent_1\").",
+                },
+            },
+            "required": []string{"agent_id"},
+        },
+    }
+}
+```
+
+#### `kill_agent` — new tool
+
+Terminate a running sub-agent.
+
+```go
+type KillAgentTool struct{}
+
+func (KillAgentTool) Definition() agent.ToolDefinition {
+    return agent.ToolDefinition{
+        Name: "kill_agent",
+        Description: "Terminate a sub-agent started by launch_agent and return its final result (if any).",
+        Parameters: map[string]any{
+            "type": "object",
+            "properties": map[string]any{
+                "agent_id": map[string]any{
+                    "type":        "string",
+                    "description": "The sub-agent id to terminate (e.g. \"agent_1\").",
+                },
+            },
+            "required": []string{"agent_id"},
+        },
+    }
+}
+```
+
+### Notification Delivery
+
+When a sub-agent completes (Spawn or Continue), the `SubAgentManager` fires the `onExit` hook. The REPL wires this hook to inject a system message into the conversation.
+
+```go
+// In cmd/octo REPL setup:
+subAgentMgr := tools.NewSubAgentManager(spawner)
+subAgentMgr.SetOnExit(func(ev tools.SubAgentNotification) {
+    // Format: "[agent agent_1] Task completed: <result>"
+    // or:     "[agent agent_1] Reply: <result>"
+    msg := formatSubAgentNotification(ev)
+    repl.injectSystemMessage(msg)
+})
+```
+
+The injected message becomes part of the conversation history. On the next LLM call, the model sees the notification and can act on it.
+
+**Open question**: If the parent is idle (no active LLM call) when the notification arrives, how is the next turn triggered?
+
+Options:
+1. **Steer queue**: Push into the existing steer mechanism. The next user message or auto-triggered turn will pick it up.
+2. **Auto-trigger**: The REPL automatically starts a new LLM turn when a notification arrives while idle. This may be surprising — the agent would "speak up" unprompted.
+3. **Hybrid**: Notifications accumulate in a queue. The REPL shows a "N pending notifications" indicator. The user can ask "what's new?" or the next natural turn processes them.
+
+**Recommendation**: Start with option 1 (steer queue). It reuses existing machinery and doesn't introduce unprompted agent speech. Evaluate option 3 if the UX feels laggy.
+
+### Concurrency Model
+
+A sub-agent can only process **one request at a time** (one Spawn or one Continue). If `Send()` is called while the sub-agent is `busy`:
+
+- **Queue the message** (preferred): Store it and send after current processing completes.
+- **Return error**: Tell the LLM "agent_1 is busy, try again later."
+
+Recommendation: **Queue with a small buffer** (e.g., 1 pending message). If the queue is full, return an error. This lets the LLM pipeline a follow-up message without waiting for the first reply.
+
+```go
+func (m *SubAgentManager) Send(agentID, message string) error {
+    // ... find agent ...
+    agent.mu.Lock()
+    if agent.busy {
+        if agent.pending != "" {
+            agent.mu.Unlock()
+            return fmt.Errorf("agent %s: already has a pending message", agentID)
+        }
+        agent.pending = message
+        agent.mu.Unlock()
+        return nil // queued, will be sent when current processing done
+    }
+    agent.busy = true
+    agent.mu.Unlock()
+    // ... start goroutine for Continue ...
+}
+```
+
+### State Transitions
+
+```
+                    launch_agent
+                         │
+                         ▼
+                   ┌──────────┐
+                   │  idle    │◄─────────────────┐
+                   │ (ready)  │                  │
+                   └────┬─────┘                  │
+                        │ send_message            │
+                        │ or pending dequeued     │
+                        ▼                         │
+                   ┌──────────┐                   │
+         ┌────────►│  busy    │──────┐            │
+         │         │(processing)     │            │
+         │         └──────────┘      │ onExit     │
+         │                │          │            │
+    kill_agent            │          ▼            │
+         │                │    ┌──────────┐       │
+         │                └───►│  done    │───────┘
+         │                     │(result   │   new send_message
+         └────────────────────►│ available)│   (if not killed)
+                               └──────────┘
+```
+
+### LLM Prompt Updates
+
+Add to the base prompt (`internal/prompt/base.md`):
+
+```markdown
+## Sub-Agent Async Model
+
+When you use `launch_agent`, the sub-agent runs in the background. You will
+NOT receive its result immediately. Instead, the system will automatically
+notify you when the sub-agent completes, carrying its final result.
+
+Similarly, `send_message` delivers your message asynchronously. The sub-agent's
+reply will arrive via notification.
+
+While sub-agents run, you can:
+- Continue answering the user's other questions
+- Launch more sub-agents
+- Run other tools
+
+Do NOT call `agent_status` to poll for results. Only use `agent_status` if:
+- The user explicitly asks for a status update
+- You need to check progress mid-run before deciding next steps
+
+Notifications appear as system messages in your context, prefixed with
+`[agent <id>]`. You can reference the agent id in follow-up `send_message`
+calls.
+```
+
+## Implementation Plan
+
+### Phase 1: Core Infrastructure
+
+1. **Create `internal/tools/subagent_manager.go`**
+   - `SubAgentManager` struct and methods
+   - `asyncSubAgent` internal state machine
+   - `SubAgentNotification` and `SubAgentInfo` types
+   - Unit tests with mock spawner
+
+2. **Modify `internal/tools/launch_agent.go`**
+   - Add `mgr *SubAgentManager` field to `LaunchAgentTool`
+   - Change `Execute` to always call `mgr.Start()`
+   - Update `Definition` description for async semantics
+   - Update tests
+
+3. **Modify `internal/tools/send_message.go`**
+   - Add `mgr *SubAgentManager` field to `SendMessageTool`
+   - Change `Execute` to call `mgr.Send()`
+   - Update `Definition` description
+   - Update tests
+
+### Phase 2: New Tools
+
+4. **Create `internal/tools/agent_status.go`**
+   - `AgentStatusTool` implementation
+   - Tests
+
+5. **Create `internal/tools/kill_agent.go`**
+   - `KillAgentTool` implementation
+   - Tests
+
+### Phase 3: Integration
+
+6. **Modify `cmd/octo/chat.go` (or REPL setup)**
+   - Initialize `SubAgentManager` with the real spawner
+   - Wire `onExit` hook to inject notifications into conversation
+   - Pass manager to tool constructors
+
+7. **Modify `internal/tools/registry.go`**
+   - Register new tools
+   - Wire `SubAgentManager` into `LaunchAgentTool` and `SendMessageTool`
+
+8. **Update `internal/prompt/base.md`**
+   - Add sub-agent async model section
+
+### Phase 4: Validation
+
+9. **Integration tests**
+   - Launch async sub-agent, verify immediate return
+   - Verify notification delivery on completion
+   - Send message to running sub-agent, verify async reply
+   - Kill sub-agent mid-run
+
+10. **Manual REPL testing**
+    - Launch multiple sub-agents in one batch
+    - Interact with user while sub-agents run
+    - Verify notifications appear in subsequent turns
+
+## Backwards Compatibility
+
+This is a **breaking change** to `launch_agent` and `send_message` semantics:
+
+- Existing prompts that expect synchronous sub-agent results will break.
+- The tool schema changes (no `background` param, but behavior changes).
+- The LLM must be re-prompted with the async model.
+
+Mitigation:
+- Clear documentation in the prompt.
+- The `agent_status` tool provides an escape hatch for code that needs to wait.
+
+## Open Questions
+
+1. **Notification auto-trigger**: Should the REPL automatically start a new LLM turn when a notification arrives while idle? (Currently: no, use steer queue.)
+2. **Message queue depth**: How many pending messages per sub-agent? (Currently: 1.)
+3. **Sub-agent timeout**: Should async sub-agents have a global timeout? (Currently: no, rely on spawner/implementation.)
+4. **Result retention**: How long to keep sub-agent results after delivery? (Currently: until session end or `kill_agent`.)
+
+## Related Work
+
+- `internal/tools/background.go` — `BackgroundManager` pattern (direct model).
+- `internal/taskgraph/` — DAG scheduler for `octo task` (separate concern, but shares the async execution concept).
+- `dev-docs/tui-input-modes-design.md` — steer mechanism for mid-turn injection.

--- a/internal/tools/agent_status.go
+++ b/internal/tools/agent_status.go
@@ -1,0 +1,70 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// AgentStatusTool queries the state and latest result of a sub-agent previously
+// started with launch_agent. It is synchronous — the result is returned
+// immediately, not via notification.
+type AgentStatusTool struct {
+	mgr *SubAgentManager
+}
+
+func (t AgentStatusTool) manager() *SubAgentManager {
+	if t.mgr != nil {
+		return t.mgr
+	}
+	return defaultSubAgentMgr
+}
+
+func (AgentStatusTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "agent_status",
+		Description: "Check the status and latest result of a sub-agent you started with launch_agent. " +
+			"Returns whether it is running, idle, or exited, along with its most recent output. " +
+			"Use this when you want to poll a sub-agent's progress or read its result without waiting for a notification.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"agent_id": map[string]any{
+					"type":        "string",
+					"description": "Id of the sub-agent to query, as returned by launch_agent (e.g. 'agent_1').",
+				},
+			},
+			"required": []string{"agent_id"},
+		},
+	}
+}
+
+func (t AgentStatusTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	if IsSubAgent(ctx) {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("agent_status: a sub-agent cannot query another sub-agent")
+	}
+
+	agentID := strings.TrimSpace(stringArg(input, "agent_id"))
+	if agentID == "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("agent_status: agent_id is required")
+	}
+
+	mgr := t.manager()
+	if mgr == nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("agent_status: sub-agent dispatch is not configured for this session")
+	}
+
+	result, status, found := mgr.Read(agentID)
+	if !found {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("agent_status: no sub-agent %q", agentID)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Status: %s\n", status)
+	if result != "" {
+		fmt.Fprintf(&sb, "Latest result:\n%s", result)
+	}
+	return agent.ToolResult{Text: sb.String()}, nil
+}

--- a/internal/tools/agent_status_test.go
+++ b/internal/tools/agent_status_test.go
@@ -1,0 +1,111 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAgentStatusTool_Schema(t *testing.T) {
+	def := AgentStatusTool{}.Definition()
+	if def.Name != "agent_status" {
+		t.Errorf("Name = %q", def.Name)
+	}
+	props, _ := def.Parameters["properties"].(map[string]any)
+	if _, ok := props["agent_id"]; !ok {
+		t.Error("schema missing property agent_id")
+	}
+	required, _ := def.Parameters["required"].([]string)
+	if !containsString(required, "agent_id") {
+		t.Errorf("agent_id should be required, got %v", required)
+	}
+}
+
+func TestAgentStatusTool_Execute(t *testing.T) {
+	stub := &stubSpawner{replies: []SpawnResult{{Reply: "the result", AgentID: "a1"}}}
+	mgr := NewSubAgentManager(stub)
+
+	id, err := mgr.Start(SpawnRequest{Description: "d", Prompt: "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	out, err := AgentStatusTool{mgr: mgr}.Execute(context.Background(), "agent_status", map[string]any{
+		"agent_id": id,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Text, "Status: idle") {
+		t.Errorf("expected idle status, got %q", out.Text)
+	}
+	if !strings.Contains(out.Text, "the result") {
+		t.Errorf("expected result text, got %q", out.Text)
+	}
+}
+
+func TestAgentStatusTool_UnknownAgent(t *testing.T) {
+	stub := &stubSpawner{}
+	mgr := NewSubAgentManager(stub)
+
+	_, err := AgentStatusTool{mgr: mgr}.Execute(context.Background(), "agent_status", map[string]any{
+		"agent_id": "agent_999",
+	})
+	if err == nil || !strings.Contains(err.Error(), "no sub-agent") {
+		t.Errorf("expected 'no sub-agent' error, got %v", err)
+	}
+}
+
+func TestAgentStatusTool_RequiredArgs(t *testing.T) {
+	stub := &stubSpawner{}
+	mgr := NewSubAgentManager(stub)
+	_, err := AgentStatusTool{mgr: mgr}.Execute(context.Background(), "agent_status", map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "agent_id is required") {
+		t.Errorf("expected 'agent_id is required' error, got %v", err)
+	}
+}
+
+func TestAgentStatusTool_NoManagerConfigured(t *testing.T) {
+	_, err := AgentStatusTool{}.Execute(context.Background(), "agent_status", map[string]any{
+		"agent_id": "id",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("expected 'not configured' error, got %v", err)
+	}
+}
+
+func TestAgentStatusTool_RecursionRefused(t *testing.T) {
+	stub := &stubSpawner{}
+	mgr := NewSubAgentManager(stub)
+	ctx := WithSubAgentMarker(context.Background())
+	_, err := AgentStatusTool{mgr: mgr}.Execute(ctx, "agent_status", map[string]any{
+		"agent_id": "id",
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot query another sub-agent") {
+		t.Errorf("expected recursion refusal, got %v", err)
+	}
+}
+
+func TestDefaultTools_AgentStatusGatedOnManager(t *testing.T) {
+	SetDefaultSubAgentManager(nil)
+	t.Cleanup(func() { SetDefaultSubAgentManager(nil) })
+
+	has := func() bool {
+		for _, d := range DefaultTools() {
+			if d.Name == "agent_status" {
+				return true
+			}
+		}
+		return false
+	}
+
+	if has() {
+		t.Error("agent_status should be absent when no SubAgentManager is configured")
+	}
+	SetDefaultSubAgentManager(NewSubAgentManager(&stubSpawner{}))
+	if !has() {
+		t.Error("agent_status should be present once a SubAgentManager is registered")
+	}
+}

--- a/internal/tools/kill_agent.go
+++ b/internal/tools/kill_agent.go
@@ -1,0 +1,64 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// KillAgentTool terminates a running sub-agent. The sub-agent's context is
+// cancelled and it is marked as exited. Any pending message is dropped.
+type KillAgentTool struct {
+	mgr *SubAgentManager
+}
+
+func (t KillAgentTool) manager() *SubAgentManager {
+	if t.mgr != nil {
+		return t.mgr
+	}
+	return defaultSubAgentMgr
+}
+
+func (KillAgentTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "kill_agent",
+		Description: "Terminate a sub-agent you previously started with launch_agent. " +
+			"Use this when a sub-agent is stuck, no longer needed, or you want to free resources. " +
+			"The sub-agent's context is cancelled and it is marked as exited.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"agent_id": map[string]any{
+					"type":        "string",
+					"description": "Id of the sub-agent to kill, as returned by launch_agent (e.g. 'agent_1').",
+				},
+			},
+			"required": []string{"agent_id"},
+		},
+	}
+}
+
+func (t KillAgentTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	if IsSubAgent(ctx) {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("kill_agent: a sub-agent cannot kill another sub-agent")
+	}
+
+	agentID := strings.TrimSpace(stringArg(input, "agent_id"))
+	if agentID == "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("kill_agent: agent_id is required")
+	}
+
+	mgr := t.manager()
+	if mgr == nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("kill_agent: sub-agent dispatch is not configured for this session")
+	}
+
+	if !mgr.Kill(agentID) {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("kill_agent: no sub-agent %q", agentID)
+	}
+	return agent.ToolResult{
+		Text: fmt.Sprintf("Sub-agent %s has been terminated.", agentID),
+	}, nil
+}

--- a/internal/tools/kill_agent_test.go
+++ b/internal/tools/kill_agent_test.go
@@ -1,0 +1,114 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestKillAgentTool_Schema(t *testing.T) {
+	def := KillAgentTool{}.Definition()
+	if def.Name != "kill_agent" {
+		t.Errorf("Name = %q", def.Name)
+	}
+	props, _ := def.Parameters["properties"].(map[string]any)
+	if _, ok := props["agent_id"]; !ok {
+		t.Error("schema missing property agent_id")
+	}
+	required, _ := def.Parameters["required"].([]string)
+	if !containsString(required, "agent_id") {
+		t.Errorf("agent_id should be required, got %v", required)
+	}
+}
+
+func TestKillAgentTool_Execute(t *testing.T) {
+	stub := &stubSpawner{replies: []SpawnResult{{Reply: "never"}}}
+	mgr := NewSubAgentManager(stub)
+
+	id, err := mgr.Start(SpawnRequest{Description: "d", Prompt: "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	out, err := KillAgentTool{mgr: mgr}.Execute(context.Background(), "kill_agent", map[string]any{
+		"agent_id": id,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Text, "terminated") {
+		t.Errorf("expected termination message, got %q", out.Text)
+	}
+
+	// Verify it's actually exited.
+	_, status, _ := mgr.Read(id)
+	if !strings.Contains(status, "exited") {
+		t.Errorf("expected exited status, got %q", status)
+	}
+}
+
+func TestKillAgentTool_UnknownAgent(t *testing.T) {
+	stub := &stubSpawner{}
+	mgr := NewSubAgentManager(stub)
+
+	_, err := KillAgentTool{mgr: mgr}.Execute(context.Background(), "kill_agent", map[string]any{
+		"agent_id": "agent_999",
+	})
+	if err == nil || !strings.Contains(err.Error(), "no sub-agent") {
+		t.Errorf("expected 'no sub-agent' error, got %v", err)
+	}
+}
+
+func TestKillAgentTool_RequiredArgs(t *testing.T) {
+	stub := &stubSpawner{}
+	mgr := NewSubAgentManager(stub)
+	_, err := KillAgentTool{mgr: mgr}.Execute(context.Background(), "kill_agent", map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "agent_id is required") {
+		t.Errorf("expected 'agent_id is required' error, got %v", err)
+	}
+}
+
+func TestKillAgentTool_NoManagerConfigured(t *testing.T) {
+	_, err := KillAgentTool{}.Execute(context.Background(), "kill_agent", map[string]any{
+		"agent_id": "id",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("expected 'not configured' error, got %v", err)
+	}
+}
+
+func TestKillAgentTool_RecursionRefused(t *testing.T) {
+	stub := &stubSpawner{}
+	mgr := NewSubAgentManager(stub)
+	ctx := WithSubAgentMarker(context.Background())
+	_, err := KillAgentTool{mgr: mgr}.Execute(ctx, "kill_agent", map[string]any{
+		"agent_id": "id",
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot kill another sub-agent") {
+		t.Errorf("expected recursion refusal, got %v", err)
+	}
+}
+
+func TestDefaultTools_KillAgentGatedOnManager(t *testing.T) {
+	SetDefaultSubAgentManager(nil)
+	t.Cleanup(func() { SetDefaultSubAgentManager(nil) })
+
+	has := func() bool {
+		for _, d := range DefaultTools() {
+			if d.Name == "kill_agent" {
+				return true
+			}
+		}
+		return false
+	}
+
+	if has() {
+		t.Error("kill_agent should be absent when no SubAgentManager is configured")
+	}
+	SetDefaultSubAgentManager(NewSubAgentManager(&stubSpawner{}))
+	if !has() {
+		t.Error("kill_agent should be present once a SubAgentManager is registered")
+	}
+}

--- a/internal/tools/launch_agent.go
+++ b/internal/tools/launch_agent.go
@@ -79,6 +79,10 @@ func ActiveSpawner() Spawner { return activeSpawner }
 
 func spawnerEnabled() bool { return activeSpawner != nil }
 
+// subAgentManagerEnabled reports whether a SubAgentManager is registered,
+// which is required for the async launch_agent / send_agent_message tools.
+func subAgentManagerEnabled() bool { return defaultSubAgentMgr != nil }
+
 // subAgentCtxKey marks a context as belonging to a sub-agent's run. The
 // launch_agent tool checks for it to refuse recursive nesting (a sub-agent
 // trying to spawn another sub-agent), defense-in-depth on top of the
@@ -105,20 +109,34 @@ func IsSubAgent(ctx context.Context) bool {
 // — name borrowed from Claude Code's `Agent` tool but the surface is closer
 // to Codex's sub-agent (no event stream surfaced to the parent, just a
 // final string).
-type LaunchAgentTool struct{}
+//
+// The spawn is asynchronous: Execute returns immediately with a "started"
+// message; the result arrives later via the SubAgentManager's onExit hook
+// as a SubAgentNotification.
+type LaunchAgentTool struct {
+	mgr *SubAgentManager
+}
+
+func (t LaunchAgentTool) manager() *SubAgentManager {
+	if t.mgr != nil {
+		return t.mgr
+	}
+	return defaultSubAgentMgr
+}
 
 func (LaunchAgentTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name: "launch_agent",
-		Description: "Spawn an autonomous sub-agent to handle a focused sub-task and " +
-			"return its final answer. Use when you need parallel investigation (research two " +
-			"unrelated areas in one tool_use), when you want a fresh context window for an " +
-			"isolated sub-problem (the sub-agent doesn't see this conversation), or when the " +
-			"sub-task is well-defined enough to delegate without back-and-forth. The sub-agent " +
-			"has the same tools as you (minus launch_agent itself — no recursion) and reports " +
-			"a single text reply when done. Multiple launch_agent calls in one tool_use batch " +
-			"run in parallel. Don't use for tasks that need ongoing user steering or that " +
-			"depend on what's in this conversation.",
+		Description: "Spawn an autonomous sub-agent to handle a focused sub-task. " +
+			"The sub-agent runs asynchronously: you will receive a notification with its " +
+			"final answer when it completes. Use when you need parallel investigation " +
+			"(research two unrelated areas in one tool_use), when you want a fresh context " +
+			"window for an isolated sub-problem (the sub-agent doesn't see this conversation), " +
+			"or when the sub-task is well-defined enough to delegate without back-and-forth. " +
+			"The sub-agent has the same tools as you (minus launch_agent itself — no recursion). " +
+			"Multiple launch_agent calls in one tool_use batch run in parallel. " +
+			"Don't use for tasks that need ongoing user steering or that depend on " +
+			"what's in this conversation.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -145,10 +163,7 @@ func (LaunchAgentTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (LaunchAgentTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
-	if !spawnerEnabled() {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("launch_agent: sub-agent dispatch is not configured for this session")
-	}
+func (t LaunchAgentTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	if IsSubAgent(ctx) {
 		// Defense in depth — the Spawner is supposed to filter launch_agent
 		// out of a child's tool list, but a hallucinated tool call would
@@ -167,24 +182,24 @@ func (LaunchAgentTool) Execute(ctx context.Context, _ string, input map[string]a
 		desc = firstLine(prompt)
 	}
 
+	mgr := t.manager()
+	if mgr == nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("launch_agent: sub-agent dispatch is not configured for this session")
+	}
+
 	req := SpawnRequest{
 		Description: desc,
 		Prompt:      prompt,
 		Tools:       stringSliceArg(input, "tools"),
 		Model:       strings.TrimSpace(stringArg(input, "model")),
 	}
-	res, err := activeSpawner.Spawn(ctx, req)
+	id, err := mgr.Start(req)
 	if err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("launch_agent: %w", err)
 	}
-	reply := strings.TrimSpace(res.Reply)
-	if reply == "" {
-		// A sub-agent that ended with no final text isn't fatal — it just
-		// has nothing to say. Surface that explicitly so the parent doesn't
-		// guess.
-		return agent.ToolResult{Text: "(sub-agent " + desc + " produced no reply)"}, nil
-	}
-	return agent.ToolResult{Text: withAgentTag(res.AgentID, reply)}, nil
+	return agent.ToolResult{
+		Text: fmt.Sprintf("Started sub-agent %s. You will be notified when it completes.", id),
+	}, nil
 }
 
 // stringSliceArg pulls an []string argument tolerating absence and the JSON

--- a/internal/tools/launch_agent_test.go
+++ b/internal/tools/launch_agent_test.go
@@ -26,6 +26,10 @@ type stubSpawner struct {
 	continueErr   error
 	contAgentID   string
 	contMessage   string
+	contCalled    chan struct{} // closed on first Continue call; safe to recreate per test
+
+	// Spawn support (for async tests).
+	spawnCalled chan struct{} // closed on first Spawn call; safe to recreate per test
 }
 
 func (s *stubSpawner) Spawn(_ context.Context, req SpawnRequest) (SpawnResult, error) {
@@ -39,6 +43,10 @@ func (s *stubSpawner) Spawn(_ context.Context, req SpawnRequest) (SpawnResult, e
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.calls = append(s.calls, req)
+	if s.spawnCalled != nil {
+		close(s.spawnCalled)
+		s.spawnCalled = nil
+	}
 	if len(s.replies) == 0 {
 		return SpawnResult{}, nil
 	}
@@ -53,6 +61,10 @@ func (s *stubSpawner) Continue(_ context.Context, agentID, message string) (Spaw
 	defer s.mu.Unlock()
 	s.contAgentID = agentID
 	s.contMessage = message
+	if s.contCalled != nil {
+		close(s.contCalled)
+		s.contCalled = nil
+	}
 	if s.continueErr != nil {
 		return SpawnResult{}, s.continueErr
 	}
@@ -83,27 +95,32 @@ func TestLaunchAgentTool_Schema(t *testing.T) {
 }
 
 func TestLaunchAgentTool_Execute(t *testing.T) {
-	useSpawner(t, &stubSpawner{
+	stub := &stubSpawner{
 		replies: []SpawnResult{{Reply: "sub-agent finding", InputTokens: 100, OutputTokens: 50}},
-	})
+	}
+	mgr := NewSubAgentManager(stub)
 
-	out, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+	out, err := LaunchAgentTool{mgr: mgr}.Execute(context.Background(), "launch_agent", map[string]any{
 		"description": "Investigate X",
 		"prompt":      "Find every reference to FooBar.",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out.Text != "sub-agent finding" {
-		t.Errorf("Execute returned %q, want %q", out.Text, "sub-agent finding")
+	if !strings.Contains(out.Text, "Started sub-agent") {
+		t.Errorf("Execute returned %q, want 'Started sub-agent' prefix", out.Text)
 	}
 }
 
 func TestLaunchAgentTool_PassesArgsThroughToSpawner(t *testing.T) {
-	stub := &stubSpawner{replies: []SpawnResult{{Reply: "ok"}}}
-	useSpawner(t, stub)
+	spawnCalled := make(chan struct{})
+	stub := &stubSpawner{
+		replies:     []SpawnResult{{Reply: "ok"}},
+		spawnCalled: spawnCalled,
+	}
+	mgr := NewSubAgentManager(stub)
 
-	_, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+	_, err := LaunchAgentTool{mgr: mgr}.Execute(context.Background(), "launch_agent", map[string]any{
 		"description": "Audit",
 		"prompt":      "Run a security audit.",
 		"tools":       []any{"read_file", "grep"},
@@ -112,6 +129,14 @@ func TestLaunchAgentTool_PassesArgsThroughToSpawner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Wait for the async Spawn goroutine to reach the spawner.
+	select {
+	case <-spawnCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Spawn to be called")
+	}
+
 	if len(stub.calls) != 1 {
 		t.Fatalf("expected 1 spawner call, got %d", len(stub.calls))
 	}
@@ -125,14 +150,28 @@ func TestLaunchAgentTool_PassesArgsThroughToSpawner(t *testing.T) {
 }
 
 func TestLaunchAgentTool_DescriptionDefaultsFromPrompt(t *testing.T) {
-	stub := &stubSpawner{replies: []SpawnResult{{Reply: "ok"}}}
-	useSpawner(t, stub)
+	spawnCalled := make(chan struct{})
+	stub := &stubSpawner{
+		replies:     []SpawnResult{{Reply: "ok"}},
+		spawnCalled: spawnCalled,
+	}
+	mgr := NewSubAgentManager(stub)
 
-	_, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+	_, err := LaunchAgentTool{mgr: mgr}.Execute(context.Background(), "launch_agent", map[string]any{
 		"prompt": "Examine the cache invalidation logic.\nReport back.",
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	select {
+	case <-spawnCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Spawn to be called")
+	}
+
+	if len(stub.calls) == 0 {
+		t.Fatal("expected at least 1 spawner call")
 	}
 	if stub.calls[0].Description == "" {
 		t.Error("missing description should fall back to first prompt line")
@@ -140,11 +179,12 @@ func TestLaunchAgentTool_DescriptionDefaultsFromPrompt(t *testing.T) {
 }
 
 func TestLaunchAgentTool_RecursionRefused(t *testing.T) {
-	useSpawner(t, &stubSpawner{replies: []SpawnResult{{Reply: "would have worked"}}})
+	stub := &stubSpawner{replies: []SpawnResult{{Reply: "would have worked"}}}
+	mgr := NewSubAgentManager(stub)
 
 	// Mark the context as already inside a sub-agent.
 	ctx := WithSubAgentMarker(context.Background())
-	_, err := LaunchAgentTool{}.Execute(ctx, "launch_agent", map[string]any{
+	_, err := LaunchAgentTool{mgr: mgr}.Execute(ctx, "launch_agent", map[string]any{
 		"description": "x",
 		"prompt":      "y",
 	})
@@ -153,8 +193,7 @@ func TestLaunchAgentTool_RecursionRefused(t *testing.T) {
 	}
 }
 
-func TestLaunchAgentTool_NoSpawnerConfigured(t *testing.T) {
-	SetSpawner(nil)
+func TestLaunchAgentTool_NoManagerConfigured(t *testing.T) {
 	_, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
 		"description": "x",
 		"prompt":      "y",
@@ -165,8 +204,9 @@ func TestLaunchAgentTool_NoSpawnerConfigured(t *testing.T) {
 }
 
 func TestLaunchAgentTool_PromptRequired(t *testing.T) {
-	useSpawner(t, &stubSpawner{})
-	_, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+	stub := &stubSpawner{}
+	mgr := NewSubAgentManager(stub)
+	_, err := LaunchAgentTool{mgr: mgr}.Execute(context.Background(), "launch_agent", map[string]any{
 		"description": "x",
 	})
 	if err == nil || !strings.Contains(err.Error(), "prompt is required") {
@@ -174,35 +214,81 @@ func TestLaunchAgentTool_PromptRequired(t *testing.T) {
 	}
 }
 
-func TestLaunchAgentTool_EmptyReplySurfacedExplicitly(t *testing.T) {
-	useSpawner(t, &stubSpawner{replies: []SpawnResult{{Reply: "   "}}})
+func TestLaunchAgentTool_EmptyReplyNotification(t *testing.T) {
+	stub := &stubSpawner{replies: []SpawnResult{{Reply: "   "}}}
+	mgr := NewSubAgentManager(stub)
 
-	out, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+	var notif SubAgentNotification
+	done := make(chan struct{})
+	mgr.SetOnExit(func(ev SubAgentNotification) {
+		notif = ev
+		close(done)
+	})
+
+	out, err := LaunchAgentTool{mgr: mgr}.Execute(context.Background(), "launch_agent", map[string]any{
 		"description": "silent run",
 		"prompt":      "do nothing",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out.Text, "produced no reply") {
-		t.Errorf("empty reply should be surfaced explicitly, got %q", out.Text)
+	if !strings.Contains(out.Text, "Started sub-agent") {
+		t.Errorf("expected 'Started sub-agent' message, got %q", out.Text)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for notification")
+	}
+
+	// Empty reply should still produce a notification (with empty or whitespace result).
+	if notif.AgentID == "" {
+		t.Error("expected non-empty AgentID in notification")
+	}
+	if notif.Kind != "spawn_done" {
+		t.Errorf("Kind = %q, want spawn_done", notif.Kind)
 	}
 }
 
 func TestLaunchAgentTool_SpawnerErrorPropagates(t *testing.T) {
-	useSpawner(t, &stubSpawner{err: errors.New("provider unreachable")})
-	_, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
+	stub := &stubSpawner{err: errors.New("provider unreachable")}
+	mgr := NewSubAgentManager(stub)
+
+	var notif SubAgentNotification
+	done := make(chan struct{})
+	mgr.SetOnExit(func(ev SubAgentNotification) {
+		notif = ev
+		close(done)
+	})
+
+	_, err := LaunchAgentTool{mgr: mgr}.Execute(context.Background(), "launch_agent", map[string]any{
 		"description": "x",
 		"prompt":      "y",
 	})
-	if err == nil || !strings.Contains(err.Error(), "provider unreachable") {
-		t.Errorf("expected propagated spawner error, got %v", err)
+	// Execute returns immediately (async); error arrives via notification.
+	if err != nil {
+		t.Fatalf("Execute should not error for async spawn, got %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for error notification")
+	}
+
+	if !strings.Contains(notif.Result, "provider unreachable") {
+		t.Errorf("expected error notification containing 'provider unreachable', got %q", notif.Result)
 	}
 }
 
 func TestDefaultTools_LaunchAgentGatedOnSpawner(t *testing.T) {
 	SetSpawner(nil)
-	t.Cleanup(func() { SetSpawner(nil) })
+	SetDefaultSubAgentManager(nil)
+	t.Cleanup(func() {
+		SetSpawner(nil)
+		SetDefaultSubAgentManager(nil)
+	})
 
 	has := func() bool {
 		for _, d := range DefaultTools() {
@@ -214,11 +300,18 @@ func TestDefaultTools_LaunchAgentGatedOnSpawner(t *testing.T) {
 	}
 
 	if has() {
-		t.Error("launch_agent should be absent when no spawner is configured")
+		t.Error("launch_agent should be absent when no spawner/manager is configured")
 	}
+	// Registering a spawner should NOT make launch_agent appear anymore —
+	// it needs a SubAgentManager instead.
 	useSpawner(t, &stubSpawner{})
+	if has() {
+		t.Error("launch_agent should still be absent with only spawner (needs SubAgentManager)")
+	}
+	// Registering the manager makes it appear.
+	SetDefaultSubAgentManager(NewSubAgentManager(&stubSpawner{}))
 	if !has() {
-		t.Error("launch_agent should be present once a spawner is registered")
+		t.Error("launch_agent should be present once a SubAgentManager is registered")
 	}
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -36,6 +36,8 @@ var allTools = []tool{
 	RememberTool{},
 	LaunchAgentTool{},
 	SendMessageTool{},
+	AgentStatusTool{},
+	KillAgentTool{},
 	AskUserQuestionTool{},
 	TaskCreateTool{},
 	TaskUpdateTool{},
@@ -196,13 +198,13 @@ func tokenizeCommand(s string) []string {
 // DefaultTools returns the slice of ToolDefinitions sent to the LLM when
 // `--tools` is on. Order matches allTools. Each capability-gated tool is
 // withheld unless the corresponding registration call has been made —
-// SkillTool needs SetSkills, RememberTool needs SetMemoryStore, LaunchAgentTool
-// needs SetSpawner. Advertising a tool that can only error wastes a slot and
-// confuses the model.
+// SkillTool needs SetSkills, RememberTool needs SetMemoryStore, sub-agent
+// tools need a SubAgentManager. Advertising a tool that can only error wastes
+// a slot and confuses the model.
 func DefaultTools() []agent.ToolDefinition {
 	skillsOn := skillsEnabled()
 	memoryOn := memoryEnabled()
-	spawnerOn := spawnerEnabled()
+	mgrOn := subAgentManagerEnabled()
 	askerOn := askerEnabled()
 	tasksOn := tasksEnabled()
 	defs := make([]agent.ToolDefinition, 0, len(allTools))
@@ -213,10 +215,16 @@ func DefaultTools() []agent.ToolDefinition {
 		if _, isRemember := t.(RememberTool); isRemember && !memoryOn {
 			continue
 		}
-		if _, isLaunch := t.(LaunchAgentTool); isLaunch && !spawnerOn {
+		if _, isLaunch := t.(LaunchAgentTool); isLaunch && !mgrOn {
 			continue
 		}
-		if _, isSend := t.(SendMessageTool); isSend && !spawnerOn {
+		if _, isSend := t.(SendMessageTool); isSend && !mgrOn {
+			continue
+		}
+		if _, isStatus := t.(AgentStatusTool); isStatus && !mgrOn {
+			continue
+		}
+		if _, isKill := t.(KillAgentTool); isKill && !mgrOn {
 			continue
 		}
 		if _, isAsk := t.(AskUserQuestionTool); isAsk && !askerOn {

--- a/internal/tools/send_message.go
+++ b/internal/tools/send_message.go
@@ -8,28 +8,35 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 )
 
-// SendMessageTool continues a sub-agent previously started with launch_agent,
-// sending it a new message and returning its next reply. Only the top-level
-// parent agent gets this tool — the Spawner filters it out of every child's
-// toolbelt (same rule as launch_agent), so a sub-agent can't message another.
-type SendMessageTool struct{}
+// SendMessageTool sends a message to a sub-agent previously started with
+// launch_agent. The message is delivered asynchronously; the reply arrives via
+// a system notification when the sub-agent responds.
+type SendMessageTool struct {
+	mgr *SubAgentManager
+}
+
+func (t SendMessageTool) manager() *SubAgentManager {
+	if t.mgr != nil {
+		return t.mgr
+	}
+	return defaultSubAgentMgr
+}
 
 func (SendMessageTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name: "send_message",
-		Description: "Continue a sub-agent you previously started with launch_agent by sending " +
-			"it a new message, and get its next reply. The sub-agent remembers everything it did " +
-			"before — use this when a delegated sub-task needs multiple rounds, or to give a " +
-			"follow-up instruction based on the sub-agent's earlier reply (instead of launching a " +
-			"fresh one that starts from scratch). The agent_id comes from the launch_agent result " +
-			"(the value in its '[agent <id>]' tag). If the reply says the agent is no longer alive, " +
-			"start a new one with launch_agent.",
+		Description: "Send a message to a sub-agent you previously started with launch_agent. " +
+			"The message is delivered asynchronously; you will receive the reply via " +
+			"a system notification when the sub-agent responds. " +
+			"The sub-agent remembers everything it did before. " +
+			"The agent_id comes from the launch_agent result. " +
+			"If the agent is no longer alive, start a new one with launch_agent.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"agent_id": map[string]any{
 					"type":        "string",
-					"description": "Id of the sub-agent to continue, as returned by launch_agent (the value in its '[agent <id>]' tag).",
+					"description": "Id of the sub-agent to message, as returned by launch_agent (e.g. 'agent_1').",
 				},
 				"message": map[string]any{
 					"type":        "string",
@@ -41,10 +48,7 @@ func (SendMessageTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (SendMessageTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
-	if !spawnerEnabled() {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("send_message: sub-agent dispatch is not configured for this session")
-	}
+func (t SendMessageTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	if IsSubAgent(ctx) {
 		// Symmetric with launch_agent's recursion guard: a sub-agent must not
 		// be able to wake another sub-agent. Defense in depth on top of the
@@ -61,15 +65,17 @@ func (SendMessageTool) Execute(ctx context.Context, _ string, input map[string]a
 		return agent.ToolResult{Text: ""}, fmt.Errorf("send_message: message is required")
 	}
 
-	res, err := activeSpawner.Continue(ctx, agentID, message)
-	if err != nil {
+	mgr := t.manager()
+	if mgr == nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("send_message: sub-agent dispatch is not configured for this session")
+	}
+
+	if err := mgr.Send(agentID, message); err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("send_message: %w", err)
 	}
-	reply := strings.TrimSpace(res.Reply)
-	if reply == "" {
-		return agent.ToolResult{Text: "(sub-agent " + agentID + " produced no reply)"}, nil
-	}
-	return agent.ToolResult{Text: withAgentTag(res.AgentID, reply)}, nil
+	return agent.ToolResult{
+		Text: fmt.Sprintf("Message sent to %s. You will be notified when it replies.", agentID),
+	}, nil
 }
 
 // withAgentTag prefixes a sub-agent reply with "[agent <id>] " so the parent

--- a/internal/tools/send_message_test.go
+++ b/internal/tools/send_message_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSendMessageTool_Schema(t *testing.T) {
@@ -24,41 +25,44 @@ func TestSendMessageTool_Schema(t *testing.T) {
 	}
 }
 
-func TestSendMessageTool_ContinuesAndTagsReply(t *testing.T) {
-	stub := &stubSpawner{continueReply: SpawnResult{AgentID: "a1b2c3d4", Reply: "next round done"}}
-	useSpawner(t, stub)
+func TestSendMessageTool_AsyncDelivery(t *testing.T) {
+	contCalled := make(chan struct{})
+	stub := &stubSpawner{
+		continueReply: SpawnResult{AgentID: "a1b2c3d4", Reply: "next round done"},
+		contCalled:    contCalled,
+	}
+	mgr := NewSubAgentManager(stub)
 
-	out, err := SendMessageTool{}.Execute(context.Background(), "send_message", map[string]any{
-		"agent_id": "a1b2c3d4",
+	// First launch a sub-agent so it exists.
+	_, _ = mgr.Start(SpawnRequest{Description: "test", Prompt: "do it"})
+	time.Sleep(50 * time.Millisecond)
+
+	out, err := SendMessageTool{mgr: mgr}.Execute(context.Background(), "send_message", map[string]any{
+		"agent_id": "agent_1",
 		"message":  "now do the second half",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out.Text != "[agent a1b2c3d4] next round done" {
-		t.Errorf("Execute returned %q, want tagged reply", out.Text)
+	if !strings.Contains(out.Text, "Message sent") {
+		t.Errorf("Execute returned %q, want 'Message sent' prefix", out.Text)
 	}
-	if stub.contAgentID != "a1b2c3d4" || stub.contMessage != "now do the second half" {
+
+	// Wait for the async Continue goroutine to reach the spawner.
+	select {
+	case <-contCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Continue to be called")
+	}
+
+	if stub.contAgentID != "agent_1" || stub.contMessage != "now do the second half" {
 		t.Errorf("Continue got (%q,%q)", stub.contAgentID, stub.contMessage)
 	}
 }
 
-func TestSendMessageTool_EmptyReplySurfaced(t *testing.T) {
-	useSpawner(t, &stubSpawner{continueReply: SpawnResult{AgentID: "id", Reply: "  "}})
-	out, err := SendMessageTool{}.Execute(context.Background(), "send_message", map[string]any{
-		"agent_id": "id",
-		"message":  "ping",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out.Text, "produced no reply") {
-		t.Errorf("empty reply should be surfaced, got %q", out.Text)
-	}
-}
-
 func TestSendMessageTool_RequiredArgs(t *testing.T) {
-	useSpawner(t, &stubSpawner{})
+	stub := &stubSpawner{}
+	mgr := NewSubAgentManager(stub)
 	cases := []struct {
 		name  string
 		input map[string]any
@@ -69,7 +73,7 @@ func TestSendMessageTool_RequiredArgs(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := SendMessageTool{}.Execute(context.Background(), "send_message", tc.input)
+			_, err := SendMessageTool{mgr: mgr}.Execute(context.Background(), "send_message", tc.input)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Errorf("want %q, got %v", tc.want, err)
 			}
@@ -78,9 +82,10 @@ func TestSendMessageTool_RequiredArgs(t *testing.T) {
 }
 
 func TestSendMessageTool_RecursionRefused(t *testing.T) {
-	useSpawner(t, &stubSpawner{continueReply: SpawnResult{AgentID: "id", Reply: "would have worked"}})
+	stub := &stubSpawner{continueReply: SpawnResult{AgentID: "id", Reply: "would have worked"}}
+	mgr := NewSubAgentManager(stub)
 	ctx := WithSubAgentMarker(context.Background())
-	_, err := SendMessageTool{}.Execute(ctx, "send_message", map[string]any{
+	_, err := SendMessageTool{mgr: mgr}.Execute(ctx, "send_message", map[string]any{
 		"agent_id": "id",
 		"message":  "wake up",
 	})
@@ -89,8 +94,7 @@ func TestSendMessageTool_RecursionRefused(t *testing.T) {
 	}
 }
 
-func TestSendMessageTool_NoSpawnerConfigured(t *testing.T) {
-	SetSpawner(nil)
+func TestSendMessageTool_NoManagerConfigured(t *testing.T) {
 	_, err := SendMessageTool{}.Execute(context.Background(), "send_message", map[string]any{
 		"agent_id": "id",
 		"message":  "x",
@@ -100,20 +104,22 @@ func TestSendMessageTool_NoSpawnerConfigured(t *testing.T) {
 	}
 }
 
-func TestSendMessageTool_ContinueErrorPropagates(t *testing.T) {
-	useSpawner(t, &stubSpawner{continueErr: errors.New("no longer alive")})
-	_, err := SendMessageTool{}.Execute(context.Background(), "send_message", map[string]any{
+func TestSendMessageTool_SendErrorPropagates(t *testing.T) {
+	stub := &stubSpawner{continueErr: errors.New("no longer alive")}
+	mgr := NewSubAgentManager(stub)
+	// Don't create the agent first — Send will fail with "no sub-agent".
+	_, err := SendMessageTool{mgr: mgr}.Execute(context.Background(), "send_message", map[string]any{
 		"agent_id": "stale",
 		"message":  "x",
 	})
-	if err == nil || !strings.Contains(err.Error(), "no longer alive") {
-		t.Errorf("expected propagated continue error, got %v", err)
+	if err == nil {
+		t.Fatal("expected error for unknown agent")
 	}
 }
 
-func TestDefaultTools_SendMessageGatedOnSpawner(t *testing.T) {
-	SetSpawner(nil)
-	t.Cleanup(func() { SetSpawner(nil) })
+func TestDefaultTools_SendMessageGatedOnManager(t *testing.T) {
+	SetDefaultSubAgentManager(nil)
+	t.Cleanup(func() { SetDefaultSubAgentManager(nil) })
 
 	has := func() bool {
 		for _, d := range DefaultTools() {
@@ -125,24 +131,10 @@ func TestDefaultTools_SendMessageGatedOnSpawner(t *testing.T) {
 	}
 
 	if has() {
-		t.Error("send_message should be absent when no spawner is configured")
+		t.Error("send_message should be absent when no SubAgentManager is configured")
 	}
-	useSpawner(t, &stubSpawner{})
+	SetDefaultSubAgentManager(NewSubAgentManager(&stubSpawner{}))
 	if !has() {
-		t.Error("send_message should be present once a spawner is registered")
-	}
-}
-
-func TestLaunchAgentTool_TagsReplyWithAgentID(t *testing.T) {
-	useSpawner(t, &stubSpawner{replies: []SpawnResult{{AgentID: "deadbeef", Reply: "the finding"}}})
-	out, err := LaunchAgentTool{}.Execute(context.Background(), "launch_agent", map[string]any{
-		"description": "Investigate",
-		"prompt":      "look into X",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if out.Text != "[agent deadbeef] the finding" {
-		t.Errorf("launch_agent reply should carry the agent tag, got %q", out.Text)
+		t.Error("send_message should be present once a SubAgentManager is registered")
 	}
 }

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -1,0 +1,340 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// maxSubAgentResultBytes caps how much result text is retained per async sub-agent.
+const maxSubAgentResultBytes = 1 << 20 // 1 MiB
+
+// SubAgentNotification is delivered to the onExit hook when a sub-agent
+// finishes a task (launch_agent) or replies to a message (send_message).
+type SubAgentNotification struct {
+	AgentID      string // e.g. "agent_1"
+	Description  string // human-readable label from launch_agent
+	Kind         string // "spawn_done" | "message_reply"
+	Result       string // final reply text
+	InputTokens  int
+	OutputTokens int
+}
+
+// SubAgentInfo is a snapshot of a sub-agent for listing.
+type SubAgentInfo struct {
+	ID          string
+	Description string
+	Start       time.Time
+	Busy        bool
+}
+
+// asyncSubAgent tracks one detached sub-agent launched via SubAgentManager.
+type asyncSubAgent struct {
+	id          string
+	description string
+	cancel      context.CancelFunc
+	start       time.Time
+
+	mu           sync.Mutex
+	busy         bool   // true while processing a Spawn or Continue
+	pending      string // queued message waiting to be sent
+	result       string // latest result (truncated to maxSubAgentResultBytes)
+	exited       bool   // true if the sub-agent context was cancelled / killed
+	exitErr      error
+	inputTokens  int
+	outputTokens int
+}
+
+func (a *asyncSubAgent) setResult(result string, inputTokens, outputTokens int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.result = truncateSubAgentResult(result)
+	a.inputTokens = inputTokens
+	a.outputTokens = outputTokens
+}
+
+func (a *asyncSubAgent) setBusy(v bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.busy = v
+}
+
+func (a *asyncSubAgent) setDone(err error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if err != nil {
+		a.exited = true
+	}
+	a.exitErr = err
+	a.busy = false
+}
+
+func (a *asyncSubAgent) setExited(err error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.exited = true
+	a.exitErr = err
+	a.busy = false
+}
+
+func (a *asyncSubAgent) readState() (result, status string, busy, exited bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	result = a.result
+	busy = a.busy
+	exited = a.exited
+	if a.exited {
+		if a.exitErr != nil {
+			status = "exited: " + a.exitErr.Error()
+		} else {
+			status = "exited: 0"
+		}
+	} else if a.busy {
+		status = "running"
+	} else {
+		status = "idle"
+	}
+	return
+}
+
+func truncateSubAgentResult(s string) string {
+	if len(s) <= maxSubAgentResultBytes {
+		return s
+	}
+	return s[:maxSubAgentResultBytes] + "\n...[truncated]"
+}
+
+// defaultSubAgentMgr is the process-wide manager used by the built-in tools
+// when no manager is injected.
+var defaultSubAgentMgr *SubAgentManager
+
+// SetDefaultSubAgentManager registers the global manager used by LaunchAgentTool
+// and SendMessageTool when no local manager is set.
+func SetDefaultSubAgentManager(m *SubAgentManager) { defaultSubAgentMgr = m }
+
+// SubAgentManager owns the set of async sub-agents for a session.
+// Methods are safe for concurrent use.
+type SubAgentManager struct {
+	mu      sync.Mutex
+	agents  map[string]*asyncSubAgent
+	seq     int
+	spawner Spawner
+	onExit  func(SubAgentNotification)
+}
+
+// NewSubAgentManager returns an empty manager.
+func NewSubAgentManager(spawner Spawner) *SubAgentManager {
+	return &SubAgentManager{
+		agents:  map[string]*asyncSubAgent{},
+		spawner: spawner,
+	}
+}
+
+// SetOnExit registers a completion hook fired once per sub-agent when it
+// finishes processing. Pass nil to clear.
+func (m *SubAgentManager) SetOnExit(fn func(SubAgentNotification)) {
+	m.mu.Lock()
+	m.onExit = fn
+	m.mu.Unlock()
+}
+
+// Start creates a new sub-agent and runs it asynchronously.
+// Returns the agent_id immediately; result arrives via onExit.
+func (m *SubAgentManager) Start(req SpawnRequest) (string, error) {
+	if m.spawner == nil {
+		return "", fmt.Errorf("subagent: no spawner configured")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	m.mu.Lock()
+	m.seq++
+	id := fmt.Sprintf("agent_%d", m.seq)
+	agent := &asyncSubAgent{
+		id:          id,
+		description: req.Description,
+		cancel:      cancel,
+		start:       time.Now(),
+		busy:        true,
+	}
+	m.agents[id] = agent
+	m.mu.Unlock()
+
+	go func() {
+		res, err := m.spawner.Spawn(ctx, req)
+		if err == nil {
+			agent.setResult(res.Reply, res.InputTokens, res.OutputTokens)
+		}
+		agent.setDone(err)
+
+		m.mu.Lock()
+		hook := m.onExit
+		m.mu.Unlock()
+		if hook != nil {
+			result, _, _, _ := agent.readState()
+			if err != nil {
+				result = err.Error()
+			}
+			agent.mu.Lock()
+			inTok := agent.inputTokens
+			outTok := agent.outputTokens
+			agent.mu.Unlock()
+			hook(SubAgentNotification{
+				AgentID:      id,
+				Description:  req.Description,
+				Kind:         "spawn_done",
+				Result:       result,
+				InputTokens:  inTok,
+				OutputTokens: outTok,
+			})
+		}
+	}()
+
+	return id, nil
+}
+
+// Send delivers a message to an existing sub-agent asynchronously.
+// Returns immediately; reply arrives via onExit.
+func (m *SubAgentManager) Send(agentID, message string) error {
+	m.mu.Lock()
+	agent := m.agents[agentID]
+	m.mu.Unlock()
+	if agent == nil {
+		return fmt.Errorf("subagent: no sub-agent %q", agentID)
+	}
+
+	agent.mu.Lock()
+	if agent.exited {
+		agent.mu.Unlock()
+		return fmt.Errorf("subagent: %s has exited", agentID)
+	}
+	if agent.busy {
+		if agent.pending != "" {
+			agent.mu.Unlock()
+			return fmt.Errorf("subagent: %s already has a pending message", agentID)
+		}
+		agent.pending = message
+		agent.mu.Unlock()
+		return nil // queued, will be sent when current processing done
+	}
+	agent.busy = true
+	agent.mu.Unlock()
+
+	go m.runContinue(agentID, message)
+	return nil
+}
+
+func (m *SubAgentManager) runContinue(agentID, message string) {
+	agent := m.agents[agentID]
+	if agent == nil {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Replace the agent's cancel so Kill targets the current operation.
+	agent.mu.Lock()
+	agent.cancel = cancel
+	agent.mu.Unlock()
+
+	res, err := m.spawner.Continue(ctx, agentID, message)
+	if err == nil {
+		agent.setResult(res.Reply, res.InputTokens, res.OutputTokens)
+	}
+	agent.setDone(err)
+
+	m.mu.Lock()
+	hook := m.onExit
+	m.mu.Unlock()
+	if hook != nil {
+		result, _, _, _ := agent.readState()
+		if err != nil {
+			result = err.Error()
+		}
+		agent.mu.Lock()
+		inTok := agent.inputTokens
+		outTok := agent.outputTokens
+		agent.mu.Unlock()
+		hook(SubAgentNotification{
+			AgentID:      agentID,
+			Description:  agent.description,
+			Kind:         "message_reply",
+			Result:       result,
+			InputTokens:  inTok,
+			OutputTokens: outTok,
+		})
+	}
+
+	// Process pending message, if any.
+	agent.mu.Lock()
+	pending := agent.pending
+	agent.pending = ""
+	if pending != "" && !agent.exited {
+		agent.busy = true
+		agent.mu.Unlock()
+		go m.runContinue(agentID, pending)
+		return
+	}
+	agent.mu.Unlock()
+}
+
+// Read returns the latest result and status for an agent.
+// found is false when id is unknown.
+func (m *SubAgentManager) Read(id string) (result, status string, found bool) {
+	m.mu.Lock()
+	agent := m.agents[id]
+	m.mu.Unlock()
+	if agent == nil {
+		return "", "", false
+	}
+	result, status, _, _ = agent.readState()
+	return result, status, true
+}
+
+// Kill terminates the sub-agent for id. Returns false when id is unknown.
+func (m *SubAgentManager) Kill(id string) bool {
+	m.mu.Lock()
+	agent := m.agents[id]
+	m.mu.Unlock()
+	if agent == nil {
+		return false
+	}
+	agent.setExited(context.Canceled)
+	agent.cancel()
+	return true
+}
+
+// KillAll terminates every tracked sub-agent. Called on session shutdown.
+func (m *SubAgentManager) KillAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, agent := range m.agents {
+		agent.cancel()
+	}
+}
+
+// ListRunning returns the agents that haven't exited yet, oldest first.
+func (m *SubAgentManager) ListRunning() []SubAgentInfo {
+	m.mu.Lock()
+	agents := make([]*asyncSubAgent, 0, len(m.agents))
+	for _, a := range m.agents {
+		agents = append(agents, a)
+	}
+	m.mu.Unlock()
+
+	var out []SubAgentInfo
+	for _, a := range agents {
+		_, _, busy, done := a.readState()
+		if !done {
+			out = append(out, SubAgentInfo{
+				ID:          a.id,
+				Description: a.description,
+				Start:       a.start,
+				Busy:        busy,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Start.Before(out[j].Start) })
+	return out
+}

--- a/internal/tools/subagent_manager_test.go
+++ b/internal/tools/subagent_manager_test.go
@@ -1,0 +1,270 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// mockSpawner is a test double for Spawner.
+type mockSpawner struct {
+	mu      sync.Mutex
+	spawns  []SpawnRequest
+	cont    []struct{ id, msg string }
+	replies []SpawnResult
+	err     error
+}
+
+func (m *mockSpawner) Spawn(_ context.Context, req SpawnRequest) (SpawnResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.spawns = append(m.spawns, req)
+	if m.err != nil {
+		return SpawnResult{}, m.err
+	}
+	if len(m.replies) > 0 {
+		r := m.replies[0]
+		m.replies = m.replies[1:]
+		return r, nil
+	}
+	return SpawnResult{Reply: "mock reply"}, nil
+}
+
+func (m *mockSpawner) Continue(_ context.Context, id, msg string) (SpawnResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cont = append(m.cont, struct{ id, msg string }{id, msg})
+	if m.err != nil {
+		return SpawnResult{}, m.err
+	}
+	if len(m.replies) > 0 {
+		r := m.replies[0]
+		m.replies = m.replies[1:]
+		return r, nil
+	}
+	return SpawnResult{Reply: "mock continue reply"}, nil
+}
+
+func TestSubAgentManagerStart(t *testing.T) {
+	sp := &mockSpawner{replies: []SpawnResult{{Reply: "hello", AgentID: "a1"}}}
+	mgr := NewSubAgentManager(sp)
+
+	id, err := mgr.Start(SpawnRequest{Description: "test", Prompt: "do it"})
+	if err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+	if !strings.HasPrefix(id, "agent_") {
+		t.Fatalf("unexpected id: %s", id)
+	}
+
+	// Should be running immediately.
+	info := mgr.ListRunning()
+	if len(info) != 1 || info[0].ID != id {
+		t.Fatalf("expected 1 running agent, got %+v", info)
+	}
+}
+
+func TestSubAgentManagerNotification(t *testing.T) {
+	sp := &mockSpawner{replies: []SpawnResult{{Reply: "result", InputTokens: 10, OutputTokens: 5}}}
+	mgr := NewSubAgentManager(sp)
+
+	var notif SubAgentNotification
+	done := make(chan struct{})
+	mgr.SetOnExit(func(ev SubAgentNotification) {
+		notif = ev
+		close(done)
+	})
+
+	id, err := mgr.Start(SpawnRequest{Description: "d", Prompt: "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for notification")
+	}
+
+	if notif.AgentID != id {
+		t.Fatalf("AgentID = %q, want %q", notif.AgentID, id)
+	}
+	if notif.Kind != "spawn_done" {
+		t.Fatalf("Kind = %q, want spawn_done", notif.Kind)
+	}
+	if notif.Result != "result" {
+		t.Fatalf("Result = %q, want result", notif.Result)
+	}
+	if notif.InputTokens != 10 {
+		t.Fatalf("InputTokens = %d, want 10", notif.InputTokens)
+	}
+	if notif.OutputTokens != 5 {
+		t.Fatalf("OutputTokens = %d, want 5", notif.OutputTokens)
+	}
+}
+
+func TestSubAgentManagerSend(t *testing.T) {
+	sp := &mockSpawner{replies: []SpawnResult{
+		{Reply: "spawned"},
+		{Reply: "replied"},
+	}}
+	mgr := NewSubAgentManager(sp)
+
+	var notifs []SubAgentNotification
+	var mu sync.Mutex
+	mgr.SetOnExit(func(ev SubAgentNotification) {
+		mu.Lock()
+		defer mu.Unlock()
+		notifs = append(notifs, ev)
+	})
+
+	id, err := mgr.Start(SpawnRequest{Description: "d", Prompt: "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for spawn to finish.
+	time.Sleep(100 * time.Millisecond)
+
+	// Send a message.
+	if err := mgr.Send(id, "follow up"); err != nil {
+		t.Fatalf("Send error: %v", err)
+	}
+
+	// Wait for reply notification.
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	if len(notifs) != 2 {
+		t.Fatalf("expected 2 notifications, got %d", len(notifs))
+	}
+	if notifs[1].Kind != "message_reply" {
+		t.Fatalf("second Kind = %q, want message_reply", notifs[1].Kind)
+	}
+	if notifs[1].Result != "replied" {
+		t.Fatalf("second Result = %q, want replied", notifs[1].Result)
+	}
+	mu.Unlock()
+}
+
+func TestSubAgentManagerSendQueue(t *testing.T) {
+	sp := &mockSpawner{replies: []SpawnResult{
+		{Reply: "first"},
+		{Reply: "second"},
+	}}
+	mgr := NewSubAgentManager(sp)
+
+	var notifs []SubAgentNotification
+	var mu sync.Mutex
+	mgr.SetOnExit(func(ev SubAgentNotification) {
+		mu.Lock()
+		defer mu.Unlock()
+		notifs = append(notifs, ev)
+	})
+
+	id, err := mgr.Start(SpawnRequest{Description: "d", Prompt: "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for spawn to finish first.
+	time.Sleep(100 * time.Millisecond)
+
+	// Send first message.
+	if err := mgr.Send(id, "msg1"); err != nil {
+		t.Fatalf("Send msg1 error: %v", err)
+	}
+	// Second should be queued.
+	if err := mgr.Send(id, "msg2"); err != nil {
+		t.Fatalf("Send msg2 error: %v", err)
+	}
+	// Third should fail (queue full).
+	if err := mgr.Send(id, "msg3"); err == nil {
+		t.Fatal("expected error for third Send, got nil")
+	}
+
+	// Wait for all to complete.
+	time.Sleep(300 * time.Millisecond)
+
+	mu.Lock()
+	if len(notifs) != 3 {
+		t.Fatalf("expected 3 notifications, got %d", len(notifs))
+	}
+	mu.Unlock()
+}
+
+func TestSubAgentManagerKill(t *testing.T) {
+	sp := &mockSpawner{replies: []SpawnResult{{Reply: "never"}}}
+	mgr := NewSubAgentManager(sp)
+
+	id, err := mgr.Start(SpawnRequest{Description: "d", Prompt: "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !mgr.Kill(id) {
+		t.Fatal("Kill returned false")
+	}
+
+	// Wait for cancellation to propagate.
+	time.Sleep(100 * time.Millisecond)
+
+	_, status, _ := mgr.Read(id)
+	if !strings.Contains(status, "exited") {
+		t.Fatalf("expected exited status, got %q", status)
+	}
+}
+
+func TestSubAgentManagerRead(t *testing.T) {
+	sp := &mockSpawner{replies: []SpawnResult{{Reply: "the result"}}}
+	mgr := NewSubAgentManager(sp)
+
+	id, err := mgr.Start(SpawnRequest{Description: "d", Prompt: "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for completion.
+	time.Sleep(100 * time.Millisecond)
+
+	result, status, found := mgr.Read(id)
+	if !found {
+		t.Fatal("expected found")
+	}
+	if result != "the result" {
+		t.Fatalf("result = %q, want the result", result)
+	}
+	if status != "idle" {
+		t.Fatalf("expected idle status, got %q", status)
+	}
+}
+
+func TestSubAgentManagerReadUnknown(t *testing.T) {
+	mgr := NewSubAgentManager(&mockSpawner{})
+	_, _, found := mgr.Read("agent_999")
+	if found {
+		t.Fatal("expected not found")
+	}
+}
+
+func TestSubAgentManagerSendToUnknown(t *testing.T) {
+	mgr := NewSubAgentManager(&mockSpawner{})
+	if err := mgr.Send("agent_999", "hi"); err == nil {
+		t.Fatal("expected error for unknown agent")
+	}
+}
+
+func TestSubAgentManagerSendToExited(t *testing.T) {
+	sp := &mockSpawner{replies: []SpawnResult{{Reply: "done"}}}
+	mgr := NewSubAgentManager(sp)
+
+	id, _ := mgr.Start(SpawnRequest{Description: "d", Prompt: "p"})
+	mgr.Kill(id)
+	time.Sleep(100 * time.Millisecond)
+
+	if err := mgr.Send(id, "too late"); err == nil {
+		t.Fatal("expected error for exited agent")
+	}
+}


### PR DESCRIPTION
Migrate sub-agent tools from synchronous to fully asynchronous model.

**New tools:**
- `agent_status` — query sub-agent state (running/idle/exited) and latest result
- `kill_agent` — terminate a sub-agent

**Async migration:**
- `launch_agent` — returns immediately with "Started sub-agent X..."; result arrives later via SubAgentNotification
- `send_message` — returns immediately with "Message sent..."; reply arrives via notification

**Core infrastructure:**
- SubAgentManager (internal/tools/subagent_manager.go) — async lifecycle, 1-message pending queue per agent, onExit hook for spawn_done / message_reply

**Integration:**
- REPL/TUI onExit hook injects notifications via Agent.Steer() as system-reminder blocks
- TUI shows one-line scrollback notice via subAgentNoteMsg
- Session exit calls KillAll() to reap sub-agents

**Gate:** all four sub-agent tools require a registered SubAgentManager to appear in DefaultTools().
