### PR TITLE
feat(config): arrow-key menus for the setup wizard

### DIFF
--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -199,10 +199,17 @@ func apiKeyStatus(provider string, cfg config.Config) string {
 func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 	existing, _ := config.Load() // a malformed file is treated as empty here — the wizard overwrites it
 
+	// An arrow-key menu needs an editable terminal on both ends. When stdin is
+	// piped, the output isn't a TTY, or readline declines (Windows), fall back
+	// to the typed-answer flow so scripts and tests keep working unchanged.
+	tty := stdinIsTTY(stdin) && writerIsTTY(stdout)
+
 	var reader lineReader
-	if stdinIsTTY(stdin) {
+	if tty {
 		if rl, err := newReadlineReader(defaultHistoryFile()); err == nil {
 			reader = rl
+		} else {
+			tty = false
 		}
 	}
 	if reader == nil {
@@ -211,55 +218,136 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 	defer reader.Close()
 
 	fmt.Fprintln(stdout, "octo config — set your default provider and model (~/.octo/config.yaml).")
-	fmt.Fprintln(stdout, "Press Enter to keep the shown default. CLI flags and env vars still override per run.")
+	if tty {
+		fmt.Fprintln(stdout, "Use ↑/↓ to choose, Enter to confirm. CLI flags and env vars still override per run.")
+	} else {
+		fmt.Fprintln(stdout, "Press Enter to keep the shown default. CLI flags and env vars still override per run.")
+	}
 	fmt.Fprintln(stdout)
 
-	provider := promptDefault(reader, stdout, "Provider (anthropic | openai | kimi | deepseek | ...)", firstNonEmpty(existing.Provider, app.ProviderAnthropic))
-	provider = strings.ToLower(strings.TrimSpace(provider))
-	if !app.IsKnownVendor(provider) {
-		fmt.Fprintf(stderr, "octo config: unknown provider %q\n", provider)
-		return 2
+	// Provider.
+	var provider string
+	if tty {
+		items := make([]selectItem, len(app.Registry))
+		for i, v := range app.Registry {
+			items[i] = selectItem{label: v.DisplayName, desc: v.ID, value: v.ID}
+		}
+		choice, ok := runSelect(stdin, stdout, "Provider", items, firstNonEmpty(existing.Provider, app.ProviderAnthropic))
+		if !ok {
+			return cancelWizard(stderr)
+		}
+		provider = choice.value
+		fmt.Fprintf(stdout, "Provider: %s (%s)\n\n", app.VendorDisplayName(provider), provider)
+	} else {
+		provider = strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
+			"Provider (anthropic | openai | kimi | deepseek | ...)", firstNonEmpty(existing.Provider, app.ProviderAnthropic))))
+		if !app.IsKnownVendor(provider) {
+			fmt.Fprintf(stderr, "octo config: unknown provider %q\n", provider)
+			return 2
+		}
 	}
 
-	modelDefault := firstNonEmpty(existing.Model, defaultModels[provider])
-	model := strings.TrimSpace(promptDefault(reader, stdout, "Model", modelDefault))
+	// Model.
+	var model string
+	if tty {
+		def := defaultModels[provider]
+		startVal := def
+		if existing.Provider == provider && existing.Model != "" {
+			startVal = existing.Model
+		}
+		items := buildModelItems(app.VendorModels(provider), def, startVal)
+		items = append(items, selectItem{label: "Custom model…", desc: "enter a model id", value: customSentinel})
+		choice, ok := runSelect(stdin, stdout, "Model", items, startVal)
+		if !ok {
+			return cancelWizard(stderr)
+		}
+		if choice.value == customSentinel {
+			model = strings.TrimSpace(promptDefault(reader, stdout, "Model", startVal))
+		} else {
+			model = choice.value
+		}
+		shown := model
+		if shown == "" || shown == def {
+			shown = def + " (default)"
+		}
+		fmt.Fprintf(stdout, "Model: %s\n\n", shown)
+	} else {
+		model = strings.TrimSpace(promptDefault(reader, stdout, "Model", firstNonEmpty(existing.Model, defaultModels[provider])))
+	}
 	// Accepting the provider's built-in default leaves Model unset so it floats
 	// with future releases (and never contaminates a different --provider).
 	if model == defaultModels[provider] {
 		model = ""
 	}
 
-	baseURL := strings.TrimSpace(promptDefault(reader, stdout, "Custom base URL (optional, for DeepSeek/Kimi/etc.)", existing.BaseURL))
+	// Base URL / endpoint. Vendors with regional variants get a menu; everyone
+	// else is offered a free-text custom URL.
+	baseURL := existing.BaseURL
+	variants := app.VendorEndpointVariants(provider)
+	if tty && len(variants) > 0 {
+		items := []selectItem{{label: "Default endpoint", desc: app.DefaultBaseURL(provider), value: ""}}
+		for _, v := range variants {
+			items = append(items, selectItem{label: v.Label, desc: v.BaseURL, value: v.BaseURL})
+		}
+		items = append(items, selectItem{label: "Custom base URL…", desc: "enter a URL", value: customSentinel})
+		choice, ok := runSelect(stdin, stdout, "Endpoint", items, existing.BaseURL)
+		if !ok {
+			return cancelWizard(stderr)
+		}
+		if choice.value == customSentinel {
+			baseURL = strings.TrimSpace(promptDefault(reader, stdout, "Custom base URL", existing.BaseURL))
+		} else {
+			baseURL = choice.value
+		}
+		if baseURL == "" {
+			fmt.Fprintf(stdout, "Endpoint: default\n\n")
+		} else {
+			fmt.Fprintf(stdout, "Endpoint: %s\n\n", baseURL)
+		}
+	} else {
+		baseURL = strings.TrimSpace(promptDefault(reader, stdout, "Custom base URL (optional, for DeepSeek/Kimi/etc.)", existing.BaseURL))
+	}
 
 	out := config.Config{Provider: provider, Model: model, BaseURL: baseURL, APIKey: existing.APIKey}
 
 	// Co-authored-by: default on; ask once in wizard.
-	coauthorDefault := "y"
-	if existing.Coauthor != nil && !*existing.Coauthor {
-		coauthorDefault = "n"
+	coauthorDefault := existing.Coauthor == nil || *existing.Coauthor
+	coauthorVal, ok := pickYesNo(tty, reader, stdin, stdout,
+		"Append Co-authored-by to git commits?", coauthorDefault)
+	if !ok {
+		return cancelWizard(stderr)
 	}
-	coauthorAns := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
-		"Append Co-authored-by to git commits? (Y/n)", coauthorDefault)))
-	coauthorVal := coauthorAns != "n" && coauthorAns != "no"
 	out.Coauthor = &coauthorVal
 
