### PR TITLE
feat(tui): interactive expand/collapse for sub-agent panel

### DIFF
--- a/cmd/octo/subagent_panel_test.go
+++ b/cmd/octo/subagent_panel_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Leihb/octo-agent/internal/tools"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // newPanelModel builds a tuiModel with just the sub-agent panel state, enough to
@@ -82,5 +83,102 @@ func TestSubAgentPanel_StartedResetsChain(t *testing.T) {
 	}
 	if len(m.subAgentOrder) != 1 {
 		t.Errorf("order changed on re-start: %v", m.subAgentOrder)
+	}
+}
+
+func TestSubAgentPanel_HistoryAccumulates(t *testing.T) {
+	m := newPanelModel()
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "started"})
+	for _, name := range []string{"read_file", "grep", "read_file", "edit_file", "terminal"} {
+		m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "tool", ToolName: name})
+	}
+	sa := m.subAgents["agent_1"]
+	if len(sa.history) != 5 {
+		t.Errorf("history len = %d, want 5", len(sa.history))
+	}
+	// recent is still capped
+	if len(sa.recent) != maxSubAgentRecentTools {
+		t.Errorf("recent len = %d, want %d", len(sa.recent), maxSubAgentRecentTools)
+	}
+}
+
+func TestSubAgentPanel_ExpandToggle(t *testing.T) {
+	m := newPanelModel()
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "started"})
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "tool", ToolName: "grep"})
+	m.subAgentFocus = 0
+
+	m.handleSubAgentPanelKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.subAgents["agent_1"].expanded {
+		t.Error("expected expanded after Enter")
+	}
+
+	m.handleSubAgentPanelKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.subAgents["agent_1"].expanded {
+		t.Error("expected collapsed after second Enter")
+	}
+}
+
+func TestSubAgentPanel_FocusNavigation(t *testing.T) {
+	m := newPanelModel()
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "started"})
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_2", Kind: "started"})
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_3", Kind: "started"})
+	m.subAgentFocus = 2 // start at the bottom
+
+	m.handleSubAgentPanelKey(tea.KeyMsg{Type: tea.KeyUp})
+	if m.subAgentFocus != 1 {
+		t.Errorf("focus = %d, want 1", m.subAgentFocus)
+	}
+
+	m.handleSubAgentPanelKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.subAgentFocus != 2 {
+		t.Errorf("focus = %d, want 2", m.subAgentFocus)
+	}
+
+	// ↓ past the last agent exits focus mode.
+	m.handleSubAgentPanelKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.subAgentFocus != -1 {
+		t.Errorf("focus = %d, want -1 (exited)", m.subAgentFocus)
+	}
+}
+
+func TestSubAgentPanel_RemoveAdjustsFocus(t *testing.T) {
+	m := newPanelModel()
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "started"})
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_2", Kind: "started"})
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_3", Kind: "started"})
+	m.subAgentFocus = 1 // focus on agent_2
+
+	m.removeSubAgent("agent_2")
+	if m.subAgentFocus != 1 {
+		t.Errorf("focus = %d, want 1 (agent_3 slid down)", m.subAgentFocus)
+	}
+
+	m.removeSubAgent("agent_3")
+	if m.subAgentFocus != 0 {
+		t.Errorf("focus = %d, want 0 (last remaining)", m.subAgentFocus)
+	}
+
+	m.removeSubAgent("agent_1")
+	if m.subAgentFocus != -1 {
+		t.Errorf("focus = %d, want -1 (none left)", m.subAgentFocus)
+	}
+}
+
+func TestSubAgentPanel_LiveHeightExpanded(t *testing.T) {
+	m := newPanelModel()
+	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "started"})
+	for i := 0; i < 5; i++ {
+		m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "tool", ToolName: "t"})
+	}
+	m.subAgents["agent_1"].expanded = true
+
+	// liveHeight includes textarea + status bar even on an empty model.
+	// We only care that expansion adds len(history) extra lines.
+	collapsedH := m.liveHeight()
+	m.subAgents["agent_1"].expanded = false
+	if got := m.liveHeight(); got != collapsedH-5 {
+		t.Errorf("collapsed liveHeight = %d, want %d (diff should be 5 history lines)", got, collapsedH-5)
 	}
 }

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -379,6 +379,12 @@ type tuiModel struct {
 	// subAgentOrder preserves launch order for stable rendering.
 	subAgents     map[string]*subAgentUI
 	subAgentOrder []string
+
+	// subAgentFocus is the index into subAgentOrder of the currently-focused
+	// sub-agent in the panel (-1 when the input box has focus). Navigation with
+	// ↑/↓ moves the focus; Enter toggles expand/collapse; Esc returns focus to
+	// the input box.
+	subAgentFocus int
 }
 
 // subAgentUI is the live panel state for one running sub-agent.
