### PR TITLE
feat(tui): CC-style live task checklist — ✓/■/□, creation order, ActiveForm spinner

### DIFF
--- a/cmd/octo/tuirepl_tasks.go
+++ b/cmd/octo/tuirepl_tasks.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Leihb/octo-agent/internal/tasks"
@@ -11,18 +12,22 @@ import (
 	"github.com/muesli/reflow/truncate"
 )
 
-// Live task-list styles — Claude Code's todo block: a checkbox glyph per task,
-// the in-progress one highlighted, completed ones dimmed and struck through.
+// Live task-list styles — Claude Code's todo block: glyph and label styled
+// separately per status. Completed = green ✓ with the label struck through;
+// in-progress = filled square in the brand colour with the label bold;
+// pending = hollow square, label in the terminal's default foreground.
 var (
-	taskConnStyle    = lipgloss.NewStyle().Foreground(tui.ColDim)
-	taskPendingStyle = lipgloss.NewStyle().Foreground(tui.ColMuted)
-	taskActiveStyle  = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
-	taskDoneStyle    = lipgloss.NewStyle().Foreground(tui.ColDim).Strikethrough(true)
+	taskConnStyle   = lipgloss.NewStyle().Foreground(tui.ColDim)
+	taskGlyphDone   = lipgloss.NewStyle().Foreground(tui.ColAccent).SetString("✓")
+	taskGlyphActive = lipgloss.NewStyle().Foreground(tui.ColBrand).SetString("■")
+	taskGlyphPend   = lipgloss.NewStyle().Foreground(tui.ColDim).SetString("□")
+	taskTextDone    = lipgloss.NewStyle().Foreground(tui.ColDim).Strikethrough(true)
+	taskTextActive  = lipgloss.NewStyle().Bold(true)
 )
 
-// maxTaskRows caps how many task rows the live block shows before collapsing
-// the tail into a "└ N more" line. List() orders in-progress → pending →
-// completed, so the rows we keep are always the most pressing ones.
+// maxTaskRows caps how many lines the live block occupies (markers included).
+// Beyond it, completed head rows fold into a "✓ N done" line first — they're
+// the least pressing — then the tail collapses into "… N more".
 const maxTaskRows = 8
 
 // taskListView renders the live task block shown under the activity spinner
@@ -36,6 +41,24 @@ func (m *tuiModel) taskListView() string {
 		return ""
 	}
 	return renderTaskLines(store.List(), m.width)
+}
+
+// activeTaskPhrase returns the in-progress task's present-continuous form (or
+// its subject), so the activity spinner can read "Migrating config readers…"
+// instead of a generic thinking verb. "" when no store or no task is active.
+func (m *tuiModel) activeTaskPhrase() string {
+	store := tools.ActiveTaskStore()
+	if store == nil {
+		return ""
+	}
+	items := store.List() // ordered in-progress first
+	if len(items) == 0 || items[0].Status != tasks.InProgress {
+		return ""
+	}
+	if items[0].ActiveForm != "" {
+		return items[0].ActiveForm
+	}
+	return items[0].Subject
 }
 
 // renderTaskLines is the pure formatter behind taskListView, split out so it
@@ -53,54 +76,66 @@ func renderTaskLines(items []tasks.Task, width int) string {
 		return ""
 	}
 
-	rows := items
+	// Checklist order: by creation (ID), so the block reads top-to-bottom as
+	// progress — completed head, active middle, pending tail (Claude Code
+	// style). List() is status-sorted for other consumers; re-sort here.
+	rows := append([]tasks.Task(nil), items...)
+	sort.Slice(rows, func(i, j int) bool { return rows[i].ID < rows[j].ID })
+
+	// Over budget: fold completed rows off the head into one "✓ N done" line.
+	foldedDone := 0
+	for len(rows) > maxTaskRows-1 && rows[0].Status == tasks.Completed {
+		rows = rows[1:]
+		foldedDone++
+	}
+	// Still over (long pending tail): collapse the tail into "… N more".
+	budget := maxTaskRows
+	if foldedDone > 0 {
+		budget-- // the fold marker occupies a line
+	}
 	moreCount := 0
