### PR TITLE
fix(conductor): tighten budget, add wall-clock timeout, SIGTERM handling, session persistence

### DIFF
--- a/cmd/octo/conduct.go
+++ b/cmd/octo/conduct.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/app"
@@ -61,6 +64,7 @@ func printConductUsage(w io.Writer) {
 	fmt.Fprintln(w, "  --max-attempts N           Verify-fail retries per unit before it blocks (default 3)")
 	fmt.Fprintln(w, "  --max-iterations N         Loop-turn budget backstop (default scales with units)")
 	fmt.Fprintln(w, "  --stall-rounds N           Stop after N rounds with no unit completed (default 5, 0 = off)")
+	fmt.Fprintln(w, "  --max-unit-duration D      Wall-clock timeout per unit (default 60s)")
 	fmt.Fprintln(w, "  --concurrency N            Parallel workers in isolated worktrees (default 1)")
 	fmt.Fprintln(w, "  --no-worktree              Run workers in the main tree even when concurrency=1")
 	fmt.Fprintln(w, "  --replan=false             Disable automatic re-planning when stuck")
@@ -68,17 +72,18 @@ func printConductUsage(w io.Writer) {
 
 // conductFlags holds the parsed start-flags shared across the start/resume paths.
 type conductFlags struct {
-	provider      string
-	model         string
-	planOnly      bool
-	verify        bool   // LLM judge gate
-	verifyCmd     string // objective shell gate, e.g. "go build ./... && go test ./..."
-	maxAttempts   int
-	maxIterations int
-	stallRounds   int
-	concurrency   int
-	noWorktree    bool
-	replan        bool
+	provider        string
+	model           string
+	planOnly        bool
+	verify          bool   // LLM judge gate
+	verifyCmd       string // objective shell gate, e.g. "go build ./... && go test ./..."
+	maxAttempts     int
+	maxIterations   int
+	stallRounds     int
+	concurrency     int
+	noWorktree      bool
+	replan          bool
+	maxUnitDuration time.Duration
 }
 
 func conductFlagSet(name string, f *conductFlags, stderr io.Writer) *flag.FlagSet {
@@ -92,18 +97,21 @@ func conductFlagSet(name string, f *conductFlags, stderr io.Writer) *flag.FlagSe
 	fs.IntVar(&f.maxAttempts, "max-attempts", 0, "Verify-fail retries per unit before blocking")
 	fs.IntVar(&f.maxIterations, "max-iterations", 0, "Loop-turn budget backstop")
 	fs.IntVar(&f.stallRounds, "stall-rounds", 5, "Stop after N rounds with no progress (0=off)")
+	fs.DurationVar(&f.maxUnitDuration, "max-unit-duration", 0, "Wall-clock timeout per unit (default 60s)")
 	fs.IntVar(&f.concurrency, "concurrency", 1, "Parallel workers in isolated worktrees")
 	fs.BoolVar(&f.noWorktree, "no-worktree", false, "Run workers in the main tree")
 	fs.BoolVar(&f.replan, "replan", true, "Let the conductor revise the plan as it learns (disable with --replan=false)")
+	fs.DurationVar(&f.maxUnitDuration, "max-unit-duration", 0, "Wall-clock timeout per unit (default 60s)")
 	return fs
 }
 
 func (f conductFlags) config() conductor.Config {
 	return conductor.Config{
-		MaxAttempts:   f.maxAttempts,
-		MaxIterations: f.maxIterations,
-		MaxConcurrent: f.concurrency,
-		StallRounds:   f.stallRounds,
+		MaxAttempts:     f.maxAttempts,
+		MaxIterations:   f.maxIterations,
+		MaxConcurrent:   f.concurrency,
+		StallRounds:     f.stallRounds,
+		MaxUnitDuration: f.maxUnitDuration,
 	}
 }
 
@@ -252,7 +260,9 @@ func conductLedger(store *conductor.Store, id string, f conductFlags, stdout, st
 	}
 
 	fmt.Fprintln(stdout, "Conducting…  (unattended — Ctrl-C to stop; resume later)")
-	err := c.Run(context.Background(), id)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	err := c.Run(ctx, id)
 
 	led, gerr := store.Get(id)
 	if gerr == nil {
@@ -411,7 +421,7 @@ func (spawnerWorker) Run(ctx context.Context, spec conductor.WorkSpec) (conducto
 	if spec.Workdir != "" {
 		ctx = tools.WithWorkingDir(ctx, spec.Workdir)
 	}
-	res, err := sp.Spawn(ctx, tools.SpawnRequest{Description: spec.Label, Prompt: spec.Prompt})
+	res, err := sp.Spawn(ctx, tools.SpawnRequest{Description: spec.Label, Prompt: spec.Prompt, SessionDir: spec.SessionDir})
 	if err != nil {
 		return conductor.WorkResult{}, err
 	}
@@ -419,6 +429,7 @@ func (spawnerWorker) Run(ctx context.Context, spec conductor.WorkSpec) (conducto
 		Handle:     res.AgentID,
 		Reply:      res.Reply,
 		Incomplete: res.StopReason == agent.StopReasonMaxTurns,
+		Turns:      res.Turns,
 	}, nil
 }
 
@@ -435,5 +446,6 @@ func (spawnerWorker) Continue(ctx context.Context, handle, message string) (cond
 		Handle:     res.AgentID,
 		Reply:      res.Reply,
 		Incomplete: res.StopReason == agent.StopReasonMaxTurns,
+		Turns:      res.Turns,
 	}, nil
 }

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -33,6 +33,10 @@ type Session struct {
 	Source    string    `json:"source,omitempty"` // how the session was created: "" (manual) | "cron" | "channel" | "setup"
 	Messages  []Message `json:"messages"`
 
+	// Dir overrides the default ~/.octo/sessions location. Empty means use the
+	// default. Not serialized — it's a runtime override.
+	Dir string `json:"-"`
+
 	// persisted is how many messages are already on disk. Save appends
 	// Messages[persisted:]; it's not serialized.
 	persisted int
@@ -132,9 +136,13 @@ func sessionsDir() (string, error) {
 
 // SavePath returns the JSONL path where this session would be saved.
 func (s *Session) SavePath() (string, error) {
-	dir, err := sessionsDir()
-	if err != nil {
-		return "", err
+	dir := s.Dir
+	if dir == "" {
+		var err error
+		dir, err = sessionsDir()
+		if err != nil {
+			return "", err
+		}
 	}
 	return filepath.Join(dir, s.ID+".jsonl"), nil
 }

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -48,7 +49,7 @@ func NewSpawner(parent *agent.Agent, executor agent.ToolExecutor, toolsFn func()
 // Set to the same default as the parent (100) so sub-agents have enough
 // budget for complex sub-tasks. Each Continue re-arms
 // this budget for the next round.
-const childMaxTurns = 100
+const childMaxTurns = 30
 
 // Spawn implements tools.Spawner. It builds an isolated child, registers it so
 // a later Continue can resume it, runs the first prompt, and returns the
@@ -72,10 +73,18 @@ func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.Spaw
 	child.Gate = s.parent.Gate
 	child.MaxTurns = childMaxTurns
 
-	lc := &liveChild{agent: child, tools: childTools, executor: s.executor}
+	lc := &liveChild{agent: child, tools: childTools, executor: s.executor, sessionDir: req.SessionDir}
 	id := s.reg.put(lc)
 
-	reply, in, out, stop, err := s.runChild(ctx, lc, req.Prompt)
+	if req.SessionDir != "" {
+		_ = os.MkdirAll(req.SessionDir, 0o755)
+		sess := agent.NewSession(child.Model, child.System)
+		sess.ID = id
+		sess.Dir = req.SessionDir
+		lc.session = sess
+	}
+
+	reply, in, out, stop, turns, err := s.runChild(ctx, lc, req.Prompt)
 	if err != nil {
 		return tools.SpawnResult{}, err
 	}
@@ -84,6 +93,7 @@ func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.Spaw
 		Reply:        reply,
 		InputTokens:  in,
 		OutputTokens: out,
+		Turns:        turns,
 		StopReason:   stop,
 	}, nil
 }
@@ -97,7 +107,7 @@ func (s *Spawner) Continue(ctx context.Context, agentID, message string) (tools.
 		return tools.SpawnResult{}, fmt.Errorf(
 			"agent %s is no longer alive (idle-expired or evicted); launch a fresh sub-agent instead", agentID)
 	}
-	reply, in, out, stop, err := s.runChild(ctx, lc, message)
+	reply, in, out, stop, turns, err := s.runChild(ctx, lc, message)
 	if err != nil {
 		return tools.SpawnResult{}, err
 	}
@@ -106,6 +116,7 @@ func (s *Spawner) Continue(ctx context.Context, agentID, message string) (tools.
 		Reply:        reply,
 		InputTokens:  in,
 		OutputTokens: out,
+		Turns:        turns,
 		StopReason:   stop,
 	}, nil
 }
@@ -115,14 +126,14 @@ func (s *Spawner) Continue(ctx context.Context, agentID, message string) (tools.
 // the sub-agent context marker so the child can't recurse, and accrues only the
 // token delta for this round into the parent (SessionTokens is cumulative, so
 // re-accruing the total would double-count earlier rounds). The returned (in,
-// out) are this round's delta.
+// out) are this round's delta; turns is the child's TurnIterations count.
 //
 // A max-turns checkpoint is NOT an error: the partial reply and StopReason
 // ("max_turns") are returned so a caller (the conductor) can checkpoint and
 // Continue. Tokens spent on the partial round are still accrued. Callers that
 // drive a continuation (the conductor) inspect
 // StopReason themselves.
-func (s *Spawner) runChild(ctx context.Context, lc *liveChild, prompt string) (reply string, in, out int, stopReason string, err error) {
+func (s *Spawner) runChild(ctx context.Context, lc *liveChild, prompt string) (reply string, in, out int, stopReason string, turns int, err error) {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 
@@ -145,8 +156,9 @@ func (s *Spawner) runChild(ctx context.Context, lc *liveChild, prompt string) (r
 		}
 	}
 	r, err := lc.agent.RunStream(childCtx, prompt, lc.tools, lc.executor, handler)
+	turns = lc.agent.TurnIterations()
 	if err != nil {
-		return "", 0, 0, "", err
+		return "", 0, 0, "", turns, err
 	}
 
 	// Accrue the round's token delta even on a max-turns checkpoint — the
@@ -156,7 +168,20 @@ func (s *Spawner) runChild(ctx context.Context, lc *liveChild, prompt string) (r
 	lc.accruedIn, lc.accruedOut = totIn, totOut
 	s.parent.AccrueChildUsage(in, out)
 
-	return r.Content, in, out, r.StopReason, nil
+	lc.syncSession()
+	return r.Content, in, out, r.StopReason, turns, nil
+}
+
+// syncSession persists the child's conversation to disk when sessionDir was
+// supplied. Called at the end of every runChild round (Spawn + Continue) so
+// the transcript is always up-to-date. Failures are silent — session logging
+// is best-effort and must never block the sub-agent.
+func (lc *liveChild) syncSession() {
+	if lc.session == nil || lc.sessionDir == "" {
+		return
+	}
+	lc.session.SyncFrom(lc.agent.History)
+	_ = lc.session.Save()
 }
 
 // filterChildTools drops Agent (a sub-agent cannot spawn another sub-agent —
@@ -221,6 +246,12 @@ type liveChild struct {
 
 	lastUsed time.Time // for TTL eviction
 	seq      uint64    // monotonic touch order, for LRU eviction (clock-independent)
+
+	// sessionDir + session persist the sub-agent transcript when the caller
+	// (conductor) wants post-mortem traceability. Empty sessionDir means no
+	// persistence (the default for chat/REPL sub-agents).
+	sessionDir string
+	session    *agent.Session
 }
 
 // childRegistry holds the live children for one spawner (one REPL session).

--- a/internal/app/spawner_test.go
+++ b/internal/app/spawner_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -456,5 +458,54 @@ func TestAgentSpawner_MarksContextSoRecursionRefused(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "cannot spawn") {
 		t.Errorf("recursive sub_agent should be refused, got %v", err)
+	}
+}
+
+func TestAgentSpawner_SessionDirPersistsTranscript(t *testing.T) {
+	tmp := t.TempDir()
+	send := &subAgentSender{reply: "sub-agent answer", inputTokens: 100, outputTokens: 40}
+	parent := agent.New(send, "parent-model")
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+
+	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{
+		Description: "Test",
+		Prompt:      "do something",
+		SessionDir:  tmp,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.AgentID == "" {
+		t.Fatal("expected non-empty AgentID")
+	}
+
+	// The session file should have been written.
+	path := filepath.Join(tmp, res.AgentID+".jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("session file not written: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("session file is empty")
+	}
+
+	// Should contain the prompt and the reply as JSONL records.
+	body := string(data)
+	if !strings.Contains(body, "do something") {
+		t.Error("session transcript missing user prompt")
+	}
+	if !strings.Contains(body, "sub-agent answer") {
+		t.Error("session transcript missing assistant reply")
+	}
+
+	// Continue should append to the same file.
+	before, _ := os.ReadFile(path)
+	_, err = sp.Continue(context.Background(), res.AgentID, "continue please")
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.ReadFile(path)
+	if len(after) <= len(before) {
+		t.Error("Continue should have appended more records to the session file")
 	}
 }

--- a/internal/conductor/conductor.go
+++ b/internal/conductor/conductor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -21,9 +22,10 @@ type Worker interface {
 
 // WorkSpec is one worker dispatch.
 type WorkSpec struct {
-	Label   string // short label for progress/logs
-	Prompt  string // the fully assembled worker context
-	Workdir string // Phase 2: the worktree to root the worker's shell in ("" = process cwd)
+	Label      string // short label for progress/logs
+	Prompt     string // the fully assembled worker context
+	Workdir    string // Phase 2: the worktree to root the worker's shell in ("" = process cwd)
+	SessionDir string // per-unit sub-agent session log directory ("" = no persistence)
 }
 
 // WorkResult is a worker round's outcome. Incomplete is true when the worker
@@ -34,6 +36,11 @@ type WorkResult struct {
 	Handle     string
 	Reply      string
 	Incomplete bool
+	// Turns is the number of provider round-trips the sub-agent consumed in
+	// this round (Spawn or Continue). The conductor folds this into its global
+	// Iterations budget so the cap reflects actual LLM calls, not just conductor
+	// dispatch rounds.
+	Turns int
 }
 
 // Verifier is the completion gate. A unit is never Done until Verify returns
@@ -106,6 +113,11 @@ type Config struct {
 	// StallRounds: after this many consecutive iterations with no unit
 	// reaching Done, the loop declares a stall and stops (Phase 3). <=0 → off.
 	StallRounds int
+	// MaxUnitDuration caps wall-clock time for a single worker round (Spawn or
+	// Continue). If the worker exceeds this, the context is cancelled and the
+	// unit is retried. <=0 → 60s default. This prevents a single sub-agent
+	// from hanging the whole conductor.
+	MaxUnitDuration time.Duration
 }
 
 func (c Config) maxAttempts() int {
@@ -113,6 +125,13 @@ func (c Config) maxAttempts() int {
 		return c.MaxAttempts
 	}
 	return 3
+}
+
+func (c Config) maxUnitDuration() time.Duration {
+	if c.MaxUnitDuration > 0 {
+		return c.MaxUnitDuration
+	}
+	return 60 * time.Second
 }
 
 // maxRecoverRounds bounds how many consecutive re-plan attempts the loop will
@@ -214,11 +233,15 @@ func (c *Conductor) Run(ctx context.Context, id string) error {
 			return c.finalize(ctx, id)
 		}
 
-		progressed := c.runBatch(ctx, id, batch)
+		progressed, totalTurns := c.runBatch(ctx, id, batch)
 
-		// Bump the iteration counter once per worker dispatch in the batch.
-		n := len(batch)
-		_, _ = c.store.Update(id, func(l *Ledger) error { l.Iterations += n; return nil })
+		// Bump the iteration counter by the actual sub-agent turns consumed,
+		// so the budget reflects real LLM round-trips, not just conductor
+		// dispatch rounds. Minimum 1 so empty rounds still count.
+		if totalTurns < 1 {
+			totalTurns = 1
+		}
+		_, _ = c.store.Update(id, func(l *Ledger) error { l.Iterations += totalTurns; return nil })
 
 		if progressed {
 			roundsSinceProgress = 0
@@ -284,8 +307,8 @@ type dispatchOutcome struct {
 // concurrently, then integrates the outcomes SERIALLY in unit-id order. The
 // concurrency is the design's bounded parallelism; the serial integrate keeps
 // trunk merges + ledger transitions race-free. Returns whether any unit
-// reached Done this round.
-func (c *Conductor) runBatch(ctx context.Context, id string, batch []dispatchItem) bool {
+// reached Done this round, and the sum of sub-agent turns consumed.
+func (c *Conductor) runBatch(ctx context.Context, id string, batch []dispatchItem) (progressed bool, totalTurns int) {
 	outcomes := make([]dispatchOutcome, len(batch))
 	if len(batch) == 1 {
 		outcomes[0] = c.dispatchUnit(ctx, id, batch[0])
@@ -301,13 +324,13 @@ func (c *Conductor) runBatch(ctx context.Context, id string, batch []dispatchIte
 		wg.Wait()
 	}
 
-	progressed := false
 	for _, oc := range outcomes {
+		totalTurns += oc.res.Turns
 		if c.integrate(ctx, id, oc) {
 			progressed = true
 		}
 	}
-	return progressed
+	return progressed, totalTurns
 }
 
 // dispatchUnit runs (or resumes) one unit's worker and verifies its output in
@@ -360,24 +383,33 @@ func (c *Conductor) dispatchUnit(ctx context.Context, id string, item dispatchIt
 		return nil
 	})
 
+	// Wall-clock timeout so one slow sub-agent can't block the whole conductor.
+	unitCtx, cancel := context.WithTimeout(ctx, c.cfg.maxUnitDuration())
+	defer cancel()
+
 	if item.resume && u.Handle != "" {
 		msg := u.ContinueMsg
 		if msg == "" {
 			msg = "Continue where you left off and finish the task."
 		}
 		c.logf("▶ #%d resuming\n", unitID)
-		oc.res, oc.workerErr = c.worker.Continue(ctx, u.Handle, msg)
+		oc.res, oc.workerErr = c.worker.Continue(unitCtx, u.Handle, msg)
 	} else {
 		spec := WorkSpec{
-			Label:   fmt.Sprintf("#%d %s", unitID, oneLine(u.Description, 60)),
-			Prompt:  c.buildPrompt(id, l, u, oc.workdir),
-			Workdir: oc.workdir,
+			Label:      fmt.Sprintf("#%d %s", unitID, oneLine(u.Description, 60)),
+			Prompt:     c.buildPrompt(id, l, u, oc.workdir),
+			Workdir:    oc.workdir,
+			SessionDir: filepath.Join(c.store.Dir(id), "sessions"),
 		}
 		c.logf("▶ #%d running\n", unitID)
-		oc.res, oc.workerErr = c.worker.Run(ctx, spec)
+		oc.res, oc.workerErr = c.worker.Run(unitCtx, spec)
 	}
 
 	if oc.workerErr != nil {
+		if unitCtx.Err() == context.DeadlineExceeded {
+			c.logf("⏱ #%d wall-clock timeout (>%s)\n", unitID, c.cfg.maxUnitDuration())
+			c.store.AppendJournal(id, fmt.Sprintf("#%d timeout after %s", unitID, c.cfg.maxUnitDuration()))
+		}
 		return oc
 	}
 

--- a/internal/conductor/conductor_test.go
+++ b/internal/conductor/conductor_test.go
@@ -28,31 +28,58 @@ func newFnWorker(fn func(unitID, call int, resume bool, spec WorkSpec) WorkResul
 	return &fnWorker{calls: map[int]int{}, prompts: map[int]string{}, fn: fn}
 }
 
-func (w *fnWorker) Run(_ context.Context, spec WorkSpec) (WorkResult, error) {
+func (w *fnWorker) Run(ctx context.Context, spec WorkSpec) (WorkResult, error) {
+	if err := ctx.Err(); err != nil {
+		return WorkResult{}, err
+	}
 	id := unitIDFromLabel(spec.Label)
 	w.mu.Lock()
 	c := w.calls[id]
 	w.calls[id]++
 	w.prompts[id] = spec.Prompt
 	w.mu.Unlock()
-	res := w.fn(id, c, false, spec)
-	if res.Handle == "" {
-		res.Handle = "h" + strconv.Itoa(id)
+	// Run fn in a goroutine so a cancelled context can interrupt even a
+	// blocking fn (e.g. time.Sleep), matching real behaviour where LLM calls
+	// respect ctx cancellation.
+	ch := make(chan WorkResult, 1)
+	go func() { ch <- w.fn(id, c, false, spec) }()
+	select {
+	case res := <-ch:
+		if err := ctx.Err(); err != nil {
+			return WorkResult{}, err
+		}
+		if res.Handle == "" {
+			res.Handle = "h" + strconv.Itoa(id)
+		}
+		return res, nil
+	case <-ctx.Done():
+		return WorkResult{}, ctx.Err()
 	}
-	return res, nil
 }
 
-func (w *fnWorker) Continue(_ context.Context, handle, _ string) (WorkResult, error) {
+func (w *fnWorker) Continue(ctx context.Context, handle, _ string) (WorkResult, error) {
+	if err := ctx.Err(); err != nil {
+		return WorkResult{}, err
+	}
 	id, _ := strconv.Atoi(strings.TrimPrefix(handle, "h"))
 	w.mu.Lock()
 	c := w.calls[id]
 	w.calls[id]++
 	w.mu.Unlock()
-	res := w.fn(id, c, true, WorkSpec{})
-	if res.Handle == "" {
-		res.Handle = handle
+	ch := make(chan WorkResult, 1)
+	go func() { ch <- w.fn(id, c, true, WorkSpec{}) }()
+	select {
+	case res := <-ch:
+		if err := ctx.Err(); err != nil {
+			return WorkResult{}, err
+		}
+		if res.Handle == "" {
+			res.Handle = handle
+		}
+		return res, nil
+	case <-ctx.Done():
+		return WorkResult{}, ctx.Err()
 	}
-	return res, nil
 }
 
 func (w *fnWorker) callCount(id int) int {
@@ -396,5 +423,56 @@ func TestConductCancellation(t *testing.T) {
 	l, _ := s.Get(id)
 	if l.Status != LedgerCancelled {
 		t.Fatalf("status = %s, want cancelled", l.Status)
+	}
+}
+
+func TestConductTurnsChargeIterations(t *testing.T) {
+	s := newTestStore(t)
+	id := seed(t, s, "g", []Unit{
+		{ID: 1, Description: "a"},
+		{ID: 2, Description: "b"},
+	})
+	worker := newFnWorker(func(unitID, call int, resume bool, spec WorkSpec) WorkResult {
+		// Each "run" consumes 5 sub-agent turns.
+		return WorkResult{Reply: "ok", Turns: 5}
+	})
+	c := New(s, worker, alwaysGreen(), nil, Config{})
+	if err := c.Run(context.Background(), id); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	l, _ := s.Get(id)
+	// Two units × 5 turns each = 10 total iterations.
+	if l.Iterations != 10 {
+		t.Errorf("iterations = %d, want 10 (turns charged to budget)", l.Iterations)
+	}
+}
+
+func TestConductWallClockTimeoutRetries(t *testing.T) {
+	s := newTestStore(t)
+	id := seed(t, s, "g", []Unit{{ID: 1, Description: "slow task"}})
+	var calls atomic.Int32
+	worker := newFnWorker(func(unitID, call int, resume bool, spec WorkSpec) WorkResult {
+		calls.Add(1)
+		if call == 0 {
+			// Sleep past the wall-clock budget so the conductor sees a timeout.
+			time.Sleep(200 * time.Millisecond)
+		}
+		return WorkResult{Reply: "recovered"}
+	})
+	c := New(s, worker, alwaysGreen(), nil, Config{MaxUnitDuration: 50 * time.Millisecond})
+	if err := c.Run(context.Background(), id); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	l, _ := s.Get(id)
+	if l.Status != LedgerDone {
+		t.Fatalf("status = %s, want done", l.Status)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("worker calls = %d, want 2 (timeout + retry)", calls.Load())
+	}
+	// Journal should mention the timeout.
+	journal := s.ReadJournal(id)
+	if !strings.Contains(journal, "timeout") {
+		t.Errorf("journal missing timeout entry:\n%s", journal)
 	}
 }

--- a/internal/conductor/store.go
+++ b/internal/conductor/store.go
@@ -181,6 +181,17 @@ func (s *Store) AppendJournal(id, line string) {
 	fmt.Fprintf(f, "[%s] %s\n", ts, strings.TrimRight(line, "\n"))
 }
 
+// ReadJournal returns the full text of the ledger's JOURNAL.md, or "" if absent.
+func (s *Store) ReadJournal(id string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, err := os.ReadFile(s.JournalPath(id))
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
 // ReadConventions returns the current conventions doc, or "" if absent.
 func (s *Store) ReadConventions(id string) string {
 	b, err := os.ReadFile(s.ConventionsPath(id))

--- a/internal/tools/spawner.go
+++ b/internal/tools/spawner.go
@@ -46,6 +46,11 @@ type SpawnRequest struct {
 	// ReadOnly, when true, strips the mutating tools (write_file, edit_file)
 	// from the child's toolbelt on top of the always-dropped Agent tool.
 	ReadOnly bool
+
+	// SessionDir, when non-empty, tells the spawner to persist the sub-agent's
+	// full conversation transcript to <SessionDir>/<agent-id>.jsonl so it can
+	// be inspected after a failure.
+	SessionDir string
 }
 
 // SpawnResult is the sub-agent's final output, plus its token usage so the
@@ -57,6 +62,9 @@ type SpawnResult struct {
 	Reply        string
 	InputTokens  int
 	OutputTokens int
+	// Turns is the number of provider round-trips the sub-agent executed.
+	// Used by the conductor to charge its global iteration budget.
+	Turns int
 	// StopReason carries why the sub-agent stopped. Empty for normal
 	// completion; "max_turns" when the loop budget was exhausted.
 	StopReason string


### PR DESCRIPTION
Fix four conductor mechanism bugs that caused tasks to hang silently:

1. **childMaxTurns 100 → 30**
   A single sub-agent could burn 100 tool rounds (~5 min) while the conductor's iteration budget counted only 1 dispatch round.

2. **Per-unit wall-clock timeout**
   New  (default 60s, configurable via ). A context.WithTimeout wraps each Spawn/Continue; on deadline exceeded the unit is retried with a journal entry.

3. **Sub-agent turns charge the iteration budget**
    carries actual provider round-trips consumed; the conductor adds this to  instead of just counting dispatch batches.

4. **SIGTERM/SIGINT graceful shutdown**
    replaces  so Ctrl-C or SIGTERM cancels the loop, marks the ledger cancelled, and exits cleanly.

Also adds session persistence for sub-agents (full transcript saved to  after every round).