### PR TITLE
feat(server): self-restart — supervisor/worker, drain, /api/restart, restart_server tool

### DIFF
--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -26,8 +27,16 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	cors := fs.String("cors", "", "CORS allowed origins (comma-separated, * for any)")
 	noChannel := fs.Bool("no-channel", false, "Disable IM channel (DingTalk, Feishu)")
 	noMemory := fs.Bool("no-memory", false, "Disable cross-session memory injection")
+	noSupervisor := fs.Bool("no-supervisor", false, "Run the server directly, without the self-restart supervisor (exit code 42 still signals a restart request to an external supervisor)")
 	if err := fs.Parse(args); err != nil {
 		return 2
+	}
+
+	if shouldSupervise(*noSupervisor, os.Getenv(serveWorkerEnv)) {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(sigCh)
+		return superviseLoop(spawnServeWorker(args, stdout, stderr), sigCh, stderr)
 	}
 
 	var corsOrigins []string
@@ -75,11 +84,37 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		_ = srv.Shutdown(ctx)
 	}()
 
-	if err := srv.ListenAndServe(); err != nil {
+	err = srv.ListenAndServe()
+	switch {
+	case err == nil:
+	case errors.Is(err, server.ErrRestartRequested):
+		fmt.Fprintln(stdout, "octo serve: restarting...")
+	default:
 		fmt.Fprintf(stderr, "octo serve: %v\n", err)
+	}
+	return serveExitCode(err)
+}
+
+// shouldSupervise decides whether `octo serve` runs as the supervisor parent
+// (the default) or as the worker. The worker marker env covers both the
+// supervisor's own child and users running under an external supervisor;
+// --no-supervisor is the explicit flag form of the same opt-out.
+func shouldSupervise(noSupervisor bool, workerEnv string) bool {
+	return !noSupervisor && workerEnv != "1"
+}
+
+// serveExitCode maps the worker's ListenAndServe result onto the process
+// exit-code contract: clean stop → 0, restart request → ExitRestart,
+// anything else → 1.
+func serveExitCode(err error) int {
+	switch {
+	case err == nil:
+		return 0
+	case errors.Is(err, server.ErrRestartRequested):
+		return server.ExitRestart
+	default:
 		return 1
 	}
-	return 0
 }
 
 func splitComma(s string) []string {

--- a/cmd/octo/serve_supervisor.go
+++ b/cmd/octo/serve_supervisor.go
@@ -51,6 +51,15 @@ func superviseLoop(spawn func() (func() int, func(os.Signal), error), sigCh <-ch
 			}
 		}
 
+		// A signal racing the worker's exit may still be queued (select picks
+		// randomly when both are ready); drain it so we don't respawn a
+		// worker that is already doomed.
+		select {
+		case <-sigCh:
+			quitting = true
+		default:
+		}
+
 		if code == server.ExitRestart && !quitting {
 			fmt.Fprintln(stderr, "octo serve: restarting worker")
 			continue
@@ -85,21 +94,26 @@ func spawnServeWorker(args []string, stdout, stderr io.Writer) func() (func() in
 			}
 			var ee *exec.ExitError
 			if errors.As(err, &ee) {
-				return ee.ExitCode()
+				// Signal-killed workers report -1; normalise to a defined
+				// crash code instead of leaking it through os.Exit (255).
+				if c := ee.ExitCode(); c >= 0 {
+					return c
+				}
 			}
-			// Wait failed without an exit code (I/O error, killed before
-			// start completed); treat as a crash.
+			// Wait failed without a usable exit code (I/O error, killed by
+			// signal, killed before start completed); treat as a crash.
 			return 1
 		}
 		forward := func(sig os.Signal) {
 			if cmd.Process == nil {
 				return
 			}
-			// Windows has no Unix signals; the graceful path there is the
-			// console Ctrl-C event the worker already received. Forwarding
-			// means terminating the process.
+			// Windows: a console Ctrl-C event was already delivered to the
+			// worker (same console group), so forwarding is redundant — and
+			// the only mechanism available, Process.Kill, would land before
+			// the worker's graceful Shutdown and orphan its background
+			// processes. Let the worker handle the event it already has.
 			if runtime.GOOS == "windows" {
-				_ = cmd.Process.Kill()
 				return
 			}
 			_ = cmd.Process.Signal(sig)

--- a/cmd/octo/serve_supervisor.go
+++ b/cmd/octo/serve_supervisor.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/Leihb/octo-agent/internal/server"
+)
+
+// serveWorkerEnv marks a process as the serve worker. The supervisor sets it
+// on the child it spawns; setting it externally (systemd, launchd, a shell)
+// skips the built-in supervisor so an external one can own the respawn via
+// exit code server.ExitRestart.
+const serveWorkerEnv = "OCTO_SERVE_WORKER"
+
+// superviseLoop drives the supervisor: spawn a worker, wait, and dispatch on
+// its exit code — server.ExitRestart respawns (picking up a replaced binary),
+// anything else propagates. A signal received while a worker runs is
+// forwarded and permanently stops respawning: the user asked the whole serve
+// to quit, and on POSIX the worker usually got the same terminal signal
+// directly anyway.
+//
+// spawn starts one worker and returns a wait function (blocks until exit,
+// returns the exit code) and a signal-forwarding function. Split out from
+// the exec.Cmd mechanics so the loop is testable with fakes.
+func superviseLoop(spawn func() (func() int, func(os.Signal), error), sigCh <-chan os.Signal, stderr io.Writer) int {
+	quitting := false
+	for {
+		wait, forward, err := spawn()
+		if err != nil {
+			fmt.Fprintf(stderr, "octo serve: supervisor: %v\n", err)
+			return 1
+		}
+
+		done := make(chan int, 1)
+		go func() { done <- wait() }()
+
+		var code int
+	waitLoop:
+		for {
+			select {
+			case sig := <-sigCh:
+				quitting = true
+				forward(sig)
+			case code = <-done:
+				break waitLoop
+			}
+		}
+
+		if code == server.ExitRestart && !quitting {
+			fmt.Fprintln(stderr, "octo serve: restarting worker")
+			continue
+		}
+		return code
+	}
+}
+
+// spawnServeWorker returns the production spawn function for superviseLoop:
+// re-exec the current binary with `serve <args>` and the worker marker env.
+// The binary path is resolved once at supervisor start and re-opened by the
+// OS on every spawn, so a binary replaced on disk takes effect on the next
+// restart without the supervisor itself changing.
+func spawnServeWorker(args []string, stdout, stderr io.Writer) func() (func() int, func(os.Signal), error) {
+	exe, exeErr := os.Executable()
+	return func() (func() int, func(os.Signal), error) {
+		if exeErr != nil {
+			return nil, nil, exeErr
+		}
+		cmd := exec.Command(exe, append([]string{"serve"}, args...)...)
+		cmd.Stdout = stdout
+		cmd.Stderr = stderr
+		cmd.Env = append(os.Environ(), serveWorkerEnv+"=1")
+		if err := cmd.Start(); err != nil {
+			return nil, nil, err
+		}
+
+		wait := func() int {
+			err := cmd.Wait()
+			if err == nil {
+				return 0
+			}
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
+				return ee.ExitCode()
+			}
+			// Wait failed without an exit code (I/O error, killed before
+			// start completed); treat as a crash.
+			return 1
+		}
+		forward := func(sig os.Signal) {
+			if cmd.Process == nil {
+				return
+			}
+			// Windows has no Unix signals; the graceful path there is the
+			// console Ctrl-C event the worker already received. Forwarding
+			// means terminating the process.
+			if runtime.GOOS == "windows" {
+				_ = cmd.Process.Kill()
+				return
+			}
+			_ = cmd.Process.Signal(sig)
+		}
+		return wait, forward, nil
+	}
+}

--- a/cmd/octo/serve_supervisor_test.go
+++ b/cmd/octo/serve_supervisor_test.go
@@ -178,3 +178,21 @@ func TestServeExitCode(t *testing.T) {
 		}
 	}
 }
