### PR TITLE
feat(tui): ↑ retracts a pending steer message back into the input box

### DIFF
--- a/cmd/octo/steer_recall_test.go
+++ b/cmd/octo/steer_recall_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// steerModel returns a model mid-turn with the given steer messages submitted
+// (queued in the inbox + shown as pending), the input box empty.
+func steerModel(t *testing.T, steers ...string) *tuiModel {
+	t.Helper()
+	m := newTestModel()
+	m.turnRunning = true
+	for _, s := range steers {
+		setInput(m, s)
+		m.submit()
+	}
+	return m
+}
+
+func TestSteerRecall_UpRetractsLastPending(t *testing.T) {
+	m := steerModel(t, "first steer", "second steer")
+
+	// ↑ retracts the most recent pending steer into the input box.
+	m.handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	if m.ta.Value() != "second steer" {
+		t.Fatalf("↑ recalled %q, want 'second steer'", m.ta.Value())
+	}
+	// It's removed from the pending display AND the inbox (won't be sent).
+	if len(m.pendingSteer) != 1 || m.pendingSteer[0] != "first steer" {
+		t.Errorf("pendingSteer = %v, want [first steer]", m.pendingSteer)
+	}
+	if drained := m.a.Inbox.Drain(); len(drained) != 1 || drained[0] != "first steer" {
+		t.Errorf("inbox after retract = %v, want [first steer]", drained)
+	}
+}
+
+func TestSteerRecall_UpDoesNotRetractWhenInputPresent(t *testing.T) {
+	m := steerModel(t, "pending one")
+	setInput(m, "typing my own")
+
+	m.handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	// With text present, ↑ keeps its ordinary history-browse behaviour and must
+	// NOT retract the pending steer — it stays queued (display + inbox).
+	if len(m.pendingSteer) != 1 || m.pendingSteer[0] != "pending one" {
+		t.Errorf("pending steer should stay queued, got %v", m.pendingSteer)
+	}
+	if !m.a.Inbox.HasPending() {
+		t.Error("steer should remain in the inbox when not retracted")
+	}
+}
+
+func TestSteerRecall_AlreadyDrainedFallsThroughToHistory(t *testing.T) {
+	m := steerModel(t, "drained steer")
+	// Simulate the loop draining the inbox before the user hits ↑.
+	_ = m.a.Inbox.Drain()
+
+	m.handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	// Inbox.Remove fails (already committed), so ↑ falls through to ordinary
+	// history recall — which still has the steer (added at submit time).
+	if m.ta.Value() != "drained steer" {
+		t.Errorf("↑ value = %q, want history-recalled 'drained steer'", m.ta.Value())
+	}
+	// pendingSteer is untouched by the fall-through (the EventSteerInjected that
+	// would clear it is processed separately).
+	if len(m.pendingSteer) != 1 {
+		t.Errorf("pendingSteer = %v, want it left for EventSteerInjected to clear", m.pendingSteer)
+	}
+}
+
+func TestSteerRecall_NoPendingUsesHistory(t *testing.T) {
+	m := newTestModel()
+	// An ordinary idle submit populates history but no pending steer.
+	setInput(m, "earlier prompt")
+	m.submit() // idle (turnRunning false) → starts a turn, but history has it
+	m.turnRunning = false
+
+	m.handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	if m.ta.Value() != "earlier prompt" {
+		t.Errorf("↑ with no pending steer = %q, want history recall 'earlier prompt'", m.ta.Value())
+	}
+}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -166,6 +166,19 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.submit()
 
 	case tea.KeyUp:
