### PR TITLE
feat(tools): intercept rm in terminal tool and move files to trash

### DIFF
--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Leihb/octo-agent/internal/trash"
 	"gopkg.in/yaml.v3"
 )
 
@@ -303,10 +304,11 @@ func (r *Registry) Delete(name string) error {
 	delete(r.skills, name)
 	delete(r.disabled, name)
 
-	// Remove the on-disk directory
+	// Move to trash before permanently deleting.
 	if s.Dir != "" {
-		if err := os.RemoveAll(s.Dir); err != nil {
-			return fmt.Errorf("remove skill directory %s: %w", s.Dir, err)
+		projDir := filepath.Dir(s.Dir)
+		if err := trash.Move(s.Dir, projDir); err != nil {
+			return fmt.Errorf("trash skill directory %s: %w", s.Dir, err)
 		}
 	}
 	return nil

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -2,11 +2,14 @@ package tools
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"sync"
 
 	"github.com/Leihb/octo-agent/internal/sandbox"
+	"github.com/Leihb/octo-agent/internal/trash"
 )
 
 // activeSandbox, when non-nil, confines every terminal command (foreground and
@@ -26,6 +29,37 @@ func NetworkAllowed() bool {
 	}
 	return activeSandbox.AllowNetwork
 }
+
+// safeRmWrapper is injected before every POSIX shell command so that direct
+// `rm` invocations move files to the project-scoped trash instead of
+// permanently deleting them.  It reads $OCTO_TRASH_DIR (set by shellCommand)
+// and writes .meta.json sidecars compatible with the trash package.
+const safeRmWrapper = `__octo_safe_rm() {
+  local _trash_dir="$OCTO_TRASH_DIR"
+  [ -z "$_trash_dir" ] && return
+  local _arg
+  for _arg in "$@"; do
+    case "$_arg" in -*) continue ;; esac
+    if [ -e "$_arg" ] || [ -L "$_arg" ]; then
+      local _ts _base _dest _orig
+      _ts=$(date +%%Y%%m%%d-%%H%%M%%S)
+      _base=$(basename "$_arg")
+      _dest="$_trash_dir/${_ts}_${_base}"
+      _orig="$_arg"
+      case "$_orig" in /*) ;; *) _orig="$PWD/$_orig" ;; esac
+      mkdir -p "$_trash_dir"
+      cp -r "$PWD/$_arg" "$_dest" 2>/dev/null || continue
+      printf '{"original":"%%s","deleted_at":"%%s","project":"%%s"}\n' \
+        "$(printf '%%s' "$_orig" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)" \
+        "$(printf '%%s' "$PWD" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        > "$_dest.meta.json"
+    fi
+  done
+}
+rm() { __octo_safe_rm "$@"; command rm "$@"; }
+%s
+`
 
 // shellCommand builds the *exec.Cmd that runs `command` via the shell, wrapped
 // in the active sandbox when one is set. Both TerminalTool and the background
@@ -47,7 +81,18 @@ func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 		// -NonInteractive: never block on a PowerShell prompt mid-command.
 		cmd = exec.CommandContext(ctx, resolvePowerShell(), "-NoProfile", "-NonInteractive", "-Command", command)
 	} else {
-		cmd = exec.CommandContext(ctx, "sh", "-c", command)
+		projectDir := WorkingDir(ctx)
+		if projectDir == "" {
+			projectDir, _ = os.Getwd()
+		}
+		if projectDir != "" {
+			trashDir := trash.ProjectDir(projectDir)
+			wrapped := fmt.Sprintf(safeRmWrapper, command)
+			cmd = exec.CommandContext(ctx, "sh", "-c", wrapped)
+			cmd.Env = append(os.Environ(), "OCTO_TRASH_DIR="+trashDir)
+		} else {
+			cmd = exec.CommandContext(ctx, "sh", "-c", command)
+		}
 	}
 	if attr := setProcessGroupOpts(); attr != nil {
 		cmd.SysProcAttr = attr

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -26,8 +26,8 @@ func TestShellCommand_PlatformShell(t *testing.T) {
 			t.Errorf("windows shell should be pwsh/powershell, got %q", args[0])
 		}
 	} else {
-		if len(args) != 3 || args[0] != "sh" || args[1] != "-c" || args[2] != "echo hi" {
-			t.Errorf("posix shell should be [sh -c \"echo hi\"], got %v", args)
+		if len(args) != 3 || args[0] != "sh" || args[1] != "-c" || !strings.Contains(args[2], "echo hi") {
+			t.Errorf("posix shell should be [sh -c ...echo hi...], got %v", args)
 		}
 	}
 }

--- a/internal/trash/trash.go
+++ b/internal/trash/trash.go
@@ -38,13 +38,22 @@ func Dir() string {
 	return filepath.Join(home, ".octo", "trash")
 }
 
