### PR TITLE
fix(web): emit background task events so the badge and notices render

### DIFF
--- a/internal/server/bg_tasks.go
+++ b/internal/server/bg_tasks.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"strings"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// Background-process visibility for the web UI. The frontend renders a
+// "N background task(s)" badge with a popover from background_tasks_update,
+// and an inline chat notice from background_task_notice; these helpers are
+// the server-side emitters feeding the session's per-session
+// tools.BackgroundManager state into the WebSocket stream.
+
+// backgroundTasksUpdate builds the badge payload from a live process list.
+func backgroundTasksUpdate(sessionID string, infos []tools.BgInfo, now time.Time) wsEventBackgroundTaskUpdate {
+	list := make([]wsBackgroundTask, 0, len(infos))
+	for _, in := range infos {
+		list = append(list, wsBackgroundTask{
+			HandleID: in.ID,
+			Command:  in.Command,
+			Elapsed:  int(now.Sub(in.Start).Seconds()),
+		})
+	}
+	return wsEventBackgroundTaskUpdate{
+		Type:      "background_tasks_update",
+		SessionID: sessionID,
+		Running:   len(list),
+		Tasks:     list,
+	}
+}
+
+// broadcastBackgroundTasks pushes the session's current background-process
+// list to its subscribers. Called after every tool call — a tool call is the
+// only way a turn starts or kills a process — and from the exit hook, so the
+// badge tracks starts, kills, and natural completions.
+func (s *Server) broadcastBackgroundTasks(sessionID string) {
+	infos := tools.SessionBackgroundManager(sessionID).ListRunning()
+	s.wsHub.broadcast(sessionID, backgroundTasksUpdate(sessionID, infos, time.Now()))
+}
+
+// wireBackgroundTaskNotices registers the session manager's exit hook so a
+// finished background process surfaces as a chat notice and the badge count
+// drops. Re-registered (idempotently) at each turn start; the hook outlives
+// the turn, so a process finishing between turns still notifies subscribed
+// tabs — broadcasting to a session with no subscribers is a no-op.
+func (s *Server) wireBackgroundTaskNotices(sessionID string) {
+	tools.SessionBackgroundManager(sessionID).SetOnExit(func(e tools.BgExit) {
+		s.wsHub.broadcast(sessionID, wsEventBackgroundTaskNotice{
+			Type:      "background_task_notice",
+			SessionID: sessionID,
+			Command:   e.Command,
+			HandleID:  e.ID,
+			Status:    bgNoticeStatus(e.Status),
+		})
+		s.broadcastBackgroundTasks(sessionID)
+	})
+}
+
+// bgNoticeStatus maps a BackgroundManager exit status ("exited: 0",
+// "exited: signal: killed", …) onto the frontend notice levels
+// (success / cancelled / failed).
+func bgNoticeStatus(status string) string {
+	switch {
+	case status == "exited: 0":
+		return "success"
+	case strings.Contains(status, "killed"):
+		return "cancelled"
+	default:
+		return "failed"
+	}
+}

