### PR TITLE
tui: switch input to textarea, Alt+Enter for newline

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/tools"
 	"github.com/Leihb/octo-agent/internal/tui"
 	"github.com/charmbracelet/bubbles/key"
-	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -23,7 +23,8 @@ import (
 //
 // Input modes while a turn runs (design §7):
 //   - Enter      → steer  (folded into the turn at the next tool-batch boundary)
-//   - Alt+Enter  → queue  (run as a fresh turn after this one finishes)
+//   - Alt+Enter  → newline (insert a line break in the input box)
+//   - Ctrl+Q     → queue  (run as a fresh turn after this one finishes)
 //   - Esc        → interrupt the current turn (queue survives)
 //   - Ctrl+C     → interrupt if a turn runs, else save & quit
 //   - Ctrl+D     → save & quit
@@ -169,8 +170,8 @@ type tuiModel struct {
 	// --plain (cfg.plain), where text commits as raw lines.
 	md markdownRenderer
 
-	// ti is the single-line text input (bubbles/textinput).
-	ti textinput.Model
+	// ta is the multi-line text input (bubbles/textarea).
+	ta textarea.Model
 
 	// inputHistory stores submitted lines for ↑/↓ recall.
 	inputHistory    []string
@@ -192,7 +193,7 @@ type tuiModel struct {
 	// the input back). Keyed by ToolID; entry removed on done/error.
 	toolInput map[string]map[string]any
 
-	// queue holds Alt+Enter messages to run as future turns (design §8/§10).
+	// queue holds Ctrl+Q messages to run as future turns (design §8/§10).
 	queue []pendingItem
 
 	// pendingSteer holds steer messages typed during a running turn that
@@ -250,25 +251,29 @@ type modalState struct {
 }
 
 func newTUIModel(cfg replConfig) *tuiModel {
-	ti := textinput.New()
-	ti.Prompt = ""
-	ti.Placeholder = "Ask anything…"
-	ti.Focus()
-	// Disable bubbles' built-in up/down (suggestion navigation) so we can use
-	// them for input-history recall instead.
-	ti.KeyMap.NextSuggestion = key.Binding{}
-	ti.KeyMap.PrevSuggestion = key.Binding{}
+	ta := textarea.New()
+	ta.Placeholder = "Ask anything…"
+	ta.Focus()
+	ta.ShowLineNumbers = false
+	ta.Prompt = ""
+	// Disable textarea's built-in newline on Enter so we can handle it
+	// ourselves (Enter = submit, Alt+Enter = insert newline).
+	ta.KeyMap.InsertNewline = key.Binding{}
+	// Disable up/down line navigation so we can use them for input-history
+	// recall instead.
+	ta.KeyMap.LineNext = key.Binding{}
+	ta.KeyMap.LinePrevious = key.Binding{}
 	style := "dark"
 	if !tui.IsDark() {
 		style = "light"
 	}
-	return &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ti: ti, inputHistoryIdx: -1, md: markdownRenderer{style: style}}
+	return &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}}
 }
 
 func (m *tuiModel) Init() tea.Cmd {
 	return tea.Sequence(
 		tea.Println(tui.Banner("", m.a.Model, m.cwd, m.width)),
-		textinput.Blink,
+		textarea.Blink,
 	)
 }
 
@@ -312,30 +317,26 @@ func (m *tuiModel) startTurnEcho(line, echo string) tea.Cmd {
 }
 
 func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	model, cmd := m.update(msg)
-	return model, tea.Batch(cmd, m.flushPrints())
-}
-
-func (m *tuiModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		m.ti.Width = msg.Width - 4 // account for border + padding
-		return m, nil
+		m.ta.SetWidth(msg.Width - 4) // account for border + padding
+		m.ta.SetHeight(min(6, msg.Height/4))
+		return m, m.flushPrints()
 
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 
 	case turnStartedMsg:
-		return m, nil
+		return m, m.flushPrints()
 
 	case tickMsg:
 		// Animate while a turn runs OR while background processes are still
 		// going (so the live "background (N running)" panel keeps ticking even
 		// between turns); let the ticker die once both are quiet.
 		if !m.turnRunning && len(tools.RunningBackground()) == 0 {
-			return m, nil
+			return m, m.flushPrints()
 		}
 		m.spinnerFrame++
 		return m, tickCmd()
@@ -345,7 +346,7 @@ func (m *tuiModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case noticeMsg:
 		m.println(noticeStyle.Render(msg.text))
-		return m, nil
+		return m, m.flushPrints()
 
 	case bgExitMsg:
 		// Async background-process completion: show a one-line scrollback notice
@@ -361,7 +362,7 @@ func (m *tuiModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.startTurnEcho(s, "")
 			}
 		}
-		return m, nil
+		return m, m.flushPrints()
 
 	case subAgentNoteMsg:
 		// Async sub-agent completion: show a one-line scrollback notice (the
@@ -379,7 +380,7 @@ func (m *tuiModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.startTurnEcho(s, "")
 			}
 		}
