### PR TITLE
feat(tui): after-turn follow-up suggestion as ghost text

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -104,6 +104,19 @@ func openMCPLogFile() *os.File {
 	return f
 }
 
+// suggestEnabled resolves whether to offer after-turn follow-up suggestions:
+// on by default, off when --no-suggest is set or OCTO_SUGGEST is falsey.
+func suggestEnabled(noSuggestFlag bool) bool {
+	if noSuggestFlag {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("OCTO_SUGGEST"))) {
+	case "0", "false", "off", "no":
+		return false
+	}
+	return true
+}
+
 // tuiDisabledByEnv reports whether OCTO_TUI is set to a falsey value, the env
 // equivalent of --no-tui (handy for dumb terminals / CI without editing the
 // command line).
@@ -173,6 +186,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	plain := fs.Bool("plain", false, "Render tool events as one-line ↳ status lines instead of rich diff cards")
 	promptFile := fs.String("prompt-file", "", "Read the prompt from this file (newlines preserved) and run it as one headless agentic turn, then exit. For scripting/eval.")
 	noTUI := fs.Bool("no-tui", false, "Force the headless one-shot path on a terminal instead of the interactive TUI (also OCTO_TUI=0). The prompt comes from a positional message, --prompt-file, or piped stdin.")
+	noSuggest := fs.Bool("no-suggest", false, "Disable the after-turn follow-up suggestion (ghost text accepted with Tab/→). Also OCTO_SUGGEST=0.")
 	quietFlag := fs.Bool("quiet", false, "Strip all status chrome (no spinner, no banner, no cache line). Also OCTO_VERBOSITY=quiet.")
 	verboseFlag := fs.Bool("verbose", false, "Print extra context (provider/model/endpoint, always-on cache line). Also OCTO_VERBOSITY=verbose.")
 	permMode := fs.String("permission-mode", "", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask) | auto (allow on ask). Empty = use `octo config` value, else interactive.")
@@ -608,6 +622,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		a:          a,
 		session:    agent.NewSession(resolvedModel, *system),
 		noSave:     true,
+		suggest:    suggestEnabled(*noSuggest),
 		plain:      *plain,
 		verbosity:  resolveVerbosity(*quietFlag, *verboseFlag),
 		stdin:      stdin,

