### PR TITLE
feat(agent): recover from transient mid-stream stalls; raise idle timeout to 5m

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -447,6 +448,7 @@ func (a *Agent) runLoop(
 	a.appendUserInput(userInput)
 
 	limit := a.turnLimit()
+	streamStalls := 0 // transient mid-stream stalls re-issued for the current round
 	for i := 0; limit == unlimitedTurns || i < limit; i++ {
 		// Interrupt (Ctrl-C) between iterations — e.g. right after a tool batch.
 		if ctx.Err() != nil {
@@ -486,14 +488,30 @@ func (a *Agent) runLoop(
 				continue
 			}
 
+			// ── Transient mid-stream stall recovery ──
+			// The streaming idle-timeout watchdog (or similar) fired: the server
+			// went silent mid-response. The partial reply was never appended, so
+			// re-issuing this round from the unchanged history is safe — only the
+			// already-streamed text is re-emitted. Bounded so a persistently dead
+			// stream still ends the turn.
+			if isTransientStreamErr(err) && streamStalls < maxStreamStalls {
+				streamStalls++
+				if handler != nil {
+					handler(AgentEvent{Kind: EventTextDelta, Text: fmt.Sprintf(
+						"\n[octo] stream stalled; retrying (%d/%d)…\n", streamStalls, maxStreamStalls)})
+				}
+				continue
+			}
+
 			if i == 0 {
 				a.History.popLast()
 			}
 			return Reply{}, fmt.Errorf("agent: loop[%d]: %w", i, err)
 		}
 
-		// Success — reset overflow attempt flag for next turn
+		// Success — reset the overflow and stream-stall budgets for the next round.
 		a.overflow.reset()
+		streamStalls = 0
 
 		a.accrueUsage(reply)
 
@@ -666,6 +684,26 @@ func (a *Agent) budgetStop(handler EventHandler, reason, msg string) (Reply, err
 // checks this one sentinel.
 func isTruncated(stopReason string) bool {
 	return stopReason == StopReasonMaxTokens
+}
+
+// maxStreamStalls bounds how many times a single round may be re-issued after a
+// transient mid-stream stall before the turn is failed. Reset after any healthy
+// round, so a long turn that stalls at different points each gets a fresh budget.
+const maxStreamStalls = 3
+
+// transientStreamError is implemented by provider errors that represent a
+// recoverable mid-stream stall (e.g. the streaming idle-timeout watchdog
+// firing). Declaring it as an interface here lets the loop classify such errors
+// without the agent package importing any provider package — Go interface
+// satisfaction is structural, so the provider error just needs the method.
+type transientStreamError interface{ TransientStream() bool }
+
+// isTransientStreamErr reports whether err (or anything it wraps) is a
+// recoverable mid-stream stall. The round can be safely re-issued because the
+// partial reply was never appended to history.
+func isTransientStreamErr(err error) bool {
+	var t transientStreamError
+	return errors.As(err, &t) && t.TransientStream()
 }
 
 // isMaxTokensTooLargeErr best-effort detects a provider rejecting an escalated

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1239,3 +1239,57 @@ func equalInts(a, b []int) bool {
 	}
 	return true
 }
+
+// ─── Transient mid-stream stall recovery ───────────────────────────────────
+
+// fakeStallErr implements the transientStreamError marker so the loop treats it
+// as a recoverable mid-stream stall (mirrors retry.ErrStreamIdle without
+// importing provider).
+type fakeStallErr struct{}
+
+func (fakeStallErr) Error() string         { return "stream stalled (test)" }
+func (fakeStallErr) TransientStream() bool { return true }
+
+func TestRunLoop_TransientStall_RetriesThenSucceeds(t *testing.T) {
+	send := &fakeToolSender{
+		errs:    []error{fakeStallErr{}, nil},
+		replies: []Reply{{}, {Content: "done", StopReason: "end_turn"}},
+	}
+	a := New(send, "m")
+	defs, exec := truncSetup()
+
+	reply, err := a.Run(context.Background(), "do work", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: unexpected error (stall should recover): %v", err)
+	}
+	if reply.Content != "done" || reply.StopReason != "end_turn" {
+		t.Errorf("reply = %+v, want done/end_turn", reply)
+	}
+	if send.calls != 2 {
+		t.Errorf("calls = %d, want 2 (one stall + one success)", send.calls)
+	}
+	// The failed round must not have left anything in history: [user, assistant].
+	if snap := a.History.Snapshot(); len(snap) != 2 {
+		t.Errorf("History len = %d, want 2 (%+v)", len(snap), snap)
+	}
+}
+
+func TestRunLoop_TransientStall_BoundedGivesUp(t *testing.T) {
+	// One more stall than the budget — the turn must end in error, not loop.
+	send := &fakeToolSender{
+		errs: []error{fakeStallErr{}, fakeStallErr{}, fakeStallErr{}, fakeStallErr{}},
+	}
+	a := New(send, "m")
+	defs, exec := truncSetup()
+
+	_, err := a.Run(context.Background(), "do work", defs, exec)
+	if err == nil {
+		t.Fatal("Run: expected error after exhausting stall retries")
+	}
+	if !isTransientStreamErr(err) {
+		t.Errorf("err = %v, want it to wrap a transient stream error", err)
+	}
+	if send.calls != maxStreamStalls+1 {
+		t.Errorf("calls = %d, want %d (budget %d + final)", send.calls, maxStreamStalls+1, maxStreamStalls)
+	}
+}

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -40,10 +40,12 @@ const DefaultMaxTokens = 4096
 // DefaultStreamIdleTimeout bounds how long a streaming response may go silent
 // (no bytes received) before SendStream aborts it as a stall. The Messages API
 // emits periodic `ping` events to keep streams alive, so a healthy stream never
-// idles this long; 120s is generous enough to ride out a slow first token or a
-// briefly congested endpoint while still catching a server that stops sending
-// without closing the connection.
-const DefaultStreamIdleTimeout = 120 * time.Second
+// idles this long. 5 minutes is generous enough to ride out a slow first token
+// at a large context or a briefly congested third-party endpoint (some
+// Anthropic-compatible proxies don't relay pings) while still catching a server
+// that stops sending without closing. A stall that does trip it is recovered by
+// the agent loop (see isTransientStreamErr), not surfaced as a turn error.
+const DefaultStreamIdleTimeout = 5 * time.Minute
 
 // Client talks to an Anthropic-compatible Messages API. Construct via New();
 // zero values are not valid because APIKey is required.

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -36,10 +36,12 @@ const DefaultMaxTokens = 4096
 // DefaultStreamIdleTimeout bounds how long a streaming response may go silent
 // (no bytes received) before SendStream aborts it as a stall. Chat Completions
 // backends stream chunks continuously while generating, so a healthy stream
-// never idles this long; 120s is generous enough to ride out a slow first token
-// or a briefly congested endpoint while still catching a server that stops
-// sending without closing the connection.
-const DefaultStreamIdleTimeout = 120 * time.Second
+// never idles this long. 5 minutes is generous enough to ride out a slow first
+// token at a large context or a briefly congested endpoint while still catching
+// a server that stops sending without closing. A stall that does trip it is
+// recovered by the agent loop (see isTransientStreamErr), not surfaced as a
+// turn error.
+const DefaultStreamIdleTimeout = 5 * time.Minute
 
 // Client talks to an OpenAI-compatible Chat Completions API. Construct via
 // New(); zero values are not valid because APIKey is required.

--- a/internal/provider/retry/idle.go
+++ b/internal/provider/retry/idle.go
@@ -1,7 +1,6 @@
 package retry
 
 import (
-	"errors"
 	"io"
 	"time"
 )
@@ -9,13 +8,29 @@ import (
 // ErrStreamIdle is returned by a reader from IdleTimeoutReader when no bytes
 // arrive for longer than the configured idle window — the server accepted the
 // streaming connection and then went silent without closing it. Providers
-// surface this to fail the turn cleanly instead of blocking forever in a read.
+// surface this to fail the read cleanly instead of blocking forever.
 //
-// Unlike request-establishment failures (see Do), a mid-stream stall is not
-// retried: the turn has already emitted tokens to the caller, so an auto-retry
-// would duplicate them. Failing cleanly lets the agent loop roll its history
-// back and the caller (or an unattended eval/cron run) decide whether to re-run.
-var ErrStreamIdle = errors.New("provider: streaming response idle timeout (server stopped sending without closing)")
+// It is NOT retried at the transport layer (unlike request-establishment
+// failures, see Do): a mid-stream stall has already emitted tokens to the
+// caller, so a transport-level auto-retry would duplicate them. Instead the
+// error carries TransientStream() == true, letting the agent loop recognise it
+// (without importing this package) and re-issue the round from unchanged
+// history — where the partial reply was never committed, so the retry is safe.
+var ErrStreamIdle error = streamIdleError{}
+
+// streamIdleError is a comparable empty-struct error so errors.Is(err,
+// ErrStreamIdle) still matches by value, while also exposing TransientStream
+// for higher layers to classify it structurally.
+type streamIdleError struct{}
+
+func (streamIdleError) Error() string {
+	return "provider: streaming response idle timeout (server stopped sending without closing)"
+}
+
+// TransientStream marks this as a recoverable mid-stream stall. The agent loop
+// matches it via a same-named interface, so it can retry the round without a
+// dependency on this package.
+func (streamIdleError) TransientStream() bool { return true }
 
 // IdleTimeoutReader wraps r so that any single read which makes no progress for
 // longer than timeout aborts the stream: onIdle is invoked — typically a

--- a/internal/provider/retry/idle_test.go
+++ b/internal/provider/retry/idle_test.go
@@ -2,6 +2,7 @@ package retry
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -89,4 +90,19 @@ func TestIdleTimeoutReader_FiresOnStall(t *testing.T) {
 
 	// Release the abandoned goroutine so the test leaves nothing blocked.
 	close(blk.release)
+}
+
+// ErrStreamIdle must carry the TransientStream() marker (so the agent loop can
+// classify it without importing this package) and stay matchable by errors.Is
+// even when wrapped by a provider.
+func TestErrStreamIdle_TransientMarker(t *testing.T) {
+	wrapped := fmt.Errorf("anthropic: stream read: %w", ErrStreamIdle)
+
+	if !errors.Is(wrapped, ErrStreamIdle) {
+		t.Error("errors.Is should match ErrStreamIdle through wrapping")
+	}
+	var ts interface{ TransientStream() bool }
+	if !errors.As(wrapped, &ts) || !ts.TransientStream() {
+		t.Error("ErrStreamIdle should be classifiable as a transient stream error via errors.As")
+	}
 }


### PR DESCRIPTION
## What

Fixes a real-world failure: a transient streaming stall aborted a long agentic turn —

```
error: agent: loop[24]: anthropic: stream read: provider: streaming response idle timeout (server stopped sending without closing)
```

24 iterations of work, killed by one mid-stream silence.

## Root cause

The streaming idle-timeout watchdog (`retry.IdleTimeoutReader`) correctly fires when the server goes silent mid-response without closing — without it octo would hang forever. But:

- The error was **fatal**: the agent loop recovered from context overflow (`overflow.tryRecover`) but had **no handling for transient stream errors**, so it propagated and ended the turn.
- The default window was **120s**, which can trip on a slow first token at a large context (24 iterations deep → big prompt) or a third-party Anthropic-compatible proxy that doesn't relay `ping` heartbeats.

The partial reply was never appended to history (the error path returns before the append), so the stall was always **safely recoverable** — the loop just didn't try.

## The fix (A + C)

- **A — loop recovery.** On a transient stream stall the loop re-issues the round, bounded by `maxStreamStalls` (3, reset after any healthy round). Re-issuing from the **unchanged history** is safe — only already-streamed text is re-emitted, far better than losing the turn. A persistent stall still ends the turn after the budget.
- **C — raise the default** `DefaultStreamIdleTimeout` 120s → **5m** (anthropic + openai).

### Keeping the agent package provider-free

`retry.ErrStreamIdle` becomes a typed error exposing `TransientStream() bool`. The agent loop classifies it via a **same-named interface** (`errors.As`) — Go interface satisfaction is structural, so the agent package imports no provider package. `errors.Is(err, ErrStreamIdle)` still matches by value.

## Tests

- Loop retries a stall then succeeds; history stays clean (`[user, assistant]`).
- A persistent stall is bounded (`maxStreamStalls+1` calls) and ends the turn.
- `ErrStreamIdle` keeps `errors.Is` and gains the transient marker (via `errors.As` through wrapping).
- `make fmt-check` / `make vet` / `go test -race ./...` green; agent stays provider-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)