### PR TITLE
feat: notify the model of background completions in server and IM modes

### DIFF
--- a/cmd/octo/bgnotify_wiring_test.go
+++ b/cmd/octo/bgnotify_wiring_test.go
@@ -29,7 +29,7 @@ func TestRunTurn_PrependsIdleBgNote(t *testing.T) {
 	cs := &capturingSender{stubSender: stubSender{reply: "ok"}}
 	a := agent.New(cs, "m")
 	// Simulate a background process finishing while the REPL was idle.
-	a.Inbox.Enqueue(formatBgNote(tools.BgExit{ID: "bg_1", Command: "go build ./...", Status: "exited: 0", NewOutput: "done"}))
+	a.Inbox.Enqueue(tools.FormatBgNote(tools.BgExit{ID: "bg_1", Command: "go build ./...", Status: "exited: 0", NewOutput: "done"}))
 
 	cfg := replConfig{a: a} // no tools, no memStore, no hooks
 	if _, err := runTurn(context.Background(), a, cfg, noopSink{}, "what's next?"); err != nil {

--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -283,7 +283,17 @@ func handleAgentMessage(ctx context.Context, mgr *channel.Manager, ad channel.Ad
 		ctx = tools.WithTaskStore(ctx, sess.Tasks)
 		// Per-chat background manager: this chat's bg processes persist across
 		// messages and stay isolated from other chats; reaped on daemon shutdown.
-		ctx = tools.WithBackgroundManager(ctx, tools.SessionBackgroundManager("im:"+string(sess.Key)))
+		bgMgr := tools.SessionBackgroundManager("im:" + string(sess.Key))
+		// Surface background completions to the model — parity with the
+		// CLI/TUI's SetBackgroundOnExit → Inbox wiring. sess.Agent persists
+		// across messages, so an idle-time completion waits in the Inbox and
+		// is drained at the start of the next message's turn. The note is a
+		// <system-reminder> block; the UIController never echoes steer events,
+		// so nothing leaks into the chat.
+		bgMgr.SetOnExit(func(e tools.BgExit) {
+			sess.Agent.Inbox.Enqueue(tools.FormatBgNote(e))
+		})
+		ctx = tools.WithBackgroundManager(ctx, bgMgr)
 	}
 
 	_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, ev.Text)

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -116,7 +116,7 @@ func runOnce(cfg replConfig, prompt string, stream bool) int {
 			cfg.subAgentMgr.KillAll()
 		}()
 	}
