### PR TITLE
feat(tools,server,channel): per-session background managers for isolation

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -281,6 +281,9 @@ func handleAgentMessage(ctx context.Context, mgr *channel.Manager, ad channel.Ad
 		// The task store lives on the session, so the task list persists across
 		// messages in this chat (a fresh per-message store would reset it).
 		ctx = tools.WithTaskStore(ctx, sess.Tasks)
+		// Per-chat background manager: this chat's bg processes persist across
+		// messages and stay isolated from other chats; reaped on daemon shutdown.
+		ctx = tools.WithBackgroundManager(ctx, tools.SessionBackgroundManager("im:"+string(sess.Key)))
 	}
 
 	_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, ev.Text)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -442,6 +442,7 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.forgetTurnLock(id)
+	tools.CloseSessionBackgroundManager(id) // reap the session's background daemons
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": []string{id}})
 }
 
@@ -470,6 +471,7 @@ func (s *Server) handleDeleteSessions(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		s.forgetTurnLock(id)
+		tools.CloseSessionBackgroundManager(id) // reap the session's background daemons
 		deleted = append(deleted, id)
 	}
 
@@ -568,10 +570,14 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.C
 	if err != nil {
 		return ctx, nil, nil, fmt.Errorf("permission engine: %w", err)
 	}
-	// Wire interactive permission confirmation when we know the session.
+	// Wire interactive permission confirmation when we know the session, and
+	// scope background processes to a per-session manager so one session's
+	// terminal_output / kill_shell can't see another's, and its daemons are
+	// reaped when the session is deleted (handleDeleteSession).
 	var ask app.PermissionAsk
 	if sid, ok := ctx.Value(ctxKeySessionID{}).(string); ok && sid != "" {
 		ask = s.permissionAskFrom(sid)
+		ctx = tools.WithBackgroundManager(ctx, tools.SessionBackgroundManager(sid))
 	}
 	a.Gate = app.NewPermissionGate(engine, ask)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -899,6 +899,7 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 		subMgr.SetSynchronous(true)
 		ctx = tools.WithSubAgentManager(ctx, subMgr)
 		ctx = tools.WithTaskStore(ctx, sess.Tasks)
