### PR TITLE
fix(tui): textarea first line scrolls out of view on newline

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -304,7 +304,7 @@ func newTUIModel(cfg replConfig) *tuiModel {
 		style = "light"
 	}
 	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}}
-	m.updateTextAreaHeight()
+	_ = m.updateTextAreaHeight()
 	return m
 }
 
@@ -360,7 +360,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.ta.SetWidth(msg.Width - 4) // account for border + padding
-		m.updateTextAreaHeight()
+		_ = m.updateTextAreaHeight()
 		return m, m.flushPrints()
 
 	case tea.KeyMsg:

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -61,15 +61,16 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Idle: clear the input line.
 		m.ta.Reset()
 		m.inputHistoryIdx = -1
-		m.updateTextAreaHeight()
-		return m, nil
+		return m, m.updateTextAreaHeight()
 
 	case tea.KeyCtrlJ:
 		// Ctrl+J inserts a newline (LF) into the textarea. Works on all
 		// terminals, including those where Alt+Enter is not mapped.
 		var cmd tea.Cmd
 		m.ta, cmd = m.ta.Update(tea.KeyMsg{Type: tea.KeyEnter})
-		m.updateTextAreaHeight()
+		if hcmd := m.updateTextAreaHeight(); hcmd != nil {
+			cmd = tea.Batch(cmd, hcmd)
+		}
 		return m, cmd
 
 	case tea.KeyCtrlQ:
@@ -120,7 +121,9 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// Alt+Enter inserts a newline into the textarea.
 			var cmd tea.Cmd
 			m.ta, cmd = m.ta.Update(tea.KeyMsg{Type: tea.KeyEnter})
-			m.updateTextAreaHeight()
+			if hcmd := m.updateTextAreaHeight(); hcmd != nil {
+				cmd = tea.Batch(cmd, hcmd)
+			}
 			return m, cmd
 		}
 		return m.submit()
@@ -130,7 +133,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.inputHistoryIdx++
 			m.ta.SetValue(m.inputHistory[len(m.inputHistory)-1-m.inputHistoryIdx])
 			m.ta.CursorEnd()
-			m.updateTextAreaHeight()
+			return m, m.updateTextAreaHeight()
 		}
 		return m, nil
 
@@ -139,11 +142,11 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.inputHistoryIdx--
 			m.ta.SetValue(m.inputHistory[len(m.inputHistory)-1-m.inputHistoryIdx])
 			m.ta.CursorEnd()
-			m.updateTextAreaHeight()
+			return m, m.updateTextAreaHeight()
 		} else if m.inputHistoryIdx == 0 {
 			m.inputHistoryIdx = -1
 			m.ta.Reset()
-			m.updateTextAreaHeight()
+			return m, m.updateTextAreaHeight()
 		}
 		return m, nil
 	}
@@ -152,7 +155,9 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// is handled by bubbles/textarea.
 	var cmd tea.Cmd
 	m.ta, cmd = m.ta.Update(msg)
-	m.updateTextAreaHeight()
+	if hcmd := m.updateTextAreaHeight(); hcmd != nil {
+		cmd = tea.Batch(cmd, hcmd)
+	}
 	return m, cmd
 }
 
@@ -470,13 +475,24 @@ func (m *tuiModel) View() string {
 
 // updateTextAreaHeight sets the textarea height to match the number of lines
 // in the current value, capped at a maximum so it doesn't take over the screen.
-func (m *tuiModel) updateTextAreaHeight() {
+// When the height changes it sends a no-op key to the textarea so that its
+// internal repositionView runs with the new height, preventing the viewport
+// from scrolling past content that is still visible.
+func (m *tuiModel) updateTextAreaHeight() tea.Cmd {
 	lines := strings.Count(m.ta.Value(), "\n") + 1
 	maxH := min(6, m.height/4)
 	if maxH < 1 {
 		maxH = 1
 	}
-	m.ta.SetHeight(min(lines, maxH))
+	newH := min(lines, maxH)
+	if m.ta.Height() == newH {
+		return nil
+	}
+	m.ta.SetHeight(newH)
+	// Trigger repositionView with the updated height by sending a harmless key.
+	var cmd tea.Cmd
+	m.ta, cmd = m.ta.Update(tea.KeyMsg{Type: tea.KeyHome})
+	return cmd
 }
 
 func (m *tuiModel) renderInputBox() string {


### PR DESCRIPTION
When a newline was inserted, textarea.Update ran repositionView with the old height (1). Since the cursor moved to line 2, repositionView scrolled the viewport down (YOffset=1) to keep the cursor visible. Only then did updateTextAreaHeight set the height to 2, but YOffset stayed at 1, pushing the first line above the visible area.

Fix: updateTextAreaHeight now returns a tea.Cmd. When the height changes, it sends a no-op key (KeyHome) to the textarea so repositionView re-runs with the new height, resetting YOffset to 0 and keeping all lines visible.