### PR TITLE
feat(tui): replay prior turns into the scrollback when resuming a session

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -333,6 +333,11 @@ type tuiModel struct {
 	// scrollback above the live View() area — no alt-screen buffer needed.
 	printlnBuf []string
 
+	// historyReplayed guards the one-time replay of a resumed session's prior
+	// turns into the scrollback. Done on the first WindowSizeMsg so markdown
+	// wraps to the real terminal width rather than the Init-time fallback.
+	historyReplayed bool
+
 	// height is the terminal height in cells, updated by WindowSizeMsg.
 	height int
 
@@ -505,6 +510,14 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.ta.SetWidth(msg.Width)
 		_ = m.updateTextAreaHeight()
+		// Replay a resumed session's prior turns into the scrollback once, now
+		// that the real wrap width is known. No-op for a fresh session.
+		if !m.historyReplayed {
+			m.historyReplayed = true
+			for _, line := range m.replayHistoryLines() {
+				m.println(line)
+			}
+		}
 		return m, m.flushPrints()
 
 	case tea.KeyMsg:
@@ -944,6 +957,99 @@ func (m *tuiModel) styleThinking(line string) string {
 		return thinkingStyle.Render("💭 " + line)
 	}
 	return thinkingStyle.Render("   " + line)
+}
+
+// replayHistoryLines renders a resumed session's prior turns into scrollback
+// lines: user prompts and assistant replies verbatim (markdown unless --plain),
+// each tool call collapsed to a one-line ✓/✗ summary, closed by a dim "resumed"
+// marker. Returns nil for a fresh session (empty history).
+func (m *tuiModel) replayHistoryLines() []string {
+	msgs := m.a.History.Snapshot()
+	if len(msgs) == 0 {
+		return nil
+	}
+	// Pair each tool_use with its tool_result (by ID) so the collapsed line can
+	// show the call's outcome.
+	results := map[string]agent.ContentBlock{}
+	for _, msg := range msgs {
+		for _, b := range msg.Blocks {
+			if b.Type == "tool_result" {
+				results[b.ToolUseID] = b
+			}
+		}
+	}
+
+	var out []string
+	for _, msg := range msgs {
+		switch msg.Role {
+		case agent.RoleUser:
+			// Skip pure tool_result carriers — only real typed prompts echo.
+			if t := userMessageText(msg); strings.TrimSpace(t) != "" {
+				out = append(out, userEchoStyle.Render("> ")+t)
+			}
+		case agent.RoleAssistant:
+			if len(msg.Blocks) == 0 {
+				if s := m.renderReplayText(msg.Content); s != "" {
+					out = append(out, s)
+				}
+				continue
+			}
+			for _, b := range msg.Blocks {
+				switch b.Type {
+				case "text":
+					if s := m.renderReplayText(b.Text); s != "" {
+						out = append(out, s)
+					}
+				case "tool_use":
+					out = append(out, replayToolLine(b, results[b.ID]))
+				}
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return append(out, hintStyle.Render(fmt.Sprintf("── resumed · %d messages ──", len(msgs))))
+}
+
+// renderReplayText styles one block of restored assistant/user prose: markdown
+// unless --plain. Empty input renders to "".
+func (m *tuiModel) renderReplayText(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return ""
+	}
+	if m.cfg.plain {
+		return strings.TrimRight(s, "\n")
+	}
+	return m.md.render(s, m.width)
+}
+
+// userMessageText returns a user message's human-typed text, ignoring
+// tool_result carriers and non-text (e.g. image) blocks.
+func userMessageText(msg agent.Message) string {
+	if len(msg.Blocks) == 0 {
+		return msg.Content
+	}
+	var b strings.Builder
+	for _, blk := range msg.Blocks {
+		if blk.Type == "text" {
+			b.WriteString(blk.Text)
+		}
+	}
+	return b.String()
+}
+
+// replayToolLine collapses a tool_use (and its paired result) into a single
+// ↳ verb(target) ✓/✗ line — the resumed-history counterpart of the live card.
+func replayToolLine(use, result agent.ContentBlock) string {
+	label := "↳ " + use.Name
+	if target := cardTargetFor(use.Name, use.Input); target != "" {
+		label += "(" + target + ")"
+	}
+	if result.Type == "tool_result" && result.IsError {
+		return toolErrStyle.Render(label + " ✗")
+	}
+	return label + " ✓"
 }
 
 func (m *tuiModel) appendText(text string) {

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -222,6 +223,68 @@ func TestTUI_ThinkingMarkerPerBlock(t *testing.T) {
 	joined := strings.Join(m.printlnBuf, "\n")
 	if n := strings.Count(joined, "💭"); n != 2 {
 		t.Errorf("each reasoning block should get a 💭; got %d in:\n%s", n, joined)
+	}
+}
+
+// Resuming a session replays prior turns into the scrollback: prompts and
+// replies verbatim, tool calls collapsed to a one-line ✓/✗ (no raw output),
+// closed by a dim "resumed" marker.
+func TestTUI_ReplayHistoryLines(t *testing.T) {
+	m := newTestModel()
+	m.width = 80
+	h := m.a.History
+	h.Append(agent.NewUserMessage("hello there"))
+	h.Append(agent.NewToolUseMessage([]agent.ContentBlock{
+		agent.NewTextBlock("let me check"),
+		agent.NewToolUseBlock("c1", "terminal", map[string]any{"command": "ls"}),
+	}))
+	h.Append(agent.NewToolResultMessage([]agent.ContentBlock{
+		agent.NewToolResultBlock("c1", "file1\nfile2", false),
+	}))
+	h.Append(agent.NewAssistantMessage("here are the files"))
+
+	joined := stripANSI(strings.Join(m.replayHistoryLines(), "\n"))
+
+	for _, want := range []string{"hello there", "let me check", "here are the files", "terminal", "✓", "resumed"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("replay missing %q; got:\n%s", want, joined)
+		}
+	}
+	// The collapsed tool line must NOT include the raw tool output.
+	if strings.Contains(joined, "file1") {
+		t.Errorf("raw tool output should be collapsed away; got:\n%s", joined)
+	}
+}
+
+// stripANSI removes ANSI SGR escape sequences so assertions can match the
+// underlying text (glamour splits words across color spans).
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string { return ansiRE.ReplaceAllString(s, "") }
+
+func TestTUI_ReplayHistoryLines_FreshSessionEmpty(t *testing.T) {
+	m := newTestModel()
+	if lines := m.replayHistoryLines(); lines != nil {
+		t.Errorf("a fresh session should replay nothing; got %v", lines)
+	}
+}
+
+// A failed tool call collapses to a ✗ line.
+func TestTUI_ReplayHistoryLines_ToolError(t *testing.T) {
+	m := newTestModel()
+	m.width = 80
+	h := m.a.History
+	h.Append(agent.NewUserMessage("run it"))
+	h.Append(agent.NewToolUseMessage([]agent.ContentBlock{
+		agent.NewToolUseBlock("c1", "terminal", map[string]any{"command": "boom"}),
+	}))
+	h.Append(agent.NewToolResultMessage([]agent.ContentBlock{
+		agent.NewToolResultBlock("c1", "exit 1", true),
+	}))
+
+	joined := strings.Join(m.replayHistoryLines(), "\n")
+	if !strings.Contains(joined, "✗") {
+		t.Errorf("failed tool should collapse to a ✗ line; got:\n%s", joined)
 	}
 }
 


### PR DESCRIPTION
## What

Resuming a session (`octo chat -c <id>`) restored the history into the agent, but the TUI opened at a **blank screen** — none of the prior conversation was shown, so you had no visible context for what you were continuing.

Now, on resume the TUI replays the restored turns into the scrollback.

## Behavior

Rendered on the first `WindowSizeMsg` (so markdown wraps to the real terminal width, not the Init-time fallback):

- **User prompts** and **assistant replies** verbatim — markdown-rendered (raw under `--plain`).
- **Tool calls collapsed** to a one-line `↳ verb(target) ✓/✗` summary — `tool_use` paired with its `tool_result` by ID for the outcome — so old command output / search-result JSON doesn't flood the scrollback. (Per the chosen "conversation-focused" fidelity.)
- Closed by a dim **`── resumed · N messages ──`** marker delimiting history from the live input.
- Pure `tool_result` carrier messages are not echoed as user turns; a fresh session replays nothing.

## Tests

- `TestTUI_ReplayHistoryLines` — prompts + replies + a collapsed `✓` tool line + the marker present; raw tool output absent.
- `TestTUI_ReplayHistoryLines_ToolError` — failed tool collapses to `✗`.
- `TestTUI_ReplayHistoryLines_FreshSessionEmpty` — fresh session replays nothing.
- `go build`, `gofmt -l` (empty), `go vet`, `go test ./cmd/octo/` green.

## Note

Replay is read-only and TUI-only (resume already requires a TTY). The agent's loaded `History` is unchanged, so the next turn still hits the same prompt cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)