### PR TITLE
docs: update unified-agent-tool.md to reflect final sub_agent naming

### DIFF
--- a/dev-docs/unified-agent-tool.md
+++ b/dev-docs/unified-agent-tool.md
@@ -2,7 +2,7 @@
 
 ## 目标
 
-把 `launch_agent` + `send_message` + `agent_status` + `kill_agent` + 4 个 preset agent 合并成一个统一的 `Agent` 工具，参考 Claude Code 的设计。
+把 `launch_agent` + `send_message` + `agent_status` + `kill_agent` + 4 个 preset agent 合并成一个统一的 `sub_agent` 工具，参考 Claude Code 的设计。
 
 ## 当前问题
 
@@ -13,21 +13,21 @@
 
 ## 新设计
 
-### Agent 工具（统一）
+### sub_agent 工具（统一）
 
 ```go
 type AgentTool struct{}
 
 func (AgentTool) Definition() agent.ToolDefinition {
     return agent.ToolDefinition{
-        Name: "Agent",
+        Name: "sub_agent",
         Description: "Launch an autonomous sub-agent to handle a focused sub-task. ...",
         Parameters: map[string]any{
             "type": "object",
             "properties": map[string]any{
                 "description": { "type": "string", ... },
                 "prompt": { "type": "string", ... },
-                "subagent_type": { "type": "string", "optional": true, 
+                "subagent_type": { "type": "string", "optional": true,
                     "description": "Agent type: 'explore', 'plan', 'general', 'code-review', or omit to fork yourself" },
                 "run_in_background": { "type": "boolean", "optional": true,
                     "description": "Run asynchronously. You'll be notified when it completes." },
@@ -55,16 +55,16 @@ func (AgentTool) Definition() agent.ToolDefinition {
 1. 子 agent 继承父 agent 的完整 history
 2. 子 agent 共享父 agent 的 system prompt
 3. 子 agent 使用相同的 model（除非显式覆盖）
-4. 子 agent 可以访问相同的工具（递归防护：移除 Agent 工具）
+4. 子 agent 可以访问相同的工具（递归防护：移除 sub_agent 工具）
 5. 同步模式下直接返回结果；异步模式下通过通知返回
 
 ### 删除的工具
 
-- `launch_agent` → 合并到 `Agent`
-- `send_message` → 合并到 `Agent`（通过 `run_in_background` 控制）
+- `launch_agent` → 合并到 `sub_agent`
+- `send_message` → **删除**。旧设计需要模型先 `launch_agent` 再 `send_message` 才能继续对话，交互复杂且容易出错。新设计中同步模式直接返回结果，异步模式通过通知返回，模型只需一次调用即可完成任务，无需手动续聊。
 - `agent_status` → 删除（异步任务通过通知系统管理）
 - `kill_agent` → 删除（异步任务通过通知系统管理）
-- `explore_agent`, `plan_agent`, `general_agent`, `code_review_agent` → 合并到 `Agent` 的 `subagent_type` 参数
+- `explore_agent`, `plan_agent`, `general_agent`, `code_review_agent` → 合并到 `sub_agent` 的 `subagent_type` 参数
 
 ### Agent 定义系统（新）
 
@@ -84,12 +84,13 @@ You are a read-only exploration sub-agent. Your job is to locate and understand 
 
 ### 实现步骤
 
-1. 创建 `internal/tools/agent.go`（新的统一 Agent 工具）
-2. 创建 `internal/tools/agent_definitions.go`（agent 定义加载）
-3. 删除 `launch_agent.go`, `send_message.go`, `agent_status.go`, `kill_agent.go`, `preset_agents.go`
-4. 更新 `registry.go`
-5. 更新 `subagent_manager.go`（简化同步/异步逻辑）
-6. 更新测试
+1. 创建 `internal/tools/agent.go`（新的统一 sub_agent 工具）
+2. 创建 `internal/tools/agent_presets.go`（agent 预设定义）
+3. 创建 `internal/tools/spawner.go`（Spawner 接口）
+4. 删除 `launch_agent.go`, `send_message.go`, `agent_status.go`, `kill_agent.go`, `preset_agents.go`
+5. 更新 `registry.go`
+6. 更新 `subagent_manager.go`
+7. 更新测试
 
 ## 兼容性
 


### PR DESCRIPTION
- Rename all references from Agent to sub_agent
- Document why send_message was removed (simplified sync/async model)
- Update implementation steps to match actual code structure

<!-- Write this PR description in English. -->

## What

<!-- One or two sentences: what does this PR change? -->

## Why

<!-- The need this addresses, and who benefits. -->

## User-visible impact

<!-- Default behavior changes? New config? Breaking changes? "None" is a valid answer. -->

---

## Self-review

Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### 1. Architecture

- [ ] Smallest possible diff for the need
- [ ] No new configuration knobs (or justified below)
- [ ] No new dependencies (or justified below)
- [ ] Fits the existing design / naming / layering

### 2. Need

- [ ] Common need that benefits most users, **or** scope and side effects are explained below
- [ ] No unintended impact on other users' workflows or defaults

### 3. Code

- [ ] All tests pass
- [ ] Coverage does not drop; new code has new tests
- [ ] Commit messages and this PR are written in English
- [ ] This branch was created from the latest `main` and is currently up to date with it

### Bonus

- [ ] This PR was authored using Octo itself

---

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs you considered, or follow-ups planned. -->