-	// Reasoning effort: empty (off) by default; offer the existing value.
-	effortAns := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
-		"Reasoning effort (low | medium | high, empty = off)", existing.ReasoningEffort)))
-	if !validReasoningEffort(effortAns) {
-		fmt.Fprintf(stderr, "octo config: invalid reasoning effort %q (use 'low', 'medium', 'high', or empty)\n", effortAns)
-		return 2
+	// Reasoning effort: off (empty) by default; offer the existing value.
+	if tty {
+		choice, ok := runSelect(stdin, stdout, "Reasoning effort", []selectItem{
+			{label: "Off", value: ""},
+			{label: "Low", value: "low"},
+			{label: "Medium", value: "medium"},
+			{label: "High", value: "high"},
+		}, existing.ReasoningEffort)
+		if !ok {
+			return cancelWizard(stderr)
+		}
+		out.ReasoningEffort = choice.value
+	} else {
+		effortAns := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
+			"Reasoning effort (low | medium | high, empty = off)", existing.ReasoningEffort)))
+		if !validReasoningEffort(effortAns) {
+			fmt.Fprintf(stderr, "octo config: invalid reasoning effort %q (use 'low', 'medium', 'high', or empty)\n", effortAns)
+			return 2
+		}
+		out.ReasoningEffort = effortAns
 	}
-	out.ReasoningEffort = effortAns
 
 	// Show the reasoning/thinking trace: default on.
