### PR TITLE
fix(agent): answer mid-turn steers in-turn so image attachments aren't dropped

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -206,6 +206,11 @@ func (s *tuiSink) Ask(ctx context.Context, p UserPrompt) (UserResponse, error) {
 
 type pendingItem struct {
 	text string
+	// blocks carries image attachments that rode a steer which wasn't drained
+	// in-loop (e.g. enqueued in the narrow window as a turn was ending). They
+	// are attached to the next user message via AttachUserBlocks on dequeue so
+	// the image is never silently dropped.
+	blocks []agent.ContentBlock
 }
 
 // ── model ──
@@ -403,6 +408,27 @@ func (m *tuiModel) startTurn(line string) tea.Cmd {
 	return m.startTurnEcho(line, line)
 }
 
+// pendingFromInbox folds drained inbox items into one follow-up turn item,
+// joining their text and collecting any image blocks so attachments survive the
+// requeue (the in-loop drain normally consumes steers first; this covers a
+// steer that raced in as the turn was ending).
+func pendingFromInbox(items []agent.InboxItem) pendingItem {
+	var blocks []agent.ContentBlock
+	for _, it := range items {
+		blocks = append(blocks, it.Blocks...)
+	}
+	return pendingItem{text: strings.Join(agent.Texts(items), "\n\n"), blocks: blocks}
+}
+
+// startQueued launches a dequeued follow-up turn, attaching any image blocks the
+// item carried so they ride the new user message rather than being dropped.
+func (m *tuiModel) startQueued(it pendingItem) tea.Cmd {
+	if len(it.blocks) > 0 {
+		m.a.AttachUserBlocks(it.blocks)
+	}
+	return m.startTurnEcho(it.text, "") // echo already shown when queued
+}
+
 // startTurnEcho launches a turn in a background goroutine driven by runTurn. The
 // sink streams events back as tea.Msgs; turnFinishedMsg fires when runTurn
 // returns so Update can save, drain steer, and dequeue. echo is the transcript
@@ -571,18 +597,18 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// notice that raced in via Inbox) starts immediately rather than
 			// waiting for turnFinishedMsg.
 			if items := m.a.Inbox.Drain(); len(items) > 0 {
-				s := strings.Join(agent.Texts(items), "\n\n")
-				for _, line := range strings.Split(s, "\n\n") {
-					if !strings.HasPrefix(line, "<system-reminder>") {
+				it := pendingFromInbox(items)
+				for _, line := range strings.Split(it.text, "\n\n") {
+					if line != "" && !strings.HasPrefix(line, "<system-reminder>") {
 						m.println(userEchoStyle.Render("> ") + line)
 					}
 				}
-				m.queue = append([]pendingItem{{text: s}}, m.queue...)
+				m.queue = append([]pendingItem{it}, m.queue...)
 			}
 			if len(m.queue) > 0 {
 				next := m.queue[0]
 				m.queue = m.queue[1:]
-				return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(next.text, ""))
+				return m, tea.Sequence(m.flushPrints(), m.startQueued(next))
 			}
 		}
 		// On a clean completion, ask for one follow-up suggestion (off the event
@@ -822,10 +848,16 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 		// Inbox drained mid-turn: print the steer messages to the scrollback
 		// immediately so they appear in chronological order (before the next
 		// assistant reply), and remove them from the pending live display.
-		// Skip <system-reminder> blocks — they are model-facing context, not
-		// user-visible transcript.
+		// First commit any buffered assistant text so the prior reply's trailing
+		// paragraph stays above the steer line (e.g. when a steer lands right
+		// after the model finished a text answer and the turn loops to answer it).
+		if s, ok := m.flushTextString(); ok {
+			m.println(s)
+		}
+		// Skip <system-reminder> blocks (model-facing context) and empty text
+		// (an image-only steer carries its payload in blocks, not Messages).
 		for _, s := range ev.Messages {
-			if !strings.HasPrefix(s, "<system-reminder>") {
+			if s != "" && !strings.HasPrefix(s, "<system-reminder>") {
 				m.println(userEchoStyle.Render("> ") + s)
 			}
 		}
@@ -957,20 +989,20 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 	// Drain any inbox messages that weren't consumed during the turn and
 	// run them as the next turn, ahead of explicitly-queued items.
 	if items := m.a.Inbox.Drain(); len(items) > 0 {
-		s := strings.Join(agent.Texts(items), "\n\n")
-		for _, line := range strings.Split(s, "\n\n") {
-			if !strings.HasPrefix(line, "<system-reminder>") {
+		it := pendingFromInbox(items)
+		for _, line := range strings.Split(it.text, "\n\n") {
+			if line != "" && !strings.HasPrefix(line, "<system-reminder>") {
 				m.println(userEchoStyle.Render("> ") + line)
 			}
 		}
-		m.queue = append([]pendingItem{{text: s}}, m.queue...)
+		m.queue = append([]pendingItem{it}, m.queue...)
 	}
 
 	// Dequeue the next pending turn, if any.
 	if len(m.queue) > 0 {
 		next := m.queue[0]
 		m.queue = m.queue[1:]
-		return m, m.startTurnEcho(next.text, "") // echo already shown above
+		return m, m.startQueued(next)
 	}
 	return m, nil
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -630,6 +630,17 @@ func (a *Agent) runLoop(
 		}
 		a.History.Append(NewAssistantMessage(content))
 		reply.Content = content
+
+		// A mid-turn steer (text and/or pasted images) arrived while the model
+		// was producing this answer. Don't end the turn: loop so the next
+		// iteration drains it into history and the model responds in-turn,
+		// rather than stranding it for the front-end to re-queue as a fresh
+		// turn (which would drop any image blocks). EventTurnDone stays
+		// once-only — it fires only when we actually return below.
+		if a.Inbox.HasPending() {
+			continue
+		}
+
 		if handler != nil {
 			r := reply
 			handler(AgentEvent{Kind: EventTurnDone, Reply: &r})

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -250,6 +250,9 @@ type fakeToolSender struct {
 	// gotTools / gotMsgs capture the last tool-aware call's inputs.
 	gotTools []ToolDefinition
 	gotMsgs  []Message
+	// onCall, when set, runs just before each reply is returned, receiving the
+	// 0-based call index. Used to simulate a steer arriving mid-turn.
+	onCall func(callIdx int)
 }
 
 func (f *fakeToolSender) SendMessages(_ context.Context, _, _ string, msgs []Message, maxTokens int) (Reply, error) {
@@ -267,6 +270,9 @@ func (f *fakeToolSender) SendMessagesWithTools(_ context.Context, _, _ string, m
 }
 
 func (f *fakeToolSender) nextReply() (Reply, error) {
+	if f.onCall != nil {
+		f.onCall(f.calls)
+	}
 	if f.calls < len(f.errs) && f.errs[f.calls] != nil {
 		err := f.errs[f.calls]
 		f.calls++

--- a/internal/agent/steer_midturn_test.go
+++ b/internal/agent/steer_midturn_test.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+// A mid-turn steer that arrives while the model is producing its FINAL answer
+// (no further tool calls) must be answered within the same turn — drained into
+// history and sent — rather than stranded for the front-end to re-queue (which
+// historically dropped any image blocks). Covers the three steer shapes the
+// feature must support: image-only, text-only, and multiple images.
+func TestAgent_MidTurnSteer_AnsweredInTurn(t *testing.T) {
+	img1 := NewImageBlock("image/png", []byte("one"))
+	img2 := NewImageBlock("image/jpeg", []byte("two"))
+
+	cases := []struct {
+		name        string
+		steerText   string
+		steerBlocks []ContentBlock
+		// wantImgs is how many image blocks the injected user message must carry.
+		wantImgs int
+		// wantText is the text block the injected user message must carry ("" = none).
+		wantText string
+	}{
+		{"image only", "", []ContentBlock{img1}, 1, ""},
+		{"text only", "and the logs?", nil, 0, "and the logs?"},
+		{"multiple images", "compare these", []ContentBlock{img1, img2}, 2, "compare these"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			send := &fakeToolSender{
+				replies: []Reply{
+					{Content: "first answer", StopReason: "end_turn"},
+					{Content: "answer to the steer", StopReason: "end_turn"},
+				},
+			}
+			a := New(send, "m")
+			// Enqueue the steer the moment the model returns its first (final)
+			// answer — i.e. after call 0 has produced its reply.
+			send.onCall = func(idx int) {
+				if idx == 0 {
+					a.Inbox.EnqueueWithBlocks(c.steerText, c.steerBlocks)
+				}
+			}
+
+			// A tool def routes Run through runLoop (the steer-drain path); the
+			// replies are end_turn, so no tool is actually invoked.
+			defs := []ToolDefinition{{Name: "bash", Description: "run shell"}}
+			reply, err := a.Run(context.Background(), "first question", defs, &fakeExecutor{})
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+
+			// The turn must not end on the first answer; it loops to answer the steer.
+			if reply.Content != "answer to the steer" {
+				t.Fatalf("final Content = %q, want the steer to have been answered in-turn", reply.Content)
+			}
+			// Both sends happened (the steer triggered a second round).
+			if send.calls != 2 {
+				t.Fatalf("sender called %d times, want 2", send.calls)
+			}
+
+			// History: user(q), assistant(first), user(steer), assistant(final).
+			snap := a.History.Snapshot()
+			if len(snap) != 4 {
+				t.Fatalf("History len = %d, want 4: %+v", len(snap), snap)
+			}
+			steerMsg := snap[2]
+			if steerMsg.Role != RoleUser {
+				t.Fatalf("snap[2] role = %q, want user", steerMsg.Role)
+			}
+			gotImgs, gotText := 0, ""
+			for _, b := range steerMsg.Blocks {
+				switch b.Type {
+				case "image":
+					gotImgs++
+				case "text":
+					gotText = b.Text
+				}
+			}
+			// A text-only steer is appended as a plain string message (no Blocks).
+			if len(steerMsg.Blocks) == 0 {
+				gotText = steerMsg.Content
+			}
+			if gotImgs != c.wantImgs {
+				t.Errorf("injected image blocks = %d, want %d (blocks: %+v)", gotImgs, c.wantImgs, steerMsg.Blocks)
+			}
+			if gotText != c.wantText {
+				t.Errorf("injected text = %q, want %q", gotText, c.wantText)
+			}
+
+			// The inbox is empty after the loop consumed the steer.
+			if a.Inbox.HasPending() {
+				t.Errorf("inbox still has pending items after the turn")
+			}
+		})
+	}
+}
+
+// With no mid-turn steer, the turn ends on the first answer exactly as before
+// (the HasPending check must not perturb the common path).
+func TestAgent_NoSteer_EndsNormally(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{{Content: "done", StopReason: "end_turn"}},
+	}
+	a := New(send, "m")
+	reply, err := a.Run(context.Background(), "q", nil, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.Content != "done" {
+		t.Errorf("Content = %q", reply.Content)
+	}
+	if send.calls != 1 {
+		t.Errorf("sender called %d times, want 1", send.calls)
+	}
+}


### PR DESCRIPTION
## Problem (review of #349)

A mid-turn steer carrying images (`EnqueueWithBlocks`) was only delivered if the model happened to make **another tool call** after the steer arrived — that's the only time the agent loop reaches its top-of-iteration inbox drain. When the steer landed while the model was producing its **final text answer** (the common case), the loop returned, and the TUI's leftover-drain re-queued it as text via `agent.Texts()`, **silently dropping the image blocks**. An image-only steer became an empty follow-up turn.

## Fix (approach B — fix it in the agent core)

- **`agent.go`** — before ending the turn, if `Inbox.HasPending()`, loop instead of returning so the steer (text and/or images) is drained into history and answered **within the same turn**. `EventTurnDone` stays once-only (fires only on the real return). No infinite loop: the top-of-loop drain empties the inbox; bounded by the turn limit.
- **`tuirepl.go` `EventSteerInjected`** — flush buffered assistant text before printing the steer line (keeps "answer → steer → next answer" in order), and skip empty text (image-only steers carry their payload in blocks, not `Messages`).
- **`tuirepl.go`** — carry image blocks through `pendingItem` and re-attach them on dequeue (`AttachUserBlocks`), closing the narrow race where a steer enqueued exactly as the turn ends still reaches the leftover-drain.

## Tests

`steer_midturn_test.go` drives `runLoop` with a steer enqueued the moment the model returns its first answer, asserting it's answered in-turn with the right blocks for the three shapes the feature must support:
- **image-only** (no text)
- **text-only** (no image)
- **multiple images**

plus a no-steer control that ends normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)