### PR TITLE
feat(agent): Layer 2 truncation recovery (resume-and-chunk)

### DIFF
--- a/dev-docs/backlog.md
+++ b/dev-docs/backlog.md
@@ -84,13 +84,11 @@
   - 面板标题在焦点模式下显示快捷键提示 `[↑/↓ nav · Enter expand · Esc back]`
   - `removeSubAgent` 自动调整焦点索引，避免焦点悬空
 
-### 6. 截断恢复 Layer 2（resume-and-chunk）
+### 6. 截断恢复 Layer 2（resume-and-chunk）✅
 
 - **位置**：`dev-docs/truncation-recovery.md:105`
 - **现状**：Layer 1（escalate-and-retry）已实现——遇到 `max_tokens` 时自动提升 cap 重试一次
-- **尚未做**：Layer 2——保留部分输出，喂回 "you were cut off; resume mid-thought and write in smaller pieces" 提示并继续（Claude Code 式多轮恢复）。需要处理 provider 对不完整 `tool_use` block 的兼容性。
-- **影响**：低——Layer 1 已覆盖绝大多数大文件写入场景
-- **建议**：等有大模型在 escalate 后仍然截断的真实案例时再起工。
+- **已完成**：Layer 2 实装——当 escalate 后仍然截断时，将 partial text 追加到 history，注入 recovery user message，继续 loop 让模型完成剩余内容。限制最多 3 次恢复，防止无限循环。跳过了截断的 tool_use（OpenAI 协议中 partial tool_use 在 history 中不安全）。引入 `escalateExhausted` 标志避免 resume 后重复 escalate。
 
 ### 7. Conductor Phase 2 / Phase 3（渐进交付的后续阶段）
 

--- a/dev-docs/backlog.md
+++ b/dev-docs/backlog.md
@@ -32,28 +32,17 @@
 
 ## P1 — 高影响、低复杂度
 
-### 1. Skill Toggle 状态持久化
+### 1. Skill Toggle 状态持久化 ✅
 
 - **位置**：`internal/server/skill_toggle_handler.go`
-- **现状**：`PATCH /api/skills/{name}/toggle` 是 no-op stub，返回成功但不持久化
-  ```go
-  writeJSON(w, http.StatusOK, map[string]any{
-      "name":    name,
-      "enabled": true,
-      "note":    "skill toggle is not yet persisted in the Go rewrite",
-  })
-  ```
-- **影响**：Web UI 里点 toggle 只是临时 UI 状态，刷新后丢失
-- **建议**：写入 `~/.octo/skills.yml`（或复用 config.yaml 的 tools 节），server 启动时重读。可独立成一个 PR。
+- **现状**：`PATCH /api/skills/{name}/toggle` 之前是 no-op stub
+- **已完成**：`tools.disabled_skills` 写入 `~/.octo/config.yaml`，`skills.Registry` 用 disabled-name set 过滤 `Get`/`List`/`Len`/`RenderManifest`，server 启动时从 config 重读。`GET /api/skills` 返回 `enabled` 字段。
 
-### 2. Web UI Benchmark Panel（后端缺失）
+### 2. Web UI Benchmark API ✅
 
-- **位置**：
-  - 前端：`internal/server/static/index.html:303`、`sessions.js:3981`
-  - 后端：`internal/server/`（无对应 handler）
-- **现状**：前端有完整的 benchmark UI（模型切换器里的延迟测试按钮），调用 `POST /api/sessions/{id}/benchmark`，但后端没有实现该 endpoint
-- **影响**：Web UI 的 latency 信号栏只能看历史缓存，无法跑新的 benchmark
-- **建议**：在 `internal/server/` 里加一个 benchmark handler，跑一个轻量的 provider ping（如发一个空 user message 测 TTFT）。前端代码已就绪，只需补齐后端。
+- **位置**：`internal/server/benchmark_handler.go`
+- **现状**：前端有 benchmark UI 但后端缺失对应 handler
+- **已完成**：新增 `POST /api/sessions/{id}/benchmark`，streaming TTFT 测量（通过 `StreamingSender` 检测首个 token 到达时间），非 streaming fallback，60s 超时。前端无需改动。
 
 ---
 

--- a/dev-docs/truncation-recovery.md
+++ b/dev-docs/truncation-recovery.md
@@ -102,12 +102,46 @@ case — a `write_file` call, whose content surfaces as a tool card rather than
 prose — the visible result is the final file, so impact is minor. Suppressing
 the re-emit is left to a later change.
 
