### PR TITLE
fix(tools): group-kill in Remove's belt-and-suspenders path for consistency

### DIFF
--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -405,9 +405,15 @@ func (m *BackgroundManager) Remove(id string) {
 	delete(m.procs, id)
 	m.mu.Unlock()
 	// Belt-and-suspenders: if Remove is ever called on a still-running id,
-	// cancel it so the process can't outlive its map entry.
+	// take it down so it can't outlive its map entry. Cancelling alone only
+	// SIGKILLs the shell wrapper and orphans its children, so — like Kill and
+	// KillAll — also signal the whole process group. A no-op on an already
+	// exited process (the common reap path), where the group is gone.
 	if ok && p != nil {
 		p.cancel()
+		if p.proc != nil {
+			_ = killProcessGroup(p.proc, "SIGKILL")
+		}
 	}
 }
 

--- a/internal/tools/background_orphan_test.go
+++ b/internal/tools/background_orphan_test.go
@@ -10,24 +10,16 @@ import (
 	"time"
 )
 
-// TestKillAll_KillsOrphanedChildren is a regression test for background
-// processes surviving session shutdown (TUI exit). The shell wrapper
-// backgrounds a child (sleep) and prints its PID; KillAll must take the whole
-// process group down, not just SIGKILL the wrapper and leave the child
-// reparented to init and alive.
-func TestKillAll_KillsOrphanedChildren(t *testing.T) {
-	mgr := NewBackgroundManager()
-
-	// `sleep 60 &` makes sleep a background child of the wrapping shell; the
-	// shell echoes its PID ($!) and waits. Cancelling the context SIGKILLs only
-	// the shell — without a process-group kill, sleep is orphaned and lives on.
+// startWithBackgroundChild launches a tracked process whose wrapping shell
+// backgrounds a `sleep` and echoes that child's PID ($!), then waits. The
+// returned PID is the grandchild that gets orphaned if only the shell wrapper
+// (the direct child / group leader) is SIGKILLed instead of the whole group.
+func startWithBackgroundChild(t *testing.T, mgr *BackgroundManager) (id string, childPID int) {
+	t.Helper()
 	id, err := mgr.Start("sleep 60 & echo $! ; wait")
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-
-	// Read the child PID the shell echoed.
-	var childPID int
 	for i := 0; i < 50 && childPID == 0; i++ {
 		out, _, _, _ := mgr.Read(id)
 		if fields := strings.Fields(strings.TrimSpace(out)); len(fields) > 0 {
@@ -40,25 +32,45 @@ func TestKillAll_KillsOrphanedChildren(t *testing.T) {
 	if childPID == 0 {
 		t.Fatal("did not capture background child PID from shell output")
 	}
-
-	// Sanity: the child is alive before shutdown (signal 0 = existence check).
+	// Sanity: the child is alive (signal 0 = existence check).
 	if err := syscall.Kill(childPID, 0); err != nil {
-		t.Fatalf("child %d should be alive before KillAll: %v", childPID, err)
+		t.Fatalf("child %d should be alive: %v", childPID, err)
 	}
+	return id, childPID
+}
 
-	mgr.KillAll()
-
-	// The child must be reaped along with its process group.
-	alive := true
+// assertReaped polls until the child PID is gone (ESRCH), failing if it
+// survives — i.e. was orphaned rather than taken down with its process group.
+func assertReaped(t *testing.T, childPID int, after string) {
+	t.Helper()
 	for i := 0; i < 100; i++ {
 		if err := syscall.Kill(childPID, 0); err == syscall.ESRCH {
-			alive = false
-			break
+			return
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	if alive {
-		_ = syscall.Kill(childPID, syscall.SIGKILL) // don't leak on failure
-		t.Fatalf("background child %d survived KillAll (orphaned)", childPID)
-	}
+	_ = syscall.Kill(childPID, syscall.SIGKILL) // don't leak on failure
+	t.Fatalf("background child %d survived %s (orphaned)", childPID, after)
+}
+
+// TestKillAll_KillsOrphanedChildren is a regression test for background
+// processes surviving session shutdown (TUI exit). KillAll must take the whole
+// process group down, not just SIGKILL the wrapper and leave the child
+// reparented to init and alive.
+func TestKillAll_KillsOrphanedChildren(t *testing.T) {
+	mgr := NewBackgroundManager()
+	_, childPID := startWithBackgroundChild(t, mgr)
+	mgr.KillAll()
+	assertReaped(t, childPID, "KillAll")
+}
+
+// TestRemove_KillsOrphanedChildren guards the belt-and-suspenders path in
+// Remove: if it's ever called on a still-running id, the process (and its
+// children) must not outlive the map entry. Cancelling the context alone would
+// orphan the grandchild, so Remove also group-kills.
+func TestRemove_KillsOrphanedChildren(t *testing.T) {
+	mgr := NewBackgroundManager()
+	id, childPID := startWithBackgroundChild(t, mgr)
+	mgr.Remove(id)
+	assertReaped(t, childPID, "Remove")
 }


### PR DESCRIPTION
Follow-up to #507, covering the two related paths flagged there.

## `Remove(id)` — hardened (this PR)

`Remove`'s defensive branch claims "if Remove is ever called on a still-running id, cancel it so the process can't outlive its map entry" — but it only called `p.cancel()`, which SIGKILLs the shell wrapper and orphans its children, the exact leak #507 fixed in `KillAll`. So the stated guarantee was false on that path.

Both real callers are safe **today**: `terminal.go` reaps via `Remove` only after the process has `exited` (line 209), or calls `Kill()` — which group-kills — *before* `Remove` on the cancel path (line 197–199). So this is **not a live leak**, just an incorrect safety net. Like `Kill`/`KillAll`, `Remove` now signals the whole process group; it's a no-op on an already-exited process (the common reap path).

## `SubAgentManager.KillAll` — no change needed (investigated)

Sub-agents are in-process goroutines, so cancelling their context is the correct teardown — they own no OS process. Their `terminal background:true` commands run through the shared package-global `defaultBg` (the only `TerminalTool{}` is constructed with no injected manager, `registry.go:25`), which is already taken down by #507's `KillAllBackground`. No separate orphan path exists.

## Test

Extends the POSIX regression suite from #507: a `Remove`-on-a-live-process variant asserting the backgrounded child is reaped.

- **Red** without the fix: `background child <pid> survived Remove (orphaned)`
- **Green** with it
- `go test -race ./internal/tools/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)