### PR TITLE
feat(tools): spill overlong terminal output to a temp file

### DIFF
--- a/cmd/octo/bgnotify.go
+++ b/cmd/octo/bgnotify.go
@@ -19,7 +19,10 @@ func formatBgNote(e tools.BgExit) string {
 	fmt.Fprintf(&b, "Background process %s (`%s`) %s.", e.ID, e.Command, e.Status)
 	if out := strings.TrimRight(e.NewOutput, "\n"); out != "" {
 		b.WriteString("\nOutput since last check:\n")
-		b.WriteString(out)
+		// A long-running build/test that finished in the background can emit
+		// far more than fits a single notice — spill it to a temp file and
+		// show a head+tail preview, same as the synchronous terminal path.
+		b.WriteString(tools.MaybeSpillOutput(e.ID, out))
 	} else {
 		b.WriteString("\n(no new output)")
 	}

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -93,6 +93,7 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	handler := replToolEventHandler(stdout, *plain)
 	_, err = a.RunStream(context.Background(), initInstruction, tools.DefaultTools(), tools.NewDefaultRegistry(), handler)
 	tools.KillAllBackground()
+	tools.CleanSpillFiles()
 	fmt.Fprintln(stdout)
 	if err != nil {
 		fmt.Fprintf(stderr, "octo init: %v\n", err)

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -76,6 +76,7 @@ func runOnce(cfg replConfig, prompt string, stream bool) int {
 
 	// Reap background processes the turn spawned so none outlive the run.
 	defer tools.KillAllBackground()
+	defer tools.CleanSpillFiles()
 
 	// Sub-agent completions and background-process notices ride the inbox, so a
 	// later iteration of this single agentic turn picks them up (the agent

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -34,6 +34,7 @@ import (
 //   - Ctrl+D             → save & quit
 func runTUI(cfg replConfig) int {
 	defer tools.KillAllBackground()
+	defer tools.CleanSpillFiles()
 
 	m := newTUIModel(cfg)
 	p := tea.NewProgram(m, tea.WithFilter(shiftEnterFilter))

--- a/internal/tools/spill.go
+++ b/internal/tools/spill.go
@@ -1,0 +1,151 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// TerminalSpillBytes is the size past which terminal output is written to a
+// temp file instead of being returned to the LLM inline. ~16 KB (~4k tokens)
+// is comfortably "too long" for a single tool result; below it the output is
+// handed back unchanged.
+const TerminalSpillBytes = 16 * 1024
+
+// spillHeadLines and spillTailLines bound the inline preview when output is
+// spilled. Build/test failures put their error at the tail, so we keep both
+// ends — the common case is answered without the agent reading the file.
+const (
+	spillHeadLines = 50
+	spillTailLines = 50
+)
+
+// spillMaxAge is how long a spill file lives before a later spill sweeps it.
+// Files from a clean shutdown are removed immediately (CleanSpillFiles); this
+// only catches the leftovers of a crashed session.
+const spillMaxAge = 24 * time.Hour
+
+// MaybeSpillOutput returns body unchanged when it is small enough to give the
+// LLM directly. When body exceeds TerminalSpillBytes — and has more lines than
+// the preview would show — it writes the full body to a temp file and returns
+// a head+tail preview plus the file path and a one-line read hint, so the
+// agent decides how to read the rest (read_file with offset/limit, or grep)
+// instead of having the whole blob flood its context.
+//
+// id names the source (e.g. a background process id) and is woven into the
+// temp filename. On any write failure it degrades to returning body unchanged:
+// losing context is worse than a missing file.
+func MaybeSpillOutput(id, body string) string {
+	if len(body) <= TerminalSpillBytes {
+		return body
+	}
+	lines := strings.Split(body, "\n")
+	if len(lines) <= spillHeadLines+spillTailLines {
+		// A few very long lines — a line-based preview would hide nothing,
+		// so a temp file buys us no context savings. Return as-is (bounded
+		// by the 1 MiB per-line scanner cap upstream).
+		return body
+	}
+
+	path, err := writeSpillFile(id, body)
+	if err != nil {
+		return body
+	}
+
+	head := strings.Join(lines[:spillHeadLines], "\n")
+	tail := strings.Join(lines[len(lines)-spillTailLines:], "\n")
+	marker := fmt.Sprintf(
+		"[output too long: %d lines / %s written to\n %s\n showing first %d + last %d lines. read_file (offset/limit) or grep that path for the rest.]",
+		len(lines), formatBytes(int64(len(body))), path, spillHeadLines, spillTailLines,
+	)
+	return head + "\n\n" + marker + "\n\n" + tail
+}
+
+// writeSpillFile persists body under ~/.octo/tmp and returns the absolute path.
+// The filename carries the source id and this process's pid so concurrent
+// sessions never collide and CleanSpillFiles can find its own files.
+func writeSpillFile(id, body string) (string, error) {
+	dir, err := spillDir()
+	if err != nil {
+		return "", err
+	}
+	sweepOldSpillFiles(dir)
+	name := fmt.Sprintf("term-%s-%d.log", sanitizeSpillID(id), os.Getpid())
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// spillDir returns (creating if needed) ~/.octo/tmp.
+func spillDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".octo", "tmp")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// sanitizeSpillID keeps the filename safe: an id is normally "bg_7", but guard
+// against anything with path separators or spaces sneaking in.
+func sanitizeSpillID(id string) string {
+	if id == "" {
+		id = "out"
+	}
+	repl := func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			return r
+		}
+		return '_'
+	}
+	return strings.Map(repl, id)
+}
+
+// sweepOldSpillFiles best-effort removes spill files older than spillMaxAge —
+// the leftovers of sessions that crashed before CleanSpillFiles ran. Errors
+// are ignored; this is housekeeping, not correctness.
+func sweepOldSpillFiles(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-spillMaxAge)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasPrefix(e.Name(), "term-") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			_ = os.Remove(filepath.Join(dir, e.Name()))
+		}
+	}
+}
+
+// CleanSpillFiles removes this process's spill files. Wire it into session
+// shutdown next to KillAllBackground so a normal exit leaves no leftovers.
+func CleanSpillFiles() {
+	dir, err := spillDir()
+	if err != nil {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	suffix := fmt.Sprintf("-%d.log", os.Getpid())
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "term-") && strings.HasSuffix(e.Name(), suffix) {
+			_ = os.Remove(filepath.Join(dir, e.Name()))
+		}
+	}
+}

