### PR TITLE
fix(tui): remove '^C interrupted' display on Esc interrupt

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -426,8 +426,6 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.err != nil && msg.err != context.Canceled {
 			m.println(errorStyle.Render("error: " + msg.err.Error()))
-		} else if msg.err == context.Canceled {
-			m.println(noticeStyle.Render("^C interrupted"))
 		} else if c := cacheLine(m.cfg.verbosity, msg.reply); c != "" {
 			m.println(c)
 		}

--- a/cmd/octo/tuirepl_goal.go
+++ b/cmd/octo/tuirepl_goal.go
@@ -191,10 +191,7 @@ func (m *tuiModel) onGoalDone(msg goalDoneMsg) (tea.Model, tea.Cmd) {
 	}
 	switch {
 	case msg.err != nil && errors.Is(msg.err, context.Canceled):
-		if b.Len() > 0 {
-			b.WriteByte('\n')
-		}
-		b.WriteString(noticeStyle.Render("^C interrupted"))
+		// Goal interrupted: show task status without extra interrupt notice.
 	case msg.err != nil:
 		if b.Len() > 0 {
 			b.WriteByte('\n')

--- a/cmd/octo/turncore.go
+++ b/cmd/octo/turncore.go
@@ -160,8 +160,8 @@ func (v *plainView) TurnEnded(reply agent.Reply, err error) {
 	v.spin.Stop() // belt-and-braces in case the turn produced zero events
 	switch {
 	case errors.Is(err, context.Canceled):
-		// Ctrl-C: the agent already finalized history into a well-formed state.
-		fmt.Fprintln(v.out, "\n^C interrupted")
+		// Ctrl-C / Esc: silently terminate. The agent already finalized
+		// history into a well-formed state.
 	case err != nil:
 		fmt.Fprintf(v.errOut, "\nerror: %v\n", err)
 	default:


### PR DESCRIPTION
## Summary

When the user presses Esc to interrupt a running turn, the TUI previously displayed `^C interrupted`. This is unnecessary noise — the turn simply terminates silently.

## Steer Message Processing

Steer messages typed during a running turn are already correctly processed after interrupt:

1. User types steer → `Inbox.Enqueue(text)`
2. User presses Esc → context cancelled → turn ends
3. `turnEndedMsg` handler drains inbox → queues steer messages → starts new turn

No code changes needed for steer processing — it was already working correctly.

## Changes

- `tuirepl.go`: Remove `^C interrupted` println in `turnEndedMsg` handler
- `tuirepl_goal.go`: Remove `^C interrupted` in `onGoalDone`
- `turncore.go`: Remove `^C interrupted` println in `plainView.TurnEnded`

## Testing

- All `internal/agent` tests pass ✓
- All TUI tests (`TestTUI_*`) pass ✓
- `TestRunTurn`, `TestBg*`, `TestInbox*`, `TestREPL*` pass ✓