### PR TITLE
fix(windows): paste garbling + double-click launcher for testers

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,6 +75,9 @@ archives:
       - README_CN.md
       - LICENSE.txt
       - CHANGELOG.md
+      # Windows double-click launcher: opens PowerShell with octo on PATH and
+      # starts a session. Harmless in the tar.gz archives; meant for the zip.
+      - packaging/windows/start-octo.cmd
 
 checksum:
   name_template: checksums.txt

--- a/cmd/octo/lineread.go
+++ b/cmd/octo/lineread.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -92,6 +93,15 @@ type readlineLineReader struct {
 }
 
 func newReadlineReader(historyFile string) (*readlineLineReader, error) {
+	// chzyer/readline drives the Windows console through its own raw-mode ANSI
+	// emulation, which mangles pasted input (a pasted URL comes through garbled
+	// or not at all). Decline on Windows so callers fall back to the cooked-mode
+	// scanner, where PowerShell/Conhost handle paste natively. Editing/history
+	// is lost there, but interactive Windows sessions use the bubbletea TUI for
+	// the REPL anyway — the only readline consumer left is the config wizard.
+	if runtime.GOOS == "windows" {
+		return nil, errors.New("interactive line editing is unavailable on Windows")
+	}
 	if historyFile != "" {
 		if err := os.MkdirAll(filepath.Dir(historyFile), 0o755); err != nil {
 			// Non-fatal: fall through with history disabled rather than

--- a/packaging/windows/start-octo.cmd
+++ b/packaging/windows/start-octo.cmd
@@ -1,0 +1,16 @@
+@echo off
+REM ===========================================================================
+REM  octo - double-click launcher (Windows)
+REM
+REM  Double-click this file to open PowerShell in this folder, with octo on the
+REM  PATH, and start an interactive session. PowerShell stays open after octo
+REM  exits (-NoExit), so any error message remains readable and you can re-run
+REM  commands such as `octo config` or `octo chat`.
+REM
+REM  Kept ASCII-only on purpose: a .cmd with non-ASCII text mangles in the
+REM  default console code page. octo itself renders any Chinese/UTF-8 output.
+REM
+REM  First run? Set your provider and API key with:  octo config
+REM ===========================================================================
+cd /d "%~dp0"
+powershell -NoExit -Command "$env:Path = '%~dp0;' + $env:Path; Write-Host 'octo is ready. First run? type:  octo config' -ForegroundColor Cyan; & '%~dp0octo.exe' chat"


### PR DESCRIPTION
Two Windows-tester fixes bundled (same goal: make Windows testing painless).

## 1. Paste garbling in `octo config`

**Problem:** On Windows PowerShell, running `octo config` and pasting a base URL produces garbled text / the paste doesn't go in.

**Cause:** The interactive reader uses `chzyer/readline`, which drives the Windows console through its own raw-mode ANSI emulation instead of native cooked/line-input mode — that path mangles pasted input. The config wizard takes the readline path on a TTY, so it's hit directly.

**Fix:** Decline `newReadlineReader` on `runtime.GOOS == "windows"`. Both callers (config wizard, chat REPL) already fall back to the `bufio.Scanner` reader, so this one guard routes Windows to cooked-mode input where conhost/PowerShell handle paste natively.

**Trade-off (Windows only):** conhost line-input mode still gives backspace, arrow editing, Home/End, session history (↑/F7) and paste — all kept. Lost: octo's *persistent* history file (`~/.octo/history`) and `Ctrl-R` search. The wizard is one-shot Q&A; the interactive REPL uses the bubbletea TUI on Windows (its own input), so the readline path is essentially just the wizard. macOS/Linux unchanged.

## 2. Double-click launcher

`packaging/windows/start-octo.cmd`, shipped in the release archives. Double-clicking opens PowerShell in the binary's folder (octo on PATH), starts a session, and stays open (`-NoExit`) so first-run errors stay readable instead of flashing closed. ASCII-only on purpose — a non-ASCII .cmd mangles in the default console code page; octo renders any Chinese/UTF-8 output itself.

## Verification

- `go vet ./cmd/octo/` ✅
- `GOOS=windows GOARCH=amd64 go build ./cmd/octo/` ✅
- config/reader tests pass ✅
- `goreleaser check` ✅
- Not reproducible on macOS (no Windows box) — worth a manual check on a Windows build: paste a base URL into `octo config`, and double-click `start-octo.cmd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)