### PR TITLE
feat(tui): show model name and reasoning effort in status bar

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -718,22 +718,24 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 
 		cfg := replConfig{
-			a:          a,
-			session:    sess,
-			noSave:     *noSave,
-			suggest:    suggestEnabled(*noSuggest),
-			plain:      *plain,
-			verbosity:  resolveVerbosity(*quietFlag, *verboseFlag),
-			stdin:      stdin,
-			stdout:     stdout,
-			stderr:     stderr,
-			skillReg:   skillReg,
-			memDir:     memDir,
-			reader:     replReader,          // shared with the asker / permission gate
-			view:       replView,            // same surface for turn render + Ask prompts
-			hooks:      hooks.LoadFromEnv(), // C9 Phase 3: external retrieval layer hooks
-			permEngine: permEngine,
-			mcpBoot:    mcpBoot, // nil unless tools on with servers configured
+			a:               a,
+			session:         sess,
+			noSave:          *noSave,
+			suggest:         suggestEnabled(*noSuggest),
+			plain:           *plain,
+			verbosity:       resolveVerbosity(*quietFlag, *verboseFlag),
+			stdin:           stdin,
+			stdout:          stdout,
+			stderr:          stderr,
+			skillReg:        skillReg,
+			memDir:          memDir,
+			reader:          replReader,          // shared with the asker / permission gate
+			view:            replView,            // same surface for turn render + Ask prompts
+			hooks:           hooks.LoadFromEnv(), // C9 Phase 3: external retrieval layer hooks
+			permEngine:      permEngine,
+			mcpBoot:         mcpBoot, // nil unless tools on with servers configured
+			modelName:       resolvedModel,
+			reasoningEffort: resolvedEffort,
 		}
 		if toolsOn {
 			// Built-ins only at first paint — the MCP registry is still nil
@@ -750,20 +752,22 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// One agentic turn, then exit. The session is ephemeral — one-shot runs are
 	// not persisted (resuming with -c stays a TUI affordance).
 	replCfg := replConfig{
-		a:          a,
-		session:    agent.NewSession(resolvedModel, *system),
-		noSave:     true,
-		plain:      *plain,
-		verbosity:  resolveVerbosity(*quietFlag, *verboseFlag),
-		stdin:      stdin,
-		stdout:     stdout,
-		stderr:     stderr,
-		skillReg:   skillReg,
-		memDir:     memDir,
-		reader:     replReader,
-		view:       replView,
-		hooks:      hooks.LoadFromEnv(),
-		permEngine: permEngine,
+		a:               a,
+		session:         agent.NewSession(resolvedModel, *system),
+		noSave:          true,
+		plain:           *plain,
+		verbosity:       resolveVerbosity(*quietFlag, *verboseFlag),
+		stdin:           stdin,
+		stdout:          stdout,
+		stderr:          stderr,
+		skillReg:        skillReg,
+		memDir:          memDir,
+		reader:          replReader,
+		view:            replView,
+		hooks:           hooks.LoadFromEnv(),
+		permEngine:      permEngine,
+		modelName:       resolvedModel,
+		reasoningEffort: resolvedEffort,
 	}
 	if toolsOn {
 		replCfg.tools = tools.DefaultToolsFor(resolvedModel)

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -54,6 +54,11 @@ type replConfig struct {
 	// the TUI path sets it; the headless one-shot connects synchronously
 	// (its single turn needs the full tool surface up front). nil → no MCP.
 	mcpBoot *mcpBootstrap
+	// modelName is the resolved model displayed in the TUI status bar.
+	modelName string
+	// reasoningEffort is the resolved reasoning level ("low" | "medium" | "high" | "")
+	// displayed in the TUI status bar; empty means off.
+	reasoningEffort string
 }
 
 // mcpBootstrap carries the inputs runTUI needs to connect MCP servers from a

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1052,11 +1052,17 @@ func (m *tuiModel) renderInputBox() string {
 	return m.ta.View()
 }
 
-// renderStatusBar renders the cwd / context% / permission / elapsed segments,
-// with a separator line above and the contextual key hint below (Claude Code
-// style).
+// renderStatusBar renders the model / thinking / cwd / context% / permission
+// segments, with a separator line above and the contextual key hint below
+// (Claude Code style).
 func (m *tuiModel) renderStatusBar() string {
 	var segs [][2]string
+	if m.cfg.modelName != "" {
+		segs = append(segs, [2]string{"model", m.cfg.modelName})
+	}
+	if m.cfg.reasoningEffort != "" {
+		segs = append(segs, [2]string{"think", m.cfg.reasoningEffort})
+	}
 	if m.cwd != "" {
 		segs = append(segs, [2]string{"cwd", m.cwd})
 	}
@@ -1073,7 +1079,7 @@ func (m *tuiModel) renderStatusBar() string {
 
 	// Key hints live in the startup banner, not here, and the running-turn
 	// duration is intentionally omitted — the status bar stays a compact
-	// cwd / context% / perm-mode strip.
+	// model / cwd / context% / perm-mode strip.
 	return tui.StatusBar(segs, "", m.width)
 }
 


### PR DESCRIPTION
Adds the resolved model name and reasoning-effort level to the TUI bottom status bar so users can see which model and thinking intensity are active at a glance.

### Changes
- `replConfig`: add `modelName` and `reasoningEffort` fields
- `chat.go`: wire resolved model + effort into both TUI and headless configs  
- `tuirepl_view.go`: prepend `model` and `think` segments to the status bar, using the existing brand-dim highlight for the model name

### Screenshot (conceptual)
```
claude-sonnet-4 · medium · ~/Projects/octo · ctx 12% · perm
```

- [x] `go vet ./...` passes
- [x] `go test -race ./cmd/octo/...` passes
- No new third-party dependencies