### PR TITLE
chore(release): bump version to 0.12.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "0.12.0"
+var Version = "0.12.1"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump version from 0.12.0 to 0.12.1.\n\nCo-authored-by: octo-agent <no-reply@octo-agent.dev>