### PR TITLE
feat: [BACKGROUND COMPLETED] marker for async notifications

### DIFF
--- a/cmd/octo/bgnotify.go
+++ b/cmd/octo/bgnotify.go
@@ -15,6 +15,7 @@ import (
 func formatBgNote(e tools.BgExit) string {
 	var b strings.Builder
 	b.WriteString("<system-reminder>\n")
+	b.WriteString("[BACKGROUND COMPLETED]\n")
 	fmt.Fprintf(&b, "Background process %s (`%s`) %s.", e.ID, e.Command, e.Status)
 	if out := strings.TrimRight(e.NewOutput, "\n"); out != "" {
 		b.WriteString("\nOutput since last check:\n")

--- a/cmd/octo/subagent_notify.go
+++ b/cmd/octo/subagent_notify.go
@@ -15,6 +15,7 @@ import (
 func formatSubAgentNote(ev tools.SubAgentNotification) string {
 	var b strings.Builder
 	b.WriteString("<system-reminder>\n")
+	b.WriteString("[BACKGROUND COMPLETED]\n")
 	switch ev.Kind {
 	case "spawn_done":
 		fmt.Fprintf(&b, "Sub-agent %s (%s) has completed.", ev.AgentID, ev.Description)

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -79,6 +79,10 @@ The user always wins. Save the new fact via `remember`; the consolidator will re
 - When you reference code, cite it as `path:line` so the user can jump to it.
 - Report what you did and what's next in a sentence or two, not a wall of text.
 
+## Background processes
+
+- When a background process (e.g. `gh pr checks --watch`, long builds) completes, the harness injects a `[BACKGROUND COMPLETED]` system-reminder. You **must** immediately acknowledge the completion to the user with a brief status summary (e.g. "CI passed, merging now" or "Build failed — see logs above"). Do not wait for the user to ask.
+
 ## Tool-use timing
 
 - **When the user gives feedback, a reminder, or a correction, acknowledge it in text before you call any tool.** The user should see your response (e.g. an apology, a confirmation, or a brief plan) *before* the tool output appears. Never execute tools silently and only explain afterward.


### PR DESCRIPTION
Add [BACKGROUND COMPLETED] prefix to system-reminder notifications so the model can reliably identify async completion events and respond immediately.

**Changes:**
- : prepend  to background process notices
- : prepend  to sub-agent notices  
- : add rule requiring immediate acknowledgment of 

**Fixes:**
Background process completion (e.g. ) was silently injected without the model reacting, because the notification looked like any other system-reminder.