### PR TITLE
feat(web-ui): add live sub-agent panel

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -525,7 +525,7 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 
 	// Tool-enabled path: wire the per-turn tool environment (gate + ctx-scoped
 	// sub-agent manager + task store) bound to this turn's agent.
-	ctx, executor, err := s.prepareToolTurn(ctx, a)
+	ctx, executor, _, err := s.prepareToolTurn(ctx, a)
 	if err != nil {
 		return "", err
 	}
@@ -545,14 +545,14 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 // dispatch to them rather than the process-global gating sentinels. The manager
 // runs synchronously — a request/response turn has no follow-up channel for an
 // async sub-agent result — and each turn gets a private store, so concurrent
-// sessions never share sub-agent or task state. Returns the augmented ctx and
-// the executor to run the turn with.
-func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.Context, agent.ToolExecutor, error) {
+// sessions never share sub-agent or task state. Returns the augmented ctx, the
+// executor, and the manager so callers can wire live-panel event hooks.
+func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.Context, agent.ToolExecutor, *tools.SubAgentManager, error) {
 	executor := tools.NewDefaultRegistry()
 
 	engine, err := permission.New(permissionConfigPath(), s.cwd, resolvePermissionMode())
 	if err != nil {
-		return ctx, nil, fmt.Errorf("permission engine: %w", err)
+		return ctx, nil, nil, fmt.Errorf("permission engine: %w", err)
 	}
 	// Wire interactive permission confirmation when we know the session.
 	var ask app.PermissionAsk
@@ -569,7 +569,7 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.C
 	ctx = tools.WithSubAgentManager(ctx, mgr)
 	ctx = tools.WithTaskStore(ctx, tasks.New())
 
-	return ctx, executor, nil
+	return ctx, executor, mgr, nil
 }
 
 func permissionConfigPath() string {

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -66,9 +66,10 @@ func (s *Server) handleTurnSSE(w http.ResponseWriter, r *http.Request) {
 	runCtx := r.Context()
 	var toolDefs []agent.ToolDefinition
 	var executor agent.ToolExecutor
+	var mgr *tools.SubAgentManager
 	if s.cfg.Tools {
 		var perr error
-		runCtx, executor, perr = s.prepareToolTurn(runCtx, a)
+		runCtx, executor, mgr, perr = s.prepareToolTurn(runCtx, a)
 		if perr != nil {
 			ev := agent.AgentEvent{Kind: agent.EventToolError, Err: perr.Error()}
 			b, _ := json.Marshal(ev)
@@ -81,6 +82,22 @@ func (s *Server) handleTurnSSE(w http.ResponseWriter, r *http.Request) {
 	eventHandler := func(ev agent.AgentEvent) {
 		b, _ := json.Marshal(ev)
 		sseEvent(w, string(b))
+	}
+
+	// Wire sub-agent events into the SSE stream so the live panel shows
+	// sub-agent activity even on the SSE transport.
+	if mgr != nil {
+		mgr.SetOnEvent(func(ev tools.SubAgentEvent) {
+			b, _ := json.Marshal(map[string]any{
+				"type":        "sub_agent_event",
+				"session_id":  sess.ID,
+				"agent_id":    ev.AgentID,
+				"description": ev.Description,
+				"kind":        ev.Kind,
+				"tool_name":   ev.ToolName,
+			})
+			sseEvent(w, string(b))
+		})
 	}
 
 	reply, err := a.RunStream(runCtx, req.Message, toolDefs, executor, eventHandler)

--- a/internal/server/static/app.css
+++ b/internal/server/static/app.css
@@ -5227,6 +5227,100 @@ body {
   opacity: 0.6;
   font-size: 11px;
 }
+
+/* ── Sub-agent badge in #session-info-bar ────────────────────────────── */
+.sib-subagents {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 1px 8px;
+  border-radius: 10px;
+  background: var(--color-bg-tertiary, rgba(120, 120, 120, 0.12));
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+  cursor: default;
+  user-select: none;
+}
+.sib-subagents .subagents-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #3b82f6;
+  box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.6);
+  animation: subagents-pulse 1.4s ease-out infinite;
+}
+@keyframes subagents-pulse {
+  0%   { box-shadow: 0 0 0 0   rgba(59, 130, 246, 0.5); }
+  70%  { box-shadow: 0 0 0 6px rgba(59, 130, 246, 0);   }
+  100% { box-shadow: 0 0 0 0   rgba(59, 130, 246, 0);   }
+}
+
+.sib-subagents-popover {
+  position: fixed;
+  z-index: 1000;
+  min-width: 280px;
+  max-width: 520px;
+  padding: 6px 0;
+  background: var(--color-bg-primary, #fff);
+  border: 1px solid var(--color-border-primary, #e0e0e0);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.sib-subagents-popover-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 12px;
+}
+.sib-subagents-popover-row:not(:last-child) {
+  border-bottom: 1px solid var(--color-border-secondary, #f0f0f0);
+}
+.sib-subagents-popover-row.sib-subagents-popover-errored {
+  color: #dc2626;
+}
+.sib-subagents-popover-desc {
+  color: var(--color-text-primary);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sib-subagents-popover-elapsed {
+  color: var(--color-text-tertiary, #999);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── Sub-agent transition bubble in #messages ────────────────────────── */
+.msg-subagent-notice {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 8px 0;
+  padding: 6px 10px;
+  border-left: 3px solid #3b82f6;
+  background: var(--color-bg-secondary, rgba(59, 130, 246, 0.05));
+  color: var(--color-text-secondary);
+  font-size: 12.5px;
+  border-radius: 4px;
+  opacity: 0.9;
+}
+.msg-subagent-notice .subagent-icon  { flex: 0 0 auto; font-weight: 600; }
+.msg-subagent-notice .subagent-text  { flex: 0 0 auto; }
+.msg-subagent-notice .subagent-desc  {
+  flex: 1 1 auto;
+  font-size: 12px;
+  padding: 1px 5px;
+  background: rgba(59, 130, 246, 0.1);
+  border-radius: 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 #profile-panel {
   flex: 1;
   display: flex;

--- a/internal/server/static/i18n.js
+++ b/internal/server/static/i18n.js
@@ -38,6 +38,10 @@ const I18n = (() => {
       "bgtasks.badge":   "🔄 {{n}} background task(s)",
       "bgtasks.tooltip": "Hover for details · click to expand",
       "bgtasks.notice":  "Background task {{status}}:",
+      // ── Sub-agents ──
+      "subagents.badge":    "🤖 {{n}} sub-agent(s)",
+      "subagents.tooltip":  "Hover for details · click to expand",
+      "subagents.notice":   "Sub-agent {{status}}:",
       // ── Inbox queue hint (above the input bar) ──
       "inbox.queue.one":   "1 message waiting — the agent will read it next.",
       "inbox.queue.many":  "{{n}} messages waiting — the agent will read them next.",
@@ -511,6 +515,10 @@ const I18n = (() => {
       "bgtasks.badge":   "🔄 {{n}} 个后台任务",
       "bgtasks.tooltip": "悬浮查看详情 · 点击展开",
       "bgtasks.notice":  "后台任务 {{status}}：",
+      // ── Sub-agents ──
+      "subagents.badge":    "🤖 {{n}} 个子代理",
+      "subagents.tooltip":  "悬浮查看详情 · 点击展开",
+      "subagents.notice":   "子代理 {{status}}：",
       // ── Inbox queue hint (above the input bar) ──
       "inbox.queue.one":   "1 条消息排队中 — agent 处理完手头的事会马上看。",
       "inbox.queue.many":  "{{n}} 条消息排队中 — agent 处理完手头的事会马上看。",

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -262,6 +262,9 @@
         <span id="sib-bgtasks" class="sib-bgtasks" style="display:none" tabindex="0"
               role="status" aria-live="polite"></span>
         <span class="sib-sep sib-sep-after-bgtasks" style="display:none">│</span>
+        <span id="sib-subagents" class="sib-subagents" style="display:none" tabindex="0"
+              role="status" aria-live="polite"></span>
+        <span class="sib-sep sib-sep-after-subagents" style="display:none">│</span>
         <span id="sib-model-wrap">
           <span id="sib-model" class="sib-model-clickable" data-i18n-title="sib.model.tooltip" title="Click to switch model"></span>
           <div id="sib-model-dropdown" class="sib-model-dropdown" style="display:none"></div>

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -51,6 +51,12 @@ const Sessions = (() => {
   let   _suggestionText     = null;
   let   _defaultPlaceholder = null;  // captured lazily so i18n changes still work
 
+  // Sub-agent live panel state — mirrors TUI subAgentUI.
+  // Keyed by agent_id; each entry tracks description, start time, recent
+  // tools, and whether any tool errored.
+  const _subAgents = {};  // { [agent_id]: { description, start, recent:[], errored } }
+  const _maxSubAgentRecentTools = 4;
+
   // ── Markdown renderer ──────────────────────────────────────────────────
   //
   // Renders assistant message text as Markdown HTML using the marked library.
@@ -2115,6 +2121,102 @@ const Sessions = (() => {
       messages.appendChild(el);
       _scrollToBottomIfNeeded(messages);
     },
+
+    // ── Sub-agent live panel ──────────────────────────────────────────────
+    // Mirrors the TUI sub-agent panel: tracks running sub-agents, their
+    // description, elapsed time, and recent tool chain.
+
+    handleSubAgentEvent(agentID, description, kind, toolName) {
+      let sa = _subAgents[agentID];
+      if (!sa) {
+        sa = { description: description || agentID, start: Date.now(), recent: [], errored: false };
+        _subAgents[agentID] = sa;
+      }
+      switch (kind) {
+        case "started":
+          sa.recent = [];
+          sa.errored = false;
+          if (description) sa.description = description;
+          break;
+        case "tool":
+          sa.recent.push(toolName || "tool");
+          if (sa.recent.length > _maxSubAgentRecentTools) {
+            sa.recent = sa.recent.slice(sa.recent.length - _maxSubAgentRecentTools);
+          }
+          break;
+        case "tool_error":
+          sa.errored = true;
+          sa.recent.push((toolName || "tool") + " ✗");
+          if (sa.recent.length > _maxSubAgentRecentTools) {
+            sa.recent = sa.recent.slice(sa.recent.length - _maxSubAgentRecentTools);
+          }
+          break;
+      }
+      this._updateSubAgentBadge();
+    },
+
+    handleSubAgentDone(agentID) {
+      if (agentID && _subAgents[agentID]) {
+        delete _subAgents[agentID];
+      } else {
+        // Sync mode sends sub_agent_done without agent_id — clear all.
+        Object.keys(_subAgents).forEach(k => delete _subAgents[k]);
+      }
+      this._updateSubAgentBadge();
+    },
+
+    _updateSubAgentBadge() {
+      const badge = $("sib-subagents");
+      const sep   = document.querySelector(".sib-sep-after-subagents");
+      if (!badge) return;
+
+      const ids = Object.keys(_subAgents);
+      if (ids.length === 0) {
+        badge.style.display = "none";
+        if (sep) sep.style.display = "none";
+        const pop = $("sib-subagents-popover");
+        if (pop) pop.style.display = "none";
+        return;
+      }
+
+      const label = I18n.t("subagents.badge", { n: ids.length });
+      badge.innerHTML = `<span class="subagents-dot" aria-hidden="true"></span><span class="subagents-count">${escapeHtml(label)}</span>`;
+      badge.style.display = "";
+      if (sep) sep.style.display = "";
+
+      // Build tooltip lines.
+      const lines = ids.map(id => {
+        const sa = _subAgents[id];
+        const elapsed = Math.floor((Date.now() - sa.start) / 1000);
+        const elapsedStr = elapsed >= 60
+          ? `${Math.floor(elapsed / 60)}m ${elapsed % 60}s`
+          : `${elapsed}s`;
+        const chain = sa.recent.length > 0 ? ` → ${sa.recent.join(" → ")}` : "";
+        return `${sa.description}${chain}  (${elapsedStr})`;
+      });
+      badge.title = lines.join("\n");
+    },
+
+    appendSubAgentNotice(description, status) {
+      Sessions.collapseToolGroup();
+      const messages = $("messages");
+      const el = document.createElement("div");
+      el.className = `msg msg-subagent-notice msg-subagent-${status || "done"}`;
+
+      const iconMap = { done: "✓", error: "⚠" };
+      const icon = iconMap[status] || "✓";
+
+      const descShort = (description || "").length > 60
+        ? (description.slice(0, 60) + "…")
+        : (description || "");
+
+      el.innerHTML = `<span class="subagent-icon">${icon}</span>` +
+        `<span class="subagent-text">${I18n.t("subagents.notice", { status: status || "done" })}</span> ` +
+        `<span class="subagent-desc" title="${escapeHtml(description || '')}">${escapeHtml(descShort)}</span>`;
+      messages.appendChild(el);
+      _scrollToBottomIfNeeded(messages);
+    },
+
     // ── Init ──────────────────────────────────────────────────────────────
     init() {
       _initNewMessageBanner();
@@ -4349,15 +4451,28 @@ const Sessions = (() => {
       return;
     }
 
-    // Click outside — close bg-tasks popover if open.
+    // Toggle sub-agents popover when clicking the badge in the SIB.
+    if (e.target.closest("#sib-subagents")) {
+      e.stopPropagation();
+      _toggleSubAgentsPopover(e.target.closest("#sib-subagents"));
+      return;
+    }
+
+    // Click outside — close popovers if open.
     if (!e.target.closest("#sib-bgtasks-popover") && !e.target.closest("#sib-bgtasks")) {
       _closeBgTasksPopover();
+    }
+    if (!e.target.closest("#sib-subagents-popover") && !e.target.closest("#sib-subagents")) {
+      _closeSubAgentsPopover();
     }
   });
 
   // Close popover on Escape.
   document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") { _closeBgTasksPopover(); }
+    if (e.key === "Escape") {
+      _closeBgTasksPopover();
+      _closeSubAgentsPopover();
+    }
   });
 
   // ── Background-tasks popover ──────────────────────────────────────────
@@ -4425,6 +4540,73 @@ const Sessions = (() => {
       return `<div class="sib-bgtasks-popover-row">
         <code class="sib-bgtasks-popover-cmd">${cmd}</code>
         <span class="sib-bgtasks-popover-elapsed">${elapsedStr}</span>
+      </div>`;
+    }).join("");
+    pop.innerHTML = rows;
+  }
+
+  // ── Sub-agents popover ────────────────────────────────────────────────
+
+  function _ensureSubAgentsPopover() {
+    let pop = document.getElementById("sib-subagents-popover");
+    if (pop) return pop;
+    pop = document.createElement("div");
+    pop.id = "sib-subagents-popover";
+    pop.className = "sib-subagents-popover";
+    pop.setAttribute("role", "tooltip");
+    pop.style.display = "none";
+    document.body.appendChild(pop);
+    return pop;
+  }
+
+  function _toggleSubAgentsPopover(anchorEl) {
+    const pop = _ensureSubAgentsPopover();
+    if (pop.style.display !== "none") {
+      pop.style.display = "none";
+      return;
+    }
+
+    const ids = Object.keys(_subAgents);
+    if (ids.length === 0) return;
+
+    _renderSubAgentsPopover(pop, ids);
+
+    pop.style.display = "block";
+    pop.style.visibility = "hidden";
+    const popHeight = pop.offsetHeight;
+
+    const rect = anchorEl.getBoundingClientRect();
+    const gap = 6;
+    const vh = window.innerHeight;
+    const fitsBelow = rect.bottom + gap + popHeight <= vh;
+
+    pop.style.left = `${rect.left + rect.width / 2}px`;
+    pop.style.transform = "translate(-50%, 0)";
+    if (fitsBelow) {
+      pop.style.top = `${rect.bottom + gap}px`;
+    } else {
+      pop.style.top = `${rect.top - popHeight - gap}px`;
+    }
+    pop.style.visibility = "";
+  }
+
+  function _closeSubAgentsPopover() {
+    const pop = document.getElementById("sib-subagents-popover");
+    if (pop && pop.style.display !== "none") pop.style.display = "none";
+  }
+
+  function _renderSubAgentsPopover(pop, ids) {
+    const rows = ids.map(id => {
+      const sa = _subAgents[id];
+      const elapsed = Math.floor((Date.now() - sa.start) / 1000);
+      const elapsedStr = elapsed >= 60
+        ? `${Math.floor(elapsed / 60)}m ${elapsed % 60}s`
+        : `${elapsed}s`;
+      const chain = sa.recent.length > 0 ? ` → ${sa.recent.join(" → ")}` : "";
+      const errCls = sa.errored ? " sib-subagents-popover-errored" : "";
+      return `<div class="sib-subagents-popover-row${errCls}">
+        <span class="sib-subagents-popover-desc">${escapeHtml(sa.description)}${chain}</span>
+        <span class="sib-subagents-popover-elapsed">${elapsedStr}</span>
       </div>`;
     }).join("");
     pop.innerHTML = rows;

--- a/internal/server/static/ws-dispatcher.js
+++ b/internal/server/static/ws-dispatcher.js
@@ -360,6 +360,16 @@ WS.onEvent(ev => {
       Sessions.appendBgTaskNotice(ev.command, ev.handle_id, ev.status);
       break;
 
+    case "sub_agent_event":
+      if (ev.session_id !== Sessions.activeId) break;
+      Sessions.handleSubAgentEvent(ev.agent_id, ev.description, ev.kind, ev.tool_name);
+      break;
+
+    case "sub_agent_done":
+      if (ev.session_id !== Sessions.activeId) break;
+      Sessions.handleSubAgentDone(ev.agent_id);
+      break;
+
     case "user_message_queue_status":
       // Agent broadcast: N user messages are sitting in the inbox waiting
       // to be drained at the next iteration boundary. Show/hide the

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -83,7 +83,7 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 	var executor agent.ToolExecutor
 	if s.cfg.Tools {
 		var perr error
-		ctx, executor, perr = s.prepareToolTurn(ctx, a)
+		ctx, executor, _, perr = s.prepareToolTurn(ctx, a)
 		if perr != nil {
 			return sess.ID, fmt.Errorf("prepare tools: %w", perr)
 		}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -375,14 +375,28 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 
 	var toolDefs []agent.ToolDefinition
 	var executor agent.ToolExecutor
+	var subMgr *tools.SubAgentManager
 	if s.cfg.Tools {
 		var perr error
-		runCtx, executor, perr = s.prepareToolTurn(runCtx, a)
+		runCtx, executor, subMgr, perr = s.prepareToolTurn(runCtx, a)
 		if perr != nil {
 			sw.error(perr.Error())
 			return
 		}
 		toolDefs = tools.DefaultToolsFor(a.Model)
+		// Wire sub-agent live-panel events into the WebSocket stream.
+		if subMgr != nil {
+			subMgr.SetOnEvent(func(ev tools.SubAgentEvent) {
+				s.wsHub.broadcast(sess.ID, map[string]any{
+					"type":        "sub_agent_event",
+					"session_id":  sess.ID,
+					"agent_id":    ev.AgentID,
+					"description": ev.Description,
+					"kind":        ev.Kind,
+					"tool_name":   ev.ToolName,
+				})
+			})
+		}
 	}
 
 	reply, err := a.RunStream(runCtx, content, toolDefs, executor, sw.handleEvent)
@@ -541,6 +555,13 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 			"session_id": w.sessionID,
 			"result":     ev.Output,
 		})
+		// Signal sub-agent completion so the frontend can clear the live panel.
+		if ev.ToolName == "sub_agent" {
+			w.hub.broadcast(w.sessionID, map[string]any{
+				"type":       "sub_agent_done",
+				"session_id": w.sessionID,
+			})
+		}
 		// Clear live state on tool done.
 		w.server.liveStateMu.Lock()
 		if ls, ok := w.server.liveStates[w.sessionID]; ok {

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -177,9 +177,23 @@ func subAgentsSynchronous() bool {
 // RunSync spawns a sub-agent and blocks until it completes, returning its
 // reply. Used by the synchronous sub_agent path; the spawner stamps the
 // sub-agent marker and keeps the child resumable for a later ContinueSync.
+// When an onEvent hook is registered the child's tool-level activity is
+// streamed the same way async sub-agents are, so live panels work for both
+// sync and async modes.
 func (m *SubAgentManager) RunSync(ctx context.Context, req SpawnRequest) (SpawnResult, error) {
 	if m.spawner == nil {
 		return SpawnResult{}, fmt.Errorf("subagent: no spawner configured")
+	}
+	// Give this sync sub-agent a temporary ID so the event stream can track
+	// it the same way async agents are tracked.
+	m.mu.Lock()
+	m.seq++
+	id := fmt.Sprintf("sync_%d", m.seq)
+	m.mu.Unlock()
+
+	if sink := m.eventSink(id, req.Description); sink != nil {
+		ctx = WithSubAgentEventSink(ctx, sink)
+		sink(SubAgentEvent{Kind: "started"})
 	}
 	return m.spawner.Spawn(ctx, req)
 }


### PR DESCRIPTION
Expose sub-agent runtime events through WebSocket and SSE so the Web UI can show a live sub-agent panel mirroring the TUI.

**Backend**
- `RunSync` now injects an `eventSink` when onEvent is wired, so sync-mode sub-agents stream tool-level activity.
- `prepareToolTurn` returns the `*SubAgentManager` so callers can attach live-panel hooks.
- `doAgentTurn` (WS) and `handleTurnSSE` forward `SubAgentEvent`s as typed WS/SSE messages.
- `EventToolDone` for `sub_agent` broadcasts `sub_agent_done` to clear the UI panel.

**Frontend**
- `sib-subagents` badge in session-info-bar with blue pulse animation.
- Popover showing description + recent tool chain + elapsed time per sub-agent.
- `msg-subagent-notice` transition bubble in messages.
- EN/CN i18n for all new strings.

**Tested**
- `make test` (`go test -race ./...`) passes.
- No new third-party dependencies.