### PR TITLE
feat(session): auto-generate a title for each session, shown in the list

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/skills"
 	"github.com/Leihb/octo-agent/internal/tools"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // replConfig holds everything runREPL needs.
@@ -309,10 +310,11 @@ func printSessions(w io.Writer) error {
 	return nil
 }
 
-// formatSessionList renders the rightmost columns the user cares about for a
-// "pick one to resume" overview: 8-char short ID (the thing they paste back
-// into `octo chat -c`), a human-readable created-at, the model, and the
-// turn count. Shared between `octo chat --list-sessions` and REPL /sessions
+// formatSessionList renders the columns the user cares about for a "pick one to
+// resume" overview: 8-char short ID (the thing they paste back into
+// `octo chat -c`), a human-readable created-at, the title (generated, or a
+// first-message fallback so older sessions stay recognisable), the model, and
+// the turn count. Shared between `octo chat --list-sessions` and REPL /sessions
 // so both views agree on shape.
 func formatSessionList(sessions []*agent.Session) string {
 	var b strings.Builder
@@ -323,14 +325,37 @@ func formatSessionList(sessions []*agent.Session) string {
 			plural = ""
 		}
 		when := s.CreatedAt.Local().Format("2006-01-02 15:04")
-		fmt.Fprintf(&b, "  %s  %s  %-30s  %d turn%s\n",
-			s.ShortID(), when, s.Model, turns, plural)
+		// padCol (not %-40s) because titles are often CJK: %-Ns pads by byte/rune
+		// count, which over- or under-pads double-width runes and leaves the model
+		// column ragged.
+		title := padCol(s.DisplayTitle(), 40)
+		fmt.Fprintf(&b, "  %s  %s  %s  %-22s  %d turn%s\n",
+			s.ShortID(), when, title, s.Model, turns, plural)
 	}
 	// strings.Builder result has no trailing newline trimmed — printSessions
 	// uses Fprintln below which would add one if we kept it. Drop the final
 	// "\n" we just emitted so the outer caller controls spacing.
 	out := b.String()
 	return strings.TrimRight(out, "\n")
+}
+
+// padCol collapses whitespace in s, truncates it to maxW display columns
+// (appending an ellipsis when cut), and right-pads with spaces to exactly maxW
+// columns. It measures with lipgloss.Width so wide (CJK) runes count as two
+// columns, keeping the following column aligned.
+func padCol(s string, maxW int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if lipgloss.Width(s) > maxW {
+		r := []rune(s)
+		for len(r) > 0 && lipgloss.Width(string(r))+1 > maxW {
+			r = r[:len(r)-1]
+		}
+		s = string(r) + "…"
+	}
+	if pad := maxW - lipgloss.Width(s); pad > 0 {
+		s += strings.Repeat(" ", pad)
+	}
+	return s
 }
 
 // replToolEventHandler returns an EventHandler that paints tool activity

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -130,6 +130,7 @@ type bgExitMsg struct{ e tools.BgExit }                      // a background pro
 type subAgentNoteMsg struct{ ev tools.SubAgentNotification } // a sub-agent completed (async)
 type subAgentEventMsg struct{ ev tools.SubAgentEvent }       // a sub-agent's runtime activity (async)
 type suggestionMsg struct{ text string }                     // an after-turn follow-up suggestion (async)
