### PR TITLE
feat(tui): slim the status bar, move key hints into the startup banner

### DIFF
--- a/cmd/octo/tuirepl_p2_test.go
+++ b/cmd/octo/tuirepl_p2_test.go
@@ -4,22 +4,27 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
-func TestRenderStatusBar_ShowsModelAndHint(t *testing.T) {
-	m := newTestModel() // agent model name is "m"
-	out := m.renderStatusBar()
-	if !strings.Contains(out, "m") {
-		t.Errorf("status bar should include the model; got:\n%s", out)
+// The status bar is a compact cwd / context% / perm strip: no key hints (those
+// live in the startup banner) and no running-turn duration.
+func TestRenderStatusBar_NoHintNoDuration(t *testing.T) {
+	m := newTestModel()
+	if !strings.Contains(m.renderStatusBar(), m.cwd) {
+		t.Errorf("status bar should include the cwd; got:\n%s", m.renderStatusBar())
 	}
-	// Idle: no persistent hint (the startup hint is shown once in the Banner).
-	if strings.Contains(out, "Enter send") {
-		t.Errorf("idle status bar should NOT show a persistent send hint; got:\n%s", out)
-	}
-	// Running hint switches.
+
 	m.turnRunning = true
-	if got := m.renderStatusBar(); !strings.Contains(got, "interrupt") {
-		t.Errorf("running status bar should show the interrupt hint; got:\n%s", got)
+	m.turnStart = time.Now().Add(-90 * time.Second)
+	out := m.renderStatusBar()
+	for _, hint := range []string{"Enter", "interrupt", "newline", "queue"} {
+		if strings.Contains(out, hint) {
+			t.Errorf("status bar must not show key hint %q (banner owns hints); got:\n%s", hint, out)
+		}
+	}
+	if strings.Contains(out, "1m30s") || strings.Contains(out, "elapsed") {
+		t.Errorf("status bar must not show the turn duration; got:\n%s", out)
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -749,11 +749,7 @@ func (m *tuiModel) liveHeight() int {
 	}
 	h += m.completionHeight() // slash-completion menu (0 when closed)
 	h += m.ta.Height()        // input box (textarea grows with content)
-	if m.turnRunning {
-		h += 3 // status bar with hint: separator + segments + hint
-	} else {
-		h += 2 // status bar without hint: separator + segments
-	}
+	h += 2                    // status bar: separator + segments (no hint line)
 	return h
 }
 
@@ -953,22 +949,11 @@ func (m *tuiModel) renderStatusBar() string {
 	if m.cfg.permEngine != nil {
 		segs = append(segs, [2]string{"perm", string(m.cfg.permEngine.GetMode())})
 	}
-	if m.turnRunning && !m.turnStart.IsZero() {
-		segs = append(segs, [2]string{"elapsed", time.Since(m.turnStart).Round(time.Second).String()})
-	}
 
-	var hint string
-	if m.turnRunning {
-		esc := "Esc interrupt"
-		if m.echoPending != "" {
-			esc = "Esc take back" // no output yet — Esc returns the message to the input
-		}
-		hint = "Enter steer · Shift+Enter/Alt+Enter/Ctrl+J newline · Ctrl+Q queue · " + esc
-		if len(m.queue) > 0 {
-			hint += " · Ctrl+X unqueue"
-		}
-	}
-	return tui.StatusBar(segs, hint, m.width)
+	// Key hints live in the startup banner, not here, and the running-turn
+	// duration is intentionally omitted — the status bar stays a compact
+	// cwd / context% / perm-mode strip.
+	return tui.StatusBar(segs, "", m.width)
 }
 
 // workingDir returns the current directory, or "" if it can't be determined.

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -58,7 +58,17 @@ var (
 			Foreground(ColMuted)
 	bannerSepStyle = lipgloss.NewStyle().
 			Foreground(ColBorder)
+	bannerHintStyle = lipgloss.NewStyle().
+			Foreground(ColDimmer).
+			Italic(true)
 )
+
+// bannerHints are the key bindings shown beside the mascot at startup, so the
+// bottom status bar can stay free of a persistent hint line.
+var bannerHints = []string{
+	"Enter send · Shift+Enter/Ctrl+J newline · Ctrl+Q queue",
+	"Shift+Tab perm-mode · Esc interrupt · Ctrl+C quit",
+}
 
 // octopusASCII is the pixel-art octo mascot (8x7 grid).
 var octopusASCII = []string{
@@ -106,6 +116,12 @@ func Banner(version, model, cwd string, width int) string {
 		case 2:
 			b.WriteString("  ")
 			b.WriteString(bannerSubStyle.Render(info))
+		case 3:
+			b.WriteString("  ")
+			b.WriteString(bannerHintStyle.Render(bannerHints[0]))
+		case 4:
+			b.WriteString("  ")
+			b.WriteString(bannerHintStyle.Render(bannerHints[1]))
 		}
 		b.WriteByte('\n')
 	}

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -54,6 +54,16 @@ func TestBanner_ContainsTitleAndInfo(t *testing.T) {
 	}
 }
 
+// Key hints moved from the status bar into the startup banner.
+func TestBanner_ContainsKeyHints(t *testing.T) {
+	out := Banner("", "claude", "~/proj", 60)
+	for _, want := range []string{"Enter send", "newline", "Ctrl+Q queue", "Esc interrupt", "Ctrl+C quit"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Banner missing key hint %q in:\n%s", want, out)
+		}
+	}
+}
+
 func TestBanner_MinWidth(t *testing.T) {
 	out := Banner("", "", "", 5)
 	if !strings.Contains(out, "octo chat") {


### PR DESCRIPTION
## What

The bottom status bar carried a running-turn **duration** and a persistent **key-hint line** under it. Both are noise once you know the shortcuts.

**Before**
```
~/Projects/github/octo-agent · 35% · auto · 12m43s
Enter steer · Shift+Enter/Alt+Enter/Ctrl+J newline · Ctrl+Q queue · Esc interrupt
```

**After** — status bar is a compact strip, hints shown once at startup:
```
~/Projects/github/octo-agent · 35% · auto
```
```
    ████████
  ████░░░░████  ◆ octo chat  0.12.1-dev
  ████████████  k2.6 · ~/Projects/github/octo-agent
████████████████  Enter send · Shift+Enter/Ctrl+J newline · Ctrl+Q queue
████  ████  ████  Shift+Tab perm-mode · Esc interrupt · Ctrl+C quit
██    ████    ██
      ████
──────────────────────────────────────────────────────────────────────
```

## Changes

- `renderStatusBar`: drop the `elapsed` duration segment and the per-turn hint line → `cwd / context% / perm` only.
- Live-height accounting for the status bar is now a constant 2 lines (separator + segments).
- `tui.Banner`: render the key bindings on two dimmed lines beside the mascot.

## Tests

- `TestRenderStatusBar_NoHintNoDuration` — status bar shows the cwd, never a key hint, never a duration (even mid-turn).
- `TestBanner_ContainsKeyHints` — banner includes the binding hints.
- Existing banner/status tests updated; `go build`, `gofmt -l` (empty), `go vet`, `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)