### PR TITLE
fix(tui): allow free-text input when selecting Other in ask_user_question modal

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -406,6 +406,10 @@ type modalState struct {
 	cursor   int
 	options  []string // rendered option labels (questions only)
 	selected map[int]bool
+	// otherActive is true when the user has selected "Other" and is now typing
+	// free text inline inside the modal.
+	otherActive bool
+	otherInput  string
 }
 
 func newTUIModel(cfg replConfig) *tuiModel {

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -429,6 +429,106 @@ func TestTUI_QuestionModalMultiSelect(t *testing.T) {
 	}
 }
 
+func TestTUI_QuestionModalOtherFreeText(t *testing.T) {
+	m := newTestModel()
+	resp := make(chan UserResponse, 1)
+	m.openModal(askMsg{prompt: UserPrompt{
+		Kind:     KindQuestion,
+		Question: "pick",
+		Options:  []string{"alpha", "beta"},
+	}, resp: resp})
+
+	// Move to "Other" and confirm to enter free-text mode.
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyDown})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyDown})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.modal.otherActive {
+		t.Fatal("selecting Other should activate free-text input")
+	}
+
+	// Type "custom", backspace once, then confirm.
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c', 'u', 's', 't', 'o', 'm'}})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyBackspace})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	got := <-resp
+	if got.Custom != "custo" {
+		t.Errorf("custom = %q, want custo", got.Custom)
+	}
+	if got.Cancelled {
+		t.Error("should not be cancelled after confirming non-empty text")
+	}
+}
+
+func TestTUI_QuestionModalOtherEmptyCancels(t *testing.T) {
+	m := newTestModel()
+	resp := make(chan UserResponse, 1)
+	m.openModal(askMsg{prompt: UserPrompt{
+		Kind:     KindQuestion,
+		Question: "pick",
+		Options:  []string{"alpha"},
+	}, resp: resp})
+
+	// Select Other (Enter), then confirm empty input (Enter) to cancel.
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyDown})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyEnter})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	got := <-resp
+	if !got.Cancelled {
+		t.Errorf("empty Other should cancel, got %+v", got)
+	}
+}
+
+func TestTUI_QuestionModalOtherEscCancels(t *testing.T) {
+	m := newTestModel()
+	resp := make(chan UserResponse, 1)
+	m.openModal(askMsg{prompt: UserPrompt{
+		Kind:     KindQuestion,
+		Question: "pick",
+		Options:  []string{"alpha"},
+	}, resp: resp})
+
+	// Select Other (Enter), type something, then press Esc.
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyDown})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyEnter})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyEsc})
+
+	got := <-resp
+	if !got.Cancelled {
+		t.Errorf("Esc in Other input should cancel, got %+v", got)
+	}
+}
+
+func TestTUI_QuestionModalMultiSelectOther(t *testing.T) {
+	m := newTestModel()
+	resp := make(chan UserResponse, 1)
+	m.openModal(askMsg{prompt: UserPrompt{
+		Kind:        KindQuestion,
+		Question:    "pick",
+		Options:     []string{"alpha", "beta"},
+		MultiSelect: true,
+	}, resp: resp})
+
+	// Toggle Other and confirm to enter free-text mode.
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyDown})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyDown})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeySpace})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.modal.otherActive {
+		t.Fatal("selecting Other in multi-select should activate free-text input")
+	}
+
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m', 'y'}})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	got := <-resp
+	if got.Custom != "my" {
+		t.Errorf("custom = %q, want my", got.Custom)
+	}
+}
+
 func TestTUI_AppendText_BlockBufferingNonPlain(t *testing.T) {
 	m := newTestModel() // cfg.plain == false → markdown block buffering
 	m.appendText("hello ")

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -634,6 +634,9 @@ func (m *tuiModel) openModal(msg askMsg) {
 		st.options = append(st.options, msg.prompt.Options...)
 		st.options = append(st.options, "Other (free text)")
 	}
+	st.cursor = 0
+	st.otherActive = false
+	st.otherInput = ""
 	m.modal = st
 }
 
@@ -659,6 +662,29 @@ func (m *tuiModel) handleModalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.answerModal(UserResponse{Allow: true, Always: true})
 		case msg.Type == tea.KeyEsc, keyIs(msg, 'n'):
 			m.answerModal(UserResponse{Allow: false})
