### PR TITLE
fix(agent): merge synthetic tool_results into trailing user messages

### DIFF
--- a/internal/agent/history.go
+++ b/internal/agent/history.go
@@ -84,6 +84,19 @@ func (h *History) Tail(n int) []Message {
 	return out
 }
 
+// replaceLast replaces the last message in history with m. If history is empty,
+// this is a no-op. Used by ensureToolPairing to merge synthetic tool_results
+// into an existing user message (e.g., from inbox drain) to preserve the
+// tool_use/tool_result pairing requirement.
+func (h *History) replaceLast(m Message) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.messages) == 0 {
+		return
+	}
+	h.messages[len(h.messages)-1] = m
+}
+
 // FindSystemMsg returns the first system message index, or -1.
 func (h *History) FindSystemMsg() int {
 	h.mu.RLock()

--- a/internal/agent/toolpairing.go
+++ b/internal/agent/toolpairing.go
@@ -36,8 +36,13 @@ func synthesizeInterruptedToolResults(blocks []ContentBlock) []ContentBlock {
 //   - Orphaned assistant(tool_use) at the end of history (no following tool_result)
 //   - Multiple consecutive tool_use messages without tool_results (rare edge case)
 //
-// Synthesized tool_results use is_error=true with "[Interrupted by user]" to
-// signal clearly to the LLM that the tool did not complete.
+// IMPORTANT: If the last message is a non-tool-result user message (e.g., from
+// inbox drain), the synthetic tool_results are MERGED into that message rather
+// than appended as a new message. This preserves the Anthropic API requirement
+// that tool_use must be immediately followed by tool_result.
+//
+// Synthesized tool_results use is_error=true with "[Tool execution was interrupted]"
+// to signal clearly to the LLM that the tool did not complete.
 func (a *Agent) ensureToolPairing() {
 	msgs := a.History.Snapshot()
 	if len(msgs) == 0 {
@@ -80,5 +85,32 @@ func (a *Agent) ensureToolPairing() {
 	for _, b := range orphans {
 		results = append(results, NewToolResultBlock(b.ID, "[Tool execution was interrupted or failed to complete]", true))
 	}
-	a.History.Append(NewToolResultMessage(results))
+
+	// Check if the last message is a non-tool-result user message (e.g., from
+	// inbox drain). If so, we need to MERGE the synthetic tool_results into
+	// that message to preserve the tool_use/tool_result pairing requirement.
+	lastMsg := msgs[len(msgs)-1]
+	if lastMsg.Role == RoleUser && !hasToolResult(lastMsg) {
+		// Merge: replace the last user message with one that contains both
+		// the original content AND the synthetic tool_results.
+		// The tool_results must come FIRST to satisfy the API requirement.
+		mergedBlocks := make([]ContentBlock, 0, len(results)+1)
+		mergedBlocks = append(mergedBlocks, results...)
+
+		// Add the original content as a text block
+		if lastMsg.Content != "" {
+			mergedBlocks = append(mergedBlocks, NewTextBlock(lastMsg.Content))
+		}
+		// Add any existing blocks from the last message
+		mergedBlocks = append(mergedBlocks, lastMsg.Blocks...)
+
+		// Replace the last message in history
+		a.History.replaceLast(Message{
+			Role:   RoleUser,
+			Blocks: mergedBlocks,
+		})
+	} else {
+		// No merge needed - just append as a new user message
+		a.History.Append(NewToolResultMessage(results))
+	}
 }

--- a/internal/agent/toolpairing_test.go
+++ b/internal/agent/toolpairing_test.go
@@ -150,6 +150,52 @@ func TestEnsureToolPairing(t *testing.T) {
 			t.Errorf("last block ToolUseID = %q, want c2", last.Blocks[0].ToolUseID)
 		}
 	})
+
+	t.Run("orphaned tool_use with trailing user message gets merged", func(t *testing.T) {
+		// This is the critical bug fix: when inbox drain adds a user message
+		// after an orphaned tool_use, the synthetic tool_result must be
+		// MERGED into that user message to preserve the API's tool_use/
+		// tool_result pairing requirement.
+		a := New(&summarizeFake{}, "m")
+		a.History.Append(NewUserMessage("read it"))
+		a.History.Append(NewToolUseMessage([]ContentBlock{NewToolUseBlock("c1", "read_file", nil)}))
+		// Simulate inbox drain adding a steer message
+		a.History.Append(NewUserMessage("also handle errors"))
+		// Missing tool_result for c1!
+
+		a.ensureToolPairing()
+
+		// History should NOT grow - the last message should be REPLACED (merged)
+		if a.History.Len() != 3 {
+			t.Fatalf("history len = %d, want 3 (merged, not appended)", a.History.Len())
+		}
+		msgs := a.History.Snapshot()
+		last := msgs[2]
+		if last.Role != RoleUser {
+			t.Fatalf("last message role = %q, want user", last.Role)
+		}
+		// Should have: tool_result block + text block (merged)
+		if len(last.Blocks) != 2 {
+			t.Fatalf("last message blocks = %d, want 2 (tool_result + text)", len(last.Blocks))
+		}
+		// First block should be the synthetic tool_result
+		if last.Blocks[0].Type != "tool_result" {
+			t.Errorf("last.Blocks[0].Type = %q, want tool_result", last.Blocks[0].Type)
+		}
+		if last.Blocks[0].ToolUseID != "c1" {
+			t.Errorf("last.Blocks[0].ToolUseID = %q, want c1", last.Blocks[0].ToolUseID)
+		}
+		if !last.Blocks[0].IsError {
+			t.Error("last.Blocks[0].IsError = false, want true")
+		}
+		// Second block should be the original steer text
+		if last.Blocks[1].Type != "text" {
+			t.Errorf("last.Blocks[1].Type = %q, want text", last.Blocks[1].Type)
+		}
+		if last.Blocks[1].Text != "also handle errors" {
+			t.Errorf("last.Blocks[1].Text = %q, want %q", last.Blocks[1].Text, "also handle errors")
+		}
+	})
 }
 
 func TestFinishInterrupted_OrphanedToolUse(t *testing.T) {


### PR DESCRIPTION
## Problem

PR #261 added `ensureToolPairing()` to detect and fix orphaned `tool_use` blocks before sending to the API. However, the implementation had a critical bug:

When `inbox drain` adds a user message after an orphaned `tool_use`, `ensureToolPairing()` would **append** a new user message with synthetic `tool_result` blocks. This breaks the Anthropic API's requirement that `tool_use` must be **immediately** followed by its `tool_result`.

### Example of the Bug

```
[N-1] assistant: tool_use(grep:2)
[N]   user: "steer message" (from inbox drain)
[N+1] user: tool_result(grep:2) <- appended by ensureToolPairing
```

The API rejects this with:
```
HTTP 400 (invalid_request_error): an assistant message with 'tool_calls' 
must be followed by tool messages responding to each 'tool_call_id'.
```

## Solution

When `ensureToolPairing()` detects orphaned `tool_use` blocks **and** the last message is a non-`tool_result` user message, **merge** the synthetic `tool_result` blocks **into** that message instead of appending a new one:

```
[N-1] assistant: tool_use(grep:2)
[N]   user: [tool_result(grep:2), text("steer message")] <- merged
```

This preserves the `tool_use`/`tool_result` pairing requirement while still allowing steer messages from inbox drain to reach the model.

## Changes

- `toolpairing.go`: Detect trailing user message and merge synthetic `tool_result` blocks into it
- `history.go`: Add `replaceLast()` helper for atomic message replacement
- `toolpairing_test.go`: Add test case for merge scenario

## Testing

- All existing tests pass ✓
- New test case `orphaned_tool_use_with_trailing_user_message_gets_merged` validates the fix ✓
- Local testing with `go test -race ./internal/agent/...` ✓