### PR TITLE
fix(web): deliver image and file attachments to the agent instead of dropping them

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -552,7 +552,7 @@ func (a *Agent) runLoop(
 				for i, it := range steerItems {
 					msgs[i] = it.Text
 				}
-				handler(AgentEvent{Kind: EventSteerInjected, Messages: msgs})
+				handler(AgentEvent{Kind: EventSteerInjected, Messages: msgs, Steer: steerItems})
 			}
 		}
 

--- a/internal/agent/content.go
+++ b/internal/agent/content.go
@@ -64,6 +64,12 @@ type ContentBlock struct {
 	// (Claude, GPT-4o, Kimi k2.6, etc.). The provider adapter serialises it to
 	// the vendor-specific wire format (Anthropic base64 source, OpenAI data URL).
 	Image *ImageData `json:"-"`
+
+	// ImagePath points at a persisted on-disk copy of Image (type=="image").
+	// Image bytes are never serialised into the session transcript; a block
+	// saved with a path is rehydrated from it by LoadSession so a resumed
+	// conversation can re-send the image to the provider.
+	ImagePath string `json:"image_path,omitempty"`
 }
 
 // ImageData holds raw image bytes and their MIME type for multimodal uploads.

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -127,6 +127,11 @@ type AgentEvent struct {
 	Reply      *Reply         `json:"reply,omitempty"`
 	Messages   []string       `json:"messages,omitempty"`
 	Compact    *CompactStats  `json:"compact,omitempty"`
+
+	// Steer carries the full inbox items behind an EventSteerInjected —
+	// including attachment blocks — for handlers that render more than the
+	// plain texts in Messages.
+	Steer []InboxItem `json:"-"`
 }
 
 // CompactStats carries the numbers behind the compaction events. BeforeTokens

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -345,8 +345,54 @@ func LoadSession(id string) (*Session, error) {
 		// Meta line was missing/corrupt — fall back to the filename stem.
 		s.ID = strings.TrimSuffix(filepath.Base(path), ".jsonl")
 	}
+	rehydrateImageBlocks(s.Messages)
 	s.persisted = len(s.Messages) // a resumed session continues appending
 	return s, nil
+}
+
+// rehydrateImageBlocks reloads persisted image attachments (ImagePath) into
+// memory so provider adapters can re-send them on resumed turns — image bytes
+// are never serialised into the transcript itself. A block whose file is gone,
+// or a legacy block saved without a path, degrades to a text placeholder: the
+// anthropic adapter hard-errors on an image block with no data, which would
+// otherwise make every later turn of the resumed session fail.
+func rehydrateImageBlocks(msgs []Message) {
+	for mi := range msgs {
+		for bi := range msgs[mi].Blocks {
+			b := &msgs[mi].Blocks[bi]
+			if b.Type != "image" || b.Image != nil {
+				continue
+			}
+			if b.ImagePath != "" {
+				if data, err := os.ReadFile(b.ImagePath); err == nil {
+					b.Image = &ImageData{MIMEType: imageMIMEFromPath(b.ImagePath), Data: data}
+					continue
+				}
+			}
+			name := "image"
+			if b.ImagePath != "" {
+				name = filepath.Base(b.ImagePath)
+			}
+			*b = NewTextBlock("[image attachment no longer available: " + name + "]")
+		}
+	}
+}
+
+// imageMIMEFromPath maps a file extension to its image MIME type, defaulting
+// to JPEG (the web UI re-encodes every image upload as JPEG).
+func imageMIMEFromPath(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".png":
+		return "image/png"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".bmp":
+		return "image/bmp"
+	default:
+		return "image/jpeg"
+	}
 }
 
 // resolveSessionPath maps an id (bare, suffixed, or absolute path) to the

--- a/internal/agent/session_image_test.go
+++ b/internal/agent/session_image_test.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// LoadSession must reload persisted image attachments from ImagePath (bytes
+// are never serialised into the transcript), and degrade gracefully — the
+// anthropic adapter hard-errors on an image block with no data, so a husk
+// left in history would fail every later turn of the resumed session.
+func TestLoadSession_RehydratesImageBlocks(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	imgPath := filepath.Join(tmp, "pic.png")
+	payload := []byte{0x89, 'P', 'N', 'G', 1, 2, 3}
+	if err := os.WriteFile(imgPath, payload, 0o600); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	sess := NewSession("m", "")
+	block := ContentBlock{Type: "image", ImagePath: imgPath}
+	sess.Messages = append(sess.Messages, Message{
+		Role:   RoleUser,
+		Blocks: []ContentBlock{NewTextBlock("look at this"), block},
+	})
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	blocks := loaded.Messages[0].Blocks
+	if len(blocks) != 2 {
+		t.Fatalf("blocks = %d, want 2", len(blocks))
+	}
+	img := blocks[1]
+	if img.Type != "image" || img.Image == nil {
+		t.Fatalf("image block not rehydrated: %+v", img)
+	}
+	if string(img.Image.Data) != string(payload) {
+		t.Errorf("rehydrated bytes mismatch")
+	}
+	if img.Image.MIMEType != "image/png" {
+		t.Errorf("MIMEType = %q, want image/png", img.Image.MIMEType)
+	}
+}
+
+func TestLoadSession_MissingImageFileBecomesPlaceholder(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := NewSession("m", "")
+	sess.Messages = append(sess.Messages, Message{
+		Role: RoleUser,
+		Blocks: []ContentBlock{
+			{Type: "image", ImagePath: filepath.Join(tmp, "gone.jpg")},
+			{Type: "image"}, // legacy husk saved before ImagePath existed
+		},
+	})
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	for i, b := range loaded.Messages[0].Blocks {
+		if b.Type != "text" {
+			t.Errorf("block %d type = %q, want text placeholder", i, b.Type)
+		}
+		if !strings.Contains(b.Text, "no longer available") {
+			t.Errorf("block %d text = %q", i, b.Text)
+		}
+	}
+}

