### PR TITLE
fix(tui): strip model-only "do not poll" notice from terminal cards

### DIFF
--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -1,6 +1,11 @@
 package main
 
-import "github.com/Leihb/octo-agent/internal/tui"
+import (
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/tools"
+	"github.com/Leihb/octo-agent/internal/tui"
+)
 
 // outputCardMaxLines caps how many output lines a tool-result card shows
 // before collapsing the rest into a "N more lines" marker.
@@ -74,6 +79,12 @@ func renderToolCard(toolName string, input map[string]any, output string, isErr 
 		if p, _ := input["path"].(string); p != "" {
 			lang = tui.GuessLanguage(p)
 		}
+	}
+	if toolName == "terminal" {
+		// The background-launch result carries a model-only "don't poll"
+		// instruction appended after a blank line. It's noise for the human, so
+		// drop it from the card — the "Started background process N" line stays.
+		output = strings.TrimRight(strings.TrimSuffix(output, tools.BgPollNotice), "\n")
 	}
 	return tui.RenderOutputCard(verb, cardTargetFor(toolName, input), output, outputCardMaxLines, isErr, lang)
 }

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -17,6 +17,12 @@ import (
 // synchronously before it is automatically promoted to a background process.
 var TerminalTimeout = 30 * time.Second
 
+// BgPollNotice is the model-facing instruction appended to a background-launch
+// tool result. It steers the model away from polling terminal_output and
+// carries no information for the human, so the TUI strips it from result cards
+// (see renderToolCard) rather than printing it to the scrollback.
+const BgPollNotice = "DO NOT poll terminal_output. The system will automatically notify you when this process finishes, carrying its full output. You can continue with other tasks while it runs."
+
 // TerminalTool is an agent.ToolExecutor that runs shell commands through the
 // system shell (`sh -c` on macOS/Linux, PowerShell on Windows; see
 // shellCommand). Stdout and stderr are combined and returned as the tool
@@ -110,7 +116,7 @@ func (t TerminalTool) ExecuteStream(
 		if err != nil {
 			return agent.ToolResult{Text: ""}, err
 		}
-		return agent.ToolResult{Text: fmt.Sprintf("Started background process %s.\n\nDO NOT poll terminal_output. The system will automatically notify you when this process finishes, carrying its full output. You can continue with other tasks while it runs.", id)}, nil
+		return agent.ToolResult{Text: fmt.Sprintf("Started background process %s.\n\n%s", id, BgPollNotice)}, nil
 	}
 
 	// Synchronous path: start as a background process so that if we hit the
@@ -150,7 +156,7 @@ func (t TerminalTool) ExecuteStream(
 			outMu.Unlock()
 			body = strings.ReplaceAll(body, "\t", "    ")
 			body = MaybeSpillOutput(id, body)
-			return agent.ToolResult{Text: fmt.Sprintf("%s\n\n[timeout: command exceeded %s and continues as background process %s]\n\nDO NOT poll terminal_output. The system will automatically notify you when this process finishes, carrying its full output. You can continue with other tasks while it runs.", body, TerminalTimeout, id)}, nil
+			return agent.ToolResult{Text: fmt.Sprintf("%s\n\n[timeout: command exceeded %s and continues as background process %s]\n\n%s", body, TerminalTimeout, id, BgPollNotice)}, nil
 		case <-ctx.Done():
 			// User cancelled (Esc / Ctrl-C): kill the background process.
 			t.manager().Kill(id)


### PR DESCRIPTION
## What

The `terminal` background-launch result packs a model-facing instruction (`DO NOT poll terminal_output…`) together with the human-relevant fact (`Started background process bg_N`). The TUI renders the whole tool output in the result card, so the instruction leaked into the human scrollback as noise.

## Fix

- Extract the notice into a single shared `tools.BgPollNotice` constant, used at both the background-launch and timeout-promotion sites in `terminal.go` (single source of truth).
- Strip it from the `terminal` card in `renderToolCard` (TUI-only). The `Started background process bg_N` line stays; the model still receives the full notice in the tool result.

## Scope check

Swept the other card tools (`edit_file/grep/web_search/glob/read_file/web_fetch`) — none embed model-only instructions in their output. The `terminal_output` tool's "STOP POLLING" notice is not a card tool, so it never reaches scrollback. This was the only leak.

## Test

`go build ./...`, `gofmt -l` clean, `go test ./internal/tools/ ./cmd/octo/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)