### PR TITLE
feat(web): structured tool result payloads + collapse tool output to a one-line summary

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1040,6 +1040,7 @@ func emitToolResultEvents(handler EventHandler, useBlocks, resultBlocks []Conten
 			ToolID:   r.ToolUseID,
 			ToolName: nameByID[r.ToolUseID],
 			Output:   truncateOutput(r.Result),
+			UI:       r.UI,
 		}
 		if r.IsError {
 			ev.Kind = EventToolError
@@ -1182,7 +1183,9 @@ func toolResultBlocks(id string, result ToolResult, err error) []ContentBlock {
 		return []ContentBlock{NewToolResultBlock(id, microCompact(err.Error()), true)}
 	}
 	blocks := make([]ContentBlock, 0, 1+len(result.Blocks))
-	blocks = append(blocks, NewToolResultBlock(id, microCompact(result.Text), false))
+	rb := NewToolResultBlock(id, microCompact(result.Text), false)
+	rb.UI = result.UI
+	blocks = append(blocks, rb)
 	blocks = append(blocks, result.Blocks...)
 	return blocks
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1618,3 +1618,43 @@ func TestCleanSuggestion(t *testing.T) {
 		}
 	}
 }
+
+// The UI payload set by a tool must survive the trip onto the tool_result
+// ContentBlock (so it persists with the session) and onto the EventToolDone
+// event (so the web server can broadcast it without re-parsing Output).
+func TestToolResultUIPayload_FlowsToBlockAndEvent(t *testing.T) {
+	ui := map[string]any{"type": "web_search", "total": 2}
+
+	blocks := toolResultBlocks("call_1", ToolResult{Text: "ok", UI: ui}, nil)
+	if len(blocks) != 1 {
+		t.Fatalf("blocks = %d, want 1", len(blocks))
+	}
+	if got, ok := blocks[0].UI.(map[string]any); !ok || got["type"] != "web_search" {
+		t.Fatalf("block UI = %#v, want the tool's payload", blocks[0].UI)
+	}
+
+	var events []AgentEvent
+	emitToolResultEvents(
+		func(ev AgentEvent) { events = append(events, ev) },
+		[]ContentBlock{NewToolUseBlock("call_1", "web_search", nil)},
+		blocks,
+	)
+	if len(events) != 1 || events[0].Kind != EventToolDone {
+		t.Fatalf("events = %+v, want one EventToolDone", events)
+	}
+	if got, ok := events[0].UI.(map[string]any); !ok || got["total"] != 2 {
+		t.Fatalf("event UI = %#v, want the tool's payload", events[0].UI)
+	}
+}
+
+// An error result must not carry a UI payload — the error path builds its
+// block from the error string, never from ToolResult.UI.
+func TestToolResultUIPayload_DroppedOnError(t *testing.T) {
+	blocks := toolResultBlocks("call_1", ToolResult{UI: map[string]any{"type": "x"}}, errors.New("boom"))
+	if len(blocks) != 1 || !blocks[0].IsError {
+		t.Fatalf("blocks = %+v, want one error block", blocks)
+	}
+	if blocks[0].UI != nil {
+		t.Fatalf("error block UI = %#v, want nil", blocks[0].UI)
+	}
+}

--- a/internal/agent/content.go
+++ b/internal/agent/content.go
@@ -42,6 +42,12 @@ type ContentBlock struct {
 	// The LLM can inspect Result for the error message and recover gracefully.
 	IsError bool `json:"is_error,omitempty"`
 
+	// UI is an optional structured rendering of the result for UI consumers
+	// (type=="tool_result"). Persisted with the session so history replay can
+	// render rich result cards. Provider adapters build their wire payloads
+	// field-by-field and never serialise this — it is invisible to the model.
+	UI any `json:"ui,omitempty"`
+
 	// Thinking is the reasoning trace text (type=="thinking"). Anthropic-protocol
 	// reasoning models (Claude, Kimi k2.6) return it as a first-class content
 	// block that must be preserved and replayed on subsequent requests when tool

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -104,7 +104,7 @@ const EventToolOutputCap = 512
 //   - EventToolInputDelta: ToolID, ToolName, InputDelta
 //   - EventToolStarted:    ToolID, ToolName, Input
 //   - EventToolProgress:   ToolID, ToolName, Chunk
-//   - EventToolDone:       ToolID, ToolName, Output
+//   - EventToolDone:       ToolID, ToolName, Output, UI (when the tool provides one)
 //   - EventToolError:      ToolID, ToolName, Output (may be empty), Err
 //   - EventTurnDone:       Reply
 //   - EventSteerInjected:  Messages
@@ -124,9 +124,14 @@ type AgentEvent struct {
 	Chunk      string         `json:"chunk,omitempty"`
 	Output     string         `json:"output,omitempty"`
 	Err        string         `json:"err,omitempty"`
-	Reply      *Reply         `json:"reply,omitempty"`
-	Messages   []string       `json:"messages,omitempty"`
-	Compact    *CompactStats  `json:"compact,omitempty"`
+
+	// UI is the tool's optional structured result payload (EventToolDone).
+	// Unlike Output it is never truncated — it is already a compact summary
+	// built by the tool itself (see ToolResult.UI).
+	UI       any           `json:"ui,omitempty"`
+	Reply    *Reply        `json:"reply,omitempty"`
+	Messages []string      `json:"messages,omitempty"`
+	Compact  *CompactStats `json:"compact,omitempty"`
 
 	// Steer carries the full inbox items behind an EventSteerInjected —
 	// including attachment blocks — for handlers that render more than the

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -260,7 +260,7 @@ func firstUserSnippet(msgs []Message) string {
 				}
 			}
 		}