--- a/internal/server/attachments.go
+++ b/internal/server/attachments.go
@@ -1,0 +1,171 @@
+package server
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// User attachments sent over the WebSocket message payload. Images arrive as
+// data URLs (the composer compresses them client-side); documents were already
+// uploaded via POST /api/upload and arrive as an /api/uploads/ URL reference.
+
+// userAttachments is the parsed, persisted form of a WS message's files array.
+type userAttachments struct {
+	// blocks are image content blocks for the model: decoded bytes plus the
+	// path of the on-disk copy the session transcript will reference.
+	blocks []agent.ContentBlock
+	// images are frontend display refs for the user bubble: an /api/uploads/
+	// URL for an image thumbnail, or a "pdf:<name>" badge sentinel for a
+	// document (the convention the history renderer already understands).
+	images []string
+	// notes are text lines folded into the message so the model learns the
+	// on-disk path of each document attachment (read_file can open them).
+	notes []string
+}
+
+// ensureUploadsDir returns ~/.octo/uploads, creating it if needed.
+func ensureUploadsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("uploads: home dir: %w", err)
+	}
+	dir := filepath.Join(home, ".octo", uploadsDirName)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("uploads: mkdir: %w", err)
+	}
+	return dir, nil
+}
+
+// parseUserFiles converts a WS files payload into model blocks, display refs,
+// and document path notes. Per-file failures are logged and skipped so one bad
+// attachment doesn't drop the rest of the message.
+func parseUserFiles(files []wsUserFile) userAttachments {
+	var att userAttachments
+	for _, f := range files {
+		switch {
+		case f.DataURL != "":
+			block, url, err := saveImageAttachment(f.Name, f.DataURL)
+			if err != nil {
+				log.Printf("[ws] image attachment %q: %v", f.Name, err)
+				continue
+			}
+			att.blocks = append(att.blocks, block)
+			att.images = append(att.images, url)
+		case f.Path != "":
+			dir, err := ensureUploadsDir()
+			if err != nil {
+				log.Printf("[ws] file attachment %q: %v", f.Name, err)
+				continue
+			}
+			// The composer sends back the /api/uploads/<name> URL that
+			// POST /api/upload returned; map it to the file on disk.
+			abs := filepath.Join(dir, filepath.Base(f.Path))
+			if _, err := os.Stat(abs); err != nil {
+				log.Printf("[ws] file attachment %q: %v", f.Name, err)
+				continue
+			}
+			att.images = append(att.images, "pdf:"+f.Name)
+			att.notes = append(att.notes, fmt.Sprintf("[Attached file: %s]", abs))
+		}
+	}
+	return att
+}
+
+// saveImageAttachment decodes a base64 data URL, persists the bytes under
+// ~/.octo/uploads (the transcript stores the path, never the bytes), and
+// returns the model-facing image block plus the /api/uploads/ display URL.
+func saveImageAttachment(name, dataURL string) (agent.ContentBlock, string, error) {
+	mime, data, err := decodeDataURL(dataURL)
+	if err != nil {
+		return agent.ContentBlock{}, "", err
+	}
+
+	dir, err := ensureUploadsDir()
+	if err != nil {
+		return agent.ContentBlock{}, "", err
+	}
+
+	// Basename only, no traversal; the stored extension is derived from the
+	// actual MIME type (the composer re-encodes to JPEG but keeps the original
+	// filename) so rehydration and Content-Type sniffing stay truthful.
+	base := strings.ReplaceAll(filepath.Base(name), "..", "_")
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		base = "image"
+	}
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	dstName := fmt.Sprintf("%d_%s%s", time.Now().UnixNano(), base, extForImageMIME(mime))
+	dstPath := filepath.Join(dir, dstName)
+	if err := os.WriteFile(dstPath, data, 0o600); err != nil {
+		return agent.ContentBlock{}, "", fmt.Errorf("write %s: %w", dstPath, err)
+	}
+
+	block := agent.NewImageBlock(mime, data)
+	block.ImagePath = dstPath
+	return block, "/api/uploads/" + dstName, nil
+}
+
+// decodeDataURL splits "data:<mime>;base64,<payload>" into its parts.
+func decodeDataURL(dataURL string) (mime string, data []byte, err error) {
+	rest, ok := strings.CutPrefix(dataURL, "data:")
+	if !ok {
+		return "", nil, fmt.Errorf("not a data URL")
+	}
+	meta, payload, ok := strings.Cut(rest, ",")
+	if !ok {
+		return "", nil, fmt.Errorf("malformed data URL")
+	}
+	mime, _, _ = strings.Cut(meta, ";")
+	if !strings.HasPrefix(mime, "image/") {
+		return "", nil, fmt.Errorf("unsupported attachment type %q", mime)
+	}
+	data, err = base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return "", nil, fmt.Errorf("decode base64: %w", err)
+	}
+	if len(data) == 0 {
+		return "", nil, fmt.Errorf("empty image payload")
+	}
+	return mime, data, nil
+}
+
+// extForImageMIME picks the stored file extension for an image MIME type.
+func extForImageMIME(mime string) string {
+	switch mime {
+	case "image/png":
+		return ".png"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	case "image/bmp":
+		return ".bmp"
+	default:
+		return ".jpg"
+	}
+}
+
+// ─── GET /api/uploads/{name} ────────────────────────────────────────────────
+
+// handleGetUpload serves a previously uploaded attachment back to the browser;
+// image thumbnails in chat history reference /api/uploads/<name>.
+func (s *Server) handleGetUpload(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" || name != filepath.Base(name) || strings.Contains(name, "..") {
+		writeError(w, http.StatusBadRequest, "invalid file name")
+		return
+	}
+	dir, err := ensureUploadsDir()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	http.ServeFile(w, r, filepath.Join(dir, name))
+}