--- a/internal/tools/spill_test.go
+++ b/internal/tools/spill_test.go
@@ -1,0 +1,91 @@
+package tools
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// spillHome points ~/.octo at a temp dir so spill files don't touch the real
+// home, and cleans up after the test.
+func spillHome(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+}
+
+func TestMaybeSpillOutput_SmallPassesThrough(t *testing.T) {
+	spillHome(t)
+	body := "short output\nwith a few lines\n"
+	if got := MaybeSpillOutput("bg_1", body); got != body {
+		t.Errorf("small output should pass through unchanged, got:\n%s", got)
+	}
+}
+
+func TestMaybeSpillOutput_LargeSpillsToFile(t *testing.T) {
+	spillHome(t)
+	// Many short lines well over the byte threshold and the line preview.
+	var b strings.Builder
+	total := 2000
+	for i := 0; i < total; i++ {
+		b.WriteString("this is a line of build output number ")
+		b.WriteByte(byte('0' + i%10))
+		b.WriteByte('\n')
+	}
+	body := b.String()
+	if len(body) <= TerminalSpillBytes {
+		t.Fatalf("test setup: body should exceed threshold (%d)", len(body))
+	}
+
+	out := MaybeSpillOutput("bg_42", body)
+
+	// Preview must mention the spill, the total line count, and a path.
+	if !strings.Contains(out, "output too long") {
+		t.Errorf("expected spill marker, got:\n%s", out[:min(len(out), 300)])
+	}
+	if !strings.Contains(out, "term-bg_42-") {
+		t.Errorf("expected spill file path in preview, got:\n%s", out)
+	}
+	// Inline preview must be far smaller than the full body.
+	if len(out) >= len(body) {
+		t.Errorf("preview (%d) should be smaller than body (%d)", len(out), len(body))
+	}
+
+	// The path named in the preview must exist and hold the full body.
+	path := extractSpillPath(t, out)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("spill file %q unreadable: %v", path, err)
+	}
+	if string(data) != body {
+		t.Errorf("spill file should hold the full body verbatim (%d vs %d bytes)", len(data), len(body))
+	}
+
+	// CleanSpillFiles must remove this process's spill files.
+	CleanSpillFiles()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("CleanSpillFiles should have removed %q (err=%v)", path, err)
+	}
+}
+
+func TestMaybeSpillOutput_FewLongLinesPassThrough(t *testing.T) {
+	spillHome(t)
+	// Over the byte threshold but only a handful of (very long) lines — a
+	// line-based preview would hide nothing, so we return as-is.
+	body := strings.Repeat("x", TerminalSpillBytes+100) + "\n" + strings.Repeat("y", 100)
+	if got := MaybeSpillOutput("bg_7", body); got != body {
+		t.Errorf("few long lines should pass through unchanged")
+	}
+}
+
+// extractSpillPath pulls the temp-file path out of the preview marker.
+func extractSpillPath(t *testing.T, preview string) string {
+	t.Helper()
+	for _, line := range strings.Split(preview, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, "term-bg_") && strings.HasSuffix(line, ".log") {
+			return line
+		}
+	}
+	t.Fatalf("no spill path found in preview:\n%s", preview)
+	return ""
+}

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -149,6 +149,7 @@ func (t TerminalTool) ExecuteStream(
 			body := strings.TrimRight(out.String(), "\n")
 			outMu.Unlock()
 			body = strings.ReplaceAll(body, "\t", "    ")
+			body = MaybeSpillOutput(id, body)
 			return agent.ToolResult{Text: fmt.Sprintf("%s\n\n[timeout: command exceeded %s and continues as background process %s]\n\nDO NOT poll terminal_output. The system will automatically notify you when this process finishes, carrying its full output. You can continue with other tasks while it runs.", body, TerminalTimeout, id)}, nil
 		case <-ctx.Done():
 			// User cancelled (Esc / Ctrl-C): kill the background process.
@@ -167,6 +168,7 @@ func (t TerminalTool) ExecuteStream(
 			body := strings.TrimRight(out.String(), "\n")
 			outMu.Unlock()
 			body = strings.ReplaceAll(body, "\t", "    ")
+			body = MaybeSpillOutput(id, body)
 			if status != "exited: 0" {
 				return agent.ToolResult{Text: body + "\n[exit: " + strings.TrimPrefix(status, "exited: ") + "]"}, nil
 			}
@@ -228,7 +230,7 @@ func (t TerminalOutputTool) Execute(_ context.Context, _ string, input map[strin
 		}
 		return agent.ToolResult{Text: header + "\n(no new output)"}, nil
 	}
-	return agent.ToolResult{Text: header + "\n" + out}, nil
+	return agent.ToolResult{Text: header + "\n" + MaybeSpillOutput(id, out)}, nil
 }
 
 // KillShellTool terminates a background process started by TerminalTool with
@@ -282,5 +284,5 @@ func (t KillShellTool) Execute(_ context.Context, _ string, input map[string]any
 	if out == "" {
 		return agent.ToolResult{Text: header + "\n(no new output)"}, nil
 	}
-	return agent.ToolResult{Text: header + "\n" + out}, nil
+	return agent.ToolResult{Text: header + "\n" + MaybeSpillOutput(id, out)}, nil
 }


### PR DESCRIPTION
## Problem

Terminal output had **no total-size cap** — only a 1 MiB per-line scanner limit. So `cat big_file`, a verbose `make`/`go test`, or a chatty background process could dump tens of thousands of lines into a single tool result and flood the model's context. (Truncating it like `glob`/`read_file` was the obvious fix, but for terminal that silently drops the part the agent needs — often the error at the very bottom.)

## Approach

Spill instead of truncate: persist the full output to a temp file and hand the agent a preview + the path, so it decides how to read the rest with the tools it already has (`read_file` offset/limit, `grep`).

`MaybeSpillOutput(id, body)`:
- Returns `body` unchanged when it's ≤ `TerminalSpillBytes` (16 KB) — routine output is untouched.
- Above that (and with more lines than the preview would show), writes the full body to `~/.octo/tmp/term-<id>-<pid>.log` and returns:

```
<first 50 lines>

[output too long: 4231 lines / 612.0 KB written to
 /Users/you/.octo/tmp/term-bg_7.log
 showing first 50 + last 50 lines. read_file (offset/limit) or grep that path for the rest.]

<last 50 lines>
```

- Head **and** tail because build/test failures put the error at the tail.
- A few very long lines (over the byte cap but ≤100 lines) pass through unchanged — a line-based preview would hide nothing.
- Any write failure degrades to returning `body` unchanged: losing context is worse than a missing file.

Wired through every terminal output surface: synchronous exit, timeout promotion, `terminal_output`, `kill_shell`, and the background-completion notice (`formatBgNote`).

## Lifecycle

- `CleanSpillFiles()` removes this process's spill files on session shutdown — wired next to `KillAllBackground()` in the REPL, TUI, and `init` paths.
- A best-effort 24h sweep on each write reclaims leftovers from crashed sessions.
- Files are pid-scoped so concurrent sessions never collide or delete each other's files.

## Scope

Terminal only. `grep`'s 200-line cap (separate PR) stays as is — narrowing a pattern is a better recovery there than re-grepping a spilled file. `read_file` already paginates a real file, so it needs no spill.

## Tests

`TestMaybeSpillOutput_SmallPassesThrough`, `_LargeSpillsToFile` (asserts preview marker, path, full-body round-trip on disk, and `CleanSpillFiles` removal), `_FewLongLinesPassThrough`. Existing terminal + bg-notify tests pass under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)