### PR TITLE
fix(web): expose working_dir/permission_mode/reasoning_effort/context_usage in status bar

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -40,19 +40,23 @@ type turnRequest struct {
 // sessionItem is the shape the Web UI expects for each session in listings
 // and after creation. It is a superset of the raw agent.Session fields.
 type sessionItem struct {
-	ID           string    `json:"id"`
-	Name         string    `json:"name"`
-	Title        string    `json:"title"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
-	Model        string    `json:"model"`
-	ModelID      string    `json:"model_id,omitempty"`
-	Status       string    `json:"status"`
-	Source       string    `json:"source"`
-	AgentProfile string    `json:"agent_profile"`
-	Pinned       bool      `json:"pinned"`
-	TotalTasks   int       `json:"total_tasks"`
-	TurnCount    int       `json:"turn_count"`
+	ID              string    `json:"id"`
+	Name            string    `json:"name"`
+	Title           string    `json:"title"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+	Model           string    `json:"model"`
+	ModelID         string    `json:"model_id,omitempty"`
+	Status          string    `json:"status"`
+	Source          string    `json:"source"`
+	AgentProfile    string    `json:"agent_profile"`
+	Pinned          bool      `json:"pinned"`
+	TotalTasks      int       `json:"total_tasks"`
+	TurnCount       int       `json:"turn_count"`
+	WorkingDir      string    `json:"working_dir,omitempty"`
+	PermissionMode  string    `json:"permission_mode,omitempty"`
+	ReasoningEffort string    `json:"reasoning_effort,omitempty"`
+	ContextUsage    int       `json:"context_usage,omitempty"`
 }
 
 type sessionDetail struct {
@@ -78,7 +82,7 @@ type sessionCreateRequest struct {
 }
 
 // toSessionItem builds a frontend-friendly session descriptor.
-func toSessionItem(s *agent.Session, source, agentProfile string) sessionItem {
+func (srv *Server) toSessionItem(s *agent.Session, source, agentProfile string) sessionItem {
 	updated := s.CreatedAt
 	if p, err := s.SavePath(); err == nil {
 		if st, err := os.Stat(p); err == nil {
@@ -89,20 +93,38 @@ func toSessionItem(s *agent.Session, source, agentProfile string) sessionItem {
 	if name == "" {
 		name = s.DisplayTitle()
 	}
+	wd, pm, re, ctxUsage := srv.sessionStatusFields()
 	return sessionItem{
-		ID:           s.ID,
-		Name:         name,
-		Title:        s.Title,
-		CreatedAt:    s.CreatedAt,
-		UpdatedAt:    updated,
-		Model:        s.Model,
-		Status:       "idle",
-		Source:       source,
-		AgentProfile: agentProfile,
-		Pinned:       false,
-		TotalTasks:   0,
-		TurnCount:    s.TurnCount(),
+		ID:              s.ID,
+		Name:            name,
+		Title:           s.Title,
+		CreatedAt:       s.CreatedAt,
+		UpdatedAt:       updated,
+		Model:           s.Model,
+		Status:          "idle",
+		Source:          source,
+		AgentProfile:    agentProfile,
+		Pinned:          false,
+		TotalTasks:      0,
+		TurnCount:       s.TurnCount(),
+		WorkingDir:      wd,
+		PermissionMode:  pm,
+		ReasoningEffort: re,
+		ContextUsage:    ctxUsage,
 	}
+}
+
+// sessionStatusFields returns the server-level session metadata that is shared
+// across all sessions (cwd, permission mode, reasoning effort, current context
+// usage). The Web UI mirrors the CLI bottom status bar, so these values are
+// surfaced on every session descriptor.
+func (srv *Server) sessionStatusFields() (workingDir, permissionMode, reasoningEffort string, contextUsage int) {
+	workingDir = srv.cwd
+	permissionMode = string(resolvePermissionMode())
+	if cfg, err := config.Load(); err == nil {
+		reasoningEffort = cfg.ReasoningEffort
+	}
+	return workingDir, permissionMode, reasoningEffort, 0
 }
 
 type toolInfo struct {
@@ -237,7 +259,7 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 	for _, sess := range sessions {
 		// Source and agent_profile are not persisted on the session itself in
 		// the Go rewrite; default to "manual" / "general" so the UI renders.
-		item := toSessionItem(sess, "manual", "general")
+		item := s.toSessionItem(sess, "manual", "general")
 		out = append(out, item)
 		if item.Source == "cron" {
 			cronCount++
@@ -292,7 +314,7 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"session": toSessionItem(sess, source, agentProfile)})
+	writeJSON(w, http.StatusOK, map[string]any{"session": s.toSessionItem(sess, source, agentProfile)})
 }
 
 // ─── GET /api/sessions/:id/messages ─────────────────────────────────────────

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -2887,13 +2887,22 @@ const Sessions = (() => {
       if (sibReasoningWrap) sibReasoningWrap.style.display = "";
       if (sibSepAfterReasoning) sibSepAfterReasoning.style.display = "";
 
-      // Working dir — show full path
+      // Working dir — show full path, hide entirely if empty
       const sibDir = $("sib-dir");
-      if (sibDir && s.working_dir) {
-        sibDir.textContent = s.working_dir;
-        sibDir.title = `${s.working_dir} (${I18n.t("sib.dir.tooltip")})`;
-        sibDir.dataset.workingDir = s.working_dir;
-        sibDir.dataset.sessionId = s.id;
+      const sibSepAfterDir = document.querySelector(".sib-sep-after-dir");
+      if (sibDir) {
+        if (s.working_dir) {
+          sibDir.textContent = s.working_dir;
+          sibDir.title = `${s.working_dir} (${I18n.t("sib.dir.tooltip")})`;
+          sibDir.dataset.workingDir = s.working_dir;
+          sibDir.dataset.sessionId = s.id;
+          sibDir.style.display = "";
+          if (sibSepAfterDir) sibSepAfterDir.style.display = "";
+        } else {
+          sibDir.textContent = "";
+          sibDir.style.display = "none";
+          if (sibSepAfterDir) sibSepAfterDir.style.display = "none";
+        }
       }
 
       // Context usage — hide if 0 or missing

--- a/internal/server/static/ws-dispatcher.js
+++ b/internal/server/static/ws-dispatcher.js
@@ -119,6 +119,9 @@ WS.onEvent(ev => {
         // list returns, so updateInfoBar doesn't need to branch on the source.
         if (ev.latency !== undefined) patch.latest_latency = ev.latency;
         if (ev.context_usage !== undefined) patch.context_usage = ev.context_usage;
+        if (ev.working_dir !== undefined) patch.working_dir = ev.working_dir;
+        if (ev.permission_mode !== undefined) patch.permission_mode = ev.permission_mode;
+        if (ev.reasoning_effort !== undefined) patch.reasoning_effort = ev.reasoning_effort;
       }
       if (!sid) break;
       Sessions.patch(sid, patch);

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -28,17 +28,22 @@ func (s *Server) listSessionsBrief() []wsSessionInfo {
 	if err != nil {
 		return nil
 	}
+	wd, pm, re, ctxUsage := s.sessionStatusFields()
 	out := make([]wsSessionInfo, 0, len(sessions))
 	for _, sess := range sessions {
 		source := "manual"
 		out = append(out, wsSessionInfo{
-			ID:         sess.ID,
-			Name:       sess.DisplayTitle(),
-			Status:     "idle",
-			CreatedAt:  sess.CreatedAt.UnixMilli(),
-			Source:     source,
-			Model:      sess.Model,
-			TotalTurns: sess.TurnCount(),
+			ID:              sess.ID,
+			Name:            sess.DisplayTitle(),
+			Status:          "idle",
+			CreatedAt:       sess.CreatedAt.UnixMilli(),
+			Source:          source,
+			Model:           sess.Model,
+			TotalTurns:      sess.TurnCount(),
+			WorkingDir:      wd,
+			PermissionMode:  pm,
+			ReasoningEffort: re,
+			ContextUsage:    ctxUsage,
 		})
 	}
 	return out
@@ -366,11 +371,15 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 			// so turn_done + assistant_message were broadcast by the handler.
 			// Nothing more for the reply itself.
 		} else {
+			wd, pm, re, _ := s.sessionStatusFields()
 			sw.error(err.Error())
 			s.wsHub.broadcast(sess.ID, map[string]any{
-				"type":       "session_update",
-				"session_id": sess.ID,
-				"status":     "idle",
+				"type":             "session_update",
+				"session_id":       sess.ID,
+				"status":           "idle",
+				"working_dir":      wd,
+				"permission_mode":  pm,
+				"reasoning_effort": re,
 			})
 			return
 		}
@@ -414,11 +423,15 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 			ctxPct = 100
 		}
 	}
+	wd, pm, re, _ := s.sessionStatusFields()
 	s.wsHub.broadcast(sess.ID, map[string]any{
-		"type":          "session_update",
-		"session_id":    sess.ID,
-		"status":        "idle",
-		"context_usage": ctxPct,
+		"type":             "session_update",
+		"session_id":       sess.ID,
+		"status":           "idle",
+		"context_usage":    ctxPct,
+		"working_dir":      wd,
+		"permission_mode":  pm,
+		"reasoning_effort": re,
 	})
 }
 

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -73,13 +73,17 @@ type wsEventSessionList struct {
 }
 
 type wsSessionInfo struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	Status     string `json:"status,omitempty"` // "idle" | "working"
-	CreatedAt  int64  `json:"created_at"`       // unix ms
-	Source     string `json:"source,omitempty"` // "manual" | "cron" | "channel" | "setup"
-	Model      string `json:"model,omitempty"`
-	TotalTurns int    `json:"total_turns,omitempty"`
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	Status          string `json:"status,omitempty"` // "idle" | "working"
+	CreatedAt       int64  `json:"created_at"`       // unix ms
+	Source          string `json:"source,omitempty"` // "manual" | "cron" | "channel" | "setup"
+	Model           string `json:"model,omitempty"`
+	TotalTurns      int    `json:"total_turns,omitempty"`
+	WorkingDir      string `json:"working_dir,omitempty"`
+	PermissionMode  string `json:"permission_mode,omitempty"`
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	ContextUsage    int    `json:"context_usage,omitempty"`
 }
 
 type wsEventHistoryUserMessage struct {
@@ -142,11 +146,14 @@ type wsEventComplete struct {
 }
 
 type wsEventSessionUpdate struct {
-	Type         string  `json:"type"`
-	Status       string  `json:"status,omitempty"`
-	Tasks        int     `json:"tasks,omitempty"`
-	Latency      float64 `json:"latency,omitempty"`
-	ContextUsage int     `json:"context_usage,omitempty"` // 0–100 context window %
+	Type            string  `json:"type"`
+	Status          string  `json:"status,omitempty"`
+	Tasks           int     `json:"tasks,omitempty"`
+	Latency         float64 `json:"latency,omitempty"`
+	ContextUsage    int     `json:"context_usage,omitempty"` // 0–100 context window %
+	WorkingDir      string  `json:"working_dir,omitempty"`
+	PermissionMode  string  `json:"permission_mode,omitempty"`
+	ReasoningEffort string  `json:"reasoning_effort,omitempty"`
 }
 
 type wsEventTodoUpdate struct {


### PR DESCRIPTION
The web status bar was only rendering model + a fallback "Default" reasoning label because the backend never sent working_dir, permission_mode, reasoning_effort, or context_usage in either GET /api/sessions or the WS session_list/session_update events.

### Backend
- Add WorkingDir, PermissionMode, ReasoningEffort, ContextUsage to sessionItem and wsSessionInfo.
- Convert toSessionItem to a Server method so it can read s.cwd, resolvePermissionMode(), and config.ReasoningEffort.
- Broadcast the same fields in session_update on turn completion/error.

### Frontend
- Patch working_dir, permission_mode, reasoning_effort from session_update events into the local session cache.
- Hide #sib-dir and .sib-sep-after-dir when working_dir is empty so an empty directory never leaves a dangling "│" separator.

This makes the web status bar consistent with the TUI: model | reasoning | working_dir | ctx N% | permission_mode.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>