### PR TITLE
serve: clickable URL + Web UI chat interface

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,41 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Developer (Roy), using locally for debugging and interacting with the octo-agent AI coding assistant via browser.
+
+## Product Purpose
+
+A lightweight web UI for octo-agent server that provides a chat interface to create sessions, send messages, and view streaming responses. Design serves the product — the UI gets out of the way so the developer can focus on the conversation.
+
+## Brand Personality
+
+- Minimalist: every element earns its place
+- Precise: sharp edges, consistent spacing, intentional hierarchy
+- Capable: looks like a tool built by developers, for developers
+
+## Anti-references
+
+- No marketing fluff, hero sections, or decorative elements
+- No rounded cards, soft shadows, or glassmorphism
+- No animated backgrounds, gradients, or decorative motion
+- No cream/sand/beige warm neutrals (AI default of 2026)
+- No emoji overload or playful illustrations
+
+## Design Principles
+
+1. **Content first**: the conversation is the interface; chrome should recede
+2. **Information density over whitespace**: show more history, less padding
+3. **Terminal aesthetic**: monospace for metadata, clean sans-serif for content
+4. **Dark by default**: deep blacks, high contrast, reduced eye strain for long sessions
+5. **Keyboard-driven**: Enter to send, Shift+Enter for newline, no mouse required
+
+## Accessibility & Inclusion
+
+- WCAG 2.1 AA minimum
+- Respect `prefers-reduced-motion` (no animations when set)
+- High contrast text (≥4.5:1 for body, ≥3:1 for large text)

