### PR TITLE
feat(tools): terminal detached:true — launch daemons that outlive octo

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -74,6 +74,7 @@ Memories are snapshots and can be stale. If one names a file path, function, fla
 ## Background processes
 
 - **Never use `nohup` or shell `&` in a synchronous `terminal` call.** In sync mode the tool creates stdout/stderr pipes that are inherited by the forked child; `cmd.Wait()` does not return until all pipe write-ends are closed, so the command appears to hang until the background process exits. Always use `run_in_background:true` for anything that outlives the immediate turn.
+- **`run_in_background` vs `detached` — pick by lifecycle.** `run_in_background:true` is the default for work tied to this session (servers, watchers, one-shot builds): octo tracks it, you can read its output and kill it, and it is **stopped when the session ends**. Use `detached:true` ONLY when the user explicitly wants a process to **outlive octo** — e.g. exposing a port with `ngrok`, starting a standalone daemon. A detached process runs in its own session, is untracked (no `terminal_output` / `kill_shell`), is not killed on exit, and returns only its OS pid. Don't reach for `detached` to dodge the session timeout — that's what `run_in_background` is for. Never hand-roll `nohup`/`setsid`/`&`; set `detached:true` and the tool handles it.
 
 ### One-shot tasks (compiles, tests, installs, builds, linting, CI checks)
 

--- a/internal/tools/detached.go
+++ b/internal/tools/detached.go
@@ -1,0 +1,74 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// startDetached launches command as a daemon that outlives the agent harness:
+// a new session (detachedCommand) immune to the harness's process-group kills,
+// not bound to a cancelable context, with stdio pointed at a log file and
+// /dev/null rather than the harness pipes. It is deliberately NOT registered in
+// the BackgroundManager — fire-and-forget — so terminal_output / kill_shell and
+// the on-exit KillAll all ignore it. The caller gets only the OS pid and the
+// resolved log path; managing the process afterward is up to the user.
+//
+// logFile is resolved relative to the working dir when not absolute; an empty
+// logFile defaults to "nohup.out" there, matching the nohup convention.
+func startDetached(ctx context.Context, command, logFile string) (pid int, logPath string, err error) {
+	workdir := WorkingDir(ctx)
+	if workdir == "" {
+		workdir, _ = os.Getwd()
+	}
+
+	logPath = resolveLogPath(workdir, logFile)
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return 0, "", fmt.Errorf("detached: open log %q: %w", logPath, err)
+	}
+
+	cmd := detachedCommand(ctx, command)
+	cmd.Stdout = f
+	cmd.Stderr = f
+	cmd.Stdin = nil // nil Stdin = /dev/null; a detached daemon must not hold the harness's stdin
+
+	if err := cmd.Start(); err != nil {
+		_ = f.Close()
+		return 0, "", fmt.Errorf("detached: start: %w", err)
+	}
+	pid = cmd.Process.Pid
+	_ = f.Close() // the child holds its own dup of the fd
+
+	// Reap in the background so the daemon doesn't linger as a zombie while octo
+	// is still alive; once octo exits the child is reparented to init. We never
+	// signal it — outliving the session is the whole point.
+	go func() { _ = cmd.Wait() }()
+
+	return pid, logPath, nil
+}
+
+// resolveLogPath picks the detached daemon's log file: an explicit path
+// (~-expanded, made absolute against workdir if relative), else nohup.out in
+// the working dir.
+func resolveLogPath(workdir, logFile string) string {
+	if logFile == "" {
+		return filepath.Join(workdir, "nohup.out")
+	}
+	logFile = expandHome(logFile)
+	if filepath.IsAbs(logFile) {
+		return logFile
+	}
+	return filepath.Join(workdir, logFile)
+}
+
+// expandHome replaces a leading ~ or ~/ with the user's home directory.
+func expandHome(path string) string {
+	if path == "~" || (len(path) >= 2 && path[:2] == "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[1:])
+		}
+	}
+	return path
+}