--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+func TestBgNoticeStatus(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"exited: 0", "success"},
+		{"exited: exit status 1", "failed"},
+		{"exited: signal: killed", "cancelled"},
+		{"exited: something else", "failed"},
+	}
+	for _, c := range cases {
+		if got := bgNoticeStatus(c.in); got != c.want {
+			t.Errorf("bgNoticeStatus(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestBackgroundTasksUpdate_Payload(t *testing.T) {
+	now := time.Now()
+	infos := []tools.BgInfo{
+		{ID: "bg_1", Command: "sleep 30", Start: now.Add(-12 * time.Second), Status: "running"},
+		{ID: "bg_2", Command: "tail -f log", Start: now.Add(-3 * time.Second), Status: "running"},
+	}
+	ev := backgroundTasksUpdate("sess-1", infos, now)
+
+	if ev.Type != "background_tasks_update" {
+		t.Errorf("Type = %q", ev.Type)
+	}
+	if ev.SessionID != "sess-1" {
+		t.Errorf("SessionID = %q", ev.SessionID)
+	}
+	if ev.Running != 2 || len(ev.Tasks) != 2 {
+		t.Fatalf("Running = %d, Tasks = %d, want 2/2", ev.Running, len(ev.Tasks))
+	}
+	if ev.Tasks[0].HandleID != "bg_1" || ev.Tasks[0].Command != "sleep 30" || ev.Tasks[0].Elapsed != 12 {
+		t.Errorf("Tasks[0] = %+v", ev.Tasks[0])
+	}
+
+	// Empty list must still marshal with running 0 and a non-null tasks array
+	// so the frontend hides the badge instead of choking on null.
+	b, err := json.Marshal(backgroundTasksUpdate("sess-1", nil, now))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if raw["running"] != float64(0) {
+		t.Errorf("running = %v, want 0", raw["running"])
+	}
+	if _, ok := raw["tasks"].([]any); !ok {
+		t.Errorf("tasks = %v (%T), want JSON array", raw["tasks"], raw["tasks"])
+	}
+}
+
+// TestWireBackgroundTaskNotices_BroadcastsExit is the regression guard for the
+// web-UI "background tasks invisible" gap: the server defined the
+// background_task_notice / background_tasks_update event types but never
+// emitted them, so the frontend badge and notices never appeared.
+func TestWireBackgroundTaskNotices_BroadcastsExit(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "bg-notice-test-session"
+	defer tools.CloseSessionBackgroundManager(sid)
+
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+	srv.wsHub.subscribe(conn, sid)
+
+	srv.wireBackgroundTaskNotices(sid)
+
+	if _, err := tools.SessionBackgroundManager(sid).Start("echo done"); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	var gotNotice, gotUpdate bool
+	deadline := time.After(5 * time.Second)
+	for !(gotNotice && gotUpdate) {
+		select {
+		case b := <-conn.send:
+			var ev map[string]any
+			if err := json.Unmarshal(b, &ev); err != nil {
+				continue
+			}
+			switch ev["type"] {
+			case "background_task_notice":
+				gotNotice = true
+				if ev["status"] != "success" {
+					t.Errorf("notice status = %v, want success", ev["status"])
+				}
+				if ev["command"] != "echo done" {
+					t.Errorf("notice command = %v", ev["command"])
+				}
+				if ev["session_id"] != sid {
+					t.Errorf("notice session_id = %v", ev["session_id"])
+				}
+			case "background_tasks_update":
+				gotUpdate = true
+				if ev["running"] != float64(0) {
+					t.Errorf("update running = %v, want 0 after exit", ev["running"])
+				}
+			}
+		case <-deadline:
+			t.Fatalf("timed out; notice=%v update=%v", gotNotice, gotUpdate)
+		}
+	}
+}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -55,6 +55,14 @@ func (s *Server) SetSubscribed(conn *wsConn, sessionID string) {}
 // replayLiveState replays in-progress agent state (progress + stdout) to a
 // newly-subscribing browser tab so it catches up with what it missed.
 func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
+	// Bring the background-task badge up to date for this tab regardless of
+	// whether a turn is in flight — background processes outlive turns. Always
+	// sent (even with zero running) so switching sessions clears a stale badge.
+	infos := tools.SessionBackgroundManager(sessionID).ListRunning()
+	if b, err := json.Marshal(backgroundTasksUpdate(sessionID, infos, time.Now())); err == nil {
+		conn.send <- b
+	}
+
 	s.liveStateMu.RLock()
 	state, ok := s.liveStates[sessionID]
 	s.liveStateMu.RUnlock()
@@ -416,6 +424,8 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 			return
 		}
 		toolDefs = tools.DefaultToolsFor(a.Model)
+		// Surface background-process completions (badge + chat notice).
+		s.wireBackgroundTaskNotices(sess.ID)
 		// Wire sub-agent live-panel events into the WebSocket stream.
 		if subMgr != nil {
 			subMgr.SetOnEvent(func(ev tools.SubAgentEvent) {
@@ -619,6 +629,9 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 			ls.toolCall = nil
 		}
 		w.server.liveStateMu.Unlock()
+		// A tool call is the only place a turn starts or kills a background
+		// process — refresh the badge.
+		w.server.broadcastBackgroundTasks(w.sessionID)
 
 	case agent.EventToolError:
 		w.hub.broadcast(w.sessionID, map[string]any{
@@ -629,6 +642,7 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 		w.server.liveStateMu.Lock()
 		delete(w.server.liveStates, w.sessionID)
 		w.server.liveStateMu.Unlock()
+		w.server.broadcastBackgroundTasks(w.sessionID)
 
 	case agent.EventThinkingDelta:
 		w.hub.broadcast(w.sessionID, map[string]string{

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -190,9 +190,10 @@ type wsEventRequestUserQuestion struct {
 }
 
 type wsEventBackgroundTaskUpdate struct {
-	Type    string             `json:"type"`
-	Running int                `json:"running"`
-	Tasks   []wsBackgroundTask `json:"tasks"`
+	Type      string             `json:"type"`
+	SessionID string             `json:"session_id"`
+	Running   int                `json:"running"`
+	Tasks     []wsBackgroundTask `json:"tasks"`
 }
 
 type wsBackgroundTask struct {
@@ -202,10 +203,11 @@ type wsBackgroundTask struct {
 }
 
 type wsEventBackgroundTaskNotice struct {
-	Type     string `json:"type"`
-	Command  string `json:"command"`
-	HandleID string `json:"handle_id"`
-	Status   string `json:"status"`
+	Type      string `json:"type"`
+	SessionID string `json:"session_id"`
+	Command   string `json:"command"`
+	HandleID  string `json:"handle_id"`
+	Status    string `json:"status"`
 }
 
 type wsEventUserMessageQueueStatus struct {


### PR DESCRIPTION
## Problem

后台任务在 web UI 完全不显示。前端对 `background_tasks_update` / `background_task_notice` 的处理(SIB 徽标 + popover + 聊天内通知)一直是完整的,但服务端只在 `ws_types.go` 里定义了两个事件结构体,从未在任何地方构造或广播 —— 死代码。

## Fix

把会话级 `tools.BackgroundManager` 接入 WebSocket 流(镜像 TUI 在 `tuirepl.go` 的做法):

- **turn 开始时**注册 `SetOnExit` 钩子:后台进程结束 → 广播 `background_task_notice`(success/cancelled/failed)+ 刷新任务列表。钩子挂在跨 turn 存活的 per-session manager 上,turn 之间结束的进程也能通知到。
- **每次工具调用后**广播 `background_tasks_update` —— 工具调用是 turn 内启动/杀死后台进程的唯一时机。
- **subscribe 时**直发一次快照,页面刷新/切换会话后徽标状态正确(包括清掉残留徽标)。

事件结构体补上前端 dispatcher 过滤所需的 `session_id` 字段。

## Tests

- `TestBgNoticeStatus` — 退出状态到前端通知级别的映射
- `TestBackgroundTasksUpdate_Payload` — 徽标 payload 构造(含空列表序列化为 `[]` 而非 `null`)
- `TestWireBackgroundTaskNotices_BroadcastsExit` — 回归测试:真实后台进程退出 → 订阅连接收到 notice + update

`go test -race ./internal/server/ ./internal/tools/` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)