### PR TITLE
feat(tui): live indicator while compacting conversation history

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -306,6 +306,15 @@ type tuiModel struct {
 	// until completion.)
 	running *runningTool
 
+	// compacting is set between EventCompactStarted and EventCompactDone while
+	// history compaction runs. It drives a dedicated live spinner line so the
+	// user sees the conversation isn't frozen while the summary streams in.
+	compacting       bool
+	compactStart     time.Time
+	compactTokens    int    // running estimate of the summary generated so far
+	compactMaxTokens int    // the summary's output-token cap (denominator)
+	compactPreview   string // tail of the streamed summary, shown under the spinner
+
 	// printlnBuf accumulates lines to emit via tea.Println at the end of each
 	// Update cycle. In inline mode, committed output goes to the terminal
 	// scrollback above the live View() area — no alt-screen buffer needed.
@@ -777,6 +786,36 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 			return
 		}
 		m.commitToolLine(toolErrStyle.Render(fmt.Sprintf("↳ %s ✗ — %s", ev.ToolName, truncate1Line(ev.Err))))
+		return
+
+	case agent.EventCompactStarted:
+		m.compacting = true
+		m.compactStart = time.Now()
+		m.compactTokens = 0
+		m.compactPreview = ""
+		if ev.Compact != nil {
+			m.compactMaxTokens = ev.Compact.MaxTokens
+		}
+		return
+
+	case agent.EventCompactProgress:
+		if ev.Compact != nil {
+			m.compactTokens = ev.Compact.SummaryTokens
+		}
+		// Keep a bounded tail of the streamed summary for the live preview.
+		m.compactPreview = lastRunes(m.compactPreview+ev.Chunk, 240)
+		return
+
+	case agent.EventCompactDone:
+		m.compacting = false
+		m.compactPreview = ""
+		// Only announce a real reduction; a no-op (summary failed / unchanged)
+		// clears the indicator silently rather than implying work was done.
+		if c := ev.Compact; c != nil && c.AfterTokens > 0 && c.AfterTokens < c.BeforeTokens {
+			m.println(noticeStyle.Render(fmt.Sprintf(
+				"✦ compacted context · folded %d message(s) · ~%s → ~%s tokens",
+				c.FoldedMsgs, humanTokens(c.BeforeTokens), humanTokens(c.AfterTokens))))
+		}
 		return
 
 	case agent.EventSteerInjected:

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -366,6 +366,25 @@ func shortMIME(mime string) string {
 	return strings.ToUpper(mime)
 }
 
