### PR TITLE
feat(tools): Tool Search for MCP (deferred schema loading)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -160,6 +160,25 @@ func resolveShowReasoning(flagSet, flagVal bool, cfg config.Config) bool {
 	return true
 }
 
+// toolSearchConfigFrom maps the persisted tools.tool_search block onto the
+// tools-package config. Unknown/empty "enabled" defaults to auto; numeric zero
+// values are left for SetToolSearchConfig to backfill with documented defaults.
+func toolSearchConfigFrom(c config.ToolSearchConfig) tools.ToolSearchConfig {
+	mode := tools.ToolSearchAuto
+	switch c.Enabled {
+	case "on":
+		mode = tools.ToolSearchOn
+	case "off":
+		mode = tools.ToolSearchOff
+	}
+	return tools.ToolSearchConfig{
+		Mode:           mode,
+		ThresholdPct:   c.ThresholdPct,
+		SearchLimit:    c.SearchDefaultLimit,
+		MaxSearchLimit: c.MaxSearchLimit,
+	}
+}
+
 // resolveReasoningEffort picks the reasoning intensity: --reasoning-effort flag
 // > config file > "" (off).
 func resolveReasoningEffort(flagVal string, cfg config.Config) string {
@@ -339,6 +358,10 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 2
 	}
 
+	// Install the Tool Search config so DefaultToolsFor can decide whether to
+	// defer MCP schemas behind the search/describe/call bridge for this model.
+	tools.SetToolSearchConfig(toolSearchConfigFrom(cfg.Tools.ToolSearch))
+
 	// Resolve reasoning controls: --reasoning-effort sets the intensity (OpenAI
 	// reasoning_effort / mapped Anthropic budget); --show-reasoning gates whether
 	// the trace is streamed to the terminal. Both fall back to `octo config`.
@@ -516,7 +539,11 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 	// Agentic setup — shared by both paths, which each run the full tool loop.
 	toolExecutor = tools.NewDefaultRegistry()
-	spawner := newAgentSpawner(a, toolExecutor, tools.DefaultTools)
+	// Sub-agents share the parent's model for the Tool Search threshold decision
+	// (a model override is rare and still resolves to a sane window).
+	spawner := newAgentSpawner(a, toolExecutor, func() []agent.ToolDefinition {
+		return tools.DefaultToolsFor(a.Model)
+	})
 	tools.SetSpawner(spawner)
 	subAgentMgr = tools.NewSubAgentManager(spawner)
 	if useTUI {
@@ -683,7 +710,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			// Built-ins only at first paint — the MCP registry is still nil
 			// (mcpBoot connects it in the background). mcpReadyMsg recomputes
 			// this list once the servers are live.
-			cfg.tools = tools.DefaultTools()
+			cfg.tools = tools.DefaultToolsFor(resolvedModel)
 			cfg.executor = toolExecutor
 			cfg.subAgentMgr = subAgentMgr
 		}
@@ -710,7 +737,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		permEngine: permEngine,
 	}
 	if toolsOn {
-		replCfg.tools = tools.DefaultTools()
+		replCfg.tools = tools.DefaultToolsFor(resolvedModel)
 		replCfg.executor = toolExecutor
 		replCfg.subAgentMgr = subAgentMgr
 	}

--- a/cmd/octo/permission_gate.go
+++ b/cmd/octo/permission_gate.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/Leihb/octo-agent/internal/permission"
+	"github.com/Leihb/octo-agent/internal/tools"
 )
 
 // cliPermissionGate adapts a permission.Engine into an agent.PermissionGate.
