### PR TITLE
fix(mcp): keep stdio server stderr off the TUI screen

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -81,6 +82,26 @@ func resolveMaxTokensEscalate(flagVal int, provName string) int {
 		return escalateMaxTokensOpenAI
 	}
 	return escalateMaxTokensAnthropic
+}
+
+// openMCPLogFile opens ~/.octo/logs/mcp.log (append) to receive stdio MCP
+// servers' child stderr while the TUI owns the screen, so their diagnostics are
+// recoverable rather than corrupting the frame. Returns nil on any failure; the
+// caller then discards child stderr — never the terminal.
+func openMCPLogFile() *os.File {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return nil
+	}
+	dir := filepath.Join(home, ".octo", "logs")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil
+	}
+	f, err := os.OpenFile(filepath.Join(dir, "mcp.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil
+	}
+	return f
 }
 
 // tuiDisabledByEnv reports whether OCTO_TUI is set to a falsey value, the env
@@ -460,6 +481,22 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		if err != nil {
 			fmt.Fprintf(stderr, "octo chat: mcp config: %v\n", err)
 		} else if len(mcpCfg.Servers) > 0 {
+			// A stdio server's subprocess writes diagnostics to its stderr at
+			// arbitrary times during the session, from an exec copy goroutine.
+			// Under the bubbletea TUI a direct terminal write corrupts the frame,
+			// so route it to a log file (recoverable, never the screen). In
+			// plain/headless mode leave it nil: the transport defaults to
+			// os.Stderr, the only writer that's safe for the goroutine to share
+			// concurrently (the stderr param may be a non-thread-safe buffer).
+			var childStderr io.Writer
+			if useTUI {
+				if f := openMCPLogFile(); f != nil {
+					childStderr = f
+					defer f.Close()
+				} else {
+					childStderr = io.Discard
+				}
+			}
 			mcpReg := mcp.ConnectAll(
 				context.Background(),
 				mcpCfg,
@@ -468,6 +505,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 					return newCLIOAuthPrompt(stdout, serverName)
 				},
 				stderr,
+				childStderr,
 			)
 			if mcpReg.Len() > 0 {
 				tools.SetMCPRegistry(mcpReg)

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -48,7 +48,13 @@ type Connection struct {
 // device-flow card with the server name it's authorising. May be nil
 // when no entry uses OAuth — a nil factory triggers the same "auth
 // required but not wired" error as a missing config.
-func ConnectAll(ctx context.Context, cfg *Config, info Implementation, authPromptFor func(serverName string) OAuthPrompt, warn io.Writer) *Registry {
+//
+// childStderr is where each stdio server's subprocess diagnostics go. It is
+// distinct from warn (startup connect failures, printed before any TUI takes
+// over): a child's stderr streams throughout the session, so under a TUI it
+// must point at a log file or io.Discard, never the terminal. nil falls back to
+// os.Stderr inside the transport.
+func ConnectAll(ctx context.Context, cfg *Config, info Implementation, authPromptFor func(serverName string) OAuthPrompt, warn, childStderr io.Writer) *Registry {
 	r := &Registry{conns: map[string]*Connection{}}
 	if cfg == nil {
 		return r
@@ -59,7 +65,7 @@ func ConnectAll(ctx context.Context, cfg *Config, info Implementation, authPromp
 		if entry.Auth == "oauth" && authPromptFor != nil {
 			prompt = authPromptFor(name)
 		}
-		conn, err := connectOne(ctx, name, entry, info, prompt)
+		conn, err := connectOne(ctx, name, entry, info, prompt, childStderr)
 		if err != nil {
 			if warn != nil {
 				fmt.Fprintf(warn, "mcp: server %q skipped: %v\n", name, err)
@@ -71,7 +77,7 @@ func ConnectAll(ctx context.Context, cfg *Config, info Implementation, authPromp
 	return r
 }
 
-func connectOne(ctx context.Context, name string, entry ServerEntry, info Implementation, authPrompt OAuthPrompt) (*Connection, error) {
+func connectOne(ctx context.Context, name string, entry ServerEntry, info Implementation, authPrompt OAuthPrompt, childStderr io.Writer) (*Connection, error) {
 	// Per-server timeout. OAuth-protected servers get a longer window
 	// because the user has to do the device-flow dance interactively;
 	// stdio + static-auth servers should still snap up in ~10s.
@@ -89,6 +95,7 @@ func connectOne(ctx context.Context, name string, entry ServerEntry, info Implem
 			Command: entry.Command,
 			Args:    entry.Args,
 			Env:     entry.Env,
+			Stderr:  childStderr,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -40,11 +40,18 @@ type StdioConfig struct {
 	Command string
 	Args    []string
 	Env     map[string]string
+	// Stderr receives the child's diagnostic output. nil defaults to os.Stderr.
+	// Callers running an alternate-screen TUI MUST set this to a non-terminal
+	// sink (a log file or io.Discard): the child writes its stderr at arbitrary
+	// times during the session, and a direct terminal write corrupts the
+	// rendered frame.
+	Stderr io.Writer
 }
 
 // NewStdioTransport spawns the configured subprocess and wires its stdin /
-// stdout to a line-delimited JSON-RPC pipe. stderr is inherited so the
-// child's diagnostic logs appear directly under the parent's stderr.
+// stdout to a line-delimited JSON-RPC pipe. The child's stderr goes to
+// cfg.Stderr (os.Stderr when unset) — callers under a TUI must redirect it
+// off the terminal.
 //
 // The returned transport is already running — Close will signal shutdown
 // by closing stdin (the conventional MCP "I'm done, please exit") and then
@@ -69,7 +76,14 @@ func NewStdioTransport(ctx context.Context, cfg StdioConfig) (*StdioTransport, e
 		}
 		cmd.Env = env
 	}
-	cmd.Stderr = os.Stderr // child's logs flow through to user terminal
+	// Child diagnostics go to cfg.Stderr (a log file under a TUI; os.Stderr in
+	// plain/headless mode). Writing a child's async stderr straight to the
+	// terminal corrupts an alternate-screen TUI frame.
+	if cfg.Stderr != nil {
+		cmd.Stderr = cfg.Stderr
+	} else {
+		cmd.Stderr = os.Stderr
+	}
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/mcp/stdio_test.go
+++ b/internal/mcp/stdio_test.go
@@ -2,11 +2,13 @@ package mcp
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 )
@@ -20,6 +22,11 @@ func TestHelperProcess(t *testing.T) {
 		return
 	}
 	defer os.Exit(0)
+	// Emit a marker to stderr at startup so a test can assert the transport
+	// routes the child's stderr to the configured sink, not the terminal.
+	if m := os.Getenv("GO_HELPER_STDERR"); m != "" {
+		fmt.Fprint(os.Stderr, m)
+	}
 	dec := json.NewDecoder(bufio.NewReader(os.Stdin))
 	enc := json.NewEncoder(os.Stdout)
 	for {
@@ -70,6 +77,36 @@ func helperCommand() StdioConfig {
 		Command: os.Args[0],
 		Args:    []string{"-test.run=TestHelperProcess"},
 		Env:     map[string]string{"GO_HELPER_PROCESS": "1"},
+	}
+}
+
+// TestStdioTransport_StderrRoutedToConfig verifies the child's stderr goes to
+// cfg.Stderr (a log file / discard under a TUI) instead of the terminal, so it
+// can't corrupt a bubbletea frame.
+func TestStdioTransport_StderrRoutedToConfig(t *testing.T) {
+	if _, err := exec.LookPath(os.Args[0]); err != nil {
+		t.Skip("self-binary not found; running outside a test binary")
+	}
+	const marker = "CHILD-STDERR-MARKER"
+	cfg := helperCommand()
+	cfg.Env["GO_HELPER_STDERR"] = marker
+	var captured bytes.Buffer
+	cfg.Stderr = &captured
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	tx, err := NewStdioTransport(ctx, cfg)
+	if err != nil {
+		t.Fatalf("NewStdioTransport: %v", err)
+	}
+	// Close stdin so the helper's decode loop exits; Close Wait()s the child,
+	// which also flushes the exec stderr-copy goroutine into captured — so the
+	// read below is race-free.
+	if err := tx.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := captured.String(); !strings.Contains(got, marker) {
+		t.Errorf("child stderr not routed to cfg.Stderr; captured %q, want it to contain %q", got, marker)
 	}
 }
 


### PR DESCRIPTION
## Bug

A stdio MCP server's subprocess stderr leaked onto the TUI, corrupting the frame:

```
[CodeGraph MCP] Auto-synced 1 file(s) in 151ms
```

appeared mid-screen, over the rendered prompt.

## Root cause

`NewStdioTransport` wired the child's stderr straight to `os.Stderr`:

```go
cmd.Stderr = os.Stderr // child's logs flow through to user terminal
```

That's fine in plain/headless mode, but the child logs asynchronously throughout the session, and a direct terminal write corrupts a bubbletea alternate-screen frame.

## Fix

- `StdioConfig` gains a `Stderr io.Writer`; `NewStdioTransport` uses it (`nil` → `os.Stderr`, preserving plain/headless behaviour).
- `ConnectAll`/`connectOne` thread a `childStderr` writer — distinct from the startup `warn` writer, which prints *before* the TUI takes over — down to the transport.
- Under the TUI, `cmd/octo` routes child stderr to `~/.octo/logs/mcp.log` (best-effort; `io.Discard` on failure): recoverable, never the screen. Plain/headless leaves it `nil` so the transport defaults to `os.Stderr`.

### Why nil (not the `stderr` param) in plain/headless

The child's stderr is copied by an `os/exec` goroutine, so the sink must be safe for **concurrent** writes. `os.Stderr` (`*os.File`) is; the `stderr` param can be a non-thread-safe `bytes.Buffer` — and the `cmd/octo` tests actually spawn a real stdio server (from `~/.octo/mcp.json`), so routing the child copy through the test buffer raced with synchronous writes. Passing `nil` keeps the original safe `os.Stderr` path. (Caught by `go test -race`.)

## Test

The self-exec helper process emits a stderr marker; a new test asserts the transport routes it to the configured `cfg.Stderr` sink (captured buffer), not the terminal. `make fmt-check` / `make vet` / `go test -race ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)