### PR TITLE
feat(tools): show_artifact — surface script-built files in the artifacts panel

### DIFF
--- a/dev-docs/web-artifacts-panel-design.md
+++ b/dev-docs/web-artifacts-panel-design.md
@@ -34,7 +34,9 @@ Both transport paths already deliver everything the panel needs; detection is fr
 - **Live**: the WS `tool_result` event carries `ui_payload` (`ws_handlers.go`, `wsEventToolResult.UIPayload` in `ws_types.go`). `write_file` emits `{type: "write", path, size_bytes}` (`internal/tools/write_file.go`); `edit_file` emits `{type: "edit", path, occurrences, diff}` (`internal/tools/edit_file.go`).
 - **History**: `GET /api/sessions/:id/messages` reconstructs the same `tool_result` events from persisted `ContentBlock.UI` (`handlers.go`), so the panel rebuilds identically on page reload and session switch.
 
-A single frontend hook inspects each `ui_payload` with `type === "write" || type === "edit"`, matches the path extension against the table above, and upserts the artifact entry. No backend state, no new conventions for the model to learn.
+A single frontend hook inspects each `ui_payload` with `type` of `write`, `edit`, or `artifact`, matches the path extension against the table above, and upserts the artifact entry. No backend state.
+
+**Script-produced files** (built rather than written through the file tools — e.g. web-artifacts-builder's Parcel-bundled `bundle.html`) don't pass through `write_file`, so the `show_artifact` tool (`internal/tools/artifact.go`) covers them: the model calls it with the file's absolute path, it validates existence and previewability, and emits the `{type: "artifact", path, size_bytes}` payload the same hook ingests. The previewable-extension table is owned by the tools package (`tools.ArtifactContentType`) so the tool's validation and the endpoint's gate cannot drift apart.
 
 ## Content endpoint
 
@@ -44,7 +46,7 @@ The payload carries only the path; the panel needs bytes.
 GET /api/sessions/{id}/artifacts?path=<absolute path>
 ```
 
-**Authorization beyond the access key: the path must be one this session's agent wrote.** The handler loads the session transcript and scans `tool_use` blocks (persisted with their `Input` maps, `internal/agent/content.go`) for `write_file`/`edit_file` calls; the requested path must equal one of their `path` inputs after `filepath.Clean`. Anything else is 404. This derives the whitelist from the transcript on each request — no extra state, survives server restarts, and caps disclosure at "files the user already watched the agent write in this very session".
+**Authorization beyond the access key: the path must be one this session's agent wrote or explicitly presented.** The handler loads the session transcript and scans `tool_use` blocks (persisted with their `Input` maps, `internal/agent/content.go`) for `write_file`/`edit_file`/`show_artifact` calls; the requested path must equal one of their `path` inputs after `filepath.Clean`. Anything else is 404. This derives the whitelist from the transcript on each request — no extra state, survives server restarts, and caps disclosure at "files the user already watched the agent write in this very session".
 
 Response headers:
 

--- a/internal/server/artifact_handler.go
+++ b/internal/server/artifact_handler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tools"
 )
 
 // ─── GET /api/sessions/{id}/artifacts?path=… ────────────────────────────────
@@ -23,22 +24,6 @@ import (
 // 413 and the panel offers no preview. Artifact HTML bundles run 200 KB–2 MB.
 const artifactMaxBytes = 10 << 20
 
-// artifactContentTypes maps the previewable extensions to the explicit
-// Content-Type the response carries (never sniffed). Extensions outside this
-// table are not artifacts and are refused.
-var artifactContentTypes = map[string]string{
-	".html":     "text/html; charset=utf-8",
-	".htm":      "text/html; charset=utf-8",
-	".md":       "text/markdown; charset=utf-8",
-	".markdown": "text/markdown; charset=utf-8",
-	".png":      "image/png",
-	".jpg":      "image/jpeg",
-	".jpeg":     "image/jpeg",
-	".gif":      "image/gif",
-	".svg":      "image/svg+xml",
-	".webp":     "image/webp",
-}
-
 func (s *Server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	reqPath := strings.TrimSpace(r.URL.Query().Get("path"))
@@ -47,7 +32,9 @@ func (s *Server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctype, ok := artifactContentTypes[strings.ToLower(filepath.Ext(reqPath))]
+	// The previewable-extension table lives in the tools package so this gate
+	// and the show_artifact tool's validation can't drift apart.
+	ctype, ok := tools.ArtifactContentType(reqPath)
 	if !ok {
 		writeError(w, http.StatusNotFound, "not a previewable artifact type")
 		return
@@ -90,14 +77,16 @@ func (s *Server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 	_, _ = io.Copy(w, f)
 }
 
-// sessionWrotePath reports whether the transcript contains a write_file or
-// edit_file tool_use whose path input matches reqPath (after Clean on both
-// sides — the payloads carry absolute paths, so no base-dir join is needed).
+// sessionWrotePath reports whether the transcript contains a write_file,
+// edit_file, or show_artifact tool_use whose path input matches reqPath
+// (after Clean on both sides — the payloads carry absolute paths, so no
+// base-dir join is needed). show_artifact is how script-produced files
+// (built rather than written through the file tools) enter the whitelist.
 func sessionWrotePath(sess *agent.Session, reqPath string) bool {
 	want := filepath.Clean(reqPath)
 	for _, m := range sess.Messages {
 		for _, b := range m.Blocks {
-			if b.Type != "tool_use" || (b.Name != "write_file" && b.Name != "edit_file") {
+			if b.Type != "tool_use" || (b.Name != "write_file" && b.Name != "edit_file" && b.Name != "show_artifact") {
 				continue
 			}
 			p, ok := b.Input["path"].(string)

--- a/internal/server/artifact_handler_test.go
+++ b/internal/server/artifact_handler_test.go
@@ -129,6 +129,38 @@ func TestHandleGetArtifact_SizeCap(t *testing.T) {
 	}
 }
 
+func TestHandleGetArtifact_ShowArtifactCountsAsWrite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	// Simulates a script-built file surfaced via the show_artifact tool: no
+	// write_file in the transcript, only the show_artifact tool_use.
+	p := filepath.Join(t.TempDir(), "bundle.html")
+	if err := os.WriteFile(p, []byte("<h1>built</h1>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sess := agent.NewSession("stub-model", "")
+	sess.Messages = append(sess.Messages, agent.Message{
+		Role: agent.RoleAssistant,
+		Blocks: []agent.ContentBlock{{
+			Type: "tool_use", ID: "t1", Name: "show_artifact",
+			Input: map[string]any{"path": p},
+		}}})
+	if err := sess.Save(); err != nil {
+		t.Fatal(err)
+	}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	w := getArtifact(t, srv, sess.ID, p)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if w.Body.String() != "<h1>built</h1>" {
+		t.Errorf("body = %q", w.Body.String())
+	}
+}
+
 func TestHandleGetArtifact_EditCountsAsWrite(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)

--- a/internal/server/static/artifacts.js
+++ b/internal/server/static/artifacts.js
@@ -38,9 +38,11 @@ const Artifacts = (() => {
   }
 
   /** Ingest one tool ui_payload. opts.live distinguishes live turns from
-   *  history replay (only live arrivals auto-open the panel). */
+   *  history replay (only live arrivals auto-open the panel). "artifact" is
+   *  show_artifact's payload — script-produced files surfaced explicitly. */
   function observe(uiPayload, opts) {
-    if (!uiPayload || (uiPayload.type !== "write" && uiPayload.type !== "edit")) return;
+    if (!uiPayload) return;
+    if (uiPayload.type !== "write" && uiPayload.type !== "edit" && uiPayload.type !== "artifact") return;
     const path = uiPayload.path;
     if (!path) return;
     const kind = _kindOf(path);

--- a/internal/skills/defaults/web-artifacts-builder/SKILL.md
+++ b/internal/skills/defaults/web-artifacts-builder/SKILL.md
@@ -65,7 +65,7 @@ This creates `bundle.html` — a self-contained file with all JavaScript, CSS, a
 
 ### Step 4: Deliver the Artifact
 
-Report the absolute path of `bundle.html` to the user. The file is fully self-contained — it opens directly in any browser with no server and no network.
+Call the `show_artifact` tool with the absolute path of `bundle.html` — in the web UI this renders it in the Artifacts panel. Then report the path to the user. The file is fully self-contained — it opens directly in any browser with no server and no network.
 
 ### Step 5: Testing/Visualizing the Artifact (Optional)
 

--- a/internal/tools/artifact.go
+++ b/internal/tools/artifact.go
@@ -1,0 +1,101 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// artifactContentTypes maps previewable extensions to the explicit
+// Content-Type served for them. Shared by ShowArtifactTool (early validation
+// with a useful error) and the server's artifact endpoint (response headers
+// and final gate) so the two can't drift apart.
+var artifactContentTypes = map[string]string{
+	".html":     "text/html; charset=utf-8",
+	".htm":      "text/html; charset=utf-8",
+	".md":       "text/markdown; charset=utf-8",
+	".markdown": "text/markdown; charset=utf-8",
+	".png":      "image/png",
+	".jpg":      "image/jpeg",
+	".jpeg":     "image/jpeg",
+	".gif":      "image/gif",
+	".svg":      "image/svg+xml",
+	".webp":     "image/webp",
+}
+
+// ArtifactContentType returns the Content-Type for a previewable artifact
+// path, or ok=false when the extension isn't previewable.
+func ArtifactContentType(path string) (ctype string, ok bool) {
+	ctype, ok = artifactContentTypes[strings.ToLower(filepath.Ext(path))]
+	return ctype, ok
+}
+
+func artifactExtList() string {
+	exts := make([]string, 0, len(artifactContentTypes))
+	for e := range artifactContentTypes {
+		exts = append(exts, e)
+	}
+	sort.Strings(exts)
+	return strings.Join(exts, ", ")
+}
+
+// ShowArtifactTool surfaces an existing file to the user as a previewable
+// artifact. write_file/edit_file payloads already feed the web Artifacts
+// panel automatically; this tool covers files produced any other way —
+// build scripts (e.g. web-artifacts-builder's bundle.html), generators,
+// downloads. Its tool_use block also lands in the session transcript, which
+// is what authorizes the artifact endpoint to serve the path.
+type ShowArtifactTool struct{}
+
+func (ShowArtifactTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "show_artifact",
+		Description: "Present a previewable file (HTML page, Markdown document, or image) to the " +
+			"user as an artifact. Use after a file was produced by a script or build step — " +
+			"files you create with write_file are surfaced automatically and don't need this. " +
+			"In the web UI the file appears in the Artifacts panel; in other clients the path " +
+			"is simply reported. The file must already exist.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Absolute path of the file to present. Previewable types: " + artifactExtList() + ".",
+				},
+			},
+			"required": []string{"path"},
+		},
+	}
+}
+
+func (ShowArtifactTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	path := strings.TrimSpace(stringArg(input, "path"))
+	if path == "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("show_artifact: path is required")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("show_artifact: %w", err)
+	}
+	if _, ok := ArtifactContentType(abs); !ok {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("show_artifact: %q is not a previewable type (want %s)", abs, artifactExtList())
+	}
+	fi, err := os.Stat(abs)
+	if err != nil {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("show_artifact: %w", err)
+	}
+	if fi.IsDir() {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("show_artifact: %q is a directory", abs)
+	}
+
+	ui := map[string]any{"type": "artifact", "path": abs, "size_bytes": fi.Size()}
+	return agent.ToolResult{
+		Text: fmt.Sprintf("Artifact presented: %s (%d bytes)", abs, fi.Size()),
+		UI:   ui,
+	}, nil
+}

--- a/internal/tools/artifact_test.go
+++ b/internal/tools/artifact_test.go
@@ -1,0 +1,65 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestShowArtifact_HappyPath(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "bundle.html")
+	if err := os.WriteFile(p, []byte("<h1>x</h1>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := (ShowArtifactTool{}).Execute(context.Background(), "show_artifact", map[string]any{"path": p})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	ui, ok := res.UI.(map[string]any)
+	if !ok {
+		t.Fatalf("UI payload type %T", res.UI)
+	}
+	if ui["type"] != "artifact" || ui["path"] != p {
+		t.Errorf("ui = %+v", ui)
+	}
+	if !strings.Contains(res.Text, p) {
+		t.Errorf("Text = %q, want it to carry the path", res.Text)
+	}
+}
+
+func TestShowArtifact_Errors(t *testing.T) {
+	dir := t.TempDir()
+	goFile := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(goFile, []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name  string
+		input map[string]any
+	}{
+		{"missing path", map[string]any{}},
+		{"nonexistent file", map[string]any{"path": filepath.Join(dir, "nope.html")}},
+		{"non-previewable extension", map[string]any{"path": goFile}},
+		{"directory", map[string]any{"path": dir + string(filepath.Separator) + "sub.html"}},
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "sub.html"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range cases {
+		if _, err := (ShowArtifactTool{}).Execute(context.Background(), "show_artifact", c.input); err == nil {
+			t.Errorf("%s: want error", c.name)
+		}
+	}
+}
+
+func TestArtifactContentType(t *testing.T) {
+	if ct, ok := ArtifactContentType("/x/y/Report.MD"); !ok || !strings.HasPrefix(ct, "text/markdown") {
+		t.Errorf("case-insensitive ext: ct=%q ok=%v", ct, ok)
+	}
+	if _, ok := ArtifactContentType("/x/y/binary.exe"); ok {
+		t.Error("exe should not be previewable")
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -30,6 +30,7 @@ var allTools = []tool{
 	ReadFileTool{},
 	WriteFileTool{},
 	EditFileTool{},
+	ShowArtifactTool{},
 	GlobTool{},
 	GrepTool{},
 	WebFetchTool{},


### PR DESCRIPTION
## Gap being closed

The Artifacts panel (#574) detects `write_file`/`edit_file` ui_payloads — but files produced by **scripts** (web-artifacts-builder's Parcel-bundled `bundle.html` (#575), generators, downloads) never pass through the file tools, so the panel couldn't see them and the content endpoint's transcript whitelist wouldn't serve them.

## What

New `show_artifact` tool (`internal/tools/artifact.go`):

- Model calls it with an absolute path after a build step produces a previewable file; `write_file`-created files don't need it (the description says so).
- Validates existence + previewable extension (clear error listing supported types), emits `{type: "artifact", path, size_bytes}` — ingested by the panel's existing observe hook, live and on history replay alike.
- Its `tool_use` block in the transcript is what authorizes `GET /api/sessions/{id}/artifacts` to serve the path — `sessionWrotePath` now accepts `show_artifact` alongside write/edit. Same derivation, no new state; all existing 404/413/sandbox guarantees unchanged.
- The previewable-extension table moves to `tools.ArtifactContentType` (server imports tools already), so the tool's validation and the endpoint's gate share one source and can't drift.
- `web-artifacts-builder` default skill's deliver step now calls the tool, then reports the path.
- Design doc updated to current state.

## Verification

- Tool unit tests: happy path payload shape, missing/nonexistent/non-previewable/directory errors, case-insensitive extension mapping.
- Handler test: a transcript containing **only** a `show_artifact` tool_use (no write_file) serves the file 200 — the exact script-built scenario.
- `node --check` on artifacts.js; `go test -race ./...`, vet, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)