@@ -386,8 +392,10 @@ type subAgentUI struct {
 	description string
 	start       time.Time
 	toolCount   int
-	recent      []string // last few tool names, for the live chain
+	recent      []string // last few tool names, for the live chain (collapsed view)
+	history     []string // complete tool history (expanded view)
 	errored     bool
+	expanded    bool // true when the panel shows the full history
 }
 
 // runningTool is the live indicator state for an in-flight card tool.
@@ -435,7 +443,7 @@ func newTUIModel(cfg replConfig) *tuiModel {
 	if !tui.IsDark() {
 		style = "light"
 	}
-	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}}
+	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}, subAgentFocus: -1}
 	_ = m.updateTextAreaHeight()
 	return m
 }
@@ -780,6 +788,7 @@ func (m *tuiModel) handleSubAgentEvent(ev tools.SubAgentEvent) {
 		// A fresh round (sub_agent): reset the chain, keep the slot.
 		sa.toolCount = 0
 		sa.recent = nil
+		sa.history = nil
 		sa.errored = false
 		if ev.Description != "" {
 			sa.description = ev.Description
@@ -795,6 +804,7 @@ func (m *tuiModel) handleSubAgentEvent(ev tools.SubAgentEvent) {
 		if len(sa.recent) > maxSubAgentRecentTools {
 			sa.recent = sa.recent[len(sa.recent)-maxSubAgentRecentTools:]
 		}
+		sa.history = append(sa.history, name)
 	}
 }
 
@@ -804,10 +814,25 @@ func (m *tuiModel) removeSubAgent(id string) {
 		return
 	}
 	delete(m.subAgents, id)
+	removedIdx := -1
 	for i, x := range m.subAgentOrder {
 		if x == id {
 			m.subAgentOrder = append(m.subAgentOrder[:i], m.subAgentOrder[i+1:]...)
+			removedIdx = i
 			break
+		}
+	}
+	// Adjust focus if the removed agent had focus.
+	if m.subAgentFocus >= 0 {
+		if removedIdx < m.subAgentFocus {
+			m.subAgentFocus--
+		} else if removedIdx == m.subAgentFocus {
+			if m.subAgentFocus >= len(m.subAgentOrder) {
+				m.subAgentFocus = len(m.subAgentOrder) - 1
+			}
+			if m.subAgentFocus < 0 {
+				m.subAgentFocus = -1
+			}
 		}
 	}
 }

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -48,6 +48,11 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleModalKey(msg)
 	}
 
+	// Sub-agent panel navigation mode takes over ↑/↓/Enter/Esc when active.
+	if m.subAgentFocus >= 0 {
+		return m.handleSubAgentPanelKey(msg)
+	}
+
 	// Slash-command completion menu owns Tab/↑/↓/Enter/Esc while it's open, so
 	// it can navigate and accept without those keys reaching history nav or
 	// submit. Plain typing falls through and re-filters the menu below.
@@ -223,6 +228,12 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.ta.CursorEnd()
 			return m, m.updateTextAreaHeight()
 		}
+		// History exhausted and input empty — shift focus to the sub-agent panel
+		// when there are running agents.
+		if strings.TrimSpace(m.ta.Value()) == "" && len(m.subAgentOrder) > 0 {
+			m.subAgentFocus = len(m.subAgentOrder) - 1
+			return m, nil
+		}
 		return m, nil
 
 	case tea.KeyDown:
@@ -266,6 +277,38 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		cmd = tea.Batch(cmd, hcmd)
 	}
 	return m, cmd
+}
+
+// handleSubAgentPanelKey routes keys when the sub-agent panel has focus.
+// ↑/↓ moves between agents, Enter toggles expand/collapse, Esc returns to input.
+func (m *tuiModel) handleSubAgentPanelKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyUp:
+		if m.subAgentFocus > 0 {
+			m.subAgentFocus--
+		}
+		return m, nil
+	case tea.KeyDown:
+		if m.subAgentFocus < len(m.subAgentOrder)-1 {
+			m.subAgentFocus++
+		} else {
+			// ↓ past the last agent returns focus to the input box.
+			m.subAgentFocus = -1
+		}
+		return m, nil
+	case tea.KeyEnter:
+		if m.subAgentFocus >= 0 && m.subAgentFocus < len(m.subAgentOrder) {
+			id := m.subAgentOrder[m.subAgentFocus]
+			if sa := m.subAgents[id]; sa != nil {
+				sa.expanded = !sa.expanded
+			}
+		}
+		return m, nil
+	case tea.KeyEsc:
+		m.subAgentFocus = -1
+		return m, nil
+	}
+	return m, nil
 }
 
 // imageExts are the file extensions tryAttachDroppedImage recognises.
