### PR TITLE
feat(agent): real token counts for compaction + configurable auto threshold

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -241,7 +241,8 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	permMode := fs.String("permission-mode", "", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask) | auto (allow on ask). Empty = use `octo config` value, else interactive.")
 	noCoauthor := fs.Bool("no-coauthor", false, "Disable appending Co-authored-by to git commit messages. Also OCTO_COAUTHOR=0.")
 	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = auto: 100 interactive, unlimited unattended/--prompt-file)")
-	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (~75% of the model's context window), <0 = disabled")
+	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (percentage of the model's context window, settable via --compact-auto-pct or config), <0 = disabled")
+	compactAutoPct := fs.Int("compact-auto-pct", 0, "Auto-compaction threshold as a percentage of the model's context window (0 = use `octo config` or built-in default 75). Only used when --compact-threshold=0.")
 	reasoningEffort := fs.String("reasoning-effort", "", "Reasoning intensity: low | medium | high (empty = off). OpenAI → reasoning_effort; Anthropic → mapped thinking budget. Also from `octo config`.")
 	showReasoning := fs.Bool("show-reasoning", true, "Stream the reasoning/thinking trace to the terminal (dimmed). Use --show-reasoning=false to hide it. Also from `octo config`.")
 	useSandbox := fs.Bool("sandbox", false, "Confine terminal commands to the project dir + tmp with no network (OS-enforced; macOS/Linux). Fails closed if unavailable.")
@@ -465,6 +466,14 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	a.MaxTokensEscalate = resolveMaxTokensEscalate(*maxTokensEscalate, provName)
 	a.MaxTurns = resolveMaxTurns(*maxTurns, seedPrompt != "", stdinIsTTY(stdin))
 	a.CompactThreshold = *compactThreshold
+	// Resolve auto-compaction percentage: explicit flag > config > built-in default.
+	autoPct := *compactAutoPct
+	if autoPct == 0 {
+		autoPct = cfg.CompactAutoPct
+	}
+	if autoPct > 0 {
+		a.CompactAutoFraction = float64(autoPct) / 100.0
+	}
 
 	// Build the tool executor up-front (REPL mode only — single-turn mode
 	// doesn't dispatch tools) and register the sub-agent dispatcher BEFORE the

--- a/cmd/octo/completion.go
+++ b/cmd/octo/completion.go
@@ -117,7 +117,7 @@ func chatCandidates(words []string, prev string) []string {
 	case "--reasoning-effort":
 		return []string{"low", "medium", "high"}
 	case "--model", "--system", "--max-tokens", "--max-tokens-escalate", "--max-turns",
-		"--compact-threshold",
+		"--compact-threshold", "--compact-auto-pct",
 		"--sandbox-write", "--sandbox-read":
 		// These take freeform values; nothing useful to suggest.
 		return nil
@@ -261,6 +261,7 @@ var chatFlags = []string{
 	"--permission-mode", "--list-sessions", "--list-skills",
 	"--quiet", "--verbose", "--plain", "--stream", "--system",
 	"--reasoning-effort", "--show-reasoning",
+	"--compact-auto-pct",
 	"--help",
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -144,6 +144,11 @@ type Agent struct {
 	// default); >0 is an explicit token count. See compactTriggerTokens.
 	CompactThreshold int
 
+	// CompactAutoFraction is the share (0.0–1.0) of the model's context window
+	// at which auto-compaction triggers when CompactThreshold == 0. Zero uses
+	// the built-in default (0.75). Values outside 0–1 are clamped.
+	CompactAutoFraction float64
+
 	// overflow handles "context too long" 400 errors by compressing history
 	// and retrying. Aligned with Ruby's perform_context_overflow_compression.
 	overflow overflowRecovery

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -145,17 +145,40 @@ func contextWindow(model string) int {
 // CompactThreshold:
 //
 //	< 0  → disabled (0)
-//	== 0 → auto: a fraction of the model's context window
+//	== 0 → auto: a fraction of the model's context window (settable via
+//	       CompactAutoFraction, default compactThresholdFraction)
 //	> 0  → that explicit token count
 func (a *Agent) compactTriggerTokens() int {
 	switch {
 	case a.CompactThreshold < 0:
 		return 0
 	case a.CompactThreshold == 0:
-		return int(float64(contextWindow(a.Model)) * compactThresholdFraction)
+		frac := a.CompactAutoFraction
+		if frac <= 0 {
+			frac = compactThresholdFraction
+		}
+		if frac > 1 {
+			frac = 1
+		}
+		return int(float64(contextWindow(a.Model)) * frac)
 	default:
 		return a.CompactThreshold
 	}
+}
+
+// historyTokens returns the best available token count for the given messages.
+// When the provider has reported a real input token count (lastInputTokens > 0),
+// it returns that value; otherwise it falls back to the heuristic estimate.
+// The real count is more accurate because it reflects exactly how the provider's
+// tokenizer counted the prompt, including any format overhead the estimate misses.
+func (a *Agent) historyTokens(msgs []Message) int {
+	a.usageMu.Lock()
+	real := a.lastInputTokens
+	a.usageMu.Unlock()
+	if real > 0 {
+		return real
+	}
+	return estimateMessages(msgs)
 }
 
 // summarizeMaxTokens caps the summary length. A summary is meant to be a
@@ -198,13 +221,15 @@ Focus on:
 
 Begin your response NOW. Remember: PURE TEXT only, starting with <topics> then <summary>.`
 
-// maybeCompact summarizes the older portion of history when the estimated
-// total context size (from History.Snapshot) crosses CompactThreshold. It runs
-// only at a safe boundary — between turns, splitting on a plain user message —
-// so tool_use/tool_result pairs are never severed. A nil return means either
-// "compaction disabled / not needed" or "compacted successfully"; an error
-// means the summarization side-call failed (the caller logs and proceeds with
-// uncompacted history rather than aborting the turn).
+// maybeCompact summarizes the older portion of history when the total context
+// size crosses CompactThreshold. It prefers the real token count reported by
+// the provider (lastInputTokens) and falls back to a heuristic estimate when no
+// real data is available yet. It runs only at a safe boundary — between turns,
+// splitting on a plain user message — so tool_use/tool_result pairs are never
+// severed. A nil return means either "compaction disabled / not needed" or
+// "compacted successfully"; an error means the summarization side-call failed
+// (the caller logs and proceeds with uncompacted history rather than aborting
+// the turn).
 //
 // handler may be nil (the non-streaming Run path); when set, maybeCompact
 // emits EventCompactStarted/Progress/Done around the summarization so the UI
@@ -218,7 +243,7 @@ func (a *Agent) maybeCompact(ctx context.Context, handler EventHandler) error {
 	}
 
 	msgs := a.History.Snapshot()
-	before := estimateMessages(msgs)
+	before := a.historyTokens(msgs)
 	if before < trigger {
 		return nil
 	}
@@ -279,9 +304,10 @@ func emitCompactDone(handler EventHandler, before, after, folded int) {
 // alternation holds), and the LLM returns a summary. The caller is responsible
 // for rebuilding history with the summary.
 //
-// Overflow protection: if the estimated token count of msgs exceeds the model's
-// context window, messages are popped from the head until it fits. This
-// prevents the compression call itself from 400-ing.
+// Overflow protection: if the token count of msgs exceeds the model's context
+// window, messages are popped from the head until it fits. This prevents the
+// compression call itself from 400-ing. The count prefers the provider's real
+// lastInputTokens and falls back to a heuristic estimate.
 //
 // When the Sender implements StreamingSender and a handler is attached, the
 // summary is streamed so the caller can surface EventCompactProgress as it
@@ -293,7 +319,7 @@ func (a *Agent) summarize(ctx context.Context, msgs []Message, handler EventHand
 	// (e.g. a single huge tool_result tipped it over).
 	window := contextWindow(a.Model)
 	for {
-		est := estimateMessages(msgs)
+		est := a.historyTokens(msgs)
 		if est < window {
 			break
 		}
@@ -379,18 +405,20 @@ func hasToolResult(m Message) bool {
 // tool batch, before the next LLM call. This catches history growth within a
 // turn that lastInputTokens (from the previous provider call) doesn't reflect.
 //
-// The heuristic is aggressive: if the estimated token count exceeds 90% of the
-// model's context window, we compact. This prevents the next send() from 400-ing.
+// The check is aggressive: if the token count exceeds 90% of the model's
+// context window, we compact. This prevents the next send() from 400-ing. The
+// count prefers the provider's real lastInputTokens and falls back to a
+// heuristic estimate.
 func (a *Agent) shouldCompactBetweenBatches() bool {
 	trigger := a.compactTriggerTokens()
 	if trigger <= 0 {
 		return false
 	}
-	est := estimateMessages(a.History.Snapshot())
+	tokens := a.historyTokens(a.History.Snapshot())
 	window := contextWindow(a.Model)
 	// Compact if we're within 10% of the window (more aggressive than the
 	// between-turns trigger, which uses compactThresholdFraction = 75%).
-	return est > int(float64(window)*0.9)
+	return tokens > int(float64(window)*0.9)
 }
 
 // ── Token estimation (fast heuristic) ──────────────────────────────────────

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -105,6 +105,21 @@ func TestCompactTriggerTokens(t *testing.T) {
 	if got := a.compactTriggerTokens(); got != 4242 {
 		t.Errorf("explicit trigger = %d, want 4242", got)
 	}
+
+	// Custom auto fraction (50%).
+	a.CompactThreshold = 0
+	a.CompactAutoFraction = 0.5
+	want50 := int(float64(defaultContextWindow) * 0.5)
+	if got := a.compactTriggerTokens(); got != want50 {
+		t.Errorf("custom 50%% trigger = %d, want %d", got, want50)
+	}
+
+	// Fraction clamped to 1.0 when > 1.
+	a.CompactAutoFraction = 2.0
+	want100 := defaultContextWindow
+	if got := a.compactTriggerTokens(); got != want100 {
+		t.Errorf("clamped 200%% trigger = %d, want %d", got, want100)
+	}
 }
 
 // TestMaybeCompact_AutoDefaultTriggers proves the C6 flip: with CompactThreshold

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -129,13 +129,14 @@ type AgentEvent struct {
 	Compact    *CompactStats  `json:"compact,omitempty"`
 }
 
-// CompactStats carries the numbers behind the compaction events. All counts
-// are heuristic token estimates (see estimateMessages), not exact provider
-// counts — they exist for a human-readable progress indicator, nothing more.
+// CompactStats carries the numbers behind the compaction events. BeforeTokens
+// and AfterTokens prefer the provider's real input token count when available
+// (lastInputTokens) and fall back to a heuristic estimate otherwise. They exist
+// for a human-readable progress indicator, nothing more.
 type CompactStats struct {
-	// BeforeTokens is the estimated context size before compaction.
+	// BeforeTokens is the context size before compaction (real when available).
 	BeforeTokens int `json:"before_tokens,omitempty"`
-	// AfterTokens is the estimated context size after compaction (done only).
+	// AfterTokens is the context size after compaction (real when available, done only).
 	AfterTokens int `json:"after_tokens,omitempty"`
 	// FoldedMsgs is how many leading messages were folded into the summary.
 	FoldedMsgs int `json:"folded_msgs,omitempty"`

--- a/internal/agent/overflow.go
+++ b/internal/agent/overflow.go
@@ -143,7 +143,7 @@ func (a *Agent) tryOverflowCompact(ctx context.Context, pullBackMode int, handle
 		return false
 	}
 
-	before := estimateMessages(msgs)
+	before := a.historyTokens(msgs)
 	if handler != nil {
 		handler(AgentEvent{Kind: EventCompactStarted, Compact: &CompactStats{
 			BeforeTokens: before,
@@ -173,7 +173,7 @@ func (a *Agent) tryOverflowCompact(ctx context.Context, pullBackMode int, handle
 	}
 
 	a.resetContextTrigger() // reset trigger so we don't immediately re-compact
-	emitCompactDone(handler, before, estimateMessages(a.History.Snapshot()), split)
+	emitCompactDone(handler, before, a.historyTokens(a.History.Snapshot()), split)
 	return true
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,11 @@ type Config struct {
 	// When empty, `octo serve` falls back to OCTO_ACCESS_KEY env var or
 	// generates a random key on startup.
 	AccessKey string `yaml:"access_key,omitempty"`
+	// CompactAutoPct is the auto-compaction threshold as a percentage of the
+	// model's context window (0–100). When CompactThreshold == 0, the agent
+	// compacts once the context exceeds this share of the window. Zero means
+	// the built-in default (75%).
+	CompactAutoPct int `yaml:"compact_auto_pct,omitempty"`
 	// Tools holds opt-in tooling behaviour (Tool Search for MCP, etc.). A
 	// missing block leaves the built-in defaults.
 	Tools ToolsConfig `yaml:"tools,omitempty"`


### PR DESCRIPTION
## Summary

1. **Real token counts for compaction** — Replace heuristic  with provider-reported  for all compaction trigger decisions. Falls back to heuristic when no real data is available yet (fresh session or post-compaction reset).

2. **Configurable auto-compaction threshold** — The previously hard-coded 75% default is now overrideable via percentage.

## New API / Config

-  (, 0.0–1.0)
- CLI:  (auto-compact at 60% of context window)
- Config:  in 
- Priority: CLI flag > config > built-in default (75%)

## Files changed

-  — ,  with configurable fraction
-  — use  for overflow recovery
-  — update  comments
-  — new  field
-  — new  config field
-  — new  flag + wiring
-  — TAB completion for new flag
-  — tests for custom fraction and clamping