### PR TITLE
fix(web): repair 3 more frontend-backend contract mismatches

### DIFF
--- a/internal/server/cron_task_handlers.go
+++ b/internal/server/cron_task_handlers.go
@@ -37,9 +37,9 @@ func (s *Server) handleRunCronTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Find task by name and run it.
+	// Find task by name or id and run it.
 	for _, t := range s.scheduler.List() {
-		if t.Name == name {
+		if t.Name == name || t.ID == name {
 			sessionID, err := s.scheduler.RunNow(r.Context(), t.ID)
 			if err != nil {
 				writeError(w, http.StatusBadRequest, err.Error())
@@ -77,9 +77,9 @@ func (s *Server) handlePatchCronTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Find task by name and update.
+	// Find task by name or id and update.
 	for _, t := range s.scheduler.List() {
-		if t.Name == name {
+		if t.Name == name || t.ID == name {
 			if req.Enabled != nil {
 				t.Enabled = *req.Enabled
 				_ = s.scheduler.Update(t)

--- a/internal/server/static/profile.js
+++ b/internal/server/static/profile.js
@@ -389,8 +389,8 @@ const Profile = (() => {
         "/api/memories/" + encodeURIComponent(m.filename),
         { method: "DELETE" }
       );
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok || !data.ok) {
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
         throw new Error(data.error || `HTTP ${res.status}`);
       }
       // Optimistic local remove + re-render.

--- a/internal/server/static/skills.js
+++ b/internal/server/static/skills.js
@@ -346,15 +346,17 @@ const Skills = (() => {
 
             try {
               const form = new FormData();
-              form.append("file", file);
+              form.append("files", file);
               const res  = await fetch("/api/upload", { method: "POST", body: form });
               const data = await res.json();
-              if (res.ok && data.path) {
+              const files = data.files || [];
+              const uploaded = files[0];
+              if (res.ok && uploaded && uploaded.url) {
                 // Fill the server-side temp path — /skill-add will read it directly
-                input.value = data.path;
+                input.value = uploaded.url;
               } else {
                 input.value = "";
-                alert(data.error || "Upload failed");
+                alert(uploaded?.error || data.error || "Upload failed");
               }
             } catch (e) {
               input.value = "";

--- a/internal/server/static/tasks.js
+++ b/internal/server/static/tasks.js
@@ -97,18 +97,18 @@ const Tasks = (() => {
 
     row.querySelector(".task-btn-run").addEventListener("click", e => {
       e.stopPropagation();
-      Tasks.run(t.name);
+      Tasks.run(t.id);
     });
     const toggleBtn = row.querySelector(".task-btn-toggle");
     if (toggleBtn) {
       toggleBtn.addEventListener("click", e => {
         e.stopPropagation();
-        Tasks.toggleEnabled(t.name, isPaused);  // isPaused=true means we want to enable
+        Tasks.toggleEnabled(t.id, isPaused);  // isPaused=true means we want to enable
       });
     }
     row.querySelector(".task-btn-edit").addEventListener("click", e => {
       e.stopPropagation();
-      Tasks.editInSession(t.name);
+      Tasks.editInSession(t.id, t.name);
     });
     row.querySelector(".task-btn-del").addEventListener("click", e => {
       e.stopPropagation();
@@ -192,28 +192,24 @@ const Tasks = (() => {
 
     // ── CRUD ─────────────────────────────────────────────────────────────
 
-    async run(name) {
-      const res = await fetch(`/api/cron-tasks/${encodeURIComponent(name)}/run`, {
+    async run(id) {
+      const res = await fetch(`/api/cron-tasks/${encodeURIComponent(id)}/run`, {
         method: "POST"
       });
       const data = await res.json();
       if (!res.ok) { alert(I18n.t("tasks.runError") + (data.error || "unknown")); return; }
 
-      if (data.session) {
+      if (data.session_id) {
         await Tasks.load();
-        Sessions.add(data.session);
-        Sessions.renderList();
-        Sessions.setPendingRunTask(data.session.id);
-        Sessions.select(data.session.id);
       }
     },
 
     /** Toggle a scheduled task's enabled flag. `wasPaused` is the current
      *  paused-state before the click; if true, we resume (enabled: true).
      *  Optimistic: we update local state first, then reload on success. */
-    async toggleEnabled(name, wasPaused) {
+    async toggleEnabled(id, wasPaused) {
       const nextEnabled = wasPaused; // paused → resume(true); running → pause(false)
-      const res = await fetch(`/api/cron-tasks/${encodeURIComponent(name)}`, {
+      const res = await fetch(`/api/cron-tasks/${encodeURIComponent(id)}`, {
         method:  "PATCH",
         headers: { "Content-Type": "application/json" },
         body:    JSON.stringify({ enabled: nextEnabled })
@@ -259,7 +255,7 @@ const Tasks = (() => {
     },
 
     /** Edit a task by creating a new session and auto-sending the edit command. */
-    async editInSession(name) {
+    async editInSession(id, name) {
       const maxN = Sessions.all.reduce((max, s) => {
         const m = s.name.match(/^Session (\d+)$/);
         return m ? Math.max(max, parseInt(m[1], 10)) : max;
@@ -282,7 +278,7 @@ const Tasks = (() => {
 
       Sessions.add(session);
       Sessions.renderList();
-      Sessions.setPendingMessage(session.id, `/cron-task-creator I'm editing ${name} task`);
+      Sessions.setPendingMessage(session.id, `/cron-task-creator edit ${id} "${name || ''}"`);
       Sessions.select(session.id);
     },
 


### PR DESCRIPTION
第四批 Web UI bug 修复：

### Bug 1: skills.js 上传字段名不匹配
skills.js 发送 `formData.append("file", file)`，但 upload handler 读取 `"files"`，导致后端永远返回 "no files uploaded"。此外前端检查 `data.path` 但后端返回 `{"files": [{"url", ...}]}`。
→ 统一字段名为 "files"，适配后端响应格式。

### Bug 2: profile.js memory delete 假报错
profile.js 检查 `data.ok`，但后端返回 `{"status": "deleted"}` 没有 `ok` 字段。删除操作明明成功却永远抛出错误。
→ 移除不存在的 `ok` 检查。

### Bug 3: tasks.js 使用空 name 作为 API 参数
后端返回的 task name 为空字符串，但前端用 `t.name` 作为 `run`/`toggle`/`edit` 的 API 路径参数，导致 404。
→ 所有 CRUD 操作改为使用 `t.id`。后端查找逻辑同时支持 id 和 name，兼容新旧客户端。

### 验证
- `go test -race ./...` 全绿

---

Co-authored-by: octo-agent <no-reply@octo-agent.dev>