### PR TITLE
feat: add Co-authored-by trailer to git commits with configurable switch

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -141,7 +141,7 @@ func runChannelStart(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 		a.CWD = cwd
 		a.MaxTokens = *maxTokens
 		a.MaxTurns = *maxTurns
-		a.System = prompt.Compose(*system, cwd, env, skillsManifest, "")
+		a.System = prompt.Compose(*system, cwd, env, skillsManifest, "", true)
 		return a
 	}
 

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -66,6 +66,25 @@ func tuiDisabledByEnv() bool {
 	return false
 }
 
+// resolveCoauthor determines whether the agent should append a Co-authored-by
+// line to git commit messages. Precedence: --no-coauthor flag > OCTO_COAUTHOR
+// env > config file > default (true).
+func resolveCoauthor(noCoauthorFlag bool, cfg config.Config) bool {
+	if noCoauthorFlag {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("OCTO_COAUTHOR"))) {
+	case "0", "false", "off", "no":
+		return false
+	case "1", "true", "on", "yes":
+		return true
+	}
+	if cfg.Coauthor != nil {
+		return *cfg.Coauthor
+	}
+	return true
+}
+
 // defaultModels maps each provider to the model used when `--model` isn't
 // supplied. Both defaults are the cheapest reasoning-capable model in the
 // respective vendor's catalogue at the time of writing — the right pick for
@@ -107,6 +126,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	quietFlag := fs.Bool("quiet", false, "Strip all status chrome (no spinner, no banner, no cache line). Also OCTO_VERBOSITY=quiet.")
 	verboseFlag := fs.Bool("verbose", false, "Print extra context (provider/model/endpoint, always-on cache line). Also OCTO_VERBOSITY=verbose.")
 	permMode := fs.String("permission-mode", "", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask) | auto (allow on ask). Empty = use `octo config` value, else interactive.")
+	noCoauthor := fs.Bool("no-coauthor", false, "Disable appending Co-authored-by to git commit messages. Also OCTO_COAUTHOR=0.")
 	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = auto: 100 interactive, unlimited unattended/--prompt-file)")
 	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (~75% of the model's context window), <0 = disabled")
 	thinkingBudget := fs.Int("thinking-budget", 0, "Enable extended thinking with this token budget (Anthropic/Kimi); 0 = off")
@@ -259,6 +279,9 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "octo: provider=%s model=%s endpoint=%s\n",
 			provName, resolvedModel, effectiveEndpoint(provName, cfg))
 	}
+
+	// Resolve coauthor: flag > env > config > default (true).
+	coauthor := resolveCoauthor(*noCoauthor, cfg)
 
 	// Compose the system prompt once (base + project .octorules + user --system)
 	// and freeze it for the session — recomputing mid-session would bust the
@@ -438,7 +461,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if memDir != "" {
 		memInjection = memory.RenderInjection(memDir)
 	}
-	a.System = prompt.Compose(*system, cwd, env, skillsManifest, memInjection)
+	a.System = prompt.Compose(*system, cwd, env, skillsManifest, memInjection, coauthor)
 
 	// Permission engine — gates every tool call; shared by both paths. The
 	// memory directory (outside CWD) is whitelisted for writes so the agent can
@@ -469,7 +492,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			}
 			// Recompose from the session's raw user layer so base/project/env
 			// pick up any changes since the session was created.
-			a.System = prompt.Compose(sess.System, cwd, env, skillsManifest, memInjection)
+			a.System = prompt.Compose(sess.System, cwd, env, skillsManifest, memInjection, coauthor)
 		} else {
 			sess = agent.NewSession(resolvedModel, *system)
 		}

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -166,6 +166,15 @@ func runConfigShow(stdout, stderr io.Writer) int {
 		fmt.Fprintln(stdout, "  base URL:  (provider default)")
 	}
 	fmt.Fprintf(stdout, "  API key:   %s\n", apiKeyStatus(provider, cfg))
+	coauthorStatus := "on (default)"
+	if cfg.Coauthor != nil {
+		if *cfg.Coauthor {
+			coauthorStatus = "on (config)"
+		} else {
+			coauthorStatus = "off (config)"
+		}
+	}
+	fmt.Fprintf(stdout, "  coauthor:  %s\n", coauthorStatus)
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "CLI flags (--provider, --model, --system) and env vars override this file per run.")
 	return 0
@@ -226,6 +235,16 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 	baseURL := strings.TrimSpace(promptDefault(reader, stdout, "Custom base URL (optional, for DeepSeek/Kimi/etc.)", existing.BaseURL))
 
 	out := config.Config{Provider: provider, Model: model, BaseURL: baseURL, APIKey: existing.APIKey}