--- a/internal/tools/detached_test.go
+++ b/internal/tools/detached_test.go
@@ -1,0 +1,100 @@
+//go:build darwin || linux
+
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+var pidRe = regexp.MustCompile(`pid (\d+)`)
+
+// TestTerminal_Detached_OutlivesHarness is the core guarantee of detached:true —
+// the process runs in its own session, is NOT tracked by the BackgroundManager,
+// and survives KillAllBackground (the on-exit reap). It also checks output lands
+// in the requested log file.
+func TestTerminal_Detached_OutlivesHarness(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "daemon.log")
+
+	res, err := TerminalTool{}.Execute(context.Background(), "terminal", map[string]any{
+		"command":  "echo hello-daemon; sleep 60",
+		"detached": true,
+		"log_file": logPath,
+	})
+	if err != nil {
+		t.Fatalf("detached launch: %v", err)
+	}
+
+	m := pidRe.FindStringSubmatch(res.Text)
+	if m == nil {
+		t.Fatalf("no pid in result: %q", res.Text)
+	}
+	pid, _ := strconv.Atoi(m[1])
+	defer func() { _ = syscall.Kill(pid, syscall.SIGKILL) }() // don't leak the sleep
+
+	// Alive right after launch.
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("detached pid %d not alive after launch: %v", pid, err)
+	}
+
+	// Not tracked: fire-and-forget means it never enters the manager.
+	for _, p := range RunningBackground() {
+		t.Fatalf("detached process should be untracked, but RunningBackground lists %+v", p)
+	}
+
+	// The whole point: the harness's on-exit reap must NOT touch it.
+	KillAllBackground()
+	time.Sleep(200 * time.Millisecond)
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("detached pid %d was killed by KillAllBackground (should survive): %v", pid, err)
+	}
+
+	// Output went to the log file.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if b, _ := os.ReadFile(logPath); strings.Contains(string(b), "hello-daemon") {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("log file %s never received the daemon's output", logPath)
+}
+
+// TestTerminal_Detached_DefaultLogIsNohupOut verifies the nohup-style default
+// log path when log_file is omitted.
+func TestTerminal_Detached_DefaultLogIsNohupOut(t *testing.T) {
+	tmp := t.TempDir()
+	ctx := WithWorkingDir(context.Background(), tmp)
+
+	res, err := TerminalTool{}.Execute(ctx, "terminal", map[string]any{
+		"command":  "echo via-default; sleep 60",
+		"detached": true,
+	})
+	if err != nil {
+		t.Fatalf("detached launch: %v", err)
+	}
+	m := pidRe.FindStringSubmatch(res.Text)
+	if m == nil {
+		t.Fatalf("no pid in result: %q", res.Text)
+	}
+	pid, _ := strconv.Atoi(m[1])
+	defer func() { _ = syscall.Kill(pid, syscall.SIGKILL) }()
+
+	want := filepath.Join(tmp, "nohup.out")
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if b, _ := os.ReadFile(want); strings.Contains(string(b), "via-default") {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("default log %s never received output", want)
+}

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -75,30 +75,65 @@ func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 		}
 		return cmd, err
 	}
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		// -NoProfile: reproducible env (don't run the user's $PROFILE).
-		// -NonInteractive: never block on a PowerShell prompt mid-command.
-		cmd = exec.CommandContext(ctx, resolvePowerShell(), "-NoProfile", "-NonInteractive", "-Command", command)
-	} else {
-		projectDir := WorkingDir(ctx)
-		if projectDir == "" {
-			projectDir, _ = os.Getwd()
-		}
-		if projectDir != "" {
-			trashDir := trash.ProjectDir(projectDir)
-			wrapped := fmt.Sprintf(safeRmWrapper, command)
-			cmd = exec.CommandContext(ctx, "sh", "-c", wrapped)
-			cmd.Env = append(os.Environ(), "OCTO_TRASH_DIR="+trashDir)
-		} else {
-			cmd = exec.CommandContext(ctx, "sh", "-c", command)
-		}
+	name, args, env := shellInvocation(ctx, command)
+	cmd := exec.CommandContext(ctx, name, args...)
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
 	}
 	if attr := setProcessGroupOpts(); attr != nil {
 		cmd.SysProcAttr = attr
 	}
 	applyWorkingDir(ctx, cmd)
 	return cmd, nil
