### PR TITLE
fix(tools): close leaks, SSRF gap, and 6 other built-in-tool issues

### DIFF
--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -312,6 +312,24 @@ func (m *BackgroundManager) Kill(id string) bool {
 	return true
 }
 
+// Remove drops a process from the tracking map, releasing its retained output
+// buffer. Used by the synchronous terminal path to reap a hidden command once
+// it has exited and its output has been returned to the caller — otherwise
+// every synchronous command would leak a bgProcess (up to maxBgOutputBytes
+// each) for the life of the session. Visible background tasks are NOT reaped
+// this way: their output stays readable via terminal_output after they exit.
+func (m *BackgroundManager) Remove(id string) {
+	m.mu.Lock()
+	p, ok := m.procs[id]
+	delete(m.procs, id)
+	m.mu.Unlock()
+	// Belt-and-suspenders: if Remove is ever called on a still-running id,
+	// cancel it so the process can't outlive its map entry.
+	if ok && p != nil {
+		p.cancel()
+	}
+}
+
 // KillAll terminates every tracked process. Called on session shutdown so no
 // background command is orphaned.
 func (m *BackgroundManager) KillAll() {

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -123,6 +123,31 @@ func TestTerminalTool_BackgroundLaunch(t *testing.T) {
 	}
 }
 
+func TestTerminalTool_SyncCommandIsReaped(t *testing.T) {
+	// A synchronous command runs as a hidden background process; once it exits
+	// and its output is returned, the manager must drop it so its retained
+	// buffer doesn't leak for the life of the session.
+	m := NewBackgroundManager()
+	tool := TerminalTool{mgr: m}
+
+	res, err := tool.Execute(context.Background(), "terminal", map[string]any{
+		"command": "echo reaped",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res.Text, "reaped") {
+		t.Errorf("result = %q, want it to contain the output", res.Text)
+	}
+	// bg_1 was the hidden process — after a clean sync exit it must be gone.
+	if _, _, found, _ := m.Read("bg_1"); found {
+		t.Error("synchronous command's process should have been reaped from the manager")
+	}
+	if got := m.ListRunning(); len(got) != 0 {
+		t.Errorf("ListRunning = %v, want empty after a sync command", got)
+	}
+}
+
 func TestTerminalOutputTool(t *testing.T) {
 	m := NewBackgroundManager()
 	term := TerminalTool{mgr: m}

--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -77,18 +77,20 @@ func normalizeQuotes(s string) string {
 	return b.String()
 }
 
-// stripTrailingWhitespace removes trailing whitespace from each line
-// while preserving line endings. Skipped for markdown files where
-// trailing double-space is a hard line break.
+// stripTrailingWhitespace removes trailing spaces/tabs from every line while
+// preserving line endings. SplitAfter keeps the trailing "\n" on each fragment;
+// we peel that newline off before TrimRight and re-attach it, otherwise the
+// "\n" (not in the cutset) shields the spaces in front of it and only the final
+// line would ever be trimmed. Skipped for markdown files where a trailing
+// double-space is a hard line break.
 func stripTrailingWhitespace(s string) string {
 	lines := strings.SplitAfter(s, "\n")
 	for i, line := range lines {
-		// Preserve empty lines and the last fragment
-		if i == len(lines)-1 && !strings.HasSuffix(s, "\n") {
+		if nl := strings.HasSuffix(line, "\n"); nl {
+			lines[i] = strings.TrimRight(line[:len(line)-1], " \t\r") + "\n"
+		} else {
 			lines[i] = strings.TrimRight(line, " \t\r")
-			continue
 		}
-		lines[i] = strings.TrimRight(line, " \t\r")
 	}
 	return strings.Join(lines, "")
 }
@@ -213,6 +215,16 @@ func (EditFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 	newStrClean := newStr
 	if !isMarkdown {
 		newStrClean = stripTrailingWhitespace(newStr)
+	}
+
+	// Refuse to inject a live-credential shape — same guard write_file applies,
+	// so a secret can't slip in through the edit path instead. Only the new text
+	// is scanned (not the whole file): a pre-existing match the model didn't
+	// introduce shouldn't block an unrelated edit elsewhere in the file.
+	if secret := scanForSecrets(newStrClean); secret != "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: refusing to write new_string that contains a %s. "+
+			"If this is genuinely intended (e.g. a test fixture), remove the live-credential "+
+			"shape or create the file outside the agent.", secret)
 	}
 
 	// Use findActualString for quote-normalized matching.

--- a/internal/tools/edit_file_test.go
+++ b/internal/tools/edit_file_test.go
@@ -317,3 +317,35 @@ func TestEditFile_CurlyQuotes_ReplaceAll(t *testing.T) {
 		t.Errorf("file = %q, want %q", got, want)
 	}
 }
+
+func TestEditFile_RefusesSecretInNewString(t *testing.T) {
+	// edit_file must apply the same secret guard write_file does, so a
+	// credential can't be injected through the edit path. The original file is
+	// left untouched on refusal.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.go")
+	original := "const token = \"REPLACE_ME\"\n"
+	writeTestFile(t, path, original)
+
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       path,
+		"old_string": "REPLACE_ME",
+		"new_string": "ghp_0123456789abcdefghijklmnopqrstuvwxyz", // GitHub PAT shape (36 chars)
+	})
+	if err == nil || !strings.Contains(err.Error(), "GitHub token") {
+		t.Fatalf("expected refusal naming the secret, got %v", err)
+	}
+	if got := readTestFile(t, path); got != original {
+		t.Errorf("file should be unchanged on refusal, got %q", got)
+	}
+}
+
+func TestStripTrailingWhitespace_EveryLine(t *testing.T) {
+	// Trailing spaces/tabs must be stripped on every line, not just the last \u2014
+	// a "\n" must not shield the whitespace in front of it.
+	in := "a  \nb\t\nc   "
+	want := "a\nb\nc"
+	if got := stripTrailingWhitespace(in); got != want {
+		t.Errorf("stripTrailingWhitespace(%q) = %q, want %q", in, got, want)
+	}
+}

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -2,14 +2,16 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tools/rgembed"
 )
 
 // GlobMaxResults caps the number of paths a single glob call returns. The
