### PR TITLE
Bump version to v0.12.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@
 package version
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "0.11.2"
+var Version = "0.12.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump version to v0.12.0 for M8 release (octo-agent-server).