### PR TITLE
fix(agent): guard session token counters; withhold status/kill in sync mode (PR2d)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -149,6 +149,11 @@ type Agent struct {
 	// and retrying. Aligned with Ruby's perform_context_overflow_compression.
 	overflow overflowRecovery
 
+	// usageMu guards the cumulative counters below. They are written by the
+	// turn loop (accrueUsage) AND by sub-agent goroutines (AccrueChildUsage,
+	// which run concurrently when a launch_agent batch fans out), and read from
+	// the TUI goroutine (SessionTokens / ContextUsage / SessionCacheTokens).
+	usageMu sync.Mutex
 	// Cumulative token counts for this session (all turns combined).
 	sessionInputTokens  int
 	sessionOutputTokens int
@@ -1226,6 +1231,8 @@ func textFromBlocks(blocks []ContentBlock) string {
 // accrueUsage folds one reply's token/cache counts into the session totals
 // and records the context size used by the compaction trigger.
 func (a *Agent) accrueUsage(reply Reply) {
+	a.usageMu.Lock()
+	defer a.usageMu.Unlock()
 	a.sessionInputTokens += reply.InputTokens
 	a.sessionOutputTokens += reply.OutputTokens
 	a.sessionCacheReadTokens += reply.CacheReadTokens
@@ -1243,6 +1250,8 @@ func (a *Agent) accrueUsage(reply Reply) {
 // SessionTokens returns the cumulative input and output token counts for all
 // turns made so far in this Agent's lifetime.
 func (a *Agent) SessionTokens() (inputTokens, outputTokens int) {
+	a.usageMu.Lock()
+	defer a.usageMu.Unlock()
 	return a.sessionInputTokens, a.sessionOutputTokens
 }
 
@@ -1252,8 +1261,26 @@ func (a *Agent) SessionTokens() (inputTokens, outputTokens int) {
 // left untouched — the child runs against the same provider but reports its
 // own cache hits internally; the parent only sees the bottom-line counts here.
 func (a *Agent) AccrueChildUsage(inputTokens, outputTokens int) {
+	a.addUsage(inputTokens, outputTokens)
+}
+
+// addUsage folds input/output token counts into the session totals under the
+// usage lock. Shared by AccrueChildUsage (concurrent sub-agent goroutines) and
+// the internal sub-operation accruals (compaction / consolidation / planning),
+// all of which can run while a sub-agent goroutine is still accruing.
+func (a *Agent) addUsage(inputTokens, outputTokens int) {
+	a.usageMu.Lock()
+	defer a.usageMu.Unlock()
 	a.sessionInputTokens += inputTokens
 	a.sessionOutputTokens += outputTokens
+}
+
+// resetContextTrigger zeroes the compaction-trigger context size under the
+// usage lock (it's read from the TUI goroutine via ContextUsage).
+func (a *Agent) resetContextTrigger() {
+	a.usageMu.Lock()
+	a.lastInputTokens = 0
+	a.usageMu.Unlock()
 }
 
 // ContextUsage reports how full the model's context window is: used is the
@@ -1261,13 +1288,18 @@ func (a *Agent) AccrueChildUsage(inputTokens, outputTokens int) {
 // window is the model's approximate context-window size. Lets the TUI status
 // bar render a "ctx N%" gauge. window is always > 0.
 func (a *Agent) ContextUsage() (used, window int) {
-	return a.lastInputTokens, contextWindow(a.Model)
+	a.usageMu.Lock()
+	used = a.lastInputTokens
+	a.usageMu.Unlock()
+	return used, contextWindow(a.Model)
 }
 
 // SessionCacheTokens returns the cumulative cache read/write token counts.
 // Read is input served from cache (cheap); write is input written into the
 // cache (Anthropic only). Both zero when the backend reports no cache info.
 func (a *Agent) SessionCacheTokens() (readTokens, writeTokens int) {
+	a.usageMu.Lock()
+	defer a.usageMu.Unlock()
 	return a.sessionCacheReadTokens, a.sessionCacheWriteTokens
 }
 

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -254,7 +254,7 @@ func (a *Agent) maybeCompact(ctx context.Context, handler EventHandler) error {
 		a.History.Append(m)
 	}
 	// Reset the trigger so we don't re-compact until the context grows again.
-	a.lastInputTokens = 0
+	a.resetContextTrigger()
 
 	emitCompactDone(handler, before, estimateMessages(a.History.Snapshot()), split)
 	return nil
@@ -341,8 +341,7 @@ func (a *Agent) summarize(ctx context.Context, msgs []Message, handler EventHand
 	}
 
 	// Summary tokens count toward the session budget like any other call.
-	a.sessionInputTokens += reply.InputTokens
-	a.sessionOutputTokens += reply.OutputTokens
+	a.addUsage(reply.InputTokens, reply.OutputTokens)
 	return reply.Content, nil
 }
 

--- a/internal/agent/consolidate.go
+++ b/internal/agent/consolidate.go
@@ -53,7 +53,6 @@ func (a *Agent) ConsolidateMemory(ctx context.Context, priorSummary, newNotes st
 	if err != nil {
 		return "", err
 	}
-	a.sessionInputTokens += reply.InputTokens
-	a.sessionOutputTokens += reply.OutputTokens
+	a.addUsage(reply.InputTokens, reply.OutputTokens)
 	return strings.TrimSpace(reply.Content), nil
 }

--- a/internal/agent/overflow.go
+++ b/internal/agent/overflow.go
@@ -172,7 +172,7 @@ func (a *Agent) tryOverflowCompact(ctx context.Context, pullBackMode int, handle
 		a.History.Append(m)
 	}
 
-	a.lastInputTokens = 0 // reset trigger so we don't immediately re-compact
+	a.resetContextTrigger() // reset trigger so we don't immediately re-compact
 	emitCompactDone(handler, before, estimateMessages(a.History.Snapshot()), split)
 	return true
 }

--- a/internal/agent/plan.go
+++ b/internal/agent/plan.go
@@ -133,8 +133,7 @@ func (a *Agent) PlanTask(ctx context.Context, goal string) (PlanResult, error) {
 	if err != nil {
 		return PlanResult{}, err
 	}
-	a.sessionInputTokens += reply.InputTokens
-	a.sessionOutputTokens += reply.OutputTokens
+	a.addUsage(reply.InputTokens, reply.OutputTokens)
 	return parsePlan(reply.Content)
 }
 

--- a/internal/agent/usage_race_test.go
+++ b/internal/agent/usage_race_test.go
@@ -1,0 +1,30 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestAccrueChildUsageConcurrent guards the usage-counter mutex: a fanned-out
+// launch_agent batch runs sub-agents concurrently, each folding its tokens into
+// the shared parent via AccrueChildUsage. Run with -race, this catches an
+// unguarded counter; the sum check catches lost updates.
+func TestAccrueChildUsageConcurrent(t *testing.T) {
+	a := New(&fakeSender{}, "test-model")
+
+	const n = 64
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a.AccrueChildUsage(1, 2)
+		}()
+	}
+	wg.Wait()
+
+	in, out := a.SessionTokens()
+	if in != n || out != 2*n {
+		t.Errorf("SessionTokens = (%d, %d), want (%d, %d)", in, out, n, 2*n)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -226,6 +226,10 @@ func DefaultTools() []agent.ToolDefinition { return DefaultToolsFor("") }
 func DefaultToolsFor(model string) []agent.ToolDefinition {
 	skillsOn := skillsEnabled()
 	mgrOn := subAgentManagerEnabled()
+	// In synchronous mode (server / IM bridge) sub-agents finish inline, so
+	// agent_status / kill_agent have nothing to inspect or terminate — withhold
+	// them even though the manager is on.
+	statusKillOn := mgrOn && !subAgentsSynchronous()
 	askerOn := askerEnabled()
 	tasksOn := tasksEnabled()
 	defs := make([]agent.ToolDefinition, 0, len(allTools))
@@ -242,10 +246,10 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 		if _, isSend := t.(SendMessageTool); isSend && !mgrOn {
 			continue
 		}
-		if _, isStatus := t.(AgentStatusTool); isStatus && !mgrOn {
+		if _, isStatus := t.(AgentStatusTool); isStatus && !statusKillOn {
 			continue
 		}
-		if _, isKill := t.(KillAgentTool); isKill && !mgrOn {
+		if _, isKill := t.(KillAgentTool); isKill && !statusKillOn {
 			continue
 		}
 		if _, isAsk := t.(AskUserQuestionTool); isAsk && !askerOn {

--- a/internal/tools/registry_sync_test.go
+++ b/internal/tools/registry_sync_test.go
@@ -1,0 +1,42 @@
+package tools
+
+import "testing"
+
+func advertisedNames() map[string]bool {
+	m := map[string]bool{}
+	for _, d := range DefaultToolsFor("") {
+		m[d.Name] = true
+	}
+	return m
+}
+
+// TestSyncModeWithholdsStatusKill verifies a synchronous manager (server / IM)
+// advertises launch_agent + send_message but withholds agent_status /
+// kill_agent — those have nothing to act on once sub-agents run inline.
+func TestSyncModeWithholdsStatusKill(t *testing.T) {
+	mgr := NewSubAgentManager(&mockSpawner{})
+	mgr.SetSynchronous(true)
+	SetDefaultSubAgentManager(mgr)
+	t.Cleanup(func() { SetDefaultSubAgentManager(nil) })
+
+	names := advertisedNames()
+	if !names["launch_agent"] || !names["send_message"] {
+		t.Error("launch_agent and send_message should be advertised in sync mode")
+	}
+	if names["agent_status"] || names["kill_agent"] {
+		t.Error("agent_status / kill_agent should be withheld in sync mode")
+	}
+}
+
+// TestAsyncModeAdvertisesStatusKill verifies the interactive (async) default
+// still advertises the full set, including agent_status / kill_agent.
+func TestAsyncModeAdvertisesStatusKill(t *testing.T) {
+	mgr := NewSubAgentManager(&mockSpawner{}) // async
+	SetDefaultSubAgentManager(mgr)
+	t.Cleanup(func() { SetDefaultSubAgentManager(nil) })
+
+	names := advertisedNames()
+	if !names["agent_status"] || !names["kill_agent"] {
+		t.Error("agent_status / kill_agent should be advertised in async mode")
+	}
+}

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -162,6 +162,14 @@ func (m *SubAgentManager) Synchronous() bool {
 	return m.synchronous
 }
 
+// subAgentsSynchronous reports whether the process-global manager runs
+// sub-agents inline. In synchronous mode a sub-agent completes before
+// launch_agent returns, so agent_status / kill_agent have nothing to act on —
+// DefaultToolsFor withholds them there rather than advertise dead tools.
+func subAgentsSynchronous() bool {
+	return defaultSubAgentMgr != nil && defaultSubAgentMgr.Synchronous()
+}
+
 // RunSync spawns a sub-agent and blocks until it completes, returning its
 // reply. Used by the synchronous launch_agent path; the spawner stamps the
 // sub-agent marker and keeps the child resumable for a later ContinueSync.


### PR DESCRIPTION
## What

Two finishing items for sub-agent parity.

### 1. Data race on the session token counters

`launch_agent` is in `readOnlyTools`, so a fanned-out `launch_agent` batch already runs its sub-agents **concurrently** via the parallel dispatch branch. Each child folds its tokens into the shared parent through `AccrueChildUsage`, which mutated `sessionInputTokens`/`sessionOutputTokens` with **no lock** — a pre-existing data race (also reachable in the CLI's async path; now routinely exercised by the server/IM synchronous path).

Add a `usageMu` guarding every read/write of the cumulative counters:
- writers: `accrueUsage`, `AccrueChildUsage`, and the compaction / consolidation / planning accruals (routed through a new `addUsage` helper), plus the `lastInputTokens` resets (`resetContextTrigger`).
- readers (called from the TUI goroutine): `SessionTokens`, `ContextUsage`, `SessionCacheTokens`.

### 2. `agent_status` / `kill_agent` withheld in sync mode

In synchronous mode a sub-agent completes *before* `launch_agent` returns, so these tools have nothing to inspect or terminate. `DefaultToolsFor` now withholds them when the process-global manager is synchronous (server / IM), while keeping them for the interactive CLI.

## Tests
- `internal/agent`: concurrent `AccrueChildUsage` (run under `-race`, plus a sum check for lost updates).
- `internal/tools`: `DefaultToolsFor` advertising — sync mode keeps `launch_agent`/`send_message` but drops `agent_status`/`kill_agent`; async mode keeps all.

## Verification
`go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test -race ./...` green (exit 0, no data races).

🤖 Generated with [Claude Code](https://claude.com/claude-code)