### PR TITLE
chore: add git configuration template, hooks, and fix gitState repo detection

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,21 @@
+#!/bin/sh
+# 提交信息规范检查
+commit_msg_file=$1
+commit_msg=$(head -n1 "$commit_msg_file")
+
+# 检查是否为空或注释
+if [ -z "$commit_msg" ] || echo "$commit_msg" | grep -q '^#'; then
+    echo "Error: Commit message cannot be empty"
+    exit 1
+fi
+
+# 检查格式: type(scope): subject
+if ! echo "$commit_msg" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|chore|revert|wip)(\(.+\))?: .+'; then
+    echo "Error: Commit message format is invalid"
+    echo "Expected format: <type>(<scope>): <subject>"
+    echo "Valid types: feat, fix, docs, style, refactor, perf, test, chore, revert, wip"
+    exit 1
+fi
+
+echo "Commit message format check passed"
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/sh
+# 检查是否有未跟踪的大文件(>10MB)
+MAX_SIZE=10485760
+
+# 获取暂存区文件列表
+files=$(git diff --cached --name-only --diff-filter=ACMR)
+
+for file in $files; do
+    # 获取文件大小
+    size=$(git cat-file -s :"$file" 2>/dev/null)
+    if [ -n "$size" ] && [ "$size" -gt "$MAX_SIZE" ]; then
+        echo "Error: $file is larger than 10MB ($size bytes)"
+        echo "Please use Git LFS for large files or add to .gitignore"
+        exit 1
+    fi
+done
+
+# 检查是否有合并冲突标记
+if git diff --cached --name-only | xargs grep -l '^<<<<<<<' 2>/dev/null; then
+    echo "Error: Found merge conflict markers in staged files"
+    exit 1
+fi
+
+echo "Pre-commit checks passed"
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,21 @@
+#!/bin/sh
+# 推送前检查
+remote="$1"
+url="$2"
+
+# 检查是否有未提交的更改
+if ! git diff-index --quiet HEAD --; then
+    echo "Warning: You have uncommitted changes"
+fi
+
+# 运行测试（如果有）
+if [ -f "Makefile" ] && grep -q "^test:" Makefile; then
+    echo "Running tests..."
+    if ! make test; then
+        echo "Error: Tests failed"
+        exit 1
+    fi
+fi
+
+echo "Pre-push checks passed"
+exit 0

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,17 @@
+# <type>(<scope>): <subject>
+#
+# <body>
+#
+# <footer>
+#
+# Type 可以是:
+#   feat     : 新功能
+#   fix      : 修复
+#   docs     : 文档
+#   style    : 格式(不影响代码运行的变动)
+#   refactor : 重构
+#   perf     : 性能优化
+#   test     : 测试
+#   chore    : 构建过程或辅助工具的变动
+#   revert   : 回滚
+#   wip      : 工作中

--- a/cmd/octo/envcontext.go
+++ b/cmd/octo/envcontext.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -54,6 +55,29 @@ func gitState(cwd string) (branch string, dirty, ok bool) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
+
+	// Verify cwd is actually inside a git repo, not just a subdir of one
+	// reached by git's upward traversal.
+	topLevel, err := gitRun(ctx, cwd, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", false, false
+	}
+	// Normalize paths for comparison (git returns abs paths; cwd may be ".").
+	// Use filepath.Clean to normalize separators so the comparison works on
+	// Windows where git may return forward slashes.
+	absCwd, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", false, false
+	}
+	absCwd = filepath.Clean(absCwd)
+	absTop := filepath.Clean(strings.TrimSpace(topLevel))
+	if absTop == "" {
+		return "", false, false
+	}
+	// cwd must be inside or equal to the repo root.
+	if !strings.HasPrefix(absCwd, absTop) {
+		return "", false, false
+	}
 
 	branchOut, err := gitRun(ctx, cwd, "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {


### PR DESCRIPTION
## Changes

- Add `.gitmessage` with Conventional Commits template
- Add Git hooks (pre-commit, commit-msg, pre-push)
- Fix `gitState` to properly detect non-git directories using `--show-toplevel`
- Normalize path separators for Windows compatibility

## Verification

All tests pass locally with `make test`.