@@ -793,7 +836,17 @@ func (m *tuiModel) liveHeight() int {
 		h += 3 + len(bg) // panel border (2) + title (1) + body lines
 	}
 	if n := len(m.subAgentOrder); n > 0 {
-		h += 3 + n // panel border (2) + title (1) + one line per sub-agent
+		h += 3 // panel border (2) + title (1)
+		for _, id := range m.subAgentOrder {
+			sa := m.subAgents[id]
+			if sa == nil {
+				continue
+			}
+			h++ // header line
+			if sa.expanded {
+				h += len(sa.history) // one line per tool in history
+			}
+		}
 	}
 	h += m.completionHeight() // slash-completion menu (0 when closed)
 	h += m.ta.Height()        // input box (textarea grows with content)
@@ -916,14 +969,29 @@ func (m *tuiModel) View() string {
 			if sa.description != "" {
 				label = fmt.Sprintf("%s (%s)", id, truncate1Line(sa.description))
 			}
+			focus := "  "
+			if m.subAgentFocus == i {
+				focus = "▸ "
+			}
 			chain := "starting…"
 			if len(sa.recent) > 0 {
 				chain = strings.Join(sa.recent, " · ")
 			}
-			fmt.Fprintf(&lines, "%c %s — %s  (%d tools, %s)",
-				frame, label, chain, sa.toolCount, time.Since(sa.start).Round(time.Second))
+			elapsed := time.Since(sa.start).Round(time.Second)
+			fmt.Fprintf(&lines, "%s%c %s — %s  (%d tools, %s)",
+				focus, frame, label, chain, sa.toolCount, elapsed)
+			if sa.expanded && len(sa.history) > 0 {
+				for _, h := range sa.history {
+					lines.WriteByte('\n')
+					lines.WriteString("    ▸ " + h)
+				}
+			}
 		}
-		b.WriteString(tui.Panel(fmt.Sprintf("sub-agents (%d running)", len(m.subAgentOrder)), lines.String()))
+		title := fmt.Sprintf("sub-agents (%d running)", len(m.subAgentOrder))
+		if m.subAgentFocus >= 0 {
+			title += "  [↑/↓ nav · Enter expand · Esc back]"
+		}
+		b.WriteString(tui.Panel(title, lines.String()))
 		b.WriteByte('\n')
 	}
 

--- a/dev-docs/backlog.md
+++ b/dev-docs/backlog.md
@@ -83,13 +83,17 @@
 
 ## P3 — 低影响 / 未来工作
 
-### 5. TUI 子 Agent 面板交互式展开/折叠
+### 5. TUI 子 Agent 面板交互式展开/折叠 ✅
 
 - **位置**：`dev-docs/sub-agent-design.md:201`
 - **现状**：TUI 底部有 sub-agent 实时面板，每行内联显示最近几个 tool 名 + 累计计数
-- **尚未做**：按某个键（如 Enter）展开某个子 agent 的完整 tool 调用历史（需要焦点管理 + 按键处理）
-- **影响**：低——核心信息已显示，展开是锦上添花
-- **建议**：如果后续 TUI 做更多“可交互面板”重构时一并处理。
+- **已完成**：
+  - `subAgentUI` 新增 `history []string` 记录完整 tool 调用链（`recent` 仍保留用于折叠时的内联预览）
+  - `subAgentFocus int` 焦点管理：↑/↓ 在子 agent 间导航，Enter 展开/折叠，Esc 返回输入框
+  - 进入焦点模式：输入框为空、光标在第一行、按 ↑ 且 history 已到顶时自动进入
+  - 展开时渲染完整 history（每行一个 tool，缩进显示），`liveHeight` 动态计算展开后的高度
+  - 面板标题在焦点模式下显示快捷键提示 `[↑/↓ nav · Enter expand · Esc back]`
+  - `removeSubAgent` 自动调整焦点索引，避免焦点悬空
 
 ### 6. 截断恢复 Layer 2（resume-and-chunk）
 


### PR DESCRIPTION
## What

Closes P3 backlog item #5.

The TUI bottom sub-agent panel now supports keyboard-driven focus navigation and expand/collapse, so you can inspect a running sub-agent's full tool history without leaving the REPL.

