### PR TITLE
feat(agent): separate batch-level compaction threshold with 85% default

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -243,6 +243,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = auto: 100 interactive, unlimited unattended/--prompt-file)")
 	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (percentage of the model's context window, settable via --compact-auto-pct or config), <0 = disabled")
 	compactAutoPct := fs.Int("compact-auto-pct", 0, "Auto-compaction threshold as a percentage of the model's context window (0 = use `octo config` or built-in default 75). Only used when --compact-threshold=0.")
+	compactBatchThreshold := fs.Int("compact-batch-threshold", 0, "Batch-level compaction: compact after a tool batch when context exceeds this many tokens; 0 = auto (~85% of the model's context window), <0 = disabled between batches")
 	reasoningEffort := fs.String("reasoning-effort", "", "Reasoning intensity: low | medium | high (empty = off). OpenAI → reasoning_effort; Anthropic → mapped thinking budget. Also from `octo config`.")
 	showReasoning := fs.Bool("show-reasoning", true, "Stream the reasoning/thinking trace to the terminal (dimmed). Use --show-reasoning=false to hide it. Also from `octo config`.")
 	useSandbox := fs.Bool("sandbox", false, "Confine terminal commands to the project dir + tmp with no network (OS-enforced; macOS/Linux). Fails closed if unavailable.")
@@ -473,6 +474,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	if autoPct > 0 {
 		a.CompactAutoFraction = float64(autoPct) / 100.0
+	}
+	// Resolve batch-level compaction threshold: explicit flag > config > follow between-turns.
+	if *compactBatchThreshold != 0 {
+		a.CompactBatchThreshold = *compactBatchThreshold
+	} else if cfg.CompactBatchThreshold != 0 {
+		a.CompactBatchThreshold = cfg.CompactBatchThreshold
 	}
 
 	// Build the tool executor up-front (REPL mode only — single-turn mode

--- a/cmd/octo/completion.go
+++ b/cmd/octo/completion.go
@@ -117,7 +117,7 @@ func chatCandidates(words []string, prev string) []string {
 	case "--reasoning-effort":
 		return []string{"low", "medium", "high"}
 	case "--model", "--system", "--max-tokens", "--max-tokens-escalate", "--max-turns",
-		"--compact-threshold", "--compact-auto-pct",
+		"--compact-threshold", "--compact-auto-pct", "--compact-batch-threshold",
 		"--sandbox-write", "--sandbox-read":
 		// These take freeform values; nothing useful to suggest.
 		return nil
@@ -261,7 +261,7 @@ var chatFlags = []string{
 	"--permission-mode", "--list-sessions", "--list-skills",
 	"--quiet", "--verbose", "--plain", "--stream", "--system",
 	"--reasoning-effort", "--show-reasoning",
-	"--compact-auto-pct",
+	"--compact-auto-pct", "--compact-batch-threshold",
 	"--help",
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -149,6 +149,13 @@ type Agent struct {
 	// the built-in default (0.75). Values outside 0–1 are clamped.
 	CompactAutoFraction float64
 
+	// CompactBatchThreshold controls compaction after a tool batch, before the
+	// next LLM call. Semantics mirror CompactThreshold:
+	//   < 0  → disabled (never compact between batches)
+	//   == 0 → follow compactTriggerTokens (the default)
+	//   > 0  → that explicit token count
+	CompactBatchThreshold int
+
 	// overflow handles "context too long" 400 errors by compressing history
 	// and retrying. Aligned with Ruby's perform_context_overflow_compression.
 	overflow overflowRecovery

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -401,15 +401,32 @@ func hasToolResult(m Message) bool {
 	return false
 }
 
+// compactBatchTriggerTokens resolves the batch-level compaction trigger:
+//
+//	< 0  → disabled (0)
+//	== 0 → auto: 85% of the model's context window (slightly higher than the
+//	       between-turns default of 75%, giving tool batches more headroom)
+//	> 0  → that explicit token count
+func (a *Agent) compactBatchTriggerTokens() int {
+	switch {
+	case a.CompactBatchThreshold < 0:
+		return 0
+	case a.CompactBatchThreshold == 0:
+		return int(float64(contextWindow(a.Model)) * 0.85)
+	default:
+		return a.CompactBatchThreshold
+	}
+}
+
 // shouldCompactBetweenBatches reports whether compaction should run after a
 // tool batch, before the next LLM call. This catches history growth within a
 // turn that lastInputTokens (from the previous provider call) doesn't reflect.
 //
-// It uses the same threshold as between-turns compaction (compactTriggerTokens),
-// so the batch-level check stays in sync with the user's configured auto-pct
-// or explicit threshold.
+// By default it triggers at 85% of the context window (slightly later than
+// between-turns compaction) to avoid interrupting a tool loop too aggressively.
+// Set CompactBatchThreshold to override independently.
 func (a *Agent) shouldCompactBetweenBatches() bool {
-	trigger := a.compactTriggerTokens()
+	trigger := a.compactBatchTriggerTokens()
 	if trigger <= 0 {
 		return false
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,10 @@ type Config struct {
 	// compacts once the context exceeds this share of the window. Zero means
 	// the built-in default (75%).
 	CompactAutoPct int `yaml:"compact_auto_pct,omitempty"`
+	// CompactBatchThreshold controls compaction after a tool batch. Semantics
+	// mirror CompactThreshold: <0 disables, 0 follows the between-turns trigger,
+	// >0 is an explicit token count.
+	CompactBatchThreshold int `yaml:"compact_batch_threshold,omitempty"`
 	// Tools holds opt-in tooling behaviour (Tool Search for MCP, etc.). A
 	// missing block leaves the built-in defaults.
 	Tools ToolsConfig `yaml:"tools,omitempty"`


### PR DESCRIPTION
## Summary

Add  so batch-level compaction (after tool batches) can use a different trigger than between-turns compaction.

## New API / Config

-  — semantics mirror 
- CLI: 
- Config:  in 

## Defaults

| | Between-turns | Batch-level |
|---|---|---|
| auto | 75% | **85%** |
| explicit |  |  |
| disabled |  |  |

Batch-level defaults to 85% (vs 75% for between-turns), giving tool batches slightly more headroom before compacting mid-loop.

## Files changed

-  — new  field
-  —  resolver
-  —  config field
-  —  flag + wiring
-  — TAB completion for new flag