### PR TITLE
feat(config): migrate config.json to config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This unifies Anthropic `thinking` blocks and OpenAI `reasoning_content` behind o
 
 ### Defaults (`octo config`)
 
-`octo config` saves your default provider, model, (optionally) base URL, and reasoning settings to `~/.octo/config.json`, so a bare `octo chat` works without re-typing `--provider`/`--model` every time:
+`octo config` saves your default provider, model, (optionally) base URL, and reasoning settings to `~/.octo/config.yaml`, so a bare `octo chat` works without re-typing `--provider`/`--model` every time:
 
 ```bash
 octo config        # interactive wizard
@@ -138,7 +138,7 @@ octo config show   # print the effective settings + where each comes from
 octo config path   # print the file location
 ```
 
-Precedence is **CLI flag > env var > `~/.octo/config.json` > built-in default**. API keys are read from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` first; the wizard can store one in the file (mode `0600`), but the env var is recommended.
+Precedence is **CLI flag > env var > `~/.octo/config.yaml` > built-in default**. API keys are read from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` first; the wizard can store one in the file (mode `0600`), but the env var is recommended.
 
 ## Skills
 

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -314,7 +314,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	cfg, err := config.Load()
 	if err != nil {
 		fmt.Fprintf(stderr, "octo chat: %v\n", err)
-		fmt.Fprintln(stderr, "Run `octo config` to rewrite ~/.octo/config.json.")
+		fmt.Fprintln(stderr, "Run `octo config` to rewrite ~/.octo/config.yaml.")
 		return 1
 	}
 

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -103,7 +103,7 @@ func effectiveEndpoint(provider string, cfg config.Config) string {
 }
 
 // runConfig handles `octo config [show|path]` and, with no subcommand, an