+		}
+		return m, nil
+	}
+
+	// Inline free-text input for the "Other" option.
+	if st.otherActive {
+		switch msg.Type {
+		case tea.KeyEsc:
+			m.answerModal(UserResponse{Cancelled: true})
+		case tea.KeyEnter:
+			if trimmed := strings.TrimSpace(st.otherInput); trimmed != "" {
+				m.answerModal(UserResponse{Custom: trimmed})
+			} else {
+				m.answerModal(UserResponse{Cancelled: true})
+			}
+		case tea.KeyBackspace:
+			if len(st.otherInput) > 0 {
+				// Remove the last UTF-8 rune.
+				r := []rune(st.otherInput)
+				st.otherInput = string(r[:len(r)-1])
+			}
+		case tea.KeyRunes:
+			st.otherInput += string(msg.Runes)
 		}
 		return m, nil
 	}
@@ -697,14 +723,18 @@ func (m *tuiModel) handleModalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// confirmQuestion maps the modal selection onto a UserResponse. The trailing
-// "Other" slot can't be resolved to free text without a second input step; for
-// now picking it cancels (the model can ask again or pick a default). A future
-// pass can add an inline free-text field.
+// confirmQuestion maps the modal selection onto a UserResponse. Selecting the
+// trailing "Other" slot switches the modal into inline free-text input rather
+// than cancelling.
 func (m *tuiModel) confirmQuestion(st *modalState) {
 	otherIdx := len(st.options) - 1
 
 	if st.prompt.MultiSelect {
+		wantOther := st.selected[otherIdx]
+		if wantOther {
+			st.otherActive = true
+			return
+		}
 		var picks []string
 		for i := range st.options {
 			if i == otherIdx {
@@ -723,7 +753,7 @@ func (m *tuiModel) confirmQuestion(st *modalState) {
 	}
 
 	if st.cursor == otherIdx {
-		m.answerModal(UserResponse{Cancelled: true})
+		st.otherActive = true
 		return
 	}
 	m.answerModal(UserResponse{Choices: []string{st.prompt.Options[st.cursor]}})
@@ -1041,6 +1071,11 @@ func (m *tuiModel) modalView() string {
 			}
 		}
 		b.WriteString(fmt.Sprintf("  %s%s%s\n", cursor, mark, opt))
+	}
+	if st.otherActive {
+		b.WriteString("  Other: " + st.otherInput + "▋" + "\n")
+		b.WriteString(hintStyle.Render("Enter confirm · Esc cancel · Backspace delete"))
+		return tui.Box(b.String())
 	}
 	hint := "↑/↓ move · Enter select · Esc cancel"
 	if st.prompt.MultiSelect {


### PR DESCRIPTION
The TUI modal previously cancelled immediately when the user selected the "Other (free text)" option. This PR adds an inline input sub-state so the user can type custom text, confirm with Enter, or cancel with Esc.

### Changes
- : add  and  fields
- : capture typed runes, backspace, enter, esc in Other mode
- : enter Other input mode instead of cancelling (single and multi-select)
- : render the inline input line with a caret and updated hint
- Tests: add coverage for single-select Other, empty-input cancellation, Esc cancellation, and multi-select Other

### Checklist
- [x] ok  	github.com/Leihb/octo-agent/cmd/octo	7.170s
?   	github.com/Leihb/octo-agent/cmd/octo-eval	[no test files]
ok  	github.com/Leihb/octo-agent/internal/agent	0.954s
ok  	github.com/Leihb/octo-agent/internal/app	0.533s
ok  	github.com/Leihb/octo-agent/internal/channel	1.089s
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	1.209s
?   	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	[no test files]
ok  	github.com/Leihb/octo-agent/internal/conductor	2.442s
ok  	github.com/Leihb/octo-agent/internal/config	1.773s
ok  	github.com/Leihb/octo-agent/internal/eval	4.239s
ok  	github.com/Leihb/octo-agent/internal/hooks	10.153s
ok  	github.com/Leihb/octo-agent/internal/mcp	11.164s
ok  	github.com/Leihb/octo-agent/internal/memory	2.280s
ok  	github.com/Leihb/octo-agent/internal/permission	2.320s
ok  	github.com/Leihb/octo-agent/internal/prompt	2.088s
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	2.026s
ok  	github.com/Leihb/octo-agent/internal/provider/openai	1.649s
ok  	github.com/Leihb/octo-agent/internal/provider/retry	1.812s
ok  	github.com/Leihb/octo-agent/internal/sandbox	1.854s
ok  	github.com/Leihb/octo-agent/internal/server	1.604s
ok  	github.com/Leihb/octo-agent/internal/skills	1.771s
ok  	github.com/Leihb/octo-agent/internal/tasks	1.940s
ok  	github.com/Leihb/octo-agent/internal/tools	10.871s
ok  	github.com/Leihb/octo-agent/internal/tools/rgembed	1.770s
ok  	github.com/Leihb/octo-agent/internal/tui	2.084s
ok  	github.com/Leihb/octo-agent/internal/version	2.094s passes
- [x]  clean
- [x]  clean

Fixes P0 from UX handoff.