### PR TITLE
tools/web_fetch: 5s jina timeout + fallback on context deadline exceeded

### DIFF
--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -67,12 +67,12 @@ func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any)
 		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: only http/https URLs are allowed (got %q)", u.Scheme)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
 	// Strategy: try Jina Reader proxy first (better quality), then fall back
 	// to a direct fetch on network-level or 5xx/429 proxy failures.
-	out, jinaErr := fetchViaJina(ctx, raw)
+	// Jina gets a short 5s timeout so a slow proxy doesn't block the fallback.
+	jinaCtx, jinaCancel := context.WithTimeout(ctx, 5*time.Second)
+	out, jinaErr := fetchViaJina(jinaCtx, raw)
+	jinaCancel()
 	if jinaErr == nil {
 		return out, nil
 	}
@@ -81,7 +81,10 @@ func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any)
 	// errors, or 429 rate-limit. 4xx client errors (e.g. 404) from the proxy
 	// are NOT retried — the proxy correctly reflected an upstream 404.
 	if shouldFallback(jinaErr) {
-		out, directErr := fetchDirect(ctx, raw)
+		// Give the direct fetch the remaining time up to 30s total.
+		directCtx, directCancel := context.WithTimeout(ctx, 30*time.Second)
+		out, directErr := fetchDirect(directCtx, raw)
+		directCancel()
 		if directErr == nil {
 			return out, nil
 		}
@@ -108,6 +111,7 @@ func shouldFallback(err error) bool {
 		strings.Contains(s, "timeout") ||
 		strings.Contains(s, "temporary failure") ||
 		strings.Contains(s, "i/o timeout") ||
+		strings.Contains(s, "context deadline exceeded") ||
 		strings.Contains(s, "EOF") {
 		return true
 	}

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // withJinaHost swaps JinaReaderHost for the test server URL. Since
@@ -306,6 +307,38 @@ func TestWebFetch_FallsBackOnHTTP429(t *testing.T) {
 		t.Fatalf("expected fallback to succeed, got: %v", err)
 	}
 	if !strings.Contains(out.Text, "direct after rate limit") {
+		t.Errorf("expected direct content, got: %q", out.Text)
+	}
+}
+
+func TestWebFetch_FallsBackOnContextDeadlineExceeded(t *testing.T) {
+	// Jina proxy that sleeps longer than the 5s jina timeout but less than
+	// the total budget, so the fallback has time to succeed.
+	jina := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(6 * time.Second)
+	}))
+	defer jina.Close()
+
+	direct := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("direct after deadline"))
+	}))
+	defer direct.Close()
+
+	old := jinaReaderHostForTest
+	jinaReaderHostForTest = jina.URL + "/"
+	defer func() { jinaReaderHostForTest = old }()
+
+	// Total budget 10s — jina gets 5s, direct gets up to 30s (capped by this 10s).
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	out, err := WebFetchTool{}.Execute(ctx, "web_fetch", map[string]any{
+		"url": direct.URL + "/page",
+	})
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got: %v", err)
+	}
+	if !strings.Contains(out.Text, "direct after deadline") {
 		t.Errorf("expected direct content, got: %q", out.Text)
 	}
 }


### PR DESCRIPTION
- Jina proxy now gets a 5s timeout instead of 30s, so a slow/unresponsive proxy quickly falls back to direct fetch.
- Direct fetch gets its own 30s timeout (from the original parent context).
- Add "context deadline exceeded" to shouldFallback so proxy timeouts trigger the fallback path.
- Add test for context-deadline fallback scenario.

Fixes #174 (follow-up)