### PR TITLE
feat: add octo-agent User-Agent header

### DIFF
--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/provider"
 	"github.com/Leihb/octo-agent/internal/provider/retry"
+	"github.com/Leihb/octo-agent/internal/version"
 )
 
 // DefaultBaseURL is Anthropic's API base. The actual Messages endpoint is
@@ -146,6 +147,7 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 			return provider.Response{}, retry.Decision{}, fmt.Errorf("anthropic: build request: %w", err)
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("User-Agent", version.UserAgent())
 		httpReq.Header.Set("x-api-key", c.APIKey)
 		apiVer := c.APIVersion
 		if apiVer == "" {

--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/provider"
 	"github.com/Leihb/octo-agent/internal/provider/retry"
+	"github.com/Leihb/octo-agent/internal/version"
 )
 
 // blockAccumulator holds in-progress state for a single content block while
@@ -87,6 +88,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 			return nil, retry.Decision{}, fmt.Errorf("anthropic: build stream request: %w", err)
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("User-Agent", version.UserAgent())
 		httpReq.Header.Set("Accept", "text/event-stream")
 		httpReq.Header.Set("x-api-key", c.APIKey)
 		apiVer := c.APIVersion

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/provider"
 	"github.com/Leihb/octo-agent/internal/provider/retry"
+	"github.com/Leihb/octo-agent/internal/version"
 )
 
 // DefaultBaseURL is OpenAI's API host. The actual Chat Completions endpoint
@@ -140,6 +141,7 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 			return nil, retry.Decision{}, fmt.Errorf("openai: build request: %w", err)
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("User-Agent", version.UserAgent())
 		httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
 
 		resp, err := httpClient.Do(httpReq)

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/provider"
 	"github.com/Leihb/octo-agent/internal/provider/retry"
+	"github.com/Leihb/octo-agent/internal/version"
 )
 
 // toolCallState accumulates streaming fragments for one tool call.
@@ -80,6 +81,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 			return nil, retry.Decision{}, fmt.Errorf("openai: build stream request: %w", err)
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("User-Agent", version.UserAgent())
 		httpReq.Header.Set("Accept", "text/event-stream")
 		httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
 

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/version"
 )
 
 // JinaReaderHost is the public Jina AI Reader endpoint. Sending a URL via
@@ -141,7 +142,7 @@ func fetchViaJina(ctx context.Context, rawURL string) (agent.ToolResult, error) 
 	}
 	req.Header.Set("Accept", "text/markdown,text/plain,*/*")
 	// Identify ourselves so Jina can reach us about issues.
-	req.Header.Set("User-Agent", "octo-agent/web_fetch")
+	req.Header.Set("User-Agent", version.UserAgent())
 
 	resp, err := webFetchHTTPClient().Do(req)
 	if err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,6 +6,10 @@
 //	go build -ldflags "-X github.com/Leihb/octo-agent/internal/version.Version=0.1.0 -X github.com/Leihb/octo-agent/internal/version.Commit=$(git rev-parse --short HEAD)" ./cmd/octo
 package version
 
+import (
+	"runtime"
+)
+
 // Version is the SemVer string for this build. Overridden via -ldflags.
 var Version = "0.12.0"
 
@@ -20,4 +24,17 @@ func String() string {
 		return Version
 	}
 	return Version + " (" + Commit + ")"
+}
+
+// UserAgent returns the standard User-Agent string for octo-agent HTTP requests.
+// Format follows the convention used by Claude Code:
+//
+//	octo-agent/<version> (<os>; <arch>)
+//
+// Examples:
+//
+//	octo-agent/0.12.0 (darwin; arm64)
+//	octo-agent/0.12.0 (linux; amd64)
+func UserAgent() string {
+	return "octo-agent/" + Version + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,6 +1,9 @@
 package version
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestString_WithoutCommit(t *testing.T) {
 	t.Cleanup(saveAndRestore(&Version, &Commit))
@@ -17,6 +20,23 @@ func TestString_WithCommit(t *testing.T) {
 	Commit = "abc1234"
 	if got, want := String(), "1.2.3 (abc1234)"; got != want {
 		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestUserAgent(t *testing.T) {
+	t.Cleanup(saveAndRestore(&Version, &Commit))
+	Version = "0.12.0"
+	Commit = "abc1234"
+	got := UserAgent()
+	if !strings.HasPrefix(got, "octo-agent/0.12.0 (") {
+		t.Errorf("UserAgent() = %q, expected prefix octo-agent/0.12.0 (", got)
+	}
+	if !strings.HasSuffix(got, ")") {
+		t.Errorf("UserAgent() = %q, expected suffix )", got)
+	}
+	// Must contain OS and arch separated by semicolon.
+	if !strings.Contains(got, "; ") {
+		t.Errorf("UserAgent() = %q, expected '; ' between OS and arch", got)
 	}
 }
 


### PR DESCRIPTION
Add `version.UserAgent()` following the Claude Code convention: `octo-agent/<version> (<os>; <arch>)`

Wired into all outgoing HTTP requests:
- Anthropic provider (Send + SendStream)
- OpenAI provider (Send + SendStream)
- web_fetch Jina Reader proxy

web_search DDG/Bing scrapers keep their rotating browser UAs (anti-bot requirement).

Includes unit test for UserAgent() format validation.