### PR TITLE
fix(tui): print drained steer messages to scrollback

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -650,8 +650,15 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 	m.turnRunning = false
 	m.cancelTurn = nil
 	m.streaming = false
-	m.running = nil      // clear any live tool indicator (e.g. on interrupt)
-	m.pendingSteer = nil // clear pending steer display (drained or degraded)
+	m.running = nil // clear any live tool indicator (e.g. on interrupt)
+
+	// Steer messages that were drained into history during the turn should
+	// appear in the scrollback like regular user messages. Print them before
+	// clearing the pending display.
+	for _, s := range m.pendingSteer {
+		m.println(userEchoStyle.Render("> ") + s)
+	}
+	m.pendingSteer = nil
 
 	// Auto-save (history is well-formed even after an interrupt).
 	if !m.cfg.noSave {

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -457,8 +457,9 @@ func (m *tuiModel) View() string {
 
 	// Pending steer — show what the user typed mid-turn, indented right above
 	// the input box (Claude Code style: input上方，比普通消息多了一个indent).
-	// Does not enter the scrollback until drained via EventSteerInjected,
-	// preserving chronological order with tool_result.
+	// Once the agent loop drains the inbox these messages are printed to the
+	// scrollback in handleTurnFinished so they appear in the transcript like
+	// regular user messages.
 	if len(m.pendingSteer) > 0 {
 		for _, s := range m.pendingSteer {
 			b.WriteString(pendingSteerStyle.Render("  > ") + pendingSteerStyle.Render(s))


### PR DESCRIPTION
Steer messages typed mid-turn were shown live in the View() area but vanished from the UI once the agent loop drained them into history. This PR prints them to the scrollback like regular user messages before clearing the pending display.

**Changes:**
- : print  messages to scrollback before clearing
- Updated View() comment to remove stale reference to non-existent 