### PR TITLE
fix(web): wire the session rename action to a real endpoint

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -732,6 +732,44 @@ func (s *Server) handleFileAction(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// ─── PATCH /api/sessions/{id} ───────────────────────────────────────────────
+
+// updateSessionRequest carries the user-editable session fields. Only the
+// title (the sidebar "name") is editable today.
+type updateSessionRequest struct {
+	Name string `json:"name"`
+}
+
+// handleUpdateSession renames a session — the sidebar's rename action.
+func (s *Server) handleUpdateSession(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing session id")
+		return
+	}
+	var req updateSessionRequest
+	if err := readBodyJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+
+	sess, err := agent.LoadSession(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	if err := sess.SetTitle(name); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("set title: %v", err))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"session": s.toSessionItem(sess, "manual", "general")})
+}
+
 // ─── PATCH /api/sessions/{id}/model ─────────────────────────────────────────
 
 type updateSessionModelRequest struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -326,6 +326,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/sessions/{id}", s.requireAuth(s.handleGetSession))
 	s.mux.HandleFunc("GET /api/sessions/{id}/messages", s.requireAuth(s.handleGetSessionMessages))
 	s.mux.HandleFunc("DELETE /api/sessions/{id}", s.requireAuth(s.handleDeleteSession))
+	s.mux.HandleFunc("PATCH /api/sessions/{id}", s.requireAuth(s.handleUpdateSession))
 	s.mux.HandleFunc("PATCH /api/sessions/{id}/model", s.requireAuth(s.handleUpdateSessionModel))
 	s.mux.HandleFunc("PATCH /api/sessions/{id}/reasoning_effort", s.requireAuth(s.handleUpdateSessionReasoningEffort))
 	s.mux.HandleFunc("PATCH /api/sessions/{id}/working_dir", s.requireAuth(s.handleUpdateSessionWorkingDir))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1149,3 +1149,45 @@ func TestWSStreamWriter_ReseedsThinkingAfterTool(t *testing.T) {
 		})
 	}
 }
+
+// PATCH /api/sessions/{id} is the sidebar rename action — the title must
+// persist through a session reload, and bad input must not slip through.
+func TestHandleUpdateSession_Rename(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := agent.NewSession("stub-model", "")
+	sess.Messages = []agent.Message{{Role: agent.RoleUser, Content: "hi"}}
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	do := func(id, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPatch, "/api/sessions/"+id, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.mux.ServeHTTP(w, req)
+		return w
+	}
+
+	if w := do(sess.ID, `{"name":"My research session"}`); w.Code != http.StatusOK {
+		t.Fatalf("rename status = %d; body=%s", w.Code, w.Body.String())
+	}
+	loaded, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.Title != "My research session" {
+		t.Errorf("Title = %q, want the new name", loaded.Title)
+	}
+
+	if w := do(sess.ID, `{"name":"  "}`); w.Code != http.StatusBadRequest {
+		t.Errorf("blank name status = %d, want 400", w.Code)
+	}
+	if w := do("no-such-session", `{"name":"x"}`); w.Code != http.StatusNotFound {
+		t.Errorf("unknown id status = %d, want 404", w.Code)
+	}
+}


### PR DESCRIPTION
## Problem

The sidebar's rename action (actions menu → Rename → modal) sends `PATCH /api/sessions/{id}` with `{"name": "..."}`, but the server never registered that route — only `GET`/`DELETE /api/sessions/{id}` and the `/model`, `/reasoning_effort`, `/working_dir` sub-resource PATCHes exist. Every rename returned 405 and failed silently (console error only); the UI looked like nothing happened.

## Changes

- `handleUpdateSession` on `PATCH /api/sessions/{id}`: trims and validates the name (400 on blank, 404 on unknown session), calls `sess.SetTitle` — which appends a title record to the transcript so the rename survives reloads without rewriting the file — and returns the updated session item.
- Route registered with auth like its siblings.

No frontend changes needed; the modal and optimistic list patch were already in place, just talking to a void.

## Tests

`TestHandleUpdateSession_Rename` — rename persists through `LoadSession`, blank name → 400, unknown id → 404. `make test` (race) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)