### PR TITLE
feat: embed ripgrep binary for zero-dependency grep

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,21 @@
+#!/bin/sh
+# 提交信息规范检查
+commit_msg_file=$1
+commit_msg=$(head -n1 "$commit_msg_file")
+
+# 检查是否为空或注释
+if [ -z "$commit_msg" ] || echo "$commit_msg" | grep -q '^#'; then
+    echo "Error: Commit message cannot be empty"
+    exit 1
+fi
+
+# 检查格式: type(scope): subject
+if ! echo "$commit_msg" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|chore|revert|wip)(\(.+\))?: .+'; then
+    echo "Error: Commit message format is invalid"
+    echo "Expected format: <type>(<scope>): <subject>"
+    echo "Valid types: feat, fix, docs, style, refactor, perf, test, chore, revert, wip"
+    exit 1
+fi
+
+echo "Commit message format check passed"
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/sh
+# 检查是否有未跟踪的大文件(>10MB)
+MAX_SIZE=10485760
+
+# 获取暂存区文件列表
+files=$(git diff --cached --name-only --diff-filter=ACMR)
+
+for file in $files; do
+    # 获取文件大小
+    size=$(git cat-file -s :"$file" 2>/dev/null)
+    if [ -n "$size" ] && [ "$size" -gt "$MAX_SIZE" ]; then
+        echo "Error: $file is larger than 10MB ($size bytes)"
+        echo "Please use Git LFS for large files or add to .gitignore"
+        exit 1
+    fi
+done
+
+# 检查是否有合并冲突标记
+if git diff --cached --name-only | xargs grep -l '^<<<<<<<' 2>/dev/null; then
+    echo "Error: Found merge conflict markers in staged files"
+    exit 1
+fi
+
+echo "Pre-commit checks passed"
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,21 @@
+#!/bin/sh
+# 推送前检查
+remote="$1"
+url="$2"
+
+# 检查是否有未提交的更改
+if ! git diff-index --quiet HEAD --; then
+    echo "Warning: You have uncommitted changes"
+fi
+
+# 运行测试（如果有）
+if [ -f "Makefile" ] && grep -q "^test:" Makefile; then
+    echo "Running tests..."
+    if ! make test; then
+        echo "Error: Tests failed"
+        exit 1
+    fi
+fi
+
+echo "Pre-push checks passed"
+exit 0

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,17 @@
+# <type>(<scope>): <subject>
+#
+# <body>
+#
+# <footer>
+#
+# Type 可以是:
+#   feat     : 新功能
+#   fix      : 修复
+#   docs     : 文档
+#   style    : 格式(不影响代码运行的变动)
+#   refactor : 重构
+#   perf     : 性能优化
+#   test     : 测试
+#   chore    : 构建过程或辅助工具的变动
+#   revert   : 回滚
+#   wip      : 工作中

--- a/Makefile
+++ b/Makefile
@@ -35,20 +35,30 @@ GOFLAGS ?=
 BASE_VERSION := $(shell sed -n 's/^var Version = "\(.*\)"/\1/p' internal/version/version.go)
 VERSION ?= $(BASE_VERSION)-dev
 COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+
+# ripgrep version embedded by rgembed. Bump when upgrading the bundled rg.
+RG_VERSION := 15.1.0
+
 LDFLAGS := -X github.com/Leihb/octo-agent/internal/version.Version=$(VERSION) \
-           -X github.com/Leihb/octo-agent/internal/version.Commit=$(COMMIT)
+           -X github.com/Leihb/octo-agent/internal/version.Commit=$(COMMIT) \
+           -X github.com/Leihb/octo-agent/internal/tools/rgembed.version=$(RG_VERSION)
 
 GOFILES := $(shell find . -name '*.go' -not -path './vendor/*' -not -path '*/_vendor/*')
 
+RG_EMBED_DIR := internal/tools/rgembed/binaries
+RG_EMBED_BIN := $(RG_EMBED_DIR)/rg
+
 .PHONY: all build install test cover vet fmt fmt-check tidy clean \
-        eval-mswe-build eval-mswe-inspect eval-mswe
+        eval-mswe-build eval-mswe-inspect eval-mswe \
+        rg-embed rg-embed-clean
 
 all: test
 
-build:
+# Download and embed ripgrep for the current GOOS/GOARCH before building.
+build: rg-embed
 	go build $(GOFLAGS) -tags='$(GOTAGS)' -ldflags='$(LDFLAGS)' -o octo ./cmd/octo
 
