### PR TITLE
fix: remove dead access-key CLI code

### DIFF
--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -88,23 +88,6 @@ func effectiveEndpoint(provider string, cfg config.Config) string {
 // runConfig handles `octo config [show|path]` and, with no subcommand, an
 // interactive setup wizard that writes ~/.octo/config.yaml.
 func runConfig(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
-	// Check for --access-key flag before subcommand dispatch.
-	for i, a := range args {
-		if a == "--access-key" || strings.HasPrefix(a, "--access-key=") {
-			var key string
-			if strings.HasPrefix(a, "--access-key=") {
-				key = strings.TrimPrefix(a, "--access-key=")
-			} else if i+1 < len(args) {
-				key = args[i+1]
-				args = append(args[:i], args[i+2:]...)
-			} else {
-				fmt.Fprintln(stderr, "octo config: --access-key requires a value")
-				return 2
-			}
-			return runConfigSetAccessKey(key, stdout, stderr)
-		}
-	}
-
 	sub := ""
 	if len(args) > 0 {
 		sub = args[0]
@@ -180,14 +163,6 @@ func runConfigShow(stdout, stderr io.Writer) int {
 		effortStatus = cfg.ReasoningEffort + " (config)"
 	}
 	fmt.Fprintf(stdout, "  reasoning: %s\n", effortStatus)
-	accessKeyStatus := "not set"
-	if cfg.AccessKey != "" {
-		accessKeyStatus = "set (config)"
-	}
-	if os.Getenv("OCTO_ACCESS_KEY") != "" {
-		accessKeyStatus = "set via $OCTO_ACCESS_KEY"
-	}
-	fmt.Fprintf(stdout, "  access key: %s\n", accessKeyStatus)
 	showStatus := "on (default)"
 	if cfg.ShowReasoning != nil {
 		if *cfg.ShowReasoning {
@@ -322,23 +297,6 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 	} else {
 		fmt.Fprintln(stdout, "Run `octo chat` to start.")
 	}
-	return 0
-}
-
-// runConfigSetAccessKey writes the access key to the config file without
-// disturbing other fields.
-func runConfigSetAccessKey(key string, stdout, stderr io.Writer) int {
-	cfg, err := config.Load()
-	if err != nil {
-		fmt.Fprintf(stderr, "octo config: %v\n", err)
-		return 1
-	}
-	cfg.AccessKey = key
-	if err := cfg.Save(); err != nil {
-		fmt.Fprintf(stderr, "octo config: %v\n", err)
-		return 1
-	}
-	fmt.Fprintln(stdout, "Access key saved.")
 	return 0
 }
 

--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -210,20 +210,16 @@ Environment:
 func serveHelp(w io.Writer) {
 	fmt.Fprintln(w, `octo serve — start the HTTP server (REST API + SSE + Web UI).
 
-The server binds to localhost:8080 by default. All API and WebSocket routes
-require an access key; /api/health is public (used by the Web UI to validate
-the key before storing it).
+The server binds to localhost:8080 by default.
 
 Examples:
-  octo serve                           Start on :8080 with auto-generated key
+  octo serve                           Start on :8080
   octo serve --addr 127.0.0.1:3000     Bind to a specific address
-  octo serve --access-key my-secret    Use a fixed key (printed on startup)
   octo serve --no-channel              Skip IM platform bridges
   octo serve --no-tools                Disable the agentic tool loop
 
 Common flags:
   --addr <host:port>       Bind address (default :8080)
-  --access-key <key>       Shared secret for Web UI / API auth
   --provider <name>        anthropic (default) | openai
   --model <name>           Override the default model
   --system <text>          Custom system prompt
@@ -234,14 +230,10 @@ Common flags:
   --no-channel             Disable IM channel startup
 
 Environment:
-  OCTO_ACCESS_KEY          Override the config access_key, per run
   ANTHROPIC_API_KEY        Required when --provider=anthropic
   OPENAI_API_KEY           Required when --provider=openai
   ANTHROPIC_BASE_URL       Override the Anthropic endpoint
   OPENAI_BASE_URL          Override the OpenAI endpoint
-
-Key resolution (highest first):
-  --access-key flag > OCTO_ACCESS_KEY env > config file > auto-generated 64-char hex
 
 Run "octo serve --help" for the full flag list.`)
 }
@@ -259,15 +251,11 @@ Usage:
   octo config show                 Print the effective provider/model and where each
                                    comes from (never prints the key itself)
   octo config path                 Print the config file path
-  octo config --access-key <key>   Set the Web UI / API access key
-
 File (~/.octo/config.yaml):
   provider: openai
   model: gpt-4o-mini
   base_url: https://api.deepseek.com   # optional, for compatible 3rd parties
-  access_key: my-secret-key            # optional, for octo serve auth
 
 Environment:
-  ANTHROPIC_API_KEY / OPENAI_API_KEY    Override any stored key, per run.
-  OCTO_ACCESS_KEY                       Override the config access_key, per run.`)
+  ANTHROPIC_API_KEY / OPENAI_API_KEY    Override any stored key, per run.`)
 }

--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -25,7 +25,6 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	tools := fs.Bool("tools", true, "Enable agentic tool loop")
 	cors := fs.String("cors", "", "CORS allowed origins (comma-separated, * for any)")
 	noChannel := fs.Bool("no-channel", false, "Disable IM channel (DingTalk, Feishu)")
-	accessKey := fs.String("access-key", "", "Shared secret for Web UI / API auth. Also OCTO_ACCESS_KEY. Empty = auto-generated.")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -49,7 +48,6 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		Tools:       *tools,
 		CORSOrigins: corsOrigins,
 		NoChannel:   *noChannel,
-		AccessKey:   *accessKey,
 	}
 
 	srv, err := server.New(cfg)
@@ -63,7 +61,6 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		host = "localhost" + host
 	}
 	fmt.Fprintf(stdout, "octo server listening on http://%s\n", host)
-	fmt.Fprintf(stdout, "access key: %s\n", srv.AccessKey())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Access-key authentication was removed in v0.16.0 (server layer is already no-op), but the CLI still had several remnants:

- `octo serve` printed an empty access key on startup
- `--access-key` flag on `octo serve` (ignored by server)
- `octo config --access-key` subcommand (wrote to config but never used)
- Access-key status shown in `octo config show`
- Help text describing access-key auth and key resolution

Delete all CLI-level dead code. Server/config structs keep the field for backward compatibility with existing config files.