### PR TITLE
feat(app): MCP + Tool Search parity for server and IM bridge (PR2c)

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -168,12 +168,19 @@ func runChannelStart(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 		return a
 	}
 
-	// Advertise sub-agent + task tools by registering the process-global gating
-	// sentinels. Each message overrides them with a ctx-scoped manager + store
-	// (see handleAgentMessage), so this is gating-only + a never-hit fallback.
-	// Skipped when tools are off.
+	// Tool environment, skipped when tools are off:
+	//   - sub-agent + task gating sentinels (each message overrides them with a
+	//     ctx-scoped manager + store; see handleAgentMessage),
+	//   - Tool Search config + MCP servers, connected non-interactively so the
+	//     bridge gets the same MCP surface as the CLI.
 	if !*noTools {
 		defer registerChannelSubAgentTools(agentFactory())()
+		tools.SetToolSearchConfig(app.ToolSearchConfigFrom(cfg.Tools.ToolSearch))
+		mcpCleanup, mcpErr := app.ConnectMCP(context.Background(), cwd, stderr)
+		if mcpErr != nil {
+			fmt.Fprintf(stderr, "octo channel: mcp: %v\n", mcpErr)
+		}
+		defer mcpCleanup()
 	}
 
 	mode := channel.BindingMode(*bindMode)

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -158,22 +158,10 @@ func resolveShowReasoning(flagSet, flagVal bool, cfg config.Config) bool {
 }
 
 // toolSearchConfigFrom maps the persisted tools.tool_search block onto the
-// tools-package config. Unknown/empty "enabled" defaults to auto; numeric zero
-// values are left for SetToolSearchConfig to backfill with documented defaults.
+// tools-package config. Delegates to app.ToolSearchConfigFrom so every entry
+// point shares one conversion.
 func toolSearchConfigFrom(c config.ToolSearchConfig) tools.ToolSearchConfig {
-	mode := tools.ToolSearchAuto
-	switch c.Enabled {
-	case "on":
-		mode = tools.ToolSearchOn
-	case "off":
-		mode = tools.ToolSearchOff
-	}
-	return tools.ToolSearchConfig{
-		Mode:           mode,
-		ThresholdPct:   c.ThresholdPct,
-		SearchLimit:    c.SearchDefaultLimit,
-		MaxSearchLimit: c.MaxSearchLimit,
-	}
+	return app.ToolSearchConfigFrom(c)
 }
 
 // resolveReasoningEffort picks the reasoning intensity: --reasoning-effort flag

