### PR TITLE
fix(web): repair 3 more frontend-backend contract mismatches

### DIFF
--- a/internal/server/static/profile.js
+++ b/internal/server/static/profile.js
@@ -145,8 +145,12 @@ const Profile = (() => {
     try {
       const res  = await fetch("/api/memories");
       const data = await res.json();
-      if (!res.ok || !data.ok) throw new Error(data.error || "Load failed");
-      _data.memories = data.memories || [];
+      if (!res.ok) throw new Error(data.error || "Load failed");
+      // Backend returns {files: [{name, path}, ...]} — map to frontend shape.
+      _data.memories = (data.files || []).map(f => ({
+        filename: f.name || "",
+        path:     f.path || "",
+      }));
     } catch (e) {
       console.error("[Profile] load memories failed", e);
       _data.memories = [];
@@ -273,7 +277,6 @@ const Profile = (() => {
           fetch("/api/memories/" + encodeURIComponent(m.filename))
             .then(r => r.json())
             .then(d => {
-              if (!d.ok) throw new Error(d.error || "Load failed");
               const stripped = _stripFrontmatter(d.content || "");
               body.innerHTML = _renderMarkdown(stripped)
                 || `<div class="profile-empty">${_t("profile.emptyContent")}</div>`;

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -639,15 +639,20 @@ const Sessions = (() => {
     }
     // Upload file to server via HTTP — only the path is returned, no base64 in memory
     const formData = new FormData();
-    formData.append("file", file);
+    formData.append("files", file);
     fetch("/api/upload", { method: "POST", body: formData })
       .then(r => r.json())
       .then(data => {
-        if (!data.ok) { alert(`Upload failed: ${data.error}`); return; }
+        const files = data.files || [];
+        if (files.length === 0 || files[0].error) {
+          alert(`Upload failed: ${files[0]?.error || data.error || "unknown error"}`);
+          return;
+        }
+        const uploaded = files[0];
         _pendingFiles.push({
-          name:      data.name,
-          path:      data.path,
-          mime_type: file.type
+          name:      uploaded.name,
+          path:      uploaded.url,
+          mime_type: uploaded.mime_type || file.type
         });
         _renderAttachmentPreviews();
         setTimeout(() => $("user-input").focus(), 100);

--- a/internal/server/static/tasks.js
+++ b/internal/server/static/tasks.js
@@ -112,7 +112,7 @@ const Tasks = (() => {
     });
     row.querySelector(".task-btn-del").addEventListener("click", e => {
       e.stopPropagation();
-      Tasks.delete(t.name);
+      Tasks.delete(t.id);
     });
 
     return row;
@@ -286,9 +286,9 @@ const Tasks = (() => {
       Sessions.select(session.id);
     },
 
-    async delete(name) {
-      if (!confirm(I18n.t("tasks.confirmDelete", { name }))) return;
-      const res = await fetch(`/api/cron-tasks/${encodeURIComponent(name)}`, { method: "DELETE" });
+    async delete(id) {
+      if (!confirm(I18n.t("tasks.confirmDelete"))) return;
+      const res = await fetch(`/api/tasks/${encodeURIComponent(id)}`, { method: "DELETE" });
       if (!res.ok) { alert(I18n.t("tasks.deleteError")); return; }
 
       await Tasks.load();


### PR DESCRIPTION
第三批 Web UI bug 修复：

### Bug 1: Profile Memories 加载失败
profile.js 检查 `data.ok` 和 `data.memories`，但后端返回 `{"files": [{"name","path"}]}`，既无 `ok` 也无 `memories`。单个 memory 展开也检查 `d.ok`，同样不存在。→ 移除不存在的 `ok` 检查，将 `files` 映射为前端期望的 `{filename, path}`。

### Bug 2: 文件上传失败
sessions.js 发送 `formData.append("file", file)`，但 upload handler 读取 `MultipartForm.File["files"]`，字段名不匹配导致后端永远返回 "no files uploaded"。另外前端检查 `data.ok` 但后端返回 `{"files": [...]}`。→ 统一字段名为 "files"，适配后端返回格式。

### Bug 3: Task 删除 404
tasks.js 调用 `DELETE /api/cron-tasks/{name}`，但后端只有 `DELETE /api/tasks/{id}`，参数也不匹配。→ 改为传入 task id 并调用 `DELETE /api/tasks/{id}`。

### 验证
- `go test -race ./...` 全绿

---

Co-authored-by: octo-agent <no-reply@octo-agent.dev>