### PR TITLE
feat(tui): live task list under the activity spinner

### DIFF
--- a/cmd/octo/tuirepl_tasks.go
+++ b/cmd/octo/tuirepl_tasks.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/tasks"
+	"github.com/Leihb/octo-agent/internal/tools"
+	"github.com/Leihb/octo-agent/internal/tui"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/reflow/truncate"
+)
+
+// Live task-list styles — Claude Code's todo block: a checkbox glyph per task,
+// the in-progress one highlighted, completed ones dimmed and struck through.
+var (
+	taskConnStyle    = lipgloss.NewStyle().Foreground(tui.ColDim)
+	taskPendingStyle = lipgloss.NewStyle().Foreground(tui.ColMuted)
+	taskActiveStyle  = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	taskDoneStyle    = lipgloss.NewStyle().Foreground(tui.ColDim).Strikethrough(true)
+)
+
+// maxTaskRows caps how many task rows the live block shows before collapsing
+// the tail into a "└ N more" line. List() orders in-progress → pending →
+// completed, so the rows we keep are always the most pressing ones.
+const maxTaskRows = 8
+
+// taskListView renders the live task block shown under the activity spinner
+// while a turn runs. It returns "" when there's nothing worth showing: no
+// store, no tasks, or every task already completed — the block tracks
+// outstanding work, so an all-done list would just clutter the live area
+// (the committed transcript still holds the history).
+func (m *tuiModel) taskListView() string {
+	store := tools.ActiveTaskStore()
+	if store == nil {
+		return ""
+	}
+	return renderTaskLines(store.List(), m.width)
+}
+
+// renderTaskLines is the pure formatter behind taskListView, split out so it
+// can be tested without the global store. width <= 0 disables truncation.
+func renderTaskLines(items []tasks.Task, width int) string {
+	// Hide the block once nothing is outstanding (all completed / empty).
+	outstanding := false
+	for _, t := range items {
+		if t.Status == tasks.Pending || t.Status == tasks.InProgress {
+			outstanding = true
+			break
+		}
+	}
+	if !outstanding {
+		return ""
+	}
+
+	rows := items
+	moreCount := 0
+	if len(rows) > maxTaskRows {
+		// Reserve the last visible line for the "N more" marker.
+		moreCount = len(rows) - (maxTaskRows - 1)
+		rows = rows[:maxTaskRows-1]
+	}
+
+	var b strings.Builder
+	for i, t := range rows {
+		// The first row carries the tree elbow tying the block to the spinner
+		// above; the rest align their glyph under it.
+		if i == 0 {
+			b.WriteString(taskConnStyle.Render("└ "))
+		} else {
+			b.WriteString("\n  ")
+		}
+		b.WriteString(renderTaskRow(t, width))
+	}
+	if moreCount > 0 {
+		b.WriteString("\n  ")
+		b.WriteString(taskConnStyle.Render(fmt.Sprintf("… %d more", moreCount)))
+	}
+	return b.String()
+}
+
+// renderTaskRow formats a single task line: glyph + label, styled by status,
+// truncated to fit the terminal width (the 2-column row prefix is accounted
+// for by the caller's layout, so we budget width-2 here).
+func renderTaskRow(t tasks.Task, width int) string {
+	var glyph string
+	var style lipgloss.Style
+	text := t.Subject
+	switch t.Status {
+	case tasks.InProgress:
+		glyph, style = "□", taskActiveStyle
+		if t.ActiveForm != "" {
+			text = t.ActiveForm // present-continuous form reads better while active
+		}
+	case tasks.Completed:
+		glyph, style = "✓", taskDoneStyle
+	default: // Pending
+		glyph, style = "□", taskPendingStyle
+	}
+
+	line := glyph + " " + text
+	if width > 6 {
+		line = truncate.StringWithTail(line, uint(width-2), "…")
+	}
+	return style.Render(line)
+}

