### PR TITLE
feat(subagent): live TUI panel of running sub-agents' tool chains

### DIFF
--- a/cmd/octo/sub_agent.go
+++ b/cmd/octo/sub_agent.go
@@ -114,7 +114,24 @@ func (s *agentSpawner) runChild(ctx context.Context, lc *liveChild, prompt strin
 	defer lc.mu.Unlock()
 
 	childCtx := tools.WithSubAgentMarker(ctx)
-	r, err := lc.agent.Run(childCtx, prompt, lc.tools, lc.executor)
+
+	// When the manager stamped an event sink into ctx (TUI live panel), stream
+	// the child's tool-level activity to it. Only tool_started/tool_error are
+	// forwarded — not per-token text — to keep event volume sane with several
+	// sub-agents running at once. No sink (taskgraph/headless) => nil handler =>
+	// RunStream behaves exactly like Run.
+	var handler agent.EventHandler
+	if sink := tools.SubAgentEventSink(ctx); sink != nil {
+		handler = func(ev agent.AgentEvent) {
+			switch ev.Kind {
+			case agent.EventToolStarted:
+				sink(tools.SubAgentEvent{Kind: "tool", ToolName: ev.ToolName})
+			case agent.EventToolError:
+				sink(tools.SubAgentEvent{Kind: "tool_error", ToolName: ev.ToolName})
+			}
+		}
+	}
+	r, err := lc.agent.RunStream(childCtx, prompt, lc.tools, lc.executor, handler)
 	if err != nil {
 		return "", 0, 0, err
 	}

--- a/cmd/octo/subagent_panel_test.go
+++ b/cmd/octo/subagent_panel_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// newPanelModel builds a tuiModel with just the sub-agent panel state, enough to
+// exercise the fold/remove logic without a bubbletea program.
+func newPanelModel() *tuiModel {
+	return &tuiModel{subAgents: map[string]*subAgentUI{}}
+}
+
+func TestSubAgentPanel_StartedThenTools(t *testing.T) {
+	m := newPanelModel()
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Description: "Find code", Kind: "started"})
+	if len(m.subAgentOrder) != 1 || m.subAgentOrder[0] != "agent_1" {
+		t.Fatalf("order = %v, want [agent_1]", m.subAgentOrder)
+	}
+	for _, name := range []string{"read_file", "grep", "read_file"} {
+		m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "tool", ToolName: name})
+	}
+	sa := m.subAgents["agent_1"]
+	if sa.toolCount != 3 {
+		t.Errorf("toolCount = %d, want 3", sa.toolCount)
+	}
+	if sa.description != "Find code" {
+		t.Errorf("description = %q", sa.description)
+	}
+	if got := sa.recent[len(sa.recent)-1]; got != "read_file" {
+		t.Errorf("last recent = %q, want read_file", got)
+	}
+}
+
+func TestSubAgentPanel_RecentCapped(t *testing.T) {
+	m := newPanelModel()
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "started"})
+	for i := 0; i < maxSubAgentRecentTools+3; i++ {
+		m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "tool", ToolName: "t"})
+	}
+	if got := len(m.subAgents["agent_1"].recent); got != maxSubAgentRecentTools {
+		t.Errorf("recent len = %d, want %d (capped)", got, maxSubAgentRecentTools)
+	}
+}
+
+func TestSubAgentPanel_ToolError(t *testing.T) {
+	m := newPanelModel()
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "started"})
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "tool_error", ToolName: "terminal"})
+	sa := m.subAgents["agent_1"]
+	if !sa.errored {
+		t.Error("errored flag not set")
+	}
+	if got := sa.recent[len(sa.recent)-1]; got != "terminal ✗" {
+		t.Errorf("recent = %q, want 'terminal ✗'", got)
+	}
+}
+
+func TestSubAgentPanel_RemoveOnComplete(t *testing.T) {
+	m := newPanelModel()
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "started"})
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_2", Kind: "started"})
+	m.removeSubAgent("agent_1")
+	if _, ok := m.subAgents["agent_1"]; ok {
+		t.Error("agent_1 still present after remove")
+	}
+	if len(m.subAgentOrder) != 1 || m.subAgentOrder[0] != "agent_2" {
+		t.Errorf("order = %v, want [agent_2]", m.subAgentOrder)
+	}
+}
+
+func TestSubAgentPanel_StartedResetsChain(t *testing.T) {
+	m := newPanelModel()
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "started"})
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "tool", ToolName: "grep"})
+	// A second round (send_message) re-starts: chain resets, slot stays.
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "started"})
+	sa := m.subAgents["agent_1"]
+	if sa.toolCount != 0 || len(sa.recent) != 0 {
+		t.Errorf("chain not reset on re-start: count=%d recent=%v", sa.toolCount, sa.recent)
+	}
+	if len(m.subAgentOrder) != 1 {
+		t.Errorf("order changed on re-start: %v", m.subAgentOrder)
+	}
+}

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -68,8 +68,13 @@ func runTUI(cfg replConfig) int {
 			cfg.a.Inbox.Enqueue(formatSubAgentNote(ev))
 			p.Send(subAgentNoteMsg{ev})
 		})
