### PR TITLE
feat(tui): slash-command completion menu (commands + skills)

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -159,6 +159,9 @@ func printTuiHelp(w io.Writer) {
 	fmt.Fprintln(w, "  /mcp        Show connected MCP servers and their surfaces")
 	fmt.Fprintln(w, "  /goal       Plan + run a goal as a task DAG (also: /goal list, /goal resume <id>)")
 	fmt.Fprintln(w, "  /exit       Save and exit  (also: /quit, Ctrl-C, Ctrl-D)")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Type / to open the completion menu (Tab/↑↓ select, Enter complete) — it lists")
+	fmt.Fprintln(w, "every command and skill, so you don't have to remember names.")
 }
 
 // printMemory shows what cross-session memory looks like: active entries

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -217,6 +217,13 @@ type tuiModel struct {
 	// started browsing history with ↑, so ↓ can restore it.
 	inputDraft string
 
+	// Slash-command completion menu. complItems is the current filtered
+	// candidate set (built-in commands + skills); non-empty means the menu is
+	// open. complIdx is the highlighted row. Recomputed on every keystroke when
+	// the input is a bare "/command" token (see updateCompletion).
+	complItems []complItem
+	complIdx   int
+
 	// turnRunning is true between starting a turn and turnFinishedMsg.
 	turnRunning bool
 	cancelTurn  context.CancelFunc

--- a/cmd/octo/tuirepl_completion.go
+++ b/cmd/octo/tuirepl_completion.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// complItem is one row in the slash-command completion menu.
+type complItem struct {
+	name string // the trigger, e.g. "/skills" or "/review"
+	desc string // one-line description shown to the right
+}
+
+// maxComplVisible caps how many completion rows render at once; the list
+// scrolls around the selection beyond that.
+const maxComplVisible = 10
+
+// builtinSlashCommands are the always-available TUI slash commands, in display
+// order. Skills are appended after these by slashCandidates.
+var builtinSlashCommands = []complItem{
+	{"/help", "List commands and tools"},
+	{"/skills", "List discovered skills"},
+	{"/mcp", "List connected MCP servers"},
+	{"/memory", "Show cross-session memory"},
+	{"/goal", "Plan + run a goal as a task DAG"},
+	{"/init", "Generate a .octorules guide for this repo"},
+	{"/save", "Save the current session"},
+	{"/sessions", "List recent sessions"},
+	{"/exit", "Quit octo"},
+}
+
+// slashCandidates returns every completable slash command: the built-ins plus
+// one "/<name>" entry per discovered skill.
+func (m *tuiModel) slashCandidates() []complItem {
+	items := make([]complItem, 0, len(builtinSlashCommands)+16)
+	items = append(items, builtinSlashCommands...)
+	if m.cfg.skillReg != nil {
+		for _, s := range m.cfg.skillReg.List() {
+			items = append(items, complItem{name: "/" + s.Name, desc: s.Description})
+		}
+	}
+	return items
+}
+
+// updateCompletion (re)computes the menu from the current input. It opens the
+// menu when the input is a bare "/command" token (a leading slash, no
+// whitespace yet) and the session is idle; otherwise it closes the menu.
+// complIdx is clamped but not reset here — callers reset it on a fresh edit.
+func (m *tuiModel) updateCompletion() {
+	v := m.ta.Value()
+	if m.turnRunning || !strings.HasPrefix(v, "/") || strings.ContainsAny(v, " \t\n") {
+		m.complItems = nil
+		return
+	}
+	prefix := strings.ToLower(v)
+	var matches []complItem
+	for _, c := range m.slashCandidates() {
+		if strings.HasPrefix(strings.ToLower(c.name), prefix) {
+			matches = append(matches, c)
+		}
+	}
+	m.complItems = matches
+	if m.complIdx >= len(matches) {
+		m.complIdx = 0
+	}
+}
+
+// acceptCompletion fills the input with the highlighted command plus a trailing
+// space (so the user can type args or press Enter to run) and closes the menu.
+func (m *tuiModel) acceptCompletion() {
+	if m.complIdx < 0 || m.complIdx >= len(m.complItems) {
+		return
+	}
+	m.ta.SetValue(m.complItems[m.complIdx].name + " ")
+	m.ta.CursorEnd()
+	m.complItems = nil
+}
+
+// complWindow returns the [start,end) slice of complItems to render, scrolled so
+// the selection stays visible.
+func (m *tuiModel) complWindow() (start, end int) {
+	n := len(m.complItems)
+	if n <= maxComplVisible {
+		return 0, n
+	}
+	start = m.complIdx - maxComplVisible/2
+	if start < 0 {
+		start = 0
+	}
+	if start > n-maxComplVisible {
+		start = n - maxComplVisible
+	}
+	return start, start + maxComplVisible
+}
+
+// completionHeight is the row count completionView occupies, so liveHeight can
+// reserve space in the inline layout.
+func (m *tuiModel) completionHeight() int {
+	if len(m.complItems) == 0 {
+		return 0
+	}
+	start, end := m.complWindow()
+	return (end - start) + 1 // rows + the hint line
+}
+
+// completionView renders the menu: one row per candidate (name + description),
+// the selection marked, and a key-hint footer.
+func (m *tuiModel) completionView() string {
+	if len(m.complItems) == 0 {
+		return ""
+	}
+	start, end := m.complWindow()
+	var b strings.Builder
+	for i := start; i < end; i++ {
+		it := m.complItems[i]
+		name := fmt.Sprintf("%-20s", it.name)
+		if i == m.complIdx {
+			b.WriteString(complSelStyle.Render("▸ "+name) + " " + hintStyle.Render(truncate1Line(it.desc)))
+		} else {
+			b.WriteString("  " + complNameStyle.Render(name) + " " + hintStyle.Render(truncate1Line(it.desc)))
+		}
+		b.WriteByte('\n')
+	}
+	hint := "Tab/↑↓ select · Enter complete · Esc dismiss"
+	if n := len(m.complItems); n > maxComplVisible {
+		hint = fmt.Sprintf("…%d more · %s", n-maxComplVisible, hint)
+	}
+	b.WriteString(hintStyle.Render("  " + hint))
+	b.WriteByte('\n')
+	return b.String()
+}

--- a/cmd/octo/tuirepl_completion_test.go
+++ b/cmd/octo/tuirepl_completion_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// setInputAndComplete mirrors what a keystroke does: set the value, reset the
+// selection, and re-filter the menu.
+func setInputAndComplete(m *tuiModel, s string) {
+	m.ta.SetValue(s)
+	m.ta.CursorEnd()
+	m.complIdx = 0
+	m.updateCompletion()
+}
+
+func complNames(m *tuiModel) []string {
+	out := make([]string, len(m.complItems))
+	for i, it := range m.complItems {
+		out[i] = it.name
+	}
+	return out
+}
+
+func TestCompletion_BareSlashListsAllBuiltins(t *testing.T) {
+	m := newTestModel()
+	setInputAndComplete(m, "/")
+	if len(m.complItems) != len(builtinSlashCommands) {
+		t.Fatalf("bare / should list all %d built-ins; got %d (%v)",
+			len(builtinSlashCommands), len(m.complItems), complNames(m))
+	}
+	got := strings.Join(complNames(m), " ")
+	for _, want := range []string{"/help", "/skills", "/mcp"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("menu missing %s; got %s", want, got)
+		}
+	}
+}
+
+func TestCompletion_PrefixFilters(t *testing.T) {
+	m := newTestModel()
+	setInputAndComplete(m, "/s")
+	// Built-ins starting with /s: /skills, /save, /sessions.
+	if got := complNames(m); len(got) != 3 {
+		t.Fatalf("/s should match /skills /save /sessions; got %v", got)
+	}
+	setInputAndComplete(m, "/me")
+	if got := complNames(m); len(got) != 1 || got[0] != "/memory" {
+		t.Errorf("/me should match only /memory; got %v", got)
+	}
+}
+
+func TestCompletion_ClosedConditions(t *testing.T) {
+	m := newTestModel()
+
+	setInputAndComplete(m, "/help ") // trailing space → command token finished
+	if m.complItems != nil {
+		t.Errorf("menu should close once a space is typed; got %v", complNames(m))
+	}
+	setInputAndComplete(m, "hello") // no leading slash
+	if m.complItems != nil {
+		t.Errorf("menu should be closed for non-slash input; got %v", complNames(m))
+	}
+	m.turnRunning = true
+	setInputAndComplete(m, "/")
+	if m.complItems != nil {
+		t.Errorf("menu should stay closed while a turn runs; got %v", complNames(m))
+	}
+}
+
+func TestCompletion_IncludesSkills(t *testing.T) {
+	m := newTestModel()
+	m.cfg.skillReg = skillRegFor(t, map[string]string{
+		"review": "---\nname: review\ndescription: Review the current diff\n---\nbody",
+	})
+	setInputAndComplete(m, "/rev")
+	if got := complNames(m); len(got) != 1 || got[0] != "/review" {
+		t.Fatalf("/rev should match the /review skill; got %v", got)
+	}
+	if m.complItems[0].desc != "Review the current diff" {
+		t.Errorf("skill description = %q", m.complItems[0].desc)
+	}
+}
+
+func TestCompletion_ViewRendersMenuAndHint(t *testing.T) {
+	m := newTestModel()
+	m.width = 80
+	setInputAndComplete(m, "/sk")
+	out := m.View()
+	if !strings.Contains(out, "/skills") {
+		t.Errorf("View should render the matching command; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Enter complete") {
+		t.Errorf("View should render the completion key hint; got:\n%s", out)
+	}
+	if h := m.completionHeight(); h != 2 { // 1 row + hint line
+		t.Errorf("completionHeight for one match = %d, want 2", h)
+	}
+}
+
+func TestCompletion_NavigationCycles(t *testing.T) {
+	m := newTestModel()
+	setInputAndComplete(m, "/s") // 3 matches, idx 0
+	if len(m.complItems) != 3 {
+		t.Fatalf("setup: want 3 matches, got %d", len(m.complItems))
+	}
+	tab := func() { m.handleKey(tea.KeyMsg{Type: tea.KeyTab}) }
+	tab()
+	if m.complIdx != 1 {
+		t.Errorf("Tab → idx 1, got %d", m.complIdx)
+	}
+	tab()
+	tab() // 2 → 0 (cycle)
+	if m.complIdx != 0 {
+		t.Errorf("Tab should cycle back to 0; got %d", m.complIdx)
+	}
+	m.handleKey(tea.KeyMsg{Type: tea.KeyUp}) // 0 → 2 (wrap up)
+	if m.complIdx != 2 {
+		t.Errorf("Up should wrap to last (2); got %d", m.complIdx)
+	}
+}
+
+func TestCompletion_EnterAcceptsWithoutSubmitting(t *testing.T) {
+	m := newTestModel()
+	setInputAndComplete(m, "/sk") // → /skills, idx 0
+	if len(m.complItems) == 0 {
+		t.Fatal("setup: expected an open menu")
+	}
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.turnRunning {
+		t.Error("Enter on an open menu must accept the completion, not start a turn")
+	}
+	if got := m.ta.Value(); got != "/skills " {
+		t.Errorf("accepted value = %q, want %q", got, "/skills ")
+	}
+	if m.complItems != nil {
+		t.Error("menu should close after accepting")
+	}
+}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -35,11 +35,35 @@ var (
 	hintStyle         = lipgloss.NewStyle().Foreground(tui.ColDimmer).Italic(true)
 	userEchoStyle     = lipgloss.NewStyle().Foreground(tui.ColUserMsg).Bold(true)
 	pendingSteerStyle = lipgloss.NewStyle().Foreground(tui.ColMuted)
+	complSelStyle     = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	complNameStyle    = lipgloss.NewStyle().Foreground(tui.ColAccent)
 )
 
 func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.modal != nil {
 		return m.handleModalKey(msg)
+	}
+
+	// Slash-command completion menu owns Tab/↑/↓/Enter/Esc while it's open, so
+	// it can navigate and accept without those keys reaching history nav or
+	// submit. Plain typing falls through and re-filters the menu below.
+	if len(m.complItems) > 0 {
+		switch msg.Type {
+		case tea.KeyTab, tea.KeyDown:
+			m.complIdx = (m.complIdx + 1) % len(m.complItems)
+			return m, nil
+		case tea.KeyUp:
+			m.complIdx = (m.complIdx - 1 + len(m.complItems)) % len(m.complItems)
+			return m, nil
+		case tea.KeyEnter:
+			if !msg.Alt {
+				m.acceptCompletion()
+				return m, m.updateTextAreaHeight()
+			}
+		case tea.KeyEsc:
+			m.complItems = nil
+			return m, nil
+		}
 	}
 
 	switch msg.Type {
@@ -176,6 +200,9 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// is handled by bubbles/textarea.
 	var cmd tea.Cmd
 	m.ta, cmd = m.ta.Update(msg)
+	// A fresh edit re-filters the slash-completion menu from the top.
+	m.complIdx = 0
+	m.updateCompletion()
 	if hcmd := m.updateTextAreaHeight(); hcmd != nil {
 		cmd = tea.Batch(cmd, hcmd)
 	}
@@ -415,7 +442,8 @@ func (m *tuiModel) liveHeight() int {
 	if bg := tools.RunningBackground(); len(bg) > 0 {
 		h += 3 + len(bg) // panel border (2) + title (1) + body lines
 	}
-	h += m.ta.Height() // input box (textarea grows with content)
+	h += m.completionHeight() // slash-completion menu (0 when closed)
+	h += m.ta.Height()        // input box (textarea grows with content)
 	if m.turnRunning {
 		h += 3 // status bar with hint: separator + segments + hint
 	} else {
@@ -493,6 +521,9 @@ func (m *tuiModel) View() string {
 			b.WriteByte('\n')
 		}
 	}
+
+	// Slash-command completion menu, right above the input box (Claude Code style).
+	b.WriteString(m.completionView())
 
 	// Input box + status bar
 	b.WriteString(m.renderInputBox())


### PR DESCRIPTION
## What

Typing `/` in the TUI now opens a **completion menu** listing every built-in slash command and every discovered **skill** (with descriptions), filtered by prefix as you type.

```
▸ /skills              List discovered skills
  /save                Save the current session
  /sessions            List recent sessions
  Tab/↑↓ select · Enter complete · Esc dismiss
> /s
```

- **Tab / ↑ / ↓** — move the selection (cycles)
- **Enter** — complete the highlighted entry into the input as `/name ` (ready for args, or a second Enter to run); does **not** auto-submit
- **Esc** — dismiss the menu (input kept)

Solves the "no completion, no list hint" pain — especially for **skills**, where there can be dozens and nobody remembers the exact names.

## Behaviour
- Opens only on a bare `/command` token (leading slash, no whitespace) while idle; re-filters on each keystroke; closes once you type a space or clear the slash.
- Renders right above the input box (Claude Code style) and is counted in `liveHeight` so the inline layout reserves its rows. Scrolls around the selection past 10 entries.
- `/help` now points users at it.

## Scope
Built-in commands + skills (per the agreed scope). MCP prompts aren't slash-invokable today, so they're out of scope here — a possible follow-up (`/mcp__server__prompt`).

## Tests
`tuirepl_completion_test.go`: bare-slash lists all built-ins, prefix filtering, closed-conditions (space / non-slash / turn running), skills included, Tab/↑↓ cycling, Enter-accepts-without-submitting, and a View render assertion. `go test -race ./...` (22 pkgs), `go vet`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)