### PR TITLE
fix(tui): correct scrollback viewport height calculation

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -358,13 +358,18 @@ func (m *tuiModel) liveHeight() int {
 	if m.running != nil || (m.turnRunning && !m.streaming) {
 		h++
 	}
-	if len(m.queue) > 0 {
-		h += 3 // panel title + border
+	if n := len(m.queue); n > 0 {
+		h += 3 + n // panel border (2) + title (1) + n body lines
 	}
 	if bg := tools.RunningBackground(); len(bg) > 0 {
-		h += 2 + len(bg) // panel with lines
+		h += 3 + len(bg) // panel border (2) + title (1) + body lines
 	}
-	h += 2 // input box + status bar
+	h++ // input box
+	if m.turnRunning {
+		h += 3 // status bar with hint: separator + segments + hint
+	} else {
+		h += 2 // status bar without hint: separator + segments
+	}
 	return h
 }
 
@@ -385,7 +390,7 @@ func (m *tuiModel) View() string {
 	// ── Scrollback (message history) ──
 	// Calculate how many lines we can show between header and live region.
 	liveH := m.liveHeight()
-	headerH := 1                                // ccHeader is 1 line
+	headerH := tui.BannerHeight + 1             // Banner + the newline after it
 	available := m.height - headerH - liveH - 1 // -1 for safety margin
 	if available < 0 {
 		available = 0

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -71,6 +71,9 @@ var octopusASCII = []string{
 	"      ████",
 }
 
+// BannerHeight is the number of lines Banner renders (including the separator).
+const BannerHeight = 8
+
 // Banner renders the octo chat welcome header with pixel-art mascot.
 // The icon sits left of the title, Claude Code style.
 func Banner(version, model, cwd string, width int) string {


### PR DESCRIPTION
修复 TUI 中 scrollback 视口高度计算错误导致鼠标滚轮滚动无响应的问题。

### 问题
TUI 中鼠标滚轮滚动 scrollback 时，内容似乎没有滚动。根本原因是 available（scrollback 可用行数）被高估，导致 scrollback 区域超出屏幕底部，被 live 区域覆盖。用户滚动时，被滚动的内容在屏幕外。

### 修复
- internal/tui/theme.go: 添加 BannerHeight = 8 常量
- cmd/octo/tuirepl_view.go:
  - headerH: 从硬编码 1 修复为 tui.BannerHeight + 1
  - liveHeight(): 修正 queue panel、background panel、status bar 的高度计算

### 测试
- go test ./... 全部通过
- go vet ./... 通过