### PR TITLE
fix(server): track running adapters directly on Server + docs(prompt): nohup/\u0026 warning

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -73,6 +73,8 @@ Memories are snapshots and can be stale. If one names a file path, function, fla
 
 ## Background processes
 
+- **Never use `nohup` or shell `&` in a synchronous `terminal` call.** In sync mode the tool creates stdout/stderr pipes that are inherited by the forked child; `cmd.Wait()` does not return until all pipe write-ends are closed, so the command appears to hang until the background process exits. Always use `run_in_background:true` for anything that outlives the immediate turn.
+
 ### One-shot tasks (compiles, tests, installs, builds, linting, CI checks)
 
 - Use `terminal` with `run_in_background:true`. Do not let a long command block the session.

--- a/internal/server/channels_handler.go
+++ b/internal/server/channels_handler.go
@@ -248,13 +248,8 @@ func platformToInfo(name string, pc channel.PlatformConfig) channelInfo {
 
 // isAdapterRunning reports whether the platform adapter is currently active.
 func (s *Server) isAdapterRunning(platform string) bool {
-	if s.channelMgr == nil {
-		return false
-	}
-	if !s.channelMgr.IsRunning() {
-		return false
-	}
-	return s.channelMgr.AdapterFor(platform) != nil
+	_, ok := s.runningAdapters.Load(platform)
+	return ok
 }
 
 func maskSecret(s string) string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -133,9 +133,10 @@ type Server struct {
 
 	// channel manager for IM platform bridging (DingTalk, Feishu, etc.).
 	// nil when NoChannel is set or no channels are configured.
-	channelCfg    *channel.Config
-	channelMgr    *channel.Manager
-	channelCancel context.CancelFunc
+	channelCfg      *channel.Config
+	channelMgr      *channel.Manager
+	channelCancel   context.CancelFunc
+	runningAdapters sync.Map // string -> channel.Adapter
 
 	// mcpCleanup unregisters + closes the MCP registry connected at start.
 	// Always non-nil after New (a no-op when no servers connected).
@@ -850,6 +851,7 @@ func (s *Server) startChannels() {
 			continue
 		}
 
+		s.runningAdapters.Store(name, ad)
 		go func(a channel.Adapter, platform string) {
 			_ = a.Start(ctx, func(ev channel.InboundEvent) {
 				ev.Platform = platform
@@ -902,4 +904,5 @@ func (s *Server) stopChannels() {
 	if s.channelCancel != nil {
 		s.channelCancel()
 	}
+	s.runningAdapters = sync.Map{}
 }


### PR DESCRIPTION
## Problem

The Web UI showed "Enabled but not running" for all channel adapters (including WeChat) even when they were actively processing messages.

### Root cause

The server starts adapters directly in  but never calls .  Consequently  was always  and the earlier fix (#502) that queried  +  returned  for every platform.

## Changes

### Server ()

- Add  () to track adapters launched by .
- Register each adapter on successful construction, clear on shutdown.
- Simplify  to look at  instead of the dormant Manager.

### Prompt ()

- Add explicit rule: **Never use  or shell  in a synchronous  call.**
- Backgrounding a process via  in sync mode inherits the stdout/stderr pipes;  blocks until the child exits, making the tool appear hung. Always use  for anything that outlives the turn.

## Verification

- go test -race  -tags='' ./...
ok  	github.com/Leihb/octo-agent/cmd/octo	(cached)
?   	github.com/Leihb/octo-agent/cmd/octo-eval	[no test files]
ok  	github.com/Leihb/octo-agent/internal/agent	(cached)
ok  	github.com/Leihb/octo-agent/internal/app	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel	(cached)
?   	github.com/Leihb/octo-agent/internal/channel/adapters/dingtalk	[no test files]
?   	github.com/Leihb/octo-agent/internal/channel/adapters/feishu	[no test files]
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	(cached)
ok  	github.com/Leihb/octo-agent/internal/conductor	(cached)
ok  	github.com/Leihb/octo-agent/internal/config	(cached)
ok  	github.com/Leihb/octo-agent/internal/eval	(cached)
ok  	github.com/Leihb/octo-agent/internal/hooks	(cached)
ok  	github.com/Leihb/octo-agent/internal/mcp	(cached)
ok  	github.com/Leihb/octo-agent/internal/memory	(cached)
ok  	github.com/Leihb/octo-agent/internal/permission	(cached)
ok  	github.com/Leihb/octo-agent/internal/prompt	(cached)
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/openai	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/retry	(cached)
ok  	github.com/Leihb/octo-agent/internal/sandbox	(cached)
?   	github.com/Leihb/octo-agent/internal/scheduler	[no test files]
ok  	github.com/Leihb/octo-agent/internal/server	(cached)
ok  	github.com/Leihb/octo-agent/internal/skills	(cached)
ok  	github.com/Leihb/octo-agent/internal/tasks	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools/rgembed	(cached)
?   	github.com/Leihb/octo-agent/internal/trash	[no test files]
ok  	github.com/Leihb/octo-agent/internal/tui	(cached)
ok  	github.com/Leihb/octo-agent/internal/version	(cached) passes (go test -race ./...).
- No front-end changes needed; the UI already reads  and .