### PR TITLE
feat(tui): print resume command on exit

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -99,6 +99,9 @@ func runTUI(cfg replConfig) int {
 			return 1
 		}
 	}
+	if !cfg.verbosity.quiet() {
+		fmt.Fprintf(cfg.stdout, "\nSession saved. Resume anytime with: octo chat -c %s\n", cfg.session.ShortID())
+	}
 	return 0
 }
 


### PR DESCRIPTION
After the TUI exits, print the exact `octo chat -c <short-id>` command so the user can resume the session without looking it up.