### PR TITLE
feat(tui): denoise the transcript — CC-style quiet scrollback

### DIFF
--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -9,8 +9,9 @@ import (
 )
 
 // outputCardMaxLines caps how many output lines a tool-result card shows
-// before collapsing the rest into a "N more lines" marker.
-const outputCardMaxLines = 12
+// before collapsing the rest into an "… +N lines" marker. Kept small (Claude
+// Code shows ~3) — the full output went to the model, the card is a glimpse.
+const outputCardMaxLines = 4
 
 // cardVerbFor maps a tool name to the verb shown in its result card, or ""
 // for tools that render as a terse one-line status instead of a card. This is

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -284,13 +284,12 @@ type tuiModel struct {
 	// flushed to the terminal scrollback via tea.Println.
 	partial strings.Builder
 
-	// thinkPartial holds the in-progress reasoning trace not yet committed to
-	// the scrollback. Complete lines are flushed dimmed; the trailing partial
-	// line is flushed when the answer (or a tool event) begins.
-	thinkPartial strings.Builder
-	// thinkingStarted marks that this turn's reasoning trace has begun, so the
-	// 💭 prefix is emitted once rather than per line. Reset each turn.
-	thinkingStarted bool
+	// turnOutChars counts this turn's streamed output characters (reasoning +
+	// answer text + tool arguments). The reasoning trace itself never lands in
+	// the scrollback — over a long agentic turn it would dominate the transcript
+	// — the count just feeds the activity line's "↑ ~N tokens" readout so the
+	// wait still reads as progress (Claude Code style).
+	turnOutChars int
 
 	// toolInput caches each tool call's input from EventToolStarted so the
 	// matching EventToolDone can render a card (tool_result events don't carry
@@ -355,6 +354,10 @@ type tuiModel struct {
 	// Update cycle. In inline mode, committed output goes to the terminal
 	// scrollback above the live View() area — no alt-screen buffer needed.
 	printlnBuf []string
+	// lastPrintBlank tracks whether the last queued scrollback line was blank,
+	// so printlnBlock can separate block-level items with exactly one blank
+	// line instead of stacking them edge-to-edge.
+	lastPrintBlank bool
 
 	// historyReplayed guards the one-time replay of a resumed session's prior
 	// turns into the scrollback. Done on the first WindowSizeMsg so markdown
@@ -529,8 +532,7 @@ func (m *tuiModel) startTurnEchoRestore(line, echo, restore string) tea.Cmd {
 	m.spinnerFrame = 0
 	m.running = nil
 	m.partial.Reset()
-	m.thinkPartial.Reset()
-	m.thinkingStarted = false
+	m.turnOutChars = 0
 	m.toolStreamName, m.toolStreamID, m.toolStreamBytes = "", "", 0
 	m.clearSuggestion() // a new turn supersedes any pending follow-up
 	ctx, cancel := context.WithCancel(context.Background())
@@ -566,7 +568,7 @@ func (m *tuiModel) commitEcho() {
 	if m.echoPending == "" {
 		return
 	}
-	m.println(m.echoPending)
+	m.printlnBlock(m.echoPending)
 	m.echoPending = ""
 	m.echoRestore = ""
 }
@@ -609,7 +611,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.flushPrints()
 
 	case noticeMsg:
-		m.println(noticeStyle.Render(msg.text))
+		m.printlnBlock(noticeStyle.Render(msg.text))
 		return m, m.flushPrints()
 
 	case mcpReadyMsg:
@@ -624,7 +626,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.cfg.tools = tools.DefaultToolsFor(m.cfg.a.Model)
 			}
 			if !m.cfg.verbosity.quiet() {
-				m.println(noticeStyle.Render(fmt.Sprintf("● MCP ready — %d server(s) connected", msg.reg.Len())))
+				m.printlnBlock(noticeStyle.Render(fmt.Sprintf("● MCP ready — %d server(s) connected", msg.reg.Len())))
 			}
 		}
 		return m, m.flushPrints()
@@ -633,7 +635,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Print a concise, Claude-Code-style scrollback notice so the user
 		// sees the completion even when the model-facing <system-reminder>
 		// is folded into a later turn.
-		notice := bgDoneStyle.Render(fmt.Sprintf("● Background process %s (`%s`) %s", msg.e.ID, msg.e.Command, msg.e.Status))
+		m.printlnBlock(bgDoneStyle.Render(fmt.Sprintf("● Background process %s (`%s`) %s", msg.e.ID, msg.e.Command, msg.e.Status)))
 		// Idle auto-turn: if no turn is running and nothing is queued, drain the
 		// inbox (which holds the full <system-reminder> notice) and start a
 		// turn so the model sees the completion immediately — matching the plain
@@ -641,10 +643,10 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !m.turnRunning && len(m.queue) == 0 {
 			if items := m.a.Inbox.Drain(); len(items) > 0 {
 				s := strings.Join(agent.Texts(items), "\n\n")
-				return m, tea.Sequence(tea.Println(notice), m.startTurnEcho(s, ""))
+				return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(s, ""))
 			}
 		}
