### PR TITLE
fix(ui): hide Weixin Login (QR) button when not configured

### DIFF
--- a/internal/server/static/channels.js
+++ b/internal/server/static/channels.js
@@ -141,7 +141,7 @@ const Channels = (() => {
             </svg>
             ${I18n.t("channels.btn.test")}
           </button>
-          ${platform === "weixin" ? `
+          ${platform === "weixin" && hasConfig ? `
           <button class="btn-channel-test btn-secondary" id="btn-login-weixin">
             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
@@ -156,7 +156,7 @@ const Channels = (() => {
             ${hasConfig ? I18n.t("channels.btn.reconfigure") : I18n.t("channels.btn.setup")}
           </button>
         </div>
-        ${platform === "weixin" ? `<div class="channel-login-area" id="weixin-login-area"></div>` : ""}
+        ${platform === "weixin" && hasConfig ? `<div class="channel-login-area" id="weixin-login-area"></div>` : ""}
       </div>
     `;
 


### PR DESCRIPTION
The QR login button and its container were always shown for the Weixin platform regardless of whether the channel had been configured. This led to a broken UI state (failed QR image load) when users clicked the button on an unconfigured card.

Now both the button and the login area are only rendered when hasConfig is true, matching the behavior of the toggle switch.