### PR TITLE
fix(tools): detached commands honor the OS sandbox (no special-casing)

### DIFF
--- a/internal/tools/detached.go
+++ b/internal/tools/detached.go
@@ -29,7 +29,11 @@ func startDetached(ctx context.Context, command, logFile string) (pid int, logPa
 		return 0, "", fmt.Errorf("detached: open log %q: %w", logPath, err)
 	}
 
-	cmd := detachedCommand(ctx, command)
+	cmd, err := detachedCommand(ctx, command)
+	if err != nil {
+		_ = f.Close()
+		return 0, "", fmt.Errorf("detached: build command: %w", err)
+	}
 	cmd.Stdout = f
 	cmd.Stderr = f
 	cmd.Stdin = nil // nil Stdin = /dev/null; a detached daemon must not hold the harness's stdin

--- a/internal/tools/detached_test.go
+++ b/internal/tools/detached_test.go
@@ -12,6 +12,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/Leihb/octo-agent/internal/sandbox"
 )
 
 var pidRe = regexp.MustCompile(`pid (\d+)`)
@@ -97,4 +99,55 @@ func TestTerminal_Detached_DefaultLogIsNohupOut(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatalf("default log %s never received output", want)
+}
+
+// TestTerminal_Detached_HonorsSandbox proves detached is NOT special-cased out
+// of the OS sandbox: when a sandbox is active, a detached daemon is confined
+// just like any terminal command — a write inside the project root succeeds, a
+// write outside it is blocked. Skipped where the OS can't enforce a sandbox.
+func TestTerminal_Detached_HonorsSandbox(t *testing.T) {
+	if !sandbox.Available() {
+		t.Skip("no OS sandbox available on this host")
+	}
+	cwd := t.TempDir()
+	p := sandbox.DefaultPolicy(cwd)
+	SetSandbox(&p)
+	defer SetSandbox(nil)
+
+	home, _ := os.UserHomeDir()
+	outside := filepath.Join(home, ".octo_detached_sbx_probe")
+	_ = os.Remove(outside)
+	defer os.Remove(outside)
+	inside := filepath.Join(cwd, "inside.txt")
+
+	// Attempt the forbidden write FIRST, then the allowed one — so once
+	// inside.txt appears we know the outside write was already attempted (and,
+	// if the sandbox is applied, blocked).
+	ctx := WithWorkingDir(context.Background(), cwd)
+	res, err := TerminalTool{}.Execute(ctx, "terminal", map[string]any{
+		"command":  "echo out > " + outside + "; echo in > " + inside,
+		"detached": true,
+		"log_file": filepath.Join(cwd, "d.log"),
+	})
+	if err != nil {
+		t.Fatalf("detached launch: %v", err)
+	}
+	if m := pidRe.FindStringSubmatch(res.Text); m != nil {
+		pid, _ := strconv.Atoi(m[1])
+		defer func() { _ = syscall.Kill(pid, syscall.SIGKILL) }()
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(inside); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if _, err := os.Stat(inside); err != nil {
+		t.Fatalf("allowed write inside the sandbox root never happened: %v", err)
+	}
+	if _, err := os.Stat(outside); err == nil {
+		t.Errorf("detached process wrote %s outside the sandbox root — sandbox was not applied", outside)
+	}
 }

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -75,10 +75,24 @@ func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 		}
 		return cmd, err
 	}
