### PR TITLE
feat(channel): enforce permissions on the IM bridge (PR3)

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/Leihb/octo-agent/internal/channel/adapters/weixin"
 	"github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink"
 	"github.com/Leihb/octo-agent/internal/config"
+	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/prompt"
 	"github.com/Leihb/octo-agent/internal/skills"
 	"github.com/Leihb/octo-agent/internal/tools"
@@ -137,6 +138,17 @@ func runChannelStart(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 	skillsManifest := skills.RenderManifest(skillReg)
 	tools.SetSkills(skillReg)
 
+	// Permission gate — the IM bridge's first enforcement. A chat channel has
+	// no one to prompt, so the gate is non-interactive (ask → deny) in strict
+	// mode: safe tools run, risky ones are refused with a reason the model
+	// sees. Same posture as the HTTP server. One engine is shared across all
+	// sessions (Check is concurrency-safe; ask=nil never calls Remember).
+	gate, err := newChannelGate(cwd)
+	if err != nil {
+		fmt.Fprintf(stderr, "octo channel: %v\n", err)
+		return 1
+	}
+
 	agentFactory := func() *agent.Agent {
 		// The key was validated above; NewSender only re-errors on client
 		// construction, which doesn't happen for an already-resolved key.
@@ -151,6 +163,7 @@ func runChannelStart(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 		a.MaxTokens = *maxTokens
 		a.MaxTurns = *maxTurns
 		a.System = prompt.Compose(*system, cwd, env, skillsManifest, "", true)
+		a.Gate = gate
 		return a
 	}
 
@@ -235,4 +248,17 @@ func handleAgentMessage(ctx context.Context, mgr *channel.Manager, ad channel.Ad
 	}
 
 	_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, ev.Text)
+}
+
+// newChannelGate builds the IM bridge's permission gate: strict mode with a nil
+// asker, so ask-class verdicts resolve to deny (a chat channel has no
+// interactive prompt). It reads ~/.octo/permissions.yml when present, falling
+// back to the built-in defaults otherwise — the same engine the CLI and HTTP
+// server use.
+func newChannelGate(cwd string) (agent.PermissionGate, error) {
+	engine, err := permission.New(permissionConfigPath(), cwd, permission.ModeStrict)
+	if err != nil {
+		return nil, fmt.Errorf("permission engine: %w", err)
+	}
+	return app.NewPermissionGate(engine, nil), nil
 }

--- a/cmd/octo/channel_test.go
+++ b/cmd/octo/channel_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+// TestNewChannelGate_NonInteractive verifies the IM bridge gate: safe tools are
+// allowed, while ask-class tools resolve to deny (there is no chat prompt to
+// confirm over). This is the IM path's first permission enforcement — before
+// PR3 the channel ran tools ungated.
+func TestNewChannelGate_NonInteractive(t *testing.T) {
+	gate, err := newChannelGate(t.TempDir())
+	if err != nil {
+		t.Fatalf("newChannelGate: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// A safe, auto-allowed command runs.
+	if allow, _ := gate.Check(ctx, "terminal", map[string]any{"command": "ls -la"}); !allow {
+		t.Error("expected `ls -la` to be allowed")
+	}
+
+	// An ask-class command (sudo) has no allow rule → implicit ask → strict
+	// mode + nil asker → deny.
+	if allow, reason := gate.Check(ctx, "terminal", map[string]any{"command": "sudo rm /tmp/x"}); allow {
+		t.Error("expected `sudo` to be denied in the non-interactive gate")
+	} else if reason == "" {
+		t.Error("expected a denial reason for the model to see")
+	}
+
+	// A hard-deny command is refused regardless of mode.
+	if allow, _ := gate.Check(ctx, "terminal", map[string]any{"command": "rm -rf /"}); allow {
+		t.Error("expected `rm -rf /` to be denied")
+	}
+}


### PR DESCRIPTION
## What

The IM bridge (`octo channel start`) ran tool calls **ungated** — the only entry point with no permission enforcement. A chat message could drive `write_file`, `terminal`, `web_fetch`, etc. with nothing in the way (the "裸跑工具" smell the unified-bootstrap design called out).

This PR gives the channel its first permission enforcement via the unified gate from `internal/app`.

## Changes

- **`cmd/octo/channel.go`**: build one `permission.Engine` (strict mode) at channel start and attach `app.NewPermissionGate(engine, nil)` to every session's agent in the factory (`a.Gate = gate`). `nil` asker = non-interactive: a chat channel has no one to prompt, so ask-class verdicts resolve to **deny** — the same posture the HTTP server uses. Gate construction is factored into `newChannelGate(cwd)`.
- **`cmd/octo/channel_test.go`**: unit test — safe command allowed, ask-class (`sudo`) denied with a reason, hard-deny (`rm -rf /`) denied.

### Behavior change

This is an intentional security fix. With the default policy in strict mode:
- **Allowed:** `ls`, `cat`, `git status/log/diff`, `go test/build/vet`, `grep`, `glob`, `web_search`, `read_file` (non-secret), `write_file`/`edit_file` within CWD.
- **Denied:** disasters (`rm -rf /`, `sed -i`) outright; ask-class (`sudo`, `curl`, `ssh`, `rm -rf`, out-of-CWD writes, `web_fetch` to unknown/private hosts) resolve to deny since there's no interactive prompt. The denial reason is returned to the model so it can adapt.

The engine is shared across all chat sessions — `Engine.Check` is concurrency-safe and `ask=nil` never calls `Remember`.

## Out of scope (follow-up)

Sub-agent / Tool Search / MCP parity for the channel stays deferred to PR2b alongside the server — done correctly it needs context-scoped sub-agent dispatch + a synchronous spawn path, which is not behavior-preserving.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l cmd/octo/` — clean
- `go test -race ./...` — green (exit 0)
- `go test ./cmd/octo/ -run TestNewChannelGate -v` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)