### PR TITLE
refactor(app): add WireTools, shared tool-environment setup (PR1b-3)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -23,7 +23,6 @@ import (
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/prompt"
 	"github.com/Leihb/octo-agent/internal/skills"
-	"github.com/Leihb/octo-agent/internal/tasks"
 	"github.com/Leihb/octo-agent/internal/tools"
 	"github.com/Leihb/octo-agent/internal/version"
 )
@@ -535,14 +534,13 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	// Agentic setup — shared by both paths, which each run the full tool loop.
-	toolExecutor = tools.NewDefaultRegistry()
-	// Sub-agents share the parent's model for the Tool Search threshold decision
-	// (a model override is rare and still resolves to a sane window).
-	spawner := app.NewSpawner(a, toolExecutor, func() []agent.ToolDefinition {
-		return tools.DefaultToolsFor(a.Model)
-	})
-	tools.SetSpawner(spawner)
-	subAgentMgr = tools.NewSubAgentManager(spawner)
+	// WireTools builds the executor, registers the sub-agent spawner, creates the
+	// sub-agent manager, and installs the session task store; its cleanup resets
+	// those process-global registrations at session end.
+	toolEnv, toolCleanup := app.WireTools(a, true)
+	defer toolCleanup()
+	toolExecutor = toolEnv.Executor
+	subAgentMgr = toolEnv.SubAgentMgr
 	if useTUI {
 		// bubbletea owns stdin and renders its own input; the asker and gate
 		// are wired to the TUI sink inside runTUI.
@@ -567,11 +565,6 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		tools.SetAsker(newREPLAsker(replView))
 		defer tools.SetAsker(nil)
 	}
-
-	// Session-scoped task tracker backing the task_create / task_update /
-	// task_list tools. Lost on exit by design.
-	tools.SetTaskStore(tasks.New())
-	defer tools.SetTaskStore(nil)
 
 	// MCP servers: load config, connect, register so DefaultTools and
 	// DefaultRegistry pick them up. Best-effort — a misconfigured or missing

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tasks"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// ToolEnv is the wired tool environment for a session: the executor the agent
+// loop dispatches tool calls through, the manager that tracks async sub-agents
+// (launch_agent / send_message), and a model-aware tool-list function. Call
+// ToolsFor again after MCP connects so the list (or its Tool Search bridge)
+// picks up the new surface.
+type ToolEnv struct {
+	Executor    tools.DefaultRegistry
+	SubAgentMgr *tools.SubAgentManager
+	ToolsFor    func() []agent.ToolDefinition
+}
+
+// WireTools sets up the tool environment every full-loop entry point shares —
+// the CLI today, the HTTP server and IM bridge as they migrate. It builds a
+// read-before-write executor, registers the sub-agent spawner globally (so
+// launch_agent appears in the catalog, which is why SetSpawner must run before
+// any DefaultTools call), creates the async sub-agent manager, and — when
+// enableTasks — installs the session task store.
+//
+// It returns the wired environment and a cleanup that resets the process-global
+// registrations (spawner, task store); defer it for the session's lifetime. The
+// caller still owns the agent's Sender, System prompt, knobs, gate, asker, and
+// MCP connection strategy — those legitimately differ per entry point.
+func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
+	executor := tools.NewDefaultRegistry()
+	toolsFor := func() []agent.ToolDefinition { return tools.DefaultToolsFor(a.Model) }
+
+	spawner := NewSpawner(a, executor, toolsFor)
+	tools.SetSpawner(spawner)
+	mgr := tools.NewSubAgentManager(spawner)
+
+	cleanup := func() { tools.SetSpawner(nil) }
+	if enableTasks {
+		tools.SetTaskStore(tasks.New())
+		prev := cleanup
+		cleanup = func() {
+			prev()
+			tools.SetTaskStore(nil)
+		}
+	}
+
+	return ToolEnv{Executor: executor, SubAgentMgr: mgr, ToolsFor: toolsFor}, cleanup
+}

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+func TestWireTools_SetsUpEnvAndCleansUp(t *testing.T) {
+	// Reset the process globals afterwards regardless of what the test asserts.
+	t.Cleanup(func() { tools.SetSpawner(nil); tools.SetTaskStore(nil) })
+
+	a := agent.New(sender{p: &mockProvider{}}, "claude-haiku-4-5")
+	env, cleanup := WireTools(a, true)
+
+	if tools.ActiveSpawner() == nil {
+		t.Error("WireTools should register a spawner so launch_agent appears in the catalog")
+	}
+	if tools.ActiveTaskStore() == nil {
+		t.Error("WireTools(enableTasks=true) should install a task store")
+	}
+	if env.SubAgentMgr == nil {
+		t.Error("WireTools should return a sub-agent manager")
+	}
+	if env.ToolsFor == nil {
+		t.Fatal("WireTools should return a tool-list function")
+	}
+	// ToolsFor is model-aware and must at least return the core built-ins.
+	if len(env.ToolsFor()) == 0 {
+		t.Error("ToolsFor returned an empty tool list")
+	}
+
+	cleanup()
+	if tools.ActiveSpawner() != nil {
+		t.Error("cleanup should reset the spawner")
+	}
+	if tools.ActiveTaskStore() != nil {
+		t.Error("cleanup should reset the task store")
+	}
+}
+
+func TestWireTools_TasksDisabled(t *testing.T) {
+	t.Cleanup(func() { tools.SetSpawner(nil); tools.SetTaskStore(nil) })
+
+	a := agent.New(sender{p: &mockProvider{}}, "claude-haiku-4-5")
+	_, cleanup := WireTools(a, false)
+	defer cleanup()
+
+	if tools.ActiveTaskStore() != nil {
+		t.Error("WireTools(enableTasks=false) must not install a task store")
+	}
+	if tools.ActiveSpawner() == nil {
+		t.Error("spawner should still be registered when tasks are disabled")
+	}
+}


### PR DESCRIPTION
Next step of the unified-bootstrap work (after #387 sender, #388 gate, #389 spawner). Consolidates the tool-environment wiring that every full-loop entry point needs.

## What
`app.WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, cleanup)` builds, in one place, the block the CLI does inline today:
- a read-before-write executor (`tools.NewDefaultRegistry`),
- the sub-agent **spawner**, registered globally *before* any `DefaultTools` call so `launch_agent` appears in the catalog,
- the async **sub-agent manager**,
- optionally the session **task store**,
- and a `cleanup` that resets the process-global registrations at session end.

The caller still owns the agent's `Sender`, `System` prompt, knobs, gate, asker, and MCP connection strategy — the parts that legitimately differ per entry point.

`cmd/octo` migrates its inline block onto `WireTools`. Behavior-preserving (the same globals are set before the tool list is computed); the unused `tasks` import drops out.

## Why this and not a full Bootstrap
The CLI composes its system prompt **after** the spawner exists — the startup memory-consolidation pass uses the spawner — so the agent-construction + prompt assembly isn't cleanly hoistable into a single `Bootstrap()` yet. `WireTools` captures the part that *is* cleanly shared, and is exactly what lets the server and IM bridge (PR2/PR3) gain sub-agents + tasks when they adopt it. The remaining assembly will firm up as those migrations reveal the shared shape.

Tests: `internal/app/bootstrap_test.go` (env set up + cleanup resets, tasks-disabled path). `go test -race ./...`, `go vet`, `make fmt-check` all green.