### PR TITLE
tui: alt-screen with internal scrollback, CC-style layout

### DIFF
--- a/cmd/octo/bgnotify_wiring_test.go
+++ b/cmd/octo/bgnotify_wiring_test.go
@@ -53,12 +53,12 @@ func TestRunTurn_PrependsIdleBgNote(t *testing.T) {
 	}
 }
 
-// TestTUI_BgExitMsgShowsNotice confirms an async background-exit message renders
-// a scrollback notice (a non-nil print command) rather than being dropped.
+// TestTUI_BgExitMsgShowsNotice confirms an async background-exit message is
+// appended to the scrollback buffer.
 func TestTUI_BgExitMsgShowsNotice(t *testing.T) {
 	m := newTestModel()
-	_, cmd := m.Update(bgExitMsg{e: tools.BgExit{ID: "bg_1", Command: "go test ./...", Status: "exited: 0"}})
-	if cmd == nil {
-		t.Fatal("bgExitMsg should produce a scrollback notice command")
+	m.Update(bgExitMsg{e: tools.BgExit{ID: "bg_1", Command: "go test ./...", Status: "exited: 0"}})
+	if len(m.scrollback) == 0 {
+		t.Fatal("bgExitMsg should append a scrollback notice")
 	}
 }

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -31,7 +31,7 @@ func runTUI(cfg replConfig) int {
 	defer tools.KillAllBackground()
 
 	m := newTUIModel(cfg)
-	p := tea.NewProgram(m)
+	p := tea.NewProgram(m, tea.WithAltScreen())
 	sink := &tuiSink{prog: p}
 	m.sink = sink
 
@@ -214,6 +214,14 @@ type tuiModel struct {
 	// tools suppress their started line, so without this they'd show nothing
 	// until completion.)
 	running *runningTool
+
+	// scrollback holds committed transcript lines (user messages, assistant
+	// text, tool cards, notices) rendered inside the alt-screen below the banner.
+	// On exit the buffer is dumped back to the main screen so history survives.
+	scrollback []string
+
+	// height is the terminal height in cells, updated by WindowSizeMsg.
+	height int
 }
 
 // runningTool is the live indicator state for an in-flight card tool.
@@ -285,17 +293,17 @@ func (m *tuiModel) startTurnEcho(line, echo string) tea.Cmd {
 	// transcript — except a degraded background-notice "turn", which already
 	// surfaced as a bg notice and isn't user input. Either way, start the
 	// animation ticker for the spinner + elapsed clock.
-	var echoCmd tea.Cmd
 	if echo != "" && !strings.HasPrefix(echo, "<system-reminder>") {
-		echoCmd = tea.Println(userEchoStyle.Render("> ") + echo)
+		m.pushScrollback(userEchoStyle.Render("> ") + echo)
 	}
-	return tea.Batch(echoCmd, tickCmd())
+	return tickCmd()
 }
 
 func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
+		m.height = msg.Height
 		m.ti.Width = msg.Width - 4 // account for border + padding
 		return m, nil
 
@@ -319,54 +327,39 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.handleEvent(msg.ev)
 
 	case noticeMsg:
-		return m, tea.Println(noticeStyle.Render(msg.text))
+		m.pushScrollback(noticeStyle.Render(msg.text))
+		return m, nil
 
 	case bgExitMsg:
 		// Async background-process completion: show a one-line scrollback notice
-		// (the full output rode into the conversation via Steer). Safe to print
-		// mid-turn — it's just another committed line.
-		return m, tea.Println(noticeStyle.Render(fmt.Sprintf(
+		// (the full output rode into the conversation via Steer).
+		m.pushScrollback(noticeStyle.Render(fmt.Sprintf(
 			"↳ %s (%s) %s", msg.e.ID, truncate1Line(msg.e.Command), msg.e.Status)))
+		return m, nil
 
 	case subAgentNoteMsg:
 		// Async sub-agent completion: show a one-line scrollback notice (the
-		// full result rode into the conversation via Steer). Safe to print
-		// mid-turn.
+		// full result rode into the conversation via Steer).
 		label := "completed"
 		if msg.ev.Kind == "message_reply" {
 			label = "replied"
 		}
-		return m, tea.Println(noticeStyle.Render(fmt.Sprintf(
+		m.pushScrollback(noticeStyle.Render(fmt.Sprintf(
 			"↳ sub-agent %s (%s) %s", msg.ev.AgentID, truncate1Line(msg.ev.Description), label)))
+		return m, nil
 
 	case turnEndedMsg:
 		// Flush any trailing assistant block (markdown-rendered); then render
-		// the cache/error footer. All lines are merged into a single tea.Println
-		// because tea.Batch runs commands concurrently and their output order is
-		// undefined — this was causing the cache line to appear before the
-		// flushed assistant text.
-		var b strings.Builder
+		// the cache/error footer.
 		if s, ok := m.flushTextString(); ok {
-			b.WriteString(s)
+			m.pushScrollback(s)
 		}
 		if msg.err != nil && msg.err != context.Canceled {
-			if b.Len() > 0 {
-				b.WriteByte('\n')
-			}
-			b.WriteString(errorStyle.Render("error: " + msg.err.Error()))
+			m.pushScrollback(errorStyle.Render("error: " + msg.err.Error()))
 		} else if msg.err == context.Canceled {
-			if b.Len() > 0 {
-				b.WriteByte('\n')
-			}
-			b.WriteString(noticeStyle.Render("^C interrupted"))
+			m.pushScrollback(noticeStyle.Render("^C interrupted"))
 		} else if c := cacheLine(m.cfg.verbosity, msg.reply); c != "" {
-			if b.Len() > 0 {
-				b.WriteByte('\n')
-			}
-			b.WriteString(c)
-		}
-		if b.Len() > 0 {
-			return m, tea.Println(b.String())
+			m.pushScrollback(c)
 		}
 		return m, nil
 
@@ -386,9 +379,10 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case goalCancelledMsg:
 		m.turnRunning = false
 		m.cancelTurn = nil
-		return m, tea.Println(noticeStyle.Render(fmt.Sprintf(
+		m.pushScrollback(noticeStyle.Render(fmt.Sprintf(
 			"Cancelled. Planned as %s — run later with /goal resume %s (or octo goal run %s).",
 			msg.task.ShortID(), msg.task.ShortID(), msg.task.ShortID())))
+		return m, nil
 
 	case goalDoneMsg:
 		return m.onGoalDone(msg)
@@ -459,7 +453,8 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) tea.Cmd {
 				m.inputHistory = append(m.inputHistory, line)
 			}
 		}
-		return tea.Println(userEchoStyle.Render("> ") + ev.Text)
+		m.pushScrollback(userEchoStyle.Render("> ") + ev.Text)
+		return nil
 	}
 	return nil
 }
@@ -487,7 +482,8 @@ func (m *tuiModel) appendText(text string) tea.Cmd {
 		complete := buf[:idx]
 		m.partial.Reset()
 		m.partial.WriteString(buf[idx+1:])
-		return tea.Println(complete)
+		m.pushScrollback(complete)
+		return nil
 	}
 
 	commit, rest := splitCommittableMarkdown(m.partial.String())
@@ -496,7 +492,8 @@ func (m *tuiModel) appendText(text string) tea.Cmd {
 	}
 	m.partial.Reset()
 	m.partial.WriteString(rest)
-	return tea.Println(m.md.render(commit, m.width))
+	m.pushScrollback(m.md.render(commit, m.width))
+	return nil
 }
 
 // flushText commits whatever assistant text is still buffered (the final or
@@ -507,13 +504,13 @@ func (m *tuiModel) flushText() tea.Cmd {
 	if !ok {
 		return nil
 	}
-	return tea.Println(s)
+	m.pushScrollback(s)
+	return nil
 }
 
 // flushTextString returns the buffered assistant text (rendered through glamour
 // unless --plain) and true when there was pending text. Used internally when
-// multiple lines must be emitted in strict order — the caller batches them into
-// a single tea.Println instead of tea.Batch which runs commands concurrently.
+// multiple lines must be emitted in strict order.
 func (m *tuiModel) flushTextString() (string, bool) {
 	p := m.partial.String()
 	if p == "" {
@@ -526,17 +523,19 @@ func (m *tuiModel) flushTextString() (string, bool) {
 	return m.md.render(p, m.width), true
 }
 
-// commitToolLine flushes any in-progress text, then prints the tool line/card.
-// The two lines are merged into a single tea.Println because tea.Batch runs
-// commands concurrently and their output order is undefined.
+// commitToolLine flushes any in-progress text, then appends the tool line/card
+// to the scrollback.
 func (m *tuiModel) commitToolLine(line string) tea.Cmd {
-	var b strings.Builder
 	if s, ok := m.flushTextString(); ok {
-		b.WriteString(s)
-		b.WriteByte('\n')
+		m.pushScrollback(s)
 	}
-	b.WriteString(line)
-	return tea.Println(b.String())
+	m.pushScrollback(line)
+	return nil
+}
+
+// pushScrollback appends a line to the internal scrollback buffer.
+func (m *tuiModel) pushScrollback(line string) {
+	m.scrollback = append(m.scrollback, line)
 }
 
 func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
@@ -553,13 +552,12 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 
 	// Degrade-to-queue: a steer that never hit a tool-batch boundary runs as
 	// the next turn, ahead of explicitly-queued items (design §8).
-	var cmds []tea.Cmd
 	if s := m.a.DrainSteer(); s != "" {
 		// Steer was never injected into a tool_result — show it now so the
 		// user sees it before the degraded turn starts, and add it to
 		// inputHistory so ↑ can recall it for re-editing.
 		for _, line := range strings.Split(s, "\n\n") {
-			cmds = append(cmds, tea.Println(userEchoStyle.Render("> ")+line))
+			m.pushScrollback(userEchoStyle.Render("> ") + line)
 			if len(m.inputHistory) == 0 || m.inputHistory[len(m.inputHistory)-1] != line {
 				m.inputHistory = append(m.inputHistory, line)
 			}
@@ -571,11 +569,7 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 	if len(m.queue) > 0 {
 		next := m.queue[0]
 		m.queue = m.queue[1:]
-		cmds = append(cmds, m.startTurnEcho(next.text, "")) // echo already shown above
-		return m, tea.Batch(cmds...)
-	}
-	if len(cmds) > 0 {
-		return m, tea.Batch(cmds...)
+		return m, m.startTurnEcho(next.text, "") // echo already shown above
 	}
 	return m, nil
 }

--- a/cmd/octo/tuirepl_goal.go
+++ b/cmd/octo/tuirepl_goal.go
@@ -37,16 +37,19 @@ type goalDoneMsg struct {
 func (m *tuiModel) dispatchGoal(args string) (tea.Model, tea.Cmd) {
 	fields := strings.Fields(args)
 	if len(fields) == 0 || strings.ToLower(fields[0]) == "help" {
-		return m, tea.Println(goalUsage())
+		m.pushScrollback(goalUsage())
+		return m, nil
 	}
 	switch strings.ToLower(fields[0]) {
 	case "list", "ls":
 		var b bytes.Buffer
 		runTaskList(nil, &b, &b)
-		return m, tea.Println(strings.TrimRight(b.String(), "\n"))
+		m.pushScrollback(strings.TrimRight(b.String(), "\n"))
+		return m, nil
 	case "resume":
 		if len(fields) < 2 {
-			return m, tea.Println(noticeStyle.Render("Usage: /goal resume <id>"))
+			m.pushScrollback(noticeStyle.Render("Usage: /goal resume <id>"))
+			return m, nil
 		}
 		return m.goalResume(fields[1])
 	default:
@@ -104,10 +107,9 @@ func (m *tuiModel) startGoalPlan(goal string) tea.Cmd {
 		task, err := store.Create(goal, subs)
 		prog.Send(goalPlannedMsg{task: task, err: err})
 	}()
-	return tea.Batch(
-		tea.Println(promptStyle.Render("> ")+"/goal "+goal+"\n"+noticeStyle.Render("Planning…")),
-		tickCmd(),
-	)
+	m.pushScrollback(promptStyle.Render("> ") + "/goal " + goal)
+	m.pushScrollback(noticeStyle.Render("Planning…"))
+	return tickCmd()
 }
 
 // onGoalPlanned renders the planned DAG and opens a confirm modal. A one-shot
@@ -117,12 +119,13 @@ func (m *tuiModel) onGoalPlanned(msg goalPlannedMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
 		m.turnRunning = false
 		m.cancelTurn = nil
-		return m, tea.Println(errorStyle.Render("goal: " + msg.err.Error()))
+		m.pushScrollback(errorStyle.Render("goal: " + msg.err.Error()))
+		return m, nil
 	}
 
 	var b bytes.Buffer
 	printPlannedDAG(&b, msg.task)
-	planLine := tea.Println(strings.TrimRight(b.String(), "\n"))
+	m.pushScrollback(strings.TrimRight(b.String(), "\n"))
 
 	ch := make(chan UserResponse, 1)
 	m.openModal(askMsg{
@@ -144,7 +147,7 @@ func (m *tuiModel) onGoalPlanned(msg goalPlannedMsg) (tea.Model, tea.Cmd) {
 		}
 		prog.Send(goalRunMsg{task: task})
 	}()
-	return m, planLine
+	return m, nil
 }
 
 // startGoalRun drives the scheduler in the background. Scheduler progress is
@@ -172,10 +175,8 @@ func (m *tuiModel) startGoalRun(taskID string) tea.Cmd {
 		task, _ := store.Get(taskID)
 		prog.Send(goalDoneMsg{task: task, err: runErr})
 	}()
-	return tea.Batch(
-		tea.Println(noticeStyle.Render("Running…")),
-		tickCmd(),
-	)
+	m.pushScrollback(noticeStyle.Render("Running…"))
+	return tickCmd()
 }
 
 // onGoalDone reports the final task state and releases the session.
@@ -206,7 +207,7 @@ func (m *tuiModel) onGoalDone(msg goalDoneMsg) (tea.Model, tea.Cmd) {
 		b.WriteString(noticeStyle.Render("Goal " + msg.task.ShortID() + " finished."))
 	}
 	if b.Len() > 0 {
-		return m, tea.Println(b.String())
+		m.pushScrollback(b.String())
 	}
 	return m, nil
 }
@@ -216,20 +217,21 @@ func (m *tuiModel) onGoalDone(msg goalDoneMsg) (tea.Model, tea.Cmd) {
 func (m *tuiModel) goalResume(idArg string) (tea.Model, tea.Cmd) {
 	store, err := taskgraph.NewStore()
 	if err != nil {
-		return m, tea.Println(errorStyle.Render("goal: " + err.Error()))
+		m.pushScrollback(errorStyle.Render("goal: " + err.Error()))
+		return m, nil
 	}
 	id, err := store.ResolveID(idArg)
 	if err != nil {
-		return m, tea.Println(errorStyle.Render("goal: " + err.Error() + "  (try /goal list)"))
+		m.pushScrollback(errorStyle.Render("goal: " + err.Error() + "  (try /goal list)"))
+		return m, nil
 	}
 	t, err := store.Update(id, resetForResume)
 	if err != nil {
-		return m, tea.Println(errorStyle.Render("goal: " + err.Error()))
+		m.pushScrollback(errorStyle.Render("goal: " + err.Error()))
+		return m, nil
 	}
-	return m, tea.Batch(
-		tea.Println(noticeStyle.Render(fmt.Sprintf("Resuming %s — re-running pending subtasks…", t.ShortID()))),
-		m.startGoalRun(t.ID),
-	)
+	m.pushScrollback(noticeStyle.Render(fmt.Sprintf("Resuming %s — re-running pending subtasks…", t.ShortID())))
+	return m, m.startGoalRun(t.ID)
 }
 
 // teaScrollbackWriter adapts the scheduler's io.Writer progress output into

--- a/cmd/octo/tuirepl_slash_test.go
+++ b/cmd/octo/tuirepl_slash_test.go
@@ -29,8 +29,11 @@ func TestTUI_SlashInfoCommandsDontStartTurn(t *testing.T) {
 		if m.turnRunning {
 			t.Errorf("%s should not start a turn", cmd)
 		}
-		if cmdFn == nil {
-			t.Errorf("%s should return a render Cmd", cmd)
+		if cmdFn != nil {
+			t.Errorf("%s should not return a Cmd (content goes to scrollback)", cmd)
+		}
+		if len(m.scrollback) == 0 {
+			t.Errorf("%s should append to scrollback", cmd)
 		}
 	}
 }
@@ -65,8 +68,11 @@ func TestTUI_GoalHelpDoesNotStartTurn(t *testing.T) {
 		if m.turnRunning {
 			t.Errorf("/goal %q should print usage, not start work", arg)
 		}
-		if cmd == nil {
-			t.Errorf("/goal %q should return a usage Cmd", arg)
+		if cmd != nil {
+			t.Errorf("/goal %q should not return a Cmd (content goes to scrollback)", arg)
+		}
+		if len(m.scrollback) == 0 {
+			t.Errorf("/goal %q should append usage to scrollback", arg)
 		}
 	}
 }
@@ -133,16 +139,16 @@ func TestTUI_GoalDoneInterruptedReleasesSession(t *testing.T) {
 
 func TestTUI_GoalCancelledReleasesSession(t *testing.T) {
 	// Declining the confirm modal routes goalCancelledMsg through Update,
-	// which must release the session and print a resume hint.
+	// which must release the session and append a resume hint to scrollback.
 	m := newTestModel()
 	m.turnRunning = true
 	task := &taskgraph.Task{ID: "20260529-120000-abcd1234", Goal: "g", Status: taskgraph.TaskPending}
-	_, cmd := m.Update(goalCancelledMsg{task: task})
+	m.Update(goalCancelledMsg{task: task})
 	if m.turnRunning {
 		t.Error("cancelling a planned goal must release the session")
 	}
-	if cmd == nil {
-		t.Error("expected a resume-hint notice Cmd")
+	if len(m.scrollback) == 0 {
+		t.Error("expected a resume-hint notice in scrollback")
 	}
 }
 
@@ -152,8 +158,11 @@ func TestTUI_GoalResumeMissingID(t *testing.T) {
 	if m.turnRunning {
 		t.Error("/goal resume with no id should print usage, not start work")
 	}
-	if cmd == nil {
-		t.Error("expected a usage Cmd")
+	if cmd != nil {
+		t.Error("should not return a Cmd (content goes to scrollback)")
+	}
+	if len(m.scrollback) == 0 {
+		t.Error("expected usage in scrollback")
 	}
 }
 
@@ -169,8 +178,11 @@ func TestTUI_GoalResumeUnknownID(t *testing.T) {
 	if m.turnRunning {
 		t.Error("an unresolvable id must not start a run")
 	}
-	if cmd == nil {
-		t.Error("expected an error notice Cmd")
+	if cmd != nil {
+		t.Error("should not return a Cmd (content goes to scrollback)")
+	}
+	if len(m.scrollback) == 0 {
+		t.Error("expected an error notice in scrollback")
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -36,7 +36,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyCtrlD:
 		m.quit = true
-		return m, tea.Quit
+		return m, tea.Sequence(m.dumpScrollbackCmd(), tea.Quit)
 
 	case tea.KeyCtrlC:
 		if m.turnRunning {
@@ -44,7 +44,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.quit = true
-		return m, tea.Quit
+		return m, tea.Sequence(m.dumpScrollbackCmd(), tea.Quit)
 
 	case tea.KeyEsc:
 		if m.turnRunning {
@@ -63,7 +63,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if n := len(m.queue); n > 0 {
 			dropped := m.queue[n-1].text
 			m.queue = m.queue[:n-1]
-			return m, tea.Println(queueStyle.Render("✕ unqueued: " + dropped))
+			m.pushScrollback(queueStyle.Render("✕ unqueued: " + dropped))
 		}
 		return m, nil
 
@@ -80,7 +80,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				next = permission.ModeInteractive
 			}
 			m.cfg.permEngine.SetMode(next)
-			return m, tea.Println(noticeStyle.Render("Permission mode: " + string(next)))
+			m.pushScrollback(noticeStyle.Render("Permission mode: " + string(next)))
 		}
 		return m, nil
 
@@ -140,7 +140,8 @@ func (m *tuiModel) submit(alt bool) (tea.Model, tea.Cmd) {
 	if alt {
 		// Queue: run as a future turn.
 		m.queue = append(m.queue, pendingItem{text: text})
-		return m, tea.Println(queueStyle.Render("＋ queued: " + text))
+		m.pushScrollback(queueStyle.Render("＋ queued: " + text))
+		return m, nil
 	}
 	// Steer: fold into the running turn at the next tool-batch boundary.
 	// No immediate UI echo — the steer text is displayed later via
@@ -160,7 +161,8 @@ func (m *tuiModel) dispatchSlash(text string) (tea.Model, tea.Cmd) {
 	// /init: generate .octorules as a normal tool-enabled turn.
 	if text == "/init" {
 		if len(cfg.tools) == 0 || cfg.executor == nil {
-			return m, tea.Println(noticeStyle.Render("/init needs tools — restart with: octo chat --tools"))
+			m.pushScrollback(noticeStyle.Render("/init needs tools — restart with: octo chat --tools"))
+			return m, nil
 		}
 		return m, m.startTurnEcho(initInstruction, "/init")
 	}
@@ -179,7 +181,7 @@ func (m *tuiModel) dispatchSlash(text string) (tea.Model, tea.Cmd) {
 	switch cmd {
 	case "/exit", "/quit":
 		m.quit = true
-		return m, tea.Quit
+		return m, tea.Sequence(m.dumpScrollbackCmd(), tea.Quit)
 	case "/goal":
 		return m.dispatchGoal(strings.TrimSpace(strings.TrimPrefix(text, first)))
 	case "/help", "/save", "/sessions", "/skills", "/memory", "/mcp":
@@ -202,7 +204,8 @@ func (m *tuiModel) dispatchSlash(text string) (tea.Model, tea.Cmd) {
 		case "/mcp":
 			printMCP(&b)
 		}
-		return m, tea.Println(strings.TrimRight(b.String(), "\n"))
+		m.pushScrollback(strings.TrimRight(b.String(), "\n"))
+		return m, nil
 	default:
 		// Not a recognised command — treat it as ordinary user text so
 		// paths, regexes, and other /-prefixed messages reach the model.
@@ -330,6 +333,41 @@ func keyIs(msg tea.KeyMsg, r rune) bool {
 
 // ── View ──
 
+// ccHeader renders the Claude Code-style top header: model · cwd.
+func (m *tuiModel) ccHeader() string {
+	var parts []string
+	if m.a.Model != "" {
+		parts = append(parts, m.a.Model)
+	}
+	if m.cwd != "" {
+		parts = append(parts, m.cwd)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return noticeStyle.Render(strings.Join(parts, " · "))
+}
+
+// liveHeight returns the number of lines the "live" region (partial text,
+// spinner, queue, background, input box, status bar) occupies.
+func (m *tuiModel) liveHeight() int {
+	h := 0
+	if m.partial.String() != "" {
+		h++
+	}
+	if m.running != nil || (m.turnRunning && !m.streaming) {
+		h++
+	}
+	if len(m.queue) > 0 {
+		h += 3 // panel title + border
+	}
+	if bg := tools.RunningBackground(); len(bg) > 0 {
+		h += 2 + len(bg) // panel with lines
+	}
+	h += 2 // input box + status bar
+	return h
+}
+
 func (m *tuiModel) View() string {
 	if m.quit {
 		return ""
@@ -340,19 +378,36 @@ func (m *tuiModel) View() string {
 
 	var b strings.Builder
 
-	// Banner always renders at the top of the fixed viewport; scrollback
-	// content naturally pushes it upward rather than abruptly hiding it.
-	b.WriteString(tui.Banner("", m.a.Model, m.cwd, m.width))
-	b.WriteByte('\n')
+	// ── Header ──
+	if h := m.ccHeader(); h != "" {
+		b.WriteString(h)
+		b.WriteByte('\n')
+	}
 
-	// Live partial assistant line (committed lines already scrolled up).
-	// Render through glamour so wrapping stays consistent with committed blocks.
+	// ── Scrollback (message history) ──
+	// Calculate how many lines we can show between header and live region.
+	liveH := m.liveHeight()
+	headerH := 1                                // ccHeader is 1 line
+	available := m.height - headerH - liveH - 1 // -1 for safety margin
+	if available < 0 {
+		available = 0
+	}
+	start := 0
+	if len(m.scrollback) > available {
+		start = len(m.scrollback) - available
+	}
+	for i := start; i < len(m.scrollback); i++ {
+		b.WriteString(m.scrollback[i])
+		b.WriteByte('\n')
+	}
+
+	// ── Live partial assistant text ──
 	if p := m.partial.String(); p != "" {
 		b.WriteString(m.md.render(p, m.width))
 		b.WriteByte('\n')
 	}
-	// Animated activity indicator: a running card-tool, else the "thinking"
-	// placeholder during the initial wait. Both tick via spinnerFrame.
+
+	// ── Activity indicator ──
 	if m.running != nil {
 		b.WriteString(m.spinnerLine(m.running.verb+"("+m.running.target+")", m.running.start))
 		b.WriteByte('\n')
@@ -361,7 +416,7 @@ func (m *tuiModel) View() string {
 		b.WriteByte('\n')
 	}
 
-	// Queue panel (bordered).
+	// ── Queue panel ──
 	if len(m.queue) > 0 {
 		var items strings.Builder
 		for i, q := range m.queue {
@@ -374,8 +429,7 @@ func (m *tuiModel) View() string {
 		b.WriteByte('\n')
 	}
 
-	// Background-processes panel (bordered): the still-running `terminal
-	// background:true` commands, animated by the ticker.
+	// ── Background processes panel ──
 	if bg := tools.RunningBackground(); len(bg) > 0 {
 		frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
 		var lines strings.Builder
@@ -389,7 +443,7 @@ func (m *tuiModel) View() string {
 		b.WriteByte('\n')
 	}
 
-	// Flat input line (no border) + separator + status bar.
+	// ── Input box + status bar ──
 	b.WriteString(m.renderInputBox())
 	b.WriteByte('\n')
 	b.WriteString(m.renderStatusBar())
@@ -534,4 +588,11 @@ func cacheLine(v verbosity, reply agent.Reply) string {
 	}
 	return noticeStyle.Render(fmt.Sprintf("  ⓘ cache: %d read, %d write (in %d / out %d)",
 		reply.CacheReadTokens, reply.CacheWriteTokens, reply.InputTokens, reply.OutputTokens))
+}
+
+// dumpScrollbackCmd returns a tea.Cmd that prints the scrollback buffer to the
+// terminal's main screen before the alt-screen is torn down. This preserves the
+// conversation history after exit, matching Claude Code's behaviour.
+func (m *tuiModel) dumpScrollbackCmd() tea.Cmd {
+	return tea.Println(strings.Join(m.scrollback, "\n"))
 }


### PR DESCRIPTION
Replace inline mode with alt-screen mode where all content is rendered inside View(). Fixes banner movement issue; matches Claude Code behaviour.

**Changes:**
- Enable alt-screen via `tea.WithAltScreen()`
- Internal `scrollback []string` buffer in `tuiModel`
- All `tea.Println` → `m.pushScrollback()`
- `View()` renders: header → history → partial text → spinner → panels → input → status bar
- Height-constrained scrollback (shows most recent lines)
- Exit dumps scrollback to main screen so history survives
- CC-style header line (model · cwd) replaces pixel-art banner

**Testing:**
- All TUI tests updated and passing
- Full `go test ./...` green