### PR TITLE
feat(weixin): implement iLink protocol with QR login

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -10,15 +10,80 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/channel"
+	"github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink"
 	"github.com/Leihb/octo-agent/internal/config"
 	"github.com/Leihb/octo-agent/internal/prompt"
 	"github.com/Leihb/octo-agent/internal/skills"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
-// runChannel handles `octo channel start`.
+// runChannel handles `octo channel start` and `octo channel login`.
 func runChannel(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("channel", flag.ContinueOnError)
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "Usage: octo channel <login|start> [flags]")
+		return 2
+	}
+
+	switch args[0] {
+	case "login":
+		return runChannelLogin(args[1:], stdin, stdout, stderr)
+	case "start":
+		return runChannelStart(args[1:], stdin, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "octo channel: unknown subcommand %q\n", args[0])
+		fmt.Fprintln(stderr, "Usage: octo channel <login|start>")
+		return 2
+	}
+}
+
+// runChannelLogin handles `octo channel login`.
+// It shows a QR code URL, polls for scan status, and saves the bot_token.
+func runChannelLogin(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("channel login", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	platform := fs.String("platform", "weixin", "Platform to log in to")
+	force := fs.Bool("force", false, "Force re-login even if credentials exist")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if *platform != "weixin" {
+		fmt.Fprintf(stderr, "octo channel login: unsupported platform %q (only 'weixin' supported)\n", *platform)
+		return 2
+	}
+
+	ctx := context.Background()
+	client := ilink.NewClient()
+
+	fmt.Fprintln(stdout, "Starting WeChat iLink login...")
+	fmt.Fprintln(stdout, "")
+
+	creds, err := ilink.Login(ctx, client, ilink.LoginOptions{
+		Force: *force,
+		OnQRURL: func(url string) {
+			fmt.Fprintf(stdout, "📱 Scan this QR code in WeChat:\n%s\n", url)
+		},
+		OnScanned: func() {
+			fmt.Fprintln(stdout, "✓ QR code scanned — confirm login in WeChat")
+		},
+		OnExpired: func() {
+			fmt.Fprintln(stdout, "✗ QR code expired — requesting new one")
+		},
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "octo channel login: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintln(stdout, "")
+	fmt.Fprintf(stdout, "✓ Logged in as %s\n", creds.UserID)
+	fmt.Fprintf(stdout, "Credentials saved to %s\n", ilink.DefaultCredPath())
+	return 0
+}
+
+// runChannelStart handles `octo channel start`.
+func runChannelStart(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("channel start", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	providerName := fs.String("provider", "", "Provider: anthropic | openai")
 	model := fs.String("model", "", "Model name")
@@ -28,11 +93,6 @@ func runChannel(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message")
 	noTools := fs.Bool("no-tools", false, "Disable built-in tools")
 	if err := fs.Parse(args); err != nil {
-		return 2
-	}
-
-	if len(fs.Args()) == 0 || fs.Args()[0] != "start" {
-		fmt.Fprintln(stderr, "Usage: octo channel start [flags]")
 		return 2
 	}
 
@@ -86,16 +146,9 @@ func runChannel(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	mode := channel.BindingMode(*bindMode)
 	mgr := channel.NewManager(chCfg, agentFactory, mode)
 
-	// Wire inbound message handling: for each message, get/create session,
-	// build a UIController, and run the agent.
-	// The manager's Start handles adapter lifecycle; we inject our own
-	// onMessage callback by wrapping the adapter starts.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Override the manager's default message handling with agent execution.
-	// We do this by starting adapters ourselves and using the manager for
-	// session management only.
 	for _, name := range chCfg.EnabledPlatforms() {
 		pc := chCfg.Platform(name)
 		if pc == nil {
@@ -147,20 +200,6 @@ func handleCommand(mgr *channel.Manager, ad channel.Adapter, ev channel.InboundE
 	if len(text) == 0 || text[0] != '/' {
 		return false
 	}
-	// Delegate to manager's command router, but we need to send replies ourselves
-	// since the manager doesn't have direct adapter access in this wiring.
-	// The manager's handleInbound does routing + reply; we replicate the check.
-	// For simplicity, we let the manager handle it and rely on its sendReply.
-	// But mgr.sendReply needs the adapter stored in mgr.adapters.
-	// So we just let the manager's normal flow handle commands by calling
-	// handleInbound directly — but that also calls handleSessionMessage.
-	// Instead, we manually route commands here.
-
-	// Actually, the simplest approach: use the manager's commandRouter directly.
-	// But it's unexported. We reimplement the command detection.
-	// For now, just return false and let the agent handle it as a message.
-	// Commands like /bind /status will be processed by the LLM as regular text.
-	// TODO: expose command routing or handle here.
 	return false
 }
 

--- a/internal/channel/adapters/weixin/ilink/auth.go
+++ b/internal/channel/adapters/weixin/ilink/auth.go
@@ -1,0 +1,174 @@
+// Package ilink implements the WeChat iLink Bot HTTP protocol.
+package ilink
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// DefaultCredPath returns ~/.octo/weixin-credentials.json
+func DefaultCredPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".octo", "weixin-credentials.json")
+}
+
+// LoadCredentials loads stored credentials from disk.
+func LoadCredentials(path string) (*Credentials, error) {
+	if path == "" {
+		path = DefaultCredPath()
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var creds Credentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, err
+	}
+	return &creds, nil
+}
+
+// SaveCredentials persists credentials to disk with 0600 permissions.
+func SaveCredentials(creds *Credentials, path string) error {
+	if path == "" {
+		path = DefaultCredPath()
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	data, _ := json.MarshalIndent(creds, "", "  ")
+	return os.WriteFile(path, append(data, '\n'), 0600)
+}
+
+// ClearCredentials removes stored credentials.
+func ClearCredentials(path string) error {
+	if path == "" {
+		path = DefaultCredPath()
+	}
+	return os.Remove(path)
+}
+
+// LoginOptions configures the login flow.
+type LoginOptions struct {
+	BaseURL   string
+	CredPath  string
+	Force     bool
+	OnQRURL   func(url string)
+	OnScanned func()
+	OnExpired func()
+}
+
+const (
+	maxQRRefreshCount = 3
+	fixedQRBaseURL    = "https://ilinkai.weixin.qq.com"
+)
+
+// Login performs QR code login, returning credentials.
+// If stored credentials exist and Force is false, returns them directly.
+// Handles IDC redirect (scaned_but_redirect) and limits QR refreshes.
+func Login(ctx context.Context, client *Client, opts LoginOptions) (*Credentials, error) {
+	baseURL := opts.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+
+	if !opts.Force {
+		creds, err := LoadCredentials(opts.CredPath)
+		if err == nil && creds != nil {
+			return creds, nil
+		}
+	}
+
+	qrRefreshCount := 0
+	for {
+		qrRefreshCount++
+		if qrRefreshCount > maxQRRefreshCount {
+			return nil, fmt.Errorf("QR code expired %d times — login aborted", maxQRRefreshCount)
+		}
+
+		qr, err := client.GetQRCode(ctx, fixedQRBaseURL)
+		if err != nil {
+			return nil, fmt.Errorf("get QR code: %w", err)
+		}
+
+		if opts.OnQRURL != nil {
+			opts.OnQRURL(qr.QRCodeImgURL)
+		} else {
+			fmt.Fprintf(os.Stderr, "[weixin] Scan this URL in WeChat: %s\n", qr.QRCodeImgURL)
+		}
+
+		lastStatus := ""
+		currentPollBaseURL := fixedQRBaseURL
+		for {
+			status, err := client.PollQRStatus(ctx, currentPollBaseURL, qr.QRCode)
+			if err != nil {
+				return nil, fmt.Errorf("poll QR status: %w", err)
+			}
+
+			if status.Status != lastStatus {
+				lastStatus = status.Status
+				switch status.Status {
+				case "scaned":
+					if opts.OnScanned != nil {
+						opts.OnScanned()
+					} else {
+						fmt.Fprintln(os.Stderr, "[weixin] QR scanned — confirm in WeChat")
+					}
+				case "expired":
+					if opts.OnExpired != nil {
+						opts.OnExpired()
+					} else {
+						fmt.Fprintln(os.Stderr, "[weixin] QR expired — requesting new one")
+					}
+				case "confirmed":
+					fmt.Fprintln(os.Stderr, "[weixin] Login confirmed")
+				}
+			}
+
+			if status.Status == "confirmed" {
+				if status.BotToken == "" || status.BotID == "" || status.UserID == "" {
+					return nil, fmt.Errorf("login confirmed but missing credentials")
+				}
+				resolvedBase := baseURL
+				if status.BaseURL != "" {
+					resolvedBase = status.BaseURL
+				}
+				creds := &Credentials{
+					Token:     status.BotToken,
+					BaseURL:   resolvedBase,
+					AccountID: status.BotID,
+					UserID:    status.UserID,
+					SavedAt:   time.Now().UTC().Format(time.RFC3339),
+				}
+				if err := SaveCredentials(creds, opts.CredPath); err != nil {
+					fmt.Fprintf(os.Stderr, "[weixin] Warning: could not save credentials: %v\n", err)
+				}
+				return creds, nil
+			}
+
+			// Handle IDC redirect
+			if status.Status == "scaned_but_redirect" {
+				if status.RedirectHost != "" {
+					currentPollBaseURL = "https://" + status.RedirectHost
+					fmt.Fprintf(os.Stderr, "[weixin] IDC redirect → %s\n", status.RedirectHost)
+				}
+				time.Sleep(2 * time.Second)
+				continue
+			}
+
+			if status.Status == "expired" {
+				break // Outer loop gets a new QR
+			}
+
+			time.Sleep(2 * time.Second)
+		}
+	}
+}

--- a/internal/channel/adapters/weixin/ilink/protocol.go
+++ b/internal/channel/adapters/weixin/ilink/protocol.go
@@ -1,0 +1,281 @@
+// Package ilink implements the WeChat iLink Bot HTTP protocol.
+//
+// This is a pure-Go implementation of the iLink protocol (https://ilinkai.weixin.qq.com)
+// with no external dependencies. It supports QR login, long-poll message receiving,
+// text/media sending, and typing indicators.
+package ilink
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const (
+	// DefaultBaseURL is the iLink API host.
+	DefaultBaseURL = "https://ilinkai.weixin.qq.com"
+	// CDNBaseURL is the media CDN host.
+	CDNBaseURL = "https://novac2c.cdn.weixin.qq.com/c2c"
+	// ChannelVersion is the protocol version.
+	ChannelVersion = "0.1.0"
+	// iLinkAppID is the iLink-App-Id header value.
+	iLinkAppID = "bot"
+	// iLinkClientVer is the iLink-App-ClientVersion header value (0x00MMNNPP for 0.1.0 = 256).
+	iLinkClientVer = "256"
+)
+
+// APIError is returned when the iLink API returns a non-zero ret or HTTP error.
+type APIError struct {
+	Message    string
+	HTTPStatus int
+	ErrCode    int
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("ilink api: %s (http=%d, errcode=%d)", e.Message, e.HTTPStatus, e.ErrCode)
+}
+
+// IsSessionExpired returns true if this error indicates session timeout.
+func (e *APIError) IsSessionExpired() bool {
+	return e.ErrCode == -14
+}
+
+// RandomWechatUIN generates the X-WECHAT-UIN header value.
+func RandomWechatUIN() string {
+	var buf [4]byte
+	rand.Read(buf[:])
+	val := binary.BigEndian.Uint32(buf[:])
+	return base64.StdEncoding.EncodeToString([]byte(strconv.FormatUint(uint64(val), 10)))
+}
+
+// CommonHeaders returns headers included in both GET and POST requests.
+func CommonHeaders() http.Header {
+	h := http.Header{}
+	h.Set("iLink-App-Id", iLinkAppID)
+	h.Set("iLink-App-ClientVersion", iLinkClientVer)
+	return h
+}
+
+// AuthHeaders returns the standard iLink POST headers.
+func AuthHeaders(token string) http.Header {
+	h := CommonHeaders()
+	h.Set("Content-Type", "application/json")
+	h.Set("AuthorizationType", "ilink_bot_token")
+	h.Set("Authorization", "Bearer "+token)
+	h.Set("X-WECHAT-UIN", RandomWechatUIN())
+	return h
+}
+
+func baseInfo() map[string]string {
+	return map[string]string{"channel_version": ChannelVersion}
+}
+
+// Client wraps HTTP calls to the iLink API.
+type Client struct {
+	HTTP *http.Client
+}
+
+// NewClient creates a protocol client with sensible defaults.
+func NewClient() *Client {
+	return &Client{
+		HTTP: &http.Client{Timeout: 45 * time.Second},
+	}
+}
+
+// QRCodeResponse from get_bot_qrcode.
+type QRCodeResponse struct {
+	QRCode       string `json:"qrcode"`
+	QRCodeImgURL string `json:"qrcode_img_content"`
+}
+
+// QRStatusResponse from get_qrcode_status.
+type QRStatusResponse struct {
+	Status       string `json:"status"` // wait, scaned, confirmed, expired, scaned_but_redirect
+	BotToken     string `json:"bot_token,omitempty"`
+	BotID        string `json:"ilink_bot_id,omitempty"`
+	UserID       string `json:"ilink_user_id,omitempty"`
+	BaseURL      string `json:"baseurl,omitempty"`
+	RedirectHost string `json:"redirect_host,omitempty"` // set when status is scaned_but_redirect
+}
+
+// GetUpdatesResponse from getupdates.
+type GetUpdatesResponse struct {
+	Ret           int               `json:"ret"`
+	Msgs          []json.RawMessage `json:"msgs"`
+	GetUpdatesBuf string            `json:"get_updates_buf"`
+	ErrCode       int               `json:"errcode,omitempty"`
+	ErrMsg        string            `json:"errmsg,omitempty"`
+}
+
+// GetConfigResponse from getconfig.
+type GetConfigResponse struct {
+	TypingTicket string `json:"typing_ticket,omitempty"`
+	Ret          int    `json:"ret,omitempty"`
+}
+
+// GetQRCode requests a new QR code for login.
+func (c *Client) GetQRCode(ctx context.Context, baseURL string) (*QRCodeResponse, error) {
+	u := baseURL + "/ilink/bot/get_bot_qrcode?bot_type=3"
+	req, _ := http.NewRequestWithContext(ctx, "GET", u, nil)
+	for k, v := range CommonHeaders() {
+		req.Header[k] = v
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get_bot_qrcode: %w", err)
+	}
+	defer resp.Body.Close()
+	var result QRCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("get_bot_qrcode decode: %w", err)
+	}
+	return &result, nil
+}
+
+// PollQRStatus polls the QR code scan status.
+func (c *Client) PollQRStatus(ctx context.Context, baseURL, qrcode string) (*QRStatusResponse, error) {
+	u := baseURL + "/ilink/bot/get_qrcode_status?qrcode=" + url.QueryEscape(qrcode)
+	req, _ := http.NewRequestWithContext(ctx, "GET", u, nil)
+	for k, v := range CommonHeaders() {
+		req.Header[k] = v
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var result QRStatusResponse
+	json.NewDecoder(resp.Body).Decode(&result)
+	return &result, nil
+}
+
+// apiPost sends a POST to the iLink API and parses the response.
+func (c *Client) apiPost(ctx context.Context, baseURL, endpoint, token string, body interface{}, timeout time.Duration) (json.RawMessage, error) {
+	data, _ := json.Marshal(body)
+	u := baseURL + endpoint
+	httpCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(httpCtx, "POST", u, bytes.NewReader(data))
+	for k, v := range AuthHeaders(token) {
+		req.Header[k] = v
+	}
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, &APIError{Message: string(raw), HTTPStatus: resp.StatusCode}
+	}
+
+	// Check ret != 0 or errcode != 0
+	var check struct {
+		Ret     int    `json:"ret"`
+		ErrCode int    `json:"errcode"`
+		ErrMsg  string `json:"errmsg"`
+	}
+	json.Unmarshal(raw, &check)
+	if check.Ret != 0 || check.ErrCode != 0 {
+		code := check.ErrCode
+		if code == 0 {
+			code = check.Ret
+		}
+		msg := check.ErrMsg
+		if msg == "" {
+			msg = fmt.Sprintf("ret=%d", check.Ret)
+		}
+		return nil, &APIError{Message: msg, HTTPStatus: resp.StatusCode, ErrCode: code}
+	}
+
+	return json.RawMessage(raw), nil
+}
+
+// GetUpdates performs a long-poll for new messages.
+func (c *Client) GetUpdates(ctx context.Context, baseURL, token, cursor string) (*GetUpdatesResponse, error) {
+	body := map[string]interface{}{
+		"get_updates_buf": cursor,
+		"base_info":       baseInfo(),
+	}
+	raw, err := c.apiPost(ctx, baseURL, "/ilink/bot/getupdates", token, body, 45*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	var result GetUpdatesResponse
+	json.Unmarshal(raw, &result)
+	return &result, nil
+}
+
+// SendMessage sends a message through the iLink API.
+func (c *Client) SendMessage(ctx context.Context, baseURL, token string, msg interface{}) error {
+	body := map[string]interface{}{
+		"msg":       msg,
+		"base_info": baseInfo(),
+	}
+	_, err := c.apiPost(ctx, baseURL, "/ilink/bot/sendmessage", token, body, 15*time.Second)
+	return err
+}
+
+// GetConfig gets the typing ticket for a user.
+func (c *Client) GetConfig(ctx context.Context, baseURL, token, userID, contextToken string) (*GetConfigResponse, error) {
+	body := map[string]interface{}{
+		"ilink_user_id": userID,
+		"context_token": contextToken,
+		"base_info":     baseInfo(),
+	}
+	raw, err := c.apiPost(ctx, baseURL, "/ilink/bot/getconfig", token, body, 15*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	var result GetConfigResponse
+	json.Unmarshal(raw, &result)
+	return &result, nil
+}
+
+// SendTyping sends or cancels the typing indicator.
+func (c *Client) SendTyping(ctx context.Context, baseURL, token, userID, ticket string, status int) error {
+	body := map[string]interface{}{
+		"ilink_user_id": userID,
+		"typing_ticket": ticket,
+		"status":        status,
+		"base_info":     baseInfo(),
+	}
+	_, err := c.apiPost(ctx, baseURL, "/ilink/bot/sendtyping", token, body, 15*time.Second)
+	return err
+}
+
+// BuildTextMessage creates a text message payload.
+func BuildTextMessage(userID, contextToken, text string) map[string]interface{} {
+	return map[string]interface{}{
+		"from_user_id":  "",
+		"to_user_id":    userID,
+		"client_id":     newUUID(),
+		"message_type":  2,
+		"message_state": 2,
+		"context_token": contextToken,
+		"item_list": []map[string]interface{}{
+			{"type": 1, "text_item": map[string]string{"text": text}},
+		},
+	}
+}
+
+func newUUID() string {
+	var buf [16]byte
+	rand.Read(buf[:])
+	buf[6] = (buf[6] & 0x0f) | 0x40
+	buf[8] = (buf[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16])
+}

--- a/internal/channel/adapters/weixin/ilink/types.go
+++ b/internal/channel/adapters/weixin/ilink/types.go
@@ -1,0 +1,205 @@
+package ilink
+
+import "time"
+
+// MessageType indicates who sent the message.
+type MessageType int
+
+const (
+	MessageTypeUser MessageType = 1
+	MessageTypeBot  MessageType = 2
+)
+
+// MessageState indicates the message delivery state.
+type MessageState int
+
+const (
+	MessageStateNew        MessageState = 0
+	MessageStateGenerating MessageState = 1
+	MessageStateFinish     MessageState = 2
+)
+
+// MessageItemType indicates the content type of a message item.
+type MessageItemType int
+
+const (
+	ItemText  MessageItemType = 1
+	ItemImage MessageItemType = 2
+	ItemVoice MessageItemType = 3
+	ItemFile  MessageItemType = 4
+	ItemVideo MessageItemType = 5
+)
+
+// MediaType is used in upload requests.
+type MediaType int
+
+const (
+	MediaImage MediaType = 1
+	MediaVideo MediaType = 2
+	MediaFile  MediaType = 3
+	MediaVoice MediaType = 4
+)
+
+// BaseInfo is included in every POST request body.
+type BaseInfo struct {
+	ChannelVersion string `json:"channel_version"`
+}
+
+// CDNMedia references an encrypted file on the WeChat CDN.
+type CDNMedia struct {
+	EncryptQueryParam string `json:"encrypt_query_param"`
+	AESKey            string `json:"aes_key"`
+	EncryptType       int    `json:"encrypt_type,omitempty"`
+	// FullURL is the complete download URL returned by server; when set, use directly.
+	FullURL string `json:"full_url,omitempty"`
+}
+
+// TextItem holds text content.
+type TextItem struct {
+	Text string `json:"text"`
+}
+
+// ImageItem holds image content and CDN references.
+type ImageItem struct {
+	Media       *CDNMedia `json:"media,omitempty"`
+	ThumbMedia  *CDNMedia `json:"thumb_media,omitempty"`
+	AESKey      string    `json:"aeskey,omitempty"`
+	URL         string    `json:"url,omitempty"`
+	MidSize     int64     `json:"mid_size,omitempty"`
+	ThumbSize   int64     `json:"thumb_size,omitempty"`
+	ThumbWidth  int       `json:"thumb_width,omitempty"`
+	ThumbHeight int       `json:"thumb_height,omitempty"`
+	HDSize      int64     `json:"hd_size,omitempty"`
+}
+
+// VoiceItem holds voice content.
+type VoiceItem struct {
+	Media      *CDNMedia `json:"media,omitempty"`
+	EncodeType int       `json:"encode_type,omitempty"`
+	Text       string    `json:"text,omitempty"`
+	Playtime   int       `json:"playtime,omitempty"`
+}
+
+// FileItem holds file content.
+type FileItem struct {
+	Media    *CDNMedia `json:"media,omitempty"`
+	FileName string    `json:"file_name,omitempty"`
+	MD5      string    `json:"md5,omitempty"`
+	Len      string    `json:"len,omitempty"`
+}
+
+// VideoItem holds video content.
+type VideoItem struct {
+	Media      *CDNMedia `json:"media,omitempty"`
+	VideoSize  int64     `json:"video_size,omitempty"`
+	PlayLength int       `json:"play_length,omitempty"`
+	ThumbMedia *CDNMedia `json:"thumb_media,omitempty"`
+}
+
+// RefMessage represents a quoted/referenced message.
+type RefMessage struct {
+	Title       string       `json:"title,omitempty"`
+	MessageItem *MessageItem `json:"message_item,omitempty"`
+}
+
+// MessageItem is a single content item within a message.
+type MessageItem struct {
+	Type      MessageItemType `json:"type"`
+	TextItem  *TextItem       `json:"text_item,omitempty"`
+	ImageItem *ImageItem      `json:"image_item,omitempty"`
+	VoiceItem *VoiceItem      `json:"voice_item,omitempty"`
+	FileItem  *FileItem       `json:"file_item,omitempty"`
+	VideoItem *VideoItem      `json:"video_item,omitempty"`
+	RefMsg    *RefMessage     `json:"ref_msg,omitempty"`
+}
+
+// WireMessage is the raw message from the iLink API.
+type WireMessage struct {
+	Seq          int64         `json:"seq,omitempty"`
+	MessageID    int64         `json:"message_id,omitempty"`
+	FromUserID   string        `json:"from_user_id"`
+	ToUserID     string        `json:"to_user_id"`
+	ClientID     string        `json:"client_id"`
+	CreateTimeMs int64         `json:"create_time_ms"`
+	MessageType  MessageType   `json:"message_type"`
+	MessageState MessageState  `json:"message_state"`
+	ContextToken string        `json:"context_token"`
+	ItemList     []MessageItem `json:"item_list"`
+}
+
+// ContentType is the primary type of an incoming message.
+type ContentType string
+
+const (
+	ContentText  ContentType = "text"
+	ContentImage ContentType = "image"
+	ContentVoice ContentType = "voice"
+	ContentFile  ContentType = "file"
+	ContentVideo ContentType = "video"
+)
+
+// IncomingMessage is a parsed, user-friendly representation.
+type IncomingMessage struct {
+	UserID        string
+	Text          string
+	Type          ContentType
+	Timestamp     time.Time
+	Images        []ImageContent
+	Voices        []VoiceContent
+	Files         []FileContent
+	Videos        []VideoContent
+	QuotedMessage *QuotedMessage
+	Raw           *WireMessage
+	ContextToken  string // internal, managed by SDK
+}
+
+// ImageContent holds parsed image data from a message.
+type ImageContent struct {
+	Media      *CDNMedia
+	ThumbMedia *CDNMedia
+	AESKey     string
+	URL        string
+	Width      int
+	Height     int
+}
+
+// VoiceContent holds parsed voice data.
+type VoiceContent struct {
+	Media      *CDNMedia
+	Text       string
+	DurationMs int
+	EncodeType int
+}
+
+// FileContent holds parsed file data.
+type FileContent struct {
+	Media    *CDNMedia
+	FileName string
+	MD5      string
+	Size     int64
+}
+
+// VideoContent holds parsed video data.
+type VideoContent struct {
+	Media      *CDNMedia
+	ThumbMedia *CDNMedia
+	DurationMs int
+	Width      int
+	Height     int
+}
+
+// QuotedMessage represents a referenced message.
+type QuotedMessage struct {
+	Title string
+	Text  string
+	Type  ContentType
+}
+
+// Credentials holds bot authentication data.
+type Credentials struct {
+	Token     string `json:"token"`
+	BaseURL   string `json:"baseUrl"`
+	AccountID string `json:"accountId"`
+	UserID    string `json:"userId"`
+	SavedAt   string `json:"savedAt,omitempty"`
+}

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -1,22 +1,20 @@
-// Package weixin implements the Weixin (微信) iLink HTTP adapter.
+// Package weixin implements the Weixin (微信) iLink adapter.
 //
-// It uses long-polling HTTP to receive messages and a send queue with
-// rate limiting and retry for outbound messages.
+// It uses the iLink protocol (https://ilinkai.weixin.qq.com) for QR login,
+// long-poll message receiving, and message sending.
 package weixin
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/channel"
+	"github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink"
 )
 
 const platformName = "weixin"
@@ -28,67 +26,64 @@ func init() {
 // Config keys expected in channels.yml.
 const (
 	cfgBaseURL    = "base_url"
-	cfgAppID      = "app_id"
-	cfgAppSecret  = "app_secret"
-	cfgWebhookURL = "webhook_url"
+	cfgCredPath   = "cred_path"
 	cfgTimeoutSec = "timeout_sec"
 )
 
 // Adapter implements channel.Adapter for Weixin iLink.
 type Adapter struct {
-	baseURL   string
-	appID     string
-	appSecret string
-	client    *http.Client
+	baseURL  string
+	credPath string
+	client   *ilink.Client
 
 	mu        sync.Mutex
 	running   bool
 	cancel    context.CancelFunc
 	onMessage func(channel.InboundEvent)
 
-	// sendQueue serializes outbound messages with rate limiting.
-	sendQueue chan sendJob
-
-	// typingKeepalive sends periodic typing indicators while processing.
-	typingKeepalive *time.Ticker
-	typingStop      chan struct{}
+	// bot wraps the iLink SDK.
+	bot *ilinkBot
 }
 
-// sendJob is one outbound message queued for sending.
-type sendJob struct {
-	chatID   string
-	text     string
-	filePath string
-	fileName string
-	replyTo  string
-	result   chan channel.SendResult
+// ilinkBot wraps the ilink client with credential management.
+type ilinkBot struct {
+	client        *ilink.Client
+	creds         *ilink.Credentials
+	contextTokens sync.Map // userID -> contextToken
+	cursor        string
 }
 
 // New creates a Weixin adapter from platform config.
 func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
 	baseURL, _ := cfg[cfgBaseURL].(string)
 	if baseURL == "" {
-		baseURL = "https://api.weixin.qq.com"
+		baseURL = ilink.DefaultBaseURL
+	}
+	credPath, _ := cfg[cfgCredPath].(string)
+	if credPath == "" {
+		credPath = ilink.DefaultCredPath()
 	}
 	timeoutSec, _ := cfg[cfgTimeoutSec].(int)
 	if timeoutSec <= 0 {
 		timeoutSec = 30
 	}
 
+	client := ilink.NewClient()
+	client.HTTP.Timeout = time.Duration(timeoutSec) * time.Second
+
 	return &Adapter{
-		baseURL:    strings.TrimSuffix(baseURL, "/"),
-		appID:      stringOr(cfg[cfgAppID], ""),
-		appSecret:  stringOr(cfg[cfgAppSecret], ""),
-		client:     &http.Client{Timeout: time.Duration(timeoutSec) * time.Second},
-		sendQueue:  make(chan sendJob, 100),
-		typingStop: make(chan struct{}),
+		baseURL:  strings.TrimSuffix(baseURL, "/"),
+		credPath: credPath,
+		client:   client,
 	}, nil
 }
 
 // Platform returns "weixin".
 func (a *Adapter) Platform() string { return platformName }
 
-// Start begins the long-poll receive loop and the send queue worker.
+// Start begins the long-poll receive loop.
+// It loads stored credentials; if none exist, the adapter returns an error
+// prompting the user to run `octo channel login` first.
 func (a *Adapter) Start(ctx context.Context, onMessage func(channel.InboundEvent)) error {
 	a.mu.Lock()
 	if a.running {
@@ -100,19 +95,79 @@ func (a *Adapter) Start(ctx context.Context, onMessage func(channel.InboundEvent
 	ctx, a.cancel = context.WithCancel(ctx)
 	a.mu.Unlock()
 
-	// Start the send queue worker.
-	go a.sendWorker(ctx)
+	// Load credentials.
+	creds, err := ilink.LoadCredentials(a.credPath)
+	if err != nil {
+		return fmt.Errorf("weixin: load credentials: %w (run `octo channel login` first)", err)
+	}
+	if creds == nil {
+		return fmt.Errorf("weixin: no credentials found (run `octo channel login` first)")
+	}
+
+	a.bot = &ilinkBot{
+		client: a.client,
+		creds:  creds,
+	}
 
 	// Start long-polling for messages.
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
+	retryDelay := time.Second
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-ticker.C:
-			a.pollOnce(ctx)
+		default:
+		}
+
+		updates, err := a.bot.client.GetUpdates(ctx, a.bot.creds.BaseURL, a.bot.creds.Token, a.bot.cursor)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			apiErr, isAPI := err.(*ilink.APIError)
+			if isAPI && apiErr.IsSessionExpired() {
+				// Session expired — clear credentials and stop.
+				_ = ilink.ClearCredentials(a.credPath)
+				a.bot.contextTokens = sync.Map{}
+				a.bot.cursor = ""
+				return fmt.Errorf("weixin: session expired (run `octo channel login` again)")
+			}
+
+			time.Sleep(retryDelay)
+			retryDelay = min(retryDelay*2, 10*time.Second)
+			continue
+		}
+
+		if updates.GetUpdatesBuf != "" {
+			a.bot.cursor = updates.GetUpdatesBuf
+		}
+		retryDelay = time.Second
+
+		for _, rawMsg := range updates.Msgs {
+			var wire ilink.WireMessage
+			if err := json.Unmarshal(rawMsg, &wire); err != nil {
+				continue
+			}
+			a.bot.rememberContext(&wire)
+			incoming := parseMessage(&wire)
+			if incoming == nil {
+				continue
+			}
+			ev := channel.InboundEvent{
+				Type:         "message",
+				Platform:     platformName,
+				ChatID:       incoming.UserID,
+				UserID:       incoming.UserID,
+				Text:         incoming.Text,
+				MessageID:    fmt.Sprintf("%d", wire.MessageID),
+				ChatType:     "direct",
+				ContextToken: incoming.ContextToken,
+				Raw:          incoming.Raw,
+			}
+			if a.onMessage != nil {
+				a.onMessage(ev)
+			}
 		}
 	}
 }
@@ -128,31 +183,41 @@ func (a *Adapter) Stop() error {
 	if a.cancel != nil {
 		a.cancel()
 	}
-	close(a.typingStop)
 	a.mu.Unlock()
 	return nil
 }
 
-// SendText enqueues a text message for delivery.
+// SendText sends a text message to a user.
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
-	resCh := make(chan channel.SendResult, 1)
-	select {
-	case a.sendQueue <- sendJob{chatID: chatID, text: text, replyTo: replyTo, result: resCh}:
-		return <-resCh
-	default:
-		return channel.SendResult{OK: false, Error: "send queue full"}
+	if a.bot == nil || a.bot.creds == nil {
+		return channel.SendResult{OK: false, Error: "not logged in"}
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	ct, ok := a.bot.contextTokens.Load(chatID)
+	if !ok {
+		return channel.SendResult{OK: false, Error: "no context_token for user " + chatID}
+	}
+
+	chunks := chunkText(text, 4000)
+	var lastErr error
+	for _, chunk := range chunks {
+		msg := ilink.BuildTextMessage(chatID, ct.(string), chunk)
+		if err := a.bot.client.SendMessage(ctx, a.bot.creds.BaseURL, a.bot.creds.Token, msg); err != nil {
+			lastErr = err
+		}
+	}
+	if lastErr != nil {
+		return channel.SendResult{OK: false, Error: lastErr.Error()}
+	}
+	return channel.SendResult{OK: true}
 }
 
-// SendFile enqueues a file message for delivery.
+// SendFile sends a file hint (full file upload not yet implemented).
 func (a *Adapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
-	resCh := make(chan channel.SendResult, 1)
-	select {
-	case a.sendQueue <- sendJob{chatID: chatID, filePath: path, fileName: name, replyTo: replyTo, result: resCh}:
-		return <-resCh
-	default:
-		return channel.SendResult{OK: false, Error: "send queue full"}
-	}
+	return a.SendText(chatID, fmt.Sprintf("📎 File: %s", name), replyTo)
 }
 
 // UpdateMessage is not supported by Weixin iLink.
@@ -163,209 +228,144 @@ func (a *Adapter) SupportsMessageUpdates() bool { return false }
 
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
-	var errs []string
-	if a.appID == "" {
-		errs = append(errs, "weixin: app_id is required")
-	}
-	if a.appSecret == "" {
-		errs = append(errs, "weixin: app_secret is required")
-	}
-	return errs
+	return nil // Weixin iLink uses credentials file, not config fields.
 }
 
-// pollOnce performs one long-poll request for inbound messages.
-func (a *Adapter) pollOnce(ctx context.Context) {
-	u, err := url.Parse(a.baseURL + "/cgi-bin/message/custom/polling")
-	if err != nil {
-		return
+// rememberContext stores the context_token for a user.
+func (b *ilinkBot) rememberContext(wire *ilink.WireMessage) {
+	userID := wire.FromUserID
+	if wire.MessageType == ilink.MessageTypeBot {
+		userID = wire.ToUserID
 	}
-	q := u.Query()
-	q.Set("appid", a.appID)
-	q.Set("appsecret", a.appSecret)
-	u.RawQuery = q.Encode()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return
-	}
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		return
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return
-	}
-
-	var pollResp pollResponse
-	if err := json.Unmarshal(body, &pollResp); err != nil {
-		return
-	}
-
-	for _, msg := range pollResp.Messages {
-		ev := channel.InboundEvent{
-			Type:         "message",
-			Platform:     platformName,
-			ChatID:       msg.FromUserName,
-			UserID:       msg.FromUserName,
-			Text:         msg.Content,
-			MessageID:    msg.MsgID,
-			ChatType:     chatType(msg.MsgType),
-			ContextToken: msg.ContextToken,
-			Raw:          msg,
-		}
-		if a.onMessage != nil {
-			a.onMessage(ev)
-		}
+	if userID != "" && wire.ContextToken != "" {
+		b.contextTokens.Store(userID, wire.ContextToken)
 	}
 }
 
-// sendWorker processes the send queue with rate limiting and retry.
-func (a *Adapter) sendWorker(ctx context.Context) {
-	const (
-		maxRetries = 3
-		baseDelay  = 500 * time.Millisecond
-	)
+// parseMessage converts a WireMessage to an IncomingMessage.
+func parseMessage(wire *ilink.WireMessage) *ilink.IncomingMessage {
+	if wire.MessageType != ilink.MessageTypeUser {
+		return nil
+	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case job, ok := <-a.sendQueue:
-			if !ok {
-				return
+	msg := &ilink.IncomingMessage{
+		UserID:       wire.FromUserID,
+		Text:         extractText(wire.ItemList),
+		Type:         detectType(wire.ItemList),
+		Timestamp:    time.UnixMilli(wire.CreateTimeMs),
+		Raw:          wire,
+		ContextToken: wire.ContextToken,
+	}
+
+	for _, item := range wire.ItemList {
+		if item.ImageItem != nil {
+			msg.Images = append(msg.Images, ilink.ImageContent{
+				Media: item.ImageItem.Media, ThumbMedia: item.ImageItem.ThumbMedia,
+				AESKey: item.ImageItem.AESKey, URL: item.ImageItem.URL,
+				Width: item.ImageItem.ThumbWidth, Height: item.ImageItem.ThumbHeight,
+			})
+		}
+		if item.VoiceItem != nil {
+			msg.Voices = append(msg.Voices, ilink.VoiceContent{
+				Media: item.VoiceItem.Media, Text: item.VoiceItem.Text,
+				DurationMs: item.VoiceItem.Playtime, EncodeType: item.VoiceItem.EncodeType,
+			})
+		}
+		if item.FileItem != nil {
+			size, _ := strconv.ParseInt(item.FileItem.Len, 10, 64)
+			msg.Files = append(msg.Files, ilink.FileContent{
+				Media: item.FileItem.Media, FileName: item.FileItem.FileName,
+				MD5: item.FileItem.MD5, Size: size,
+			})
+		}
+		if item.VideoItem != nil {
+			msg.Videos = append(msg.Videos, ilink.VideoContent{
+				Media: item.VideoItem.Media, ThumbMedia: item.VideoItem.ThumbMedia,
+				DurationMs: item.VideoItem.PlayLength,
+			})
+		}
+		if item.RefMsg != nil {
+			q := &ilink.QuotedMessage{Title: item.RefMsg.Title}
+			if item.RefMsg.MessageItem != nil && item.RefMsg.MessageItem.TextItem != nil {
+				q.Text = item.RefMsg.MessageItem.TextItem.Text
 			}
-			var res channel.SendResult
-			for i := 0; i < maxRetries; i++ {
-				if i > 0 {
-					time.Sleep(baseDelay * time.Duration(i))
-				}
-				if job.filePath != "" {
-					res = a.doSendFile(ctx, job)
-				} else {
-					res = a.doSendText(ctx, job)
-				}
-				if res.OK {
-					break
-				}
-			}
-			if job.result != nil {
-				job.result <- res
-			}
-			// Rate limit: sleep between sends.
-			time.Sleep(200 * time.Millisecond)
+			msg.QuotedMessage = q
 		}
 	}
+
+	return msg
 }
 
-// doSendText sends a text message via the Weixin API.
-func (a *Adapter) doSendText(ctx context.Context, job sendJob) channel.SendResult {
-	payload := map[string]any{
-		"touser":  job.chatID,
-		"msgtype": "text",
-		"text":    map[string]string{"content": job.text},
+func detectType(items []ilink.MessageItem) ilink.ContentType {
+	if len(items) == 0 {
+		return ilink.ContentText
 	}
-	if job.replyTo != "" {
-		payload["context_token"] = job.replyTo
-	}
-	return a.postJSON(ctx, "/cgi-bin/message/custom/send", payload)
-}
-
-// doSendFile sends a file message via the Weixin API.
-func (a *Adapter) doSendFile(ctx context.Context, job sendJob) channel.SendResult {
-	// File upload is a two-step process: upload media, then send by media_id.
-	// For simplicity in the adapter skeleton, we send the file path as a text hint.
-	payload := map[string]any{
-		"touser":  job.chatID,
-		"msgtype": "text",
-		"text":    map[string]string{"content": fmt.Sprintf("📎 File: %s", job.fileName)},
-	}
-	return a.postJSON(ctx, "/cgi-bin/message/custom/send", payload)
-}
-
-// postJSON sends a JSON POST to the Weixin API.
-func (a *Adapter) postJSON(ctx context.Context, path string, payload map[string]any) channel.SendResult {
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return channel.SendResult{OK: false, Error: err.Error()}
-	}
-
-	u := a.baseURL + path
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(data))
-	if err != nil {
-		return channel.SendResult{OK: false, Error: err.Error()}
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		return channel.SendResult{OK: false, Error: err.Error()}
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return channel.SendResult{OK: false, Error: err.Error()}
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return channel.SendResult{OK: false, Error: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(body))}
-	}
-
-	var apiResp apiResponse
-	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return channel.SendResult{OK: true, MessageID: ""}
-	}
-	if apiResp.ErrCode != 0 {
-		return channel.SendResult{OK: false, Error: fmt.Sprintf("weixin error %d: %s", apiResp.ErrCode, apiResp.ErrMsg)}
-	}
-	return channel.SendResult{OK: true, MessageID: apiResp.MsgID}
-}
-
-// pollResponse is the shape of the long-poll response.
-type pollResponse struct {
-	Messages []weixinMessage `json:"messages"`
-}
-
-// weixinMessage is a single inbound message from Weixin.
-type weixinMessage struct {
-	ToUserName   string `json:"ToUserName"`
-	FromUserName string `json:"FromUserName"`
-	CreateTime   int64  `json:"CreateTime"`
-	MsgType      string `json:"MsgType"`
-	Content      string `json:"Content"`
-	MsgID        string `json:"MsgId"`
-	ContextToken string `json:"ContextToken,omitempty"`
-}
-
-// apiResponse is the common Weixin API response envelope.
-type apiResponse struct {
-	ErrCode int    `json:"errcode"`
-	ErrMsg  string `json:"errmsg"`
-	MsgID   string `json:"msgid,omitempty"`
-}
-
-// chatType maps Weixin msg types to our chat type.
-func chatType(msgType string) string {
-	switch msgType {
-	case "text", "image", "voice", "video", "file":
-		return "direct"
+	switch items[0].Type {
+	case ilink.ItemImage:
+		return ilink.ContentImage
+	case ilink.ItemVoice:
+		return ilink.ContentVoice
+	case ilink.ItemFile:
+		return ilink.ContentFile
+	case ilink.ItemVideo:
+		return ilink.ContentVideo
 	default:
-		return "group"
+		return ilink.ContentText
 	}
 }
 
-// stringOr returns v if it's a string, otherwise fallback.
-func stringOr(v any, fallback string) string {
-	if s, ok := v.(string); ok {
-		return s
+func extractText(items []ilink.MessageItem) string {
+	var parts []string
+	for _, item := range items {
+		switch item.Type {
+		case ilink.ItemText:
+			if item.TextItem != nil {
+				parts = append(parts, item.TextItem.Text)
+			}
+		case ilink.ItemImage:
+			if item.ImageItem != nil && item.ImageItem.URL != "" {
+				parts = append(parts, item.ImageItem.URL)
+			} else {
+				parts = append(parts, "[image]")
+			}
+		case ilink.ItemVoice:
+			if item.VoiceItem != nil && item.VoiceItem.Text != "" {
+				parts = append(parts, item.VoiceItem.Text)
+			} else {
+				parts = append(parts, "[voice]")
+			}
+		case ilink.ItemFile:
+			if item.FileItem != nil {
+				parts = append(parts, fmt.Sprintf("[file: %s]", item.FileItem.FileName))
+			} else {
+				parts = append(parts, "[file]")
+			}
+		case ilink.ItemVideo:
+			parts = append(parts, "[video]")
+		}
 	}
-	return fallback
+	return strings.Join(parts, " ")
+}
+
+func chunkText(text string, maxLen int) []string {
+	if len(text) <= maxLen {
+		return []string{text}
+	}
+	var chunks []string
+	for len(text) > 0 {
+		if len(text) <= maxLen {
+			chunks = append(chunks, text)
+			break
+		}
+		chunks = append(chunks, text[:maxLen])
+		text = text[maxLen:]
+	}
+	return chunks
+}
+
+func min(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/internal/channel/adapters/weixin/weixin_test.go
+++ b/internal/channel/adapters/weixin/weixin_test.go
@@ -3,223 +3,111 @@ package weixin
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/channel"
+	"github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink"
 )
 
 func TestAdapter_ValidateConfig(t *testing.T) {
-	a := &Adapter{appID: "", appSecret: ""}
+	a := &Adapter{}
 	errs := a.ValidateConfig(channel.PlatformConfig{})
-	if len(errs) != 2 {
-		t.Fatalf("expected 2 validation errors, got %d: %v", len(errs), errs)
-	}
-
-	a = &Adapter{appID: "app1", appSecret: "secret1"}
-	errs = a.ValidateConfig(channel.PlatformConfig{})
 	if len(errs) != 0 {
 		t.Fatalf("expected 0 validation errors, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestAdapter_SendText(t *testing.T) {
+func TestAdapter_SendText_NotLoggedIn(t *testing.T) {
+	a := &Adapter{}
+	res := a.SendText("user1", "hello", "")
+	if res.OK {
+		t.Fatal("expected failure when not logged in")
+	}
+}
+
+func TestAdapter_SendText_NoContextToken(t *testing.T) {
+	a := &Adapter{
+		bot: &ilinkBot{
+			creds: &ilink.Credentials{Token: "tok", BaseURL: "http://example.com"},
+		},
+	}
+	res := a.SendText("user1", "hello", "")
+	if res.OK {
+		t.Fatal("expected failure when no context_token")
+	}
+}
+
+func TestAdapter_SendText_Success(t *testing.T) {
 	var received []map[string]any
-	var mu sync.Mutex
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/cgi-bin/message/custom/send" {
-			body, _ := io.ReadAll(r.Body)
+		if r.URL.Path == "/ilink/bot/sendmessage" {
+			body := make([]byte, r.ContentLength)
+			r.Body.Read(body)
 			var payload map[string]any
 			_ = json.Unmarshal(body, &payload)
-			mu.Lock()
 			received = append(received, payload)
-			mu.Unlock()
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "errmsg": "ok", "msgid": "mid123"})
+			_ = json.NewEncoder(w).Encode(map[string]any{"ret": 0})
 		}
 	}))
 	defer ts.Close()
 
 	a := &Adapter{
-		baseURL:    ts.URL,
-		appID:      "app1",
-		appSecret:  "secret1",
-		client:     &http.Client{Timeout: 5 * time.Second},
-		sendQueue:  make(chan sendJob, 10),
-		typingStop: make(chan struct{}),
+		baseURL: ts.URL,
+		bot: &ilinkBot{
+			client: ilink.NewClient(),
+			creds:  &ilink.Credentials{Token: "tok", BaseURL: ts.URL},
+		},
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go a.sendWorker(ctx)
+	a.bot.contextTokens.Store("user1", "ctx123")
 
 	res := a.SendText("user1", "hello world", "")
 	if !res.OK {
 		t.Fatalf("expected send OK, got error: %s", res.Error)
 	}
-	if res.MessageID != "mid123" {
-		t.Fatalf("unexpected message ID: %q", res.MessageID)
-	}
 
-	// Wait for async send.
-	time.Sleep(100 * time.Millisecond)
-
-	mu.Lock()
 	if len(received) != 1 {
 		t.Fatalf("expected 1 received request, got %d", len(received))
 	}
-	payload := received[0]
-	mu.Unlock()
-
-	if payload["touser"] != "user1" {
-		t.Errorf("unexpected touser: %v", payload["touser"])
-	}
-	if payload["msgtype"] != "text" {
-		t.Errorf("unexpected msgtype: %v", payload["msgtype"])
+	msg := received[0]["msg"].(map[string]any)
+	if msg["to_user_id"] != "user1" {
+		t.Errorf("unexpected to_user_id: %v", msg["to_user_id"])
 	}
 }
 
-func TestAdapter_SendText_Retry(t *testing.T) {
-	attempts := 0
+func TestAdapter_SendFile(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attempts++
-		if attempts < 2 {
-			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = w.Write([]byte(`{"errcode": -1, "errmsg": "system busy"}`))
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "errmsg": "ok", "msgid": "mid456"})
-	}))
-	defer ts.Close()
-
-	a := &Adapter{
-		baseURL:    ts.URL,
-		appID:      "app1",
-		appSecret:  "secret1",
-		client:     &http.Client{Timeout: 5 * time.Second},
-		sendQueue:  make(chan sendJob, 10),
-		typingStop: make(chan struct{}),
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go a.sendWorker(ctx)
-
-	res := a.SendText("user1", "retry test", "")
-	if !res.OK {
-		t.Fatalf("expected send OK after retry, got error: %s", res.Error)
-	}
-	if attempts < 2 {
-		t.Fatalf("expected at least 2 attempts, got %d", attempts)
-	}
-}
-
-func TestAdapter_SendQueueFull(t *testing.T) {
-	a := &Adapter{
-		baseURL:    "http://localhost:1",
-		appID:      "app1",
-		appSecret:  "secret1",
-		client:     &http.Client{Timeout: 100 * time.Millisecond},
-		sendQueue:  make(chan sendJob, 1),
-		typingStop: make(chan struct{}),
-	}
-
-	// Fill the queue without a worker.
-	a.sendQueue <- sendJob{result: make(chan channel.SendResult, 1)}
-
-	res := a.SendText("user1", "overflow", "")
-	if res.OK {
-		t.Fatal("expected failure when queue full")
-	}
-	if !strings.Contains(res.Error, "full") {
-		t.Fatalf("expected 'full' in error, got: %s", res.Error)
-	}
-}
-
-func TestAdapter_PollOnce(t *testing.T) {
-	var received []channel.InboundEvent
-	var mu sync.Mutex
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/cgi-bin/message/custom/polling" {
-			resp := pollResponse{
-				Messages: []weixinMessage{
-					{
-						FromUserName: "user1",
-						MsgType:      "text",
-						Content:      "hello bot",
-						MsgID:        "msg123",
-						ContextToken: "ctx456",
-					},
-				},
-			}
+		if r.URL.Path == "/ilink/bot/sendmessage" {
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(resp)
+			_ = json.NewEncoder(w).Encode(map[string]any{"ret": 0})
 		}
 	}))
 	defer ts.Close()
 
 	a := &Adapter{
-		baseURL:    ts.URL,
-		appID:      "app1",
-		appSecret:  "secret1",
-		client:     &http.Client{Timeout: 5 * time.Second},
-		sendQueue:  make(chan sendJob, 10),
-		typingStop: make(chan struct{}),
+		baseURL: ts.URL,
+		bot: &ilinkBot{
+			client: ilink.NewClient(),
+			creds:  &ilink.Credentials{Token: "tok", BaseURL: ts.URL},
+		},
 	}
+	a.bot.contextTokens.Store("user1", "ctx123")
 
-	onMessage := func(ev channel.InboundEvent) {
-		mu.Lock()
-		received = append(received, ev)
-		mu.Unlock()
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
-
-	// Run pollOnce manually.
-	a.onMessage = onMessage
-	a.pollOnce(ctx)
-
-	mu.Lock()
-	if len(received) != 1 {
-		t.Fatalf("expected 1 received event, got %d", len(received))
-	}
-	ev := received[0]
-	mu.Unlock()
-
-	if ev.Platform != "weixin" {
-		t.Errorf("unexpected platform: %q", ev.Platform)
-	}
-	if ev.ChatID != "user1" {
-		t.Errorf("unexpected chatID: %q", ev.ChatID)
-	}
-	if ev.Text != "hello bot" {
-		t.Errorf("unexpected text: %q", ev.Text)
-	}
-	if ev.MessageID != "msg123" {
-		t.Errorf("unexpected messageID: %q", ev.MessageID)
-	}
-	if ev.ContextToken != "ctx456" {
-		t.Errorf("unexpected contextToken: %q", ev.ContextToken)
-	}
-	if ev.ChatType != "direct" {
-		t.Errorf("unexpected chatType: %q", ev.ChatType)
+	res := a.SendFile("user1", "/tmp/test.txt", "test.txt", "")
+	if !res.OK {
+		t.Fatalf("expected send OK, got error: %s", res.Error)
 	}
 }
 
 func TestAdapter_StopNotRunning(t *testing.T) {
-	a := &Adapter{
-		sendQueue:  make(chan sendJob, 1),
-		typingStop: make(chan struct{}),
-	}
+	a := &Adapter{}
 	err := a.Stop()
 	if err != nil {
 		t.Fatalf("expected nil error when stopping non-running adapter, got: %v", err)
@@ -227,23 +115,28 @@ func TestAdapter_StopNotRunning(t *testing.T) {
 }
 
 func TestAdapter_StartAlreadyRunning(t *testing.T) {
-	a := &Adapter{
-		baseURL:    "http://localhost:1",
-		appID:      "app1",
-		appSecret:  "secret1",
-		client:     &http.Client{Timeout: 100 * time.Millisecond},
-		sendQueue:  make(chan sendJob, 1),
-		typingStop: make(chan struct{}),
-	}
-
-	// Simulate already running.
-	a.running = true
+	a := &Adapter{running: true}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	err := a.Start(ctx, func(ev channel.InboundEvent) {})
 	if err == nil {
 		t.Fatal("expected error when starting already-running adapter")
+	}
+}
+
+func TestAdapter_StartNoCredentials(t *testing.T) {
+	// Use a temp dir so credentials don't exist.
+	tmpDir := t.TempDir()
+	a := &Adapter{
+		credPath: filepath.Join(tmpDir, "creds.json"),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := a.Start(ctx, func(ev channel.InboundEvent) {})
+	if err == nil {
+		t.Fatal("expected error when no credentials")
 	}
 }
 
@@ -254,37 +147,17 @@ func TestAdapter_SupportsMessageUpdates(t *testing.T) {
 	}
 }
 
-func TestAdapter_SendFile(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "errmsg": "ok", "msgid": "mid789"})
-	}))
-	defer ts.Close()
-
-	a := &Adapter{
-		baseURL:    ts.URL,
-		appID:      "app1",
-		appSecret:  "secret1",
-		client:     &http.Client{Timeout: 5 * time.Second},
-		sendQueue:  make(chan sendJob, 10),
-		typingStop: make(chan struct{}),
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go a.sendWorker(ctx)
-
-	res := a.SendFile("user1", "/tmp/test.txt", "test.txt", "")
-	if !res.OK {
-		t.Fatalf("expected send OK, got error: %s", res.Error)
+func TestAdapter_UpdateMessage(t *testing.T) {
+	a := &Adapter{}
+	if a.UpdateMessage("c1", "m1", "text") {
+		t.Error("expected UpdateMessage to return false")
 	}
 }
 
 func TestNew(t *testing.T) {
 	cfg := channel.PlatformConfig{
-		"app_id":      "test_app",
-		"app_secret":  "test_secret",
 		"base_url":    "https://custom.example.com",
+		"cred_path":   "/tmp/test-creds.json",
 		"timeout_sec": 60,
 	}
 	ad, err := New(cfg)
@@ -292,17 +165,14 @@ func TestNew(t *testing.T) {
 		t.Fatalf("New error: %v", err)
 	}
 	wa := ad.(*Adapter)
-	if wa.appID != "test_app" {
-		t.Errorf("unexpected appID: %q", wa.appID)
-	}
-	if wa.appSecret != "test_secret" {
-		t.Errorf("unexpected appSecret: %q", wa.appSecret)
-	}
 	if wa.baseURL != "https://custom.example.com" {
 		t.Errorf("unexpected baseURL: %q", wa.baseURL)
 	}
-	if wa.client.Timeout != 60*time.Second {
-		t.Errorf("unexpected timeout: %v", wa.client.Timeout)
+	if wa.credPath != "/tmp/test-creds.json" {
+		t.Errorf("unexpected credPath: %q", wa.credPath)
+	}
+	if wa.client.HTTP.Timeout != 60*time.Second {
+		t.Errorf("unexpected timeout: %v", wa.client.HTTP.Timeout)
 	}
 }
 
@@ -312,10 +182,163 @@ func TestNew_Defaults(t *testing.T) {
 		t.Fatalf("New error: %v", err)
 	}
 	wa := ad.(*Adapter)
-	if wa.baseURL != "https://api.weixin.qq.com" {
+	if wa.baseURL != "https://ilinkai.weixin.qq.com" {
 		t.Errorf("unexpected default baseURL: %q", wa.baseURL)
 	}
-	if wa.client.Timeout != 30*time.Second {
-		t.Errorf("unexpected default timeout: %v", wa.client.Timeout)
+	if wa.client.HTTP.Timeout != 30*time.Second {
+		t.Errorf("unexpected default timeout: %v", wa.client.HTTP.Timeout)
 	}
+}
+
+func TestParseMessage(t *testing.T) {
+	wire := &ilink.WireMessage{
+		MessageType:  ilink.MessageTypeUser,
+		FromUserID:   "user1",
+		ContextToken: "ctx123",
+		CreateTimeMs: 1700000000000,
+		ItemList: []ilink.MessageItem{
+			{Type: ilink.ItemText, TextItem: &ilink.TextItem{Text: "hello"}},
+		},
+	}
+	msg := parseMessage(wire)
+	if msg == nil {
+		t.Fatal("expected non-nil message")
+	}
+	if msg.UserID != "user1" {
+		t.Errorf("unexpected userID: %q", msg.UserID)
+	}
+	if msg.Text != "hello" {
+		t.Errorf("unexpected text: %q", msg.Text)
+	}
+	if msg.ContextToken != "ctx123" {
+		t.Errorf("unexpected contextToken: %q", msg.ContextToken)
+	}
+}
+
+func TestParseMessage_BotMessage(t *testing.T) {
+	wire := &ilink.WireMessage{
+		MessageType: ilink.MessageTypeBot,
+		FromUserID:  "bot1",
+	}
+	msg := parseMessage(wire)
+	if msg != nil {
+		t.Fatal("expected nil for bot message")
+	}
+}
+
+func TestExtractText(t *testing.T) {
+	items := []ilink.MessageItem{
+		{Type: ilink.ItemText, TextItem: &ilink.TextItem{Text: "hello"}},
+		{Type: ilink.ItemImage, ImageItem: &ilink.ImageItem{URL: "http://img"}},
+	}
+	text := extractText(items)
+	if text != "hello http://img" {
+		t.Errorf("unexpected text: %q", text)
+	}
+}
+
+func TestChunkText(t *testing.T) {
+	chunks := chunkText("hello", 10)
+	if len(chunks) != 1 || chunks[0] != "hello" {
+		t.Fatalf("unexpected chunks: %v", chunks)
+	}
+
+	chunks = chunkText("hello world foo bar", 5)
+	if len(chunks) != 4 {
+		t.Fatalf("expected 4 chunks, got %d", len(chunks))
+	}
+}
+
+func TestMin(t *testing.T) {
+	if min(1*time.Second, 2*time.Second) != 1*time.Second {
+		t.Error("unexpected min")
+	}
+	if min(3*time.Second, 2*time.Second) != 2*time.Second {
+		t.Error("unexpected min")
+	}
+}
+
+func TestAdapter_StartWithCredentials(t *testing.T) {
+	// Create a mock iLink server.
+	var mu sync.Mutex
+	callCount := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		callCount++
+
+		switch r.URL.Path {
+		case "/ilink/bot/getupdates":
+			// Return one message then empty.
+			if callCount == 1 {
+				resp := map[string]any{
+					"ret":             0,
+					"get_updates_buf": "buf1",
+					"msgs": []json.RawMessage{
+						mustJSON(ilink.WireMessage{
+							MessageType:  ilink.MessageTypeUser,
+							FromUserID:   "user1",
+							ContextToken: "ctx123",
+							CreateTimeMs: time.Now().UnixMilli(),
+							ItemList: []ilink.MessageItem{
+								{Type: ilink.ItemText, TextItem: &ilink.TextItem{Text: "hi"}},
+							},
+						}),
+					},
+				}
+				json.NewEncoder(w).Encode(resp)
+			} else {
+				// Empty response to avoid timeout.
+				json.NewEncoder(w).Encode(map[string]any{"ret": 0, "get_updates_buf": "buf1"})
+			}
+		}
+	}))
+	defer ts.Close()
+
+	// Write fake credentials.
+	tmpDir := t.TempDir()
+	credPath := filepath.Join(tmpDir, "creds.json")
+	creds := &ilink.Credentials{
+		Token:   "test-token",
+		BaseURL: ts.URL,
+		UserID:  "bot1",
+	}
+	data, _ := json.Marshal(creds)
+	os.WriteFile(credPath, data, 0600)
+
+	a := &Adapter{
+		baseURL:  ts.URL,
+		credPath: credPath,
+		client:   ilink.NewClient(),
+	}
+
+	var received []channel.InboundEvent
+	onMessage := func(ev channel.InboundEvent) {
+		mu.Lock()
+		received = append(received, ev)
+		mu.Unlock()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err := a.Start(ctx, onMessage)
+	if err != nil && err != context.DeadlineExceeded && err != context.Canceled {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	if len(received) != 1 {
+		t.Fatalf("expected 1 received event, got %d", len(received))
+	}
+	if received[0].Text != "hi" {
+		t.Errorf("unexpected text: %q", received[0].Text)
+	}
+	mu.Unlock()
+}
+
+func mustJSON(v any) json.RawMessage {
+	b, _ := json.Marshal(v)
+	return b
 }


### PR DESCRIPTION
This PR replaces the skeleton Weixin adapter with a real iLink protocol implementation.

### What's new

**iLink protocol client** ():
-  — HTTP client with iLink headers, QR code fetching, QR status polling, long-poll GetUpdates, SendMessage, GetConfig, SendTyping
-  — credential persistence to ,  with full QR flow, IDC redirect handling, auto-retry on expiry
-  — WireMessage, MessageItem, IncomingMessage, CDNMedia, Credentials, content type constants

**Rewritten Weixin adapter** ():
- Loads credentials from disk on Start (fails with helpful message if missing)
- Long-poll loop with exponential backoff retry
- Session expiry detection → clears credentials + stops
-  tracking per user for reply routing
- Text chunking (4000 chars) for long messages
- Image/voice/file/video message parsing

**CLI** ():
-  — shows QR code URL, polls scan status, saves 
-  flag (default ),  to re-login

### Testing
- ?   	github.com/Leihb/octo-agent/cmd/mswe-eval	[no test files]
ok  	github.com/Leihb/octo-agent/cmd/octo	(cached)
?   	github.com/Leihb/octo-agent/cmd/tui-preview	[no test files]
ok  	github.com/Leihb/octo-agent/internal/agent	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	(cached)
?   	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	[no test files]
ok  	github.com/Leihb/octo-agent/internal/config	(cached)
ok  	github.com/Leihb/octo-agent/internal/hooks	(cached)
ok  	github.com/Leihb/octo-agent/internal/mcp	(cached)
ok  	github.com/Leihb/octo-agent/internal/memory	(cached)
ok  	github.com/Leihb/octo-agent/internal/mswe	(cached)
ok  	github.com/Leihb/octo-agent/internal/permission	(cached)
ok  	github.com/Leihb/octo-agent/internal/prompt	(cached)
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/openai	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/retry	(cached)
ok  	github.com/Leihb/octo-agent/internal/sandbox	(cached)
ok  	github.com/Leihb/octo-agent/internal/skills	(cached)
ok  	github.com/Leihb/octo-agent/internal/taskgraph	(cached)
ok  	github.com/Leihb/octo-agent/internal/tasks	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools	(cached)
ok  	github.com/Leihb/octo-agent/internal/tui	(cached)
ok  	github.com/Leihb/octo-agent/internal/version	(cached) passes
-  clean
- No external dependencies introduced (pure Go implementation based on protocol docs)