### PR TITLE
feat(server): run web sub-agents async with session-scoped lifecycle

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -108,7 +108,7 @@ func runOnce(cfg replConfig, prompt string, stream bool) int {
 	if cfg.subAgentMgr != nil {
 		tools.SetDefaultSubAgentManager(cfg.subAgentMgr)
 		cfg.subAgentMgr.SetOnExit(func(ev tools.SubAgentNotification) {
-			a.Inbox.Enqueue(formatSubAgentNote(ev))
+			a.Inbox.Enqueue(tools.FormatSubAgentNote(ev))
 		})
 		defer func() {
 			cfg.subAgentMgr.SetOnExit(nil)

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -77,7 +77,7 @@ func runTUI(cfg replConfig) int {
 	if cfg.subAgentMgr != nil {
 		tools.SetDefaultSubAgentManager(cfg.subAgentMgr)
 		cfg.subAgentMgr.SetOnExit(func(ev tools.SubAgentNotification) {
-			cfg.a.Inbox.Enqueue(formatSubAgentNote(ev))
+			cfg.a.Inbox.Enqueue(tools.FormatSubAgentNote(ev))
 			p.Send(subAgentNoteMsg{ev})
 		})
 		// Runtime activity (started + per-tool) for the live bottom panel.
@@ -777,6 +777,13 @@ const maxSubAgentRecentTools = 4
 // state. "started" creates/refreshes the entry; "tool"/"tool_error" append to
 // its chain.
 func (m *tuiModel) handleSubAgentEvent(ev tools.SubAgentEvent) {
+	// "done" removes the entry; handled before the create-on-miss below so a
+	// late done can't resurrect a panel slot the completion note already
+	// removed.
+	if ev.Kind == "done" {
+		m.removeSubAgent(ev.AgentID)
+		return
+	}
 	sa := m.subAgents[ev.AgentID]
 	if sa == nil {
 		sa = &subAgentUI{description: ev.Description, start: time.Now()}

--- a/internal/server/bg_tasks.go
+++ b/internal/server/bg_tasks.go
@@ -62,13 +62,24 @@ func (s *Server) wireBackgroundTaskNotices(sessionID string) {
 }
 
 // notifyAgentBgExit pushes a background-completion note to the model — parity
-// with the CLI/TUI's SetBackgroundOnExit → Inbox wiring. Mid-turn the note
-// goes straight into the running Agent's Inbox (drained between loop
-// iterations); while idle it goes to the steer queue, which the next turn
-// flushes into its Inbox at start. The note is a <system-reminder> block, so
-// the web transcript never renders it as user speech.
+// with the CLI/TUI's SetBackgroundOnExit → Inbox wiring.
 func (s *Server) notifyAgentBgExit(sessionID string, e tools.BgExit) {
-	note := tools.FormatBgNote(e)
+	s.deliverModelNote(sessionID, tools.FormatBgNote(e))
+}
+
+// notifySubAgentExit pushes an async sub-agent completion to the model —
+// parity with the CLI/TUI's SubAgentManager.SetOnExit → Inbox wiring.
+func (s *Server) notifySubAgentExit(sessionID string, ev tools.SubAgentNotification) {
+	s.deliverModelNote(sessionID, tools.FormatSubAgentNote(ev))
+}
+
+// deliverModelNote routes a <system-reminder> completion note to the model.
+// Mid-turn it goes straight into the running Agent's Inbox (drained between
+// loop iterations); while idle it goes to the steer queue and a turn is
+// kicked so the model reacts immediately — the same idle auto-turn the TUI
+// does. The note is a <system-reminder> block, so the web transcript never
+// renders it as user speech.
+func (s *Server) deliverModelNote(sessionID, note string) {
 	s.sessionAgentsMu.Lock()
 	a := s.sessionAgents[sessionID]
 	s.sessionAgentsMu.Unlock()
@@ -77,6 +88,51 @@ func (s *Server) notifyAgentBgExit(sessionID string, e tools.BgExit) {
 		return
 	}
 	s.enqueueSteer(sessionID, agent.InboxItem{Text: note})
+	s.kickIdleSteerTurn(sessionID)
+}
+
+// kickIdleSteerTurn starts a turn for sessionID when none is running, so a
+// completion note queued while idle reaches the model immediately. No-op when
+// a turn is running (its chained loop drains the queue at turn end) or the
+// queue is already empty by the time the lock is held.
+func (s *Server) kickIdleSteerTurn(sessionID string) {
+	mu := s.sessionTurnLock(sessionID)
+	mu.Lock()
+	if s.turnRunning[sessionID] {
+		mu.Unlock()
+		return
+	}
+	sess, err := agent.LoadSession(sessionID)
+	if err != nil {
+		// Session not loadable (deleted, or a transient read error) — leave
+		// the queue untouched; the next turn will pick the note up.
+		mu.Unlock()
+		return
+	}
+	items := s.drainSteer(sessionID)
+	if len(items) == 0 {
+		mu.Unlock()
+		return
+	}
+	s.turnRunning[sessionID] = true
+	mu.Unlock()
+
+	var texts []string
+	var blocks []agent.ContentBlock
+	for _, it := range items {
+		if strings.TrimSpace(it.Text) != "" {
+			texts = append(texts, it.Text)
+		}
+		blocks = append(blocks, it.Blocks...)
+	}
+	go func() {
+		defer func() {
+			mu.Lock()
+			s.turnRunning[sessionID] = false
+			mu.Unlock()
+		}()
+		s.runAgentTurnLoop(sess, strings.Join(texts, "\n\n"), blocks, imageRefsFromBlocks(blocks))
+	}()
 }
 
 // bgNoticeStatus maps a BackgroundManager exit status ("exited: 0",

--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -153,5 +154,95 @@ func TestNotifyAgentBgExit_IdleGoesToSteerQueue(t *testing.T) {
 	items := srv.drainSteer("sess-1")
 	if len(items) != 1 || !strings.Contains(items[0].Text, "[BACKGROUND COMPLETED]") || !strings.Contains(items[0].Text, "bg_2") {
 		t.Fatalf("steer queue = %+v, want one bg note", items)
+	}
+}
+
+// An idle-time note must not just sit in the steer queue — it kicks a turn so
+// the model reacts immediately (parity with the TUI's idle auto-turn). The
+// kicked turn consumes the note; the reminder never renders as a user bubble
+// (doAgentTurn strips <system-reminder> spans from the broadcast).
+func TestDeliverModelNote_IdleKicksTurn(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.wsHub = newWSHub()
+	srv.turnRunning = map[string]bool{}
+	srv.liveStates = map[string]*sessionLiveState{}
+	srv.interrupts = map[string]context.CancelFunc{}
+
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv.deliverModelNote(sess.ID, "<system-reminder>\n[BACKGROUND COMPLETED]\nBackground process bg_1 (`make build`) exited: 0.\n</system-reminder>")
+
+	// The kicked turn runs asynchronously; wait for it to finish.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		mu := srv.sessionTurnLock(sess.ID)
+		mu.Lock()
+		running := srv.turnRunning[sess.ID]
+		mu.Unlock()
+		if !running {
+			// Either finished or never started — check results below.
+			loaded, err := agent.LoadSession(sess.ID)
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if len(loaded.Messages) >= 2 {
+				if leftover := srv.drainSteer(sess.ID); len(leftover) != 0 {
+					t.Errorf("steer queue = %+v, want drained", leftover)
+				}
+				return // turn ran: user note + assistant reply persisted
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("kicked turn never completed")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// prepareToolTurn must hand back the SAME session-scoped manager on every
+// turn of a session (async mode), so spawns survive turn boundaries — and a
+// sid-less context still gets the old per-turn synchronous manager.
+func TestPrepareToolTurn_SessionScopedAsyncManager(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Tools: true})
+	a := agent.New(&stubSender{}, "stub-model")
+
+	ctx := context.WithValue(context.Background(), ctxKeySessionID{}, "sess-mgr-test")
+	t.Cleanup(func() { tools.CloseSessionSubAgentManager("sess-mgr-test") })
+
+	_, _, m1, err := srv.prepareToolTurn(ctx, a)
+	if err != nil {
+		t.Fatalf("prepareToolTurn: %v", err)
+	}
+	_, _, m2, err := srv.prepareToolTurn(ctx, a)
+	if err != nil {
+		t.Fatalf("prepareToolTurn: %v", err)
+	}
+	if m1 != m2 {
+		t.Error("same session should reuse one sub-agent manager across turns")
+	}
+	if m1.Synchronous() {
+		t.Error("session-scoped manager should be async")
+	}
+
+	_, _, anon, err := srv.prepareToolTurn(context.Background(), a)
+	if err != nil {
+		t.Fatalf("prepareToolTurn (no sid): %v", err)
+	}
+	if !anon.Synchronous() {
+		t.Error("sid-less context should fall back to a synchronous manager")
+	}
+	if anon == m1 {
+		t.Error("sid-less manager must not be the session-scoped one")
 	}
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -479,6 +479,7 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 	}
 	s.forgetTurnLock(id)
 	tools.CloseSessionBackgroundManager(id) // reap the session's background daemons
+	tools.CloseSessionSubAgentManager(id)   // and its sub-agents
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": []string{id}})
 }
 
@@ -508,6 +509,7 @@ func (s *Server) handleDeleteSessions(w http.ResponseWriter, r *http.Request) {
 		}
 		s.forgetTurnLock(id)
 		tools.CloseSessionBackgroundManager(id) // reap the session's background daemons
+		tools.CloseSessionSubAgentManager(id)   // and its sub-agents
 		deleted = append(deleted, id)
 	}
 
@@ -626,11 +628,44 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.C
 	}
 	a.Gate = app.NewPermissionGate(engine, ask)
 
-	spawner := app.NewSpawner(a, executor, func() []agent.ToolDefinition {
-		return tools.DefaultToolsFor(a.Model)
-	})
-	mgr := tools.NewSubAgentManager(spawner)
-	mgr.SetSynchronous(true)
+	mkSpawner := func() tools.Spawner {
+		return app.NewSpawner(a, executor, func() []agent.ToolDefinition {
+			return tools.DefaultToolsFor(a.Model)
+		})
+	}
+	var mgr *tools.SubAgentManager
+	if sid, ok := ctx.Value(ctxKeySessionID{}).(string); ok && sid != "" {
+		// Session-scoped manager: it (and its spawner's child registry)
+		// persists across turns, so sub-agents may run async — a spawn
+		// outlives its turn, the completion lands via the manager's onExit
+		// hook, and children stay resumable later. The spawner is built once,
+		// on the session's first tool turn; the Sender/System it captures are
+		// per-server and stable.
+		mgr = tools.SessionSubAgentManager(sid, mkSpawner)
+		// (Re-)wire the hooks every turn — idempotent, and they outlive the
+		// turn so an async completion between turns still lands.
+		mgr.SetOnEvent(func(ev tools.SubAgentEvent) {
+			if s.wsHub == nil {
+				return
+			}
+			s.wsHub.broadcast(sid, map[string]any{
+				"type":        "sub_agent_event",
+				"session_id":  sid,
+				"agent_id":    ev.AgentID,
+				"description": ev.Description,
+				"kind":        ev.Kind,
+				"tool_name":   ev.ToolName,
+			})
+		})
+		mgr.SetOnExit(func(ev tools.SubAgentNotification) {
+			s.notifySubAgentExit(sid, ev)
+		})
+	} else {
+		// No session identity (one-shot runTurn paths): keep the old
+		// request/response semantics — block on every sub-agent.
+		mgr = tools.NewSubAgentManager(mkSpawner())
+		mgr.SetSynchronous(true)
+	}
 	ctx = tools.WithSubAgentManager(ctx, mgr)
 	ctx = tools.WithTaskStore(ctx, tasks.New())
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -308,6 +308,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	// terminal background commands run through the process-global manager
 	// regardless of which session launched them, so one call covers all.
 	tools.KillAllBackground()
+	tools.KillAllSessionSubAgents()
 	tools.SetDefaultSubAgentManager(nil)
 	tools.SetTaskStore(nil)
 	if s.mcpCleanup != nil {

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -2159,6 +2159,12 @@ const Sessions = (() => {
     // description, elapsed time, and recent tool chain.
 
     handleSubAgentEvent(agentID, description, kind, toolName) {
+      // "done" removes the entry — handled before the create-on-miss below
+      // so a late done can't resurrect a slot that was already cleared.
+      if (kind === "done") {
+        this.handleSubAgentDone(agentID);
+        return;
+      }
       let sa = _subAgents[agentID];
       if (!sa) {
         sa = { description: description || agentID, start: Date.now(), recent: [], errored: false };
@@ -2188,10 +2194,10 @@ const Sessions = (() => {
     },
 
     handleSubAgentDone(agentID) {
-      if (agentID && _subAgents[agentID]) {
-        delete _subAgents[agentID];
+      if (agentID) {
+        delete _subAgents[agentID]; // no-op when already cleared
       } else {
-        // Sync mode sends sub_agent_done without agent_id — clear all.
+        // Legacy sub_agent_done without agent_id — clear all.
         Object.keys(_subAgents).forEach(k => delete _subAgents[k]);
       }
       this._updateSubAgentBadge();

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -365,16 +365,21 @@ func (s *Server) drainSteer(sessionID string) []agent.InboxItem {
 func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent.ContentBlock, images []string) {
 	// Confirm the user message immediately so the frontend can swap the
 	// ghost (.msg-pending) bubble for the real one before streaming starts.
-	userEvent := map[string]any{
-		"type":       "history_user_message",
-		"session_id": sess.ID,
-		"content":    content,
-		"created_at": time.Now().UnixMilli(),
+	// <system-reminder> spans are stripped from the bubble: a turn kicked by a
+	// completion note (kickIdleSteerTurn) is pure reminder and renders nothing.
+	visible := strings.TrimSpace(agent.StripSystemReminders(content))
+	if visible != "" || len(images) > 0 {
+		userEvent := map[string]any{
+			"type":       "history_user_message",
+			"session_id": sess.ID,
+			"content":    visible,
+			"created_at": time.Now().UnixMilli(),
+		}
+		if len(images) > 0 {
+			userEvent["images"] = images
+		}
+		s.wsHub.broadcast(sess.ID, userEvent)
 	}
-	if len(images) > 0 {
-		userEvent["images"] = images
-	}
-	s.wsHub.broadcast(sess.ID, userEvent)
 
 	// Persist the user message right away so a page refresh mid-turn doesn't
 	// lose it.  We append it for Save(), then pop it back off so buildAgent
@@ -481,10 +486,11 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 
 	var toolDefs []agent.ToolDefinition
 	var executor agent.ToolExecutor
-	var subMgr *tools.SubAgentManager
 	if s.cfg.Tools {
 		var perr error
-		runCtx, executor, subMgr, perr = s.prepareToolTurn(runCtx, a)
+		// prepareToolTurn wires the session-scoped sub-agent manager's hooks
+		// (live-panel events + completion notes to the model).
+		runCtx, executor, _, perr = s.prepareToolTurn(runCtx, a)
 		if perr != nil {
 			sw.error(perr.Error())
 			return
@@ -492,19 +498,6 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		toolDefs = tools.DefaultToolsFor(a.Model)
 		// Surface background-process completions (badge + chat notice).
 		s.wireBackgroundTaskNotices(sess.ID)
-		// Wire sub-agent live-panel events into the WebSocket stream.
-		if subMgr != nil {
-			subMgr.SetOnEvent(func(ev tools.SubAgentEvent) {
-				s.wsHub.broadcast(sess.ID, map[string]any{
-					"type":        "sub_agent_event",
-					"session_id":  sess.ID,
-					"agent_id":    ev.AgentID,
-					"description": ev.Description,
-					"kind":        ev.Kind,
-					"tool_name":   ev.ToolName,
-				})
-			})
-		}
 	}
 
 	reply, err := a.RunStream(runCtx, content, toolDefs, executor, sw.handleEvent)
@@ -767,19 +760,15 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 			toolResult["ui_payload"] = ev.UI
 		}
 		w.hub.broadcast(w.sessionID, toolResult)
-		// Signal sub-agent completion so the frontend can clear the live panel.
-		if ev.ToolName == "sub_agent" {
-			w.hub.broadcast(w.sessionID, map[string]any{
-				"type":       "sub_agent_done",
-				"session_id": w.sessionID,
-			})
-		}
 		// The agent immediately starts the next LLM round after a tool result,
 		// and that round emits no event until its first delta (or the next
 		// tool_call). Re-seed the "thinking" indicator so the UI animates
 		// across the gap instead of the next tool popping out of dead air —
 		// same rationale as the turn-start seed in doAgentTurn. The frontend
 		// clears it on the next tool_call / assistant_message / complete.
+		// (No sub_agent_done broadcast here: in async mode the tool returns
+		// while agents still run — the manager's per-agent "done" event is
+		// the completion signal for the live panel.)
 		w.reseedThinkingProgress()
 		// A tool call is the only place a turn starts or kills a background
 		// process — refresh the badge.

--- a/internal/tools/session_managers.go
+++ b/internal/tools/session_managers.go
@@ -73,6 +73,59 @@ func CloseSessionBackgroundManager(id string) {
 	}
 }
 
+// Per-session sub-agent managers, keyed the same way as the background
+// managers. Unlike the per-turn managers the server used to build, these
+// persist across turns, which is what makes async sub-agents possible there:
+// a spawn outlives the turn that launched it, its completion hook still has a
+// home, and the spawner's child registry keeps children resumable in later
+// turns. Reaped on session delete (CloseSessionSubAgentManager) or daemon
+// shutdown (KillAllSessionSubAgents).
+var (
+	sessionSubMgrsMu sync.Mutex
+	sessionSubMgrs   = map[string]*SubAgentManager{}
+)
+
+// SessionSubAgentManager returns the per-session sub-agent manager for id,
+// creating it via mkSpawner on first use. Subsequent calls reuse the existing
+// manager (and its spawner), so mkSpawner is only invoked once per session.
+func SessionSubAgentManager(id string, mkSpawner func() Spawner) *SubAgentManager {
+	sessionSubMgrsMu.Lock()
+	defer sessionSubMgrsMu.Unlock()
+	m := sessionSubMgrs[id]
+	if m == nil {
+		m = NewSubAgentManager(mkSpawner())
+		sessionSubMgrs[id] = m
+	}
+	return m
+}
+
+// CloseSessionSubAgentManager kills every sub-agent tracked for a session and
+// drops its manager. No-op for an unknown id.
+func CloseSessionSubAgentManager(id string) {
+	sessionSubMgrsMu.Lock()
+	m := sessionSubMgrs[id]
+	delete(sessionSubMgrs, id)
+	sessionSubMgrsMu.Unlock()
+	if m != nil {
+		m.KillAll()
+	}
+}
+
+// KillAllSessionSubAgents terminates every sub-agent across all sessions.
+// Called on daemon shutdown, mirroring KillAllBackground.
+func KillAllSessionSubAgents() {
+	sessionSubMgrsMu.Lock()
+	mgrs := make([]*SubAgentManager, 0, len(sessionSubMgrs))
+	for _, m := range sessionSubMgrs {
+		mgrs = append(mgrs, m)
+	}
+	sessionSubMgrs = map[string]*SubAgentManager{}
+	sessionSubMgrsMu.Unlock()
+	for _, m := range mgrs {
+		m.KillAll()
+	}
+}
+
 // allBackgroundManagers returns defaultBg plus every live per-session manager,
 // so process-wide operations (shutdown reap) cover every tracked process.
 func allBackgroundManagers() []*BackgroundManager {

--- a/internal/tools/session_managers_test.go
+++ b/internal/tools/session_managers_test.go
@@ -23,3 +23,35 @@ func TestSessionBackgroundManager_Registry(t *testing.T) {
 	}
 	CloseSessionBackgroundManager("sess-A")
 }
+
+// TestSessionSubAgentManager_Registry mirrors the background-manager registry
+// contract: get-or-create identity, single spawner construction, and Close
+// dropping the entry.
+func TestSessionSubAgentManager_Registry(t *testing.T) {
+	built := 0
+	mk := func() Spawner { built++; return &fakeSpawner{} }
+
+	a1 := SessionSubAgentManager("sub-A", mk)
+	a2 := SessionSubAgentManager("sub-A", mk)
+	b := SessionSubAgentManager("sub-B", mk)
+	defer CloseSessionSubAgentManager("sub-B")
+
+	if a1 != a2 {
+		t.Error("same id should return the same manager instance")
+	}
+	if built != 2 {
+		t.Errorf("spawner built %d times, want 2 (once per session)", built)
+	}
+	if a1 == b {
+		t.Error("different ids should get distinct managers")
+	}
+	if a1.Synchronous() {
+		t.Error("session manager should default to async")
+	}
+
+	CloseSessionSubAgentManager("sub-A")
+	a3 := SessionSubAgentManager("sub-A", mk)
+	if a3 == a1 {
+		t.Error("Close should drop the entry so the next lookup builds fresh")
+	}
+}

--- a/internal/tools/subagent_event.go
+++ b/internal/tools/subagent_event.go
@@ -17,6 +17,8 @@ type SubAgentEvent struct {
 	//   "started"    — the sub-agent began a task (or a Continue round)
 	//   "tool"       — it dispatched a tool (ToolName set)
 	//   "tool_error" — a tool returned an error (ToolName set)
+	//   "done"       — the round finished (sync return or async completion);
+	//                  live panels drop the entry on this
 	Kind     string
 	ToolName string
 }

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -203,6 +203,7 @@ func (m *SubAgentManager) RunSync(ctx context.Context, req SpawnRequest) (SpawnR
 	if sink := m.eventSink(id, req.Description); sink != nil {
 		ctx = WithSubAgentEventSink(ctx, sink)
 		sink(SubAgentEvent{Kind: "started"})
+		defer sink(SubAgentEvent{Kind: "done"})
 	}
 	return m.spawner.Spawn(ctx, req)
 }
@@ -316,7 +317,8 @@ func (m *SubAgentManager) Start(req SpawnRequest) (string, error) {
 
 	// Stream runtime events (started + per-tool) for live display. nil sink =>
 	// no onEvent hook => the spawner runs without streaming.
-	if sink := m.eventSink(id, req.Description); sink != nil {
+	sink := m.eventSink(id, req.Description)
+	if sink != nil {
 		ctx = WithSubAgentEventSink(ctx, sink)
 		sink(SubAgentEvent{Kind: "started"})
 	}
@@ -327,6 +329,11 @@ func (m *SubAgentManager) Start(req SpawnRequest) (string, error) {
 			m.activeAsync--
 			m.mu.Unlock()
 		}()
+		if sink != nil {
+			// Deferred (not inline after the hook) so a panic-free exit always
+			// clears the live-panel entry, even on spawn error.
+			defer sink(SubAgentEvent{Kind: "done"})
+		}
 		res, err := m.spawner.Spawn(ctx, req)
 		stopReason := ""
 		if err == nil {
@@ -411,8 +418,11 @@ func (m *SubAgentManager) runContinue(agentID, message string) {
 	agent.mu.Unlock()
 
 	// Stream runtime events for this round too, so the live panel re-shows the
-	// sub-agent as running while it handles the message.
-	if sink := m.eventSink(agentID, desc); sink != nil {
+	// sub-agent as running while it handles the message. "done" is emitted
+	// explicitly before any pending-message handoff (not deferred) so it can't
+	// race the next round's "started".
+	sink := m.eventSink(agentID, desc)
+	if sink != nil {
 		ctx = WithSubAgentEventSink(ctx, sink)
 		sink(SubAgentEvent{Kind: "started"})
 	}
@@ -448,6 +458,9 @@ func (m *SubAgentManager) runContinue(agentID, message string) {
 			OutputTokens: outTok,
 			StopReason:   sr,
 		})
+	}
+	if sink != nil {
+		sink(SubAgentEvent{Kind: "done"})
 	}
 
 	// Process pending message, if any.

--- a/internal/tools/subagent_manager_test.go
+++ b/internal/tools/subagent_manager_test.go
@@ -1,0 +1,77 @@
+package tools
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// collectEvents registers an onEvent hook that appends every event kind to a
+// shared slice, returning an accessor for the collected kinds.
+func collectEvents(m *SubAgentManager) func() []string {
+	var mu sync.Mutex
+	var kinds []string
+	m.SetOnEvent(func(ev SubAgentEvent) {
+		mu.Lock()
+		kinds = append(kinds, ev.Kind)
+		mu.Unlock()
+	})
+	return func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), kinds...)
+	}
+}
+
+// A synchronous round must bracket its work with started/done events so live
+// panels can show and then drop the entry — sync completions never fire the
+// onExit hook, so "done" is the only completion signal a panel gets.
+func TestRunSync_EmitsStartedAndDone(t *testing.T) {
+	m := NewSubAgentManager(&fakeSpawner{})
+	kinds := collectEvents(m)
+
+	if _, err := m.RunSync(context.Background(), SpawnRequest{Description: "d", Prompt: "p"}); err != nil {
+		t.Fatalf("RunSync: %v", err)
+	}
+
+	got := kinds()
+	if len(got) != 2 || got[0] != "started" || got[1] != "done" {
+		t.Fatalf("events = %v, want [started done]", got)
+	}
+}
+
+// An async spawn must emit "done" after completion too (alongside the onExit
+// notification), so the web live panel clears per-agent.
+func TestStart_EmitsDoneOnCompletion(t *testing.T) {
+	m := NewSubAgentManager(&fakeSpawner{})
+	kinds := collectEvents(m)
+
+	exited := make(chan struct{})
+	m.SetOnExit(func(SubAgentNotification) { close(exited) })
+
+	if _, err := m.Start(SpawnRequest{Description: "d", Prompt: "p"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-exited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("onExit never fired")
+	}
+	// "done" is emitted by a deferred call after the hook — give the goroutine
+	// a moment to unwind.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got := kinds()
+		if len(got) >= 2 && got[len(got)-1] == "done" {
+			if got[0] != "started" {
+				t.Fatalf("events = %v, want started first", got)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("events = %v, want trailing done", got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/tools/subagent_notify.go
+++ b/internal/tools/subagent_notify.go
@@ -1,18 +1,16 @@
-package main
+package tools
 
 import (
 	"fmt"
 	"strings"
-
-	"github.com/Leihb/octo-agent/internal/tools"
 )
 
-// formatSubAgentNote renders a sub-agent completion notification as a
+// FormatSubAgentNote renders a sub-agent completion notification as a
 // <system-reminder> block. It rides the existing steer path (Agent.Steer →
 // folded into the next tool_result, or prepended to the next turn — see
 // turncore.go), so the model reads it as an environment event rather than
 // user speech.
-func formatSubAgentNote(ev tools.SubAgentNotification) string {
+func FormatSubAgentNote(ev SubAgentNotification) string {
 	var b strings.Builder
 	b.WriteString("<system-reminder>\n")
 	b.WriteString("[BACKGROUND COMPLETED]\n")

--- a/internal/tools/subagent_notify_test.go
+++ b/internal/tools/subagent_notify_test.go
@@ -1,17 +1,15 @@
-package main
+package tools
 
 import (
 	"strings"
 	"testing"
-
-	"github.com/Leihb/octo-agent/internal/tools"
 )
 
 // TestFormatSubAgentNote_MaxTurnsFlagged verifies an async sub-agent that hit
 // its turn limit is flagged INCOMPLETE in the completion notice, so the parent
 // doesn't treat partial work as a finished answer.
 func TestFormatSubAgentNote_MaxTurnsFlagged(t *testing.T) {
-	got := formatSubAgentNote(tools.SubAgentNotification{
+	got := FormatSubAgentNote(SubAgentNotification{
 		AgentID:     "agent_1",
 		Description: "investigate",
 		Kind:        "spawn_done",
@@ -23,7 +21,7 @@ func TestFormatSubAgentNote_MaxTurnsFlagged(t *testing.T) {
 	}
 
 	// Normal completion is not flagged.
-	clean := formatSubAgentNote(tools.SubAgentNotification{
+	clean := FormatSubAgentNote(SubAgentNotification{
 		AgentID: "agent_2", Description: "x", Kind: "spawn_done", Result: "done",
 	})
 	if strings.Contains(clean, "INCOMPLETE") {


### PR DESCRIPTION
## Problem

Server (web) sub-agents were forced synchronous (`SetSynchronous(true)`), because everything about them was per-turn: `prepareToolTurn` built a fresh manager + spawner each turn and they died with it, so an async spawn would have outlived its completion hook. The costs:

- **No parallel fan-out** — `sub_agent` is not in the read-only parallel-dispatch set, so every spawn blocked the loop serially; `run_in_background=true` was silently downgraded with a note.
- **Steering went unresponsive** during a long sub-agent (the Inbox only drains between loop iterations).
- **`continue` was broken across turns** — the spawner's child registry died with the turn.

The infrastructure to fix this landed in #536/#543: a per-session manager pattern, the steer queue, `StripSystemReminders`, and `deliverModelNote`.

## Changes

**tools**
- Per-session `SubAgentManager` registry (`SessionSubAgentManager` / `CloseSessionSubAgentManager` / `KillAllSessionSubAgents`), mirroring the background-manager registry. Manager + spawner (and its child registry) persist across turns: spawns survive turn end, children stay resumable.
- Managers emit a `"done"` sub-agent event at round completion — sync return and async exit — so live panels clear **per-agent**. (In `runContinue` it is emitted before the pending-message handoff, not deferred, so it can't race the next round's `"started"`.)
- `FormatSubAgentNote` moved from `cmd/octo` into `tools` (same motivation as `FormatBgNote` in #543).

**server**
- `prepareToolTurn`: ctx carries a session id → session-scoped **async** manager, hooks wired there (idempotent per turn): live-panel events over WS + completion notes to the model via the shared `deliverModelNote` path (running Agent's Inbox mid-turn, steer queue while idle). Sid-less paths keep a per-turn synchronous manager.
- **Idle auto-turn**: a completion note delivered while no turn is running now kicks one (`kickIdleSteerTurn`) so the model reacts immediately — the TUI's idle auto-turn, ported. Background-process notes share it via `deliverModelNote`. `doAgentTurn` strips `<system-reminder>` spans from the live user bubble, so a note-kicked turn renders no user speech.
- The clear-all `sub_agent_done` broadcast on tool completion is removed — wrong in async mode (it nuked still-running agents from the panel); the per-agent `"done"` event replaces it.
- Session delete / daemon shutdown reap sub-agents alongside background processes.

**web/TUI**
- Both panels handle the `"done"` kind: delete the entry, update the badge — guarded so a late `done` can't resurrect a cleared slot (TUI) or clear unrelated entries (web).

**IM stays synchronous deliberately**: a chat is request/response with no bot-initiated sends, so an idle async completion would strand until the user's next message.

## Tests

- `TestSessionSubAgentManager_Registry` — get-or-create identity, one spawner per session, async default, close-drops-entry.
- `TestRunSync_EmitsStartedAndDone` / `TestStart_EmitsDoneOnCompletion` — completion events for both dispatch modes.
- `TestPrepareToolTurn_SessionScopedAsyncManager` — same manager across turns, async; sid-less fallback stays sync.
- `TestDeliverModelNote_IdleKicksTurn` — idle note → auto-turn runs against the stub sender, queue drained, note + reply persisted.
- `TestServerRunsSubAgentSynchronously` still passes: per-call default (`run_in_background` unset) remains blocking.
- `make test` (race) green across the repo; `node --check` on sessions.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)