### PR TITLE
fix(tui): show the 💭 marker on every reasoning block, not just the turn's first

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -923,18 +923,21 @@ func (m *tuiModel) appendThinking(text string) {
 	m.thinkPartial.WriteString(buf)
 }
 
-// flushThinking commits any buffered trailing reasoning line. No-op when the
-// turn produced no reasoning.
+// flushThinking commits any buffered trailing reasoning line and ends the
+// current reasoning block. A turn's agentic loop produces a fresh block of
+// reasoning before each model round-trip (between tool calls); resetting
+// thinkingStarted here means every block gets its own 💭 marker, matching the
+// plain/headless renderer.
 func (m *tuiModel) flushThinking() {
-	if m.thinkPartial.Len() == 0 {
-		return
+	if m.thinkPartial.Len() > 0 {
+		m.println(m.styleThinking(m.thinkPartial.String()))
+		m.thinkPartial.Reset()
 	}
-	m.println(m.styleThinking(m.thinkPartial.String()))
-	m.thinkPartial.Reset()
+	m.thinkingStarted = false
 }
 
 // styleThinking renders one reasoning line dimmed, prefixing 💭 on the first
-// line of the turn's trace so the block reads as one unit.
+// line of each reasoning block so the block reads as one unit.
 func (m *tuiModel) styleThinking(line string) string {
 	if !m.thinkingStarted {
 		m.thinkingStarted = true

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -198,10 +198,30 @@ func TestTUI_ThinkingRendersBeforeAnswer(t *testing.T) {
 		t.Fatalf("thinking trace should be committed to scrollback; got %q", joined)
 	}
 	if n := strings.Count(joined, "💭"); n != 1 {
-		t.Errorf("💭 should prefix only the first thinking line; got %d in %q", n, joined)
+		t.Errorf("💭 should prefix only the first line of the block; got %d in %q", n, joined)
 	}
 	if m.thinkPartial.Len() != 0 {
 		t.Errorf("thinking buffer should be flushed once the answer starts; still holds %q", m.thinkPartial.String())
+	}
+}
+
+// A turn's agentic loop produces a fresh reasoning block before each model
+// round-trip (between tool calls); every block must get its own 💭, not just
+// the turn's first one.
+func TestTUI_ThinkingMarkerPerBlock(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+
+	// Block 1 → a tool runs → block 2 → the answer.
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: "first thought\n"})
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventToolStarted, ToolID: "c1", ToolName: "terminal", Input: map[string]any{"command": "ls"}})
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventToolDone, ToolID: "c1", ToolName: "terminal", Output: "ok"})
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: "second thought\n"})
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "answer"})
+
+	joined := strings.Join(m.printlnBuf, "\n")
+	if n := strings.Count(joined, "💭"); n != 2 {
+		t.Errorf("each reasoning block should get a 💭; got %d in:\n%s", n, joined)
 	}
 }
 


### PR DESCRIPTION
## Problem

Follow-up to #358. In the TUI, only the **first** reasoning block of a turn got a 💭 marker. A turn's agentic loop emits a fresh reasoning trace before each model round-trip (between tool calls — e.g. think → search → think → fetch → think → answer), so the 2nd+ blocks rendered in the correct dimmed color but **without the 💭 icon** — inconsistent with the plain/headless renderer, which re-opens 💭 after every non-thinking output.

Root cause: `thinkingStarted` was reset only once per user turn (in `startTurnEchoRestore`), so after the first block set it `true` it never re-armed.

## Fix

Reset `thinkingStarted` in `flushThinking`, which already runs whenever a non-thinking event ends a reasoning block. Each subsequent block then re-emits its 💭 — matching the headless behavior.

## Tests

- `TestTUI_ThinkingMarkerPerBlock` — think → tool → think → answer yields **two** 💭.
- `TestTUI_ThinkingRendersBeforeAnswer` still asserts a single block gets exactly one 💭.
- `go build`, `gofmt -l` (empty), `go vet`, `go test ./cmd/octo/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)