### PR TITLE
feat(skills): tell the model the skill dir so bundled references resolve

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -288,12 +288,11 @@ func skillTrigger(reg *skills.Registry, line string) (skills.Skill, string, bool
 }
 
 // inlineSkill builds the turn input for an explicit /<name> trigger: the skill
-// body, optionally followed by the user's trailing arguments.
-func inlineSkill(body, args string) string {
-	if args == "" {
-		return body
-	}
-	return body + "\n\nUser input: " + args
+// rendered with its directory header (so referenced files resolve) plus any
+// trailing user arguments. Same text the `skill` tool returns for a
+// model-initiated load — see skills.RenderSkill.
+func inlineSkill(s skills.Skill, args string) string {
+	return skills.RenderSkill(s, args)
 }
 
 // printSkills lists the discovered skills, or a hint when there are none.

--- a/cmd/octo/skill_repl_test.go
+++ b/cmd/octo/skill_repl_test.go
@@ -60,11 +60,19 @@ func TestSkillTrigger(t *testing.T) {
 }
 
 func TestInlineSkill(t *testing.T) {
-	if got := inlineSkill("BODY", ""); got != "BODY" {
+	// No Dir → no location header, so the bare body (matching the old behaviour).
+	plain := skills.Skill{Body: "BODY"}
+	if got := inlineSkill(plain, ""); got != "BODY" {
 		t.Errorf("no args → %q", got)
 	}
-	if got := inlineSkill("BODY", "x"); got != "BODY\n\nUser input: x" {
+	if got := inlineSkill(plain, "x"); got != "BODY\n\nUser input: x" {
 		t.Errorf("with args → %q", got)
+	}
+	// With Dir → the directory header is prefixed so referenced files resolve.
+	withDir := skills.Skill{Name: "review", Body: "BODY", Dir: "/abs/skills/review"}
+	got := inlineSkill(withDir, "")
+	if !strings.Contains(got, "/abs/skills/review") || !strings.Contains(got, "BODY") {
+		t.Errorf("expected dir header + body; got:\n%s", got)
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -262,7 +262,7 @@ func (m *tuiModel) dispatchSlash(text string) (tea.Model, tea.Cmd) {
 		if args != "" {
 			echo += " " + args
 		}
-		return m, m.startTurnEcho(inlineSkill(s.Body, args), echo)
+		return m, m.startTurnEcho(inlineSkill(s, args), echo)
 	}
 
 	first := strings.Fields(text)[0]

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -206,3 +206,24 @@ func RenderManifest(r *Registry) string {
 	}
 	return strings.TrimRight(b.String(), "\n")
 }
+
+// RenderSkill produces the text handed to the model when a skill is loaded —
+// via the `skill` tool (model-initiated) or a /<name> trigger (user-initiated).
+// It prefixes a one-line location header so the model can resolve files the
+// SKILL.md references (scripts, templates, reference docs bundled in the skill
+// directory) with its file tools, then the body, then any trailing user args.
+// Without the header a relative reference like "see references/api.md" would be
+// resolved against the project cwd and miss.
+func RenderSkill(s Skill, args string) string {
+	var b strings.Builder
+	if s.Dir != "" {
+		fmt.Fprintf(&b, "[skill %q — bundled files live in: %s\n", s.Name, s.Dir)
+		b.WriteString("Resolve any paths this skill references (scripts, templates, reference docs) " +
+			"against that directory and read them with your file tools.]\n\n")
+	}
+	b.WriteString(s.Body)
+	if args != "" {
+		b.WriteString("\n\nUser input: " + args)
+	}
+	return b.String()
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -172,3 +172,25 @@ func TestRenderManifest(t *testing.T) {
 		t.Errorf("manifest missing skill line:\n%s", m)
 	}
 }
+
+func TestRenderSkill(t *testing.T) {
+	// No Dir → bare body (and trailing args when given).
+	plain := Skill{Name: "x", Body: "DO THE THING"}
+	if got := RenderSkill(plain, ""); got != "DO THE THING" {
+		t.Errorf("no dir, no args → %q", got)
+	}
+	if got := RenderSkill(plain, "now"); got != "DO THE THING\n\nUser input: now" {
+		t.Errorf("no dir, with args → %q", got)
+	}
+
+	// With Dir → a location header is prefixed so referenced files resolve,
+	// and the body still follows.
+	s := Skill{Name: "review", Body: "Read references/spec.md", Dir: "/abs/skills/review"}
+	got := RenderSkill(s, "")
+	if !strings.Contains(got, "/abs/skills/review") {
+		t.Errorf("header should carry the skill dir; got:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "Read references/spec.md") {
+		t.Errorf("body should follow the header; got:\n%s", got)
+	}
+}

--- a/internal/tools/skill.go
+++ b/internal/tools/skill.go
@@ -60,5 +60,7 @@ func (SkillTool) Execute(_ context.Context, _ string, input map[string]any) (age
 	if !ok {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("skill: unknown skill %q", name)
 	}
-	return agent.ToolResult{Text: s.Body}, nil
+	// RenderSkill prefixes the skill's directory so the model can read any
+	// files the body references (scripts, templates, reference docs).
+	return agent.ToolResult{Text: skills.RenderSkill(s, "")}, nil
 }

--- a/internal/tools/skill_test.go
+++ b/internal/tools/skill_test.go
@@ -33,8 +33,13 @@ func TestSkillTool_Execute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if out.Text != "Step 1: be nice." {
-		t.Errorf("body = %q", out.Text)
+	// The body comes through, prefixed with a location header so the model can
+	// resolve files the skill references.
+	if !strings.Contains(out.Text, "Step 1: be nice.") {
+		t.Errorf("body missing from result: %q", out.Text)
+	}
+	if !strings.Contains(out.Text, "bundled files live in") || !strings.Contains(out.Text, filepath.Join(".octo", "skills", "greet")) {
+		t.Errorf("expected a skill-directory header; got: %q", out.Text)
 	}
 }
 


### PR DESCRIPTION
## Problem

A `SKILL.md` body can reference files bundled in the skill directory — `scripts/setup.sh`, `references/api.md`, `templates/pr.md`. Both load paths (the `skill` tool and the `/<name>` trigger) served the body **verbatim** and never told the model where the skill lives, so a relative reference resolved against the **project cwd** and missed. `Skill.Dir` was captured at discovery but never used — bundled-reference skills were effectively broken.

## Fix

Add `skills.RenderSkill(s, args)`: prefix a one-line **location header** with the skill's absolute directory —

```
[skill "review" — bundled files live in: /abs/.octo/skills/review
Resolve any paths this skill references (scripts, templates, reference docs)
against that directory and read them with your file tools.]

<SKILL.md body>
```

— then the body, then any trailing user args. Both load paths go through it:
- `SkillTool.Execute` (model-initiated, after matching the L1 manifest)
- `inlineSkill` (the `/<name>` trigger)

Matches Claude Code's on-demand bundled-resource model — the model reads referenced files itself with its file tools; it just needed the base path. No path rewriting required. When `Dir` is empty the header is omitted (bare body, unchanged).

## Tests
- `skills.RenderSkill`: no-dir bare body / with-args / with-dir header.
- `SkillTool.Execute`: body present + dir header present.
- `inlineSkill`: bare body when no dir, header when dir set.

`go test -race ./...` (22 pkgs), `go vet`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)