### PR TITLE
fix(server): read cookie auth and migrate legacy localStorage key

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -281,9 +281,18 @@ func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
 // ─── GET /api/health ────────────────────────────────────────────────────────
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	// When an access_key is provided, validate it so the Web UI can use this
-	// endpoint to verify the key before storing it. Without a key, stay public.
-	if r.URL.Query().Get("access_key") != "" && !s.validateAccessKey(r) {
+	// When an access_key is provided (query, header, or cookie), validate it
+	// so the Web UI can use this endpoint to verify the key before storing it.
+	// Without any key, stay public.
+	hasKey := r.URL.Query().Get("access_key") != "" ||
+		r.Header.Get("X-Access-Key") != "" ||
+		r.Header.Get("Authorization") != ""
+	if !hasKey {
+		if _, err := r.Cookie("octo_access_key"); err == nil {
+			hasKey = true
+		}
+	}
+	if hasKey && !s.validateAccessKey(r) {
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -536,6 +536,11 @@ func (s *Server) validateAccessKey(r *http.Request) bool {
 			key = strings.TrimPrefix(auth, "Bearer ")
 		}
 	}
+	if key == "" {
+		if c, err := r.Cookie("octo_access_key"); err == nil {
+			key = c.Value
+		}
+	}
 	return key == s.accessKey
 }
 

--- a/internal/server/static/auth.js
+++ b/internal/server/static/auth.js
@@ -30,8 +30,19 @@ const Auth = (() => {
   };
 
   function _getStoredKey() {
+    // Prefer the canonical underscore key; fall back to the legacy hyphenated
+    // key so users who authenticated with an older frontend version are not
+    // locked out. When the legacy key is found, migrate it in place.
+    let key = localStorage.getItem(STORAGE_KEY);
+    if (!key) {
+      key = localStorage.getItem('octo-access-key');
+      if (key) {
+        localStorage.setItem(STORAGE_KEY, key);
+        localStorage.removeItem('octo-access-key');
+      }
+    }
     return (
-      localStorage.getItem(STORAGE_KEY) ||
+      key ||
       new URLSearchParams(location.search).get('access_key') ||
       null
     );


### PR DESCRIPTION
修复 Web UI 认证失效问题——输入正确的 access key 后仍然无法登录。

## Bug 根因（三重叠加）

1. **后端不读 cookie**：auth.js 登录成功后设置 cookie `octo_access_key`，但后端 `validateAccessKey` 只检查 query param / header，从不读 cookie → 所有 API 请求 401。
2. **Health 不验证 cookie**：auth.js 用 `/api/sessions?limit=1` 探测认证状态（依赖 cookie），但 health 端点只在 query param 存在时才验证 → 有效 key 也返回 401 → 无限重新 prompt。
3. **localStorage key 名不一致**：老版本 auth.js 用 `octo-access-key`（连字符），新版用 `octo_access_key`（下划线）。有旧 key 的用户升级后直接锁死。

## 修复

| 文件 | 修改 |
|------|------|
| `server.go` | `validateAccessKey` 新增 cookie `octo_access_key` 读取 |
| `handlers.go` | `handleHealth` 在 cookie 存在时验证 key |
| `auth.js` | `_getStoredKey` 兼容旧版 `octo-access-key`，发现后自动迁移到新格式 |

## CDP 浏览器实测验证

- 旧版 key（连字符）→ 自动迁移，页面正常加载 ✅
- 全新用户 + 正确 key → 登录成功 ✅
- 错误 key → 停留在 prompt，不进入页面 ✅

## 测试
- `go test -race ./internal/server/...` ✅