+
+// TestSuperviseLoop_QueuedSignalSkipsRespawn: a signal that lands together
+// with an ExitRestart exit must not spawn a doomed replacement worker.
+func TestSuperviseLoop_QueuedSignalSkipsRespawn(t *testing.T) {
+	f := &fakeSpawner{codes: []int{server.ExitRestart}}
+	sigCh := make(chan os.Signal, 1)
+	sigCh <- syscall.SIGINT
+	var errBuf bytes.Buffer
+
+	code := superviseLoop(f.spawn, sigCh, &errBuf)
+
+	if code != server.ExitRestart {
+		t.Errorf("code = %d, want %d", code, server.ExitRestart)
+	}
+	if f.spawned != 1 {
+		t.Errorf("spawned = %d, want 1 (queued signal must suppress respawn)", f.spawned)
+	}
+}

--- a/cmd/octo/serve_supervisor_test.go
+++ b/cmd/octo/serve_supervisor_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/server"
+)
+
+// fakeSpawner scripts a sequence of worker lifetimes for superviseLoop. Each
+// entry is the exit code the fake worker reports; workers exit immediately
+// unless holdForSignal is set, in which case they block until signalled.
+type fakeSpawner struct {
+	codes         []int
+	spawned       int
+	holdForSignal bool
+	sigReceived   chan os.Signal
+}
+
+func (f *fakeSpawner) spawn() (func() int, func(os.Signal), error) {
+	if f.spawned >= len(f.codes) {
+		panic("fakeSpawner: spawned more workers than scripted")
+	}
+	code := f.codes[f.spawned]
+	f.spawned++
+
+	release := make(chan struct{})
+	if !f.holdForSignal {
+		close(release)
+	}
+	wait := func() int {
+		<-release
+		return code
+	}
+	sigFn := func(sig os.Signal) {
+		if f.sigReceived != nil {
+			f.sigReceived <- sig
+		}
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}
+	return wait, sigFn, nil
+}
+
+func TestSuperviseLoop_CleanExitNoRespawn(t *testing.T) {
+	f := &fakeSpawner{codes: []int{0}}
+	var errBuf bytes.Buffer
+
+	code := superviseLoop(f.spawn, make(chan os.Signal), &errBuf)
+
+	if code != 0 {
+		t.Errorf("code = %d, want 0", code)
+	}
+	if f.spawned != 1 {
+		t.Errorf("spawned = %d, want 1", f.spawned)
+	}
+}
+
+func TestSuperviseLoop_RestartCodeRespawns(t *testing.T) {
+	f := &fakeSpawner{codes: []int{server.ExitRestart, server.ExitRestart, 0}}
+	var errBuf bytes.Buffer
+
+	code := superviseLoop(f.spawn, make(chan os.Signal), &errBuf)
+
+	if code != 0 {
+		t.Errorf("code = %d, want 0", code)
+	}
+	if f.spawned != 3 {
+		t.Errorf("spawned = %d, want 3 (two respawns then clean exit)", f.spawned)
+	}
+}
+
+func TestSuperviseLoop_CrashCodePropagates(t *testing.T) {
+	f := &fakeSpawner{codes: []int{server.ExitRestart, 7}}
+	var errBuf bytes.Buffer
+
+	code := superviseLoop(f.spawn, make(chan os.Signal), &errBuf)
+
+	if code != 7 {
+		t.Errorf("code = %d, want 7 (crash propagates, no respawn)", code)
+	}
+	if f.spawned != 2 {
+		t.Errorf("spawned = %d, want 2", f.spawned)
+	}
+}
+
+// TestSuperviseLoop_SignalStopsRespawn covers the Ctrl-C path: the parent
+// forwards the signal to the worker and must NOT respawn even when the
+// worker's exit code is ExitRestart (a restart drain interrupted mid-flight).
+func TestSuperviseLoop_SignalStopsRespawn(t *testing.T) {
+	f := &fakeSpawner{
+		codes:         []int{server.ExitRestart},
+		holdForSignal: true,
+		sigReceived:   make(chan os.Signal, 1),
+	}
+	sigCh := make(chan os.Signal, 1)
+	var errBuf bytes.Buffer
+
+	done := make(chan int, 1)
+	go func() { done <- superviseLoop(f.spawn, sigCh, &errBuf) }()
+
+	sigCh <- syscall.SIGTERM
+
+	select {
+	case sig := <-f.sigReceived:
+		if sig != syscall.SIGTERM {
+			t.Errorf("forwarded signal = %v, want SIGTERM", sig)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("signal was not forwarded to the worker")
+	}
+
+	select {
+	case code := <-done:
+		if code != server.ExitRestart {
+			t.Errorf("code = %d, want %d (worker's code propagates)", code, server.ExitRestart)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("superviseLoop did not return after signalled worker exit")
+	}
+	if f.spawned != 1 {
+		t.Errorf("spawned = %d, want 1 (no respawn after signal)", f.spawned)
+	}
+}
+
+func TestSuperviseLoop_SpawnErrorReturns1(t *testing.T) {
+	spawn := func() (func() int, func(os.Signal), error) {
+		return nil, nil, os.ErrNotExist
+	}
+	var errBuf bytes.Buffer
+
+	code := superviseLoop(spawn, make(chan os.Signal), &errBuf)
+
+	if code != 1 {
+		t.Errorf("code = %d, want 1", code)
+	}
+	if errBuf.Len() == 0 {
+		t.Error("expected an error message on stderr")
+	}
+}

--- a/cmd/octo/serve_supervisor_test.go
+++ b/cmd/octo/serve_supervisor_test.go
@@ -144,3 +144,37 @@ func TestSuperviseLoop_SpawnErrorReturns1(t *testing.T) {
 		t.Error("expected an error message on stderr")
 	}
 }
+
+func TestShouldSupervise(t *testing.T) {
+	cases := []struct {
+		noSupervisor bool
+		workerEnv    string
+		want         bool
+	}{
+		{false, "", true},   // default: supervise
+		{false, "1", false}, // spawned worker, or external supervisor
+		{true, "", false},   // explicit opt-out
+		{true, "1", false},
+	}
+	for _, c := range cases {
+		if got := shouldSupervise(c.noSupervisor, c.workerEnv); got != c.want {
+			t.Errorf("shouldSupervise(%v, %q) = %v, want %v", c.noSupervisor, c.workerEnv, got, c.want)
+		}
+	}
+}
+
+func TestServeExitCode(t *testing.T) {
+	cases := []struct {
+		err  error
+		want int
+	}{
+		{nil, 0},
+		{server.ErrRestartRequested, server.ExitRestart},
+		{os.ErrClosed, 1},
+	}
+	for _, c := range cases {
+		if got := serveExitCode(c.err); got != c.want {
+			t.Errorf("serveExitCode(%v) = %d, want %d", c.err, got, c.want)
+		}
+	}
+}

--- a/dev-docs/server-self-restart-design.md
+++ b/dev-docs/server-self-restart-design.md
@@ -42,14 +42,15 @@ mechanism behind two scenarios:
 
 1. Spawns the worker: same binary path (captured via `os.Executable` at
    startup), same argv, with `OCTO_SERVE_WORKER=1` in the environment.
-   stdin/stdout/stderr pass through, so logs look exactly like today.
+   stdout/stderr pass through, so logs look exactly like today (stdin is not
+   wired — the server never reads it).
 2. Waits for the worker to exit.
 3. Dispatches on the exit code:
    - `42` (`server.ExitRestart`) — re-spawn from the stored binary path and
      loop. The path is re-opened on each spawn, so a replaced binary takes
      effect.
    - anything else — exit with the same code. `0` stays `0`, crashes
-     propagate.
+     propagate (a signal-killed worker's `-1` normalises to `1`).
 
 When `OCTO_SERVE_WORKER=1` is set, `runServe` skips the supervisor and runs
 the server directly — this is both how the parent's child runs and the opt-out
@@ -64,19 +65,26 @@ group, so parent and worker both receive it. The parent treats a received
 SIGINT/SIGTERM as "quitting": it stops respawning, waits for the worker (whose
 existing signal handler runs `Shutdown`), and exits with the worker's code.
 When the parent is signalled directly (e.g. `kill <parent-pid>`), it forwards
-the signal to the worker. On Windows the parent kills the worker process on
-interrupt; the drain guarantees below make that safe.
+the signal to the worker. On Windows forwarding is a no-op: the worker already
+received the console Ctrl-C event (same console group), and the only
+alternative, `Process.Kill`, would land before the worker's graceful Shutdown
+and orphan its background processes. A signal that races the worker's exit is
+drained before the respawn decision, so the supervisor never spawns a worker
+that is already doomed.
 
 ## Restart triggers
 
-- `POST /api/restart` — `requireAuth`, responds `202 Accepted` immediately,
-  then starts the drain. This is the endpoint the web UI calls.
-- `restart_server` tool — registered only by the server, injected through the
-  same setter pattern as the WebSocket asker (`tools.SetAsker`), so the CLI
-  and sub-agents never see it. The tool returns success text immediately
-  ("restart scheduled after this turn"); the drain naturally waits for the
-  calling turn to finish, so the agent's final reply ("restarting now…")
-  reaches the user before the connection drops.
+- `POST /api/restart` — responds `202 Accepted` immediately, then starts the
+  drain. This is the endpoint the web UI's version popover calls. It sits on
+  the API mux with the same auth posture as every other endpoint (the
+  `requireAuth` wrapper is currently a pass-through; the API's trust model is
+  the localhost-by-default bind address).
+- `restart_server` tool — registered only by the server via
+  `tools.SetRestarter` (the same setter pattern as the WebSocket asker), so
+  the CLI and TUI never advertise it. The tool requires a `reason`, returns
+  success text immediately ("restart scheduled after this turn"), and the
+  drain naturally waits for the calling turn to finish, so the agent's final
+  reply ("restarting now…") reaches the user before the connection drops.
 
 The tool goes through the per-turn permission gate like any other
 state-changing tool; on IM channels the interactive ask flow covers
@@ -84,16 +92,24 @@ confirmation.
 
 ## Drain sequence
 
-A restart request flips the server into draining state:
+A restart request flips the server into draining state (`drainGate` in
+`internal/server/drain.go` counts in-flight turns; every turn-execution path
+registers with it):
 
-1. **Stop intake.** New turn requests get `503` with a retry hint; IM
-   adapters stop (`stopChannels`) so no new IM turns start.
-2. **Wait for in-flight turns**, tracked by the existing `turnRunning` map,
-   bounded by a drain timeout (default 30s).
-3. **Shutdown.** The existing `Shutdown` path runs: kill background
-   processes, kill session sub-agents, MCP cleanup, `http.Shutdown`.
+1. **Gate intake.** New turns are refused at every entry point, each in its
+   transport's retryable shape: HTTP turn endpoints and SSE return `503`, the
+   WS path broadcasts an error event, scheduled task runs return an error,
+   and an IM message gets a polite "send that again in a moment" reply. IM
+   adapters deliberately stay up through the drain — the turn that triggered
+   the restart must deliver its final reply through a live adapter. Turn
+   loops also stop chaining queued steer messages into fresh turns once the
+   drain starts.
+2. **Wait for in-flight turns**, bounded by a drain timeout (default 30s).
+3. **Shutdown.** The existing single-flight `Shutdown` path runs: stop IM
+   adapters, kill background processes, kill session sub-agents, MCP
+   cleanup, `http.Shutdown`.
 4. `ListenAndServe` returns `ErrRestartRequested`; `runServe` returns exit
-   code `42`.
+   code `42`. (A plain shutdown — Ctrl-C — surfaces as `nil` and exit 0.)
 
 The timeout is a hard bound, not a negotiation: a turn still running at 30s is
 abandoned. Round-granularity session persistence plus the SSE replay buffer
@@ -130,20 +146,23 @@ catch-all for everything else.
 
 | Piece | Where | What |
 |---|---|---|
-| Supervisor loop | `cmd/octo/serve.go` | spawn/wait/dispatch, signal handling, `OCTO_SERVE_WORKER` detection, `--no-supervisor` |
-| Exit code | `internal/server` | `ExitRestart = 42`, `ErrRestartRequested` |
-| Drain state | `internal/server/server.go` | draining flag, 503 gate, turn-drain wait, timeout |
-| Restart endpoint | `internal/server` | `POST /api/restart` behind `requireAuth` |
-| Restart tool | `internal/tools` + server wiring | `restart_server`, server-injected, permission-gated |
+| Supervisor loop | `cmd/octo/serve_supervisor.go` + `serve.go` | spawn/wait/dispatch, signal handling, `OCTO_SERVE_WORKER` detection, `--no-supervisor` |
+| Exit code | `internal/server/restart.go` | `ExitRestart = 42`, `ErrRestartRequested`, `Restart()` |
+| Drain state | `internal/server/drain.go` | `drainGate`: in-flight count, intake refusal, drain wait + timeout |
+| Restart endpoint | `internal/server/restart.go` | `POST /api/restart`, 202 then background drain |
+| Restart tool | `internal/tools/restart.go` + server wiring | `restart_server`, `SetRestarter`-injected, permission-gated |
 
 ## Testing
 
-- Drain logic: unit tests with fake in-flight turns covering finish-before-
-  timeout and timeout-abandons paths.
-- Supervisor loop: re-exec helper-process pattern (`TestMain` dispatching on
-  an env var, the same trick `os/exec` tests use) — child exits 42 then 0,
-  parent observed to respawn exactly once. No live network, per project rule.
-- Endpoint: `httptest` — auth required, 202 response, draining 503 on
-  subsequent turn requests.
+- Drain gate: unit tests cover begin/end pairing, drain-waits-for-active-turn,
+  timeout-reports-dirty, and multi-turn ordering.
+- Supervisor loop: the spawn/wait/signal mechanics sit behind an injectable
+  spawn function, so the loop's respawn/propagate/signal semantics are covered
+  by in-process fakes. No live network, per project rule.
+- Endpoint + wiring: `httptest` through the real mux — 202 on restart,
+  draining 503 on turn endpoints, scheduled-run refusal, polite IM reply via a
+  fake adapter, restart-vs-plain-shutdown sentinel on a real ephemeral-port
+  listener, single-flight `Shutdown` under `-race`.
 - CI matrix (Linux/macOS/Windows) exercises the spawn/wait path on all three;
-  the Windows rename dance is covered by the upgrade step's own test.
+  the Windows rename dance belongs to the (future) upgrade flow, not this
+  machinery.

--- a/dev-docs/server-self-restart-design.md
+++ b/dev-docs/server-self-restart-design.md
@@ -86,9 +86,13 @@ that is already doomed.
   drain naturally waits for the calling turn to finish, so the agent's final
   reply ("restarting now…") reaches the user before the connection drops.
 
-The tool goes through the per-turn permission gate like any other
-state-changing tool; on IM channels the interactive ask flow covers
-confirmation.
+The tool is ask-class in `internal/permission/defaults.yml` (explicitly, so
+nobody relaxes it by accident). On the web that means the browser
+confirmation prompt; the IM channel gate runs strict with no asker, so
+ask resolves to deny — an IM-triggered restart is refused until an
+interactive IM ask flow exists. Server sub-agents see the tool (the
+restarter registration is process-global) but inherit the parent's gate,
+so they face the same confirmation or denial.
 
 ## Drain sequence
 

--- a/internal/permission/defaults.yml
+++ b/internal/permission/defaults.yml
@@ -126,3 +126,12 @@ task_list:
 # prompting so the onboard and other skill flows work over HTTP / IM.
 skill:
   - allow: { pattern: "" }
+
+# Process restart — always confirm. The implicit default would already be
+# ask, but the rule is explicit so nobody pattern-matches this block and
+# adds an allow: an unconfirmed restart_server call would bounce the whole
+# server. Non-interactive transports (IM bridge's strict gate) resolve ask
+# to deny — restart from IM stays refused until an interactive ask exists
+# there. Auto-approve mode runs it without prompting, like everything else.
+restart_server:
+  - ask: { pattern: "" }

--- a/internal/server/drain.go
+++ b/internal/server/drain.go
@@ -42,10 +42,23 @@ func (g *drainGate) end() {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.active--
+	if g.active < 0 {
+		// An unmatched end would otherwise silently make every drain hang
+		// its full timeout (active never reaches 0 again). Fail loud.
+		panic("drainGate: end without begin")
+	}
 	if g.draining && g.active == 0 && g.idle != nil {
 		close(g.idle)
 		g.idle = nil
 	}
+}
+
+// isDraining reports whether a drain has started. Turn loops use it to stop
+// chaining queued follow-up turns once a restart is underway.
+func (g *drainGate) isDraining() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.draining
 }
 
 // drain blocks new turns and waits up to timeout for active ones to finish.
@@ -58,8 +71,12 @@ func (g *drainGate) drain(timeout time.Duration) bool {
 		g.mu.Unlock()
 		return true
 	}
-	idle := make(chan struct{})
-	g.idle = idle
+	// Reuse an existing waiter channel so a second drain call doesn't strand
+	// the first caller on a channel nobody will ever close.
+	if g.idle == nil {
+		g.idle = make(chan struct{})
+	}
+	idle := g.idle
 	g.mu.Unlock()
 
 	select {

--- a/internal/server/drain.go
+++ b/internal/server/drain.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// errDraining is returned by drainGate.begin once a restart drain has
+// started. Handlers map it to their transport's "try again shortly" shape:
+// HTTP 503, a WS error event, or a polite IM text reply.
+var errDraining = errors.New("server is restarting; try again shortly")
+
+// drainGate counts in-flight turns and, once draining, refuses new ones.
+// Every turn execution path calls begin/end; Restart calls drain to wait for
+// the in-flight set to empty before shutting down. The zero value is ready
+// to use.
+//
+// This deliberately gates turn *intake* rather than stopping IM adapters
+// up-front: an adapter must stay up until the drain completes so the turn
+// that triggered the restart can deliver its final "restarting now" reply.
+type drainGate struct {
+	mu       sync.Mutex
+	draining bool
+	active   int
+	idle     chan struct{} // non-nil while a drain waits on active turns
+}
+
+// begin registers a turn. It fails with errDraining once drain has started.
+func (g *drainGate) begin() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.draining {
+		return errDraining
+	}
+	g.active++
+	return nil
+}
+
+// end deregisters a turn registered with begin.
+func (g *drainGate) end() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.active--
+	if g.draining && g.active == 0 && g.idle != nil {
+		close(g.idle)
+		g.idle = nil
+	}
+}
+
+// drain blocks new turns and waits up to timeout for active ones to finish.
+// It reports whether the drain completed cleanly; on false the caller
+// proceeds anyway (session persistence bounds the damage at one round).
+func (g *drainGate) drain(timeout time.Duration) bool {
+	g.mu.Lock()
+	g.draining = true
+	if g.active == 0 {
+		g.mu.Unlock()
+		return true
+	}
+	idle := make(chan struct{})
+	g.idle = idle
+	g.mu.Unlock()
+
+	select {
+	case <-idle:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}

--- a/internal/server/drain_test.go
+++ b/internal/server/drain_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDrainGate_BeginAfterDrainRefused(t *testing.T) {
+	var g drainGate
+
+	if err := g.begin(); err != nil {
+		t.Fatalf("begin before drain: %v, want nil", err)
+	}
+	g.end()
+
+	if ok := g.drain(0); !ok {
+		t.Fatal("drain with no active turns should report clean")
+	}
+	if err := g.begin(); !errors.Is(err, errDraining) {
+		t.Fatalf("begin after drain = %v, want errDraining", err)
+	}
+}
+
+func TestDrainGate_DrainWaitsForActiveTurn(t *testing.T) {
+	var g drainGate
+
+	if err := g.begin(); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan bool, 1)
+	go func() { done <- g.drain(5 * time.Second) }()
+
+	// The drain must not complete while the turn is active.
+	select {
+	case <-done:
+		t.Fatal("drain returned while a turn was still active")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	g.end()
+
+	select {
+	case clean := <-done:
+		if !clean {
+			t.Error("drain = false (timeout), want true (clean)")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("drain did not return after the active turn ended")
+	}
+}
+
+func TestDrainGate_TimeoutReportsDirty(t *testing.T) {
+	var g drainGate
+
+	if err := g.begin(); err != nil {
+		t.Fatal(err)
+	}
+	defer g.end()
+
+	if clean := g.drain(50 * time.Millisecond); clean {
+		t.Error("drain = true, want false when a turn outlives the timeout")
+	}
+}
+
+func TestDrainGate_MultipleTurns(t *testing.T) {
+	var g drainGate
+
+	for i := 0; i < 3; i++ {
+		if err := g.begin(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	done := make(chan bool, 1)
+	go func() { done <- g.drain(5 * time.Second) }()
+
+	g.end()
+	g.end()
+	select {
+	case <-done:
+		t.Fatal("drain returned with one turn still active")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	g.end()
+	select {
+	case clean := <-done:
+		if !clean {
+			t.Error("drain = false, want true after all turns ended")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("drain did not return after last turn ended")
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -173,6 +174,10 @@ func (s *Server) handleCreateChat(w http.ResponseWriter, r *http.Request) {
 	defer mu.Unlock()
 
 	reply, err := s.runTurn(r.Context(), sess, req.Message)
+	if errors.Is(err, errDraining) {
+		writeError(w, http.StatusServiceUnavailable, err.Error())
+		return
+	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -233,6 +238,10 @@ func (s *Server) handleTurn(w http.ResponseWriter, r *http.Request) {
 	defer mu.Unlock()
 
 	reply, err := s.runTurn(r.Context(), sess, req.Message)
+	if errors.Is(err, errDraining) {
+		writeError(w, http.StatusServiceUnavailable, err.Error())
+		return
+	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -598,6 +607,11 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 // runTurn executes one user message against a session. It builds the agent,
 // runs the tool loop if enabled, and returns the assistant's text reply.
 func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput string) (string, error) {
+	if err := s.drain.begin(); err != nil {
+		return "", err
+	}
+	defer s.drain.end()
+
 	ctx = context.WithValue(ctx, ctxKeySessionID{}, sess.ID)
 	a := s.buildAgent(sess)
 

--- a/internal/server/restart.go
+++ b/internal/server/restart.go
@@ -23,16 +23,29 @@ var ErrRestartRequested = errors.New("server restart requested")
 // shutdownTimeout bounds the http.Shutdown wait during a restart.
 const shutdownTimeout = 10 * time.Second
 
+// defaultDrainTimeout is the hard bound on waiting for in-flight turns
+// before a restart proceeds anyway. Round-granularity session persistence
+// plus the SSE replay buffer cap the damage of a forced cut at one round.
+const defaultDrainTimeout = 30 * time.Second
+
 // Restart requests a graceful restart. It is idempotent — only the first
-// call wins — and returns immediately; the shutdown runs in the background
-// so the caller (an HTTP handler or a tool executing inside a turn) is not
-// blocked. reason is logged for the operator.
+// call wins — and returns immediately; the drain and shutdown run in the
+// background so the caller (an HTTP handler or a tool executing inside a
+// turn, whose own turn the drain waits for) is not blocked. reason is
+// logged for the operator.
 func (s *Server) Restart(reason string) {
 	if !s.restartPending.CompareAndSwap(false, true) {
 		return
 	}
 	fmt.Fprintf(os.Stderr, "octo serve: restart requested (%s)\n", reason)
 	go func() {
+		timeout := s.drainTimeout
+		if timeout <= 0 {
+			timeout = defaultDrainTimeout
+		}
+		if clean := s.drain.drain(timeout); !clean {
+			fmt.Fprintf(os.Stderr, "octo serve: drain timed out after %s; restarting with turns in flight\n", timeout)
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		_ = s.Shutdown(ctx)

--- a/internal/server/restart.go
+++ b/internal/server/restart.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// ExitRestart is the process exit code the serve worker uses to ask its
+// supervisor for a respawn. The supervisor (cmd/octo serve, or an external
+// one via e.g. systemd RestartForceExitStatus) re-spawns the worker from the
+// on-disk binary path, so a replaced binary takes effect on restart.
+const ExitRestart = 42
+
+// ErrRestartRequested is returned by ListenAndServe when the server stopped
+// because a restart was requested (API or restart_server tool), as opposed
+// to a plain shutdown. Callers map it to ExitRestart.
+var ErrRestartRequested = errors.New("server restart requested")
+
+// shutdownTimeout bounds the http.Shutdown wait during a restart.
+const shutdownTimeout = 10 * time.Second
+
+// Restart requests a graceful restart. It is idempotent — only the first
+// call wins — and returns immediately; the shutdown runs in the background
+// so the caller (an HTTP handler or a tool executing inside a turn) is not
+// blocked. reason is logged for the operator.
+func (s *Server) Restart(reason string) {
+	if !s.restartPending.CompareAndSwap(false, true) {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "octo serve: restart requested (%s)\n", reason)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		_ = s.Shutdown(ctx)
+	}()
+}
+
+// handleRestart serves POST /api/restart. It acknowledges with 202 before
+// the shutdown begins; the caller observes the actual restart as a dropped
+// connection followed by the new worker accepting again.
+func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
+	s.Restart("api")
+	writeJSON(w, http.StatusAccepted, map[string]string{"status": "restarting"})
+}

--- a/internal/server/restart_test.go
+++ b/internal/server/restart_test.go
@@ -23,6 +23,11 @@ func TestHandleRestart_Returns202AndMarksPending(t *testing.T) {
 	if !srv.restartPending.Load() {
 		t.Error("restartPending = false after POST /api/restart, want true")
 	}
+
+	// Join the background shutdown goroutine (Shutdown is single-flight: a
+	// second call waits for the first) so it can't race the next test on the
+	// process-global tool registries.
+	_ = srv.Shutdown(context.Background())
 }
 
 func TestRestart_Idempotent(t *testing.T) {
@@ -34,6 +39,30 @@ func TestRestart_Idempotent(t *testing.T) {
 	if !srv.restartPending.Load() {
 		t.Error("restartPending = false after Restart, want true")
 	}
+	_ = srv.Shutdown(context.Background())
+}
+
+// TestShutdown_SingleFlight runs concurrent Shutdown calls; under -race this
+// proves the process-global registry teardown is not executed twice in
+// parallel (the Restart-goroutine vs Ctrl-C-handler race).
+func TestShutdown_SingleFlight(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	const callers = 4
+	errs := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func() { errs <- srv.Shutdown(context.Background()) }()
+	}
+	for i := 0; i < callers; i++ {
+		select {
+		case err := <-errs:
+			if err != nil {
+				t.Errorf("Shutdown returned %v, want nil", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("concurrent Shutdown calls did not all return")
+		}
+	}
 }
 
 // TestListenAndServe_RestartReturnsSentinel binds a real listener on an
@@ -41,7 +70,6 @@ func TestRestart_Idempotent(t *testing.T) {
 // with ErrRestartRequested rather than the plain http.ErrServerClosed.
 func TestListenAndServe_RestartReturnsSentinel(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
-	srv.http.Addr = "127.0.0.1:0"
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/server/restart_test.go
+++ b/internal/server/restart_test.go
@@ -7,10 +7,12 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/channel"
 	"github.com/Leihb/octo-agent/internal/scheduler"
 )
 
@@ -217,5 +219,36 @@ func TestRunTask_DrainingRefused(t *testing.T) {
 	_, err := srv.RunTask(context.Background(), scheduler.Task{Name: "t", Prompt: "p"})
 	if !errors.Is(err, errDraining) {
 		t.Fatalf("RunTask during drain = %v, want errDraining", err)
+	}
+}
+
+// drainTestAdapter records SendText calls; every other Adapter method is
+// unused on the draining path and inherited from the embedded nil interface
+// (calling one would panic, which is what we want in this test).
+type drainTestAdapter struct {
+	channel.Adapter
+	sent []string
+}
+
+func (a *drainTestAdapter) SendText(chatID, text, replyTo string) channel.SendResult {
+	a.sent = append(a.sent, text)
+	return channel.SendResult{}
+}
+
+// TestHandleChannelMessage_DrainingRepliesPolitely pins the design deviation:
+// IM adapters stay up through the drain, and a message arriving mid-drain
+// gets an explicit "try again" reply instead of being dropped silently.
+func TestHandleChannelMessage_DrainingRepliesPolitely(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.drain.drain(0)
+
+	ad := &drainTestAdapter{}
+	srv.handleChannelMessage(context.Background(), ad, channel.InboundEvent{ChatID: "c1", Text: "hi"})
+
+	if len(ad.sent) != 1 {
+		t.Fatalf("SendText calls = %d, want 1", len(ad.sent))
+	}
+	if !strings.Contains(ad.sent[0], "restarting") {
+		t.Errorf("reply %q should mention the restart", ad.sent[0])
 	}
 }

--- a/internal/server/restart_test.go
+++ b/internal/server/restart_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHandleRestart_Returns202AndMarksPending(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/restart", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 (body: %s)", w.Code, w.Body.String())
+	}
+	if !srv.restartPending.Load() {
+		t.Error("restartPending = false after POST /api/restart, want true")
+	}
+}
+
+func TestRestart_Idempotent(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	srv.Restart("first")
+	srv.Restart("second") // must not panic or double-shutdown
+
+	if !srv.restartPending.Load() {
+		t.Error("restartPending = false after Restart, want true")
+	}
+}
+
+// TestListenAndServe_RestartReturnsSentinel binds a real listener on an
+// ephemeral port, requests a restart, and verifies ListenAndServe comes back
+// with ErrRestartRequested rather than the plain http.ErrServerClosed.
+func TestListenAndServe_RestartReturnsSentinel(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.http.Addr = "127.0.0.1:0"
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.serveOn(ln) }()
+
+	srv.Restart("test")
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrRestartRequested) {
+			t.Fatalf("serveOn returned %v, want ErrRestartRequested", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serveOn did not return within 5s of Restart")
+	}
+}
+
+// TestListenAndServe_PlainShutdownIsClean verifies a non-restart Shutdown
+// (the Ctrl-C path) does NOT surface as a restart request or an error.
+func TestListenAndServe_PlainShutdownIsClean(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.serveOn(ln) }()
+
+	// Give Serve a beat to start accepting, then shut down normally.
+	time.Sleep(50 * time.Millisecond)
+	if err := srv.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("serveOn returned %v after plain Shutdown, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serveOn did not return within 5s of Shutdown")
+	}
+}

--- a/internal/server/restart_test.go
+++ b/internal/server/restart_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net"
@@ -8,6 +9,9 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/scheduler"
 )
 
 func TestHandleRestart_Returns202AndMarksPending(t *testing.T) {
@@ -115,5 +119,103 @@ func TestListenAndServe_PlainShutdownIsClean(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("serveOn did not return within 5s of Shutdown")
+	}
+}
+
+// TestRestart_WaitsForInflightTurn: restart must not shut the server down
+// while a turn is active; it proceeds as soon as the turn ends.
+func TestRestart_WaitsForInflightTurn(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.serveOn(ln) }()
+
+	if err := srv.drain.begin(); err != nil { // simulate an in-flight turn
+		t.Fatal(err)
+	}
+	srv.Restart("test")
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("server stopped (%v) while a turn was in flight", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	srv.drain.end()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrRestartRequested) {
+			t.Fatalf("serveOn = %v, want ErrRestartRequested", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not stop after the in-flight turn ended")
+	}
+}
+
+// TestRestart_DrainTimeoutForcesShutdown: a turn that outlives the drain
+// timeout must not block the restart forever.
+func TestRestart_DrainTimeoutForcesShutdown(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.drainTimeout = 100 * time.Millisecond
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.serveOn(ln) }()
+
+	if err := srv.drain.begin(); err != nil {
+		t.Fatal(err)
+	}
+	defer srv.drain.end() // never ends within the timeout
+
+	srv.Restart("test")
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrRestartRequested) {
+			t.Fatalf("serveOn = %v, want ErrRestartRequested", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not force shutdown after drain timeout")
+	}
+}
+
+// TestHandleTurn_DrainingReturns503: new turn requests during a drain get a
+// retryable 503 instead of starting work that the shutdown would cut short.
+func TestHandleTurn_DrainingReturns503(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	srv.drain.drain(0)
+
+	body := bytes.NewBufferString(`{"message":"hello"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/"+sess.ID+"/turn", body)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// TestRunTask_DrainingRefused: scheduled task runs are refused during drain.
+func TestRunTask_DrainingRefused(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.drain.drain(0)
+
+	_, err := srv.RunTask(context.Background(), scheduler.Task{Name: "t", Prompt: "p"})
+	if !errors.Is(err, errDraining) {
+		t.Fatalf("RunTask during drain = %v, want errDraining", err)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -188,6 +188,13 @@ type Server struct {
 	// one (exit 0).
 	restartPending atomic.Bool
 
+	// shutdownMu/shutdownDone/shutdownErr make Shutdown single-flight: the
+	// first caller runs it, later callers wait on shutdownDone and read
+	// shutdownErr. All zero-valued until the first Shutdown call.
+	shutdownMu   sync.Mutex
+	shutdownDone chan struct{}
+	shutdownErr  error
+
 	// senderMu serialises lazy initialisation of sender when the server starts
 	// in onboarding mode (API key missing) and the user completes setup later.
 	senderMu sync.Mutex
@@ -368,7 +375,41 @@ func (s *Server) serveOn(ln net.Listener) error {
 
 // Shutdown gracefully shuts down the server, releasing the process-global
 // sub-agent + task registrations installed by enableSubAgentTools.
+//
+// It is single-flight: Restart's background shutdown and the Ctrl-C signal
+// path can race here, and the body mutates process-global registries that
+// must not be torn down twice concurrently. The first caller runs the
+// shutdown; later callers wait for it to finish (or their ctx to expire)
+// and return the same error.
 func (s *Server) Shutdown(ctx context.Context) error {
+	s.shutdownMu.Lock()
+	if s.shutdownDone == nil {
+		done := make(chan struct{})
+		s.shutdownDone = done
+		s.shutdownMu.Unlock()
+
+		err := s.doShutdown(ctx)
+
+		s.shutdownMu.Lock()
+		s.shutdownErr = err
+		s.shutdownMu.Unlock()
+		close(done)
+		return err
+	}
+	done := s.shutdownDone
+	s.shutdownMu.Unlock()
+
+	select {
+	case <-done:
+		s.shutdownMu.Lock()
+		defer s.shutdownMu.Unlock()
+		return s.shutdownErr
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Server) doShutdown(ctx context.Context) error {
 	s.stopChannels()
 	// Kill background processes started via web/IM sessions so they don't
 	// outlive the daemon — the same orphan-prevention the CLI/TUI do on exit.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -271,6 +271,12 @@ func New(cfg Config) (*Server, error) {
 	// tool catalog and can be dispatched through the browser.
 	tools.SetAsker(s.wsAsker())
 
+	// Register the restarter so restart_server appears in the tool catalog —
+	// the agent can then honour "重启一下服务" from web or IM. The restart
+	// drains in-flight turns (including the one calling the tool) before the
+	// worker exits with ExitRestart for the supervisor to respawn.
+	tools.SetRestarter(s.Restart)
+
 	s.registerRoutes()
 	s.initWS()
 	if sender != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -271,10 +271,13 @@ func New(cfg Config) (*Server, error) {
 	// tool catalog and can be dispatched through the browser.
 	tools.SetAsker(s.wsAsker())
 
-	// Register the restarter so restart_server appears in the tool catalog —
-	// the agent can then honour "重启一下服务" from web or IM. The restart
-	// drains in-flight turns (including the one calling the tool) before the
-	// worker exits with ExitRestart for the supervisor to respawn.
+	// Register the restarter so restart_server appears in the tool catalog.
+	// Permission is ask-class (defaults.yml): the web UI confirms via the
+	// browser prompt; the IM channel gate runs strict with no asker, so an
+	// IM-triggered restart resolves to deny until an interactive ask flow
+	// exists there. The restart drains in-flight turns (including the one
+	// calling the tool) before the worker exits with ExitRestart for the
+	// supervisor to respawn.
 	tools.SetRestarter(s.Restart)
 
 	s.registerRoutes()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -195,6 +195,11 @@ type Server struct {
 	shutdownDone chan struct{}
 	shutdownErr  error
 
+	// drain gates every turn execution path during a restart. drainTimeout
+	// overrides the 30s default in tests; zero means the default.
+	drain        drainGate
+	drainTimeout time.Duration
+
 	// senderMu serialises lazy initialisation of sender when the server starts
 	// in onboarding mode (API key missing) and the user completes setup later.
 	senderMu sync.Mutex
@@ -1042,6 +1047,15 @@ func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEven
 
 // handleChannelMessage runs an agent turn for a channel inbound event.
 func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, ev channel.InboundEvent) {
+	if err := s.drain.begin(); err != nil {
+		// Restart drain in progress. The adapter is still up (it stops only
+		// after the drain, so in-flight replies get delivered) — tell the
+		// user to retry instead of silently dropping the message.
+		ad.SendText(ev.ChatID, "The server is restarting — please send that again in a moment.", ev.MessageID)
+		return
+	}
+	defer s.drain.end()
+
 	sess := s.channelMgr.GetOrCreateSession(ev)
 	if sess == nil {
 		return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
@@ -181,6 +183,11 @@ type Server struct {
 	// accessKey is the shared secret for Web UI / API authentication.
 	accessKey string
 
+	// restartPending is set by Restart and read after the listener closes to
+	// distinguish a restart-driven shutdown (exit ExitRestart) from a plain
+	// one (exit 0).
+	restartPending atomic.Bool
+
 	// senderMu serialises lazy initialisation of sender when the server starts
 	// in onboarding mode (API key missing) and the user completes setup later.
 	senderMu sync.Mutex
@@ -334,9 +341,29 @@ func (s *Server) AccessKey() string {
 // serving so persisted tasks fire from server start, not from the first hit
 // on a task endpoint.
 func (s *Server) ListenAndServe() error {
+	ln, err := net.Listen("tcp", s.http.Addr)
+	if err != nil {
+		return err
+	}
+	return s.serveOn(ln)
+}
+
+// serveOn runs the server on an already-bound listener (split from
+// ListenAndServe so tests can use an ephemeral port). A stop via Shutdown is
+// reported as nil — it is the expected end of a server's life, not an error —
+// unless a restart was requested, in which case ErrRestartRequested tells the
+// caller to exit with ExitRestart.
+func (s *Server) serveOn(ln net.Listener) error {
 	s.initScheduler()
 	s.startChannels()
-	return s.http.ListenAndServe()
+	err := s.http.Serve(ln)
+	if errors.Is(err, http.ErrServerClosed) {
+		if s.restartPending.Load() {
+			return ErrRestartRequested
+		}
+		return nil
+	}
+	return err
 }
 
 // Shutdown gracefully shuts down the server, releasing the process-global

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -48,17 +48,19 @@ func (s *Server) handleTurnSSE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Refuse new turns during a restart drain — before the SSE headers go
-	// out, so the client gets a plain retryable 503.
+	mu := s.sessionTurnLock(sess.ID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Refuse new turns during a restart drain — after the turn lock (so a
+	// queued SSE turn admitted before the drain doesn't slip through) but
+	// before the SSE headers go out, so the client gets a plain retryable
+	// 503 instead of a corrupted stream.
 	if err := s.drain.begin(); err != nil {
 		writeError(w, http.StatusServiceUnavailable, err.Error())
 		return
 	}
 	defer s.drain.end()
-
-	mu := s.sessionTurnLock(sess.ID)
-	mu.Lock()
-	defer mu.Unlock()
 
 	// Set up SSE headers.
 	w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -48,6 +48,14 @@ func (s *Server) handleTurnSSE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Refuse new turns during a restart drain — before the SSE headers go
+	// out, so the client gets a plain retryable 503.
+	if err := s.drain.begin(); err != nil {
+		writeError(w, http.StatusServiceUnavailable, err.Error())
+		return
+	}
+	defer s.drain.end()
+
 	mu := s.sessionTurnLock(sess.ID)
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -66,6 +66,11 @@ func (s *Server) initScheduler() {
 // RunTask implements scheduler.Runner. It executes a scheduled task by
 // creating (or reusing) a session and running a single turn.
 func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, error) {
+	if err := s.drain.begin(); err != nil {
+		return "", err
+	}
+	defer s.drain.end()
+
 	// Try to load an existing session for this task.
 	sess, err := agent.LoadSession(task.SessionID)
 	if err != nil {

--- a/internal/server/version_upgrade_handlers.go
+++ b/internal/server/version_upgrade_handlers.go
@@ -2,9 +2,6 @@ package server
 
 import (
 	"net/http"
-	"os"
-	"os/exec"
-	"runtime"
 
 	"github.com/Leihb/octo-agent/internal/version"
 )
@@ -19,31 +16,6 @@ func (s *Server) handleVersionUpgrade(w http.ResponseWriter, r *http.Request) {
 		"ok":      false,
 		"message": "Upgrade is not supported in the Go rewrite. Please install the latest release manually.",
 	})
-}
-
-// ─── POST /api/restart ──────────────────────────────────────────────────────
-
-func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
-	// Best-effort self-restart: exec the same binary with the same args.
-	// The HTTP response is sent before the process exits so the client
-	// gets a clean 200.
-	go func() {
-		exe, err := os.Executable()
-		if err != nil {
-			return
-		}
-		cmd := exec.Command(exe, os.Args[1:]...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		_ = cmd.Start()
-		// Give the new process a moment to start, then exit.
-		if runtime.GOOS != "windows" {
-			_ = cmd.Process.Release()
-		}
-		os.Exit(0)
-	}()
-
-	writeJSON(w, http.StatusOK, map[string]any{"restarting": true})
 }
 
 // ─── GET /api/version (extended) ────────────────────────────────────────────

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -453,8 +453,9 @@ func (s *Server) runAgentTurnLoop(sess *agent.Session, initialContent string, bl
 		// browser instead of starting a turn the shutdown would cut short.
 		if s.wsHub != nil {
 			s.wsHub.broadcast(sess.ID, map[string]string{
-				"type":    "error",
-				"message": err.Error(),
+				"type":       "error",
+				"message":    err.Error(),
+				"session_id": sess.ID,
 			})
 		}
 		return
@@ -464,6 +465,19 @@ func (s *Server) runAgentTurnLoop(sess *agent.Session, initialContent string, bl
 	content := initialContent
 	for {
 		s.doAgentTurn(sess, content, blocks, images)
+		if s.drain.isDraining() {
+			// Don't chain queued steer messages into fresh turns during a
+			// drain — they'd start work the shutdown cuts at the timeout.
+			// Tell the user to resend instead of eating the input silently.
+			if items := s.drainSteer(sess.ID); len(items) > 0 && s.wsHub != nil {
+				s.wsHub.broadcast(sess.ID, map[string]string{
+					"type":       "error",
+					"message":    errDraining.Error(),
+					"session_id": sess.ID,
+				})
+			}
+			break
+		}
 		steerItems := s.drainSteer(sess.ID)
 		if len(steerItems) == 0 {
 			break

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -448,6 +448,19 @@ func joinNonEmpty(parts []string, sep string) string {
 // doAgentTurn is the single-turn body shared by the loop and retry paths.
 
 func (s *Server) runAgentTurnLoop(sess *agent.Session, initialContent string, blocks []agent.ContentBlock, images []string) {
+	if err := s.drain.begin(); err != nil {
+		// Restart drain in progress: surface a retryable error to the
+		// browser instead of starting a turn the shutdown would cut short.
+		if s.wsHub != nil {
+			s.wsHub.broadcast(sess.ID, map[string]string{
+				"type":    "error",
+				"message": err.Error(),
+			})
+		}
+		return
+	}
+	defer s.drain.end()
+
 	content := initialContent
 	for {
 		s.doAgentTurn(sess, content, blocks, images)

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -41,6 +41,7 @@ var allTools = []tool{
 	TaskCreateTool{},
 	TaskUpdateTool{},
 	TaskListTool{},
+	RestartServerTool{},
 }
 
 // DefaultRegistry is the agent.ToolExecutor used when `octo chat --tools` is
@@ -228,6 +229,7 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 	mgrOn := subAgentManagerEnabled()
 	askerOn := askerEnabled()
 	tasksOn := tasksEnabled()
+	restarterOn := restarterEnabled()
 	defs := make([]agent.ToolDefinition, 0, len(allTools))
 	for _, t := range allTools {
 		if _, isSkill := t.(SkillTool); isSkill && !skillsOn {
@@ -237,6 +239,9 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 			continue
 		}
 		if _, isAsk := t.(AskUserQuestionTool); isAsk && !askerOn {
+			continue
+		}
+		if _, isRestart := t.(RestartServerTool); isRestart && !restarterOn {
 			continue
 		}
 		if _, isTaskCreate := t.(TaskCreateTool); isTaskCreate && !tasksOn {

--- a/internal/tools/restart.go
+++ b/internal/tools/restart.go
@@ -1,0 +1,70 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// activeRestarter, when non-nil, backs the restart_server tool and gates its
+// advertisement in DefaultToolsFor. The server registers it (the restart
+// goes through Server.Restart's drain); it stays nil in CLI/TUI/sub-agent
+// processes, where there is no supervisor contract to honour.
+var activeRestarter func(reason string)
+
+// SetRestarter registers the function the restart_server tool delegates to.
+// Pass nil to disable (the tool then doesn't appear in DefaultToolsFor).
+// Mirrors SetAsker: process-global, set once at server start.
+func SetRestarter(f func(reason string)) { activeRestarter = f }
+
+func restarterEnabled() bool { return activeRestarter != nil }
+
+// RestartServerTool lets the model restart the octo server process — after a
+// binary upgrade or a config change that is only read at startup. The
+// restart is scheduled, not immediate: the server drains in-flight turns
+// (including the one executing this tool), so the model's final reply still
+// reaches the user before the process exits and the supervisor respawns it.
+type RestartServerTool struct{}
+
+func (RestartServerTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "restart_server",
+		Description: "Schedule a graceful restart of the octo server process. Use after replacing the " +
+			"octo binary (upgrade) or changing configuration that is only read at startup " +
+			"(provider, model, system prompt, channels.yml). The restart happens AFTER the " +
+			"current turn completes: in-flight turns drain first, then the supervisor " +
+			"respawns the server from the binary on disk. Tell the user the server is " +
+			"restarting in your reply — it will be briefly unreachable, and web/IM clients " +
+			"reconnect automatically.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"reason": map[string]any{
+					"type":        "string",
+					"description": "Short operator-facing reason for the restart, e.g. 'binary upgraded to 0.18.0' or 'config change: switched default model'. Logged on the server console.",
+				},
+			},
+			"required": []string{"reason"},
+		},
+	}
+}
+
+func (RestartServerTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	if !restarterEnabled() {
+		return agent.ToolResult{}, fmt.Errorf("restart_server: not available in this mode (server only)")
+	}
+	reason := strings.TrimSpace(stringArg(input, "reason"))
+	if reason == "" {
+		return agent.ToolResult{}, fmt.Errorf("restart_server: reason is required")
+	}
+
+	activeRestarter(reason)
+
+	return agent.ToolResult{
+		Text: "Restart scheduled: the server will drain in-flight turns and restart after this turn completes. " +
+			"Clients reconnect automatically once the new process is up.",
+		UI: map[string]any{"type": "restart", "reason": reason},
+	}, nil
+}

--- a/internal/tools/restart.go
+++ b/internal/tools/restart.go
@@ -10,8 +10,11 @@ import (
 
 // activeRestarter, when non-nil, backs the restart_server tool and gates its
 // advertisement in DefaultToolsFor. The server registers it (the restart
-// goes through Server.Restart's drain); it stays nil in CLI/TUI/sub-agent
-// processes, where there is no supervisor contract to honour.
+// goes through Server.Restart's drain); it stays nil in CLI/TUI processes,
+// where there is no supervisor contract to honour. Within the server
+// process the global is shared, so server sub-agents see the tool too —
+// they inherit the parent's permission gate, which asks (web) or denies
+// (IM strict) the same way it would for the parent.
 var activeRestarter func(reason string)
 
 // SetRestarter registers the function the restart_server tool delegates to.
@@ -52,7 +55,8 @@ func (RestartServerTool) Definition() agent.ToolDefinition {
 }
 
 func (RestartServerTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
-	if !restarterEnabled() {
+	restarter := activeRestarter
+	if restarter == nil {
 		return agent.ToolResult{}, fmt.Errorf("restart_server: not available in this mode (server only)")
 	}
 	reason := strings.TrimSpace(stringArg(input, "reason"))
@@ -60,7 +64,7 @@ func (RestartServerTool) Execute(ctx context.Context, _ string, input map[string
 		return agent.ToolResult{}, fmt.Errorf("restart_server: reason is required")
 	}
 
-	activeRestarter(reason)
+	restarter(reason)
 
 	return agent.ToolResult{
 		Text: "Restart scheduled: the server will drain in-flight turns and restart after this turn completes. " +

--- a/internal/tools/restart_test.go
+++ b/internal/tools/restart_test.go
@@ -1,0 +1,60 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func defaultToolNames(model string) map[string]bool {
+	names := map[string]bool{}
+	for _, d := range DefaultToolsFor(model) {
+		names[d.Name] = true
+	}
+	return names
+}
+
+func TestRestartServerTool_HiddenWithoutRestarter(t *testing.T) {
+	SetRestarter(nil)
+	t.Cleanup(func() { SetRestarter(nil) })
+
+	if defaultToolNames("")["restart_server"] {
+		t.Error("restart_server advertised with no restarter registered (CLI/TUI mode)")
+	}
+}
+
+func TestRestartServerTool_AdvertisedWithRestarter(t *testing.T) {
+	SetRestarter(func(reason string) {})
+	t.Cleanup(func() { SetRestarter(nil) })
+
+	if !defaultToolNames("")["restart_server"] {
+		t.Error("restart_server missing from DefaultToolsFor with a restarter registered")
+	}
+}
+
+func TestRestartServerTool_ExecuteSchedulesRestart(t *testing.T) {
+	var gotReason string
+	SetRestarter(func(reason string) { gotReason = reason })
+	t.Cleanup(func() { SetRestarter(nil) })
+
+	res, err := RestartServerTool{}.Execute(context.Background(), "restart_server",
+		map[string]any{"reason": "config change: new model default"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotReason != "config change: new model default" {
+		t.Errorf("restarter got reason %q", gotReason)
+	}
+	if !strings.Contains(res.Text, "after this turn") {
+		t.Errorf("result %q should tell the model the restart happens after this turn", res.Text)
+	}
+}
+
+func TestRestartServerTool_ExecuteWithoutRestarterErrors(t *testing.T) {
+	SetRestarter(nil)
+
+	_, err := RestartServerTool{}.Execute(context.Background(), "restart_server", map[string]any{})
+	if err == nil {
+		t.Fatal("Execute without a restarter should error")
+	}
+}

--- a/internal/tools/restart_test.go
+++ b/internal/tools/restart_test.go
@@ -6,19 +6,11 @@ import (
 	"testing"
 )
 
-func defaultToolNames(model string) map[string]bool {
-	names := map[string]bool{}
-	for _, d := range DefaultToolsFor(model) {
-		names[d.Name] = true
-	}
-	return names
-}
-
 func TestRestartServerTool_HiddenWithoutRestarter(t *testing.T) {
 	SetRestarter(nil)
 	t.Cleanup(func() { SetRestarter(nil) })
 
-	if defaultToolNames("")["restart_server"] {
+	if advertisedNames()["restart_server"] {
 		t.Error("restart_server advertised with no restarter registered (CLI/TUI mode)")
 	}
 }
@@ -27,7 +19,7 @@ func TestRestartServerTool_AdvertisedWithRestarter(t *testing.T) {
 	SetRestarter(func(reason string) {})
 	t.Cleanup(func() { SetRestarter(nil) })
 
-	if !defaultToolNames("")["restart_server"] {
+	if !advertisedNames()["restart_server"] {
 		t.Error("restart_server missing from DefaultToolsFor with a restarter registered")
 	}
 }


### PR DESCRIPTION
Implements dev-docs/server-self-restart-design.md (#588). Scenarios: binary upgrade and config-change pickup.

## What landed

**Process model** — `octo serve` now runs supervised by default: a tiny parent spawns the worker (`OCTO_SERVE_WORKER=1`, same argv, same binary path re-resolved each spawn so a replaced binary takes effect). Exit-code contract: `42` (`server.ExitRestart`) → respawn; anything else propagates; plain Ctrl-C shutdown now exits 0 (was 1 via unfiltered `http.ErrServerClosed`). `--no-supervisor` / external `OCTO_SERVE_WORKER=1` compose with systemd (`RestartForceExitStatus=42`) / launchd.

**Graceful drain** — `drainGate` counts in-flight turns across all five execution paths (HTTP turn, SSE, WS loop, scheduled tasks, IM messages). `Restart()` drains ≤30s then shuts down regardless (round-granularity persistence + replay buffer bound the damage at one round). New turns during a drain get transport-appropriate refusals: HTTP/SSE 503, WS error event, IM polite retry text. IM adapters deliberately stay up through the drain so the triggering turn's final reply is delivered; steer chaining stops once draining.

**Triggers** — `POST /api/restart` (202, replaces the legacy fire-and-forget `exec + os.Exit(0)` handler that raced the port bind and skipped graceful shutdown; the web version-popover caller is body-agnostic, verified). `restart_server` tool, injected via `tools.SetRestarter` (SetAsker pattern), explicit ask rule in `defaults.yml` — web confirms via browser prompt; IM's strict no-asker gate denies until an interactive IM ask flow lands.

**Hardening from per-slice subagent reviews** — single-flight `Shutdown` (Restart goroutine vs signal handler raced on process-global registries); Windows signal forwarding is a no-op (worker already has the console event; Kill would orphan background processes); queued-signal respawn suppression; drainGate underflow panic + re-entrant drain; SSE admission ordering.

## Verification

- `go test -race ./...` green, `go vet` + `gofmt` clean (37 new tests)
- Live smoke twice: `octo serve` → `POST /api/restart` → 202 → worker exits 42 → supervisor respawns → `/api/health` 200 → SIGTERM → exit 0
- Design doc updated to match the implementation (intake gating instead of up-front `stopChannels`, Windows posture, auth wording)

🤖 Generated with [Claude Code](https://claude.com/claude-code)