### PR TITLE
fix(server): persist a task's session at run start, not only at completion

### DIFF
--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -76,10 +76,17 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 		}
 		sess = agent.NewSession(model, s.system)
 		sess.Source = "cron"
+		sess.Title = task.Name
 		task.SessionID = sess.ID
 		// If the task specifies a directory, note it in system prompt.
 		if task.Directory != "" {
 			sess.System = fmt.Sprintf("Working directory: %s\n%s", task.Directory, sess.System)
+		}
+		// Persist immediately: a task run can take many minutes, and until the
+		// session file exists the run is invisible in the web session list —
+		// clicking Run looked like it did nothing.
+		if err := sess.Save(); err != nil {
+			return sess.ID, fmt.Errorf("save session: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Problem

Clicking Run on a scheduled task gave the "Started" acknowledgement, then nothing: no session in the sidebar, not even after a page reload. The session file is only written when the run completes — and a real run can take a long time (a kimi `octo-agent-issue-check` run measured 18 minutes and 100 tool rounds before hitting the max-turns cap). For that entire window the run was invisible.

## Fix

`RunTask` saves the freshly created session (titled with the task name, `source: "cron"`) before starting the turn. The session shows up in the web list immediately; the run appends its messages to it as it always did.

## Verification

E2E against a locally built serve: created a throwaway task, POSTed run, and the session appeared in `GET /api/sessions` within 1 second — `source: cron`, named after the task — while the run was still in flight. `go test -race ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)