### PR TITLE
feat(tools): spill large web_fetch responses + guard non-text content

### DIFF
--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -29,6 +31,17 @@ var jinaReaderHostForTest = JinaReaderHost
 // targeted slices via grep / a follow-up fetch.
 const WebFetchMaxBytes = 200_000
 
+// WebFetchPreviewBytes is the size past which web_fetch writes the full
+// response to a temp file and returns only a preview summary. Below this
+// the body is returned inline (same behaviour as before).
+const WebFetchPreviewBytes = 8 * 1024
+
+// WebFetchPreviewLines bounds the head+tail preview when output is spilled.
+const (
+	webFetchPreviewHeadLines = 30
+	webFetchPreviewTailLines = 10
+)
+
 // WebFetchTool fetches a URL and returns its body as Markdown. It prefers
 // the Jina AI Reader proxy for JS-rendered pages and clean HTML-to-Markdown
 // conversion, but falls back to a direct HTTP fetch when the proxy fails.
@@ -39,8 +52,10 @@ func (WebFetchTool) Definition() agent.ToolDefinition {
 		Name: "web_fetch",
 		Description: "Fetch a URL and return its content. Prefers the Jina Reader proxy " +
 			"for JS-rendered pages and clean HTML-to-Markdown conversion; falls back to " +
-			"a direct HTTP fetch when the proxy is unavailable. Response is truncated at " +
-			"~200 KB; for long pages, fetch a more specific URL or grep the returned text. " +
+			"a direct HTTP fetch when the proxy is unavailable. " +
+			"Responses larger than ~8 KB are saved to a temp file; the tool returns a " +
+			"preview summary (size, content-type, first/last lines) plus the file path. " +
+			"Use read_file or grep on that path to inspect the full content. " +
 			"Public web only — no authentication.",
 		Parameters: map[string]any{
 			"type": "object",
@@ -156,7 +171,7 @@ func fetchViaJina(ctx context.Context, rawURL string) (agent.ToolResult, error) 
 		return agent.ToolResult{Text: ""}, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
-	return readBody(resp.Body)
+	return readBody(resp.Body, rawURL, resp.Header.Get("Content-Type"))
 }
 
 // fetchDirect performs a direct HTTP GET against the original URL. It uses
@@ -193,12 +208,13 @@ func fetchDirect(ctx context.Context, rawURL string) (agent.ToolResult, error) {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
-	return readBody(resp.Body)
+	return readBody(resp.Body, rawURL, resp.Header.Get("Content-Type"))
 }
 
-// readBody reads up to WebFetchMaxBytes+1 from r, truncating if necessary
-// and appending a clear marker.
-func readBody(r io.Reader) (agent.ToolResult, error) {
+// readBody reads the full body, caps it at WebFetchMaxBytes, then either
+// returns it inline (if small) or spills it to a temp file and returns a
+// preview summary.
+func readBody(r io.Reader, sourceURL, contentType string) (agent.ToolResult, error) {
 	body, err := io.ReadAll(io.LimitReader(r, WebFetchMaxBytes+1))
 	if err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("read body: %w", err)
@@ -209,11 +225,86 @@ func readBody(r io.Reader) (agent.ToolResult, error) {
 		truncated = true
 	}
 
-	out := string(body)
-	if truncated {
-		out += "\n\n…[truncated at " + strconv.Itoa(WebFetchMaxBytes) + " bytes]"
+	// Small enough — return inline (preserves old behaviour for tiny pages).
+	if len(body) <= WebFetchPreviewBytes {
+		out := string(body)
+		if truncated {
+			out += "\n\n…[truncated at " + strconv.Itoa(WebFetchMaxBytes) + " bytes]"
+		}
+		return agent.ToolResult{Text: out}, nil
 	}
-	return agent.ToolResult{Text: out}, nil
+
+	// Large — spill to temp file and return preview summary.
+	return spillWebFetch(body, sourceURL, contentType, truncated)
+}
+
+// spillWebFetch writes body to a temp file and returns a preview summary
+// with file path, size, content-type, and head+tail lines.
+func spillWebFetch(body []byte, sourceURL, contentType string, truncated bool) (agent.ToolResult, error) {
+	text := string(body)
+	lines := strings.Split(text, "\n")
+
+	path, err := writeWebFetchSpillFile(sourceURL, body)
+	if err != nil {
+		// Degrade gracefully: return inline on write failure.
+		out := text
+		if truncated {
+			out += "\n\n…[truncated at " + strconv.Itoa(WebFetchMaxBytes) + " bytes]"
+		}
+		return agent.ToolResult{Text: out}, nil
+	}
+
+	headCount := webFetchPreviewHeadLines
+	if headCount > len(lines) {
+		headCount = len(lines)
+	}
+	tailCount := webFetchPreviewTailLines
+	if tailCount > len(lines)-headCount {
+		tailCount = len(lines) - headCount
+	}
+
+	var preview strings.Builder
+	fmt.Fprintf(&preview, "URL: %s\n", sourceURL)
+	fmt.Fprintf(&preview, "Size: %s (%d lines)\n", formatBytes(int64(len(body))), len(lines))
+	if contentType != "" {
+		fmt.Fprintf(&preview, "Content-Type: %s\n", contentType)
+	}
+	fmt.Fprintf(&preview, "Saved to: %s\n", path)
+	if truncated {
+		fmt.Fprintf(&preview, "Note: response truncated at %s (server sent more)\n", formatBytes(int64(WebFetchMaxBytes)))
+	}
+	fmt.Fprintf(&preview, "\n--- first %d lines ---\n", headCount)
+	preview.WriteString(strings.Join(lines[:headCount], "\n"))
+	if tailCount > 0 {
+		fmt.Fprintf(&preview, "\n\n--- last %d lines ---\n", tailCount)
+		preview.WriteString(strings.Join(lines[len(lines)-tailCount:], "\n"))
+	}
+	fmt.Fprintf(&preview, "\n\n[Full content saved to %s — use read_file or grep to inspect.]", path)
+
+	return agent.ToolResult{Text: preview.String()}, nil
+}
+
+// writeWebFetchSpillFile persists body under ~/.octo/tmp and returns the
+// absolute path. The filename is derived from the URL host + a timestamp
+// so concurrent fetches never collide.
+func writeWebFetchSpillFile(sourceURL string, body []byte) (string, error) {
+	dir, err := spillDir()
+	if err != nil {
+		return "", err
+	}
+	sweepOldSpillFiles(dir)
+
+	u, _ := url.Parse(sourceURL)
+	host := "unknown"
+	if u != nil && u.Host != "" {
+		host = sanitizeSpillID(u.Host)
+	}
+	name := fmt.Sprintf("webfetch-%s-%d.log", host, time.Now().UnixNano())
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 // webHTTPClient is the shared http.Client used by the network backends of

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -56,6 +56,8 @@ func (WebFetchTool) Definition() agent.ToolDefinition {
 			"Responses larger than ~8 KB are saved to a temp file; the tool returns a " +
 			"preview summary (size, content-type, first/last lines) plus the file path. " +
 			"Use read_file or grep on that path to inspect the full content. " +
+			"Returns text only — for a binary/image URL it returns a short notice (download " +
+			"it with the terminal tool, then read_file an image for multimodal viewing). " +
 			"Public web only — no authentication.",
 		Parameters: map[string]any{
 			"type": "object",
@@ -215,6 +217,14 @@ func fetchDirect(ctx context.Context, rawURL string) (agent.ToolResult, error) {
 // returns it inline (if small) or spills it to a temp file and returns a
 // preview summary.
 func readBody(r io.Reader, sourceURL, contentType string) (agent.ToolResult, error) {
+	// Content-type guard: web_fetch only returns text. A binary response
+	// (image, PDF, audio/video, archive, …) would otherwise be stringified into
+	// garbage that wastes the model's context. Return a clean pointer to the
+	// right tool instead of reading the body at all.
+	if !isTextualContentType(contentType) {
+		return agent.ToolResult{Text: binaryContentNotice(sourceURL, contentType)}, nil
+	}
+
 	body, err := io.ReadAll(io.LimitReader(r, WebFetchMaxBytes+1))
 	if err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("read body: %w", err)
@@ -236,6 +246,84 @@ func readBody(r io.Reader, sourceURL, contentType string) (agent.ToolResult, err
 
 	// Large — spill to temp file and return preview summary.
 	return spillWebFetch(body, sourceURL, contentType, truncated)
+}
+
+// mediaType returns the lowercased media type of a Content-Type header,
+// stripping any ";charset=…" / boundary parameters and surrounding space.
+func mediaType(contentType string) string {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = strings.TrimSpace(ct[:i])
+	}
+	return ct
+}
+
+// isTextualContentType reports whether a Content-Type names text web_fetch can
+// usefully return. An empty type is treated as text — many servers omit it and
+// the body is usually HTML/markdown. Covers text/*, JSON/XML/JS, and the
+// +json / +xml structured-syntax suffixes.
+func isTextualContentType(contentType string) bool {
+	ct := mediaType(contentType)
+	if ct == "" {
+		return true
+	}
+	if strings.HasPrefix(ct, "text/") {
+		return true
+	}
+	if strings.HasSuffix(ct, "+json") || strings.HasSuffix(ct, "+xml") {
+		return true
+	}
+	switch ct {
+	case "application/json", "application/xml", "application/javascript",
+		"application/ecmascript", "application/markdown", "application/x-ndjson",
+		"application/x-www-form-urlencoded", "application/yaml", "application/x-yaml":
+		return true
+	}
+	return false
+}
+
+// imageTypeExtension maps an image media type to the file extension read_file
+// recognises (so a downloaded image is rendered visually, not refused). Returns
+// "" for non-image or unknown types.
+func imageTypeExtension(ct string) string {
+	switch mediaType(ct) {
+	case "image/png":
+		return ".png"
+	case "image/jpeg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	case "image/bmp":
+		return ".bmp"
+	case "image/tiff":
+		return ".tiff"
+	case "image/heic":
+		return ".heic"
+	case "image/x-icon", "image/vnd.microsoft.icon":
+		return ".ico"
+	}
+	return ""
+}
+
+// binaryContentNotice is the message web_fetch returns for a non-text response:
+// it names the type and points at the tool that can actually handle it, instead
+// of dumping garbled bytes into the model's context.
+func binaryContentNotice(sourceURL, contentType string) string {
+	shown := strings.TrimSpace(contentType)
+	if shown == "" {
+		shown = "non-text"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "web_fetch: %s returned %s content — web_fetch only handles text, so the bytes are not shown.\n", sourceURL, shown)
+	if ext := imageTypeExtension(contentType); ext != "" {
+		fmt.Fprintf(&b, "To view this image, download it and open it with read_file (which returns images for multimodal viewing):\n")
+		fmt.Fprintf(&b, "  terminal: curl -sL %q -o /tmp/web_fetch_image%s\n  read_file: /tmp/web_fetch_image%s", sourceURL, ext, ext)
+	} else {
+		b.WriteString("If you need its contents, download it with the terminal tool (curl/wget) and use the appropriate tool on the saved file.")
+	}
+	return b.String()
 }
 
 // spillWebFetch writes body to a temp file and returns a preview summary

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -10,6 +10,54 @@ import (
 	"time"
 )
 
+// A non-text response (e.g. an image) must not be stringified into garbage:
+// readBody returns a clean notice pointing at the right tool, with no raw bytes.
+func TestReadBody_BinaryContentTypeGuarded(t *testing.T) {
+	png := "\x89PNG\r\n\x1a\nBINARY-PIXEL-JUNK"
+	res, err := readBody(strings.NewReader(png), "https://x.test/logo.png", "image/png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(res.Text, "PNG") || strings.Contains(res.Text, "BINARY-PIXEL-JUNK") {
+		t.Errorf("binary bytes must not leak into the result; got:\n%s", res.Text)
+	}
+	for _, want := range []string{"image/png", "read_file", ".png", "curl"} {
+		if !strings.Contains(res.Text, want) {
+			t.Errorf("image notice should mention %q; got:\n%s", want, res.Text)
+		}
+	}
+	if len(res.Blocks) != 0 {
+		t.Errorf("guard must not emit content blocks (text-only notice); got %d", len(res.Blocks))
+	}
+}
+
+func TestReadBody_TextContentTypePassesThrough(t *testing.T) {
+	res, err := readBody(strings.NewReader("# hello world"), "https://x.test", "text/markdown; charset=utf-8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Text, "hello world") {
+		t.Errorf("text content should pass through unchanged; got:\n%s", res.Text)
+	}
+}
+
+func TestIsTextualContentType(t *testing.T) {
+	textual := []string{"", "text/html", "text/plain; charset=utf-8", "application/json",
+		"application/xhtml+xml", "image/svg+xml", "application/atom+xml", "application/x-ndjson"}
+	for _, ct := range textual {
+		if !isTextualContentType(ct) {
+			t.Errorf("%q should be treated as textual", ct)
+		}
+	}
+	binary := []string{"image/png", "image/jpeg", "application/pdf", "application/octet-stream",
+		"audio/mpeg", "video/mp4", "font/woff2", "application/zip"}
+	for _, ct := range binary {
+		if isTextualContentType(ct) {
+			t.Errorf("%q should NOT be treated as textual", ct)
+		}
+	}
+}
+
 // withJinaHost swaps JinaReaderHost for the test server URL. Since
 // JinaReaderHost is a const, we test by directly hitting the helper that
 // uses the URL passed in. Instead, we mock at the network layer by setting

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -158,8 +159,81 @@ func TestWebFetch_Truncates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
+	// Large responses are now spilled to a temp file; the preview should
+	// mention truncation and provide a file path.
 	if !strings.Contains(out.Text, "truncated") {
 		t.Errorf("expected truncation marker, got tail: %q", out.Text[max(0, len(out.Text)-100):])
+	}
+	if !strings.Contains(out.Text, "Saved to:") {
+		t.Errorf("expected spilled file path in preview, got: %q", out.Text)
+	}
+}
+
+func TestWebFetch_SmallResponseNotSpilled(t *testing.T) {
+	// A tiny body should be returned inline (old behaviour).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hello world"))
+	}))
+	defer srv.Close()
+
+	old := jinaReaderHostForTest
+	jinaReaderHostForTest = srv.URL + "/"
+	defer func() { jinaReaderHostForTest = old }()
+
+	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
+		"url": "https://example.com/small",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.Text != "hello world" {
+		t.Errorf("expected inline small response, got: %q", out.Text)
+	}
+}
+
+func TestWebFetch_LargeResponseSpilled(t *testing.T) {
+	// A body larger than WebFetchPreviewBytes should be spilled.
+	// Each line is short so we have many lines (line-based preview is useful).
+	line := strings.Repeat("x", 50) + "\n"
+	repeatCount := (WebFetchPreviewBytes / len(line)) + 20
+	big := strings.Repeat(line, repeatCount)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(big))
+	}))
+	defer srv.Close()
+
+	old := jinaReaderHostForTest
+	jinaReaderHostForTest = srv.URL + "/"
+	defer func() { jinaReaderHostForTest = old }()
+
+	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
+		"url": "https://example.com/large",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.Text, "Saved to:") {
+		t.Errorf("expected spilled file path, got: %q", out.Text)
+	}
+	if !strings.Contains(out.Text, "Content-Type:") {
+		t.Errorf("expected content-type in preview, got: %q", out.Text)
+	}
+	if !strings.Contains(out.Text, "first 30 lines") {
+		t.Errorf("expected head preview, got: %q", out.Text)
+	}
+	// Make sure the file actually exists and contains the full body.
+	pathLine := strings.SplitN(out.Text, "Saved to: ", 2)
+	if len(pathLine) < 2 {
+		t.Fatalf("could not extract file path from output")
+	}
+	path := strings.SplitN(pathLine[1], "\n", 2)[0]
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("spill file not readable: %v", err)
+	}
+	if string(data) != big {
+		t.Errorf("spill file content mismatch")
 	}
 }
 


