### PR TITLE
refactor(app): extract provider construction into internal/app (PR1a)

### DIFF
--- a/.octorules
+++ b/.octorules
@@ -10,13 +10,14 @@ The canonical project guidance for contributors and AI coding agents. Keep this 
 
 ```
 cmd/octo/          CLI entry, flag parsing, REPL, sessions
+internal/app/      Provider-client construction + session bootstrap
 internal/agent/    Agent loop, history, content blocks, Sender interfaces
 internal/provider/ Provider interface + per-vendor implementations
 internal/tools/    Concrete ToolExecutor implementations
 internal/version/  Version constants overridable via -ldflags
 ```
 
-Dependency direction is one-way: `provider → agent`, `tools → agent`, never the other way. `cmd/octo` is the only package allowed to import `provider` directly; everything else talks through `agent.Sender` / `StreamingSender` / `ToolSender` / `ToolStreamingSender`.
+Dependency direction is one-way: `provider → agent`, `tools → agent`, never the other way. `internal/app` is the single place that constructs provider clients and adapts them to `agent.Sender`; every entry point (`cmd/octo`, `internal/server`) reaches the LLM through it rather than importing `provider` directly. (`internal/server` still has its own copy pending migration.)
 
 ## Adding capability
 

--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/channel"
 	_ "github.com/Leihb/octo-agent/internal/channel/adapters/weixin"
 	"github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink"
@@ -121,10 +122,13 @@ func runChannelStart(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 		fmt.Fprintf(stderr, "octo channel: unknown provider %q\n", provName)
 		return 2
 	}
-	prov, err := buildProvider(provName, cfg, stderr)
+	// Validate credentials once (printing setup help on a missing key); the
+	// per-session sender is built in the factory below with a fresh cache key.
+	apiKey, err := resolveAPIKey(provName, cfg, stderr)
 	if err != nil {
 		return 1
 	}
+	baseURL := resolveBaseURL(provName, cfg)
 
 	// Build agent factory.
 	cwd, _ := os.Getwd()
@@ -134,10 +138,15 @@ func runChannelStart(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 	tools.SetSkills(skillReg)
 
 	agentFactory := func() *agent.Agent {
-		a := agent.New(providerSender{
-			p:        prov,
-			cacheKey: newCacheKey(),
-		}, resolvedModel)
+		// The key was validated above; NewSender only re-errors on client
+		// construction, which doesn't happen for an already-resolved key.
+		llmSender, _ := app.NewSender(app.SenderOptions{
+			Provider: provName,
+			APIKey:   apiKey,
+			BaseURL:  baseURL,
+			CacheKey: newCacheKey(),
+		})
+		a := agent.New(llmSender, resolvedModel)
 		a.CWD = cwd
 		a.MaxTokens = *maxTokens
 		a.MaxTurns = *maxTurns

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -15,15 +15,13 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/config"
 	"github.com/Leihb/octo-agent/internal/hooks"
 	"github.com/Leihb/octo-agent/internal/mcp"
 	"github.com/Leihb/octo-agent/internal/memory"
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/prompt"
-	"github.com/Leihb/octo-agent/internal/provider"
-	"github.com/Leihb/octo-agent/internal/provider/anthropic"
-	"github.com/Leihb/octo-agent/internal/provider/openai"
 	"github.com/Leihb/octo-agent/internal/skills"
 	"github.com/Leihb/octo-agent/internal/tasks"
 	"github.com/Leihb/octo-agent/internal/tools"
@@ -415,7 +413,11 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 	}
 
-	prov, err := buildProvider(provName, cfg, stderr)
+	llmSender, err := buildSender(provName, cfg, stderr, senderTuning{
+		thinkingBudget:  anthropicThinkingBudget(resolvedEffort),
+		reasoningEffort: resolvedEffort,
+		showReasoning:   resolvedShowReasoning,
+	})
 	if err != nil {
 		return 1
 	}
@@ -467,15 +469,10 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 	}
 
-	// A stable per-process cache key lets OpenAI route every turn (and every
-	// tool-loop iteration) of this conversation to the same prompt cache.
-	a := agent.New(providerSender{
-		p:               prov,
-		cacheKey:        newCacheKey(),
-		thinkingBudget:  anthropicThinkingBudget(resolvedEffort),
-		reasoningEffort: resolvedEffort,
-		showReasoning:   resolvedShowReasoning,
-	}, resolvedModel)
+	// The sender (built above with a stable per-process cache key) lets OpenAI
+	// route every turn — and every tool-loop iteration — of this conversation
+	// to the same prompt cache.
+	a := agent.New(llmSender, resolvedModel)
 	a.CWD = cwd
 	a.MaxTokens = *maxTokens
 	a.MaxTokensEscalate = resolveMaxTokensEscalate(*maxTokensEscalate, provName)
@@ -754,13 +751,46 @@ func printUsageLine(w io.Writer, reply agent.Reply) {
 		reply.InputTokens, reply.OutputTokens, reply.CacheReadTokens, reply.CacheWriteTokens)
 }
 
