### PR TITLE
fix(web): compact tool_call cards, remove verbose JSON summary

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -351,17 +350,10 @@ func (s *Server) handleGetSessionMessages(w http.ResponseWriter, r *http.Request
 			// Emit tool_call events for any tool_use blocks.
 			for _, b := range m.Blocks {
 				if b.Type == "tool_use" {
-					inputJSON := ""
-					if b.Input != nil {
-						if jb, err := json.Marshal(b.Input); err == nil {
-							inputJSON = string(jb)
-						}
-					}
 					events = append(events, map[string]any{
-						"type":    "tool_call",
-						"name":    b.Name,
-						"args":    b.Input,
-						"summary": fmt.Sprintf("🔧 %s %s", b.Name, inputJSON),
+						"type": "tool_call",
+						"name": b.Name,
+						"args": b.Input,
 					})
 				}
 			}

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -1306,7 +1306,7 @@ const Sessions = (() => {
   function _summariseArgs(toolName, args) {
     if (!args || typeof args !== "object") return String(args || "");
     // Pick the most informative single field as a short summary
-    const pick = args.path || args.command || args.query || args.url ||
+    const pick = args.path || args.command || args.pattern || args.query || args.url ||
                  args.task || args.content || args.question || args.message;
     if (pick) return String(pick).slice(0, 80);
     // Fallback: first string value

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -457,23 +457,16 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 		})
 
 	case agent.EventToolStarted:
-		inputJSON := ""
-		if ev.Input != nil {
-			b, _ := json.Marshal(ev.Input)
-			inputJSON = string(b)
-		}
 		tc := wsEventToolCall{
-			Type:    "tool_call",
-			Name:    ev.ToolName,
-			Args:    ev.Input,
-			Summary: fmt.Sprintf("🔧 %s %s", ev.ToolName, inputJSON),
+			Type: "tool_call",
+			Name: ev.ToolName,
+			Args: ev.Input,
 		}
 		w.hub.broadcast(w.sessionID, map[string]any{
 			"type":       tc.Type,
 			"session_id": w.sessionID,
 			"name":       tc.Name,
 			"args":       tc.Args,
-			"summary":    tc.Summary,
 		})
 
 		// Track as live state for replay.


### PR DESCRIPTION
## 修复

Web 端 tool_call 消息卡片之前把完整 JSON 参数塞进 summary，导致一行巨长、没有截断、视觉混乱。

## 改动

- **ws_handlers.go**: 移除 WS  事件中的  字段（不再序列化完整 JSON）
- **handlers.go**: 移除 history API  事件中的  字段
- **sessions.js**:  增加  支持（grep 工具），前端自动提取关键参数并截断到 80 字符

## 效果

| 之前 | 之后 |
|------|------|
| ⚙ 🔧 grep {"mode":"files_with_matches","path":"...",...} | ⚙ grep /Users/qiao/Projects/octo-agent… |
| ⚙ 🔧 terminal {"command":"cd ... && gh pr view ..."} | ⚙ terminal cd /Users/… && gh pr view feat/… |

参数摘要走  样式（ + ），和 TUI 一样紧凑。