-	showDefault := "y"
-	if existing.ShowReasoning != nil && !*existing.ShowReasoning {
-		showDefault = "n"
+	showDefault := existing.ShowReasoning == nil || *existing.ShowReasoning
+	showVal, ok := pickYesNo(tty, reader, stdin, stdout,
+		"Show the reasoning/thinking trace while streaming?", showDefault)
+	if !ok {
+		return cancelWizard(stderr)
 	}
-	showAns := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
-		"Show the reasoning/thinking trace while streaming? (Y/n)", showDefault)))
-	showVal := showAns != "n" && showAns != "no"
 	out.ShowReasoning = &showVal
 
 	// API key: env is the recommended home for it. Offer to store it only if
@@ -298,6 +386,59 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stdout, "Run `octo chat` to start.")
 	}
 	return 0
+}
+
+// customSentinel is the menu value standing in for "let me type my own". It
+// uses a NUL byte so it can never collide with a real model id or URL.
+const customSentinel = "\x00custom"
+
+// cancelWizard reports the wizard was aborted (Esc/Ctrl-C at a menu) and
+// returns the process exit code for that.
+func cancelWizard(stderr io.Writer) int {
+	fmt.Fprintln(stderr, "octo config: cancelled, nothing saved.")
+	return 1
+}
+
+// buildModelItems turns a vendor's model catalogue into menu rows, marking the
+// built-in default and folding in the user's current pick when it isn't part
+// of the catalogue (so re-running the wizard shows it pre-selected).
+func buildModelItems(models []string, def, current string) []selectItem {
+	items := make([]selectItem, 0, len(models)+1)
+	seen := make(map[string]bool, len(models))
+	for _, m := range models {
+		seen[m] = true
+		desc := ""
+		if m == def {
+			desc = "default"
+		}
+		items = append(items, selectItem{label: m, desc: desc, value: m})
+	}
+	if current != "" && current != def && !seen[current] {
+		items = append(items, selectItem{label: current, desc: "current", value: current})
+	}
+	return items
+}
+
+// pickYesNo asks a boolean question: an arrow-key Yes/No menu on a TTY, the
+// typed "(Y/n)" prompt otherwise. ok is false only when a TTY menu is
+// cancelled.
+func pickYesNo(tty bool, reader lineReader, stdin io.Reader, stdout io.Writer, prompt string, def bool) (val, ok bool) {
+	defVal := "n"
+	if def {
+		defVal = "y"
+	}
+	if tty {
+		choice, ok := runSelect(stdin, stdout, prompt, []selectItem{
+			{label: "Yes", value: "y"},
+			{label: "No", value: "n"},
+		}, defVal)
+		if !ok {
+			return false, false
+		}
+		return choice.value == "y", true
+	}
+	ans := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout, prompt+" (Y/n)", defVal)))
+	return ans != "n" && ans != "no", true
 }
 
 // promptDefault asks one question, showing def as the value used on empty input.