-	tools.SetBackgroundOnExit(func(e tools.BgExit) { a.Inbox.Enqueue(formatBgNote(e)) })
+	tools.SetBackgroundOnExit(func(e tools.BgExit) { a.Inbox.Enqueue(tools.FormatBgNote(e)) })
 	defer tools.SetBackgroundOnExit(nil)
 
 	// The view sink renders the turn (spinner, streamed text, tool-event lines,

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -98,7 +98,7 @@ func runTUI(cfg replConfig) int {
 	// event loop. Without this a finished background command is invisible
 	// until the model polls terminal_output.
 	tools.SetBackgroundOnExit(func(e tools.BgExit) {
-		cfg.a.Inbox.Enqueue(formatBgNote(e))
+		cfg.a.Inbox.Enqueue(tools.FormatBgNote(e))
 		p.Send(bgExitMsg{e})
 	})
 	defer tools.SetBackgroundOnExit(nil)

--- a/internal/server/bg_tasks.go
+++ b/internal/server/bg_tasks.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
@@ -41,10 +42,11 @@ func (s *Server) broadcastBackgroundTasks(sessionID string) {
 }
 
 // wireBackgroundTaskNotices registers the session manager's exit hook so a
-// finished background process surfaces as a chat notice and the badge count
-// drops. Re-registered (idempotently) at each turn start; the hook outlives
-// the turn, so a process finishing between turns still notifies subscribed
-// tabs — broadcasting to a session with no subscribers is a no-op.
+// finished background process surfaces as a chat notice, the badge count
+// drops, and the model is notified. Re-registered (idempotently) at each turn
+// start; the hook outlives the turn, so a process finishing between turns
+// still notifies subscribed tabs — broadcasting to a session with no
+// subscribers is a no-op.
 func (s *Server) wireBackgroundTaskNotices(sessionID string) {
 	tools.SessionBackgroundManager(sessionID).SetOnExit(func(e tools.BgExit) {
 		s.wsHub.broadcast(sessionID, wsEventBackgroundTaskNotice{
@@ -55,7 +57,26 @@ func (s *Server) wireBackgroundTaskNotices(sessionID string) {
 			Status:    bgNoticeStatus(e.Status),
 		})
 		s.broadcastBackgroundTasks(sessionID)
+		s.notifyAgentBgExit(sessionID, e)
 	})
+}
+
+// notifyAgentBgExit pushes a background-completion note to the model — parity
+// with the CLI/TUI's SetBackgroundOnExit → Inbox wiring. Mid-turn the note
+// goes straight into the running Agent's Inbox (drained between loop
+// iterations); while idle it goes to the steer queue, which the next turn
+// flushes into its Inbox at start. The note is a <system-reminder> block, so
+// the web transcript never renders it as user speech.
+func (s *Server) notifyAgentBgExit(sessionID string, e tools.BgExit) {
+	note := tools.FormatBgNote(e)
+	s.sessionAgentsMu.Lock()
+	a := s.sessionAgents[sessionID]
+	s.sessionAgentsMu.Unlock()
+	if a != nil {
+		a.Inbox.Enqueue(note)
+		return
+	}
+	s.enqueueSteer(sessionID, agent.InboxItem{Text: note})
 }
 
 // bgNoticeStatus maps a BackgroundManager exit status ("exited: 0",

--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
@@ -118,5 +120,38 @@ func TestWireBackgroundTaskNotices_BroadcastsExit(t *testing.T) {
 		case <-deadline:
 			t.Fatalf("timed out; notice=%v update=%v", gotNotice, gotUpdate)
 		}
+	}
+}
+
+// notifyAgentBgExit must reach the model on both paths: the running Agent's
+// Inbox mid-turn, the steer queue while idle. Parity with the CLI/TUI's
+// SetBackgroundOnExit → Inbox wiring.
+func TestNotifyAgentBgExit_MidTurnGoesToInbox(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	a := agent.New(&recordingSender{}, "stub-model")
+	srv.sessionAgentsMu.Lock()
+	srv.sessionAgents["sess-1"] = a
+	srv.sessionAgentsMu.Unlock()
+
+	srv.notifyAgentBgExit("sess-1", tools.BgExit{ID: "bg_1", Command: "make build", Status: "exited: 0", NewOutput: "done"})
+
+	items := a.Inbox.Drain()
+	if len(items) != 1 || !strings.Contains(items[0].Text, "[BACKGROUND COMPLETED]") || !strings.Contains(items[0].Text, "bg_1") {
+		t.Fatalf("inbox = %+v, want one bg note", items)
+	}
+	// Nothing should have leaked into the idle steer queue.
+	if leftover := srv.drainSteer("sess-1"); len(leftover) != 0 {
+		t.Errorf("steer queue = %+v, want empty", leftover)
+	}
+}
+
+func TestNotifyAgentBgExit_IdleGoesToSteerQueue(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	srv.notifyAgentBgExit("sess-1", tools.BgExit{ID: "bg_2", Command: "make test", Status: "exited: exit status 1"})
+
+	items := srv.drainSteer("sess-1")
+	if len(items) != 1 || !strings.Contains(items[0].Text, "[BACKGROUND COMPLETED]") || !strings.Contains(items[0].Text, "bg_2") {
+		t.Fatalf("steer queue = %+v, want one bg note", items)
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -307,6 +307,8 @@ func mustServer(t *testing.T, cfg Config) *Server {
 		turnLocks:      map[string]*sync.Mutex{},
 		sender:         &stubSender{},
 		accessKey:      resolveAccessKey(cfg.AccessKey, config.Config{}),
+		sessionAgents:  make(map[string]*agent.Agent),
+		steerQueues:    make(map[string][]agent.InboxItem),
 	}
 	srv.registerRoutes()
 	// Wrap with CORS middleware so tests that exercise CORS hit the right layer.

--- a/internal/tools/bgnotify.go
+++ b/internal/tools/bgnotify.go
@@ -1,18 +1,17 @@
-package main
+package tools
 
 import (
 	"fmt"
 	"strings"
-
-	"github.com/Leihb/octo-agent/internal/tools"
 )
 
-// formatBgNote renders a background-process completion as a <system-reminder>
-// block. It rides the existing steer path (Agent.Steer → folded into the next
-// tool_result, or prepended to the next turn — see turncore.go), so the model
-// reads it as an environment event rather than user speech. Wrapping in
-// <system-reminder> matches octo's convention for injected, non-user context.
-func formatBgNote(e tools.BgExit) string {
+// FormatBgNote renders a background-process completion as a <system-reminder>
+// block. It rides the steer path of whichever frontend wires it (CLI/TUI:
+// Inbox.Enqueue; server: Inbox or steer queue; IM: the session agent's
+// Inbox), so the model reads it as an environment event rather than user
+// speech. Wrapping in <system-reminder> matches octo's convention for
+// injected, non-user context — UIs strip these spans from user-visible text.
+func FormatBgNote(e BgExit) string {
 	var b strings.Builder
 	b.WriteString("<system-reminder>\n")
 	b.WriteString("[BACKGROUND COMPLETED]\n")
@@ -22,7 +21,7 @@ func formatBgNote(e tools.BgExit) string {
 		// A long-running build/test that finished in the background can emit
 		// far more than fits a single notice — spill it to a temp file and
 		// show a head+tail preview, same as the synchronous terminal path.
-		b.WriteString(tools.MaybeSpillOutput(e.ID, out))
+		b.WriteString(MaybeSpillOutput(e.ID, out))
 	} else {
 		b.WriteString("\n(no new output)")
 	}

--- a/internal/tools/bgnotify_test.go
+++ b/internal/tools/bgnotify_test.go
@@ -1,14 +1,12 @@
-package main
+package tools
 
 import (
 	"strings"
 	"testing"
-
-	"github.com/Leihb/octo-agent/internal/tools"
 )
 
 func TestFormatBgNote_WrapsAsSystemReminder(t *testing.T) {
-	got := formatBgNote(tools.BgExit{
+	got := FormatBgNote(BgExit{
 		ID:        "bg_1",
 		Command:   "go test ./...",
 		Status:    "exited: 0",
@@ -19,20 +17,20 @@ func TestFormatBgNote_WrapsAsSystemReminder(t *testing.T) {
 		"bg_1", "go test ./...", "exited: 0", "ok  github.com/x/y  1.2s",
 	} {
 		if !strings.Contains(got, want) {
-			t.Errorf("formatBgNote missing %q in:\n%s", want, got)
+			t.Errorf("FormatBgNote missing %q in:\n%s", want, got)
 		}
 	}
 }
 
 func TestFormatBgNote_NoOutput(t *testing.T) {
-	got := formatBgNote(tools.BgExit{ID: "bg_2", Command: "true", Status: "exited: 0"})
+	got := FormatBgNote(BgExit{ID: "bg_2", Command: "true", Status: "exited: 0"})
 	if !strings.Contains(got, "(no new output)") {
 		t.Errorf("want '(no new output)' marker; got:\n%s", got)
 	}
 }
 
 func TestFormatBgNote_CarriesNonZeroExit(t *testing.T) {
-	got := formatBgNote(tools.BgExit{ID: "bg_3", Command: "false", Status: "exited: exit status 1"})
+	got := FormatBgNote(BgExit{ID: "bg_3", Command: "false", Status: "exited: exit status 1"})
 	if !strings.Contains(got, "exit status 1") {
 		t.Errorf("want the non-zero exit surfaced; got:\n%s", got)
 	}


### PR DESCRIPTION
## Problem

When a `run_in_background` process finishes, the CLI/TUI notify the model via `SetBackgroundOnExit → Inbox.Enqueue(formatBgNote(e))`. Server (web) and IM modes never had this wiring: the web only broadcast a human-facing badge + chat notice, IM had no exit hook at all. In both modes the model stayed unaware a background build/test had finished unless it polled `terminal_output` — despite the `terminal` tool description promising "the system automatically notifies you on completion".

## Changes

- **`tools.FormatBgNote`** — moved from `cmd/octo/bgnotify.go` into `internal/tools` (it formats a `tools.BgExit` using `tools.MaybeSpillOutput`; with three frontends needing it, the main package was the wrong home). CLI/TUI call sites updated; format tests moved alongside.
- **Server** (`bg_tasks.go`): the per-session exit hook now also calls `notifyAgentBgExit` — mid-turn the note goes straight into the running Agent's Inbox (drained between loop iterations, same as CLI); while idle it goes to the steer queue, which the next turn flushes into its Inbox at start. Same delivery pattern as mid-turn user messages (`handleWSUserMessage`).
- **IM** (`cmd/octo/channel.go`): the per-chat background manager gets an exit hook enqueueing into the session agent's persistent Inbox. An idle-time completion waits there until the chat's next message. The `UIController` never echoes steer events, so nothing surfaces in the chat.

The note is a `<system-reminder>` block; the web transcript strips those from user-visible text (#536), so this adds model awareness with **no UI leak** — the leak fix landed first by design.

## Tests

- `TestNotifyAgentBgExit_MidTurnGoesToInbox` / `_IdleGoesToSteerQueue` cover both server delivery paths (`mustServer` now initializes `sessionAgents`/`steerQueues` like the real constructor).
- `FormatBgNote` tests moved to `internal/tools` unchanged; CLI wiring test (`TestRunTurn_PrependsIdleBgNote`) still passes against the relocated helper.
- `make test` (race) green across the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)