### PR TITLE
feat(server): persist turn progress to disk at round granularity

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1296,5 +1296,6 @@ func (h *History) popLast() {
 	defer h.mu.Unlock()
 	if n := len(h.messages); n > 0 {
 		h.messages = h.messages[:n-1]
+		h.rewritten = true
 	}
 }

--- a/internal/agent/history.go
+++ b/internal/agent/history.go
@@ -13,6 +13,14 @@ import "sync"
 type History struct {
 	mu       sync.RWMutex
 	messages []Message
+
+	// rewritten is set by every mutation that isn't a plain Append (compaction,
+	// overflow recovery, tool-pairing repair, popLast). Session.SyncFrom
+	// consumes it to learn that the persisted file's prefix may no longer match
+	// memory, so the next Save must rewrite the file instead of appending. A
+	// pure length comparison can't detect this: a rewrite can leave history at
+	// or above the persisted length while changing earlier messages.
+	rewritten bool
 }
 
 // NewHistory returns an empty History.
@@ -49,6 +57,7 @@ func (h *History) Reset() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.messages = nil
+	h.rewritten = true
 }
 
 // TruncateTo keeps only the first n messages.
@@ -58,6 +67,7 @@ func (h *History) TruncateTo(n int) {
 	defer h.mu.Unlock()
 	if n < len(h.messages) {
 		h.messages = h.messages[:n]
+		h.rewritten = true
 	}
 }
 
@@ -68,6 +78,7 @@ func (h *History) ReplaceAll(msgs []Message) {
 	defer h.mu.Unlock()
 	h.messages = make([]Message, len(msgs))
 	copy(h.messages, msgs)
+	h.rewritten = true
 }
 
 // Tail returns the last n messages (or all if fewer).
@@ -95,6 +106,26 @@ func (h *History) replaceLast(m Message) {
 		return
 	}
 	h.messages[len(h.messages)-1] = m
+	h.rewritten = true
+}
+
+// RewriteDirty reports whether history has been rewritten (any non-append
+// mutation) since the flag was last consumed by takeRewriteDirty. Callers use
+// it as a cheap "do I need to re-sync" check; it does not clear the flag.
+func (h *History) RewriteDirty() bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.rewritten
+}
+
+// takeRewriteDirty returns the rewritten flag and clears it. Consumed by
+// Session.SyncFrom, which translates it into a full-file rewrite on Save.
+func (h *History) takeRewriteDirty() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	d := h.rewritten
+	h.rewritten = false
+	return d
 }
 
 // FindSystemMsg returns the first system message index, or -1.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -36,6 +36,12 @@ type Session struct {
 	// persisted is how many messages are already on disk. Save appends
 	// Messages[persisted:]; it's not serialized.
 	persisted int
+
+	// forceRewrite is set when SyncFrom observes that the source History was
+	// rewritten (compaction, repair, popLast): the on-disk prefix may no
+	// longer match Messages, so the next Save must rewrite the whole file.
+	// Cleared by a successful rewriteAll. Not serialized.
+	forceRewrite bool
 }
 
 // NewSession creates a Session with an ID derived from the current time plus
@@ -134,12 +140,20 @@ func messageRecord(m Message) sessionRecord {
 }
 
 // Save persists the session. The common case appends only the messages added
-// since the last Save. When the in-memory history is shorter than what's on
-// disk — which happens when compaction rewrites history into a summary — the
-// file is rewritten from scratch instead (an infrequent O(n) event).
+// since the last Save. The file is rewritten from scratch (an infrequent O(n)
+// event) when the on-disk prefix can't be trusted: a history rewrite observed
+// by SyncFrom (forceRewrite), or an in-memory list shorter than what's on disk
+// — the length check is kept as a belt-and-braces fallback for callers that
+// assign Messages directly instead of going through SyncFrom. With no new
+// messages and a trusted prefix, Save is a no-op, so per-event callers (the
+// server persists mid-turn progress on every agent event) don't touch the
+// file at all between rounds.
 func (s *Session) Save() error {
-	if s.persisted == 0 || len(s.Messages) < s.persisted {
+	if s.forceRewrite || s.persisted == 0 || len(s.Messages) < s.persisted {
 		return s.rewriteAll()
+	}
+	if len(s.Messages) == s.persisted {
+		return nil
 	}
 	return s.appendDelta()
 }
@@ -171,6 +185,7 @@ func (s *Session) rewriteAll() error {
 		return fmt.Errorf("session: flush %s: %w", path, err)
 	}
 	s.persisted = len(s.Messages)
+	s.forceRewrite = false
 	return nil
 }
 
