### PR TITLE
feat(dingtalk): proactive pushes via the robot send APIs

### DIFF
--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -43,6 +43,7 @@ func init() {
 const (
 	cfgClientID     = "client_id"
 	cfgClientSecret = "client_secret"
+	cfgRobotCode    = "robot_code"
 	cfgAllowedUsers = "allowed_users"
 )
 
@@ -50,6 +51,8 @@ const (
 type Adapter struct {
 	clientID     string
 	clientSecret string
+	robotCode    string // defaults to clientID — they coincide for enterprise-internal robots
+	apiBase      string
 	allowedUsers map[string]bool
 
 	http        *http.Client
@@ -87,9 +90,16 @@ func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
 		}
 	}
 
+	robotCode, _ := cfg[cfgRobotCode].(string)
+	if robotCode == "" {
+		robotCode = cid
+	}
+
 	return &Adapter{
 		clientID:     cid,
 		clientSecret: secret,
+		robotCode:    robotCode,
+		apiBase:      apiBase,
 		allowedUsers: allowed,
 		http:         &http.Client{Timeout: 30 * time.Second},
 		webhooks:     make(map[string]webhookEntry),
@@ -138,13 +148,15 @@ func (a *Adapter) Stop() error {
 	return nil
 }
 
-// SendText sends a Markdown message via sessionWebhook.
+// SendText sends a Markdown message. It prefers the chat's sessionWebhook
+// (free, no extra permissions, but only exists after an inbound message and
+// expires); without one it falls back to the proactive robot API, which is
+// what a standalone push (channel.SendOnce from octo serve) always uses.
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
-	url := a.resolveWebhook(chatID)
-	if url == "" {
-		return channel.SendResult{OK: false, Error: "no valid webhook (expired or never received)"}
+	if url := a.resolveWebhook(chatID); url != "" {
+		return a.sendWebhook(url, text)
 	}
-	return a.sendWebhook(url, text)
+	return a.sendProactive(chatID, text)
 }
 
 // SendFile is not yet implemented for DingTalk.
@@ -178,7 +190,7 @@ func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 func (a *Adapter) refreshToken() error {
 	body := map[string]string{"appKey": a.clientID, "appSecret": a.clientSecret}
 	b, _ := json.Marshal(body)
-	resp, err := a.http.Post(apiBase+"/v1.0/oauth2/accessToken", "application/json", bytes.NewReader(b))
+	resp, err := a.http.Post(a.apiBase+"/v1.0/oauth2/accessToken", "application/json", bytes.NewReader(b))
 	if err != nil {
 		return err
 	}
@@ -206,12 +218,25 @@ func (a *Adapter) refreshToken() error {
 
 func (a *Adapter) getToken() string {
 	a.tokenMu.Lock()
-	defer a.tokenMu.Unlock()
-	if time.Now().After(a.tokenExpiry) {
+	tok := a.accessToken
+	expired := time.Now().After(a.tokenExpiry)
+	a.tokenMu.Unlock()
+
+	// No token yet: the adapter is being used for an outbound send without
+	// Start() (e.g. channel.SendOnce). Fetch synchronously or the request
+	// goes out with an empty token header.
+	if tok == "" {
+		_ = a.refreshToken()
+		a.tokenMu.Lock()
+		tok = a.accessToken
+		a.tokenMu.Unlock()
+		return tok
+	}
+	if expired {
 		// Best-effort refresh — don't block.
 		go a.refreshToken()
 	}
-	return a.accessToken
+	return tok
 }
 
 // ─── Gateway ───────────────────────────────────────────────────────────────
@@ -222,7 +247,7 @@ func (a *Adapter) openGateway() (string, error) {
 		"clientSecret": a.clientSecret,
 	}
 	b, _ := json.Marshal(body)
-	resp, err := a.http.Post(apiBase+"/v1.0/gateway/connections/open", "application/json", bytes.NewReader(b))
+	resp, err := a.http.Post(a.apiBase+"/v1.0/gateway/connections/open", "application/json", bytes.NewReader(b))
 	if err != nil {
 		return "", err
 	}
@@ -411,6 +436,50 @@ func (a *Adapter) resolveWebhook(chatID string) string {
 		return ""
 	}
 	return e.URL
+}
+
+// sendProactive pushes a message through the robot send APIs, which need no
+// sessionWebhook — only the app credentials and the "robot message send"
+// permission granted in the DingTalk admin console. An openConversationId
+// (always "cid"-prefixed) routes to the group API; anything else is treated
+// as a staff/user id and routed to the one-on-one batch API. Note the cid
+// form only works for group chats — a 1:1 push must target the user id, not
+// the DM conversation id.
+func (a *Adapter) sendProactive(chatID, text string) channel.SendResult {
+	tok := a.getToken()
+	if tok == "" {
+		return channel.SendResult{OK: false, Error: "no access token"}
+	}
+
+	msgParam, _ := json.Marshal(map[string]string{"title": "Octo", "text": text})
+	body := map[string]any{
+		"robotCode": a.robotCode,
+		"msgKey":    "sampleMarkdown",
+		"msgParam":  string(msgParam),
+	}
+	path := "/v1.0/robot/oToMessages/batchSend"
+	if strings.HasPrefix(chatID, "cid") {
+		path = "/v1.0/robot/groupMessages/send"
+		body["openConversationId"] = chatID
+	} else {
+		body["userIds"] = []string{chatID}
+	}
+
+	b, _ := json.Marshal(body)
+	req, _ := http.NewRequest("POST", a.apiBase+path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-acs-dingtalk-access-token", tok)
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode/100 != 2 {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("robot api %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))}
+	}
+	return channel.SendResult{OK: true}
 }
 
 func (a *Adapter) sendWebhook(url, text string) channel.SendResult {

--- a/internal/channel/adapters/dingtalk/dingtalk_test.go
+++ b/internal/channel/adapters/dingtalk/dingtalk_test.go
@@ -1,0 +1,140 @@
+package dingtalk
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// stubAPI fakes the DingTalk token + robot send endpoints and records the
+// send requests it receives.
+type stubAPI struct {
+	mu    sync.Mutex
+	sends []struct {
+		path string
+		body map[string]any
+	}
+}
+
+func (s *stubAPI) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.0/oauth2/accessToken":
+			_ = json.NewEncoder(w).Encode(map[string]any{"accessToken": "tok-1", "expireIn": 7200})
+		case "/v1.0/robot/oToMessages/batchSend", "/v1.0/robot/groupMessages/send":
+			if got := r.Header.Get("x-acs-dingtalk-access-token"); got != "tok-1" {
+				t.Errorf("token header = %q, want tok-1", got)
+			}
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			s.mu.Lock()
+			s.sends = append(s.sends, struct {
+				path string
+				body map[string]any
+			}{r.URL.Path, body})
+			s.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"processQueryKey": "ok"})
+		default:
+			t.Errorf("unexpected request: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func testAdapter(ts *httptest.Server) *Adapter {
+	return &Adapter{
+		clientID:     "appkey",
+		clientSecret: "secret",
+		robotCode:    "appkey",
+		apiBase:      ts.URL,
+		http:         ts.Client(),
+		webhooks:     make(map[string]webhookEntry),
+	}
+}
+
+// TestSendText_ProactiveUserPush covers the standalone path: no
+// sessionWebhook cached, a bare user id routes to the one-on-one batch API,
+// and the first token fetch happens synchronously.
+func TestSendText_ProactiveUserPush(t *testing.T) {
+	stub := &stubAPI{}
+	ts := stub.server(t)
+	defer ts.Close()
+
+	a := testAdapter(ts)
+	if res := a.SendText("staff007", "task done", ""); !res.OK {
+		t.Fatalf("send: %s", res.Error)
+	}
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.sends) != 1 {
+		t.Fatalf("sends = %d, want 1", len(stub.sends))
+	}
+	got := stub.sends[0]
+	if got.path != "/v1.0/robot/oToMessages/batchSend" {
+		t.Fatalf("path = %s", got.path)
+	}
+	users, _ := got.body["userIds"].([]any)
+	if len(users) != 1 || users[0] != "staff007" {
+		t.Errorf("userIds = %v, want [staff007]", got.body["userIds"])
+	}
+	if got.body["robotCode"] != "appkey" || got.body["msgKey"] != "sampleMarkdown" {
+		t.Errorf("body = %v", got.body)
+	}
+}
+
+// TestSendText_ProactiveGroupPush routes a cid-prefixed openConversationId to
+// the group API.
+func TestSendText_ProactiveGroupPush(t *testing.T) {
+	stub := &stubAPI{}
+	ts := stub.server(t)
+	defer ts.Close()
+
+	a := testAdapter(ts)
+	if res := a.SendText("cidAbC123==", "task done", ""); !res.OK {
+		t.Fatalf("send: %s", res.Error)
+	}
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.sends) != 1 || stub.sends[0].path != "/v1.0/robot/groupMessages/send" {
+		t.Fatalf("sends = %+v, want one group send", stub.sends)
+	}
+	if stub.sends[0].body["openConversationId"] != "cidAbC123==" {
+		t.Errorf("openConversationId = %v", stub.sends[0].body["openConversationId"])
+	}
+}
+
+// TestSendText_PrefersSessionWebhook keeps the reply path on the free
+// webhook channel when one is cached and fresh.
+func TestSendText_PrefersSessionWebhook(t *testing.T) {
+	var webhookHits int
+	wh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		webhookHits++
+		_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0})
+	}))
+	defer wh.Close()
+
+	stub := &stubAPI{}
+	ts := stub.server(t)
+	defer ts.Close()
+
+	a := testAdapter(ts)
+	a.webhooks["chat1"] = webhookEntry{URL: wh.URL, ExpiresAtMs: time.Now().Add(time.Hour).UnixMilli()}
+
+	if res := a.SendText("chat1", "hello", ""); !res.OK {
+		t.Fatalf("send: %s", res.Error)
+	}
+	if webhookHits != 1 {
+		t.Fatalf("webhook hits = %d, want 1", webhookHits)
+	}
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.sends) != 0 {
+		t.Fatalf("robot api sends = %d, want 0", len(stub.sends))
+	}
+}

