### PR TITLE
fix(server): persist session source so cron sessions are labelled in the UI

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -30,6 +30,7 @@ type Session struct {
 	Model     string    `json:"model"`
 	System    string    `json:"system,omitempty"`
 	Title     string    `json:"title,omitempty"`
+	Source    string    `json:"source,omitempty"` // how the session was created: "" (manual) | "cron" | "channel" | "setup"
 	Messages  []Message `json:"messages"`
 
 	// persisted is how many messages are already on disk. Save appends
@@ -119,11 +120,12 @@ type sessionRecord struct {
 	Model     string    `json:"model,omitempty"`
 	System    string    `json:"system,omitempty"`
 	Title     string    `json:"title,omitempty"`
+	Source    string    `json:"source,omitempty"`
 	Message   *Message  `json:"message,omitempty"`
 }
 
 func (s *Session) metaRecord() sessionRecord {
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title}
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source}
 }
 
 func messageRecord(m Message) sessionRecord {
@@ -338,6 +340,7 @@ func LoadSession(id string) (*Session, error) {
 		case "meta":
 			s.ID, s.CreatedAt, s.Model, s.System = rec.ID, rec.CreatedAt, rec.Model, rec.System
 			s.Title = rec.Title // a compacted file carries the title in its meta header
+			s.Source = rec.Source
 		case "title":
 			s.Title = rec.Title // last one wins
 		case "message":

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -33,6 +33,22 @@ func TestNewSession(t *testing.T) {
 	}
 }
 
+func TestSessionSourceRoundTrip(t *testing.T) {
+	setTempHome(t)
+	s := NewSession("m", "")
+	s.Source = "cron"
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got.Source != "cron" {
+		t.Fatalf("Source = %q, want %q", got.Source, "cron")
+	}
+}
+
 func TestSessionIDFormat(t *testing.T) {
 	s := NewSession("m", "")
 	// YYYYMMDD-HHMMSS-xxxxxxxx — 24 chars (15 timestamp + '-' + 8 hex suffix).

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -258,9 +258,14 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 	out := make([]sessionItem, 0, len(sessions))
 	cronCount := 0
 	for _, sess := range sessions {
-		// Source and agent_profile are not persisted on the session itself in
-		// the Go rewrite; default to "manual" / "general" so the UI renders.
-		item := s.toSessionItem(sess, "manual", "general")
+		// agent_profile is not persisted on the session; default to "general"
+		// so the UI renders. Sessions from before source was persisted load
+		// with an empty Source and fall back to "manual".
+		source := sess.Source
+		if source == "" {
+			source = "manual"
+		}
+		item := s.toSessionItem(sess, source, "general")
 		out = append(out, item)
 		if item.Source == "cron" {
 			cronCount++
@@ -307,6 +312,7 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sess := agent.NewSession(model, "")
+	sess.Source = source
 	if req.Name != "" {
 		sess.Title = req.Name
 	}

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -71,6 +71,7 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 			model = s.model
 		}
 		sess = agent.NewSession(model, s.system)
+		sess.Source = "cron"
 		task.SessionID = sess.ID
 		// If the task specifies a directory, note it in system prompt.
 		if task.Directory != "" {

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -32,7 +32,10 @@ func (s *Server) listSessionsBrief() []wsSessionInfo {
 	wd, pm, re, ctxUsage := s.sessionStatusFields()
 	out := make([]wsSessionInfo, 0, len(sessions))
 	for _, sess := range sessions {
-		source := "manual"
+		source := sess.Source
+		if source == "" {
+			source = "manual"
+		}
 		out = append(out, wsSessionInfo{
 			ID:              sess.ID,
 			Name:            sess.DisplayTitle(),


### PR DESCRIPTION
## Problem

Sessions created by the cron scheduler show up in the web sidebar as ordinary manual sessions. The frontend has complete support for cron labelling (badge, cron group item, cron sub-view, `cron_count`), but it all lies dormant because the server hardcodes `source: "manual"` for every session — the session store never persisted how a session was created.

## Fix

- `agent.Session` gains a `Source` field, carried in the JSONL meta record (`""` = manual, so all pre-existing transcripts keep working; compaction preserves it since `rewriteAll` writes the meta header via `metaRecord()`).
- The scheduler's `RunTask` marks the sessions it creates as `"cron"`; `POST /api/sessions` persists the source the UI sent (`manual`/`setup`).
- `handleListSessions` (REST) and `listSessionsBrief` (WS handshake) now report the persisted source, falling back to `"manual"` for legacy sessions, which activates the existing cron badge/group/sub-view in the sidebar.

## Verification

- New round-trip test `TestSessionSourceRoundTrip`; `go test -race ./...` green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)