### PR TITLE
feat(skills): platform-specific Node/bash install guidance in default skills

### DIFF
--- a/internal/skills/defaults/web-access/SKILL.md
+++ b/internal/skills/defaults/web-access/SKILL.md
@@ -14,13 +14,19 @@ metadata:
 
 ## 前置检查
 
-在开始联网操作前，先检查 CDP 模式可用性：
+CDP 模式必需 **Node.js 22+**（使用原生 WebSocket）。check-deps 脚本自身也要靠 node 运行，所以先确认 node 存在（`node -v`）。**node 缺失或版本过低时不要擅自安装**——告诉用户 CDP 模式需要 Node.js 22+，并给出对应平台的安装方式，等用户确认：
+
+- Windows: `winget install OpenJS.NodeJS.LTS`（或 https://nodejs.org 下载安装包）
+- macOS: `brew install node`
+- Linux: 发行版包管理器或 https://nodejs.org
+
+没有 Node 时本技能并非不可用：静态层（内置 `web_fetch` / `web_search`）不依赖 Node，可先用静态层完成任务，仅在确需浏览器操作时再请用户安装。
+
+node 就绪后，检查 CDP 模式可用性：
 
 ```bash
 node "<SKILL_DIR>/scripts/check-deps.mjs"
 ```
-
-**Node.js 22+** 必需（使用原生 WebSocket）。
 
 按脚本输出处理：
 - `exit 0` → 继续

--- a/internal/skills/defaults/web-artifacts-builder/SKILL.md
+++ b/internal/skills/defaults/web-artifacts-builder/SKILL.md
@@ -15,7 +15,10 @@ To build a powerful frontend artifact — a self-contained single HTML file that
 
 **Stack**: React 18 + TypeScript + Vite + Parcel (bundling) + Tailwind CSS + shadcn/ui
 
-**Requirements**: Node.js 18+ on PATH (the init script checks and reports if missing).
+**Requirements**: `bash` and Node.js 18+ on PATH. Verify both before starting (`bash --version`, `node -v`). If either is missing, tell the user what to install and wait for their go-ahead — never install unasked:
+
+- Node.js — Windows: `winget install OpenJS.NodeJS.LTS` (or https://nodejs.org); macOS: `brew install node`; Linux: distro package manager or https://nodejs.org
+- bash on Windows — the scripts are bash; Git for Windows provides it (`winget install Git.Git`, then use Git Bash's `bash.exe`). Without bash or WSL this skill cannot run on Windows — say so plainly; do not attempt to translate the scripts to PowerShell.
 
 Note: the `scripts/` paths are relative to this skill's directory (its absolute path is in the header above) — invoke them as `bash <skill-dir>/scripts/init-artifact.sh`. Run the project itself in the user's working directory, not inside the skill directory.
 


### PR DESCRIPTION
## Problem

Asked: *does octo clearly guide a Windows user to install Node when a skill needs it?* It didn't — and on Windows the failure lands even earlier than Node:

- `web-artifacts-builder`'s scripts are bash; octo's Windows `terminal` is PowerShell, so `bash …` fails with *"'bash' is not recognized"* **before** the init script's own Node version check can run.
- `web-access`'s `check-deps.mjs` needs node to execute, so it can't diagnose a missing node (chicken-and-egg), and it contains no install guidance.
- What happened next was pure model improvisation — usually right-ish, but not guaranteed, not platform-aware, and nothing stopped an unasked install.

## Fix (instruction-level, two SKILL.md files)

- **web-artifacts-builder**: Requirements now lists `bash` + Node 18+, says to verify both up front (`bash --version`, `node -v`), gives platform-correct install commands (winget / brew / distro), and states plainly that without bash/WSL the skill cannot run on Windows — explicitly forbidding a PowerShell translation attempt of the scripts.
- **web-access**: preflight section now leads with "check `node -v` *before* running check-deps" (the script can't self-diagnose a missing runtime), gives the same per-platform install commands, requires asking the user before installing, and points the model at the static layer (built-in `web_fetch`/`web_search`) as the no-Node fallback so the skill stays useful.

Both align with the #582 principle: list what's needed, ask, never install unasked.

## Verification

`go test ./internal/skills/` green (content-only change; embed/materialize covered by existing tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)