### PR TITLE
feat(prompt): complexity-adaptive recap for multi-step sessions

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -52,9 +52,9 @@ Memories are snapshots and can be stale. If one names a file path, function, fla
 
 ## Output
 
-- Be concise and direct. Skip filler and preamble.
+- Be concise and direct. Skip filler and preamble. Scale the length of your answer to the weight of the task — most turns close in a sentence or two, not a wall of text.
 - When you reference code, cite it as `path:line` so the user can jump to it.
-- Report what you did and what's next in a sentence or two, not a wall of text.
+- Close a **complex, multi-step** session (several files touched, multiple commits/PRs, or a non-obvious chain of decisions) with a recap scaled to that complexity: what changed, the decision path if it wasn't self-evident, and any loose end or risk the user didn't ask about but should know — stale local branch state, a deferred follow-up, a caveat in what you shipped. Reach for this only when the work genuinely earned it; never pad a simple task with it. Prefer a compact shape — a short table or a numbered chain — over prose.
 
 ## Background processes
 


### PR DESCRIPTION
## What

The base prompt's `## Output` section unconditionally instructed the agent to close every turn in "a sentence or two, not a wall of text". That actively suppressed end-of-session recaps even when a genuinely complex, multi-PR session warranted one — the polished kind of summary good agentic models produce on their own.

## Change

One paragraph in `internal/prompt/base.md`:

- **Keep the concise default** — reworded to "most turns close in a sentence or two" so simple tasks stay terse.
- **Add a complexity-gated recap clause** — after a multi-step session (several files, multiple commits/PRs, a non-obvious decision chain), close with a recap scaled to that complexity: what changed, the decision path if non-obvious, and any loose end/risk the user didn't ask about (stale local branch state, deferred follow-up, a caveat in what shipped).
- **Trigger fixed, shape free** — the condition is explicit but the recap form is left to the model, so it adapts rather than templating. Prefer a compact table/numbered chain over prose. Explicit "never pad a simple task" backstop.

## Why this shape

A hard summary template would make simple turns verbose too. A soft, complexity-gated guideline lets the model decide *whether* and *how much* — which is where the quality lives.

## Verification

- `make build` — clean
- `go test ./internal/prompt/` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)