### PR TITLE
feat(server): warn the model after a turn died with the server

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -91,6 +91,32 @@ func (s *Session) UsedTools() bool {
 	return false
 }
 
+// EndsMidTurn reports whether the persisted transcript stops in the middle of
+// a turn: the last message is a user message still awaiting a reply (the
+// initiating input, a tool_result batch, or a mid-turn steer), or an
+// assistant tool_use whose results never landed. A turn that finished — or
+// was interrupted by the user — always ends on a plain assistant text message
+// (finishInterrupted guarantees this), so a mid-turn tail means the process
+// died with the turn in flight: crash, kill, power loss. Callers use it to
+// warn the model that tool side effects from that turn may be unrecorded.
+func (s *Session) EndsMidTurn() bool {
+	if len(s.Messages) == 0 {
+		return false
+	}
+	last := s.Messages[len(s.Messages)-1]
+	switch last.Role {
+	case RoleUser:
+		return true
+	case RoleAssistant:
+		for _, b := range last.Blocks {
+			if b.Type == "tool_use" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // sessionsDir returns (and creates if needed) ~/.octo/sessions.
 func sessionsDir() (string, error) {
 	home, err := os.UserHomeDir()

--- a/internal/agent/session_midturn_test.go
+++ b/internal/agent/session_midturn_test.go
@@ -1,0 +1,37 @@
+package agent
+
+import "testing"
+
+// TestSessionEndsMidTurn pins the crash signature: a transcript ending on a
+// user message or an unanswered assistant tool_use means the process died
+// mid-turn, while every clean ending (finished reply, interrupt note) is a
+// plain assistant text message.
+func TestSessionEndsMidTurn(t *testing.T) {
+	toolUse := Message{Role: RoleAssistant, Blocks: []ContentBlock{
+		NewToolUseBlock("tu1", "terminal", map[string]any{"command": "ls"}),
+	}}
+	toolResult := NewToolResultMessage([]ContentBlock{
+		NewToolResultBlock("tu1", "file.txt", false),
+	})
+
+	cases := []struct {
+		name     string
+		messages []Message
+		want     bool
+	}{
+		{"empty session", nil, false},
+		{"ends on initiating user message", []Message{NewUserMessage("hi")}, true},
+		{"ends on tool_result batch", []Message{NewUserMessage("hi"), toolUse, toolResult}, true},
+		{"ends on assistant tool_use", []Message{NewUserMessage("hi"), toolUse}, true},
+		{"ends on finished reply", []Message{NewUserMessage("hi"), NewAssistantMessage("done")}, false},
+		{"ends on interrupt note", []Message{NewUserMessage("hi"), toolUse, toolResult, NewAssistantMessage("[interrupted]")}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Session{Messages: tc.messages}
+			if got := s.EndsMidTurn(); got != tc.want {
+				t.Errorf("EndsMidTurn() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/crash_reminder_test.go
+++ b/internal/server/crash_reminder_test.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// msgRecordingSender captures the message lists it is asked to stream so a test
+// can inspect exactly what the model would have seen.
+type msgRecordingSender struct {
+	mu    sync.Mutex
+	calls [][]agent.Message
+}
+
+func (s *msgRecordingSender) record(msgs []agent.Message) {
+	cp := make([]agent.Message, len(msgs))
+	copy(cp, msgs)
+	s.mu.Lock()
+	s.calls = append(s.calls, cp)
+	s.mu.Unlock()
+}
+
+func (s *msgRecordingSender) SendMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int) (agent.Reply, error) {
+	s.record(msgs)
+	return agent.Reply{Content: "ok"}, nil
+}
+
+func (s *msgRecordingSender) StreamMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int, onChunk func(string), _ func(string)) (agent.Reply, error) {
+	s.record(msgs)
+	if onChunk != nil {
+		onChunk("ok")
+	}
+	return agent.Reply{Content: "ok"}, nil
+}
+
+// lastUserContent returns the text of the last user message of the first
+// recorded provider call.
+func (s *msgRecordingSender) lastUserContent(t *testing.T) string {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.calls) == 0 {
+		t.Fatal("provider was never called")
+	}
+	msgs := s.calls[0]
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == agent.RoleUser {
+			if msgs[i].Content != "" {
+				return msgs[i].Content
+			}
+			for _, b := range msgs[i].Blocks {
+				if b.Type == "text" {
+					return b.Text
+				}
+			}
+		}
+	}
+	t.Fatal("no user message reached the provider")
+	return ""
+}
+
+// newCrashReminderServer builds the minimal turn-capable server used by the
+// crash-reminder tests.
+func newCrashReminderServer(t *testing.T, sender *msgRecordingSender) *Server {
+	t.Helper()
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.sender = sender
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]agent.InboxItem)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+	return srv
+}
+
+// TestDoAgentTurn_CrashRecoveryReminder: a session whose transcript ends
+// mid-turn (the previous turn died with the server) must warn the model on
+// the next turn that tool side effects may be unrecorded — without the
+// reminder ever reaching a UI surface.
+func TestDoAgentTurn_CrashRecoveryReminder(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sender := &msgRecordingSender{}
+	srv := newCrashReminderServer(t, sender)
+
+	// A crashed turn's persisted tail: the user asked, the assistant called a
+	// tool, and the process died before the results landed.
+	sess := agent.NewSession("stub-model", "")
+	sess.Title = "fixed title"
+	sess.Messages = []agent.Message{
+		agent.NewUserMessage("delete the old backups"),
+		{Role: agent.RoleAssistant, Blocks: []agent.ContentBlock{
+			agent.NewToolUseBlock("tu1", "terminal", map[string]any{"command": "rm -r backups/"}),
+		}},
+	}
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv.doAgentTurn(sess, "did it work?", nil, nil)
+
+	got := sender.lastUserContent(t)
+	if !strings.Contains(got, "<system-reminder>") || !strings.Contains(got, "ended abnormally") {
+		t.Errorf("model did not receive the crash-recovery reminder; user content = %q", got)
+	}
+	if !strings.Contains(got, "did it work?") {
+		t.Errorf("reminder displaced the user's own text; user content = %q", got)
+	}
+
+	// The reminder is model-facing only: the history endpoint must strip it.
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/"+sess.ID+"/messages", nil)
+	req.SetPathValue("id", sess.ID)
+	rec := httptest.NewRecorder()
+	srv.handleGetSessionMessages(rec, req)
+	var body struct {
+		Events []map[string]any `json:"events"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, ev := range body.Events {
+		if c, _ := ev["content"].(string); strings.Contains(c, "system-reminder") || strings.Contains(c, "ended abnormally") {
+			t.Errorf("reminder leaked into a UI surface: %v", ev)
+		}
+	}
+}
+
+// TestDoAgentTurn_NoReminderAfterCleanTurn: a transcript ending on a plain
+// assistant reply (finished turn, or finishInterrupted's note after a manual
+// interrupt) must not trigger the reminder.
+func TestDoAgentTurn_NoReminderAfterCleanTurn(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sender := &msgRecordingSender{}
+	srv := newCrashReminderServer(t, sender)
+
+	sess := agent.NewSession("stub-model", "")
+	sess.Title = "fixed title"
+	sess.Messages = []agent.Message{
+		agent.NewUserMessage("hi"),
+		agent.NewAssistantMessage("hello!"),
+	}
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv.doAgentTurn(sess, "next question", nil, nil)
+
+	got := sender.lastUserContent(t)
+	if strings.Contains(got, "system-reminder") {
+		t.Errorf("reminder fired after a cleanly finished turn; user content = %q", got)
+	}
+}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -484,7 +484,24 @@ func (s *Server) drainSteer(sessionID string) []agent.InboxItem {
 	return items
 }
 
+// crashRecoveryReminder is prepended (as model-facing context, stripped from
+// every UI surface by StripSystemReminders) to the first user message of a
+// turn whose session transcript still ends mid-turn — meaning the previous
+// turn died with the server process. Its rounds were persisted incrementally,
+// but the round in flight at the crash is gone, so executed tools may have
+// changed state without their results being recorded.
+const crashRecoveryReminder = `<system-reminder>The previous turn in this session ended abnormally (the server stopped mid-turn). Tool calls from that turn may have executed and changed state even if their results are missing from this conversation. Verify the current state before repeating or continuing potentially destructive actions.</system-reminder>`
+
 func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent.ContentBlock, images []string) {
+	// A transcript that still ends mid-turn here means the previous turn died
+	// with the server — a finished or user-interrupted turn always ends on a
+	// plain assistant message. Warn the model once: the reminder rides this
+	// turn's user message, and the turn's own completion makes the tail clean
+	// again, so it cannot re-fire.
+	if sess.EndsMidTurn() {
+		content = crashRecoveryReminder + "\n\n" + content
+	}
+
 	// Build the user message first: its CreatedAt is both the persisted
 	// timestamp and the broadcast created_at below, so the live event and a
 	// concurrent history fetch carry the SAME dedup key. (Mirror


### PR DESCRIPTION
## Problem

Follow-up to #577. A crashed turn's completed rounds now survive on disk, but the model can't tell the turn ended abnormally: the round in flight at the crash (and its tool results) is gone while its side effects are not. On the next turn the model may repeat destructive work or reason from a state it believes unchanged.

## Fix

- `Session.EndsMidTurn()` (agent layer): the crash signature is a transcript ending on a **user message** (initiating input / tool_result batch / steer, all awaiting a reply) or an **assistant tool_use without results**. A finished turn — or one interrupted by the user — always ends on a plain assistant text message (`finishInterrupted` restores that invariant), so the signature cannot fire after a manual interrupt.
- `doAgentTurn` prepends a `<system-reminder>` ("previous turn ended abnormally; tool calls may have executed and changed state; verify before repeating destructive actions") to the next turn's user message. The reminder rides into history and to the provider; the turn's completion leaves a clean tail, so it fires exactly once per crash.
- UI invisibility is the existing `StripSystemReminders` mechanism — ghost bubble, live broadcast, and the history endpoint all strip it.

## Tests

- `TestSessionEndsMidTurn` — signature table incl. the interrupt-note tail (must NOT match).
- `TestDoAgentTurn_CrashRecoveryReminder` — crashed-tail session: the provider sees the reminder + the user's own text; the history endpoint serves neither.
- `TestDoAgentTurn_NoReminderAfterCleanTurn` — clean tail stays silent.

`go test -race ./...`, `go vet`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)