### PR TITLE
fix(tui/repl): bg/sub-agent notifications as standalone user messages

### DIFF
--- a/cmd/octo/bgnotify.go
+++ b/cmd/octo/bgnotify.go
@@ -7,14 +7,12 @@ import (
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
-// formatBgNote renders a background-process completion as a <system-reminder>
-// block. It rides the existing steer path (Agent.Steer → folded into the next
-// tool_result, or prepended to the next turn — see turncore.go), so the model
-// reads it as an environment event rather than user speech. Wrapping in
-// <system-reminder> matches octo's convention for injected, non-user context.
+// formatBgNote renders a background-process completion as a plain user-facing
+// message. The text is meant to be submitted as a standalone turn (queued or
+// auto-triggered) so the model treats it as a first-class inbox item, not a
+// hidden system-reminder block folded into another message.
 func formatBgNote(e tools.BgExit) string {
 	var b strings.Builder
-	b.WriteString("<system-reminder>\n")
 	fmt.Fprintf(&b, "Background process %s (`%s`) %s.", e.ID, e.Command, e.Status)
 	if out := strings.TrimRight(e.NewOutput, "\n"); out != "" {
 		b.WriteString("\nOutput since last check:\n")
@@ -22,6 +20,5 @@ func formatBgNote(e tools.BgExit) string {
 	} else {
 		b.WriteString("\n(no new output)")
 	}
-	b.WriteString("\n</system-reminder>")
 	return b.String()
 }

--- a/cmd/octo/bgnotify_test.go
+++ b/cmd/octo/bgnotify_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
-func TestFormatBgNote_WrapsAsSystemReminder(t *testing.T) {
+func TestFormatBgNote_ContainsExpectedFields(t *testing.T) {
 	got := formatBgNote(tools.BgExit{
 		ID:        "bg_1",
 		Command:   "go test ./...",
@@ -15,12 +15,15 @@ func TestFormatBgNote_WrapsAsSystemReminder(t *testing.T) {
 		NewOutput: "ok  github.com/x/y  1.2s\n",
 	})
 	for _, want := range []string{
-		"<system-reminder>", "</system-reminder>",
 		"bg_1", "go test ./...", "exited: 0", "ok  github.com/x/y  1.2s",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("formatBgNote missing %q in:\n%s", want, got)
 		}
+	}
+	// Must NOT contain system-reminder tags — it's a plain user message now.
+	if strings.Contains(got, "<system-reminder>") {
+		t.Errorf("formatBgNote should not wrap in <system-reminder>; got:\n%s", got)
 	}
 }
 

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -70,13 +70,21 @@ func runREPL(cfg replConfig) int {
 	// outlive the session.
 	defer tools.KillAllBackground()
 
-	// Sub-agent manager: wire the onExit hook so completion notifications ride
-	// the same steer path as background-process notices. Register the manager
-	// globally so the built-in tools pick it up without per-instance injection.
+	// Shared pending buffer for background-process and sub-agent completion
+	// notifications in the plain REPL. The TUI uses its own queue mechanism.
+	var bgPendingMu sync.Mutex
+	var bgPending []string
+
+	// Sub-agent manager: wire the onExit hook so completion notifications are
+	// enqueued into the pending buffer (same as background-process notices).
+	// Register the manager globally so the built-in tools pick it up without
+	// per-instance injection.
 	if cfg.subAgentMgr != nil {
 		tools.SetDefaultSubAgentManager(cfg.subAgentMgr)
 		cfg.subAgentMgr.SetOnExit(func(ev tools.SubAgentNotification) {
-			a.Steer(formatSubAgentNote(ev))
+			bgPendingMu.Lock()
+			bgPending = append(bgPending, formatSubAgentNote(ev))
+			bgPendingMu.Unlock()
 		})
 		defer func() {
 			cfg.subAgentMgr.SetOnExit(nil)
@@ -85,12 +93,14 @@ func runREPL(cfg replConfig) int {
 		}()
 	}
 
-	// Background-completion notice: inject into the conversation via Steer so
-	// the model is told when a detached command finishes (drained at the next
-	// tool-batch boundary, or prepended to the next turn — see turncore.go).
-	// The plain path prints no async UI line (it would interleave with the
-	// synchronous render loop); the TUI path adds a scrollback notice on top.
-	tools.SetBackgroundOnExit(func(e tools.BgExit) { a.Steer(formatBgNote(e)) })
+	// Background-completion notice: enqueue into the pending buffer so the
+	// model is told when a detached command finishes. The plain path auto-
+	// triggers a turn via idleBgWait; the TUI path enqueues into the queue.
+	tools.SetBackgroundOnExit(func(e tools.BgExit) {
+		bgPendingMu.Lock()
+		bgPending = append(bgPending, formatBgNote(e))
+		bgPendingMu.Unlock()
+	})
 	defer tools.SetBackgroundOnExit(nil)
 
 	// Startup banner — fully suppressed in quiet mode, expanded with
@@ -242,8 +252,8 @@ func runREPL(cfg replConfig) int {
 		var line string
 		var isAutoTurn bool
 
-		// Wait for either user input or a background-completion steer that
-		// arrived while we were idle. The steer path auto-triggers a turn so
+		// Wait for either user input or a background-completion notification
+		// that arrived while we were idle. The bg path auto-triggers a turn so
 		// the model can react to the event without the user typing anything.
 		select {
 		case raw, ok := <-inputCh:
@@ -261,10 +271,15 @@ func runREPL(cfg replConfig) int {
 				done = true
 				continue
 			}
-		case <-idleSteerWait(a):
-			// Background process finished while idle. Drain the steer buffer
+		case <-idleBgWait(&bgPendingMu, &bgPending):
+			// Background process finished while idle. Drain the pending buffer
 			// and run an auto-turn so the model sees the notification.
-			line = a.DrainSteer()
+			bgPendingMu.Lock()
+			if len(bgPending) > 0 {
+				line = bgPending[0]
+				bgPending = bgPending[1:]
+			}
+			bgPendingMu.Unlock()
 			isAutoTurn = true
 		}
 
@@ -332,16 +347,19 @@ func runREPL(cfg replConfig) int {
 	return 0
 }
 
-// idleSteerWait returns a channel that receives a single value once a steer
-// message is pending on the agent. It polls every 200 ms so the select in
-// runREPL doesn't block indefinitely on user input when a background process
-// completes. The returned channel is closed after firing; callers should not
-// reuse it.
-func idleSteerWait(a *agent.Agent) <-chan struct{} {
+// idleBgWait returns a channel that receives a single value once a background-
+// process completion notification is pending. It polls every 200 ms so the
+// select in runREPL doesn't block indefinitely on user input when a background
+// process completes. The returned channel is closed after firing; callers
+// should not reuse it.
+func idleBgWait(mu *sync.Mutex, pending *[]string) <-chan struct{} {
 	ch := make(chan struct{}, 1)
 	go func() {
 		for {
-			if a.HasPendingSteer() {
+			mu.Lock()
+			has := len(*pending) > 0
+			mu.Unlock()
+			if has {
 				ch <- struct{}{}
 				return
 			}

--- a/cmd/octo/subagent_notify.go
+++ b/cmd/octo/subagent_notify.go
@@ -7,14 +7,12 @@ import (
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
-// formatSubAgentNote renders a sub-agent completion notification as a
-// <system-reminder> block. It rides the existing steer path (Agent.Steer →
-// folded into the next tool_result, or prepended to the next turn — see
-// turncore.go), so the model reads it as an environment event rather than
-// user speech.
+// formatSubAgentNote renders a sub-agent completion notification as a plain
+// user-facing message. The text is meant to be submitted as a standalone turn
+// (queued or auto-triggered) so the model treats it as a first-class inbox
+// item, not a hidden system-reminder block folded into another message.
 func formatSubAgentNote(ev tools.SubAgentNotification) string {
 	var b strings.Builder
-	b.WriteString("<system-reminder>\n")
 	switch ev.Kind {
 	case "spawn_done":
 		fmt.Fprintf(&b, "Sub-agent %s (%s) has completed.", ev.AgentID, ev.Description)
@@ -30,6 +28,5 @@ func formatSubAgentNote(ev tools.SubAgentNotification) string {
 	if ev.InputTokens > 0 || ev.OutputTokens > 0 {
 		fmt.Fprintf(&b, "\n[usage] in %d / out %d", ev.InputTokens, ev.OutputTokens)
 	}
-	b.WriteString("\n</system-reminder>")
 	return b.String()
 }

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -322,16 +322,33 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Println(noticeStyle.Render(msg.text))
 
 	case bgExitMsg:
-		// Async background-process completion: show a one-line scrollback notice
-		// (the full output rode into the conversation via Steer). Safe to print
-		// mid-turn — it's just another committed line.
+		// Async background-process completion: enqueue as a standalone pending
+		// turn so it drains FIFO alongside queued user messages. The model will
+		// see it as a first-class inbox item and respond explicitly.
+		m.queue = append(m.queue, pendingItem{text: formatBgNote(msg.e)})
+		// If idle, auto-start the queued turn immediately so the model reacts
+		// without waiting for user input. Pop it now so handleTurnFinished
+		// doesn't double-start.
+		if !m.turnRunning && len(m.queue) == 1 {
+			next := m.queue[0]
+			m.queue = m.queue[1:]
+			return m, m.startTurnEcho(next.text, "")
+		}
+		// Otherwise (turn running or more items queued): just show a one-line
+		// scrollback notice for UI observability.
 		return m, tea.Println(noticeStyle.Render(fmt.Sprintf(
 			"↳ %s (%s) %s", msg.e.ID, truncate1Line(msg.e.Command), msg.e.Status)))
 
 	case subAgentNoteMsg:
-		// Async sub-agent completion: show a one-line scrollback notice (the
-		// full result rode into the conversation via Steer). Safe to print
-		// mid-turn.
+		// Async sub-agent completion: enqueue as a standalone pending turn so
+		// it drains FIFO alongside queued user messages and background notices.
+		m.queue = append(m.queue, pendingItem{text: formatSubAgentNote(msg.ev)})
+		// If idle, auto-start immediately.
+		if !m.turnRunning && len(m.queue) == 1 {
+			next := m.queue[0]
+			m.queue = m.queue[1:]
+			return m, m.startTurnEcho(next.text, "")
+		}
 		label := "completed"
 		if msg.ev.Kind == "message_reply" {
 			label = "replied"


### PR DESCRIPTION
Background-process and sub-agent completion notifications previously rode the Steer path: wrapped in <system-reminder> blocks and folded into tool_result messages or prepended to the next turn. This made them easy to miss.

Now they are enqueued as standalone pending turns:
- **TUI**: bgExitMsg/subAgentNoteMsg enqueue to m.queue; idle auto-starts
- **Plain REPL**: uses a dedicated bgPending buffer + idleBgWait polling
- **formatBgNote/formatSubAgentNote** no longer wrap in <system-reminder>

This ensures notifications are treated as user messages, echoed into scrollback, and responded to explicitly by the model.

Fixes: user feedback that system-reminder notifications were being ignored.