### PR TITLE
fix(tui): keep banner visible instead of abruptly hiding it on first input

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -214,7 +214,6 @@ type tuiModel struct {
 	// tools suppress their started line, so without this they'd show nothing
 	// until completion.)
 	running *runningTool
-
 }
 
 // runningTool is the live indicator state for an in-flight card tool.

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -215,8 +215,6 @@ type tuiModel struct {
 	// until completion.)
 	running *runningTool
 
-	// showBanner is true until the first user input dismisses the welcome banner.
-	showBanner bool
 }
 
 // runningTool is the live indicator state for an in-flight card tool.
@@ -250,7 +248,7 @@ func newTUIModel(cfg replConfig) *tuiModel {
 	if !tui.IsDark() {
 		style = "light"
 	}
-	return &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ti: ti, inputHistoryIdx: -1, showBanner: true, md: markdownRenderer{style: style}}
+	return &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ti: ti, inputHistoryIdx: -1, md: markdownRenderer{style: style}}
 }
 
 func (m *tuiModel) Init() tea.Cmd { return textinput.Blink }

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -121,7 +121,6 @@ func (m *tuiModel) submit(alt bool) (tea.Model, tea.Cmd) {
 	if text == "" {
 		return m, nil
 	}
-	m.showBanner = false // dismiss welcome banner on first input
 	m.ti.Reset()
 	m.inputHistoryIdx = -1
 	// Save to history for ↑/↓ recall (dedup consecutive identical lines).
@@ -341,11 +340,10 @@ func (m *tuiModel) View() string {
 
 	var b strings.Builder
 
-	// Welcome banner shown on first launch until the user starts typing.
-	if m.showBanner {
-		b.WriteString(tui.Banner("", m.a.Model, m.cwd, m.width))
-		b.WriteByte('\n')
-	}
+	// Banner always renders at the top of the fixed viewport; scrollback
+	// content naturally pushes it upward rather than abruptly hiding it.
+	b.WriteString(tui.Banner("", m.a.Model, m.cwd, m.width))
+	b.WriteByte('\n')
 
 	// Live partial assistant line (committed lines already scrolled up).
 	// Render through glamour so wrapping stays consistent with committed blocks.


### PR DESCRIPTION
The welcome banner (which also carries the idle hint) was being immediately removed from the fixed viewport via m.showBanner = false as soon as the user pressed Enter. This made it disappear abruptly while the first turn was still running, leaving the bottom half of the screen empty and the keyboard hints unreachable.

Remove the showBanner toggle entirely. The Banner now always renders at the top of View(); scrollback content naturally pushes it upward as the conversation grows, so it fades out of view organically rather than vanishing in a single frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)