### PR TITLE
feat(server): MCP server management API + tool_search settings API

### DIFF
--- a/internal/app/mcp.go
+++ b/internal/app/mcp.go
@@ -40,8 +40,7 @@ func ConnectMCP(ctx context.Context, cwd string, warn io.Writer) (func(), error)
 	connectCtx, cancel := context.WithTimeout(ctx, mcpConnectTimeout)
 	defer cancel() // only bounds the connect pass; live connections aren't tied to it
 
-	info := mcp.Implementation{Name: "octo", Version: version.Version}
-	reg := mcp.ConnectAll(connectCtx, cfg, info, nil /* no interactive OAuth */, warn, nil)
+	reg := mcp.ConnectAll(connectCtx, cfg, mcpInfo(), nil /* no interactive OAuth */, warn, nil)
 	if reg.Len() == 0 {
 		reg.Close()
 		return func() {}, nil
@@ -52,6 +51,75 @@ func ConnectMCP(ctx context.Context, cwd string, warn io.Writer) (func(), error)
 		tools.SetMCPRegistry(nil)
 		reg.Close()
 	}, nil
+}
+
+// mcpInfo is the client identity every octo entry point presents in the MCP
+// initialize handshake.
+func mcpInfo() mcp.Implementation {
+	return mcp.Implementation{Name: "octo", Version: version.Version}
+}
+
+// SwapMCP reloads the MCP config under cwd, connects a fresh registry, and
+// atomically replaces the active one (closing the old registry after the
+// swap so in-flight readers holding it can finish dialing). Unlike ConnectMCP
+// it installs the registry even when zero servers connected — the per-server
+// connect errors it records are what a management UI displays. With zero
+// servers configured the active registry is cleared. On config error the
+// active registry is left untouched.
+//
+// Callers that expose this concurrently (the web server) must serialise calls
+// themselves; two overlapping swaps would race on which registry survives.
+func SwapMCP(ctx context.Context, cwd string, warn io.Writer) error {
+	cfg, err := mcp.LoadConfig(cwd)
+	if err != nil {
+		return err
+	}
+	old := tools.ActiveMCPRegistry()
+	var reg *mcp.Registry
+	if cfg != nil && len(cfg.Servers) > 0 {
+		connectCtx, cancel := context.WithTimeout(ctx, mcpConnectTimeout)
+		defer cancel()
+		reg = mcp.ConnectAll(connectCtx, cfg, mcpInfo(), nil /* no interactive OAuth */, warn, nil)
+	}
+	tools.SetMCPRegistry(reg)
+	if old != nil {
+		old.Close()
+	}
+	return nil
+}
+
+// ConnectMCPServer connects (or reconnects) a single named server into the
+// active registry, installing an empty registry first if none is active —
+// the incremental path the web management API uses so adding one server
+// doesn't restart every other connection. The connect error (if any) is
+// recorded on the registry and returned.
+func ConnectMCPServer(ctx context.Context, name string, entry mcp.ServerEntry, childStderr io.Writer) error {
+	reg := tools.ActiveMCPRegistry()
+	if reg == nil {
+		reg = mcp.NewRegistry()
+		tools.SetMCPRegistry(reg)
+	}
+	connectCtx, cancel := context.WithTimeout(ctx, mcpConnectTimeout)
+	defer cancel()
+	return reg.Connect(connectCtx, name, entry, mcpInfo(), nil /* no interactive OAuth */, childStderr)
+}
+
+// DisconnectMCPServer drops one server's live connection (and recorded
+// connect error) from the active registry, if any.
+func DisconnectMCPServer(name string) {
+	if reg := tools.ActiveMCPRegistry(); reg != nil {
+		reg.Remove(name)
+	}
+}
+
+// ShutdownMCP clears the active registry and closes it. The counterpart of
+// SwapMCP for process shutdown.
+func ShutdownMCP() {
+	old := tools.ActiveMCPRegistry()
+	tools.SetMCPRegistry(nil)
+	if old != nil {
+		old.Close()
+	}
 }
 
 // ToolSearchConfigFrom maps the persisted tools.tool_search config block onto

