### PR TITLE
fix(server): PATCH /api/cron-tasks/{name} now supports notify

### DIFF
--- a/internal/server/cron_task_handlers.go
+++ b/internal/server/cron_task_handlers.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"net/http"
+
+	"github.com/Leihb/octo-agent/internal/scheduler"
 )
 
 // ─── GET /api/cron-tasks ────────────────────────────────────────────────────
@@ -55,12 +57,13 @@ func (s *Server) handleRunCronTask(w http.ResponseWriter, r *http.Request) {
 // ─── PATCH /api/cron-tasks/{name} ───────────────────────────────────────────
 
 type patchCronTaskRequest struct {
-	Enabled   *bool   `json:"enabled,omitempty"`
-	Cron      *string `json:"cron,omitempty"`
-	Prompt    *string `json:"prompt,omitempty"`
-	Model     *string `json:"model,omitempty"`
-	Agent     *string `json:"agent,omitempty"`
-	Directory *string `json:"directory,omitempty"`
+	Enabled   *bool                    `json:"enabled,omitempty"`
+	Cron      *string                  `json:"cron,omitempty"`
+	Prompt    *string                  `json:"prompt,omitempty"`
+	Model     *string                  `json:"model,omitempty"`
+	Agent     *string                  `json:"agent,omitempty"`
+	Directory *string                  `json:"directory,omitempty"`
+	Notify    *scheduler.NotifyTargets `json:"notify,omitempty"`
 }
 
 func (s *Server) handlePatchCronTask(w http.ResponseWriter, r *http.Request) {
@@ -108,6 +111,10 @@ func (s *Server) handlePatchCronTask(w http.ResponseWriter, r *http.Request) {
 			}
 			if req.Directory != nil {
 				t.Directory = *req.Directory
+				changed = true
+			}
+			if req.Notify != nil {
+				t.Notify = *req.Notify
 				changed = true
 			}
 			if changed {

--- a/internal/skills/defaults/cron-task-creator/SKILL.md
+++ b/internal/skills/defaults/cron-task-creator/SKILL.md
@@ -115,7 +115,7 @@ curl -s -X PATCH http://127.0.0.1:8080/api/cron-tasks/<name-or-id> \
 curl -s http://127.0.0.1:8080/api/tasks
 ```
 
-Supported PATCH fields: `enabled`, `cron`, `prompt`, `model`, `agent`, `directory`.
+Supported PATCH fields: `enabled`, `cron`, `prompt`, `model`, `agent`, `directory`, `notify`.
 
 ## Other operations
 


### PR DESCRIPTION
Extends PATCH /api/cron-tasks/{name} to accept the  field, so users can add or remove IM notification targets on existing tasks without recreating them.\n\nChanges:\n- Add  to .\n- Apply the notify field in  when provided.\n- Update the  skill docs to list  as a supported PATCH field and include the 'edit file then PATCH' workflow.\n\nCo-authored-by: octo-agent <no-reply@octo-agent.dev>