### PR TITLE
fix: expose sub_agent tool to the LLM catalog

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -35,8 +35,12 @@ func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
 	spawner := NewSpawner(a, executor, toolsFor)
 	tools.SetSpawner(spawner)
 	mgr := tools.NewSubAgentManager(spawner)
+	tools.SetDefaultSubAgentManager(mgr)
 
-	cleanup := func() { tools.SetSpawner(nil) }
+	cleanup := func() {
+		tools.SetDefaultSubAgentManager(nil)
+		tools.SetSpawner(nil)
+	}
 	if enableTasks {
 		tools.SetTaskStore(tasks.New())
 		prev := cleanup

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -23,6 +23,18 @@ func TestWireTools_SetsUpEnvAndCleansUp(t *testing.T) {
 	if env.SubAgentMgr == nil {
 		t.Error("WireTools should return a sub-agent manager")
 	}
+	// The sub-agent manager must be registered globally so that DefaultToolsFor
+	// advertises the sub_agent tool to the LLM.
+	hasSubAgent := false
+	for _, d := range env.ToolsFor() {
+		if d.Name == "sub_agent" {
+			hasSubAgent = true
+			break
+		}
+	}
+	if !hasSubAgent {
+		t.Error("WireTools should advertise the sub_agent tool in the catalog")
+	}
 	if env.ToolsFor == nil {
 		t.Fatal("WireTools should return a tool-list function")
 	}
@@ -37,6 +49,13 @@ func TestWireTools_SetsUpEnvAndCleansUp(t *testing.T) {
 	}
 	if tools.ActiveTaskStore() != nil {
 		t.Error("cleanup should reset the task store")
+	}
+	// After cleanup, the sub_agent tool should no longer be advertised.
+	for _, d := range env.ToolsFor() {
+		if d.Name == "sub_agent" {
+			t.Error("cleanup should reset the sub-agent manager so sub_agent is no longer advertised")
+			break
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

WireTools created the SubAgentManager but never called SetDefaultSubAgentManager, so subAgentManagerEnabled() was always false and the sub_agent tool was silently filtered from DefaultToolsFor. This meant the agent could never see or invoke the sub_agent tool.

## Fix

- Register the manager globally on setup ()
- Clear it in cleanup so the tool disappears when the session ends
- Add bootstrap-test assertions verifying sub_agent appears in the catalog after WireTools and disappears after cleanup

## Testing

- go test ./internal/app/... ./internal/tools/... -race ✅