-		return m, nil
+		return m, m.flushPrints()
 
 	case turnEndedMsg:
 		// Flush any trailing assistant block (markdown-rendered); then render
@@ -394,14 +395,39 @@ func (m *tuiModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else if c := cacheLine(m.cfg.verbosity, msg.reply); c != "" {
 			m.println(c)
 		}
-		return m, nil
+		// On interrupt, eagerly reset turnRunning so background-process
+		// auto-turn (bgExitMsg) can fire immediately instead of waiting for
+		// turnFinishedMsg. The steer drain and dequeue still happen in
+		// handleTurnFinished when the goroutine actually returns.
+		if msg.err == context.Canceled {
+			m.turnRunning = false
+			m.running = nil
+			// Eagerly drain steer so a pending steer (or background-process
+			// notice that raced in via Steer) starts immediately rather than
+			// waiting for turnFinishedMsg.
+			if s := m.a.DrainSteer(); s != "" {
+				for _, line := range strings.Split(s, "\n\n") {
+					m.println(userEchoStyle.Render("> ") + line)
+					if len(m.inputHistory) == 0 || m.inputHistory[len(m.inputHistory)-1] != line {
+						m.inputHistory = append(m.inputHistory, line)
+					}
+				}
+				m.queue = append([]pendingItem{{text: s}}, m.queue...)
+			}
+			if len(m.queue) > 0 {
+				next := m.queue[0]
+				m.queue = m.queue[1:]
+				return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(next.text, ""))
+			}
+		}
+		return m, m.flushPrints()
 
 	case turnFinishedMsg:
 		return m.handleTurnFinished()
 
 	case askMsg:
 		m.openModal(msg)
-		return m, nil
+		return m, m.flushPrints()
 
 	case goalPlannedMsg:
 		return m.onGoalPlanned(msg)
@@ -415,12 +441,12 @@ func (m *tuiModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.println(noticeStyle.Render(fmt.Sprintf(
 			"Cancelled. Planned as %s — run later with /goal resume %s (or octo goal run %s).",
 			msg.task.ShortID(), msg.task.ShortID(), msg.task.ShortID())))
-		return m, nil
+		return m, m.flushPrints()
 
 	case goalDoneMsg:
 		return m.onGoalDone(msg)
 	}
-	return m, nil
+	return m, m.flushPrints()
 }
 
 // handleEvent commits streaming text and tool events to the scrollback,

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -28,19 +28,19 @@ func newTestModel() *tuiModel {
 }
 
 func setInput(m *tuiModel, s string) {
-	m.ti.SetValue(s)
-	m.ti.CursorEnd()
+	m.ta.SetValue(s)
+	m.ta.CursorEnd()
 }
 
 func TestTUI_IdleEnterStartsTurn(t *testing.T) {
 	m := newTestModel()
 	setInput(m, "hello")
-	_, _ = m.submit(false)
+	_, _ = m.submit()
 	if !m.turnRunning {
 		t.Fatal("idle Enter should start a turn")
 	}
-	if m.ti.Value() != "" {
-		t.Errorf("input should clear after submit, got %q", m.ti.Value())
+	if m.ta.Value() != "" {
+		t.Errorf("input should clear after submit, got %q", m.ta.Value())
 	}
 }
 
@@ -48,7 +48,7 @@ func TestTUI_RunningEnterSteers(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true
 	setInput(m, "also handle errors")
-	_, _ = m.submit(false) // Enter
+	_, _ = m.submit() // Enter
 	if !m.a.HasPendingSteer() {
 		t.Fatal("Enter while running should steer the agent")
 	}
@@ -82,13 +82,13 @@ func TestTUI_CtrlXUnqueuesMostRecent(t *testing.T) {
 	}
 }
 
-func TestTUI_RunningAltEnterQueues(t *testing.T) {
+func TestTUI_RunningCtrlQQueues(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true
 	setInput(m, "run the linter")
-	_, _ = m.submit(true) // Alt+Enter
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlQ})
 	if len(m.queue) != 1 || m.queue[0].text != "run the linter" {
-		t.Fatalf("Alt+Enter should queue, got %+v", m.queue)
+		t.Fatalf("Ctrl+Q should queue, got %+v", m.queue)
 	}
 	if m.a.HasPendingSteer() {
 		t.Error("queue must not steer the agent")
@@ -258,7 +258,7 @@ func TestTUI_InputHistoryRecall(t *testing.T) {
 
 	// Up recalls the most recent line.
 	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyUp})
-	if got := m.ti.Value(); got != "third" {
+	if got := m.ta.Value(); got != "third" {
 		t.Errorf("input after first Up = %q, want third", got)
 	}
 	if m.inputHistoryIdx != 0 {
@@ -267,20 +267,20 @@ func TestTUI_InputHistoryRecall(t *testing.T) {
 
 	// Up again goes further back.
 	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyUp})
-	if got := m.ti.Value(); got != "second" {
+	if got := m.ta.Value(); got != "second" {
 		t.Errorf("input after second Up = %q, want second", got)
 	}
 
 	// Down moves forward in history.
 	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyDown})
-	if got := m.ti.Value(); got != "third" {
+	if got := m.ta.Value(); got != "third" {
 		t.Errorf("input after Down = %q, want third", got)
 	}
 
 	// Down past the newest restores empty input.
 	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyDown})
