### PR TITLE
fix(tools): web_fetch — 64 KB inline threshold + outline/head spill preview

### DIFF
--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -35,14 +35,17 @@ const WebFetchMaxBytes = 5 * 1024 * 1024 // 5 MB
 
 // WebFetchInlineBytes is the size up to which a fetched body is returned
 // inline. Larger responses (up to WebFetchMaxBytes) are written to a temp file
-// and summarised with a head+tail preview, so a big page never floods the
+// and summarised with an outline + head preview, so a big page never floods the
 // model's context while its full content stays one read_file away.
 const WebFetchInlineBytes = 64 * 1024
 
-// WebFetchPreviewLines bounds the head+tail preview when output is spilled.
+// Preview bounds when a spilled response is summarised: a markdown-heading
+// outline (so the page structure is visible for targeted read_file/grep) plus
+// the opening lines. The tail is omitted — for a web page it's usually footer
+// noise, while the substance sits in the body the outline maps.
 const (
-	webFetchPreviewHeadLines = 30
-	webFetchPreviewTailLines = 10
+	webFetchPreviewHeadLines   = 40
+	webFetchOutlineMaxHeadings = 50
 )
 
 // WebFetchTool fetches a URL and returns its body as Markdown. It prefers
@@ -326,8 +329,9 @@ func binaryContentNotice(sourceURL, contentType string) string {
 	return b.String()
 }
 
