### PR TITLE
fix(server): validate access key on /api/health when provided

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -281,6 +281,12 @@ func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
 // ─── GET /api/health ────────────────────────────────────────────────────────
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	// When an access_key is provided, validate it so the Web UI can use this
+	// endpoint to verify the key before storing it. Without a key, stay public.
+	if r.URL.Query().Get("access_key") != "" && !s.validateAccessKey(r) {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -141,6 +141,28 @@ func TestAccessKey_HealthIsPublic(t *testing.T) {
 	}
 }
 
+func TestAccessKey_HealthRejectsWrongKey(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false, AccessKey: "test-secret-42"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health?access_key=wrong", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("health with wrong key: status = %d, want 401", w.Code)
+	}
+}
+
+func TestAccessKey_HealthAcceptsCorrectKey(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false, AccessKey: "test-secret-42"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health?access_key=test-secret-42", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("health with correct key: status = %d, want 200", w.Code)
+	}
+}
+
 func TestAccessKey_GeneratedWhenEmpty(t *testing.T) {
 	// When AccessKey is empty and OCTO_ACCESS_KEY is not set, a random key is generated.
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})


### PR DESCRIPTION
The Web UI uses `/api/health?access_key=...` to verify the access key before storing it in localStorage. However, `handleHealth` was returning 200 for **any** key (or no key) because it never called `validateAccessKey`.

**Fix:** when an `access_key` query parameter is present, validate it.
- Wrong key → 401 Unauthorized
- No key → still public 200 (health check semantics preserved)

Also adds tests for both wrong-key rejection and correct-key acceptance.