### PR TITLE
fix(tools): trigger direct-fetch fallback on connection reset by peer

### DIFF
--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -113,6 +113,7 @@ func shouldFallback(err error) bool {
 		strings.Contains(s, "x509:") ||
 		strings.Contains(s, "no such host") ||
 		strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "connection reset by peer") ||
 		strings.Contains(s, "timeout") ||
 		strings.Contains(s, "temporary failure") ||
 		strings.Contains(s, "i/o timeout") ||

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -311,6 +311,42 @@ func TestWebFetch_FallsBackOnHTTP429(t *testing.T) {
 	}
 }
 
+func TestWebFetch_FallsBackOnConnectionResetByPeer(t *testing.T) {
+	// Simulate the exact error Jina returns when the upstream resets the TCP
+	// connection — this must trigger the direct-fetch fallback.
+	jina := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("server does not support hijacking")
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			t.Fatalf("hijack failed: %v", err)
+		}
+		conn.Close()
+	}))
+	defer jina.Close()
+
+	direct := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("direct after reset"))
+	}))
+	defer direct.Close()
+
+	old := jinaReaderHostForTest
+	jinaReaderHostForTest = jina.URL + "/"
+	defer func() { jinaReaderHostForTest = old }()
+
+	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
+		"url": direct.URL + "/page",
+	})
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got: %v", err)
+	}
+	if !strings.Contains(out.Text, "direct after reset") {
+		t.Errorf("expected direct content, got: %q", out.Text)
+	}
+}
+
 func TestWebFetch_FallsBackOnContextDeadlineExceeded(t *testing.T) {
 	// Jina proxy that sleeps longer than the 5s jina timeout but less than
 	// the total budget, so the fallback has time to succeed.


### PR DESCRIPTION
The Jina Reader proxy occasionally fails with a TCP reset from the upstream (e.g. weather.cma.cn). "shouldFallback()" only checked for "connection refused", so the tool surfaced the proxy error instead of falling back to a direct HTTP fetch.

**Changes**
- Add "connection reset by peer" to the network-error whitelist in "shouldFallback()"
- Add "TestWebFetch_FallsBackOnConnectionResetByPeer" to cover the fallback path

**Test**
"go test -race -run TestWebFetch ./internal/tools/" passes.