### PR TITLE
ui: remove unused More Options dropdown

### DIFF
--- a/internal/server/static/app.css
+++ b/internal/server/static/app.css
@@ -465,19 +465,12 @@ body {
   white-space: nowrap;
 }
 
-/* ── Split button [+ ▾] ─────────────────────────────────────────────────── */
-.btn-split-wrap {
-  position: relative;
-  display: flex;
-  align-items: center;
-  border-radius: 5px;
-  overflow: visible;
-}
-.btn-split-main {
+/* ── New session button ──────────────────────────────────────────────────── */
+#btn-new-session-inline {
   height: 1.375rem;
   padding: 0 0.5rem;
   border: none;
-  border-radius: 5px 0 0 5px;
+  border-radius: 5px;
   background: var(--color-accent-primary);
   color: #fff;
   font-size: 0.6875rem;
@@ -487,54 +480,9 @@ body {
   cursor: pointer;
   transition: background 0.15s, color 0.15s, box-shadow 0.15s;
 }
-.btn-split-main:hover {
+#btn-new-session-inline:hover {
   background: var(--color-button-primary-hover);
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-}
-.btn-split-arrow {
-  height: 1.375rem;
-  padding: 0 0.25rem;
-  border: none;
-  border-left: 1px solid rgba(255,255,255,0.3);
-  border-radius: 0 5px 5px 0;
-  background: var(--color-accent-primary);
-  color: #fff;
-  font-size: 0.625rem;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-.btn-split-arrow:hover {
-  background: var(--color-button-primary-hover);
-}
-
-/* ── Dropdown menu ───────────────────────────────────────────────────────── */
-.new-session-dropdown {
-  position: absolute;
-  top: calc(100% + 0.25rem);
-  right: 0;
-  min-width: 11.25rem;
-  background: var(--color-bg-card);
-  border: 1px solid var(--color-border-primary);
-  border-radius: 7px;
-  box-shadow: var(--shadow-md);
-  z-index: 200;
-  padding: 0.25rem 0;
-  overflow: hidden;
-}
-.new-session-dropdown[hidden] { display: none; }
-.dropdown-item {
-  padding: 0.25rem 0.625rem;
-  font-size: 0.6875rem;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: all 0.12s;
-  display: flex;
-  align-items: center;
-}
-.dropdown-item:hover {
-  background: var(--color-bg-hover);
-  color: var(--color-accent-primary);
 }
 
 /* ── Session source badge ────────────────────────────────────────────────── */

--- a/internal/server/static/i18n.js
+++ b/internal/server/static/i18n.js
@@ -105,7 +105,6 @@ const I18n = (() => {
       "sessions.actions.rename": "Rename",
       "sessions.actions.delete": "Delete",
       "sessions.actions.selectMultiple": "Select Multiple",
-      "sessions.newSessionAdvanced": "More Options",
       "sessions.batch.cancel":    "Cancel",
       "sessions.batch.selectAll": "Select All",
       "sessions.batch.delete":    "Delete Selected",

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -69,19 +69,7 @@
                 <line x1="10.3" y1="10.3" x2="14" y2="14" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
               </svg>
             </button>
-            <div class="btn-split-wrap">
-              <button id="btn-new-session-inline" class="btn-split-main" title="New Session" data-i18n="sessions.newSession">+ New Session</button>
-              <button id="btn-new-session-arrow" class="btn-split-arrow" title="Options">▾</button>
-              <!-- Dropdown -->
-              <div id="new-session-dropdown" class="new-session-dropdown" hidden>
-                <div class="dropdown-item" id="btn-new-session-modal" data-i18n="sessions.newSessionAdvanced">
-                  <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: -1px; margin-right: 5px; opacity: 0.6;">
-                    <path d="M8 0a.5.5 0 01.5.5v2a.5.5 0 01-1 0v-2A.5.5 0 018 0zm0 13a.5.5 0 01.5.5v2a.5.5 0 01-1 0v-2A.5.5 0 018 13zm8-5a.5.5 0 01-.5.5h-2a.5.5 0 010-1h2a.5.5 0 01.5.5zM3 8a.5.5 0 01-.5.5h-2a.5.5 0 010-1h2A.5.5 0 013 8zm10.657-5.657a.5.5 0 010 .707l-1.414 1.415a.5.5 0 11-.707-.708l1.414-1.414a.5.5 0 01.707 0zm-9.193 9.193a.5.5 0 010 .707L3.05 13.657a.5.5 0 01-.707-.707l1.414-1.414a.5.5 0 01.707 0zm9.193 2.121a.5.5 0 01-.707 0l-1.414-1.414a.5.5 0 01.707-.707l1.414 1.414a.5.5 0 010 .707zM4.464 4.465a.5.5 0 01-.707 0L2.343 3.05a.5.5 0 11.707-.707l1.414 1.414a.5.5 0 010 .708z"/>
-                  </svg>
-                  <span data-i18n="sessions.newSessionAdvanced">More Options</span>
-                </div>
-              </div>
-            </div>
+            <button id="btn-new-session-inline" title="New Session" data-i18n="sessions.newSession">+ New Session</button>
           </div>
         </div>
 

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -429,30 +429,6 @@ const Sessions = (() => {
     document.getElementById("btn-new-session-inline")
       .addEventListener("click", () => Sessions.create("general"));
 
-    // Split button: arrow (toggle dropdown)
-    document.getElementById("btn-new-session-arrow")
-      .addEventListener("click", (e) => {
-        e.stopPropagation();
-        const dd = document.getElementById("new-session-dropdown");
-        dd.hidden = !dd.hidden;
-      });
-
-    // Dropdown item "Advanced Options…" — delegated because the dropdown
-    // panel may be re-rendered; this keeps the binding stable.
-    document.addEventListener("click", (e) => {
-      if (e.target && e.target.id === "btn-new-session-modal") {
-        e.stopPropagation();
-        document.getElementById("new-session-dropdown").hidden = true;
-        Sessions.openNewSessionModal();
-      }
-    });
-
-    // Close dropdown when clicking anywhere else
-    document.addEventListener("click", () => {
-      const dd = document.getElementById("new-session-dropdown");
-      if (dd && !dd.hidden) dd.hidden = true;
-    });
-
     // Welcome screen "+ New Session" button
     document.getElementById("btn-welcome-new")
       .addEventListener("click", () => Sessions.create("general"));


### PR DESCRIPTION
Remove the split-button dropdown next to "+ New Session" that contained a single "More Options" item with no functionality.

**Changes:**
- Simplify button from split-button to a single button in `index.html`
- Remove split-button, arrow, dropdown, and dropdown-item CSS in `app.css`
- Remove arrow click, dropdown item click, and outside-click handlers in `sessions.js`
- Remove `sessions.newSessionAdvanced` i18n key in `i18n.js`