### PR TITLE
fix(tools): close sub-agent contract gaps + cap async fan-out

### DIFF
--- a/cmd/octo/subagent_notify.go
+++ b/cmd/octo/subagent_notify.go
@@ -28,6 +28,9 @@ func formatSubAgentNote(ev tools.SubAgentNotification) string {
 		b.WriteString("\nResult:\n")
 		b.WriteString(ev.Result)
 	}
+	if ev.StopReason == "max_turns" {
+		b.WriteString("\n[INCOMPLETE: this sub-agent hit its turn limit — the result above is partial, not a finished answer.]")
+	}
 	if ev.InputTokens > 0 || ev.OutputTokens > 0 {
 		fmt.Fprintf(&b, "\n[usage] in %d / out %d", ev.InputTokens, ev.OutputTokens)
 	}

--- a/cmd/octo/subagent_notify_test.go
+++ b/cmd/octo/subagent_notify_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// TestFormatSubAgentNote_MaxTurnsFlagged verifies an async sub-agent that hit
+// its turn limit is flagged INCOMPLETE in the completion notice, so the parent
+// doesn't treat partial work as a finished answer.
+func TestFormatSubAgentNote_MaxTurnsFlagged(t *testing.T) {
+	got := formatSubAgentNote(tools.SubAgentNotification{
+		AgentID:     "agent_1",
+		Description: "investigate",
+		Kind:        "spawn_done",
+		Result:      "partial findings",
+		StopReason:  "max_turns",
+	})
+	if !strings.Contains(got, "INCOMPLETE") {
+		t.Errorf("max_turns notice should be flagged INCOMPLETE, got:\n%s", got)
+	}
+
+	// Normal completion is not flagged.
+	clean := formatSubAgentNote(tools.SubAgentNotification{
+		AgentID: "agent_2", Description: "x", Kind: "spawn_done", Result: "done",
+	})
+	if strings.Contains(clean, "INCOMPLETE") {
+		t.Errorf("a complete notice should not be flagged, got:\n%s", clean)
+	}
+}

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -33,14 +33,17 @@ func (AgentTool) Definition() agent.ToolDefinition {
 			"Use when you need parallel investigation, a fresh context for an isolated " +
 			"sub-problem, or when the task is well-defined enough to delegate.\n\n" +
 			"Two modes:\n" +
-			"- **Fork** (omit subagent_type): the child inherits your full conversation " +
-			"context and system prompt. Cheap — shares your prompt cache. Use when the " +
-			"intermediate tool output isn't worth keeping in your context.\n" +
-			"- **Fresh agent** (set subagent_type): the child starts with zero context. " +
-			"Provide a complete task description. Use when you want an independent read " +
-			"(e.g. code review) or a specialized persona.\n\n" +
+			"- **Fork** (omit subagent_type): the child inherits your system prompt — the " +
+			"shared harness identity (base rules, env, skills, memory) — and shares its " +
+			"prompt cache, so it's cheap. It does NOT see this conversation's messages, so " +
+			"still put everything the task needs in `prompt`. Use when the intermediate " +
+			"tool output isn't worth keeping in your context.\n" +
+			"- **Fresh agent** (set subagent_type): the child starts with zero context and a " +
+			"specialized persona. Provide a complete task description. Use when you want an " +
+			"independent read (e.g. code review).\n\n" +
 			"Set run_in_background=true to run asynchronously — you will be notified when " +
-			"it completes. Leave it false (default) to block and receive the result directly.",
+			"it completes. Leave it false (default) to block and receive the result directly. " +
+			"(Some transports run every sub-agent synchronously; the result says so when it does.)",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -54,7 +57,7 @@ func (AgentTool) Definition() agent.ToolDefinition {
 				},
 				"subagent_type": map[string]any{
 					"type":        "string",
-					"description": "Optional agent type. 'explore' (read-only research), 'plan' (read-only planning), 'general' (full toolbelt), 'code-review' (read-only review). Omit to fork yourself — inherits your context.",
+					"description": "Optional agent type. 'explore' (read-only research), 'plan' (read-only planning), 'general' (full toolbelt), 'code-review' (read-only review). Omit to fork yourself — the child inherits your system prompt (not this conversation's messages).",
 				},
 				"run_in_background": map[string]any{
 					"type":        "boolean",
@@ -119,10 +122,13 @@ func (AgentTool) Execute(ctx context.Context, _ string, input map[string]any) (a
 
 	// Determine sync vs async
 	runInBackground := boolArg(input, "run_in_background")
-	// Synchronous transports (server / IM) have no follow-up-turn channel,
-	// so force sync even if the model asked for background.
-	if mgr.Synchronous() {
+	// Synchronous transports (server / IM) have no follow-up-turn channel, so
+	// force sync even if the model asked for background — and tell the model,
+	// rather than silently downgrading its choice.
+	forcedSync := false
+	if runInBackground && mgr.Synchronous() {
 		runInBackground = false
+		forcedSync = true
 	}
 
 	if runInBackground {
@@ -135,12 +141,21 @@ func (AgentTool) Execute(ctx context.Context, _ string, input map[string]any) (a
 		}, nil
 	}
 
-	// Synchronous path — block and return the result
+	// Synchronous path — block and return the result.
 	res, err := mgr.RunSync(ctx, req)
 	if err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("sub_agent: %w", err)
 	}
-	return agent.ToolResult{Text: withAgentTag(res.AgentID, res.Reply)}, nil
+	text := withAgentTag(res.AgentID, res.Reply)
+	// Surface a truncated result rather than passing a partial reply off as
+	// complete: a sub-agent that hit its turn limit returns partial work.
+	if res.StopReason == "max_turns" {
+		text += "\n\n[INCOMPLETE: this sub-agent hit its turn limit — the result above is partial. Re-launch with a narrower task, or treat it as unfinished.]"
+	}
+	if forcedSync {
+		text += "\n\n[note: ran synchronously and returned its full result here — this transport doesn't support background sub-agents, so run_in_background was ignored.]"
+	}
+	return agent.ToolResult{Text: text}, nil
 }
 
 // boolArg pulls a boolean argument, defaulting to false.

--- a/internal/tools/subagent_contract_test.go
+++ b/internal/tools/subagent_contract_test.go
@@ -1,0 +1,110 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// blockingSpawner blocks in Spawn until release is closed, so a test can hold
+// async sub-agents "running" and exercise the concurrency cap.
+type blockingSpawner struct{ release chan struct{} }
+
+func (s *blockingSpawner) Spawn(_ context.Context, _ SpawnRequest) (SpawnResult, error) {
+	<-s.release
+	return SpawnResult{AgentID: "c", Reply: "done"}, nil
+}
+func (s *blockingSpawner) Continue(_ context.Context, _, _ string) (SpawnResult, error) {
+	return SpawnResult{}, nil
+}
+
+// resultSpawner returns a fixed reply + stop reason synchronously.
+type resultSpawner struct {
+	reply      string
+	stopReason string
+}
+
+func (s *resultSpawner) Spawn(_ context.Context, _ SpawnRequest) (SpawnResult, error) {
+	return SpawnResult{AgentID: "c1", Reply: s.reply, StopReason: s.stopReason}, nil
+}
+func (s *resultSpawner) Continue(_ context.Context, _, _ string) (SpawnResult, error) {
+	return SpawnResult{}, nil
+}
+
+// TestSubAgentManager_ConcurrencyCap verifies async spawns are bounded: the
+// cap-th+1 launch is rejected while the others are running, and a slot frees up
+// once one finishes.
+func TestSubAgentManager_ConcurrencyCap(t *testing.T) {
+	sp := &blockingSpawner{release: make(chan struct{})}
+	mgr := NewSubAgentManager(sp) // async
+
+	for i := 0; i < maxConcurrentSubAgents; i++ {
+		if _, err := mgr.Start(SpawnRequest{Description: "x"}); err != nil {
+			t.Fatalf("start %d (within cap) should succeed: %v", i, err)
+		}
+	}
+	if _, err := mgr.Start(SpawnRequest{Description: "over"}); err == nil {
+		t.Fatal("start past the cap should be rejected")
+	} else if !strings.Contains(err.Error(), "too many") {
+		t.Errorf("cap error should explain itself, got: %v", err)
+	}
+
+	// Let the running ones finish; a slot should free up.
+	close(sp.release)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := mgr.Start(SpawnRequest{Description: "after"}); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("a slot should free up after running sub-agents finish")
+}
+
+// TestAgentTool_SyncMaxTurnsSurfaced verifies a sync sub-agent that hit its
+// turn limit is flagged INCOMPLETE rather than passed off as a finished result.
+func TestAgentTool_SyncMaxTurnsSurfaced(t *testing.T) {
+	mgr := NewSubAgentManager(&resultSpawner{reply: "partial work", stopReason: "max_turns"})
+	ctx := WithSubAgentManager(context.Background(), mgr)
+
+	res, err := (AgentTool{}).Execute(ctx, "sub_agent", map[string]any{
+		"description": "d", "prompt": "p",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(res.Text, "INCOMPLETE") {
+		t.Errorf("max_turns result should be flagged INCOMPLETE, got: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "partial work") {
+		t.Errorf("the partial reply should still be returned, got: %q", res.Text)
+	}
+
+	// A normal completion must NOT be flagged.
+	mgr2 := NewSubAgentManager(&resultSpawner{reply: "done", stopReason: ""})
+	ctx2 := WithSubAgentManager(context.Background(), mgr2)
+	res2, _ := (AgentTool{}).Execute(ctx2, "sub_agent", map[string]any{"description": "d", "prompt": "p"})
+	if strings.Contains(res2.Text, "INCOMPLETE") {
+		t.Errorf("a complete result should not be flagged, got: %q", res2.Text)
+	}
+}
+
+// TestAgentTool_ForcedSyncNote verifies that asking for background on a
+// synchronous transport tells the model it ran synchronously instead of
+// silently ignoring the choice.
+func TestAgentTool_ForcedSyncNote(t *testing.T) {
+	mgr := NewSubAgentManager(&resultSpawner{reply: "done"})
+	mgr.SetSynchronous(true)
+	ctx := WithSubAgentManager(context.Background(), mgr)
+
+	res, err := (AgentTool{}).Execute(ctx, "sub_agent", map[string]any{
+		"description": "d", "prompt": "p", "run_in_background": true,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(res.Text, "ran synchronously") {
+		t.Errorf("forced-sync downgrade should be surfaced, got: %q", res.Text)
+	}
+}

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -125,6 +125,14 @@ func SetDefaultSubAgentManager(m *SubAgentManager) { defaultSubAgentMgr = m }
 // which is required for the Agent tool.
 func subAgentManagerEnabled() bool { return defaultSubAgentMgr != nil }
 
+// maxConcurrentSubAgents caps how many async sub-agents may run at once, so a
+// model that fires off a large fan-out of run_in_background:true calls can't
+// spawn an unbounded number of concurrent agent loops (each making API calls).
+// New spawns past the cap are rejected with a clear error so the model waits
+// for some to finish; it does not bound resumed (Send/Continue) rounds, which
+// are limited by the live-child cap.
+const maxConcurrentSubAgents = 8
+
 // SubAgentManager owns the set of async sub-agents for a session.
 // Methods are safe for concurrent use.
 type SubAgentManager struct {
@@ -135,6 +143,7 @@ type SubAgentManager struct {
 	onExit      func(SubAgentNotification)
 	onEvent     func(SubAgentEvent)
 	synchronous bool
+	activeAsync int // running async spawns, for the concurrency cap
 }
 
 // NewSubAgentManager returns an empty manager.
@@ -286,6 +295,13 @@ func (m *SubAgentManager) Start(req SpawnRequest) (string, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	m.mu.Lock()
+	if m.activeAsync >= maxConcurrentSubAgents {
+		n := m.activeAsync // read under the lock; don't touch m.activeAsync after Unlock
+		m.mu.Unlock()
+		cancel()
+		return "", fmt.Errorf("too many sub-agents running (%d/%d) — wait for some to finish (you'll be notified) before launching more", n, maxConcurrentSubAgents)
+	}
+	m.activeAsync++
 	m.seq++
 	id := fmt.Sprintf("agent_%d", m.seq)
 	agent := &asyncSubAgent{
@@ -306,6 +322,11 @@ func (m *SubAgentManager) Start(req SpawnRequest) (string, error) {
 	}
 
 	go func() {
+		defer func() {
+			m.mu.Lock()
+			m.activeAsync--
+			m.mu.Unlock()
+		}()
 		res, err := m.spawner.Spawn(ctx, req)
 		stopReason := ""
 		if err == nil {


### PR DESCRIPTION
Four fixes from the sub-agent review — all cases where what the model is *told* diverges from what *happens*, plus unbounded parallelism.

## 1. Silent `max_turns` truncation
A sub-agent that hits its turn limit returns **partial** work with `StopReason: "max_turns"`, but both delivery paths dropped it: the **sync** `sub_agent` result returned only `res.Reply`, and the **async** completion notice (`formatSubAgentNote`) rendered `Result` without the stop reason. The parent treated truncated work as a finished answer. Both paths now append `[INCOMPLETE: hit its turn limit — partial]`.

## 2. Misleading fork description
The tool said fork "inherits your full conversation context" — but `Spawn` only copies the **system prompt** (harness identity + memory/skills/env), never the conversation messages (the design doc itself says "fresh History"). Reworded: fork inherits the system prompt and shares its cache; the task still needs all context in `prompt`.

## 3. Silent async downgrade
Synchronous transports (server / IM) force sync even when `run_in_background:true` was requested. The result now **says** it ran synchronously instead of silently ignoring the model's choice.

## 4. Unbounded async fan-out
`Start` spawned a goroutine per async sub-agent with no limit — a model firing many `run_in_background:true` calls could start an unbounded number of concurrent agent loops (each making API calls). New `maxConcurrentSubAgents` (8): spawns past it are rejected with a clear "wait for some to finish" error. Resumed `Send`/`Continue` rounds aren't bounded (limited by the live-child cap). `activeAsync` is tracked under the manager mutex, decremented when each spawn goroutine ends.

## Tests
Concurrency cap (reject past cap; slot frees on completion), sync + async `max_turns` flagging, forced-sync note. `-race` clean — the detector caught a real lock-scope bug in the cap's error path during development (reading `activeAsync` after unlocking), now fixed.

## Note / follow-up
`dev-docs/sub-agent-design.md` is substantially stale (predates the unified `sub_agent` tool — still documents `launch_agent`/`send_message`, and describes max-turns as a hard failure) and overlaps with `unified-agent-tool.md`. Left untouched here rather than half-patched; worth a consolidation pass like the terminal docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)