### PR TITLE
fix(webui): authentication, API endpoints, and panel rendering

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -14,12 +14,15 @@ import (
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/tasks"
 	"github.com/Leihb/octo-agent/internal/tools"
+	"github.com/Leihb/octo-agent/internal/version"
 )
 
 // ─── Request/Response types ─────────────────────────────────────────────────
 
 type createChatRequest struct {
 	Message string `json:"message"`
+	Model   string `json:"model,omitempty"`
+	Name    string `json:"name,omitempty"`
 }
 
 type createChatResponse struct {
@@ -71,7 +74,14 @@ func (s *Server) handleCreateChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sess := agent.NewSession(s.model, s.system)
+	model := s.model
+	if req.Model != "" {
+		model = req.Model
+	}
+	sess := agent.NewSession(model, s.system)
+	if req.Name != "" {
+		_ = sess.SetTitle(req.Name)
+	}
 
 	mu := s.sessionTurnLock(sess.ID)
 	mu.Lock()
@@ -272,6 +282,12 @@ func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// ─── GET /api/version ───────────────────────────────────────────────────────
+
+func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"version": version.Version})
 }
 
 // ─── Turn execution ─────────────────────────────────────────────────────────

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -249,6 +249,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/tools", s.requireAuth(s.handleListTools))
 	s.mux.HandleFunc("GET /api/skills", s.requireAuth(s.handleListSkills))
 	s.mux.HandleFunc("GET /api/health", s.handleHealth)
+	s.mux.HandleFunc("GET /api/version", s.handleVersion)
 	s.mux.HandleFunc("GET /api/channels", s.requireAuth(s.handleListChannels))
 	s.mux.HandleFunc("GET /api/channels/available", s.requireAuth(s.handleAvailableChannels))
 	s.mux.HandleFunc("GET /api/channels/{platform}", s.requireAuth(s.handleGetChannel))

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -104,7 +104,7 @@
               <button id="btn-new-session-inline" class="btn-split-main" title="New Session">+ New Session</button>
               <button id="btn-new-session-arrow" class="btn-split-arrow" title="Options">▾</button>
               <div id="new-session-dropdown" class="new-session-dropdown" hidden>
-                <div class="dropdown-item" id="btn-new-session-modal">More Options</div>
+                <div class="dropdown-item" id="btn-new-session-more">More Options</div>
               </div>
             </div>
           </div>
@@ -318,8 +318,21 @@
     <div id="channels-panel" style="display:none">
       <div id="channels-body">
         <div class="channels-page-header">
-          <h2 class="channels-page-title">Channels</h2>
-          <p class="channels-page-subtitle">Connect IM platforms so your users can chat with the assistant</p>
+          <div style="display:flex;justify-content:space-between;align-items:flex-start">
+            <div>
+              <h2 class="channels-page-title">Channels</h2>
+              <p class="channels-page-subtitle">Connect IM platforms so your users can chat with the assistant</p>
+            </div>
+            <div style="position:relative">
+              <button id="btn-add-channel" class="btn-create-task" style="white-space:nowrap">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M5 12h14"/><path d="M12 5v14"/>
+                </svg>
+                <span>Add Platform</span>
+              </button>
+              <div id="add-channel-dropdown" class="new-session-dropdown" hidden style="right:0;min-width:220px"></div>
+            </div>
+          </div>
         </div>
         <div id="channels-list"></div>
       </div>

--- a/internal/server/static/js/auth.js
+++ b/internal/server/static/js/auth.js
@@ -116,3 +116,36 @@ const Auth = (() => {
     get passed() { return _passed; },
   };
 })();
+
+// ── api — authenticated fetch wrapper ──────────────────────────────────────
+//
+// Automatically appends the access_key query param to every request.
+// Use this for all REST API calls from the Web UI.
+// ─────────────────────────────────────────────────────────────────────────
+const api = {
+  fetch(url, options = {}) {
+    const key = Auth.getKey();
+    let fullUrl = url;
+    if (key) {
+      const sep = url.includes('?') ? '&' : '?';
+      fullUrl = `${url}${sep}access_key=${encodeURIComponent(key)}`;
+    }
+    return window.fetch(fullUrl, options);
+  },
+
+  get(url) {
+    return this.fetch(url, { method: 'GET' });
+  },
+
+  post(url, body) {
+    return this.fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  },
+
+  delete(url) {
+    return this.fetch(url, { method: 'DELETE' });
+  },
+};

