### PR TITLE
feat(web): make the running-tool indicator clearly visible

### DIFF
--- a/internal/server/static/app.css
+++ b/internal/server/static/app.css
@@ -2144,7 +2144,32 @@ body {
 .tool-item-status.ok     { color: var(--color-success); }
 .tool-item-status.failed { color: var(--color-error); }
 .tool-item-status.err    { color: var(--color-error); }
-.tool-item-status.running { color: var(--color-accent-primary); animation: pulse 1.2s infinite; }
+/* In-flight tool: spinner at the row end instead of a faint pulsing "…". */
+.tool-item-status.running {
+  align-self: center;
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 2px solid var(--color-accent-primary);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: pending-spin 0.8s linear infinite;
+}
+/* The whole running row glows and its gear spins, so the active tool stays
+   visible even when the row sits at the very bottom of the message stream. */
+.tool-item.running {
+  background: var(--color-accent-soft);
+  box-shadow: inset 2px 0 0 var(--color-accent-primary);
+  animation: tool-running-glow 1.2s ease-in-out infinite;
+}
+.tool-item.running .tool-item-gear {
+  display: inline-block;
+  color: var(--color-accent-primary);
+  animation: pending-spin 1.6s linear infinite;
+}
+@keyframes tool-running-glow {
+  0%, 100% { background: var(--color-accent-soft); }
+  50%      { background: color-mix(in srgb, var(--color-accent-primary) 22%, transparent); }
+}
 .tool-item-stdout {
   display: none;
   margin: 0.25rem 0 2px 0;

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -1042,23 +1042,26 @@ const Sessions = (() => {
   // Build one .tool-item row element.
   function _makeToolItem(name, args, summary) {
     const item = document.createElement("div");
-    item.className = "tool-item";
+    // "running" drives the in-flight visuals (row glow, spinning gear,
+    // spinner); _applyResultToItem removes it when the result lands.
+    item.className = "tool-item running";
 
     // Use backend-provided summary when available, fall back to client-side summarise
     const argSummary = summary || _summariseArgs(name, args);
 
     // When a structured summary is available, show it as the primary label (no redundant tool name).
     // Otherwise show the raw tool name + arg summary as before.
+    const gear = `<span class="tool-item-gear">⚙</span>`;
     const label = summary
-      ? `<span class="tool-item-name">⚙ ${escapeHtml(summary)}</span>`
-      : `<span class="tool-item-name">⚙ ${escapeHtml(name)}</span>` +
+      ? `<span class="tool-item-name">${gear} ${escapeHtml(summary)}</span>`
+      : `<span class="tool-item-name">${gear} ${escapeHtml(name)}</span>` +
         (argSummary ? `<span class="tool-item-arg">${escapeHtml(argSummary)}</span>` : "");
 
     item.innerHTML =
       `<div class="tool-item-header">` +
         `<span class="tool-item-chevron">▸</span>` +
         label +
-        `<span class="tool-item-status running">…</span>` +
+        `<span class="tool-item-status running"></span>` +
       `</div>` +
       `<pre class="tool-item-stdout"></pre>`;
     // The result area is collapsed to the one-line header by default;
@@ -1376,6 +1379,7 @@ const Sessions = (() => {
   // otherwise), header hint, and the default-collapsed state. Shared by the
   // live path (_completeLastToolItem) and history replay.
   function _applyResultToItem(item, result, uiPayload) {
+    item.classList.remove("running");
     const status = item.querySelector(".tool-item-status");
     if (status) {
       const st = uiPayload && uiPayload.status ? uiPayload.status : "ok";
@@ -1435,6 +1439,13 @@ const Sessions = (() => {
   // "expanded" so the single tool item remains visible after collapse.
   function _collapseToolGroup(group) {
     const body = group.querySelector(".tool-group-body");
+    // A collapse means the turn moved on — no tool in this group can still be
+    // in flight. Stop the running animation on items whose result never
+    // arrived (e.g. interrupted turn).
+    if (body) {
+      body.querySelectorAll(".tool-item.running").forEach(it => it.classList.remove("running"));
+      body.querySelectorAll(".tool-item-status.running").forEach(st => st.classList.remove("running"));
+    }
     const n    = body ? body.children.length : 0;
     // Only hide the body (collapse) when there are multiple tools with a visible header.
     // A single-tool group has no header, so we keep its body visible forever.


### PR DESCRIPTION
## Problem

The in-flight tool row in the web UI showed only a tiny pulsing `…` (0.69rem, opacity pulse) at the far right of the row. It's easy to miss which tool is currently running — especially when the message stream is scrolled to the bottom and the row sits right at the viewport edge.

## Change

Three reinforcing cues on the running tool item:

- **Spinner** — the `…` status marker becomes a rotating border spinner (reuses the existing `pending-spin` keyframes).
- **Row glow** — the whole `.tool-item.running` row gets an accent-tinted background that pulses between `--color-accent-soft` and a stronger mix, plus an inset accent bar on the left.
- **Spinning gear** — the `⚙` icon (now wrapped in `.tool-item-gear`) rotates and takes the accent color while running.

Lifecycle: `_makeToolItem` adds the `running` class, `_applyResultToItem` removes it when the result lands, and `_collapseToolGroup` clears any leftover running state so an interrupted turn doesn't leave a spinner going forever.

Both themes covered (`--color-accent-soft` is defined for light and dark).

## Before / after

| before | after |
|---|---|
| faint `…` pulsing at row end | spinner + glowing row + spinning gear |

Verified with a headless-Chrome render of the exact markup: running row shows the tinted background, accent bar, and spinner; finished rows are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)