--- a/cmd/octo/tuirepl_tasks_test.go
+++ b/cmd/octo/tuirepl_tasks_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/tasks"
+)
+
+func TestRenderTaskLines_HidesWhenNothingOutstanding(t *testing.T) {
+	if got := renderTaskLines(nil, 80); got != "" {
+		t.Errorf("empty list: want \"\", got %q", got)
+	}
+	allDone := []tasks.Task{
+		{ID: 1, Subject: "a", Status: tasks.Completed},
+		{ID: 2, Subject: "b", Status: tasks.Completed},
+	}
+	if got := renderTaskLines(allDone, 80); got != "" {
+		t.Errorf("all-completed list should be hidden, got %q", got)
+	}
+}
+
+func TestRenderTaskLines_Layout(t *testing.T) {
+	items := []tasks.Task{
+		{ID: 1, Subject: "Migrate auth", ActiveForm: "Migrating auth", Status: tasks.InProgress},
+		{ID: 2, Subject: "Add test", Status: tasks.Pending},
+		{ID: 3, Subject: "Update docs", Status: tasks.Completed},
+	}
+	out := renderTaskLines(items, 80)
+	lines := strings.Split(out, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 rows, got %d:\n%s", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "└") {
+		t.Errorf("first row should carry the tree elbow, got %q", lines[0])
+	}
+	// In-progress uses the present-continuous ActiveForm, not the Subject.
+	if !strings.Contains(lines[0], "Migrating auth") {
+		t.Errorf("in-progress row should use ActiveForm, got %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "□") {
+		t.Errorf("in-progress row should use the box glyph, got %q", lines[0])
+	}
+	if !strings.Contains(lines[2], "✓") || !strings.Contains(lines[2], "Update docs") {
+		t.Errorf("completed row should use the check glyph + subject, got %q", lines[2])
+	}
+}
+
+func TestRenderTaskLines_CollapsesLongList(t *testing.T) {
+	var items []tasks.Task
+	for i := 1; i <= 12; i++ {
+		items = append(items, tasks.Task{ID: i, Subject: "task", Status: tasks.Pending})
+	}
+	out := renderTaskLines(items, 80)
+	lines := strings.Split(out, "\n")
+	if len(lines) != maxTaskRows {
+		t.Fatalf("want %d rows (capped), got %d:\n%s", maxTaskRows, len(lines), out)
+	}
+	last := lines[len(lines)-1]
+	// 12 total, maxTaskRows-1 = 7 shown, so 5 collapsed.
+	if !strings.Contains(last, "5 more") {
+		t.Errorf("last row should report the collapsed count, got %q", last)
+	}
+}
+
+func TestRenderTaskRow_TruncatesToWidth(t *testing.T) {
+	long := tasks.Task{ID: 1, Subject: strings.Repeat("x", 200), Status: tasks.Pending}
+	row := renderTaskRow(long, 40)
+	if !strings.Contains(row, "…") {
+		t.Errorf("over-wide row should be truncated with an ellipsis, got %q", row)
+	}
+}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -483,6 +483,16 @@ func (m *tuiModel) View() string {
 		b.WriteByte('\n')
 	}
 
+	// Live task list — attached under the activity area while a turn runs
+	// (Claude Code style). Hidden when idle, and self-suppressing when there's
+	// no outstanding work (see taskListView).
+	if m.turnRunning {
+		if tl := m.taskListView(); tl != "" {
+			b.WriteString(tl)
+			b.WriteByte('\n')
+		}
+	}
+
 	// Queue panel
 	if len(m.queue) > 0 {
 		var items strings.Builder


### PR DESCRIPTION
## What

The task data layer (`internal/tasks` + the `task_create/update/list` tools) was already complete, but the TUI never rendered it — `View()` drew the spinner, queue, and background panels but no task list, so the model's tracked steps stayed invisible. This adds a Claude Code-style live task block.

## Layout

Attached under the activity area while a turn runs:

```
* Thinking (12s)
└ □ Migrate auth middleware     ← in-progress: bold + brand color, ActiveForm text
  □ Add migration test          ← pending: muted
  ✓ Update README               ← completed: dimmed + strikethrough
  … 3 more                      ← shown only when >8 tasks
```

## Behavior

- **Shown only while a turn runs** (gated on `turnRunning`); disappears when idle — history stays in the committed transcript.
- **Self-suppressing** when nothing is outstanding: an empty or all-completed list renders `""`, so the block doesn't clutter the live area once work is done.
- **Long lists cap at 8 rows** with a `… N more` tail. `List()` already orders in-progress → pending → completed, so the kept rows are always the most pressing.
- **CJK-safe truncation** via `reflow/truncate`.

## Implementation notes

- New file `cmd/octo/tuirepl_tasks.go` — pure formatter (`renderTaskLines` / `renderTaskRow`) split from the model method `taskListView()` so it unit-tests without the global store.
- `View()` gains a 6-line block after the spinner.
- In-progress vs pending share the `□` glyph, distinguished by bold + color (same as Claude Code — relies on style, not glyph swap).
- No changes to the task data layer, the spinner, or any tool.

## Verification

- `make build` — clean
- `go vet ./cmd/octo/` — clean
- `go test -race ./cmd/octo/ ./internal/tasks/ ./internal/tools/` — pass (4 new test cases: hide-when-done, layout, collapse, truncation)
- `gofmt -l` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)