### PR TITLE
config: add OCTO_PROVIDER env var support

### DIFF
--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -27,7 +27,7 @@ func firstNonEmpty(vals ...string) string {
 // model (i.e. an unknown provider with no explicit model) — the caller prints
 // an error and exits.
 func resolveProviderModel(flagProvider, flagModel string, cfg config.Config) (provider, model string, ok bool) {
-	provider = firstNonEmpty(flagProvider, cfg.Provider, providerAnthropic)
+	provider = firstNonEmpty(flagProvider, os.Getenv("OCTO_PROVIDER"), cfg.Provider, providerAnthropic)
 	// Precedence: --model flag > env (ANTHROPIC_MODEL / OPENAI_MODEL) > config
 	// (same-provider only) > built-in default. The env tier mirrors how the
 	// base URL and key resolve env-first, so a third-party Claude-/OpenAI-
@@ -140,9 +140,11 @@ func runConfigShow(stdout, stderr io.Writer) int {
 	}
 	path, _ := config.Path()
 
-	provider := firstNonEmpty(cfg.Provider, providerAnthropic)
+	provider := firstNonEmpty(os.Getenv("OCTO_PROVIDER"), cfg.Provider, providerAnthropic)
 	provSrc := "default"
-	if cfg.Provider != "" {
+	if envProv := os.Getenv("OCTO_PROVIDER"); envProv != "" {
+		provSrc = "env"
+	} else if cfg.Provider != "" {
 		provSrc = "config"
 	}
 	model := firstNonEmpty(cfg.Model, defaultModels[provider])

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestResolveBaseURL_Precedence(t *testing.T) {
+	// Isolate from host env vars so the test is deterministic.
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("OPENAI_BASE_URL", "")
+
 	// env wins over config.
 	t.Setenv("ANTHROPIC_BASE_URL", "https://api.deepseek.com/anthropic")
 	cfg := config.Config{Provider: providerAnthropic, BaseURL: "https://cfg.example"}
@@ -27,7 +31,6 @@ func TestResolveBaseURL_Precedence(t *testing.T) {
 	}
 
 	// No override anywhere → effectiveEndpoint shows the marked default.
-	t.Setenv("ANTHROPIC_BASE_URL", "")
 	empty := config.Config{}
 	if got := resolveBaseURL(providerAnthropic, empty); got != "" {
 		t.Errorf("no override should be empty, got %q", got)
@@ -69,6 +72,7 @@ func TestResolveProviderModel_Precedence(t *testing.T) {
 	// cases below are deterministic.
 	t.Setenv("ANTHROPIC_MODEL", "")
 	t.Setenv("OPENAI_MODEL", "")
+	t.Setenv("OCTO_PROVIDER", "")
 	cfg := config.Config{Provider: "openai", Model: "cfg-model"}
 	tests := []struct {
 		name              string
@@ -94,6 +98,25 @@ func TestResolveProviderModel_Precedence(t *testing.T) {
 					tc.flagProv, tc.flagMdl, tc.cfg, gotProv, gotMdl, ok, tc.wantProv, tc.wantMdl, tc.wantOK)
 			}
 		})
+	}
+}
+
+func TestResolveProviderModel_ProviderEnv(t *testing.T) {
+	// OCTO_PROVIDER beats config and default, but --provider flag still beats env.
+	t.Setenv("OCTO_PROVIDER", "openai")
+	t.Setenv("OPENAI_MODEL", "")
+	cfg := config.Config{Provider: providerAnthropic, Model: "cfg-model"}
+
+	if p, _, _ := resolveProviderModel("", "", cfg); p != "openai" {
+		t.Errorf("OCTO_PROVIDER should beat config, got %q", p)
+	}
+	if p, _, _ := resolveProviderModel("anthropic", "", cfg); p != "anthropic" {
+		t.Errorf("--provider flag should beat OCTO_PROVIDER, got %q", p)
+	}
+	// When OCTO_PROVIDER selects a provider, its model env var is read.
+	t.Setenv("OPENAI_MODEL", "deepseek-chat")
+	if _, m, _ := resolveProviderModel("", "", config.Config{}); m != "deepseek-chat" {
+		t.Errorf("OCTO_PROVIDER=openai + OPENAI_MODEL should resolve model, got %q", m)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add `OCTO_PROVIDER` environment variable to override the provider selection, matching the existing env var pattern for per-provider settings (`OPENAI_MODEL`, `ANTHROPIC_BASE_URL`, etc.).

## Precedence

CLI flag (> `OCTO_PROVIDER` env > config file > built-in default.

## Changes

- `cmd/octo/config.go`: read `OCTO_PROVIDER` in `resolveProviderModel` and `runConfigShow`
- `cmd/octo/config_test.go`: add `TestResolveProviderModel_ProviderEnv`, fix `TestResolveBaseURL_Precedence` to isolate from host env vars

## Usage