--- a/internal/server/attachments.go
+++ b/internal/server/attachments.go
@@ -136,6 +136,18 @@ func decodeDataURL(dataURL string) (mime string, data []byte, err error) {
 	return mime, data, nil
 }
 
+// imageRefsFromBlocks derives the frontend thumbnail URLs for a message's
+// persisted image blocks (blocks without an on-disk copy are skipped).
+func imageRefsFromBlocks(blocks []agent.ContentBlock) []string {
+	var refs []string
+	for _, b := range blocks {
+		if b.Type == "image" && b.ImagePath != "" {
+			refs = append(refs, "/api/uploads/"+filepath.Base(b.ImagePath))
+		}
+	}
+	return refs
+}
+
 // extForImageMIME picks the stored file extension for an image MIME type.
 func extForImageMIME(mime string) string {
 	switch mime {

--- a/internal/server/attachments_test.go
+++ b/internal/server/attachments_test.go
@@ -1,0 +1,231 @@
+package server
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+func jpegDataURL(payload []byte) string {
+	return "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(payload)
+}
+
+func TestParseUserFiles_ImageDataURL(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	payload := []byte{0xFF, 0xD8, 0xFF, 1, 2, 3}
+	att := parseUserFiles([]wsUserFile{
+		{Name: "shot.png", MimeType: "image/jpeg", DataURL: jpegDataURL(payload)},
+	})
+
+	if len(att.blocks) != 1 || len(att.images) != 1 || len(att.notes) != 0 {
+		t.Fatalf("blocks/images/notes = %d/%d/%d, want 1/1/0",
+			len(att.blocks), len(att.images), len(att.notes))
+	}
+	b := att.blocks[0]
+	if b.Type != "image" || b.Image == nil {
+		t.Fatalf("block = %+v", b)
+	}
+	if string(b.Image.Data) != string(payload) {
+		t.Errorf("decoded bytes mismatch")
+	}
+	if b.Image.MIMEType != "image/jpeg" {
+		t.Errorf("MIMEType = %q", b.Image.MIMEType)
+	}
+	// Persisted copy exists, carries a MIME-true extension, and the display
+	// URL references it.
+	if b.ImagePath == "" {
+		t.Fatal("ImagePath not set")
+	}
+	if filepath.Ext(b.ImagePath) != ".jpg" {
+		t.Errorf("stored ext = %q, want .jpg (MIME-derived)", filepath.Ext(b.ImagePath))
+	}
+	onDisk, err := os.ReadFile(b.ImagePath)
+	if err != nil || string(onDisk) != string(payload) {
+		t.Errorf("persisted copy: err=%v, match=%v", err, string(onDisk) == string(payload))
+	}
+	wantURL := "/api/uploads/" + filepath.Base(b.ImagePath)
+	if att.images[0] != wantURL {
+		t.Errorf("display URL = %q, want %q", att.images[0], wantURL)
+	}
+}
+
+func TestParseUserFiles_DocPath(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	dir, err := ensureUploadsDir()
+	if err != nil {
+		t.Fatalf("uploads dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "123_report.pdf"), []byte("pdf"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	att := parseUserFiles([]wsUserFile{
+		{Name: "report.pdf", MimeType: "application/pdf", Path: "/api/uploads/123_report.pdf"},
+	})
+
+	if len(att.blocks) != 0 || len(att.images) != 1 || len(att.notes) != 1 {
+		t.Fatalf("blocks/images/notes = %d/%d/%d, want 0/1/1",
+			len(att.blocks), len(att.images), len(att.notes))
+	}
+	if att.images[0] != "pdf:report.pdf" {
+		t.Errorf("badge sentinel = %q", att.images[0])
+	}
+	wantPath := filepath.Join(dir, "123_report.pdf")
+	if !strings.Contains(att.notes[0], wantPath) {
+		t.Errorf("note %q does not reference %q", att.notes[0], wantPath)
+	}
+}
+
+func TestParseUserFiles_SkipsBadEntries(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	att := parseUserFiles([]wsUserFile{
+		{Name: "bad.jpg", DataURL: "not-a-data-url"},
+		{Name: "evil.pdf", Path: "/api/uploads/does-not-exist.pdf"},
+		{Name: "text.txt", DataURL: "data:text/plain;base64,aGk="}, // non-image data URL
+	})
+	if len(att.blocks) != 0 || len(att.images) != 0 || len(att.notes) != 0 {
+		t.Errorf("bad entries not skipped: %+v", att)
+	}
+}
+
+func TestHandleGetUpload(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	dir, err := ensureUploadsDir()
+	if err != nil {
+		t.Fatalf("uploads dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "1_pic.jpg"), []byte("img-bytes"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	ts := httptest.NewServer(srv.http.Handler)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/uploads/1_pic.jpg")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Traversal must be rejected.
+	for _, bad := range []string{"..%2F..%2Fsecret", "a%2Fb.jpg"} {
+		resp, err := http.Get(ts.URL + "/api/uploads/" + bad)
+		if err != nil {
+			t.Fatalf("get %s: %v", bad, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			t.Errorf("traversal %q served with 200", bad)
+		}
+	}
+}
+
+// TestHandleWSUserMessage_ImageOnly is the regression guard for the web-UI
+// "sent an image, nothing happened" bug: handleWSUserMessage ignored
+// msg.Files entirely and returned early on empty text, silently dropping
+// image-only messages.
+func TestHandleWSUserMessage_ImageOnly(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]string)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+	srv.wsHub.subscribe(conn, sess.ID)
+
+	payload := []byte{0xFF, 0xD8, 0xFF, 9, 9}
+	srv.handleWSUserMessage(conn, &wsMsgUserMessage{
+		SessionID: sess.ID,
+		Content:   json.RawMessage(`""`),
+		Files: []wsUserFile{
+			{Name: "shot.jpg", MimeType: "image/jpeg", DataURL: jpegDataURL(payload)},
+		},
+	})
+
+	// Drain broadcasts until the turn completes; the user-message event must
+	// carry the thumbnail URL.
+	var gotImages bool
+	deadline := time.After(5 * time.Second)
+drain:
+	for {
+		select {
+		case b := <-conn.send:
+			var ev map[string]any
+			if err := json.Unmarshal(b, &ev); err != nil {
+				continue
+			}
+			switch ev["type"] {
+			case "history_user_message":
+				if imgs, ok := ev["images"].([]any); ok && len(imgs) == 1 {
+					url, _ := imgs[0].(string)
+					if strings.HasPrefix(url, "/api/uploads/") {
+						gotImages = true
+					}
+				}
+			case "complete":
+				break drain
+			}
+		case <-deadline:
+			t.Fatal("turn did not complete — image-only message still dropped?")
+		}
+	}
+	if !gotImages {
+		t.Error("history_user_message carried no /api/uploads/ image ref")
+	}
+
+	// The persisted session must carry the image block with its file path.
+	loaded, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	var foundBlock bool
+	for _, m := range loaded.Messages {
+		for _, blk := range m.Blocks {
+			if blk.Type == "image" && blk.ImagePath != "" && blk.Image != nil {
+				foundBlock = true
+			}
+		}
+	}
+	if !foundBlock {
+		t.Error("no rehydratable image block persisted in session")
+	}
+}

--- a/internal/server/attachments_test.go
+++ b/internal/server/attachments_test.go
@@ -156,7 +156,7 @@ func TestHandleWSUserMessage_ImageOnly(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	srv.initWS()
 	srv.turnRunning = make(map[string]bool)
-	srv.steerQueues = make(map[string][]string)
+	srv.steerQueues = make(map[string][]agent.InboxItem)
 	srv.sessionAgents = make(map[string]*agent.Agent)
 
 	sess := agent.NewSession("stub-model", "")

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -342,8 +342,10 @@ func (s *Server) handleGetSessionMessages(w http.ResponseWriter, r *http.Request
 		case agent.RoleUser:
 			// Emit tool_result events for any tool_result blocks before the
 			// user message (they carry the actual output).
+			hasToolResult := false
 			for _, b := range m.Blocks {
 				if b.Type == "tool_result" {
+					hasToolResult = true
 					events = append(events, map[string]any{
 						"type":   "tool_result",
 						"result": b.Result,
@@ -359,14 +361,38 @@ func (s *Server) handleGetSessionMessages(w http.ResponseWriter, r *http.Request
 			if m.CreatedAt.IsZero() {
 				createdAt = int64(i + 1)
 			}
-			// Only emit history_user_message if there is actual text content
+			// A multipart user message (image attachments) carries its text
+			// in blocks rather than Content, and its images as blocks whose
+			// persisted file maps to an /api/uploads/ thumbnail URL. Blocks
+			// of a tool_result message are tool bookkeeping, not user input.
+			text := m.Content
+			var images []string
+			if !hasToolResult {
+				for _, b := range m.Blocks {
+					switch b.Type {
+					case "text":
+						if text == "" {
+							text = b.Text
+						}
+					case "image":
+						if b.ImagePath != "" {
+							images = append(images, "/api/uploads/"+filepath.Base(b.ImagePath))
+						}
+					}
+				}
+			}
+			// Only emit history_user_message if there is user-visible content
 			// (tool_result-only messages are bookkeeping, not user-visible).
-			if m.Content != "" {
-				events = append(events, map[string]any{
+			if text != "" || len(images) > 0 {
+				ev := map[string]any{
 					"type":       "history_user_message",
-					"content":    m.Content,
+					"content":    text,
 					"created_at": createdAt,
-				})
+				}
+				if len(images) > 0 {
+					ev["images"] = images
+				}
+				events = append(events, ev)
 			}
 		case agent.RoleAssistant:
 			// Emit tool_call events for any tool_use blocks.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -340,6 +340,7 @@ func (s *Server) registerRoutes() {
 
 	// Upload
 	s.mux.HandleFunc("POST /api/upload", s.requireAuth(s.handleUpload))
+	s.mux.HandleFunc("GET /api/uploads/{name}", s.requireAuth(s.handleGetUpload))
 
 	// File action (open / download)
 	s.mux.HandleFunc("POST /api/file-action", s.requireAuth(s.handleFileAction))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -94,7 +94,7 @@ type Server struct {
 
 	// steerQueues holds mid-turn user messages (steer) that arrive while a
 	// turn is in flight.  Consumed by the turn loop after each iteration.
-	steerQueues map[string][]string
+	steerQueues map[string][]agent.InboxItem
 	steerMu     sync.Mutex
 
 	// sessionAgents tracks the currently-running Agent per session so that
@@ -188,7 +188,7 @@ func New(cfg Config) (*Server, error) {
 		homeMemDir:       homeMemDir,
 		turnLocks:        map[string]*sync.Mutex{},
 		turnRunning:      make(map[string]bool),
-		steerQueues:      make(map[string][]string),
+		steerQueues:      make(map[string][]agent.InboxItem),
 		sessionAgents:    make(map[string]*agent.Agent),
 		accessKey:        accessKey,
 		questionChans:    make(map[string]chan tools.AskResponse),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -867,7 +867,7 @@ func TestDoAgentTurn_SeedsThinkingProgress(t *testing.T) {
 	// Maps doAgentTurn touches that the full constructor sets up but mustServer
 	// (a minimal hand-built Server) does not.
 	srv.turnRunning = make(map[string]bool)
-	srv.steerQueues = make(map[string][]string)
+	srv.steerQueues = make(map[string][]agent.InboxItem)
 	srv.sessionAgents = make(map[string]*agent.Agent)
 
 	sess := agent.NewSession("stub-model", "")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -884,7 +884,7 @@ func TestDoAgentTurn_SeedsThinkingProgress(t *testing.T) {
 	srv.wsHub.register <- conn
 	srv.wsHub.subscribe(conn, sess.ID)
 
-	srv.doAgentTurn(sess, "hi")
+	srv.doAgentTurn(sess, "hi", nil, nil)
 
 	// Broadcast is async through the hub's event loop; drain until the turn's
 	// terminal "complete" event (or a safety deadline).

--- a/internal/server/steer_probe_test.go
+++ b/internal/server/steer_probe_test.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// midTurnSender simulates a user message arriving while the LLM call is in
+// flight: its first round invokes the injected callback (which feeds the real
+// handleWSUserMessage), then answers like the stub. Guarded by a mutex — the
+// after-turn suggestion goroutine calls the sender concurrently.
+type midTurnSender struct {
+	inject func()
+	mu     sync.Mutex
+	rounds int
+}
+
+func (s *midTurnSender) SendMessages(_ context.Context, _, _ string, _ []agent.Message, _ int) (agent.Reply, error) {
+	s.mu.Lock()
+	s.rounds++
+	first := s.rounds == 1
+	s.mu.Unlock()
+	if first && s.inject != nil {
+		s.inject()
+	}
+	return agent.Reply{Content: "stub reply"}, nil
+}
+
+// TestMidTurnSteer_DeliveredOnceWithImage guards two behaviours of the
+// mid-turn (steer) path:
+//
+//  1. Single delivery. A steer message used to be enqueued into BOTH the
+//     server steerQueues and the running Agent's Inbox, so it was answered
+//     and persisted twice (once by the post-turn leftover drain, once by the
+//     chained turn).
+//  2. Image attachments ride the Inbox as real content blocks
+//     (EnqueueWithBlocks), exactly like the TUI's mid-turn paste — not as a
+//     degraded text note.
+func TestMidTurnSteer_DeliveredOnceWithImage(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]agent.InboxItem)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	payload := []byte{0xFF, 0xD8, 0xFF, 7, 7}
+	srv.sender = &midTurnSender{inject: func() {
+		srv.handleWSUserMessage(nil, &wsMsgUserMessage{
+			SessionID: sess.ID,
+			Content:   json.RawMessage(`"steer-msg"`),
+			Files: []wsUserFile{
+				{Name: "mid.jpg", MimeType: "image/jpeg", DataURL: jpegDataURL(payload)},
+			},
+		})
+	}}
+
+	// Mirror handleWSUserMessage's idle branch: mark the turn running, then
+	// run the loop (the injected steer arrives during round 1's LLM call).
+	srv.turnRunning[sess.ID] = true
+	srv.runAgentTurnLoop(sess, "first-msg", nil, nil)
+
+	loaded, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	textCount, imageCount := 0, 0
+	for i, m := range loaded.Messages {
+		t.Logf("msg[%d] role=%s content=%q blocks=%d", i, m.Role, m.Content, len(m.Blocks))
+		if m.Role != agent.RoleUser {
+			continue
+		}
+		if m.Content == "steer-msg" {
+			textCount++
+		}
+		for _, b := range m.Blocks {
+			if b.Type == "text" && b.Text == "steer-msg" {
+				textCount++
+			}
+			if b.Type == "image" && b.ImagePath != "" {
+				imageCount++
+			}
+		}
+	}
+	if textCount != 1 {
+		t.Errorf("steer-msg appears %d times in transcript, want 1", textCount)
+	}
+	if imageCount != 1 {
+		t.Errorf("steer image block appears %d times in transcript, want 1", imageCount)
+	}
+}

--- a/internal/server/upload_handler.go
+++ b/internal/server/upload_handler.go
@@ -27,14 +27,9 @@ func (s *Server) handleUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	home, err := os.UserHomeDir()
+	uploadDir, err := ensureUploadsDir()
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "cannot determine home dir")
-		return
-	}
-	uploadDir := filepath.Join(home, ".octo", uploadsDirName)
-	if err := os.MkdirAll(uploadDir, 0o700); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("mkdir: %v", err))
+		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -121,24 +120,20 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 
 	if s.turnRunning[sess.ID] {
 		mu.Unlock()
-		// The steer queue and Inbox are text-only, so a mid-turn image rides
-		// as a path note: read_file returns it as an image block, so the
-		// model can still view it on the next iteration.
-		if len(att.blocks) > 0 {
-			var lines []string
-			for _, b := range att.blocks {
-				lines = append(lines, fmt.Sprintf("[Attached image: %s — open it with read_file to view]", b.ImagePath))
-			}
-			content = strings.TrimSpace(content + "\n\n" + strings.Join(lines, "\n"))
-		}
-		s.enqueueSteer(sess.ID, content)
-		// Also inject into the running Agent's Inbox so the runLoop can
-		// drain it between tool-call iterations.
+		// A mid-turn message has exactly one home: the running Agent's Inbox
+		// when it is registered (the runLoop drains it between iterations —
+		// attachment blocks and all), the steer queue otherwise (consumed by
+		// runAgentTurnLoop as the next chained turn). Enqueueing into both,
+		// as this branch once did, processed the same message twice.
 		s.sessionAgentsMu.Lock()
-		if a := s.sessionAgents[sess.ID]; a != nil {
-			a.Inbox.Enqueue(content)
+		a := s.sessionAgents[sess.ID]
+		if a != nil {
+			a.Inbox.EnqueueWithBlocks(content, att.blocks)
 		}
 		s.sessionAgentsMu.Unlock()
+		if a == nil {
+			s.enqueueSteer(sess.ID, agent.InboxItem{Text: content, Blocks: att.blocks})
+		}
 		// The frontend already rendered a ghost bubble in _sendMessage;
 		// history_user_message (broadcast when the turn drains steer) will
 		// replace it.  No need for a separate pending_user_messages event.
@@ -223,7 +218,6 @@ func (s *Server) handleWSRetry(conn *wsConn, sessionID string) {
 	// retried turn re-sends them.
 	content := userMsg.Content
 	var blocks []agent.ContentBlock
-	var images []string
 	for _, b := range userMsg.Blocks {
 		switch b.Type {
 		case "text":
@@ -232,11 +226,9 @@ func (s *Server) handleWSRetry(conn *wsConn, sessionID string) {
 			}
 		case "image":
 			blocks = append(blocks, b)
-			if b.ImagePath != "" {
-				images = append(images, "/api/uploads/"+filepath.Base(b.ImagePath))
-			}
 		}
 	}
+	images := imageRefsFromBlocks(blocks)
 
 	s.turnRunning[sess.ID] = true
 	mu.Unlock()
@@ -328,29 +320,37 @@ func (s *Server) runAgentTurnLoop(sess *agent.Session, initialContent string, bl
 	content := initialContent
 	for {
 		s.doAgentTurn(sess, content, blocks, images)
-		// Attachments belong to the initial message only; steer follow-ups
-		// are plain text.
-		blocks, images = nil, nil
-		steerMsgs := s.drainSteer(sess.ID)
-		if len(steerMsgs) == 0 {
+		steerItems := s.drainSteer(sess.ID)
+		if len(steerItems) == 0 {
 			break
 		}
-		content = strings.Join(steerMsgs, "\n\n")
+		// Fold the queued steer items into one chained turn: texts joined,
+		// attachment blocks carried over, thumbnails re-derived.
+		var texts []string
+		blocks = nil
+		for _, it := range steerItems {
+			if strings.TrimSpace(it.Text) != "" {
+				texts = append(texts, it.Text)
+			}
+			blocks = append(blocks, it.Blocks...)
+		}
+		content = strings.Join(texts, "\n\n")
+		images = imageRefsFromBlocks(blocks)
 	}
 }
 
-func (s *Server) enqueueSteer(sessionID, content string) {
+func (s *Server) enqueueSteer(sessionID string, items ...agent.InboxItem) {
 	s.steerMu.Lock()
-	s.steerQueues[sessionID] = append(s.steerQueues[sessionID], content)
+	s.steerQueues[sessionID] = append(s.steerQueues[sessionID], items...)
 	s.steerMu.Unlock()
 }
 
-func (s *Server) drainSteer(sessionID string) []string {
+func (s *Server) drainSteer(sessionID string) []agent.InboxItem {
 	s.steerMu.Lock()
-	msgs := s.steerQueues[sessionID]
+	items := s.steerQueues[sessionID]
 	s.steerQueues[sessionID] = nil
 	s.steerMu.Unlock()
-	return msgs
+	return items
 }
 
 func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent.ContentBlock, images []string) {
@@ -446,12 +446,8 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 
 	// Flush any steer messages that arrived before the Agent was built into
 	// the Agent's Inbox so the runLoop can drain them between iterations.
-	s.steerMu.Lock()
-	steerBacklog := s.steerQueues[sess.ID]
-	s.steerQueues[sess.ID] = nil
-	s.steerMu.Unlock()
-	for _, m := range steerBacklog {
-		a.Inbox.Enqueue(m)
+	for _, it := range s.drainSteer(sess.ID) {
+		a.Inbox.EnqueueWithBlocks(it.Text, it.Blocks)
 	}
 
 	// Register this Agent so concurrent mid-turn messages can reach its Inbox.
@@ -462,6 +458,16 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		s.sessionAgentsMu.Lock()
 		delete(s.sessionAgents, sess.ID)
 		s.sessionAgentsMu.Unlock()
+	}()
+	// Messages still in the Inbox when the turn ends — they arrived during the
+	// final LLM round, or the turn errored out before draining them — go back
+	// to the steer queue so runAgentTurnLoop chains them into the next turn,
+	// which answers, broadcasts, and persists them exactly once. (Runs before
+	// the deregistration defer above, so no message slips past both homes.)
+	defer func() {
+		if items := a.Inbox.Drain(); len(items) > 0 {
+			s.enqueueSteer(sess.ID, items...)
+		}
 	}()
 
 	var toolDefs []agent.ToolDefinition
@@ -526,22 +532,6 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			"reply":      map[string]any{"content": rCopy.Content},
 		})
 		sw.sendRaw(b)
-	}
-
-	// Drain inbox (steer/queued messages that arrived mid-turn). Surface them
-	// as user bubbles so they don't vanish from the transcript, and persist
-	// them into session history so they survive a page reload.
-	if items := a.Inbox.Drain(); len(items) > 0 {
-		for _, it := range items {
-			s.wsHub.broadcast(sess.ID, map[string]any{
-				"type":       "history_user_message",
-				"session_id": sess.ID,
-				"content":    it.Text,
-				"created_at": time.Now().UnixMilli(),
-			})
-			sess.Messages = append(sess.Messages, agent.NewUserMessage(it.Text))
-		}
-		_ = sess.Save()
 	}
 
 	s.wsHub.broadcast(sess.ID, map[string]any{
@@ -697,13 +687,26 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 		})
 
 	case agent.EventSteerInjected:
-		for _, msg := range ev.Messages {
-			w.hub.broadcast(w.sessionID, map[string]any{
+		// Prefer the full inbox items (text + attachment blocks) so a steer
+		// message's image thumbnails reach the bubble; Messages is the
+		// text-only fallback for events from older emitters.
+		items := ev.Steer
+		if len(items) == 0 {
+			for _, msg := range ev.Messages {
+				items = append(items, agent.InboxItem{Text: msg})
+			}
+		}
+		for _, it := range items {
+			evt := map[string]any{
 				"type":       "history_user_message",
 				"session_id": w.sessionID,
-				"content":    msg,
+				"content":    it.Text,
 				"created_at": time.Now().UnixMilli(),
-			})
+			}
+			if imgs := imageRefsFromBlocks(it.Blocks); len(imgs) > 0 {
+				evt["images"] = imgs
+			}
+			w.hub.broadcast(w.sessionID, evt)
 		}
 
 	case agent.EventTurnDone:

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -96,8 +97,14 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 	}
 
 	content := extractTextContent(msg.Content)
-	if content == "" {
+	att := parseUserFiles(msg.Files)
+	if content == "" && len(att.blocks) == 0 && len(att.notes) == 0 {
 		return
+	}
+	// Document attachments ride as path notes in the text so the model can
+	// read_file them and the transcript keeps a visible record.
+	if len(att.notes) > 0 {
+		content = strings.TrimSpace(content + "\n\n" + strings.Join(att.notes, "\n"))
 	}
 
 	sess, err := agent.LoadSession(sid)
@@ -114,6 +121,16 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 
 	if s.turnRunning[sess.ID] {
 		mu.Unlock()
+		// The steer queue and Inbox are text-only, so a mid-turn image rides
+		// as a path note: read_file returns it as an image block, so the
+		// model can still view it on the next iteration.
+		if len(att.blocks) > 0 {
+			var lines []string
+			for _, b := range att.blocks {
+				lines = append(lines, fmt.Sprintf("[Attached image: %s — open it with read_file to view]", b.ImagePath))
+			}
+			content = strings.TrimSpace(content + "\n\n" + strings.Join(lines, "\n"))
+		}
 		s.enqueueSteer(sess.ID, content)
 		// Also inject into the running Agent's Inbox so the runLoop can
 		// drain it between tool-call iterations.
@@ -137,7 +154,7 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 			s.turnRunning[sess.ID] = false
 			mu.Unlock()
 		}()
-		s.runAgentTurnLoop(sess, content)
+		s.runAgentTurnLoop(sess, content, att.blocks, att.images)
 	}()
 }
 
@@ -201,6 +218,26 @@ func (s *Server) handleWSRetry(conn *wsConn, sessionID string) {
 	sess.Messages = sess.Messages[:lastUserIdx]
 	_ = sess.Save()
 
+	// A multipart user message (image attachments) keeps its text in a text
+	// block; re-attach the image blocks (rehydrated by LoadSession) so the
+	// retried turn re-sends them.
+	content := userMsg.Content
+	var blocks []agent.ContentBlock
+	var images []string
+	for _, b := range userMsg.Blocks {
+		switch b.Type {
+		case "text":
+			if content == "" {
+				content = b.Text
+			}
+		case "image":
+			blocks = append(blocks, b)
+			if b.ImagePath != "" {
+				images = append(images, "/api/uploads/"+filepath.Base(b.ImagePath))
+			}
+		}
+	}
+
 	s.turnRunning[sess.ID] = true
 	mu.Unlock()
 
@@ -210,7 +247,7 @@ func (s *Server) handleWSRetry(conn *wsConn, sessionID string) {
 			s.turnRunning[sess.ID] = false
 			mu.Unlock()
 		}()
-		s.runAgentTurnLoop(sess, userMsg.Content)
+		s.runAgentTurnLoop(sess, content, blocks, images)
 	}()
 }
 
@@ -287,10 +324,13 @@ func joinNonEmpty(parts []string, sep string) string {
 //
 // doAgentTurn is the single-turn body shared by the loop and retry paths.
 
-func (s *Server) runAgentTurnLoop(sess *agent.Session, initialContent string) {
+func (s *Server) runAgentTurnLoop(sess *agent.Session, initialContent string, blocks []agent.ContentBlock, images []string) {
 	content := initialContent
 	for {
-		s.doAgentTurn(sess, content)
+		s.doAgentTurn(sess, content, blocks, images)
+		// Attachments belong to the initial message only; steer follow-ups
+		// are plain text.
+		blocks, images = nil, nil
 		steerMsgs := s.drainSteer(sess.ID)
 		if len(steerMsgs) == 0 {
 			break
@@ -313,21 +353,35 @@ func (s *Server) drainSteer(sessionID string) []string {
 	return msgs
 }
 
-func (s *Server) doAgentTurn(sess *agent.Session, content string) {
+func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent.ContentBlock, images []string) {
 	// Confirm the user message immediately so the frontend can swap the
 	// ghost (.msg-pending) bubble for the real one before streaming starts.
-	s.wsHub.broadcast(sess.ID, map[string]any{
+	userEvent := map[string]any{
 		"type":       "history_user_message",
 		"session_id": sess.ID,
 		"content":    content,
 		"created_at": time.Now().UnixMilli(),
-	})
+	}
+	if len(images) > 0 {
+		userEvent["images"] = images
+	}
+	s.wsHub.broadcast(sess.ID, userEvent)
 
 	// Persist the user message right away so a page refresh mid-turn doesn't
 	// lose it.  We append it for Save(), then pop it back off so buildAgent
 	// doesn't double-count it — RunStream will add the same message to
-	// a.History via appendUserInput.
-	sess.Messages = append(sess.Messages, agent.NewUserMessage(content))
+	// a.History via appendUserInput. Mirror appendUserInput's multipart shape
+	// (optional text block, then attachments) so the persisted line matches.
+	userMsg := agent.NewUserMessage(content)
+	if len(blocks) > 0 {
+		multi := make([]agent.ContentBlock, 0, len(blocks)+1)
+		if content != "" {
+			multi = append(multi, agent.NewTextBlock(content))
+		}
+		userMsg.Content = ""
+		userMsg.Blocks = append(multi, blocks...)
+	}
+	sess.Messages = append(sess.Messages, userMsg)
 	_ = sess.Save()
 	sess.Messages = sess.Messages[:len(sess.Messages)-1]
 
@@ -384,6 +438,11 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string) {
 	}()
 
 	a := s.buildAgent(sess)
+	if len(blocks) > 0 {
+		// Image attachments fold into the same user turn as the text when
+		// RunStream appends the user input.
+		a.AttachUserBlocks(blocks)
+	}
 
 	// Flush any steer messages that arrived before the Agent was built into
 	// the Agent's Inbox so the runLoop can drain them between iterations.

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -26,8 +26,13 @@ type wsMsgUserMessage struct {
 }
 
 type wsUserFile struct {
-	Name    string `json:"name"`
+	Name string `json:"name"`
+	// DataURL carries an image attachment inline (base64 data URL).
 	DataURL string `json:"data_url,omitempty"`
+	// Path references a document already uploaded via POST /api/upload
+	// (an /api/uploads/<name> URL).
+	Path     string `json:"path,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
 }
 
 type wsMsgInterrupt struct {


### PR DESCRIPTION
## Problem

Web 端发图片后气泡里看不到图、也不知道发没发成功:

- `handleWSUserMessage` 只读了文本,`msg.Files` 从未被读取(自 #417 Ruby→Go 迁移起就没实现);
- 纯图片无文字的消息命中 `content == ""` 早退,服务端无任何响应 —— ghost 气泡的 spinner 永远转;
- 带文字的图片消息:文字正常,但服务端回的 `history_user_message` 没有 `images`,替换 ghost 气泡后缩略图消失。

前端(composer、ws-dispatcher、历史渲染器)对 `files`/`images` 协议的支持一直是完整的,本修复纯服务端 + agent 层。

## Fix

**空闲路径(`ws_handlers.go` + 新增 `attachments.go`)**
- 解析 `msg.Files`:图片 data URL 解码 → 落盘 `~/.octo/uploads/` → 经 `Agent.AttachUserBlocks` 作为 image block 进入本轮 user turn(视觉模型直接可见);文档类附件(已经过 `POST /api/upload`)以路径注记并入文本,模型可 `read_file`;
- `history_user_message` 带上 `images` 数组(上传 URL / `pdf:` 徽标哨兵),真实气泡保留缩略图;
- 新增 `GET /api/uploads/{name}`,刷新页面后缩略图可加载;
- `GET /api/sessions/{id}/messages` 现在能从多段(blocks)user 消息提取文本和图片引用 —— 之前文本在 blocks 里的 user 消息会被整条跳过。

**中途(steer)路径 —— 与 TUI 同机制**
- `Inbox` 本就支持 `EnqueueWithBlocks`(TUI 中途贴图即此路径),web 中途附件同样以 image block 进入正在运行的 Agent Inbox,runLoop 在迭代间合入对话;
- 顺带修复一个探针验证过的存量双发 bug:#490 起中途消息同时进 `steerQueues` 和 Inbox,被处理两次(一次由 turn 后残留落盘/runLoop 中途消费,一次由 steer 链重放)。现在中途消息只有一个归属:Agent 已注册 → 只进 Inbox;否则 → 只进 steer 队列(已改为 `[]agent.InboxItem`,块随行);
- turn 结束时 Inbox 残留改为重新入队、由链式 turn 应答 —— 之前残留会被落盘成"无应答"消息,出错路径甚至直接丢失;
- `AgentEvent` 新增 `Steer` 字段携带完整 inbox 项,steer 气泡也能显示缩略图。

**持久化(存引用,不存字节)**
- `ContentBlock` 新增 `image_path`(持久化);`LoadSession` 据此回填图片字节;
- 文件丢失或旧版无路径的 image 块降级为文本占位 —— anthropic 适配器对无数据的 image block 直接报错,此前恢复带图会话后每一轮都会失败(TUI 贴图会话同样命中),此修复一并解决。

## Tests

- `TestLoadSession_RehydratesImageBlocks` / `TestLoadSession_MissingImageFileBecomesPlaceholder`
- `TestParseUserFiles_ImageDataURL` / `TestParseUserFiles_DocPath` / `TestParseUserFiles_SkipsBadEntries`
- `TestHandleGetUpload`(含路径穿越拒绝)
- `TestHandleWSUserMessage_ImageOnly` —— 纯图片消息完成一整轮,事件带 `/api/uploads/` 引用,会话持久化出可回填的 image block
- `TestMidTurnSteer_DeliveredOnceWithImage` —— 中途消息(带图)只投递一次,图片以 block 入库(该测试在旧代码上复现双发:同一条 steer 在 transcript 中出现两次)

`make test`(全量 -race)、`make vet`、`make fmt-check` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)