### PR TITLE
fix(web): repair 3 more frontend-backend API contract mismatches

### DIFF
--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -229,6 +229,7 @@ type configResponse struct {
 }
 
 type modelConfig struct {
+	ID              string `json:"id"`
 	Type            string `json:"type"`
 	Model           string `json:"model"`
 	BaseURL         string `json:"base_url"`
@@ -244,6 +245,7 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 
 	if cfg.Model != "" || cfg.BaseURL != "" {
 		models = append(models, modelConfig{
+			ID:              "default",
 			Type:            "default",
 			Model:           cfg.Model,
 			BaseURL:         cfg.BaseURL,
@@ -344,5 +346,71 @@ func (s *Server) handleSaveModelConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": "default"})
+}
+
+// handleUpdateModelConfig updates an existing model config (same as save for single-model).
+func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing model id")
+		return
+	}
+
+	var req saveModelRequest
+	if err := readBodyJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	cfg, _ := config.Load()
+	cfg.Model = req.Model
+	cfg.BaseURL = req.BaseURL
+	if req.APIKey != "" {
+		cfg.APIKey = req.APIKey
+	}
+	if req.AnthropicFormat {
+		cfg.Provider = "anthropic"
+	} else {
+		cfg.Provider = "openai"
+	}
+
+	if err := cfg.Save(); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// handleDeleteModelConfig removes the single model config.
+func (s *Server) handleDeleteModelConfig(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing model id")
+		return
+	}
+
+	cfg, _ := config.Load()
+	cfg.Model = ""
+	cfg.BaseURL = ""
+	cfg.APIKey = ""
+	cfg.Provider = ""
+
+	if err := cfg.Save(); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// handleSetDefaultModelConfig sets the model as default (no-op in single-model system).
+func (s *Server) handleSetDefaultModelConfig(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing model id")
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -277,6 +277,9 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/config", s.requireAuth(s.handleGetConfig))
 	s.mux.HandleFunc("POST /api/config/test", s.requireAuth(s.handleTestConfig))
 	s.mux.HandleFunc("POST /api/config/models", s.requireAuth(s.handleSaveModelConfig))
+	s.mux.HandleFunc("PATCH /api/config/models/{id}", s.requireAuth(s.handleUpdateModelConfig))
+	s.mux.HandleFunc("DELETE /api/config/models/{id}", s.requireAuth(s.handleDeleteModelConfig))
+	s.mux.HandleFunc("POST /api/config/models/{id}/default", s.requireAuth(s.handleSetDefaultModelConfig))
 
 	// Upload
 	s.mux.HandleFunc("POST /api/upload", s.requireAuth(s.handleUpload))

--- a/internal/server/static/channels.js
+++ b/internal/server/static/channels.js
@@ -197,13 +197,14 @@ const Channels = (() => {
     const desired = checkbox.checked;
     checkbox.disabled = true;
     try {
-      const res = await fetch(`/api/channels/${encodeURIComponent(platform)}/enabled`, {
-        method:  "PATCH",
+      // Backend route is POST /api/channels/{platform} (not PATCH /enabled).
+      const res = await fetch(`/api/channels/${encodeURIComponent(platform)}`, {
+        method:  "POST",
         headers: { "Content-Type": "application/json" },
-        body:    JSON.stringify({ enabled: desired }),
+        body:    JSON.stringify({ enabled: desired, fields: {} }),
       });
       const data = await res.json();
-      if (!res.ok || !data.ok) throw new Error(data.error || "toggle failed");
+      if (!res.ok) throw new Error(data.error || "toggle failed");
       await _load({ silent: true });
     } catch (e) {
       checkbox.checked = !desired;

--- a/internal/server/static/skills.js
+++ b/internal/server/static/skills.js
@@ -500,11 +500,10 @@ const SkillAC = (() => {
     _currentSession = sessionId || null;
   }
 
-  /** Fetch live skill list from server for the current session. */
+  /** Fetch live skill list from server. */
   async function _fetchSkills() {
-    if (!_currentSession) return [];
     try {
-      const res  = await fetch(`/api/sessions/${_currentSession}/skills`);
+      const res  = await fetch("/api/skills");
       const data = await res.json();
       return data.skills || [];
     } catch (e) {


### PR DESCRIPTION
第二批 Web UI bug 修复：

### Bug 1: Channel toggle 404
channels.js 调用 ，后端不存在此路由。
→ 改为 ，body 为 ，复用现有的 。

### Bug 2: Session skills 404
skills.js 调用 ，后端不存在此路由。
→ Skills 是全局资源，改为 。

### Bug 3: Settings 模型 CRUD 不完整
settings.js 期望  和 ，但后端只有 。
→ 补充三个 handler，并在  返回中为模型添加 uid=501(qiao) gid=20(staff) groups=20(staff),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),98(_lpadmin),701(com.apple.sharepoint.group.1),33(_appstore),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),399(com.apple.access_ssh),400(com.apple.access_remote_ae) 字段，让前端能跟踪状态。

### 验证
- ok  	github.com/Leihb/octo-agent/cmd/octo	(cached)
?   	github.com/Leihb/octo-agent/cmd/octo-eval	[no test files]
ok  	github.com/Leihb/octo-agent/internal/agent	(cached)
ok  	github.com/Leihb/octo-agent/internal/app	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel	(cached)
?   	github.com/Leihb/octo-agent/internal/channel/adapters/dingtalk	[no test files]
?   	github.com/Leihb/octo-agent/internal/channel/adapters/feishu	[no test files]
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	(cached)
?   	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	[no test files]
ok  	github.com/Leihb/octo-agent/internal/conductor	(cached)
ok  	github.com/Leihb/octo-agent/internal/config	(cached)
ok  	github.com/Leihb/octo-agent/internal/eval	(cached)
ok  	github.com/Leihb/octo-agent/internal/hooks	(cached)
ok  	github.com/Leihb/octo-agent/internal/mcp	(cached)
ok  	github.com/Leihb/octo-agent/internal/memory	(cached)
ok  	github.com/Leihb/octo-agent/internal/permission	(cached)
ok  	github.com/Leihb/octo-agent/internal/prompt	(cached)
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/openai	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/retry	(cached)
ok  	github.com/Leihb/octo-agent/internal/sandbox	(cached)
?   	github.com/Leihb/octo-agent/internal/scheduler	[no test files]
ok  	github.com/Leihb/octo-agent/internal/server	(cached)
ok  	github.com/Leihb/octo-agent/internal/skills	(cached)
ok  	github.com/Leihb/octo-agent/internal/tasks	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools/rgembed	(cached)
?   	github.com/Leihb/octo-agent/internal/trash	[no test files]
ok  	github.com/Leihb/octo-agent/internal/tui	(cached)
ok  	github.com/Leihb/octo-agent/internal/version	(cached) 全绿
- curl 验证所有新增/修改的 API 端点均正常响应

---

Co-authored-by: octo-agent <no-reply@octo-agent.dev>