### PR TITLE
feat(server): IM interactive permission ask — confirm tool calls from the chat

### DIFF
--- a/dev-docs/im-interactive-ask-design.md
+++ b/dev-docs/im-interactive-ask-design.md
@@ -33,10 +33,16 @@ deadlock. Instead:
 - `channel.Session` carries a single ask slot (`ask.go`): `BeginAsk` claims
   it and returns a reply channel; `DeliverAskReply` routes text to it and
   reports whether it was consumed. One ask at a time, one reply per ask.
+- The slot records the asking chat and user, and only a matching reply is
+  accepted. Session keying (`BindByChatUser` in production) usually
+  guarantees this already, but the slot enforces it directly so a group
+  member can't answer someone else's prompt under shared-session binding
+  modes, and the asker can't be answered from another chat.
 - The server's inbound dispatcher (`routeChannelEvent`) checks, in order:
   slash commands (so `/stop` still cancels the asking turn), then a pending
   ask (the message is the answer, consumed inline off the adapter read
-  loop), then the normal turn path.
+  loop), then the normal turn path. Text-less events (stickers, images)
+  never answer an ask.
 
 A known, accepted race: a genuine steer message that arrives exactly while
 an ask is pending is consumed as the answer. A non-affirmative answer just
@@ -47,14 +53,23 @@ denies — the cost is one denied tool call and a resent message.
 `channelPermissionAsk` (server) sends:
 
 ```
-⚠️ Allow <tool>? Reply yes / 允许 to approve — any other reply denies.
-(Auto-deny in 5m0s; /stop cancels the task.)
+⚠️ Allow terminal — "sudo rm /tmp/x"? Reply yes / 允许 to approve — any
+other reply denies; only the requester's reply counts. (Auto-deny in 5m0s;
+/stop cancels the task.)
 ```
 
-Approval requires an explicit affirmative — one of `yes y ok allow 是 可以
-同意 允许` (case-insensitive, trimmed). Everything else denies: arbitrary
-replies, the 5-minute timeout, and turn cancellation (`/stop` cancels the
-turn ctx, which the ask select observes). `remember` is always false.
+The prompt always shows *what* is being approved, not just the tool name:
+the IM transport renders no tool cards before the gate fires, so without
+the input summary (`askInputSummary` — command/path/url first, JSON head
+otherwise, truncated) the user would approve blind. Approval requires an
+explicit affirmative — one of `yes y ok allow 是 可以 同意 允许`
+(case-insensitive, trimmed). Everything else denies: arbitrary replies,
+the 5-minute timeout, and turn cancellation (`/stop` cancels the turn ctx,
+which the ask select observes). `remember` is always false.
+
+A pending ask keeps its turn in flight, so it holds a restart-drain slot;
+the drain's 30-second hard bound cuts an unanswered prompt rather than
+waiting out the full 5 minutes.
 
 ## Per-turn gate
 

--- a/dev-docs/im-interactive-ask-design.md
+++ b/dev-docs/im-interactive-ask-design.md
@@ -1,0 +1,88 @@
+# IM Interactive Permission Ask
+
+IM channel turns confirm ask-class tool calls the same way web turns do —
+interactively — instead of denying them outright. When a tool call resolves
+to an ask verdict, the agent sends a confirmation prompt into the chat and
+the session's next plain message is consumed as the answer. This brings IM
+to permission parity with the web UI's confirmation modal.
+
+## Goals
+
+- Ask-class verdicts (sudo commands, `restart_server`, anything without an
+  allow rule) become answerable from DingTalk/Feishu/Telegram/Discord/WeCom/
+  Weixin chats.
+- Fail closed: silence, ambiguity, cancellation, and timeout all deny.
+- Same permission *policy* as everywhere else — only the prompt transport
+  differs.
+
+## Non-goals
+
+- No platform buttons or interactive cards. Plain text works identically on
+  all six platforms; buttons would need six adapter implementations for a
+  marginal UX gain.
+- No "remember this decision". Chat approvals are one-shot — in a group
+  chat, a remembered allow would outlive the person who granted it.
+
+## Answer = the next message
+
+The asking turn blocks inside the tool loop, holding the session's `runMu`.
+The answer therefore cannot travel through the normal turn path — a new turn
+would queue behind `BeginRun` waiting for the very turn that is asking, a
+deadlock. Instead:
+
+- `channel.Session` carries a single ask slot (`ask.go`): `BeginAsk` claims
+  it and returns a reply channel; `DeliverAskReply` routes text to it and
+  reports whether it was consumed. One ask at a time, one reply per ask.
+- The server's inbound dispatcher (`routeChannelEvent`) checks, in order:
+  slash commands (so `/stop` still cancels the asking turn), then a pending
+  ask (the message is the answer, consumed inline off the adapter read
+  loop), then the normal turn path.
+
+A known, accepted race: a genuine steer message that arrives exactly while
+an ask is pending is consumed as the answer. A non-affirmative answer just
+denies — the cost is one denied tool call and a resent message.
+
+## The prompt and the answer
+
+`channelPermissionAsk` (server) sends:
+
+```
+⚠️ Allow <tool>? Reply yes / 允许 to approve — any other reply denies.
+(Auto-deny in 5m0s; /stop cancels the task.)
+```
+
+Approval requires an explicit affirmative — one of `yes y ok allow 是 可以
+同意 允许` (case-insensitive, trimmed). Everything else denies: arbitrary
+replies, the 5-minute timeout, and turn cancellation (`/stop` cancels the
+turn ctx, which the ask select observes). `remember` is always false.
+
+## Per-turn gate
+
+`handleChannelMessage` builds a fresh gate for every IM turn — engine with
+the configured permission mode (`resolvePermissionMode`, same as web) plus
+`channelPermissionAsk` — and sets it on the session agent after `BeginRun`
+(turns are serialised, so this cannot race a running turn). This replaces
+the old factory-time gate, which froze a hard-coded strict-mode policy
+snapshot at session creation and — via its `gate, _ :=` construction —
+silently ran turns *ungated* when engine construction failed. An engine
+failure now aborts the turn with an error reply in the chat.
+
+## Components
+
+| Piece | Where | What |
+|---|---|---|
+| Ask slot | `internal/channel/ask.go` | `Session.BeginAsk` / `DeliverAskReply`, one pending ask per session |
+| Chat ask | `internal/server/channel_ask.go` | prompt text, affirmative set, 5-minute timeout, ctx-cancel deny |
+| Routing | `internal/server/server.go` `routeChannelEvent` | command → pending ask → turn, in that order |
+| Per-turn gate | `internal/server/server.go` `handleChannelMessage` | configured mode + chat ask, engine failure aborts the turn |
+
+## Testing
+
+- Ask slot: claim/deliver/release/one-reply-only/second-begin-refused unit
+  tests in `internal/channel`.
+- Chat ask: affirmative table, allow/deny/cancel/timeout paths against a
+  fake adapter.
+- Routing: pending ask consumes the message, `/stop` bypasses the ask, a
+  normal message runs a full stub-sender turn.
+- Gate: end-to-end policy check (allow without prompt, ask prompts then
+  follows the reply, hard-deny never prompts).