-// buildProvider constructs a provider.Provider for the requested vendor.
-// Credentials and endpoint resolve env-first, then fall back to the persisted
-// config (cfg): the API key comes from the provider's env var, else cfg.APIKey
-// when the stored config is for this same provider; the base URL likewise. On
-// configuration errors it writes a user-facing message to stderr and returns a
+// senderTuning carries the optional reasoning/thinking knobs a caller wants on
+// the sender. The zero value (no extended reasoning) is what the IM bridge and
+// server use.
+type senderTuning struct {
+	thinkingBudget  int
+	reasoningEffort string
+	showReasoning   bool
+}
+
+// buildSender resolves credentials/endpoint (env-first, then the persisted
+// config) and returns an agent.Sender built through internal/app — the single
+// place that constructs provider clients. On a configuration error it writes a
+// user-facing message to stderr and returns a non-nil error. A fresh
+// prompt-cache key is generated per call.
+func buildSender(name string, cfg config.Config, stderr io.Writer, tuning senderTuning) (agent.Sender, error) {
+	apiKey, err := resolveAPIKey(name, cfg, stderr)
+	if err != nil {
+		return nil, err
+	}
+	s, err := app.NewSender(app.SenderOptions{
+		Provider:        name,
+		APIKey:          apiKey,
+		BaseURL:         resolveBaseURL(name, cfg),
+		CacheKey:        newCacheKey(),
+		ThinkingBudget:  tuning.thinkingBudget,
+		ReasoningEffort: tuning.reasoningEffort,
+		ShowReasoning:   tuning.showReasoning,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "octo chat: %v\n", err)
+		return nil, err
+	}
+	return s, nil
+}
+
+// resolveAPIKey returns the API key for the requested vendor: the provider's
+// env var, else cfg.APIKey when the stored config is for this same provider. On
+// a missing key it prints provider-specific setup help to stderr and returns a
 // non-nil error.
-func buildProvider(name string, cfg config.Config, stderr io.Writer) (provider.Provider, error) {
+func resolveAPIKey(name string, cfg config.Config, stderr io.Writer) (string, error) {
 	switch name {
 	case providerAnthropic:
 		apiKey := os.Getenv("ANTHROPIC_API_KEY")
@@ -779,17 +809,9 @@ func buildProvider(name string, cfg config.Config, stderr io.Writer) (provider.P
 			fmt.Fprintln(stderr, "Or use OpenAI:")
 			fmt.Fprintln(stderr, "  export OPENAI_API_KEY=sk-...")
 			fmt.Fprintln(stderr, "  octo chat --provider openai")
-			return nil, errors.New("missing ANTHROPIC_API_KEY")
+			return "", errors.New("missing ANTHROPIC_API_KEY")
 		}
-		client, err := anthropic.New(apiKey)
-		if err != nil {
-			fmt.Fprintf(stderr, "octo chat: %v\n", err)
-			return nil, err
-		}
-		if baseURL := resolveBaseURL(name, cfg); baseURL != "" {
-			client.BaseURL = baseURL
-		}
-		return client, nil
+		return apiKey, nil
 
 	case providerOpenAI:
 		apiKey := os.Getenv("OPENAI_API_KEY")
@@ -808,59 +830,14 @@ func buildProvider(name string, cfg config.Config, stderr io.Writer) (provider.P
 			fmt.Fprintln(stderr, "Or use Anthropic (the default):")
 			fmt.Fprintln(stderr, "  export ANTHROPIC_API_KEY=sk-ant-...")
 			fmt.Fprintln(stderr, "  octo chat                 # no --provider flag needed")
-			return nil, errors.New("missing OPENAI_API_KEY")
+			return "", errors.New("missing OPENAI_API_KEY")
 		}
-		client, err := openai.New(apiKey)
-		if err != nil {
-			fmt.Fprintf(stderr, "octo chat: %v\n", err)
-			return nil, err
-		}
-		if baseURL := resolveBaseURL(name, cfg); baseURL != "" {
-			client.BaseURL = baseURL
-		}
-		return client, nil
+		return apiKey, nil
 
 	default:
 		fmt.Fprintf(stderr, "octo chat: unknown provider %q (use 'anthropic' or 'openai')\n", name)
-		return nil, fmt.Errorf("unknown provider %q", name)
+		return "", fmt.Errorf("unknown provider %q", name)
 	}
-}
-
-// providerSender adapts a provider.Provider into agent.Sender. Keeping the
-// adapter in cmd/octo means the agent package never imports provider — a
-// one-directional dep graph that pays off as more provider implementations
-// land.
-type providerSender struct {
-	p provider.Provider
-	// cacheKey is a stable per-conversation identifier forwarded as the
-	// provider's prompt-cache key (OpenAI prompt_cache_key). Keeping it
-	// constant across a session's turns lets the backend route them to the
-	// same prompt cache. Empty is fine — providers omit the field.
-	cacheKey string
-	// thinkingBudget, when > 0, enables extended thinking (Anthropic) with this
-	// token budget for the reasoning trace. Derived from the unified reasoning
-	// effort. Ignored by the OpenAI provider.
-	thinkingBudget int
-	// reasoningEffort ("low" | "medium" | "high"), when non-empty, is forwarded
-	// to the OpenAI provider as reasoning_effort. Ignored by Anthropic, which
-	// uses thinkingBudget instead.
-	reasoningEffort string
-	// showReasoning gates whether the reasoning/thinking trace is surfaced to
-	// the agent event stream (and thus rendered by the view). When false the
-	// provider is told not to stream reasoning, even though the model may still
-	// produce it server-side and history may still carry it.
-	showReasoning bool
-}
-
-// reasoningSink returns the OnThinking callback to hand the provider: the
-// agent's onThinking when reasoning display is enabled, else nil so the
-// provider skips surfacing reasoning entirely. The trace's dim styling lives
-// in the view layer (plainView / TUI), not here.
-func (s providerSender) reasoningSink(onThinking func(string)) func(string) {
-	if !s.showReasoning || onThinking == nil {
-		return nil
-	}
-	return onThinking
 }
 
 // newCacheKey returns a random hex token used as the prompt-cache key for one
@@ -873,172 +850,3 @@ func newCacheKey() string {
 	}
 	return "octo-" + hex.EncodeToString(b[:])
 }
