### PR TITLE
feat(tui): auto-grow textarea from 1 line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage.html
 /.claude/settings.local.json
 .codegraph/
 /.claude/scheduled_tasks.lock
+/.worktrees/

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -61,6 +61,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Idle: clear the input line.
 		m.ta.Reset()
 		m.inputHistoryIdx = -1
+		m.updateTextAreaHeight()
 		return m, nil
 
 	case tea.KeyCtrlJ:
@@ -68,6 +69,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// terminals, including those where Alt+Enter is not mapped.
 		var cmd tea.Cmd
 		m.ta, cmd = m.ta.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		m.updateTextAreaHeight()
 		return m, cmd
 
 	case tea.KeyCtrlQ:
@@ -118,6 +120,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// Alt+Enter inserts a newline into the textarea.
 			var cmd tea.Cmd
 			m.ta, cmd = m.ta.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			m.updateTextAreaHeight()
 			return m, cmd
 		}
 		return m.submit()
@@ -127,6 +130,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.inputHistoryIdx++
 			m.ta.SetValue(m.inputHistory[len(m.inputHistory)-1-m.inputHistoryIdx])
 			m.ta.CursorEnd()
+			m.updateTextAreaHeight()
 		}
 		return m, nil
 
@@ -135,9 +139,11 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.inputHistoryIdx--
 			m.ta.SetValue(m.inputHistory[len(m.inputHistory)-1-m.inputHistoryIdx])
 			m.ta.CursorEnd()
+			m.updateTextAreaHeight()
 		} else if m.inputHistoryIdx == 0 {
 			m.inputHistoryIdx = -1
 			m.ta.Reset()
+			m.updateTextAreaHeight()
 		}
 		return m, nil
 	}
@@ -146,6 +152,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// is handled by bubbles/textarea.
 	var cmd tea.Cmd
 	m.ta, cmd = m.ta.Update(msg)
+	m.updateTextAreaHeight()
 	return m, cmd
 }
 
@@ -460,6 +467,18 @@ func (m *tuiModel) View() string {
 	b.WriteString(m.renderStatusBar())
 	return b.String()
 }
+
+// updateTextAreaHeight sets the textarea height to match the number of lines
+// in the current value, capped at a maximum so it doesn't take over the screen.
+func (m *tuiModel) updateTextAreaHeight() {
+	lines := strings.Count(m.ta.Value(), "\n") + 1
+	maxH := min(6, m.height/4)
+	if maxH < 1 {
+		maxH = 1
+	}
+	m.ta.SetHeight(min(lines, maxH))
+}
+
 func (m *tuiModel) renderInputBox() string {
 	return promptStyle.Render("> ") + m.ta.View()
 }


### PR DESCRIPTION
The input box now starts at a single line and grows dynamically as the user inserts newlines, capped at min(6, height/4).

Updates the textarea height on every keystroke, history recall, and newline insertion (Alt+Enter / Ctrl+J).