### PR TITLE
feat(scheduler): notify task results to multiple IM targets

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -6,6 +6,7 @@
 package scheduler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -28,6 +29,29 @@ type NotifyTarget struct {
 	ChatID   string `json:"chat_id"`
 }
 
+// NotifyTargets is a list of notify destinations; each run is pushed to every
+// entry. It unmarshals from either a JSON array or a bare object, so task
+// files written when notify was a single target keep loading.
+type NotifyTargets []NotifyTarget
+
+func (n *NotifyTargets) UnmarshalJSON(b []byte) error {
+	trimmed := bytes.TrimSpace(b)
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		var one NotifyTarget
+		if err := json.Unmarshal(trimmed, &one); err != nil {
+			return err
+		}
+		*n = NotifyTargets{one}
+		return nil
+	}
+	var many []NotifyTarget
+	if err := json.Unmarshal(trimmed, &many); err != nil {
+		return err
+	}
+	*n = many
+	return nil
+}
+
 // Task represents a scheduled agent task.
 type Task struct {
 	ID        string        `json:"id"`
@@ -37,7 +61,7 @@ type Task struct {
 	Model     string        `json:"model,omitempty"`
 	Agent     string        `json:"agent,omitempty"` // "general" | "coding"
 	Directory string        `json:"directory,omitempty"`
-	Notify    *NotifyTarget `json:"notify,omitempty"`
+	Notify    NotifyTargets `json:"notify,omitempty"`
 	Enabled   bool          `json:"enabled"`
 	CreatedAt time.Time     `json:"created_at"`
 	LastRun   time.Time     `json:"last_run,omitempty"`

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
@@ -281,5 +282,37 @@ func TestLoadAllRegistersEnabledTasks(t *testing.T) {
 	}
 	if got := len(s2.cron.Entries()); got != 1 {
 		t.Fatalf("cron entries after reload = %d, want 1 (only the enabled task)", got)
+	}
+}
+
+func TestNotifyTargetsUnmarshal_ObjectAndArray(t *testing.T) {
+	// A task file written when notify was a single object must keep loading.
+	var fromObject Task
+	if err := json.Unmarshal([]byte(`{"id":"t1","notify":{"platform":"feishu","chat_id":"oc_1"}}`), &fromObject); err != nil {
+		t.Fatalf("unmarshal object form: %v", err)
+	}
+	if len(fromObject.Notify) != 1 || fromObject.Notify[0].ChatID != "oc_1" {
+		t.Fatalf("object form: notify = %v", fromObject.Notify)
+	}
+
+	var fromArray Task
+	if err := json.Unmarshal([]byte(`{"id":"t2","notify":[{"platform":"feishu","chat_id":"oc_1"},{"platform":"weixin","chat_id":"u_2"}]}`), &fromArray); err != nil {
+		t.Fatalf("unmarshal array form: %v", err)
+	}
+	if len(fromArray.Notify) != 2 || fromArray.Notify[1].Platform != "weixin" {
+		t.Fatalf("array form: notify = %v", fromArray.Notify)
+	}
+
+	// Round-trip: marshal writes an array, which unmarshals back unchanged.
+	b, err := json.Marshal(fromArray)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var again Task
+	if err := json.Unmarshal(b, &again); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if len(again.Notify) != 2 {
+		t.Fatalf("round-trip: notify = %v", again.Notify)
 	}
 }

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -22,7 +22,7 @@ type taskRequest struct {
 	Prompt string                  `json:"prompt"`
 	Model  string                  `json:"model,omitempty"`
 	Agent  string                  `json:"agent,omitempty"`
-	Notify *scheduler.NotifyTarget `json:"notify,omitempty"`
+	Notify scheduler.NotifyTargets `json:"notify,omitempty"`
 }
 
 type taskResponse struct {
@@ -32,7 +32,7 @@ type taskResponse struct {
 	Prompt    string                  `json:"prompt"`
 	Model     string                  `json:"model,omitempty"`
 	Agent     string                  `json:"agent,omitempty"`
-	Notify    *scheduler.NotifyTarget `json:"notify,omitempty"`
+	Notify    scheduler.NotifyTargets `json:"notify,omitempty"`
 	Enabled   bool                    `json:"enabled"`
 	CreatedAt string                  `json:"created_at,omitempty"`
 	LastRun   string                  `json:"last_run,omitempty"`
@@ -124,15 +124,15 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 	return sess.ID, nil
 }
 
-// notifyTaskResult pushes a task run's outcome to its IM notify target, if
-// one is configured. Delivery failures are logged, never fatal — the run
-// itself already happened and is recorded in the session.
+// notifyTaskResult pushes a task run's outcome to every configured IM notify
+// target. Delivery failures are logged per target, never fatal — the run
+// itself already happened and is recorded in the session, and one channel
+// failing must not silence the others.
 func (s *Server) notifyTaskResult(task scheduler.Task, text string) {
-	if task.Notify == nil {
-		return
-	}
-	if err := channel.SendOnce(task.Notify.Platform, task.Notify.ChatID, text); err != nil {
-		log.Printf("[scheduler] task %q notify: %v", task.Name, err)
+	for _, n := range task.Notify {
+		if err := channel.SendOnce(n.Platform, n.ChatID, text); err != nil {
+			log.Printf("[scheduler] task %q notify %s/%s: %v", task.Name, n.Platform, n.ChatID, err)
+		}
 	}
 }
 

--- a/internal/skills/defaults/cron-task-creator/SKILL.md
+++ b/internal/skills/defaults/cron-task-creator/SKILL.md
@@ -21,7 +21,7 @@ history from previous executions.
 | `model` | no | Model override; defaults to the server's model |
 | `agent` | no | `"general"` or `"coding"` |
 | `directory` | no | Working directory hint, prepended to the task session's system prompt |
-| `notify` | no | `{"platform": "feishu", "chat_id": "oc_..."}` — push each run's final reply (or a failure note) to an IM chat |
+| `notify` | no | IM chats to push each run's final reply (or a failure note) to: `[{"platform": "feishu", "chat_id": "oc_..."}, {"platform": "weixin", "chat_id": "..."}]` — every entry gets the push. A bare object (single target) is also accepted. |
 | `enabled` | yes | Whether the schedule is active |
 
 ## Cron expression format — 6 fields, seconds first


### PR DESCRIPTION
## Problem

`notify` held a single `{platform, chat_id}`, so a task's result could go to Feishu *or* Weixin, not both.

## Design

`notify` becomes a list — every entry gets the push, per-target failures are logged individually so one dead channel doesn't silence the rest:

```json
"notify": [
  {"platform": "feishu", "chat_id": "oc_xxx"},
  {"platform": "weixin", "chat_id": "<ilink_user_id>"}
]
```

"All channels" can't be derived automatically — each platform needs an explicit chat to deliver to (and DingTalk can't push proactively at all) — so the list is the general form: configure one entry per channel you want.

`NotifyTargets.UnmarshalJSON` accepts both an array and the previous bare-object form, so existing task files keep loading. Marshalling always writes the array form. The tasks REST API carries the same type.

## Verification

- `TestNotifyTargetsUnmarshal_ObjectAndArray`: object compat, array form, marshal round-trip.
- `go test -race ./...` green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)