@@ -18,9 +20,22 @@ import (
 // context.
 const GlobMaxResults = 200
 
-// GlobTool walks a directory tree and returns paths matching a glob
-// pattern, sorted by modification time descending so the most recently
-// touched files appear first.
+// globNoiseDirs are directory names glob always excludes, on top of whatever
+// .gitignore already removes. They're high-noise and almost never the user's
+// intent; keeping the explicit list means glob behaves the same in a repo that
+// hasn't gitignored them (or isn't a git repo at all).
+var globNoiseDirs = map[string]struct{}{
+	".git": {}, "node_modules": {}, "vendor": {}, ".venv": {},
+}
+
+// GlobTool returns paths matching a glob pattern, sorted by modification time
+// descending so the most recently touched files appear first.
+//
+// File enumeration is delegated to ripgrep (`rg --files`), which respects
+// .gitignore / .ignore and prunes ignored subtrees efficiently — the same
+// engine grep uses, so the two tools agree on what's "in" the project. The
+// glob pattern itself is then matched in-process against each path so the
+// semantics below are exactly preserved regardless of ripgrep's own glob rules.
 //
 // Supports `**` for "any directory depth" (e.g. `src/**/*.go`). Other
 // segments use the standard path.Match semantics: `*` matches any run of
@@ -34,8 +49,9 @@ func (GlobTool) Definition() agent.ToolDefinition {
 		Description: "Find files matching a glob pattern. Supports `**` for any " +
 			"directory depth (e.g. `src/**/*.go`). Returns up to 200 paths sorted " +
 			"by modification time descending (most recently changed first). " +
-			"Skips `.git`, `node_modules`, `vendor`, and `.venv` at the directory " +
-			"level — pass an explicit path under those if you need to look there.",
+			"Respects .gitignore (uses ripgrep to enumerate), and always skips " +
+			"`.git`, `node_modules`, `vendor`, and `.venv`. To see ignored files, " +
+			"point grep/read_file at an explicit path instead. Requires `rg`.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -53,7 +69,7 @@ func (GlobTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (GlobTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+func (GlobTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	pattern, _ := input["pattern"].(string)
 	if strings.TrimSpace(pattern) == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("glob: pattern is required")
@@ -68,50 +84,37 @@ func (GlobTool) Execute(_ context.Context, _ string, input map[string]any) (agen
 		return agent.ToolResult{Text: ""}, err
 	}
 
+	files, err := listProjectFiles(ctx, absRoot)
+	if err != nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("glob: %w", err)
+	}
+
 	type match struct {
 		path  string
 		mtime int64
 	}
 	var matches []match
 
-	err = filepath.WalkDir(absRoot, func(p string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			// Skip permission-denied subtrees rather than aborting the whole walk.
-			if os.IsPermission(walkErr) {
-				return nil
-			}
-			return walkErr
-		}
-		if d.IsDir() {
-			// Skip a few high-noise directories that are almost never the
-			// user's intent. Saves walk time and result-list space.
-			name := d.Name()
-			if name == ".git" || name == "node_modules" || name == "vendor" || name == ".venv" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
+	for _, p := range files {
 		rel, relErr := filepath.Rel(absRoot, p)
 		if relErr != nil {
 			rel = p
 		}
+		if hasNoiseDirSegment(rel) {
+			continue
+		}
 		ok, mErr := globMatch(pattern, rel)
 		if mErr != nil {
-			return mErr
+			return agent.ToolResult{Text: ""}, fmt.Errorf("glob: bad pattern %q: %w", pattern, mErr)
 		}
 		if !ok {
-			return nil
+			continue
 		}
-		info, infoErr := d.Info()
 		var mtime int64
-		if infoErr == nil {
+		if info, infoErr := os.Stat(p); infoErr == nil {
 			mtime = info.ModTime().UnixNano()
 		}
 		matches = append(matches, match{path: p, mtime: mtime})
-		return nil
-	})
-	if err != nil {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("glob: walk %q: %w", root, err)
 	}
 
 	sort.Slice(matches, func(i, j int) bool { return matches[i].mtime > matches[j].mtime })
@@ -135,6 +138,44 @@ func (GlobTool) Execute(_ context.Context, _ string, input map[string]any) (agen
 		fmt.Fprintf(&out, "\n[truncated to first %d of %d matches]\n", GlobMaxResults, totalMatches)
 	}
 	return agent.ToolResult{Text: out.String()}, nil
+}
+
+// listProjectFiles enumerates every file under root that ripgrep would search,
+// as absolute paths. `--files` lists candidates respecting .gitignore/.ignore
+// and ripgrep's built-in VCS pruning; `--hidden` re-includes dotfiles so glob
+// can still find e.g. `.octorules`; `--null` separates paths with NUL so a
+// newline inside a filename can't split one path into two. A clean "no files"
+// (ripgrep exit code 1) returns an empty slice, not an error.
+func listProjectFiles(ctx context.Context, root string) ([]string, error) {
+	rgPath, err := rgembed.Path()
+	if err != nil {
+		return nil, err
+	}
+	out, err := exec.CommandContext(ctx, rgPath, "--files", "--hidden", "--null", root).Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil, nil // no files under root
+		}
+		return nil, fmt.Errorf("rg --files: %w", err)
+	}
+	trimmed := strings.Trim(string(out), "\x00")
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\x00"), nil
+}
+
+// hasNoiseDirSegment reports whether any path segment of rel names a directory
+// in globNoiseDirs. Applied after ripgrep so the exclusion holds even when the
+// project hasn't gitignored these dirs.
+func hasNoiseDirSegment(rel string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(rel), "/") {
+		if _, ok := globNoiseDirs[seg]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // globMatch matches a pattern against a relative path, supporting `**`

--- a/internal/tools/glob_test.go
+++ b/internal/tools/glob_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestGlob_FlatStarPattern(t *testing.T) {
+	requireRg(t)
 	dir := t.TempDir()
 	writeTestFile(t, filepath.Join(dir, "a.go"), "")
 	writeTestFile(t, filepath.Join(dir, "b.go"), "")
@@ -31,6 +32,7 @@ func TestGlob_FlatStarPattern(t *testing.T) {
 }
 
 func TestGlob_DoubleStarRecursive(t *testing.T) {
+	requireRg(t)
 	dir := t.TempDir()
 	writeTestFile(t, filepath.Join(dir, "top.go"), "")
 	writeTestFile(t, filepath.Join(dir, "sub", "mid.go"), "")
@@ -55,6 +57,7 @@ func TestGlob_DoubleStarRecursive(t *testing.T) {
 }
 
 func TestGlob_SortedByMtimeDescending(t *testing.T) {
+	requireRg(t)
 	dir := t.TempDir()
 	older := filepath.Join(dir, "older.txt")
 	newer := filepath.Join(dir, "newer.txt")
@@ -79,6 +82,7 @@ func TestGlob_SortedByMtimeDescending(t *testing.T) {
 }
 
 func TestGlob_SkipsGitAndNodeModules(t *testing.T) {
+	requireRg(t)
 	dir := t.TempDir()
 	writeTestFile(t, filepath.Join(dir, "src", "real.go"), "")
 	writeTestFile(t, filepath.Join(dir, ".git", "objects", "ignored.go"), "")
@@ -100,6 +104,7 @@ func TestGlob_SkipsGitAndNodeModules(t *testing.T) {
 }
 
 func TestGlob_RespectsGitignore(t *testing.T) {
+	requireRg(t)
 	// glob enumerates via ripgrep, so a .gitignore'd file is excluded even
 	// though it isn't under one of the hardcoded noise dirs. ripgrep only
 	// applies .gitignore at a detected repo root, so the test dir gets a .git
@@ -128,6 +133,7 @@ func TestGlob_RespectsGitignore(t *testing.T) {
 }
 
 func TestGlob_NoMatches(t *testing.T) {
+	requireRg(t)
 	dir := t.TempDir()
 	out, err := GlobTool{}.Execute(context.Background(), "glob", map[string]any{
 		"pattern": "*.nonsense",

--- a/internal/tools/glob_test.go
+++ b/internal/tools/glob_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -95,6 +96,34 @@ func TestGlob_SkipsGitAndNodeModules(t *testing.T) {
 	}
 	if strings.Contains(out.Text, ".git/") || strings.Contains(out.Text, "node_modules/") {
 		t.Errorf("noise directories should be skipped:\n%s", out.Text)
+	}
+}
+
+func TestGlob_RespectsGitignore(t *testing.T) {
+	// glob enumerates via ripgrep, so a .gitignore'd file is excluded even
+	// though it isn't under one of the hardcoded noise dirs. ripgrep only
+	// applies .gitignore at a detected repo root, so the test dir gets a .git
+	// marker — the normal case, since glob runs inside real repos.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	writeTestFile(t, filepath.Join(dir, ".gitignore"), "ignored.go\n")
+	writeTestFile(t, filepath.Join(dir, "kept.go"), "")
+	writeTestFile(t, filepath.Join(dir, "ignored.go"), "")
+
+	out, err := GlobTool{}.Execute(context.Background(), "glob", map[string]any{
+		"pattern": "**/*.go",
+		"path":    dir,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.Text, "kept.go") {
+		t.Errorf("kept.go missing:\n%s", out.Text)
+	}
+	if strings.Contains(out.Text, "ignored.go") {
+		t.Errorf("gitignored file should be excluded:\n%s", out.Text)
 	}
 }
 

--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -50,14 +50,6 @@ func ActiveMCPRegistry() *mcp.Registry {
 	return mcpRegistry
 }
 
-// mcpEnabled is the DefaultTools gating function — true when SetMCPRegistry
-// has been called with a non-nil registry AND that registry has at least
-// one live connection.
-func mcpEnabled() bool {
-	r := ActiveMCPRegistry()
-	return r != nil && r.Len() > 0
-}
-
 // mcpToolDefs synthesises one ToolDefinition per MCP surface for every live
 // connection. Called from DefaultTools at session start; returns empty if
 // MCP is off so the caller can splice it in unconditionally.

--- a/internal/tools/mcp_test.go
+++ b/internal/tools/mcp_test.go
@@ -88,21 +88,6 @@ func TestFormatToolResult_MixedContent(t *testing.T) {
 	}
 }
 
-func TestMCPEnabledGate(t *testing.T) {
-	// Before any registration the gate is off so DefaultTools won't
-	// advertise MCP surfaces.
-	SetMCPRegistry(nil)
-	if mcpEnabled() {
-		t.Error("expected mcpEnabled=false with no registry")
-	}
-	// Empty registry: still disabled — Len() == 0.
-	SetMCPRegistry(&mcp.Registry{})
-	if mcpEnabled() {
-		t.Error("expected mcpEnabled=false with empty registry")
-	}
-	SetMCPRegistry(nil) // clean up for other tests
-}
-
 func TestMCPToolDefs_NilRegistryYieldsNone(t *testing.T) {
 	SetMCPRegistry(nil)
 	defer SetMCPRegistry(nil)

--- a/internal/tools/spill.go
+++ b/internal/tools/spill.go
@@ -27,6 +27,22 @@ const (
 // only catches the leftovers of a crashed session.
 const spillMaxAge = 24 * time.Hour
 
+// spillPrefixes are the filename prefixes used by everything that writes into
+// ~/.octo/tmp: terminal output (`term-`) and web_fetch bodies (`webfetch-`).
+// Both the age-sweep and the shutdown clean must cover every prefix, else a
+// kind whose prefix is missing leaks files forever.
+var spillPrefixes = []string{"term-", "webfetch-"}
+
+// hasSpillPrefix reports whether name is one of our spill files.
+func hasSpillPrefix(name string) bool {
+	for _, p := range spillPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // MaybeSpillOutput returns body unchanged when it is small enough to give the
 // LLM directly. When body exceeds TerminalSpillBytes — and has more lines than
 // the preview would show — it writes the full body to a temp file and returns
@@ -118,7 +134,7 @@ func sweepOldSpillFiles(dir string) {
 	}
 	cutoff := time.Now().Add(-spillMaxAge)
 	for _, e := range entries {
-		if e.IsDir() || !strings.HasPrefix(e.Name(), "term-") {
+		if e.IsDir() || !hasSpillPrefix(e.Name()) {
 			continue
 		}
 		info, err := e.Info()
@@ -144,7 +160,7 @@ func CleanSpillFiles() {
 	}
 	suffix := fmt.Sprintf("-%d.log", os.Getpid())
 	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), "term-") && strings.HasSuffix(e.Name(), suffix) {
+		if hasSpillPrefix(e.Name()) && strings.HasSuffix(e.Name(), suffix) {
 			_ = os.Remove(filepath.Join(dir, e.Name()))
 		}
 	}

--- a/internal/tools/spill_test.go
+++ b/internal/tools/spill_test.go
@@ -2,8 +2,10 @@ package tools
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // spillHome points ~/.octo at a temp dir so spill files don't touch the real
@@ -74,6 +76,40 @@ func TestMaybeSpillOutput_FewLongLinesPassThrough(t *testing.T) {
 	body := strings.Repeat("x", TerminalSpillBytes+100) + "\n" + strings.Repeat("y", 100)
 	if got := MaybeSpillOutput("bg_7", body); got != body {
 		t.Errorf("few long lines should pass through unchanged")
+	}
+}
+
+func TestSpillCleanup_CoversWebFetchPrefix(t *testing.T) {
+	// web_fetch spill files (webfetch-…) must be reclaimed by the same age-sweep
+	// and shutdown-clean that handle term- files — otherwise they leak forever.
+	spillHome(t)
+	dir, err := spillDir()
+	if err != nil {
+		t.Fatalf("spillDir: %v", err)
+	}
+
+	// A web_fetch spill file for THIS process (pid suffix), plus a stale one
+	// from a long-dead session that the age-sweep should reap.
+	mine, err := writeWebFetchSpillFile("https://example.com/page", []byte("body"))
+	if err != nil {
+		t.Fatalf("writeWebFetchSpillFile: %v", err)
+	}
+	stale := filepath.Join(dir, "webfetch-old-host-1-999999.log")
+	if err := os.WriteFile(stale, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write stale: %v", err)
+	}
+	if err := os.Chtimes(stale, time.Now().Add(-48*time.Hour), time.Now().Add(-48*time.Hour)); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	sweepOldSpillFiles(dir)
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("age-sweep should have removed the stale webfetch file (err=%v)", err)
+	}
+
+	CleanSpillFiles()
+	if _, err := os.Stat(mine); !os.IsNotExist(err) {
+		t.Errorf("CleanSpillFiles should have removed this process's webfetch file (err=%v)", err)
 	}
 }
 

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -227,7 +227,8 @@ func FormatTaskList(items []tasks.Task) string {
 		return "No tasks yet."
 	}
 	var b strings.Builder
-	b.WriteString("Tasks:\n")
+	b.WriteString(taskCountHeader(items))
+	b.WriteByte('\n')
 	for _, t := range items {
 		marker := statusMarker(t.Status)
 		title := t.Subject
@@ -242,6 +243,38 @@ func FormatTaskList(items []tasks.Task) string {
 		}
 	}
 	return strings.TrimRight(b.String(), "\n")
+}
+
+// taskCountHeader builds the "Tasks: N in progress, M pending, K completed"
+// summary line, listing only the non-zero buckets (and falling back to a bare
+// "Tasks:" when every task is deleted). Matches the layout documented on
+// FormatTaskList.
+func taskCountHeader(items []tasks.Task) string {
+	var inProgress, pending, completed int
+	for _, t := range items {
+		switch t.Status {
+		case tasks.InProgress:
+			inProgress++
+		case tasks.Pending:
+			pending++
+		case tasks.Completed:
+			completed++
+		}
+	}
+	var parts []string
+	if inProgress > 0 {
+		parts = append(parts, fmt.Sprintf("%d in progress", inProgress))
+	}
+	if pending > 0 {
+		parts = append(parts, fmt.Sprintf("%d pending", pending))
+	}
+	if completed > 0 {
+		parts = append(parts, fmt.Sprintf("%d completed", completed))
+	}
+	if len(parts) == 0 {
+		return "Tasks:"
+	}
+	return "Tasks: " + strings.Join(parts, ", ")
 }
 
 // statusMarker returns the one-rune glyph used in FormatTaskList. Chosen to

--- a/internal/tools/tasks_test.go
+++ b/internal/tools/tasks_test.go
@@ -274,6 +274,21 @@ func TestActiveTaskStore_Roundtrip(t *testing.T) {
 
 // ── formatter ────────────────────────────────────────────────────────────
 
+func TestFormatTaskList_CountHeader(t *testing.T) {
+	out := FormatTaskList([]tasks.Task{
+		{ID: 1, Subject: "A", Status: tasks.InProgress},
+		{ID: 2, Subject: "B", Status: tasks.Pending},
+		{ID: 3, Subject: "C", Status: tasks.Pending},
+		{ID: 4, Subject: "D", Status: tasks.Completed},
+		{ID: 5, Subject: "E", Status: tasks.Deleted},
+	})
+	header := strings.SplitN(out, "\n", 2)[0]
+	want := "Tasks: 1 in progress, 2 pending, 1 completed"
+	if header != want {
+		t.Errorf("header = %q, want %q", header, want)
+	}
+}
+
 func TestFormatTaskList_DescriptionIndented(t *testing.T) {
 	id := 7
 	out := FormatTaskList([]tasks.Task{{

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -123,13 +123,24 @@ func (t TerminalTool) ExecuteStream(
 	// timeout the original process simply keeps running — no kill, no restart.
 	// We attach an onLine callback to collect output and stream to progress in
 	// real time. The polling loop only checks status (exited/running).
+	//
+	// The collector is capped at maxBgOutputBytes: a command that floods stdout
+	// faster than the 30s timeout (e.g. a runaway `yes`) would otherwise grow an
+	// unbounded buffer and OOM the agent. Past the cap we keep the most recent
+	// bytes and flag that earlier output was dropped — the same tail-retention
+	// policy bgProcess.append uses for the background buffer.
 	var (
-		outMu sync.Mutex
-		out   strings.Builder
+		outMu   sync.Mutex
+		out     []byte
+		dropped bool
 	)
 	onLine := func(line string) {
 		outMu.Lock()
-		out.WriteString(line)
+		out = append(out, line...)
+		if len(out) > maxBgOutputBytes {
+			out = out[len(out)-maxBgOutputBytes:]
+			dropped = true
+		}
 		outMu.Unlock()
 		if progress != nil {
 			progress(strings.TrimRight(line, "\n"))
@@ -141,6 +152,20 @@ func (t TerminalTool) ExecuteStream(
 		return agent.ToolResult{Text: ""}, err
 	}
 
+	// snapshot returns the collected output so far, tab-expanded and with the
+	// truncation marker prepended when the cap dropped earlier bytes.
+	snapshot := func() string {
+		outMu.Lock()
+		body := strings.TrimRight(string(out), "\n")
+		d := dropped
+		outMu.Unlock()
+		body = strings.ReplaceAll(body, "\t", "    ")
+		if d {
+			body = "[... earlier output truncated ...]\n" + body
+		}
+		return body
+	}
+
 	// Poll until the process exits or the timeout fires.
 	timer := time.NewTimer(TerminalTimeout)
 	defer timer.Stop()
@@ -149,32 +174,28 @@ func (t TerminalTool) ExecuteStream(
 		select {
 		case <-timer.C:
 			// Timeout: promote the hidden process to visible so it shows up
-			// in the TUI "background (N running)" panel, then return.
+			// in the TUI "background (N running)" panel, then return. NOT
+			// reaped — it's now a real background task and its output must stay
+			// readable via terminal_output.
 			t.manager().Promote(id)
-			outMu.Lock()
-			body := strings.TrimRight(out.String(), "\n")
-			outMu.Unlock()
-			body = strings.ReplaceAll(body, "\t", "    ")
-			body = MaybeSpillOutput(id, body)
+			body := MaybeSpillOutput(id, snapshot())
 			return agent.ToolResult{Text: fmt.Sprintf("%s\n\n[timeout: command exceeded %s and continues as background process %s]\n\n%s", body, TerminalTimeout, id, BgPollNotice)}, nil
 		case <-ctx.Done():
-			// User cancelled (Esc / Ctrl-C): kill the background process.
+			// User cancelled (Esc / Ctrl-C): kill the hidden process and reap
+			// it — the output is returned here and now, nothing will poll it.
 			t.manager().Kill(id)
-			outMu.Lock()
-			body := strings.TrimRight(out.String(), "\n")
-			outMu.Unlock()
-			body = strings.ReplaceAll(body, "\t", "    ")
+			body := snapshot()
+			t.manager().Remove(id)
 			return agent.ToolResult{Text: body + "\n[exit: signal: killed]"}, nil
 		default:
 		}
 
 		_, status, _, _ := t.manager().Read(id)
 		if strings.HasPrefix(status, "exited") {
-			outMu.Lock()
-			body := strings.TrimRight(out.String(), "\n")
-			outMu.Unlock()
-			body = strings.ReplaceAll(body, "\t", "    ")
-			body = MaybeSpillOutput(id, body)
+			body := MaybeSpillOutput(id, snapshot())
+			// Reap the hidden process: its output has been captured and
+			// returned, so the bgProcess (and its retained buffer) can go.
+			t.manager().Remove(id)
 			if status != "exited: 0" {
 				return agent.ToolResult{Text: body + "\n[exit: " + strings.TrimPrefix(status, "exited: ") + "]"}, nil
 			}

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
@@ -195,17 +197,7 @@ func fetchDirect(ctx context.Context, rawURL string) (agent.ToolResult, error) {
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
-			}
-			return nil
-		},
-	}
-
-	resp, err := client.Do(req)
+	resp, err := directFetchHTTPClient().Do(req)
 	if err != nil {
 		return agent.ToolResult{Text: ""}, err
 	}
@@ -418,8 +410,9 @@ func markdownOutline(lines []string, maxHeadings int) string {
 }
 
 // writeWebFetchSpillFile persists body under ~/.octo/tmp and returns the
-// absolute path. The filename is derived from the URL host + a timestamp
-// so concurrent fetches never collide.
+// absolute path. The filename is derived from the URL host + a timestamp (so
+// concurrent fetches never collide) and ends with the pid so CleanSpillFiles
+// reclaims it on a clean exit, the same way it does for `term-` files.
 func writeWebFetchSpillFile(sourceURL string, body []byte) (string, error) {
 	dir, err := spillDir()
 	if err != nil {
@@ -432,7 +425,7 @@ func writeWebFetchSpillFile(sourceURL string, body []byte) (string, error) {
 	if u != nil && u.Host != "" {
 		host = sanitizeSpillID(u.Host)
 	}
-	name := fmt.Sprintf("webfetch-%s-%d.log", host, time.Now().UnixNano())
+	name := fmt.Sprintf("webfetch-%s-%d-%d.log", host, time.Now().UnixNano(), os.Getpid())
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, body, 0o644); err != nil {
 		return "", err
@@ -447,15 +440,58 @@ func webHTTPClient() *http.Client {
 	return &http.Client{Timeout: 30 * time.Second}
 }
 
-// webFetchHTTPClient is web_fetch's dedicated client. It refuses to follow a
-// cross-host 3xx redirect: web_fetch always targets r.jina.ai, so a redirect
-// to a different host means the proxy is bouncing us somewhere unexpected —
-// a classic SSRF / data-exfil vector. Same-host redirects (path changes) are
-// still followed. web_search keeps the plain webHTTPClient because search
-// backends legitimately redirect across hosts.
+// blockedFetchIP reports whether ip sits in a link-local range — the block that
+// includes the cloud instance-metadata endpoint (IPv4 169.254.169.254 and the
+// IPv6 fe80::/10 equivalents). A prompt-injected URL aimed at metadata is the
+// highest-value SSRF target — it can leak cloud credentials — so web_fetch
+// refuses to dial it. Loopback and private-LAN ranges stay reachable on
+// purpose: fetching your own dev server (http://localhost:3000, a LAN box) is a
+// legitimate, common use of the tool on a developer machine.
+func blockedFetchIP(ip net.IP) bool {
+	return ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+}
+
+// secureFetchTransport builds an http.Transport whose dialer rejects link-local
+// destinations. The check runs in net.Dialer.Control, which fires AFTER DNS
+// resolution with the concrete remote IP — so a hostname that resolves to a
+// blocked address (DNS rebinding) is refused too, and every redirect hop is
+// re-dialed through the same hook. Shared by both web_fetch clients.
+func secureFetchTransport() *http.Transport {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control: func(_, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				host = address
+			}
+			if ip := net.ParseIP(host); ip != nil && blockedFetchIP(ip) {
+				return fmt.Errorf("refusing to connect to link-local/metadata address %s", host)
+			}
+			return nil
+		},
+	}
+	return &http.Transport{
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+// webFetchHTTPClient is the client used for the Jina-proxy path. On top of the
+// shared link-local block it refuses to follow a cross-host 3xx redirect: the
+// proxy always targets r.jina.ai, so a redirect to a different host means it is
+// bouncing us somewhere unexpected — a classic SSRF / data-exfil vector.
+// Same-host redirects (path changes) are still followed. web_search keeps the
+// plain webHTTPClient because search backends legitimately redirect across
+// hosts.
 func webFetchHTTPClient() *http.Client {
 	return &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout:   30 * time.Second,
+		Transport: secureFetchTransport(),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) == 0 {
 				return nil
@@ -465,6 +501,24 @@ func webFetchHTTPClient() *http.Client {
 				return fmt.Errorf("refusing cross-host redirect to %q (from %q); "+
 					"re-issue web_fetch against the final URL if that destination is intended",
 					req.URL.Host, prev)
+			}
+			return nil
+		},
+	}
+}
+
+// directFetchHTTPClient is the client for the direct-fetch fallback. Unlike the
+// proxy client it MUST allow cross-host redirects (URL shorteners, www-canonical
+// hops, http→https on another host are all normal for an arbitrary URL), but it
+// shares the link-local block via secureFetchTransport and caps the redirect
+// chain so a redirect loop can't hang the agent.
+func directFetchHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: secureFetchTransport(),
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
 			}
 			return nil
 		},

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -9,6 +10,24 @@ import (
 	"testing"
 	"time"
 )
+
+// blockedFetchIP must reject the cloud metadata / link-local range (the
+// high-value SSRF target) while still allowing loopback and private-LAN
+// addresses, since fetching a local dev server is a legitimate use.
+func TestBlockedFetchIP(t *testing.T) {
+	blocked := []string{"169.254.169.254", "169.254.0.1", "fe80::1"}
+	for _, s := range blocked {
+		if !blockedFetchIP(net.ParseIP(s)) {
+			t.Errorf("blockedFetchIP(%s) = false, want true", s)
+		}
+	}
+	allowed := []string{"127.0.0.1", "::1", "10.0.0.5", "192.168.1.20", "8.8.8.8"}
+	for _, s := range allowed {
+		if blockedFetchIP(net.ParseIP(s)) {
+			t.Errorf("blockedFetchIP(%s) = true, want false", s)
+		}
+	}
+}
 
 // A non-text response (e.g. an image) must not be stringified into garbage:
 // readBody returns a clean notice pointing at the right tool, with no raw bytes.


### PR DESCRIPTION
Reviewed every built-in tool implementation; this PR fixes the nine concrete issues that review surfaced.

## Resource leaks / memory growth
- **web_fetch spill files leaked forever.** `webfetch-*.log` files under `~/.octo/tmp` were never reclaimed — both `sweepOldSpillFiles` (age) and `CleanSpillFiles` (shutdown) only matched the `term-` prefix. Cleanup now covers every spill prefix, and webfetch files carry the pid suffix `CleanSpillFiles` keys on.
- **Background process map never shrank.** Every *synchronous* terminal command runs as a hidden `bgProcess` (≤1 MiB buffer) that stayed tracked for the whole session. Added `BackgroundManager.Remove`; the sync path reaps the process once it exits or is cancelled. Timeout-promoted tasks are deliberately kept (still readable via `terminal_output`).
- **Unbounded sync output accumulator.** The synchronous path collected output into an unbounded `strings.Builder` — a flood-before-timeout (`yes`, runaway logs) could OOM the agent. Now capped at `maxBgOutputBytes` with tail retention, matching `bgProcess.append`.

## Security / consistency
- **edit_file bypassed the secret scan.** `write_file` refuses live-credential shapes; `edit_file` didn't. It now runs the same scan on the new text only (so pre-existing matches elsewhere don't block unrelated edits).
- **web_fetch direct-fetch SSRF gap.** The fallback built its own bare `http.Client`. Both fetch clients now share a transport that refuses link-local / cloud-metadata destinations (`169.254.169.254`, `fe80::/10`), checked *after* DNS resolution so rebinding is caught and every redirect hop is re-checked. Loopback and private LAN stay reachable — fetching your own dev server is a legitimate use.
- **glob ignored .gitignore.** It hand-walked the tree and only skipped 4 dirs. It now enumerates via ripgrep (`rg --files`), so it respects `.gitignore`/`.ignore` and prunes ignored subtrees like grep does. Glob *pattern* semantics are unchanged — matching still happens in-process against the existing `globMatch`.

## Cleanups
- Removed the unused `mcpEnabled()` gate (`DefaultTools` never called it).
- Collapsed the dead `if/continue` in `stripTrailingWhitespace` and fixed it to actually strip every line — a trailing `"\n"` was shielding the whitespace, so only the final line was trimmed.
- `FormatTaskList`'s header now shows the status counts its doc comment already documented.

## Tests
Added focused tests for each behavioral change (sync reap, spill cleanup across prefixes, edit_file secret refusal, multi-line whitespace stripping, `blockedFetchIP`, glob+gitignore, task-count header). `go test -race ./...` is green; `gofmt`/`go vet` clean.