### PR TITLE
feat(serve): web-UI session delete + bump to v0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ octo chat --sandbox --sandbox-read /opt/data     # extra readable dir (repeatabl
 | Memory | done | Persistent cross-session memory under `~/.octo/memory/`, auto extract/consolidate |
 | Sub-agents | done | `launch_agent` fan-out, async + resumable (`send_message`, `agent_status`, `kill_agent`) |
 | Orchestration | done | `octo conduct` — plan a goal into a subtask DAG, run it via sub-agents, resume after crash |
-| Web server | done | `octo serve` — REST + SSE, embedded dashboard UI (bind localhost) |
+| Web server | done | `octo serve` — REST + SSE, embedded dashboard UI with session browse/delete (bind localhost) |
 | IM bridge | done | `octo channel` — WeChat iLink adapter (QR login, per-user sessions, slash commands) |
 
 ## Architecture

--- a/docs/index.html
+++ b/docs/index.html
@@ -134,7 +134,7 @@
         </div>
         <div class="card">
           <h3>Web UI</h3>
-          <p>Local web app at <code class="inline">:8888</code>. Same agent, richer rendering.</p>
+          <p>Local web app at <code class="inline">:8888</code>. Same agent, richer rendering, browse and delete sessions.</p>
         </div>
         <div class="card">
           <h3>IM bridges</h3>

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -517,6 +517,35 @@ func ResolveSessionID(input string) (string, error) {
 		input, len(matches), strings.Join(matches, "\n  "))
 }
 
+// DeleteSession removes the transcript file for the given session id. id may be
+// a bare id or one with a .jsonl/.json suffix; absolute paths are rejected, and
+// any id that would resolve outside the sessions directory (e.g. via "..") is
+// refused so a caller-supplied id can't reach arbitrary files. A missing file
+// is treated as success — deleting an already-gone session is not an error.
+func DeleteSession(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return fmt.Errorf("session id is empty")
+	}
+	if filepath.IsAbs(id) {
+		return fmt.Errorf("session %q: absolute paths not allowed", id)
+	}
+	stem := strings.TrimSuffix(strings.TrimSuffix(id, ".jsonl"), ".json")
+	// Reject anything that isn't a plain filename stem (no separators, no "..").
+	if stem != filepath.Base(stem) || strings.Contains(stem, "..") {
+		return fmt.Errorf("invalid session id %q", id)
+	}
+	dir, err := sessionsDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, stem+".jsonl")
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("session: remove %s: %w", path, err)
+	}
+	return nil
+}
+
 // ToHistory converts the session's message slice into an agent History.
 func (s *Session) ToHistory() *History {
 	h := NewHistory()

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -558,3 +558,35 @@ func TestSession_UsedTools_EmptyMessagesIsFalse(t *testing.T) {
 		t.Error("empty session should not be UsedTools()")
 	}
 }
