### PR TITLE
feat(cli): headless agentic one-shot (claude -p), retire the plain REPL

### DIFF
--- a/cmd/mswe-eval/main.go
+++ b/cmd/mswe-eval/main.go
@@ -233,16 +233,12 @@ func generateOne(inst mswe.Instance, octoBin, evalHome, workdir, model, provider
 		return "", fmt.Errorf("checkout %s: %v (%s)", inst.BaseCommit(), err, truncate(out, 200))
 	}
 
-	// Drive octo through REPL mode (the agentic tool-execution loop only runs
-	// in REPL mode — a single-turn `octo chat "msg"` does one model round-trip
-	// WITHOUT executing tools, so it would never edit files). The issue is
-	// delivered via --prompt-file as ONE multi-line turn: octo's piped REPL
-	// reads stdin line-by-line (one turn per line), so passing a multi-line
-	// prompt on stdin shreds the issue body into dozens of fragmented,
-	// low-context turns. Strict perms + the eval HOME's permissive
-	// permissions.yml let tools run without prompts; --no-save keeps the
-	// throwaway session out of history. The prompt file lives in workdir (not
-	// repoDir) so `git add -A` below doesn't sweep it into the patch.
+	// Drive octo as a headless one-shot: --prompt-file delivers the whole issue
+	// as a single agentic turn (the full tool loop runs, so it can edit files),
+	// then octo exits. Strict perms + the eval HOME's permissive permissions.yml
+	// let tools run without prompts; --no-save keeps the throwaway session out of
+	// history. The prompt file lives in workdir (not repoDir) so `git add -A`
+	// below doesn't sweep it into the patch.
 	env := append(os.Environ(), "HOME="+evalHome)
 	promptPath := filepath.Join(workdir, fmt.Sprintf("prompt-%s__%s__%d.txt", inst.Org(), inst.Repo(), inst.Number()))
 	if err := os.WriteFile(promptPath, []byte(octoPrompt(inst)), 0o644); err != nil {
@@ -265,7 +261,7 @@ func generateOne(inst mswe.Instance, octoBin, evalHome, workdir, model, provider
 	}
 	// Per-instance timeout backstops a turn that genuinely won't converge (the
 	// streaming idle-timeout in octo handles a stalled connection); kill octo
-	// after `timeout`. Empty stdin → after the seeded turn, EOF ends the session.
+	// after `timeout`. Stdin is empty — the prompt comes from --prompt-file.
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	octoOut, oerr := runStdin(ctx, repoDir, env, "", octoBin, octoArgs...)
@@ -457,9 +453,8 @@ func run(dir string, env []string, name string, args ...string) (string, error) 
 	return string(out), err
 }
 
