### PR TITLE
fix(tui): emit EventSteerInjected for chronological steer display

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -549,6 +549,23 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 		}
 		m.commitToolLine(toolErrStyle.Render(fmt.Sprintf("↳ %s ✗ — %s", ev.ToolName, truncate1Line(ev.Err))))
 		return
+
+	case agent.EventSteerInjected:
+		// Inbox drained mid-turn: print the steer messages to the scrollback
+		// immediately so they appear in chronological order (before the next
+		// assistant reply), and remove them from the pending live display.
+		for _, s := range ev.Messages {
+			m.println(userEchoStyle.Render("> ") + s)
+		}
+		// pendingSteer is FIFO and mirrors the inbox, so the drained messages
+		// are always a prefix.
+		n := len(ev.Messages)
+		if n >= len(m.pendingSteer) {
+			m.pendingSteer = nil
+		} else {
+			m.pendingSteer = m.pendingSteer[n:]
+		}
+		return
 	}
 }
 
@@ -652,9 +669,9 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 	m.streaming = false
 	m.running = nil // clear any live tool indicator (e.g. on interrupt)
 
-	// Steer messages that were drained into history during the turn should
-	// appear in the scrollback like regular user messages. Print them before
-	// clearing the pending display.
+	// Any steer messages that weren't drained via EventSteerInjected during
+	// the turn (e.g. typed after the last loop iteration) are printed now so
+	// they don't vanish from the transcript.
 	for _, s := range m.pendingSteer {
 		m.println(userEchoStyle.Render("> ") + s)
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -422,8 +422,13 @@ func (a *Agent) runLoop(
 		// Drain inbox messages that arrived since the last iteration.
 		// Done before the LLM call so the model sees mid-turn user input
 		// as a first-class message boundary, not folded into tool output.
-		for _, m := range a.Inbox.Drain() {
-			a.History.Append(NewUserMessage(m))
+		if steerMsgs := a.Inbox.Drain(); len(steerMsgs) > 0 {
+			for _, m := range steerMsgs {
+				a.History.Append(NewUserMessage(m))
+			}
+			if handler != nil {
+				handler(AgentEvent{Kind: EventSteerInjected, Messages: steerMsgs})
+			}
 		}
 
 		// Defensive check: ensure every tool_use block has a matching tool_result.

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -50,6 +50,13 @@ const (
 	// after the assistant's final reply is committed to history. Reply
 	// carries the aggregated final Reply.
 	EventTurnDone EventKind = "turn_done"
+
+	// EventSteerInjected fires when the agent loop drains the inbox and
+	// injects mid-turn user messages into history. Messages carries the
+	// drained texts so observers (e.g. the TUI) can render them in the
+	// transcript at the correct chronological position — before the next
+	// assistant reply, not after the turn ends.
+	EventSteerInjected EventKind = "steer_injected"
 )
 
 // EventToolOutputCap is the maximum length of the Output field emitted on
@@ -71,6 +78,7 @@ const EventToolOutputCap = 512
 //   - EventToolDone:       ToolID, ToolName, Output
 //   - EventToolError:      ToolID, ToolName, Output (may be empty), Err
 //   - EventTurnDone:       Reply
+//   - EventSteerInjected:  Messages
 //
 // JSON tags are included so HTTP/SSE transports (M8 web server) can
 // marshal events directly without an intermediate type.
@@ -85,6 +93,7 @@ type AgentEvent struct {
 	Output     string         `json:"output,omitempty"`
 	Err        string         `json:"err,omitempty"`
 	Reply      *Reply         `json:"reply,omitempty"`
+	Messages   []string       `json:"messages,omitempty"`
 }
 
 // EventHandler is the callback type passed into Agent.RunStream. The handler


### PR DESCRIPTION
When multiple steer messages were typed mid-turn, they were printed to scrollback only after the turn finished, making them appear after the assistant's final reply instead of before it.

This PR adds EventSteerInjected which fires when the agent loop drains the inbox and injects mid-turn user messages into history. The TUI handles this event by printing steer messages to scrollback immediately, preserving chronological order.