@@ -214,6 +229,12 @@ func (s *Session) SetTitle(title string) error {
 	if s.persisted == 0 {
 		// Nothing on disk yet; the next Save writes the title via metaRecord.
 		return nil
+	}
+	if s.forceRewrite {
+		// The file ends in an incomplete tail (crash mid-append) or its prefix
+		// is stale (history rewrite): a raw append would corrupt it. Rewrite
+		// instead — rewriteAll folds the title into the meta header.
+		return s.rewriteAll()
 	}
 	path, err := s.SavePath()
 	if err != nil {
@@ -313,17 +334,34 @@ func LoadSession(id string) (*Session, error) {
 		return nil, err
 	}
 
-	f, err := os.Open(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("session %q not found", id)
 		}
 		return nil, fmt.Errorf("session: open %s: %w", path, err)
 	}
-	defer f.Close()
+
+	// A complete record always ends in '\n' (json.Encoder writes it), so bytes
+	// after the last newline are an incomplete tail — left by a crash mid-append
+	// or by a writer the read is racing. Drop the tail instead of failing the
+	// whole session: it is at most one message that was never fully committed.
+	// The tail bytes are still in the file, though, so a plain append would
+	// fuse them with the next record into one corrupt line — force the first
+	// Save of this Session to rewrite the file instead.
+	droppedTail := false
+	if n := bytes.LastIndexByte(data, '\n'); n >= 0 {
+		if n+1 < len(data) {
+			droppedTail = true
+		}
+		data = data[:n+1]
+	} else {
+		droppedTail = len(data) > 0
+		data = nil
+	}
 
 	s := &Session{}
-	sc := bufio.NewScanner(f)
+	sc := bufio.NewScanner(bytes.NewReader(data))
 	// A single message (e.g. a large tool_result) can exceed the default 64 KB
 	// line cap; allow up to 16 MB per line.
 	sc.Buffer(make([]byte, 64*1024), 16*1024*1024)
@@ -359,6 +397,7 @@ func LoadSession(id string) (*Session, error) {
 	}
 	rehydrateImageBlocks(s.Messages)
 	s.persisted = len(s.Messages) // a resumed session continues appending
+	s.forceRewrite = droppedTail
 	return s, nil
 }
 
@@ -620,7 +659,12 @@ func (s *Session) ToHistory() *History {
 }
 
 // SyncFrom copies the current messages from h into the session.
-// Call this before Save to flush the latest turns.
+// Call this before Save to flush the latest turns. When the history was
+// rewritten since the last sync (compaction, repair, popLast), the next Save
+// rewrites the file instead of appending — see History.rewritten.
 func (s *Session) SyncFrom(h *History) {
 	s.Messages = h.Snapshot()
+	if h.takeRewriteDirty() {
+		s.forceRewrite = true
+	}
 }

