### PR TITLE
feat(tui): syntax-highlight read_file output cards

### DIFF
--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -69,5 +69,11 @@ func renderToolCard(toolName string, input map[string]any, output string, isErr 
 		newS, _ := input["new_string"].(string)
 		return tui.RenderEditCard(path, oldS, newS)
 	}
-	return tui.RenderOutputCard(verb, cardTargetFor(toolName, input), output, outputCardMaxLines, isErr)
+	lang := ""
+	if toolName == "read_file" {
+		if p, _ := input["path"].(string); p != "" {
+			lang = tui.GuessLanguage(p)
+		}
+	}
+	return tui.RenderOutputCard(verb, cardTargetFor(toolName, input), output, outputCardMaxLines, isErr, lang)
 }

--- a/internal/tui/diffcard.go
+++ b/internal/tui/diffcard.go
@@ -98,7 +98,7 @@ func RenderEditCard(filePath, oldString, newString string) string {
 		Added:    added,
 		Removed:  removed,
 		Lines:    lines,
-		Language: guessLanguage(filePath),
+		Language: GuessLanguage(filePath),
 	}
 	return c.Render()
 }
@@ -240,9 +240,9 @@ func highlightLine(src, language string, dark bool) string {
 	return strings.TrimRight(buf.String(), "\n")
 }
 
-// guessLanguage maps a path extension to a Chroma lexer name. Empty
+// GuessLanguage maps a path extension to a Chroma lexer name. Empty
 // return disables highlighting.
-func guessLanguage(path string) string {
+func GuessLanguage(path string) string {
 	switch {
 	case strings.HasSuffix(path, ".go"):
 		return "go"

--- a/internal/tui/diffcard_test.go
+++ b/internal/tui/diffcard_test.go
@@ -114,7 +114,7 @@ func TestGuessLanguage(t *testing.T) {
 		"foo.yaml": "yaml",
 	}
 	for path, want := range cases {
-		if got := guessLanguage(path); got != want {
+		if got := GuessLanguage(path); got != want {
 			t.Errorf("guessLanguage(%q) = %q, want %q", path, got, want)
 		}
 	}

--- a/internal/tui/outputcard.go
+++ b/internal/tui/outputcard.go
@@ -19,7 +19,8 @@ var (
 // maxLines (<=0 = no cap) with a "└ N more lines" marker for the remainder.
 // isErr tints the bullet red. Empty output renders "(no output)". The trailing
 // newline is omitted so callers control spacing (mirrors Card.Render).
-func RenderOutputCard(verb, target, output string, maxLines int, isErr bool) string {
+// When language is non-empty, each line is syntax-highlighted with Chroma.
+func RenderOutputCard(verb, target, output string, maxLines int, isErr bool, language string) string {
 	bullet := outBullet
 	if isErr {
 		bullet = outBulletErr
@@ -38,8 +39,14 @@ func RenderOutputCard(verb, target, output string, maxLines int, isErr bool) str
 	if maxLines > 0 && len(lines) > maxLines {
 		shown, extra = lines[:maxLines], len(lines)-maxLines
 	}
+
+	dark := IsDark()
 	for _, ln := range shown {
-		b.WriteString("\n  " + outGutter.String() + " " + ln)
+		body := ln
+		if language != "" {
+			body = highlightLine(ln, language, dark)
+		}
+		b.WriteString("\n  " + outGutter.String() + " " + body)
 	}
 	if extra > 0 {
 		b.WriteString("\n  " + outMore.Render("└ "+pluralise(extra, "more line")))

--- a/internal/tui/outputcard_test.go
+++ b/internal/tui/outputcard_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRenderOutputCard_HeaderAndBody(t *testing.T) {
-	got := RenderOutputCard("Run", "go test ./...", "ok  pkg/a  0.2s\nok  pkg/b  0.1s", 0, false)
+	got := RenderOutputCard("Run", "go test ./...", "ok  pkg/a  0.2s\nok  pkg/b  0.1s", 0, false, "")
 	for _, want := range []string{"Run(go test ./...)", "ok  pkg/a  0.2s", "ok  pkg/b  0.1s"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing %q in:\n%s", want, got)
@@ -19,7 +19,7 @@ func TestRenderOutputCard_CapsWithMoreMarker(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		lines = append(lines, "line")
 	}
-	got := RenderOutputCard("Search", "foo", strings.Join(lines, "\n"), 5, false)
+	got := RenderOutputCard("Search", "foo", strings.Join(lines, "\n"), 5, false, "")
 	if !strings.Contains(got, "15 more lines") {
 		t.Errorf("expected '15 more lines' marker; got:\n%s", got)
 	}
@@ -30,15 +30,24 @@ func TestRenderOutputCard_CapsWithMoreMarker(t *testing.T) {
 }
 
 func TestRenderOutputCard_EmptyOutput(t *testing.T) {
-	got := RenderOutputCard("Run", "true", "", 0, false)
+	got := RenderOutputCard("Run", "true", "", 0, false, "")
 	if !strings.Contains(got, "(no output)") {
 		t.Errorf("expected '(no output)'; got:\n%s", got)
 	}
 }
 
 func TestRenderOutputCard_SingularMoreLine(t *testing.T) {
-	got := RenderOutputCard("Run", "x", "a\nb\nc", 2, false)
+	got := RenderOutputCard("Run", "x", "a\nb\nc", 2, false, "")
 	if !strings.Contains(got, "1 more line") || strings.Contains(got, "1 more lines") {
 		t.Errorf("expected singular '1 more line'; got:\n%s", got)
+	}
+}
+
+func TestRenderOutputCard_Highlight(t *testing.T) {
+	output := "package main\n\nfunc main() {}"
+	got := RenderOutputCard("Read", "main.go", output, 0, false, "go")
+	// Chroma highlighting should inject ANSI escape codes.
+	if !strings.Contains(got, "\x1b[") {
+		t.Errorf("expected ANSI escapes from Chroma highlighting; got:\n%s", got)
 	}
 }


### PR DESCRIPTION
Adds Chroma syntax highlighting to the TUI output card for `read_file`, so a file you read renders with the same coloring as the edit/diff cards instead of as flat text.

## Changes

- `RenderOutputCard` gains a `language` parameter; when non-empty, each shown line is highlighted with Chroma (theme-aware via `IsDark()`). Empty language preserves the old plain-text rendering.
- `guessLanguage` → exported `GuessLanguage` so the card renderer in `cmd/octo` can map a path to a lexer.
- `renderToolCard` passes the guessed language only for `read_file` (by its `path` arg); all other tools keep plain output.

## Tests

- New `TestRenderOutputCard_Highlight` asserts ANSI escapes are injected when a language is set.
- Existing `RenderOutputCard` call sites updated for the new signature; `TestGuessLanguage` follows the rename.

Rebased onto current main (post #334/#335) — builds and `go test ./internal/tui/ ./cmd/octo/` pass clean. The signature change doesn't touch the spill/grep/read_file paths those PRs landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)