### PR TITLE
refactor(server): stop running IM channels in octo serve

### DIFF
--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -217,7 +217,6 @@ The server binds to localhost:8080 by default.
 Examples:
   octo serve                           Start on :8080
   octo serve --addr 127.0.0.1:3000     Bind to a specific address
-  octo serve --no-channel              Skip IM platform bridges
   octo serve --no-tools                Disable the agentic tool loop
 
 Common flags:
@@ -229,7 +228,6 @@ Common flags:
   --tools                  Enable agentic tool loop (default true)
   --no-tools               Disable agentic tool loop
   --cors <origins>         CORS allowed origins (comma-separated, * for any)
-  --no-channel             Disable IM channel startup
 
 Environment:
   ANTHROPIC_API_KEY        Required when --provider=anthropic

--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -24,7 +24,6 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	maxTokens := fs.Int("max-tokens", 0, "max_tokens for responses")
 	tools := fs.Bool("tools", true, "Enable agentic tool loop")
 	cors := fs.String("cors", "", "CORS allowed origins (comma-separated, * for any)")
-	noChannel := fs.Bool("no-channel", false, "Disable IM channel (DingTalk, Feishu)")
 	noMemory := fs.Bool("no-memory", false, "Disable cross-session memory injection")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -48,7 +47,6 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		MaxTokens:   *maxTokens,
 		Tools:       *tools,
 		CORSOrigins: corsOrigins,
-		NoChannel:   *noChannel,
 		NoMemory:    *noMemory,
 	}
 

--- a/internal/server/channels_handler.go
+++ b/internal/server/channels_handler.go
@@ -247,9 +247,11 @@ func platformToInfo(name string, pc channel.PlatformConfig) channelInfo {
 }
 
 // isAdapterRunning reports whether the platform adapter is currently active.
+// The HTTP server no longer runs IM adapters — that moved to the standalone
+// `octo channel start` command, which lives in a separate process the server
+// can't observe — so this always reports false.
 func (s *Server) isAdapterRunning(platform string) bool {
-	_, ok := s.runningAdapters.Load(platform)
-	return ok
+	return false
 }
 
 func maskSecret(s string) string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,10 +19,8 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/app"
-	"github.com/Leihb/octo-agent/internal/channel"
 	"github.com/Leihb/octo-agent/internal/config"
 	"github.com/Leihb/octo-agent/internal/memory"
-	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/prompt"
 	"github.com/Leihb/octo-agent/internal/scheduler"
 	"github.com/Leihb/octo-agent/internal/skills"
