### PR TITLE
feat(wecom): group-robot webhook fallback so task notify can push

### DIFF
--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -17,12 +17,14 @@
 package wecom
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -54,15 +56,23 @@ const (
 	cfgBotID        = "bot_id"
 	cfgSecret       = "secret"
 	cfgAllowedUsers = "allowed_users"
+	// Group-robot webhook for proactive pushes (either the full URL or just
+	// the key from the webhook URL the WeCom admin shows).
+	cfgWebhookURL = "webhook_url"
+	cfgWebhookKey = "webhook_key"
 	// cfgWSURL is a test seam, not user-facing config.
 	cfgWSURL = "ws_url"
 )
+
+// defaultWebhookBase is the group-robot webhook endpoint webhook_key expands to.
+const defaultWebhookBase = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send"
 
 // Adapter implements channel.Adapter for WeCom intelligent robots.
 type Adapter struct {
 	botID        string
 	secret       string
 	wsURL        string
+	webhookURL   string
 	allowedUsers map[string]bool
 
 	conn   *websocket.Conn
@@ -71,15 +81,28 @@ type Adapter struct {
 	pendingAcks map[string]chan *wsFrame
 	ackMu       sync.Mutex
 
+	http   *http.Client
 	cancel context.CancelFunc
 }
 
-// New creates a WeCom adapter from platform config.
+// New creates a WeCom adapter from platform config. The aibot credentials
+// (bot_id + secret) drive the interactive WebSocket channel; a group-robot
+// webhook (webhook_url / webhook_key) drives proactive pushes when the
+// WebSocket isn't connected — e.g. channel.SendOnce from octo serve, which
+// runs no inbound adapters. Either is sufficient on its own.
 func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
 	botID, _ := cfg[cfgBotID].(string)
 	secret, _ := cfg[cfgSecret].(string)
-	if botID == "" || secret == "" {
-		return nil, fmt.Errorf("wecom: bot_id and secret are required")
+
+	webhookURL, _ := cfg[cfgWebhookURL].(string)
+	if webhookURL == "" {
+		if key, _ := cfg[cfgWebhookKey].(string); key != "" {
+			webhookURL = defaultWebhookBase + "?key=" + key
+		}
+	}
+
+	if (botID == "" || secret == "") && webhookURL == "" {
+		return nil, fmt.Errorf("wecom: bot_id+secret (aibot) or webhook_key/webhook_url (group robot) is required")
 	}
 
 	wsURL, _ := cfg[cfgWSURL].(string)
@@ -100,8 +123,10 @@ func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
 		botID:        botID,
 		secret:       secret,
 		wsURL:        wsURL,
+		webhookURL:   webhookURL,
 		allowedUsers: allowed,
 		pendingAcks:  make(map[string]chan *wsFrame),
+		http:         &http.Client{Timeout: 30 * time.Second},
 	}, nil
 }
 
