### PR TITLE
fix(tui): use textarea built-in prompt for aligned multi-line input

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // runTUI is the interactive bubbletea REPL: the TTY counterpart to runREPL's
@@ -294,7 +295,9 @@ func newTUIModel(cfg replConfig) *tuiModel {
 	ta.Placeholder = "Ask anything…"
 	ta.Focus()
 	ta.ShowLineNumbers = false
-	ta.Prompt = ""
+	ta.Prompt = "> "
+	ta.FocusedStyle.Prompt = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	ta.BlurredStyle.Prompt = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
 	// Disable up/down line navigation so we can use them for input-history
 	// recall instead.
 	ta.KeyMap.LineNext = key.Binding{}
@@ -359,7 +362,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		m.ta.SetWidth(msg.Width - 4) // account for border + padding
+		m.ta.SetWidth(msg.Width)
 		_ = m.updateTextAreaHeight()
 		return m, m.flushPrints()
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -497,7 +497,7 @@ func (m *tuiModel) updateTextAreaHeight() tea.Cmd {
 }
 
 func (m *tuiModel) renderInputBox() string {
-	return promptStyle.Render("> ") + m.ta.View()
+	return m.ta.View()
 }
 
 // renderStatusBar renders the cwd / context% / permission / elapsed segments,


### PR DESCRIPTION
Previously we cleared ta.Prompt and manually prepended > in renderInputBox(). This caused two problems:

1. Only the first line had the > prefix; subsequent lines were not indented, so multi-line input was misaligned.
2. textarea wrapped text based on a width that ignored the external prompt, causing inconsistent line breaks.

Fix: set ta.Prompt = > so textarea renders the prompt on the first line and pads subsequent lines with matching whitespace. Also apply brand color/bold to FocusedStyle.Prompt and BlurredStyle.Prompt. renderInputBox() now simply returns ta.View().