### PR TITLE
fix(web): persist user message immediately on WS send

### DIFF
--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -323,6 +323,14 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 		"created_at": time.Now().UnixMilli(),
 	})
 
+	// Persist the user message right away so a page refresh mid-turn doesn't
+	// lose it.  We append it for Save(), then pop it back off so buildAgent
+	// doesn't double-count it — RunStream will add the same message to
+	// a.History via appendUserInput.
+	sess.Messages = append(sess.Messages, agent.NewUserMessage(content))
+	_ = sess.Save()
+	sess.Messages = sess.Messages[:len(sess.Messages)-1]
+
 	sw := s.newWSStreamWriter(sess.ID)
 
 	if err := s.ensureSender(); err != nil {


### PR DESCRIPTION
## Problem

When the user sends a message via the Web UI, the user message is only persisted to the JSONL file **after** the agent turn completes. If the user refreshes the page while the agent is still generating a response, the message disappears because it was never written to disk.

## Fix

Persist the user message to the JSONL file **immediately** on WS send, before `RunStream` starts. To avoid double-counting, we:

1. Append the message to `sess.Messages`
2. Call `sess.Save()` (writes via `appendDelta`)
3. Pop the message back off `sess.Messages`

This keeps `sess.Messages` clean for `buildAgent()`, which loads history into `a.History`. `RunStream` then appends the user message via `appendUserInput()` as usual. The turn-end `SyncFrom(a.History) + Save()` appends only the assistant/tool messages added after this point.

## Safety

- On interruption, `finishInterrupted` repairs `a.History`; `SyncFrom` replaces `sess.Messages`; if the length shrinks below `persisted`, `Save()` falls back to `rewriteAll` (full rewrite) — no orphaned tool_use blocks.
- `make test` (`go test -race ./...`) passes.

## Verification

1. Create a session via WS
2. Send a message
3. Check `~/.octo/sessions/xxx.jsonl` while the turn is still running — the user message is already present
4. After the turn completes, the assistant message is appended without duplication