### PR TITLE
feat(tui): /model and /thinking slash commands

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -736,6 +736,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			mcpBoot:         mcpBoot, // nil unless tools on with servers configured
 			modelName:       resolvedModel,
 			reasoningEffort: resolvedEffort,
+			providerName:    provName,
 		}
 		if toolsOn {
 			// Built-ins only at first paint — the MCP registry is still nil
@@ -768,6 +769,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		permEngine:      permEngine,
 		modelName:       resolvedModel,
 		reasoningEffort: resolvedEffort,
+		providerName:    provName,
 	}
 	if toolsOn {
 		replCfg.tools = tools.DefaultToolsFor(resolvedModel)

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -59,6 +59,9 @@ type replConfig struct {
 	// reasoningEffort is the resolved reasoning level ("low" | "medium" | "high" | "")
 	// displayed in the TUI status bar; empty means off.
 	reasoningEffort string
+	// providerName is the resolved provider (e.g. "anthropic", "openai") used
+	// to rebuild the sender when the user switches model or thinking level.
+	providerName string
 }
 
 // mcpBootstrap carries the inputs runTUI needs to connect MCP servers from a

--- a/cmd/octo/tuirepl_completion.go
+++ b/cmd/octo/tuirepl_completion.go
@@ -19,6 +19,8 @@ const maxComplVisible = 10
 // order. Skills are appended after these by slashCandidates.
 var builtinSlashCommands = []complItem{
 	{"/help", "List commands and tools"},
+	{"/model", "Switch to another model"},
+	{"/thinking", "Set reasoning effort (off/low/medium/high)"},
 	{"/skills", "List discovered skills"},
 	{"/mcp", "List connected MCP servers"},
 	{"/memory", "Show cross-session memory"},

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -12,6 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/config"
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/tools"
 	"github.com/Leihb/octo-agent/internal/tui"
@@ -630,6 +631,10 @@ func (m *tuiModel) dispatchSlash(text string) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case "/conduct":
 		return m.dispatchConduct(strings.TrimSpace(strings.TrimPrefix(text, first)))
+	case "/model":
+		return m.dispatchModel(strings.TrimSpace(strings.TrimPrefix(text, first)))
+	case "/thinking":
+		return m.dispatchThinking(strings.TrimSpace(strings.TrimPrefix(text, first)))
 	case "/help", "/save", "/sessions", "/skills", "/memory", "/mcp":
 		var b bytes.Buffer
 		switch cmd {
@@ -657,6 +662,65 @@ func (m *tuiModel) dispatchSlash(text string) (tea.Model, tea.Cmd) {
 		// paths, regexes, and other /-prefixed messages reach the model.
 		return m, m.startTurn(text)
 	}
+}
+
+// dispatchModel handles "/model <name>" — switch the active model for the
+// current session. The provider stays the same; only the model identifier
+// changes, so the sender does not need rebuilding.
+func (m *tuiModel) dispatchModel(name string) (tea.Model, tea.Cmd) {
+	if name == "" {
+		m.println(errorStyle.Render("Usage: /model <model-name>"))
+		return m, nil
+	}
+	m.a.Model = name
+	m.cfg.modelName = name
+	// Tool surface may differ per model (e.g. vision vs non-vision).
+	if m.cfg.tools != nil {
+		m.cfg.tools = tools.DefaultToolsFor(name)
+	}
+	m.println(noticeStyle.Render(fmt.Sprintf("Model: %s", name)))
+	return m, nil
+}
+
+// dispatchThinking handles "/thinking <off|low|medium|high>" — change the
+// reasoning effort level. This rebuilds the sender because thinkingBudget and
+// reasoningEffort are set at construction time.
+func (m *tuiModel) dispatchThinking(level string) (tea.Model, tea.Cmd) {
+	level = strings.ToLower(level)
+	if level == "" {
+		level = "off"
+	}
+	if level != "off" && level != "low" && level != "medium" && level != "high" {
+		m.println(errorStyle.Render("Usage: /thinking off | low | medium | high"))
+		return m, nil
+	}
+
+	// Load current config to rebuild the sender with the new tuning.
+	cfg, _ := config.Load()
+	if m.cfg.providerName == "" {
+		m.println(errorStyle.Render("Provider not set — cannot rebuild sender"))
+		return m, nil
+	}
+
+	tuning := senderTuning{}
+	if level != "off" {
+		tuning.reasoningEffort = level
+		tuning.thinkingBudget = anthropicThinkingBudget(level)
+	}
+
+	newSender, err := buildSender(m.cfg.providerName, cfg, m.cfg.stderr, tuning)
+	if err != nil {
+		m.println(errorStyle.Render(fmt.Sprintf("Failed to rebuild sender: %v", err)))
+		return m, nil
+	}
+
+	m.a.Sender = newSender
+	m.cfg.reasoningEffort = level
+	if level == "off" {
+		level = "off"
+	}
+	m.println(noticeStyle.Render(fmt.Sprintf("Thinking: %s", level)))
+	return m, nil
 }
 
 func (m *tuiModel) interrupt() {

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -291,6 +291,8 @@
         <span class="sib-sep sib-sep-after-reasoning">│</span>
         <span id="sib-dir" data-i18n-title="sib.dir.tooltip" title="Click to change directory"></span>
         <span class="sib-sep sib-sep-after-dir">│</span>
+        <span id="sib-ctx"></span>
+        <span class="sib-sep sib-sep-after-ctx">│</span>
         <!-- Permission mode -->
         <span id="sib-mode"></span>
       </div>

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -274,17 +274,11 @@
       </div>
       <!-- Session info bar — mirrors CLI bottom status bar -->
       <div id="session-info-bar" style="display:none">
-        <!-- Order: id | dir | model | reasoning | signal | mode -->
+        <!-- Order: model | reasoning | dir | mode -->
         <!-- Pattern: element + separator-after-element (except last) -->
         <span id="sib-bgtasks" class="sib-bgtasks" style="display:none" tabindex="0"
               role="status" aria-live="polite"></span>
         <span class="sib-sep sib-sep-after-bgtasks" style="display:none">│</span>
-        <span id="sib-id-wrap">
-          <span id="sib-id"></span>
-        </span>
-        <span class="sib-sep sib-sep-after-id">│</span>
-        <span id="sib-dir" data-i18n-title="sib.dir.tooltip" title="Click to change directory"></span>
-        <span class="sib-sep sib-sep-after-dir">│</span>
         <span id="sib-model-wrap">
           <span id="sib-model" class="sib-model-clickable" data-i18n-title="sib.model.tooltip" title="Click to switch model"></span>
           <div id="sib-model-dropdown" class="sib-model-dropdown" style="display:none"></div>
@@ -295,16 +289,8 @@
           <div id="sib-reasoning-dropdown" class="sib-reasoning-dropdown" style="display:none" role="menu"></div>
         </span>
         <span class="sib-sep sib-sep-after-reasoning">│</span>
-        <!-- Latency signal: 4-bar signal + TTFT number. Hidden until the first LLM
-             call completes (see updateInfoBar / Sessions.renderSignalBars). Click
-             opens a mini benchmark panel (see Step 3/4 — not yet implemented). -->
-        <span id="sib-signal-wrap" style="display:none">
-          <span id="sib-signal" class="sib-signal-clickable" data-i18n-title="sib.signal.tooltip" title="Recent LLM latency">
-            <span class="sig-bars" aria-hidden="true"><i></i><i></i><i></i><i></i></span>
-            <span class="sig-text"></span>
-          </span>
-        </span>
-        <span class="sib-sep sib-sep-after-signal" style="display:none">│</span>
+        <span id="sib-dir" data-i18n-title="sib.dir.tooltip" title="Click to change directory"></span>
+        <span class="sib-sep sib-sep-after-dir">│</span>
         <!-- Permission mode -->
         <span id="sib-mode"></span>
       </div>

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -2851,42 +2851,12 @@ const Sessions = (() => {
       this._lastSession = s;
       if (!s) {
         // Hide all spans when no session
-        ["sib-id", "sib-dir", "sib-mode", "sib-model", "sib-reasoning"].forEach(id => {
+        ["sib-dir", "sib-mode", "sib-model", "sib-reasoning"].forEach(id => {
           const el = $(id); if (el) el.textContent = "";
         });
-        const sibIdEl = $("sib-id");
-        if (sibIdEl) delete sibIdEl.dataset.sessionId;
         const bar = $("session-info-bar");
         if (bar) bar.style.display = "none";
         return;
-      }
-
-      // Session ID (short — first 8 chars).
-      const sibId = $("sib-id");
-      if (sibId) {
-        sibId.textContent = s.id ? s.id.slice(0, 8) : "";
-        sibId.title = s.id || "";
-        if (s.id) {
-          sibId.dataset.sessionId = s.id;
-        } else {
-          delete sibId.dataset.sessionId;
-        }
-      }
-
-      // Working dir — show full path
-      const sibDir = $("sib-dir");
-      if (sibDir && s.working_dir) {
-        sibDir.textContent = s.working_dir;
-        sibDir.title = `${s.working_dir} (${I18n.t("sib.dir.tooltip")})`;
-        sibDir.dataset.workingDir = s.working_dir;
-        sibDir.dataset.sessionId = s.id;
-      }
-
-      // Permission mode — hide element if empty
-      const sibMode = $("sib-mode");
-      if (sibMode) {
-        sibMode.textContent = s.permission_mode || "";
-        sibMode.style.display = s.permission_mode ? "" : "none";
       }
 
       // Model — hide wrap entirely if empty
@@ -2904,6 +2874,7 @@ const Sessions = (() => {
       }
       if (sibModelWrap) sibModelWrap.style.display = s.model ? "" : "none";
 
+      // Reasoning effort
       const sibReasoning = $("sib-reasoning");
       const sibReasoningWrap = $("sib-reasoning-wrap");
       const sibSepAfterReasoning = document.querySelector(".sib-sep-after-reasoning");
@@ -2916,12 +2887,21 @@ const Sessions = (() => {
       if (sibReasoningWrap) sibReasoningWrap.style.display = "";
       if (sibSepAfterReasoning) sibSepAfterReasoning.style.display = "";
 
-      // Latency signal — read from s.latest_latency (populated by:
-      //   - HTTP /api/sessions → session_registry#list (from agent.latest_latency)
-      //   - WS session_update events patched by app.js
-      // Hidden entirely when no latency recorded yet (fresh session, or old
-      // pre-feature sessions that have never made an LLM call this run).
-      this._renderSignal(s.latest_latency);
+      // Working dir — show full path
+      const sibDir = $("sib-dir");
+      if (sibDir && s.working_dir) {
+        sibDir.textContent = s.working_dir;
+        sibDir.title = `${s.working_dir} (${I18n.t("sib.dir.tooltip")})`;
+        sibDir.dataset.workingDir = s.working_dir;
+        sibDir.dataset.sessionId = s.id;
+      }
+
+      // Permission mode — hide element if empty
+      const sibMode = $("sib-mode");
+      if (sibMode) {
+        sibMode.textContent = s.permission_mode || "";
+        sibMode.style.display = s.permission_mode ? "" : "none";
+      }
 
       const bar = $("session-info-bar");
       if (bar) bar.style.display = "flex";

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -2851,7 +2851,7 @@ const Sessions = (() => {
       this._lastSession = s;
       if (!s) {
         // Hide all spans when no session
-        ["sib-dir", "sib-mode", "sib-model", "sib-reasoning"].forEach(id => {
+        ["sib-dir", "sib-mode", "sib-model", "sib-reasoning", "sib-ctx"].forEach(id => {
           const el = $(id); if (el) el.textContent = "";
         });
         const bar = $("session-info-bar");
@@ -2894,6 +2894,18 @@ const Sessions = (() => {
         sibDir.title = `${s.working_dir} (${I18n.t("sib.dir.tooltip")})`;
         sibDir.dataset.workingDir = s.working_dir;
         sibDir.dataset.sessionId = s.id;
+      }
+
+      // Context usage — hide if 0 or missing
+      const sibCtx = $("sib-ctx");
+      const sibSepAfterCtx = document.querySelector(".sib-sep-after-ctx");
+      if (sibCtx) {
+        const ctxPct = s.context_usage || 0;
+        sibCtx.textContent = ctxPct > 0 ? `ctx ${ctxPct}%` : "";
+        sibCtx.style.display = ctxPct > 0 ? "" : "none";
+      }
+      if (sibSepAfterCtx) {
+        sibSepAfterCtx.style.display = (s.context_usage || 0) > 0 ? "" : "none";
       }
 
       // Permission mode — hide element if empty

--- a/internal/server/static/ws-dispatcher.js
+++ b/internal/server/static/ws-dispatcher.js
@@ -118,6 +118,7 @@ WS.onEvent(ev => {
         // Stored under latest_latency — same field name the HTTP /api/sessions
         // list returns, so updateInfoBar doesn't need to branch on the source.
         if (ev.latency !== undefined) patch.latest_latency = ev.latency;
+        if (ev.context_usage !== undefined) patch.context_usage = ev.context_usage;
       }
       if (!sid) break;
       Sessions.patch(sid, patch);

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -406,10 +406,19 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 		"iterations": 1,
 	})
 
+	used, window := a.ContextUsage()
+	ctxPct := 0
+	if window > 0 {
+		ctxPct = used * 100 / window
+		if ctxPct > 100 {
+			ctxPct = 100
+		}
+	}
 	s.wsHub.broadcast(sess.ID, map[string]any{
-		"type":       "session_update",
-		"session_id": sess.ID,
-		"status":     "idle",
+		"type":           "session_update",
+		"session_id":     sess.ID,
+		"status":         "idle",
+		"context_usage":  ctxPct,
 	})
 }
 

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -415,10 +415,10 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 		}
 	}
 	s.wsHub.broadcast(sess.ID, map[string]any{
-		"type":           "session_update",
-		"session_id":     sess.ID,
-		"status":         "idle",
-		"context_usage":  ctxPct,
+		"type":          "session_update",
+		"session_id":    sess.ID,
+		"status":        "idle",
+		"context_usage": ctxPct,
 	})
 }
 

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -142,10 +142,11 @@ type wsEventComplete struct {
 }
 
 type wsEventSessionUpdate struct {
-	Type    string  `json:"type"`
-	Status  string  `json:"status,omitempty"`
-	Tasks   int     `json:"tasks,omitempty"`
-	Latency float64 `json:"latency,omitempty"`
+	Type         string  `json:"type"`
+	Status       string  `json:"status,omitempty"`
+	Tasks        int     `json:"tasks,omitempty"`
+	Latency      float64 `json:"latency,omitempty"`
+	ContextUsage int     `json:"context_usage,omitempty"` // 0–100 context window %
 }
 
 type wsEventTodoUpdate struct {


### PR DESCRIPTION
Add two new slash commands to the TUI for switching model and reasoning effort on the fly, matching the Web UI dropdown menus.

### New commands
- `/model <name>` — switch the active model (updates agent.Model, status bar, and tool surface)
- `/thinking <off|low|medium|high>` — switch reasoning effort (rebuilds the sender with the new thinkingBudget/reasoningEffort tuning)

### Changes
- `replConfig`: add `providerName` field (needed to rebuild sender)
- `chat.go`: wire `providerName` into `replConfig`
- `builtinSlashCommands`: add `/model` and `/thinking` entries
- `dispatchSlash`: route to `dispatchModel` / `dispatchThinking`

- [x] `go vet ./...` passes
- [x] `go test -race ./cmd/octo/...` passes