--- a/internal/server/static/js/channels.js
+++ b/internal/server/static/js/channels.js
@@ -20,14 +20,14 @@ const Channels = (() => {
 
   async function loadAvailable() {
     try {
-      const res = await fetch("/api/channels/available");
+      const res = await api.get("/api/channels/available");
       if (res.ok) _available = await res.json();
     } catch (e) { /* ignore */ }
   }
 
   async function loadChannels() {
     try {
-      const res = await fetch("/api/channels");
+      const res = await api.get("/api/channels");
       if (res.ok) _channels = await res.json();
     } catch (e) { /* ignore */ }
     render();
@@ -46,41 +46,17 @@ const Channels = (() => {
     const container = document.getElementById("channels-body");
     if (!container) return;
 
-    // Only render header once.
-    let header = container.querySelector(".channels-page-header");
-    if (!header) {
-      header = document.createElement("div");
-      header.className = "channels-page-header";
-      header.id = "channels-custom-header";
-      header.innerHTML = `
-        <div style="display:flex;justify-content:space-between;align-items:flex-start">
-          <div>
-            <h2 class="channels-page-title">Channels</h2>
-            <p class="channels-page-subtitle">Connect IM platforms so your users can chat with the assistant via DingTalk, Feishu, or WeChat.</p>
-          </div>
-          <div style="position:relative">
-            <button id="btn-add-channel" class="btn-create-task" style="white-space:nowrap">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M5 12h14"/><path d="M12 5v14"/>
-              </svg>
-              <span>Add Platform</span>
-            </button>
-            <div id="add-channel-dropdown" class="new-session-dropdown" hidden style="right:0;min-width:220px"></div>
-          </div>
-        </div>`;
-      container.insertBefore(header, container.firstChild);
-
-      // Wire add button dropdown.
-      const addBtn = document.getElementById("btn-add-channel");
-      const dropdown = document.getElementById("add-channel-dropdown");
-      if (addBtn && dropdown) {
-        addBtn.addEventListener("click", (e) => {
-          e.stopPropagation();
-          buildAddDropdown(dropdown);
-          dropdown.hidden = !dropdown.hidden;
-        });
-        document.addEventListener("click", () => { dropdown.hidden = true; });
-      }
+    // Wire add button dropdown (idempotent — safe to call multiple times).
+    const addBtn = document.getElementById("btn-add-channel");
+    const dropdown = document.getElementById("add-channel-dropdown");
+    if (addBtn && dropdown && !addBtn._wired) {
+      addBtn._wired = true;
+      addBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        buildAddDropdown(dropdown);
+        dropdown.hidden = !dropdown.hidden;
+      });
+      document.addEventListener("click", () => { dropdown.hidden = true; });
     }
 
     // Update title if needed.
@@ -255,11 +231,7 @@ const Channels = (() => {
     });
 
     try {
-      const res = await fetch(`/api/channels/${platform}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enabled, fields }),
-      });
+      const res = await api.post(`/api/channels/${platform}`, { enabled, fields });
       if (res.ok) {
         closeEditor();
         await loadChannels();
@@ -288,11 +260,7 @@ const Channels = (() => {
     }
 
     try {
-      const res = await fetch(`/api/channels/${platform}/test`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ fields }),
-      });
+      const res = await api.post(`/api/channels/${platform}/test`, { fields });
       const data = await res.json();
       if (resultEl) {
         resultEl.textContent = data.ok ? "✅ " + (data.message || "OK") : "❌ " + (data.error || "Failed");
@@ -310,7 +278,7 @@ const Channels = (() => {
     if (!confirm(`Remove ${platform} configuration? This cannot be undone.`)) return;
 
     try {
-      const res = await fetch(`/api/channels/${platform}`, { method: "DELETE" });
+      const res = await api.delete(`/api/channels/${platform}`);
       if (res.ok) {
         await loadChannels();
       }

--- a/internal/server/static/js/profile.js
+++ b/internal/server/static/js/profile.js
@@ -31,13 +31,13 @@ const Profile = (() => {
     const container = $("profile-soul-body");
     if (!container) return;
     try {
-      const res = await fetch("/api/profile/soul");
+      const res = await api.get("/api/profile/soul");
       if (!res.ok) {
         container.textContent = "SOUL.md not found. Run onboarding to create one.";
         return;
       }
       const data = await res.json();
-      container.textContent = data.content || "";
+      container.innerHTML = renderMarkdown(data.content || "");
     } catch (e) {
       container.textContent = "Failed to load SOUL.md";
     }
@@ -47,13 +47,13 @@ const Profile = (() => {
     const container = $("profile-user-body");
     if (!container) return;
     try {
-      const res = await fetch("/api/profile/user");
+      const res = await api.get("/api/profile/user");
       if (!res.ok) {
         container.textContent = "USER.md not found. Run onboarding to create one.";
         return;
       }
       const data = await res.json();
-      container.textContent = data.content || "";
+      container.innerHTML = renderMarkdown(data.content || "");
     } catch (e) {
       container.textContent = "Failed to load USER.md";
     }
@@ -63,7 +63,7 @@ const Profile = (() => {
     const container = $("memories-list");
     if (!container) return;
     try {
-      const res = await fetch("/api/memories");
+      const res = await api.get("/api/memories");
       if (!res.ok) {
         container.textContent = "No memories yet.";
         return;

--- a/internal/server/static/js/sessions.js
+++ b/internal/server/static/js/sessions.js
@@ -90,7 +90,7 @@ const Sessions = (() => {
 
     // Load message history from REST API.
     try {
-      const res = await fetch(`/api/sessions/${id}`);
+      const res = await api.get(`/api/sessions/${id}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const sess = await res.json();
 
@@ -247,11 +247,7 @@ const Sessions = (() => {
 
   async function createSessionAndSend(content) {
     try {
-      const res = await fetch("/api/chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: content }),
-      });
+      const res = await api.post("/api/chat", { message: content });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       _activeId = data.session_id;
@@ -367,6 +363,16 @@ const Sessions = (() => {
     WSDispatcher.on("turn_done", (ev) => {
       setSendEnabled(true);
       updateInfoBar();
+      // Re-render Markdown on the last bot bubble now that streaming is done.
+      if (ev.reply && ev.reply.content) {
+        const msgs = $("messages");
+        if (msgs) {
+          const last = msgs.querySelector(".message.bot:last-of-type .content");
+          if (last) {
+            last.innerHTML = renderMarkdown(ev.reply.content);
+          }
+        }
+      }
     });
 
     WSDispatcher.on("complete", (ev) => {
@@ -416,7 +422,7 @@ const Sessions = (() => {
     });
 
     // Load initial session list from REST as fallback.
-    fetch("/api/sessions")
+    api.get("/api/sessions")
       .then(r => r.json())
       .then(data => {
         if (Array.isArray(data) && _sessions.length === 0) {
@@ -548,7 +554,7 @@ const Sessions = (() => {
     });
 
     // New session modal.
-    const newSessionModalBtn = $("btn-new-session-modal");
+    const newSessionModalBtn = $("btn-new-session-more");
     const modalOverlay = $("new-session-modal");
     const modalCancel = $("new-session-cancel");
     const modalCreate = $("new-session-create");
@@ -566,13 +572,10 @@ const Sessions = (() => {
       modalCreate.addEventListener("click", async () => {
         const name = $("new-session-name")?.value || "";
         const model = $("new-session-model")?.value || "";
+        const dir = $("new-session-directory")?.value || "";
         modalOverlay.style.display = "none";
         try {
-          const res = await fetch("/api/chat", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ message: "/help" }),
-          });
+          const res = await api.post("/api/chat", { message: "/help", model, name });
           if (res.ok) {
             const data = await res.json();
             Sessions.select(data.session_id);

--- a/internal/server/static/js/settings.js
+++ b/internal/server/static/js/settings.js
@@ -6,8 +6,8 @@
 const Settings = (() => {
   let _models = [];
 
-  function init() {
-    renderModels();
+  async function init() {
+    await loadModels();
     wireEvents();
   }
 
@@ -48,8 +48,29 @@ const Settings = (() => {
         const idx = parseInt(btn.dataset.idx);
         _models.splice(idx, 1);
         renderModels();
+        syncModelSelect();
       });
     });
+
+    syncModelSelect();
+  }
+
+  // Sync the new-session modal's model select with the current model list.
+  function syncModelSelect() {
+    const select = $("new-session-model");
+    if (!select) return;
+    const currentVal = select.value;
+    select.innerHTML = "";
+    _models.forEach(m => {
+      const opt = document.createElement("option");
+      opt.value = m.model;
+      opt.textContent = `${escapeHtml(m.model)} (${escapeHtml(m.provider)})`;
+      select.appendChild(opt);
+    });
+    // Restore previous selection if still valid.
+    if (currentVal && _models.find(m => m.model === currentVal)) {
+      select.value = currentVal;
+    }
   }
 
   function wireEvents() {

--- a/internal/server/static/js/skills.js
+++ b/internal/server/static/js/skills.js
@@ -46,7 +46,7 @@ const Skills = (() => {
 
   async function loadSkills() {
     try {
-      const res = await fetch("/api/skills");
+      const res = await api.get("/api/skills");
       if (!res.ok) return;
       _skills = await res.json();
       render();

--- a/internal/server/static/js/tasks.js
+++ b/internal/server/static/js/tasks.js
@@ -19,7 +19,7 @@ const Tasks = (() => {
 
   async function load() {
     try {
-      const res = await fetch("/api/tasks");
+      const res = await api.get("/api/tasks");
       if (!res.ok) return;
       _tasks = await res.json();
     } catch (e) {
@@ -67,7 +67,7 @@ const Tasks = (() => {
       btn.addEventListener("click", async () => {
         const id = btn.dataset.id;
         try {
-          await fetch(`/api/tasks/${id}/run`, { method: "POST" });
+          await api.post(`/api/tasks/${id}/run`);
         } catch (e) {
           console.error(e);
         }
@@ -78,7 +78,7 @@ const Tasks = (() => {
         const id = btn.dataset.id;
         if (!confirm("Delete this task?")) return;
         try {
-          const res = await fetch(`/api/tasks/${id}`, { method: "DELETE" });
+          const res = await api.delete(`/api/tasks/${id}`);
           if (res.ok) { await load(); render(); }
         } catch (e) {
           console.error(e);
@@ -100,11 +100,7 @@ const Tasks = (() => {
 
   async function createTask(name, cronExpr, prompt) {
     try {
-      const res = await fetch("/api/tasks", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, cron: cronExpr, prompt }),
-      });
+      const res = await api.post("/api/tasks", { name, cron: cronExpr, prompt });
       if (res.ok) { await load(); render(); }
     } catch (e) {
       console.error(e);

--- a/internal/server/static/js/trash.js
+++ b/internal/server/static/js/trash.js
@@ -27,7 +27,7 @@ const Trash = (() => {
 
   async function loadFiles() {
     try {
-      const res = await fetch("/api/trash");
+      const res = await api.get("/api/trash");
       if (!res.ok) {
         _files = [];
       } else {
@@ -41,11 +41,7 @@ const Trash = (() => {
 
   async function emptyTrash(mode) {
     try {
-      await fetch("/api/trash/empty", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ mode }),
-      });
+      await api.post("/api/trash/empty", { mode });
       await loadFiles();
     } catch (e) {
       console.error(e);
@@ -89,7 +85,7 @@ const Trash = (() => {
         const id = btn.dataset.id;
         if (!id) return;
         try {
-          const res = await fetch(`/api/trash/${encodeURIComponent(id)}/restore`, { method: "POST" });
+          const res = await api.post(`/api/trash/${encodeURIComponent(id)}/restore`);
           if (res.ok) {
             await loadFiles();
           } else {

--- a/internal/server/static/js/version.js
+++ b/internal/server/static/js/version.js
@@ -11,7 +11,7 @@ const Version = (() => {
 
   async function loadVersion() {
     try {
-      const res = await fetch("/api/version");
+      const res = await api.get("/api/version");
       if (!res.ok) return;
       const data = await res.json();
 


### PR DESCRIPTION
Fixes identified through real browser testing with web-access:

- Add authenticated fetch wrapper (api.*) to all JS modules so REST calls include the access_key query param. Before this every API call from the browser returned 401.
- Add missing GET /api/version endpoint (was 404).
- Support model/name overrides in POST /api/chat request.
- Fix Profile panel: render Markdown instead of raw text for Soul/User.
- Fix Channels panel: move Add Platform button into static HTML so renderHeader() wires events idempotently.
- Fix Settings: init now loads the default model list and syncs it into the new-session modal's model select.
- Fix new-session modal ID collision (btn-new-session-modal vs overlay).
- Re-render Markdown on turn_done after streaming text deltas.
- Update all JS modules to use api.get/post/delete instead of raw fetch.

All server tests pass.