### PR TITLE
feat: home-directory memory inheritance across projects

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -477,11 +477,17 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// front, injected into the system prompt (below), and whitelisted for writes
 	// when the permission engine is built. --no-memory disables it; a resolve
 	// error degrades to no memory rather than failing.
-	var memDir string
+	// Home-directory memories are inherited into every project.
+	var memDir, homeMemDir string
 	if !*noMemory {
 		if d, err := memory.Dir(memory.ProjectRoot(cwd)); err == nil {
 			if memory.EnsureDir(d) == nil {
 				memDir = d
+			}
+		}
+		if d, err := memory.HomeDir(); err == nil {
+			if memory.EnsureDir(d) == nil {
+				homeMemDir = d
 			}
 		}
 	}
@@ -667,7 +673,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// directory on demand with its file tools — no consolidation pass.
 	var memInjection string
 	if memDir != "" {
-		memInjection = memory.RenderInjection(memDir)
+		memInjection = memory.RenderInjection(memDir, homeMemDir)
 	}
 	a.System = prompt.Compose(*system, cwd, env, skillsManifest, memInjection, coauthor)
 
@@ -677,7 +683,11 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// byte-stable. A MEMORY.md without those sections yields no hook — unchanged
 	// behaviour.
 	if memDir != "" {
-		if rules := memory.ParseRules(memDir); rules.HasAny() {
+		rules := memory.ParseRules(memDir)
+		if homeMemDir != "" {
+			rules.Merge(memory.ParseRules(homeMemDir))
+		}
+		if rules.HasAny() {
 			inj := memory.NewInjector(rules)
 			a.UserInputHook = inj.Reminder
 		}
@@ -688,7 +698,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// manage its memory files without a prompt on every save.
 	var permEngine *permission.Engine
 	if toolsOn {
-		eng, perr := permission.New(permissionConfigPath(), cwd, resolvePermissionMode(resolvedPermMode), memDir)
+		eng, perr := permission.New(permissionConfigPath(), cwd, resolvePermissionMode(resolvedPermMode), memDir, homeMemDir)
 		if perr != nil {
 			fmt.Fprintf(stderr, "octo chat: permission config: %v\n", perr)
 			return 1

--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -175,15 +175,17 @@ the index, injected into the system prompt each session; topic files beside it
 hold detail and load on demand.
 
 Commands:
-  octo memory list     List the project's memory files (default)
-  octo memory path     Print the project's memory directory
+  octo memory list     List the project's and inherited memory files (default)
+  octo memory path     Print the project's and inherited memory directories
 
 Layout:
-  ~/.octo/memories/<repo-slug>/MEMORY.md   Index, injected every session
-  ~/.octo/memories/<repo-slug>/<topic>.md  Detail files the agent reads on demand
+  ~/.octo/memories/<repo-slug>/MEMORY.md   Project index, injected every session
+  ~/.octo/memories/<repo-slug>/<topic>.md  Project detail files
+  ~/.octo/memories/<home-slug>/MEMORY.md   Inherited (home) index, available in every project
 
-The directory is keyed by git repo root, so each project has its own memory.
-To disable memory injection for a single session, run "octo chat --no-memory".`)
+The project directory is keyed by git repo root. Home-directory memories are
+inherited into every project. To disable memory injection for a single session,
+run "octo chat --no-memory".`)
 }
 
 func initHelp(w io.Writer) {

--- a/cmd/octo/memory.go
+++ b/cmd/octo/memory.go
@@ -9,8 +9,8 @@ import (
 )
 
 // runMemory handles `octo memory <subcommand>`:
-//   - path: print the current project's memory directory
-//   - list: list the files in it (MEMORY.md + topic files)
+//   - path: print the current project's and inherited memory directories
+//   - list: list the files in them (MEMORY.md + topic files)
 //
 // Memory is plain markdown the agent manages with its file tools; this command
 // is just a viewer/locator.
@@ -30,29 +30,45 @@ func runMemory(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "octo memory: %v\n", err)
 		return 1
 	}
+	homeDir, _ := memory.HomeDir()
+	if homeDir == dir {
+		homeDir = "" // same as project (running in home) — don't duplicate
+	}
 
 	if sub == "path" {
 		fmt.Fprintln(stdout, dir)
+		if homeDir != "" {
+			fmt.Fprintf(stdout, "Inherited: %s\n", homeDir)
+		}
 		return 0
 	}
 
 	fmt.Fprintf(stdout, "Memory directory: %s\n", dir)
+	printDirEntries(stdout, dir)
+
+	if homeDir != "" {
+		fmt.Fprintf(stdout, "\nInherited memories: %s\n", homeDir)
+		printDirEntries(stdout, homeDir)
+	}
+	return 0
+}
+
+func printDirEntries(w io.Writer, dir string) {
 	entries, err := os.ReadDir(dir)
 	if err != nil || len(entries) == 0 {
-		fmt.Fprintln(stdout, "  (empty — nothing remembered yet)")
-		return 0
+		fmt.Fprintln(w, "  (empty — nothing remembered yet)")
+		return
 	}
 	for _, e := range entries {
 		name := e.Name()
 		if e.IsDir() {
-			fmt.Fprintf(stdout, "  %s/\n", name)
+			fmt.Fprintf(w, "  %s/\n", name)
 			continue
 		}
 		if info, ierr := e.Info(); ierr == nil {
-			fmt.Fprintf(stdout, "  %-28s %6dB\n", name, info.Size())
+			fmt.Fprintf(w, "  %-28s %6dB\n", name, info.Size())
 		} else {
-			fmt.Fprintf(stdout, "  %s\n", name)
+			fmt.Fprintf(w, "  %s\n", name)
 		}
 	}
-	return 0
 }

--- a/dev-docs/memory-design.md
+++ b/dev-docs/memory-design.md
@@ -23,6 +23,12 @@ separate and described in `identity-files-design.md`.
   facts don't bleed across repos. Outside a git repo the working directory is
   used. The slug is the repo basename plus a short hash of the full path, so two
   checkouts that share a basename don't collide.
+- **Inheritance.** The home directory (`~`) also has its own memory slot.
+  When running inside any project, the home MEMORY.md is injected *before* the
+  project MEMORY.md, so cross-project preferences and personal facts are
+  available everywhere. The agent is instructed to sort new memories by scope:
+  project-specific facts go to the project memory; cross-project or personal
+  preferences go to the home (inherited) memory.
 - **MEMORY.md is the index.** It is loaded into the system prompt at session
   start, truncated to the first 200 lines / 25 KB (whichever comes first),
   mirroring Claude Code's cap. Topic files are not loaded up front — the agent
@@ -31,15 +37,15 @@ separate and described in `identity-files-design.md`.
 ## Injection
 
 At session start `cmd/octo` resolves the directory, creates it, and injects
-`memory.RenderInjection(dir)` into the composed system prompt (the `memory`
-layer of `prompt.Compose`). The injection is a short instruction block —
-*where* memory lives and *how* to manage it — followed by the current MEMORY.md
-(or an "empty" marker so a fresh project knows where to start). The notes are
-framed as the agent's own durable record of the user's preferences, workflow
-rules, and project facts, to be followed as standing guidance; the current user
-request and safety override a conflicting note. The block is frozen for the
-session: what the agent writes now surfaces in the *next* session, not the
-current one.
+`memory.RenderInjection(dir, inheritedDirs...)` into the composed system prompt
+(the `memory` layer of `prompt.Compose`). The injection is a short instruction
+block — *where* memory lives and *how* to manage it — followed by inherited
+MEMORY.md files (home directory first) and then the project MEMORY.md (or an
+"empty" marker so a fresh project knows where to start). The notes are framed
+as the agent's own durable record of the user's preferences, workflow rules,
+and project facts, to be followed as standing guidance; the current user request
+and safety override a conflicting note. The block is frozen for the session:
+what the agent writes now surfaces in the *next* session, not the current one.
 
 The session-prompt guidance (`internal/prompt/base.md`, "Memory" section)
 covers when to save (lasting preferences, corrections + the why, validated
@@ -86,7 +92,8 @@ The agent saves with `write_file` (append to MEMORY.md or a topic file), edits
 with `edit_file`, and removes with `terminal` (`rm`/`mv`). The memory directory
 lives outside the working directory, where the permission engine's default
 `write_file`/`edit_file` rules only auto-allow `$CWD/**`. So `cmd/octo` passes
-the directory to `permission.New(..., allowWriteRoots...)`, which prepends an
+both the project memory directory and the inherited home memory directory to
+`permission.New(..., allowWriteRoots...)`, which prepends an
 `allow { path: [<memDir>, <memDir>/**] }` rule to those tools — the agent
 manages its memory without a prompt on every save, while CWD and
 secret-path rules still apply everywhere else.

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -57,6 +57,15 @@ func Dir(repoRoot string) (string, error) {
 	return filepath.Join(home, ".octo", "memories", repoSlug(repoRoot)), nil
 }
 
+// HomeDir returns the memory directory for the user's home directory.
+func HomeDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", fmt.Errorf("memory: cannot resolve home dir: %w", err)
+	}
+	return Dir(home)
+}
+
 // repoSlug derives a stable, human-readable directory name from a repo root:
 // the basename plus a short hash of the full path, so two repos sharing a
 // basename (e.g. two checkouts of "app") don't collide.
