### PR TITLE
feat(channel): per-session task store for the IM bridge (PR2e)

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -262,18 +262,20 @@ func handleAgentMessage(ctx context.Context, mgr *channel.Manager, ad channel.Ad
 		executor = tools.NewDefaultRegistry()
 		toolDefs = tools.DefaultToolsFor(sess.Agent.Model)
 
-		// Per-message sub-agent manager + task store bound to THIS chat's agent,
-		// stamped into ctx so the sub-agent / task tools dispatch to them rather
-		// than the process-global gating sentinels. Synchronous — a chat message
-		// is request/response with no follow-up channel for an async result — and
-		// each message gets a private store, so concurrent chats stay isolated.
+		// Per-message sub-agent manager bound to THIS chat's agent, stamped into
+		// ctx so the sub-agent tools dispatch to it rather than the process-global
+		// gating sentinel. Synchronous — a chat message is request/response with no
+		// follow-up channel for an async result — and bound to sess.Agent so
+		// concurrent chats stay isolated.
 		spawner := app.NewSpawner(sess.Agent, executor, func() []agent.ToolDefinition {
 			return tools.DefaultToolsFor(sess.Agent.Model)
 		})
 		subMgr := tools.NewSubAgentManager(spawner)
 		subMgr.SetSynchronous(true)
 		ctx = tools.WithSubAgentManager(ctx, subMgr)
-		ctx = tools.WithTaskStore(ctx, tasks.New())
+		// The task store lives on the session, so the task list persists across
+		// messages in this chat (a fresh per-message store would reset it).
+		ctx = tools.WithTaskStore(ctx, sess.Tasks)
 	}
 
 	_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, ev.Text)

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tasks"
 )
 
 // BindingMode determines how an inbound message maps to an agent session.
@@ -44,8 +45,13 @@ func sessionKeyFor(mode BindingMode, ev InboundEvent) SessionKey {
 
 // Session holds the agent and its binding state for one conversation.
 type Session struct {
-	Key     SessionKey
-	Agent   *agent.Agent
+	Key   SessionKey
+	Agent *agent.Agent
+	// Tasks is the conversation's task store. It lives as long as the session,
+	// so task_* state persists across messages within one chat (a fresh
+	// per-message store would reset the list every turn). Stamped into the turn
+	// ctx by the IM handler; *tasks.Store satisfies tools.TaskStore.
+	Tasks   *tasks.Store
 	ChatID  string
 	UserID  string
 	BoundAt time.Time
@@ -53,6 +59,20 @@ type Session struct {
 
 // AgentFactory creates a new agent.Agent for a session.
 type AgentFactory func() *agent.Agent
+
+// newSession builds a Session with a fresh agent and per-conversation task
+// store. Centralised so every binding path (explicit /bind, auto-create on
+// first message, GetOrCreateSession) wires sessions identically.
+func (m *Manager) newSession(key SessionKey, ev InboundEvent) *Session {
+	return &Session{
+		Key:     key,
+		Agent:   m.factory(),
+		Tasks:   tasks.New(),
+		ChatID:  ev.ChatID,
+		UserID:  ev.UserID,
+		BoundAt: time.Now(),
+	}
+}
 
 // Manager owns the lifecycle of adapters and their bound sessions.
 type Manager struct {
@@ -200,13 +220,7 @@ func (m *Manager) cmdBind(ev InboundEvent, args []string) string {
 	if _, loaded := m.sessions.Load(key); loaded {
 		m.sessions.Delete(key)
 	}
-	sess := &Session{
-		Key:     key,
-		Agent:   m.factory(),
-		ChatID:  ev.ChatID,
-		UserID:  ev.UserID,
-		BoundAt: time.Now(),
-	}
+	sess := m.newSession(key, ev)
 	m.sessions.Store(key, sess)
 	modeStr := string(m.mode)
 	if modeStr == "" {
@@ -267,13 +281,7 @@ func (m *Manager) handleSessionMessage(ctx context.Context, ev InboundEvent) {
 	val, loaded := m.sessions.Load(key)
 	if !loaded {
 		// Auto-create session on first message.
-		sess := &Session{
-			Key:     key,
-			Agent:   m.factory(),
-			ChatID:  ev.ChatID,
-			UserID:  ev.UserID,
-			BoundAt: time.Now(),
-		}
+		sess := m.newSession(key, ev)
 		val, _ = m.sessions.LoadOrStore(key, sess)
 	}
 	sess := val.(*Session)
@@ -325,13 +333,7 @@ func (m *Manager) GetOrCreateSession(ev InboundEvent) *Session {
 	key := sessionKeyFor(m.mode, ev)
 	val, loaded := m.sessions.Load(key)
 	if !loaded {
-		sess := &Session{
-			Key:     key,
-			Agent:   m.factory(),
-			ChatID:  ev.ChatID,
-			UserID:  ev.UserID,
-			BoundAt: time.Now(),
-		}
+		sess := m.newSession(key, ev)
 		val, _ = m.sessions.LoadOrStore(key, sess)
 	}
 	return val.(*Session)

--- a/internal/channel/session_tasks_test.go
+++ b/internal/channel/session_tasks_test.go
@@ -1,0 +1,36 @@
+package channel
+
+import "testing"
+
+// TestSessionTaskStorePersists verifies each session owns a task store that
+// survives across messages in the same chat — so the IM bridge's task list
+// doesn't reset every turn. (A fresh per-message store would lose it.)
+func TestSessionTaskStorePersists(t *testing.T) {
+	cfg := &Config{Channels: map[string]PlatformConfig{"mock": {"enabled": true}}}
+	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
+
+	ev := InboundEvent{Platform: "mock", ChatID: "c1", UserID: "u1"}
+
+	s1 := mgr.GetOrCreateSession(ev)
+	if s1.Tasks == nil {
+		t.Fatal("session should have a task store")
+	}
+	if _, err := s1.Tasks.Create("ship it", "", ""); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	// A later message for the same chat reuses the session and its store.
+	s2 := mgr.GetOrCreateSession(ev)
+	if s2 != s1 {
+		t.Fatal("same chat should reuse the session")
+	}
+	if got := len(s2.Tasks.List()); got != 1 {
+		t.Errorf("task store should persist across messages, got %d tasks", got)
+	}
+
+	// A different chat gets its own, independent store.
+	other := mgr.GetOrCreateSession(InboundEvent{Platform: "mock", ChatID: "c2", UserID: "u2"})
+	if len(other.Tasks.List()) != 0 {
+		t.Error("a different chat should have an independent task store")
+	}
+}


### PR DESCRIPTION
## What

The IM bridge stamped a fresh `tasks.New()` into ctx on **every message**, so a chat's task list reset each turn — a `task_create` in one message was gone by the next. This moves the store onto the channel `Session` so it lives as long as the conversation.

## How

- `channel.Session` gains a `Tasks *tasks.Store` field. The three session-creation paths (explicit `/bind`, auto-create on first message, `GetOrCreateSession`) are centralised into a new `Manager.newSession`, which wires the agent + a fresh store identically.
- `cmd/octo/channel.go`'s handler stamps `sess.Tasks` into the turn ctx instead of a per-message store.

Result: `task_*` state persists across messages within a chat, dies with the session (no leak), and different chats stay isolated.

The HTTP server keeps its per-turn store — its agent is rebuilt per request anyway, so there's nothing to persist across turns there.

## Tests
- `internal/channel`: a session's task store survives repeated `GetOrCreateSession` calls for the same chat, and a different chat gets an independent store.

## Verification
`go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test -race ./...` green (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)