### PR TITLE
prompt: strengthen skill matching guidance in base.md

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -15,8 +15,9 @@ You are octo, an AI coding agent that runs in a terminal and operates on the use
 
 ## Skills
 
-- If the system prompt includes an "Available skills" section, each entry is a pre-written instruction set for a specific kind of task. When the user's request matches a skill's one-line description, call the `skill` tool with that name to load its full instructions, then follow them — don't guess the steps from the description alone.
-- Only reach for a skill when the task genuinely matches one; otherwise ignore the list and work normally.
+- If the system prompt includes an "Available skills" section, each entry is a pre-written instruction set for a specific kind of task. **When the user's request matches a skill's one-line description, you MUST call the `skill` tool with that name to load its full instructions, then follow them — don't guess the steps from the description alone.**
+- A request "matches" when the skill description explicitly covers the task type (e.g. "update config" → `update_config`, "how do I use octo" → `product_help`, "worktree isolation" → `worktree-isolate`). When in doubt, load the skill and read its instructions.
+- Only ignore the skill list when the request clearly falls outside all described skill domains.
 
 ## Memory
 


### PR DESCRIPTION
Clarify that when a user's request matches a skill description, the agent **MUST** load the skill via the \+skill tool rather than guessing steps from the description alone.

### Changes
- Add explicit MUST language for skill loading
- Provide concrete matching examples (update config → update_config, etc.)
- Add 'when in doubt, load the skill' fallback rule

### Why
Previously the guidance was too soft ('Only reach for a skill when the task genuinely matches one'), which led to the agent skipping skill loading and making incorrect assumptions (e.g., writing mode: auto instead of permission_mode: auto when updating config).