+// humanTokens renders a token count compactly (e.g. 142000 → "142k").
+func humanTokens(n int) string {
+	if n >= 1000 {
+		return fmt.Sprintf("%.1fk", float64(n)/1000)
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+// lastRunes returns the final n runes of s (rune-safe so multi-byte CJK
+// summaries aren't sliced mid-character). Used to bound the live compaction
+// preview without growing it without limit.
+func lastRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[len(r)-n:])
+}
+
 // humanByteSize renders a byte count compactly (B / KB / MB).
 func humanByteSize(n int) string {
 	const kb, mb = 1024, 1024 * 1024
@@ -674,7 +693,22 @@ func (m *tuiModel) View() string {
 	}
 
 	// Activity indicator
-	if m.running != nil {
+	if m.compacting {
+		// Compaction runs between LLM calls; surface a dedicated spinner with a
+		// live "generated ~N / max tokens" readout plus a streaming preview so
+		// the user can tell the conversation is being summarized, not frozen.
+		label := "Compacting conversation history…"
+		if m.compactMaxTokens > 0 {
+			label += fmt.Sprintf("  ~%s / ~%s tokens",
+				humanTokens(m.compactTokens), humanTokens(m.compactMaxTokens))
+		}
+		b.WriteString(m.spinnerLine(label, m.compactStart))
+		b.WriteByte('\n')
+		if preview := strings.TrimSpace(strings.ReplaceAll(m.compactPreview, "\n", " ")); preview != "" {
+			b.WriteString(hintStyle.Render("  … " + lastRunes(preview, 100)))
+			b.WriteByte('\n')
+		}
+	} else if m.running != nil {
 		b.WriteString(m.spinnerLine(m.running.verb+"("+m.running.target+")", m.running.start))
 		b.WriteByte('\n')
 	} else if m.turnRunning && m.partial.Len() == 0 {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -470,7 +470,7 @@ func (a *Agent) runLoop(
 	// ends on a complete assistant message) rather than mid-loop, where a
 	// tool_use/tool_result pair could be split. A summarization failure is
 	// non-fatal — we log nothing and proceed with the full history.
-	_ = a.maybeCompact(ctx)
+	_ = a.maybeCompact(ctx, handler)
 
 	a.appendUserInput(userInput)
 
@@ -522,7 +522,7 @@ func (a *Agent) runLoop(
 			}
 
 			// ── Context overflow recovery (aligned with Ruby) ──
-			if a.overflow.tryRecover(ctx, a, err) {
+			if a.overflow.tryRecover(ctx, a, err, handler) {
 				// Compression succeeded — retry the same iteration
 				// without incrementing i or popping user message
 				continue
@@ -619,7 +619,7 @@ func (a *Agent) runLoop(
 			// grown significantly. If the estimated size is near the window,
 			// compact before the next LLM call to avoid a 400.
 			if a.shouldCompactBetweenBatches() {
-				_ = a.maybeCompact(ctx)
+				_ = a.maybeCompact(ctx, handler)
 			}
 			continue
 		}

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -201,14 +201,21 @@ Begin your response NOW. Remember: PURE TEXT only, starting with <topics> then <
 // "compaction disabled / not needed" or "compacted successfully"; an error
 // means the summarization side-call failed (the caller logs and proceeds with
 // uncompacted history rather than aborting the turn).
-func (a *Agent) maybeCompact(ctx context.Context) error {
+//
+// handler may be nil (the non-streaming Run path); when set, maybeCompact
+// emits EventCompactStarted/Progress/Done around the summarization so the UI
+// can show a live "compacting conversation history" indicator. Once Started
+// has fired, Done always fires too — even on failure — so observers never get
+// stuck showing the indicator.
+func (a *Agent) maybeCompact(ctx context.Context, handler EventHandler) error {
 	trigger := a.compactTriggerTokens()
 	if trigger <= 0 {
 		return nil
 	}
 
 	msgs := a.History.Snapshot()
-	if estimateMessages(msgs) < trigger {
+	before := estimateMessages(msgs)
+	if before < trigger {
 		return nil
 	}
 
@@ -217,12 +224,23 @@ func (a *Agent) maybeCompact(ctx context.Context) error {
 		return nil // not enough complete turns to safely compact yet
 	}
 
-	summary, err := a.summarize(ctx, msgs[:split])
+	if handler != nil {
+		handler(AgentEvent{Kind: EventCompactStarted, Compact: &CompactStats{
+			BeforeTokens: before,
+			FoldedMsgs:   split,
+			KeptTurns:    compactKeepTurns,
+			MaxTokens:    summarizeMaxTokens,
+		}})
+	}
+
+	summary, err := a.summarize(ctx, msgs[:split], handler)
 	if err != nil {
+		emitCompactDone(handler, before, before, split) // no-op: clear the indicator
 		return fmt.Errorf("agent: compact: %w", err)
 	}
 	if summary == "" {
-		return nil // nothing usable came back; leave history alone
+		emitCompactDone(handler, before, before, split) // nothing usable came back
+		return nil                                      // leave history alone
 	}
 
 	// Rebuild: one summary user-message, then the kept recent turns verbatim.
@@ -233,7 +251,22 @@ func (a *Agent) maybeCompact(ctx context.Context) error {
 	}
 	// Reset the trigger so we don't re-compact until the context grows again.
 	a.lastInputTokens = 0
+
+	emitCompactDone(handler, before, estimateMessages(a.History.Snapshot()), split)
 	return nil
+}
+
+// emitCompactDone fires EventCompactDone if a handler is attached. before ==
+// after signals a no-op compaction (the full history was kept).
+func emitCompactDone(handler EventHandler, before, after, folded int) {
+	if handler == nil {
+		return
+	}
+	handler(AgentEvent{Kind: EventCompactDone, Compact: &CompactStats{
+		BeforeTokens: before,
+		AfterTokens:  after,
+		FoldedMsgs:   folded,
+	}})
 }
 
 // summarize asks the Sender to condense the given messages into a summary.
@@ -245,7 +278,11 @@ func (a *Agent) maybeCompact(ctx context.Context) error {
 // Overflow protection: if the estimated token count of msgs exceeds the model's
 // context window, messages are popped from the head until it fits. This
 // prevents the compression call itself from 400-ing.
-func (a *Agent) summarize(ctx context.Context, msgs []Message) (string, error) {
+//
+// When the Sender implements StreamingSender and a handler is attached, the
+// summary is streamed so the caller can surface EventCompactProgress as it
+// arrives; otherwise it falls back to the buffered SendMessages.
+func (a *Agent) summarize(ctx context.Context, msgs []Message, handler EventHandler) (string, error) {
 	// ── Overflow protection ──────────────────────────────────────────────
 	// If msgs alone exceeds the window, pop from head until it fits.
 	// This handles the case where the history is already over the limit
@@ -268,7 +305,27 @@ func (a *Agent) summarize(ctx context.Context, msgs []Message) (string, error) {
 	req = append(req, msgs...)
 	req = append(req, NewUserMessage(compressionPrompt))
 
-	reply, err := a.Sender.SendMessages(ctx, a.Model, "", req, summarizeMaxTokens)
+	// Stream the summary when we can, so the UI can show a live "generated ~N
+	// tokens" indicator. The deltas surface as EventCompactProgress — NOT
+	// EventTextDelta — so consumers never mistake the summary for the
+	// assistant's reply. Falls back to a buffered call otherwise.
+	var reply Reply
+	var err error
+	if ss, ok := a.Sender.(StreamingSender); ok && handler != nil {
+		var acc strings.Builder
+		reply, err = ss.StreamMessages(ctx, a.Model, "", req, summarizeMaxTokens, func(delta string) {
+			if delta == "" {
+				return
+			}
+			acc.WriteString(delta)
+			handler(AgentEvent{Kind: EventCompactProgress, Chunk: delta, Compact: &CompactStats{
+				SummaryTokens: estimateText(acc.String()),
+				MaxTokens:     summarizeMaxTokens,
+			}})
+		})
+	} else {
+		reply, err = a.Sender.SendMessages(ctx, a.Model, "", req, summarizeMaxTokens)
+	}
 	if err != nil {
 		return "", err
 	}

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -119,7 +119,7 @@ func TestMaybeCompact_AutoDefaultTriggers(t *testing.T) {
 		a.History.Append(NewUserMessage(longMsg))
 		a.History.Append(NewAssistantMessage(longMsg))
 	}
-	if err := a.maybeCompact(context.Background()); err != nil {
+	if err := a.maybeCompact(context.Background(), nil); err != nil {
 		t.Fatal(err)
 	}
 	if f.calls != 1 {
@@ -138,7 +138,7 @@ func TestMaybeCompact_DisabledOrBelowThreshold(t *testing.T) {
 
 	// Disabled (negative threshold) — even a huge context must not compact.
 	a.CompactThreshold = -1
-	if err := a.maybeCompact(context.Background()); err != nil {
+	if err := a.maybeCompact(context.Background(), nil); err != nil {
 		t.Fatal(err)
 	}
 	if f.calls != 0 || a.History.Len() != 12 {
@@ -147,7 +147,7 @@ func TestMaybeCompact_DisabledOrBelowThreshold(t *testing.T) {
 
 	// Enabled but history still under threshold.
 	a.CompactThreshold = 100000 // way above the ~1500 tokens of the 12 messages
-	if err := a.maybeCompact(context.Background()); err != nil {
+	if err := a.maybeCompact(context.Background(), nil); err != nil {
 		t.Fatal(err)
 	}
 	if f.calls != 0 || a.History.Len() != 12 {
@@ -167,7 +167,7 @@ func TestMaybeCompact_RewritesHistory(t *testing.T) {
 	}
 	// History now well over the 100-token threshold.
 
-	if err := a.maybeCompact(context.Background()); err != nil {
+	if err := a.maybeCompact(context.Background(), nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -195,6 +195,96 @@ func TestMaybeCompact_RewritesHistory(t *testing.T) {
 	// Trigger reset so we don't immediately re-compact.
 	if a.lastInputTokens != 0 {
 		t.Errorf("lastInputTokens should reset to 0, got %d", a.lastInputTokens)
+	}
+}
+
+// streamingSummarizeFake implements StreamingSender, emitting the canned
+// summary in chunks so the compaction-progress events can be observed.
+type streamingSummarizeFake struct {
+	summary string
+	chunks  int
+}
+
+func (f *streamingSummarizeFake) SendMessages(_ context.Context, _, _ string, _ []Message, _ int) (Reply, error) {
+	return Reply{Content: f.summary}, nil
+}
+
+func (f *streamingSummarizeFake) StreamMessages(_ context.Context, _, _ string, _ []Message, _ int, onChunk func(string)) (Reply, error) {
+	// Emit one rune at a time so SummaryTokens grows monotonically across events.
+	for _, r := range f.summary {
+		f.chunks++
+		onChunk(string(r))
+	}
+	return Reply{Content: f.summary, InputTokens: 5, OutputTokens: 3}, nil
+}
+
+// TestMaybeCompact_EmitsProgressEvents proves compaction surfaces a
+// started → progress(streaming) → done event sequence with sane stats, so the
+// TUI can show a live "compacting conversation history" indicator.
+func TestMaybeCompact_EmitsProgressEvents(t *testing.T) {
+	f := &streamingSummarizeFake{summary: "GOAL build X. Touched main.go."}
+	a := New(f, "m")
+	a.CompactThreshold = 100
+
+	longMsg := strings.Repeat("x ", 500) // ~250 tokens each
+	for i := 0; i < 6; i++ {
+		a.History.Append(NewUserMessage(longMsg))
+		a.History.Append(NewAssistantMessage(longMsg))
+	}
+
+	var events []AgentEvent
+	handler := func(ev AgentEvent) { events = append(events, ev) }
+
+	if err := a.maybeCompact(context.Background(), handler); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(events) < 3 {
+		t.Fatalf("expected started + progress + done events, got %d", len(events))
+	}
+
+	// First event: started, with the pre-compaction estimate and fold counts.
+	first := events[0]
+	if first.Kind != EventCompactStarted {
+		t.Errorf("first event = %q, want compact_started", first.Kind)
+	}
+	if first.Compact == nil || first.Compact.BeforeTokens <= 0 {
+		t.Errorf("started event missing BeforeTokens: %+v", first.Compact)
+	}
+	if first.Compact.KeptTurns != compactKeepTurns {
+		t.Errorf("started KeptTurns = %d, want %d", first.Compact.KeptTurns, compactKeepTurns)
+	}
+	if first.Compact.MaxTokens != summarizeMaxTokens {
+		t.Errorf("started MaxTokens = %d, want %d", first.Compact.MaxTokens, summarizeMaxTokens)
+	}
+
+	// Middle: at least one progress event whose summary estimate is monotonic.
+	var progress []AgentEvent
+	prevTokens := -1
+	for _, ev := range events {
+		if ev.Kind != EventCompactProgress {
+			continue
+		}
+		progress = append(progress, ev)
+		if ev.Chunk == "" {
+			t.Errorf("progress event missing Chunk")
+		}
+		if ev.Compact == nil || ev.Compact.SummaryTokens < prevTokens {
+			t.Errorf("progress SummaryTokens not monotonic: %+v (prev=%d)", ev.Compact, prevTokens)
+		}
+		prevTokens = ev.Compact.SummaryTokens
+	}
+	if len(progress) == 0 {
+		t.Errorf("expected at least one compact_progress event")
+	}
+
+	// Last event: done, with after < before (a real reduction happened).
+	last := events[len(events)-1]
+	if last.Kind != EventCompactDone {
+		t.Errorf("last event = %q, want compact_done", last.Kind)
+	}
+	if last.Compact == nil || last.Compact.AfterTokens <= 0 || last.Compact.AfterTokens >= last.Compact.BeforeTokens {
+		t.Errorf("done event should show reduction: %+v", last.Compact)
 	}
 }
 

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -57,6 +57,27 @@ const (
 	// transcript at the correct chronological position — before the next
 	// assistant reply, not after the turn ends.
 	EventSteerInjected EventKind = "steer_injected"
+
+	// EventCompactStarted fires when history compaction begins, just before
+	// the summarization side-call. Compact carries the pre-compaction context
+	// estimate and how much is being folded so observers can show a "compacting
+	// conversation history" indicator. Compaction is silent to the model; these
+	// events exist only to keep the user informed.
+	EventCompactStarted EventKind = "compact_started"
+
+	// EventCompactProgress fires repeatedly while the summary streams back from
+	// the model. Chunk carries the newest text fragment of the summary;
+	// Compact.SummaryTokens is the running estimate of summary length so far.
+	// Observers can show a live "generated ~N tokens" indicator. Fires only
+	// when the underlying Sender streams; otherwise compaction jumps straight
+	// from started to done.
+	EventCompactProgress EventKind = "compact_progress"
+
+	// EventCompactDone fires once compaction finishes (or fails). Compact
+	// carries the before/after context estimates; when they are equal the
+	// compaction was a no-op (summarization failed or returned nothing) and the
+	// full history was kept. Observers should clear any compaction indicator.
+	EventCompactDone EventKind = "compact_done"
 )
 
 // EventToolOutputCap is the maximum length of the Output field emitted on
@@ -79,6 +100,9 @@ const EventToolOutputCap = 512
 //   - EventToolError:      ToolID, ToolName, Output (may be empty), Err
 //   - EventTurnDone:       Reply
 //   - EventSteerInjected:  Messages
+//   - EventCompactStarted:  Compact (BeforeTokens, FoldedMsgs, KeptTurns, MaxTokens)
+//   - EventCompactProgress: Chunk, Compact (SummaryTokens, MaxTokens)
+//   - EventCompactDone:     Compact (BeforeTokens, AfterTokens, FoldedMsgs)
 //
 // JSON tags are included so HTTP/SSE transports (M8 web server) can
 // marshal events directly without an intermediate type.
@@ -94,6 +118,26 @@ type AgentEvent struct {
 	Err        string         `json:"err,omitempty"`
 	Reply      *Reply         `json:"reply,omitempty"`
 	Messages   []string       `json:"messages,omitempty"`
+	Compact    *CompactStats  `json:"compact,omitempty"`
+}
+
+// CompactStats carries the numbers behind the compaction events. All counts
+// are heuristic token estimates (see estimateMessages), not exact provider
+// counts — they exist for a human-readable progress indicator, nothing more.
+type CompactStats struct {
+	// BeforeTokens is the estimated context size before compaction.
+	BeforeTokens int `json:"before_tokens,omitempty"`
+	// AfterTokens is the estimated context size after compaction (done only).
+	AfterTokens int `json:"after_tokens,omitempty"`
+	// FoldedMsgs is how many leading messages were folded into the summary.
+	FoldedMsgs int `json:"folded_msgs,omitempty"`
+	// KeptTurns is how many recent user turns were kept verbatim.
+	KeptTurns int `json:"kept_turns,omitempty"`
+	// SummaryTokens is the running estimate of the summary generated so far
+	// (progress only).
+	SummaryTokens int `json:"summary_tokens,omitempty"`
+	// MaxTokens is the summary's output-token cap, for a "N / max" readout.
+	MaxTokens int `json:"max_tokens,omitempty"`
 }
 
 // EventHandler is the callback type passed into Agent.RunStream. The handler

--- a/internal/agent/overflow.go
+++ b/internal/agent/overflow.go
@@ -72,7 +72,7 @@ func contextTooLongError(err error) bool {
 //
 // Layer 2 (aggressive): pull back ~half the history. Sacrifices cache but
 // guarantees the compression call fits.
-func (r *overflowRecovery) tryRecover(ctx context.Context, a *Agent, sendErr error) bool {
+func (r *overflowRecovery) tryRecover(ctx context.Context, a *Agent, sendErr error, handler EventHandler) bool {
 	if r.attempted || r.inProgress {
 		return false
 	}
@@ -85,12 +85,12 @@ func (r *overflowRecovery) tryRecover(ctx context.Context, a *Agent, sendErr err
 	defer func() { r.inProgress = false }()
 
 	// Layer 1: standard cache-preserving compression
-	if a.tryOverflowCompact(ctx, pullBackStandard) {
+	if a.tryOverflowCompact(ctx, pullBackStandard, handler) {
 		return true
 	}
 
 	// Layer 2: aggressive fallback
-	if a.tryOverflowCompact(ctx, pullBackAggressive) {
+	if a.tryOverflowCompact(ctx, pullBackAggressive, handler) {
 		return true
 	}
 
@@ -110,7 +110,7 @@ const (
 // tryOverflowCompact is the Layer 1/2 entry point for 400-recovery compression.
 // It pops K messages from tail, runs compression, then reattaches them.
 // Returns true if compression succeeded and history was rebuilt.
-func (a *Agent) tryOverflowCompact(ctx context.Context, pullBackMode int) bool {
+func (a *Agent) tryOverflowCompact(ctx context.Context, pullBackMode int, handler EventHandler) bool {
 	trigger := a.compactTriggerTokens()
 	if trigger <= 0 {
 		return false // compaction disabled
@@ -143,9 +143,20 @@ func (a *Agent) tryOverflowCompact(ctx context.Context, pullBackMode int) bool {
 		return false
 	}
 
+	before := estimateMessages(msgs)
+	if handler != nil {
+		handler(AgentEvent{Kind: EventCompactStarted, Compact: &CompactStats{
+			BeforeTokens: before,
+			FoldedMsgs:   split,
+			KeptTurns:    compactKeepTurns,
+			MaxTokens:    summarizeMaxTokens,
+		}})
+	}
+
 	// Run compression side-call on truncated history
-	summary, err := a.summarize(ctx, truncated.Snapshot()[:split])
+	summary, err := a.summarize(ctx, truncated.Snapshot()[:split], handler)
 	if err != nil || summary == "" {
+		emitCompactDone(handler, before, before, split) // no-op: clear the indicator
 		return false
 	}
 
@@ -162,6 +173,7 @@ func (a *Agent) tryOverflowCompact(ctx context.Context, pullBackMode int) bool {
 	}
 
 	a.lastInputTokens = 0 // reset trigger so we don't immediately re-compact
+	emitCompactDone(handler, before, estimateMessages(a.History.Snapshot()), split)
 	return true
 }
 


### PR DESCRIPTION
## Problem

When compaction triggered, `maybeCompact` ran `_ = a.maybeCompact(ctx)` completely silently — the agent talks to the TUI only through `AgentEvent`s, and there was no event kind for compaction. The conversation history just silently shrank, with no sign it was happening or how far along it was.

## Change

Surface compaction in the TUI as a live spinner with a streaming `~N / max tokens` readout and a summary preview, then a one-line completion notice with before/after context sizes.

**Agent layer**
- `event.go`: add `EventCompactStarted` / `EventCompactProgress` / `EventCompactDone` + a `CompactStats` struct (before/after token estimates, folded-message count, running summary tokens).
- `compaction.go`: thread an `EventHandler` through `maybeCompact` / `summarize`. The summary now **streams** via `StreamingSender` when available, firing `EventCompactProgress` per delta — surfaced as `EventCompactProgress` (carrying `Chunk`), **not** `EventTextDelta`, so the summary is never mistaken for the assistant's reply. `Done` always fires once `Started` has (even on failure) so the indicator can't get stuck.
- `overflow.go`: thread the handler through the 400-overflow recovery path too, so both compaction entry points report consistently.

**TUI**
- New `compacting` model state; `handleEvent` drives a dedicated spinner + rune-safe streaming preview, and prints `✦ compacted context · folded N message(s) · ~142.0k → ~38.0k tokens` on a real reduction (no-op clears silently).

**Scope: TUI-only** — plain/headless/server handlers consume only `EventTextDelta`, so they ignore the new kinds and the summary never leaks to stdout.

## Tests

- New `TestMaybeCompact_EmitsProgressEvents` (streaming fake) asserts started → progress(monotonic) → done with sane stats.
- `go test -race ./...`, `go vet ./...`, `gofmt -l .` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)