### PR TITLE
fix(tui): suppress attachment add/discard echo lines

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -115,10 +115,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		// Idle: clear the input line and discard any pending attachments.
-		if len(m.pendingAttachments) > 0 {
-			m.pendingAttachments = nil
-			m.println(noticeStyle.Render("📎 attachments discarded"))
-		}
+		m.pendingAttachments = nil
 		m.ta.Reset()
 		m.inputHistoryIdx = -1
 		return m, m.updateTextAreaHeight()
@@ -276,7 +273,6 @@ func (m *tuiModel) pasteClipboardImage() (tea.Model, tea.Cmd) {
 		block: agent.NewImageBlock(mime, data),
 		label: label,
 	})
-	m.println(noticeStyle.Render("📎 attached " + label + " — it rides your next message"))
 	return m, nil
 }
 


### PR DESCRIPTION
Paste (Ctrl+V) and Esc discard no longer print 'attached ...' and 'attachments discarded' lines into the scrollback. The pending attachment state is already visible as a chip above the input box, so the echo was redundant noise.