### PR TITLE
feat(tui): paste clipboard images into the input with Ctrl+V

### DIFF
--- a/cmd/octo/clipimg_darwin.go
+++ b/cmd/octo/clipimg_darwin.go
@@ -1,0 +1,61 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// captureClipboardImage reads an image from the macOS clipboard and returns
+// its raw bytes plus MIME type. It coerces whatever the clipboard holds (a
+// screenshot, a copied image) to PNG via AppleScript, which is built in — no
+// Homebrew dependency. ok is false (with a friendly reason in err) when the
+// clipboard holds no image.
+func captureClipboardImage() (data []byte, mime string, err error) {
+	tmp, err := os.CreateTemp("", "octo-clip-*.png")
+	if err != nil {
+		return nil, "", fmt.Errorf("clipboard: temp file: %w", err)
+	}
+	path := tmp.Name()
+	_ = tmp.Close()
+	defer os.Remove(path)
+
+	// AppleScript: coerce the clipboard to PNG and write it to path. The
+	// coercion fails (caught) when the clipboard has no image, in which case
+	// we return "NO_IMAGE" so the caller can show a friendly notice rather
+	// than a raw osascript error.
+	script := fmt.Sprintf(`try
+	set imgData to (the clipboard as «class PNGf»)
+on error
+	return "NO_IMAGE"
+end try
+set f to open for access POSIX file %q with write permission
+set eof f to 0
+write imgData to f
+close access f
+return "OK"`, path)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "osascript", "-e", script).Output()
+	if err != nil {
+		return nil, "", fmt.Errorf("clipboard: osascript: %w", err)
+	}
+	if strings.TrimSpace(string(out)) == "NO_IMAGE" {
+		return nil, "", fmt.Errorf("no image in clipboard")
+	}
+
+	data, err = os.ReadFile(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("clipboard: read: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, "", fmt.Errorf("no image in clipboard")
+	}
+	return data, "image/png", nil
+}

--- a/cmd/octo/clipimg_linux.go
+++ b/cmd/octo/clipimg_linux.go
@@ -1,0 +1,72 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// captureClipboardImage reads an image from the Linux clipboard, trying
+// Wayland (wl-paste) first, then X11 (xclip). Both are common but neither is
+// guaranteed installed, so a missing-tool case returns an actionable message.
+// Whatever image type the clipboard offers (PNG, JPEG…) is returned as-is.
+func captureClipboardImage() (data []byte, mime string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, hasWlPaste := lookPath("wl-paste")
+	_, hasXclip := lookPath("xclip")
+	if !hasWlPaste && !hasXclip {
+		return nil, "", fmt.Errorf("clipboard image paste needs wl-clipboard (Wayland) or xclip (X11) installed")
+	}
+
+	if hasWlPaste {
+		if d, m, ok := wlPasteImage(ctx); ok {
+			return d, m, nil
+		}
+	}
+	if hasXclip {
+		// xclip can't easily enumerate image targets, so probe the common ones.
+		for _, m := range []string{"image/png", "image/jpeg"} {
+			out, e := exec.CommandContext(ctx, "xclip", "-selection", "clipboard", "-t", m, "-o").Output()
+			if e == nil && len(out) > 0 {
+				return out, m, nil
+			}
+		}
+	}
+	return nil, "", fmt.Errorf("no image in clipboard")
+}
+
+// wlPasteImage asks wl-paste which types the clipboard offers, picks the first
+// image/* type, and pastes it. ok is false when there's no image type or the
+// paste fails.
+func wlPasteImage(ctx context.Context) (data []byte, mime string, ok bool) {
+	typesOut, err := exec.CommandContext(ctx, "wl-paste", "--list-types").Output()
+	if err != nil {
+		return nil, "", false
+	}
+	for _, line := range strings.Fields(string(typesOut)) {
+		if strings.HasPrefix(line, "image/") {
+			mime = line
+			break
+		}
+	}
+	if mime == "" {
+		return nil, "", false
+	}
+	out, err := exec.CommandContext(ctx, "wl-paste", "--no-newline", "--type", mime).Output()
+	if err != nil || len(out) == 0 {
+		return nil, "", false
+	}
+	return out, mime, true
+}
+
+// lookPath reports whether a binary is on PATH.
+func lookPath(name string) (string, bool) {
+	p, err := exec.LookPath(name)
+	return p, err == nil
+}

