### PR TITLE
fix(tui): guarantee scrollback output order

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -341,19 +341,34 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case turnEndedMsg:
 		// Flush any trailing assistant block (markdown-rendered); then render
-		// the cache/error footer.
-		var cmds []tea.Cmd
-		if flush := m.flushText(); flush != nil {
-			cmds = append(cmds, flush)
+		// the cache/error footer. All lines are merged into a single tea.Println
+		// because tea.Batch runs commands concurrently and their output order is
+		// undefined — this was causing the cache line to appear before the
+		// flushed assistant text.
+		var b strings.Builder
+		if s, ok := m.flushTextString(); ok {
+			b.WriteString(s)
 		}
 		if msg.err != nil && msg.err != context.Canceled {
-			cmds = append(cmds, tea.Println(errorStyle.Render("error: "+msg.err.Error())))
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(errorStyle.Render("error: " + msg.err.Error()))
 		} else if msg.err == context.Canceled {
-			cmds = append(cmds, tea.Println(noticeStyle.Render("^C interrupted")))
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(noticeStyle.Render("^C interrupted"))
 		} else if c := cacheLine(m.cfg.verbosity, msg.reply); c != "" {
-			cmds = append(cmds, tea.Println(c))
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(c)
 		}
-		return m, tea.Batch(cmds...)
+		if b.Len() > 0 {
+			return m, tea.Println(b.String())
+		}
+		return m, nil
 
 	case turnFinishedMsg:
 		return m.handleTurnFinished()
@@ -472,11 +487,7 @@ func (m *tuiModel) appendText(text string) tea.Cmd {
 		complete := buf[:idx]
 		m.partial.Reset()
 		m.partial.WriteString(buf[idx+1:])
-		var cmds []tea.Cmd
-		for _, line := range strings.Split(complete, "\n") {
-			cmds = append(cmds, tea.Println(line))
-		}
-		return tea.Batch(cmds...)
+		return tea.Println(complete)
 	}
 
 	commit, rest := splitCommittableMarkdown(m.partial.String())
@@ -492,23 +503,40 @@ func (m *tuiModel) appendText(text string) tea.Cmd {
 // pre-tool block), rendered through glamour unless --plain. Returns nil when
 // nothing is pending.
 func (m *tuiModel) flushText() tea.Cmd {
+	s, ok := m.flushTextString()
+	if !ok {
+		return nil
+	}
+	return tea.Println(s)
+}
+
+// flushTextString returns the buffered assistant text (rendered through glamour
+// unless --plain) and true when there was pending text. Used internally when
+// multiple lines must be emitted in strict order — the caller batches them into
+// a single tea.Println instead of tea.Batch which runs commands concurrently.
+func (m *tuiModel) flushTextString() (string, bool) {
 	p := m.partial.String()
 	if p == "" {
-		return nil
+		return "", false
 	}
 	m.partial.Reset()
 	if m.cfg.plain {
-		return tea.Println(p)
+		return p, true
 	}
-	return tea.Println(m.md.render(p, m.width))
+	return m.md.render(p, m.width), true
 }
 
 // commitToolLine flushes any in-progress text, then prints the tool line/card.
+// The two lines are merged into a single tea.Println because tea.Batch runs
+// commands concurrently and their output order is undefined.
 func (m *tuiModel) commitToolLine(line string) tea.Cmd {
-	if flush := m.flushText(); flush != nil {
-		return tea.Batch(flush, tea.Println(line))
+	var b strings.Builder
+	if s, ok := m.flushTextString(); ok {
+		b.WriteString(s)
+		b.WriteByte('\n')
 	}
-	return tea.Println(line)
+	b.WriteString(line)
+	return tea.Println(b.String())
 }
 
 func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {

--- a/cmd/octo/tuirepl_goal.go
+++ b/cmd/octo/tuirepl_goal.go
@@ -105,8 +105,7 @@ func (m *tuiModel) startGoalPlan(goal string) tea.Cmd {
 		prog.Send(goalPlannedMsg{task: task, err: err})
 	}()
 	return tea.Batch(
-		tea.Println(promptStyle.Render("> ")+"/goal "+goal),
-		tea.Println(noticeStyle.Render("Planning…")),
+		tea.Println(promptStyle.Render("> ")+"/goal "+goal+"\n"+noticeStyle.Render("Planning…")),
 		tickCmd(),
 	)
 }
@@ -183,21 +182,33 @@ func (m *tuiModel) startGoalRun(taskID string) tea.Cmd {
 func (m *tuiModel) onGoalDone(msg goalDoneMsg) (tea.Model, tea.Cmd) {
 	m.turnRunning = false
 	m.cancelTurn = nil
-	var cmds []tea.Cmd
+	var b strings.Builder
 	if msg.task != nil {
-		var b bytes.Buffer
-		printTaskStatus(&b, msg.task)
-		cmds = append(cmds, tea.Println(strings.TrimRight(b.String(), "\n")))
+		var sb bytes.Buffer
+		printTaskStatus(&sb, msg.task)
+		b.WriteString(strings.TrimRight(sb.String(), "\n"))
 	}
 	switch {
 	case msg.err != nil && errors.Is(msg.err, context.Canceled):
-		cmds = append(cmds, tea.Println(noticeStyle.Render("^C interrupted")))
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(noticeStyle.Render("^C interrupted"))
 	case msg.err != nil:
-		cmds = append(cmds, tea.Println(errorStyle.Render("goal: "+msg.err.Error())))
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(errorStyle.Render("goal: " + msg.err.Error()))
 	case msg.task != nil:
-		cmds = append(cmds, tea.Println(noticeStyle.Render("Goal "+msg.task.ShortID()+" finished.")))
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(noticeStyle.Render("Goal " + msg.task.ShortID() + " finished."))
 	}
-	return m, tea.Batch(cmds...)
+	if b.Len() > 0 {
+		return m, tea.Println(b.String())
+	}
+	return m, nil
 }
 
 // goalResume resets a task's failed/skipped subtasks to pending and re-runs it.


### PR DESCRIPTION
bubbletea's tea.Batch runs commands concurrently, so multiple tea.Println calls issued in a batch could execute in any order. This caused the cache line to appear before the flushed assistant text, and tool cards to appear before the text that preceded them.

Fix: wherever we previously used tea.Batch to emit two or more scrollback lines in sequence, merge them into a single tea.Println with embedded newlines.