-		text = stripSystemReminders(text)
+		text = StripSystemReminders(text)
 		// Collapse to the first non-empty line.
 		for _, line := range strings.Split(text, "\n") {
 			line = strings.TrimSpace(line)
@@ -276,9 +276,12 @@ func firstUserSnippet(msgs []Message) string {
 	return ""
 }
 
-// stripSystemReminders removes <system-reminder>…</system-reminder> spans the
-// harness injects into user turns so they don't leak into the preview.
-func stripSystemReminders(s string) string {
+// StripSystemReminders removes <system-reminder>…</system-reminder> spans the
+// harness injects into user turns (background-process completion notes,
+// recalled memories, …). They are model-facing context, not user speech —
+// strip them anywhere user text is rendered (session previews, the web
+// transcript) so they don't leak into the UI.
+func StripSystemReminders(s string) string {
 	for {
 		start := strings.Index(s, "<system-reminder>")
 		if start < 0 {

--- a/internal/agent/tool.go
+++ b/internal/agent/tool.go
@@ -19,6 +19,12 @@ type ToolDefinition struct {
 type ToolResult struct {
 	Text   string         // required textual summary
 	Blocks []ContentBlock // optional rich content (images, etc.)
+
+	// UI is an optional structured rendering of the result for UI consumers
+	// (the web frontend's rich result cards). It never reaches the model —
+	// only Text/Blocks do. It travels on the tool_result ContentBlock (and
+	// therefore persists with the session) and on the EventToolDone event.
+	UI any
 }
 
 // ToolExecutor dispatches tool calls on behalf of the agentic loop. Each

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -385,6 +385,11 @@ func (s *Server) handleGetSessionMessages(w http.ResponseWriter, r *http.Request
 					}
 				}
 			}
+			// <system-reminder> spans (background-process completion notes,
+			// recalled memories) are model-facing context persisted inside
+			// user turns — strip them so replay matches the TUI, which never
+			// shows them.
+			text = strings.TrimSpace(agent.StripSystemReminders(text))
 			// Only emit history_user_message if there is user-visible content
 			// (tool_result-only messages are bookkeeping, not user-visible).
 			if text != "" || len(images) > 0 {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -346,10 +346,14 @@ func (s *Server) handleGetSessionMessages(w http.ResponseWriter, r *http.Request
 			for _, b := range m.Blocks {
 				if b.Type == "tool_result" {
 					hasToolResult = true
-					events = append(events, map[string]any{
+					ev := map[string]any{
 						"type":   "tool_result",
 						"result": b.Result,
-					})
+					}
+					if b.UI != nil {
+						ev["ui_payload"] = b.UI
+					}
+					events = append(events, ev)
 				}
 			}
 			// Use the message's own CreatedAt when available.  Older session

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -760,6 +760,11 @@ func TestHandleGetSessionMessages_MultiToolUse(t *testing.T) {
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)
 
+	// res1 carries a structured UI payload; res2 doesn't. The replay must
+	// surface the payload as ui_payload after the session JSON round-trip.
+	res1 := agent.NewToolResultBlock("call_1", "file.txt\n", false)
+	res1.UI = map[string]any{"type": "file_list", "total": 1}
+
 	sess := agent.NewSession("stub-model", "")
 	sess.Messages = []agent.Message{
 		{Role: agent.RoleUser, Content: "list and grep"},
@@ -768,7 +773,7 @@ func TestHandleGetSessionMessages_MultiToolUse(t *testing.T) {
 			agent.NewToolUseBlock("call_2", "grep", map[string]any{"pattern": "foo"}),
 		}),
 		agent.NewToolResultMessage([]agent.ContentBlock{
-			agent.NewToolResultBlock("call_1", "file.txt\n", false),
+			res1,
 			agent.NewToolResultBlock("call_2", "file.txt:1:foo\n", false),
 		}),
 		agent.NewAssistantMessage("Found it"),
@@ -816,6 +821,15 @@ func TestHandleGetSessionMessages_MultiToolUse(t *testing.T) {
 		if gotTypes[i] != want {
 			t.Fatalf("event[%d].type = %q, want %q; full=%v", i, gotTypes[i], want, gotTypes)
 		}
+	}
+
+	// events[4] / events[5] are the two tool_results: only the first has UI.
+	ui, ok := body.Events[4]["ui_payload"].(map[string]any)
+	if !ok || ui["type"] != "file_list" {
+		t.Errorf("events[4].ui_payload = %#v, want file_list payload", body.Events[4]["ui_payload"])
+	}
+	if _, present := body.Events[5]["ui_payload"]; present {
+		t.Errorf("events[5].ui_payload present, want absent: %#v", body.Events[5]["ui_payload"])
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -753,6 +753,63 @@ func TestHandleGetSessionMessages_IncludesToolCalls(t *testing.T) {
 	}
 }
 
+// History replay must never render <system-reminder> spans (background
+// completion notes, recalled memories) as user bubbles — the TUI skips them
+// and the web transcript must match.
+func TestHandleGetSessionMessages_StripsSystemReminders(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := agent.NewSession("stub-model", "")
+	sess.Messages = []agent.Message{
+		{Role: agent.RoleUser, Content: "run the build in the background"},
+		agent.NewAssistantMessage("Started."),
+		// A background-completion note injected via steer: pure reminder, no
+		// user speech. Must produce NO history_user_message.
+		{Role: agent.RoleUser, Content: "<system-reminder>\n[BACKGROUND COMPLETED]\nBackground process bg_1 (`make build`) exited: 0.\nOutput since last check:\nhuge build log…\n</system-reminder>"},
+		agent.NewAssistantMessage("Build finished."),
+		// Mixed turn: reminder prepended to real user text. Only the user
+		// text survives.
+		{Role: agent.RoleUser, Content: "<system-reminder>recalled memory</system-reminder>\nnow run the tests"},
+	}
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/"+sess.ID+"/messages", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Events []map[string]any `json:"events"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+
+	var userTexts []string
+	for _, ev := range body.Events {
+		if ev["type"] == "history_user_message" {
+			userTexts = append(userTexts, ev["content"].(string))
+		}
+	}
+	want := []string{"run the build in the background", "now run the tests"}
+	if len(userTexts) != len(want) {
+		t.Fatalf("user messages = %q, want %q", userTexts, want)
+	}
+	for i := range want {
+		if userTexts[i] != want[i] {
+			t.Errorf("user message[%d] = %q, want %q", i, userTexts[i], want[i])
+		}
+	}
+}
+
 // TestHandleGetSessionMessages_MultiToolUse verifies the full event sequence
 // for a session with multiple tool_use blocks and tool_results.
 func TestHandleGetSessionMessages_MultiToolUse(t *testing.T) {

--- a/internal/server/static/app.css
+++ b/internal/server/static/app.css
@@ -2123,14 +2123,30 @@ body {
   align-items: baseline;
   gap: 0.375rem;
 }
+/* Result area is collapsed to the one-line header by default; the chevron
+   appears once there is output to expand. */
+.tool-item.has-output .tool-item-header { cursor: pointer; }
+.tool-item.has-output .tool-item-header:hover { background: var(--color-bg-secondary); border-radius: 4px; }
+.tool-item-chevron {
+  color: var(--color-text-tertiary);
+  font-size: 0.625rem;
+  flex-shrink: 0;
+  visibility: hidden;
+  transition: transform 0.15s ease;
+}
+.tool-item.has-output .tool-item-chevron { visibility: visible; }
+.tool-item.expanded .tool-item-chevron { transform: rotate(90deg); }
 .tool-item-name { color: var(--color-warning); font-weight: 600; }
 .tool-item-arg  { color: var(--color-text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 25rem; }
+.tool-item-meta { margin-left: auto; color: var(--color-text-tertiary); font-size: 0.6875rem; flex-shrink: 0; }
 .tool-item-status { margin-left: auto; font-size: 0.6875rem; flex-shrink: 0; }
+.tool-item-meta + .tool-item-status { margin-left: 0; }
 .tool-item-status.ok     { color: var(--color-success); }
 .tool-item-status.failed { color: var(--color-error); }
 .tool-item-status.err    { color: var(--color-error); }
 .tool-item-status.running { color: var(--color-accent-primary); animation: pulse 1.2s infinite; }
 .tool-item-stdout {
+  display: none;
   margin: 0.25rem 0 2px 0;
   padding: 0.375rem 0.5rem;
   background: var(--color-bg-secondary);
@@ -2145,6 +2161,7 @@ body {
   overflow-y: auto;
   line-height: 1.5;
 }
+.tool-item.expanded.has-output .tool-item-stdout { display: block; }
 /* ANSI color classes for tool stdout */
 .tool-item-stdout .ansi-red     { color: #e06c75; }
 .tool-item-stdout .ansi-green   { color: #98c379; }

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -1056,10 +1056,20 @@ const Sessions = (() => {
 
     item.innerHTML =
       `<div class="tool-item-header">` +
+        `<span class="tool-item-chevron">▸</span>` +
         label +
         `<span class="tool-item-status running">…</span>` +
       `</div>` +
-      `<pre class="tool-item-stdout" style="display:none"></pre>`;
+      `<pre class="tool-item-stdout"></pre>`;
+    // The result area is collapsed to the one-line header by default;
+    // clicking the header toggles it (only meaningful once output exists).
+    // data-user-toggled records a manual choice so auto expand/collapse
+    // (streaming starts / tool completes) never fights the user.
+    item.querySelector(".tool-item-header").addEventListener("click", () => {
+      if (!item.classList.contains("has-output")) return;
+      item.dataset.userToggled = "1";
+      item.classList.toggle("expanded");
+    });
     return item;
   }
 
@@ -1114,6 +1124,13 @@ const Sessions = (() => {
     }).join("\n");
   }
 
+  // Mark a tool-item as having output and auto-expand it while the tool is
+  // still producing it — unless the user has toggled the item manually.
+  function _revealStdout(toolItem) {
+    toolItem.classList.add("has-output");
+    if (!toolItem.dataset.userToggled) toolItem.classList.add("expanded");
+  }
+
   // Render a diff block into the given tool-item's stdout area.
   function _applyDiffToItem(toolItem, diffText, truncated) {
     if (!toolItem) return;
@@ -1122,7 +1139,7 @@ const Sessions = (() => {
     let html = _formatDiffToHtml(diffText);
     if (truncated) html += '\n\n<span class="ansi-yellow">… diff truncated</span>';
     stdout.innerHTML = html;
-    if (stdout.style.display === "none") stdout.style.display = "";
+    _revealStdout(toolItem);
     stdout.scrollTop = stdout.scrollHeight;
   }
 
@@ -1339,13 +1356,24 @@ const Sessions = (() => {
     return item;
   }
 
-  // Mark the last tool-item in a group as done (update status indicator).
-  function _completeLastToolItem(group, result, uiPayload) {
-    const body  = group.querySelector(".tool-group-body");
-    const items = body.querySelectorAll(".tool-item");
-    if (!items.length) return;
-    const last   = items[items.length - 1];
-    const status = last.querySelector(".tool-item-status");
+  // Produce a short header hint from a structured payload (e.g. "5 results")
+  // so the collapsed one-line summary says what the tool found.
+  function _payloadHeaderMeta(p) {
+    switch (p.type) {
+      case "web_search": return `${p.total || (p.results || []).length || 0} results`;
+      case "search":     return `${p.total_matches || 0} matches`;
+      case "file_list":  return `${p.total || (p.entries || []).length || 0} items`;
+      case "file_read":  return p.lines_read != null ? `${p.lines_read} lines` : "";
+      default:           return "";
+    }
+  }
+
+  // Apply a finished tool result to one .tool-item: status tick, result
+  // content (rich card when a structured payload is available, raw text
+  // otherwise), header hint, and the default-collapsed state. Shared by the
+  // live path (_completeLastToolItem) and history replay.
+  function _applyResultToItem(item, result, uiPayload) {
+    const status = item.querySelector(".tool-item-status");
     if (status) {
       const st = uiPayload && uiPayload.status ? uiPayload.status : "ok";
       if (st === "error" || st === "failed") {
@@ -1356,29 +1384,47 @@ const Sessions = (() => {
         status.textContent = "✓";
       }
     }
-    // Render the result string (e.g. "waiting (#4) — 128B\nstep1\nstep2…")
-    // into the stdout area so the user can see what actually happened.
-    // If the area already has streamed content (future feature), leave it.
-    const stdout = last.querySelector(".tool-item-stdout");
+    const stdout = item.querySelector(".tool-item-stdout");
     if (stdout) {
       const existing = stdout.textContent.trim();
+      let hasContent = !!existing;
+      let rendered = false;
       if (uiPayload && uiPayload.type) {
         const rich = _renderRichResult(uiPayload);
         if (rich) {
           stdout.innerHTML = rich;
-          stdout.style.display = "";
-          return;
+          hasContent = true;
+          rendered = true;
+          const meta = _payloadHeaderMeta(uiPayload);
+          if (meta && status) {
+            const el = document.createElement("span");
+            el.className = "tool-item-meta";
+            el.textContent = meta;
+            status.before(el);
+          }
         }
       }
-      const resultStr = (result == null) ? "" : String(result).trim();
-      if (!existing && resultStr) {
-        stdout.innerHTML = _ansiToHtml(resultStr);
-        stdout.style.display = "";
-      } else if (!existing && !resultStr) {
-        stdout.style.display = "none";
+      if (!rendered) {
+        // Render the raw result string (e.g. "waiting (#4) — 128B\nstep1…").
+        // If the area already has streamed content, leave it as-is.
+        const resultStr = (result == null) ? "" : String(result).trim();
+        if (!existing && resultStr) {
+          stdout.innerHTML = _ansiToHtml(resultStr);
+          hasContent = true;
+        }
       }
-      // else: leave existing content as-is
+      item.classList.toggle("has-output", hasContent);
     }
+    // Collapse back to the one-line summary unless the user expanded manually.
+    if (!item.dataset.userToggled) item.classList.remove("expanded");
+  }
+
+  // Mark the last tool-item in a group as done.
+  function _completeLastToolItem(group, result, uiPayload) {
+    const body  = group.querySelector(".tool-group-body");
+    const items = body.querySelectorAll(".tool-item");
+    if (!items.length) return;
+    _applyResultToItem(items[items.length - 1], result, uiPayload);
   }
 
   // Collapse a tool group (called when AI responds or task finishes).
@@ -1501,35 +1547,7 @@ const Sessions = (() => {
         // assistant_message collapses the group and clears it, but the lastItem
         // is still the correct target for the result.
         if (historyCtx.lastItem) {
-          const status = historyCtx.lastItem.querySelector(".tool-item-status");
-          if (status) {
-            const st = ev.ui_payload && ev.ui_payload.status ? ev.ui_payload.status : "ok";
-            if (st === "error" || st === "failed") {
-              status.className = "tool-item-status failed";
-              status.textContent = "✗";
-            } else {
-              status.className = "tool-item-status ok";
-              status.textContent = "✓";
-            }
-          }
-          const stdout = historyCtx.lastItem.querySelector(".tool-item-stdout");
-          if (stdout) {
-            if (ev.ui_payload && ev.ui_payload.type) {
-              const rich = _renderRichResult(ev.ui_payload);
-              if (rich) {
-                stdout.innerHTML = rich;
-                stdout.style.display = "";
-              }
-            } else {
-              const resultStr = (ev.result == null) ? "" : String(ev.result).trim();
-              if (resultStr && !stdout.textContent.trim()) {
-                stdout.innerHTML = _ansiToHtml(resultStr);
-                stdout.style.display = "";
-              } else if (!resultStr && !stdout.textContent.trim()) {
-                stdout.style.display = "none";
-              }
-            }
-          }
+          _applyResultToItem(historyCtx.lastItem, ev.result, ev.ui_payload);
           historyCtx.lastItem = null;
         }
         break;
@@ -1553,7 +1571,7 @@ const Sessions = (() => {
     const stdout = toolItem.querySelector(".tool-item-stdout");
     if (!stdout) return;
     stdout.innerHTML += lines.map(_ansiToHtml).join("");
-    if (stdout.style.display === "none") stdout.style.display = "";
+    _revealStdout(toolItem);
     stdout.scrollTop = stdout.scrollHeight;
     const messages = $("messages");
     _scrollToBottomIfNeeded(messages);

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -1364,6 +1364,9 @@ const Sessions = (() => {
       case "search":     return `${p.total_matches || 0} matches`;
       case "file_list":  return `${p.total || (p.entries || []).length || 0} items`;
       case "file_read":  return p.lines_read != null ? `${p.lines_read} lines` : "";
+      case "edit":       return `${p.occurrences || 1} change(s)`;
+      case "write":      return p.size_bytes != null ? `${p.size_bytes} bytes` : "";
+      case "todo":       return p.progress || "";
       default:           return "";
     }
   }

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -730,11 +730,15 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 		w.server.liveStateMu.Unlock()
 
 	case agent.EventToolDone:
-		w.hub.broadcast(w.sessionID, map[string]any{
+		toolResult := map[string]any{
 			"type":       "tool_result",
 			"session_id": w.sessionID,
 			"result":     ev.Output,
-		})
+		}
+		if ev.UI != nil {
+			toolResult["ui_payload"] = ev.UI
+		}
+		w.hub.broadcast(w.sessionID, toolResult)
 		// Signal sub-agent completion so the frontend can clear the live panel.
 		if ev.ToolName == "sub_agent" {
 			w.hub.broadcast(w.sessionID, map[string]any{

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -786,13 +786,21 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 			}
 		}
 		for _, it := range items {
+			// <system-reminder> blocks (background-process completion notes,
+			// recalled memories) are model-facing context, not user speech —
+			// the TUI skips them and the web transcript must too.
+			text := strings.TrimSpace(agent.StripSystemReminders(it.Text))
+			imgs := imageRefsFromBlocks(it.Blocks)
+			if text == "" && len(imgs) == 0 {
+				continue
+			}
 			evt := map[string]any{
 				"type":       "history_user_message",
 				"session_id": w.sessionID,
-				"content":    it.Text,
+				"content":    text,
 				"created_at": time.Now().UnixMilli(),
 			}
-			if imgs := imageRefsFromBlocks(it.Blocks); len(imgs) > 0 {
+			if len(imgs) > 0 {
 				evt["images"] = imgs
 			}
 			w.hub.broadcast(w.sessionID, evt)

--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -270,10 +270,36 @@ func (EditFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: write %q: %w", path, err)
 	}
 
+	occurrences := 1
 	if replaceAll {
-		return agent.ToolResult{Text: fmt.Sprintf("Replaced %d occurrence(s) in %s", count, abs)}, nil
+		occurrences = count
 	}
-	return agent.ToolResult{Text: fmt.Sprintf("Replaced 1 occurrence in %s", abs)}, nil
+	ui := map[string]any{
+		"type":        "edit",
+		"path":        abs,
+		"occurrences": occurrences,
+		"diff":        editUIDiff(actualOldStr, actualNewStr),
+	}
+	if replaceAll {
+		return agent.ToolResult{Text: fmt.Sprintf("Replaced %d occurrence(s) in %s", count, abs), UI: ui}, nil
+	}
+	return agent.ToolResult{Text: fmt.Sprintf("Replaced 1 occurrence in %s", abs), UI: ui}, nil
+}
+
+// editUIDiff renders the replacement as a removed/added block for the web
+// UI's diff view. The edit is an exact substring swap, so old/new lines ARE
+// the change — no diff algorithm needed.
+func editUIDiff(oldStr, newStr string) string {
+	var b strings.Builder
+	for _, l := range strings.Split(strings.TrimRight(oldStr, "\n"), "\n") {
+		b.WriteString("- " + l + "\n")
+	}
+	if newStr != "" {
+		for _, l := range strings.Split(strings.TrimRight(newStr, "\n"), "\n") {
+			b.WriteString("+ " + l + "\n")
+		}
+	}
+	return uiHead(b.String(), 24, 1600)
 }
 
 // preserveQuoteStyle copies curly quote style from actualOldStr to newStr

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -131,13 +131,31 @@ func (GlobTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 		out.WriteString(m.path)
 		out.WriteByte('\n')
 	}
+
+	// UI payload: entries are relative to the search root to keep the card
+	// (and the session JSON it persists in) compact.
+	entries := make([]map[string]any, 0, min(len(matches), 20))
+	for _, m := range matches[:min(len(matches), 20)] {
+		name := m.path
+		if rel, relErr := filepath.Rel(absRoot, m.path); relErr == nil {
+			name = rel
+		}
+		entries = append(entries, map[string]any{"name": name})
+	}
+	ui := map[string]any{
+		"type":    "file_list",
+		"path":    absRoot,
+		"entries": entries,
+		"total":   totalMatches,
+	}
+
 	if out.Len() == 0 {
-		return agent.ToolResult{Text: fmt.Sprintf("(no matches for %q under %s)", pattern, absRoot)}, nil
+		return agent.ToolResult{Text: fmt.Sprintf("(no matches for %q under %s)", pattern, absRoot), UI: ui}, nil
 	}
 	if truncated {
 		fmt.Fprintf(&out, "\n[truncated to first %d of %d matches]\n", GlobMaxResults, totalMatches)
 	}
-	return agent.ToolResult{Text: out.String()}, nil
+	return agent.ToolResult{Text: out.String(), UI: ui}, nil
 }
 
 // listProjectFiles enumerates every file under root that ripgrep would search,

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -124,15 +125,19 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 	}
 
 	// Context lines only make sense for mode=content.
+	hasContext := false
 	if mode == "content" {
 		if c := intArg(input, "context_lines", 0); c > 0 {
 			args = append(args, "-C", strconv.Itoa(c))
+			hasContext = true
 		}
 		if b := intArg(input, "before", 0); b > 0 {
 			args = append(args, "-B", strconv.Itoa(b))
+			hasContext = true
 		}
 		if a := intArg(input, "after", 0); a > 0 {
 			args = append(args, "-A", strconv.Itoa(a))
+			hasContext = true
 		}
 	}
 
@@ -151,12 +156,12 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 		// the LLM's perspective — surface it as a normal result.
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
-			return agent.ToolResult{Text: "(no matches)"}, nil
+			return agent.ToolResult{Text: "(no matches)", UI: grepUIEmpty(pattern)}, nil
 		}
 		return agent.ToolResult{Text: ""}, fmt.Errorf("grep: rg failed: %w", err)
 	}
 	if len(out) == 0 {
-		return agent.ToolResult{Text: "(no matches)"}, nil
+		return agent.ToolResult{Text: "(no matches)", UI: grepUIEmpty(pattern)}, nil
 	}
 
 	text := strings.TrimRight(string(out), "\n")
@@ -167,9 +172,69 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 		// "lines" not "matches" — in content mode context lines and `--`
 		// separators count too.
 		kept := strings.Join(lines[:GrepMaxLines], "\n")
-		return agent.ToolResult{Text: fmt.Sprintf(
-			"%s\n\n[truncated to first %d of %d lines — narrow the pattern, add include='*.ext', or set a more specific path]",
-			kept, GrepMaxLines, len(lines))}, nil
+		return agent.ToolResult{
+			Text: fmt.Sprintf(
+				"%s\n\n[truncated to first %d of %d lines — narrow the pattern, add include='*.ext', or set a more specific path]",
+				kept, GrepMaxLines, len(lines)),
+			UI: grepUI(pattern, mode, hasContext, kept),
+		}, nil
 	}
-	return agent.ToolResult{Text: text}, nil
+	return agent.ToolResult{Text: text, UI: grepUI(pattern, mode, hasContext, text)}, nil
+}
+
+// grepUIMatchRe splits an rg content line "path:lineNo:content". The
+// non-greedy path group still survives Windows drive prefixes ("C:\…")
+// because the engine settles on the first ":<digits>:" boundary.
+var grepUIMatchRe = regexp.MustCompile(`^(.+?):(\d+):(.*)$`)
+
+// grepUIEmpty is the zero-match "search" payload.
+func grepUIEmpty(pattern string) map[string]any {
+	return map[string]any{
+		"type":               "search",
+		"pattern":            pattern,
+		"matches":            []map[string]any{},
+		"total_matches":      0,
+		"files_with_matches": 0,
+	}
+}
+
+// grepUI builds the "search" UI payload from rg content-mode output.
+// Context runs and non-content modes produce line shapes that would
+// mis-parse, so they get no payload (the raw text still renders). Returns
+// nil too when nothing parses — e.g. a single-file search, where rg omits
+// the leading path. The return type is `any` (not the map type) so a nil
+// result stays a true nil inside ToolResult.UI.
+func grepUI(pattern, mode string, hasContext bool, text string) any {
+	if mode != "content" || hasContext {
+		return nil
+	}
+	var matches []map[string]any
+	files := make(map[string]struct{})
+	total := 0
+	for _, line := range strings.Split(text, "\n") {
+		m := grepUIMatchRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		total++
+		files[m[1]] = struct{}{}
+		if len(matches) < 10 {
+			lineNo, _ := strconv.Atoi(m[2])
+			matches = append(matches, map[string]any{
+				"file":    m[1],
+				"line_no": lineNo,
+				"line":    uiHead(strings.TrimSpace(m[3]), 1, 200),
+			})
+		}
+	}
+	if total == 0 {
+		return nil
+	}
+	return map[string]any{
+		"type":               "search",
+		"pattern":            pattern,
+		"matches":            matches,
+		"total_matches":      total,
+		"files_with_matches": len(files),
+	}
 }

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -173,6 +173,21 @@ func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 	if returned == 0 {
 		return agent.ToolResult{Text: "[empty file]"}, nil
 	}
+
+	// UI payload built before the truncation/EOF footers land in out, so the
+	// preview shows file content only. Total line count is unknown when the
+	// scan stopped early at the cap.
+	ui := map[string]any{
+		"type":            "file_read",
+		"path":            path,
+		"lines_read":      returned,
+		"truncated":       truncated,
+		"content_preview": uiHead(out.String(), 8, 600),
+	}
+	if !truncated {
+		ui["total_lines"] = lineNum
+	}
+
 	if truncated {
 		// Without this footer the read stops silently at the cap, so the
 		// model can't tell a complete read from a truncated one — it then
@@ -187,7 +202,7 @@ func (ReadFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 		fmt.Fprintf(&out, "\n[end of file: %d lines total]\n", lineNum)
 	}
 
-	result := agent.ToolResult{Text: out.String()}
+	result := agent.ToolResult{Text: out.String(), UI: ui}
 	if isMemory {
 		memCount := memory.CountMemories(out.String())
 		result.Text = fmt.Sprintf("Recalled %d %s from %s\n\n%s", memCount, pluralize(memCount, "memory", "memories"), filepath.Base(abs), out.String())

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -121,7 +121,10 @@ func (TaskCreateTool) Execute(ctx context.Context, _ string, input map[string]an
 	if err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("task_create: %w", err)
 	}
-	return agent.ToolResult{Text: fmt.Sprintf("Created task #%d: %s", id, subject)}, nil
+	return agent.ToolResult{
+		Text: fmt.Sprintf("Created task #%d: %s", id, subject),
+		UI:   taskUI(fmt.Sprintf("Created #%d", id), store),
+	}, nil
 }
 
 // ============================================================================
@@ -216,7 +219,10 @@ func (TaskUpdateTool) Execute(ctx context.Context, _ string, input map[string]an
 	if u.Status != nil && oldTask.Status != got.Status {
 		statusClause = fmt.Sprintf("%s → %s", oldTask.Status, got.Status)
 	}
-	return agent.ToolResult{Text: fmt.Sprintf("Updated task #%d (%s): %s", got.ID, statusClause, got.Subject)}, nil
+	return agent.ToolResult{
+		Text: fmt.Sprintf("Updated task #%d (%s): %s", got.ID, statusClause, got.Subject),
+		UI:   taskUI(fmt.Sprintf("Updated #%d", got.ID), store),
+	}, nil
 }
 
 // ============================================================================
@@ -246,7 +252,35 @@ func (TaskListTool) Execute(ctx context.Context, _ string, _ map[string]any) (ag
 	if store == nil {
 		return agent.ToolResult{}, fmt.Errorf("task_list: task tracking is not configured for this session")
 	}
-	return agent.ToolResult{Text: FormatTaskList(store.List())}, nil
+	return agent.ToolResult{Text: FormatTaskList(store.List()), UI: taskUI("Tasks", store)}, nil
+}
+
+// taskUI builds the "todo" UI payload: the current list (deleted tasks
+// hidden) plus a done-count progress line for the collapsed summary.
+func taskUI(action string, store TaskStore) map[string]any {
+	var todos []map[string]any
+	done, total := 0, 0
+	for _, t := range store.List() {
+		if t.Status == tasks.Deleted {
+			continue
+		}
+		total++
+		if t.Status == tasks.Completed {
+			done++
+		}
+		if len(todos) < 20 {
+			todos = append(todos, map[string]any{
+				"task":   t.Subject,
+				"status": string(t.Status),
+			})
+		}
+	}
+	return map[string]any{
+		"type":     "todo",
+		"action":   action,
+		"progress": fmt.Sprintf("%d/%d done", done, total),
+		"todos":    todos,
+	}
 }
 
 // FormatTaskList renders a slice of tasks for display. Used both by the

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -129,9 +129,12 @@ func (t TerminalTool) ExecuteStream(
 		if err != nil {
 			return agent.ToolResult{Text: ""}, err
 		}
-		return agent.ToolResult{Text: fmt.Sprintf(
-			"Started detached process (pid %d). It runs independently of octo and will NOT be tracked or stopped when this session ends — manage it yourself (e.g. `kill %d`). stdout+stderr → %s",
-			pid, pid, logPath)}, nil
+		return agent.ToolResult{
+			Text: fmt.Sprintf(
+				"Started detached process (pid %d). It runs independently of octo and will NOT be tracked or stopped when this session ends — manage it yourself (e.g. `kill %d`). stdout+stderr → %s",
+				pid, pid, logPath),
+			UI: terminalUI(command, "running", fmt.Sprintf("detached, pid %d → %s", pid, logPath)),
+		}, nil
 	}
 
 	// Background launch: detach, no timeout, return the id immediately. The
@@ -141,7 +144,10 @@ func (t TerminalTool) ExecuteStream(
 		if err != nil {
 			return agent.ToolResult{Text: ""}, err
 		}
-		return agent.ToolResult{Text: fmt.Sprintf("Started background process %s.\n\n%s", id, BgPollNotice)}, nil
+		return agent.ToolResult{
+			Text: fmt.Sprintf("Started background process %s.\n\n%s", id, BgPollNotice),
+			UI:   terminalUI(command, "running", fmt.Sprintf("background process %s", id)),
+		}, nil
 	}
 
 	// Synchronous path: start as a background process so that if we hit the
@@ -204,14 +210,20 @@ func (t TerminalTool) ExecuteStream(
 			// readable via terminal_output.
 			t.managerFor(ctx).Promote(id)
 			body := MaybeSpillOutput(id, snapshot())
-			return agent.ToolResult{Text: fmt.Sprintf("%s\n\n[timeout: command exceeded %s and continues as background process %s]\n\n%s", body, TerminalTimeout, id, BgPollNotice)}, nil
+			return agent.ToolResult{
+				Text: fmt.Sprintf("%s\n\n[timeout: command exceeded %s and continues as background process %s]\n\n%s", body, TerminalTimeout, id, BgPollNotice),
+				UI:   terminalUI(command, "running", body),
+			}, nil
 		case <-ctx.Done():
 			// User cancelled (Esc / Ctrl-C): kill the hidden process and reap
 			// it — the output is returned here and now, nothing will poll it.
 			t.managerFor(ctx).Kill(id)
 			body := snapshot()
 			t.managerFor(ctx).Remove(id)
-			return agent.ToolResult{Text: body + "\n[exit: signal: killed]"}, nil
+			return agent.ToolResult{
+				Text: body + "\n[exit: signal: killed]",
+				UI:   terminalUI(command, "failed", body+"\n[exit: signal: killed]"),
+			}, nil
 		default:
 		}
 
@@ -222,11 +234,23 @@ func (t TerminalTool) ExecuteStream(
 			// returned, so the bgProcess (and its retained buffer) can go.
 			t.managerFor(ctx).Remove(id)
 			if status != "exited: 0" {
-				return agent.ToolResult{Text: body + "\n[exit: " + strings.TrimPrefix(status, "exited: ") + "]"}, nil
+				text := body + "\n[exit: " + strings.TrimPrefix(status, "exited: ") + "]"
+				return agent.ToolResult{Text: text, UI: terminalUI(command, "failed", text)}, nil
 			}
-			return agent.ToolResult{Text: body}, nil
+			return agent.ToolResult{Text: body, UI: terminalUI(command, "success", body)}, nil
 		}
 		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// terminalUI builds the "terminal" UI payload. The preview keeps the TAIL of
+// the output — for shell commands the error/summary is at the bottom.
+func terminalUI(command, status, output string) map[string]any {
+	return map[string]any{
+		"type":           "terminal",
+		"command":        uiHead(command, 2, 200),
+		"status":         status,
+		"output_preview": uiTail(output, 16, 1200),
 	}
 }
 

--- a/internal/tools/uipayload.go
+++ b/internal/tools/uipayload.go
@@ -1,0 +1,52 @@
+package tools
+
+import "strings"
+
+// Helpers for building ToolResult.UI payloads — the structured result
+// summaries the web frontend renders as rich cards (sessions.js
+// _renderRichResult). A payload's "type" value must match a frontend
+// renderer. Payloads persist in session JSON and ride every tool_result
+// broadcast, so previews are hard-capped to keep transcripts small.
+
+// uiHead returns the first maxLines lines of s, additionally capped at
+// maxBytes bytes (cut at a line boundary where possible).
+func uiHead(s string, maxLines, maxBytes int) string {
+	s = strings.TrimRight(s, "\n")
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) > maxLines {
+		lines = lines[:maxLines]
+	}
+	out := strings.Join(lines, "\n")
+	if len(out) > maxBytes {
+		out = out[:maxBytes]
+		if i := strings.LastIndexByte(out, '\n'); i > 0 {
+			out = out[:i]
+		}
+	}
+	return out
+}
+
+// uiTail returns the last maxLines lines of s, additionally capped at
+// maxBytes bytes. Used where the end of the output matters most (shell
+// commands: the error/summary is at the bottom).
+func uiTail(s string, maxLines, maxBytes int) string {
+	s = strings.TrimRight(s, "\n")
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+	out := strings.Join(lines, "\n")
+	if len(out) > maxBytes {
+		out = out[len(out)-maxBytes:]
+		if i := strings.IndexByte(out, '\n'); i >= 0 && i < len(out)-1 {
+			out = out[i+1:]
+		}
+	}
+	return out
+}

--- a/internal/tools/uipayload_test.go
+++ b/internal/tools/uipayload_test.go
@@ -80,6 +80,7 @@ func TestReadFile_UIPayload(t *testing.T) {
 }
 
 func TestGlob_UIPayload(t *testing.T) {
+	requireRg(t)
 	dir := t.TempDir()
 	for _, name := range []string{"a.go", "b.go", "c.txt"} {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
@@ -107,6 +108,7 @@ func TestGlob_UIPayload(t *testing.T) {
 }
 
 func TestGrep_UIPayload_ContentMode(t *testing.T) {
+	requireRg(t)
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hit here\nmiss\nanother hit\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -128,6 +130,7 @@ func TestGrep_UIPayload_ContentMode(t *testing.T) {
 }
 
 func TestGrep_UIPayload_SkippedForContextRuns(t *testing.T) {
+	requireRg(t)
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hit\nctx\n"), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/tools/uipayload_test.go
+++ b/internal/tools/uipayload_test.go
@@ -1,0 +1,226 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUIHead(t *testing.T) {
+	cases := []struct {
+		in       string
+		maxLines int
+		maxBytes int
+		want     string
+	}{
+		{"", 5, 100, ""},
+		{"a\nb\nc\n", 5, 100, "a\nb\nc"},
+		{"a\nb\nc", 2, 100, "a\nb"},
+		{"aaaa\nbbbb\ncccc", 5, 9, "aaaa"}, // byte cap cuts at line boundary
+		{"aaaaaaaaaa", 5, 4, "aaaa"},       // single long line: hard byte cut
+	}
+	for _, c := range cases {
+		if got := uiHead(c.in, c.maxLines, c.maxBytes); got != c.want {
+			t.Errorf("uiHead(%q,%d,%d) = %q, want %q", c.in, c.maxLines, c.maxBytes, got, c.want)
+		}
+	}
+}
+
+func TestUITail(t *testing.T) {
+	cases := []struct {
+		in       string
+		maxLines int
+		maxBytes int
+		want     string
+	}{
+		{"", 5, 100, ""},
+		{"a\nb\nc\n", 5, 100, "a\nb\nc"},
+		{"a\nb\nc", 2, 100, "b\nc"},
+		{"aaaa\nbbbb\ncccc", 5, 9, "cccc"}, // byte cap keeps whole last lines
+		{"aaaaaaaaaa", 5, 4, "aaaa"},       // single long line: hard byte cut
+	}
+	for _, c := range cases {
+		if got := uiTail(c.in, c.maxLines, c.maxBytes); got != c.want {
+			t.Errorf("uiTail(%q,%d,%d) = %q, want %q", c.in, c.maxLines, c.maxBytes, got, c.want)
+		}
+	}
+}
+
+// uiOf extracts the map payload from a ToolResult, failing the test when
+// missing — shared by the per-tool payload tests below.
+func uiOf(t *testing.T, res any) map[string]any {
+	t.Helper()
+	ui, ok := res.(map[string]any)
+	if !ok {
+		t.Fatalf("UI payload = %T (%v), want map", res, res)
+	}
+	return ui
+}
+
+func TestReadFile_UIPayload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := ReadFileTool{}.Execute(context.Background(), "read_file", map[string]any{"path": path})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	ui := uiOf(t, res.UI)
+	if ui["type"] != "file_read" || ui["lines_read"] != 3 || ui["total_lines"] != 3 || ui["truncated"] != false {
+		t.Errorf("payload = %+v", ui)
+	}
+	preview, _ := ui["content_preview"].(string)
+	if !strings.Contains(preview, "two") || strings.Contains(preview, "[end of file") {
+		t.Errorf("preview = %q, want file content without footers", preview)
+	}
+}
+
+func TestGlob_UIPayload(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.go", "b.go", "c.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	res, err := GlobTool{}.Execute(context.Background(), "glob", map[string]any{
+		"pattern": "*.go", "path": dir,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	ui := uiOf(t, res.UI)
+	if ui["type"] != "file_list" || ui["total"] != 2 {
+		t.Errorf("payload = %+v", ui)
+	}
+	entries, _ := ui["entries"].([]map[string]any)
+	if len(entries) != 2 {
+		t.Fatalf("entries = %+v", entries)
+	}
+	// Entries are root-relative, not absolute.
+	if name, _ := entries[0]["name"].(string); filepath.IsAbs(name) || !strings.HasSuffix(name, ".go") {
+		t.Errorf("entry name = %q, want relative *.go", name)
+	}
+}
+
+func TestGrep_UIPayload_ContentMode(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hit here\nmiss\nanother hit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := GrepTool{}.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "hit", "path": dir,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	ui := uiOf(t, res.UI)
+	if ui["type"] != "search" || ui["total_matches"] != 2 || ui["files_with_matches"] != 1 {
+		t.Errorf("payload = %+v", ui)
+	}
+	matches, _ := ui["matches"].([]map[string]any)
+	if len(matches) != 2 || matches[0]["line_no"] != 1 {
+		t.Errorf("matches = %+v", matches)
+	}
+}
+
+func TestGrep_UIPayload_SkippedForContextRuns(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hit\nctx\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := GrepTool{}.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "hit", "path": dir, "context_lines": 1,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.UI != nil {
+		t.Errorf("context run should carry no UI payload, got %+v", res.UI)
+	}
+}
+
+func TestTerminal_UIPayload(t *testing.T) {
+	res, err := TerminalTool{}.Execute(context.Background(), "terminal", map[string]any{
+		"command": "echo hello",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	ui := uiOf(t, res.UI)
+	if ui["type"] != "terminal" || ui["status"] != "success" || ui["command"] != "echo hello" {
+		t.Errorf("payload = %+v", ui)
+	}
+
+	res, err = TerminalTool{}.Execute(context.Background(), "terminal", map[string]any{
+		"command": "echo oops; exit 1",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	ui = uiOf(t, res.UI)
+	if ui["status"] != "failed" {
+		t.Errorf("payload = %+v, want status failed", ui)
+	}
+	if preview, _ := ui["output_preview"].(string); !strings.Contains(preview, "oops") {
+		t.Errorf("preview = %q, want stdout tail", preview)
+	}
+}
+
+func TestEditFile_UIPayload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("hello old world\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path": path, "old_string": "old world", "new_string": "new world",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	ui := uiOf(t, res.UI)
+	if ui["type"] != "edit" || ui["occurrences"] != 1 {
+		t.Errorf("payload = %+v", ui)
+	}
+	diff, _ := ui["diff"].(string)
+	if !strings.Contains(diff, "- old world") || !strings.Contains(diff, "+ new world") {
+		t.Errorf("diff = %q, want -old/+new lines", diff)
+	}
+}
+
+func TestWriteFile_UIPayload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	res, err := WriteFileTool{}.Execute(context.Background(), "write_file", map[string]any{
+		"path": path, "content": "hello\n",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	ui := uiOf(t, res.UI)
+	if ui["type"] != "write" || ui["size_bytes"] != 6 {
+		t.Errorf("payload = %+v", ui)
+	}
+}
+
+func TestTasks_UIPayload(t *testing.T) {
+	useTaskStore(t)
+	res, err := TaskCreateTool{}.Execute(context.Background(), "task_create", map[string]any{
+		"subject": "Do the thing",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	ui := uiOf(t, res.UI)
+	if ui["type"] != "todo" || ui["action"] != "Created #1" || ui["progress"] != "0/1 done" {
+		t.Errorf("payload = %+v", ui)
+	}
+	todos, _ := ui["todos"].([]map[string]any)
+	if len(todos) != 1 || todos[0]["task"] != "Do the thing" || todos[0]["status"] != "pending" {
+		t.Errorf("todos = %+v", todos)
+	}
+}

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -113,6 +113,7 @@ func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any)
 	out, jinaErr := fetchViaJina(jinaCtx, raw)
 	jinaCancel()
 	if jinaErr == nil {
+		out.UI = webFetchUI(raw, out.Text)
 		return out, nil
 	}
 
@@ -125,6 +126,7 @@ func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any)
 		out, directErr := fetchDirect(directCtx, raw)
 		directCancel()
 		if directErr == nil {
+			out.UI = webFetchUI(raw, out.Text)
 			return out, nil
 		}
 		// Both failed — surface both errors so the LLM knows what happened.
@@ -132,6 +134,17 @@ func (WebFetchTool) Execute(ctx context.Context, _ string, input map[string]any)
 	}
 
 	return agent.ToolResult{Text: ""}, fmt.Errorf("web_fetch: %w", jinaErr)
+}
+
+// webFetchUI builds the "web_fetch" UI payload. Title and status code are
+// not surfaced by the fetch pipeline, so the card shows URL + a short
+// preview of the rendered text.
+func webFetchUI(url, text string) map[string]any {
+	return map[string]any{
+		"type":            "web_fetch",
+		"url":             url,
+		"content_preview": uiHead(text, 4, 300),
+	}
 }
 
 // shouldFallback returns true when a Jina proxy error is worth retrying

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -129,6 +129,10 @@ func TestWebFetch_AgainstHTTPTest(t *testing.T) {
 	if !strings.Contains(out.Text, "Hello") || !strings.Contains(out.Text, "markdown") {
 		t.Errorf("unexpected body: %q", out.Text)
 	}
+	ui, ok := out.UI.(map[string]any)
+	if !ok || ui["type"] != "web_fetch" || ui["url"] != "https://example.com/article" {
+		t.Errorf("UI payload = %#v", out.UI)
+	}
 }
 
 func TestWebFetch_RefusesCrossHostRedirect(t *testing.T) {

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -177,7 +177,18 @@ func (WebSearchTool) Execute(ctx context.Context, _ string, input map[string]any
 	if err != nil {
 		return agent.ToolResult{}, fmt.Errorf("web_search: marshal: %w", err)
 	}
-	return agent.ToolResult{Text: string(body)}, nil
+	res := agent.ToolResult{Text: string(body)}
+	if succeeded {
+		// Structured payload for the web frontend's rich result card
+		// (sessions.js _renderWebSearchResult expects query/results/total).
+		res.UI = map[string]any{
+			"type":    "web_search",
+			"query":   response.Query,
+			"results": response.Results,
+			"total":   response.Count,
+		}
+	}
+	return res, nil
 }
 
 // ───────────────────── paid API backends ─────────────────────

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -72,6 +72,13 @@ func TestWebSearch_BravePreferred(t *testing.T) {
 	if len(resp.Results) != 2 || resp.Results[0].URL != "https://r1" {
 		t.Errorf("results = %+v", resp.Results)
 	}
+	ui, ok := out.UI.(map[string]any)
+	if !ok {
+		t.Fatalf("UI payload = %T, want map", out.UI)
+	}
+	if ui["type"] != "web_search" || ui["query"] != "go generics" || ui["total"] != 2 {
+		t.Errorf("UI payload = %+v", ui)
+	}
 }
 
 func TestWebSearch_TavilyWhenBraveAbsent(t *testing.T) {
@@ -215,6 +222,9 @@ func TestWebSearch_AllBackendsFail(t *testing.T) {
 	}
 	if resp.Count != 0 {
 		t.Errorf("expected zero results, got %d", resp.Count)
+	}
+	if out.UI != nil {
+		t.Errorf("failed search should carry no UI payload, got %+v", out.UI)
 	}
 }
 

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -70,9 +70,10 @@ func (WriteFileTool) Execute(_ context.Context, _ string, input map[string]any) 
 	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
 		lineCount++
 	}
+	ui := map[string]any{"type": "write", "path": abs, "size_bytes": len(content)}
 	if memory.IsMemoryPath(abs) {
 		memCount := memory.CountMemories(content)
-		return agent.ToolResult{Text: fmt.Sprintf("Saved %d %s to %s", memCount, pluralize(memCount, "memory", "memories"), filepath.Base(abs))}, nil
+		return agent.ToolResult{Text: fmt.Sprintf("Saved %d %s to %s", memCount, pluralize(memCount, "memory", "memories"), filepath.Base(abs)), UI: ui}, nil
 	}
-	return agent.ToolResult{Text: fmt.Sprintf("Wrote %d bytes (%d lines) to %s", len(content), lineCount, abs)}, nil
+	return agent.ToolResult{Text: fmt.Sprintf("Wrote %d bytes (%d lines) to %s", len(content), lineCount, abs), UI: ui}, nil
 }


### PR DESCRIPTION
## Problem

Tool calls in the web UI dump raw JSON/text into the transcript (screenshot case: `web_search` printing its whole `WebSearchResponse`), pushing the actual answer below the fold. The frontend already ships 9 rich result-card renderers (`_renderRichResult`), but nothing on the backend ever populated `ui_payload`, so every result fell through to the raw `<pre>` path.

## Changes

**Backend — wire `ui_payload` end to end (tools produce it)**

- `agent.ToolResult` gains an optional `UI any` field: a structured rendering of the result for UI consumers. It never reaches the model — only `Text`/`Blocks` do.
- It travels on the `tool_result` `ContentBlock` (`json:"ui,omitempty"`, so it persists with the session and survives history replay) and on `EventToolDone` (untruncated, unlike `Output`).
- `ws_handlers.go` broadcasts it as `ui_payload` on live `tool_result` events; `handlers.go` emits it during history replay. Provider adapters build their wire payloads field-by-field, so the new field is invisible to the API.

**All built-in tools now produce payloads**

| Tool | Card type | Payload |
|---|---|---|
| `web_search` | web_search | query + clickable titles/snippets + total |
| `read_file` | file_read | lines read/total, truncation, content preview |
| `glob` | file_list | root-relative entries + total |
| `grep` | search | parsed `file:line:content` matches (plain content mode only — context runs / single-file output would mis-parse and get none) |
| `terminal` | terminal | command, success/failed/running, tail-of-output preview |
| `web_fetch` | web_fetch | url + short text preview |
| `edit_file` | edit | occurrences + `-old`/`+new` replacement block (an exact substring swap IS the diff) |
| `write_file` | write | path + size |
| `task_*` | todo | current list + done-count progress |

Previews are hard-capped via shared `uiHead`/`uiTail` helpers since payloads persist in session JSON.

**Frontend — collapse tool output to a one-line summary by default**

- Each tool item is now a single line: chevron + name/args summary + per-type result hint (`5 results` / `12 matches` / `3/5 done`) + status tick. Clicking the header toggles the result area.
- Streaming stdout and diff previews auto-expand while the tool is running, then collapse on completion. A manual toggle (`data-user-toggled`) always wins over the automatics.
- Live path and history replay share one code path (`_applyResultToItem`).

**Fix — background-completion notes no longer leak into the transcript**

Background-process completion notes are injected into the model's inbox as `<system-reminder>` blocks (`formatBgNote`) and persist inside user turns. The TUI skips them when rendering; the web server broadcast them verbatim as `history_user_message`, so the full output dump of a finished background command rendered as a giant user bubble — both live (`EventSteerInjected`) and on history replay of CLI/TUI sessions. `agent.StripSystemReminders` (exported from the session-title helper) is now applied on both server paths: a pure-reminder steer item produces no bubble; a mixed turn keeps only the user's own words. The IM channel was audited and is unaffected (it neither echoes steer events nor injects bg notes).

## Tests

- Agent: payload reaches the result block and `EventToolDone`; error results never carry one.
- Tools: per-tool payload assertions, `uiHead`/`uiTail` unit tests, typed-nil regression for grep's skip path; rg-dependent tests follow the `requireRg` skip convention.
- Server: `ui_payload` survives the session JSON round-trip into replay events; `TestHandleGetSessionMessages_StripsSystemReminders` covers the leak fix (pure-reminder and mixed turns).
- `make test` (race) green across the repo; CI green on Linux/macOS/Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)