--- a/internal/app/mcp.go
+++ b/internal/app/mcp.go
@@ -1,0 +1,75 @@
+package app
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/config"
+	"github.com/Leihb/octo-agent/internal/mcp"
+	"github.com/Leihb/octo-agent/internal/tools"
+	"github.com/Leihb/octo-agent/internal/version"
+)
+
+// mcpConnectTimeout bounds the whole non-interactive connect pass. It caps the
+// per-server windows in mcp.connectOne (notably the 5-minute OAuth budget),
+// since a non-interactive transport can't complete a device flow anyway — an
+// OAuth server without a cached/refreshable token is skipped within this bound
+// rather than hanging startup.
+const mcpConnectTimeout = 60 * time.Second
+
+// ConnectMCP loads the MCP server config under cwd, connects every server
+// non-interactively, and registers the resulting surface so DefaultToolsFor /
+// the tool executor pick it up. It is the server/IM counterpart to the CLI's
+// own (interactive, OAuth-prompting) connect path — here authPromptFor is nil,
+// so servers needing a fresh device flow are skipped (mcp.deviceFlow nil-guards
+// the prompt) while stdio, header-auth, and cached-OAuth servers connect.
+//
+// Returns a cleanup that unregisters and closes the registry; it is always
+// non-nil (a no-op when no servers connected), so callers can defer it
+// unconditionally. warn receives per-server skip diagnostics.
+func ConnectMCP(ctx context.Context, cwd string, warn io.Writer) (func(), error) {
+	cfg, err := mcp.LoadConfig(cwd)
+	if err != nil {
+		return func() {}, err
+	}
+	if cfg == nil || len(cfg.Servers) == 0 {
+		return func() {}, nil
+	}
+
+	connectCtx, cancel := context.WithTimeout(ctx, mcpConnectTimeout)
+	defer cancel() // only bounds the connect pass; live connections aren't tied to it
+
+	info := mcp.Implementation{Name: "octo", Version: version.Version}
+	reg := mcp.ConnectAll(connectCtx, cfg, info, nil /* no interactive OAuth */, warn, nil)
+	if reg.Len() == 0 {
+		reg.Close()
+		return func() {}, nil
+	}
+
+	tools.SetMCPRegistry(reg)
+	return func() {
+		tools.SetMCPRegistry(nil)
+		reg.Close()
+	}, nil
+}
+
+// ToolSearchConfigFrom maps the persisted tools.tool_search config block onto
+// the tools-package config. Unknown/empty "enabled" defaults to auto; numeric
+// zero values are left for SetToolSearchConfig to backfill with its documented
+// defaults. Shared by every entry point so Tool Search behaves identically.
+func ToolSearchConfigFrom(c config.ToolSearchConfig) tools.ToolSearchConfig {
+	mode := tools.ToolSearchAuto
+	switch c.Enabled {
+	case "on":
+		mode = tools.ToolSearchOn
+	case "off":
+		mode = tools.ToolSearchOff
+	}
+	return tools.ToolSearchConfig{
+		Mode:           mode,
+		ThresholdPct:   c.ThresholdPct,
+		SearchLimit:    c.SearchDefaultLimit,
+		MaxSearchLimit: c.MaxSearchLimit,
+	}
+}

