### PR TITLE
feat(channel): add DingTalk and Feishu adapters + integrate into octo serve

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/channel"
+	_ "github.com/Leihb/octo-agent/internal/channel/adapters/dingtalk"
+	_ "github.com/Leihb/octo-agent/internal/channel/adapters/feishu"
 	_ "github.com/Leihb/octo-agent/internal/channel/adapters/weixin"
 	"github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink"
 	"github.com/Leihb/octo-agent/internal/config"

--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -24,6 +24,7 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	maxTokens := fs.Int("max-tokens", 0, "max_tokens for responses")
 	tools := fs.Bool("tools", true, "Enable agentic tool loop")
 	cors := fs.String("cors", "", "CORS allowed origins (comma-separated, * for any)")
+	noChannel := fs.Bool("no-channel", false, "Disable IM channel (DingTalk, Feishu)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -46,6 +47,7 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		MaxTokens:   *maxTokens,
 		Tools:       *tools,
 		CORSOrigins: corsOrigins,
+		NoChannel:   *noChannel,
 	}
 
 	srv, err := server.New(cfg)

--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -1,0 +1,432 @@
+// Package dingtalk implements the DingTalk (钉钉) Stream Mode adapter.
+//
+// DingTalk Stream Mode provides a persistent WebSocket connection for
+// receiving bot messages and a webhook/OAPI for sending replies.
+//
+// Flow:
+//  1. OAuth client_credentials → access_token
+//  2. Open gateway connection → ticket
+//  3. WebSocket to wss://wss.dingtalk.com/connect
+//  4. Register for /v1.0/im/bot/messages/get topic
+//  5. Receive frames → extract message → deliver to ChannelManager
+//  6. Send replies via sessionWebhook (from inbound event) or OAPI
+package dingtalk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/channel"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	platformName = "dingtalk"
+	apiBase      = "https://api.dingtalk.com"
+	gatewayHost  = "wss://wss.dingtalk.com"
+	msgTopic     = "/v1.0/im/bot/messages/get"
+)
+
+func init() {
+	channel.Register(platformName, New)
+}
+
+// Config keys.
+const (
+	cfgClientID     = "client_id"
+	cfgClientSecret = "client_secret"
+	cfgAllowedUsers = "allowed_users"
+)
+
+// Adapter implements channel.Adapter for DingTalk Stream Mode.
+type Adapter struct {
+	clientID     string
+	clientSecret string
+	allowedUsers map[string]bool
+
+	http        *http.Client
+	accessToken string
+	tokenExpiry time.Time
+	tokenMu     sync.Mutex
+
+	webhooks  map[string]webhookEntry
+	webhookMu sync.Mutex
+
+	running bool
+	cancel  context.CancelFunc
+}
+
+type webhookEntry struct {
+	URL         string
+	ExpiresAtMs int64
+}
+
+// New creates a DingTalk adapter from platform config.
+func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
+	cid, _ := cfg[cfgClientID].(string)
+	secret, _ := cfg[cfgClientSecret].(string)
+	if cid == "" || secret == "" {
+		return nil, fmt.Errorf("dingtalk: client_id and client_secret are required")
+	}
+
+	allowed := make(map[string]bool)
+	if raw, ok := cfg[cfgAllowedUsers].(string); ok {
+		for _, u := range strings.Split(raw, ",") {
+			u = strings.TrimSpace(u)
+			if u != "" {
+				allowed[u] = true
+			}
+		}
+	}
+
+	return &Adapter{
+		clientID:     cid,
+		clientSecret: secret,
+		allowedUsers: allowed,
+		http:         &http.Client{Timeout: 30 * time.Second},
+		webhooks:     make(map[string]webhookEntry),
+	}, nil
+}
+
+// Platform returns "dingtalk".
+func (a *Adapter) Platform() string { return platformName }
+
+// Start connects to DingTalk Stream Mode and blocks until ctx is cancelled.
+func (a *Adapter) Start(ctx context.Context, onMessage func(channel.InboundEvent)) error {
+	a.running = true
+	ctx, a.cancel = context.WithCancel(ctx)
+	defer func() { a.running = false }()
+
+	if err := a.refreshToken(); err != nil {
+		return fmt.Errorf("dingtalk: token: %w", err)
+	}
+
+	ticket, err := a.openGateway()
+	if err != nil {
+		return fmt.Errorf("dingtalk: gateway: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/connect?appKey=%s&ticket=%s", gatewayHost, a.clientID, ticket)
+	dialer := websocket.DefaultDialer
+	conn, _, err := dialer.DialContext(ctx, url, nil)
+	if err != nil {
+		return fmt.Errorf("dingtalk: connect: %w", err)
+	}
+	defer conn.Close()
+
+	if err := a.register(conn); err != nil {
+		return fmt.Errorf("dingtalk: register: %w", err)
+	}
+
+	log.Printf("[dingtalk] stream connected, listening")
+	return a.readFrames(ctx, conn, onMessage)
+}
+
+// Stop gracefully shuts down.
+func (a *Adapter) Stop() error {
+	if a.cancel != nil {
+		a.cancel()
+	}
+	return nil
+}
+
+// SendText sends a Markdown message via sessionWebhook.
+func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
+	url := a.resolveWebhook(chatID)
+	if url == "" {
+		return channel.SendResult{OK: false, Error: "no valid webhook (expired or never received)"}
+	}
+	return a.sendWebhook(url, text)
+}
+
+// SendFile is not yet implemented for DingTalk.
+func (a *Adapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: false, Error: "SendFile not yet implemented"}
+}
+
+// UpdateMessage — DingTalk does not support editing sent messages.
+func (a *Adapter) UpdateMessage(chatID, messageID, text string) bool { return false }
+
+// SupportsMessageUpdates returns false.
+func (a *Adapter) SupportsMessageUpdates() bool { return false }
+
+// SendTyping sends a typing indicator. DingTalk Stream Mode does not support this.
+func (a *Adapter) SendTyping(chatID, contextToken string) error { return nil }
+
+// ValidateConfig checks required fields.
+func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
+	var errs []string
+	if cid, _ := cfg[cfgClientID].(string); cid == "" {
+		errs = append(errs, "client_id is required")
+	}
+	if sec, _ := cfg[cfgClientSecret].(string); sec == "" {
+		errs = append(errs, "client_secret is required")
+	}
+	return errs
+}
+
+// ─── OAuth ─────────────────────────────────────────────────────────────────
+
+func (a *Adapter) refreshToken() error {
+	body := map[string]string{"appKey": a.clientID, "appSecret": a.clientSecret}
+	b, _ := json.Marshal(body)
+	resp, err := a.http.Post(apiBase+"/v1.0/oauth2/accessToken", "application/json", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		AccessToken string `json:"accessToken"`
+		ExpireIn    int    `json:"expireIn"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return err
+	}
+	if r.AccessToken == "" {
+		return fmt.Errorf("empty access token in response")
+	}
+
+	a.tokenMu.Lock()
+	a.accessToken = r.AccessToken
+	a.tokenExpiry = time.Now().Add(time.Duration(r.ExpireIn-60) * time.Second)
+	a.tokenMu.Unlock()
+
+	log.Printf("[dingtalk] token obtained, expires in %ds", r.ExpireIn)
+	return nil
+}
+
+func (a *Adapter) getToken() string {
+	a.tokenMu.Lock()
+	defer a.tokenMu.Unlock()
+	if time.Now().After(a.tokenExpiry) {
+		// Best-effort refresh — don't block.
+		go a.refreshToken()
+	}
+	return a.accessToken
+}
+
+// ─── Gateway ───────────────────────────────────────────────────────────────
+
+func (a *Adapter) openGateway() (string, error) {
+	body := map[string]string{
+		"clientId":     a.clientID,
+		"clientSecret": a.clientSecret,
+	}
+	b, _ := json.Marshal(body)
+	resp, err := a.http.Post(apiBase+"/v1.0/gateway/connections/open", "application/json", bytes.NewReader(b))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		Ticket string `json:"ticket"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return "", err
+	}
+	return r.Ticket, nil
+}
+
+// ─── Stream frames ─────────────────────────────────────────────────────────
+
+type streamFrame struct {
+	SpecVersion string            `json:"specVersion"`
+	Type        string            `json:"type"`
+	Headers     map[string]string `json:"headers"`
+	Data        json.RawMessage   `json:"data"`
+}
+
+func (a *Adapter) register(conn *websocket.Conn) error {
+	frame := streamFrame{
+		SpecVersion: "1.0",
+		Type:        "register",
+		Headers:     map[string]string{"clientId": a.clientID, "topic": msgTopic},
+	}
+	b, _ := json.Marshal(frame)
+	return conn.WriteMessage(websocket.TextMessage, b)
+}
+
+func (a *Adapter) readFrames(ctx context.Context, conn *websocket.Conn, onMessage func(channel.InboundEvent)) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+
+		var frame streamFrame
+		if err := json.Unmarshal(raw, &frame); err != nil {
+			continue
+		}
+		if frame.Type == "SYSTEM" {
+			continue
+		}
+		if frame.Headers["topic"] != msgTopic {
+			continue
+		}
+		a.handleInbound(frame.Data, onMessage)
+	}
+}
+
+// ─── Inbound event handling ────────────────────────────────────────────────
+
+type dtEvent struct {
+	SenderStaffID             string `json:"senderStaffId"`
+	SenderID                  string `json:"senderId"`
+	ConversationID            string `json:"conversationId"`
+	SessionWebhook            string `json:"sessionWebhook"`
+	SessionWebhookExpiredTime int64  `json:"sessionWebhookExpiredTime"`
+	ConversationType          string `json:"conversationType"`
+	RobotCode                 string `json:"robotCode"`
+	MsgID                     string `json:"msgId"`
+	MsgType                   string `json:"msgtype"`
+	ChatbotUserID             string `json:"chatbotUserId"`
+	Text                      struct {
+		Content string `json:"content"`
+	} `json:"text"`
+	Content struct {
+		Content string `json:"content"`
+	} `json:"content"`
+	AtUsers []struct {
+		DingtalkID string `json:"dingtalkId"`
+	} `json:"atUsers"`
+}
+
+func (a *Adapter) handleInbound(raw json.RawMessage, onMessage func(channel.InboundEvent)) {
+	var ev dtEvent
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		log.Printf("[dingtalk] unmarshal event: %v", err)
+		return
+	}
+
+	senderID := ev.SenderStaffID
+	if senderID == "" {
+		senderID = ev.SenderID
+	}
+	if senderID == "" {
+		return
+	}
+
+	chatID := ev.ConversationID
+	if chatID == "" {
+		chatID = senderID
+	}
+
+	// Cache webhook.
+	if ev.SessionWebhook != "" {
+		a.webhookMu.Lock()
+		a.webhooks[chatID] = webhookEntry{URL: ev.SessionWebhook, ExpiresAtMs: ev.SessionWebhookExpiredTime}
+		a.webhookMu.Unlock()
+	}
+
+	// Group chat: only @-mention.
+	if ev.ConversationType == "2" {
+		mentioned := false
+		for _, u := range ev.AtUsers {
+			if u.DingtalkID == ev.ChatbotUserID {
+				mentioned = true
+				break
+			}
+		}
+		content := ev.Text.Content
+		if content == "" {
+			content = ev.Content.Content
+		}
+		if !mentioned && !strings.Contains(content, "@") {
+			return
+		}
+	}
+
+	if len(a.allowedUsers) > 0 && !a.allowedUsers[senderID] {
+		return
+	}
+
+	text := extractDTText(ev)
+	if text == "" {
+		return
+	}
+
+	ct := "direct"
+	if ev.ConversationType == "2" {
+		ct = "group"
+	}
+
+	onMessage(channel.InboundEvent{
+		Type:      "message",
+		Platform:  platformName,
+		ChatID:    chatID,
+		UserID:    senderID,
+		Text:      text,
+		MessageID: ev.MsgID,
+		ChatType:  ct,
+		Raw:       ev,
+	})
+}
+
+func extractDTText(ev dtEvent) string {
+	switch ev.MsgType {
+	case "text":
+		c := ev.Text.Content
+		if idx := strings.Index(c, " "); idx > 0 && strings.HasPrefix(c, "@") {
+			c = strings.TrimSpace(c[idx+1:])
+		}
+		return c
+	case "richText":
+		// RichText content is in Content.Content field.
+		return ev.Content.Content
+	default:
+		return ""
+	}
+}
+
+// ─── Send ──────────────────────────────────────────────────────────────────
+
+func (a *Adapter) resolveWebhook(chatID string) string {
+	a.webhookMu.Lock()
+	defer a.webhookMu.Unlock()
+	e, ok := a.webhooks[chatID]
+	if !ok {
+		return ""
+	}
+	if e.ExpiresAtMs > 0 && time.Now().UnixMilli()+5*60*1000 >= e.ExpiresAtMs {
+		delete(a.webhooks, chatID)
+		return ""
+	}
+	return e.URL
+}
+
+func (a *Adapter) sendWebhook(url, text string) channel.SendResult {
+	body := map[string]any{
+		"msgtype": "markdown",
+		"markdown": map[string]string{
+			"title": "Octo",
+			"text":  text,
+		},
+	}
+	b, _ := json.Marshal(body)
+	resp, err := a.http.Post(url, "application/json", bytes.NewReader(b))
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	return channel.SendResult{OK: true}
+}

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -1,0 +1,473 @@
+// Package feishu implements the Feishu (飞书) adapter.
+//
+// Feishu uses a WebSocket connection for receiving bot messages and a REST
+// API for sending.
+//
+// Flow:
+//  1. OAuth → tenant_access_token
+//  2. POST /open-apis/ws/connection → WebSocket URL
+//  3. Connect WebSocket, listen for im.message.receive_v1 events
+//  4. Send replies via POST /open-apis/im/v1/messages
+package feishu
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/channel"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	platformName  = "feishu"
+	defaultDomain = "https://open.feishu.cn"
+)
+
+func init() {
+	channel.Register(platformName, New)
+}
+
+// Config keys.
+const (
+	cfgAppID        = "app_id"
+	cfgAppSecret    = "app_secret"
+	cfgDomain       = "domain"
+	cfgAllowedUsers = "allowed_users"
+)
+
+// Adapter implements channel.Adapter for Feishu.
+type Adapter struct {
+	appID        string
+	appSecret    string
+	domain       string
+	allowedUsers map[string]bool
+
+	http        *http.Client
+	accessToken string
+	tokenExpiry time.Time
+	tokenMu     sync.Mutex
+
+	botOpenID string
+	running   bool
+	cancel    context.CancelFunc
+}
+
+// New creates a Feishu adapter from platform config.
+func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
+	appID, _ := cfg[cfgAppID].(string)
+	secret, _ := cfg[cfgAppSecret].(string)
+	if appID == "" || secret == "" {
+		return nil, fmt.Errorf("feishu: app_id and app_secret are required")
+	}
+
+	domain, _ := cfg[cfgDomain].(string)
+	if domain == "" {
+		domain = defaultDomain
+	}
+
+	allowed := make(map[string]bool)
+	if raw, ok := cfg[cfgAllowedUsers].(string); ok {
+		for _, u := range strings.Split(raw, ",") {
+			u = strings.TrimSpace(u)
+			if u != "" {
+				allowed[u] = true
+			}
+		}
+	}
+
+	return &Adapter{
+		appID:        appID,
+		appSecret:    secret,
+		domain:       domain,
+		allowedUsers: allowed,
+		http:         &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+// Platform returns "feishu".
+func (a *Adapter) Platform() string { return platformName }
+
+// Start connects to Feishu WebSocket and listens for messages.
+func (a *Adapter) Start(ctx context.Context, onMessage func(channel.InboundEvent)) error {
+	a.running = true
+	ctx, a.cancel = context.WithCancel(ctx)
+	defer func() { a.running = false }()
+
+	if err := a.refreshToken(); err != nil {
+		return fmt.Errorf("feishu: token: %w", err)
+	}
+
+	wsURL, err := a.getWSEndpoint()
+	if err != nil {
+		return fmt.Errorf("feishu: ws endpoint: %w", err)
+	}
+
+	dialer := websocket.DefaultDialer
+	conn, _, err := dialer.DialContext(ctx, wsURL, nil)
+	if err != nil {
+		return fmt.Errorf("feishu: connect: %w", err)
+	}
+	defer conn.Close()
+
+	log.Printf("[feishu] connected to WebSocket")
+
+	// Get bot's open_id once.
+	a.botOpenID = a.getBotOpenID()
+
+	return a.readEvents(ctx, conn, onMessage)
+}
+
+// Stop gracefully shuts down.
+func (a *Adapter) Stop() error {
+	if a.cancel != nil {
+		a.cancel()
+	}
+	return nil
+}
+
+// SendText sends a text message.
+func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
+	msgID, err := a.sendMessage(chatID, text)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	return channel.SendResult{OK: true, MessageID: msgID}
+}
+
+// SendFile is not yet implemented for Feishu.
+func (a *Adapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: false, Error: "SendFile not yet implemented"}
+}
+
+// UpdateMessage edits an existing message.
+func (a *Adapter) UpdateMessage(chatID, messageID, text string) bool {
+	return a.updateMessage(messageID, text)
+}
+
+// SupportsMessageUpdates returns true.
+func (a *Adapter) SupportsMessageUpdates() bool { return true }
+
+// SendTyping — Feishu does not have a typing indicator API.
+func (a *Adapter) SendTyping(chatID, contextToken string) error { return nil }
+
+// ValidateConfig checks required fields.
+func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
+	var errs []string
+	if id, _ := cfg[cfgAppID].(string); id == "" {
+		errs = append(errs, "app_id is required")
+	}
+	if sec, _ := cfg[cfgAppSecret].(string); sec == "" {
+		errs = append(errs, "app_secret is required")
+	}
+	return errs
+}
+
+// ─── OAuth ─────────────────────────────────────────────────────────────────
+
+func (a *Adapter) refreshToken() error {
+	body := map[string]string{"app_id": a.appID, "app_secret": a.appSecret}
+	b, _ := json.Marshal(body)
+
+	resp, err := a.http.Post(
+		a.domain+"/open-apis/auth/v3/tenant_access_token/internal",
+		"application/json",
+		bytes.NewReader(b),
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		Code              int    `json:"code"`
+		Msg               string `json:"msg"`
+		TenantAccessToken string `json:"tenant_access_token"`
+		Expire            int    `json:"expire"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return err
+	}
+	if r.Code != 0 {
+		return fmt.Errorf("oauth error %d: %s", r.Code, r.Msg)
+	}
+
+	a.tokenMu.Lock()
+	a.accessToken = r.TenantAccessToken
+	a.tokenExpiry = time.Now().Add(time.Duration(r.Expire-60) * time.Second)
+	a.tokenMu.Unlock()
+
+	log.Printf("[feishu] token obtained, expires in %ds", r.Expire)
+	return nil
+}
+
+func (a *Adapter) getToken() string {
+	a.tokenMu.Lock()
+	defer a.tokenMu.Unlock()
+	if time.Now().After(a.tokenExpiry) {
+		go a.refreshToken()
+	}
+	return a.accessToken
+}
+
+// ─── WebSocket ─────────────────────────────────────────────────────────────
+
+func (a *Adapter) getWSEndpoint() (string, error) {
+	req, _ := http.NewRequest("POST", a.domain+"/open-apis/ws/connection", nil)
+	req.Header.Set("Authorization", "Bearer "+a.getToken())
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		Code int `json:"code"`
+		Data struct {
+			URL string `json:"url"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return "", err
+	}
+	if r.Code != 0 {
+		return "", fmt.Errorf("ws endpoint: code %d", r.Code)
+	}
+	return r.Data.URL, nil
+}
+
+func (a *Adapter) readEvents(ctx context.Context, conn *websocket.Conn, onMessage func(channel.InboundEvent)) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+
+		var envelope struct {
+			Type string          `json:"type"`
+			Data json.RawMessage `json:"data"`
+		}
+		if err := json.Unmarshal(raw, &envelope); err != nil {
+			continue
+		}
+
+		switch envelope.Type {
+		case "ping":
+			pong, _ := json.Marshal(map[string]string{"type": "pong"})
+			conn.WriteMessage(websocket.TextMessage, pong)
+		case "message":
+			a.handleEvent(envelope.Data, onMessage)
+		}
+	}
+}
+
+// ─── Bot info ──────────────────────────────────────────────────────────────
+
+func (a *Adapter) getBotOpenID() string {
+	req, _ := http.NewRequest("GET", a.domain+"/open-apis/bot/v3/info", nil)
+	req.Header.Set("Authorization", "Bearer "+a.getToken())
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		Code int `json:"code"`
+		Data struct {
+			Bot struct {
+				OpenID string `json:"open_id"`
+			} `json:"bot"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return ""
+	}
+	return r.Data.Bot.OpenID
+}
+
+// ─── Message handling ──────────────────────────────────────────────────────
+
+type fsEvent struct {
+	Schema string `json:"schema"`
+	Header struct {
+		EventType string `json:"event_type"`
+	} `json:"header"`
+	Event struct {
+		Message struct {
+			MessageID   string `json:"message_id"`
+			ChatID      string `json:"chat_id"`
+			ChatType    string `json:"chat_type"`
+			MessageType string `json:"message_type"`
+			Content     string `json:"content"`
+		} `json:"message"`
+		Sender struct {
+			SenderID struct {
+				OpenID string `json:"open_id"`
+			} `json:"sender_id"`
+		} `json:"sender"`
+	} `json:"event"`
+}
+
+type msgContent struct {
+	Text string `json:"text"`
+}
+
+func (a *Adapter) handleEvent(raw json.RawMessage, onMessage func(channel.InboundEvent)) {
+	var ev fsEvent
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		log.Printf("[feishu] unmarshal event: %v", err)
+		return
+	}
+
+	if ev.Header.EventType != "im.message.receive_v1" {
+		return
+	}
+
+	msg := ev.Event.Message
+	chatType := "direct"
+	if msg.ChatType == "group" {
+		chatType = "group"
+	}
+
+	senderID := ev.Event.Sender.SenderID.OpenID
+	if senderID == "" {
+		return
+	}
+
+	// Group chat: @-mention check.
+	if chatType == "group" {
+		if a.botOpenID == "" || !strings.Contains(msg.Content, a.botOpenID) {
+			return
+		}
+	}
+
+	if len(a.allowedUsers) > 0 && !a.allowedUsers[senderID] {
+		return
+	}
+
+	var content msgContent
+	json.Unmarshal([]byte(msg.Content), &content)
+
+	text := strings.TrimSpace(content.Text)
+	if text == "" {
+		return
+	}
+
+	// Strip @-mentions.
+	text = stripAtMentions(text)
+
+	onMessage(channel.InboundEvent{
+		Type:      "message",
+		Platform:  platformName,
+		ChatID:    msg.ChatID,
+		UserID:    senderID,
+		Text:      text,
+		MessageID: msg.MessageID,
+		ChatType:  chatType,
+		Raw:       ev,
+	})
+}
+
+func stripAtMentions(text string) string {
+	// Remove Feishu @-mention format: @name or <at>...</at>
+	for {
+		start := strings.Index(text, "<at ")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(text[start:], "</at>")
+		if end < 0 {
+			break
+		}
+		text = text[:start] + text[start+end+5:]
+	}
+	text = strings.TrimSpace(text)
+	// Remove leading @name patterns.
+	for strings.HasPrefix(text, "@") {
+		idx := strings.Index(text, " ")
+		if idx < 0 {
+			break
+		}
+		text = strings.TrimSpace(text[idx+1:])
+	}
+	return text
+}
+
+// ─── Send ──────────────────────────────────────────────────────────────────
+
+func (a *Adapter) sendMessage(chatID, text string) (string, error) {
+	body := map[string]any{
+		"receive_id": chatID,
+		"msg_type":   "text",
+		"content":    map[string]string{"text": text},
+	}
+	b, _ := json.Marshal(body)
+
+	url := a.domain + "/open-apis/im/v1/messages?receive_id_type=chat_id"
+	req, _ := http.NewRequest("POST", url, bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+a.getToken())
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			MessageID string `json:"message_id"`
+		} `json:"data"`
+	}
+	respBytes, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(respBytes, &r); err != nil {
+		return "", fmt.Errorf("send: %s", string(respBytes))
+	}
+	if r.Code != 0 {
+		return "", fmt.Errorf("send %d: %s", r.Code, r.Msg)
+	}
+	return r.Data.MessageID, nil
+}
+
+func (a *Adapter) updateMessage(messageID, text string) bool {
+	body := map[string]any{
+		"content": map[string]string{"text": text},
+	}
+	b, _ := json.Marshal(body)
+
+	url := a.domain + "/open-apis/im/v1/messages/" + messageID
+	req, _ := http.NewRequest("PATCH", url, bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+a.getToken())
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		Code int `json:"code"`
+	}
+	json.NewDecoder(resp.Body).Decode(&r)
+	return r.Code == 0
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/app"
+	"github.com/Leihb/octo-agent/internal/channel"
 	"github.com/Leihb/octo-agent/internal/config"
+	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/prompt"
 	"github.com/Leihb/octo-agent/internal/scheduler"
 	"github.com/Leihb/octo-agent/internal/skills"
@@ -50,6 +52,11 @@ type Config struct {
 
 	// CORSOrigins lists allowed origins for CORS. Empty disables CORS.
 	CORSOrigins []string
+
+	// NoChannel disables IM channel (DingTalk, Feishu, etc.) startup.
+	// When false (default), channels are started from ~/.octo/channels.yml
+	// alongside the HTTP server.
+	NoChannel bool
 }
 
 // Server is the HTTP server skeleton. It owns the mux, the agent factory,
@@ -89,6 +96,12 @@ type Server struct {
 
 	// scheduler for cron-based background tasks.
 	scheduler *scheduler.Scheduler
+
+	// channel manager for IM platform bridging (DingTalk, Feishu, etc.).
+	// nil when NoChannel is set or no channels are configured.
+	channelCfg    *channel.Config
+	channelMgr    *channel.Manager
+	channelCancel context.CancelFunc
 
 	// mcpCleanup unregisters + closes the MCP registry connected at start.
 	// Always non-nil after New (a no-op when no servers connected).
@@ -131,6 +144,7 @@ func New(cfg Config) (*Server, error) {
 	s.initWS()
 	s.enableSubAgentTools()
 	s.enableMCP()
+	s.initChannels()
 
 	s.http = &http.Server{
 		Addr:         cfg.Addr,
@@ -189,12 +203,14 @@ func (s *Server) enableMCP() {
 
 // ListenAndServe starts the HTTP server.
 func (s *Server) ListenAndServe() error {
+	s.startChannels()
 	return s.http.ListenAndServe()
 }
 
 // Shutdown gracefully shuts down the server, releasing the process-global
 // sub-agent + task registrations installed by enableSubAgentTools.
 func (s *Server) Shutdown(ctx context.Context) error {
+	s.stopChannels()
 	tools.SetDefaultSubAgentManager(nil)
 	tools.SetTaskStore(nil)
 	if s.mcpCleanup != nil {
@@ -459,4 +475,130 @@ func validateBindAddr(addr string) error {
 		return fmt.Errorf("bind address %q is not localhost: create %s to enable non-localhost binds", addr, permPath)
 	}
 	return nil
+}
+
+// ─── Channel (IM Bridge) ───────────────────────────────────────────────────
+
+// initChannels loads channel config and creates a manager when channels are
+// configured and not disabled via --no-channel.
+func (s *Server) initChannels() {
+	if s.cfg.NoChannel {
+		return
+	}
+	chCfg, err := channel.LoadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "octo serve: channel config: %v\n", err)
+		return
+	}
+	platforms := chCfg.EnabledPlatforms()
+	if len(platforms) == 0 {
+		return
+	}
+
+	// Build agent factory that mirrors the server's agent setup.
+	gate, _ := s.buildChannelGate()
+	factory := func() *agent.Agent {
+		a := agent.New(s.sender, s.model)
+		a.CWD = s.cwd
+		a.MaxTokens = s.cfg.MaxTokens
+		a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, "", true)
+		if gate != nil {
+			a.Gate = gate
+		}
+		return a
+	}
+
+	s.channelCfg = chCfg
+	s.channelMgr = channel.NewManager(chCfg, factory, channel.BindByChatUser)
+
+	fmt.Fprintf(os.Stderr, "octo serve: channels enabled: %s\n", strings.Join(platforms, ", "))
+}
+
+// buildChannelGate creates a strict-mode permission gate for the IM bridge.
+func (s *Server) buildChannelGate() (agent.PermissionGate, error) {
+	engine, err := permission.New(permissionConfigPath(), s.cwd, permission.ModeStrict)
+	if err != nil {
+		return nil, fmt.Errorf("permission engine: %w", err)
+	}
+	return app.NewPermissionGate(engine, nil), nil
+}
+
+// startChannels launches all enabled channel adapters in background goroutines.
+func (s *Server) startChannels() {
+	if s.channelMgr == nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.channelCancel = cancel
+
+	// For each enabled platform, create adapter and start it.
+	for _, name := range s.channelCfg.EnabledPlatforms() {
+		pc := s.channelCfg.Platform(name)
+		if pc == nil {
+			continue
+		}
+		ctor, err := channel.Find(name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "octo serve: channel %s: %v\n", name, err)
+			continue
+		}
+		ad, err := ctor(pc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "octo serve: channel %s adapter: %v\n", name, err)
+			continue
+		}
+		if errs := ad.ValidateConfig(pc); len(errs) > 0 {
+			for _, e := range errs {
+				fmt.Fprintf(os.Stderr, "octo serve: channel %s config: %s\n", name, e)
+			}
+			continue
+		}
+
+		go func(a channel.Adapter, platform string) {
+			_ = a.Start(ctx, func(ev channel.InboundEvent) {
+				ev.Platform = platform
+				s.handleChannelMessage(ctx, a, ev)
+			})
+		}(ad, name)
+	}
+}
+
+// handleChannelMessage runs an agent turn for a channel inbound event.
+func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, ev channel.InboundEvent) {
+	// Handle slash commands (e.g. /bind, /sessions).
+	if reply := s.channelMgr.CommandRouter(ev); reply != "" {
+		ad.SendText(ev.ChatID, reply, ev.MessageID)
+		return
+	}
+
+	sess := s.channelMgr.GetOrCreateSession(ev)
+	if sess == nil {
+		return
+	}
+
+	ctrl := channel.NewUIController(ad, ev.ChatID, ev.MessageID)
+
+	var toolDefs []agent.ToolDefinition
+	var executor agent.ToolExecutor
+	if s.cfg.Tools {
+		executor = tools.NewDefaultRegistry()
+		toolDefs = tools.DefaultToolsFor(sess.Agent.Model)
+
+		spawner := app.NewSpawner(sess.Agent, executor, func() []agent.ToolDefinition {
+			return tools.DefaultToolsFor(sess.Agent.Model)
+		})
+		subMgr := tools.NewSubAgentManager(spawner)
+		subMgr.SetSynchronous(true)
+		ctx = tools.WithSubAgentManager(ctx, subMgr)
+		ctx = tools.WithTaskStore(ctx, sess.Tasks)
+	}
+
+	_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, ev.Text)
+}
+
+// stopChannels shuts down all channel adapters.
+func (s *Server) stopChannels() {
+	if s.channelCancel != nil {
+		s.channelCancel()
+	}
 }


### PR DESCRIPTION
## Summary

Add DingTalk Stream Mode and Feishu WebSocket IM adapters, and integrate the Channel Manager into `octo serve` so Web UI and IM platforms can run simultaneously.

## Changes

### New adapters (905 lines)
- **DingTalk**: Stream Mode WebSocket (`wss://wss.dingtalk.com`), OAuth token with auto-refresh, sessionWebhook send, @-mention detection, allowed_users whitelist
- **Feishu**: REST-to-WebSocket connection flow, tenant_access_token with auto-refresh, ping/pong heartbeat, `im.message.receive_v1` event processing, message editing support, @-mention stripping

### octo serve integration (144 lines)
- `server.Config.NoChannel` flag (default: auto-start channels)
- `Server.initChannels()` loads `~/.octo/channels.yml` and creates Manager
- `Server.startChannels()` / `handleChannelMessage()` / `stopChannels()`
- Shared sender/model/skills/permission/MCP between Web and IM
- `--no-channel` flag to disable

## Architecture

```
octo serve
  ├── HTTP Server (localhost:8080)
  │   ├── Web UI (SPA)
  │   ├── REST API + WebSocket
  │
  └── Channel Manager ─── shared config
      ├── DingTalk (Stream Mode)
      ├── Feishu (WebSocket)
      └── WeChat (iLink, pre-existing)
```

## Testing
- `go build ./cmd/octo/` ✅
- `go vet ./...` ✅
- `go test ./internal/server/ ./internal/channel/...` ✅