--- a/internal/agent/session_persist_test.go
+++ b/internal/agent/session_persist_test.go
@@ -1,0 +1,197 @@
+package agent
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestHistoryRewriteDirty checks that every non-append mutation marks the
+// history as rewritten and that plain appends do not — Session.SyncFrom
+// relies on this to know when the persisted file's prefix went stale.
+func TestHistoryRewriteDirty(t *testing.T) {
+	mutations := []struct {
+		name string
+		do   func(h *History)
+	}{
+		{"ReplaceAll", func(h *History) { h.ReplaceAll([]Message{NewUserMessage("x")}) }},
+		{"Reset", func(h *History) { h.Reset() }},
+		{"TruncateTo", func(h *History) { h.TruncateTo(1) }},
+		{"replaceLast", func(h *History) { h.replaceLast(NewUserMessage("y")) }},
+		{"popLast", func(h *History) { h.popLast() }},
+	}
+	for _, m := range mutations {
+		t.Run(m.name, func(t *testing.T) {
+			h := NewHistory()
+			h.Append(NewUserMessage("a"))
+			h.Append(NewAssistantMessage("b"))
+			if h.RewriteDirty() {
+				t.Fatal("Append alone must not mark history rewritten")
+			}
+			m.do(h)
+			if !h.RewriteDirty() {
+				t.Fatalf("%s did not mark history rewritten", m.name)
+			}
+			if !h.takeRewriteDirty() {
+				t.Fatal("takeRewriteDirty returned false on a dirty history")
+			}
+			if h.RewriteDirty() || h.takeRewriteDirty() {
+				t.Fatal("takeRewriteDirty did not clear the flag")
+			}
+		})
+	}
+}
+
+// TestSessionSave_RewriteAfterHistoryRewrite is the corruption guard for
+// incremental mid-turn saves: a history rewrite (compaction) that leaves the
+// message count at or above the persisted count used to slip past Save's
+// length check, appending on top of a stale prefix. SyncFrom must carry the
+// rewrite over so Save rewrites the file.
+func TestSessionSave_RewriteAfterHistoryRewrite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := NewSession("m", "")
+	h := NewHistory()
+	for _, m := range []Message{
+		NewUserMessage("one"), NewAssistantMessage("two"), NewUserMessage("three"),
+	} {
+		h.Append(m)
+	}
+	sess.SyncFrom(h)
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Rewrite history to the SAME length with a different prefix — the case
+	// the pure length check cannot see.
+	h.ReplaceAll([]Message{
+		NewUserMessage("[summary]"), NewUserMessage("three"), NewAssistantMessage("four"),
+	})
+	sess.SyncFrom(h)
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save after rewrite: %v", err)
+	}
+
+	got, err := LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(got.Messages) != 3 || got.Messages[0].Content != "[summary]" || got.Messages[2].Content != "four" {
+		t.Fatalf("persisted messages do not match rewritten history: %+v", got.Messages)
+	}
+}
+
+// TestSessionSave_NoopWhenUnchanged checks the fast path the server's
+// per-event persister depends on: a Save with no new messages must leave the
+// file byte-for-byte untouched.
+func TestSessionSave_NoopWhenUnchanged(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := NewSession("m", "")
+	sess.Messages = []Message{NewUserMessage("hello")}
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	path, _ := sess.SavePath()
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if err := sess.Save(); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Fatal("no-op Save modified the file")
+	}
+}
+
+// TestLoadSession_DropsPartialTail simulates a crash mid-append: the file
+// ends in an incomplete JSON line. Loading must succeed with the complete
+// records, and the next Save must rewrite the file so the dangling bytes
+// can't fuse with a future append into one corrupt line.
+func TestLoadSession_DropsPartialTail(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := NewSession("m", "")
+	sess.Messages = []Message{NewUserMessage("hello"), NewAssistantMessage("world")}
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	path, _ := sess.SavePath()
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := f.WriteString(`{"type":"message","message":{"content":"PARTIAL-TAIL`); err != nil {
+		t.Fatalf("write tail: %v", err)
+	}
+	f.Close()
+
+	got, err := LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("load with partial tail: %v", err)
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("messages = %d, want 2 (partial tail dropped)", len(got.Messages))
+	}
+
+	// Resume the session: append a message and save. The partial tail must
+	// not survive into the rewritten file.
+	got.Messages = append(got.Messages, NewUserMessage("again"))
+	if err := got.Save(); err != nil {
+		t.Fatalf("save after tail drop: %v", err)
+	}
+	raw, _ := os.ReadFile(path)
+	if strings.Contains(string(raw), "PARTIAL-TAIL") {
+		t.Fatal("partial tail bytes survived the post-recovery save")
+	}
+	re, err := LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(re.Messages) != 3 || re.Messages[2].Content != "again" {
+		t.Fatalf("reloaded messages = %+v, want 3 ending in \"again\"", re.Messages)
+	}
+}
+
+// TestSetTitle_RewritesAfterPartialTail: SetTitle appends a raw title record;
+// after a crash left a partial tail it must rewrite instead, or the title
+// record fuses with the dangling bytes into one corrupt line.
+func TestSetTitle_RewritesAfterPartialTail(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := NewSession("m", "")
+	sess.Messages = []Message{NewUserMessage("hello")}
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	path, _ := sess.SavePath()
+	f, _ := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
+	f.WriteString(`{"type":"mess`)
+	f.Close()
+
+	got, err := LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := got.SetTitle("My Title"); err != nil {
+		t.Fatalf("set title: %v", err)
+	}
+	re, err := LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("reload after SetTitle: %v", err)
+	}
+	if re.Title != "My Title" || len(re.Messages) != 1 {
+		t.Fatalf("reloaded title=%q messages=%d, want \"My Title\"/1", re.Title, len(re.Messages))
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -339,12 +339,24 @@ func (s *Server) handleGetSessionMessages(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// While a turn is in flight its progress is saved to disk incrementally,
+	// and the WS replay buffer delivers those same rounds to (re)subscribing
+	// tabs. Serve only the messages that predate the turn so the two sources
+	// never overlap — without this cap a mid-turn refresh would render every
+	// tool card twice.
+	msgs := sess.Messages
+	s.liveStateMu.RLock()
+	if ls, ok := s.liveStates[id]; ok && ls.historyWatermark > 0 && ls.historyWatermark < len(msgs) {
+		msgs = msgs[:ls.historyWatermark]
+	}
+	s.liveStateMu.RUnlock()
+
 	// The Web UI expects an event stream that mirrors the live WS traffic.
 	// We translate the persisted message list into user/assistant events and
 	// reconstruct tool_call / tool_result pairs from tool_use / tool_result
 	// blocks so the history replay is visually complete.
-	events := make([]map[string]any, 0, len(sess.Messages)*2)
-	for i, m := range sess.Messages {
+	events := make([]map[string]any, 0, len(msgs)*2)
+	for i, m := range msgs {
 		switch m.Role {
 		case agent.RoleUser:
 			// Emit tool_result events for any tool_result blocks before the

--- a/internal/server/incremental_persist_test.go
+++ b/internal/server/incremental_persist_test.go
@@ -1,0 +1,279 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// blockingToolSender drives a two-round tool turn and blocks at the start of
+// each round until released: round 1 so the test can steer a message into the
+// running turn, round 2 as the deterministic mid-turn point to observe what
+// doAgentTurn has persisted so far. Rounds beyond 2 (title/suggestion
+// side-calls) return immediately.
+type blockingToolSender struct {
+	mu       sync.Mutex
+	round    int
+	entered1 chan struct{}
+	release1 chan struct{}
+	entered2 chan struct{}
+	release2 chan struct{}
+}
+
+func (s *blockingToolSender) SendMessages(_ context.Context, _, _ string, _ []agent.Message, _ int) (agent.Reply, error) {
+	return agent.Reply{Content: "side-call"}, nil
+}
+
+func (s *blockingToolSender) StreamMessages(_ context.Context, _, _ string, _ []agent.Message, _ int, onChunk func(string), _ func(string)) (agent.Reply, error) {
+	return agent.Reply{Content: "side-call"}, nil
+}
+
+func (s *blockingToolSender) SendMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, _ []agent.ToolDefinition) (agent.Reply, error) {
+	return agent.Reply{Content: "side-call"}, nil
+}
+
+func (s *blockingToolSender) StreamMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, _ []agent.ToolDefinition, onChunk func(string), _ agent.ToolInputDeltaFunc, _ agent.ThinkingDeltaFunc) (agent.Reply, error) {
+	s.mu.Lock()
+	s.round++
+	round := s.round
+	s.mu.Unlock()
+	switch round {
+	case 1:
+		close(s.entered1)
+		<-s.release1
+		// A read of a nonexistent path: allowed by the embedded permission
+		// defaults (no gate prompt) and fails fast with an error tool_result,
+		// which keeps the loop running into round 2 — no filesystem side
+		// effects.
+		return agent.Reply{
+			Blocks: []agent.ContentBlock{
+				agent.NewToolUseBlock("tu1", "read_file", map[string]any{"path": "/nonexistent/incremental-persist-test"}),
+			},
+			StopReason: "tool_use",
+		}, nil
+	case 2:
+		close(s.entered2)
+		<-s.release2
+		if onChunk != nil {
+			onChunk("round two")
+		}
+		return agent.Reply{Content: "round two"}, nil
+	default:
+		return agent.Reply{Content: "side-call"}, nil
+	}
+}
+
+// hasBlock reports whether the message carries a block of the given type.
+func hasBlock(m agent.Message, blockType string) bool {
+	for _, b := range m.Blocks {
+		if b.Type == blockType {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDoAgentTurn_PersistsProgressIncrementally is the crash-durability
+// guard: by the time the second LLM round is running, the first round's
+// tool_use, its tool_result, and the steer message that arrived mid-turn must
+// already be on disk — a server killed at that point loses at most the round
+// in flight, not the whole turn. It also checks the watermark cap end-to-end:
+// a mid-turn history fetch must serve only messages from before the turn,
+// because the WS replay buffer owns the turn's own events (without the cap
+// every card renders twice on refresh).
+func TestDoAgentTurn_PersistsProgressIncrementally(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sender := &blockingToolSender{
+		entered1: make(chan struct{}),
+		release1: make(chan struct{}),
+		entered2: make(chan struct{}),
+		release2: make(chan struct{}),
+	}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
+	srv.sender = sender
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]agent.InboxItem)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	sess.Title = "fixed title" // suppress the async title-generation side-call
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.doAgentTurn(sess, "hello", nil, nil)
+	}()
+	releaseOnce := func(ch chan struct{}) {
+		select {
+		case <-ch:
+		default:
+			close(ch)
+		}
+	}
+	t.Cleanup(func() {
+		releaseOnce(sender.release1)
+		releaseOnce(sender.release2)
+		<-done
+	})
+
+	// Round 1 is blocked inside the provider call: the Agent is registered
+	// (that happens before RunStream) and the turn cannot finish yet. Steer a
+	// message into its inbox — the loop drains it before round 2 — then let
+	// round 1 return its tool call.
+	select {
+	case <-sender.entered1:
+	case <-time.After(5 * time.Second):
+		t.Fatal("round 1 never started")
+	}
+	srv.sessionAgentsMu.Lock()
+	a := srv.sessionAgents[sess.ID]
+	srv.sessionAgentsMu.Unlock()
+	if a == nil {
+		t.Fatal("agent not registered while round 1 in flight")
+	}
+	a.Inbox.Enqueue("steer message")
+	releaseOnce(sender.release1)
+
+	select {
+	case <-sender.entered2:
+	case <-time.After(5 * time.Second):
+		t.Fatal("round 2 never started")
+	}
+
+	// ── Mid-turn: round 2 is blocked inside the provider call. ──
+
+	onDisk, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("mid-turn load: %v", err)
+	}
+	if len(onDisk.Messages) != 4 {
+		t.Fatalf("mid-turn persisted %d messages, want 4 (user, tool_use, tool_result, steer): %+v",
+			len(onDisk.Messages), onDisk.Messages)
+	}
+	if onDisk.Messages[0].Content != "hello" {
+		t.Errorf("persisted[0] = %q, want the user message", onDisk.Messages[0].Content)
+	}
+	if !hasBlock(onDisk.Messages[1], "tool_use") {
+		t.Errorf("persisted[1] lacks the round-1 tool_use block: %+v", onDisk.Messages[1])
+	}
+	if !hasBlock(onDisk.Messages[2], "tool_result") {
+		t.Errorf("persisted[2] lacks the tool_result block: %+v", onDisk.Messages[2])
+	}
+	if onDisk.Messages[3].Content != "steer message" {
+		t.Errorf("persisted[3] = %q, want the steer message", onDisk.Messages[3].Content)
+	}
+
+	// The history endpoint must cap at the watermark (the turn's user
+	// message): the incrementally-persisted rounds belong to the WS replay
+	// buffer until the turn ends.
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/"+sess.ID+"/messages", nil)
+	req.SetPathValue("id", sess.ID)
+	rec := httptest.NewRecorder()
+	srv.handleGetSessionMessages(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("messages endpoint = %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Events []map[string]any `json:"events"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, ev := range body.Events {
+		switch ev["type"] {
+		case "tool_call", "tool_result", "assistant_message":
+			t.Fatalf("mid-turn history served in-flight turn content: %v (events=%v)", ev, body.Events)
+		}
+	}
+
+	// ── Finish the turn: the full transcript persists and the cap lifts. ──
+
+	releaseOnce(sender.release2)
+	<-done
+
+	final, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("final load: %v", err)
+	}
+	if n := len(final.Messages); n != 5 {
+		t.Fatalf("final persisted %d messages, want 5 (… + final assistant reply): %+v", n, final.Messages)
+	}
+	if final.Messages[4].Content != "round two" {
+		t.Errorf("final reply = %q, want \"round two\"", final.Messages[4].Content)
+	}
+
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/api/sessions/"+sess.ID+"/messages", nil)
+	req2.SetPathValue("id", sess.ID)
+	srv.handleGetSessionMessages(rec2, req2)
+	var body2 struct {
+		Events []map[string]any `json:"events"`
+	}
+	if err := json.Unmarshal(rec2.Body.Bytes(), &body2); err != nil {
+		t.Fatalf("unmarshal final: %v", err)
+	}
+	toolCalls := 0
+	for _, ev := range body2.Events {
+		if ev["type"] == "tool_call" {
+			toolCalls++
+		}
+	}
+	if toolCalls != 1 {
+		t.Fatalf("post-turn history tool_call count = %d, want 1 (cap must lift)", toolCalls)
+	}
+}
+
+// TestHandleEvent_CompactDoneShiftsWatermark checks the watermark arithmetic
+// for mid-turn compaction: folding K leading messages into one summary moves
+// the pre-turn boundary to W-K+1, and folding past the boundary clamps to 1
+// (only the summary predates the turn). No-op compactions (before == after)
+// must leave the watermark alone.
+func TestHandleEvent_CompactDoneShiftsWatermark(t *testing.T) {
+	cases := []struct {
+		name          string
+		watermark     int
+		stats         *agent.CompactStats
+		wantWatermark int
+	}{
+		{"folds within pre-turn prefix", 10, &agent.CompactStats{BeforeTokens: 100, AfterTokens: 40, FoldedMsgs: 6}, 5},
+		{"folds into the current turn", 3, &agent.CompactStats{BeforeTokens: 100, AfterTokens: 40, FoldedMsgs: 8}, 1},
+		{"no-op compaction", 10, &agent.CompactStats{BeforeTokens: 100, AfterTokens: 100, FoldedMsgs: 6}, 10},
+		{"nil stats", 10, nil, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+			srv.initWS()
+			const sid = "compact-watermark-session"
+			srv.liveStateMu.Lock()
+			srv.liveStates[sid] = &sessionLiveState{
+				progress:         &wsEventProgress{Type: "progress", Phase: "active"},
+				historyWatermark: tc.watermark,
+			}
+			srv.liveStateMu.Unlock()
+
+			sw := srv.newWSStreamWriter(sid)
+			sw.handleEvent(agent.AgentEvent{Kind: agent.EventCompactDone, Compact: tc.stats})
+
+			srv.liveStateMu.RLock()
+			got := srv.liveStates[sid].historyWatermark
+			srv.liveStateMu.RUnlock()
+			if got != tc.wantWatermark {
+				t.Errorf("watermark = %d, want %d", got, tc.wantWatermark)
+			}
+		})
+	}
+}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -32,6 +32,16 @@ type sessionLiveState struct {
 	// tool call; anything still unflushed is replayed directly after events.
 	textBuf     strings.Builder
 	thinkingBuf strings.Builder
+
+	// historyWatermark is how many persisted messages predate this turn
+	// (including the turn's own user message). The turn's progress is saved
+	// to disk incrementally, so without a cut-off a mid-turn history fetch
+	// would reconstruct the same rounds the replay buffer resends — every
+	// tool card twice. The history endpoint serves messages below the
+	// watermark; the buffer owns everything above it. Mid-turn compaction
+	// shifts it (see the EventCompactDone handler). 0 means unset (no cap):
+	// a real watermark is always ≥ 1 because the user message saves first.
+	historyWatermark int
 }
 
 // maxLiveTurnEvents caps the replay buffer; a turn that somehow exceeds it
@@ -511,9 +521,12 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// Persist the user message right away so a page refresh mid-turn doesn't
 	// lose it.  We append it for Save(), then pop it back off so buildAgent
 	// doesn't double-count it — RunStream will add the same message to
-	// a.History via appendUserInput.
+	// a.History via appendUserInput. The count including the user message is
+	// the turn's history watermark: while the turn runs, the history endpoint
+	// serves only messages below it and the WS replay buffer owns the rest.
 	sess.Messages = append(sess.Messages, userMsg)
 	_ = sess.Save()
+	historyWatermark := len(sess.Messages)
 	sess.Messages = sess.Messages[:len(sess.Messages)-1]
 
 	sw := s.newWSStreamWriter(sess.ID)
@@ -541,6 +554,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			Phase:        "active",
 			StartedAt:    startedAt,
 		},
