### PR TITLE
fix(server): serve SPA entrypoint directly so `octo serve` UI loads

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -149,14 +149,18 @@ func TestStaticHandler_IndexFallback(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.http.Handler.ServeHTTP(w, req)
 
-	// The static handler redirects / to /index.html (301) when the embedded
-	// static directory exists, or serves fallback HTML when it doesn't.
-	// Accept either 200 (fallback) or 301 (redirect to index.html).
-	if w.Code != http.StatusOK && w.Code != http.StatusMovedPermanently {
-		t.Fatalf("status = %d, want 200 or 301", w.Code)
+	// The static handler must serve the SPA entrypoint at "/" with a 200 and
+	// HTML body. It must never reply with a redirect: http.FileServer's
+	// "/index.html" → "./" canonicalisation would bounce "/" back to itself
+	// in an infinite loop, leaving the UI unable to load.
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
 	}
-	if w.Code == http.StatusOK && !strings.Contains(w.Body.String(), "Octo Agent Server") {
-		t.Fatal("expected fallback HTML")
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("Content-Type = %q, want text/html", ct)
+	}
+	if !strings.Contains(w.Body.String(), "<html") {
+		t.Fatalf("expected HTML body, got %q", w.Body.String())
 	}
 }
 

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -39,20 +39,24 @@ func (s *Server) staticHandler() http.Handler {
 			return
 		}
 
-		// Clean the path and try to open the file.
-		cleanPath := path.Clean(r.URL.Path)
-		if cleanPath == "/" {
-			cleanPath = "/index.html"
+		// Resolve the requested file. The root and any path that doesn't map
+		// to an embedded file are served the SPA entrypoint.
+		name := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
+		if name != "" {
+			if f, err := sub.Open(name); err == nil {
+				_ = f.Close()
+				fileServer.ServeHTTP(w, r)
+				return
+			}
 		}
 
-		_, err := sub.Open(strings.TrimPrefix(cleanPath, "/"))
-		if err != nil {
-			// File not found — serve index.html for SPA routing.
-			cleanPath = "/index.html"
-		}
-
-		r.URL.Path = cleanPath
-		fileServer.ServeHTTP(w, r)
+		// Serve index.html directly rather than rewriting the path to
+		// "/index.html" and delegating to fileServer: http.FileServer
+		// canonicalises any "/index.html" request with a 301 redirect to
+		// "./", which resolves back to "/" and loops forever. ServeFileFS
+		// keys its redirect off r.URL.Path (here "/" or an SPA route), so it
+		// serves the file without redirecting.
+		http.ServeFileFS(w, r, sub, "index.html")
 	})
 }
 


### PR DESCRIPTION
## Problem

`octo serve` opens but the browser never renders the UI — it hangs in an **infinite redirect loop**, broken since M8 (#287).

The static handler rewrote `/` → `/index.html` and handed it to `http.FileServer`. `http.FileServer` canonicalises any request ending in `/index.html` with a **301 redirect to `./`**. `./` resolves back to `/`, so the browser bounces `/` → `301 ./` → `/` → … forever.

The `static/` directory ships a placeholder `index.html`, so `fs.Sub` always succeeds and the dev fallback branch never runs. The original test accepted the 301 as a valid result (its comment shows the misunderstanding), so CI never caught it.

## Fix

`internal/server/static.go`:
- Real, existing static assets (`/app.js`, etc.) still go through `http.FileServer`.
- The root path and SPA-fallback routes are served via `http.ServeFileFS(w, r, sub, "index.html")`. `ServeFileFS` keys its redirect off `r.URL.Path` (here `/` or an SPA route — neither ends in `/index.html`), so it serves the entrypoint **without** the looping redirect.

`internal/server/server_test.go`: the assertion now requires `/` to return `200` + `text/html` and **never** redirect.

## Verification

- `make fmt-check`, `go vet`, `go test -race ./internal/server/` all pass.
- End-to-end against a real build:
  - `/` → `200` + HTML (loop gone)
  - `/some/spa/route` → `200` (SPA fallback)
  - `/index.html` → `301 ./` → `/` → `200` (standard canonicalisation, terminates — no loop)

## Note

`static/index.html` is still a placeholder (`<h1>Octo Web UI</h1>`); the real front-end bundle isn't built in yet. This PR only fixes the server correctly serving the page — the UI now opens. Shipping the actual Web UI assets is separate follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)