### PR TITLE
feat(tui): add Alt+Up/Alt+Down scroll for MacBook keyboards

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -110,6 +110,12 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.submit(msg.Alt)
 
 	case tea.KeyUp:
+		// Alt+Up: scroll up half page (MacBook-friendly — no PgUp key).
+		if msg.Alt {
+			m.sticky = false
+			m.scrollOffset += m.height / 2
+			return m, nil
+		}
 		if m.inputHistoryIdx+1 < len(m.inputHistory) {
 			m.inputHistoryIdx++
 			m.ti.SetValue(m.inputHistory[len(m.inputHistory)-1-m.inputHistoryIdx])
@@ -118,6 +124,15 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyDown:
+		// Alt+Down: scroll down half page (MacBook-friendly — no PgDn key).
+		if msg.Alt {
+			m.sticky = false
+			m.scrollOffset -= m.height / 2
+			if m.scrollOffset < 0 {
+				m.scrollOffset = 0
+			}
+			return m, nil
+		}
 		if m.inputHistoryIdx > 0 {
 			m.inputHistoryIdx--
 			m.ti.SetValue(m.inputHistory[len(m.inputHistory)-1-m.inputHistoryIdx])


### PR DESCRIPTION
MacBook keyboards lack dedicated PageUp/PageDown keys. Alt+Up/Down (Option+Arrow on macOS) provides half-page scroll.

- **Alt+Up** (Option+↑): scroll up half page, disengage auto-follow
- **Alt+Down** (Option+↓): scroll down half page, disengage auto-follow
- Bare up/down: input history recall (unchanged)
- **PgUp/PgDn**: still work on full keyboards (from #241)
- **End**: jump to bottom + re-engage (from #238)