### PR TITLE
fix(web): show the interrupt button while a turn is running

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -102,7 +102,7 @@ func (srv *Server) toSessionItem(s *agent.Session, source, agentProfile string) 
 		CreatedAt:       s.CreatedAt,
 		UpdatedAt:       updated,
 		Model:           s.Model,
-		Status:          "idle",
+		Status:          srv.sessionStatus(s.ID),
 		Source:          source,
 		AgentProfile:    agentProfile,
 		Pinned:          false,

--- a/internal/server/session_status_test.go
+++ b/internal/server/session_status_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// TestSessionStatus_ReflectsRunningTurn guards the interrupt-button contract:
+// the frontend shows the stop button only while status == "running", and a
+// session reports "running" exactly while its turn's interrupt cancel func is
+// registered.
+func TestSessionStatus_ReflectsRunningTurn(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.initWS()
+	srv.interrupts = make(map[string]context.CancelFunc)
+
+	if got := srv.sessionStatus("s1"); got != "idle" {
+		t.Fatalf("status before turn = %q, want idle", got)
+	}
+
+	_, cancel := context.WithCancel(context.Background())
+	srv.registerInterrupt("s1", cancel)
+	if got := srv.sessionStatus("s1"); got != "running" {
+		t.Fatalf("status during turn = %q, want running", got)
+	}
+	if got := srv.sessionStatus("other"); got != "idle" {
+		t.Fatalf("status of other session = %q, want idle", got)
+	}
+
+	// handleWSInterrupt cancels and deregisters — status flips back to idle.
+	srv.handleWSInterrupt("s1")
+	if got := srv.sessionStatus("s1"); got != "idle" {
+		t.Fatalf("status after interrupt = %q, want idle", got)
+	}
+
+	// The session list payload carries the live status too (page reload
+	// mid-turn must still show the button).
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	_, cancel2 := context.WithCancel(context.Background())
+	srv.registerInterrupt(sess.ID, cancel2)
+	defer cancel2()
+	item := srv.toSessionItem(sess, "manual", "")
+	if item.Status != "running" {
+		t.Fatalf("session list status = %q, want running", item.Status)
+	}
+}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -39,7 +39,7 @@ func (s *Server) listSessionsBrief() []wsSessionInfo {
 		out = append(out, wsSessionInfo{
 			ID:              sess.ID,
 			Name:            sess.DisplayTitle(),
-			Status:          "idle",
+			Status:          s.sessionStatus(sess.ID),
 			CreatedAt:       sess.CreatedAt.UnixMilli(),
 			Source:          source,
 			Model:           sess.Model,
@@ -477,6 +477,14 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		s.interruptMu.Unlock()
 	}()
 
+	// Tell the frontend the turn started: "running" is what shows the
+	// interrupt button (the turn-end paths broadcast "idle" to hide it).
+	s.wsHub.broadcast(sess.ID, map[string]any{
+		"type":       "session_update",
+		"session_id": sess.ID,
+		"status":     "running",
+	})
+
 	a := s.buildAgent(sess)
 	if len(blocks) > 0 {
 		// Image attachments fold into the same user turn as the text when
@@ -896,6 +904,19 @@ func (s *Server) registerInterrupt(sessionID string, cancel context.CancelFunc) 
 	s.interruptMu.Lock()
 	s.interrupts[sessionID] = cancel
 	s.interruptMu.Unlock()
+}
+
+// sessionStatus returns the status string the frontend keys on ("running"
+// shows the interrupt button; anything else hides it). A registered interrupt
+// cancel func exists exactly for the duration of a turn — read via its own
+// mutex, unlike the turnRunning map which is guarded by per-session turnLocks.
+func (s *Server) sessionStatus(sessionID string) string {
+	s.interruptMu.Lock()
+	defer s.interruptMu.Unlock()
+	if _, ok := s.interrupts[sessionID]; ok {
+		return "running"
+	}
+	return "idle"
 }
 
 // Request confirmation from user (blocks until user responds in browser or ctx


### PR DESCRIPTION
## Summary

The web chat's stop button has existed in the frontend all along — `#btn-interrupt` in index.html, red-square CSS, click handler sending the WS `interrupt` message, and `updateStatusBar` toggling visibility on `status === "running"`. It just never appeared, because the server never said "running":

- Turn start only broadcast a `progress` event — no `session_update` with `status: "running"`.
- Both session list payloads (HTTP `toSessionItem`, WS `wsSessionInfo`) hardcoded `Status: "idle"`.

So the only status the frontend ever saw was "idle" and the button stayed `display:none` forever.

## Changes

- `runAgentTurn` broadcasts `session_update {status:"running"}` right after registering the turn's interrupt cancel func; the existing turn-end paths already broadcast `"idle"`, which hides the button again (including after an interrupt — the canceled turn still reaches the final idle broadcast).
- New `sessionStatus(sessionID)` helper derives live status from the `interrupts` map (a registered cancel func exists exactly for the duration of a turn; it has its own mutex, unlike the `turnRunning` map which is guarded by per-session turn locks). Used by both session list payloads so a page reload or session switch mid-turn also shows the button.

No frontend changes needed.

## Test plan

- New `TestSessionStatus_ReflectsRunningTurn`: idle before turn, "running" while an interrupt is registered, back to idle after `handleWSInterrupt`, and the HTTP session item carries "running" mid-turn.
- `make fmt-check`, `go vet ./...`, `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)