### PR TITLE
feat(agent): let mid-turn steer carry image attachments via Inbox

### DIFF
--- a/cmd/octo/steer_recall_test.go
+++ b/cmd/octo/steer_recall_test.go
@@ -31,7 +31,7 @@ func TestSteerRecall_UpRetractsLastPending(t *testing.T) {
 	if len(m.pendingSteer) != 1 || m.pendingSteer[0] != "first steer" {
 		t.Errorf("pendingSteer = %v, want [first steer]", m.pendingSteer)
 	}
-	if drained := m.a.Inbox.Drain(); len(drained) != 1 || drained[0] != "first steer" {
+	if drained := m.a.Inbox.Drain(); len(drained) != 1 || drained[0].Text != "first steer" {
 		t.Errorf("inbox after retract = %v, want [first steer]", drained)
 	}
 }

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -496,8 +496,8 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// turn so the model sees the completion immediately — matching the plain
 		// REPL's idleInboxWait behaviour.
 		if !m.turnRunning && len(m.queue) == 0 {
-			if msgs := m.a.Inbox.Drain(); len(msgs) > 0 {
-				s := strings.Join(msgs, "\n\n")
+			if items := m.a.Inbox.Drain(); len(items) > 0 {
+				s := strings.Join(agent.Texts(items), "\n\n")
 				return m, tea.Sequence(tea.Println(notice), m.startTurnEcho(s, ""))
 			}
 		}
@@ -529,8 +529,8 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Idle auto-turn: same logic as bgExitMsg — drain inbox and trigger a
 		// turn so the model sees the notification immediately.
 		if !m.turnRunning && len(m.queue) == 0 {
-			if msgs := m.a.Inbox.Drain(); len(msgs) > 0 {
-				s := strings.Join(msgs, "\n\n")
+			if items := m.a.Inbox.Drain(); len(items) > 0 {
+				s := strings.Join(agent.Texts(items), "\n\n")
 				return m, m.startTurnEcho(s, "")
 			}
 		}
@@ -561,8 +561,8 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Eagerly drain inbox so a pending message (or background-process
 			// notice that raced in via Inbox) starts immediately rather than
 			// waiting for turnFinishedMsg.
-			if msgs := m.a.Inbox.Drain(); len(msgs) > 0 {
-				s := strings.Join(msgs, "\n\n")
+			if items := m.a.Inbox.Drain(); len(items) > 0 {
+				s := strings.Join(agent.Texts(items), "\n\n")
 				for _, line := range strings.Split(s, "\n\n") {
 					if !strings.HasPrefix(line, "<system-reminder>") {
 						m.println(userEchoStyle.Render("> ") + line)
@@ -917,8 +917,8 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 
 	// Drain any inbox messages that weren't consumed during the turn and
 	// run them as the next turn, ahead of explicitly-queued items.
-	if msgs := m.a.Inbox.Drain(); len(msgs) > 0 {
-		s := strings.Join(msgs, "\n\n")
+	if items := m.a.Inbox.Drain(); len(items) > 0 {
+		s := strings.Join(agent.Texts(items), "\n\n")
 		for _, line := range strings.Split(s, "\n\n") {
 			if !strings.HasPrefix(line, "<system-reminder>") {
 				m.println(userEchoStyle.Render("> ") + line)

--- a/cmd/octo/tuirepl_attach_test.go
+++ b/cmd/octo/tuirepl_attach_test.go
@@ -46,10 +46,9 @@ func TestTUI_EscDiscardsAttachments(t *testing.T) {
 	}
 }
 
-// TestTUI_MidTurnKeepsAttachments verifies that submitting while a turn runs
-// keeps the attachment pending (it can't ride a text-only steer) and still
-// enqueues the steer text.
-func TestTUI_MidTurnKeepsAttachments(t *testing.T) {
+// TestTUI_MidTurnSendsAttachments verifies that submitting while a turn runs
+// folds pending attachments into the steer message (they ride via Inbox).
+func TestTUI_MidTurnSendsAttachments(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true
 	m.pendingAttachments = []pendingAttachment{fakeAttachment()}
@@ -57,10 +56,20 @@ func TestTUI_MidTurnKeepsAttachments(t *testing.T) {
 
 	_, _ = m.submit()
 
-	if len(m.pendingAttachments) != 1 {
-		t.Errorf("attachment should stay pending mid-turn, got %d", len(m.pendingAttachments))
+	if len(m.pendingAttachments) != 0 {
+		t.Errorf("attachment should be consumed on mid-turn submit, still have %d", len(m.pendingAttachments))
 	}
 	if !m.a.Inbox.HasPending() {
-		t.Error("steer text should still be enqueued mid-turn")
+		t.Fatal("steer text should still be enqueued mid-turn")
+	}
+	items := m.a.Inbox.Drain()
+	if len(items) != 1 {
+		t.Fatalf("inbox len = %d, want 1", len(items))
+	}
+	if items[0].Text != "also look here" {
+		t.Errorf("inbox text = %q, want 'also look here'", items[0].Text)
+	}
+	if len(items[0].Blocks) != 1 {
+		t.Errorf("inbox blocks = %d, want 1 (the image)", len(items[0].Blocks))
 	}
 }

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -52,9 +52,9 @@ func TestTUI_RunningEnterEnqueues(t *testing.T) {
 	if !m.a.Inbox.HasPending() {
 		t.Fatal("Enter while running should enqueue to inbox")
 	}
-	msgs := m.a.Inbox.Drain()
-	if len(msgs) != 1 || msgs[0] != "also handle errors" {
-		t.Errorf("inbox = %v", msgs)
+	items := m.a.Inbox.Drain()
+	if len(items) != 1 || items[0].Text != "also handle errors" {
+		t.Errorf("inbox = %v", items)
 	}
 	if len(m.queue) != 0 {
 		t.Errorf("inbox must not enqueue to queue, queue = %+v", m.queue)

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -415,15 +415,19 @@ func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 		return m, m.startTurnEcho(text, echo)
 	}
 
-	// Mid-turn: image attachments can't ride a text-only steer, so keep them
-	// pending for the next new turn. The chip above the input box already shows
-	// the attachment state, no extra echo needed.
-	// Mid-turn input goes to the inbox. It will be drained into history at
-	// the start of the next loop iteration, before the LLM call, so the
-	// model sees it as a first-class user message.
-	if text != "" {
+	// Mid-turn: enqueue the steer text, folding in any pending image
+	// attachments so they ride this message rather than being stranded.
+	if text != "" || len(m.pendingAttachments) > 0 {
 		m.pendingSteer = append(m.pendingSteer, text)
-		m.a.Inbox.Enqueue(text)
+		var blocks []agent.ContentBlock
+		if len(m.pendingAttachments) > 0 {
+			blocks = make([]agent.ContentBlock, 0, len(m.pendingAttachments))
+			for _, a := range m.pendingAttachments {
+				blocks = append(blocks, a.block)
+			}
+			m.pendingAttachments = nil
+		}
+		m.a.Inbox.EnqueueWithBlocks(text, blocks)
 	}
 	return m, nil
 }

--- a/cmd/octo/turncore.go
+++ b/cmd/octo/turncore.go
@@ -61,7 +61,7 @@ func runTurn(ctx context.Context, a *agent.Agent, cfg replConfig, sink ViewSink,
 	// This is the idle counterpart to the in-turn drain that RunStream does at
 	// the start of each loop iteration.
 	if pending := a.Inbox.Drain(); len(pending) > 0 {
-		turnInput = strings.Join(pending, "\n\n") + "\n\n" + turnInput
+		turnInput = strings.Join(agent.Texts(pending), "\n\n") + "\n\n" + turnInput
 	}
 
 	// Pre-turn hook: feed the raw user input to an external retrieval layer;

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -485,12 +485,25 @@ func (a *Agent) runLoop(
 		// Drain inbox messages that arrived since the last iteration.
 		// Done before the LLM call so the model sees mid-turn user input
 		// as a first-class message boundary, not folded into tool output.
-		if steerMsgs := a.Inbox.Drain(); len(steerMsgs) > 0 {
-			for _, m := range steerMsgs {
-				a.History.Append(NewUserMessage(m))
+		if steerItems := a.Inbox.Drain(); len(steerItems) > 0 {
+			for _, it := range steerItems {
+				if len(it.Blocks) > 0 {
+					blocks := make([]ContentBlock, 0, 1+len(it.Blocks))
+					if it.Text != "" {
+						blocks = append(blocks, NewTextBlock(it.Text))
+					}
+					blocks = append(blocks, it.Blocks...)
+					a.History.Append(Message{Role: RoleUser, Blocks: blocks})
+				} else {
+					a.History.Append(NewUserMessage(it.Text))
+				}
 			}
 			if handler != nil {
-				handler(AgentEvent{Kind: EventSteerInjected, Messages: steerMsgs})
+				msgs := make([]string, len(steerItems))
+				for i, it := range steerItems {
+					msgs[i] = it.Text
+				}
+				handler(AgentEvent{Kind: EventSteerInjected, Messages: msgs})
 			}
 		}
 

--- a/internal/agent/inbox.go
+++ b/internal/agent/inbox.go
@@ -5,38 +5,51 @@ import (
 	"sync"
 )
 
+// InboxItem is one queued user message, optionally carrying content blocks
+// (e.g. images pasted in the TUI) that should ride on the same turn.
+type InboxItem struct {
+	Text   string
+	Blocks []ContentBlock
+}
+
 // Inbox is a thread-safe queue for user messages that arrive while a turn is
 // running. It mirrors Ruby octo's @inbox: messages accumulate here and are
 // drained into history at the start of each loop iteration, before the LLM
 // call. This keeps mid-turn input handling simple and avoids the complexity of
 // merging steer text into tool_result messages.
 type Inbox struct {
-	mu   sync.Mutex
-	msgs []string
+	mu    sync.Mutex
+	items []InboxItem
 }
 
-// Enqueue adds a message to the inbox. Empty/whitespace-only messages are
-// ignored. Safe to call from any goroutine (e.g. the UI goroutine while the
-// agent loop is running).
+// Enqueue adds a text-only message to the inbox. Empty/whitespace-only
+// messages are ignored. Safe to call from any goroutine.
 func (ib *Inbox) Enqueue(msg string) {
-	if strings.TrimSpace(msg) == "" {
+	ib.EnqueueWithBlocks(msg, nil)
+}
+
+// EnqueueWithBlocks adds a message with optional content blocks to the inbox.
+// Empty/whitespace-only text is ignored, but a non-empty block list with empty
+// text is accepted (image-only steer). Safe to call from any goroutine.
+func (ib *Inbox) EnqueueWithBlocks(msg string, blocks []ContentBlock) {
+	if strings.TrimSpace(msg) == "" && len(blocks) == 0 {
 		return
 	}
 	ib.mu.Lock()
-	ib.msgs = append(ib.msgs, msg)
+	ib.items = append(ib.items, InboxItem{Text: msg, Blocks: blocks})
 	ib.mu.Unlock()
 }
 
-// Drain returns all queued messages and clears the inbox. Returns nil when
+// Drain returns all queued items and clears the inbox. Returns nil when
 // nothing is queued. Called from the loop goroutine at iteration start.
-func (ib *Inbox) Drain() []string {
+func (ib *Inbox) Drain() []InboxItem {
 	ib.mu.Lock()
 	defer ib.mu.Unlock()
-	if len(ib.msgs) == 0 {
+	if len(ib.items) == 0 {
 		return nil
 	}
-	out := ib.msgs
-	ib.msgs = nil
+	out := ib.items
+	ib.items = nil
 	return out
 }
 
@@ -44,23 +57,33 @@ func (ib *Inbox) Drain() []string {
 func (ib *Inbox) HasPending() bool {
 	ib.mu.Lock()
 	defer ib.mu.Unlock()
-	return len(ib.msgs) > 0
+	return len(ib.items) > 0
 }
 
-// Remove deletes the last queued message equal to msg and reports whether one
-// was removed. It is used to retract a steer message that hasn't been drained
-// yet: matching by value (last occurrence) means a background notice enqueued
-// between submit and retract doesn't shift the target. Returns false when the
-// message is no longer queued (the loop already drained it) — the caller must
-// then treat it as committed, not retractable.
+// Remove deletes the last queued item whose text equals msg and reports
+// whether one was removed. It is used to retract a steer message that hasn't
+// been drained yet: matching by value (last occurrence) means a background
+// notice enqueued between submit and retract doesn't shift the target. Returns
+// false when the message is no longer queued (the loop already drained it) —
+// the caller must then treat it as committed, not retractable.
 func (ib *Inbox) Remove(msg string) bool {
 	ib.mu.Lock()
 	defer ib.mu.Unlock()
-	for i := len(ib.msgs) - 1; i >= 0; i-- {
-		if ib.msgs[i] == msg {
-			ib.msgs = append(ib.msgs[:i], ib.msgs[i+1:]...)
+	for i := len(ib.items) - 1; i >= 0; i-- {
+		if ib.items[i].Text == msg {
+			ib.items = append(ib.items[:i], ib.items[i+1:]...)
 			return true
 		}
 	}
 	return false
+}
+
+// Texts returns the text of each item, preserving order. Helper for callers
+// that only need the string slice (e.g. background notifications).
+func Texts(items []InboxItem) []string {
+	out := make([]string, len(items))
+	for i, it := range items {
+		out[i] = it.Text
+	}
+	return out
 }

--- a/internal/agent/inbox_test.go
+++ b/internal/agent/inbox_test.go
@@ -27,17 +27,49 @@ func TestInbox_EnqueueDrain(t *testing.T) {
 		t.Fatal("expected pending messages after two enqueues")
 	}
 
-	msgs := ib.Drain()
-	if len(msgs) != 2 {
-		t.Fatalf("Drain len = %d, want 2", len(msgs))
+	items := ib.Drain()
+	if len(items) != 2 {
+		t.Fatalf("Drain len = %d, want 2", len(items))
 	}
-	if msgs[0] != "first" || msgs[1] != "second" {
-		t.Errorf("Drain = %v, want [first second]", msgs)
+	if items[0].Text != "first" || items[1].Text != "second" {
+		t.Errorf("Drain = %v, want [first second]", items)
 	}
 
 	// Drain must clear.
 	if ib.HasPending() || ib.Drain() != nil {
 		t.Error("Drain did not clear the inbox")
+	}
+}
+
+func TestInbox_EnqueueWithBlocks(t *testing.T) {
+	var ib Inbox
+	img := NewImageBlock("image/png", []byte{0x89, 'P', 'N', 'G'})
+	ib.EnqueueWithBlocks("look at this", []ContentBlock{img})
+	ib.Enqueue("plain text")
+
+	items := ib.Drain()
+	if len(items) != 2 {
+		t.Fatalf("Drain len = %d, want 2", len(items))
+	}
+	if items[0].Text != "look at this" || len(items[0].Blocks) != 1 {
+		t.Errorf("item[0] = %+v, want text + 1 block", items[0])
+	}
+	if items[1].Text != "plain text" || len(items[1].Blocks) != 0 {
+		t.Errorf("item[1] = %+v, want text + 0 blocks", items[1])
+	}
+}
+
+func TestInbox_EnqueueWithBlocks_ImageOnly(t *testing.T) {
+	var ib Inbox
+	img := NewImageBlock("image/png", []byte{1, 2, 3})
+	ib.EnqueueWithBlocks("", []ContentBlock{img})
+
+	items := ib.Drain()
+	if len(items) != 1 {
+		t.Fatalf("Drain len = %d, want 1", len(items))
+	}
+	if items[0].Text != "" || len(items[0].Blocks) != 1 {
+		t.Errorf("item[0] = %+v, want empty text + 1 block", items[0])
 	}
 }
 
@@ -51,8 +83,9 @@ func TestInbox_Remove(t *testing.T) {
 	if !ib.Remove("a") {
 		t.Fatal("Remove(a) = false, want true")
 	}
-	if got := ib.Drain(); len(got) != 2 || got[0] != "a" || got[1] != "b" {
-		t.Errorf("after Remove(a) drain = %v, want [a b]", got)
+	items := ib.Drain()
+	if len(items) != 2 || items[0].Text != "a" || items[1].Text != "b" {
+		t.Errorf("after Remove(a) drain = %v, want [a b]", items)
 	}
 }
 


### PR DESCRIPTION
Previously, image attachments pasted during a running turn were stranded — they couldn't ride a text-only steer and had to wait for the next new turn.

This change extends Inbox to carry ContentBlocks alongside text, so mid-turn steer messages can now carry image attachments just like idle-turn messages.

Key changes:
-  replaces bare string, holding Text + optional Blocks
-  lets callers attach image blocks to a steer message
-  drains InboxItems and builds proper user messages with blocks
- TUI  mid-turn now folds pendingAttachments into the steer

Background notifications (pure text) continue to work unchanged.