+		// Retract the most recent pending steer (typed mid-turn, not yet drained)
+		// back into the empty input box for editing — and drop it from the queue
+		// so it won't also be sent. If it was already drained (Inbox.Remove
+		// fails) it's committed; fall through to ordinary history recall.
+		if strings.TrimSpace(m.ta.Value()) == "" && len(m.pendingSteer) > 0 {
+			last := m.pendingSteer[len(m.pendingSteer)-1]
+			if m.a.Inbox.Remove(last) {
+				m.pendingSteer = m.pendingSteer[:len(m.pendingSteer)-1]
+				m.ta.SetValue(last)
+				m.ta.CursorEnd()
+				return m, m.updateTextAreaHeight()
+			}
+		}
 		// If the cursor is not on the first display row, move up inside the
 		// textarea (line navigation). Otherwise browse input history.
 		if m.ta.Line() > 0 || m.ta.LineInfo().RowOffset > 0 {

--- a/internal/agent/inbox.go
+++ b/internal/agent/inbox.go
@@ -46,3 +46,21 @@ func (ib *Inbox) HasPending() bool {
 	defer ib.mu.Unlock()
 	return len(ib.msgs) > 0
 }
+
+// Remove deletes the last queued message equal to msg and reports whether one
+// was removed. It is used to retract a steer message that hasn't been drained
+// yet: matching by value (last occurrence) means a background notice enqueued
+// between submit and retract doesn't shift the target. Returns false when the
+// message is no longer queued (the loop already drained it) — the caller must
+// then treat it as committed, not retractable.
+func (ib *Inbox) Remove(msg string) bool {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+	for i := len(ib.msgs) - 1; i >= 0; i-- {
+		if ib.msgs[i] == msg {
+			ib.msgs = append(ib.msgs[:i], ib.msgs[i+1:]...)
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/inbox_test.go
+++ b/internal/agent/inbox_test.go
@@ -40,3 +40,29 @@ func TestInbox_EnqueueDrain(t *testing.T) {
 		t.Error("Drain did not clear the inbox")
 	}
 }
+
+func TestInbox_Remove(t *testing.T) {
+	var ib Inbox
+	ib.Enqueue("a")
+	ib.Enqueue("b")
+	ib.Enqueue("a") // duplicate
+
+	// Removes the LAST matching entry.
+	if !ib.Remove("a") {
+		t.Fatal("Remove(a) = false, want true")
+	}
+	if got := ib.Drain(); len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("after Remove(a) drain = %v, want [a b]", got)
+	}
+}
+
+func TestInbox_Remove_NotFound(t *testing.T) {
+	var ib Inbox
+	ib.Enqueue("x")
+	if ib.Remove("nope") {
+		t.Error("Remove of absent message returned true")
+	}
+	if !ib.HasPending() {
+		t.Error("Remove of absent message should leave the queue intact")
+	}
+}


### PR DESCRIPTION
## Bug

A steer message typed mid-turn was queued (inbox + pending panel) with **no way to take it back**. `↑` only browsed input history — which *copies* the text but leaves the steer queued, so it still gets sent. You couldn't actually un-send a steer you regretted (the reported "当前 steer 消息没法通过上方向键撤回到输入框").

## Fix

When the input box is **empty** and there are pending steers, `↑` now **retracts** the most recent one:
- pops it from the pending panel,
- removes it from the inbox so it won't be delivered,
- loads it into the input box to edit or discard.

Fall-throughs preserve existing behaviour:
- If the loop **already drained** the steer (`Inbox.Remove` fails), it's committed → `↑` falls through to ordinary history recall.
- With **text already in the box**, `↑` keeps its normal history-browse behaviour and never retracts.

## Changes

- `internal/agent`: `Inbox.Remove(msg)` deletes the **last** queued entry equal to `msg` (by value + last-match, so a background notice enqueued between submit and retract doesn't shift the target), reporting whether one was removed.
- `cmd/octo`: the `KeyUp` handler retracts before the cursor/history logic, gated on empty input + a non-empty pending-steer list.

## Tests

- `Inbox.Remove`: last-match removal, not-found leaves the queue intact.
- TUI: `↑` retracts the last pending steer (gone from panel + inbox); no-op retract when text is present (steer stays queued); falls through to history recall when already drained; uses history when nothing is pending.
- `make fmt-check` / `make vet` / `go test -race ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)