### PR TITLE
fix(tui): stop overlapping turns from corrupting tool history

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -609,31 +609,20 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else if c := cacheLine(m.cfg.verbosity, msg.reply); c != "" {
 			m.println(c)
 		}
-		// On interrupt, eagerly reset turnRunning so background-process
-		// auto-turn (bgExitMsg) can fire immediately instead of waiting for
-		// turnFinishedMsg. The inbox drain and dequeue still happen in
-		// handleTurnFinished when the goroutine actually returns.
-		if msg.err == context.Canceled {
-			m.turnRunning = false
-			m.running = nil
-			// Eagerly drain inbox so a pending message (or background-process
-			// notice that raced in via Inbox) starts immediately rather than
-			// waiting for turnFinishedMsg.
-			if items := m.a.Inbox.Drain(); len(items) > 0 {
-				it := pendingFromInbox(items)
-				for _, line := range strings.Split(it.text, "\n\n") {
-					if line != "" && !strings.HasPrefix(line, "<system-reminder>") {
-						m.println(userEchoStyle.Render("> ") + line)
-					}
-				}
-				m.queue = append([]pendingItem{it}, m.queue...)
-			}
-			if len(m.queue) > 0 {
-				next := m.queue[0]
-				m.queue = m.queue[1:]
-				return m, tea.Sequence(m.flushPrints(), m.startQueued(next))
-			}
-		}
+		// turnEndedMsg only marks the end of the agent loop's output; the turn
+		// goroutine is still alive until turnFinishedMsg. Do NOT reset turnRunning
+		// or start the next queued/inbox turn here — that is handleTurnFinished's
+		// job, and it fires the moment the goroutine actually returns. Starting a
+		// turn now (the old eager-restart path) launched a second runTurn goroutine
+		// while the interrupted one was still draining a blocking tool dispatch;
+		// the two then interleaved their History.Append calls and produced a
+		// structurally invalid log (consecutive assistant messages, a tool_use
+		// answered twice) that permanently 400'd the session. Keeping turnRunning
+		// true until the goroutine returns makes every `!turnRunning` start-gate a
+		// correct single-turn guardrail. A background notice that races in via the
+		// Inbox during this window is drained by handleTurnFinished, so nothing is
+		// lost — only deferred by the few ms it takes the cancelled turn to unwind.
+
 		// On a clean completion, ask for one follow-up suggestion (off the event
 		// loop). Skipped on error/interrupt and when disabled (--no-suggest).
 		if m.cfg.suggest && msg.err == nil {

--- a/internal/agent/toolpairing.go
+++ b/internal/agent/toolpairing.go
@@ -10,6 +10,106 @@ func hasToolUse(m Message) bool {
 	return false
 }
 
+// blocksOf returns m's content blocks, lifting a plain-text Content message into
+// a single text block so callers can treat every message uniformly.
+func blocksOf(m Message) []ContentBlock {
+	if len(m.Blocks) > 0 {
+		return m.Blocks
+	}
+	if m.Content != "" {
+		return []ContentBlock{NewTextBlock(m.Content)}
+	}
+	return nil
+}
+
+// normalizeToolHistory repairs structural corruption in the message log that a
+// provider would reject, rewriting History in place only if something changed.
+// It is a defensive companion to ensureToolPairing: well-formed single-threaded
+// history never triggers it, but if two turn goroutines ever briefly overlap and
+// interleave their History.Append calls (the cae91036 incident), the log can end
+// up with two consecutive assistant messages or a tool_use answered twice — both
+// of which 400 the next send and permanently wedge the session.
+func (a *Agent) normalizeToolHistory() {
+	msgs := a.History.Snapshot()
+	repaired, changed := normalizeMessages(msgs)
+	if changed {
+		a.History.ReplaceAll(repaired)
+	}
+}
+
+// normalizeMessages returns msgs with two structural repairs applied, plus
+// whether anything changed. Pure (no History access) so it is unit-testable.
+//
+//   - Consecutive assistant messages are coalesced into one. The wire format
+//     requires an assistant tool_use message to be immediately followed by the
+//     tool_result(s) answering it; an assistant message followed by another
+//     assistant message orphans the first one's tool calls (HTTP 400
+//     "tool_call_ids did not have response messages").
+//   - Duplicate tool_result blocks sharing a tool_use_id are dropped, keeping
+//     the first occurrence. A single tool_use answered twice is also rejected.
+//
+// New backing arrays are allocated for any message it rewrites, so the caller's
+// snapshot (which shares block slices with the live History) is never mutated.
+func normalizeMessages(msgs []Message) ([]Message, bool) {
+	if len(msgs) == 0 {
+		return msgs, false
+	}
+	changed := false
+
+	// Pass 1 — coalesce consecutive assistant messages.
+	coalesced := make([]Message, 0, len(msgs))
+	for _, m := range msgs {
+		if n := len(coalesced); m.Role == RoleAssistant && n > 0 && coalesced[n-1].Role == RoleAssistant {
+			prev := coalesced[n-1]
+			merged := make([]ContentBlock, 0, len(blocksOf(prev))+len(blocksOf(m)))
+			merged = append(merged, blocksOf(prev)...)
+			merged = append(merged, blocksOf(m)...)
+			coalesced[n-1] = Message{Role: RoleAssistant, Blocks: merged}
+			changed = true
+			continue
+		}
+		coalesced = append(coalesced, m)
+	}
+
+	// Pass 2 — drop duplicate tool_result blocks (keeping the first occurrence
+	// per id), and drop any message left empty as a result. The duplicate may
+	// live in its own message (a second goroutine appended a whole tool_result
+	// message for an id another goroutine had already answered), so emptied
+	// messages are removed rather than left as zero-block stragglers.
+	seen := make(map[string]bool)
+	out := make([]Message, 0, len(coalesced))
+	for _, m := range coalesced {
+		if len(m.Blocks) == 0 {
+			out = append(out, m)
+			continue
+		}
+		kept := make([]ContentBlock, 0, len(m.Blocks))
+		dropped := false
+		for _, b := range m.Blocks {
+			if b.Type == "tool_result" {
+				if seen[b.ToolUseID] {
+					dropped = true
+					continue
+				}
+				seen[b.ToolUseID] = true
+			}
+			kept = append(kept, b)
+		}
+		if !dropped {
+			out = append(out, m)
+			continue
+		}
+		changed = true
+		if len(kept) == 0 && m.Content == "" {
+			continue // message held only duplicate tool_results — drop it
+		}
+		m.Blocks = kept
+		out = append(out, m)
+	}
+
+	return out, changed
+}
+
 // synthesizeInterruptedToolResults creates error tool_result blocks for each
 // tool_use block in the given message. Used when a turn is interrupted and
 // the tool_use has no matching tool_result (either because dispatchTools never
@@ -43,7 +143,13 @@ func synthesizeInterruptedToolResults(blocks []ContentBlock) []ContentBlock {
 //
 // Synthesized tool_results use is_error=true with "[Tool execution was interrupted]"
 // to signal clearly to the LLM that the tool did not complete.
+//
+// It first runs normalizeToolHistory to repair any structurally invalid log
+// (consecutive assistant messages, duplicate tool_results) so the orphan scan
+// below sees a clean message sequence.
 func (a *Agent) ensureToolPairing() {
+	a.normalizeToolHistory()
+
 	msgs := a.History.Snapshot()
 	if len(msgs) == 0 {
 		return

--- a/internal/agent/toolpairing_test.go
+++ b/internal/agent/toolpairing_test.go
@@ -198,6 +198,156 @@ func TestEnsureToolPairing(t *testing.T) {
 	})
 }
 
+func TestNormalizeMessages(t *testing.T) {
+	t.Run("well-formed history unchanged", func(t *testing.T) {
+		msgs := []Message{
+			NewUserMessage("read it"),
+			NewToolUseMessage([]ContentBlock{NewToolUseBlock("c1", "read_file", nil)}),
+			NewToolResultMessage([]ContentBlock{NewToolResultBlock("c1", "content", false)}),
+			NewAssistantMessage("done"),
+		}
+		got, changed := normalizeMessages(msgs)
+		if changed {
+			t.Errorf("changed = true, want false for well-formed history")
+		}
+		if len(got) != 4 {
+			t.Errorf("len = %d, want 4", len(got))
+		}
+	})
+
+	t.Run("coalesces consecutive assistant messages", func(t *testing.T) {
+		msgs := []Message{
+			NewUserMessage("go"),
+			NewToolUseMessage([]ContentBlock{NewToolUseBlock("a", "terminal", nil)}),
+			NewToolUseMessage([]ContentBlock{NewToolUseBlock("b", "terminal", nil)}),
+		}
+		got, changed := normalizeMessages(msgs)
+		if !changed {
+			t.Fatal("changed = false, want true")
+		}
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2 (assistants merged)", len(got))
+		}
+		if got[1].Role != RoleAssistant || len(got[1].Blocks) != 2 {
+			t.Fatalf("merged assistant should have 2 blocks, got %d", len(got[1].Blocks))
+		}
+		if got[1].Blocks[0].ID != "a" || got[1].Blocks[1].ID != "b" {
+			t.Errorf("block order = %q,%q, want a,b", got[1].Blocks[0].ID, got[1].Blocks[1].ID)
+		}
+	})
+
+	t.Run("does not alias the input backing array", func(t *testing.T) {
+		first := NewToolUseMessage([]ContentBlock{NewToolUseBlock("a", "terminal", nil)})
+		msgs := []Message{
+			NewUserMessage("go"),
+			first,
+			NewToolUseMessage([]ContentBlock{NewToolUseBlock("b", "terminal", nil)}),
+		}
+		normalizeMessages(msgs)
+		// The original message's block slice must be untouched.
+		if len(first.Blocks) != 1 || first.Blocks[0].ID != "a" {
+			t.Errorf("input message mutated: %+v", first.Blocks)
+		}
+	})
+
+	t.Run("dedupes tool_result within one message, keeping first", func(t *testing.T) {
+		msgs := []Message{
+			NewToolUseMessage([]ContentBlock{NewToolUseBlock("c1", "terminal", nil)}),
+			NewToolResultMessage([]ContentBlock{
+				NewToolResultBlock("c1", "first", false),
+				NewToolResultBlock("c1", "second", false),
+			}),
+		}
+		got, changed := normalizeMessages(msgs)
+		if !changed {
+			t.Fatal("changed = false, want true")
+		}
+		if len(got[1].Blocks) != 1 {
+			t.Fatalf("blocks = %d, want 1", len(got[1].Blocks))
+		}
+		if got[1].Blocks[0].Result != "first" {
+			t.Errorf("kept Result = %q, want first", got[1].Blocks[0].Result)
+		}
+	})
+
+	t.Run("drops a message emptied by dedupe", func(t *testing.T) {
+		msgs := []Message{
+			NewToolUseMessage([]ContentBlock{NewToolUseBlock("c1", "terminal", nil)}),
+			NewToolResultMessage([]ContentBlock{NewToolResultBlock("c1", "real", false)}),
+			NewToolResultMessage([]ContentBlock{NewToolResultBlock("c1", "dup", false)}),
+		}
+		got, changed := normalizeMessages(msgs)
+		if !changed {
+			t.Fatal("changed = false, want true")
+		}
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2 (duplicate result message dropped)", len(got))
+		}
+	})
+
+	t.Run("repairs the cae91036 interleaved-turns shape", func(t *testing.T) {
+		// Two terminal tool_use messages back-to-back (the second turn raced in),
+		// then results out of order, with tool 0bQ answered twice — once by an
+		// ensureToolPairing placeholder, once by the real (late) dispatch result.
+		msgs := []Message{
+			NewToolUseMessage([]ContentBlock{NewToolUseBlock("0bQ", "terminal", nil)}),
+			NewToolUseMessage([]ContentBlock{NewToolUseBlock("SXl", "terminal", nil)}),
+			NewToolResultMessage([]ContentBlock{NewToolResultBlock("SXl", "{json}", false)}),
+			NewToolResultMessage([]ContentBlock{NewToolResultBlock("0bQ", "[interrupted]", true)}),
+			NewToolResultMessage([]ContentBlock{NewToolResultBlock("0bQ", "Refreshing checks...", false)}),
+		}
+		got, changed := normalizeMessages(msgs)
+		if !changed {
+			t.Fatal("changed = false, want true")
+		}
+		// Expect: one assistant(2 tool_use), then result messages — no two
+		// assistant messages in a row, and 0bQ answered exactly once.
+		if got[0].Role != RoleAssistant || len(got[0].Blocks) != 2 {
+			t.Fatalf("got[0] should be merged assistant with 2 tool_use, got role=%q blocks=%d", got[0].Role, len(got[0].Blocks))
+		}
+		for i := 1; i < len(got); i++ {
+			if got[i].Role == RoleAssistant {
+				t.Fatalf("got[%d] is a second assistant message; coalescing failed", i)
+			}
+		}
+		results := map[string]int{}
+		for _, m := range got {
+			for _, b := range m.Blocks {
+				if b.Type == "tool_result" {
+					results[b.ToolUseID]++
+				}
+			}
+		}
+		if results["0bQ"] != 1 {
+			t.Errorf("0bQ answered %d times, want 1", results["0bQ"])
+		}
+		if results["SXl"] != 1 {
+			t.Errorf("SXl answered %d times, want 1", results["SXl"])
+		}
+	})
+}
+
+func TestEnsureToolPairing_HealsInterleavedHistory(t *testing.T) {
+	a := New(&summarizeFake{}, "m")
+	a.History.Append(NewToolUseMessage([]ContentBlock{NewToolUseBlock("0bQ", "terminal", nil)}))
+	a.History.Append(NewToolUseMessage([]ContentBlock{NewToolUseBlock("SXl", "terminal", nil)}))
+	a.History.Append(NewToolResultMessage([]ContentBlock{NewToolResultBlock("SXl", "{json}", false)}))
+	a.History.Append(NewToolResultMessage([]ContentBlock{NewToolResultBlock("0bQ", "[interrupted]", true)}))
+	a.History.Append(NewToolResultMessage([]ContentBlock{NewToolResultBlock("0bQ", "real", false)}))
+
+	a.ensureToolPairing()
+
+	msgs := a.History.Snapshot()
+	if msgs[0].Role != RoleAssistant || len(msgs[0].Blocks) != 2 {
+		t.Fatalf("first message should be a merged assistant turn, got role=%q blocks=%d", msgs[0].Role, len(msgs[0].Blocks))
+	}
+	for i := 1; i < len(msgs); i++ {
+		if msgs[i].Role == RoleAssistant {
+			t.Fatalf("msgs[%d] is a stray second assistant message", i)
+		}
+	}
+}
+
 func TestFinishInterrupted_OrphanedToolUse(t *testing.T) {
 	a := New(&summarizeFake{}, "m")
 	a.History.Append(NewUserMessage("read it"))


### PR DESCRIPTION
## Problem

Reported from session `cae91036`: octo got permanently stuck repeating

```
anthropic: HTTP 400 (invalid_request_error): an assistant message with 'tool_calls'
must be followed by tool messages responding to each 'tool_call_id'. The following
tool_call_ids did not have response messages: terminal:62
```

at `loop[0]`, `loop[10]`, `loop[11]` — every retry 400'd.

## Root cause

The persisted history was structurally invalid. Its tail held **two consecutive `assistant` tool_use messages** with no `tool_result` between them, and **one `tool_use` answered twice**:

```
141  assistant  tool_use  0bQ   terminal: gh pr checks --watch
142  assistant  tool_use  SXl   terminal: gh pr view --json …
143  user       tool_result ← SXl
144  user       tool_result ← 0bQ   "[Tool execution was interrupted or failed to complete]"  (synthesized)
145  user       tool_result ← 0bQ   "Refreshing checks…[timeout: …bg_37]"                     (real)
```

A single sequential `runLoop` can never produce two adjacent assistant messages — it always appends exactly one `tool_result` message right after each `tool_use` message. This shape is only reachable if **two turn goroutines ran concurrently and interleaved their `History.Append` calls**.

The overlap came from the interrupt path. `turnEndedMsg` (fired when the agent loop's *output* ends) eagerly reset `turnRunning=false` and dequeued the next turn, while the interrupted goroutine was still blocked draining a **synchronous** `gh pr checks --watch` (run past the 30 s timeout → promoted to background `bg_37`, line 145's `[timeout: …]` marker confirms it). The new goroutine then wrote to the shared `History` alongside the still-unwinding old one. Once written, the corrupt log was persisted and re-sent on every turn — the Kimi (`k2.6`) Anthropic-protocol endpoint rejected it with the OpenAI-style pairing error (`terminal:62` is Kimi's internal rename of the orphaned `0bQ` call). `ensureToolPairing` couldn't recover it: it only adds results for orphaned tool_use, it didn't merge the adjacent assistants or dedupe the double result.

## Fix

**1. Turn-lifecycle guardrail (`cmd/octo/tuirepl.go`)** — `turnEndedMsg` no longer resets `turnRunning` or starts the next turn. That's `handleTurnFinished`'s job, which fires the moment the goroutine actually returns (`turnFinishedMsg`). `turnRunning` now faithfully tracks goroutine liveness, so every `!turnRunning` start-gate becomes a correct single-turn guardrail. A background notice racing in via the Inbox during the brief unwind window is still drained by `handleTurnFinished` — nothing is lost, only deferred by the few ms the cancelled turn takes to return.

**2. `ensureToolPairing` safety net (`internal/agent/toolpairing.go`)** — `normalizeToolHistory`, run before each send, coalesces consecutive assistant messages and dedupes `tool_result` blocks by `tool_use_id` (dropping any message emptied as a result). Both are no-ops on well-formed single-threaded history, so it's a pure defense-in-depth layer — and it lets an already-corrupted session **self-heal on the next send** (so existing wedged sessions recover after upgrading).

## Tests

- `TestNormalizeMessages` — coalescing, dedupe-keeps-first, drop-emptied-message, no-alias of the input backing array, and a direct reproduction of the `cae91036` shape.
- `TestEnsureToolPairing_HealsInterleavedHistory` — end-to-end heal through `ensureToolPairing`.
- Full `go test -race ./...` green; existing `cmd/octo` TUI tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)