### PR TITLE
feat(tools): rework terminal observability — push completion, snapshot progress, terminal_list

### DIFF
--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -102,11 +102,6 @@ func renderToolCard(toolName string, input map[string]any, output string, isErr 
 		// drop it from the card — the "Started background process N" line stays.
 		output = strings.TrimRight(strings.TrimSuffix(output, tools.BgPollNotice), "\n")
 	}
-	if toolName == "terminal_output" {
-		// terminal_output can carry a model-only "STOP POLLING" notice when the
-		// process is still running with no new output. Strip it from the card.
-		output = strings.TrimRight(strings.TrimSuffix(output, tools.TerminalOutputStopPolling), "\n")
-	}
 	if toolName == "write_file" {
 		// write_file's own output is already a human-readable summary
 		// ("Wrote N bytes (M lines) to /path"); show that instead of a

--- a/cmd/octo/toolcards_test.go
+++ b/cmd/octo/toolcards_test.go
@@ -3,8 +3,6 @@ package main
 import (
 	"strings"
 	"testing"
-
-	"github.com/Leihb/octo-agent/internal/tools"
 )
 
 func TestCardVerbFor(t *testing.T) {
@@ -64,11 +62,10 @@ func TestRenderToolCard_Dispatch(t *testing.T) {
 		t.Errorf("terminal should render an output card; got:\n%s", run)
 	}
 
-	// terminal_output strips the STOP POLLING notice.
-	pollOut := "[status: running]\n(no new output)\n\n" + tools.TerminalOutputStopPolling
-	check := renderToolCard("terminal_output", map[string]any{"id": "bg_1"}, pollOut, false)
-	if strings.Contains(check, "STOP POLLING") {
-		t.Errorf("terminal_output card should strip STOP POLLING; got:\n%s", check)
+	// terminal_output → snapshot card with status + tail.
+	out := renderToolCard("terminal_output", map[string]any{"id": "bg_1"}, "[status: running]\nstarting up", false)
+	if !strings.Contains(out, "starting up") {
+		t.Errorf("terminal_output should render an output card; got:\n%s", out)
 	}
 
 	// non-card tool → "".

--- a/dev-docs/terminal-tools.md
+++ b/dev-docs/terminal-tools.md
@@ -1,0 +1,137 @@
+# Terminal tool family
+
+The terminal tools let the agent run shell commands — synchronously, as
+tracked background processes, or as detached daemons — and observe and control
+those processes. They live in `internal/tools/` and all route process work
+through one `BackgroundManager`.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `terminal` | Run a command. Synchronous, `run_in_background:true`, or `detached:true`. |
+| `terminal_output` | Snapshot the last N lines of a background process's output + status. |
+| `terminal_list` | List this session's background processes (id, status, elapsed, command). |
+| `terminal_input` | Write to a background process's stdin. |
+| `kill_shell` | Signal/terminate a background process and return its final output. |
+
+`terminal` is the only one that starts work; the rest address an existing
+process by the `bg_N` id `terminal` returns.
+
+## Three ways to run a command
+
+`terminal` picks the mode from its flags (checked in this order):
+
+1. **`detached:true`** — a daemon that deliberately outlives octo. Built by
+   `detachedCommand`: a new session (`setsid` on POSIX,
+   `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows) so the harness's
+   process-group kill can't reach it, on `context.WithoutCancel(ctx)` so a turn
+   ending can't kill it. stdout/stderr go to a log file (`log_file`, default
+   `./nohup.out`), stdin to `/dev/null`. It is **not** tracked in any manager —
+   fire-and-forget — so `terminal_output` / `kill_shell` / shutdown all ignore
+   it; only the OS pid is returned. It still runs through the same shell
+   wrapping and OS sandbox as any other command (detach controls lifetime, the
+   sandbox controls what it may touch — orthogonal).
+
+2. **`run_in_background:true`** — a tracked background process. Returns a
+   `bg_N` id immediately, no timeout. Output is observable via
+   `terminal_output`, the process via `terminal_list` / `kill_shell`, and it is
+   **killed when the session ends**.
+
+3. **Synchronous (default)** — runs with a 120 s timeout. Implemented as a
+   hidden (`visible:false`) background process so that on timeout it is simply
+   *promoted* to a visible background task (no kill, no restart) and its id
+   returned. On normal completion it is reaped (`Remove`).
+
+`guardCommand` blocks dangerous commands before any of these branches.
+
+## BackgroundManager and the process lifecycle
+
+`BackgroundManager` owns the tracked processes (`map[id]*bgProcess`). Each
+`bgProcess` keeps a capped tail buffer (`maxBgOutputBytes`, 1 MiB) of combined
+stdout+stderr, its status, and a `cancel` for its command context.
+
+### Spawn
+
+`Start` builds the command via `shellCommand` (shell wrapping + safe-rm trash
+wrapper + OS sandbox when active), starts it in its **own process group**
+(`Setpgid`), and tracks it. A reader goroutine drains output into the buffer; a
+waiter goroutine `cmd.Wait()`s, closes the pipe and stdin, then runs the
+completion hook.
+
+### Terminate — single chokepoint
+
+All termination goes through one private function, `terminate(p, signal)`,
+which owns two rules so they can't drift between call sites:
+
+- **Always signal the whole process group** (`kill(-pid)` on POSIX,
+  `taskkill /T` on Windows) — never just the direct child. The direct child is
+  the `sh -c` / `pwsh` wrapper; signalling only it orphans whatever it spawned.
+- **Cancel the context only on `SIGKILL`** (so `exec.CommandContext` fires its
+  own SIGKILL as a backstop). On `SIGTERM`/`SIGINT` cancelling would let exec
+  race in an automatic SIGKILL and defeat the graceful stop.
+
+`KillWithSignal` (one process), `KillAll` (all in a manager), and `Remove`
+(reap on map removal) all call `terminate`.
+
+### Reap on exit
+
+`KillAllBackground` is wired into every entry point's shutdown — CLI/TUI REPL,
+`octo serve` (`Server.Shutdown`), and the IM bridge (`octo channel`) — and
+reaps `defaultBg` **and every per-session manager**, so no background process
+outlives its host process. Detached daemons are exempt by construction (not
+tracked).
+
+## Per-session scoping
+
+`defaultBg` is the process-global manager used by the CLI/TUI (one process = one
+session). The web server and IM bridge instead give each conversation its **own**
+manager so background processes are isolated — their own `bg_N` namespace,
+invisible to other sessions — and reaped when the session ends.
+
+This reuses the ctx-scoped service pattern (cf. `WithSubAgentManager`,
+`WithTaskStore`):
+
+- `WithBackgroundManager(ctx, mgr)` stamps the per-session manager onto the turn
+  context. Each terminal tool resolves its manager via
+  `resolveBackgroundManager(ctx, t.mgr)` — **ctx-scoped > tool-local field >
+  `defaultBg`**.
+- `SessionBackgroundManager(id)` / `CloseSessionBackgroundManager(id)` maintain a
+  registry keyed by an opaque session id. The web server stamps it in
+  `prepareToolTurn` (keyed by session id) and closes it on session delete; the
+  IM bridge stamps it per chat (keyed by `"im:"+sessionKey`), persisting across
+  messages in that chat.
+
+The CLI/TUI never stamp a ctx manager, so they keep using `defaultBg` (and its
+completion-push hook + `RunningBackground` panel, which the server/IM never
+wire).
+
+## Observability: push for completion, pull-snapshot for progress
+
+Two distinct needs, two distinct mechanisms:
+
+- **Completion is pushed.** When a tracked process exits, the manager's
+  `onExit` hook fires with the final output; the REPL injects a
+  `[BACKGROUND COMPLETED]` system-reminder into the conversation. The model
+  never needs to poll to learn that a process finished or to get its result.
+
+- **Progress is pulled, as a snapshot.** `terminal_output` returns the last N
+  lines (`lines`, default 50) plus status via `bgProcess.tail`, which does
+  **not** advance any cursor. Repeated calls return the same view, so there is
+  no "new since last call" to chase and no incentive to loop. `terminal_list`
+  is the other snapshot — the set of live/recent processes — for recovering a
+  lost id.
+
+The internal cursor read (`readNew`) still exists for the synchronous poll loop
+and the completion push; only the model-facing `terminal_output` uses the
+non-advancing snapshot.
+
+## Cross-platform shell
+
+`shellInvocation` / `shellCommand` select the shell once: `sh -c` on
+macOS/Linux (with the safe-rm trash wrapper when a project dir is known),
+PowerShell (`pwsh`, else `powershell`) on Windows. Process-group and detach
+options are platform-specific (`internal/tools/terminal_kill.go` for POSIX,
+`terminal_kill_windows.go` for Windows). `terminal_input`'s stdin delivery is
+reliable only on POSIX — PowerShell's `-Command` mode does not deterministically
+forward redirected stdin to a spawned native process.

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -88,7 +88,7 @@ Memories are snapshots and can be stale. If one names a file path, function, fla
 
 - Use `terminal` with `run_in_background:true`.
 - After launch, **verify the service with an external check** (e.g., `curl http://localhost:PORT`, `pgrep`, or reading a PID file) rather than polling `terminal_output`.
-- You may call `terminal_output` occasionally to inspect startup logs or diagnose issues, but do not call it in a tight loop.
+- `terminal_output` is a **snapshot** of a process's last N lines, not a feed — call it on demand to inspect startup logs or check progress; repeated calls return the current tail, so there's nothing to gain from looping. Lost a process id? Use `terminal_list` to see what's running.
 - Stop with `kill_shell`. For servers and other services, prefer `signal: "SIGTERM"` for graceful shutdown. Use `signal: "SIGKILL"` (default) for forceful termination or when SIGTERM fails.
 
 ## Tool-use timing

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -72,6 +72,44 @@ func (p *bgProcess) finish(err error) {
 	p.mu.Unlock()
 }
 
+// statusLocked returns the status string ("running" / "exited: …"). Caller must
+// hold p.mu.
+func (p *bgProcess) statusLocked() string {
+	if !p.done {
+		return "running"
+	}
+	if p.exitErr != nil {
+		return "exited: " + p.exitErr.Error()
+	}
+	return "exited: 0"
+}
+
+// tail returns the last n lines of retained output (n <= 0 = all retained) plus
+// the current status. Unlike readNew it does NOT advance the read cursor: it's a
+// non-destructive snapshot, so repeated calls return the same view and there is
+// no incentive to poll. A truncation marker is prefixed when output was dropped
+// (buffer cap or the n-line clamp).
+func (p *bgProcess) tail(n int) (output, status string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	body := p.buf
+	truncated := p.produced > int64(len(p.buf)) // earlier bytes dropped by the cap
+	if n > 0 {
+		lines := bytes.Split(bytes.TrimRight(body, "\n"), []byte{'\n'})
+		if len(lines) > n {
+			lines = lines[len(lines)-n:]
+			truncated = true
+		}
+		body = bytes.Join(lines, []byte{'\n'})
+	}
+	out := string(body)
+	if truncated && out != "" {
+		out = "[... earlier output truncated ...]\n" + out
+	}
+	return out, p.statusLocked()
+}
+
 // readNew returns output produced since the last Read and the current status,
 // advancing the read cursor. When retained output was dropped (buffer cap), the
 // returned text is prefixed with a truncation marker.
@@ -88,14 +126,7 @@ func (p *bgProcess) readNew() (string, string, bool) {
 	out = append(out, p.buf[p.readOff-bufStart:]...)
 	p.readOff = p.produced
 
-	status := "running"
-	if p.done {
-		if p.exitErr != nil {
-			status = "exited: " + p.exitErr.Error()
-		} else {
-			status = "exited: 0"
-		}
-	}
+	status := p.statusLocked()
 
 	// Anti-polling: time-window based. Within a 30-second window, 3 or more
 	// empty reads on a running process trigger a block. This is lenient enough
@@ -283,17 +314,45 @@ func (m *BackgroundManager) Read(id string) (output, status string, found bool, 
 	return out, st, true, blk
 }
 
-// BgInfo is a snapshot of a still-running background process, for a live
-// "background (N running)" panel in the TUI.
+// Tail returns a non-destructive snapshot of the last `lines` lines of a
+// process's output (lines <= 0 = all retained), plus its status. found is false
+// when id is unknown. Unlike Read it does not advance the cursor — it's for
+// on-demand progress peeks (the terminal_output tool), so it never blocks and
+// repeated calls are idempotent.
+func (m *BackgroundManager) Tail(id string, lines int) (output, status string, found bool) {
+	m.mu.Lock()
+	p := m.procs[id]
+	m.mu.Unlock()
+	if p == nil {
+		return "", "", false
+	}
+	out, st := p.tail(lines)
+	return out, st, true
+}
+
+// BgInfo is a snapshot of a tracked background process — used both by the TUI's
+// live "background (N running)" panel and by the terminal_list tool.
 type BgInfo struct {
 	ID      string
 	Command string
 	Start   time.Time
+	Status  string // "running" / "exited: …"
 }
 
 // ListRunning returns the visible processes that haven't exited yet, oldest first.
 // Processes started invisibly (e.g. sync mode) are excluded until promoted.
 func (m *BackgroundManager) ListRunning() []BgInfo {
+	return m.list(false)
+}
+
+// List returns every visible tracked process — running AND exited-but-not-yet
+// reaped — oldest first, so the model (via terminal_list) can recover ids and
+// see what has finished. Invisible (sync, pre-timeout) processes are excluded.
+func (m *BackgroundManager) List() []BgInfo {
+	return m.list(true)
+}
+
+func (m *BackgroundManager) list(includeExited bool) []BgInfo {
 	m.mu.Lock()
 	procs := make([]*bgProcess, 0, len(m.procs))
 	for _, p := range m.procs {
@@ -306,9 +365,10 @@ func (m *BackgroundManager) ListRunning() []BgInfo {
 		p.mu.Lock()
 		done := p.done
 		visible := p.visible
+		info := BgInfo{ID: p.id, Command: p.command, Start: p.start, Status: p.statusLocked()}
 		p.mu.Unlock()
-		if !done && visible {
-			out = append(out, BgInfo{ID: p.id, Command: p.command, Start: p.start})
+		if visible && (includeExited || !done) {
+			out = append(out, info)
 		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Start.Before(out[j].Start) })

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -271,10 +271,12 @@ func TestTerminalTool_TimeoutPromotesToBackground(t *testing.T) {
 	t.Fatal("timed out waiting for background process to exit")
 }
 
-// TestTerminalOutputTool_AntiPolling verifies that after three empty polls
-// within the time window on a running background process, terminal_output
-// returns an error to force the LLM to stop polling.
-func TestTerminalOutputTool_AntiPolling(t *testing.T) {
+// TestTerminalOutputTool_SnapshotIdempotent verifies the snapshot semantics:
+// terminal_output is a non-advancing peek, so repeated calls on a running
+// process never error or "block" — they just return the current tail and
+// status. (Replaces the old delta + anti-polling behavior, which the snapshot
+// model removes by design.)
+func TestTerminalOutputTool_SnapshotIdempotent(t *testing.T) {
 	m := NewBackgroundManager()
 	term := TerminalTool{mgr: m}
 	outTool := TerminalOutputTool{mgr: m}
@@ -286,24 +288,15 @@ func TestTerminalOutputTool_AntiPolling(t *testing.T) {
 		t.Fatalf("launch: %v", err)
 	}
 
-	// First and second empty polls should warn but succeed (within the 30s window).
-	for i := 1; i <= 2; i++ {
+	// Many empty polls in a row: all succeed, none block, all report running.
+	for i := 1; i <= 5; i++ {
 		res, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_1"})
 		if err != nil {
-			t.Fatalf("poll %d should succeed: %v", i, err)
+			t.Fatalf("poll %d should never error in the snapshot model: %v", i, err)
 		}
-		if !strings.Contains(res.Text, "STOP POLLING") {
-			t.Errorf("poll %d should warn, got %q", i, res.Text)
+		if !strings.Contains(res.Text, "[status: running]") {
+			t.Errorf("poll %d should report running, got %q", i, res.Text)
 		}
-	}
-
-	// Third empty poll within the window: should be blocked with an error.
-	_, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_1"})
-	if err == nil {
-		t.Fatal("third poll should error")
-	}
-	if !strings.Contains(err.Error(), "polling blocked") {
-		t.Errorf("error should mention 'polling blocked', got %v", err)
 	}
 }
 
@@ -332,10 +325,5 @@ func TestTerminalOutputTool_ReadOnly(t *testing.T) {
 	}
 	if _, status, _, _ := m.Read("bg_1"); status != "running" {
 		t.Errorf("process should still be running after terminal_output, status=%q", status)
-	}
-	// When the process is running and there is no new output, the result must
-	// contain a strong anti-polling warning.
-	if !strings.Contains(resOut.Text, "STOP POLLING") {
-		t.Errorf("terminal_output on running process with no new output should warn against polling, got %q", resOut.Text)
 	}
 }

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -25,6 +25,7 @@ var allTools = []tool{
 	TerminalTool{},
 	TerminalOutputTool{},
 	TerminalInputTool{},
+	TerminalListTool{},
 	KillShellTool{},
 	ReadFileTool{},
 	WriteFileTool{},

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -29,11 +29,6 @@ const BgPollNotice = "DO NOT poll terminal_output. The system will automatically
 // terminal_output.
 const ServiceModeNotice = "After launching a long-running service, verify it with an external check (e.g., `curl http://localhost:PORT` or `pgrep`) rather than polling terminal_output. terminal_output is for inspecting startup logs or diagnosing issues — do not call it in a tight loop."
 
-// TerminalOutputStopPolling is the model-facing instruction appended to a
-// terminal_output result when the process is still running with no new output.
-// Like BgPollNotice, it is noise for the human so the TUI strips it from cards.
-const TerminalOutputStopPolling = "STOP POLLING. The system will automatically notify you when this background process finishes. Do NOT call terminal_output again unless you need to check progress mid-run."
-
 // TerminalTool is an agent.ToolExecutor that runs shell commands through the
 // system shell (`sh -c` on macOS/Linux, PowerShell on Windows; see
 // shellCommand). Stdout and stderr are combined and returned as the tool
@@ -249,7 +244,7 @@ func (t TerminalOutputTool) managerFor(ctx context.Context) *BackgroundManager {
 func (TerminalOutputTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name:        "terminal_output",
-		Description: "Read output produced since the last check from a background process (the id returned by terminal with run_in_background:true), along with its status (running / exited). To terminate the process, use the kill_shell tool.\n\nFor ONE-SHOT tasks (compiles, tests, builds): you do NOT need to poll this tool. The system automatically notifies you when the process finishes.\n\nFor LONG-RUNNING services (servers, watchers): you may call this tool occasionally to inspect startup logs or diagnose issues, but do not call it in a tight loop. Prefer verifying the service with an external check (e.g., curl, pgrep) instead.",
+		Description: "Peek at the recent output of a background process (the id from terminal run_in_background:true): a snapshot of the last N lines plus its status (running / exited). Read-only; to stop the process use kill_shell.\n\nUse this to CHECK PROGRESS of a still-running process on demand — e.g. inspect a server's startup logs. You do NOT need it to learn that a process finished or to get its result: completion is pushed to you automatically, carrying the final output. This is a snapshot, not a feed — repeated calls return the current tail, there is no 'new since last call', so do not call it in a loop. To find an id you've lost track of, use terminal_list.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -257,32 +252,40 @@ func (TerminalOutputTool) Definition() agent.ToolDefinition {
 					"type":        "string",
 					"description": "The background process id (e.g. \"bg_1\").",
 				},
+				"lines": map[string]any{
+					"type":        "integer",
+					"description": "How many trailing lines of output to return. Defaults to 50; use 0 for all retained output.",
+				},
 			},
 			"required": []string{"id"},
 		},
 	}
 }
 
-// Execute returns the new output plus a status line. Read-only — it never
-// terminates the process (that's kill_shell).
+// defaultTailLines is how many trailing lines terminal_output returns when the
+// caller doesn't specify.
+const defaultTailLines = 50
+
+// Execute returns a snapshot of the process's last N lines plus a status line.
+// Read-only and non-advancing — it never terminates the process (that's
+// kill_shell) and never moves a read cursor, so it can't "block" and there is
+// no polling incentive.
 func (t TerminalOutputTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	id, _ := input["id"].(string)
 	if id == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: id is required")
 	}
-	out, status, found, blocked := t.managerFor(ctx).Read(id)
-	if !found {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: no background process %q", id)
+	lines := defaultTailLines
+	if v, ok := input["lines"].(float64); ok { // JSON numbers decode as float64
+		lines = int(v)
 	}
-	if blocked {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: polling blocked for %s — the process is still running with no new output. Wait for the automatic completion notification instead.", id)
+	out, status, found := t.managerFor(ctx).Tail(id, lines)
+	if !found {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: no background process %q (it may have been reaped — use terminal_list to see live processes)", id)
 	}
 	header := "[status: " + status + "]"
 	if out == "" {
-		if status == "running" {
-			return agent.ToolResult{Text: header + "\n(no new output)\n\n" + TerminalOutputStopPolling}, nil
-		}
-		return agent.ToolResult{Text: header + "\n(no new output)"}, nil
+		return agent.ToolResult{Text: header + "\n(no output yet)"}, nil
 	}
 	return agent.ToolResult{Text: header + "\n" + MaybeSpillOutput(id, out)}, nil
 }
@@ -393,4 +396,41 @@ func (t KillShellTool) Execute(ctx context.Context, _ string, input map[string]a
 		return agent.ToolResult{Text: header + "\n(no new output)"}, nil
 	}
 	return agent.ToolResult{Text: header + "\n" + MaybeSpillOutput(id, out)}, nil
+}
+
+// TerminalListTool lists this session's background processes (running and
+// recently-finished), so the model can recover a process id it lost track of
+// and see what is still running. The observe surface is push for completion +
+// pull-snapshot for everything else: terminal_list (this), terminal_output
+// (per-process tail). Neither advances any cursor.
+type TerminalListTool struct{ mgr *BackgroundManager }
+
+func (t TerminalListTool) managerFor(ctx context.Context) *BackgroundManager {
+	return resolveBackgroundManager(ctx, t.mgr)
+}
+
+// Definition takes no parameters.
+func (TerminalListTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name:        "terminal_list",
+		Description: "List this session's background processes — those started with terminal run_in_background:true — with their id, status (running / exited), elapsed time, and command. Use to recover a process id you've lost track of, or to see what is still running before checking its output (terminal_output) or stopping it (kill_shell). Detached processes (terminal detached:true) are NOT listed — they're untracked by design.",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+	}
+}
+
+// Execute renders the tracked background processes as a compact table.
+func (t TerminalListTool) Execute(ctx context.Context, _ string, _ map[string]any) (agent.ToolResult, error) {
+	infos := t.managerFor(ctx).List()
+	if len(infos) == 0 {
+		return agent.ToolResult{Text: "No background processes."}, nil
+	}
+	var b strings.Builder
+	for _, in := range infos {
+		elapsed := time.Since(in.Start).Round(time.Second)
+		fmt.Fprintf(&b, "%s  [%s]  %s  %s\n", in.ID, in.Status, elapsed, in.Command)
+	}
+	return agent.ToolResult{Text: strings.TrimRight(b.String(), "\n")}, nil
 }

--- a/internal/tools/terminal_observe_test.go
+++ b/internal/tools/terminal_observe_test.go
@@ -1,0 +1,78 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestTerminalListTool lists running background processes so the model can
+// recover an id, and reflects status once a process exits.
+func TestTerminalListTool(t *testing.T) {
+	m := NewBackgroundManager()
+	term := TerminalTool{mgr: m}
+	listTool := TerminalListTool{mgr: m}
+	ctx := context.Background()
+
+	// Nothing running yet.
+	if res, _ := listTool.Execute(ctx, "terminal_list", nil); !strings.Contains(res.Text, "No background processes") {
+		t.Errorf("empty list should say so, got %q", res.Text)
+	}
+
+	if _, err := term.Execute(ctx, "terminal", map[string]any{
+		"command":           "sleep 30",
+		"run_in_background": true,
+	}); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+
+	res, err := listTool.Execute(ctx, "terminal_list", nil)
+	if err != nil {
+		t.Fatalf("terminal_list: %v", err)
+	}
+	if !strings.Contains(res.Text, "bg_1") || !strings.Contains(res.Text, "running") {
+		t.Errorf("list should show the running process id + status, got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "sleep 30") {
+		t.Errorf("list should include the command, got %q", res.Text)
+	}
+}
+
+// TestTerminalOutputTool_LinesSnapshot verifies the lines param trims to the
+// last N lines and that the snapshot is non-advancing (a second call returns
+// the same tail, not "new since last read").
+func TestTerminalOutputTool_LinesSnapshot(t *testing.T) {
+	m := NewBackgroundManager()
+	outTool := TerminalOutputTool{mgr: m}
+	ctx := context.Background()
+
+	// Print 5 lines then exit; wait for completion.
+	if _, err := (TerminalTool{mgr: m}).Execute(ctx, "terminal", map[string]any{
+		"command":           "printf 'l1\\nl2\\nl3\\nl4\\nl5\\n'",
+		"run_in_background": true,
+	}); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	waitFor(t, "exit", func() bool {
+		_, s, _, _ := m.Read("bg_1")
+		return strings.HasPrefix(s, "exited")
+	})
+
+	// Last 2 lines only.
+	res, err := outTool.Execute(ctx, "terminal_output", map[string]any{"id": "bg_1", "lines": float64(2)})
+	if err != nil {
+		t.Fatalf("terminal_output: %v", err)
+	}
+	if !strings.Contains(res.Text, "l4") || !strings.Contains(res.Text, "l5") {
+		t.Errorf("tail(2) should contain the last two lines, got %q", res.Text)
+	}
+	if strings.Contains(res.Text, "l1") {
+		t.Errorf("tail(2) should not contain the first line, got %q", res.Text)
+	}
+
+	// Idempotent: a second identical call returns the same snapshot.
+	res2, _ := outTool.Execute(ctx, "terminal_output", map[string]any{"id": "bg_1", "lines": float64(2)})
+	if res2.Text != res.Text {
+		t.Errorf("snapshot should be idempotent:\nfirst:  %q\nsecond: %q", res.Text, res2.Text)
+	}
+}


### PR DESCRIPTION
Item **#3** + the approved **#4** design — the last of the terminal-tool cleanups (after #512 terminate chokepoint, #513 per-session managers).

## Why

The old observe surface fought itself: `terminal_output` returned *"new output since last read"* (a cursor/delta), which only makes sense if you loop — so the tool **invited** polling, then leaned on an anti-polling blocker + prompt warnings to discourage it. Completion and progress were conflated.

## Change — split the two needs

- **Completion = push** (unchanged): the `onExit` hook already carries final output and the REPL injects a `[BACKGROUND COMPLETED]` reminder. The model never polls to learn a process finished or to get its result.
- **Progress = pull SNAPSHOT**: `terminal_output` now returns the **last N lines** (`lines`, default 50) via a new non-advancing `bgProcess.tail`. Repeated calls return the same view — no cursor, no "block", no incentive to loop. The delta/anti-polling machinery (and `TerminalOutputStopPolling` + its TUI strip) are removed.
- **New `terminal_list` tool**: this session's background processes (id, status, elapsed, command), so the model can recover a lost id or see what's running. Backed by `BackgroundManager.List` (running + exited-unreaped); `ListRunning`/`List` share one helper and `BgInfo` carries `Status`. Detached processes are not listed (untracked by design).

## Docs

- `base.md`: describes the snapshot + `terminal_list` surface; drops the "don't poll" framing now that the tool can't be polled meaningfully.
- **New `dev-docs/terminal-tools.md`** — current-state architecture doc for the whole family: the three run modes (sync / background / detached), the `BackgroundManager` lifecycle, the single `terminate()` chokepoint (#512), per-session manager scoping (#513), and this observe surface. (Per the reminder to update design docs — written now that the architecture is settled across #512/#513/#510/this.)

## Tests

- `terminal_list` (running + command + status), `terminal_output` lines-tail + snapshot idempotency.
- The obsolete anti-polling test is replaced with a snapshot-idempotency test; `ReadOnly` test keeps its still-valid assertions.
- `go test -race ./internal/tools/ ./cmd/octo/ ./internal/server/ ./internal/prompt/` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)