+		// Runtime activity (started + per-tool) for the live bottom panel.
+		cfg.subAgentMgr.SetOnEvent(func(ev tools.SubAgentEvent) {
+			p.Send(subAgentEventMsg{ev})
+		})
 		defer func() {
 			cfg.subAgentMgr.SetOnExit(nil)
+			cfg.subAgentMgr.SetOnEvent(nil)
 			tools.SetDefaultSubAgentManager(nil)
 			cfg.subAgentMgr.KillAll()
 		}()
@@ -118,6 +123,7 @@ type turnFinishedMsg struct{ err error } // the turn goroutine returned
 type noticeMsg struct{ text string }
 type bgExitMsg struct{ e tools.BgExit }                      // a background process finished (async)
 type subAgentNoteMsg struct{ ev tools.SubAgentNotification } // a sub-agent completed (async)
+type subAgentEventMsg struct{ ev tools.SubAgentEvent }       // a sub-agent's runtime activity (async)
 type tickMsg struct{}                                        // animation tick while a turn runs
 type askMsg struct {
 	prompt UserPrompt
@@ -277,6 +283,22 @@ type tuiModel struct {
 
 	// height is the terminal height in cells, updated by WindowSizeMsg.
 	height int
+
+	// subAgents holds the live state of currently-running sub-agents, keyed by
+	// manager handle (agent_N), rendered as a bottom panel. An entry appears on
+	// the "started" event and is removed when its completion note arrives.
+	// subAgentOrder preserves launch order for stable rendering.
+	subAgents     map[string]*subAgentUI
+	subAgentOrder []string
+}
+
+// subAgentUI is the live panel state for one running sub-agent.
+type subAgentUI struct {
+	description string
+	start       time.Time
+	toolCount   int
+	recent      []string // last few tool names, for the live chain
+	errored     bool
 }
 
 // runningTool is the live indicator state for an in-flight card tool.
@@ -320,7 +342,7 @@ func newTUIModel(cfg replConfig) *tuiModel {
 	if !tui.IsDark() {
 		style = "light"
 	}
-	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}}
+	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}}
 	_ = m.updateTextAreaHeight()
 	return m
 }
@@ -389,7 +411,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Animate while a turn runs OR while background processes are still
 		// going (so the live "background (N running)" panel keeps ticking even
 		// between turns); let the ticker die once both are quiet.
