### PR TITLE
fix(tui): liveHeight under-counted textarea rows

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -389,7 +389,7 @@ func (m *tuiModel) liveHeight() int {
 	if bg := tools.RunningBackground(); len(bg) > 0 {
 		h += 3 + len(bg) // panel border (2) + title (1) + body lines
 	}
-	h++ // input box
+	h += m.ta.Height() // input box (textarea grows with content)
 	if m.turnRunning {
 		h += 3 // status bar with hint: separator + segments + hint
 	} else {


### PR DESCRIPTION
liveHeight() hard-coded the input box as 1 line, but textarea grows with content up to 6 lines. This caused bubbletea to under-reserve vertical space, pushing earlier input lines above the visible area when typing multi-line input.

Fix: use m.ta.Height() so liveHeight tracks the actual textarea size.