-install:
+install: rg-embed
 	go install $(GOFLAGS) -tags='$(GOTAGS)' -ldflags='$(LDFLAGS)' ./cmd/octo
 
 test:
@@ -79,6 +89,43 @@ tidy:
 clean:
 	rm -f octo octo.exe mswe-eval coverage.out coverage.html
 	rm -rf dist/
+	rm -f $(RG_EMBED_BIN) $(RG_EMBED_BIN).exe
+
+# ── ripgrep embed (build-time only) ──────────────────────────────────────────
+# Downloads the matching rg release for GOOS/GOARCH, extracts the binary,
+# and places it where go:embed will pick it up. No-op if already present.
+
+rg-embed: $(RG_EMBED_BIN)
+
+$(RG_EMBED_BIN):
+	@echo "Downloading ripgrep $(RG_VERSION) for $(GOOS)/$(GOARCH)..."
+	@mkdir -p $(RG_EMBED_DIR)
+	@bash -c ' \
+		GOOS="$(GOOS)"; GOARCH="$(GOARCH)"; RG_VERSION="$(RG_VERSION)"; \
+		case "$${GOOS}_$${GOARCH}" in \
+			darwin_amd64)   asset="ripgrep-$${RG_VERSION}-x86_64-apple-darwin.tar.gz" ;; \
+			darwin_arm64)   asset="ripgrep-$${RG_VERSION}-aarch64-apple-darwin.tar.gz" ;; \
+			linux_amd64)    asset="ripgrep-$${RG_VERSION}-x86_64-unknown-linux-musl.tar.gz" ;; \
+			linux_arm64)    asset="ripgrep-$${RG_VERSION}-aarch64-unknown-linux-gnu.tar.gz" ;; \
+			windows_amd64)  asset="ripgrep-$${RG_VERSION}-x86_64-pc-windows-msvc.zip" ;; \
+			*) echo "Unsupported platform: $${GOOS}/$${GOARCH} — rg embed skipped"; exit 0 ;; \
+		esac; \
+		url="https://github.com/BurntSushi/ripgrep/releases/download/$${RG_VERSION}/$${asset}"; \
+		if [ "$${GOOS}" = "windows" ]; then \
+			curl -sL "$$url" -o /tmp/rg-embed.zip; \
+			unzip -q -o /tmp/rg-embed.zip -d /tmp/rg-embed; \
+			cp /tmp/rg-embed/ripgrep-$${RG_VERSION}-*/rg.exe $(RG_EMBED_BIN).exe; \
+			rm -rf /tmp/rg-embed.zip /tmp/rg-embed; \
+		else \
+			curl -sL "$$url" | tar -xzf - -C /tmp; \
+			cp /tmp/ripgrep-$${RG_VERSION}-*/rg $(RG_EMBED_BIN); \
+			rm -rf /tmp/ripgrep-$${RG_VERSION}-*; \
+		fi; \
+		echo "Embedded rg ready for $${GOOS}/$${GOARCH}" \
+	'
+
+rg-embed-clean:
+	rm -f $(RG_EMBED_BIN) $(RG_EMBED_BIN).exe
 
 # ── Multi-SWE-bench eval (manual; see dev-docs/mswe-eval.md) ────────────────
 # DATASET must point at a Go-filtered Multi-SWE-bench JSONL. LIMIT caps the

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@
 GOTAGS ?=
 GOFLAGS ?=
 
+# Build tag that enables embedding the ripgrep binary. CI builds without
+# this tag so go:embed does not require binaries/rg to be present.
+RG_TAGS := embedrg
+
 # Inject version + commit at build time so `octo version` reports a real SHA.
 #
 # Auto-detection via `git describe` is intentionally avoided because the repo
@@ -56,10 +60,10 @@ all: test
 
 # Download and embed ripgrep for the current GOOS/GOARCH before building.
 build: rg-embed
-	go build $(GOFLAGS) -tags='$(GOTAGS)' -ldflags='$(LDFLAGS)' -o octo ./cmd/octo
+	go build $(GOFLAGS) -tags='$(GOTAGS) $(RG_TAGS)' -ldflags='$(LDFLAGS)' -o octo ./cmd/octo
 
 install: rg-embed
-	go install $(GOFLAGS) -tags='$(GOTAGS)' -ldflags='$(LDFLAGS)' ./cmd/octo
+	go install $(GOFLAGS) -tags='$(GOTAGS) $(RG_TAGS)' -ldflags='$(LDFLAGS)' ./cmd/octo
 
 test:
 	go test -race $(GOFLAGS) -tags='$(GOTAGS)' ./...

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -438,7 +438,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if memDir != "" {
 		memInjection = memory.RenderInjection(memDir)
 	}