+
+	// Co-authored-by: default on; ask once in wizard.
+	coauthorDefault := "y"
+	if existing.Coauthor != nil && !*existing.Coauthor {
+		coauthorDefault = "n"
+	}
+	coauthorAns := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
+		"Append Co-authored-by to git commits? (Y/n)", coauthorDefault)))
+	coauthorVal := coauthorAns != "n" && coauthorAns != "no"
+	out.Coauthor = &coauthorVal
 
 	// API key: env is the recommended home for it. Offer to store it only if
 	// the env var is empty, and make declining the obvious default.

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -202,8 +202,8 @@ func TestRunConfig_Wizard_SwitchesProviderAndPromptsForKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Answers: provider=openai, model=(default), base_url=(blank), store_key=y, key=new-openai-key.
-	in := strings.NewReader("openai\n\n\ny\nnew-openai-key\n")
+	// Answers: provider=openai, model=(default), base_url=(blank), coauthor=y, store_key=y, key=new-openai-key.
+	in := strings.NewReader("openai\n\n\ny\ny\nnew-openai-key\n")
 	var stdout, stderr bytes.Buffer
 	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -79,7 +79,7 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	a := agent.New(providerSender{p: prov, cacheKey: newCacheKey()}, resolvedModel)
-	a.System = prompt.Compose("", cwd, env, "", "") // init is a one-shot task; no skills/memory
+	a.System = prompt.Compose("", cwd, env, "", "", true) // init is a one-shot task; no skills/memory
 
 	engine, err := permission.New(permissionConfigPath(), cwd, resolvePermissionMode(*permMode))
 	if err != nil {

--- a/cmd/octo/task.go
+++ b/cmd/octo/task.go
@@ -114,7 +114,7 @@ func runTaskStart(args []string, stdout, stderr io.Writer) int {
 	a.MaxTokens = defaultMaxTokensForPlanner
 	cwd, _ := os.Getwd()
 	a.CWD = cwd
-	a.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "")
+	a.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "", true)
 
 	fmt.Fprintf(stdout, "Planning…  goal: %s\n", oneLine(goal))
 	res, err := a.PlanTask(context.Background(), goal)
@@ -263,7 +263,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 	parent.MaxTokens = defaultMaxTokensForPlanner
 	cwd, _ := os.Getwd()
 	parent.CWD = cwd
-	parent.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "")
+	parent.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "", true)
 
 	executor := tools.NewDefaultRegistry()
 	tools.SetSpawner(newAgentSpawner(parent, executor, tools.DefaultTools))
