### PR TITLE
fix(server): stop leaked test goroutines from writing sessions into the real HOME

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -217,7 +217,13 @@ func (s *Session) SetTitle(title string) error {
 	if err != nil {
 		return err
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	// No O_CREATE: persisted > 0 means the transcript should already exist.
+	// If it doesn't (session deleted meanwhile, or the path resolves
+	// differently than when it was saved — e.g. an async title goroutine
+	// outliving a test's HOME override), creating a file holding nothing but
+	// a title record would leave an orphan "session" in list views. Fail
+	// instead; a later turn retries title generation.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return fmt.Errorf("session: open %s: %w", path, err)
 	}

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -193,6 +193,34 @@ func TestSetTitle_AppendsAndReloads(t *testing.T) {
 	}
 }
 
+func TestSetTitle_NeverCreatesOrphanFile(t *testing.T) {
+	// A session that believes it is persisted but whose transcript is gone
+	// (deleted meanwhile, or the path resolves to a different HOME than the
+	// one it was saved under) must NOT materialize a file holding nothing but
+	// a title record — those show up as ghost sessions in list views.
+	setTempHome(t)
+
+	s := NewSession("m", "")
+	s.Messages = []Message{NewUserMessage("ping"), NewAssistantMessage("pong")}
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+	path, err := s.SavePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.SetTitle("ghost"); err == nil {
+		t.Fatal("SetTitle on a missing transcript: want error, got nil")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("SetTitle created an orphan title-only file at %s", path)
+	}
+}
+
 func TestSetTitle_LastWins(t *testing.T) {
 	setTempHome(t)
 	s := NewSession("m", "")

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain pins HOME for the entire test binary. Turn paths spawn
+// fire-and-forget goroutines (title generation, follow-up suggestions) that
+// can outlive an individual test's t.Setenv("HOME") scope; once the test ends
+// the env is restored, and a goroutine that resolves ~/.octo after that would
+// write session files into the developer's real home directory (observed as
+// "stub reply" sessions in the Web UI sidebar). With a process-lifetime temp
+// HOME, nothing a leaked goroutine writes can escape the sandbox. Individual
+// tests that t.Setenv their own HOME still work — they restore to this temp
+// dir, not the real one.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "octo-server-test-home-")
+	if err == nil {
+		os.Setenv("HOME", tmp)
+		os.Setenv("USERPROFILE", tmp)
+	}
+	code := m.Run()
+	if tmp != "" {
+		os.RemoveAll(tmp)
+	}
+	os.Exit(code)
+}


### PR DESCRIPTION
## Problem

Every `go test ./internal/server/` run left a few ghost sessions named **"stub reply"** (dated 1/1 — zero timestamp) in the developer's real `~/.octo/sessions`, visible in the Web UI sidebar.

Mechanism:
1. A test isolates with `t.Setenv("HOME", tmp)`; `doAgentTurn` runs and saves the session under tmp.
2. The turn end spawns the **fire-and-forget title-generation goroutine** (`ws_handlers.go`); with the test's `stubSender` the generated title is literally "stub reply".
3. The test returns → `t.Setenv` restores the real HOME.
4. The still-running goroutine's `SetTitle` re-resolves `~/.octo` under the **real** home, and because it opened with `O_CREATE`, it materialized a file containing nothing but `{"type":"title","title":"stub reply"}`.

## Fix (two layers)

- **`internal/server/main_test.go`**: `TestMain` pins HOME/USERPROFILE to a process-lifetime temp dir, so anything a leaked goroutine writes stays sandboxed. Per-test `t.Setenv` still works — it restores to the temp dir, not the real home.
- **`Session.SetTitle` drops `O_CREATE`** (`session.go`): `persisted > 0` means the transcript must already exist; if it doesn't (deleted concurrently, or resolved under a different HOME), fail and let a later turn retry — never create an orphan title-only file. The doc comment already promised "if the transcript already exists on disk, appends"; now the code matches. This also guards the production race of deleting a session while its title generation is in flight.

## Test plan

- [x] New `TestSetTitle_NeverCreatesOrphanFile`: transcript removed between Save and SetTitle → error returned, no file created.
- [x] `go vet ./...`, `go test -race ./...` all green.
- [x] Verified the leak reproduces on main (11 title-only files appeared in `~/.octo/sessions` during today's test runs) and the files match the predicted 74-byte single-record shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)