### PR TITLE
tools/background: hide sync-started processes from ListRunning until timeout

### DIFF
--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -34,6 +34,12 @@ type bgProcess struct {
 	pollCount int // consecutive empty reads while running
 
 	onLine func(string) // optional real-time callback for sync-mode streaming
+
+	// visible controls whether the process appears in ListRunning /
+	// RunningBackground. Sync-started processes are hidden until they time
+	// out and become true background tasks, so the TUI "background (N)"
+	// panel doesn't flicker during a normal synchronous call.
+	visible bool
 }
 
 func (p *bgProcess) append(b []byte) {
@@ -143,6 +149,13 @@ func WithOnLine(fn func(string)) StartOption {
 	return func(p *bgProcess) { p.onLine = fn }
 }
 
+// WithVisible sets the process visibility in ListRunning. Sync-started
+// processes start hidden (visible=false) and are promoted to visible=true
+// when they time out.
+func WithVisible(v bool) StartOption {
+	return func(p *bgProcess) { p.visible = v }
+}
+
 // Start launches command detached (via `sh -c`), with no timeout, and returns
 // its background id. Output streams into a capped buffer; the process is killed
 // if its context is cancelled (Kill / KillAll).
@@ -167,7 +180,7 @@ func (m *BackgroundManager) Start(command string, opts ...StartOption) (string, 
 	m.mu.Lock()
 	m.seq++
 	id := fmt.Sprintf("bg_%d", m.seq)
-	p := &bgProcess{id: id, command: command, cancel: cancel, proc: cmd.Process, start: time.Now()}
+	p := &bgProcess{id: id, command: command, cancel: cancel, proc: cmd.Process, start: time.Now(), visible: true}
 	for _, opt := range opts {
 		opt(p)
 	}
@@ -235,7 +248,8 @@ type BgInfo struct {
 	Start   time.Time
 }
 
-// ListRunning returns the processes that haven't exited yet, oldest first.
+// ListRunning returns the visible processes that haven't exited yet, oldest first.
+// Processes started invisibly (e.g. sync mode) are excluded until promoted.
 func (m *BackgroundManager) ListRunning() []BgInfo {
 	m.mu.Lock()
 	procs := make([]*bgProcess, 0, len(m.procs))
@@ -248,13 +262,29 @@ func (m *BackgroundManager) ListRunning() []BgInfo {
 	for _, p := range procs {
 		p.mu.Lock()
 		done := p.done
+		visible := p.visible
 		p.mu.Unlock()
-		if !done {
+		if !done && visible {
 			out = append(out, BgInfo{ID: p.id, Command: p.command, Start: p.start})
 		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Start.Before(out[j].Start) })
 	return out
+}
+
+// Promote makes a background process visible in ListRunning. Used when a
+// sync-started process times out and becomes a true background task.
+func (m *BackgroundManager) Promote(id string) bool {
+	m.mu.Lock()
+	p := m.procs[id]
+	m.mu.Unlock()
+	if p == nil {
+		return false
+	}
+	p.mu.Lock()
+	p.visible = true
+	p.mu.Unlock()
+	return true
 }
 
 // Kill terminates the process for id. Returns false when id is unknown.

--- a/internal/tools/background_listrunning_test.go
+++ b/internal/tools/background_listrunning_test.go
@@ -50,3 +50,31 @@ func TestRunningBackground_DefaultManagerDelegates(t *testing.T) {
 	// Smoke: the package-level helper reads the default manager without panicking.
 	_ = RunningBackground()
 }
+
+// TestBackgroundManager_ListRunning_ExcludesInvisible verifies that processes
+// started with visible=false do not appear in ListRunning until Promoted.
+func TestBackgroundManager_ListRunning_ExcludesInvisible(t *testing.T) {
+	m := NewBackgroundManager()
+	id, err := m.Start("sleep 2", WithVisible(false))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Invisible processes should not be listed.
+	if run := m.ListRunning(); len(run) != 0 {
+		t.Errorf("invisible process should not be listed; got %+v", run)
+	}
+
+	// After promotion it appears.
+	if !m.Promote(id) {
+		t.Fatal("Promote returned false for a live process")
+	}
+	if run := m.ListRunning(); len(run) != 1 {
+		t.Fatalf("after promote ListRunning = %d entries, want 1: %+v", len(run), run)
+	}
+
+	// Promote of unknown id returns false.
+	if m.Promote("bg_does_not_exist") {
+		t.Error("Promote of unknown id should return false")
+	}
+}

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -130,7 +130,7 @@ func (t TerminalTool) ExecuteStream(
 		}
 	}
 
-	id, err := t.manager().Start(command, WithOnLine(onLine))
+	id, err := t.manager().Start(command, WithOnLine(onLine), WithVisible(false))
 	if err != nil {
 		return agent.ToolResult{Text: ""}, err
 	}
@@ -142,8 +142,9 @@ func (t TerminalTool) ExecuteStream(
 	for {
 		select {
 		case <-timer.C:
-			// Timeout: the original process is still running in the background.
-			// Return what we have so far plus the bg id.
+			// Timeout: promote the hidden process to visible so it shows up
+			// in the TUI "background (N running)" panel, then return.
+			t.manager().Promote(id)
 			outMu.Lock()
 			body := strings.TrimRight(out.String(), "\n")
 			outMu.Unlock()


### PR DESCRIPTION
When a synchronous terminal command is started, it now begins as an invisible background process (visible=false). This prevents it from appearing in the TUI's "background (N running)" panel during normal execution. Only when the command exceeds TerminalTimeout and is "promoted" to a true background task does it become visible.

Changes:
- bgProcess: add visible field
- StartOption: add WithVisible(bool)
- BackgroundManager.Start: default visible=true, overridable by opts
- BackgroundManager.ListRunning: filter on visible && !done
- BackgroundManager.Promote(id): flip visible=true
- TerminalTool.ExecuteStream: start sync processes with visible=false, call Promote(id) on timeout
- Add TestBackgroundManager_ListRunning_ExcludesInvisible