### PR TITLE
refactor(agent): remove dupBreaker, add prompt rule instead

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -499,8 +498,7 @@ func (a *Agent) runLoop(
 	a.appendUserInput(userInput)
 
 	limit := a.turnLimit()
-	streamStalls := 0        // transient mid-stream stalls re-issued for the current round
-	breaker := &dupBreaker{} // breaks degenerate identical-tool-call loops within this run
+	streamStalls := 0 // transient mid-stream stalls re-issued for the current round
 	for i := 0; limit == unlimitedTurns || i < limit; i++ {
 		// Interrupt (Ctrl-C) between iterations — e.g. right after a tool batch.
 		if ctx.Err() != nil {
@@ -627,7 +625,7 @@ func (a *Agent) runLoop(
 			// handler is threaded through to dispatchTools so streaming
 			// tools (StreamingToolExecutor) can fire EventToolProgress as
 			// output arrives mid-execution.
-			resultBlocks, err := dispatchTools(ctx, executor, reply.Blocks, handler, a.Gate, breaker)
+			resultBlocks, err := dispatchTools(ctx, executor, reply.Blocks, handler, a.Gate)
 			if err != nil {
 				return Reply{}, fmt.Errorf("agent: dispatch tools[%d]: %w", i, err)
 			}
@@ -1015,48 +1013,6 @@ var readOnlyTools = map[string]bool{
 type toolCall struct {
 	block      ContentBlock
 	denyReason string // non-empty → blocked by the gate; don't execute
-	sig        string // tool name + canonical input; identifies a repeat call
-	duplicate  bool   // identical to the previous executed call; nudge, don't execute
-}
-
-// dupBreaker remembers the signature of the previous dispatch's last executed
-// tool call so dispatchTools can short-circuit a byte-for-byte identical repeat.
-//
-// Weak models (observed with kimi k2.6) can latch onto one tool call and
-// re-issue the exact same call every turn without making progress — e.g. a grep
-// for a function that returns only its signature line, which the model keeps
-// re-running while expecting the body. Left unchecked the loop burns the entire
-// max-turns budget. Returning a nudge instead of re-executing breaks the loop
-// and tells the model to change strategy.
-//
-// Consecutive-only by design: it compares against the single most recent
-// executed call, so legitimate re-runs with intervening work (run tests → edit →
-// run tests) never trip. A dupBreaker is per-run (created in runLoop), so the
-// same call is fine across separate turns.
-type dupBreaker struct {
-	last string // signature of the previous dispatch's last executed call
-}
-
-// dupCallNudge is returned in place of re-executing an identical repeat call.
-// Phrased as a normal (non-error) result so the model treats it as feedback to
-// act on, not a failure to retry.
-const dupCallNudge = "You just ran this exact tool call (same name and arguments) and already have its " +
-	"result above. Re-running it returns identical output and makes no progress. Change your approach: adjust " +
-	"the arguments, use a different tool, or act on the result you already have. (For example, if a grep " +
-	"returned only a function's signature line, set context_lines or read the file to see the body.)"
-
-// callSignature is a stable identity for a tool call: name plus its input
-// serialized as canonical JSON (encoding/json sorts map keys, so the output is
-// deterministic regardless of map iteration order). Two calls share a signature
-// iff their name and arguments are byte-for-byte equivalent.
-func callSignature(name string, input map[string]any) string {
-	b, err := json.Marshal(input)
-	if err != nil {
-		// Unserialisable input is implausible for tool args, but fall back to a
-		// best-effort string so dedup can only ever miss, never misfire.
-		return name + "\x00" + fmt.Sprintf("%v", input)
-	}
-	return name + "\x00" + string(b)
 }
 
 // dispatchTools runs every tool_use block in blocks and returns the matching
@@ -1077,14 +1033,14 @@ func callSignature(name string, input map[string]any) string {
 // requires executor.Execute to be safe for concurrent calls on distinct
 // inputs — DefaultRegistry is (its only shared state, the read tracker, is
 // mutex-guarded).
-func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentBlock, handler EventHandler, gate PermissionGate, breaker *dupBreaker) ([]ContentBlock, error) {
-	// Pass 1 — collect calls, run the gate serially, and flag identical repeats.
+func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentBlock, handler EventHandler, gate PermissionGate) ([]ContentBlock, error) {
+	// Pass 1 — collect calls and run the gate serially.
 	var calls []toolCall
 	for _, b := range blocks {
 		if b.Type != "tool_use" {
 			continue
 		}
-		c := toolCall{block: b, sig: callSignature(b.Name, b.Input)}
+		c := toolCall{block: b}
 		if gate != nil {
 			if allowed, reason := gate.Check(ctx, b.Name, b.Input); !allowed {
 				if reason == "" {
@@ -1093,26 +1049,7 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 				c.denyReason = reason
 			}
 		}
-		// A call identical to the previous dispatch's last executed call is a
-		// degenerate repeat: short-circuit it with a nudge rather than re-running.
-		if c.denyReason == "" && breaker != nil && breaker.last != "" && c.sig == breaker.last {
-			c.duplicate = true
-		}
 		calls = append(calls, c)
-	}
-
-	// Record the signature of this batch's last call that will actually execute,
-	// so the next dispatch can detect a repeat. Done before execution because
-	// "will execute" depends only on the gate/duplicate verdict, not the result.
-	// If every call was denied or skipped, breaker.last is left unchanged so a
-	// continuing repeat keeps tripping.
-	if breaker != nil {
-		for i := len(calls) - 1; i >= 0; i-- {
-			if calls[i].denyReason == "" && !calls[i].duplicate {
-				breaker.last = calls[i].sig
-				break
-			}
-		}
 	}
 
 	// Pass 2 — execute. Each tool may return multiple blocks (e.g. tool_result +
@@ -1125,10 +1062,6 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 		for i := range calls {
 			if calls[i].denyReason != "" {
 				resultSlices[i] = []ContentBlock{NewToolResultBlock(calls[i].block.ID, calls[i].denyReason, true)}
-				continue
-			}
-			if calls[i].duplicate {
-				resultSlices[i] = []ContentBlock{NewToolResultBlock(calls[i].block.ID, dupCallNudge, false)}
 				continue
 			}
 			wg.Add(1)
@@ -1148,10 +1081,6 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 		b := calls[i].block
 		if calls[i].denyReason != "" {
 			resultSlices[i] = []ContentBlock{NewToolResultBlock(b.ID, calls[i].denyReason, true)}
-			continue
-		}
-		if calls[i].duplicate {
-			resultSlices[i] = []ContentBlock{NewToolResultBlock(b.ID, dupCallNudge, false)}
 			continue
 		}
 		var (

--- a/internal/agent/dispatch_test.go
+++ b/internal/agent/dispatch_test.go
@@ -83,7 +83,7 @@ func TestDispatchTools_ParallelReadOnly(t *testing.T) {
 
 	done := make(chan []ContentBlock, 1)
 	go func() {
-		r, _ := dispatchTools(context.Background(), exec, blocks, nil, nil, nil)
+		r, _ := dispatchTools(context.Background(), exec, blocks, nil, nil)
 		done <- r
 	}()
 
@@ -126,7 +126,7 @@ func TestDispatchTools_MixedBatchSerialCorrect(t *testing.T) {
 		NewToolUseBlock("c2", "write_file", map[string]any{"path": "b", "content": "x"}),
 		NewToolUseBlock("c3", "grep", map[string]any{"pattern": "y"}),
 	}
-	results, err := dispatchTools(context.Background(), exec, blocks, nil, nil, nil)
+	results, err := dispatchTools(context.Background(), exec, blocks, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,84 +137,6 @@ func TestDispatchTools_MixedBatchSerialCorrect(t *testing.T) {
 		if results[i].Result != "ok:"+blocks[i].Name {
 			t.Errorf("results[%d].Result = %q", i, results[i].Result)
 		}
-	}
-}
-
-func TestCallSignature(t *testing.T) {
-	// Map key order must not affect the signature (encoding/json sorts keys).
-	a := callSignature("grep", map[string]any{"pattern": "x", "path": "p"})
-	b := callSignature("grep", map[string]any{"path": "p", "pattern": "x"})
-	if a != b {
-		t.Errorf("signature must be order-independent:\n %q\n %q", a, b)
-	}
-	// Different args → different signature.
-	if callSignature("grep", map[string]any{"pattern": "x"}) == callSignature("grep", map[string]any{"pattern": "y"}) {
-		t.Error("different args produced the same signature")
-	}
-	// Different tool name → different signature.
-	if callSignature("grep", nil) == callSignature("glob", nil) {
-		t.Error("different tool names produced the same signature")
-	}
-}
-
-func TestDispatchTools_DuplicateCallBroken(t *testing.T) {
-	// One breaker shared across dispatches simulates the run loop. The same
-	// (name, input) issued twice in a row must execute once, then be
-	// short-circuited with a non-error nudge on the repeat.
-	breaker := &dupBreaker{}
-	exec := &countingExec{}
-	call := []ContentBlock{NewToolUseBlock("c1", "grep", map[string]any{"pattern": "func cleanSuggestion"})}
-
-	first, err := dispatchTools(context.Background(), exec, call, nil, nil, breaker)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if first[0].Result != "ok:grep" || first[0].IsError {
-		t.Fatalf("first call should execute normally, got %+v", first[0])
-	}
-
-	repeat := []ContentBlock{NewToolUseBlock("c2", "grep", map[string]any{"pattern": "func cleanSuggestion"})}
-	second, err := dispatchTools(context.Background(), exec, repeat, nil, nil, breaker)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if second[0].IsError {
-		t.Errorf("duplicate nudge must not be an error result: %+v", second[0])
-	}
-	if !strings.Contains(second[0].Result, "this exact tool call") {
-		t.Errorf("duplicate should return the nudge, got %q", second[0].Result)
-	}
-	if len(exec.called) != 1 {
-		t.Errorf("executor ran %d times, want 1 (the repeat must be skipped)", len(exec.called))
-	}
-
-	// A different call after the repeat executes again and resets the breaker.
-	other := []ContentBlock{NewToolUseBlock("c3", "grep", map[string]any{"pattern": "something else"})}
-	third, err := dispatchTools(context.Background(), exec, other, nil, nil, breaker)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if third[0].Result != "ok:grep" || third[0].IsError {
-		t.Errorf("a distinct call must execute, got %+v", third[0])
-	}
-	if len(exec.called) != 2 {
-		t.Errorf("executor ran %d times, want 2", len(exec.called))
-	}
-}
-
-func TestDispatchTools_NilBreakerNeverDedups(t *testing.T) {
-	// With no breaker (the test/legacy path), identical calls always execute.
-	exec := &countingExec{}
-	call := func(id string) []ContentBlock {
-		return []ContentBlock{NewToolUseBlock(id, "grep", map[string]any{"pattern": "x"})}
-	}
-	for _, id := range []string{"c1", "c2", "c3"} {
-		if _, err := dispatchTools(context.Background(), exec, call(id), nil, nil, nil); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if len(exec.called) != 3 {
-		t.Errorf("nil breaker must not dedup: executor ran %d times, want 3", len(exec.called))
 	}
 }
 
@@ -238,7 +160,7 @@ func TestDispatchTools_DeniedCallInParallelBatch(t *testing.T) {
 		NewToolUseBlock("c2", "grep", map[string]any{"pattern": "x"}),
 		NewToolUseBlock("c3", "glob", map[string]any{"pattern": "*"}),
 	}
-	results, err := dispatchTools(context.Background(), exec, blocks, nil, gate, nil)
+	results, err := dispatchTools(context.Background(), exec, blocks, nil, gate)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/microcompact_test.go
+++ b/internal/agent/microcompact_test.go
@@ -62,7 +62,7 @@ func (hugeExec) Execute(_ context.Context, _ string, _ map[string]any) (ToolResu
 
 func TestDispatchTools_TruncatesOversizedResult(t *testing.T) {
 	blocks := []ContentBlock{NewToolUseBlock("c1", "read_file", map[string]any{"path": "big"})}
-	results, err := dispatchTools(context.Background(), hugeExec{}, blocks, nil, nil, nil)
+	results, err := dispatchTools(context.Background(), hugeExec{}, blocks, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -7,6 +7,7 @@ You are octo, an AI coding agent that runs in a terminal and operates on the use
 - Use `edit_file` for partial changes, never `sed -i` or an in-place shell edit — those bypass the diff and safety checks and will be refused.
 - Make the smallest change that satisfies the request. Don't refactor, reformat, or "improve" code that wasn't part of the task.
 - When you search, prefer `grep`/`glob` over reading whole directories.
+- **Never repeat the same tool call with identical arguments.** If you need to verify a result, refer to the output already shown in the conversation history rather than re-executing. Re-running identical commands wastes tokens and makes no progress.
 
 ## Tools and permissions
 


### PR DESCRIPTION
The dupBreaker mechanism (detecting identical consecutive tool calls and returning a nudge instead of executing) was a workaround for weak models getting stuck in tool call loops. It had several problems:

1. It did not actually stop the loop — the model would receive the nudge and often just retry the same call again.
2. It added complexity to dispatchTools (signature computation, duplicate flagging, breaker state tracking).
3. It was agent-layer code trying to solve a prompt-layer problem.

Replace it with an explicit rule in base.md: `Never repeat the same tool call with identical arguments.` This is clearer, simpler, and lets the model self-correct rather than being overridden by code.

**Changes:**
- Remove dupBreaker, dupCallNudge, callSignature, and duplicate field from toolCall (internal/agent/agent.go)
- Remove corresponding tests (dispatch_test.go)
- Update dispatchTools signature to drop breaker parameter
- Add anti-repeat rule to internal/prompt/base.md

Co-authored-by: octo-agent <no-reply@octo-agent.dev>