### PR TITLE
feat(tools): platform install-trap guidance for Windows and macOS sessions

### DIFF
--- a/cmd/octo/envcontext.go
+++ b/cmd/octo/envcontext.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/Leihb/octo-agent/internal/tools"
 )
 
 // buildEnvContext renders a snapshot of the working environment for the
@@ -32,16 +34,10 @@ func buildEnvContext(cwd string) string {
 	}
 	fmt.Fprintf(&b, "- Today's date: %s\n", time.Now().Format("2006-01-02"))
 	fmt.Fprintf(&b, "- OS/arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
-	if runtime.GOOS == "windows" {
-		// The `terminal` tool runs commands through PowerShell here, not POSIX
-		// sh — steer the model away from emitting `ls`/`grep`/`rm -rf`/`&&`-on-
-		// cmd and toward PowerShell. The cross-platform built-in tools are the
-		// better default regardless.
-		b.WriteString("- Shell: PowerShell. Use PowerShell syntax and cmdlets " +
-			"(Get-ChildItem, Get-Content, Select-String, Remove-Item, $env:VAR), not POSIX sh. " +
-			"Chain commands with `;` rather than `&&` (Windows PowerShell 5.1 lacks `&&`). " +
-			"Prefer the built-in read_file / glob / grep tools over shelling out — they're identical across platforms.\n")
-	}
+	// Platform-shell guidance (PowerShell dialect + the install/PATH/UAC traps
+	// on Windows, sudo/PATH/CLT traps on macOS) lives in internal/tools next
+	// to the shell selection itself, shared with the server's context builder.
+	b.WriteString(tools.ShellEnvNote())
 	return b.String()
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -677,6 +677,9 @@ func buildEnvContext(cwd string) string {
 		fmt.Fprintf(&b, "- Working directory: %s\n", cwd)
 	}
 	fmt.Fprintf(&b, "- Today's date: %s\n", time.Now().Format("2006-01-02"))
+	// Platform-shell guidance (dialect + install/PATH traps), shared with the
+	// CLI builder so web sessions get the same orientation.
+	b.WriteString(tools.ShellEnvNote())
 	return b.String()
 }
 

--- a/internal/skills/defaults/web-access/SKILL.md
+++ b/internal/skills/defaults/web-access/SKILL.md
@@ -19,6 +19,8 @@ CDP 模式必需 **Node.js 22+**（使用原生 WebSocket）。check-deps 脚本
 - Windows: `winget install OpenJS.NodeJS.LTS`（或 https://nodejs.org 下载安装包）
 - macOS: `brew install node`
 - Linux: 发行版包管理器或 https://nodejs.org
+- **小白用户（或无 winget/Homebrew）**：直接给 https://nodejs.org 的 LTS 安装包链接，让用户下载双击、一路"下一步"装完后回来告诉你；提前告知安装器会弹系统授权框（Windows UAC / macOS 密码），需要用户在屏幕前确认
+- 刚装好的 node 在本会话 PATH 中可能不可见（命令继承 octo 启动时的环境）——按环境须知刷新 PATH 或全路径调用（Windows `& "$env:ProgramFiles\nodejs\node.exe" -v`，macOS `/usr/local/bin/node -v` 或 `/opt/homebrew/bin/node -v`）；仍异常就请用户重启 octo
 
 没有 Node 时本技能并非不可用：静态层（内置 `web_fetch` / `web_search`）不依赖 Node，可先用静态层完成任务，仅在确需浏览器操作时再请用户安装。
 

--- a/internal/skills/defaults/web-artifacts-builder/SKILL.md
+++ b/internal/skills/defaults/web-artifacts-builder/SKILL.md
@@ -17,8 +17,9 @@ To build a powerful frontend artifact — a self-contained single HTML file that
 
 **Requirements**: `bash` and Node.js 18+ on PATH. Verify both before starting (`bash --version`, `node -v`). If either is missing, tell the user what to install and wait for their go-ahead — never install unasked:
 
