### PR TITLE
fix(tools): use --max-columns-preview to prevent grep retry loops

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -30,7 +30,7 @@ func (GrepTool) Definition() agent.ToolDefinition {
 			"per-file counts, or the default mode='content' to see matching lines. " +
 			"Set context_lines (or before/after) to include surrounding lines. " +
 			"Respects .gitignore. Matching lines over 500 chars are truncated " +
-			"with an [Omitted long matching line] marker. Requires `rg` on PATH.",
+			"with a preview of the first 500 bytes. Requires `rg` on PATH.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -89,10 +89,12 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 	}
 
 	// --max-columns 500 truncates any single matching line longer than 500
-	// chars and emits a "[Omitted long matching line]" marker. Without this,
-	// a hit on a minified bundle / base64 blob can flood the LLM's context
-	// with one line. Matches the cap Claude Code's GrepTool uses.
-	args := []string{"--color=never", "--max-columns", "500"}
+	// chars. Without this, a hit on a minified bundle / base64 blob can flood
+	// the LLM's context with one line. --max-columns-preview shows the first
+	// 500 bytes instead of replacing the entire line with an unhelpful
+	// "[Omitted long matching line]" marker, which previously caused the LLM
+	// to think the result was incomplete and retry in a loop.
+	args := []string{"--color=never", "--max-columns", "500", "--max-columns-preview"}
 	switch mode {
 	case "content":
 		// default rg output

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -137,8 +137,10 @@ func TestGrep_RequiresPattern(t *testing.T) {
 func TestGrep_TruncatesLongMatchingLines(t *testing.T) {
 	requireRg(t)
 	// Simulate a minified-bundle hit: one line of 1000 a's containing
-	// the pattern. With --max-columns 500, rg should suppress the body
-	// and emit the "[Omitted long matching line]" marker instead.
+	// the pattern. With --max-columns 500 --max-columns-preview, rg shows
+	// the first 500 bytes and appends "[... omitted end of long line]".
+	// This prevents the LLM from seeing only an unhelpful omission marker
+	// and retrying the same search in a loop.
 	dir := t.TempDir()
 	longLine := strings.Repeat("a", 1000) + "NEEDLE" + strings.Repeat("b", 1000)
 	writeTestFile(t, filepath.Join(dir, "minified.js"), longLine+"\n")
@@ -150,15 +152,20 @@ func TestGrep_TruncatesLongMatchingLines(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	// The literal long run of 'a' must NOT appear in output.
-	if strings.Contains(out.Text, strings.Repeat("a", 200)) {
+	// The full long run of 'a' must NOT appear in output — only the preview.
+	if strings.Contains(out.Text, strings.Repeat("a", 600)) {
 		sample := out.Text
 		if len(sample) > 200 {
 			sample = sample[:200]
 		}
 		t.Errorf("long line leaked through; head of output:\n%s", sample)
 	}
-	if !strings.Contains(out.Text, "Omitted long matching line") {
-		t.Errorf("expected omission marker; output:\n%s", out.Text)
+	// Should contain the preview truncation marker, not the old full omission.
+	if !strings.Contains(out.Text, "omitted end of long line") {
+		t.Errorf("expected preview truncation marker; output:\n%s", out.Text)
+	}
+	// The old unhelpful marker should no longer appear.
+	if strings.Contains(out.Text, "Omitted long matching line") {
+		t.Errorf("old full-omission marker should not appear; output:\n%s", out.Text)
 	}
 }


### PR DESCRIPTION
When ripgrep hits a line >500 bytes with <code>--max-columns</code> alone, it replaces the entire line with an unhelpful <code>[Omitted long matching line]</code> marker. The LLM sees no actual content, assumes the result was truncated, and retries with different patterns — causing an infinite loop (see screenshot in issue).

Add <code>--max-columns-preview</code> so rg shows the first 500 bytes plus a <code>[... omitted end of long line]</code> suffix. The LLM can now judge whether the hit is relevant and stop searching.

**Changes:**
- <code>internal/tools/grep.go</code>: add <code>--max-columns-preview</code> flag, update tool description
- <code>internal/tools/grep_test.go</code>: update assertions for preview output