### PR TITLE
feat: memory save-nudge + IM parity (memory L2, interactive permission ask)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -688,17 +688,18 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// Attention layer: re-surface MEMORY.md's structured rules (## 必须遵守 /
 	// ## 触发提醒) on the message stream at the point of action. This rides each
 	// user turn rather than the cached system prompt, so the prompt prefix stays
-	// byte-stable. A MEMORY.md without those sections yields no hook — unchanged
-	// behaviour.
+	// byte-stable. The same injector carries the save-nudge, appended to a tool
+	// result when a milestone-shaped command (gh pr create/merge) lands, so the
+	// injector is wired even when MEMORY.md has no structured rules — Reminder
+	// is silent then.
 	if memDir != "" {
 		rules := memory.ParseRules(memDir)
 		if homeMemDir != "" {
 			rules.Merge(memory.ParseRules(homeMemDir))
 		}
-		if rules.HasAny() {
-			inj := memory.NewInjector(rules)
-			a.UserInputHook = inj.Reminder
-		}
+		inj := memory.NewInjector(rules)
+		a.UserInputHook = inj.Reminder
+		a.ToolResultHook = inj.SaveNudge
 	}
 
 	// Permission engine — gates every tool call; shared by both paths. The

--- a/dev-docs/memory-design.md
+++ b/dev-docs/memory-design.md
@@ -55,10 +55,11 @@ what the agent writes now surfaces in the *next* session, not the current one.
 
 The session-prompt guidance (`internal/prompt/base.md`, "Memory" section)
 covers when to save (lasting preferences, corrections + the why, validated
-judgment, external resources), what not to save (one-off task state, anything
-derivable from the repo, secrets), grounding answers in memory with a brief
-inline attribution, and verifying a remembered file/flag still exists before
-acting on it.
+judgment, project decisions and milestones — the rationale and the
+alternatives ruled out, not the diff — and external resources), what not to
+save (one-off task state, the content of code changes, secrets), grounding
+answers in memory with a brief inline attribution, and verifying a remembered
+file/flag still exists before acting on it.
 
 ## Attention layer — structured rules, re-surfaced at the point of action
 
@@ -90,7 +91,32 @@ turn). The reminder rides the message stream rather than the system prompt, so
 the cached prompt prefix stays byte-stable across the session.
 
 A MEMORY.md without these sections — the plain pointer-index format — parses to
