### PR TITLE
chore(release): v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased — 0.17.0-dev]
+## [Unreleased — 0.18.0-dev]
+
+## [0.17.0] — 2026-06-09
 
 ## [0.16.0] — 2026-06-09
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "0.17.0"
+var Version = "0.18.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump version to 0.18.0-dev and update changelog for v0.17.0 release.

Tag v0.17.0 already pushed.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>