### PR TITLE
fix(webui): add CreatedAt to agent.Message to prevent history dedup collision

### DIFF
--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -7,6 +7,8 @@
 // provider streaming aggregators and the tool registry.
 package agent
 
+import "time"
+
 // Role is the message author role, mirroring the role string used by both
 // supported LLM API protocols (Anthropic Messages, OpenAI Chat Completions).
 type Role string
@@ -25,24 +27,25 @@ const (
 // prefer Blocks; when only Content is set the adapter encodes it as a single
 // text block.
 type Message struct {
-	Role    Role           `json:"role"`
-	Content string         `json:"content,omitempty"`
-	Blocks  []ContentBlock `json:"blocks,omitempty"`
+	Role      Role           `json:"role"`
+	Content   string         `json:"content,omitempty"`
+	Blocks    []ContentBlock `json:"blocks,omitempty"`
+	CreatedAt time.Time      `json:"created_at,omitempty"`
 }
 
-// NewUserMessage constructs a Message with RoleUser.
+// NewUserMessage constructs a Message with RoleUser and a current timestamp.
 func NewUserMessage(content string) Message {
-	return Message{Role: RoleUser, Content: content}
+	return Message{Role: RoleUser, Content: content, CreatedAt: time.Now()}
 }
 
-// NewAssistantMessage constructs a Message with RoleAssistant.
-// If content is empty, it falls back to a non-empty placeholder so the
-// message is valid for providers (Anthropic rejects empty assistant content).
+// NewAssistantMessage constructs a Message with RoleAssistant and a current
+// timestamp. If content is empty, it falls back to a non-empty placeholder so
+// the message is valid for providers (Anthropic rejects empty assistant content).
 func NewAssistantMessage(content string) Message {
 	if content == "" {
 		content = "[no content]"
 	}
-	return Message{Role: RoleAssistant, Content: content}
+	return Message{Role: RoleAssistant, Content: content, CreatedAt: time.Now()}
 }
 
 // NewSystemMessage constructs a Message with RoleSystem.
@@ -51,7 +54,7 @@ func NewAssistantMessage(content string) Message {
 // rather than as a role within the messages array; the agent's provider
 // adapter is responsible for that translation.
 func NewSystemMessage(content string) Message {
-	return Message{Role: RoleSystem, Content: content}
+	return Message{Role: RoleSystem, Content: content, CreatedAt: time.Now()}
 }
 
 // NewToolUseMessage constructs an assistant Message whose content is a slice
@@ -59,7 +62,7 @@ func NewSystemMessage(content string) Message {
 // contains one or more tool_use blocks (and optionally a preceding text block
 // with the model's reasoning).
 func NewToolUseMessage(blocks []ContentBlock) Message {
-	return Message{Role: RoleAssistant, Blocks: blocks}
+	return Message{Role: RoleAssistant, Blocks: blocks, CreatedAt: time.Now()}
 }
 
 // NewToolResultMessage constructs a user Message that carries tool execution
@@ -67,5 +70,5 @@ func NewToolUseMessage(blocks []ContentBlock) Message {
 // block whose ToolUseID matches a tool_use block in the preceding assistant
 // message.
 func NewToolResultMessage(results []ContentBlock) Message {
-	return Message{Role: RoleUser, Blocks: results}
+	return Message{Role: RoleUser, Blocks: results, CreatedAt: time.Now()}
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -314,13 +314,22 @@ func (s *Server) handleGetSessionMessages(w http.ResponseWriter, r *http.Request
 	// For now we translate the persisted message list into user/assistant
 	// events; tool calls are not reconstructed from the transcript.
 	events := make([]map[string]any, 0, len(sess.Messages))
-	for _, m := range sess.Messages {
+	for i, m := range sess.Messages {
 		switch m.Role {
 		case agent.RoleUser:
+			// Use the message's own CreatedAt when available.  Older session
+			// files don't have per-message timestamps, so fall back to the
+			// array index as a unique cursor (not sess.CreatedAt — that
+			// collides with the Web UI's dedup logic and drops everything
+			// after the first user message).
+			createdAt := m.CreatedAt.Unix()
+			if m.CreatedAt.IsZero() {
+				createdAt = int64(i + 1)
+			}
 			events = append(events, map[string]any{
 				"type":       "history_user_message",
 				"content":    m.Content,
-				"created_at": sess.CreatedAt,
+				"created_at": createdAt,
 			})
 		case agent.RoleAssistant:
 			events = append(events, map[string]any{

--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -2,8 +2,8 @@ package tools
 
 import (
 	"context"
-	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -248,6 +248,11 @@ func TestTerminalInputTool_SendInput(t *testing.T) {
 	// Use a small Go program as the test subject so it works on every OS
 	// (Windows CI doesn't have head/sed). The program reads a line from
 	// stdin and prints it back with a prefix.
+	//
+	// We compile it first with "go build" and then run the binary directly.
+	// "go run" triggers a compilation on every launch; on Windows CI that
+	// takes 1-3 s, which is longer than the 200 ms sleep below, so the
+	// input arrives before the process is ready and is silently dropped.
 	tmpDir := t.TempDir()
 	prog := filepath.Join(tmpDir, "stdin_echo.go")
 	src := `package main
@@ -265,12 +270,21 @@ func main() {
 		t.Fatalf("write helper: %v", err)
 	}
 
-	id, err := mgr.Start(fmt.Sprintf("go run %s", prog))
+	bin := filepath.Join(tmpDir, "stdin_echo")
+	if os.PathSeparator == '\\' {
+		bin += ".exe"
+	}
+	buildOut, err := exec.Command("go", "build", "-o", bin, prog).CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build helper: %v\n%s", err, buildOut)
+	}
+
+	id, err := mgr.Start(bin)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
-	// Give the Go runtime a moment to start the program.
+	// Give the program a moment to start and open its stdin reader.
 	time.Sleep(200 * time.Millisecond)
 
 	// Send input including a newline so the scanner can proceed.


### PR DESCRIPTION
The WebUI deduplicates messages by `created_at`. The backend `handleGetSessionMessages` was setting every user message's `created_at` to `sess.CreatedAt`, so all but the first user message were silently dropped.

### Changes
- Add `CreatedAt time.Time` to `agent.Message` (persisted in JSONL)
- Set timestamps in all `New*Message` constructors
- Backend prefers `m.CreatedAt`, falls back to index for old files without per-message timestamps

### Before
Opening a session with multiple turns only showed the first 2 messages (1 user + 1 assistant). Remaining messages were dropped by dedup because all user messages shared the same `created_at`.

### After
All messages render correctly. Old sessions without per-message timestamps still work via fallback.