### PR TITLE
fix(tui): detect dropped images with spaces at drop time

### DIFF
--- a/cmd/octo/dropimage_test.go
+++ b/cmd/octo/dropimage_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// findImagePath must recognise a dropped image path in the shapes terminals
+// actually emit: bare, backslash-escaped spaces (macOS Terminal/iTerm drag),
+// quoted, and embedded in typed text. The regression that motivated the
+// rewrite: filenames with spaces (every macOS screenshot) were split at the
+// former-escaped space and never matched.
+func TestFindImagePath(t *testing.T) {
+	dir := t.TempDir()
+
+	plain := filepath.Join(dir, "shot.png")
+	withSpaces := filepath.Join(dir, "Screenshot 2026-06-03 at 12.00.00.png")
+	for _, p := range []string{plain, withSpaces} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A terminal escapes spaces with backslashes when a file is dragged in.
+	escaped := strings.ReplaceAll(withSpaces, " ", `\ `)
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare", plain, plain},
+		{"bare trailing space", plain + " ", plain},
+		{"escaped spaces", escaped, withSpaces},
+		{"escaped trailing space", escaped + " ", withSpaces},
+		{"single quoted", "'" + withSpaces + "'", withSpaces},
+		{"double quoted", `"` + withSpaces + `"`, withSpaces},
+		{"embedded in text", "please look at " + escaped + " and explain", withSpaces},
+		{"embedded plain", "see " + plain + " here", plain},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, start, end, ok := findImagePath(tc.in)
+			if !ok {
+				t.Fatalf("findImagePath(%q) returned ok=false, want path %q", tc.in, tc.want)
+			}
+			if got != tc.want {
+				t.Errorf("path = %q, want %q", got, tc.want)
+			}
+			if start < 0 || end > len(tc.in) || start >= end {
+				t.Errorf("range [%d,%d) out of bounds for %q", start, end, tc.in)
+			}
+		})
+	}
+}
+
+func TestFindImagePathMisses(t *testing.T) {
+	dir := t.TempDir()
+	notImage := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(notImage, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []string{
+		"",
+		"just some text with no path",
+		"a word ending in png but not a file",
+		notImage,                          // exists, but not an image
+		filepath.Join(dir, "missing.png"), // image ext, no file
+		"talk about screenshot.png that isn't here", // image ext, no file
+	}
+	for _, in := range cases {
+		if _, _, _, ok := findImagePath(in); ok {
+			t.Errorf("findImagePath(%q) = ok, want miss", in)
+		}
+	}
+}
+
+func TestIsUnescapedBoundary(t *testing.T) {
+	cases := []struct {
+		s    string
+		i    int
+		want bool
+	}{
+		{"a b", 1, true},   // plain space
+		{`a\ b`, 2, false}, // escaped space (odd backslashes)
+		{`a\\ b`, 3, true}, // escaped backslash then space (even)
+		{"a\tb", 1, true},  // tab
+		{"abc", 1, false},  // not whitespace
+	}
+	for _, tc := range cases {
+		if got := isUnescapedBoundary(tc.s, tc.i); got != tc.want {
+			t.Errorf("isUnescapedBoundary(%q, %d) = %v, want %v", tc.s, tc.i, got, tc.want)
+		}
+	}
+}

--- a/cmd/octo/dropimage_test.go
+++ b/cmd/octo/dropimage_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -23,34 +24,41 @@ func TestFindImagePath(t *testing.T) {
 		}
 	}
 
