### PR TITLE
feat(skills): load skills added mid-session via reload-on-miss

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -275,6 +275,14 @@ func skillTrigger(reg *skills.Registry, line string) (skills.Skill, string, bool
 	}
 	s, ok := reg.Get(name)
 	if !ok {
+		// Re-scan once in case the skill was added after session start: the
+		// frozen manifest won't list it, but the user can still trigger it by
+		// name. Mirrors the skill tool's reload-on-miss; the rescan only runs
+		// on a non-reserved /command that didn't match a known skill.
+		reg.Reload()
+		s, ok = reg.Get(name)
+	}
+	if !ok {
 		return skills.Skill{}, "", false
 	}
 	args := strings.TrimSpace(strings.TrimPrefix(line, fields[0]))

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
@@ -39,9 +40,14 @@ type Skill struct {
 	Source      string // "project" | "user" (display only, for --list-skills)
 }
 
-// Registry holds the skills discovered for a session, indexed by name.
+// Registry holds the skills discovered for a session, indexed by name. It is
+// safe for concurrent use (sub-agents share one registry and call the skill
+// tool from separate goroutines). cwd is remembered so Reload can re-scan the
+// same roots a session was discovered from.
 type Registry struct {
+	mu     sync.RWMutex
 	skills map[string]Skill
+	cwd    string
 }
 
 // userSkillsRoot returns ~/.octo/skills, or "" when the home dir can't be
@@ -59,7 +65,7 @@ var userSkillsRoot = func() string {
 // root is scanned last, overwriting the map entry). A missing root is not an
 // error — most environments won't have both.
 func Discover(cwd string) *Registry {
-	r := &Registry{skills: make(map[string]Skill)}
+	r := &Registry{skills: make(map[string]Skill), cwd: cwd}
 	// Lowest precedence first; scanRoot overwrites by name, so user then
 	// project win. Default skills (shipped with the binary, materialized to
 	// ~/.octo/skills-default) are the floor — a user overrides one by dropping
@@ -158,8 +164,26 @@ func (r *Registry) Get(name string) (Skill, bool) {
 	if r == nil {
 		return Skill{}, false
 	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	s, ok := r.skills[name]
 	return s, ok
+}
+
+// Reload re-scans the skill roots in place, picking up skills added, removed, or
+// edited since the registry was first discovered. The system-prompt manifest is
+// intentionally NOT refreshed (recomputing it mid-session would change the
+// cached prompt prefix); this only refreshes what the `skill` tool can load, so
+// a skill dropped into ~/.octo/skills mid-session becomes loadable without a
+// restart. Safe to call concurrently with Get/List/Len.
+func (r *Registry) Reload() {
+	if r == nil {
+		return
+	}
+	fresh := Discover(r.cwd) // build off the lock, then swap atomically
+	r.mu.Lock()
+	r.skills = fresh.skills
+	r.mu.Unlock()
 }
 
 // Len reports how many skills were discovered.
@@ -167,6 +191,8 @@ func (r *Registry) Len() int {
 	if r == nil {
 		return 0
 	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return len(r.skills)
 }
 
@@ -176,10 +202,12 @@ func (r *Registry) List() []Skill {
 	if r == nil {
 		return nil
 	}
+	r.mu.RLock()
 	out := make([]Skill, 0, len(r.skills))
 	for _, s := range r.skills {
 		out = append(out, s)
 	}
+	r.mu.RUnlock()
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Source != out[j].Source {
 			return out[i].Source == "project" // project before user

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -27,6 +27,35 @@ func useUserRoot(t *testing.T, dir string) {
 	t.Cleanup(func() { userSkillsRoot = orig })
 }
 
+// Reload re-scans the same roots in place, so a skill added (or edited) after
+// Discover becomes available without rebuilding the registry — the mechanism
+// that lets the `skill` tool load a skill dropped in mid-session.
+func TestReload_PicksUpLateSkill(t *testing.T) {
+	useDefaultRoot(t, t.TempDir()) // isolate from real ~/.octo/skills-default
+	userRoot := t.TempDir()
+	useUserRoot(t, userRoot)
+
+	r := Discover("")
+	if _, ok := r.Get("latecomer"); ok {
+		t.Fatal("latecomer should not exist before it is written")
+	}
+
+	writeSkill(t, userRoot, "latecomer", "---\nname: latecomer\ndescription: added after discover\n---\nbody here")
+
+	// Still absent until a reload — the registry is a frozen snapshot.
+	if _, ok := r.Get("latecomer"); ok {
+		t.Fatal("Get should not see the new skill before Reload")
+	}
+	r.Reload()
+	s, ok := r.Get("latecomer")
+	if !ok {
+		t.Fatal("Reload should pick up the late-added skill")
+	}
+	if s.Description != "added after discover" {
+		t.Errorf("Description = %q", s.Description)
+	}
+}
+
 func TestDiscover_Empty(t *testing.T) {
 	useUserRoot(t, filepath.Join(t.TempDir(), "nonexistent"))
 	r := Discover(filepath.Join(t.TempDir(), "alsogone"))

--- a/internal/tools/skill.go
+++ b/internal/tools/skill.go
@@ -58,6 +58,15 @@ func (SkillTool) Execute(_ context.Context, _ string, input map[string]any) (age
 	}
 	s, ok := activeSkills.Get(name)
 	if !ok {
+		// Miss: the skill may have been added or renamed after session start.
+		// The system-prompt manifest is frozen (for prompt-cache stability), but
+		// the tool re-scans disk so a freshly-dropped skill is still loadable
+		// without restarting the session. The fast path above means this disk
+		// scan only runs on a miss, not on every load.
+		activeSkills.Reload()
+		s, ok = activeSkills.Get(name)
+	}
+	if !ok {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("skill: unknown skill %q", name)
 	}
 	// RenderSkill prefixes the skill's directory so the model can read any


### PR DESCRIPTION
## Problem

Skills are discovered **once at session start** and frozen into the system-prompt manifest (recomputing it mid-session would change the cached prompt prefix and bust the provider's prompt cache). Consequence: a skill dropped into `~/.octo/skills` *after* a session started couldn't be loaded by the `skill` tool. The agent would **see** it via `octo chat --list-skills` (a fresh subprocess that re-scans) but its own in-session registry was frozen without it — reading as *"the skill tool doesn't support user-level skills."*

Confirmed root cause: restarting the session fixes it. Not source-specific (user vs default) — purely "added after the snapshot."

## Fix (the compromise discussed)

Refresh **only** what the `skill` tool can load; leave the manifest frozen so the prompt cache is untouched.

- `skills.Registry` gains a `sync.RWMutex` (it's shared across sub-agent goroutines) and remembers the `cwd` it was discovered from.
- New `Registry.Reload()` re-scans the same roots in place and swaps the map atomically.
- The `skill` tool **and** the `/<name>` trigger reload-on-miss: the fast path (skill already known) does **no** I/O; the disk rescan runs only when a name isn't found. So a freshly-dropped skill becomes loadable without a restart, and the system-prompt manifest (hence the prompt cache) is never recomputed mid-session.

## Tests
- `TestReload_PicksUpLateSkill` (skills): a skill written after `Discover` is invisible to `Get` until `Reload`, then loads.
- Verified the tool path end-to-end (reload-on-miss loads a late-added skill with no re-Discover).
- `go test -race ./...`, `go vet`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)