### PR TITLE
fix(tools): bound silent truncation in read_file & grep to stop loops/floods

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -12,6 +12,13 @@ import (
 	"github.com/Leihb/octo-agent/internal/tools/rgembed"
 )
 
+// GrepMaxLines caps how many output lines a single grep call returns.
+// Without it a broad pattern (e.g. `func`) on a large repo floods the LLM
+// context with thousands of hits. Past the cap the output is truncated
+// with a marker naming the total, so the model narrows the pattern instead
+// of assuming it saw everything. Mirrors GlobMaxResults' role for glob.
+const GrepMaxLines = 200
+
 // GrepTool is a thin wrapper over `ripgrep` (`rg`). It accepts a regex
 // pattern and one of three output modes: full content lines, file paths
 // only, or per-file match counts.
@@ -29,8 +36,10 @@ func (GrepTool) Definition() agent.ToolDefinition {
 			"Use mode='files_with_matches' for path-only output, mode='count' for " +
 			"per-file counts, or the default mode='content' to see matching lines. " +
 			"Set context_lines (or before/after) to include surrounding lines. " +
-			"Respects .gitignore. Matching lines over 500 chars are truncated " +
-			"with a preview of the first 500 bytes. Requires `rg` on PATH.",
+			"Respects .gitignore. Returns at most 200 output lines — narrow the " +
+			"pattern or set include/path if you hit the cap. Matching lines over " +
+			"500 chars are truncated with a preview of the first 500 bytes. " +
+			"Requires `rg` on PATH.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -148,5 +157,18 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 	if len(out) == 0 {
 		return agent.ToolResult{Text: "(no matches)"}, nil
 	}
-	return agent.ToolResult{Text: strings.TrimRight(string(out), "\n")}, nil
+
+	text := strings.TrimRight(string(out), "\n")
+	lines := strings.Split(text, "\n")
+	if len(lines) > GrepMaxLines {
+		// Truncate and tell the model the total so it doesn't mistake a
+		// capped result for the complete set and re-run the same search.
+		// "lines" not "matches" — in content mode context lines and `--`
+		// separators count too.
+		kept := strings.Join(lines[:GrepMaxLines], "\n")
+		return agent.ToolResult{Text: fmt.Sprintf(
+			"%s\n\n[truncated to first %d of %d lines — narrow the pattern, add include='*.ext', or set a more specific path]",
+			kept, GrepMaxLines, len(lines))}, nil
+	}
+	return agent.ToolResult{Text: text}, nil
 }

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -134,6 +134,54 @@ func TestGrep_RequiresPattern(t *testing.T) {
 	}
 }
 
+func TestGrep_CapsTotalLines(t *testing.T) {
+	requireRg(t)
+	// A pattern that hits far more than GrepMaxLines lines must be
+	// truncated with a marker naming the total — otherwise a broad search
+	// floods context and the model can't tell it saw only part of the set.
+	dir := t.TempDir()
+	var b strings.Builder
+	for i := 0; i < GrepMaxLines+50; i++ {
+		b.WriteString("needle\n")
+	}
+	writeTestFile(t, filepath.Join(dir, "many.txt"), b.String())
+
+	out, err := GrepTool{}.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "needle",
+		"path":    dir,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.Text, "truncated to first 200 of") {
+		t.Errorf("expected truncation marker with total, got:\n%s", out.Text[:min(len(out.Text), 300)])
+	}
+	// The kept body is exactly GrepMaxLines content lines; the marker adds
+	// a blank line + one line. Content lines must not exceed the cap.
+	body := strings.SplitN(out.Text, "\n\n[truncated", 2)[0]
+	if got := len(strings.Split(body, "\n")); got != GrepMaxLines {
+		t.Errorf("expected %d content lines before marker, got %d", GrepMaxLines, got)
+	}
+}
+
+func TestGrep_NoMarkerUnderCap(t *testing.T) {
+	requireRg(t)
+	// A result at or under the cap must not claim truncation.
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "few.txt"), "needle\nneedle\nneedle\n")
+
+	out, err := GrepTool{}.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "needle",
+		"path":    dir,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(out.Text, "truncated") {
+		t.Errorf("under-cap result should not be marked truncated:\n%s", out.Text)
+	}
+}
+
 func TestGrep_TruncatesLongMatchingLines(t *testing.T) {
 	requireRg(t)
 	// Simulate a minified-bundle hit: one line of 1000 a's containing

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -130,9 +130,10 @@ func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
 
 	var (
-		out      strings.Builder
-		lineNum  int
-		returned int
+		out       strings.Builder
+		lineNum   int
+		returned  int
+		truncated bool
 	)
 	for scanner.Scan() {
 		lineNum++
@@ -140,6 +141,10 @@ func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 			continue
 		}
 		if returned >= limit {
+			// Hit the line cap with at least one more line in the file.
+			// lineNum already points at that next unshown line, so it is
+			// the offset the caller should resume from.
+			truncated = true
 			break
 		}
 		// Width-6 line number column matches `cat -n` so a 100k-line file
@@ -157,6 +162,15 @@ func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 	}
 	if returned == 0 {
 		return agent.ToolResult{Text: "(empty file)"}, nil
+	}
+	if truncated {
+		// Without this footer the read stops silently at the cap, so the
+		// model can't tell a complete read from a truncated one — it then
+		// either edits against lines it never saw or re-reads the same
+		// window expecting different output. Spelling out the exact resume
+		// offset breaks that loop.
+		fmt.Fprintf(&out, "\n[truncated: shown lines %d-%d; file has more. Continue with offset=%d.]\n",
+			offset, offset+returned-1, lineNum)
 	}
 	return agent.ToolResult{Text: out.String()}, nil
 }

