### PR TITLE
fix(web): final answer rendered above tool calls when model streams text before tools

### DIFF
--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -3155,6 +3155,10 @@ const Sessions = (() => {
     // Append a tool_call as a compact item inside the live tool group.
     // Creates the group if it doesn't exist yet.
     appendToolCall(name, args, summary) {
+      // Commit any pre-tool streamed text as its own bubble. Without this the
+      // live bubble stays tracked across the tool phase, so the next turn's
+      // text_delta appends the final answer into it — ABOVE the tool group.
+      Sessions._flushLiveText();
       const messages = $("messages");
       if (!Sessions._liveToolGroup) {
         Sessions._liveToolGroup = _makeToolGroup();


### PR DESCRIPTION
## Problem

In the Web UI, when a turn includes tool calls, the agent's final answer can render **above** the "N tool(s) used" group — i.e. the reply appears before the tools that produced it.

## Root cause

`Sessions._flushLiveText()` in `sessions.js` was written to commit the live streaming bubble before tool events (its comment says *"Called before tool events commit, matching the TUI's commitToolLine behaviour"*) — but **nothing ever called it**.

Sequence that triggers the bug (only when the model streams text *before* its first tool call, e.g. "我来看一下…"):

1. Pre-tool `text_delta` creates the live assistant bubble at the end of `#messages`.
2. `tool_call` appends the tool group **after** the bubble, but `_liveAssistant[sid].el` keeps pointing at it.
3. Next iteration's `text_delta` finds the stale bubble still in the DOM and appends the final answer into it — above the tool group.
4. `turn_done` → `finalizeAssistantMessage` replaces that same bubble in place, also **overwriting the pre-tool text** (turn_done carries only the last LLM call's text).

Turns that start with a pure tool_use have no stale bubble, so the first post-tool delta takes the create path (which collapses the group and appends at the end) — that's why the bug is intermittent.

## Fix

Call `Sessions._flushLiveText()` at the top of `appendToolCall`. Pre-tool text commits as its own bubble (matching TUI behaviour, no content loss), and the first delta after the tools creates a fresh bubble below the collapsed tool group.

## Testing

- `node --check` on sessions.js, `go build ./...`, `go test ./internal/server/` all pass.
- Manual: turn where the model emits text → 3 tool calls → final answer now renders user → pre-tool text → tool group → answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)