@@ -23,6 +24,12 @@ type cliPermissionGate struct {
 
 // Check implements agent.PermissionGate.
 func (g *cliPermissionGate) Check(ctx context.Context, name string, input map[string]any) (bool, string) {
+	// A Tool Search tool_call wraps the real MCP tool — evaluate policy and
+	// prompt against that real tool, not the "tool_call" bridge, so per-tool
+	// allow/deny rules and the approval prompt show the right name.
+	if real, realInput, ok := tools.ToolCallTarget(name, input); ok {
+		name, input = real, realInput
+	}
 	switch g.engine.Check(name, input) {
 	case permission.Allow:
 		return true, ""

--- a/cmd/octo/permission_gate_test.go
+++ b/cmd/octo/permission_gate_test.go
@@ -122,6 +122,23 @@ func TestCLIGate_AutoApproveModeNeverPrompts(t *testing.T) {
 	}
 }
 
+func TestCLIGate_UnwrapsToolCallToRealName(t *testing.T) {
+	// A Tool Search tool_call must be evaluated against the wrapped tool, not
+	// the opaque "tool_call" bridge: wrapping a dangerous terminal command must
+	// still be denied on the inner name.
+	g, _ := newGate(t, permission.ModeInteractive, "")
+	ok, reason := g.Check(context.Background(), "tool_call", map[string]any{
+		"name":      "terminal",
+		"arguments": map[string]any{"command": "rm -rf /"},
+	})
+	if ok {
+		t.Error("tool_call wrapping 'rm -rf /' must be denied via the unwrapped name")
+	}
+	if !strings.Contains(reason, "permission_denied") {
+		t.Errorf("expected denial reason, got %q", reason)
+	}
+}
+
 func TestResolvePermissionMode(t *testing.T) {
 	if resolvePermissionMode("strict") != permission.ModeStrict {
 		t.Error("strict should map to ModeStrict")

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -609,7 +609,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.reg != nil && msg.reg.Len() > 0 {
 			tools.SetMCPRegistry(msg.reg)
 			if m.cfg.executor != nil {
-				m.cfg.tools = tools.DefaultTools()
+				m.cfg.tools = tools.DefaultToolsFor(m.cfg.a.Model)
 			}
 			if !m.cfg.verbosity.quiet() {
 				m.println(noticeStyle.Render(fmt.Sprintf("● MCP ready — %d server(s) connected", msg.reg.Len())))

--- a/dev-docs/tool-search-mcp.md
+++ b/dev-docs/tool-search-mcp.md
@@ -1,0 +1,153 @@
+# Tool Search for MCP 设计
+
+> 用三个桥工具替换全量上传的 MCP 工具 schema,按需检索 / 加载 / 调用,削减每轮请求的 token 开销。
+
+---
+
+## 背景与问题
+
+每个连上的 MCP server 会把它的**每一个**工具的完整 JSON Schema 注入模型可见的 tools 列表,而这份列表每一轮请求都会重发。一两个工具多的 server(几十个工具各带参数 schema)就能占掉几万 token,且与对话内容无关。后果有两个:
+
+1. **成本**:schema 每轮重发,长会话里累计可观;在 anthropic 协议下还会撑大需要缓存的 tools 前缀。
+2. **准确率**:工具一多,模型在无关工具间"决策瘫痪",选错工具的概率上升。
+
+octo-agent 的工具装配链路:
+
+```
+tools.DefaultTools()  →  agent.Request.Tools  →  provider 序列化  →  wire
+```
+
+`tools.DefaultTools()`(`internal/tools/registry.go`)在末尾无条件 `append(mcpToolDefs()...)`;`mcpToolDefs()`(`internal/tools/mcp.go`)为每个 live connection 的每个工具合成完整 `agent.ToolDefinition`。Tool Search 在这条链路上做延迟加载。
+
+## 设计取舍:进程内桥,provider 无关
+
+octo-agent 同时支持 anthropic 协议(真 Anthropic、Kimi `/coding`、DeepSeek `/anthropic`)和 openai 协议(DeepSeek 默认、DashScope、Kimi)。Anthropic 平台原生的 `defer_loading` + `tool_search_tool_regex_20251119` 只在 anthropic 协议下有效,对 openai 协议后端无能为力,而后者是日常与 MSWE 评测的主力。
+
+因此 Tool Search 实现在 **tools 层的进程内桥**:对所有后端透明,provider 序列化零改动,桥工具数量固定(3 个)天然缓存友好。代价是检索由 octo 自己用 BM25 完成,而非模型受过专门训练的服务端检索——准确率收益需实测,**主要确定收益是 token / 成本下降与缓存友好**。
+
+anthropic 协议下的原生 `defer_loading` 是一个独立、可叠加的后续优化,不在本设计范围。
+
+## 三个桥工具
+
+激活后,`DefaultTools()` 不再吐出 N 个 MCP 工具,而是吐出三个桥工具;MCP 工具退入"延迟目录",仅可经桥访问。
+
+| 工具 | 入参 | 行为 |
+|---|---|---|
+| `tool_search` | `query`, `limit?` | BM25 检索延迟目录,返回命中工具的 `name` + 一行描述(**不含 schema**) |
+| `tool_describe` | `name` | 返回该工具的完整 JSON Schema |
+| `tool_call` | `name`, `arguments` | 真正调用:内部转发到 `executeMCP(name, arguments)` |
+
+核心工具(`terminal`、`read_file`、`grep`、`glob`、`web_*`、`launch_agent`、`task_*` 等)**永不延迟**,始终直接出现在列表里。只有 MCP 工具进入延迟目录。桥工具的描述里写清三步协议(search → describe → call),引导模型正确使用。
+
+## 延迟目录与 BM25 索引
+
+- **数据源**:`ActiveMCPRegistry().Connections()` 中每个 `mcp.Tool` 的 `name`、`description`、参数名。
+- **算法**:纯 Go 的小 BM25,无三方依赖;命中为空(zero-IDF)时退化为子串匹配,对齐 Anthropic 行为。
+- **生命周期**:每轮无状态重建。工具数量在几十量级,重建成本可忽略,且避免 registry 变化导致的目录漂移。
+- **检索粒度**:`tool_search` 默认返回 `search_default_limit`(5)条,上限 `max_search_limit`(20)。
+
+## 派发
+
+`DefaultRegistry.Execute`(`internal/tools/registry.go`)在 MCP 路由之前先认桥工具:
+
+```go
+switch name {
+case "tool_search":   return r.toolSearch(input)
+case "tool_describe": return r.toolDescribe(input)
+case "tool_call":     return executeMCPBridge(ctx, input) // {name, arguments} → executeMCP
+}
+```
+
+`tool_call` 落到既有的 `executeMCP`,后者按 `mcp__` 前缀工作,无需改动——延迟目录里的工具名本身就是 `mcp__<server>__<tool>`。
+
+### 权限粒度
+
+权限 gate(`agent.PermissionGate`)在 agent loop 中对每个 tool_use 调用前检查。桥工具下,模型实际发起的 tool_use 名是 `tool_call`,真实工具名在 `arguments.name` 里。gate 必须**对内层真实工具名**做判定,否则审批粒度退化为"是否允许 tool_call"这一个粗粒度开关。loop 在见到 `tool_call` 时解包 `arguments.name` 再交给 gate。同理 hooks / approval prompt 都跑在真实名上。
+
+## 激活:auto 阈值
+
+`tools.DefaultTools()` 本身 model-agnostic,而阈值判断需要 model 的上下文窗口。引入 `tools.DefaultToolsFor(model string)`:
+
+- `DefaultTools()` == `DefaultToolsFor("")`,等价于关闭延迟(全量),保持所有现有调用点向后兼容。
+- 知道 model 的调用点(`cmd/octo/chat.go`、`cmd/octo/channel.go`、sub-agent spawner)改调 `DefaultToolsFor(a.Model)`。
+
+判定逻辑(`enabled: auto`):
+
+```
+估算 MCP schema tokens ≈ Σ(每个延迟工具 schema 的字节数) / 4
+若  estTokens ≥ threshold_pct% × contextWindow(model)  →  启用桥
+否则                                                    →  直接全量透传(零开销)
+```
+
+`contextWindow(model)` 已存在于 `internal/agent/compaction.go`,直接复用。阈值以下不引入任何桥,小工具集场景行为与现状一致。
+
+## 配置
+
+挂在 `~/.octo/config.yaml`(`internal/config/config.go` 的 `Config` 下):
+
+```yaml
+tools:
+  tool_search:
+    enabled: auto          # auto(默认) | on | off
+    threshold_pct: 10      # auto 模式的激活阈值,占上下文窗口百分比
+    search_default_limit: 5
+    max_search_limit: 20
+```
+
+- `off`:现状,MCP 工具全量上传。
+- `on`:只要有 MCP 工具就强制走桥,忽略阈值。
+- `auto`:按上面的阈值决定。
+
+## 时序
+
+```
+模型                      DefaultRegistry              MCP Registry
+ │  tool_search("create issue")  │                          │
+ ├──────────────────────────────►│  BM25 over catalog       │
+ │  [{name, one-line desc}, …]    │◄─────────────────────────┤
+ │◄──────────────────────────────┤                          │
+ │                                │                          │
+ │  tool_describe("mcp__gh__…")   │                          │
+ ├──────────────────────────────►│  schema lookup           │
+ │  full JSON Schema              │                          │
+ │◄──────────────────────────────┤                          │
+ │                                │                          │
+ │  tool_call("mcp__gh__…", {…})  │                          │
+ ├──────────────────────────────►│  executeMCP(name, args)  │
+ │                                ├─────────────────────────►│
+ │  tool result                   │◄─────────────────────────┤
+ │◄──────────────────────────────┤  (gate checks real name) │
+```
+
+## 兼容性
+
+- **双协议**:桥在 tools 层,anthropic / openai 序列化均透明,无 provider 改动。
+- **sub-agent**:spawner 持有 `tools.DefaultTools` 函数值;改传 `DefaultToolsFor(model)` 后子代理同样受益(子代理连同一套 MCP)。
+- **`mcp__` 路由**:`tool_call` 复用既有 `executeMCP`,零改动。
+- **MCP 非文本结果**:现有 `formatToolResult` 已将 image/audio 压成占位符,桥不改变这点(独立 gap,不在范围)。
+
+## 已知取舍
+
+- **准确率收益不保证复刻官方数字**:Anthropic 公布的 49%→74%(Opus 4)/ 79.5%→88.1%(Opus 4.5)是在**原生**、模型受训的 tool-search 上测得。本设计是自建桥,确定收益是 token / 成本与缓存,准确率以实测为准。
+- **多一次往返**:search → describe → call 比直接调多 1–2 个 tool turn;对只用少量 MCP 工具的任务,延迟略增,但省下的每轮 schema 重发通常更划算。
+
+## 非目标
+
+- 不实现 anthropic 原生 `defer_loading`(后续可叠加的独立优化)。
+- 不延迟核心内置工具,只延迟 MCP(及未来非核心插件)工具。
+- 不改变 MCP 非文本结果的处理。
+- 不引入持久化索引或跨会话缓存——目录每轮无状态重建。
+
+## 落地切片
+
+1. BM25 索引 + 三个桥工具定义 + `DefaultRegistry` 派发(纯 tools 层,可独立测)。
+2. 权限 gate 解包 `tool_call.arguments.name` 后按真实工具名检查。
+3. `DefaultToolsFor(model)` + auto 阈值 + 配置项 + 调用点迁移。
+
+## 测试
+
+- BM25 命中与排序、zero-IDF 子串回退。
+- 三桥派发:`tool_search` 返回不含 schema、`tool_describe` 返回完整 schema、`tool_call` 闭环到 `executeMCP`。
+- auto 阈值边界(刚好低于 / 高于 `threshold_pct`)。
+- gate 对内层真实名生效。
+- 用 httptest 起假 MCP server 验证 `tool_call` → `executeMCP` 全链路,遵循"go test 无 live network"约定。

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -21,6 +21,10 @@ const compactThresholdFraction = 0.75
 // slightly earlier — never overflow — so unknown models stay safe.
 const defaultContextWindow = 128_000
 
+// ContextWindow exposes contextWindow to other packages (e.g. the tools layer's
+// Tool Search threshold) without duplicating the model→window table.
+func ContextWindow(model string) int { return contextWindow(model) }
+
 // contextWindow returns the approximate context-window size (in tokens) for a
 // model. Values are deliberately conservative; matched case-insensitively by
 // substring so dated/aliased names ("claude-haiku-4-5-2025…") still resolve.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,29 @@ type Config struct {
 	// env var is empty. Opt-in via `octo config` and stored mode 0600. Prefer
 	// the env var.
 	APIKey string `yaml:"api_key,omitempty"`
+	// Tools holds opt-in tooling behaviour (Tool Search for MCP, etc.). A
+	// missing block leaves the built-in defaults.
+	Tools ToolsConfig `yaml:"tools,omitempty"`
+}
+
+// ToolsConfig groups per-tool behaviour knobs under the `tools:` block.
+type ToolsConfig struct {
+	// ToolSearch defers MCP tool schemas behind a search/describe/call bridge.
+	ToolSearch ToolSearchConfig `yaml:"tool_search,omitempty"`
+}
+
+// ToolSearchConfig mirrors the documented tools.tool_search block. Empty fields
+// fall back to the tools-package defaults (auto / 10% / 5 / 20).
+type ToolSearchConfig struct {
+	// Enabled is "auto" (default), "on", or "off".
+	Enabled string `yaml:"enabled,omitempty"`
+	// ThresholdPct is the auto-mode activation threshold as a percent of the
+	// model's context window.
+	ThresholdPct int `yaml:"threshold_pct,omitempty"`
+	// SearchDefaultLimit is how many hits tool_search returns by default.
+	SearchDefaultLimit int `yaml:"search_default_limit,omitempty"`
+	// MaxSearchLimit caps the caller-supplied limit.
+	MaxSearchLimit int `yaml:"max_search_limit,omitempty"`
 }
 
 // Path returns the absolute path to the config file (~/.octo/config.yaml).

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -317,6 +317,12 @@ type serverPermissionGate struct {
 }
 
 func (g *serverPermissionGate) Check(ctx context.Context, name string, input map[string]any) (bool, string) {
+	// Keep parity with the CLI gate: if a Tool Search tool_call ever reaches the
+	// server (once MCP is wired here), evaluate policy against the wrapped real
+	// tool, not the opaque "tool_call" bridge.
+	if real, realInput, ok := tools.ToolCallTarget(name, input); ok {
+		name, input = real, realInput
+	}
 	switch g.engine.Check(name, input) {
 	case permission.Allow:
 		return true, ""

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -71,6 +71,18 @@ func (r DefaultRegistry) Execute(ctx context.Context, name string, input map[str
 		return agent.ToolResult{Text: out}, err
 	}
 
+	// Tool Search bridge: search/describe the deferred MCP catalog, or invoke
+	// a tool through tool_call (which routes back into executeMCP on the real
+	// name). Handled here because the bridge tools aren't in allTools.
+	switch name {
+	case toolSearchName:
+		return execToolSearch(input)
+	case toolDescribeName:
+		return execToolDescribe(input)
+	case toolCallName:
+		return execToolCall(ctx, input)
+	}
+
 	// Read-before-write pre-check (skipped when no tracker is configured).
 	if r.tracker != nil && (name == "write_file" || name == "edit_file") {
 		if path, ok := input["path"].(string); ok {
@@ -194,13 +206,24 @@ func tokenizeCommand(s string) []string {
 	return tokens
 }
 
-// DefaultTools returns the slice of ToolDefinitions sent to the LLM when
-// `--tools` is on. Order matches allTools. Each capability-gated tool is
-// withheld unless the corresponding registration call has been made —
-// SkillTool needs SetSkills, RememberTool needs SetMemoryStore, sub-agent
-// tools need a SubAgentManager. Advertising a tool that can only error wastes
-// a slot and confuses the model.
-func DefaultTools() []agent.ToolDefinition {
+// DefaultTools returns the tool list with no model context — equivalent to
+// DefaultToolsFor(""). MCP schemas are always uploaded in full (the Tool Search
+// bridge needs the model to evaluate its auto threshold), so unmigrated callers
+// keep the original behaviour.
+func DefaultTools() []agent.ToolDefinition { return DefaultToolsFor("") }
+
+// DefaultToolsFor returns the slice of ToolDefinitions sent to the LLM when
+// `--tools` is on, for the given model. Order matches allTools. Each
+// capability-gated tool is withheld unless the corresponding registration call
+// has been made — SkillTool needs SetSkills, sub-agent tools need a
+// SubAgentManager. Advertising a tool that can only error wastes a slot and
+// confuses the model.
+//
+// MCP surfaces ride alongside the built-ins. When Tool Search is active for
+// this model (see toolSearchActive) the full per-tool catalog is replaced by
+// the three search/describe/call bridge tools, so the model's tools array
+// carries three small schemas instead of every MCP tool's schema every turn.
+func DefaultToolsFor(model string) []agent.ToolDefinition {
 	skillsOn := skillsEnabled()
 	mgrOn := subAgentManagerEnabled()
 	askerOn := askerEnabled()
@@ -239,9 +262,14 @@ func DefaultTools() []agent.ToolDefinition {
 		}
 		defs = append(defs, t.Definition())
 	}
-	// MCP-advertised surfaces ride alongside built-ins, gated on a non-nil
-	// registry registered via SetMCPRegistry. Synthesised per-connection so
-	// each server's tools/resources/prompts surface together.
-	defs = append(defs, mcpToolDefs()...)
+	// MCP-advertised surfaces. Synthesised per-connection (one def per
+	// tool/resource/prompt) when uploaded in full; collapsed to the three
+	// bridge tools when Tool Search is active for this model.
+	mcpDefs := mcpCatalog()
+	if toolSearchActive(model, mcpDefs) {
+		defs = append(defs, toolSearchBridgeDefs()...)
+	} else {
+		defs = append(defs, mcpDefs...)
+	}
 	return defs
 }

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -1,0 +1,458 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"sync"
+	"unicode"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// Tool Search defers MCP tool schemas behind three bridge tools instead of
+// uploading every schema on every turn. The model discovers tools with
+// tool_search, loads one schema with tool_describe, and invokes it with
+// tool_call — which routes straight into executeMCP, so all the existing
+// mcp__-prefix dispatch, permission, and hook machinery runs against the real
+// tool name. See dev-docs/tool-search-mcp.md.
+
+// Bridge tool names. tool_call is the only path by which a deferred MCP tool is
+// actually invoked when Tool Search is active.
+const (
+	toolSearchName   = "tool_search"
+	toolDescribeName = "tool_describe"
+	toolCallName     = "tool_call"
+)
+
+// mcpCatalog returns the deferred MCP tool catalog (the same defs mcpToolDefs
+// would upload in full). A package var so tests can inject a fixed catalog
+// without standing up a live MCP registry — mirrors jinaReaderHostForTest.
+var mcpCatalog = mcpToolDefs
+
+// ── configuration ──────────────────────────────────────────────────────────
+
+// ToolSearchMode selects when the bridge replaces full MCP schema upload.
+type ToolSearchMode int
+
+const (
+	// ToolSearchAuto activates the bridge only when deferred MCP schemas would
+	// occupy at least ThresholdPct% of the model's context window.
+	ToolSearchAuto ToolSearchMode = iota
+	// ToolSearchOn activates the bridge whenever any MCP tool is present.
+	ToolSearchOn
+	// ToolSearchOff never activates the bridge — MCP schemas upload in full.
+	ToolSearchOff
+)
+
+// ToolSearchConfig is the tools-package view of the user's tool_search config.
+// cmd/octo maps the ~/.octo/config.yaml block onto this and installs it via
+// SetToolSearchConfig, mirroring SetSandbox / SetMCPRegistry.
+type ToolSearchConfig struct {
+	Mode           ToolSearchMode
+	ThresholdPct   int // auto-mode activation threshold, percent of context window
+	SearchLimit    int // default number of hits tool_search returns
+	MaxSearchLimit int // upper bound on the caller-supplied limit
+}
+
+// defaultToolSearchConfig matches the documented defaults (auto / 10% / 5 / 20).
+func defaultToolSearchConfig() ToolSearchConfig {
+	return ToolSearchConfig{Mode: ToolSearchAuto, ThresholdPct: 10, SearchLimit: 5, MaxSearchLimit: 20}
+}
+
+var (
+	toolSearchCfgMu sync.RWMutex
+	toolSearchCfg   = defaultToolSearchConfig()
+)
+
+// SetToolSearchConfig installs the active tool_search configuration. Fields
+// left at their zero value fall back to the documented defaults so a partial
+// config block behaves sensibly.
+func SetToolSearchConfig(c ToolSearchConfig) {
+	d := defaultToolSearchConfig()
+	if c.ThresholdPct <= 0 {
+		c.ThresholdPct = d.ThresholdPct
+	}
+	if c.SearchLimit <= 0 {
+		c.SearchLimit = d.SearchLimit
+	}
+	if c.MaxSearchLimit <= 0 {
+		c.MaxSearchLimit = d.MaxSearchLimit
+	}
+	toolSearchCfgMu.Lock()
+	toolSearchCfg = c
+	toolSearchCfgMu.Unlock()
+}
+
+func toolSearchConfig() ToolSearchConfig {
+	toolSearchCfgMu.RLock()
+	defer toolSearchCfgMu.RUnlock()
+	return toolSearchCfg
+}
+
+// toolSearchActive decides whether to replace the MCP defs with the bridge for
+// a given model. mcpDefs is the catalog that would otherwise be uploaded.
+//
+// An empty model (the DefaultTools back-compat entry) never activates the
+// bridge, so callers that don't know the model keep the original behaviour.
+func toolSearchActive(model string, mcpDefs []agent.ToolDefinition) bool {
+	if len(mcpDefs) == 0 {
+		return false
+	}
+	switch toolSearchConfig().Mode {
+	case ToolSearchOff:
+		return false
+	case ToolSearchOn:
+		return true
+	default: // auto
+		if model == "" {
+			return false
+		}
+		window := agent.ContextWindow(model)
+		budget := window * toolSearchConfig().ThresholdPct / 100
+		return estimateSchemaTokens(mcpDefs) >= budget
+	}
+}
+
+// estimateSchemaTokens approximates how many tokens the MCP tool definitions
+// occupy. A coarse bytes/4 heuristic is plenty for a threshold decision.
+func estimateSchemaTokens(defs []agent.ToolDefinition) int {
+	bytes := 0
+	for _, d := range defs {
+		bytes += len(d.Name) + len(d.Description)
+		if b, err := json.Marshal(d.Parameters); err == nil {
+			bytes += len(b)
+		}
+	}
+	return bytes / 4
+}
+
+// ── bridge tool definitions ────────────────────────────────────────────────
+
+// toolSearchBridgeDefs returns the three bridge tools advertised in place of
+// the full MCP catalog when Tool Search is active.
+func toolSearchBridgeDefs() []agent.ToolDefinition {
+	cfg := toolSearchConfig()
+	return []agent.ToolDefinition{
+		{
+			Name: toolSearchName,
+			Description: fmt.Sprintf("Search the catalog of available MCP tools by keyword and "+
+				"return matching tool names with a one-line description (NOT their full schema). "+
+				"MCP tools are not loaded up front — discover them here first. Workflow: "+
+				"tool_search to find a tool, tool_describe to load its parameters, tool_call to "+
+				"invoke it. Returns up to %d hits by default.", cfg.SearchLimit),
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"query": map[string]any{
+						"type":        "string",
+						"description": "Keywords describing the tool you need, e.g. 'create github issue'.",
+					},
+					"limit": map[string]any{
+						"type":        "integer",
+						"description": fmt.Sprintf("Max hits to return (default %d, capped at %d).", cfg.SearchLimit, cfg.MaxSearchLimit),
+					},
+				},
+				"required": []string{"query"},
+			},
+		},
+		{
+			Name: toolDescribeName,
+			Description: "Load the full JSON Schema (parameters) for one MCP tool discovered via " +
+				"tool_search. Call this before tool_call so you know the tool's exact arguments.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{
+						"type":        "string",
+						"description": "The exact tool name from tool_search (e.g. 'mcp__github__create_issue').",
+					},
+				},
+				"required": []string{"name"},
+			},
+		},
+		{
+			Name: toolCallName,
+			Description: "Invoke an MCP tool discovered via tool_search. Pass the tool name and its " +
+				"arguments (matching the schema from tool_describe). This is the only way to call a " +
+				"deferred MCP tool while Tool Search is active.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{
+						"type":        "string",
+						"description": "The exact MCP tool name to invoke (e.g. 'mcp__github__create_issue').",
+					},
+					"arguments": map[string]any{
+						"type":        "object",
+						"description": "The arguments object for the tool, matching its schema from tool_describe.",
+					},
+				},
+				"required": []string{"name", "arguments"},
+			},
+		},
+	}
+}
+
+// ── dispatch (called from DefaultRegistry.Execute) ─────────────────────────
+
+// execToolSearch runs a BM25 search over the live MCP catalog and returns the
+// matching tool names with their one-line descriptions — never their schemas.
+func execToolSearch(input map[string]any) (agent.ToolResult, error) {
+	query := strings.TrimSpace(stringArg(input, "query"))
+	if query == "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("tool_search: query is required")
+	}
+	cfg := toolSearchConfig()
+	limit := intArg(input, "limit", cfg.SearchLimit)
+	if limit < 1 {
+		limit = cfg.SearchLimit
+	}
+	if limit > cfg.MaxSearchLimit {
+		limit = cfg.MaxSearchLimit
+	}
+
+	catalog := mcpCatalog()
+	if len(catalog) == 0 {
+		return agent.ToolResult{Text: "(no MCP tools available)"}, nil
+	}
+	hits := bm25Search(catalog, query, limit)
+	if len(hits) == 0 {
+		return agent.ToolResult{Text: fmt.Sprintf("(no tools match %q)", query)}, nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d match(es) for %q — use tool_describe to load a tool's parameters:\n", len(hits), query)
+	for _, d := range hits {
+		desc := firstLine(d.Description)
+		if desc == "" {
+			desc = "(no description)"
+		}
+		fmt.Fprintf(&b, "- %s — %s\n", d.Name, desc)
+	}
+	return agent.ToolResult{Text: strings.TrimRight(b.String(), "\n")}, nil
+}
+
+// execToolDescribe returns the full JSON Schema of one catalog tool.
+func execToolDescribe(input map[string]any) (agent.ToolResult, error) {
+	name := strings.TrimSpace(stringArg(input, "name"))
+	if name == "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("tool_describe: name is required")
+	}
+	for _, d := range mcpCatalog() {
+		if d.Name == name {
+			schema, err := json.MarshalIndent(d.Parameters, "", "  ")
+			if err != nil {
+				return agent.ToolResult{Text: ""}, fmt.Errorf("tool_describe: marshal schema: %w", err)
+			}
+			return agent.ToolResult{Text: fmt.Sprintf("%s\n\n%s\n\n%s", d.Name, firstLine(d.Description), string(schema))}, nil
+		}
+	}
+	return agent.ToolResult{Text: ""}, fmt.Errorf("tool_describe: no tool named %q (use tool_search to find the exact name)", name)
+}
+
+// execToolCall unwraps {name, arguments} and forwards to executeMCP, so the
+// real MCP dispatch (and the permission/hook machinery keyed on the real name)
+// runs unchanged.
+func execToolCall(ctx context.Context, input map[string]any) (agent.ToolResult, error) {
+	name := strings.TrimSpace(stringArg(input, "name"))
+	if name == "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("tool_call: name is required")
+	}
+	args, _ := input["arguments"].(map[string]any)
+	if args == nil {
+		args = map[string]any{}
+	}
+	out, ok, err := executeMCP(ctx, name, args)
+	if !ok {
+		// executeMCP only declines names without the mcp__ prefix.
+		return agent.ToolResult{Text: ""}, fmt.Errorf("tool_call: %q is not an MCP tool (names look like 'mcp__<server>__<tool>')", name)
+	}
+	return agent.ToolResult{Text: out}, err
+}
+
+// ToolCallTarget unwraps a tool_call bridge invocation into the real MCP tool
+// name and its arguments, so permission checks and hooks key on the real tool
+// rather than the "tool_call" wrapper. ok is false when name isn't a tool_call
+// (or carries no inner tool name), in which case the caller uses name/input
+// unchanged.
+func ToolCallTarget(name string, input map[string]any) (realName string, realInput map[string]any, ok bool) {
+	if name != toolCallName {
+		return "", nil, false
+	}
+	realName = strings.TrimSpace(stringArg(input, "name"))
+	if realName == "" {
+		return "", nil, false
+	}
+	realInput, _ = input["arguments"].(map[string]any)
+	if realInput == nil {
+		realInput = map[string]any{}
+	}
+	return realName, realInput, true
+}
+
+// ── BM25 ────────────────────────────────────────────────────────────────────
+
+// bm25Search ranks catalog entries against query using BM25 over each tool's
+// name + description + parameter-property names, and returns the top n. When no
+// term has any document frequency (zero IDF — e.g. a brand-new term), it falls
+// back to a substring match on name + description so a reasonable query never
+// comes back empty just because the corpus is tiny.
+func bm25Search(catalog []agent.ToolDefinition, query string, n int) []agent.ToolDefinition {
+	const k1, b = 1.5, 0.75
+
+	docs := make([][]string, len(catalog))
+	var totalLen int
+	for i, d := range catalog {
+		docs[i] = tokenizeForSearch(catalogText(d))
+		totalLen += len(docs[i])
+	}
+	avgLen := 0.0
+	if len(docs) > 0 {
+		avgLen = float64(totalLen) / float64(len(docs))
+	}
+
+	// Document frequency per term.
+	df := map[string]int{}
+	for _, toks := range docs {
+		for t := range uniqueTokens(toks) {
+			df[t]++
+		}
+	}
+
+	qTerms := tokenizeForSearch(query)
+	N := float64(len(docs))
+
+	type scored struct {
+		idx   int
+		score float64
+	}
+	var ranked []scored
+	for i, toks := range docs {
+		tf := termFreq(toks)
+		var score float64
+		for _, qt := range qTerms {
+			f := float64(tf[qt])
+			if f == 0 {
+				continue
+			}
+			idf := math.Log(1 + (N-float64(df[qt])+0.5)/(float64(df[qt])+0.5))
+			denom := f + k1*(1-b+b*float64(len(toks))/maxF(avgLen, 1))
+			score += idf * (f * (k1 + 1)) / denom
+		}
+		if score > 0 {
+			ranked = append(ranked, scored{i, score})
+		}
+	}
+
+	if len(ranked) == 0 {
+		return substringFallback(catalog, query, n)
+	}
+	sort.SliceStable(ranked, func(i, j int) bool { return ranked[i].score > ranked[j].score })
+	if len(ranked) > n {
+		ranked = ranked[:n]
+	}
+	out := make([]agent.ToolDefinition, 0, len(ranked))
+	for _, r := range ranked {
+		out = append(out, catalog[r.idx])
+	}
+	return out
+}
+
+// substringFallback returns catalog entries whose name or description contains
+// the query (case-insensitive), capped at n. Used when BM25 finds nothing.
+func substringFallback(catalog []agent.ToolDefinition, query string, n int) []agent.ToolDefinition {
+	q := strings.ToLower(strings.TrimSpace(query))
+	var out []agent.ToolDefinition
+	for _, d := range catalog {
+		if strings.Contains(strings.ToLower(d.Name+" "+d.Description), q) {
+			out = append(out, d)
+			if len(out) >= n {
+				break
+			}
+		}
+	}
+	return out
+}
+
+// catalogText is the searchable text for one tool: its name, description, and
+// the names of its top-level parameter properties.
+func catalogText(d agent.ToolDefinition) string {
+	var b strings.Builder
+	b.WriteString(d.Name)
+	b.WriteByte(' ')
+	b.WriteString(d.Description)
+	if props, ok := d.Parameters["properties"].(map[string]any); ok {
+		for k := range props {
+			b.WriteByte(' ')
+			b.WriteString(k)
+		}
+	}
+	return b.String()
+}
+
+// tokenizeForSearch lower-cases and splits on non-alphanumeric runes, and also
+// splits snake_case / mcp__ separators (already covered by the underscore split)
+// and camelCase boundaries so "createIssue" matches "create" and "issue".
+func tokenizeForSearch(s string) []string {
+	var raw []string
+	cur := strings.Builder{}
+	flush := func() {
+		if cur.Len() > 0 {
+			raw = append(raw, cur.String())
+			cur.Reset()
+		}
+	}
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			cur.WriteRune(unicode.ToLower(r))
+		} else {
+			flush()
+		}
+	}
+	flush()
+
+	// Split camelCase tokens into their parts (kept alongside the whole token).
+	var out []string
+	for _, tok := range raw {
+		out = append(out, tok)
+		for _, part := range splitCamel(tok) {
+			if part != tok {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
+}
+
+// splitCamel breaks a token on lower→upper boundaries; here the input is
+// already lower-cased, so this only ever returns the token itself. Kept as a
+// hook so future tokenization (raw, pre-lowercase) can split camelCase without
+// touching callers.
+func splitCamel(tok string) []string { return []string{tok} }
+
+func termFreq(toks []string) map[string]int {
+	m := make(map[string]int, len(toks))
+	for _, t := range toks {
+		m[t]++
+	}
+	return m
+}
+
+func uniqueTokens(toks []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(toks))
+	for _, t := range toks {
+		m[t] = struct{}{}
+	}
+	return m
+}
+
+func maxF(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/tools/tool_search_test.go
+++ b/internal/tools/tool_search_test.go
@@ -1,0 +1,217 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// fakeCatalog installs a fixed MCP catalog for the duration of a test, so the
+// bridge logic can be exercised without a live MCP registry.
+func fakeCatalog(t *testing.T, defs []agent.ToolDefinition) {
+	t.Helper()
+	prev := mcpCatalog
+	mcpCatalog = func() []agent.ToolDefinition { return defs }
+	t.Cleanup(func() { mcpCatalog = prev })
+}
+
+// resetToolSearchConfig restores defaults after a test mutates the global.
+func resetToolSearchConfig(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { SetToolSearchConfig(defaultToolSearchConfig()) })
+}
+
+func sampleCatalog() []agent.ToolDefinition {
+	return []agent.ToolDefinition{
+		{Name: "mcp__github__create_issue", Description: "Create a new GitHub issue in a repository",
+			Parameters: map[string]any{"type": "object", "properties": map[string]any{"title": map[string]any{"type": "string"}, "body": map[string]any{"type": "string"}}}},
+		{Name: "mcp__github__list_pulls", Description: "List pull requests",
+			Parameters: map[string]any{"type": "object", "properties": map[string]any{"state": map[string]any{"type": "string"}}}},
+		{Name: "mcp__slack__post_message", Description: "Post a message to a Slack channel",
+			Parameters: map[string]any{"type": "object", "properties": map[string]any{"channel": map[string]any{"type": "string"}}}},
+	}
+}
+
+func TestBM25Search_RanksRelevantFirst(t *testing.T) {
+	hits := bm25Search(sampleCatalog(), "create github issue", 5)
+	if len(hits) == 0 {
+		t.Fatal("expected at least one hit")
+	}
+	if hits[0].Name != "mcp__github__create_issue" {
+		t.Errorf("top hit = %q, want mcp__github__create_issue", hits[0].Name)
+	}
+}
+
+func TestBM25Search_RespectsLimit(t *testing.T) {
+	hits := bm25Search(sampleCatalog(), "github", 1)
+	if len(hits) != 1 {
+		t.Fatalf("len(hits) = %d, want 1", len(hits))
+	}
+}
+
+func TestBM25Search_SubstringFallback(t *testing.T) {
+	// "slack" appears only in a tool name, not as a free-standing English term
+	// the BM25 query would otherwise weight — but more importantly this exercises
+	// that a query matching nothing by token still finds via substring.
+	hits := bm25Search(sampleCatalog(), "post_message", 5)
+	if len(hits) == 0 || hits[0].Name != "mcp__slack__post_message" {
+		t.Errorf("expected slack post_message hit, got %+v", hits)
+	}
+}
+
+func TestExecToolSearch_NoSchemaLeaked(t *testing.T) {
+	fakeCatalog(t, sampleCatalog())
+	res, err := execToolSearch(map[string]any{"query": "github issue"})
+	if err != nil {
+		t.Fatalf("execToolSearch: %v", err)
+	}
+	if !strings.Contains(res.Text, "mcp__github__create_issue") {
+		t.Errorf("expected the issue tool in results:\n%s", res.Text)
+	}
+	// The search result must NOT include schema details like property names.
+	if strings.Contains(res.Text, "properties") || strings.Contains(res.Text, "\"title\"") {
+		t.Errorf("search result leaked schema:\n%s", res.Text)
+	}
+}
+
+func TestExecToolSearch_EmptyCatalog(t *testing.T) {
+	fakeCatalog(t, nil)
+	res, err := execToolSearch(map[string]any{"query": "anything"})
+	if err != nil {
+		t.Fatalf("execToolSearch: %v", err)
+	}
+	if !strings.Contains(res.Text, "no MCP tools") {
+		t.Errorf("want no-tools notice, got %q", res.Text)
+	}
+}
+
+func TestExecToolDescribe_ReturnsSchema(t *testing.T) {
+	fakeCatalog(t, sampleCatalog())
+	res, err := execToolDescribe(map[string]any{"name": "mcp__github__create_issue"})
+	if err != nil {
+		t.Fatalf("execToolDescribe: %v", err)
+	}
+	for _, want := range []string{"mcp__github__create_issue", "properties", "title", "body"} {
+		if !strings.Contains(res.Text, want) {
+			t.Errorf("schema missing %q:\n%s", want, res.Text)
+		}
+	}
+}
+
+func TestExecToolDescribe_UnknownName(t *testing.T) {
+	fakeCatalog(t, sampleCatalog())
+	if _, err := execToolDescribe(map[string]any{"name": "mcp__nope__nothing"}); err == nil {
+		t.Error("expected error for unknown tool name")
+	}
+}
+
+func TestToolCallTarget_Unwraps(t *testing.T) {
+	real, args, ok := ToolCallTarget("tool_call", map[string]any{
+		"name":      "mcp__github__create_issue",
+		"arguments": map[string]any{"title": "hi"},
+	})
+	if !ok || real != "mcp__github__create_issue" {
+		t.Fatalf("unwrap = (%q, %v)", real, ok)
+	}
+	if args["title"] != "hi" {
+		t.Errorf("args not carried through: %v", args)
+	}
+	// A non-tool_call name is left alone.
+	if _, _, ok := ToolCallTarget("terminal", map[string]any{"command": "ls"}); ok {
+		t.Error("ToolCallTarget should not unwrap a non-tool_call name")
+	}
+}
+
+func TestExecToolCall_RejectsNonMCP(t *testing.T) {
+	// tool_call only proxies mcp__ tools; a bare name must error cleanly.
+	if _, err := execToolCall(context.Background(), map[string]any{"name": "terminal", "arguments": map[string]any{}}); err == nil {
+		t.Error("expected error proxying a non-MCP tool name")
+	}
+}
+
+func TestToolSearchActive_Modes(t *testing.T) {
+	resetToolSearchConfig(t)
+	cat := sampleCatalog()
+
+	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchOff})
+	if toolSearchActive("claude-opus-4-8", cat) {
+		t.Error("off mode must never activate")
+	}
+
+	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchOn})
+	if !toolSearchActive("claude-opus-4-8", cat) {
+		t.Error("on mode must activate when MCP tools present")
+	}
+	if toolSearchActive("claude-opus-4-8", nil) {
+		t.Error("on mode must not activate with an empty catalog")
+	}
+
+	// auto with an empty model never activates (back-compat for DefaultTools()).
+	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchAuto, ThresholdPct: 10})
+	if toolSearchActive("", cat) {
+		t.Error("auto with empty model must not activate")
+	}
+}
+
+func TestToolSearchActive_AutoThreshold(t *testing.T) {
+	resetToolSearchConfig(t)
+	// A tiny catalog is well under 10% of a 1M-token window → no activation.
+	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchAuto, ThresholdPct: 10})
+	if toolSearchActive("claude-opus-4-8", sampleCatalog()) {
+		t.Error("small catalog should stay under the auto threshold for a 1M window")
+	}
+	// A 0% threshold means any non-empty catalog crosses it.
+	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchAuto, ThresholdPct: 1})
+	big := make([]agent.ToolDefinition, 0, 400)
+	for i := 0; i < 400; i++ {
+		big = append(big, agent.ToolDefinition{
+			Name:        "mcp__srv__tool",
+			Description: strings.Repeat("x", 500),
+			Parameters:  map[string]any{"type": "object", "properties": map[string]any{"a": map[string]any{"type": "string"}}},
+		})
+	}
+	if !toolSearchActive("claude-haiku-4-5", big) {
+		t.Error("a large catalog should cross the auto threshold")
+	}
+}
+
+func TestDefaultToolsFor_BridgeReplacesCatalog(t *testing.T) {
+	resetToolSearchConfig(t)
+	fakeCatalog(t, sampleCatalog())
+	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchOn})
+
+	defs := DefaultToolsFor("claude-opus-4-8")
+	names := map[string]bool{}
+	for _, d := range defs {
+		names[d.Name] = true
+	}
+	for _, want := range []string{toolSearchName, toolDescribeName, toolCallName} {
+		if !names[want] {
+			t.Errorf("expected bridge tool %q in the list", want)
+		}
+	}
+	// The raw MCP tools must NOT be advertised when the bridge is active.
+	if names["mcp__github__create_issue"] {
+		t.Error("raw MCP tool should be deferred behind the bridge, not advertised")
+	}
+}
+
+func TestDefaultToolsFor_OffUploadsFullCatalog(t *testing.T) {
+	resetToolSearchConfig(t)
+	fakeCatalog(t, sampleCatalog())
+	SetToolSearchConfig(ToolSearchConfig{Mode: ToolSearchOff})
+
+	defs := DefaultToolsFor("claude-opus-4-8")
+	names := map[string]bool{}
+	for _, d := range defs {
+		names[d.Name] = true
+	}
+	if !names["mcp__github__create_issue"] {
+		t.Error("off mode must advertise the raw MCP tools")
+	}
+	if names[toolSearchName] {
+		t.Error("off mode must not advertise the bridge")
+	}
+}


