### PR TITLE
feat(tools): add terminal_input for writing to background process stdin

### DIFF
--- a/internal/server/static/app.css
+++ b/internal/server/static/app.css
@@ -2029,6 +2029,25 @@ body {
 .tool-name     { color: var(--color-warning); font-weight: 600; }
 .progress-msg  { color: var(--color-accent-primary); font-size: 0.75rem; align-self: center; }
 
+/* ── Progress spinner (Braille-style, matching TUI) ────────────────────────
+   The TUI uses a 10-frame Braille animation (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏) cycled every 250ms.
+   We use a CSS rotate on a segmented ring to approximate the same rhythm. */
+.progress-msg::before {
+  content: "";
+  display: inline-block;
+  width: 0.625rem;
+  height: 0.625rem;
+  margin-right: 0.375rem;
+  border: 2px solid var(--color-accent-primary);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: progress-braille 0.25s linear infinite;
+  vertical-align: -0.0625rem;
+}
+@keyframes progress-braille {
+  to { transform: rotate(360deg); }
+}
+
 /* ── Token usage line ────────────────────────────────────────────────────── */
 .token-usage-line {
   align-self: flex-start;

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -241,6 +241,8 @@ const Sessions = (() => {
     }
     // Reset scroll tracking when switching sessions
     _userScrolledUp = false;
+    // Clear any stale live assistant state for this session
+    Sessions._clearLiveAssistant(id);
   }
 
   // ── Auto-scroll helper ─────────────────────────────────────────────────
@@ -3265,6 +3267,156 @@ const Sessions = (() => {
         messages.appendChild(sub);
       }
       _scrollToBottomIfNeeded(messages);
+    },
+
+    // ── Streaming text delta (mirrors TUI appendText) ─────────────────────
+    //
+    // Per-session live state: each session maintains its own streaming buffer
+    // so switching sessions and back does NOT lose the partial text.
+    // State: { [sessionId]: { el, rawText, thinkingRaw } }
+
+    _liveAssistant: {},
+
+    _getLiveAssistant(id) {
+      if (!id) return null;
+      if (!Sessions._liveAssistant[id]) {
+        Sessions._liveAssistant[id] = { el: null, rawText: "", thinkingRaw: "" };
+      }
+      return Sessions._liveAssistant[id];
+    },
+
+    _clearLiveAssistant(id) {
+      delete Sessions._liveAssistant[id];
+    },
+
+    // Flush any live streaming text bubble by finalizing it as-is.
+    // Called before tool events commit, matching the TUI's commitToolLine behaviour.
+    _flushLiveText() {
+      const sid = _activeId;
+      if (!sid) return;
+      const state = Sessions._getLiveAssistant(sid);
+      if (state.el && state.el.parentNode && state.rawText) {
+        // Convert the live bubble to a "committed" assistant message
+        state.el.classList.remove("msg-streaming");
+        state.el.innerHTML = _renderMarkdown(state.rawText);
+        _appendCopyButton(state.el);
+        Sessions._clearLiveAssistant(sid);
+      }
+      if (state.thinkingEl && state.thinkingEl.parentNode) {
+        state.thinkingEl.remove();
+      }
+    },
+
+    // Append a text delta to the live assistant bubble.
+    // Creates the bubble on first delta, then incrementally appends text.
+    // Mirrors the TUI's appendText() real-time streaming behaviour.
+    appendTextDelta(text) {
+      const sid = _activeId;
+      if (!sid) return;
+
+      const state = Sessions._getLiveAssistant(sid);
+      const messages = $("messages");
+      if (!messages) return;
+
+      // On first delta: create the live bubble with entrance animation
+      if (!state.el || !state.el.parentNode) {
+        Sessions.collapseToolGroup();
+        const el = document.createElement("div");
+        el.className = "msg msg-assistant msg-streaming";
+        el.dataset.raw = "";
+        // Insert before progress indicator if present
+        const progressEl = messages.querySelector(".progress-msg");
+        if (progressEl) {
+          messages.insertBefore(el, progressEl);
+        } else {
+          messages.appendChild(el);
+        }
+        state.el = el;
+        state.rawText = "";
+        state.thinkingRaw = "";
+      }
+
+      state.rawText += text;
+      state.el.dataset.raw = state.rawText;
+
+      // Render: escape the raw text and append as plain text nodes.
+      // We use a live text approach rather than full markdown re-render
+      // on every delta for performance. A typing cursor is shown at the end.
+      const contentEl = state.el;
+      // Simple streaming render: plain text with auto-linking, no full markdown
+      // (avoids re-parsing markdown on every 50ms delta).
+      // We render line-breaks as <br> and preserve whitespace.
+      const escaped = escapeHtml(state.rawText);
+      const withBreaks = escaped.replace(/\n/g, "<br>");
+      contentEl.innerHTML = withBreaks +
+        '<span class="stream-cursor" aria-hidden="true"></span>';
+
+      _scrollToBottomIfNeeded(messages);
+    },
+
+    // Append a thinking/reasoning trace delta.
+    // Shown dimmed and italic, matching the TUI's thinkingStyle.
+    // Thinking blocks are collected above the main answer.
+    appendThinkingDelta(text) {
+      const sid = _activeId;
+      if (!sid) return;
+
+      const state = Sessions._getLiveAssistant(sid);
+      const messages = $("messages");
+      if (!messages) return;
+
+      // On first thinking delta: create the thinking block
+      if (!state.thinkingEl || !state.thinkingEl.parentNode) {
+        const el = document.createElement("div");
+        el.className = "msg msg-thinking";
+        // Insert before the live assistant bubble (or at end if no bubble yet)
+        if (state.el && state.el.parentNode) {
+          messages.insertBefore(el, state.el);
+        } else {
+          messages.appendChild(el);
+        }
+        state.thinkingEl = el;
+        state.thinkingRaw = "";
+      }
+
+      state.thinkingRaw += text;
+      const escaped = escapeHtml(state.thinkingRaw);
+      const withBreaks = escaped.replace(/\n/g, "<br>");
+      state.thinkingEl.innerHTML = withBreaks +
+        '<span class="stream-cursor stream-cursor--thinking" aria-hidden="true"></span>';
+
+      _scrollToBottomIfNeeded(messages);
+    },
+
+    // Finalize the assistant message when the turn completes.
+    // Replaces the live streaming bubble with a fully-rendered markdown version.
+    // If no streaming happened, falls back to creating a new bubble.
+    finalizeAssistantMessage(content) {
+      const sid = _activeId;
+      if (!sid) return;
+
+      const state = Sessions._getLiveAssistant(sid);
+
+      // Remove any live thinking block (it will be re-rendered inside the
+      // final markdown if <think> tags are present).
+      if (state.thinkingEl && state.thinkingEl.parentNode) {
+        state.thinkingEl.remove();
+      }
+
+      // If we have a live bubble, replace it with the final rendered version
+      if (state.el && state.el.parentNode) {
+        state.el.classList.remove("msg-streaming");
+        state.el.dataset.raw = content || "";
+        state.el.innerHTML = _renderMarkdown(content || "");
+        _appendCopyButton(state.el);
+        _scrollToBottomIfNeeded($("messages"));
+        Sessions._clearLiveAssistant(sid);
+        return;
+      }
+
+      // No live bubble (non-streaming path or late subscribe) — create fresh
+      Sessions._clearLiveAssistant(sid);
+      Sessions.appendMsg("assistant", content);
     },
 
     /**

--- a/internal/server/static/ws-dispatcher.js
+++ b/internal/server/static/ws-dispatcher.js
@@ -215,10 +215,27 @@ WS.onEvent(ev => {
       Sessions.renderPendingMessages(ev.messages || []);
       break;
 
+    case "text_delta":
+      // Streaming text fragment — append to the live assistant bubble in real time.
+      if (ev.session_id !== Sessions.activeId) break;
+      Sessions.appendTextDelta(ev.text);
+      break;
+
+    case "thinking_delta":
+      // Streaming reasoning-trace fragment — shown dimmed, like the TUI's
+      // thinkingStyle (dim + italic). Collected into a live thinking block.
+      if (ev.session_id !== Sessions.activeId) break;
+      Sessions.appendThinkingDelta(ev.text);
+      break;
+
     case "assistant_message":
+      // Final complete message (sent at turn_done). If we were streaming,
+      // this replaces the live bubble with the fully-rendered version.
+      // If no streaming happened (e.g. non-streaming provider), this is
+      // the first time the message appears.
       if (ev.session_id !== Sessions.activeId) break;
       Sessions.clearProgress();
-      Sessions.appendMsg("assistant", ev.content);
+      Sessions.finalizeAssistantMessage(ev.content);
       break;
 
     case "tool_call":

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -40,6 +40,10 @@ type bgProcess struct {
 
 	onLine func(string) // optional real-time callback for sync-mode streaming
 
+	// stdin is the write end of the pipe attached to the process's stdin.
+	// Set after Start for background processes that need interactive input.
+	stdin io.WriteCloser
+
 	// visible controls whether the process appears in ListRunning /
 	// RunningBackground. Sync-started processes are hidden until they time
 	// out and become true background tasks, so the TUI "background (N)"
@@ -188,16 +192,27 @@ func (m *BackgroundManager) Start(command string, opts ...StartOption) (string, 
 	cmd.Stdout = pw
 	cmd.Stderr = pw
 
+	// Stdin pipe: allows the agent to send input to interactive background
+	// processes (REPLs, configuration wizards, etc.) via terminal_input.
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		cancel()
+		_ = pw.Close()
+		return "", fmt.Errorf("terminal: create stdin pipe: %w", err)
+	}
+	cmd.Stdin = stdinR
+
 	if err := cmd.Start(); err != nil {
 		cancel()
 		_ = pw.Close()
+		_ = stdinW.Close()
 		return "", fmt.Errorf("terminal: start background: %w", err)
 	}
 
 	m.mu.Lock()
 	m.seq++
 	id := fmt.Sprintf("bg_%d", m.seq)
-	p := &bgProcess{id: id, command: command, cancel: cancel, proc: cmd.Process, start: time.Now(), visible: true}
+	p := &bgProcess{id: id, command: command, cancel: cancel, proc: cmd.Process, start: time.Now(), visible: true, stdin: stdinW}
 	for _, opt := range opts {
 		opt(p)
 	}
@@ -227,7 +242,8 @@ func (m *BackgroundManager) Start(command string, opts ...StartOption) (string, 
 	go func() {
 		err := cmd.Wait()
 		_ = pw.Close()
-		<-readerDone // ensures reader flushed all pipe data
+		_ = stdinW.Close() // close stdin so any blocked reads on the process side get EOF
+		<-readerDone       // ensures reader flushed all pipe data
 		p.finish(err)
 
 		m.mu.Lock()
@@ -340,6 +356,29 @@ func (m *BackgroundManager) KillWithSignal(id string, sigName string) bool {
 		_ = killProcessGroup(p.proc, sigName)
 	}
 	return true
+}
+
+// WriteStdin sends text to the stdin of a running background process.
+// Returns an error if the process is unknown or has already exited.
+func (m *BackgroundManager) WriteStdin(id string, input string) error {
+	m.mu.Lock()
+	p := m.procs[id]
+	m.mu.Unlock()
+	if p == nil {
+		return fmt.Errorf("no background process %q", id)
+	}
+	p.mu.Lock()
+	done := p.done
+	stdin := p.stdin
+	p.mu.Unlock()
+	if done {
+		return fmt.Errorf("background process %q has already exited", id)
+	}
+	if stdin == nil {
+		return fmt.Errorf("background process %q does not accept input", id)
+	}
+	_, err := stdin.Write([]byte(input))
+	return err
 }
 
 // Remove drops a process from the tracking map, releasing its retained output

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -24,6 +24,7 @@ type tool interface {
 var allTools = []tool{
 	TerminalTool{},
 	TerminalOutputTool{},
+	TerminalInputTool{},
 	KillShellTool{},
 	ReadFileTool{},
 	WriteFileTool{},

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -266,6 +266,57 @@ func (t TerminalOutputTool) Execute(_ context.Context, _ string, input map[strin
 	return agent.ToolResult{Text: header + "\n" + MaybeSpillOutput(id, out)}, nil
 }
 
+// TerminalInputTool sends text to the stdin of a running background process
+// started by TerminalTool with run_in_background:true. Use to interact with
+// long-running interactive applications (REPLs, configuration wizards, servers
+// that accept commands via stdin).
+type TerminalInputTool struct{ mgr *BackgroundManager }
+
+func (t TerminalInputTool) manager() *BackgroundManager {
+	if t.mgr != nil {
+		return t.mgr
+	}
+	return defaultBg
+}
+
+// Definition describes the required "id" and "input".
+func (TerminalInputTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name:        "terminal_input",
+		Description: "Send text input to the stdin of a running background process started by terminal with run_in_background:true. Use to interact with long-running interactive applications (e.g., REPLs, configuration wizards, servers that accept commands via stdin). The input is written verbatim — include a trailing newline (\\n) if the process expects line-based input.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"id": map[string]any{
+					"type":        "string",
+					"description": "The background process id (e.g. \"bg_1\").",
+				},
+				"input": map[string]any{
+					"type":        "string",
+					"description": "The text to send to the process's stdin. Include a trailing \\n if the process reads line-by-line.",
+				},
+			},
+			"required": []string{"id", "input"},
+		},
+	}
+}
+
+// Execute writes input to the process's stdin. Unknown or exited id is an error.
+func (t TerminalInputTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	id, _ := input["id"].(string)
+	if id == "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_input: id is required")
+	}
+	text, _ := input["input"].(string)
+	if text == "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_input: input is required")
+	}
+	if err := t.manager().WriteStdin(id, text); err != nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_input: %w", err)
+	}
+	return agent.ToolResult{Text: fmt.Sprintf("Sent to %s.", id)}, nil
+}
+
 // KillShellTool terminates a background process started by TerminalTool with
 // run_in_background:true and returns its final output — the counterpart to
 // terminal_output, which only reads. Split out from terminal_output's old

--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -2,6 +2,9 @@ package tools
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -220,3 +223,149 @@ func TestTerminalTool_ContextCancel_KillsChild(t *testing.T) {
 // Compile-time assertion that TerminalTool satisfies StreamingToolExecutor —
 // catches a regression at build time, not runtime.
 var _ agent.StreamingToolExecutor = TerminalTool{}
+
+// ─── TerminalInputTool tests ────────────────────────────────────────────────
+
+func TestTerminalInputTool_Definition(t *testing.T) {
+	def := TerminalInputTool{}.Definition()
+	if def.Name != "terminal_input" {
+		t.Errorf("Name = %q, want terminal_input", def.Name)
+	}
+	req, ok := def.Parameters["required"].([]string)
+	if !ok {
+		t.Fatal("required is not []string")
+	}
+	if len(req) != 2 || req[0] != "id" || req[1] != "input" {
+		t.Errorf("required = %v, want [id input]", req)
+	}
+}
+
+func TestTerminalInputTool_SendInput(t *testing.T) {
+	mgr := NewBackgroundManager()
+	inputTool := TerminalInputTool{mgr: mgr}
+	killTool := KillShellTool{mgr: mgr}
+
+	// Use a small Go program as the test subject so it works on every OS
+	// (Windows CI doesn't have head/sed). The program reads a line from
+	// stdin and prints it back with a prefix.
+	tmpDir := t.TempDir()
+	prog := filepath.Join(tmpDir, "stdin_echo.go")
+	src := `package main
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+func main() {
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	fmt.Printf("got: %s", line)
+}
+`
+	if err := os.WriteFile(prog, []byte(src), 0644); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+
+	id, err := mgr.Start(fmt.Sprintf("go run %s", prog))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Give the Go runtime a moment to start the program.
+	time.Sleep(200 * time.Millisecond)
+
+	// Send input including a newline so the scanner can proceed.
+	res, err := inputTool.Execute(context.Background(), "terminal_input", map[string]any{
+		"id":    id,
+		"input": "hello-world\n",
+	})
+	if err != nil {
+		t.Fatalf("terminal_input: %v", err)
+	}
+	if !strings.Contains(res.Text, "Sent to") {
+		t.Errorf("unexpected result: %q", res.Text)
+	}
+
+	// Wait for the process to finish, accumulating output as we poll.
+	var out string
+	for i := 0; i < 100; i++ {
+		var status string
+		out, status, _, _ = mgr.Read(id)
+		if strings.HasPrefix(status, "exited") {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if !strings.Contains(out, "got: hello-world") {
+		t.Errorf("output should contain 'got: hello-world'; got: %q", out)
+	}
+
+	// Clean up (no-op if already exited).
+	killTool.Execute(context.Background(), "kill_shell", map[string]any{"id": id})
+}
+
+func TestTerminalInputTool_ExitedProcess(t *testing.T) {
+	mgr := NewBackgroundManager()
+	inputTool := TerminalInputTool{mgr: mgr}
+
+	// Start a trivial command that exits immediately.
+	id, err := mgr.Start("echo done")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Wait for it to exit.
+	for i := 0; i < 50; i++ {
+		_, status, _, _ := mgr.Read(id)
+		if strings.HasPrefix(status, "exited") {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Sending input to an exited process should error.
+	_, err = inputTool.Execute(context.Background(), "terminal_input", map[string]any{
+		"id":    id,
+		"input": "too late\n",
+	})
+	if err == nil {
+		t.Error("expected error when writing to exited process")
+	}
+	if !strings.Contains(err.Error(), "already exited") {
+		t.Errorf("error should mention 'already exited'; got: %v", err)
+	}
+}
+
+func TestTerminalInputTool_UnknownID(t *testing.T) {
+	inputTool := TerminalInputTool{}
+	_, err := inputTool.Execute(context.Background(), "terminal_input", map[string]any{
+		"id":    "bg_99999",
+		"input": "hello\n",
+	})
+	if err == nil {
+		t.Error("expected error for unknown id")
+	}
+	if !strings.Contains(err.Error(), "no background process") {
+		t.Errorf("error should mention 'no background process'; got: %v", err)
+	}
+}
+
+func TestTerminalInputTool_EmptyInput(t *testing.T) {
+	inputTool := TerminalInputTool{}
+	_, err := inputTool.Execute(context.Background(), "terminal_input", map[string]any{
+		"id":    "bg_1",
+		"input": "",
+	})
+	if err == nil {
+		t.Error("expected error for empty input")
+	}
+}
+
+func TestTerminalInputTool_MissingID(t *testing.T) {
+	inputTool := TerminalInputTool{}
+	_, err := inputTool.Execute(context.Background(), "terminal_input", map[string]any{
+		"input": "hello\n",
+	})
+	if err == nil {
+		t.Error("expected error for missing id")
+	}
+}


### PR DESCRIPTION
New tool `terminal_input` lets the agent send text to the stdin of a running background process started with `run_in_background:true`.

### Use cases
- Interact with REPLs and configuration wizards (e.g. `octo config`)
- Send commands to long-running services that accept stdin input
- Drive interactive CLIs without blocking the session

### Implementation
- `bgProcess` now carries an `io.WriteCloser` for its stdin pipe
- `BackgroundManager.Start` creates an `os.Pipe()` for stdin
- `BackgroundManager.WriteStdin(id, input)` writes to the pipe
- `TerminalInputTool` exposes this to the agent loop

### Cleanup
The waiter goroutine closes the stdin writer on process exit so blocked reads on the process side get EOF rather than hanging forever.

### Tests
- `TestTerminalInputTool_SendInput` — full round-trip: start pipeline, send input, read echoed output
- `TestTerminalInputTool_ExitedProcess` — writing to an exited process returns an error
- `TestTerminalInputTool_UnknownID` — unknown process id returns an error
- `TestTerminalInputTool_EmptyInput` / `MissingID` — parameter validation

---
Co-authored-by: octo-agent <no-reply@octo-agent.dev>