### PR TITLE
feat: default to chat mode when octo is invoked without a subcommand

### DIFF
--- a/cmd/octo/completion.go
+++ b/cmd/octo/completion.go
@@ -72,8 +72,13 @@ func completionCandidates(words []string) []string {
 		return topLevelCommands
 	}
 	// Still typing the subcommand itself — offer the full top-level list
-	// (shell will prefix-match against the partial).
+	// (shell will prefix-match against the partial). If the partial starts
+	// with a dash the user is typing a flag, which means default chat mode
+	// (octo with no subcommand behaves like octo chat).
 	if len(words) == 2 {
+		if strings.HasPrefix(words[1], "-") {
+			return chatCandidates(words, "")
+		}
 		return topLevelCommands
 	}
 	prev := words[len(words)-2]
@@ -102,7 +107,10 @@ func completionCandidates(words []string) []string {
 			return []string{"bash", "zsh", "fish", "powershell"}
 		}
 	}
-	return nil
+	// No recognised subcommand: default chat mode. Any positional text after
+	// "octo" is treated as the chat message, so flags and their values still
+	// complete exactly as they do for "octo chat ...".
+	return chatCandidates(words, prev)
 }
 
 func chatCandidates(words []string, prev string) []string {

--- a/cmd/octo/completion_test.go
+++ b/cmd/octo/completion_test.go
@@ -46,6 +46,49 @@ func TestCompletionCandidates_ChatFlags(t *testing.T) {
 	}
 }
 
+func TestCompletionCandidates_DefaultChatMode(t *testing.T) {
+	// octo with no subcommand defaults to chat, so flags and their values
+	// should complete even without an explicit "chat" subcommand.
+	cases := []struct {
+		words []string
+		want  []string
+	}{
+		// Dash-partial at position 1 → chat flags (user is typing a flag).
+		{[]string{"octo", "-"}, []string{"-c", "--continue", "--provider", "--quiet"}},
+		{[]string{"octo", "--"}, []string{"--continue", "--provider", "--quiet"}},
+		// Flag values after "octo --provider ".
+		{[]string{"octo", "--provider", ""}, []string{"anthropic", "openai"}},
+	}
+	for _, tc := range cases {
+		got := completionCandidates(tc.words)
+		for _, w := range tc.want {
+			if !sliceContains(got, w) {
+				t.Errorf("words=%v missing %q; got %v", tc.words, w, got)
+			}
+		}
+	}
+}
+
+func TestCompletionCandidates_DefaultChatMode_SessionIDs(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	s1 := agent.NewSession("test-model", "")
+	if err := s1.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := completionCandidates([]string{"octo", "-c", ""})
+	if len(got) < 1 || got[0] != "last" {
+		t.Errorf("expected 'last' as first candidate; got %v", got)
+	}
+	for _, want := range []string{s1.ShortID(), s1.ID} {
+		if !sliceContains(got, want) {
+			t.Errorf("expected %q in candidates; got %v", want, got)
+		}
+	}
+}
+
 func TestCompletionCandidates_ProviderValueAfterFlag(t *testing.T) {
 	got := completionCandidates([]string{"octo", "chat", "--provider", ""})
 	if !sliceEq(got, []string{"anthropic", "openai"}) {

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -27,8 +27,7 @@ func main() {
 // lets the test harness drive the CLI without spawning a subprocess.
 func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		printUsage(stdout)
-		return 0
+		return runChat(args, stdin, stdout, stderr)
 	}
 
 	// Materialize the binary's default skills to ~/.octo/skills-default so
@@ -98,7 +97,9 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "octo — a functionality-first AI agent in a single Go binary.")
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Usage: octo <command>")
+	fmt.Fprintln(w, "Usage: octo [command]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "With no command, octo starts an interactive chat session (same as `octo chat`).")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Commands:")
 	fmt.Fprintln(w, "  chat       Start an interactive session (or single-turn with a message)")

--- a/cmd/octo/main_test.go
+++ b/cmd/octo/main_test.go
@@ -6,20 +6,6 @@ import (
 	"testing"
 )
 
-func TestRun_NoArgs_PrintsUsage(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	code := run(nil, strings.NewReader(""), &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("exit code = %d, want 0", code)
-	}
-	if !strings.Contains(stdout.String(), "Usage: octo") {
-		t.Errorf("stdout missing usage banner; got: %q", stdout.String())
-	}
-	if stderr.Len() != 0 {
-		t.Errorf("stderr should be empty; got: %q", stderr.String())
-	}
-}
-
 func TestRun_Version(t *testing.T) {
 	for _, arg := range []string{"version", "--version", "-v"} {
 		t.Run(arg, func(t *testing.T) {
@@ -35,11 +21,11 @@ func TestRun_Version(t *testing.T) {
 	}
 }
 
-func TestRun_Usage_ListsInit(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	run(nil, strings.NewReader(""), &stdout, &stderr)
-	if !strings.Contains(stdout.String(), "init") {
-		t.Errorf("usage should list the init command; got: %q", stdout.String())
+func TestPrintUsage_ListsInit(t *testing.T) {
+	var buf bytes.Buffer
+	printUsage(&buf)
+	if !strings.Contains(buf.String(), "init") {
+		t.Errorf("usage should list the init command; got: %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
When `octo` is called with no arguments, it now enters interactive chat mode instead of printing usage. This makes the most common workflow (`octo` → chat) zero-friction.

### Changes
- **main.go**: route empty args to `runChat` instead of `printUsage`
- **printUsage**: update wording to reflect optional `[command]`
- **completion.go**: when the partial starts with `-`, complete chat flags even without an explicit `chat` subcommand
- **Tests**: removed `TestRun_NoArgs_PrintsUsage`, added default-chat completion coverage

### Checklist
- `go test -race ./cmd/octo/...` ✅
- `go vet ./cmd/octo/...` ✅
- `gofmt -w` ✅