### PR TITLE
fix(tui): show write_file summary in card

### DIFF
--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -88,5 +88,11 @@ func renderToolCard(toolName string, input map[string]any, output string, isErr 
 		// drop it from the card — the "Started background process N" line stays.
 		output = strings.TrimRight(strings.TrimSuffix(output, tools.BgPollNotice), "\n")
 	}
+	if toolName == "write_file" {
+		// write_file's own output is already a human-readable summary
+		// ("Wrote N bytes (M lines) to /path"); show that instead of a
+		// redundant content preview.
+		return tui.RenderOutputCard(verb, cardTargetFor(toolName, input), output, 0, isErr, "")
+	}
 	return tui.RenderOutputCard(verb, cardTargetFor(toolName, input), output, outputCardMaxLines, isErr, lang)
 }


### PR DESCRIPTION
write_file's tool result is already a human-readable summary ("Wrote N bytes (M lines) to /path"). Rendering it as a normal output card would show the file content, which is redundant and noisy.

**Before:**
```
● Write(/path/to/file.go)
  │ package main
  │ import "fmt"
  │ ...
```

**After:**
```
● Write(/path/to/file.go)
  │ Wrote 1,234 bytes (42 lines) to /path/to/file.go
```