### PR TITLE
feat(tools): Windows rm→trash parity + document Windows limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ octo chat --sandbox --sandbox-write ./build      # extra writable dir (repeatabl
 octo chat --sandbox --sandbox-read /opt/data     # extra readable dir (repeatable)
 ```
 
+## Platform notes
+
+octo runs on Linux, macOS, and Windows. A few behaviors differ on Windows:
+
+- **Shell is PowerShell.** The `terminal` tool runs commands through PowerShell (`pwsh`, else Windows PowerShell 5.1), not POSIX `sh` — use PowerShell syntax (`Get-ChildItem`, `Select-String`, `Remove-Item`, `$env:VAR`) and chain with `;` (5.1 has no `&&`). The agent is told this, and the built-in `read_file` / `glob` / `grep` / `write_file` / `edit_file` tools are cross-platform and don't shell out, so prefer them.
+- **Deletes go to the trash, like POSIX.** Agent-issued `Remove-Item` / `rm` / `del` are intercepted and the targets copied to `~/.octo/trash/` before deletion, so they're recoverable from the Web UI trash panel — the same protection as the POSIX `rm` wrapper. Best-effort: literal and globbed filesystem paths are backed up; provider paths (`Env:`, registry), pipeline input, and anything that fails to copy fall through to a normal delete.
+- **`--sandbox` is unavailable on Windows.** OS confinement is macOS Seatbelt / Linux Landlock only; on Windows `--sandbox` fails closed (refuses to run). The permission engine (interactive prompts) is the safety layer there.
+- **`terminal_input`** (writing to a background process's stdin) is reliable only on POSIX shells; PowerShell's `-Command` mode doesn't deterministically forward stdin to a spawned process.
+
 ## What's implemented
 
 | Area | Status | Description |

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -43,6 +43,11 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		// Internal: the OS-sandbox re-exec shim (Linux). Applies confinement to
 		// itself, then execs the real command. Not user-facing.
 		return sandbox.ShimMain()
+	case "__trash-backup":
+		// Internal: the Windows safe-delete wrapper calls this to copy paths
+		// into the trash before the real Remove-Item deletes them. Not
+		// user-facing.
+		return runTrashBackup(args[1:])
 	case "version", "--version", "-v":
 		fmt.Fprintf(stdout, "octo %s\n", version.String())
 		return 0

--- a/cmd/octo/trashbackup.go
+++ b/cmd/octo/trashbackup.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+
+	"github.com/Leihb/octo-agent/internal/trash"
+)
+
+// runTrashBackup copies the given paths into the trash WITHOUT deleting them —
+// the Windows safe-delete wrapper (see internal/tools/sandbox.go) calls
+// `octo __trash-backup -- <path>...` before the real Remove-Item, so an
+// agent-issued delete is recoverable, matching the POSIX rm-to-trash wrapper.
+//
+// Best-effort by design: per-path failures (a provider path like Env:\X, a
+// permission error, a path that isn't a real file) are ignored, and it always
+// exits 0 so it can never block the delete the user/model actually asked for.
+// The project root comes from OCTO_TRASH_PROJECT (set by the wrapper), falling
+// back to the working directory.
+func runTrashBackup(paths []string) int {
+	project := os.Getenv("OCTO_TRASH_PROJECT")
+	if project == "" {
+		project, _ = os.Getwd()
+	}
+	for _, p := range paths {
+		if p == "" || p == "--" {
+			continue
+		}
+		_ = trash.Backup(p, project)
+	}
+	return 0
+}

--- a/cmd/octo/trashbackup_test.go
+++ b/cmd/octo/trashbackup_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunTrashBackup backs the given paths up to the trash (project from
+// OCTO_TRASH_PROJECT), leaves the originals in place, and always returns 0.
+func TestRunTrashBackup(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	project := t.TempDir()
+	t.Setenv("OCTO_TRASH_PROJECT", project)
+	f := filepath.Join(project, "keep.txt")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// "--" and a bogus path are tolerated; the real path is backed up.
+	if code := runTrashBackup([]string{"--", filepath.Join(project, "ghost"), f}); code != 0 {
+		t.Errorf("runTrashBackup must always exit 0, got %d", code)
+	}
+	if _, err := os.Stat(f); err != nil {
+		t.Errorf("backup must NOT delete the original: %v", err)
+	}
+	// The trash project dir should hold a .meta.json for the backed-up file.
+	trashProj := filepath.Join(home, ".octo", "trash")
+	var found bool
+	_ = filepath.Walk(trashProj, func(p string, _ os.FileInfo, _ error) error {
+		if strings.HasSuffix(p, ".meta.json") {
+			found = true
+		}
+		return nil
+	})
+	if !found {
+		t.Error("expected a .meta.json in the trash after backup")
+	}
+}

--- a/dev-docs/terminal-tools.md
+++ b/dev-docs/terminal-tools.md
@@ -165,9 +165,14 @@ processes run at once, but the agent loop still takes one turn at a time.
 ## Cross-platform shell
 
 `shellInvocation` / `shellCommand` select the shell once: `sh -c` on
-macOS/Linux (with the safe-rm trash wrapper when a project dir is known),
-PowerShell (`pwsh`, else `powershell`) on Windows. Process-group and detach
-options are platform-specific (`internal/tools/terminal_kill.go` for POSIX,
-`terminal_kill_windows.go` for Windows). `terminal_input`'s stdin delivery is
-reliable only on POSIX — PowerShell's `-Command` mode does not deterministically
-forward redirected stdin to a spawned native process.
+macOS/Linux, PowerShell (`pwsh`, else `powershell`) on Windows. Both wrap
+deletes to the trash when a project dir is known, so an agent-issued delete is
+recoverable: POSIX prepends an `rm()` shell function (`safeRmWrapper`); Windows
+shadows `Remove-Item` (and its aliases `rm`/`del`) with a function that calls
+`octo __trash-backup` to copy the targets in first (`windowsSafeRmWrapper`).
+Both are best-effort and copy-then-delete, so the real delete still runs.
+Process-group and detach options are platform-specific
+(`internal/tools/terminal_kill.go` for POSIX, `terminal_kill_windows.go` for
+Windows). `terminal_input`'s stdin delivery is reliable only on POSIX —
+PowerShell's `-Command` mode does not deterministically forward redirected
+stdin to a spawned native process.

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/Leihb/octo-agent/internal/sandbox"
@@ -61,6 +62,29 @@ rm() { __octo_safe_rm "$@"; command rm "$@"; }
 %s
 `
 
