### PR TITLE
build: derive dev version from version.go so make build matches the tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,17 @@ GOFLAGS ?=
 
 # Inject version + commit at build time so `octo version` reports a real SHA.
 #
-# Auto-detection via `git describe` is intentionally avoided here because the
-# repo still carries Ruby-era tags (v0.11.2, v0.11.2-final-ruby) that would
-# pollute the reported version. Dev builds say "<next>-dev"; release builds
-# should set VERSION explicitly:
+# Auto-detection via `git describe` is intentionally avoided because the repo
+# still carries Ruby-era tags (v0.11.2, v0.11.2-final-ruby) that would pollute
+# the reported version. The single source of truth for the version number is
+# internal/version/version.go (what release bumps already edit); dev builds
+# derive "<that>-dev" from it, so the two never drift. Release builds set
+# VERSION explicitly:
 #
-#   VERSION=0.6.0 make build
+#   VERSION=0.12.0 make build
 #
-VERSION ?= 0.6.0-dev
+BASE_VERSION := $(shell sed -n 's/^var Version = "\(.*\)"/\1/p' internal/version/version.go)
+VERSION ?= $(BASE_VERSION)-dev
 COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 LDFLAGS := -X github.com/Leihb/octo-agent/internal/version.Version=$(VERSION) \
            -X github.com/Leihb/octo-agent/internal/version.Commit=$(COMMIT)


### PR DESCRIPTION
## Problem

`make build` reported **0.6.0-dev** while `go build` / `go install` and the latest tag both say **0.12.0**.

Cause: two version sources drifted. Release "Bump version" PRs only edit `internal/version/version.go` (e.g. #289 → `var Version = "0.12.0"`), but the Makefile had a separately hand-maintained `VERSION ?= 0.6.0-dev` that nobody updated since the 0.6 era.

## Fix

Make `internal/version/version.go` the single source of truth. The Makefile now derives `<that>-dev` from it via `sed`, so a version bump carries the dev build along automatically — no second place to update, no future drift. Release builds still override explicitly (`VERSION=0.12.0 make build`). `git describe` is still avoided (Ruby-era tags would pollute it).

Verified:
- `make build` → `octo 0.12.0-dev (8abf043)`
- `VERSION=0.12.0 make build` → `octo 0.12.0 (8abf043)`

Makefile-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)