@@ -111,6 +136,9 @@ func (a *Adapter) Platform() string { return platformName }
 // Start connects to the WeCom WebSocket and blocks until ctx is cancelled.
 // Transient connection errors reconnect; an auth rejection aborts.
 func (a *Adapter) Start(ctx context.Context, onMessage func(channel.InboundEvent)) error {
+	if a.botID == "" || a.secret == "" {
+		return fmt.Errorf("wecom: bot_id and secret are required for the interactive channel (webhook-only config can still push notifications)")
+	}
 	ctx, a.cancel = context.WithCancel(ctx)
 
 	for {
@@ -146,8 +174,19 @@ func (a *Adapter) Stop() error {
 	return nil
 }
 
-// SendText sends a markdown message via aibot_send_msg.
+// SendText sends a markdown message via aibot_send_msg when the WebSocket is
+// connected. Without a connection — channel.SendOnce from octo serve, which
+// runs no inbound adapters — it falls back to the group-robot webhook, which
+// delivers to the webhook's bound group (chatID cannot select a chat there).
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
+	a.connMu.Lock()
+	connected := a.conn != nil
+	a.connMu.Unlock()
+
+	if !connected {
+		return a.sendWebhook(text)
+	}
+
 	_, err := a.sendFrameAndWait("aibot_send_msg", map[string]any{
 		"chatid":   chatID,
 		"msgtype":  "markdown",
@@ -155,6 +194,34 @@ func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 	})
 	if err != nil {
 		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	return channel.SendResult{OK: true}
+}
+
+// sendWebhook posts a markdown message to the configured group-robot webhook.
+func (a *Adapter) sendWebhook(text string) channel.SendResult {
+	if a.webhookURL == "" {
+		return channel.SendResult{OK: false, Error: "not connected and no webhook_key/webhook_url configured for proactive pushes"}
+	}
+	body, _ := json.Marshal(map[string]any{
+		"msgtype":  "markdown",
+		"markdown": map[string]string{"content": text},
+	})
+	resp, err := a.http.Post(a.webhookURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		ErrCode int    `json:"errcode"`
+		ErrMsg  string `json:"errmsg"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("bad webhook response: %v", err)}
+	}
+	if r.ErrCode != 0 {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("webhook error %d: %s", r.ErrCode, r.ErrMsg)}
 	}
 	return channel.SendResult{OK: true}
 }
@@ -176,12 +243,25 @@ func (a *Adapter) SendTyping(chatID, contextToken string) error { return nil }
 
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
-	var errs []string
-	if v, _ := cfg[cfgBotID].(string); v == "" {
-		errs = append(errs, "bot_id is required")
+	botID, _ := cfg[cfgBotID].(string)
+	secret, _ := cfg[cfgSecret].(string)
+	whURL, _ := cfg[cfgWebhookURL].(string)
+	whKey, _ := cfg[cfgWebhookKey].(string)
+
+	hasAibot := botID != "" || secret != ""
+	hasWebhook := whURL != "" || whKey != ""
+	if !hasAibot && !hasWebhook {
+		return []string{"bot_id+secret (aibot) or webhook_key/webhook_url (group robot) is required"}
 	}
-	if v, _ := cfg[cfgSecret].(string); v == "" {
-		errs = append(errs, "secret is required")
+
+	var errs []string
+	if hasAibot {
+		if botID == "" {
+			errs = append(errs, "bot_id is required")
+		}
+		if secret == "" {
+			errs = append(errs, "secret is required")
+		}
 	}
 	return errs
 }

--- a/internal/channel/adapters/wecom/wecom_test.go
+++ b/internal/channel/adapters/wecom/wecom_test.go
@@ -2,6 +2,7 @@ package wecom
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -244,10 +245,76 @@ func TestSendText_WaitsForAck(t *testing.T) {
 
 func TestValidateConfig(t *testing.T) {
 	a := &Adapter{}
-	if errs := a.ValidateConfig(channel.PlatformConfig{}); len(errs) != 2 {
-		t.Fatalf("expected 2 errors, got %v", errs)
+	if errs := a.ValidateConfig(channel.PlatformConfig{}); len(errs) != 1 {
+		t.Fatalf("expected 1 error for empty config, got %v", errs)
 	}
 	if errs := a.ValidateConfig(channel.PlatformConfig{"bot_id": "x", "secret": "y"}); len(errs) != 0 {
 		t.Fatalf("expected no errors, got %v", errs)
+	}
+	// Webhook-only (push notifications) is a valid configuration.
+	if errs := a.ValidateConfig(channel.PlatformConfig{"webhook_key": "k"}); len(errs) != 0 {
+		t.Fatalf("expected no errors for webhook-only, got %v", errs)
+	}
+	// A half-filled aibot pair is flagged even when the webhook is present.
+	if errs := a.ValidateConfig(channel.PlatformConfig{"bot_id": "x", "webhook_key": "k"}); len(errs) != 1 {
+		t.Fatalf("expected 1 error for half aibot pair, got %v", errs)
+	}
+}
+
+// TestSendText_WebhookFallback covers the proactive-push path used by
+// channel.SendOnce from octo serve: no WebSocket connection, message goes to
+// the configured group-robot webhook.
+func TestSendText_WebhookFallback(t *testing.T) {
+	var got map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("key") != "k1" {
+			t.Errorf("key = %q, want k1", r.URL.Query().Get("key"))
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "errmsg": "ok"})
+	}))
+	defer ts.Close()
+
+	a, err := New(channel.PlatformConfig{"webhook_url": ts.URL + "?key=k1"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	res := a.SendText("ignored-chat", "task done", "")
+	if !res.OK {
+		t.Fatalf("send: %s", res.Error)
+	}
+	if got["msgtype"] != "markdown" {
+		t.Errorf("msgtype = %v", got["msgtype"])
+	}
+	md, _ := got["markdown"].(map[string]any)
+	if md["content"] != "task done" {
+		t.Errorf("content = %v", md["content"])
+	}
+}
+
+func TestSendText_WebhookErrcode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 93000, "errmsg": "invalid webhook url"})
+	}))
+	defer ts.Close()
+
+	a, err := New(channel.PlatformConfig{"webhook_url": ts.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if res := a.SendText("c", "x", ""); res.OK {
+		t.Fatal("want failure on non-zero errcode")
+	}
+}
+
+func TestSendText_NoConnectionNoWebhook(t *testing.T) {
+	a, err := New(channel.PlatformConfig{"bot_id": "x", "secret": "y"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res := a.SendText("c", "x", "")
+	if res.OK {
+		t.Fatal("want failure when not connected and no webhook configured")
 	}
 }

--- a/internal/channel/notify.go
+++ b/internal/channel/notify.go
@@ -5,13 +5,13 @@ import "fmt"
 // SendOnce delivers a single outbound message to an IM chat by constructing
 // the platform adapter from ~/.octo/channels.yml on the fly. It exists for
 // proactive pushes (e.g. scheduled-task results) from processes that don't run
-// inbound adapters, such as octo serve. Feishu sends with app credentials
-// alone (tenant token → REST). DingTalk sends through the proactive robot
-// APIs (app credentials; needs the robot-message-send permission, and the
-// chat id must be a staff id or a "cid…" openConversationId). Weixin sends
-// with the on-disk login credentials plus the chat's last context_token from
-// the write-through store the receive loop maintains — so the target user
-// must have messaged the bot at least once.
+// inbound adapters, such as octo serve. Every registered platform can be
+// pushed to, each with its own credential/target rules (documented in the
+// cron-task-creator skill): Feishu and DingTalk use app credentials over
+// REST, Telegram and Discord use their bot tokens, WeCom needs a group-robot
+// webhook_key, and Weixin needs the on-disk login plus a context_token from
+// the write-through store — so the target user must have messaged the bot at
+// least once.
 func SendOnce(platform, chatID, text string) error {
 	cfg, err := LoadConfig()
 	if err != nil {

--- a/internal/server/channels_handler.go
+++ b/internal/server/channels_handler.go
@@ -188,7 +188,7 @@ func (s *Server) handleAvailableChannels(w http.ResponseWriter, r *http.Request)
 		"discord":  {"bot_token", "allowed_users"},
 		"feishu":   {"app_id", "app_secret", "domain", "allowed_users"},
 		"telegram": {"bot_token", "base_url", "parse_mode", "allowed_users"},
-		"wecom":    {"bot_id", "secret", "allowed_users"},
+		"wecom":    {"bot_id", "secret", "webhook_key", "allowed_users"},
 		"weixin":   {"base_url", "cred_path"},
 	}
 

--- a/internal/skills/defaults/cron-task-creator/SKILL.md
+++ b/internal/skills/defaults/cron-task-creator/SKILL.md
@@ -134,3 +134,12 @@ curl -s -X PATCH  http://127.0.0.1:8080/api/cron-tasks/{name} \
     latest `context_token` to `~/.octo/weixin-contexts.json`, which the push
     reads; a long-stale token may be rejected by WeChat — chatting with the
     bot refreshes it).
+  - **Telegram**: `chat_id` is the Telegram chat id (user, group, or
+    channel); the bot must be able to message it (user has started the bot,
+    or bot is a member of the group/channel).
+  - **Discord**: `chat_id` is the channel id; the bot needs the Send
+    Messages permission in that channel.
+  - **WeCom**: pushes go through a group-robot webhook — set `webhook_key`
+    (or full `webhook_url`) in the channel config. The webhook is bound to
+    one group, so `chat_id` is ignored for pushes (use the group name as a
+    label).


### PR DESCRIPTION
## Problem

With #558 merging the Telegram/Discord/WeCom adapters and #553/#555/#565 wiring task-result pushes, the remaining question was which of the three migrated platforms can actually receive a `notify` push from `octo serve` (which runs no inbound adapters):

- **Telegram / Discord — already work.** Their `SendText` is plain REST with a bot token built entirely in `New()`; the standalone `channel.SendOnce` path reaches them as-is. No code change needed.
- **WeCom — could not.** The aibot protocol sends `aibot_send_msg` frames over the live WebSocket owned by `octo channel start` and waits for an ack; with no connection, `SendText` failed with "not connected".

## Fix

WeCom config accepts a group-robot webhook ([消息推送配置说明](https://developer.work.weixin.qq.com/document/path/91770)) — `webhook_key` (expands to `https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=…`) or a full `webhook_url`:

- `SendText` keeps the aibot frame path while the WebSocket is connected and falls back to the webhook otherwise — the path `channel.SendOnce` always hits.
- Webhook-only config is valid on its own (push-only); `Start` still requires `bot_id`+`secret` and says so explicitly. `ValidateConfig` enforces "aibot pair complete OR webhook present".
- The webhook is bound to one group, so `chat_id` can't select a chat on this path — documented in the cron-task-creator SKILL.md along with Telegram (`chat_id` = chat id) and Discord (`chat_id` = channel id, needs Send Messages permission) rules.
- Web channel panel gains the `webhook_key` field for wecom.

With this, all six platforms accept task-result pushes.

## Verification

- `TestSendText_WebhookFallback` (key + markdown body asserted against a stub), `TestSendText_WebhookErrcode`, `TestSendText_NoConnectionNoWebhook`, updated `TestValidateConfig` (webhook-only valid, half aibot pair flagged).
- `go test -race ./...` green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)