@@ -518,7 +518,7 @@ func resumeAndRun(t *taskgraph.Task, flagProvider, flagModel string, cfg config.
 	parent.MaxTokens = defaultMaxTokensForPlanner
 	cwd, _ := os.Getwd()
 	parent.CWD = cwd
-	parent.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "")
+	parent.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "", true)
 
 	executor := tools.NewDefaultRegistry()
 	tools.SetSpawner(newAgentSpawner(parent, executor, tools.DefaultTools))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,9 @@ type Config struct {
 	Model          string `json:"model,omitempty"`
 	BaseURL        string `json:"base_url,omitempty"`
 	PermissionMode string `json:"permission_mode,omitempty"`
+	// Coauthor, when true, instructs the agent to append a Co-authored-by line
+	// to every git commit message it writes. Default is true (enabled).
+	Coauthor *bool `json:"coauthor,omitempty"`
 	// APIKey, when set, is a plaintext fallback used only if the provider's
 	// env var is empty. Opt-in via `octo config` and stored mode 0600. Prefer
 	// the env var.

--- a/internal/prompt/identity_test.go
+++ b/internal/prompt/identity_test.go
@@ -34,7 +34,7 @@ func useIdentityFiles(t *testing.T, soul, profile string) {
 
 func TestCompose_IdentityLayers(t *testing.T) {
 	useIdentityFiles(t, "SOUL_PERSONA", "USER_PROFILE_X")
-	out := Compose("", t.TempDir(), "ENV_Z", "SKILLS_M", "")
+	out := Compose("", t.TempDir(), "ENV_Z", "SKILLS_M", "", true)
 
 	baseIdx := strings.Index(out, "octo")
 	soulIdx := strings.Index(out, "SOUL_PERSONA")
@@ -58,7 +58,7 @@ func TestCompose_IdentityLayers(t *testing.T) {
 
 func TestCompose_IdentityAbsentSkipped(t *testing.T) {
 	useIdentityFiles(t, "", "") // neither file present
-	out := Compose("", t.TempDir(), "", "", "")
+	out := Compose("", t.TempDir(), "", "", "", false)
 	if strings.Contains(out, "soul.md") || strings.Contains(out, "user.md") {
 		t.Errorf("absent identity files should add no layer:\n%s", out)
 	}
@@ -73,7 +73,7 @@ func TestCompose_ProfileBeforeRules(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("PROJECT_RULE"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	out := Compose("", dir, "", "", "")
+	out := Compose("", dir, "", "", "", false)
 	profileIdx := strings.Index(out, "USER_PROFILE_X")
 	projIdx := strings.Index(out, "PROJECT_RULE")
 	if profileIdx == -1 || projIdx == -1 || profileIdx >= projIdx {

--- a/internal/prompt/memory_test.go
+++ b/internal/prompt/memory_test.go
@@ -33,7 +33,7 @@ func TestCompose_UserLayerBetweenEnvAndProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out := Compose("SYSTEM_OVERRIDE", dir, "ENV_BLOCK", "", "")
+	out := Compose("SYSTEM_OVERRIDE", dir, "ENV_BLOCK", "", "", true)
 
 	envIdx := strings.Index(out, "ENV_BLOCK")
 	userIdx := strings.Index(out, "USER_GLOBAL_RULE")
@@ -58,7 +58,7 @@ func TestCompose_NoUserFile_NoUserLayer(t *testing.T) {
 	// path), so this isolates the test from real ~/.octo/{soul,user,octorules}.
 	useIdentityFiles(t, "", "")
 
-	out := Compose("", t.TempDir(), "", "", "")
+	out := Compose("", t.TempDir(), "", "", "", false)
 	if strings.Contains(out, "octorules.md") {
 		t.Errorf("absent user file should add no layer:\n%s", out)
 	}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -21,6 +21,18 @@ import (
 //go:embed base.md
 var base string
 
+// coauthorRule is injected right after base when coauthor mode is enabled.
+// It instructs the agent to append a Co-authored-by trailer to every git
+// commit message it writes, following Git trailer format (RFC 822-style
+// headers at the end of the message, separated by a blank line).
+const coauthorRule = `## Git commits
+
+When you run ` + "`git commit`" + ` (via the terminal tool or any other path), append the following Co-authored-by trailer to the commit message:
+
+  Co-authored-by: octo-agent <octo-agent@leihb.github.io>
+
+The trailer must be placed at the very end of the commit message, separated from the body by a blank line, following standard Git trailer format. Do not add this trailer if the user explicitly tells you not to.`
+
 // ProjectContextFile is the per-repo conventions file Compose looks for in
 // the working directory. It carries project-specific rules the agent should
 // follow (the human-facing counterpart to CLAUDE.md).
@@ -71,8 +83,15 @@ var userRulesPath = func() string {
 // (see expandIncludes). env is passed in rather than computed here so this
 // package stays pure (no os/exec, no git); the caller snapshots it once at
 // session start, which keeps the cached prompt prefix stable across turns.
-func Compose(userSystem, cwd, env, skills, memory string) string {
+//
+// coauthor, when true, injects a rule into the system prompt instructing the
+// agent to append a Co-authored-by trailer to every git commit message it writes.
+func Compose(userSystem, cwd, env, skills, memory string, coauthor bool) string {
 	layers := []string{strings.TrimSpace(base)}
+
+	if coauthor {
+		layers = append(layers, coauthorRule)
+	}
 
 	if s := readSoul(); s != "" {
 		layers = append(layers, "# Agent identity (~/.octo/soul.md)\n\n"+s)

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCompose_BaseAlwaysPresent(t *testing.T) {
-	out := Compose("", t.TempDir(), "", "", "") // empty user/env/skills, no .octorules
+	out := Compose("", t.TempDir(), "", "", "", false) // empty user/env/skills, no .octorules
 	if !strings.Contains(out, "octo") {
 		t.Errorf("composed prompt should contain the base identity:\n%s", out)
 	}
@@ -22,7 +22,7 @@ func TestCompose_LayersInOrder(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ProjectContextFile), []byte("PROJECT_RULE_X"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	out := Compose("USER_RULE_Y", dir, "ENV_BLOCK_Z", "SKILLS_MANIFEST_W", "")
+	out := Compose("USER_RULE_Y", dir, "ENV_BLOCK_Z", "SKILLS_MANIFEST_W", "", true)
 
 	baseIdx := strings.Index(out, "octo")
 	envIdx := strings.Index(out, "ENV_BLOCK_Z")
@@ -47,7 +47,7 @@ func TestCompose_SkipsAbsentLayers(t *testing.T) {
 	// same on a developer machine and on a fresh CI runner.
 	useIdentityFiles(t, "", "")
 	// No env, no skills, no .octorules, no user prompt → just the base, no separators.
-	out := Compose("", t.TempDir(), "", "", "")
+	out := Compose("", t.TempDir(), "", "", "", false)
 	if strings.Contains(out, "---") {
 		t.Errorf("single-layer prompt should have no separator:\n%s", out)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -187,7 +187,7 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	a := agent.New(sender, s.model)
 	a.CWD = s.cwd
 	a.MaxTokens = s.cfg.MaxTokens
-	a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, "")
+	a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, "", true)
 	if sess.Model != "" {
 		a.Model = sess.Model
 	}


### PR DESCRIPTION
Add a Co-authored-by line to every git commit message the agent writes, following standard Git trailer format.

**Config precedence (highest first):**
1. CLI flag: `--no-coauthor`
2. Environment: `OCTO_COAUTHOR=0`
3. Config file: `~/.octo/config.json` `coauthor` field (default true)

**Changes:**
- `internal/config/config.go`: add `Coauthor *bool` field
- `internal/prompt/prompt.go`: inject coauthor rule into system prompt when enabled
- `cmd/octo/chat.go`: add `--no-coauthor` flag and `resolveCoauthor()`
- `cmd/octo/config.go`: wizard prompts for coauthor, show displays status
- `cmd/octo/{init,channel,task}.go` + `internal/server/server.go`: update Compose calls
- Tests updated to match new Compose signature