### PR TITLE
fix(tui): restore draft text when Down returns from history browsing

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -213,6 +213,9 @@ type tuiModel struct {
 	// inputHistory stores submitted lines for ↑/↓ recall.
 	inputHistory    []string
 	inputHistoryIdx int // -1 = not browsing, 0..len-1 = browsing
+	// inputDraft holds the text that was in the input box before the user
+	// started browsing history with ↑, so ↓ can restore it.
+	inputDraft string
 
 	// turnRunning is true between starting a turn and turnFinishedMsg.
 	turnRunning bool

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -138,6 +138,9 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if m.inputHistoryIdx+1 < len(m.inputHistory) {
+			if m.inputHistoryIdx == -1 {
+				m.inputDraft = m.ta.Value()
+			}
 			m.inputHistoryIdx++
 			m.ta.SetValue(m.inputHistory[len(m.inputHistory)-1-m.inputHistoryIdx])
 			m.ta.CursorEnd()
@@ -161,7 +164,9 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.updateTextAreaHeight()
 		} else if m.inputHistoryIdx == 0 {
 			m.inputHistoryIdx = -1
-			m.ta.Reset()
+			m.ta.SetValue(m.inputDraft)
+			m.inputDraft = ""
+			m.ta.CursorEnd()
 			return m, m.updateTextAreaHeight()
 		}
 		return m, nil


### PR DESCRIPTION
When the user pressed Up to browse input history, the multi-line text in the input box was lost. Pressing Down to return to the present would only show an empty input (Reset).

Fix: save the current textarea value into inputDraft before switching to history. When Down reaches the end of history (idx == 0), restore inputDraft instead of resetting.