-- Node.js — Windows: `winget install OpenJS.NodeJS.LTS` (or https://nodejs.org); macOS: `brew install node`; Linux: distro package manager or https://nodejs.org
-- bash on Windows — the scripts are bash; Git for Windows provides it (`winget install Git.Git`, then use Git Bash's `bash.exe`). Without bash or WSL this skill cannot run on Windows — say so plainly; do not attempt to translate the scripts to PowerShell.
+- Node.js — Windows: `winget install OpenJS.NodeJS.LTS`; macOS: `brew install node`; Linux: distro package manager. **Novice users (or no winget/Homebrew)**: hand them the https://nodejs.org LTS installer link and let them click through the GUI installer with defaults, then verify. Expect an elevation/permission dialog they must approve at the screen.
+- bash on Windows — the scripts are bash; Git for Windows provides it (`winget install Git.Git`, or the https://git-scm.com GUI installer). The default install does **not** put `bash` on PATH — invoke it by full path: `& "$env:ProgramFiles\Git\bin\bash.exe" <skill-dir>/scripts/init-artifact.sh <name>`. Without Git Bash or WSL this skill cannot run on Windows — say so plainly; do not attempt to translate the scripts to PowerShell.
+- After any mid-session install, the new tool may be missing from this session's PATH — refresh PATH or use full paths per the environment notes; if problems persist, have the user restart octo.
 
 Note: the `scripts/` paths are relative to this skill's directory (its absolute path is in the header above) — invoke them as `bash <skill-dir>/scripts/init-artifact.sh`. Run the project itself in the user's working directory, not inside the skill directory.
 

--- a/internal/tools/envnote.go
+++ b/internal/tools/envnote.go
@@ -1,0 +1,57 @@
+package tools
+
+import "runtime"
+
+// shellEnvNoteWindows is the Windows shell guidance injected into the session
+// environment context. It lives next to shellCommand (sandbox.go) — the code
+// that actually picks PowerShell — so the behavior and its description can't
+// drift apart, and is shared by the CLI and server context builders.
+//
+// Beyond dialect, it covers the three traps that strand a session that
+// installs a tool mid-conversation:
+//   - each terminal command inherits octo's startup PATH, so a fresh install
+//     is invisible until PATH is refreshed in-command or octo restarts;
+//   - installers raise a UAC dialog only a user at the screen can approve;
+//   - the default execution policy blocks Node's npm.ps1 shim.
+const shellEnvNoteWindows = "- Shell: PowerShell. Use PowerShell syntax and cmdlets " +
+	"(Get-ChildItem, Get-Content, Select-String, Remove-Item, $env:VAR), not POSIX sh. " +
+	"Chain commands with `;` rather than `&&` (Windows PowerShell 5.1 lacks `&&`). " +
+	"Prefer the built-in read_file / glob / grep tools over shelling out — they're identical across platforms.\n" +
+	"- Installing tools mid-session: every terminal command runs in a fresh shell inheriting octo's " +
+	"startup PATH, so a tool installed via winget/MSI is NOT found afterwards even though the install " +
+	"succeeded. Refresh PATH inside the same command — " +
+	"`$env:Path = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [Environment]::GetEnvironmentVariable('Path','User')` " +
+	"— or invoke the binary by full path (e.g. `& \"$env:ProgramFiles\\nodejs\\node.exe\" -v`). " +
+	"If oddities persist, ask the user to restart octo.\n" +
+	"- Installers raise a UAC elevation dialog the user must approve at the screen — warn them to expect it. " +
+	"When winget is unavailable (older Windows 10) or the user is a novice, prefer handing them a download " +
+	"link (e.g. the nodejs.org LTS installer) to click through the GUI installer, then verify afterwards.\n" +
+	"- The default PowerShell execution policy blocks Node's npm.ps1 shim ('running scripts is disabled') — " +
+	"invoke `npm.cmd` / `npx.cmd` explicitly instead.\n"
+
+// shellEnvNoteDarwin covers the macOS equivalents: sudo prompts hang the
+// non-interactive shell, mid-session installs miss this session's PATH
+// (Apple Silicon Homebrew lives in /opt/homebrew/bin), a fresh Mac pops the
+// Xcode CLT dialog on first git/compiler use, and novices do better with a
+// GUI .pkg than with installing Homebrew first.
+const shellEnvNoteDarwin = "- Shell notes (macOS): never run `sudo` through the terminal tool — the password " +
+	"prompt can't be answered here and the command hangs; use a GUI installer or Homebrew instead. " +
+	"A tool installed mid-session may not be on this session's PATH (commands inherit octo's startup " +
+	"environment; Apple Silicon Homebrew installs to /opt/homebrew/bin) — invoke it by full path " +
+	"(e.g. `/opt/homebrew/bin/node -v`) or ask the user to restart octo. " +
+	"On a fresh Mac the first `git`/compiler use pops the Xcode Command Line Tools install dialog while " +
+	"the command itself fails — tell the user to click Install, wait for it to finish, then retry. " +
+	"For novice users without Homebrew, hand them a GUI installer link (e.g. the nodejs.org LTS .pkg) " +
+	"rather than installing Homebrew first.\n"
+
+// ShellEnvNote returns platform-shell guidance for the session environment
+// context, or "" on platforms where the default POSIX assumptions hold.
+func ShellEnvNote() string {
+	switch runtime.GOOS {
+	case "windows":
+		return shellEnvNoteWindows
+	case "darwin":
+		return shellEnvNoteDarwin
+	}
+	return ""
+}

--- a/internal/tools/envnote_test.go
+++ b/internal/tools/envnote_test.go
@@ -1,0 +1,51 @@
+package tools
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The notes are runtime-gated, so assert the constants directly — the
+// guidance must keep its load-bearing elements regardless of test platform.
+func TestShellEnvNoteContent(t *testing.T) {
+	for _, want := range []string{
+		"PowerShell",
+		"GetEnvironmentVariable('Path','Machine')", // in-command PATH refresh
+		"restart octo",
+		"UAC",
+		"npm.cmd", // execution-policy workaround
+	} {
+		if !strings.Contains(shellEnvNoteWindows, want) {
+			t.Errorf("windows note missing %q", want)
+		}
+	}
+	for _, want := range []string{
+		"sudo",              // non-interactive shell hangs on the password prompt
+		"/opt/homebrew/bin", // Apple Silicon PATH trap
+		"Xcode Command Line Tools",
+		"restart octo",
+	} {
+		if !strings.Contains(shellEnvNoteDarwin, want) {
+			t.Errorf("darwin note missing %q", want)
+		}
+	}
+}
+
+func TestShellEnvNote_PlatformGate(t *testing.T) {
+	got := ShellEnvNote()
+	switch runtime.GOOS {
+	case "windows":
+		if got != shellEnvNoteWindows {
+			t.Error("windows should get the windows note")
+		}
+	case "darwin":
+		if got != shellEnvNoteDarwin {
+			t.Error("darwin should get the darwin note")
+		}
+	default:
+		if got != "" {
+			t.Errorf("non-windows/darwin should get no note, got %q", got)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Follow-up to #584's install commands: a novice following them still gets stranded.

**Windows breakpoints:**
1. **Stale PATH** (the killer): every terminal command runs in a fresh PowerShell inheriting *octo's startup environment* — a `winget`/MSI install succeeds, yet `node -v` still says "not recognized", and the model loops on reinstalling.
2. **bash not on PATH**: Git for Windows' default install exposes only `Git\cmd` (git.exe); `bash` stays unrecognized after a "successful" install.
3. **UAC**: installers raise an elevation dialog only a user at the screen can approve — remote (web/IM) sessions hang silently; older Win10 may lack winget entirely.

**macOS equivalents:** `sudo` hangs the non-interactive shell on a password prompt; Apple Silicon Homebrew installs to `/opt/homebrew/bin` which the inherited PATH may miss; a fresh Mac pops the Xcode CLT dialog while the first `git` use fails; novices shouldn't be routed through installing Homebrew first.

## What

- **`tools.ShellEnvNote()`** (`internal/tools/envnote.go`) — platform guidance placed next to the shell selection itself (`sandbox.go`): PowerShell dialect + in-command PATH refresh incantation + full-path invocation + UAC warning + `npm.cmd` execution-policy workaround on Windows; sudo / Homebrew-path / CLT-dialog / GUI-installer-first notes on macOS. "Restart octo" as the novice-comprehensible last resort on both.
- **Both env-context builders consume it** — also fixing an existing drift: the server's `buildEnvContext` told Windows models *nothing* about PowerShell, so web sessions (the entry point novices most likely use) lacked even the dialect hint the CLI had.
- **Default skills (web-artifacts-builder / web-access)** add the novice path: hand the user the nodejs.org GUI installer link ("click through with defaults, tell me when done"), expect the elevation dialog, invoke bash by full path on Windows (`& "$env:ProgramFiles\Git\bin\bash.exe" …`), refresh-PATH-or-restart after any mid-session install.

## Verification

Content-pinning tests assert the load-bearing elements of both notes regardless of test platform (PATH-refresh incantation, UAC, npm.cmd, sudo, /opt/homebrew/bin, CLT) plus the GOOS gate. `go test -race ./...`, vet, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)