### PR TITLE
feat(weixin): support proactive task-result pushes via persisted context tokens

### DIFF
--- a/internal/channel/adapters/weixin/contexts.go
+++ b/internal/channel/adapters/weixin/contexts.go
@@ -1,0 +1,63 @@
+package weixin
+
+// The iLink protocol requires a context_token on every outbound message, and
+// tokens only arrive on inbound messages. The receive loop used to keep them
+// purely in memory, which made proactive pushes (channel.SendOnce from octo
+// serve, a different process) impossible. This file is the write-through disk
+// store that bridges the two processes: the receive loop persists the latest
+// token per user here, and a standalone send reads it back.
+//
+// How long WeChat honours an old context_token is not documented; a send with
+// a stale token fails with an API error, which callers surface or log. Tokens
+// stay fresh as long as the user keeps talking to the bot while
+// `octo channel start` is running.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// contextStorePath derives the token-store path from the credentials path so
+// both live in the same directory (default ~/.octo/).
+func contextStorePath(credPath string) string {
+	return filepath.Join(filepath.Dir(credPath), "weixin-contexts.json")
+}
+
+// loadContextTokens reads the store. A missing or unreadable file is an empty
+// map — the caller's lookup then fails with its own, clearer error.
+func loadContextTokens(path string) map[string]string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return map[string]string{}
+	}
+	var m map[string]string
+	if json.Unmarshal(data, &m) != nil || m == nil {
+		return map[string]string{}
+	}
+	return m
+}
+
+// saveContextToken records the latest context_token for a user. Writes go
+// through a temp file + rename so a concurrent reader in another process
+// never sees a torn file. Errors are swallowed: the in-memory token still
+// serves the running process, the store is best-effort.
+func saveContextToken(path, userID, token string) {
+	if path == "" || userID == "" || token == "" {
+		return
+	}
+	m := loadContextTokens(path)
+	if m[userID] == token {
+		return
+	}
+	m[userID] = token
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0600); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, path)
+}