-
-func (s providerSender) SendMessages(ctx context.Context, model, system string, msgs []agent.Message, maxTokens int) (agent.Reply, error) {
-	if s.p == nil {
-		return agent.Reply{}, errors.New("providerSender: provider is nil")
-	}
-	resp, err := s.p.Send(ctx, provider.Request{
-		Model:           model,
-		SystemPrompt:    system,
-		Messages:        msgs,
-		MaxTokens:       maxTokens,
-		CacheKey:        s.cacheKey,
-		ThinkingBudget:  s.thinkingBudget,
-		ReasoningEffort: s.reasoningEffort,
-	})
-	if err != nil {
-		return agent.Reply{}, err
-	}
-	return replyFromResponse(resp), nil
-}
-
-// StreamMessages implements agent.StreamingSender by delegating to the
-// underlying provider's SendStream — when the provider implements
-// provider.StreamingProvider. If it doesn't (e.g. a future
-// non-streaming-capable backend), we fall back to the buffered Send path
-// and synthesise a single onChunk call with the full content so callers
-// see the same shape either way.
-func (s providerSender) StreamMessages(
-	ctx context.Context,
-	model, system string,
-	msgs []agent.Message,
-	maxTokens int,
-	onChunk func(string),
-	onThinking func(string),
-) (agent.Reply, error) {
-	if s.p == nil {
-		return agent.Reply{}, errors.New("providerSender: provider is nil")
-	}
-	req := provider.Request{
-		Model:           model,
-		SystemPrompt:    system,
-		Messages:        msgs,
-		MaxTokens:       maxTokens,
-		CacheKey:        s.cacheKey,
-		ThinkingBudget:  s.thinkingBudget,
-		ReasoningEffort: s.reasoningEffort,
-	}
-	if sp, ok := s.p.(provider.StreamingProvider); ok {
-		resp, err := sp.SendStream(ctx, req, provider.StreamCallbacks{
-			OnText:     onChunk,
-			OnThinking: s.reasoningSink(onThinking),
-		})
-		if err != nil {
-			return agent.Reply{}, err
-		}
-		return replyFromResponse(resp), nil
-	}
-
-	resp, err := s.p.Send(ctx, req)
-	if err != nil {
-		return agent.Reply{}, err
-	}
-	if onChunk != nil && resp.Content != "" {
-		onChunk(resp.Content)
-	}
-	return replyFromResponse(resp), nil
-}
-
-func replyFromResponse(resp provider.Response) agent.Reply {
-	return agent.Reply{
-		Content:          resp.Content,
-		Blocks:           resp.Blocks,
-		Model:            resp.Model,
-		StopReason:       resp.StopReason,
-		InputTokens:      resp.InputTokens,
-		OutputTokens:     resp.OutputTokens,
-		CacheReadTokens:  resp.CacheReadTokens,
-		CacheWriteTokens: resp.CacheWriteTokens,
-	}
-}
-
-// SendMessagesWithTools implements agent.ToolSender. It passes the tool
-// definitions to the provider via provider.Request.Tools and returns the full
-// content-block list (including tool_use blocks) in the Reply.
-func (s providerSender) SendMessagesWithTools(
-	ctx context.Context,
-	model, system string,
-	msgs []agent.Message,
-	maxTokens int,
-	tools []agent.ToolDefinition,
-) (agent.Reply, error) {
-	if s.p == nil {
-		return agent.Reply{}, errors.New("providerSender: provider is nil")
-	}
-	resp, err := s.p.Send(ctx, provider.Request{
-		Model:           model,
-		SystemPrompt:    system,
-		Messages:        msgs,
-		MaxTokens:       maxTokens,
-		CacheKey:        s.cacheKey,
-		Tools:           tools,
-		ThinkingBudget:  s.thinkingBudget,
-		ReasoningEffort: s.reasoningEffort,
-	})
-	if err != nil {
-		return agent.Reply{}, err
-	}
-	return replyFromResponse(resp), nil
-}
-
-// StreamMessagesWithTools implements agent.ToolStreamingSender. It passes
-// tools to the provider and streams text deltas via onChunk; tool_use blocks
-// are accumulated and returned in Reply.Blocks at the end of the stream.
-func (s providerSender) StreamMessagesWithTools(
-	ctx context.Context,
-	model, system string,
-	msgs []agent.Message,
-	maxTokens int,
-	tools []agent.ToolDefinition,
-	onChunk func(string),
-	onToolDelta agent.ToolInputDeltaFunc,
-	onThinking agent.ThinkingDeltaFunc,
-) (agent.Reply, error) {
-	if s.p == nil {
-		return agent.Reply{}, errors.New("providerSender: provider is nil")
-	}
-	req := provider.Request{
-		Model:           model,
-		SystemPrompt:    system,
-		Messages:        msgs,
-		MaxTokens:       maxTokens,
-		CacheKey:        s.cacheKey,
-		Tools:           tools,
-		ThinkingBudget:  s.thinkingBudget,
-		ReasoningEffort: s.reasoningEffort,
-	}
-	if sp, ok := s.p.(provider.StreamingProvider); ok {
-		// Callbacks are forwarded straight through. provider.StreamCallbacks is
-		// a per-event union — reasoning streams first, then text and tool-input
-		// deltas interleave. Dim styling for the reasoning trace lives in the
-		// view; reasoningSink drops it entirely when display is off.
-		resp, err := sp.SendStream(ctx, req, provider.StreamCallbacks{
-			OnText:      onChunk,
-			OnToolDelta: onToolDelta,
-			OnThinking:  s.reasoningSink(onThinking),
-		})
-		if err != nil {
-			return agent.Reply{}, err
-		}
-		return replyFromResponse(resp), nil
-	}
-
-	// Buffered fallback.
-	resp, err := s.p.Send(ctx, req)
-	if err != nil {
-		return agent.Reply{}, err
-	}
-	if onChunk != nil && resp.Content != "" {
-		onChunk(resp.Content)
-	}
-	return replyFromResponse(resp), nil
-}
-
-// Compile-time assertions: providerSender satisfies all agent sender interfaces.
-var (
-	_ agent.Sender              = providerSender{}
-	_ agent.StreamingSender     = providerSender{}
-	_ agent.ToolSender          = providerSender{}
-	_ agent.ToolStreamingSender = providerSender{}
-)

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,7 +13,6 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/config"
-	"github.com/Leihb/octo-agent/internal/provider"
 )
 
 // TestRunChat_NoArgs_NoStdin_Errors verifies the headless routing: with no
