### PR TITLE
feat(scheduler): push task run results to an IM chat via notify target

### DIFF
--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -210,11 +210,24 @@ func (a *Adapter) refreshToken() error {
 
 func (a *Adapter) getToken() string {
 	a.tokenMu.Lock()
-	defer a.tokenMu.Unlock()
-	if time.Now().After(a.tokenExpiry) {
+	tok := a.accessToken
+	expired := time.Now().After(a.tokenExpiry)
+	a.tokenMu.Unlock()
+
+	// No token yet: this adapter is being used for an outbound send without
+	// Start() (e.g. channel.SendOnce). Fetch synchronously or the first send
+	// goes out with an empty Authorization header.
+	if tok == "" {
+		_ = a.refreshToken()
+		a.tokenMu.Lock()
+		tok = a.accessToken
+		a.tokenMu.Unlock()
+		return tok
+	}
+	if expired {
 		go a.refreshToken()
 	}
-	return a.accessToken
+	return tok
 }
 
 // ─── WebSocket ─────────────────────────────────────────────────────────────

--- a/internal/channel/notify.go
+++ b/internal/channel/notify.go
@@ -1,0 +1,33 @@
+package channel
+
+import "fmt"
+
+// SendOnce delivers a single outbound message to an IM chat by constructing
+// the platform adapter from ~/.octo/channels.yml on the fly. It exists for
+// proactive pushes (e.g. scheduled-task results) from processes that don't run
+// inbound adapters, such as octo serve. Only platforms whose SendText works
+// without inbound context can deliver this way — Feishu does (app credentials
+// → tenant token → REST); DingTalk needs a session webhook from a prior
+// inbound message and Weixin a login, both of which surface as adapter errors.
+func SendOnce(platform, chatID, text string) error {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return err
+	}
+	pc, ok := cfg.Channels[platform]
+	if !ok {
+		return fmt.Errorf("channel %q not configured", platform)
+	}
+	ctor, err := Find(platform)
+	if err != nil {
+		return err
+	}
+	a, err := ctor(pc)
+	if err != nil {
+		return err
+	}
+	if res := a.SendText(chatID, text, ""); !res.OK {
+		return fmt.Errorf("send to %s chat %s: %s", platform, chatID, res.Error)
+	}
+	return nil
+}

--- a/internal/channel/notify_test.go
+++ b/internal/channel/notify_test.go
@@ -1,0 +1,90 @@
+package channel_test
+
+// External test package: the feishu adapter imports channel, so an in-package
+// test importing the adapter would be an import cycle.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/channel"
+	_ "github.com/Leihb/octo-agent/internal/channel/adapters/feishu"
+)
+
+// writeChannelsYML points HOME at a temp dir holding the given channels.yml.
+func writeChannelsYML(t *testing.T, yml string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	dir := filepath.Join(tmp, ".octo")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "channels.yml"), []byte(yml), 0600); err != nil {
+		t.Fatalf("write channels.yml: %v", err)
+	}
+}
+
+func TestSendOnce_UnconfiguredPlatform(t *testing.T) {
+	writeChannelsYML(t, "channels: {}\n")
+	if err := channel.SendOnce("feishu", "oc_x", "hi"); err == nil {
+		t.Fatal("want error for unconfigured platform, got nil")
+	}
+}
+
+func TestSendOnce_UnknownPlatform(t *testing.T) {
+	writeChannelsYML(t, "channels:\n  nosuch:\n    enabled: true\n")
+	if err := channel.SendOnce("nosuch", "c1", "hi"); err == nil {
+		t.Fatal("want error for unregistered adapter, got nil")
+	}
+}
+
+// TestSendOnce_FeishuDelivers exercises the full standalone-send path: adapter
+// constructed from config without Start(), synchronous first token fetch, then
+// the message POST — against a stub Feishu API.
+func TestSendOnce_FeishuDelivers(t *testing.T) {
+	var gotToken, gotSend bool
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/open-apis/auth/v3/tenant_access_token/internal":
+			gotToken = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"code": 0, "tenant_access_token": "tok-1", "expire": 7200,
+			})
+		case "/open-apis/im/v1/messages":
+			gotSend = true
+			if got := r.Header.Get("Authorization"); got != "Bearer tok-1" {
+				t.Errorf("Authorization = %q, want Bearer tok-1", got)
+			}
+			var body struct {
+				ReceiveID string `json:"receive_id"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body.ReceiveID != "oc_test" {
+				t.Errorf("receive_id = %q, want oc_test", body.ReceiveID)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"code": 0, "data": map[string]string{"message_id": "om_1"},
+			})
+		default:
+			t.Errorf("unexpected request: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer stub.Close()
+
+	writeChannelsYML(t,
+		"channels:\n  feishu:\n    enabled: true\n    app_id: a\n    app_secret: s\n    domain: "+stub.URL+"\n")
+
+	if err := channel.SendOnce("feishu", "oc_test", "task done"); err != nil {
+		t.Fatalf("SendOnce: %v", err)
+	}
+	if !gotToken || !gotSend {
+		t.Fatalf("token=%v send=%v, want both true", gotToken, gotSend)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -21,20 +21,28 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
+// NotifyTarget routes a task run's outcome to an IM chat: the final reply on
+// success, a short failure note on error.
+type NotifyTarget struct {
+	Platform string `json:"platform"` // e.g. "feishu"
+	ChatID   string `json:"chat_id"`
+}
+
 // Task represents a scheduled agent task.
 type Task struct {
-	ID        string    `json:"id"`
-	Name      string    `json:"name"`
-	Cron      string    `json:"cron"`
-	Prompt    string    `json:"prompt"`
-	Model     string    `json:"model,omitempty"`
-	Agent     string    `json:"agent,omitempty"` // "general" | "coding"
-	Directory string    `json:"directory,omitempty"`
-	Enabled   bool      `json:"enabled"`
-	CreatedAt time.Time `json:"created_at"`
-	LastRun   time.Time `json:"last_run,omitempty"`
-	NextRun   time.Time `json:"next_run,omitempty"`
-	SessionID string    `json:"session_id,omitempty"` // last session ID
+	ID        string        `json:"id"`
+	Name      string        `json:"name"`
+	Cron      string        `json:"cron"`
+	Prompt    string        `json:"prompt"`
+	Model     string        `json:"model,omitempty"`
+	Agent     string        `json:"agent,omitempty"` // "general" | "coding"
+	Directory string        `json:"directory,omitempty"`
+	Notify    *NotifyTarget `json:"notify,omitempty"`
+	Enabled   bool          `json:"enabled"`
+	CreatedAt time.Time     `json:"created_at"`
+	LastRun   time.Time     `json:"last_run,omitempty"`
+	NextRun   time.Time     `json:"next_run,omitempty"`
+	SessionID string        `json:"session_id,omitempty"` // last session ID
 }
 
 // Runner is the interface the scheduler calls to execute a task.
@@ -138,6 +146,7 @@ func (s *Scheduler) Update(task Task) error {
 	existing.Model = task.Model
 	existing.Agent = task.Agent
 	existing.Directory = task.Directory
+	existing.Notify = task.Notify
 	existing.Enabled = task.Enabled
 	cp := *existing
 	s.mu.Unlock()

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -3,11 +3,13 @@ package server
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/channel"
 	"github.com/Leihb/octo-agent/internal/scheduler"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
@@ -15,24 +17,26 @@ import (
 // ─── Tasks REST API ─────────────────────────────────────────────────────────
 
 type taskRequest struct {
-	Name   string `json:"name"`
-	Cron   string `json:"cron"`
-	Prompt string `json:"prompt"`
-	Model  string `json:"model,omitempty"`
-	Agent  string `json:"agent,omitempty"`
+	Name   string                  `json:"name"`
+	Cron   string                  `json:"cron"`
+	Prompt string                  `json:"prompt"`
+	Model  string                  `json:"model,omitempty"`
+	Agent  string                  `json:"agent,omitempty"`
+	Notify *scheduler.NotifyTarget `json:"notify,omitempty"`
 }
 
 type taskResponse struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Cron      string `json:"cron"`
-	Prompt    string `json:"prompt"`
-	Model     string `json:"model,omitempty"`
-	Agent     string `json:"agent,omitempty"`
-	Enabled   bool   `json:"enabled"`
-	CreatedAt string `json:"created_at,omitempty"`
-	LastRun   string `json:"last_run,omitempty"`
-	SessionID string `json:"session_id,omitempty"`
+	ID        string                  `json:"id"`
+	Name      string                  `json:"name"`
+	Cron      string                  `json:"cron"`
+	Prompt    string                  `json:"prompt"`
+	Model     string                  `json:"model,omitempty"`
+	Agent     string                  `json:"agent,omitempty"`
+	Notify    *scheduler.NotifyTarget `json:"notify,omitempty"`
+	Enabled   bool                    `json:"enabled"`
+	CreatedAt string                  `json:"created_at,omitempty"`
+	LastRun   string                  `json:"last_run,omitempty"`
+	SessionID string                  `json:"session_id,omitempty"`
 }
 
 // initScheduler creates the scheduler if not already initialized. It is
@@ -100,16 +104,29 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 	if err != nil {
 		sess.SyncFrom(a.History)
 		_ = sess.Save()
+		s.notifyTaskResult(task, fmt.Sprintf("⏰ %s failed: %v", task.Name, err))
 		return sess.ID, fmt.Errorf("run task: %w", err)
 	}
+	s.notifyTaskResult(task, fmt.Sprintf("⏰ %s\n\n%s", task.Name, reply.Content))
 
 	sess.SyncFrom(a.History)
 	if err := sess.Save(); err != nil {
 		return sess.ID, fmt.Errorf("save session: %w", err)
 	}
 
-	_ = reply
 	return sess.ID, nil
+}
+
+// notifyTaskResult pushes a task run's outcome to its IM notify target, if
+// one is configured. Delivery failures are logged, never fatal — the run
+// itself already happened and is recorded in the session.
+func (s *Server) notifyTaskResult(task scheduler.Task, text string) {
+	if task.Notify == nil {
+		return
+	}
+	if err := channel.SendOnce(task.Notify.Platform, task.Notify.ChatID, text); err != nil {
+		log.Printf("[scheduler] task %q notify: %v", task.Name, err)
+	}
 }
 
 func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
@@ -147,6 +164,7 @@ func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 		Prompt:  req.Prompt,
 		Model:   req.Model,
 		Agent:   req.Agent,
+		Notify:  req.Notify,
 		Enabled: true,
 	}
 	if err := s.scheduler.Add(&task); err != nil {
@@ -200,6 +218,7 @@ func taskToResponse(t scheduler.Task) taskResponse {
 		Prompt:  t.Prompt,
 		Model:   t.Model,
 		Agent:   t.Agent,
+		Notify:  t.Notify,
 		Enabled: t.Enabled,
 	}
 	if !t.CreatedAt.IsZero() {

--- a/internal/skills/defaults/cron-task-creator/SKILL.md
+++ b/internal/skills/defaults/cron-task-creator/SKILL.md
@@ -21,6 +21,7 @@ history from previous executions.
 | `model` | no | Model override; defaults to the server's model |
 | `agent` | no | `"general"` or `"coding"` |
 | `directory` | no | Working directory hint, prepended to the task session's system prompt |
+| `notify` | no | `{"platform": "feishu", "chat_id": "oc_..."}` — push each run's final reply (or a failure note) to an IM chat |
 | `enabled` | yes | Whether the schedule is active |
 
 ## Cron expression format — 6 fields, seconds first
@@ -108,3 +109,9 @@ curl -s -X PATCH  http://127.0.0.1:8080/api/cron-tasks/{name} \
   creation time by the API, but a hand-written JSON file with a bad expression
   fails silently at load (logged to stderr only) — double-check the 6-field
   format when writing files directly.
+- **IM notification (`notify`) requires the platform to support proactive
+  sends.** Feishu works (app credentials from `~/.octo/channels.yml`);
+  DingTalk and Weixin cannot push without a prior inbound message, so a
+  `notify` pointing at them fails (logged on the server, run unaffected). The
+  Feishu `chat_id` looks like `oc_…` — get it from the chat's settings or by
+  messaging the bot and reading the server log.


### PR DESCRIPTION
## Problem

Scheduled task results were invisible unless you opened the task's session in the web sidebar — the final reply was literally discarded (`_ = reply` in `RunTask`). There was no path to deliver results to an IM chat: `octo serve` runs no inbound adapters (they live in the separate `octo channel start` process), and the task schema had no delivery target.

## Design

Per-task opt-in notify target:

```json
{
  "name": "octo-agent-issue-check",
  "cron": "0 0 9 * * *",
  "prompt": "...",
  "notify": {"platform": "feishu", "chat_id": "oc_xxx"}
}
```

- **`channel.SendOnce(platform, chatID, text)`** constructs the platform adapter from `~/.octo/channels.yml` on the fly and sends one message without `Start()` — proactive pushes from processes that don't run inbound adapters.
- **`RunTask`** pushes the final reply on success and a short `⏰ <name> failed: <err>` note on failure, for both cron firings and manual runs. Delivery failures are logged, never fatal.
- **Feishu adapter fix**: first `getToken()` on a fresh adapter used to fire an async refresh and return an empty token, so a standalone send carried an empty `Authorization` header. The first fetch is now synchronous; expiry refresh stays async.
- Feishu is the only platform that can push proactively (app credentials → tenant token → REST). DingTalk needs a session webhook from a prior inbound message, Weixin a login — both surface as adapter errors. Documented in the cron-task-creator SKILL.md.
- The tasks REST API (`POST /api/tasks`, list endpoints) carries `notify` through, and `Scheduler.Update` preserves it on edits.

## Verification

- `TestSendOnce_FeishuDelivers` drives the full standalone path (config → adapter → synchronous token fetch → message POST) against a stub Feishu API via the adapter's `domain` override; error paths covered for unconfigured/unregistered platforms.
- `go test -race ./...` green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)