--- a/cmd/octo/completion.go
+++ b/cmd/octo/completion.go
@@ -255,7 +255,7 @@ var taskSubcommands = []string{
 // list focused avoids drowning the completion popup with rarely-used flags.
 var chatFlags = []string{
 	"-c", "--continue", "--tools", "--no-tools", "--provider", "--model",
-	"--no-save", "--no-memory", "--sandbox", "--sandbox-allow-net",
+	"--no-save", "--no-memory", "--no-suggest", "--sandbox", "--sandbox-allow-net",
 	"--permission-mode", "--list-sessions", "--list-skills",
 	"--quiet", "--verbose", "--plain", "--stream", "--system",
 	"--help",

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -23,6 +23,7 @@ type replConfig struct {
 	a           *agent.Agent
 	session     *agent.Session
 	noSave      bool
+	suggest     bool               // true → after each turn, offer an LLM follow-up suggestion (TUI ghost text)
 	plain       bool               // true → fall back to terse ↳ status lines for all tool events
 	verbosity   verbosity          // quiet | normal | verbose; controls spinner + chrome
 	permEngine  *permission.Engine // nil → no tool-permission gating

--- a/cmd/octo/suggestion_test.go
+++ b/cmd/octo/suggestion_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestSuggestion_SetAcceptClear(t *testing.T) {
+	m := newTestModel()
+
+	m.setSuggestion("run the tests")
+	if m.suggestion != "run the tests" {
+		t.Fatalf("suggestion = %q", m.suggestion)
+	}
+	if m.ta.Placeholder != "run the tests" {
+		t.Errorf("placeholder = %q, want the suggestion as ghost text", m.ta.Placeholder)
+	}
+
+	m.acceptSuggestion()
+	if m.ta.Value() != "run the tests" {
+		t.Errorf("after accept, input = %q, want the suggestion filled in", m.ta.Value())
+	}
+	if m.suggestion != "" {
+		t.Error("suggestion should be cleared after accept")
+	}
+	if m.ta.Placeholder != inputPlaceholder {
+		t.Errorf("placeholder = %q, want it restored to %q", m.ta.Placeholder, inputPlaceholder)
+	}
+}
+
+func TestSuggestion_ClearRestoresPlaceholder(t *testing.T) {
+	m := newTestModel()
+	m.setSuggestion("commit")
+	m.clearSuggestion()
+	if m.suggestion != "" || m.ta.Placeholder != inputPlaceholder {
+		t.Errorf("after clear: suggestion=%q placeholder=%q", m.suggestion, m.ta.Placeholder)
+	}
+}
+
+func TestSuggestion_TabAcceptsWhenEmpty(t *testing.T) {
+	m := newTestModel()
+	m.setSuggestion("open the PR")
+
+	if _, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyTab}); m.ta.Value() != "open the PR" {
+		t.Errorf("Tab on empty input should accept; input = %q", m.ta.Value())
+	}
+	if m.suggestion != "" {
+		t.Error("suggestion not cleared after Tab accept")
+	}
+}
+
+func TestSuggestion_RightArrowAcceptsWhenEmpty(t *testing.T) {
+	m := newTestModel()
+	m.setSuggestion("deploy to staging")
+	if _, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyRight}); m.ta.Value() != "deploy to staging" {
+		t.Errorf("→ on empty input should accept; input = %q", m.ta.Value())
+	}
+}
+
+func TestSuggestion_TabIgnoredWhenInputPresent(t *testing.T) {
+	m := newTestModel()
+	m.setSuggestion("a suggestion")
+	setInput(m, "my own text")
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyTab})
+	// With text present, Tab must NOT replace it with the suggestion.
+	if m.ta.Value() != "my own text" {
+		t.Errorf("Tab with input present overwrote it: %q", m.ta.Value())
+	}
+	if m.suggestion != "a suggestion" {
+		t.Error("suggestion should remain pending when not accepted")
+	}
+}
+
+func TestSuggestion_StartTurnClears(t *testing.T) {
+	m := newTestModel()
+	m.setSuggestion("stale")
+	_ = m.startTurnEcho("go", "go")
+	if m.suggestion != "" {
+		t.Error("starting a turn should clear the pending suggestion")
+	}
+}
+
+func TestSuggestion_MsgIgnoredWhileTurnRunning(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	_, _ = m.Update(suggestionMsg{text: "late suggestion"})
+	if m.suggestion != "" {
+		t.Error("a suggestion arriving during a turn should be dropped")
+	}
+}

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -111,6 +111,10 @@ func runTUI(cfg replConfig) int {
 	return 0
 }
 
+// inputPlaceholder is the idle hint shown in the empty input box. It's swapped
+// for a pending follow-up suggestion (ghost text) when one is available.
+const inputPlaceholder = "Ask anything…"
+
 // ── messages marshalled from the agent goroutine onto the event loop ──
 
 type turnStartedMsg struct{}
@@ -124,6 +128,7 @@ type noticeMsg struct{ text string }
 type bgExitMsg struct{ e tools.BgExit }                      // a background process finished (async)
 type subAgentNoteMsg struct{ ev tools.SubAgentNotification } // a sub-agent completed (async)
 type subAgentEventMsg struct{ ev tools.SubAgentEvent }       // a sub-agent's runtime activity (async)
