### PR TITLE
fix(tui): stop inbox messages from polluting input history

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -461,9 +461,6 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				s := strings.Join(msgs, "\n\n")
 				for _, line := range strings.Split(s, "\n\n") {
 					m.println(userEchoStyle.Render("> ") + line)
-					if len(m.inputHistory) == 0 || m.inputHistory[len(m.inputHistory)-1] != line {
-						m.inputHistory = append(m.inputHistory, line)
-					}
 				}
 				m.queue = append([]pendingItem{{text: s}}, m.queue...)
 			}
@@ -702,9 +699,6 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 		s := strings.Join(msgs, "\n\n")
 		for _, line := range strings.Split(s, "\n\n") {
 			m.println(userEchoStyle.Render("> ") + line)
-			if len(m.inputHistory) == 0 || m.inputHistory[len(m.inputHistory)-1] != line {
-				m.inputHistory = append(m.inputHistory, line)
-			}
 		}
 		m.queue = append([]pendingItem{{text: s}}, m.queue...)
 	}


### PR DESCRIPTION
Background-process completion notices and other inbox messages were being appended to inputHistory, causing them to appear when the user pressed Up to recall previous input.

Fix: remove the inputHistory append calls in both turnEndedMsg and handleTurnFinished where inbox messages are drained. Only actual user submissions (submit, Ctrl+Q queue) should enter inputHistory.