### PR TITLE
fix(web): generate titles for sessions born with the "Session N" placeholder

### DIFF
--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -8,10 +8,30 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 )
 
+func TestIsAutoNamePlaceholder(t *testing.T) {
+	cases := []struct {
+		title string
+		want  bool
+	}{
+		{"", true},
+		{"  ", true},
+		{"Session 1", true},
+		{"Session 42", true},
+		{"Session", false},
+		{"修复登录问题", false},
+		{"My Session 2", false},
+	}
+	for _, c := range cases {
+		if got := isAutoNamePlaceholder(c.title); got != c.want {
+			t.Errorf("isAutoNamePlaceholder(%q) = %v, want %v", c.title, got, c.want)
+		}
+	}
+}
+
 // TestDoAgentTurn_GeneratesSessionTitle is the regression guard for web
-// sessions never getting an auto-generated title: only the TUI called
-// GenerateTitle after the first turn, so web-created sessions stayed on the
-// first-message-snippet fallback forever.
+// sessions never getting an auto-generated title. Two historical gaps: only
+// the TUI called GenerateTitle, and web sessions are created with a
+// "Session N" placeholder title that blocked the untitled-only gate.
 func TestDoAgentTurn_GeneratesSessionTitle(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -23,7 +43,10 @@ func TestDoAgentTurn_GeneratesSessionTitle(t *testing.T) {
 	srv.steerQueues = make(map[string][]agent.InboxItem)
 	srv.sessionAgents = make(map[string]*agent.Agent)
 
+	// Born with the frontend's auto-assigned placeholder, like every session
+	// created via POST /api/sessions.
 	sess := agent.NewSession("stub-model", "")
+	sess.Title = "Session 2"
 	if err := sess.Save(); err != nil {
 		t.Fatalf("save: %v", err)
 	}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -572,7 +573,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// Once per session, after its first successful turn: generate a sidebar
 	// title (matches TUI titleCmd behaviour). Fire-and-forget; a failure is
 	// silent and simply retried after a later turn.
-	if err == nil && sess.Title == "" && s.claimTitleGeneration(sess.ID) {
+	if err == nil && isAutoNamePlaceholder(sess.Title) && s.claimTitleGeneration(sess.ID) {
 		sid := sess.ID
 		go func() {
 			defer s.releaseTitleGeneration(sid)
@@ -587,7 +588,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			// goroutine, and Session isn't goroutine-safe. A load that races
 			// a concurrent append just errors out and a later turn retries.
 			fresh, lerr := agent.LoadSession(sid)
-			if lerr != nil || fresh.Title != "" {
+			if lerr != nil || !isAutoNamePlaceholder(fresh.Title) {
 				return
 			}
 			if fresh.SetTitle(t) != nil {
@@ -621,6 +622,18 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			})
 		}()
 	}
+}
+
+// sessionPlaceholderRe matches the frontend's auto-assigned "Session N"
+// default name on freshly created web sessions.
+var sessionPlaceholderRe = regexp.MustCompile(`^Session \d+$`)
+
+// isAutoNamePlaceholder reports whether a session title is absent or still the
+// frontend's "Session N" placeholder — both get replaced by a generated title
+// after the first completed turn. A name the user typed themselves is kept.
+func isAutoNamePlaceholder(title string) bool {
+	t := strings.TrimSpace(title)
+	return t == "" || sessionPlaceholderRe.MatchString(t)
 }
 
 // claimTitleGeneration marks a title generation in flight for the session;


### PR DESCRIPTION
## Problem

#533 的标题生成在 web 上没生效:前端 "+ New Session" 会带上自动编号的 `name: "Session N"`,`handleCreateSession` 把它持久化为 `Title` —— web 会话天生带标题,`Title == ""` 门禁永远不触发(TUI 会话无标题诞生,所以 TUI 一直正常)。

## Fix

新增 `isAutoNamePlaceholder`:空标题与 `^Session \d+$` 占位名同等对待,首轮完成后都会被生成的标题覆盖;用户手动输入的名字保持不动。生成 goroutine 里 fresh load 后的二次校验同步收紧为同一判定。

已存在的 "Session N" 会话也会在下一个 turn 结束后自动补上标题。

## Tests

- `TestIsAutoNamePlaceholder` —— 占位名判定(含中文自定义名、"My Session 2" 等非占位样例)
- `TestDoAgentTurn_GeneratesSessionTitle` —— 改为以 `Title = "Session 2"` 出生(复刻 POST /api/sessions 实际行为),断言仍生成标题并广播

`make test`(全量 -race)、`make vet`、`make fmt-check` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)