-	name, args, env := shellInvocation(ctx, command)
-	cmd := exec.CommandContext(ctx, name, args...)
-	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		// -NoProfile: reproducible env (don't run the user's $PROFILE).
+		// -NonInteractive: never block on a PowerShell prompt mid-command.
+		cmd = exec.CommandContext(ctx, resolvePowerShell(), "-NoProfile", "-NonInteractive", "-Command", command)
+	} else {
+		projectDir := WorkingDir(ctx)
+		if projectDir == "" {
+			projectDir, _ = os.Getwd()
+		}
+		if projectDir != "" {
+			trashDir := trash.ProjectDir(projectDir)
+			wrapped := fmt.Sprintf(safeRmWrapper, command)
+			cmd = exec.CommandContext(ctx, "sh", "-c", wrapped)
+			cmd.Env = append(os.Environ(), "OCTO_TRASH_DIR="+trashDir)
+		} else {
+			cmd = exec.CommandContext(ctx, "sh", "-c", command)
+		}
 	}
 	if attr := setProcessGroupOpts(); attr != nil {
 		cmd.SysProcAttr = attr
@@ -87,53 +101,27 @@ func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
-// shellInvocation returns the shell program, its argv, and any extra env needed
-// to run `command` via the platform shell: POSIX `sh -c` (with the safe-rm
-// trash wrapper when a project dir is known) on macOS/Linux, PowerShell on
-// Windows. Both shellCommand and detachedCommand build their *exec.Cmd from
-// this so the wrapping stays identical regardless of how the process is bound.
-func shellInvocation(ctx context.Context, command string) (name string, args []string, env []string) {
-	if runtime.GOOS == "windows" {
-		// -NoProfile: reproducible env (don't run the user's $PROFILE).
-		// -NonInteractive: never block on a PowerShell prompt mid-command.
-		return resolvePowerShell(), []string{"-NoProfile", "-NonInteractive", "-Command", command}, nil
-	}
-	projectDir := WorkingDir(ctx)
-	if projectDir == "" {
-		projectDir, _ = os.Getwd()
-	}
-	if projectDir != "" {
-		trashDir := trash.ProjectDir(projectDir)
-		wrapped := fmt.Sprintf(safeRmWrapper, command)
-		return "sh", []string{"-c", wrapped}, []string{"OCTO_TRASH_DIR=" + trashDir}
-	}
-	return "sh", []string{"-c", command}, nil
-}
-
 // detachedCommand builds an *exec.Cmd that runs `command` fully detached from
-// the agent harness. Two things make it outlive octo, unlike shellCommand:
-//   - setDetachedProcessOpts starts it in a NEW session (setsid on POSIX,
-//     DETACHED_PROCESS|CREATE_NEW_PROCESS_GROUP on Windows), so it has its own
-//     process group and the harness's kill(-pgid) / taskkill can't reach it;
-//   - it is NOT bound to a cancelable context, so a turn ending — or the agent
-//     loop tearing down ctx — can't kill it.
+// the agent harness, while otherwise behaving exactly like a normal terminal
+// command — same shell wrapping, same OS-sandbox confinement when one is
+// active. It differs from shellCommand in only two ways:
+//   - it builds on context.WithoutCancel(ctx), so the daemon keeps the working
+//     dir but a turn ending (ctx cancellation) can't kill it;
+//   - it overrides SysProcAttr to start the process in a NEW session (setsid on
+//     POSIX, DETACHED_PROCESS|CREATE_NEW_PROCESS_GROUP on Windows), so the
+//     harness's kill(-pgid) / taskkill can't reach it.
 //
 // The caller wires stdio (a detached daemon must not hold the harness's pipes)
-// and must not track it in the BackgroundManager: it is fire-and-forget.
-// Deliberately bypasses the OS sandbox — detaching is an explicit "escape the
-// harness" action, and confining a process you're handing back to the user is
-// contradictory.
-func detachedCommand(ctx context.Context, command string) *exec.Cmd {
-	name, args, env := shellInvocation(ctx, command)
-	cmd := exec.Command(name, args...)
-	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
+// and must not track it in the BackgroundManager: it is fire-and-forget. The
+// sandbox sets confinement via the wrapper exe/profile, not SysProcAttr, so
+// overriding the latter doesn't weaken it.
+func detachedCommand(ctx context.Context, command string) (*exec.Cmd, error) {
+	cmd, err := shellCommand(context.WithoutCancel(ctx), command)
+	if err != nil {
+		return nil, err
 	}
-	if attr := setDetachedProcessOpts(); attr != nil {
-		cmd.SysProcAttr = attr
-	}
-	applyWorkingDir(ctx, cmd)
-	return cmd
+	cmd.SysProcAttr = setDetachedProcessOpts()
+	return cmd, nil
 }
 
 // applyWorkingDir roots the command in the conductor-stamped working directory


### PR DESCRIPTION
Follow-up to #510, per feedback: **detached and the sandbox aren't contradictory — don't special-case detached out of it.**

## Why the bypass was wrong

#510 had `detachedCommand` skip the sandbox, reasoning that detaching is "escaping the harness." That conflated two orthogonal axes:

- **Sandbox** = *what* a process may touch (filesystem / network).
- **Detach** = *how long* it lives (survives the session).

They don't conflict. A daemon you deliberately keep alive should still be confined to the project root when a sandbox is active.

## Change

`detachedCommand` now routes through `shellCommand` — same shell wrapping, same `sandbox.Command` confinement when active — differing only in the two things that actually define "detached":

- builds on `context.WithoutCancel(ctx)`, so it keeps the working dir but a turn ending (ctx cancellation) can't kill it;
- overrides `SysProcAttr` to a new session (`setsid` / `DETACHED_PROCESS|CREATE_NEW_PROCESS_GROUP`) so the harness's `kill(-pgid)` / `taskkill` can't reach it.

Overriding `SysProcAttr` is safe: `sandbox.Command` applies confinement via the wrapper exe + profile/env, **not** process attrs (verified on darwin + linux — neither sets `SysProcAttr`).

Also reverts the `shellInvocation` extraction from #510 — with `detachedCommand` reusing `shellCommand`, that helper had a single caller again, so `shellCommand` returns to its original inline form (smaller net diff).

## Test

New sandbox integration test: with a sandbox active, a detached daemon's write **inside** the project root succeeds and a write **outside** is blocked (attempting the forbidden write first, so the allowed file appearing proves the forbidden one was already attempted). Skipped where the OS can't enforce a sandbox; runs on macOS/Linux CI where it can — and passed locally on macOS, confirming confinement now applies.

`go test -race ./internal/tools/` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)