### PR TITLE
fix(web): show the task name in the delete-task confirm dialog

### DIFF
--- a/internal/server/static/tasks.js
+++ b/internal/server/static/tasks.js
@@ -113,7 +113,7 @@ const Tasks = (() => {
     });
     row.querySelector(".task-btn-del").addEventListener("click", e => {
       e.stopPropagation();
-      Tasks.delete(t.id);
+      Tasks.delete(t.id, t.name);
     });
 
     return row;
@@ -307,8 +307,8 @@ const Tasks = (() => {
       Sessions.select(session.id);
     },
 
-    async delete(id) {
-      if (!confirm(I18n.t("tasks.confirmDelete"))) return;
+    async delete(id, name) {
+      if (!confirm(I18n.t("tasks.confirmDelete", { name: name || id }))) return;
       const res = await fetch(`/api/tasks/${encodeURIComponent(id)}`, { method: "DELETE" });
       if (!res.ok) { alert(I18n.t("tasks.deleteError")); return; }
 


### PR DESCRIPTION
The delete-task confirm dialog showed the literal `{{name}}` placeholder because `Tasks.delete` called `I18n.t("tasks.confirmDelete")` without the interpolation param. Pass the task name from the row into `Tasks.delete` and through to `I18n.t` (falling back to the id if the name is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)