### PR TITLE
fix(tui): suppress system-reminder in EventSteerInjected scrollback echo

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -560,8 +560,12 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 		// Inbox drained mid-turn: print the steer messages to the scrollback
 		// immediately so they appear in chronological order (before the next
 		// assistant reply), and remove them from the pending live display.
+		// Skip <system-reminder> blocks — they are model-facing context, not
+		// user-visible transcript.
 		for _, s := range ev.Messages {
-			m.println(userEchoStyle.Render("> ") + s)
+			if !strings.HasPrefix(s, "<system-reminder>") {
+				m.println(userEchoStyle.Render("> ") + s)
+			}
 		}
 		// pendingSteer is FIFO and mirrors the inbox, so the drained messages
 		// are always a prefix.


### PR DESCRIPTION
## Problem

PR #308 fixed system-reminder suppression in two inbox-drain paths (turnEndedMsg cancel branch and handleTurnFinished), but missed the third path: **EventSteerInjected**.

In the kill_shell scenario:
1. kill_shell kills a background process
2. The process' onExit hook fires, enqueueing a `\u003csystem-reminder\u003e` block into Inbox
3. runLoop drains inbox mid-turn and emits EventSteerInjected
4. TUI prints every message in EventSteerInjected to scrollback — **including `\u003csystem-reminder\u003e`**

## Fix

Filter out `\u003csystem-reminder\u003e` blocks in EventSteerInjected handling, matching the existing suppression in the other two drain paths.