### PR TITLE
feat(tools): add preset sub-agent types (explore/plan/general/code-review)

### DIFF
--- a/cmd/octo/sub_agent.go
+++ b/cmd/octo/sub_agent.go
@@ -54,7 +54,7 @@ const childMaxTurns = 100
 // a later send_message can continue it, runs the first prompt, and returns the
 // child's id alongside its reply.
 func (s *agentSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
-	childTools := filterChildTools(s.toolsFn(), req.Tools)
+	childTools := filterChildTools(s.toolsFn(), req.Tools, req.ReadOnly)
 
 	model := req.Model
 	if model == "" {
@@ -63,6 +63,11 @@ func (s *agentSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools
 
 	child := agent.New(s.parent.Sender, model)
 	child.System = s.parent.System // share harness identity (base + soul + env + skills + memory + …)
+	if req.SystemSuffix != "" {
+		// Preset agents append a persona after the shared identity, so the
+		// child keeps the harness context but takes on its specialized role.
+		child.System = s.parent.System + "\n\n" + req.SystemSuffix
+	}
 	child.MaxTokens = s.parent.MaxTokens
 	child.Gate = s.parent.Gate
 	child.MaxTurns = childMaxTurns
@@ -157,8 +162,11 @@ func (s *agentSpawner) runChild(ctx context.Context, lc *liveChild, prompt strin
 // filterChildTools drops launch_agent and send_message (a sub-agent can
 // neither spawn nor wake another sub-agent — those stay top-level-only) and,
 // when allowed is non-empty, intersects with that allowlist so the parent can
-// hand the child a restricted toolbelt (e.g. read-only research).
-func filterChildTools(parent []agent.ToolDefinition, allowed []string) []agent.ToolDefinition {
+// hand the child a restricted toolbelt (e.g. read-only research). When readOnly
+// is set, the mutating tools (write_file, edit_file) are dropped too — used by
+// read-only presets so the child keeps terminal/MCP/codegraph but can't change
+// files. The two filters compose: a readOnly preset still honours allowed.
+func filterChildTools(parent []agent.ToolDefinition, allowed []string, readOnly bool) []agent.ToolDefinition {
 	var allowSet map[string]bool
 	if len(allowed) > 0 {
 		allowSet = make(map[string]bool, len(allowed))
@@ -169,6 +177,9 @@ func filterChildTools(parent []agent.ToolDefinition, allowed []string) []agent.T
 	out := make([]agent.ToolDefinition, 0, len(parent))
 	for _, td := range parent {
 		if td.Name == "launch_agent" || td.Name == "send_message" {
+			continue
+		}
+		if readOnly && (td.Name == "write_file" || td.Name == "edit_file") {
 			continue
 		}
 		if allowSet != nil && !allowSet[td.Name] {

--- a/cmd/octo/sub_agent_test.go
+++ b/cmd/octo/sub_agent_test.go
@@ -99,7 +99,7 @@ func TestAgentSpawner_AppliesToolAllowlist(t *testing.T) {
 	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return parentTools })
 
 	// Allowlist restricts to read_file + grep. launch_agent always excluded.
-	got := filterChildTools(parentTools, []string{"read_file", "grep"})
+	got := filterChildTools(parentTools, []string{"read_file", "grep"}, false)
 	if len(got) != 2 {
 		t.Fatalf("filtered tools len = %d, want 2: %+v", len(got), got)
 	}
@@ -109,7 +109,7 @@ func TestAgentSpawner_AppliesToolAllowlist(t *testing.T) {
 	}
 
 	// No allowlist → all parent tools minus launch_agent.
-	got = filterChildTools(parentTools, nil)
+	got = filterChildTools(parentTools, nil, false)
 	if len(got) != 3 {
 		t.Errorf("nil allowlist should keep all non-launch_agent tools: %+v", got)
 	}
@@ -313,7 +313,7 @@ func TestFilterChildTools_DropsSendMessage(t *testing.T) {
 		{Name: "launch_agent"},
 		{Name: "send_message"},
 	}
-	got := filterChildTools(parentTools, nil)
+	got := filterChildTools(parentTools, nil, false)
 	for _, td := range got {
 		if td.Name == "send_message" || td.Name == "launch_agent" {
 			t.Errorf("child toolbelt must not contain %q", td.Name)
@@ -322,6 +322,69 @@ func TestFilterChildTools_DropsSendMessage(t *testing.T) {
 	if len(got) != 1 || got[0].Name != "read_file" {
 		t.Errorf("expected only read_file to survive, got %+v", got)
 	}
+}
+
+func TestFilterChildTools_ReadOnlyDropsMutators(t *testing.T) {
+	parentTools := []agent.ToolDefinition{
+		{Name: "read_file"},
+		{Name: "grep"},
+		{Name: "terminal"},
+		{Name: "write_file"},
+		{Name: "edit_file"},
+	}
+	got := filterChildTools(parentTools, nil, true)
+	for _, td := range got {
+		if td.Name == "write_file" || td.Name == "edit_file" {
+			t.Errorf("read-only child must not contain %q", td.Name)
+		}
+	}
+	// terminal and the read tools survive — read-only only strips file mutators.
+	names := map[string]bool{}
+	for _, td := range got {
+		names[td.Name] = true
+	}
+	for _, want := range []string{"read_file", "grep", "terminal"} {
+		if !names[want] {
+			t.Errorf("read-only child should keep %q, got %+v", want, got)
+		}
+	}
+}
+
+func TestAgentSpawner_AppliesSystemSuffix(t *testing.T) {
+	send := &subAgentSender{reply: "ok"}
+	parent := agent.New(send, "parent-model")
+	parent.System = "BASE IDENTITY"
+	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+
+	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{
+		Prompt:       "go",
+		SystemSuffix: "PERSONA: explore only",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	lc := sp.reg.m[onlyChildID(t, sp)]
+	if lc == nil {
+		t.Fatal("expected a registered child")
+	}
+	if got := lc.agent.System; got != "BASE IDENTITY\n\nPERSONA: explore only" {
+		t.Errorf("child System = %q, want base + persona suffix", got)
+	}
+}
+
+// onlyChildID returns the single registered child id, failing if there isn't
+// exactly one.
+func onlyChildID(t *testing.T, sp *agentSpawner) string {
+	t.Helper()
+	sp.reg.mu.Lock()
+	defer sp.reg.mu.Unlock()
+	if len(sp.reg.m) != 1 {
+		t.Fatalf("expected exactly 1 registered child, got %d", len(sp.reg.m))
+	}
+	for id := range sp.reg.m {
+		return id
+	}
+	return ""
 }
 
 func TestChildRegistry_LRUEviction(t *testing.T) {

--- a/internal/tools/launch_agent.go
+++ b/internal/tools/launch_agent.go
@@ -44,6 +44,19 @@ type SpawnRequest struct {
 	// Model, when non-empty, overrides the parent's model for this child.
 	// Empty means "use the parent's default" — typically the same model.
 	Model string
+
+	// SystemSuffix, when non-empty, is appended to the child's system prompt
+	// (after the shared parent System) to give a preset agent its persona.
+	// Empty for a plain launch_agent call — the child then runs with the
+	// parent's identity unchanged.
+	SystemSuffix string
+
+	// ReadOnly, when true, strips the mutating tools (write_file, edit_file)
+	// from the child's toolbelt on top of the always-dropped launch_agent /
+	// send_message. The child still inherits everything else — terminal,
+	// web tools, MCP/codegraph — so read-only presets (explore, plan,
+	// code-review) stay capable without being able to change files.
+	ReadOnly bool
 }
 
 // SpawnResult is the sub-agent's final output, plus its token usage so the

--- a/internal/tools/preset_agents.go
+++ b/internal/tools/preset_agents.go
@@ -1,0 +1,177 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// presetAgent describes a named sub-agent type. Each preset becomes its own
+// top-level tool (explore_agent, plan_agent, …) rather than a parameter on
+// launch_agent, so the model picks a role by name and the schema spells out
+// what each one is for. A preset bundles three things launch_agent leaves to
+// the caller: a curated persona (appended to the child's system prompt), a
+// read-only toolbelt switch, and an optional model override.
+type presetAgent struct {
+	// name is the LLM-facing tool name.
+	name string
+	// label is the default progress-UI description when the model omits one.
+	label string
+	// description is the tool description shown to the model.
+	description string
+	// persona is appended to the child's system prompt (SpawnRequest.SystemSuffix).
+	persona string
+	// readOnly drops write_file / edit_file from the child's toolbelt.
+	readOnly bool
+}
+
+// presetAgents is the canonical set of built-in sub-agent types. Adding a
+// preset here registers its tool automatically via the init() below.
+var presetAgents = []presetAgent{
+	{
+		name:  "explore_agent",
+		label: "Explore the codebase",
+		description: "Spawn a read-only sub-agent to investigate and report on the codebase. " +
+			"It can read files, grep, glob, run read-only shell commands, and use any " +
+			"code-intelligence tools available, but cannot modify files. Use to locate code, " +
+			"understand how subsystems connect, or answer a broad 'where/how does X work' " +
+			"question without polluting this context. Runs asynchronously — you get a " +
+			"notification with its findings when it completes. Returns a report, not a code change.",
+		readOnly: true,
+		persona: "You are a read-only exploration sub-agent. Your job is to locate and understand " +
+			"code, then report findings — not to modify anything. Use read_file, grep, glob, " +
+			"read-only terminal commands (git, find, ls), and any code-intelligence tools available. " +
+			"Do NOT write or edit files. Deliverable: a concise report answering the task directly — " +
+			"the relevant file paths with line numbers, how the pieces connect, and the minimal code " +
+			"quoted to make the point. Don't dump whole files.",
+	},
+	{
+		name:  "plan_agent",
+		label: "Draft an implementation plan",
+		description: "Spawn a read-only sub-agent that investigates the codebase and returns a " +
+			"concrete, step-by-step implementation plan. It can read and search but cannot modify " +
+			"files. Use when a task is well-defined enough to plan in isolation and you want a " +
+			"dependency-ordered breakdown grounded in the real code. Runs asynchronously — you get " +
+			"a notification with the plan when it completes.",
+		readOnly: true,
+		persona: "You are a planning sub-agent. Investigate the codebase read-only, then produce a " +
+			"concrete, step-by-step implementation plan. Do NOT modify files. Deliverable: an ordered " +
+			"plan — the files to change and what changes in each, in dependency order; the key design " +
+			"decisions and trade-offs; risks and a test strategy. Ground every step in code you have " +
+			"actually inspected (cite file:line). Do not write speculative steps you couldn't verify.",
+	},
+	{
+		name:  "general_agent",
+		label: "Handle a delegated task",
+		description: "Spawn a general-purpose sub-agent with the full toolbelt (it can read, write, " +
+			"edit, and run commands) to handle a focused, self-contained task end-to-end. Use when " +
+			"the sub-task is well-defined enough to delegate without back-and-forth and you want it " +
+			"done in a fresh context window. Runs asynchronously — you get a notification with the " +
+			"result when it completes. For a read-only investigation prefer explore_agent; to restrict " +
+			"the toolbelt explicitly, use launch_agent.",
+		readOnly: false,
+		persona: "You are an autonomous general-purpose sub-agent handling a delegated task end-to-end. " +
+			"You have the full toolbelt. Complete the task, verify your work, and return a clear, " +
+			"self-contained result the caller can act on without seeing your intermediate steps.",
+	},
+	{
+		name:  "code_review_agent",
+		label: "Review the changes",
+		description: "Spawn a read-only sub-agent to review code changes for correctness bugs, " +
+			"convention violations, performance issues, missing tests, and security problems. It can " +
+			"run `git diff`/`git status`, read the touched files, and search, but cannot modify files. " +
+			"Use after making changes or to review a diff. Runs asynchronously — you get a notification " +
+			"with the findings when it completes.",
+		readOnly: true,
+		persona: "You are a code-review sub-agent. Review the changes — use `git diff`, `git status`, " +
+			"and read the touched files — for correctness bugs, convention violations, performance " +
+			"issues, missing tests, and security problems. Do NOT modify files. Deliverable: a " +
+			"prioritized list of findings, each with file:line, a severity, what is wrong, and a " +
+			"suggested fix. If you find nothing material, say so explicitly rather than inventing nits.",
+	},
+}
+
+// init registers one PresetAgentTool per preset alongside the hand-written
+// built-ins. allTools is already initialised when init runs (package-level var
+// literals evaluate before init functions), so the append lands after the
+// literal entries — the presets show up at the end of DefaultTools().
+func init() {
+	for _, p := range presetAgents {
+		allTools = append(allTools, PresetAgentTool{spec: p})
+	}
+}
+
+// PresetAgentTool is one named sub-agent type. It reuses the same async
+// SubAgentManager.Start path as LaunchAgentTool — so the result arrives via a
+// notification, agent_status/kill_agent/send_message all work on it — but fixes
+// the persona and read-only toolbelt from its preset instead of taking them as
+// LLM arguments. Only description and prompt remain caller-supplied.
+type PresetAgentTool struct {
+	spec presetAgent
+	mgr  *SubAgentManager
+}
+
+func (t PresetAgentTool) manager() *SubAgentManager {
+	if t.mgr != nil {
+		return t.mgr
+	}
+	return defaultSubAgentMgr
+}
+
+func (t PresetAgentTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name:        t.spec.name,
+		Description: t.spec.description,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"description": map[string]any{
+					"type":        "string",
+					"description": "Short human-readable label for this sub-agent (3-7 words). Shown in progress UI; doesn't shape behavior.",
+				},
+				"prompt": map[string]any{
+					"type":        "string",
+					"description": "The task for the sub-agent. Self-contained: include all context it needs (file paths, constraints, the exact question) since it can't see this conversation.",
+				},
+			},
+			"required": []string{"prompt"},
+		},
+	}
+}
+
+func (t PresetAgentTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	if IsSubAgent(ctx) {
+		// Same recursion guard as launch_agent — a sub-agent cannot spawn
+		// another sub-agent, even via a preset tool.
+		return agent.ToolResult{Text: ""}, fmt.Errorf("%s: a sub-agent cannot spawn another sub-agent", t.spec.name)
+	}
+
+	prompt := strings.TrimSpace(stringArg(input, "prompt"))
+	if prompt == "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("%s: prompt is required", t.spec.name)
+	}
+	desc := strings.TrimSpace(stringArg(input, "description"))
+	if desc == "" {
+		desc = t.spec.label
+	}
+
+	mgr := t.manager()
+	if mgr == nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("%s: sub-agent dispatch is not configured for this session", t.spec.name)
+	}
+
+	id, err := mgr.Start(SpawnRequest{
+		Description:  desc,
+		Prompt:       prompt,
+		SystemSuffix: t.spec.persona,
+		ReadOnly:     t.spec.readOnly,
+	})
+	if err != nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("%s: %w", t.spec.name, err)
+	}
+	return agent.ToolResult{
+		Text: fmt.Sprintf("Started %s %s. You will be notified when it completes.", t.spec.name, id),
+	}, nil
+}

--- a/internal/tools/preset_agents_test.go
+++ b/internal/tools/preset_agents_test.go
@@ -1,0 +1,167 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// presetByName returns the registered PresetAgentTool with the given name.
+func presetByName(t *testing.T, name string) PresetAgentTool {
+	t.Helper()
+	for _, tl := range allTools {
+		if p, ok := tl.(PresetAgentTool); ok && p.spec.name == name {
+			return p
+		}
+	}
+	t.Fatalf("preset agent %q is not registered in allTools", name)
+	return PresetAgentTool{}
+}
+
+func TestPresetAgents_Registered(t *testing.T) {
+	want := []string{"explore_agent", "plan_agent", "general_agent", "code_review_agent"}
+	for _, name := range want {
+		p := presetByName(t, name)
+		def := p.Definition()
+		if def.Name != name {
+			t.Errorf("Definition().Name = %q, want %q", def.Name, name)
+		}
+		props, _ := def.Parameters["properties"].(map[string]any)
+		if _, ok := props["prompt"]; !ok {
+			t.Errorf("%s schema missing 'prompt'", name)
+		}
+		// Presets fix the toolbelt and model themselves — those must not be
+		// caller-tunable arguments like launch_agent's.
+		if _, ok := props["tools"]; ok {
+			t.Errorf("%s should not expose a 'tools' argument", name)
+		}
+		if _, ok := props["model"]; ok {
+			t.Errorf("%s should not expose a 'model' argument", name)
+		}
+		required, _ := def.Parameters["required"].([]string)
+		if !containsString(required, "prompt") {
+			t.Errorf("%s should require 'prompt', got %v", name, required)
+		}
+	}
+}
+
+func TestPresetAgents_ReadOnlyFlags(t *testing.T) {
+	cases := map[string]bool{
+		"explore_agent":     true,
+		"plan_agent":        true,
+		"code_review_agent": true,
+		"general_agent":     false,
+	}
+	for name, wantReadOnly := range cases {
+		if got := presetByName(t, name).spec.readOnly; got != wantReadOnly {
+			t.Errorf("%s readOnly = %v, want %v", name, got, wantReadOnly)
+		}
+	}
+}
+
+func TestPresetAgentTool_ForwardsPersonaAndReadOnly(t *testing.T) {
+	spawnCalled := make(chan struct{})
+	stub := &stubSpawner{
+		replies:     []SpawnResult{{Reply: "ok"}},
+		spawnCalled: spawnCalled,
+	}
+	mgr := NewSubAgentManager(stub)
+
+	explore := presetByName(t, "explore_agent")
+	explore.mgr = mgr
+
+	out, err := explore.Execute(context.Background(), "explore_agent", map[string]any{
+		"prompt": "Where is the SSE aggregator?",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Text, "Started explore_agent") {
+		t.Errorf("Execute returned %q, want 'Started explore_agent' prefix", out.Text)
+	}
+
+	select {
+	case <-spawnCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Spawn to be called")
+	}
+
+	if len(stub.calls) != 1 {
+		t.Fatalf("expected 1 spawner call, got %d", len(stub.calls))
+	}
+	got := stub.calls[0]
+	if !got.ReadOnly {
+		t.Error("explore_agent should forward ReadOnly=true to the spawner")
+	}
+	if !strings.Contains(got.SystemSuffix, "read-only exploration") {
+		t.Errorf("explore_agent persona not forwarded as SystemSuffix: %q", got.SystemSuffix)
+	}
+	// Description should default to the preset label when the caller omits one.
+	if got.Description != explore.spec.label {
+		t.Errorf("Description = %q, want default label %q", got.Description, explore.spec.label)
+	}
+}
+
+func TestPresetAgentTool_PromptRequired(t *testing.T) {
+	mgr := NewSubAgentManager(&stubSpawner{})
+	p := presetByName(t, "plan_agent")
+	p.mgr = mgr
+	_, err := p.Execute(context.Background(), "plan_agent", map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "prompt is required") {
+		t.Errorf("expected 'prompt is required' error, got %v", err)
+	}
+}
+
+func TestPresetAgentTool_RecursionRefused(t *testing.T) {
+	mgr := NewSubAgentManager(&stubSpawner{})
+	p := presetByName(t, "general_agent")
+	p.mgr = mgr
+	ctx := WithSubAgentMarker(context.Background())
+	_, err := p.Execute(ctx, "general_agent", map[string]any{"prompt": "do a thing"})
+	if err == nil || !strings.Contains(err.Error(), "cannot spawn") {
+		t.Errorf("expected recursion refusal, got %v", err)
+	}
+}
+
+func TestPresetAgentTool_NoManagerConfigured(t *testing.T) {
+	// Bare value (nil mgr) with no default manager registered.
+	SetDefaultSubAgentManager(nil)
+	t.Cleanup(func() { SetDefaultSubAgentManager(nil) })
+	p := presetByName(t, "code_review_agent")
+	p.mgr = nil
+	_, err := p.Execute(context.Background(), "code_review_agent", map[string]any{"prompt": "review the diff"})
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("expected 'not configured' error, got %v", err)
+	}
+}
+
+func TestDefaultTools_PresetsGatedOnManager(t *testing.T) {
+	SetSpawner(nil)
+	SetDefaultSubAgentManager(nil)
+	t.Cleanup(func() {
+		SetSpawner(nil)
+		SetDefaultSubAgentManager(nil)
+	})
+
+	present := func(name string) bool {
+		for _, d := range DefaultTools() {
+			if d.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, name := range []string{"explore_agent", "plan_agent", "general_agent", "code_review_agent"} {
+		if present(name) {
+			t.Errorf("%s should be absent with no manager configured", name)
+		}
+	}
+	SetDefaultSubAgentManager(NewSubAgentManager(&stubSpawner{}))
+	for _, name := range []string{"explore_agent", "plan_agent", "general_agent", "code_review_agent"} {
+		if !present(name) {
+			t.Errorf("%s should be present once a SubAgentManager is registered", name)
+		}
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -213,6 +213,9 @@ func DefaultTools() []agent.ToolDefinition {
 		if _, isLaunch := t.(LaunchAgentTool); isLaunch && !mgrOn {
 			continue
 		}
+		if _, isPreset := t.(PresetAgentTool); isPreset && !mgrOn {
+			continue
+		}
 		if _, isSend := t.(SendMessageTool); isSend && !mgrOn {
 			continue
 		}


### PR DESCRIPTION
## Why

`octo-agent` shipped a generic `launch_agent` tool but no *named* agent types the way Claude Code (`Explore`/`Plan`) or Codex (`codex_explore_agent`) do. Picking a role meant hand-specifying a tool allowlist and prompt every time.

## What

Four preset sub-agent tools, exposed as separate top-level tools (Codex-style), each routing through the same async `SubAgentManager` as `launch_agent` — so notifications, `agent_status`, `kill_agent`, and `send_message` continuation all work on them:

| Tool | Toolbelt | Role |
|---|---|---|
| `explore_agent` | read-only | locate & report on code |
| `plan_agent` | read-only | step-by-step implementation plan |
| `general_agent` | full | delegate a self-contained task end-to-end |
| `code_review_agent` | read-only | review a diff for bugs/conventions/perf/security |

Each preset fixes its own **persona** (appended to the child's system prompt after the shared harness identity) and **read-only flag**; the only LLM-supplied arguments are `description` (optional) and `prompt`.

## How

- `SpawnRequest` gains `SystemSuffix` (persona) and `ReadOnly` — backward-compatible zero-value defaults, so the conductor and memory consolidator are unaffected.
- New `internal/tools/preset_agents.go`: the `presetAgent` registry + `PresetAgentTool`, registered into `allTools` via `init()`, gated on a configured `SubAgentManager` (same as `launch_agent`).
- The spawner appends `SystemSuffix` to `child.System`; `filterChildTools` gained a `readOnly` param that drops `write_file`/`edit_file` while keeping terminal/MCP/codegraph — matching Claude Code's Explore semantics ("all tools except Edit/Write"). A **denylist** was chosen over an allowlist so read-only presets still get `git diff`/`find` and codegraph tools.
- `launch_agent` is unchanged and still available for custom tool-subset/model spawns.

## Tests

- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `go test -race ./...` passes, including new coverage for registration, manager gating, read-only flag + persona forwarding, `filterChildTools` read-only behavior, and the spawner's system-suffix append.

🤖 Generated with [Claude Code](https://claude.com/claude-code)