### PR TITLE
fix(tools): include line numbers in grep output

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -39,6 +39,7 @@ func (GrepTool) Definition() agent.ToolDefinition {
 			"Respects .gitignore. Returns at most 200 output lines — narrow the " +
 			"pattern or set include/path if you hit the cap. Matching lines over " +
 			"500 chars are truncated with a preview of the first 500 bytes. " +
+			"Output includes line numbers. " +
 			"Requires `rg` on PATH.",
 		Parameters: map[string]any{
 			"type": "object",
@@ -103,7 +104,7 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 	// 500 bytes instead of replacing the entire line with an unhelpful
 	// "[Omitted long matching line]" marker, which previously caused the LLM
 	// to think the result was incomplete and retry in a loop.
-	args := []string{"--color=never", "--max-columns", "500", "--max-columns-preview"}
+	args := []string{"--color=never", "--line-number", "--max-columns", "500", "--max-columns-preview"}
 	switch mode {
 	case "content":
 		// default rg output


### PR DESCRIPTION
Ripgrep suppresses line numbers when stdout is not a TTY (e.g. when captured by exec.Command). Add --line-number explicitly so content mode results always include line numbers, which the agent needs to reference code locations accurately.

<!-- Write this PR description in English. -->

## What

<!-- One or two sentences: what does this PR change? -->

## Why

<!-- The need this addresses, and who benefits. -->

## User-visible impact

<!-- Default behavior changes? New config? Breaking changes? "None" is a valid answer. -->

---

## Self-review

Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### 1. Architecture

- [ ] Smallest possible diff for the need
- [ ] No new configuration knobs (or justified below)
- [ ] No new dependencies (or justified below)
- [ ] Fits the existing design / naming / layering

### 2. Need

- [ ] Common need that benefits most users, **or** scope and side effects are explained below
- [ ] No unintended impact on other users' workflows or defaults

### 3. Code

- [ ] All tests pass
- [ ] Coverage does not drop; new code has new tests
- [ ] Commit messages and this PR are written in English
- [ ] This branch was created from the latest `main` and is currently up to date with it

### Bonus

- [ ] This PR was authored using Octo itself

---

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs you considered, or follow-ups planned. -->
