### PR TITLE
fix(web): render streaming text as markdown so the bubble doesn't jump at turn end

### DIFF
--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -3388,6 +3388,13 @@ const Sessions = (() => {
     },
 
     _clearLiveAssistant(id) {
+      const state = Sessions._liveAssistant[id];
+      // Cancel any pending throttled stream render so a late timer can't
+      // overwrite the finalized bubble (and re-add the typing cursor).
+      if (state && state.renderTimer) {
+        clearTimeout(state.renderTimer);
+        state.renderTimer = null;
+      }
       delete Sessions._liveAssistant[id];
     },
 
@@ -3441,19 +3448,38 @@ const Sessions = (() => {
       state.rawText += text;
       state.el.dataset.raw = state.rawText;
 
-      // Render: escape the raw text and append as plain text nodes.
-      // We use a live text approach rather than full markdown re-render
-      // on every delta for performance. A typing cursor is shown at the end.
-      const contentEl = state.el;
-      // Simple streaming render: plain text with auto-linking, no full markdown
-      // (avoids re-parsing markdown on every 50ms delta).
-      // We render line-breaks as <br> and preserve whitespace.
-      const escaped = escapeHtml(state.rawText);
-      const withBreaks = escaped.replace(/\n/g, "<br>");
-      contentEl.innerHTML = withBreaks +
-        '<span class="stream-cursor" aria-hidden="true"></span>';
+      // Live markdown rendering, throttled: re-render the accumulated buffer
+      // at most once per 150ms window so the streaming bubble matches the
+      // final render (no plain-text → markdown jump at turn end) without
+      // re-running marked + hljs + KaTeX on every token-sized delta.
+      Sessions._scheduleStreamRender(state, messages);
+    },
 
-      _scrollToBottomIfNeeded(messages);
+    // Schedule a throttled markdown render of the live streaming bubble.
+    // Every delta calls this; a timer is only ever pending once, and the
+    // trailing render after the last delta is guaranteed because the timer
+    // always fires with the latest rawText.
+    _scheduleStreamRender(state, messages) {
+      if (state.renderTimer) return;
+      const interval = 150;
+      const since = Date.now() - (state.lastRenderAt || 0);
+      state.renderTimer = setTimeout(() => {
+        state.renderTimer = null;
+        state.lastRenderAt = Date.now();
+        if (!state.el || !state.el.parentNode) return;
+        state.el.innerHTML = _renderMarkdown(state.rawText);
+        // Typing cursor: inline at the end of the last block when that makes
+        // sense; below the content for blocks that can't host inline children
+        // (tables, lists, code blocks).
+        const cursor = document.createElement("span");
+        cursor.className = "stream-cursor";
+        cursor.setAttribute("aria-hidden", "true");
+        const last = state.el.lastElementChild;
+        const inlineHost = last && !/^(TABLE|PRE|UL|OL|HR)$/.test(last.tagName) &&
+          !last.classList.contains("code-block") ? last : state.el;
+        inlineHost.appendChild(cursor);
+        _scrollToBottomIfNeeded(messages);
+      }, Math.max(0, interval - since));
     },
 
     // Append a thinking/reasoning trace delta.


### PR DESCRIPTION
## Problem

流式输出期间实时卡片只做纯文本渲染(escape + `<br>`),表格、加粗、代码块都以原始 markdown 字符显示;消息完成后终态用 `_renderMarkdown` 全量渲染,界面突变一下。

## Fix

- 流式 delta 改为对累积 buffer 跑与终态同一个 `_renderMarkdown`(marked + hljs + KaTeX),**150ms 节流**:同一窗口内只解析一次,定时器触发时总是渲染最新 buffer,最后一段 delta 的收尾渲染有保证;
- 打字光标每次渲染后重新挂到最后一个块的行内末尾(表格/列表/代码块等不能承载行内子元素的,退到内容下方);
- `_clearLiveAssistant` 取消挂起的节流定时器 —— 三条终态路径(工具事件 flush、`finalizeAssistantMessage`、会话切换)都经过它,迟到的定时器不会覆盖终态气泡或残留光标。

终态渲染逻辑不变;因为流式与终态共用同一渲染函数,turn 结束时不再突变。

## Verify

`node --check` 语法通过;`go build`(静态资源 embed)通过。手工验证:让模型输出含表格/加粗/代码块的长回复,流式过程中即为渲染后的样式,结束瞬间无跳变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)