### PR TITLE
feat(memory): add forget tool + Store.Delete (symmetric with remember)

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -186,9 +186,9 @@ func printMemory(w io.Writer, store *memory.Store) {
 	}
 
 	if len(active) > 0 {
-		fmt.Fprintln(w, "Active entries (not yet consolidated):")
+		fmt.Fprintln(w, "Active entries (not yet consolidated) — forgettable by name:")
 		for _, e := range active {
-			fmt.Fprintf(w, "  [%-9s] %s\n", e.Type, e.Description)
+			fmt.Fprintf(w, "  %-22s [%-9s] %s\n", e.Name, e.Type, e.Description)
 		}
 	}
 	for i, sb := range buckets {

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -191,6 +191,42 @@ func (s *Store) Save(e Entry) error {
 	return nil
 }
 
+// Delete removes the <name>.md entry and rebuilds the index, holding the lock —
+// the inverse of Save. It returns an error when no such entry exists.
+// filepath.Base + the equality check guard against a name that tries to escape
+// the memory dir; a trailing ".md" is tolerated.
+func (s *Store) Delete(name string) error {
+	name = strings.TrimSuffix(strings.TrimSpace(name), ".md")
+	if name == "" {
+		return fmt.Errorf("memory: name is required")
+	}
+	if filepath.Base(name) != name || name == "." || name == ".." {
+		return fmt.Errorf("memory: invalid name %q", name)
+	}
+
+	unlock, err := s.lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	path := filepath.Join(s.dir, name+".md")
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("memory: no entry named %q", name)
+		}
+		return err
+	}
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	if err := s.rebuildIndex(); err != nil {
+		return err
+	}
+	s.maybeCommit("forget: " + name)
+	return nil
+}
+
 func (s *Store) writeEntry(e Entry) error {
 	if err := s.ensureDir(); err != nil {
 		return err
@@ -370,7 +406,7 @@ func (s *Store) RenderInjection(cwd string) (string, error) {
 		if e.Cwd != "" && e.Cwd != cwd {
 			continue // belongs to a different project
 		}
-		fmt.Fprintf(&recent, "- [%s] %s\n", e.Type, e.Description)
+		fmt.Fprintf(&recent, "- %s [%s]: %s\n", e.Name, e.Type, e.Description)
 	}
 	if recent.Len() > 0 {
 		sections = append(sections, "## Recent (not yet consolidated)\n\n"+strings.TrimRight(recent.String(), "\n"))

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -505,3 +505,39 @@ func TestSummaries_GlobalAndProject(t *testing.T) {
 		t.Errorf("project bucket should recover cwd from marker: %+v", buckets[1])
 	}
 }
+
+func TestStore_Delete(t *testing.T) {
+	s := NewStoreAt(t.TempDir())
+	mustSave := func(name, desc string, typ Type) {
+		t.Helper()
+		if err := s.Save(Entry{Name: name, Description: desc, Type: typ, Body: "x"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustSave("run-tests", "run tests before committing", TypeFeedback)
+	mustSave("prefers-go", "prefers Go", TypeUser)
+
+	if err := s.Delete("run-tests"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	entries, _ := s.List()
+	if len(entries) != 1 || entries[0].Name != "prefers-go" {
+		t.Fatalf("after delete, entries = %+v", entries)
+	}
+
+	// A trailing ".md" is tolerated.
+	if err := s.Delete("prefers-go.md"); err != nil {
+		t.Errorf("trailing .md should be tolerated: %v", err)
+	}
+	if entries, _ := s.List(); len(entries) != 0 {
+		t.Errorf("expected empty store, got %d", len(entries))
+	}
+
+	// Unknown name errors; path traversal is rejected.
+	if err := s.Delete("nope"); err == nil {
+		t.Error("deleting an unknown entry should error")
+	}
+	if err := s.Delete("../escape"); err == nil {
+		t.Error("path traversal should be rejected")
+	}
+}

--- a/internal/tools/forget.go
+++ b/internal/tools/forget.go
@@ -1,0 +1,51 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// ForgetTool deletes a remembered fact by name — the inverse of RememberTool.
+// It shares the package-level store (SetMemoryStore) and the memoryEnabled gate,
+// so it's advertised only when memory is on. Only individual (not-yet-
+// consolidated) entries are addressable by name; facts already folded into the
+// summary live as prose and can't be forgotten this way.
+type ForgetTool struct{}
+
+func (ForgetTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "forget",
+		Description: "Delete a remembered fact by its name. Names are shown in the " +
+			"\"Memory (from past sessions)\" section of the system prompt and by /memory. " +
+			"Use when the user asks to forget something, or a remembered fact has become " +
+			"wrong or obsolete. Only individual (not-yet-consolidated) entries can be " +
+			"forgotten by name.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "string",
+					"description": "The memory's name, exactly as shown in the memory list.",
+				},
+			},
+			"required": []string{"name"},
+		},
+	}
+}
+
+func (ForgetTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	name := strings.TrimSpace(stringArg(input, "name"))
+	if name == "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("forget: name is required")
+	}
+	if !memoryEnabled() {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("forget: memory is disabled for this session")
+	}
+	if err := activeMemory.Delete(name); err != nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("forget: %w", err)
+	}
+	return agent.ToolResult{Text: "Forgot: " + name}, nil
+}

