### PR TITLE
fix(channel): wire up slash commands in IM channel

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/channel"
@@ -197,11 +198,15 @@ func runChannelStart(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 
 // handleCommand processes slash commands. Returns true if the event was a command.
 func handleCommand(mgr *channel.Manager, ad channel.Adapter, ev channel.InboundEvent) bool {
-	text := ev.Text
-	if len(text) == 0 || text[0] != '/' {
+	text := strings.TrimSpace(ev.Text)
+	if !strings.HasPrefix(text, "/") {
 		return false
 	}
-	return false
+	reply := mgr.CommandRouter(ev)
+	if reply != "" {
+		ad.SendText(ev.ChatID, reply, ev.MessageID)
+	}
+	return true
 }
 
 // handleAgentMessage runs the agent for a non-command inbound message.

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -160,7 +160,7 @@ func (m *Manager) IsRunning() bool {
 func (m *Manager) handleInbound(ctx context.Context, ev InboundEvent) {
 	text := strings.TrimSpace(ev.Text)
 	if strings.HasPrefix(text, "/") {
-		reply := m.commandRouter(ev)
+		reply := m.CommandRouter(ev)
 		if reply != "" {
 			m.sendReply(ev, reply)
 		}
@@ -169,8 +169,8 @@ func (m *Manager) handleInbound(ctx context.Context, ev InboundEvent) {
 	m.handleSessionMessage(ctx, ev)
 }
 
-// commandRouter processes slash commands and returns a reply text.
-func (m *Manager) commandRouter(ev InboundEvent) string {
+// CommandRouter processes slash commands and returns a reply text.
+func (m *Manager) CommandRouter(ev InboundEvent) string {
 	parts := strings.Fields(strings.TrimSpace(ev.Text))
 	if len(parts) == 0 {
 		return ""

--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -162,7 +162,7 @@ func TestManager_CommandRouter(t *testing.T) {
 
 	// /bind
 	ev := InboundEvent{Platform: "mock", ChatID: "c1", UserID: "u1", Text: "/bind"}
-	reply := mgr.commandRouter(ev)
+	reply := mgr.CommandRouter(ev)
 	if reply == "" {
 		t.Fatal("expected non-empty reply for /bind")
 	}
@@ -172,28 +172,28 @@ func TestManager_CommandRouter(t *testing.T) {
 
 	// /status
 	ev.Text = "/status"
-	reply = mgr.commandRouter(ev)
+	reply = mgr.CommandRouter(ev)
 	if reply == "" {
 		t.Fatal("expected non-empty reply for /status")
 	}
 
 	// /list
 	ev.Text = "/list"
-	reply = mgr.commandRouter(ev)
+	reply = mgr.CommandRouter(ev)
 	if reply == "" {
 		t.Fatal("expected non-empty reply for /list")
 	}
 
 	// /stop (does not delete)
 	ev.Text = "/stop"
-	reply = mgr.commandRouter(ev)
+	reply = mgr.CommandRouter(ev)
 	if reply == "" {
 		t.Fatal("expected non-empty reply for /stop")
 	}
 
 	// /unbind (deletes)
 	ev.Text = "/unbind"
-	reply = mgr.commandRouter(ev)
+	reply = mgr.CommandRouter(ev)
 	if mgr.SessionCount() != 0 {
 		t.Fatalf("expected 0 sessions after /unbind, got %d", mgr.SessionCount())
 	}
@@ -258,7 +258,7 @@ func TestManager_SendReply(t *testing.T) {
 func TestManager_UnknownCommand(t *testing.T) {
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
 	ev := InboundEvent{Text: "/foobar"}
-	reply := mgr.commandRouter(ev)
+	reply := mgr.CommandRouter(ev)
 	if reply == "" {
 		t.Fatal("expected error reply for unknown command")
 	}


### PR DESCRIPTION
The CLI's handleCommand was a stub that detected slash commands but always returned false, causing /bind, /status, etc. to be sent to the LLM as regular user messages instead of being handled locally.

## Changes
- Export Manager.commandRouter as CommandRouter so CLI can reuse it.
- Implement handleCommand to delegate to CommandRouter and send the reply back through the adapter.

## Verification
- go vet ./... ✅
- go test -race ./internal/channel/... ./cmd/octo/... ✅

Fixes: IM slash commands (/bind, /stop, /unbind, /status, /list) now work correctly.