### PR TITLE
fix(web): re-scan skills from disk on every GET /api/skills

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/config"
 	"github.com/Leihb/octo-agent/internal/permission"
+	"github.com/Leihb/octo-agent/internal/skills"
 	"github.com/Leihb/octo-agent/internal/tasks"
 	"github.com/Leihb/octo-agent/internal/tools"
 	"github.com/Leihb/octo-agent/internal/version"
@@ -531,6 +532,15 @@ func (s *Server) handleListTools(w http.ResponseWriter, r *http.Request) {
 // ─── GET /api/skills ────────────────────────────────────────────────────────
 
 func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
+	// The registry is a startup-time snapshot. Skills added, edited, or
+	// removed on disk (rather than through this API) would otherwise stay
+	// invisible — or worse, deleted ones would linger in the panel — until
+	// the server restarts. Re-scan before listing; Reload only reads each
+	// skill dir's SKILL.md frontmatter, so it's cheap enough per request.
+	s.skillReg.Reload()
+	// Refresh the manifest for sessions built after this point, same as the
+	// toggle/delete handlers do.
+	s.skillsManifest = skills.RenderManifest(s.skillReg)
 	list := s.skillReg.All()
 	out := make([]skillInfo, 0, len(list))
 	for _, sk := range list {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -541,6 +541,63 @@ func TestHandleToggleSkill_NotFound(t *testing.T) {
 	}
 }
 
+// TestHandleListSkills_RescansDisk is the regression guard for the stale
+// skill panel: the registry is discovered once at server start, so without a
+// per-request re-scan a skill directory deleted (or added) on disk would stay
+// wrong in the panel until the server restarts.
+func TestHandleListSkills_RescansDisk(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	hasSkill := func(name string) bool {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/api/skills?access_key="+srv.AccessKey(), nil)
+		w := httptest.NewRecorder()
+		srv.mux.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+		}
+		var body struct {
+			Skills []struct {
+				Name string `json:"name"`
+			} `json:"skills"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatal(err)
+		}
+		for _, sk := range body.Skills {
+			if sk.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	// A skill dropped on disk AFTER server start must show up without restart.
+	skillDir := filepath.Join(tmp, ".octo", "skills", "ghost")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: ghost\ndescription: appears and disappears\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !hasSkill("ghost") {
+		t.Fatal("skill added on disk after start not listed; list handler did not re-scan")
+	}
+
+	// A skill deleted on disk must vanish from the next list response.
+	if err := os.RemoveAll(skillDir); err != nil {
+		t.Fatal(err)
+	}
+	if hasSkill("ghost") {
+		t.Fatal("skill deleted on disk still listed; panel would show a ghost entry until restart")
+	}
+}
+
 func TestHandleBenchmark_Success(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	req := httptest.NewRequest(http.MethodPost, "/api/sessions/test-session/benchmark?access_key="+srv.AccessKey(), nil)


### PR DESCRIPTION
## Problem

Deleting a skill directory on disk (rather than via the panel's trash icon) left it visible in the Skill Management panel until `octo serve` restarted. Same staleness in reverse: a skill dropped into `~/.octo/skills` never appeared.

Root cause: `skills.Discover` runs once in `server.New` and `GET /api/skills` serves that startup snapshot. Only the panel's own toggle/delete endpoints mutate the in-memory registry, so any filesystem change is invisible.

## Fix

`handleListSkills` now calls `Registry.Reload()` before listing — the same in-place re-scan the `skill` tool and the CLI REPL already use — and refreshes `skillsManifest` the way the toggle/delete handlers do. Reload reads only each skill dir's SKILL.md frontmatter, so per-request cost is milliseconds.

## Test plan

- [x] New `TestHandleListSkills_RescansDisk`: a skill created on disk after server start appears in the next list response; deleting the directory makes it vanish from the next response.
- [x] `go test -race ./internal/server/ ./internal/skills/`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)