### PR TITLE
feat(tui): render terminal_output/kill_shell/terminal_input as rich cards

### DIFF
--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/tools"
@@ -21,6 +22,12 @@ func cardVerbFor(toolName string) string {
 		return "Update"
 	case "terminal":
 		return "Run"
+	case "terminal_output":
+		return "Check"
+	case "kill_shell":
+		return "Kill"
+	case "terminal_input":
+		return "Input"
 	case "grep":
 		return "Grep"
 	case "web_search":
@@ -44,6 +51,13 @@ func cardTargetFor(toolName string, input map[string]any) string {
 	switch toolName {
 	case "terminal":
 		key = "command"
+	case "terminal_output", "kill_shell", "terminal_input":
+		if id, ok := input["id"].(string); ok && id != "" {
+			if cmd, found := tools.BgCommand(id); found && cmd != "" {
+				return fmt.Sprintf("%s (%s)", id, truncate1Line(cmd))
+			}
+			return id
+		}
 	case "grep", "glob":
 		key = "pattern"
 	case "web_search":
@@ -87,6 +101,11 @@ func renderToolCard(toolName string, input map[string]any, output string, isErr 
 		// instruction appended after a blank line. It's noise for the human, so
 		// drop it from the card — the "Started background process N" line stays.
 		output = strings.TrimRight(strings.TrimSuffix(output, tools.BgPollNotice), "\n")
+	}
+	if toolName == "terminal_output" {
+		// terminal_output can carry a model-only "STOP POLLING" notice when the
+		// process is still running with no new output. Strip it from the card.
+		output = strings.TrimRight(strings.TrimSuffix(output, tools.TerminalOutputStopPolling), "\n")
 	}
 	if toolName == "write_file" {
 		// write_file's own output is already a human-readable summary

--- a/cmd/octo/toolcards_test.go
+++ b/cmd/octo/toolcards_test.go
@@ -3,19 +3,25 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/Leihb/octo-agent/internal/tools"
 )
 
 func TestCardVerbFor(t *testing.T) {
 	cases := map[string]string{
-		"edit_file":  "Update",
-		"terminal":   "Run",
-		"grep":       "Grep",
-		"web_search": "Search",
-		"glob":       "Glob",
-		"read_file":  "Read",
-		"web_fetch":  "Fetch",
-		"sub_agent":  "", // not a card tool → one-liner
-		"remember":   "",
+		"edit_file":       "Update",
+		"terminal":        "Run",
+		"terminal_output": "Check",
+		"kill_shell":      "Kill",
+		"terminal_input":  "Input",
+		"grep":            "Grep",
+		"web_search":      "Search",
+		"glob":            "Glob",
+		"read_file":       "Read",
+		"write_file":      "Write",
+		"web_fetch":       "Fetch",
+		"sub_agent":       "", // not a card tool → one-liner
+		"remember":        "",
 	}
 	for tool, want := range cases {
 		if got := cardVerbFor(tool); got != want {
@@ -58,6 +64,13 @@ func TestRenderToolCard_Dispatch(t *testing.T) {
 		t.Errorf("terminal should render an output card; got:\n%s", run)
 	}
 
+	// terminal_output strips the STOP POLLING notice.
+	pollOut := "[status: running]\n(no new output)\n\n" + tools.TerminalOutputStopPolling
+	check := renderToolCard("terminal_output", map[string]any{"id": "bg_1"}, pollOut, false)
+	if strings.Contains(check, "STOP POLLING") {
+		t.Errorf("terminal_output card should strip STOP POLLING; got:\n%s", check)
+	}
+
 	// non-card tool → "".
 	if got := renderToolCard("sub_agent", map[string]any{}, "x", false); got != "" {
 		t.Errorf("non-card tool should return \"\"; got %q", got)
@@ -72,6 +85,10 @@ func TestRendersCard_PlainDisablesCards(t *testing.T) {
 	plainOn := &tuiModel{cfg: replConfig{plain: true}}
 	if plainOn.rendersCard("edit_file") {
 		t.Error("with --plain on, no tool should render as a card")
+	}
+	// terminal_output is now a card tool.
+	if !plainOff.rendersCard("terminal_output") {
+		t.Error("with --plain off, terminal_output should render as a card")
 	}
 	// A non-card tool is never a card regardless of --plain.
 	if plainOff.rendersCard("sub_agent") {

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -381,6 +381,18 @@ func (m *BackgroundManager) WriteStdin(id string, input string) error {
 	return err
 }
 
+// Command returns the original command string for a background process id,
+// or ("", false) if the id is unknown or has been removed.
+func (m *BackgroundManager) Command(id string) (string, bool) {
+	m.mu.Lock()
+	p := m.procs[id]
+	m.mu.Unlock()
+	if p == nil {
+		return "", false
+	}
+	return p.command, true
+}
+
 // Remove drops a process from the tracking map, releasing its retained output
 // buffer. Used by the synchronous terminal path to reap a hidden command once
 // it has exited and its output has been returned to the caller — otherwise
@@ -426,3 +438,7 @@ func SetBackgroundOnExit(fn func(BgExit)) { defaultBg.SetOnExit(fn) }
 // RunningBackground lists the still-running processes on the default manager,
 // for the TUI's live "background (N running)" panel.
 func RunningBackground() []BgInfo { return defaultBg.ListRunning() }
+
+// BgCommand returns the original command string for a background process id
+// on the default manager, or ("", false) if unknown.
+func BgCommand(id string) (string, bool) { return defaultBg.Command(id) }

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -29,6 +29,11 @@ const BgPollNotice = "DO NOT poll terminal_output. The system will automatically
 // terminal_output.
 const ServiceModeNotice = "After launching a long-running service, verify it with an external check (e.g., `curl http://localhost:PORT` or `pgrep`) rather than polling terminal_output. terminal_output is for inspecting startup logs or diagnosing issues — do not call it in a tight loop."
 
+// TerminalOutputStopPolling is the model-facing instruction appended to a
+// terminal_output result when the process is still running with no new output.
+// Like BgPollNotice, it is noise for the human so the TUI strips it from cards.
+const TerminalOutputStopPolling = "STOP POLLING. The system will automatically notify you when this background process finishes. Do NOT call terminal_output again unless you need to check progress mid-run."
+
 // TerminalTool is an agent.ToolExecutor that runs shell commands through the
 // system shell (`sh -c` on macOS/Linux, PowerShell on Windows; see
 // shellCommand). Stdout and stderr are combined and returned as the tool
@@ -259,7 +264,7 @@ func (t TerminalOutputTool) Execute(_ context.Context, _ string, input map[strin
 	header := "[status: " + status + "]"
 	if out == "" {
 		if status == "running" {
-			return agent.ToolResult{Text: header + "\n(no new output)\n\nSTOP POLLING. The system will automatically notify you when this background process finishes. Do NOT call terminal_output again unless you need to check progress mid-run."}, nil
+			return agent.ToolResult{Text: header + "\n(no new output)\n\n" + TerminalOutputStopPolling}, nil
 		}
 		return agent.ToolResult{Text: header + "\n(no new output)"}, nil
 	}


### PR DESCRIPTION
## Motivation

Currently, `terminal_output` is not a card tool. The TUI renders it as a terse one-liner that shows only the background process id, e.g.:

> terminal_output bg_58 ...

This gives the user zero context about what command `bg_58` was actually running, which is especially unhelpful when multiple background processes are active.

## What changed

- **Card rendering for background management tools**
  - `terminal_output` → verb `Check`
  - `kill_shell` → verb `Kill`
  - `terminal_input` → verb `Input`

- **Resolve bg id to its original command**
  - Added `BackgroundManager.Command(id)` and convenience `BgCommand(id)`.
  - `cardTargetFor` now looks up the original command string for these tools, so the card header shows:
    > Check(bg_58 (gh pr checks 477...))
    instead of just:
    > Check(bg_58)

- **Strip model-only noise from cards**
  - Extracted the inline `STOP POLLING` notice into an exported constant `TerminalOutputStopPolling`, consistent with how `BgPollNotice` is already stripped from `terminal` cards.

- **Tests**
  - Added coverage for new verbs, STOP POLLING stripping, and the `rendersCard` check.

## Effect

| Before | After |
|--------|-------|
| terminal_output bg_58 ... | Check(bg_58 (gh pr checks 477...)) |
| | │ [status: running] |
| | │ (no new output) |

## Verification

`make test` (`go test -race ./...`) passes.