-// spillWebFetch writes body to a temp file and returns a preview summary
-// with file path, size, content-type, and head+tail lines.
+// spillWebFetch writes body to a temp file and returns a preview summary with
+// file path, size, content-type, a markdown-heading outline, and the opening
+// lines.
 func spillWebFetch(body []byte, sourceURL, contentType string, truncated bool) (agent.ToolResult, error) {
 	text := string(body)
 	lines := strings.Split(text, "\n")
@@ -346,10 +350,6 @@ func spillWebFetch(body []byte, sourceURL, contentType string, truncated bool) (
 	if headCount > len(lines) {
 		headCount = len(lines)
 	}
-	tailCount := webFetchPreviewTailLines
-	if tailCount > len(lines)-headCount {
-		tailCount = len(lines) - headCount
-	}
 
 	var preview strings.Builder
 	fmt.Fprintf(&preview, "URL: %s\n", sourceURL)
@@ -361,15 +361,60 @@ func spillWebFetch(body []byte, sourceURL, contentType string, truncated bool) (
 	if truncated {
 		fmt.Fprintf(&preview, "Note: response truncated at %s (server sent more)\n", formatBytes(int64(WebFetchMaxBytes)))
 	}
+	if outline := markdownOutline(lines, webFetchOutlineMaxHeadings); outline != "" {
+		preview.WriteString("\n--- outline (headings) ---\n")
+		preview.WriteString(outline)
+	}
 	fmt.Fprintf(&preview, "\n--- first %d lines ---\n", headCount)
 	preview.WriteString(strings.Join(lines[:headCount], "\n"))
-	if tailCount > 0 {
-		fmt.Fprintf(&preview, "\n\n--- last %d lines ---\n", tailCount)
-		preview.WriteString(strings.Join(lines[len(lines)-tailCount:], "\n"))
-	}
 	fmt.Fprintf(&preview, "\n\n[Full content saved to %s — use read_file or grep to inspect.]", path)
 
 	return agent.ToolResult{Text: preview.String()}, nil
+}
+
+// markdownOutline extracts ATX markdown headings (#, ##, … up to ######) and
+// renders them as an indented outline, so a spilled page's structure is visible
+// at a glance for targeted read_file/grep. Headings inside fenced code blocks
+// are ignored. Returns "" when there are no headings (raw HTML, plain text,
+// JSON); at most maxHeadings are listed, with a trailing "+N more" count.
+func markdownOutline(lines []string, maxHeadings int) string {
+	var b strings.Builder
+	shown, total := 0, 0
+	inFence := false
+	for _, ln := range lines {
+		t := strings.TrimSpace(ln)
+		if strings.HasPrefix(t, "```") || strings.HasPrefix(t, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		level := 0
+		for level < len(t) && t[level] == '#' {
+			level++
+		}
+		// An ATX heading is 1–6 '#' followed by a space and some text.
+		if level < 1 || level > 6 || level >= len(t) || t[level] != ' ' {
+			continue
+		}
+		title := strings.TrimSpace(t[level+1:])
+		if title == "" {
+			continue
+		}
+		total++
+		if shown < maxHeadings {
+			fmt.Fprintf(&b, "%s%s\n", strings.Repeat("  ", level-1), title)
+			shown++
+		}
+	}
+	if total == 0 {
+		return ""
+	}
+	if total > shown {
+		fmt.Fprintf(&b, "… +%d more heading(s)\n", total-shown)
+	}
+	return b.String()
 }
 
 // writeWebFetchSpillFile persists body under ~/.octo/tmp and returns the

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -26,15 +26,18 @@ const JinaReaderHost = "https://r.jina.ai/"
 // out to a local httptest server; production reads the const default.
 var jinaReaderHostForTest = JinaReaderHost
 
-// WebFetchMaxBytes caps the response size returned to the LLM. Past this,
-// the body is truncated with a clear marker so the LLM can ask for more
-// targeted slices via grep / a follow-up fetch.
-const WebFetchMaxBytes = 200_000
+// WebFetchMaxBytes is the absolute ceiling on a single fetched body, whether
+// returned inline or spilled to a temp file. It bounds memory and disk for a
+// pathological response; past it the body is truncated with a clear marker.
+// Set well above any real page so the spilled file holds the full content in
+// practice.
+const WebFetchMaxBytes = 5 * 1024 * 1024 // 5 MB
 
-// WebFetchPreviewBytes is the size past which web_fetch writes the full
-// response to a temp file and returns only a preview summary. Below this
-// the body is returned inline (same behaviour as before).
-const WebFetchPreviewBytes = 8 * 1024
+// WebFetchInlineBytes is the size up to which a fetched body is returned
+// inline. Larger responses (up to WebFetchMaxBytes) are written to a temp file
+// and summarised with a head+tail preview, so a big page never floods the
+// model's context while its full content stays one read_file away.
+const WebFetchInlineBytes = 64 * 1024
 
 // WebFetchPreviewLines bounds the head+tail preview when output is spilled.
 const (
@@ -53,7 +56,7 @@ func (WebFetchTool) Definition() agent.ToolDefinition {
 		Description: "Fetch a URL and return its content. Prefers the Jina Reader proxy " +
 			"for JS-rendered pages and clean HTML-to-Markdown conversion; falls back to " +
 			"a direct HTTP fetch when the proxy is unavailable. " +
-			"Responses larger than ~8 KB are saved to a temp file; the tool returns a " +
+			"Responses larger than ~64 KB are saved to a temp file; the tool returns a " +
 			"preview summary (size, content-type, first/last lines) plus the file path. " +
 			"Use read_file or grep on that path to inspect the full content. " +
 			"Returns text only — for a binary/image URL it returns a short notice (download " +
@@ -213,9 +216,9 @@ func fetchDirect(ctx context.Context, rawURL string) (agent.ToolResult, error) {
 	return readBody(resp.Body, rawURL, resp.Header.Get("Content-Type"))
 }
 
-// readBody reads the full body, caps it at WebFetchMaxBytes, then either
-// returns it inline (if small) or spills it to a temp file and returns a
-// preview summary.
+// readBody reads the body (capped at WebFetchMaxBytes), then either returns it
+// inline (≤ WebFetchInlineBytes) or spills the full content to a temp file and
+// returns a head+tail preview summary.
 func readBody(r io.Reader, sourceURL, contentType string) (agent.ToolResult, error) {
 	// Content-type guard: web_fetch only returns text. A binary response
 	// (image, PDF, audio/video, archive, …) would otherwise be stringified into
@@ -235,16 +238,13 @@ func readBody(r io.Reader, sourceURL, contentType string) (agent.ToolResult, err
 		truncated = true
 	}
 
-	// Small enough — return inline (preserves old behaviour for tiny pages).
-	if len(body) <= WebFetchPreviewBytes {
-		out := string(body)
-		if truncated {
-			out += "\n\n…[truncated at " + strconv.Itoa(WebFetchMaxBytes) + " bytes]"
-		}
-		return agent.ToolResult{Text: out}, nil
+	// Within the inline budget — return it directly. An inline body is always
+	// well under WebFetchMaxBytes, so it is never truncated here.
+	if len(body) <= WebFetchInlineBytes {
+		return agent.ToolResult{Text: string(body)}, nil
 	}
 
-	// Large — spill to temp file and return preview summary.
+	// Larger — spill the full body to a temp file and return a preview summary.
 	return spillWebFetch(body, sourceURL, contentType, truncated)
 }
 

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -271,6 +271,86 @@ func TestWebFetch_MediumResponseInline(t *testing.T) {
 	}
 }
 
+func TestMarkdownOutline(t *testing.T) {
+	src := []string{
+		"# Title",
+		"intro text",
+		"## Section A",
+		"body",
+		"### Sub A.1",
+		"```",
+		"## NotAHeading (inside fence)",
+		"```",
+		"## Section B",
+		"#nospace is not a heading",
+		"####### too many hashes",
+	}
+	got := markdownOutline(src, 50)
+	for _, want := range []string{"Title", "Section A", "Sub A.1", "Section B"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("outline missing %q; got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "NotAHeading") {
+		t.Errorf("headings inside code fences must be ignored; got:\n%s", got)
+	}
+	if strings.Contains(got, "nospace") || strings.Contains(got, "too many hashes") {
+		t.Errorf("non-ATX lines must not count as headings; got:\n%s", got)
+	}
+	// Indentation reflects level: "## Section A" sits one indent below "# Title".
+	if !strings.Contains(got, "\n  Section A\n") {
+		t.Errorf("level-2 heading should be indented two spaces; got:\n%s", got)
+	}
+
+	// No headings (e.g. raw HTML / plain text) → empty outline.
+	if out := markdownOutline([]string{"<html>", "plain text", "more"}, 50); out != "" {
+		t.Errorf("no-heading input should yield empty outline, got %q", out)
+	}
+
+	// Cap respected with a "+N more" tail.
+	many := make([]string, 0, 10)
+	for i := 0; i < 10; i++ {
+		many = append(many, "# H")
+	}
+	if out := markdownOutline(many, 3); !strings.Contains(out, "+7 more") {
+		t.Errorf("expected '+7 more' when capped at 3 of 10; got:\n%s", out)
+	}
+}
+
+// A spilled markdown page surfaces a heading outline in its preview.
+func TestWebFetch_SpillIncludesOutline(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("# Main Title\n")
+	for i := 0; i < 3000; i++ { // push well past the 64 KB inline cap
+		sb.WriteString("filler line of body content\n")
+		if i == 1000 {
+			sb.WriteString("## Halfway Section\n")
+		}
+	}
+	body := sb.String()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/markdown")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	old := jinaReaderHostForTest
+	jinaReaderHostForTest = srv.URL + "/"
+	defer func() { jinaReaderHostForTest = old }()
+
+	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
+		"url": "https://example.com/doc",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, want := range []string{"outline (headings)", "Main Title", "Halfway Section", "Saved to:"} {
+		if !strings.Contains(out.Text, want) {
+			t.Errorf("spilled preview missing %q; got:\n%s", want, out.Text)
+		}
+	}
+}
+
 func TestWebFetch_LargeResponseSpilled(t *testing.T) {
 	// A body larger than WebFetchInlineBytes should be spilled.
 	// Each line is short so we have many lines (line-based preview is useful).
@@ -299,7 +379,7 @@ func TestWebFetch_LargeResponseSpilled(t *testing.T) {
 	if !strings.Contains(out.Text, "Content-Type:") {
 		t.Errorf("expected content-type in preview, got: %q", out.Text)
 	}
-	if !strings.Contains(out.Text, "first 30 lines") {
+	if !strings.Contains(out.Text, "first 40 lines") {
 		t.Errorf("expected head preview, got: %q", out.Text)
 	}
 	// Make sure the file actually exists and contains the full body.

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -239,11 +239,43 @@ func TestWebFetch_SmallResponseNotSpilled(t *testing.T) {
 	}
 }
 
+// A medium page — bigger than the old 8 KB threshold but within the 64 KB
+// inline budget — is returned inline, not spilled. The common "fetch a doc and
+// read it" case shouldn't be forced into a second read_file round-trip.
+func TestWebFetch_MediumResponseInline(t *testing.T) {
+	body := strings.Repeat("line of content\n", 2000) // ~32 KB
+	if len(body) > WebFetchInlineBytes {
+		t.Fatalf("test body %d must stay under the inline cap %d", len(body), WebFetchInlineBytes)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	old := jinaReaderHostForTest
+	jinaReaderHostForTest = srv.URL + "/"
+	defer func() { jinaReaderHostForTest = old }()
+
+	out, err := WebFetchTool{}.Execute(context.Background(), "web_fetch", map[string]any{
+		"url": "https://example.com/medium",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(out.Text, "Saved to:") {
+		t.Errorf("a %d-byte response (≤ %d) should return inline, not spill", len(body), WebFetchInlineBytes)
+	}
+	if out.Text != body {
+		t.Errorf("inline response should be the body verbatim; got %d bytes, want %d", len(out.Text), len(body))
+	}
+}
+
 func TestWebFetch_LargeResponseSpilled(t *testing.T) {
-	// A body larger than WebFetchPreviewBytes should be spilled.
+	// A body larger than WebFetchInlineBytes should be spilled.
 	// Each line is short so we have many lines (line-based preview is useful).
 	line := strings.Repeat("x", 50) + "\n"
-	repeatCount := (WebFetchPreviewBytes / len(line)) + 20
+	repeatCount := (WebFetchInlineBytes / len(line)) + 20
 	big := strings.Repeat(line, repeatCount)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")


### PR DESCRIPTION
Follow-up to #365, tuning both the spill **threshold** and the spill **preview**.

## 1. Inline threshold 8 KB → 64 KB

The spill threshold was 8 KB, so normal pages (docs, READMEs, articles, API refs — typically 15–80 KB of markdown) all spilled to a temp file and came back as a tiny preview, forcing a second `read_file` round-trip for the common "fetch and read" case with no real context saving.

- **Inline up to 64 KB** (`WebFetchInlineBytes`) — typical pages return in one shot again.
- **Beyond 64 KB** — spill the full body + preview, where spill actually pays off.
- **Absolute ceiling 200 KB → 5 MB** (`WebFetchMaxBytes`) so the spilled file holds the **full** page, not a 200 KB truncation; only a pathological >5 MB response is truncated (existing marker). 5 MB matches the `read_file` image cap.

## 2. Preview: heading outline + head (was head/tail)

head/tail is a terminal-output heuristic. For a spilled **web page** the tail is usually footer/link noise and the substance sits in the middle — which head/tail skipped entirely. Now the preview is:

```
URL / Size / Content-Type / Saved to: …
--- outline (headings) ---
Main Title
  Section A
    Sub A.1
  Section B
--- first 40 lines ---
…
[Full content saved to … — use read_file or grep to inspect.]
```

The outline extracts ATX markdown headings (`#`..`######`), indented by level, **code-fence aware**, capped at 50 with a `+N more` tail. No headings (raw HTML / plain text / JSON) → outline omitted, head only. This gives the model the page's structure to grep/read precisely.

## Tests

- `TestWebFetch_MediumResponseInline` — ~32 KB page returns inline verbatim, not spilled (threshold regression guard).
- `TestMarkdownOutline` — heading extraction: levels/indent, code-fence skip, non-ATX rejection, no-heading→empty, cap + "+N more".
- `TestWebFetch_SpillIncludesOutline` — a spilled markdown page surfaces `outline (headings)` + its titles.
- Existing spill/inline/truncation tests updated; `go build`, `gofmt -l` (empty), `go vet`, `go test ./internal/tools/` all green.