+type titleMsg struct{ text string }                          // a generated session title (async)
 type tickMsg struct{}                                        // animation tick while a turn runs
 type askMsg struct {
 	prompt UserPrompt
@@ -345,6 +346,10 @@ type tuiModel struct {
 	// text in the empty input box (the textarea placeholder). Accepted with
 	// Tab/→, cleared when a turn starts. Empty means none pending.
 	suggestion string
+
+	// titlePending guards the one-shot async title generation so a second turn
+	// finishing before the first title returns doesn't fire it twice.
+	titlePending bool
 
 	// subAgents holds the live state of currently-running sub-agents, keyed by
 	// manager handle (agent_N), rendered as a bottom panel. An entry appears on
@@ -578,6 +583,14 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, m.flushPrints()
 
+	case titleMsg:
+		// Persist the generated title (silent — it surfaces in the session list).
+		m.titlePending = false
+		if msg.text != "" && !m.cfg.noSave {
+			_ = m.cfg.session.SetTitle(msg.text)
+		}
+		return m, m.flushPrints()
+
 	case subAgentNoteMsg:
 		// A sub-agent finished this round — drop it from the live panel (it's
 		// idle now; a later send_message re-adds it via a fresh "started").
@@ -623,10 +636,19 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Inbox during this window is drained by handleTurnFinished, so nothing is
 		// lost — only deferred by the few ms it takes the cancelled turn to unwind.
 
-		// On a clean completion, ask for one follow-up suggestion (off the event
-		// loop). Skipped on error/interrupt and when disabled (--no-suggest).
-		if m.cfg.suggest && msg.err == nil {
-			return m, tea.Batch(m.flushPrints(), m.suggestCmd())
+		// On a clean completion, kick off the off-loop after-turn helpers:
+		// a follow-up suggestion (when enabled via --suggest) and, once per
+		// session, a generated title for the session list. Both are skipped on
+		// error/interrupt.
+		if msg.err == nil {
+			cmds := []tea.Cmd{m.flushPrints()}
+			if m.cfg.suggest {
+				cmds = append(cmds, m.suggestCmd())
+			}
+			if c := m.titleCmd(); c != nil {
+				cmds = append(cmds, c)
+			}
+			return m, tea.Batch(cmds...)
 		}
 		return m, m.flushPrints()
 
@@ -733,6 +755,32 @@ func (m *tuiModel) suggestCmd() tea.Cmd {
 			return nil
 		}
 		return suggestionMsg{text: s}
+	}
+}
+
+// titleCmd generates a session title off the event loop, once per session. It
+// returns nil (no-op) when the session is already titled, a generation is
+// already in flight, saving is off, or there's no turn to summarize yet — so it
+// fires exactly once, after the first completed turn. The result is persisted
+// by the titleMsg handler.
+func (m *tuiModel) titleCmd() tea.Cmd {
+	if m.cfg.noSave || m.titlePending || m.cfg.session.Title != "" {
+		return nil
+	}
+	if m.a.History.Len() == 0 {
+		return nil
+	}
+	m.titlePending = true
+	a := m.a
+	tools := m.cfg.tools // same toolbelt as the loop, so the request hits the prompt cache
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		t, err := a.GenerateTitle(ctx, tools)
+		if err != nil {
+			return titleMsg{text: ""}
+		}
+		return titleMsg{text: t}
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -820,6 +820,79 @@ func (a *Agent) Suggest(ctx context.Context, tools []ToolDefinition) (string, er
 	return cleanSuggestion(reply.Content), nil
 }
 
+// titleMaxTokens caps the title response — it's a handful of words.
+const titleMaxTokens = 32
+
+const titleInstruction = "Summarize this conversation as a short title of at most 6 words. " +
+	"Reply with the title text only — no preamble, no quotes, no trailing punctuation, no markdown."
+
+// GenerateTitle produces a short title summarizing the conversation so far, for
+// display in the session list. Like Suggest it is a throwaway provider call: the
+// instruction is appended to a snapshot of history (never the live History) and
+// its token usage is not accrued into the session. Returns "" (no error) when
+// there's nothing to title.
+//
+// tools should be the SAME toolbelt the agentic loop uses so the request reuses
+// the main conversation's prompt cache (see Suggest for the cache-prefix
+// rationale). The model is told not to call tools; a stray tool_use yields empty
+// Content and we simply produce no title.
+func (a *Agent) GenerateTitle(ctx context.Context, tools []ToolDefinition) (string, error) {
+	if a.Sender == nil || a.Model == "" {
+		return "", fmt.Errorf("agent: title: not configured")
+	}
+	snap := a.History.Snapshot()
+	if len(snap) == 0 {
+		return "", nil
+	}
+	msgs := make([]Message, 0, len(snap)+1)
+	msgs = append(msgs, snap...)
+	msgs = append(msgs, NewUserMessage(titleInstruction))
+
+	var reply Reply
+	var err error
+	if ts, ok := a.Sender.(ToolSender); ok && len(tools) > 0 {
+		reply, err = ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, titleMaxTokens, tools)
+	} else {
+		reply, err = a.Sender.SendMessages(ctx, a.Model, a.System, msgs, titleMaxTokens)
+	}
+	if err != nil {
+		return "", err
+	}
+	return cleanTitle(reply.Content), nil
+}
+
+// cleanTitle reduces the model's reply to a single tidy line: first non-empty
+// line, stripped of surrounding quotes/markdown and trailing punctuation, capped
+// to a list-friendly length.
+func cleanTitle(s string) string {
+	const maxLen = 60
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "# ")
+		// The model sometimes wraps the title in quotes AND adds trailing
+		// punctuation (e.g. `"Fix the bug".`), so trim both sets repeatedly
+		// until the string stops shrinking — one pass leaves the outer quote
+		// stranded behind the period.
+		for {
+			trimmed := strings.TrimSpace(line)
+			trimmed = strings.Trim(trimmed, "\"'`*")
+			trimmed = strings.TrimRight(trimmed, ".。!！?？")
+			if trimmed == line {
+				break
+			}
+			line = trimmed
+		}
+		if line == "" {
+			continue
+		}
+		if r := []rune(line); len(r) > maxLen {
+			return strings.TrimSpace(string(r[:maxLen-1])) + "…"
+		}
+		return line
+	}
+	return ""
+}
+
 // cleanSuggestion picks the first non-empty line and strips list/quote
 // decoration the model sometimes adds despite the instruction.
 func cleanSuggestion(s string) string {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1422,6 +1422,77 @@ func TestAgent_Suggest_NotConfigured(t *testing.T) {
 	}
 }
 
