### PR TITLE
fix(web): remove broken AI-key-guide link and dead currency/cost code

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1220,7 +1220,7 @@ func (a *Agent) SessionTokens() (inputTokens, outputTokens int) {
 }
 
 // AccrueChildUsage folds tokens spent by a spawned sub-agent into this
-// agent's session totals, so /cost and SessionTokens still report one
+// agent's session totals, so SessionTokens still reports one
 // consolidated number even when the LLM used sub_agent. cache totals are
 // left untouched — the child runs against the same provider but reports its
 // own cache hits internally; the parent only sees the bottom-line counts here.
@@ -1267,10 +1267,6 @@ func (a *Agent) SessionCacheTokens() (readTokens, writeTokens int) {
 	return a.sessionCacheReadTokens, a.sessionCacheWriteTokens
 }
 
-// SessionCostUSD returns a rough USD estimate for the tokens used so far.
-// Pricing is based on publicly listed rates as of May 2026 and is best-effort
-// — it uses a prefix match on the model name and falls back to a conservative
-// mid-tier estimate for unknown models.
 // popLast is an internal helper used by Turn to undo the user-message append
 // when the Sender call fails. Exported users should not need this.
 func (h *History) popLast() {

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -18,7 +18,7 @@ import (
 // fresh History, no visibility into the parent's conversation, its own
 // loop budget. The final child reply text is returned to the parent as the
 // sub_agent tool_result; the child's token usage is rolled into the
-// parent's session totals so /cost reports one consolidated number.
+// parent's session totals so they report one consolidated number.
 //
 // toolsFn is a deferred lookup of the LLM-facing tool catalog (DefaultTools).
 // Resolving it on each Spawn — rather than capturing a slice at construction

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -131,7 +131,6 @@ type configResponse struct {
 	Models          []modelConfig `json:"models,omitempty"`
 	DefaultModelIdx int           `json:"default_model_idx,omitempty"`
 	FontSize        string        `json:"font_size,omitempty"`
-	Currency        string        `json:"currency,omitempty"`
 	Language        string        `json:"language,omitempty"`
 }
 
@@ -173,7 +172,6 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 		Models:          models,
 		DefaultModelIdx: defaultIdx,
 		FontSize:        "medium",
-		Currency:        "USD",
 		Language:        "en",
 	})
 }

--- a/internal/server/static/app.css
+++ b/internal/server/static/app.css
@@ -1113,7 +1113,7 @@ body {
   white-space: normal;
   flex: 1;
 }
