### PR TITLE
feat(tui+web): status bar model/thinking + tool grouping fix

### DIFF
--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -1404,7 +1404,7 @@ const Sessions = (() => {
     const n    = body ? body.children.length : 0;
     // Only hide the body (collapse) when there are multiple tools with a visible header.
     // A single-tool group has no header, so we keep its body visible forever.
-    if (n > 1) group.classList.add("expanded");
+    if (n > 1) group.classList.remove("expanded");
   }
 
   // Render a single history event into a target container.
@@ -1479,10 +1479,10 @@ const Sessions = (() => {
       }
 
       case "assistant_message": {
-        // Collapse tool group before assistant reply
-        if (historyCtx.group) { _collapseToolGroup(historyCtx.group); historyCtx.group = null; }
         const content = (ev.content || "").trim();
         if (!content) break; // skip empty assistant messages
+        // Collapse tool group before assistant reply
+        if (historyCtx.group) { _collapseToolGroup(historyCtx.group); historyCtx.group = null; }
         const el = document.createElement("div");
         el.className = "msg msg-assistant";
         el.dataset.raw = content;
@@ -3169,6 +3169,9 @@ const Sessions = (() => {
     },
 
     appendMsg(type, html, { time } = {}) {
+      // Skip empty assistant messages — don't render an air bubble.
+      if (type === "assistant" && (!html || !html.trim())) return;
+
       // Starting a new assistant/user/info message: close any open tool group
       if (type !== "tool") Sessions.collapseToolGroup();
 
@@ -3178,9 +3181,6 @@ const Sessions = (() => {
       if (type === "error") {
         messages.querySelectorAll(".msg-error").forEach(el => el.remove());
       }
-
-      // Skip empty assistant messages — don't render an air bubble.
-      if (type === "assistant" && (!html || !html.trim())) return;
 
       const el = document.createElement("div");
       el.className = `msg msg-${type}`;

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -415,10 +415,10 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 		}
 	}
 	s.wsHub.broadcast(sess.ID, map[string]any{
-		"type":           "session_update",
-		"session_id":     sess.ID,
-		"status":         "idle",
-		"context_usage":  ctxPct,
+		"type":          "session_update",
+		"session_id":    sess.ID,
+		"status":        "idle",
+		"context_usage": ctxPct,
 	})
 }
 

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -415,10 +415,10 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 		}
 	}
 	s.wsHub.broadcast(sess.ID, map[string]any{
-		"type":          "session_update",
-		"session_id":    sess.ID,
-		"status":        "idle",
-		"context_usage": ctxPct,
+		"type":           "session_update",
+		"session_id":     sess.ID,
+		"status":         "idle",
+		"context_usage":  ctxPct,
 	})
 }
 


### PR DESCRIPTION
## Changes

### TUI
- Add /model and /thinking slash commands

### Web UI
- Align status bar order with TUI — model first, remove id/signal
- Add context usage % to status bar
- Strip verbose JSON from tool_call summary
- Reconstruct tool_call/tool_result from session blocks
- **Fix: consecutive tool_use grouping and group collapse**
  - Empty assistant messages no longer close the active tool group
  - _collapseToolGroup() was adding 'expanded' instead of removing it

Co-authored-by: octo-agent <no-reply@octo-agent.dev>