### PR TITLE
fix(web): auto-generate session titles after the first completed turn

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -102,6 +102,11 @@ type Server struct {
 	sessionAgents   map[string]*agent.Agent
 	sessionAgentsMu sync.Mutex
 
+	// titlePending guards one in-flight title generation per session
+	// (lazily initialised by claimTitleGeneration).
+	titlePending map[string]bool
+	titleMu      sync.Mutex
+
 	// WebSocket hub for real-time browser communication.
 	wsHub *wsHub
 

--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// TestDoAgentTurn_GeneratesSessionTitle is the regression guard for web
+// sessions never getting an auto-generated title: only the TUI called
+// GenerateTitle after the first turn, so web-created sessions stayed on the
+// first-message-snippet fallback forever.
+func TestDoAgentTurn_GeneratesSessionTitle(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]agent.InboxItem)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Registered but NOT subscribed to the session: session_renamed must be a
+	// global broadcast (the sidebar lists every session in every tab).
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+
+	srv.doAgentTurn(sess, "hello there", nil, nil)
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case b := <-conn.send:
+			var ev map[string]any
+			if err := json.Unmarshal(b, &ev); err != nil {
+				continue
+			}
+			if ev["type"] != "session_renamed" {
+				continue
+			}
+			if ev["session_id"] != sess.ID {
+				t.Errorf("session_id = %v, want %s", ev["session_id"], sess.ID)
+			}
+			if ev["name"] != "stub reply" {
+				t.Errorf("name = %v, want %q", ev["name"], "stub reply")
+			}
+			// The title must also be persisted.
+			loaded, err := agent.LoadSession(sess.ID)
+			if err != nil {
+				t.Fatalf("reload: %v", err)
+			}
+			if loaded.Title != "stub reply" {
+				t.Errorf("persisted Title = %q, want %q", loaded.Title, "stub reply")
+			}
+			return
+		case <-deadline:
+			t.Fatal("no session_renamed broadcast — title was never generated")
+		}
+	}
+}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -569,6 +569,32 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		"reasoning_effort": re,
 	})
 
+	// Once per session, after its first successful turn: generate a sidebar
+	// title (matches TUI titleCmd behaviour). Fire-and-forget; a failure is
+	// silent and simply retried after a later turn.
+	if err == nil && sess.Title == "" && s.claimTitleGeneration(sess.ID) {
+		go func() {
+			defer s.releaseTitleGeneration(sess.ID)
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+			t, terr := a.GenerateTitle(ctx, toolDefs)
+			if terr != nil || strings.TrimSpace(t) == "" {
+				return
+			}
+			if sess.SetTitle(t) != nil {
+				return
+			}
+			// Global broadcast: the sidebar lists every session, so every
+			// connected tab needs the rename, not just this session's
+			// subscribers.
+			s.wsHub.broadcast("", map[string]any{
+				"type":       "session_renamed",
+				"session_id": sess.ID,
+				"name":       t,
+			})
+		}()
+	}
+
 	// After-turn follow-up suggestion (matches TUI suggestCmd behaviour).
 	// Fire-and-forget: the frontend shows it as ghost text; failures are silent.
 	if err == nil {
@@ -586,6 +612,29 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			})
 		}()
 	}
+}
+
+// claimTitleGeneration marks a title generation in flight for the session;
+// it returns false when one is already running so concurrent turn ends don't
+// spend duplicate provider calls. The map is lazily initialised because tests
+// build minimal Servers by hand.
+func (s *Server) claimTitleGeneration(sessionID string) bool {
+	s.titleMu.Lock()
+	defer s.titleMu.Unlock()
+	if s.titlePending == nil {
+		s.titlePending = make(map[string]bool)
+	}
+	if s.titlePending[sessionID] {
+		return false
+	}
+	s.titlePending[sessionID] = true
+	return true
+}
+
+func (s *Server) releaseTitleGeneration(sessionID string) {
+	s.titleMu.Lock()
+	delete(s.titlePending, sessionID)
+	s.titleMu.Unlock()
 }
 
 // ─── wsStreamWriter ────────────────────────────────────────────────────────

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -573,15 +573,24 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// title (matches TUI titleCmd behaviour). Fire-and-forget; a failure is
 	// silent and simply retried after a later turn.
 	if err == nil && sess.Title == "" && s.claimTitleGeneration(sess.ID) {
+		sid := sess.ID
 		go func() {
-			defer s.releaseTitleGeneration(sess.ID)
+			defer s.releaseTitleGeneration(sid)
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 			defer cancel()
 			t, terr := a.GenerateTitle(ctx, toolDefs)
 			if terr != nil || strings.TrimSpace(t) == "" {
 				return
 			}
-			if sess.SetTitle(t) != nil {
+			// Apply the title to a freshly loaded Session, not the live one —
+			// chained steer turns keep appending to sess on the loop
+			// goroutine, and Session isn't goroutine-safe. A load that races
+			// a concurrent append just errors out and a later turn retries.
+			fresh, lerr := agent.LoadSession(sid)
+			if lerr != nil || fresh.Title != "" {
+				return
+			}
+			if fresh.SetTitle(t) != nil {
 				return
 			}
 			// Global broadcast: the sidebar lists every session, so every
@@ -589,7 +598,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			// subscribers.
 			s.wsHub.broadcast("", map[string]any{
 				"type":       "session_renamed",
-				"session_id": sess.ID,
+				"session_id": sid,
 				"name":       t,
 			})
 		}()


### PR DESCRIPTION
## Problem

Web 端新建的会话不会自动生成标题:`GenerateTitle` 只有 TUI 在调(`titleCmd`,首轮完成后触发),server 端从未调用,侧边栏永远停留在首条消息截断的 fallback 上。

## Fix

在 `doAgentTurn` 镜像 TUI `titleCmd` 语义:

- 无标题会话的首个成功 turn 之后,fire-and-forget goroutine 调 `GenerateTitle`(与主循环同一 toolbelt,命中 prompt cache);每会话同时只允许一个在途生成(`claimTitleGeneration`),失败静默、后续 turn 重试;
- `SetTitle` 持久化(append-only title 记录);
- 广播 `session_renamed` —— 用**全局**广播而非会话定向:侧边栏在每个 tab 都列出全部会话,只发给该会话的订阅者会漏掉其它 tab。前端对 `session_renamed` 的处理是现成的。

## Tests

- `TestDoAgentTurn_GeneratesSessionTitle` —— 回归:turn 完成后收到全局 `session_renamed`(连接未订阅该会话也能收到)、标题持久化到会话文件。

`make test`(全量 -race)、`make vet`、`make fmt-check` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)