## How to use

1. **Enter focus mode**: press ↑ when the input box is empty, cursor is on the first line, and input history is exhausted. The panel title changes to show .
2. **Navigate**: ↑/↓ moves the ▸ cursor between running sub-agents.
3. **Expand/collapse**: Enter toggles the selected agent between the compact one-line view (recent tools) and the full indented history list.
4. **Exit**: Esc returns focus to the input box; ↓ past the last agent also exits.

## Changes

-  gains  (unbounded complete chain) alongside the existing capped .
-  tracks panel focus.
-  handles ↑/↓/Enter/Esc when focus is on the panel.
-  renders the ▸ focus indicator and expanded history with indented bullets.
-  dynamically accounts for expanded history lines.
-  adjusts focus index to prevent dangling focus.

## Testing

- go test -race  -tags='' ./...
ok  	github.com/Leihb/octo-agent/cmd/octo	3.707s
?   	github.com/Leihb/octo-agent/cmd/octo-eval	[no test files]
ok  	github.com/Leihb/octo-agent/internal/agent	(cached)
ok  	github.com/Leihb/octo-agent/internal/app	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel	(cached)
?   	github.com/Leihb/octo-agent/internal/channel/adapters/dingtalk	[no test files]
?   	github.com/Leihb/octo-agent/internal/channel/adapters/feishu	[no test files]
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	(cached)
ok  	github.com/Leihb/octo-agent/internal/conductor	(cached)
ok  	github.com/Leihb/octo-agent/internal/config	(cached)
ok  	github.com/Leihb/octo-agent/internal/eval	(cached)
ok  	github.com/Leihb/octo-agent/internal/hooks	(cached)
ok  	github.com/Leihb/octo-agent/internal/mcp	(cached)
ok  	github.com/Leihb/octo-agent/internal/memory	(cached)
ok  	github.com/Leihb/octo-agent/internal/permission	(cached)
ok  	github.com/Leihb/octo-agent/internal/prompt	(cached)
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/openai	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/retry	(cached)
ok  	github.com/Leihb/octo-agent/internal/sandbox	(cached)
?   	github.com/Leihb/octo-agent/internal/scheduler	[no test files]
ok  	github.com/Leihb/octo-agent/internal/server	(cached)
ok  	github.com/Leihb/octo-agent/internal/skills	(cached)
ok  	github.com/Leihb/octo-agent/internal/tasks	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools/rgembed	(cached)
?   	github.com/Leihb/octo-agent/internal/trash	[no test files]
ok  	github.com/Leihb/octo-agent/internal/tui	(cached)
ok  	github.com/Leihb/octo-agent/internal/version	(cached) passes (ok  	github.com/Leihb/octo-agent/cmd/octo	(cached)
?   	github.com/Leihb/octo-agent/cmd/octo-eval	[no test files]
ok  	github.com/Leihb/octo-agent/internal/agent	(cached)
ok  	github.com/Leihb/octo-agent/internal/app	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel	(cached)
?   	github.com/Leihb/octo-agent/internal/channel/adapters/dingtalk	[no test files]
?   	github.com/Leihb/octo-agent/internal/channel/adapters/feishu	[no test files]
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	(cached)
ok  	github.com/Leihb/octo-agent/internal/conductor	(cached)
ok  	github.com/Leihb/octo-agent/internal/config	(cached)
ok  	github.com/Leihb/octo-agent/internal/eval	(cached)
ok  	github.com/Leihb/octo-agent/internal/hooks	(cached)
ok  	github.com/Leihb/octo-agent/internal/mcp	(cached)
ok  	github.com/Leihb/octo-agent/internal/memory	(cached)
ok  	github.com/Leihb/octo-agent/internal/permission	(cached)
ok  	github.com/Leihb/octo-agent/internal/prompt	(cached)
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/openai	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/retry	(cached)
ok  	github.com/Leihb/octo-agent/internal/sandbox	(cached)
?   	github.com/Leihb/octo-agent/internal/scheduler	[no test files]
ok  	github.com/Leihb/octo-agent/internal/server	(cached)
ok  	github.com/Leihb/octo-agent/internal/skills	(cached)
ok  	github.com/Leihb/octo-agent/internal/tasks	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools/rgembed	(cached)
?   	github.com/Leihb/octo-agent/internal/trash	[no test files]
ok  	github.com/Leihb/octo-agent/internal/tui	(cached)
ok  	github.com/Leihb/octo-agent/internal/version	(cached))
- New tests: , , , , 

Co-authored-by: octo-agent <no-reply@octo-agent.dev>