-// interactive setup wizard that writes ~/.octo/config.json.
+// interactive setup wizard that writes ~/.octo/config.yaml.
 func runConfig(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	sub := ""
 	if len(args) > 0 {
@@ -227,7 +227,7 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	defer reader.Close()
 
-	fmt.Fprintln(stdout, "octo config — set your default provider and model (~/.octo/config.json).")
+	fmt.Fprintln(stdout, "octo config — set your default provider and model (~/.octo/config.yaml).")
 	fmt.Fprintln(stdout, "Press Enter to keep the shown default. CLI flags and env vars still override per run.")
 	fmt.Fprintln(stdout)
 

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -128,8 +128,8 @@ func TestRunConfig_Path(t *testing.T) {
 	if code := runConfig([]string{"path"}, strings.NewReader(""), &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "config.json") {
-		t.Errorf("path output should mention config.json; got %q", stdout.String())
+	if !strings.Contains(stdout.String(), "config.yaml") {
+		t.Errorf("path output should mention config.yaml; got %q", stdout.String())
 	}
 }
 

--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -207,7 +207,7 @@ Environment:
 
 func configHelp(w io.Writer) {
 	fmt.Fprintln(w, `octo config — save your default provider, model, and (optionally) base URL to
-~/.octo/config.json so a bare `+"`octo chat`"+` works without re-typing flags.
+~/.octo/config.yaml so a bare `+"`octo chat`"+` works without re-typing flags.
 
 Precedence (highest first): CLI flag (--provider/--model) > env var > this file
 > built-in default. API keys are read from the environment first; storing one
@@ -219,12 +219,10 @@ Usage:
                           comes from (never prints the key itself)
   octo config path        Print the config file path
 
-File (~/.octo/config.json):
-  {
-    "provider": "openai",
-    "model":    "gpt-4o-mini",
-    "base_url": "https://api.deepseek.com"   // optional, for compatible 3rd parties
-  }
+File (~/.octo/config.yaml):
+  provider: openai
+  model: gpt-4o-mini
+  base_url: https://api.deepseek.com   # optional, for compatible 3rd parties
 
 Environment:
   ANTHROPIC_API_KEY / OPENAI_API_KEY    Override any stored key, per run.`)

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -54,7 +54,7 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	cfg, err := config.Load()
 	if err != nil {
 		fmt.Fprintf(stderr, "octo init: %v\n", err)
-		fmt.Fprintln(stderr, "Run `octo config` to rewrite ~/.octo/config.json.")
+		fmt.Fprintln(stderr, "Run `octo config` to rewrite ~/.octo/config.yaml.")
 		return 1
 	}
 	provName, resolvedModel, ok := resolveProviderModel(*providerName, *model, cfg)

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -98,7 +98,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "Commands:")
 	fmt.Fprintln(w, "  chat       Start an interactive session (or single-turn with a message)")
 	fmt.Fprintln(w, "  channel    Start IM platform bridges (e.g. `octo channel start`)")
-	fmt.Fprintln(w, "  config     Set your default provider/model (~/.octo/config.json)")
+	fmt.Fprintln(w, "  config     Set your default provider/model (~/.octo/config.yaml)")
 	fmt.Fprintln(w, "  serve      Start the HTTP server (REST + SSE + Web UI)")
 	fmt.Fprintln(w, "  init       Analyze the repo and generate/update .octorules")
 	fmt.Fprintln(w, "  memory     Manage cross-session memory (e.g. `octo memory list`)")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // Package config holds the user's persisted CLI defaults at
-// ~/.octo/config.json — the provider/model/base-URL a fresh `octo chat`
+// ~/.octo/config.yaml — the provider/model/base-URL a fresh `octo chat`
 // should use without re-typing flags or re-exporting env vars every session.
 //
 // Precedence is resolved by the caller (cmd/octo): an explicit CLI flag beats
@@ -10,48 +10,49 @@
 package config
 
 import (
-	"encoding/json"
 	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Config is the persisted set of CLI defaults. Every field is optional; a
 // missing file (or a missing field) leaves the zero value, and the caller
 // substitutes its built-in default.
 type Config struct {
-	Provider       string `json:"provider,omitempty"`
-	Model          string `json:"model,omitempty"`
-	BaseURL        string `json:"base_url,omitempty"`
-	PermissionMode string `json:"permission_mode,omitempty"`
+	Provider       string `yaml:"provider,omitempty"`
+	Model          string `yaml:"model,omitempty"`
+	BaseURL        string `yaml:"base_url,omitempty"`
+	PermissionMode string `yaml:"permission_mode,omitempty"`
 	// Coauthor, when true, instructs the agent to append a Co-authored-by line
 	// to every git commit message it writes. Default is true (enabled).
-	Coauthor *bool `json:"coauthor,omitempty"`
+	Coauthor *bool `yaml:"coauthor,omitempty"`
 	// ShowReasoning controls whether a reasoning model's thinking trace is
 	// streamed to the terminal (dimmed). Covers both Anthropic thinking blocks
 	// and OpenAI reasoning_content. nil means the built-in default (enabled).
-	ShowReasoning *bool `json:"show_reasoning,omitempty"`
+	ShowReasoning *bool `yaml:"show_reasoning,omitempty"`
 	// ReasoningEffort sets the unified reasoning intensity ("low" | "medium" |
 	// "high"). OpenAI sends it as reasoning_effort; Anthropic maps it to an
 	// extended-thinking token budget. Empty means off (no extended reasoning).
-	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	ReasoningEffort string `yaml:"reasoning_effort,omitempty"`
 	// APIKey, when set, is a plaintext fallback used only if the provider's
 	// env var is empty. Opt-in via `octo config` and stored mode 0600. Prefer
 	// the env var.
-	APIKey string `json:"api_key,omitempty"`
+	APIKey string `yaml:"api_key,omitempty"`
 }
 
-// Path returns the absolute path to the config file (~/.octo/config.json).
+// Path returns the absolute path to the config file (~/.octo/config.yaml).
 func Path() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".octo", "config.json"), nil
+	return filepath.Join(home, ".octo", "config.yaml"), nil
 }
 
-// Load reads ~/.octo/config.json. A missing file is not an error — it returns
+// Load reads ~/.octo/config.yaml. A missing file is not an error — it returns
 // the zero Config so first-run callers need no special-casing. A present but
 // malformed file IS an error, so a typo surfaces instead of silently
 // reverting to defaults.
@@ -68,13 +69,13 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 	var c Config
-	if err := json.Unmarshal(data, &c); err != nil {
+	if err := yaml.Unmarshal(data, &c); err != nil {
 		return Config{}, err
 	}
 	return c, nil
 }
 
-// Save writes the config to ~/.octo/config.json with mode 0600 (it may hold an
+// Save writes the config to ~/.octo/config.yaml with mode 0600 (it may hold an
 // API key), creating ~/.octo if needed.
 func (c Config) Save() error {
 	path, err := Path()
@@ -84,10 +85,9 @@ func (c Config) Save() error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
-	data, err := json.MarshalIndent(c, "", "  ")
+	data, err := yaml.Marshal(c)
 	if err != nil {
 		return err
 	}
-	data = append(data, '\n')
 	return os.WriteFile(path, data, 0o600)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -53,7 +53,7 @@ func TestSave_FileMode0600(t *testing.T) {
 	if err := (Config{APIKey: "sk-secret"}).Save(); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	path := filepath.Join(home, ".octo", "config.json")
+	path := filepath.Join(home, ".octo", "config.yaml")
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("stat: %v", err)
@@ -72,7 +72,7 @@ func TestLoad_MalformedIsError(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{not json"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("not: valid: yaml: ["), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := Load(); err == nil {

--- a/internal/skills/defaults/product_help/CLI.md
+++ b/internal/skills/defaults/product_help/CLI.md
@@ -13,7 +13,7 @@ Flags:
 - `--no-reasoning` — Disable reasoning trace display
 
 ### `octo config [subcommand]`
-Manage persisted configuration (`~/.octo/config.json`).
+Manage persisted configuration (`~/.octo/config.yaml`).
 
 Subcommands:
 - `setup` / `init` (default) — Interactive wizard to set provider, model, and options

--- a/internal/skills/defaults/product_help/CONFIG.md
+++ b/internal/skills/defaults/product_help/CONFIG.md
@@ -2,7 +2,7 @@
 
 ## Config file
 
-Path: `~/.octo/config.json`
+Path: `~/.octo/config.yaml`
 
 Created interactively via `octo config` or edited directly.
 
@@ -31,12 +31,10 @@ CLI flags (`--provider`, `--model`, etc.) > env vars (`OCTO_PROVIDER`, `ANTHROPI
 
 ## Example
 
-```json
-{
-  "provider": "anthropic",
-  "model": "claude-sonnet-4-20250514",
-  "coauthor": true,
-  "show_reasoning": true,
-  "reasoning_effort": "medium"
-}
+```yaml
+provider: anthropic
+model: claude-sonnet-4-20250514
+coauthor: true
+show_reasoning: true
+reasoning_effort: medium
 ```

--- a/internal/skills/defaults/product_help/README.md
+++ b/internal/skills/defaults/product_help/README.md
@@ -130,7 +130,7 @@ This unifies Anthropic `thinking` blocks and OpenAI `reasoning_content` behind o
 
 ### Defaults (`octo config`)
 
-`octo config` saves your default provider, model, (optionally) base URL, and reasoning settings to `~/.octo/config.json`, so a bare `octo chat` works without re-typing `--provider`/`--model` every time:
+`octo config` saves your default provider, model, (optionally) base URL, and reasoning settings to `~/.octo/config.yaml`, so a bare `octo chat` works without re-typing `--provider`/`--model` every time:
 
 ```bash
 octo config        # interactive wizard
@@ -138,7 +138,7 @@ octo config show   # print the effective settings + where each comes from
 octo config path   # print the file location
 ```
 
-Precedence is **CLI flag > env var > `~/.octo/config.json` > built-in default**. API keys are read from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` first; the wizard can store one in the file (mode `0600`), but the env var is recommended.
+Precedence is **CLI flag > env var > `~/.octo/config.yaml` > built-in default**. API keys are read from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` first; the wizard can store one in the file (mode `0600`), but the env var is recommended.
 
 ## Skills
 

--- a/internal/skills/defaults/product_help/SKILL.md
+++ b/internal/skills/defaults/product_help/SKILL.md
@@ -43,4 +43,4 @@ User: "what does permission_mode do?"
 
 User: "how do I switch to OpenAI?"
 → Read `CONFIG.md` and `CLI.md`
-→ Explain `octo config` wizard vs. editing `~/.octo/config.json` directly
+→ Explain `octo config` wizard vs. editing `~/.octo/config.yaml` directly

--- a/internal/skills/defaults/product_help/TROUBLESHOOTING.md
+++ b/internal/skills/defaults/product_help/TROUBLESHOOTING.md
@@ -24,7 +24,7 @@ Common issues and their fixes.
 ### `octo chat` says "no API key"
 
 - Check that the env var is set: `echo $ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`)
-- Or run `octo config` to store the key in `~/.octo/config.json` (mode 0600)
+- Or run `octo config` to store the key in `~/.octo/config.yaml` (mode 0600)
 - Check `octo config show` to see where the provider/model resolve from
 
 ### Provider/model not what I expected

--- a/internal/skills/defaults/update_config/SKILL.md
+++ b/internal/skills/defaults/update_config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-config
-description: Update octo's persisted configuration files — ~/.octo/config.json (provider, model, etc.), ~/.octo/mcp.json (MCP servers), and ~/.octo/permissions.yml (permission rules). Use when the user wants to change any octo setting without running the setup wizard manually.
+description: Update octo's persisted configuration files — ~/.octo/config.yaml (provider, model, etc.), ~/.octo/mcp.json (MCP servers), and ~/.octo/permissions.yml (permission rules). Use when the user wants to change any octo setting without running the setup wizard manually.
 ---
 
 # Update octo configuration
@@ -9,7 +9,7 @@ octo has three persisted configuration files. Read with `read_file`, modify, and
 
 | File | Format | What it controls |
 |------|--------|------------------|
-| `~/.octo/config.json` | JSON | Provider, model, base URL, permission mode, coauthor, reasoning |
+| `~/.octo/config.yaml` | YAML | Provider, model, base URL, permission mode, coauthor, reasoning |
 | `~/.octo/mcp.json` | JSON | MCP servers (stdio and HTTP) |
 | `~/.octo/permissions.yml` | YAML | Custom permission rules per-tool |
 
@@ -23,20 +23,18 @@ octo has three persisted configuration files. Read with `read_file`, modify, and
 
 ---
 
-## 1. ~/.octo/config.json
+## 1. ~/.octo/config.yaml
 
 ### Schema
 
-```json
-{
-  "provider": "anthropic | openai",
-  "model": "string (model name, e.g. claude-sonnet-4-20250514)",
-  "base_url": "string (optional custom endpoint)",
-  "permission_mode": "string (optional: strict | confirm | auto)",
-  "coauthor": true | false,
-  "show_reasoning": true | false,
-  "reasoning_effort": "low | medium | high | \"\""
-}
+```yaml
+provider: anthropic | openai
+model: string (model name, e.g. claude-sonnet-4-20250514)
+base_url: string (optional custom endpoint)
+permission_mode: string (optional: strict | confirm | auto)
+coauthor: true | false
+show_reasoning: true | false
+reasoning_effort: low | medium | high | ""
 ```
 
 - `provider`: only `"anthropic"` or `"openai"` are valid.
@@ -47,13 +45,12 @@ octo has three persisted configuration files. Read with `read_file`, modify, and
 
 ### Steps
 
-1. Read `~/.octo/config.json`. If missing, treat as empty `{}`.
+1. Read `~/.octo/config.yaml`. If missing, treat as empty document.
 2. Ask the user if ambiguous (e.g. "switch provider" → ask which one).
 3. Validate: reject unknown providers, malformed URLs, unknown permission modes, invalid reasoning effort.
 4. Merge the new value into the existing object.
-5. Pretty-print JSON with 2-space indentation and trailing newline.
-6. Write back with `write_file`, then `chmod 600 ~/.octo/config.json`.
-7. Confirm what changed (excluding `api_key`).
+5. Write back with `write_file`, then `chmod 600 ~/.octo/config.yaml`.
+6. Confirm what changed (excluding `api_key`).
 
 ---
 
@@ -139,9 +136,9 @@ tool_name:
 ## Example interactions
 
 **User:** "use openai as my default"
-→ Read config.json, see `"provider": "anthropic"`
+→ Read config.yaml, see `provider: anthropic`
 → Suggest: "Switch provider to openai and model to gpt-4.1?"
-→ User confirms → Write updated config.json, chmod 600
+→ User confirms → Write updated config.yaml, chmod 600
 
 **User:** "add a filesystem MCP server"
 → Read mcp.json, see current servers


### PR DESCRIPTION
Switch the persisted CLI defaults from JSON to YAML for better human editability (comments, no trailing commas, relaxed syntax).

### Changes
- **internal/config/config.go**: use yaml.v3, struct tags changed to yaml, Path() returns config.yaml, Save() uses yaml.Marshal
- **internal/config/config_test.go**: update file paths and malformed test
- **cmd/octo/config.go**: wizard now writes YAML, update prompt text
- **cmd/octo/config_test.go**: path test expects config.yaml
- **cmd/octo/chat.go, init.go, main.go, help.go**: update all user-facing references
- **Bundled skill docs** (product_help + update_config) and README: update examples and paths

### Breaking
No migration path — early adopters need to re-run `octo config` to regenerate the file.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>