+
+func TestDeleteSession(t *testing.T) {
+	setTempHome(t)
+
+	s := NewSession("claude-haiku-4-5-20251001", "")
+	s.Messages = []Message{{Role: RoleUser, Content: "hi"}}
+	if err := s.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	if err := DeleteSession(s.ID); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if _, err := LoadSession(s.ID); err == nil {
+		t.Fatal("session still loadable after delete")
+	}
+
+	// Deleting a missing session is not an error (idempotent).
+	if err := DeleteSession(s.ID); err != nil {
+		t.Errorf("deleting an already-gone session should be nil, got %v", err)
+	}
+}
+
+func TestDeleteSession_RejectsTraversal(t *testing.T) {
+	setTempHome(t)
+
+	for _, id := range []string{"", "../escape", "sub/dir", "/abs/path"} {
+		if err := DeleteSession(id); err == nil {
+			t.Errorf("DeleteSession(%q) = nil, want error", id)
+		}
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -189,6 +189,53 @@ func (s *Server) handleGetSession(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// ─── DELETE /api/sessions/:id ───────────────────────────────────────────────
+
+func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing session id")
+		return
+	}
+	if err := agent.DeleteSession(id); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.forgetTurnLock(id)
+	writeJSON(w, http.StatusOK, map[string]any{"deleted": []string{id}})
+}
+
+// ─── POST /api/sessions/delete (batch) ──────────────────────────────────────
+
+type deleteSessionsRequest struct {
+	IDs []string `json:"ids"`
+}
+
+func (s *Server) handleDeleteSessions(w http.ResponseWriter, r *http.Request) {
+	var req deleteSessionsRequest
+	if err := readBodyJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if len(req.IDs) == 0 {
+		writeError(w, http.StatusBadRequest, "ids is required")
+		return
+	}
+
+	deleted := make([]string, 0, len(req.IDs))
+	failed := map[string]string{}
+	for _, id := range req.IDs {
+		if err := agent.DeleteSession(id); err != nil {
+			failed[id] = err.Error()
+			continue
+		}
+		s.forgetTurnLock(id)
+		deleted = append(deleted, id)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"deleted": deleted, "failed": failed})
+}
+
 // ─── GET /api/tools ─────────────────────────────────────────────────────────
 
 func (s *Server) handleListTools(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -128,7 +128,9 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("POST /api/chat", s.handleCreateChat)
 	s.mux.HandleFunc("POST /api/chat/{id}/turn", s.handleTurnOrSSE)
 	s.mux.HandleFunc("GET /api/sessions", s.handleListSessions)
+	s.mux.HandleFunc("POST /api/sessions/delete", s.handleDeleteSessions)
 	s.mux.HandleFunc("GET /api/sessions/{id}", s.handleGetSession)
+	s.mux.HandleFunc("DELETE /api/sessions/{id}", s.handleDeleteSession)
 	s.mux.HandleFunc("GET /api/tools", s.handleListTools)
 	s.mux.HandleFunc("GET /api/skills", s.handleListSkills)
 	s.mux.HandleFunc("GET /api/health", s.handleHealth)
@@ -153,7 +155,7 @@ func (s *Server) corsMiddleware(next http.Handler) http.Handler {
 		}
 		if allowed {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 		}
 		if r.Method == http.MethodOptions {
@@ -178,6 +180,14 @@ func (s *Server) sessionTurnLock(id string) *sync.Mutex {
 	mu := &sync.Mutex{}
 	s.turnLocks[id] = mu
 	return mu
+}
+
+// forgetTurnLock drops a session's turn mutex after the session is deleted, so
+// the map doesn't accumulate locks for sessions that no longer exist.
+func (s *Server) forgetTurnLock(id string) {
+	s.turnMu.Lock()
+	defer s.turnMu.Unlock()
+	delete(s.turnLocks, id)
 }
 
 // buildAgent creates a fresh agent for a turn. The caller must have locked

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -115,6 +115,87 @@ func TestHandleGetSession_NotFound(t *testing.T) {
 	}
 }
 
+func TestHandleDeleteSession(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := agent.NewSession("stub-model", "")
+	sess.Messages = []agent.Message{{Role: agent.RoleUser, Content: "hi"}}
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/sessions/"+sess.ID, nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if _, err := agent.LoadSession(sess.ID); err == nil {
+		t.Fatal("session still loadable after delete")
+	}
+}
+
+func TestHandleDeleteSessions_Batch(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	var ids []string
+	for i := 0; i < 3; i++ {
+		sess := agent.NewSession("stub-model", "")
+		sess.Messages = []agent.Message{{Role: agent.RoleUser, Content: "hi"}}
+		if err := sess.Save(); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+		ids = append(ids, sess.ID)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	payload, _ := json.Marshal(deleteSessionsRequest{IDs: ids})
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/delete", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Deleted []string          `json:"deleted"`
+		Failed  map[string]string `json:"failed"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Deleted) != 3 {
+		t.Fatalf("deleted = %v, want 3", body.Deleted)
+	}
+	for _, id := range ids {
+		if _, err := agent.LoadSession(id); err == nil {
+			t.Errorf("session %s still loadable after batch delete", id)
+		}
+	}
+}
+
+func TestHandleDeleteSessions_EmptyIDs(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/delete", bytes.NewReader([]byte(`{"ids":[]}`)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
 func TestHandleCreateChat_MissingMessage(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 

--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -82,6 +82,8 @@ h1{color:#333}code{background:#f4f4f4;padding:2px 6px;border-radius:3px}
 <li><code>POST /api/chat/:id/turn</code> — send a message to an existing session</li>
 <li><code>GET  /api/sessions</code> — list recent sessions</li>
 <li><code>GET  /api/sessions/:id</code> — get session details</li>
+<li><code>DELETE /api/sessions/:id</code> — delete one session</li>
+<li><code>POST /api/sessions/delete</code> — delete sessions in bulk (body: {ids:[…]})</li>
 <li><code>GET  /api/tools</code> — list available tools</li>
 <li><code>GET  /api/skills</code> — list available skills</li>
 <li><code>GET  /api/health</code> — health check</li>

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -92,11 +92,75 @@ html, body {
   margin-bottom: 4px;
   font-size: 13px;
   transition: background 0.15s;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
 }
 
 .session-item:hover {
   background: rgba(88, 166, 255, 0.1);
 }
+
+/* The text column grows; checkbox / delete button sit on the sides. */
+.session-item .sess-body { flex: 1; min-width: 0; }
+
+.session-item .sess-check {
+  margin-top: 2px;
+  flex: 0 0 auto;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+/* Per-item delete button: hidden until the row is hovered. */
+.session-item .sess-del {
+  flex: 0 0 auto;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.session-item:hover .sess-del { opacity: 1; }
+
+.session-item .sess-del:hover { color: var(--error); }
+
+/* Selection toolbar (shown only in select mode). */
+.select-bar {
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  align-items: center;
+}
+
+.select-bar button {
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.select-bar button.danger {
+  border-color: var(--error);
+  color: var(--error);
+}
+
+.select-bar button.danger:disabled {
+  border-color: var(--border);
+  color: var(--text-secondary);
+  cursor: not-allowed;
+}
+
+.select-bar .spacer { flex: 1; }
 
 .session-item.active {
   background: rgba(88, 166, 255, 0.15);
@@ -407,7 +471,16 @@ html, body {
   <div class="sidebar">
     <div class="sidebar-header">
       <h2>🐙 Octo</h2>
-      <button class="new-btn" id="newSessionBtn">+ New</button>
+      <div style="display:flex;gap:6px">
+        <button class="new-btn" id="selectBtn">Select</button>
+        <button class="new-btn" id="newSessionBtn">+ New</button>
+      </div>
+    </div>
+    <div class="select-bar" id="selectBar" style="display:none">
+      <button id="selectAllBtn">All</button>
+      <span class="spacer"></span>
+      <button class="danger" id="deleteSelectedBtn" disabled>Delete</button>
+      <button id="cancelSelectBtn">Cancel</button>
     </div>
     <div class="session-list" id="sessionList"></div>
   </div>
@@ -435,10 +508,19 @@ const status = document.getElementById('status');
 const sessionInfo = document.getElementById('sessionInfo');
 const sessionList = document.getElementById('sessionList');
 const newSessionBtn = document.getElementById('newSessionBtn');
+const selectBtn = document.getElementById('selectBtn');
+const selectBar = document.getElementById('selectBar');
+const selectAllBtn = document.getElementById('selectAllBtn');
+const deleteSelectedBtn = document.getElementById('deleteSelectedBtn');
+const cancelSelectBtn = document.getElementById('cancelSelectBtn');
 
 let sessionId = null;
 let isTyping = false;
 let sessions = [];
+
+// Selection mode: when on, the list shows checkboxes and a delete toolbar.
+let selectMode = false;
+const selectedIds = new Set();
 
 // Auto-resize textarea
 function resetInputHeight() {
@@ -458,6 +540,61 @@ input.addEventListener('keydown', (e) => {
 
 sendBtn.addEventListener('click', sendMessage);
 newSessionBtn.addEventListener('click', startNewSession);
+selectBtn.addEventListener('click', () => setSelectMode(!selectMode));
+cancelSelectBtn.addEventListener('click', () => setSelectMode(false));
+selectAllBtn.addEventListener('click', toggleSelectAll);
+deleteSelectedBtn.addEventListener('click', deleteSelected);
+
+function setSelectMode(on) {
+  selectMode = on;
+  selectedIds.clear();
+  selectBar.style.display = on ? 'flex' : 'none';
+  selectBtn.textContent = on ? 'Done' : 'Select';
+  renderSessionList();
+  updateDeleteButton();
+}
+
+function updateDeleteButton() {
+  deleteSelectedBtn.disabled = selectedIds.size === 0;
+  deleteSelectedBtn.textContent = selectedIds.size ? `Delete (${selectedIds.size})` : 'Delete';
+}
+
+function toggleSelectAll() {
+  if (selectedIds.size === sessions.length) {
+    selectedIds.clear();
+  } else {
+    sessions.forEach(s => selectedIds.add(s.id));
+  }
+  renderSessionList();
+  updateDeleteButton();
+}
+
+// deleteSessions calls the batch endpoint, then refreshes the list. If the
+// currently open session was among those removed, the view resets to the
+// new-session welcome screen.
+async function deleteSessions(ids) {
+  if (!ids.length) return;
+  try {
+    const res = await fetch('/api/sessions/delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids })
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (ids.includes(sessionId)) startNewSession();
+    await loadSessions();
+  } catch (err) {
+    setStatus('Error deleting session', true);
+  }
+}
+
+async function deleteSelected() {
+  const ids = [...selectedIds];
+  if (!ids.length) return;
+  if (!confirm(`Delete ${ids.length} session${ids.length > 1 ? 's' : ''}? This cannot be undone.`)) return;
+  await deleteSessions(ids);
+  setSelectMode(false);
+}
 
 function setStatus(text, isError = false) {
   status.textContent = text;
@@ -592,6 +729,22 @@ function renderSessionList() {
   sessions.forEach(s => {
     const div = document.createElement('div');
     div.className = 'session-item' + (s.id === sessionId ? ' active' : '');
+
+    if (selectMode) {
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.className = 'sess-check';
+      cb.checked = selectedIds.has(s.id);
+      cb.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (cb.checked) selectedIds.add(s.id); else selectedIds.delete(s.id);
+        updateDeleteButton();
+      });
+      div.appendChild(cb);
+    }
+
+    const body = document.createElement('div');
+    body.className = 'sess-body';
     const title = s.title || s.id.slice(0, 8);
     const idEl = document.createElement('div');
     idEl.className = 'sess-id';
@@ -599,9 +752,33 @@ function renderSessionList() {
     const dateEl = document.createElement('div');
     dateEl.className = 'sess-date';
     dateEl.textContent = new Date(s.created_at).toLocaleString();
-    div.appendChild(idEl);
-    div.appendChild(dateEl);
-    div.addEventListener('click', () => switchSession(s.id));
+    body.appendChild(idEl);
+    body.appendChild(dateEl);
+    div.appendChild(body);
+
+    if (!selectMode) {
+      const del = document.createElement('button');
+      del.className = 'sess-del';
+      del.textContent = '✕';
+      del.title = 'Delete session';
+      del.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        if (!confirm('Delete this session? This cannot be undone.')) return;
+        await deleteSessions([s.id]);
+      });
+      div.appendChild(del);
+    }
+
+    // In select mode the whole row toggles the checkbox; otherwise it opens.
+    div.addEventListener('click', () => {
+      if (selectMode) {
+        if (selectedIds.has(s.id)) selectedIds.delete(s.id); else selectedIds.add(s.id);
+        renderSessionList();
+        updateDeleteButton();
+      } else {
+        switchSession(s.id);
+      }
+    });
     sessionList.appendChild(div);
   });
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "0.12.1"
+var Version = "0.13.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## What

Adds session deletion to the Web UI and REST API (single + batch), and bumps the release to **v0.13.0**.

## Changes

**Agent**
- `agent.DeleteSession(id)` — removes `~/.octo/sessions/<id>.jsonl`. Idempotent (missing file = success). Rejects absolute paths, path separators, and `..` so a caller-supplied id can't reach outside the sessions directory.

**Server**
- `DELETE /api/sessions/{id}` — single delete.
- `POST /api/sessions/delete` with `{"ids":[...]}` — batch; reports partial failures (`{deleted:[...], failed:{id:reason}}`) instead of aborting.
- Both call `forgetTurnLock(id)` so the per-session mutex map doesn't accumulate locks for deleted sessions.
- `DELETE` added to CORS allowed methods. The batch route is registered before the `{id}` wildcard so `/delete` isn't swallowed.

**Web UI** (`static/index.html`)
- Hover **✕** on a row for a quick single delete (with confirm).
- **Select** mode: per-row checkboxes, **All** toggle, **Delete (n)** button (with confirm).
- Deleting the currently-open session resets the view to the welcome screen.

**Release**
- `internal/version/version.go`: `0.12.1 → 0.13.0` (minor — new user-facing feature).
- README capability row + docs landing card note session browse/delete.

## Tests

- agent: `TestDeleteSession`, `TestDeleteSession_RejectsTraversal`.
- server: `TestHandleDeleteSession`, `TestHandleDeleteSessions_Batch`, `TestHandleDeleteSessions_EmptyIDs`.
- `make fmt-check`, `make vet`, `make test` (race) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)