--- a/internal/channel/notify.go
+++ b/internal/channel/notify.go
@@ -6,11 +6,12 @@ import "fmt"
 // the platform adapter from ~/.octo/channels.yml on the fly. It exists for
 // proactive pushes (e.g. scheduled-task results) from processes that don't run
 // inbound adapters, such as octo serve. Feishu sends with app credentials
-// alone (tenant token → REST). Weixin sends with the on-disk login credentials
-// plus the chat's last context_token from the write-through store the receive
-// loop maintains — so the target user must have messaged the bot at least
-// once. DingTalk needs a session webhook from a prior inbound message and
-// cannot push this way; that surfaces as an adapter error.
+// alone (tenant token → REST). DingTalk sends through the proactive robot
+// APIs (app credentials; needs the robot-message-send permission, and the
+// chat id must be a staff id or a "cid…" openConversationId). Weixin sends
+// with the on-disk login credentials plus the chat's last context_token from
+// the write-through store the receive loop maintains — so the target user
+// must have messaged the bot at least once.
 func SendOnce(platform, chatID, text string) error {
 	cfg, err := LoadConfig()
 	if err != nil {

--- a/internal/skills/defaults/cron-task-creator/SKILL.md
+++ b/internal/skills/defaults/cron-task-creator/SKILL.md
@@ -119,13 +119,18 @@ curl -s -X PATCH  http://127.0.0.1:8080/api/cron-tasks/{name} \
   creation time by the API, but a hand-written JSON file with a bad expression
   fails silently at load (logged to stderr only) — double-check the 6-field
   format when writing files directly.
-- **IM notification (`notify`) requires the platform to support proactive
-  sends.** Feishu works with app credentials alone (`~/.octo/channels.yml`);
-  its `chat_id` looks like `oc_…` — get it from the chat's settings or by
-  messaging the bot and reading the server log. Weixin works too: `chat_id`
-  is the iLink user id, and the user must have messaged the bot at least once
-  (the receive loop persists each user's latest `context_token` to
-  `~/.octo/weixin-contexts.json`, which the push reads; a long-stale token may
-  be rejected by WeChat — chatting with the bot refreshes it). DingTalk cannot
-  push without a prior inbound webhook; a `notify` pointing at it fails
-  (logged on the server, run unaffected).
+- **IM notification (`notify`) — per-platform `chat_id` rules.** All three
+  platforms can be pushed to; a failed push is logged on the server and never
+  affects the run.
+  - **Feishu**: works with app credentials alone (`~/.octo/channels.yml`);
+    `chat_id` looks like `oc_…` — get it from the chat's settings or by
+    messaging the bot and reading the server log.
+  - **DingTalk**: pushes via the proactive robot APIs. `chat_id` is a staff
+    id (one-on-one) or a `cid…` openConversationId (group) — a DM's
+    conversation id does NOT work, use the user's staff id. Requires the
+    "robot message send" permission on the app in the DingTalk admin console.
+  - **Weixin**: `chat_id` is the iLink user id, and the user must have
+    messaged the bot at least once (the receive loop persists each user's
+    latest `context_token` to `~/.octo/weixin-contexts.json`, which the push
+    reads; a long-stale token may be rejected by WeChat — chatting with the
+    bot refreshes it).


### PR DESCRIPTION
## Problem

DingTalk was the one platform a scheduled task's `notify` target couldn't reach. The adapter's only send channel was the `sessionWebhook` carried by each inbound message — ephemeral (expires), in-memory, and nonexistent in `octo serve`, which runs no inbound adapters.

## Design

DingTalk's open platform has proactive robot send APIs that need no webhook, just the app's access token and the robot-message-send permission ([单聊](https://open.dingtalk.com/document/development/the-application-robot-in-the-enterprise-sends-a-single-chat), [机器人发送消息](https://open.dingtalk.com/document/dingstart/robot-reply-and-send-messages)):

- `SendText` prefers the cached sessionWebhook when fresh (free, no extra permission), and falls back to the proactive APIs otherwise — which is what the standalone `channel.SendOnce` path from `octo serve` always hits.
- Routing by chat id shape: `cid…` (openConversationId) → `POST /v1.0/robot/groupMessages/send`; anything else is a staff id → `POST /v1.0/robot/oToMessages/batchSend`. A DM's conversation id does not work for proactive pushes — the target must be the user's staff id; documented in the cron-task-creator SKILL.md.
- First token fetch is synchronous now (same fix feishu got in #553): the old async-only `getToken` returned an empty token on a fresh adapter, so a standalone send would have carried an empty auth header.
- `robotCode` defaults to `client_id` (they coincide for enterprise-internal robots) and can be overridden with the `robot_code` config key. `apiBase` is per-adapter for testability.

With this, all three platforms accept task-result pushes:

```json
"notify": [
  {"platform": "feishu",   "chat_id": "oc_xxx"},
  {"platform": "dingtalk", "chat_id": "<staffId 或 cid...>"},
  {"platform": "weixin",   "chat_id": "<ilink_user_id>"}
]
```

## Verification

- `TestSendText_ProactiveUserPush` / `TestSendText_ProactiveGroupPush` — full standalone path against a stub API: synchronous token fetch, correct endpoint routing, token header, body shape.
- `TestSendText_PrefersSessionWebhook` — fresh webhook still wins; robot API untouched.
- `go test -race ./...` green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)