### PR TITLE
fix(tools): suppress onExit for invisible sync processes

### DIFF
--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -217,8 +217,18 @@ func (m *BackgroundManager) Start(command string, opts ...StartOption) (string, 
 		hook := m.onExit
 		m.mu.Unlock()
 		if hook != nil {
-			out, status, _ := p.readNew()
-			hook(BgExit{ID: p.id, Command: p.command, Status: status, NewOutput: out})
+			p.mu.Lock()
+			visible := p.visible
+			p.mu.Unlock()
+			// Only notify for processes that are visible as background tasks.
+			// Sync-started processes start invisible (visible=false); they are
+			// promoted to visible=true when they time out. If a sync process
+			// finishes before the timeout, it was never a background task and
+			// its result was already returned synchronously — no notification.
+			if visible {
+				out, status, _ := p.readNew()
+				hook(BgExit{ID: p.id, Command: p.command, Status: status, NewOutput: out})
+			}
 		}
 	}()
 

--- a/internal/tools/background_onexit_test.go
+++ b/internal/tools/background_onexit_test.go
@@ -76,3 +76,78 @@ func TestBackgroundManager_NoHookByDefault(t *testing.T) {
 		t.Errorf("output = %q, want 'plain'", out)
 	}
 }
+
+// TestBackgroundManager_OnExitNotFiredForInvisibleProcess verifies that a
+// sync-started process which finishes *before* the timeout (and therefore
+// never gets Promoted to visible) does NOT fire the onExit hook. This
+// prevents a spurious "background finished" system-reminder for a command
+// whose result was already returned synchronously.
+func TestBackgroundManager_OnExitNotFiredForInvisibleProcess(t *testing.T) {
+	m := NewBackgroundManager()
+
+	fired := make(chan BgExit, 1)
+	m.SetOnExit(func(e BgExit) {
+		select {
+		case fired <- e:
+		default:
+		}
+	})
+
+	// Start invisible (visible=false), exactly like the sync path does.
+	id, err := m.Start("echo sync-done", WithVisible(false))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for the process to finish.
+	waitFor(t, "process to exit", func() bool {
+		_, s, f, _ := m.Read(id)
+		return f && strings.HasPrefix(s, "exited")
+	})
+
+	// Give the waiter goroutine time to evaluate the visible flag.
+	select {
+	case got := <-fired:
+		t.Fatalf("onExit should NOT fire for an invisible sync process, but got %+v", got)
+	case <-time.After(200 * time.Millisecond):
+		// Expected: no hook fired.
+	}
+}
+
+// TestBackgroundManager_OnExitFiresAfterPromote verifies that a sync-started
+// process which times out (gets Promoted to visible=true) and then finishes
+// DOES fire the onExit hook, because it became a true background task.
+func TestBackgroundManager_OnExitFiresAfterPromote(t *testing.T) {
+	m := NewBackgroundManager()
+
+	fired := make(chan BgExit, 1)
+	m.SetOnExit(func(e BgExit) {
+		select {
+		case fired <- e:
+		default:
+		}
+	})
+
+	// Start invisible, then promote before it finishes.
+	id, err := m.Start("sleep 0.1", WithVisible(false))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Promote immediately (simulating the timeout path).
+	m.Promote(id)
+
+	var got BgExit
+	select {
+	case got = <-fired:
+	case <-time.After(3 * time.Second):
+		t.Fatal("onExit hook did not fire after Promote within 3s")
+	}
+
+	if got.ID != id {
+		t.Errorf("ID = %q, want %q", got.ID, id)
+	}
+	if got.Status != "exited: 0" {
+		t.Errorf("Status = %q, want 'exited: 0'", got.Status)
+	}
+}


### PR DESCRIPTION
修复同步命令在超时前完成时错误触发 onExit system-reminder 的竞态条件问题。

**问题**: 
同步启动的 terminal 命令（background:false）如果在 30 秒超时前完成，waiter goroutine 仍然会触发 onExit 回调，导致一个虚假的 "后台进程已完成" system-reminder 被注入对话。但此时命令结果已经通过同步路径返回了。

**根因**: 
waiter goroutine 在进程完成时无条件调用 onExit，没有区分该进程是否真正被提升为后台任务。

**修复**: 
在触发 onExit 前检查 。同步进程以 invisible（visible=false）启动，只有在超时后 Promote 才会变成 visible=true。如果进程在 Promote 前就已退出，说明它从未成为真正的后台任务，不需要通知。

**三种场景的行为**:
1. background:true 启动 → visible=true → 完成时触发 onExit ✅
2. 同步启动、超时前完成 → visible=false → 不触发 onExit ✅
3. 同步启动、超时后 Promote、然后完成 → visible=true → 完成时触发 onExit ✅

**新增测试**:
- : 验证同步完成的 invisible 进程不触发 hook
- : 验证 Promote 后的进程完成时正确触发 hook