@@ -53,11 +51,6 @@ type Config struct {
 
 	// CORSOrigins lists allowed origins for CORS. Empty disables CORS.
 	CORSOrigins []string
-
-	// NoChannel disables IM channel (DingTalk, Feishu, etc.) startup.
-	// When false (default), channels are started from ~/.octo/channels.yml
-	// alongside the HTTP server.
-	NoChannel bool
 
 	// AccessKey is the shared secret used to authenticate Web UI and API
 	// requests. When empty, the server looks for OCTO_ACCESS_KEY env var.
@@ -130,13 +123,6 @@ type Server struct {
 
 	// scheduler for cron-based background tasks.
 	scheduler *scheduler.Scheduler
-
-	// channel manager for IM platform bridging (DingTalk, Feishu, etc.).
-	// nil when NoChannel is set or no channels are configured.
-	channelCfg      *channel.Config
-	channelMgr      *channel.Manager
-	channelCancel   context.CancelFunc
-	runningAdapters sync.Map // string -> channel.Adapter
 
 	// mcpCleanup unregisters + closes the MCP registry connected at start.
 	// Always non-nil after New (a no-op when no servers connected).
@@ -219,7 +205,6 @@ func New(cfg Config) (*Server, error) {
 		s.enableSubAgentTools()
 	}
 	s.enableMCP()
-	s.initChannels()
 
 	s.http = &http.Server{
 		Addr:         cfg.Addr,
@@ -288,14 +273,12 @@ func (s *Server) AccessKey() string {
 
 // ListenAndServe starts the HTTP server.
 func (s *Server) ListenAndServe() error {
-	s.startChannels()
 	return s.http.ListenAndServe()
 }
 
 // Shutdown gracefully shuts down the server, releasing the process-global
 // sub-agent + task registrations installed by enableSubAgentTools.
 func (s *Server) Shutdown(ctx context.Context) error {
-	s.stopChannels()
 	// Kill background processes started via web/IM sessions so they don't
 	// outlive the daemon — the same orphan-prevention the CLI/TUI do on exit.
 	// terminal background commands run through the process-global manager
@@ -767,148 +750,4 @@ func validateBindAddr(addr string) error {
 		return fmt.Errorf("bind address %q is not localhost: create %s to enable non-localhost binds", addr, permPath)
 	}
 	return nil
-}
-
-// ─── Channel (IM Bridge) ───────────────────────────────────────────────────
-
-// initChannels loads channel config and creates a manager when channels are
-// configured and not disabled via --no-channel.
-func (s *Server) initChannels() {
-	if s.cfg.NoChannel {
-		return
-	}
-	if s.sender == nil {
-		// Skip channel init when the server is in onboarding mode (no API key
-		// yet). Channels will be started on the next server restart after the
-		// user completes setup.
-		return
-	}
-	chCfg, err := channel.LoadConfig()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "octo serve: channel config: %v\n", err)
-		return
-	}
-	platforms := chCfg.EnabledPlatforms()
-	if len(platforms) == 0 {
-		return
-	}
-
-	// Build agent factory that mirrors the server's agent setup.
-	gate, _ := s.buildChannelGate()
-	var memInjection string
-	if s.memDir != "" {
-		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
-	}
-	factory := func() *agent.Agent {
-		a := agent.New(s.sender, s.model)
-		a.CWD = s.cwd
-		a.MaxTokens = s.cfg.MaxTokens
-		a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
-		if gate != nil {
-			a.Gate = gate
-		}
-		return a
-	}
-
-	s.channelCfg = chCfg
-	s.channelMgr = channel.NewManager(chCfg, factory, channel.BindByChatUser)
-
-	fmt.Fprintf(os.Stderr, "octo serve: channels enabled: %s\n", strings.Join(platforms, ", "))
-}
-
-// buildChannelGate creates a non-interactive permission gate for the IM bridge.
-func (s *Server) buildChannelGate() (agent.PermissionGate, error) {
-	engine, err := permission.New(permissionConfigPath(), s.cwd, resolvePermissionMode(), s.memDir, s.homeMemDir)
-	if err != nil {
-		return nil, fmt.Errorf("permission engine: %w", err)
-	}
-	return app.NewPermissionGate(engine, nil), nil
-}
-
-// startChannels launches all enabled channel adapters in background goroutines.
-func (s *Server) startChannels() {
-	if s.channelMgr == nil {
-		return
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	s.channelCancel = cancel
-
-	// For each enabled platform, create adapter and start it.
-	for _, name := range s.channelCfg.EnabledPlatforms() {
-		pc := s.channelCfg.Platform(name)
-		if pc == nil {
-			continue
-		}
-		ctor, err := channel.Find(name)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "octo serve: channel %s: %v\n", name, err)
-			continue
-		}
-		ad, err := ctor(pc)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "octo serve: channel %s adapter: %v\n", name, err)
-			continue
-		}
-		if errs := ad.ValidateConfig(pc); len(errs) > 0 {
-			for _, e := range errs {
-				fmt.Fprintf(os.Stderr, "octo serve: channel %s config: %s\n", name, e)
-			}
-			continue
-		}
-
-		s.runningAdapters.Store(name, ad)
-		go func(a channel.Adapter, platform string) {
-			_ = a.Start(ctx, func(ev channel.InboundEvent) {
-				ev.Platform = platform
-				s.handleChannelMessage(ctx, a, ev)
-			})
-		}(ad, name)
-	}
-}
-
-// handleChannelMessage runs an agent turn for a channel inbound event.
-func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, ev channel.InboundEvent) {
-	// Handle slash commands (e.g. /bind, /sessions) — only when the message
-	// starts with "/". Without this guard, plain text like "你好" is parsed
-	// as an unknown command and never reaches the agent.
-	text := strings.TrimSpace(ev.Text)
-	if strings.HasPrefix(text, "/") {
-		if reply := s.channelMgr.CommandRouter(ev); reply != "" {
-			ad.SendText(ev.ChatID, reply, ev.MessageID)
-			return
-		}
-	}
-
-	sess := s.channelMgr.GetOrCreateSession(ev)
-	if sess == nil {
-		return
-	}
-
-	ctrl := channel.NewUIController(ad, ev.ChatID, ev.MessageID)
-
-	var toolDefs []agent.ToolDefinition
-	var executor agent.ToolExecutor
-	if s.cfg.Tools {
-		executor = tools.NewDefaultRegistry()
-		toolDefs = tools.DefaultToolsFor(sess.Agent.Model)
-
-		spawner := app.NewSpawner(sess.Agent, executor, func() []agent.ToolDefinition {
-			return tools.DefaultToolsFor(sess.Agent.Model)
-		})
-		subMgr := tools.NewSubAgentManager(spawner)
-		subMgr.SetSynchronous(true)
-		ctx = tools.WithSubAgentManager(ctx, subMgr)
-		ctx = tools.WithTaskStore(ctx, sess.Tasks)
-		ctx = tools.WithBackgroundManager(ctx, tools.SessionBackgroundManager("im:"+string(sess.Key)))
-	}
-
-	_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, ev.Text)
-}
-
-// stopChannels shuts down all channel adapters.
-func (s *Server) stopChannels() {
-	if s.channelCancel != nil {
-		s.channelCancel()
-	}
-	s.runningAdapters = sync.Map{}
 }


### PR DESCRIPTION
## What

`octo serve` no longer starts IM channel adapters. That responsibility belongs solely to the standalone `octo channel start` command, keeping the HTTP server and the IM bridge as cleanly separated entry points.

## Changes

- **`internal/server/server.go`** — removed all channel-*running* code: `initChannels`, `startChannels`, `stopChannels`, `handleChannelMessage`, `buildChannelGate`, and the `channelCfg`/`channelMgr`/`channelCancel`/`runningAdapters` fields, plus the now-unreachable calls in `New()`/`ListenAndServe()`/`Shutdown()` and the unused `channel`/`permission` imports.
- **`internal/server/channels_handler.go`** — `isAdapterRunning` now returns `false` (the running channel lives in a separate process the server can't observe). The channels REST config API (list/get/save/delete) is untouched, so the Web UI can still configure `channels.yml`.
- **`cmd/octo/serve.go`** — removed the `--no-channel` flag and `Config.NoChannel` wiring (no longer meaningful).
- **`cmd/octo/help.go`** — removed the two `--no-channel` help lines.

## Behavior note

The Web UI's per-channel "running" indicator now always shows `false` — adapter state moved to the `octo channel start` process, which the server can't observe.

## Verification

- `go build ./...` — clean
- `go vet` + `gofmt -l` on edited files — clean
- `go test ./internal/server/ ./cmd/octo/` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)