### PR TITLE
fix(tui): fix mouse scroll not working on some terminals

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -31,7 +31,7 @@ func runTUI(cfg replConfig) int {
 	defer tools.KillAllBackground()
 
 	m := newTUIModel(cfg)
-	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseAllMotion())
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	sink := &tuiSink{prog: p}
 	m.sink = sink
 
@@ -564,14 +564,12 @@ func (m *tuiModel) commitToolLine(line string) tea.Cmd {
 }
 
 // pushScrollback appends a line to the internal scrollback buffer.
-// If a turn is running, the view auto-follows by resetting scrollOffset to 0
-// so new content is always visible. When no turn is active, the scroll position
-// is preserved so the user can review history undisturbed.
+// When scrollOffset == 0 (view pinned to bottom), the View() start calculation
+// naturally follows new content because start = len(scrollback) - available.
+// When the user has scrolled up (scrollOffset > 0), their position is preserved
+// — use mouse wheel or trackpad to scroll back down.
 func (m *tuiModel) pushScrollback(line string) {
 	m.scrollback = append(m.scrollback, line)
-	if m.turnRunning {
-		m.scrollOffset = 0
-	}
 }
 
 func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -312,6 +312,7 @@ func TestTUI_SubmitSavesToHistory(t *testing.T) {
 
 func TestTUI_ScrollbackAutoFollowsDuringTurn(t *testing.T) {
 	m := newTestModel()
+	m.height = 30
 
 	// Pre-populate scrollback with enough lines to scroll.
 	for i := 0; i < 30; i++ {
@@ -319,16 +320,25 @@ func TestTUI_ScrollbackAutoFollowsDuringTurn(t *testing.T) {
 	}
 
 	// User scrolls up.
-	m.scrollOffset = 10
-	if m.scrollOffset != 10 {
-		t.Fatal("scrollOffset should be 10 after scrolling up")
+	m.scrollOffset = 5
+	if m.scrollOffset != 5 {
+		t.Fatal("scrollOffset should be 5 after scrolling up")
 	}
 
-	// New content arrives during a turn — should auto-reset to bottom.
+	// New content arrives during a turn — should NOT reset scrollOffset.
+	// The user's scrolled position is preserved.
 	m.turnRunning = true
 	m.pushScrollback("new content")
+	if m.scrollOffset != 5 {
+		t.Errorf("pushScrollback should preserve scrollOffset when user scrolled up, got %d", m.scrollOffset)
+	}
+
+	// When at bottom (scrollOffset=0), new content is naturally followed
+	// because View() start = len(scrollback) - available.
+	m.scrollOffset = 0
+	m.pushScrollback("another line")
 	if m.scrollOffset != 0 {
-		t.Errorf("pushScrollback during turn should reset scrollOffset to 0, got %d", m.scrollOffset)
+		t.Errorf("pushScrollback at bottom should keep scrollOffset 0, got %d", m.scrollOffset)
 	}
 }
 


### PR DESCRIPTION
Two changes:

1. **Mouse mode: AllMotion → CellMotion.** `WithMouseAllMotion()` sends events on every pixel movement, which can overwhelm the event queue and prevent wheel events from being delivered on some terminals (especially macOS trackpads). `WithMouseCellMotion()` only sends events when the mouse crosses cell boundaries.

2. **Remove pushScrollback auto-reset.** The previous scroll fix forced `scrollOffset` to 0 on every `pushScrollback` during a turn, preventing users from scrolling up to read history — each new line snapped them back to the bottom. Now `scrollOffset` is preserved; the `View()` start calculation naturally follows new content when `scrollOffset == 0`.