-// Move moves a file to the trash, preserving its original path for later
-// restoration. It creates the project subdirectory under the trash root,
-// copies the file there, and writes a .meta.json sidecar. On success the
-// original file is removed.
+// ProjectDir returns the per-project trash subdirectory for projectDir.
+func ProjectDir(projectDir string) string {
+	return filepath.Join(Dir(), hashProject(projectDir))
+}
+
+// Move moves a file or directory to the trash, preserving its original path for
+// later restoration. It creates the project subdirectory under the trash root,
+// copies the item there, and writes a .meta.json sidecar. On success the
+// original is removed.
 func Move(originalPath, projectDir string) error {
-	if _, err := os.Stat(originalPath); os.IsNotExist(err) {
-		return fmt.Errorf("file not found: %s", originalPath)
+	fi, err := os.Stat(originalPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("file not found: %s", originalPath)
+		}
+		return err
 	}
 
 	trashRoot := Dir()
@@ -61,23 +70,36 @@ func Move(originalPath, projectDir string) error {
 	trashPath := filepath.Join(targetDir, trashName)
 
 	// Copy.
-	if err := copyFile(originalPath, trashPath); err != nil {
-		return err
+	if fi.IsDir() {
+		if err := copyDir(originalPath, trashPath); err != nil {
+			return err
+		}
+	} else {
+		if err := copyFile(originalPath, trashPath); err != nil {
+			return err
+		}
 	}
 
 	// Write meta.
-	meta := meta{
+	m := meta{
 		Original:  originalPath,
 		DeletedAt: time.Now().UTC().Format(time.RFC3339),
 		Project:   projectDir,
 	}
-	metaData, _ := json.MarshalIndent(meta, "", "  ")
+	metaData, _ := json.MarshalIndent(m, "", "  ")
 	if err := os.WriteFile(trashPath+".meta.json", metaData, 0600); err != nil {
-		os.Remove(trashPath)
+		if fi.IsDir() {
+			os.RemoveAll(trashPath)
+		} else {
+			os.Remove(trashPath)
+		}
 		return err
 	}
 
 	// Remove original.
+	if fi.IsDir() {
+		return os.RemoveAll(originalPath)
+	}
 	return os.Remove(originalPath)
 }
 
@@ -128,7 +150,7 @@ func List() ([]Entry, error) {
 			continue
 		}
 		for _, f := range files {
-			if f.IsDir() || strings.HasSuffix(f.Name(), ".meta.json") {
+			if strings.HasSuffix(f.Name(), ".meta.json") {
 				continue
 			}
 			trashPath := filepath.Join(projDir, f.Name())
@@ -137,10 +159,13 @@ func List() ([]Entry, error) {
 			if err != nil {
 				continue
 			}
-			info, _ := f.Info()
 			size := int64(0)
-			if info != nil {
-				size = info.Size()
+			if info, err := os.Stat(trashPath); err == nil {
+				if info.IsDir() {
+					size = dirSize(trashPath)
+				} else {
+					size = info.Size()
+				}
 			}
 			entries = append(entries, Entry{
 				ID:        filepath.Base(trashPath),
@@ -185,7 +210,11 @@ func Empty(mode string) (int, int64, error) {
 			}
 		}
 		if remove {
-			os.Remove(e.TrashPath)
+			if info, err := os.Stat(e.TrashPath); err == nil && info.IsDir() {
+				os.RemoveAll(e.TrashPath)
+			} else {
+				os.Remove(e.TrashPath)
+			}
 			os.Remove(e.TrashPath + ".meta.json")
 			count++
 			freed += e.Size
@@ -216,6 +245,34 @@ func copyFile(src, dst string) error {
 
 	_, err = io.Copy(out, in)
 	return err
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+		return copyFile(path, dstPath)
+	})
+}
+
+func dirSize(dir string) int64 {
+	var total int64
+	_ = filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
 }
 
 func readMeta(path string) (meta, error) {


### PR DESCRIPTION
## What

Intercept file deletions and move them to the per-project trash (`~/.octo/trash/`) before permanent removal:

1. **Terminal `rm` commands** (POSIX only): every `sh -c` command is prefixed with a bash `rm()` function that copies files/directories to trash and writes `.meta.json` sidecars before the real `rm` deletes them.
2. **Skill deletion** (Web UI): deleting a skill from the Skills panel now moves the skill directory to trash instead of permanently deleting it.

## How

- Extend `trash.Move` to support both files and directories (adds `copyDir` / `dirSize` helpers).
- `trash.List` and `trash.Empty` now handle directory entries correctly.
- Export `trash.ProjectDir()` so callers can resolve the per-project trash path.
- Inject `safeRmWrapper` in `shellCommand` for POSIX `sh -c\ paths.
- Wire `trash.Move` into `skills.Registry.Delete` before `os.RemoveAll`.
- Windows (PowerShell) is left untouched.
- Update `sandbox_test.go` to accept wrapped command strings.

## Verification

- `make test` passes (go test -race ./...).

---

Fixes: terminal `rm` and skill deletions permanently deleting files without a safety net.