### PR TITLE
fix(provider): nest image blocks into tool_result content

### DIFF
--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -401,11 +401,25 @@ func mergeUserMessages(prev apiMessage, next agent.Message) (apiMessage, error) 
 }
 
 // marshalBlocks converts agent.ContentBlock slice to []apiContentBlock.
-// tool_result blocks are serialized with a nested "content" string field
-// per the Anthropic wire format.
+// tool_result blocks are serialized with a nested "content" field per the
+// Anthropic wire format.
+//
+// IMPORTANT: When a tool_result is followed by non-tool_result blocks (image,
+// text), those blocks are nested INTO the tool_result's content array. This
+// preserves the Anthropic API requirement that tool_use must be immediately
+// followed by tool_result with no intervening blocks. Without this nesting,
+// image blocks between two tool_result blocks would break the tool_use/
+// tool_result pairing and cause HTTP 400 errors.
+//
+// Example transformation:
+//
+//	Input:  [tool_result(id1), image, tool_result(id2), image]
+//	Output: [tool_result(id1, content:[text, image]), tool_result(id2, content:[text, image])]
 func marshalBlocks(blocks []agent.ContentBlock) ([]map[string]any, error) {
 	out := make([]map[string]any, 0, len(blocks))
-	for _, b := range blocks {
+	i := 0
+	for i < len(blocks) {
+		b := blocks[i]
 		switch b.Type {
 		case "text":
 			out = append(out, map[string]any{
@@ -429,17 +443,61 @@ func marshalBlocks(blocks []agent.ContentBlock) ([]map[string]any, error) {
 			}
 			out = append(out, m)
 		case "tool_result":
+			// Collect following non-tool_result blocks to nest inside this
+			// tool_result's content. This ensures image blocks from read_file
+			// (or any tool returning images) are properly associated with
+			// their tool_result rather than appearing as sibling blocks.
+			var nestedContent []map[string]any
+			if b.Result != "" {
+				nestedContent = append(nestedContent, map[string]any{
+					"type": "text",
+					"text": b.Result,
+				})
+			}
+			j := i + 1
+			for j < len(blocks) && blocks[j].Type != "tool_result" && blocks[j].Type != "tool_use" {
+				switch blocks[j].Type {
+				case "image":
+					if blocks[j].Image == nil {
+						return nil, fmt.Errorf("anthropic: image block missing Image data")
+					}
+					nestedContent = append(nestedContent, map[string]any{
+						"type": "image",
+						"source": map[string]any{
+							"type":       "base64",
+							"media_type": blocks[j].Image.MIMEType,
+							"data":       encodeBase64(blocks[j].Image.Data),
+						},
+					})
+				case "text":
+					nestedContent = append(nestedContent, map[string]any{
+						"type": "text",
+						"text": blocks[j].Text,
+					})
+				}
+				j++
+			}
+
 			m := map[string]any{
 				"type":        "tool_result",
 				"tool_use_id": b.ToolUseID,
-				"content":     b.Result,
+			}
+			// Use content array when there are nested blocks (images), otherwise
+			// use plain string for simpler tool results.
+			if len(nestedContent) == 1 && nestedContent[0]["type"] == "text" {
+				m["content"] = b.Result
+			} else if len(nestedContent) > 0 {
+				m["content"] = nestedContent
+			} else {
+				m["content"] = b.Result
 			}
 			if b.IsError {
 				m["is_error"] = true
 			}
 			out = append(out, m)
+			i = j - 1 // advance past consumed blocks (-1 because loop does i++)
 		case "image":
-			// Anthropic image block: base64-encoded data with source type.
+			// Standalone image block (not following a tool_result).
 			if b.Image == nil {
 				return nil, fmt.Errorf("anthropic: image block missing Image data")
 			}
@@ -454,6 +512,7 @@ func marshalBlocks(blocks []agent.ContentBlock) ([]map[string]any, error) {
 		default:
 			return nil, fmt.Errorf("anthropic: unknown block type %q", b.Type)
 		}
+		i++
 	}
 	return out, nil
 }

--- a/internal/provider/anthropic/tools_test.go
+++ b/internal/provider/anthropic/tools_test.go
@@ -213,8 +213,9 @@ func TestSend_ToolResultMessage(t *testing.T) {
 }
 
 // TestSend_ToolResultWithSteerText verifies a user/tool_result message that
-// also carries a steer text block (design §5) serializes as a multi-block user
-// message [{tool_result}, {text}] — the API-blessed mid-turn-steer shape.
+// also carries a steer text block (design §5) serializes the steer text
+// nested inside the tool_result's content array — preserving the tool_use/
+// tool_result pairing required by the Anthropic API.
 func TestSend_ToolResultWithSteerText(t *testing.T) {
 	var capturedBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -258,14 +259,28 @@ func TestSend_ToolResultWithSteerText(t *testing.T) {
 	if err := json.Unmarshal(wireReq.Messages[2].Content, &userContent); err != nil {
 		t.Fatalf("decode user content: %v", err)
 	}
-	if len(userContent) != 2 {
-		t.Fatalf("user content blocks = %d, want 2 (tool_result + text): %v", len(userContent), userContent)
+	// Should be 1 block: tool_result with nested content array [text, text]
+	if len(userContent) != 1 {
+		t.Fatalf("user content blocks = %d, want 1 (tool_result with nested content): %v", len(userContent), userContent)
 	}
 	if userContent[0]["type"] != "tool_result" {
 		t.Errorf("blocks[0].type = %v, want tool_result", userContent[0]["type"])
 	}
-	if userContent[1]["type"] != "text" || userContent[1]["text"] != "also handle the error case" {
-		t.Errorf("blocks[1] = %v, want text steer", userContent[1])
+	// Verify nested content array
+	nestedContent, ok := userContent[0]["content"].([]any)
+	if !ok {
+		t.Fatalf("tool_result.content is not an array: %v", userContent[0]["content"])
+	}
+	if len(nestedContent) != 2 {
+		t.Fatalf("nested content len = %d, want 2: %v", len(nestedContent), nestedContent)
+	}
+	first, _ := nestedContent[0].(map[string]any)
+	second, _ := nestedContent[1].(map[string]any)
+	if first["type"] != "text" || first["text"] != "hi" {
+		t.Errorf("nested[0] = %v, want text/hi", first)
+	}
+	if second["type"] != "text" || second["text"] != "also handle the error case" {
+		t.Errorf("nested[1] = %v, want text steer", second)
 	}
 }
 
@@ -386,8 +401,9 @@ func TestSend_MergesConsecutivePlainUserMessages(t *testing.T) {
 	}
 }
 
-// TestSend_ImageBlock_WireFormat verifies that an image content block is
-// serialized as an Anthropic image source block with base64 data.
+// TestSend_ImageBlock_WireFormat verifies that an image content block
+// following a tool_result is nested inside the tool_result's content array,
+// preserving the tool_use/tool_result pairing required by the Anthropic API.
 func TestSend_ImageBlock_WireFormat(t *testing.T) {
 	var capturedBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -425,7 +441,7 @@ func TestSend_ImageBlock_WireFormat(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 
-	// user, assistant(tool_use), user(tool_result + image)
+	// user, assistant(tool_use), user(tool_result with nested [text, image])
 	if len(wireReq.Messages) != 3 {
 		t.Fatalf("messages len = %d, want 3: %s", len(wireReq.Messages), capturedBody)
 	}
@@ -434,16 +450,30 @@ func TestSend_ImageBlock_WireFormat(t *testing.T) {
 	if err := json.Unmarshal(wireReq.Messages[2].Content, &userContent); err != nil {
 		t.Fatalf("decode user content: %v", err)
 	}
-	if len(userContent) != 2 {
-		t.Fatalf("user content blocks = %d, want 2 (tool_result + image): %v", len(userContent), userContent)
+	// Should be 1 block: tool_result with nested content array [text, image]
+	if len(userContent) != 1 {
+		t.Fatalf("user content blocks = %d, want 1 (tool_result with nested content): %v", len(userContent), userContent)
 	}
 	if userContent[0]["type"] != "tool_result" {
 		t.Errorf("blocks[0].type = %v, want tool_result", userContent[0]["type"])
 	}
-	if userContent[1]["type"] != "image" {
-		t.Errorf("blocks[1].type = %v, want image", userContent[1]["type"])
+	// Verify nested content array
+	nestedContent, ok := userContent[0]["content"].([]any)
+	if !ok {
+		t.Fatalf("tool_result.content is not an array: %v", userContent[0]["content"])
 	}
-	src, ok := userContent[1]["source"].(map[string]any)
+	if len(nestedContent) != 2 {
+		t.Fatalf("nested content len = %d, want 2 (text + image): %v", len(nestedContent), nestedContent)
+	}
+	textPart, _ := nestedContent[0].(map[string]any)
+	imagePart, _ := nestedContent[1].(map[string]any)
+	if textPart["type"] != "text" {
+		t.Errorf("nested[0].type = %v, want text", textPart["type"])
+	}
+	if imagePart["type"] != "image" {
+		t.Errorf("nested[1].type = %v, want image", imagePart["type"])
+	}
+	src, ok := imagePart["source"].(map[string]any)
 	if !ok {
 		t.Fatalf("image source missing or wrong type")
 	}

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -293,47 +293,67 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 		// role="user" message AFTER the tool outputs, which is the OpenAI-shaped
 		// equivalent of Anthropic's [tool_result…, text] user message.
 		//
-		// Image blocks are folded into the user message as content parts (OpenAI
-		// vision format: [{type:"text",text:"..."},{type:"image_url",image_url:{url:"data:..."}}]).
+		// Image blocks following a tool_result are nested INTO that tool message's
+		// content array (OpenAI vision format). This preserves the tool_result/
+		// image association required by the API — without nesting, images between
+		// two tool_results would break the tool_call_id pairing.
 		if m.Role == agent.RoleUser && len(m.Blocks) > 0 {
 			var steerText strings.Builder
-			var contentParts []apiContentPart
-			for _, b := range m.Blocks {
+			i := 0
+			for i < len(m.Blocks) {
+				b := m.Blocks[i]
 				switch b.Type {
 				case "tool_result":
-					out = append(out, apiMessage{
-						Role:       "tool",
-						Content:    b.Result,
-						ToolCallID: b.ToolUseID,
-					})
+					// Collect following image blocks to nest inside this tool
+					// message's content. Text blocks are NOT nested — they become
+					// separate steer user messages after all tool outputs.
+					var imageParts []apiContentPart
+					j := i + 1
+					for j < len(m.Blocks) && m.Blocks[j].Type == "image" {
+						if m.Blocks[j].Image != nil {
+							dataURL := fmt.Sprintf("data:%s;base64,%s", m.Blocks[j].Image.MIMEType, base64.StdEncoding.EncodeToString(m.Blocks[j].Image.Data))
+							imageParts = append(imageParts, apiContentPart{
+								Type: "image_url",
+								ImageURL: &struct {
+									URL string `json:"url"`
+								}{URL: dataURL},
+							})
+						}
+						j++
+					}
+					msg := apiMessage{Role: "tool", ToolCallID: b.ToolUseID}
+					if len(imageParts) > 0 {
+						// Nest text + images into content array for vision support.
+						parts := make([]apiContentPart, 0, 1+len(imageParts))
+						if b.Result != "" {
+							parts = append(parts, apiContentPart{Type: "text", Text: b.Result})
+						}
+						parts = append(parts, imageParts...)
+						msg.ContentParts = parts
+					} else {
+						msg.Content = b.Result
+					}
+					out = append(out, msg)
+					i = j
 				case "text":
 					if steerText.Len() > 0 {
 						steerText.WriteString("\n\n")
 					}
 					steerText.WriteString(b.Text)
+					i++
 				case "image":
-					if b.Image != nil {
-						dataURL := fmt.Sprintf("data:%s;base64,%s", b.Image.MIMEType, base64.StdEncoding.EncodeToString(b.Image.Data))
-						contentParts = append(contentParts, apiContentPart{
-							Type: "image_url",
-							ImageURL: &struct {
-								URL string `json:"url"`
-							}{URL: dataURL},
-						})
+					// Standalone image (not following a tool_result) — add to steer.
+					if steerText.Len() > 0 {
+						steerText.WriteString("\n\n")
 					}
+					steerText.WriteString("[image]")
+					i++
+				default:
+					i++
 				}
 			}
 			if steerText.Len() > 0 {
-				contentParts = append([]apiContentPart{{Type: "text", Text: steerText.String()}}, contentParts...)
-			}
-			if len(contentParts) > 0 {
-				// Use array format only when images are present; otherwise stick to
-				// plain string content for compatibility with tests and simpler wire.
-				if len(contentParts) == 1 && contentParts[0].Type == "text" {
-					out = append(out, apiMessage{Role: "user", Content: contentParts[0].Text})
-				} else {
-					out = append(out, apiMessage{Role: "user", ContentParts: contentParts})
-				}
+				out = append(out, apiMessage{Role: "user", Content: steerText.String()})
 			}
 			continue
 		}

--- a/internal/provider/openai/tools_test.go
+++ b/internal/provider/openai/tools_test.go
@@ -374,31 +374,31 @@ func TestSend_ImageBlock_WireFormat(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 
-	// user, assistant(tool_call), tool(result), user(image)
-	if len(wireReq.Messages) != 4 {
-		t.Fatalf("messages len = %d, want 4: %s", len(wireReq.Messages), capturedBody)
+	// user, assistant(tool_call), tool(result with nested [text, image_url])
+	if len(wireReq.Messages) != 3 {
+		t.Fatalf("messages len = %d, want 3: %s", len(wireReq.Messages), capturedBody)
 	}
-	// msg[2] = tool result
+	// msg[2] = tool result with nested content array
 	if wireReq.Messages[2].Role != "tool" || wireReq.Messages[2].ToolCallID != "call-1" {
 		t.Errorf("msg[2] = %+v, want tool/call-1", wireReq.Messages[2])
 	}
-	// msg[3] = user message carrying the image block
-	if wireReq.Messages[3].Role != "user" {
-		t.Errorf("msg[3].role = %q, want user", wireReq.Messages[3].Role)
-	}
-	// Content should be an array with an image_url part.
-	parts, ok := wireReq.Messages[3].Content.([]any)
+	// Content should be an array with text + image_url parts.
+	parts, ok := wireReq.Messages[2].Content.([]any)
 	if !ok {
-		t.Fatalf("msg[3].content = %T, want []any", wireReq.Messages[3].Content)
+		t.Fatalf("msg[2].content = %T, want []any (nested content array)", wireReq.Messages[2].Content)
 	}
-	if len(parts) != 1 {
-		t.Fatalf("content parts len = %d, want 1", len(parts))
+	if len(parts) != 2 {
+		t.Fatalf("content parts len = %d, want 2 (text + image_url)", len(parts))
 	}
-	first, _ := parts[0].(map[string]any)
-	if first["type"] != "image_url" {
-		t.Errorf("parts[0].type = %v, want image_url", first["type"])
+	textPart, _ := parts[0].(map[string]any)
+	if textPart["type"] != "text" {
+		t.Errorf("parts[0].type = %v, want text", textPart["type"])
 	}
-	imgURL, _ := first["image_url"].(map[string]any)
+	imgPart, _ := parts[1].(map[string]any)
+	if imgPart["type"] != "image_url" {
+		t.Errorf("parts[1].type = %v, want image_url", imgPart["type"])
+	}
+	imgURL, _ := imgPart["image_url"].(map[string]any)
 	url, _ := imgURL["url"].(string)
 	if !strings.HasPrefix(url, "data:image/png;base64,") {
 		t.Errorf("image_url.url prefix wrong: %q", url)


### PR DESCRIPTION
## Problem

When `read_file` returns a `tool_result` with an image block (e.g., reading a .png file), the image was emitted as a **sibling block** alongside the `tool_result` in the user message. This breaks the API's `tool_use`/`tool_result` pairing requirement.

### Reproduction (from session 50d3b761)

Input: 2 images sent as user message, LLM called read_file on both.

The tool_result blocks had image blocks as siblings:
- [tool_result(1), image, tool_result(2), image]

This breaks pairing, causing HTTP 400:
"tool_call_ids did not have response messages: read_file:1"

## Root Cause

`toolResultBlocks()` in agent.go appends image blocks as siblings of the tool_result block. The adapters then serialize them as separate blocks in the user message, breaking the strict tool_use -> tool_result pairing.

## Fix

Nest image blocks INTO the preceding tool_result's content array at the adapter level.

### Anthropic adapter
- marshalBlocks(): index-based iteration; when tool_result is followed by image/text blocks, nest them into tool_result.content as an array
- Plain string content preserved when no images follow

### OpenAI adapter
- toAPIMessages(): index-based iteration for user messages with blocks; when tool_result is followed by image blocks, nest them into the role="tool" message's content array
- Text blocks remain as separate steer user messages (unchanged)

## Testing

- Updated tests for both adapters to verify nested content format
- All internal/provider/anthropic tests pass
- All internal/provider/openai tests pass
- All internal/agent tests pass