+// windowsSafeRmWrapper is the PowerShell counterpart of safeRmWrapper. It
+// shadows Remove-Item (and therefore its aliases rm / del / ri / rd / erase,
+// which resolve to the cmdlet name and so hit this function — functions take
+// precedence over cmdlets) with one that first copies any existing filesystem
+// paths in the arguments into the trash (via `octo __trash-backup`), then calls
+// the real cmdlet to perform the delete. Best-effort, mirroring the POSIX rm
+// wrapper: only literal/globbed filesystem paths are backed up; provider paths
+// (Env:, Registry), pipeline input, and any backup failure fall straight
+// through to the real delete unchanged. The module-qualified cmdlet name avoids
+// recursing into this function. First %s is the octo binary, second is the
+// user command.
+const windowsSafeRmWrapper = `function Remove-Item {
+  foreach ($a in $args) {
+    if (($a -is [string]) -and (-not $a.StartsWith('-'))) {
+      foreach ($rp in (Microsoft.PowerShell.Management\Resolve-Path -Path $a -ErrorAction SilentlyContinue)) {
+        if ($rp.Provider.Name -eq 'FileSystem') { & '%s' __trash-backup -- $rp.Path 2>$null }
+      }
+    }
+  }
+  Microsoft.PowerShell.Management\Remove-Item @args
+}
+%s`
+
 // shellCommand builds the *exec.Cmd that runs `command` via the shell, wrapped
 // in the active sandbox when one is set. Both TerminalTool and the background
 // manager route through here so confinement is uniform.
