### PR TITLE
fix(web): surface reasoning/thinking content in assistant messages

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -379,9 +379,23 @@ func (s *Server) handleGetSessionMessages(w http.ResponseWriter, r *http.Request
 					})
 				}
 			}
+			// Pull reasoning/thinking trace from blocks ( Anthropic "thinking"
+			// or OpenAI reasoning stashed on "tool_use").
+			thinking := ""
+			for _, b := range m.Blocks {
+				if b.Type == "thinking" && b.Thinking != "" {
+					thinking = b.Thinking
+					break
+				}
+				if b.Type == "tool_use" && b.Reasoning != "" {
+					thinking = b.Reasoning
+					break
+				}
+			}
 			events = append(events, map[string]any{
-				"type":    "assistant_message",
-				"content": m.Content,
+				"type":     "assistant_message",
+				"content":  m.Content,
+				"thinking": thinking,
 			})
 		}
 	}

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -1459,13 +1459,21 @@ const Sessions = (() => {
 
       case "assistant_message": {
         const content = (ev.content || "").trim();
-        if (!content) break; // skip empty assistant messages
+        const thinking = (ev.thinking || "").trim();
+        if (!content && !thinking) break; // skip empty assistant messages
         // Collapse tool group before assistant reply
         if (historyCtx.group) { _collapseToolGroup(historyCtx.group); historyCtx.group = null; }
         const el = document.createElement("div");
         el.className = "msg msg-assistant";
         el.dataset.raw = content;
-        el.innerHTML = _renderMarkdown(content);
+        let html = "";
+        if (thinking) {
+          html += _buildThinkingBlock(_markedParse(thinking));
+        }
+        if (content) {
+          html += _renderMarkdown(content);
+        }
+        el.innerHTML = html;
         _appendCopyButton(el);
         container.appendChild(el);
         break;
@@ -3376,23 +3384,26 @@ const Sessions = (() => {
     // Finalize the assistant message when the turn completes.
     // Replaces the live streaming bubble with a fully-rendered markdown version.
     // If no streaming happened, falls back to creating a new bubble.
-    finalizeAssistantMessage(content) {
+    finalizeAssistantMessage(content, thinking) {
       const sid = _activeId;
       if (!sid) return;
 
       const state = Sessions._getLiveAssistant(sid);
 
-      // Remove any live thinking block (it will be re-rendered inside the
-      // final markdown if <think> tags are present).
+      // Remove any live thinking block (replaced by the final collapsed version).
       if (state.thinkingEl && state.thinkingEl.parentNode) {
         state.thinkingEl.remove();
       }
+
+      const thinkingHtml = thinking ? _buildThinkingBlock(_markedParse(thinking)) : "";
+      const contentHtml = _renderMarkdown(content || "");
+      const finalHtml = thinkingHtml + contentHtml;
 
       // If we have a live bubble, replace it with the final rendered version
       if (state.el && state.el.parentNode) {
         state.el.classList.remove("msg-streaming");
         state.el.dataset.raw = content || "";
-        state.el.innerHTML = _renderMarkdown(content || "");
+        state.el.innerHTML = finalHtml;
         _appendCopyButton(state.el);
         _scrollToBottomIfNeeded($("messages"));
         Sessions._clearLiveAssistant(sid);
@@ -3401,7 +3412,18 @@ const Sessions = (() => {
 
       // No live bubble (non-streaming path or late subscribe) — create fresh
       Sessions._clearLiveAssistant(sid);
-      Sessions.appendMsg("assistant", content);
+      if (thinking) {
+        const messages = $("messages");
+        const el = document.createElement("div");
+        el.className = "msg msg-assistant";
+        el.dataset.raw = content || "";
+        el.innerHTML = finalHtml;
+        _appendCopyButton(el);
+        messages.appendChild(el);
+        _scrollToBottomIfNeeded(messages);
+      } else {
+        Sessions.appendMsg("assistant", content);
+      }
     },
 
     /**

--- a/internal/server/static/ws-dispatcher.js
+++ b/internal/server/static/ws-dispatcher.js
@@ -239,7 +239,7 @@ WS.onEvent(ev => {
       // the first time the message appears.
       if (ev.session_id !== Sessions.activeId) break;
       Sessions.clearProgress();
-      Sessions.finalizeAssistantMessage(ev.content);
+      Sessions.finalizeAssistantMessage(ev.content, ev.thinking);
       break;
 
     case "tool_call":

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -589,6 +589,7 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 				"type":       "assistant_message",
 				"session_id": w.sessionID,
 				"content":    ev.Reply.Content,
+				"thinking":   extractThinking(ev.Reply),
 			})
 		}
 		// Clear live state.
@@ -657,4 +658,23 @@ func (s *Server) requestConfirmation(ctx context.Context, sessionID, message, ki
 		s.confirmMu.Unlock()
 		return "", fmt.Errorf("confirmation timed out")
 	}
+}
+
+// extractThinking pulls a reasoning/thinking trace from a Reply's Blocks so the
+// web UI can render it alongside the final assistant message. Anthropic models
+// return it as a standalone "thinking" block; OpenAI models stash it on the
+// first "tool_use" block (Reasoning field). Empty string when none is present.
+func extractThinking(reply *agent.Reply) string {
+	if reply == nil {
+		return ""
+	}
+	for _, b := range reply.Blocks {
+		if b.Type == "thinking" && b.Thinking != "" {
+			return b.Thinking
+		}
+		if b.Type == "tool_use" && b.Reasoning != "" {
+			return b.Reasoning
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
## Problem

Web UI 不显示模型的 reasoning/thinking 内容（Anthropic thinking blocks、OpenAI reasoning_content）。三个原因：

1. 后端 `assistant_message` 事件只发送 `content`，没传 thinking
2. 前端 `finalizeAssistantMessage` 删除了 live thinking block 但不重新渲染
3. 历史加载时 content 为空就跳过，即使 thinking 存在

## Changes

| 文件 | 修改 |
|------|------|
| `ws_handlers.go` | `assistant_message` 添加 `thinking` 字段，从 `Reply.Blocks` 提取（Anthropic `thinking` block 或 OpenAI `tool_use` 的 `Reasoning` 字段） |
| `handlers.go` | 历史事件 replay 同样提取 thinking |
| `ws-dispatcher.js` | 把 `ev.thinking` 传给 `finalizeAssistantMessage` |
| `sessions.js` | 流式完成和历史加载时，把 thinking 渲染为可折叠的 `details` 块（复用已有的 `.thinking-block` CSS） |

## Verification

- `make test` 全绿
- 修改复用已有的 `_buildThinkingBlock` / `.thinking-block` 样式，无需新增 CSS

---

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
