### PR TITLE
feat(agent): recover from output-token truncation by escalating the cap

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -53,6 +54,33 @@ func resolveMaxTurns(flagVal int, seeded, interactive bool) int {
 		return unattendedMaxTurns
 	}
 	return 0
+}
+
+// Provider-aware defaults for the escalated output cap retried on truncation.
+// Conservative per protocol since octo has no per-model capability table; a
+// model whose ceiling is below the target backs off at the API (see the agent
+// loop's isMaxTokensTooLargeErr). See dev-docs/truncation-recovery.md.
+const (
+	escalateMaxTokensOpenAI    = 16384
+	escalateMaxTokensAnthropic = 32768
+)
+
+// resolveMaxTokensEscalate picks the escalated cap: an explicit flag (>= 0)
+// wins, then OCTO_MAX_TOKENS_ESCALATE, then the provider-aware default. 0
+// disables escalation.
+func resolveMaxTokensEscalate(flagVal int, provName string) int {
+	if flagVal >= 0 {
+		return flagVal
+	}
+	if env := strings.TrimSpace(os.Getenv("OCTO_MAX_TOKENS_ESCALATE")); env != "" {
+		if n, err := strconv.Atoi(env); err == nil && n >= 0 {
+			return n
+		}
+	}
+	if provName == providerOpenAI {
+		return escalateMaxTokensOpenAI
+	}
+	return escalateMaxTokensAnthropic
 }
 
 // tuiDisabledByEnv reports whether OCTO_TUI is set to a falsey value, the env
@@ -111,6 +139,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	model := fs.String("model", "", "Model name (else ANTHROPIC_MODEL/OPENAI_MODEL env, then `octo config`, then the provider's cheapest reasoning model)")
 	system := fs.String("system", "", "System prompt (optional)")
 	maxTokens := fs.Int("max-tokens", 0, "max_tokens for the response (0 = provider default)")
+	maxTokensEscalate := fs.Int("max-tokens-escalate", -1, "Per-response cap retried once when a reply is truncated by the output cap (-1 = provider-aware default, 0 = disable). Also OCTO_MAX_TOKENS_ESCALATE.")
 	stream := fs.Bool("stream", true, "Stream the reply (chunks printed as they arrive); --stream=false buffers")
 	continueID := fs.String("c", "", "Resume a session — accepts 'last', a short ID, or a substring of an ID")
 	continueIDLong := fs.String("continue", "", "Resume a session — accepts 'last', a short ID, or a substring of an ID")
@@ -328,6 +357,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}, resolvedModel)
 	a.CWD = cwd
 	a.MaxTokens = *maxTokens
+	a.MaxTokensEscalate = resolveMaxTokensEscalate(*maxTokensEscalate, provName)
 	a.MaxTurns = resolveMaxTurns(*maxTurns, seedPrompt != "", stdinIsTTY(stdin))
 	a.CompactThreshold = *compactThreshold
 

