### PR TITLE
fix(tui): textarea initial height collapse on first keystroke

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -303,7 +303,9 @@ func newTUIModel(cfg replConfig) *tuiModel {
 	if !tui.IsDark() {
 		style = "light"
 	}
-	return &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}}
+	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}}
+	m.updateTextAreaHeight()
+	return m
 }
 
 func (m *tuiModel) Init() tea.Cmd {
@@ -358,7 +360,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.ta.SetWidth(msg.Width - 4) // account for border + padding
-		m.ta.SetHeight(min(6, msg.Height/4))
+		m.updateTextAreaHeight()
 		return m, m.flushPrints()
 
 	case tea.KeyMsg:


### PR DESCRIPTION
Fixes the input box starting tall (placeholder wrapped across multiple lines) then suddenly collapsing to one line after the first keystroke.

**Root cause:** WindowSizeMsg set textarea height to , but an empty textarea renders its placeholder wrapped across multiple visual lines. When the first character was typed,  recalculated the height to 1 line, causing the visible collapse.

**Fix:** Always use  so the empty-state height is 1 line, consistent with the post-keystroke height. Also call it during model initialization.