-	if m.ti.Value() != "" {
-		t.Errorf("input after Down past newest = %q, want empty", m.ti.Value())
+	if m.ta.Value() != "" {
+		t.Errorf("input after Down past newest = %q, want empty", m.ta.Value())
 	}
 	if m.inputHistoryIdx != -1 {
 		t.Errorf("history idx = %d, want -1", m.inputHistoryIdx)
@@ -290,21 +290,21 @@ func TestTUI_InputHistoryRecall(t *testing.T) {
 func TestTUI_SubmitSavesToHistory(t *testing.T) {
 	m := newTestModel()
 	setInput(m, "hello")
-	_, _ = m.submit(false)
+	_, _ = m.submit()
 	if len(m.inputHistory) != 1 || m.inputHistory[0] != "hello" {
 		t.Errorf("history after submit = %v, want [hello]", m.inputHistory)
 	}
 
 	// Duplicate consecutive line is deduped.
 	setInput(m, "hello")
-	_, _ = m.submit(false)
+	_, _ = m.submit()
 	if len(m.inputHistory) != 1 {
 		t.Errorf("history after duplicate = %v, want still 1 entry", m.inputHistory)
 	}
 
 	// Different line is added.
 	setInput(m, "world")
-	_, _ = m.submit(false)
+	_, _ = m.submit()
 	if len(m.inputHistory) != 2 || m.inputHistory[1] != "world" {
 		t.Errorf("history after new line = %v, want [hello world]", m.inputHistory)
 	}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -15,6 +15,14 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+// min returns the smaller of a and b.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 var (
 	promptStyle       = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
 	noticeStyle       = lipgloss.NewStyle().Foreground(tui.ColMuted)
@@ -27,9 +35,6 @@ var (
 	pendingSteerStyle = lipgloss.NewStyle().Foreground(tui.ColMuted)
 )
 
-// wheelScrollLines is how many lines one wheel tick scrolls.  Larger than 1
-// so track-pad two-finger scrolling feels responsive (bubbletea delivers one
-// MouseWheel event per gesture tick, not per pixel).
 func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.modal != nil {
 		return m.handleModalKey(msg)
@@ -54,14 +59,29 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		// Idle: clear the input line.
-		m.ti.Reset()
+		m.ta.Reset()
 		m.inputHistoryIdx = -1
+		return m, nil
+
+	case tea.KeyCtrlQ:
+		// Queue the current input to run as a future turn.
+		text := strings.TrimSpace(m.ta.Value())
+		if text == "" {
+			return m, nil
+		}
+		m.ta.Reset()
+		m.inputHistoryIdx = -1
+		if len(m.inputHistory) == 0 || m.inputHistory[len(m.inputHistory)-1] != text {
+			m.inputHistory = append(m.inputHistory, text)
+		}
+		m.queue = append(m.queue, pendingItem{text: text})
+		m.println(queueStyle.Render("＋ queued: " + text))
 		return m, nil
 
 	case tea.KeyCtrlX:
 		// Cancel the most-recently queued message. The queue survives Esc
 		// (interrupt only stops the running turn), so this is the way to undo a
-		// mis-queued Alt+Enter; repeat to clear the queue.
+		// mis-queued Ctrl+Q; repeat to clear the queue.
 		if n := len(m.queue); n > 0 {
 			dropped := m.queue[n-1].text
 			m.queue = m.queue[:n-1]
@@ -87,43 +107,49 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyEnter:
-		return m.submit(msg.Alt)
+		if msg.Alt {
+			// Alt+Enter inserts a newline into the textarea.
+			var cmd tea.Cmd
+			m.ta, cmd = m.ta.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			return m, cmd
+		}
+		return m.submit()
 
 	case tea.KeyUp:
 		if m.inputHistoryIdx+1 < len(m.inputHistory) {
 			m.inputHistoryIdx++
-			m.ti.SetValue(m.inputHistory[len(m.inputHistory)-1-m.inputHistoryIdx])
-			m.ti.CursorEnd()
+			m.ta.SetValue(m.inputHistory[len(m.inputHistory)-1-m.inputHistoryIdx])
+			m.ta.CursorEnd()
 		}
 		return m, nil
 
 	case tea.KeyDown:
 		if m.inputHistoryIdx > 0 {
 			m.inputHistoryIdx--
-			m.ti.SetValue(m.inputHistory[len(m.inputHistory)-1-m.inputHistoryIdx])
-			m.ti.CursorEnd()
+			m.ta.SetValue(m.inputHistory[len(m.inputHistory)-1-m.inputHistoryIdx])
+			m.ta.CursorEnd()
 		} else if m.inputHistoryIdx == 0 {
 			m.inputHistoryIdx = -1
-			m.ti.Reset()
+			m.ta.Reset()
 		}
 		return m, nil
 	}
 
 	// Everything else (typing, left/right, backspace, word movement, etc.)
-	// is handled by bubbles/textinput.
+	// is handled by bubbles/textarea.
 	var cmd tea.Cmd
-	m.ti, cmd = m.ti.Update(msg)
+	m.ta, cmd = m.ta.Update(msg)
 	return m, cmd
 }
 
-// submit acts on Enter / Alt+Enter. Idle → start a turn. Running → steer (Enter)
-// or queue (Alt+Enter). Empty input is ignored.
-func (m *tuiModel) submit(alt bool) (tea.Model, tea.Cmd) {
-	text := strings.TrimSpace(m.ti.Value())
+// submit acts on Enter. Idle → start a turn. Running → steer. Empty input is
+// ignored.
+func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
+	text := strings.TrimSpace(m.ta.Value())
 	if text == "" {
 		return m, nil
 	}
-	m.ti.Reset()
+	m.ta.Reset()
 	m.inputHistoryIdx = -1
 	// Save to history for ↑/↓ recall (dedup consecutive identical lines).
 	if len(m.inputHistory) == 0 || m.inputHistory[len(m.inputHistory)-1] != text {
@@ -139,12 +165,6 @@ func (m *tuiModel) submit(alt bool) (tea.Model, tea.Cmd) {
 		return m, m.startTurn(text)
 	}
 
-	if alt {
-		// Queue: run as a future turn.
-		m.queue = append(m.queue, pendingItem{text: text})
-		m.println(queueStyle.Render("＋ queued: " + text))
-		return m, nil
-	}
 	// Steer: fold into the running turn at the next tool-batch boundary.
 	// Echo is deferred to EventSteerInjected (preserves chronological order
 	// with tool_result). A "pending steer" indicator is shown in the live
@@ -435,7 +455,7 @@ func (m *tuiModel) View() string {
 	return b.String()
 }
 func (m *tuiModel) renderInputBox() string {
-	return promptStyle.Render("> ") + m.ti.View()
+	return promptStyle.Render("> ") + m.ta.View()
 }
 
 // renderStatusBar renders the cwd / context% / permission / elapsed segments,
@@ -462,7 +482,7 @@ func (m *tuiModel) renderStatusBar() string {
 
 	var hint string
 	if m.turnRunning {
-		hint = "Enter steer · Alt+Enter queue · Esc interrupt"
+		hint = "Enter steer · Alt+Enter newline · Ctrl+Q queue · Esc interrupt"
 		if len(m.queue) > 0 {
 			hint += " · Ctrl+X unqueue"
 		}


### PR DESCRIPTION
Replace single-line textinput with multi-line textarea so users can insert newlines with Alt+Enter.

**Key mapping changes:**
| Key | Before | After |
|---|---|---|
| Enter | submit / steer | submit / steer (unchanged) |
| Alt+Enter | queue | **insert newline** |
| Ctrl+Q | — | **queue** |
| Ctrl+X | unqueue | unqueue (unchanged) |
| Esc | interrupt / clear | interrupt / clear (unchanged) |
| ↑/↓ | history recall | history recall (unchanged) |

Textarea line navigation is disabled so ↑/↓ continue to work for history recall. InsertNewline is disabled so Enter does not insert a newline by default.

Closes the request to support Alt+Enter for newline in the input box.