--- a/cmd/octo/configselect.go
+++ b/cmd/octo/configselect.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"io"
+
+	"github.com/Leihb/octo-agent/internal/tui"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// selectItem is one row in an arrow-key selection menu. label is the primary
+// text, desc the dimmed annotation shown after it (e.g. "default", a base URL,
+// a vendor id), and value the string returned when the row is chosen.
+type selectItem struct {
+	label string
+	desc  string
+	value string
+}
+
+var (
+	selectCursorStyle = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	selectLabelStyle  = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	selectDescStyle   = lipgloss.NewStyle().Foreground(tui.ColMuted)
+	selectPromptStyle = lipgloss.NewStyle().Bold(true)
+)
+
+// selectModel is a minimal single-select list: arrow keys (or j/k) move the
+// cursor, Enter chooses, Esc/Ctrl-C cancels. It renders inline (no alt-screen)
+// and clears itself on exit so the wizard can print a one-line confirmation.
+type selectModel struct {
+	prompt    string
+	items     []selectItem
+	cursor    int
+	chosen    bool
+	cancelled bool
+}
+
+func (m selectModel) Init() tea.Cmd { return nil }
+
+func (m selectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch {
+	case key.Matches(km, selectKeys.up):
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case key.Matches(km, selectKeys.down):
+		if m.cursor < len(m.items)-1 {
+			m.cursor++
+		}
+	case key.Matches(km, selectKeys.choose):
+		m.chosen = true
+		return m, tea.Quit
+	case key.Matches(km, selectKeys.cancel):
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m selectModel) View() string {
+	// Once the user has acted, render nothing — the menu disappears and the
+	// wizard prints the resolved choice in its place.
+	if m.chosen || m.cancelled {
+		return ""
+	}
+	var b []byte
+	b = append(b, selectPromptStyle.Render(m.prompt)...)
+	b = append(b, '\n')
+	for i, it := range m.items {
+		cursor := "  "
+		label := it.label
+		if i == m.cursor {
+			cursor = selectCursorStyle.Render("❯ ")
+			label = selectLabelStyle.Render(label)
+		}
+		b = append(b, "  "...)
+		b = append(b, cursor...)
+		b = append(b, label...)
+		if it.desc != "" {
+			b = append(b, "  "...)
+			b = append(b, selectDescStyle.Render(it.desc)...)
+		}
+		b = append(b, '\n')
+	}
+	b = append(b, selectDescStyle.Render("  ↑/↓ move · Enter select · Esc cancel")...)
+	b = append(b, '\n')
+	return string(b)
+}
+
+type selectKeyMap struct {
+	up     key.Binding
+	down   key.Binding
+	choose key.Binding
+	cancel key.Binding
+}
+
+var selectKeys = selectKeyMap{
+	up:     key.NewBinding(key.WithKeys("up", "k")),
+	down:   key.NewBinding(key.WithKeys("down", "j")),
+	choose: key.NewBinding(key.WithKeys("enter")),
+	cancel: key.NewBinding(key.WithKeys("esc", "ctrl+c")),
+}
+
+// runSelect shows an arrow-key menu over items and returns the chosen item.
+// The cursor starts on the row whose value equals defaultValue (else the
+// first). ok is false if the user cancelled (Esc/Ctrl-C) or the program
+// errored — callers treat that as "abort the wizard".
+func runSelect(in io.Reader, out io.Writer, prompt string, items []selectItem, defaultValue string) (selectItem, bool) {
+	start := 0
+	for i, it := range items {
+		if it.value == defaultValue {
+			start = i
+			break
+		}
+	}
+	m := selectModel{prompt: prompt, items: items, cursor: start}
+	final, err := tea.NewProgram(m, tea.WithInput(in), tea.WithOutput(out)).Run()
+	if err != nil {
+		return selectItem{}, false
+	}
+	res := final.(selectModel)
+	if !res.chosen || res.cancelled {
+		return selectItem{}, false
+	}
+	return res.items[res.cursor], true
+}

--- a/cmd/octo/configselect_test.go
+++ b/cmd/octo/configselect_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func keyMsg(s string) tea.KeyMsg {
+	switch s {
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}
+
+// step feeds one key and returns the updated concrete model.
+func step(m selectModel, k string) selectModel {
+	next, _ := m.Update(keyMsg(k))
+	return next.(selectModel)
+}
+
+func TestSelectModel_Navigation(t *testing.T) {
+	items := []selectItem{{value: "a"}, {value: "b"}, {value: "c"}}
+	m := selectModel{items: items, cursor: 0}
+
+	// Down moves the cursor; clamps at the last row.
+	m = step(m, "down")
+	m = step(m, "down")
+	m = step(m, "down") // clamp
+	if m.cursor != 2 {
+		t.Fatalf("cursor = %d, want 2 (clamped at last)", m.cursor)
+	}
+	// j/k aliases work too.
+	m = step(m, "k")
+	if m.cursor != 1 {
+		t.Fatalf("k should move up; cursor = %d, want 1", m.cursor)
+	}
+	// Up clamps at the first row.
+	m = step(m, "up")
+	m = step(m, "up")
+	if m.cursor != 0 {
+		t.Fatalf("cursor = %d, want 0 (clamped at first)", m.cursor)
+	}
+}
+
+func TestSelectModel_ChooseAndCancel(t *testing.T) {
+	items := []selectItem{{value: "a"}, {value: "b"}}
+
+	chosen := step(selectModel{items: items, cursor: 1}, "enter")
+	if !chosen.chosen || chosen.cancelled {
+		t.Fatalf("enter should choose; got chosen=%v cancelled=%v", chosen.chosen, chosen.cancelled)
+	}
+	if chosen.View() != "" {
+		t.Error("View should be empty once chosen so the menu clears")
+	}
+
+	cancelled := step(selectModel{items: items}, "esc")
+	if cancelled.chosen || !cancelled.cancelled {
+		t.Fatalf("esc should cancel; got chosen=%v cancelled=%v", cancelled.chosen, cancelled.cancelled)
+	}
+}
+
+func TestBuildModelItems(t *testing.T) {
+	models := []string{"m-small", "m-big"}
+
+	// Default model is annotated; current pick already in the catalogue adds no row.
+	items := buildModelItems(models, "m-small", "m-big")
+	if len(items) != 2 {
+		t.Fatalf("len = %d, want 2", len(items))
+	}
+	if items[0].desc != "default" {
+		t.Errorf("m-small should be marked default, got %q", items[0].desc)
+	}
+
+	// A current pick outside the catalogue is appended so it can be pre-selected.
+	items = buildModelItems(models, "m-small", "m-custom")
+	if len(items) != 3 || items[2].value != "m-custom" || items[2].desc != "current" {
+		t.Fatalf("custom current model not folded in: %+v", items)
+	}
+}

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -216,6 +216,24 @@ func VendorDefaultModel(id string) string {
 	return ""
 }
 
+// VendorModels returns the catalogue of model IDs offered for a vendor (for a
+// UI dropdown), or nil if the vendor is unknown.
+func VendorModels(id string) []string {
+	if v := vendorByID(id); v != nil {
+		return v.Models
+	}
+	return nil
+}
+
+// VendorEndpointVariants returns the regional endpoint alternatives for a
+// vendor, or nil if it has none / is unknown.
+func VendorEndpointVariants(id string) []EndpointVariant {
+	if v := vendorByID(id); v != nil {
+		return v.EndpointVariants
+	}
+	return nil
+}
+
 // VendorAPIKeyEnvVar returns the environment-variable name for a vendor's API key.
 func VendorAPIKeyEnvVar(id string) string {
 	if v := vendorByID(id); v != nil {


### PR DESCRIPTION
## What

`octo config` 的交互改造:在真实终端里把"盲输入"换成**方向键选项菜单**,对齐 web onboarding 的下拉体验。用户反馈选模型时旧的补全提示省略了太多、又必须精确敲对字符串。

## 改动

**新增** `cmd/octo/configselect.go` — 基于已有 bubbletea 依赖的轻量单选菜单(`↑/↓` 或 `j/k` 移动、`Enter` 确认、`Esc`/`Ctrl-C` 取消)。选完自动清屏,wizard 在原位打印一行确认,保持终端整洁。

**wizard** (`cmd/octo/config.go`):
- **Provider** — 列出 registry 全部厂商(显示名 + id),不再是省略一堆的 `anthropic | openai | kimi | ...` 提示文字。
- **Model** — 列出该厂商全部 model 并标注 `default`;当前配置的 model 若不在目录里会附加 `current` 行并预选;末尾 `Custom model…` 走自由输入。
- **Endpoint** — 对有区域变体的厂商(kimi/glm/minimax 等)给 `Default / Mainland China / International / Custom…` 菜单,替代手输 URL。
- **Reasoning effort** — `Off / Low / Medium / High` 菜单(旧流程敲错单词直接 exit 2)。
- **Co-authored-by / Show trace** — `Yes/No` 菜单。
- API key 仍走文本输入(敏感值)。

**registry** (`internal/app/provider.go`) — 新增 `VendorModels` / `VendorEndpointVariants` 访问器。

## 兼容性

菜单仅在 stdin+stdout 均为 TTY 时启用。管道输入、非 TTY、Windows(readline 不可用)自动回落到原"敲答案"流程——脚本和现有测试零改动。

## 验证

- `go test ./cmd/octo/ ./internal/app/` 通过,`go vet` 干净,`gofmt` 干净。
- 新增 `configselect_test.go`:菜单导航/确认/取消、`buildModelItems` 逻辑。
- 实测非 TTY 管道流程,prompt 序列与改动前完全一致。

TTY 下真实箭头交互需在终端手动验收。

🤖 Generated with [Claude Code](https://claude.com/claude-code)