### PR TITLE
test: isolate HOME in OpenAI chat end-to-end tests

### DIFF
--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -276,6 +276,12 @@ func TestRunChat_OpenAI_EndToEnd(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	// Isolate HOME so the tools-on session reads an empty mcp.json instead of
+	// the developer's real ~/.octo/mcp.json — connecting to live MCP servers
+	// would block the headless turn indefinitely (no connect timeout).
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	t.Setenv("OPENAI_API_KEY", "test-key")
 	t.Setenv("OPENAI_BASE_URL", srv.URL)
 	t.Setenv("ANTHROPIC_API_KEY", "") // ensure we're testing the openai branch
@@ -400,6 +406,11 @@ func TestRunChat_OpenAI_StreamingEndToEnd(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	// See TestRunChat_OpenAI_EndToEnd: isolate HOME so the tools-on session
+	// doesn't connect to the developer's real MCP servers and hang.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	t.Setenv("OPENAI_API_KEY", "k")
 	t.Setenv("OPENAI_BASE_URL", srv.URL)
 	t.Setenv("ANTHROPIC_API_KEY", "")


### PR DESCRIPTION
## Problem

`go test ./cmd/octo/` hangs for ~600s on a developer machine that has MCP servers configured in `~/.octo/mcp.json`, failing only via the go-test watchdog. Goroutine dump points at `internal/mcp.(*Client).Initialize` → `StdioTransport.Receive`.

## Root cause

`TestRunChat_OpenAI_EndToEnd` and `TestRunChat_OpenAI_StreamingEndToEnd` call `runChat` with tools on. That path runs `mcp.LoadConfig(cwd)` (chat.go:634), which always reads `~/.octo/mcp.json` via `os.UserHomeDir()`, then `ConnectAll` with `context.Background()` — **no connect timeout**. Unlike their Anthropic siblings (e.g. `TestRunChat_Anthropic_StreamingEndToEnd`), these two never repointed `HOME` at a temp dir, so they:

- spawned the real stdio server (`codegraph serve --mcp`) and blocked on its first frame, and
- attempted OAuth against the real `lark-project` HTTP server.

CI passes because its clean `HOME` has no `mcp.json`, so `LoadConfig` returns no servers and the connect is skipped.

## Fix

Point `HOME`/`USERPROFILE` at `t.TempDir()` in both tests so the session loads an empty MCP config — the same isolation every other `runChat` test already uses. No production code touched.

## Testing

`go test ./cmd/octo/` now completes in ~3s (was a 600s hang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)