--- a/internal/app/mcp_test.go
+++ b/internal/app/mcp_test.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/config"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+func TestToolSearchConfigFrom(t *testing.T) {
+	cases := []struct {
+		enabled string
+		want    tools.ToolSearchMode
+	}{
+		{"on", tools.ToolSearchOn},
+		{"off", tools.ToolSearchOff},
+		{"", tools.ToolSearchAuto},
+		{"garbage", tools.ToolSearchAuto},
+	}
+	for _, c := range cases {
+		got := ToolSearchConfigFrom(config.ToolSearchConfig{
+			Enabled:            c.enabled,
+			ThresholdPct:       42,
+			SearchDefaultLimit: 7,
+			MaxSearchLimit:     99,
+		})
+		if got.Mode != c.want {
+			t.Errorf("enabled=%q: mode = %v, want %v", c.enabled, got.Mode, c.want)
+		}
+		if got.ThresholdPct != 42 || got.SearchLimit != 7 || got.MaxSearchLimit != 99 {
+			t.Errorf("enabled=%q: numeric fields not passed through: %+v", c.enabled, got)
+		}
+	}
+}
+
+// TestConnectMCPNoServers verifies the no-config path: with no MCP config under
+// HOME or the project dir, ConnectMCP is a no-op that returns a non-nil cleanup
+// and registers nothing.
+func TestConnectMCPNoServers(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp) // Windows home
+
+	cleanup, err := ConnectMCP(context.Background(), t.TempDir(), io.Discard)
+	if err != nil {
+		t.Fatalf("ConnectMCP: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("cleanup must be non-nil even when no servers connect")
+	}
+	cleanup() // must not panic
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -65,6 +65,10 @@ type Server struct {
 	// session-scoped turn locks: one turn per session at a time.
 	turnLocks map[string]*sync.Mutex
 	turnMu    sync.Mutex
+
+	// mcpCleanup unregisters + closes the MCP registry connected at start.
+	// Always non-nil after New (a no-op when no servers connected).
+	mcpCleanup func()
 }
 
 // New builds a Server. It resolves provider/model, discovers skills, and
@@ -101,6 +105,7 @@ func New(cfg Config) (*Server, error) {
 
 	s.registerRoutes()
 	s.enableSubAgentTools()
+	s.enableMCP()
 
 	s.http = &http.Server{
 		Addr:         cfg.Addr,
@@ -136,6 +141,27 @@ func (s *Server) enableSubAgentTools() {
 	tools.SetTaskStore(tasks.New())
 }
 
+// enableMCP applies the Tool Search config and connects the configured MCP
+// servers non-interactively, registering their surface so DefaultToolsFor
+// advertises them (or the Tool Search bridge). Best-effort: a misconfigured or
+// unreachable server is logged and skipped. No-op when tools are disabled.
+// mcpCleanup is always set (a no-op when nothing connected) so Shutdown can call
+// it unconditionally.
+func (s *Server) enableMCP() {
+	s.mcpCleanup = func() {}
+	if !s.cfg.Tools {
+		return
+	}
+	if cfg, err := config.Load(); err == nil {
+		tools.SetToolSearchConfig(app.ToolSearchConfigFrom(cfg.Tools.ToolSearch))
+	}
+	cleanup, err := app.ConnectMCP(context.Background(), s.cwd, os.Stderr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "octo serve: mcp: %v\n", err)
+	}
+	s.mcpCleanup = cleanup
+}
+
 // ListenAndServe starts the HTTP server.
 func (s *Server) ListenAndServe() error {
 	return s.http.ListenAndServe()
@@ -146,6 +172,9 @@ func (s *Server) ListenAndServe() error {
 func (s *Server) Shutdown(ctx context.Context) error {
 	tools.SetDefaultSubAgentManager(nil)
 	tools.SetTaskStore(nil)
+	if s.mcpCleanup != nil {
+		s.mcpCleanup()
+	}
 	return s.http.Shutdown(ctx)
 }
 


### PR DESCRIPTION
## What

The final capability gap from the unified-bootstrap design: only the CLI connected MCP servers and applied the Tool Search config. The HTTP server and IM bridge never called `SetMCPRegistry` (count was always 0) or `SetToolSearchConfig`, so MCP tools and Tool Search were unavailable there.

This closes it with a shared, **non-interactive** connector in `internal/app`.

## How

- **`app.ConnectMCP(ctx, cwd, warn)`** — loads the MCP config, connects every server with a **nil OAuth prompt** (`mcp.deviceFlow` nil-guards it: stdio / header-auth / cached-OAuth servers connect; a fresh device-flow server is skipped, since a non-interactive process can't complete one), registers the surface via `tools.SetMCPRegistry`, and returns an always-non-nil cleanup. A **60s connect bound** caps the per-server OAuth window so a token-less OAuth server can't hang startup.
- **`app.ToolSearchConfigFrom`** — the `config → tools` converter, lifted out of `cmd/octo` (whose `toolSearchConfigFrom` now delegates) so all three entry points share one mapping.

**Wiring**
- `internal/server`: `New` calls `enableMCP()` (`SetToolSearchConfig` + `ConnectMCP`, best-effort/logged); `Shutdown` runs the cleanup. Per-turn tool lists already use `DefaultToolsFor(model)` (PR2b), so MCP tools / the Tool Search bridge now ride along automatically.
- `cmd/octo/channel.go`: the tools-on startup block now also sets Tool Search and connects MCP, deferring the cleanup.

Both connect synchronously at startup, like the CLI's headless path.

## Result: full parity

| capability | CLI | HTTP server | IM bridge |
|---|---|---|---|
| provider construction (`internal/app`) | ✅ | ✅ | ✅ |
| permission gate | ✅ | ✅ | ✅ |
| sub-agents + tasks | ✅ | ✅ | ✅ |
| **MCP + Tool Search** | ✅ | ✅ **(this PR)** | ✅ **(this PR)** |

## Tests
- `internal/app`: the config converter (on/off/auto + numeric passthrough) and the no-server connect path (hermetic — `HOME`/`USERPROFILE` + project dir isolated).

## Verification
`go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test -race ./...` green (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)