### PR TITLE
feat(tui): remove scrollback notices for bg/sub-agent completions

### DIFF
--- a/cmd/octo/bgnotify_wiring_test.go
+++ b/cmd/octo/bgnotify_wiring_test.go
@@ -53,14 +53,13 @@ func TestRunTurn_PrependsIdleBgNote(t *testing.T) {
 	}
 }
 
-// TestTUI_BgExitMsgShowsNotice confirms an async background-exit message is
-// appended to the scrollback buffer.
-func TestTUI_BgExitMsgShowsNotice(t *testing.T) {
+// TestTUI_BgExitMsgNoScrollbackNotice confirms an async background-exit message
+// does NOT append a scrollback notice (the full output rides into the conversation
+// via Inbox instead).
+func TestTUI_BgExitMsgNoScrollbackNotice(t *testing.T) {
 	m := newTestModel()
 	m.Update(bgExitMsg{e: tools.BgExit{ID: "bg_1", Command: "go test ./...", Status: "exited: 0"}})
-	// In inline mode, bgExitMsg emits via tea.Println (returned as Cmd).
-	// printlnBuf is a staging buffer cleared by flushPrints() in Update().
 	if len(m.printlnBuf) > 0 {
-		t.Log("bgExitMsg queued println lines")
+		t.Errorf("bgExitMsg should not queue println lines, got %d", len(m.printlnBuf))
 	}
 }

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -401,10 +401,8 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.flushPrints()
 
 	case bgExitMsg:
-		// Async background-process completion: show a one-line scrollback notice
-		// (the full output rode into the conversation via Inbox).
-		m.println(noticeStyle.Render(fmt.Sprintf(
-			"↳ %s (%s) %s", msg.e.ID, truncate1Line(msg.e.Command), msg.e.Status)))
+		// Async background-process completion: the full output rode into the
+		// conversation via Inbox; no scrollback notice needed.
 		// Idle auto-turn: if no turn is running and nothing is queued, drain the
 		// inbox (which holds the full <system-reminder> notice) and start a
 		// turn so the model sees the completion immediately — matching the plain
@@ -418,14 +416,8 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.flushPrints()
 
 	case subAgentNoteMsg:
-		// Async sub-agent completion: show a one-line scrollback notice (the
-		// full result rode into the conversation via Steer).
-		label := "completed"
-		if msg.ev.Kind == "message_reply" {
-			label = "replied"
-		}
-		m.println(noticeStyle.Render(fmt.Sprintf(
-			"↳ sub-agent %s (%s) %s", msg.ev.AgentID, truncate1Line(msg.ev.Description), label)))
+		// Async sub-agent completion: the full result rode into the conversation
+		// via Inbox; no scrollback notice needed.
 		// Idle auto-turn: same logic as bgExitMsg — drain inbox and trigger a
 		// turn so the model sees the notification immediately.
 		if !m.turnRunning && len(m.queue) == 0 {


### PR DESCRIPTION
Background-process and sub-agent completions no longer emit a one-line scrollback notice. The full output already rides into the conversation via Inbox, and the model replies with a summary — the scrollback line was redundant noise.