+}
+
+// shellInvocation returns the shell program, its argv, and any extra env needed
+// to run `command` via the platform shell: POSIX `sh -c` (with the safe-rm
+// trash wrapper when a project dir is known) on macOS/Linux, PowerShell on
+// Windows. Both shellCommand and detachedCommand build their *exec.Cmd from
+// this so the wrapping stays identical regardless of how the process is bound.
+func shellInvocation(ctx context.Context, command string) (name string, args []string, env []string) {
+	if runtime.GOOS == "windows" {
+		// -NoProfile: reproducible env (don't run the user's $PROFILE).
+		// -NonInteractive: never block on a PowerShell prompt mid-command.
+		return resolvePowerShell(), []string{"-NoProfile", "-NonInteractive", "-Command", command}, nil
+	}
+	projectDir := WorkingDir(ctx)
+	if projectDir == "" {
+		projectDir, _ = os.Getwd()
+	}
+	if projectDir != "" {
+		trashDir := trash.ProjectDir(projectDir)
+		wrapped := fmt.Sprintf(safeRmWrapper, command)
+		return "sh", []string{"-c", wrapped}, []string{"OCTO_TRASH_DIR=" + trashDir}
+	}
+	return "sh", []string{"-c", command}, nil
+}
+
+// detachedCommand builds an *exec.Cmd that runs `command` fully detached from
+// the agent harness. Two things make it outlive octo, unlike shellCommand:
+//   - setDetachedProcessOpts starts it in a NEW session (setsid on POSIX,
+//     DETACHED_PROCESS|CREATE_NEW_PROCESS_GROUP on Windows), so it has its own
+//     process group and the harness's kill(-pgid) / taskkill can't reach it;
+//   - it is NOT bound to a cancelable context, so a turn ending — or the agent
+//     loop tearing down ctx — can't kill it.
+//
+// The caller wires stdio (a detached daemon must not hold the harness's pipes)
+// and must not track it in the BackgroundManager: it is fire-and-forget.
+// Deliberately bypasses the OS sandbox — detaching is an explicit "escape the
+// harness" action, and confining a process you're handing back to the user is
+// contradictory.
+func detachedCommand(ctx context.Context, command string) *exec.Cmd {
+	name, args, env := shellInvocation(ctx, command)
+	cmd := exec.Command(name, args...)
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+	if attr := setDetachedProcessOpts(); attr != nil {
+		cmd.SysProcAttr = attr
+	}
+	applyWorkingDir(ctx, cmd)
+	return cmd
 }
 
 // applyWorkingDir roots the command in the conductor-stamped working directory

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -73,7 +73,15 @@ func (TerminalTool) Definition() agent.ToolDefinition {
 				},
 				"run_in_background": map[string]any{
 					"type":        "boolean",
-					"description": "Run detached in the background (no 120s timeout, non-blocking). Returns a process id. Use for one-shot tasks that take more than a few seconds (compiling, testing, installing, building, CI checks) or for long-running services (servers, watchers). For one-shot tasks the system auto-notifies on completion. For long-running services, verify with an external check (e.g., curl, pgrep) rather than polling terminal_output.",
+					"description": "Run detached in the background (no 120s timeout, non-blocking). Returns a process id. Use for one-shot tasks that take more than a few seconds (compiling, testing, installing, building, CI checks) or for long-running services (servers, watchers). For one-shot tasks the system auto-notifies on completion. For long-running services, verify with an external check (e.g., curl, pgrep) rather than polling terminal_output. The process is tracked by octo and KILLED when the session ends — for a daemon meant to outlive octo, use detached:true instead.",
+				},
+				"detached": map[string]any{
+					"type":        "boolean",
+					"description": "Launch the command as a daemon that DELIBERATELY outlives octo: it runs in its own session, is NOT tracked, and is NOT killed when the session ends. Returns only the OS pid — terminal_output and kill_shell cannot see it, so the user manages it themselves (e.g. `kill <pid>`). Use ONLY when the user explicitly wants a process to survive the agent (e.g. exposing a port with ngrok, starting a standalone server). For tasks that should be cleaned up with the session, use run_in_background instead. No `nohup`/`&` needed — detachment is handled for you. stdout+stderr go to log_file.",
+				},
+				"log_file": map[string]any{
+					"type":        "string",
+					"description": "Where a detached:true process writes stdout+stderr. Relative paths resolve against the working dir; ~ is expanded. Defaults to ./nohup.out. Ignored unless detached:true.",
 				},
 			},
 			"required": []string{"command"},
@@ -118,6 +126,20 @@ func (t TerminalTool) ExecuteStream(
 	}
 	if err := guardCommand(command); err != nil {
 		return agent.ToolResult{Text: ""}, err
+	}
+
+	// Detached launch: a daemon that deliberately outlives octo. Not tracked, not
+	// killed on exit — fire-and-forget. The guard above still applies. Checked
+	// before run_in_background so detached wins if both are set.
+	if det, _ := input["detached"].(bool); det {
+		logFile, _ := input["log_file"].(string)
+		pid, logPath, err := startDetached(ctx, command, logFile)
+		if err != nil {
+			return agent.ToolResult{Text: ""}, err
+		}
+		return agent.ToolResult{Text: fmt.Sprintf(
+			"Started detached process (pid %d). It runs independently of octo and will NOT be tracked or stopped when this session ends — manage it yourself (e.g. `kill %d`). stdout+stderr → %s",
+			pid, pid, logPath)}, nil
 	}
 
 	// Background launch: detach, no timeout, return the id immediately. The

