### PR TITLE
fix(server): replay pending question/confirmation prompts on WS resubscribe

### DIFF
--- a/internal/server/pending_prompt_test.go
+++ b/internal/server/pending_prompt_test.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// TestReplayLiveState_ReplaysPendingPrompts is the regression guard for the
+// "refresh during ask_user_question" bug: the question's original broadcast
+// only reached the tabs connected at the time, so a reloaded page showed a
+// dead spinner with no way to answer.
+func TestReplayLiveState_ReplaysPendingPrompts(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+	srv.pendingQuestions = map[string]wsEventRequestUserQuestion{}
+	srv.pendingConfirms = map[string]wsEventRequestConfirmation{}
+
+	const sid = "replay-prompt-session"
+	defer tools.CloseSessionBackgroundManager(sid)
+
+	srv.pendingQuestions[sid] = wsEventRequestUserQuestion{
+		Type: "request_user_question", QuestionID: "q_1", Question: "pick one", Options: []string{"a", "b"},
+	}
+	srv.pendingConfirms[sid] = wsEventRequestConfirmation{
+		Type: "request_confirmation", ConfID: "conf_1", Message: "Allow terminal?", Kind: "yes_no",
+	}
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.replayLiveState(sid, conn)
+
+	var gotQ, gotC bool
+	for len(conn.send) > 0 {
+		var ev map[string]any
+		if json.Unmarshal(<-conn.send, &ev) != nil {
+			continue
+		}
+		switch ev["type"] {
+		case "request_user_question":
+			gotQ = true
+			if ev["question_id"] != "q_1" {
+				t.Errorf("question_id = %v, want q_1", ev["question_id"])
+			}
+		case "request_confirmation":
+			gotC = true
+			if ev["conf_id"] != "conf_1" {
+				t.Errorf("conf_id = %v, want conf_1", ev["conf_id"])
+			}
+		}
+	}
+	if !gotQ || !gotC {
+		t.Fatalf("replayed question=%v confirmation=%v, want both", gotQ, gotC)
+	}
+}
+
+// TestWSAsker_RegistersAndClearsPendingQuestion drives a full ask round-trip
+// and checks the pending entry exists while the ask is outstanding and is
+// gone after the answer arrives.
+func TestWSAsker_RegistersAndClearsPendingQuestion(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+	srv.questionChans = map[string]chan tools.AskResponse{}
+	srv.pendingQuestions = map[string]wsEventRequestUserQuestion{}
+	srv.pendingConfirms = map[string]wsEventRequestConfirmation{}
+
+	const sid = "asker-pending-session"
+	ctx := context.WithValue(context.Background(), ctxKeySessionID{}, sid)
+
+	go func() {
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			srv.pendingPromptMu.Lock()
+			ev, ok := srv.pendingQuestions[sid]
+			srv.pendingPromptMu.Unlock()
+			if ok {
+				srv.handleWSUserQuestionAnswer(ev.QuestionID, []string{"a"}, "", false)
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	res, err := srv.wsAsker().Ask(ctx, tools.AskRequest{Question: "pick", Options: []string{"a", "b"}})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if len(res.Choices) != 1 || res.Choices[0] != "a" {
+		t.Fatalf("choices = %v, want [a]", res.Choices)
+	}
+
+	srv.pendingPromptMu.Lock()
+	_, still := srv.pendingQuestions[sid]
+	srv.pendingPromptMu.Unlock()
+	if still {
+		t.Fatal("pending question not cleared after answer")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -122,6 +122,13 @@ type Server struct {
 	questionChans map[string]chan tools.AskResponse
 	questionMu    sync.Mutex
 
+	// pending interactive prompts per session, replayed on WS (re)subscribe so
+	// a page refresh doesn't orphan an in-flight question or confirmation —
+	// the original broadcast only reached the tabs connected at the time.
+	pendingQuestions map[string]wsEventRequestUserQuestion
+	pendingConfirms  map[string]wsEventRequestConfirmation
+	pendingPromptMu  sync.Mutex
+
 	// live state tracking per session for WS replay on subscribe.
 	liveStates  map[string]*sessionLiveState
 	liveStateMu sync.RWMutex
@@ -207,7 +214,10 @@ func New(cfg Config) (*Server, error) {
 		steerQueues:      make(map[string][]agent.InboxItem),
 		sessionAgents:    make(map[string]*agent.Agent),
 		accessKey:        accessKey,
+		confirmations:    make(map[string]chan string),
 		questionChans:    make(map[string]chan tools.AskResponse),
+		pendingQuestions: make(map[string]wsEventRequestUserQuestion),
+		pendingConfirms:  make(map[string]wsEventRequestConfirmation),
 		sessionInjectors: make(map[string]*memory.Injector),
 	}
 
@@ -706,30 +716,41 @@ func (a wsAsker) Ask(ctx context.Context, q tools.AskRequest) (tools.AskResponse
 	a.s.questionChans[qid] = ch
 	a.s.questionMu.Unlock()
 
-	a.s.wsHub.broadcast(sessionID, wsEventRequestUserQuestion{
+	ev := wsEventRequestUserQuestion{
 		Type:        "request_user_question",
 		QuestionID:  qid,
 		Question:    q.Question,
 		Options:     q.Options,
 		MultiSelect: q.MultiSelect,
 		Header:      q.Header,
-	})
+	}
+
+	// Record the outstanding question so a tab that (re)subscribes mid-ask —
+	// e.g. after a page refresh — gets it replayed instead of a dead spinner.
+	a.s.pendingPromptMu.Lock()
+	a.s.pendingQuestions[sessionID] = ev
+	a.s.pendingPromptMu.Unlock()
+
+	cleanup := func() {
+		a.s.questionMu.Lock()
+		delete(a.s.questionChans, qid)
+		a.s.questionMu.Unlock()
+		a.s.pendingPromptMu.Lock()
+		delete(a.s.pendingQuestions, sessionID)
+		a.s.pendingPromptMu.Unlock()
+	}
+
+	a.s.wsHub.broadcast(sessionID, ev)
 
 	select {
 	case res := <-ch:
-		a.s.questionMu.Lock()
-		delete(a.s.questionChans, qid)
-		a.s.questionMu.Unlock()
+		cleanup()
 		return res, nil
 	case <-ctx.Done():
-		a.s.questionMu.Lock()
-		delete(a.s.questionChans, qid)
-		a.s.questionMu.Unlock()
+		cleanup()
 		return tools.AskResponse{Cancelled: true}, nil
 	case <-time.After(5 * time.Minute):
-		a.s.questionMu.Lock()
-		delete(a.s.questionChans, qid)
-		a.s.questionMu.Unlock()
+		cleanup()
 		return tools.AskResponse{}, fmt.Errorf("ask_user_question: timed out waiting for user answer")
 	}
 }

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -67,6 +67,25 @@ func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
 		conn.send <- b
 	}
 
+	// Replay an outstanding interactive prompt. Its original broadcast only
+	// reached the tabs connected at the time; without this, a page refresh
+	// during ask_user_question / a permission confirmation leaves the new tab
+	// stuck on a spinner with no way to answer.
+	s.pendingPromptMu.Lock()
+	pendingQ, hasQ := s.pendingQuestions[sessionID]
+	pendingC, hasC := s.pendingConfirms[sessionID]
+	s.pendingPromptMu.Unlock()
+	if hasQ {
+		if b, err := json.Marshal(pendingQ); err == nil {
+			conn.send <- b
+		}
+	}
+	if hasC {
+		if b, err := json.Marshal(pendingC); err == nil {
+			conn.send <- b
+		}
+	}
+
 	s.liveStateMu.RLock()
 	state, ok := s.liveStates[sessionID]
 	s.liveStateMu.RUnlock()
@@ -889,29 +908,40 @@ func (s *Server) requestConfirmation(ctx context.Context, sessionID, message, ki
 	s.confirmations[confID] = ch
 	s.confirmMu.Unlock()
 
-	s.wsHub.broadcast(sessionID, wsEventRequestConfirmation{
+	ev := wsEventRequestConfirmation{
 		Type:    "request_confirmation",
 		ConfID:  confID,
 		Message: message,
 		Kind:    kind,
-	})
+	}
+
+	// Record the outstanding confirmation so a tab that (re)subscribes
+	// mid-ask — e.g. after a page refresh — gets it replayed.
+	s.pendingPromptMu.Lock()
+	s.pendingConfirms[sessionID] = ev
+	s.pendingPromptMu.Unlock()
+
+	cleanup := func() {
+		s.confirmMu.Lock()
+		delete(s.confirmations, confID)
+		s.confirmMu.Unlock()
+		s.pendingPromptMu.Lock()
+		delete(s.pendingConfirms, sessionID)
+		s.pendingPromptMu.Unlock()
+	}
+
+	s.wsHub.broadcast(sessionID, ev)
 
 	// Wait for response, timeout, or cancellation.
 	select {
 	case result := <-ch:
-		s.confirmMu.Lock()
-		delete(s.confirmations, confID)
-		s.confirmMu.Unlock()
+		cleanup()
 		return result, nil
 	case <-ctx.Done():
-		s.confirmMu.Lock()
-		delete(s.confirmations, confID)
-		s.confirmMu.Unlock()
+		cleanup()
 		return "", fmt.Errorf("confirmation cancelled")
 	case <-time.After(5 * time.Minute):
-		s.confirmMu.Lock()
-		delete(s.confirmations, confID)
-		s.confirmMu.Unlock()
+		cleanup()
 		return "", fmt.Errorf("confirmation timed out")
 	}
 }


### PR DESCRIPTION
## Problem

Refreshing the page while `ask_user_question` (or a permission confirmation) was waiting for an answer left the session stuck on a dead tool spinner. The prompt event is broadcast once, to the tabs connected at that moment; a reloaded tab never receives it, has no way to answer, and the ask dies on its 5-minute timeout. Hit in the wild via the task panel's Edit flow (`/cron-task-creator edit …` asks a clarifying question).

## Fix

- Track the outstanding question/confirmation per session (`pendingQuestions` / `pendingConfirms`); `replayLiveState` re-sends it to any tab that (re)subscribes, next to the existing progress/stdout replay. Cleared on answer, cancel, and timeout. At most one of each can be outstanding per session since the ask blocks the agent loop.
- **Latent crash fix:** the `confirmations` map was never allocated in `New`, so the first interactive permission confirmation would have panicked on a nil-map write.

## Verification

- `TestReplayLiveState_ReplaysPendingPrompts` — resubscribe replays both prompt kinds.
- `TestWSAsker_RegistersAndClearsPendingQuestion` — full ask round-trip; pending entry exists while outstanding, cleared after the answer.
- `go test -race ./...` green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)