### PR TITLE
server(ws): emit next_message_suggestion after each turn

### DIFF
--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -463,6 +463,24 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 		"permission_mode":  pm,
 		"reasoning_effort": re,
 	})
+
+	// After-turn follow-up suggestion (matches TUI suggestCmd behaviour).
+	// Fire-and-forget: the frontend shows it as ghost text; failures are silent.
+	if err == nil {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+			text, serr := a.Suggest(ctx, toolDefs)
+			if serr != nil || strings.TrimSpace(text) == "" {
+				return
+			}
+			s.wsHub.broadcast(sess.ID, map[string]any{
+				"type":       "next_message_suggestion",
+				"session_id": sess.ID,
+				"text":       text,
+			})
+		}()
+	}
 }
 
 // ─── wsStreamWriter ────────────────────────────────────────────────────────


### PR DESCRIPTION
After a successful agent turn, fire-and-forget an `a.Suggest()` call using the same toolbelt as the main loop (prompt-cache prefix matches and hits). The result is broadcast as a WS `next_message_suggestion` event.

The web UI already renders it as ghost text in the composer (Tab to accept, Esc to clear, keystroke to dismiss).

Mirrors TUI `suggestCmd` behaviour: 20 s timeout, silent on error/empty.