### PR TITLE
fix(web): MCP panel header buttons rendered off-screen

### DIFF
--- a/internal/server/static/app.css
+++ b/internal/server/static/app.css
@@ -5773,6 +5773,9 @@ body {
 
 .channels-page-header {
   margin-bottom: 0.25rem;
+  /* anchor for .skill-action-btns (absolute top-right) on the MCP panel,
+     which reuses this header class */
+  position: relative;
 }
 
 .channels-page-title {


### PR DESCRIPTION
## Summary

The MCP panel's header buttons (Import JSON / Reload / Add Server, and #589's AI Setup) have been invisible since the panel shipped in #542 — which is also why adding/importing "looked missing" from the UI.

Root cause: `.skill-action-btns` is `position: absolute; top: 0; right: 0`, so it anchors to the nearest positioned ancestor. The Skills panel header (`.skills-page-header`) is `position: relative`, but the MCP panel reuses `.channels-page-header`, which had no positioning — the button group escaped the header and rendered at the viewport's top-right, hidden under the topbar.

Fix: one line — make `.channels-page-header` `position: relative`. The other panels using this class (Channels, File Recall, Memory) have no absolutely-positioned header children, so they're unaffected.

## Test plan
- `make build` green (CSS is embedded in the binary)
- Manually: open the MCP panel — Import JSON / Reload / Add Server / AI Setup now show at the header's top-right, same as the Skills panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)