### PR TITLE
fix: disambiguate inherited memories in Web UI and correct agent self-perception

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -1,4 +1,4 @@
-You are octo, an AI coding agent that runs in a terminal and operates on the user's real machine through tools.
+You are octo, an AI coding agent that operates on the user's real machine through tools (file editing, shell commands, web browser automation via CDP, and more).
 
 ## How to work
 

--- a/internal/server/memory_handler.go
+++ b/internal/server/memory_handler.go
@@ -19,7 +19,7 @@ func (s *Server) handleGetMemory(w http.ResponseWriter, r *http.Request) {
 
 	// Security: prevent path traversal.
 	fname = filepath.Base(fname)
-	p, ok := s.resolveMemoryPath(fname)
+	p, ok := s.resolveMemoryPath(fname, r.URL.Query().Get("source"))
 	if !ok {
 		writeError(w, http.StatusNotFound, "memory not found")
 		return
@@ -48,7 +48,7 @@ func (s *Server) handleDeleteMemory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fname = filepath.Base(fname)
-	p, ok := s.resolveMemoryPath(fname)
+	p, ok := s.resolveMemoryPath(fname, r.URL.Query().Get("source"))
 	if !ok {
 		writeError(w, http.StatusNotFound, "memory not found")
 		return
@@ -70,10 +70,13 @@ func (s *Server) handleDeleteMemory(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
 
-// resolveMemoryPath looks for fname first in the project memory dir, then in
-// the inherited (home) memory dir. The bool reports whether a valid dir was
-// found (not whether the file exists).
-func (s *Server) resolveMemoryPath(fname string) (string, bool) {
+// resolveMemoryPath resolves fname to an absolute path. If source is
+// "inherited" it looks only in homeMemDir; otherwise it looks first in
+// memDir then in homeMemDir.
+func (s *Server) resolveMemoryPath(fname, source string) (string, bool) {
+	if source == "inherited" && s.homeMemDir != "" {
+		return filepath.Join(s.homeMemDir, fname), true
+	}
 	for _, dir := range []string{s.memDir, s.homeMemDir} {
 		if dir != "" {
 			return filepath.Join(dir, fname), true

--- a/internal/server/static/profile.js
+++ b/internal/server/static/profile.js
@@ -230,6 +230,7 @@ const Profile = (() => {
     const card = document.createElement("div");
     card.className = "memory-card";
     card.dataset.filename = m.filename;
+    card.dataset.source = m.source || "project";
 
     const topic   = m.topic || m.filename;
     const desc    = m.description || "";
@@ -246,6 +247,7 @@ const Profile = (() => {
           <span class="memory-filename">${_escapeHtml(m.filename)}</span>
           <span>${_escapeHtml(updated)}</span>
           <span>${size}</span>
+          ${m.source === "inherited" ? '<span class="memory-source-tag">inherited</span>' : ""}
         </div>
       </div>
       <div class="memory-card-actions">
@@ -286,7 +288,8 @@ const Profile = (() => {
       e.preventDefault();
       const target = a.dataset.memory;
       if (!target) return;
-      const el = document.querySelector(`.memory-card[data-filename="${CSS.escape(target)}"]`);
+      const el = document.querySelector(`.memory-card[data-filename="${CSS.escape(target)}"]`)
+        || document.querySelectorAll(`.memory-card[data-filename="${CSS.escape(target)}"]`)[0];
       if (el) {
         const btn = el.querySelector(".btn-memory-expand");
         if (btn && btn.getAttribute("aria-expanded") !== "true") btn.click();
@@ -312,7 +315,8 @@ const Profile = (() => {
       } else {
         if (!body.dataset.loaded) {
           body.innerHTML = `<div class="memory-card-loading">${_t("memories.loading")}</div>`;
-          fetch("/api/memories/" + encodeURIComponent(m.filename))
+          const src = m.source || "project";
+          fetch("/api/memories/" + encodeURIComponent(m.filename) + "?source=" + encodeURIComponent(src))
             .then(r => r.json())
             .then(d => {
               const stripped = _stripFrontmatter(d.content || "");
@@ -423,16 +427,17 @@ const Profile = (() => {
     if (!confirm(_t("memories.confirmDelete", { name: label }))) return;
 
     try {
+      const src = m.source || "project";
       const res = await fetch(
-        "/api/memories/" + encodeURIComponent(m.filename),
+        "/api/memories/" + encodeURIComponent(m.filename) + "?source=" + encodeURIComponent(src),
         { method: "DELETE" }
       );
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         throw new Error(data.error || `HTTP ${res.status}`);
       }
-      // Optimistic local remove + re-render.
-      _data.memories = _data.memories.filter(x => x.filename !== m.filename);
+      // Optimistic local remove + re-render (consider source for duplicate filenames).
+      _data.memories = _data.memories.filter(x => !(x.filename === m.filename && (x.source || "project") === src));
       _renderMemories();
     } catch (e) {
       console.error("[Profile] delete memory failed", e);

--- a/internal/skills/defaults/web-access/SKILL.md
+++ b/internal/skills/defaults/web-access/SKILL.md
@@ -3,8 +3,8 @@ name: web-access
 license: MIT
 github: https://github.com/eze-is/web-access
 description:
-  所有联网操作必须通过此 skill 处理，包括：搜索、网页抓取、登录后操作、网络交互等。
-  触发场景：用户要求搜索信息、查看网页内容、访问需要登录的网站、操作网页界面、抓取社交媒体内容（小红书、微博、推特等）、读取动态渲染页面、以及任何需要真实浏览器环境的网络任务。
+  所有联网操作必须通过此 skill 处理，包括：搜索、网页抓取、浏览器自动化操作、登录后操作、网络交互等。
+  触发场景：用户要求搜索信息、查看网页内容、通过 CDP 操控浏览器操作网页界面、访问需要登录的网站、抓取社交媒体内容（小红书、微博、推特等）、读取动态渲染页面、以及任何需要真实浏览器环境的网络任务。
 metadata:
   author: 一泽Eze
   version: "2.5.3"
@@ -65,7 +65,7 @@ node "<SKILL_DIR>/scripts/check-deps.mjs"
 
 浏览器 CDP 不要求 URL 已知——可从任意入口出发，通过页面内搜索、点击、跳转等方式找到目标内容。web_search、web_fetch、terminal（curl）均不处理登录态。
 
-**Jina**（可选预处理层，可与 web_fetch/terminal（curl）组合使用，由于其特性可节省 tokens 消耗，请积极在任务合适时组合使用）：第三方网络服务，可将网页转为 Markdown，大幅节省 token 但可能有信息损耗。调用方式为 `r.jina.ai/example.com`（URL 前加前缀，不保留原网址 http 前缀），限 20 RPM。适合文章、博客、文档、PDF 等以正文为核心的页面；对数据面板、商品页等非文章结构页面可能提取到错误区块。
+**Jina**（可选预处理层，可与 web_fetch/terminal（curl）组合使用，由于其特性可节省 tokens 消耗，请积极在任务合适时组合使用）：第三方网络服务，可将网页转为 Markdown，大幅节省 token 但可能有信息损耗。`web_fetch` 工具内部会自动优先通过 Jina 拉取，失败后再直接访问原始页面，因此**调用 `web_fetch` 时直接传入原始 URL 即可，不要自行拼接 `r.jina.ai/` 前缀**。限 20 RPM。适合文章、博客、文档、PDF 等以正文为核心的页面；对数据面板、商品页等非文章结构页面可能提取到错误区块。
 
 进入浏览器层后，通过 curl 调用 CDP Proxy API（`localhost:3456`）获取页面信息和执行操作：
 

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -89,6 +89,15 @@ func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any)
 	if strings.TrimSpace(raw) == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: url is required")
 	}
+	// Strip a mistakenly-passed Jina prefix so both the proxy and fallback
+	// paths operate on the original URL.
+	jinaHost := jinaReaderHostForTest
+	if !strings.HasSuffix(jinaHost, "/") {
+		jinaHost += "/"
+	}
+	if strings.HasPrefix(raw, jinaHost) {
+		raw = strings.TrimPrefix(raw, jinaHost)
+	}
 	u, err := url.Parse(raw)
 	if err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: parse url: %w", err)


### PR DESCRIPTION
## Summary

Fixes a bug where the Web UI's Memory panel could not correctly display or delete inherited (home-directory) memory files when they shared a name with project memory files (e.g. both have `MEMORY.md`).

Also updates the system prompt and skill description so the agent does not incorrectly self-limit to CLI-only operations.

## Changes

### Bug fixes
- **`internal/server/memory_handler.go`**: `resolveMemoryPath` now accepts a `source` query parameter. `source=inherited` forces lookup in `homeMemDir` instead of defaulting to the project directory.
- **`internal/server/static/profile.js`**: Cards now carry `data-source` from the API list, display an "inherited" tag, and pass `?source=...` on expand fetch and DELETE requests.
- **`internal/tools/web_fetch.go`**: Strip a mistakenly-passed Jina prefix so the tool does not double-prefix URLs.

### Prompt / skill fixes
- **`internal/prompt/base.md`**: Replaced "runs in a terminal" with "operates on the user's real machine through tools (file editing, shell commands, web browser automation via CDP, and more)" to prevent the agent from incorrectly assuming it lacks browser capabilities.
- **`internal/skills/defaults/web-access/SKILL.md`**: Updated description to explicitly mention "browser automation" and "CDP" as trigger keywords.

## Testing
- `go test ./...` passes.
- Verified API: `GET /api/memories/MEMORY.md?source=inherited` returns the home memory content correctly.
- Web UI tested via browser CDP automation (after the fix, inherited MEMORY.md expands to the correct content).

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