### PR DESCRIPTION
Implements approach B from `dev-docs/tool-search-mcp.md`: a **provider-agnostic in-process bridge** that stops uploading every MCP tool's JSON Schema on every turn.

## What it does
When the deferred MCP catalog is large enough to matter, `DefaultToolsFor(model)` replaces the full per-tool schema list with three small bridge tools:

- `tool_search(query, limit?)` — BM25 over tool name + description + parameter names (substring fallback for zero-IDF queries). Returns names + one-line descriptions, **never schemas**.
- `tool_describe(name)` — loads one tool's full JSON Schema on demand.
- `tool_call(name, arguments)` — invokes a deferred tool; routes straight into the existing `executeMCP`, so all `mcp__`-prefix dispatch is unchanged.

Core built-ins (terminal, read_file, …) are never deferred — only MCP tools.

## Activation (`auto` by default)
Defers only when estimated MCP schema tokens ≥ `threshold_pct`% (default 10) of the model's context window. Below that it's a pass-through (zero overhead). `DefaultTools()` == `DefaultToolsFor("")` keeps the old full-upload behaviour for model-agnostic callers (server/IM paths, `octo init`).

## Config (`~/.octo/config.yaml`)
```yaml
tools:
  tool_search:
    enabled: auto        # auto | on | off
    threshold_pct: 10
    search_default_limit: 5
    max_search_limit: 20
```

## Correctness notes
- **Permission gate** unwraps `tool_call` and evaluates policy + prompts against the *real* wrapped tool name, not the opaque bridge (test: `TestCLIGate_UnwrapsToolCallToRealName`).
- `agent.ContextWindow` exported so the tools layer can size the threshold without duplicating the model→window table.
- Provider-agnostic: works for both anthropic and openai backends. The Anthropic-native `defer_loading` path is a separate, additive future optimization (out of scope; noted in the design doc).

## Tests
New `tool_search_test.go` (BM25 ranking + limit + fallback, search-leaks-no-schema, describe-returns-schema, tool_call unwrap + non-MCP rejection, auto/on/off + threshold boundary, bridge-replaces-catalog vs off-uploads-full) and the gate unwrap test. `make fmt-check`, `go vet`, and `go test -race ./...` are green.

Design: `dev-docs/tool-search-mcp.md`.

⚠️ Expectation note: the published 49%→74% (Opus 4) accuracy figure was measured on Anthropic's *native* tool-search; this bridge's confident win is token/cost (~80%+ schema reduction) and cache-friendliness — accuracy impact should be measured before claiming it.