### PR TITLE
feat(skills): bridge Claude Code tool names when loading external skills

### DIFF
--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -332,19 +332,39 @@ func RenderManifest(r *Registry) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
+// ccCompatNote bridges skills authored for Claude Code — the ecosystem most
+// SKILL.md files are written for — onto octo's toolbelt at load time. A static
+// note beats rewriting the skill on install: rewriting can't tell a tool
+// reference from a string inside a bundled script, and for source-available
+// skills a rewrite is a derivative work their license forbids. Injected for
+// user/project skills only; octo-native defaults don't need it.
+const ccCompatNote = "This skill may have been written for Claude Code. In this environment, " +
+	"map tool references accordingly: Bash → terminal; Read/Write/Edit → read_file / " +
+	"write_file / edit_file; Grep/Glob → grep / glob; Task/Agent → sub_agent; " +
+	"WebFetch/WebSearch → web_fetch / web_search. There is no persistent working " +
+	"directory across terminal calls — use absolute paths, or chain `cd … && …` " +
+	"inside one command. If the skill depends on a Claude Code feature with no " +
+	"equivalent here (hooks, plan mode, output styles), tell the user instead of " +
+	"improvising."
+
 // RenderSkill produces the text handed to the model when a skill is loaded —
 // via the `skill` tool (model-initiated) or a /<name> trigger (user-initiated).
 // It prefixes a one-line location header so the model can resolve files the
 // SKILL.md references (scripts, templates, reference docs bundled in the skill
 // directory) with its file tools, then the body, then any trailing user args.
 // Without the header a relative reference like "see references/api.md" would be
-// resolved against the project cwd and miss.
+// resolved against the project cwd and miss. Non-default skills additionally
+// get the Claude Code → octo tool-name bridging note.
 func RenderSkill(s Skill, args string) string {
 	var b strings.Builder
 	if s.Dir != "" {
 		fmt.Fprintf(&b, "[skill %q — bundled files live in: %s\n", s.Name, s.Dir)
 		b.WriteString("Resolve any paths this skill references (scripts, templates, reference docs) " +
-			"against that directory and read them with your file tools.]\n\n")
+			"against that directory and read them with your file tools.")
+		if s.Source != "default" {
+			b.WriteString("\n" + ccCompatNote)
+		}
+		b.WriteString("]\n\n")
 	}
 	b.WriteString(s.Body)
 	if args != "" {

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -222,6 +222,17 @@ func TestRenderSkill(t *testing.T) {
 	if !strings.HasSuffix(got, "Read references/spec.md") {
 		t.Errorf("body should follow the header; got:\n%s", got)
 	}
+
+	// User/project skills get the Claude Code → octo bridging note; octo-native
+	// defaults don't.
+	u := Skill{Name: "ext", Body: "B", Dir: "/d", Source: "user"}
+	if got := RenderSkill(u, ""); !strings.Contains(got, "Bash → terminal") {
+		t.Errorf("user skill should carry the compat note; got:\n%s", got)
+	}
+	d := Skill{Name: "wt", Body: "B", Dir: "/d", Source: "default"}
+	if got := RenderSkill(d, ""); strings.Contains(got, "Bash → terminal") {
+		t.Errorf("default skill should not carry the compat note; got:\n%s", got)
+	}
 }
 
 func TestSetDisabled(t *testing.T) {


### PR DESCRIPTION
## Why

Skills installed via `octo skills add` (#560) or the web Import endpoint (#564) — and skills symlinked from `~/.claude/skills` — are mostly authored for Claude Code. The SKILL.md format is identical, but the content references Claude Code's toolbelt ("use the **Edit tool**", "the **Bash tool**", "spawn an **Agent**"). octo's tools are named differently (`edit_file`, `terminal`, `sub_agent`), and octo has no persistent session cwd. The model can often guess the mapping; this makes it deterministic.

Concretely: the four anthropics document skills contain 4 "Edit tool" references; community skills reference Bash/Read/Write/Task freely.

## What

`RenderSkill` — the single point where a skill body is handed to the model (both the `skill` tool and `/<name>` triggers) — now appends a static bridging note to the location header for **user/project** skills:

> This skill may have been written for Claude Code. … Bash → terminal; Read/Write/Edit → read_file / write_file / edit_file; Grep/Glob → grep / glob; Task/Agent → sub_agent; WebFetch/WebSearch → web_fetch / web_search. There is no persistent working directory across terminal calls… If the skill depends on a Claude Code feature with no equivalent here (hooks, plan mode), tell the user instead of improvising.

Default skills are octo-native and skip the note.

## Why not rewrite the skill at install time

- A textual rewrite can't reliably distinguish a tool reference in prose from the same string inside a bundled script or example — corruption risk with no verification.
- For source-available skills (e.g. anthropics document skills), a rewrite is a derivative work their license forbids; verbatim copies are the only compliant form. Installed bytes stay untouched — the bridging lives in the prompt.
- One note covers every external skill, past and future, including symlinked ones that never went through an installer.

## Verification

`TestRenderSkill` extended: user-source skills carry the note, default-source skills don't, Dir-less rendering unchanged. `go test -race` on skills/tools/cmd packages, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)