### PR TITLE
fix(subagent): treat max-turns as failure instead of success

### DIFF
--- a/cmd/octo/sub_agent.go
+++ b/cmd/octo/sub_agent.go
@@ -118,6 +118,9 @@ func (s *agentSpawner) runChild(ctx context.Context, lc *liveChild, prompt strin
 	if err != nil {
 		return "", 0, 0, err
 	}
+	if r.StopReason == agent.StopReasonMaxTurns {
+		return "", 0, 0, fmt.Errorf("sub-agent reached max-turns limit (%d) — task incomplete", lc.agent.MaxTurns)
+	}
 
 	totIn, totOut := lc.agent.SessionTokens()
 	in, out = totIn-lc.accruedIn, totOut-lc.accruedOut


### PR DESCRIPTION
When a sub-agent hits the max-turns limit, `budgetStop` returns a `Reply` with `StopReason "max_turns"` but `err == nil`. The spawner treated this as success, so the Scheduler marked the subtask Done and the task appeared complete — even though the sub-agent's work was truncated.

**Fix:** `runChild` now checks `r.StopReason` and returns an error for `max_turns`, causing the Scheduler to mark the subtask Failed (stop-on-fail) so the user sees the failure and can resume with higher `--max-turns`.