### PR TITLE
fix(anthropic): merge consecutive user messages

### DIFF
--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -317,10 +317,28 @@ func toAPITools(defs []agent.ToolDefinition) []apiTool {
 //
 // Messages with Blocks are serialized as a []apiContentBlock JSON array;
 // plain-text messages are serialized as a JSON string for compatibility.
+//
+// Consecutive user messages are merged into one so that a tool_use block is
+// immediately followed by its tool_result block with no intervening user
+// message boundary. This satisfies Anthropic's API requirement that every
+// tool_use id must have a matching tool_result in the next message.
 func toAPIMessages(in []agent.Message) ([]apiMessage, error) {
 	out := make([]apiMessage, 0, len(in))
 	for _, m := range in {
 		if m.Role == agent.RoleSystem {
+			continue
+		}
+
+		// Merge consecutive user messages: Anthropic requires strict
+		// user/assistant alternation, and a tool_use must be immediately
+		// followed by a tool_result in the next message. A steer message
+		// appended after the tool_result would break this pairing.
+		if m.Role == agent.RoleUser && len(out) > 0 && out[len(out)-1].Role == "user" {
+			merged, err := mergeUserMessages(out[len(out)-1], m)
+			if err != nil {
+				return nil, err
+			}
+			out[len(out)-1] = merged
 			continue
 		}
 
@@ -345,6 +363,41 @@ func toAPIMessages(in []agent.Message) ([]apiMessage, error) {
 		}
 	}
 	return out, nil
+}
+
+// mergeUserMessages combines two user-role messages into one. Both may be
+// plain string content or block-array content; the result is always a block
+// array so heterogeneous merges are uniform.
+func mergeUserMessages(prev apiMessage, next agent.Message) (apiMessage, error) {
+	// Decode prev content into blocks.
+	var prevBlocks []map[string]any
+	if err := json.Unmarshal(prev.Content, &prevBlocks); err != nil {
+		// prev was a plain string — promote to a single text block.
+		var s string
+		if err := json.Unmarshal(prev.Content, &s); err != nil {
+			return apiMessage{}, fmt.Errorf("anthropic: unmarshal prev user message: %w", err)
+		}
+		prevBlocks = []map[string]any{{"type": "text", "text": s}}
+	}
+
+	// Decode next content into blocks.
+	var nextBlocks []map[string]any
+	if len(next.Blocks) > 0 {
+		var err error
+		nextBlocks, err = marshalBlocks(next.Blocks)
+		if err != nil {
+			return apiMessage{}, err
+		}
+	} else {
+		nextBlocks = []map[string]any{{"type": "text", "text": next.Content}}
+	}
+
+	merged := append(prevBlocks, nextBlocks...)
+	raw, err := json.Marshal(merged)
+	if err != nil {
+		return apiMessage{}, fmt.Errorf("anthropic: marshal merged user message: %w", err)
+	}
+	return apiMessage{Role: "user", Content: raw}, nil
 }
 
 // marshalBlocks converts agent.ContentBlock slice to []apiContentBlock.

--- a/internal/provider/anthropic/tools_test.go
+++ b/internal/provider/anthropic/tools_test.go
@@ -269,6 +269,123 @@ func TestSend_ToolResultWithSteerText(t *testing.T) {
 	}
 }
 
