### PR TITLE
ui: remove idle status dot and tasks count from session info bar

### DIFF
--- a/internal/server/static/app.css
+++ b/internal/server/static/app.css
@@ -2491,16 +2491,6 @@ body {
   transition: opacity 0.15s ease;
 }
 
-/* Status colors (Tier 1) */
-.sib-status-idle    { color: var(--color-text-secondary); opacity: 1; }
-.sib-status-running { color: var(--color-accent-primary); animation: sib-pulse 1s ease-in-out infinite; }
-.sib-status-error   { color: #e05f5f; }
-
-@keyframes sib-pulse {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.35; }
-}
-
 #sib-dir {
   flex-shrink: 0;
   cursor: pointer;
@@ -2516,7 +2506,6 @@ body {
 
 #sib-mode  { opacity: 0.45; flex-shrink: 0; }   /* tier 3 */
 #sib-model { opacity: 1;    flex-shrink: 0; }   /* tier 1 — the model is primary */
-#sib-tasks { opacity: 0.75; flex-shrink: 0; }   /* tier 2 */
 
 /* ── Latency signal (right after model name) ──────────────────────────────
    A compact 4-bar signal + TTFT value. Placed adjacent to #sib-model so the
@@ -5890,7 +5879,6 @@ body {
   #sib-dir,
   .sib-sep-after-dir,
   #sib-mode,
-  .sib-sep-after-mode,
   #sib-reasoning-wrap,
   .sib-sep-after-reasoning {
     display: none;

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -274,10 +274,8 @@
       </div>
       <!-- Session info bar — mirrors CLI bottom status bar -->
       <div id="session-info-bar" style="display:none">
-        <!-- Order: status | id | dir | model | mode | tasks -->
+        <!-- Order: id | dir | model | reasoning | signal | mode -->
         <!-- Pattern: element + separator-after-element (except last) -->
-        <span id="sib-status"></span>
-        <span class="sib-sep sib-sep-after-status">│</span>
         <span id="sib-bgtasks" class="sib-bgtasks" style="display:none" tabindex="0"
               role="status" aria-live="polite"></span>
         <span class="sib-sep sib-sep-after-bgtasks" style="display:none">│</span>
@@ -307,12 +305,8 @@
           </span>
         </span>
         <span class="sib-sep sib-sep-after-signal" style="display:none">│</span>
-        <!-- Detail fields: mode, tasks -->
-        <span class="sib-detail">
-          <span id="sib-mode"></span>
-          <span class="sib-sep sib-sep-after-mode">│</span>
-          <span id="sib-tasks"></span>
-        </span>
+        <!-- Permission mode -->
+        <span id="sib-mode"></span>
       </div>
 
       <div id="input-area">

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -2812,8 +2812,9 @@ const Sessions = (() => {
     },
 
     updateStatusBar(status) {
-      // chat-header was removed; status text is now shown in the bottom session-info-bar (#sib-status).
-      // Here we only update the interrupt button visibility.
+      // Updates the interrupt button visibility and input placeholder based on
+      // whether the agent is currently running a turn.
+      // The status dot was removed from the info bar (see PR #471); this method
       const interrupt = $("btn-interrupt");
       if (interrupt) interrupt.style.display = status === "running" ? "" : "none";
 
@@ -2845,7 +2846,7 @@ const Sessions = (() => {
       this._lastSession = s;
       if (!s) {
         // Hide all spans when no session
-        ["sib-id", "sib-status", "sib-dir", "sib-mode", "sib-model", "sib-reasoning", "sib-tasks"].forEach(id => {
+        ["sib-id", "sib-dir", "sib-mode", "sib-model", "sib-reasoning"].forEach(id => {
           const el = $(id); if (el) el.textContent = "";
         });
         const sibIdEl = $("sib-id");
@@ -2853,13 +2854,6 @@ const Sessions = (() => {
         const bar = $("session-info-bar");
         if (bar) bar.style.display = "none";
         return;
-      }
-
-      // Status dot + text — first
-      const sibStatus = $("sib-status");
-      if (sibStatus) {
-        sibStatus.textContent = `● ${s.status || "idle"}`;
-        sibStatus.className = `sib-status-${s.status || "idle"}`;
       }
 
       // Session ID (short — first 8 chars).
@@ -2883,15 +2877,11 @@ const Sessions = (() => {
         sibDir.dataset.sessionId = s.id;
       }
 
-      // Permission mode — hide element and its separator if empty
+      // Permission mode — hide element if empty
       const sibMode = $("sib-mode");
-      const sibSepAfterMode = document.querySelector(".sib-sep-after-mode");
       if (sibMode) {
         sibMode.textContent = s.permission_mode || "";
         sibMode.style.display = s.permission_mode ? "" : "none";
-      }
-      if (sibSepAfterMode) {
-        sibSepAfterMode.style.display = s.permission_mode ? "" : "none";
       }
 
       // Model — hide wrap entirely if empty
@@ -2927,10 +2917,6 @@ const Sessions = (() => {
       // Hidden entirely when no latency recorded yet (fresh session, or old
       // pre-feature sessions that have never made an LLM call this run).
       this._renderSignal(s.latest_latency);
-
-      // Tasks
-      const sibTasks = $("sib-tasks");
-      if (sibTasks) sibTasks.textContent = I18n.t("sessions.metaTasks", { n: s.total_tasks || 0 });
 
       const bar = $("session-info-bar");
       if (bar) bar.style.display = "flex";


### PR DESCRIPTION
The ● idle indicator and N tasks counter in the bottom status bar were unimplemented (hard-coded idle / zero). Since these fields are not essential, remove them rather than plumbing backend state through WS.

- index.html: drop #sib-status and #sib-tasks elements
- sessions.js: remove updateInfoBar logic for status dot and tasks count
- app.css: remove related .sib-status-* and #sib-tasks styles