--- a/internal/channel/adapters/weixin/contexts_test.go
+++ b/internal/channel/adapters/weixin/contexts_test.go
@@ -1,0 +1,142 @@
+package weixin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/channel"
+	"github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink"
+)
+
+func TestContextTokenStore_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "weixin-contexts.json")
+
+	saveContextToken(path, "user1", "ctx-a")
+	saveContextToken(path, "user2", "ctx-b")
+	saveContextToken(path, "user1", "ctx-a2") // newer token wins
+
+	m := loadContextTokens(path)
+	if m["user1"] != "ctx-a2" || m["user2"] != "ctx-b" {
+		t.Fatalf("tokens = %v, want user1=ctx-a2 user2=ctx-b", m)
+	}
+}
+
+func TestContextTokenStore_MissingFileIsEmpty(t *testing.T) {
+	m := loadContextTokens(filepath.Join(t.TempDir(), "nope.json"))
+	if len(m) != 0 {
+		t.Fatalf("tokens = %v, want empty", m)
+	}
+}
+
+// TestSendText_StandaloneDelivers exercises the no-Start() path used by
+// channel.SendOnce: credentials and context token both come from disk and the
+// message goes out synchronously.
+func TestSendText_StandaloneDelivers(t *testing.T) {
+	var mu sync.Mutex
+	var received []map[string]any
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		if r.URL.Path == "/ilink/bot/sendmessage" {
+			var payload map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			received = append(received, payload)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"ret": 0})
+		}
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	credPath := filepath.Join(dir, "weixin-credentials.json")
+	if err := ilink.SaveCredentials(&ilink.Credentials{Token: "tok", BaseURL: ts.URL}, credPath); err != nil {
+		t.Fatalf("save creds: %v", err)
+	}
+	saveContextToken(contextStorePath(credPath), "user1", "ctx123")
+
+	a := &Adapter{credPath: credPath, client: ilink.NewClient()}
+
+	res := a.SendText("user1", "task done", "")
+	if !res.OK {
+		t.Fatalf("standalone send: %s", res.Error)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("received %d requests, want 1", len(received))
+	}
+	msg := received[0]["msg"].(map[string]any)
+	if msg["to_user_id"] != "user1" || msg["context_token"] != "ctx123" {
+		t.Errorf("msg = %v, want to_user_id=user1 context_token=ctx123", msg)
+	}
+}
+
+func TestSendText_StandaloneNoToken(t *testing.T) {
+	dir := t.TempDir()
+	credPath := filepath.Join(dir, "weixin-credentials.json")
+	if err := ilink.SaveCredentials(&ilink.Credentials{Token: "tok", BaseURL: "http://example.invalid"}, credPath); err != nil {
+		t.Fatalf("save creds: %v", err)
+	}
+
+	a := &Adapter{credPath: credPath, client: ilink.NewClient()}
+	if res := a.SendText("stranger", "hi", ""); res.OK {
+		t.Fatal("want failure when no stored context_token")
+	}
+}
+
+// TestSendText_RunningFallsBackToStore covers a process restart: the receive
+// loop is up (bot != nil) but the in-memory token map is empty, so the send
+// falls back to the on-disk store.
+func TestSendText_RunningFallsBackToStore(t *testing.T) {
+	dir := t.TempDir()
+	credPath := filepath.Join(dir, "weixin-credentials.json")
+	saveContextToken(contextStorePath(credPath), "user1", "ctx-disk")
+
+	a := &Adapter{
+		credPath: credPath,
+		client:   ilink.NewClient(),
+		bot: &ilinkBot{
+			client: ilink.NewClient(),
+			creds:  &ilink.Credentials{Token: "tok", BaseURL: "http://example.invalid"},
+		},
+	}
+	a.sendQ = newSendQueue(a.client, "http://example.invalid", "tok")
+
+	// Enqueue-only path: OK means the token lookup succeeded.
+	if res := a.SendText("user1", "hello", ""); !res.OK {
+		t.Fatalf("want OK via disk fallback, got: %s", res.Error)
+	}
+}
+
+func TestHandleInbound_PersistsContextToken(t *testing.T) {
+	dir := t.TempDir()
+	credPath := filepath.Join(dir, "weixin-credentials.json")
+	a := &Adapter{credPath: credPath, client: ilink.NewClient(), bot: &ilinkBot{}}
+
+	a.handleInbound(&ilink.WireMessage{
+		MessageType:  ilink.MessageTypeUser,
+		FromUserID:   "user9",
+		ContextToken: "ctx-9",
+		ItemList:     []ilink.MessageItem{{Type: ilink.ItemText, TextItem: &ilink.TextItem{Text: "hi"}}},
+	}, func(channel.InboundEvent) {})
+
+	if got := loadContextTokens(contextStorePath(credPath))["user9"]; got != "ctx-9" {
+		t.Fatalf("persisted token = %q, want ctx-9", got)
+	}
+}
+
+// ensure the temp-file rename leaves no .tmp behind
+func TestContextTokenStore_NoTempLeftover(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "weixin-contexts.json")
+	saveContextToken(path, "u", "t")
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("temp file left behind: %v", err)
+	}
+}

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -381,11 +381,18 @@ func (a *Adapter) Stop() error {
 // SendText enqueues text for buffered delivery.
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 	if a.bot == nil || a.bot.creds == nil {
-		return channel.SendResult{OK: false, Error: "not logged in"}
+		return a.sendStandalone(chatID, text)
 	}
 
-	ct, ok := a.bot.contextTokens.Load(chatID)
-	if !ok {
+	var token string
+	if ct, ok := a.bot.contextTokens.Load(chatID); ok {
+		token = ct.(string)
+	} else if a.credPath != "" {
+		// Memory miss (e.g. the process restarted since the user last wrote):
+		// fall back to the write-through store.
+		token = loadContextTokens(contextStorePath(a.credPath))[chatID]
+	}
+	if token == "" {
 		return channel.SendResult{OK: false, Error: "no context_token for user " + chatID}
 	}
 
@@ -394,7 +401,42 @@ func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 		return channel.SendResult{OK: true}
 	}
 
-	a.sendQ.enqueue(chatID, plain, ct.(string))
+	a.sendQ.enqueue(chatID, plain, token)
+	return channel.SendResult{OK: true}
+}
+
+// sendStandalone delivers one message without Start(): credentials from disk
+// and the chat's last context_token from the write-through store maintained
+// by the receive loop. This is the path channel.SendOnce takes when octo
+// serve pushes a scheduled-task result — the inbound adapter runs in a
+// different process (octo channel start), so neither bot state nor the send
+// queue exist here. The send is synchronous; the caller owns retries.
+func (a *Adapter) sendStandalone(chatID, text string) channel.SendResult {
+	if a.credPath == "" {
+		return channel.SendResult{OK: false, Error: "not logged in"}
+	}
+	creds, err := ilink.LoadCredentials(a.credPath)
+	if err != nil || creds == nil {
+		return channel.SendResult{OK: false, Error: "not logged in (run `octo channel login` first)"}
+	}
+
+	token := loadContextTokens(contextStorePath(a.credPath))[chatID]
+	if token == "" {
+		return channel.SendResult{OK: false, Error: "no stored context_token for " + chatID +
+			" — the user must message the bot at least once while `octo channel start` is running"}
+	}
+
+	plain := markdownToPlain(text)
+	if plain == "" {
+		return channel.SendResult{OK: true}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := a.client.SendMessage(ctx, creds.BaseURL, creds.Token,
+		ilink.BuildTextMessage(chatID, token, plain)); err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
 	return channel.SendResult{OK: true}
 }
 
@@ -623,9 +665,13 @@ func (a *Adapter) handleInbound(wire *ilink.WireMessage, onMessage func(channel.
 		return
 	}
 
-	// Store context_token.
+	// Store context_token in memory and write it through to disk so other
+	// processes (octo serve pushing task results) can send to this user too.
 	if a.bot != nil {
 		a.bot.contextTokens.Store(userID, wire.ContextToken)
+	}
+	if a.credPath != "" {
+		saveContextToken(contextStorePath(a.credPath), userID, wire.ContextToken)
 	}
 
 	// Extract text and files.

--- a/internal/channel/notify.go
+++ b/internal/channel/notify.go
@@ -5,10 +5,12 @@ import "fmt"
 // SendOnce delivers a single outbound message to an IM chat by constructing
 // the platform adapter from ~/.octo/channels.yml on the fly. It exists for
 // proactive pushes (e.g. scheduled-task results) from processes that don't run
-// inbound adapters, such as octo serve. Only platforms whose SendText works
-// without inbound context can deliver this way — Feishu does (app credentials
-// → tenant token → REST); DingTalk needs a session webhook from a prior
-// inbound message and Weixin a login, both of which surface as adapter errors.
+// inbound adapters, such as octo serve. Feishu sends with app credentials
+// alone (tenant token → REST). Weixin sends with the on-disk login credentials
+// plus the chat's last context_token from the write-through store the receive
+// loop maintains — so the target user must have messaged the bot at least
+// once. DingTalk needs a session webhook from a prior inbound message and
+// cannot push this way; that surfaces as an adapter error.
 func SendOnce(platform, chatID, text string) error {
 	cfg, err := LoadConfig()
 	if err != nil {

--- a/internal/skills/defaults/cron-task-creator/SKILL.md
+++ b/internal/skills/defaults/cron-task-creator/SKILL.md
@@ -110,8 +110,12 @@ curl -s -X PATCH  http://127.0.0.1:8080/api/cron-tasks/{name} \
   fails silently at load (logged to stderr only) — double-check the 6-field
   format when writing files directly.
 - **IM notification (`notify`) requires the platform to support proactive
-  sends.** Feishu works (app credentials from `~/.octo/channels.yml`);
-  DingTalk and Weixin cannot push without a prior inbound message, so a
-  `notify` pointing at them fails (logged on the server, run unaffected). The
-  Feishu `chat_id` looks like `oc_…` — get it from the chat's settings or by
-  messaging the bot and reading the server log.
+  sends.** Feishu works with app credentials alone (`~/.octo/channels.yml`);
+  its `chat_id` looks like `oc_…` — get it from the chat's settings or by
+  messaging the bot and reading the server log. Weixin works too: `chat_id`
+  is the iLink user id, and the user must have messaged the bot at least once
+  (the receive loop persists each user's latest `context_token` to
+  `~/.octo/weixin-contexts.json`, which the push reads; a long-stale token may
+  be rejected by WeChat — chatting with the bot refreshes it). DingTalk cannot
+  push without a prior inbound webhook; a `notify` pointing at it fails
+  (logged on the server, run unaffected).


### PR DESCRIPTION
## Problem

#553 added IM push for scheduled-task results, but only Feishu could deliver: the iLink protocol requires a `context_token` on every outbound Weixin message, tokens only arrive on inbound messages, and they lived purely in the memory of the `octo channel start` process. `octo serve` — a different process — had nothing to send with, so a `notify` target pointing at Weixin always failed.

## Design

**Write-through token store.** The receive loop now persists each user's latest `context_token` to `~/.octo/weixin-contexts.json` (next to the credentials file; temp-file + rename so a reader in another process never sees a torn write; skips the write when the token is unchanged).

**Two new lookup paths in `SendText`:**
- **Standalone (no `Start()`)** — the `channel.SendOnce` path from `octo serve`: load credentials from disk, the chat's stored token from the write-through store, and send synchronously with the caller owning retries.
- **Running but cold memory** — the receive loop is up but the process restarted since the user last wrote: fall back from the in-memory map to the disk store.

**Honesty about token lifetime:** how long WeChat honours an old `context_token` is not documented anywhere we can verify. A stale token fails the send with an API error (logged, run unaffected). Tokens stay fresh as long as the user keeps chatting with the bot while `octo channel start` runs. Documented in the cron-task-creator SKILL.md.

Usage:

```json
"notify": {"platform": "weixin", "chat_id": "<ilink_user_id>"}
```

Preconditions: `octo channel login` done once (QR), and the target user has messaged the bot at least once since this change so a token is on disk.

## Verification

- `TestSendText_StandaloneDelivers` drives the full no-`Start()` path (disk creds + disk token → synchronous `sendmessage` POST with the right `context_token`) against a stub iLink API.
- `TestSendText_RunningFallsBackToStore`, `TestHandleInbound_PersistsContextToken`, store round-trip/missing-file/no-temp-leftover tests.
- All pre-existing weixin tests pass unchanged (`SendText` semantics preserved: no creds → "not logged in", no token anywhere → error).
- `go test -race ./...` green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)