+// TestSend_MergesConsecutiveUserMessages verifies that consecutive user
+// messages (e.g. tool_result followed by a steer message) are merged into a
+// single user message so Anthropic's tool_use/tool_result pairing requirement
+// is satisfied.
+func TestSend_MergesConsecutiveUserMessages(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"m","type":"message","role":"assistant","model":"x","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	// Simulate agent history where steer was appended as a standalone user
+	// message after the tool_result (the agent layer's design).
+	msgs := []agent.Message{
+		agent.NewUserMessage("run echo hi"),
+		agent.NewToolUseMessage([]agent.ContentBlock{
+			agent.NewToolUseBlock("call-1", "bash", map[string]any{"command": "echo hi"}),
+		}),
+		agent.NewToolResultMessage([]agent.ContentBlock{
+			agent.NewToolResultBlock("call-1", "hi", false),
+		}),
+		agent.NewUserMessage("also handle the error case"),
+	}
+
+	if _, err := c.Send(context.Background(), provider.Request{Model: "x", Messages: msgs, Tools: []agent.ToolDefinition{{Name: "bash"}}}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var wireReq struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(capturedBody, &wireReq); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Should be 3 messages: user text, assistant(tool_use), merged user(tool_result + steer text)
+	if len(wireReq.Messages) != 3 {
+		t.Fatalf("messages len = %d, want 3: %s", len(wireReq.Messages), capturedBody)
+	}
+
+	// Message 2 should be the merged user message with both tool_result and text.
+	if wireReq.Messages[2].Role != "user" {
+		t.Errorf("messages[2].role = %q, want user", wireReq.Messages[2].Role)
+	}
+	var userContent []map[string]any
+	if err := json.Unmarshal(wireReq.Messages[2].Content, &userContent); err != nil {
+		t.Fatalf("decode user content: %v", err)
+	}
+	if len(userContent) != 2 {
+		t.Fatalf("user content blocks = %d, want 2 (tool_result + text): %v", len(userContent), userContent)
+	}
+	if userContent[0]["type"] != "tool_result" {
+		t.Errorf("blocks[0].type = %v, want tool_result", userContent[0]["type"])
+	}
+	if userContent[1]["type"] != "text" || userContent[1]["text"] != "also handle the error case" {
+		t.Errorf("blocks[1] = %v, want text steer", userContent[1])
+	}
+}
+
+// TestSend_MergesConsecutivePlainUserMessages verifies that two plain-text
+// user messages are merged into a single user message with two text blocks.
+func TestSend_MergesConsecutivePlainUserMessages(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"m","type":"message","role":"assistant","model":"x","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	msgs := []agent.Message{
+		agent.NewUserMessage("first message"),
+		agent.NewUserMessage("second message"),
+	}
+
+	if _, err := c.Send(context.Background(), provider.Request{Model: "x", Messages: msgs}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var wireReq struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(capturedBody, &wireReq); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(wireReq.Messages) != 1 {
+		t.Fatalf("messages len = %d, want 1: %s", len(wireReq.Messages), capturedBody)
+	}
+
+	var content []map[string]any
+	if err := json.Unmarshal(wireReq.Messages[0].Content, &content); err != nil {
+		t.Fatalf("decode content: %v", err)
+	}
+	if len(content) != 2 {
+		t.Fatalf("content blocks = %d, want 2: %v", len(content), content)
+	}
+	if content[0]["type"] != "text" || content[0]["text"] != "first message" {
+		t.Errorf("blocks[0] = %v", content[0])
+	}
+	if content[1]["type"] != "text" || content[1]["text"] != "second message" {
+		t.Errorf("blocks[1] = %v", content[1])
+	}
+}
+
 // TestSend_ImageBlock_WireFormat verifies that an image content block is
 // serialized as an Anthropic image source block with base64 data.
 func TestSend_ImageBlock_WireFormat(t *testing.T) {


### PR DESCRIPTION
Anthropic API requires every tool_use block to be immediately followed by a matching tool_result in the next message. When steer messages (mid-turn user input, background-process completion notices) are appended as standalone user messages after the tool_result, the API rejects the request with:

> messages.N: tool_use ids were found without tool_result blocks immediately after

This fix merges consecutive user messages in the Anthropic adapter's toAPIMessages, preserving the agent layer's message semantics (steer as distinct user messages for model responsiveness and background-task driving) while satisfying the API constraint.

Changes:
- toAPIMessages: detect consecutive user messages and merge them into one block-array message
- mergeUserMessages: helper that combines plain-text and block-array user messages uniformly
- Tests: verify tool_result+steer merge and plain-text+plain-text merge