### PR TITLE
feat(tui): add PageUp/PageDown keyboard scroll

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -128,6 +128,20 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	// PageUp/PageDown: keyboard scroll — reliable fallback when
+	// mouse wheel events are not delivered (some terminals/tmux).
+	// Half-page scroll matches Claude Code's behavior.
+	case tea.KeyPgUp:
+		m.sticky = false
+		m.scrollOffset += m.height / 2
+		return m, nil
+	case tea.KeyPgDown:
+		m.sticky = false
+		m.scrollOffset -= m.height / 2
+		if m.scrollOffset < 0 {
+			m.scrollOffset = 0
+		}
+		return m, nil
 	case tea.KeyEnd:
 		// Jump to bottom and re-engage auto-follow.
 		m.sticky = true


### PR DESCRIPTION
Keyboard scrolling as reliable fallback when mouse wheel events are not delivered by the terminal (tmux, certain macOS terminals, SSH sessions).

- **PageUp**: scroll up half page, disengage auto-follow
- **PageDown**: scroll down half page, disengage auto-follow
- **End**: jump to bottom, re-engage auto-follow (already in #238)

All three keys set `sticky=false` so they disengage auto-follow tracking until End re-engages it.