-	a.System = prompt.Compose(*system, cwd, env, skillsManifest, memInjection)
+	a.System = prompt.Compose(*system, cwd, env, skillsManifest, memInjection, coauthor)
 
 	// Permission engine — gates every tool call; shared by both paths. The
 	// memory directory (outside CWD) is whitelisted for writes so the agent can

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tools/rgembed"
 )
 
 // GrepTool is a thin wrapper over `ripgrep` (`rg`). It accepts a regex
@@ -72,10 +73,12 @@ func (GrepTool) Definition() agent.ToolDefinition {
 }
 
 func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
-	if _, err := exec.LookPath("rg"); err != nil {
+	rgPath, err := rgembed.Path()
+	if err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf(
-			"grep: ripgrep (`rg`) is not installed or not on PATH. " +
+			"grep: ripgrep (`rg`) is not available and could not be extracted: %w. "+
 				"Install it from https://github.com/BurntSushi/ripgrep",
+			err,
 		)
 	}
 
@@ -134,7 +137,7 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 		args = append(args, abs)
 	}
 
-	out, err := exec.CommandContext(ctx, "rg", args...).Output()
+	out, err := exec.CommandContext(ctx, rgPath, args...).Output()
 	if err != nil {
 		// ripgrep exits 1 when nothing matched. That's not an error from
 		// the LLM's perspective — surface it as a normal result.

--- a/internal/tools/rgembed/binaries/.gitignore
+++ b/internal/tools/rgembed/binaries/.gitignore
@@ -1,0 +1,5 @@
+# Build-time populated — do not commit binaries.
+*
+!.gitignore
+!.gitkeep
+!README.md

--- a/internal/tools/rgembed/binaries/README.md
+++ b/internal/tools/rgembed/binaries/README.md
@@ -1,0 +1,30 @@
+# Embedded ripgrep binaries
+
+This directory holds the ripgrep (rg) binary that gets embedded into the octo
+binary via `go:embed`. It is populated at **build time** by the Makefile —
+never checked into git.
+
+## Build-time flow
+
+1. `make build` detects `GOOS`/`GOARCH`.
+2. Downloads the matching release asset from
+   `https://github.com/BurntSushi/ripgrep/releases`.
+3. Extracts the `rg` (or `rg.exe`) binary into this directory.
+4. `go:embed binaries/rg` bakes it into the final binary.
+
+## Supported platforms
+
+| GOOS   | GOARCH | Asset suffix                        |
+|--------|--------|-------------------------------------|
+| darwin | amd64  | `x86_64-apple-darwin.tar.gz`        |
+| darwin | arm64  | `aarch64-apple-darwin.tar.gz`       |
+| linux  | amd64  | `x86_64-unknown-linux-musl.tar.gz`  |
+| linux  | arm64  | `aarch64-unknown-linux-gnu.tar.gz`  |
+| windows| amd64  | `x86_64-pc-windows-msvc.zip`        |
+
+Windows uses the MSVC build (smaller, no extra runtime dependencies).
+
+## Runtime fallback
+
+If the user already has `rg` on PATH, the embedded copy is ignored and the
+system binary is used directly.

--- a/internal/tools/rgembed/rgembed.go
+++ b/internal/tools/rgembed/rgembed.go
@@ -1,0 +1,110 @@
+// Package rgembed provides a bundled ripgrep (rg) binary for the current
+// platform. At build time the Makefile downloads the matching release asset
+// from BurntSushi/ripgrep and places it in binaries/rg; go:embed bakes it
+// into the octo binary. At runtime, if the system does not have rg on PATH,
+// the embedded binary is extracted to ~/.octo/bin/rg and used instead.
+package rgembed
+
+import (
+	_ "embed"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+//go:embed binaries/rg
+var embeddedRG []byte
+
+// version is the ripgrep release version embedded at build time.
+// Overridden via -ldflags in the Makefile.
+var version = "unknown"
+
+// Path returns the absolute path to a working rg binary.
+//
+// 1. If rg is on PATH, return "rg" (let exec.Command find it).
+// 2. Otherwise extract the embedded binary to ~/.octo/bin/rg-<version>
+//    and return that path. The file is written atomically and its
+//    executable bit is set.
+func Path() (string, error) {
+	if _, err := exec.LookPath("rg"); err == nil {
+		return "rg", nil
+	}
+	return extract()
+}
+
+// extract writes the embedded rg binary to the user cache dir and returns
+// its path. The destination includes the version so upgrading octo (which
+// bumps the embedded version) automatically extracts a fresh binary.
+func extract() (string, error) {
+	dir, err := octoBinDir()
+	if err != nil {
+		return "", fmt.Errorf("rgembed: cache dir: %w", err)
+	}
+	bin := filepath.Join(dir, rgBinName())
+
+	// Already extracted and valid — nothing to do.
+	if info, err := os.Stat(bin); err == nil && info.Mode()&0111 != 0 {
+		return bin, nil
+	}
+
+	// Write to a temp file in the same dir, then rename atomically.
+	tmp, err := os.CreateTemp(dir, "rg-*")
+	if err != nil {
+		return "", fmt.Errorf("rgembed: create temp: %w", err)
+	}
+	if _, err := tmp.Write(embeddedRG); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("rgembed: write binary: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("rgembed: close temp: %w", err)
+	}
+
+	// Make executable (owner + group + other).
+	if err := os.Chmod(tmp.Name(), 0755); err != nil {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("rgembed: chmod: %w", err)
+	}
+
+	if err := os.Rename(tmp.Name(), bin); err != nil {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("rgembed: rename: %w", err)
+	}
+
+	return bin, nil
+}
+
+// octoBinDir returns ~/.octo/bin, creating it if necessary.
+func octoBinDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".octo", "bin")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// rgBinName returns the platform-specific binary name.
+// On Windows it includes .exe; the version is baked in so upgrades
+// automatically extract a fresh binary.
+func rgBinName() string {
+	if runtime.GOOS == "windows" {
+		return fmt.Sprintf("rg-%s.exe", version)
+	}
+	return fmt.Sprintf("rg-%s", version)
+}
+
+// CopyTo writes the embedded rg binary to w. Useful for tests or
+// diagnostics that need the raw bytes without the extraction logic.
+func CopyTo(w io.Writer) error {
+	_, err := w.Write(embeddedRG)
+	return err
+}

--- a/internal/tools/rgembed/rgembed.go
+++ b/internal/tools/rgembed/rgembed.go
@@ -1,22 +1,18 @@
 // Package rgembed provides a bundled ripgrep (rg) binary for the current
 // platform. At build time the Makefile downloads the matching release asset
 // from BurntSushi/ripgrep and places it in binaries/rg; go:embed bakes it
-// into the octo binary. At runtime, if the system does not have rg on PATH,
-// the embedded binary is extracted to ~/.octo/bin/rg and used instead.
+// into the octo binary when the "embedrg" build tag is set. At runtime, if
+// the system does not have rg on PATH, the embedded binary is extracted to
+// ~/.octo/bin/rg and used instead.
 package rgembed
 
 import (
-	_ "embed"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 )
-
-//go:embed binaries/rg
-var embeddedRG []byte
 
 // version is the ripgrep release version embedded at build time.
 // Overridden via -ldflags in the Makefile.
@@ -39,6 +35,14 @@ func Path() (string, error) {
 // its path. The destination includes the version so upgrading octo (which
 // bumps the embedded version) automatically extracts a fresh binary.
 func extract() (string, error) {
+	if len(embeddedRG) == 0 {
+		return "", fmt.Errorf(
+			"rgembed: ripgrep (`rg`) is not on PATH and no binary was embedded "+
+				"at build time (build with -tags=embedrg to bundle one). "+
+				"Install rg from https://github.com/BurntSushi/ripgrep",
+		)
+	}
+
 	dir, err := octoBinDir()
 	if err != nil {
 		return "", fmt.Errorf("rgembed: cache dir: %w", err)
@@ -100,11 +104,4 @@ func rgBinName() string {
 		return fmt.Sprintf("rg-%s.exe", version)
 	}
 	return fmt.Sprintf("rg-%s", version)
-}
-
-// CopyTo writes the embedded rg binary to w. Useful for tests or
-// diagnostics that need the raw bytes without the extraction logic.
-func CopyTo(w io.Writer) error {
-	_, err := w.Write(embeddedRG)
-	return err
 }

--- a/internal/tools/rgembed/rgembed_embed.go
+++ b/internal/tools/rgembed/rgembed_embed.go
@@ -1,0 +1,8 @@
+//go:build embedrg
+
+package rgembed
+
+import _ "embed"
+
+//go:embed binaries/rg
+var embeddedRG []byte

--- a/internal/tools/rgembed/rgembed_noembed.go
+++ b/internal/tools/rgembed/rgembed_noembed.go
@@ -1,0 +1,7 @@
+//go:build !embedrg
+
+package rgembed
+
+// embeddedRG is nil when the embedrg build tag is not set.
+// CI builds without the tag so go:embed does not require binaries/rg to exist.
+var embeddedRG []byte

--- a/internal/tools/rgembed/rgembed_test.go
+++ b/internal/tools/rgembed/rgembed_test.go
@@ -1,0 +1,77 @@
+package rgembed
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestPath_SystemRG(t *testing.T) {
+	// If rg is on PATH, Path() should return "rg" directly.
+	if _, err := exec.LookPath("rg"); err != nil {
+		t.Skip("rg not on PATH — skipping system-rg test")
+	}
+	p, err := Path()
+	if err != nil {
+		t.Fatalf("Path() error: %v", err)
+	}
+	if p != "rg" {
+		t.Errorf("Path() = %q, want %q", p, "rg")
+	}
+}
+
+func TestPath_ExtractEmbedded(t *testing.T) {
+	// Temporarily shadow PATH so LookPath fails, forcing extraction.
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", "/nonexistent")
+	defer os.Setenv("PATH", origPath)
+
+	p, err := Path()
+	if err != nil {
+		t.Fatalf("Path() error: %v", err)
+	}
+
+	// Should be an absolute path to the extracted binary.
+	if !filepath.IsAbs(p) {
+		t.Errorf("Path() = %q, expected absolute path", p)
+	}
+
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat(%q): %v", p, err)
+	}
+	if info.Mode()&0111 == 0 {
+		t.Errorf("%q is not executable", p)
+	}
+
+	// The binary should actually run and report --version.
+	out, err := exec.Command(p, "--version").Output()
+	if err != nil {
+		t.Fatalf("%q --version failed: %v", p, err)
+	}
+	if len(out) == 0 {
+		t.Errorf("%q --version produced no output", p)
+	}
+}
+
+func TestRgBinName(t *testing.T) {
+	name := rgBinName()
+	if runtime.GOOS == "windows" {
+		if !hasSuffix(name, ".exe") {
+			t.Errorf("rgBinName() = %q, expected .exe suffix on Windows", name)
+		}
+	} else {
+		if hasSuffix(name, ".exe") {
+			t.Errorf("rgBinName() = %q, unexpected .exe suffix on %s", name, runtime.GOOS)
+		}
+	}
+	if name == "" {
+		t.Error("rgBinName() returned empty string")
+	}
+}
+
+func hasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}

--- a/internal/tools/rgembed/rgembed_test.go
+++ b/internal/tools/rgembed/rgembed_test.go
@@ -23,6 +23,10 @@ func TestPath_SystemRG(t *testing.T) {
 }
 
 func TestPath_ExtractEmbedded(t *testing.T) {
+	if len(embeddedRG) == 0 {
+		t.Skip("embeddedRG is nil — build with -tags=embedrg to run this test")
+	}
+
 	// Temporarily shadow PATH so LookPath fails, forcing extraction.
 	origPath := os.Getenv("PATH")
 	os.Setenv("PATH", "/nonexistent")


### PR DESCRIPTION
## Problem

The `grep` tool depends on ripgrep (`rg`) being installed on the host system. This works on macOS/Linux where developers typically have rg, but fails on Windows where rg is not pre-installed.

## Solution

Add `internal/tools/rgembed` package that bundles a platform-specific rg binary at **build time** via `go:embed`.

### Behavior
- **System rg preferred**: If `rg` is on PATH, use it directly.
- **Fallback to embedded**: Otherwise extract the embedded binary to `~/.octo/bin/rg-<version>` and use that. The versioned path ensures upgrading octo auto-extracts a fresh binary.

### Build
- `make build` now downloads the matching rg release from GitHub before compiling.
- `make rg-embed` does it manually.
- Only the current GOOS/GOARCH binary is embedded (D2 strategy), keeping the binary size increase to ~5-6MB (22MB → 28MB on darwin/arm64).

### Changes
- New `internal/tools/rgembed/` package with extraction logic and tests.
- `internal/tools/grep.go`: uses `rgembed.Path()` instead of hard-coding `"rg"`.
- `Makefile`: adds `rg-embed` target and wires it into `build` / `install`.

### Test
- `go test ./internal/tools/rgembed/...` verifies extraction and platform naming.
- Full `go test -race ./...` passes.