@@ -79,7 +103,21 @@ func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 	if runtime.GOOS == "windows" {
 		// -NoProfile: reproducible env (don't run the user's $PROFILE).
 		// -NonInteractive: never block on a PowerShell prompt mid-command.
-		cmd = exec.CommandContext(ctx, resolvePowerShell(), "-NoProfile", "-NonInteractive", "-Command", command)
+		ps := resolvePowerShell()
+		projectDir := WorkingDir(ctx)
+		if projectDir == "" {
+			projectDir, _ = os.Getwd()
+		}
+		// Wrap Remove-Item to copy to trash first (parity with the POSIX rm
+		// wrapper), but only when we can locate the octo binary and a project
+		// dir; otherwise run the command bare (no protection, but never broken).
+		if exe, err := os.Executable(); err == nil && projectDir != "" {
+			wrapped := fmt.Sprintf(windowsSafeRmWrapper, strings.ReplaceAll(exe, "'", "''"), command)
+			cmd = exec.CommandContext(ctx, ps, "-NoProfile", "-NonInteractive", "-Command", wrapped)
+			cmd.Env = append(os.Environ(), "OCTO_TRASH_PROJECT="+projectDir)
+		} else {
+			cmd = exec.CommandContext(ctx, ps, "-NoProfile", "-NonInteractive", "-Command", command)
+		}
 	} else {
 		projectDir := WorkingDir(ctx)
 		if projectDir == "" {

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -17,9 +17,10 @@ func TestShellCommand_PlatformShell(t *testing.T) {
 	}
 	args := cmd.Args
 	if runtime.GOOS == "windows" {
-		// pwsh/powershell ... -Command "echo hi"
-		if len(args) < 2 || args[len(args)-2] != "-Command" || args[len(args)-1] != "echo hi" {
-			t.Errorf("windows shell should end with -Command \"echo hi\", got %v", args)
+		// pwsh/powershell ... -Command "<safe-rm wrapper>\n echo hi" — the
+		// command is embedded at the end of the Remove-Item trash wrapper.
+		if len(args) < 2 || args[len(args)-2] != "-Command" || !strings.Contains(args[len(args)-1], "echo hi") {
+			t.Errorf("windows shell should end with -Command containing \"echo hi\", got %v", args)
 		}
 		base := strings.ToLower(filepath.Base(args[0]))
 		if !strings.Contains(base, "pwsh") && !strings.Contains(base, "powershell") {

--- a/internal/tools/sandbox_windows_test.go
+++ b/internal/tools/sandbox_windows_test.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestShellCommand_WindowsWrapsRemoveItem verifies the Windows branch injects
+// the Remove-Item → trash wrapper and sets the project env, so agent-issued
+// deletes are recoverable (parity with the POSIX rm wrapper).
+func TestShellCommand_WindowsWrapsRemoveItem(t *testing.T) {
+	cmd, err := shellCommand(context.Background(), "Remove-Item foo")
+	if err != nil {
+		t.Fatalf("shellCommand: %v", err)
+	}
+	joined := strings.Join(cmd.Args, "\n")
+	if !strings.Contains(joined, "function Remove-Item") {
+		t.Errorf("windows shellCommand should inject the Remove-Item trash wrapper; args=%v", cmd.Args)
+	}
+	if !strings.Contains(joined, "__trash-backup") {
+		t.Errorf("wrapper should call `octo __trash-backup`; args=%v", cmd.Args)
+	}
+	var hasProj bool
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "OCTO_TRASH_PROJECT=") {
+			hasProj = true
+		}
+	}
+	if !hasProj {
+		t.Error("OCTO_TRASH_PROJECT should be set for the trash wrapper")
+	}
+}

--- a/internal/trash/trash.go
+++ b/internal/trash/trash.go
@@ -43,11 +43,13 @@ func ProjectDir(projectDir string) string {
 	return filepath.Join(Dir(), hashProject(projectDir))
 }
 
-// Move moves a file or directory to the trash, preserving its original path for
-// later restoration. It creates the project subdirectory under the trash root,
-// copies the item there, and writes a .meta.json sidecar. On success the
-// original is removed.
-func Move(originalPath, projectDir string) error {
+// Backup copies a file or directory into the trash with a .meta.json sidecar,
+// preserving its original path for later restoration, WITHOUT removing the
+// original. It's the copy-only half of Move: the Windows safe-delete wrapper
+// uses it to make a delete recoverable while letting the real Remove-Item
+// perform the delete (mirroring the POSIX rm wrapper — copy to trash, then
+// delete).
+func Backup(originalPath, projectDir string) error {
 	fi, err := os.Stat(originalPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -95,12 +97,17 @@ func Move(originalPath, projectDir string) error {
 		}
 		return err
 	}
+	return nil
+}
 
-	// Remove original.
-	if fi.IsDir() {
-		return os.RemoveAll(originalPath)
+// Move backs a file or directory up to the trash and then removes the original.
+// On success the original is gone but recoverable from the trash.
+func Move(originalPath, projectDir string) error {
+	if err := Backup(originalPath, projectDir); err != nil {
+		return err
 	}
-	return os.Remove(originalPath)
+	// os.RemoveAll handles both files and directories.
+	return os.RemoveAll(originalPath)
 }
 
 // Restore moves a trashed file back to its original location.

--- a/internal/trash/trash_test.go
+++ b/internal/trash/trash_test.go
@@ -1,0 +1,79 @@
+package trash
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// isolateHome points the trash root (os.UserHomeDir) at a temp dir so tests
+// don't touch the real ~/.octo/trash.
+func isolateHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)        // macOS/Linux
+	t.Setenv("USERPROFILE", home) // Windows
+}
+
+func metaCount(t *testing.T, project string) int {
+	t.Helper()
+	entries, _ := os.ReadDir(ProjectDir(project))
+	n := 0
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".meta.json") {
+			n++
+		}
+	}
+	return n
+}
+
+// TestBackup copies the file into the trash with a sidecar but leaves the
+// original in place (the copy-only half used by the Windows delete wrapper).
+func TestBackup(t *testing.T) {
+	isolateHome(t)
+	project := t.TempDir()
+	f := filepath.Join(project, "doomed.txt")
+	if err := os.WriteFile(f, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Backup(f, project); err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+	if _, err := os.Stat(f); err != nil {
+		t.Errorf("Backup must NOT remove the original, but it's gone: %v", err)
+	}
+	if got := metaCount(t, project); got != 1 {
+		t.Errorf("expected 1 trashed entry with meta, got %d", got)
+	}
+}
+
+// TestMove backs up AND removes the original.
+func TestMove(t *testing.T) {
+	isolateHome(t)
+	project := t.TempDir()
+	f := filepath.Join(project, "doomed.txt")
+	if err := os.WriteFile(f, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Move(f, project); err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	if _, err := os.Stat(f); !os.IsNotExist(err) {
+		t.Errorf("Move must remove the original, but it still exists (err=%v)", err)
+	}
+	if got := metaCount(t, project); got != 1 {
+		t.Errorf("expected 1 trashed entry with meta, got %d", got)
+	}
+}
+
+// TestBackup_MissingFile errors (and so the Windows wrapper ignores it).
+func TestBackup_MissingFile(t *testing.T) {
+	isolateHome(t)
+	project := t.TempDir()
+	if err := Backup(filepath.Join(project, "nope"), project); err == nil {
+		t.Error("Backup of a missing path should error")
+	}
+}


### PR DESCRIPTION
Addresses the two usability items from the Windows review: **#1** the safety asymmetry (deletes recoverable on POSIX, permanent on Windows) and **#2** undocumented Windows limitations.

## #1 — Windows deletes now go to the trash

On POSIX, `shellCommand` prepends an `rm()` shell function that copies targets to `~/.octo/trash/` before the real `rm`. Windows had **no equivalent** — `Remove-Item` / `rm` / `del` deleted permanently. Combined with `--sandbox` being unavailable on Windows, the permission prompt was the *only* guard, and one wrong "allow" was unrecoverable.

Mirror the POSIX wrapper:
- **`trash.Backup`** — the copy-only half of `trash.Move` (copy + `.meta.json`, no remove). `Move` is now `Backup` + `os.RemoveAll`. Identical on-disk format, so Windows-trashed entries show up in the Web UI trash panel.
- **`octo __trash-backup`** — hidden subcommand that `trash.Backup`s each path (project from `OCTO_TRASH_PROJECT`, else cwd). Best-effort; **always exits 0** so it can never block the real delete.
- **`windowsSafeRmWrapper`** — a PowerShell prelude that shadows `Remove-Item` (the aliases `rm`/`del`/`ri`/`rd`/`erase` resolve to the cmdlet name → the function, which takes precedence) with one that `Resolve-Path`s each filesystem arg, copies it in via `octo __trash-backup`, then runs the **module-qualified** real cmdlet (no recursion). Best-effort like POSIX: provider paths (`Env:`, registry), pipeline input, and copy failures fall straight through to a plain delete. `shellCommand` injects it when the octo binary + a project dir are known, setting `OCTO_TRASH_PROJECT`.

## #2 — Documented Windows limitations

README gains a **Platform notes** section: PowerShell shell (`;` not `&&`, prefer the cross-platform built-in tools), deletes-to-trash now works on Windows, `--sandbox` is macOS/Linux only (fails closed on Windows → rely on permission prompts), `terminal_input` is POSIX-reliable only. `dev-docs/terminal-tools.md` updated to describe both safe-delete wrappers.

## Tests
- `trash.Backup` (copies, keeps original) vs `Move` (removes); missing-path errors.
- `runTrashBackup` (backs up, keeps original, exits 0, tolerates bad / `--` args).
- Windows-only: `shellCommand` injects the wrapper + sets `OCTO_TRASH_PROJECT`.
- `go test -race ./internal/trash/ ./internal/tools/ ./cmd/octo/` + `go vet` clean.

The end-to-end PowerShell delete-to-trash path runs on Windows; the Go pieces (`Backup`, the helper) are covered cross-platform and the wrapper wiring is covered by the Windows-only test on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)