### PR TITLE
tools: web_fetch/web_search respect sandbox network policy

### DIFF
--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -18,6 +18,15 @@ var activeSandbox *sandbox.Policy
 // Pass nil to disable. cmd/octo calls this when --sandbox is requested.
 func SetSandbox(p *sandbox.Policy) { activeSandbox = p }
 
+// NetworkAllowed reports whether the active sandbox policy permits network
+// access. When no sandbox is active (nil policy) network is allowed.
+func NetworkAllowed() bool {
+	if activeSandbox == nil {
+		return true
+	}
+	return activeSandbox.AllowNetwork
+}
+
 // shellCommand builds the *exec.Cmd that runs `command` via the shell, wrapped
 // in the active sandbox when one is set. Both TerminalTool and the background
 // manager route through here so confinement is uniform.

--- a/internal/tools/sandbox_network_test.go
+++ b/internal/tools/sandbox_network_test.go
@@ -1,0 +1,93 @@
+//go:build darwin || linux
+
+package tools
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/sandbox"
+)
+
+// TestWebFetch_SandboxBlocksNetwork verifies that when a sandbox with
+// AllowNetwork=false is active, web_fetch returns a clear error instead of
+// attempting the request.
+func TestWebFetch_SandboxBlocksNetwork(t *testing.T) {
+	if !sandbox.Available() {
+		t.Skip("no OS sandbox available on this host")
+	}
+	cwd := t.TempDir()
+	p := sandbox.DefaultPolicy(cwd)
+	p.AllowNetwork = false
+	SetSandbox(&p)
+	defer SetSandbox(nil)
+
+	_, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
+		"url": "https://example.com",
+	})
+	if err == nil {
+		t.Fatal("expected error when network is sandboxed")
+	}
+	if !strings.Contains(err.Error(), "network access is disabled by sandbox") {
+		t.Errorf("expected sandbox error, got: %v", err)
+	}
+}
+
+// TestWebFetch_SandboxAllowsNetwork verifies that when a sandbox with
+// AllowNetwork=true is active, web_fetch works normally.
+func TestWebFetch_SandboxAllowsNetwork(t *testing.T) {
+	if !sandbox.Available() {
+		t.Skip("no OS sandbox available on this host")
+	}
+	cwd := t.TempDir()
+	p := sandbox.DefaultPolicy(cwd)
+	p.AllowNetwork = true
+	SetSandbox(&p)
+	defer SetSandbox(nil)
+
+	// Point Jina at a local server so we don't need real network.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("# allowed"))
+	}))
+	defer srv.Close()
+
+	old := jinaReaderHostForTest
+	jinaReaderHostForTest = srv.URL + "/"
+	defer func() { jinaReaderHostForTest = old }()
+
+	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
+		"url": "https://example.com",
+	})
+	if err != nil {
+		t.Fatalf("expected success when network is allowed, got: %v", err)
+	}
+	if !strings.Contains(out.Text, "allowed") {
+		t.Errorf("expected 'allowed' in response, got: %q", out.Text)
+	}
+}
+
+// TestWebSearch_SandboxBlocksNetwork verifies that when a sandbox with
+// AllowNetwork=false is active, web_search returns a clear error.
+func TestWebSearch_SandboxBlocksNetwork(t *testing.T) {
+	if !sandbox.Available() {
+		t.Skip("no OS sandbox available on this host")
+	}
+	cwd := t.TempDir()
+	p := sandbox.DefaultPolicy(cwd)
+	p.AllowNetwork = false
+	SetSandbox(&p)
+	defer SetSandbox(nil)
+
+	_, err := WebSearchTool{}.Execute(context.Background(), "web_search", map[string]any{
+		"query": "test",
+	})
+	if err == nil {
+		t.Fatal("expected error when network is sandboxed")
+	}
+	if !strings.Contains(err.Error(), "network access is disabled by sandbox") {
+		t.Errorf("expected sandbox error, got: %v", err)
+	}
+}

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -55,6 +55,10 @@ func (WebFetchTool) Definition() agent.ToolDefinition {
 }
 
 func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	if !NetworkAllowed() {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: network access is disabled by sandbox")
+	}
+
 	raw, _ := input["url"].(string)
 	if strings.TrimSpace(raw) == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: url is required")

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -95,6 +95,10 @@ func (WebSearchTool) Definition() agent.ToolDefinition {
 }
 
 func (WebSearchTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	if !NetworkAllowed() {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("web_search: network access is disabled by sandbox")
+	}
+
 	query, _ := input["query"].(string)
 	if strings.TrimSpace(query) == "" {
 		return agent.ToolResult{}, fmt.Errorf("web_search: query is required")


### PR DESCRIPTION
When --sandbox is active and AllowNetwork=false (the default), both web_fetch and web_search now return a clear error instead of attempting the request. This prevents gold-patch leakage during eval runs where the agent might try to look up the answer online.

Changes:
- tools.NetworkAllowed() exposes the active sandbox policy's network bit
- web_fetch Execute checks NetworkAllowed() before any HTTP call
- web_search Execute checks NetworkAllowed() before any HTTP call
- Add sandbox_network_test.go with tests for blocked/allowed network

Fixes #173