@@ -349,201 +346,6 @@ func TestRunChat_UnknownProvider(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "unknown provider") {
 		t.Errorf("stderr should mention unknown provider; got: %q", stderr.String())
-	}
-}
-
-func TestRunChat_EndToEnd(t *testing.T) {
-	// httptest server impersonating Anthropic — proves the full chain
-	// (cmd → adapter → provider → HTTP) is wired correctly.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{
-			"id":"msg_test",
-			"type":"message",
-			"role":"assistant",
-			"model":"claude-haiku-4-5-20251001",
-			"content":[{"type":"text","text":"pong"}],
-			"stop_reason":"end_turn",
-			"usage":{"input_tokens":3,"output_tokens":1}
-		}`))
-	}))
-	defer srv.Close()
-
-	// Override the Anthropic endpoint via env-derived plumbing: chat.go
-	// constructs the client itself, so we test end-to-end via the lower-level
-	// provider+adapter+agent chain rather than through runChat. (runChat's
-	// other paths are covered by the surrounding tests.)
-	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-
-	// Use the providerSender adapter directly to exercise the wiring.
-	fake := &mockProvider{reply: provider.Response{
-		Content: "pong", Model: "m", StopReason: "end_turn",
-	}}
-	a := agent.New(providerSender{p: fake}, "claude-haiku-4-5-20251001")
-	reply, err := a.Turn(context.Background(), "ping")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reply.Content != "pong" {
-		t.Errorf("Content = %q, want pong", reply.Content)
-	}
-	if fake.gotReq.Model != "claude-haiku-4-5-20251001" {
-		t.Errorf("model passed through = %q", fake.gotReq.Model)
-	}
-	if len(fake.gotReq.Messages) != 1 || fake.gotReq.Messages[0].Content != "ping" {
-		t.Errorf("messages passed through = %+v", fake.gotReq.Messages)
-	}
-}
-
-func TestProviderSender_NilProvider(t *testing.T) {
-	s := providerSender{p: nil}
-	if _, err := s.SendMessages(context.Background(), "m", "", nil, 0); err == nil {
-		t.Error("expected error for nil provider")
-	}
-}
-
-func TestProviderSender_ProviderError_Surfaces(t *testing.T) {
-	fake := &mockProvider{err: errors.New("upstream boom")}
-	s := providerSender{p: fake}
-	_, err := s.SendMessages(context.Background(), "m", "", []agent.Message{agent.NewUserMessage("hi")}, 0)
-	if err == nil || !strings.Contains(err.Error(), "upstream boom") {
-		t.Errorf("expected upstream error, got: %v", err)
-	}
-}
-
-// mockProvider implements provider.Provider for tests.
-type mockProvider struct {
-	reply  provider.Response
-	err    error
-	gotReq provider.Request
-}
-
-func (m *mockProvider) Name() string { return "mock" }
-
-func (m *mockProvider) Send(_ context.Context, req provider.Request) (provider.Response, error) {
-	m.gotReq = req
-	return m.reply, m.err
-}
-
-// streamingMockProvider also implements provider.StreamingProvider so we can
-// verify providerSender.StreamMessages picks the streaming path when the
-// underlying provider supports it.
-type streamingMockProvider struct {
-	mockProvider
-	deltas       []string
-	thinkDeltas  []string
-	streamReply  provider.Response
-	streamCalled bool
-	// onThinkingSet records whether the caller wired an OnThinking callback —
-	// providerSender drops it when reasoning display is off.
-	onThinkingSet bool
-}
-
-func (m *streamingMockProvider) SendStream(_ context.Context, req provider.Request, cb provider.StreamCallbacks) (provider.Response, error) {
-	m.streamCalled = true
-	m.gotReq = req
-	m.onThinkingSet = cb.OnThinking != nil
-	for _, d := range m.thinkDeltas {
-		if cb.OnThinking != nil {
-			cb.OnThinking(d)
-		}
-	}
-	for _, d := range m.deltas {
-		if cb.OnText != nil {
-			cb.OnText(d)
-		}
-	}
-	if m.err != nil {
-		return provider.Response{}, m.err
-	}
-	return m.streamReply, nil
-}
-
-func TestProviderSender_ReasoningSink_Gating(t *testing.T) {
-	cases := []struct {
-		name          string
-		showReasoning bool
-		onThinking    func(string)
-		wantForwarded bool // whether the provider received a non-nil OnThinking
-	}{
-		{"on + handler → forwarded", true, func(string) {}, true},
-		{"off → dropped", false, func(string) {}, false},
-		{"on but nil handler → nil", true, nil, false},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			fake := &streamingMockProvider{
-				thinkDeltas: []string{"reasoning"},
-				streamReply: provider.Response{Content: "ok", StopReason: "end_turn"},
-			}
-			s := providerSender{p: fake, showReasoning: c.showReasoning}
-			var got []string
-			_, err := s.StreamMessages(
-				context.Background(), "m", "",
-				[]agent.Message{agent.NewUserMessage("hi")}, 0,
-				func(string) {},
-				c.onThinking,
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if fake.onThinkingSet != c.wantForwarded {
-				t.Errorf("provider OnThinking set = %v, want %v", fake.onThinkingSet, c.wantForwarded)
-			}
-			_ = got
-		})
-	}
-}
-
-func TestProviderSender_StreamingPathPreferred(t *testing.T) {
-	fake := &streamingMockProvider{
-		deltas:      []string{"hi ", "there"},
-		streamReply: provider.Response{Content: "hi there", Model: "m", StopReason: "end_turn"},
-	}
-	s := providerSender{p: fake}
-
-	var got []string
-	reply, err := s.StreamMessages(
-		context.Background(), "m", "",
-		[]agent.Message{agent.NewUserMessage("hi")}, 0,
-		func(d string) { got = append(got, d) },
-		nil,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !fake.streamCalled {
-		t.Error("expected SendStream to be called when provider supports it")
-	}
-	if reply.Content != "hi there" {
-		t.Errorf("Content = %q", reply.Content)
-	}
-	if len(got) != 2 || got[0] != "hi " || got[1] != "there" {
-		t.Errorf("chunks = %v", got)
-	}
-}
-
-func TestProviderSender_StreamingFallback_NonStreamingProvider(t *testing.T) {
-	// mockProvider only implements provider.Provider — not StreamingProvider.
-	// providerSender.StreamMessages must fall back to Send and synthesise
-	// a single onChunk call with the full content.
-	fake := &mockProvider{reply: provider.Response{Content: "buffered"}}
-	s := providerSender{p: fake}
-
-	var got []string
-	reply, err := s.StreamMessages(
-		context.Background(), "m", "",
-		[]agent.Message{agent.NewUserMessage("hi")}, 0,
-		func(d string) { got = append(got, d) },
-		nil,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reply.Content != "buffered" {
-		t.Errorf("Content = %q", reply.Content)
-	}
-	if len(got) != 1 || got[0] != "buffered" {
-		t.Errorf("fallback should emit one chunk with full content; got %v", got)
 	}
 }
 

--- a/cmd/octo/conduct.go
+++ b/cmd/octo/conduct.go
@@ -368,11 +368,11 @@ func buildConductAgent(f conductFlags, stdout, stderr io.Writer) (*agent.Agent, 
 		fmt.Fprintf(stderr, "octo conduct: unknown provider %q (use 'anthropic' or 'openai')\n", provName)
 		return nil, func() {}, 2
 	}
-	prov, err := buildProvider(provName, cfg, stderr)
+	llmSender, err := buildSender(provName, cfg, stderr, senderTuning{})
 	if err != nil {
 		return nil, func() {}, 1
 	}
-	a := agent.New(providerSender{p: prov, cacheKey: newCacheKey()}, resolvedModel)
+	a := agent.New(llmSender, resolvedModel)
 	a.MaxTokens = defaultMaxTokensForPlanner
 	cwd, _ := os.Getwd()
 	a.CWD = cwd

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/config"
-	"github.com/Leihb/octo-agent/internal/provider/anthropic"
-	"github.com/Leihb/octo-agent/internal/provider/openai"
 )
 
 // firstNonEmpty returns the first non-empty string, or "" if all are empty.
@@ -93,11 +92,8 @@ func effectiveEndpoint(provider string, cfg config.Config) string {
 	if u := resolveBaseURL(provider, cfg); u != "" {
 		return u
 	}
-	switch provider {
-	case providerAnthropic:
-		return anthropic.DefaultBaseURL + " (default)"
-	case providerOpenAI:
-		return openai.DefaultBaseURL + " (default)"
+	if def := app.DefaultBaseURL(provider); def != "" {
+		return def + " (default)"
 	}
 	return "(default)"
 }

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -63,7 +63,7 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	prov, err := buildProvider(provName, cfg, stderr)
+	llmSender, err := buildSender(provName, cfg, stderr, senderTuning{})
 	if err != nil {
 		return 1
 	}
@@ -78,7 +78,7 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 	}
 
-	a := agent.New(providerSender{p: prov, cacheKey: newCacheKey()}, resolvedModel)
+	a := agent.New(llmSender, resolvedModel)
 	a.System = prompt.Compose("", cwd, env, "", "", true) // init is a one-shot task; no skills/memory
 
 	engine, err := permission.New(permissionConfigPath(), cwd, resolvePermissionMode(*permMode))

--- a/internal/app/sender.go
+++ b/internal/app/sender.go
@@ -1,0 +1,285 @@
+// Package app is the single place that constructs provider clients and wires
+// them into an agent. CLI, HTTP server, and IM bridge all bootstrap through
+// here, so the provider wire packages are imported in exactly one spot and the
+// one-directional dependency graph (provider → agent) stays intact.
+//
+// This file owns provider-client construction and the provider.Provider →
+// agent.Sender adapter. Higher-level session assembly (executor, gate, MCP,
+// sub-agents) lands in bootstrap.go as the migration proceeds.
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/provider"
+	"github.com/Leihb/octo-agent/internal/provider/anthropic"
+	"github.com/Leihb/octo-agent/internal/provider/openai"
+)
+
+// Provider name constants accepted by NewSender. They match the vendor strings
+// the CLI/server already resolve, so callers can pass their resolved name
+// through unchanged.
+const (
+	ProviderAnthropic = "anthropic"
+	ProviderOpenAI    = "openai"
+)
+
+// SenderOptions is everything needed to build an agent.Sender for a vendor.
+// Key resolution and any user-facing help text stay with the caller (a CLI
+// prints setup hints; a server returns an error) — this layer only constructs.
+type SenderOptions struct {
+	Provider string // ProviderAnthropic | ProviderOpenAI
+	APIKey   string
+	BaseURL  string // optional endpoint override; empty uses the vendor default
+
+	// CacheKey is forwarded as the provider's prompt-cache key, stable across a
+	// conversation's turns so the backend routes them to the same cache.
+	CacheKey string
+	// ThinkingBudget > 0 enables Anthropic extended thinking with this trace
+	// budget; ignored by OpenAI.
+	ThinkingBudget int
+	// ReasoningEffort ("low"|"medium"|"high") is forwarded to OpenAI as
+	// reasoning_effort; ignored by Anthropic (which uses ThinkingBudget).
+	ReasoningEffort string
+	// ShowReasoning gates whether the reasoning/thinking trace is surfaced to
+	// the agent event stream.
+	ShowReasoning bool
+}
+
+// NewSender builds the provider client for opts and wraps it as an agent.Sender.
+// It is the single entry point through which every transport obtains a sender.
+func NewSender(opts SenderOptions) (agent.Sender, error) {
+	p, err := buildClient(opts.Provider, opts.APIKey, opts.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	return sender{
+		p:               p,
+		cacheKey:        opts.CacheKey,
+		thinkingBudget:  opts.ThinkingBudget,
+		reasoningEffort: opts.ReasoningEffort,
+		showReasoning:   opts.ShowReasoning,
+	}, nil
+}
+
+// DefaultBaseURL returns the vendor's built-in API endpoint for the given
+// provider, or "" for an unknown one. Exposed so callers can show the
+// effective endpoint without importing the vendor packages themselves.
+func DefaultBaseURL(providerName string) string {
+	switch providerName {
+	case ProviderAnthropic:
+		return anthropic.DefaultBaseURL
+	case ProviderOpenAI:
+		return openai.DefaultBaseURL
+	}
+	return ""
+}
+
+// buildClient constructs the vendor client and applies an optional base-URL
+// override. The caller is responsible for having resolved a non-empty key.
+func buildClient(name, apiKey, baseURL string) (provider.Provider, error) {
+	switch name {
+	case ProviderAnthropic:
+		client, err := anthropic.New(apiKey)
+		if err != nil {
+			return nil, err
+		}
+		if baseURL != "" {
+			client.BaseURL = baseURL
+		}
+		return client, nil
+	case ProviderOpenAI:
+		client, err := openai.New(apiKey)
+		if err != nil {
+			return nil, err
+		}
+		if baseURL != "" {
+			client.BaseURL = baseURL
+		}
+		return client, nil
+	default:
+		return nil, fmt.Errorf("unknown provider %q", name)
+	}
+}
+
+// sender adapts a provider.Provider into agent.Sender. Keeping the adapter here
+// means the agent package never imports provider — a one-directional dep graph
+// that pays off as more provider implementations land.
+type sender struct {
+	p               provider.Provider
+	cacheKey        string
+	thinkingBudget  int
+	reasoningEffort string
+	showReasoning   bool
+}
+
+// reasoningSink returns the OnThinking callback to hand the provider: the
+// agent's onThinking when reasoning display is enabled, else nil so the
+// provider skips surfacing reasoning entirely.
+func (s sender) reasoningSink(onThinking func(string)) func(string) {
+	if !s.showReasoning || onThinking == nil {
+		return nil
+	}
+	return onThinking
+}
+
+func (s sender) SendMessages(ctx context.Context, model, system string, msgs []agent.Message, maxTokens int) (agent.Reply, error) {
+	if s.p == nil {
+		return agent.Reply{}, errors.New("app: provider is nil")
+	}
+	resp, err := s.p.Send(ctx, provider.Request{
+		Model:           model,
+		SystemPrompt:    system,
+		Messages:        msgs,
+		MaxTokens:       maxTokens,
+		CacheKey:        s.cacheKey,
+		ThinkingBudget:  s.thinkingBudget,
+		ReasoningEffort: s.reasoningEffort,
+	})
+	if err != nil {
+		return agent.Reply{}, err
+	}
+	return replyFromResponse(resp), nil
+}
+
+// StreamMessages delegates to the provider's SendStream when it implements
+// provider.StreamingProvider, else falls back to the buffered Send path and
+// synthesises a single onChunk call with the full content.
+func (s sender) StreamMessages(
+	ctx context.Context,
+	model, system string,
+	msgs []agent.Message,
+	maxTokens int,
+	onChunk func(string),
+	onThinking func(string),
+) (agent.Reply, error) {
+	if s.p == nil {
+		return agent.Reply{}, errors.New("app: provider is nil")
+	}
+	req := provider.Request{
+		Model:           model,
+		SystemPrompt:    system,
+		Messages:        msgs,
+		MaxTokens:       maxTokens,
+		CacheKey:        s.cacheKey,
+		ThinkingBudget:  s.thinkingBudget,
+		ReasoningEffort: s.reasoningEffort,
+	}
+	if sp, ok := s.p.(provider.StreamingProvider); ok {
+		resp, err := sp.SendStream(ctx, req, provider.StreamCallbacks{
+			OnText:     onChunk,
+			OnThinking: s.reasoningSink(onThinking),
+		})
+		if err != nil {
+			return agent.Reply{}, err
+		}
+		return replyFromResponse(resp), nil
+	}
+
+	resp, err := s.p.Send(ctx, req)
+	if err != nil {
+		return agent.Reply{}, err
+	}
+	if onChunk != nil && resp.Content != "" {
+		onChunk(resp.Content)
+	}
+	return replyFromResponse(resp), nil
+}
+
+// SendMessagesWithTools implements agent.ToolSender.
+func (s sender) SendMessagesWithTools(
+	ctx context.Context,
+	model, system string,
+	msgs []agent.Message,
+	maxTokens int,
+	toolDefs []agent.ToolDefinition,
+) (agent.Reply, error) {
+	if s.p == nil {
+		return agent.Reply{}, errors.New("app: provider is nil")
+	}
+	resp, err := s.p.Send(ctx, provider.Request{
+		Model:           model,
+		SystemPrompt:    system,
+		Messages:        msgs,
+		MaxTokens:       maxTokens,
+		CacheKey:        s.cacheKey,
+		Tools:           toolDefs,
+		ThinkingBudget:  s.thinkingBudget,
+		ReasoningEffort: s.reasoningEffort,
+	})
+	if err != nil {
+		return agent.Reply{}, err
+	}
+	return replyFromResponse(resp), nil
+}
+
+// StreamMessagesWithTools implements agent.ToolStreamingSender.
+func (s sender) StreamMessagesWithTools(
+	ctx context.Context,
+	model, system string,
+	msgs []agent.Message,
+	maxTokens int,
+	toolDefs []agent.ToolDefinition,
+	onChunk func(string),
+	onToolDelta agent.ToolInputDeltaFunc,
+	onThinking agent.ThinkingDeltaFunc,
+) (agent.Reply, error) {
+	if s.p == nil {
+		return agent.Reply{}, errors.New("app: provider is nil")
+	}
+	req := provider.Request{
+		Model:           model,
+		SystemPrompt:    system,
+		Messages:        msgs,
+		MaxTokens:       maxTokens,
+		CacheKey:        s.cacheKey,
+		Tools:           toolDefs,
+		ThinkingBudget:  s.thinkingBudget,
+		ReasoningEffort: s.reasoningEffort,
+	}
+	if sp, ok := s.p.(provider.StreamingProvider); ok {
+		resp, err := sp.SendStream(ctx, req, provider.StreamCallbacks{
+			OnText:      onChunk,
+			OnToolDelta: onToolDelta,
+			OnThinking:  s.reasoningSink(onThinking),
+		})
+		if err != nil {
+			return agent.Reply{}, err
+		}
+		return replyFromResponse(resp), nil
+	}
+
+	// Buffered fallback.
+	resp, err := s.p.Send(ctx, req)
+	if err != nil {
+		return agent.Reply{}, err
+	}
+	if onChunk != nil && resp.Content != "" {
+		onChunk(resp.Content)
+	}
+	return replyFromResponse(resp), nil
+}
+
+func replyFromResponse(resp provider.Response) agent.Reply {
+	return agent.Reply{
+		Content:          resp.Content,
+		Blocks:           resp.Blocks,
+		Model:            resp.Model,
+		StopReason:       resp.StopReason,
+		InputTokens:      resp.InputTokens,
+		OutputTokens:     resp.OutputTokens,
+		CacheReadTokens:  resp.CacheReadTokens,
+		CacheWriteTokens: resp.CacheWriteTokens,
+	}
+}
+
+// Compile-time assertions: sender satisfies all agent sender interfaces.
+var (
+	_ agent.Sender              = sender{}
+	_ agent.StreamingSender     = sender{}
+	_ agent.ToolSender          = sender{}
+	_ agent.ToolStreamingSender = sender{}
+)

--- a/internal/app/sender_test.go
+++ b/internal/app/sender_test.go
@@ -1,0 +1,188 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/provider"
+)
+
+func TestSender_PassesRequestThrough(t *testing.T) {
+	fake := &mockProvider{reply: provider.Response{
+		Content: "pong", Model: "m", StopReason: "end_turn",
+	}}
+	a := agent.New(sender{p: fake}, "claude-haiku-4-5-20251001")
+	reply, err := a.Turn(context.Background(), "ping")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply.Content != "pong" {
+		t.Errorf("Content = %q, want pong", reply.Content)
+	}
+	if fake.gotReq.Model != "claude-haiku-4-5-20251001" {
+		t.Errorf("model passed through = %q", fake.gotReq.Model)
+	}
+	if len(fake.gotReq.Messages) != 1 || fake.gotReq.Messages[0].Content != "ping" {
+		t.Errorf("messages passed through = %+v", fake.gotReq.Messages)
+	}
+}
+
+func TestSender_NilProvider(t *testing.T) {
+	s := sender{p: nil}
+	if _, err := s.SendMessages(context.Background(), "m", "", nil, 0); err == nil {
+		t.Error("expected error for nil provider")
+	}
+}
+
+func TestSender_ProviderError_Surfaces(t *testing.T) {
+	fake := &mockProvider{err: errors.New("upstream boom")}
+	s := sender{p: fake}
+	_, err := s.SendMessages(context.Background(), "m", "", []agent.Message{agent.NewUserMessage("hi")}, 0)
+	if err == nil || !strings.Contains(err.Error(), "upstream boom") {
+		t.Errorf("expected upstream error, got: %v", err)
+	}
+}
+
+// mockProvider implements provider.Provider for tests.
+type mockProvider struct {
+	reply  provider.Response
+	err    error
+	gotReq provider.Request
+}
+
+func (m *mockProvider) Name() string { return "mock" }
+
+func (m *mockProvider) Send(_ context.Context, req provider.Request) (provider.Response, error) {
+	m.gotReq = req
+	return m.reply, m.err
+}
+
+// streamingMockProvider also implements provider.StreamingProvider so we can
+// verify sender.StreamMessages picks the streaming path when the underlying
+// provider supports it.
+type streamingMockProvider struct {
+	mockProvider
+	deltas       []string
+	thinkDeltas  []string
+	streamReply  provider.Response
+	streamCalled bool
+	// onThinkingSet records whether the caller wired an OnThinking callback —
+	// sender drops it when reasoning display is off.
+	onThinkingSet bool
+}
+
+func (m *streamingMockProvider) SendStream(_ context.Context, req provider.Request, cb provider.StreamCallbacks) (provider.Response, error) {
+	m.streamCalled = true
+	m.gotReq = req
+	m.onThinkingSet = cb.OnThinking != nil
+	for _, d := range m.thinkDeltas {
+		if cb.OnThinking != nil {
+			cb.OnThinking(d)
+		}
+	}
+	for _, d := range m.deltas {
+		if cb.OnText != nil {
+			cb.OnText(d)
+		}
+	}
+	if m.err != nil {
+		return provider.Response{}, m.err
+	}
+	return m.streamReply, nil
+}
+
+func TestSender_ReasoningSink_Gating(t *testing.T) {
+	cases := []struct {
+		name          string
+		showReasoning bool
+		onThinking    func(string)
+		wantForwarded bool // whether the provider received a non-nil OnThinking
+	}{
+		{"on + handler → forwarded", true, func(string) {}, true},
+		{"off → dropped", false, func(string) {}, false},
+		{"on but nil handler → nil", true, nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fake := &streamingMockProvider{
+				thinkDeltas: []string{"reasoning"},
+				streamReply: provider.Response{Content: "ok", StopReason: "end_turn"},
+			}
+			s := sender{p: fake, showReasoning: c.showReasoning}
+			_, err := s.StreamMessages(
+				context.Background(), "m", "",
+				[]agent.Message{agent.NewUserMessage("hi")}, 0,
+				func(string) {},
+				c.onThinking,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if fake.onThinkingSet != c.wantForwarded {
+				t.Errorf("provider OnThinking set = %v, want %v", fake.onThinkingSet, c.wantForwarded)
+			}
+		})
+	}
+}
+
+func TestSender_StreamingPathPreferred(t *testing.T) {
+	fake := &streamingMockProvider{
+		deltas:      []string{"hi ", "there"},
+		streamReply: provider.Response{Content: "hi there", Model: "m", StopReason: "end_turn"},
+	}
+	s := sender{p: fake}
+
+	var got []string
+	reply, err := s.StreamMessages(
+		context.Background(), "m", "",
+		[]agent.Message{agent.NewUserMessage("hi")}, 0,
+		func(d string) { got = append(got, d) },
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fake.streamCalled {
+		t.Error("expected SendStream to be called when provider supports it")
+	}
+	if reply.Content != "hi there" {
+		t.Errorf("Content = %q", reply.Content)
+	}
+	if len(got) != 2 || got[0] != "hi " || got[1] != "there" {
+		t.Errorf("chunks = %v", got)
+	}
+}
+
+func TestSender_StreamingFallback_NonStreamingProvider(t *testing.T) {
+	// mockProvider only implements provider.Provider — not StreamingProvider.
+	// sender.StreamMessages must fall back to Send and synthesise a single
+	// onChunk call with the full content.
+	fake := &mockProvider{reply: provider.Response{Content: "buffered"}}
+	s := sender{p: fake}
+
+	var got []string
+	reply, err := s.StreamMessages(
+		context.Background(), "m", "",
+		[]agent.Message{agent.NewUserMessage("hi")}, 0,
+		func(d string) { got = append(got, d) },
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply.Content != "buffered" {
+		t.Errorf("Content = %q", reply.Content)
+	}
+	if len(got) != 1 || got[0] != "buffered" {
+		t.Errorf("fallback should emit one chunk with full content; got %v", got)
+	}
+}
+
+func TestNewSender_UnknownProvider(t *testing.T) {
+	if _, err := NewSender(SenderOptions{Provider: "nope", APIKey: "k"}); err == nil {
+		t.Error("expected error for unknown provider")
+	}
+}


### PR DESCRIPTION
First step of the unified-bootstrap effort (design: `dev-docs/unified-session-bootstrap.md`, merged in #386). Gives provider-client construction one home so the three entry points stop duplicating it.

## What moves
- **New `internal/app`** — `NewSender(SenderOptions) (agent.Sender, error)` builds the vendor client (anthropic/openai) + applies a base-URL override + wraps it in the `provider.Provider → agent.Sender` adapter. `DefaultBaseURL` exposes the vendor endpoints for the verbose display. The old `providerSender` adapter and `replyFromResponse` move here verbatim (renamed `sender`).
- **`cmd/octo`** — `buildProvider` splits into `resolveAPIKey` (key resolution + the CLI setup-help text, which stays a CLI concern) and `buildSender` (delegates to `app.NewSender`). All four call sites migrate: chat, channel (IM), init, conduct.
- Adapter tests move to `internal/app/sender_test.go` next to the code.

## Why it matters
`cmd/octo` **no longer imports `internal/provider` or the vendor packages at all** — `config.go`'s endpoint display now goes through `app.DefaultBaseURL`. This restores the one-directional dependency the server had already broken by copying the provider builder. `.octorules` is updated: `internal/app` is the single provider-construction site; `internal/server`'s duplicate is flagged as pending migration (PR2).

## Scope
Behavior-preserving foundation only. The full `app.Bootstrap` (executor + gate + MCP + sub-agents/tasks assembly) and the CLI's migration onto it are **PR1b**; server and IM migrations are PR2/PR3. Splitting it this way keeps each diff reviewable.

`go test -race ./...`, `go vet`, and `make fmt-check` all green.