### PR TITLE
fix(channel): make /stop actually interrupt the in-flight agent turn

### DIFF
--- a/cmd/octo/channel.go
+++ b/cmd/octo/channel.go
@@ -222,7 +222,11 @@ func runChannelStart(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 				if handleCommand(mgr, a, ev) {
 					return
 				}
-				handleAgentMessage(ctx, mgr, a, ev, !*noTools)
+				// Run the agent off the adapter's read loop so commands —
+				// notably /stop — are still processed while a turn is in
+				// flight. Session.BeginRun serialises turns per session, so
+				// concurrent messages in one chat can't interleave.
+				go handleAgentMessage(ctx, mgr, a, ev, !*noTools)
 			})
 		}(ad, name)
 	}
@@ -261,6 +265,11 @@ func handleAgentMessage(ctx context.Context, mgr *channel.Manager, ad channel.Ad
 	if sess == nil {
 		return
 	}
+
+	// Waits for any in-flight turn in this session, then makes this turn
+	// cancellable by /stop (Session.Interrupt).
+	ctx, done := sess.BeginRun(ctx)
+	defer done()
 
 	ctrl := channel.NewUIController(ad, ev.ChatID, ev.MessageID)
 

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -55,6 +55,46 @@ type Session struct {
 	ChatID  string
 	UserID  string
 	BoundAt time.Time
+
+	// runMu serialises agent turns within this session: the IM dispatcher runs
+	// each message in its own goroutine, and two interleaved turns would
+	// corrupt the agent's user/assistant history alternation. runCancel
+	// (guarded by cancelMu, not runMu — /stop must not queue behind the very
+	// turn it is trying to cancel) aborts the in-flight turn.
+	runMu     sync.Mutex
+	cancelMu  sync.Mutex
+	runCancel context.CancelFunc
+}
+
+// BeginRun prepares one agent turn: it blocks until any previous turn in this
+// session finishes, then returns a cancellable ctx for the run and a done
+// func that releases the session. Always call done (typically deferred).
+func (s *Session) BeginRun(ctx context.Context) (context.Context, func()) {
+	s.runMu.Lock()
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancelMu.Lock()
+	s.runCancel = cancel
+	s.cancelMu.Unlock()
+	return ctx, func() {
+		s.cancelMu.Lock()
+		s.runCancel = nil
+		s.cancelMu.Unlock()
+		cancel()
+		s.runMu.Unlock()
+	}
+}
+
+// Interrupt cancels the session's in-flight agent turn, if any. It reports
+// whether a turn was actually running.
+func (s *Session) Interrupt() bool {
+	s.cancelMu.Lock()
+	defer s.cancelMu.Unlock()
+	if s.runCancel == nil {
+		return false
+	}
+	s.runCancel()
+	s.runCancel = nil
+	return true
 }
 
 // AgentFactory creates a new agent.Agent for a session.
@@ -229,13 +269,19 @@ func (m *Manager) cmdBind(ev InboundEvent, args []string) string {
 	return fmt.Sprintf("Session bound (%s). Key: %s", modeStr, key)
 }
 
-// cmdStop stops the current session (pauses it without deleting history).
+// cmdStop interrupts the session's in-flight agent turn (mirrors the Ctrl-C /
+// web "interrupt" semantics; history is repaired by finishInterrupted and the
+// session stays usable).
 func (m *Manager) cmdStop(ev InboundEvent) string {
 	key := sessionKeyFor(m.mode, ev)
-	if _, loaded := m.sessions.Load(key); !loaded {
+	val, loaded := m.sessions.Load(key)
+	if !loaded {
 		return "No active session for this context."
 	}
-	return "Session stopped. Use /bind to resume or start a new one."
+	if val.(*Session).Interrupt() {
+		return "Task interrupted."
+	}
+	return "No task is running."
 }
 
 // cmdUnbind deletes the current session and its history.

--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -2,6 +2,7 @@ package channel
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -184,11 +185,14 @@ func TestManager_CommandRouter(t *testing.T) {
 		t.Fatal("expected non-empty reply for /list")
 	}
 
-	// /stop (does not delete)
+	// /stop with no turn in flight (does not delete the session)
 	ev.Text = "/stop"
 	reply = mgr.CommandRouter(ev)
-	if reply == "" {
-		t.Fatal("expected non-empty reply for /stop")
+	if !strings.Contains(reply, "No task is running") {
+		t.Fatalf("expected idle /stop reply, got %q", reply)
+	}
+	if mgr.SessionCount() != 1 {
+		t.Fatalf("expected session to survive /stop, got %d", mgr.SessionCount())
 	}
 
 	// /unbind (deletes)
@@ -197,6 +201,73 @@ func TestManager_CommandRouter(t *testing.T) {
 	if mgr.SessionCount() != 0 {
 		t.Fatalf("expected 0 sessions after /unbind, got %d", mgr.SessionCount())
 	}
+}
+
+func TestManager_StopInterruptsRunningTurn(t *testing.T) {
+	cfg := &Config{Channels: map[string]PlatformConfig{}}
+	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
+
+	ev := InboundEvent{Platform: "mock", ChatID: "c1", UserID: "u1"}
+	sess := mgr.GetOrCreateSession(ev)
+
+	runCtx, done := sess.BeginRun(context.Background())
+	defer done()
+
+	ev.Text = "/stop"
+	reply := mgr.CommandRouter(ev)
+	if !strings.Contains(reply, "Task interrupted") {
+		t.Fatalf("expected interrupt reply, got %q", reply)
+	}
+	if runCtx.Err() == nil {
+		t.Fatal("expected the run context to be cancelled by /stop")
+	}
+
+	// A second /stop finds nothing to interrupt.
+	if reply := mgr.CommandRouter(ev); !strings.Contains(reply, "No task is running") {
+		t.Fatalf("expected idle reply on second /stop, got %q", reply)
+	}
+}
+
+func TestSession_BeginRunSerialisesTurns(t *testing.T) {
+	sess := &Session{}
+
+	_, done1 := sess.BeginRun(context.Background())
+
+	second := make(chan struct{})
+	go func() {
+		_, done2 := sess.BeginRun(context.Background())
+		done2()
+		close(second)
+	}()
+
+	select {
+	case <-second:
+		t.Fatal("second turn started before the first finished")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	done1()
+	select {
+	case <-second:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second turn never started after the first finished")
+	}
+}
+
+func TestSession_InterruptIdleIsNoop(t *testing.T) {
+	sess := &Session{}
+	if sess.Interrupt() {
+		t.Fatal("Interrupt on an idle session should report false")
+	}
+	// done() after Interrupt must not double-release or panic.
+	ctx, done := sess.BeginRun(context.Background())
+	if !sess.Interrupt() {
+		t.Fatal("Interrupt on a running session should report true")
+	}
+	if ctx.Err() == nil {
+		t.Fatal("expected cancelled ctx")
+	}
+	done()
 }
 
 func TestManager_AutoSessionCreation(t *testing.T) {


### PR DESCRIPTION
## Summary

`/stop` in the IM bridge was a no-op: it checked that a session existed and replied "Session stopped." without stopping anything. The Ruby bridge's `/stop` interrupted the currently running task; this restores that behavior in Go, using the same pattern as the web server's per-session `interrupts` map.

### Changes

- **`Session.BeginRun` / `Session.Interrupt`** (`internal/channel/manager.go`) — each agent turn gets a cancellable context registered on the session; `/stop` cancels it. `BeginRun` also serialises turns within a session via a run mutex, while the cancel func lives behind a separate mutex so `/stop` never queues behind the very turn it's cancelling.
- **`cmdStop`** — interrupts the in-flight turn → "Task interrupted.", or reports "No task is running." The agent core's `finishInterrupted` already repairs the user/assistant history alternation on `context.Canceled`, so the session remains usable.
- **Dispatcher** (`cmd/octo/channel.go`) — agent turns now run in their own goroutine instead of inside the adapter's read loop. This is load-bearing for the fix: previously the read loop was blocked for the duration of a turn, so a `/stop` sent mid-turn wasn't even read until the turn had finished. Per-session serialisation via `BeginRun` keeps concurrent messages in one chat from interleaving on the same agent.

### Tests

- `/stop` on an idle session → "No task is running.", session survives
- `/stop` during a turn cancels the run context and reports "Task interrupted."; a second `/stop` finds nothing to interrupt
- `BeginRun` blocks a second turn until the first releases; `Interrupt` on idle is a safe no-op and `done()` after `Interrupt` doesn't double-release

`make fmt-check`, `go vet ./...`, `go test ./...` (full suite, `-race` on the touched packages) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)