### PR TITLE
fix: restore strict permission mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased — 0.18.0-dev]
 
+### Added
+- **Strict permission mode is back.** Removing `ModeStrict` (#461) broke the unattended surfaces that depended on it: `octo init`'s default `--permission-mode strict` failed its own flag validation, the eval harness passed `strict` to `octo chat` and got exit 2, and on a TTY `strict` silently became `interactive` (prompting — the opposite of the documented "deny on ask"). `ModeStrict` again resolves `ask` → `deny` in the engine itself, independent of whether a prompter is wired; the IM channel gate uses it explicitly, and the denial reason now says strict mode denied the call instead of claiming the user declined.
+
 ## [0.17.0] — 2026-06-09
 
 ## [0.16.0] — 2026-06-09

--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -295,7 +295,7 @@ func handleAgentMessage(ctx context.Context, mgr *channel.Manager, ad channel.Ad
 // back to the built-in defaults otherwise — the same engine the CLI and HTTP
 // server use.
 func newChannelGate(cwd string) (agent.PermissionGate, error) {
-	engine, err := permission.New(permissionConfigPath(), cwd, permission.ModeInteractive)
+	engine, err := permission.New(permissionConfigPath(), cwd, permission.ModeStrict)
 	if err != nil {
 		return nil, fmt.Errorf("permission engine: %w", err)
 	}

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -343,8 +343,10 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	// Validate up front. Fail closed on a typo rather than silently falling
 	// back to the more-permissive interactive mode.
-	if resolvedPermMode != string(permission.ModeInteractive) && resolvedPermMode != string(permission.ModeAutoApprove) {
-		fmt.Fprintf(stderr, "octo chat: invalid --permission-mode %q (want 'interactive' or 'auto')\n", resolvedPermMode)
+	if resolvedPermMode != string(permission.ModeInteractive) &&
+		resolvedPermMode != string(permission.ModeAutoApprove) &&
+		resolvedPermMode != string(permission.ModeStrict) {
+		fmt.Fprintf(stderr, "octo chat: invalid --permission-mode %q (want 'interactive', 'strict' or 'auto')\n", resolvedPermMode)
 		return 2
 	}
 
@@ -597,11 +599,17 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		// auto-denies — the headless posture.
 		if stdinIsTTY(stdin) {
 			rl, err := newReadlineReader(defaultHistoryFile())
-			if err != nil {
+			switch {
+			case err == nil:
+				replReader = rl
+			case errors.Is(err, errReadlineUnsupported):
+				// Expected on Windows: cooked-mode conhost handles paste and
+				// basic editing natively, so degrade silently — this is the
+				// designed posture, not an error worth announcing every run.
+				replReader = newScannerLineReader(stdin, stdout)
+			default:
 				fmt.Fprintf(stderr, "octo chat: line editor unavailable (%v); falling back to plain input\n", err)
 				replReader = newScannerLineReader(stdin, stdout)
-			} else {
-				replReader = rl
 			}
 		} else {
 			replReader = newScannerLineReader(stdin, stdout)

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -46,8 +46,10 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if *permMode != string(permission.ModeInteractive) && *permMode != string(permission.ModeAutoApprove) {
-		fmt.Fprintf(stderr, "octo init: invalid --permission-mode %q (want 'interactive' or 'auto')\n", *permMode)
+	if *permMode != string(permission.ModeInteractive) &&
+		*permMode != string(permission.ModeAutoApprove) &&
+		*permMode != string(permission.ModeStrict) {
+		fmt.Fprintf(stderr, "octo init: invalid --permission-mode %q (want 'interactive', 'strict' or 'auto')\n", *permMode)
 		return 2
 	}
 

--- a/cmd/octo/lineread.go
+++ b/cmd/octo/lineread.go
@@ -92,6 +92,12 @@ type readlineLineReader struct {
 	interrupted bool
 }
 
+// errReadlineUnsupported marks the expected, by-design refusal to use
+// chzyer/readline on a platform (today: Windows). Callers use it to fall back
+// to the scanner silently — it is not a user-facing error, unlike a genuine
+// readline init failure.
+var errReadlineUnsupported = errors.New("interactive line editing is unavailable on Windows")
+
 func newReadlineReader(historyFile string) (*readlineLineReader, error) {
 	// chzyer/readline drives the Windows console through its own raw-mode ANSI
 	// emulation, which mangles pasted input (a pasted URL comes through garbled
@@ -100,7 +106,7 @@ func newReadlineReader(historyFile string) (*readlineLineReader, error) {
 	// is lost there, but interactive Windows sessions use the bubbletea TUI for
 	// the REPL anyway — the only readline consumer left is the config wizard.
 	if runtime.GOOS == "windows" {
-		return nil, errors.New("interactive line editing is unavailable on Windows")
+		return nil, errReadlineUnsupported
 	}
 	if historyFile != "" {
 		if err := os.MkdirAll(filepath.Dir(historyFile), 0o755); err != nil {

--- a/cmd/octo/permission_gate.go
+++ b/cmd/octo/permission_gate.go
@@ -48,8 +48,12 @@ func permissionConfigPath() string {
 // permission.Mode. Unknown values fall back to interactive (the safe,
 // CLI-friendly default) and the caller is expected to have validated.
 func resolvePermissionMode(s string) permission.Mode {
-	if s == string(permission.ModeAutoApprove) {
+	switch s {
+	case string(permission.ModeAutoApprove):
 		return permission.ModeAutoApprove
+	case string(permission.ModeStrict):
+		return permission.ModeStrict
+	default:
+		return permission.ModeInteractive
 	}
-	return permission.ModeInteractive
 }

--- a/cmd/octo/permission_gate_test.go
+++ b/cmd/octo/permission_gate_test.go
@@ -106,6 +106,27 @@ func TestCLIGate_AutoApproveModeNeverPrompts(t *testing.T) {
 	}
 }
 
+func TestCLIGate_StrictModeDeniesAskWithoutPrompting(t *testing.T) {
+	// In strict mode the engine collapses ask → deny, so a command that would
+	// normally prompt is refused without touching stdin — even though a
+	// prompter IS wired (a TTY must not weaken the strict posture).
+	g, out := newGate(t, permission.ModeStrict, "y\n") // a prompt would read "y" and allow
+	ok, reason := g.Check(context.Background(), "terminal", map[string]any{"command": "sudo apt update"})
+	if ok {
+		t.Error("strict mode must deny ask-class commands")
+	}
+	if !strings.Contains(reason, "permission_denied") {
+		t.Errorf("expected structured denial reason, got %q", reason)
+	}
+	if out.Len() != 0 {
+		t.Errorf("strict mode must not prompt; got %q", out.String())
+	}
+	// Explicit allow rules still pass through.
+	if ok, reason := g.Check(context.Background(), "terminal", map[string]any{"command": "ls"}); !ok {
+		t.Errorf("strict mode must not block allow-listed commands; reason=%q", reason)
+	}
+}
+
 func TestCLIGate_UnwrapsToolCallToRealName(t *testing.T) {
 	// A Tool Search mcp_call must be evaluated against the wrapped tool, not
 	// the opaque "mcp_call" bridge: wrapping a dangerous terminal command must
@@ -130,11 +151,11 @@ func TestResolvePermissionMode(t *testing.T) {
 	if resolvePermissionMode("auto") != permission.ModeAutoApprove {
 		t.Error("auto should map to ModeAutoApprove")
 	}
-	// Unknown values (including the former "strict") fall back to interactive.
+	if resolvePermissionMode("strict") != permission.ModeStrict {
+		t.Error("strict should map to ModeStrict")
+	}
+	// Unknown values fall back to interactive.
 	if resolvePermissionMode("garbage") != permission.ModeInteractive {
 		t.Error("unknown should fall back to ModeInteractive")
-	}
-	if resolvePermissionMode("strict") != permission.ModeInteractive {
-		t.Error("deprecated strict should fall back to ModeInteractive")
 	}
 }

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -47,12 +47,15 @@ const (
 //
 // Interactive (CLI default) returns Ask as-is so the caller can prompt the
 // user. AutoApprove converts Ask → Allow, so no interactive prompt is shown.
-// Allow / Deny pass through unchanged in both modes.
+// Strict converts Ask → Deny — the unattended posture (evals, the IM channel
+// bridge, scripted runs) where nobody can answer a prompt and blanket
+// approval is unacceptable. Allow / Deny pass through unchanged in all modes.
 type Mode string
 
 const (
 	ModeInteractive Mode = "interactive"
 	ModeAutoApprove Mode = "auto"
+	ModeStrict      Mode = "strict"
 )
 
 // Rule is one entry in the rule list for a tool. Exactly one of Pattern /
@@ -165,7 +168,8 @@ func New(configPath string, cwd string, mode Mode, allowWriteRoots ...string) (*
 //  1. Session-remembered decision (set by Remember) short-circuits.
 //  2. Rules for the tool are scanned in order; first match wins.
 //  3. No match → implicit Ask.
-//  4. Mode adjustment: ModeAutoApprove turns Ask into Allow.
+//  4. Mode adjustment: ModeAutoApprove turns Ask into Allow; ModeStrict
+//     turns Ask into Deny.
 func (e *Engine) Check(toolName string, input map[string]any) Decision {
 	sig := signature(toolName, input)
 
@@ -211,17 +215,28 @@ func (e *Engine) DenialReason(toolName string, input map[string]any) string {
 			return formatRuleReason(toolName, r)
 		}
 	}
+	if e.mode == ModeStrict {
+		return fmt.Sprintf("permission_denied: %s — requires confirmation, and strict mode denies without prompting.", toolName)
+	}
 	return fmt.Sprintf("permission_denied: %s — user declined the interactive prompt.", toolName)
 }
 
 // applyMode adjusts Ask decisions based on the engine mode:
 //   - ModeAutoApprove: Ask → Allow
+//   - ModeStrict: Ask → Deny
 //   - ModeInteractive: Ask passes through unchanged
 func (e *Engine) applyMode(d Decision) Decision {
-	if e.mode == ModeAutoApprove && d == Ask {
-		return Allow
+	if d != Ask {
+		return d
 	}
-	return d
+	switch e.mode {
+	case ModeAutoApprove:
+		return Allow
+	case ModeStrict:
+		return Deny
+	default:
+		return d
+	}
 }
 
 // matches reports whether rule r applies to the tool invocation. The

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -195,6 +195,29 @@ func TestAutoApproveMode_TurnsAskIntoAllow(t *testing.T) {
 	}
 }
 
+func TestStrictMode_TurnsAskIntoDeny(t *testing.T) {
+	e, err := New("", "/work", ModeStrict)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := e.Check("terminal", map[string]any{"command": "rm -rf node_modules"}); got != Deny {
+		t.Errorf("strict ask→deny: got %s, want Deny", got)
+	}
+	// Explicit allows still allow.
+	if got := e.Check("terminal", map[string]any{"command": "ls"}); got != Allow {
+		t.Errorf("strict still allows allow rules: got %s", got)
+	}
+	// Explicit denies still deny.
+	if got := e.Check("terminal", map[string]any{"command": "rm -rf /"}); got != Deny {
+		t.Errorf("strict still denies deny rules: got %s", got)
+	}
+	// The denial reason must not claim the user declined — nobody was asked.
+	reason := e.DenialReason("terminal", map[string]any{"command": "some-unknown-cmd"})
+	if !strings.Contains(reason, "strict") {
+		t.Errorf("strict denial reason should mention strict mode, got %q", reason)
+	}
+}
+
 // ─── Remember cache ────────────────────────────────────────────────────────
 
 func TestRemember_ShortCircuits(t *testing.T) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -609,6 +609,8 @@ func resolvePermissionMode() permission.Mode {
 	switch cfg.PermissionMode {
 	case string(permission.ModeAutoApprove):
 		return permission.ModeAutoApprove
+	case string(permission.ModeStrict):
+		return permission.ModeStrict
 	default:
 		return permission.ModeInteractive
 	}


### PR DESCRIPTION
## What

Restore the `strict` permission mode that #461 removed.

Dropping `ModeStrict` broke every unattended surface that relied on it:

- `octo init`'s own default `--permission-mode strict` failed flag validation.
- The eval harness passes `strict` to `octo chat` → got exit 2.
- On a TTY, `strict` silently degraded to `interactive` and **prompted** — the exact opposite of the documented "deny on ask" posture.

## Changes

- **`internal/permission`** — `ModeStrict` resolves `Ask → Deny` in the engine itself, independent of whether a prompter is wired. `DenialReason` now states strict mode denied the call rather than claiming the user declined a prompt nobody saw. Explicit allow/deny rules still pass through unchanged.
- **`cmd/octo/chat.go`, `init.go`** — `--permission-mode` validation accepts `strict` again (error text updated).
- **`cmd/octo/channel.go`** — IM channel gate uses `ModeStrict` explicitly (was `ModeInteractive`).
- **`cmd/octo/permission_gate.go`, `internal/server/handlers.go`** — mode resolution maps `"strict"` → `ModeStrict`.
- **`lineread.go` / `chat.go`** — silently fall back to the scanner line reader when readline is unsupported on Windows (`errReadlineUnsupported`) instead of printing a warning every run; that path is the designed posture, not an error.
- Tests + CHANGELOG.

## Testing

`internal/permission` and the affected `cmd/octo` permission tests pass:

\`\`\`
ok  github.com/Leihb/octo-agent/internal/permission
ok  github.com/Leihb/octo-agent/cmd/octo  (TestCLIGate_StrictMode*, TestResolvePermissionMode, TestStrictMode*)
\`\`\`

gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)