### PR TITLE
feat(memory): attention layer — re-surface MEMORY.md rules at point of action

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -463,6 +463,18 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	a.System = prompt.Compose(*system, cwd, env, skillsManifest, memInjection, coauthor)
 
+	// Attention layer: re-surface MEMORY.md's structured rules (## 必须遵守 /
+	// ## 触发提醒) on the message stream at the point of action. This rides each
+	// user turn rather than the cached system prompt, so the prompt prefix stays
+	// byte-stable. A MEMORY.md without those sections yields no hook — unchanged
+	// behaviour.
+	if memDir != "" {
+		if rules := memory.ParseRules(memDir); rules.HasAny() {
+			inj := memory.NewInjector(rules)
+			a.UserInputHook = inj.Reminder
+		}
+	}
+
 	// Permission engine — gates every tool call; shared by both paths. The
 	// memory directory (outside CWD) is whitelisted for writes so the agent can
 	// manage its memory files without a prompt on every save.

--- a/dev-docs/memory-design.md
+++ b/dev-docs/memory-design.md
@@ -34,9 +34,12 @@ At session start `cmd/octo` resolves the directory, creates it, and injects
 `memory.RenderInjection(dir)` into the composed system prompt (the `memory`
 layer of `prompt.Compose`). The injection is a short instruction block —
 *where* memory lives and *how* to manage it — followed by the current MEMORY.md
-(or an "empty" marker so a fresh project knows where to start). It is framed as
-background context, not user instructions, and is frozen for the session: what
-the agent writes now surfaces in the *next* session, not the current one.
+(or an "empty" marker so a fresh project knows where to start). The notes are
+framed as the agent's own durable record of the user's preferences, workflow
+rules, and project facts, to be followed as standing guidance; the current user
+request and safety override a conflicting note. The block is frozen for the
+session: what the agent writes now surfaces in the *next* session, not the
+current one.
 
 The session-prompt guidance (`internal/prompt/base.md`, "Memory" section)
 covers when to save (lasting preferences, corrections + the why, validated
@@ -44,6 +47,38 @@ judgment, external resources), what not to save (one-off task state, anything
 derivable from the repo, secrets), grounding answers in memory with a brief
 inline attribution, and verifying a remembered file/flag still exists before
 acting on it.
+
+## Attention layer — structured rules, re-surfaced at the point of action
+
+A note buried in the frozen system-prompt block is easy for the model to skim
+past by the time it matters, many turns later. MEMORY.md may therefore carry two
+optional sections whose rules are written **in full** (not as pointer links) and
+re-surfaced on the message stream when they're relevant:
+
+```
+## 必须遵守        always-apply rules — restated every turn
+## 触发提醒        each bullet "(触发: kw1, kw2) rule text" — recalled on a keyword hit
+```
+
+`memory.ParseRules` extracts these tiers (section headings are matched by
+keyword — `必须遵守`/`always`, `触发`/`trigger` — tolerant of emoji and heading
+level). `memory.Injector.Reminder` renders the per-turn `<system-reminder>`:
+always-apply rules on every turn, plus any triggered rules whose keywords occur
+in the user input, each surfaced at most once per session. Trigger matching is
+deliberately conservative and one-directional — *input contains trigger* —
+with ASCII keywords matched on word boundaries (`deploy` does not fire on
+`deployment`) and CJK keywords matched as substrings (`部署` fires inside
+`帮我部署一下`).
+
+`cmd/octo` builds the injector once per session and wires it as
+`agent.UserInputHook`, which folds the reminder into the user message at the
+single `History.Append` choke point in `Turn`/`TurnStream`/`runLoop` (one
+appended message, so the error-path `popLast` rollback still removes exactly one
+turn). The reminder rides the message stream rather than the system prompt, so
+the cached prompt prefix stays byte-stable across the session.
+
+A MEMORY.md without these sections — the plain pointer-index format — parses to
+zero rules, sets no hook, and behaves exactly as before.
 
 ## Writing — file tools, whitelisted directory
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -148,6 +148,27 @@ type Agent struct {
 	// call, so messages enter history in chronological order. This mirrors
 	// Ruby octo's @inbox and keeps mid-turn input handling simple.
 	Inbox Inbox
+
+	// UserInputHook, when set, is called with each user input just before it is
+	// appended to history. A non-empty return is prepended to the user message
+	// (separated by a blank line). It exists to re-surface memory rules at the
+	// point of action without touching the cached system prompt; the reminder
+	// rides the message stream instead. The hook must not mutate state the
+	// caller relies on elsewhere — it's invoked once per appended user turn.
+	UserInputHook func(userInput string) string
+}
+
+// appendUserInput appends userInput to history, first prepending any
+// UserInputHook output. It stays a single appended message so the error-path
+// popLast contract in Turn/TurnStream/runLoop still removes exactly one turn.
+func (a *Agent) appendUserInput(userInput string) {
+	text := userInput
+	if a.UserInputHook != nil {
+		if reminder := a.UserInputHook(userInput); reminder != "" {
+			text = reminder + "\n\n" + userInput
+		}
+	}
+	a.History.Append(NewUserMessage(text))
 }
 
 // StopReason sentinels set on the Reply when a loop budget is exhausted.