-	if len(rows) > maxTaskRows {
-		// Reserve the last visible line for the "N more" marker.
-		moreCount = len(rows) - (maxTaskRows - 1)
-		rows = rows[:maxTaskRows-1]
+	if len(rows) > budget {
+		moreCount = len(rows) - (budget - 1)
+		rows = rows[:budget-1]
 	}
 
 	var b strings.Builder
-	for i, t := range rows {
-		// The first row carries the tree elbow tying the block to the spinner
-		// above; the rest align their glyph under it.
-		if i == 0 {
+	// The first line carries the tree elbow tying the block to the spinner
+	// above; the rest align under it.
+	writeLine := func(s string) {
+		if b.Len() == 0 {
 			b.WriteString(taskConnStyle.Render("└ "))
 		} else {
 			b.WriteString("\n  ")
 		}
-		b.WriteString(renderTaskRow(t, width))
+		b.WriteString(s)
+	}
+	if foldedDone > 0 {
+		writeLine(taskGlyphDone.String() + " " + taskConnStyle.Render(fmt.Sprintf("%d done", foldedDone)))
+	}
+	for _, t := range rows {
+		writeLine(renderTaskRow(t, width))
 	}
 	if moreCount > 0 {
-		b.WriteString("\n  ")
-		b.WriteString(taskConnStyle.Render(fmt.Sprintf("… %d more", moreCount)))
+		writeLine(taskConnStyle.Render(fmt.Sprintf("… %d more", moreCount)))
 	}
 	return b.String()
 }
 
-// renderTaskRow formats a single task line: glyph + label, styled by status,
-// truncated to fit the terminal width (the 2-column row prefix is accounted
-// for by the caller's layout, so we budget width-2 here).
+// renderTaskRow formats a single task line: status glyph + subject, glyph and
+// label styled separately, the label truncated to fit the terminal width
+// (2-column indent + glyph + space accounted for).
 func renderTaskRow(t tasks.Task, width int) string {
-	var glyph string
-	var style lipgloss.Style
 	text := t.Subject
+	if width > 8 {
+		text = truncate.StringWithTail(text, uint(width-6), "…")
+	}
 	switch t.Status {
 	case tasks.InProgress:
-		glyph, style = "□", taskActiveStyle
-		if t.ActiveForm != "" {
-			text = t.ActiveForm // present-continuous form reads better while active
-		}
+		return taskGlyphActive.String() + " " + taskTextActive.Render(text)
 	case tasks.Completed:
-		glyph, style = "✓", taskDoneStyle
+		return taskGlyphDone.String() + " " + taskTextDone.Render(text)
 	default: // Pending
-		glyph, style = "□", taskPendingStyle
+		return taskGlyphPend.String() + " " + text
 	}
-
-	line := glyph + " " + text
-	if width > 6 {
-		line = truncate.StringWithTail(line, uint(width-2), "…")
-	}
-	return style.Render(line)
 }

--- a/cmd/octo/tuirepl_tasks_test.go
+++ b/cmd/octo/tuirepl_tasks_test.go
@@ -21,10 +21,13 @@ func TestRenderTaskLines_HidesWhenNothingOutstanding(t *testing.T) {
 }
 
 func TestRenderTaskLines_Layout(t *testing.T) {
+	// Status-sorted input (as Store.List() returns it); the block re-sorts by
+	// ID so it reads as a checklist: completed head, active middle, pending
+	// tail.
 	items := []tasks.Task{
-		{ID: 1, Subject: "Migrate auth", ActiveForm: "Migrating auth", Status: tasks.InProgress},
-		{ID: 2, Subject: "Add test", Status: tasks.Pending},
-		{ID: 3, Subject: "Update docs", Status: tasks.Completed},
+		{ID: 2, Subject: "Migrate auth", ActiveForm: "Migrating auth", Status: tasks.InProgress},
+		{ID: 3, Subject: "Add test", Status: tasks.Pending},
+		{ID: 1, Subject: "Update docs", Status: tasks.Completed},
 	}
 	out := renderTaskLines(items, 80)
 	lines := strings.Split(out, "\n")
@@ -34,15 +37,40 @@ func TestRenderTaskLines_Layout(t *testing.T) {
 	if !strings.Contains(lines[0], "└") {
 		t.Errorf("first row should carry the tree elbow, got %q", lines[0])
 	}
-	// In-progress uses the present-continuous ActiveForm, not the Subject.
-	if !strings.Contains(lines[0], "Migrating auth") {
-		t.Errorf("in-progress row should use ActiveForm, got %q", lines[0])
+	// Creation order: the completed task (ID 1) renders first, struck through.
+	if !strings.Contains(lines[0], "✓") || !strings.Contains(lines[0], "Update docs") {
+		t.Errorf("completed row should lead with the check glyph + subject, got %q", lines[0])
 	}
-	if !strings.Contains(lines[0], "□") {
-		t.Errorf("in-progress row should use the box glyph, got %q", lines[0])
+	// In-progress: filled square + subject (the ActiveForm feeds the spinner
+	// label, not the list row).
+	if !strings.Contains(lines[1], "■") || !strings.Contains(lines[1], "Migrate auth") {
+		t.Errorf("in-progress row should use ■ + subject, got %q", lines[1])
 	}
-	if !strings.Contains(lines[2], "✓") || !strings.Contains(lines[2], "Update docs") {
-		t.Errorf("completed row should use the check glyph + subject, got %q", lines[2])
+	if !strings.Contains(lines[2], "□") || !strings.Contains(lines[2], "Add test") {
+		t.Errorf("pending row should use the hollow box + subject, got %q", lines[2])
+	}
+}
+
+func TestRenderTaskLines_FoldsCompletedHead(t *testing.T) {
+	var items []tasks.Task
+	for i := 1; i <= 6; i++ {
+		items = append(items, tasks.Task{ID: i, Subject: "done", Status: tasks.Completed})
+	}
+	for i := 7; i <= 12; i++ {
+		items = append(items, tasks.Task{ID: i, Subject: "todo", Status: tasks.Pending})
+	}
+	out := renderTaskLines(items, 80)
+	lines := strings.Split(out, "\n")
+	if len(lines) > maxTaskRows {
+		t.Fatalf("block must stay within %d lines, got %d:\n%s", maxTaskRows, len(lines), out)
+	}
+	// The completed head folds into a "N done" marker before any tail collapse.
+	if !strings.Contains(lines[0], "done") || !strings.Contains(lines[0], "5") {
+		t.Errorf("first line should fold the completed head (5 done), got %q", lines[0])
+	}
+	// All 6 pending rows survive the fold.
+	if got := strings.Count(out, "todo"); got != 6 {
+		t.Errorf("all pending rows should stay visible, got %d of 6:\n%s", got, out)
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -36,6 +36,7 @@ var (
 	queueStyle        = lipgloss.NewStyle().Foreground(tui.ColAccent)
 	modalStyle        = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
 	hintStyle         = lipgloss.NewStyle().Foreground(tui.ColDimmer).Italic(true)
+	activityStyle     = lipgloss.NewStyle().Foreground(tui.ColBrand)
 	userEchoStyle     = lipgloss.NewStyle().Foreground(tui.ColUserMsg).Bold(true)
 	pendingSteerStyle = lipgloss.NewStyle().Foreground(tui.ColMuted)
 	complSelStyle     = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
@@ -1247,12 +1248,21 @@ func (m *tuiModel) spinnerLine(label string, since time.Time) string {
 // thinkingLine is the wait-on-the-model activity line. Since the reasoning
 // trace itself is not shown, the line carries the turn's elapsed time and a
 // rough output-token count ("↑ ~N tokens", chars/4) so a long silent stretch
-// still reads as the model working, Claude Code style.
+// still reads as the model working, Claude Code style. When a task is in
+// progress its present-continuous form replaces the generic thinking verb
+// ("Migrating config readers…" instead of "Thinking…").
 func (m *tuiModel) thinkingLine() string {
 	frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
+	phrase := m.activeTaskPhrase()
+	if phrase == "" {
+		phrase = m.thinkingPhrase()
+	}
 	meta := time.Since(m.turnStart).Round(time.Second).String()
 	if m.turnOutChars > 0 {
 		meta += fmt.Sprintf(" · ↑ ~%s tokens", humanTokens(m.turnOutChars/4))
 	}
-	return hintStyle.Render(fmt.Sprintf("%c %s… (%s)", frame, m.thinkingPhrase(), meta))
+	return fmt.Sprintf("%s %s %s",
+		hintStyle.Render(string(frame)),
+		activityStyle.Render(phrase+"…"),
+		hintStyle.Render("("+meta+")"))
 }

--- a/dev-docs/tui-ux-upgrade-design.md
+++ b/dev-docs/tui-ux-upgrade-design.md
@@ -105,6 +105,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 | 富 spinner（Braille + 轮转提示词） | ✅ | `tuirepl_view.go:spinnerLine/thinkingPhrase`, `spinner.go` |
 | glamour markdown（流式 block 边界提交） | ✅ | `markdown.go` |
 | 面板化（队列/后台/模态） | ✅ | `internal/tui/theme.go:Panel/Box` |
+| Live 任务检查单（创建序 ✓/■/□，spinner 显示进行中任务 ActiveForm，超长先折叠已完成头部为「✓ N done」再尾部「… N more」） | ✅ | `tuirepl_tasks.go` |
 | 统一自适应主题 | ✅ | `internal/tui/theme.go` |
 | 章鱼像素-art 横幅 | ✅ | `internal/tui/theme.go:Banner`（Init 时打印一次） |
 | 卡片归属 TUI-only（plainView 纯文本） | ✅ | `toolcards.go`, `repl.go` |


### PR DESCRIPTION
## What

Restyles the live task block under the activity spinner to match Claude Code's todo panel:

```
⠹ Migrating config readers… (24s · ↑ ~3.2k tokens)
└ ✓ R̶e̶w̶r̶i̶t̶e̶ ̶i̶n̶t̶e̶r̶n̶a̶l̶/̶c̶o̶n̶f̶i̶g̶:̶ ̶m̶o̶d̶e̶l̶s̶ ̶l̶i̶s̶t̶ ̶s̶c̶h̶e̶m̶a̶
  ■ **Migrate config readers/writers: cmd/octo + internal/server**
  ■ **Real CRUD in onboard_config_handlers.go + tests**
  □ settings.js id-based addressing
  □ make fmt-check vet test; open PR1 with auto-merge
```

- **Checklist order** — rows re-sort by creation (ID), so the block reads top-to-bottom as progress: completed head, active middle, pending tail. `Store.List()` stays status-sorted for other consumers; the re-sort is renderer-local.
- **Per-status glyph + label styling** — completed: green `✓`, label dim + strikethrough; in-progress: filled `■` in brand colour, label **bold**; pending: hollow `□`, default-foreground label. Glyph and label styled separately (previously one style covered the whole row).
- **ActiveForm drives the spinner** — when a task is in progress, the activity line reads `⠹ Migrating config readers… (12s · ↑ ~3.2k tokens)` instead of a generic `Thinking…`; label in brand colour, meta dimmed. List rows always show the imperative Subject (ActiveForm moved up to the spinner).
- **Smarter overflow** — over `maxTaskRows` (8), completed head rows fold into one `✓ N done` line first, then the tail collapses into `… N more` — pending work stays visible instead of being the first thing dropped.

## Tests
- Layout test rewritten for the new contract (creation order, ■/□/✓ glyph split, Subject in rows).
- New fold test: 6 done + 6 pending → `✓ 5 done` marker, all 6 pending visible, block ≤ 8 lines.
- `go test -race` green on cmd/octo + internal/tui; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)