--- a/dev-docs/server-self-restart-design.md
+++ b/dev-docs/server-self-restart-design.md
@@ -88,11 +88,10 @@ that is already doomed.
 
 The tool is ask-class in `internal/permission/defaults.yml` (explicitly, so
 nobody relaxes it by accident). On the web that means the browser
-confirmation prompt; the IM channel gate runs strict with no asker, so
-ask resolves to deny — an IM-triggered restart is refused until an
-interactive IM ask flow exists. Server sub-agents see the tool (the
-restarter registration is process-global) but inherit the parent's gate,
-so they face the same confirmation or denial.
+confirmation prompt; on IM channels the in-chat reply prompt (see
+`im-interactive-ask-design.md` — explicit affirmative only). Server
+sub-agents see the tool (the restarter registration is process-global) but
+inherit the parent's gate, so they face the same confirmation.
 
 ## Drain sequence
 

--- a/internal/channel/ask.go
+++ b/internal/channel/ask.go
@@ -1,0 +1,47 @@
+package channel
+
+import "fmt"
+
+// The interactive permission ask for IM channels: a tool call that resolves
+// to an ask-class verdict sends a confirmation prompt into the chat, and the
+// session's NEXT plain message is consumed as the answer. The inbound
+// dispatcher routes that message via DeliverAskReply BEFORE spawning a turn —
+// routing it through the normal turn path would deadlock behind runMu, which
+// the asking turn still holds.
+
+// BeginAsk claims the session's single ask slot and returns the channel on
+// which the answer text will arrive, plus a release func the caller must run
+// when the ask resolves (answer, timeout, or cancellation). A second BeginAsk
+// while one is pending is refused — within a session turns are serialised, so
+// this only guards against misuse.
+func (s *Session) BeginAsk() (<-chan string, func(), error) {
+	s.askMu.Lock()
+	defer s.askMu.Unlock()
+	if s.pendingAsk != nil {
+		return nil, nil, fmt.Errorf("an approval prompt is already pending in this chat")
+	}
+	ch := make(chan string, 1)
+	s.pendingAsk = ch
+	release := func() {
+		s.askMu.Lock()
+		if s.pendingAsk == ch {
+			s.pendingAsk = nil
+		}
+		s.askMu.Unlock()
+	}
+	return ch, release, nil
+}
+
+// DeliverAskReply routes text to a pending ask and reports whether it was
+// consumed. False means no ask is waiting — the caller should treat the
+// message as normal chat input. Each ask consumes exactly one reply.
+func (s *Session) DeliverAskReply(text string) bool {
+	s.askMu.Lock()
+	defer s.askMu.Unlock()
+	if s.pendingAsk == nil {
+		return false
+	}
+	s.pendingAsk <- text // buffered (cap 1); never blocks
+	s.pendingAsk = nil
+	return true
+}

--- a/internal/channel/ask.go
+++ b/internal/channel/ask.go
@@ -11,10 +11,14 @@ import "fmt"
 
 // BeginAsk claims the session's single ask slot and returns the channel on
 // which the answer text will arrive, plus a release func the caller must run
