### PR TITLE
fix(tools): kill the process group in KillAll so background children don't survive TUI exit

### DIFF
--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -413,11 +413,20 @@ func (m *BackgroundManager) Remove(id string) {
 
 // KillAll terminates every tracked process. Called on session shutdown so no
 // background command is orphaned.
+//
+// Cancelling the context alone only SIGKILLs the direct child — the shell
+// wrapper (sh -c / pwsh) that shellCommand spawns. Any process that wrapper
+// started (the actual long-running server) would be reparented and survive.
+// So, like Kill, we signal the whole process group (POSIX kill(-pid); Windows
+// taskkill /T) to take the wrapper's children down with it.
 func (m *BackgroundManager) KillAll() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, p := range m.procs {
 		p.cancel()
+		if p.proc != nil {
+			_ = killProcessGroup(p.proc, "SIGKILL")
+		}
 	}
 }
 

--- a/internal/tools/background_orphan_test.go
+++ b/internal/tools/background_orphan_test.go
@@ -1,0 +1,64 @@
+//go:build darwin || linux
+
+package tools
+
+import (
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestKillAll_KillsOrphanedChildren is a regression test for background
+// processes surviving session shutdown (TUI exit). The shell wrapper
+// backgrounds a child (sleep) and prints its PID; KillAll must take the whole
+// process group down, not just SIGKILL the wrapper and leave the child
+// reparented to init and alive.
+func TestKillAll_KillsOrphanedChildren(t *testing.T) {
+	mgr := NewBackgroundManager()
+
+	// `sleep 60 &` makes sleep a background child of the wrapping shell; the
+	// shell echoes its PID ($!) and waits. Cancelling the context SIGKILLs only
+	// the shell — without a process-group kill, sleep is orphaned and lives on.
+	id, err := mgr.Start("sleep 60 & echo $! ; wait")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Read the child PID the shell echoed.
+	var childPID int
+	for i := 0; i < 50 && childPID == 0; i++ {
+		out, _, _, _ := mgr.Read(id)
+		if fields := strings.Fields(strings.TrimSpace(out)); len(fields) > 0 {
+			if pid, perr := strconv.Atoi(fields[0]); perr == nil {
+				childPID = pid
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if childPID == 0 {
+		t.Fatal("did not capture background child PID from shell output")
+	}
+
+	// Sanity: the child is alive before shutdown (signal 0 = existence check).
+	if err := syscall.Kill(childPID, 0); err != nil {
+		t.Fatalf("child %d should be alive before KillAll: %v", childPID, err)
+	}
+
+	mgr.KillAll()
+
+	// The child must be reaped along with its process group.
+	alive := true
+	for i := 0; i < 100; i++ {
+		if err := syscall.Kill(childPID, 0); err == syscall.ESRCH {
+			alive = false
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if alive {
+		_ = syscall.Kill(childPID, syscall.SIGKILL) // don't leak on failure
+		t.Fatalf("background child %d survived KillAll (orphaned)", childPID)
+	}
+}


### PR DESCRIPTION
## Problem

Background tasks the agent starts (`terminal` with `run_in_background:true`) keep running after the user exits the TUI. Reported in real use.

## Root cause

On shutdown the REPL/TUI defers `tools.KillAllBackground()` (`repl.go:102`, `tuirepl.go:37`), but `BackgroundManager.KillAll()` only called `p.cancel()`. Cancelling the `exec.CommandContext` context SIGKILLs the **direct child only** — the shell wrapper (`sh -c` / `pwsh`) that `shellCommand` spawns, which is the process-group leader. Any process that wrapper launched (the actual dev server / long-running command) is reparented to init/launchd and survives as an orphan.

The per-id `Kill` / `KillWithSignal` path doesn't have this bug — it also calls `killProcessGroup`, which signals the whole group (POSIX `kill(-pid)`, Windows `taskkill /T`). `KillAll` was simply never updated to match when group-killing was introduced.

## Fix

`KillAll` now mirrors `Kill`'s SIGKILL path: cancel the context **and** `killProcessGroup(p.proc, "SIGKILL")` for each tracked process, taking the wrapper's children down with it. Doing it inline (rather than relying on the context watchdog goroutine) also removes the race where the process exits before the SIGKILL lands.

## Test

New POSIX regression test (`background_orphan_test.go`, `darwin || linux`): starts `sleep 60 & echo $! ; wait`, captures the backgrounded child's PID, calls `KillAll`, and asserts the child is reaped (`kill(pid, 0)` → `ESRCH`).

- **Red** without the fix: `background child <pid> survived KillAll (orphaned)`
- **Green** with the fix
- `go test -race ./internal/tools/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)