### PR TITLE
fix(server): broadcast history_user_message to replace pending ghost bubble

### DIFF
--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -227,6 +227,15 @@ func joinNonEmpty(parts []string, sep string) string {
 // streams events to WS, saves the session, and cleans up live state.
 
 func (s *Server) runAgentTurn(sess *agent.Session, content string) {
+	// Confirm the user message immediately so the frontend can swap the
+	// ghost (.msg-pending) bubble for the real one before streaming starts.
+	s.wsHub.broadcast(sess.ID, map[string]any{
+		"type":       "history_user_message",
+		"session_id": sess.ID,
+		"content":    content,
+		"created_at": time.Now().UnixMilli(),
+	})
+
 	sw := s.newWSStreamWriter(sess.ID)
 
 	if err := s.ensureSender(); err != nil {


### PR DESCRIPTION
The frontend renders a .msg-pending ghost bubble when the user sends a message, expecting the backend to emit a history_user_message event that replaces it with the real user bubble. The backend never sent this event over WebSocket, so the ghost bubble stayed forever (spinning).

Broadcast history_user_message at the top of runAgentTurn so the frontend can swap the ghost before streaming begins.