@@ -102,17 +111,46 @@ func truncateForInjection(s string) string {
 // instruction block telling the model where its memory lives and how to manage
 // it, followed by the current MEMORY.md (truncated). The instruction is emitted
 // even when memory is empty so a fresh project knows where to start saving.
-func RenderInjection(dir string) string {
+//
+// If inheritedDirs are provided, their MEMORY.md files are also injected
+// first, so home-directory (global) memories are available in every project.
+func RenderInjection(dir string, inheritedDirs ...string) string {
+	// dedupe inheritedDirs against dir so home-dir doesn't double-inject
+	var filtered []string
+	for _, d := range inheritedDirs {
+		if d != dir {
+			filtered = append(filtered, d)
+		}
+	}
+	inheritedDirs = filtered
+
 	var b strings.Builder
 	b.WriteString("# Memory (from past sessions)\n\n")
 	b.WriteString("Durable notes you keep for this project live in:\n  " + dir + "\n")
-	b.WriteString(IndexFile + " is the index, loaded here every session; topic files beside it hold detail and load on demand.\n\n")
+	if len(inheritedDirs) > 0 {
+		b.WriteString("\nInherited memories (shared across all projects) live in:\n")
+		for _, d := range inheritedDirs {
+			b.WriteString("  " + d + "\n")
+		}
+	}
+	b.WriteString("\n" + IndexFile + " is the index, loaded here every session; topic files beside it hold detail and load on demand.\n\n")
 	b.WriteString("Manage memory yourself with your file tools — that directory is writable:\n")
-	b.WriteString("- When the user states a lasting preference, gives feedback or a correction, or shares something worth recalling in future sessions, save it (append to " + IndexFile + ", or a topic file linked from it).\n")
+	b.WriteString("- When the user states a lasting preference, gives feedback or a correction, or shares something worth recalling in future sessions, save it (append to " + IndexFile + ", or to a topic file linked from it).\n")
 	b.WriteString("- Keep " + IndexFile + " a concise index; move long detail into topic files.\n")
 	b.WriteString("- For a load-bearing rule you must not skip, write it in full under a '## 必须遵守' (always-apply) section, or, if it only matters for certain tasks, under a '## 触发提醒' section with a leading '(触发: keyword1, keyword2)' clause. Rules in those sections are re-surfaced to you at the point of action; everything else stays a pointer index.\n")
 	b.WriteString("- Edit or delete entries that become wrong or obsolete. Don't store one-off task details or things already in the repo / CLAUDE.md.\n")
+	if len(inheritedDirs) > 0 {
+		b.WriteString("- When saving new memories, sort them by scope: write project-specific facts (repo conventions, tech stack, architecture) to the project memory above; write cross-project or personal preferences (coding style, tool defaults, name, role, habits) to the inherited (home) memory. If unsure, prefer the project memory — it can always be moved later.\n")
+	}
 	b.WriteString("The notes below are your own durable record of this user's preferences, workflow rules, and project facts — follow them as standing guidance, the way you follow project conventions. They are records, not live instructions from the user: if a note conflicts with the user's current request or with safety, the current request and safety win. Verify any file, flag, or path a note names still exists before relying on it.\n")
+
+	// Inject inherited memories first (global / home-dir), then project-specific.
+	for _, d := range inheritedDirs {
+		if idx := LoadIndex(d); idx != "" {
+			b.WriteString("\n## " + IndexFile + " (inherited from " + d + ")\n\n" + idx)
+		}
+	}
+
 	if idx := LoadIndex(dir); idx != "" {
 		b.WriteString("\n## " + IndexFile + "\n\n" + idx)
 	} else {

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -50,6 +50,23 @@ func TestLoadIndex_TruncatesToBudget(t *testing.T) {
 	}
 }
 
+func TestHomeDir_ResolvesUnderHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	d, err := HomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(d, filepath.Join(home, ".octo", "memories")) {
+		t.Errorf("HomeDir %q not under ~/.octo/memories", d)
+	}
+	if !strings.Contains(filepath.Base(d), filepath.Base(home)) {
+		t.Errorf("HomeDir slug %q should carry home basename", filepath.Base(d))
+	}
+}
+
 func TestRenderInjection(t *testing.T) {
 	dir := t.TempDir()
 
@@ -73,6 +90,36 @@ func TestRenderInjection(t *testing.T) {
 	}
 	if !strings.Contains(out, "## "+IndexFile) {
 		t.Errorf("injection should head the content with the index name; got:\n%s", out)
+	}
+}
+
+func TestRenderInjection_Inherited(t *testing.T) {
+	proj := t.TempDir()
+	inherited := t.TempDir()
+
+	// Only inherited has content.
+	if err := os.WriteFile(filepath.Join(inherited, IndexFile), []byte("- global pref\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := RenderInjection(proj, inherited)
+	if !strings.Contains(out, "global pref") {
+		t.Errorf("injection should include inherited MEMORY.md content; got:\n%s", out)
+	}
+	if !strings.Contains(out, "inherited from") {
+		t.Errorf("injection should label inherited memories; got:\n%s", out)
+	}
+	if !strings.Contains(out, "is empty") {
+		t.Errorf("project memory should still be marked empty; got:\n%s", out)
+	}
+
+	// When dir == inherited (e.g. running in home), dedupe so content
+	// appears only once under the project heading.
+	if err := os.WriteFile(filepath.Join(proj, IndexFile), []byte("- local rule\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out = RenderInjection(proj, proj)
+	if strings.Count(out, "## "+IndexFile) != 1 {
+		t.Errorf("duplicate dir should dedupe; got %d headings:\n%s", strings.Count(out, "## "+IndexFile), out)
 	}
 }
 

--- a/internal/memory/rules.go
+++ b/internal/memory/rules.go
@@ -34,6 +34,35 @@ type Rules struct {
 // HasAny reports whether there is anything to inject.
 func (r *Rules) HasAny() bool { return len(r.Always) > 0 || len(r.Triggered) > 0 }
 
+// Merge merges other into r (in-place). Duplicate rules (by Text) are skipped
+// so project rules take precedence over inherited ones. De-duplication is
+// cross-section: if a project Triggered rule and an inherited Always rule share
+// the same text, the project rule wins.
+func (r *Rules) Merge(other *Rules) {
+	if other == nil {
+		return
+	}
+	seen := make(map[string]bool)
+	for _, rule := range r.Always {
+		seen[rule.Text] = true
+	}
+	for _, rule := range r.Triggered {
+		seen[rule.Text] = true
+	}
+	for _, rule := range other.Always {
+		if !seen[rule.Text] {
+			r.Always = append(r.Always, rule)
+			seen[rule.Text] = true
+		}
+	}
+	for _, rule := range other.Triggered {
+		if !seen[rule.Text] {
+			r.Triggered = append(r.Triggered, rule)
+			seen[rule.Text] = true
+		}
+	}
+}
+
 // section classifies a markdown heading into one of the actionable tiers.
 type section int
 

--- a/internal/memory/rules_test.go
+++ b/internal/memory/rules_test.go
@@ -92,6 +92,49 @@ func TestParseRules_TriggeredBulletWithoutClause(t *testing.T) {
 	}
 }
 
+func TestRules_Merge(t *testing.T) {
+	// Project rules (receiving side).
+	proj := &Rules{
+		Always:    []Rule{{Text: "rule A"}, {Text: "rule B"}},
+		Triggered: []Rule{{Text: "rule C", Triggers: []string{"c"}}},
+	}
+	// Inherited rules (merging side).
+	inherited := &Rules{
+		Always:    []Rule{{Text: "rule B"}, {Text: "rule D"}},                          // B duplicates project Always
+		Triggered: []Rule{{Text: "rule C"}, {Text: "rule E", Triggers: []string{"e"}}}, // C duplicates project Triggered
+	}
+	proj.Merge(inherited)
+
+	// Always should keep A, B (project) + D (inherited); skip duplicate B.
+	if len(proj.Always) != 3 {
+		t.Fatalf("Always = %d, want 3: %+v", len(proj.Always), proj.Always)
+	}
+	if proj.Always[0].Text != "rule A" || proj.Always[1].Text != "rule B" || proj.Always[2].Text != "rule D" {
+		t.Errorf("Always texts = %v", proj.Always)
+	}
+
+	// Triggered should keep C (project) + E (inherited); skip duplicate C.
+	if len(proj.Triggered) != 2 {
+		t.Fatalf("Triggered = %d, want 2: %+v", len(proj.Triggered), proj.Triggered)
+	}
+	if proj.Triggered[0].Text != "rule C" || proj.Triggered[1].Text != "rule E" {
+		t.Errorf("Triggered texts = %v", proj.Triggered)
+	}
+
+	// Cross-section dedup: a project Triggered rule should block an inherited
+	// Always rule with the same text.
+	proj2 := &Rules{
+		Triggered: []Rule{{Text: "shared"}},
+	}
+	inherited2 := &Rules{
+		Always: []Rule{{Text: "shared"}},
+	}
+	proj2.Merge(inherited2)
+	if len(proj2.Always) != 0 {
+		t.Errorf("cross-section dedup failed: Always = %v", proj2.Always)
+	}
+}
+
 func TestTriggerHit(t *testing.T) {
 	cases := []struct {
 		input, trigger string

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -62,7 +62,7 @@ var userRulesPath = func() string {
 //  2. soul    — ~/.octo/soul.md, if present (agent identity & behavior)
 //  3. env     — environment snapshot (cwd, git, date, OS) the caller renders
 //  4. skills  — the available-skills manifest the caller renders, if any
-//  5. memory  — cross-session memory the caller renders, if any (C9)
+//  5. memory  — cross-session memory the caller renders, if any (C9; includes inherited home-dir memories)
 //  6. profile — ~/.octo/user.md, if present (who the user is)
 //  7. user    — ~/.octo/octorules.md, if present (cross-project user rules)
 //  8. project — ProjectContextFile in cwd, if present (repo conventions)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -564,7 +564,7 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.Context, agent.ToolExecutor, *tools.SubAgentManager, error) {
 	executor := tools.NewDefaultRegistry()
 
-	engine, err := permission.New(permissionConfigPath(), s.cwd, resolvePermissionMode())
+	engine, err := permission.New(permissionConfigPath(), s.cwd, resolvePermissionMode(), s.memDir, s.homeMemDir)
 	if err != nil {
 		return ctx, nil, nil, fmt.Errorf("permission engine: %w", err)
 	}

--- a/internal/server/memory_handler.go
+++ b/internal/server/memory_handler.go
@@ -19,12 +19,11 @@ func (s *Server) handleGetMemory(w http.ResponseWriter, r *http.Request) {
 
 	// Security: prevent path traversal.
 	fname = filepath.Base(fname)
-	dir := s.memDir
-	if dir == "" {
+	p, ok := s.resolveMemoryPath(fname)
+	if !ok {
 		writeError(w, http.StatusNotFound, "memory not found")
 		return
 	}
-	p := filepath.Join(dir, fname)
 
 	data, err := os.ReadFile(p)
 	if err != nil {
@@ -49,12 +48,11 @@ func (s *Server) handleDeleteMemory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fname = filepath.Base(fname)
-	dir := s.memDir
-	if dir == "" {
+	p, ok := s.resolveMemoryPath(fname)
+	if !ok {
 		writeError(w, http.StatusNotFound, "memory not found")
 		return
 	}
-	p := filepath.Join(dir, fname)
 
 	if _, err := os.Stat(p); err != nil {
 		if os.IsNotExist(err) {
@@ -64,10 +62,22 @@ func (s *Server) handleDeleteMemory(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	if err := trash.Move(p, dir); err != nil {
+	if err := trash.Move(p, filepath.Dir(p)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+// resolveMemoryPath looks for fname first in the project memory dir, then in
+// the inherited (home) memory dir. The bool reports whether a valid dir was
+// found (not whether the file exists).
+func (s *Server) resolveMemoryPath(fname string) (string, bool) {
+	for _, dir := range []string{s.memDir, s.homeMemDir} {
+		if dir != "" {
+			return filepath.Join(dir, fname), true
+		}
+	}
+	return "", false
 }

--- a/internal/server/profile_handler.go
+++ b/internal/server/profile_handler.go
@@ -36,38 +36,46 @@ func (s *Server) handleGetProfileUser(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetMemories(w http.ResponseWriter, r *http.Request) {
-	dir := s.memDir
-	if dir == "" {
-		writeJSON(w, http.StatusOK, map[string]any{"files": []any{}})
-		return
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		writeJSON(w, http.StatusOK, map[string]any{"files": []any{}})
-		return
-	}
-
 	type memFile struct {
 		Name      string `json:"name"`
 		Path      string `json:"path"`
 		Size      int64  `json:"size"`
 		UpdatedAt string `json:"updated_at"`
+		Source    string `json:"source"`
 	}
 	files := make([]memFile, 0)
-	for _, e := range entries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+
+	for _, src := range []struct {
+		dir   string
+		label string
+	}{{
+		s.memDir, "project",
+	}, {
+		s.homeMemDir, "inherited",
+	}} {
+		if src.dir == "" {
 			continue
 		}
-		info, err := e.Info()
+		entries, err := os.ReadDir(src.dir)
 		if err != nil {
 			continue
 		}
-		files = append(files, memFile{
-			Name:      e.Name(),
-			Path:      filepath.Join(dir, e.Name()),
-			Size:      info.Size(),
-			UpdatedAt: info.ModTime().UTC().Format(time.RFC3339),
-		})
+		for _, e := range entries {
+			if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+				continue
+			}
+			info, err := e.Info()
+			if err != nil {
+				continue
+			}
+			files = append(files, memFile{
+				Name:      e.Name(),
+				Path:      filepath.Join(src.dir, e.Name()),
+				Size:      info.Size(),
+				UpdatedAt: info.ModTime().UTC().Format(time.RFC3339),
+				Source:    src.label,
+			})
+		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"files": files})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,6 +84,7 @@ type Server struct {
 	cwd            string
 	envCtx         string
 	memDir         string
+	homeMemDir     string
 
 	// session-scoped turn locks: one turn per session at a time.
 	turnLocks map[string]*sync.Mutex
@@ -172,11 +173,16 @@ func New(cfg Config) (*Server, error) {
 	accessKey := resolveAccessKey(cfg.AccessKey, fileCfg)
 
 	// Resolve cross-session memory directory.
-	var memDir string
+	var memDir, homeMemDir string
 	if !cfg.NoMemory {
 		if d, err := memory.Dir(memory.ProjectRoot(cwd)); err == nil {
 			if memory.EnsureDir(d) == nil {
 				memDir = d
+			}
+		}
+		if d, err := memory.HomeDir(); err == nil {
+			if memory.EnsureDir(d) == nil {
+				homeMemDir = d
 			}
 		}
 	}
@@ -192,6 +198,7 @@ func New(cfg Config) (*Server, error) {
 		cwd:              cwd,
 		envCtx:           envCtx,
 		memDir:           memDir,
+		homeMemDir:       homeMemDir,
 		turnLocks:        map[string]*sync.Mutex{},
 		turnRunning:      make(map[string]bool),
 		steerQueues:      make(map[string][]string),
@@ -238,7 +245,7 @@ func (s *Server) enableSubAgentTools() {
 	template := agent.New(s.sender, s.model)
 	var memInjection string
 	if s.memDir != "" {
-		memInjection = memory.RenderInjection(s.memDir)
+		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
 	}
 	template.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
 	executor := tools.NewDefaultRegistry()
@@ -439,7 +446,7 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	// L1: project memory embedded in the system prompt (stable across turns).
 	var memInjection string
 	if s.memDir != "" {
-		memInjection = memory.RenderInjection(s.memDir)
+		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
 	}
 	a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
 
@@ -449,6 +456,9 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 		inj, ok := s.sessionInjectors[sess.ID]
 		if !ok {
 			rules := memory.ParseRules(s.memDir)
+			if s.homeMemDir != "" {
+				rules.Merge(memory.ParseRules(s.homeMemDir))
+			}
 			if rules.HasAny() {
 				inj = memory.NewInjector(rules)
 				s.sessionInjectors[sess.ID] = inj
@@ -781,7 +791,7 @@ func (s *Server) initChannels() {
 	gate, _ := s.buildChannelGate()
 	var memInjection string
 	if s.memDir != "" {
-		memInjection = memory.RenderInjection(s.memDir)
+		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
 	}
 	factory := func() *agent.Agent {
 		a := agent.New(s.sender, s.model)
@@ -802,7 +812,7 @@ func (s *Server) initChannels() {
 
 // buildChannelGate creates a non-interactive permission gate for the IM bridge.
 func (s *Server) buildChannelGate() (agent.PermissionGate, error) {
-	engine, err := permission.New(permissionConfigPath(), s.cwd, resolvePermissionMode())
+	engine, err := permission.New(permissionConfigPath(), s.cwd, resolvePermissionMode(), s.memDir, s.homeMemDir)
 	if err != nil {
 		return nil, fmt.Errorf("permission engine: %w", err)
 	}

--- a/internal/skills/defaults/product_help/MEMORY.md
+++ b/internal/skills/defaults/product_help/MEMORY.md
@@ -23,6 +23,12 @@ separate and described in `identity-files-design.md`.
   facts don't bleed across repos. Outside a git repo the working directory is
   used. The slug is the repo basename plus a short hash of the full path, so two
   checkouts that share a basename don't collide.
+- **Inheritance.** The home directory (`~`) also has its own memory slot.
+  When running inside any project, the home MEMORY.md is injected *before* the
+  project MEMORY.md, so cross-project preferences and personal facts are
+  available everywhere. The agent is instructed to sort new memories by scope:
+  project-specific facts go to the project memory; cross-project or personal
+  preferences go to the home (inherited) memory.
 - **MEMORY.md is the index.** It is loaded into the system prompt at session
   start, truncated to the first 200 lines / 25 KB (whichever comes first),
   mirroring Claude Code's cap. Topic files are not loaded up front — the agent
@@ -31,15 +37,15 @@ separate and described in `identity-files-design.md`.
 ## Injection
 
 At session start `cmd/octo` resolves the directory, creates it, and injects
-`memory.RenderInjection(dir)` into the composed system prompt (the `memory`
-layer of `prompt.Compose`). The injection is a short instruction block —
-*where* memory lives and *how* to manage it — followed by the current MEMORY.md
-(or an "empty" marker so a fresh project knows where to start). The notes are
-framed as the agent's own durable record of the user's preferences, workflow
-rules, and project facts, to be followed as standing guidance; the current user
-request and safety override a conflicting note. The block is frozen for the
-session: what the agent writes now surfaces in the *next* session, not the
-current one.
+`memory.RenderInjection(dir, inheritedDirs...)` into the composed system prompt
+(the `memory` layer of `prompt.Compose`). The injection is a short instruction
+block — *where* memory lives and *how* to manage it — followed by inherited
+MEMORY.md files (home directory first) and then the project MEMORY.md (or an
+"empty" marker so a fresh project knows where to start). The notes are framed
+as the agent's own durable record of the user's preferences, workflow rules,
+and project facts, to be followed as standing guidance; the current user request
+and safety override a conflicting note. The block is frozen for the session:
+what the agent writes now surfaces in the *next* session, not the current one.
 
 The session-prompt guidance (`internal/prompt/base.md`, "Memory" section)
 covers when to save (lasting preferences, corrections + the why, validated
@@ -86,7 +92,8 @@ The agent saves with `write_file` (append to MEMORY.md or a topic file), edits
 with `edit_file`, and removes with `terminal` (`rm`/`mv`). The memory directory
 lives outside the working directory, where the permission engine's default
 `write_file`/`edit_file` rules only auto-allow `$CWD/**`. So `cmd/octo` passes
-the directory to `permission.New(..., allowWriteRoots...)`, which prepends an
+both the project memory directory and the inherited home memory directory to
+`permission.New(..., allowWriteRoots...)`, which prepends an
 `allow { path: [<memDir>, <memDir>/**] }` rule to those tools — the agent
 manages its memory without a prompt on every save, while CWD and
 secret-path rules still apply everywhere else.


### PR DESCRIPTION
Allow the home directory (`~`) to serve as a global memory slot that is inherited into every project.

## What changed

- **`memory.HomeDir()`** resolves the home memory directory using the same slug logic as project directories.
- **`RenderInjection`** now accepts `inheritedDirs...`. When running inside a project, the home `MEMORY.md` is injected *before* the project `MEMORY.md` in the system prompt.
- Both **CLI chat mode** and **server mode** resolve and inject `homeMemDir`.
- The **permission engine** is whitelisted for both `memDir` and `homeMemDir`, so the agent can write to either without interactive prompts.
- The **system prompt** now includes guidance telling the agent how to sort new memories by scope:
  - project-specific facts → project memory
  - cross-project / personal preferences → home (inherited) memory

## Updated docs

- `dev-docs/memory-design.md`
- `internal/skills/defaults/product_help/MEMORY.md`

## Why

Users often have preferences, workflow rules, and personal facts that apply across all projects (coding style, tool defaults, name/role, proxy settings). Previously these had to be duplicated into every project's memory or stored in the hand-written `~/.octo/user.md` / `~/.octo/octorules.md` layers. With inheritance, the agent's automatic memory layer can now hold global facts too, and the agent knows how to keep project and global scopes separate.