### PR TITLE
feat(tui): add Claude-Code-style background task completion notice

### DIFF
--- a/cmd/octo/bgnotify_wiring_test.go
+++ b/cmd/octo/bgnotify_wiring_test.go
@@ -53,13 +53,14 @@ func TestRunTurn_PrependsIdleBgNote(t *testing.T) {
 	}
 }
 
-// TestTUI_BgExitMsgNoScrollbackNotice confirms an async background-exit message
-// does NOT append a scrollback notice (the full output rides into the conversation
-// via Inbox instead).
-func TestTUI_BgExitMsgNoScrollbackNotice(t *testing.T) {
+// TestTUI_BgExitMsgScrollbackNotice confirms an async background-exit message
+// returns a tea.Println command with a concise Claude-Code-style notice.
+func TestTUI_BgExitMsgScrollbackNotice(t *testing.T) {
 	m := newTestModel()
-	m.Update(bgExitMsg{e: tools.BgExit{ID: "bg_1", Command: "go test ./...", Status: "exited: 0"}})
-	if len(m.printlnBuf) > 0 {
-		t.Errorf("bgExitMsg should not queue println lines, got %d", len(m.printlnBuf))
+	_, cmd := m.Update(bgExitMsg{e: tools.BgExit{ID: "bg_1", Command: "go test ./...", Status: "exited: 0"}})
+	if cmd == nil {
+		t.Fatal("bgExitMsg should return a non-nil cmd")
 	}
+	// bubbletea commands are opaque functions; we can't easily inspect the string
+	// they will print. Verify at least that a cmd is returned (smoke test).
 }

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -404,8 +404,10 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.flushPrints()
 
 	case bgExitMsg:
-		// Async background-process completion: the full output rode into the
-		// conversation via Inbox; no scrollback notice needed.
+		// Print a concise, Claude-Code-style scrollback notice so the user
+		// sees the completion even when the model-facing <system-reminder>
+		// is folded into a later turn.
+		notice := bgDoneStyle.Render(fmt.Sprintf("● Background process %s (`%s`) %s", msg.e.ID, msg.e.Command, msg.e.Status))
 		// Idle auto-turn: if no turn is running and nothing is queued, drain the
 		// inbox (which holds the full <system-reminder> notice) and start a
 		// turn so the model sees the completion immediately — matching the plain
@@ -413,10 +415,10 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !m.turnRunning && len(m.queue) == 0 {
 			if msgs := m.a.Inbox.Drain(); len(msgs) > 0 {
 				s := strings.Join(msgs, "\n\n")
-				return m, m.startTurnEcho(s, "")
+				return m, tea.Sequence(tea.Println(notice), m.startTurnEcho(s, ""))
 			}
 		}
-		return m, m.flushPrints()
+		return m, tea.Sequence(tea.Println(notice), m.flushPrints())
 
 	case subAgentNoteMsg:
 		// Async sub-agent completion: the full result rode into the conversation

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -37,6 +37,7 @@ var (
 	pendingSteerStyle = lipgloss.NewStyle().Foreground(tui.ColMuted)
 	complSelStyle     = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
 	complNameStyle    = lipgloss.NewStyle().Foreground(tui.ColAccent)
+	bgDoneStyle       = lipgloss.NewStyle().Foreground(tui.ColAccent)
 )
 
 func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
When a background process finishes, the TUI now prints a concise scrollback line (green dot + id + command + status) so the user sees the completion immediately, even if the full system-reminder is folded into a later turn.