### PR TITLE
Fix vendor registry: kimi-coding protocol + base URL /v1 dedupe

### DIFF
--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -23,7 +23,7 @@ type Vendor struct {
 	DisplayName      string            // human label, e.g. "Kimi (Moonshot)"
 	Protocol         string            // "anthropic" or "openai"
 	API              string            // "anthropic-messages" or "openai-completions" or "openai-responses"
-	DefaultBaseURL   string            // vendor's official endpoint
+	DefaultBaseURL   string            // vendor's official endpoint (host only; the client appends the protocol path)
 	DefaultModel     string            // cheapest/reasoning-capable default
 	Models           []string          // available models (for UI dropdown)
 	LiteModel        string            // lightweight/cheaper model variant
@@ -40,7 +40,7 @@ var Registry = []Vendor{
 		DisplayName:    "OpenRouter",
 		Protocol:       "openai",
 		API:            "openai-responses",
-		DefaultBaseURL: "https://openrouter.ai/api/v1",
+		DefaultBaseURL: "https://openrouter.ai/api",
 		DefaultModel:   "anthropic/claude-sonnet-4-6",
 		Models: []string{
 			"anthropic/claude-sonnet-4-6",
@@ -71,14 +71,14 @@ var Registry = []Vendor{
 		DisplayName:    "Minimax",
 		Protocol:       "openai",
 		API:            "openai-completions",
-		DefaultBaseURL: "https://api.minimaxi.com/v1",
+		DefaultBaseURL: "https://api.minimaxi.com",
 		DefaultModel:   "MiniMax-M2.7",
 		Models:         []string{"MiniMax-M2.5", "MiniMax-M2.7"},
 		APIKeyEnvVar:   "MINIMAX_API_KEY",
 		WebsiteURL:     "https://www.minimaxi.com/user-center/basic-information/interface-key",
 		EndpointVariants: []EndpointVariant{
-			{Label: "Mainland China", LabelKey: "settings.models.baseurl.variant.mainland_cn", BaseURL: "https://api.minimaxi.com/v1", Region: "cn"},
-			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://api.minimax.io/v1", Region: "intl"},
+			{Label: "Mainland China", LabelKey: "settings.models.baseurl.variant.mainland_cn", BaseURL: "https://api.minimaxi.com", Region: "cn"},
+			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://api.minimax.io", Region: "intl"},
 		},
 	},
 	{
@@ -86,21 +86,21 @@ var Registry = []Vendor{
 		DisplayName:    "Kimi (Moonshot)",
 		Protocol:       "openai",
 		API:            "openai-completions",
-		DefaultBaseURL: "https://api.moonshot.cn/v1",
+		DefaultBaseURL: "https://api.moonshot.cn",
 		DefaultModel:   "kimi-k2.6",
 		Models:         []string{"kimi-k2.6", "kimi-k2.5"},
 		APIKeyEnvVar:   "MOONSHOT_API_KEY",
 		WebsiteURL:     "https://platform.moonshot.cn/console/api-keys",
 		EndpointVariants: []EndpointVariant{
-			{Label: "Mainland China", LabelKey: "settings.models.baseurl.variant.mainland_cn", BaseURL: "https://api.moonshot.cn/v1", Region: "cn"},
-			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://api.moonshot.ai/v1", Region: "intl"},
+			{Label: "Mainland China", LabelKey: "settings.models.baseurl.variant.mainland_cn", BaseURL: "https://api.moonshot.cn", Region: "cn"},
+			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://api.moonshot.ai", Region: "intl"},
 		},
 	},
 	{
 		ID:             "kimi-coding",
 		DisplayName:    "Kimi Coding",
-		Protocol:       "openai",
-		API:            "openai-completions",
+		Protocol:       "anthropic",
+		API:            "anthropic-messages",
 		DefaultBaseURL: "https://api.kimi.com/coding",
 		DefaultModel:   "kimi-for-coding",
 		Models:         []string{"kimi-for-coding"},
@@ -120,7 +120,7 @@ var Registry = []Vendor{
 		WebsiteURL:     "https://open.bigmodel.cn/usercenter/apikey",
 		EndpointVariants: []EndpointVariant{
 			{Label: "Mainland China", LabelKey: "settings.models.baseurl.variant.mainland_cn", BaseURL: "https://open.bigmodel.cn/api/paas/v4", Region: "cn"},
-			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://api.z.ai/v1", Region: "intl"},
+			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://api.z.ai", Region: "intl"},
 		},
 	},
 	{
@@ -128,7 +128,7 @@ var Registry = []Vendor{
 		DisplayName:    "OpenAI",
 		Protocol:       "openai",
 		API:            "openai-responses",
-		DefaultBaseURL: "https://api.openai.com/v1",
+		DefaultBaseURL: "https://api.openai.com",
 		DefaultModel:   "gpt-5.4",
 		Models:         []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini"},
 		LiteModel:      "gpt-5.4-mini",
@@ -152,7 +152,7 @@ var Registry = []Vendor{
 		DisplayName:    "SiliconFlow",
 		Protocol:       "openai",
 		API:            "openai-completions",
-		DefaultBaseURL: "https://api.siliconflow.cn/v1",
+		DefaultBaseURL: "https://api.siliconflow.cn",
 		DefaultModel:   "deepseek-ai/DeepSeek-V3",
 		Models:         []string{"deepseek-ai/DeepSeek-V3", "deepseek-ai/DeepSeek-R1"},
 		APIKeyEnvVar:   "SILICONFLOW_API_KEY",
@@ -163,7 +163,7 @@ var Registry = []Vendor{
 		DisplayName:    "Mistral",
 		Protocol:       "openai",
 		API:            "openai-completions",
-		DefaultBaseURL: "https://api.mistral.ai/v1",
+		DefaultBaseURL: "https://api.mistral.ai",
 		DefaultModel:   "mistral-large-latest",
 		Models:         []string{"mistral-large-latest", "mistral-medium-latest"},
 		APIKeyEnvVar:   "MISTRAL_API_KEY",
@@ -174,7 +174,7 @@ var Registry = []Vendor{
 		DisplayName:    "Groq",
 		Protocol:       "openai",
 		API:            "openai-completions",
-		DefaultBaseURL: "https://api.groq.com/openai/v1",
+		DefaultBaseURL: "https://api.groq.com/openai",
 		DefaultModel:   "llama-4-scout",
 		Models:         []string{"llama-4-scout", "llama-4-maverick"},
 		APIKeyEnvVar:   "GROQ_API_KEY",

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -1,0 +1,90 @@
+package app
+
+import (
+	"testing"
+)
+
+func TestVendor_KimiCoding(t *testing.T) {
+	v := vendorByID("kimi-coding")
+	if v == nil {
+		t.Fatal("kimi-coding not found in registry")
+	}
+
+	if v.DisplayName != "Kimi Coding" {
+		t.Errorf("DisplayName = %q, want Kimi Coding", v.DisplayName)
+	}
+	if v.Protocol != "anthropic" {
+		t.Errorf("Protocol = %q, want anthropic", v.Protocol)
+	}
+	if v.API != "anthropic-messages" {
+		t.Errorf("API = %q, want anthropic-messages", v.API)
+	}
+	if v.DefaultBaseURL != "https://api.kimi.com/coding" {
+		t.Errorf("DefaultBaseURL = %q, want https://api.kimi.com/coding", v.DefaultBaseURL)
+	}
+	if v.DefaultModel != "kimi-for-coding" {
+		t.Errorf("DefaultModel = %q, want kimi-for-coding", v.DefaultModel)
+	}
+	if v.APIKeyEnvVar != "MOONSHOT_API_KEY" {
+		t.Errorf("APIKeyEnvVar = %q, want MOONSHOT_API_KEY", v.APIKeyEnvVar)
+	}
+}
+
+func TestVendor_KimiCoding_BuildClient(t *testing.T) {
+	// buildClient should succeed with a dummy key for the anthropic protocol.
+	_, err := buildClient("kimi-coding", "sk-dummy-key", "")
+	if err != nil {
+		t.Fatalf("buildClient(kimi-coding) error: %v", err)
+	}
+}
+
+func TestVendor_KimiCoding_BuildClient_CustomBaseURL(t *testing.T) {
+	// Verify the custom base URL override is applied.
+	client, err := buildClient("kimi-coding", "sk-dummy-key", "https://custom.example/v1")
+	if err != nil {
+		t.Fatalf("buildClient error: %v", err)
+	}
+
+	// The openai client exposes BaseURL as a field.
+	// Use reflection to avoid importing the internal/openai package here.
+	if client == nil {
+		t.Fatal("client is nil")
+	}
+
+	// The client is an openai.Client which has a BaseURL field.
+	// We can't import internal/provider/openai from app_test due to layering,
+	// so we rely on TestConnection with a mock server in integration tests.
+	// This test at least verifies buildClient does not reject the vendor ID.
+}
+
+func TestIsKnownVendor(t *testing.T) {
+	for _, id := range []string{
+		"openrouter", "deepseek", "minimax", "kimi", "kimi-coding",
+		"glm", "openai", "anthropic", "siliconflow", "mistral", "groq",
+	} {
+		if !IsKnownVendor(id) {
+			t.Errorf("IsKnownVendor(%q) = false, want true", id)
+		}
+	}
+	if IsKnownVendor("bogus") {
+		t.Error("IsKnownVendor(bogus) = true, want false")
+	}
+}
+
+func TestVendorEnvVars(t *testing.T) {
+	tests := []struct {
+		id, wantEnv string
+	}{
+		{"kimi-coding", "MOONSHOT_API_KEY"},
+		{"kimi", "MOONSHOT_API_KEY"},
+		{"deepseek", "DEEPSEEK_API_KEY"},
+		{"openai", "OPENAI_API_KEY"},
+		{"anthropic", "ANTHROPIC_API_KEY"},
+	}
+	for _, tc := range tests {
+		got := VendorAPIKeyEnvVar(tc.id)
+		if got != tc.wantEnv {
+			t.Errorf("VendorAPIKeyEnvVar(%q) = %q, want %q", tc.id, got, tc.wantEnv)
+		}
+	}
+}


### PR DESCRIPTION
- kimi-coding speaks **anthropic** protocol (verified with real key against /v1/messages)
- Strip trailing /v1 from all openai-protocol DefaultBaseURLs — the openai client appends /v1/chat/completions itself, so a registry URL like  produced a double /v1 path
- Add provider_test.go with vendor lookup + buildClient coverage

Co-authored-by: octo-agent <no-reply@octo-agent.dev>