### PR TITLE
feat(server): sub-agent + task parity via context-scoped sync dispatch (PR2b)

### DIFF
--- a/internal/permission/defaults.yml
+++ b/internal/permission/defaults.yml
@@ -105,3 +105,24 @@ grep:
   - allow: { pattern: "" }
 web_search:
   - allow: { pattern: "" }
+
+# Control-plane / meta tools — allowed without prompting. They have no direct
+# side effect: a sub-agent inherits its parent's gate, so launch_agent /
+# send_message can't let it do anything the gate wouldn't already permit, and
+# the task_* tools are in-memory bookkeeping. Without an allow here they fall
+# through to the implicit ask, which a non-interactive transport (HTTP server,
+# IM bridge) resolves to deny — silently disabling sub-agents and tasks there.
+launch_agent:
+  - allow: { pattern: "" }
+send_message:
+  - allow: { pattern: "" }
+agent_status:
+  - allow: { pattern: "" }
+kill_agent:
+  - allow: { pattern: "" }
+task_create:
+  - allow: { pattern: "" }
+task_update:
+  - allow: { pattern: "" }
+task_list:
+  - allow: { pattern: "" }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/permission"
+	"github.com/Leihb/octo-agent/internal/tasks"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
@@ -289,25 +290,48 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 		return reply.Content, nil
 	}
 
-	// Tool-enabled path: build executor and permission gate.
-	executor := tools.NewDefaultRegistry()
-	toolDefs := tools.DefaultTools()
-
-	// Server permission gate: strict mode — ask → deny.
-	cwd := s.cwd
-	engine, err := permission.New(permissionConfigPath(), cwd, permission.ModeStrict)
+	// Tool-enabled path: wire the per-turn tool environment (gate + ctx-scoped
+	// sub-agent manager + task store) bound to this turn's agent.
+	ctx, executor, err := s.prepareToolTurn(ctx, a)
 	if err != nil {
-		return "", fmt.Errorf("permission engine: %w", err)
+		return "", err
 	}
-	a.Gate = app.NewPermissionGate(engine, nil)
 
-	reply, err := a.Run(ctx, userInput, toolDefs, executor)
+	reply, err := a.Run(ctx, userInput, tools.DefaultToolsFor(a.Model), executor)
 	if err != nil {
 		return "", err
 	}
 
 	sess.SyncFrom(a.History)
 	return reply.Content, nil
+}
+
+// prepareToolTurn wires the per-turn tool environment for agent a: the strict,
+// non-interactive permission gate, plus a sub-agent manager and task store
+// bound to THIS turn's agent and stamped into ctx so the sub-agent / task tools
+// dispatch to them rather than the process-global gating sentinels. The manager
+// runs synchronously — a request/response turn has no follow-up channel for an
+// async sub-agent result — and each turn gets a private store, so concurrent
+// sessions never share sub-agent or task state. Returns the augmented ctx and
+// the executor to run the turn with.
+func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.Context, agent.ToolExecutor, error) {
+	executor := tools.NewDefaultRegistry()
+
+	engine, err := permission.New(permissionConfigPath(), s.cwd, permission.ModeStrict)
+	if err != nil {
+		return ctx, nil, fmt.Errorf("permission engine: %w", err)
+	}
+	a.Gate = app.NewPermissionGate(engine, nil)
+
+	spawner := app.NewSpawner(a, executor, func() []agent.ToolDefinition {
+		return tools.DefaultToolsFor(a.Model)
+	})
+	mgr := tools.NewSubAgentManager(spawner)
+	mgr.SetSynchronous(true)
+	ctx = tools.WithSubAgentManager(ctx, mgr)
+	ctx = tools.WithTaskStore(ctx, tasks.New())
+
+	return ctx, executor, nil
 }
 
 func permissionConfigPath() string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/config"
 	"github.com/Leihb/octo-agent/internal/prompt"
 	"github.com/Leihb/octo-agent/internal/skills"
