### PR TITLE
refactor(app): move the sub-agent spawner into internal/app (PR1b-2)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -538,7 +538,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	toolExecutor = tools.NewDefaultRegistry()
 	// Sub-agents share the parent's model for the Tool Search threshold decision
 	// (a model override is rare and still resolves to a sane window).
-	spawner := newAgentSpawner(a, toolExecutor, func() []agent.ToolDefinition {
+	spawner := app.NewSpawner(a, toolExecutor, func() []agent.ToolDefinition {
 		return tools.DefaultToolsFor(a.Model)
 	})
 	tools.SetSpawner(spawner)

--- a/cmd/octo/conduct.go
+++ b/cmd/octo/conduct.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/conductor"
 	"github.com/Leihb/octo-agent/internal/config"
 	"github.com/Leihb/octo-agent/internal/prompt"
@@ -379,7 +380,7 @@ func buildConductAgent(f conductFlags, stdout, stderr io.Writer) (*agent.Agent, 
 	a.System = prompt.Compose("", cwd, buildEnvContext(cwd), "", "", true)
 
 	executor := tools.NewDefaultRegistry()
-	tools.SetSpawner(newAgentSpawner(a, executor, tools.DefaultTools))
+	tools.SetSpawner(app.NewSpawner(a, executor, tools.DefaultTools))
 	return a, func() { tools.SetSpawner(nil) }, 0
 }
 

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
-// agentSpawner implements tools.Spawner by building a child agent on each
+// Spawner implements tools.Spawner by building a child agent on each
 // launch_agent call. The child shares the parent's Sender (one provider
 // connection) and System (same harness identity), but runs in isolation:
 // fresh History, no visibility into the parent's conversation, its own
@@ -24,7 +24,7 @@ import (
 // Resolving it on each Spawn — rather than capturing a slice at construction
 // — lets cmd/octo set up the spawner before computing the tool list, since
 // SetSpawner has to run first for launch_agent to appear in DefaultTools().
-type agentSpawner struct {
+type Spawner struct {
 	parent   *agent.Agent
 	executor agent.ToolExecutor
 	toolsFn  func() []agent.ToolDefinition
@@ -35,8 +35,8 @@ type agentSpawner struct {
 	reg *childRegistry
 }
 
-func newAgentSpawner(parent *agent.Agent, executor agent.ToolExecutor, toolsFn func() []agent.ToolDefinition) *agentSpawner {
-	return &agentSpawner{
+func NewSpawner(parent *agent.Agent, executor agent.ToolExecutor, toolsFn func() []agent.ToolDefinition) *Spawner {
+	return &Spawner{
 		parent:   parent,
 		executor: executor,
 		toolsFn:  toolsFn,
@@ -53,7 +53,7 @@ const childMaxTurns = 100
 // Spawn implements tools.Spawner. It builds an isolated child, registers it so
 // a later send_message can continue it, runs the first prompt, and returns the
 // child's id alongside its reply.
-func (s *agentSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
+func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
 	childTools := filterChildTools(s.toolsFn(), req.Tools, req.ReadOnly)
 
 	model := req.Model
@@ -91,7 +91,7 @@ func (s *agentSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools
 // Continue implements tools.Spawner. It re-runs a still-alive child with a new
 // message. An unknown / evicted id returns an error whose text steers the model
 // to launch a fresh sub-agent.
-func (s *agentSpawner) Continue(ctx context.Context, agentID, message string) (tools.SpawnResult, error) {
+func (s *Spawner) Continue(ctx context.Context, agentID, message string) (tools.SpawnResult, error) {
 	lc, ok := s.reg.get(agentID)
 	if !ok {
 		return tools.SpawnResult{}, fmt.Errorf(
@@ -122,7 +122,7 @@ func (s *agentSpawner) Continue(ctx context.Context, agentID, message string) (t
 // Continue. Tokens spent on the partial round are still accrued. Callers that
 // drive a continuation (the conductor) inspect
 // StopReason themselves.
-func (s *agentSpawner) runChild(ctx context.Context, lc *liveChild, prompt string) (reply string, in, out int, stopReason string, err error) {
+func (s *Spawner) runChild(ctx context.Context, lc *liveChild, prompt string) (reply string, in, out int, stopReason string, err error) {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 

--- a/internal/app/spawner_test.go
+++ b/internal/app/spawner_test.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"context"
@@ -56,7 +56,7 @@ func TestAgentSpawner_RunsChildAndRollsTokensIntoParent(t *testing.T) {
 		{Name: "grep"},
 		{Name: "launch_agent"},
 	}
-	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return parentTools })
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return parentTools })
 
 	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{
 		Description: "Investigate",
@@ -96,7 +96,7 @@ func TestAgentSpawner_AppliesToolAllowlist(t *testing.T) {
 		{Name: "terminal"},
 		{Name: "launch_agent"},
 	}
-	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return parentTools })
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return parentTools })
 
 	// Allowlist restricts to read_file + grep. launch_agent always excluded.
 	got := filterChildTools(parentTools, []string{"read_file", "grep"}, false)
@@ -134,7 +134,7 @@ func TestAgentSpawner_AppliesToolAllowlist(t *testing.T) {
 func TestAgentSpawner_ModelOverride(t *testing.T) {
 	send := &subAgentSender{reply: "ok"}
 	parent := agent.New(send, "parent-model")
-	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
 
 	_, err := sp.Spawn(context.Background(), tools.SpawnRequest{
 		Description: "x",
@@ -152,7 +152,7 @@ func TestAgentSpawner_ModelOverride(t *testing.T) {
 func TestAgentSpawner_SpawnReturnsIDAndContinueResumesSameChild(t *testing.T) {
 	send := &subAgentSender{reply: "round one", inputTokens: 200, outputTokens: 80}
 	parent := agent.New(send, "parent-model")
-	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
 
 	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{Description: "x", Prompt: "first task"})
 	if err != nil {
@@ -188,7 +188,7 @@ func TestAgentSpawner_SpawnReturnsIDAndContinueResumesSameChild(t *testing.T) {
 func TestSubAgentManager_SendResumesSameChildThroughSpawner(t *testing.T) {
 	send := &subAgentSender{reply: "round one", inputTokens: 100, outputTokens: 40}
 	parent := agent.New(send, "parent-model")
-	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
 
 	mgr := tools.NewSubAgentManager(sp)
 	notes := make(chan tools.SubAgentNotification, 4)
@@ -240,7 +240,7 @@ func TestSubAgentManager_SendResumesSameChildThroughSpawner(t *testing.T) {
 func TestAgentSpawner_ContinueAccruesOnlyDeltaTokens(t *testing.T) {
 	send := &subAgentSender{reply: "ok", inputTokens: 200, outputTokens: 80}
 	parent := agent.New(send, "parent-model")
-	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
 
 	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{Description: "x", Prompt: "go"})
 	if err != nil {
@@ -268,7 +268,7 @@ func TestAgentSpawner_ContinueAccruesOnlyDeltaTokens(t *testing.T) {
 func TestAgentSpawner_ContinueUnknownID(t *testing.T) {
 	send := &subAgentSender{reply: "ok"}
 	parent := agent.New(send, "parent-model")
-	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
 
 	_, err := sp.Continue(context.Background(), "nope", "hi")
 	if err == nil || !strings.Contains(err.Error(), "no longer alive") {
@@ -279,7 +279,7 @@ func TestAgentSpawner_ContinueUnknownID(t *testing.T) {
 func TestAgentSpawner_ConcurrentContinueSerialized(t *testing.T) {
 	send := &subAgentSender{reply: "ok", inputTokens: 10, outputTokens: 5}
 	parent := agent.New(send, "parent-model")
-	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
 
 	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{Description: "x", Prompt: "go"})
 	if err != nil {
@@ -354,7 +354,7 @@ func TestAgentSpawner_AppliesSystemSuffix(t *testing.T) {
 	send := &subAgentSender{reply: "ok"}
 	parent := agent.New(send, "parent-model")
 	parent.System = "BASE IDENTITY"
-	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
 
 	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{
 		Prompt:       "go",
@@ -374,7 +374,7 @@ func TestAgentSpawner_AppliesSystemSuffix(t *testing.T) {
 
 // onlyChildID returns the single registered child id, failing if there isn't
 // exactly one.
-func onlyChildID(t *testing.T, sp *agentSpawner) string {
+func onlyChildID(t *testing.T, sp *Spawner) string {
 	t.Helper()
 	sp.reg.mu.Lock()
 	defer sp.reg.mu.Unlock()
@@ -438,7 +438,7 @@ func TestChildRegistry_TTLEviction(t *testing.T) {
 func TestAgentSpawner_MarksContextSoRecursionRefused(t *testing.T) {
 	send := &subAgentSender{reply: "ok"}
 	parent := agent.New(send, "parent-model")
-	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
 
 	// Wire SpawnRequest into a real launch_agent tool that checks the sub-agent
 	// context flag. After Spawn returns, the OUTER context shouldn't be marked

--- a/internal/app/spawner_verify_test.go
+++ b/internal/app/spawner_verify_test.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 
 // TestVerify_SendMessageReallyResumes drives the exact production tool surface
 // the LLM triggers — LaunchAgentTool.Execute then SendMessageTool.Execute,
-// wired through the default SubAgentManager + real agentSpawner exactly as the
+// wired through the default SubAgentManager + real Spawner exactly as the
 // REPL wires them — and confirms send_message resumes the same child rather
 // than reporting "no longer alive".
 func TestVerify_SendMessageReallyResumes(t *testing.T) {
@@ -20,7 +20,7 @@ func TestVerify_SendMessageReallyResumes(t *testing.T) {
 	parent.System = "PARENT"
 
 	// Real spawner with the real childRegistry underneath.
-	sp := newAgentSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
 
 	// Wire the manager exactly like cmd/octo/tuirepl.go does in production:
 	// SetDefaultSubAgentManager so the bare tools resolve it via t.manager().


### PR DESCRIPTION
Continues the unified-bootstrap groundwork (after #387 provider construction, #388 gate). Relocates the sub-agent **spawner** — the only piece that builds child agents — into `internal/app`, so it's shared rather than CLI-private.

## What moves
`cmd/octo/sub_agent.go` depended only on `agent` + `tools`, so it moves whole-cloth to `internal/app/spawner.go`:
- `agentSpawner` → exported `Spawner`; `newAgentSpawner` → `app.NewSpawner(parent, executor, toolsFn)` returning the `tools.Spawner`.
- The child registry (LRU + TTL eviction), `filterChildTools`, and the per-round delta token accounting move verbatim.
- The spawner tests — unit + the `send_message`-really-resumes integration test — move to `internal/app` too, where they retain access to the unexported registry internals they assert on.

`cmd/octo` (chat, conduct) now call `app.NewSpawner`.

## Why
`internal/app` now holds the three shared building blocks — **sender, gate, spawner**. The next PR introduces `app.Bootstrap` that assembles them with the executor + sub-agent manager + task store + tool-search config + agent knobs, and migrates the CLI onto it; server and IM follow, gaining full parity.

Behavior-preserving. `go test -race ./...`, `go vet`, `make fmt-check` all green.