### PR TITLE
fix(web): keep an animated indicator between tool rounds

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1005,3 +1005,90 @@ drain:
 			firstProgressIdx, firstTextIdx, types)
 	}
 }
+
+// TestWSStreamWriter_ReseedsThinkingAfterTool is the regression guard for the
+// web-UI "tools pop out of dead air" gap. The frontend clears the progress
+// indicator when a tool_call renders, and the next LLM round emits nothing
+// until its first delta — so after every tool_result (and recoverable
+// tool_error) the stream writer must broadcast a fresh "thinking" progress
+// and keep it in live state for late-subscriber replay.
+func TestWSStreamWriter_ReseedsThinkingAfterTool(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "sess-reseed"
+	srv.liveStateMu.Lock()
+	srv.liveStates[sid] = &sessionLiveState{}
+	srv.liveStateMu.Unlock()
+
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+	srv.wsHub.subscribe(conn, sid)
+
+	sw := srv.newWSStreamWriter(sid)
+
+	// drainUntilProgress reads broadcasts until a progress event (or deadline)
+	// and returns it along with every event type seen on the way.
+	drainUntilProgress := func() (map[string]any, []string) {
+		deadline := time.After(2 * time.Second)
+		var types []string
+		for {
+			select {
+			case b := <-conn.send:
+				var ev map[string]any
+				if err := json.Unmarshal(b, &ev); err != nil {
+					continue
+				}
+				typ, _ := ev["type"].(string)
+				types = append(types, typ)
+				if typ == "progress" {
+					return ev, types
+				}
+			case <-deadline:
+				return nil, types
+			}
+		}
+	}
+
+	for _, tc := range []struct {
+		name  string
+		event agent.AgentEvent
+	}{
+		{"tool_done", agent.AgentEvent{Kind: agent.EventToolDone, ToolName: "terminal", Output: "ok"}},
+		{"tool_error", agent.AgentEvent{Kind: agent.EventToolError, ToolName: "terminal", Err: "exit 1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sw.handleEvent(tc.event)
+
+			ev, types := drainUntilProgress()
+			if ev == nil {
+				t.Fatalf("no progress broadcast after %s; got %v", tc.name, types)
+			}
+			if pt, _ := ev["progress_type"].(string); pt != "thinking" {
+				t.Errorf("progress_type = %q, want \"thinking\"", pt)
+			}
+			if ph, _ := ev["phase"].(string); ph != "active" {
+				t.Errorf("phase = %q, want \"active\"", ph)
+			}
+			if at, _ := ev["started_at"].(float64); at <= 0 {
+				t.Errorf("started_at = %v, want > 0", ev["started_at"])
+			}
+
+			// Live state must carry the reseeded progress so a tab subscribing
+			// mid-gap replays an indicator instead of a blank screen.
+			srv.liveStateMu.Lock()
+			ls := srv.liveStates[sid]
+			srv.liveStateMu.Unlock()
+			if ls == nil {
+				t.Fatalf("live state deleted after %s; replay would be blank", tc.name)
+			}
+			if ls.progress == nil || ls.progress.ProgressType != "thinking" {
+				t.Errorf("live state progress = %+v, want reseeded thinking phase", ls.progress)
+			}
+		})
+	}
+}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -688,6 +688,34 @@ func (w *wsStreamWriter) error(msg string) {
 	})
 }
 
