### PR TITLE
feat(tui): show pending steer above input box (Claude Code style)

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -195,6 +195,12 @@ type tuiModel struct {
 	// queue holds Alt+Enter messages to run as future turns (design §8/§10).
 	queue []pendingItem
 
+	// pendingSteer holds steer messages typed during a running turn that
+	// haven't been drained yet. Shown in the live View area (below the
+	// scrollback) so the user sees immediate feedback without breaking
+	// the chronological message order (Claude Code style).
+	pendingSteer []string
+
 	// modal, when non-nil, is an active Ask prompt (design §6).
 	modal *modalState
 
@@ -475,6 +481,8 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) tea.Cmd {
 		// chronological order — the user sees their steer where the model
 		// actually receives it, not prematurely when they typed it.
 		// Also add to inputHistory so ↑ can recall each steer line.
+		// Clear the "pending steer" live indicator.
+		m.pendingSteer = nil
 		for _, line := range strings.Split(ev.Text, "\n\n") {
 			if len(m.inputHistory) == 0 || m.inputHistory[len(m.inputHistory)-1] != line {
 				m.inputHistory = append(m.inputHistory, line)
@@ -585,7 +593,8 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 	m.turnRunning = false
 	m.cancelTurn = nil
 	m.streaming = false
-	m.running = nil // clear any live tool indicator (e.g. on interrupt)
+	m.running = nil      // clear any live tool indicator (e.g. on interrupt)
+	m.pendingSteer = nil // clear pending steer display (drained or degraded)
 
 	// Auto-save (history is well-formed even after an interrupt).
 	if !m.cfg.noSave {

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -16,14 +16,15 @@ import (
 )
 
 var (
-	promptStyle   = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
-	noticeStyle   = lipgloss.NewStyle().Foreground(tui.ColMuted)
-	errorStyle    = lipgloss.NewStyle().Foreground(tui.ColDanger)
-	toolErrStyle  = lipgloss.NewStyle().Foreground(tui.ColDanger)
-	queueStyle    = lipgloss.NewStyle().Foreground(tui.ColAccent)
-	modalStyle    = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
-	hintStyle     = lipgloss.NewStyle().Foreground(tui.ColDimmer).Italic(true)
-	userEchoStyle = lipgloss.NewStyle().Foreground(tui.ColUserMsg).Bold(true)
+	promptStyle       = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	noticeStyle       = lipgloss.NewStyle().Foreground(tui.ColMuted)
+	errorStyle        = lipgloss.NewStyle().Foreground(tui.ColDanger)
+	toolErrStyle      = lipgloss.NewStyle().Foreground(tui.ColDanger)
+	queueStyle        = lipgloss.NewStyle().Foreground(tui.ColAccent)
+	modalStyle        = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	hintStyle         = lipgloss.NewStyle().Foreground(tui.ColDimmer).Italic(true)
+	userEchoStyle     = lipgloss.NewStyle().Foreground(tui.ColUserMsg).Bold(true)
+	pendingSteerStyle = lipgloss.NewStyle().Foreground(tui.ColMuted)
 )
 
 // wheelScrollLines is how many lines one wheel tick scrolls.  Larger than 1
@@ -145,9 +146,10 @@ func (m *tuiModel) submit(alt bool) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	// Steer: fold into the running turn at the next tool-batch boundary.
-	// No immediate UI echo — the steer text is displayed later via
-	// EventSteerInjected when it is actually drained into the tool_result,
-	// preserving chronological order.
+	// Echo is deferred to EventSteerInjected (preserves chronological order
+	// with tool_result). A "pending steer" indicator is shown in the live
+	// View area below the scrollback for immediate visual feedback.
+	m.pendingSteer = append(m.pendingSteer, text)
 	m.a.Steer(text)
 	return m, nil
 }
@@ -218,6 +220,7 @@ func (m *tuiModel) interrupt() {
 	if m.cancelTurn != nil {
 		m.cancelTurn()
 	}
+	m.pendingSteer = nil
 }
 
 // ── modal (Ask) ──
@@ -344,6 +347,9 @@ func (m *tuiModel) liveHeight() int {
 	if m.running != nil || (m.turnRunning && !m.streaming) {
 		h++
 	}
+	if n := len(m.pendingSteer); n > 0 {
+		h += n // one line per pending steer message
+	}
 	if n := len(m.queue); n > 0 {
 		h += 3 + n // panel border (2) + title (1) + n body lines
 	}
@@ -409,6 +415,17 @@ func (m *tuiModel) View() string {
 		}
 		b.WriteString(tui.Panel(fmt.Sprintf("background (%d running)", len(bg)), lines.String()))
 		b.WriteByte('\n')
+	}
+
+	// Pending steer — show what the user typed mid-turn, indented right above
+	// the input box (Claude Code style: input上方，比普通消息多了一个indent).
+	// Does not enter the scrollback until drained via EventSteerInjected,
+	// preserving chronological order with tool_result.
+	if len(m.pendingSteer) > 0 {
+		for _, s := range m.pendingSteer {
+			b.WriteString(pendingSteerStyle.Render("  > ") + pendingSteerStyle.Render(s))
+			b.WriteByte('\n')
+		}
 	}
 
 	// Input box + status bar


### PR DESCRIPTION
User steer typed mid-turn now appears as an indented indicator right above the input box (live View area), without entering the scrollback. When the steer is drained at the next tool-batch boundary, EventSteerInjected commits it into the scrollback at the correct chronological position (after tool_result).

**Changes:**
- Add `pendingSteer []string` field to `tuiModel`
- `submit()`: append to `pendingSteer` instead of deferring entirely
- `View()`: render pending steer with `  > ` indent, muted style, right above the input box
- `EventSteerInjected`: clear `pendingSteer` on drain
- `handleTurnFinished` / `interrupt`: clear `pendingSteer`

**Visual:**
```
┌─ scrollback ──────────────┐
│ assistant: running tool... │
│ tool_result: output        │
├─ live ────────────────────┤
│ ⟳ Thinking (3s)           │
│   > also handle errors    │  ← pending steer, indent above input
│ > _                        │  ← input box
└───────────────────────────┘
```