### PR TITLE
feat(tools): friendly output for memory file reads/writes

### DIFF
--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -121,6 +121,36 @@ func RenderInjection(dir string) string {
 	return b.String()
 }
 
+// IsMemoryPath reports whether absPath is inside the per-repo memory
+// directory (~/.octo/memory/<repo-slug>/). Used by the file tools to
+// emit friendlier output when the agent reads or writes its own notes.
+func IsMemoryPath(absPath string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	prefix := filepath.Join(home, ".octo", "memory")
+	return strings.HasPrefix(absPath, prefix+string(filepath.Separator))
+}
+
+// CountMemories estimates how many "memory entries" a markdown file
+// contains by counting top-level headings (# or ##). This is a rough
+// heuristic — good enough for progress UI but not a semantic parser.
+func CountMemories(content string) int {
+	var count int
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "# ") || strings.HasPrefix(trimmed, "## ") {
+			count++
+		}
+	}
+	if count == 0 && strings.TrimSpace(content) != "" {
+		// A non-empty file with no headings still holds at least one memory.
+		return 1
+	}
+	return count
+}
+
 // Slugify reduces s to a lowercase kebab token usable as a path segment.
 func Slugify(s string) string {
 	var b strings.Builder

--- a/internal/tools/args.go
+++ b/internal/tools/args.go
@@ -35,6 +35,14 @@ func stringSliceArg(input map[string]any, key string) []string {
 	return nil
 }
 
+// pluralize returns singular when n == 1, otherwise plural.
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}
+
 func firstLine(s string) string {
 	for _, line := range strings.Split(s, "\n") {
 		line = strings.TrimSpace(line)

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/memory"
 )
 
 // imageExtensions maps file extensions to their MIME types for images
@@ -111,6 +112,8 @@ func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 		return agent.ToolResult{}, fmt.Errorf("read_file: refusing to read %s — %s", path, reason)
 	}
 
+	isMemory := memory.IsMemoryPath(abs)
+
 	offset := intArg(input, "offset", 1)
 	if offset < 1 {
 		offset = 1
@@ -183,7 +186,13 @@ func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 		// already consumed just to confirm whether more content exists.
 		fmt.Fprintf(&out, "\n[end of file: %d lines total]\n", lineNum)
 	}
-	return agent.ToolResult{Text: out.String()}, nil
+
+	result := agent.ToolResult{Text: out.String()}
+	if isMemory {
+		memCount := memory.CountMemories(out.String())
+		result.Text = fmt.Sprintf("Recalled %d %s from %s\n\n%s", memCount, pluralize(memCount, "memory", "memories"), filepath.Base(abs), out.String())
+	}
+	return result, nil
 }
 
 // imageMIMEType returns the MIME type for known image extensions, or "".

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/memory"
 )
 
 // WriteFileTool writes (or overwrites) a file with the given content. Parent
@@ -68,6 +69,10 @@ func (WriteFileTool) Execute(_ context.Context, _ string, input map[string]any) 
 	lineCount := strings.Count(content, "\n")
 	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
 		lineCount++
+	}
+	if memory.IsMemoryPath(abs) {
+		memCount := memory.CountMemories(content)
+		return agent.ToolResult{Text: fmt.Sprintf("Saved %d %s to %s", memCount, pluralize(memCount, "memory", "memories"), filepath.Base(abs))}, nil
 	}
 	return agent.ToolResult{Text: fmt.Sprintf("Wrote %d bytes (%d lines) to %s", len(content), lineCount, abs)}, nil
 }


### PR DESCRIPTION
When read_file or write_file target a file under ~/.octo/memory/, emit a human-friendly message instead of the generic bytes/lines count:

- read: "Recalled 3 memories from MEMORY.md"
- write: "Saved 2 memories to preferences.md"

Memory count is estimated by counting top-level markdown headings (# and ##). A non-empty file with no headings counts as 1 memory.

Changes:
- internal/memory/memory.go: add IsMemoryPath + CountMemories helpers
- internal/tools/args.go: add pluralize helper
- internal/tools/read_file.go: wrap memory files with recall message
- internal/tools/write_file.go: emit save message for memory files

<!-- Write this PR description in English. -->

## What

<!-- One or two sentences: what does this PR change? -->

## Why

<!-- The need this addresses, and who benefits. -->

## User-visible impact

<!-- Default behavior changes? New config? Breaking changes? "None" is a valid answer. -->

---

## Self-review

Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### 1. Architecture

- [ ] Smallest possible diff for the need
- [ ] No new configuration knobs (or justified below)
- [ ] No new dependencies (or justified below)
- [ ] Fits the existing design / naming / layering

### 2. Need

- [ ] Common need that benefits most users, **or** scope and side effects are explained below
- [ ] No unintended impact on other users' workflows or defaults

### 3. Code

- [ ] All tests pass
- [ ] Coverage does not drop; new code has new tests
- [ ] Commit messages and this PR are written in English
- [ ] This branch was created from the latest `main` and is currently up to date with it

### Bonus

- [ ] This PR was authored using Octo itself

---

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs you considered, or follow-ups planned. -->
