### PR TITLE
feat(skills): teach external skills to preflight runtime dependencies

### DIFF
--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -345,7 +345,11 @@ const ccCompatNote = "This skill may have been written for Claude Code. In this 
 	"directory across terminal calls — use absolute paths, or chain `cd … && …` " +
 	"inside one command. If the skill depends on a Claude Code feature with no " +
 	"equivalent here (hooks, plan mode, output styles), tell the user instead of " +
-	"improvising."
+	"improvising. Skills are often authored for managed sandboxes with interpreters " +
+	"and libraries preinstalled — this machine makes no such guarantee. Before the " +
+	"first step that needs a runtime, verify it (e.g. `python3 -c 'import openpyxl'`, " +
+	"`node -v`, `soffice --version`); if anything is missing, list what's needed and " +
+	"ask the user before installing — never install into their environment unasked."
 
 // RenderSkill produces the text handed to the model when a skill is loaded —
 // via the `skill` tool (model-initiated) or a /<name> trigger (user-initiated).

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -226,8 +226,13 @@ func TestRenderSkill(t *testing.T) {
 	// User/project skills get the Claude Code → octo bridging note; octo-native
 	// defaults don't.
 	u := Skill{Name: "ext", Body: "B", Dir: "/d", Source: "user"}
-	if got := RenderSkill(u, ""); !strings.Contains(got, "Bash → terminal") {
-		t.Errorf("user skill should carry the compat note; got:\n%s", got)
+	uGot := RenderSkill(u, "")
+	if !strings.Contains(uGot, "Bash → terminal") {
+		t.Errorf("user skill should carry the compat note; got:\n%s", uGot)
+	}
+	// Runtime-dependency preflight: verify before use, ask before installing.
+	if !strings.Contains(uGot, "ask the user before installing") {
+		t.Errorf("compat note should carry the dependency-preflight guidance; got:\n%s", uGot)
 	}
 	d := Skill{Name: "wt", Body: "B", Dir: "/d", Source: "default"}
 	if got := RenderSkill(d, ""); strings.Contains(got, "Bash → terminal") {


### PR DESCRIPTION
## Problem

Ecosystem skills are typically authored for managed sandboxes with interpreters and libraries preinstalled — the anthropics xlsx skill literally says *"You can assume LibreOffice is installed"*. On a user machine, python3 / openpyxl / markitdown / LibreOffice / Node may be absent, and today the failure lands **mid-task**: `ModuleNotFoundError` after files were already modified, the model flailing through `pip install` → PEP 668 `externally-managed-environment` loops, or installing into the user's environment without asking.

## Fix (layer 1 of the options discussed — user-selected)

One addition to the load-time compat note that already covers every user/project skill (#567): before the first step that needs a runtime, **verify it** (`python3 -c 'import openpyxl'`, `node -v`, `soffice --version`); if missing, **list what's needed and ask** — never install unasked.

Covers all external skills past and future with zero per-skill work, zero new conventions, and no change to skill content. Default skills skip the note as before (ours already carry explicit Requirements lines / script-level checks).

Declared-dependency frontmatter (`requires:`) and an `octo skills doctor` command were considered and deferred — revisit if instruction-level preflight proves insufficient.

## Verification

`TestRenderSkill` asserts the preflight guidance renders for user-source skills; `go test -race ./internal/skills/`, vet, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)