### PR TITLE
feat(skills): add update_config and product_help default skills

### DIFF
--- a/internal/skills/defaults/product_help/CLI.md
+++ b/internal/skills/defaults/product_help/CLI.md
@@ -1,0 +1,44 @@
+# octo CLI Reference
+
+## Commands
+
+### `octo chat [prompt]`
+Start an interactive REPL session or run a single prompt and exit.
+
+Flags:
+- `--provider` — Override the default provider (`anthropic` or `openai`)
+- `--model` — Override the default model
+- `--system` — Path to a custom system-prompt file
+- `--reasoning-effort low|medium|high` — Enable extended reasoning
+- `--no-reasoning` — Disable reasoning trace display
+
+### `octo config [subcommand]`
+Manage persisted configuration (`~/.octo/config.json`).
+
+Subcommands:
+- `setup` / `init` (default) — Interactive wizard to set provider, model, and options
+- `show` / `get` — Display current effective configuration and where each value comes from
+- `path` — Print the config file path
+
+### `octo skills [subcommand]`
+Manage skills.
+
+Subcommands:
+- `list` — List available skills (default, user, project)
+- `path` — Show skill search paths
+- `update` — Refresh default skills from the binary
+
+### `octo serve`
+Start the web UI server.
+
+### `octo version`
+Print version information.
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `OCTO_PROVIDER` | Default provider (`anthropic` or `openai`) |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` | API key for the respective provider |
+| `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` | Custom endpoint URL |
+| `ANTHROPIC_MODEL` / `OPENAI_MODEL` | Default model override |

--- a/internal/skills/defaults/product_help/CONFIG.md
+++ b/internal/skills/defaults/product_help/CONFIG.md
@@ -1,0 +1,42 @@
+# octo Configuration Reference
+
+## Config file
+
+Path: `~/.octo/config.json`
+
+Created interactively via `octo config` or edited directly.
+
+## Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `provider` | string | `"anthropic"` or `"openai"` |
+| `model` | string | Model name (e.g. `claude-sonnet-4-20250514`, `gpt-4.1`) |
+| `base_url` | string | Optional custom API endpoint |
+| `permission_mode` | string | `"strict"`, `"confirm"`, or `"auto"` |
+| `coauthor` | bool | Append `Co-authored-by` to git commits |
+| `show_reasoning` | bool | Stream reasoning/thinking traces to terminal |
+| `reasoning_effort` | string | `"low"`, `"medium"`, `"high"`, or `""` (off) |
+| `api_key` | string | Plaintext fallback (discouraged — use env var instead) |
+
+## Precedence
+
+CLI flags (`--provider`, `--model`, etc.) > env vars (`OCTO_PROVIDER`, `ANTHROPIC_API_KEY`, etc.) > config file > built-in defaults.
+
+## Permission modes
+
+- **strict** — Block risky operations (file overwrites outside worktrees, shell commands that modify system state, etc.). The agent must ask for explicit approval.
+- **confirm** — Ask before executing any tool that has side effects (default behavior).
+- **auto** — Run without asking. Useful for trusted, repetitive workflows. Use with caution.
+
+## Example
+
+```json
+{
+  "provider": "anthropic",
+  "model": "claude-sonnet-4-20250514",
+  "coauthor": true,
+  "show_reasoning": true,
+  "reasoning_effort": "medium"
+}
+```

--- a/internal/skills/defaults/product_help/MCP.md
+++ b/internal/skills/defaults/product_help/MCP.md
@@ -1,0 +1,115 @@
+# MCP (Model Context Protocol) Configuration
+
+octo supports MCP servers that expose external tools, resources, and prompts to the agent. MCP servers are configured via JSON and loaded on session start.
+
+## Config files
+
+Two files are read and merged:
+
+| File | Scope |
+|------|-------|
+| `~/.octo/mcp.json` | User-global — shared across all projects |
+| `<project>/.octo/mcp.json` | Project-local — overrides user-global by server name |
+
+Missing files are silently ignored. Project-local entries with the same name as a user-global entry win.
+
+## Config format
+
+```json
+{
+  "mcpServers": {
+    "server-name": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      "env": {"FOO": "bar"}
+    },
+    "remote-api": {
+      "url": "https://example.com/mcp",
+      "headers": {"Authorization": "Bearer ..."},
+      "auth": "oauth"
+    }
+  }
+}
+```
+
+## Server types
+
+### stdio (local subprocess)
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `command` | yes | Executable to spawn |
+| `args` | no | Arguments passed to the command |
+| `env` | no | Extra environment variables |
+
+Example: filesystem server via npx
+```json
+{
+  "mcpServers": {
+    "fs": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/me/projects"]
+    }
+  }
+}
+```
+
+### HTTP (remote endpoint)
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | yes | MCP endpoint URL |
+| `headers` | no | Extra HTTP headers |
+| `auth` | no | `"oauth"` for device-flow OAuth, or omit |
+
+Example: remote API with OAuth
+```json
+{
+  "mcpServers": {
+    "my-api": {
+      "url": "https://api.example.com/mcp",
+      "auth": "oauth"
+    }
+  }
+}
+```
+
+## Auth strategies
+
+- `""` (default) — No automatic auth. Pass tokens manually via `headers`.
+- `"oauth"` — Runs RFC-compliant device-flow OAuth on first connect and on every 401. Tokens are cached at `~/.octo/mcp-tokens/<server>.json`.
+
+## Disabling a server
+
+Add `"disabled": true` to keep the config but skip loading it:
+
+```json
+{
+  "mcpServers": {
+    "broken": {
+      "command": "npx",
+      "args": ["-y", "@some/broken-server"],
+      "disabled": true
+    }
+  }
+}
+```
+
+## Verification
+
+After editing `mcp.json`, start `octo chat` and look for the startup line:
+
+```
+Connected 2 MCP servers: fs, my-api
+```
+
+If a server fails to connect, the error is printed to stderr and that server is skipped — the session continues with the others.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `command not found` | Ensure the binary is on `$PATH` or use an absolute path |
+| `connection refused` | Check the URL and network; verify the server is running |
+| OAuth loop | Delete `~/.octo/mcp-tokens/<server>.json` to force re-auth |
+| Server not appearing | Check JSON syntax; validate with `python3 -m json.tool mcp.json` |

--- a/internal/skills/defaults/product_help/MEMORY.md
+++ b/internal/skills/defaults/product_help/MEMORY.md
@@ -1,0 +1,113 @@
+# Cross-session memory
+
+octo's memory is a per-repo directory of plain markdown that the agent manages
+with its own file tools — the Claude Code model. There is no dedicated
+remember/forget tool, no typed-entry store, and no code-driven consolidation:
+the agent reads, writes, edits, and deletes memory files directly, so editing
+and deletion are first-class and instant.
+
+This is the agent's *automatic* layer. The *hand-written* layers — `~/.octo/soul.md`,
+`~/.octo/user.md`, `~/.octo/octorules.md`, and per-repo `.octorules` — are
+separate and described in `identity-files-design.md`.
+
+## Layout
+
+```
+~/.octo/memory/<repo-slug>/
+  MEMORY.md      index, injected into the system prompt every session
+  <topic>.md     detail files the agent creates and reads on demand
+```
+
+- **Per repo.** The directory is keyed by the git top-level of the working
+  directory (`memory.ProjectRoot`), so each project has its own memory and
+  facts don't bleed across repos. Outside a git repo the working directory is
+  used. The slug is the repo basename plus a short hash of the full path, so two
+  checkouts that share a basename don't collide.
+- **MEMORY.md is the index.** It is loaded into the system prompt at session
+  start, truncated to the first 200 lines / 25 KB (whichever comes first),
+  mirroring Claude Code's cap. Topic files are not loaded up front — the agent
+  reads them on demand with its file tools when MEMORY.md points at one.
+
+## Injection
+
+At session start `cmd/octo` resolves the directory, creates it, and injects
+`memory.RenderInjection(dir)` into the composed system prompt (the `memory`
+layer of `prompt.Compose`). The injection is a short instruction block —
+*where* memory lives and *how* to manage it — followed by the current MEMORY.md
+(or an "empty" marker so a fresh project knows where to start). The notes are
+framed as the agent's own durable record of the user's preferences, workflow
+rules, and project facts, to be followed as standing guidance; the current user
+request and safety override a conflicting note. The block is frozen for the
+session: what the agent writes now surfaces in the *next* session, not the
+current one.
+
+The session-prompt guidance (`internal/prompt/base.md`, "Memory" section)
+covers when to save (lasting preferences, corrections + the why, validated
+judgment, external resources), what not to save (one-off task state, anything
+derivable from the repo, secrets), grounding answers in memory with a brief
+inline attribution, and verifying a remembered file/flag still exists before
+acting on it.
+
+## Attention layer — structured rules, re-surfaced at the point of action
+
+A note buried in the frozen system-prompt block is easy for the model to skim
+past by the time it matters, many turns later. MEMORY.md may therefore carry two
+optional sections whose rules are written **in full** (not as pointer links) and
+re-surfaced on the message stream when they're relevant:
+
+```
+## 必须遵守        always-apply rules — restated every turn
+## 触发提醒        each bullet "(触发: kw1, kw2) rule text" — recalled on a keyword hit
+```
+
+`memory.ParseRules` extracts these tiers (section headings are matched by
+keyword — `必须遵守`/`always`, `触发`/`trigger` — tolerant of emoji and heading
+level). `memory.Injector.Reminder` renders the per-turn `<system-reminder>`:
+always-apply rules on every turn, plus any triggered rules whose keywords occur
+in the user input, each surfaced at most once per session. Trigger matching is
+deliberately conservative and one-directional — *input contains trigger* —
+with ASCII keywords matched on word boundaries (`deploy` does not fire on
+`deployment`) and CJK keywords matched as substrings (`部署` fires inside
+`帮我部署一下`).
+
+`cmd/octo` builds the injector once per session and wires it as
+`agent.UserInputHook`, which folds the reminder into the user message at the
+single `History.Append` choke point in `Turn`/`TurnStream`/`runLoop` (one
+appended message, so the error-path `popLast` rollback still removes exactly one
+turn). The reminder rides the message stream rather than the system prompt, so
+the cached prompt prefix stays byte-stable across the session.
+
+A MEMORY.md without these sections — the plain pointer-index format — parses to
+zero rules, sets no hook, and behaves exactly as before.
+
+## Writing — file tools, whitelisted directory
+
+The agent saves with `write_file` (append to MEMORY.md or a topic file), edits
+with `edit_file`, and removes with `terminal` (`rm`/`mv`). The memory directory
+lives outside the working directory, where the permission engine's default
+`write_file`/`edit_file` rules only auto-allow `$CWD/**`. So `cmd/octo` passes
+the directory to `permission.New(..., allowWriteRoots...)`, which prepends an
+`allow { path: [<memDir>, <memDir>/**] }` rule to those tools — the agent
+manages its memory without a prompt on every save, while CWD and
+secret-path rules still apply everywhere else.
+
+## Inspecting
+
+- `octo memory list` — list the project's memory files; `octo memory path` —
+  print the directory.
+- `/memory` in the TUI — the same listing.
+
+These are viewers/locators only; the files are the source of truth and the
+agent owns them.
+
+## Why this shape
+
+The earlier design was a typed one-file-per-fact store written through a
+`remember` tool and folded into consolidated summaries by a background
+sub-agent. It had no way to remove a fact once consolidated — a wrong or
+obsolete entry lived in the summary prose with no addressable handle, re-injected
+every session. The file model removes that gap by construction: memory is just
+files, so correcting or forgetting is an ordinary edit or delete. It also drops
+a large amount of machinery (typed entries, summaries, state, archive, git
+auto-commit, the remember/forget tools, the per-turn nudge) in favour of the
+tools the agent already has.

--- a/internal/skills/defaults/product_help/PERMISSIONS.md
+++ b/internal/skills/defaults/product_help/PERMISSIONS.md
@@ -1,0 +1,92 @@
+# Permission System
+
+octo's permission engine gates every tool call through a rule-driven decision engine. Each invocation is evaluated against an ordered list of rules; the first matching rule wins. If no rule matches, the implicit default is `ask`.
+
+## Modes
+
+The engine runs in one of three modes, selectable at startup or cycled at runtime:
+
+| Mode | Behavior | Best for |
+|------|----------|----------|
+| **interactive** | `ask` → prompt the user for approval | CLI default — safe and usable |
+| **strict** | `ask` → deny automatically | Non-interactive callers (HTTP server, IM bridge) |
+| **auto** | `ask` → allow automatically | Trusted, repetitive workflows — use with caution |
+
+Cycle modes in the TUI with **Shift+Tab**.
+
+## Rule format
+
+Rules are defined in `~/.octo/permissions.yml` (user overrides) and an embedded `defaults.yml` (base layer). The YAML schema:
+
+```yaml
+tool_name:
+  - allow: { pattern: "substring" }
+  - deny:  { pattern: "substring" }
+  - ask:   { pattern: "substring" }
+```
+
+Rules are scanned in order; the first match wins. A tool with no matching rules falls through to the implicit `ask`.
+
+### Rule axes
+
+| Axis | Applies to | Syntax |
+|------|-----------|--------|
+| `pattern` | `terminal` — substring match against the command string | Plain string, case-sensitive |
+| `path` | `write_file`, `edit_file`, `read_file` — glob match against file path | Glob with `**` for recursive dirs; `$CWD` expands to working directory |
+| `hostname` | `web_fetch` — glob match against URL host | `*` matches a single DNS label |
+
+### Pattern refinements
+
+- A pattern ending in `/` or `~` (filesystem root marker) only matches when that marker ends an argument. So `deny: rm -rf /` blocks `rm -rf /` and `rm -rf /*` but **not** `rm -rf /path/under`.
+- Empty pattern (`""`) matches unconditionally — used for default allow/deny on pattern-free tools.
+
+## Default rules (excerpt)
+
+```yaml
+terminal:
+  - deny:  { pattern: "rm -rf /" }
+  - deny:  { pattern: "rm -rf ~" }
+  - ask:   { pattern: "rm -rf" }
+  - ask:   { pattern: "sudo " }
+  - ask:   { pattern: "curl " }
+  - allow: { pattern: "ls" }
+  - allow: { pattern: "git status" }
+  - allow: { pattern: "go test" }
+
+write_file:
+  - deny:  { path: ["**/.ssh/**", "**/.env", "**/id_rsa*"] }
+  - allow: { path: ["$CWD/**"] }
+
+web_fetch:
+  - deny:  { hostname: ["10.*", "192.168.*", "127.*", "localhost"] }
+  - allow: { hostname: ["github.com", "*.github.com", "go.dev"] }
+```
+
+## Session memory
+
+When the user answers a permission prompt, they can choose:
+- **y** — allow this once
+- **a** — allow for the rest of this session (remembered until exit)
+- **n / Esc** — deny this once
+
+Session-remembered decisions are keyed by a hash of (tool, input), so identical calls short-circuit without re-prompting.
+
+## Custom rules
+
+Create `~/.octo/permissions.yml` to override defaults per-tool:
+
+```yaml
+terminal:
+  - allow: { pattern: "docker " }   # auto-allow docker commands
+  - deny:  { pattern: "docker system prune" }  # except this one
+```
+
+User rules **fully replace** the default rule list for that tool (not append). To keep defaults and add extras, copy the defaults and edit.
+
+## Denial messages
+
+When a tool call is denied, the engine returns a structured reason that the LLM sees, so it can explain to the user instead of failing silently:
+
+- `permission_denied: terminal matched deny rule (pattern: "rm -rf /")`
+- `permission_denied: write_file matched deny rule (path: [**/.ssh/**])`
+- `permission_denied: web_fetch — no matching rule in strict mode (implicit ask → deny)`

--- a/internal/skills/defaults/product_help/README.md
+++ b/internal/skills/defaults/product_help/README.md
@@ -1,0 +1,231 @@
+# octo-agent
+
+[![Go CI](https://img.shields.io/github/actions/workflow/status/Leihb/octo-agent/go.yml?label=ci&style=flat-square)](https://github.com/Leihb/octo-agent/actions)
+[![Website](https://img.shields.io/badge/website-octo--agent.dev-4f46e5?style=flat-square)](https://octo-agent.dev)
+[![Go](https://img.shields.io/badge/go-%3E%3D%201.22-00ADD8?style=flat-square)](https://go.dev)
+[![License](https://img.shields.io/badge/license-MIT-lightgrey?style=flat-square)](LICENSE.txt)
+
+<p align="center">
+  <a href="README.md">English</a> · <a href="README_CN.md">简体中文</a>
+</p>
+
+A functionality-first AI agent, distributed as a single Go binary. Speaks two native API protocols — **Anthropic Messages** and **OpenAI Chat Completions** — and works against any compatible third party (DeepSeek, Kimi, Bailian, OpenRouter, vLLM, …). Aims for three equal interfaces: **CLI**, **Web**, and **IM**.
+
+## Status
+
+> **Pre-1.0.** All three interfaces are live: the CLI (an interactive TUI in a terminal, a headless agentic one-shot everywhere else), a local web server (`octo serve`), and an IM bridge (`octo channel`, WeChat iLink). On top of the agent loop there are skills, MCP clients, OS-level sandboxing, persistent memory, sub-agents, and a task graph for autonomous multi-step goals.
+
+## Install
+
+**Prebuilt binary (no Go toolchain needed).** Grab the archive for your OS/arch
+from the [latest release](https://github.com/Leihb/octo-agent/releases/latest),
+unpack it, and put `octo` on your `PATH`:
+
+```bash
+# macOS (Apple Silicon) example — swap the asset name for your platform
+curl -sSL https://github.com/Leihb/octo-agent/releases/latest/download/octo_<version>_darwin_arm64.tar.gz | tar xz
+sudo mv octo /usr/local/bin/
+octo version
+```
+
+Archives ship for linux / darwin / windows on amd64 + arm64; `checksums.txt`
+in each release verifies the download.
+
+**From Go:**
+
+```bash
+go install github.com/Leihb/octo-agent/cmd/octo@latest
+```
+
+**From source:**
+
+```bash
+git clone https://github.com/Leihb/octo-agent.git
+cd octo-agent
+make build       # produces ./octo
+```
+
+## Quick start
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...      # or OPENAI_API_KEY=...
+
+# One-time setup: save your default provider/model (skip the export above next time)
+octo config
+
+# Headless one-shot (claude -p style): one prompt → full agentic tool loop → exit.
+# Built-in tools (shell, read/edit files, search), MCP servers, and skills are
+# all on by default, so a single message can actually do work.
+octo chat "Add a --json flag to 'octo config show' and run the tests"
+
+# The prompt can also come from a pipe or a file — handy for scripts / CI:
+echo "Summarise what changed in the last commit" | octo chat
+octo chat --prompt-file ./task.md
+
+# Interactive multi-turn: run octo in a terminal with no message to get the TUI
+# (rich tool cards, session auto-saved). Resume a previous session with -c.
+octo chat
+octo chat --list-sessions
+octo chat -c <session-id>
+
+# Streaming on by default; --stream=false buffers and prints only the final
+# reply text (clean for capturing into a file).
+octo chat --stream=false "..."
+
+# OpenAI / DeepSeek / Bailian (OpenAI-compatible)
+octo chat --provider openai --model gpt-4o-mini "..."
+
+# Anthropic-compatible third parties (DeepSeek, Kimi, etc.)
+ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic \
+  octo chat --model deepseek-chat "..."
+
+# Extended reasoning: set the intensity (Anthropic thinking / OpenAI reasoning_effort)
+# and stream the dimmed thinking trace. --show-reasoning=false hides the trace.
+octo chat --reasoning-effort high "..."
+
+# Plain chat with no tools / MCP / skills
+octo chat --no-tools "..."
+
+# Sandbox the tool commands: confine the terminal tool to the project dir + tmp, no network
+octo chat --sandbox "..."
+
+# Generate a .octorules guide for this repo
+octo init
+
+# List discovered skills
+octo chat --list-skills
+
+# Web server + dashboard (binds localhost by default)
+octo serve --addr 127.0.0.1:8080
+
+# IM bridge (WeChat iLink): scan-to-login, then run the daemon
+octo channel login
+octo channel start
+
+# Autonomous long-horizon goal: plan into a subtask DAG and run it to completion
+octo conduct "Add a --json flag to octo config show"
+octo conduct status <id>
+```
+
+## Configuration
+
+Octo composes its system prompt from several optional layers (later overrides earlier):
+
+- `~/.octo/soul.md` — agent identity & behavior, an openclaw/hermes-style persona.
+- `~/.octo/user.md` — who you are; a profile injected into every session.
+- `~/.octo/octorules.md` — your global, cross-project rules and preferences.
+- `.octorules` — per-repo conventions, committed with the project. Generate one with `octo init` (or `/init` in the TUI).
+- `--system "..."` — a one-off override for a single run.
+
+The identity and rule files support `@include path/to/fragment.md` to pull in shared content.
+
+### Reasoning
+
+Reasoning models can deliberate before answering. Two knobs control it, both available as CLI flags and as `octo config` defaults:
+
+- `--reasoning-effort low|medium|high` — the intensity. OpenAI-protocol backends receive it as `reasoning_effort`; Anthropic-protocol backends map it to an extended-thinking token budget. Empty (the default) means off.
+- `--show-reasoning` (default on) — stream the thinking trace to the terminal, dimmed. `--show-reasoning=false` keeps reasoning enabled but hides the trace.
+
+This unifies Anthropic `thinking` blocks and OpenAI `reasoning_content` behind one pair of controls.
+
+### Defaults (`octo config`)
+
+`octo config` saves your default provider, model, (optionally) base URL, and reasoning settings to `~/.octo/config.json`, so a bare `octo chat` works without re-typing `--provider`/`--model` every time:
+
+```bash
+octo config        # interactive wizard
+octo config show   # print the effective settings + where each comes from
+octo config path   # print the file location
+```
+
+Precedence is **CLI flag > env var > `~/.octo/config.json` > built-in default**. API keys are read from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` first; the wizard can store one in the file (mode `0600`), but the env var is recommended.
+
+## Skills
+
+Skills are reusable instruction sets in Claude Code's SKILL.md format, discovered from:
+
+- `~/.octo/skills/<name>/SKILL.md` — user-level, across all projects.
+- `.octo/skills/<name>/SKILL.md` — project-level (takes precedence over user-level).
+
+The format is identical to Claude Code's, so you can symlink `~/.claude/skills` to `~/.octo/skills` and reuse what you already have. Each `SKILL.md` is YAML frontmatter plus a markdown body:
+
+```markdown
+---
+name: review
+description: Review the current diff for correctness and style
+---
+Walk the diff hunk by hunk and flag correctness bugs first, then style.
+```
+
+At session start Octo lists each skill's name and description in the system prompt; the model loads a skill's full instructions on demand (via the `skill` tool) when a task matches. You can also trigger one explicitly — `octo chat --list-skills` to see what's discovered, then `/skills` to list and `/<name>` (e.g. `/review`) to run one in the TUI.
+
+## Sandboxing
+
+`--sandbox` confines the `terminal` tool to the project directory plus temp, with no network, enforced by the OS (macOS Seatbelt, Linux Landlock + seccomp). It's off by default and fails closed when the OS mechanism is unavailable.
+
+```bash
+octo chat --sandbox                              # confine, deny network
+octo chat --sandbox --sandbox-allow-net          # allow network
+octo chat --sandbox --sandbox-write ./build      # extra writable dir (repeatable)
+octo chat --sandbox --sandbox-read /opt/data     # extra readable dir (repeatable)
+```
+
+## What's implemented
+
+| Area | Status | Description |
+|------|--------|-------------|
+| Core CLI | done | Headless agentic one-shot (`claude -p` style) + interactive TUI, streaming, session persistence (`~/.octo/sessions/`), `/cost` `/save` `/sessions` |
+| Providers | done | Anthropic Messages + OpenAI Chat Completions, plus any compatible third party |
+| Reasoning | done | Unified extended thinking (Anthropic) / `reasoning_content` (OpenAI), `--reasoning-effort`, `--show-reasoning` |
+| Tools | done | `terminal` (+ background), file read/write/edit, glob, grep, web fetch/search |
+| Agentic loop | done | Multi-step tool calling, permission gating, history compaction, graceful Ctrl-C |
+| Memory & config | done | `~/.octo/octorules.md`, `.octorules`, `octo init`, `@include` |
+| Skills | done | Claude Code-compatible SKILL.md loader (`--list-skills`, `/skills`, `/<name>`) |
+| Sandbox | done | OS-enforced `--sandbox` (macOS / Linux) |
+| MCP client | done | `mcp.json` stdio + Streamable HTTP servers, tools/resources/prompts, device-flow OAuth |
+| Memory | done | Persistent cross-session memory under `~/.octo/memory/`, auto extract/consolidate |
+| Sub-agents | done | `launch_agent` fan-out, async + resumable (`send_message`, `agent_status`, `kill_agent`) |
+| Orchestration | done | `octo conduct` — plan a goal into a subtask DAG, run it via sub-agents, resume after crash |
+| Web server | done | `octo serve` — REST + SSE, embedded dashboard UI (bind localhost) |
+| IM bridge | done | `octo channel` — WeChat iLink adapter (QR login, per-user sessions, slash commands) |
+
+## Architecture
+
+Layered, one-directional dependency graph:
+
+```
+cmd/octo/          CLI entry (chat one-shot + TUI, serve, channel, conduct, mcp, slash commands)
+   ↓
+internal/agent/    History, sessions, content blocks, Sender interface,
+                   Agent.Turn / TurnStream / Run (tool-calling loop)
+   ↓
+internal/provider/ Provider interface + concrete implementations
+                   ├─ anthropic/   x-api-key, system top-level, content[].text
+                   └─ openai/      Bearer auth, system in messages[0]
+   ↓
+internal/tools/    ToolExecutor implementations — terminal (+ background),
+                   file read/write/edit, glob, grep, web fetch/search, skill
+internal/skills/   SKILL.md discovery + system-prompt manifest
+internal/permission/  allow/deny/ask rule engine gating every tool call
+internal/mcp/      MCP client (stdio + HTTP, OAuth)
+internal/server/   octo serve — HTTP REST + SSE + embedded dashboard
+internal/channel/  IM bridge — adapter interface + WeChat iLink adapter
+internal/conductor/  octo conduct — subtask DAG planner + scheduler
+```
+
+Each provider implements both **buffered** (`Send`) and **streaming** (`SendStream`) variants. The agent layer mirrors with `Sender` / `StreamingSender` / `ToolSender` / `ToolStreamingSender` — interfaces are added incrementally so non-streaming providers still work.
+
+## Development
+
+```bash
+make build         # ./octo
+make test          # go test -race ./...
+make vet           # go vet ./...
+make fmt-check     # gofmt -l . must be empty
+```
+
+Project conventions live in [`.octorules`](.octorules) (the human-facing rules); [`CLAUDE.md`](CLAUDE.md) expands them with the operational detail AI coding agents need in this repo. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the human PR workflow.
+
+## License
+
+MIT. See [`LICENSE.txt`](LICENSE.txt).

--- a/internal/skills/defaults/product_help/SKILL.md
+++ b/internal/skills/defaults/product_help/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: product-help
+description: Answer questions about how to use octo by reading the product documentation. Use when the user asks "how do I...", "what is...", "where is the docs for...", or any usage/help question about octo itself.
+---
+
+# Product Help — answer octo usage questions from documentation
+
+You have access to octo's product documentation. Use it to answer user questions accurately. Do not guess or hallucinate features.
+
+## Documentation sources
+
+1. **Bundled docs** — check the skill directory for reference files:
+   - `README.md` — quick start, installation, basic usage
+   - `CLI.md` — command reference (`octo chat`, `octo config`, `octo skills`, etc.)
+   - `CONFIG.md` — configuration file format and all supported fields
+   - `SKILLS.md` — how to write custom skills
+   - `WORKFLOW.md` — development workflow, git conventions, PR process
+
+   Read the relevant file(s) with `read_file` before answering.
+
+2. **Online docs** (fallback) — if the bundled docs don't cover the question, fetch from the official documentation:
+   - Base URL: `https://github.com/Leihb/octo-agent/blob/main/`
+   - Append the relevant doc filename (e.g. `README.md`, `dev-docs/go-rewrite-roadmap.md`)
+   - Use `web_fetch` to retrieve the raw markdown content
+
+## How to answer
+
+1. **Identify the topic.** Map the user's question to the most relevant doc file(s).
+2. **Read the source.** Use `read_file` for bundled docs or `web_fetch` for online docs.
+3. **Quote selectively.** Cite specific sections or code blocks from the docs to back up your answer.
+4. **Be concise.** Give the direct answer first, then optionally link to the full doc for deeper reading.
+5. **Say when you don't know.** If neither bundled nor online docs cover the question, say so honestly — don't make up an answer.
+
+## Example interactions
+
+User: "how do I add a custom skill?"
+→ Read `SKILLS.md` from the skill directory
+→ Answer with the directory layout, frontmatter format, and how to trigger it
+
+User: "what does permission_mode do?"
+→ Read `CONFIG.md` from the skill directory
+→ Explain the three modes with their behavior
+
+User: "how do I switch to OpenAI?"
+→ Read `CONFIG.md` and `CLI.md`
+→ Explain `octo config` wizard vs. editing `~/.octo/config.json` directly

--- a/internal/skills/defaults/product_help/SKILLS.md
+++ b/internal/skills/defaults/product_help/SKILLS.md
@@ -1,0 +1,71 @@
+# Default Skills (embed + materialize)
+
+> A curated set of skills ships with the binary and lands on disk on first run,
+> so a fresh `octo` install has useful skills without the user authoring any.
+
+## 1. Goal
+
+After install, a curated skill set (today: `worktree-isolate`) is discoverable,
+listable, and overridable — **offline, version-locked to the binary, and never
+clobbering a user's own skills.**
+
+## 2. Decision: embed, don't download
+
+The default set is embedded in the binary via `//go:embed` and materialized to
+disk on startup — **not** fetched from a remote. Embedding keeps a fresh install
+offline-capable (works for `go install`, air-gapped, CI) and immune to
+supply-chain / network-failure modes. A real download path is reserved for a
+future *optional* community catalog (`octo skills add <name>`), which is a
+separate concern from the built-in defaults.
+
+## 3. Mechanism
+
+- **Source of truth:** `internal/skills/defaults/<name>/SKILL.md`, embedded as
+  `defaultsFS` (`internal/skills/defaults.go`).
+- **Materialize:** `MaterializeDefaults(version)` writes the embedded tree to
+  `~/.octo/skills-default/`, stamped with the binary version in `.octo-version`.
+  It's a fast no-op once the stamp matches; a version bump wipes-and-rewrites the
+  whole dir (stale/renamed skills handled). Called best-effort at startup in
+  `cmd/octo` `run()` (skipped for the `__complete` / `__sandboxed-exec` fast
+  paths); a read-only HOME degrades to "no defaults", never an error.
+- **Dedicated dir:** `~/.octo/skills-default/` is exclusively octo-managed and
+  kept **separate** from `~/.octo/skills/`, so refreshing defaults never touches
+  a user's own skills and needs no per-file provenance tracking.
+
+## 4. Precedence
+
+`Discover` scans lowest-first; `scanRoot` overwrites by name:
+
+```
+default  ~/.octo/skills-default/   (shipped, materialized)
+   ↓ overridden by
+user     ~/.octo/skills/
+   ↓ overridden by
+project  ./.octo/skills/
+```
+
+A user overrides a default skill by dropping a same-named skill in
+`~/.octo/skills/`. `--list-skills` / `octo skills list` tag each with its
+source.
+
+## 5. CLI
+
+```
+octo skills list      # all skills, grouped default → user → project
+octo skills update    # force re-materialize the defaults (ignores the stamp)
+octo skills path      # print the three roots
+```
+
+## 6. Adding a default skill
+
+Drop `internal/skills/defaults/<name>/SKILL.md` (standard SKILL.md frontmatter:
+`name` + `description`). It ships on the next release and materializes on the
+user's next run after upgrade. Keep the set small and high-value — every default
+costs system-prompt manifest space for every user.
+
+## 7. Out of scope
+
+- **Remote / community skills** (`octo skills add`, a catalog) — a separate
+  optional feature; defaults stay embedded.
+- **Per-file user-edit preservation in the default dir** — unnecessary, because
+  users edit in `~/.octo/skills/`, not the octo-managed default dir.

--- a/internal/skills/defaults/product_help/TROUBLESHOOTING.md
+++ b/internal/skills/defaults/product_help/TROUBLESHOOTING.md
@@ -1,0 +1,121 @@
+# Troubleshooting
+
+Common issues and their fixes.
+
+## Installation
+
+### `octo: command not found`
+
+- Ensure the binary is on your `$PATH`:
+  ```bash
+  export PATH="$PATH:/path/to/octo/bin"
+  ```
+- Or use the full path: `./octo`
+
+### macOS "cannot be opened because the developer cannot be verified"
+
+- Right-click the binary → Open, or run:
+  ```bash
+  xattr -d com.apple.quarantine /path/to/octo
+  ```
+
+## Configuration
+
+### `octo chat` says "no API key"
+
+- Check that the env var is set: `echo $ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`)
+- Or run `octo config` to store the key in `~/.octo/config.json` (mode 0600)
+- Check `octo config show` to see where the provider/model resolve from
+
+### Provider/model not what I expected
+
+Precedence (highest first): CLI flag > env var > config file > built-in default.
+
+- `--provider` / `--model` flags override everything
+- `OCTO_PROVIDER` / `ANTHROPIC_MODEL` env vars override the config file
+- The config file's model is only honored when the resolved provider matches
+
+## TUI
+
+### TUI doesn't start (falls back to plain REPL)
+
+- TUI requires a TTY. Piped input (`echo "hello" | octo chat`) runs headless
+- Check `octo chat --help` for `--no-tui` or TTY-related flags
+
+### Image paste (Ctrl+V) doesn't work
+
+- Only works on **macOS** today (uses AppleScript to read clipboard)
+- Ensure the clipboard actually contains an image, not a file reference
+- Try dragging the image into the terminal instead
+
+### Input history not persisting
+
+- History is saved to `~/.octo/history` (or `$OCTO_HISTORY_FILE`)
+- Ensure `~/.octo` is writable
+
+## MCP
+
+### "No MCP servers connected"
+
+- Verify `~/.octo/mcp.json` exists and is valid JSON
+- Check that the server command is on `$PATH` (or use absolute path)
+- Run with `--verbose` to see connection errors
+
+### MCP server keeps disconnecting
+
+- Some servers (especially stdio-based) crash on malformed input — check their logs
+- OAuth servers: delete `~/.octo/mcp-tokens/<server>.json` to force re-auth
+
+## Permissions
+
+### "permission_denied" on safe operations
+
+- Check current mode with `Shift+Tab` (cycles interactive → strict → auto)
+- In strict mode, all unmatched operations are denied — switch to interactive
+- Or add an allow rule to `~/.octo/permissions.yml`
+
+### Accidentally denied "always allow this session"
+
+- Restart octo — session memory is cleared on exit
+- Or switch permission mode to auto (Shift+Tab) temporarily
+
+## Sessions
+
+### Session not found when resuming
+
+- Sessions are saved to `~/.octo/sessions/`
+- Resume with `octo chat -c <session-id>`
+- List recent sessions with `/sessions` in TUI
+
+### Session file corrupted
+
+- Sessions are JSON — validate with `python3 -m json.tool ~/.octo/sessions/<id>.json`
+- Corrupted sessions are skipped at load; remove the file to clear the error
+
+## Performance
+
+### Slow first turn / long "Thinking" spinner
+
+- Large repos: the initial `.octorules` + file tree scan can take time
+- Use `--quiet` to reduce rendering overhead
+- Check context usage in the status bar — high ctx% triggers compaction which pauses the stream
+
+### "Context too long" error
+
+- History compaction runs automatically when context usage is high
+- If it still fails, start a new session (`/exit` then `octo chat`)
+- Or use a model with a larger context window
+
+## Git
+
+### Co-authored-by not appearing
+
+- Check `octo config show` — `coauthor` should be "on"
+- Only applies to commits written by octo (via `terminal: git commit`)
+- The trailer is appended automatically; if you edit the message manually, it may be lost
+
+## Getting help
+
+- Run `octo help <command>` for detailed command docs
+- Run `/help` in the TUI for keyboard shortcuts
+- Check the status bar hints — they change based on current state

--- a/internal/skills/defaults/product_help/TUI.md
+++ b/internal/skills/defaults/product_help/TUI.md
@@ -1,0 +1,96 @@
+# TUI (Terminal User Interface) Reference
+
+octo's TUI is a bubbletea-based interactive interface launched by `octo chat` with no positional argument. It provides multi-turn conversation, live tool rendering, and rich keyboard shortcuts.
+
+## Slash commands
+
+Type `/` to open the completion menu (Tab/↑/↓ to navigate, Enter to accept). Available commands:
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show this help message |
+| `/init` | Analyze repo and generate/update `.octorules` (needs `--tools`) |
+| `/save` | Save the session now (also auto-saves after each turn) |
+| `/sessions` | List the 10 most recent sessions |
+| `/skills` | List available skills (trigger with `/<name>`) |
+| `/memory` | List what's remembered across sessions |
+| `/mcp` | Show connected MCP servers and their surfaces |
+| `/conduct` | Conduct a goal to completion (`/conduct list`, `/conduct resume <id>`) |
+| `/exit` or `/quit` | Save and exit |
+
+## Keyboard shortcuts
+
+### Input editing
+
+| Key | Action |
+|-----|--------|
+| **Enter** | Submit message / start turn |
+| **Alt+Enter** / **Shift+Enter** / **Ctrl+J** | Insert newline in textarea |
+| **↑** / **↓** | Browse input history (when cursor is on first/last line) or navigate lines |
+| **Ctrl+V** | Paste image from clipboard as attachment |
+| **Esc** | Clear input + discard attachments (idle); interrupt running turn; take back unsent message |
+
+### Turn control
+
+| Key | Action |
+|-----|--------|
+| **Ctrl+C** | Interrupt running turn; quit when idle |
+| **Ctrl+D** | Quit (save and exit) |
+| **Ctrl+Q** | Queue current input to run as a future turn |
+| **Ctrl+X** | Cancel the most recently queued message (repeat to clear queue) |
+| **Esc** (mid-turn, no output yet) | Take back — restore message to input box |
+| **Esc** (mid-turn, with output) | Interrupt — stop the current turn |
+
+### Permission mode
+
+| Key | Action |
+|-----|--------|
+| **Shift+Tab** | Cycle permission mode: interactive → strict → auto → interactive |
+
+### Completion menu
+
+| Key | Action |
+|-----|--------|
+| **Tab** / **↓** | Next item |
+| **↑** | Previous item |
+| **Enter** | Accept selected item |
+| **Esc** | Dismiss menu |
+| **Type `/`** | Open completion menu (lists all commands and skills) |
+
+### Suggestion (ghost text)
+
+| Key | Action |
+|-----|--------|
+| **Tab** / **→** | Accept the pending follow-up suggestion |
+| **Type anything** | Dismiss suggestion |
+
+### Permission prompt modal
+
+| Key | Action |
+|-----|--------|
+| **y** | Allow this once |
+| **a** | Allow for this session (remembered) |
+| **n** / **Esc** | Deny |
+
+### Question modal
+
+| Key | Action |
+|-----|--------|
+| **↑** / **↓** or **j** / **k** | Move selection |
+| **Space** | Toggle multi-select option |
+| **Enter** | Confirm selection |
+| **Esc** | Cancel |
+
+## Drag and drop
+
+Drag an image file into the terminal — octo detects the path and attaches it automatically (works on terminals that paste the file path as text).
+
+## Status bar
+
+The bottom status bar shows:
+- **cwd** — current working directory (abbreviated with `~`)
+- **ctx** — context window usage percentage
+- **perm** — current permission mode (interactive / strict / auto)
+- **elapsed** — turn duration (while running)
+
+Contextual hints appear below the status bar depending on state (e.g. "Enter steer · Ctrl+Q queue · Esc interrupt").

--- a/internal/skills/defaults/product_help/WORKFLOW.md
+++ b/internal/skills/defaults/product_help/WORKFLOW.md
@@ -1,0 +1,48 @@
+# octo-agent Project Rules
+
+The canonical project guidance for contributors and AI coding agents. Keep this short — substantive design context belongs in `dev-docs/`.
+
+## Project
+
+`octo-agent` is a Go AI agent CLI (Go 1.22+, single binary). Module path `github.com/Leihb/octo-agent`. CLI today; Web UI and IM bridges land in M8/M9 — see `dev-docs/go-rewrite-roadmap.md`.
+
+## Layering
+
+```
+cmd/octo/          CLI entry, flag parsing, REPL, sessions
+internal/agent/    Agent loop, history, content blocks, Sender interfaces
+internal/provider/ Provider interface + per-vendor implementations
+internal/tools/    Concrete ToolExecutor implementations
+internal/version/  Version constants overridable via -ldflags
+```
+
+Dependency direction is one-way: `provider → agent`, `tools → agent`, never the other way. `cmd/octo` is the only package allowed to import `provider` directly; everything else talks through `agent.Sender` / `StreamingSender` / `ToolSender` / `ToolStreamingSender`.
+
+## Adding capability
+
+- **New provider** — implement `provider.Provider` (required) and optionally `provider.StreamingProvider`, `provider.ToolProvider`, `provider.ToolStreamingProvider`. Put it under `internal/provider/<name>/`. Each protocol's wire-format quirks are isolated inside the package; the agent layer must not learn about them.
+- **New tool** — implement `agent.ToolExecutor` and `Definition() agent.ToolDefinition` returning the JSON Schema the LLM sees. Place it under `internal/tools/<name>.go`. Register it in `tools.DefaultRegistry` and add it to `tools.DefaultTools()` if it belongs in the default set.
+- **New skill** (M7+) — `~/.octo/skills/<name>/SKILL.md` with the same frontmatter format Claude Code uses. The skill loader composes existing tools — adding a skill should not require new tool code.
+
+## Code style
+
+- Go 1.22 syntax. `gofmt -w` is the formatter; `go vet ./...` must pass.
+- Tests live next to code (`foo.go` + `foo_test.go`). Use `httptest.NewServer` for HTTP-mocked tests; do not hit live APIs in `go test ./...`.
+- Comments in English. Prefer self-documenting names over comments. Only comment the **why**, never the **what**.
+- No new third-party dependencies without justification in the PR description.
+
+## Workflow
+
+- **Branch off latest `main`** before editing. Never commit on `main` directly.
+- Push lands via PR only. Squash-and-merge is the project default; force-push only after explicit approval.
+- Commit messages and PR descriptions in English.
+- One concept per PR. Mass mechanical changes (rename, move) can ride together but should be a single self-contained change set.
+
+## Testing
+
+- `make test` runs `go test -race ./...` — must be green before pushing.
+- Integration tests against real provider APIs are run by hand with a real key, not in CI.
+
+## What lives in `dev-docs/`
+
+Architecture decisions, milestone plans, and verified-fact dumps (e.g. the iLink protocol notes in the roadmap). One Markdown file per topic. Don't commit speculative or unverified claims — verify before writing.

--- a/internal/skills/defaults/update_config/SKILL.md
+++ b/internal/skills/defaults/update_config/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: update-config
+description: Update octo's persisted configuration files — ~/.octo/config.json (provider, model, etc.), ~/.octo/mcp.json (MCP servers), and ~/.octo/permissions.yml (permission rules). Use when the user wants to change any octo setting without running the setup wizard manually.
+---
+
+# Update octo configuration
+
+octo has three persisted configuration files. Read with `read_file`, modify, and write back with `write_file`.
+
+| File | Format | What it controls |
+|------|--------|------------------|
+| `~/.octo/config.json` | JSON | Provider, model, base URL, permission mode, coauthor, reasoning |
+| `~/.octo/mcp.json` | JSON | MCP servers (stdio and HTTP) |
+| `~/.octo/permissions.yml` | YAML | Custom permission rules per-tool |
+
+## Rules (all files)
+
+- **Always read first** — use `read_file` to see current values before changing anything.
+- **Preserve existing values** — only change the field(s) the user asked for; leave everything else untouched.
+- **Validate before writing** — reject invalid values (unknown provider, malformed URL, bad YAML, etc.).
+- **Never expose secrets** — if a file contains API keys or tokens, do not echo them back to the user.
+- **Confirm with the user** before writing if the change would overwrite an existing non-default value.
+
+---
+
+## 1. ~/.octo/config.json
+
+### Schema
+
+```json
+{
+  "provider": "anthropic | openai",
+  "model": "string (model name, e.g. claude-sonnet-4-20250514)",
+  "base_url": "string (optional custom endpoint)",
+  "permission_mode": "string (optional: strict | confirm | auto)",
+  "coauthor": true | false,
+  "show_reasoning": true | false,
+  "reasoning_effort": "low | medium | high | \"\""
+}
+```
+
+- `provider`: only `"anthropic"` or `"openai"` are valid.
+- `permission_mode`: `"strict"` (block risky ops), `"confirm"` (ask before executing), `"auto"` (run without asking). Omit to use the built-in default.
+- `coauthor`: when `true`, octo appends `Co-authored-by: octo-agent <no-reply@octo-agent.dev>` to every git commit it writes.
+- `show_reasoning`: when `true`, reasoning/thinking traces are streamed to the terminal.
+- `reasoning_effort`: `""` (empty) means off; otherwise `"low"`, `"medium"`, or `"high"`.
+
+### Steps
+
+1. Read `~/.octo/config.json`. If missing, treat as empty `{}`.
+2. Ask the user if ambiguous (e.g. "switch provider" → ask which one).
+3. Validate: reject unknown providers, malformed URLs, unknown permission modes, invalid reasoning effort.
+4. Merge the new value into the existing object.
+5. Pretty-print JSON with 2-space indentation and trailing newline.
+6. Write back with `write_file`, then `chmod 600 ~/.octo/config.json`.
+7. Confirm what changed (excluding `api_key`).
+
+---
+
+## 2. ~/.octo/mcp.json
+
+### Schema
+
+```json
+{
+  "mcpServers": {
+    "server-name": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      "env": {"FOO": "bar"}
+    },
+    "remote-api": {
+      "url": "https://example.com/mcp",
+      "headers": {"Authorization": "Bearer ..."},
+      "auth": "oauth"
+    }
+  }
+}
+```
+
+- Each server entry is either **stdio** (`command` set) or **HTTP** (`url` set). Both set is invalid.
+- `auth`: `"oauth"` for device-flow OAuth (HTTP only), or omit.
+- `disabled`: `true` to keep the config but skip loading.
+
+### Steps
+
+1. Read `~/.octo/mcp.json`. If missing, treat as `{"mcpServers": {}}`.
+2. Determine the operation:
+   - **Add** a new server — ask for name, type (stdio/HTTP), and required fields.
+   - **Edit** an existing server — show current config, ask which fields to change.
+   - **Remove** a server — confirm, then delete the entry.
+   - **Enable/disable** — toggle the `disabled` flag.
+3. Validate:
+   - Reject stdio+HTTP hybrid entries.
+   - Reject unknown `auth` values.
+   - Reject malformed `url`.
+4. Merge into the existing `mcpServers` object.
+5. Pretty-print JSON with 2-space indentation and trailing newline.
+6. Write back with `write_file`, then `chmod 600 ~/.octo/mcp.json`.
+7. Confirm and remind: changes take effect on next `octo chat` start.
+
+---
+
+## 3. ~/.octo/permissions.yml
+
+### Schema
+
+```yaml
+tool_name:
+  - allow: { pattern: "substring" }
+  - deny:  { path: ["**/secret/**"] }
+  - ask:   { hostname: ["*.internal.com"] }
+```
+
+- Top-level keys are **tool names** (`terminal`, `write_file`, `edit_file`, `read_file`, `web_fetch`, etc.).
+- Each rule has exactly one of `allow` / `deny` / `ask`.
+- Rule axes:
+  - `pattern` — substring match for `terminal` commands (case-sensitive)
+  - `path` — glob match for file tools; `**` = any depth; `$CWD` = working directory
+  - `hostname` — glob match for `web_fetch` hosts; `*` = one DNS label
+- User rules **fully replace** the default rule list per-tool (not append).
+
+### Steps
+
+1. Read `~/.octo/permissions.yml`. If missing, the user has no custom rules yet.
+2. Determine the operation:
+   - **Add a rule** — ask which tool, decision (allow/deny/ask), and matching criteria.
+   - **Remove a rule** — show current rules for the tool, ask which to delete.
+   - **Show current rules** — pretty-print the file (or say "using defaults" if missing).
+3. Validate:
+   - Reject unknown tool names.
+   - Reject rules with multiple or missing decision clauses.
+   - Warn if a new rule would make the tool unusable (e.g. deny everything).
+4. Write back with `write_file`, then `chmod 600 ~/.octo/permissions.yml`.
+5. Confirm and remind: changes are live immediately in the current session.
+
+---
+
+## Example interactions
+
+**User:** "use openai as my default"
+→ Read config.json, see `"provider": "anthropic"`
+→ Suggest: "Switch provider to openai and model to gpt-4.1?"
+→ User confirms → Write updated config.json, chmod 600
+
+**User:** "add a filesystem MCP server"
+→ Read mcp.json, see current servers
+→ Ask: name, command, args → Validate → Merge → Write back
+
+**User:** "allow docker commands"
+→ Read permissions.yml, see current rules (or none)
+→ Add: `terminal: [{ allow: { pattern: "docker " } }]`
+→ Validate → Write back
+
+**User:** "show my permission rules"
+→ Read permissions.yml → Pretty-print, or say "using defaults" if missing


### PR DESCRIPTION
Add two new built-in default skills shipped with the binary:

- **update_config**: interactive skill to read and modify octo configuration files:
  - ~/.octo/config.json (provider, model, base_url, permission_mode, coauthor, show_reasoning, reasoning_effort)
  - ~/.octo/mcp.json (add/edit/remove/enable/disable MCP servers)
  - ~/.octo/permissions.yml (custom permission rules per-tool)

- **product_help**: documentation lookup skill that answers octo usage questions by reading bundled reference docs from the skill directory, with online fallback to GitHub.

Bundled docs include: README, CLI, CONFIG, MCP, PERMISSIONS, SKILLS, MEMORY, TUI, TROUBLESHOOTING, WORKFLOW.

Both skills are embedded via //go:embed and materialize to ~/.octo/skills-default on binary startup, overridable by user skills.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>