### PR TITLE
chore: bump version to 0.16.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "0.15.0"
+var Version = "0.16.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump version to 0.16.0.

New feature in this release:
- Bundle web-access as a default skill (#449)