### PR TITLE
fix(tui): keep the thinking spinner up while waiting on the model

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -227,9 +227,6 @@ type tuiModel struct {
 	// (identified by splitCommittableMarkdown) are promoted to printlnBuf and
 	// flushed to the terminal scrollback via tea.Println.
 	partial strings.Builder
-	// streaming tracks whether the current turn has emitted any output yet
-	// (drives the "thinking…" placeholder).
-	streaming bool
 
 	// toolInput caches each tool call's input from EventToolStarted so the
 	// matching EventToolDone can render a card (tool_result events don't carry
@@ -341,7 +338,6 @@ func (m *tuiModel) startTurn(line string) tea.Cmd {
 // pass "" to suppress the echo entirely.
 func (m *tuiModel) startTurnEcho(line, echo string) tea.Cmd {
 	m.turnRunning = true
-	m.streaming = false
 	m.turnStart = time.Now()
 	m.spinnerFrame = 0
 	m.running = nil
@@ -496,7 +492,6 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // markdown blocks are promoted to the scrollback via println/flushPrints.
 // Tool events flush any pending text first, then commit their line/card.
 func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
-	m.streaming = true
 	switch ev.Kind {
 	case agent.EventTextDelta:
 		m.appendText(ev.Text)
@@ -668,7 +663,6 @@ func (m *tuiModel) flushPrints() tea.Cmd {
 func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 	m.turnRunning = false
 	m.cancelTurn = nil
-	m.streaming = false
 	m.running = nil // clear any live tool indicator (e.g. on interrupt)
 
 	// Any steer messages that weren't drained via EventSteerInjected during

--- a/cmd/octo/tuirepl_goal.go
+++ b/cmd/octo/tuirepl_goal.go
@@ -71,7 +71,6 @@ func goalUsage() string {
 // starts while the goal is in flight. The result returns via goalPlannedMsg.
 func (m *tuiModel) startGoalPlan(goal string) tea.Cmd {
 	m.turnRunning = true
-	m.streaming = false
 	m.turnStart = time.Now()
 	m.spinnerFrame = 0
 	m.running = nil
@@ -155,7 +154,6 @@ func (m *tuiModel) onGoalPlanned(msg goalPlannedMsg) (tea.Model, tea.Cmd) {
 // returns via goalDoneMsg. Reused by both fresh-plan confirmation and resume.
 func (m *tuiModel) startGoalRun(taskID string) tea.Cmd {
 	m.turnRunning = true
-	m.streaming = false
 	m.turnStart = time.Now()
 	m.spinnerFrame = 0
 	m.running = nil

--- a/cmd/octo/tuirepl_p3_test.go
+++ b/cmd/octo/tuirepl_p3_test.go
@@ -71,6 +71,57 @@ func TestSpinnerLine_Contents(t *testing.T) {
 	}
 }
 
+// TestTUI_SpinnerShownWhileWaitingBetweenSteps guards the gap that left the
+// TUI frozen with no indicator: after a tool finished and the turn is still
+// running, the agent is waiting on the model's next response — there is no
+// live tool and no streaming text. The activity line must still show a
+// thinking/working spinner so the user can tell the turn isn't idle.
+func TestTUI_SpinnerShownWhileWaitingBetweenSteps(t *testing.T) {
+	m := newTestModel()
+	m.width = 80
+	m.turnRunning = true
+	m.turnStart = time.Now()
+	m.spinnerFrame = 0 // thinkingPhrase() == "Thinking"
+
+	// A tool ran and completed earlier this turn (this also latches the old
+	// "streaming" flag true), then the agent loops back to the model.
+	m.handleEvent(agent.AgentEvent{
+		Kind: agent.EventToolStarted, ToolID: "c1", ToolName: "terminal",
+		Input: map[string]any{"command": "ls"},
+	})
+	m.handleEvent(agent.AgentEvent{
+		Kind: agent.EventToolDone, ToolID: "c1", ToolName: "terminal", Output: "file",
+	})
+
+	// Precondition: the silent inter-step wait — no live tool, no partial text.
+	if m.running != nil {
+		t.Fatalf("precondition: running should be nil after tool done")
+	}
+	if m.partial.Len() != 0 {
+		t.Fatalf("precondition: partial should be empty, got %q", m.partial.String())
+	}
+
+	if out := m.View(); !strings.Contains(out, "Thinking") {
+		t.Errorf("expected a thinking spinner while waiting on the next model step; View was:\n%s", out)
+	}
+}
+
+// TestTUI_NoThinkingSpinnerWhileStreamingText is the other half of the
+// contract: while assistant text is actively streaming (partial non-empty),
+// the live text is the feedback, so the thinking spinner stays out of the way.
+func TestTUI_NoThinkingSpinnerWhileStreamingText(t *testing.T) {
+	m := newTestModel()
+	m.width = 80
+	m.turnRunning = true
+	m.turnStart = time.Now()
+	m.spinnerFrame = 0 // thinkingPhrase() == "Thinking"
+	m.partial.WriteString("hello world")
+
+	if out := m.View(); strings.Contains(out, "Thinking") {
+		t.Errorf("thinking spinner should be suppressed while text streams; View was:\n%s", out)
+	}
+}
+
 func TestThinkingPhrase_Rotates(t *testing.T) {
 	m := newTestModel()
 	m.spinnerFrame = 0

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -403,7 +403,7 @@ func (m *tuiModel) liveHeight() int {
 	if m.partial.String() != "" {
 		h++
 	}
-	if m.running != nil || (m.turnRunning && !m.streaming) {
+	if m.running != nil || (m.turnRunning && m.partial.Len() == 0) {
 		h++
 	}
 	if n := len(m.pendingSteer); n > 0 {
@@ -444,7 +444,13 @@ func (m *tuiModel) View() string {
 	if m.running != nil {
 		b.WriteString(m.spinnerLine(m.running.verb+"("+m.running.target+")", m.running.start))
 		b.WriteByte('\n')
-	} else if m.turnRunning && !m.streaming {
+	} else if m.turnRunning && m.partial.Len() == 0 {
+		// Turn is running but nothing is on the activity line right now — no
+		// live tool and no streaming text. That's the wait on the model
+		// (initial prompt, or between steps after a tool result). Show the
+		// thinking spinner so the user can tell the turn isn't idle. While
+		// text is actively streaming (partial non-empty), the text itself is
+		// the feedback, so the spinner stays out of the way.
 		b.WriteString(m.spinnerLine(m.thinkingPhrase(), m.turnStart))
 		b.WriteByte('\n')
 	}


### PR DESCRIPTION
## Problem

During task execution the TUI showed **no animation** during the silent waits — you couldn't tell whether the agent was still working (LLM call in flight) or had gone idle waiting for input.

## Root cause

The activity-line spinner was gated on `!m.streaming`, but `streaming` was a **sticky per-turn latch**: `false` at turn start → flipped `true` on the *first* event → never reset until the turn ended. So the `Thinking…` spinner only showed during the initial pre-first-event wait. Once any event arrived, the activity line went blank for the rest of the turn — including the gaps where a tool has finished and the agent is **waiting on the model's next response**. Frozen screen, no indicator.

## Fix

Gate the thinking spinner on `m.partial.Len() == 0` instead — show it whenever the turn is running with nothing else on the activity line (no live tool `m.running`, no streaming text in `m.partial`). That covers the initial wait **and** every between-steps wait. While text actively streams, the text itself is the feedback, so the spinner stays out of the way. Both the `View()` render and the matching `liveHeight()` accounting are updated together.

The `streaming` field is now unused — removed along with its 5 assignments (including the two goal-mode entry points).

## Tests
- `TestTUI_SpinnerShownWhileWaitingBetweenSteps` — simulates tool-done → waiting; **red before the fix** (activity line blank), green after.
- `TestTUI_NoThinkingSpinnerWhileStreamingText` — mirror: no spinner while `partial` has live text.

`go test -race ./...` (22 pkgs), `go vet`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)