### PR TITLE
feat(skills): ship find-skills as a default skill

### DIFF
--- a/internal/skills/defaults/find-skills/LICENSE.txt
+++ b/internal/skills/defaults/find-skills/LICENSE.txt
@@ -1,0 +1,24 @@
+This skill is adapted from "find-skills" in vercel-labs/skills
+(https://github.com/vercel-labs/skills), © Vercel, Inc., licensed under MIT.
+Modifications for octo (install commands, tool names, skill-creator pointer)
+© the octo-agent contributors, MIT.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/internal/skills/defaults/find-skills/SKILL.md
+++ b/internal/skills/defaults/find-skills/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: find-skills
+description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+---
+
+# Find Skills
+
+This skill helps you discover skills from the open agent skills ecosystem and install them into octo.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## Where Skills Live
+
+Skills are modular packages of instructions and resources in a shared SKILL.md format. octo reads the same format as Claude Code and the skills.sh ecosystem, so most published skills work here.
+
+- **Browse and search:** https://skills.sh/ — the ecosystem index, ranked by installs
+- **Search CLI (optional, needs Node.js):** `npx skills find [query]`
+- **Install into octo:** `octo skills add <owner>/<repo>/<path-in-repo>` (or a github.com tree URL)
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Check the Leaderboard First
+
+Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) (use web_fetch) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
+
+For example, top skills for web development include:
+
+- `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
+- `anthropics/skills` — Frontend design, document processing (100K+ installs)
+
+### Step 3: Search for Skills
+
+If the leaderboard doesn't cover the user's need, search by keyword — `web_fetch` on `https://skills.sh/search?q=[query]`, or `npx skills find [query]` in the terminal when Node.js is available.
+
+For example:
+
+- User asks "how do I make my React app faster?" → search `react performance`
+- User asks "can you help me with PR reviews?" → search `pr review`
+- User asks "I need to create a changelog" → search `changelog`
+
+### Step 4: Verify Quality Before Recommending
+
+**Do not recommend a skill based solely on search results.** Always verify:
+
+1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
+2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
+3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
+4. **License** — Check the source repo's license before installing; some skills (e.g. the anthropics document skills) are source-available with redistribution limits. Installing for the user's own use is fine; flag anything beyond that.
+
+### Step 5: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install count and source
+3. The install command they can run
+4. A link to learn more at skills.sh
+
+skills.sh refers to a skill as `owner/repo@skill-name`; octo installs by the skill's **directory path inside the repo**. Most repos keep skills under `skills/<name>/`. Confirm the path by browsing the repo (web_fetch the GitHub page) before giving the command.
+
+Example response:
+
+```
+I found a skill that might help! The "react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+(185K installs)
+
+To install it into octo:
+octo skills add vercel-labs/agent-skills/skills/react-best-practices
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
+```
+
+### Step 6: Offer to Install
+
+If the user wants to proceed, install it for them from the terminal:
+
+```bash
+octo skills add <owner>/<repo>/<path-to-skill-dir>
+```
+
+This installs to the user level (`~/.octo/skills`); add `--force` to replace an existing skill of the same name. Verify with `octo skills list` — the skill is immediately loadable in this session and triggers as `/<name>` in new ones.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with octo's `/skill-creator`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill —
+just say "/skill-creator" and I'll walk you through it.
+```


### PR DESCRIPTION
## What

Adds `find-skills` to the embedded default skill set — adapted from [vercel-labs/skills](https://github.com/vercel-labs/skills) `skills/find-skills` (**MIT**, unlike the anthropics document skills; attribution + full license text kept in `LICENSE.txt` inside the skill directory).

The skill teaches the model to act as a skill-discovery assistant: when the user asks "is there a skill for X" / "how do I do X", check the [skills.sh](https://skills.sh/) leaderboard and keyword search, vet candidates (install count, source reputation, GitHub stars, license), present options, and install on request.

## Adaptations for octo (rest kept verbatim)

- **Install command**: upstream uses `npx skills add <owner/repo@skill> -g -y`, which installs into Claude Code's skill roots — octo would never discover those. Replaced with `octo skills add <owner>/<repo>/<path-in-repo>` (#560), including guidance to resolve the `owner/repo@skill` ecosystem reference to the actual repo directory path before giving the command, plus `--force` and `octo skills list` verification.
- **Search**: `npx skills find` kept as the optional Node.js path; added `web_fetch` on `https://skills.sh/search?q=…` (URL verified, HTTP 200) so discovery works without Node.
- **License vetting step added**: learned from the anthropics document skills — check the source repo's license before recommending installs.
- **Skill creation pointer**: `npx skills init` → octo's existing `/skill-creator` default skill.

## Verification

`go test ./internal/skills/` green; built the binary, `octo skills update` + `octo skills list` shows `/find-skills [default]` materialized and discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)