+	"github.com/Leihb/octo-agent/internal/tasks"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
@@ -99,6 +100,7 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	s.registerRoutes()
+	s.enableSubAgentTools()
 
 	s.http = &http.Server{
 		Addr:         cfg.Addr,
@@ -111,13 +113,39 @@ func New(cfg Config) (*Server, error) {
 	return s, nil
 }
 
+// enableSubAgentTools registers the process-global sub-agent manager + task
+// store so DefaultToolsFor advertises launch_agent / send_message / task_* . On
+// the server these globals are gating sentinels and a never-hit fallback: every
+// turn stamps its own ctx-scoped manager + store (bound to that turn's agent)
+// via prepareToolTurn, and dispatch prefers the ctx-scoped ones — so concurrent
+// sessions never share sub-agent or task state. The template agent only seeds
+// the sentinel spawner. No-op when tools are disabled.
+func (s *Server) enableSubAgentTools() {
+	if !s.cfg.Tools {
+		return
+	}
+	template := agent.New(s.sender, s.model)
+	template.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, "", true)
+	executor := tools.NewDefaultRegistry()
+	spawner := app.NewSpawner(template, executor, func() []agent.ToolDefinition {
+		return tools.DefaultToolsFor(s.model)
+	})
+	mgr := tools.NewSubAgentManager(spawner)
+	mgr.SetSynchronous(true)
+	tools.SetDefaultSubAgentManager(mgr)
+	tools.SetTaskStore(tasks.New())
+}
+
 // ListenAndServe starts the HTTP server.
 func (s *Server) ListenAndServe() error {
 	return s.http.ListenAndServe()
 }
 
