### PR TITLE
chore: bump version to 0.14.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "0.13.1"
+var Version = "0.14.2"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Co-authored-by: octo-agent <no-reply@octo-agent.dev>