+		ctx = tools.WithBackgroundManager(ctx, tools.SessionBackgroundManager("im:"+string(sess.Key)))
 	}
 
 	_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, ev.Text)

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -440,9 +440,14 @@ func (m *BackgroundManager) KillAll() {
 // processes across the session.
 var defaultBg = NewBackgroundManager()
 
-// KillAllBackground terminates all background processes started via the default
-// manager. Wire it into session/REPL shutdown to avoid orphans.
-func KillAllBackground() { defaultBg.KillAll() }
+// KillAllBackground terminates every tracked background process — the default
+// manager AND every per-session manager. Wire it into session/REPL/daemon
+// shutdown to avoid orphans regardless of which session launched a process.
+func KillAllBackground() {
+	for _, m := range allBackgroundManagers() {
+		m.KillAll()
+	}
+}
 
 // SetBackgroundOnExit registers the completion hook on the default manager (the
 // one the built-in terminal tool uses). The REPL wires this to push a

--- a/internal/tools/session_managers.go
+++ b/internal/tools/session_managers.go
@@ -1,0 +1,87 @@
+package tools
+
+import (
+	"context"
+	"sync"
+)
+
+// backgroundManagerCtxKey scopes a BackgroundManager to a turn's context, the
+// same way WithSubAgentManager / WithTaskStore scope theirs. The web server and
+// IM bridge stamp a per-session manager so each conversation's background
+// processes are isolated — their own bg_N id namespace, invisible to other
+// sessions' terminal_output / kill_shell — and are reaped when the session
+// ends, instead of sharing the process-global defaultBg.
+type backgroundManagerCtxKey struct{}
+
+// WithBackgroundManager returns ctx carrying mgr as the manager the terminal
+// tools dispatch to for this turn.
+func WithBackgroundManager(ctx context.Context, mgr *BackgroundManager) context.Context {
+	return context.WithValue(ctx, backgroundManagerCtxKey{}, mgr)
+}
+
+func backgroundManagerFromContext(ctx context.Context) *BackgroundManager {
+	m, _ := ctx.Value(backgroundManagerCtxKey{}).(*BackgroundManager)
+	return m
+}
+
+// resolveBackgroundManager picks the manager a terminal tool should use: the
+// ctx-scoped per-session one (web/IM) first, then a tool-local override, then
+// the process-global default (CLI/TUI, which never stamp a ctx manager).
+func resolveBackgroundManager(ctx context.Context, local *BackgroundManager) *BackgroundManager {
+	if m := backgroundManagerFromContext(ctx); m != nil {
+		return m
+	}
+	if local != nil {
+		return local
+	}
+	return defaultBg
+}
+
+// Per-session background managers, keyed by an opaque session id chosen by the
+// caller (web session id / IM session key). Created on demand, reaped either
+// when the session is deleted (CloseSessionBackgroundManager) or on daemon
+// shutdown (KillAllBackground reaps all of them). Kept separate from defaultBg
+// so the CLI/TUI — which never stamp a ctx manager — are unaffected.
+var (
+	sessionMgrsMu sync.Mutex
+	sessionMgrs   = map[string]*BackgroundManager{}
+)
+
+// SessionBackgroundManager returns the per-session manager for id, creating and
+// registering it on first use.
+func SessionBackgroundManager(id string) *BackgroundManager {
+	sessionMgrsMu.Lock()
+	defer sessionMgrsMu.Unlock()
+	m := sessionMgrs[id]
+	if m == nil {
+		m = NewBackgroundManager()
+		sessionMgrs[id] = m
+	}
+	return m
+}
+
+// CloseSessionBackgroundManager kills every process tracked for a session and
+// drops its manager. Call when a session is deleted so its background daemons
+// don't leak until daemon shutdown. No-op for an unknown id.
+func CloseSessionBackgroundManager(id string) {
+	sessionMgrsMu.Lock()
+	m := sessionMgrs[id]
+	delete(sessionMgrs, id)
+	sessionMgrsMu.Unlock()
+	if m != nil {
+		m.KillAll()
+	}
+}
+
+// allBackgroundManagers returns defaultBg plus every live per-session manager,
+// so process-wide operations (shutdown reap) cover every tracked process.
+func allBackgroundManagers() []*BackgroundManager {
+	sessionMgrsMu.Lock()
+	defer sessionMgrsMu.Unlock()
+	out := make([]*BackgroundManager, 0, len(sessionMgrs)+1)
+	out = append(out, defaultBg)
+	for _, m := range sessionMgrs {
+		out = append(out, m)
+	}
+	return out
+}

--- a/internal/tools/session_managers_posix_test.go
+++ b/internal/tools/session_managers_posix_test.go
@@ -1,0 +1,48 @@
+//go:build darwin || linux
+
+package tools
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestBackgroundManager_CtxScopedIsolatedAndReaped verifies the per-session
+// wiring: a terminal command started under a ctx-scoped manager lands in THAT
+// manager (not another session's), and KillAllBackground reaps per-session
+// managers, not only the global default.
+func TestBackgroundManager_CtxScopedIsolatedAndReaped(t *testing.T) {
+	mA := SessionBackgroundManager("sess-iso-A")
+	mB := SessionBackgroundManager("sess-iso-B")
+	defer CloseSessionBackgroundManager("sess-iso-A")
+	defer CloseSessionBackgroundManager("sess-iso-B")
+
+	ctx := WithBackgroundManager(context.Background(), mA)
+	if _, err := (TerminalTool{}).Execute(ctx, "terminal", map[string]any{
+		"command":           "sleep 60",
+		"run_in_background": true,
+	}); err != nil {
+		t.Fatalf("background launch: %v", err)
+	}
+
+	// Routed to session A's manager.
+	if got := len(mA.ListRunning()); got != 1 {
+		t.Fatalf("session A manager should track 1 process, got %d", got)
+	}
+	// Isolation: session B can't see it.
+	if got := len(mB.ListRunning()); got != 0 {
+		t.Fatalf("session B manager should see no processes, got %d", got)
+	}
+
+	// KillAllBackground must reap per-session managers, not just defaultBg.
+	KillAllBackground()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(mA.ListRunning()) == 0 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("KillAllBackground did not reap the per-session manager's process")
+}

--- a/internal/tools/session_managers_test.go
+++ b/internal/tools/session_managers_test.go
@@ -1,0 +1,25 @@
+package tools
+
+import "testing"
+
+// TestSessionBackgroundManager_Registry covers get-or-create identity and that
+// Close drops the entry so a later lookup builds a fresh manager.
+func TestSessionBackgroundManager_Registry(t *testing.T) {
+	a1 := SessionBackgroundManager("sess-A")
+	a2 := SessionBackgroundManager("sess-A")
+	b := SessionBackgroundManager("sess-B")
+	defer CloseSessionBackgroundManager("sess-B")
+
+	if a1 != a2 {
+		t.Error("same id should return the same manager instance")
+	}
+	if a1 == b {
+		t.Error("different ids should return different manager instances")
+	}
+
+	CloseSessionBackgroundManager("sess-A")
+	if a3 := SessionBackgroundManager("sess-A"); a3 == a1 {
+		t.Error("after Close, a fresh manager should be created for the id")
+	}
+	CloseSessionBackgroundManager("sess-A")
+}

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -50,11 +50,8 @@ const TerminalOutputStopPolling = "STOP POLLING. The system will automatically n
 // exists so tests can inject an isolated manager.
 type TerminalTool struct{ mgr *BackgroundManager }
 
-func (t TerminalTool) manager() *BackgroundManager {
-	if t.mgr != nil {
-		return t.mgr
-	}
-	return defaultBg
+func (t TerminalTool) managerFor(ctx context.Context) *BackgroundManager {
+	return resolveBackgroundManager(ctx, t.mgr)
 }
 
 // Definition returns the agent.ToolDefinition the LLM receives in the tools
@@ -145,7 +142,7 @@ func (t TerminalTool) ExecuteStream(
 	// Background launch: detach, no timeout, return the id immediately. The
 	// guard above still applies, so dangerous commands are blocked either way.
 	if bg, _ := input["run_in_background"].(bool); bg {
-		id, err := t.manager().Start(command)
+		id, err := t.managerFor(ctx).Start(command)
 		if err != nil {
 			return agent.ToolResult{Text: ""}, err
 		}
@@ -180,7 +177,7 @@ func (t TerminalTool) ExecuteStream(
 		}
 	}
 
-	id, err := t.manager().Start(command, WithOnLine(onLine), WithVisible(false))
+	id, err := t.managerFor(ctx).Start(command, WithOnLine(onLine), WithVisible(false))
 	if err != nil {
 		return agent.ToolResult{Text: ""}, err
 	}
@@ -210,25 +207,25 @@ func (t TerminalTool) ExecuteStream(
 			// in the TUI "background (N running)" panel, then return. NOT
 			// reaped — it's now a real background task and its output must stay
 			// readable via terminal_output.
-			t.manager().Promote(id)
+			t.managerFor(ctx).Promote(id)
 			body := MaybeSpillOutput(id, snapshot())
 			return agent.ToolResult{Text: fmt.Sprintf("%s\n\n[timeout: command exceeded %s and continues as background process %s]\n\n%s", body, TerminalTimeout, id, BgPollNotice)}, nil
 		case <-ctx.Done():
 			// User cancelled (Esc / Ctrl-C): kill the hidden process and reap
 			// it — the output is returned here and now, nothing will poll it.
-			t.manager().Kill(id)
+			t.managerFor(ctx).Kill(id)
 			body := snapshot()
-			t.manager().Remove(id)
+			t.managerFor(ctx).Remove(id)
 			return agent.ToolResult{Text: body + "\n[exit: signal: killed]"}, nil
 		default:
 		}
 
-		_, status, _, _ := t.manager().Read(id)
+		_, status, _, _ := t.managerFor(ctx).Read(id)
 		if strings.HasPrefix(status, "exited") {
 			body := MaybeSpillOutput(id, snapshot())
 			// Reap the hidden process: its output has been captured and
 			// returned, so the bgProcess (and its retained buffer) can go.
-			t.manager().Remove(id)
+			t.managerFor(ctx).Remove(id)
 			if status != "exited: 0" {
 				return agent.ToolResult{Text: body + "\n[exit: " + strings.TrimPrefix(status, "exited: ") + "]"}, nil
 			}
@@ -243,11 +240,8 @@ func (t TerminalTool) ExecuteStream(
 // detached commands useful. It can also kill the process.
 type TerminalOutputTool struct{ mgr *BackgroundManager }
 
-func (t TerminalOutputTool) manager() *BackgroundManager {
-	if t.mgr != nil {
-		return t.mgr
-	}
-	return defaultBg
+func (t TerminalOutputTool) managerFor(ctx context.Context) *BackgroundManager {
+	return resolveBackgroundManager(ctx, t.mgr)
 }
 
 // Definition describes the required "id". Reading is non-destructive; to stop a
@@ -271,12 +265,12 @@ func (TerminalOutputTool) Definition() agent.ToolDefinition {
 
 // Execute returns the new output plus a status line. Read-only — it never
 // terminates the process (that's kill_shell).
-func (t TerminalOutputTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+func (t TerminalOutputTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	id, _ := input["id"].(string)
 	if id == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: id is required")
 	}
-	out, status, found, blocked := t.manager().Read(id)
+	out, status, found, blocked := t.managerFor(ctx).Read(id)
 	if !found {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: no background process %q", id)
 	}
@@ -299,11 +293,8 @@ func (t TerminalOutputTool) Execute(_ context.Context, _ string, input map[strin
 // that accept commands via stdin).
 type TerminalInputTool struct{ mgr *BackgroundManager }
 
-func (t TerminalInputTool) manager() *BackgroundManager {
-	if t.mgr != nil {
-		return t.mgr
-	}
-	return defaultBg
+func (t TerminalInputTool) managerFor(ctx context.Context) *BackgroundManager {
+	return resolveBackgroundManager(ctx, t.mgr)
 }
 
 // Definition describes the required "id" and "input".
@@ -329,7 +320,7 @@ func (TerminalInputTool) Definition() agent.ToolDefinition {
 }
 
 // Execute writes input to the process's stdin. Unknown or exited id is an error.
-func (t TerminalInputTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+func (t TerminalInputTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	id, _ := input["id"].(string)
 	if id == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_input: id is required")
@@ -338,7 +329,7 @@ func (t TerminalInputTool) Execute(_ context.Context, _ string, input map[string
 	if text == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_input: input is required")
 	}
-	if err := t.manager().WriteStdin(id, text); err != nil {
+	if err := t.managerFor(ctx).WriteStdin(id, text); err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_input: %w", err)
 	}
 	return agent.ToolResult{Text: fmt.Sprintf("Sent to %s.", id)}, nil
@@ -350,11 +341,8 @@ func (t TerminalInputTool) Execute(_ context.Context, _ string, input map[string
 // kill:true flag so "stop this process" is a first-class, obvious action.
 type KillShellTool struct{ mgr *BackgroundManager }
 
-func (t KillShellTool) manager() *BackgroundManager {
-	if t.mgr != nil {
-		return t.mgr
-	}
-	return defaultBg
+func (t KillShellTool) managerFor(ctx context.Context) *BackgroundManager {
+	return resolveBackgroundManager(ctx, t.mgr)
 }
 
 // Definition describes the required "id".
@@ -383,7 +371,7 @@ func (KillShellTool) Definition() agent.ToolDefinition {
 // Execute kills the process, then returns its final remaining output. An
 // unknown id is an error (Kill reports it); an already-exited process is a
 // no-op kill and still returns its last output.
-func (t KillShellTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+func (t KillShellTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	id, _ := input["id"].(string)
 	if id == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("kill_shell: id is required")
@@ -392,7 +380,7 @@ func (t KillShellTool) Execute(_ context.Context, _ string, input map[string]any
 	if sig == "" {
 		sig = "SIGKILL"
 	}
-	mgr := t.manager()
+	mgr := t.managerFor(ctx)
 	if !mgr.KillWithSignal(id, sig) {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("kill_shell: no background process %q", id)
 	}


### PR DESCRIPTION
Item **#2** of the terminal-tool cleanup (after #512's terminate chokepoint).

## Problem

`defaultBg` was a process-global singleton — every web session, IM chat, and sub-agent funneled background processes into **one pool with one `bg_N` id namespace**. On a multi-session server: session A could `terminal_output` / `kill_shell` session B's processes, and a web session ending left its processes running until daemon shutdown (no per-session cleanup).

## Change

Mirrors the existing ctx-scoped service pattern (`WithSubAgentManager` / `WithTaskStore`):

- **`WithBackgroundManager(ctx, mgr)` + `resolveBackgroundManager(ctx, local)`** — the four terminal tools resolve **ctx-scoped manager > tool-local field > `defaultBg`**. `manager()` → `managerFor(ctx)`.
- **Per-session registry** — `SessionBackgroundManager(id)` / `CloseSessionBackgroundManager(id)`, keyed by an opaque session id.
- **`KillAllBackground` now reaps `defaultBg` AND every per-session manager**, so daemon shutdown still cleans up everything regardless of owner (critical: processes no longer all live in `defaultBg`).

## Wiring

- **Web:** `prepareToolTurn` stamps the per-session manager (keyed by session id); `handleDeleteSession`/`handleDeleteSessions` call `CloseSessionBackgroundManager` so a deleted session's daemons are reaped immediately.
- **IM** (standalone `octo channel` + channel-under-serve): per-chat manager keyed by `"im:"+sessionKey`, persisting across messages in a chat, isolated from other chats.
- **CLI/TUI unchanged:** they never stamp a ctx manager → keep using `defaultBg` (and its `SetBackgroundOnExit` push + `RunningBackground` panel, which server/channel never wired — so **no notification regression**).

## Tests

- Registry identity + Close semantics (cross-platform).
- ctx-routing, cross-session isolation, and `KillAllBackground` reaping a per-session manager (POSIX).
- `go test -race ./internal/tools/ ./internal/server/ ./cmd/octo/` + `go vet` clean.

## Still to come

- **#3**: `terminal_list` + reworking `terminal_output` into an on-demand tail snapshot (push for completion carrying final output, pull-snapshot for progress) — your approved #4 design.
- **Design doc**: one current-state doc covering the whole terminal/background architecture (terminate chokepoint, per-session managers, detached, push/pull observe surface) — written after #3 so it captures the final shape rather than churning twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)