--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -54,7 +54,11 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	fmt.Fprintf(stdout, "octo server listening on http://%s\n", *addr)
+	host := *addr
+	if strings.HasPrefix(host, ":") {
+		host = "localhost" + host
+	}
+	fmt.Fprintf(stdout, "octo server listening on http://%s\n", host)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -34,6 +34,7 @@ type sessionSummary struct {
 	CreatedAt time.Time `json:"created_at"`
 	Model     string    `json:"model"`
 	TurnCount int       `json:"turn_count"`
+	Title     string    `json:"title"`
 }
 
 type sessionDetail struct {
@@ -159,6 +160,7 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 			CreatedAt: sess.CreatedAt,
 			Model:     sess.Model,
 			TurnCount: sess.TurnCount(),
+			Title:     sess.DisplayTitle(),
 		})
 	}
 	writeJSON(w, http.StatusOK, out)

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1,1 +1,719 @@
-<!DOCTYPE html><html><head><meta charset=utf-8><title>Octo</title></head><body><h1>Octo Web UI</h1></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Octo Agent</title>
+<style>
+:root {
+  --bg: #0d1117;
+  --surface: #161b22;
+  --sidebar: #0d1117;
+  --border: #30363d;
+  --text: #c9d1d9;
+  --text-secondary: #8b949e;
+  --accent: #58a6ff;
+  --accent-hover: #79b8ff;
+  --user-bg: #238636;
+  --user-bg-soft: rgba(35, 134, 54, 0.15);
+  --bot-bg: #161b22;
+  --error: #f85149;
+  --success: #3fb950;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text);
+  background: var(--bg);
+}
+
+/* Layout: sidebar + main */
+.app {
+  display: flex;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+}
+
+/* Sidebar */
+.sidebar {
+  width: 260px;
+  min-width: 260px;
+  background: var(--sidebar);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-header {
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.sidebar-header h2 {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.sidebar-header .new-btn {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.sidebar-header .new-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.session-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.session-item {
+  padding: 10px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  margin-bottom: 4px;
+  font-size: 13px;
+  transition: background 0.15s;
+}
+
+.session-item:hover {
+  background: rgba(88, 166, 255, 0.1);
+}
+
+.session-item.active {
+  background: rgba(88, 166, 255, 0.15);
+  border-left: 3px solid var(--accent);
+}
+
+.session-item .sess-id {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-bottom: 2px;
+}
+
+.session-item .sess-date {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+/* Main area */
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--bg);
+}
+
+/* Header */
+.header {
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--surface);
+}
+
+.header h1 {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.header .status {
+  font-size: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.header .status::before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--success);
+}
+
+.header .status.error::before {
+  background: var(--error);
+}
+
+.header .status.thinking::before {
+  background: var(--accent);
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Chat area */
+.chat-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.welcome {
+  text-align: center;
+  color: var(--text-secondary);
+  margin: auto;
+  max-width: 480px;
+}
+
+.welcome h2 {
+  margin-bottom: 12px;
+  color: var(--text);
+  font-size: 20px;
+}
+
+.welcome p {
+  margin-bottom: 8px;
+  line-height: 1.6;
+}
+
+/* Messages */
+.message {
+  max-width: 85%;
+  padding: 12px 16px;
+  border-radius: 12px;
+  line-height: 1.6;
+  word-break: break-word;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.message.user {
+  align-self: flex-end;
+  background: var(--user-bg-soft);
+  border: 1px solid var(--user-bg);
+  color: var(--text);
+  border-bottom-right-radius: 4px;
+}
+
+.message.bot {
+  align-self: flex-start;
+  background: var(--bot-bg);
+  border: 1px solid var(--border);
+  border-bottom-left-radius: 4px;
+}
+
+.message .meta {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.message.user .meta {
+  color: var(--user-bg);
+}
+
+.message.bot .meta {
+  color: var(--accent);
+}
+
+.message .content {
+  white-space: pre-wrap;
+}
+
+.message .content code {
+  background: rgba(0,0,0,0.3);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 90%;
+}
+
+.message .content pre {
+  background: rgba(0,0,0,0.3);
+  padding: 12px;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin: 8px 0;
+}
+
+.message .content pre code {
+  background: none;
+  padding: 0;
+}
+
+.message .content blockquote {
+  border-left: 3px solid var(--border);
+  padding-left: 12px;
+  margin: 8px 0;
+  color: var(--text-secondary);
+}
+
+/* Typing indicator */
+.typing {
+  align-self: flex-start;
+  color: var(--text-secondary);
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 16px;
+}
+
+.typing span {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: var(--text-secondary);
+  border-radius: 50%;
+  animation: blink 1.4s infinite both;
+}
+
+.typing span:nth-child(2) { animation-delay: 0.2s; }
+.typing span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes blink {
+  0%, 80%, 100% { opacity: 0.3; }
+  40% { opacity: 1; }
+}
+
+/* Input area */
+.input-area {
+  padding: 16px 20px;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.input-area textarea {
+  flex: 1;
+  resize: none;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.5;
+  max-height: 120px;
+  min-height: 44px;
+  font-family: inherit;
+}
+
+.input-area textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.input-area button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.input-area button:hover {
+  background: var(--accent-hover);
+}
+
+.input-area button:disabled {
+  background: var(--border);
+  cursor: not-allowed;
+}
+
+/* Tool calls */
+.tool-call {
+  background: rgba(88, 166, 255, 0.08);
+  border: 1px solid rgba(88, 166, 255, 0.25);
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin-top: 8px;
+  font-size: 13px;
+}
+
+.tool-call .tool-name {
+  color: var(--accent);
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.tool-call .tool-args {
+  color: var(--text-secondary);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  white-space: pre-wrap;
+  font-size: 12px;
+}
+
+.error-msg {
+  color: var(--error);
+  font-size: 13px;
+  margin-top: 4px;
+}
+
+/* Session info bar */
+.session-info {
+  font-size: 12px;
+  color: var(--text-secondary);
+  padding: 6px 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; }
+}
+</style>
+</head>
+<body>
+<div class="app">
+  <!-- Sidebar -->
+  <div class="sidebar">
+    <div class="sidebar-header">
+      <h2>🐙 Octo</h2>
+      <button class="new-btn" id="newSessionBtn">+ New</button>
+    </div>
+    <div class="session-list" id="sessionList"></div>
+  </div>
+
+  <!-- Main -->
+  <div class="main">
+    <div class="header">
+      <h1>Chat</h1>
+      <div class="status" id="status">Ready</div>
+    </div>
+    <div class="session-info" id="sessionInfo" style="display:none"></div>
+    <div class="chat-container" id="chat"></div>
+    <div class="input-area">
+      <textarea id="input" rows="1" placeholder="Type a message... (Shift+Enter for newline)"></textarea>
+      <button id="sendBtn">Send</button>
+    </div>
+  </div>
+</div>
+
+<script>
+const chat = document.getElementById('chat');
+const input = document.getElementById('input');
+const sendBtn = document.getElementById('sendBtn');
+const status = document.getElementById('status');
+const sessionInfo = document.getElementById('sessionInfo');
+const sessionList = document.getElementById('sessionList');
+const newSessionBtn = document.getElementById('newSessionBtn');
+
+let sessionId = null;
+let isTyping = false;
+let sessions = [];
+
+// Auto-resize textarea
+input.addEventListener('input', () => {
+  input.style.height = 'auto';
+  input.style.height = Math.min(input.scrollHeight, 120) + 'px';
+});
+
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    sendMessage();
+  }
+});
+
+sendBtn.addEventListener('click', sendMessage);
+newSessionBtn.addEventListener('click', startNewSession);
+
+function setStatus(text, isError = false) {
+  status.textContent = text;
+  status.className = 'status' + (isError ? ' error' : text === 'Thinking...' ? ' thinking' : '');
+}
+
+function addMessage(role, content, html = false) {
+  const div = document.createElement('div');
+  div.className = `message ${role}`;
+  const meta = document.createElement('div');
+  meta.className = 'meta';
+  meta.textContent = role === 'user' ? 'You' : 'Octo';
+  const body = document.createElement('div');
+  body.className = 'content';
+  if (html) {
+    body.innerHTML = content;
+  } else {
+    body.textContent = content;
+  }
+  div.appendChild(meta);
+  div.appendChild(body);
+  chat.appendChild(div);
+  chat.scrollTop = chat.scrollHeight;
+  return body;
+}
+
+function startNewSession() {
+  sessionId = null;
+  chat.innerHTML = `
+    <div class="welcome">
+      <h2>👋 Welcome</h2>
+      <p>Start a conversation by typing below. The first message creates a new session.</p>
+      <p>After the first turn, responses stream in real-time.</p>
+    </div>
+  `;
+  sessionInfo.style.display = 'none';
+  input.focus();
+  renderSessionList();
+}
+
+async function loadSessions() {
+  try {
+    const res = await fetch('/api/sessions');
+    if (!res.ok) return;
+    sessions = await res.json();
+    renderSessionList();
+  } catch (e) {
+    console.error('Failed to load sessions:', e);
+  }
+}
+
+function renderSessionList() {
+  sessionList.innerHTML = '';
+  if (sessions.length === 0) {
+    sessionList.innerHTML = '<div style="padding: 20px; color: var(--text-secondary); font-size: 13px; text-align: center;">No sessions yet</div>';
+    return;
+  }
+  sessions.forEach(s => {
+    const div = document.createElement('div');
+    div.className = 'session-item' + (s.id === sessionId ? ' active' : '');
+    const title = s.title || s.id.slice(0, 8);
+    div.innerHTML = `
+      <div class="sess-id">${title}</div>
+      <div class="sess-date">${new Date(s.created_at).toLocaleString()}</div>
+    `;
+    div.addEventListener('click', () => switchSession(s.id));
+    sessionList.appendChild(div);
+  });
+}
+
+async function switchSession(id) {
+  if (isTyping) return;
+  try {
+    const res = await fetch(`/api/sessions/${id}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const sess = await res.json();
+    sessionId = id;
+    sessionInfo.style.display = 'block';
+    sessionInfo.textContent = `Session: ${id}`;
+    chat.innerHTML = '';
+    sess.messages.forEach(m => {
+      if (m.role === 'user') {
+        addMessage('user', m.content);
+      } else if (m.role === 'assistant') {
+        addMessage('bot', m.content, true).innerHTML = renderMarkdown(m.content);
+      }
+    });
+    renderSessionList();
+    chat.scrollTop = chat.scrollHeight;
+  } catch (err) {
+    setStatus('Error loading session', true);
+  }
+}
+
+function showTyping() {
+  const div = document.createElement('div');
+  div.className = 'typing';
+  div.id = 'typing';
+  div.innerHTML = 'Thinking<span></span><span></span><span></span>';
+  chat.appendChild(div);
+  chat.scrollTop = chat.scrollHeight;
+}
+
+function hideTyping() {
+  const el = document.getElementById('typing');
+  if (el) el.remove();
+}
+
+function renderMarkdown(text) {
+  let html = text
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/```(\w+)?\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>')
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*([^*]+)\*/g, '<em>$1</em>')
+    .replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>')
+    .replace(/\n/g, '<br>');
+  return html;
+}
+
+async function sendMessage() {
+  const text = input.value.trim();
+  if (!text || isTyping) return;
+
+  input.value = '';
+  input.style.height = 'auto';
+  addMessage('user', text);
+  isTyping = true;
+  sendBtn.disabled = true;
+  showTyping();
+  setStatus('Thinking...');
+
+  try {
+    if (!sessionId) {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text })
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      sessionId = data.session_id;
+      sessionInfo.style.display = 'block';
+      sessionInfo.textContent = `Session: ${sessionId}`;
+      hideTyping();
+      addMessage('bot', data.reply, true).innerHTML = renderMarkdown(data.reply);
+      setStatus('Ready');
+      loadSessions();
+    } else {
+      const res = await fetch(`/api/chat/${sessionId}/turn`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'text/event-stream'
+        },
+        body: JSON.stringify({ message: text })
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      hideTyping();
+      const botDiv = addMessage('bot', '', true);
+      let fullText = '';
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop();
+        for (const line of lines) {
+          if (line.startsWith('data: ')) {
+            const data = line.slice(6);
+            if (!data) continue;
+            try {
+              const ev = JSON.parse(data);
+              handleEvent(ev, botDiv, () => fullText);
+              if (ev.kind === 'turn_done') {
+                fullText = ev.reply?.content || fullText;
+              }
+            } catch (e) {
+              // ignore parse errors
+            }
+          }
+        }
+      }
+      setStatus('Ready');
+    }
+  } catch (err) {
+    hideTyping();
+    const errDiv = document.createElement('div');
+    errDiv.className = 'error-msg';
+    errDiv.textContent = `Error: ${err.message}`;
+    chat.lastElementChild?.appendChild(errDiv);
+    setStatus('Error', true);
+  } finally {
+    isTyping = false;
+    sendBtn.disabled = false;
+    input.focus();
+  }
+}
+
+function handleEvent(ev, botDiv, getFullText) {
+  switch (ev.kind) {
+    case 'assistant_text_delta':
+      botDiv.innerHTML = renderMarkdown(getFullText() + (ev.delta || ''));
+      chat.scrollTop = chat.scrollHeight;
+      break;
+    case 'tool_call':
+      const toolDiv = document.createElement('div');
+      toolDiv.className = 'tool-call';
+      toolDiv.innerHTML = `<div class="tool-name">🔧 ${ev.tool_name || 'tool'}</div>`;
+      if (ev.tool_input) {
+        const argsDiv = document.createElement('div');
+        argsDiv.className = 'tool-args';
+        argsDiv.textContent = JSON.stringify(ev.tool_input, null, 2);
+        toolDiv.appendChild(argsDiv);
+      }
+      botDiv.appendChild(toolDiv);
+      chat.scrollTop = chat.scrollHeight;
+      break;
+    case 'tool_result':
+      if (ev.result) {
+        const resultDiv = document.createElement('div');
+        resultDiv.className = 'tool-call';
+        resultDiv.style.marginTop = '4px';
+        resultDiv.innerHTML = `<div class="tool-name">✅ Result</div><div class="tool-args">${JSON.stringify(ev.result, null, 2)}</div>`;
+        botDiv.appendChild(resultDiv);
+        chat.scrollTop = chat.scrollHeight;
+      }
+      break;
+    case 'tool_error':
+      const errDiv = document.createElement('div');
+      errDiv.className = 'tool-call';
+      errDiv.style.borderColor = 'rgba(248,81,73,.3)';
+      errDiv.innerHTML = `<div class="tool-name" style="color:#f85149">❌ Error</div><div class="tool-args">${ev.error || 'Unknown error'}</div>`;
+      botDiv.appendChild(errDiv);
+      chat.scrollTop = chat.scrollHeight;
+      break;
+    case 'turn_done':
+      if (ev.reply?.content) {
+        botDiv.innerHTML = renderMarkdown(ev.reply.content);
+      }
+      break;
+  }
+}
+
+// Init
+loadSessions();
+chat.innerHTML = `
+  <div class="welcome">
+    <h2>👋 Welcome to Octo Agent</h2>
+    <p>Start a conversation by typing below. The first message creates a new session.</p>
+    <p>After the first turn, responses stream in real-time via SSE.</p>
+  </div>
+`;
+</script>
+</body>
+</html>


### PR DESCRIPTION
### Changes

1. **Clickable server URL** (cmd/octo/serve.go)
   - When -addr is :8080, print http://localhost:8080 instead of http://:8080
   - Makes the link clickable in most terminals

2. **Functional Web UI** (internal/server/static/index.html)
   - Create sessions via POST /api/chat
   - Stream real-time responses via SSE (Accept: text/event-stream)
   - Auto-resize textarea, Shift+Enter for newline
   - Simple markdown rendering (code blocks, inline code, bold, italic, quotes)
   - Tool call / result / error display
   - Dark theme (GitHub-inspired)

Open http://localhost:8080 after octo serve to see the chat interface.
