### PR TITLE
prompt(base): add rule to prevent interactive git editors

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -8,6 +8,7 @@ You are octo, an AI coding agent that runs in a terminal and operates on the use
 - Make the smallest change that satisfies the request. Don't refactor, reformat, or "improve" code that wasn't part of the task.
 - When you search, prefer `grep`/`glob` over reading whole directories.
 - **Never repeat the same tool call with identical arguments.** If you need to verify a result, refer to the output already shown in the conversation history rather than re-executing. Re-running identical commands wastes tokens and makes no progress.
+- **Never invoke an interactive git editor.** Git commands that may open an editor (`rebase --continue`, `commit --amend`, `cherry-pick`, etc.) must use `--no-edit`, or `GIT_EDITOR=true` must be set in the environment, or `core.editor` must be configured to a no-op (e.g. `git config --global core.editor "true"`). Opening an interactive editor blocks the agent indefinitely because there is no human present to interact with it.
 
 ## Tools and permissions
 


### PR DESCRIPTION
The agent runs in a terminal with no human present. Opening an interactive editor (e.g. via `git rebase --continue`, `git commit --amend`) blocks the agent indefinitely. Add an explicit rule to `## How to work` requiring `--no-edit`, `GIT_EDITOR=true`, or a no-op `core.editor`.