### PR TITLE
fix(web): show thinking spinner immediately when a turn starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased — 0.18.0-dev]
 
+### Fixed
+- **Web UI now shows a "thinking" spinner the whole time the agent is working.** After the user sent a message the frontend swapped the ghost bubble for the real one and then sat with no indicator until the first streamed token — provider connect and the model's pre-text reasoning fire no events, so a multi-second turn looked hung. The server now broadcasts an initial `thinking` progress the moment a turn starts (and stores it in live state so a reconnecting tab replays it); the real tool/text events adopt the same progress element in place, so there's no flicker.
+
 ### Added
 - **Strict permission mode is back.** Removing `ModeStrict` (#461) broke the unattended surfaces that depended on it: `octo init`'s default `--permission-mode strict` failed its own flag validation, the eval harness passed `strict` to `octo chat` and got exit 2, and on a TTY `strict` silently became `interactive` (prompting — the opposite of the documented "deny on ask"). `ModeStrict` again resolves `ask` → `deny` in the engine itself, independent of whether a prompter is wired; the IM channel gate uses it explicitly, and the denial reason now says strict mode denied the call instead of claiming the user declined.
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/config"
@@ -847,5 +848,87 @@ func TestRunTurnForwardsTools(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("web_search not among forwarded tools: %v", rec.lastTools)
+	}
+}
+
+// TestDoAgentTurn_SeedsThinkingProgress is the regression guard for the web-UI
+// "no spinner after send" gap. doAgentTurn must broadcast an initial "thinking"
+// progress immediately — before any text streams — so the frontend keeps an
+// indicator on screen between swapping the ghost bubble for the real one and
+// the first delta. Provider connect + pre-text reasoning fire no events, so
+// without the seed the session looks hung.
+func TestDoAgentTurn_SeedsThinkingProgress(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.initWS()
+	// Maps doAgentTurn touches that the full constructor sets up but mustServer
+	// (a minimal hand-built Server) does not.
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]string)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Subscribe a fake connection so we capture what the turn broadcasts.
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+	srv.wsHub.subscribe(conn, sess.ID)
+
+	srv.doAgentTurn(sess, "hi")
+
+	// Broadcast is async through the hub's event loop; drain until the turn's
+	// terminal "complete" event (or a safety deadline).
+	var types []string
+	firstProgressIdx, firstTextIdx := -1, -1
+	progressType := ""
+	deadline := time.After(2 * time.Second)
+drain:
+	for {
+		select {
+		case b := <-conn.send:
+			var ev map[string]any
+			if err := json.Unmarshal(b, &ev); err != nil {
+				continue
+			}
+			typ, _ := ev["type"].(string)
+			switch typ {
+			case "progress":
+				if firstProgressIdx < 0 {
+					firstProgressIdx = len(types)
+					progressType, _ = ev["progress_type"].(string)
+				}
+			case "text_delta":
+				if firstTextIdx < 0 {
+					firstTextIdx = len(types)
+				}
+			}
+			types = append(types, typ)
+			if typ == "complete" {
+				break drain
+			}
+		case <-deadline:
+			break drain
+		}
+	}
+
+	if firstProgressIdx < 0 {
+		t.Fatalf("turn broadcast no progress event; got %v", types)
+	}
+	if progressType != "thinking" {
+		t.Errorf("first progress_type = %q, want \"thinking\"; events=%v", progressType, types)
+	}
+	if firstTextIdx >= 0 && firstProgressIdx > firstTextIdx {
+		t.Errorf("thinking progress must precede first text_delta; progress@%d text@%d; events=%v",
+			firstProgressIdx, firstTextIdx, types)
 	}
 }

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -338,10 +338,34 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 		return
 	}
 
-	// Set up progress tracking for this session.
+	// Set up progress tracking for this session, seeded with an initial
+	// "thinking" phase that is broadcast immediately. Building the agent,
+	// connecting to the provider, and the model's pre-text reasoning can take
+	// several seconds during which no tool or text event fires. Without this
+	// seed the frontend swaps the ghost bubble for the real one and then sits
+	// with no indicator until the first delta — the session looks hung. The
+	// real tool/text events adopt this progress element in place (the frontend
+	// keys on started_at), so there is no flicker, and a late-subscribing tab
+	// replays it via replayLiveState.
+	startedAt := time.Now().UnixMilli()
 	s.liveStateMu.Lock()
-	s.liveStates[sess.ID] = &sessionLiveState{}
+	s.liveStates[sess.ID] = &sessionLiveState{
+		progress: &wsEventProgress{
+			Type:         "progress",
+			ProgressType: "thinking",
+			Phase:        "active",
+			StartedAt:    startedAt,
+		},
+	}
 	s.liveStateMu.Unlock()
+	s.wsHub.broadcast(sess.ID, map[string]any{
+		"type":          "progress",
+		"session_id":    sess.ID,
+		"progress_type": "thinking",
+		"phase":         "active",
+		"status":        "start",
+		"started_at":    startedAt,
+	})
 
 	defer func() {
 		// Clear live state at the end of the turn.


### PR DESCRIPTION
## Problem

After sending a message in the web UI, the agent interaction felt dead — no spinner while waiting for the reply.

The frontend renders a ghost bubble with a spinner on send, but the server's `history_user_message` broadcast immediately swaps it for the real user bubble, **removing the spinner**. From there:

- `progress` events are only emitted on the first **tool call** (`EventToolStarted`).
- `text_delta` is only emitted on the first **streamed token**.

Between those, the server builds the agent, connects to the provider, and the model does its pre-text reasoning — **no events fire**. So a multi-second turn sat with the user's message and no indicator, looking hung.

## Fix

`doAgentTurn` now broadcasts an initial `thinking` progress the instant a turn starts, and seeds it into `sessionLiveState` so a tab subscribing mid-turn replays it via `replayLiveState`.

No frontend changes needed — the existing pipeline already handles it:
- the `progress` dispatch calls `showProgress`, rendering the Braille spinner;
- `appendTextDelta` already inserts the streaming bubble **before** the `.progress-msg` element, so text streams above a persistent indicator;
- `assistant_message` / `tool_call` / `complete` clear it;
- real events carry their own `started_at`, so `showProgress` adopts the existing DOM element in place — **no flicker**.

## Testing

New `TestDoAgentTurn_SeedsThinkingProgress` subscribes a fake WS connection, runs a turn through the stub sender, and asserts a `thinking` progress is broadcast and precedes the first `text_delta`.

\`\`\`
ok  github.com/Leihb/octo-agent/internal/server
\`\`\`

gofmt + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)