### PR TITLE
feat(tui): support mouse wheel scrolling in scrollback

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -31,7 +31,7 @@ func runTUI(cfg replConfig) int {
 	defer tools.KillAllBackground()
 
 	m := newTUIModel(cfg)
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	sink := &tuiSink{prog: p}
 	m.sink = sink
 
@@ -227,6 +227,10 @@ type tuiModel struct {
 	// On exit the buffer is dumped back to the main screen so history survives.
 	scrollback []string
 
+	// scrollOffset is the number of lines the user has scrolled up in the
+	// scrollback (0 = pinned to bottom, showing the newest content).
+	scrollOffset int
+
 	// height is the terminal height in cells, updated by WindowSizeMsg.
 	height int
 }
@@ -313,6 +317,9 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.ti.Width = msg.Width - 4 // account for border + padding
 		return m, nil
+
+	case tea.MouseMsg:
+		return m.handleMouse(msg)
 
 	case tea.KeyMsg:
 		return m.handleKey(msg)

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -28,6 +28,21 @@ var (
 
 // handleKey routes a keypress by context: a modal grabs all keys; otherwise the
 // keymap depends on whether a turn is running (design §7).
+func (m *tuiModel) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	// Only handle wheel events; ignore clicks, drags, etc.
+	switch msg.Type {
+	case tea.MouseWheelUp:
+		m.scrollOffset++
+		return m, nil
+	case tea.MouseWheelDown:
+		if m.scrollOffset > 0 {
+			m.scrollOffset--
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
 func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.modal != nil {
 		return m.handleModalKey(msg)
@@ -395,6 +410,19 @@ func (m *tuiModel) View() string {
 	start := 0
 	if len(m.scrollback) > available {
 		start = len(m.scrollback) - available
+	}
+	// Apply user scroll offset (mouse wheel), clamped so we never scroll past
+	// the top or below the bottom.
+	start -= m.scrollOffset
+	if start < 0 {
+		start = 0
+	}
+	maxOffset := len(m.scrollback) - available
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if m.scrollOffset > maxOffset {
+		m.scrollOffset = maxOffset
 	}
 	for i := start; i < len(m.scrollback); i++ {
 		b.WriteString(m.scrollback[i])


### PR DESCRIPTION
Mouse wheel events were swallowed by the textinput component, scrolling input history instead of the conversation transcript.

- Enable tea.WithMouseCellMotion() in the bubbletea program.
- Add scrollOffset to tuiModel to track user scroll position.
- Handle MouseWheelUp/Down in Update, adjusting scrollOffset.
- Clamp scrollOffset in View so it stays within valid bounds.

Fixes: mouse scroll now scrolls the message history.