### PR TITLE
Refactor: vendor registry replaces duplicated provider presets

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -75,7 +74,7 @@ func resolveMaxTokensEscalate(flagVal int, provName string) int {
 			return n
 		}
 	}
-	if provName == providerOpenAI {
+	if app.VendorProtocol(provName) == "openai" {
 		return escalateMaxTokensOpenAI
 	}
 	return escalateMaxTokensAnthropic
@@ -200,9 +199,13 @@ func anthropicThinkingBudget(effort string) int {
 // supplied. Both defaults are the cheapest reasoning-capable model in the
 // respective vendor's catalogue at the time of writing — the right pick for
 // a scaffold whose primary purpose is verifying the wire end-to-end.
-var defaultModels = map[string]string{
-	providerAnthropic: "claude-haiku-4-5-20251001",
-	providerOpenAI:    "gpt-4o-mini",
+var defaultModels map[string]string
+
+func init() {
+	defaultModels = make(map[string]string, len(app.Registry))
+	for _, v := range app.Registry {
+		defaultModels[v.ID] = v.DefaultModel
+	}
 }
 
 // runChat handles `octo chat [flags] [message]`.
@@ -341,7 +344,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 	provName, resolvedModel, ok := resolveProviderModel(*providerName, *model, cfg)
 	if !ok {
-		fmt.Fprintf(stderr, "octo chat: unknown provider %q (use 'anthropic' or 'openai')\n", provName)
+		fmt.Fprintf(stderr, "octo chat: unknown provider %q\n", provName)
 		return 2
 	}
 
@@ -788,53 +791,30 @@ func buildSender(name string, cfg config.Config, stderr io.Writer, tuning sender
 // a missing key it prints provider-specific setup help to stderr and returns a
 // non-nil error.
 func resolveAPIKey(name string, cfg config.Config, stderr io.Writer) (string, error) {
-	switch name {
-	case providerAnthropic:
-		apiKey := os.Getenv("ANTHROPIC_API_KEY")
-		if apiKey == "" && cfg.Provider == providerAnthropic {
-			apiKey = cfg.APIKey
-		}
-		if apiKey == "" {
-			fmt.Fprintln(stderr, "octo: ANTHROPIC_API_KEY is not set.")
-			fmt.Fprintln(stderr, "")
-			fmt.Fprintln(stderr, "To use Anthropic (default):")
-			fmt.Fprintln(stderr, "  1. Get a key at https://console.anthropic.com/")
-			fmt.Fprintln(stderr, "  2. export ANTHROPIC_API_KEY=sk-ant-...")
-			fmt.Fprintln(stderr, "")
-			fmt.Fprintln(stderr, "Or run `octo config` to save a default provider/key.")
-			fmt.Fprintln(stderr, "")
-			fmt.Fprintln(stderr, "Or use OpenAI:")
-			fmt.Fprintln(stderr, "  export OPENAI_API_KEY=sk-...")
-			fmt.Fprintln(stderr, "  octo chat --provider openai")
-			return "", errors.New("missing ANTHROPIC_API_KEY")
-		}
-		return apiKey, nil
-
-	case providerOpenAI:
-		apiKey := os.Getenv("OPENAI_API_KEY")
-		if apiKey == "" && cfg.Provider == providerOpenAI {
-			apiKey = cfg.APIKey
-		}
-		if apiKey == "" {
-			fmt.Fprintln(stderr, "octo: OPENAI_API_KEY is not set.")
-			fmt.Fprintln(stderr, "")
-			fmt.Fprintln(stderr, "To use OpenAI:")
-			fmt.Fprintln(stderr, "  1. Get a key at https://platform.openai.com/api-keys")
-			fmt.Fprintln(stderr, "  2. export OPENAI_API_KEY=sk-...")
-			fmt.Fprintln(stderr, "")
-			fmt.Fprintln(stderr, "Or run `octo config` to save a default provider/key.")
-			fmt.Fprintln(stderr, "")
-			fmt.Fprintln(stderr, "Or use Anthropic (the default):")
-			fmt.Fprintln(stderr, "  export ANTHROPIC_API_KEY=sk-ant-...")
-			fmt.Fprintln(stderr, "  octo chat                 # no --provider flag needed")
-			return "", errors.New("missing OPENAI_API_KEY")
-		}
-		return apiKey, nil
-
-	default:
-		fmt.Fprintf(stderr, "octo chat: unknown provider %q (use 'anthropic' or 'openai')\n", name)
+	if !app.IsKnownVendor(name) {
+		fmt.Fprintf(stderr, "octo chat: unknown provider %q\n", name)
 		return "", fmt.Errorf("unknown provider %q", name)
 	}
+
+	envVar := app.VendorAPIKeyEnvVar(name)
+	apiKey := os.Getenv(envVar)
+	if apiKey == "" && cfg.Provider == name {
+		apiKey = cfg.APIKey
+	}
+	if apiKey == "" {
+		fmt.Fprintf(stderr, "octo: %s is not set.\n", envVar)
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintf(stderr, "To use %s:\n", app.VendorDisplayName(name))
+		if url := app.VendorWebsiteURL(name); url != "" {
+			fmt.Fprintf(stderr, "  1. Get a key at %s\n", url)
+		}
+		fmt.Fprintf(stderr, "  2. export %s=sk-...\n", envVar)
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "Or run `octo config` to save a default provider/key.")
+		fmt.Fprintln(stderr, "")
+		return "", fmt.Errorf("missing %s", envVar)
+	}
+	return apiKey, nil
 }
 
 // newCacheKey returns a random hex token used as the prompt-cache key for one

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -47,13 +47,11 @@ func TestRunChat_MissingAPIKey(t *testing.T) {
 		t.Errorf("exit code = %d, want 1", code)
 	}
 	// New (UX-3) actionable error: identifies the missing env var AND points
-	// the user at the signup URL + alternative provider so the first-run
-	// experience isn't a dead-end.
+	// the user at the signup URL so the first-run experience isn't a dead-end.
 	out := stderr.String()
 	for _, want := range []string{
 		"ANTHROPIC_API_KEY",
 		"console.anthropic.com",
-		"--provider openai",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("stderr should mention %q; got:\n%s", want, out)
@@ -301,13 +299,11 @@ func TestRunChat_OpenAI_MissingAPIKey(t *testing.T) {
 	if code != 1 {
 		t.Errorf("exit code = %d, want 1", code)
 	}
-	// New (UX-3) actionable error: points the user at the OpenAI signup
-	// URL plus the Anthropic fallback so a missing key has a path forward.
+	// New (UX-3) actionable error: points the user at the OpenAI signup URL.
 	out := stderr.String()
 	for _, want := range []string{
 		"OPENAI_API_KEY",
 		"platform.openai.com",
-		"ANTHROPIC_API_KEY",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("stderr should mention %q; got:\n%s", want, out)

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -26,7 +26,7 @@ func firstNonEmpty(vals ...string) string {
 // model (i.e. an unknown provider with no explicit model) — the caller prints
 // an error and exits.
 func resolveProviderModel(flagProvider, flagModel string, cfg config.Config) (provider, model string, ok bool) {
-	provider = firstNonEmpty(flagProvider, os.Getenv("OCTO_PROVIDER"), cfg.Provider, providerAnthropic)
+	provider = firstNonEmpty(flagProvider, os.Getenv("OCTO_PROVIDER"), cfg.Provider, app.ProviderAnthropic)
 	// Precedence: --model flag > env (ANTHROPIC_MODEL / OPENAI_MODEL) > config
 	// (same-provider only) > built-in default. The env tier mirrors how the
 	// base URL and key resolve env-first, so a third-party Claude-/OpenAI-
@@ -59,30 +59,17 @@ func providerBaseURL(provider string, cfg config.Config) string {
 }
 
 // modelFromEnv returns the per-provider model env override, or "" if unset.
-// Named to match the BASE_URL / API_KEY env vars so a third-party endpoint can
-// be configured purely through the environment.
 func modelFromEnv(provider string) string {
-	switch provider {
-	case providerAnthropic:
-		return os.Getenv("ANTHROPIC_MODEL")
-	case providerOpenAI:
-		return os.Getenv("OPENAI_MODEL")
-	}
-	return ""
+	envVar := strings.ToUpper(provider) + "_MODEL"
+	return os.Getenv(envVar)
 }
 
 // resolveBaseURL returns the base-URL override for the provider, env-first
-// (ANTHROPIC_BASE_URL / OPENAI_BASE_URL) then the persisted config. "" means no
-// override — the provider uses its built-in default endpoint. This is the
-// single source of truth shared by buildProvider and the verbose endpoint line.
+// (<PROVIDER>_BASE_URL) then the persisted config. "" means no
+// override — the provider uses its built-in default endpoint.
 func resolveBaseURL(provider string, cfg config.Config) string {
-	switch provider {
-	case providerAnthropic:
-		return firstNonEmpty(os.Getenv("ANTHROPIC_BASE_URL"), providerBaseURL(provider, cfg))
-	case providerOpenAI:
-		return firstNonEmpty(os.Getenv("OPENAI_BASE_URL"), providerBaseURL(provider, cfg))
-	}
-	return ""
+	envVar := strings.ToUpper(provider) + "_BASE_URL"
+	return firstNonEmpty(os.Getenv(envVar), providerBaseURL(provider, cfg))
 }
 
 // effectiveEndpoint is resolveBaseURL for display: it substitutes the
@@ -218,9 +205,9 @@ func runConfigShow(stdout, stderr io.Writer) int {
 // apiKeyStatus reports where a key for the given provider would come from,
 // without revealing it. Env always wins over a config-stored key.
 func apiKeyStatus(provider string, cfg config.Config) string {
-	envVar := "ANTHROPIC_API_KEY"
-	if provider == providerOpenAI {
-		envVar = "OPENAI_API_KEY"
+	envVar := app.VendorAPIKeyEnvVar(provider)
+	if envVar == "" {
+		envVar = strings.ToUpper(provider) + "_API_KEY"
 	}
 	if os.Getenv(envVar) != "" {
 		return "set via $" + envVar
@@ -252,10 +239,10 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 	fmt.Fprintln(stdout, "Press Enter to keep the shown default. CLI flags and env vars still override per run.")
 	fmt.Fprintln(stdout)
 
-	provider := promptDefault(reader, stdout, "Provider (anthropic | openai)", firstNonEmpty(existing.Provider, providerAnthropic))
+	provider := promptDefault(reader, stdout, "Provider (anthropic | openai | kimi | deepseek | ...)", firstNonEmpty(existing.Provider, app.ProviderAnthropic))
 	provider = strings.ToLower(strings.TrimSpace(provider))
-	if provider != providerAnthropic && provider != providerOpenAI {
-		fmt.Fprintf(stderr, "octo config: unknown provider %q (use 'anthropic' or 'openai')\n", provider)
+	if !app.IsKnownVendor(provider) {
+		fmt.Fprintf(stderr, "octo config: unknown provider %q\n", provider)
 		return 2
 	}
 
@@ -302,9 +289,9 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 
 	// API key: env is the recommended home for it. Offer to store it only if
 	// the env var is empty, and make declining the obvious default.
-	envVar := "ANTHROPIC_API_KEY"
-	if provider == providerOpenAI {
-		envVar = "OPENAI_API_KEY"
+	envVar := app.VendorAPIKeyEnvVar(provider)
+	if envVar == "" {
+		envVar = strings.ToUpper(provider) + "_API_KEY"
 	}
 	// Prompt for key when env is empty AND (no stored key OR switching provider —
 	// a key stored for a different provider doesn't help the new one).

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -57,7 +57,7 @@ func TestResolveProviderModel_ModelEnv(t *testing.T) {
 		t.Errorf("--model flag should beat env, got %q", m)
 	}
 	// The model env is per-provider: ANTHROPIC_MODEL must not leak onto openai.
-	if _, m, _ := resolveProviderModel(providerOpenAI, "", config.Config{}); m != "gpt-4o-mini" {
+	if _, m, _ := resolveProviderModel(providerOpenAI, "", config.Config{}); m != "gpt-5.4" {
 		t.Errorf("ANTHROPIC_MODEL must not affect openai, got %q (want default)", m)
 	}
 	// OPENAI_MODEL drives the openai default slot.
@@ -83,10 +83,10 @@ func TestResolveProviderModel_Precedence(t *testing.T) {
 	}{
 		{"flag beats config", "anthropic", "flag-model", cfg, "anthropic", "flag-model", true},
 		{"config beats default", "", "", cfg, "openai", "cfg-model", true},
-		{"flag provider, default model", "openai", "", config.Config{}, "openai", "gpt-4o-mini", true},
-		{"empty everything → anthropic default", "", "", config.Config{}, "anthropic", "claude-haiku-4-5-20251001", true},
-		{"config provider, builtin model", "", "", config.Config{Provider: "openai"}, "openai", "gpt-4o-mini", true},
-		{"flag provider overrides config provider — no model contamination", "anthropic", "", cfg, "anthropic", "claude-haiku-4-5-20251001", true},
+		{"flag provider, default model", "openai", "", config.Config{}, "openai", "gpt-5.4", true},
+		{"empty everything → anthropic default", "", "", config.Config{}, "anthropic", "claude-sonnet-4-6", true},
+		{"config provider, builtin model", "", "", config.Config{Provider: "openai"}, "openai", "gpt-5.4", true},
+		{"flag provider overrides config provider — no model contamination", "anthropic", "", cfg, "anthropic", "claude-sonnet-4-6", true},
 		{"unknown provider, no model → not ok", "bogus", "", config.Config{}, "bogus", "", false},
 		{"unknown provider WITH model → ok (buildProvider rejects later)", "bogus", "m", config.Config{}, "bogus", "m", true},
 	}

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -1,0 +1,251 @@
+// Package app defines the provider-vendor registry and protocol mapping.
+//
+// A "provider" here is a business-level vendor (kimi, deepseek, openai,
+// anthropic, …), not a wire protocol.  Each vendor carries:
+//   - the wire protocol it speaks (anthropic-messages or openai-completions)
+//   - its default endpoint, default model, and API-key env var
+//
+// CLI, server, and Web UI all resolve through this single registry so a new
+// vendor only needs one line here.
+package app
+
+// EndpointVariant is a regional endpoint alternative for a vendor.
+type EndpointVariant struct {
+	Label    string `json:"label"`
+	LabelKey string `json:"label_key,omitempty"`
+	BaseURL  string `json:"base_url"`
+	Region   string `json:"region,omitempty"`
+}
+
+// Vendor is everything needed to bootstrap a provider client and render it in
+type Vendor struct {
+	ID               string            // canonical identifier, e.g. "kimi"
+	DisplayName      string            // human label, e.g. "Kimi (Moonshot)"
+	Protocol         string            // "anthropic" or "openai"
+	API              string            // "anthropic-messages" or "openai-completions" or "openai-responses"
+	DefaultBaseURL   string            // vendor's official endpoint
+	DefaultModel     string            // cheapest/reasoning-capable default
+	Models           []string          // available models (for UI dropdown)
+	LiteModel        string            // lightweight/cheaper model variant
+	APIKeyEnvVar     string            // environment variable name for the key
+	WebsiteURL       string            // link to the key-management page
+	EndpointVariants []EndpointVariant // regional endpoint alternatives
+}
+
+// Registry is the ordered list of supported vendors.  The order is the
+// display order in the Web UI onboarding dropdown.
+var Registry = []Vendor{
+	{
+		ID:             "openrouter",
+		DisplayName:    "OpenRouter",
+		Protocol:       "openai",
+		API:            "openai-responses",
+		DefaultBaseURL: "https://openrouter.ai/api/v1",
+		DefaultModel:   "anthropic/claude-sonnet-4-6",
+		Models: []string{
+			"anthropic/claude-sonnet-4-6",
+			"anthropic/claude-opus-4-7",
+			"anthropic/claude-opus-4-6",
+			"anthropic/claude-haiku-4-5",
+			"openai/gpt-5.5",
+			"openai/gpt-5.4",
+			"openai/gpt-5.4-mini",
+		},
+		APIKeyEnvVar: "OPENROUTER_API_KEY",
+		WebsiteURL:   "https://openrouter.ai/keys",
+	},
+	{
+		ID:             "deepseek",
+		DisplayName:    "DeepSeek",
+		Protocol:       "openai",
+		API:            "openai-completions",
+		DefaultBaseURL: "https://api.deepseek.com",
+		DefaultModel:   "deepseek-v4-pro",
+		Models:         []string{"deepseek-v4-flash", "deepseek-v4-pro"},
+		LiteModel:      "deepseek-v4-flash",
+		APIKeyEnvVar:   "DEEPSEEK_API_KEY",
+		WebsiteURL:     "https://platform.deepseek.com/api_keys",
+	},
+	{
+		ID:             "minimax",
+		DisplayName:    "Minimax",
+		Protocol:       "openai",
+		API:            "openai-completions",
+		DefaultBaseURL: "https://api.minimaxi.com/v1",
+		DefaultModel:   "MiniMax-M2.7",
+		Models:         []string{"MiniMax-M2.5", "MiniMax-M2.7"},
+		APIKeyEnvVar:   "MINIMAX_API_KEY",
+		WebsiteURL:     "https://www.minimaxi.com/user-center/basic-information/interface-key",
+		EndpointVariants: []EndpointVariant{
+			{Label: "Mainland China", LabelKey: "settings.models.baseurl.variant.mainland_cn", BaseURL: "https://api.minimaxi.com/v1", Region: "cn"},
+			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://api.minimax.io/v1", Region: "intl"},
+		},
+	},
+	{
+		ID:             "kimi",
+		DisplayName:    "Kimi (Moonshot)",
+		Protocol:       "openai",
+		API:            "openai-completions",
+		DefaultBaseURL: "https://api.moonshot.cn/v1",
+		DefaultModel:   "kimi-k2.6",
+		Models:         []string{"kimi-k2.6", "kimi-k2.5"},
+		APIKeyEnvVar:   "MOONSHOT_API_KEY",
+		WebsiteURL:     "https://platform.moonshot.cn/console/api-keys",
+		EndpointVariants: []EndpointVariant{
+			{Label: "Mainland China", LabelKey: "settings.models.baseurl.variant.mainland_cn", BaseURL: "https://api.moonshot.cn/v1", Region: "cn"},
+			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://api.moonshot.ai/v1", Region: "intl"},
+		},
+	},
+	{
+		ID:             "kimi-coding",
+		DisplayName:    "Kimi Coding",
+		Protocol:       "openai",
+		API:            "openai-completions",
+		DefaultBaseURL: "https://api.kimi.com/coding",
+		DefaultModel:   "kimi-for-coding",
+		Models:         []string{"kimi-for-coding"},
+		APIKeyEnvVar:   "MOONSHOT_API_KEY",
+		WebsiteURL:     "https://platform.moonshot.cn/console/api-keys",
+	},
+	{
+		ID:             "glm",
+		DisplayName:    "GLM (Zhipu)",
+		Protocol:       "openai",
+		API:            "openai-completions",
+		DefaultBaseURL: "https://open.bigmodel.cn/api/paas/v4",
+		DefaultModel:   "glm-4.5",
+		Models:         []string{"glm-4.5", "glm-4.5-air", "glm-4.5-flash"},
+		LiteModel:      "glm-4.5-flash",
+		APIKeyEnvVar:   "ZHIPU_API_KEY",
+		WebsiteURL:     "https://open.bigmodel.cn/usercenter/apikey",
+		EndpointVariants: []EndpointVariant{
+			{Label: "Mainland China", LabelKey: "settings.models.baseurl.variant.mainland_cn", BaseURL: "https://open.bigmodel.cn/api/paas/v4", Region: "cn"},
+			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://api.z.ai/v1", Region: "intl"},
+		},
+	},
+	{
+		ID:             "openai",
+		DisplayName:    "OpenAI",
+		Protocol:       "openai",
+		API:            "openai-responses",
+		DefaultBaseURL: "https://api.openai.com/v1",
+		DefaultModel:   "gpt-5.4",
+		Models:         []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini"},
+		LiteModel:      "gpt-5.4-mini",
+		APIKeyEnvVar:   "OPENAI_API_KEY",
+		WebsiteURL:     "https://platform.openai.com/api-keys",
+	},
+	{
+		ID:             "anthropic",
+		DisplayName:    "Anthropic",
+		Protocol:       "anthropic",
+		API:            "anthropic-messages",
+		DefaultBaseURL: "https://api.anthropic.com",
+		DefaultModel:   "claude-sonnet-4-6",
+		Models:         []string{"claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"},
+		LiteModel:      "claude-haiku-4-5",
+		APIKeyEnvVar:   "ANTHROPIC_API_KEY",
+		WebsiteURL:     "https://console.anthropic.com/settings/keys",
+	},
+	{
+		ID:             "siliconflow",
+		DisplayName:    "SiliconFlow",
+		Protocol:       "openai",
+		API:            "openai-completions",
+		DefaultBaseURL: "https://api.siliconflow.cn/v1",
+		DefaultModel:   "deepseek-ai/DeepSeek-V3",
+		Models:         []string{"deepseek-ai/DeepSeek-V3", "deepseek-ai/DeepSeek-R1"},
+		APIKeyEnvVar:   "SILICONFLOW_API_KEY",
+		WebsiteURL:     "https://cloud.siliconflow.cn/account/ak",
+	},
+	{
+		ID:             "mistral",
+		DisplayName:    "Mistral",
+		Protocol:       "openai",
+		API:            "openai-completions",
+		DefaultBaseURL: "https://api.mistral.ai/v1",
+		DefaultModel:   "mistral-large-latest",
+		Models:         []string{"mistral-large-latest", "mistral-medium-latest"},
+		APIKeyEnvVar:   "MISTRAL_API_KEY",
+		WebsiteURL:     "https://console.mistral.ai/api-keys/",
+	},
+	{
+		ID:             "groq",
+		DisplayName:    "Groq",
+		Protocol:       "openai",
+		API:            "openai-completions",
+		DefaultBaseURL: "https://api.groq.com/openai/v1",
+		DefaultModel:   "llama-4-scout",
+		Models:         []string{"llama-4-scout", "llama-4-maverick"},
+		APIKeyEnvVar:   "GROQ_API_KEY",
+		WebsiteURL:     "https://console.groq.com/keys",
+	},
+}
+
+// vendorByID returns the vendor with the given ID, or nil if unknown.
+func vendorByID(id string) *Vendor {
+	for i := range Registry {
+		if Registry[i].ID == id {
+			return &Registry[i]
+		}
+	}
+	return nil
+}
+
+// VendorBaseURL returns the default base URL for a vendor ID, or "" if unknown.
+func VendorBaseURL(id string) string {
+	if v := vendorByID(id); v != nil {
+		return v.DefaultBaseURL
+	}
+	return ""
+}
+
+// VendorProtocol returns "anthropic" or "openai" for a vendor ID, or "" if unknown.
+func VendorProtocol(id string) string {
+	if v := vendorByID(id); v != nil {
+		return v.Protocol
+	}
+	return ""
+}
+
+// VendorDefaultModel returns the built-in default model for a vendor ID.
+func VendorDefaultModel(id string) string {
+	if v := vendorByID(id); v != nil {
+		return v.DefaultModel
+	}
+	return ""
+}
+
+// VendorAPIKeyEnvVar returns the environment-variable name for a vendor's API key.
+func VendorAPIKeyEnvVar(id string) string {
+	if v := vendorByID(id); v != nil {
+		return v.APIKeyEnvVar
+	}
+	return ""
+}
+
+// VendorDisplayName returns the human-readable label for a vendor ID.
+func VendorDisplayName(id string) string {
+	if v := vendorByID(id); v != nil {
+		return v.DisplayName
+	}
+	return id
+}
+
+// VendorWebsiteURL returns the key-management page URL for a vendor ID.
+func VendorWebsiteURL(id string) string {
+	if v := vendorByID(id); v != nil {
+		return v.WebsiteURL
+	}
+	return ""
+}
+
+// IsKnownVendor reports whether id is a registered vendor ID.
+func IsKnownVendor(id string) bool {
+	return vendorByID(id) != nil
+}
+
+// IsAnthropicProtocol reports whether the vendor speaks the Anthropic protocol.
+func IsAnthropicProtocol(id string) bool {
+	return VendorProtocol(id) == "anthropic"
+}

--- a/internal/app/sender.go
+++ b/internal/app/sender.go
@@ -19,9 +19,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/provider/openai"
 )
 
-// Provider name constants accepted by NewSender. They match the vendor strings
-// the CLI/server already resolve, so callers can pass their resolved name
-// through unchanged.
+// Provider name constants (legacy).  New code should use vendor IDs directly.
 const (
 	ProviderAnthropic = "anthropic"
 	ProviderOpenAI    = "openai"
@@ -31,7 +29,7 @@ const (
 // Key resolution and any user-facing help text stay with the caller (a CLI
 // prints setup hints; a server returns an error) — this layer only constructs.
 type SenderOptions struct {
-	Provider string // ProviderAnthropic | ProviderOpenAI
+	Provider string // vendor ID, e.g. "kimi", "deepseek", "anthropic", "openai"
 	APIKey   string
 	BaseURL  string // optional endpoint override; empty uses the vendor default
 
@@ -39,10 +37,11 @@ type SenderOptions struct {
 	// conversation's turns so the backend routes them to the same cache.
 	CacheKey string
 	// ThinkingBudget > 0 enables Anthropic extended thinking with this trace
-	// budget; ignored by OpenAI.
+	// budget; ignored by OpenAI-protocol vendors.
 	ThinkingBudget int
-	// ReasoningEffort ("low"|"medium"|"high") is forwarded to OpenAI as
-	// reasoning_effort; ignored by Anthropic (which uses ThinkingBudget).
+	// ReasoningEffort ("low"|"medium"|"high") is forwarded to OpenAI-protocol
+	// vendors as reasoning_effort; ignored by Anthropic-protocol vendors
+	// (which use ThinkingBudget).
 	ReasoningEffort string
 	// ShowReasoning gates whether the reasoning/thinking trace is surfaced to
 	// the agent event stream.
@@ -66,23 +65,24 @@ func NewSender(opts SenderOptions) (agent.Sender, error) {
 }
 
 // DefaultBaseURL returns the vendor's built-in API endpoint for the given
-// provider, or "" for an unknown one. Exposed so callers can show the
+// provider ID, or "" for an unknown one. Exposed so callers can show the
 // effective endpoint without importing the vendor packages themselves.
+//
+// Deprecated: prefer VendorBaseURL(id) from provider.go.
 func DefaultBaseURL(providerName string) string {
-	switch providerName {
-	case ProviderAnthropic:
-		return anthropic.DefaultBaseURL
-	case ProviderOpenAI:
-		return openai.DefaultBaseURL
-	}
-	return ""
+	return VendorBaseURL(providerName)
 }
 
 // buildClient constructs the vendor client and applies an optional base-URL
 // override. The caller is responsible for having resolved a non-empty key.
 func buildClient(name, apiKey, baseURL string) (provider.Provider, error) {
-	switch name {
-	case ProviderAnthropic:
+	v := vendorByID(name)
+	if v == nil {
+		return nil, fmt.Errorf("unknown provider %q", name)
+	}
+
+	switch v.Protocol {
+	case "anthropic":
 		client, err := anthropic.New(apiKey)
 		if err != nil {
 			return nil, err
@@ -91,7 +91,7 @@ func buildClient(name, apiKey, baseURL string) (provider.Provider, error) {
 			client.BaseURL = baseURL
 		}
 		return client, nil
-	case ProviderOpenAI:
+	case "openai":
 		client, err := openai.New(apiKey)
 		if err != nil {
 			return nil, err
@@ -101,7 +101,7 @@ func buildClient(name, apiKey, baseURL string) (provider.Provider, error) {
 		}
 		return client, nil
 	default:
-		return nil, fmt.Errorf("unknown provider %q", name)
+		return nil, fmt.Errorf("unknown protocol %q for provider %q", v.Protocol, name)
 	}
 }
 

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -15,7 +15,7 @@ import (
 
 // ─── Provider Presets ───────────────────────────────────────────────────────
 
-// endpointVariant is a regional endpoint alternative for a provider.
+// endpointVariant is the JSON shape the frontend expects for regional endpoints.
 type endpointVariant struct {
 	Label    string `json:"label"`
 	LabelKey string `json:"label_key,omitempty"`
@@ -23,7 +23,7 @@ type endpointVariant struct {
 	Region   string `json:"region,omitempty"`
 }
 
-// providerPreset is a built-in provider configuration template.
+// providerPreset is the JSON shape returned by GET /api/providers.
 type providerPreset struct {
 	ID               string            `json:"id"`
 	Name             string            `json:"name"`
@@ -36,136 +36,40 @@ type providerPreset struct {
 	WebsiteURL       string            `json:"website_url,omitempty"`
 }
 
-var providerPresets = []providerPreset{
-	{
-		ID:           "openrouter",
-		Name:         "OpenRouter",
-		BaseURL:      "https://openrouter.ai/api/v1",
-		API:          "openai-responses",
-		DefaultModel: "anthropic/claude-sonnet-4-6",
-		Models: []string{
-			"anthropic/claude-sonnet-4-6",
-			"anthropic/claude-opus-4-7",
-			"anthropic/claude-opus-4-6",
-			"anthropic/claude-haiku-4-5",
-			"openai/gpt-5.5",
-			"openai/gpt-5.4",
-			"openai/gpt-5.4-mini",
-		},
-		WebsiteURL: "https://openrouter.ai/keys",
-	},
-	{
-		ID:           "deepseekv4",
-		Name:         "DeepSeek V4",
-		BaseURL:      "https://api.deepseek.com",
-		API:          "openai-completions",
-		DefaultModel: "deepseek-v4-pro",
-		Models:       []string{"deepseek-v4-flash", "deepseek-v4-pro"},
-		LiteModel:    "deepseek-v4-flash",
-		WebsiteURL:   "https://platform.deepseek.com/api_keys",
-	},
-	{
-		ID:           "minimax",
-		Name:         "Minimax",
-		BaseURL:      "https://api.minimaxi.com/v1",
-		API:          "openai-completions",
-		DefaultModel: "MiniMax-M2.7",
-		Models:       []string{"MiniMax-M2.5", "MiniMax-M2.7"},
-		EndpointVariants: []endpointVariant{
-			{Label: "Mainland China", LabelKey: "settings.models.baseurl.variant.mainland_cn", BaseURL: "https://api.minimaxi.com/v1", Region: "cn"},
-			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://api.minimax.io/v1", Region: "intl"},
-		},
-		WebsiteURL: "https://www.minimaxi.com/user-center/basic-information/interface-key",
-	},
-	{
-		ID:           "kimi",
-		Name:         "Kimi (Moonshot)",
-		BaseURL:      "https://api.moonshot.cn/v1",
-		API:          "openai-completions",
-		DefaultModel: "kimi-k2.6",
-		Models:       []string{"kimi-k2.6", "kimi-k2.5"},
-		EndpointVariants: []endpointVariant{
-			{Label: "Mainland China", LabelKey: "settings.models.baseurl.variant.mainland_cn", BaseURL: "https://api.moonshot.cn/v1", Region: "cn"},
-			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://api.moonshot.ai/v1", Region: "intl"},
-		},
-		WebsiteURL: "https://platform.moonshot.cn/console/api-keys",
-	},
-	{
-		ID:           "kimi-coding",
-		Name:         "Kimi Coding",
-		BaseURL:      "https://api.kimi.com/coding",
-		API:          "openai-completions",
-		DefaultModel: "kimi-for-coding",
-		Models:       []string{"kimi-for-coding"},
-		WebsiteURL:   "https://platform.moonshot.cn/console/api-keys",
-	},
-	{
-		ID:           "glm",
-		Name:         "GLM (Zhipu)",
-		BaseURL:      "https://open.bigmodel.cn/api/paas/v4",
-		API:          "openai-completions",
-		DefaultModel: "glm-4.5",
-		Models:       []string{"glm-4.5", "glm-4.5-air", "glm-4.5-flash"},
-		LiteModel:    "glm-4.5-flash",
-		EndpointVariants: []endpointVariant{
-			{Label: "Mainland China", LabelKey: "settings.models.baseurl.variant.mainland_cn", BaseURL: "https://open.bigmodel.cn/api/paas/v4", Region: "cn"},
-			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://api.z.ai/v1", Region: "intl"},
-		},
-		WebsiteURL: "https://open.bigmodel.cn/usercenter/apikey",
-	},
-	{
-		ID:           "openai",
-		Name:         "OpenAI",
-		BaseURL:      "https://api.openai.com/v1",
-		API:          "openai-responses",
-		DefaultModel: "gpt-5.4",
-		Models:       []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini"},
-		LiteModel:    "gpt-5.4-mini",
-		WebsiteURL:   "https://platform.openai.com/api-keys",
-	},
-	{
-		ID:           "anthropic",
-		Name:         "Anthropic",
-		BaseURL:      "https://api.anthropic.com",
-		API:          "anthropic-messages",
-		DefaultModel: "claude-sonnet-4-6",
-		Models:       []string{"claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"},
-		LiteModel:    "claude-haiku-4-5",
-		WebsiteURL:   "https://console.anthropic.com/settings/keys",
-	},
-	{
-		ID:           "siliconflow",
-		Name:         "SiliconFlow",
-		BaseURL:      "https://api.siliconflow.cn/v1",
-		API:          "openai-completions",
-		DefaultModel: "deepseek-ai/DeepSeek-V3",
-		Models:       []string{"deepseek-ai/DeepSeek-V3", "deepseek-ai/DeepSeek-R1"},
-		WebsiteURL:   "https://cloud.siliconflow.cn/account/ak",
-	},
-	{
-		ID:           "mistral",
-		Name:         "Mistral",
-		BaseURL:      "https://api.mistral.ai/v1",
-		API:          "openai-completions",
-		DefaultModel: "mistral-large-latest",
-		Models:       []string{"mistral-large-latest", "mistral-medium-latest"},
-		WebsiteURL:   "https://console.mistral.ai/api-keys/",
-	},
-	{
-		ID:           "groq",
-		Name:         "Groq",
-		BaseURL:      "https://api.groq.com/openai/v1",
-		API:          "openai-completions",
-		DefaultModel: "llama-4-scout",
-		Models:       []string{"llama-4-scout", "llama-4-maverick"},
-		WebsiteURL:   "https://console.groq.com/keys",
-	},
+// buildProviderPresets builds the response for GET /api/providers from the
+// canonical app.Registry.  This is the single source of truth — a new vendor
+// only needs one line in internal/app/provider.go.
+func buildProviderPresets() []providerPreset {
+	presets := make([]providerPreset, 0, len(app.Registry))
+	for _, v := range app.Registry {
+		variants := make([]endpointVariant, len(v.EndpointVariants))
+		for i, ev := range v.EndpointVariants {
+			variants[i] = endpointVariant{
+				Label:    ev.Label,
+				LabelKey: ev.LabelKey,
+				BaseURL:  ev.BaseURL,
+				Region:   ev.Region,
+			}
+		}
+		presets = append(presets, providerPreset{
+			ID:               v.ID,
+			Name:             v.DisplayName,
+			BaseURL:          v.DefaultBaseURL,
+			API:              v.API,
+			DefaultModel:     v.DefaultModel,
+			Models:           v.Models,
+			LiteModel:        v.LiteModel,
+			EndpointVariants: variants,
+			WebsiteURL:       v.WebsiteURL,
+		})
+	}
+	return presets
 }
 
 // ─── GET /api/providers ─────────────────────────────────────────────────────
 
 func (s *Server) handleListProviders(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{"providers": providerPresets})
+	writeJSON(w, http.StatusOK, map[string]any{"providers": buildProviderPresets()})
 }
 
 // ─── GET /api/onboard/status ────────────────────────────────────────────────
@@ -192,8 +96,8 @@ func detectOnboardPhase() string {
 		hasKey = true
 	}
 	if !hasKey {
-		for _, env := range []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OCTO_API_KEY"} {
-			if os.Getenv(env) != "" {
+		for _, v := range app.Registry {
+			if os.Getenv(v.APIKeyEnvVar) != "" {
 				hasKey = true
 				break
 			}
@@ -237,6 +141,7 @@ type modelConfig struct {
 	Model           string `json:"model"`
 	BaseURL         string `json:"base_url"`
 	APIKey          string `json:"api_key,omitempty"`
+	Provider        string `json:"provider,omitempty"`
 	AnthropicFormat bool   `json:"anthropic_format"`
 }
 
@@ -253,7 +158,8 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 			Model:           cfg.Model,
 			BaseURL:         cfg.BaseURL,
 			APIKey:          maskKey(cfg.APIKey),
-			AnthropicFormat: cfg.Provider == "anthropic",
+			Provider:        cfg.Provider,
+			AnthropicFormat: app.IsAnthropicProtocol(cfg.Provider),
 		})
 	}
 
@@ -332,6 +238,7 @@ type saveModelRequest struct {
 	Model           string `json:"model"`
 	BaseURL         string `json:"base_url"`
 	APIKey          string `json:"api_key"`
+	Provider        string `json:"provider,omitempty"`
 	AnthropicFormat bool   `json:"anthropic_format"`
 }
 
@@ -348,7 +255,9 @@ func (s *Server) handleSaveModelConfig(w http.ResponseWriter, r *http.Request) {
 	if req.APIKey != "" {
 		cfg.APIKey = req.APIKey
 	}
-	if req.AnthropicFormat {
+	if req.Provider != "" {
+		cfg.Provider = req.Provider
+	} else if req.AnthropicFormat {
 		cfg.Provider = "anthropic"
 	} else {
 		cfg.Provider = "openai"
@@ -382,7 +291,9 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 	if req.APIKey != "" {
 		cfg.APIKey = req.APIKey
 	}
-	if req.AnthropicFormat {
+	if req.Provider != "" {
+		cfg.Provider = req.Provider
+	} else if req.AnthropicFormat {
 		cfg.Provider = "anthropic"
 	} else {
 		cfg.Provider = "openai"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -443,28 +443,18 @@ func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, stri
 // else cfg.APIKey when the stored config targets the same provider. Errors with
 // the same "X is not set" message the server reported before.
 func resolveAPIKey(name string, cfg config.Config) (string, error) {
-	switch name {
-	case "anthropic":
-		apiKey := os.Getenv("ANTHROPIC_API_KEY")
-		if apiKey == "" && cfg.Provider == "anthropic" {
-			apiKey = cfg.APIKey
-		}
-		if apiKey == "" {
-			return "", fmt.Errorf("ANTHROPIC_API_KEY is not set")
-		}
-		return apiKey, nil
-	case "openai":
-		apiKey := os.Getenv("OPENAI_API_KEY")
-		if apiKey == "" && cfg.Provider == "openai" {
-			apiKey = cfg.APIKey
-		}
-		if apiKey == "" {
-			return "", fmt.Errorf("OPENAI_API_KEY is not set")
-		}
-		return apiKey, nil
-	default:
+	if !app.IsKnownVendor(name) {
 		return "", fmt.Errorf("unknown provider %q", name)
 	}
+	envVar := app.VendorAPIKeyEnvVar(name)
+	apiKey := os.Getenv(envVar)
+	if apiKey == "" && cfg.Provider == name {
+		apiKey = cfg.APIKey
+	}
+	if apiKey == "" {
+		return "", fmt.Errorf("%s is not set", envVar)
+	}
+	return apiKey, nil
 }
 
 func firstNonEmpty(vals ...string) string {
@@ -477,23 +467,12 @@ func firstNonEmpty(vals ...string) string {
 }
 
 func modelFromEnv(provider string) string {
-	switch provider {
-	case "anthropic":
-		return os.Getenv("ANTHROPIC_MODEL")
-	case "openai":
-		return os.Getenv("OPENAI_MODEL")
-	}
-	return ""
+	envVar := strings.ToUpper(provider) + "_MODEL"
+	return os.Getenv(envVar)
 }
 
 func defaultModelFor(provider string) string {
-	switch provider {
-	case "anthropic":
-		return "claude-haiku-4-5-20251001"
-	case "openai":
-		return "gpt-4o-mini"
-	}
-	return ""
+	return app.VendorDefaultModel(provider)
 }
 
 func resolveBaseURL(provider string, cfg config.Config) string {

--- a/internal/server/static/onboard.js
+++ b/internal/server/static/onboard.js
@@ -390,12 +390,13 @@ const Onboard = (() => {
     btn.textContent = I18n.t("onboard.key.testing");
     _setResult(null, "");
 
-    // Determine provider preset and anthropic_format
+    // Determine provider preset and protocol
     const valueSpan = $("setup-provider-wrapper")?.querySelector(".custom-select-value");
     const providerValue = valueSpan?.dataset.value || '';
     const preset = providerValue && providerValue !== '__custom__'
       ? _providers.find(p => p.id === providerValue)
       : null;
+    const providerID = preset ? preset.id : 'openai';
     const anthropicFormat = preset && preset.api === 'anthropic-messages';
 
     // Step 1: test connection
@@ -425,7 +426,7 @@ const Onboard = (() => {
       const res  = await fetch("/api/config/models", {
         method:  "POST",
         headers: { "Content-Type": "application/json" },
-        body:    JSON.stringify({ type: "default", model, base_url: baseUrl, api_key: apiKey, anthropic_format: false })
+        body:    JSON.stringify({ type: "default", model, base_url: baseUrl, api_key: apiKey, provider: providerID, anthropic_format: anthropicFormat })
       });
       const data = await res.json();
       if (!data.ok) {


### PR DESCRIPTION
- Consolidate all vendor metadata into `internal/app/provider.go` (single source of truth)
- `app.Registry` now carries: API type, models list, lite model, endpoint variants
- Server builds JSON presets dynamically from Registry (no more duplicated `providerPresets`)
- `detectOnboardPhase` scans all registered vendor env vars
- Adding a new vendor = one line in Registry

Co-authored-by: octo-agent <no-reply@octo-agent.dev>