### PR TITLE
feat(tui): show live progress while a tool's arguments stream

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -332,6 +332,16 @@ type tuiModel struct {
 	// until completion.)
 	running *runningTool
 
+	// toolStream* track a tool call whose arguments are still streaming from the
+	// model — e.g. a large write_file whose whole content arrives as one long
+	// input_json_delta. Without a readout the turn shows only the generic
+	// "Thinking" spinner for many seconds, reading as a freeze; instead View
+	// shows a live "Writing… N KB" line whose byte counter visibly grows.
+	// toolStreamID detects when a new tool's args start (reset the counter).
+	toolStreamID    string
+	toolStreamName  string
+	toolStreamBytes int
+
 	// compacting is set between EventCompactStarted and EventCompactDone while
 	// history compaction runs. It drives a dedicated live spinner line so the
 	// user sees the conversation isn't frozen while the summary streams in.
@@ -509,6 +519,7 @@ func (m *tuiModel) startTurnEchoRestore(line, echo, restore string) tea.Cmd {
 	m.partial.Reset()
 	m.thinkPartial.Reset()
 	m.thinkingStarted = false
+	m.toolStreamName, m.toolStreamID, m.toolStreamBytes = "", "", 0
 	m.clearSuggestion() // a new turn supersedes any pending follow-up
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancelTurn = cancel
@@ -886,11 +897,26 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 		m.appendThinking(ev.Text)
 		return
 
+	case agent.EventToolInputDelta:
+		// The model is still streaming this tool call's arguments (e.g. a large
+		// write_file content). Surface a live byte counter so the wait reads as
+		// progress, not a freeze. Reset when a different tool's args begin.
+		if ev.ToolID != m.toolStreamID {
+			m.toolStreamID = ev.ToolID
+			m.toolStreamBytes = 0
+		}
+		m.toolStreamName = ev.ToolName
+		m.toolStreamBytes += len(ev.InputDelta)
+		return
+
 	case agent.EventTextDelta:
 		m.appendText(ev.Text)
 		return
 
 	case agent.EventToolStarted:
+		// Args finished streaming; the tool now executes. Clear the stream
+		// readout so the running-card spinner (or one-line status) takes over.
+		m.toolStreamName, m.toolStreamID, m.toolStreamBytes = "", "", 0
 		if m.toolInput == nil {
 			m.toolInput = map[string]map[string]any{}
 		}

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -182,6 +182,35 @@ func TestTUI_FirstOutputCommitsEcho(t *testing.T) {
 	}
 }
 
+// While the model streams a large tool argument (e.g. a big write_file body),
+// the view must show a live byte counter so the wait reads as progress, not a
+// freeze. EventToolStarted (args complete) clears the readout.
+func TestTUI_ToolInputStreamProgress(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventToolInputDelta, ToolID: "c1", ToolName: "write_file", InputDelta: strings.Repeat("x", 2048)})
+	if m.toolStreamName != "write_file" || m.toolStreamBytes != 2048 {
+		t.Fatalf("after first delta: name=%q bytes=%d", m.toolStreamName, m.toolStreamBytes)
+	}
+	out := m.View()
+	if !strings.Contains(out, "Writing") || !strings.Contains(out, "2.0 KB") {
+		t.Errorf("view should show a live write progress line; got:\n%s", out)
+	}
+
+	// A second fragment of the same call accumulates.
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventToolInputDelta, ToolID: "c1", ToolName: "write_file", InputDelta: strings.Repeat("x", 1024)})
+	if m.toolStreamBytes != 3072 {
+		t.Fatalf("bytes should accumulate within one call, got %d", m.toolStreamBytes)
+	}
+
+	// Args complete → tool dispatches → readout clears.
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventToolStarted, ToolID: "c1", ToolName: "write_file", Input: map[string]any{"path": "x.html"}})
+	if m.toolStreamName != "" || m.toolStreamBytes != 0 {
+		t.Errorf("EventToolStarted should clear the stream readout; name=%q bytes=%d", m.toolStreamName, m.toolStreamBytes)
+	}
+}
+
 // Reasoning deltas must commit to the scrollback (dimmed) before the answer,
 // with the 💭 marker on the first line only — so the trace stays in the
 // transcript above the reply instead of vanishing into a spinner.

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -473,6 +473,24 @@ func lastRunes(s string, n int) string {
 	return string(r[len(r)-n:])
 }
 
+// streamVerbFor labels the live tool-argument-streaming indicator with a
+// gerund so it reads as an action in progress ("Writing… 12.3 KB"). Falls back
+// to the card verb, then the raw tool name for tools without a friendly verb.
+func streamVerbFor(toolName string) string {
+	switch toolName {
+	case "write_file":
+		return "Writing"
+	case "edit_file":
+		return "Editing"
+	case "terminal":
+		return "Preparing command"
+	}
+	if v := cardVerbFor(toolName); v != "" {
+		return v
+	}
+	return toolName
+}
+
 // humanByteSize renders a byte count compactly (B / KB / MB).
 func humanByteSize(n int) string {
 	const kb, mb = 1024, 1024 * 1024
@@ -794,6 +812,14 @@ func (m *tuiModel) View() string {
 		}
 	} else if m.running != nil {
 		b.WriteString(m.spinnerLine(m.running.verb+"("+m.running.target+")", m.running.start))
+		b.WriteByte('\n')
+	} else if m.turnRunning && m.toolStreamName != "" {
+		// The model is streaming a tool call's arguments (e.g. a large
+		// write_file body). Show a live byte counter so a multi-second argument
+		// stream reads as progress, not a freeze. The count is JSON-stream bytes
+		// (a touch larger than the final value), which is fine for a heartbeat.
+		label := fmt.Sprintf("%s… %s", streamVerbFor(m.toolStreamName), humanByteSize(m.toolStreamBytes))
+		b.WriteString(m.spinnerLine(label, m.turnStart))
 		b.WriteByte('\n')
 	} else if m.turnRunning && m.partial.Len() == 0 {
 		// Turn is running but nothing is on the activity line right now — no


### PR DESCRIPTION
## Problem

When the model generates a **large tool call** — e.g. `write_file` whose entire content streams as one long `input_json_delta` — the TUI looked **frozen** for the whole multi-second argument stream. It received the `EventToolInputDelta` events but `handleEvent` had no case for them, so:
- no streaming text yet (it's tool *input*, not the answer) → `partial` empty,
- the tool hasn't dispatched yet → `running` nil,
- → the view fell back to the generic `Thinking` spinner for 20–30s while a big file streamed in.

(Reported in a real session: "界面看着像没响应了,其实是模型请求还没返回 … agent 在写一个大文件,流式响应花了较长时间。")

## Fix

Handle `EventToolInputDelta`: track the streaming call's id/name and accumulated bytes, and render a live indicator whose **byte counter grows with each delta**:

```
⠹ Writing… 12.5 KB (8s)
```

- Reset the counter when a different tool's args begin; cleared on `EventToolStarted` (the running-card spinner takes over) and at turn start.
- `streamVerbFor` gives a gerund label (Writing / Editing / Preparing command / …), falling back to the card verb then the tool name.
- Byte count is JSON-stream size (slightly larger than the final value) — fine for a heartbeat. Reuses the existing `humanByteSize`.
- `liveHeight()` already counts one activity line for `turnRunning && partial empty`, so the height estimate stays correct.

## Test
- `TestTUI_ToolInputStreamProgress`: deltas accumulate, the view shows `Writing… 2.0 KB`, a second fragment accumulates, and `EventToolStarted` clears the readout.
- `go test -race ./...`, `go vet`, `gofmt`, native + `GOOS=windows` build — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)