### PR TITLE
fix(memory): surface silent failures + share memory across worktrees

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -240,7 +240,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	listSkills := fs.Bool("list-skills", false, "Print available skills (user + project) and exit")
 	enableTools := fs.Bool("tools", true, "Built-in tools (terminal, edit_file, …) for the agentic loop. On by default; use --no-tools to disable.")
 	noTools := fs.Bool("no-tools", false, "Disable the built-in tools (and MCP/skill execution) — plain chat only")
-	noMemory := fs.Bool("no-memory", false, "Disable cross-session memory (the remember tool + memory injection)")
+	noMemory := fs.Bool("no-memory", false, "Disable cross-session memory (MEMORY.md injection + the writable memory directory)")
 	plain := fs.Bool("plain", false, "Render tool events as one-line ↳ status lines instead of rich diff cards")
 	promptFile := fs.String("prompt-file", "", "Read the prompt from this file (newlines preserved) and run it as one headless agentic turn, then exit. For scripting/eval.")
 	noTUI := fs.Bool("no-tui", false, "Force the headless one-shot path on a terminal instead of the interactive TUI (also OCTO_TUI=0). The prompt comes from a positional message, --prompt-file, or piped stdin.")

--- a/cmd/octo/memory.go
+++ b/cmd/octo/memory.go
@@ -45,12 +45,22 @@ func runMemory(args []string, stdout, stderr io.Writer) int {
 
 	fmt.Fprintf(stdout, "Memory directory: %s\n", dir)
 	printDirEntries(stdout, dir)
+	printLint(stdout, dir)
 
 	if homeDir != "" {
 		fmt.Fprintf(stdout, "\nInherited memories: %s\n", homeDir)
 		printDirEntries(stdout, homeDir)
+		printLint(stdout, homeDir)
 	}
 	return 0
+}
+
+// printLint surfaces MEMORY.md problems that would otherwise fail silently
+// (over-budget truncation, un-recallable triggered rules).
+func printLint(w io.Writer, dir string) {
+	for _, warn := range memory.Lint(dir) {
+		fmt.Fprintf(w, "  ⚠ %s\n", warn)
+	}
 }
 
 func printDirEntries(w io.Writer, dir string) {

--- a/dev-docs/memory-design.md
+++ b/dev-docs/memory-design.md
@@ -18,11 +18,14 @@ separate and described in `identity-files-design.md`.
   <topic>.md     detail files the agent creates and reads on demand
 ```
 
-- **Per repo.** The directory is keyed by the git top-level of the working
-  directory (`memory.ProjectRoot`), so each project has its own memory and
-  facts don't bleed across repos. Outside a git repo the working directory is
-  used. The slug is the repo basename plus a short hash of the full path, so two
-  checkouts that share a basename don't collide.
+- **Per repo, shared across worktrees.** The directory is keyed by the repo
+  root (`memory.ProjectRoot`), so each project has its own memory and facts
+  don't bleed across repos. The root is derived from the git *common* dir
+  (`<root>/.git`), which the main checkout and every linked worktree share, so a
+  worktree doesn't start with empty project memory; the result is symlink-
+  resolved so one repo always maps to one slug. Outside a git repo the working
+  directory is used. The slug is the repo basename plus a short hash of the full
+  path, so two checkouts that share a basename don't collide.
 - **Inheritance.** The home directory (`~`) also has its own memory slot.
   When running inside any project, the home MEMORY.md is injected *before* the
   project MEMORY.md, so cross-project preferences and personal facts are
@@ -31,8 +34,11 @@ separate and described in `identity-files-design.md`.
   preferences go to the home (inherited) memory.
 - **MEMORY.md is the index.** It is loaded into the system prompt at session
   start, truncated to the first 200 lines / 25 KB (whichever comes first),
-  mirroring Claude Code's cap. Topic files are not loaded up front — the agent
-  reads them on demand with its file tools when MEMORY.md points at one.
+  mirroring Claude Code's cap. When the file exceeds that budget the injected
+  block carries an explicit truncation warning (so entries past the cut aren't
+  dropped silently), and `octo memory` lints for it. Topic files are not loaded
+  up front — the agent reads them on demand with its file tools when MEMORY.md
+  points at one.
 
 ## Injection
 

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -34,18 +34,53 @@ const (
 	maxInjectBytes = 25 * 1024
 )
 
-// ProjectRoot returns the git top-level containing dir, or dir itself when it's
-// not in a git repo (or git is unavailable). Memory is scoped per repo root.
+// ProjectRoot returns the repo root that memory is scoped to for dir, or dir
+// itself when it's not in a git repo (or git is unavailable).
+//
+// It derives the root from the git *common* dir rather than the per-worktree
+// top-level, so every linked worktree of a repo shares one memory scope (a
+// worktree checkout doesn't start with empty project memory). The common dir is
+// `<root>/.git`, shared by the main worktree and all linked ones:
+//   - main worktree → ".git" (relative to dir) → root = dir
+//   - linked worktree → "<root>/.git" (absolute) → root = <root>
+//
+// Either way the main-checkout result is unchanged from the old --show-toplevel
+// behavior, so existing memory dirs keep their slug.
 func ProjectRoot(dir string) string {
 	if dir == "" {
 		return ""
 	}
+	if out, err := exec.Command("git", "-C", dir, "rev-parse", "--git-common-dir").Output(); err == nil {
+		common := strings.TrimSpace(string(out))
+		if common != "" {
+			if !filepath.IsAbs(common) {
+				common = filepath.Join(dir, common) // relative paths are relative to `dir` (the -C target)
+			}
+			common = filepath.Clean(common)
+			if filepath.Base(common) == ".git" {
+				return resolveSymlinks(filepath.Dir(common))
+			}
+			// Bare repo or unusual layout — fall through to the top-level.
+		}
+	}
 	if out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output(); err == nil {
 		if root := strings.TrimSpace(string(out)); root != "" {
-			return root
+			return resolveSymlinks(root)
 		}
 	}
 	return dir
+}
+
+// resolveSymlinks returns the symlink-free form of p so the same repo always
+// maps to one slug — git reports a resolved absolute path for a linked
+// worktree's common dir, and the old --show-toplevel was likewise resolved, so
+// the main checkout and its worktrees must normalize the same way. Falls back
+// to p when it can't be resolved.
+func resolveSymlinks(p string) string {
+	if r, err := filepath.EvalSymlinks(p); err == nil {
+		return r
+	}
+	return p
 }
 
 // Dir returns the memory directory for repoRoot: ~/.octo/memories/<repo-slug>.
@@ -86,26 +121,49 @@ func EnsureDir(dir string) error { return os.MkdirAll(dir, 0o755) }
 // LoadIndex returns MEMORY.md truncated to the injection budget, or "" when the
 // file is absent or empty.
 func LoadIndex(dir string) string {
+	s, _ := loadIndex(dir)
+	return s
+}
+
+// loadIndex returns the truncated index and whether truncation dropped any
+// content (the file exceeded maxInjectBytes or maxInjectLines).
+func loadIndex(dir string) (string, bool) {
 	b, err := os.ReadFile(filepath.Join(dir, IndexFile))
 	if err != nil {
-		return ""
+		return "", false
 	}
 	return truncateForInjection(string(b))
 }
 
-func truncateForInjection(s string) string {
+// truncateForInjection clamps s to the injection budget and reports whether
+// anything was dropped.
+func truncateForInjection(s string) (string, bool) {
+	truncated := false
 	if len(s) > maxInjectBytes {
 		s = s[:maxInjectBytes]
+		truncated = true
 	}
 	sc := bufio.NewScanner(strings.NewReader(s))
 	sc.Buffer(make([]byte, 0, 64*1024), maxInjectBytes+1024)
 	var b strings.Builder
-	for n := 0; n < maxInjectLines && sc.Scan(); n++ {
+	n := 0
+	for n < maxInjectLines && sc.Scan() {
 		b.WriteString(sc.Text())
 		b.WriteByte('\n')
+		n++
 	}
-	return strings.TrimRight(b.String(), "\n")
+	if sc.Scan() { // a line remains past the cap
+		truncated = true
+	}
+	return strings.TrimRight(b.String(), "\n"), truncated
 }
+
+// truncationWarning is appended inside an injected index that was cut to the
+// budget, so the model (and the user via `octo memory`) knows entries are
+// missing rather than silently losing them.
+const truncationWarning = "\n\n⚠ This MEMORY.md exceeds the injection budget (" +
+	"200 lines / 25KB); entries past the cut are NOT loaded this session. " +
+	"Prune it or move detail into topic files."
 
 // RenderInjection builds the memory section for the system prompt: an
 // instruction block telling the model where its memory lives and how to manage
@@ -146,13 +204,19 @@ func RenderInjection(dir string, inheritedDirs ...string) string {
 
 	// Inject inherited memories first (global / home-dir), then project-specific.
 	for _, d := range inheritedDirs {
-		if idx := LoadIndex(d); idx != "" {
+		if idx, trunc := loadIndex(d); idx != "" {
 			b.WriteString("\n## " + IndexFile + " (inherited from " + d + ")\n\n" + idx)
+			if trunc {
+				b.WriteString(truncationWarning)
+			}
 		}
 	}
 
-	if idx := LoadIndex(dir); idx != "" {
+	if idx, trunc := loadIndex(dir); idx != "" {
 		b.WriteString("\n## " + IndexFile + "\n\n" + idx)
+		if trunc {
+			b.WriteString(truncationWarning)
+		}
 	} else {
 		b.WriteString("\n(" + IndexFile + " is empty — start it when there's something worth remembering.)")
 	}

--- a/internal/memory/robustness_test.go
+++ b/internal/memory/robustness_test.go
@@ -1,0 +1,110 @@
+package memory
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestProjectRoot_WorktreeSharesRoot verifies the scoping fix: a linked
+// worktree resolves to the same project root as the main checkout, so it shares
+// one memory scope instead of starting empty.
+func TestProjectRoot_WorktreeSharesRoot(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	main := t.TempDir()
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run(main, "init", "-q")
+	if err := os.WriteFile(filepath.Join(main, "f"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(main, "add", "-A")
+	run(main, "commit", "-qm", "init")
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	run(main, "worktree", "add", "-q", wt, "HEAD")
+
+	mainRoot := ProjectRoot(main)
+	wtRoot := ProjectRoot(wt)
+	if wtRoot != mainRoot {
+		t.Errorf("worktree should share the main repo's memory scope:\n  main: %s\n  wt:   %s", mainRoot, wtRoot)
+	}
+	// And it must be the main repo, not the worktree's own path.
+	if resolved, _ := filepath.EvalSymlinks(wt); wtRoot == resolved {
+		t.Errorf("worktree root should be the main repo, not the worktree dir %s", wtRoot)
+	}
+}
+
+func TestTruncateForInjection_Flag(t *testing.T) {
+	small, trunc := truncateForInjection("a\nb\nc")
+	if trunc {
+		t.Errorf("small input should not be truncated, got %q", small)
+	}
+	var big strings.Builder
+	for i := 0; i < maxInjectLines+50; i++ {
+		big.WriteString("line\n")
+	}
+	out, trunc := truncateForInjection(big.String())
+	if !trunc {
+		t.Error("over-line-budget input should be flagged truncated")
+	}
+	if got := strings.Count(out, "\n") + 1; got > maxInjectLines {
+		t.Errorf("truncated output should be <= %d lines, got %d", maxInjectLines, got)
+	}
+}
+
+func TestRenderInjection_TruncationWarning(t *testing.T) {
+	dir := t.TempDir()
+	var big strings.Builder
+	for i := 0; i < maxInjectLines+20; i++ {
+		big.WriteString("- entry\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, IndexFile), []byte(big.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := RenderInjection(dir)
+	if !strings.Contains(got, "exceeds the injection budget") {
+		t.Errorf("over-budget index should inject a truncation warning; got:\n%s", got[len(got)-300:])
+	}
+}
+
+func TestLint(t *testing.T) {
+	// Clean file → no warnings.
+	clean := t.TempDir()
+	os.WriteFile(filepath.Join(clean, IndexFile), []byte("# notes\n- a pointer\n\n## 触发提醒\n- (触发: deploy) push to staging first\n"), 0o644)
+	if w := Lint(clean); len(w) != 0 {
+		t.Errorf("clean memory should lint clean, got %v", w)
+	}
+
+	// Triggered rule with no clause → never-recalled warning.
+	bad := t.TempDir()
+	os.WriteFile(filepath.Join(bad, IndexFile), []byte("## 触发提醒\n- always rebase before merging\n"), 0o644)
+	w := Lint(bad)
+	if len(w) == 0 || !strings.Contains(strings.Join(w, "\n"), "never be recalled") {
+		t.Errorf("triggered rule with no clause should warn, got %v", w)
+	}
+
+	// Over-budget → budget warning.
+	over := t.TempDir()
+	var big strings.Builder
+	for i := 0; i < maxInjectLines+5; i++ {
+		big.WriteString("- x\n")
+	}
+	os.WriteFile(filepath.Join(over, IndexFile), []byte(big.String()), 0o644)
+	if w := Lint(over); len(w) == 0 || !strings.Contains(strings.Join(w, "\n"), "injection budget") {
+		t.Errorf("over-budget index should warn, got %v", w)
+	}
+}

--- a/internal/memory/rules.go
+++ b/internal/memory/rules.go
@@ -14,9 +14,43 @@ package memory
 
 import (
 	"bufio"
+	"fmt"
 	"regexp"
 	"strings"
 )
+
+// Lint inspects a memory dir's MEMORY.md for problems that silently degrade
+// recall, returning human-readable warnings (nil when clean):
+//   - the index exceeds the injection budget, so entries past the cut are not
+//     loaded into the session;
+//   - a bullet under a 触发提醒 (triggered) section has no parseable
+//     "(触发: …)" clause, so it can never be recalled — the most common
+//     silent failure, since the rule still looks present in the file.
+//
+// It lints the injected view (truncated to the budget), matching what is
+// actually active this session.
+func Lint(dir string) []string {
+	raw, truncated := loadIndex(dir)
+	var warns []string
+	if truncated {
+		warns = append(warns, "MEMORY.md exceeds the injection budget (200 lines / 25KB) — entries past the cut are not loaded. Prune it or move detail into topic files.")
+	}
+	for _, r := range parseRules(raw).Triggered {
+		if len(r.Triggers) == 0 {
+			warns = append(warns, fmt.Sprintf("rule under 触发提醒 has no (触发: …) clause and will never be recalled — add one or move it to 必须遵守: %q", oneLine(r.Text)))
+		}
+	}
+	return warns
+}
+
+// oneLine collapses a rule to a short single-line form for warning output.
+func oneLine(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) > 60 {
+		s = s[:57] + "…"
+	}
+	return s
+}
 
 // Rule is one actionable memory item parsed from MEMORY.md's structured
 // sections. Text is the full rule; Triggers is empty for always-apply rules.


### PR DESCRIPTION
Four robustness fixes from the memory-feature review (items 1–3 + the scoping edge).

## 1. Truncation is no longer silent
`MEMORY.md` is injected truncated to 200 lines / 25 KB. Previously, exceeding that just dropped the tail (often the newest entries) with no signal. `truncateForInjection` now reports whether it cut anything, and `RenderInjection` appends an explicit warning **inside the injected block** so the model knows entries past the cut aren't loaded.

## 2. Parse / budget failures are visible
New `memory.Lint(dir)` flags the two silent degraders:
- the index is over budget (entries past the cut aren't loaded);
- a bullet under `## 触发提醒` has no parseable `(触发: …)` clause — it still *looks* present in the file but **can never be recalled** (the most insidious failure).

`octo memory` now prints these warnings (`⚠ …`) for the project and inherited dirs.

## 3. Worktree scoping (the edge from the review)
`ProjectRoot` derived the scope from the per-worktree `--show-toplevel`, so every worktree of a repo got its **own, empty** memory. It now derives the root from the git **common** dir (`<root>/.git`, shared by the main checkout and all linked worktrees), so a worktree shares the main repo's memory. The result is symlink-resolved so one repo always maps to one slug — and the main-checkout result is unchanged from the old (also-resolved) `--show-toplevel`, so **existing memory dirs keep their slug** (no migration).

## 4. Stale flag help
`--no-memory` claimed it disables "the remember tool" — there is no remember tool. Fixed to "MEMORY.md injection + the writable memory directory".

## Tests / docs
- `TestProjectRoot_WorktreeSharesRoot` (real git: worktree root == main root, ≠ worktree dir), truncation flag, injected warning, `Lint` (clean / no-trigger rule / over-budget).
- `go test -race ./internal/memory/ ./cmd/octo/` + `go vet` clean.
- `dev-docs/memory-design.md` updated for the worktree scoping and truncation warning.

Not done (from the review, by design / out of scope): semantic recall, confidence/recency/conflict-resolution, code-driven consolidation — left to the "dumb storage + smart model" philosophy unless recall misses prove painful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)