### PR TITLE
ci: opt into Node 24 early to silence deprecation warnings

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           cache: true
+        env:
+          # Opt into Node 24 early to silence deprecation warnings.
+          # Both actions/checkout@v4 and actions/setup-go@v5 support it.
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       - name: go vet
         run: go vet ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           go-version: '1.22'
           cache: true
+        env:
+          # Opt into Node 24 early to silence deprecation warnings.
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       - uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
GitHub Actions is deprecating Node 20 by June 16, 2026. Setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on `actions/setup-go@v5` opts in early and removes the annotation noise from CI logs.