### PR TITLE
fix(tools): block excessive terminal_output polling

### DIFF
--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -23,12 +23,13 @@ type bgProcess struct {
 	cancel  context.CancelFunc
 	start   time.Time
 
-	mu       sync.Mutex
-	buf      []byte // most recent <= maxBgOutputBytes of combined stdout+stderr
-	produced int64  // total bytes ever written to the logical stream
-	readOff  int64  // absolute offset already returned by Read
-	done     bool
-	exitErr  error
+	mu        sync.Mutex
+	buf       []byte // most recent <= maxBgOutputBytes of combined stdout+stderr
+	produced  int64  // total bytes ever written to the logical stream
+	readOff   int64  // absolute offset already returned by Read
+	done      bool
+	exitErr   error
+	pollCount int // consecutive empty reads while running
 }
 
 func (p *bgProcess) append(b []byte) {
@@ -51,7 +52,7 @@ func (p *bgProcess) finish(err error) {
 // readNew returns output produced since the last Read and the current status,
 // advancing the read cursor. When retained output was dropped (buffer cap), the
 // returned text is prefixed with a truncation marker.
-func (p *bgProcess) readNew() (string, string) {
+func (p *bgProcess) readNew() (string, string, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -72,7 +73,19 @@ func (p *bgProcess) readNew() (string, string) {
 			status = "exited: 0"
 		}
 	}
-	return string(out), status
+
+	// Anti-polling: if running and no new output, increment poll count.
+	// After 2 consecutive empty polls, report that polling is blocked.
+	blocked := false
+	if !p.done && len(out) == 0 {
+		p.pollCount++
+		if p.pollCount >= 2 {
+			blocked = true
+		}
+	} else {
+		p.pollCount = 0
+	}
+	return string(out), status, blocked
 }
 
 // BgExit is delivered to a BackgroundManager's onExit hook when a detached
@@ -162,7 +175,7 @@ func (m *BackgroundManager) Start(command string) (string, error) {
 		hook := m.onExit
 		m.mu.Unlock()
 		if hook != nil {
-			out, status := p.readNew() // advances the cursor → dedup vs terminal_output
+			out, status, _ := p.readNew() // advances the cursor → dedup vs terminal_output
 			hook(BgExit{ID: p.id, Command: p.command, Status: status, NewOutput: out})
 		}
 	}()
@@ -171,16 +184,18 @@ func (m *BackgroundManager) Start(command string) (string, error) {
 }
 
 // Read returns output produced since the last call for id, plus a status
-// string. found is false when id is unknown.
-func (m *BackgroundManager) Read(id string) (output, status string, found bool) {
+// string. found is false when id is unknown. blocked is true when the caller
+// has polled too many times without new output while the process is still
+// running — this forces the LLM to stop polling.
+func (m *BackgroundManager) Read(id string) (output, status string, found bool, blocked bool) {
 	m.mu.Lock()
 	p := m.procs[id]
 	m.mu.Unlock()
 	if p == nil {
-		return "", "", false
+		return "", "", false, false
 	}
-	out, st := p.readNew()
-	return out, st, true
+	out, st, blk := p.readNew()
+	return out, st, true, blk
 }
 
 // BgInfo is a snapshot of a still-running background process, for a live

--- a/internal/tools/background_listrunning_test.go
+++ b/internal/tools/background_listrunning_test.go
@@ -38,7 +38,7 @@ func TestBackgroundManager_ListRunning_ExcludesExited(t *testing.T) {
 	}
 	// Wait for it to finish (Read reports exited), then it must not be listed.
 	waitFor(t, "process to exit", func() bool {
-		_, status, _ := m.Read(id)
+		_, status, _, _ := m.Read(id)
 		return strings.HasPrefix(status, "exited")
 	})
 	if run := m.ListRunning(); len(run) != 0 {

--- a/internal/tools/background_onexit_test.go
+++ b/internal/tools/background_onexit_test.go
@@ -49,7 +49,7 @@ func TestBackgroundManager_OnExitHookFires(t *testing.T) {
 
 	// Dedup: the hook already consumed the output via readNew, so a subsequent
 	// terminal_output-style poll must not re-report the same bytes.
-	o, _, found := m.Read(id)
+	o, _, found, _ := m.Read(id)
 	if !found {
 		t.Fatal("process should still be known after exit")
 	}
@@ -68,7 +68,7 @@ func TestBackgroundManager_NoHookByDefault(t *testing.T) {
 	}
 	var out string
 	waitFor(t, "process to exit", func() bool {
-		o, s, f := m.Read(id)
+		o, s, f, _ := m.Read(id)
 		out += o
 		return f && strings.HasPrefix(s, "exited")
 	})

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -129,6 +129,11 @@ func TestTerminalOutputTool(t *testing.T) {
 	waitFor(t, "terminal_output to show exit", func() bool {
 		rTool, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_1"})
 		if err != nil {
+			// Anti-polling block is temporary while the process is still running
+			// with no new output; retry until it exits.
+			if strings.Contains(err.Error(), "polling blocked") {
+				return false
+			}
 			t.Fatalf("terminal_output: %v", err)
 		}
 		res += rTool.Text

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -31,7 +31,7 @@ func TestBackgroundManager_RunsAndReportsExit(t *testing.T) {
 	var out, status string
 	waitFor(t, "process to exit", func() bool {
 		var found bool
-		o, s, f := m.Read(id)
+		o, s, f, _ := m.Read(id)
 		found = f
 		if o != "" {
 			out += o // accumulate across reads (cursor advances)
@@ -57,17 +57,17 @@ func TestBackgroundManager_IncrementalRead(t *testing.T) {
 
 	// First chunk: "one" before "two" is emitted.
 	waitFor(t, "first line", func() bool {
-		o, _, _ := m.Read(id)
+		o, _, _, _ := m.Read(id)
 		return strings.Contains(o, "one")
 	})
 	// A read right after consuming "one" should not re-return it.
-	o, _, _ := m.Read(id)
+	o, _, _, _ := m.Read(id)
 	if strings.Contains(o, "one") {
 		t.Errorf("second read re-returned old output: %q", o)
 	}
 	// Eventually "two" arrives as new output.
 	waitFor(t, "second line", func() bool {
-		o, _, _ := m.Read(id)
+		o, _, _, _ := m.Read(id)
 		return strings.Contains(o, "two")
 	})
 }
@@ -82,7 +82,7 @@ func TestBackgroundManager_Kill(t *testing.T) {
 		t.Fatal("Kill returned false for a live process")
 	}
 	waitFor(t, "killed process to report exit", func() bool {
-		_, s, _ := m.Read(id)
+		_, s, _, _ := m.Read(id)
 		return strings.HasPrefix(s, "exited")
 	})
 
@@ -221,13 +221,47 @@ func TestTerminalTool_TimeoutPromotesToBackground(t *testing.T) {
 	// can be very slow.
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		_, s, _ := m.Read("bg_1")
+		_, s, _, _ := m.Read("bg_1")
 		if strings.HasPrefix(s, "exited") {
 			return
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatal("timed out waiting for background process to exit")
+}
+
+// TestTerminalOutputTool_AntiPolling verifies that after two consecutive empty
+// polls on a running background process, terminal_output returns an error to
+// force the LLM to stop polling.
+func TestTerminalOutputTool_AntiPolling(t *testing.T) {
+	m := NewBackgroundManager()
+	term := TerminalTool{mgr: m}
+	outTool := TerminalOutputTool{mgr: m}
+
+	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
+		"command":    "sleep 30",
+		"background": true,
+	}); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+
+	// First empty poll: should warn but succeed.
+	res1, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_1"})
+	if err != nil {
+		t.Fatalf("first poll should succeed: %v", err)
+	}
+	if !strings.Contains(res1.Text, "STOP POLLING") {
+		t.Errorf("first poll should warn, got %q", res1.Text)
+	}
+
+	// Second empty poll: should be blocked with an error.
+	_, err = outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_1"})
+	if err == nil {
+		t.Fatal("second poll should error")
+	}
+	if !strings.Contains(err.Error(), "polling blocked") {
+		t.Errorf("error should mention 'polling blocked', got %v", err)
+	}
 }
 
 func TestTerminalOutputTool_ReadOnly(t *testing.T) {
@@ -253,7 +287,7 @@ func TestTerminalOutputTool_ReadOnly(t *testing.T) {
 	if strings.Contains(resOut.Text, "killed") {
 		t.Errorf("terminal_output must not kill, got %q", resOut.Text)
 	}
-	if _, status, _ := m.Read("bg_1"); status != "running" {
+	if _, status, _, _ := m.Read("bg_1"); status != "running" {
 		t.Errorf("process should still be running after terminal_output, status=%q", status)
 	}
 	// When the process is running and there is no new output, the result must

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -264,9 +264,12 @@ func (t TerminalOutputTool) Execute(_ context.Context, _ string, input map[strin
 	if id == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: id is required")
 	}
-	out, status, found := t.manager().Read(id)
+	out, status, found, blocked := t.manager().Read(id)
 	if !found {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: no background process %q", id)
+	}
+	if blocked {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: polling blocked for %s — the process is still running with no new output. Wait for the automatic completion notification instead.", id)
 	}
 	header := "[status: " + status + "]"
 	if out == "" {
@@ -324,7 +327,7 @@ func (t KillShellTool) Execute(_ context.Context, _ string, input map[string]any
 	// Give the process a moment to flush and the waiter to record exit.
 	time.Sleep(50 * time.Millisecond)
 
-	out, status, _ := mgr.Read(id) // found guaranteed: Kill succeeded
+	out, status, _, _ := mgr.Read(id) // found guaranteed: Kill succeeded
 	header := "[killed] [status: " + status + "]"
 	if out == "" {
 		return agent.ToolResult{Text: header + "\n(no new output)"}, nil


### PR DESCRIPTION
BackgroundManager now tracks consecutive empty polls on running processes. After 2 empty reads, TerminalOutputTool returns an error instead of the STOP POLLING warning, forcing the LLM to stop polling.

This addresses the issue where the LLM ignored the STOP POLLING message and continued calling terminal_output in a loop.