### PR TITLE
test: isolate HOME in mock-server chat tests

### DIFF
--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -85,6 +85,9 @@ func TestRunChat_HonoursAnthropicBaseURL(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	t.Setenv("ANTHROPIC_API_KEY", "k")
 	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
 
@@ -148,6 +151,9 @@ func TestRunChat_PromptFile_SingleTurn(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	t.Setenv("ANTHROPIC_API_KEY", "k")
 	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
 
@@ -363,6 +369,9 @@ func TestRunChat_Anthropic_StreamingEndToEnd(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	t.Setenv("ANTHROPIC_API_KEY", "k")
 	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
 


### PR DESCRIPTION
## Problem

Three mock-server chat tests were missing , so  loaded the user's real  and hit the live provider instead of the  mock.

## Fix

Add  /  isolation to:
- 
- 
- 

## Verification

ok  	github.com/Leihb/octo-agent/cmd/octo	(cached)
→ pass ✅