--- a/internal/tools/read_file_test.go
+++ b/internal/tools/read_file_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,6 +49,61 @@ func TestReadFile_OffsetAndLimit(t *testing.T) {
 	}
 	if strings.Contains(out.Text, "     2\tline2") || strings.Contains(out.Text, "     5\tline5") {
 		t.Errorf("offset/limit returned unwanted lines:\n%s", out.Text)
+	}
+}
+
+func TestReadFile_TruncationFooter(t *testing.T) {
+	// A file longer than the requested window must report that it was
+	// truncated and tell the model the exact offset to resume from —
+	// otherwise the model can't tell a partial read from a complete one
+	// and ends up re-reading the same window or editing unseen lines.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "long.txt")
+	var b strings.Builder
+	for i := 1; i <= 10; i++ {
+		fmt.Fprintf(&b, "line%d\n", i)
+	}
+	writeTestFile(t, path, b.String())
+
+	out, err := ReadFileTool{}.Execute(context.Background(), "read_file", map[string]any{
+		"path":   path,
+		"offset": 2,
+		"limit":  3,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	// Showed lines 2-4; the next unread line is 5.
+	if !strings.Contains(out.Text, "truncated") {
+		t.Errorf("expected truncation marker, got:\n%s", out.Text)
+	}
+	if !strings.Contains(out.Text, "offset=5") {
+		t.Errorf("expected resume offset=5, got:\n%s", out.Text)
+	}
+	if !strings.Contains(out.Text, "shown lines 2-4") {
+		t.Errorf("expected shown-range 2-4, got:\n%s", out.Text)
+	}
+}
+
+func TestReadFile_NoFooterWhenComplete(t *testing.T) {
+	// A read that reaches EOF — even when the limit is hit exactly on the
+	// last line — must NOT claim truncation, or the model loops re-reading
+	// a file it already saw in full.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "exact.txt")
+	writeTestFile(t, path, "a\nb\nc\n")
+
+	// Limit equals the line count: last line is the limit-th line, EOF
+	// follows, so no truncation.
+	out, err := ReadFileTool{}.Execute(context.Background(), "read_file", map[string]any{
+		"path":  path,
+		"limit": 3,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(out.Text, "truncated") {
+		t.Errorf("complete read should not be marked truncated:\n%s", out.Text)
 	}
 }
 


### PR DESCRIPTION
Two tools could feed the model output with no signal about what it didn't see, driving re-read loops or context floods. This aligns both with the pattern `glob` already follows (cap + total-count marker).

## 1. read_file — silent stop at the line cap → re-read loop

`read_file` stopped at the line cap (default 2000) with no marker, total, or resume offset. The model couldn't distinguish a partial read from a complete one, so it would either:

1. **Edit against unseen lines** → `edit_file` fails "string not found" → re-read → loop.
2. **Re-read the same window** verbatim expecting the rest → identical output → loop.

The cap was copied from Claude Code's Read tool (`ReadFileMaxLines = 2000`) but the truncation hint that tool emits was not.

**Fix:** when the cap is hit with more lines remaining, append a footer:

```
[truncated: shown lines 2-4; file has more. Continue with offset=5.]
```

`lineNum` already points at the next unshown line when `break` fires, so it is exactly the resume offset. A read that reaches EOF — including the boundary where `limit` equals the remaining line count — is never marked truncated.

No total line count: that would require scanning the whole file on every paginated call. The resume offset is the actionable bit that breaks the loop.

## 2. grep — no result cap → context flood

`grep` was the only search tool with no result cap (glob stops at 200, web_fetch truncates at 200 KB, web_search bounds at 20). A broad pattern like `func` dumped every hit into context, and the model couldn't tell a flood from the complete set. The long-*line* case was already handled with `--max-columns-preview` — explicitly to stop a retry loop — but the long-*result* case was not.

**Fix:** cap output at `GrepMaxLines` (200), mirroring `GlobMaxResults`, with a marker naming the total:

```
[truncated to first 200 of 1543 lines — narrow the pattern, add include='*.ext', or set a more specific path]
```

"lines" not "matches" — in content mode context lines and `--` separators count toward the cap too.

## Tests

- `TestReadFile_TruncationFooter` / `TestReadFile_NoFooterWhenComplete` — footer + resume offset; `limit == line count` boundary must not claim truncation.
- `TestGrep_CapsTotalLines` / `TestGrep_NoMarkerUnderCap` — marker with total above the cap; no marker at/under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)