### PR TITLE
feat(channel): sub-agent + task parity on the IM bridge (PR2b-2)

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/prompt"
 	"github.com/Leihb/octo-agent/internal/skills"
+	"github.com/Leihb/octo-agent/internal/tasks"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
@@ -167,6 +168,14 @@ func runChannelStart(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 		return a
 	}
 
+	// Advertise sub-agent + task tools by registering the process-global gating
+	// sentinels. Each message overrides them with a ctx-scoped manager + store
+	// (see handleAgentMessage), so this is gating-only + a never-hit fallback.
+	// Skipped when tools are off.
+	if !*noTools {
+		defer registerChannelSubAgentTools(agentFactory())()
+	}
+
 	mode := channel.BindingMode(*bindMode)
 	mgr := channel.NewManager(chCfg, agentFactory, mode)
 
@@ -243,8 +252,21 @@ func handleAgentMessage(ctx context.Context, mgr *channel.Manager, ad channel.Ad
 	var toolDefs []agent.ToolDefinition
 	var executor agent.ToolExecutor
 	if toolsOn {
-		toolDefs = tools.DefaultTools()
 		executor = tools.NewDefaultRegistry()
+		toolDefs = tools.DefaultToolsFor(sess.Agent.Model)
+
+		// Per-message sub-agent manager + task store bound to THIS chat's agent,
+		// stamped into ctx so the sub-agent / task tools dispatch to them rather
+		// than the process-global gating sentinels. Synchronous — a chat message
+		// is request/response with no follow-up channel for an async result — and
+		// each message gets a private store, so concurrent chats stay isolated.
+		spawner := app.NewSpawner(sess.Agent, executor, func() []agent.ToolDefinition {
+			return tools.DefaultToolsFor(sess.Agent.Model)
+		})
+		subMgr := tools.NewSubAgentManager(spawner)
+		subMgr.SetSynchronous(true)
+		ctx = tools.WithSubAgentManager(ctx, subMgr)
+		ctx = tools.WithTaskStore(ctx, tasks.New())
 	}
 
 	_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, ev.Text)
@@ -261,4 +283,26 @@ func newChannelGate(cwd string) (agent.PermissionGate, error) {
 		return nil, fmt.Errorf("permission engine: %w", err)
 	}
 	return app.NewPermissionGate(engine, nil), nil
+}
+
+// registerChannelSubAgentTools installs the process-global sub-agent manager +
+// task store so DefaultToolsFor advertises launch_agent / send_message /
+// task_* . These are gating sentinels and a never-hit fallback — each message
+// stamps its own ctx-scoped, synchronous manager + store bound to that chat's
+// agent (handleAgentMessage), which dispatch prefers, so concurrent chats never
+// share sub-agent or task state. The template agent only seeds the sentinel
+// spawner. Returns a cleanup that clears the registrations.
+func registerChannelSubAgentTools(template *agent.Agent) func() {
+	executor := tools.NewDefaultRegistry()
+	spawner := app.NewSpawner(template, executor, func() []agent.ToolDefinition {
+		return tools.DefaultToolsFor(template.Model)
+	})
+	sub := tools.NewSubAgentManager(spawner)
+	sub.SetSynchronous(true)
+	tools.SetDefaultSubAgentManager(sub)
+	tools.SetTaskStore(tasks.New())
+	return func() {
+		tools.SetDefaultSubAgentManager(nil)
+		tools.SetTaskStore(nil)
+	}
 }

--- a/cmd/octo/channel_subagent_test.go
+++ b/cmd/octo/channel_subagent_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// TestRegisterChannelSubAgentToolsAdvertises verifies the IM bridge advertises
+// the sub-agent and task tools once the gating sentinels are registered (they'd
+// otherwise be withheld by DefaultToolsFor), and that the cleanup clears them.
+func TestRegisterChannelSubAgentToolsAdvertises(t *testing.T) {
+	template := agent.New(&stubSender{}, "test-model")
+
+	cleanup := registerChannelSubAgentTools(template)
+	defer cleanup()
+
+	names := map[string]bool{}
+	for _, d := range tools.DefaultToolsFor("") {
+		names[d.Name] = true
+	}
+	for _, want := range []string{"launch_agent", "send_message", "task_create", "task_list"} {
+		if !names[want] {
+			t.Errorf("expected %q advertised after registerChannelSubAgentTools", want)
+		}
+	}
+
+	cleanup()
+	cleared := map[string]bool{}
+	for _, d := range tools.DefaultToolsFor("") {
+		cleared[d.Name] = true
+	}
+	if cleared["launch_agent"] {
+		t.Error("expected launch_agent withdrawn after cleanup")
+	}
+}


### PR DESCRIPTION
## What

Completes the capability parity started in PR2b (#393, server). The IM bridge (`octo channel start`) now has **sub-agents** and **tasks**, reusing the same context-scoped, synchronous mechanism — no new machinery, just wiring.

## How

- **Startup:** `registerChannelSubAgentTools` installs the process-global gating sentinels (sync manager + task store) so `DefaultToolsFor` advertises `launch_agent` / `send_message` / `task_*`. Cleared on shutdown.
- **Per message:** `handleAgentMessage` builds a synchronous `SubAgentManager` + fresh task store **bound to that chat's agent** (`sess.Agent`) and stamps them into ctx; dispatch prefers them over the sentinels. Tool list switches from `DefaultTools()` to `DefaultToolsFor(sess.Agent.Model)`. Concurrent chats never share sub-agent or task state, and a sub-agent runs **inline** within the message (a chat is request/response — no async follow-up channel).

Sub-agents inherit the chat's gate (PR3), and the control-plane tools are allowed by the default policy (PR2b), so this works under the bridge's strict, non-interactive gate.

## Out of scope (same deferrals as PR2b)
- MCP / Tool Search parity.
- Parallel sync sub-agents (a `launch_agent` batch runs serially); `agent_status`/`kill_agent` are no-ops in sync mode.
- Task store is **per-message** (consistent with the server), not per-chat-session — per-session persistence could be a future enhancement.

## Tests
- `cmd/octo`: `registerChannelSubAgentTools` advertises the sub-agent/task tools and the cleanup withdraws them.

## Verification
`go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test -race ./...` green (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)