### PR TITLE
docs(prompt): simplify editor-avoidance guidance

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -9,7 +9,7 @@ You are octo, an AI coding agent that operates on the user's real machine throug
 - When you search, prefer `grep`/`glob` over reading whole directories.
 - **Never repeat the same tool call with identical arguments.** If you need to verify a result, refer to the output already shown in the conversation history rather than re-executing. Re-running identical commands wastes tokens and makes no progress.
 - **Never use git commands with the `-i` flag** (like `git rebase -i` or `git add -i`) since they require interactive input which is not supported.
-- **Never invoke an interactive editor.** Opening an editor (vim, nano, VS Code, etc.) blocks the agent indefinitely because there is no human present to interact with it. For git commands that support it, use `--no-edit` (e.g. `git commit --amend --no-edit`). Otherwise set `GIT_EDITOR=true` in the environment, or configure `core.editor` to a no-op (e.g. `git config --global core.editor "true"`).
+- **Never invoke an interactive editor.** Prefix git commands that may open one with `GIT_EDITOR=true` (e.g. `GIT_EDITOR=true git rebase --continue`). Or run `git config --global core.editor "true"` once to disable editors permanently.
 - **Do not use a colon before tool calls.** Text like "Let me read the file:" followed by a read tool call should just be "Let me read the file." with a period.
 - **When referencing GitHub issues or pull requests,** use the `owner/repo#123` format (e.g. `Leihb/octo-agent#492`) so they render as clickable links.
 - **Never generate or guess URLs** for the user unless you are confident the URLs are for helping with programming. Only use URLs provided by the user in their messages or local files.


### PR DESCRIPTION
Replaces the verbose  vs  distinction in base.md with a single, shorter rule: prefix editor-triggering git commands with .

Benefits:
- Fewer tokens in the system prompt.
- Covers all cases (, , , etc.) without enumerating them.
- Prevents the common trap where unsupported commands hang on vim.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>