-// Shutdown gracefully shuts down the server.
+// Shutdown gracefully shuts down the server, releasing the process-global
+// sub-agent + task registrations installed by enableSubAgentTools.
 func (s *Server) Shutdown(ctx context.Context) error {
+	tools.SetDefaultSubAgentManager(nil)
+	tools.SetTaskStore(nil)
 	return s.http.Shutdown(ctx)
 }
 

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
-	"github.com/Leihb/octo-agent/internal/app"
-	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
@@ -60,15 +58,19 @@ func (s *Server) handleTurnSSE(w http.ResponseWriter, r *http.Request) {
 
 	a := s.buildAgent(sess)
 
+	runCtx := r.Context()
 	var toolDefs []agent.ToolDefinition
 	var executor agent.ToolExecutor
 	if s.cfg.Tools {
-		executor = tools.NewDefaultRegistry()
-		toolDefs = tools.DefaultTools()
-		engine, err := permission.New(permissionConfigPath(), s.cwd, permission.ModeStrict)
-		if err == nil {
-			a.Gate = app.NewPermissionGate(engine, nil)
+		var perr error
+		runCtx, executor, perr = s.prepareToolTurn(runCtx, a)
+		if perr != nil {
+			ev := agent.AgentEvent{Kind: agent.EventToolError, Err: perr.Error()}
+			b, _ := json.Marshal(ev)
+			sseEvent(w, string(b))
+			return
 		}
+		toolDefs = tools.DefaultToolsFor(a.Model)
 	}
 
 	eventHandler := func(ev agent.AgentEvent) {
@@ -76,7 +78,7 @@ func (s *Server) handleTurnSSE(w http.ResponseWriter, r *http.Request) {
 		sseEvent(w, string(b))
 	}
 
-	reply, err := a.RunStream(r.Context(), req.Message, toolDefs, executor, eventHandler)
+	reply, err := a.RunStream(runCtx, req.Message, toolDefs, executor, eventHandler)
 	if err != nil {
 		ev := agent.AgentEvent{Kind: agent.EventToolError, Err: err.Error()}
 		b, _ := json.Marshal(ev)

--- a/internal/server/subagent_test.go
+++ b/internal/server/subagent_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// TestEnableSubAgentToolsAdvertises verifies that starting a tools-enabled
+// server registers the gating sentinels so DefaultToolsFor advertises the
+// sub-agent and task tools (which would otherwise be withheld).
+func TestEnableSubAgentToolsAdvertises(t *testing.T) {
+	srv := &Server{
+		cfg:       Config{Tools: true},
+		sender:    &stubSender{},
+		model:     "stub-model",
+		cwd:       t.TempDir(),
+		turnLocks: map[string]*sync.Mutex{},
+	}
+	srv.enableSubAgentTools()
+	t.Cleanup(func() {
+		tools.SetDefaultSubAgentManager(nil)
+		tools.SetTaskStore(nil)
+	})
+
+	names := map[string]bool{}
+	for _, d := range tools.DefaultToolsFor("") {
+		names[d.Name] = true
+	}
+	for _, want := range []string{"launch_agent", "send_message", "task_create", "task_list"} {
+		if !names[want] {
+			t.Errorf("expected %q to be advertised after enableSubAgentTools", want)
+		}
+	}
+}
+
+// scriptedSender returns a fixed sequence of replies across all sender methods,
+// sharing one counter between the parent turn and any sub-agent it spawns (both
+// run against the same sender). It lets a test drive a launch_agent tool_use
+// and observe the sub-agent run inline.
+type scriptedSender struct {
+	mu      sync.Mutex
+	replies []agent.Reply
+	calls   int
+}
+
+func (s *scriptedSender) next() agent.Reply {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var r agent.Reply
+	if s.calls < len(s.replies) {
+		r = s.replies[s.calls]
+	} else {
+		r = agent.Reply{Content: "fallback"}
+	}
+	s.calls++
+	return r
+}
+
+func (s *scriptedSender) SendMessages(_ context.Context, _, _ string, _ []agent.Message, _ int) (agent.Reply, error) {
+	return s.next(), nil
+}
+
+func (s *scriptedSender) StreamMessages(_ context.Context, _, _ string, _ []agent.Message, _ int, onChunk func(string), _ func(string)) (agent.Reply, error) {
+	r := s.next()
+	if onChunk != nil && r.Content != "" {
+		onChunk(r.Content)
+	}
+	return r, nil
+}
+
+func (s *scriptedSender) SendMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, _ []agent.ToolDefinition) (agent.Reply, error) {
+	return s.next(), nil
+}
+
+func (s *scriptedSender) StreamMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, _ []agent.ToolDefinition, onChunk func(string), _ agent.ToolInputDeltaFunc, _ agent.ThinkingDeltaFunc) (agent.Reply, error) {
+	r := s.next()
+	if onChunk != nil && r.Content != "" {
+		onChunk(r.Content)
+	}
+	return r, nil
+}
+
+// TestServerRunsSubAgentSynchronously drives a full turn whose first reply asks
+// for a sub-agent: the synchronous launch_agent path must run the child inline
+// (against the same scripted sender) and feed its reply back so the turn
+// finishes in one request. Three sender calls prove it: parent → child → parent.
+func TestServerRunsSubAgentSynchronously(t *testing.T) {
+	// Isolate HOME so the permission engine uses the embedded defaults (which
+	// allow launch_agent), not a developer's ~/.octo/permissions.yml.
+	t.Setenv("HOME", t.TempDir())
+
+	sender := &scriptedSender{replies: []agent.Reply{
+		// 1. Parent asks to spawn a sub-agent.
+		{
+			Blocks: []agent.ContentBlock{
+				agent.NewToolUseBlock("tu1", "launch_agent", map[string]any{
+					"description": "sub task",
+					"prompt":      "do the sub task",
+				}),
+			},
+			StopReason: "tool_use",
+		},
+		// 2. The sub-agent's own reply (no tools) — ends the child loop.
+		{Content: "child result"},
+		// 3. Parent's final answer after seeing the sub-agent result.
+		{Content: "parent final answer"},
+	}}
+
+	srv := &Server{
+		cfg:       Config{Tools: true},
+		sender:    sender,
+		model:     "stub-model",
+		cwd:       t.TempDir(),
+		turnLocks: map[string]*sync.Mutex{},
+	}
+	srv.enableSubAgentTools()
+	t.Cleanup(func() {
+		tools.SetDefaultSubAgentManager(nil)
+		tools.SetTaskStore(nil)
+	})
+
+	sess := agent.NewSession("stub-model", "")
+	reply, err := srv.runTurn(context.Background(), sess, "please use a sub-agent")
+	if err != nil {
+		t.Fatalf("runTurn: %v", err)
+	}
+	if reply != "parent final answer" {
+		t.Errorf("expected the parent's final answer, got %q", reply)
+	}
+	if sender.calls != 3 {
+		t.Errorf("expected 3 sender calls (parent, sub-agent, parent), got %d — sub-agent didn't run inline", sender.calls)
+	}
+}

--- a/internal/tools/agent_status.go
+++ b/internal/tools/agent_status.go
@@ -15,13 +15,6 @@ type AgentStatusTool struct {
 	mgr *SubAgentManager
 }
 
-func (t AgentStatusTool) manager() *SubAgentManager {
-	if t.mgr != nil {
-		return t.mgr
-	}
-	return defaultSubAgentMgr
-}
-
 func (AgentStatusTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name: "agent_status",
@@ -51,7 +44,7 @@ func (t AgentStatusTool) Execute(ctx context.Context, _ string, input map[string
 		return agent.ToolResult{Text: ""}, fmt.Errorf("agent_status: agent_id is required")
 	}
 
-	mgr := t.manager()
+	mgr := resolveSubAgentManager(ctx, t.mgr)
 	if mgr == nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("agent_status: sub-agent dispatch is not configured for this session")
 	}

--- a/internal/tools/kill_agent.go
+++ b/internal/tools/kill_agent.go
@@ -14,13 +14,6 @@ type KillAgentTool struct {
 	mgr *SubAgentManager
 }
 
-func (t KillAgentTool) manager() *SubAgentManager {
-	if t.mgr != nil {
-		return t.mgr
-	}
-	return defaultSubAgentMgr
-}
-
 func (KillAgentTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name: "kill_agent",
@@ -50,7 +43,7 @@ func (t KillAgentTool) Execute(ctx context.Context, _ string, input map[string]a
 		return agent.ToolResult{Text: ""}, fmt.Errorf("kill_agent: agent_id is required")
 	}
 
-	mgr := t.manager()
+	mgr := resolveSubAgentManager(ctx, t.mgr)
 	if mgr == nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("kill_agent: sub-agent dispatch is not configured for this session")
 	}

--- a/internal/tools/launch_agent.go
+++ b/internal/tools/launch_agent.go
@@ -134,13 +134,6 @@ type LaunchAgentTool struct {
 	mgr *SubAgentManager
 }
 
-func (t LaunchAgentTool) manager() *SubAgentManager {
-	if t.mgr != nil {
-		return t.mgr
-	}
-	return defaultSubAgentMgr
-}
-
 func (LaunchAgentTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name: "launch_agent",
@@ -199,7 +192,7 @@ func (t LaunchAgentTool) Execute(ctx context.Context, _ string, input map[string
 		desc = firstLine(prompt)
 	}
 
-	mgr := t.manager()
+	mgr := resolveSubAgentManager(ctx, t.mgr)
 	if mgr == nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("launch_agent: sub-agent dispatch is not configured for this session")
 	}
@@ -210,6 +203,19 @@ func (t LaunchAgentTool) Execute(ctx context.Context, _ string, input map[string
 		Tools:       stringSliceArg(input, "tools"),
 		Model:       strings.TrimSpace(stringArg(input, "model")),
 	}
+
+	// Synchronous transports (HTTP server, IM bridge) have no follow-up-turn
+	// channel to deliver an async result, so run the sub-agent inline and
+	// return its full reply as the tool_result. The [agent <id>] tag lets the
+	// model address it in a later send_message within the same turn.
+	if mgr.Synchronous() {
+		res, err := mgr.RunSync(ctx, req)
+		if err != nil {
+			return agent.ToolResult{Text: ""}, fmt.Errorf("launch_agent: %w", err)
+		}
+		return agent.ToolResult{Text: withAgentTag(res.AgentID, res.Reply)}, nil
+	}
+
 	id, err := mgr.Start(req)
 	if err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("launch_agent: %w", err)

--- a/internal/tools/send_message.go
+++ b/internal/tools/send_message.go
@@ -15,13 +15,6 @@ type SendMessageTool struct {
 	mgr *SubAgentManager
 }
 
-func (t SendMessageTool) manager() *SubAgentManager {
-	if t.mgr != nil {
-		return t.mgr
-	}
-	return defaultSubAgentMgr
-}
-
 func (SendMessageTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name: "send_message",
@@ -65,9 +58,20 @@ func (t SendMessageTool) Execute(ctx context.Context, _ string, input map[string
 		return agent.ToolResult{Text: ""}, fmt.Errorf("send_message: message is required")
 	}
 
-	mgr := t.manager()
+	mgr := resolveSubAgentManager(ctx, t.mgr)
 	if mgr == nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("send_message: sub-agent dispatch is not configured for this session")
+	}
+
+	// Synchronous transports continue the child inline and return its reply,
+	// matching the synchronous launch_agent path. agentID is the spawner-side
+	// id launch_agent surfaced in its [agent <id>] tag.
+	if mgr.Synchronous() {
+		res, err := mgr.ContinueSync(ctx, agentID, message)
+		if err != nil {
+			return agent.ToolResult{Text: ""}, fmt.Errorf("send_message: %w", err)
+		}
+		return agent.ToolResult{Text: withAgentTag(res.AgentID, res.Reply)}, nil
 	}
 
 	if err := mgr.Send(agentID, message); err != nil {

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -124,12 +124,13 @@ func SetDefaultSubAgentManager(m *SubAgentManager) { defaultSubAgentMgr = m }
 // SubAgentManager owns the set of async sub-agents for a session.
 // Methods are safe for concurrent use.
 type SubAgentManager struct {
-	mu      sync.Mutex
-	agents  map[string]*asyncSubAgent
-	seq     int
-	spawner Spawner
-	onExit  func(SubAgentNotification)
-	onEvent func(SubAgentEvent)
+	mu          sync.Mutex
+	agents      map[string]*asyncSubAgent
+	seq         int
+	spawner     Spawner
+	onExit      func(SubAgentNotification)
+	onEvent     func(SubAgentEvent)
+	synchronous bool
 }
 
 // NewSubAgentManager returns an empty manager.
@@ -138,6 +139,80 @@ func NewSubAgentManager(spawner Spawner) *SubAgentManager {
 		agents:  map[string]*asyncSubAgent{},
 		spawner: spawner,
 	}
+}
+
+// SetSynchronous selects the launch_agent dispatch model. The default (false)
+// is the interactive async path: Start returns immediately and the reply
+// arrives via onExit, which the REPL/TUI re-injects as a follow-up turn. A
+// request/response transport (HTTP server, IM bridge) has no follow-up-turn
+// channel, so it sets this true: launch_agent then blocks the turn on RunSync
+// and returns the child's reply directly as the tool_result. Set once at
+// startup, before any turn runs.
+func (m *SubAgentManager) SetSynchronous(v bool) {
+	m.mu.Lock()
+	m.synchronous = v
+	m.mu.Unlock()
+}
+
+// Synchronous reports whether the manager runs sub-agents inline (see
+// SetSynchronous).
+func (m *SubAgentManager) Synchronous() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.synchronous
+}
+
+// RunSync spawns a sub-agent and blocks until it completes, returning its
+// reply. Used by the synchronous launch_agent path; the spawner stamps the
+// sub-agent marker and keeps the child resumable for a later ContinueSync.
+func (m *SubAgentManager) RunSync(ctx context.Context, req SpawnRequest) (SpawnResult, error) {
+	if m.spawner == nil {
+		return SpawnResult{}, fmt.Errorf("subagent: no spawner configured")
+	}
+	return m.spawner.Spawn(ctx, req)
+}
+
+// ContinueSync re-runs a still-alive sub-agent (addressed by its spawner-side
+// id) with a new message and blocks until it replies. The synchronous
+// counterpart of Send.
+func (m *SubAgentManager) ContinueSync(ctx context.Context, agentID, message string) (SpawnResult, error) {
+	if m.spawner == nil {
+		return SpawnResult{}, fmt.Errorf("subagent: no spawner configured")
+	}
+	return m.spawner.Continue(ctx, agentID, message)
+}
+
+// subAgentManagerCtxKey carries a per-turn SubAgentManager so the sub-agent
+// tools dispatch to it instead of the process-global defaultSubAgentMgr. A
+// request/response transport (server, IM) builds a fresh manager bound to the
+// turn's agent and stamps it here; the interactive CLI leaves it unset and
+// falls through to the global.
+type subAgentManagerCtxKeyType struct{}
+
+var subAgentManagerCtxKey = subAgentManagerCtxKeyType{}
+
+// WithSubAgentManager returns ctx carrying mgr for the sub-agent tools to find.
+func WithSubAgentManager(ctx context.Context, mgr *SubAgentManager) context.Context {
+	return context.WithValue(ctx, subAgentManagerCtxKey, mgr)
+}
+
+// subAgentManagerFromContext returns the ctx-scoped manager, or nil.
+func subAgentManagerFromContext(ctx context.Context) *SubAgentManager {
+	m, _ := ctx.Value(subAgentManagerCtxKey).(*SubAgentManager)
+	return m
+}
+
+// resolveSubAgentManager picks the manager a tool should dispatch to: the
+// ctx-scoped one (per-turn, server/IM) first, then a tool-local override, then
+// the process-global default (CLI). Returns nil when none is configured.
+func resolveSubAgentManager(ctx context.Context, local *SubAgentManager) *SubAgentManager {
+	if m := subAgentManagerFromContext(ctx); m != nil {
+		return m
+	}
+	if local != nil {
+		return local
+	}
+	return defaultSubAgentMgr
 }
 
 // SetOnExit registers a completion hook fired once per sub-agent when it

--- a/internal/tools/subagent_sync_test.go
+++ b/internal/tools/subagent_sync_test.go
@@ -1,0 +1,130 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/tasks"
+)
+
+// TestLaunchAgentSyncReturnsReplyDirectly verifies the synchronous launch_agent
+// path: with a synchronous manager, Execute blocks on the spawner and returns
+// the child's reply as the tool_result (tagged with the agent id), rather than
+// the async "Started…" acknowledgement.
+func TestLaunchAgentSyncReturnsReplyDirectly(t *testing.T) {
+	sp := &mockSpawner{replies: []SpawnResult{{Reply: "child answer", AgentID: "c1"}}}
+	mgr := NewSubAgentManager(sp)
+	mgr.SetSynchronous(true)
+
+	ctx := WithSubAgentManager(context.Background(), mgr)
+	res, err := (LaunchAgentTool{}).Execute(ctx, "launch_agent", map[string]any{
+		"description": "do a thing",
+		"prompt":      "the task",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(res.Text, "Started") {
+		t.Errorf("sync launch should return the reply, not an async ack: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "child answer") {
+		t.Errorf("expected child reply in result, got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "c1") {
+		t.Errorf("expected [agent c1] tag in result, got %q", res.Text)
+	}
+	if len(sp.spawns) != 1 {
+		t.Errorf("expected 1 synchronous spawn, got %d", len(sp.spawns))
+	}
+}
+
+// TestLaunchAgentAsyncUnchanged is the regression guard that the default
+// (interactive) path still fires-and-forgets with a "Started…" ack.
+func TestLaunchAgentAsyncUnchanged(t *testing.T) {
+	sp := &mockSpawner{replies: []SpawnResult{{Reply: "x", AgentID: "c1"}}}
+	mgr := NewSubAgentManager(sp) // not synchronous
+
+	ctx := WithSubAgentManager(context.Background(), mgr)
+	res, err := (LaunchAgentTool{}).Execute(ctx, "launch_agent", map[string]any{
+		"description": "d",
+		"prompt":      "p",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res.Text, "Started") {
+		t.Errorf("async launch should return a Started ack, got %q", res.Text)
+	}
+}
+
+// TestCtxManagerPreferredOverGlobal verifies dispatch resolves the ctx-scoped
+// manager ahead of the process-global default — the core of per-session
+// isolation on the server / IM bridge.
+func TestCtxManagerPreferredOverGlobal(t *testing.T) {
+	globalSp := &mockSpawner{replies: []SpawnResult{{Reply: "global", AgentID: "g"}}}
+	globalMgr := NewSubAgentManager(globalSp) // async
+	SetDefaultSubAgentManager(globalMgr)
+	t.Cleanup(func() { SetDefaultSubAgentManager(nil) })
+
+	ctxSp := &mockSpawner{replies: []SpawnResult{{Reply: "scoped reply", AgentID: "s"}}}
+	ctxMgr := NewSubAgentManager(ctxSp)
+	ctxMgr.SetSynchronous(true)
+
+	ctx := WithSubAgentManager(context.Background(), ctxMgr)
+	res, err := (LaunchAgentTool{}).Execute(ctx, "launch_agent", map[string]any{"prompt": "p"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res.Text, "scoped reply") {
+		t.Errorf("expected the ctx-scoped manager to handle the call, got %q", res.Text)
+	}
+	if len(ctxSp.spawns) != 1 || len(globalSp.spawns) != 0 {
+		t.Errorf("ctx spawner should run (1) and global should not (0); got ctx=%d global=%d",
+			len(ctxSp.spawns), len(globalSp.spawns))
+	}
+}
+
+// TestSendMessageSyncContinues verifies the synchronous send_message path
+// continues the child inline and returns its reply.
+func TestSendMessageSyncContinues(t *testing.T) {
+	sp := &mockSpawner{replies: []SpawnResult{{Reply: "continued", AgentID: "c1"}}}
+	mgr := NewSubAgentManager(sp)
+	mgr.SetSynchronous(true)
+
+	ctx := WithSubAgentManager(context.Background(), mgr)
+	res, err := (SendMessageTool{}).Execute(ctx, "send_message", map[string]any{
+		"agent_id": "c1",
+		"message":  "keep going",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res.Text, "continued") {
+		t.Errorf("expected continued reply, got %q", res.Text)
+	}
+	if len(sp.cont) != 1 || sp.cont[0].id != "c1" {
+		t.Errorf("expected one Continue on c1, got %+v", sp.cont)
+	}
+}
+
+// TestTaskStoreCtxScoped verifies task_* tools write to the ctx-scoped store,
+// not the process-global one — so concurrent server sessions don't share tasks.
+func TestTaskStoreCtxScoped(t *testing.T) {
+	global := tasks.New()
+	SetTaskStore(global)
+	t.Cleanup(func() { SetTaskStore(nil) })
+
+	scoped := tasks.New()
+	ctx := WithTaskStore(context.Background(), scoped)
+
+	if _, err := (TaskCreateTool{}).Execute(ctx, "task_create", map[string]any{"subject": "scoped task"}); err != nil {
+		t.Fatalf("task_create: %v", err)
+	}
+	if got := len(scoped.List()); got != 1 {
+		t.Errorf("expected the ctx-scoped store to hold the task, got %d", got)
+	}
+	if got := len(global.List()); got != 0 {
+		t.Errorf("expected the global store untouched, got %d", got)
+	}
+}

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -37,6 +37,35 @@ func ActiveTaskStore() TaskStore { return activeTasks }
 
 func tasksEnabled() bool { return activeTasks != nil }
 
+// taskStoreCtxKey carries a per-turn TaskStore so the task_* tools dispatch to
+// it instead of the process-global activeTasks. A request/response transport
+// (server, IM) stamps a fresh per-session store here; the interactive CLI
+// leaves it unset and falls through to the global.
+type taskStoreCtxKeyType struct{}
+
+var taskStoreCtxKey = taskStoreCtxKeyType{}
+
+// WithTaskStore returns ctx carrying store for the task_* tools to find.
+func WithTaskStore(ctx context.Context, store TaskStore) context.Context {
+	return context.WithValue(ctx, taskStoreCtxKey, store)
+}
+
+// taskStoreFromContext returns the ctx-scoped store, or nil.
+func taskStoreFromContext(ctx context.Context) TaskStore {
+	s, _ := ctx.Value(taskStoreCtxKey).(TaskStore)
+	return s
+}
+
+// resolveTaskStore picks the store a task_* tool should use: the ctx-scoped one
+// (per-turn, server/IM) first, then the process-global default (CLI). Returns
+// nil when none is configured.
+func resolveTaskStore(ctx context.Context) TaskStore {
+	if s := taskStoreFromContext(ctx); s != nil {
+		return s
+	}
+	return activeTasks
+}
+
 // ============================================================================
 // task_create
 // ============================================================================
@@ -75,15 +104,16 @@ func (TaskCreateTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (TaskCreateTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
-	if !tasksEnabled() {
+func (TaskCreateTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	store := resolveTaskStore(ctx)
+	if store == nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("task_create: task tracking is not configured for this session")
 	}
 	subject := strings.TrimSpace(stringArg(input, "subject"))
 	if subject == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("task_create: subject is required")
 	}
-	id, err := activeTasks.Create(
+	id, err := store.Create(
 		subject,
 		stringArg(input, "description"),
 		stringArg(input, "active_form"),
@@ -142,8 +172,9 @@ func (TaskUpdateTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (TaskUpdateTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
-	if !tasksEnabled() {
+func (TaskUpdateTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	store := resolveTaskStore(ctx)
+	if store == nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("task_update: task tracking is not configured for this session")
 	}
 	id := intArg(input, "task_id", 0)
@@ -176,7 +207,7 @@ func (TaskUpdateTool) Execute(_ context.Context, _ string, input map[string]any)
 		return agent.ToolResult{Text: ""}, fmt.Errorf("task_update: nothing to update (provide status, subject, description, or active_form)")
 	}
 
-	got, err := activeTasks.Update(id, u)
+	got, err := store.Update(id, u)
 	if err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("task_update: %w", err)
 	}
@@ -205,11 +236,12 @@ func (TaskListTool) Definition() agent.ToolDefinition {
 	}
 }
 
-func (TaskListTool) Execute(_ context.Context, _ string, _ map[string]any) (agent.ToolResult, error) {
-	if !tasksEnabled() {
+func (TaskListTool) Execute(ctx context.Context, _ string, _ map[string]any) (agent.ToolResult, error) {
+	store := resolveTaskStore(ctx)
+	if store == nil {
 		return agent.ToolResult{}, fmt.Errorf("task_list: task tracking is not configured for this session")
 	}
-	return agent.ToolResult{Text: FormatTaskList(activeTasks.List())}, nil
+	return agent.ToolResult{Text: FormatTaskList(store.List())}, nil
 }
 
 // FormatTaskList renders a slice of tasks for display. Used both by the


### PR DESCRIPTION
## What

Gives the HTTP server real **sub-agent** (`launch_agent`/`send_message`) and **task** (`task_*`) support — the last capability gap from the unified-bootstrap design.

It couldn't have them before because the whole subsystem is **process-global and shaped for the interactive loop**: dispatch resolves a global manager / task store, the spawner binds to one parent agent, and `launch_agent` is **async fire-and-forget** (its reply arrives via an `onExit` hook the REPL re-injects as a follow-up turn). The server — fresh agent per turn, concurrent sessions — fits none of that.

## How

**Context-scoped dispatch (additive — CLI unchanged).** `internal/tools` gains `WithSubAgentManager`/`WithTaskStore` (ctx) + accessors. The `launch_agent`/`send_message`/`agent_status`/`kill_agent` and `task_*` tools resolve **ctx-first → tool-local → process-global**. The CLI never stamps ctx, so it keeps using the globals it already sets — zero behavior change there.

**Synchronous spawn path.** `SubAgentManager` gains `SetSynchronous` + `RunSync`/`ContinueSync`. When synchronous, `launch_agent` blocks on the spawner and returns the child's reply directly as the tool_result (tagged `[agent <id>]`) instead of the async "Started…" ack; `send_message` continues inline likewise.

**Server wiring.** `New` registers the gating sentinels so `DefaultToolsFor` advertises the tools (reset in `Shutdown`). Each turn (`prepareToolTurn`, shared by `runTurn` + SSE) builds a synchronous manager + fresh task store **bound to that turn's agent** and stamps them into ctx — so `System`/`Model`/`Gate`/token-accrual are correct and **concurrent sessions never share sub-agent or task state**.

**Permission policy.** `defaults.yml` now allows the control-plane tools (`launch_agent`, `send_message`, `agent_status`, `kill_agent`, `task_*`). They have no direct side effect — a sub-agent **inherits its parent's gate** (so its real actions are still gated) and `task_*` are in-memory bookkeeping. Without this they'd fall through to the implicit `ask`, which a non-interactive transport (server, IM) resolves to **deny**, silently disabling the feature. Side benefit: the CLI no longer prompts on these meta tools.

## Out of scope (follow-up)
- **IM bridge wiring** — reuses the same per-turn ctx setup in `cmd/octo/channel.go`; next PR.
- **MCP / Tool Search** parity.
- **Parallel** sync sub-agents (a `launch_agent` batch runs serially in sync mode; correct, just not concurrent). `agent_status`/`kill_agent` report nothing in sync mode (no detached agent once the reply has returned) — a known, harmless limitation.

## Tests
- `internal/tools`: ctx-over-global resolution; sync vs async launch; sync send; ctx-scoped task store.
- `internal/server`: tool advertisement after start; a full turn that runs a sub-agent **inline** (parent → child → parent in one request, proven by 3 sender calls).

## Verification
`go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test -race ./...` green (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)