+type suggestionMsg struct{ text string }                     // an after-turn follow-up suggestion (async)
 type tickMsg struct{}                                        // animation tick while a turn runs
 type askMsg struct {
 	prompt UserPrompt
@@ -284,6 +289,11 @@ type tuiModel struct {
 	// height is the terminal height in cells, updated by WindowSizeMsg.
 	height int
 
+	// suggestion is a pending after-turn follow-up suggestion shown as ghost
+	// text in the empty input box (the textarea placeholder). Accepted with
+	// Tab/→, cleared when a turn starts. Empty means none pending.
+	suggestion string
+
 	// subAgents holds the live state of currently-running sub-agents, keyed by
 	// manager handle (agent_N), rendered as a bottom panel. An entry appears on
 	// the "started" event and is removed when its completion note arrives.
@@ -321,7 +331,7 @@ type modalState struct {
 
 func newTUIModel(cfg replConfig) *tuiModel {
 	ta := textarea.New()
-	ta.Placeholder = "Ask anything…"
+	ta.Placeholder = inputPlaceholder
 	ta.Focus()
 	ta.ShowLineNumbers = false
 	// Only the first line shows "> "; subsequent lines are padded with spaces
@@ -371,6 +381,7 @@ func (m *tuiModel) startTurnEcho(line, echo string) tea.Cmd {
 	m.spinnerFrame = 0
 	m.running = nil
 	m.partial.Reset()
+	m.clearSuggestion() // a new turn supersedes any pending follow-up
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancelTurn = cancel
 	a := m.a
@@ -451,6 +462,14 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, m.flushPrints()
 
+	case suggestionMsg:
+		// Show the follow-up only while idle with an empty input — a new turn or
+		// in-progress typing makes a stale suggestion unwelcome.
+		if !m.turnRunning && strings.TrimSpace(m.ta.Value()) == "" {
+			m.setSuggestion(msg.text)
+		}
+		return m, m.flushPrints()
+
 	case subAgentNoteMsg:
 		// A sub-agent finished this round — drop it from the live panel (it's
 		// idle now; a later send_message re-adds it via a fresh "started").
@@ -502,6 +521,11 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.queue = m.queue[1:]
 				return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(next.text, ""))
 			}
+		}
+		// On a clean completion, ask for one follow-up suggestion (off the event
+		// loop). Skipped on error/interrupt and when disabled (--no-suggest).
+		if m.cfg.suggest && msg.err == nil {
+			return m, tea.Batch(m.flushPrints(), m.suggestCmd())
 		}
 		return m, m.flushPrints()
 
@@ -584,6 +608,52 @@ func (m *tuiModel) removeSubAgent(id string) {
 			break
 		}
 	}
+}
+
+// suggestCmd asks the model for one follow-up suggestion off the event loop.
+// A nil/empty result yields a nil msg, which bubbletea ignores.
+func (m *tuiModel) suggestCmd() tea.Cmd {
+	a := m.a
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		s, err := a.Suggest(ctx)
+		if err != nil || strings.TrimSpace(s) == "" {
+			return nil
+		}
+		return suggestionMsg{text: s}
+	}
+}
+
+// setSuggestion shows s as ghost text in the empty input box (the placeholder),
+// truncated to one line so it never wraps the input.
+func (m *tuiModel) setSuggestion(s string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return
+	}
+	m.suggestion = s
+	m.ta.Placeholder = truncate1Line(s)
+}
+
+// clearSuggestion drops the pending suggestion and restores the idle hint.
+func (m *tuiModel) clearSuggestion() {
+	if m.suggestion == "" {
+		return
+	}
+	m.suggestion = ""
+	m.ta.Placeholder = inputPlaceholder
+}
+
+// acceptSuggestion fills the input with the pending suggestion for the user to
+// edit or send, then clears it.
+func (m *tuiModel) acceptSuggestion() {
+	if m.suggestion == "" {
+		return
+	}
+	m.ta.SetValue(m.suggestion)
+	m.ta.CursorEnd()
+	m.clearSuggestion()
 }
 
 func (m *tuiModel) handleEvent(ev agent.AgentEvent) {

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -614,10 +614,13 @@ func (m *tuiModel) removeSubAgent(id string) {
 // A nil/empty result yields a nil msg, which bubbletea ignores.
 func (m *tuiModel) suggestCmd() tea.Cmd {
 	a := m.a
+	// Same toolbelt as the agentic loop, so the suggest request's
+	// tools→system→history prefix matches and hits the prompt cache.
+	tools := m.cfg.tools
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
-		s, err := a.Suggest(ctx)
+		s, err := a.Suggest(ctx, tools)
 		if err != nil || strings.TrimSpace(s) == "" {
 			return nil
 		}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -67,6 +67,16 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Ghost-text follow-up: Tab or → accepts the pending suggestion when the
+	// input is empty, filling it in to edit or send. With text present these
+	// keys keep their normal behaviour (cursor / tab insert).
+	if m.suggestion != "" && strings.TrimSpace(m.ta.Value()) == "" {
+		if msg.Type == tea.KeyTab || msg.Type == tea.KeyRight {
+			m.acceptSuggestion()
+			return m, m.updateTextAreaHeight()
+		}
+	}
+
 	switch msg.Type {
 	case tea.KeyCtrlD:
 		m.quit = true

--- a/dev-docs/next-suggestion.md
+++ b/dev-docs/next-suggestion.md
@@ -7,17 +7,26 @@ dismisses it. On by default; `--no-suggest` / `OCTO_SUGGEST=0` turns it off.
 
 ## Generation
 
-`Agent.Suggest(ctx)` (internal/agent) makes a throwaway provider call: it
+`Agent.Suggest(ctx, tools)` (internal/agent) makes a throwaway provider call: it
 appends a one-line instruction to a **snapshot** of history (never the live
 `History`) and asks for a single next user message, capped at `suggestMaxTokens`.
-Because it's a snapshot, the conversation isn't polluted; because the history
-prefix is prompt-cached, only the instruction and the one-line reply are fresh
-tokens. The result is passed through `cleanSuggestion` (first non-empty line,
-list/quote decoration stripped). Its usage is intentionally **not** accrued into
-the session — it's an auxiliary UI call, not part of a turn.
+Because it's a snapshot, the conversation isn't polluted. The result is passed
+through `cleanSuggestion` (first non-empty line, list/quote decoration stripped).
+Its usage is intentionally **not** accrued into the session — it's an auxiliary
+UI call, not part of a turn. Returns `""` (no error) when there's nothing to
+suggest.
 
-`Suggest` is provider-agnostic and lives in the agent package alongside the
-`Sender`; it returns `""` (no error) when there's nothing to suggest.
+**Cache alignment is the whole reason it's cheap.** Anthropic's cache prefix is
+ordered `tools → system → messages`. The agentic loop sends a tools block, so if
+Suggest sent *no* tools (a plain `SendMessages`) its prefix would diverge at
+block 0 and the entire history would be re-billed at full input price every
+turn. So Suggest takes the **same `tools`** the loop uses and routes through the
+`ToolSender` path: the `tools → system → history` prefix matches, the whole
+history is reused at the cheap cache-read rate, and only the instruction plus the
+one-line reply are fresh tokens. The instruction tells the model not to call
+tools; if it returns a `tool_use` anyway, `Content` is empty and that turn simply
+yields no suggestion. The TUI passes `cfg.tools`; with no ToolSender/tools,
+Suggest falls back to `SendMessages` (uncached but still correct).
 
 ## TUI wiring (cmd/octo)
 

--- a/dev-docs/next-suggestion.md
+++ b/dev-docs/next-suggestion.md
@@ -1,0 +1,45 @@
+# After-turn follow-up suggestion
+
+After each turn the TUI offers **one** LLM-generated follow-up — a next message
+the user might send — as **ghost text** in the empty input box. `Tab` or `→`
+accepts it (fills the input to edit or send); typing or starting a turn
+dismisses it. On by default; `--no-suggest` / `OCTO_SUGGEST=0` turns it off.
+
+## Generation
+
+`Agent.Suggest(ctx)` (internal/agent) makes a throwaway provider call: it
+appends a one-line instruction to a **snapshot** of history (never the live
+`History`) and asks for a single next user message, capped at `suggestMaxTokens`.
+Because it's a snapshot, the conversation isn't polluted; because the history
+prefix is prompt-cached, only the instruction and the one-line reply are fresh
+tokens. The result is passed through `cleanSuggestion` (first non-empty line,
+list/quote decoration stripped). Its usage is intentionally **not** accrued into
+the session — it's an auxiliary UI call, not part of a turn.
+
+`Suggest` is provider-agnostic and lives in the agent package alongside the
+`Sender`; it returns `""` (no error) when there's nothing to suggest.
+
+## TUI wiring (cmd/octo)
+
+- On a clean `turnEndedMsg` (no error/interrupt) and when `cfg.suggest` is set,
+  the model dispatches `suggestCmd()` — a `tea.Cmd` that runs `Suggest` off the
+  event loop and returns a `suggestionMsg` (nil on empty/error, which bubbletea
+  ignores).
+- `suggestionMsg` is applied only while **idle with an empty input**, so a stale
+  suggestion never clobbers in-progress typing or a running turn.
+- Ghost text reuses the textarea **placeholder**: `setSuggestion` swaps the
+  idle "Ask anything…" hint for the suggestion (one line); `clearSuggestion`
+  restores it. `acceptSuggestion` fills the value and clears.
+- `handleKey` intercepts `Tab`/`→` to accept **only when the input is empty**;
+  with text present those keys keep their normal behaviour. Starting a turn
+  (`startTurnEcho`) clears any pending suggestion.
+
+Plain/headless mode is untouched: the suggestion is a TUI ghost-text affordance,
+and the plain path has nowhere to render it.
+
+## Constraints
+
+- Only generated in the interactive TUI; one suggestion at a time.
+- No persistence; no extra model call when disabled.
+- Does not change `agent.AgentEvent` or the turn loop — it's a post-turn side
+  call plus input-box rendering.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -706,6 +706,54 @@ func isTransientStreamErr(err error) bool {
 	return errors.As(err, &t) && t.TransientStream()
 }
 
+// suggestMaxTokens caps the follow-up suggestion response — it's one short line.
+const suggestMaxTokens = 256
+
+const suggestInstruction = "Suggest ONE concise, specific next message I (the user) might send to continue this work. " +
+	"Output only that message text — phrased as I would type it, a single line, no preamble, no quotes, no numbering."
+
+// Suggest produces a single follow-up message the user might want to send next,
+// based on the conversation so far. It is a throwaway provider call: the
+// instruction is appended to a snapshot of history (never to the live History),
+// so it doesn't pollute the conversation, and its token usage is not accrued
+// into the session. Returns "" (no error) when there's nothing to suggest.
+//
+// Cheap in practice: the history prefix is prompt-cached, so only the short
+// instruction and the one-line reply are fresh tokens.
+func (a *Agent) Suggest(ctx context.Context) (string, error) {
+	if a.Sender == nil || a.Model == "" {
+		return "", fmt.Errorf("agent: suggest: not configured")
+	}
+	snap := a.History.Snapshot()
+	if len(snap) == 0 {
+		return "", nil
+	}
+	msgs := make([]Message, 0, len(snap)+1)
+	msgs = append(msgs, snap...)
+	msgs = append(msgs, NewUserMessage(suggestInstruction))
+
+	reply, err := a.Sender.SendMessages(ctx, a.Model, a.System, msgs, suggestMaxTokens)
+	if err != nil {
+		return "", err
+	}
+	return cleanSuggestion(reply.Content), nil
+}
+
+// cleanSuggestion picks the first non-empty line and strips list/quote
+// decoration the model sometimes adds despite the instruction.
+func cleanSuggestion(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "- ")
+		line = strings.TrimPrefix(line, "* ")
+		line = strings.TrimSpace(strings.Trim(line, "\"'`"))
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
 // isMaxTokensTooLargeErr best-effort detects a provider rejecting an escalated
 // max_tokens because it exceeds the model's ceiling (e.g. Claude 3 caps at
 // 4096). Both Anthropic and OpenAI-protocol backends name max_tokens in the

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -710,7 +710,8 @@ func isTransientStreamErr(err error) bool {
 const suggestMaxTokens = 256
 
 const suggestInstruction = "Suggest ONE concise, specific next message I (the user) might send to continue this work. " +
-	"Output only that message text — phrased as I would type it, a single line, no preamble, no quotes, no numbering."
+	"Do not call any tools — reply with the message text only, phrased as I would type it, a single line, " +
+	"no preamble, no quotes, no numbering."
 
 // Suggest produces a single follow-up message the user might want to send next,
 // based on the conversation so far. It is a throwaway provider call: the
@@ -718,9 +719,14 @@ const suggestInstruction = "Suggest ONE concise, specific next message I (the us
 // so it doesn't pollute the conversation, and its token usage is not accrued
 // into the session. Returns "" (no error) when there's nothing to suggest.
 //
-// Cheap in practice: the history prefix is prompt-cached, so only the short
-// instruction and the one-line reply are fresh tokens.
-func (a *Agent) Suggest(ctx context.Context) (string, error) {
+// tools should be the SAME toolbelt the agentic loop uses. Anthropic's cache
+// prefix is ordered tools → system → messages, so sending the identical tools
+// makes this call reuse the main conversation's prompt cache (the whole history
+// is billed at the cheap cache-read rate) instead of re-billing it in full.
+// Without tools the prefix diverges at block 0 and nothing is cached. The model
+// is told not to call tools; if it returns a tool_use anyway, Content is empty
+// and we simply produce no suggestion that turn.
+func (a *Agent) Suggest(ctx context.Context, tools []ToolDefinition) (string, error) {
 	if a.Sender == nil || a.Model == "" {
 		return "", fmt.Errorf("agent: suggest: not configured")
 	}
@@ -732,7 +738,13 @@ func (a *Agent) Suggest(ctx context.Context) (string, error) {
 	msgs = append(msgs, snap...)
 	msgs = append(msgs, NewUserMessage(suggestInstruction))
 
-	reply, err := a.Sender.SendMessages(ctx, a.Model, a.System, msgs, suggestMaxTokens)
+	var reply Reply
+	var err error
+	if ts, ok := a.Sender.(ToolSender); ok && len(tools) > 0 {
+		reply, err = ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, suggestMaxTokens, tools)
+	} else {
+		reply, err = a.Sender.SendMessages(ctx, a.Model, a.System, msgs, suggestMaxTokens)
+	}
 	if err != nil {
 		return "", err
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1293,3 +1293,64 @@ func TestRunLoop_TransientStall_BoundedGivesUp(t *testing.T) {
 		t.Errorf("calls = %d, want %d (budget %d + final)", send.calls, maxStreamStalls+1, maxStreamStalls)
 	}
 }
+
+// ─── Suggest (after-turn follow-up) ────────────────────────────────────────
+
+func TestAgent_Suggest(t *testing.T) {
+	send := &fakeSender{reply: Reply{Content: "  - run the tests now\nignored second line"}}
+	a := New(send, "m")
+	a.System = "sys"
+	a.History.Append(NewUserMessage("do X"))
+	a.History.Append(NewAssistantMessage("did X"))
+
+	s, err := a.Suggest(context.Background())
+	if err != nil {
+		t.Fatalf("Suggest: %v", err)
+	}
+	if s != "run the tests now" {
+		t.Errorf("suggestion = %q, want %q (first line, decoration stripped)", s, "run the tests now")
+	}
+	// Must NOT pollute the conversation.
+	if a.History.Len() != 2 {
+		t.Errorf("history len = %d, want 2 (Suggest must not append)", a.History.Len())
+	}
+	// The instruction rides as the final message, with the small cap.
+	if n := len(send.gotMessages); n == 0 || send.gotMessages[n-1].Content != suggestInstruction {
+		t.Errorf("last sent message = %+v, want the suggest instruction", send.gotMessages)
+	}
+	if send.gotMaxToks != suggestMaxTokens {
+		t.Errorf("maxTokens = %d, want %d", send.gotMaxToks, suggestMaxTokens)
+	}
+}
+
+func TestAgent_Suggest_EmptyHistory(t *testing.T) {
+	a := New(&fakeSender{reply: Reply{Content: "x"}}, "m")
+	s, err := a.Suggest(context.Background())
+	if err != nil || s != "" {
+		t.Errorf("Suggest on empty history = (%q, %v), want (\"\", nil)", s, err)
+	}
+}
+
+func TestAgent_Suggest_NotConfigured(t *testing.T) {
+	a := New(nil, "")
+	if _, err := a.Suggest(context.Background()); err == nil {
+		t.Error("Suggest with no sender/model should error")
+	}
+}
+
+func TestCleanSuggestion(t *testing.T) {
+	cases := map[string]string{
+		"run the tests":        "run the tests",
+		"  \n- commit the fix": "commit the fix",
+		"* add a test":         "add a test",
+		"\"open the PR\"":      "open the PR",
+		"`gofmt the file`":     "gofmt the file",
+		"":                     "",
+		"\n\n":                 "",
+	}
+	for in, want := range cases {
+		if got := cleanSuggestion(in); got != want {
+			t.Errorf("cleanSuggestion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -247,15 +247,22 @@ type fakeToolSender struct {
 	// gotMaxToks records the maxTokens passed on each call, in order, so tests
 	// can assert escalation re-issued at the higher cap.
 	gotMaxToks []int
+	// gotTools / gotMsgs capture the last tool-aware call's inputs.
+	gotTools []ToolDefinition
+	gotMsgs  []Message
 }
 
-func (f *fakeToolSender) SendMessages(_ context.Context, _, _ string, _ []Message, maxTokens int) (Reply, error) {
+func (f *fakeToolSender) SendMessages(_ context.Context, _, _ string, msgs []Message, maxTokens int) (Reply, error) {
 	f.gotMaxToks = append(f.gotMaxToks, maxTokens)
+	f.gotMsgs = append([]Message(nil), msgs...)
+	f.gotTools = nil
 	return f.nextReply()
 }
 
-func (f *fakeToolSender) SendMessagesWithTools(_ context.Context, _, _ string, _ []Message, maxTokens int, _ []ToolDefinition) (Reply, error) {
+func (f *fakeToolSender) SendMessagesWithTools(_ context.Context, _, _ string, msgs []Message, maxTokens int, tools []ToolDefinition) (Reply, error) {
 	f.gotMaxToks = append(f.gotMaxToks, maxTokens)
+	f.gotMsgs = append([]Message(nil), msgs...)
+	f.gotTools = tools
 	return f.nextReply()
 }
 
@@ -1303,7 +1310,7 @@ func TestAgent_Suggest(t *testing.T) {
 	a.History.Append(NewUserMessage("do X"))
 	a.History.Append(NewAssistantMessage("did X"))
 
-	s, err := a.Suggest(context.Background())
+	s, err := a.Suggest(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Suggest: %v", err)
 	}
@@ -1323,9 +1330,35 @@ func TestAgent_Suggest(t *testing.T) {
 	}
 }
 
+// When a ToolSender + tools are available, Suggest must route through the
+// tool-aware path with the SAME tools, so its tools→system→history prefix
+// matches the agentic loop and reuses the prompt cache.
+func TestAgent_Suggest_UsesToolsForCacheAlignment(t *testing.T) {
+	send := &fakeToolSender{replies: []Reply{{Content: "open the PR"}}}
+	a := New(send, "m")
+	a.History.Append(NewUserMessage("do X"))
+	a.History.Append(NewAssistantMessage("did X"))
+	toolset := []ToolDefinition{{Name: "terminal"}, {Name: "edit_file"}}
+
+	s, err := a.Suggest(context.Background(), toolset)
+	if err != nil {
+		t.Fatalf("Suggest: %v", err)
+	}
+	if s != "open the PR" {
+		t.Errorf("suggestion = %q", s)
+	}
+	if len(send.gotTools) != len(toolset) {
+		t.Errorf("Suggest sent %d tools, want %d (must match the loop's toolbelt for cache reuse)", len(send.gotTools), len(toolset))
+	}
+	// History snapshot + the instruction, in order.
+	if n := len(send.gotMsgs); n < 3 || send.gotMsgs[n-1].Content != suggestInstruction {
+		t.Errorf("last message = %+v, want the suggest instruction after the history", send.gotMsgs)
+	}
+}
+
 func TestAgent_Suggest_EmptyHistory(t *testing.T) {
 	a := New(&fakeSender{reply: Reply{Content: "x"}}, "m")
-	s, err := a.Suggest(context.Background())
+	s, err := a.Suggest(context.Background(), nil)
 	if err != nil || s != "" {
 		t.Errorf("Suggest on empty history = (%q, %v), want (\"\", nil)", s, err)
 	}
@@ -1333,7 +1366,7 @@ func TestAgent_Suggest_EmptyHistory(t *testing.T) {
 
 func TestAgent_Suggest_NotConfigured(t *testing.T) {
 	a := New(nil, "")
-	if _, err := a.Suggest(context.Background()); err == nil {
+	if _, err := a.Suggest(context.Background(), nil); err == nil {
 		t.Error("Suggest with no sender/model should error")
 	}
 }


### PR DESCRIPTION
## What

Adds a "next suggestion" affordance: after each turn the TUI offers **one** LLM-generated follow-up — a next message you might send — as **ghost text** in the empty input box. **`Tab`** or **`→`** accepts it (fills the input to edit or send); typing or starting a turn dismisses it.

```
> open the PR for this fix▏      ← dim ghost text; Tab/→ to accept
```

On by default; `--no-suggest` / `OCTO_SUGGEST=0` turns it off.

## How

- **`internal/agent` — `Agent.Suggest(ctx)`**: a throwaway provider call. A one-line instruction is appended to a **snapshot** of history (never the live `History`), capped at `suggestMaxTokens`; the reply is run through `cleanSuggestion` (first non-empty line, list/quote decoration stripped). The conversation isn't polluted, and since the history prefix is prompt-cached it's cheap. Returns `""` when there's nothing to suggest. Provider-agnostic; usage intentionally **not** accrued (it's an auxiliary UI call).
- **`cmd/octo` TUI**: a clean `turnEndedMsg` dispatches `suggestCmd()` — a `tea.Cmd` that runs `Suggest` off the event loop and returns a `suggestionMsg` (nil on empty/error). The suggestion is applied only while **idle with an empty input**, so it never clobbers in-progress typing or a running turn. Ghost text reuses the textarea **placeholder**; `handleKey` accepts `Tab`/`→` **only when the input is empty** (otherwise they keep their normal behaviour). Starting a turn clears any pending suggestion.
- **Gate**: `--no-suggest` flag + `OCTO_SUGGEST` env (`suggestEnabled`), threaded via `replConfig.suggest`.

Plain/headless mode is untouched — ghost text is a TUI affordance with nowhere to render in the plain path.

## Tests

- `internal/agent`: `Suggest` doesn't append to history, sends the instruction + small cap, handles empty history / not-configured; `cleanSuggestion` decoration stripping.
- `cmd/octo`: set/accept/clear; `Tab` and `→` accept when empty; ignored when input present; cleared on turn start; dropped while a turn runs.
- `make fmt-check` / `make vet` / `go test -race ./...` green; `internal/agent` stays provider-free.

## Design notes

One suggestion at a time, TUI-only, no persistence, no extra model call when disabled. See `dev-docs/next-suggestion.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)