### PR TITLE
fix(web): use per-repo memory directory and render internal memory links

### DIFF
--- a/internal/server/memory_handler.go
+++ b/internal/server/memory_handler.go
@@ -19,7 +19,12 @@ func (s *Server) handleGetMemory(w http.ResponseWriter, r *http.Request) {
 
 	// Security: prevent path traversal.
 	fname = filepath.Base(fname)
-	p := filepath.Join(octoDir(), "memories", fname)
+	dir := s.memDir
+	if dir == "" {
+		writeError(w, http.StatusNotFound, "memory not found")
+		return
+	}
+	p := filepath.Join(dir, fname)
 
 	data, err := os.ReadFile(p)
 	if err != nil {
@@ -44,7 +49,12 @@ func (s *Server) handleDeleteMemory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fname = filepath.Base(fname)
-	p := filepath.Join(octoDir(), "memories", fname)
+	dir := s.memDir
+	if dir == "" {
+		writeError(w, http.StatusNotFound, "memory not found")
+		return
+	}
+	p := filepath.Join(dir, fname)
 
 	if _, err := os.Stat(p); err != nil {
 		if os.IsNotExist(err) {
@@ -54,8 +64,7 @@ func (s *Server) handleDeleteMemory(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	memDir := filepath.Join(octoDir(), "memories")
-	if err := trash.Move(p, memDir); err != nil {
+	if err := trash.Move(p, dir); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/server/profile_handler.go
+++ b/internal/server/profile_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Leihb/octo-agent/internal/trash"
 )
@@ -35,7 +36,11 @@ func (s *Server) handleGetProfileUser(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetMemories(w http.ResponseWriter, r *http.Request) {
-	dir := filepath.Join(octoDir(), "memories")
+	dir := s.memDir
+	if dir == "" {
+		writeJSON(w, http.StatusOK, map[string]any{"files": []any{}})
+		return
+	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		writeJSON(w, http.StatusOK, map[string]any{"files": []any{}})
@@ -43,17 +48,25 @@ func (s *Server) handleGetMemories(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type memFile struct {
-		Name string `json:"name"`
-		Path string `json:"path"`
+		Name      string `json:"name"`
+		Path      string `json:"path"`
+		Size      int64  `json:"size"`
+		UpdatedAt string `json:"updated_at"`
 	}
 	files := make([]memFile, 0)
 	for _, e := range entries {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
 			continue
 		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
 		files = append(files, memFile{
-			Name: e.Name(),
-			Path: filepath.Join(dir, e.Name()),
+			Name:      e.Name(),
+			Path:      filepath.Join(dir, e.Name()),
+			Size:      info.Size(),
+			UpdatedAt: info.ModTime().UTC().Format(time.RFC3339),
 		})
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"files": files})

--- a/internal/server/static/i18n.js
+++ b/internal/server/static/i18n.js
@@ -294,6 +294,7 @@ const I18n = (() => {
       "memories.empty":         "No memories yet. The assistant will create them as you work.",
       "memories.emptyHint":     "",
       "memories.summary":       "{{count}} memory file(s)",
+      "memories.linkNotFound":  "Linked memory file not found: {{name}}",
       // Legacy keys — kept for compatibility with any external callers.
       "memories.refresh":       "Curate",
       "memories.refreshTitle":  "Open a session and let the assistant tidy this memory with you",
@@ -766,6 +767,7 @@ const I18n = (() => {
       "memories.empty":         "还没有记忆。助手会在后续工作中自动创建。",
       "memories.emptyHint":     "",
       "memories.summary":       "共 {{count}} 条记忆",
+      "memories.linkNotFound":  "找不到链接的记忆文件：{{name}}",
       // 旧 keys（兼容保留）
       "memories.refresh":       "整理",
       "memories.refreshTitle":  "开启一个会话，让助理和你一起整理这条记忆",

--- a/internal/server/static/profile.js
+++ b/internal/server/static/profile.js
@@ -45,12 +45,33 @@ const Profile = (() => {
       .replace(/'/g, "&#39;");
   }
 
+  function _renderLink(href, text) {
+    // Strip hash/leading ./ for internal memory references.
+    const rawHref = href.split("#")[0].replace(/^\.\//, "");
+    const safeHref = _escapeHtml(href);
+    const safeText = text;
+
+    // Reject obvious unsafe schemes.
+    if (/^(javascript|data|vbscript):/i.test(href)) {
+      return safeText;
+    }
+
+    // Internal link to another memory file: hand it to the UI expand handler.
+    if (/\.md$/i.test(rawHref)) {
+      return `<a href="#" class="memory-link" data-memory="${_escapeHtml(rawHref)}">${safeText}</a>`;
+    }
+
+    // External or absolute link: open safely in a new tab.
+    return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer">${safeText}</a>`;
+  }
+
   function _renderInline(text) {
-    // Inline: **bold**, *em*, `code`. Text is already HTML-escaped by caller.
+    // Inline: **bold**, *em*, `code`, [text](href). Text is already HTML-escaped by caller.
     return text
       .replace(/`([^`]+)`/g, "<code>$1</code>")
       .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
-      .replace(/(^|[^*])\*([^*\s][^*]*?)\*(?!\*)/g, "$1<em>$2</em>");
+      .replace(/(^|[^*])\*([^*\s][^*]*?)\*(?!\*)/g, "$1<em>$2</em>")
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (m, txt, href) => _renderLink(href, txt));
   }
 
   function _renderMarkdown(raw) {
@@ -257,6 +278,23 @@ const Profile = (() => {
     body.className = "memory-card-body";
     body.style.display = "none";
     card.appendChild(body);
+
+    // Clicking a link to another memory file expands that card.
+    body.addEventListener("click", (e) => {
+      const a = e.target.closest(".memory-link");
+      if (!a) return;
+      e.preventDefault();
+      const target = a.dataset.memory;
+      if (!target) return;
+      const el = document.querySelector(`.memory-card[data-filename="${CSS.escape(target)}"]`);
+      if (el) {
+        const btn = el.querySelector(".btn-memory-expand");
+        if (btn && btn.getAttribute("aria-expanded") !== "true") btn.click();
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+      } else {
+        alert(_t("memories.linkNotFound", { name: target }));
+      }
+    });
 
     head.querySelector(".btn-memory-curate")
       .addEventListener("click", (e) => { e.stopPropagation(); _curateMemory(m); });


### PR DESCRIPTION
## What changed

- `/api/memories` handlers now read from the repo-scoped memory directory (`~/.octo/memories/REPO-SLUG`) resolved at server startup via `memory.Dir`, instead of the flat `~/.octo/memories` path.
- `GET /api/memories` now returns `size` and `updated_at` so the memory cards render file metadata correctly.
- The Markdown renderer in the profile panel now supports `[text](file.md)` links; clicking an internal memory link expands and scrolls to the target card.

## Notes

No new third-party dependencies. JS files were syntax-checked with `node --check`; Go tests pass with `go test -race ./...`.