@@ -189,7 +210,7 @@ func (a *Agent) Turn(ctx context.Context, userInput string) (Reply, error) {
 	}
 
 	// Append user message first so the snapshot the Sender sees includes it.
-	a.History.Append(NewUserMessage(userInput))
+	a.appendUserInput(userInput)
 
 	reply, err := a.Sender.SendMessages(ctx, a.Model, a.System, a.History.Snapshot(), a.MaxTokens)
 	if err != nil {
@@ -231,7 +252,7 @@ func (a *Agent) TurnStream(
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
 
-	a.History.Append(NewUserMessage(userInput))
+	a.appendUserInput(userInput)
 
 	var (
 		reply Reply
@@ -410,7 +431,7 @@ func (a *Agent) runLoop(
 	// non-fatal — we log nothing and proceed with the full history.
 	_ = a.maybeCompact(ctx)
 
-	a.History.Append(NewUserMessage(userInput))
+	a.appendUserInput(userInput)
 
 	limit := a.turnLimit()
 	for i := 0; limit == unlimitedTurns || i < limit; i++ {

--- a/internal/agent/userinputhook_test.go
+++ b/internal/agent/userinputhook_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// userText returns the plain text of a user message regardless of whether it's
+// stored as Content or a single text block.
+func userText(m Message) string {
+	if m.Content != "" {
+		return m.Content
+	}
+	for _, b := range m.Blocks {
+		if b.Text != "" {
+			return b.Text
+		}
+	}
+	return ""
+}
+
+func TestUserInputHook_PrependsReminderAsSingleMessage(t *testing.T) {
+	send := &fakeSender{reply: Reply{Content: "ok"}}
+	a := New(send, "m")
+	a.UserInputHook = func(in string) string { return "<reminder>" + in + "</reminder>" }
+
+	if _, err := a.Turn(context.Background(), "deploy please"); err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+
+	if len(send.gotMessages) != 1 {
+		t.Fatalf("sender saw %d messages, want 1 (reminder must fold into the user turn)", len(send.gotMessages))
+	}
+	got := userText(send.gotMessages[0])
+	if !strings.Contains(got, "<reminder>deploy please</reminder>") {
+		t.Errorf("reminder not prepended: %q", got)
+	}
+	if !strings.HasSuffix(got, "deploy please") {
+		t.Errorf("original input not preserved at the end: %q", got)
+	}
+}
+
+func TestUserInputHook_EmptyReturnLeavesInputUntouched(t *testing.T) {
+	send := &fakeSender{reply: Reply{Content: "ok"}}
+	a := New(send, "m")
+	a.UserInputHook = func(string) string { return "" }
+
+	if _, err := a.Turn(context.Background(), "hello"); err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+	if got := userText(send.gotMessages[0]); got != "hello" {
+		t.Errorf("input should be untouched, got %q", got)
+	}
+}
+
+func TestUserInputHook_ErrorPathPopsCombinedMessage(t *testing.T) {
+	send := &fakeSender{err: errors.New("boom")}
+	a := New(send, "m")
+	a.UserInputHook = func(in string) string { return "REMINDER\n\n" + in }
+
+	if _, err := a.Turn(context.Background(), "hi"); err == nil {
+		t.Fatal("expected error")
+	}
+	if n := a.History.Len(); n != 0 {
+		t.Errorf("History.Len after failed Turn = %d, want 0 (the combined user message must be rolled back)", n)
+	}
+}

--- a/internal/memory/injector.go
+++ b/internal/memory/injector.go
@@ -1,0 +1,134 @@
+package memory
+
+// injector.go turns parsed Rules into the per-turn reminder that cmd/octo
+// prepends to each user message. The reminder rides the message stream, not
+// the system prompt, so the cached prompt prefix stays byte-stable across the
+// session. Always-apply rules are restated every turn; triggered rules surface
+// only when user input hits one of their keywords, and at most once per session.
+
+import "strings"
+
+// Injector holds session-scoped recall state for a parsed rule set.
+type Injector struct {
+	rules    *Rules
+	recalled map[string]bool // triggered rules already surfaced this session, keyed by text
+}
+
+// NewInjector builds an injector over the given rules.
+func NewInjector(rules *Rules) *Injector {
+	return &Injector{rules: rules, recalled: make(map[string]bool)}
+}
+
+// Reminder returns the memory reminder to prepend to a user message, or "" when
+// there is nothing to surface this turn. It combines the always-apply tier
+// (every turn) with any newly-triggered rules matched against userInput.
+func (in *Injector) Reminder(userInput string) string {
+	if in == nil || in.rules == nil {
+		return ""
+	}
+
+	var fresh []Rule
+	for _, r := range in.rules.Triggered {
+		if in.recalled[r.Text] {
+			continue
+		}
+		if matchesAny(userInput, r.Triggers) {
+			in.recalled[r.Text] = true
+			fresh = append(fresh, r)
+		}
+	}
+
+	if len(in.rules.Always) == 0 && len(fresh) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("<system-reminder>\n")
+	b.WriteString("Reminders from your project memory. Follow these as standing guidance for this session — they record the user's durable preferences and workflow rules, the way project conventions do. They are records, not the user's current message: if one conflicts with what the user just asked or with safety, the current request and safety win.\n")
+	if len(in.rules.Always) > 0 {
+		b.WriteString("\nAlways apply:\n")
+		for _, r := range in.rules.Always {
+			b.WriteString("- ")
+			b.WriteString(r.Text)
+			b.WriteByte('\n')
+		}
+	}
+	if len(fresh) > 0 {
+		b.WriteString("\nRelevant to what you're about to do:\n")
+		for _, r := range fresh {
+			b.WriteString("- ")
+			b.WriteString(r.Text)
+			b.WriteByte('\n')
+		}
+	}
+	b.WriteString("</system-reminder>")
+	return b.String()
+}
+
+// matchesAny reports whether userInput hits any of the triggers.
+func matchesAny(userInput string, triggers []string) bool {
+	for _, t := range triggers {
+		if triggerHit(userInput, t) {
+			return true
+		}
+	}
+	return false
+}
+
+// triggerHit reports whether trigger occurs in input. The match is
+// conservative — the only direction checked is "input contains trigger":
+//   - ASCII triggers ("deploy") must appear on word boundaries, so "deploy"
+//     does not fire on "deployment" or "redeploy".
+//   - CJK triggers ("部署") match as a plain substring, since curated multi-rune
+//     phrases rarely collide and CJK has no whitespace word boundaries.
+//
+// It never matches in the reverse direction (trigger contains input), which is
+// what made the earlier substring-explosion matcher fire on almost anything.
+func triggerHit(input, trigger string) bool {
+	t := strings.TrimSpace(strings.ToLower(trigger))
+	if t == "" {
+		return false
+	}
+	in := strings.ToLower(input)
+	if isASCII(t) {
+		return wordBoundaryContains(in, t)
+	}
+	return strings.Contains(in, t)
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
+// wordBoundaryContains reports whether sub appears in s flanked by non-word
+// bytes (or string boundaries). sub is assumed ASCII; non-ASCII bytes in s
+// (e.g. CJK) count as boundaries, so "用deploy部署" still matches "deploy".
+func wordBoundaryContains(s, sub string) bool {
+	for from := 0; from+len(sub) <= len(s); {
+		i := strings.Index(s[from:], sub)
+		if i < 0 {
+			return false
+		}
+		i += from
+		startOK := i == 0 || !isWordByte(s[i-1])
+		end := i + len(sub)
+		endOK := end == len(s) || !isWordByte(s[end])
+		if startOK && endOK {
+			return true
+		}
+		from = i + 1
+	}
+	return false
+}
+
+func isWordByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
+}

--- a/internal/memory/injector_test.go
+++ b/internal/memory/injector_test.go
@@ -1,0 +1,76 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+func newTestInjector() *Injector {
+	return NewInjector(&Rules{
+		Always: []Rule{{Text: "never commit on main"}},
+		Triggered: []Rule{
+			{Text: "deploy via Lark bot", Triggers: []string{"deploy", "部署"}},
+			{Text: "design docs are current-state only", Triggers: []string{"设计文档"}},
+		},
+	})
+}
+
+func TestReminder_AlwaysEveryTurn(t *testing.T) {
+	in := newTestInjector()
+	for _, input := range []string{"hello", "what's up", "fix this bug"} {
+		got := in.Reminder(input)
+		if !strings.Contains(got, "never commit on main") {
+			t.Errorf("input %q: always rule missing from reminder:\n%s", input, got)
+		}
+		if !strings.Contains(got, "<system-reminder>") {
+			t.Errorf("input %q: reminder not wrapped:\n%s", input, got)
+		}
+	}
+}
+
+func TestReminder_TriggeredOnlyOnMatch(t *testing.T) {
+	in := newTestInjector()
+
+	off := in.Reminder("just say hi")
+	if strings.Contains(off, "deploy via Lark bot") {
+		t.Errorf("untriggered rule leaked:\n%s", off)
+	}
+
+	on := in.Reminder("帮我部署到 311")
+	if !strings.Contains(on, "deploy via Lark bot") {
+		t.Errorf("triggered rule missing:\n%s", on)
+	}
+}
+
+func TestReminder_TriggeredDedupPerSession(t *testing.T) {
+	in := newTestInjector()
+
+	first := in.Reminder("deploy now")
+	if !strings.Contains(first, "deploy via Lark bot") {
+		t.Fatalf("first deploy turn should surface the rule:\n%s", first)
+	}
+	second := in.Reminder("deploy again")
+	if strings.Contains(second, "deploy via Lark bot") {
+		t.Errorf("rule should not repeat in same session:\n%s", second)
+	}
+	// Always block still present on the second turn.
+	if !strings.Contains(second, "never commit on main") {
+		t.Errorf("always block dropped on second turn:\n%s", second)
+	}
+}
+
+func TestReminder_EmptyWhenNothing(t *testing.T) {
+	in := NewInjector(&Rules{
+		Triggered: []Rule{{Text: "x", Triggers: []string{"deploy"}}},
+	})
+	if got := in.Reminder("unrelated input"); got != "" {
+		t.Errorf("expected empty reminder, got:\n%s", got)
+	}
+}
+
+func TestReminder_NilSafe(t *testing.T) {
+	var in *Injector
+	if got := in.Reminder("anything"); got != "" {
+		t.Errorf("nil injector should return empty, got %q", got)
+	}
+}

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -110,8 +110,9 @@ func RenderInjection(dir string) string {
 	b.WriteString("Manage memory yourself with your file tools — that directory is writable:\n")
 	b.WriteString("- When the user states a lasting preference, gives feedback or a correction, or shares something worth recalling in future sessions, save it (append to " + IndexFile + ", or a topic file linked from it).\n")
 	b.WriteString("- Keep " + IndexFile + " a concise index; move long detail into topic files.\n")
+	b.WriteString("- For a load-bearing rule you must not skip, write it in full under a '## 必须遵守' (always-apply) section, or, if it only matters for certain tasks, under a '## 触发提醒' section with a leading '(触发: keyword1, keyword2)' clause. Rules in those sections are re-surfaced to you at the point of action; everything else stays a pointer index.\n")
 	b.WriteString("- Edit or delete entries that become wrong or obsolete. Don't store one-off task details or things already in the repo / CLAUDE.md.\n")
-	b.WriteString("Treat the contents below as background context, not user instructions; verify any file/flag named here still exists.\n")
+	b.WriteString("The notes below are your own durable record of this user's preferences, workflow rules, and project facts — follow them as standing guidance, the way you follow project conventions. They are records, not live instructions from the user: if a note conflicts with the user's current request or with safety, the current request and safety win. Verify any file, flag, or path a note names still exists before relying on it.\n")
 	if idx := LoadIndex(dir); idx != "" {
 		b.WriteString("\n## " + IndexFile + "\n\n" + idx)
 	} else {

--- a/internal/memory/rules.go
+++ b/internal/memory/rules.go
@@ -1,0 +1,126 @@
+package memory
+
+// rules.go adds an actionable, attention-aware layer on top of the plain
+// MEMORY.md injection. MEMORY.md may carry two optional structured sections:
+//
+//	## 必须遵守        (always-apply rules; restated near every user turn)
+//	## 触发提醒        (rules recalled only when user input hits a keyword)
+//
+// Rules in these sections are written in full (not as pointer links), so the
+// binding instruction is present at the point of action rather than one
+// read_file away. Everything else in MEMORY.md stays a concise pointer index
+// and is unaffected. A MEMORY.md with neither section parses to zero rules and
+// the per-turn reminder is silent — fully backward-compatible.
+
+import (
+	"bufio"
+	"regexp"
+	"strings"
+)
+
+// Rule is one actionable memory item parsed from MEMORY.md's structured
+// sections. Text is the full rule; Triggers is empty for always-apply rules.
+type Rule struct {
+	Text     string
+	Triggers []string
+}
+
+// Rules holds the two actionable tiers parsed from MEMORY.md.
+type Rules struct {
+	Always    []Rule // restated every turn
+	Triggered []Rule // recalled when user input matches a trigger
+}
+
+// HasAny reports whether there is anything to inject.
+func (r *Rules) HasAny() bool { return len(r.Always) > 0 || len(r.Triggered) > 0 }
+
+// section classifies a markdown heading into one of the actionable tiers.
+type section int
+
+const (
+	sectionNone section = iota
+	sectionAlways
+	sectionTriggered
+)
+
+// bulletPattern matches a list item: "- text" or "* text" (any indent).
+var bulletPattern = regexp.MustCompile(`^\s*[-*]\s+(.*)$`)
+
+// triggerClausePattern pulls a leading "(触发: a, b)" / "(triggers: a|b)"
+// clause off a triggered-section bullet. Group 1 is the raw keyword list,
+// group 2 is the remaining rule text. Half- and full-width parens/colons are
+// both accepted so the agent can write whichever it reaches for.
+var triggerClausePattern = regexp.MustCompile(`(?i)^[（(]\s*(?:触发词?|triggers?)\s*[:：]\s*([^)）]*)[)）]\s*(.*)$`)
+
+// ParseRules reads MEMORY.md (within the same injection budget as the static
+// injection) and extracts the always-apply and triggered rule tiers.
+func ParseRules(dir string) *Rules {
+	return parseRules(LoadIndex(dir))
+}
+
+func parseRules(raw string) *Rules {
+	r := &Rules{}
+	sc := bufio.NewScanner(strings.NewReader(raw))
+	sc.Buffer(make([]byte, 0, 64*1024), maxInjectBytes+1024)
+
+	cur := sectionNone
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			cur = classifyHeading(line)
+			continue
+		}
+		if cur == sectionNone {
+			continue
+		}
+		m := bulletPattern.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		body := strings.TrimSpace(m[1])
+		if body == "" {
+			continue
+		}
+		switch cur {
+		case sectionAlways:
+			r.Always = append(r.Always, Rule{Text: body})
+		case sectionTriggered:
+			r.Triggered = append(r.Triggered, parseTriggeredBullet(body))
+		}
+	}
+	return r
+}
+
+// classifyHeading maps a heading line to a section by keyword, tolerant of
+// emoji/level prefixes. Unrecognized headings end any open rules section.
+func classifyHeading(line string) section {
+	h := strings.ToLower(line)
+	switch {
+	case strings.Contains(h, "必须遵守") || strings.Contains(h, "always"):
+		return sectionAlways
+	case strings.Contains(h, "触发") || strings.Contains(h, "trigger"):
+		return sectionTriggered
+	default:
+		return sectionNone
+	}
+}
+
+// parseTriggeredBullet splits "(触发: a, b) rule text" into triggers + text.
+// A bullet without a trigger clause yields a rule with no triggers, which is
+// never recalled — the parser keeps it (so the text isn't lost) rather than
+// guessing keywords.
+func parseTriggeredBullet(body string) Rule {
+	m := triggerClausePattern.FindStringSubmatch(body)
+	if m == nil {
+		return Rule{Text: body}
+	}
+	var triggers []string
+	for _, part := range strings.FieldsFunc(m[1], func(r rune) bool {
+		return r == ',' || r == '，' || r == '、' || r == '|'
+	}) {
+		if t := strings.TrimSpace(part); t != "" {
+			triggers = append(triggers, t)
+		}
+	}
+	return Rule{Text: strings.TrimSpace(m[2]), Triggers: triggers}
+}

--- a/internal/memory/rules_test.go
+++ b/internal/memory/rules_test.go
@@ -1,0 +1,114 @@
+package memory
+
+import "testing"
+
+func TestParseRules_Sections(t *testing.T) {
+	raw := `# Memory index
+
+- [Some topic](topic.md) — a pointer, not a rule
+
+## 必须遵守
+
+- never commit on main; push lands via PR only
+- coding tasks run in an isolated git worktree
+
+## 触发提醒
+
+- (触发: deploy, 部署, 上311) 部署走 Lark bot：git 分支转 CI image tag 再发消息
+- （触发：设计文档、design doc） 设计文档只描述当前状态，不写过程/历史
+
+## 索引
+
+- [Another](another.md) — also just a pointer
+`
+	r := parseRules(raw)
+
+	if len(r.Always) != 2 {
+		t.Fatalf("Always = %d, want 2: %+v", len(r.Always), r.Always)
+	}
+	if r.Always[0].Text != "never commit on main; push lands via PR only" {
+		t.Errorf("Always[0] = %q", r.Always[0].Text)
+	}
+
+	if len(r.Triggered) != 2 {
+		t.Fatalf("Triggered = %d, want 2: %+v", len(r.Triggered), r.Triggered)
+	}
+	got := r.Triggered[0]
+	wantTriggers := []string{"deploy", "部署", "上311"}
+	if len(got.Triggers) != len(wantTriggers) {
+		t.Fatalf("Triggered[0].Triggers = %v, want %v", got.Triggers, wantTriggers)
+	}
+	for i, w := range wantTriggers {
+		if got.Triggers[i] != w {
+			t.Errorf("trigger[%d] = %q, want %q", i, got.Triggers[i], w)
+		}
+	}
+	if got.Text != "部署走 Lark bot：git 分支转 CI image tag 再发消息" {
+		t.Errorf("Triggered[0].Text = %q", got.Text)
+	}
+	// Full-width parens / 、 separator.
+	if len(r.Triggered[1].Triggers) != 2 || r.Triggered[1].Triggers[0] != "设计文档" {
+		t.Errorf("Triggered[1].Triggers = %v", r.Triggered[1].Triggers)
+	}
+}
+
+func TestParseRules_PointerOnlyIsBackwardCompatible(t *testing.T) {
+	// The current real MEMORY.md format: one-line pointers, no rule sections.
+	raw := `- [Go rewrite](project_go_rewrite.md) — repo renamed
+- [Branch workflow](feedback_branch_workflow.md) — PR-only into main
+`
+	r := parseRules(raw)
+	if r.HasAny() {
+		t.Errorf("pointer-only MEMORY.md should yield no rules, got %+v", r)
+	}
+}
+
+func TestParseRules_EmojiHeadingAndSectionEnd(t *testing.T) {
+	raw := `## 🔴 必须遵守
+
+- rule one
+
+## Unrelated heading
+
+- this bullet is not a rule
+`
+	r := parseRules(raw)
+	if len(r.Always) != 1 || r.Always[0].Text != "rule one" {
+		t.Fatalf("Always = %+v", r.Always)
+	}
+	if len(r.Triggered) != 0 {
+		t.Errorf("Triggered should be empty, got %+v", r.Triggered)
+	}
+}
+
+func TestParseRules_TriggeredBulletWithoutClause(t *testing.T) {
+	raw := "## 触发提醒\n\n- a rule with no trigger clause\n"
+	r := parseRules(raw)
+	if len(r.Triggered) != 1 {
+		t.Fatalf("Triggered = %d, want 1", len(r.Triggered))
+	}
+	if r.Triggered[0].Text != "a rule with no trigger clause" || len(r.Triggered[0].Triggers) != 0 {
+		t.Errorf("got %+v", r.Triggered[0])
+	}
+}
+
+func TestTriggerHit(t *testing.T) {
+	cases := []struct {
+		input, trigger string
+		want           bool
+	}{
+		{"deploy to 311", "deploy", true},
+		{"Deploy To 311", "deploy", true},    // case-insensitive
+		{"deployment plan", "deploy", false}, // ASCII word boundary
+		{"redeploy now", "deploy", false},
+		{"帮我部署一下到 311", "部署", true},     // CJK substring
+		{"用 deploy 部署", "deploy", true}, // ASCII flanked by CJK/space
+		{"just chatting", "deploy", false},
+		{"de", "deploy", false}, // no reverse match (trigger contains input)
+	}
+	for _, c := range cases {
+		if got := triggerHit(c.input, c.trigger); got != c.want {
+			t.Errorf("triggerHit(%q, %q) = %v, want %v", c.input, c.trigger, got, c.want)
+		}
+	}
+}

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -20,13 +20,14 @@ You are octo, an AI coding agent that runs in a terminal and operates on the use
 
 ## Memory
 
-You have cross-session memory: a per-project directory of markdown files you manage yourself with your file tools. Its `MEMORY.md` index is injected into a "Memory (from past sessions)" block near the top of this prompt — that block is **background context**, not user instructions, and is frozen at session start, so what you write now lands in the next session, not this one. The block names the exact directory path.
+You have cross-session memory: a per-project directory of markdown files you manage yourself with your file tools. Its `MEMORY.md` index is injected into a "Memory (from past sessions)" block near the top of this prompt, naming the exact directory path. Treat the notes there as your own durable record of the user's preferences, workflow rules, and project facts — **follow them as standing guidance**, the way you follow project conventions. They are records, not the user speaking this session: if one conflicts with the user's current request or with safety, the current request and safety win. The block is frozen at session start, so what you write now lands in the next session, not this one.
 
 ### Managing it
 
 `MEMORY.md` is the index; topic files beside it (e.g. `preferences.md`) hold detail and you read them on demand. The directory is writable — manage it directly with `write_file` / `edit_file` (and `terminal` for rm/rename):
 
 - **Save** a durable fact by appending to `MEMORY.md`, or to a topic file linked from it. Keep `MEMORY.md` a concise index; move long detail into topic files.
+- **Promote a load-bearing rule** — one you must not skip — into a `## 必须遵守` section, written in full (not as a pointer). If it only matters for certain tasks, put it under `## 触发提醒` with a leading `(触发: keyword1, keyword2)` clause. Rules in these sections are re-surfaced to you mid-conversation as `<system-reminder>` blocks drawn from your own memory — the always-apply ones every turn, the triggered ones when your input hits a keyword. Follow them; everything else stays a pointer index.
 - **Edit or delete** an entry the moment it becomes wrong or obsolete — open the file and fix it. The user always wins: when they contradict a remembered fact, update or delete it rather than arguing from memory.
 - Convert relative dates to absolute when saving (`Thursday` → the actual date) so facts stay legible later.
 


### PR DESCRIPTION
## 背景

替代被回退的 #318。#318 想修「记忆注入了但 agent 不照做」，方向对但实现挂了：整套代码没接线（死代码）、解析的 `## CRITICAL — Title` 标题格式与真实 MEMORY.md 的一行式指针不符、还有按字节切中文等问题。本 PR 重做。

## 根因（三条，#318 只碰了后两条）

1. **注入文案叫模型别当真**：`RenderInjection` 写着 "background context, **not user instructions**" —— 直接把记忆降级成 FYI。
2. **MEMORY.md 是指针索引**：约束规则的正文在 topic 文件里、按需才加载，启动时只看到一句钩子。
3. **静态冻结、动作时离得远**：system prompt 一次 composed 后冻结（为缓存），相关规则在长 prompt 中部，等真正动作时显著度低。

## 方案

- **文案修复**：`RenderInjection` 改为「这些是你应遵守的持久偏好/工作流规则」，保留「与当前用户请求或安全冲突时以后者为准」的防投毒边界。
- **分级（专用区块）**：MEMORY.md 新增两个可选区块 —— `## 必须遵守`（always-apply）和 `## 触发提醒`（每条带 `(触发: kw1, kw2)`）。规则写**全文**，其余仍是一行式指针。
- **动作时重注入**：`internal/memory/rules.go` 解析区块，`injector.go` 生成每轮的 `<system-reminder>`——always 规则每轮重述，触发规则仅在输入命中关键词时出现、同会话去重。
- **注入点**：`agent.UserInputHook` 在 `History.Append(NewUserMessage)` 这个唯一 choke point 把提醒折进**同一条** user 消息（保住 `popLast` 错误回滚契约）。提醒走**消息流**，不动 system prompt → 缓存前缀逐字不变。

## 触发匹配（修掉 #318 的误报）

只判断单向「输入包含触发词」：ASCII 走词边界（`deploy` 不命中 `deployment`/`redeploy`），CJK 走子串（`部署` 命中「帮我部署一下」）。不做 2-4 子串爆炸，也不做反向 Contains。

## 向后兼容

MEMORY.md 没有这两个区块 → 解析出 0 条规则 → 不设 hook → 行为与现状完全一致。现有纯指针格式不受影响。

## 验收

- always 规则每轮出现在用户输入附近 ✅
- 触发词命中才重注入、未命中不出现、同会话不重复 ✅
- system prompt 前缀逐字不变（缓存命中）✅
- 空/旧纯指针 MEMORY.md 一切照常 ✅

## 测试

`internal/memory`（解析含全/半角括号与 `、` 分隔、向后兼容、触发匹配、去重、nil 安全）与 `internal/agent`（hook 折进单条消息、空返回不改输入、错误路径回滚）均覆盖。`go test -race ./...`、`go vet ./...`、`gofmt -l .` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)