### PR TITLE
feat(tui): add stickyScroll auto-follow (Claude Code style)

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -231,6 +231,11 @@ type tuiModel struct {
 	// scrollback (0 = pinned to bottom, showing the newest content).
 	scrollOffset int
 
+	// sticky is true when the view should auto-follow new content (pinned to
+	// bottom). Set on new-turn start and scrollToBottom; cleared by any manual
+	// scroll (mouse wheel, keyboard nav). Mirrors Claude Code's stickyScroll.
+	sticky bool
+
 	// height is the terminal height in cells, updated by WindowSizeMsg.
 	height int
 }
@@ -285,6 +290,7 @@ func (m *tuiModel) startTurn(line string) tea.Cmd {
 func (m *tuiModel) startTurnEcho(line, echo string) tea.Cmd {
 	m.turnRunning = true
 	m.streaming = false
+	m.sticky = true
 	m.turnStart = time.Now()
 	m.spinnerFrame = 0
 	m.running = nil
@@ -564,12 +570,14 @@ func (m *tuiModel) commitToolLine(line string) tea.Cmd {
 }
 
 // pushScrollback appends a line to the internal scrollback buffer.
-// When scrollOffset == 0 (view pinned to bottom), the View() start calculation
-// naturally follows new content because start = len(scrollback) - available.
-// When the user has scrolled up (scrollOffset > 0), their position is preserved
-// — use mouse wheel or trackpad to scroll back down.
+// When sticky (auto-follow mode), keeps the view pinned to the bottom.
+// When the user has scrolled up (sticky=false, scrollOffset>0), their
+// position is preserved until they explicitly scrollToBottom or press End.
 func (m *tuiModel) pushScrollback(line string) {
 	m.scrollback = append(m.scrollback, line)
+	if m.sticky {
+		m.scrollOffset = 0
+	}
 }
 
 func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -310,35 +310,74 @@ func TestTUI_SubmitSavesToHistory(t *testing.T) {
 	}
 }
 
-func TestTUI_ScrollbackAutoFollowsDuringTurn(t *testing.T) {
+func TestTUI_StickyFollowsContent(t *testing.T) {
 	m := newTestModel()
 	m.height = 30
 
-	// Pre-populate scrollback with enough lines to scroll.
 	for i := 0; i < 30; i++ {
 		m.pushScrollback("old line")
 	}
 
-	// User scrolls up.
-	m.scrollOffset = 5
-	if m.scrollOffset != 5 {
-		t.Fatal("scrollOffset should be 5 after scrolling up")
-	}
-
-	// New content arrives during a turn — should NOT reset scrollOffset.
-	// The user's scrolled position is preserved.
-	m.turnRunning = true
-	m.pushScrollback("new content")
-	if m.scrollOffset != 5 {
-		t.Errorf("pushScrollback should preserve scrollOffset when user scrolled up, got %d", m.scrollOffset)
-	}
-
-	// When at bottom (scrollOffset=0), new content is naturally followed
-	// because View() start = len(scrollback) - available.
+	// Sticky=true (default on new turn): pushScrollback keeps view at bottom.
+	m.sticky = true
 	m.scrollOffset = 0
+	m.pushScrollback("new content")
+	if m.scrollOffset != 0 {
+		t.Errorf("sticky pushScrollback should keep scrollOffset 0, got %d", m.scrollOffset)
+	}
+
+	// Sticky=true with non-zero scrollOffset: pull back to bottom.
+	m.scrollOffset = 10
 	m.pushScrollback("another line")
 	if m.scrollOffset != 0 {
-		t.Errorf("pushScrollback at bottom should keep scrollOffset 0, got %d", m.scrollOffset)
+		t.Errorf("sticky pushScrollback should reset scrollOffset to 0, got %d", m.scrollOffset)
+	}
+}
+
+func TestTUI_NotStickyPreservesPosition(t *testing.T) {
+	m := newTestModel()
+	m.height = 30
+
+	for i := 0; i < 30; i++ {
+		m.pushScrollback("old line")
+	}
+
+	// sticky=false (user has scrolled): pushScrollback preserves position.
+	m.sticky = false
+	m.scrollOffset = 5
+	m.pushScrollback("new content")
+	if m.scrollOffset != 5 {
+		t.Errorf("non-sticky pushScrollback should preserve scrollOffset, got %d", m.scrollOffset)
+	}
+}
+
+func TestTUI_MouseWheelClearsSticky(t *testing.T) {
+	m := newTestModel()
+	m.sticky = true
+
+	m.handleMouse(tea.MouseMsg{Type: tea.MouseWheelUp})
+	if m.sticky {
+		t.Error("MouseWheelUp should clear sticky")
+	}
+
+	m.sticky = true
+	m.handleMouse(tea.MouseMsg{Type: tea.MouseWheelDown})
+	if m.sticky {
+		t.Error("MouseWheelDown should clear sticky")
+	}
+}
+
+func TestTUI_EndKeyScrollsToBottom(t *testing.T) {
+	m := newTestModel()
+	m.sticky = false
+	m.scrollOffset = 20
+
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEnd})
+	if m.scrollOffset != 0 {
+		t.Errorf("End key should reset scrollOffset to 0, got %d", m.scrollOffset)
+	}
+	if !m.sticky {
+		t.Error("End key should set sticky=true")
 	}
 }
 
@@ -350,12 +389,12 @@ func TestTUI_ScrollbackPreservesOffsetWhenIdle(t *testing.T) {
 	}
 
 	m.scrollOffset = 8
+	m.sticky = false
 
-	// No turn running — pushScrollback should preserve scrollOffset.
-	m.turnRunning = false
+	// sticky=false — pushScrollback should preserve scrollOffset.
 	m.pushScrollback("some notice line")
 	if m.scrollOffset != 8 {
-		t.Errorf("pushScrollback while idle should preserve scrollOffset, got %d", m.scrollOffset)
+		t.Errorf("pushScrollback while not sticky should preserve scrollOffset, got %d", m.scrollOffset)
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -36,9 +36,11 @@ const wheelScrollLines = 4
 func (m *tuiModel) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.MouseWheelUp:
+		m.sticky = false
 		m.scrollOffset += wheelScrollLines
 		return m, nil
 	case tea.MouseWheelDown:
+		m.sticky = false
 		m.scrollOffset -= wheelScrollLines
 		if m.scrollOffset < 0 {
 			m.scrollOffset = 0
@@ -124,6 +126,12 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.inputHistoryIdx = -1
 			m.ti.Reset()
 		}
+		return m, nil
+
+	case tea.KeyEnd:
+		// Jump to bottom and re-engage auto-follow.
+		m.sticky = true
+		m.scrollOffset = 0
 		return m, nil
 	}
 


### PR DESCRIPTION
Adds sticky flag for scroll behavior, matching Claude Code's model:

| Action | sticky | Behavior |
|---|---|---|
| New turn | true | View follows new content |
| Mouse wheel scroll | false | Disengages — user has control |
| End key | true | Jump to bottom + re-engage |
| `pushScrollback` (sticky=true) | — | Keeps view at bottom |
| `pushScrollback` (sticky=false) | — | Preserves user position |

Previously, once the user scrolled up, there was no way for the view to auto-resume following new content. Now:
1. Default: auto-follow (like before, but explicit)
2. User scrolls → takes control, view stays put
3. Press End → jump back to bottom, re-engage following