### PR DESCRIPTION
Two related `web_fetch` improvements.

## 1. Spill large responses to a temp file

Previously a large page was truncated at ~200 KB and dumped inline, flooding context. Now responses larger than ~8 KB are written to a temp file under `~/.octo/tmp`, and the tool returns a **preview summary** — size, content-type, first/last lines, and the saved path — so the model can `read_file`/`grep` the full content on demand. Small pages still return inline (unchanged).

## 2. Content-type guard for non-text responses

`readBody` stringified whatever bytes came back, so a binary URL (image, PDF, archive, audio/video) became garbled text that wasted context. Now it checks `Content-Type` first:

- **Non-text** (`image/*`, `application/pdf`, `application/octet-stream`, `audio/*`, `video/*`, `font/*`, `application/zip`, …) → a short notice naming the type and pointing at the right tool. For images it gives the exact `curl … -o /tmp/web_fetch_image.<ext>` + `read_file` steps (extension derived from the type) so the image renders for multimodal viewing.
- **Text** (`text/*`, JSON/XML/JS, `+json`/`+xml` suffixes; empty type assumed text) → passes through unchanged.

No image bytes are returned by `web_fetch` itself — viewing is already covered by the `terminal` (download) + `read_file` (visual read) path; this just stops the garbage and points the way.

## Tests

- Spill: large response saved + preview summary returned; small response inline.
- Guard: `TestReadBody_BinaryContentTypeGuarded` (image/png → notice with `read_file`/`.png`/`curl`, no raw bytes, no blocks), `TestReadBody_TextContentTypePassesThrough`, `TestIsTextualContentType` (text vs binary table).
- `go build`, `gofmt -l` (empty), `go vet`, `go test ./internal/tools/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)