### PR TITLE
feat: auto-onboard when config is missing

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -31,6 +32,11 @@ const (
 	providerAnthropic = "anthropic"
 	providerOpenAI    = "openai"
 )
+
+// errMissingAPIKey is returned by resolveAPIKey when no API key is available.
+// The caller (runChat) can detect this and auto-launch the config wizard on an
+// interactive terminal instead of failing silently.
+var errMissingAPIKey = errors.New("missing API key")
 
 // unattendedMaxTurns is the agentic-loop cap applied when --max-turns is left
 // at its auto-sentinel (0) and there's no interactive human to continue past
@@ -411,7 +417,33 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		showReasoning:   resolvedShowReasoning,
 	})
 	if err != nil {
-		return 1
+		// If the sender failed because of a missing API key and we're on an
+		// interactive terminal, run the config wizard automatically rather than
+		// leaving the user to figure out `octo config` on their own.
+		if errors.Is(err, errMissingAPIKey) && stdinIsTTY(stdin) {
+			fmt.Fprintln(stderr, "")
+			fmt.Fprintln(stderr, "No API key configured. Let's set up octo first.")
+			if runConfigWizard(stdin, stdout, stderr) != 0 {
+				return 1
+			}
+			// Reload config and retry sender construction.
+			cfg, _ = config.Load()
+			provName, resolvedModel, ok = resolveProviderModel(*providerName, *model, cfg)
+			if !ok {
+				fmt.Fprintf(stderr, "octo chat: unknown provider %q\n", provName)
+				return 2
+			}
+			llmSender, err = buildSender(provName, cfg, stderr, senderTuning{
+				thinkingBudget:  anthropicThinkingBudget(resolvedEffort),
+				reasoningEffort: resolvedEffort,
+				showReasoning:   resolvedShowReasoning,
+			})
+			if err != nil {
+				return 1
+			}
+		} else {
+			return 1
+		}
 	}
 
 	// Verbose: surface the resolved provider / model / endpoint so a
@@ -812,7 +844,7 @@ func resolveAPIKey(name string, cfg config.Config, stderr io.Writer) (string, er
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Or run `octo config` to save a default provider/key.")
 		fmt.Fprintln(stderr, "")
-		return "", fmt.Errorf("missing %s", envVar)
+		return "", fmt.Errorf("%w: %s", errMissingAPIKey, envVar)
 	}
 	return apiKey, nil
 }

