### PR TITLE
chore: bump version to 0.13.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "0.13.0"
+var Version = "0.13.1"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump version constant from 0.13.0 → 0.13.1.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>