+// reseedThinkingProgress broadcasts a fresh "thinking" progress phase and
+// records it as the session's live state. Called after a tool finishes (or
+// errors): the next LLM round is already running but stays silent until its
+// first delta, so without this the indicator the frontend cleared at
+// tool_call never comes back between rounds.
+func (w *wsStreamWriter) reseedThinkingProgress() {
+	startedAt := time.Now().UnixMilli()
+	w.server.liveStateMu.Lock()
+	if ls, ok := w.server.liveStates[w.sessionID]; ok {
+		ls.toolCall = nil
+		ls.progress = &wsEventProgress{
+			Type:         "progress",
+			ProgressType: "thinking",
+			Phase:        "active",
+			StartedAt:    startedAt,
+		}
+	}
+	w.server.liveStateMu.Unlock()
+	w.hub.broadcast(w.sessionID, map[string]any{
+		"type":          "progress",
+		"session_id":    w.sessionID,
+		"progress_type": "thinking",
+		"phase":         "active",
+		"status":        "start",
+		"started_at":    startedAt,
+	})
+}
+
 // handleEvent converts agent.AgentEvent to WS JSON events and broadcasts them.
 // It also updates the server's live state for late-subscriber replay.
 func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
@@ -746,13 +774,13 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 				"session_id": w.sessionID,
 			})
 		}
-		// Clear live state on tool done.
-		w.server.liveStateMu.Lock()
-		if ls, ok := w.server.liveStates[w.sessionID]; ok {
-			ls.progress = nil
-			ls.toolCall = nil
-		}
-		w.server.liveStateMu.Unlock()
+		// The agent immediately starts the next LLM round after a tool result,
+		// and that round emits no event until its first delta (or the next
+		// tool_call). Re-seed the "thinking" indicator so the UI animates
+		// across the gap instead of the next tool popping out of dead air —
+		// same rationale as the turn-start seed in doAgentTurn. The frontend
+		// clears it on the next tool_call / assistant_message / complete.
+		w.reseedThinkingProgress()
 		// A tool call is the only place a turn starts or kills a background
 		// process — refresh the badge.
 		w.server.broadcastBackgroundTasks(w.sessionID)
@@ -763,9 +791,11 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 			"session_id": w.sessionID,
 			"error":      ev.Err,
 		})
-		w.server.liveStateMu.Lock()
-		delete(w.server.liveStates, w.sessionID)
-		w.server.liveStateMu.Unlock()
+		// A tool error does not end the turn — the error result goes back to
+		// the model, which keeps running. Re-seed the indicator just like
+		// EventToolDone (deleting the live state here would also blank the
+		// progress replay for late-subscribing tabs mid-turn).
+		w.reseedThinkingProgress()
 		w.server.broadcastBackgroundTasks(w.sessionID)
 
 	case agent.EventThinkingDelta:


### PR DESCRIPTION
## Problem

After the user sends a message, the web UI shows the "Thinking…" spinner until the first response — but in multi-round tool turns, every tool card after the first appears out of dead air, with no animation in between.

Root cause is a one-shot progress contract:

- The server broadcasts exactly **one** `progress` event per turn — the turn-start seed in `doAgentTurn` (`ws_handlers.go`).
- The frontend's `tool_call` handler calls `clearProgress()` (`ws-dispatcher.js`), removing the indicator when the first tool renders.
- After each `tool_result`, the agent immediately starts the next LLM round, which emits **no event** until its first delta or the next `tool_call` — so the gap between tool rounds had nothing on screen.
- Bonus: `EventToolError` deleted the session's entire live state even though a tool error doesn't end the turn, blanking the progress replay for late-subscribing tabs.

## Fix

`wsStreamWriter` now re-seeds a fresh `thinking` progress phase (new `started_at`) after every `tool_result` and recoverable `tool_error`, mirroring the turn-start seed, and records it in `liveStates` for late-subscriber replay. **No frontend changes** — the existing `progress` handler renders the reseeded phase (animated Braille spinner + elapsed seconds), and `tool_call` / `assistant_message` / `complete` already clear it at the right moments.

Resulting timeline: spinner → tool card (pulsing `…` while running) → ✓ result → **spinner (was: nothing)** → next tool card / streamed answer.

## Test plan

- [x] New `TestWSStreamWriter_ReseedsThinkingAfterTool` (tool_done + tool_error subtests): asserts the progress broadcast (`thinking`/`active`/`started_at>0`) and that live state retains a reseeded progress for replay.
- [x] `go vet`, `go test -race ./internal/server/`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)