### PR TITLE
refactor(server): build the sender through internal/app (PR2)

### DIFF
--- a/.octorules
+++ b/.octorules
@@ -17,7 +17,7 @@ internal/tools/    Concrete ToolExecutor implementations
 internal/version/  Version constants overridable via -ldflags
 ```
 
-Dependency direction is one-way: `provider → agent`, `tools → agent`, never the other way. `internal/app` is the single place that constructs provider clients and adapts them to `agent.Sender`; every entry point (`cmd/octo`, `internal/server`) reaches the LLM through it rather than importing `provider` directly. (`internal/server` still has its own copy pending migration.)
+Dependency direction is one-way: `provider → agent`, `tools → agent`, never the other way. `internal/app` is the single place that constructs provider clients and adapts them to `agent.Sender`; every entry point (`cmd/octo`, `internal/server`) reaches the LLM through it rather than importing `provider` directly.
 
 ## Adding capability
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,11 +18,9 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/config"
 	"github.com/Leihb/octo-agent/internal/prompt"
-	"github.com/Leihb/octo-agent/internal/provider"
-	"github.com/Leihb/octo-agent/internal/provider/anthropic"
-	"github.com/Leihb/octo-agent/internal/provider/openai"
 	"github.com/Leihb/octo-agent/internal/skills"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
@@ -55,7 +53,7 @@ type Server struct {
 	http *http.Server
 
 	// agent factory state (resolved once at start)
-	provider       provider.Provider
+	sender         agent.Sender
 	model          string
 	system         string
 	skillReg       *skills.Registry
@@ -75,7 +73,7 @@ func New(cfg Config) (*Server, error) {
 		return nil, err
 	}
 
-	prov, model, err := resolveProviderAndModel(cfg.Provider, cfg.Model)
+	sender, model, err := resolveProviderAndModel(cfg.Provider, cfg.Model)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +88,7 @@ func New(cfg Config) (*Server, error) {
 	s := &Server{
 		cfg:            cfg,
 		mux:            http.NewServeMux(),
-		provider:       prov,
+		sender:         sender,
 		model:          model,
 		system:         cfg.System,
 		skillReg:       skillReg,
@@ -193,8 +191,7 @@ func (s *Server) forgetTurnLock(id string) {
 // buildAgent creates a fresh agent for a turn. The caller must have locked
 // the session's turn mutex.
 func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
-	sender := providerSender{p: s.provider}
-	a := agent.New(sender, s.model)
+	a := agent.New(s.sender, s.model)
 	a.CWD = s.cwd
 	a.MaxTokens = s.cfg.MaxTokens
 	a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, "", true)
@@ -225,9 +222,13 @@ func readBodyJSON(r *http.Request, v any) error {
 	return json.NewDecoder(r.Body).Decode(v)
 }
 
-// ─── Provider resolution (shared logic extracted from cmd/octo) ─────────────
+// ─── Provider resolution ────────────────────────────────────────────────────
+//
+// The server resolves provider/model/key/base-URL exactly as before, then hands
+// the result to app.NewSender — internal/app is the single place that builds the
+// vendor client, so the server no longer imports internal/provider.
 
-func resolveProviderAndModel(flagProvider, flagModel string) (provider.Provider, string, error) {
+func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, string, error) {
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, "", fmt.Errorf("load config: %w", err)
@@ -248,14 +249,25 @@ func resolveProviderAndModel(flagProvider, flagModel string) (provider.Provider,
 		return nil, "", fmt.Errorf("unknown provider %q", provName)
 	}
 
-	prov, err := buildProvider(provName, cfg)
+	apiKey, err := resolveAPIKey(provName, cfg)
 	if err != nil {
 		return nil, "", err
 	}
-	return prov, model, nil
+	sender, err := app.NewSender(app.SenderOptions{
+		Provider: provName,
+		APIKey:   apiKey,
+		BaseURL:  resolveBaseURL(provName, cfg),
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return sender, model, nil
 }
 
-func buildProvider(name string, cfg config.Config) (provider.Provider, error) {
+// resolveAPIKey returns the API key for the vendor: the provider's env var,
+// else cfg.APIKey when the stored config targets the same provider. Errors with
+// the same "X is not set" message the server reported before.
+func resolveAPIKey(name string, cfg config.Config) (string, error) {
 	switch name {
 	case "anthropic":
 		apiKey := os.Getenv("ANTHROPIC_API_KEY")
@@ -263,34 +275,20 @@ func buildProvider(name string, cfg config.Config) (provider.Provider, error) {
 			apiKey = cfg.APIKey
 		}
 		if apiKey == "" {
-			return nil, fmt.Errorf("ANTHROPIC_API_KEY is not set")
+			return "", fmt.Errorf("ANTHROPIC_API_KEY is not set")
 		}
-		client, err := anthropic.New(apiKey)
-		if err != nil {
-			return nil, err
-		}
-		if baseURL := resolveBaseURL(name, cfg); baseURL != "" {
-			client.BaseURL = baseURL
-		}
-		return client, nil
+		return apiKey, nil
 	case "openai":
 		apiKey := os.Getenv("OPENAI_API_KEY")
 		if apiKey == "" && cfg.Provider == "openai" {
 			apiKey = cfg.APIKey
 		}
 		if apiKey == "" {
-			return nil, fmt.Errorf("OPENAI_API_KEY is not set")
+			return "", fmt.Errorf("OPENAI_API_KEY is not set")
 		}
-		client, err := openai.New(apiKey)
-		if err != nil {
-			return nil, err
-		}
-		if baseURL := resolveBaseURL(name, cfg); baseURL != "" {
-			client.BaseURL = baseURL
-		}
-		return client, nil
+		return apiKey, nil
 	default:
-		return nil, fmt.Errorf("unknown provider %q", name)
+		return "", fmt.Errorf("unknown provider %q", name)
 	}
 }
 
@@ -369,94 +367,3 @@ func validateBindAddr(addr string) error {
 	}
 	return nil
 }
-
-// providerSender adapts provider.Provider into agent.Sender.
-type providerSender struct {
-	p provider.Provider
-}
-
-func (s providerSender) SendMessages(ctx context.Context, model, system string, msgs []agent.Message, maxTokens int) (agent.Reply, error) {
-	resp, err := s.p.Send(ctx, provider.Request{
-		Model:        model,
-		SystemPrompt: system,
-		Messages:     msgs,
-		MaxTokens:    maxTokens,
-	})
-	if err != nil {
-		return agent.Reply{}, err
-	}
-	return replyFromResponse(resp), nil
-}
-
-// SendMessagesWithTools implements agent.ToolSender. Without it the agent
-// loop's type assertion falls back to a plain tool-less Turn, so every tool
-// (web_search included) would silently vanish from the web UI even though
-// runTurn passes the full DefaultTools() set.
-func (s providerSender) SendMessagesWithTools(ctx context.Context, model, system string, msgs []agent.Message, maxTokens int, tools []agent.ToolDefinition) (agent.Reply, error) {
-	resp, err := s.p.Send(ctx, provider.Request{
-		Model:        model,
-		SystemPrompt: system,
-		Messages:     msgs,
-		MaxTokens:    maxTokens,
-		Tools:        tools,
-	})
-	if err != nil {
-		return agent.Reply{}, err
-	}
-	return replyFromResponse(resp), nil
-}
-
-// StreamMessagesWithTools implements agent.ToolStreamingSender, the capability
-// the SSE path (RunStream) requires to forward tools. Providers that can't
-// stream fall back to the buffered tool-aware send.
-func (s providerSender) StreamMessagesWithTools(
-	ctx context.Context,
-	model, system string,
-	msgs []agent.Message,
-	maxTokens int,
-	tools []agent.ToolDefinition,
-	onChunk func(string),
-	onToolDelta agent.ToolInputDeltaFunc,
-	onThinking agent.ThinkingDeltaFunc,
-) (agent.Reply, error) {
-	req := provider.Request{
-		Model:        model,
-		SystemPrompt: system,
-		Messages:     msgs,
-		MaxTokens:    maxTokens,
-		Tools:        tools,
-	}
-	if sp, ok := s.p.(provider.StreamingProvider); ok {
-		resp, err := sp.SendStream(ctx, req, provider.StreamCallbacks{
-			OnText:      onChunk,
-			OnToolDelta: onToolDelta,
-			OnThinking:  onThinking,
-		})
-		if err != nil {
-			return agent.Reply{}, err
-		}
-		return replyFromResponse(resp), nil
-	}
-	return s.SendMessagesWithTools(ctx, model, system, msgs, maxTokens, tools)
-}
-
-func replyFromResponse(resp provider.Response) agent.Reply {
-	return agent.Reply{
-		Content:          resp.Content,
-		Blocks:           resp.Blocks,
-		Model:            resp.Model,
-		StopReason:       resp.StopReason,
-		InputTokens:      resp.InputTokens,
-		OutputTokens:     resp.OutputTokens,
-		CacheReadTokens:  resp.CacheReadTokens,
-		CacheWriteTokens: resp.CacheWriteTokens,
-	}
-}
-
-// Compile-time assertions: the server's sender must satisfy the full tool-
-// aware surface, or the agent loop silently degrades to a tool-less Turn.
-var (
-	_ agent.Sender              = providerSender{}
-	_ agent.ToolSender          = providerSender{}
-	_ agent.ToolStreamingSender = providerSender{}
-)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/Leihb/octo-agent/internal/agent"
-	"github.com/Leihb/octo-agent/internal/provider"
 	"github.com/Leihb/octo-agent/internal/skills"
 )
 
@@ -304,7 +303,7 @@ func mustServer(t *testing.T, cfg Config) *Server {
 		cwd:            "",
 		envCtx:         "",
 		turnLocks:      map[string]*sync.Mutex{},
-		provider:       &stubProvider{},
+		sender:         &stubSender{},
 	}
 	srv.registerRoutes()
 	// Wrap with CORS middleware so tests that exercise CORS hit the right layer.
@@ -312,51 +311,71 @@ func mustServer(t *testing.T, cfg Config) *Server {
 	return srv
 }
 
-// stubProvider implements provider.Provider for tests.
-type stubProvider struct{}
+// stubSender is a no-network agent.Sender for tests. It satisfies the full
+// tool-aware surface so the agent loop never degrades, and always replies
+// "stub reply".
+type stubSender struct{}
 
-func (s *stubProvider) Name() string { return "stub" }
-
-func (s *stubProvider) Send(_ context.Context, _ provider.Request) (provider.Response, error) {
-	return provider.Response{Content: "stub reply"}, nil
+func (stubSender) SendMessages(_ context.Context, _, _ string, _ []agent.Message, _ int) (agent.Reply, error) {
+	return agent.Reply{Content: "stub reply"}, nil
 }
 
-func (s *stubProvider) SendStream(_ context.Context, _ provider.Request, cb provider.StreamCallbacks) (provider.Response, error) {
-	if cb.OnText != nil {
-		cb.OnText("stub reply")
+func (stubSender) StreamMessages(_ context.Context, _, _ string, _ []agent.Message, _ int, onChunk func(string), _ func(string)) (agent.Reply, error) {
+	if onChunk != nil {
+		onChunk("stub reply")
 	}
-	return provider.Response{Content: "stub reply"}, nil
+	return agent.Reply{Content: "stub reply"}, nil
 }
 
-// recordingProvider captures the last Request it received so a test can assert
-// what the agent layer actually forwarded to the wire.
-type recordingProvider struct{ last provider.Request }
-
-func (p *recordingProvider) Name() string { return "recording" }
-
-func (p *recordingProvider) Send(_ context.Context, req provider.Request) (provider.Response, error) {
-	p.last = req
-	return provider.Response{Content: "ok"}, nil
+func (stubSender) SendMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, _ []agent.ToolDefinition) (agent.Reply, error) {
+	return agent.Reply{Content: "stub reply"}, nil
 }
 
-func (p *recordingProvider) SendStream(_ context.Context, req provider.Request, cb provider.StreamCallbacks) (provider.Response, error) {
-	p.last = req
-	if cb.OnText != nil {
-		cb.OnText("ok")
+func (stubSender) StreamMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, _ []agent.ToolDefinition, onChunk func(string), _ agent.ToolInputDeltaFunc, _ agent.ThinkingDeltaFunc) (agent.Reply, error) {
+	if onChunk != nil {
+		onChunk("stub reply")
 	}
-	return provider.Response{Content: "ok"}, nil
+	return agent.Reply{Content: "stub reply"}, nil
+}
+
+// recordingSender captures the tool definitions the agent layer forwarded so a
+// test can assert the full tool set reached the wire.
+type recordingSender struct{ lastTools []agent.ToolDefinition }
+
+func (s *recordingSender) SendMessages(_ context.Context, _, _ string, _ []agent.Message, _ int) (agent.Reply, error) {
+	return agent.Reply{Content: "ok"}, nil
+}
+
+func (s *recordingSender) StreamMessages(_ context.Context, _, _ string, _ []agent.Message, _ int, onChunk func(string), _ func(string)) (agent.Reply, error) {
+	if onChunk != nil {
+		onChunk("ok")
+	}
+	return agent.Reply{Content: "ok"}, nil
+}
+
+func (s *recordingSender) SendMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, toolDefs []agent.ToolDefinition) (agent.Reply, error) {
+	s.lastTools = toolDefs
+	return agent.Reply{Content: "ok"}, nil
+}
+
+func (s *recordingSender) StreamMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, toolDefs []agent.ToolDefinition, onChunk func(string), _ agent.ToolInputDeltaFunc, _ agent.ThinkingDeltaFunc) (agent.Reply, error) {
+	s.lastTools = toolDefs
+	if onChunk != nil {
+		onChunk("ok")
+	}
+	return agent.Reply{Content: "ok"}, nil
 }
 
 // TestRunTurnForwardsTools is the regression guard for the web-UI bug where the
-// server's providerSender only implemented the base Sender, so the agent loop
-// fell back to a tool-less Turn and every tool (web_search included) vanished.
+// server's sender only implemented the base Sender, so the agent loop fell back
+// to a tool-less Turn and every tool (web_search included) vanished.
 func TestRunTurnForwardsTools(t *testing.T) {
-	rec := &recordingProvider{}
+	rec := &recordingSender{}
 	srv := &Server{
 		cfg:       Config{Tools: true},
 		model:     "stub-model",
 		turnLocks: map[string]*sync.Mutex{},
-		provider:  rec,
+		sender:    rec,
 	}
 
 	sess := agent.NewSession("stub-model", "")
@@ -364,17 +383,17 @@ func TestRunTurnForwardsTools(t *testing.T) {
 		t.Fatalf("runTurn: %v", err)
 	}
 
-	if len(rec.last.Tools) == 0 {
-		t.Fatal("expected tools forwarded to provider, got none (sender degraded to tool-less Turn)")
+	if len(rec.lastTools) == 0 {
+		t.Fatal("expected tools forwarded to sender, got none (sender degraded to tool-less Turn)")
 	}
 	found := false
-	for _, d := range rec.last.Tools {
+	for _, d := range rec.lastTools {
 		if d.Name == "web_search" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("web_search not among forwarded tools: %v", rec.last.Tools)
+		t.Errorf("web_search not among forwarded tools: %v", rec.lastTools)
 	}
 }


### PR DESCRIPTION
## What

`internal/server` was the last package (besides the entry points) that constructed its own provider clients — a duplicate `buildProvider` / `resolveBaseURL` / `providerSender` that imported `internal/provider` and the vendor packages directly, breaking the one-directional dependency rule `.octorules` flagged as pending debt.

This PR routes the server's provider construction through `app.NewSender`, making `internal/app` the **only** package that builds vendor clients.

## Changes

- **`internal/server/server.go`**: drop the `internal/provider*` imports; `Server.provider provider.Provider` → `sender agent.Sender`; `resolveProviderAndModel` now returns an `agent.Sender` built via `app.NewSender` (provider/model/key/base-URL resolution rules unchanged, key resolution extracted to `resolveAPIKey`); delete the `providerSender` adapter, `replyFromResponse`, and the compile-time interface assertions (`app.NewSender` already returns a sender satisfying the full tool-aware surface and asserts it in one place).
- **`internal/server/server_test.go`**: swap the `provider.Provider` fakes for `agent.Sender` fakes (the new injection seam). The forward-tools regression guard (`TestRunTurnForwardsTools`) is retained against a recording sender.
- **`.octorules`**: drop the "(`internal/server` still has its own copy pending migration.)" debt note.

**Behavior-preserving** — only the construction seam moves.

## Out of scope (follow-up)

Sub-agent / Tool Search / MCP parity for the server is intentionally deferred. Done correctly it needs context-scoped sub-agent dispatch + a synchronous spawn path (the async `onExit` model has no home in request/response), which is not behavior-preserving and belongs in its own PR.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `gofmt -l internal/server/` — clean
- `go test -race ./...` — green (exit 0)
- `grep -rn "internal/provider" internal/server/` — only a comment remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)