--- a/cmd/octo/clipimg_other.go
+++ b/cmd/octo/clipimg_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package main
+
+import "fmt"
+
+// captureClipboardImage is unsupported off macOS for now. Linux (wl-paste /
+// xclip) and Windows (PowerShell Get-Clipboard) can be added behind the same
+// signature when needed.
+func captureClipboardImage() (data []byte, mime string, err error) {
+	return nil, "", fmt.Errorf("clipboard image paste is only supported on macOS right now")
+}

--- a/cmd/octo/clipimg_other.go
+++ b/cmd/octo/clipimg_other.go
@@ -1,12 +1,14 @@
-//go:build !darwin
+//go:build !darwin && !linux && !windows
 
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"runtime"
+)
 
-// captureClipboardImage is unsupported off macOS for now. Linux (wl-paste /
-// xclip) and Windows (PowerShell Get-Clipboard) can be added behind the same
-// signature when needed.
+// captureClipboardImage covers the platforms without a dedicated clipboard
+// backend (the BSDs, etc.). macOS, Linux, and Windows have their own files.
 func captureClipboardImage() (data []byte, mime string, err error) {
-	return nil, "", fmt.Errorf("clipboard image paste is only supported on macOS right now")
+	return nil, "", fmt.Errorf("clipboard image paste is not supported on %s", runtime.GOOS)
 }

