### PR TITLE
feat(tools): teach the pipe full-buffering escape (stdbuf -oL)

### DIFF
--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -55,7 +55,7 @@ func (t TerminalTool) managerFor(ctx context.Context) *BackgroundManager {
 func (TerminalTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name:        "terminal",
-		Description: "Run a shell command in the system shell (POSIX sh on macOS/Linux, PowerShell on Windows — see the Shell line in the environment context) and return stdout+stderr. Use for file operations, running programs, etc. Prefer dedicated tools (read_file, write_file, edit_file, glob, grep) over raw shell commands when they exist.\n\nChoosing sync vs background:\n- Default (no run_in_background): runs synchronously with a 120s timeout. Use for fast commands whose output you need immediately (e.g. `ls`, `git status`, `grep`, short scripts).\n- run_in_background:true — ONE-SHOT tasks (compiling, testing, installing, building, linting, CI checks): detaches immediately, returns a process id. The system automatically notifies you on completion. DO NOT poll terminal_output.\n- run_in_background:true — LONG-RUNNING services (servers, watchers, docker compose up): detaches immediately, returns a process id. After launch, verify the service with an external check (e.g., `curl http://localhost:PORT`, `pgrep`) rather than polling terminal_output. Use terminal_output only to inspect startup logs or diagnose issues — do not call it in a tight loop.",
+		Description: "Run a shell command in the system shell (POSIX sh on macOS/Linux, PowerShell on Windows — see the Shell line in the environment context) and return stdout+stderr. Use for file operations, running programs, etc. Prefer dedicated tools (read_file, write_file, edit_file, glob, grep) over raw shell commands when they exist.\n\nChoosing sync vs background:\n- Default (no run_in_background): runs synchronously with a 120s timeout. Use for fast commands whose output you need immediately (e.g. `ls`, `git status`, `grep`, short scripts).\n- run_in_background:true — ONE-SHOT tasks (compiling, testing, installing, building, linting, CI checks): detaches immediately, returns a process id. The system automatically notifies you on completion. DO NOT poll terminal_output.\n- run_in_background:true — LONG-RUNNING services (servers, watchers, docker compose up): detaches immediately, returns a process id. After launch, verify the service with an external check (e.g., `curl http://localhost:PORT`, `pgrep`) rather than polling terminal_output. Use terminal_output only to inspect startup logs or diagnose issues — do not call it in a tight loop.\n\nBuffering: the process is connected via pipes, not a terminal, so stdio block-buffers its output — a chatty program's logs can sit unflushed and invisible to terminal_output for a long time. On macOS/Linux, when you will want live logs, prefix the command with `stdbuf -oL` (e.g. `stdbuf -oL npm run dev`) to force line buffering.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -309,7 +309,16 @@ func (t TerminalOutputTool) Execute(ctx context.Context, _ string, input map[str
 	}
 	header := "[status: " + status + "]"
 	if out == "" {
-		return agent.ToolResult{Text: header + "\n(no output yet)"}, nil
+		msg := header + "\n(no output yet)"
+		// A running process with nothing to show is, more often than not, the
+		// pipe full-buffering trap: stdio block-buffers when not on a TTY, so
+		// logs sit in the child's buffer. Teach the fix at the moment it bites.
+		if status == "running" {
+			msg += "\n(if this persists for a process that should be logging, its stdio is likely " +
+				"block-buffered because it's piped — on macOS/Linux relaunch it as `stdbuf -oL <cmd>` " +
+				"to force line buffering)"
+		}
+		return agent.ToolResult{Text: msg}, nil
 	}
 	return agent.ToolResult{Text: header + "\n" + MaybeSpillOutput(id, out)}, nil
 }


### PR DESCRIPTION
## Problem

Background processes are connected via pipes, not a PTY, so their stdio **block-buffers** — a chatty dev server's logs can sit unflushed in a 4–64 KB buffer while `terminal_output` keeps answering `(no output yet)`, and the model (or the user watching it) concludes the process is hung.

This is the one real cost of the deliberate pipe-over-PTY design (clean non-TTY output, Windows parity, no termios state) — and it has a one-word escape: `stdbuf -oL`, present on Linux (coreutils) and modern macOS (`/usr/bin/stdbuf`).

## What

Two touchpoints, teaching the fix where it's needed:

1. **Preventive** — the `terminal` description's long-running guidance now says to prefix commands with `stdbuf -oL` (e.g. `stdbuf -oL npm run dev`) when live logs will matter.
2. **At the moment the trap bites** — `terminal_output`'s `(no output yet)` reply, **only when the process is still running**, adds: if a process that should be logging stays silent, its stdio is likely block-buffered; relaunch as `stdbuf -oL <cmd>`. Exited-with-no-output keeps the plain message (the hint would be noise there).

Windows is deliberately excluded — no stdbuf, and PowerShell buffering semantics differ.

## Verification

`go test -race ./internal/tools/` green (no existing assertions on the exact `(no output yet)` string); vet, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
