### PR TITLE
fix(agent): prevent orphaned tool_use causing HTTP 400 errors

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -426,6 +426,12 @@ func (a *Agent) runLoop(
 			a.History.Append(NewUserMessage(m))
 		}
 
+		// Defensive check: ensure every tool_use block has a matching tool_result.
+		// This handles edge cases where compaction, overflow recovery, or an
+		// interrupted dispatchTools left orphaned tool_use blocks. Synthesizing
+		// error tool_results prevents Anthropic HTTP 400 errors.
+		a.ensureToolPairing()
+
 		reply, err := send(ctx, a.History.Snapshot())
 		if err != nil {
 			// Interrupt during the provider call: finalize cleanly rather than
@@ -513,21 +519,31 @@ func (a *Agent) runLoop(
 //   - last message is the unanswered user input → drop it (turn never happened)
 //   - last message is a tool_result (user role) → cap with an assistant note,
 //     so the next user turn doesn't produce two user messages in a row
-//   - last message is already an assistant turn → nothing to do
+//   - last message is an assistant(tool_use) without tool_result → synthesize
+//     error tool_results and cap with an assistant note
+//   - last message is already a plain assistant turn → nothing to do
 //
-// The synthesized tool_result blocks for interrupted tool calls are produced
-// by dispatchTools itself (cancelled executions become is_error results), so
-// every tool_use already has a matching tool_result by the time we get here.
+// The synthesized tool_result blocks for interrupted tool calls are normally
+// produced by dispatchTools itself (cancelled executions become is_error
+// results). This function handles the edge case where dispatchTools didn't
+// complete before the interrupt was detected.
 func (a *Agent) finishInterrupted(handler EventHandler) (Reply, error) {
 	msgs := a.History.Snapshot()
 	if n := len(msgs); n > 0 {
 		last := msgs[n-1]
-		if last.Role == RoleUser {
-			if hasToolResult(last) {
-				a.History.Append(NewAssistantMessage(interruptNote))
-			} else {
-				a.History.popLast()
+		switch {
+		case last.Role == RoleAssistant && hasToolUse(last):
+			// Orphaned assistant(tool_use) — dispatchTools didn't produce results.
+			// Synthesize error tool_results so the next send() doesn't 400.
+			results := synthesizeInterruptedToolResults(last.Blocks)
+			if len(results) > 0 {
+				a.History.Append(NewToolResultMessage(results))
 			}
+			a.History.Append(NewAssistantMessage(interruptNote))
+		case last.Role == RoleUser && hasToolResult(last):
+			a.History.Append(NewAssistantMessage(interruptNote))
+		case last.Role == RoleUser:
+			a.History.popLast()
 		}
 	}
 	reply := Reply{Content: interruptNote, StopReason: StopReasonInterrupted}

--- a/internal/agent/toolpairing.go
+++ b/internal/agent/toolpairing.go
@@ -1,0 +1,84 @@
+package agent
+
+// hasToolUse reports whether m contains any tool_use block.
+func hasToolUse(m Message) bool {
+	for _, b := range m.Blocks {
+		if b.Type == "tool_use" {
+			return true
+		}
+	}
+	return false
+}
+
+// synthesizeInterruptedToolResults creates error tool_result blocks for each
+// tool_use block in the given message. Used when a turn is interrupted and
+// the tool_use has no matching tool_result (either because dispatchTools never
+// ran, or because it failed to produce results before the interrupt).
+//
+// The error message "[Interrupted by user]" signals clearly to the LLM that
+// the tool did not complete and should be retried if needed.
+func synthesizeInterruptedToolResults(blocks []ContentBlock) []ContentBlock {
+	var results []ContentBlock
+	for _, b := range blocks {
+		if b.Type == "tool_use" {
+			results = append(results, NewToolResultBlock(b.ID, interruptNote, true))
+		}
+	}
+	return results
+}
+
+// ensureToolPairing scans the history and fixes any orphaned tool_use blocks
+// by synthesizing error tool_result blocks. This is a defensive check that
+// runs before each send() call in runLoop to prevent Anthropic HTTP 400 errors
+// ("tool_calls must be followed by tool messages").
+//
+// The function handles these cases:
+//   - Orphaned assistant(tool_use) at the end of history (no following tool_result)
+//   - Multiple consecutive tool_use messages without tool_results (rare edge case)
+//
+// Synthesized tool_results use is_error=true with "[Interrupted by user]" to
+// signal clearly to the LLM that the tool did not complete.
+func (a *Agent) ensureToolPairing() {
+	msgs := a.History.Snapshot()
+	if len(msgs) == 0 {
+		return
+	}
+
+	// Scan for orphaned tool_use blocks. We need to track which tool_use IDs
+	// have been answered by tool_result blocks in subsequent messages.
+	//
+	// Build a set of answered tool_use IDs from tool_result blocks.
+	answered := make(map[string]bool)
+	for _, m := range msgs {
+		if m.Role == RoleUser {
+			for _, b := range m.Blocks {
+				if b.Type == "tool_result" {
+					answered[b.ToolUseID] = true
+				}
+			}
+		}
+	}
+
+	// Find orphaned tool_use blocks (those without a matching tool_result).
+	var orphans []ContentBlock
+	for _, m := range msgs {
+		if m.Role == RoleAssistant {
+			for _, b := range m.Blocks {
+				if b.Type == "tool_use" && !answered[b.ID] {
+					orphans = append(orphans, b)
+				}
+			}
+		}
+	}
+
+	if len(orphans) == 0 {
+		return
+	}
+
+	// Synthesize error tool_results for all orphaned tool_use blocks.
+	var results []ContentBlock
+	for _, b := range orphans {
+		results = append(results, NewToolResultBlock(b.ID, "[Tool execution was interrupted or failed to complete]", true))
+	}
+	a.History.Append(NewToolResultMessage(results))
+}

--- a/internal/agent/toolpairing_test.go
+++ b/internal/agent/toolpairing_test.go
@@ -1,0 +1,185 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestHasToolUse(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  Message
+		want bool
+	}{
+		{
+			name: "plain text message",
+			msg:  NewAssistantMessage("hello"),
+			want: false,
+		},
+		{
+			name: "message with tool_use block",
+			msg:  NewToolUseMessage([]ContentBlock{NewToolUseBlock("c1", "read_file", nil)}),
+			want: true,
+		},
+		{
+			name: "message with mixed blocks",
+			msg: Message{
+				Role: RoleAssistant,
+				Blocks: []ContentBlock{
+					NewTextBlock("thinking..."),
+					NewToolUseBlock("c1", "read_file", nil),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "tool_result message",
+			msg:  NewToolResultMessage([]ContentBlock{NewToolResultBlock("c1", "result", false)}),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasToolUse(tt.msg); got != tt.want {
+				t.Errorf("hasToolUse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSynthesizeInterruptedToolResults(t *testing.T) {
+	blocks := []ContentBlock{
+		NewTextBlock("Let me read that file"),
+		NewToolUseBlock("c1", "read_file", map[string]any{"path": "foo.go"}),
+		NewToolUseBlock("c2", "grep", map[string]any{"pattern": "bar"}),
+	}
+
+	results := synthesizeInterruptedToolResults(blocks)
+
+	if len(results) != 2 {
+		t.Fatalf("synthesizeInterruptedToolResults() returned %d results, want 2", len(results))
+	}
+	for i, r := range results {
+		if r.Type != "tool_result" {
+			t.Errorf("result[%d].Type = %q, want tool_result", i, r.Type)
+		}
+		if !r.IsError {
+			t.Errorf("result[%d].IsError = false, want true", i)
+		}
+		if r.Result != interruptNote {
+			t.Errorf("result[%d].Result = %q, want %q", i, r.Result, interruptNote)
+		}
+	}
+	if results[0].ToolUseID != "c1" {
+		t.Errorf("results[0].ToolUseID = %q, want c1", results[0].ToolUseID)
+	}
+	if results[1].ToolUseID != "c2" {
+		t.Errorf("results[1].ToolUseID = %q, want c2", results[1].ToolUseID)
+	}
+}
+
+func TestEnsureToolPairing(t *testing.T) {
+	t.Run("no orphaned tool_use", func(t *testing.T) {
+		a := New(&summarizeFake{}, "m")
+		a.History.Append(NewUserMessage("read it"))
+		a.History.Append(NewToolUseMessage([]ContentBlock{NewToolUseBlock("c1", "read_file", nil)}))
+		a.History.Append(NewToolResultMessage([]ContentBlock{NewToolResultBlock("c1", "content", false)}))
+		a.History.Append(NewAssistantMessage("done"))
+
+		a.ensureToolPairing()
+
+		// History should be unchanged
+		if a.History.Len() != 4 {
+			t.Errorf("history len = %d, want 4", a.History.Len())
+		}
+	})
+
+	t.Run("orphaned tool_use gets synthesized result", func(t *testing.T) {
+		a := New(&summarizeFake{}, "m")
+		a.History.Append(NewUserMessage("read it"))
+		a.History.Append(NewToolUseMessage([]ContentBlock{NewToolUseBlock("c1", "read_file", nil)}))
+		// Missing tool_result!
+
+		a.ensureToolPairing()
+
+		if a.History.Len() != 3 {
+			t.Fatalf("history len = %d, want 3", a.History.Len())
+		}
+		msgs := a.History.Snapshot()
+		last := msgs[2]
+		if last.Role != RoleUser {
+			t.Fatalf("last message role = %q, want user", last.Role)
+		}
+		if len(last.Blocks) != 1 {
+			t.Fatalf("last message blocks = %d, want 1", len(last.Blocks))
+		}
+		if last.Blocks[0].Type != "tool_result" {
+			t.Errorf("last block type = %q, want tool_result", last.Blocks[0].Type)
+		}
+		if last.Blocks[0].ToolUseID != "c1" {
+			t.Errorf("last block ToolUseID = %q, want c1", last.Blocks[0].ToolUseID)
+		}
+		if !last.Blocks[0].IsError {
+			t.Error("last block IsError = false, want true")
+		}
+	})
+
+	t.Run("multiple orphaned tool_use blocks", func(t *testing.T) {
+		a := New(&summarizeFake{}, "m")
+		a.History.Append(NewUserMessage("read files"))
+		a.History.Append(NewToolUseMessage([]ContentBlock{
+			NewToolUseBlock("c1", "read_file", nil),
+			NewToolUseBlock("c2", "read_file", nil),
+		}))
+		// Only one tool_result
+		a.History.Append(NewToolResultMessage([]ContentBlock{NewToolResultBlock("c1", "content", false)}))
+
+		a.ensureToolPairing()
+
+		if a.History.Len() != 4 {
+			t.Fatalf("history len = %d, want 4", a.History.Len())
+		}
+		msgs := a.History.Snapshot()
+		last := msgs[3]
+		if len(last.Blocks) != 1 {
+			t.Fatalf("last message blocks = %d, want 1 (only c2 orphaned)", len(last.Blocks))
+		}
+		if last.Blocks[0].ToolUseID != "c2" {
+			t.Errorf("last block ToolUseID = %q, want c2", last.Blocks[0].ToolUseID)
+		}
+	})
+}
+
+func TestFinishInterrupted_OrphanedToolUse(t *testing.T) {
+	a := New(&summarizeFake{}, "m")
+	a.History.Append(NewUserMessage("read it"))
+	// Assistant wants to use a tool, but dispatchTools never ran
+	a.History.Append(NewToolUseMessage([]ContentBlock{NewToolUseBlock("c1", "read_file", nil)}))
+
+	_, err := a.finishInterrupted(nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+
+	msgs := a.History.Snapshot()
+	// Should have: user, assistant(tool_use), user(tool_result), assistant(interrupt note)
+	if len(msgs) != 4 {
+		t.Fatalf("history len = %d, want 4", len(msgs))
+	}
+	// Check synthesized tool_result
+	if msgs[2].Role != RoleUser {
+		t.Fatalf("msgs[2].Role = %q, want user", msgs[2].Role)
+	}
+	if len(msgs[2].Blocks) != 1 || msgs[2].Blocks[0].Type != "tool_result" {
+		t.Fatalf("msgs[2] should have tool_result block")
+	}
+	if !msgs[2].Blocks[0].IsError {
+		t.Error("synthesized tool_result should be is_error=true")
+	}
+	// Check interrupt note
+	if msgs[3].Role != RoleAssistant || msgs[3].Content != interruptNote {
+		t.Errorf("msgs[3] should be assistant interrupt note")
+	}
+}


### PR DESCRIPTION
## Problem

Intermittent Anthropic API 400 errors:
```
error: agent: loop[1]: anthropic: HTTP 400 (invalid_request_error): 
an assistant message with 'tool_calls' must be followed by tool messages 
responding to each 'tool_call_id'. The following tool_call_ids did not 
have response messages: read_file:1
```

## Root Cause

Orphaned `assistant(tool_use)` blocks in history when:
1. Context cancellation between `History.Append(NewToolUseMessage(...))` and `dispatchTools` completion
2. `finishInterrupted` didn't handle the `assistant(tool_use)` case — only handled `user` messages
3. Edge cases in compaction/overflow recovery leaving tool_use without tool_result

## Fix

Two-layer defensive approach:

### Layer 1: Fix `finishInterrupted`
Handle orphaned `assistant(tool_use)` by synthesizing error `tool_result` blocks and appending an interrupt note:
```go
case last.Role == RoleAssistant && hasToolUse(last):
    results := synthesizeInterruptedToolResults(last.Blocks)
    if len(results) > 0 {
        a.History.Append(NewToolResultMessage(results))
    }
    a.History.Append(NewAssistantMessage(interruptNote))
```

### Layer 2: `ensureToolPairing` before send()
Defensive scan before each `send()` in `runLoop` to catch any orphaned tool_use blocks regardless of root cause. Synthesizes `is_error=true` tool_results with "[Tool execution was interrupted or failed to complete]".

## Impact on Existing Behavior

- **Background process notifications**: ✓ Unchanged — inbox drain timing preserved
- **Sub-agent completion notifications**: ✓ Unchanged — same flow  
- **Mid-turn steer messages**: ✓ Unchanged — still drained at loop iteration top
- **Idle auto-turn**: ✓ Unchanged — TUI and plain REPL paths unaffected

The only behavioral change: edge cases that would previously 400 now get a synthesized error tool_result, allowing the turn to continue gracefully.

## Testing

- New unit tests for `hasToolUse`, `synthesizeInterruptedToolResults`, `ensureToolPairing`
- Updated `TestFinishInterrupted_OrphanedToolUse` test case
- All `internal/agent` tests pass ✓
- Pre-existing `cmd/octo` test failures are environment-related (OPENAI_API_KEY), unrelated to this change