### PR TITLE
fix(tui): only first line shows > prompt, reset viewport on height change

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -295,7 +295,14 @@ func newTUIModel(cfg replConfig) *tuiModel {
 	ta.Placeholder = "Ask anything…"
 	ta.Focus()
 	ta.ShowLineNumbers = false
-	ta.Prompt = "> "
+	// Only the first line shows "> "; subsequent lines are padded with spaces
+	// so text aligns (Claude Code style).
+	ta.SetPromptFunc(2, func(lineIdx int) string {
+		if lineIdx == 0 {
+			return "> "
+		}
+		return "  "
+	})
 	ta.FocusedStyle.Prompt = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
 	ta.BlurredStyle.Prompt = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
 	// Disable up/down line navigation so we can use them for input-history

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/permission"
@@ -476,9 +478,8 @@ func (m *tuiModel) View() string {
 
 // updateTextAreaHeight sets the textarea height to match the number of lines
 // in the current value, capped at a maximum so it doesn't take over the screen.
-// When the height changes it sends a no-op key to the textarea so that its
-// internal repositionView runs with the new height, preventing the viewport
-// from scrolling past content that is still visible.
+// When the height grows we also reset the viewport YOffset to 0 via reflection
+// so that earlier lines remain visible instead of being scrolled out of view.
 func (m *tuiModel) updateTextAreaHeight() tea.Cmd {
 	lines := strings.Count(m.ta.Value(), "\n") + 1
 	maxH := min(6, m.height/4)
@@ -490,10 +491,16 @@ func (m *tuiModel) updateTextAreaHeight() tea.Cmd {
 		return nil
 	}
 	m.ta.SetHeight(newH)
-	// Trigger repositionView with the updated height by sending a harmless key.
-	var cmd tea.Cmd
-	m.ta, cmd = m.ta.Update(tea.KeyMsg{Type: tea.KeyHome})
-	return cmd
+	// textarea.viewport is unexported; use unsafe to reset YOffset.
+	v := reflect.ValueOf(&m.ta).Elem().FieldByName("viewport")
+	if !v.IsValid() || v.IsNil() {
+		return nil
+	}
+	vp := reflect.NewAt(v.Elem().Type(), unsafe.Pointer(v.Elem().UnsafeAddr())).Elem()
+	if yOffset := vp.FieldByName("YOffset"); yOffset.IsValid() {
+		yOffset.SetInt(0)
+	}
+	return nil
 }
 
 func (m *tuiModel) renderInputBox() string {


### PR DESCRIPTION
The previous fix gave every line a > prefix, which does not match Claude Code's style where only the first line has > and subsequent lines are space-padded for alignment.

Changes:
- Use SetPromptFunc so line 0 renders > and all other lines render two spaces, keeping text aligned.
- Replace the KeyHome no-op trick with direct unsafe reflection to reset viewport.YOffset to 0 when SetHeight changes the textarea height. This prevents the first line from scrolling out of view when the input box grows.