### PR TITLE
fix(tui): detect dropped image paths on Enter submit

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -401,6 +401,11 @@ func humanByteSize(n int) string {
 // submit acts on Enter. Idle → start a turn. Running → steer. Empty input
 // with no attachments is ignored.
 func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
+	// Last-chance catch for image file paths that were pasted/dropped into the
+	// textarea without triggering the per-keystroke detection (e.g. bracketed
+	// paste from a terminal drag-and-drop).
+	m.tryAttachDroppedImage()
+
 	text := strings.TrimSpace(m.ta.Value())
 	if text == "" && len(m.pendingAttachments) == 0 {
 		return m, nil


### PR DESCRIPTION
Terminal drag-and-drop emits bracketed paste, not tea.KeyMsg, so the per-keystroke tryAttachDroppedImage never fires. Add a last-chance call in submit() so pressing Enter catches image paths that were pasted into the textarea.