### PR TITLE
fix(channel): register weixin adapter via blank import

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/channel"
+	_ "github.com/Leihb/octo-agent/internal/channel/adapters/weixin"
 	"github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink"
 	"github.com/Leihb/octo-agent/internal/config"
 	"github.com/Leihb/octo-agent/internal/prompt"


### PR DESCRIPTION
The weixin adapter registers itself in its package init(), but the package was never imported, so the adapter was missing from the registry at runtime.