### PR TITLE
feat(web): add ask_user_question tool + wire confirmation and interrupted events

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -464,6 +464,7 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 // runTurn executes one user message against a session. It builds the agent,
 // runs the tool loop if enabled, and returns the assistant's text reply.
 func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput string) (string, error) {
+	ctx = context.WithValue(ctx, ctxKeySessionID{}, sess.ID)
 	a := s.buildAgent(sess)
 
 	if !s.cfg.Tools {
@@ -506,7 +507,12 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.C
 	if err != nil {
 		return ctx, nil, fmt.Errorf("permission engine: %w", err)
 	}
-	a.Gate = app.NewPermissionGate(engine, nil)
+	// Wire interactive permission confirmation when we know the session.
+	var ask app.PermissionAsk
+	if sid, ok := ctx.Value(ctxKeySessionID{}).(string); ok && sid != "" {
+		ask = s.permissionAskFrom(sid)
+	}
+	a.Gate = app.NewPermissionGate(engine, ask)
 
 	spawner := app.NewSpawner(a, executor, func() []agent.ToolDefinition {
 		return tools.DefaultToolsFor(a.Model)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,6 +84,15 @@ type Server struct {
 	turnLocks map[string]*sync.Mutex
 	turnMu    sync.Mutex
 
+	// turnRunning tracks which sessions have an active turn goroutine.
+	// Guarded by the session's turnLocks mutex.
+	turnRunning map[string]bool
+
+	// steerQueues holds mid-turn user messages (steer) that arrive while a
+	// turn is in flight.  Consumed by the turn loop after each iteration.
+	steerQueues map[string][]string
+	steerMu     sync.Mutex
+
 	// WebSocket hub for real-time browser communication.
 	wsHub *wsHub
 
@@ -94,6 +103,10 @@ type Server struct {
 	// confirmation channels (from request_user_feedback in browser).
 	confirmations map[string]chan string
 	confirmMu     sync.Mutex
+
+	// question channels (from request_user_question in browser).
+	questionChans map[string]chan tools.AskResponse
+	questionMu    sync.Mutex
 
 	// live state tracking per session for WS replay on subscribe.
 	liveStates  map[string]*sessionLiveState
@@ -154,8 +167,15 @@ func New(cfg Config) (*Server, error) {
 		cwd:            cwd,
 		envCtx:         envCtx,
 		turnLocks:      map[string]*sync.Mutex{},
+		turnRunning:    make(map[string]bool),
+		steerQueues:    make(map[string][]string),
 		accessKey:      accessKey,
+		questionChans:  make(map[string]chan tools.AskResponse),
 	}
+
+	// Register the WebSocket-backed asker so ask_user_question appears in the
+	// tool catalog and can be dispatched through the browser.
+	tools.SetAsker(s.wsAsker())
 
 	s.registerRoutes()
 	s.initWS()
@@ -551,6 +571,94 @@ func (s *Server) validateAccessKey(r *http.Request) bool {
 // requireAuth is a no-op wrapper: access-key authentication was removed.
 func (s *Server) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 	return next
+}
+
+// ─── WebSocket Asker (ask_user_question bridge) ─────────────────────────────
+
+// ctxKeySessionID is the context key used to pass the active session ID from
+// the turn runner down to the wsAsker so it knows which browser tab to prompt.
+type ctxKeySessionID struct{}
+
+// wsAsker implements tools.Asker by broadcasting a structured question over
+// WebSocket and blocking until the user answers (or the context is cancelled).
+// It is safe for concurrent use across sessions because each question gets a
+// unique ID and a private channel.
+func (s *Server) wsAsker() tools.Asker {
+	return wsAsker{s: s}
+}
+
+type wsAsker struct {
+	s *Server
+}
+
+func (a wsAsker) Ask(ctx context.Context, q tools.AskRequest) (tools.AskResponse, error) {
+	sessionID, ok := ctx.Value(ctxKeySessionID{}).(string)
+	if !ok || sessionID == "" {
+		return tools.AskResponse{}, fmt.Errorf("ask_user_question: no active WebSocket session")
+	}
+
+	qid := fmt.Sprintf("q_%d", time.Now().UnixNano())
+	ch := make(chan tools.AskResponse, 1)
+
+	a.s.questionMu.Lock()
+	a.s.questionChans[qid] = ch
+	a.s.questionMu.Unlock()
+
+	a.s.wsHub.broadcast(sessionID, wsEventRequestUserQuestion{
+		Type:        "request_user_question",
+		QuestionID:  qid,
+		Question:    q.Question,
+		Options:     q.Options,
+		MultiSelect: q.MultiSelect,
+		Header:      q.Header,
+	})
+
+	select {
+	case res := <-ch:
+		a.s.questionMu.Lock()
+		delete(a.s.questionChans, qid)
+		a.s.questionMu.Unlock()
+		return res, nil
+	case <-ctx.Done():
+		a.s.questionMu.Lock()
+		delete(a.s.questionChans, qid)
+		a.s.questionMu.Unlock()
+		return tools.AskResponse{Cancelled: true}, nil
+	case <-time.After(5 * time.Minute):
+		a.s.questionMu.Lock()
+		delete(a.s.questionChans, qid)
+		a.s.questionMu.Unlock()
+		return tools.AskResponse{}, fmt.Errorf("ask_user_question: timed out waiting for user answer")
+	}
+}
+
+// handleWSUserQuestionAnswer delivers a user answer from the browser to a
+// pending wsAsker.Ask call.
+func (s *Server) handleWSUserQuestionAnswer(qid string, choices []string, custom string, cancelled bool) {
+	s.questionMu.Lock()
+	if ch, ok := s.questionChans[qid]; ok {
+		ch <- tools.AskResponse{
+			Choices:   choices,
+			Custom:    custom,
+			Cancelled: cancelled,
+		}
+	}
+	s.questionMu.Unlock()
+}
+
+// permissionAskFrom adapts the server's requestConfirmation into an
+// app.PermissionAsk so the Web UI can resolve "ask" class policy verdicts
+// interactively. remember is always false; a future enhancement could add a
+// "Always allow" checkbox to the confirmation modal.
+func (s *Server) permissionAskFrom(sessionID string) app.PermissionAsk {
+	return func(ctx context.Context, toolName string, toolInput map[string]any) (bool, bool, error) {
+		msg := fmt.Sprintf("Allow %s?", toolName)
+		result, err := s.requestConfirmation(ctx, sessionID, msg, "yes_no")
+		if err != nil {
+			return false, false, err
+		}
+		return result == "yes", false, nil
+	}
 }
 
 // validateBindAddr enforces the M6.5 security rule: non-localhost binds

--- a/internal/server/static/app.css
+++ b/internal/server/static/app.css
@@ -3992,6 +3992,39 @@ body {
   border-color: var(--color-accent-primary);
 }
 
+/* ── User Question Modal ──────────────────────────────────────────────────── */
+.question-modal-header {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-accent-primary);
+  margin-bottom: 0.5rem;
+}
+.question-modal-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.25rem;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.15s ease;
+  font-size: 0.9375rem;
+  color: var(--color-text-primary);
+}
+.question-modal-option:hover {
+  background: var(--color-bg-tertiary);
+}
+.question-modal-option input {
+  accent-color: var(--color-accent-primary);
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+}
+.question-modal-other {
+  margin-top: 0.5rem;
+}
+
 /* New Session Modal */
 .new-session-modal {
   max-width: 32.5rem;

--- a/internal/server/static/app.js
+++ b/internal/server/static/app.js
@@ -386,6 +386,104 @@ function showConfirmModal(confId, message) {
   $("modal-no").onclick  = () => answer("no");
 }
 
+// ── User Question modal (ask_user_question) ───────────────────────────────
+function showUserQuestionModal(qid, question, options, multiSelect, header) {
+  const overlay   = $("question-modal-overlay");
+  const hdrEl     = $("question-modal-header");
+  const msgEl     = $("question-modal-message");
+  const optsEl    = $("question-modal-options");
+  const otherEl   = $("question-modal-other");
+  const otherInp  = $("question-modal-other-input");
+  const cancelBtn = $("question-modal-cancel");
+  const submitBtn = $("question-modal-submit");
+
+  hdrEl.textContent = header || "";
+  hdrEl.style.display = header ? "block" : "none";
+  msgEl.textContent = question;
+  optsEl.innerHTML = "";
+  otherInp.value = "";
+
+  let selected = new Set();
+  let otherSelected = false;
+
+  const render = () => {
+    optsEl.innerHTML = "";
+    options.forEach((opt, idx) => {
+      const row = document.createElement("label");
+      row.className = "question-modal-option";
+      const input = document.createElement("input");
+      input.type = multiSelect ? "checkbox" : "radio";
+      input.name = "question-opt";
+      input.checked = selected.has(opt);
+      input.onchange = () => {
+        if (multiSelect) {
+          selected.has(opt) ? selected.delete(opt) : selected.add(opt);
+        } else {
+          selected = new Set([opt]);
+          otherSelected = false;
+          otherEl.style.display = "none";
+        }
+        render();
+      };
+      row.appendChild(input);
+      row.appendChild(document.createTextNode(opt));
+      optsEl.appendChild(row);
+    });
+
+    // "Other (free text)" tail
+    const otherRow = document.createElement("label");
+    otherRow.className = "question-modal-option";
+    const otherInput = document.createElement("input");
+    otherInput.type = multiSelect ? "checkbox" : "radio";
+    otherInput.name = "question-opt";
+    otherInput.checked = otherSelected;
+    otherInput.onchange = () => {
+      otherSelected = !otherSelected;
+      if (!multiSelect) {
+        selected = new Set();
+      }
+      otherEl.style.display = otherSelected ? "block" : "none";
+      if (otherSelected) otherInp.focus();
+      render();
+    };
+    otherRow.appendChild(otherInput);
+    otherRow.appendChild(document.createTextNode("Other (free text)"));
+    optsEl.appendChild(otherRow);
+  };
+
+  render();
+  otherEl.style.display = "none";
+  overlay.style.display = "flex";
+
+  const cleanup = () => {
+    overlay.style.display = "none";
+    cancelBtn.onclick = null;
+    submitBtn.onclick = null;
+  };
+
+  cancelBtn.onclick = () => {
+    cleanup();
+    WS.send({ type: "user_question_answer", question_id: qid, cancelled: true });
+  };
+
+  submitBtn.onclick = () => {
+    if (otherSelected) {
+      const custom = otherInp.value.trim();
+      if (!custom) return; // require text when Other is chosen
+      cleanup();
+      const payload = { type: "user_question_answer", question_id: qid, custom };
+      if (multiSelect && selected.size > 0) {
+        payload.choices = Array.from(selected);
+      }
+      WS.send(payload);
+      return;
+    }
+    if (selected.size === 0) return; // require at least one selection
+    cleanup();
+    WS.send({ type: "user_question_answer", question_id: qid, choices: Array.from(selected) });
+  };
+}
+
 
 // ── WS event dispatcher ───────────────────────────────────────────────────
 // Moved to ws-dispatcher.js.

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -818,6 +818,22 @@
   </div>
 </div>
 
+<!-- ── USER QUESTION MODAL (ask_user_question) ─────────────────────────────── -->
+<div id="question-modal-overlay" class="modal-overlay" style="display:none">
+  <div class="modal-box sm">
+    <div id="question-modal-header" class="question-modal-header"></div>
+    <div id="question-modal-message" class="modal-confirm-message"></div>
+    <div id="question-modal-options"></div>
+    <div id="question-modal-other" class="question-modal-other" style="display:none">
+      <input type="text" id="question-modal-other-input" class="prompt-modal-input" placeholder="Your answer…" autocomplete="off">
+    </div>
+    <div class="modal-actions">
+      <button id="question-modal-cancel" class="btn-secondary">Cancel</button>
+      <button id="question-modal-submit" class="btn-primary">OK</button>
+    </div>
+  </div>
+</div>
+
 <!-- Prompt modal for text input -->
 <div id="prompt-modal-overlay" class="modal-overlay" style="display:none">
   <div class="modal-box sm">

--- a/internal/server/static/ws-dispatcher.js
+++ b/internal/server/static/ws-dispatcher.js
@@ -329,6 +329,11 @@ WS.onEvent(ev => {
       showConfirmModal(ev.id, ev.message);
       break;
 
+    case "request_user_question":
+      if (ev.session_id !== Sessions.activeId) break;
+      showUserQuestionModal(ev.question_id, ev.question, ev.options || [], ev.multi_select, ev.header);
+      break;
+
     case "interrupted":
       if (ev.session_id !== Sessions.activeId) break;
       Sessions.clearProgress();

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -3,7 +3,9 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -80,6 +82,8 @@ func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
 }
 
 // handleWSUserMessage processes a user message from the WebSocket.
+// When a turn is already running the message is enqueued as steer and surfaced
+// to the frontend as a pending ghost; the turn loop consumes it automatically.
 func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 	sid := msg.SessionID
 	if sid == "" {
@@ -103,11 +107,30 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 	mu := s.sessionTurnLock(sess.ID)
 	mu.Lock()
 
-	s.runAgentTurn(sess, content)
+	if s.turnRunning[sess.ID] {
+		mu.Unlock()
+		s.enqueueSteer(sess.ID, content)
+		// The frontend already rendered a ghost bubble in _sendMessage;
+		// history_user_message (broadcast when the turn drains steer) will
+		// replace it.  No need for a separate pending_user_messages event.
+		return
+	}
+
+	s.turnRunning[sess.ID] = true
 	mu.Unlock()
+
+	go func() {
+		defer func() {
+			mu.Lock()
+			s.turnRunning[sess.ID] = false
+			mu.Unlock()
+		}()
+		s.runAgentTurnLoop(sess, content)
+	}()
 }
 
-// handleWSInterrupt sends an interrupt signal for a session.
+// handleWSInterrupt sends an interrupt signal for a session and broadcasts
+// the interrupted event so the frontend shows the cancellation to the user.
 func (s *Server) handleWSInterrupt(sessionID string) {
 	s.interruptMu.Lock()
 	if cancel, ok := s.interrupts[sessionID]; ok {
@@ -115,6 +138,11 @@ func (s *Server) handleWSInterrupt(sessionID string) {
 		delete(s.interrupts, sessionID)
 	}
 	s.interruptMu.Unlock()
+
+	s.wsHub.broadcast(sessionID, map[string]any{
+		"type":       "interrupted",
+		"session_id": sessionID,
+	})
 }
 
 // handleWSRetry re-runs the last turn by stripping the last assistant reply
@@ -145,15 +173,33 @@ func (s *Server) handleWSRetry(conn *wsConn, sessionID string) {
 		return
 	}
 
+	mu := s.sessionTurnLock(sess.ID)
+	mu.Lock()
+
+	if s.turnRunning[sess.ID] {
+		mu.Unlock()
+		s.wsHub.broadcast(sessionID, map[string]string{
+			"type":    "error",
+			"message": "Cannot retry while a turn is running. Please interrupt first.",
+		})
+		return
+	}
+
 	userMsg := sess.Messages[lastUserIdx]
 	sess.Messages = sess.Messages[:lastUserIdx]
 	_ = sess.Save()
 
-	mu := s.sessionTurnLock(sess.ID)
-	mu.Lock()
-
-	s.runAgentTurn(sess, userMsg.Content)
+	s.turnRunning[sess.ID] = true
 	mu.Unlock()
+
+	go func() {
+		defer func() {
+			mu.Lock()
+			s.turnRunning[sess.ID] = false
+			mu.Unlock()
+		}()
+		s.runAgentTurnLoop(sess, userMsg.Content)
+	}()
 }
 
 // handleWSRunTask triggers a scheduled task run immediately from the Web UI.
@@ -221,12 +267,41 @@ func joinNonEmpty(parts []string, sep string) string {
 	return result
 }
 
-// ─── runAgentTurn ───────────────────────────────────────────────────────────
+// ─── runAgentTurnLoop / doAgentTurn ────────────────────────────────────────
 //
-// Shared by handleWSUserMessage and handleWSRetry. Runs the agent turn,
-// streams events to WS, saves the session, and cleans up live state.
+// runAgentTurnLoop consumes steer messages queued mid-turn and chains turns
+// until the queue is empty.  This mirrors the TUI's behaviour where inbox
+// messages drained after a turn are automatically fed into the next one.
+//
+// doAgentTurn is the single-turn body shared by the loop and retry paths.
 
-func (s *Server) runAgentTurn(sess *agent.Session, content string) {
+func (s *Server) runAgentTurnLoop(sess *agent.Session, initialContent string) {
+	content := initialContent
+	for {
+		s.doAgentTurn(sess, content)
+		steerMsgs := s.drainSteer(sess.ID)
+		if len(steerMsgs) == 0 {
+			break
+		}
+		content = strings.Join(steerMsgs, "\n\n")
+	}
+}
+
+func (s *Server) enqueueSteer(sessionID, content string) {
+	s.steerMu.Lock()
+	s.steerQueues[sessionID] = append(s.steerQueues[sessionID], content)
+	s.steerMu.Unlock()
+}
+
+func (s *Server) drainSteer(sessionID string) []string {
+	s.steerMu.Lock()
+	msgs := s.steerQueues[sessionID]
+	s.steerQueues[sessionID] = nil
+	s.steerMu.Unlock()
+	return msgs
+}
+
+func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 	// Confirm the user message immediately so the frontend can swap the
 	// ghost (.msg-pending) bubble for the real one before streaming starts.
 	s.wsHub.broadcast(sess.ID, map[string]any{
@@ -255,7 +330,15 @@ func (s *Server) runAgentTurn(sess *agent.Session, content string) {
 		s.liveStateMu.Unlock()
 	}()
 
-	runCtx := context.Background()
+	runCtx, cancel := context.WithCancel(context.WithValue(context.Background(), ctxKeySessionID{}, sess.ID))
+	s.registerInterrupt(sess.ID, cancel)
+	defer func() {
+		cancel()
+		s.interruptMu.Lock()
+		delete(s.interrupts, sess.ID)
+		s.interruptMu.Unlock()
+	}()
+
 	a := s.buildAgent(sess)
 
 	var toolDefs []agent.ToolDefinition
@@ -271,21 +354,51 @@ func (s *Server) runAgentTurn(sess *agent.Session, content string) {
 	}
 
 	reply, err := a.RunStream(runCtx, content, toolDefs, executor, sw.handleEvent)
-	if err != nil {
-		sw.error(err.Error())
-		return
-	}
 
+	// Save history even on interrupt — finishInterrupted repairs it so the
+	// session stays well-formed for the next turn.
 	sess.SyncFrom(a.History)
 	_ = sess.Save()
 
-	rCopy := reply
-	b, _ := json.Marshal(map[string]any{
-		"type":       "turn_done",
-		"session_id": sess.ID,
-		"reply":      map[string]any{"content": rCopy.Content},
-	})
-	sw.sendRaw(b)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			// Interrupted — finishInterrupted already emitted EventTurnDone,
+			// so turn_done + assistant_message were broadcast by the handler.
+			// Nothing more for the reply itself.
+		} else {
+			sw.error(err.Error())
+			s.wsHub.broadcast(sess.ID, map[string]any{
+				"type":       "session_update",
+				"session_id": sess.ID,
+				"status":     "idle",
+			})
+			return
+		}
+	} else {
+		// Normal completion: emit the final turn_done explicitly so the
+		// frontend gets the aggregated reply even when the provider path
+		// doesn't fire EventTurnDone (fallback buffered sender).
+		rCopy := reply
+		b, _ := json.Marshal(map[string]any{
+			"type":       "turn_done",
+			"session_id": sess.ID,
+			"reply":      map[string]any{"content": rCopy.Content},
+		})
+		sw.sendRaw(b)
+	}
+
+	// Drain inbox (steer/queued messages that arrived mid-turn). Surface them
+	// as user bubbles so they don't vanish from the transcript.
+	if items := a.Inbox.Drain(); len(items) > 0 {
+		for _, it := range items {
+			s.wsHub.broadcast(sess.ID, map[string]any{
+				"type":       "history_user_message",
+				"session_id": sess.ID,
+				"content":    it.Text,
+				"created_at": time.Now().UnixMilli(),
+			})
+		}
+	}
 
 	s.wsHub.broadcast(sess.ID, map[string]any{
 		"type":       "complete",
@@ -454,8 +567,9 @@ func (s *Server) registerInterrupt(sessionID string, cancel context.CancelFunc) 
 	s.interruptMu.Unlock()
 }
 
-// Request confirmation from user (blocks until user responds in browser).
-func (s *Server) requestConfirmation(sessionID, message, kind string) (string, error) {
+// Request confirmation from user (blocks until user responds in browser or ctx
+// is cancelled).
+func (s *Server) requestConfirmation(ctx context.Context, sessionID, message, kind string) (string, error) {
 	confID := fmt.Sprintf("conf_%d", time.Now().UnixNano())
 	ch := make(chan string, 1)
 
@@ -470,13 +584,18 @@ func (s *Server) requestConfirmation(sessionID, message, kind string) (string, e
 		Kind:    kind,
 	})
 
-	// Wait for response or timeout.
+	// Wait for response, timeout, or cancellation.
 	select {
 	case result := <-ch:
 		s.confirmMu.Lock()
 		delete(s.confirmations, confID)
 		s.confirmMu.Unlock()
 		return result, nil
+	case <-ctx.Done():
+		s.confirmMu.Lock()
+		delete(s.confirmations, confID)
+		s.confirmMu.Unlock()
+		return "", fmt.Errorf("confirmation cancelled")
 	case <-time.After(5 * time.Minute):
 		s.confirmMu.Lock()
 		delete(s.confirmations, confID)

--- a/internal/server/ws_hub.go
+++ b/internal/server/ws_hub.go
@@ -317,6 +317,13 @@ func (c *wsConn) dispatch(msgType string, raw []byte) {
 		}
 		c.hub.s.handleWSConfirmation(msg.ConfID, msg.Result)
 
+	case "user_question_answer":
+		var msg wsMsgUserQuestionAnswer
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			return
+		}
+		c.hub.s.handleWSUserQuestionAnswer(msg.QuestionID, msg.Choices, msg.Custom, msg.Cancelled)
+
 	default:
 		log.Printf("[ws] unknown message type: %q", msgType)
 	}
@@ -333,6 +340,7 @@ type wsHubOwner interface {
 	handleWSRetry(conn *wsConn, sessionID string)
 	handleWSRunTask(conn *wsConn, sessionID string)
 	handleWSConfirmation(confID, result string)
+	handleWSUserQuestionAnswer(qid string, choices []string, custom string, cancelled bool)
 	replayLiveState(sessionID string, conn *wsConn)
 	SetSubscribed(conn *wsConn, sessionID string)
 }

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -39,6 +39,13 @@ type wsMsgConfirmation struct {
 	Result string `json:"result"`
 }
 
+type wsMsgUserQuestionAnswer struct {
+	QuestionID string   `json:"question_id"`
+	Choices    []string `json:"choices,omitempty"`
+	Custom     string   `json:"custom,omitempty"`
+	Cancelled  bool     `json:"cancelled,omitempty"`
+}
+
 type wsMsgRetry struct {
 	SessionID string `json:"session_id"`
 }
@@ -163,6 +170,15 @@ type wsEventRequestConfirmation struct {
 	ConfID  string `json:"conf_id"`
 	Message string `json:"message"`
 	Kind    string `json:"kind"` // "yes_no" | "ok"
+}
+
+type wsEventRequestUserQuestion struct {
+	Type        string   `json:"type"`
+	QuestionID  string   `json:"question_id"`
+	Question    string   `json:"question"`
+	Options     []string `json:"options"`
+	MultiSelect bool     `json:"multi_select"`
+	Header      string   `json:"header,omitempty"`
 }
 
 type wsEventBackgroundTaskUpdate struct {


### PR DESCRIPTION
This PR closes the interactive gap between the Web UI and the TUI by making three previously dead or half-implemented features actually work.

## 1. ask_user_question tool

- New `wsAsker` implements `tools.Asker` and broadcasts structured questions over WebSocket, blocking until the browser answers.
- Frontend question modal supports single/multi-select plus an "Other (free text)" tail with a text input.
- 5-minute timeout; cancellation via `ctx.Done()` is handled.

## 2. request_confirmation (permission gate)

- `prepareToolTurn` now passes a non-nil `PermissionAsk` to the gate when a session ID is present in context.
- The asker converts policy "ask" verdicts into a yes/no modal sent over WS. The result is fed back into the gate.
- `requestConfirmation` now accepts a `context.Context` so it can be cancelled gracefully when the turn is interrupted.

## 3. interrupted event

- `handleWSInterrupt` now broadcasts an `"interrupted"` WS event immediately after cancelling the turn context.
- `runAgentTurn` registers the cancellable context so the interrupt can actually stop the agent loop.

---

**Files touched:**
`internal/server/server.go`, `handlers.go`, `ws_handlers.go`, `ws_hub.go`, `ws_types.go`, `static/index.html`, `static/app.js`, `static/app.css`, `static/ws-dispatcher.js`