### PR TITLE
refactor(app): unify the permission gate in internal/app (PR1b-1)

### DIFF
--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -87,7 +87,7 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 1
 	}
 	initView := newPlainView(newScannerLineReader(stdin, stdout), stdout, stderr, verbosityNormal, *plain)
-	a.Gate = &cliPermissionGate{engine: engine, ask: initView}
+	a.Gate = newCLIGate(engine, initView)
 
 	fmt.Fprintln(stdout, "Analyzing the repository to generate .octorules…")
 	handler := replToolEventHandler(stdout, *plain)

--- a/cmd/octo/permission_gate.go
+++ b/cmd/octo/permission_gate.go
@@ -2,59 +2,36 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/permission"
-	"github.com/Leihb/octo-agent/internal/tools"
 )
 
-// cliPermissionGate adapts a permission.Engine into an agent.PermissionGate.
-// It resolves allow/deny verdicts directly and, for ask verdicts in
-// interactive mode, raises a KindPermission prompt through the view (stdin
-// line today, modal in the TUI) and maps the structured answer.
-//
-// In strict mode the engine has already collapsed ask → deny, so the prompt
-// path is never reached — Check just returns the denial with its reason.
-type cliPermissionGate struct {
-	engine *permission.Engine
-	ask    userPrompter // the view; raises the approval prompt
+// newCLIGate builds the shared app permission gate wired to an interactive
+// prompter: ask-class verdicts raise a KindPermission prompt through the view
+// (stdin line today, modal in the TUI) and map the structured answer. A nil
+// prompter yields a non-interactive gate (ask → deny). In strict mode the
+// engine has already collapsed ask → deny, so the prompt path is never reached.
+func newCLIGate(engine *permission.Engine, ask userPrompter) agent.PermissionGate {
+	return app.NewPermissionGate(engine, permissionAskFrom(ask))
 }
 
-// Check implements agent.PermissionGate.
-func (g *cliPermissionGate) Check(ctx context.Context, name string, input map[string]any) (bool, string) {
-	// A Tool Search tool_call wraps the real MCP tool — evaluate policy and
-	// prompt against that real tool, not the "tool_call" bridge, so per-tool
-	// allow/deny rules and the approval prompt show the right name.
-	if real, realInput, ok := tools.ToolCallTarget(name, input); ok {
-		name, input = real, realInput
+// permissionAskFrom adapts a userPrompter (the view) into an app.PermissionAsk.
+// A nil prompter returns nil, which the gate treats as non-interactive.
+func permissionAskFrom(ask userPrompter) app.PermissionAsk {
+	if ask == nil {
+		return nil
 	}
-	switch g.engine.Check(name, input) {
-	case permission.Allow:
-		return true, ""
-	case permission.Deny:
-		return false, g.engine.DenialReason(name, input)
-	case permission.Ask:
-		return g.prompt(ctx, name, input)
+	return func(ctx context.Context, name string, input map[string]any) (bool, bool, error) {
+		resp, err := ask.Ask(ctx, UserPrompt{Kind: KindPermission, ToolName: name, ToolInput: input})
+		if err != nil {
+			return false, false, err
+		}
+		return resp.Allow, resp.Always, nil
 	}
-	return false, g.engine.DenialReason(name, input)
-}
-
-// prompt raises the approval request and maps the answer: allow once, allow +
-// remember for the session, or deny (incl. empty / no view).
-func (g *cliPermissionGate) prompt(ctx context.Context, name string, input map[string]any) (bool, string) {
-	if g.ask == nil {
-		return false, fmt.Sprintf("permission_denied: user declined to run %s", name)
-	}
-	resp, err := g.ask.Ask(ctx, UserPrompt{Kind: KindPermission, ToolName: name, ToolInput: input})
-	if err != nil || !resp.Allow {
-		return false, fmt.Sprintf("permission_denied: user declined to run %s", name)
-	}
-	if resp.Always {
-		g.engine.Remember(name, input, permission.Allow)
-	}
-	return true, ""
 }
 
 // permissionConfigPath returns ~/.octo/permissions.yml. An empty string is

--- a/cmd/octo/permission_gate_test.go
+++ b/cmd/octo/permission_gate_test.go
@@ -6,10 +6,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/permission"
 )
 
-func newGate(t *testing.T, mode permission.Mode, stdin string) (*cliPermissionGate, *bytes.Buffer) {
+// newGate builds the CLI-wired shared gate over a scripted-stdin plain view, so
+// these tests exercise newCLIGate + the userPrompter→PermissionAsk adapter end
+// to end (the gate's pure policy logic is covered in internal/app/gate_test.go).
+func newGate(t *testing.T, mode permission.Mode, stdin string) (agent.PermissionGate, *bytes.Buffer) {
 	t.Helper()
 	eng, err := permission.New("", "/work", mode)
 	if err != nil {
@@ -17,11 +21,7 @@ func newGate(t *testing.T, mode permission.Mode, stdin string) (*cliPermissionGa
 	}
 	var out bytes.Buffer
 	view := newPlainView(newScannerLineReader(strings.NewReader(stdin), &out), &out, &out, verbosityNormal, false)
-	g := &cliPermissionGate{
-		engine: eng,
-		ask:    view,
-	}
-	return g, &out
+	return newCLIGate(eng, view), &out
 }
 
 func TestCLIGate_AllowPassesThrough(t *testing.T) {

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -121,7 +121,7 @@ func runOnce(cfg replConfig, prompt string, stream bool) int {
 		view = newPlainView(cfg.reader, cfg.stdout, cfg.stderr, cfg.verbosity, cfg.plain)
 	}
 	if cfg.permEngine != nil {
-		a.Gate = &cliPermissionGate{engine: cfg.permEngine, ask: view}
+		a.Gate = newCLIGate(cfg.permEngine, view)
 	}
 
 	// SIGINT cancels the in-flight turn; the agent finalizes well-formed history

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -67,7 +67,7 @@ func runTUI(cfg replConfig) int {
 	// as modals on this event loop instead of reading stdin (which bubbletea
 	// owns). Overrides whatever the plain path wired.
 	if cfg.permEngine != nil {
-		cfg.a.Gate = &cliPermissionGate{engine: cfg.permEngine, ask: sink}
+		cfg.a.Gate = newCLIGate(cfg.permEngine, sink)
 	}
 	tools.SetAsker(newREPLAsker(sink))
 

--- a/internal/app/gate.go
+++ b/internal/app/gate.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/permission"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// PermissionAsk prompts the user to approve one tool call (already unwrapped to
+// its real tool name). It returns whether to allow the call and whether to
+// remember that decision for the rest of the session. A nil PermissionAsk makes
+// the gate non-interactive: ask-class verdicts resolve straight to deny.
+type PermissionAsk func(ctx context.Context, toolName string, toolInput map[string]any) (allow, remember bool, err error)
+
+// NewPermissionGate builds the single agent.PermissionGate every transport
+// uses. The engine resolves allow/deny/ask policy. Pass a non-nil ask for an
+// interactive transport (the CLI prompts the user on ask-class verdicts); pass
+// nil for a non-interactive one (HTTP server, IM bridge), where ask resolves to
+// deny — the same posture the old per-transport gates had.
+func NewPermissionGate(engine *permission.Engine, ask PermissionAsk) agent.PermissionGate {
+	return &permissionGate{engine: engine, ask: ask}
+}
+
+type permissionGate struct {
+	engine *permission.Engine
+	ask    PermissionAsk
+}
+
+// Check implements agent.PermissionGate.
+func (g *permissionGate) Check(ctx context.Context, name string, input map[string]any) (bool, string) {
+	// A Tool Search tool_call wraps the real MCP tool — evaluate policy (and
+	// prompt) against the wrapped tool, not the opaque "tool_call" bridge.
+	if real, realInput, ok := tools.ToolCallTarget(name, input); ok {
+		name, input = real, realInput
+	}
+	switch g.engine.Check(name, input) {
+	case permission.Allow:
+		return true, ""
+	case permission.Deny:
+		return false, g.engine.DenialReason(name, input)
+	case permission.Ask:
+		if g.ask == nil {
+			// Non-interactive: resolve ask → deny with the policy's reason.
+			return false, g.engine.DenialReason(name, input)
+		}
+		allow, remember, err := g.ask(ctx, name, input)
+		if err != nil || !allow {
+			return false, fmt.Sprintf("permission_denied: user declined to run %s", name)
+		}
+		if remember {
+			g.engine.Remember(name, input, permission.Allow)
+		}
+		return true, ""
+	}
+	return false, g.engine.DenialReason(name, input)
+}

--- a/internal/app/gate_test.go
+++ b/internal/app/gate_test.go
@@ -1,0 +1,129 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/permission"
+)
+
+func newEngine(t *testing.T, mode permission.Mode) *permission.Engine {
+	t.Helper()
+	eng, err := permission.New("", "/work", mode)
+	if err != nil {
+		t.Fatalf("permission.New: %v", err)
+	}
+	return eng
+}
+
+// allowAsk is a PermissionAsk that records calls and returns a fixed verdict.
+func recordingAsk(allow, remember bool, err error, calls *int) PermissionAsk {
+	return func(_ context.Context, _ string, _ map[string]any) (bool, bool, error) {
+		*calls++
+		return allow, remember, err
+	}
+}
+
+func TestGate_AllowPassesThrough(t *testing.T) {
+	calls := 0
+	g := NewPermissionGate(newEngine(t, permission.ModeInteractive), recordingAsk(true, false, nil, &calls))
+	ok, _ := g.Check(context.Background(), "terminal", map[string]any{"command": "ls"})
+	if !ok {
+		t.Error("ls should be allowed")
+	}
+	if calls != 0 {
+		t.Errorf("allow must not prompt; asked %d time(s)", calls)
+	}
+}
+
+func TestGate_DenyReturnsReason(t *testing.T) {
+	calls := 0
+	g := NewPermissionGate(newEngine(t, permission.ModeInteractive), recordingAsk(true, false, nil, &calls))
+	ok, reason := g.Check(context.Background(), "terminal", map[string]any{"command": "rm -rf /"})
+	if ok {
+		t.Error("rm -rf / must be denied")
+	}
+	if !strings.Contains(reason, "permission_denied") {
+		t.Errorf("expected structured denial reason, got %q", reason)
+	}
+	if calls != 0 {
+		t.Errorf("deny must not prompt; asked %d time(s)", calls)
+	}
+}
+
+func TestGate_AskInteractive_Allow(t *testing.T) {
+	calls := 0
+	g := NewPermissionGate(newEngine(t, permission.ModeInteractive), recordingAsk(true, false, nil, &calls))
+	ok, _ := g.Check(context.Background(), "terminal", map[string]any{"command": "sudo apt update"})
+	if !ok || calls != 1 {
+		t.Errorf("ask-class should prompt once and allow; ok=%v calls=%d", ok, calls)
+	}
+}
+
+func TestGate_AskInteractive_DeclineOrError(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		allow bool
+		err   error
+	}{
+		{"declined", false, nil},
+		{"error", false, errors.New("reader closed")},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			calls := 0
+			g := NewPermissionGate(newEngine(t, permission.ModeInteractive), recordingAsk(c.allow, false, c.err, &calls))
+			ok, reason := g.Check(context.Background(), "terminal", map[string]any{"command": "sudo apt update"})
+			if ok {
+				t.Error("decline/error must deny")
+			}
+			if !strings.Contains(reason, "declined") {
+				t.Errorf("reason should note the user declined, got %q", reason)
+			}
+		})
+	}
+}
+
+func TestGate_AskRemembers(t *testing.T) {
+	calls := 0
+	g := NewPermissionGate(newEngine(t, permission.ModeInteractive), recordingAsk(true, true, nil, &calls))
+	input := map[string]any{"command": "sudo apt update"}
+	if ok, _ := g.Check(context.Background(), "terminal", input); !ok {
+		t.Fatal("first ask should allow")
+	}
+	if ok, _ := g.Check(context.Background(), "terminal", input); !ok {
+		t.Error("remembered decision should allow on repeat")
+	}
+	if calls != 1 {
+		t.Errorf("second call should not prompt again; total asks=%d, want 1", calls)
+	}
+}
+
+func TestGate_NonInteractive_DeniesAsk(t *testing.T) {
+	// A nil PermissionAsk is the server/IM posture: ask-class verdicts deny
+	// without prompting, carrying the policy's reason.
+	g := NewPermissionGate(newEngine(t, permission.ModeInteractive), nil)
+	ok, reason := g.Check(context.Background(), "terminal", map[string]any{"command": "sudo apt update"})
+	if ok {
+		t.Error("non-interactive gate must deny ask-class commands")
+	}
+	if !strings.Contains(reason, "permission_denied") {
+		t.Errorf("expected denial reason, got %q", reason)
+	}
+}
+
+func TestGate_UnwrapsToolCall(t *testing.T) {
+	// A Tool Search tool_call must be evaluated against the wrapped tool name.
+	g := NewPermissionGate(newEngine(t, permission.ModeInteractive), nil)
+	ok, reason := g.Check(context.Background(), "tool_call", map[string]any{
+		"name":      "terminal",
+		"arguments": map[string]any{"command": "rm -rf /"},
+	})
+	if ok {
+		t.Error("tool_call wrapping rm -rf / must be denied via the unwrapped name")
+	}
+	if !strings.Contains(reason, "permission_denied") {
+		t.Errorf("expected denial reason, got %q", reason)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
@@ -298,7 +299,7 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 	if err != nil {
 		return "", fmt.Errorf("permission engine: %w", err)
 	}
-	a.Gate = &serverPermissionGate{engine: engine}
+	a.Gate = app.NewPermissionGate(engine, nil)
 
 	reply, err := a.Run(ctx, userInput, toolDefs, executor)
 	if err != nil {
@@ -307,31 +308,6 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 
 	sess.SyncFrom(a.History)
 	return reply.Content, nil
-}
-
-// serverPermissionGate adapts permission.Engine into agent.PermissionGate.
-// In server mode, "ask" resolves to "deny" (strict mode already does this,
-// but we double-check here for clarity).
-type serverPermissionGate struct {
-	engine *permission.Engine
-}
-
-func (g *serverPermissionGate) Check(ctx context.Context, name string, input map[string]any) (bool, string) {
-	// Keep parity with the CLI gate: if a Tool Search tool_call ever reaches the
-	// server (once MCP is wired here), evaluate policy against the wrapped real
-	// tool, not the opaque "tool_call" bridge.
-	if real, realInput, ok := tools.ToolCallTarget(name, input); ok {
-		name, input = real, realInput
-	}
-	switch g.engine.Check(name, input) {
-	case permission.Allow:
-		return true, ""
-	case permission.Deny:
-		return false, g.engine.DenialReason(name, input)
-	case permission.Ask:
-		return false, g.engine.DenialReason(name, input)
-	}
-	return false, g.engine.DenialReason(name, input)
 }
 
 func permissionConfigPath() string {

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
@@ -66,7 +67,7 @@ func (s *Server) handleTurnSSE(w http.ResponseWriter, r *http.Request) {
 		toolDefs = tools.DefaultTools()
 		engine, err := permission.New(permissionConfigPath(), s.cwd, permission.ModeStrict)
 		if err == nil {
-			a.Gate = &serverPermissionGate{engine: engine}
+			a.Gate = app.NewPermissionGate(engine, nil)
 		}
 	}
 


### PR DESCRIPTION
Next increment of the unified-bootstrap work (after #387). Collapses the two divergent permission gates — and the IM bridge's *missing* one — into a single implementation in `internal/app`.

## Before
- CLI: `cliPermissionGate` (ask → interactive prompt).
- Server: `serverPermissionGate` (ask → deny) — a second copy of the same switch.
- IM bridge: no gate at all.

## After
- **`app.NewPermissionGate(engine, ask)`** is the one `agent.PermissionGate`. A non-nil `PermissionAsk` → interactive (ask prompts, supports remember); `nil` → non-interactive (ask → deny). It unwraps a Tool Search `tool_call` to the real tool name before evaluating policy, exactly as both old gates did.
- **cmd/octo**: `cliPermissionGate` removed; `newCLIGate` wires the shared gate to the view via a `userPrompter → PermissionAsk` adapter; the three sites (init, repl, tui) migrate.
- **internal/server**: `serverPermissionGate` removed; both sites use `app.NewPermissionGate(engine, nil)`.

## Tests
Gate policy logic now has direct coverage in `internal/app/gate_test.go` (allow/deny/ask-allow/ask-decline/remember/non-interactive-deny/tool_call-unwrap). The cmd/octo test retargets to `newCLIGate`, so it still exercises the real scripted-stdin view + the adapter end to end.

Behavior-preserving for CLI and server. `go test -race ./...`, `go vet`, `make fmt-check` all green.

Next: `app.Bootstrap` assembles the full session (executor, spawner, tasks, MCP); the entries migrate onto it, at which point the IM bridge inherits this gate (its first permission enforcement).