### PR TITLE
feat(weixin): CDN file upload for SendFile

### DIFF
--- a/dev-docs/backlog.md
+++ b/dev-docs/backlog.md
@@ -68,16 +68,16 @@
   ```
 - **已完成**：新增 `internal/tools/agents.go`，扫描 `~/.octo/agents/*.md`，YAML frontmatter 格式（`name` / `description` / `read_only`），正文为 persona。`lookupAgentPreset` 优先用户定义、再回退内置；`listPresetNames` 合并两者去重。
 
-### 4. 微信 CDN 文件上传
+### 4. 微信 CDN 文件上传 ✅
 
 - **位置**：`internal/channel/adapters/weixin/weixin.go:411`
-- **现状**：用户发文件时，目前只回复一条文本提示：
-  ```go
-  // TODO: implement CDN file upload. For now fall through to text hint.
-  return a.SendText(chatID, fmt.Sprintf("📎 File: %s", name), replyTo)
-  ```
-- **影响**：IM 桥的文件传输体验不完整，用户收到的是文件名文本而非真实文件
-- **建议**：实现微信 CDN 文件上传接口（先获取 media_id，再发文件消息）。这是 iLink 协议已支持的常规能力。
+- **现状**：`SendFile` 之前是 TODO stub，只回复文本提示
+- **已完成**：
+  - 新增 `ilink/crypto.go`：AES-128-ECB + PKCS7 加解密（参考 corespeed-io/wechatbot 实现）
+  - 扩展 `ilink/protocol.go`：`GetUploadURL`、`UploadToCDN`（带 3 次重试）、`BuildMediaMessage`、`BuildCDNUploadURL`
+  - `weixin.go` 的 `SendFile` 实现完整 CDN 上传流程：生成 AES key → 加密文件 → getuploadurl → POST 到 CDN → 构造 file_item 消息发送
+  - 按扩展名自动路由 media type（image/video/file）
+  - `CDNBaseURL` 改为 var，方便测试 mock
 
 ---
 

--- a/internal/channel/adapters/weixin/ilink/crypto.go
+++ b/internal/channel/adapters/weixin/ilink/crypto.go
@@ -1,0 +1,107 @@
+package ilink
+
+import (
+	"crypto/aes"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+)
+
+var hexPattern = regexp.MustCompile(`^[0-9a-fA-F]{32}$`)
+
+// EncryptAESECB encrypts plaintext with AES-128-ECB and PKCS7 padding.
+func EncryptAESECB(plaintext, key []byte) ([]byte, error) {
+	if len(key) != 16 {
+		return nil, fmt.Errorf("AES key must be 16 bytes, got %d", len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	padded := pkcs7Pad(plaintext, aes.BlockSize)
+	ciphertext := make([]byte, len(padded))
+	for i := 0; i < len(padded); i += aes.BlockSize {
+		block.Encrypt(ciphertext[i:i+aes.BlockSize], padded[i:i+aes.BlockSize])
+	}
+	return ciphertext, nil
+}
+
+// DecryptAESECB decrypts AES-128-ECB ciphertext and removes PKCS7 padding.
+func DecryptAESECB(ciphertext, key []byte) ([]byte, error) {
+	if len(key) != 16 {
+		return nil, fmt.Errorf("AES key must be 16 bytes, got %d", len(key))
+	}
+	if len(ciphertext)%aes.BlockSize != 0 {
+		return nil, fmt.Errorf("ciphertext length %d is not a multiple of block size", len(ciphertext))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	plaintext := make([]byte, len(ciphertext))
+	for i := 0; i < len(ciphertext); i += aes.BlockSize {
+		block.Decrypt(plaintext[i:i+aes.BlockSize], ciphertext[i:i+aes.BlockSize])
+	}
+	return pkcs7Unpad(plaintext)
+}
+
+// GenerateAESKey generates a random 16-byte AES key.
+func GenerateAESKey() ([]byte, error) {
+	key := make([]byte, 16)
+	_, err := rand.Read(key)
+	return key, err
+}
+
+// DecodeAESKey decodes an aes_key from the protocol.
+// Handles: direct hex (32 chars), base64(raw 16 bytes), base64(hex string 32 chars).
+func DecodeAESKey(encoded string) ([]byte, error) {
+	if hexPattern.MatchString(encoded) {
+		return hex.DecodeString(encoded)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		decoded, err = base64.URLEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, fmt.Errorf("cannot base64 decode aes_key: %w", err)
+		}
+	}
+	if len(decoded) == 16 {
+		return decoded, nil
+	}
+	if len(decoded) == 32 && hexPattern.Match(decoded) {
+		return hex.DecodeString(string(decoded))
+	}
+	return nil, fmt.Errorf("decoded aes_key has unexpected length %d (want 16 or 32)", len(decoded))
+}
+
+// EncodeAESKeyHex returns the hex string of a key (for getuploadurl).
+func EncodeAESKeyHex(key []byte) string {
+	return hex.EncodeToString(key)
+}
+
+// EncodeAESKeyBase64 returns base64(hex) for CDNMedia.aes_key.
+func EncodeAESKeyBase64(key []byte) string {
+	return base64.StdEncoding.EncodeToString([]byte(hex.EncodeToString(key)))
+}
+
+func pkcs7Pad(data []byte, blockSize int) []byte {
+	padding := blockSize - len(data)%blockSize
+	pad := make([]byte, padding)
+	for i := range pad {
+		pad[i] = byte(padding)
+	}
+	return append(data, pad...)
+}
+
+func pkcs7Unpad(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty data")
+	}
+	padding := int(data[len(data)-1])
+	if padding > len(data) || padding == 0 {
+		return nil, fmt.Errorf("invalid PKCS7 padding")
+	}
+	return data[:len(data)-padding], nil
+}

--- a/internal/channel/adapters/weixin/ilink/crypto_test.go
+++ b/internal/channel/adapters/weixin/ilink/crypto_test.go
@@ -1,0 +1,111 @@
+package ilink
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncryptDecryptAESECB_RoundTrip(t *testing.T) {
+	key, err := GenerateAESKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	plaintext := []byte("hello world, this is a test message for AES-128-ECB encryption")
+
+	ciphertext, err := EncryptAESECB(plaintext, key)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if len(ciphertext)%16 != 0 {
+		t.Errorf("ciphertext length %d not a multiple of 16", len(ciphertext))
+	}
+
+	decrypted, err := DecryptAESECB(ciphertext, key)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if !bytes.Equal(decrypted, plaintext) {
+		t.Errorf("decrypted mismatch: got %q, want %q", decrypted, plaintext)
+	}
+}
+
+func TestEncryptAESECB_WrongKeySize(t *testing.T) {
+	_, err := EncryptAESECB([]byte("test"), []byte("short"))
+	if err == nil {
+		t.Error("expected error for short key")
+	}
+}
+
+func TestDecryptAESECB_WrongKeySize(t *testing.T) {
+	_, err := DecryptAESECB(make([]byte, 16), []byte("short"))
+	if err == nil {
+		t.Error("expected error for short key")
+	}
+}
+
+func TestDecryptAESECB_BadBlockSize(t *testing.T) {
+	key, _ := GenerateAESKey()
+	_, err := DecryptAESECB([]byte("short"), key)
+	if err == nil {
+		t.Error("expected error for non-block-size ciphertext")
+	}
+}
+
+func TestDecodeAESKey_Hex(t *testing.T) {
+	hexKey := "0123456789abcdef0123456789abcdef"
+	decoded, err := DecodeAESKey(hexKey)
+	if err != nil {
+		t.Fatalf("decode hex: %v", err)
+	}
+	if len(decoded) != 16 {
+		t.Errorf("len=%d, want 16", len(decoded))
+	}
+}
+
+func TestDecodeAESKey_Base64Raw(t *testing.T) {
+	// base64 of raw 16 bytes
+	raw := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	encoded := EncodeAESKeyBase64(raw) // base64(hex) - the format used in CDNMedia
+	// But DecodeAESKey should handle base64(hex) too since hex is 32 bytes and base64 of 32 bytes = ~44 bytes
+	decoded, err := DecodeAESKey(encoded)
+	if err != nil {
+		t.Fatalf("decode base64(hex): %v", err)
+	}
+	if !bytes.Equal(decoded, raw) {
+		t.Errorf("decoded mismatch")
+	}
+}
+
+func TestEncodeAESKeyHex(t *testing.T) {
+	key := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	hexStr := EncodeAESKeyHex(key)
+	if len(hexStr) != 32 {
+		t.Errorf("hex len=%d, want 32", len(hexStr))
+	}
+}
+
+func TestPkcs7PadUnpad(t *testing.T) {
+	data := []byte("hello")
+	padded := pkcs7Pad(data, 16)
+	if len(padded) != 16 {
+		t.Errorf("padded len=%d, want 16", len(padded))
+	}
+	unpadded, err := pkcs7Unpad(padded)
+	if err != nil {
+		t.Fatalf("unpad: %v", err)
+	}
+	if !bytes.Equal(unpadded, data) {
+		t.Errorf("unpadded mismatch")
+	}
+}
+
+func TestPkcs7Unpad_Invalid(t *testing.T) {
+	_, err := pkcs7Unpad([]byte{})
+	if err == nil {
+		t.Error("expected error for empty data")
+	}
+	_, err = pkcs7Unpad([]byte{0x01, 0x02, 0xFF})
+	if err == nil {
+		t.Error("expected error for invalid padding")
+	}
+}

--- a/internal/channel/adapters/weixin/ilink/protocol.go
+++ b/internal/channel/adapters/weixin/ilink/protocol.go
@@ -23,8 +23,6 @@ import (
 const (
 	// DefaultBaseURL is the iLink API host.
 	DefaultBaseURL = "https://ilinkai.weixin.qq.com"
-	// CDNBaseURL is the media CDN host.
-	CDNBaseURL = "https://novac2c.cdn.weixin.qq.com/c2c"
 	// ChannelVersion is the protocol version.
 	ChannelVersion = "0.1.0"
 	// iLinkAppID is the iLink-App-Id header value.
@@ -32,6 +30,9 @@ const (
 	// iLinkClientVer is the iLink-App-ClientVersion header value (0x00MMNNPP for 0.1.0 = 256).
 	iLinkClientVer = "256"
 )
+
+// CDNBaseURL is the media CDN host. It is a var so tests can redirect uploads.
+var CDNBaseURL = "https://novac2c.cdn.weixin.qq.com/c2c"
 
 // APIError is returned when the iLink API returns a non-zero ret or HTTP error.
 type APIError struct {
@@ -301,4 +302,105 @@ func (c *Client) downloadRaw(ctx context.Context, url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	return io.ReadAll(resp.Body)
+}
+
+// GetUploadURLRequest holds parameters for getuploadurl.
+type GetUploadURLRequest struct {
+	FileKey     string `json:"filekey"`
+	MediaType   int    `json:"media_type"`
+	ToUserID    string `json:"to_user_id"`
+	RawSize     int    `json:"rawsize"`
+	RawFileMD5  string `json:"rawfilemd5"`
+	FileSize    int    `json:"filesize"`
+	NoNeedThumb bool   `json:"no_need_thumb,omitempty"`
+	AESKey      string `json:"aeskey,omitempty"`
+}
+
+// GetUploadURLResponse from getuploadurl.
+type GetUploadURLResponse struct {
+	UploadParam      string `json:"upload_param"`
+	ThumbUploadParam string `json:"thumb_upload_param,omitempty"`
+	UploadFullURL    string `json:"upload_full_url,omitempty"`
+}
+
+// GetUploadURL requests an upload URL for CDN media upload.
+func (c *Client) GetUploadURL(ctx context.Context, baseURL, token string, req GetUploadURLRequest) (*GetUploadURLResponse, error) {
+	body := map[string]interface{}{
+		"filekey":       req.FileKey,
+		"media_type":    req.MediaType,
+		"to_user_id":    req.ToUserID,
+		"rawsize":       req.RawSize,
+		"rawfilemd5":    req.RawFileMD5,
+		"filesize":      req.FileSize,
+		"no_need_thumb": req.NoNeedThumb,
+		"aeskey":        req.AESKey,
+		"base_info":     baseInfo(),
+	}
+	raw, err := c.apiPost(ctx, baseURL, "/ilink/bot/getuploadurl", token, body, 15*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	var result GetUploadURLResponse
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("getuploadurl decode: %w", err)
+	}
+	return &result, nil
+}
+
+// UploadToCDN uploads encrypted bytes to the CDN with retry (up to 3 attempts).
+// Returns the download encrypted_query_param from the x-encrypted-param header.
+func (c *Client) UploadToCDN(ctx context.Context, cdnURL string, ciphertext []byte) (string, error) {
+	const maxRetries = 3
+	var lastErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, "POST", cdnURL, bytes.NewReader(ciphertext))
+		if err != nil {
+			return "", fmt.Errorf("cdn upload request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+		resp, err := c.HTTP.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("cdn upload attempt %d: %w", attempt, err)
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+			errMsg := resp.Header.Get("x-error-message")
+			if errMsg == "" {
+				errMsg = string(body)
+			}
+			return "", fmt.Errorf("cdn upload client error %d: %s", resp.StatusCode, errMsg)
+		}
+		if resp.StatusCode != 200 {
+			errMsg := resp.Header.Get("x-error-message")
+			lastErr = fmt.Errorf("cdn upload server error %d: %s", resp.StatusCode, errMsg)
+			continue
+		}
+		downloadParam := resp.Header.Get("x-encrypted-param")
+		if downloadParam == "" {
+			lastErr = fmt.Errorf("cdn upload response missing x-encrypted-param header")
+			continue
+		}
+		return downloadParam, nil
+	}
+	return "", fmt.Errorf("cdn upload failed after %d attempts: %w", maxRetries, lastErr)
+}
+
+// BuildCDNUploadURL constructs a CDN upload URL from params.
+func BuildCDNUploadURL(cdnBaseURL, uploadParam, filekey string) string {
+	return cdnBaseURL + "/upload?encrypted_query_param=" + url.QueryEscape(uploadParam) + "&filekey=" + url.QueryEscape(filekey)
+}
+
+// BuildMediaMessage creates a media message payload.
+func BuildMediaMessage(userID, contextToken string, itemList []map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"from_user_id":  "",
+		"to_user_id":    userID,
+		"client_id":     newUUID(),
+		"message_type":  2,
+		"message_state": 2,
+		"context_token": contextToken,
+		"item_list":     itemList,
+	}
 }

--- a/internal/channel/adapters/weixin/ilink/protocol_upload_test.go
+++ b/internal/channel/adapters/weixin/ilink/protocol_upload_test.go
@@ -1,0 +1,150 @@
+package ilink
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetUploadURL(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ilink/bot/getuploadurl" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ret":             0,
+			"upload_param":    "test-param",
+			"upload_full_url": "",
+		})
+	}))
+	defer ts.Close()
+
+	c := NewClient()
+	resp, err := c.GetUploadURL(context.Background(), ts.URL, "tok", GetUploadURLRequest{
+		FileKey:    "key123",
+		MediaType:  3,
+		ToUserID:   "user1",
+		RawSize:    100,
+		RawFileMD5: "abc123",
+		FileSize:   128,
+	})
+	if err != nil {
+		t.Fatalf("GetUploadURL error: %v", err)
+	}
+	if resp.UploadParam != "test-param" {
+		t.Errorf("upload_param = %q, want test-param", resp.UploadParam)
+	}
+}
+
+func TestUploadToCDN_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.Header().Set("x-encrypted-param", "encrypted123")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := NewClient()
+	param, err := c.UploadToCDN(context.Background(), ts.URL, []byte("encrypted data"))
+	if err != nil {
+		t.Fatalf("UploadToCDN error: %v", err)
+	}
+	if param != "encrypted123" {
+		t.Errorf("param = %q, want encrypted123", param)
+	}
+}
+
+func TestUploadToCDN_RetryOn5xx(t *testing.T) {
+	attempts := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("x-encrypted-param", "ok-after-retry")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := NewClient()
+	param, err := c.UploadToCDN(context.Background(), ts.URL, []byte("data"))
+	if err != nil {
+		t.Fatalf("UploadToCDN error: %v", err)
+	}
+	if param != "ok-after-retry" {
+		t.Errorf("param = %q", param)
+	}
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestUploadToCDN_ClientErrorNoRetry(t *testing.T) {
+	attempts := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("x-error-message", "bad request")
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	c := NewClient()
+	_, err := c.UploadToCDN(context.Background(), ts.URL, []byte("data"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (no retry on 4xx)", attempts)
+	}
+}
+
+func TestBuildCDNUploadURL(t *testing.T) {
+	url := BuildCDNUploadURL("https://cdn.example.com/c2c", "param=val", "key123")
+	if !strings.Contains(url, "encrypted_query_param=param%3Dval") {
+		t.Errorf("missing encrypted_query_param: %s", url)
+	}
+	if !strings.Contains(url, "filekey=key123") {
+		t.Errorf("missing filekey: %s", url)
+	}
+}
+
+func TestBuildMediaMessage(t *testing.T) {
+	items := []map[string]interface{}{
+		{"type": 4, "file_item": map[string]string{"file_name": "test.txt"}},
+	}
+	msg := BuildMediaMessage("user1", "ctx123", items)
+	if msg["to_user_id"] != "user1" {
+		t.Errorf("to_user_id = %v", msg["to_user_id"])
+	}
+	if msg["context_token"] != "ctx123" {
+		t.Errorf("context_token = %v", msg["context_token"])
+	}
+	itemList := msg["item_list"].([]map[string]interface{})
+	if len(itemList) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(itemList))
+	}
+}
+
+func TestClient_UploadToCDN_Timeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("x-encrypted-param", "too-late")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := NewClient()
+	c.HTTP.Timeout = 50 * time.Millisecond
+	_, err := c.UploadToCDN(context.Background(), ts.URL, []byte("data"))
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -7,13 +7,17 @@ package weixin
 
 import (
 	"context"
+	"crypto/md5"
+	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -408,9 +412,145 @@ func (a *Adapter) SendFile(chatID, path, name, replyTo string) channel.SendResul
 	// Flush pending text first (Ruby convention).
 	a.sendQ.flush(chatID)
 
-	// TODO: implement CDN file upload. For now fall through to text hint.
-	_ = ct
-	return a.SendText(chatID, fmt.Sprintf("📎 File: %s", name), replyTo)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("read file: %v", err)}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	result, err := a.cdnUpload(ctx, chatID, data, name)
+	if err != nil {
+		log.Printf("[weixin] cdn upload %s failed: %v", name, err)
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("cdn upload: %v", err)}
+	}
+
+	items, err := a.buildMediaItems(result, name, data)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+
+	msg := ilink.BuildMediaMessage(chatID, ct.(string), items)
+	if err := a.client.SendMessage(ctx, a.bot.creds.BaseURL, a.bot.creds.Token, msg); err != nil {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("send message: %v", err)}
+	}
+	return channel.SendResult{OK: true}
+}
+
+// cdnUpload uploads data to WeChat CDN and returns the media reference.
+func (a *Adapter) cdnUpload(ctx context.Context, userID string, data []byte, fileName string) (*cdnUploadResult, error) {
+	aesKey, err := ilink.GenerateAESKey()
+	if err != nil {
+		return nil, fmt.Errorf("generate aes key: %w", err)
+	}
+	ciphertext, err := ilink.EncryptAESECB(data, aesKey)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt: %w", err)
+	}
+
+	var fileKeyBuf [16]byte
+	if _, err := rand.Read(fileKeyBuf[:]); err != nil {
+		return nil, fmt.Errorf("generate file key: %w", err)
+	}
+	fileKey := hex.EncodeToString(fileKeyBuf[:])
+
+	rawMD5 := md5.Sum(data)
+	rawMD5Hex := hex.EncodeToString(rawMD5[:])
+
+	mediaType := mediaTypeForFile(fileName)
+
+	uploadResp, err := a.client.GetUploadURL(ctx, a.bot.creds.BaseURL, a.bot.creds.Token, ilink.GetUploadURLRequest{
+		FileKey:     fileKey,
+		MediaType:   mediaType,
+		ToUserID:    userID,
+		RawSize:     len(data),
+		RawFileMD5:  rawMD5Hex,
+		FileSize:    len(ciphertext),
+		NoNeedThumb: true,
+		AESKey:      ilink.EncodeAESKeyHex(aesKey),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getuploadurl: %w", err)
+	}
+	if uploadResp.UploadParam == "" {
+		return nil, fmt.Errorf("getuploadurl did not return upload_param")
+	}
+
+	cdnURL := ilink.BuildCDNUploadURL(ilink.CDNBaseURL, uploadResp.UploadParam, fileKey)
+	encryptParam, err := a.client.UploadToCDN(ctx, cdnURL, ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("cdn upload: %w", err)
+	}
+
+	return &cdnUploadResult{
+		Media: ilink.CDNMedia{
+			EncryptQueryParam: encryptParam,
+			AESKey:            ilink.EncodeAESKeyBase64(aesKey),
+			EncryptType:       1,
+		},
+		AESKey:            aesKey,
+		EncryptedFileSize: len(ciphertext),
+		MediaType:         mediaType,
+	}, nil
+}
+
+// buildMediaItems constructs the item_list for a media message based on upload result.
+func (a *Adapter) buildMediaItems(result *cdnUploadResult, fileName string, data []byte) ([]map[string]interface{}, error) {
+	mediaMap := map[string]interface{}{
+		"encrypt_query_param": result.Media.EncryptQueryParam,
+		"aes_key":             result.Media.AESKey,
+		"encrypt_type":        result.Media.EncryptType,
+	}
+
+	switch result.MediaType {
+	case int(ilink.MediaImage):
+		return []map[string]interface{}{
+			{"type": ilink.ItemImage, "image_item": map[string]interface{}{
+				"media":    mediaMap,
+				"mid_size": result.EncryptedFileSize,
+			}},
+		}, nil
+	case int(ilink.MediaVideo):
+		return []map[string]interface{}{
+			{"type": ilink.ItemVideo, "video_item": map[string]interface{}{
+				"media":      mediaMap,
+				"video_size": result.EncryptedFileSize,
+			}},
+		}, nil
+	default:
+		return []map[string]interface{}{
+			{"type": ilink.ItemFile, "file_item": map[string]interface{}{
+				"media":     mediaMap,
+				"file_name": fileName,
+				"len":       strconv.Itoa(len(data)),
+			}},
+		}, nil
+	}
+}
+
+// cdnUploadResult holds the outcome of a CDN upload.
+type cdnUploadResult struct {
+	Media             ilink.CDNMedia
+	AESKey            []byte
+	EncryptedFileSize int
+	MediaType         int
+}
+
+var (
+	imageExts = map[string]bool{".png": true, ".jpg": true, ".jpeg": true, ".gif": true, ".webp": true, ".bmp": true}
+	videoExts = map[string]bool{".mp4": true, ".mov": true, ".webm": true, ".mkv": true, ".avi": true}
+)
+
+func mediaTypeForFile(fileName string) int {
+	ext := strings.ToLower(filepath.Ext(fileName))
+	if imageExts[ext] {
+		return int(ilink.MediaImage)
+	}
+	if videoExts[ext] {
+		return int(ilink.MediaVideo)
+	}
+	return int(ilink.MediaFile)
 }
 
 // UpdateMessage is not supported.

--- a/internal/channel/adapters/weixin/weixin_test.go
+++ b/internal/channel/adapters/weixin/weixin_test.go
@@ -94,12 +94,27 @@ func TestAdapter_SendText_Success(t *testing.T) {
 }
 
 func TestAdapter_SendFile(t *testing.T) {
+	// Create a real temp file to upload.
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.WriteString("hello world")
+	tmpFile.Close()
+
 	var mu sync.Mutex
 	var received []map[string]any
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		defer mu.Unlock()
-		if r.URL.Path == "/ilink/bot/sendmessage" {
+		switch r.URL.Path {
+		case "/ilink/bot/getuploadurl":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ret":          0,
+				"upload_param": "mock-upload-param",
+			})
+		case "/ilink/bot/sendmessage":
 			var payload map[string]any
 			body := make([]byte, r.ContentLength)
 			r.Body.Read(body)
@@ -107,9 +122,17 @@ func TestAdapter_SendFile(t *testing.T) {
 			received = append(received, payload)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{"ret": 0})
+		case "/upload":
+			w.Header().Set("x-encrypted-param", "mock-encrypt-param")
+			w.WriteHeader(http.StatusOK)
 		}
 	}))
 	defer ts.Close()
+
+	// Point CDNBaseURL at our test server.
+	origCDN := ilink.CDNBaseURL
+	ilink.CDNBaseURL = ts.URL
+	defer func() { ilink.CDNBaseURL = origCDN }()
 
 	a := &Adapter{
 		baseURL: ts.URL,
@@ -122,9 +145,24 @@ func TestAdapter_SendFile(t *testing.T) {
 	a.bot.contextTokens.Store("user1", "ctx123")
 	a.sendQ = newSendQueue(a.client, ts.URL, "tok")
 
-	res := a.SendFile("user1", "/tmp/test.txt", "test.txt", "")
+	res := a.SendFile("user1", tmpFile.Name(), "test.txt", "")
 	if !res.OK {
 		t.Fatalf("expected send OK, got error: %s", res.Error)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) == 0 {
+		t.Fatal("expected sendmessage request")
+	}
+	msg := received[0]["msg"].(map[string]any)
+	items := msg["item_list"].([]any)
+	if len(items) == 0 {
+		t.Fatal("expected at least one item")
+	}
+	item := items[0].(map[string]any)
+	if item["type"] != float64(ilink.ItemFile) {
+		t.Errorf("expected file item type, got %v", item["type"])
 	}
 }
 


### PR DESCRIPTION
## What

Closes P2 backlog item #4.

Implements real WeChat CDN file upload for the iLink adapter, replacing the old TODO stub that only sent a text hint (📎 File: filename).

## How it works

1. Generate random AES-128 key, encrypt file with ECB + PKCS7
2. Call  to get a signed 
3. POST encrypted bytes to the CDN upload endpoint
4. Read  from response header
5. Build  /  /  payload
6. Send via existing  API

## Auto-routing by extension

| Extension | media_type | message item |
|-----------|------------|--------------|
| .png/.jpg/.gif/.webp | 1 | image_item |
| .mp4/.mov/.webm/.mkv | 2 | video_item |
| everything else | 3 | file_item |

## New code

-  — AES-128-ECB encrypt/decrypt, PKCS7 padding, key encode/decode
-  — ,  (3-retry, 4xx abort), , 
-  —  +  helpers,  router

## Testing

- go test -race  -tags='' ./...
ok  	github.com/Leihb/octo-agent/cmd/octo	(cached)
?   	github.com/Leihb/octo-agent/cmd/octo-eval	[no test files]
ok  	github.com/Leihb/octo-agent/internal/agent	(cached)
ok  	github.com/Leihb/octo-agent/internal/app	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel	(cached)
?   	github.com/Leihb/octo-agent/internal/channel/adapters/dingtalk	[no test files]
?   	github.com/Leihb/octo-agent/internal/channel/adapters/feishu	[no test files]
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	(cached)
ok  	github.com/Leihb/octo-agent/internal/conductor	(cached)
ok  	github.com/Leihb/octo-agent/internal/config	(cached)
ok  	github.com/Leihb/octo-agent/internal/eval	(cached)
ok  	github.com/Leihb/octo-agent/internal/hooks	(cached)
ok  	github.com/Leihb/octo-agent/internal/mcp	(cached)
ok  	github.com/Leihb/octo-agent/internal/memory	(cached)
ok  	github.com/Leihb/octo-agent/internal/permission	(cached)
ok  	github.com/Leihb/octo-agent/internal/prompt	(cached)
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/openai	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/retry	(cached)
ok  	github.com/Leihb/octo-agent/internal/sandbox	(cached)
?   	github.com/Leihb/octo-agent/internal/scheduler	[no test files]
ok  	github.com/Leihb/octo-agent/internal/server	(cached)
ok  	github.com/Leihb/octo-agent/internal/skills	(cached)
ok  	github.com/Leihb/octo-agent/internal/tasks	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools/rgembed	(cached)
?   	github.com/Leihb/octo-agent/internal/trash	[no test files]
ok  	github.com/Leihb/octo-agent/internal/tui	(cached)
ok  	github.com/Leihb/octo-agent/internal/version	(cached) passes (ok  	github.com/Leihb/octo-agent/cmd/octo	(cached)
?   	github.com/Leihb/octo-agent/cmd/octo-eval	[no test files]
ok  	github.com/Leihb/octo-agent/internal/agent	(cached)
ok  	github.com/Leihb/octo-agent/internal/app	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel	(cached)
?   	github.com/Leihb/octo-agent/internal/channel/adapters/dingtalk	[no test files]
?   	github.com/Leihb/octo-agent/internal/channel/adapters/feishu	[no test files]
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	(cached)
ok  	github.com/Leihb/octo-agent/internal/conductor	(cached)
ok  	github.com/Leihb/octo-agent/internal/config	(cached)
ok  	github.com/Leihb/octo-agent/internal/eval	(cached)
ok  	github.com/Leihb/octo-agent/internal/hooks	(cached)
ok  	github.com/Leihb/octo-agent/internal/mcp	(cached)
ok  	github.com/Leihb/octo-agent/internal/memory	(cached)
ok  	github.com/Leihb/octo-agent/internal/permission	(cached)
ok  	github.com/Leihb/octo-agent/internal/prompt	(cached)
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/openai	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/retry	(cached)
ok  	github.com/Leihb/octo-agent/internal/sandbox	(cached)
?   	github.com/Leihb/octo-agent/internal/scheduler	[no test files]
ok  	github.com/Leihb/octo-agent/internal/server	(cached)
ok  	github.com/Leihb/octo-agent/internal/skills	(cached)
ok  	github.com/Leihb/octo-agent/internal/tasks	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools/rgembed	(cached)
?   	github.com/Leihb/octo-agent/internal/trash	[no test files]
ok  	github.com/Leihb/octo-agent/internal/tui	(cached)
ok  	github.com/Leihb/octo-agent/internal/version	(cached))
-  mocks the full upload pipeline
-  — round-trip, key decode, padding
-  — success, 5xx retry, 4xx no-retry, timeout

Co-authored-by: octo-agent <no-reply@octo-agent.dev>