### PR TITLE
fix(ui): prevent real-time messages from being occluded by bottom bar

### DIFF
--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -254,6 +254,7 @@ const Sessions = (() => {
   // faster than scrollTop can catch up, incorrectly triggering the "not at bottom" check.
 
   let _userScrolledUp = false;  // true if user manually scrolled away from bottom
+  let _scrollRafPending = false;
 
   function _isAtBottom(container) {
     if (!container) return false;
@@ -266,8 +267,17 @@ const Sessions = (() => {
     // Only auto-scroll if user hasn't manually scrolled up
     // Once they scroll up, stop auto-scrolling until they scroll back to bottom themselves
     if (!_userScrolledUp) {
-      container.scrollTop = container.scrollHeight;
-      _hideNewMessageBanner();
+      // Defer scroll to next animation frame so the browser has completed
+      // layout for newly-inserted content (prevents partial occlusion when
+      // scrollHeight is read before reflow).
+      if (!_scrollRafPending) {
+        _scrollRafPending = true;
+        requestAnimationFrame(() => {
+          _scrollRafPending = false;
+          container.scrollTop = container.scrollHeight;
+          _hideNewMessageBanner();
+        });
+      }
     } else {
       _showNewMessageBanner();
     }
@@ -2902,7 +2912,14 @@ const Sessions = (() => {
       }
 
       const bar = $("session-info-bar");
-      if (bar) bar.style.display = "flex";
+      if (bar) {
+        const wasHidden = bar.style.display === "none";
+        bar.style.display = "flex";
+        if (wasHidden) {
+          const messages = $("messages");
+          _scrollToBottomIfNeeded(messages);
+        }
+      }
     },
 
     /** Render the 4-bar latency signal next to the model name in the status bar.
@@ -3216,10 +3233,9 @@ const Sessions = (() => {
       // User messages: force scroll to bottom (user just sent a message)
       // Assistant/info: conditional scroll (preserve position if user is viewing history)
       if (type === "user") {
-        messages.scrollTop = messages.scrollHeight;
-      } else {
-        _scrollToBottomIfNeeded(messages);
+        _userScrolledUp = false; // reset so new user message is always visible
       }
+      _scrollToBottomIfNeeded(messages);
     },
 
     appendInfo(text, subline) {


### PR DESCRIPTION
## Problem

Web UI 中实时流式消息会被底部 \`session-info-bar\` / \`input-area\` 部分遮挡，特别是：
1. 快速流式输出时 \`scrollHeight\` 读取在布局完成之前，导致滚动不到位；
2. 切换 session 时 \`session-info-bar\` 从隐藏变为显示，占用了下方空间但 \`scrollTop\` 未同步调整；
3. 用户消息直接使用 \`scrollTop = scrollHeight\`，不走统一的防抖路径。

## Changes

- \`_scrollToBottomIfNeeded\`：用 \`requestAnimationFrame\` defer 滚动，确保浏览器完成布局后再读 \`scrollHeight\`
- \`updateInfoBar\`：状态栏从 \`display:none\` 变为 \`flex\` 后触发一次滚动到底部
- \`appendMessage\`：用户消息统一走 \`_scrollToBottomIfNeeded\`（先 reset \`_userScrolledUp\`）

## Verification

- \`make test\` 全绿
- 修改仅涉及前端 JS（\`sessions.js\`），无 Go 代码变更

---

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
