### PR TITLE
feat(skills): `octo skills add` — install skills from GitHub repos

### DIFF
--- a/cmd/octo/skills_cmd.go
+++ b/cmd/octo/skills_cmd.go
@@ -6,12 +6,13 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/Leihb/octo-agent/internal/skills"
 	"github.com/Leihb/octo-agent/internal/version"
 )
 
-// runSkills handles `octo skills [list|update|path]`. Bare `octo skills`
+// runSkills handles `octo skills [list|add|update|path]`. Bare `octo skills`
 // defaults to list. Skills are discovered from three roots (default < user <
 // project); the default set ships embedded in the binary and is materialized to
 // disk on startup (see internal/skills/defaults.go).
@@ -23,14 +24,56 @@ func runSkills(args []string, stdout, stderr io.Writer) int {
 	switch sub {
 	case "list":
 		return skillsList(stdout)
+	case "add":
+		return skillsAdd(args[1:], stdout, stderr)
 	case "update":
 		return skillsUpdate(stdout, stderr)
 	case "path":
 		return skillsPath(stdout)
 	default:
-		fmt.Fprintf(stderr, "octo skills: unknown subcommand %q (want list | update | path)\n", sub)
+		fmt.Fprintf(stderr, "octo skills: unknown subcommand %q (want list | add | update | path)\n", sub)
 		return 2
 	}
+}
+
+// skillsAdd installs a skill from a public GitHub repository into the
+// user-level root (~/.octo/skills). The skill's content is fetched directly
+// from the source repository onto this machine — octo redistributes nothing,
+// so source-available skills (e.g. the document skills in anthropics/skills)
+// can be installed without octo shipping their content.
+func skillsAdd(args []string, stdout, stderr io.Writer) int {
+	var source string
+	force, bad := false, false
+	for _, a := range args {
+		switch {
+		case a == "--force" || a == "-f":
+			force = true
+		case strings.HasPrefix(a, "-") || source != "":
+			bad = true
+		default:
+			source = a
+		}
+	}
+	if bad || source == "" {
+		fmt.Fprintln(stderr, "usage: octo skills add <owner/repo[/sub/path] | github.com tree URL> [--force]")
+		fmt.Fprintln(stderr, "  e.g. octo skills add anthropics/skills/skills/docx")
+		fmt.Fprintln(stderr, "       octo skills add https://github.com/anthropics/skills/tree/main/skills/pdf")
+		return 2
+	}
+	src, err := skills.ParseSource(source)
+	if err != nil {
+		fmt.Fprintf(stderr, "octo skills add: %v\n", err)
+		return 2
+	}
+	name, desc, err := skills.Install(src, skills.UserRoot(), force)
+	if err != nil {
+		fmt.Fprintf(stderr, "octo skills add: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Installed /%s → %s\n", name, filepath.Join(skills.UserRoot(), name))
+	fmt.Fprintf(stdout, "  %s\n", desc)
+	fmt.Fprintln(stdout, "The skill was fetched from its source repository for your local use; check that repository's license before redistributing it.")
+	return 0
 }
 
 func skillsList(stdout io.Writer) int {

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -1,0 +1,255 @@
+package skills
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Source identifies a skill directory inside a GitHub repository.
+type Source struct {
+	Owner   string
+	Repo    string
+	Ref     string // empty = the repository's default branch
+	Subpath string // slash-separated path inside the repo; empty = repo root
+}
+
+// String renders the source in the canonical shorthand form for messages.
+func (s Source) String() string {
+	out := s.Owner + "/" + s.Repo
+	if s.Ref != "" {
+		out += "@" + s.Ref
+	}
+	if s.Subpath != "" {
+		out += "/" + s.Subpath
+	}
+	return out
+}
+
+// ParseSource accepts either a GitHub tree URL
+// (https://github.com/owner/repo/tree/ref/sub/path) or the shorthand
+// owner/repo[/sub/path]. The shorthand carries no ref and resolves to the
+// repository's default branch.
+func ParseSource(s string) (Source, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return Source{}, fmt.Errorf("empty source")
+	}
+	if strings.Contains(s, "://") {
+		return parseSourceURL(s)
+	}
+	parts := strings.Split(strings.Trim(s, "/"), "/")
+	if len(parts) < 2 {
+		return Source{}, fmt.Errorf("source %q: want owner/repo[/sub/path] or a github.com/.../tree/... URL", s)
+	}
+	return Source{Owner: parts[0], Repo: parts[1], Subpath: strings.Join(parts[2:], "/")}, nil
+}
+
+func parseSourceURL(s string) (Source, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return Source{}, fmt.Errorf("source %q: %w", s, err)
+	}
+	if u.Host != "github.com" && u.Host != "www.github.com" {
+		return Source{}, fmt.Errorf("source %q: only github.com URLs are supported", s)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 {
+		return Source{}, fmt.Errorf("source %q: want github.com/owner/repo[/tree/ref/sub/path]", s)
+	}
+	src := Source{Owner: parts[0], Repo: parts[1]}
+	rest := parts[2:]
+	if len(rest) == 0 {
+		return src, nil
+	}
+	// Only the /tree/<ref>/<subpath> form is meaningful for a directory; a ref
+	// containing "/" can't be told apart from the subpath, so the first segment
+	// after tree/ is taken as the whole ref.
+	if rest[0] != "tree" || len(rest) < 2 {
+		return Source{}, fmt.Errorf("source %q: want github.com/owner/repo/tree/ref/sub/path", s)
+	}
+	src.Ref = rest[1]
+	src.Subpath = strings.Join(rest[2:], "/")
+	return src, nil
+}
+
+// tarballURL builds the GitHub tarball endpoint for a source. The API serves
+// public repos unauthenticated and resolves an empty ref to the default
+// branch. A var so tests can point it at an httptest server.
+var tarballURL = func(s Source) string {
+	u := "https://api.github.com/repos/" + s.Owner + "/" + s.Repo + "/tarball"
+	if s.Ref != "" {
+		u += "/" + s.Ref
+	}
+	return u
+}
+
+// installMaxBytes caps the total bytes extracted from a tarball so a
+// hostile or bloated repository can't fill the disk. Real skills are a few
+// megabytes at most (the OOXML document skills are ~1.2 MB each).
+const installMaxBytes = 256 << 20
+
+var installClient = &http.Client{Timeout: 5 * time.Minute}
+
+// Install downloads the repository tarball, extracts src.Subpath, validates
+// its SKILL.md, and moves it into destRoot (normally UserRoot()). The
+// installed directory is named after the SKILL.md frontmatter name, falling
+// back to the subpath's basename. Refuses to replace an existing skill unless
+// force is set. Returns the installed skill's name and description.
+func Install(src Source, destRoot string, force bool) (name, desc string, err error) {
+	resp, err := installClient.Get(tarballURL(src))
+	if err != nil {
+		return "", "", fmt.Errorf("download %s: %w", src, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("download %s: HTTP %s (private repos and bad refs both surface here)", src, resp.Status)
+	}
+
+	if err := os.MkdirAll(destRoot, 0o755); err != nil {
+		return "", "", err
+	}
+	// Stage into a temp dir next to the final location so the move is a
+	// same-volume rename and a failed install never leaves a half-written skill.
+	tmp, err := os.MkdirTemp(destRoot, ".install-")
+	if err != nil {
+		return "", "", err
+	}
+	defer os.RemoveAll(tmp)
+
+	if err := extractSubdir(resp.Body, src.Subpath, tmp); err != nil {
+		return "", "", fmt.Errorf("extract %s: %w", src, err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(tmp, SkillFile))
+	if err != nil {
+		return "", "", fmt.Errorf("%s has no readable %s — not a skill directory", src, SkillFile)
+	}
+	fmName, fmDesc, ok := parseNamed(b)
+	if !ok || fmDesc == "" {
+		return "", "", fmt.Errorf("%s: %s is missing frontmatter name/description", src, SkillFile)
+	}
+	name = fmName
+	if name == "" {
+		name = path.Base(src.Subpath)
+	}
+	if name == "" || name == "." || name == "/" {
+		name = src.Repo
+	}
+
+	dest := filepath.Join(destRoot, name)
+	if _, err := os.Stat(dest); err == nil {
+		if !force {
+			return "", "", fmt.Errorf("skill %q already exists at %s (use --force to replace)", name, dest)
+		}
+		if err := os.RemoveAll(dest); err != nil {
+			return "", "", err
+		}
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		return "", "", err
+	}
+	return name, fmDesc, nil
+}
+
+// parseNamed is parse plus the frontmatter name, which Install uses to pick
+// the destination directory (the registry keys skills by directory name).
+func parseNamed(b []byte) (name, desc string, ok bool) {
+	front, _, ok := splitFrontmatter(string(b))
+	if !ok {
+		return "", "", false
+	}
+	var fm frontmatter
+	if err := yaml.Unmarshal([]byte(front), &fm); err != nil {
+		return "", "", false
+	}
+	return strings.TrimSpace(fm.Name), strings.TrimSpace(fm.Description), true
+}
+
+// extractSubdir streams a GitHub tarball, keeping only regular files under
+// subpath (repo-relative, after stripping the owner-repo-sha/ prefix GitHub
+// adds) and writing them under dest. Symlinks and other special entries are
+// skipped — a skill is plain files, and honoring links from an untrusted
+// archive is a path-escape risk.
+func extractSubdir(r io.Reader, subpath, dest string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+
+	var total int64
+	found := false
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		rel := stripTopDir(hdr.Name)
+		if rel == "" {
+			continue
+		}
+		if subpath != "" {
+			if !strings.HasPrefix(rel, subpath+"/") {
+				continue
+			}
+			rel = strings.TrimPrefix(rel, subpath+"/")
+		}
+		// Reject entries that would land outside dest. path.Clean plus the
+		// separator check covers ".." chains and absolute names.
+		clean := path.Clean(rel)
+		if clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
+			return fmt.Errorf("tar entry %q escapes the skill directory", hdr.Name)
+		}
+		total += hdr.Size
+		if total > installMaxBytes {
+			return fmt.Errorf("tarball exceeds %d MB extraction cap", installMaxBytes>>20)
+		}
+		target := filepath.Join(dest, filepath.FromSlash(clean))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		f, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(f, io.LimitReader(tr, hdr.Size)); err != nil {
+			f.Close()
+			return err
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+		found = true
+	}
+	if !found {
+		return fmt.Errorf("no files found under %q in the repository tarball", subpath)
+	}
+	return nil
+}
+
+// stripTopDir drops the single top-level directory GitHub prepends to every
+// tarball entry (owner-repo-sha/...), returning the repo-relative path.
+func stripTopDir(name string) string {
+	if i := strings.IndexByte(name, '/'); i >= 0 {
+		return name[i+1:]
+	}
+	return ""
+}

--- a/internal/skills/install_test.go
+++ b/internal/skills/install_test.go
@@ -1,0 +1,201 @@
+package skills
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseSource(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Source
+		err  bool
+	}{
+		{in: "anthropics/skills/skills/docx", want: Source{Owner: "anthropics", Repo: "skills", Subpath: "skills/docx"}},
+		{in: "anthropics/skills", want: Source{Owner: "anthropics", Repo: "skills"}},
+		{in: "https://github.com/anthropics/skills/tree/main/skills/pdf", want: Source{Owner: "anthropics", Repo: "skills", Ref: "main", Subpath: "skills/pdf"}},
+		{in: "https://github.com/anthropics/skills", want: Source{Owner: "anthropics", Repo: "skills"}},
+		{in: "https://github.com/anthropics/skills/blob/main/skills/pdf", err: true},
+		{in: "https://gitlab.com/x/y/tree/main/z", err: true},
+		{in: "justonename", err: true},
+		{in: "", err: true},
+	}
+	for _, c := range cases {
+		got, err := ParseSource(c.in)
+		if c.err {
+			if err == nil {
+				t.Errorf("ParseSource(%q): want error, got %+v", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseSource(%q): %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseSource(%q) = %+v, want %+v", c.in, got, c.want)
+		}
+	}
+}
+
+// makeTarball builds a gzipped tarball with GitHub's owner-repo-sha/ top-level
+// prefix on every entry.
+func makeTarball(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		hdr := &tar.Header{
+			Name: "anthropics-skills-0abc123/" + name,
+			Mode: 0o644,
+			Size: int64(len(content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// serveTarball points tarballURL at an httptest server returning body for the
+// test's duration.
+func serveTarball(t *testing.T, body []byte) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	orig := tarballURL
+	tarballURL = func(Source) string { return srv.URL }
+	t.Cleanup(func() {
+		tarballURL = orig
+		srv.Close()
+	})
+}
+
+const validSkillMd = "---\nname: docx\ndescription: Work with Word documents.\n---\nbody\n"
+
+func TestInstall_ExtractsSubpathOnly(t *testing.T) {
+	serveTarball(t, makeTarball(t, map[string]string{
+		"skills/docx/SKILL.md":            validSkillMd,
+		"skills/docx/scripts/__init__.py": "",
+		"skills/docx/scripts/pack.py":     "print('hi')",
+		"skills/pdf/SKILL.md":             "---\nname: pdf\ndescription: other\n---\n",
+		"README.md":                       "root readme",
+	}))
+
+	root := t.TempDir()
+	name, desc, err := Install(Source{Owner: "a", Repo: "s", Subpath: "skills/docx"}, root, false)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if name != "docx" || desc != "Work with Word documents." {
+		t.Errorf("name=%q desc=%q", name, desc)
+	}
+	for _, f := range []string{"SKILL.md", "scripts/__init__.py", "scripts/pack.py"} {
+		if _, err := os.Stat(filepath.Join(root, "docx", f)); err != nil {
+			t.Errorf("expected %s installed: %v", f, err)
+		}
+	}
+	// Files outside the subpath must not leak in.
+	if _, err := os.Stat(filepath.Join(root, "docx", "README.md")); !os.IsNotExist(err) {
+		t.Error("README.md from repo root leaked into the skill")
+	}
+	if entries, _ := os.ReadDir(root); len(entries) != 1 {
+		t.Errorf("expected exactly the installed skill in root, got %d entries", len(entries))
+	}
+}
+
+func TestInstall_RefusesExistingWithoutForce(t *testing.T) {
+	serveTarball(t, makeTarball(t, map[string]string{"skills/docx/SKILL.md": validSkillMd}))
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docx"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Install(Source{Owner: "a", Repo: "s", Subpath: "skills/docx"}, root, false); err == nil {
+		t.Fatal("want error installing over an existing skill without force")
+	}
+	if _, _, err := Install(Source{Owner: "a", Repo: "s", Subpath: "skills/docx"}, root, true); err != nil {
+		t.Fatalf("force install: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docx", "SKILL.md")); err != nil {
+		t.Errorf("force install should have replaced the skill: %v", err)
+	}
+}
+
+func TestInstall_SubpathMissing(t *testing.T) {
+	serveTarball(t, makeTarball(t, map[string]string{"README.md": "x"}))
+	if _, _, err := Install(Source{Owner: "a", Repo: "s", Subpath: "skills/nope"}, t.TempDir(), false); err == nil {
+		t.Fatal("want error for a subpath absent from the tarball")
+	}
+}
+
+func TestInstall_RejectsInvalidSkillMd(t *testing.T) {
+	serveTarball(t, makeTarball(t, map[string]string{"skills/docx/SKILL.md": "no frontmatter here"}))
+	if _, _, err := Install(Source{Owner: "a", Repo: "s", Subpath: "skills/docx"}, t.TempDir(), false); err == nil {
+		t.Fatal("want error for SKILL.md without frontmatter")
+	}
+}
+
+func TestInstall_RejectsPathTraversal(t *testing.T) {
+	serveTarball(t, makeTarball(t, map[string]string{
+		"skills/docx/SKILL.md":   validSkillMd,
+		"skills/docx/../../evil": "boom",
+	}))
+	root := t.TempDir()
+	if _, _, err := Install(Source{Owner: "a", Repo: "s", Subpath: "skills/docx"}, root, false); err == nil {
+		t.Fatal("want error for a tar entry escaping the skill directory")
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(root), "evil")); !os.IsNotExist(err) {
+		t.Error("traversal entry was written outside the dest root")
+	}
+}
+
+func TestInstall_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	orig := tarballURL
+	tarballURL = func(Source) string { return srv.URL }
+	t.Cleanup(func() {
+		tarballURL = orig
+		srv.Close()
+	})
+	if _, _, err := Install(Source{Owner: "a", Repo: "nope"}, t.TempDir(), false); err == nil {
+		t.Fatal("want error on HTTP 404")
+	}
+}
+
+func TestInstall_RepoRootSkill(t *testing.T) {
+	serveTarball(t, makeTarball(t, map[string]string{
+		"SKILL.md": "---\nname: solo\ndescription: a whole-repo skill\n---\n",
+		"ref.md":   "extra",
+	}))
+	root := t.TempDir()
+	name, _, err := Install(Source{Owner: "a", Repo: "solo-skill"}, root, false)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if name != "solo" {
+		t.Errorf("name = %q, want solo (from frontmatter)", name)
+	}
+	if _, err := os.Stat(filepath.Join(root, "solo", "ref.md")); err != nil {
+		t.Errorf("ref.md missing: %v", err)
+	}
+}


### PR DESCRIPTION
## Why not vendor?

The original ask was to ship the [anthropics/skills](https://github.com/anthropics/skills) document skills (docx / pdf / pptx / xlsx) as octo default skills. Those four are **source-available, not open source** — each carries a LICENSE.txt that forbids redistribution, copying, and derivative works. Embedding them in this public repo and shipping them in the binary would violate that license, so instead octo gets a generic installer and the user fetches them directly from the source repository onto their own machine. octo redistributes nothing.

## What

`octo skills add <source> [--force]` installs a skill from any public GitHub repository into `~/.octo/skills`:

```
octo skills add anthropics/skills/skills/docx
octo skills add https://github.com/anthropics/skills/tree/main/skills/pdf
```

- Downloads the repo tarball via the GitHub API (unauthenticated, public repos; empty ref resolves to the default branch), extracts **only** the requested subpath.
- Validates SKILL.md frontmatter before installing; the installed directory is named after the frontmatter `name` (falling back to subpath basename / repo name), so the `/<name>` trigger matches the skill's intent.
- Stages through a temp dir sibling to the destination — same-volume rename, no half-written skills on failure.
- Refuses to replace an existing skill without `--force`.
- Hardened extraction: regular files only (symlinks skipped), path-traversal entries rejected, total-size cap.
- Prints a license reminder after install.

## Verification

- Unit tests via `httptest` (no live network, per project rules): subpath isolation, `__init__.py`-style underscore files, force semantics, missing subpath, invalid frontmatter, path traversal, HTTP errors, whole-repo skills.
- Manual end-to-end against the real GitHub API: installed all four document skills; `diff -rq` against a fresh clone of anthropics/skills shows byte-identical trees, and `octo skills list` discovers all four as user skills.
- `go test -race ./...`, `go vet`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)