### PR TITLE
fix(tui): render write_file as a rich card

### DIFF
--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -29,6 +29,8 @@ func cardVerbFor(toolName string) string {
 		return "Glob"
 	case "read_file":
 		return "Read"
+	case "write_file":
+		return "Write"
 	case "web_fetch":
 		return "Fetch"
 	}
@@ -46,7 +48,7 @@ func cardTargetFor(toolName string, input map[string]any) string {
 		key = "pattern"
 	case "web_search":
 		key = "query"
-	case "read_file", "edit_file":
+	case "read_file", "edit_file", "write_file":
 		key = "path"
 	case "web_fetch":
 		key = "url"
@@ -75,7 +77,7 @@ func renderToolCard(toolName string, input map[string]any, output string, isErr 
 		return tui.RenderEditCard(path, oldS, newS)
 	}
 	lang := ""
-	if toolName == "read_file" {
+	if toolName == "read_file" || toolName == "write_file" {
 		if p, _ := input["path"].(string); p != "" {
 			lang = tui.GuessLanguage(p)
 		}


### PR DESCRIPTION
write_file was missing from `cardVerbFor`, so it fell back to a terse one-line status instead of the aligned card format.

**Changes:**
- Add `write_file → "Write"` to `cardVerbFor`
- Include `write_file` in `cardTargetFor` path-key lookup
- Enable syntax highlighting from file extension

**Before:**
```
↳ write_file: content=package tools... path=/tmp/...
```

**After:**
```
● Write(/tmp/.../file.go)
  │ package tools
  │ ...
```