+func TestAgent_GenerateTitle(t *testing.T) {
+	send := &fakeSender{reply: Reply{Content: "\"Fix the login redirect bug\"."}}
+	a := New(send, "m")
+	a.System = "sys"
+	a.History.Append(NewUserMessage("the login page redirects in a loop"))
+	a.History.Append(NewAssistantMessage("found it"))
+
+	title, err := a.GenerateTitle(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GenerateTitle: %v", err)
+	}
+	if title != "Fix the login redirect bug" {
+		t.Errorf("title = %q, want %q (quotes + trailing punctuation stripped)", title, "Fix the login redirect bug")
+	}
+	// Must NOT pollute the conversation.
+	if a.History.Len() != 2 {
+		t.Errorf("history len = %d, want 2 (GenerateTitle must not append)", a.History.Len())
+	}
+	if n := len(send.gotMessages); n == 0 || send.gotMessages[n-1].Content != titleInstruction {
+		t.Errorf("last sent message = %+v, want the title instruction", send.gotMessages)
+	}
+	if send.gotMaxToks != titleMaxTokens {
+		t.Errorf("maxTokens = %d, want %d", send.gotMaxToks, titleMaxTokens)
+	}
+}
+
+func TestAgent_GenerateTitle_EmptyHistory(t *testing.T) {
+	a := New(&fakeSender{reply: Reply{Content: "x"}}, "m")
+	title, err := a.GenerateTitle(context.Background(), nil)
+	if err != nil || title != "" {
+		t.Errorf("GenerateTitle on empty history = (%q, %v), want (\"\", nil)", title, err)
+	}
+}
+
+func TestAgent_GenerateTitle_NotConfigured(t *testing.T) {
+	a := New(nil, "")
+	if _, err := a.GenerateTitle(context.Background(), nil); err == nil {
+		t.Error("GenerateTitle with no sender/model should error")
+	}
+}
+
+func TestCleanTitle(t *testing.T) {
+	cases := map[string]string{
+		"Refactor the parser":          "Refactor the parser",
+		"\"Quoted title\"":             "Quoted title",
+		"# Markdown heading":           "Markdown heading",
+		"trailing period.":             "trailing period",
+		"中文标题。":                        "中文标题",
+		"  \n  spaced out  \n ignored": "spaced out",
+		"":                             "",
+		"\n\n":                         "",
+	}
+	for in, want := range cases {
+		if got := cleanTitle(in); got != want {
+			t.Errorf("cleanTitle(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCleanTitle_RuneSafeTruncation(t *testing.T) {
+	// A long CJK title must be truncated on a rune boundary, never mid-byte.
+	in := strings.Repeat("订", 80)
+	got := cleanTitle(in)
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("cleanTitle(long) = %q, want a trailing ellipsis", got)
+	}
+	if r := []rune(got); len(r) != 60 { // 59 kept + the ellipsis
+		t.Errorf("cleanTitle(long) rune len = %d, want 60", len(r))
+	}
+}
+
 func TestCleanSuggestion(t *testing.T) {
 	cases := map[string]string{
 		"run the tests":        "run the tests",

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -27,6 +27,7 @@ type Session struct {
 	CreatedAt time.Time `json:"created_at"`
 	Model     string    `json:"model"`
 	System    string    `json:"system,omitempty"`
+	Title     string    `json:"title,omitempty"`
 	Messages  []Message `json:"messages"`
 
 	// persisted is how many messages are already on disk. Save appends
@@ -103,19 +104,24 @@ func (s *Session) SavePath() (string, error) {
 	return filepath.Join(dir, s.ID+".jsonl"), nil
 }
 
-// sessionRecord is one JSONL line. Type discriminates the meta header from a
-// message record.
+// sessionRecord is one JSONL line. Type discriminates the meta header, a
+// message record, and a title record. The title is appended on its own line
+// (rather than rewriting the meta header) so the append-only path is preserved:
+// it's generated after the first turn, by which point the meta line is already
+// on disk. LoadSession takes the last title record as authoritative; rewriteAll
+// also folds the title back into the meta header so a compacted file keeps it.
 type sessionRecord struct {
-	Type      string    `json:"type"` // "meta" | "message"
+	Type      string    `json:"type"` // "meta" | "message" | "title"
 	ID        string    `json:"id,omitempty"`
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	Model     string    `json:"model,omitempty"`
 	System    string    `json:"system,omitempty"`
+	Title     string    `json:"title,omitempty"`
 	Message   *Message  `json:"message,omitempty"`
 }
 
 func (s *Session) metaRecord() sessionRecord {
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System}
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title}
 }
 
 func messageRecord(m Message) sessionRecord {
@@ -190,6 +196,102 @@ func (s *Session) appendDelta() error {
 	return nil
 }
 
+// SetTitle records a short human-readable title for the session. It updates the
+// in-memory field and, if the transcript already exists on disk, appends a title
+// record so the title survives without rewriting the file. A fresh session whose
+// file isn't written yet just carries the title until the first Save folds it
+// into the meta header. Calling with an empty or unchanged title is a no-op.
+func (s *Session) SetTitle(title string) error {
+	title = strings.TrimSpace(title)
+	if title == "" || title == s.Title {
+		return nil
+	}
+	s.Title = title
+	if s.persisted == 0 {
+		// Nothing on disk yet; the next Save writes the title via metaRecord.
+		return nil
+	}
+	path, err := s.SavePath()
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("session: open %s: %w", path, err)
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(sessionRecord{Type: "title", Title: title}); err != nil {
+		return fmt.Errorf("session: append title: %w", err)
+	}
+	return nil
+}
+
+// DisplayTitle returns the label shown for the session in list views: the
+// generated Title when present, otherwise a snippet of the first user message
+// (so pre-title sessions and not-yet-titled ones are still recognisable), and
+// finally "(untitled)" when there's nothing to show.
+func (s *Session) DisplayTitle() string {
+	if t := strings.TrimSpace(s.Title); t != "" {
+		return t
+	}
+	if snippet := firstUserSnippet(s.Messages); snippet != "" {
+		return snippet
+	}
+	return "(untitled)"
+}
+
+// firstUserSnippet extracts a one-line preview from the first user message,
+// skipping injected <system-reminder> blocks and tool-result turns, and
+// truncating to a list-friendly width.
+func firstUserSnippet(msgs []Message) string {
+	const maxLen = 60
+	for _, m := range msgs {
+		if m.Role != RoleUser {
+			continue
+		}
+		text := m.Content
+		if text == "" {
+			for _, b := range m.Blocks {
+				if b.Type == "text" {
+					text = b.Text
+					break
+				}
+			}
+		}
+		text = stripSystemReminders(text)
+		// Collapse to the first non-empty line.
+		for _, line := range strings.Split(text, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			if r := []rune(line); len(r) > maxLen {
+				return strings.TrimSpace(string(r[:maxLen-1])) + "…"
+			}
+			return line
+		}
+	}
+	return ""
+}
+
+// stripSystemReminders removes <system-reminder>…</system-reminder> spans the
+// harness injects into user turns so they don't leak into the preview.
+func stripSystemReminders(s string) string {
+	for {
+		start := strings.Index(s, "<system-reminder>")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(s, "</system-reminder>")
+		if end < 0 || end < start {
+			s = s[:start]
+			break
+		}
+		s = s[:start] + s[end+len("</system-reminder>"):]
+	}
+	return s
+}
+
 // LoadSession reads ~/.octo/sessions/<id>.jsonl. id may be a bare session id,
 // an id with a .jsonl/.json suffix, or an absolute path to a transcript file.
 func LoadSession(id string) (*Session, error) {
@@ -224,6 +326,9 @@ func LoadSession(id string) (*Session, error) {
 		switch rec.Type {
 		case "meta":
 			s.ID, s.CreatedAt, s.Model, s.System = rec.ID, rec.CreatedAt, rec.Model, rec.System
+			s.Title = rec.Title // a compacted file carries the title in its meta header
+		case "title":
+			s.Title = rec.Title // last one wins
 		case "message":
 			if rec.Message != nil {
 				s.Messages = append(s.Messages, *rec.Message)

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -166,6 +166,146 @@ func TestSave_RewritesWhenHistoryShrinks(t *testing.T) {
 	}
 }
 
+func TestSetTitle_AppendsAndReloads(t *testing.T) {
+	// A title set after the first Save is appended as its own record (the meta
+	// header on disk is left untouched) and survives a reload.
+	setTempHome(t)
+
+	s := NewSession("m", "")
+	s.Messages = []Message{NewUserMessage("ping"), NewAssistantMessage("pong")}
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTitle("  Fix the login bug  "); err != nil {
+		t.Fatalf("SetTitle: %v", err)
+	}
+
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != "Fix the login bug" {
+		t.Errorf("Title = %q, want %q (trimmed)", got.Title, "Fix the login bug")
+	}
+	// Messages must be intact alongside the appended title record.
+	if len(got.Messages) != 2 {
+		t.Errorf("Messages len = %d, want 2", len(got.Messages))
+	}
+}
+
+func TestSetTitle_LastWins(t *testing.T) {
+	setTempHome(t)
+	s := NewSession("m", "")
+	s.Messages = []Message{NewUserMessage("ping")}
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTitle("first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTitle("second"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != "second" {
+		t.Errorf("Title = %q, want %q (last title record wins)", got.Title, "second")
+	}
+}
+
+func TestSetTitle_SurvivesCompaction(t *testing.T) {
+	// A history-shrinking Save (compaction) rewrites the file; the title must be
+	// folded back into the meta header rather than lost with the dropped lines.
+	setTempHome(t)
+	s := NewSession("m", "")
+	s.Messages = []Message{NewUserMessage("u1"), NewAssistantMessage("a1"), NewUserMessage("u2")}
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTitle("kept title"); err != nil {
+		t.Fatal(err)
+	}
+	s.Messages = []Message{NewUserMessage("[summary]")} // shorter → rewriteAll
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != "kept title" {
+		t.Errorf("Title = %q, want %q after compaction", got.Title, "kept title")
+	}
+}
+
+func TestSetTitle_BeforeSave(t *testing.T) {
+	// Setting a title on a never-saved session keeps it in memory; the first
+	// Save then persists it via the meta header (no file to append to yet).
+	setTempHome(t)
+	s := NewSession("m", "")
+	if err := s.SetTitle("early"); err != nil {
+		t.Fatal(err)
+	}
+	s.Messages = []Message{NewUserMessage("hi")}
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != "early" {
+		t.Errorf("Title = %q, want %q", got.Title, "early")
+	}
+}
+
+func TestDisplayTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		s    *Session
+		want string
+	}{
+		{
+			name: "explicit title wins",
+			s:    &Session{Title: "My Title", Messages: []Message{NewUserMessage("ignored")}},
+			want: "My Title",
+		},
+		{
+			name: "falls back to first user message",
+			s:    &Session{Messages: []Message{NewUserMessage("help me refactor the parser")}},
+			want: "help me refactor the parser",
+		},
+		{
+			name: "strips system-reminder and takes first real line",
+			s: &Session{Messages: []Message{NewUserMessage(
+				"<system-reminder>injected context</system-reminder>\n\nreal question here")}},
+			want: "real question here",
+		},
+		{
+			name: "skips a leading tool-result user turn",
+			s: &Session{Messages: []Message{
+				NewToolResultMessage([]ContentBlock{NewToolResultBlock("id", "out", false)}),
+				NewUserMessage("the actual prompt"),
+			}},
+			want: "the actual prompt",
+		},
+		{
+			name: "untitled when empty",
+			s:    &Session{},
+			want: "(untitled)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.s.DisplayTitle(); got != tt.want {
+				t.Errorf("DisplayTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSavePath_IsJSONL(t *testing.T) {
 	setTempHome(t)
 	s := NewSession("m", "")


### PR DESCRIPTION
## 动机

会话列表只显示 `短ID + 创建时间 + 模型 + 轮数`，没有标题——在列表里很难认出某个具体会话。参考 Claude Code 的做法，自动为每个会话生成一个短标题并在列表中展示。

## 实现

- **生成**（`internal/agent/agent.go`）：`GenerateTitle` 照搬 `Agent.Suggest` 的旁路调用模式——快照历史 + 一条总结指令，不污染对话、不计入会话 token、复用 prompt cache。`cleanTitle` 清掉引号/markdown/尾标点，按 rune 安全截断。
- **触发**（`cmd/octo/tuirepl.go`）：TUI 首轮干净结束后异步生成一次（`titlePending` 防重复，已有标题则跳过）。静默存盘。resume 的无标题老会话也会在下一轮后补生成。
- **持久化**（`internal/agent/session.go`）：`Session.Title` 以追加式 `title` JSONL 记录落盘（首轮结束时 meta 头已在盘上，保持 append-only 架构不回写旧行）；`rewriteAll` 把标题折进 meta 头，compaction 后不丢。
- **兜底**：`DisplayTitle()` 无标题时回退到首条用户消息截断（剥掉 `<system-reminder>`），老会话和未生成标题的也能认出。
- **展示**（`cmd/octo/repl.go`）：列表增加标题列，用 `lipgloss.Width` 做显示宽度对齐，CJK 标题不会把后续列挤歪。

仅 TUI 入口生成；headless 一次性模式不生成。

## 测试

`go build ./...` / `go test -race`（agent + cmd/octo）/ `gofmt` / `go vet` 全过。新增覆盖：`SetTitle`（追加 / last-wins / compaction / 未存盘）、`DisplayTitle` 各兜底分支、`GenerateTitle`、`cleanTitle`（含 CJK rune 截断）。

实测 \`--list-sessions\` 渲染，老会话正确回退显示首条消息，列对齐干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)