### PR TITLE
fix(tools): prevent read_file pagination loops with explicit EOF markers

### DIFF
--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -49,6 +49,8 @@ func (ReadFileTool) Definition() agent.ToolDefinition {
 		Name: "read_file",
 		Description: "Read a UTF-8 text file and return its content with cat-n-style " +
 			"line numbers. Up to 2000 lines per call — use offset/limit to paginate. " +
+			"When the response includes '[end of file: N lines total]' the entire file " +
+			"has been read; do not call read_file again for the same path. " +
 			"Absolute paths are preferred; relative paths resolve against the current " +
 			"working directory. Refuses binary extensions (executables, archives, " +
 			"PDFs, DBs) and blocking device files (/dev/random, /dev/tty etc). " +
@@ -158,10 +160,15 @@ func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 	}
 
 	if returned == 0 && lineNum > 0 {
-		return agent.ToolResult{}, fmt.Errorf("read_file: offset %d is past end of file (only %d lines)", offset, lineNum)
+		// A past-end offset used to be an error, which made agents retry
+		// the same file or backtrack. Returning a clear "already at EOF"
+		// result lets them stop paginating instead of looping.
+		return agent.ToolResult{
+			Text: fmt.Sprintf("[end of file: %d lines total. Offset %d is past the end — no more content to read.]", lineNum, offset),
+		}, nil
 	}
 	if returned == 0 {
-		return agent.ToolResult{Text: "(empty file)"}, nil
+		return agent.ToolResult{Text: "[empty file]"}, nil
 	}
 	if truncated {
 		// Without this footer the read stops silently at the cap, so the
@@ -169,8 +176,12 @@ func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 		// either edits against lines it never saw or re-reads the same
 		// window expecting different output. Spelling out the exact resume
 		// offset breaks that loop.
-		fmt.Fprintf(&out, "\n[truncated: shown lines %d-%d; file has more. Continue with offset=%d.]\n",
-			offset, offset+returned-1, lineNum)
+		fmt.Fprintf(&out, "\n[truncated: shown lines %d-%d. Next unread line is %d. Continue with offset=%d if needed.]\n",
+			offset, offset+returned-1, lineNum, lineNum)
+	} else {
+		// Explicit EOF marker prevents agents from re-reading a file they
+		// already consumed just to confirm whether more content exists.
+		fmt.Fprintf(&out, "\n[end of file: %d lines total]\n", lineNum)
 	}
 	return agent.ToolResult{Text: out.String()}, nil
 }

--- a/internal/tools/read_file_test.go
+++ b/internal/tools/read_file_test.go
@@ -83,18 +83,18 @@ func TestReadFile_TruncationFooter(t *testing.T) {
 	if !strings.Contains(out.Text, "shown lines 2-4") {
 		t.Errorf("expected shown-range 2-4, got:\n%s", out.Text)
 	}
+	if !strings.Contains(out.Text, "Next unread line is 5") {
+		t.Errorf("expected 'Next unread line is 5', got:\n%s", out.Text)
+	}
 }
 
-func TestReadFile_NoFooterWhenComplete(t *testing.T) {
-	// A read that reaches EOF — even when the limit is hit exactly on the
-	// last line — must NOT claim truncation, or the model loops re-reading
-	// a file it already saw in full.
+func TestReadFile_EndOfFileFooterWhenComplete(t *testing.T) {
+	// A read that reaches EOF must report completion explicitly so the
+	// model knows not to re-read the file.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "exact.txt")
 	writeTestFile(t, path, "a\nb\nc\n")
 
-	// Limit equals the line count: last line is the limit-th line, EOF
-	// follows, so no truncation.
 	out, err := ReadFileTool{}.Execute(context.Background(), "read_file", map[string]any{
 		"path":  path,
 		"limit": 3,
@@ -105,19 +105,30 @@ func TestReadFile_NoFooterWhenComplete(t *testing.T) {
 	if strings.Contains(out.Text, "truncated") {
 		t.Errorf("complete read should not be marked truncated:\n%s", out.Text)
 	}
+	if !strings.Contains(out.Text, "[end of file: 3 lines total]") {
+		t.Errorf("complete read should include end-of-file footer:\n%s", out.Text)
+	}
 }
 
 func TestReadFile_PastEnd(t *testing.T) {
+	// Reading past EOF should return a friendly marker, not an error,
+	// so agents stop paginating instead of looping on the same file.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "short.txt")
 	writeTestFile(t, path, "only\n")
 
-	_, err := ReadFileTool{}.Execute(context.Background(), "read_file", map[string]any{
+	out, err := ReadFileTool{}.Execute(context.Background(), "read_file", map[string]any{
 		"path":   path,
 		"offset": 100,
 	})
-	if err == nil || !strings.Contains(err.Error(), "past end") {
-		t.Errorf("expected past-end error, got %v", err)
+	if err != nil {
+		t.Fatalf("past-end read should not error, got %v", err)
+	}
+	if !strings.Contains(out.Text, "end of file") {
+		t.Errorf("expected end-of-file marker, got %q", out.Text)
+	}
+	if !strings.Contains(out.Text, "no more content") {
+		t.Errorf("expected 'no more content' hint, got %q", out.Text)
 	}
 }
 
@@ -139,8 +150,8 @@ func TestReadFile_EmptyFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out.Text, "empty") {
-		t.Errorf("expected empty-file marker, got %q", out.Text)
+	if !strings.Contains(out.Text, "[empty file]") {
+		t.Errorf("expected [empty file] marker, got %q", out.Text)
 	}
 }
 
@@ -263,8 +274,8 @@ func TestReadFile_AllowsDevNull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("/dev/null should be readable (returns EOF): %v", err)
 	}
-	if !strings.Contains(out.Text, "empty") {
-		t.Errorf("expected empty-file marker, got %q", out.Text)
+	if !strings.Contains(out.Text, "[empty file]") {
+		t.Errorf("expected [empty file] marker, got %q", out.Text)
 	}
 }
 


### PR DESCRIPTION
Replace the past-end error with a friendly EOF marker, add an explicit `[end of file]` footer on complete reads, and strengthen the truncated-read footer so agents know exactly when to stop paginating.

Changes:
- Offset past EOF now returns `[end of file: N lines total. Offset X is past the end — no more content to read.]` instead of an error.
- Complete reads append `[end of file: N lines total]`.
- Truncation footer now says `Next unread line is N. Continue with offset=N if needed.`
- Tool description instructs the model not to re-read once EOF is reported.
- Tests updated for the new behavior.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>