### PR TITLE
fix(tools): de-flake TestTerminalInputTool_SendInput (lost cursor-advancing Read chunks)

### DIFF
--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -314,10 +314,13 @@ func main() {
 	}
 
 	// Wait for the process to finish, accumulating output as we poll.
+	// Read is cursor-advancing: each call returns only the chunk produced
+	// since the previous call, so the chunks must be concatenated — keeping
+	// only the last one drops output that arrived before the exit was seen.
 	var out string
 	for i := 0; i < 100; i++ {
-		var status string
-		out, status, _, _ = mgr.Read(id)
+		chunk, status, _, _ := mgr.Read(id)
+		out += chunk
 		if strings.HasPrefix(status, "exited") {
 			break
 		}


### PR DESCRIPTION
## Problem

`TestTerminalInputTool_SendInput` flaked on macOS CI in #598 with:

```
terminal_test.go:328: output should contain 'got: hello-world'; got: ""
```

The PR it blocked is doc-only — the failure is a latent race in the test itself.

## Root cause

`BackgroundManager.Read` is cursor-advancing: each call returns only the output produced since the previous call. The poll loop **overwrote** `out` with each call instead of accumulating:

```go
out, status, _, _ = mgr.Read(id)
```

When the echoed line arrives in poll N (status still `running`) and poll N+1 returns an empty chunk with status `exited`, the empty chunk replaces the captured output and the assertion sees `""`.

## Fix

Concatenate the chunks (`out += chunk`), matching the loop's own comment ("accumulating output as we poll").

Verified: `go test -race -run TestTerminalInputTool ./internal/tools/ -count=5` passes; full `./internal/tools/` package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)