### PR TITLE
feat(channel): add typing indicator support to Weixin iLink adapter

### DIFF
--- a/internal/channel/adapter.go
+++ b/internal/channel/adapter.go
@@ -95,6 +95,10 @@ type Adapter interface {
 	// SupportsMessageUpdates reports whether the platform can edit sent messages.
 	SupportsMessageUpdates() bool
 
+	// SendTyping sends a typing indicator to the chat.
+	// The contextToken is the platform-specific reply context from the inbound event.
+	SendTyping(chatID, contextToken string) error
+
 	// ValidateConfig returns a list of human-readable errors; empty means valid.
 	ValidateConfig(cfg PlatformConfig) []string
 }

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -226,6 +226,31 @@ func (a *Adapter) UpdateMessage(chatID, messageID, text string) bool { return fa
 // SupportsMessageUpdates returns false.
 func (a *Adapter) SupportsMessageUpdates() bool { return false }
 
+// SendTyping sends a typing indicator to a user via iLink.
+func (a *Adapter) SendTyping(chatID, contextToken string) error {
+	if a.bot == nil || a.bot.creds == nil {
+		return fmt.Errorf("not logged in")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// 1. Get typing ticket.
+	cfg, err := a.bot.client.GetConfig(ctx, a.bot.creds.BaseURL, a.bot.creds.Token, chatID, contextToken)
+	if err != nil {
+		return fmt.Errorf("getconfig: %w", err)
+	}
+	if cfg.TypingTicket == "" {
+		return fmt.Errorf("no typing_ticket in getconfig response")
+	}
+
+	// 2. Send typing indicator (status=1 means "typing").
+	if err := a.bot.client.SendTyping(ctx, a.bot.creds.BaseURL, a.bot.creds.Token, chatID, cfg.TypingTicket, 1); err != nil {
+		return fmt.Errorf("sendtyping: %w", err)
+	}
+	return nil
+}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	return nil // Weixin iLink uses credentials file, not config fields.

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -301,8 +301,13 @@ func (m *Manager) sendReply(ev InboundEvent, text string) {
 
 // sendTyping sends a typing indicator to the chat.
 func (m *Manager) sendTyping(ev InboundEvent) {
-	// Typing indicators are platform-specific; adapters that support them
-	// can implement this. For now this is a no-op placeholder.
+	val, ok := m.adapters.Load(ev.Platform)
+	if !ok {
+		return
+	}
+	ad := val.(Adapter)
+	// Best-effort; ignore errors.
+	_ = ad.SendTyping(ev.ChatID, ev.ContextToken)
 }
 
 // GetSession returns the session for the given inbound event, or nil if none exists.

--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -68,8 +68,9 @@ func (m *mockAdapter) UpdateMessage(chatID, messageID, text string) bool {
 	m.updatedMsgs = append(m.updatedMsgs, updatedMsg{chatID, messageID, text})
 	return true
 }
-func (m *mockAdapter) SupportsMessageUpdates() bool               { return true }
-func (m *mockAdapter) ValidateConfig(cfg PlatformConfig) []string { return m.validateErrs }
+func (m *mockAdapter) SupportsMessageUpdates() bool                 { return true }
+func (m *mockAdapter) SendTyping(chatID, contextToken string) error { return nil }
+func (m *mockAdapter) ValidateConfig(cfg PlatformConfig) []string   { return m.validateErrs }
 
 func (m *mockAdapter) sentTextCount() int {
 	m.mu.Lock()


### PR DESCRIPTION
- Add SendTyping method to channel.Adapter interface
- Implement SendTyping in weixin adapter via GetConfig + SendTyping iLink APIs
- Wire manager.sendTyping to call adapter.SendTyping instead of no-op
- Update mockAdapter in tests to satisfy new interface