### PR TITLE
feat(edit_file): add whitespace-indent normalization for tab/space mismatch

### DIFF
--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -29,7 +29,6 @@ func (EditFileTool) Definition() agent.ToolDefinition {
 			"You MUST read the file with read_file before calling this tool. " +
 			"old_string must appear exactly once (or set replace_all=true to swap every occurrence). " +
 			"The file must already exist — use write_file to create. " +
-			"Preserve indentation (tabs/spaces) exactly as it appears in the file. " +
 			"Include enough surrounding context in old_string (typically 2-4 lines) " +
 			"to make it unique. If old_string matches multiple times and replace_all is false, " +
 			"the edit will fail — add more context to disambiguate.",
@@ -96,8 +95,10 @@ func stripTrailingWhitespace(s string) string {
 }
 
 // findActualString attempts to locate the search string in the file content,
-// first with an exact match, then with quote-normalized match.
-// Returns the actual string found in the file (preserving original quotes),
+// first with an exact match, then with quote-normalized match, and finally
+// with leading-whitespace normalization (tab → space expansion) so that
+// space-indented old_string from the LLM still matches tab-indented files.
+// Returns the actual string found in the file (preserving original formatting),
 // or empty string if not found.
 func findActualString(fileContent, searchString string) string {
 	// First try exact match
@@ -110,58 +111,135 @@ func findActualString(fileContent, searchString string) string {
 	normalizedFile := normalizeQuotes(fileContent)
 
 	idx := strings.Index(normalizedFile, normalizedSearch)
-	if idx == -1 {
-		return ""
-	}
+	if idx != -1 {
+		// Map the index back to the original file content.
+		// Since normalization only replaces runes with ASCII equivalents
+		// of the same byte length (UTF-8 curly quotes are 3 bytes each,
+		// straight quotes are 1 byte), we can't use byte offsets directly.
+		// Instead, scan through the original file rune-by-rune.
+		fileRunes := []rune(fileContent)
+		normalizedRunes := []rune(normalizedFile)
+		searchRunes := []rune(normalizedSearch)
 
-	// Map the index back to the original file content.
-	// Since normalization only replaces runes with ASCII equivalents
-	// of the same byte length (UTF-8 curly quotes are 3 bytes each,
-	// straight quotes are 1 byte), we can't use byte offsets directly.
-	// Instead, scan through the original file rune-by-rune.
-	fileRunes := []rune(fileContent)
-	normalizedRunes := []rune(normalizedFile)
-	searchRunes := []rune(normalizedSearch)
-
-	// Verify the match at the rune level in normalized space
-	if idx+len(searchRunes) > len(normalizedRunes) {
-		return ""
-	}
-	for i := 0; i < len(searchRunes); i++ {
-		if normalizedRunes[idx+i] != searchRunes[i] {
+		// Verify the match at the rune level in normalized space
+		if idx+len(searchRunes) > len(normalizedRunes) {
 			return ""
 		}
+		for i := 0; i < len(searchRunes); i++ {
+			if normalizedRunes[idx+i] != searchRunes[i] {
+				return ""
+			}
+		}
+
+		// Map rune index back to original file substring
+		// Count runes in original file up to the match position
+		origStart := -1
+		runeCount := 0
+		for i := range fileRunes {
+			if runeCount == idx {
+				origStart = i
+				break
+			}
+			runeCount++
+		}
+		if origStart == -1 {
+			return ""
+		}
+
+		origEnd := -1
+		runeCount = 0
+		for i := range fileRunes {
+			if runeCount == idx+len(searchRunes) {
+				origEnd = i
+				break
+			}
+			runeCount++
+		}
+		if origEnd == -1 {
+			origEnd = len(fileRunes)
+		}
+
+		return string(fileRunes[origStart:origEnd])
 	}
 
-	// Map rune index back to original file substring
-	// Count runes in original file up to the match position
-	origStart := -1
-	runeCount := 0
-	for i, _ := range fileRunes {
-		if runeCount == idx {
-			origStart = i
-			break
-		}
-		runeCount++
+	// Try with normalized leading whitespace (tab → space expansion).
+	// This is line-based because indentation differences only affect
+	// leading whitespace, and the matching needs to map lines back
+	// to the original file.
+	if actual := findWithIndentNorm(fileContent, searchString); actual != "" {
+		return actual
 	}
-	if origStart == -1 {
+
+	return ""
+}
+
+// normalizeLeadingWhitespace expands tabs in leading whitespace of each line
+// to 4-space stops, making tab-indented and space-indented text comparable.
+// Only leading whitespace is touched — tabs inside line content are left alone.
+func normalizeLeadingWhitespace(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + len(s)/10)
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimLeft(line, " \t")
+		if trimmed != line {
+			leadingLen := len(line) - len(trimmed)
+			leading := line[:leadingLen]
+			b.WriteString(strings.ReplaceAll(leading, "\t", "    "))
+		}
+		b.WriteString(trimmed)
+		if i < len(lines)-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// findWithIndentNorm matches searchString against fileContent after
+// normalizing leading whitespace in both. Returns the corresponding substring
+// from the original (unnormalized) fileContent so the edit preserves the
+// file's actual whitespace convention.
+func findWithIndentNorm(fileContent, searchString string) string {
+	normFile := normalizeLeadingWhitespace(fileContent)
+	normSearch := normalizeLeadingWhitespace(searchString)
+
+	if !strings.Contains(normFile, normSearch) {
 		return ""
 	}
 
-	origEnd := -1
-	runeCount = 0
-	for i, _ := range fileRunes {
-		if runeCount == idx+len(searchRunes) {
-			origEnd = i
+	fileLines := strings.Split(fileContent, "\n")
+	normFileLines := strings.Split(normFile, "\n")
+	normSearchLines := strings.Split(normSearch, "\n")
+	searchLines := strings.Split(searchString, "\n")
+
+	start := -1
+	for i := 0; i <= len(normFileLines)-len(normSearchLines); i++ {
+		match := true
+		for j := 0; j < len(normSearchLines); j++ {
+			if normFileLines[i+j] != normSearchLines[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			start = i
 			break
 		}
-		runeCount++
-	}
-	if origEnd == -1 {
-		origEnd = len(fileRunes)
 	}
 
-	return string(fileRunes[origStart:origEnd])
+	if start == -1 {
+		return ""
+	}
+
+	end := start + len(searchLines)
+	actual := strings.Join(fileLines[start:end], "\n")
+
+	// Preserve trailing newline if the search string had one
+	if strings.HasSuffix(searchString, "\n") && !strings.HasSuffix(actual, "\n") {
+		actual += "\n"
+	}
+
+	return actual
 }
 
 func (EditFileTool) Execute(_ context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
@@ -255,6 +333,9 @@ func (EditFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 	// Preserve curly quote style from the matched text when the LLM
 	// provided straight quotes but the file uses curly quotes.
 	actualNewStr := preserveQuoteStyle(oldStr, actualOldStr, newStrClean)
+	// Preserve file indent convention (tabs vs spaces) — when the file
+	// uses tabs but the LLM supplied space-indented new_string.
+	actualNewStr = preserveIndentStyle(actualOldStr, actualNewStr)
 
 	var updated string
 	if replaceAll {
@@ -381,4 +462,30 @@ func applyCurlySingleQuotes(str string) string {
 
 func isLetter(r rune) bool {
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+}
+
+// preserveIndentStyle converts leading whitespace in newStr to match the
+// file's indentation convention (detected from actualOldStr). When the file
+// uses tabs and the LLM supplied space-indented new_string, each 4-space
+// indent level is converted to one tab. This keeps the file's whitespace
+// convention consistent after the edit.
+func preserveIndentStyle(actualOldStr, newStr string) string {
+	// Only convert when the file uses tabs for indentation
+	if !strings.Contains(actualOldStr, "\n\t") && !strings.HasPrefix(actualOldStr, "\t") {
+		return newStr
+	}
+
+	newLines := strings.Split(newStr, "\n")
+	for i, line := range newLines {
+		trimmed := strings.TrimLeft(line, " \t")
+		if trimmed == line {
+			continue
+		}
+		leadingLen := len(line) - len(trimmed)
+		leading := line[:leadingLen]
+		// Count indent level: each tab = 1 level, 4 spaces = 1 level
+		level := strings.Count(leading, "\t") + (len(leading)-strings.Count(leading, "\t"))/4
+		newLines[i] = strings.Repeat("\t", level) + trimmed
+	}
+	return strings.Join(newLines, "\n")
 }

--- a/internal/tools/edit_file_test.go
+++ b/internal/tools/edit_file_test.go
@@ -419,9 +419,9 @@ func TestNormalizeLeadingWhitespace(t *testing.T) {
 		{"\tcase:", "    case:"},
 		{"\t\tchatHelp(w)", "        chatHelp(w)"},
 		{"no indent", "no indent"},
-		{"  spaces", "  spaces"},         // spaces unchanged
-		{"\t  mixed", "      mixed"},     // tab + spaces
-		{"a\n\tb\nc", "a\n    b\nc"},     // multi-line
+		{"  spaces", "  spaces"},     // spaces unchanged
+		{"\t  mixed", "      mixed"}, // tab + spaces
+		{"a\n\tb\nc", "a\n    b\nc"}, // multi-line
 	}
 	for _, tc := range tests {
 		got := normalizeLeadingWhitespace(tc.in)

--- a/internal/tools/edit_file_test.go
+++ b/internal/tools/edit_file_test.go
@@ -349,3 +349,106 @@ func TestStripTrailingWhitespace_EveryLine(t *testing.T) {
 		t.Errorf("stripTrailingWhitespace(%q) = %q, want %q", in, got, want)
 	}
 }
+
+func TestEditFile_TabIndent_NormalizedMatch(t *testing.T) {
+	// File uses tabs for indentation; LLM supplies spaces.
+	// The whitespace-normalized match should find it and map back
+	// to the actual tab-indented text.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tabbed.go")
+	writeTestFile(t, path, "\tcase \"chat\":\n\t\tchatHelp(w)\n")
+
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       path,
+		"old_string": "    case \"chat\":\n        chatHelp(w)", // spaces, not tabs
+		"new_string": "    case \"chat\":\n        chatHelp(w)\n        // new",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := readTestFile(t, path)
+	// File should keep its tab convention
+	want := "\tcase \"chat\":\n\t\tchatHelp(w)\n\t\t// new\n"
+	if got != want {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+}
+
+func TestEditFile_TabIndent_ReplaceAll(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "many.go")
+	writeTestFile(t, path, "\tfoo\n\tfoo\n\tbar\n")
+
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":        path,
+		"old_string":  "    foo", // 4 spaces
+		"new_string":  "    baz", // 4 spaces
+		"replace_all": true,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := readTestFile(t, path)
+	// File keeps tabs, but all "foo" lines become "baz"
+	want := "\tbaz\n\tbaz\n\tbar\n"
+	if got != want {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+}
+
+func TestEditFile_TabIndent_NotFound_StillErrors(t *testing.T) {
+	// When even whitespace normalization can't find the string, error.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.go")
+	writeTestFile(t, path, "\tpackage main\n\n\tfunc main() {}\n")
+
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       path,
+		"old_string": "nonexistent",
+		"new_string": "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error, got %v", err)
+	}
+}
+
+func TestNormalizeLeadingWhitespace(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"\tcase:", "    case:"},
+		{"\t\tchatHelp(w)", "        chatHelp(w)"},
+		{"no indent", "no indent"},
+		{"  spaces", "  spaces"},         // spaces unchanged
+		{"\t  mixed", "      mixed"},     // tab + spaces
+		{"a\n\tb\nc", "a\n    b\nc"},     // multi-line
+	}
+	for _, tc := range tests {
+		got := normalizeLeadingWhitespace(tc.in)
+		if got != tc.want {
+			t.Errorf("normalizeLeadingWhitespace(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFindWithIndentNorm(t *testing.T) {
+	file := "\tcase \"chat\":\n\t\tchatHelp(w)\n"
+	search := "    case \"chat\":\n        chatHelp(w)"
+
+	actual := findWithIndentNorm(file, search)
+	// search has no trailing \n, so actual should also lack it
+	want := "\tcase \"chat\":\n\t\tchatHelp(w)"
+	if actual != want {
+		t.Errorf("findWithIndentNorm = %q, want %q", actual, want)
+	}
+}
+
+func TestFindWithIndentNorm_NotFound(t *testing.T) {
+	file := "\tfoo\n\tbar\n"
+	search := "        missing"
+
+	actual := findWithIndentNorm(file, search)
+	if actual != "" {
+		t.Errorf("expected empty for non-matching search, got %q", actual)
+	}
+}


### PR DESCRIPTION
## 问题

当文件用 tab 缩进（Go 惯例），而 LLM 在 old_string 里写的是空格时，edit_file 会报 "old_string not found"。AI 从 read_file 看到的渲染输出无法区分 tab 和空格，这是高频失败场景。

## 方案

在 findActualString 中添加第三步回退策略：

1. 精确匹配（已有）
2. 弯引号规范化匹配（已有）
3. 首部空白规范化匹配（新增）—— 将每行首部 tab 展开为 4 空格后比较，找到匹配后映射回原始文件内容

同时新增 preserveIndentStyle：替换后把 new_string 的首部空白转换回文件的缩进风格（tab），保持文件内部一致。

## 变更

- internal/tools/edit_file.go — 新增 normalizeLeadingWhitespace、findWithIndentNorm、preserveIndentStyle
- internal/tools/edit_file_test.go — 新增 7 个测试用例
- 移除工具描述中 "Preserve indentation exactly" 的过时提醒
- 净增 +250 行 / -40 行