-zero rules, sets no hook, and behaves exactly as before.
+zero rules and the per-turn reminder stays silent; the injector is still wired,
+because it also carries the save-nudge below.
+
+## Save-nudge — a one-shot reminder when a milestone lands
+
+The reverse of recall: prompting the agent to *write* memory at the moment
+there is something worth writing. When a terminal command matching
+`gh pr create` / `gh pr merge` succeeds, `memory.Injector.SaveNudge` appends a
+`<system-reminder>` to that tool call's result asking the agent to record any
+durable decision — the rationale, the alternatives ruled out, constraints
+future sessions must respect — and to stay quiet if nothing qualifies. The
+nudge rides the tool result, so the model reads it in the same turn the
+milestone happened rather than next session, and the cached prompt prefix
+stays untouched.
+
+The match is deliberately narrow (a noisy nudge trains the model to ignore
+it): only the `terminal` tool, only those two `gh` subcommands, and at most
+once per user turn — the latch re-arms on the next `Reminder` call, so a long
+session nudges once per milestone-bearing turn, not once ever.
+
+Delivery uses `agent.ToolResultHook`, the tool-result counterpart of
+`UserInputHook`: the run loop invokes it serially after each tool batch is
+dispatched (never inside the parallel read-only path, so the latch needs no
+locking), skips denied and errored calls, and appends a non-empty return to
+the matching tool_result text. `cmd/octo` and the server wire both hooks to
+the same injector whenever a memory directory exists.
 
 ## Writing — file tools, whitelisted directory
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -189,6 +189,16 @@ type Agent struct {
 	// caller relies on elsewhere — it's invoked once per appended user turn.
 	UserInputHook func(userInput string) string
 
+	// ToolResultHook, when set, is called once per successfully executed tool
+	// call, after the whole batch has been dispatched. A non-empty return is
+	// appended to that call's tool_result text (separated by a blank line) —
+	// the channel for surfacing a reminder at the exact moment an action
+	// completed (e.g. the memory save-nudge after a PR merge). It is invoked
+	// serially from the run loop even when the batch itself ran in parallel,
+	// so implementations need no locking of their own. Denied and errored
+	// calls are skipped — a failed action is not a milestone.
+	ToolResultHook func(name string, input map[string]any) string
+
 	// pendingUserBlocks holds content blocks (e.g. images pasted in the TUI)
 	// to merge into the next user message. Set via AttachUserBlocks and
 	// consumed exactly once by the next appendUserInput, alongside the text.
@@ -681,6 +691,10 @@ func (a *Agent) runLoop(
 			if err != nil {
 				return Reply{}, fmt.Errorf("agent: dispatch tools[%d]: %w", i, err)
 			}
+
+			// Decorate results before events and history so every surface
+			// (model, UI stream, persisted session) sees the same text.
+			applyToolResultHook(a.ToolResultHook, reply.Blocks, resultBlocks)
 
 			// Emit EventToolDone / EventToolError per result, pairing
 			// each result with the originating tool_use block so ToolName
@@ -1188,6 +1202,39 @@ func toolResultBlocks(id string, result ToolResult, err error) []ContentBlock {
 	blocks = append(blocks, rb)
 	blocks = append(blocks, result.Blocks...)
 	return blocks
+}
+
+// applyToolResultHook appends the hook's output to each matching successful
+// tool_result block. It runs serially after dispatchTools returns — never
+// inside the parallel read-only batch — so a stateful hook (the memory
+// save-nudge latch) needs no locking. Denied and errored calls carry
+// IsError=true and are skipped.
+func applyToolResultHook(hook func(name string, input map[string]any) string, uses, results []ContentBlock) {
+	if hook == nil {
+		return
+	}
+	byID := make(map[string]*ContentBlock, len(results))
+	for i := range results {
+		if results[i].Type == "tool_result" && !results[i].IsError {
+			byID[results[i].ToolUseID] = &results[i]
+		}
+	}
+	for _, u := range uses {
+		if u.Type != "tool_use" {
+			continue
+		}
+		rb := byID[u.ID]
+		if rb == nil {
+			continue
+		}
+		if extra := hook(u.Name, u.Input); extra != "" {
+			if rb.Result == "" {
+				rb.Result = extra
+			} else {
+				rb.Result += "\n\n" + extra
+			}
+		}
+	}
 }
 
 // flattenResults collapses a per-tool slice-of-slices into a single flat slice.

--- a/internal/agent/toolresulthook_test.go
+++ b/internal/agent/toolresulthook_test.go
@@ -1,0 +1,104 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestToolResultHook_AppendsToMatchingResult(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{
+			{
+				StopReason: "tool_use",
+				Blocks: []ContentBlock{
+					NewToolUseBlock("call-1", "terminal", map[string]any{"command": "gh pr merge 7"}),
+				},
+			},
+			{Content: "done", StopReason: "end_turn"},
+		},
+	}
+	exec := &fakeExecutor{results: map[string]string{"terminal": "merged"}}
+	a := New(send, "m")
+	a.ToolResultHook = func(name string, input map[string]any) string {
+		if name != "terminal" {
+			t.Errorf("hook saw tool %q, want terminal", name)
+		}
+		if cmd, _ := input["command"].(string); cmd != "gh pr merge 7" {
+			t.Errorf("hook saw command %q", cmd)
+		}
+		return "<nudge>"
+	}
+
+	if _, err := a.Run(context.Background(), "merge it", []ToolDefinition{{Name: "terminal"}}, exec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// The model's second call must carry the decorated result.
+	var got string
+	for _, m := range send.gotMsgs {
+		for _, b := range m.Blocks {
+			if b.Type == "tool_result" && b.ToolUseID == "call-1" {
+				got = b.Result
+			}
+		}
+	}
+	if want := "merged\n\n<nudge>"; got != want {
+		t.Errorf("tool_result text = %q, want %q", got, want)
+	}
+}
+
+func TestToolResultHook_EmptyReturnLeavesResultUntouched(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{
+			{
+				StopReason: "tool_use",
+				Blocks: []ContentBlock{
+					NewToolUseBlock("call-1", "terminal", map[string]any{"command": "ls"}),
+				},
+			},
+			{Content: "done", StopReason: "end_turn"},
+		},
+	}
+	exec := &fakeExecutor{results: map[string]string{"terminal": "files"}}
+	a := New(send, "m")
+	a.ToolResultHook = func(string, map[string]any) string { return "" }
+
+	if _, err := a.Run(context.Background(), "list", []ToolDefinition{{Name: "terminal"}}, exec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, m := range send.gotMsgs {
+		for _, b := range m.Blocks {
+			if b.Type == "tool_result" && b.Result != "files" {
+				t.Errorf("tool_result text = %q, want untouched %q", b.Result, "files")
+			}
+		}
+	}
+}
+
+func TestApplyToolResultHook_SkipsErroredAndUnmatched(t *testing.T) {
+	uses := []ContentBlock{
+		NewToolUseBlock("ok", "terminal", map[string]any{"command": "gh pr create"}),
+		NewToolUseBlock("bad", "terminal", map[string]any{"command": "gh pr merge"}),
+	}
+	results := []ContentBlock{
+		NewToolResultBlock("ok", "created", false),
+		NewToolResultBlock("bad", "denied", true),
+	}
+	var seen []string
+	applyToolResultHook(func(name string, input map[string]any) string {
+		cmd, _ := input["command"].(string)
+		seen = append(seen, cmd)
+		return "N"
+	}, uses, results)
+
+	if len(seen) != 1 || seen[0] != "gh pr create" {
+		t.Errorf("hook calls = %v, want only the successful call", seen)
+	}
+	if !strings.HasSuffix(results[0].Result, "\n\nN") {
+		t.Errorf("successful result not decorated: %q", results[0].Result)
+	}
+	if results[1].Result != "denied" {
+		t.Errorf("errored result must stay untouched: %q", results[1].Result)
+	}
+}

--- a/internal/memory/injector.go
+++ b/internal/memory/injector.go
@@ -5,16 +5,26 @@ package memory
 // the system prompt, so the cached prompt prefix stays byte-stable across the
 // session. Always-apply rules are restated every turn; triggered rules surface
 // only when user input hits one of their keywords, and at most once per session.
+//
+// The injector also carries the save-nudge: a one-shot reminder appended to a
+// tool result when the session just did something milestone-shaped (a PR was
+// created or merged), prompting the agent to record durable decisions in its
+// memory directory while the moment is still in front of it.
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // Injector holds session-scoped recall state for a parsed rule set.
 type Injector struct {
 	rules    *Rules
 	recalled map[string]bool // triggered rules already surfaced this session, keyed by text
+	nudged   bool            // save-nudge already emitted this turn; reset on the next user input
 }
 
-// NewInjector builds an injector over the given rules.
+// NewInjector builds an injector over the given rules. rules may be nil or
+// empty — the injector then serves only the save-nudge.
 func NewInjector(rules *Rules) *Injector {
 	return &Injector{rules: rules, recalled: make(map[string]bool)}
 }
@@ -23,7 +33,13 @@ func NewInjector(rules *Rules) *Injector {
 // there is nothing to surface this turn. It combines the always-apply tier
 // (every turn) with any newly-triggered rules matched against userInput.
 func (in *Injector) Reminder(userInput string) string {
-	if in == nil || in.rules == nil {
+	if in == nil {
+		return ""
+	}
+	// A new user turn re-arms the save-nudge: at most one nudge per turn, not
+	// one per session — a long session can hit several milestones.
+	in.nudged = false
+	if in.rules == nil {
 		return ""
 	}
 
@@ -131,4 +147,31 @@ func isWordByte(b byte) bool {
 		(b >= 'a' && b <= 'z') ||
 		(b >= 'A' && b <= 'Z') ||
 		(b >= '0' && b <= '9')
+}
+
+// milestoneCommand matches terminal commands that mark a unit of work landing:
+// a PR created or merged via the gh CLI. Deliberately narrow — a noisy nudge
+// trains the model to ignore it.
+var milestoneCommand = regexp.MustCompile(`(^|[^[:alnum:]_])gh\s+pr\s+(create|merge)\b`)
+
+// saveNudgeText is appended to the milestone tool call's result, so the model
+// reads it in the same turn the milestone happened, not next session.
+const saveNudgeText = "<system-reminder>\n" +
+	"A pull request was just created or merged. If this work settled anything durable — a decision (especially an approach ruled OUT), a milestone, or a constraint future sessions must respect — record it in your memory directory now, per the Memory section of your instructions. The diff and git log already hold WHAT changed; memory is for the why, the alternatives rejected, and the don't-redo-this. If nothing here is durable, carry on.\n" +
+	"</system-reminder>"
+
+// SaveNudge is the agent's ToolResultHook: it returns the save-nudge reminder
+// when toolName/input is a milestone-shaped terminal command, at most once per
+// user turn (Reminder re-arms it). It is called serially from the agent run
+// loop, so the latch needs no locking.
+func (in *Injector) SaveNudge(toolName string, input map[string]any) string {
+	if in == nil || in.nudged || toolName != "terminal" {
+		return ""
+	}
+	cmd, _ := input["command"].(string)
+	if !milestoneCommand.MatchString(cmd) {
+		return ""
+	}
+	in.nudged = true
+	return saveNudgeText
 }

--- a/internal/memory/injector_test.go
+++ b/internal/memory/injector_test.go
@@ -74,3 +74,62 @@ func TestReminder_NilSafe(t *testing.T) {
 		t.Errorf("nil injector should return empty, got %q", got)
 	}
 }
+
+// ─── Save-nudge ─────────────────────────────────────────────────────────────
+
+func term(cmd string) map[string]any { return map[string]any{"command": cmd} }
+
+func TestSaveNudge_FiresOnMilestoneCommands(t *testing.T) {
+	for _, cmd := range []string{
+		"gh pr create --title x",
+		"gh pr merge 42 --squash",
+		"cd /repo && gh pr merge",
+	} {
+		in := NewInjector(nil)
+		got := in.SaveNudge("terminal", term(cmd))
+		if !strings.Contains(got, "<system-reminder>") {
+			t.Errorf("command %q: expected nudge, got %q", cmd, got)
+		}
+	}
+}
+
+func TestSaveNudge_SilentOnEverythingElse(t *testing.T) {
+	in := NewInjector(nil)
+	cases := []struct {
+		tool string
+		in   map[string]any
+	}{
+		{"terminal", term("git status")},
+		{"terminal", term("gh pr view 42")},
+		{"terminal", term("gh pr list")},
+		{"terminal", term("echo gh prX merge")},
+		{"terminal", map[string]any{}}, // no command key
+		{"write_file", term("gh pr merge")},
+	}
+	for _, c := range cases {
+		if got := in.SaveNudge(c.tool, c.in); got != "" {
+			t.Errorf("tool %s input %v: expected silence, got %q", c.tool, c.in, got)
+		}
+	}
+}
+
+func TestSaveNudge_OncePerTurn_RearmedByReminder(t *testing.T) {
+	in := NewInjector(nil)
+	if in.SaveNudge("terminal", term("gh pr create")) == "" {
+		t.Fatal("first milestone should nudge")
+	}
+	if got := in.SaveNudge("terminal", term("gh pr merge 1")); got != "" {
+		t.Errorf("second milestone in same turn should be silent, got %q", got)
+	}
+	in.Reminder("next user turn") // new turn re-arms the latch
+	if in.SaveNudge("terminal", term("gh pr merge 2")) == "" {
+		t.Error("milestone on a later turn should nudge again")
+	}
+}
+
+func TestSaveNudge_NilSafe(t *testing.T) {
+	var in *Injector
+	if got := in.SaveNudge("terminal", term("gh pr merge")); got != "" {
+		t.Errorf("nil injector should return empty, got %q", got)
+	}
+}

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -47,9 +47,10 @@ The moment you notice a signal worth carrying forward:
 - A lasting preference, role, or constraint ("I'm on the Go team", "always run tests before committing").
 - A correction ("don't do X") — save the rule **and** the WHY they gave (often a past incident).
 - A non-obvious choice the user accepts without pushback — validated judgment matters too, not just corrections.
+- A project decision or milestone — a direction settled, an approach **rejected** ("considered X, decided against — don't re-propose"), a phase shipped. The diff and git log already record *what* changed; save the *why*, the alternatives ruled out, and any constraint future sessions must respect.
 - An external resource and what it's for (a dashboard, ticket project, channel, repo).
 
-Do **not** save one-off task state, anything derivable from the code / git log / CLAUDE.md / .octorules, debug recipes already in the code, or secrets/tokens/credentials.
+Do **not** save one-off task state, the content of code changes (the diff and git log already hold those), anything already in CLAUDE.md / .octorules, debug recipes already in the code, or secrets/tokens/credentials.
 
 ### Grounding answers in memory
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -524,7 +524,10 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	}
 	a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
 
-	// L2: attention-layer rules injected per user turn (triggered keywords).
+	// L2: attention-layer rules injected per user turn (triggered keywords),
+	// plus the save-nudge appended to milestone tool results. The injector is
+	// created even when MEMORY.md has no structured rules — Reminder is silent
+	// then, but the nudge still needs the per-session latch.
 	if s.memDir != "" {
 		s.injectorMu.Lock()
 		inj, ok := s.sessionInjectors[sess.ID]
@@ -533,15 +536,12 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 			if s.homeMemDir != "" {
 				rules.Merge(memory.ParseRules(s.homeMemDir))
 			}
-			if rules.HasAny() {
-				inj = memory.NewInjector(rules)
-				s.sessionInjectors[sess.ID] = inj
-			}
+			inj = memory.NewInjector(rules)
+			s.sessionInjectors[sess.ID] = inj
 		}
 		s.injectorMu.Unlock()
-		if inj != nil {
-			a.UserInputHook = inj.Reminder
-		}
+		a.UserInputHook = inj.Reminder
+		a.ToolResultHook = inj.SaveNudge
 	}
 
 	if sess.Model != "" {


### PR DESCRIPTION
## Why

octo's memory machinery matches the Claude Code model (per-repo dir, MEMORY.md injection, file-tool self-management), but it never proactively recorded project decisions and progress the way Claude Code does. Two causes:

1. **The "When to save" guidance had no project-decision category.** Worse, "don't save anything derivable from git log" read as a reason to skip recording that a PR landed or an approach was rejected — even though git log only records *what* changed, not *why* or *what not to re-propose*.
2. **No save trigger at the moment a milestone lands.** The save instruction lived only in the frozen system prompt, dozens of turns away by the time a PR merges. (The attention layer solved exactly this problem for *recall*, but nothing did it for *writing*.)

## What

- **`internal/prompt/base.md`** — add a project-decision/milestone bullet to "When to save" (save the why and the rejected alternatives, not the diff); narrow the exclusion to the content of code changes.
- **`agent.ToolResultHook`** — tool-result counterpart of `UserInputHook`. Invoked serially in `runLoop` after `dispatchTools` returns (never inside the parallel read-only batch, so stateful hooks need no locking); skips denied/errored calls; a non-empty return is appended to the matching tool_result text, so every surface (model, UI stream, persisted session) sees the same text.
- **`memory.Injector.SaveNudge`** — emits a one-shot `<system-reminder>` when a successful `terminal` call matches `gh pr create`/`gh pr merge`. At most once per user turn; `Reminder` re-arms the latch, so long sessions nudge once per milestone-bearing turn, not once ever. Match kept deliberately narrow — a noisy nudge trains the model to ignore it.
- **Wiring** — CLI (`chat.go`), server (`buildAgent`), and the IM channel agent factory (`initChannels`) now create the injector whenever a memory dir exists (previously gated on `rules.HasAny()`); a MEMORY.md without structured rules keeps a silent `Reminder`, unchanged behaviour.
- **`dev-docs/memory-design.md`** — documents the save-nudge layer.

## Tests

- `internal/agent`: hook appended to matching result and seen by the model on the next round; empty return untouched; errored/unmatched calls skipped.
- `internal/memory`: fires on create/merge (incl. compound commands), silent on `gh pr view`/`list`/other tools/missing command, once-per-turn latch re-armed by `Reminder`, nil-safe.
- `make test` (race), `make vet`, `make fmt-check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commits (same session)

**`afbc0ec` — IM channel memory L2 parity.** Channel sessions already had the static MEMORY.md injection; they now get the attention-layer reminder and the save-nudge too. The injector is created per factory call — channel agents live as long as their session, so per-session recall/latch state rides the agent with no shared map.

**`1e4b106` — IM interactive permission ask, aligned with web.** Previously the IM gate was strict + nil asker (ask → deny), and a permission-engine construction failure silently ran tools **ungated**. Now:

- Per-turn gate in `handleChannelMessage` with the configured permission mode (`resolvePermissionMode`), mirroring `prepareToolTurn`; engine failure aborts the turn.
- `channelPermissionAsk` posts the question into the chat (tool name + salient-arg preview, 200-char cap) and claims the session's **next message** as the answer via `Session.BeginAsk`/`DeliverAskReply` — routed in the adapter inbound hook before a new turn can spawn, so the reply never deadlocks behind the turn holding `runMu`. Only an explicit affirmative (yes/y/ok/allow/是/可以/同意/允许) allows; 5-minute timeout (same as web) and `/stop` (ctx cancel) deny. `remember` stays false — chat approvals are one-shot.
- `buildChannelGate` and the factory-time gate removed; `dev-docs/unified-session-bootstrap.md` updated to current state (all three entry points: per-turn gate, transport-specific asker, no ungated fallback).

Tests: `Session` ask-slot semantics (pass-through / consume-once / stale-release), `channelPermissionAsk` allow/deny/cancel against a fake adapter, reply parsing, prompt preview + truncation. Full `make test` (race) / `vet` / `fmt-check` clean.

---

## Follow-up commits — recall/write-quality + eval (same session)

**`3e39a1b` — three recall/write-quality gaps:**
- **Correction save-nudge.** `Reminder` now also fires when user input carries correction / standing-instruction language (don't/never/always/from now on/不要/别再/记住/以后都/每次都/下次), appending a save-signal asking the agent to record the rule + the why. Works with zero structured rules. Corrections are the highest-value memory class — missing one repeats the mistake.
- **IM injection freshness.** Channel sessions live for weeks but their memory was frozen at session creation. `refreshChannelMemory` stamp-checks MEMORY.md (`memory.IndexStamp`, mtime+size) at each turn start under the run lock and re-composes L1+L2 only on change, keeping the prompt byte-stable (cache warm) otherwise.
- **Budget pre-warning + orphan lint.** The injected index and `octo memory` now warn at ≥80% of the 200-line/25KB budget (pruning still loss-free), not only after truncation. Lint also flags topic files MEMORY.md never references (unrecallable).

**`d822338` — eval coverage.** octo-eval gains multi-session tasks (`prompts:` list → sequential sessions sharing one work dir + isolated HOME) and `OCTO_EVAL_RUN_DIR` for verify, plus three `memory-*` scenarios (correction saved, fact recalled cross-session, always-apply rule changes behaviour). Harness plumbing unit-tested with a fake octo; live run left to a configured eval env.

Full `make test` (race) / `vet` / `fmt-check` clean throughout.