### PR TITLE
fix(channel): only route slash-prefixed messages to CommandRouter

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -686,10 +686,15 @@ func (s *Server) startChannels() {
 
 // handleChannelMessage runs an agent turn for a channel inbound event.
 func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, ev channel.InboundEvent) {
-	// Handle slash commands (e.g. /bind, /sessions).
-	if reply := s.channelMgr.CommandRouter(ev); reply != "" {
-		ad.SendText(ev.ChatID, reply, ev.MessageID)
-		return
+	// Handle slash commands (e.g. /bind, /sessions) — only when the message
+	// starts with "/". Without this guard, plain text like "你好" is parsed
+	// as an unknown command and never reaches the agent.
+	text := strings.TrimSpace(ev.Text)
+	if strings.HasPrefix(text, "/") {
+		if reply := s.channelMgr.CommandRouter(ev); reply != "" {
+			ad.SendText(ev.ChatID, reply, ev.MessageID)
+			return
+		}
 	}
 
 	sess := s.channelMgr.GetOrCreateSession(ev)


### PR DESCRIPTION
修复微信 IM 通道中普通消息被误当作命令处理的 bug。

### Bug
用户发送普通消息（如"你好"）时，收到回复：
> Unknown command: 你好. Available: /bind, /stop, /unbind, /status, /list

### 根因
`handleChannelMessage` 无条件地对**所有**入站消息调用 `CommandRouter`。
`CommandRouter` 将 "你好" 解析为未知命令并直接返回错误回复，
消息永远没有机会到达 agent。

### 修复
在调用 `CommandRouter` 前增加 `strings.HasPrefix(text, "/")` 检查，
与 `manager.go` 中的 `handleInbound` 保持一致：
只有以 `/` 开头的消息才走命令路由，普通文本直接交给 agent 处理。

### 验证
- `go test -race ./...` 全绿

---

Co-authored-by: octo-agent <no-reply@octo-agent.dev>