-		return m, tea.Sequence(tea.Println(notice), m.flushPrints())
+		return m, m.flushPrints()
 
 	case subAgentEventMsg:
 		m.handleSubAgentEvent(msg.ev)
@@ -695,12 +697,12 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Flush any trailing assistant block (markdown-rendered); then render
 		// the cache/error footer.
 		if s, ok := m.flushTextString(); ok {
-			m.println(s)
+			m.printlnBlock(s)
 		}
 		if msg.err != nil && msg.err != context.Canceled {
-			m.println(errorStyle.Render("error: " + msg.err.Error()))
+			m.printlnBlock(errorStyle.Render("error: " + msg.err.Error()))
 		} else if c := cacheLine(m.cfg.verbosity, msg.reply); c != "" {
-			m.println(c)
+			m.printlnBlock(c)
 		}
 		// turnEndedMsg only marks the end of the agent loop's output; the turn
 		// goroutine is still alive until turnFinishedMsg. Do NOT reset turnRunning
@@ -900,14 +902,11 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 	// Promote the deferred user echo above this turn's first output so the
 	// transcript order (your message → reply) is preserved.
 	m.commitEcho()
-	// The reasoning trace precedes the answer; flush any buffered thinking
-	// before rendering the first non-thinking output of the turn.
-	if ev.Kind != agent.EventThinkingDelta {
-		m.flushThinking()
-	}
 	switch ev.Kind {
 	case agent.EventThinkingDelta:
-		m.appendThinking(ev.Text)
+		// The reasoning trace stays out of the scrollback; only its size feeds
+		// the live activity line's token readout.
+		m.turnOutChars += len(ev.Text)
 		return
 
 	case agent.EventToolInputDelta:
@@ -920,9 +919,11 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 		}
 		m.toolStreamName = ev.ToolName
 		m.toolStreamBytes += len(ev.InputDelta)
+		m.turnOutChars += len(ev.InputDelta)
 		return
 
 	case agent.EventTextDelta:
+		m.turnOutChars += len(ev.Text)
 		m.appendText(ev.Text)
 		return
 
@@ -934,27 +935,30 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 			m.toolInput = map[string]map[string]any{}
 		}
 		m.toolInput[ev.ToolID] = ev.Input
-		// Card tools render their whole story in the done card; suppress the
-		// started line and instead show a live spinner indicator in the View
-		// region (animated by the ticker) until the done event commits the card.
-		if m.rendersCard(ev.ToolName) {
-			m.running = &runningTool{
-				verb:   cardVerbFor(ev.ToolName),
-				target: cardTargetFor(ev.ToolName, ev.Input),
-				start:  time.Now(),
-			}
+		// The plain path keeps the dense one-liner transcript (started line now,
+		// ✓/✗ later) — it matches the headless renderer.
+		if m.cfg.plain {
+			m.commitToolLine(fmt.Sprintf("↳ %s: %s", ev.ToolName, summariseInput(ev.Input)))
 			return
 		}
-		m.commitToolLine(fmt.Sprintf("↳ %s: %s", ev.ToolName, summariseInput(ev.Input)))
+		// Rich TUI: every tool suppresses its started line and shows a live
+		// spinner indicator in the View region (animated by the ticker) until
+		// the done event commits the card (card tools) or status line (others).
+		verb, target := cardVerbFor(ev.ToolName), ""
+		if verb == "" {
+			verb, target = ev.ToolName, summariseInput(ev.Input)
+		} else {
+			target = cardTargetFor(ev.ToolName, ev.Input)
+		}
+		m.running = &runningTool{verb: verb, target: target, start: time.Now()}
 		return
 
 	case agent.EventToolProgress:
-		// Card tools defer all output to the done card; dropping progress avoids
-		// noise above the card.
-		if m.rendersCard(ev.ToolName) {
-			return
+		// Rich TUI: progress is deferred to the done card / status line so the
+		// transcript stays quiet; the live spinner already shows activity.
+		if m.cfg.plain {
+			m.commitToolLine("│ " + ev.Chunk)
 		}
-		m.commitToolLine("│ " + ev.Chunk)
 		return
 
 	case agent.EventToolDone:
@@ -965,7 +969,11 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 			m.commitToolLine(renderToolCard(ev.ToolName, input, ev.Output, false))
 			return
 		}
-		m.commitToolLine(fmt.Sprintf("↳ %s ✓", ev.ToolName))
+		if m.cfg.plain {
+			m.commitToolLine(fmt.Sprintf("↳ %s ✓", ev.ToolName))
+			return
+		}
+		m.commitToolLine(tui.RenderToolStatus(ev.ToolName, summariseInput(input), false, ""))
 		return
 
 	case agent.EventToolError:
@@ -976,7 +984,11 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 			m.commitToolLine(renderToolCard(ev.ToolName, input, firstNonEmpty(ev.Output, ev.Err), true))
 			return
 		}