--- a/cmd/octo/clipimg_windows.go
+++ b/cmd/octo/clipimg_windows.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// captureClipboardImage reads an image from the Windows clipboard via
+// PowerShell, saving it to a temp PNG and reading it back. Prefers pwsh
+// (PowerShell 7+) and falls back to the built-in powershell.exe — the same
+// selection the terminal tool makes. Returns a friendly error when the
+// clipboard holds no image.
+func captureClipboardImage() (data []byte, mime string, err error) {
+	shell := "powershell"
+	if p, e := exec.LookPath("pwsh"); e == nil {
+		shell = p
+	}
+
+	tmp, err := os.CreateTemp("", "octo-clip-*.png")
+	if err != nil {
+		return nil, "", fmt.Errorf("clipboard: temp file: %w", err)
+	}
+	path := tmp.Name()
+	_ = tmp.Close()
+	defer os.Remove(path)
+
+	// Get-Image returns null when the clipboard has no bitmap; we print a
+	// sentinel so the caller can show a friendly notice. The path is injected
+	// with doubled backslashes so it's a valid PowerShell single-quoted string.
+	psPath := strings.ReplaceAll(path, `\`, `\\`)
+	script := fmt.Sprintf(`$ErrorActionPreference='Stop'
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+$img = [System.Windows.Forms.Clipboard]::GetImage()
+if ($img -eq $null) { Write-Output 'NO_IMAGE' }
+else { $img.Save('%s', [System.Drawing.Imaging.ImageFormat]::Png); Write-Output 'OK' }`, psPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, shell, "-NoProfile", "-NonInteractive", "-Command", script).Output()
+	if err != nil {
+		return nil, "", fmt.Errorf("clipboard: powershell: %w", err)
+	}
+	if strings.Contains(string(out), "NO_IMAGE") {
+		return nil, "", fmt.Errorf("no image in clipboard")
+	}
+
+	data, err = os.ReadFile(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("clipboard: read: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, "", fmt.Errorf("no image in clipboard")
+	}
+	return data, "image/png", nil
+}

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -160,6 +160,9 @@ func printTuiHelp(w io.Writer) {
 	fmt.Fprintln(w, "  /goal       Plan + run a goal as a task DAG (also: /goal list, /goal resume <id>)")
 	fmt.Fprintln(w, "  /exit       Save and exit  (also: /quit, Ctrl-C, Ctrl-D)")
 	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Keys:")
+	fmt.Fprintln(w, "  Ctrl+V      Paste an image from the clipboard (rides your next message; Esc discards)")
+	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Type / to open the completion menu (Tab/↑↓ select, Enter complete) — it lists")
 	fmt.Fprintln(w, "every command and skill, so you don't have to remember names.")
 }

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -210,6 +210,14 @@ type pendingItem struct {
 
 // ── model ──
 
+// pendingAttachment is an image captured from the clipboard, waiting to be
+// folded into the next user message. block carries the bytes for the model;
+// label is the human-readable chip text (e.g. "image (PNG, 84 KB)").
+type pendingAttachment struct {
+	block agent.ContentBlock
+	label string
+}
+
 type tuiModel struct {
 	cfg  replConfig
 	a    *agent.Agent
@@ -260,6 +268,11 @@ type tuiModel struct {
 	// scrollback) so the user sees immediate feedback without breaking
 	// the chronological message order (Claude Code style).
 	pendingSteer []string
+
+	// pendingAttachments holds images pasted with Ctrl+V, waiting to ride the
+	// next user turn. Shown as chips above the input; cleared on submit (sent)
+	// or Esc (discarded).
+	pendingAttachments []pendingAttachment
 
 	// modal, when non-nil, is an active Ask prompt (design §6).
 	modal *modalState

--- a/cmd/octo/tuirepl_attach_test.go
+++ b/cmd/octo/tuirepl_attach_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// fakeAttachment builds a pendingAttachment with a dummy image block for tests.
+func fakeAttachment() pendingAttachment {
+	return pendingAttachment{
+		block: agent.NewImageBlock("image/png", []byte{0x89, 'P', 'N', 'G'}),
+		label: "image (PNG, 4 B)",
+	}
+}
+
+// TestTUI_SubmitImageOnlyStartsTurn verifies that Enter with no text but a
+// pending attachment still starts a turn and consumes the attachment (an
+// image-only message is valid).
+func TestTUI_SubmitImageOnlyStartsTurn(t *testing.T) {
+	m := newTestModel()
+	m.pendingAttachments = []pendingAttachment{fakeAttachment()}
+	setInput(m, "")
+
+	_, _ = m.submit()
+
+	if !m.turnRunning {
+		t.Fatal("Enter with an attachment (empty text) should start a turn")
+	}
+	if len(m.pendingAttachments) != 0 {
+		t.Errorf("attachment should be consumed on submit, still have %d", len(m.pendingAttachments))
+	}
+}
+
+// TestTUI_EscDiscardsAttachments verifies idle Esc clears pending attachments
+// through the real key handler.
+func TestTUI_EscDiscardsAttachments(t *testing.T) {
+	m := newTestModel()
+	m.pendingAttachments = []pendingAttachment{fakeAttachment()}
+
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if len(m.pendingAttachments) != 0 {
+		t.Errorf("idle Esc should discard attachments, still have %d", len(m.pendingAttachments))
+	}
+}
+
+// TestTUI_MidTurnKeepsAttachments verifies that submitting while a turn runs
+// keeps the attachment pending (it can't ride a text-only steer) and still
+// enqueues the steer text.
+func TestTUI_MidTurnKeepsAttachments(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.pendingAttachments = []pendingAttachment{fakeAttachment()}
+	setInput(m, "also look here")
+
+	_, _ = m.submit()
+
+	if len(m.pendingAttachments) != 1 {
+		t.Errorf("attachment should stay pending mid-turn, got %d", len(m.pendingAttachments))
+	}
+	if !m.a.Inbox.HasPending() {
+		t.Error("steer text should still be enqueued mid-turn")
+	}
+}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -95,7 +95,11 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.interrupt()
 			return m, nil
 		}
-		// Idle: clear the input line.
+		// Idle: clear the input line and discard any pending attachments.
+		if len(m.pendingAttachments) > 0 {
+			m.pendingAttachments = nil
+			m.println(noticeStyle.Render("📎 attachments discarded"))
+		}
 		m.ta.Reset()
 		m.inputHistoryIdx = -1
 		return m, m.updateTextAreaHeight()
@@ -135,6 +139,12 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.println(queueStyle.Render("✕ unqueued: " + dropped))
 		}
 		return m, nil
+
+	case tea.KeyCtrlV:
+		// Paste an image from the clipboard as an attachment on the next turn.
+		// Normal text paste (Cmd+V on macOS) arrives as bracketed-paste runes
+		// handled by the textarea, so this binding is free for image paste.
+		return m.pasteClipboardImage()
 
 	case tea.KeyShiftTab:
 		// Cycle permission mode: interactive → strict → auto → interactive.
@@ -233,34 +243,106 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-// submit acts on Enter. Idle → start a turn. Running → steer. Empty input is
-// ignored.
+// pasteClipboardImage captures an image from the system clipboard and queues
+// it as an attachment for the next turn. With no image in the clipboard (or on
+// an unsupported platform) it surfaces a friendly notice and changes nothing.
+func (m *tuiModel) pasteClipboardImage() (tea.Model, tea.Cmd) {
+	data, mime, err := captureClipboardImage()
+	if err != nil {
+		m.println(noticeStyle.Render("📋 " + err.Error()))
+		return m, nil
+	}
+	label := fmt.Sprintf("image (%s, %s)", shortMIME(mime), humanByteSize(len(data)))
+	m.pendingAttachments = append(m.pendingAttachments, pendingAttachment{
+		block: agent.NewImageBlock(mime, data),
+		label: label,
+	})
+	m.println(noticeStyle.Render("📎 attached " + label + " — it rides your next message"))
+	return m, nil
+}
+
+// attachmentChips renders the pending attachments as a one-line summary for
+// the echo / live view, e.g. "📎 image (PNG, 84 KB)".
+func (m *tuiModel) attachmentChips() string {
+	if len(m.pendingAttachments) == 0 {
+		return ""
+	}
+	parts := make([]string, len(m.pendingAttachments))
+	for i, a := range m.pendingAttachments {
+		parts[i] = "📎 " + a.label
+	}
+	return strings.Join(parts, "  ")
+}
+
+// shortMIME turns "image/png" into "PNG" for the chip.
+func shortMIME(mime string) string {
+	if i := strings.LastIndex(mime, "/"); i >= 0 {
+		return strings.ToUpper(mime[i+1:])
+	}
+	return strings.ToUpper(mime)
+}
+
+// humanByteSize renders a byte count compactly (B / KB / MB).
+func humanByteSize(n int) string {
+	const kb, mb = 1024, 1024 * 1024
+	switch {
+	case n >= mb:
+		return fmt.Sprintf("%.1f MB", float64(n)/mb)
+	case n >= kb:
+		return fmt.Sprintf("%.1f KB", float64(n)/kb)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
+// submit acts on Enter. Idle → start a turn. Running → steer. Empty input
+// with no attachments is ignored.
 func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 	text := strings.TrimSpace(m.ta.Value())
-	if text == "" {
+	if text == "" && len(m.pendingAttachments) == 0 {
 		return m, nil
 	}
 	m.ta.Reset()
 	m.inputHistoryIdx = -1
 	// Save to history for ↑/↓ recall (dedup consecutive identical lines).
-	if len(m.inputHistory) == 0 || m.inputHistory[len(m.inputHistory)-1] != text {
+	// Skip empty text (an image-only submit has nothing to recall).
+	if text != "" && (len(m.inputHistory) == 0 || m.inputHistory[len(m.inputHistory)-1] != text) {
 		m.inputHistory = append(m.inputHistory, text)
 	}
 
 	// Slash commands are the TUI's alone — the plain REPL is a pure conversation
 	// loop. Only dispatched when idle; mid-turn input still steers / queues.
+	// A leading "/" with attachments is treated as ordinary text, not a command.
 	if !m.turnRunning {
-		if strings.HasPrefix(text, "/") {
+		if strings.HasPrefix(text, "/") && len(m.pendingAttachments) == 0 {
 			return m.dispatchSlash(text)
 		}
-		return m, m.startTurn(text)
+		// Fold any pending image attachments into this turn's user message.
+		echo := text
+		if len(m.pendingAttachments) > 0 {
+			blocks := make([]agent.ContentBlock, 0, len(m.pendingAttachments))
+			for _, a := range m.pendingAttachments {
+				blocks = append(blocks, a.block)
+			}
+			m.a.AttachUserBlocks(blocks)
+			echo = strings.TrimSpace(text + "  " + m.attachmentChips())
+			m.pendingAttachments = nil
+		}
+		return m, m.startTurnEcho(text, echo)
 	}
 
+	// Mid-turn: image attachments can't ride a text-only steer, so keep them
+	// pending for the next new turn and tell the user.
+	if len(m.pendingAttachments) > 0 {
+		m.println(noticeStyle.Render("⚠ image attachments are sent with a new turn, not a mid-turn steer — they'll ride your next message"))
+	}
 	// Mid-turn input goes to the inbox. It will be drained into history at
 	// the start of the next loop iteration, before the LLM call, so the
 	// model sees it as a first-class user message.
-	m.pendingSteer = append(m.pendingSteer, text)
-	m.a.Inbox.Enqueue(text)
+	if text != "" {
+		m.pendingSteer = append(m.pendingSteer, text)
+		m.a.Inbox.Enqueue(text)
+	}
 	return m, nil
 }
 
@@ -585,6 +667,13 @@ func (m *tuiModel) View() string {
 			b.WriteString(pendingSteerStyle.Render("  > ") + pendingSteerStyle.Render(s))
 			b.WriteByte('\n')
 		}
+	}
+
+	// Pending image attachments — chips above the input so the user knows an
+	// image will ride their next message (Esc discards them).
+	if len(m.pendingAttachments) > 0 {
+		b.WriteString(pendingSteerStyle.Render("  " + m.attachmentChips()))
+		b.WriteByte('\n')
 	}
 
 	// Slash-command completion menu, right above the input box (Claude Code style).

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -164,6 +164,20 @@ type Agent struct {
 	// rides the message stream instead. The hook must not mutate state the
 	// caller relies on elsewhere — it's invoked once per appended user turn.
 	UserInputHook func(userInput string) string
+
+	// pendingUserBlocks holds content blocks (e.g. images pasted in the TUI)
+	// to merge into the next user message. Set via AttachUserBlocks and
+	// consumed exactly once by the next appendUserInput, alongside the text.
+	pendingUserBlocks []ContentBlock
+}
+
+// AttachUserBlocks queues content blocks — typically image blocks — to be
+// folded into the next user message appended by a Turn/Run/RunStream call.
+// The blocks are consumed exactly once (by the next appendUserInput) and then
+// cleared. Call it immediately before the run so the text and the attachments
+// land on the same user turn. Passing nil clears any queued blocks.
+func (a *Agent) AttachUserBlocks(blocks []ContentBlock) {
+	a.pendingUserBlocks = blocks
 }
 
 // appendUserInput appends userInput to history, first prepending any
@@ -175,6 +189,19 @@ func (a *Agent) appendUserInput(userInput string) {
 		if reminder := a.UserInputHook(userInput); reminder != "" {
 			text = reminder + "\n\n" + userInput
 		}
+	}
+	// Attachments (e.g. a pasted image) ride on the same user turn as the
+	// text. Consume them exactly once: build a multi-part message with an
+	// optional leading text block followed by the attachment blocks.
+	if len(a.pendingUserBlocks) > 0 {
+		blocks := make([]ContentBlock, 0, 1+len(a.pendingUserBlocks))
+		if text != "" {
+			blocks = append(blocks, NewTextBlock(text))
+		}
+		blocks = append(blocks, a.pendingUserBlocks...)
+		a.pendingUserBlocks = nil
+		a.History.Append(Message{Role: RoleUser, Blocks: blocks})
+		return
 	}
 	a.History.Append(NewUserMessage(text))
 }
@@ -219,7 +246,7 @@ func (a *Agent) Turn(ctx context.Context, userInput string) (Reply, error) {
 	if a.Model == "" {
 		return Reply{}, fmt.Errorf("agent: Model is required")
 	}
-	if userInput == "" {
+	if userInput == "" && len(a.pendingUserBlocks) == 0 {
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
 
@@ -262,7 +289,7 @@ func (a *Agent) TurnStream(
 	if a.Model == "" {
 		return Reply{}, fmt.Errorf("agent: Model is required")
 	}
-	if userInput == "" {
+	if userInput == "" && len(a.pendingUserBlocks) == 0 {
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
 
@@ -316,7 +343,7 @@ func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinitio
 	if a.Model == "" {
 		return Reply{}, fmt.Errorf("agent: Model is required")
 	}
-	if userInput == "" {
+	if userInput == "" && len(a.pendingUserBlocks) == 0 {
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
 
@@ -357,7 +384,7 @@ func (a *Agent) RunStream(
 	if a.Model == "" {
 		return Reply{}, fmt.Errorf("agent: Model is required")
 	}
-	if userInput == "" {
+	if userInput == "" && len(a.pendingUserBlocks) == 0 {
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
 

--- a/internal/agent/attach_test.go
+++ b/internal/agent/attach_test.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+// TestAttachUserBlocks_MergedWithText verifies a queued image block rides the
+// next user turn alongside the text, as a single multi-part user message.
+func TestAttachUserBlocks_MergedWithText(t *testing.T) {
+	send := &fakeSender{reply: Reply{Content: "ok", StopReason: "end_turn"}}
+	a := New(send, "m")
+
+	a.AttachUserBlocks([]ContentBlock{NewImageBlock("image/png", []byte{0x89, 'P', 'N', 'G'})})
+	if _, err := a.Turn(context.Background(), "what is this?"); err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+
+	if len(send.gotMessages) != 1 {
+		t.Fatalf("want 1 message, got %d", len(send.gotMessages))
+	}
+	m := send.gotMessages[0]
+	if m.Role != RoleUser {
+		t.Fatalf("role = %q", m.Role)
+	}
+	if len(m.Blocks) != 2 {
+		t.Fatalf("want 2 blocks (text+image), got %d: %+v", len(m.Blocks), m.Blocks)
+	}
+	if m.Blocks[0].Type != "text" || m.Blocks[0].Text != "what is this?" {
+		t.Errorf("block[0] = %+v, want text 'what is this?'", m.Blocks[0])
+	}
+	if m.Blocks[1].Type != "image" || m.Blocks[1].Image == nil {
+		t.Errorf("block[1] = %+v, want image with data", m.Blocks[1])
+	}
+
+	// Consumed exactly once: a second turn carries no leftover attachment.
+	if _, err := a.Turn(context.Background(), "and now?"); err != nil {
+		t.Fatalf("Turn 2: %v", err)
+	}
+	last := send.gotMessages[len(send.gotMessages)-1]
+	if len(last.Blocks) != 0 {
+		t.Errorf("second turn should not reuse the attachment, got blocks %+v", last.Blocks)
+	}
+}
+
+// TestAttachUserBlocks_ImageOnly verifies an attachment with empty text is
+// allowed (the non-empty-input guard is relaxed when blocks are queued) and
+// produces an image-only user message.
+func TestAttachUserBlocks_ImageOnly(t *testing.T) {
+	send := &fakeSender{reply: Reply{Content: "ok", StopReason: "end_turn"}}
+	a := New(send, "m")
+
+	a.AttachUserBlocks([]ContentBlock{NewImageBlock("image/png", []byte{1, 2, 3})})
+	if _, err := a.Turn(context.Background(), ""); err != nil {
+		t.Fatalf("image-only Turn should be allowed: %v", err)
+	}
+	m := send.gotMessages[0]
+	if len(m.Blocks) != 1 || m.Blocks[0].Type != "image" {
+		t.Fatalf("want a single image block, got %+v", m.Blocks)
+	}
+}
+
+// TestEmptyInput_StillRejectedWithoutBlocks keeps the original guard: an empty
+// turn with no attachment is an error.
+func TestEmptyInput_StillRejectedWithoutBlocks(t *testing.T) {
+	send := &fakeSender{reply: Reply{Content: "ok"}}
+	a := New(send, "m")
+	if _, err := a.Turn(context.Background(), ""); err == nil {
+		t.Fatal("empty input with no attachment should still error")
+	}
+}

--- a/internal/provider/anthropic/client_test.go
+++ b/internal/provider/anthropic/client_test.go
@@ -114,6 +114,63 @@ func TestSend_Success(t *testing.T) {
 	}
 }
 
+// TestSend_UserImage_WireFormat verifies a standalone image block on a user
+// message (e.g. a pasted clipboard image) serializes to Anthropic's base64
+// image source nested in the user message content array.
+func TestSend_UserImage_WireFormat(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"msg","type":"message","role":"assistant","model":"x","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	_, err := c.Send(context.Background(), provider.Request{
+		Model: "x",
+		Messages: []agent.Message{{
+			Role: agent.RoleUser,
+			Blocks: []agent.ContentBlock{
+				agent.NewTextBlock("what is this?"),
+				agent.NewImageBlock("image/png", []byte{0x89, 'P', 'N', 'G'}),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var req struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content []struct {
+				Type   string `json:"type"`
+				Text   string `json:"text"`
+				Source *struct {
+					Type      string `json:"type"`
+					MediaType string `json:"media_type"`
+					Data      string `json:"data"`
+				} `json:"source"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(capturedBody, &req); err != nil {
+		t.Fatalf("decode: %v\n%s", err, capturedBody)
+	}
+	if len(req.Messages) != 1 || len(req.Messages[0].Content) != 2 {
+		t.Fatalf("want 1 message with text+image content: %s", capturedBody)
+	}
+	img := req.Messages[0].Content[1]
+	if img.Type != "image" || img.Source == nil {
+		t.Fatalf("content[1] = %+v, want image with source", img)
+	}
+	if img.Source.Type != "base64" || img.Source.MediaType != "image/png" || img.Source.Data == "" {
+		t.Errorf("image source = %+v, want base64 image/png with data", img.Source)
+	}
+}
+
 func TestSend_SystemMessageStripped(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bodyBytes, _ := io.ReadAll(r.Body)

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -309,6 +309,7 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 		// two tool_results would break the tool_call_id pairing.
 		if m.Role == agent.RoleUser && len(m.Blocks) > 0 {
 			var steerText strings.Builder
+			var userImageParts []apiContentPart
 			i := 0
 			for i < len(m.Blocks) {
 				b := m.Blocks[i]
@@ -352,17 +353,35 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 					steerText.WriteString(b.Text)
 					i++
 				case "image":
-					// Standalone image (not following a tool_result) — add to steer.
-					if steerText.Len() > 0 {
-						steerText.WriteString("\n\n")
+					// Standalone image (not nested into a preceding tool_result) —
+					// e.g. an image pasted into the TUI input. Carry it as an
+					// image_url part so vision models actually receive it instead
+					// of a "[image]" placeholder.
+					if b.Image != nil {
+						dataURL := fmt.Sprintf("data:%s;base64,%s", b.Image.MIMEType, base64.StdEncoding.EncodeToString(b.Image.Data))
+						userImageParts = append(userImageParts, apiContentPart{
+							Type: "image_url",
+							ImageURL: &struct {
+								URL string `json:"url"`
+							}{URL: dataURL},
+						})
 					}
-					steerText.WriteString("[image]")
 					i++
 				default:
 					i++
 				}
 			}
-			if steerText.Len() > 0 {
+			// Emit the user turn. With images, use the content-parts array
+			// (text first, then images); otherwise a plain text message.
+			switch {
+			case len(userImageParts) > 0:
+				parts := make([]apiContentPart, 0, 1+len(userImageParts))
+				if steerText.Len() > 0 {
+					parts = append(parts, apiContentPart{Type: "text", Text: steerText.String()})
+				}
+				parts = append(parts, userImageParts...)
+				out = append(out, apiMessage{Role: "user", ContentParts: parts})
+			case steerText.Len() > 0:
 				out = append(out, apiMessage{Role: "user", Content: steerText.String()})
 			}
 			continue

--- a/internal/provider/openai/tools_test.go
+++ b/internal/provider/openai/tools_test.go
@@ -276,6 +276,66 @@ func TestSend_ToolResultMessages_WireFormat(t *testing.T) {
 	}
 }
 
+// TestSend_UserImage_WireFormat verifies that a standalone image block on a
+// user message (e.g. an image pasted into the TUI input) is serialized into
+// the OpenAI content-parts array as an image_url data URL — not dropped to a
+// "[image]" placeholder.
+func TestSend_UserImage_WireFormat(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"x","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+
+	msgs := []agent.Message{{
+		Role: agent.RoleUser,
+		Blocks: []agent.ContentBlock{
+			agent.NewTextBlock("what is this?"),
+			agent.NewImageBlock("image/png", []byte{0x89, 'P', 'N', 'G'}),
+		},
+	}}
+
+	if _, err := c.Send(context.Background(), provider.Request{Model: "x", Messages: msgs}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var wireReq struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content []struct {
+				Type     string `json:"type"`
+				Text     string `json:"text"`
+				ImageURL *struct {
+					URL string `json:"url"`
+				} `json:"image_url"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(capturedBody, &wireReq); err != nil {
+		t.Fatalf("decode: %v\n%s", err, capturedBody)
+	}
+	if len(wireReq.Messages) != 1 {
+		t.Fatalf("messages len = %d, want 1: %s", len(wireReq.Messages), capturedBody)
+	}
+	parts := wireReq.Messages[0].Content
+	if len(parts) != 2 {
+		t.Fatalf("content parts = %d, want text+image: %s", len(parts), capturedBody)
+	}
+	if parts[0].Type != "text" || parts[0].Text != "what is this?" {
+		t.Errorf("part[0] = %+v, want text", parts[0])
+	}
+	if parts[1].Type != "image_url" || parts[1].ImageURL == nil {
+		t.Fatalf("part[1] = %+v, want image_url", parts[1])
+	}
+	if !strings.HasPrefix(parts[1].ImageURL.URL, "data:image/png;base64,") {
+		t.Errorf("image_url = %q, want data:image/png;base64,…", parts[1].ImageURL.URL)
+	}
+}
+
 // TestSend_ToolResultWithSteerText_WireFormat verifies that a user/tool_result
 // message carrying a trailing text block (a mid-turn steer the agent folded in
 // — see dev-docs/tui-input-modes-design.md §5) emits the tool output as a


### PR DESCRIPTION
## Problem

An image could only enter the conversation by typing a file path for the model to `read_file`. There was no way to paste an image straight from the clipboard.

## What changed

**Ctrl+V** in the TUI input now grabs an image from the system clipboard and attaches it inline to your next message — shown as a chip above the input (`📎 image (PNG, 84 KB)`). It rides the next turn; **Esc** discards it.

### Pieces

- **Clipboard capture — all three supported platforms**, behind one `captureClipboardImage` seam:
  - **macOS**: `osascript` coerces the clipboard to PNG. No Homebrew/`pngpaste` dependency.
  - **Linux**: `wl-paste` (Wayland) first — enumerates clipboard types, pastes the first `image/*` — then `xclip` (X11), probing `image/png` and `image/jpeg`. Missing both tools yields an actionable "install wl-clipboard or xclip".
  - **Windows**: PowerShell (`pwsh` if present, else `powershell.exe`) saves the clipboard bitmap to a temp PNG via `System.Windows.Forms.Clipboard`.
  - Other OSes (BSDs) return a clear "not supported on <os>" — though the project's CI matrix is Linux/macOS/Windows only anyway.
- **TUI** — `Ctrl+V` queues a `pendingAttachment`; chips render above the input. Empty text + an attachment is a valid image-only message. Mid-turn paste stays pending for the next new turn (a text-only steer can't carry an image). `Ctrl+V` is otherwise unbound — normal text paste (Cmd+V) still arrives as bracketed-paste runes.
- **Agent** — `AttachUserBlocks` queues content blocks that `appendUserInput` folds into the next user message (text block + image blocks). The non-empty-input guard is relaxed when blocks are queued, so an image-only turn is allowed; consumed exactly once.
- **OpenAI adapter fix** — a standalone user image is now serialized into the content-parts array as an `image_url` data URL instead of being dropped to a `"[image]"` placeholder. This makes the feature work on OpenAI-protocol backends (DeepSeek/DashScope), matching the Anthropic adapter which already nested standalone user images.

## Verification & limits

- **macOS**: built and tested on the dev box.
- **Linux/Windows**: cross-compiled (`GOOS=linux`/`windows`), but runtime behavior is **unverified from the macOS dev box** — they rely on the standard `wl-paste`/`xclip`/PowerShell commands. Worth a manual smoke test on each before relying on it.
- Image bytes live in the in-memory `ContentBlock`; like `read_file` images, they are **not persisted in session JSON** (`ImageData` is `json:"-"`), so a resumed session won't replay the pixels. Same limitation as the existing image path — out of scope here.

## Tests

- `internal/agent`: text+image merge, image-only allowance, single-consumption, empty-without-blocks still rejected.
- `internal/provider/openai` + `internal/provider/anthropic`: wire-format tests for a standalone user image (data URL / base64 source).
- `cmd/octo`: submit starts an image-only turn and consumes the attachment; idle Esc discards; mid-turn keeps the attachment pending and still enqueues the steer text.

`go build ./...`, `go vet ./...`, `gofmt`, `go test -race` (affected packages), and cross-builds for linux/amd64 + windows/amd64 all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)