### PR TITLE
style(web): add CSS for inherited memory source tag

### DIFF
--- a/internal/server/static/app.css
+++ b/internal/server/static/app.css
@@ -5612,6 +5612,18 @@ body {
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
 }
 
+.memory-source-tag {
+  display: inline-block;
+  padding: 0 0.375rem;
+  border-radius: 3px;
+  font-size: 0.625rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--color-accent-primary);
+  background: var(--color-accent-soft);
+}
+
 .memory-card-actions {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
Add .memory-source-tag styling so inherited memory cards show a subtle indigo pill label. Uses existing color system variables (--color-accent-primary and --color-accent-soft).

Follow-up to #501 which added the DOM element but left it unstyled.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>