-// when the ask resolves (answer, timeout, or cancellation). A second BeginAsk
-// while one is pending is refused — within a session turns are serialised, so
-// this only guards against misuse.
-func (s *Session) BeginAsk() (<-chan string, func(), error) {
+// when the ask resolves (answer, timeout, or cancellation). chatID and userID
+// pin who may answer: only a reply from the same chat by the same user is
+// accepted — session keying usually guarantees this already (BindByChatUser),
+// but the slot enforces it so the property survives other binding modes,
+// where a session is shared across users or chats. A second BeginAsk while
+// one is pending is refused — within a session turns are serialised, so this
+// only guards against misuse.
+func (s *Session) BeginAsk(chatID, userID string) (<-chan string, func(), error) {
 	s.askMu.Lock()
 	defer s.askMu.Unlock()
 	if s.pendingAsk != nil {
@@ -22,6 +26,7 @@ func (s *Session) BeginAsk() (<-chan string, func(), error) {
 	}
 	ch := make(chan string, 1)
 	s.pendingAsk = ch
+	s.askChatID, s.askUserID = chatID, userID
 	release := func() {
 		s.askMu.Lock()
 		if s.pendingAsk == ch {
@@ -33,12 +38,16 @@ func (s *Session) BeginAsk() (<-chan string, func(), error) {
 }
 
 // DeliverAskReply routes text to a pending ask and reports whether it was
-// consumed. False means no ask is waiting — the caller should treat the
-// message as normal chat input. Each ask consumes exactly one reply.
-func (s *Session) DeliverAskReply(text string) bool {
+// consumed. False means no ask is waiting (or the reply came from the wrong
+// chat or user) — the caller should treat the message as normal chat input.
+// Each ask consumes exactly one reply.
+func (s *Session) DeliverAskReply(chatID, userID, text string) bool {
 	s.askMu.Lock()
 	defer s.askMu.Unlock()
 	if s.pendingAsk == nil {
+		return false
+	}
+	if chatID != s.askChatID || userID != s.askUserID {
 		return false
 	}
 	s.pendingAsk <- text // buffered (cap 1); never blocks

--- a/internal/channel/ask_test.go
+++ b/internal/channel/ask_test.go
@@ -1,0 +1,83 @@
+package channel
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSession_BeginAskDeliverReply(t *testing.T) {
+	sess := &Session{}
+
+	replyCh, release, err := sess.BeginAsk()
+	if err != nil {
+		t.Fatalf("BeginAsk: %v", err)
+	}
+	defer release()
+
+	if !sess.DeliverAskReply("yes") {
+		t.Fatal("DeliverAskReply = false with a pending ask, want true")
+	}
+	select {
+	case got := <-replyCh:
+		if got != "yes" {
+			t.Errorf("reply = %q, want %q", got, "yes")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("reply not delivered to the ask channel")
+	}
+}
+
+func TestSession_DeliverWithoutPendingAsk(t *testing.T) {
+	sess := &Session{}
+	if sess.DeliverAskReply("hello") {
+		t.Error("DeliverAskReply = true with no pending ask; the message must flow to a normal turn")
+	}
+}
+
+func TestSession_SecondBeginAskRefused(t *testing.T) {
+	sess := &Session{}
+	_, release, err := sess.BeginAsk()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	if _, _, err := sess.BeginAsk(); err == nil {
+		t.Error("second BeginAsk should be refused while one is pending")
+	}
+}
+
+func TestSession_ReleaseClearsPending(t *testing.T) {
+	sess := &Session{}
+	_, release, err := sess.BeginAsk()
+	if err != nil {
+		t.Fatal(err)
+	}
+	release()
+
+	if sess.DeliverAskReply("late") {
+		t.Error("a reply after release must not be consumed")
+	}
+	// The slot is reusable after release.
+	if _, release2, err := sess.BeginAsk(); err != nil {
+		t.Errorf("BeginAsk after release: %v", err)
+	} else {
+		release2()
+	}
+}
+
+func TestSession_OneReplyOnly(t *testing.T) {
+	sess := &Session{}
+	_, release, err := sess.BeginAsk()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	if !sess.DeliverAskReply("yes") {
+		t.Fatal("first reply should be consumed")
+	}
+	if sess.DeliverAskReply("again") {
+		t.Error("second reply must not be consumed — the ask is already answered")
+	}
+}

--- a/internal/channel/ask_test.go
+++ b/internal/channel/ask_test.go
@@ -8,13 +8,13 @@ import (
 func TestSession_BeginAskDeliverReply(t *testing.T) {
 	sess := &Session{}
 
-	replyCh, release, err := sess.BeginAsk()
+	replyCh, release, err := sess.BeginAsk("c1", "u1")
 	if err != nil {
 		t.Fatalf("BeginAsk: %v", err)
 	}
 	defer release()
 
-	if !sess.DeliverAskReply("yes") {
+	if !sess.DeliverAskReply("c1", "u1", "yes") {
 		t.Fatal("DeliverAskReply = false with a pending ask, want true")
 	}
 	select {
@@ -29,37 +29,37 @@ func TestSession_BeginAskDeliverReply(t *testing.T) {
 
 func TestSession_DeliverWithoutPendingAsk(t *testing.T) {
 	sess := &Session{}
-	if sess.DeliverAskReply("hello") {
+	if sess.DeliverAskReply("c1", "u1", "hello") {
 		t.Error("DeliverAskReply = true with no pending ask; the message must flow to a normal turn")
 	}
 }
 
 func TestSession_SecondBeginAskRefused(t *testing.T) {
 	sess := &Session{}
-	_, release, err := sess.BeginAsk()
+	_, release, err := sess.BeginAsk("c1", "u1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer release()
 
-	if _, _, err := sess.BeginAsk(); err == nil {
+	if _, _, err := sess.BeginAsk("c1", "u1"); err == nil {
 		t.Error("second BeginAsk should be refused while one is pending")
 	}
 }
 
 func TestSession_ReleaseClearsPending(t *testing.T) {
 	sess := &Session{}
-	_, release, err := sess.BeginAsk()
+	_, release, err := sess.BeginAsk("c1", "u1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	release()
 
-	if sess.DeliverAskReply("late") {
+	if sess.DeliverAskReply("c1", "u1", "late") {
 		t.Error("a reply after release must not be consumed")
 	}
 	// The slot is reusable after release.
-	if _, release2, err := sess.BeginAsk(); err != nil {
+	if _, release2, err := sess.BeginAsk("c1", "u1"); err != nil {
 		t.Errorf("BeginAsk after release: %v", err)
 	} else {
 		release2()
@@ -68,16 +68,44 @@ func TestSession_ReleaseClearsPending(t *testing.T) {
 
 func TestSession_OneReplyOnly(t *testing.T) {
 	sess := &Session{}
-	_, release, err := sess.BeginAsk()
+	_, release, err := sess.BeginAsk("c1", "u1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer release()
 
-	if !sess.DeliverAskReply("yes") {
+	if !sess.DeliverAskReply("c1", "u1", "yes") {
 		t.Fatal("first reply should be consumed")
 	}
-	if sess.DeliverAskReply("again") {
+	if sess.DeliverAskReply("c1", "u1", "again") {
 		t.Error("second reply must not be consumed — the ask is already answered")
+	}
+}
+
+func TestSession_WrongUserOrChatNotConsumed(t *testing.T) {
+	sess := &Session{}
+	replyCh, release, err := sess.BeginAsk("c1", "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	if sess.DeliverAskReply("c1", "u2", "yes") {
+		t.Error("another user's reply must not answer the ask")
+	}
+	if sess.DeliverAskReply("c2", "u1", "yes") {
+		t.Error("a reply from another chat must not answer the ask")
+	}
+	// The rightful answer still lands afterwards.
+	if !sess.DeliverAskReply("c1", "u1", "yes") {
+		t.Fatal("the requester's reply should be consumed")
+	}
+	select {
+	case got := <-replyCh:
+		if got != "yes" {
+			t.Errorf("reply = %q, want yes", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("reply not delivered")
 	}
 }

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -64,6 +64,12 @@ type Session struct {
 	runMu     sync.Mutex
 	cancelMu  sync.Mutex
 	runCancel context.CancelFunc
+
+	// pendingAsk, while non-nil, claims the session's next plain message as
+	// the answer to an interactive permission prompt (see ask.go). Guarded by
+	// askMu, not runMu — the reply arrives while the asking turn holds runMu.
+	askMu      sync.Mutex
+	pendingAsk chan string
 }
 
 // BeginRun prepares one agent turn: it blocks until any previous turn in this

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -68,8 +68,11 @@ type Session struct {
 	// pendingAsk, while non-nil, claims the session's next plain message as
 	// the answer to an interactive permission prompt (see ask.go). Guarded by
 	// askMu, not runMu — the reply arrives while the asking turn holds runMu.
+	// askChatID/askUserID pin which chat+user may answer.
 	askMu      sync.Mutex
 	pendingAsk chan string
+	askChatID  string
+	askUserID  string
 }
 
 // BeginRun prepares one agent turn: it blocks until any previous turn in this

--- a/internal/permission/defaults.yml
+++ b/internal/permission/defaults.yml
@@ -130,8 +130,8 @@ skill:
 # Process restart — always confirm. The implicit default would already be
 # ask, but the rule is explicit so nobody pattern-matches this block and
 # adds an allow: an unconfirmed restart_server call would bounce the whole
-# server. Non-interactive transports (IM bridge's strict gate) resolve ask
-# to deny — restart from IM stays refused until an interactive ask exists
-# there. Auto-approve mode runs it without prompting, like everything else.
+# server. The web UI confirms via the browser modal; IM channels confirm
+# via the in-chat reply prompt (explicit affirmative only). Auto-approve
+# mode runs it without prompting, like everything else.
 restart_server:
   - ask: { pattern: "" }

--- a/internal/server/channel_ask.go
+++ b/internal/server/channel_ask.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -26,25 +27,58 @@ func isAffirmative(text string) bool {
 	return imAffirmatives[strings.ToLower(strings.TrimSpace(text))]
 }
 
+// askInputSummary renders the part of toolInput the user is actually
+// approving. The IM transport shows no tool cards before the gate fires, so
+// without this the user would approve blind — "Allow terminal?" tells them
+// nothing about WHICH command. Known primary fields come first; anything
+// else falls back to a JSON head.
+func askInputSummary(toolInput map[string]any) string {
+	const maxLen = 160
+	for _, key := range []string{"command", "path", "url", "reason", "pattern"} {
+		if v, ok := toolInput[key].(string); ok && strings.TrimSpace(v) != "" {
+			return truncateForAsk(v, maxLen)
+		}
+	}
+	if len(toolInput) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(toolInput)
+	if err != nil {
+		return ""
+	}
+	return truncateForAsk(string(b), maxLen)
+}
+
+func truncateForAsk(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "…"
+}
+
 // channelPermissionAsk builds the app.PermissionAsk for one IM turn: it sends
-// a confirmation prompt into the chat and consumes the session's next plain
-// message as the answer (routed by the inbound dispatcher via
-// DeliverAskReply, ahead of the turn path — see routeChannelEvent). Approval
-// requires an explicit affirmative; any other reply, the turn being cancelled
-// (/stop), or the timeout denies. remember is always false: chat approvals
-// are one-shot, a lingering allow in a group chat would outlive the person
-// who granted it.
+// a confirmation prompt into the chat and consumes the requesting user's next
+// plain message in that chat as the answer (routed by the inbound dispatcher
+// via DeliverAskReply, ahead of the turn path — see routeChannelEvent).
+// Approval requires an explicit affirmative; any other reply, the turn being
+// cancelled (/stop), or the timeout denies. remember is always false: chat
+// approvals are one-shot, a lingering allow in a group chat would outlive
+// the person who granted it.
 func (s *Server) channelPermissionAsk(sess *channel.Session, ad channel.Adapter, ev channel.InboundEvent) app.PermissionAsk {
 	return func(ctx context.Context, toolName string, toolInput map[string]any) (bool, bool, error) {
-		replyCh, release, err := sess.BeginAsk()
+		replyCh, release, err := sess.BeginAsk(ev.ChatID, ev.UserID)
 		if err != nil {
 			return false, false, err
 		}
 		defer release()
 
+		what := toolName
+		if detail := askInputSummary(toolInput); detail != "" {
+			what = fmt.Sprintf("%s — %q", toolName, detail)
+		}
 		prompt := fmt.Sprintf(
-			"⚠️ Allow %s? Reply yes / 允许 to approve — any other reply denies. (Auto-deny in %s; /stop cancels the task.)",
-			toolName, channelAskTimeout)
+			"⚠️ Allow %s? Reply yes / 允许 to approve — any other reply denies; only the requester's reply counts. (Auto-deny in %s; /stop cancels the task.)",
+			what, channelAskTimeout)
 		ad.SendText(ev.ChatID, prompt, ev.MessageID)
 
 		timer := time.NewTimer(channelAskTimeout)

--- a/internal/server/channel_ask.go
+++ b/internal/server/channel_ask.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/app"
+	"github.com/Leihb/octo-agent/internal/channel"
+)
+
+// channelAskTimeout bounds how long an IM permission prompt waits for the
+// user's reply before denying. Matches the web confirmation modal's posture
+// of "no answer = no". Variable, not const, so tests can shorten it.
+var channelAskTimeout = 5 * time.Minute
+
+// imAffirmatives are the only replies that approve an IM permission prompt.
+// Anything else denies — over chat, silence and ambiguity must fail closed.
+var imAffirmatives = map[string]bool{
+	"yes": true, "y": true, "ok": true, "allow": true,
+	"是": true, "可以": true, "同意": true, "允许": true,
+}
+
+func isAffirmative(text string) bool {
+	return imAffirmatives[strings.ToLower(strings.TrimSpace(text))]
+}
+
+// channelPermissionAsk builds the app.PermissionAsk for one IM turn: it sends
+// a confirmation prompt into the chat and consumes the session's next plain
+// message as the answer (routed by the inbound dispatcher via
+// DeliverAskReply, ahead of the turn path — see routeChannelEvent). Approval
+// requires an explicit affirmative; any other reply, the turn being cancelled
+// (/stop), or the timeout denies. remember is always false: chat approvals
+// are one-shot, a lingering allow in a group chat would outlive the person
+// who granted it.
+func (s *Server) channelPermissionAsk(sess *channel.Session, ad channel.Adapter, ev channel.InboundEvent) app.PermissionAsk {
+	return func(ctx context.Context, toolName string, toolInput map[string]any) (bool, bool, error) {
+		replyCh, release, err := sess.BeginAsk()
+		if err != nil {
+			return false, false, err
+		}
+		defer release()
+
+		prompt := fmt.Sprintf(
+			"⚠️ Allow %s? Reply yes / 允许 to approve — any other reply denies. (Auto-deny in %s; /stop cancels the task.)",
+			toolName, channelAskTimeout)
+		ad.SendText(ev.ChatID, prompt, ev.MessageID)
+
+		timer := time.NewTimer(channelAskTimeout)
+		defer timer.Stop()
+		select {
+		case text := <-replyCh:
+			return isAffirmative(text), false, nil
+		case <-ctx.Done():
+			return false, false, ctx.Err()
+		case <-timer.C:
+			return false, false, nil
+		}
+	}
+}

--- a/internal/server/channel_ask_test.go
+++ b/internal/server/channel_ask_test.go
@@ -50,7 +50,10 @@ func TestChannelPermissionAsk_AffirmativeAllows(t *testing.T) {
 	if !strings.Contains(ad.texts()[0], "terminal") {
 		t.Errorf("prompt %q should name the tool", ad.texts()[0])
 	}
-	if !sess.DeliverAskReply("允许") {
+	if !strings.Contains(ad.texts()[0], "sudo ls") {
+		t.Errorf("prompt %q must show the input being approved", ad.texts()[0])
+	}
+	if !sess.DeliverAskReply("c1", "", "允许") {
 		t.Fatal("ask slot not armed when the prompt was already sent")
 	}
 
@@ -77,7 +80,7 @@ func TestChannelPermissionAsk_NonAffirmativeDenies(t *testing.T) {
 		close(done)
 	}()
 	waitFor(t, func() bool { return len(ad.texts()) == 1 })
-	sess.DeliverAskReply("先等等，我看看")
+	sess.DeliverAskReply("c1", "", "先等等，我看看")
 	<-done
 
 	if allow {
@@ -108,7 +111,7 @@ func TestChannelPermissionAsk_ContextCancelDenies(t *testing.T) {
 	if allow || err == nil {
 		t.Errorf("cancelled ask: allow=%v err=%v, want deny with error", allow, err)
 	}
-	if sess.DeliverAskReply("yes") {
+	if sess.DeliverAskReply("c1", "", "yes") {
 		t.Error("ask slot must be released after cancellation")
 	}
 }
@@ -128,7 +131,6 @@ func TestChannelPermissionAsk_TimeoutDenies(t *testing.T) {
 	if allow {
 		t.Error("timeout must deny")
 	}
-	_ = sess
 	if len(ad.texts()) == 0 {
 		t.Error("prompt was never sent")
 	}

--- a/internal/server/channel_ask_test.go
+++ b/internal/server/channel_ask_test.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/channel"
+)
+
+func TestIsAffirmative(t *testing.T) {
+	yes := []string{"yes", "y", "OK", " ok ", "Allow", "是", "可以", "同意", "允许", "YES"}
+	for _, s := range yes {
+		if !isAffirmative(s) {
+			t.Errorf("isAffirmative(%q) = false, want true", s)
+		}
+	}
+	no := []string{"no", "n", "deny", "不", "稍等", "yes please", "", "  ", "okay?"}
+	for _, s := range no {
+		if isAffirmative(s) {
+			t.Errorf("isAffirmative(%q) = true, want false", s)
+		}
+	}
+}
+
+func askEnv(t *testing.T) (*Server, *channel.Session, *drainTestAdapter, channel.InboundEvent) {
+	t.Helper()
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	sess := &channel.Session{}
+	ad := &drainTestAdapter{}
+	ev := channel.InboundEvent{ChatID: "c1", MessageID: "m1", Text: "original"}
+	return srv, sess, ad, ev
+}
+
+func TestChannelPermissionAsk_AffirmativeAllows(t *testing.T) {
+	srv, sess, ad, ev := askEnv(t)
+	ask := srv.channelPermissionAsk(sess, ad, ev)
+
+	done := make(chan struct{})
+	var allow, remember bool
+	var err error
+	go func() {
+		allow, remember, err = ask(context.Background(), "terminal", map[string]any{"command": "sudo ls"})
+		close(done)
+	}()
+
+	// Wait until the prompt was sent and the ask slot is armed.
+	waitFor(t, func() bool { return len(ad.texts()) == 1 })
+	if !strings.Contains(ad.texts()[0], "terminal") {
+		t.Errorf("prompt %q should name the tool", ad.texts()[0])
+	}
+	if !sess.DeliverAskReply("允许") {
+		t.Fatal("ask slot not armed when the prompt was already sent")
+	}
+
+	<-done
+	if err != nil {
+		t.Fatalf("ask: %v", err)
+	}
+	if !allow {
+		t.Error("affirmative reply should allow")
+	}
+	if remember {
+		t.Error("IM approvals must be one-shot (remember=false)")
+	}
+}
+
+func TestChannelPermissionAsk_NonAffirmativeDenies(t *testing.T) {
+	srv, sess, ad, ev := askEnv(t)
+	ask := srv.channelPermissionAsk(sess, ad, ev)
+
+	done := make(chan struct{})
+	var allow bool
+	go func() {
+		allow, _, _ = ask(context.Background(), "terminal", nil)
+		close(done)
+	}()
+	waitFor(t, func() bool { return len(ad.texts()) == 1 })
+	sess.DeliverAskReply("先等等，我看看")
+	<-done
+
+	if allow {
+		t.Error("non-affirmative reply must deny")
+	}
+}
+
+func TestChannelPermissionAsk_ContextCancelDenies(t *testing.T) {
+	srv, sess, ad, ev := askEnv(t)
+	ask := srv.channelPermissionAsk(sess, ad, ev)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var allow bool
+	var err error
+	go func() {
+		allow, _, err = ask(ctx, "terminal", nil)
+		close(done)
+	}()
+	waitFor(t, func() bool { return len(ad.texts()) == 1 })
+	cancel() // the /stop path cancels the turn ctx
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ask did not return on context cancellation")
+	}
+	if allow || err == nil {
+		t.Errorf("cancelled ask: allow=%v err=%v, want deny with error", allow, err)
+	}
+	if sess.DeliverAskReply("yes") {
+		t.Error("ask slot must be released after cancellation")
+	}
+}
+
+func TestChannelPermissionAsk_TimeoutDenies(t *testing.T) {
+	old := channelAskTimeout
+	channelAskTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { channelAskTimeout = old })
+
+	srv, sess, ad, ev := askEnv(t)
+	ask := srv.channelPermissionAsk(sess, ad, ev)
+
+	allow, _, err := ask(context.Background(), "terminal", nil)
+	if err != nil {
+		t.Fatalf("timeout should deny without error, got %v", err)
+	}
+	if allow {
+		t.Error("timeout must deny")
+	}
+	_ = sess
+	if len(ad.texts()) == 0 {
+		t.Error("prompt was never sent")
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met within 2s")
+}

--- a/internal/server/channel_gate_test.go
+++ b/internal/server/channel_gate_test.go
@@ -2,40 +2,72 @@ package server
 
 import (
 	"context"
+	"strings"
 	"testing"
+
+	"github.com/Leihb/octo-agent/internal/app"
+	"github.com/Leihb/octo-agent/internal/channel"
+	"github.com/Leihb/octo-agent/internal/permission"
 )
 
-// TestBuildChannelGate_NonInteractive verifies the IM bridge gate the server
-// builds for in-process channels: safe tools are allowed, while ask-class
-// tools resolve to deny — a chat channel has no prompt to confirm over.
-// (Ported from the standalone `octo channel start` command when the bridge
-// merged into serve.)
-func TestBuildChannelGate_NonInteractive(t *testing.T) {
+// TestChannelPerTurnGate verifies the IM per-turn gate end to end: the same
+// engine + chat-ask combination handleChannelMessage builds. Allow rules run
+// without prompting, ask-class tools prompt in the chat and follow the reply,
+// hard denies never prompt.
+func TestChannelPerTurnGate(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 	srv.cwd = t.TempDir()
 
-	gate, err := srv.buildChannelGate()
+	sess := &channel.Session{}
+	ad := &drainTestAdapter{}
+	ev := channel.InboundEvent{ChatID: "c1", MessageID: "m1"}
+
+	engine, err := permission.New(permissionConfigPath(), srv.cwd, resolvePermissionMode(), srv.memDir, srv.homeMemDir)
 	if err != nil {
-		t.Fatalf("buildChannelGate: %v", err)
+		t.Fatalf("permission engine: %v", err)
 	}
+	gate := app.NewPermissionGate(engine, srv.channelPermissionAsk(sess, ad, ev))
 
 	ctx := context.Background()
 
-	// A safe, auto-allowed command runs.
+	// A safe, auto-allowed command runs without prompting the chat.
 	if allow, _ := gate.Check(ctx, "terminal", map[string]any{"command": "ls -la"}); !allow {
 		t.Error("expected `ls -la` to be allowed")
 	}
+	if n := len(ad.texts()); n != 0 {
+		t.Fatalf("allow-class check must not prompt; got %d prompts", n)
+	}
 
-	// An ask-class command (sudo) has no allow rule → implicit ask → strict
-	// mode + nil asker → deny.
-	if allow, reason := gate.Check(ctx, "terminal", map[string]any{"command": "sudo rm /tmp/x"}); allow {
-		t.Error("expected `sudo` to be denied in the non-interactive gate")
-	} else if reason == "" {
+	// An ask-class command (sudo) prompts in the chat; a non-affirmative
+	// reply denies.
+	checkDone := make(chan struct{})
+	var allow bool
+	var reason string
+	go func() {
+		allow, reason = gate.Check(ctx, "terminal", map[string]any{"command": "sudo rm /tmp/x"})
+		close(checkDone)
+	}()
+	waitFor(t, func() bool { return len(ad.texts()) == 1 })
+	if !strings.Contains(ad.texts()[0], "terminal") {
+		t.Errorf("prompt %q should name the tool", ad.texts()[0])
+	}
+	if !sess.DeliverAskReply("不行") {
+		t.Fatal("ask slot not armed")
+	}
+	<-checkDone
+	if allow {
+		t.Error("expected `sudo` to be denied after a non-affirmative reply")
+	}
+	if reason == "" {
 		t.Error("expected a denial reason for the model to see")
 	}
 
-	// A hard-deny command is refused regardless of mode.
+	// A hard-deny command is refused without prompting.
+	before := len(ad.texts())
 	if allow, _ := gate.Check(ctx, "terminal", map[string]any{"command": "rm -rf /"}); allow {
 		t.Error("expected `rm -rf /` to be denied")
+	}
+	if len(ad.texts()) != before {
+		t.Error("hard-deny must not prompt the chat")
 	}
 }

--- a/internal/server/channel_gate_test.go
+++ b/internal/server/channel_gate_test.go
@@ -51,7 +51,10 @@ func TestChannelPerTurnGate(t *testing.T) {
 	if !strings.Contains(ad.texts()[0], "terminal") {
 		t.Errorf("prompt %q should name the tool", ad.texts()[0])
 	}
-	if !sess.DeliverAskReply("不行") {
+	if !strings.Contains(ad.texts()[0], "sudo rm /tmp/x") {
+		t.Errorf("prompt %q must show the command being approved", ad.texts()[0])
+	}
+	if !sess.DeliverAskReply("c1", "", "不行") {
 		t.Fatal("ask slot not armed")
 	}
 	<-checkDone

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/channel"
+)
+
+// fullFakeAdapter implements the whole channel.Adapter surface with no-ops,
+// recording SendText calls — handleChannelMessage runs a real turn through
+// the UIController, which touches typing/update methods too.
+type fullFakeAdapter struct {
+	mu   sync.Mutex
+	sent []string
+}
+
+func (a *fullFakeAdapter) Platform() string { return "fake" }
+func (a *fullFakeAdapter) Start(ctx context.Context, _ func(channel.InboundEvent)) error {
+	<-ctx.Done()
+	return nil
+}
+func (a *fullFakeAdapter) Stop() error { return nil }
+func (a *fullFakeAdapter) SendText(chatID, text, replyTo string) channel.SendResult {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.sent = append(a.sent, text)
+	return channel.SendResult{OK: true, MessageID: "f1"}
+}
+func (a *fullFakeAdapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: true}
+}
+func (a *fullFakeAdapter) UpdateMessage(chatID, messageID, text string) bool { return true }
+func (a *fullFakeAdapter) SupportsMessageUpdates() bool                      { return false }
+func (a *fullFakeAdapter) SendTyping(chatID, contextToken string) error      { return nil }
+func (a *fullFakeAdapter) ValidateConfig(channel.PlatformConfig) []string    { return nil }
+
+func (a *fullFakeAdapter) texts() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.sent...)
+}
+
+// chanServer returns a mustServer with a channel manager wired to stub agents.
+func chanServer(t *testing.T) *Server {
+	t.Helper()
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+		return agent.New(&stubSender{}, "stub-model")
+	}, channel.BindByChat)
+	return srv
+}
+
+func evFor(text string) channel.InboundEvent {
+	return channel.InboundEvent{Platform: "fake", ChatID: "c1", UserID: "u1", MessageID: "m1", Text: text}
+}
+
+// TestRouteChannelEvent_PendingAskConsumesMessage: while a permission prompt
+// is pending, the next plain message answers it instead of starting a turn.
+func TestRouteChannelEvent_PendingAskConsumesMessage(t *testing.T) {
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	replyCh, release, err := sess.BeginAsk()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	srv.routeChannelEvent(context.Background(), ad, evFor("yes"))
+
+	select {
+	case got := <-replyCh:
+		if got != "yes" {
+			t.Errorf("ask received %q, want %q", got, "yes")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("pending ask did not receive the message")
+	}
+}
+
+// TestRouteChannelEvent_CommandBeatsPendingAsk: /stop must reach the command
+// router even while an ask is pending — it cancels the turn that is asking.
+func TestRouteChannelEvent_CommandBeatsPendingAsk(t *testing.T) {
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	replyCh, release, err := sess.BeginAsk()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	srv.routeChannelEvent(context.Background(), ad, evFor("/stop"))
+
+	select {
+	case got := <-replyCh:
+		t.Fatalf("command %q was consumed by the ask", got)
+	default:
+	}
+	if len(ad.texts()) == 0 {
+		t.Fatal("command produced no reply")
+	}
+}
+
+// TestRouteChannelEvent_NormalMessageRunsTurn: with no pending ask, a plain
+// message starts an agent turn that replies through the adapter.
+func TestRouteChannelEvent_NormalMessageRunsTurn(t *testing.T) {
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	srv.routeChannelEvent(context.Background(), ad, evFor("hello"))
+
+	waitFor(t, func() bool {
+		for _, txt := range ad.texts() {
+			if strings.Contains(txt, "stub reply") {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// TestHandleChannelMessage_SetsPerTurnGate: every IM turn gets a fresh
+// permission gate (configured mode + chat-interactive ask) on the session
+// agent — the factory-time strict gate is gone.
+func TestHandleChannelMessage_SetsPerTurnGate(t *testing.T) {
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	if sess.Agent.Gate != nil {
+		t.Fatal("factory must not pre-set a gate anymore")
+	}
+
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+
+	if sess.Agent.Gate == nil {
+		t.Error("handleChannelMessage must set a per-turn permission gate")
+	}
+}

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -66,7 +66,7 @@ func TestRouteChannelEvent_PendingAskConsumesMessage(t *testing.T) {
 	ad := &fullFakeAdapter{}
 
 	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
-	replyCh, release, err := sess.BeginAsk()
+	replyCh, release, err := sess.BeginAsk("c1", "u1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestRouteChannelEvent_CommandBeatsPendingAsk(t *testing.T) {
 	ad := &fullFakeAdapter{}
 
 	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
-	replyCh, release, err := sess.BeginAsk()
+	replyCh, release, err := sess.BeginAsk("c1", "u1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,5 +143,52 @@ func TestHandleChannelMessage_SetsPerTurnGate(t *testing.T) {
 
 	if sess.Agent.Gate == nil {
 		t.Error("handleChannelMessage must set a per-turn permission gate")
+	}
+}
+
+// TestRouteChannelEvent_OtherUserCannotAnswer pins the reply-scoping rule
+// under a shared-session binding (BindByChat): a second user's "yes" in the
+// same chat must not answer the requester's prompt.
+func TestRouteChannelEvent_OtherUserCannotAnswer(t *testing.T) {
+	srv := chanServer(t) // BindByChat: one session per chat, shared by users
+	ad := &fullFakeAdapter{}
+
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	replyCh, release, err := sess.BeginAsk("c1", "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	other := evFor("yes")
+	other.UserID = "u2"
+	srv.routeChannelEvent(context.Background(), ad, other)
+
+	select {
+	case got := <-replyCh:
+		t.Fatalf("another user's reply %q answered the ask", got)
+	default:
+	}
+}
+
+// TestRouteChannelEvent_EmptyTextNeverAnswers: a text-less event (sticker,
+// image) must not consume — and thereby deny — a pending ask.
+func TestRouteChannelEvent_EmptyTextNeverAnswers(t *testing.T) {
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	replyCh, release, err := sess.BeginAsk("c1", "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	srv.routeChannelEvent(context.Background(), ad, evFor("   "))
+
+	select {
+	case got := <-replyCh:
+		t.Fatalf("empty text %q answered the ask", got)
+	default:
 	}
 }

--- a/internal/server/restart_test.go
+++ b/internal/server/restart_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -222,17 +223,27 @@ func TestRunTask_DrainingRefused(t *testing.T) {
 	}
 }
 
-// drainTestAdapter records SendText calls; every other Adapter method is
-// unused on the draining path and inherited from the embedded nil interface
-// (calling one would panic, which is what we want in this test).
+// drainTestAdapter records SendText calls (mutex-guarded — tests poll from
+// another goroutine); every other Adapter method is unused on the paths under
+// test and inherited from the embedded nil interface (calling one would
+// panic, which is what we want in these tests).
 type drainTestAdapter struct {
 	channel.Adapter
+	mu   sync.Mutex
 	sent []string
 }
 
 func (a *drainTestAdapter) SendText(chatID, text, replyTo string) channel.SendResult {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.sent = append(a.sent, text)
 	return channel.SendResult{}
+}
+
+func (a *drainTestAdapter) texts() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.sent...)
 }
 
 // TestHandleChannelMessage_DrainingRepliesPolitely pins the design deviation:
@@ -245,10 +256,10 @@ func TestHandleChannelMessage_DrainingRepliesPolitely(t *testing.T) {
 	ad := &drainTestAdapter{}
 	srv.handleChannelMessage(context.Background(), ad, channel.InboundEvent{ChatID: "c1", Text: "hi"})
 
-	if len(ad.sent) != 1 {
-		t.Fatalf("SendText calls = %d, want 1", len(ad.sent))
+	if len(ad.texts()) != 1 {
+		t.Fatalf("SendText calls = %d, want 1", len(ad.texts()))
 	}
-	if !strings.Contains(ad.sent[0], "restarting") {
-		t.Errorf("reply %q should mention the restart", ad.sent[0])
+	if !strings.Contains(ad.texts()[0], "restarting") {
+		t.Errorf("reply %q should mention the restart", ad.texts()[0])
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -957,8 +957,12 @@ func (s *Server) initChannels() {
 		return
 	}
 
-	// Build agent factory that mirrors the server's agent setup.
-	gate, _ := s.buildChannelGate()
+	// Build agent factory that mirrors the server's agent setup. No gate is
+	// set here: handleChannelMessage builds a fresh per-turn gate (configured
+	// mode + chat-interactive ask), the same shape prepareToolTurn gives web
+	// turns. A factory-time gate would freeze one policy snapshot for the
+	// session's whole life — and the old `gate, _ :=` form silently ran turns
+	// ungated when engine construction failed.
 	var memInjection string
 	if s.memDir != "" {
 		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
@@ -968,9 +972,6 @@ func (s *Server) initChannels() {
 		a.CWD = s.cwd
 		a.MaxTokens = s.cfg.MaxTokens
 		a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
-		if gate != nil {
-			a.Gate = gate
-		}
 		return a
 	}
 
@@ -978,18 +979,6 @@ func (s *Server) initChannels() {
 	s.channelMgr = channel.NewManager(chCfg, factory, channel.BindByChatUser)
 
 	fmt.Fprintf(os.Stderr, "octo serve: channels enabled: %s\n", strings.Join(platforms, ", "))
-}
-
-// buildChannelGate creates the IM bridge's permission gate: strict mode with
-// a nil asker, so ask-class verdicts resolve to deny — a chat channel has no
-// interactive prompt. Same posture the standalone bridge had before it merged
-// into serve.
-func (s *Server) buildChannelGate() (agent.PermissionGate, error) {
-	engine, err := permission.New(permissionConfigPath(), s.cwd, permission.ModeStrict, s.memDir, s.homeMemDir)
-	if err != nil {
-		return nil, fmt.Errorf("permission engine: %w", err)
-	}
-	return app.NewPermissionGate(engine, nil), nil
 }
 
 // startChannels launches all enabled channel adapters in background goroutines.
@@ -1027,17 +1016,27 @@ func (s *Server) startChannels() {
 		go func(a channel.Adapter, platform string) {
 			_ = a.Start(ctx, func(ev channel.InboundEvent) {
 				ev.Platform = platform
-				if s.handleChannelCommand(a, ev) {
-					return
-				}
-				// Run the agent off the adapter's read loop so commands —
-				// notably /stop — are still processed while a turn is in
-				// flight. Session.BeginRun serialises turns per session, so
-				// concurrent messages in one chat can't interleave.
-				go s.handleChannelMessage(ctx, a, ev)
+				s.routeChannelEvent(ctx, a, ev)
 			})
 		}(ad, name)
 	}
+}
+
+// routeChannelEvent dispatches one inbound IM event. Order matters:
+// commands first, so /stop can cancel a turn that is itself blocked on a
+// permission ask; then a pending ask claims the message as its answer —
+// inline, NOT through the turn path, which would deadlock behind the runMu
+// the asking turn still holds; otherwise the message starts an agent turn
+// off the adapter's read loop (Session.BeginRun serialises turns per
+// session, so concurrent messages in one chat can't interleave).
+func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev channel.InboundEvent) {
+	if s.handleChannelCommand(ad, ev) {
+		return
+	}
+	if sess := s.channelMgr.GetSession(ev); sess != nil && sess.DeliverAskReply(ev.Text) {
+		return
+	}
+	go s.handleChannelMessage(ctx, ad, ev)
 }
 
 // handleChannelCommand processes slash commands (e.g. /bind, /stop). Returns
@@ -1074,6 +1073,18 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	// cancellable by /stop (Session.Interrupt).
 	ctx, done := sess.BeginRun(ctx)
 	defer done()
+
+	// Per-turn permission gate, the same shape prepareToolTurn gives web
+	// turns: configured mode + an interactive ask that prompts in the chat
+	// and consumes the next message as the answer. Built after BeginRun so
+	// it can't race the previous turn's gate. An engine failure aborts the
+	// turn — running ungated is never an acceptable fallback.
+	engine, err := permission.New(permissionConfigPath(), s.cwd, resolvePermissionMode(), s.memDir, s.homeMemDir)
+	if err != nil {
+		ad.SendText(ev.ChatID, "⚠️ Permission engine unavailable, message not processed: "+err.Error(), ev.MessageID)
+		return
+	}
+	sess.Agent.Gate = app.NewPermissionGate(engine, s.channelPermissionAsk(sess, ad, ev))
 
 	ctrl := channel.NewUIController(ad, ev.ChatID, ev.MessageID)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1032,8 +1032,12 @@ func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev c
 	if s.handleChannelCommand(ad, ev) {
 		return
 	}
-	if sess := s.channelMgr.GetSession(ev); sess != nil && sess.DeliverAskReply(ev.Text) {
-		return
+	// Text-less events (stickers, images, voice) never answer an ask — an
+	// empty reply would consume the slot and deny for nothing.
+	if strings.TrimSpace(ev.Text) != "" {
+		if sess := s.channelMgr.GetSession(ev); sess != nil && sess.DeliverAskReply(ev.ChatID, ev.UserID, ev.Text) {
+			return
+		}
 	}
 	go s.handleChannelMessage(ctx, ad, ev)
 }
@@ -1080,7 +1084,10 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	// turn — running ungated is never an acceptable fallback.
 	engine, err := permission.New(permissionConfigPath(), s.cwd, resolvePermissionMode(), s.memDir, s.homeMemDir)
 	if err != nil {
-		ad.SendText(ev.ChatID, "⚠️ Permission engine unavailable, message not processed: "+err.Error(), ev.MessageID)
+		// Generic chat reply — err.Error() can leak local paths into a
+		// group chat; the operator gets the detail on the server console.
+		fmt.Fprintf(os.Stderr, "octo serve: channel %s: permission engine: %v\n", ev.Platform, err)
+		ad.SendText(ev.ChatID, "⚠️ Permission engine unavailable — message not processed. Check the server logs.", ev.MessageID)
 		return
 	}
 	sess.Agent.Gate = app.NewPermissionGate(engine, s.channelPermissionAsk(sess, ad, ev))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -271,13 +271,12 @@ func New(cfg Config) (*Server, error) {
 	// tool catalog and can be dispatched through the browser.
 	tools.SetAsker(s.wsAsker())
 
-	// Register the restarter so restart_server appears in the tool catalog.
-	// Permission is ask-class (defaults.yml): the web UI confirms via the
-	// browser prompt; the IM channel gate runs strict with no asker, so an
-	// IM-triggered restart resolves to deny until an interactive ask flow
-	// exists there. The restart drains in-flight turns (including the one
-	// calling the tool) before the worker exits with ExitRestart for the
-	// supervisor to respawn.
+	// Register the restarter so restart_server appears in the tool catalog —
+	// the agent can then honour "重启一下服务" from web or IM. Permission is
+	// ask-class (defaults.yml): the web UI confirms via the browser prompt,
+	// IM via the in-chat reply prompt. The restart drains in-flight turns
+	// (including the one calling the tool) before the worker exits with
+	// ExitRestart for the supervisor to respawn.
 	tools.SetRestarter(s.Restart)
 
 	s.registerRoutes()

--- a/internal/tools/restart.go
+++ b/internal/tools/restart.go
@@ -13,8 +13,9 @@ import (
 // goes through Server.Restart's drain); it stays nil in CLI/TUI processes,
 // where there is no supervisor contract to honour. Within the server
 // process the global is shared, so server sub-agents see the tool too —
-// they inherit the parent's permission gate, which asks (web) or denies
-// (IM strict) the same way it would for the parent.
+// they inherit the parent's permission gate, which confirms interactively
+// (browser modal on web, in-chat reply on IM) the same way it would for
+// the parent.
 var activeRestarter func(reason string)
 
 // SetRestarter registers the function the restart_server tool delegates to.


### PR DESCRIPTION
Implements the in-chat permission ask flow (designed alongside #583 but never merged with it — `BeginAsk` existed in no commit until now). IM channel turns now confirm ask-class tool calls interactively instead of hard-denying them, bringing IM to permission parity with the web confirmation modal. Design doc: `dev-docs/im-interactive-ask-design.md`.

## How it works

- **Answer = the session's next message.** The asking turn blocks holding `runMu`, so the answer is routed inline by the inbound dispatcher (`routeChannelEvent`: command → pending ask → turn) — never through the turn path, which would deadlock. `channel.Session` gains a single ask slot (`BeginAsk`/`DeliverAskReply`).
- **The prompt shows what's being approved**: `⚠️ Allow terminal — "sudo rm /tmp/x"? Reply yes / 允许 …` — the IM transport renders no tool cards before the gate fires, so the input summary is the only thing standing between the user and a blind approval.
- **Fail closed everywhere**: only explicit affirmatives (`yes y ok allow 是 可以 同意 允许`) approve; arbitrary replies, 5-minute timeout, `/stop` (ctx cancel), and text-less events all deny. `remember` is always false — chat approvals are one-shot.
- **Replies are scoped to the asking chat + user** on the slot itself, so the guarantee survives shared-session binding modes, not just the production `BindByChatUser` keying.
- **Per-turn gate replaces the factory-time strict gate**: every IM turn builds engine (configured mode via `resolvePermissionMode`, same as web) + chat ask. This also closes the latent hole where `gate, _ :=` silently ran turns **ungated** after an engine-construction failure — the turn now aborts with a generic chat reply (detail to the server console).

## Unlocks

`restart_server` (#593) from IM: "重启一下服务" in Feishu now prompts for confirmation in the chat instead of being denied by policy. defaults.yml / tool comments / the self-restart design doc updated accordingly.

## Verification

- `go test -race ./...` green, vet + gofmt clean; 18 new tests (ask slot semantics, affirmative table, allow/deny/cancel/timeout, routing order incl. /stop-beats-ask, other-user/other-chat/empty-text rejection, end-to-end gate policy, full stub-sender turn)
- Subagent review: deadlock paths traced clean (inline delivery off the adapter read loop; cross-session via independent mutexes), ask-slot handoff race-clean, /stop end-to-end verified; its 1 Critical (blind approval) + scoping/hardening findings all fixed in the final commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)