--- a/internal/tools/forget_test.go
+++ b/internal/tools/forget_test.go
@@ -1,0 +1,69 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestForgetTool_Execute(t *testing.T) {
+	store := useMemory(t)
+	// Seed a real on-disk entry via remember.
+	if _, err := (RememberTool{}).Execute(context.Background(), "remember", map[string]any{
+		"content": "Run tests before committing.", "type": "feedback",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := store.List()
+	if len(entries) != 1 {
+		t.Fatalf("setup: want 1 entry, got %d", len(entries))
+	}
+	name := entries[0].Name
+
+	out, err := ForgetTool{}.Execute(context.Background(), "forget", map[string]any{"name": name})
+	if err != nil {
+		t.Fatalf("forget error: %v", err)
+	}
+	if !strings.Contains(out.Text, name) {
+		t.Errorf("confirmation should name the forgotten entry: %q", out.Text)
+	}
+	if remaining, _ := store.List(); len(remaining) != 0 {
+		t.Errorf("entry should be gone; %d remain", len(remaining))
+	}
+}
+
+func TestForgetTool_Errors(t *testing.T) {
+	useMemory(t)
+	if _, err := (ForgetTool{}).Execute(context.Background(), "forget", map[string]any{}); err == nil {
+		t.Error("expected error for missing name")
+	}
+	if _, err := (ForgetTool{}).Execute(context.Background(), "forget", map[string]any{"name": "ghost"}); err == nil || !strings.Contains(err.Error(), "no entry") {
+		t.Errorf("expected 'no entry' error for unknown name, got %v", err)
+	}
+
+	SetMemoryStore(nil)
+	if _, err := (ForgetTool{}).Execute(context.Background(), "forget", map[string]any{"name": "x"}); err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Errorf("expected 'disabled' error, got %v", err)
+	}
+}
+
+func TestDefaultTools_ForgetGatedOnMemory(t *testing.T) {
+	hasForget := func() bool {
+		for _, d := range DefaultTools() {
+			if d.Name == "forget" {
+				return true
+			}
+		}
+		return false
+	}
+
+	SetMemoryStore(nil)
+	if hasForget() {
+		t.Error("forget should be absent when memory is disabled")
+	}
+
+	useMemory(t)
+	if !hasForget() {
+		t.Error("forget should be advertised when memory is enabled")
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -34,6 +34,7 @@ var allTools = []tool{
 	WebSearchTool{},
 	SkillTool{},
 	RememberTool{},
+	ForgetTool{},
 	LaunchAgentTool{},
 	SendMessageTool{},
 	AgentStatusTool{},
@@ -213,6 +214,9 @@ func DefaultTools() []agent.ToolDefinition {
 			continue
 		}
 		if _, isRemember := t.(RememberTool); isRemember && !memoryOn {
+			continue
+		}
+		if _, isForget := t.(ForgetTool); isForget && !memoryOn {
 			continue
 		}
 		if _, isLaunch := t.(LaunchAgentTool); isLaunch && !mgrOn {


### PR DESCRIPTION
Follow-up to the "remember can only write" finding (you chose option B: keep `remember`, add `forget`).

## What
- **`Store.Delete(name)`** — the inverse of `Save`: remove `<name>.md`, `rebuildIndex`, git-commit, under the same lock. `filepath.Base` + an equality check reject path traversal; a trailing `.md` is tolerated; unknown names error.
- **`ForgetTool`** (tool name `forget`) — delete a remembered fact by name. Shares `activeMemory` + the `memoryEnabled` gate, so it's advertised only when memory is on, registered next to `remember`.
- **Name visibility** — so the model knows what to forget, the injected "Recent (not yet consolidated)" section and `/memory` now show each entry's `name` (`name [type]: description`), matching the `MEMORY.md` index format.

## Scope
Only individual (not-yet-consolidated) entries are addressable by name. Facts already folded into the consolidated summary live as prose, not discrete files, so they aren't deletable this way (consistent with how consolidation works).

## Tests
- `Store.Delete`: deletes by name, tolerates `.md`, errors on unknown, rejects `../` traversal.
- `ForgetTool`: deletes a seeded entry, errors on missing/unknown name and when memory is disabled.
- `DefaultTools`: `forget` gated on memory being enabled.

`go test -race ./...` (22 pkgs), `go vet`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)