### PR TITLE
fix(tui): restore textarea InsertNewline binding

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -281,9 +281,6 @@ func newTUIModel(cfg replConfig) *tuiModel {
 	ta.Focus()
 	ta.ShowLineNumbers = false
 	ta.Prompt = ""
-	// Disable textarea's built-in newline on Enter so we can handle it
-	// ourselves (Enter = submit, Alt+Enter = insert newline).
-	ta.KeyMap.InsertNewline = key.Binding{}
 	// Disable up/down line navigation so we can use them for input-history
 	// recall instead.
 	ta.KeyMap.LineNext = key.Binding{}


### PR DESCRIPTION
Setting InsertNewline to key.Binding{} cleared the key list, making key.Matches always return false. This broke Alt+Enter, Ctrl+J, and Shift+Enter newline insertion because all three paths funnel through m.ta.Update(tea.KeyMsg{Type: tea.KeyEnter}), which textarea only handles when its InsertNewline binding matches.