-// runStdin is like run but feeds stdin to the process and honors ctx (used to
-// drive octo's REPL: the prompt on stdin, EOF ending the session). When ctx's
-// deadline fires, the process is killed.
+// runStdin is like run but feeds stdin to the process and honors ctx. When
+// ctx's deadline fires, the process is killed.
 func runStdin(ctx context.Context, dir string, env []string, stdin, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -95,15 +95,15 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	stream := fs.Bool("stream", true, "Stream the reply (chunks printed as they arrive); --stream=false buffers")
 	continueID := fs.String("c", "", "Resume a session — accepts 'last', a short ID, or a substring of an ID")
 	continueIDLong := fs.String("continue", "", "Resume a session — accepts 'last', a short ID, or a substring of an ID")
-	noSave := fs.Bool("no-save", false, "Disable auto-save in REPL mode")
+	noSave := fs.Bool("no-save", false, "Disable session auto-save in the interactive TUI (headless one-shots never persist)")
 	listSessions := fs.Bool("list-sessions", false, "Print the 10 most recent sessions and exit")
 	listSkills := fs.Bool("list-skills", false, "Print available skills (user + project) and exit")
 	enableTools := fs.Bool("tools", true, "Built-in tools (terminal, edit_file, …) for the agentic loop. On by default; use --no-tools to disable.")
 	noTools := fs.Bool("no-tools", false, "Disable the built-in tools (and MCP/skill execution) — plain chat only")
 	noMemory := fs.Bool("no-memory", false, "Disable cross-session memory (the remember tool + memory injection)")
 	plain := fs.Bool("plain", false, "Render tool events as one-line ↳ status lines instead of rich diff cards")
-	promptFile := fs.String("prompt-file", "", "Read a single multi-line prompt from this file and run it as one agentic turn (newlines preserved), then continue reading turns from stdin. For scripting/eval; avoids the one-turn-per-line split of piped multi-line input.")
-	noTUI := fs.Bool("no-tui", false, "Disable the interactive TUI on a terminal; use the plain line-based REPL (also OCTO_TUI=0)")
+	promptFile := fs.String("prompt-file", "", "Read the prompt from this file (newlines preserved) and run it as one headless agentic turn, then exit. For scripting/eval.")
+	noTUI := fs.Bool("no-tui", false, "Force the headless one-shot path on a terminal instead of the interactive TUI (also OCTO_TUI=0). The prompt comes from a positional message, --prompt-file, or piped stdin.")
 	quietFlag := fs.Bool("quiet", false, "Strip all status chrome (no spinner, no banner, no cache line). Also OCTO_VERBOSITY=quiet.")
 	verboseFlag := fs.Bool("verbose", false, "Print extra context (provider/model/endpoint, always-on cache line). Also OCTO_VERBOSITY=verbose.")
 	permMode := fs.String("permission-mode", "", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask) | auto (allow on ask). Empty = use `octo config` value, else interactive.")
@@ -160,9 +160,9 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	userInput := strings.TrimSpace(strings.Join(fs.Args(), " "))
 	isREPL := userInput == ""
 
-	// --prompt-file seeds the agentic REPL with one multi-line initial turn.
-	// It's mutually exclusive with a positional message (which is single-turn,
-	// tool-free) — accepting both would silently drop one.
+	// --prompt-file supplies the one-shot prompt from a file. It's mutually
+	// exclusive with a positional message — both are prompt sources, and
+	// accepting both would silently drop one.
 	var seedPrompt string
 	if *promptFile != "" {
 		if !isREPL {
@@ -325,94 +325,113 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		replView     ViewSink
 		subAgentMgr  *tools.SubAgentManager
 	)
-	// useTUI: an interactive terminal drives the bubbletea TUI unless the user
-	// (or OCTO_TUI=0) opted out. Piped / redirected stdin always uses the plain
-	// line-based path (tests, mswe-eval, CI). See design §5, §12.
-	// --prompt-file forces the plain line-based path: seeding the turn relies
-	// on the scanner reader, and the TUI owns its own input.
+	// Two surfaces only. An interactive terminal drives the bubbletea TUI;
+	// everything else is a headless one-shot — octo's claude -p mode. A
+	// positional message, --prompt-file, piped/redirected stdin, --no-tui, or
+	// OCTO_TUI=0 all take the one-shot path (tests, mswe-eval, CI included).
 	useTUI := isREPL && stdinIsTTY(stdin) && !*noTUI && !tuiDisabledByEnv() && seedPrompt == ""
-	if isREPL {
-		toolExecutor = tools.NewDefaultRegistry()
-		spawner := newAgentSpawner(a, toolExecutor, tools.DefaultTools)
-		tools.SetSpawner(spawner)
-		subAgentMgr = tools.NewSubAgentManager(spawner)
-		if useTUI {
-			// bubbletea owns stdin and renders its own input; the asker and gate
-			// are wired to the TUI sink inside runTUI. No readline reader or
-			// plainView is built (they'd fight bubbletea for the terminal).
-			defer tools.SetAsker(nil)
-		} else {
-			if stdinIsTTY(stdin) {
-				rl, err := newReadlineReader(defaultHistoryFile())
-				if err != nil {
-					fmt.Fprintf(stderr, "octo chat: line editor unavailable (%v); falling back to plain input\n", err)
-					replReader = newScannerLineReader(stdin, stdout)
-				} else {
-					replReader = rl
-				}
-			} else {
-				replReader = newScannerLineReader(stdin, stdout)
-			}
-			// --prompt-file: deliver the file as the first turn verbatim, then
-			// fall through to stdin. Wrapping here (before the view/asker are
-			// built) means the loop, gate, and asker share the one seeded reader.
-			if seedPrompt != "" {
-				replReader = &seededLineReader{seed: seedPrompt, inner: replReader}
-			}
-			// One view backs the turn loop, the permission gate, and the asker,
-			// so they share a single presentation surface. Built here because
-			// the asker is registered before runREPL constructs its config.
-			replView = newPlainView(replReader, stdout, stderr, resolveVerbosity(*quietFlag, *verboseFlag), *plain)
-			tools.SetAsker(newREPLAsker(replView))
-			defer tools.SetAsker(nil)
+
+	// Resuming a session (-c) is an interactive affordance — it only makes sense
+	// in the TUI. A headless one-shot starts fresh.
+	if resumeID != "" && !useTUI {
+		fmt.Fprintln(stderr, "octo chat: -c/--continue needs an interactive terminal (run it without piping/--no-tui)")
+		return 2
+	}
+
+	// Resolve the single prompt for the one-shot path: positional message →
+	// --prompt-file → all of piped stdin. The TUI reads its own input.
+	var oneShotPrompt string
+	if !useTUI {
+		oneShotPrompt = userInput
+		if oneShotPrompt == "" {
+			oneShotPrompt = seedPrompt
 		}
+		if oneShotPrompt == "" && !stdinIsTTY(stdin) {
+			b, rerr := io.ReadAll(stdin)
+			if rerr != nil {
+				fmt.Fprintf(stderr, "octo chat: read stdin: %v\n", rerr)
+				return 1
+			}
+			oneShotPrompt = strings.TrimSpace(string(b))
+		}
+		if oneShotPrompt == "" {
+			fmt.Fprintln(stderr, "octo chat: no prompt — pass a message, use --prompt-file, or pipe input on stdin")
+			return 2
+		}
+	}
 
-		// Session-scoped task tracker backing the task_create / task_update /
-		// task_list tools. Lost on exit by design (cross-session persistence
-		// is M11 territory).
-		tools.SetTaskStore(tasks.New())
-		defer tools.SetTaskStore(nil)
-
-		// MCP servers: load config, connect, register so DefaultTools and
-		// DefaultRegistry pick them up. Best-effort — a misconfigured or
-		// missing server is logged on stderr and the session keeps going.
-		// Tool-disabled chat doesn't load MCP because the agent would never
-		// invoke the tools anyway and we'd be paying subprocess spawn cost
-		// for nothing.
-		if toolsOn {
-			mcpCfg, err := mcp.LoadConfig(cwd)
+	// Agentic setup — shared by both paths, which each run the full tool loop.
+	toolExecutor = tools.NewDefaultRegistry()
+	spawner := newAgentSpawner(a, toolExecutor, tools.DefaultTools)
+	tools.SetSpawner(spawner)
+	subAgentMgr = tools.NewSubAgentManager(spawner)
+	if useTUI {
+		// bubbletea owns stdin and renders its own input; the asker and gate
+		// are wired to the TUI sink inside runTUI.
+		defer tools.SetAsker(nil)
+	} else {
+		// A TTY reader (a positional message typed at a terminal) makes
+		// permission / Ask prompts interactive. Over a pipe stdin is already
+		// drained into the prompt, so the reader hits EOF and plainView
+		// auto-denies — the headless posture.
+		if stdinIsTTY(stdin) {
+			rl, err := newReadlineReader(defaultHistoryFile())
 			if err != nil {
-				fmt.Fprintf(stderr, "octo chat: mcp config: %v\n", err)
-			} else if len(mcpCfg.Servers) > 0 {
-				mcpReg := mcp.ConnectAll(
-					context.Background(),
-					mcpCfg,
-					mcp.Implementation{Name: "octo", Version: version.Version},
-					func(serverName string) mcp.OAuthPrompt {
-						return newCLIOAuthPrompt(stdout, serverName)
-					},
-					stderr,
-				)
-				if mcpReg.Len() > 0 {
-					tools.SetMCPRegistry(mcpReg)
-					defer func() {
-						tools.SetMCPRegistry(nil)
-						mcpReg.Close()
-					}()
-					if mcpReg.Len() == 1 {
-						fmt.Fprintf(stdout, "Connected 1 MCP server.\n")
-					} else {
-						fmt.Fprintf(stdout, "Connected %d MCP servers.\n", mcpReg.Len())
-					}
+				fmt.Fprintf(stderr, "octo chat: line editor unavailable (%v); falling back to plain input\n", err)
+				replReader = newScannerLineReader(stdin, stdout)
+			} else {
+				replReader = rl
+			}
+		} else {
+			replReader = newScannerLineReader(stdin, stdout)
+		}
+		replView = newPlainView(replReader, stdout, stderr, resolveVerbosity(*quietFlag, *verboseFlag), *plain)
+		tools.SetAsker(newREPLAsker(replView))
+		defer tools.SetAsker(nil)
+	}
+
+	// Session-scoped task tracker backing the task_create / task_update /
+	// task_list tools. Lost on exit by design.
+	tools.SetTaskStore(tasks.New())
+	defer tools.SetTaskStore(nil)
+
+	// MCP servers: load config, connect, register so DefaultTools and
+	// DefaultRegistry pick them up. Best-effort — a misconfigured or missing
+	// server is logged on stderr and the session keeps going. Skipped when
+	// tools are off (the agent would never invoke them).
+	if toolsOn {
+		mcpCfg, err := mcp.LoadConfig(cwd)
+		if err != nil {
+			fmt.Fprintf(stderr, "octo chat: mcp config: %v\n", err)
+		} else if len(mcpCfg.Servers) > 0 {
+			mcpReg := mcp.ConnectAll(
+				context.Background(),
+				mcpCfg,
+				mcp.Implementation{Name: "octo", Version: version.Version},
+				func(serverName string) mcp.OAuthPrompt {
+					return newCLIOAuthPrompt(stdout, serverName)
+				},
+				stderr,
+			)
+			if mcpReg.Len() > 0 {
+				tools.SetMCPRegistry(mcpReg)
+				defer func() {
+					tools.SetMCPRegistry(nil)
+					mcpReg.Close()
+				}()
+				if mcpReg.Len() == 1 {
+					fmt.Fprintf(stdout, "Connected 1 MCP server.\n")
+				} else {
+					fmt.Fprintf(stdout, "Connected %d MCP servers.\n", mcpReg.Len())
 				}
 			}
 		}
 	}
 
-	// Boundary memory (REPL only): consolidate the live-captured entries into
-	// the summary if due, BEFORE rendering this session's injection so freshly
-	// folded facts apply immediately. Best-effort — errors don't block startup.
-	if isREPL && memStore != nil {
+	// Boundary memory consolidation runs only for the interactive TUI: a
+	// headless one-shot stays deterministic (no surprise consolidation
+	// sub-agent) and fast. Both paths still get the session-start injection.
+	if useTUI && memStore != nil {
 		maybeProcessMemory(a, memStore)
 	}
 	var memInjection string
@@ -421,10 +440,20 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	a.System = prompt.Compose(*system, cwd, env, skillsManifest, memInjection)
 
-	// ── REPL mode ────────────────────────────────────────────────────────────
-	if isREPL {
-		var sess *agent.Session
+	// Permission engine — gates every tool call; shared by both paths.
+	var permEngine *permission.Engine
+	if toolsOn {
+		eng, perr := permission.New(permissionConfigPath(), cwd, resolvePermissionMode(resolvedPermMode))
+		if perr != nil {
+			fmt.Fprintf(stderr, "octo chat: permission config: %v\n", perr)
+			return 1
+		}
+		permEngine = eng
+	}
 
+	// ── Interactive TUI ───────────────────────────────────────────────────────
+	if useTUI {
+		var sess *agent.Session
 		if resumeID != "" {
 			sess, err = agent.LoadSession(resumeID)
 			if err != nil {
@@ -464,67 +493,41 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			reader:     replReader,          // shared with the asker / permission gate
 			view:       replView,            // same surface for turn render + Ask prompts
 			hooks:      hooks.LoadFromEnv(), // C9 Phase 3: external retrieval layer hooks
+			permEngine: permEngine,
 		}
 		if toolsOn {
-			// Spawner is already registered above (before the memory pass) so
-			// launch_agent shows up in DefaultTools here. Reuse the executor
-			// built earlier so the spawner and the REPL share the same read
-			// tracker / mutex-guarded state.
 			cfg.tools = tools.DefaultTools()
 			cfg.executor = toolExecutor
 			cfg.subAgentMgr = subAgentMgr
-
-			// Build the permission engine that gates every tool call.
-			cwd, _ := os.Getwd()
-			engine, err := permission.New(permissionConfigPath(), cwd, resolvePermissionMode(resolvedPermMode))
-			if err != nil {
-				fmt.Fprintf(stderr, "octo chat: permission config: %v\n", err)
-				return 1
-			}
-			cfg.permEngine = engine
 		}
-		if useTUI {
-			return runTUI(cfg)
-		}
-		return runREPL(cfg)
+		return runTUI(cfg)
 	}
 
-	// ── Single-turn mode (original M2 behaviour) ──────────────────────────────
-	// Reap any background processes the turn spawned (REPL handles its own).
-	defer tools.KillAllBackground()
-	v := resolveVerbosity(*quietFlag, *verboseFlag)
-	if *stream {
-		var spin *spinner
-		if !v.quiet() {
-			spin = newSpinner(stdout, "thinking…")
-			spin.Start(250 * time.Millisecond)
-		}
-		reply, err := a.TurnStream(context.Background(), userInput, func(d string) {
-			spin.Stop()
-			fmt.Fprint(stdout, d)
-		})
-		spin.Stop()
-		if err != nil {
-			fmt.Fprintf(stderr, "\nocto chat: %v\n", err)
-			return 1
-		}
-		fmt.Fprintln(stdout)
-		if !v.quiet() {
-			printUsageLine(stderr, reply)
-		}
-		return 0
+	// ── Headless one-shot (claude -p) ─────────────────────────────────────────
+	// One agentic turn, then exit. The session is ephemeral — one-shot runs are
+	// not persisted (resuming with -c stays a TUI affordance).
+	replCfg := replConfig{
+		a:          a,
+		session:    agent.NewSession(resolvedModel, *system),
+		noSave:     true,
+		plain:      *plain,
+		verbosity:  resolveVerbosity(*quietFlag, *verboseFlag),
+		stdin:      stdin,
+		stdout:     stdout,
+		stderr:     stderr,
+		skillReg:   skillReg,
+		memStore:   memStore,
+		reader:     replReader,
+		view:       replView,
+		hooks:      hooks.LoadFromEnv(),
+		permEngine: permEngine,
 	}
-
-	reply, err := a.Turn(context.Background(), userInput)
-	if err != nil {
-		fmt.Fprintf(stderr, "octo chat: %v\n", err)
-		return 1
+	if toolsOn {
+		replCfg.tools = tools.DefaultTools()
+		replCfg.executor = toolExecutor
+		replCfg.subAgentMgr = subAgentMgr
 	}
-	fmt.Fprintln(stdout, reply.Content)
-	if !v.quiet() {
-		printUsageLine(stderr, reply)
-	}
-	return 0
+	return runOnce(replCfg, oneShotPrompt, *stream)
 }
 
 // printUsageLine writes a one-line token/cache summary to w when the backend

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -17,23 +17,22 @@ import (
 	"github.com/Leihb/octo-agent/internal/provider"
 )
 
-// TestRunChat_NoArgs_EntersREPL verifies that omitting a message starts the
-// interactive REPL (M3) rather than erroring out (M2 behaviour).
-// We supply an immediate EOF on stdin so the REPL exits without blocking.
-func TestRunChat_NoArgs_EntersREPL(t *testing.T) {
+// TestRunChat_NoArgs_NoStdin_Errors verifies the headless routing: with no
+// positional message and nothing on a non-tty stdin, there's no prompt to run,
+// so octo errors instead of blocking. (A real terminal would drive the TUI;
+// that path can't be unit-tested without a pty.)
+func TestRunChat_NoArgs_NoStdin_Errors(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp) // Windows compat
-	// Fake provider so we don't need a real API key.
 	var stdout, stderr bytes.Buffer
-	// Immediate EOF → REPL reads nothing and exits cleanly.
 	code := runChat(nil, strings.NewReader(""), &stdout, &stderr)
-	if code != 0 {
-		t.Errorf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2; stderr=%q", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Starting session") {
-		t.Errorf("stdout should contain REPL banner; got: %q", stdout.String())
+	if !strings.Contains(stderr.String(), "no prompt") {
+		t.Errorf("stderr should explain there's no prompt; got: %q", stderr.String())
 	}
 }
 
@@ -526,9 +525,11 @@ func TestRunChat_ResumedToolSession_DefaultOnNoWarning(t *testing.T) {
 
 	// Resume with no tool flag at all. Provide immediate EOF so the REPL exits.
 	var stdout, stderr bytes.Buffer
+	// Resume is interactive-only; headless -c errors (exit 2). The point of
+	// this test is the absence of the tools-off warning, which is unaffected.
 	code := runChat([]string{"-c", sess.ID}, strings.NewReader(""), &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	if code != 2 {
+		t.Fatalf("headless -c should error (exit 2); got %d, stderr=%q", code, stderr.String())
 	}
 	if strings.Contains(stderr.String(), "may make the model emit tool calls as text") {
 		t.Errorf("tools-on resume should not warn; got stderr:\n%s", stderr.String())
@@ -556,9 +557,11 @@ func TestRunChat_ResumedToolSession_NoToolsWarns(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
+	// The --no-tools warning fires before the interactive-only resume guard, so
+	// it still reaches stderr even though the headless -c then errors (exit 2).
 	code := runChat([]string{"-c", sess.ID, "--no-tools"}, strings.NewReader(""), &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	if code != 2 {
+		t.Fatalf("headless -c should error (exit 2); got %d, stderr=%q", code, stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "may make the model emit tool calls as text") {
 		t.Errorf("expected --no-tools warning on a tool session; got stderr:\n%s", stderr.String())
@@ -584,8 +587,8 @@ func TestRunChat_ResumedPlainSession_NoWarning(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := runChat([]string{"-c", sess.ID, "--no-tools"}, strings.NewReader(""), &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	if code != 2 {
+		t.Fatalf("headless -c should error (exit 2); got %d, stderr=%q", code, stderr.String())
 	}
 	if strings.Contains(stderr.String(), "may make the model emit tool calls as text") {
 		t.Errorf("plain session should not warn; got stderr:\n%s", stderr.String())

--- a/cmd/octo/lineread.go
+++ b/cmd/octo/lineread.go
@@ -85,29 +85,6 @@ func (s *scannerLineReader) ReadLine(prompt string) (string, bool) {
 func (*scannerLineReader) Interrupted() bool { return false }
 func (*scannerLineReader) Close() error      { return nil }
 
-// seededLineReader returns seed as the result of the first ReadLine call, then
-// delegates to inner for every subsequent call. It lets --prompt-file inject a
-// single multi-line agentic turn: the scanner reader splits a multi-line prompt
-// on '\n' into one turn per line, so a piped issue body would otherwise arrive
-// as dozens of fragmented, low-context turns (the failure mode that crippled
-// the mswe-eval harness). The seed is delivered verbatim — newlines intact.
-type seededLineReader struct {
-	seed  string
-	used  bool
-	inner lineReader
-}
-
-func (s *seededLineReader) ReadLine(prompt string) (string, bool) {
-	if !s.used {
-		s.used = true
-		return s.seed, true
-	}
-	return s.inner.ReadLine(prompt)
-}
-
-func (s *seededLineReader) Interrupted() bool { return s.inner.Interrupted() }
-func (s *seededLineReader) Close() error      { return s.inner.Close() }
-
 // readlineLineReader is the interactive-tty implementation.
 type readlineLineReader struct {
 	rl          *readline.Instance

--- a/cmd/octo/lineread_test.go
+++ b/cmd/octo/lineread_test.go
@@ -40,29 +40,6 @@ func TestScannerLineReader_StripsCarriageReturn(t *testing.T) {
 	}
 }
 
-func TestSeededLineReader_SeedThenDelegates(t *testing.T) {
-	var out bytes.Buffer
-	// A multi-line seed must come back as ONE turn, newlines intact — the whole
-	// point of --prompt-file vs piping the prompt line-by-line.
-	seed := "line one\nline two\nline three"
-	inner := newScannerLineReader(strings.NewReader("next\n"), &out)
-	r := &seededLineReader{seed: seed, inner: inner}
-
-	got, ok := r.ReadLine("> ")
-	if !ok || got != seed {
-		t.Fatalf("first ReadLine = (%q, %v); want the full multi-line seed", got, ok)
-	}
-	// Second call delegates to the inner scanner.
-	got, ok = r.ReadLine("> ")
-	if !ok || got != "next" {
-		t.Fatalf("second ReadLine = (%q, %v); want (\"next\", true) from inner", got, ok)
-	}
-	// Third call hits inner EOF.
-	if _, ok := r.ReadLine(""); ok {
-		t.Errorf("expected EOF from inner after its single line")
-	}
-}
-
 func TestReadPromptLine_SingleLine(t *testing.T) {
 	var out bytes.Buffer
 	r := newScannerLineReader(strings.NewReader("hello\n"), &out)

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -9,7 +9,6 @@ import (
 	"os/signal"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
@@ -60,19 +59,28 @@ func isFirstEverSession() bool {
 	return err == nil && len(sessions) == 0
 }
 
-// runREPL runs the interactive multi-turn loop until the user exits or EOF.
-// It returns 0 on clean exit, 1 on unexpected error.
-func runREPL(cfg replConfig) int {
+// runOnce executes a single agentic turn headlessly, then exits — octo's
+// claude -p-style mode. It backs every non-TUI invocation: a positional
+// message, --prompt-file, or piped stdin. The full tool loop runs (tools are
+// on by default); rendering, the spinner, and permission/Ask prompts all flow
+// through the same plainView the interactive path used. Interactive multi-turn
+// now lives only in the TUI.
+//
+// One-shot does not persist a session (matching the original single-turn mode);
+// resuming with -c stays a TUI-only affordance.
+//
+// stream=true (the default) renders the turn live through the view; stream=false
+// runs the same agentic loop but prints only the final reply text to stdout,
+// keeping it clean for capture (`octo chat --stream=false ... > out`).
+func runOnce(cfg replConfig, prompt string, stream bool) int {
 	a := cfg.a
-	sess := cfg.session
 
-	// Kill any background processes (terminal background:true) on exit so none
-	// outlive the session.
+	// Reap background processes the turn spawned so none outlive the run.
 	defer tools.KillAllBackground()
 
-	// Sub-agent manager: wire the onExit hook so completion notifications ride
-	// the same inbox path as background-process notices. Register the manager
-	// globally so the built-in tools pick it up without per-instance injection.
+	// Sub-agent completions and background-process notices ride the inbox, so a
+	// later iteration of this single agentic turn picks them up (the agent
+	// drains the inbox at the start of each loop step).
 	if cfg.subAgentMgr != nil {
 		tools.SetDefaultSubAgentManager(cfg.subAgentMgr)
 		cfg.subAgentMgr.SetOnExit(func(ev tools.SubAgentNotification) {
@@ -84,274 +92,58 @@ func runREPL(cfg replConfig) int {
 			cfg.subAgentMgr.KillAll()
 		}()
 	}
-
-	// Background-completion notice: inject into the conversation via Inbox so
-	// the model is told when a detached command finishes (drained at the start
-	// of the next loop iteration — see agent.go runLoop).
-	// The plain path prints no async UI line (it would interleave with the
-	// synchronous render loop); the TUI path adds a scrollback notice on top.
 	tools.SetBackgroundOnExit(func(e tools.BgExit) { a.Inbox.Enqueue(formatBgNote(e)) })
 	defer tools.SetBackgroundOnExit(nil)
 
-	// Startup banner — fully suppressed in quiet mode, expanded with
-	// provider/endpoint context in verbose mode. Normal keeps today's two
-	// lines because most users use them to confirm the session ID.
-	if !cfg.verbosity.quiet() {
-		turns := sess.TurnCount()
-		if turns > 0 {
-			fmt.Fprintf(cfg.stdout, "Resumed session %s (%d turn", sess.ID, turns)
-			if turns != 1 {
-				fmt.Fprint(cfg.stdout, "s")
-			}
-			fmt.Fprintln(cfg.stdout, ")")
-		} else {
-			fmt.Fprintf(cfg.stdout, "Starting session %s (%s)\n", sess.ID, sess.Model)
-			// First-ever session: orient the newcomer once. Suppressed for
-			// everyone with prior sessions so it doesn't nag, and only shown
-			// when tools are actually on (it describes the tool surface).
-			if len(cfg.tools) > 0 && isFirstEverSession() {
-				fmt.Fprintln(cfg.stdout, "  Tools are on — I can run shell commands, read/edit files, and search.")
-				fmt.Fprintln(cfg.stdout, "  Risky actions ask for your approval first. Run `octo config` to set defaults.")
-			}
-		}
-		if cfg.verbosity.verbose() {
-			fmt.Fprintf(cfg.stdout, "  model: %s\n", a.Model)
-			if cfg.permEngine != nil {
-				fmt.Fprintf(cfg.stdout, "  permissions: %s\n", cfg.permEngine.GetMode())
-			}
-			if len(cfg.tools) > 0 {
-				fmt.Fprintf(cfg.stdout, "  tools: %d enabled\n", len(cfg.tools))
-			}
-		}
-		fmt.Fprintln(cfg.stdout, `/exit, Ctrl-C, or Ctrl-D to quit.`)
-		fmt.Fprintln(cfg.stdout)
+	// The view sink renders the turn (spinner, streamed text, tool-event lines,
+	// cache/error) and raises Ask prompts. With a TTY reader (a positional
+	// message typed at a terminal) permission prompts are interactive; over a
+	// pipe the reader is exhausted, so plainView auto-denies — the headless
+	// posture.
+	view := cfg.view
+	if view == nil {
+		view = newPlainView(cfg.reader, cfg.stdout, cfg.stderr, cfg.verbosity, cfg.plain)
+	}
+	if cfg.permEngine != nil {
+		a.Gate = &cliPermissionGate{engine: cfg.permEngine, ask: view}
 	}
 
-	// Wrap stdout/stderr in a syncWriter so the input goroutine (which prints
-	// prompts) and the turn-rendering goroutine (which prints replies/events)
-	// don't race on the same underlying writer (e.g. bytes.Buffer in tests).
-	out := cfg.stdout
-	errOut := cfg.stderr
-	if _, ok := cfg.stdout.(*syncWriter); !ok {
-		out = &syncWriter{w: cfg.stdout}
-	}
-	if _, ok := cfg.stderr.(*syncWriter); !ok {
-		errOut = &syncWriter{w: cfg.stderr}
-	}
-	cfg.stdout = out
-	cfg.stderr = errOut
-
-	reader := cfg.reader
-	if reader == nil {
-		reader = newScannerLineReader(cfg.stdin, out)
-	}
-	defer reader.Close()
-
-	// Ctrl-C handling: while a turn is running, SIGINT cancels just that turn
-	// (the loop catches context.Canceled, finalizes well-formed history, and
-	// returns to the prompt). At an idle prompt — no turn in flight — SIGINT
-	// behaviour depends on the reader: readline catches it and returns
-	// ErrInterrupt (we just re-prompt), while scanner mode falls through to
-	// the signal handler which saves and exits.
-	var (
-		turnMu     sync.Mutex
-		turnCancel context.CancelFunc
-	)
-	setTurnCancel := func(c context.CancelFunc) {
-		turnMu.Lock()
-		turnCancel = c
-		turnMu.Unlock()
-	}
+	// SIGINT cancels the in-flight turn; the agent finalizes well-formed history
+	// and runTurn returns context.Canceled, which we treat as a clean stop.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
 	defer signal.Stop(sigCh)
 	go func() {
-		for range sigCh {
-			turnMu.Lock()
-			c := turnCancel
-			turnMu.Unlock()
-			if c != nil {
-				c() // interrupt the in-flight turn; the loop returns to prompt
-				continue
-			}
-			// Idle prompt with the scanner reader (no built-in SIGINT
-			// handling): save and exit. The readline reader catches Ctrl-C
-			// itself (returns ErrInterrupt), so this branch never fires in
-			// interactive mode — its loop just re-prompts on the next pass.
-			if _, ok := reader.(*scannerLineReader); ok {
-				fmt.Fprintln(out, "\n^C")
-				if !cfg.noSave {
-					sess.SyncFrom(a.History)
-					_ = sess.Save()
-				}
-				tools.KillAllBackground()
-				os.Exit(0)
-			}
-		}
+		<-sigCh
+		cancel()
 	}()
 
-	// The view sink: renders the turn (spinner, tool-event lines, cache/^C/
-	// error) and raises Ask prompts. cmd/octo supplies it (so the gate and
-	// asker share the same instance); tests leave it nil and get a plainView
-	// over the resolved reader.
-	view := cfg.view
-	if view == nil {
-		view = newPlainView(reader, out, errOut, cfg.verbosity, cfg.plain)
-	}
-
-	// Permission gating raises its approval prompt through the view (stdin
-	// line in plainView, modal in the TUI). Tool dispatch runs synchronously
-	// inside RunStream, so the prompt and the loop never race on input.
-	if cfg.permEngine != nil {
-		a.Gate = &cliPermissionGate{
-			engine: cfg.permEngine,
-			ask:    view,
-		}
-	}
-
-	// inputCh carries user input lines from the read goroutine to the main
-	// loop. Closed on EOF so the select below exits cleanly.
-	//
-	// The goroutine never prints prompts itself — prompt rendering is the
-	// responsibility of the turn-rendering loop (or the terminal driver for
-	// readline). This avoids a data race between prompt printing and turn
-	// output on the shared stdout (bytes.Buffer in tests).
-	inputCh := make(chan string)
-	go func() {
-		defer close(inputCh)
-		for {
-			// Empty prompt so no output is written to stdout from the
-			// goroutine. readline manages its own terminal; scanner mode
-			// just reads lines without printing a prompt.
-			raw, ok := readPromptLine(reader, "", "")
-			if !ok {
-				if reader.Interrupted() {
-					// Ctrl-C at idle: re-prompt. The readline reader already
-					// cleared the line; just loop back for the next input.
-					continue
-				}
-				// EOF (Ctrl-D) or read error.
-				return
+	// Buffered: run the full agentic loop silently, then print just the final
+	// reply text. Bypasses the live view (and its spinner / tool lines) so
+	// captured stdout carries only the answer.
+	if !stream {
+		reply, err := a.Run(ctx, prompt, cfg.tools, cfg.executor)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return 0
 			}
-			inputCh <- raw
-		}
-	}()
-
-	done := false
-	for !done {
-		var line string
-		var isAutoTurn bool
-
-		// Wait for either user input or a background-completion notice that
-		// arrived while we were idle. The inbox path auto-triggers a turn so
-		// the model can react to the event without the user typing anything.
-		select {
-		case raw, ok := <-inputCh:
-			if !ok {
-				// EOF — input goroutine exited.
-				fmt.Fprintln(cfg.stdout)
-				done = true
-				continue
-			}
-			line = strings.TrimSpace(raw)
-			if line == "" {
-				continue
-			}
-			if line == "/exit" || line == "/quit" {
-				done = true
-				continue
-			}
-		case <-idleInboxWait(a):
-			// Background process finished while idle. Drain the inbox
-			// and run an auto-turn so the model sees the notification.
-			msgs := a.Inbox.Drain()
-			if len(msgs) > 0 {
-				line = strings.Join(msgs, "\n\n")
-				isAutoTurn = true
-			}
-		}
-
-		if line == "" {
-			continue
-		}
-
-		// Regular message — streaming turn (or agentic loop when tools enabled).
-		// Each turn gets its own cancellable context so SIGINT can interrupt
-		// just this turn without tearing down the session. Orchestration
-		// (memory nudge, pre/post hooks, the streaming run) lives in runTurn;
-		// all rendering flows through the view sink.
-		turnCtx, cancelTurn := context.WithCancel(context.Background())
-		setTurnCancel(cancelTurn)
-
-		_, err := runTurn(turnCtx, a, cfg, view, line)
-
-		setTurnCancel(nil)
-		cancelTurn()
-
-		// A hard (non-interrupt) error left history rolled back by the agent;
-		// skip the save and re-prompt. An interrupt (context.Canceled) keeps a
-		// well-formed history, so it falls through to auto-save like a success.
-		if err != nil && !errors.Is(err, context.Canceled) {
-			continue
-		}
-
-		// Auto-save after every turn (including interrupted ones — history is
-		// well-formed) unless opted out.
-		if !cfg.noSave {
-			sess.SyncFrom(a.History)
-			if err := sess.Save(); err != nil {
-				// Non-fatal: warn but don't break the session.
-				fmt.Fprintf(cfg.stderr, "(auto-save failed: %v)\n", err)
-			}
-		}
-
-		// After an auto-turn, briefly yield so the user sees the model's
-		// response before we loop back to waiting for input (or another
-		// steer). This prevents a rapid-fire sequence of auto-turns from
-		// feeling like a wall of text.
-		if isAutoTurn {
-			time.Sleep(100 * time.Millisecond)
-		}
-	}
-
-	// Wait for the input goroutine to finish so we don't leak it on exit.
-	// (It will exit once it sees EOF or the deferred reader.Close() below.)
-	// Drain any remaining input so the goroutine can terminate cleanly.
-	for range inputCh {
-	}
-
-	// Final save on exit.
-	if !cfg.noSave {
-		sess.SyncFrom(a.History)
-		if err := sess.Save(); err != nil {
-			fmt.Fprintf(cfg.stderr, "session save: %v\n", err)
+			fmt.Fprintf(cfg.stderr, "octo chat: %v\n", err)
 			return 1
 		}
+		fmt.Fprintln(cfg.stdout, reply.Content)
 		if !cfg.verbosity.quiet() {
-			path, _ := sess.SavePath()
-			fmt.Fprintf(cfg.stdout, "\nSession saved → %s\n", path)
+			printUsageLine(cfg.stderr, reply)
 		}
+		return 0
+	}
+
+	_, err := runTurn(ctx, a, cfg, view, prompt)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		return 1
 	}
 	return 0
-}
-
-// idleInboxWait returns a channel that receives a single value once a message
-// is pending in the agent's inbox. It polls every 200 ms so the select in
-// runREPL doesn't block indefinitely on user input when a background process
-// completes. The returned channel is closed after firing; callers should not
-// reuse it.
-func idleInboxWait(a *agent.Agent) <-chan struct{} {
-	ch := make(chan struct{}, 1)
-	go func() {
-		for {
-			if a.Inbox.HasPending() {
-				ch <- struct{}{}
-				return
-			}
-			time.Sleep(200 * time.Millisecond)
-		}
-	}()
-	return ch
 }
 
 // printTuiHelp lists the slash commands the TUI supports. Slash commands live

--- a/cmd/octo/repl_test.go
+++ b/cmd/octo/repl_test.go
@@ -63,110 +63,54 @@ func makeREPLFixture(t *testing.T, input string) (replConfig, *bytes.Buffer, *by
 	return cfg, &stdout, &stderr, stub
 }
 
-func TestREPL_SingleTurn(t *testing.T) {
-	cfg, stdout, stderr, stub := makeREPLFixture(t, "ping\n/exit\n")
+func TestRunOnce_AgenticTurn(t *testing.T) {
+	cfg, stdout, stderr, stub := makeREPLFixture(t, "")
 
-	code := runREPL(cfg)
+	code := runOnce(cfg, "ping", true)
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr: %s", code, stderr.String())
 	}
 	if stub.called != 1 {
 		t.Errorf("Sender called %d times, want 1", stub.called)
 	}
-	out := stdout.String()
-	if !strings.Contains(out, "pong") {
+	if out := stdout.String(); !strings.Contains(out, "pong") {
 		t.Errorf("stdout does not contain reply %q:\n%s", "pong", out)
 	}
 }
 
-func TestREPL_MultiTurn(t *testing.T) {
-	cfg, _, stderr, stub := makeREPLFixture(t, "one\ntwo\nthree\n/exit\n")
+func TestRunOnce_BufferedPrintsFinalText(t *testing.T) {
+	cfg, stdout, stderr, stub := makeREPLFixture(t, "")
 
-	code := runREPL(cfg)
+	code := runOnce(cfg, "ping", false) // --stream=false
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr: %s", code, stderr.String())
 	}
-	if stub.called != 3 {
-		t.Errorf("Sender called %d times, want 3", stub.called)
-	}
-}
-
-func TestREPL_EmptyLineSkipped(t *testing.T) {
-	cfg, _, _, stub := makeREPLFixture(t, "\n\nhello\n/exit\n")
-
-	runREPL(cfg)
 	if stub.called != 1 {
-		t.Errorf("Sender called %d times, want 1 (empty lines must be skipped)", stub.called)
+		t.Errorf("Sender called %d times, want 1", stub.called)
+	}
+	if out := stdout.String(); !strings.Contains(out, "pong") {
+		t.Errorf("buffered stdout does not contain reply %q:\n%s", "pong", out)
 	}
 }
 
-// Slash commands (/help, /cost, /save, unknown-command handling, skill
-// triggers) now live exclusively in the TUI — see dispatchSlash and its tests
-// in tuirepl_slash_test.go. The plain REPL keeps only /exit (+ /quit alias),
-// covered by the conversation-loop tests above.
+func TestRunOnce_DoesNotPersistSession(t *testing.T) {
+	cfg, stdout, _, _ := makeREPLFixture(t, "")
 
-func TestREPL_PlainSlashIsJustText(t *testing.T) {
-	// In the plain REPL every leading-"/" line except /exit is ordinary message
-	// text, so it reaches the model rather than being intercepted.
-	cfg, _, _, stub := makeREPLFixture(t, "/cost\n/exit\n")
-
-	runREPL(cfg)
-	if stub.called != 1 {
-		t.Errorf("Sender called %d times; /cost should be sent as a message in plain mode, want 1", stub.called)
-	}
-}
-
-func TestREPL_EOFExitsCleanly(t *testing.T) {
-	cfg, _, stderr, _ := makeREPLFixture(t, "") // EOF immediately
-
-	code := runREPL(cfg)
-	if code != 0 {
-		t.Fatalf("EOF exit code = %d, stderr: %s", code, stderr.String())
-	}
-}
-
-func TestREPL_NoSave(t *testing.T) {
-	cfg, stdout, _, _ := makeREPLFixture(t, "hi\n/exit\n")
-	cfg.noSave = true
-
-	runREPL(cfg)
+	runOnce(cfg, "hi", true)
+	// One-shot never persists — no save banner, and no session file under the
+	// temp HOME the fixture redirected to.
 	if strings.Contains(stdout.String(), "Session saved") {
-		t.Error("expected no save message with --no-save")
+		t.Error("one-shot must not print a save banner")
+	}
+	if sessions, err := agent.ListSessions(10); err == nil && len(sessions) != 0 {
+		t.Errorf("one-shot must not write a session file; found %d", len(sessions))
 	}
 }
 
-func TestREPL_AutoSaveAfterTurn(t *testing.T) {
-	cfg, _, stderr, _ := makeREPLFixture(t, "hi\n/exit\n")
-
-	code := runREPL(cfg)
-	if code != 0 {
-		t.Fatalf("exit code = %d, stderr: %s", code, stderr.String())
-	}
-	// If auto-save failed it writes to stderr.
-	if strings.Contains(stderr.String(), "auto-save failed") {
-		t.Errorf("auto-save failed: %s", stderr.String())
-	}
-}
-
-func TestREPL_ResumedSessionShowsTurnCount(t *testing.T) {
-	cfg, stdout, stderr, _ := makeREPLFixture(t, "/exit\n")
-	// Pre-populate two turns in history to simulate a resumed session.
-	cfg.a.History.Append(agent.NewUserMessage("old q"))
-	cfg.a.History.Append(agent.NewAssistantMessage("old a"))
-	cfg.session.SyncFrom(cfg.a.History)
-
-	code := runREPL(cfg)
-	if code != 0 {
-		t.Fatalf("exit code = %d, stderr: %s", code, stderr.String())
-	}
-	out := stdout.String()
-	if !strings.Contains(out, "Resumed") {
-		t.Errorf("expected 'Resumed' in output:\n%s", out)
-	}
-	if !strings.Contains(out, "1 turn") {
-		t.Errorf("expected '1 turn' in output:\n%s", out)
-	}
-}
+// Multi-turn, EOF handling, the resumed-session banner, and slash-as-text were
+// behaviours of the interactive plain REPL, which no longer exists: an
+// interactive terminal always drives the TUI, and every headless invocation is
+// a single agentic turn via runOnce. Resume (-c) is now a TUI-only affordance.
 
 // ─── replToolEventHandler tests ─────────────────────────────────────────────
 
@@ -412,39 +356,21 @@ func TestREPLToolEventHandler_PlainForcesEditFileToStatusLine(t *testing.T) {
 	}
 }
 
-func TestREPL_QuietMode_SuppressesChrome(t *testing.T) {
-	cfg, stdout, _, _ := makeREPLFixture(t, "ping\n/exit\n")
+func TestRunOnce_QuietMode_SuppressesChrome(t *testing.T) {
+	cfg, stdout, _, _ := makeREPLFixture(t, "")
 	cfg.verbosity = verbosityQuiet
 
-	if code := runREPL(cfg); code != 0 {
+	if code := runOnce(cfg, "ping", true); code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
 	out := stdout.String()
-	// Quiet mode strips: the "Starting session ..." banner, the "to quit"
-	// hint, and the "Session saved → ..." footer. The model reply itself
-	// must still come through (otherwise quiet would be useless).
-	for _, banned := range []string{"Starting session", "to quit", "Session saved"} {
-		if strings.Contains(out, banned) {
-			t.Errorf("quiet mode should not emit %q:\n%s", banned, out)
-		}
+	// Quiet strips the end-of-turn cache line; the model reply itself must
+	// still come through (otherwise quiet would be useless).
+	if strings.Contains(out, "ⓘ cache") {
+		t.Errorf("quiet mode should not emit the cache line:\n%s", out)
 	}
 	if !strings.Contains(out, "pong") {
 		t.Errorf("quiet mode must still print the model reply; got:\n%s", out)
-	}
-}
-
-func TestREPL_VerboseMode_PrintsModelAndHints(t *testing.T) {
-	cfg, stdout, _, _ := makeREPLFixture(t, "ping\n/exit\n")
-	cfg.verbosity = verbosityVerbose
-
-	if code := runREPL(cfg); code != 0 {
-		t.Fatalf("exit = %d", code)
-	}
-	out := stdout.String()
-	// Verbose mode adds a `model:` line under the banner. permissions/tools
-	// lines only render when configured (not in this fixture).
-	if !strings.Contains(out, "model: test-model") {
-		t.Errorf("verbose mode should print model line; got:\n%s", out)
 	}
 }
 
@@ -500,7 +426,7 @@ func TestREPL_MemoryNudge_AppendedWhenMemoryAndToolsActive(t *testing.T) {
 		tools:    []agent.ToolDefinition{{Name: "dummy", Description: "x", Parameters: map[string]any{"type": "object"}}},
 		executor: dummyExecutor{},
 	}
-	if code := runREPL(cfg); code != 0 {
+	if code := runOnce(cfg, "hi", true); code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
 	}
 	got := cap.lastUserContent()
@@ -531,7 +457,7 @@ func TestREPL_MemoryNudge_AbsentWhenMemoryDisabled(t *testing.T) {
 		tools:    []agent.ToolDefinition{{Name: "dummy", Description: "x", Parameters: map[string]any{"type": "object"}}},
 		executor: dummyExecutor{},
 	}
-	if code := runREPL(cfg); code != 0 {
+	if code := runOnce(cfg, "hi", true); code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
 	if got := cap.lastUserContent(); strings.Contains(got, "Memory hygiene check") {
@@ -560,7 +486,7 @@ func TestREPL_MemoryNudge_AbsentWhenToolsOff(t *testing.T) {
 		// tools empty: the remember tool can't be called, so the nudge
 		// is pointless and should be omitted.
 	}
-	if code := runREPL(cfg); code != 0 {
+	if code := runOnce(cfg, "hi", true); code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
 	if got := cap.lastUserContent(); strings.Contains(got, "Memory hygiene check") {

--- a/dev-docs/headless-oneshot.md
+++ b/dev-docs/headless-oneshot.md
@@ -1,0 +1,58 @@
+# Headless one-shot & the two REPL surfaces
+
+`octo chat` has exactly two front-ends over one agent core:
+
+- **Interactive TUI** — an interactive terminal drives the bubbletea TUI
+  (`runTUI`). This is the only multi-turn, interactive surface.
+- **Headless one-shot** — everything else runs a single agentic turn and exits
+  (`runOnce`), à la `claude -p`. The full tool loop runs; tools are on by
+  default.
+
+There is no interactive plain line-REPL: if you're at a terminal you get the
+TUI, and if you're not you get a one-shot.
+
+## Routing
+
+```
+useTUI := noPositionalMessage && stdinIsTTY && !--no-tui && !OCTO_TUI=0 && no --prompt-file
+```
+
+`useTUI` true → `runTUI`. Otherwise → `runOnce`, with the prompt resolved in
+order:
+
+1. positional message — `octo chat "fix the build"`
+2. `--prompt-file <path>` — the file's contents, newlines intact
+3. all of piped stdin — `echo "..." | octo chat`, `octo chat < issue.txt`
+
+No prompt source → an error (octo never blocks reading a tty for a headless
+run). `--no-tui` / `OCTO_TUI=0` force the one-shot path even on a terminal.
+
+## What the one-shot shares with the TUI
+
+Both build the same agentic context — built-in tools, MCP servers, the
+sub-agent dispatcher, the permission engine, skills, and the session-start
+memory injection — and both execute through `runTurn`, so memory nudges and
+pre/post hooks fire identically. They differ only in shell:
+
+- The TUI renders live cards and owns its own input; it persists the session
+  and supports `-c`/`--continue` resume and slash commands.
+- The one-shot renders through `plainView` (streamed text + terse `↳` tool
+  lines), does not persist a session, and exits after one turn. Permission /
+  Ask prompts are interactive when stdin is a tty (a message typed at a
+  terminal) and auto-deny when stdin is a consumed pipe — the headless posture.
+
+`--stream=false` runs the same agentic loop but prints only the final reply
+text, keeping captured stdout clean.
+
+Memory consolidation (the boundary-summary pass) runs only in the TUI, so a
+headless run stays deterministic and fast.
+
+## Why
+
+The TUI is hostile to pipes, tests, CI, and eval harnesses: it grabs stdin,
+emits escape sequences, and repaints. Headless consumers need a clean,
+scriptable, single-shot surface. Folding the old tool-less single-turn mode and
+the old line-per-turn piped REPL into one agentic one-shot removed a footgun
+(piping a multi-line prompt used to be shredded into one turn per line) and gave
+`octo chat "msg"` the full tool loop. mswe-eval drives this path via
+`--prompt-file`.


### PR DESCRIPTION
## What

`octo chat` now has exactly two front-ends over one agent core:

| Invocation | Surface |
|---|---|
| `octo chat` at a terminal | **bubbletea TUI** (the only interactive, multi-turn mode) |
| `octo chat "fix the build"` | **headless one-shot** — one agentic turn, then exit |
| `echo "…" \| octo chat`, `octo chat < issue.txt` | one-shot, prompt = all of stdin |
| `octo chat --prompt-file p` | one-shot, prompt = file contents |
| `--no-tui` / `OCTO_TUI=0` | force the one-shot path on a terminal |

This is octo's `claude -p`. The full tool loop runs; tools are on by default.

## Why

Two awkward modes are gone:
- **Tool-less single-turn** — `octo chat "msg"` used to do one plain model round-trip and **never executed tools**. Now it runs the agentic loop.
- **Interactive plain line-REPL** + **piped line-per-turn** — the latter shredded a multi-line piped prompt into dozens of fragmented turns (the footgun mswe-eval worked around with `--prompt-file`).

If you're at a terminal you get the TUI; if you're not, you get a clean, scriptable one-shot.

## Behaviour notes
- Prompt resolution: positional message → `--prompt-file` → piped stdin. No source → error (octo never blocks reading a tty headlessly).
- Resume (`-c`) is TUI-only; headless `-c` errors with guidance.
- One-shot does **not** persist a session (matches the old single-turn). 
- `--stream=false` runs the same agentic loop but prints only the final reply text (clean for capture).
- Both surfaces share the agentic context (tools, MCP, sub-agents, permission engine, skills, memory injection) and run through `runTurn`, so memory nudges + hooks fire identically. Boundary-memory consolidation runs only in the TUI, keeping headless deterministic.
- Permission/Ask prompts are interactive when stdin is a tty (a message typed at a terminal) and auto-deny over a consumed pipe.

## Cleanup
Deletes `runREPL`, `idleInboxWait`, and the now-unused `seededLineReader`. **mswe-eval** already drove `--prompt-file` + empty stdin, so it works unchanged (stale comments refreshed). Net **−269 lines**.

Design: `dev-docs/headless-oneshot.md`.

## Tests
- `TestRunOnce_AgenticTurn` / `TestRunOnce_BufferedPrintsFinalText` / `TestRunOnce_DoesNotPersistSession` / `TestRunOnce_QuietMode_SuppressesChrome`
- `TestRunChat_NoArgs_NoStdin_Errors`, resume-guard coverage in the three `TestRunChat_Resumed*` tests
- Memory-nudge tests converted to `runOnce`
- Smoke-tested routing (no-prompt, headless `-c`, `--no-tui`) on the built binary.

`go build ./...`, `go vet ./...`, `gofmt -l`, `go test -race ./...` (22 pkgs) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)