-## Not yet implemented: resume-and-chunk
+## Layer 2: resume-and-chunk
 
-A second tier — keep the partial output, feed back a "you were cut off; resume
-mid-thought and write in smaller pieces" message, and continue (à la Claude
-Code's multi-turn recovery) — is **not** built. It needs per-provider handling
-of the partial `tool_use` block (safe on Anthropic, needs cleanup on
-OpenAI-compatible backends) and is a separate change. Layer 1 (escalate-retry)
-covers the common large-artifact case without it.
+When escalation (layer 1) is disabled, hits a model ceiling, or the escalated
+cap is still not enough, the loop falls back to **resume-and-chunk** instead of
+ending the turn immediately.
+
+### How it works
+
+1. The **partial text** from the truncated reply is appended to history as a
+   regular assistant message.
+2. A **recovery user message** is appended:
+   > "You were cut off mid-thought. Continue exactly where you left off and
+   > complete your response. Do not repeat what you've already written."
+3. The loop `continue`s to the next iteration, where the model sees its own
+   partial output followed by the recovery prompt and completes the remaining
+   content.
+
+### Safety guards
+
+- **Only text replies** (`reply.Content != ""`). Truncated `tool_use` blocks
+  are skipped because partial tool calls in OpenAI-protocol history can 400;
+  Layer 1 (escalate-retry) already covers the large-artifact case for tools.
+- **Resume budget**: `maxTruncationResumes = 3`. After three resumes the loop
+  gives up and falls through to the existing `budgetStop` graceful stop.
+- **Escalate exhaustion tracking**: `escalateExhausted` is set once Layer 2
+  fires, preventing redundant escalate attempts on subsequent iterations — the
+  loop goes straight to Layer 2 (or budgetStop when the resume budget is out).
+- **Token accounting**: every truncated attempt and every resume round accrues
+  real tokens into the session total.
+
+### When each layer fires
+
+| Scenario | Layer 1 (escalate) | Layer 2 (resume) |
+|---|---|---|
+| Default cap too small, escalated cap works | ✅ retries once | — |
+| Escalation disabled (`MaxTokensEscalate == 0`) | — | ❌ skipped; budgetStop |
+| Escalated cap still not enough | ✅ tried | ✅ resume up to 3× |
+| Model ceiling below escalation target | ❌ error caught | — |
+| Truncated `tool_use` (empty Content) | ✅ if cap allows | ❌ skipped (unsafe) |
+
+Layer 2 is particularly useful for long prose explanations, documentation, or
+multi-file write plans that exceed even a generous escalated cap.
 ```

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -341,6 +341,18 @@ const defaultMaxTurns = 100
 // unlimitedTurns signals no cap (used for unattended runs).
 const unlimitedTurns = -1
 
+// maxTruncationResumes caps how many times layer-2 resume-and-chunk fires per
+// run. Each resume appends the partial reply + a recovery prompt, consuming
+// another iteration of the loop budget. Three resumes is enough for most
+// large prose without risking an infinite loop.
+const maxTruncationResumes = 3
+
+// truncationResumePrompt is injected as a user message when a text reply is
+// cut off by the output-token cap and escalation (layer 1) didn't help.
+// The model sees its own partial output in history and is asked to continue
+// from exactly where it left off.
+const truncationResumePrompt = "You were cut off mid-thought. Continue exactly where you left off and complete your response. Do not repeat what you've already written."
+
 // Run is the agentic loop: it appends the user message to history then
 // repeatedly calls the provider until the model reaches end_turn (no more
 // tool calls) or the iteration cap is hit. Run is the buffered, no-event
@@ -498,7 +510,9 @@ func (a *Agent) runLoop(
 	a.appendUserInput(userInput)
 
 	limit := a.turnLimit()
-	streamStalls := 0 // transient mid-stream stalls re-issued for the current round
+	streamStalls := 0      // transient mid-stream stalls re-issued for the current round
+	truncationResumes := 0 // layer-2 resume-and-chunk budget
+	escalateExhausted := false
 	for i := 0; limit == unlimitedTurns || i < limit; i++ {
 		// Interrupt (Ctrl-C) between iterations — e.g. right after a tool batch.
 		if ctx.Err() != nil {
@@ -585,12 +599,14 @@ func (a *Agent) runLoop(
 		// regenerated with more room — no provider-specific partial-tool_use
 		// handling needed. Fires only when escalation raises the cap.
 		// See dev-docs/truncation-recovery.md.
-		if isTruncated(reply.StopReason) && a.MaxTokensEscalate > a.MaxTokens {
+		if isTruncated(reply.StopReason) && !escalateExhausted && a.MaxTokensEscalate > a.MaxTokens {
 			escalated, eerr := send(ctx, a.History.Snapshot(), a.MaxTokensEscalate)
 			switch {
 			case eerr == nil:
 				reply = escalated
 				a.accrueUsage(reply)
+				truncationResumes = 0 // escalation solved it — reset resume budget
+				escalateExhausted = false
 			case ctx.Err() != nil:
 				return a.finishInterrupted(handler)
 			case isMaxTokensTooLargeErr(eerr):
@@ -605,10 +621,27 @@ func (a *Agent) runLoop(
 			}
 		}
 
-		// Still truncated (escalation disabled, model ceiling hit, or even the
-		// escalated cap fell short): end the turn cleanly rather than dispatching
-		// a half-formed tool call or returning an empty reply. History keeps the
-		// progress; the caller gets a non-error explanation.
+		// ── Output-truncation recovery (layer 2) ──
+		// When escalation was attempted (cap raised) but the reply is still
+		// truncated, keep the partial text in history and prompt the model to
+		// continue. This covers long prose replies that exceed even the escalated
+		// cap. Limited to maxTruncationResumes to prevent infinite loops. Skipped
+		// for truncated tool_use blocks (partial tool calls are unsafe in
+		// OpenAI-protocol history) and when escalation is disabled.
+		if isTruncated(reply.StopReason) && a.MaxTokensEscalate > a.MaxTokens && reply.Content != "" && truncationResumes < maxTruncationResumes {
+			a.History.Append(NewAssistantMessage(reply.Content))
+			a.History.Append(NewUserMessage(truncationResumePrompt))
+			truncationResumes++
+			escalateExhausted = true
+			if handler != nil {
+				handler(AgentEvent{Kind: EventTextDelta, Text: "\n[octo] response truncated — resuming…\n"})
+			}
+			continue
+		}
+
+		// Still truncated and ineligible for layer-2 resume (tool_use truncation
+		// or resume budget exhausted): end the turn cleanly rather than dispatching
+		// a half-formed tool call or returning an empty reply.
 		if isTruncated(reply.StopReason) {
 			return a.budgetStop(handler, StopReasonMaxTokens,
 				"[octo] Stopped: the response was truncated at the output-token cap. "+

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1261,6 +1261,115 @@ func TestRunLoop_Truncation_ModelCeilingBackoff(t *testing.T) {
 	}
 }
 
+// ─── Output-truncation recovery (layer 2) ──────────────────────────────────
+
+func TestRunLoop_Truncation_Layer2ResumesText(t *testing.T) {
+	// Three replies: truncated at default cap, truncated after escalation,
+	// then end_turn after layer-2 resume.
+	send := &fakeToolSender{replies: []Reply{
+		{StopReason: StopReasonMaxTokens, Content: "First part of a very long explanation..."},
+		{StopReason: StopReasonMaxTokens, Content: "Still truncated even at escalated cap..."},
+		{StopReason: "end_turn", Content: " and here is the continuation that completes the thought."},
+	}}
+	a := New(send, "m")
+	a.MaxTokens = 4096
+	a.MaxTokensEscalate = 16384
+	defs, exec := truncSetup()
+
+	reply, err := a.Run(context.Background(), "explain everything", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", reply.StopReason)
+	}
+
+	// History: user, assistant(escalated partial), user(resume), assistant(complete)
+	// The first truncated reply is NOT in history (layer 1 drops it); the
+	// escalated-but-still-truncated reply becomes the partial that layer 2 keeps.
+	snap := a.History.Snapshot()
+	if len(snap) != 4 {
+		t.Fatalf("History len = %d, want 4 (user + assistant partial + user resume + assistant complete)", len(snap))
+	}
+	if snap[1].Role != RoleAssistant {
+		t.Errorf("snap[1].Role = %q, want assistant", snap[1].Role)
+	}
+	partial := snap[1].Content
+	if !strings.Contains(partial, "Still truncated") {
+		t.Errorf("partial text = %q, want 'Still truncated'", partial)
+	}
+	if snap[2].Role != RoleUser {
+		t.Errorf("snap[2].Role = %q, want user (resume prompt)", snap[2].Role)
+	}
+}
+
+func TestRunLoop_Truncation_Layer2BudgetExhausted(t *testing.T) {
+	// Replies: truncated at default, truncated after escalation, then three
+	// more truncated replies that exhaust maxTruncationResumes, then graceful stop.
+	// After layer 2 fires once, escalateExhausted is set so subsequent loops skip
+	// escalation and go straight to layer 2 (or budgetStop when exhausted).
+	replies := []Reply{
+		{StopReason: StopReasonMaxTokens, Content: "part1..."}, // 4096
+		{StopReason: StopReasonMaxTokens, Content: "part2..."}, // 16384 escalate
+		{StopReason: StopReasonMaxTokens, Content: "part3..."}, // 4096 resume #1
+		{StopReason: StopReasonMaxTokens, Content: "part4..."}, // 4096 resume #2
+		{StopReason: StopReasonMaxTokens, Content: "part5..."}, // 4096 resume #3
+	}
+	send := &fakeToolSender{replies: replies}
+	a := New(send, "m")
+	a.MaxTokens = 4096
+	a.MaxTokensEscalate = 16384
+	defs, exec := truncSetup()
+
+	reply, err := a.Run(context.Background(), "long story", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.StopReason != StopReasonMaxTokens {
+		t.Errorf("StopReason = %q, want %q", reply.StopReason, StopReasonMaxTokens)
+	}
+	if !strings.Contains(reply.Content, "truncated") {
+		t.Errorf("expected graceful-stop message, got %q", reply.Content)
+	}
+
+	// History: user + assistant(part1) + user(resume) + assistant(part2) + user(resume)
+	// + assistant(part3) + user(resume) + assistant(part4) + user(resume)
+	// + assistant(part5) + user(resume) + budgetStop assistant
+	// = 1 + 5*2 + 1 = 12
+	snap := a.History.Snapshot()
+	// user(1) + assistant_part2(1) + user_resume(1) + assistant_part3(1) + user_resume(1)
+	// + assistant_part4(1) + user_resume(1) + budgetStop(1) = 8
+	if len(snap) != 8 {
+		t.Errorf("History len = %d, want 12", len(snap))
+	}
+}
+
+func TestRunLoop_Truncation_Layer2SkipsToolUse(t *testing.T) {
+	// Truncated tool_use (Content empty) is unsafe for layer 2.
+	// Two truncated replies so escalation fires then falls to graceful stop.
+	send := &fakeToolSender{replies: []Reply{
+		{StopReason: StopReasonMaxTokens, Content: ""},
+		{StopReason: StopReasonMaxTokens, Content: ""},
+	}}
+	a := New(send, "m")
+	a.MaxTokens = 4096
+	a.MaxTokensEscalate = 16384
+	defs, exec := truncSetup()
+
+	reply, err := a.Run(context.Background(), "write a big file", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.StopReason != StopReasonMaxTokens {
+		t.Errorf("StopReason = %q, want %q", reply.StopReason, StopReasonMaxTokens)
+	}
+	// Should NOT have appended the truncated reply or resume prompt.
+	snap := a.History.Snapshot()
+	if len(snap) != 2 {
+		t.Errorf("History len = %d, want 2 (user + budgetStop assistant)", len(snap))
+	}
+}
+
 func TestIsMaxTokensTooLargeErr(t *testing.T) {
 	yes := []string{
 		"400 max_tokens: 99999 is greater than the maximum allowed",


### PR DESCRIPTION
## What

Closes P3 backlog item #6.

When a model response is truncated by the output-token cap and escalation (Layer 1) is not enough, the agent loop now keeps the partial text in history and prompts the model to continue — rather than ending the turn with a budgetStop.

## How it works

1. Partial text from the truncated reply is appended to history as a regular assistant message.
2. A recovery user message is injected: "You were cut off mid-thought. Continue exactly where you left off..."
3. The loop continues; the model sees its own output and completes the remaining content.

## Safety guards

- **Text only**: skipped for truncated tool_use blocks (partial tool calls in OpenAI history can 400).
- **Resume budget**: max 3 resumes (maxTruncationResumes), then graceful stop.
- **Escalate exhaustion**: escalateExhausted flag prevents redundant escalate attempts after Layer 2 has fired once.

## Testing

- make test passes (go test -race ./...)
- New tests:
  - TestRunLoop_Truncation_Layer2ResumesText — partial text kept, model completes after recovery prompt
  - TestRunLoop_Truncation_Layer2BudgetExhausted — 3 resumes then graceful stop
  - TestRunLoop_Truncation_Layer2SkipsToolUse — empty Content skips resume

## Docs

- dev-docs/truncation-recovery.md — updated with Layer 2 design section
- dev-docs/backlog.md — marked P3#6 as completed

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