-/* Meta: second row — tasks + cost */
+/* Meta: second row — tasks */
 .session-meta {
   display: block;
   font-size: 0.625rem;
@@ -2426,7 +2426,7 @@ body {
  * Visual hierarchy (3 tiers):
  *   Tier 1 primary   (opacity 1.00)  — status, model      → "what am I and is it running"
  *   Tier 2 secondary (opacity ~0.75) — dir, tasks         → "contextual info"
- *   Tier 3 tertiary  (opacity ~0.45) — id, mode, cost, │  → "can be glanced over"
+ *   Tier 3 tertiary  (opacity ~0.45) — id, mode, │       → "can be glanced over"
  * Base bar opacity is kept high so primary tier stays fully readable; the
  * hover :hover rule lifts everything to 1.0 for detail inspection.
  */
@@ -6304,8 +6304,6 @@ body {
 /* ═════════════════════════════════════════════════════════════════════════
  * RESTORED STYLES (removed by accident in 51b11f3 — brand/creator cleanup)
  * ═════════════════════════════════════════════════════════════════════════ */
-.tu-cost  { color: var(--color-text-tertiary); }
-
 #skill-list-items { padding: 0 0.5rem 0.5rem; display: flex; flex-direction: column; gap: 2px; }
 
 /* ── Setup panel (full-screen, covers sidebar — mandatory first-run) ─────── */

--- a/internal/server/static/i18n.js
+++ b/internal/server/static/i18n.js
@@ -388,8 +388,6 @@ const I18n = (() => {
       "settings.models.field.baseurl":    "Base URL",
       "settings.models.field.apikey":     "API Key",
       "settings.models.field.getApiKey":  "How to get →",
-      "settings.models.field.docsGuide.question": "New to AI keys?",
-      "settings.models.field.docsGuide.cta":      "See the guide →",
       "settings.models.placeholder.provider": "— Choose provider —",
       "settings.models.placeholder.model":    "e.g. claude-sonnet-4-5",
       "settings.models.placeholder.baseurl":  "https://api.anthropic.com",
@@ -435,9 +433,6 @@ const I18n = (() => {
       "settings.fontSize.medium":          "Medium",
       "settings.fontSize.large":           "Large",
 
-      "settings.currency.title":           "Currency",
-      "settings.currency.usd":             "$ USD",
-      "settings.currency.cny":             "¥ CNY",
 
       // ── Onboard ──
       "onboard.title":              "Welcome to {{brand}}",
@@ -861,8 +856,6 @@ const I18n = (() => {
       "settings.models.field.baseurl":    "Base URL",
       "settings.models.field.apikey":     "API Key",
       "settings.models.field.getApiKey":  "如何获取 →",
-      "settings.models.field.docsGuide.question": "不会配置 AI 模型？",
-      "settings.models.field.docsGuide.cta":      "查看指南 →",
       "settings.models.placeholder.provider": "— 选择服务商 —",
       "settings.models.placeholder.model":    "如 claude-sonnet-4-5",
       "settings.models.placeholder.baseurl":  "https://api.anthropic.com",
@@ -908,9 +901,6 @@ const I18n = (() => {
       "settings.fontSize.medium":          "中",
       "settings.fontSize.large":           "大",
 
-      "settings.currency.title":           "货币",
-      "settings.currency.usd":             "$ 美元",
-      "settings.currency.cny":             "¥ 人民币",
 
       // ── Onboard ──
       "onboard.title":              "欢迎使用 {{brand}}",

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -574,17 +574,6 @@
           </div>
         </section>
 
-        <!-- Currency section -->
-        <section class="settings-section" id="currency-section">
-          <div class="settings-section-title">
-            <span data-i18n="settings.currency.title">Currency</span>
-          </div>
-          <div class="settings-lang-btns">
-            <button id="settings-btn-currency-usd" class="settings-lang-btn" data-currency="USD">$ USD</button>
-            <button id="settings-btn-currency-cny" class="settings-lang-btn" data-currency="CNY">¥ CNY</button>
-          </div>
-        </section>
-
 
 
       </div>

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -1881,7 +1881,6 @@ const Sessions = (() => {
 
     // Meta line — prefer relative time of last activity. Tasks count is
     // only shown when > 0 to avoid visual noise on fresh sessions.
-    // Cost is intentionally dropped from the list (move to hover/details).
     const metaParts = [];
     if (s.total_tasks && s.total_tasks > 0) {
       metaParts.push(I18n.t("sessions.metaTasks", { n: s.total_tasks }));
@@ -3227,7 +3226,7 @@ const Sessions = (() => {
     // Append a token usage line directly to the message list.
     // Server guarantees this event arrives AFTER assistant_message, so no buffering needed.
     // Format mirrors CLI:
-    //   [Tokens] | +409 | [*] | Input: 69,977 (cache: 69,566 read, 410 write) | Output: 101 | Total: 70,078 | Cost: $0.02392
+    //   [Tokens] | +409 | [*] | Input: 69,977 (cache: 69,566 read, 410 write) | Output: 101 | Total: 70,078
     appendTokenUsage(ev, container) {
       const messages = container || $("messages");
       const el = document.createElement("div");
@@ -4765,9 +4764,5 @@ const Sessions = (() => {
 })();
 
 document.addEventListener("langchange", () => {
-  if (Sessions._lastSession) Sessions.updateInfoBar(Sessions._lastSession);
-});
-
-document.addEventListener("currencychange", () => {
   if (Sessions._lastSession) Sessions.updateInfoBar(Sessions._lastSession);
 });

--- a/internal/server/static/settings.js
+++ b/internal/server/static/settings.js
@@ -140,10 +140,6 @@ const Settings = (() => {
       </div>
 
       <div class="model-card-footer">
-        ${!model.api_key_masked ? `<span class="model-card-docs-link" style="font-size:0.75rem;">
-          <span style="color:var(--muted,#6b7280);">${I18n.t("settings.models.field.docsGuide.question")}</span>
-          <a href="https://www.octo.com/docs/ai-key-guide" target="_blank" rel="noopener" style="margin-left:0.25rem;color:var(--accent,#6366f1);text-decoration:none;">${I18n.t("settings.models.field.docsGuide.cta")}</a>
-        </span>` : ""}
         <span class="model-test-result" data-index="${index}"></span>
         <div class="model-card-actions-row">
           ${!isDefault ? `<button class="btn-set-default" data-index="${index}" title="${I18n.t("settings.models.btn.setDefault")}">${I18n.t("settings.models.btn.setDefault")}</button>` : ""}
@@ -772,38 +768,9 @@ const Settings = (() => {
 
     _initLangBtns();
     _initFontBtns();
-    _initCurrencyBtns();
 
     // Re-render model cards when language changes (dynamic HTML, not data-i18n)
     document.addEventListener("langchange", () => _renderCards());
-  }
-
-  // ── Currency ──────────────────────────────────────────────────────────
-  const CURRENCY_STORAGE_KEY = "octo-currency";
-  const CURRENCY_DEFAULT     = "USD";
-
-  function _applyCurrency(currency) {
-    try { localStorage.setItem(CURRENCY_STORAGE_KEY, currency); } catch (_) {}
-    // Update active state on all currency buttons
-    document.querySelectorAll("#currency-section .settings-lang-btn").forEach(btn => {
-      btn.classList.toggle("active", btn.dataset.currency === currency);
-    });
-    // Currency change saved to localStorage; visual state updated above
-  }
-
-  function _initCurrencyBtns() {
-    // Apply saved preference (or default) on page load
-    let saved = null;
-    try { saved = localStorage.getItem(CURRENCY_STORAGE_KEY); } catch (_) {}
-    const current = saved || CURRENCY_DEFAULT;
-
-    // Wire up button clicks
-    document.querySelectorAll("#currency-section .settings-lang-btn").forEach(btn => {
-      btn.classList.toggle("active", btn.dataset.currency === current);
-      btn.addEventListener("click", () => {
-        _applyCurrency(btn.dataset.currency);
-      });
-    });
   }
 
   // ── Font Size ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

The model-settings card in the web UI linked to `https://www.octo.com/docs/ai-key-guide` — a domain that isn't this project's (`octo-agent.dev` is) and a page that never existed. This removes the broken link, then strips the rest of the unfinished **currency/cost** feature, which is fully dead code.

## Why it's all dead

- **Currency toggle (web)** — the `$ USD` / `¥ CNY` buttons only wrote a `localStorage` preference and toggled button highlight. Nothing ever *read* the value. The `currencychange` listener was never dispatched, and `updateInfoBar` doesn't reference currency anyway.
- **Cost (web)** — never rendered. The token-usage line shows no cost, the server never sends one, and the `.tu-cost` CSS class had zero JS references.
- **Cost (backend)** — `SessionCostUSD` had **zero callers** and no `/cost` command is wired anywhere. Only a stale doc comment survived, accidentally glued onto `popLast`. Comments referencing the non-existent `/cost` are cleaned up too.
- **Server `/api/config`** — dropped the `currency` field the frontend never read.

## Scope guard

Token-accrual (`AccrueChildUsage` / `SessionTokens`) is a real, working feature and is left untouched. The `theme_test.go` `{"cost", "$0.01"}` fixture is a generic segment-renderer test, unrelated to the cost feature — not touched.

## Verification

- `go build ./...` — OK
- `go test ./internal/server/ ./internal/agent/ ./internal/app/` — all pass
- `gofmt -l` — clean
- No residual `currency` / `cost` feature references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)