### PR TITLE
feat(tools): user-defined agent presets from ~/.octo/agents/*.md

### DIFF
--- a/dev-docs/backlog.md
+++ b/dev-docs/backlog.md
@@ -59,15 +59,14 @@
 
 ## P2 — 中影响、需要一定设计
 
-### 3. 用户自定义 Agent 预设
+### 3. 用户自定义 Agent 预设 ✅
 
 - **位置**：`internal/tools/agent_presets.go:62`
 - **现状**：`lookupAgentPreset` 只有 4 个硬编码预设（explore / plan / general / code-review），代码里留了 TODO：
   ```go
   // TODO: load user-defined agents from ~/.octo/agents/*.md
   ```
-- **影响**：用户无法扩展自己的 sub-agent 类型（如 "security-review"、"docs-writer"）
-- **建议**：复用 SKILL.md 的 YAML frontmatter 格式（`name` / `description` / `persona` / `read_only`），扫描 `~/.octo/agents/*.md`，在 `lookupAgentPreset` 中优先查用户定义、再回退内置。
+- **已完成**：新增 `internal/tools/agents.go`，扫描 `~/.octo/agents/*.md`，YAML frontmatter 格式（`name` / `description` / `read_only`），正文为 persona。`lookupAgentPreset` 优先用户定义、再回退内置；`listPresetNames` 合并两者去重。
 
 ### 4. 微信 CDN 文件上传
 

--- a/internal/tools/agent_presets.go
+++ b/internal/tools/agent_presets.go
@@ -56,10 +56,18 @@ var builtInPresets = []agentPreset{
 }
 
 // lookupAgentPreset resolves a subagent_type name to its preset.
-// Built-ins are checked first; user-defined agents (loaded from ~/.octo/agents)
-// override built-ins when names collide.
+// User-defined agents (loaded from ~/.octo/agents/*.md) are checked first so
+// they override built-ins when names collide.
 func lookupAgentPreset(name string) (agentPreset, bool) {
-	// TODO: load user-defined agents from ~/.octo/agents/*.md
+	discoverAgents() // cheap: one directory scan, populated into cache
+
+	discoveredAgentsMu.RLock()
+	if p, ok := discoveredAgents[name]; ok {
+		discoveredAgentsMu.RUnlock()
+		return p, true
+	}
+	discoveredAgentsMu.RUnlock()
+
 	for _, p := range builtInPresets {
 		if p.name == name {
 			return p, true
@@ -69,10 +77,26 @@ func lookupAgentPreset(name string) (agentPreset, bool) {
 }
 
 // listPresetNames returns a comma-separated list of available preset names.
+// User-defined names are included alongside built-ins.
 func listPresetNames() string {
-	var names []string
+	discoverAgents()
+
+	discoveredAgentsMu.RLock()
+	names := make([]string, 0, len(discoveredAgents)+len(builtInPresets))
+	for n := range discoveredAgents {
+		names = append(names, n)
+	}
+	discoveredAgentsMu.RUnlock()
+
+	// Add built-ins that aren't already overridden by a user agent.
+	seen := make(map[string]bool, len(names))
+	for _, n := range names {
+		seen[n] = true
+	}
 	for _, p := range builtInPresets {
-		names = append(names, p.name)
+		if !seen[p.name] {
+			names = append(names, p.name)
+		}
 	}
 	return strings.Join(names, ", ")
 }

--- a/internal/tools/agents.go
+++ b/internal/tools/agents.go
@@ -1,0 +1,112 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// agentFrontmatter is the subset of an agent definition file's YAML frontmatter
+// that we consume. Unmapped keys are ignored.
+type agentFrontmatter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	ReadOnly    bool   `yaml:"read_only"`
+}
+
+// userAgentsRoot returns ~/.octo/agents, or "" when the home dir can't be
+// resolved. It's a var so tests can point discovery at a temp directory.
+var userAgentsRoot = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "agents")
+}
+
+// discoveredAgents holds the last scanned user-defined agents.
+var (
+	discoveredAgentsMu sync.RWMutex
+	discoveredAgents   map[string]agentPreset
+)
+
+// discoverAgents scans ~/.octo/agents/*.md and populates the package-level
+// discoveredAgents cache. It is safe to call concurrently; callers that need
+// the freshest set call it before lookupAgentPreset.
+func discoverAgents() {
+	root := userAgentsRoot()
+	if root == "" {
+		return
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return // missing/unreadable root: nothing to add
+	}
+	fresh := make(map[string]agentPreset, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		p, ok := parseAgentFile(filepath.Join(root, name))
+		if !ok {
+			continue
+		}
+		// The file name (without .md) is the authoritative trigger name.
+		p.name = strings.TrimSuffix(name, ".md")
+		fresh[p.name] = p
+	}
+	discoveredAgentsMu.Lock()
+	discoveredAgents = fresh
+	discoveredAgentsMu.Unlock()
+}
+
+// parseAgentFile reads a single agent definition markdown file. It expects YAML
+// frontmatter between `---` fences; the markdown body after the closing fence
+// becomes the agent persona. ok is false when the file has no frontmatter or
+// the YAML doesn't parse.
+func parseAgentFile(path string) (agentPreset, bool) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return agentPreset{}, false
+	}
+	front, body, ok := splitFrontmatter(string(b))
+	if !ok {
+		return agentPreset{}, false
+	}
+	var fm agentFrontmatter
+	if err := yaml.Unmarshal([]byte(front), &fm); err != nil {
+		return agentPreset{}, false
+	}
+	if fm.Description == "" {
+		return agentPreset{}, false
+	}
+	return agentPreset{
+		name:        "", // filled by caller from file name
+		description: fm.Description,
+		persona:     strings.TrimSpace(body),
+		readOnly:    fm.ReadOnly,
+	}, true
+}
+
+// splitFrontmatter returns the text between the opening and closing `---`
+// fences and everything after the closing fence. ok is false unless the first
+// non-empty content is a `---` line with a matching closing fence.
+func splitFrontmatter(content string) (front, body string, ok bool) {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", "", false
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return strings.Join(lines[1:i], "\n"), strings.Join(lines[i+1:], "\n"), true
+		}
+	}
+	return "", "", false
+}

--- a/internal/tools/agents_test.go
+++ b/internal/tools/agents_test.go
@@ -1,0 +1,173 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// useAgentsRoot points userAgentsRoot at dir for the test's duration.
+func useAgentsRoot(t *testing.T, dir string) {
+	t.Helper()
+	orig := userAgentsRoot
+	userAgentsRoot = func() string { return dir }
+	t.Cleanup(func() { userAgentsRoot = orig })
+}
+
+func writeAgentFile(t *testing.T, root, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDiscoverAgents_LoadsFromDisk(t *testing.T) {
+	root := t.TempDir()
+	useAgentsRoot(t, root)
+
+	writeAgentFile(t, root, "security-review.md", "---\nname: Security Review\ndescription: Review code for security issues\nread_only: true\n---\nYou are a security reviewer. Find vulnerabilities.")
+
+	discoverAgents()
+	p, ok := lookupAgentPreset("security-review")
+	if !ok {
+		t.Fatal("security-review not discovered")
+	}
+	if p.name != "security-review" {
+		t.Errorf("name = %q, want security-review", p.name)
+	}
+	if p.description != "Review code for security issues" {
+		t.Errorf("description = %q", p.description)
+	}
+	if !p.readOnly {
+		t.Error("readOnly should be true")
+	}
+	if !strings.Contains(p.persona, "security reviewer") {
+		t.Errorf("persona = %q", p.persona)
+	}
+}
+
+func TestDiscoverAgents_UserOverridesBuiltIn(t *testing.T) {
+	root := t.TempDir()
+	useAgentsRoot(t, root)
+
+	writeAgentFile(t, root, "explore.md", "---\ndescription: My custom explore\nread_only: false\n---\nCustom persona here")
+
+	discoverAgents()
+	p, ok := lookupAgentPreset("explore")
+	if !ok {
+		t.Fatal("explore not found")
+	}
+	if p.description != "My custom explore" {
+		t.Errorf("description = %q, want override", p.description)
+	}
+	if p.persona != "Custom persona here" {
+		t.Errorf("persona = %q", p.persona)
+	}
+	if p.readOnly {
+		t.Error("readOnly should be false from override")
+	}
+}
+
+func TestDiscoverAgents_SkipsMalformed(t *testing.T) {
+	root := t.TempDir()
+	useAgentsRoot(t, root)
+
+	// No frontmatter.
+	writeAgentFile(t, root, "nofence.md", "just body")
+	// Frontmatter but no description.
+	writeAgentFile(t, root, "nodesc.md", "---\nname: x\n---\nbody")
+	// Not a .md file.
+	writeAgentFile(t, root, "readme.txt", "---\ndescription: d\n---\nbody")
+
+	discoverAgents()
+	if _, ok := lookupAgentPreset("nofence"); ok {
+		t.Error("nofence should be skipped")
+	}
+	if _, ok := lookupAgentPreset("nodesc"); ok {
+		t.Error("nodesc should be skipped")
+	}
+	if _, ok := lookupAgentPreset("readme"); ok {
+		t.Error("readme.txt should be skipped")
+	}
+}
+
+func TestDiscoverAgents_MissingRootIsNoOp(t *testing.T) {
+	useAgentsRoot(t, filepath.Join(t.TempDir(), "nonexistent"))
+	discoverAgents()
+
+	// Built-ins should still work.
+	p, ok := lookupAgentPreset("general")
+	if !ok {
+		t.Fatal("built-in general should still be found")
+	}
+	if p.name != "general" {
+		t.Errorf("name = %q", p.name)
+	}
+}
+
+func TestListPresetNames_IncludesUserAndBuiltIn(t *testing.T) {
+	root := t.TempDir()
+	useAgentsRoot(t, root)
+
+	writeAgentFile(t, root, "custom.md", "---\ndescription: c\n---\nbody")
+
+	names := listPresetNames()
+	if !strings.Contains(names, "custom") {
+		t.Errorf("listPresetNames missing custom: %q", names)
+	}
+	if !strings.Contains(names, "explore") {
+		t.Errorf("listPresetNames missing built-in explore: %q", names)
+	}
+	if !strings.Contains(names, "general") {
+		t.Errorf("listPresetNames missing built-in general: %q", names)
+	}
+}
+
+func TestListPresetNames_NoDuplicatesWhenOverridden(t *testing.T) {
+	root := t.TempDir()
+	useAgentsRoot(t, root)
+
+	writeAgentFile(t, root, "explore.md", "---\ndescription: override\n---\nbody")
+
+	names := listPresetNames()
+	count := strings.Count(names, "explore")
+	if count != 1 {
+		t.Errorf("explore appears %d times in %q", count, names)
+	}
+}
+
+func TestParseAgentFile_Valid(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.md")
+	content := "---\nname: Test\ndescription: A test agent\nread_only: true\n---\nBe helpful.\n\nAlways verify."
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, ok := parseAgentFile(path)
+	if !ok {
+		t.Fatal("parseAgentFile returned false")
+	}
+	if p.description != "A test agent" {
+		t.Errorf("description = %q", p.description)
+	}
+	if !p.readOnly {
+		t.Error("readOnly should be true")
+	}
+	if !strings.Contains(p.persona, "Be helpful.") {
+		t.Errorf("persona = %q", p.persona)
+	}
+}
+
+func TestParseAgentFile_Invalid(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.md")
+	if err := os.WriteFile(path, []byte("no frontmatter here"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := parseAgentFile(path); ok {
+		t.Error("expected false for file without frontmatter")
+	}
+}


### PR DESCRIPTION
## What

Closes P2 backlog item #3.

User-defined agent presets let users extend the built-in  types (, , , ) with their own personas — e.g. , ,  — by dropping a markdown file into .

## Format

Same frontmatter format as skills (Claude Code compatible):



## Behaviour

- File name (without ) is the authoritative trigger name
- User-defined presets **override** built-ins by name
-  is lazy and cheap — a new file dropped in mid-session is picked up on the next  call without restart
- Malformed files are skipped silently

## Testing

- go test -race  -tags='' ./...
ok  	github.com/Leihb/octo-agent/cmd/octo	(cached)
?   	github.com/Leihb/octo-agent/cmd/octo-eval	[no test files]
ok  	github.com/Leihb/octo-agent/internal/agent	(cached)
ok  	github.com/Leihb/octo-agent/internal/app	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel	(cached)
?   	github.com/Leihb/octo-agent/internal/channel/adapters/dingtalk	[no test files]
?   	github.com/Leihb/octo-agent/internal/channel/adapters/feishu	[no test files]
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	(cached)
?   	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	[no test files]
ok  	github.com/Leihb/octo-agent/internal/conductor	(cached)
ok  	github.com/Leihb/octo-agent/internal/config	(cached)
ok  	github.com/Leihb/octo-agent/internal/eval	(cached)
ok  	github.com/Leihb/octo-agent/internal/hooks	(cached)
ok  	github.com/Leihb/octo-agent/internal/mcp	(cached)
ok  	github.com/Leihb/octo-agent/internal/memory	(cached)
ok  	github.com/Leihb/octo-agent/internal/permission	(cached)
ok  	github.com/Leihb/octo-agent/internal/prompt	(cached)
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/openai	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/retry	(cached)
ok  	github.com/Leihb/octo-agent/internal/sandbox	(cached)
?   	github.com/Leihb/octo-agent/internal/scheduler	[no test files]
ok  	github.com/Leihb/octo-agent/internal/server	(cached)
ok  	github.com/Leihb/octo-agent/internal/skills	(cached)
ok  	github.com/Leihb/octo-agent/internal/tasks	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools/rgembed	(cached)
?   	github.com/Leihb/octo-agent/internal/trash	[no test files]
ok  	github.com/Leihb/octo-agent/internal/tui	(cached)
ok  	github.com/Leihb/octo-agent/internal/version	(cached) passes (go test -race ./...)
- New tests:  × 4,  × 2,  × 2

Co-authored-by: octo-agent <no-reply@octo-agent.dev>