### PR TITLE
fix(scheduler): live rescheduling for task edits/deletes + arm scheduler at serve start

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -42,14 +42,22 @@ type Runner interface {
 	RunTask(ctx context.Context, task Task) (sessionID string, err error)
 }
 
+// exprParser validates cron expressions with the same grammar the runtime
+// cron uses (six fields, seconds first, plus @descriptors), so Add/Update can
+// reject a bad expression before touching any state.
+var exprParser = cron.NewParser(
+	cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
+)
+
 // Scheduler manages cron-based task execution.
 type Scheduler struct {
 	dir    string
 	runner Runner
 	cron   *cron.Cron
 
-	mu    sync.Mutex
-	tasks map[string]*Task
+	mu      sync.Mutex
+	tasks   map[string]*Task
+	entries map[string]cron.EntryID // live cron entry per enabled task
 }
 
 // New creates a Scheduler. dir is where task JSON files are stored
@@ -60,10 +68,11 @@ func New(dir string, runner Runner) (*Scheduler, error) {
 	}
 
 	s := &Scheduler{
-		dir:    dir,
-		runner: runner,
-		cron:   cron.New(cron.WithSeconds()),
-		tasks:  make(map[string]*Task),
+		dir:     dir,
+		runner:  runner,
+		cron:    cron.New(cron.WithSeconds()),
+		tasks:   make(map[string]*Task),
+		entries: make(map[string]cron.EntryID),
 	}
 
 	if err := s.loadAll(); err != nil {
@@ -86,16 +95,14 @@ func (s *Scheduler) Stop() {
 
 // Add creates a new task and schedules it.
 func (s *Scheduler) Add(task Task) error {
+	if _, err := exprParser.Parse(task.Cron); err != nil {
+		return fmt.Errorf("invalid cron expression %q: %w", task.Cron, err)
+	}
 	if task.ID == "" {
 		task.ID = fmt.Sprintf("task_%d", time.Now().UnixMilli())
 	}
 	if task.CreatedAt.IsZero() {
 		task.CreatedAt = time.Now()
-	}
-	if task.Enabled {
-		if _, err := s.cron.AddFunc(task.Cron, s.wrap(task)); err != nil {
-			return fmt.Errorf("invalid cron expression %q: %w", task.Cron, err)
-		}
 	}
 	if err := s.save(task); err != nil {
 		return err
@@ -103,20 +110,25 @@ func (s *Scheduler) Add(task Task) error {
 	s.mu.Lock()
 	s.tasks[task.ID] = &task
 	s.mu.Unlock()
+	if task.Enabled {
+		s.schedule(task.ID, task.Cron)
+	}
 	return nil
 }
 
-// Update modifies an existing task.
+// Update modifies an existing task and reschedules its live cron entry so the
+// change (new expression, enable/disable) takes effect immediately, not at the
+// next process restart.
 func (s *Scheduler) Update(task Task) error {
+	if _, err := exprParser.Parse(task.Cron); err != nil {
+		return fmt.Errorf("invalid cron expression %q: %w", task.Cron, err)
+	}
 	s.mu.Lock()
 	existing, ok := s.tasks[task.ID]
 	if !ok {
 		s.mu.Unlock()
 		return fmt.Errorf("task %q not found", task.ID)
 	}
-
-	// Remove old cron entry (we can't easily remove individual entries in robfig/cron,
-	// so we reconstruct the whole schedule). For now, just update the stored entry.
 	existing.Name = task.Name
 	existing.Cron = task.Cron
 	existing.Prompt = task.Prompt
@@ -124,16 +136,22 @@ func (s *Scheduler) Update(task Task) error {
 	existing.Agent = task.Agent
 	existing.Directory = task.Directory
 	existing.Enabled = task.Enabled
+	cp := *existing
 	s.mu.Unlock()
 
-	return s.save(*existing)
+	s.unschedule(task.ID)
+	if cp.Enabled {
+		s.schedule(cp.ID, cp.Cron)
+	}
+	return s.save(cp)
 }
 
-// Delete removes a task by ID.
+// Delete removes a task by ID and unregisters its live cron entry.
 func (s *Scheduler) Delete(id string) error {
 	s.mu.Lock()
 	delete(s.tasks, id)
 	s.mu.Unlock()
+	s.unschedule(id)
 	p := filepath.Join(s.dir, id+".json")
 	if _, err := os.Stat(p); err == nil {
 		if err := trash.Move(p, s.dir); err != nil {
@@ -183,18 +201,56 @@ func (s *Scheduler) RunNow(ctx context.Context, id string) (string, error) {
 
 // ─── Private methods ─────────────────────────────────────────────────────
 
-func (s *Scheduler) wrap(task Task) func() {
+// schedule registers a cron entry for the task and records its EntryID so a
+// later Update/Delete can remove it. The expression is pre-validated by the
+// callers, so a parse failure here is a programming error worth logging.
+func (s *Scheduler) schedule(id, expr string) {
+	eid, err := s.cron.AddFunc(expr, s.wrap(id))
+	if err != nil {
+		log.Printf("[scheduler] cron add %q: %v", id, err)
+		return
+	}
+	s.mu.Lock()
+	s.entries[id] = eid
+	s.mu.Unlock()
+}
+
+// unschedule removes the task's live cron entry, if any.
+func (s *Scheduler) unschedule(id string) {
+	s.mu.Lock()
+	eid, ok := s.entries[id]
+	delete(s.entries, id)
+	s.mu.Unlock()
+	if ok {
+		s.cron.Remove(eid)
+	}
+}
+
+// wrap returns the function cron fires for a task. It looks the task up by ID
+// at fire time — rather than capturing a copy at registration — so a deleted
+// or disabled task stops running immediately and prompt/model edits apply to
+// the very next run.
+func (s *Scheduler) wrap(id string) func() {
 	return func() {
+		s.mu.Lock()
+		t, ok := s.tasks[id]
+		if !ok || !t.Enabled {
+			s.mu.Unlock()
+			return
+		}
+		task := *t
+		s.mu.Unlock()
+
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancel()
 
 		sessionID, err := s.runner.RunTask(ctx, task)
 		s.mu.Lock()
-		if t, ok := s.tasks[task.ID]; ok {
+		if t, ok := s.tasks[id]; ok {
 			t.LastRun = time.Now()
 			t.SessionID = sessionID
 			if err != nil {
-				log.Printf("[scheduler] task %q failed: %v", task.Name, err)
+				log.Printf("[scheduler] task %q failed: %v", t.Name, err)
 			}
 		}
 		s.mu.Unlock()
@@ -223,9 +279,7 @@ func (s *Scheduler) loadAll() error {
 		}
 		s.tasks[task.ID] = &task
 		if task.Enabled {
-			if _, err := s.cron.AddFunc(task.Cron, s.wrap(task)); err != nil {
-				log.Printf("[scheduler] cron add %q: %v", task.Name, err)
-			}
+			s.schedule(task.ID, task.Cron)
 		}
 	}
 	return nil

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,225 @@
+package scheduler
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// recordRunner records every RunTask call for assertions.
+type recordRunner struct {
+	mu    sync.Mutex
+	tasks []Task
+}
+
+func (r *recordRunner) RunTask(_ context.Context, t Task) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tasks = append(r.tasks, t)
+	return "sess_" + t.ID, nil
+}
+
+func (r *recordRunner) calls() []Task {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]Task(nil), r.tasks...)
+}
+
+func newTestScheduler(t *testing.T) (*Scheduler, *recordRunner) {
+	t.Helper()
+	r := &recordRunner{}
+	s, err := New(t.TempDir(), r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return s, r
+}
+
+func (s *Scheduler) entryCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.entries)
+}
+
+func TestAddRegistersCronEntry(t *testing.T) {
+	s, _ := newTestScheduler(t)
+	if err := s.Add(Task{ID: "t1", Name: "n", Cron: "0 0 9 * * *", Prompt: "p", Enabled: true}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if got := len(s.cron.Entries()); got != 1 {
+		t.Fatalf("cron entries = %d, want 1", got)
+	}
+	if got := s.entryCount(); got != 1 {
+		t.Fatalf("tracked entries = %d, want 1", got)
+	}
+}
+
+func TestAddRejectsInvalidCron(t *testing.T) {
+	s, _ := newTestScheduler(t)
+	// A standard 5-field crontab line is invalid (seconds field required) —
+	// it must be rejected even for a disabled task, so a later enable doesn't
+	// surface a parse error long after the user typed the expression.
+	err := s.Add(Task{ID: "t1", Name: "n", Cron: "0 9 * * *", Prompt: "p", Enabled: false})
+	if err == nil || !strings.Contains(err.Error(), "invalid cron expression") {
+		t.Fatalf("Add with 5-field cron: got %v, want invalid-expression error", err)
+	}
+	if got := len(s.tasks); got != 0 {
+		t.Fatalf("tasks stored = %d, want 0", got)
+	}
+}
+
+func TestUpdateReschedulesEntry(t *testing.T) {
+	s, _ := newTestScheduler(t)
+	task := Task{ID: "t1", Name: "n", Cron: "0 0 9 * * *", Prompt: "p", Enabled: true}
+	if err := s.Add(task); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.mu.Lock()
+	oldEntry := s.entries["t1"]
+	s.mu.Unlock()
+
+	task.Cron = "0 30 18 * * 1-5"
+	if err := s.Update(task); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := len(s.cron.Entries()); got != 1 {
+		t.Fatalf("cron entries after update = %d, want 1", got)
+	}
+	s.mu.Lock()
+	newEntry := s.entries["t1"]
+	s.mu.Unlock()
+	if newEntry == oldEntry {
+		t.Fatal("expected a fresh cron entry after cron expression change")
+	}
+	got, err := s.Get("t1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Cron != "0 30 18 * * 1-5" {
+		t.Fatalf("stored cron = %q, want updated expression", got.Cron)
+	}
+}
+
+func TestUpdateRejectsInvalidCron(t *testing.T) {
+	s, _ := newTestScheduler(t)
+	task := Task{ID: "t1", Name: "n", Cron: "0 0 9 * * *", Prompt: "p", Enabled: true}
+	if err := s.Add(task); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	task.Cron = "not a cron"
+	if err := s.Update(task); err == nil {
+		t.Fatal("Update with bad cron: want error, got nil")
+	}
+	// The original schedule must survive a rejected update.
+	if got := len(s.cron.Entries()); got != 1 {
+		t.Fatalf("cron entries = %d, want 1", got)
+	}
+	got, _ := s.Get("t1")
+	if got.Cron != "0 0 9 * * *" {
+		t.Fatalf("stored cron = %q, want original expression", got.Cron)
+	}
+}
+
+func TestDisableRemovesEntryAndStopsRuns(t *testing.T) {
+	s, r := newTestScheduler(t)
+	task := Task{ID: "t1", Name: "n", Cron: "0 0 9 * * *", Prompt: "p", Enabled: true}
+	if err := s.Add(task); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	fire := s.wrap("t1") // simulate the registered cron callback
+
+	task.Enabled = false
+	if err := s.Update(task); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := len(s.cron.Entries()); got != 0 {
+		t.Fatalf("cron entries after disable = %d, want 0", got)
+	}
+	// Even a stale callback from before the disable must not run the task.
+	fire()
+	if got := len(r.calls()); got != 0 {
+		t.Fatalf("runner calls after disable = %d, want 0", got)
+	}
+
+	// Re-enabling restores the schedule without a restart.
+	task.Enabled = true
+	if err := s.Update(task); err != nil {
+		t.Fatalf("Update re-enable: %v", err)
+	}
+	if got := len(s.cron.Entries()); got != 1 {
+		t.Fatalf("cron entries after re-enable = %d, want 1", got)
+	}
+}
+
+func TestDeleteRemovesEntryAndStopsRuns(t *testing.T) {
+	s, r := newTestScheduler(t)
+	if err := s.Add(Task{ID: "t1", Name: "n", Cron: "0 0 9 * * *", Prompt: "p", Enabled: true}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	fire := s.wrap("t1")
+
+	if err := s.Delete("t1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got := len(s.cron.Entries()); got != 0 {
+		t.Fatalf("cron entries after delete = %d, want 0", got)
+	}
+	fire()
+	if got := len(r.calls()); got != 0 {
+		t.Fatalf("runner calls after delete = %d, want 0", got)
+	}
+}
+
+func TestFireUsesCurrentTaskState(t *testing.T) {
+	s, r := newTestScheduler(t)
+	task := Task{ID: "t1", Name: "n", Cron: "0 0 9 * * *", Prompt: "old prompt", Enabled: true}
+	if err := s.Add(task); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	fire := s.wrap("t1")
+
+	task.Prompt = "new prompt"
+	if err := s.Update(task); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	fire()
+	calls := r.calls()
+	if len(calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1", len(calls))
+	}
+	if calls[0].Prompt != "new prompt" {
+		t.Fatalf("fired prompt = %q, want the updated prompt", calls[0].Prompt)
+	}
+	got, _ := s.Get("t1")
+	if got.LastRun.IsZero() || got.SessionID != "sess_t1" {
+		t.Fatalf("run bookkeeping not recorded: lastRun=%v session=%q", got.LastRun, got.SessionID)
+	}
+}
+
+func TestLoadAllRegistersEnabledTasks(t *testing.T) {
+	dir := t.TempDir()
+	r := &recordRunner{}
+	s, err := New(dir, r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := s.Add(Task{ID: "t1", Name: "a", Cron: "0 0 9 * * *", Prompt: "p", Enabled: true}); err != nil {
+		t.Fatalf("Add enabled: %v", err)
+	}
+	if err := s.Add(Task{ID: "t2", Name: "b", Cron: "@daily", Prompt: "p", Enabled: false}); err != nil {
+		t.Fatalf("Add disabled: %v", err)
+	}
+
+	// A fresh scheduler over the same dir mirrors a serve restart.
+	s2, err := New(dir, r)
+	if err != nil {
+		t.Fatalf("New (reload): %v", err)
+	}
+	if got := len(s2.List()); got != 2 {
+		t.Fatalf("loaded tasks = %d, want 2", got)
+	}
+	if got := len(s2.cron.Entries()); got != 1 {
+		t.Fatalf("cron entries after reload = %d, want 1 (only the enabled task)", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -126,8 +126,10 @@ type Server struct {
 	liveStates  map[string]*sessionLiveState
 	liveStateMu sync.RWMutex
 
-	// scheduler for cron-based background tasks.
-	scheduler *scheduler.Scheduler
+	// scheduler for cron-based background tasks. schedulerMu serialises its
+	// lazy initialisation (handlers and server start may race).
+	scheduler   *scheduler.Scheduler
+	schedulerMu sync.Mutex
 
 	// mcpCleanup unregisters + closes the MCP registry connected at start.
 	// Always non-nil after New (a no-op when no servers connected).
@@ -276,8 +278,11 @@ func (s *Server) AccessKey() string {
 	return ""
 }
 
-// ListenAndServe starts the HTTP server.
+// ListenAndServe starts the HTTP server. The cron scheduler is armed before
+// serving so persisted tasks fire from server start, not from the first hit
+// on a task endpoint.
 func (s *Server) ListenAndServe() error {
+	s.initScheduler()
 	return s.http.ListenAndServe()
 }
 

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -35,8 +35,13 @@ type taskResponse struct {
 	SessionID string `json:"session_id,omitempty"`
 }
 
-// initScheduler creates the scheduler if not already initialized.
+// initScheduler creates the scheduler if not already initialized. It is
+// called eagerly from ListenAndServe so scheduled tasks fire from server
+// start; the calls in individual handlers remain as a safety net (and as the
+// only path in tests that exercise the mux directly).
 func (s *Server) initScheduler() {
+	s.schedulerMu.Lock()
+	defer s.schedulerMu.Unlock()
 	if s.scheduler != nil {
 		return
 	}


### PR DESCRIPTION
## Problem

Found while writing the cron-task-creator skill (#538) — three behaviors that silently diverge from what the tasks API appears to promise:

1. **Scheduler never armed without a task-endpoint hit.** `initScheduler()` was only called lazily from handlers, so after `octo serve` started, persisted tasks never fired until someone happened to call `GET /api/tasks` (or open the Web UI tasks panel).
2. **Edits, disables, and deletes didn't affect the running process.** The cron callback captured a `Task` copy at registration; `Update()` only mutated the store (the code comment admitted it), and `Delete()` removed the file but the registered entry kept firing the stale copy until restart.
3. **Bad cron expressions in disabled tasks were accepted**, surfacing only later at enable/load time (and at load, only as a stderr log).

## Fix

- `Server.ListenAndServe` calls `initScheduler()` before serving; `initScheduler` is now mutex-guarded (`schedulerMu`) since handlers could already race each other. Handler-side lazy calls remain as the path for tests that exercise the mux directly.
- `Scheduler` tracks `cron.EntryID` per task. `Update` removes the old entry and re-adds when enabled; `Delete` removes the entry. The fire callback (`wrap`) now captures only the task **ID** and looks up current state at fire time — a deleted/disabled task stops immediately, and prompt/model edits apply to the very next run.
- `Add`/`Update` validate the cron expression up front (same 6-field seconds-first grammar as the runtime parser), including for disabled tasks.

## Test plan

- [x] New `internal/scheduler/scheduler_test.go`: add registers entry, invalid 5-field expression rejected, update reschedules (fresh entry, rejected update preserves old schedule), disable/delete remove the entry **and** a stale callback no-ops, fire uses post-edit prompt + records LastRun/SessionID, reload over the same dir registers only enabled tasks.
- [x] `go build ./...`, `go vet ./...`, `go test -race ./...` all green.

Note: #538's skill text documents the old restart-required behavior as caveats; I'll update that PR to match once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)