-	// A terminal escapes spaces with backslashes when a file is dragged in.
-	escaped := strings.ReplaceAll(withSpaces, " ", `\ `)
-
-	cases := []struct {
+	type tc struct {
 		name string
 		in   string
 		want string
-	}{
+	}
+	// Shapes that hold on every platform: bare paths, and spaced paths
+	// wrapped in quotes (how a Windows drag delivers spaces).
+	cases := []tc{
 		{"bare", plain, plain},
 		{"bare trailing space", plain + " ", plain},
-		{"escaped spaces", escaped, withSpaces},
-		{"escaped trailing space", escaped + " ", withSpaces},
 		{"single quoted", "'" + withSpaces + "'", withSpaces},
 		{"double quoted", `"` + withSpaces + `"`, withSpaces},
-		{"embedded in text", "please look at " + escaped + " and explain", withSpaces},
 		{"embedded plain", "see " + plain + " here", plain},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, start, end, ok := findImagePath(tc.in)
+	if runtime.GOOS != "windows" {
+		// POSIX shells backslash-escape spaces on drag; Windows uses '\' as
+		// the path separator, so this form is POSIX-only.
+		escaped := strings.ReplaceAll(withSpaces, " ", `\ `)
+		cases = append(cases,
+			tc{"escaped spaces", escaped, withSpaces},
+			tc{"escaped trailing space", escaped + " ", withSpaces},
+			tc{"embedded in text", "please look at " + escaped + " and explain", withSpaces},
+		)
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, start, end, ok := findImagePath(c.in)
 			if !ok {
-				t.Fatalf("findImagePath(%q) returned ok=false, want path %q", tc.in, tc.want)
+				t.Fatalf("findImagePath(%q) returned ok=false, want path %q", c.in, c.want)
 			}
-			if got != tc.want {
-				t.Errorf("path = %q, want %q", got, tc.want)
+			if got != c.want {
+				t.Errorf("path = %q, want %q", got, c.want)
 			}
-			if start < 0 || end > len(tc.in) || start >= end {
-				t.Errorf("range [%d,%d) out of bounds for %q", start, end, tc.in)
+			if start < 0 || end > len(c.in) || start >= end {
+				t.Errorf("range [%d,%d) out of bounds for %q", start, end, c.in)
 			}
 		})
 	}
@@ -79,20 +87,27 @@ func TestFindImagePathMisses(t *testing.T) {
 }
 
 func TestIsUnescapedBoundary(t *testing.T) {
-	cases := []struct {
+	type tc struct {
 		s    string
 		i    int
 		want bool
-	}{
-		{"a b", 1, true},   // plain space
-		{`a\ b`, 2, false}, // escaped space (odd backslashes)
-		{`a\\ b`, 3, true}, // escaped backslash then space (even)
-		{"a\tb", 1, true},  // tab
-		{"abc", 1, false},  // not whitespace
 	}
-	for _, tc := range cases {
-		if got := isUnescapedBoundary(tc.s, tc.i); got != tc.want {
-			t.Errorf("isUnescapedBoundary(%q, %d) = %v, want %v", tc.s, tc.i, got, tc.want)
+	cases := []tc{
+		{"a b", 1, true},  // plain space
+		{"a\tb", 1, true}, // tab
+		{"abc", 1, false}, // not whitespace
+	}
+	if runtime.GOOS != "windows" {
+		// Backslash only escapes on POSIX; on Windows it is a path separator
+		// and a following space is still a boundary.
+		cases = append(cases,
+			tc{`a\ b`, 2, false}, // escaped space (odd backslashes)
+			tc{`a\\ b`, 3, true}, // escaped backslash then space (even)
+		)
+	}
+	for _, c := range cases {
+		if got := isUnescapedBoundary(c.s, c.i); got != c.want {
+			t.Errorf("isUnescapedBoundary(%q, %d) = %v, want %v", c.s, c.i, got, c.want)
 		}
 	}
 }

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -266,64 +266,140 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// imageExts are the file extensions tryAttachDroppedImage recognises.
+var imageExts = []string{".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif", ".heic", ".ico"}
+
 // tryAttachDroppedImage checks whether the textarea currently contains an
 // image file path (some terminals paste a dragged file's path as text).  The
 // path may be surrounded by ordinary text, e.g. "look at /path/to/img.png and
-// tell me", and may contain escaped spaces ("\ ").  If a valid image file
-// path is found, it is removed from the textarea, queued as a pending
-// attachment, and true is returned.
+// tell me", may be backslash-escaped (terminal drag escapes spaces and parens),
+// or wrapped in quotes.  If a valid image file path is found, it is removed
+// from the textarea, queued as a pending attachment, and true is returned.
 func (m *tuiModel) tryAttachDroppedImage() bool {
 	full := m.ta.Value()
-	// Unescape common shell escapes so paths with spaces are whole.
-	unescaped := strings.ReplaceAll(full, `\ `, " ")
-	unescaped = strings.ReplaceAll(unescaped, `\(`, "(")
-	unescaped = strings.ReplaceAll(unescaped, `\)`, ")")
+	path, start, end, ok := findImagePath(full)
+	if !ok {
+		return false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	mime := "image/" + strings.TrimPrefix(ext, ".")
+	switch ext {
+	case ".jpg":
+		mime = "image/jpeg"
+	case ".tif":
+		mime = "image/tiff"
+	}
+	label := fmt.Sprintf("image (%s, %s)", shortMIME(mime), humanByteSize(len(data)))
+	m.pendingAttachments = append(m.pendingAttachments, pendingAttachment{
+		block: agent.NewImageBlock(mime, data),
+		label: label,
+	})
+	// Splice the path token out of the (original) textarea value.
+	before := strings.TrimSpace(full[:start])
+	after := strings.TrimSpace(full[end:])
+	if before != "" && after != "" {
+		m.ta.SetValue(before + " " + after)
+	} else {
+		m.ta.SetValue(before + after)
+	}
+	m.ta.CursorEnd()
+	return true
+}
 
-	// Scan for potential paths by looking for image extensions.
-	lower := strings.ToLower(unescaped)
-	for _, ext := range []string{".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif", ".heic", ".ico"} {
-		idx := strings.Index(lower, ext)
-		if idx == -1 {
-			continue
+// findImagePath scans s for a token that resolves to an existing image file. It
+// operates on the raw string (no early unescaping, so a backslash-escaped space
+// is not mistaken for a token boundary) and returns the cleaned filesystem path
+// plus the [start,end) byte range it occupies in s, so the caller can splice it
+// out. It first tries the whole trimmed input — the common case where a file is
+// dropped into an otherwise-empty box — which also catches quoted paths whose
+// internal spaces aren't backslash-escaped, then falls back to scanning for a
+// path embedded in surrounding text.
+func findImagePath(s string) (path string, start, end int, ok bool) {
+	if trimmed := strings.TrimSpace(s); trimmed != "" {
+		if clean := cleanDroppedPath(trimmed); hasImageExt(clean) {
+			if info, err := os.Stat(clean); err == nil && !info.IsDir() {
+				st := strings.Index(s, trimmed)
+				return clean, st, st + len(trimmed), true
+			}
 		}
-		// Extract the candidate path: walk back to the preceding space or
-		// start of string, and forward to the following space or end.
-		start := idx
-		for start > 0 && unescaped[start-1] != ' ' && unescaped[start-1] != '\t' && unescaped[start-1] != '\n' {
-			start--
+	}
+
+	lower := strings.ToLower(s)
+	for _, ext := range imageExts {
+		for from := 0; ; {
+			rel := strings.Index(lower[from:], ext)
+			if rel == -1 {
+				break
+			}
+			idx := from + rel
+			from = idx + len(ext)
+
+			e := idx + len(ext)
+			for e < len(s) && !isUnescapedBoundary(s, e) {
+				e++
+			}
+			st := idx
+			for st > 0 && !isUnescapedBoundary(s, st-1) {
+				st--
+			}
+			clean := cleanDroppedPath(s[st:e])
+			if !hasImageExt(clean) {
+				continue
+			}
+			if info, err := os.Stat(clean); err == nil && !info.IsDir() {
+				return clean, st, e, true
+			}
 		}
-		end := idx + len(ext)
-		for end < len(unescaped) && unescaped[end] != ' ' && unescaped[end] != '\t' && unescaped[end] != '\n' {
-			end++
+	}
+	return "", 0, 0, false
+}
+
+// isUnescapedBoundary reports whether s[i] is whitespace that is not escaped by
+// an odd number of preceding backslashes (so "\ " is treated as part of a path,
+// "\\ " as a real boundary).
+func isUnescapedBoundary(s string, i int) bool {
+	if c := s[i]; c != ' ' && c != '\t' && c != '\n' {
+		return false
+	}
+	bs := 0
+	for j := i - 1; j >= 0 && s[j] == '\\'; j-- {
+		bs++
+	}
+	return bs%2 == 0
+}
+
+// cleanDroppedPath strips one layer of matching surrounding quotes and removes
+// backslash escapes, turning a terminal-dropped token into a real filesystem
+// path.
+func cleanDroppedPath(raw string) string {
+	p := strings.TrimSpace(raw)
+	if len(p) >= 2 {
+		if (p[0] == '\'' && p[len(p)-1] == '\'') || (p[0] == '"' && p[len(p)-1] == '"') {
+			p = p[1 : len(p)-1]
 		}
-		path := strings.Trim(unescaped[start:end], `"'`)
-		info, err := os.Stat(path)
-		if err != nil || info.IsDir() {
-			continue
+	}
+	var b strings.Builder
+	b.Grow(len(p))
+	for i := 0; i < len(p); i++ {
+		if p[i] == '\\' && i+1 < len(p) {
+			i++
 		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			continue
+		b.WriteByte(p[i])
+	}
+	return b.String()
+}
+
+// hasImageExt reports whether path ends with a recognised image extension.
+func hasImageExt(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	for _, e := range imageExts {
+		if ext == e {
+			return true
 		}
-		mime := "image/" + strings.TrimPrefix(filepath.Ext(path), ".")
-		if filepath.Ext(path) == ".jpg" {
-			mime = "image/jpeg"
-		}
-		label := fmt.Sprintf("image (%s, %s)", shortMIME(mime), humanByteSize(len(data)))
-		m.pendingAttachments = append(m.pendingAttachments, pendingAttachment{
-			block: agent.NewImageBlock(mime, data),
-			label: label,
-		})
-		// Remove the path from the original (escaped) textarea value.
-		before := strings.TrimSpace(full[:start])
-		after := strings.TrimSpace(full[end:])
-		if before != "" && after != "" {
-			m.ta.SetValue(before + " " + after)
-		} else {
-			m.ta.SetValue(before + after)
-		}
-		m.ta.CursorEnd()
-		return true
 	}
 	return false
 }

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"time"
 	"unsafe"
@@ -358,12 +359,18 @@ func findImagePath(s string) (path string, start, end int, ok bool) {
 	return "", 0, 0, false
 }
 
-// isUnescapedBoundary reports whether s[i] is whitespace that is not escaped by
-// an odd number of preceding backslashes (so "\ " is treated as part of a path,
-// "\\ " as a real boundary).
+// isUnescapedBoundary reports whether s[i] is whitespace that delimits a path
+// token. On POSIX a backslash escapes the following space ("foo\ bar" is one
+// token), so a space preceded by an odd number of backslashes is not a
+// boundary; on Windows the backslash is the path separator, not an escape, so
+// every space is a boundary (spaced paths arrive quoted and are handled by the
+// whole-input fast path instead).
 func isUnescapedBoundary(s string, i int) bool {
 	if c := s[i]; c != ' ' && c != '\t' && c != '\n' {
 		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
 	}
 	bs := 0
 	for j := i - 1; j >= 0 && s[j] == '\\'; j-- {
@@ -372,15 +379,19 @@ func isUnescapedBoundary(s string, i int) bool {
 	return bs%2 == 0
 }
 
-// cleanDroppedPath strips one layer of matching surrounding quotes and removes
-// backslash escapes, turning a terminal-dropped token into a real filesystem
-// path.
+// cleanDroppedPath strips one layer of matching surrounding quotes and, on
+// POSIX, removes backslash escapes, turning a terminal-dropped token into a real
+// filesystem path. On Windows backslashes are path separators (spaces are
+// quoted, not escaped), so they are left intact.
 func cleanDroppedPath(raw string) string {
 	p := strings.TrimSpace(raw)
 	if len(p) >= 2 {
 		if (p[0] == '\'' && p[len(p)-1] == '\'') || (p[0] == '"' && p[len(p)-1] == '"') {
 			p = p[1 : len(p)-1]
 		}
+	}
+	if runtime.GOOS == "windows" {
+		return p
 	}
 	var b strings.Builder
 	b.Grow(len(p))

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -477,11 +477,6 @@ func humanByteSize(n int) string {
 // submit acts on Enter. Idle → start a turn. Running → steer. Empty input
 // with no attachments is ignored.
 func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
-	// Last-chance catch for image file paths that were pasted/dropped into the
-	// textarea without triggering the per-keystroke detection (e.g. bracketed
-	// paste from a terminal drag-and-drop).
-	m.tryAttachDroppedImage()
-
 	text := strings.TrimSpace(m.ta.Value())
 	if text == "" && len(m.pendingAttachments) == 0 {
 		return m, nil


### PR DESCRIPTION
## Problem

Dragging an image into the terminal showed the file **path as text** instead of becoming an attachment chip — the bug #346/#348/#351 kept circling but never closed.

Root cause was in `tryAttachDroppedImage`: it unescaped `\ ` to a real space **before** scanning for token boundaries, then split the candidate on spaces. Any dropped path with a space — every macOS screenshot, e.g. `Screenshot 2026-06-03 at 12.00.00.png` — got truncated to a fragment, `os.Stat` failed, and the path stayed in the box. The `start/end` indices were also computed on the unescaped string but used to splice the original, misaligning removal when escapes preceded the path.

#351's `submit()` fallback was a workaround for what was actually this spaces bug (misdiagnosed as "the key handler never fires" — bracketed paste does arrive as a `KeyMsg{KeyRunes, Paste:true}`).

## Fix

- Rewrite detection (`findImagePath`) to operate on the **raw** string with an escape-aware boundary check (`\ ` is part of the path, `\\ ` is a real boundary), plus a whole-input fast path that also handles quoted paths whose internal spaces aren't backslash-escaped.
- Conversion now happens **at drop time** (key-handler default branch), so the attachment chip appears the moment the file is dropped.
- Remove the `submit()` last-chance call — no longer needed and it only delayed conversion until Enter.

## Tests

`dropimage_test.go` covers bare / escaped-spaces / quoted / trailing-space / embedded-in-text paths, plus miss cases and the escape-aware boundary check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)