### PR TITLE
fix(web): dedup the user bubble when the history fetch races the live broadcast

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -362,7 +362,13 @@ func (s *Server) handleGetSessionMessages(w http.ResponseWriter, r *http.Request
 			// array index as a unique cursor (not sess.CreatedAt — that
 			// collides with the Web UI's dedup logic and drops everything
 			// after the first user message).
-			createdAt := m.CreatedAt.Unix()
+			//
+			// UnixMilli, not Unix: the live history_user_message broadcast in
+			// doAgentTurn sends this message's CreatedAt in milliseconds, and
+			// the Web UI dedups live-vs-history rounds by exact created_at
+			// equality — mismatched units would render the same user message
+			// twice when a history fetch races the live event.
+			createdAt := m.CreatedAt.UnixMilli()
 			if m.CreatedAt.IsZero() {
 				createdAt = int64(i + 1)
 			}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1063,6 +1063,93 @@ drain:
 	}
 }
 
+// TestDoAgentTurn_LiveAndHistoryCreatedAtMatch guards the Web UI's
+// live-vs-history dedup key. On session open, the initial /messages fetch can
+// race the live history_user_message broadcast; the frontend dedups the two
+// render paths by exact created_at equality, so the broadcast and the history
+// endpoint must report the SAME millisecond value for the same user message.
+// A mismatch (one side seconds, the other milliseconds, or two separate
+// time.Now() calls) renders the user's message twice until a page refresh.
+func TestDoAgentTurn_LiveAndHistoryCreatedAtMatch(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]agent.InboxItem)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+	srv.wsHub.subscribe(conn, sess.ID)
+
+	srv.doAgentTurn(sess, "hello dedup", nil, nil)
+
+	// Capture the live broadcast's created_at.
+	var liveCreatedAt float64
+	deadline := time.After(2 * time.Second)
+drainDedup:
+	for {
+		select {
+		case b := <-conn.send:
+			var ev map[string]any
+			if err := json.Unmarshal(b, &ev); err != nil {
+				continue
+			}
+			if typ, _ := ev["type"].(string); typ == "history_user_message" {
+				liveCreatedAt, _ = ev["created_at"].(float64)
+			} else if typ == "complete" {
+				break drainDedup
+			}
+		case <-deadline:
+			break drainDedup
+		}
+	}
+	if liveCreatedAt <= 0 {
+		t.Fatal("no live history_user_message with created_at captured")
+	}
+
+	// Fetch history and find the same user message.
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/"+sess.ID+"/messages?access_key="+srv.AccessKey(), nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("messages status = %d; body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Events []map[string]any `json:"events"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	var histCreatedAt float64
+	for _, ev := range body.Events {
+		if typ, _ := ev["type"].(string); typ == "history_user_message" {
+			if c, _ := ev["content"].(string); c == "hello dedup" {
+				histCreatedAt, _ = ev["created_at"].(float64)
+			}
+		}
+	}
+	if histCreatedAt <= 0 {
+		t.Fatal("user message not found in history endpoint response")
+	}
+	if liveCreatedAt != histCreatedAt {
+		t.Fatalf("dedup key mismatch: live created_at = %v, history created_at = %v — frontend would render the message twice",
+			liveCreatedAt, histCreatedAt)
+	}
+}
+
 // TestWSStreamWriter_ReseedsThinkingAfterTool is the regression guard for the
 // web-UI "tools pop out of dead air" gap. The frontend clears the progress
 // indicator when a tool_call renders, and the next LLM round emits nothing

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -4009,6 +4009,13 @@ const Sessions = (() => {
       dedup.add(createdAt);
     },
 
+    /** Whether a round with this created_at was already rendered (by either
+     *  the live WS handler or a history fetch) — the other path must skip it. */
+    isRendered(id, createdAt) {
+      if (!createdAt) return false;
+      return !!_renderedCreatedAt[id]?.has(createdAt);
+    },
+
     /** Mark a session as having a pending task that should start after subscribe. */
     setPendingRunTask(sessionId) {
       _pendingRunTaskId = sessionId;

--- a/internal/server/static/ws-dispatcher.js
+++ b/internal/server/static/ws-dispatcher.js
@@ -167,6 +167,14 @@ WS.onEvent(ev => {
       if (ev.session_id !== Sessions.activeId) break;
       const firstGhost = document.querySelector(".msg-pending");
       if (firstGhost) firstGhost.remove();
+      // Dedup against the initial history fetch: on session open the
+      // /messages fetch can race this live event (the turn starts over WS
+      // while the fetch is in flight), and whichever path renders second
+      // would duplicate the bubble. Both paths carry the message's persisted
+      // CreatedAt in ms, so exact-match marking makes them mutually
+      // exclusive.
+      if (Sessions.isRendered(ev.session_id, ev.created_at)) break;
+      Sessions.markRendered(ev.session_id, ev.created_at);
       let userHtml = "";
       if (Array.isArray(ev.images) && ev.images.length > 0) {
         userHtml += ev.images.map(src => {

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -363,6 +363,21 @@ func (s *Server) drainSteer(sessionID string) []agent.InboxItem {
 }
 
 func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent.ContentBlock, images []string) {
+	// Build the user message first: its CreatedAt is both the persisted
+	// timestamp and the broadcast created_at below, so the live event and a
+	// concurrent history fetch carry the SAME dedup key. (Mirror
+	// appendUserInput's multipart shape — optional text block, then
+	// attachments — so the persisted line matches what RunStream appends.)
+	userMsg := agent.NewUserMessage(content)
+	if len(blocks) > 0 {
+		multi := make([]agent.ContentBlock, 0, len(blocks)+1)
+		if content != "" {
+			multi = append(multi, agent.NewTextBlock(content))
+		}
+		userMsg.Content = ""
+		userMsg.Blocks = append(multi, blocks...)
+	}
+
 	// Confirm the user message immediately so the frontend can swap the
 	// ghost (.msg-pending) bubble for the real one before streaming starts.
 	// <system-reminder> spans are stripped from the bubble: a turn kicked by a
@@ -373,7 +388,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			"type":       "history_user_message",
 			"session_id": sess.ID,
 			"content":    visible,
-			"created_at": time.Now().UnixMilli(),
+			"created_at": userMsg.CreatedAt.UnixMilli(),
 		}
 		if len(images) > 0 {
 			userEvent["images"] = images
@@ -384,17 +399,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// Persist the user message right away so a page refresh mid-turn doesn't
 	// lose it.  We append it for Save(), then pop it back off so buildAgent
 	// doesn't double-count it — RunStream will add the same message to
-	// a.History via appendUserInput. Mirror appendUserInput's multipart shape
-	// (optional text block, then attachments) so the persisted line matches.
-	userMsg := agent.NewUserMessage(content)
-	if len(blocks) > 0 {
-		multi := make([]agent.ContentBlock, 0, len(blocks)+1)
-		if content != "" {
-			multi = append(multi, agent.NewTextBlock(content))
-		}
-		userMsg.Content = ""
-		userMsg.Blocks = append(multi, blocks...)
-	}
+	// a.History via appendUserInput.
 	sess.Messages = append(sess.Messages, userMsg)
 	_ = sess.Save()
 	sess.Messages = sess.Messages[:len(sess.Messages)-1]


### PR DESCRIPTION
## Problem

Clicking Task Management's **create a task** button (and any other auto-send entry point: skill **Use** buttons, onboarding) opens a session and sends `/cron-task-creator` — but the message bubble renders **twice**; after a refresh only one remains.

Root cause is a render race with a half-wired dedup:

1. `Sessions.select` starts the initial `/messages` fetch (HTTP, async).
2. `subscribed` arrives over WS → ghost bubble rendered → message sent.
3. `doAgentTurn` **persists the user message immediately** and broadcasts the live `history_user_message`.
4. If the fetch from step 1 is served after step 3, it returns the message too — and both paths render it.

The frontend already had a dedup mechanism for exactly this (`_renderedCreatedAt`, keyed by `created_at`), but:
- `Sessions.markRendered()` was defined and **never called** (dead code), and
- the keys could never match anyway: the history endpoint emitted **seconds** (`Unix()`) while the live broadcast emitted **milliseconds** from a different `time.Now()` call.

## Fix

- `doAgentTurn` builds the user message first and broadcasts its persisted `CreatedAt.UnixMilli()` — live event and stored message now share the exact key.
- The history endpoint emits `UnixMilli()` to match.
- The live `history_user_message` handler marks its round rendered and skips rounds the history fetch already rendered (ghost removal still happens either way) — the two render paths are now mutually exclusive in both race orders.

## Test plan

- [x] New `TestDoAgentTurn_LiveAndHistoryCreatedAtMatch`: runs a turn, captures the live broadcast's `created_at`, fetches `/api/sessions/{id}/messages`, asserts exact equality of the dedup key.
- [x] `node --check` on both touched JS files; `go vet`, `go test -race ./internal/server/`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)