+		historyWatermark: historyWatermark,
 	}
 	s.liveStateMu.Unlock()
 	s.wsHub.broadcast(sess.ID, map[string]any{
@@ -625,7 +639,27 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		s.wireBackgroundTaskNotices(sess.ID)
 	}
 
-	reply, err := a.RunStream(runCtx, content, toolDefs, executor, sw.handleEvent)
+	// Persist the turn's progress incrementally: after any event that grew or
+	// rewrote history, flush it to disk so a server crash mid-turn loses at
+	// most the round in flight, not the whole turn. The length/dirty gate
+	// makes the per-delta calls free — Save itself is also a no-op when
+	// nothing changed. RunStream invokes the handler synchronously on this
+	// goroutine, so sess needs no extra locking.
+	lastSavedLen := -1
+	persistTurnProgress := func() {
+		if n := a.History.Len(); n != lastSavedLen || a.History.RewriteDirty() {
+			sess.SyncFrom(a.History)
+			if sess.Save() == nil {
+				lastSavedLen = n
+			}
+		}
+	}
+	handler := func(ev agent.AgentEvent) {
+		sw.handleEvent(ev)
+		persistTurnProgress()
+	}
+
+	reply, err := a.RunStream(runCtx, content, toolDefs, executor, handler)
 
 	// Save history even on interrupt — finishInterrupted repairs it so the
 	// session stays well-formed for the next turn.
@@ -635,9 +669,9 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// The turn is persisted: drop the live state (and its replay buffer) now,
 	// before any further broadcasts, so a tab subscribing from here on
 	// rebuilds from history alone instead of also replaying buffered events
-	// on top of it. On success/interrupt EventTurnDone already cleared it;
-	// this covers provider-error returns. The deferred delete stays as a
-	// backstop for panics.
+	// on top of it. (This is the primary cleanup point — the EventTurnDone
+	// handler deliberately leaves the state alone; the deferred delete stays
+	// as a backstop for panics.)
 	s.liveStateMu.Lock()
 	delete(s.liveStates, sess.ID)
 	s.liveStateMu.Unlock()
@@ -951,6 +985,25 @@ func (w *wsStreamWriter) handleEvent(ev agent.AgentEvent) {
 			ls.thinkingBuf.WriteString(ev.Text)
 		}
 		w.server.liveStateMu.Unlock()
+
+	case agent.EventCompactDone:
+		// Compaction folded the FoldedMsgs oldest messages into one summary
+		// message, shifting every later index down — including the turn's
+		// history watermark. Skip no-op compactions (summarization failed or
+		// returned nothing; history untouched), signalled by before == after.
+		if c := ev.Compact; c != nil && c.FoldedMsgs > 0 && c.BeforeTokens != c.AfterTokens {
+			w.server.liveStateMu.Lock()
+			if ls, ok := w.server.liveStates[w.sessionID]; ok && ls.historyWatermark > 0 {
+				if nw := ls.historyWatermark - c.FoldedMsgs + 1; nw > 1 {
+					ls.historyWatermark = nw
+				} else {
+					// Compaction reached into the current turn: only the
+					// summary message itself predates the turn now.
+					ls.historyWatermark = 1
+				}
+			}
+			w.server.liveStateMu.Unlock()
+		}
 
 	case agent.EventSteerInjected:
 		// Prefer the full inbox items (text + attachment blocks) so a steer


### PR DESCRIPTION
## Problem

A server crash/restart while the agent is running loses everything after the initiating user message: assistant rounds (tool_use), tool results, mid-turn steer messages, and the streamed reply only reach disk at the turn-end `SyncFrom + Save`. The side effects of executed tools survive, but the model has no record of them on the next turn.

## Fix

**Round-granularity incremental persistence** (web turn loop): `doAgentTurn` wraps the event handler so that after every agent event that grew or rewrote history, the session is flushed to disk. A crash now loses at most the round in flight — the window between a tool batch committing and the next round's first delta (≈ time-to-first-token).

**Agent-layer correctness underpinnings:**

- `History` gains a `rewritten` flag set by every non-append mutation (compaction `Reset`, overflow recovery, tool-pairing `ReplaceAll`/`replaceLast`, `popLast`). `SyncFrom` carries it onto the `Session`, forcing the next `Save` to rewrite the file. The old length-only check (`len < persisted`) misses rewrites that leave history **at or above** the persisted count — an append onto a stale prefix would corrupt the file. With frequent mid-turn saves that case stops being theoretical.
- `Save` with no new messages and a trusted prefix is a no-op, making the per-event persister free between rounds.
- `LoadSession` tolerates an unterminated trailing line (crash mid-append, or a reader racing a writer) instead of failing the whole session, and forces the next `Save`/`SetTitle` to rewrite so the dangling bytes can't fuse with a future append into one corrupt line.

**Watermark-capped history (interaction with #570):** with mid-turn saves, a page refresh would render the running turn twice — once reconstructed by the history fetch, once from the WS replay buffer. Each live turn records `historyWatermark` (persisted-message count at turn start); `GET /api/sessions/:id/messages` serves only messages below it while the turn runs, and the replay buffer owns everything above. `EventCompactDone` shifts the watermark by `FoldedMsgs` when mid-turn compaction folds pre-turn messages into a summary (no-op compactions, signalled by `before == after`, leave it alone).

## Not included (deliberately)

- Crash-detection system-reminder on the next turn ("previous turn was interrupted; executed tool results may be unrecorded") — separate follow-up if wanted.
- CLI/TUI turn loops keep turn-end saves; the agent-layer fixes benefit them, but the incremental hook is server-only for now.

## Tests

- `TestDoAgentTurn_PersistsProgressIncrementally` — blocking two-round tool turn; asserts mid-turn disk content (user + tool_use + tool_result + steer), the watermark cap on the history endpoint while running, and the cap lifting after the turn.
- `TestHandleEvent_CompactDoneShiftsWatermark` — watermark arithmetic incl. fold-into-turn clamp and no-op skip.
- `TestHistoryRewriteDirty`, `TestSessionSave_RewriteAfterHistoryRewrite` (the same-length-rewrite corruption case), `TestSessionSave_NoopWhenUnchanged`, `TestLoadSession_DropsPartialTail`, `TestSetTitle_RewritesAfterPartialTail`.

`go test -race ./...`, `go vet`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)