-		m.commitToolLine(toolErrStyle.Render(fmt.Sprintf("↳ %s ✗ — %s", ev.ToolName, truncate1Line(ev.Err))))
+		if m.cfg.plain {
+			m.commitToolLine(toolErrStyle.Render(fmt.Sprintf("↳ %s ✗ — %s", ev.ToolName, truncate1Line(ev.Err))))
+			return
+		}
+		m.commitToolLine(tui.RenderToolStatus(ev.ToolName, summariseInput(input), true, truncate1Line(ev.Err)))
 		return
 
 	case agent.EventCompactStarted:
@@ -1003,7 +1015,7 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 		// Only announce a real reduction; a no-op (summary failed / unchanged)
 		// clears the indicator silently rather than implying work was done.
 		if c := ev.Compact; c != nil && c.AfterTokens > 0 && c.AfterTokens < c.BeforeTokens {
-			m.println(noticeStyle.Render(fmt.Sprintf(
+			m.printlnBlock(noticeStyle.Render(fmt.Sprintf(
 				"✦ compacted context · folded %d message(s) · ~%s → ~%s tokens",
 				c.FoldedMsgs, humanTokens(c.BeforeTokens), humanTokens(c.AfterTokens))))
 		}
@@ -1017,13 +1029,13 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 		// paragraph stays above the steer line (e.g. when a steer lands right
 		// after the model finished a text answer and the turn loops to answer it).
 		if s, ok := m.flushTextString(); ok {
-			m.println(s)
+			m.printlnBlock(s)
 		}
 		// Skip <system-reminder> blocks (model-facing context) and empty text
 		// (an image-only steer carries its payload in blocks, not Messages).
 		for _, s := range ev.Messages {
 			if s != "" && !strings.HasPrefix(s, "<system-reminder>") {
-				m.println(userEchoStyle.Render("> ") + s)
+				m.printlnBlock(userEchoStyle.Render("> ") + s)
 			}
 		}
 		// pendingSteer is FIFO and mirrors the inbox, so the drained messages
@@ -1043,53 +1055,6 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 // plain/headless path; otherwise card tools (cardVerbFor) get a card.
 func (m *tuiModel) rendersCard(toolName string) bool {
 	return !m.cfg.plain && cardVerbFor(toolName) != ""
-}
-
-// appendText buffers a streamed text delta into m.partial.  The partial is
-// rendered live in View() so the user sees tokens arrive in real time.
-// When a complete block boundary is found (blank line outside a code fence),
-// that prefix is promoted to the scrollback via println/flushPrints so it
-// becomes part of the terminal's native scrollback history.
-// appendThinking buffers a streamed reasoning-trace delta and commits each
-// completed line to the scrollback, dimmed, so the trace stays in the
-// transcript above the answer. The trailing partial line is held until
-// flushThinking (called when the answer or a tool event begins).
-func (m *tuiModel) appendThinking(text string) {
-	m.thinkPartial.WriteString(text)
-	buf := m.thinkPartial.String()
-	for {
-		idx := strings.IndexByte(buf, '\n')
-		if idx < 0 {
-			break
-		}
-		m.println(m.styleThinking(buf[:idx]))
-		buf = buf[idx+1:]
-	}
-	m.thinkPartial.Reset()
-	m.thinkPartial.WriteString(buf)
-}
-
-// flushThinking commits any buffered trailing reasoning line and ends the
-// current reasoning block. A turn's agentic loop produces a fresh block of
-// reasoning before each model round-trip (between tool calls); resetting
-// thinkingStarted here means every block gets its own 💭 marker, matching the
-// plain/headless renderer.
-func (m *tuiModel) flushThinking() {
-	if m.thinkPartial.Len() > 0 {
-		m.println(m.styleThinking(m.thinkPartial.String()))
-		m.thinkPartial.Reset()
-	}
-	m.thinkingStarted = false
-}
-
-// styleThinking renders one reasoning line dimmed, prefixing 💭 on the first
-// line of each reasoning block so the block reads as one unit.
-func (m *tuiModel) styleThinking(line string) string {
-	if !m.thinkingStarted {
-		m.thinkingStarted = true
-		return thinkingStyle.Render("💭 " + line)
-	}
-	return thinkingStyle.Render("   " + line)
 }
 
 // replayHistoryLines renders a resumed session's prior turns into scrollback
@@ -1185,6 +1150,11 @@ func replayToolLine(use, result agent.ContentBlock) string {
 	return label + " ✓"
 }
 
+// appendText buffers a streamed text delta into m.partial. The partial is
+// rendered live in View() so the user sees tokens arrive in real time. When a
+// complete block boundary is found (blank line outside a code fence), that
+// prefix is promoted to the scrollback via printlnBlock/flushPrints so it
+// becomes part of the terminal's native scrollback history.
 func (m *tuiModel) appendText(text string) {
 	m.partial.WriteString(text)
 
@@ -1207,7 +1177,7 @@ func (m *tuiModel) appendText(text string) {
 	}
 	m.partial.Reset()
 	m.partial.WriteString(rest)
-	m.println(m.md.render(commit, m.width))
+	m.printlnBlock(m.md.render(commit, m.width))
 }
 
 // flushText commits whatever assistant text is still buffered (the final or
@@ -1218,7 +1188,7 @@ func (m *tuiModel) flushText() tea.Cmd {
 	if !ok {
 		return nil
 	}
-	m.println(s)
+	m.printlnBlock(s)
 	return nil
 }
 
@@ -1241,9 +1211,9 @@ func (m *tuiModel) flushTextString() (string, bool) {
 // the tool line/card.
 func (m *tuiModel) commitToolLine(line string) {
 	if s, ok := m.flushTextString(); ok {
-		m.println(s)
+		m.printlnBlock(s)
 	}
-	m.println(line)
+	m.printlnBlock(line)
 }
 
 // println queues a line for output to the terminal scrollback via
@@ -1251,6 +1221,21 @@ func (m *tuiModel) commitToolLine(line string) {
 // In inline mode, committed lines scroll naturally above the live View() area.
 func (m *tuiModel) println(line string) {
 	m.printlnBuf = append(m.printlnBuf, line)
+	m.lastPrintBlank = line == ""
+}
+
+// printlnBlock queues a block-level item (card, message echo, markdown block,
+// notice) preceded by one blank separator line, so blocks breathe instead of
+// stacking edge-to-edge (Claude Code style). Plain mode keeps the dense
+// line-oriented layout, matching the headless renderer.
+func (m *tuiModel) printlnBlock(line string) {
+	if line == "" {
+		return
+	}
+	if !m.cfg.plain && !m.lastPrintBlank {
+		m.println("")
+	}
+	m.println(line)
 }
 
 // flushPrints returns a Cmd that prints all queued lines to the terminal
@@ -1276,7 +1261,7 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 	// the turn (e.g. typed after the last loop iteration) are printed now so
 	// they don't vanish from the transcript.
 	for _, s := range m.pendingSteer {
-		m.println(userEchoStyle.Render("> ") + s)
+		m.printlnBlock(userEchoStyle.Render("> ") + s)
 	}
 	m.pendingSteer = nil
 
@@ -1292,7 +1277,7 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 		it := pendingFromInbox(items)
 		for _, line := range strings.Split(it.text, "\n\n") {
 			if line != "" && !strings.HasPrefix(line, "<system-reminder>") {
-				m.println(userEchoStyle.Render("> ") + line)
+				m.printlnBlock(userEchoStyle.Render("> ") + line)
 			}
 		}
 		m.queue = append([]pendingItem{it}, m.queue...)

--- a/cmd/octo/tuirepl_p3_test.go
+++ b/cmd/octo/tuirepl_p3_test.go
@@ -52,14 +52,17 @@ func TestTUI_RunningToolIndicator(t *testing.T) {
 	}
 }
 
-func TestTUI_NonCardToolNoIndicator(t *testing.T) {
+func TestTUI_NonCardToolIndicator(t *testing.T) {
 	m := newTestModel()
 	m.handleEvent(agent.AgentEvent{
 		Kind: agent.EventToolStarted, ToolID: "c1", ToolName: "sub_agent",
 		Input: map[string]any{},
 	})
-	if m.running != nil {
-		t.Error("non-card tools commit a started line; they must not set the live indicator")
+	if m.running == nil || m.running.verb != "sub_agent" {
+		t.Errorf("non-card tools suppress their started line and show the live indicator instead; got %+v", m.running)
+	}
+	if len(m.printlnBuf) != 0 {
+		t.Errorf("started must not commit a scrollback line; got %v", m.printlnBuf)
 	}
 }
 

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -177,7 +177,8 @@ func TestTUI_FirstOutputCommitsEcho(t *testing.T) {
 	if m.echoPending != "" {
 		t.Error("first output should commit (clear) the deferred echo")
 	}
-	if len(m.printlnBuf) != 1 {
+	// printlnBlock prefixes the echo with one blank separator line.
+	if len(m.printlnBuf) == 0 || !strings.Contains(m.printlnBuf[len(m.printlnBuf)-1], "hello") {
 		t.Fatalf("the echo should be queued to the scrollback, got %v", m.printlnBuf)
 	}
 }
@@ -211,47 +212,81 @@ func TestTUI_ToolInputStreamProgress(t *testing.T) {
 	}
 }
 
-// Reasoning deltas must commit to the scrollback (dimmed) before the answer,
-// with the 💭 marker on the first line only — so the trace stays in the
-// transcript above the reply instead of vanishing into a spinner.
-func TestTUI_ThinkingRendersBeforeAnswer(t *testing.T) {
+// The reasoning trace stays out of the scrollback — only its size feeds the
+// live activity line's "↑ ~N tokens" readout, so a long agentic turn doesn't
+// fill the transcript with thinking text.
+func TestTUI_ThinkingStaysOutOfScrollback(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true
 
-	// One complete thinking line, then a partial; the answer flushes the rest.
 	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: "step one\n"})
-	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: "step two"})
-	m.handleEvent(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "answer"})
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: strings.Repeat("x", 3999)})
 
-	joined := strings.Join(m.printlnBuf, "\n")
-	if !strings.Contains(joined, "step one") || !strings.Contains(joined, "step two") {
-		t.Fatalf("thinking trace should be committed to scrollback; got %q", joined)
+	if joined := strings.Join(m.printlnBuf, "\n"); joined != "" {
+		t.Fatalf("thinking must not reach the scrollback; got %q", joined)
 	}
-	if n := strings.Count(joined, "💭"); n != 1 {
-		t.Errorf("💭 should prefix only the first line of the block; got %d in %q", n, joined)
+	if m.turnOutChars != 4008 {
+		t.Errorf("turnOutChars = %d, want 4008", m.turnOutChars)
 	}
-	if m.thinkPartial.Len() != 0 {
-		t.Errorf("thinking buffer should be flushed once the answer starts; still holds %q", m.thinkPartial.String())
+	// The wait-on-model activity line shows the running token estimate (chars/4).
+	out := m.View()
+	if !strings.Contains(out, "↑ ~1.0k tokens") {
+		t.Errorf("view should show the output-token readout; got:\n%s", out)
 	}
 }
 
-// A turn's agentic loop produces a fresh reasoning block before each model
-// round-trip (between tool calls); every block must get its own 💭, not just
-// the turn's first one.
-func TestTUI_ThinkingMarkerPerBlock(t *testing.T) {
+// A new turn resets the output-token readout.
+func TestTUI_TurnStartResetsOutChars(t *testing.T) {
+	m := newTestModel()
+	m.turnOutChars = 999
+	_ = m.startTurnEcho("hi", "hi")
+	if m.turnOutChars != 0 {
+		t.Errorf("turnOutChars after turn start = %d, want 0", m.turnOutChars)
+	}
+}
+
+// Non-card tools (MCP tools, sub_agent, …) commit a single header-style status
+// line on completion — no started line, no progress lines.
+func TestTUI_NonCardToolOneLine(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true
 
-	// Block 1 → a tool runs → block 2 → the answer.
-	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: "first thought\n"})
-	m.handleEvent(agent.AgentEvent{Kind: agent.EventToolStarted, ToolID: "c1", ToolName: "terminal", Input: map[string]any{"command": "ls"}})
-	m.handleEvent(agent.AgentEvent{Kind: agent.EventToolDone, ToolID: "c1", ToolName: "terminal", Output: "ok"})
-	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: "second thought\n"})
-	m.handleEvent(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "answer"})
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventToolStarted, ToolID: "c1", ToolName: "mcp_thing", Input: map[string]any{"q": "x"}})
+	if len(m.printlnBuf) != 0 {
+		t.Fatalf("started must not print; got %v", m.printlnBuf)
+	}
+	if m.running == nil || m.running.verb != "mcp_thing" {
+		t.Fatalf("started should set the live indicator; got %+v", m.running)
+	}
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventToolProgress, ToolID: "c1", ToolName: "mcp_thing", Chunk: "partial"})
+	if len(m.printlnBuf) != 0 {
+		t.Fatalf("progress must not print; got %v", m.printlnBuf)
+	}
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventToolDone, ToolID: "c1", ToolName: "mcp_thing", Output: "done"})
 
