### PR TITLE
fix(mcp): don't bind stdio subprocess to connect timeout context

### DIFF
--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // StdioTransport speaks JSON-RPC 2.0 over a subprocess's stdin/stdout. One
@@ -52,7 +53,13 @@ func NewStdioTransport(ctx context.Context, cfg StdioConfig) (*StdioTransport, e
 	if cfg.Command == "" {
 		return nil, errors.New("mcp: stdio transport: empty command")
 	}
-	cmd := exec.CommandContext(ctx, cfg.Command, cfg.Args...)
+	// Use exec.Command (not CommandContext) so the child outlives the
+	// connect-time context. connectOne creates a 10s timeout context for the
+	// initialize handshake; if we bound the subprocess to that context the
+	// child would be killed when connectOne returns, breaking every later
+	// tool call with "broken pipe". The transport's Close method handles
+	// graceful shutdown via stdin EOF.
+	cmd := exec.Command(cfg.Command, cfg.Args...)
 	// Inherit env + add/override the configured entries. Building a fresh
 	// slice keeps os.Environ() intact for the parent.
 	if len(cfg.Env) > 0 {
@@ -148,8 +155,20 @@ func (t *StdioTransport) Close() error {
 	// tiny and a failed write surfaces as an error to the caller — fine.
 	_ = t.stdin.Close()
 	_ = t.stdout.Close()
-	// Wait is best-effort: if the child is being killed by ctx (via
-	// CommandContext) it might already be reaped.
-	_ = t.cmd.Wait()
+	// Give the child a moment to exit gracefully after seeing stdin EOF.
+	// If it doesn't, force-kill so Wait doesn't hang on a stuck process.
+	done := make(chan struct{})
+	go func() {
+		_ = t.cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		if t.cmd.Process != nil {
+			_ = t.cmd.Process.Kill()
+		}
+		<-done
+	}
 	return nil
 }

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -158,6 +158,13 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 			continue
 		}
 		choice := ch.Choices[0]
+		// Some compatible backends (Kimi) embed usage inside the choice object
+		// rather than at the chunk level. Prefer chunk-level but fall back.
+		if choice.Usage != nil {
+			result.InputTokens = choice.Usage.PromptTokens
+			result.OutputTokens = choice.Usage.CompletionTokens
+			result.CacheReadTokens = choice.Usage.cachedTokens()
+		}
 		if choice.Delta.Content != "" {
 			contentB.WriteString(choice.Delta.Content)
 			if onChunk != nil {

--- a/internal/provider/openai/stream_test.go
+++ b/internal/provider/openai/stream_test.go
@@ -244,5 +244,40 @@ func TestSendStream_OpenAI_ValidatesRequest(t *testing.T) {
 	}
 }
 
+// TestSendStream_Kimi_ChoiceUsage verifies that Kimi-style usage embedded
+// inside the final choice object (rather than at the chunk level) is parsed.
+func TestSendStream_Kimi_ChoiceUsage(t *testing.T) {
+	// Kimi puts usage inside choices[0].usage on the final chunk.
+	kimiStream := "" +
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"kimi-k2.6","choices":[{"index":0,"delta":{"role":"assistant"}}]}` + "\n\n" +
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"kimi-k2.6","choices":[{"index":0,"delta":{"content":"hi "}}]}` + "\n\n" +
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"kimi-k2.6","choices":[{"index":0,"delta":{"content":"there"}}]}` + "\n\n" +
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"kimi-k2.6","choices":[{"index":0,"delta":{},"finish_reason":"stop","usage":{"prompt_tokens":19,"completion_tokens":13,"total_tokens":32}}]}` + "\n\n" +
+		"data: [DONE]\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, kimiStream)
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	resp, err := c.SendStream(context.Background(), provider.Request{
+		Model:    "kimi-k2.6",
+		Messages: []agent.Message{agent.NewUserMessage("hi")},
+	}, provider.StreamCallbacks{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Content != "hi there" {
+		t.Errorf("Content = %q, want %q", resp.Content, "hi there")
+	}
+	if resp.InputTokens != 19 || resp.OutputTokens != 13 {
+		t.Errorf("Usage = (%d, %d), want (19, 13)", resp.InputTokens, resp.OutputTokens)
+	}
+}
+
 // Compile-time assertion.
 var _ provider.StreamingProvider = (*Client)(nil)

--- a/internal/provider/openai/types.go
+++ b/internal/provider/openai/types.go
@@ -211,6 +211,10 @@ type streamChoice struct {
 	Index        int         `json:"index"`
 	Delta        streamDelta `json:"delta"`
 	FinishReason string      `json:"finish_reason,omitempty"`
+	// Usage is populated by some compatible backends (e.g. Kimi) inside the
+	// final choice object rather than at the chunk level. We read it here as
+	// a fallback when the top-level chunk.Usage is absent.
+	Usage *apiUsage `json:"usage,omitempty"`
 }
 
 // streamDelta carries the incremental fields of an assistant message.


### PR DESCRIPTION
connectOne creates a 10s timeout context for the initialize handshake and defers cancel() on return. NewStdioTransport was using exec.CommandContext, which kills the child when that context is cancelled. This caused 'broken pipe' on every subsequent tool call because the MCP server process was already dead.

Switch to exec.Command (no context) so the child outlives the handshake. Close now gives the child 5s to exit gracefully after stdin EOF before force-killing, preventing Wait() from hanging on a stuck process.