### PR TITLE
fix(conduct): show the planned DAG before the /conduct confirm modal

### DIFF
--- a/cmd/octo/tuirepl_conduct.go
+++ b/cmd/octo/tuirepl_conduct.go
@@ -118,7 +118,7 @@ func (m *tuiModel) onConductPlanned(msg conductPlannedMsg) (tea.Model, tea.Cmd) 
 		m.turnRunning = false
 		m.cancelTurn = nil
 		m.println(errorStyle.Render("conduct: " + msg.err.Error()))
-		return m, nil
+		return m, m.flushPrints()
 	}
 	m.println(msg.report)
 
@@ -146,7 +146,11 @@ func (m *tuiModel) onConductPlanned(msg conductPlannedMsg) (tea.Model, tea.Cmd) 
 		}
 		prog.Send(conductRunMsg{id: id})
 	}()
-	return m, nil
+	// Flush the planned-DAG report to scrollback BEFORE the confirm modal
+	// becomes interactive — otherwise View() renders only the modal and the
+	// user is asked to approve a plan they never saw. Every other Update branch
+	// flushes the same way; this async handler must too.
+	return m, m.flushPrints()
 }
 
 // startConductRun drives the conductor loop in the background, streaming
@@ -207,7 +211,7 @@ func (m *tuiModel) onConductDone(msg conductDoneMsg) (tea.Model, tea.Cmd) {
 	if b.Len() > 0 {
 		m.println(b.String())
 	}
-	return m, nil
+	return m, m.flushPrints()
 }
 
 // teaScrollbackWriter adapts an io.Writer (the conductor's progress stream)

--- a/cmd/octo/tuirepl_slash_test.go
+++ b/cmd/octo/tuirepl_slash_test.go
@@ -92,7 +92,7 @@ func TestTUI_ConductPlannedErrorReleasesSession(t *testing.T) {
 func TestTUI_ConductPlannedSuccessOpensConfirmModal(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true
-	_, _ = m.onConductPlanned(conductPlannedMsg{
+	_, cmd := m.onConductPlanned(conductPlannedMsg{
 		id:     "20260529-120000-abcd1234",
 		report: "Ledger abcd1234 [pending]\nGoal: do the thing",
 	})
@@ -101,6 +101,15 @@ func TestTUI_ConductPlannedSuccessOpensConfirmModal(t *testing.T) {
 	}
 	if !m.turnRunning {
 		t.Error("session stays occupied until the plan is confirmed or cancelled")
+	}
+	// The plan report must be FLUSHED to scrollback before the modal becomes
+	// interactive — otherwise the user is asked to approve a plan they can't
+	// see (View renders only the modal, hiding the still-buffered lines).
+	if cmd == nil {
+		t.Error("onConductPlanned must return a flush Cmd so the report reaches scrollback")
+	}
+	if len(m.printlnBuf) != 0 {
+		t.Errorf("plan report left buffered (%d lines) — it won't show under the modal", len(m.printlnBuf))
 	}
 	// Unblock the bridge goroutine waiting on the modal answer.
 	m.answerModal(UserResponse{Cancelled: true})


### PR DESCRIPTION
## Bug

`/conduct <goal>` in the TUI opened the **Run it / Cancel** confirm modal **without showing the plan** — you're asked to approve a ledger you can't see:

```
> /conduct 调研 ...
Planning…
┌ [conduct] ───────────────────┐
│ Conduct this plan (f5127d34)? │
│ ▸ Run it / Cancel / Other     │   ← no plan above it
└───────────────────────────────┘
```

## Cause

`onConductPlanned` buffered the report with `m.println(...)` but returned `(m, nil)`. `println` only appends to `printlnBuf`; lines reach scrollback only when a handler returns `m.flushPrints()`. Every other Update branch does — but this async message handler didn't. Once the modal is open, `View()` renders **only** the modal, hiding the still-buffered lines, and the live spinner tick reschedules without flushing, so nothing ever committed the buffer.

## Fix

`onConductPlanned` (and `onConductDone`, same class — the final report) now return `m.flushPrints()`, committing the report to scrollback **above** the modal before it becomes interactive. Regression test asserts `printlnBuf` is drained and a non-nil flush `Cmd` is returned.

`go build` / `vet` / `test -race ./cmd/octo/ ./internal/conductor/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)