### PR TITLE
feat(conduct): default no-verify; --verify=LLM judge; keep --verify-cmd shell gate

### DIFF
--- a/cmd/octo/completion.go
+++ b/cmd/octo/completion.go
@@ -151,10 +151,10 @@ func conductFlagCandidates(prev string) []string {
 	switch prev {
 	case "--provider":
 		return []string{"anthropic", "openai"}
-	case "--model", "--verify":
+	case "--model", "--verify-cmd":
 		return nil
 	}
-	return []string{"--provider", "--model", "--plan-only", "--verify",
+	return []string{"--provider", "--model", "--plan-only", "--verify", "--verify-cmd",
 		"--max-attempts", "--max-iterations", "--stall-rounds", "--concurrency",
 		"--no-worktree", "--replan"}
 }

--- a/cmd/octo/conduct.go
+++ b/cmd/octo/conduct.go
@@ -50,7 +50,9 @@ func printConductUsage(w io.Writer) {
 	fmt.Fprintln(w, "Flags (start):")
 	fmt.Fprintln(w, "  --provider, --model        Provider + model for the planner and workers")
 	fmt.Fprintln(w, "  --plan-only                Seed the ledger and exit (run later with resume)")
-	fmt.Fprintln(w, "  --verify \"<cmd>\"           Verification gate command (default: go build/vet/test)")
+	fmt.Fprintln(w, "  (default)                  No gate — a unit is done when its worker says so")
+	fmt.Fprintln(w, "  --verify                   Gate each unit with an LLM judge")
+	fmt.Fprintln(w, "  --verify-cmd \"<cmd>\"       Gate each unit with a shell command (e.g. go build/test)")
 	fmt.Fprintln(w, "  --max-attempts N           Verify-fail retries per unit before it blocks (default 3)")
 	fmt.Fprintln(w, "  --max-iterations N         Loop-turn budget backstop (default scales with units)")
 	fmt.Fprintln(w, "  --stall-rounds N           Stop after N rounds with no unit completed (0 = off)")
@@ -64,7 +66,8 @@ type conductFlags struct {
 	provider      string
 	model         string
 	planOnly      bool
-	verify        string
+	verify        bool   // LLM judge gate
+	verifyCmd     string // objective shell gate, e.g. "go build ./... && go test ./..."
 	maxAttempts   int
 	maxIterations int
 	stallRounds   int
@@ -79,7 +82,8 @@ func conductFlagSet(name string, f *conductFlags, stderr io.Writer) *flag.FlagSe
 	fs.StringVar(&f.provider, "provider", "", "Provider: anthropic | openai")
 	fs.StringVar(&f.model, "model", "", "Model name")
 	fs.BoolVar(&f.planOnly, "plan-only", false, "Seed the ledger and exit")
-	fs.StringVar(&f.verify, "verify", "", "Verification gate command (default: go build/vet/test)")
+	fs.BoolVar(&f.verify, "verify", false, "Gate each unit with an LLM judge (default: no gate — trust the worker)")
+	fs.StringVar(&f.verifyCmd, "verify-cmd", "", "Gate each unit with a shell command, e.g. \"go build ./... && go test ./...\" (overrides --verify)")
 	fs.IntVar(&f.maxAttempts, "max-attempts", 0, "Verify-fail retries per unit before blocking")
 	fs.IntVar(&f.maxIterations, "max-iterations", 0, "Loop-turn budget backstop")
 	fs.IntVar(&f.stallRounds, "stall-rounds", 0, "Stop after N rounds with no progress (0=off)")
@@ -98,11 +102,18 @@ func (f conductFlags) config() conductor.Config {
 	}
 }
 
-func (f conductFlags) verifier() conductor.Verifier {
-	if strings.TrimSpace(f.verify) != "" {
-		return &conductor.CmdVerifier{Commands: []string{f.verify}}
+// verifier picks the completion gate. Default is no gate (trust the worker's
+// own "done"); --verify-cmd installs an objective shell gate; --verify installs
+// an LLM judge. --verify-cmd wins if both are given.
+func (f conductFlags) verifier(a *agent.Agent) conductor.Verifier {
+	switch {
+	case strings.TrimSpace(f.verifyCmd) != "":
+		return &conductor.CmdVerifier{Commands: []string{f.verifyCmd}}
+	case f.verify:
+		return newJudgeVerifier(a)
+	default:
+		return conductor.NopVerifier{}
 	}
-	return conductor.NewGoVerifier()
 }
 
 // runConductStart plans the goal into a seed ledger, then conducts it.
@@ -218,7 +229,7 @@ func conductLedger(store *conductor.Store, id string, f conductFlags, stdout, st
 	defer cleanup()
 
 	worker := &spawnerWorker{}
-	c := conductor.New(store, worker, f.verifier(), stdout, f.config())
+	c := conductor.New(store, worker, f.verifier(a), stdout, f.config())
 
 	if !f.noWorktree && f.concurrency > 1 {
 		// Phase 2: isolate parallel workers in git worktrees so their edits +

--- a/cmd/octo/conduct_judge.go
+++ b/cmd/octo/conduct_judge.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/conductor"
+)
+
+const judgeMaxTokens = 1024
+
+// judgeSystem makes the model a strict reviewer. It deliberately defaults to
+// FAIL when the evidence is thin: a lenient judge is barely better than the
+// worker's own self-report, which the gate exists to distrust.
+const judgeSystem = `You are a strict reviewer in an autonomous engineering effort. A worker just
+finished a unit of work and reported what it did. Decide whether that work
+actually satisfies the unit's goal.
+
+You are given the overall goal, the unit's description, and the worker's
+reported result. You do NOT see the files directly — judge from the report,
+and be skeptical of vague or self-congratulatory claims that don't show
+concrete evidence of the work.
+
+Pass only if the reported result clearly and specifically demonstrates the
+unit's goal is met. If it's vague, partial, off-target, or just asserts
+success without substance, FAIL it and say what's missing — that reason is
+fed back to the worker as its next instruction, so make it actionable.
+
+Output ONE JSON object, no prose, no code fences:
+
+  { "pass": <true|false>, "reason": "<one or two sentences>" }`
+
+// judgeVerifier is the LLM-judge gate: a side-call asks a model whether a
+// unit's reported output meets its goal. General-purpose — works for docs,
+// design, research, and code alike (though for code an objective shell gate via
+// --verify-cmd is strictly stronger). The whole-tree Global check is a no-op:
+// per-unit judging already vetted each piece and there's no aggregate artifact
+// for the judge to re-read.
+type judgeVerifier struct{ a *agent.Agent }
+
+func newJudgeVerifier(a *agent.Agent) *judgeVerifier { return &judgeVerifier{a: a} }
+
+func (j *judgeVerifier) Verify(ctx context.Context, target conductor.VerifyTarget) (conductor.Verdict, error) {
+	if target.Global {
+		return conductor.Verdict{Green: true}, nil
+	}
+	if j.a == nil || j.a.Sender == nil {
+		return conductor.Verdict{}, fmt.Errorf("conduct: judge has no model configured")
+	}
+	user := fmt.Sprintf("Overall goal:\n%s\n\nUnit:\n%s\n\nWorker's reported result:\n%s\n\n"+
+		"Judge per your instructions. Output only the JSON object.",
+		target.Goal, strings.TrimSpace(target.UnitDesc), strings.TrimSpace(target.Result))
+
+	reply, err := j.a.Sender.SendMessages(ctx, j.a.Model, judgeSystem,
+		[]agent.Message{agent.NewUserMessage(user)}, judgeMaxTokens)
+	if err != nil {
+		return conductor.Verdict{}, err
+	}
+	return parseJudge(reply.Content)
+}
+
+// parseJudge extracts {pass, reason}. A reply with no usable JSON is treated as
+// a fail (the judge couldn't render a verdict — don't accept the unit on a
+// malformed pass), with the raw reply as the reason for debugging.
+func parseJudge(s string) (conductor.Verdict, error) {
+	obj := extractJSONObject(s)
+	if obj == "" {
+		return conductor.Verdict{Green: false, Summary: "judge returned no verdict: " + oneLine(s)}, nil
+	}
+	var raw struct {
+		Pass   bool   `json:"pass"`
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal([]byte(obj), &raw); err != nil {
+		return conductor.Verdict{Green: false, Summary: "judge verdict unparseable: " + oneLine(s)}, nil
+	}
+	reason := strings.TrimSpace(raw.Reason)
+	if reason == "" {
+		if raw.Pass {
+			reason = "meets the goal"
+		} else {
+			reason = "does not meet the goal"
+		}
+	}
+	return conductor.Verdict{Green: raw.Pass, Summary: reason}, nil
+}

--- a/cmd/octo/conduct_judge_test.go
+++ b/cmd/octo/conduct_judge_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/conductor"
+)
+
+func TestParseJudge(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		wantGreen bool
+		wantInSum string
+	}{
+		{"pass", `{"pass": true, "reason": "all good"}`, true, "all good"},
+		{"fail", `{"pass": false, "reason": "missing tests"}`, false, "missing tests"},
+		{"pass with prose+fence", "Sure:\n```json\n{\"pass\": true, \"reason\": \"ok\"}\n```", true, "ok"},
+		{"no json → fail", "looks fine to me", false, "no verdict"},
+		{"unparseable → fail", `{"pass": tru}`, false, "unparseable"},
+		{"pass empty reason", `{"pass": true}`, true, "meets the goal"},
+		{"fail empty reason", `{"pass": false}`, false, "does not meet"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := parseJudge(tt.in)
+			if err != nil {
+				t.Fatalf("parseJudge err = %v", err)
+			}
+			if v.Green != tt.wantGreen {
+				t.Errorf("green = %v, want %v (in=%q)", v.Green, tt.wantGreen, tt.in)
+			}
+			if tt.wantInSum != "" && !strings.Contains(v.Summary, tt.wantInSum) {
+				t.Errorf("summary = %q, want to contain %q", v.Summary, tt.wantInSum)
+			}
+		})
+	}
+}
+
+// TestConductVerifierSelection checks the default-no-verify / --verify=judge /
+// --verify-cmd=shell precedence (verify-cmd wins over verify).
+func TestConductVerifierSelection(t *testing.T) {
+	if _, ok := (conductFlags{}).verifier(nil).(conductor.NopVerifier); !ok {
+		t.Errorf("default verifier should be NopVerifier")
+	}
+	if _, ok := (conductFlags{verify: true}).verifier(nil).(*judgeVerifier); !ok {
+		t.Errorf("--verify should select the LLM judge")
+	}
+	if _, ok := (conductFlags{verifyCmd: "make ci"}).verifier(nil).(*conductor.CmdVerifier); !ok {
+		t.Errorf("--verify-cmd should select the shell gate")
+	}
+	// verify-cmd wins when both are set.
+	if _, ok := (conductFlags{verify: true, verifyCmd: "make ci"}).verifier(nil).(*conductor.CmdVerifier); !ok {
+		t.Errorf("--verify-cmd should override --verify")
+	}
+}
+
+// The judge's whole-tree Global check is a no-op pass (per-unit judging suffices).
+func TestJudgeGlobalIsGreen(t *testing.T) {
+	j := newJudgeVerifier(nil) // nil agent is fine; Global short-circuits before any call
+	v, err := j.Verify(context.Background(), conductor.VerifyTarget{Global: true})
+	if err != nil || !v.Green {
+		t.Fatalf("global judge verdict = %+v err=%v, want green", v, err)
+	}
+}

--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -130,17 +130,22 @@ Run "octo chat --help" for the full flag list.`)
 }
 
 func conductHelp(w io.Writer) {
-	fmt.Fprintln(w, `octo conduct — unattended long-horizon orchestration. Unlike 'octo goal'
-(a one-shot DAG fanned out under stop-on-fail), conduct drives a living
-ledger to completion: every unit's worker gets the upstream results + a
-shared conventions doc, a turn-budget checkpoint resumes instead of failing,
-and a unit is only Done once an objective gate (go build/vet/test) is green.
+	fmt.Fprintln(w, `octo conduct — unattended long-horizon orchestration. Conduct drives a living
+ledger to completion: every unit's worker gets the upstream results + a shared
+conventions doc, and a turn-budget checkpoint resumes instead of failing.
+
+Verification (how a unit becomes Done) is yours to choose:
+  (default)        no gate — the worker's own "done" is trusted
+  --verify         an LLM judge decides whether the output meets the unit's goal
+  --verify-cmd …   a shell gate (e.g. "go build ./... && go test ./..."), the
+                   strongest option for code where compile/test is decidable
 
 Examples:
-  octo conduct "port the parser package to Go"     Plan + conduct to completion
+  octo conduct "tidy up the docs/ folder"          Plan + conduct, no gate
+  octo conduct "..." --verify                      Judge each unit with an LLM
+  octo conduct "..." --verify-cmd "make ci"        Objective shell gate
   octo conduct "..." --plan-only                   Seed the ledger; run later
   octo conduct "..." --concurrency 3               Parallel workers in worktrees
-  octo conduct "..." --verify "make ci"            Custom verification gate
   octo conduct "..." --replan                      Let it re-plan when stuck
   octo conduct list                                List conducted goals
   octo conduct status last                         Per-unit report

--- a/cmd/octo/tuirepl_conduct.go
+++ b/cmd/octo/tuirepl_conduct.go
@@ -168,7 +168,9 @@ func (m *tuiModel) startConductRun(id string) tea.Cmd {
 			return
 		}
 		w := &teaScrollbackWriter{prog: prog}
-		c := conductor.New(store, &spawnerWorker{}, conductor.NewGoVerifier(), w, conductor.Config{})
+		// Interactive runs use no gate by default — the user is watching and can
+		// steer. A judged/objective gate is opt-in via the `octo conduct` CLI.
+		c := conductor.New(store, &spawnerWorker{}, conductor.NopVerifier{}, w, conductor.Config{})
 		runErr := c.Run(ctx, id)
 		prog.Send(conductDoneMsg{id: id, err: runErr})
 	}()

--- a/dev-docs/autonomous-orchestrator-design.md
+++ b/dev-docs/autonomous-orchestrator-design.md
@@ -24,8 +24,11 @@ conductor 取代了早期的一次性 DAG 编排器(曾叫 `/goal`,已移除)。
 1. **计划是磁盘上的活文件,不是内存里的不可变 DAG**(治 #2)。Conductor 每轮读它、改它。
 2. **子任务之间通过磁盘上的共享文档传递状态**(治 #1)。约定/决策/产物落盘,每个 worker
    开工先读、收工追加——module B 的 worker 由此知道 module A 的 worker 把包叫什么、类型怎么命名。
-3. **「完成」由客观验证闸门判定,不信 agent 自述**(治 #3/#4)。max-turns 是检查点不是失败:
-   保存 partial、记日志、下一轮 `Continue` 续跑。失败在 worktree 内被隔离,绿灯才合并(治 #5)。
+3. **「完成」可由可配置的验证闸门判定,而非盲信 agent 自述**(治 #3/#4)。闸门三选一:
+   默认**不验证**(信任 worker 自报完成,适合无客观 oracle 的通用/非代码目标)、**LLM judge**
+   (`--verify`,让模型判产出是否达标)、**shell 闸门**(`--verify-cmd`,如 `go build && go test`,
+   代码任务最强)。max-turns 是检查点不是失败:保存 partial、记日志、下一轮 `Continue` 续跑。
+   失败在 worktree 内被隔离,绿灯才合并(治 #5)。
 
 ## 架构
 
@@ -36,7 +39,7 @@ Conductor(长程循环 · 单线程编排 · 唯一写 LEDGER 的人)
   │  ③ 派发 Worker ──────────────► agentSpawner.Spawn / Continue(复用现有)
   │       (隔离 worktree + 喂全上下文)        │
   │  ④ Verifier 闸门 ◄───────────────────────┘
-  │       (go build / vet / test —— 客观 oracle)
+  │       (默认无 / LLM judge / shell 如 go build·test —— 可配置)
   │  ⑤ Integrator:绿灯才把 worktree 合回 trunk,处理冲突
   │  ⑥ 更新 LEDGER + JOURNAL,压缩上下文,回到 ①
   ▼
@@ -107,19 +110,28 @@ loop:
 worker 内部仍可用全套工具(terminal/编辑/读),但 `launch_agent`/`send_message` 照旧被
 `filterChildTools` 砍掉——递归分解由 Conductor 通过重规划完成,而不是 worker 自己 fork。
 
-## Verifier:可插拔验证 oracle
+## Verifier:可插拔验证闸门
 
 ```go
 type Verifier interface {
-    // Run 在给定工作区跑客观闸门,返回是否通过 + 给 worker 看的失败摘要。
-    Run(ctx context.Context, workdir string) (Verdict, error)
+    // target 带上 Goal/UnitDesc/Result/Workdir/Global —— shell 闸门只看 Workdir,
+    // LLM judge 据 Goal/UnitDesc/Result 判断,返回是否通过 + 给 worker 看的失败摘要。
+    Verify(ctx context.Context, target VerifyTarget) (Verdict, error)
 }
-type Verdict struct { Green bool; Summary string; Details string }
+type Verdict struct { Green bool; Summary string }
 ```
 
-对 TS→Go:`go build ./...` → `go vet ./...` → `go test ./...`,任一非零即红。
-红灯的 `Summary`(编译错误/失败测试)直接喂回 worker 下一轮。验证是**第一公民**:
-单元在闸门绿之前永远不是 done,worktree 也不会合并。这根除了 `/goal` 的「agent 自述完成但其实没编过」。
+三种实现,运行时三选一:
+
+- **`NopVerifier`(默认)**:永远绿,worker 自报完成即 done。适合无客观 oracle 的通用/非代码目标。
+- **LLM judge(`--verify`)**:side-call 让模型判 worker 产出是否满足 unit 目标,默认偏严(证据不足判 fail)。
+  通用——文档、设计、研究、代码都能判;但对代码,shell 闸门严格更强。
+- **`CmdVerifier`(`--verify-cmd "<cmd>"`)**:跑 shell 命令,全 0 退出才绿。如 `go build && go test`、
+  `make ci`、`pytest`。对「能不能编译/测试过」这种可判定问题,这是最强闸门。
+
+红灯的 `Summary`(编译错误 / judge 的理由)直接喂回 worker 下一轮。无论哪种闸门,单元在绿之前永远不是
+done、worktree 也不会合并——这把 `/goal` 的「agent 自述完成但其实没做到」从盲信变成可选的、可升级的校验。
+全局收尾闸门(`Global=true`)只对 shell 闸门有意义(在 trunk 根重跑);Nop / judge 直接放行。
 
 ## 并行策略
 

--- a/internal/conductor/conductor.go
+++ b/internal/conductor/conductor.go
@@ -36,18 +36,47 @@ type WorkResult struct {
 	Incomplete bool
 }
 
-// Verifier is the objective completion gate. A unit is never Done until
-// Verify returns Green. workdir is the directory to check ("" = process cwd;
-// Phase 2 passes the unit's worktree).
+// Verifier is the completion gate. A unit is never Done until Verify returns
+// Green. The conductor supports three modes, chosen by the caller:
+//
+//   - NopVerifier      — no gate; the worker's own "done" is trusted (default)
+//   - an LLM judge     — a model decides whether the unit's output meets its
+//     goal (general-purpose; works for docs/design/non-code)
+//   - CmdVerifier      — an objective shell gate (e.g. go build/test), strongest
+//     for code where "does it compile/pass" is decidable
+//
+// Verify is handed the full VerifyTarget so a judge can reason about the goal
+// and the worker's result, while a shell gate just uses Workdir.
 type Verifier interface {
-	Verify(ctx context.Context, workdir string) (Verdict, error)
+	Verify(ctx context.Context, target VerifyTarget) (Verdict, error)
+}
+
+// VerifyTarget is everything a verifier might need. A CmdVerifier reads only
+// Workdir; an LLM judge reads Goal/UnitDesc/Result. Global marks the final
+// whole-goal check after every unit is Done (per-unit fields are empty then).
+type VerifyTarget struct {
+	Goal     string // the overall ledger goal
+	UnitDesc string // this unit's description
+	Result   string // the worker's reported result/summary
+	Workdir  string // dir to check ("" = process cwd; Phase 2 = the worktree)
+	Global   bool   // the final whole-tree gate, not a single unit
 }
 
 // Verdict is a verification outcome. Summary is short failure text fed back
-// to the worker on a red verdict (e.g. the first compile errors).
+// to the worker on a red verdict (compile errors, or the judge's reasoning).
 type Verdict struct {
 	Green   bool
 	Summary string
+}
+
+// NopVerifier is the default gate: it accepts everything, so a unit is Done as
+// soon as its worker reports done. Use it for goals with no objective oracle
+// where the worker self-verifies, or when you simply don't want a gate.
+type NopVerifier struct{}
+
+// Verify always passes.
+func (NopVerifier) Verify(context.Context, VerifyTarget) (Verdict, error) {
+	return Verdict{Green: true}, nil
 }
 
 // Worktrees isolates a unit's work in its own git worktree (Phase 2). nil on
@@ -369,8 +398,13 @@ func (c *Conductor) dispatchUnit(ctx context.Context, id string, item dispatchIt
 		return oc // checkpoint — integrate handles it, no verify
 	}
 
-	// Worker says done — verify objectively in its working dir.
-	verdict, vErr := c.verifier.Verify(ctx, oc.workdir)
+	// Worker says done — run the gate (no-op / LLM judge / shell, per config).
+	verdict, vErr := c.verifier.Verify(ctx, VerifyTarget{
+		Goal:     l.Goal,
+		UnitDesc: u.Description,
+		Result:   oc.res.Reply,
+		Workdir:  oc.workdir,
+	})
 	if vErr != nil && ctx.Err() == nil {
 		verdict = Verdict{Green: false, Summary: "verifier error: " + vErr.Error()}
 	}
@@ -490,8 +524,11 @@ func (c *Conductor) finalize(ctx context.Context, id string) error {
 		return err
 	}
 	if l.AllDone() {
-		// Global verification over the whole tree before declaring success.
-		verdict, vErr := c.verifier.Verify(ctx, "")
+		// Final whole-tree gate before declaring success. A shell gate re-runs
+		// the build/tests at the repo root; NopVerifier and the LLM judge treat
+		// the global check as green (per-unit verification already vetted each
+		// piece — there's no objective whole-tree oracle for them to re-run).
+		verdict, vErr := c.verifier.Verify(ctx, VerifyTarget{Goal: l.Goal, Workdir: "", Global: true})
 		if vErr == nil && verdict.Green {
 			c.setStatus(id, LedgerDone)
 			c.logf("Goal %s complete — global verification green.\n", l.ShortID())

--- a/internal/conductor/conductor_test.go
+++ b/internal/conductor/conductor_test.go
@@ -82,19 +82,19 @@ func unitIDFromLabel(label string) int {
 type fnVerifier struct {
 	mu sync.Mutex
 	n  int
-	fn func(call int, workdir string) Verdict
+	fn func(call int, target VerifyTarget) Verdict
 }
 
-func (v *fnVerifier) Verify(_ context.Context, workdir string) (Verdict, error) {
+func (v *fnVerifier) Verify(_ context.Context, target VerifyTarget) (Verdict, error) {
 	v.mu.Lock()
 	c := v.n
 	v.n++
 	v.mu.Unlock()
-	return v.fn(c, workdir), nil
+	return v.fn(c, target), nil
 }
 
 func alwaysGreen() *fnVerifier {
-	return &fnVerifier{fn: func(int, string) Verdict { return Verdict{Green: true} }}
+	return &fnVerifier{fn: func(int, VerifyTarget) Verdict { return Verdict{Green: true} }}
 }
 
 // helpers
@@ -202,7 +202,7 @@ func TestConductVerifyRedThenGreenRetries(t *testing.T) {
 	worker := newFnWorker(func(unitID, call int, resume bool, spec WorkSpec) WorkResult {
 		return WorkResult{Reply: "attempt"}
 	})
-	verifier := &fnVerifier{fn: func(call int, _ string) Verdict {
+	verifier := &fnVerifier{fn: func(call int, _ VerifyTarget) Verdict {
 		if call == 0 {
 			return Verdict{Green: false, Summary: "build broke: undefined Foo"}
 		}
@@ -230,7 +230,7 @@ func TestConductBlocksAfterMaxAttempts(t *testing.T) {
 	worker := newFnWorker(func(unitID, call int, resume bool, spec WorkSpec) WorkResult {
 		return WorkResult{Reply: "tried"}
 	})
-	redForever := &fnVerifier{fn: func(int, string) Verdict { return Verdict{Green: false, Summary: "nope"} }}
+	redForever := &fnVerifier{fn: func(int, VerifyTarget) Verdict { return Verdict{Green: false, Summary: "nope"} }}
 	c := New(s, worker, redForever, nil, Config{MaxAttempts: 2})
 	err := c.Run(context.Background(), id)
 	if err == nil {
@@ -354,7 +354,7 @@ func TestConductReplanUnblocks(t *testing.T) {
 	// then the re-planner's recovery unit + the global gate go green.
 	calls := 0
 	var mu sync.Mutex
-	v := &fnVerifier{fn: func(_ int, _ string) Verdict {
+	v := &fnVerifier{fn: func(_ int, _ VerifyTarget) Verdict {
 		mu.Lock()
 		defer mu.Unlock()
 		calls++

--- a/internal/conductor/ledger_test.go
+++ b/internal/conductor/ledger_test.go
@@ -166,19 +166,19 @@ func TestCmdVerifier(t *testing.T) {
 	ctx := context.Background()
 
 	// Empty gate → green (self-verify mode).
-	if v, err := (&CmdVerifier{}).Verify(ctx, ""); err != nil || !v.Green {
+	if v, err := (&CmdVerifier{}).Verify(ctx, VerifyTarget{}); err != nil || !v.Green {
 		t.Fatalf("empty gate: verdict=%+v err=%v, want green", v, err)
 	}
 
 	// All pass.
 	green := &CmdVerifier{Commands: []string{"true", "true"}}
-	if v, err := green.Verify(ctx, ""); err != nil || !v.Green {
+	if v, err := green.Verify(ctx, VerifyTarget{}); err != nil || !v.Green {
 		t.Fatalf("true gate: verdict=%+v err=%v, want green", v, err)
 	}
 
 	// First failure short-circuits and names the command.
 	red := &CmdVerifier{Commands: []string{"echo boom && false", "true"}}
-	v, err := red.Verify(ctx, "")
+	v, err := red.Verify(ctx, VerifyTarget{})
 	if err != nil {
 		t.Fatalf("red gate err = %v", err)
 	}

--- a/internal/conductor/verifier_cmd.go
+++ b/internal/conductor/verifier_cmd.go
@@ -32,18 +32,17 @@ var DefaultGoCommands = []string{
 // NewGoVerifier returns a CmdVerifier running the standard Go gate.
 func NewGoVerifier() *CmdVerifier { return &CmdVerifier{Commands: DefaultGoCommands} }
 
-// Verify runs each command in workdir ("" = process cwd). It returns a green
-// verdict only if every command exits 0. A command that fails to start (e.g.
-// shell missing) returns a non-nil error; a command that runs but exits
-// non-zero is a red verdict, not an error.
-func (v *CmdVerifier) Verify(ctx context.Context, workdir string) (Verdict, error) {
+// Verify runs each command in target.Workdir ("" = process cwd). It returns a
+// green verdict only if every command exits 0. A command that fails to start
+// (e.g. shell missing) returns a non-nil error; a command that runs but exits
+// non-zero is a red verdict, not an error. Only target.Workdir is used — the
+// shell gate is objective and doesn't reason about the goal/result.
+func (v *CmdVerifier) Verify(ctx context.Context, target VerifyTarget) (Verdict, error) {
 	if len(v.Commands) == 0 {
-		// No gate configured: treat as green (the worker self-verifies). This
-		// keeps the conductor usable for non-Go / exploratory goals.
 		return Verdict{Green: true}, nil
 	}
 	for _, cmdStr := range v.Commands {
-		out, exitOK, runErr := runShell(ctx, workdir, cmdStr)
+		out, exitOK, runErr := runShell(ctx, target.Workdir, cmdStr)
 		if runErr != nil {
 			return Verdict{}, runErr
 		}


### PR DESCRIPTION
## What

Makes the conductor **language-agnostic** by changing how a unit becomes Done. Verification is now a choice, defaulting to trusting the worker:

| Mode | Flag | Behavior |
|---|---|---|
| **No gate** (default) | — | unit is Done when its worker reports done; works for any language + non-code goals (docs, design, research) |
| **LLM judge** | `--verify` | a model decides whether the unit's reported output meets its goal (skeptical prompt; fails on thin evidence) |
| **Shell gate** | `--verify-cmd "<cmd>"` | the previous objective gate (e.g. `go build ./... && go test ./...`, `make ci`, `pytest`) — strongest for code; `--verify-cmd` wins over `--verify` |

Previously the default was a hard-wired `go build/vet/test`, so conduct only really worked on Go repos. Now Go is just one `--verify-cmd` value.

## How

- `Verifier.Verify` now takes a `VerifyTarget` (`Goal`/`UnitDesc`/`Result`/`Workdir`/`Global`) so an LLM judge can reason about the goal + result, while the shell gate uses only `Workdir`.
- New `NopVerifier` (default) and `judgeVerifier` (LLM side-call, in `cmd/octo`). `CmdVerifier` kept for `--verify-cmd`.
- Whole-tree `Global` check runs only for the shell gate; Nop/judge pass it (per-unit verification already vetted each piece).
- TUI `/conduct` defaults to no gate (the user is watching and can steer).

## Tests

`parseJudge` (pass / fail / prose+fence / no-json / unparseable / empty-reason), verifier selection precedence (default Nop, `--verify` judge, `--verify-cmd` shell, cmd-wins), judge `Global` no-op. Existing conductor/ledger tests updated to the new signature. `make fmt-check` / `vet` / `test -race` all green.

## Note on the judge

The judge is a single side-call that evaluates the worker's *reported* result (it doesn't independently read the files), so it's a skeptical second opinion rather than a hard oracle. For code, `--verify-cmd` remains objectively stronger and is the recommended gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)