-		if !m.turnRunning && len(tools.RunningBackground()) == 0 {
+		if !m.turnRunning && len(tools.RunningBackground()) == 0 && len(m.subAgents) == 0 {
 			return m, m.flushPrints()
 		}
 		m.spinnerFrame++
@@ -420,7 +442,19 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Sequence(tea.Println(notice), m.flushPrints())
 
+	case subAgentEventMsg:
+		m.handleSubAgentEvent(msg.ev)
+		// Ensure the animation ticker is running so the panel's spinner/elapsed
+		// updates even between turns.
+		if !m.turnRunning {
+			return m, tea.Batch(tickCmd(), m.flushPrints())
+		}
+		return m, m.flushPrints()
+
 	case subAgentNoteMsg:
+		// A sub-agent finished this round — drop it from the live panel (it's
+		// idle now; a later send_message re-adds it via a fresh "started").
+		m.removeSubAgent(msg.ev.AgentID)
 		// Async sub-agent completion: the full result rode into the conversation
 		// via Inbox; no scrollback notice needed.
 		// Idle auto-turn: same logic as bgExitMsg — drain inbox and trigger a
@@ -502,6 +536,56 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // are accumulated in m.partial so they render live in View(); only complete
 // markdown blocks are promoted to the scrollback via println/flushPrints.
 // Tool events flush any pending text first, then commit their line/card.
+// maxSubAgentRecentTools bounds the live tool-chain shown per sub-agent.
+const maxSubAgentRecentTools = 4
+
+// handleSubAgentEvent folds one sub-agent runtime event into the live panel
+// state. "started" creates/refreshes the entry; "tool"/"tool_error" append to
+// its chain.
+func (m *tuiModel) handleSubAgentEvent(ev tools.SubAgentEvent) {
+	sa := m.subAgents[ev.AgentID]
+	if sa == nil {
+		sa = &subAgentUI{description: ev.Description, start: time.Now()}
+		m.subAgents[ev.AgentID] = sa
+		m.subAgentOrder = append(m.subAgentOrder, ev.AgentID)
+	}
+	switch ev.Kind {
+	case "started":
+		// A fresh round (launch or send_message): reset the chain, keep the slot.
+		sa.toolCount = 0
+		sa.recent = nil
+		sa.errored = false
+		if ev.Description != "" {
+			sa.description = ev.Description
+		}
+	case "tool", "tool_error":
+		sa.toolCount++
+		name := ev.ToolName
+		if ev.Kind == "tool_error" {
+			sa.errored = true
+			name += " ✗"
+		}
+		sa.recent = append(sa.recent, name)
+		if len(sa.recent) > maxSubAgentRecentTools {
+			sa.recent = sa.recent[len(sa.recent)-maxSubAgentRecentTools:]
+		}
+	}
+}
+
+// removeSubAgent drops a sub-agent from the live panel once it finishes a round.
+func (m *tuiModel) removeSubAgent(id string) {
+	if _, ok := m.subAgents[id]; !ok {
+		return
+	}
+	delete(m.subAgents, id)
+	for i, x := range m.subAgentOrder {
+		if x == id {
+			m.subAgentOrder = append(m.subAgentOrder[:i], m.subAgentOrder[i+1:]...)
+			break
+		}
+	}
+}
+
 func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 	switch ev.Kind {
 	case agent.EventTextDelta:

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -443,6 +443,9 @@ func (m *tuiModel) liveHeight() int {
 	if bg := tools.RunningBackground(); len(bg) > 0 {
 		h += 3 + len(bg) // panel border (2) + title (1) + body lines
 	}
+	if n := len(m.subAgentOrder); n > 0 {
+		h += 3 + n // panel border (2) + title (1) + one line per sub-agent
+	}
 	h += m.completionHeight() // slash-completion menu (0 when closed)
 	h += m.ta.Height()        // input box (textarea grows with content)
 	if m.turnRunning {
@@ -518,6 +521,34 @@ func (m *tuiModel) View() string {
 			fmt.Fprintf(&lines, "%c %s (%s)", frame, truncate1Line(p.Command), time.Since(p.Start).Round(time.Second))
 		}
 		b.WriteString(tui.Panel(fmt.Sprintf("background (%d running)", len(bg)), lines.String()))
+		b.WriteByte('\n')
+	}
+
+	// Sub-agents panel — live tool-call chain of each running sub-agent
+	// (Claude-Code style), mirroring the background-processes panel.
+	if len(m.subAgentOrder) > 0 {
+		frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
+		var lines strings.Builder
+		for i, id := range m.subAgentOrder {
+			sa := m.subAgents[id]
+			if sa == nil {
+				continue
+			}
+			if i > 0 {
+				lines.WriteByte('\n')
+			}
+			label := id
+			if sa.description != "" {
+				label = fmt.Sprintf("%s (%s)", id, truncate1Line(sa.description))
+			}
+			chain := "starting…"
+			if len(sa.recent) > 0 {
+				chain = strings.Join(sa.recent, " · ")
+			}
+			fmt.Fprintf(&lines, "%c %s — %s  (%d tools, %s)",
+				frame, label, chain, sa.toolCount, time.Since(sa.start).Round(time.Second))
+		}
+		b.WriteString(tui.Panel(fmt.Sprintf("sub-agents (%d running)", len(m.subAgentOrder)), lines.String()))
 		b.WriteByte('\n')
 	}
 

--- a/dev-docs/sub-agent-design.md
+++ b/dev-docs/sub-agent-design.md
@@ -174,23 +174,29 @@ sequenceDiagram
 - 不给子 agent `launch_agent` / `send_message`(递归防护)。
 - 不做父子之间的双向流式(通知是一次性的,不是流)。
 
-## 计划中:运行时实时显示
+## 运行时实时显示
 
-> 状态:设计已定,尚未实现。当前父 agent 只在子 agent **完成**时收到一条通知,看不到子 agent
-> **运行中**的内部过程。
+TUI 在底部显示一个 sub-agent 面板,实时呈现每个**活跃**子 agent 的 tool 调用链——类比
+background-processes 面板。复用现有事件体系,不改 `agent.AgentEvent`:
 
-目标是让子 agent 运行体验接近 Claude Code:启动即显示、实时显示内部 tool 调用链、底部面板展示所有
-活跃子 agent、可展开/折叠看详情。
+- **执行层**:`agentSpawner.runChild` 用 `RunStream`(而非 `Run`)跑子 agent。当 ctx 里带有事件
+  sink 时,把子 agent 的 `agent.AgentEvent` 中的 `tool_started` / `tool_error` 映射成
+  `tools.SubAgentEvent` 喂给 sink。**只转 tool 级事件**,不转 per-token 的 text/input delta——
+  多个并发子 agent 的 token 流会淹没事件循环,而面板要的是 tool 链。
+- **异步层**:`SubAgentManager` 有 `onEvent func(SubAgentEvent)`(与 `onExit` 完成回调并列)。
+  `Start` / `runContinue` 在调 `Spawn` / `Continue` 前,用 `WithSubAgentEventSink(ctx, sink)` 把一个
+  带 `agent_N` 标记的 sink 注入 ctx,并先发一个 `started` 事件(启动即显示)。没有 `onEvent` 时
+  不注入 sink,执行层不流式——taskgraph/headless 零开销、零行为变化。
+- **传递**:sink 走 **context**(`WithSubAgentEventSink` / `SubAgentEventSink`),所以 `Spawner`
+  接口签名不变,`internal/tools` 与 `cmd/octo` 解耦。
+- **TUI**:`subAgentEventMsg` 把事件投上事件循环;`subAgentUI` 状态(描述、起始时间、tool 计数、
+  最近几个 tool 名、错误标记)按 `agent_N` 聚合,渲染成 `tui.Panel`。子 agent 完成(`subAgentNoteMsg`)
+  时从面板移除;后续 `send_message` 再 `started` 重新加入。
+- **Plain REPL**:不接 `onEvent`——启动行由 `launch_agent` 的工具返回体现,完成由通知体现,不打印
+  内部 tool 链。
 
-落地思路是复用现有事件体系:
+约束:不持久化运行时事件(内存-only)、不改 `agent.AgentEvent` 定义、不在面板里支持
+kill/send_message 操作(仍通过工具调用)。
 
-- `agentSpawner.runChild` 把子 agent 的执行从 `Run` 换成 `RunStream`,传入一个 `EventHandler`,把子
-  agent 的 `agent.AgentEvent`(text_delta / tool_started / tool_done / tool_error / turn_done)映射成
-  一个新的 `tools.SubAgentEvent` 类型。
-- `SubAgentManager` 新增 `onEvent func(SubAgentEvent)` 运行时事件回调(与现有 `onExit` 完成回调并列)。
-- TUI(`cmd/octo/tuirepl*.go`)新增 `subAgentEventMsg` 消息类型与 `subAgentState` 状态映射,在底部新增
-  sub-agent 面板(复用现有 `tui.Panel`,类比 background processes 面板),展开时显示完整 tool 调用历史。
-- Plain REPL 只打印极简的启动/完成行,不显示内部 tool 链。
-
-约束:不持久化运行时事件(内存-only)、不改 `agent.AgentEvent` 定义、不在面板里支持 kill/send_message
-操作(仍通过工具调用)。
+**尚未做**:交互式展开/折叠看某个子 agent 的完整 tool 历史(需要焦点管理 + 按键)。当前面板每行
+内联显示最近几个 tool(`maxSubAgentRecentTools`)+ 累计计数,已覆盖"实时 tool 链"的核心。

--- a/internal/tools/subagent_event.go
+++ b/internal/tools/subagent_event.go
@@ -1,0 +1,43 @@
+package tools
+
+import "context"
+
+// SubAgentEvent is a runtime progress event from a sub-agent, forwarded to a
+// SubAgentManager's onEvent hook for live display. It is distinct from
+// SubAgentNotification, which is the one-shot completion record: events stream
+// while the sub-agent works, the notification fires once when it finishes.
+//
+// Only tool-level activity is carried — not per-token text — so a live panel
+// can show each sub-agent's tool-call chain without the event volume of N
+// concurrent sub-agents streaming their prose.
+type SubAgentEvent struct {
+	AgentID     string // manager handle, e.g. "agent_1"
+	Description string // human-readable label from launch_agent
+	// Kind is one of:
+	//   "started"    — the sub-agent began a task (or a send_message round)
+	//   "tool"       — it dispatched a tool (ToolName set)
+	//   "tool_error" — a tool returned an error (ToolName set)
+	Kind     string
+	ToolName string
+}
+
+type subAgentSinkKey struct{}
+
+// WithSubAgentEventSink returns a context carrying sink, which the execution
+// layer (the agentSpawner) pulls out to forward a child's runtime events. The
+// SubAgentManager stamps this in before calling Spawn/Continue, so the Spawner
+// interface itself stays unchanged and the taskgraph path (no sink) emits
+// nothing.
+func WithSubAgentEventSink(ctx context.Context, sink func(SubAgentEvent)) context.Context {
+	if sink == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, subAgentSinkKey{}, sink)
+}
+
+// SubAgentEventSink returns the sink stamped by WithSubAgentEventSink, or nil
+// when none is set (taskgraph, tests, or a manager with no onEvent hook).
+func SubAgentEventSink(ctx context.Context) func(SubAgentEvent) {
+	sink, _ := ctx.Value(subAgentSinkKey{}).(func(SubAgentEvent))
+	return sink
+}

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -129,6 +129,7 @@ type SubAgentManager struct {
 	seq     int
 	spawner Spawner
 	onExit  func(SubAgentNotification)
+	onEvent func(SubAgentEvent)
 }
 
 // NewSubAgentManager returns an empty manager.
@@ -145,6 +146,33 @@ func (m *SubAgentManager) SetOnExit(fn func(SubAgentNotification)) {
 	m.mu.Lock()
 	m.onExit = fn
 	m.mu.Unlock()
+}
+
+// SetOnEvent registers a runtime-event hook fired as a sub-agent works
+// (started + per-tool activity), for live display. Pass nil to clear. Distinct
+// from onExit, which fires once on completion.
+func (m *SubAgentManager) SetOnEvent(fn func(SubAgentEvent)) {
+	m.mu.Lock()
+	m.onEvent = fn
+	m.mu.Unlock()
+}
+
+// eventSink builds the per-agent sink stamped into the spawn context. Returns
+// nil when no onEvent hook is set, so the spawner skips streaming entirely.
+func (m *SubAgentManager) eventSink(id, description string) func(SubAgentEvent) {
+	m.mu.Lock()
+	onEvent := m.onEvent
+	m.mu.Unlock()
+	if onEvent == nil {
+		return nil
+	}
+	return func(ev SubAgentEvent) {
+		ev.AgentID = id
+		if ev.Description == "" {
+			ev.Description = description
+		}
+		onEvent(ev)
+	}
 }
 
 // Start creates a new sub-agent and runs it asynchronously.
@@ -168,6 +196,13 @@ func (m *SubAgentManager) Start(req SpawnRequest) (string, error) {
 	}
 	m.agents[id] = agent
 	m.mu.Unlock()
+
+	// Stream runtime events (started + per-tool) for live display. nil sink =>
+	// no onEvent hook => the spawner runs without streaming.
+	if sink := m.eventSink(id, req.Description); sink != nil {
+		ctx = WithSubAgentEventSink(ctx, sink)
+		sink(SubAgentEvent{Kind: "started"})
+	}
 
 	go func() {
 		res, err := m.spawner.Spawn(ctx, req)
@@ -250,7 +285,15 @@ func (m *SubAgentManager) runContinue(agentID, message string) {
 	agent.mu.Lock()
 	agent.cancel = cancel
 	backingID := agent.backingID
+	desc := agent.description
 	agent.mu.Unlock()
+
+	// Stream runtime events for this round too, so the live panel re-shows the
+	// sub-agent as running while it handles the message.
+	if sink := m.eventSink(agentID, desc); sink != nil {
+		ctx = WithSubAgentEventSink(ctx, sink)
+		sink(SubAgentEvent{Kind: "started"})
+	}
 
 	// Continue addresses the child by its Spawner-side id, not the manager's
 	// agent_N handle — the two id spaces are distinct.

--- a/internal/tools/subagent_manager_test.go
+++ b/internal/tools/subagent_manager_test.go
@@ -268,3 +268,90 @@ func TestSubAgentManagerSendToExited(t *testing.T) {
 		t.Fatal("expected error for exited agent")
 	}
 }
+
+// eventSpawner forwards a tool event through the ctx-stamped sink, exercising
+// the manager's onEvent wiring end to end.
+type eventSpawner struct{ sawSink bool }
+
+func (s *eventSpawner) Spawn(ctx context.Context, _ SpawnRequest) (SpawnResult, error) {
+	if sink := SubAgentEventSink(ctx); sink != nil {
+		s.sawSink = true
+		sink(SubAgentEvent{Kind: "tool", ToolName: "grep"})
+	}
+	return SpawnResult{Reply: "ok", AgentID: "backing"}, nil
+}
+
+func (s *eventSpawner) Continue(_ context.Context, _, _ string) (SpawnResult, error) {
+	return SpawnResult{Reply: "ok"}, nil
+}
+
+func TestSubAgentManager_OnEvent(t *testing.T) {
+	sp := &eventSpawner{}
+	mgr := NewSubAgentManager(sp)
+
+	var mu sync.Mutex
+	var events []SubAgentEvent
+	mgr.SetOnEvent(func(ev SubAgentEvent) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	})
+	done := make(chan struct{})
+	mgr.SetOnExit(func(SubAgentNotification) { close(done) })
+
+	id, err := mgr.Start(SpawnRequest{Description: "lbl", Prompt: "p"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for completion")
+	}
+
+	if !sp.sawSink {
+		t.Error("spawner never saw an event sink in ctx")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) < 2 {
+		t.Fatalf("want >=2 events (started + tool), got %+v", events)
+	}
+	if events[0].Kind != "started" {
+		t.Errorf("first event Kind = %q, want started", events[0].Kind)
+	}
+	var sawTool bool
+	for _, e := range events {
+		if e.AgentID != id {
+			t.Errorf("event AgentID = %q, want %q", e.AgentID, id)
+		}
+		if e.Description != "lbl" {
+			t.Errorf("event Description = %q, want lbl", e.Description)
+		}
+		if e.Kind == "tool" && e.ToolName == "grep" {
+			sawTool = true
+		}
+	}
+	if !sawTool {
+		t.Error("tool event not forwarded through the ctx sink")
+	}
+}
+
+func TestSubAgentManager_NoOnEvent_NoSink(t *testing.T) {
+	sp := &eventSpawner{}
+	mgr := NewSubAgentManager(sp)
+	done := make(chan struct{})
+	mgr.SetOnExit(func(SubAgentNotification) { close(done) })
+
+	if _, err := mgr.Start(SpawnRequest{Description: "d", Prompt: "p"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out")
+	}
+	if sp.sawSink {
+		t.Error("sink should be absent from ctx when no onEvent hook is set")
+	}
+}


### PR DESCRIPTION
## What

Implements the "运行时实时显示 / runtime live display" section of `dev-docs/sub-agent-design.md` (previously *designed, not implemented*).

The parent previously saw a sub-agent **only on completion** — its in-flight work was invisible. The TUI now shows a bottom **`sub-agents (N running)`** panel with each active sub-agent's live tool-call chain, mirroring the background-processes panel.

```
╭─ sub-agents (2 running) ────────────────────────────────╮
│ ⠋ agent_1 (Find Banner TUI code) — read_file · grep …  (3 tools, 12s) │
│ ⠋ agent_2 (Audit deps) — terminal  (1 tool, 4s)         │
╰─────────────────────────────────────────────────────────╯
```

## How

- **`internal/tools`** — new `SubAgentEvent` + a **context-carried sink** (`WithSubAgentEventSink` / `SubAgentEventSink`). `SubAgentManager` gains `onEvent` / `SetOnEvent`; `Start` and `runContinue` stamp a per-agent sink into ctx and emit a `started` event (shown on launch). No `onEvent` ⇒ no sink ⇒ no streaming, so taskgraph/headless paths are unchanged.
- **`cmd/octo/sub_agent.go`** — `runChild` drives the child with `RunStream` and forwards `tool_started` / `tool_error` to the sink. **Only tool-level events** are forwarded (not per-token text) to keep volume sane with several sub-agents at once. A nil sink makes `RunStream` behave exactly like `Run`.
- **`cmd/octo` TUI** — `subAgentEventMsg` + `subAgentUI` state aggregated by `agent_N`, rendered as a `tui.Panel`. Entries appear on `started`, update per tool, and are removed on the completion note (re-added on a later `send_message`).
- The **`Spawner` interface is unchanged** (the sink rides ctx), keeping `internal/tools` and `cmd/octo` decoupled.

Plain REPL is intentionally untouched (launch shows via the tool result, completion via the notification, no internal tool chain).

## Design deviations (both noted in the doc)

1. Forward only tool-level events, not the design's `text_delta` — volume control for concurrent sub-agents.
2. Ship the always-visible live chain now; **interactive expand/collapse** of a sub-agent's full history (needs focus management + key bindings) is left as follow-up. The inline last-N-tools + count already covers the core "live tool chain".

## Tests

- `internal/tools`: manager `onEvent` wiring end-to-end; ctx-sink present when hooked, absent otherwise.
- `cmd/octo`: panel state folding — started/tool/tool_error, recent-cap, remove-on-complete, re-start reset.
- `make fmt-check` / `make vet` / `go test -race ./...` green; `internal/agent` stays provider-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)