### PR TITLE
feat(web): refresh batch-select UI with custom checkbox + sticky bottom bar

### DIFF
--- a/internal/server/static/app.css
+++ b/internal/server/static/app.css
@@ -379,15 +379,21 @@ body {
 }
 #session-list { padding: 0.375rem 0.5rem 0.5rem; min-height: 6.75rem; }
 
-/* ── Batch select toolbar ───────────────────────────────────────────────── */
+/* ── Batch select toolbar (sticky bottom bar) ───────────────────────────── */
 .session-batch-toolbar {
+  position: sticky;
+  bottom: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-  padding: 0.375rem 0.5rem;
-  margin-bottom: 0.25rem;
-  border-bottom: 1px solid var(--color-border-primary);
+  padding: 0.5rem 0.75rem;
+  margin: 0.25rem -0.5rem -0.5rem;
+  background: color-mix(in srgb, var(--color-bg-primary) 80%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-top: 1px solid var(--color-border-primary);
+  z-index: 10;
 }
 .session-batch-info {
   display: flex;
@@ -429,14 +435,44 @@ body {
   color: var(--color-error);
 }
 
-/* ── Session select checkbox ────────────────────────────────────────────── */
-.session-select-checkbox {
-  width: 1rem;
-  height: 1rem;
-  margin-right: 0.5rem;
-  accent-color: var(--color-accent-primary);
-  cursor: pointer;
+/* ── Custom select circle (Gmail-style) ─────────────────────────────────── */
+.session-select-circle {
+  width: 1.125rem;
+  height: 1.125rem;
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1.5px solid var(--color-text-muted);
+  background: transparent;
+  cursor: pointer;
+  transition: all .15s ease;
+}
+.session-select-circle svg {
+  width: 0.625rem;
+  height: 0.625rem;
+  stroke: white;
+  stroke-width: 2.5;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: all .15s ease;
+}
+
+/* Selected item state */
+.session-item.selected {
+  background: color-mix(in srgb, var(--color-accent-primary) 6%, transparent);
+}
+.session-item.selected .session-select-circle {
+  background: var(--color-accent-primary);
+  border-color: var(--color-accent-primary);
+}
+.session-item.selected .session-select-circle svg {
+  opacity: 1;
+  transform: scale(1);
 }
 
 /* ── Sidebar divider (Section Labels) ───────────────────────────────────── */

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -1898,15 +1898,20 @@ const Sessions = (() => {
       : "";
 
     const isSelected = _selectedIds.has(s.id);
-    const checkboxHtml = _selectMode
-      ? `<input type="checkbox" class="session-select-checkbox" ${isSelected ? "checked" : ""} data-session-id="${escapeHtml(s.id)}">`
+    el.className = "session-item"
+      + (s.id === _activeId ? " active" : "")
+      + (isSelected ? " selected" : "");
+    if (s.pinned) el.classList.add("pinned");
+
+    const circleHtml = _selectMode
+      ? `<span class="session-select-circle" data-session-id="${escapeHtml(s.id)}"><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg></span>`
       : "";
     const actionsBtnHtml = _selectMode
       ? ""
       : `<button class="session-actions-btn" title="Actions"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="2.5" cy="7" r="1.2" fill="currentColor"/><circle cx="7" cy="7" r="1.2" fill="currentColor"/><circle cx="11.5" cy="7" r="1.2" fill="currentColor"/></svg></button>`;
 
     el.innerHTML = `
-      ${checkboxHtml}
+      ${circleHtml}
       <div class="session-body">
         <div class="session-name">${dotHtml}<span class="session-name__text">${escapeHtml(displayName)}</span>${badgeHtml}${codingBadgeHtml}${pinIcon}</div>
         <div class="session-meta">${metaText}</div>
@@ -1914,8 +1919,8 @@ const Sessions = (() => {
       ${actionsBtnHtml}`;
 
     if (_selectMode) {
-      // In select mode: checkbox toggles selection; body click also toggles
-      const checkbox = el.querySelector(".session-select-checkbox");
+      // In select mode: circle + body click toggles selection
+      const circle = el.querySelector(".session-select-circle");
       const body = el.querySelector(".session-body");
       const toggle = () => {
         if (_selectedIds.has(s.id)) {
@@ -1925,7 +1930,10 @@ const Sessions = (() => {
         }
         Sessions.renderList();
       };
-      if (checkbox) checkbox.addEventListener("change", toggle);
+      if (circle) circle.addEventListener("click", (e) => {
+        e.stopPropagation();
+        toggle();
+      });
       if (body) body.addEventListener("click", (e) => {
         e.stopPropagation();
         toggle();
@@ -2487,33 +2495,6 @@ const Sessions = (() => {
       const list = $("session-list");
       list.innerHTML = "";
 
-      // ── Batch-select toolbar ────────────────────────────────────────────
-      if (_selectMode) {
-        const toolbar = document.createElement("div");
-        toolbar.className = "session-batch-toolbar";
-        const selectedCount = _selectedIds.size;
-        toolbar.innerHTML = `
-          <div class="session-batch-info">
-            <button class="session-batch-btn" data-action="cancel">${escapeHtml(I18n.t("sessions.batch.cancel"))}</button>
-            <span class="session-batch-count">${escapeHtml(I18n.t("sessions.batch.selected", { n: selectedCount }))}</span>
-          </div>
-          <div class="session-batch-actions">
-            <button class="session-batch-btn" data-action="select-all">${escapeHtml(I18n.t("sessions.batch.selectAll"))}</button>
-            <button class="session-batch-btn session-batch-btn--danger" data-action="delete" ${selectedCount === 0 ? "disabled" : ""}>${escapeHtml(I18n.t("sessions.batch.delete"))}</button>
-          </div>
-        `;
-        toolbar.querySelectorAll("[data-action]").forEach(btn => {
-          btn.addEventListener("click", (e) => {
-            e.stopPropagation();
-            const action = btn.dataset.action;
-            if (action === "cancel") Sessions.toggleSelectMode();
-            else if (action === "select-all") Sessions.selectAll();
-            else if (action === "delete") Sessions.deleteSelectedSessions();
-          });
-        });
-        list.appendChild(toolbar);
-      }
-
       if (hasActiveFilter) {
         // Filter active: show all matching results flat, no group entry
         visible.forEach(s => _renderSessionItem(list, s));
@@ -2550,6 +2531,33 @@ const Sessions = (() => {
       }
 
       if (_hasMore) list.appendChild(_makeLoadMoreBtn());
+
+      // ── Batch-select toolbar (sticky bottom bar) ────────────────────────
+      if (_selectMode) {
+        const toolbar = document.createElement("div");
+        toolbar.className = "session-batch-toolbar";
+        const selectedCount = _selectedIds.size;
+        toolbar.innerHTML = `
+          <div class="session-batch-info">
+            <button class="session-batch-btn" data-action="cancel">${escapeHtml(I18n.t("sessions.batch.cancel"))}</button>
+            <span class="session-batch-count">${escapeHtml(I18n.t("sessions.batch.selected", { n: selectedCount }))}</span>
+          </div>
+          <div class="session-batch-actions">
+            <button class="session-batch-btn" data-action="select-all">${escapeHtml(I18n.t("sessions.batch.selectAll"))}</button>
+            <button class="session-batch-btn session-batch-btn--danger" data-action="delete" ${selectedCount === 0 ? "disabled" : ""}>${escapeHtml(I18n.t("sessions.batch.delete"))}</button>
+          </div>
+        `;
+        toolbar.querySelectorAll("[data-action]").forEach(btn => {
+          btn.addEventListener("click", (e) => {
+            e.stopPropagation();
+            const action = btn.dataset.action;
+            if (action === "cancel") Sessions.toggleSelectMode();
+            else if (action === "select-all") Sessions.selectAll();
+            else if (action === "delete") Sessions.deleteSelectedSessions();
+          });
+        });
+        list.appendChild(toolbar);
+      }
 
       // Scroll active session into view so the sidebar always shows the current session.
       if (!skipScrollToActive) {


### PR DESCRIPTION
## What

Refresh the session batch-selection interaction to feel more modern and polished.

## Changes

- **Custom checkbox**: Replaced the native  with a Gmail-style SVG circle that animates between empty and checked states.
- **Selected item state**: Added  with a subtle accent-tinted background ().
- **Sticky bottom toolbar**: Moved the batch toolbar from the top of the list to a  floating bar with  for a frosted-glass effect.
- **Preserved behavior**: All existing interactions remain unchanged (click to toggle, body click, Select All, Cancel, batch delete).

## Before / After

| Before | After |
|--------|-------|
| Native checkbox + top toolbar | Custom SVG circle + sticky bottom bar |
| Abrupt selection state | Animated checkmark + tinted row |

## Checklist

- [x] go test -race  -tags='' ./...
ok  	github.com/Leihb/octo-agent/cmd/octo	6.567s
?   	github.com/Leihb/octo-agent/cmd/octo-eval	[no test files]
ok  	github.com/Leihb/octo-agent/internal/agent	2.999s
ok  	github.com/Leihb/octo-agent/internal/app	4.602s
ok  	github.com/Leihb/octo-agent/internal/channel	1.978s
?   	github.com/Leihb/octo-agent/internal/channel/adapters/dingtalk	[no test files]
?   	github.com/Leihb/octo-agent/internal/channel/adapters/feishu	[no test files]
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	3.919s
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	2.591s
ok  	github.com/Leihb/octo-agent/internal/conductor	6.506s
ok  	github.com/Leihb/octo-agent/internal/config	4.918s
ok  	github.com/Leihb/octo-agent/internal/eval	5.858s
ok  	github.com/Leihb/octo-agent/internal/hooks	14.507s
ok  	github.com/Leihb/octo-agent/internal/mcp	14.694s
ok  	github.com/Leihb/octo-agent/internal/memory	3.125s
ok  	github.com/Leihb/octo-agent/internal/permission	2.943s
ok  	github.com/Leihb/octo-agent/internal/prompt	3.319s
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	2.612s
ok  	github.com/Leihb/octo-agent/internal/provider/openai	2.979s
ok  	github.com/Leihb/octo-agent/internal/provider/retry	2.974s
ok  	github.com/Leihb/octo-agent/internal/sandbox	2.902s
?   	github.com/Leihb/octo-agent/internal/scheduler	[no test files]
ok  	github.com/Leihb/octo-agent/internal/server	3.927s
ok  	github.com/Leihb/octo-agent/internal/skills	3.522s
ok  	github.com/Leihb/octo-agent/internal/tasks	2.995s
ok  	github.com/Leihb/octo-agent/internal/tools	16.513s
ok  	github.com/Leihb/octo-agent/internal/tools/rgembed	3.387s
?   	github.com/Leihb/octo-agent/internal/trash	[no test files]
ok  	github.com/Leihb/octo-agent/internal/tui	3.540s
ok  	github.com/Leihb/octo-agent/internal/version	2.599s passes
- [x] Visual changes verified in browser
- [x] No new third-party dependencies

Co-authored-by: octo-agent \u003cno-reply@octo-agent.dev\u003e