### PR TITLE
fix(tools): kill background process group on Kill()

### DIFF
--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -21,6 +22,7 @@ type bgProcess struct {
 	id      string
 	command string
 	cancel  context.CancelFunc
+	proc    *os.Process // set after Start; used for hard-kill
 	start   time.Time
 
 	mu       sync.Mutex
@@ -136,7 +138,7 @@ func (m *BackgroundManager) Start(command string) (string, error) {
 	m.mu.Lock()
 	m.seq++
 	id := fmt.Sprintf("bg_%d", m.seq)
-	p := &bgProcess{id: id, command: command, cancel: cancel, start: time.Now()}
+	p := &bgProcess{id: id, command: command, cancel: cancel, proc: cmd.Process, start: time.Now()}
 	m.procs[id] = p
 	m.mu.Unlock()
 
@@ -222,6 +224,9 @@ func (m *BackgroundManager) Kill(id string) bool {
 		return false
 	}
 	p.cancel()
+	if p.proc != nil {
+		_ = killProcessGroup(p.proc)
+	}
 	return true
 }
 


### PR DESCRIPTION
BackgroundManager.Kill() previously only cancelled the context, which leaves the child process running if it ignores SIGTERM. Now it also calls killProcessGroup() to send SIGKILL to the entire process group, matching the synchronous terminal path.

Fixes the issue where killed background tasks (e.g. gh pr checks, brew install) continued running and showed as 'running' in the TUI.