### PR TITLE
chore: clean up stale launch_agent / send_message references

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -295,8 +295,8 @@ func newChannelGate(cwd string) (agent.PermissionGate, error) {
 }
 
 // registerChannelSubAgentTools installs the process-global sub-agent manager +
-// task store so DefaultToolsFor advertises launch_agent / send_message /
-// task_* . These are gating sentinels and a never-hit fallback — each message
+// task store so DefaultToolsFor advertises sub_agent / task_* . These are gating
+// sentinels and a never-hit fallback — each message
 // stamps its own ctx-scoped, synchronous manager + store bound to that chat's
 // agent (handleAgentMessage), which dispatch prefers, so concurrent chats never
 // share sub-agent or task state. The template agent only seeds the sentinel

--- a/cmd/octo/conduct.go
+++ b/cmd/octo/conduct.go
@@ -356,7 +356,7 @@ func runConductShow(args []string, stdout, stderr io.Writer) int {
 }
 
 // buildConductAgent constructs the planner/worker parent agent and registers
-// the spawner so launch_agent-style workers can run. The returned cleanup
+// the spawner so sub_agent-style workers can run. The returned cleanup
 // unregisters the spawner.
 func buildConductAgent(f conductFlags, stdout, stderr io.Writer) (*agent.Agent, func(), int) {
 	cfg, err := config.Load()

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -665,7 +665,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case subAgentNoteMsg:
 		// A sub-agent finished this round — drop it from the live panel (it's
-		// idle now; a later send_message re-adds it via a fresh "started").
+		// idle now; a later Continue re-adds it via a fresh "started").
 		m.removeSubAgent(msg.ev.AgentID)
 		// Async sub-agent completion: the full result rode into the conversation
 		// via Inbox; no scrollback notice needed.
@@ -777,7 +777,7 @@ func (m *tuiModel) handleSubAgentEvent(ev tools.SubAgentEvent) {
 	}
 	switch ev.Kind {
 	case "started":
-		// A fresh round (launch or send_message): reset the chain, keep the slot.
+		// A fresh round (sub_agent): reset the chain, keep the slot.
 		sa.toolCount = 0
 		sa.recent = nil
 		sa.errored = false

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -150,7 +150,7 @@ type Agent struct {
 
 	// usageMu guards the cumulative counters below. They are written by the
 	// turn loop (accrueUsage) AND by sub-agent goroutines (AccrueChildUsage,
-	// which run concurrently when a launch_agent batch fans out), and read from
+	// which run concurrently when a sub_agent batch fans out), and read from
 	// the TUI goroutine (SessionTokens / ContextUsage / SessionCacheTokens).
 	usageMu sync.Mutex
 	// Cumulative token counts for this session (all turns combined).
@@ -1176,7 +1176,7 @@ func (a *Agent) SessionTokens() (inputTokens, outputTokens int) {
 
 // AccrueChildUsage folds tokens spent by a spawned sub-agent into this
 // agent's session totals, so /cost and SessionTokens still report one
-// consolidated number even when the LLM used launch_agent. cache totals are
+// consolidated number even when the LLM used sub_agent. cache totals are
 // left untouched — the child runs against the same provider but reports its
 // own cache hits internally; the parent only sees the bottom-line counts here.
 func (a *Agent) AccrueChildUsage(inputTokens, outputTokens int) {

--- a/internal/agent/usage_race_test.go
+++ b/internal/agent/usage_race_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // TestAccrueChildUsageConcurrent guards the usage-counter mutex: a fanned-out
-// launch_agent batch runs sub-agents concurrently, each folding its tokens into
+// sub_agent batch runs sub-agents concurrently, each folding its tokens into
 // the shared parent via AccrueChildUsage. Run with -race, this catches an
 // unguarded counter; the sum check catches lost updates.
 func TestAccrueChildUsageConcurrent(t *testing.T) {

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -8,7 +8,7 @@ import (
 
 // ToolEnv is the wired tool environment for a session: the executor the agent
 // loop dispatches tool calls through, the manager that tracks async sub-agents
-// (launch_agent / send_message), and a model-aware tool-list function. Call
+// (sub_agent), and a model-aware tool-list function. Call
 // ToolsFor again after MCP connects so the list (or its Tool Search bridge)
 // picks up the new surface.
 type ToolEnv struct {
@@ -20,7 +20,7 @@ type ToolEnv struct {
 // WireTools sets up the tool environment every full-loop entry point shares —
 // the CLI today, the HTTP server and IM bridge as they migrate. It builds a
 // read-before-write executor, registers the sub-agent spawner globally (so
-// launch_agent appears in the catalog, which is why SetSpawner must run before
+// sub_agent appears in the catalog, which is why SetSpawner must run before
 // any DefaultTools call), creates the async sub-agent manager, and — when
 // enableTasks — installs the session task store.
 //

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -15,7 +15,7 @@ func TestWireTools_SetsUpEnvAndCleansUp(t *testing.T) {
 	env, cleanup := WireTools(a, true)
 
 	if tools.ActiveSpawner() == nil {
-		t.Error("WireTools should register a spawner so launch_agent appears in the catalog")
+		t.Error("WireTools should register a spawner so sub_agent appears in the catalog")
 	}
 	if tools.ActiveTaskStore() == nil {
 		t.Error("WireTools(enableTasks=true) should install a task store")

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -13,25 +13,25 @@ import (
 )
 
 // Spawner implements tools.Spawner by building a child agent on each
-// launch_agent call. The child shares the parent's Sender (one provider
+// sub_agent call. The child shares the parent's Sender (one provider
 // connection) and System (same harness identity), but runs in isolation:
 // fresh History, no visibility into the parent's conversation, its own
 // loop budget. The final child reply text is returned to the parent as the
-// launch_agent tool_result; the child's token usage is rolled into the
+// sub_agent tool_result; the child's token usage is rolled into the
 // parent's session totals so /cost reports one consolidated number.
 //
 // toolsFn is a deferred lookup of the LLM-facing tool catalog (DefaultTools).
 // Resolving it on each Spawn — rather than capturing a slice at construction
 // — lets cmd/octo set up the spawner before computing the tool list, since
-// SetSpawner has to run first for launch_agent to appear in DefaultTools().
+// SetSpawner has to run first for sub_agent to appear in DefaultTools().
 type Spawner struct {
 	parent   *agent.Agent
 	executor agent.ToolExecutor
 	toolsFn  func() []agent.ToolDefinition
 	// reg keeps spawned children alive after Spawn returns so a later
-	// send_message (tools.Spawner.Continue) can re-run them with their history
-	// intact. In-memory and session-scoped: it lives as long as this spawner
-	// (one per REPL session), and a fresh process starts empty.
+	// Continue can re-run them with their history intact. In-memory and
+	// session-scoped: it lives as long as this spawner (one per REPL session),
+	// and a fresh process starts empty.
 	reg *childRegistry
 }
 
@@ -46,12 +46,12 @@ func NewSpawner(parent *agent.Agent, executor agent.ToolExecutor, toolsFn func()
 
 // childMaxTurns caps the sub-agent's tool loop.
 // Set to the same default as the parent (100) so sub-agents have enough
-// budget for complex sub-tasks. Each Continue (send_message) re-arms
+// budget for complex sub-tasks. Each Continue re-arms
 // this budget for the next round.
 const childMaxTurns = 100
 
 // Spawn implements tools.Spawner. It builds an isolated child, registers it so
-// a later send_message can continue it, runs the first prompt, and returns the
+// a later Continue can resume it, runs the first prompt, and returns the
 // child's id alongside its reply.
 func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
 	childTools := filterChildTools(s.toolsFn(), req.Tools, req.ReadOnly)
@@ -90,7 +90,7 @@ func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.Spaw
 
 // Continue implements tools.Spawner. It re-runs a still-alive child with a new
 // message. An unknown / evicted id returns an error whose text steers the model
-// to launch a fresh sub-agent.
+// to start a fresh sub-agent.
 func (s *Spawner) Continue(ctx context.Context, agentID, message string) (tools.SpawnResult, error) {
 	lc, ok := s.reg.get(agentID)
 	if !ok {
@@ -190,12 +190,12 @@ func filterChildTools(parent []agent.ToolDefinition, allowed []string, readOnly 
 	return out
 }
 
-// Live-child registry — keeps spawned sub-agents addressable for send_message.
+// Live-child registry — keeps spawned sub-agents addressable for Continue.
 
 const (
 	// maxLiveChildren caps how many sub-agents stay resumable at once. Beyond
 	// this the least-recently-used is evicted (its history is dropped; a
-	// send_message to it then fails and the model relaunches).
+	// Continue to it then fails and the model relaunches).
 	maxLiveChildren = 8
 	// childIdleTTL evicts a sub-agent that hasn't been touched in this long,
 	// so abandoned children don't pin their histories in memory for the whole

--- a/internal/app/spawner_test.go
+++ b/internal/app/spawner_test.go
@@ -182,8 +182,8 @@ func TestAgentSpawner_SpawnReturnsIDAndContinueResumesSameChild(t *testing.T) {
 
 // TestSubAgentManager_SendResumesSameChildThroughSpawner exercises the full
 // async path: SubAgentManager hands the model an agent_N handle, but the
-// resumable child lives in childRegistry under an 8-hex id. send_message
-// (Manager.Send → Spawner.Continue) must reach the same child, not miss the
+// resumable child lives in childRegistry under an 8-hex id. Manager.Send
+// (Spawner.Continue) must reach the same child, not miss the
 // registry and report "no longer alive".
 func TestSubAgentManager_SendResumesSameChildThroughSpawner(t *testing.T) {
 	send := &subAgentSender{reply: "round one", inputTokens: 100, outputTokens: 40}
@@ -225,7 +225,7 @@ func TestSubAgentManager_SendResumesSameChildThroughSpawner(t *testing.T) {
 
 	reply := waitNote("message_reply")
 	if strings.Contains(reply.Result, "no longer alive") {
-		t.Fatalf("send_message failed to reach the child: %q", reply.Result)
+		t.Fatalf("Send failed to reach the child: %q", reply.Result)
 	}
 	if reply.Result != "round two" {
 		t.Errorf("message_reply result = %q, want %q", reply.Result, "round two")
@@ -233,7 +233,7 @@ func TestSubAgentManager_SendResumesSameChildThroughSpawner(t *testing.T) {
 	// The continuation must reuse the same child: its history now carries
 	// [user1, assistant1, user2] = 3 messages.
 	if got := len(send.lastMessages); got != 3 {
-		t.Errorf("after send_message, child saw %d messages, want 3 (same child resumed)", got)
+		t.Errorf("after Send, child saw %d messages, want 3 (same child resumed)", got)
 	}
 }
 
@@ -439,12 +439,12 @@ func TestAgentSpawner_MarksContextSoRecursionRefused(t *testing.T) {
 	parent := agent.New(send, "parent-model")
 	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
 
-	// Wire SpawnRequest into a real launch_agent tool that checks the sub-agent
+	// Wire SpawnRequest into a real sub_agent tool that checks the sub-agent
 	// context flag. After Spawn returns, the OUTER context shouldn't be marked
 	// (only descendants of the spawn call are), but inside Spawn the child's
 	// Run sees the marked context. We can't reach that from the outside cleanly,
 	// so verify behavior by stubbing the spawner and asserting it would refuse
-	// a recursive launch_agent call.
+	// a recursive sub_agent call.
 	tools.SetSpawner(sp)
 	t.Cleanup(func() { tools.SetSpawner(nil) })
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -119,7 +119,7 @@ func New(cfg Config) (*Server, error) {
 }
 
 // enableSubAgentTools registers the process-global sub-agent manager + task
-// store so DefaultToolsFor advertises launch_agent / send_message / task_* . On
+// store so DefaultToolsFor advertises sub_agent / task_* . On
 // the server these globals are gating sentinels and a never-hit fallback: every
 // turn stamps its own ctx-scoped manager + store (bound to that turn's agent)
 // via prepareToolTurn, and dispatch prefers the ctx-scoped ones — so concurrent

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -9,7 +9,7 @@ import (
 )
 
 // AgentTool is the unified sub-agent tool. It replaces the previous
-// launch_agent / send_message / explore_agent / plan_agent / general_agent /
+// explore_agent / plan_agent / general_agent /
 // code_review_agent split with a single tool controlled by parameters.
 //
 // Parameters:

--- a/internal/tools/subagent_event.go
+++ b/internal/tools/subagent_event.go
@@ -12,9 +12,9 @@ import "context"
 // concurrent sub-agents streaming their prose.
 type SubAgentEvent struct {
 	AgentID     string // manager handle, e.g. "agent_1"
-	Description string // human-readable label from launch_agent
+	Description string // human-readable label from sub_agent
 	// Kind is one of:
-	//   "started"    — the sub-agent began a task (or a send_message round)
+	//   "started"    — the sub-agent began a task (or a Continue round)
 	//   "tool"       — it dispatched a tool (ToolName set)
 	//   "tool_error" — a tool returned an error (ToolName set)
 	Kind     string

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -12,10 +12,10 @@ import (
 const maxSubAgentResultBytes = 1 << 20 // 1 MiB
 
 // SubAgentNotification is delivered to the onExit hook when a sub-agent
-// finishes a task (launch_agent) or replies to a message (send_message).
+// finishes a task (spawn) or replies to a message (continue).
 type SubAgentNotification struct {
 	AgentID      string // e.g. "agent_1"
-	Description  string // human-readable label from launch_agent
+	Description  string // human-readable label from sub_agent
 	Kind         string // "spawn_done" | "message_reply"
 	Result       string // final reply text
 	InputTokens  int
@@ -145,11 +145,11 @@ func NewSubAgentManager(spawner Spawner) *SubAgentManager {
 	}
 }
 
-// SetSynchronous selects the launch_agent dispatch model. The default (false)
+// SetSynchronous selects the sub_agent dispatch model. The default (false)
 // is the interactive async path: Start returns immediately and the reply
 // arrives via onExit, which the REPL/TUI re-injects as a follow-up turn. A
 // request/response transport (HTTP server, IM bridge) has no follow-up-turn
-// channel, so it sets this true: launch_agent then blocks the turn on RunSync
+// channel, so it sets this true: sub_agent then blocks the turn on RunSync
 // and returns the child's reply directly as the tool_result. Set once at
 // startup, before any turn runs.
 func (m *SubAgentManager) SetSynchronous(v bool) {
@@ -168,14 +168,14 @@ func (m *SubAgentManager) Synchronous() bool {
 
 // subAgentsSynchronous reports whether the process-global manager runs
 // sub-agents inline. In synchronous mode a sub-agent completes before
-// launch_agent returns, so agent_status / kill_agent have nothing to act on —
+// sub_agent returns, so agent_status / kill_agent have nothing to act on —
 // DefaultToolsFor withholds them there rather than advertise dead tools.
 func subAgentsSynchronous() bool {
 	return defaultSubAgentMgr != nil && defaultSubAgentMgr.Synchronous()
 }
 
 // RunSync spawns a sub-agent and blocks until it completes, returning its
-// reply. Used by the synchronous launch_agent path; the spawner stamps the
+// reply. Used by the synchronous sub_agent path; the spawner stamps the
 // sub-agent marker and keeps the child resumable for a later ContinueSync.
 func (m *SubAgentManager) RunSync(ctx context.Context, req SpawnRequest) (SpawnResult, error) {
 	if m.spawner == nil {


### PR DESCRIPTION
The unified `sub_agent` tool replaced the old `launch_agent` + `send_message` split. This updates all code comments and docstrings to use current terminology (`sub_agent`, `Continue`, `Send`) instead of the retired names.

No functional changes.