### PR TITLE
test(tools): fix flaky background-manager tests on Windows CI

### DIFF
--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -9,9 +9,19 @@ import (
 )
 
 // waitFor polls fn until it returns true or the deadline passes.
+//
+// A satisfied check returns within milliseconds, so the deadline only bounds
+// the failure case — making it generous costs nothing on the happy path but
+// prevents spurious timeouts. Windows needs much more slack: every background
+// command pays PowerShell's cold-start cost (seconds, worse under CI load), so
+// a tight deadline there turns a perfectly working process into a flake.
 func waitFor(t *testing.T, what string, fn func() bool) {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
+	limit := 10 * time.Second
+	if runtime.GOOS == "windows" {
+		limit = 45 * time.Second
+	}
+	deadline := time.Now().Add(limit)
 	for time.Now().Before(deadline) {
 		if fn() {
 			return


### PR DESCRIPTION
## What

`TestBackgroundManager_ListRunning_ExcludesExited` (and the other `waitFor`-based background tests) intermittently failed on **Windows CI** with `timed out waiting for process to exit` — e.g. during PR #339's checks.

## Root cause

`waitFor` had a hard **3-second** deadline. On Windows, every background command pays PowerShell's cold-start cost (seconds, worse under CI contention), so a perfectly working `echo done` process occasionally hadn't reported `exited` within 3s → spurious timeout. macOS/Linux (`sh -c`) start fast enough to (almost) always make it.

## Fix

A satisfied check returns within milliseconds, so the deadline only bounds the *failure* case — widening it costs nothing on the happy path. Make it platform-aware: **10s on unix, 45s on Windows**.

Not a product-code change — test helper only. `go vet` + `go test -race ./internal/tools/` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)