--- a/internal/tools/terminal_kill.go
+++ b/internal/tools/terminal_kill.go
@@ -14,6 +14,14 @@ func setProcessGroupOpts() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setpgid: true}
 }
 
+// setDetachedProcessOpts starts the child in a NEW session (setsid), making it
+// a session+group leader detached from the harness. Unlike a Setpgid child, the
+// harness's kill(-pgid) can't reach it, so it survives session exit — used for
+// deliberately detached daemons (terminal detached:true).
+func setDetachedProcessOpts() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}
+
 // killProcessGroup sends the named signal to the process group rooted at p.
 // Supported names: SIGTERM, SIGINT, SIGKILL (default). On POSIX it sends the
 // signal to -Pid (the whole group).

--- a/internal/tools/terminal_kill_windows.go
+++ b/internal/tools/terminal_kill_windows.go
@@ -16,6 +16,21 @@ import (
 // Child-tree termination is handled in killProcessGroup via taskkill instead.
 func setProcessGroupOpts() *syscall.SysProcAttr { return nil }
 
+// Windows process-creation flags for a fully detached daemon. DETACHED_PROCESS
+// gives the child no console; CREATE_NEW_PROCESS_GROUP makes it the root of a
+// new group so it isn't tied to the harness's console/Ctrl events.
+const (
+	detachedProcess       = 0x00000008
+	createNewProcessGroup = 0x00000200
+)
+
+// setDetachedProcessOpts starts the child detached from the harness console in
+// its own process group, so it survives session exit — the Windows counterpart
+// of setsid, used for terminal detached:true.
+func setDetachedProcessOpts() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{CreationFlags: detachedProcess | createNewProcessGroup}
+}
+
 // processExists checks whether a process with the given PID is still running.
 func processExists(pid int) bool {
 	out, err := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/NH").Output()


### PR DESCRIPTION
## Motivation

You sometimes want the agent to start a process that **deliberately** outlives octo — e.g. `ngrok http 8080` to expose a port, or a standalone daemon. The terminal tool couldn't do this: every command (sync and background) starts in its own process group and is tracked in the global manager, and the on-exit `KillAllBackground` group-kills everything (reinforced by #507–#509). Hand-rolling `nohup … &` doesn't help — `nohup` doesn't change the pgid, so the group-kill still reaches the child, and `base.md` forbids `nohup`/`&` in sync calls anyway.

This is the deliberate-detachment counterpart to the orphan-cleanup fixes.

## What this adds — `terminal detached:true`

Decided with the user: a flag on `terminal` (not a new tool), **fully fire-and-forget**.

- **Truly detached:** new `detachedCommand` starts the process in a NEW session — `setsid` on POSIX, `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows — so the harness's `kill(-pgid)` / `taskkill` can't reach it, and it's **not bound to a cancelable context** so a turn ending can't kill it.
- **Untracked:** never enters the `BackgroundManager`, so `terminal_output` / `kill_shell` / `KillAll` all ignore it. Returns only the OS **pid** — the user manages it (`kill <pid>`).
- **Stdio:** stdout+stderr → `log_file` (default `./nohup.out`, `~`-expanded, relative to the working dir); stdin → `/dev/null`. The daemon never holds the harness's pipes.

## Implementation notes

- Refactored the shell-wrapping out of `shellCommand` into `shellInvocation`, so sync / background / detached all build identical `sh -c` / `pwsh` invocations (`sandbox_test` still green).
- Deliberately **bypasses the OS sandbox** — detaching is an explicit "escape the harness" action; confining a process you're handing back is contradictory.
- **No new permission gate:** `detached:true` is the same `terminal` call, already covered by the existing terminal gating.
- `base.md` gains `run_in_background`-vs-`detached` guidance keyed on lifecycle (and "don't use `detached` just to dodge the timeout").

## Tests (POSIX)

- A detached process is **untracked** (`RunningBackground()` empty) and **survives `KillAllBackground`** — the core guarantee.
- Output lands in the explicit `log_file` and in the default `nohup.out`.
- `go test -race ./internal/tools/ ./internal/prompt/` passes; `go vet` clean.

The detachment syscall flags differ per OS; the behavioral test is POSIX-only (consistent with the package's other process-group tests). The Windows `CreationFlags` path compiles and is exercised by the existing Windows CI build/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)