### PR TITLE
fix(server,channel): reap background processes on daemon shutdown

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -233,6 +233,9 @@ func runChannelStart(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 
 	fmt.Fprintln(stdout, "\nocto channel: shutting down...")
 	_ = mgr.Stop()
+	// Reap any background processes the IM sessions started so they don't
+	// outlive the bridge — parity with the CLI/TUI and web-server shutdown.
+	tools.KillAllBackground()
 	return 0
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -296,6 +296,11 @@ func (s *Server) ListenAndServe() error {
 // sub-agent + task registrations installed by enableSubAgentTools.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.stopChannels()
+	// Kill background processes started via web/IM sessions so they don't
+	// outlive the daemon — the same orphan-prevention the CLI/TUI do on exit.
+	// terminal background commands run through the process-global manager
+	// regardless of which session launched them, so one call covers all.
+	tools.KillAllBackground()
 	tools.SetDefaultSubAgentManager(nil)
 	tools.SetTaskStore(nil)
 	if s.mcpCleanup != nil {

--- a/internal/server/shutdown_background_test.go
+++ b/internal/server/shutdown_background_test.go
@@ -1,0 +1,44 @@
+//go:build darwin || linux
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// TestShutdown_KillsBackgroundProcesses guards the daemon-shutdown orphan fix:
+// background commands started through web/IM sessions run in the process-global
+// manager, and Server.Shutdown must reap them so they don't outlive the server.
+func TestShutdown_KillsBackgroundProcesses(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	// Launch a detached process in the same process-global manager that the
+	// web/IM terminal tool uses.
+	term := tools.TerminalTool{}
+	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
+		"command":           "sleep 60",
+		"run_in_background": true,
+	}); err != nil {
+		t.Fatalf("start background: %v", err)
+	}
+	if len(tools.RunningBackground()) == 0 {
+		t.Fatal("expected a running background process after launch")
+	}
+
+	if err := srv.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	// Shutdown must take the background process down; poll until none remain.
+	for i := 0; i < 100; i++ {
+		if len(tools.RunningBackground()) == 0 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("background process survived server Shutdown")
+}


### PR DESCRIPTION
Follow-up to #507 / #508, answering "do the web and channel UIs leak the same way?" — **yes**, and this fixes both.

## The gap

The orphan-on-exit fix was wired only into the CLI/TUI paths (`repl.go`, `tuirepl.go`, `init.go` all `defer tools.KillAllBackground()`). The two long-running daemon UIs never called it:

- **`octo serve` (web):** `Server.Shutdown` stopped channels, dropped the sub-agent/task registrations, ran MCP cleanup, and shut the HTTP server — but never killed background processes. A `terminal run_in_background:true` command started from a web (or IM-under-serve) session kept running after the server stopped.
- **`octo channel` (standalone IM bridge):** the Ctrl-C handler called `mgr.Stop()` (cancel context + stop adapters) only — same leak. `Manager.Stop()` / `stopChannels` don't touch background processes.

## Fix

A single `tools.KillAllBackground()` in each shutdown path. `terminal` background commands run through the process-global manager (`defaultBg`) regardless of which session launched them — the only `TerminalTool` is built with no injected manager — so one call covers web, IM, and sub-agent-launched commands alike.

Sub-agents need no separate handling: they're in-process goroutines that die with the process, and their background commands already land in `defaultBg`.

## Test

POSIX regression test (`internal/server`): launch a detached process in the global manager, call `Server.Shutdown`, assert it's reaped.

- **Red** without the fix: `background process survived server Shutdown`
- **Green** with it
- `go test -race ./internal/server/ ./cmd/octo/` passes

The standalone `octo channel` path is a signal-blocked `main`-package command (not unit-testable the same way); its one-line `KillAllBackground()` call relies on the same well-tested primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)