### PR TITLE
fix(edit_file): multi-width indent matching, lossless indent restyle, trailing-newline match (follow-up to #596)

### DIFF
--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -94,16 +94,23 @@ func stripTrailingWhitespace(s string) string {
 	return strings.Join(lines, "")
 }
 
+// indentWidths are the tab widths tried by the leading-whitespace fallback,
+// ordered by likelihood: read_file and the terminal tool render tabs 4 wide,
+// 8 is the classic terminal default, 2 is a common compact style models emit.
+var indentWidths = []int{4, 8, 2}
+
 // findActualString attempts to locate the search string in the file content,
 // first with an exact match, then with quote-normalized match, and finally
-// with leading-whitespace normalization (tab → space expansion) so that
-// space-indented old_string from the LLM still matches tab-indented files.
-// Returns the actual string found in the file (preserving original formatting),
-// or empty string if not found.
-func findActualString(fileContent, searchString string) string {
+// with leading-whitespace normalization (tab → space expansion at several
+// widths) so that space-indented old_string from the LLM still matches
+// tab-indented files. Returns the actual string found in the file (preserving
+// original formatting) and the tab width that matched — 4, the default indent
+// unit, unless a wider/narrower expansion was what matched. Empty string means
+// not found.
+func findActualString(fileContent, searchString string) (string, int) {
 	// First try exact match
 	if strings.Contains(fileContent, searchString) {
-		return searchString
+		return searchString, defaultIndentWidth
 	}
 
 	// Try with normalized quotes
@@ -123,11 +130,11 @@ func findActualString(fileContent, searchString string) string {
 
 		// Verify the match at the rune level in normalized space
 		if idx+len(searchRunes) > len(normalizedRunes) {
-			return ""
+			return "", 0
 		}
 		for i := 0; i < len(searchRunes); i++ {
 			if normalizedRunes[idx+i] != searchRunes[i] {
-				return ""
+				return "", 0
 			}
 		}
 
@@ -143,7 +150,7 @@ func findActualString(fileContent, searchString string) string {
 			runeCount++
 		}
 		if origStart == -1 {
-			return ""
+			return "", 0
 		}
 
 		origEnd := -1
@@ -159,24 +166,32 @@ func findActualString(fileContent, searchString string) string {
 			origEnd = len(fileRunes)
 		}
 
-		return string(fileRunes[origStart:origEnd])
+		return string(fileRunes[origStart:origEnd]), defaultIndentWidth
 	}
 
 	// Try with normalized leading whitespace (tab → space expansion).
 	// This is line-based because indentation differences only affect
 	// leading whitespace, and the matching needs to map lines back
-	// to the original file.
-	if actual := findWithIndentNorm(fileContent, searchString); actual != "" {
-		return actual
+	// to the original file. Several widths are tried because the width the
+	// model assumed when it turned tabs into spaces is unknowable.
+	for _, w := range indentWidths {
+		if actual := findWithIndentNorm(fileContent, searchString, w); actual != "" {
+			return actual, w
+		}
 	}
 
-	return ""
+	return "", 0
 }
 
+// defaultIndentWidth is the tab width assumed when no whitespace
+// normalization was needed to find the match — it matches how read_file and
+// the terminal tool render tabs.
+const defaultIndentWidth = 4
+
 // normalizeLeadingWhitespace expands tabs in leading whitespace of each line
-// to 4-space stops, making tab-indented and space-indented text comparable.
+// to width-space stops, making tab-indented and space-indented text comparable.
 // Only leading whitespace is touched — tabs inside line content are left alone.
-func normalizeLeadingWhitespace(s string) string {
+func normalizeLeadingWhitespace(s string, width int) string {
 	var b strings.Builder
 	b.Grow(len(s) + len(s)/10)
 	lines := strings.Split(s, "\n")
@@ -185,7 +200,7 @@ func normalizeLeadingWhitespace(s string) string {
 		if trimmed != line {
 			leadingLen := len(line) - len(trimmed)
 			leading := line[:leadingLen]
-			b.WriteString(strings.ReplaceAll(leading, "\t", "    "))
+			b.WriteString(strings.ReplaceAll(leading, "\t", strings.Repeat(" ", width)))
 		}
 		b.WriteString(trimmed)
 		if i < len(lines)-1 {
@@ -196,12 +211,21 @@ func normalizeLeadingWhitespace(s string) string {
 }
 
 // findWithIndentNorm matches searchString against fileContent after
-// normalizing leading whitespace in both. Returns the corresponding substring
-// from the original (unnormalized) fileContent so the edit preserves the
-// file's actual whitespace convention.
-func findWithIndentNorm(fileContent, searchString string) string {
-	normFile := normalizeLeadingWhitespace(fileContent)
-	normSearch := normalizeLeadingWhitespace(searchString)
+// normalizing leading whitespace in both at the given tab width. Returns the
+// corresponding substring from the original (unnormalized) fileContent so the
+// edit preserves the file's actual whitespace convention.
+func findWithIndentNorm(fileContent, searchString string, width int) string {
+	// The matching is line-based, so a trailing newline on the search string
+	// would otherwise become an empty last line that must equal the file's
+	// next line. Strip it for matching and restore it from the file after.
+	search := searchString
+	wantTrailingNL := strings.HasSuffix(search, "\n")
+	if wantTrailingNL {
+		search = strings.TrimSuffix(search, "\n")
+	}
+
+	normFile := normalizeLeadingWhitespace(fileContent, width)
+	normSearch := normalizeLeadingWhitespace(search, width)
 
 	if !strings.Contains(normFile, normSearch) {
 		return ""
@@ -210,7 +234,6 @@ func findWithIndentNorm(fileContent, searchString string) string {
 	fileLines := strings.Split(fileContent, "\n")
 	normFileLines := strings.Split(normFile, "\n")
 	normSearchLines := strings.Split(normSearch, "\n")
-	searchLines := strings.Split(searchString, "\n")
 
 	start := -1
 	for i := 0; i <= len(normFileLines)-len(normSearchLines); i++ {
@@ -231,11 +254,16 @@ func findWithIndentNorm(fileContent, searchString string) string {
 		return ""
 	}
 
-	end := start + len(searchLines)
+	end := start + len(normSearchLines)
 	actual := strings.Join(fileLines[start:end], "\n")
 
-	// Preserve trailing newline if the search string had one
-	if strings.HasSuffix(searchString, "\n") && !strings.HasSuffix(actual, "\n") {
+	if wantTrailingNL {
+		// The search demands a newline after the last matched line; only
+		// honor it if the file actually has one there (i.e. the match did
+		// not land on an unterminated final line).
+		if end >= len(fileLines) {
+			return ""
+		}
 		actual += "\n"
 	}
 
@@ -305,8 +333,8 @@ func (EditFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 			"shape or create the file outside the agent.", secret)
 	}
 
-	// Use findActualString for quote-normalized matching.
-	actualOldStr := findActualString(bodyForMatch, oldStr)
+	// Use findActualString for quote- and indent-normalized matching.
+	actualOldStr, indentWidth := findActualString(bodyForMatch, oldStr)
 	if actualOldStr == "" {
 		// Build a helpful error message showing what we tried
 		msg := fmt.Sprintf("edit_file: old_string not found in %s", path)
@@ -335,7 +363,7 @@ func (EditFileTool) Execute(_ context.Context, _ string, input map[string]any) (
 	actualNewStr := preserveQuoteStyle(oldStr, actualOldStr, newStrClean)
 	// Preserve file indent convention (tabs vs spaces) — when the file
 	// uses tabs but the LLM supplied space-indented new_string.
-	actualNewStr = preserveIndentStyle(actualOldStr, actualNewStr)
+	actualNewStr = preserveIndentStyle(actualOldStr, actualNewStr, indentWidth)
 
 	var updated string
 	if replaceAll {
@@ -466,10 +494,14 @@ func isLetter(r rune) bool {
 
 // preserveIndentStyle converts leading whitespace in newStr to match the
 // file's indentation convention (detected from actualOldStr). When the file
-// uses tabs and the LLM supplied space-indented new_string, each 4-space
-// indent level is converted to one tab. This keeps the file's whitespace
-// convention consistent after the edit.
-func preserveIndentStyle(actualOldStr, newStr string) string {
+// uses tabs and the LLM supplied space-indented new_string, each run of
+// `width` spaces becomes one tab — width being the tab width that located the
+// match, so the conversion mirrors the expansion. Remainder spaces (alignment,
+// or a partial level) are kept rather than truncated away, so a 2-space line
+// is never silently stripped to column zero. Lines whose leading whitespace
+// already contains a tab are left untouched: the model followed the file's
+// convention, and rewriting them would flatten tab+space alignment.
+func preserveIndentStyle(actualOldStr, newStr string, width int) string {
 	// Only convert when the file uses tabs for indentation
 	if !strings.Contains(actualOldStr, "\n\t") && !strings.HasPrefix(actualOldStr, "\t") {
 		return newStr
@@ -481,11 +513,13 @@ func preserveIndentStyle(actualOldStr, newStr string) string {
 		if trimmed == line {
 			continue
 		}
-		leadingLen := len(line) - len(trimmed)
-		leading := line[:leadingLen]
-		// Count indent level: each tab = 1 level, 4 spaces = 1 level
-		level := strings.Count(leading, "\t") + (len(leading)-strings.Count(leading, "\t"))/4
-		newLines[i] = strings.Repeat("\t", level) + trimmed
+		leading := line[:len(line)-len(trimmed)]
+		if strings.Contains(leading, "\t") {
+			continue
+		}
+		tabs := len(leading) / width
+		rem := len(leading) % width
+		newLines[i] = strings.Repeat("\t", tabs) + strings.Repeat(" ", rem) + trimmed
 	}
 	return strings.Join(newLines, "\n")
 }

--- a/internal/tools/edit_file_test.go
+++ b/internal/tools/edit_file_test.go
@@ -424,9 +424,9 @@ func TestNormalizeLeadingWhitespace(t *testing.T) {
 		{"a\n\tb\nc", "a\n    b\nc"}, // multi-line
 	}
 	for _, tc := range tests {
-		got := normalizeLeadingWhitespace(tc.in)
+		got := normalizeLeadingWhitespace(tc.in, 4)
 		if got != tc.want {
-			t.Errorf("normalizeLeadingWhitespace(%q) = %q, want %q", tc.in, got, tc.want)
+			t.Errorf("normalizeLeadingWhitespace(%q, 4) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }
@@ -435,7 +435,7 @@ func TestFindWithIndentNorm(t *testing.T) {
 	file := "\tcase \"chat\":\n\t\tchatHelp(w)\n"
 	search := "    case \"chat\":\n        chatHelp(w)"
 
-	actual := findWithIndentNorm(file, search)
+	actual := findWithIndentNorm(file, search, 4)
 	// search has no trailing \n, so actual should also lack it
 	want := "\tcase \"chat\":\n\t\tchatHelp(w)"
 	if actual != want {
@@ -447,8 +447,97 @@ func TestFindWithIndentNorm_NotFound(t *testing.T) {
 	file := "\tfoo\n\tbar\n"
 	search := "        missing"
 
-	actual := findWithIndentNorm(file, search)
+	actual := findWithIndentNorm(file, search, 4)
 	if actual != "" {
 		t.Errorf("expected empty for non-matching search, got %q", actual)
+	}
+}
+
+func TestFindWithIndentNorm_TrailingNewline(t *testing.T) {
+	// A search string ending with \n used to require the file's NEXT line to
+	// be empty (line-split artifact). It must match any mid-file block whose
+	// last line is newline-terminated.
+	file := "\tfoo\n\tbar\n"
+	search := "    foo\n"
+
+	actual := findWithIndentNorm(file, search, 4)
+	if actual != "\tfoo\n" {
+		t.Errorf("findWithIndentNorm = %q, want %q", actual, "\tfoo\n")
+	}
+}
+
+func TestFindWithIndentNorm_TrailingNewline_EOFWithoutNewline(t *testing.T) {
+	// The search demands a trailing newline the file does not have —
+	// returning the match anyway would produce an actualOldStr that is not a
+	// substring of the file.
+	file := "\tfoo"
+	search := "    foo\n"
+
+	actual := findWithIndentNorm(file, search, 4)
+	if actual != "" {
+		t.Errorf("expected empty when file lacks the trailing newline, got %q", actual)
+	}
+}
+
+func TestEditFile_TabIndent_EightSpaceWidth(t *testing.T) {
+	// Model assumed an 8-wide tab rendering. The width-4 pass misses,
+	// the width-8 pass matches, and new_string converts back at 8.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wide.go")
+	writeTestFile(t, path, "\tif ok {\n\t\treturn\n\t}\n")
+
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       path,
+		"old_string": "        if ok {\n                return\n        }",
+		"new_string": "        if ok {\n                return nil\n        }",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := readTestFile(t, path)
+	want := "\tif ok {\n\t\treturn nil\n\t}\n"
+	if got != want {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+}
+
+func TestEditFile_TabIndent_TwoSpaceWidth(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "narrow.go")
+	writeTestFile(t, path, "\tfoo()\n\t\tbar()\n")
+
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       path,
+		"old_string": "  foo()\n    bar()",
+		"new_string": "  foo2()\n    bar()",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := readTestFile(t, path)
+	want := "\tfoo2()\n\t\tbar()\n"
+	if got != want {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+}
+
+func TestPreserveIndentStyle_KeepsRemainderSpaces(t *testing.T) {
+	// 6 spaces at width 4 = 1 tab + 2 alignment spaces. The old level
+	// arithmetic truncated to 1 tab; 2 or 3 spaces collapsed to column zero.
+	old := "\tindented"
+	got := preserveIndentStyle(old, "      aligned\n  partial", 4)
+	want := "\t  aligned\n  partial"
+	if got != want {
+		t.Errorf("preserveIndentStyle = %q, want %q", got, want)
+	}
+}
+
+func TestPreserveIndentStyle_LeavesTabLinesAlone(t *testing.T) {
+	// A line that already leads with a tab followed the file convention;
+	// its alignment spaces must not be flattened.
+	old := "\tindented"
+	in := "\t\t  aligned continuation"
+	if got := preserveIndentStyle(old, in, 4); got != in {
+		t.Errorf("preserveIndentStyle = %q, want unchanged %q", got, in)
 	}
 }


### PR DESCRIPTION
Follow-up to #596, hardening the three weak spots of its leading-whitespace fallback.

## 1. Multi-width matching

#596 assumed every model expands tabs to exactly 4 spaces. That matches how read_file/terminal render tabs, but a model that assumed the classic 8-wide rendering — or emitted a compact 2-space style — fell straight through to "not found". The fallback now tries widths **4, 8, 2** in that order, and the width that located the match is threaded into `preserveIndentStyle` so the space→tab back-conversion mirrors the expansion that matched.

## 2. Lossless `preserveIndentStyle`

The old level arithmetic (`level = tabs + spaces/4`) truncated: 2 or 3 leading spaces collapsed to column zero (indentation silently stripped), 6 spaces lost their alignment remainder, and tab+space mixed leading whitespace was flattened to pure tabs. Now:

- remainder spaces are kept: 6 spaces at width 4 → `\t` + 2 spaces, 2 spaces stay 2 spaces
- lines whose leading whitespace already contains a tab are left untouched — the model followed the file convention, and rewriting would destroy alignment

## 3. Trailing-newline match

`findWithIndentNorm` is line-based, so an `old_string` ending in `\n` produced an empty last search line that had to equal the file's *next* line — the fallback could only match blocks followed by a blank line. The newline is now stripped before matching and restored from the file after; if the file's last line is unterminated, the match is rejected so `actualOldStr` stays a real substring of the file.

## Safety unchanged

All paths still feed `strings.Count` on the mapped original text — ambiguity and misses keep failing loudly. 8 new/updated test cases; full `go test -race ./internal/tools/` green, vet + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)