### PR TITLE
fix(tui): expand tabs in cards so the live region stops bleeding through

### DIFF
--- a/internal/tui/diffcard.go
+++ b/internal/tui/diffcard.go
@@ -174,7 +174,7 @@ func renderSummary(added, removed int) string {
 func renderRow(ln Line, language string, dark bool) string {
 	noCol := renderLineNo(ln)
 	mark := renderMark(ln.Kind)
-	body := ln.Text
+	body := expandTabs(ln.Text)
 	if language != "" {
 		body = highlightLine(body, language, dark)
 	}
@@ -266,6 +266,39 @@ func GuessLanguage(path string) string {
 		return "yaml"
 	}
 	return ""
+}
+
+// tabStop is the column width a tab advances to. 8 matches the terminal
+// default and `cat -n`, so expanded rows line up exactly as a raw tab would
+// have — minus the bleed-through.
+const tabStop = 8
+
+// expandTabs replaces tab characters with spaces up to the next tab stop. A
+// card row must paint every cell it occupies: a raw tab repositions the cursor
+// without overwriting the cells it skips, so stale content from the live view
+// rendered below (spinner, status bar, ghost text) shows through the gap. The
+// read_file "%6d\t" line-number separator and tab-indented source are the
+// common sources. Column counting starts at the body's own column 0; the small
+// shift from the card's gutter prefix doesn't matter once no real tabs remain.
+func expandTabs(s string) string {
+	if !strings.ContainsRune(s, '\t') {
+		return s
+	}
+	var b strings.Builder
+	col := 0
+	for _, r := range s {
+		if r == '\t' {
+			n := tabStop - col%tabStop
+			for i := 0; i < n; i++ {
+				b.WriteByte(' ')
+			}
+			col += n
+			continue
+		}
+		b.WriteRune(r)
+		col++
+	}
+	return b.String()
 }
 
 // splitLinesNoTrail splits s on '\n' but drops the trailing empty element

--- a/internal/tui/outputcard.go
+++ b/internal/tui/outputcard.go
@@ -42,9 +42,9 @@ func RenderOutputCard(verb, target, output string, maxLines int, isErr bool, lan
 
 	dark := IsDark()
 	for _, ln := range shown {
-		body := ln
+		body := expandTabs(ln)
 		if language != "" {
-			body = highlightLine(ln, language, dark)
+			body = highlightLine(body, language, dark)
 		}
 		b.WriteString("\n  " + outGutter.String() + " " + body)
 	}

--- a/internal/tui/outputcard_test.go
+++ b/internal/tui/outputcard_test.go
@@ -43,6 +43,19 @@ func TestRenderOutputCard_SingularMoreLine(t *testing.T) {
 	}
 }
 
+func TestRenderOutputCard_ExpandsTabs(t *testing.T) {
+	// read_file emits "%6d\t<line>" and indents Go with tabs. Raw tabs in a
+	// card row skip cells without painting them, letting the live view below
+	// bleed through. The renderer must expand every tab to spaces.
+	output := "     1\tpackage main\n     2\t\tfield int"
+	for _, lang := range []string{"", "go"} {
+		got := RenderOutputCard("Read", "main.go", output, 0, false, lang)
+		if strings.ContainsRune(got, '\t') {
+			t.Errorf("lang=%q: rendered card still contains a raw tab:\n%q", lang, got)
+		}
+	}
+}
+
 func TestRenderOutputCard_Highlight(t *testing.T) {
 	output := "package main\n\nfunc main() {}"
 	got := RenderOutputCard("Read", "main.go", output, 0, false, "go")


### PR DESCRIPTION
## Problem

In the TUI, `read_file` (and other) output cards showed faint stray characters in their left/gutter columns — fragments like `Thinking`, the `cwd …/github` status segment, and the `Shift+Enter` key hint bleeding through the card body.

![bug: tab-gap bleed-through]

Those fragments are pieces of the **live region** (spinner, status bar, ghost-text suggestion) that sits at the bottom during a turn.

## Root cause

Cards are pushed to scrollback via `tea.Println`, which writes the card rows *over* the rows the live region currently occupies. `read_file` formats output as `fmt.Fprintf(&out, "%6d\t%s\n", …)` — a **tab** after the line number — and Go source is tab-indented, so card rows carried raw tabs (introduced visibly by #336's syntax highlighting).

A tab repositions the terminal cursor to the next tab stop **without painting the cells it skips** (unlike a space, which overwrites). So the live-region text underneath shows through exactly those tab gaps. bubbletea's `EraseLineRight` doesn't help — it only clears to the *right* of the final cursor, while the bleed is in the gap to the *left*.

This is also why it surfaced recently: the tabs were always there, but the live status bar / spinner / ghost-text (#332) are what put visible text in those columns.

## Fix

Added `expandTabs` (8-column tab stops, matching the terminal default and `cat -n`, so layout is identical to before — just with every cell painted as a real space). Applied to the body line in both renderers:

- `renderRow` — diff/edit cards (same latent bug, since Go diffs are tab-indented)
- `RenderOutputCard` — read_file / terminal / grep cards

## Test

`TestRenderOutputCard_ExpandsTabs` asserts no raw tab survives rendering, for both the highlighted and plain paths. `internal/tui` and `cmd/octo` suites pass; build and gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)