### PR TITLE
fix(terminal): declare stdin in tool schema, surface stdin write failures (follow-up to #597)

### DIFF
--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -55,13 +55,17 @@ func (t TerminalTool) managerFor(ctx context.Context) *BackgroundManager {
 func (TerminalTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name:        "terminal",
-		Description: "Run a shell command in the system shell (POSIX sh on macOS/Linux, PowerShell on Windows — see the Shell line in the environment context) and return stdout+stderr. Use for file operations, running programs, etc. Prefer dedicated tools (read_file, write_file, edit_file, glob, grep) over raw shell commands when they exist.\n\nChoosing sync vs background:\n- Default (no run_in_background): runs synchronously with a 120s timeout. Use for fast commands whose output you need immediately (e.g. `ls`, `git status`, `grep`, short scripts).\n- run_in_background:true — ONE-SHOT tasks (compiling, testing, installing, building, linting, CI checks): detaches immediately, returns a process id. The system automatically notifies you on completion. DO NOT poll terminal_output.\n- run_in_background:true — LONG-RUNNING services (servers, watchers, docker compose up): detaches immediately, returns a process id. After launch, verify the service with an external check (e.g., `curl http://localhost:PORT`, `pgrep`) rather than polling terminal_output. Use terminal_output only to inspect startup logs or diagnose issues — do not call it in a tight loop.\n\nBuffering: the process is connected via pipes, not a terminal, so stdio block-buffers its output — a chatty program's logs can sit unflushed and invisible to terminal_output for a long time. On macOS/Linux, when you will want live logs, prefix the command with `stdbuf -oL` (e.g. `stdbuf -oL npm run dev`) to force line buffering.",
+		Description: "Run a shell command in the system shell (POSIX sh on macOS/Linux, PowerShell on Windows — see the Shell line in the environment context) and return stdout+stderr. Use for file operations, running programs, etc. Prefer dedicated tools (read_file, write_file, edit_file, glob, grep) over raw shell commands when they exist.\n\nChoosing sync vs background:\n- Default (no run_in_background): runs synchronously with a 120s timeout. Use for fast commands whose output you need immediately (e.g. `ls`, `git status`, `grep`, short scripts).\n- run_in_background:true — ONE-SHOT tasks (compiling, testing, installing, building, linting, CI checks): detaches immediately, returns a process id. The system automatically notifies you on completion. DO NOT poll terminal_output.\n- run_in_background:true — LONG-RUNNING services (servers, watchers, docker compose up): detaches immediately, returns a process id. After launch, verify the service with an external check (e.g., `curl http://localhost:PORT`, `pgrep`) rather than polling terminal_output. Use terminal_output only to inspect startup logs or diagnose issues — do not call it in a tight loop.\n\nBuffering: the process is connected via pipes, not a terminal, so stdio block-buffers its output — a chatty program's logs can sit unflushed and invisible to terminal_output for a long time. On macOS/Linux, when you will want live logs, prefix the command with `stdbuf -oL` (e.g. `stdbuf -oL npm run dev`) to force line buffering.\n\nTo feed text to a command's stdin, pass it via the stdin parameter instead of embedding it in the command string — embedded text gets interpreted by the shell (backticks, quotes, $), stdin is delivered verbatim.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"command": map[string]any{
 					"type":        "string",
 					"description": "The shell command to execute",
+				},
+				"stdin": map[string]any{
+					"type":        "string",
+					"description": "Text piped verbatim to the command's stdin, which is then closed (EOF). Use this — not interpolation into the command string — to pass long or special-character text (quotes, backticks, $) to commands that read stdin, e.g. `gh pr create --body-file -`, `git apply -`, `python script.py`.",
 				},
 				"run_in_background": map[string]any{
 					"type":        "boolean",
@@ -145,11 +149,14 @@ func (t TerminalTool) ExecuteStream(
 		if err != nil {
 			return agent.ToolResult{Text: ""}, err
 		}
+		var stdinWarn string
 		if stdinText != "" {
-			t.managerFor(ctx).WriteStdinAndClose(id, stdinText)
+			if werr := t.managerFor(ctx).WriteStdinAndClose(id, stdinText); werr != nil {
+				stdinWarn = stdinWriteWarning(werr)
+			}
 		}
 		return agent.ToolResult{
-			Text: fmt.Sprintf("Started background process %s.\n\n%s", id, BgPollNotice),
+			Text: fmt.Sprintf("Started background process %s.%s\n\n%s", id, stdinWarn, BgPollNotice),
 			UI:   terminalUI(command, "running", fmt.Sprintf("background process %s", id)),
 		}, nil
 	}
@@ -186,12 +193,16 @@ func (t TerminalTool) ExecuteStream(
 	if err != nil {
 		return agent.ToolResult{Text: ""}, err
 	}
+	var stdinWarn string
 	if stdinText != "" {
-		t.managerFor(ctx).WriteStdinAndClose(id, stdinText)
+		if werr := t.managerFor(ctx).WriteStdinAndClose(id, stdinText); werr != nil {
+			stdinWarn = stdinWriteWarning(werr)
+		}
 	}
 
 	// snapshot returns the collected output so far, tab-expanded and with the
-	// truncation marker prepended when the cap dropped earlier bytes.
+	// truncation marker prepended when the cap dropped earlier bytes. The
+	// stdin-write warning (if any) is appended so every return path carries it.
 	snapshot := func() string {
 		outMu.Lock()
 		body := strings.TrimRight(string(out), "\n")
@@ -201,7 +212,7 @@ func (t TerminalTool) ExecuteStream(
 		if d {
 			body = "[... earlier output truncated ...]\n" + body
 		}
-		return body
+		return body + stdinWarn
 	}
 
 	// Poll until the process exits or the timeout fires.
@@ -248,6 +259,15 @@ func (t TerminalTool) ExecuteStream(
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+}
+
+// stdinWriteWarning formats a WriteStdinAndClose failure for the tool result.
+// It is a warning rather than a hard error: a fast-exiting process that never
+// reads stdin (or closes it early, like `head`) loses the race with the write,
+// and the command's own output/exit status is the authoritative signal — but
+// the model must still learn the text was not delivered.
+func stdinWriteWarning(err error) string {
+	return fmt.Sprintf("\n[warning: writing stdin failed: %v — the command ran without the stdin text]", err)
 }
 
 // terminalUI builds the "terminal" UI payload. The preview keeps the TAIL of

--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -31,6 +31,9 @@ func TestTerminalTool_Definition(t *testing.T) {
 	if _, ok := props["command"]; !ok {
 		t.Error("Parameters.properties.command should exist")
 	}
+	if _, ok := props["stdin"]; !ok {
+		t.Error("Parameters.properties.stdin should exist — the executor reads it, so the schema must declare it or the model never sends it")
+	}
 	req, ok := def.Parameters["required"].([]string)
 	if !ok {
 		t.Fatal("Parameters.required is not []string")
@@ -436,7 +439,7 @@ func TestTerminalTool_Stdin_Background(t *testing.T) {
 
 	stdinBody := "hello stdin\n"
 
-	id, err := term.ExecuteStream(context.Background(), "terminal", map[string]any{
+	res, err := term.ExecuteStream(context.Background(), "terminal", map[string]any{
 		"command":           "cat",
 		"run_in_background": true,
 		"stdin":             stdinBody,
@@ -444,21 +447,32 @@ func TestTerminalTool_Stdin_Background(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExecuteStream bg: %v", err)
 	}
-	if !strings.Contains(id.Text, "Started background process") {
-		t.Fatalf("expected background start, got: %s", id.Text)
+	if !strings.Contains(res.Text, "Started background process") {
+		t.Fatalf("expected background start, got: %s", res.Text)
 	}
+	// Extract the process id from "Started background process <id>."
+	id := strings.TrimPrefix(res.Text, "Started background process ")
+	id = strings.SplitN(id, ".", 2)[0]
 
-	// Wait for process to finish
-	for i := 0; i < 50; i++ {
-		out, status, _, _ := mgr.Read("bg_1")
+	// Wait for the process to finish, accumulating output as we poll —
+	// Read is cursor-advancing, so each call returns only the new chunk.
+	var out string
+	exited := false
+	for i := 0; i < 100; i++ {
+		chunk, status, _, _ := mgr.Read(id)
+		out += chunk
 		if strings.HasPrefix(status, "exited") {
-			if out != stdinBody {
-				t.Errorf("bg stdin should reach process verbatim.\ngot:  %q\nwant: %q", out, stdinBody)
-			}
+			exited = true
 			break
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+	if !exited {
+		t.Fatal("background cat did not exit — stdin EOF likely never delivered")
+	}
+	if out != stdinBody {
+		t.Errorf("bg stdin should reach process verbatim.\ngot:  %q\nwant: %q", out, stdinBody)
+	}
 
-	kill.Execute(context.Background(), "kill_shell", map[string]any{"id": "bg_1"})
+	kill.Execute(context.Background(), "kill_shell", map[string]any{"id": id})
 }


### PR DESCRIPTION
## Problem

#597 added stdin piping to the terminal tool, but the `stdin` parameter was never declared in `Definition()` — the executor reads `input["stdin"]`, yet the JSON schema and description don't mention it. The model can't send a parameter it doesn't know exists, so the feature was unreachable in practice. Two smaller issues rode along: `WriteStdinAndClose` errors were silently discarded at both call sites, and the new background test had the same cursor-advancing-Read flake pattern that #599 fixed in `TestTerminalInputTool_SendInput` (plus a vacuous-pass path when the process never exits).

## Changes

- **Schema**: declare `stdin` in the terminal tool's parameters, add a sentence to the tool description steering long/special-character text to stdin rather than command-string interpolation. A new assertion in `TestTerminalTool_Definition` locks the schema so an executor/schema mismatch can't recur.
- **Error surfacing**: `WriteStdinAndClose` failures now append `[warning: writing stdin failed: … — the command ran without the stdin text]` to the result text on both the sync path (via `snapshot()`, so all three return paths carry it) and the background path. Deliberately a warning rather than a hard error: a fast-exiting process that never reads stdin loses the write race benignly, and the command's own output/exit status stays authoritative — but the model must learn the text wasn't delivered.
- **Test de-flake**: `TestTerminalTool_Stdin_Background` now accumulates Read chunks (`out += chunk`), `t.Fatal`s if the process never exits instead of passing with no assertion, and parses the process id from the result text instead of hardcoding `bg_1`.

Verified: `go test -race ./internal/tools/ ./cmd/octo/` green, `-run TestTerminalTool -count=3` stable, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)