### PR TITLE
docs(skills): cron-task-creator must write prompts with explicit stop conditions

### DIFF
--- a/internal/skills/defaults/cron-task-creator/SKILL.md
+++ b/internal/skills/defaults/cron-task-creator/SKILL.md
@@ -52,7 +52,17 @@ Times are interpreted in the server's local timezone.
 3. **Write a self-contained prompt.** The task session has no access to this
    conversation — the prompt must carry all context: what to do, where, and
    what the output should look like.
-4. **Create** the task (see below), then **verify** by listing tasks. Offer a
+4. **Give the prompt an explicit stop condition.** Task runs are capped at
+   100 turns and 30 minutes; an open-ended prompt makes the model keep
+   re-verifying instead of finishing (a real "check for new issues" task spent
+   18 minutes and all 100 turns re-confirming that zero issues existed). Spell
+   out when the task is done, especially for the empty case:
+   - Bad: "Check the repository for any new open issues that need attention."
+   - Good: "List open issues created in the last 24h via one
+     `gh issue list` call. If there are none, reply exactly 'no new issues'
+     and stop. Otherwise summarize each in one line and stop — do not
+     re-check."
+5. **Create** the task (see below), then **verify** by listing tasks. Offer a
    one-off immediate run to test.
 
 ## Creating a task


### PR DESCRIPTION
## Problem

The cron-task-creator skill generated an open-ended task prompt ("Check the GitHub repository for any new open issues that need attention. Look for: …"). A real run of that task spent **18 minutes and all 100 turns** re-confirming that the repo had zero open issues, ending with the max-turns stop message instead of a report.

Task runs are hard-capped at 100 provider round-trips (`defaultMaxTurns`) and 30 minutes (scheduler fire context). A prompt without a done-condition makes the model keep re-verifying instead of finishing.

## Fix

New workflow step in SKILL.md: every generated prompt must state when the task is done — especially for the empty case — with a bad/good example pair drawn from the incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)