### PR TITLE
feat(conduct): view results — conduct show + status preview + post-run prompt

### DIFF
--- a/cmd/octo/completion.go
+++ b/cmd/octo/completion.go
@@ -126,11 +126,11 @@ func chatCandidates(words []string, prev string) []string {
 func conductCandidates(words []string, prev string) []string {
 	// `octo conduct <TAB>` → subcommand list (or the start of a goal string).
 	if len(words) == 3 {
-		return []string{"list", "status", "resume"}
+		return []string{"list", "status", "show", "resume"}
 	}
 	sub := words[2]
 	switch sub {
-	case "status", "resume":
+	case "status", "show", "resume":
 		// First positional after the verb is the ledger ID.
 		if len(words) == 4 {
 			return conductIDCandidates()

--- a/cmd/octo/conduct.go
+++ b/cmd/octo/conduct.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
@@ -28,6 +29,8 @@ func runConduct(args []string, _ io.Reader, stdout, stderr io.Writer) int {
 		return runConductList(stdout, stderr)
 	case "status", "report":
 		return runConductStatus(args[1:], stdout, stderr)
+	case "show":
+		return runConductShow(args[1:], stdout, stderr)
 	case "resume":
 		return runConductResume(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
@@ -45,6 +48,7 @@ func printConductUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage: octo conduct \"<goal>\" [flags]   Plan + run a goal to completion, unattended")
 	fmt.Fprintln(w, "       octo conduct list                List every conducted goal, newest first")
 	fmt.Fprintln(w, "       octo conduct status <id>         Show one ledger's per-unit state + report")
+	fmt.Fprintln(w, "       octo conduct show <id> [unit]    Print the full result text of done units")
 	fmt.Fprintln(w, "       octo conduct resume <id>         Re-run a stopped/blocked ledger")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Flags (start):")
@@ -310,6 +314,43 @@ func runConductStatus(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	conductor.Report(stdout, led)
+	return 0
+}
+
+// runConductShow prints the full result text of done units (and errors of
+// blocked units). `octo conduct show <id>` shows all; an optional unit-id
+// narrows to one. This is where the worker's actual output lives — `status`
+// only previews it.
+func runConductShow(args []string, stdout, stderr io.Writer) int {
+	if len(args) < 1 {
+		fmt.Fprintln(stderr, "Usage: octo conduct show <id> [unit-id]")
+		return 2
+	}
+	store, err := conductor.NewStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo conduct: %v\n", err)
+		return 1
+	}
+	id, err := store.ResolveID(args[0])
+	if err != nil {
+		fmt.Fprintf(stderr, "octo conduct: %v\n", err)
+		return 1
+	}
+	unitID := 0
+	if len(args) >= 2 {
+		n, convErr := strconv.Atoi(args[1])
+		if convErr != nil || n <= 0 {
+			fmt.Fprintf(stderr, "octo conduct: unit-id must be a positive integer, got %q\n", args[1])
+			return 2
+		}
+		unitID = n
+	}
+	led, err := store.Get(id)
+	if err != nil {
+		fmt.Fprintf(stderr, "octo conduct: %v\n", err)
+		return 1
+	}
+	conductor.ShowResults(stdout, led, unitID)
 	return 0
 }
 

--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -148,7 +148,9 @@ Examples:
   octo conduct "..." --concurrency 3               Parallel workers in worktrees
   octo conduct "..." --replan                      Let it re-plan when stuck
   octo conduct list                                List conducted goals
-  octo conduct status last                         Per-unit report
+  octo conduct status last                         Per-unit state + result preview
+  octo conduct show last                           Full result text of every done unit
+  octo conduct show last 1                          Full result of just unit #1
   octo conduct resume <id>                         Resume a stopped/blocked run
 
 Unattended guardrails:

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -610,6 +610,9 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case conductDoneMsg:
 		return m.onConductDone(msg)
+
+	case conductShowMsg:
+		return m.onConductShow(msg)
 	}
 	return m, m.flushPrints()
 }

--- a/cmd/octo/tuirepl_conduct.go
+++ b/cmd/octo/tuirepl_conduct.go
@@ -31,6 +31,13 @@ type conductDoneMsg struct {
 	err error
 }
 
+// conductShowMsg carries the user's answer to the post-run "view details?"
+// prompt. show=true → print the full results to scrollback.
+type conductShowMsg struct {
+	id   string
+	show bool
+}
+
 func (m *tuiModel) dispatchConduct(args string) (tea.Model, tea.Cmd) {
 	fields := strings.Fields(args)
 	if len(fields) == 0 || strings.ToLower(fields[0]) == "help" {
@@ -186,12 +193,14 @@ func (m *tuiModel) onConductDone(msg conductDoneMsg) (tea.Model, tea.Cmd) {
 	m.turnRunning = false
 	m.cancelTurn = nil
 	var b strings.Builder
+	hasResults := false
 	store, serr := conductor.NewStore()
 	if serr == nil {
 		if led, gerr := store.Get(msg.id); gerr == nil {
 			var rb bytes.Buffer
 			conductor.Report(&rb, led)
 			b.WriteString(strings.TrimRight(rb.String(), "\n"))
+			hasResults = led.HasResults()
 		}
 	}
 	switch {
@@ -210,6 +219,50 @@ func (m *tuiModel) onConductDone(msg conductDoneMsg) (tea.Model, tea.Cmd) {
 	}
 	if b.Len() > 0 {
 		m.println(b.String())
+	}
+
+	// Proactively offer the full results — otherwise the worker's actual output
+	// is buried in the ledger and the user has to know to run `conduct show`.
+	if hasResults {
+		ch := make(chan UserResponse, 1)
+		m.openModal(askMsg{
+			prompt: UserPrompt{
+				Kind:     KindQuestion,
+				Header:   "conduct",
+				Question: "结果已出 — 要看详细结果吗?",
+				Options:  []string{"看详细结果", "不用了"},
+			},
+			resp: ch,
+		})
+		id := msg.id
+		prog := m.sink.prog
+		go func() {
+			r := <-ch
+			show := !r.Cancelled && len(r.Choices) > 0 && r.Choices[0] == "看详细结果"
+			prog.Send(conductShowMsg{id: id, show: show})
+		}()
+	}
+	return m, m.flushPrints()
+}
+
+// onConductShow handles the answer to the post-run "view details?" prompt:
+// prints the full result text if asked, and always points at the CLI command
+// for looking it up again later.
+func (m *tuiModel) onConductShow(msg conductShowMsg) (tea.Model, tea.Cmd) {
+	short := msg.id
+	if len(short) > 8 {
+		short = short[len(short)-8:]
+	}
+	if msg.show {
+		if store, err := conductor.NewStore(); err == nil {
+			if led, gerr := store.Get(msg.id); gerr == nil {
+				var b bytes.Buffer
+				conductor.ShowResults(&b, led, 0)
+				m.println(strings.TrimRight(b.String(), "\n"))
+			}
+		}
+	} else {
+		m.println(noticeStyle.Render("好的。随时用  octo conduct show " + short + "  查看完整结果。"))
 	}
 	return m, m.flushPrints()
 }

--- a/cmd/octo/tuirepl_slash_test.go
+++ b/cmd/octo/tuirepl_slash_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/Leihb/octo-agent/internal/conductor"
 )
 
 // ── dispatchSlash routing ──
@@ -122,9 +124,59 @@ func TestTUI_ConductDoneReleasesSession(t *testing.T) {
 
 	m := newTestModel()
 	m.turnRunning = true
+	// Unknown id → no ledger → no results → no modal, session released.
 	_, _ = m.onConductDone(conductDoneMsg{id: "t-12345678"})
 	if m.turnRunning {
 		t.Error("conduct completion must release the session")
+	}
+	if m.modal != nil {
+		t.Error("no results → no 'view details?' modal")
+	}
+}
+
+// A finished run with results proactively offers to show them, and onConductShow
+// emits the full result when the user says yes.
+func TestTUI_ConductDoneOffersResultDetails(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	store, err := conductor.NewStore()
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	led, err := store.Create("g", []conductor.Unit{{ID: 1, Description: "x"}})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := store.Update(led.ID, func(l *conductor.Ledger) error {
+		l.Units[0].Status = conductor.UnitDone
+		l.Units[0].ResultSummary = "THE ANSWER 42"
+		l.Status = conductor.LedgerDone
+		return nil
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	m := newTestModel()
+	m.turnRunning = true
+	_, _ = m.onConductDone(conductDoneMsg{id: led.ID})
+	if m.modal == nil {
+		t.Fatal("a finished run with results should offer a 'view details?' modal")
+	}
+	if m.turnRunning {
+		t.Error("session should be released once the run is done")
+	}
+	// Unblock the bridge goroutine waiting on the modal answer.
+	m.answerModal(UserResponse{Cancelled: true})
+
+	// Saying yes flushes the full result to scrollback.
+	_, cmd := m.onConductShow(conductShowMsg{id: led.ID, show: true})
+	if cmd == nil {
+		t.Error("onConductShow(show=true) should return a flush Cmd with the results")
+	}
+	if len(m.printlnBuf) != 0 {
+		t.Errorf("results left buffered (%d lines) instead of flushed", len(m.printlnBuf))
 	}
 }
 

--- a/internal/conductor/report.go
+++ b/internal/conductor/report.go
@@ -22,10 +22,17 @@ func Report(w io.Writer, l *Ledger) {
 	fmt.Fprintf(w, "Units: %d done · %d in-progress · %d pending · %d blocked · %d abandoned\n\n",
 		counts[UnitDone], counts[UnitInProgress], counts[UnitPending], counts[UnitBlocked], counts[UnitAbandoned])
 
+	hasResult := false
 	for _, u := range l.Units {
 		fmt.Fprintf(w, "  %s #%-3d %s\n", unitGlyph(u.Status), u.ID, oneLine(u.Description, 80))
 		if len(u.BlockedBy) > 0 {
 			fmt.Fprintf(w, "        ↳ blocked_by: %s\n", joinInts(u.BlockedBy))
+		}
+		// One-line preview of a done unit's result, so `status` shows what the
+		// worker produced — the full text is via `octo conduct show`.
+		if u.Status == UnitDone && strings.TrimSpace(u.ResultSummary) != "" {
+			hasResult = true
+			fmt.Fprintf(w, "        ↳ %s\n", oneLine(u.ResultSummary, 100))
 		}
 		if u.Status == UnitBlocked && u.LastError != "" {
 			fmt.Fprintf(w, "        ✗ %s\n", oneLine(u.LastError, 100))
@@ -43,6 +50,60 @@ func Report(w io.Writer, l *Ledger) {
 		sort.Ints(blocked)
 		fmt.Fprintf(w, "\nNeeds attention: %d blocked unit(s): %s\n", len(blocked), joinInts(blocked))
 		fmt.Fprintf(w, "Resume after intervention with: octo conduct resume %s\n", l.ShortID())
+	}
+	if hasResult {
+		fmt.Fprintf(w, "\nFull results: octo conduct show %s\n", l.ShortID())
+	}
+}
+
+// HasResults reports whether any done unit has a result worth showing. Callers
+// use it to decide whether to offer `conduct show` / a "view details?" prompt.
+func (l *Ledger) HasResults() bool {
+	for _, u := range l.Units {
+		if u.Status == UnitDone && strings.TrimSpace(u.ResultSummary) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// ShowResults writes the FULL result of each done unit (and the error of each
+// blocked unit). unitID==0 shows every unit; a positive unitID shows just that
+// one. Backs `octo conduct show <id> [unit-id]` and the TUI "view details" path.
+func ShowResults(w io.Writer, l *Ledger, unitID int) {
+	fmt.Fprintf(w, "Ledger %s  [%s] — %s\n", l.ShortID(), l.Status, oneLine(l.Goal, 0))
+
+	shown := 0
+	for _, u := range l.Units {
+		if unitID != 0 && u.ID != unitID {
+			continue
+		}
+		switch u.Status {
+		case UnitDone:
+			fmt.Fprintf(w, "\n%s #%d %s\n", unitGlyph(u.Status), u.ID, oneLine(u.Description, 0))
+			body := strings.TrimSpace(u.ResultSummary)
+			if body == "" {
+				body = "(no result text recorded)"
+			}
+			fmt.Fprintf(w, "%s\n", body)
+			shown++
+		case UnitBlocked:
+			fmt.Fprintf(w, "\n%s #%d %s\n", unitGlyph(u.Status), u.ID, oneLine(u.Description, 0))
+			fmt.Fprintf(w, "FAILED: %s\n", strings.TrimSpace(u.LastError))
+			shown++
+		default:
+			if unitID != 0 { // explicitly asked for a not-yet-done unit
+				fmt.Fprintf(w, "\n%s #%d %s — %s (no result yet)\n", unitGlyph(u.Status), u.ID, oneLine(u.Description, 0), u.Status)
+				shown++
+			}
+		}
+	}
+	if shown == 0 {
+		if unitID != 0 {
+			fmt.Fprintf(w, "\nNo unit #%d in this ledger.\n", unitID)
+		} else {
+			fmt.Fprintln(w, "\nNo results yet.")
+		}
 	}
 }
 

--- a/internal/conductor/report_show_test.go
+++ b/internal/conductor/report_show_test.go
@@ -1,0 +1,74 @@
+package conductor
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func resultLedger() *Ledger {
+	return &Ledger{
+		ID: "20260603-020753-f5127d34", Goal: "research workflows", Status: LedgerDone,
+		Units: []Unit{
+			{ID: 1, Description: "research the docs", Status: UnitDone, ResultSummary: "Found it: Dynamic Workflows ship JS orchestration."},
+			{ID: 2, Description: "impossible bit", Status: UnitBlocked, LastError: "build broke: undefined Foo"},
+			{ID: 3, Description: "not started", Status: UnitPending},
+		},
+	}
+}
+
+func TestHasResults(t *testing.T) {
+	if !resultLedger().HasResults() {
+		t.Error("HasResults = false, want true (unit 1 has a result)")
+	}
+	empty := &Ledger{Units: []Unit{{ID: 1, Status: UnitPending}}}
+	if empty.HasResults() {
+		t.Error("HasResults = true on a ledger with no done results")
+	}
+}
+
+func TestReportShowsResultPreviewAndHint(t *testing.T) {
+	var b bytes.Buffer
+	Report(&b, resultLedger())
+	out := b.String()
+	if !strings.Contains(out, "Found it: Dynamic Workflows") {
+		t.Errorf("report missing result preview:\n%s", out)
+	}
+	if !strings.Contains(out, "octo conduct show f5127d34") {
+		t.Errorf("report missing 'conduct show' hint:\n%s", out)
+	}
+}
+
+func TestShowResultsAll(t *testing.T) {
+	var b bytes.Buffer
+	ShowResults(&b, resultLedger(), 0)
+	out := b.String()
+	// Full result body of the done unit…
+	if !strings.Contains(out, "Dynamic Workflows ship JS orchestration") {
+		t.Errorf("ShowResults missing done-unit body:\n%s", out)
+	}
+	// …and the blocked unit's failure.
+	if !strings.Contains(out, "FAILED: build broke: undefined Foo") {
+		t.Errorf("ShowResults missing blocked-unit error:\n%s", out)
+	}
+}
+
+func TestShowResultsSingleUnit(t *testing.T) {
+	var b bytes.Buffer
+	ShowResults(&b, resultLedger(), 1)
+	out := b.String()
+	if !strings.Contains(out, "Dynamic Workflows ship JS orchestration") {
+		t.Errorf("ShowResults(1) missing unit 1 body:\n%s", out)
+	}
+	if strings.Contains(out, "FAILED") {
+		t.Errorf("ShowResults(1) should not include unit 2:\n%s", out)
+	}
+}
+
+func TestShowResultsUnknownUnit(t *testing.T) {
+	var b bytes.Buffer
+	ShowResults(&b, resultLedger(), 99)
+	if !strings.Contains(b.String(), "No unit #99") {
+		t.Errorf("ShowResults(99) should report the missing unit:\n%s", b.String())
+	}
+}


### PR DESCRIPTION
## Problem

After a `conduct` run finished, the worker's actual output was stored in the ledger (`Unit.ResultSummary`) but there was **no way to see it** — `status` showed only `✓ #1 done`, and you'd have to hand-read `~/.octo/conductor/<id>/ledger.json`. (Reported from a real run: "goal 完成后,我怎么查看结果".)

## What

1. **`octo conduct show <id> [unit-id]`** — prints the full result text of every done unit (and the error of each blocked unit); optional `unit-id` narrows to one. Backed by new `conductor.ShowResults`.
2. **`status` result preview** — each done unit now shows a one-line preview of its result plus a `Full results: octo conduct show <id>` hint, so it's discoverable.
3. **TUI proactive prompt** — a finished `/conduct` run with results asks **「结果已出 — 要看详细结果吗?」** → `[看详细结果 / 不用了]`. Yes flushes the full results to scrollback; No points at the `conduct show` command for later. The agent surfaces the capability rather than the user having to know it.

## Smoke (real ledger)

```
$ octo conduct status f5127d34
  ✓ #1   调研…功能
        ↳ 调研完成。以下是 Claude Code Dynamic Workflows 的简明总结：…
Full results: octo conduct show f5127d34

$ octo conduct show f5127d34
✓ #1 …
调研完成。以下是 …（完整正文）
```

## Tests

`ShowResults` (all / single / unknown unit), `Report` preview + hint, `HasResults`, and the TUI flow (modal offered only when results exist; `onConductShow(show=true)` flushes). `make fmt-check` / `vet` / `test -race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)