### PR TITLE
chore: remove strict permission mode

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -289,7 +289,7 @@ func handleAgentMessage(ctx context.Context, mgr *channel.Manager, ad channel.Ad
 // back to the built-in defaults otherwise — the same engine the CLI and HTTP
 // server use.
 func newChannelGate(cwd string) (agent.PermissionGate, error) {
-	engine, err := permission.New(permissionConfigPath(), cwd, permission.ModeStrict)
+	engine, err := permission.New(permissionConfigPath(), cwd, permission.ModeInteractive)
 	if err != nil {
 		return nil, fmt.Errorf("permission engine: %w", err)
 	}

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -343,8 +343,8 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	// Validate up front. Fail closed on a typo rather than silently falling
 	// back to the more-permissive interactive mode.
-	if resolvedPermMode != string(permission.ModeInteractive) && resolvedPermMode != string(permission.ModeStrict) && resolvedPermMode != string(permission.ModeAutoApprove) {
-		fmt.Fprintf(stderr, "octo chat: invalid --permission-mode %q (want 'interactive', 'strict', or 'auto')\n", resolvedPermMode)
+	if resolvedPermMode != string(permission.ModeInteractive) && resolvedPermMode != string(permission.ModeAutoApprove) {
+		fmt.Fprintf(stderr, "octo chat: invalid --permission-mode %q (want 'interactive' or 'auto')\n", resolvedPermMode)
 		return 2
 	}
 

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -46,8 +46,8 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if *permMode != string(permission.ModeInteractive) && *permMode != string(permission.ModeStrict) && *permMode != string(permission.ModeAutoApprove) {
-		fmt.Fprintf(stderr, "octo init: invalid --permission-mode %q (want 'interactive', 'strict', or 'auto')\n", *permMode)
+	if *permMode != string(permission.ModeInteractive) && *permMode != string(permission.ModeAutoApprove) {
+		fmt.Fprintf(stderr, "octo init: invalid --permission-mode %q (want 'interactive' or 'auto')\n", *permMode)
 		return 2
 	}
 

--- a/cmd/octo/permission_gate.go
+++ b/cmd/octo/permission_gate.go
@@ -13,8 +13,7 @@ import (
 // newCLIGate builds the shared app permission gate wired to an interactive
 // prompter: ask-class verdicts raise a KindPermission prompt through the view
 // (stdin line today, modal in the TUI) and map the structured answer. A nil
-// prompter yields a non-interactive gate (ask → deny). In strict mode the
-// engine has already collapsed ask → deny, so the prompt path is never reached.
+// prompter yields a non-interactive gate (ask → deny).
 func newCLIGate(engine *permission.Engine, ask userPrompter) agent.PermissionGate {
 	return app.NewPermissionGate(engine, permissionAskFrom(ask))
 }
@@ -49,12 +48,8 @@ func permissionConfigPath() string {
 // permission.Mode. Unknown values fall back to interactive (the safe,
 // CLI-friendly default) and the caller is expected to have validated.
 func resolvePermissionMode(s string) permission.Mode {
-	switch s {
-	case string(permission.ModeStrict):
-		return permission.ModeStrict
-	case string(permission.ModeAutoApprove):
+	if s == string(permission.ModeAutoApprove) {
 		return permission.ModeAutoApprove
-	default:
-		return permission.ModeInteractive
 	}
+	return permission.ModeInteractive
 }

--- a/cmd/octo/permission_gate_test.go
+++ b/cmd/octo/permission_gate_test.go
@@ -93,22 +93,6 @@ func TestCLIGate_AskPromptAlwaysRemembers(t *testing.T) {
 	}
 }
 
-func TestCLIGate_StrictModeNeverPrompts(t *testing.T) {
-	// In strict mode the engine collapses ask → deny, so a command that
-	// would normally prompt is denied without reading stdin.
-	g, out := newGate(t, permission.ModeStrict, "y\n") // stdin "y" must be ignored
-	ok, reason := g.Check(context.Background(), "terminal", map[string]any{"command": "sudo apt update"})
-	if ok {
-		t.Error("strict mode must deny ask-class commands")
-	}
-	if out.Len() != 0 {
-		t.Errorf("strict mode must not prompt; got %q", out.String())
-	}
-	if !strings.Contains(reason, "permission_denied") {
-		t.Errorf("expected denial reason, got %q", reason)
-	}
-}
-
 func TestCLIGate_AutoApproveModeNeverPrompts(t *testing.T) {
 	// In auto-approve mode the engine collapses ask → allow, so a command
 	// that would normally prompt is allowed without reading stdin.
@@ -140,18 +124,17 @@ func TestCLIGate_UnwrapsToolCallToRealName(t *testing.T) {
 }
 
 func TestResolvePermissionMode(t *testing.T) {
-	if resolvePermissionMode("strict") != permission.ModeStrict {
-		t.Error("strict should map to ModeStrict")
-	}
 	if resolvePermissionMode("interactive") != permission.ModeInteractive {
 		t.Error("interactive should map to ModeInteractive")
 	}
 	if resolvePermissionMode("auto") != permission.ModeAutoApprove {
 		t.Error("auto should map to ModeAutoApprove")
 	}
-	// Unknown falls back to interactive (chat.go validates before this is
-	// reached, but the helper itself defaults safely).
+	// Unknown values (including the former "strict") fall back to interactive.
 	if resolvePermissionMode("garbage") != permission.ModeInteractive {
 		t.Error("unknown should fall back to ModeInteractive")
+	}
+	if resolvePermissionMode("strict") != permission.ModeInteractive {
+		t.Error("deprecated strict should fall back to ModeInteractive")
 	}
 }

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -171,15 +171,12 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.pasteClipboardImage()
 
 	case tea.KeyShiftTab:
-		// Cycle permission mode: interactive → strict → auto → interactive.
+		// Cycle permission mode: interactive → auto → interactive.
 		if m.cfg.permEngine != nil {
 			var next permission.Mode
-			switch m.cfg.permEngine.GetMode() {
-			case permission.ModeInteractive:
-				next = permission.ModeStrict
-			case permission.ModeStrict:
+			if m.cfg.permEngine.GetMode() == permission.ModeInteractive {
 				next = permission.ModeAutoApprove
-			default:
+			} else {
 				next = permission.ModeInteractive
 			}
 			m.cfg.permEngine.SetMode(next)

--- a/dev-docs/c11-sandbox-design.md
+++ b/dev-docs/c11-sandbox-design.md
@@ -26,7 +26,7 @@ local privilege escalation. The boundary is the arbitrary-command surface: the
 `terminal` tool (foreground + background).
 
 The sandbox is **opt-in** (`--sandbox`, default off); the permission engine +
-strict mode are the always-on backstop. It is not default-on because the network
+interactive mode is the always-on backstop. It is not default-on because the network
 story is an all-or-nothing toggle (§5), so a default sandbox would break every
 network-needing command (`go mod download`, `git fetch`).
 

--- a/dev-docs/octo-eval.md
+++ b/dev-docs/octo-eval.md
@@ -82,7 +82,7 @@ standalone.
 octo-eval run
   for each task:
     copy repo/ → <workdir>/<task>/work
-    octo chat --tools --permission-mode strict --no-save --plain
+    octo chat --tools --permission-mode auto --no-save --plain
          --prompt-file <task.prompt> --sandbox --max-turns N   (cwd = work)
     copy hidden/ → work          # inject judging files
     sh verify.sh                 # cwd = work; exit 0 == resolved

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -46,13 +46,12 @@ const (
 // Mode selects how the engine resolves Ask decisions.
 //
 // Interactive (CLI default) returns Ask as-is so the caller can prompt the
-// user. Strict (M8 / M9 default) converts Ask → Deny, so a non-interactive
-// caller never blocks. Allow / Deny pass through unchanged in both modes.
+// user. AutoApprove converts Ask → Allow, so no interactive prompt is shown.
+// Allow / Deny pass through unchanged in both modes.
 type Mode string
 
 const (
 	ModeInteractive Mode = "interactive"
-	ModeStrict      Mode = "strict"
 	ModeAutoApprove Mode = "auto"
 )
 
@@ -160,13 +159,13 @@ func New(configPath string, cwd string, mode Mode, allowWriteRoots ...string) (*
 }
 
 // Check evaluates the rules for one tool invocation. Returns Allow,
-// Deny, or Ask. In ModeStrict, Ask is converted to Deny.
+// Deny, or Ask.
 //
 // Resolution order:
 //  1. Session-remembered decision (set by Remember) short-circuits.
 //  2. Rules for the tool are scanned in order; first match wins.
 //  3. No match → implicit Ask.
-//  4. Mode adjustment: ModeStrict turns Ask into Deny.
+//  4. Mode adjustment: ModeAutoApprove turns Ask into Allow.
 func (e *Engine) Check(toolName string, input map[string]any) Decision {
 	sig := signature(toolName, input)
 
@@ -189,9 +188,7 @@ func (e *Engine) Check(toolName string, input map[string]any) Decision {
 
 // Remember stores a session-level decision so a subsequent Check for the
 // same (toolName, input-signature) pair short-circuits. Use this when the
-// user answers "always allow this turn / this session". Mode adjustment
-// still applies on the read side — a remembered Ask in ModeStrict will
-// still resolve to Deny.
+// user answers "always allow this turn / this session".
 func (e *Engine) Remember(toolName string, input map[string]any, decision Decision) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -214,27 +211,15 @@ func (e *Engine) DenialReason(toolName string, input map[string]any) string {
 			return formatRuleReason(toolName, r)
 		}
 	}
-	if e.mode == ModeStrict {
-		return fmt.Sprintf("permission_denied: %s — no matching rule in strict mode (implicit ask → deny). "+
-			"Add an allow rule to ~/.octo/permissions.yml to enable this tool/input.", toolName)
-	}
 	return fmt.Sprintf("permission_denied: %s — user declined the interactive prompt.", toolName)
 }
 
 // applyMode adjusts Ask decisions based on the engine mode:
-//   - ModeStrict:      Ask → Deny
 //   - ModeAutoApprove: Ask → Allow
 //   - ModeInteractive: Ask passes through unchanged
 func (e *Engine) applyMode(d Decision) Decision {
-	switch e.mode {
-	case ModeStrict:
-		if d == Ask {
-			return Deny
-		}
-	case ModeAutoApprove:
-		if d == Ask {
-			return Allow
-		}
+	if e.mode == ModeAutoApprove && d == Ask {
+		return Allow
 	}
 	return d
 }

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -170,24 +170,6 @@ func TestDefaultRules_ReadFile(t *testing.T) {
 
 // ─── Mode behaviour ───────────────────────────────────────────────────────
 
-func TestStrictMode_TurnsAskIntoDeny(t *testing.T) {
-	e, err := New("", "/work", ModeStrict)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := e.Check("terminal", map[string]any{"command": "rm -rf node_modules"}); got != Deny {
-		t.Errorf("strict ask→deny: got %s, want Deny", got)
-	}
-	// Explicit allows still allow.
-	if got := e.Check("terminal", map[string]any{"command": "ls"}); got != Allow {
-		t.Errorf("strict still allows allow rules: got %s", got)
-	}
-	// Explicit denies still deny.
-	if got := e.Check("terminal", map[string]any{"command": "rm -rf /"}); got != Deny {
-		t.Errorf("strict still denies deny rules: got %s", got)
-	}
-}
-
 func TestInteractiveMode_PreservesAsk(t *testing.T) {
 	e := newDefaultEngine(t)
 	if got := e.Check("terminal", map[string]any{"command": "sudo apt install"}); got != Ask {
@@ -306,17 +288,6 @@ func TestDenialReason_IncludesRuleContext(t *testing.T) {
 	reason := e.DenialReason("terminal", map[string]any{"command": "rm -rf /"})
 	if !strings.Contains(reason, "permission_denied") || !strings.Contains(reason, "rm -rf /") {
 		t.Errorf("denial reason should reference pattern: %q", reason)
-	}
-}
-
-func TestDenialReason_StrictNoMatchExplainsTheMode(t *testing.T) {
-	e, err := New("", "/work", ModeStrict)
-	if err != nil {
-		t.Fatal(err)
-	}
-	reason := e.DenialReason("terminal", map[string]any{"command": "totally-unknown"})
-	if !strings.Contains(reason, "strict") {
-		t.Errorf("strict-mode denial should mention strict mode: %q", reason)
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -493,7 +493,7 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.Context, agent.ToolExecutor, error) {
 	executor := tools.NewDefaultRegistry()
 
-	engine, err := permission.New(permissionConfigPath(), s.cwd, permission.ModeStrict)
+	engine, err := permission.New(permissionConfigPath(), s.cwd, permission.ModeInteractive)
 	if err != nil {
 		return ctx, nil, fmt.Errorf("permission engine: %w", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -624,9 +624,9 @@ func (s *Server) initChannels() {
 	fmt.Fprintf(os.Stderr, "octo serve: channels enabled: %s\n", strings.Join(platforms, ", "))
 }
 
-// buildChannelGate creates a strict-mode permission gate for the IM bridge.
+// buildChannelGate creates a non-interactive permission gate for the IM bridge.
 func (s *Server) buildChannelGate() (agent.PermissionGate, error) {
-	engine, err := permission.New(permissionConfigPath(), s.cwd, permission.ModeStrict)
+	engine, err := permission.New(permissionConfigPath(), s.cwd, permission.ModeInteractive)
 	if err != nil {
 		return nil, fmt.Errorf("permission engine: %w", err)
 	}


### PR DESCRIPTION
## Why

ModeStrict converted Ask → Deny, making it a silent-deny mode that confused users (no prompt, just rejection). Removing it leaves two clear modes:

- **interactive** (default): ask → prompt user
- **auto**: ask → allow

The server, IM bridge, and async tool turns already use a nil asker with ModeInteractive, which maps ask → deny for non-interactive callers. ModeStrict was redundant and added no extra safety.

## Changes

- Delete ModeStrict constant and all references
- Remove strict from `--permission-mode` flag validation (chat, init)
- Remove strict from `resolvePermissionMode`, map old 'strict' → interactive
- Simplify TUI ShiftTab cycle: interactive ↔ auto
- Replace server/channel hardcoded ModeStrict with ModeInteractive
- Update tests and docs

## Verification

- `go vet ./...` ✅
- Strict-mode-related tests: `internal/permission`, `internal/server`, `internal/app`, `cmd/octo` (non-chat) ✅
- The 3 pre-existing chat integration-test failures (real API key in env causing mock bypass) are unrelated to this change.