--- a/internal/app/mcp_manage_test.go
+++ b/internal/app/mcp_manage_test.go
@@ -1,0 +1,164 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/mcp"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// fakeMCPHTTPServer speaks the minimal JSON-RPC-over-HTTP surface the connect
+// path needs (initialize, initialized notification, surface listings).
+func fakeMCPHTTPServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var in mcp.Message
+		_ = json.Unmarshal(body, &in)
+		if in.ID == nil {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		var result any
+		switch in.Method {
+		case "initialize":
+			result = mcp.InitializeResult{
+				ProtocolVersion: mcp.ProtocolVersion,
+				Capabilities:    mcp.ServerCapabilities{Tools: &mcp.ToolsCapability{}},
+				ServerInfo:      mcp.Implementation{Name: "fake", Version: "0"},
+			}
+		case "tools/list":
+			result = map[string]any{"tools": []mcp.Tool{{Name: "ping", Description: "ping", InputSchema: json.RawMessage(`{"type":"object"}`)}}}
+		case "resources/list":
+			result = map[string]any{"resources": []mcp.Resource{}}
+		case "prompts/list":
+			result = map[string]any{"prompts": []mcp.Prompt{}}
+		default:
+			result = map[string]any{}
+		}
+		raw, _ := json.Marshal(result)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mcp.Message{JSONRPC: "2.0", ID: in.ID, Result: raw})
+	}))
+}
+
+func writeUserMCPConfig(t *testing.T, home, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(home, ".octo"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".octo", "mcp.json"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSwapMCP_InstallsThenClears(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	defer ShutdownMCP()
+
+	srv := fakeMCPHTTPServer(t)
+	defer srv.Close()
+
+	writeUserMCPConfig(t, home, `{"mcpServers": {"fake": {"url": "`+srv.URL+`"}}}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := SwapMCP(ctx, t.TempDir(), io.Discard); err != nil {
+		t.Fatalf("SwapMCP: %v", err)
+	}
+	reg := tools.ActiveMCPRegistry()
+	if reg == nil || reg.Get("fake") == nil {
+		t.Fatal("registry with fake server should be installed")
+	}
+
+	// A server that fails to connect must still leave the registry installed
+	// (carrying the error) — that's what the management UI reads.
+	writeUserMCPConfig(t, home, `{"mcpServers": {"dead": {"url": "http://127.0.0.1:1"}}}`)
+	if err := SwapMCP(ctx, t.TempDir(), io.Discard); err != nil {
+		t.Fatalf("SwapMCP: %v", err)
+	}
+	reg = tools.ActiveMCPRegistry()
+	if reg == nil {
+		t.Fatal("registry must stay installed when all servers fail")
+	}
+	if msg, ok := reg.ConnectError("dead"); !ok || msg == "" {
+		t.Error("connect error should be recorded on the swapped registry")
+	}
+
+	// Zero servers configured clears the registry.
+	writeUserMCPConfig(t, home, `{"mcpServers": {}}`)
+	if err := SwapMCP(ctx, t.TempDir(), io.Discard); err != nil {
+		t.Fatalf("SwapMCP: %v", err)
+	}
+	if tools.ActiveMCPRegistry() != nil {
+		t.Error("empty config should clear the active registry")
+	}
+}
+
+func TestSwapMCP_ConfigErrorKeepsOldRegistry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	defer ShutdownMCP()
+
+	srv := fakeMCPHTTPServer(t)
+	defer srv.Close()
+
+	writeUserMCPConfig(t, home, `{"mcpServers": {"fake": {"url": "`+srv.URL+`"}}}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := SwapMCP(ctx, t.TempDir(), io.Discard); err != nil {
+		t.Fatalf("SwapMCP: %v", err)
+	}
+	old := tools.ActiveMCPRegistry()
+
+	writeUserMCPConfig(t, home, `not json`)
+	if err := SwapMCP(ctx, t.TempDir(), io.Discard); err == nil {
+		t.Fatal("expected config parse error")
+	}
+	if tools.ActiveMCPRegistry() != old {
+		t.Error("config error must leave the old registry untouched")
+	}
+	if old.Get("fake") == nil {
+		t.Error("old registry's connections must survive a failed swap")
+	}
+}
+
+func TestConnectMCPServer_InstallsRegistryOnDemand(t *testing.T) {
+	defer ShutdownMCP()
+	tools.SetMCPRegistry(nil)
+
+	srv := fakeMCPHTTPServer(t)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := ConnectMCPServer(ctx, "first", mcp.ServerEntry{URL: srv.URL}, nil); err != nil {
+		t.Fatalf("ConnectMCPServer: %v", err)
+	}
+	reg := tools.ActiveMCPRegistry()
+	if reg == nil || reg.Get("first") == nil {
+		t.Fatal("registry should be created and hold the connection")
+	}
+
+	DisconnectMCPServer("first")
+	if reg.Get("first") != nil {
+		t.Error("DisconnectMCPServer should drop the connection")
+	}
+	DisconnectMCPServer("never-existed") // no-op, no panic
+
+	ShutdownMCP()
+	if tools.ActiveMCPRegistry() != nil {
+		t.Error("ShutdownMCP should clear the registry")
+	}
+}

--- a/internal/mcp/manage.go
+++ b/internal/mcp/manage.go
@@ -1,0 +1,177 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// This file is the management view of the MCP config — what a settings UI
+// needs, as opposed to what a connecting session needs. LoadConfig (config.go)
+// answers "which servers should I connect": it merges, drops disabled entries,
+// and fails hard on invalid ones. LoadManaged answers "which servers exist":
+// it keeps disabled entries, annotates invalid ones instead of failing, and
+// remembers which file each entry came from so the UI can mark project-level
+// entries read-only.
+//
+// All mutations target the user-global file (~/.octo/mcp.json) only. The
+// project-local file is owned by the repository it lives in; a web UI writing
+// into someone's checkout would be a surprise.
+
+// ManagedServer is one config entry in the management view.
+type ManagedServer struct {
+	Name   string
+	Entry  ServerEntry
+	Source string // "user" | "project"; project entries shadow user ones
+	// Invalid carries the validation error for a malformed entry ("" when
+	// valid). Malformed entries are kept visible so the UI can show — and
+	// the user can fix — what LoadConfig would reject.
+	Invalid string
+}
+
+// LoadManaged returns every configured server, including disabled and invalid
+// entries, sorted by name. Project-local entries override user-global ones
+// with the same name, mirroring LoadConfig's merge rule.
+func LoadManaged(projectDir string) ([]ManagedServer, error) {
+	byName := map[string]ManagedServer{}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		cfg, err := readConfigFile(filepath.Join(home, ".octo", "mcp.json"))
+		if err != nil {
+			return nil, err
+		}
+		if cfg != nil {
+			for name, e := range cfg.Servers {
+				byName[name] = managedEntry(name, e, "user")
+			}
+		}
+	}
+
+	if projectDir != "" {
+		cfg, err := readConfigFile(filepath.Join(projectDir, ".octo", "mcp.json"))
+		if err != nil {
+			return nil, err
+		}
+		if cfg != nil {
+			for name, e := range cfg.Servers {
+				byName[name] = managedEntry(name, e, "project")
+			}
+		}
+	}
+
+	out := make([]ManagedServer, 0, len(byName))
+	for _, m := range byName {
+		out = append(out, m)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func managedEntry(name string, e ServerEntry, source string) ManagedServer {
+	m := ManagedServer{Name: name, Entry: e, Source: source}
+	if err := e.Validate(name); err != nil {
+		m.Invalid = err.Error()
+	}
+	return m
+}
+
+// UserConfigPath returns the absolute path of the user-global MCP config
+// (~/.octo/mcp.json).
+func UserConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".octo", "mcp.json"), nil
+}
+
+// ValidateServerName rejects names that would break the mcp__<server>__<tool>
+// tool-name encoding or read ambiguously in config files.
+func ValidateServerName(name string) error {
+	if name == "" {
+		return fmt.Errorf("mcp server name must not be empty")
+	}
+	if strings.ContainsAny(name, " \t\n") {
+		return fmt.Errorf("mcp server name %q must not contain whitespace", name)
+	}
+	if strings.Contains(name, "__") {
+		return fmt.Errorf("mcp server name %q must not contain \"__\" (reserved as the tool-name separator)", name)
+	}
+	return nil
+}
+
+// UpsertUserServer validates the entry and writes it into the user-global
+// config, creating the file (and ~/.octo) on first use. Existing entries
+// under other names are preserved verbatim.
+func UpsertUserServer(name string, e ServerEntry) error {
+	if err := ValidateServerName(name); err != nil {
+		return err
+	}
+	if err := e.Validate(name); err != nil {
+		return err
+	}
+	return mutateUserConfig(func(cfg *Config) error {
+		cfg.Servers[name] = e
+		return nil
+	})
+}
+
+// DeleteUserServer removes the named entry from the user-global config.
+// Deleting a name that isn't there is an error so the caller can distinguish
+// "removed" from "was a project-level entry all along".
+func DeleteUserServer(name string) error {
+	return mutateUserConfig(func(cfg *Config) error {
+		if _, ok := cfg.Servers[name]; !ok {
+			return fmt.Errorf("mcp server %q not found in user config", name)
+		}
+		delete(cfg.Servers, name)
+		return nil
+	})
+}
+
+// SetUserServerDisabled flips the disabled flag on a user-global entry.
+func SetUserServerDisabled(name string, disabled bool) error {
+	return mutateUserConfig(func(cfg *Config) error {
+		e, ok := cfg.Servers[name]
+		if !ok {
+			return fmt.Errorf("mcp server %q not found in user config", name)
+		}
+		e.Disabled = disabled
+		cfg.Servers[name] = e
+		return nil
+	})
+}
+
+// mutateUserConfig reads the raw user-global config, applies fn, and writes
+// the result back. The file is written 0600 (entries may carry auth headers)
+// and indented so it stays hand-editable.
+func mutateUserConfig(fn func(*Config) error) error {
+	path, err := UserConfigPath()
+	if err != nil {
+		return err
+	}
+	cfg, err := readConfigFile(path)
+	if err != nil {
+		return err
+	}
+	if cfg == nil {
+		cfg = &Config{}
+	}
+	if cfg.Servers == nil {
+		cfg.Servers = map[string]ServerEntry{}
+	}
+	if err := fn(cfg); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}

--- a/internal/mcp/manage_test.go
+++ b/internal/mcp/manage_test.go
@@ -1,0 +1,197 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeMCPFile(t *testing.T, dir, content string) {
+	t.Helper()
+	octoDir := filepath.Join(dir, ".octo")
+	if err := os.MkdirAll(octoDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(octoDir, "mcp.json"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupManageHome(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	return tmp
+}
+
+func TestLoadManaged_MergesAndAnnotates(t *testing.T) {
+	home := setupManageHome(t)
+	writeMCPFile(t, home, `{"mcpServers": {
+		"user-only": {"command": "echo"},
+		"shadowed":  {"command": "user-version"},
+		"off":       {"url": "https://x.example", "disabled": true},
+		"broken":    {}
+	}}`)
+	proj := t.TempDir()
+	writeMCPFile(t, proj, `{"mcpServers": {
+		"shadowed":   {"url": "https://proj.example"},
+		"proj-only":  {"command": "ls"}
+	}}`)
+
+	managed, err := LoadManaged(proj)
+	if err != nil {
+		t.Fatalf("LoadManaged: %v", err)
+	}
+
+	byName := map[string]ManagedServer{}
+	for _, m := range managed {
+		byName[m.Name] = m
+	}
+	if len(managed) != 5 {
+		t.Fatalf("got %d entries, want 5: %+v", len(managed), managed)
+	}
+	if byName["user-only"].Source != "user" {
+		t.Errorf("user-only source = %q, want user", byName["user-only"].Source)
+	}
+	if byName["proj-only"].Source != "project" {
+		t.Errorf("proj-only source = %q, want project", byName["proj-only"].Source)
+	}
+	if got := byName["shadowed"]; got.Source != "project" || got.Entry.URL != "https://proj.example" {
+		t.Errorf("shadowed should be the project version, got %+v", got)
+	}
+	if !byName["off"].Entry.Disabled {
+		t.Error("disabled entry must stay visible in the managed view")
+	}
+	if byName["broken"].Invalid == "" {
+		t.Error("invalid entry must carry a validation message, not be dropped")
+	}
+	// Sorted by name.
+	for i := 1; i < len(managed); i++ {
+		if managed[i-1].Name > managed[i].Name {
+			t.Errorf("not sorted: %q before %q", managed[i-1].Name, managed[i].Name)
+		}
+	}
+}
+
+func TestLoadManaged_NoFiles(t *testing.T) {
+	setupManageHome(t)
+	managed, err := LoadManaged(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadManaged: %v", err)
+	}
+	if len(managed) != 0 {
+		t.Fatalf("expected empty, got %+v", managed)
+	}
+}
+
+func TestUpsertUserServer_CreatesAndPreserves(t *testing.T) {
+	home := setupManageHome(t)
+
+	// First write creates ~/.octo/mcp.json from nothing.
+	if err := UpsertUserServer("alpha", ServerEntry{Command: "echo"}); err != nil {
+		t.Fatalf("UpsertUserServer: %v", err)
+	}
+	// Second write must preserve the first entry.
+	if err := UpsertUserServer("beta", ServerEntry{URL: "https://b.example"}); err != nil {
+		t.Fatalf("UpsertUserServer: %v", err)
+	}
+	// Update in place.
+	if err := UpsertUserServer("alpha", ServerEntry{Command: "ls", Args: []string{"-la"}}); err != nil {
+		t.Fatalf("UpsertUserServer update: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(home, ".octo", "mcp.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("written file is not valid JSON: %v", err)
+	}
+	if len(cfg.Servers) != 2 {
+		t.Fatalf("got %d servers, want 2", len(cfg.Servers))
+	}
+	if cfg.Servers["alpha"].Command != "ls" || len(cfg.Servers["alpha"].Args) != 1 {
+		t.Errorf("alpha not updated: %+v", cfg.Servers["alpha"])
+	}
+	if cfg.Servers["beta"].URL != "https://b.example" {
+		t.Errorf("beta lost on second write: %+v", cfg.Servers["beta"])
+	}
+}
+
+func TestUpsertUserServer_RejectsInvalid(t *testing.T) {
+	setupManageHome(t)
+	cases := []struct {
+		name  string
+		entry ServerEntry
+		want  string
+	}{
+		{"both", ServerEntry{Command: "echo", URL: "https://x"}, "cannot set both"},
+		{"neither", ServerEntry{}, "must set either"},
+		{"bad__name", ServerEntry{Command: "echo"}, "__"},
+		{"has space", ServerEntry{Command: "echo"}, "whitespace"},
+		{"", ServerEntry{Command: "echo"}, "empty"},
+	}
+	for _, c := range cases {
+		err := UpsertUserServer(c.name, c.entry)
+		if err == nil {
+			t.Errorf("name=%q: expected error", c.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), c.want) {
+			t.Errorf("name=%q: error %q should mention %q", c.name, err, c.want)
+		}
+	}
+	// Nothing should have been written.
+	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".octo", "mcp.json")); !os.IsNotExist(err) {
+		t.Error("rejected upserts must not create the config file")
+	}
+}
+
+func TestDeleteUserServer(t *testing.T) {
+	home := setupManageHome(t)
+	writeMCPFile(t, home, `{"mcpServers": {"a": {"command": "echo"}, "b": {"command": "ls"}}}`)
+
+	if err := DeleteUserServer("a"); err != nil {
+		t.Fatalf("DeleteUserServer: %v", err)
+	}
+	if err := DeleteUserServer("missing"); err == nil {
+		t.Error("deleting an unknown name must error")
+	}
+
+	managed, err := LoadManaged("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(managed) != 1 || managed[0].Name != "b" {
+		t.Fatalf("expected only b to remain, got %+v", managed)
+	}
+}
+
+func TestSetUserServerDisabled(t *testing.T) {
+	home := setupManageHome(t)
+	writeMCPFile(t, home, `{"mcpServers": {"a": {"command": "echo"}}}`)
+
+	if err := SetUserServerDisabled("a", true); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	managed, _ := LoadManaged("")
+	if !managed[0].Entry.Disabled {
+		t.Error("entry should be disabled")
+	}
+
+	if err := SetUserServerDisabled("a", false); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	managed, _ = LoadManaged("")
+	if managed[0].Entry.Disabled {
+		t.Error("entry should be enabled again")
+	}
+
+	if err := SetUserServerDisabled("missing", true); err == nil {
+		t.Error("toggling an unknown name must error")
+	}
+}

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -19,7 +19,15 @@ import (
 type Registry struct {
 	mu     sync.RWMutex
 	conns  map[string]*Connection // server name → live client
+	errs   map[string]string      // server name → last connect error (no live conn)
 	closed bool
+}
+
+// NewRegistry returns an empty registry ready for incremental Connect calls.
+// ConnectAll builds on it; management UIs use it directly when the first
+// server is added at runtime to a session that started with none.
+func NewRegistry() *Registry {
+	return &Registry{conns: map[string]*Connection{}, errs: map[string]string{}}
 }
 
 // Connection is the per-server bundle of state the adapters need: the
@@ -55,7 +63,7 @@ type Connection struct {
 // must point at a log file or io.Discard, never the terminal. nil falls back to
 // os.Stderr inside the transport.
 func ConnectAll(ctx context.Context, cfg *Config, info Implementation, authPromptFor func(serverName string) OAuthPrompt, warn, childStderr io.Writer) *Registry {
-	r := &Registry{conns: map[string]*Connection{}}
+	r := NewRegistry()
 	if cfg == nil {
 		return r
 	}
@@ -67,6 +75,7 @@ func ConnectAll(ctx context.Context, cfg *Config, info Implementation, authPromp
 		}
 		conn, err := connectOne(ctx, name, entry, info, prompt, childStderr)
 		if err != nil {
+			r.errs[name] = err.Error()
 			if warn != nil {
 				fmt.Fprintf(warn, "mcp: server %q skipped: %v\n", name, err)
 			}
@@ -139,6 +148,62 @@ func connectOne(ctx context.Context, name string, entry ServerEntry, info Implem
 		conn.Prompts = prompts
 	}
 	return conn, nil
+}
+
+// Connect (re)connects one server and installs the connection, replacing —
+// and closing — any previous connection under the same name. On failure the
+// stale connection (if any) is dropped and the error is recorded so
+// ConnectError can report it; the error is also returned. Safe for concurrent
+// use; the dial itself runs outside the lock so a slow server doesn't block
+// readers.
+func (r *Registry) Connect(ctx context.Context, name string, entry ServerEntry, info Implementation, authPrompt OAuthPrompt, childStderr io.Writer) error {
+	conn, err := connectOne(ctx, name, entry, info, authPrompt, childStderr)
+
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		if conn != nil {
+			_ = conn.Client.Close()
+		}
+		return fmt.Errorf("mcp: registry closed")
+	}
+	old := r.conns[name]
+	if err != nil {
+		delete(r.conns, name)
+		r.errs[name] = err.Error()
+	} else {
+		r.conns[name] = conn
+		delete(r.errs, name)
+	}
+	r.mu.Unlock()
+
+	if old != nil {
+		_ = old.Client.Close()
+	}
+	return err
+}
+
+// Remove closes and forgets the named connection (and any recorded connect
+// error). Removing an unknown name is a no-op.
+func (r *Registry) Remove(name string) {
+	r.mu.Lock()
+	old := r.conns[name]
+	delete(r.conns, name)
+	delete(r.errs, name)
+	r.mu.Unlock()
+	if old != nil {
+		_ = old.Client.Close()
+	}
+}
+
+// ConnectError reports the last connect failure for a server that has no live
+// connection. ok is false when the server either connected fine or was never
+// attempted.
+func (r *Registry) ConnectError(name string) (msg string, ok bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	msg, ok = r.errs[name]
+	return
 }
 
 // Connections returns the live connections in stable order so /mcp output

--- a/internal/mcp/registry_manage_test.go
+++ b/internal/mcp/registry_manage_test.go
@@ -1,0 +1,167 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// fakeMCPServer speaks just enough JSON-RPC-over-HTTP for connectOne: the
+// initialize handshake, the initialized notification, and the three surface
+// listings.
+func fakeMCPServer(t *testing.T, toolNames ...string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var in Message
+		_ = json.Unmarshal(body, &in)
+		if in.ID == nil { // notification — 204 per the Streamable HTTP spec
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		var result any
+		switch in.Method {
+		case "initialize":
+			result = InitializeResult{
+				ProtocolVersion: ProtocolVersion,
+				Capabilities:    ServerCapabilities{Tools: &ToolsCapability{}},
+				ServerInfo:      Implementation{Name: "fake", Version: "0"},
+			}
+		case "tools/list":
+			tools := make([]Tool, 0, len(toolNames))
+			for _, n := range toolNames {
+				tools = append(tools, Tool{Name: n, Description: n, InputSchema: json.RawMessage(`{"type":"object"}`)})
+			}
+			result = map[string]any{"tools": tools}
+		case "resources/list":
+			result = map[string]any{"resources": []Resource{}}
+		case "prompts/list":
+			result = map[string]any{"prompts": []Prompt{}}
+		default:
+			result = map[string]any{}
+		}
+		raw, _ := json.Marshal(result)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Message{JSONRPC: "2.0", ID: in.ID, Result: raw})
+	}))
+}
+
+func TestRegistryConnect_AddAndReplace(t *testing.T) {
+	srv := fakeMCPServer(t, "ping", "pong")
+	defer srv.Close()
+
+	r := NewRegistry()
+	defer r.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := r.Connect(ctx, "fake", ServerEntry{URL: srv.URL}, Implementation{Name: "test"}, nil, nil); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	conn := r.Get("fake")
+	if conn == nil {
+		t.Fatal("connection not installed")
+	}
+	if len(conn.Tools) != 2 {
+		t.Fatalf("tools = %d, want 2", len(conn.Tools))
+	}
+	if _, ok := r.ConnectError("fake"); ok {
+		t.Error("successful connect must not leave an error")
+	}
+
+	// Reconnect under the same name replaces the connection.
+	if err := r.Connect(ctx, "fake", ServerEntry{URL: srv.URL}, Implementation{Name: "test"}, nil, nil); err != nil {
+		t.Fatalf("reconnect: %v", err)
+	}
+	if r.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", r.Len())
+	}
+}
+
+func TestRegistryConnect_FailureRecordsError(t *testing.T) {
+	r := NewRegistry()
+	defer r.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Nothing listens here; the dial fails fast.
+	err := r.Connect(ctx, "dead", ServerEntry{URL: "http://127.0.0.1:1"}, Implementation{Name: "test"}, nil, nil)
+	if err == nil {
+		t.Fatal("expected connect error")
+	}
+	if msg, ok := r.ConnectError("dead"); !ok || msg == "" {
+		t.Fatalf("ConnectError = (%q, %v), want recorded error", msg, ok)
+	}
+	if r.Get("dead") != nil {
+		t.Error("failed connect must not leave a connection")
+	}
+
+	// A later successful connect clears the recorded error.
+	srv := fakeMCPServer(t)
+	defer srv.Close()
+	if err := r.Connect(ctx, "dead", ServerEntry{URL: srv.URL}, Implementation{Name: "test"}, nil, nil); err != nil {
+		t.Fatalf("recovery connect: %v", err)
+	}
+	if _, ok := r.ConnectError("dead"); ok {
+		t.Error("recovered connect must clear the error")
+	}
+}
+
+func TestRegistryRemove(t *testing.T) {
+	srv := fakeMCPServer(t, "ping")
+	defer srv.Close()
+
+	r := NewRegistry()
+	defer r.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := r.Connect(ctx, "fake", ServerEntry{URL: srv.URL}, Implementation{Name: "test"}, nil, nil); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	r.Remove("fake")
+	if r.Get("fake") != nil || r.Len() != 0 {
+		t.Error("Remove must drop the connection")
+	}
+	r.Remove("fake") // unknown name: no-op, no panic
+}
+
+func TestRegistryConnect_AfterCloseRejected(t *testing.T) {
+	srv := fakeMCPServer(t)
+	defer srv.Close()
+
+	r := NewRegistry()
+	r.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := r.Connect(ctx, "late", ServerEntry{URL: srv.URL}, Implementation{Name: "test"}, nil, nil); err == nil {
+		t.Fatal("Connect on a closed registry must error")
+	}
+}
+
+func TestConnectAll_RecordsPerServerErrors(t *testing.T) {
+	srv := fakeMCPServer(t, "ok-tool")
+	defer srv.Close()
+
+	cfg := &Config{Servers: map[string]ServerEntry{
+		"good": {URL: srv.URL},
+		"bad":  {URL: "http://127.0.0.1:1"},
+	}}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	r := ConnectAll(ctx, cfg, Implementation{Name: "test"}, nil, io.Discard, nil)
+	defer r.Close()
+
+	if r.Get("good") == nil {
+		t.Error("good server should connect")
+	}
+	if msg, ok := r.ConnectError("bad"); !ok || msg == "" {
+		t.Error("bad server's connect error should be recorded")
+	}
+}

--- a/internal/server/mcp_handlers.go
+++ b/internal/server/mcp_handlers.go
@@ -1,0 +1,416 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/Leihb/octo-agent/internal/app"
+	"github.com/Leihb/octo-agent/internal/config"
+	"github.com/Leihb/octo-agent/internal/mcp"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// MCP server management API. Reads merge the user-global and project-local
+// configs (internal/mcp.LoadManaged); writes go to ~/.octo/mcp.json only —
+// project-local entries are presented read-only. Mutations apply to the live
+// registry incrementally (connect/disconnect just the touched server), so a
+// change is effective for the next turn of every session without a restart.
+// All mutation handlers hold s.mcpMu — the registry swap inside reload must
+// not interleave with incremental connects.
+
+type mcpServerInfo struct {
+	Name      string            `json:"name"`
+	Transport string            `json:"transport"` // "stdio" | "http" | "" (invalid entry)
+	Source    string            `json:"source"`    // "user" | "project"
+	Disabled  bool              `json:"disabled"`
+	Invalid   string            `json:"invalid,omitempty"`
+	Command   string            `json:"command,omitempty"`
+	Args      []string          `json:"args,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+	URL       string            `json:"url,omitempty"`
+	Headers   map[string]string `json:"headers,omitempty"`
+	Auth      string            `json:"auth,omitempty"`
+	Status    string            `json:"status"` // "connected" | "error" | "disabled" | "invalid" | "disconnected"
+	Error     string            `json:"error,omitempty"`
+	Tools     int               `json:"tools"`
+}
+
+// mcpServerList builds the management view: configured entries joined with
+// live-registry state.
+func (s *Server) mcpServerList() ([]mcpServerInfo, error) {
+	managed, err := mcp.LoadManaged(s.cwd)
+	if err != nil {
+		return nil, err
+	}
+	reg := tools.ActiveMCPRegistry()
+	out := make([]mcpServerInfo, 0, len(managed))
+	for _, m := range managed {
+		info := mcpServerInfo{
+			Name:      m.Name,
+			Transport: m.Entry.Kind(),
+			Source:    m.Source,
+			Disabled:  m.Entry.Disabled,
+			Invalid:   m.Invalid,
+			Command:   m.Entry.Command,
+			Args:      m.Entry.Args,
+			Env:       m.Entry.Env,
+			URL:       m.Entry.URL,
+			Headers:   m.Entry.Headers,
+			Auth:      m.Entry.Auth,
+		}
+		switch {
+		case m.Invalid != "":
+			info.Status = "invalid"
+		case m.Entry.Disabled:
+			info.Status = "disabled"
+		case reg != nil && reg.Get(m.Name) != nil:
+			info.Status = "connected"
+			info.Tools = len(reg.Get(m.Name).Tools)
+		default:
+			info.Status = "disconnected"
+			if reg != nil {
+				if msg, ok := reg.ConnectError(m.Name); ok {
+					info.Status = "error"
+					info.Error = msg
+				}
+			}
+		}
+		out = append(out, info)
+	}
+	return out, nil
+}
+
+func (s *Server) writeMCPServerList(w http.ResponseWriter) {
+	list, err := s.mcpServerList()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"servers": list})
+}
+
+// connectIfLive dials one server into the active registry unless tools are
+// disabled for this serve process. Connect failures are not surfaced as HTTP
+// errors — the entry is saved either way and the per-server status reports
+// the failure.
+func (s *Server) connectIfLive(r *http.Request, name string, entry mcp.ServerEntry) {
+	if !s.cfg.Tools || entry.Disabled {
+		return
+	}
+	// r.Context() bounds only the dial — an established connection is not
+	// tied to it. A client that gives up mid-connect aborts the attempt; the
+	// recorded per-server error tells them what happened.
+	_ = app.ConnectMCPServer(r.Context(), name, entry, nil)
+}
+
+// ─── GET /api/mcp/servers ───────────────────────────────────────────────────
+
+func (s *Server) handleListMCPServers(w http.ResponseWriter, r *http.Request) {
+	_ = r
+	s.writeMCPServerList(w)
+}
+
+// ─── POST /api/mcp/servers ──────────────────────────────────────────────────
+
+// Accepts either a single server:
+//
+//	{"name": "fs", "server": {"command": "npx", ...}}
+//
+// or a Claude Code-style bulk import (paste of an mcp.json):
+//
+//	{"mcpServers": {"fs": {...}, "api": {...}}}
+//
+// Single create rejects an existing name with 409 (edit goes through PATCH);
+// bulk import upserts.
+func (s *Server) handleCreateMCPServer(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name    string                     `json:"name"`
+		Server  *mcp.ServerEntry           `json:"server"`
+		Servers map[string]mcp.ServerEntry `json:"mcpServers"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	s.mcpMu.Lock()
+	defer s.mcpMu.Unlock()
+
+	switch {
+	case len(req.Servers) > 0:
+		// Bulk import: validate everything first so a half-bad paste doesn't
+		// land half the servers.
+		for name, e := range req.Servers {
+			if err := mcp.ValidateServerName(name); err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			if err := e.Validate(name); err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+		}
+		for name, e := range req.Servers {
+			if err := mcp.UpsertUserServer(name, e); err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			s.connectIfLive(r, name, e)
+		}
+	case req.Name != "" && req.Server != nil:
+		managed, err := mcp.LoadManaged(s.cwd)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		for _, m := range managed {
+			if m.Name == req.Name {
+				writeError(w, http.StatusConflict, "an MCP server with this name already exists")
+				return
+			}
+		}
+		if err := mcp.UpsertUserServer(req.Name, *req.Server); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		s.connectIfLive(r, req.Name, *req.Server)
+	default:
+		writeError(w, http.StatusBadRequest, "expected {name, server} or {mcpServers}")
+		return
+	}
+
+	s.writeMCPServerList(w)
+}
+
+// userManagedServer resolves a path name to its managed entry, rejecting
+// project-level entries (read-only from the web UI). Writes the HTTP error
+// itself; the second return is false when the caller should stop.
+func (s *Server) userManagedServer(w http.ResponseWriter, name string) (mcp.ManagedServer, bool) {
+	managed, err := mcp.LoadManaged(s.cwd)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return mcp.ManagedServer{}, false
+	}
+	for _, m := range managed {
+		if m.Name != name {
+			continue
+		}
+		if m.Source != "user" {
+			writeError(w, http.StatusConflict, "project-level MCP servers are read-only here; edit .octo/mcp.json in the project")
+			return mcp.ManagedServer{}, false
+		}
+		return m, true
+	}
+	writeError(w, http.StatusNotFound, "mcp server not found")
+	return mcp.ManagedServer{}, false
+}
+
+// ─── PATCH /api/mcp/servers/{name} ──────────────────────────────────────────
+
+func (s *Server) handleUpdateMCPServer(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	var req struct {
+		Server *mcp.ServerEntry `json:"server"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Server == nil {
+		writeError(w, http.StatusBadRequest, "expected {server: {...}}")
+		return
+	}
+
+	s.mcpMu.Lock()
+	defer s.mcpMu.Unlock()
+
+	if _, ok := s.userManagedServer(w, name); !ok {
+		return
+	}
+	if err := mcp.UpsertUserServer(name, *req.Server); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	app.DisconnectMCPServer(name)
+	s.connectIfLive(r, name, *req.Server)
+	s.writeMCPServerList(w)
+}
+
+// ─── DELETE /api/mcp/servers/{name} ─────────────────────────────────────────
+
+func (s *Server) handleDeleteMCPServer(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+
+	s.mcpMu.Lock()
+	defer s.mcpMu.Unlock()
+
+	if _, ok := s.userManagedServer(w, name); !ok {
+		return
+	}
+	if err := mcp.DeleteUserServer(name); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	app.DisconnectMCPServer(name)
+	s.writeMCPServerList(w)
+}
+
+// ─── PATCH /api/mcp/servers/{name}/toggle ───────────────────────────────────
+
+func (s *Server) handleToggleMCPServer(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+
+	s.mcpMu.Lock()
+	defer s.mcpMu.Unlock()
+
+	m, ok := s.userManagedServer(w, name)
+	if !ok {
+		return
+	}
+	nowDisabled := !m.Entry.Disabled
+	if err := mcp.SetUserServerDisabled(name, nowDisabled); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if nowDisabled {
+		app.DisconnectMCPServer(name)
+	} else {
+		entry := m.Entry
+		entry.Disabled = false
+		s.connectIfLive(r, name, entry)
+	}
+	s.writeMCPServerList(w)
+}
+
+// ─── POST /api/mcp/servers/{name}/reconnect ─────────────────────────────────
+
+// Reconnect works for any source (project entries too — it touches only the
+// live connection, not the config files).
+func (s *Server) handleReconnectMCPServer(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+
+	s.mcpMu.Lock()
+	defer s.mcpMu.Unlock()
+
+	managed, err := mcp.LoadManaged(s.cwd)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	var entry *mcp.ManagedServer
+	for i := range managed {
+		if managed[i].Name == name {
+			entry = &managed[i]
+			break
+		}
+	}
+	if entry == nil {
+		writeError(w, http.StatusNotFound, "mcp server not found")
+		return
+	}
+	if entry.Invalid != "" {
+		writeError(w, http.StatusConflict, "cannot connect an invalid entry: "+entry.Invalid)
+		return
+	}
+	if entry.Entry.Disabled {
+		writeError(w, http.StatusConflict, "server is disabled; enable it first")
+		return
+	}
+	if !s.cfg.Tools {
+		writeError(w, http.StatusConflict, "tools are disabled on this server")
+		return
+	}
+	_ = app.ConnectMCPServer(r.Context(), name, entry.Entry, nil)
+	s.writeMCPServerList(w)
+}
+
+// ─── POST /api/mcp/reload ───────────────────────────────────────────────────
+
+// Full reload from disk: picks up hand-edited config files and retries every
+// failed connection in one pass.
+func (s *Server) handleReloadMCP(w http.ResponseWriter, r *http.Request) {
+	s.mcpMu.Lock()
+	defer s.mcpMu.Unlock()
+
+	if !s.cfg.Tools {
+		writeError(w, http.StatusConflict, "tools are disabled on this server")
+		return
+	}
+	if err := app.SwapMCP(r.Context(), s.cwd, nil); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.writeMCPServerList(w)
+}
+
+// ─── GET /api/config/toolsearch ─────────────────────────────────────────────
+
+type toolSearchSettings struct {
+	Enabled            string `json:"enabled"` // "auto" | "on" | "off"
+	ThresholdPct       int    `json:"threshold_pct"`
+	SearchDefaultLimit int    `json:"search_default_limit"`
+	MaxSearchLimit     int    `json:"max_search_limit"`
+}
+
+// toolSearchDefaults mirrors the documented tools.tool_search defaults
+// (auto / 10% / 5 / 20) so the UI shows effective values, not zeros.
+func toolSearchDefaults(c config.ToolSearchConfig) toolSearchSettings {
+	out := toolSearchSettings{
+		Enabled:            c.Enabled,
+		ThresholdPct:       c.ThresholdPct,
+		SearchDefaultLimit: c.SearchDefaultLimit,
+		MaxSearchLimit:     c.MaxSearchLimit,
+	}
+	if out.Enabled == "" {
+		out.Enabled = "auto"
+	}
+	if out.ThresholdPct == 0 {
+		out.ThresholdPct = 10
+	}
+	if out.SearchDefaultLimit == 0 {
+		out.SearchDefaultLimit = 5
+	}
+	if out.MaxSearchLimit == 0 {
+		out.MaxSearchLimit = 20
+	}
+	return out
+}
+
+func (s *Server) handleGetToolSearch(w http.ResponseWriter, r *http.Request) {
+	_ = r
+	cfg, err := config.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load config")
+		return
+	}
+	writeJSON(w, http.StatusOK, toolSearchDefaults(cfg.Tools.ToolSearch))
+}
+
+// ─── PUT /api/config/toolsearch ─────────────────────────────────────────────
+
+// Persists tools.tool_search.enabled and applies it to the live process so
+// the next turn of every session sees the change.
+func (s *Server) handlePutToolSearch(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Enabled string `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	switch req.Enabled {
+	case "auto", "on", "off":
+	default:
+		writeError(w, http.StatusBadRequest, `enabled must be "auto", "on", or "off"`)
+		return
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load config")
+		return
+	}
+	cfg.Tools.ToolSearch.Enabled = req.Enabled
+	if err := cfg.Save(); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to save config")
+		return
+	}
+	tools.SetToolSearchConfig(app.ToolSearchConfigFrom(cfg.Tools.ToolSearch))
+	writeJSON(w, http.StatusOK, toolSearchDefaults(cfg.Tools.ToolSearch))
+}

--- a/internal/server/mcp_handlers_test.go
+++ b/internal/server/mcp_handlers_test.go
@@ -1,0 +1,405 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/app"
+	"github.com/Leihb/octo-agent/internal/mcp"
+	"github.com/Leihb/octo-agent/internal/tools"
+
+	"gopkg.in/yaml.v3"
+)
+
+// fakeMCPServerForHandlers speaks the minimal JSON-RPC-over-HTTP surface the
+// connect path needs, advertising a single tool.
+func fakeMCPServerForHandlers(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var in mcp.Message
+		_ = json.Unmarshal(body, &in)
+		if in.ID == nil {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		var result any
+		switch in.Method {
+		case "initialize":
+			result = mcp.InitializeResult{
+				ProtocolVersion: mcp.ProtocolVersion,
+				Capabilities:    mcp.ServerCapabilities{Tools: &mcp.ToolsCapability{}},
+				ServerInfo:      mcp.Implementation{Name: "fake", Version: "0"},
+			}
+		case "tools/list":
+			result = map[string]any{"tools": []mcp.Tool{{Name: "ping", Description: "ping", InputSchema: json.RawMessage(`{"type":"object"}`)}}}
+		case "resources/list":
+			result = map[string]any{"resources": []mcp.Resource{}}
+		case "prompts/list":
+			result = map[string]any{"prompts": []mcp.Prompt{}}
+		default:
+			result = map[string]any{}
+		}
+		raw, _ := json.Marshal(result)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mcp.Message{JSONRPC: "2.0", ID: in.ID, Result: raw})
+	}))
+}
+
+// mcpTestHome points HOME at a temp dir and seeds ~/.octo/mcp.json.
+func mcpTestHome(t *testing.T, mcpJSON string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	if mcpJSON != "" {
+		if err := os.MkdirAll(filepath.Join(tmp, ".octo"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(tmp, ".octo", "mcp.json"), []byte(mcpJSON), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return tmp
+}
+
+func doJSON(t *testing.T, srv *Server, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var req *http.Request
+	if body != "" {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	return w
+}
+
+func decodeServers(t *testing.T, w *httptest.ResponseRecorder) []mcpServerInfo {
+	t.Helper()
+	var resp struct {
+		Servers []mcpServerInfo `json:"servers"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body: %s)", err, w.Body.String())
+	}
+	return resp.Servers
+}
+
+func TestHandleListMCPServers(t *testing.T) {
+	mcpTestHome(t, `{"mcpServers": {
+		"alpha": {"command": "echo"},
+		"off":   {"url": "https://x.example", "disabled": true},
+		"bad":   {}
+	}}`)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	w := doJSON(t, srv, http.MethodGet, "/api/mcp/servers", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	servers := decodeServers(t, w)
+	if len(servers) != 3 {
+		t.Fatalf("got %d servers, want 3", len(servers))
+	}
+	byName := map[string]mcpServerInfo{}
+	for _, s := range servers {
+		byName[s.Name] = s
+	}
+	if byName["alpha"].Status != "disconnected" || byName["alpha"].Transport != "stdio" {
+		t.Errorf("alpha = %+v", byName["alpha"])
+	}
+	if byName["off"].Status != "disabled" || !byName["off"].Disabled {
+		t.Errorf("off = %+v", byName["off"])
+	}
+	if byName["bad"].Status != "invalid" || byName["bad"].Invalid == "" {
+		t.Errorf("bad = %+v", byName["bad"])
+	}
+}
+
+func TestHandleCreateMCPServer_SingleAndConflict(t *testing.T) {
+	home := mcpTestHome(t, "")
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/mcp/servers",
+		`{"name": "fs", "server": {"command": "npx", "args": ["-y", "server-fs"]}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create: status = %d: %s", w.Code, w.Body.String())
+	}
+	servers := decodeServers(t, w)
+	if len(servers) != 1 || servers[0].Name != "fs" || servers[0].Source != "user" {
+		t.Fatalf("servers = %+v", servers)
+	}
+
+	// File written to user config.
+	raw, err := os.ReadFile(filepath.Join(home, ".octo", "mcp.json"))
+	if err != nil || !strings.Contains(string(raw), "server-fs") {
+		t.Fatalf("user config not written: %v %s", err, raw)
+	}
+
+	// Same name again → 409.
+	w = doJSON(t, srv, http.MethodPost, "/api/mcp/servers",
+		`{"name": "fs", "server": {"command": "other"}}`)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("duplicate create: status = %d, want 409", w.Code)
+	}
+
+	// Invalid entry → 400.
+	w = doJSON(t, srv, http.MethodPost, "/api/mcp/servers",
+		`{"name": "both", "server": {"command": "x", "url": "https://y"}}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid create: status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleCreateMCPServer_BulkImport(t *testing.T) {
+	mcpTestHome(t, "")
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/mcp/servers",
+		`{"mcpServers": {"a": {"command": "echo"}, "b": {"url": "https://b.example"}}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("bulk: status = %d: %s", w.Code, w.Body.String())
+	}
+	if servers := decodeServers(t, w); len(servers) != 2 {
+		t.Fatalf("servers = %+v", servers)
+	}
+
+	// A half-bad paste lands nothing.
+	w = doJSON(t, srv, http.MethodPost, "/api/mcp/servers",
+		`{"mcpServers": {"c": {"command": "echo"}, "bad name": {"command": "x"}}}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("half-bad bulk: status = %d, want 400", w.Code)
+	}
+	w = doJSON(t, srv, http.MethodGet, "/api/mcp/servers", "")
+	for _, s := range decodeServers(t, w) {
+		if s.Name == "c" {
+			t.Error("validation must reject the whole paste, not half of it")
+		}
+	}
+}
+
+func TestHandleUpdateMCPServer(t *testing.T) {
+	mcpTestHome(t, `{"mcpServers": {"a": {"command": "echo"}}}`)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	w := doJSON(t, srv, http.MethodPatch, "/api/mcp/servers/a",
+		`{"server": {"url": "https://new.example"}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update: status = %d: %s", w.Code, w.Body.String())
+	}
+	servers := decodeServers(t, w)
+	if servers[0].URL != "https://new.example" || servers[0].Transport != "http" {
+		t.Fatalf("servers = %+v", servers)
+	}
+
+	w = doJSON(t, srv, http.MethodPatch, "/api/mcp/servers/missing",
+		`{"server": {"command": "x"}}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("update missing: status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleDeleteMCPServer(t *testing.T) {
+	mcpTestHome(t, `{"mcpServers": {"a": {"command": "echo"}}}`)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	w := doJSON(t, srv, http.MethodDelete, "/api/mcp/servers/a", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete: status = %d: %s", w.Code, w.Body.String())
+	}
+	if servers := decodeServers(t, w); len(servers) != 0 {
+		t.Fatalf("servers = %+v, want empty", servers)
+	}
+
+	w = doJSON(t, srv, http.MethodDelete, "/api/mcp/servers/a", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("delete again: status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleToggleMCPServer(t *testing.T) {
+	mcpTestHome(t, `{"mcpServers": {"a": {"command": "echo"}}}`)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	w := doJSON(t, srv, http.MethodPatch, "/api/mcp/servers/a/toggle", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("toggle: status = %d: %s", w.Code, w.Body.String())
+	}
+	if servers := decodeServers(t, w); !servers[0].Disabled || servers[0].Status != "disabled" {
+		t.Fatalf("after disable: %+v", servers)
+	}
+
+	w = doJSON(t, srv, http.MethodPatch, "/api/mcp/servers/a/toggle", "")
+	if servers := decodeServers(t, w); servers[0].Disabled {
+		t.Fatalf("after re-enable: %+v", servers)
+	}
+}
+
+func TestMCPHandlers_ProjectEntriesReadOnly(t *testing.T) {
+	mcpTestHome(t, "")
+	proj := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(proj, ".octo"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(proj, ".octo", "mcp.json"),
+		[]byte(`{"mcpServers": {"proj": {"command": "echo"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.cwd = proj
+
+	for _, c := range []struct{ method, path, body string }{
+		{http.MethodPatch, "/api/mcp/servers/proj", `{"server": {"command": "x"}}`},
+		{http.MethodDelete, "/api/mcp/servers/proj", ""},
+		{http.MethodPatch, "/api/mcp/servers/proj/toggle", ""},
+	} {
+		w := doJSON(t, srv, c.method, c.path, c.body)
+		if w.Code != http.StatusConflict {
+			t.Errorf("%s %s: status = %d, want 409", c.method, c.path, w.Code)
+		}
+	}
+}
+
+func TestMCPLifecycle_LiveConnect(t *testing.T) {
+	mcpTestHome(t, "")
+	t.Cleanup(app.ShutdownMCP)
+	tools.SetMCPRegistry(nil)
+
+	fake := fakeMCPServerForHandlers(t)
+	defer fake.Close()
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
+
+	// Create with tools on → connects immediately.
+	w := doJSON(t, srv, http.MethodPost, "/api/mcp/servers",
+		`{"name": "live", "server": {"url": "`+fake.URL+`"}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create: status = %d: %s", w.Code, w.Body.String())
+	}
+	servers := decodeServers(t, w)
+	if servers[0].Status != "connected" || servers[0].Tools != 1 {
+		t.Fatalf("after create: %+v", servers[0])
+	}
+
+	// Disable → connection dropped.
+	w = doJSON(t, srv, http.MethodPatch, "/api/mcp/servers/live/toggle", "")
+	if servers = decodeServers(t, w); servers[0].Status != "disabled" {
+		t.Fatalf("after disable: %+v", servers[0])
+	}
+	if reg := tools.ActiveMCPRegistry(); reg != nil && reg.Get("live") != nil {
+		t.Fatal("disable should disconnect the live server")
+	}
+
+	// Re-enable → reconnects.
+	w = doJSON(t, srv, http.MethodPatch, "/api/mcp/servers/live/toggle", "")
+	if servers = decodeServers(t, w); servers[0].Status != "connected" {
+		t.Fatalf("after enable: %+v", servers[0])
+	}
+
+	// Reconnect endpoint works too.
+	w = doJSON(t, srv, http.MethodPost, "/api/mcp/servers/live/reconnect", "")
+	if servers = decodeServers(t, w); servers[0].Status != "connected" {
+		t.Fatalf("after reconnect: %+v", servers[0])
+	}
+
+	// Reload from disk keeps it connected.
+	w = doJSON(t, srv, http.MethodPost, "/api/mcp/reload", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("reload: status = %d: %s", w.Code, w.Body.String())
+	}
+	if servers = decodeServers(t, w); servers[0].Status != "connected" {
+		t.Fatalf("after reload: %+v", servers[0])
+	}
+
+	// Delete → gone from config and registry.
+	w = doJSON(t, srv, http.MethodDelete, "/api/mcp/servers/live", "")
+	if servers = decodeServers(t, w); len(servers) != 0 {
+		t.Fatalf("after delete: %+v", servers)
+	}
+	if reg := tools.ActiveMCPRegistry(); reg != nil && reg.Get("live") != nil {
+		t.Fatal("delete should disconnect the live server")
+	}
+}
+
+func TestMCPLiveConnect_FailureSurfacesAsStatus(t *testing.T) {
+	mcpTestHome(t, "")
+	t.Cleanup(app.ShutdownMCP)
+	tools.SetMCPRegistry(nil)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
+
+	// Nothing listens on this port — the entry is saved, the status says why
+	// it isn't connected, and the HTTP call still succeeds.
+	w := doJSON(t, srv, http.MethodPost, "/api/mcp/servers",
+		`{"name": "dead", "server": {"url": "http://127.0.0.1:1"}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create: status = %d: %s", w.Code, w.Body.String())
+	}
+	servers := decodeServers(t, w)
+	if servers[0].Status != "error" || servers[0].Error == "" {
+		t.Fatalf("after failed connect: %+v", servers[0])
+	}
+}
+
+func TestToolSearchSettings(t *testing.T) {
+	home := mcpTestHome(t, "")
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	// Defaults backfilled on GET.
+	w := doJSON(t, srv, http.MethodGet, "/api/config/toolsearch", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("get: status = %d", w.Code)
+	}
+	var got toolSearchSettings
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Enabled != "auto" || got.ThresholdPct != 10 || got.SearchDefaultLimit != 5 || got.MaxSearchLimit != 20 {
+		t.Fatalf("defaults = %+v", got)
+	}
+
+	// PUT persists and echoes.
+	w = doJSON(t, srv, http.MethodPut, "/api/config/toolsearch", `{"enabled": "on"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("put: status = %d: %s", w.Code, w.Body.String())
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Enabled != "on" {
+		t.Fatalf("after put: %+v", got)
+	}
+
+	// Written to ~/.octo/config.yaml.
+	raw, err := os.ReadFile(filepath.Join(home, ".octo", "config.yaml"))
+	if err != nil {
+		t.Fatalf("config.yaml not written: %v", err)
+	}
+	var y struct {
+		Tools struct {
+			ToolSearch struct {
+				Enabled string `yaml:"enabled"`
+			} `yaml:"tool_search"`
+		} `yaml:"tools"`
+	}
+	if err := yaml.Unmarshal(raw, &y); err != nil {
+		t.Fatal(err)
+	}
+	if y.Tools.ToolSearch.Enabled != "on" {
+		t.Fatalf("persisted enabled = %q, want on", y.Tools.ToolSearch.Enabled)
+	}
+
+	// Invalid value rejected.
+	w = doJSON(t, srv, http.MethodPut, "/api/config/toolsearch", `{"enabled": "sometimes"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid put: status = %d, want 400", w.Code)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -133,6 +133,11 @@ type Server struct {
 	// Always non-nil after New (a no-op when no servers connected).
 	mcpCleanup func()
 
+	// mcpMu serialises MCP config mutations + registry swaps from the web
+	// management API (and Shutdown) — SwapMCP must not run concurrently
+	// with itself or with incremental connects.
+	mcpMu sync.Mutex
+
 	// accessKey is the shared secret for Web UI / API authentication.
 	accessKey string
 
@@ -263,11 +268,16 @@ func (s *Server) enableMCP() {
 	if cfg, err := config.Load(); err == nil {
 		tools.SetToolSearchConfig(app.ToolSearchConfigFrom(cfg.Tools.ToolSearch))
 	}
-	cleanup, err := app.ConnectMCP(context.Background(), s.cwd, os.Stderr)
-	if err != nil {
+	s.mcpMu.Lock()
+	defer s.mcpMu.Unlock()
+	if err := app.SwapMCP(context.Background(), s.cwd, os.Stderr); err != nil {
 		fmt.Fprintf(os.Stderr, "octo serve: mcp: %v\n", err)
 	}
-	s.mcpCleanup = cleanup
+	s.mcpCleanup = func() {
+		s.mcpMu.Lock()
+		defer s.mcpMu.Unlock()
+		app.ShutdownMCP()
+	}
 }
 
 // AccessKey always returns an empty string: access-key authentication was
@@ -353,6 +363,17 @@ func (s *Server) registerRoutes() {
 	// Skill toggle & delete
 	s.mux.HandleFunc("PATCH /api/skills/{name}/toggle", s.requireAuth(s.handleToggleSkill))
 	s.mux.HandleFunc("DELETE /api/skills/{name}", s.requireAuth(s.handleDeleteSkill))
+
+	// MCP server management
+	s.mux.HandleFunc("GET /api/mcp/servers", s.requireAuth(s.handleListMCPServers))
+	s.mux.HandleFunc("POST /api/mcp/servers", s.requireAuth(s.handleCreateMCPServer))
+	s.mux.HandleFunc("PATCH /api/mcp/servers/{name}", s.requireAuth(s.handleUpdateMCPServer))
+	s.mux.HandleFunc("DELETE /api/mcp/servers/{name}", s.requireAuth(s.handleDeleteMCPServer))
+	s.mux.HandleFunc("PATCH /api/mcp/servers/{name}/toggle", s.requireAuth(s.handleToggleMCPServer))
+	s.mux.HandleFunc("POST /api/mcp/servers/{name}/reconnect", s.requireAuth(s.handleReconnectMCPServer))
+	s.mux.HandleFunc("POST /api/mcp/reload", s.requireAuth(s.handleReloadMCP))
+	s.mux.HandleFunc("GET /api/config/toolsearch", s.requireAuth(s.handleGetToolSearch))
+	s.mux.HandleFunc("PUT /api/config/toolsearch", s.requireAuth(s.handlePutToolSearch))
 
 	// Benchmark
 	s.mux.HandleFunc("POST /api/sessions/{id}/benchmark", s.requireAuth(s.handleBenchmark))


### PR DESCRIPTION
## Summary

Backend half of the web MCP panel (frontend follows in a separate PR). Adds a management API over the MCP config + live registry, and a settings API for the global `tools.tool_search` switch.

### internal/mcp
- **`LoadManaged`** — management view of the merged config: keeps disabled entries, annotates invalid ones instead of failing, and tags each entry `user`/`project` so the UI can mark project entries read-only.
- **User-config writes** — `UpsertUserServer` / `DeleteUserServer` / `SetUserServerDisabled` mutate `~/.octo/mcp.json` only (0600, indented). Project-local files stay owned by their repos.
- **Registry** — records per-server connect errors (`ConnectError`); gains incremental `Connect`/`Remove` so one server can be (re)connected without restarting the rest.

### internal/app
- **`SwapMCP`** — full reload from disk with atomic registry replacement; installs the registry even when zero servers connected so connect errors stay visible. Config errors leave the old registry running.
- **`ConnectMCPServer` / `DisconnectMCPServer` / `ShutdownMCP`** — incremental per-server paths used by the handlers.

### internal/server
| Route | Purpose |
|---|---|
| `GET /api/mcp/servers` | merged list: transport, source, disabled, status (`connected`/`error`/`disabled`/`invalid`/`disconnected`), tool count |
| `POST /api/mcp/servers` | single create (`{name, server}`) or Claude Code-style bulk paste (`{mcpServers}`); bulk validates everything before landing anything |
| `PATCH /api/mcp/servers/{name}` | edit (user-level only) |
| `DELETE /api/mcp/servers/{name}` | delete (user-level only) |
| `PATCH /api/mcp/servers/{name}/toggle` | enable/disable, persisted via the `disabled` flag |
| `POST /api/mcp/servers/{name}/reconnect` | redial one server (any source) |
| `POST /api/mcp/reload` | full reload from disk |
| `GET`/`PUT /api/config/toolsearch` | tri-state `auto`/`on`/`off`, persisted to `~/.octo/config.yaml` and applied live |

Every mutation applies to the live registry incrementally, so changes are effective on the next turn of every session — no restart. Mutations are serialised behind `s.mcpMu` so a reload swap can't interleave with an incremental connect.

## Test plan
- `go test -race ./...` — green (new: 6 manage tests, 5 registry tests, 3 app tests, 10 handler tests incl. a live connect/toggle/reconnect/reload lifecycle against a fake JSON-RPC MCP server)
- `gofmt -l .` empty, `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)