### PR TITLE
feat(skills): ship code-review as a default skill

### DIFF
--- a/internal/skills/defaults/code-review/SKILL.md
+++ b/internal/skills/defaults/code-review/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: code-review
+description: Review local code changes using an isolated sub-agent for unbiased analysis. Checks correctness, conventions, performance, tests, security, and tech design compliance. Use when the user wants a code review or says "review the diff" / "review my changes" / "代码评审" / "review 一下改动".
+---
+
+Review local code changes by dispatching an **isolated sub-agent** — a fresh agent with no knowledge of the current session's implementation decisions. This eliminates the bias of reviewing your own work.
+
+## Process
+
+### 1. Gather context for the sub-agent
+
+Collect everything the reviewer needs:
+
+```bash
+# What changed
+git log --oneline main..HEAD
+git diff main...HEAD
+git diff
+git diff --cached
+```
+
+Also identify:
+- Tech design doc path (if one exists in conversation context or commit messages)
+- Which services/modules are touched
+- Test files added or modified
+
+### 2. Dispatch the sub-agent
+
+Call the `sub_agent` tool with `subagent_type: "code-review"` — a read-only reviewer that starts with zero context. Pass it the diff range, file list, and tech design reference in the prompt — but NOT your implementation reasoning or conversation history.
+
+The sub-agent prompt should follow the template in [code-reviewer.md](code-reviewer.md).
+
+Fill in:
+- `{DESCRIPTION}` — brief summary of what these changes do
+- `{TECH_DESIGN_PATH}` — path to tech design doc (or "none")
+- `{BASE_SHA}` / `{HEAD_SHA}` — git range
+- `{DIFF_STAT}` — output of `git diff --stat`
+
+If the `sub_agent` tool is not available in this session, perform the review yourself following the same template — and say explicitly in the report that the review was not isolated.
+
+### 3. Act on the review
+
+When the sub-agent returns its findings:
+
+**Receiving feedback — rules:**
+- Verify before implementing. Don't blindly agree.
+- If any item is unclear, clarify ALL unclear items before fixing any.
+- Implementation order: Critical → Important → Minor, test each fix individually.
+- Push back with technical reasoning if the reviewer is wrong (missing context, doesn't apply to this codebase, YAGNI).
+- No performative agreement ("Great point!", "You're absolutely right!"). Just fix and show the result.
+
+**Priority:**
+- **Critical**: fix immediately, no exceptions
+- **Important**: fix before proceeding
+- **Minor**: note for later or fix if quick
+
+### 4. Report to user
+
+Relay the sub-agent's review to the user with your own assessment of each finding — agree, disagree with reasoning, or need discussion.

--- a/internal/skills/defaults/code-review/code-reviewer.md
+++ b/internal/skills/defaults/code-review/code-reviewer.md
@@ -1,0 +1,143 @@
+You are reviewing code changes for production readiness. You have NO prior context about this implementation — evaluate the code on its own merits.
+
+## What Was Implemented
+
+{DESCRIPTION}
+
+## Git Range
+
+**Base:** {BASE_SHA}
+**Head:** {HEAD_SHA}
+
+```bash
+git diff --stat {BASE_SHA}..{HEAD_SHA}
+git diff {BASE_SHA}..{HEAD_SHA}
+```
+
+Read the diff, then read any files you need full context on.
+
+## Tech Design
+
+{TECH_DESIGN_PATH}
+
+If a tech design path is provided, read it and check compliance.
+
+## Review Checklist
+
+**Correctness:**
+- Logic errors, off-by-one, nil/null handling
+- Edge cases not covered
+- Race conditions in concurrent code
+- Error handling: propagated correctly or swallowed silently?
+
+**Conventions:**
+- Follows existing patterns in the codebase?
+- Naming consistency with surrounding code
+- File organization matching project structure
+
+**Performance:**
+- N+1 queries
+- Missing indexes for new DB queries
+- Unbounded loops or allocations
+- Cache key design (TTL, eviction, thundering herd)
+
+**Tests:**
+- New behaviors tested?
+- Tests verify behavior through public interfaces (not implementation)?
+- Edge cases covered?
+- Missing test cases that should exist
+
+**Security:**
+- SQL injection, XSS, command injection
+- Auth/authz checks on new endpoints
+- Sensitive data in logs
+- Input validation at system boundaries
+
+**Tech design compliance** (when design doc available):
+- API contracts match the design?
+- DB schemas match the design?
+- Cache keys and MQ topics as specified?
+- Acceptance criteria all met?
+
+**External API contracts** (mandatory whenever the diff adds/modifies HTTP/gRPC
+client structs, request/response types, or boundary mappings):
+
+For EACH new or modified upstream client struct, you MUST:
+
+1. Locate the canonical source. Run and paste the commands + summary in your output:
+   ```
+   $ find . -path '*/integration/{svc}/*' -type f
+   $ grep -rn "{ServiceName}\.Client" --include="*.go"
+   $ grep -rn "type {StructName} struct" --include="*.go"
+   ```
+   Canonical = upstream server's handler/router file, OR a sibling team's existing
+   client struct, OR a published proto definition. Pick the most authoritative one
+   you can find.
+
+2. Open the canonical file at the cited line and verify VERBATIM that the diff's
+   struct fields match:
+   - JSON tags (`json:"xyz"` — one wrong character is a production bug)
+   - Field types (`int64` vs `int`, `string` vs `*string`)
+   - Method + path + query param names
+   - Response envelope shape (top-level array vs `{result: [...]}` vs bare object)
+
+3. Verify at least one boundary test deserializes a REAL JSON fixture (not just
+   `&Struct{Field: x}` construction). Construct-and-fake tests pass even when JSON
+   tags are wrong because the fake produces the same wrong struct the consumer reads.
+
+4. **Output your evidence** — for each upstream client touched, include:
+   ```
+   ## API contract verified — {svc}.{endpoint}
+   Canonical: <abs path>:<line range>
+   Match status: ✅ all fields verbatim match
+              OR ❌ mismatch: diff has `json:"operate_at"`, canonical has `json:"time"`
+   Wire contract test: ✅ TestXxx_WireContract Unmarshal real JSON
+                    OR ❌ only fake-client tests, no JSON fixture
+   ```
+
+If no canonical exists AND no upstream handler can be read, FLAG IT — the slice
+should have stopped and asked, but didn't.
+
+**Field-name mismatch vs canonical = Critical.** It passes mocked unit tests
+because the fake uses the same wrong struct; it only fails in production when
+real JSON arrives. This is the most expensive class of bug to ship.
+
+**Reviewers who skip this**: if the diff modifies boundary code and your output
+doesn't contain `## API contract verified` with grep commands and canonical
+file:line, your review is incomplete. Re-do it.
+
+## Output Format
+
+### Strengths
+[What's well done — be specific with file:line references]
+
+### Issues
+
+#### Critical (must fix)
+[Bugs, security issues, data loss risks, broken functionality]
+
+#### Important (should fix)
+[Architecture problems, missing error handling, test gaps]
+
+#### Minor (nice to have)
+[Code style, optimization opportunities]
+
+**For each issue:**
+- `file:line` — what's wrong — why it matters — how to fix (if not obvious)
+
+### Test Coverage
+[What's tested vs what should be. Gaps?]
+
+### Assessment
+
+**Ready to merge?** [Yes / No / With fixes]
+
+**Reasoning:** [1-2 sentences]
+
+## Rules
+
+- Categorize by actual severity — not everything is Critical
+- Be specific: file:line, not vague
+- If no issues found, say so — don't manufacture concerns
+- Don't mark nitpicks as Critical
+- Give a clear verdict, don't hedge

--- a/internal/skills/defaults_test.go
+++ b/internal/skills/defaults_test.go
@@ -38,6 +38,12 @@ func TestMaterializeDefaults_WritesEmbeddedAndStamps(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(root, "worktree-isolate", "SKILL.md")); err != nil {
 		t.Fatalf("expected worktree-isolate/SKILL.md materialized: %v", err)
 	}
+	// code-review bundles a companion template — both files must materialize.
+	for _, f := range []string{"SKILL.md", "code-reviewer.md"} {
+		if _, err := os.Stat(filepath.Join(root, "code-review", f)); err != nil {
+			t.Fatalf("expected code-review/%s materialized: %v", f, err)
+		}
+	}
 	// Stamp records the version.
 	b, err := os.ReadFile(filepath.Join(root, defaultStampFile))
 	if err != nil || string(b) != "v1" {


### PR DESCRIPTION
## What

Adds `code-review` to the embedded default skill set (`internal/skills/defaults/`), so every install gets an unbiased-review workflow out of the box — same mechanism as `worktree-isolate`: embedded via `go:embed`, materialized to `~/.octo/skills-default`, overridable by a same-named skill in `~/.octo/skills`.

## How it works

- **SKILL.md** — gather the local diff (`git log`/`git diff main...HEAD`/staged+unstaged), then dispatch an isolated reviewer via the existing `sub_agent` tool with `subagent_type: "code-review"` (read-only, zero conversation context), deliberately withholding the session's implementation reasoning. Findings come back triaged Critical → Important → Minor with verify-before-fix rules.
- **code-reviewer.md** — the reviewer prompt template (correctness / conventions / performance / tests / security / tech-design compliance, plus a mandatory external-API-contract verification section). Referenced relatively; `RenderSkill` already prefixes the skill dir so the model can read it.
- Falls back to an in-context review — explicitly flagged as non-isolated — when `sub_agent` isn't configured for the session.

## Tests

Extended `TestMaterializeDefaults_WritesEmbeddedAndStamps` to assert both files of this multi-file skill materialize. `go test ./internal/skills/ ./internal/tools/`, `gofmt -l`, `go vet` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)