### PR TITLE
feat(config): multi-model config — named entries, config.yml rename, real CRUD

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -152,12 +152,12 @@ func resolveCoauthor(noCoauthorFlag bool, cfg config.Config) bool {
 // resolveShowReasoning determines whether the reasoning/thinking trace is
 // streamed to the terminal. Precedence: an explicit --show-reasoning flag >
 // config file > default (true).
-func resolveShowReasoning(flagSet, flagVal bool, cfg config.Config) bool {
+func resolveShowReasoning(flagSet, flagVal bool, entry config.ModelEntry) bool {
 	if flagSet {
 		return flagVal
 	}
-	if cfg.ShowReasoning != nil {
-		return *cfg.ShowReasoning
+	if entry.ShowReasoning != nil {
+		return *entry.ShowReasoning
 	}
 	return true
 }
@@ -171,11 +171,11 @@ func toolSearchConfigFrom(c config.ToolSearchConfig) tools.ToolSearchConfig {
 
 // resolveReasoningEffort picks the reasoning intensity: --reasoning-effort flag
 // > config file > "" (off).
-func resolveReasoningEffort(flagVal string, cfg config.Config) string {
+func resolveReasoningEffort(flagVal string, entry config.ModelEntry) string {
 	if flagVal != "" {
 		return flagVal
 	}
-	return cfg.ReasoningEffort
+	return entry.ReasoningEffort
 }
 
 // validReasoningEffort reports whether e is an accepted reasoning intensity.
@@ -329,7 +329,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	cfg, err := config.Load()
 	if err != nil {
 		fmt.Fprintf(stderr, "octo chat: %v\n", err)
-		fmt.Fprintln(stderr, "Run `octo config` to rewrite ~/.octo/config.yaml.")
+		fmt.Fprintln(stderr, "Run `octo config` to rewrite ~/.octo/config.yml.")
 		return 1
 	}
 
@@ -350,7 +350,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	provName, resolvedModel, ok := resolveProviderModel(*providerName, *model, cfg)
+	provName, resolvedModel, entry, ok := resolveProviderModel(*providerName, *model, cfg)
 	if !ok {
 		fmt.Fprintf(stderr, "octo chat: unknown provider %q\n", provName)
 		return 2
@@ -362,8 +362,9 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 	// Resolve reasoning controls: --reasoning-effort sets the intensity (OpenAI
 	// reasoning_effort / mapped Anthropic budget); --show-reasoning gates whether
-	// the trace is streamed to the terminal. Both fall back to `octo config`.
-	resolvedEffort := resolveReasoningEffort(*reasoningEffort, cfg)
+	// the trace is streamed to the terminal. Both fall back to the resolved
+	// config entry.
+	resolvedEffort := resolveReasoningEffort(*reasoningEffort, entry)
 	if !validReasoningEffort(resolvedEffort) {
 		fmt.Fprintf(stderr, "octo chat: invalid --reasoning-effort %q (want 'low', 'medium', or 'high')\n", resolvedEffort)
 		return 2
@@ -374,7 +375,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			showReasoningFlagSet = true
 		}
 	})
-	resolvedShowReasoning := resolveShowReasoning(showReasoningFlagSet, *showReasoning, cfg)
+	resolvedShowReasoning := resolveShowReasoning(showReasoningFlagSet, *showReasoning, entry)
 
 	// Single-turn mode requires a message.
 	if !isREPL && resumeID != "" {
@@ -413,7 +414,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 	}
 
-	llmSender, err := buildSender(provName, cfg, stderr, senderTuning{
+	llmSender, err := buildSender(provName, entry, stderr, senderTuning{
 		thinkingBudget:  anthropicThinkingBudget(resolvedEffort),
 		reasoningEffort: resolvedEffort,
 		showReasoning:   resolvedShowReasoning,
@@ -430,12 +431,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			}
 			// Reload config and retry sender construction.
 			cfg, _ = config.Load()
-			provName, resolvedModel, ok = resolveProviderModel(*providerName, *model, cfg)
+			provName, resolvedModel, entry, ok = resolveProviderModel(*providerName, *model, cfg)
 			if !ok {
 				fmt.Fprintf(stderr, "octo chat: unknown provider %q\n", provName)
 				return 2
 			}
-			llmSender, err = buildSender(provName, cfg, stderr, senderTuning{
+			llmSender, err = buildSender(provName, entry, stderr, senderTuning{
 				thinkingBudget:  anthropicThinkingBudget(resolvedEffort),
 				reasoningEffort: resolvedEffort,
 				showReasoning:   resolvedShowReasoning,
@@ -454,7 +455,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// shown for every path (single-turn, plain REPL, TUI).
 	if resolveVerbosity(*quietFlag, *verboseFlag).verbose() {
 		fmt.Fprintf(stderr, "octo: provider=%s model=%s endpoint=%s\n",
-			provName, resolvedModel, effectiveEndpoint(provName, cfg))
+			provName, resolvedModel, effectiveEndpoint(provName, entry))
 	}
 
 	// Resolve coauthor: flag > env > config > default (true).
@@ -756,6 +757,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			modelName:       resolvedModel,
 			reasoningEffort: resolvedEffort,
 			providerName:    provName,
+			configEntry:     entry,
 		}
 		if toolsOn {
 			// Built-ins only at first paint — the MCP registry is still nil
@@ -789,6 +791,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		modelName:       resolvedModel,
 		reasoningEffort: resolvedEffort,
 		providerName:    provName,
+		configEntry:     entry,
 	}
 	if toolsOn {
 		replCfg.tools = tools.DefaultToolsFor(resolvedModel)
@@ -817,20 +820,20 @@ type senderTuning struct {
 	showReasoning   bool
 }
 
-// buildSender resolves credentials/endpoint (env-first, then the persisted
-// config) and returns an agent.Sender built through internal/app — the single
-// place that constructs provider clients. On a configuration error it writes a
-// user-facing message to stderr and returns a non-nil error. A fresh
+// buildSender resolves credentials/endpoint (env-first, then the resolved
+// config entry) and returns an agent.Sender built through internal/app — the
+// single place that constructs provider clients. On a configuration error it
+// writes a user-facing message to stderr and returns a non-nil error. A fresh
 // prompt-cache key is generated per call.
-func buildSender(name string, cfg config.Config, stderr io.Writer, tuning senderTuning) (agent.Sender, error) {
-	apiKey, err := resolveAPIKey(name, cfg, stderr)
+func buildSender(name string, entry config.ModelEntry, stderr io.Writer, tuning senderTuning) (agent.Sender, error) {
+	apiKey, err := resolveAPIKey(name, entry, stderr)
 	if err != nil {
 		return nil, err
 	}
 	s, err := app.NewSender(app.SenderOptions{
 		Provider:        name,
 		APIKey:          apiKey,
-		BaseURL:         resolveBaseURL(name, cfg),
+		BaseURL:         resolveBaseURL(name, entry),
 		CacheKey:        newCacheKey(),
 		ThinkingBudget:  tuning.thinkingBudget,
 		ReasoningEffort: tuning.reasoningEffort,
@@ -844,10 +847,10 @@ func buildSender(name string, cfg config.Config, stderr io.Writer, tuning sender
 }
 
 // resolveAPIKey returns the API key for the requested vendor: the provider's
-// env var, else cfg.APIKey when the stored config is for this same provider. On
-// a missing key it prints provider-specific setup help to stderr and returns a
-// non-nil error.
-func resolveAPIKey(name string, cfg config.Config, stderr io.Writer) (string, error) {
+// env var, else the resolved entry's stored key when it targets this same
+// provider. On a missing key it prints provider-specific setup help to stderr
+// and returns a non-nil error.
+func resolveAPIKey(name string, entry config.ModelEntry, stderr io.Writer) (string, error) {
 	if !app.IsKnownVendor(name) {
 		fmt.Fprintf(stderr, "octo chat: unknown provider %q\n", name)
 		return "", fmt.Errorf("unknown provider %q", name)
@@ -855,8 +858,8 @@ func resolveAPIKey(name string, cfg config.Config, stderr io.Writer) (string, er
 
 	envVar := app.VendorAPIKeyEnvVar(name)
 	apiKey := os.Getenv(envVar)
-	if apiKey == "" && cfg.Provider == name {
-		apiKey = cfg.APIKey
+	if apiKey == "" && entry.Provider == name {
+		apiKey = entry.APIKey
 	}
 	if apiKey == "" {
 		fmt.Fprintf(stderr, "octo: %s is not set.\n", envVar)

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -209,32 +209,32 @@ func TestResolveShowReasoning(t *testing.T) {
 		name    string
 		flagSet bool
 		flagVal bool
-		cfg     config.Config
+		entry   config.ModelEntry
 		want    bool
 	}{
-		{"default on", false, true, config.Config{}, true},
-		{"config off", false, true, config.Config{ShowReasoning: &fls}, false},
-		{"config on", false, true, config.Config{ShowReasoning: &tru}, true},
-		{"flag off beats config on", true, false, config.Config{ShowReasoning: &tru}, false},
-		{"flag on beats config off", true, true, config.Config{ShowReasoning: &fls}, true},
+		{"default on", false, true, config.ModelEntry{}, true},
+		{"config off", false, true, config.ModelEntry{ShowReasoning: &fls}, false},
+		{"config on", false, true, config.ModelEntry{ShowReasoning: &tru}, true},
+		{"flag off beats config on", true, false, config.ModelEntry{ShowReasoning: &tru}, false},
+		{"flag on beats config off", true, true, config.ModelEntry{ShowReasoning: &fls}, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := resolveShowReasoning(c.flagSet, c.flagVal, c.cfg); got != c.want {
-				t.Errorf("resolveShowReasoning(%v, %v, %+v) = %v, want %v", c.flagSet, c.flagVal, c.cfg, got, c.want)
+			if got := resolveShowReasoning(c.flagSet, c.flagVal, c.entry); got != c.want {
+				t.Errorf("resolveShowReasoning(%v, %v, %+v) = %v, want %v", c.flagSet, c.flagVal, c.entry, got, c.want)
 			}
 		})
 	}
 }
 
 func TestResolveReasoningEffort(t *testing.T) {
-	if got := resolveReasoningEffort("high", config.Config{ReasoningEffort: "low"}); got != "high" {
+	if got := resolveReasoningEffort("high", config.ModelEntry{ReasoningEffort: "low"}); got != "high" {
 		t.Errorf("flag should win: got %q", got)
 	}
-	if got := resolveReasoningEffort("", config.Config{ReasoningEffort: "medium"}); got != "medium" {
+	if got := resolveReasoningEffort("", config.ModelEntry{ReasoningEffort: "medium"}); got != "medium" {
 		t.Errorf("config fallback: got %q", got)
 	}
-	if got := resolveReasoningEffort("", config.Config{}); got != "" {
+	if got := resolveReasoningEffort("", config.ModelEntry{}); got != "" {
 		t.Errorf("default off: got %q", got)
 	}
 }

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -22,11 +22,22 @@ func firstNonEmpty(vals ...string) string {
 
 // resolveProviderModel applies precedence flag > env > config file > built-in
 // default to the provider and model. An empty flagProvider/flagModel means "not
-// set on the CLI". ok is false when the resolved provider has no known default
-// model (i.e. an unknown provider with no explicit model) — the caller prints
-// an error and exits.
-func resolveProviderModel(flagProvider, flagModel string, cfg config.Config) (provider, model string, ok bool) {
-	provider = firstNonEmpty(flagProvider, os.Getenv("OCTO_PROVIDER"), cfg.Provider, app.ProviderAnthropic)
+// set on the CLI". A --model value that names a config entry selects the whole
+// entry — provider, model, base URL, and key all come from it (overriding even
+// an explicit --provider, which can't meaningfully combine with a named
+// entry). The returned entry is the config entry the resolution anchored on,
+// so base-URL/key/reasoning lookups stay on the same entry. ok is false when
+// the resolved provider has no known default model (i.e. an unknown provider
+// with no explicit model) — the caller prints an error and exits.
+func resolveProviderModel(flagProvider, flagModel string, cfg config.Config) (provider, model string, entry config.ModelEntry, ok bool) {
+	if e, found := cfg.EntryByName(flagModel); found {
+		provider = firstNonEmpty(e.Provider, app.ProviderAnthropic)
+		model = firstNonEmpty(e.Model, defaultModels[provider])
+		return provider, model, e, model != ""
+	}
+
+	entry = cfg.DefaultEntry()
+	provider = firstNonEmpty(flagProvider, os.Getenv("OCTO_PROVIDER"), entry.Provider, app.ProviderAnthropic)
 	// Precedence: --model flag > env (ANTHROPIC_MODEL / OPENAI_MODEL) > config
 	// (same-provider only) > built-in default. The env tier mirrors how the
 	// base URL and key resolve env-first, so a third-party Claude-/OpenAI-
@@ -36,24 +47,24 @@ func resolveProviderModel(flagProvider, flagModel string, cfg config.Config) (pr
 	if model == "" {
 		model = modelFromEnv(provider)
 	}
-	// The config's model is specific to the config's provider — only honor it
+	// The entry's model is specific to the entry's provider — only honor it
 	// when the resolved provider matches, so `--provider <other>` doesn't carry
 	// one vendor's model onto another.
-	if model == "" && provider == cfg.Provider {
-		model = cfg.Model
+	if model == "" && provider == entry.Provider {
+		model = entry.Model
 	}
 	if model == "" {
 		model = defaultModels[provider]
 	}
-	return provider, model, model != ""
+	return provider, model, entry, model != ""
 }
 
-// providerBaseURL returns the config's base URL only when the stored config
-// targets the same provider — a base URL is endpoint-specific to its provider,
-// so it must not leak onto a different one selected via --provider.
-func providerBaseURL(provider string, cfg config.Config) string {
-	if cfg.Provider == provider {
-		return cfg.BaseURL
+// providerBaseURL returns the entry's base URL only when the entry targets the
+// same provider — a base URL is endpoint-specific to its provider, so it must
+// not leak onto a different one selected via --provider.
+func providerBaseURL(provider string, entry config.ModelEntry) string {
+	if entry.Provider == provider {
+		return entry.BaseURL
 	}
 	return ""
 }
@@ -65,18 +76,18 @@ func modelFromEnv(provider string) string {
 }
 
 // resolveBaseURL returns the base-URL override for the provider, env-first
-// (<PROVIDER>_BASE_URL) then the persisted config. "" means no
+// (<PROVIDER>_BASE_URL) then the resolved config entry. "" means no
 // override — the provider uses its built-in default endpoint.
-func resolveBaseURL(provider string, cfg config.Config) string {
+func resolveBaseURL(provider string, entry config.ModelEntry) string {
 	envVar := strings.ToUpper(provider) + "_BASE_URL"
-	return firstNonEmpty(os.Getenv(envVar), providerBaseURL(provider, cfg))
+	return firstNonEmpty(os.Getenv(envVar), providerBaseURL(provider, entry))
 }
 
 // effectiveEndpoint is resolveBaseURL for display: it substitutes the
 // provider's built-in default (marked) when there's no override, so a verbose
 // run always shows the host that will actually be called.
-func effectiveEndpoint(provider string, cfg config.Config) string {
-	if u := resolveBaseURL(provider, cfg); u != "" {
+func effectiveEndpoint(provider string, entry config.ModelEntry) string {
+	if u := resolveBaseURL(provider, entry); u != "" {
 		return u
 	}
 	if def := app.DefaultBaseURL(provider); def != "" {
@@ -86,7 +97,7 @@ func effectiveEndpoint(provider string, cfg config.Config) string {
 }
 
 // runConfig handles `octo config [show|path]` and, with no subcommand, an
-// interactive setup wizard that writes ~/.octo/config.yaml.
+// interactive setup wizard that writes ~/.octo/config.yml.
 func runConfig(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	sub := ""
 	if len(args) > 0 {
@@ -122,17 +133,18 @@ func runConfigShow(stdout, stderr io.Writer) int {
 		return 1
 	}
 	path, _ := config.Path()
+	entry := cfg.DefaultEntry()
 
-	provider := firstNonEmpty(os.Getenv("OCTO_PROVIDER"), cfg.Provider, providerAnthropic)
+	provider := firstNonEmpty(os.Getenv("OCTO_PROVIDER"), entry.Provider, providerAnthropic)
 	provSrc := "default"
 	if envProv := os.Getenv("OCTO_PROVIDER"); envProv != "" {
 		provSrc = "env"
-	} else if cfg.Provider != "" {
+	} else if entry.Provider != "" {
 		provSrc = "config"
 	}
-	model := firstNonEmpty(cfg.Model, defaultModels[provider])
+	model := firstNonEmpty(entry.Model, defaultModels[provider])
 	modelSrc := "default"
-	if cfg.Model != "" {
+	if entry.Model != "" {
 		modelSrc = "config"
 	}
 
@@ -141,14 +153,18 @@ func runConfigShow(stdout, stderr io.Writer) int {
 		fmt.Fprintln(stdout, "  (not created yet — run `octo config` to set it up)")
 	}
 	fmt.Fprintln(stdout)
+	if len(cfg.Models) > 1 {
+		fmt.Fprintf(stdout, "  models:    %d configured, default %q (others: %s)\n",
+			len(cfg.Models), entry.Name, otherEntryNames(cfg, entry.Name))
+	}
 	fmt.Fprintf(stdout, "  provider:  %s (%s)\n", provider, provSrc)
 	fmt.Fprintf(stdout, "  model:     %s (%s)\n", model, modelSrc)
-	if cfg.BaseURL != "" {
-		fmt.Fprintf(stdout, "  base URL:  %s (config)\n", cfg.BaseURL)
+	if entry.BaseURL != "" {
+		fmt.Fprintf(stdout, "  base URL:  %s (config)\n", entry.BaseURL)
 	} else {
 		fmt.Fprintln(stdout, "  base URL:  (provider default)")
 	}
-	fmt.Fprintf(stdout, "  API key:   %s\n", apiKeyStatus(provider, cfg))
+	fmt.Fprintf(stdout, "  API key:   %s\n", apiKeyStatus(provider, entry))
 	coauthorStatus := "on (default)"
 	if cfg.Coauthor != nil {
 		if *cfg.Coauthor {
@@ -159,13 +175,13 @@ func runConfigShow(stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "  coauthor:  %s\n", coauthorStatus)
 	effortStatus := "off (default)"
-	if cfg.ReasoningEffort != "" {
-		effortStatus = cfg.ReasoningEffort + " (config)"
+	if entry.ReasoningEffort != "" {
+		effortStatus = entry.ReasoningEffort + " (config)"
 	}
 	fmt.Fprintf(stdout, "  reasoning: %s\n", effortStatus)
 	showStatus := "on (default)"
-	if cfg.ShowReasoning != nil {
-		if *cfg.ShowReasoning {
+	if entry.ShowReasoning != nil {
+		if *entry.ShowReasoning {
 			showStatus = "on (config)"
 		} else {
 			showStatus = "off (config)"
@@ -177,9 +193,20 @@ func runConfigShow(stdout, stderr io.Writer) int {
 	return 0
 }
 
+// otherEntryNames lists the configured entry names besides skip, for display.
+func otherEntryNames(cfg config.Config, skip string) string {
+	names := make([]string, 0, len(cfg.Models))
+	for _, e := range cfg.Models {
+		if e.Name != skip {
+			names = append(names, e.Name)
+		}
+	}
+	return strings.Join(names, ", ")
+}
+
 // apiKeyStatus reports where a key for the given provider would come from,
 // without revealing it. Env always wins over a config-stored key.
-func apiKeyStatus(provider string, cfg config.Config) string {
+func apiKeyStatus(provider string, entry config.ModelEntry) string {
 	envVar := app.VendorAPIKeyEnvVar(provider)
 	if envVar == "" {
 		envVar = strings.ToUpper(provider) + "_API_KEY"
@@ -187,7 +214,7 @@ func apiKeyStatus(provider string, cfg config.Config) string {
 	if os.Getenv(envVar) != "" {
 		return "set via $" + envVar
 	}
-	if cfg.APIKey != "" && cfg.Provider == provider {
+	if entry.APIKey != "" && entry.Provider == provider {
 		return "stored in config (mode 0600)"
 	}
 	return "not set — export $" + envVar
@@ -197,7 +224,8 @@ func apiKeyStatus(provider string, cfg config.Config) string {
 // Existing values are offered as the default for each prompt so re-running it
 // edits rather than resets.
 func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
-	existing, _ := config.Load() // a malformed file is treated as empty here — the wizard overwrites it
+	full, _ := config.Load() // a malformed file is treated as empty here — the wizard overwrites it
+	existing := full.DefaultEntry()
 
 	// An arrow-key menu needs an editable terminal on both ends. When stdin is
 	// piped, the output isn't a TTY, or readline declines (Windows), fall back
@@ -217,7 +245,7 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	defer reader.Close()
 
-	fmt.Fprintln(stdout, "octo config — set your default provider and model (~/.octo/config.yaml).")
+	fmt.Fprintln(stdout, "octo config — set your default provider and model (~/.octo/config.yml).")
 	if tty {
 		fmt.Fprintln(stdout, "Use ↑/↓ to choose, Enter to confirm. CLI flags and env vars still override per run.")
 	} else {
@@ -308,16 +336,21 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 		baseURL = strings.TrimSpace(promptDefault(reader, stdout, "Custom base URL (optional, for DeepSeek/Kimi/etc.)", existing.BaseURL))
 	}
 
-	out := config.Config{Provider: provider, Model: model, BaseURL: baseURL, APIKey: existing.APIKey}
+	// The wizard edits the default entry in place; other entries and global
+	// settings (permission mode, tools, …) pass through untouched.
+	outEntry := existing
+	outEntry.Provider = provider
+	outEntry.Model = model
+	outEntry.BaseURL = baseURL
 
 	// Co-authored-by: default on; ask once in wizard.
-	coauthorDefault := existing.Coauthor == nil || *existing.Coauthor
+	coauthorDefault := full.Coauthor == nil || *full.Coauthor
 	coauthorVal, ok := pickYesNo(tty, reader, stdin, stdout,
 		"Append Co-authored-by to git commits?", coauthorDefault)
 	if !ok {
 		return cancelWizard(stderr)
 	}
-	out.Coauthor = &coauthorVal
+	full.Coauthor = &coauthorVal
 
 	// Reasoning effort: off (empty) by default; offer the existing value.
 	if tty {
@@ -330,7 +363,7 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 		if !ok {
 			return cancelWizard(stderr)
 		}
-		out.ReasoningEffort = choice.value
+		outEntry.ReasoningEffort = choice.value
 	} else {
 		effortAns := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
 			"Reasoning effort (low | medium | high, empty = off)", existing.ReasoningEffort)))
@@ -338,7 +371,7 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "octo config: invalid reasoning effort %q (use 'low', 'medium', 'high', or empty)\n", effortAns)
 			return 2
 		}
-		out.ReasoningEffort = effortAns
+		outEntry.ReasoningEffort = effortAns
 	}
 
 	// Show the reasoning/thinking trace: default on.
@@ -348,7 +381,7 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 	if !ok {
 		return cancelWizard(stderr)
 	}
-	out.ShowReasoning = &showVal
+	outEntry.ShowReasoning = &showVal
 
 	// API key: env is the recommended home for it. Offer to store it only if
 	// the env var is empty, and make declining the obvious default.
@@ -360,27 +393,25 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 	// a key stored for a different provider doesn't help the new one).
 	needsKeyPrompt := os.Getenv(envVar) == "" &&
 		(existing.APIKey == "" || existing.Provider != provider)
-	if !needsKeyPrompt {
-		// Preserve the existing key when staying on the same provider and not
-		// explicitly re-prompting.
-		out.APIKey = existing.APIKey
-	} else {
+	if needsKeyPrompt {
+		outEntry.APIKey = ""
 		ans := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
 			"Store the API key in this file? Not recommended — prefer "+envVar+" (y/N)", "n")))
 		if ans == "y" || ans == "yes" {
 			key := strings.TrimSpace(promptDefault(reader, stdout, "API key", ""))
-			out.APIKey = key
+			outEntry.APIKey = key
 		}
 	}
 
-	if err := out.Save(); err != nil {
+	full.SetDefaultEntry(outEntry)
+	if err := full.Save(); err != nil {
 		fmt.Fprintf(stderr, "octo config: %v\n", err)
 		return 1
 	}
 	path, _ := config.Path()
 	fmt.Fprintln(stdout)
 	fmt.Fprintf(stdout, "Saved %s\n", path)
-	if out.APIKey == "" && os.Getenv(envVar) == "" {
+	if outEntry.APIKey == "" && os.Getenv(envVar) == "" {
 		fmt.Fprintf(stdout, "Next: export %s=... (or re-run `octo config` to store it), then `octo chat`.\n", envVar)
 	} else {
 		fmt.Fprintln(stdout, "Run `octo chat` to start.")

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -8,6 +8,15 @@ import (
 	"github.com/Leihb/octo-agent/internal/config"
 )
 
+// oneEntryConfig builds a Config whose default entry has the given fields —
+// the multi-model equivalent of the old top-level provider/model literals.
+func oneEntryConfig(e config.ModelEntry) config.Config {
+	if e.Name == "" {
+		e.Name = "default"
+	}
+	return config.Config{Models: []config.ModelEntry{e}, DefaultModel: e.Name}
+}
+
 func TestResolveBaseURL_Precedence(t *testing.T) {
 	// Isolate from host env vars so the test is deterministic.
 	t.Setenv("ANTHROPIC_BASE_URL", "")
@@ -15,23 +24,23 @@ func TestResolveBaseURL_Precedence(t *testing.T) {
 
 	// env wins over config.
 	t.Setenv("ANTHROPIC_BASE_URL", "https://api.deepseek.com/anthropic")
-	cfg := config.Config{Provider: providerAnthropic, BaseURL: "https://cfg.example"}
-	if got := resolveBaseURL(providerAnthropic, cfg); got != "https://api.deepseek.com/anthropic" {
+	entry := config.ModelEntry{Provider: providerAnthropic, BaseURL: "https://cfg.example"}
+	if got := resolveBaseURL(providerAnthropic, entry); got != "https://api.deepseek.com/anthropic" {
 		t.Errorf("env should win, got %q", got)
 	}
 
-	// No env → config (same provider only).
+	// No env → config entry (same provider only).
 	t.Setenv("ANTHROPIC_BASE_URL", "")
-	if got := resolveBaseURL(providerAnthropic, cfg); got != "https://cfg.example" {
+	if got := resolveBaseURL(providerAnthropic, entry); got != "https://cfg.example" {
 		t.Errorf("config base URL = %q, want https://cfg.example", got)
 	}
-	// Config base URL must not leak onto a different provider.
-	if got := resolveBaseURL(providerOpenAI, cfg); got != "" {
+	// Entry base URL must not leak onto a different provider.
+	if got := resolveBaseURL(providerOpenAI, entry); got != "" {
 		t.Errorf("openai must not inherit anthropic's config base URL, got %q", got)
 	}
 
 	// No override anywhere → effectiveEndpoint shows the marked default.
-	empty := config.Config{}
+	empty := config.ModelEntry{}
 	if got := resolveBaseURL(providerAnthropic, empty); got != "" {
 		t.Errorf("no override should be empty, got %q", got)
 	}
@@ -39,7 +48,7 @@ func TestResolveBaseURL_Precedence(t *testing.T) {
 		t.Errorf("effectiveEndpoint default = %q, want the marked anthropic default", got)
 	}
 	// Override flows through to effectiveEndpoint verbatim.
-	if got := effectiveEndpoint(providerAnthropic, cfg); got != "https://cfg.example" {
+	if got := effectiveEndpoint(providerAnthropic, entry); got != "https://cfg.example" {
 		t.Errorf("effectiveEndpoint override = %q, want the config URL unmarked", got)
 	}
 }
@@ -48,21 +57,21 @@ func TestResolveProviderModel_ModelEnv(t *testing.T) {
 	// env beats config + default, but the --model flag still beats env.
 	t.Setenv("ANTHROPIC_MODEL", "claude-from-env")
 	t.Setenv("OPENAI_MODEL", "")
-	cfg := config.Config{Provider: providerAnthropic, Model: "cfg-model"}
+	cfg := oneEntryConfig(config.ModelEntry{Provider: providerAnthropic, Model: "cfg-model"})
 
-	if _, m, _ := resolveProviderModel("", "", cfg); m != "claude-from-env" {
+	if _, m, _, _ := resolveProviderModel("", "", cfg); m != "claude-from-env" {
 		t.Errorf("env should beat config, got %q", m)
 	}
-	if _, m, _ := resolveProviderModel("", "flag-model", cfg); m != "flag-model" {
+	if _, m, _, _ := resolveProviderModel("", "flag-model", cfg); m != "flag-model" {
 		t.Errorf("--model flag should beat env, got %q", m)
 	}
 	// The model env is per-provider: ANTHROPIC_MODEL must not leak onto openai.
-	if _, m, _ := resolveProviderModel(providerOpenAI, "", config.Config{}); m != "gpt-5.4" {
+	if _, m, _, _ := resolveProviderModel(providerOpenAI, "", config.Config{}); m != "gpt-5.4" {
 		t.Errorf("ANTHROPIC_MODEL must not affect openai, got %q (want default)", m)
 	}
 	// OPENAI_MODEL drives the openai default slot.
 	t.Setenv("OPENAI_MODEL", "deepseek-chat")
-	if _, m, _ := resolveProviderModel(providerOpenAI, "", config.Config{}); m != "deepseek-chat" {
+	if _, m, _, _ := resolveProviderModel(providerOpenAI, "", config.Config{}); m != "deepseek-chat" {
 		t.Errorf("OPENAI_MODEL = %q, want deepseek-chat", m)
 	}
 }
@@ -73,7 +82,7 @@ func TestResolveProviderModel_Precedence(t *testing.T) {
 	t.Setenv("ANTHROPIC_MODEL", "")
 	t.Setenv("OPENAI_MODEL", "")
 	t.Setenv("OCTO_PROVIDER", "")
-	cfg := config.Config{Provider: "openai", Model: "cfg-model"}
+	cfg := oneEntryConfig(config.ModelEntry{Provider: "openai", Model: "cfg-model"})
 	tests := []struct {
 		name              string
 		flagProv, flagMdl string
@@ -85,14 +94,14 @@ func TestResolveProviderModel_Precedence(t *testing.T) {
 		{"config beats default", "", "", cfg, "openai", "cfg-model", true},
 		{"flag provider, default model", "openai", "", config.Config{}, "openai", "gpt-5.4", true},
 		{"empty everything → anthropic default", "", "", config.Config{}, "anthropic", "claude-sonnet-4-6", true},
-		{"config provider, builtin model", "", "", config.Config{Provider: "openai"}, "openai", "gpt-5.4", true},
+		{"config provider, builtin model", "", "", oneEntryConfig(config.ModelEntry{Provider: "openai"}), "openai", "gpt-5.4", true},
 		{"flag provider overrides config provider — no model contamination", "anthropic", "", cfg, "anthropic", "claude-sonnet-4-6", true},
 		{"unknown provider, no model → not ok", "bogus", "", config.Config{}, "bogus", "", false},
 		{"unknown provider WITH model → ok (buildProvider rejects later)", "bogus", "m", config.Config{}, "bogus", "m", true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gotProv, gotMdl, ok := resolveProviderModel(tc.flagProv, tc.flagMdl, tc.cfg)
+			gotProv, gotMdl, _, ok := resolveProviderModel(tc.flagProv, tc.flagMdl, tc.cfg)
 			if gotProv != tc.wantProv || gotMdl != tc.wantMdl || ok != tc.wantOK {
 				t.Errorf("resolveProviderModel(%q,%q,%+v) = (%q,%q,%v), want (%q,%q,%v)",
 					tc.flagProv, tc.flagMdl, tc.cfg, gotProv, gotMdl, ok, tc.wantProv, tc.wantMdl, tc.wantOK)
@@ -101,21 +110,51 @@ func TestResolveProviderModel_Precedence(t *testing.T) {
 	}
 }
 
+func TestResolveProviderModel_EntryNameSelectsWholeEntry(t *testing.T) {
+	t.Setenv("ANTHROPIC_MODEL", "")
+	t.Setenv("OPENAI_MODEL", "")
+	t.Setenv("OCTO_PROVIDER", "")
+	cfg := config.Config{
+		Models: []config.ModelEntry{
+			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			{Name: "kimi", Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://kimi.example", APIKey: "sk-kimi"},
+		},
+		DefaultModel: "main",
+	}
+
+	prov, model, entry, ok := resolveProviderModel("", "kimi", cfg)
+	if !ok || prov != "kimi" || model != "kimi-k2.6" {
+		t.Fatalf("named entry: got (%q,%q,%v), want (kimi, kimi-k2.6, true)", prov, model, ok)
+	}
+	if entry.BaseURL != "https://kimi.example" || entry.APIKey != "sk-kimi" {
+		t.Errorf("entry should carry base URL and key: %+v", entry)
+	}
+	// The entry wins over an explicit --provider — the combination is
+	// meaningless and the entry is what the user named.
+	if p, _, _, _ := resolveProviderModel("anthropic", "kimi", cfg); p != "kimi" {
+		t.Errorf("entry name should override --provider, got %q", p)
+	}
+	// A non-matching --model value stays a raw model string on the default entry.
+	if p, m, _, _ := resolveProviderModel("", "some-model", cfg); p != "anthropic" || m != "some-model" {
+		t.Errorf("raw model string: got (%q,%q)", p, m)
+	}
+}
+
 func TestResolveProviderModel_ProviderEnv(t *testing.T) {
 	// OCTO_PROVIDER beats config and default, but --provider flag still beats env.
 	t.Setenv("OCTO_PROVIDER", "openai")
 	t.Setenv("OPENAI_MODEL", "")
-	cfg := config.Config{Provider: providerAnthropic, Model: "cfg-model"}
+	cfg := oneEntryConfig(config.ModelEntry{Provider: providerAnthropic, Model: "cfg-model"})
 
-	if p, _, _ := resolveProviderModel("", "", cfg); p != "openai" {
+	if p, _, _, _ := resolveProviderModel("", "", cfg); p != "openai" {
 		t.Errorf("OCTO_PROVIDER should beat config, got %q", p)
 	}
-	if p, _, _ := resolveProviderModel("anthropic", "", cfg); p != "anthropic" {
+	if p, _, _, _ := resolveProviderModel("anthropic", "", cfg); p != "anthropic" {
 		t.Errorf("--provider flag should beat OCTO_PROVIDER, got %q", p)
 	}
 	// When OCTO_PROVIDER selects a provider, its model env var is read.
 	t.Setenv("OPENAI_MODEL", "deepseek-chat")
-	if _, m, _ := resolveProviderModel("", "", config.Config{}); m != "deepseek-chat" {
+	if _, m, _, _ := resolveProviderModel("", "", config.Config{}); m != "deepseek-chat" {
 		t.Errorf("OCTO_PROVIDER=openai + OPENAI_MODEL should resolve model, got %q", m)
 	}
 }
@@ -128,8 +167,8 @@ func TestRunConfig_Path(t *testing.T) {
 	if code := runConfig([]string{"path"}, strings.NewReader(""), &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "config.yaml") {
-		t.Errorf("path output should mention config.yaml; got %q", stdout.String())
+	if !strings.Contains(stdout.String(), "config.yml") {
+		t.Errorf("path output should mention config.yml; got %q", stdout.String())
 	}
 }
 
@@ -150,15 +189,59 @@ func TestRunConfig_Wizard_WritesFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load after wizard: %v", err)
 	}
-	if got.Provider != "openai" {
-		t.Errorf("provider = %q, want openai", got.Provider)
+	entry := got.DefaultEntry()
+	if entry.Provider != "openai" {
+		t.Errorf("provider = %q, want openai", entry.Provider)
 	}
 	// Empty model answer keeps it unset so the built-in default applies later.
-	if got.Model != "" {
-		t.Errorf("model = %q, want empty (use built-in default)", got.Model)
+	if entry.Model != "" {
+		t.Errorf("model = %q, want empty (use built-in default)", entry.Model)
 	}
-	if got.APIKey != "" {
-		t.Errorf("APIKey should not be stored when env var is set; got %q", got.APIKey)
+	if entry.APIKey != "" {
+		t.Errorf("APIKey should not be stored when env var is set; got %q", entry.APIKey)
+	}
+}
+
+func TestRunConfig_Wizard_PreservesOtherEntriesAndGlobals(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("ANTHROPIC_API_KEY", "set-so-wizard-skips-key-prompt")
+
+	seed := config.Config{
+		Models: []config.ModelEntry{
+			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			{Name: "kimi", Provider: "kimi", Model: "kimi-k2.6"},
+		},
+		DefaultModel:   "main",
+		PermissionMode: "strict",
+	}
+	if err := seed.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Answers: provider=openai, model=(default), base_url=(blank).
+	in := strings.NewReader("openai\n\n\n")
+	var stdout, stderr bytes.Buffer
+	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+
+	got, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load after wizard: %v", err)
+	}
+	if len(got.Models) != 2 {
+		t.Fatalf("wizard must not drop other entries: %+v", got.Models)
+	}
+	if _, ok := got.EntryByName("kimi"); !ok {
+		t.Error("kimi entry lost")
+	}
+	if got.PermissionMode != "strict" {
+		t.Errorf("permission_mode lost: %q", got.PermissionMode)
+	}
+	if got.DefaultEntry().Provider != "openai" {
+		t.Errorf("default entry provider = %q, want openai", got.DefaultEntry().Provider)
 	}
 }
 
@@ -168,7 +251,7 @@ func TestRunConfig_Show_ReportsSourcesNotKey(t *testing.T) {
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("ANTHROPIC_API_KEY", "secret-value-should-not-print")
 
-	if err := (config.Config{Provider: "anthropic", Model: "m1"}).Save(); err != nil {
+	if err := oneEntryConfig(config.ModelEntry{Provider: "anthropic", Model: "m1"}).Save(); err != nil {
 		t.Fatal(err)
 	}
 	var stdout, stderr bytes.Buffer
@@ -198,7 +281,7 @@ func TestRunConfig_Wizard_SwitchesProviderAndPromptsForKey(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
 
 	// Start with an anthropic config that has a stored key.
-	if err := (config.Config{Provider: "anthropic", APIKey: "old-anthropic-key"}).Save(); err != nil {
+	if err := oneEntryConfig(config.ModelEntry{Provider: "anthropic", APIKey: "old-anthropic-key"}).Save(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -214,11 +297,12 @@ func TestRunConfig_Wizard_SwitchesProviderAndPromptsForKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load after wizard: %v", err)
 	}
-	if got.Provider != "openai" {
-		t.Errorf("provider = %q, want openai", got.Provider)
+	entry := got.DefaultEntry()
+	if entry.Provider != "openai" {
+		t.Errorf("provider = %q, want openai", entry.Provider)
 	}
-	if got.APIKey != "new-openai-key" {
-		t.Errorf("APIKey = %q, want new-openai-key", got.APIKey)
+	if entry.APIKey != "new-openai-key" {
+		t.Errorf("APIKey = %q, want new-openai-key", entry.APIKey)
 	}
 }
 

--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -205,7 +205,7 @@ Run "octo serve --help" for the full flag list.`)
 
 func configHelp(w io.Writer) {
 	fmt.Fprintln(w, `octo config — save your default provider, model, and (optionally) base URL to
-~/.octo/config.yaml so a bare `+"`octo chat`"+` works without re-typing flags.
+~/.octo/config.yml so a bare `+"`octo chat`"+` works without re-typing flags.
 
 Precedence (highest first): CLI flag (--provider/--model) > env var > this file
 > built-in default. API keys are read from the environment first; storing one
@@ -216,7 +216,7 @@ Usage:
   octo config show                 Print the effective provider/model and where each
                                    comes from (never prints the key itself)
   octo config path                 Print the config file path
-File (~/.octo/config.yaml):
+File (~/.octo/config.yml):
   provider: openai
   model: gpt-4o-mini
   base_url: https://api.deepseek.com   # optional, for compatible 3rd parties

--- a/cmd/octo/init.go
+++ b/cmd/octo/init.go
@@ -56,16 +56,16 @@ func runInit(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	cfg, err := config.Load()
 	if err != nil {
 		fmt.Fprintf(stderr, "octo init: %v\n", err)
-		fmt.Fprintln(stderr, "Run `octo config` to rewrite ~/.octo/config.yaml.")
+		fmt.Fprintln(stderr, "Run `octo config` to rewrite ~/.octo/config.yml.")
 		return 1
 	}
-	provName, resolvedModel, ok := resolveProviderModel(*providerName, *model, cfg)
+	provName, resolvedModel, entry, ok := resolveProviderModel(*providerName, *model, cfg)
 	if !ok {
 		fmt.Fprintf(stderr, "octo init: unknown provider %q (use 'anthropic' or 'openai')\n", provName)
 		return 2
 	}
 
-	llmSender, err := buildSender(provName, cfg, stderr, senderTuning{})
+	llmSender, err := buildSender(provName, entry, stderr, senderTuning{})
 	if err != nil {
 		return 1
 	}

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -99,7 +99,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Commands:")
 	fmt.Fprintln(w, "  chat       Start an interactive session (or single-turn with a message)")
-	fmt.Fprintln(w, "  config     Set your default provider/model (~/.octo/config.yaml)")
+	fmt.Fprintln(w, "  config     Set your default provider/model (~/.octo/config.yml)")
 	fmt.Fprintln(w, "  serve      Start the HTTP server (REST + SSE + Web UI)")
 	fmt.Fprintln(w, "  init       Analyze the repo and generate/update .octorules")
 	fmt.Fprintln(w, "  memory     Manage cross-session memory (e.g. `octo memory list`)")

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/config"
 	"github.com/Leihb/octo-agent/internal/hooks"
 	"github.com/Leihb/octo-agent/internal/mcp"
 	"github.com/Leihb/octo-agent/internal/permission"
@@ -62,6 +63,9 @@ type replConfig struct {
 	// providerName is the resolved provider (e.g. "anthropic", "openai") used
 	// to rebuild the sender when the user switches model or thinking level.
 	providerName string
+	// configEntry is the config entry the session resolved at startup; sender
+	// rebuilds (e.g. /thinking) anchor base URL and stored key on it.
+	configEntry config.ModelEntry
 }
 
 // mcpBootstrap carries the inputs runTUI needs to connect MCP servers from a

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -12,7 +12,6 @@ import (
 	"unsafe"
 
 	"github.com/Leihb/octo-agent/internal/agent"
-	"github.com/Leihb/octo-agent/internal/config"
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/tools"
 	"github.com/Leihb/octo-agent/internal/tui"
@@ -693,8 +692,6 @@ func (m *tuiModel) dispatchThinking(level string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Load current config to rebuild the sender with the new tuning.
-	cfg, _ := config.Load()
 	if m.cfg.providerName == "" {
 		m.println(errorStyle.Render("Provider not set — cannot rebuild sender"))
 		return m, nil
@@ -706,7 +703,7 @@ func (m *tuiModel) dispatchThinking(level string) (tea.Model, tea.Cmd) {
 		tuning.thinkingBudget = anthropicThinkingBudget(level)
 	}
 
-	newSender, err := buildSender(m.cfg.providerName, cfg, m.cfg.stderr, tuning)
+	newSender, err := buildSender(m.cfg.providerName, m.cfg.configEntry, m.cfg.stderr, tuning)
 	if err != nil {
 		m.println(errorStyle.Render(fmt.Sprintf("Failed to rebuild sender: %v", err)))
 		return m, nil

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -9,6 +9,8 @@
 // vendor only needs one line here.
 package app
 
+import "strings"
+
 // EndpointVariant is a regional endpoint alternative for a vendor.
 type EndpointVariant struct {
 	Label    string `json:"label"`
@@ -261,6 +263,29 @@ func VendorWebsiteURL(id string) string {
 // IsKnownVendor reports whether id is a registered vendor ID.
 func IsKnownVendor(id string) bool {
 	return vendorByID(id) != nil
+}
+
+// VendorByBaseURL returns the vendor whose default endpoint or one of whose
+// regional variants equals baseURL (ignoring a trailing slash), or "". The
+// settings panel saves entries without naming a vendor, so the server infers
+// it from the endpoint the user picked.
+func VendorByBaseURL(baseURL string) string {
+	u := strings.TrimSuffix(strings.TrimSpace(baseURL), "/")
+	if u == "" {
+		return ""
+	}
+	for i := range Registry {
+		v := &Registry[i]
+		if strings.TrimSuffix(v.DefaultBaseURL, "/") == u {
+			return v.ID
+		}
+		for _, ev := range v.EndpointVariants {
+			if strings.TrimSuffix(ev.BaseURL, "/") == u {
+				return v.ID
+			}
+		}
+	}
+	return ""
 }
 
 // IsAnthropicProtocol reports whether the vendor speaks the Anthropic protocol.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,46 +1,72 @@
 // Package config holds the user's persisted CLI defaults at
-// ~/.octo/config.yaml — the provider/model/base-URL a fresh `octo chat`
-// should use without re-typing flags or re-exporting env vars every session.
+// ~/.octo/config.yml — a list of named model configurations plus global
+// settings, so a fresh `octo chat` works without re-typing flags or
+// re-exporting env vars every session.
 //
 // Precedence is resolved by the caller (cmd/octo): an explicit CLI flag beats
 // this file, which beats the built-in default. API keys are read from the
 // environment first; storing one here is opt-in and discouraged (it lands in
-// plaintext, mode 0600), so callers fall back to Config.APIKey only when the
-// matching env var is empty.
+// plaintext, mode 0600), so callers fall back to the entry's APIKey only when
+// the matching env var is empty.
+//
+// The file was previously ~/.octo/config.yaml with a single top-level
+// provider/model pair. Load reads that legacy file (and legacy fields) when
+// config.yml is absent, normalising it into a one-entry Models list; the
+// first Save writes the new schema to config.yml and parks the legacy file
+// as config.yaml.bak.
 package config
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+// ModelEntry is one named model configuration: everything needed to build a
+// sender for it. Name is the entry's identity — the HTTP API uses it as the
+// id and `--model <name>` selects the whole entry.
+type ModelEntry struct {
+	Name     string `yaml:"name"`
+	Provider string `yaml:"provider,omitempty"`
+	Model    string `yaml:"model,omitempty"`
+	// BaseURL is an optional endpoint override; empty uses the vendor default.
+	BaseURL string `yaml:"base_url,omitempty"`
+	// APIKey, when set, is a plaintext fallback used only if the provider's
+	// env var is empty. Opt-in via `octo config` and stored mode 0600. Prefer
+	// the env var.
+	APIKey string `yaml:"api_key,omitempty"`
+	// ReasoningEffort sets the unified reasoning intensity ("low" | "medium" |
+	// "high"). OpenAI sends it as reasoning_effort; Anthropic maps it to an
+	// extended-thinking token budget. Empty means off (no extended reasoning).
+	ReasoningEffort string `yaml:"reasoning_effort,omitempty"`
+	// ShowReasoning controls whether a reasoning model's thinking trace is
+	// streamed to the terminal (dimmed). nil means the built-in default
+	// (enabled).
+	ShowReasoning *bool `yaml:"show_reasoning,omitempty"`
+}
 
 // Config is the persisted set of CLI defaults. Every field is optional; a
 // missing file (or a missing field) leaves the zero value, and the caller
 // substitutes its built-in default.
 type Config struct {
-	Provider       string `yaml:"provider,omitempty"`
-	Model          string `yaml:"model,omitempty"`
-	BaseURL        string `yaml:"base_url,omitempty"`
+	// Models is the list of named model configurations.
+	Models []ModelEntry `yaml:"models,omitempty"`
+	// DefaultModel names the entry used when nothing else selects one.
+	// Empty falls back to the first entry.
+	DefaultModel string `yaml:"default_model,omitempty"`
+	// LiteModel optionally names the entry used for cheap internal calls
+	// (history compaction). Empty means no lite model.
+	LiteModel string `yaml:"lite_model,omitempty"`
+
 	PermissionMode string `yaml:"permission_mode,omitempty"`
 	// Coauthor, when true, instructs the agent to append a Co-authored-by line
 	// to every git commit message it writes. Default is true (enabled).
 	Coauthor *bool `yaml:"coauthor,omitempty"`
-	// ShowReasoning controls whether a reasoning model's thinking trace is
-	// streamed to the terminal (dimmed). Covers both Anthropic thinking blocks
-	// and OpenAI reasoning_content. nil means the built-in default (enabled).
-	ShowReasoning *bool `yaml:"show_reasoning,omitempty"`
-	// ReasoningEffort sets the unified reasoning intensity ("low" | "medium" |
-	// "high"). OpenAI sends it as reasoning_effort; Anthropic maps it to an
-	// extended-thinking token budget. Empty means off (no extended reasoning).
-	ReasoningEffort string `yaml:"reasoning_effort,omitempty"`
-	// APIKey, when set, is a plaintext fallback used only if the provider's
-	// env var is empty. Opt-in via `octo config` and stored mode 0600. Prefer
-	// the env var.
-	APIKey string `yaml:"api_key,omitempty"`
 	// AccessKey is the shared secret for Web UI / API authentication.
 	// When empty, `octo serve` falls back to OCTO_ACCESS_KEY env var or
 	// generates a random key on startup.
@@ -83,8 +109,86 @@ type ToolSearchConfig struct {
 	MaxSearchLimit int `yaml:"max_search_limit,omitempty"`
 }
 
-// Path returns the absolute path to the config file (~/.octo/config.yaml).
+// DefaultEntry returns the entry named by DefaultModel, falling back to the
+// first entry, or a zero ModelEntry when none are configured.
+func (c Config) DefaultEntry() ModelEntry {
+	if e, ok := c.EntryByName(c.DefaultModel); ok {
+		return e
+	}
+	if len(c.Models) > 0 {
+		return c.Models[0]
+	}
+	return ModelEntry{}
+}
+
+// EntryByName returns the entry with the given name. An empty name never
+// matches.
+func (c Config) EntryByName(name string) (ModelEntry, bool) {
+	if name == "" {
+		return ModelEntry{}, false
+	}
+	for _, e := range c.Models {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return ModelEntry{}, false
+}
+
+// SetDefaultEntry replaces the default entry in place (matching by its
+// current name), or appends it when no entry exists yet, and points
+// DefaultModel at it. Writers that previously mutated the top-level
+// provider/model fields go through this.
+func (c *Config) SetDefaultEntry(e ModelEntry) {
+	if e.Name == "" {
+		e.Name = "default"
+	}
+	cur := c.DefaultEntry()
+	for i := range c.Models {
+		if c.Models[i].Name == cur.Name && cur.Name != "" {
+			// Renaming the default entry keeps references consistent.
+			if c.LiteModel == cur.Name {
+				c.LiteModel = e.Name
+			}
+			c.Models[i] = e
+			c.DefaultModel = e.Name
+			return
+		}
+	}
+	c.Models = append(c.Models, e)
+	c.DefaultModel = e.Name
+}
+
+// UniqueName derives an entry name from base (typically the model string)
+// that does not collide with any existing entry, appending -2, -3, … as
+// needed.
+func (c Config) UniqueName(base string) string {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "model"
+	}
+	if _, ok := c.EntryByName(base); !ok {
+		return base
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", base, i)
+		if _, ok := c.EntryByName(candidate); !ok {
+			return candidate
+		}
+	}
+}
+
+// Path returns the absolute path to the config file (~/.octo/config.yml).
 func Path() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".octo", "config.yml"), nil
+}
+
+// legacyPath returns the pre-rename location (~/.octo/config.yaml).
+func legacyPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
@@ -92,31 +196,79 @@ func Path() (string, error) {
 	return filepath.Join(home, ".octo", "config.yaml"), nil
 }
 
-// Load reads ~/.octo/config.yaml. A missing file is not an error — it returns
-// the zero Config so first-run callers need no special-casing. A present but
-// malformed file IS an error, so a typo surfaces instead of silently
-// reverting to defaults.
+// fileConfig is the on-disk superset: the current schema plus the legacy
+// top-level model fields, so both file generations unmarshal through one
+// struct and normalize identically.
+type fileConfig struct {
+	Config `yaml:",inline"`
+
+	LegacyProvider        string `yaml:"provider,omitempty"`
+	LegacyModel           string `yaml:"model,omitempty"`
+	LegacyBaseURL         string `yaml:"base_url,omitempty"`
+	LegacyAPIKey          string `yaml:"api_key,omitempty"`
+	LegacyReasoningEffort string `yaml:"reasoning_effort,omitempty"`
+	LegacyShowReasoning   *bool  `yaml:"show_reasoning,omitempty"`
+}
+
+// normalize folds legacy top-level model fields into a one-entry Models list.
+// Files already on the new schema pass through untouched; legacy fields are
+// ignored once a models list exists.
+func (f fileConfig) normalize() Config {
+	c := f.Config
+	if len(c.Models) > 0 {
+		return c
+	}
+	if f.LegacyProvider == "" && f.LegacyModel == "" && f.LegacyBaseURL == "" && f.LegacyAPIKey == "" {
+		return c
+	}
+	c.Models = []ModelEntry{{
+		Name:            "default",
+		Provider:        f.LegacyProvider,
+		Model:           f.LegacyModel,
+		BaseURL:         f.LegacyBaseURL,
+		APIKey:          f.LegacyAPIKey,
+		ReasoningEffort: f.LegacyReasoningEffort,
+		ShowReasoning:   f.LegacyShowReasoning,
+	}}
+	c.DefaultModel = "default"
+	return c
+}
+
+// Load reads ~/.octo/config.yml, falling back to the legacy
+// ~/.octo/config.yaml. A missing file is not an error — it returns the zero
+// Config so first-run callers need no special-casing. A present but malformed
+// file IS an error, so a typo surfaces instead of silently reverting to
+// defaults.
 func Load() (Config, error) {
 	path, err := Path()
 	if err != nil {
 		return Config{}, err
 	}
 	data, err := os.ReadFile(path)
-	if err != nil {
+	if errors.Is(err, fs.ErrNotExist) {
+		legacy, lerr := legacyPath()
+		if lerr != nil {
+			return Config{}, lerr
+		}
+		data, err = os.ReadFile(legacy)
 		if errors.Is(err, fs.ErrNotExist) {
 			return Config{}, nil
 		}
+	}
+	if err != nil {
 		return Config{}, err
 	}
-	var c Config
-	if err := yaml.Unmarshal(data, &c); err != nil {
+	var f fileConfig
+	if err := yaml.Unmarshal(data, &f); err != nil {
 		return Config{}, err
 	}
-	return c, nil
+	return f.normalize(), nil
 }
 
-// Save writes the config to ~/.octo/config.yaml with mode 0600 (it may hold an
-// API key), creating ~/.octo if needed.
+// Save writes the config to ~/.octo/config.yml with mode 0600 (it may hold
+// API keys), creating ~/.octo if needed. A legacy config.yaml present at that
+// moment is renamed to config.yaml.bak — best effort, because config.yml wins
+// the read order regardless.
 func (c Config) Save() error {
 	path, err := Path()
 	if err != nil {
@@ -129,5 +281,13 @@ func (c Config) Save() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o600)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return err
+	}
+	if legacy, lerr := legacyPath(); lerr == nil {
+		if _, statErr := os.Stat(legacy); statErr == nil {
+			_ = os.Rename(legacy, legacy+".bak")
+		}
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,25 +7,50 @@ import (
 	"testing"
 )
 
+func setHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
+	return home
+}
+
+func writeOcto(t *testing.T, home, name, content string) string {
+	t.Helper()
+	dir := filepath.Join(home, ".octo")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 func TestLoad_MissingFileIsZeroNotError(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("USERPROFILE", t.TempDir()) // Windows
+	setHome(t)
 
 	c, err := Load()
 	if err != nil {
 		t.Fatalf("Load() on missing file = %v, want nil", err)
 	}
-	if c.Provider != "" || c.Model != "" || c.BaseURL != "" {
+	if len(c.Models) != 0 || c.DefaultModel != "" {
 		t.Errorf("Load() on missing file = %+v, want zero Config", c)
 	}
 }
 
 func TestSaveLoad_RoundTrip(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
+	setHome(t)
 
-	want := Config{Provider: "openai", Model: "gpt-4o-mini", BaseURL: "https://x.example"}
+	want := Config{
+		Models: []ModelEntry{
+			{Name: "main", Provider: "anthropic", Model: "claude-fable-5"},
+			{Name: "kimi", Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://x.example"},
+		},
+		DefaultModel: "kimi",
+		LiteModel:    "main",
+	}
 	if err := want.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -34,8 +59,81 @@ func TestSaveLoad_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if got.Provider != want.Provider || got.Model != want.Model || got.BaseURL != want.BaseURL {
-		t.Errorf("round-trip = %+v, want %+v", got, want)
+	if len(got.Models) != 2 || got.Models[1] != want.Models[1] {
+		t.Errorf("round-trip models = %+v, want %+v", got.Models, want.Models)
+	}
+	if got.DefaultModel != "kimi" || got.LiteModel != "main" {
+		t.Errorf("round-trip refs = default %q lite %q", got.DefaultModel, got.LiteModel)
+	}
+	if e := got.DefaultEntry(); e.Name != "kimi" || e.BaseURL != "https://x.example" {
+		t.Errorf("DefaultEntry = %+v, want kimi entry", e)
+	}
+}
+
+func TestLoad_LegacyYAMLIsNormalised(t *testing.T) {
+	home := setHome(t)
+	writeOcto(t, home, "config.yaml",
+		"provider: openai\nmodel: gpt-4o-mini\nbase_url: https://x.example\napi_key: sk-old\nreasoning_effort: high\npermission_mode: strict\n")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(c.Models) != 1 {
+		t.Fatalf("Models = %+v, want one synthesized entry", c.Models)
+	}
+	e := c.Models[0]
+	if e.Name != "default" || e.Provider != "openai" || e.Model != "gpt-4o-mini" ||
+		e.BaseURL != "https://x.example" || e.APIKey != "sk-old" || e.ReasoningEffort != "high" {
+		t.Errorf("synthesized entry = %+v", e)
+	}
+	if c.DefaultModel != "default" {
+		t.Errorf("DefaultModel = %q, want default", c.DefaultModel)
+	}
+	if c.PermissionMode != "strict" {
+		t.Errorf("global PermissionMode lost: %q", c.PermissionMode)
+	}
+}
+
+func TestLoad_NewFileShadowsLegacy(t *testing.T) {
+	home := setHome(t)
+	writeOcto(t, home, "config.yaml", "model: old-model\nprovider: openai\n")
+	writeOcto(t, home, "config.yml",
+		"models:\n  - name: main\n    provider: anthropic\n    model: new-model\ndefault_model: main\n")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if e := c.DefaultEntry(); e.Model != "new-model" {
+		t.Errorf("DefaultEntry().Model = %q, want new-model (config.yml must win)", e.Model)
+	}
+}
+
+func TestSave_MigratesLegacyToBak(t *testing.T) {
+	home := setHome(t)
+	legacy := writeOcto(t, home, "config.yaml", "model: old-model\nprovider: openai\n")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := c.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Errorf("legacy config.yaml still present after Save")
+	}
+	if _, err := os.Stat(legacy + ".bak"); err != nil {
+		t.Errorf("config.yaml.bak missing: %v", err)
+	}
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("re-Load: %v", err)
+	}
+	if e := got.DefaultEntry(); e.Model != "old-model" || e.Provider != "openai" {
+		t.Errorf("migrated entry = %+v", e)
 	}
 }
 
@@ -46,15 +144,13 @@ func TestSave_FileMode0600(t *testing.T) {
 		// Unix platforms where it's a real access control.
 		t.Skip("Unix file permissions not enforced on Windows")
 	}
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
+	home := setHome(t)
 
-	if err := (Config{APIKey: "sk-secret"}).Save(); err != nil {
+	cfg := Config{Models: []ModelEntry{{Name: "main", APIKey: "sk-secret"}}}
+	if err := cfg.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	path := filepath.Join(home, ".octo", "config.yaml")
-	info, err := os.Stat(path)
+	info, err := os.Stat(filepath.Join(home, ".octo", "config.yml"))
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
@@ -65,17 +161,56 @@ func TestSave_FileMode0600(t *testing.T) {
 }
 
 func TestLoad_MalformedIsError(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-	dir := filepath.Join(home, ".octo")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("not: valid: yaml: ["), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	home := setHome(t)
+	writeOcto(t, home, "config.yml", "not: valid: yaml: [")
 	if _, err := Load(); err == nil {
 		t.Error("Load() on malformed file = nil, want error")
+	}
+}
+
+func TestSetDefaultEntry(t *testing.T) {
+	var c Config
+
+	// Appends when empty.
+	c.SetDefaultEntry(ModelEntry{Name: "main", Model: "m1"})
+	if len(c.Models) != 1 || c.DefaultModel != "main" {
+		t.Fatalf("after first set: %+v", c)
+	}
+
+	// Replaces in place, including a rename, and keeps the lite reference.
+	c.LiteModel = "main"
+	c.SetDefaultEntry(ModelEntry{Name: "primary", Model: "m2"})
+	if len(c.Models) != 1 || c.Models[0].Name != "primary" || c.Models[0].Model != "m2" {
+		t.Fatalf("after rename: %+v", c.Models)
+	}
+	if c.DefaultModel != "primary" || c.LiteModel != "primary" {
+		t.Errorf("references not updated: default %q lite %q", c.DefaultModel, c.LiteModel)
+	}
+
+	// Names an unnamed entry "default".
+	var c2 Config
+	c2.SetDefaultEntry(ModelEntry{Model: "m3"})
+	if c2.Models[0].Name != "default" || c2.DefaultModel != "default" {
+		t.Errorf("unnamed entry: %+v", c2)
+	}
+}
+
+func TestUniqueName(t *testing.T) {
+	c := Config{Models: []ModelEntry{{Name: "kimi-k2.6"}, {Name: "kimi-k2.6-2"}}}
+	if got := c.UniqueName("kimi-k2.6"); got != "kimi-k2.6-3" {
+		t.Errorf("UniqueName = %q, want kimi-k2.6-3", got)
+	}
+	if got := c.UniqueName("fresh"); got != "fresh" {
+		t.Errorf("UniqueName = %q, want fresh", got)
+	}
+	if got := c.UniqueName(" "); got != "model" {
+		t.Errorf("UniqueName(blank) = %q, want model", got)
+	}
+}
+
+func TestEntryByName_EmptyNeverMatches(t *testing.T) {
+	c := Config{Models: []ModelEntry{{Name: "", Model: "m"}}}
+	if _, ok := c.EntryByName(""); ok {
+		t.Error("EntryByName(\"\") matched, want no match")
 	}
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -124,7 +124,7 @@ func (srv *Server) sessionStatusFields() (workingDir, permissionMode, reasoningE
 	workingDir = srv.cwd
 	permissionMode = string(resolvePermissionMode())
 	if cfg, err := config.Load(); err == nil {
-		reasoningEffort = cfg.ReasoningEffort
+		reasoningEffort = cfg.DefaultEntry().ReasoningEffort
 	}
 	return workingDir, permissionMode, reasoningEffort, 0
 }
@@ -299,11 +299,20 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 	model := s.model
 	if req.Model != "" {
 		model = req.Model
+		// The web modal sends a config entry id; resolve it to the entry's
+		// model string. (Per-entry sender binding is the next step on the
+		// multi-model design — until then the session rides the default
+		// sender.)
+		if cfg, err := config.Load(); err == nil {
+			if e, ok := cfg.EntryByName(req.Model); ok && e.Model != "" {
+				model = e.Model
+			}
+		}
 	}
 	if model == "" {
 		// Fall back to the user's configured default model.
-		if cfg, err := config.Load(); err == nil && cfg.Model != "" {
-			model = cfg.Model
+		if cfg, err := config.Load(); err == nil && cfg.DefaultEntry().Model != "" {
+			model = cfg.DefaultEntry().Model
 		}
 	}
 	if model == "" {
@@ -871,11 +880,16 @@ func (s *Server) handleUpdateSessionModel(w http.ResponseWriter, r *http.Request
 	}
 
 	cfg, _ := config.Load()
-	// Single-model system: model_id is the new default model name unless it
-	// matches the stable "default" id we expose in /api/config.
-	if req.ModelID != "default" {
-		cfg.Model = req.ModelID
-	} else if cfg.Model == "" {
+	// model_id is a config entry name (the ids exposed by /api/config).
+	// A value that names no entry is treated as a raw model string applied
+	// to the default entry, preserving the pre-multi-model contract.
+	if _, ok := cfg.EntryByName(req.ModelID); ok {
+		cfg.DefaultModel = req.ModelID
+	} else if req.ModelID != "default" {
+		entry := cfg.DefaultEntry()
+		entry.Model = req.ModelID
+		cfg.SetDefaultEntry(entry)
+	} else if cfg.DefaultEntry().Model == "" {
 		// Edge case: frontend selected "default" but no model is configured.
 		writeError(w, http.StatusBadRequest, "no default model configured")
 		return
@@ -887,11 +901,11 @@ func (s *Server) handleUpdateSessionModel(w http.ResponseWriter, r *http.Request
 	}
 
 	// Update the runtime default so the next agent turn uses the new model.
-	s.model = cfg.Model
+	s.model = cfg.DefaultEntry().Model
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"ok":       true,
-		"model":    cfg.Model,
+		"model":    cfg.DefaultEntry().Model,
 		"model_id": req.ModelID,
 	})
 }
@@ -927,7 +941,9 @@ func (s *Server) handleUpdateSessionReasoningEffort(w http.ResponseWriter, r *ht
 	}
 
 	cfg, _ := config.Load()
-	cfg.ReasoningEffort = level
+	entry := cfg.DefaultEntry()
+	entry.ReasoningEffort = level
+	cfg.SetDefaultEntry(entry)
 	if err := cfg.Save(); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return

--- a/internal/server/mcp_handlers_test.go
+++ b/internal/server/mcp_handlers_test.go
@@ -378,10 +378,10 @@ func TestToolSearchSettings(t *testing.T) {
 		t.Fatalf("after put: %+v", got)
 	}
 
-	// Written to ~/.octo/config.yaml.
-	raw, err := os.ReadFile(filepath.Join(home, ".octo", "config.yaml"))
+	// Written to ~/.octo/config.yml.
+	raw, err := os.ReadFile(filepath.Join(home, ".octo", "config.yml"))
 	if err != nil {
-		t.Fatalf("config.yaml not written: %v", err)
+		t.Fatalf("config.yml not written: %v", err)
 	}
 	var y struct {
 		Tools struct {

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -92,8 +92,11 @@ func detectOnboardPhase() string {
 
 	// Check if any provider key is available.
 	hasKey := false
-	if cfg.APIKey != "" {
-		hasKey = true
+	for _, e := range cfg.Models {
+		if e.APIKey != "" {
+			hasKey = true
+			break
+		}
 	}
 	if !hasKey {
 		for _, v := range app.Registry {
@@ -136,10 +139,10 @@ type configResponse struct {
 
 type modelConfig struct {
 	ID              string `json:"id"`
-	Type            string `json:"type"`
+	Type            string `json:"type,omitempty"`
 	Model           string `json:"model"`
 	BaseURL         string `json:"base_url"`
-	APIKey          string `json:"api_key,omitempty"`
+	APIKeyMasked    string `json:"api_key_masked,omitempty"`
 	Provider        string `json:"provider,omitempty"`
 	AnthropicFormat bool   `json:"anthropic_format"`
 	PermissionMode  string `json:"permission_mode,omitempty"`
@@ -147,25 +150,42 @@ type modelConfig struct {
 	ShowReasoning   *bool  `json:"show_reasoning,omitempty"`
 }
 
+// defaultEntryIdx returns the index of the default entry: the one named by
+// DefaultModel, else 0.
+func defaultEntryIdx(cfg config.Config) int {
+	for i, e := range cfg.Models {
+		if e.Name == cfg.DefaultModel {
+			return i
+		}
+	}
+	return 0
+}
+
 func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	cfg, _ := config.Load()
 
 	models := []modelConfig{}
-	defaultIdx := 0
+	defaultIdx := defaultEntryIdx(cfg)
 
-	if cfg.Model != "" || cfg.BaseURL != "" {
-		models = append(models, modelConfig{
-			ID:              "default",
-			Type:            "default",
-			Model:           cfg.Model,
-			BaseURL:         cfg.BaseURL,
-			APIKey:          maskKey(cfg.APIKey),
-			Provider:        cfg.Provider,
-			AnthropicFormat: app.IsAnthropicProtocol(cfg.Provider),
-			PermissionMode:  cfg.PermissionMode,
-			ReasoningEffort: cfg.ReasoningEffort,
-			ShowReasoning:   cfg.ShowReasoning,
-		})
+	for i, e := range cfg.Models {
+		m := modelConfig{
+			ID:              e.Name,
+			Model:           e.Model,
+			BaseURL:         e.BaseURL,
+			APIKeyMasked:    maskKey(e.APIKey),
+			Provider:        e.Provider,
+			AnthropicFormat: app.IsAnthropicProtocol(e.Provider),
+			ReasoningEffort: e.ReasoningEffort,
+			ShowReasoning:   e.ShowReasoning,
+		}
+		switch {
+		case i == defaultIdx:
+			m.Type = "default"
+			m.PermissionMode = cfg.PermissionMode
+		case e.Name == cfg.LiteModel:
+			m.Type = "lite"
+		}
+		models = append(models, m)
 	}
 
 	writeJSON(w, http.StatusOK, configResponse{
@@ -223,6 +243,10 @@ func (s *Server) handleTestConfig(w http.ResponseWriter, r *http.Request) {
 	if req.AnthropicFormat {
 		providerName = app.ProviderAnthropic
 	}
+	// The panel doesn't name a vendor; a known endpoint pins the protocol.
+	if v := app.VendorByBaseURL(req.BaseURL); v != "" {
+		providerName = v
+	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
 	defer cancel()
@@ -249,49 +273,73 @@ type saveModelRequest struct {
 	ShowReasoning   *bool  `json:"show_reasoning,omitempty"`
 }
 
-func applyModelRequestToConfig(req saveModelRequest, cfg *config.Config) {
-	cfg.Model = req.Model
-	cfg.BaseURL = req.BaseURL
-	if req.APIKey != "" {
-		cfg.APIKey = req.APIKey
+// applyModelRequestToEntry overlays the request onto an entry. An empty (or
+// still-masked) api_key keeps the stored key — the panel echoes masked keys
+// and omits unchanged ones. The vendor resolves from explicit request field >
+// known endpoint > the entry's current value; only a brand-new entry with no
+// signal at all falls back to the anthropic_format flag.
+func applyModelRequestToEntry(req saveModelRequest, e *config.ModelEntry) {
+	e.Model = req.Model
+	e.BaseURL = req.BaseURL
+	if req.APIKey != "" && !strings.Contains(req.APIKey, "****") {
+		e.APIKey = req.APIKey
 	}
-	if req.Provider != "" {
-		cfg.Provider = req.Provider
-	} else if req.AnthropicFormat {
-		cfg.Provider = "anthropic"
-	} else {
-		cfg.Provider = "openai"
-	}
-	if req.PermissionMode != "" {
-		cfg.PermissionMode = req.PermissionMode
+	switch {
+	case req.Provider != "":
+		e.Provider = req.Provider
+	case app.VendorByBaseURL(req.BaseURL) != "":
+		e.Provider = app.VendorByBaseURL(req.BaseURL)
+	case e.Provider == "" && req.AnthropicFormat:
+		e.Provider = app.ProviderAnthropic
+	case e.Provider == "":
+		e.Provider = app.ProviderOpenAI
 	}
 	if req.ReasoningEffort != "" {
-		cfg.ReasoningEffort = req.ReasoningEffort
+		e.ReasoningEffort = req.ReasoningEffort
 	}
 	if req.ShowReasoning != nil {
-		cfg.ShowReasoning = req.ShowReasoning
+		e.ShowReasoning = req.ShowReasoning
 	}
 }
 
+// handleSaveModelConfig creates a new model entry (POST /api/config/models).
 func (s *Server) handleSaveModelConfig(w http.ResponseWriter, r *http.Request) {
 	var req saveModelRequest
 	if err := readBodyJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	if req.Model == "" {
+		writeError(w, http.StatusBadRequest, "model is required")
+		return
+	}
 
-	cfg, _ := config.Load()
-	applyModelRequestToConfig(req, &cfg)
+	cfg, err := config.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
+		return
+	}
+
+	var entry config.ModelEntry
+	applyModelRequestToEntry(req, &entry)
+	entry.Name = cfg.UniqueName(req.Model)
+	cfg.Models = append(cfg.Models, entry)
+	if cfg.DefaultModel == "" || len(cfg.Models) == 1 {
+		cfg.DefaultModel = entry.Name
+	}
+	if req.PermissionMode != "" {
+		cfg.PermissionMode = req.PermissionMode
+	}
 
 	if err := cfg.Save(); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": "default"})
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": entry.Name})
 }
 
-// handleUpdateModelConfig updates an existing model config (same as save for single-model).
+// handleUpdateModelConfig updates the entry named by {id}.
 func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
@@ -305,8 +353,27 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	cfg, _ := config.Load()
-	applyModelRequestToConfig(req, &cfg)
+	cfg, err := config.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
+		return
+	}
+
+	updated := false
+	for i := range cfg.Models {
+		if cfg.Models[i].Name == id {
+			applyModelRequestToEntry(req, &cfg.Models[i])
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config named %q", id))
+		return
+	}
+	if req.PermissionMode != "" {
+		cfg.PermissionMode = req.PermissionMode
+	}
 
 	if err := cfg.Save(); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
@@ -316,7 +383,8 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
-// handleDeleteModelConfig removes the single model config.
+// handleDeleteModelConfig removes the entry named by {id} and repairs the
+// default/lite references that pointed at it.
 func (s *Server) handleDeleteModelConfig(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
@@ -324,11 +392,35 @@ func (s *Server) handleDeleteModelConfig(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	cfg, _ := config.Load()
-	cfg.Model = ""
-	cfg.BaseURL = ""
-	cfg.APIKey = ""
-	cfg.Provider = ""
+	cfg, err := config.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
+		return
+	}
+
+	kept := cfg.Models[:0]
+	removed := false
+	for _, e := range cfg.Models {
+		if e.Name == id {
+			removed = true
+			continue
+		}
+		kept = append(kept, e)
+	}
+	if !removed {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config named %q", id))
+		return
+	}
+	cfg.Models = kept
+	if cfg.DefaultModel == id {
+		cfg.DefaultModel = ""
+		if len(cfg.Models) > 0 {
+			cfg.DefaultModel = cfg.Models[0].Name
+		}
+	}
+	if cfg.LiteModel == id {
+		cfg.LiteModel = ""
+	}
 
 	if err := cfg.Save(); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
@@ -338,12 +430,32 @@ func (s *Server) handleDeleteModelConfig(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
-// handleSetDefaultModelConfig sets the model as default (no-op in single-model system).
+// handleSetDefaultModelConfig points default_model at the entry named by {id}.
 func (s *Server) handleSetDefaultModelConfig(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
 		writeError(w, http.StatusBadRequest, "missing model id")
 		return
 	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
+		return
+	}
+	if _, ok := cfg.EntryByName(id); !ok {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config named %q", id))
+		return
+	}
+	cfg.DefaultModel = id
+
+	if err := cfg.Save(); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
+		return
+	}
+
+	// The next agent turn should pick up the new default.
+	s.model = cfg.DefaultEntry().Model
+
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -1,0 +1,262 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/config"
+)
+
+func setTestHome(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	return tmp
+}
+
+func seedModels(t *testing.T, cfg config.Config) {
+	t.Helper()
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func getConfigResponse(t *testing.T, srv *Server) configResponse {
+	t.Helper()
+	w := doJSON(t, srv, http.MethodGet, "/api/config", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/config = %d: %s", w.Code, w.Body.String())
+	}
+	var resp configResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func TestConfigModels_GetListsAllEntries(t *testing.T) {
+	setTestHome(t)
+	tru := true
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-main-12345678"},
+			{Name: "kimi", Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://kimi.example", ShowReasoning: &tru},
+			{Name: "cheap", Provider: "deepseek", Model: "deepseek-chat"},
+		},
+		DefaultModel: "kimi",
+		LiteModel:    "cheap",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	resp := getConfigResponse(t, srv)
+	if len(resp.Models) != 3 {
+		t.Fatalf("models = %d, want 3: %+v", len(resp.Models), resp.Models)
+	}
+	if resp.DefaultModelIdx != 1 {
+		t.Errorf("default_model_idx = %d, want 1", resp.DefaultModelIdx)
+	}
+	byID := map[string]modelConfig{}
+	for _, m := range resp.Models {
+		byID[m.ID] = m
+	}
+	if byID["kimi"].Type != "default" || byID["cheap"].Type != "lite" || byID["main"].Type != "" {
+		t.Errorf("type badges wrong: %+v", resp.Models)
+	}
+	if byID["main"].APIKeyMasked == "" || byID["main"].APIKeyMasked == "sk-main-12345678" {
+		t.Errorf("api_key_masked = %q, want masked non-empty", byID["main"].APIKeyMasked)
+	}
+	if !byID["main"].AnthropicFormat || byID["cheap"].AnthropicFormat {
+		t.Errorf("anthropic_format flags wrong: %+v", resp.Models)
+	}
+}
+
+func TestConfigModels_PostAppendsEntry(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models:       []config.ModelEntry{{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6"}},
+		DefaultModel: "main",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/models",
+		`{"model":"kimi-k2.6","base_url":"https://api.moonshot.cn","api_key":"sk-kimi"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST = %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		OK bool   `json:"ok"`
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK || resp.ID == "" {
+		t.Fatalf("response = %+v", resp)
+	}
+
+	cfg, _ := config.Load()
+	if len(cfg.Models) != 2 {
+		t.Fatalf("entries = %d, want 2 — the second card must not overwrite the first", len(cfg.Models))
+	}
+	if cfg.DefaultModel != "main" {
+		t.Errorf("default moved to %q, want main", cfg.DefaultModel)
+	}
+	added, ok := cfg.EntryByName(resp.ID)
+	if !ok {
+		t.Fatalf("entry %q not stored", resp.ID)
+	}
+	if added.APIKey != "sk-kimi" || added.BaseURL != "https://api.moonshot.cn" {
+		t.Errorf("stored entry = %+v", added)
+	}
+	// base_url matches the kimi vendor preset → provider inferred.
+	if added.Provider != "kimi" {
+		t.Errorf("provider = %q, want kimi (inferred from base_url)", added.Provider)
+	}
+}
+
+func TestConfigModels_PostFirstEntryBecomesDefault(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/models",
+		`{"model":"claude-sonnet-4-6","base_url":"https://api.anthropic.com","api_key":"sk-x","provider":"anthropic"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	if len(cfg.Models) != 1 || cfg.DefaultModel != cfg.Models[0].Name {
+		t.Fatalf("first entry must become default: %+v", cfg)
+	}
+	if cfg.Models[0].Provider != "anthropic" {
+		t.Errorf("explicit provider must win: %q", cfg.Models[0].Provider)
+	}
+}
+
+func TestConfigModels_PatchUpdatesAndKeepsKey(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-keep-me"},
+		},
+		DefaultModel: "main",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	// No api_key in the request → stored key survives. A still-masked echo is
+	// also treated as "no change".
+	w := doJSON(t, srv, http.MethodPatch, "/api/config/models/main",
+		`{"model":"claude-opus-4-7","base_url":"","api_key":"sk-k****1234"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	e, _ := cfg.EntryByName("main")
+	if e.Model != "claude-opus-4-7" {
+		t.Errorf("model = %q, want claude-opus-4-7", e.Model)
+	}
+	if e.APIKey != "sk-keep-me" {
+		t.Errorf("api_key = %q, want preserved sk-keep-me", e.APIKey)
+	}
+	// The panel hardcodes anthropic_format=false and sends no provider; an
+	// update with no vendor signal must not clobber the stored provider.
+	if e.Provider != "anthropic" {
+		t.Errorf("provider = %q, want anthropic preserved", e.Provider)
+	}
+
+	if w := doJSON(t, srv, http.MethodPatch, "/api/config/models/ghost", `{"model":"x"}`); w.Code != http.StatusNotFound {
+		t.Errorf("PATCH unknown id = %d, want 404", w.Code)
+	}
+}
+
+func TestConfigModels_DeleteRepairsReferences(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Name: "main", Provider: "anthropic", Model: "m1"},
+			{Name: "kimi", Provider: "kimi", Model: "m2"},
+		},
+		DefaultModel: "main",
+		LiteModel:    "kimi",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	// Deleting the default reassigns it to the first remaining entry.
+	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/main", ""); w.Code != http.StatusOK {
+		t.Fatalf("DELETE = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	if len(cfg.Models) != 1 || cfg.DefaultModel != "kimi" {
+		t.Fatalf("after delete: %+v", cfg)
+	}
+
+	// Deleting the lite entry clears the lite reference.
+	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/kimi", ""); w.Code != http.StatusOK {
+		t.Fatalf("DELETE = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ = config.Load()
+	if len(cfg.Models) != 0 || cfg.LiteModel != "" || cfg.DefaultModel != "" {
+		t.Fatalf("after second delete: %+v", cfg)
+	}
+
+	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/ghost", ""); w.Code != http.StatusNotFound {
+		t.Errorf("DELETE unknown id = %d, want 404", w.Code)
+	}
+}
+
+func TestConfigModels_SetDefault(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Name: "main", Provider: "anthropic", Model: "m1"},
+			{Name: "kimi", Provider: "kimi", Model: "m2"},
+		},
+		DefaultModel: "main",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/kimi/default", ""); w.Code != http.StatusOK {
+		t.Fatalf("set-default = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	if cfg.DefaultModel != "kimi" {
+		t.Fatalf("default = %q, want kimi", cfg.DefaultModel)
+	}
+	if srv.model != "m2" {
+		t.Errorf("runtime model = %q, want m2", srv.model)
+	}
+
+	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/ghost/default", ""); w.Code != http.StatusNotFound {
+		t.Errorf("set-default unknown id = %d, want 404", w.Code)
+	}
+}
+
+func TestConfigModels_UniqueNameGeneration(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	ids := map[string]bool{}
+	for i := 0; i < 3; i++ {
+		w := doJSON(t, srv, http.MethodPost, "/api/config/models",
+			fmt.Sprintf(`{"model":"kimi-k2.6","api_key":"sk-%d"}`, i))
+		if w.Code != http.StatusOK {
+			t.Fatalf("POST #%d = %d: %s", i, w.Code, w.Body.String())
+		}
+		var resp struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatal(err)
+		}
+		if ids[resp.ID] {
+			t.Fatalf("duplicate id %q", resp.ID)
+		}
+		ids[resp.ID] = true
+	}
+	cfg, _ := config.Load()
+	if len(cfg.Models) != 3 {
+		t.Fatalf("entries = %d, want 3", len(cfg.Models))
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -665,13 +665,14 @@ func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, stri
 		return nil, "", fmt.Errorf("load config: %w", err)
 	}
 
-	provName := firstNonEmpty(flagProvider, os.Getenv("OCTO_PROVIDER"), cfg.Provider, "anthropic")
+	entry := cfg.DefaultEntry()
+	provName := firstNonEmpty(flagProvider, os.Getenv("OCTO_PROVIDER"), entry.Provider, "anthropic")
 	model := flagModel
 	if model == "" {
 		model = modelFromEnv(provName)
 	}
-	if model == "" && provName == cfg.Provider {
-		model = cfg.Model
+	if model == "" && provName == entry.Provider {
+		model = entry.Model
 	}
 	if model == "" {
 		model = defaultModelFor(provName)
@@ -702,17 +703,17 @@ func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, stri
 }
 
 // resolveAPIKey returns the API key for the vendor: the provider's env var,
-// else cfg.APIKey when the stored config targets the same provider. An empty
-// key is returned (not an error) so the server can start in onboarding mode
-// and retry once the user completes setup via the Web UI.
+// else the default entry's stored key when it targets the same provider. An
+// empty key is returned (not an error) so the server can start in onboarding
+// mode and retry once the user completes setup via the Web UI.
 func resolveAPIKey(name string, cfg config.Config) (string, error) {
 	if !app.IsKnownVendor(name) {
 		return "", fmt.Errorf("unknown provider %q", name)
 	}
 	envVar := app.VendorAPIKeyEnvVar(name)
 	apiKey := os.Getenv(envVar)
-	if apiKey == "" && cfg.Provider == name {
-		apiKey = cfg.APIKey
+	if entry := cfg.DefaultEntry(); apiKey == "" && entry.Provider == name {
+		apiKey = entry.APIKey
 	}
 	return apiKey, nil
 }
@@ -736,8 +737,8 @@ func defaultModelFor(provider string) string {
 }
 
 func resolveBaseURL(provider string, cfg config.Config) string {
-	if cfg.Provider == provider {
-		return cfg.BaseURL
+	if entry := cfg.DefaultEntry(); entry.Provider == provider {
+		return entry.BaseURL
 	}
 	return ""
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -689,8 +689,8 @@ func TestHandleUpdateSessionReasoningEffort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.ReasoningEffort != "high" {
-		t.Fatalf("reasoning_effort = %q, want high", cfg.ReasoningEffort)
+	if got := cfg.DefaultEntry().ReasoningEffort; got != "high" {
+		t.Fatalf("reasoning_effort = %q, want high", got)
 	}
 }
 

--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -52,7 +52,7 @@ const (
 )
 
 // ToolSearchConfig is the tools-package view of the user's tool_search config.
-// cmd/octo maps the ~/.octo/config.yaml block onto this and installs it via
+// cmd/octo maps the ~/.octo/config.yml block onto this and installs it via
 // SetToolSearchConfig, mirroring SetSandbox / SetMCPRegistry.
 type ToolSearchConfig struct {
 	Mode           ToolSearchMode


### PR DESCRIPTION
PR 1 of 3 implementing [dev-docs/multi-model-config-design.md](https://github.com/Leihb/octo-agent/blob/main/dev-docs/multi-model-config-design.md) (#592).

## What

- **`config.yml` schema**: the single top-level provider/model pair becomes a named `models:` list; `default_model` / `lite_model` are top-level name references. `permission_mode` and other globals stay top-level.
- **Migration**: `Load()` reads `config.yml`, falls back to legacy `config.yaml`, and normalises legacy top-level fields into a one-entry list. First `Save()` writes the new schema and parks the old file as `config.yaml.bak`. Old configs and old session JSON keep working untouched.
- **Real CRUD** for the settings panel (`onboard_config_handlers.go`):
  - `GET /api/config` returns the full entry list — id = entry name, `api_key_masked` (the field `settings.js` was already reading; the Go backend never sent it), `type` derived from `default_model`/`lite_model`, real `default_model_idx`.
  - `POST` appends with a generated unique name — **previously adding a second model silently overwrote the first**.
  - `PATCH {id}` updates without clobbering the stored key (masked echo = no change) or the provider (no-signal update keeps it).
  - `DELETE {id}` repairs default/lite references.
  - `POST {id}/default` actually sets the default — **previously a literal no-op**.
- **CLI**: `--model <entry-name>` selects the whole entry (provider + endpoint + key + reasoning settings). The `octo config` wizard edits the default entry in place — fixing a pre-existing bug where it overwrote the whole file and dropped `permission_mode`/`tools` settings.
- **Vendor inference**: `app.VendorByBaseURL` matches known endpoints (incl. regional variants), replacing the always-`openai` fallback on panel saves and `/api/config/test`.

## What this PR does NOT do (next PRs)

- PR 2: per-session sender binding (`Session.ModelConfig` + sender cache); `PATCH /api/sessions/{id}/model` still applies globally for now.
- PR 3: lite-model compaction.

## Tests

- `internal/config`: legacy→yml migration, shadow order, `.bak` rename, name uniqueness, `SetDefaultEntry` reference repair.
- `internal/server`: CRUD round-trips (append-not-overwrite, masked-key preservation, provider preservation, reference repair on delete, set-default), all against temp $HOME.
- `cmd/octo`: entry-name resolution precedence, wizard preserves other entries + globals.
- Full `go test -race ./...` green; the frontend needed zero changes (it was already id-based — the Ruby-era contract this restores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)