--- a/internal/server/benchmark_handler.go
+++ b/internal/server/benchmark_handler.go
@@ -26,6 +26,11 @@ type benchmarkResult struct {
 // ─── POST /api/sessions/{id}/benchmark ──────────────────────────────────────
 
 func (s *Server) handleBenchmark(w http.ResponseWriter, r *http.Request) {
+	if err := s.ensureSender(); err != nil {
+		writeError(w, http.StatusServiceUnavailable, err.Error())
+		return
+	}
+
 	sessionID := r.PathValue("id")
 	if sessionID == "" {
 		writeError(w, http.StatusBadRequest, "missing session id")

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -121,6 +121,11 @@ type skillInfo struct {
 // ─── POST /api/chat ─────────────────────────────────────────────────────────
 
 func (s *Server) handleCreateChat(w http.ResponseWriter, r *http.Request) {
+	if err := s.ensureSender(); err != nil {
+		writeError(w, http.StatusServiceUnavailable, err.Error())
+		return
+	}
+
 	var req createChatRequest
 	if err := readBodyJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
@@ -173,6 +178,11 @@ func (s *Server) handleTurnOrSSE(w http.ResponseWriter, r *http.Request) {
 // ─── POST /api/chat/:id/turn ────────────────────────────────────────────────
 
 func (s *Server) handleTurn(w http.ResponseWriter, r *http.Request) {
+	if err := s.ensureSender(); err != nil {
+		writeError(w, http.StatusServiceUnavailable, err.Error())
+		return
+	}
+
 	id := r.PathValue("id")
 	if id == "" {
 		writeError(w, http.StatusBadRequest, "missing session id")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -114,6 +114,10 @@ type Server struct {
 
 	// accessKey is the shared secret for Web UI / API authentication.
 	accessKey string
+
+	// senderMu serialises lazy initialisation of sender when the server starts
+	// in onboarding mode (API key missing) and the user completes setup later.
+	senderMu sync.Mutex
 }
 
 // New builds a Server. It resolves provider/model, discovers skills, and
@@ -155,7 +159,9 @@ func New(cfg Config) (*Server, error) {
 
 	s.registerRoutes()
 	s.initWS()
-	s.enableSubAgentTools()
+	if sender != nil {
+		s.enableSubAgentTools()
+	}
 	s.enableMCP()
 	s.initChannels()
 
@@ -428,6 +434,12 @@ func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, stri
 	if err != nil {
 		return nil, "", err
 	}
+	if apiKey == "" {
+		// No API key configured yet — server starts in onboarding mode.
+		// Chat endpoints will retry on every request until the user completes
+		// setup via the Web UI.
+		return nil, model, nil
+	}
 	sender, err := app.NewSender(app.SenderOptions{
 		Provider: provName,
 		APIKey:   apiKey,
@@ -440,8 +452,9 @@ func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, stri
 }
 
 // resolveAPIKey returns the API key for the vendor: the provider's env var,
-// else cfg.APIKey when the stored config targets the same provider. Errors with
-// the same "X is not set" message the server reported before.
+// else cfg.APIKey when the stored config targets the same provider. An empty
+// key is returned (not an error) so the server can start in onboarding mode
+// and retry once the user completes setup via the Web UI.
 func resolveAPIKey(name string, cfg config.Config) (string, error) {
 	if !app.IsKnownVendor(name) {
 		return "", fmt.Errorf("unknown provider %q", name)
@@ -450,9 +463,6 @@ func resolveAPIKey(name string, cfg config.Config) (string, error) {
 	apiKey := os.Getenv(envVar)
 	if apiKey == "" && cfg.Provider == name {
 		apiKey = cfg.APIKey
-	}
-	if apiKey == "" {
-		return "", fmt.Errorf("%s is not set", envVar)
 	}
 	return apiKey, nil
 }
@@ -502,6 +512,34 @@ func buildEnvContext(cwd string) string {
 	return b.String()
 }
 
+// ensureSender lazily initialises the sender when the server started in
+// onboarding mode (nil sender). It re-reads config on every call so that
+// once the user completes onboard and saves the API key, the next chat
+// request picks it up without a server restart. Thread-safe via senderMu.
+func (s *Server) ensureSender() error {
+	if s.sender != nil {
+		return nil
+	}
+	s.senderMu.Lock()
+	defer s.senderMu.Unlock()
+	if s.sender != nil {
+		return nil
+	}
+	sender, model, err := resolveProviderAndModel(s.cfg.Provider, s.cfg.Model)
+	if err != nil {
+		return err
+	}
+	if sender == nil {
+		return fmt.Errorf("server not configured: complete setup via the Web UI")
+	}
+	s.sender = sender
+	s.model = model
+	if s.cfg.Tools {
+		s.enableSubAgentTools()
+	}
+	return nil
+}
+
 // validateAccessKey is a no-op: access-key authentication was removed in
 // v0.16.0. Kept as a placeholder so callers do not need to change.
 func (s *Server) validateAccessKey(r *http.Request) bool {
@@ -549,6 +587,12 @@ func validateBindAddr(addr string) error {
 // configured and not disabled via --no-channel.
 func (s *Server) initChannels() {
 	if s.cfg.NoChannel {
+		return
+	}
+	if s.sender == nil {
+		// Skip channel init when the server is in onboarding mode (no API key
+		// yet). Channels will be started on the next server restart after the
+		// user completes setup.
 		return
 	}
 	chCfg, err := channel.LoadConfig()

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -43,6 +43,11 @@ func (s *Server) handleTurnSSE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := s.ensureSender(); err != nil {
+		writeError(w, http.StatusServiceUnavailable, err.Error())
+		return
+	}
+
 	mu := s.sessionTurnLock(sess.ID)
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -229,6 +229,11 @@ func joinNonEmpty(parts []string, sep string) string {
 func (s *Server) runAgentTurn(sess *agent.Session, content string) {
 	sw := s.newWSStreamWriter(sess.ID)
 
+	if err := s.ensureSender(); err != nil {
+		sw.error(err.Error())
+		return
+	}
+
 	// Set up progress tracking for this session.
 	s.liveStateMu.Lock()
 	s.liveStates[sess.ID] = &sessionLiveState{}


### PR DESCRIPTION
### octo serve

- Server now starts in **onboarding mode** when no API key is configured.
-  returns a nil sender instead of erroring, so the HTTP layer comes up and serves static files + onboard APIs.
- Chat/turn/benchmark/WS endpoints lazily initialise the sender on the first request via , which re-reads config. Once the user completes onboard via the Web UI and saves the API key, the next chat request picks it up without a server restart.
- Channel (IM bridge) init is skipped in onboarding mode.

### octo chat

- When  fails because the API key is missing and stdin is a TTY,  **automatically launches the config wizard** instead of exiting. After the wizard finishes, it reloads config and retries sender construction.
-  returns a sentinel error () so the caller can distinguish a missing key from other configuration errors.