-	joined := strings.Join(m.printlnBuf, "\n")
-	if n := strings.Count(joined, "💭"); n != 2 {
-		t.Errorf("each reasoning block should get a 💭; got %d in:\n%s", n, joined)
+	joined := stripANSI(strings.Join(m.printlnBuf, "\n"))
+	if !strings.Contains(joined, "● mcp_thing(q=x)") {
+		t.Errorf("done should commit one status line; got %q", joined)
+	}
+	if m.running != nil {
+		t.Error("done should clear the live indicator")
+	}
+}
+
+// Block-level scrollback items are separated by exactly one blank line; the
+// separator is not duplicated when the previous line is already blank.
+func TestTUI_PrintlnBlockSeparation(t *testing.T) {
+	m := newTestModel()
+	m.printlnBlock("first")
+	m.printlnBlock("second")
+	want := []string{"", "first", "", "second"}
+	if len(m.printlnBuf) != len(want) {
+		t.Fatalf("printlnBuf = %q, want %q", m.printlnBuf, want)
+	}
+	for i, w := range want {
+		if m.printlnBuf[i] != w {
+			t.Fatalf("printlnBuf[%d] = %q, want %q", i, m.printlnBuf[i], w)
+		}
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -36,7 +36,6 @@ var (
 	queueStyle        = lipgloss.NewStyle().Foreground(tui.ColAccent)
 	modalStyle        = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
 	hintStyle         = lipgloss.NewStyle().Foreground(tui.ColDimmer).Italic(true)
-	thinkingStyle     = lipgloss.NewStyle().Foreground(tui.ColDim).Italic(true)
 	userEchoStyle     = lipgloss.NewStyle().Foreground(tui.ColUserMsg).Bold(true)
 	pendingSteerStyle = lipgloss.NewStyle().Foreground(tui.ColMuted)
 	complSelStyle     = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
@@ -970,7 +969,7 @@ func (m *tuiModel) View() string {
 		// thinking spinner so the user can tell the turn isn't idle. While
 		// text is actively streaming (partial non-empty), the text itself is
 		// the feedback, so the spinner stays out of the way.
-		b.WriteString(m.spinnerLine(m.thinkingPhrase(), m.turnStart))
+		b.WriteString(m.thinkingLine())
 		b.WriteByte('\n')
 	}
 
@@ -1219,16 +1218,11 @@ func (m *tuiModel) modalView() string {
 }
 
 // cacheLine formats the per-turn cache footer, or "" when nothing to show.
-// Mirrors plainView's rule: shown when cache moved, always in verbose.
+// Verbose-only: at default verbosity the footer would land after every turn
+// (cache moves on essentially every Anthropic-protocol call) and the status
+// bar's ctx% already covers the at-a-glance need.
 func cacheLine(v verbosity, reply agent.Reply) string {
-	if v.quiet() {
-		return ""
-	}
-	show := reply.CacheReadTokens > 0 || reply.CacheWriteTokens > 0
-	if v.verbose() {
-		show = true
-	}
-	if !show {
+	if !v.verbose() {
 		return ""
 	}
 	return noticeStyle.Render(fmt.Sprintf("  ⓘ cache: %d read, %d write (in %d / out %d)",
@@ -1248,4 +1242,17 @@ func (m *tuiModel) thinkingPhrase() string {
 func (m *tuiModel) spinnerLine(label string, since time.Time) string {
 	frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
 	return hintStyle.Render(fmt.Sprintf("%c %s (%s)", frame, label, time.Since(since).Round(time.Second)))
+}
+
+// thinkingLine is the wait-on-the-model activity line. Since the reasoning
+// trace itself is not shown, the line carries the turn's elapsed time and a
+// rough output-token count ("↑ ~N tokens", chars/4) so a long silent stretch
+// still reads as the model working, Claude Code style.
+func (m *tuiModel) thinkingLine() string {
+	frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
+	meta := time.Since(m.turnStart).Round(time.Second).String()
+	if m.turnOutChars > 0 {
+		meta += fmt.Sprintf(" · ↑ ~%s tokens", humanTokens(m.turnOutChars/4))
+	}
+	return hintStyle.Render(fmt.Sprintf("%c %s… (%s)", frame, m.thinkingPhrase(), meta))
 }

--- a/dev-docs/tui-ux-upgrade-design.md
+++ b/dev-docs/tui-ux-upgrade-design.md
@@ -28,7 +28,7 @@
   │  ● Run(go test ./...)  ← 输出预览卡片                              │
   │  完成。                                                            │
   ├─ View() — 钉在底部，不随内容滚动 ──────────────────────────────────┤
-  │  ⠹ Thinking (2.3s)                    ← live 区                    │
+  │  ⠹ Thinking… (2.3s · ↑ ~1.2k tokens)  ← live 区                    │
   │  ┌ queue (2) ──────────────┐          ← 边框面板                   │
   │  │ 1. add error handling    │                                      │
   │  │ 2. write tests           │                                      │
@@ -77,10 +77,22 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 | AgentEvent | 处理 |
 |---|---|
-| `EventTextDelta` | 累积到 `m.partial`；block 边界经 glamour 渲染后 `m.println()` |
-| `EventToolStarted` | 卡片工具：`m.running` 设为 live spinner；非卡片：`m.println("↳ tool: input")` |
-| `EventToolProgress` | 卡片工具：忽略；非卡片：`m.println("│ chunk")` |
-| `EventToolDone/Error` | 清除 `m.running`；卡片：`renderToolCard()` → `m.println()`；非卡片：`m.println("↳ tool ✓/✗")` |
+| `EventThinkingDelta` | 不进 scrollback；只累积 `turnOutChars`，喂给 live 区 `thinkingLine` 的「↑ ~N tokens」读数 |
+| `EventTextDelta` | 累积到 `m.partial`；block 边界经 glamour 渲染后 `m.printlnBlock()` |
+| `EventToolStarted` | 所有工具：`m.running` 设为 live spinner（不提交 started 行）；`--plain` 保留 `↳ tool: input` 行 |
+| `EventToolProgress` | 忽略（live spinner 已示活动）；`--plain` 保留 `│ chunk` 行 |
+| `EventToolDone/Error` | 清除 `m.running`；卡片：`renderToolCard()`；非卡片：`tui.RenderToolStatus` 单行 `● tool(input)`；`--plain` 保留 `↳ tool ✓/✗` |
+
+### 降噪规则（对标 Claude Code）
+
+- **思考过程不落盘**：reasoning trace 不进 scrollback，等待期的活动行显示
+  `⠹ Thinking… (12s · ↑ ~3.2k tokens)`（token 数 = 本回合输出字符 / 4 估算）。
+- **块间空行**：所有 block 级内容（用户 echo、markdown block、卡片、通知）经
+  `printlnBlock()` 提交，块与块之间恰好一个空行；`--plain` 保持紧凑行布局。
+- **卡片行数上限**：输出卡 `outputCardMaxLines = 4`；diff 卡每侧（删除/新增）
+  `diffCardMaxRows = 6`；折叠标记统一为 `… +N lines`。
+- **cache 行仅 verbose**：`ⓘ cache: …` 回合页脚只在 `--verbose` 下输出，默认
+  靠状态栏 ctx% 感知。
 
 ---
 

--- a/internal/tui/diffcard.go
+++ b/internal/tui/diffcard.go
@@ -61,6 +61,16 @@ func (c Card) Render() string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
+// diffCardMaxRows caps each side (removed, added) of an edit_file diff card;
+// the remainder collapses into an "… +N lines" row so a large edit doesn't
+// fill the screen. Per side rather than total, so a big rewrite still shows
+// the head of both the old and the new text.
+const diffCardMaxRows = 6
+
+// ellipsisKind marks a Line as a collapsed-rows "… +N lines" marker rather
+// than diff content; renderRow draws it dimmed, with no wash or highlighting.
+const ellipsisKind = '…'
+
 // RenderEditCard builds and renders a card for an `edit_file` invocation.
 // It reads filePath to compute the line number where newString lands; if
 // the read fails (file moved, perms, etc.) the card still renders, just
@@ -77,20 +87,8 @@ func RenderEditCard(filePath, oldString, newString string) string {
 	}
 
 	lines := make([]Line, 0, removed+added)
-	for i, t := range splitLinesNoTrail(oldString) {
-		num := 0
-		if startLine > 0 {
-			num = startLine + i
-		}
-		lines = append(lines, Line{Num: num, Kind: '-', Text: t})
-	}
-	for i, t := range splitLinesNoTrail(newString) {
-		num := 0
-		if startLine > 0 {
-			num = startLine + i
-		}
-		lines = append(lines, Line{Num: num, Kind: '+', Text: t})
-	}
+	lines = appendDiffRows(lines, splitLinesNoTrail(oldString), '-', startLine)
+	lines = appendDiffRows(lines, splitLinesNoTrail(newString), '+', startLine)
 
 	c := Card{
 		Verb:     "Update",
@@ -101,6 +99,27 @@ func RenderEditCard(filePath, oldString, newString string) string {
 		Language: GuessLanguage(filePath),
 	}
 	return c.Render()
+}
+
+// appendDiffRows appends one side of the diff, capped at diffCardMaxRows with
+// an ellipsis row for the remainder. Rows are numbered from startLine (0 =
+// no number column).
+func appendDiffRows(lines []Line, src []string, kind rune, startLine int) []Line {
+	shown, extra := src, 0
+	if len(src) > diffCardMaxRows {
+		shown, extra = src[:diffCardMaxRows], len(src)-diffCardMaxRows
+	}
+	for i, t := range shown {
+		num := 0
+		if startLine > 0 {
+			num = startLine + i
+		}
+		lines = append(lines, Line{Num: num, Kind: kind, Text: t})
+	}
+	if extra > 0 {
+		lines = append(lines, Line{Kind: ellipsisKind, Text: "… +" + pluralise(extra, "line")})
+	}
+	return lines
 }
 
 // ─── internals ────────────────────────────────────────────────────────────
@@ -172,6 +191,9 @@ func renderSummary(added, removed int) string {
 }
 
 func renderRow(ln Line, language string, dark bool) string {
+	if ln.Kind == ellipsisKind {
+		return "  " + outMore.Render(ln.Text)
+	}
 	noCol := renderLineNo(ln)
 	mark := renderMark(ln.Kind)
 	body := expandTabs(ln.Text)

--- a/internal/tui/outputcard.go
+++ b/internal/tui/outputcard.go
@@ -16,7 +16,7 @@ var (
 
 // RenderOutputCard renders a tool's textual output as a card: a header row
 // (● verb(target)) above the output, each line behind a "│" gutter, capped to
-// maxLines (<=0 = no cap) with a "└ N more lines" marker for the remainder.
+// maxLines (<=0 = no cap) with an "… +N lines" marker for the remainder.
 // isErr tints the bullet red. Empty output renders "(no output)". The trailing
 // newline is omitted so callers control spacing (mirrors Card.Render).
 // When language is non-empty, each line is syntax-highlighted with Chroma.
@@ -49,7 +49,22 @@ func RenderOutputCard(verb, target, output string, maxLines int, isErr bool, lan
 		b.WriteString("\n  " + outGutter.String() + " " + body)
 	}
 	if extra > 0 {
-		b.WriteString("\n  " + outMore.Render("└ "+pluralise(extra, "more line")))
+		b.WriteString("\n  " + outMore.Render("… +"+pluralise(extra, "line")))
 	}
 	return b.String()
+}
+
+// RenderToolStatus renders a tool call that has no body card as a single
+// header-style line — "● name(target)" — so card and non-card tools share one
+// visual language. isErr tints the bullet red and appends errText dimmed.
+func RenderToolStatus(name, target string, isErr bool, errText string) string {
+	bullet := outBullet
+	if isErr {
+		bullet = outBulletErr
+	}
+	s := fmt.Sprintf("%s %s", bullet, headerVerb.Render(fmt.Sprintf("%s(%s)", name, target)))
+	if isErr && errText != "" {
+		s += " " + outMore.Render("— "+errText)
+	}
+	return s
 }

--- a/internal/tui/outputcard_test.go
+++ b/internal/tui/outputcard_test.go
@@ -20,8 +20,8 @@ func TestRenderOutputCard_CapsWithMoreMarker(t *testing.T) {
 		lines = append(lines, "line")
 	}
 	got := RenderOutputCard("Search", "foo", strings.Join(lines, "\n"), 5, false, "")
-	if !strings.Contains(got, "15 more lines") {
-		t.Errorf("expected '15 more lines' marker; got:\n%s", got)
+	if !strings.Contains(got, "… +15 lines") {
+		t.Errorf("expected '… +15 lines' marker; got:\n%s", got)
 	}
 	// Exactly 5 body lines shown (count the gutter glyph occurrences).
 	if n := strings.Count(got, "│"); n != 5 {
@@ -38,8 +38,19 @@ func TestRenderOutputCard_EmptyOutput(t *testing.T) {
 
 func TestRenderOutputCard_SingularMoreLine(t *testing.T) {
 	got := RenderOutputCard("Run", "x", "a\nb\nc", 2, false, "")
-	if !strings.Contains(got, "1 more line") || strings.Contains(got, "1 more lines") {
-		t.Errorf("expected singular '1 more line'; got:\n%s", got)
+	if !strings.Contains(got, "… +1 line") || strings.Contains(got, "1 lines") {
+		t.Errorf("expected singular '… +1 line'; got:\n%s", got)
+	}
+}
+
+func TestRenderToolStatus(t *testing.T) {
+	got := RenderToolStatus("mcp_thing", "q=x", false, "")
+	if !strings.Contains(got, "mcp_thing(q=x)") {
+		t.Errorf("missing header in:\n%s", got)
+	}
+	gotErr := RenderToolStatus("mcp_thing", "q=x", true, "boom")
+	if !strings.Contains(gotErr, "— boom") {
+		t.Errorf("error status should append the error; got:\n%s", gotErr)
 	}
 }
 


### PR DESCRIPTION
## What

Brings the inline TUI's noise level down to Claude Code's. Four changes:

### 1. Thinking stays out of the scrollback
The reasoning trace no longer commits dimmed 💭 lines (over a long agentic turn it dominated the transcript). The wait-on-model activity line now carries the signal instead:

```
⠹ Thinking… (12s · ↑ ~3.2k tokens)
```

Token readout = (thinking + text + tool-arg chars)/4, reset per turn.

### 2. Tighter cards
- Output cards: `outputCardMaxLines` 12 → **4** (CC shows ~3; the full output went to the model — the card is a glimpse).
- Diff cards: new `diffCardMaxRows = 6` **per side** (removed/added), so a big rewrite still shows the head of both old and new text.
- Collapse marker unified to `… +N lines`.

### 3. Cache footer is verbose-only
`ⓘ cache: N read, N write …` landed after essentially every turn (cache moves on every Anthropic-protocol call). Now `--verbose` only; the status bar's ctx% covers the at-a-glance need.

### 4. Blocks breathe + non-card tools are one line
- Block-level items (user echo, markdown blocks, cards, notices) go through a new `printlnBlock()` that inserts exactly one blank separator line — the CC "清爽" feel comes largely from this.
- Non-card tools (MCP tools, `sub_agent`, …) no longer print `↳ started` + `│ progress` + `↳ done` (3 lines); they show the live spinner while running and commit a single `● tool(input)` status line on completion (`tui.RenderToolStatus`), sharing the card header's visual language.

`--plain` keeps the dense line-oriented layout, matching the headless renderer (decision #8 unchanged).

## Docs
`dev-docs/tui-ux-upgrade-design.md` event-mapping table updated + new 降噪规则 section.

## Tests
- Rewrote the two thinking-trace tests → thinking never reaches `printlnBuf`, token counter accumulates and resets per turn.
- New: non-card one-line status, `printlnBlock` separation, `RenderToolStatus`.
- `go test -race ./...` green, `gofmt -l` clean, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)