--- a/cmd/octo/completion.go
+++ b/cmd/octo/completion.go
@@ -112,7 +112,7 @@ func chatCandidates(words []string, prev string) []string {
 		return []string{"anthropic", "openai"}
 	case "--permission-mode":
 		return []string{"interactive", "strict", "auto"}
-	case "--model", "--system", "--max-tokens", "--max-turns",
+	case "--model", "--system", "--max-tokens", "--max-tokens-escalate", "--max-turns",
 		"--compact-threshold", "--thinking-budget",
 		"--sandbox-write", "--sandbox-read":
 		// These take freeform values; nothing useful to suggest.

--- a/dev-docs/truncation-recovery.md
+++ b/dev-docs/truncation-recovery.md
@@ -1,0 +1,113 @@
+# Output-truncation recovery
+
+When a model response is cut off by the per-response output-token cap
+(`max_tokens`), the agent loop **retries the same round once at a higher cap**
+instead of ending the turn with a discarded, half-formed response. This is what
+lets a single large artifact — a full HTML page emitted as one `write_file` tool
+call — land even when it exceeds the default cap.
+
+## The failure it fixes
+
+A tool call's arguments are model **output tokens**: when octo writes a file,
+the model emits the entire file content as the `write_file` call's argument JSON.
+A large file plus any preceding text can exceed the output cap, so the response
+is truncated mid-JSON. Two things then conspire:
+
+- The provider reports truncation, not a tool call — `finish_reason="length"`
+  (OpenAI) / `stop_reason="max_tokens"` (Anthropic), never `tool_use`.
+- The truncated argument JSON is unparseable, so the assembled tool-use block
+  carries empty input (`openai/stream.go` ignores the unmarshal error).
+
+The loop only continues on `tool_use`, so a truncated turn fell through to the
+"final reply" branch and ended — the half-written file never dispatched, nothing
+landed. On large artifacts this is intermittent: it depends on how verbose the
+model is that run.
+
+## Design
+
+### One canonical truncation sentinel
+
+Adapters normalise their wire value to a single agent-level constant,
+`StopReasonMaxTokens = "max_tokens"`, the same way they already map
+`tool_calls`/`tool_use`:
+
+| Provider | wire value | normalised to |
+|---|---|---|
+| Anthropic | `stop_reason: "max_tokens"` | `"max_tokens"` (unchanged) |
+| OpenAI    | `finish_reason: "length"`   | `"max_tokens"` |
+
+The loop then checks one thing.
+
+### Escalate-and-retry, from the same history
+
+After each model call, if the reply is truncated and an escalation cap is
+configured above the current cap, the loop re-issues the **same round** at the
+escalated cap. Crucially it retries from the **unchanged history** — the
+truncated reply is never appended — so a half-written tool call is simply
+regenerated with more room. This sidesteps the hard, provider-specific problem
+of resuming a partial `tool_use` block (OpenAI-compatible backends reject a
+malformed tool call in history); no partial state is ever kept.
+
+Escalation fires **at most once per round**. Each model call's usage is
+accounted (both the truncated attempt and the retry cost real tokens).
+
+### Provider-aware escalation default
+
+octo has no per-model capability table, so the escalation target is a
+conservative default per protocol, overridable by flag/env:
+
+| Provider | first attempt | escalation target |
+|---|---|---|
+| OpenAI protocol | provider default (4096) | 16384 |
+| Anthropic protocol | provider default (4096) | 32768 |
+
+- `--max-tokens-escalate N` / `OCTO_MAX_TOKENS_ESCALATE=N` overrides it;
+  `0` disables escalation entirely.
+- Escalation only ever raises the cap: if the caller already set `--max-tokens`
+  above the escalation target, no escalation happens.
+
+**Model-ceiling backoff.** Some models cap below the escalation target (Claude 3
+tops out at 4096). Escalating past a model's ceiling returns a `max_tokens`
+error; the loop detects it (`isMaxTokensTooLargeErr`, a best-effort match on the
+provider error text), keeps the original truncated reply, and falls through to a
+graceful stop rather than failing the turn.
+
+### Graceful stop when still truncated
+
+If escalation is disabled, hits the model ceiling, or the escalated cap is still
+not enough, the loop ends the turn through the existing `budgetStop` path with
+`StopReason` `max_tokens` and a clear message — history keeps the progress, the
+caller gets a non-error explanation, and no half-formed tool call is dispatched.
+
+## Seam
+
+The provider call in `runLoop` (`internal/agent/agent.go`) goes through a `send`
+closure. Its signature carries the per-call cap so the loop can re-issue at a
+different value:
+
+```
+send func(ctx, msgs []Message, maxTokens int) (Reply, error)
+```
+
+`Run` and `RunStream` build the closure over the active `ToolSender` /
+`ToolStreamingSender`, passing the cap straight through to the provider request.
+The escalation policy lives entirely in `runLoop`; the `Sender` interfaces are
+unchanged, so provider adapters need no new methods.
+
+## Known limitation (streaming re-emit)
+
+In the streaming path the truncated attempt has already emitted its deltas to the
+handler before the retry runs, so an escalated retry re-streams. For the primary
+case — a `write_file` call, whose content surfaces as a tool card rather than
+prose — the visible result is the final file, so impact is minor. Suppressing
+the re-emit is left to a later change.
+
+## Not yet implemented: resume-and-chunk
+
+A second tier — keep the partial output, feed back a "you were cut off; resume
+mid-thought and write in smaller pieces" message, and continue (à la Claude
+Code's multi-turn recovery) — is **not** built. It needs per-provider handling
+of the partial `tool_use` block (safe on Anthropic, needs cleanup on
+OpenAI-compatible backends) and is a separate change. Layer 1 (escalate-retry)
+covers the common large-artifact case without it.
+```

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -122,6 +122,13 @@ type Agent struct {
 	// with a friendly budget reply (StopReason "max_turns"), not an error.
 	MaxTurns int
 
+	// MaxTokensEscalate is the per-response cap retried once, from unchanged
+	// history, when a round is truncated by the output cap (StopReasonMaxTokens).
+	// It only ever raises the cap: escalation fires only when this exceeds the
+	// round's current cap. <= 0 disables escalation. See
+	// dev-docs/truncation-recovery.md.
+	MaxTokensEscalate int
+
 	// CompactThreshold controls history compaction: when the most recent
 	// context sent (lastInputTokens) crosses the effective trigger, the next
 	// Run/RunStream summarizes the older turns before continuing. Semantics:
@@ -177,6 +184,12 @@ func (a *Agent) appendUserInput(userInput string) {
 const (
 	StopReasonMaxTurns    = "max_turns"
 	StopReasonInterrupted = "interrupted"
+	// StopReasonMaxTokens is the canonical output-truncation sentinel. Provider
+	// adapters normalise their wire value to it (Anthropic "max_tokens", OpenAI
+	// "length") so the loop checks one thing. The loop also reuses it as the
+	// synthetic StopReason when a turn is ended because the response stayed
+	// truncated even after escalation. See dev-docs/truncation-recovery.md.
+	StopReasonMaxTokens = "max_tokens"
 )
 
 // interruptNote caps an interrupted turn as an assistant message so history
@@ -318,8 +331,8 @@ func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinitio
 	// Buffered send + nil handler: runLoop runs the same dispatch/history
 	// machinery as the streaming path but emits no events.
 	return a.runLoop(ctx, userInput, tools, executor, nil,
-		func(ctx context.Context, msgs []Message) (Reply, error) {
-			return ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, a.MaxTokens, tools)
+		func(ctx context.Context, msgs []Message, maxTokens int) (Reply, error) {
+			return ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, maxTokens, tools)
 		})
 }
 
@@ -384,14 +397,14 @@ func (a *Agent) RunStream(
 	// Try ToolStreamingSender first, then fall back to ToolSender (buffered).
 	if tss, ok := a.Sender.(ToolStreamingSender); ok {
 		return a.runLoop(ctx, userInput, tools, executor, handler,
-			func(ctx context.Context, msgs []Message) (Reply, error) {
-				return tss.StreamMessagesWithTools(ctx, a.Model, a.System, msgs, a.MaxTokens, tools, onChunk, onToolDelta)
+			func(ctx context.Context, msgs []Message, maxTokens int) (Reply, error) {
+				return tss.StreamMessagesWithTools(ctx, a.Model, a.System, msgs, maxTokens, tools, onChunk, onToolDelta)
 			})
 	}
 	if ts, ok := a.Sender.(ToolSender); ok {
 		return a.runLoop(ctx, userInput, tools, executor, handler,
-			func(ctx context.Context, msgs []Message) (Reply, error) {
-				reply, err := ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, a.MaxTokens, tools)
+			func(ctx context.Context, msgs []Message, maxTokens int) (Reply, error) {
+				reply, err := ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, maxTokens, tools)
 				if err == nil && reply.Content != "" {
 					onChunk(reply.Content)
 				}
@@ -422,7 +435,7 @@ func (a *Agent) runLoop(
 	tools []ToolDefinition,
 	executor ToolExecutor,
 	handler EventHandler,
-	send func(ctx context.Context, msgs []Message) (Reply, error),
+	send func(ctx context.Context, msgs []Message, maxTokens int) (Reply, error),
 ) (Reply, error) {
 	// Compact older history before starting a new turn, if the last context
 	// crossed the threshold. Done here (a safe between-turns boundary, history
@@ -458,7 +471,7 @@ func (a *Agent) runLoop(
 		// error tool_results prevents Anthropic HTTP 400 errors.
 		a.ensureToolPairing()
 
-		reply, err := send(ctx, a.History.Snapshot())
+		reply, err := send(ctx, a.History.Snapshot(), a.MaxTokens)
 		if err != nil {
 			// Interrupt during the provider call: finalize cleanly rather than
 			// surfacing context.Canceled as a turn error.
@@ -483,6 +496,43 @@ func (a *Agent) runLoop(
 		a.overflow.reset()
 
 		a.accrueUsage(reply)
+
+		// ── Output-truncation recovery (layer 1) ──
+		// The response was cut off by the output-token cap. Retry this same
+		// round once at the escalated cap, from the UNCHANGED history (the
+		// truncated reply is never appended), so a half-written tool call is
+		// regenerated with more room — no provider-specific partial-tool_use
+		// handling needed. Fires only when escalation raises the cap.
+		// See dev-docs/truncation-recovery.md.
+		if isTruncated(reply.StopReason) && a.MaxTokensEscalate > a.MaxTokens {
+			escalated, eerr := send(ctx, a.History.Snapshot(), a.MaxTokensEscalate)
+			switch {
+			case eerr == nil:
+				reply = escalated
+				a.accrueUsage(reply)
+			case ctx.Err() != nil:
+				return a.finishInterrupted(handler)
+			case isMaxTokensTooLargeErr(eerr):
+				// The model's ceiling is below the escalation target (e.g.
+				// Claude 3 caps at 4096). Keep the truncated reply and fall
+				// through to the graceful stop below.
+			default:
+				if i == 0 {
+					a.History.popLast()
+				}
+				return Reply{}, fmt.Errorf("agent: loop[%d] escalate: %w", i, eerr)
+			}
+		}
+
+		// Still truncated (escalation disabled, model ceiling hit, or even the
+		// escalated cap fell short): end the turn cleanly rather than dispatching
+		// a half-formed tool call or returning an empty reply. History keeps the
+		// progress; the caller gets a non-error explanation.
+		if isTruncated(reply.StopReason) {
+			return a.budgetStop(handler, StopReasonMaxTokens,
+				"[octo] Stopped: the response was truncated at the output-token cap. "+
+					"Raise --max-tokens / --max-tokens-escalate, or ask me to continue in smaller steps.")
+		}
 
 		if reply.StopReason == "tool_use" {
 			a.History.Append(NewToolUseMessage(reply.Blocks))
@@ -609,6 +659,34 @@ func (a *Agent) budgetStop(handler EventHandler, reason, msg string) (Reply, err
 		handler(AgentEvent{Kind: EventTurnDone, Reply: &r})
 	}
 	return reply, nil
+}
+
+// isTruncated reports whether a reply was cut off by the output-token cap.
+// Adapters normalise their wire value to StopReasonMaxTokens, so the loop only
+// checks this one sentinel.
+func isTruncated(stopReason string) bool {
+	return stopReason == StopReasonMaxTokens
+}
+
+// isMaxTokensTooLargeErr best-effort detects a provider rejecting an escalated
+// max_tokens because it exceeds the model's ceiling (e.g. Claude 3 caps at
+// 4096). Both Anthropic and OpenAI-protocol backends name max_tokens in the
+// message; the surrounding wording varies, so this matches loosely. On a false
+// negative the escalation error simply surfaces as a normal turn error.
+func isMaxTokensTooLargeErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	if !strings.Contains(s, "max_tokens") && !strings.Contains(s, "max tokens") {
+		return false
+	}
+	for _, marker := range []string{"exceed", "greater than", "too large", "maximum", "at most", "less than or equal"} {
+		if strings.Contains(s, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // emitToolStartedEvents fires one EventToolStarted per tool_use block.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -240,17 +240,31 @@ func TestAgent_TurnStream_Error_RestoresHistory(t *testing.T) {
 type fakeToolSender struct {
 	replies []Reply
 	calls   int
+	// errs, when non-nil and indexed by call, makes that call return the error
+	// instead of a reply (used to exercise escalation backoff). A nil entry
+	// falls through to replies.
+	errs []error
+	// gotMaxToks records the maxTokens passed on each call, in order, so tests
+	// can assert escalation re-issued at the higher cap.
+	gotMaxToks []int
 }
 
-func (f *fakeToolSender) SendMessages(_ context.Context, _, _ string, _ []Message, _ int) (Reply, error) {
+func (f *fakeToolSender) SendMessages(_ context.Context, _, _ string, _ []Message, maxTokens int) (Reply, error) {
+	f.gotMaxToks = append(f.gotMaxToks, maxTokens)
 	return f.nextReply()
 }
 
-func (f *fakeToolSender) SendMessagesWithTools(_ context.Context, _, _ string, _ []Message, _ int, _ []ToolDefinition) (Reply, error) {
+func (f *fakeToolSender) SendMessagesWithTools(_ context.Context, _, _ string, _ []Message, maxTokens int, _ []ToolDefinition) (Reply, error) {
+	f.gotMaxToks = append(f.gotMaxToks, maxTokens)
 	return f.nextReply()
 }
 
 func (f *fakeToolSender) nextReply() (Reply, error) {
+	if f.calls < len(f.errs) && f.errs[f.calls] != nil {
+		err := f.errs[f.calls]
+		f.calls++
+		return Reply{}, err
+	}
 	if f.calls >= len(f.replies) {
 		return Reply{}, fmt.Errorf("fakeToolSender: no more replies (call %d)", f.calls)
 	}
@@ -1080,4 +1094,148 @@ func TestContextUsage_IncludesCacheTokens(t *testing.T) {
 	if window <= 0 {
 		t.Errorf("ContextUsage window = %d, want > 0", window)
 	}
+}
+
+// ─── Output-truncation recovery (layer 1) ──────────────────────────────────
+
+// truncToolDefs/exec: a minimal tool set so Run takes the runLoop path. The
+// truncation replies carry no tool_use, so the executor never fires.
+func truncSetup() ([]ToolDefinition, *fakeExecutor) {
+	return []ToolDefinition{{Name: "bash", Description: "run shell"}}, &fakeExecutor{}
+}
+
+func TestRunLoop_Truncation_EscalatesAndContinues(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{
+		{StopReason: StopReasonMaxTokens, Content: "half-writt"}, // truncated
+		{StopReason: "end_turn", Content: "done"},                // escalated retry succeeds
+	}}
+	a := New(send, "m")
+	a.MaxTokens = 4096
+	a.MaxTokensEscalate = 16384
+	defs, exec := truncSetup()
+
+	reply, err := a.Run(context.Background(), "write a big file", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.Content != "done" || reply.StopReason != "end_turn" {
+		t.Errorf("reply = %+v, want done/end_turn", reply)
+	}
+	// Re-issued the same round at the escalated cap.
+	if want := []int{4096, 16384}; !equalInts(send.gotMaxToks, want) {
+		t.Errorf("gotMaxToks = %v, want %v", send.gotMaxToks, want)
+	}
+	// The truncated reply must NOT be in history; only [user, assistant(done)].
+	snap := a.History.Snapshot()
+	if len(snap) != 2 || snap[1].Role != RoleAssistant {
+		t.Fatalf("History = %+v, want [user, assistant]", snap)
+	}
+	if got := textFromBlocks(snap[1].Blocks); got == "half-writt" {
+		t.Error("truncated reply leaked into history")
+	}
+}
+
+func TestRunLoop_Truncation_EscalationDisabled_GracefulStop(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{
+		{StopReason: StopReasonMaxTokens, Content: "partial"},
+	}}
+	a := New(send, "m")
+	a.MaxTokens = 4096
+	a.MaxTokensEscalate = 0 // disabled
+	defs, exec := truncSetup()
+
+	reply, err := a.Run(context.Background(), "write a big file", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.StopReason != StopReasonMaxTokens {
+		t.Errorf("StopReason = %q, want %q", reply.StopReason, StopReasonMaxTokens)
+	}
+	if !strings.Contains(reply.Content, "truncated") {
+		t.Errorf("graceful-stop message = %q, want it to mention truncation", reply.Content)
+	}
+	if len(send.gotMaxToks) != 1 {
+		t.Errorf("calls = %d, want 1 (no escalation)", len(send.gotMaxToks))
+	}
+}
+
+func TestRunLoop_Truncation_EscalatedStillTruncated_GracefulStop(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{
+		{StopReason: StopReasonMaxTokens},
+		{StopReason: StopReasonMaxTokens}, // even 64k-ish cap not enough
+	}}
+	a := New(send, "m")
+	a.MaxTokens = 4096
+	a.MaxTokensEscalate = 16384
+	defs, exec := truncSetup()
+
+	reply, err := a.Run(context.Background(), "write a huge file", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.StopReason != StopReasonMaxTokens {
+		t.Errorf("StopReason = %q, want graceful %q", reply.StopReason, StopReasonMaxTokens)
+	}
+	if want := []int{4096, 16384}; !equalInts(send.gotMaxToks, want) {
+		t.Errorf("gotMaxToks = %v, want %v", send.gotMaxToks, want)
+	}
+}
+
+func TestRunLoop_Truncation_ModelCeilingBackoff(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{{StopReason: StopReasonMaxTokens}},
+		errs:    []error{nil, errors.New("400 max_tokens: 99999 is greater than the maximum allowed for this model")},
+	}
+	a := New(send, "m")
+	a.MaxTokens = 4096
+	a.MaxTokensEscalate = 99999 // above the model ceiling
+	defs, exec := truncSetup()
+
+	reply, err := a.Run(context.Background(), "write a file", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: unexpected error (ceiling should back off, not fail): %v", err)
+	}
+	if reply.StopReason != StopReasonMaxTokens {
+		t.Errorf("StopReason = %q, want graceful %q after ceiling backoff", reply.StopReason, StopReasonMaxTokens)
+	}
+	if want := []int{4096, 99999}; !equalInts(send.gotMaxToks, want) {
+		t.Errorf("gotMaxToks = %v, want %v", send.gotMaxToks, want)
+	}
+}
+
+func TestIsMaxTokensTooLargeErr(t *testing.T) {
+	yes := []string{
+		"400 max_tokens: 99999 is greater than the maximum allowed",
+		"max_tokens too large for model",
+		"max tokens exceeds the model maximum",
+		"`max_tokens` must be less than or equal to 8192",
+	}
+	for _, s := range yes {
+		if !isMaxTokensTooLargeErr(errors.New(s)) {
+			t.Errorf("isMaxTokensTooLargeErr(%q) = false, want true", s)
+		}
+	}
+	no := []error{
+		nil,
+		errors.New("rate limit exceeded"),
+		errors.New("context deadline exceeded"),
+		errors.New("max_tokens parameter accepted"),
+	}
+	for _, e := range no {
+		if isMaxTokensTooLargeErr(e) {
+			t.Errorf("isMaxTokensTooLargeErr(%v) = true, want false", e)
+		}
+	}
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -185,6 +185,12 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 	// Convert tool calls to agent.ContentBlock.
 	var blocks []agent.ContentBlock
 	var stopReason = first.FinishReason
+	// Normalise the output-cap truncation signal to the canonical sentinel the
+	// agent loop checks (matches Anthropic's "max_tokens"), so truncation
+	// recovery is provider-agnostic. Independent of whether a tool call is present.
+	if stopReason == "length" {
+		stopReason = "max_tokens"
+	}
 	if len(first.Message.ToolCalls) > 0 {
 		for _, tc := range first.Message.ToolCalls {
 			var input map[string]any

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -202,8 +202,14 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		}
 		if choice.FinishReason != "" {
 			stopReason := choice.FinishReason
-			if stopReason == "tool_calls" {
+			switch stopReason {
+			case "tool_calls":
 				stopReason = "tool_use"
+			case "length":
+				// Normalise the output-cap truncation signal to the canonical
+				// sentinel the agent loop checks (matches Anthropic's
+				// "max_tokens"), so truncation recovery is provider-agnostic.
+				stopReason = "max_tokens"
 			}
 			result.StopReason = stopReason
 		}

--- a/internal/provider/openai/stream_test.go
+++ b/internal/provider/openai/stream_test.go
@@ -87,6 +87,41 @@ func TestSendStream_OpenAI_AggregatesAndCallsBack(t *testing.T) {
 	}
 }
 
+// A finish_reason of "length" (output-cap truncation) must be normalised to the
+// canonical "max_tokens" sentinel so the agent loop's truncation recovery is
+// provider-agnostic.
+func TestSendStream_OpenAI_LengthNormalisedToMaxTokens(t *testing.T) {
+	stream := `data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}` + "\n\n" +
+		`data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"length"}]}` + "\n\n" +
+		"data: [DONE]\n\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, stream)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	c, err := New("test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.BaseURL = srv.URL
+
+	resp, err := c.SendStream(context.Background(), provider.Request{
+		Model:    "gpt-4o-mini",
+		Messages: []agent.Message{agent.NewUserMessage("write a big file")},
+	}, provider.StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("SendStream: %v", err)
+	}
+	if resp.StopReason != "max_tokens" {
+		t.Errorf("StopReason = %q, want %q (length must normalise)", resp.StopReason, "max_tokens")
+	}
+}
+
 func TestSendStream_SendsIncludeUsage(t *testing.T) {
 	// DashScope / real OpenAI send no usage at all on a stream unless we ask via
 	// stream_options.include_usage. Assert the outgoing body carries it.


### PR DESCRIPTION
## What

When a model response is cut off by the per-response output cap (`max_tokens`), the agent loop now **retries the same round once at a higher cap** instead of ending the turn with a discarded, half-formed response. This lets a large single-file artifact — a full HTML page emitted as one `write_file` call — land even when it exceeds the default cap.

## The bug

A tool call's arguments are model output tokens, so writing a big file can blow past the output cap mid-JSON. Truncation reports `finish_reason="length"` (OpenAI) / `stop_reason="max_tokens"` (Anthropic) — **never `tool_use`** — and the half-written argument JSON is unparseable (empty tool input). The loop only continues on `tool_use`, so a truncated turn fell through to the final-reply branch and ended: the tool call never dispatched, nothing landed. On large artifacts this was intermittent.

## The fix (layer 1: escalate-and-retry)

- **One canonical sentinel.** The OpenAI adapter normalises `finish_reason="length"` → `"max_tokens"` (streaming + non-streaming), matching Anthropic, so the loop checks one thing.
- **Retry from unchanged history.** On truncation the loop re-issues the same round at `MaxTokensEscalate`; the truncated reply is never appended, so a half-written tool call is simply regenerated with more room — no provider-specific partial-`tool_use` handling. Fires once per round; both attempts' token usage is accounted.
- **Model-ceiling backoff.** A model whose cap is below the target (Claude 3 tops out at 4096) returns a `max_tokens` error; `isMaxTokensTooLargeErr` detects it, keeps the truncated reply, and ends gracefully instead of failing.
- **Config.** `--max-tokens-escalate N` / `OCTO_MAX_TOKENS_ESCALATE`, provider-aware default (OpenAI 16384, Anthropic 32768), `0` disables.

The `Sender` interfaces are unchanged — only the internal `send` closure carries the per-call cap.

## Verification

- `make fmt-check` / `make vet` / `go test -race ./...` green.
- New unit tests: escalate-and-continue, escalation disabled → graceful stop, escalated-still-truncated → graceful stop, model-ceiling backoff, error matcher, and the OpenAI `length`→`max_tokens` normalisation (httptest).
- **End-to-end on DeepSeek:** the octo-eval `photographer-homepage` task — previously flaky (truncated at the 8k cap, `index.html` never written) — now resolves reliably **2/2**, escalating 8192 → 16384 (score 9/10 both runs).

## Not in scope

A second tier — keep the partial output and nudge the model to resume in smaller chunks (à la Claude Code's multi-turn recovery) — needs per-provider handling of the partial `tool_use` block and is documented as future work in `dev-docs/truncation-recovery.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)