### PR TITLE
feat(server): per-session model binding via config entries

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -31,7 +31,11 @@ type Session struct {
 	System    string    `json:"system,omitempty"`
 	Title     string    `json:"title,omitempty"`
 	Source    string    `json:"source,omitempty"` // how the session was created: "" (manual) | "cron" | "channel" | "setup"
-	Messages  []Message `json:"messages"`
+	// ModelConfig names the user-config model entry this session is bound to.
+	// Empty means "the default entry at turn time" — also the value for every
+	// session predating per-session model binding.
+	ModelConfig string    `json:"model_config,omitempty"`
+	Messages    []Message `json:"messages"`
 
 	// Dir overrides the default ~/.octo/sessions location. Empty means use the
 	// default. Not serialized — it's a runtime override.
@@ -154,18 +158,19 @@ func (s *Session) SavePath() (string, error) {
 // on disk. LoadSession takes the last title record as authoritative; rewriteAll
 // also folds the title back into the meta header so a compacted file keeps it.
 type sessionRecord struct {
-	Type      string    `json:"type"` // "meta" | "message" | "title"
-	ID        string    `json:"id,omitempty"`
-	CreatedAt time.Time `json:"created_at,omitempty"`
-	Model     string    `json:"model,omitempty"`
-	System    string    `json:"system,omitempty"`
-	Title     string    `json:"title,omitempty"`
-	Source    string    `json:"source,omitempty"`
-	Message   *Message  `json:"message,omitempty"`
+	Type        string    `json:"type"` // "meta" | "message" | "title" | "model_config"
+	ID          string    `json:"id,omitempty"`
+	CreatedAt   time.Time `json:"created_at,omitempty"`
+	Model       string    `json:"model,omitempty"`
+	System      string    `json:"system,omitempty"`
+	Title       string    `json:"title,omitempty"`
+	Source      string    `json:"source,omitempty"`
+	ModelConfig string    `json:"model_config,omitempty"`
+	Message     *Message  `json:"message,omitempty"`
 }
 
 func (s *Session) metaRecord() sessionRecord {
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source}
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig}
 }
 
 func messageRecord(m Message) sessionRecord {
@@ -287,6 +292,55 @@ func (s *Session) SetTitle(title string) error {
 	defer f.Close()
 	if err := json.NewEncoder(f).Encode(sessionRecord{Type: "title", Title: title}); err != nil {
 		return fmt.Errorf("session: append title: %w", err)
+	}
+	return nil
+}
+
+// SetModelConfig binds the session to a named config entry (empty name =
+// the default entry) and records the entry's model string so the session
+// displays and resumes on the right model. Like SetTitle, it appends a
+// record when the transcript is already on disk so the binding survives
+// without rewriting the file; a switch to the values already in place is a
+// no-op.
+func (s *Session) SetModelConfig(name, model string) error {
+	if name == s.ModelConfig && (model == "" || model == s.Model) {
+		return nil
+	}
+	s.ModelConfig = name
+	if model != "" {
+		s.Model = model
+	}
+	if s.persisted == 0 {
+		// persisted == 0 means no MESSAGES on disk, not no file: a fresh
+		// session saved before its first turn is a meta-only transcript, and
+		// a load-modify-discard caller (the model-switch handler) would lose
+		// the binding if we waited for "the next Save" on an object about to
+		// be thrown away. Rewrite the existing file; a session with no file
+		// yet just carries the binding until its first Save.
+		if path, perr := s.SavePath(); perr == nil {
+			if _, statErr := os.Stat(path); statErr == nil {
+				return s.rewriteAll()
+			}
+		}
+		return nil
+	}
+	if s.forceRewrite {
+		// Stale or truncated on-disk prefix — fold into a full rewrite, same
+		// reasoning as SetTitle.
+		return s.rewriteAll()
+	}
+	path, err := s.SavePath()
+	if err != nil {
+		return err
+	}
+	// No O_CREATE — see SetTitle: never materialise an orphan transcript.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("session: open %s: %w", path, err)
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(sessionRecord{Type: "model_config", ModelConfig: name, Model: s.Model}); err != nil {
+		return fmt.Errorf("session: append model_config: %w", err)
 	}
 	return nil
 }
@@ -413,8 +467,14 @@ func LoadSession(id string) (*Session, error) {
 			s.ID, s.CreatedAt, s.Model, s.System = rec.ID, rec.CreatedAt, rec.Model, rec.System
 			s.Title = rec.Title // a compacted file carries the title in its meta header
 			s.Source = rec.Source
+			s.ModelConfig = rec.ModelConfig
 		case "title":
 			s.Title = rec.Title // last one wins
+		case "model_config":
+			s.ModelConfig = rec.ModelConfig // last one wins, like title
+			if rec.Model != "" {
+				s.Model = rec.Model
+			}
 		case "message":
 			if rec.Message != nil {
 				s.Messages = append(s.Messages, *rec.Message)

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -634,3 +634,88 @@ func TestDeleteSession_RejectsTraversal(t *testing.T) {
 		}
 	}
 }
+
+func TestSetModelConfig_AppendsAndReloads(t *testing.T) {
+	// A model binding set after the first Save is appended as its own record
+	// and survives a reload, carrying both the entry name and model string.
+	setTempHome(t)
+
+	s := NewSession("old-model", "")
+	s.Messages = []Message{NewUserMessage("ping"), NewAssistantMessage("pong")}
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetModelConfig("kimi", "kimi-k2.6"); err != nil {
+		t.Fatalf("SetModelConfig: %v", err)
+	}
+
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ModelConfig != "kimi" || got.Model != "kimi-k2.6" {
+		t.Errorf("reloaded = (%q, %q), want (kimi, kimi-k2.6)", got.ModelConfig, got.Model)
+	}
+	if len(got.Messages) != 2 {
+		t.Errorf("Messages len = %d, want 2", len(got.Messages))
+	}
+
+	// Unbinding (back to the default entry) also survives a reload.
+	if err := got.SetModelConfig("", "claude-sonnet-4-6"); err != nil {
+		t.Fatal(err)
+	}
+	again, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.ModelConfig != "" || again.Model != "claude-sonnet-4-6" {
+		t.Errorf("after unbind = (%q, %q), want (\"\", claude-sonnet-4-6)", again.ModelConfig, again.Model)
+	}
+}
+
+func TestSetModelConfig_SurvivesRewrite(t *testing.T) {
+	// A full rewrite (compaction path) folds the binding into the meta header.
+	setTempHome(t)
+
+	s := NewSession("m", "")
+	s.Messages = []Message{NewUserMessage("ping"), NewAssistantMessage("pong")}
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetModelConfig("kimi", "kimi-k2.6"); err != nil {
+		t.Fatal(err)
+	}
+	s.forceRewrite = true
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ModelConfig != "kimi" || got.Model != "kimi-k2.6" {
+		t.Errorf("after rewrite = (%q, %q), want (kimi, kimi-k2.6)", got.ModelConfig, got.Model)
+	}
+}
+
+func TestSetModelConfig_BeforeSave(t *testing.T) {
+	// Binding before the first Save just rides the meta header.
+	setTempHome(t)
+
+	s := NewSession("m", "")
+	if err := s.SetModelConfig("kimi", "kimi-k2.6"); err != nil {
+		t.Fatal(err)
+	}
+	s.Messages = []Message{NewUserMessage("ping")}
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ModelConfig != "kimi" || got.Model != "kimi-k2.6" {
+		t.Errorf("loaded = (%q, %q), want (kimi, kimi-k2.6)", got.ModelConfig, got.Model)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -297,15 +297,18 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	model := s.model
+	modelConfig := ""
 	if req.Model != "" {
 		model = req.Model
-		// The web modal sends a config entry id; resolve it to the entry's
-		// model string. (Per-entry sender binding is the next step on the
-		// multi-model design — until then the session rides the default
-		// sender.)
+		// The web modal sends a config entry id; the session binds to that
+		// entry so its turns run on the entry's sender. A non-matching value
+		// stays a raw model string on the default sender.
 		if cfg, err := config.Load(); err == nil {
-			if e, ok := cfg.EntryByName(req.Model); ok && e.Model != "" {
-				model = e.Model
+			if e, ok := cfg.EntryByName(req.Model); ok {
+				modelConfig = e.Name
+				if e.Model != "" {
+					model = e.Model
+				}
 			}
 		}
 	}
@@ -331,6 +334,7 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 
 	sess := agent.NewSession(model, "")
 	sess.Source = source
+	sess.ModelConfig = modelConfig
 	if req.Name != "" {
 		sess.Title = req.Name
 	}
@@ -858,10 +862,12 @@ type updateSessionModelRequest struct {
 	ModelID string `json:"model_id"`
 }
 
-// handleUpdateSessionModel updates the active model for the server's default
-// model config. The Web UI treats this as a per-session action (the user clicks
-// the model name in the session info bar), but the Go rewrite currently uses a
-// single global model configuration, so the change applies to all future turns.
+// handleUpdateSessionModel switches THIS session's model: model_id naming a
+// config entry binds the session to it (provider, endpoint, key — the whole
+// entry, applied from the next turn via the per-entry sender cache); other
+// values are treated as a raw model string on the session, staying on the
+// default sender. The global default model is not touched — that's
+// POST /api/config/models/{id}/default.
 func (s *Server) handleUpdateSessionModel(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
@@ -879,33 +885,39 @@ func (s *Server) handleUpdateSessionModel(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	sess, err := agent.LoadSession(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
 	cfg, _ := config.Load()
-	// model_id is a config entry name (the ids exposed by /api/config).
-	// A value that names no entry is treated as a raw model string applied
-	// to the default entry, preserving the pre-multi-model contract.
-	if _, ok := cfg.EntryByName(req.ModelID); ok {
-		cfg.DefaultModel = req.ModelID
-	} else if req.ModelID != "default" {
-		entry := cfg.DefaultEntry()
-		entry.Model = req.ModelID
-		cfg.SetDefaultEntry(entry)
-	} else if cfg.DefaultEntry().Model == "" {
-		// Edge case: frontend selected "default" but no model is configured.
-		writeError(w, http.StatusBadRequest, "no default model configured")
+	var model string
+	if entry, ok := cfg.EntryByName(req.ModelID); ok {
+		model = entry.Model
+		err = sess.SetModelConfig(entry.Name, entry.Model)
+	} else if req.ModelID == "default" {
+		// Legacy id for "the default entry". Unbind so the session follows
+		// whatever the default is at turn time.
+		model = cfg.DefaultEntry().Model
+		if model == "" {
+			writeError(w, http.StatusBadRequest, "no default model configured")
+			return
+		}
+		err = sess.SetModelConfig("", model)
+	} else {
+		// Raw model string: keep the default sender, change only the model.
+		model = req.ModelID
+		err = sess.SetModelConfig("", model)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save session: %v", err))
 		return
 	}
-
-	if err := cfg.Save(); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
-		return
-	}
-
-	// Update the runtime default so the next agent turn uses the new model.
-	s.model = cfg.DefaultEntry().Model
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"ok":       true,
-		"model":    cfg.DefaultEntry().Model,
+		"model":    model,
 		"model_id": req.ModelID,
 	})
 }

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -335,6 +335,7 @@ func (s *Server) handleSaveModelConfig(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return
 	}
+	s.invalidateSenderCache()
 
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": entry.Name})
 }
@@ -379,6 +380,7 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return
 	}
+	s.invalidateSenderCache()
 
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
@@ -426,6 +428,7 @@ func (s *Server) handleDeleteModelConfig(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return
 	}
+	s.invalidateSenderCache()
 
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
@@ -456,6 +459,7 @@ func (s *Server) handleSetDefaultModelConfig(w http.ResponseWriter, r *http.Requ
 
 	// The next agent turn should pick up the new default.
 	s.model = cfg.DefaultEntry().Model
+	s.invalidateSenderCache()
 
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/config"
 )
 
@@ -258,5 +259,57 @@ func TestConfigModels_UniqueNameGeneration(t *testing.T) {
 	cfg, _ := config.Load()
 	if len(cfg.Models) != 3 {
 		t.Fatalf("entries = %d, want 3", len(cfg.Models))
+	}
+}
+
+func TestCreateSession_EntryIDBindsSession(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			{Name: "kimi", Provider: "kimi", Model: "kimi-k2.6"},
+		},
+		DefaultModel: "main",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/sessions", `{"model":"kimi"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /api/sessions = %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Session struct {
+			ID    string `json:"id"`
+			Model string `json:"model"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Session.Model != "kimi-k2.6" {
+		t.Errorf("session model = %q, want kimi-k2.6 (entry id resolved)", resp.Session.Model)
+	}
+	sess, err := agent.LoadSession(resp.Session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.ModelConfig != "kimi" {
+		t.Errorf("model_config = %q, want kimi", sess.ModelConfig)
+	}
+
+	// A raw model string stays unbound.
+	w = doJSON(t, srv, http.MethodPost, "/api/sessions", `{"model":"some-other-model"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST raw = %d: %s", w.Code, w.Body.String())
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	sess, err = agent.LoadSession(resp.Session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.ModelConfig != "" || sess.Model != "some-other-model" {
+		t.Errorf("raw session = (%q, %q), want (some-other-model, \"\")", sess.Model, sess.ModelConfig)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -121,6 +121,12 @@ type Server struct {
 	sessionAgents   map[string]*agent.Agent
 	sessionAgentsMu sync.Mutex
 
+	// senderCache holds one sender per config entry name, built lazily for
+	// sessions bound to a non-default model entry. Invalidated wholesale on
+	// any /api/config/models mutation; the next turn rebuilds.
+	senderCache   map[string]agent.Sender
+	senderCacheMu sync.Mutex
+
 	// titlePending guards one in-flight title generation per session
 	// (lazily initialised by claimTitleGeneration).
 	titlePending map[string]bool
@@ -594,7 +600,8 @@ func (s *Server) forgetTurnLock(id string) {
 // buildAgent creates a fresh agent for a turn. The caller must have locked
 // the session's turn mutex.
 func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
-	a := agent.New(s.sender, s.model)
+	sender, model := s.senderForSession(sess)
+	a := agent.New(sender, model)
 	a.CWD = s.cwd
 	a.MaxTokens = s.cfg.MaxTokens
 
@@ -625,9 +632,6 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 		a.ToolResultHook = inj.SaveNudge
 	}
 
-	if sess.Model != "" {
-		a.Model = sess.Model
-	}
 	if len(sess.Messages) > 0 {
 		a.History = sess.ToHistory()
 	}
@@ -740,6 +744,76 @@ func resolveBaseURL(provider string, cfg config.Config) string {
 		return entry.BaseURL
 	}
 	return ""
+}
+
+// senderForSession resolves the (sender, model) a turn should run on. A
+// session bound to a config entry (ModelConfig) gets that entry's sender from
+// the cache, built on first use; everything else — unbound sessions, a
+// missing entry (deleted since binding), or a build failure — falls back to
+// the server's default sender so a stale binding degrades instead of
+// breaking the turn.
+func (s *Server) senderForSession(sess *agent.Session) (agent.Sender, string) {
+	model := s.model
+	if sess.Model != "" {
+		model = sess.Model
+	}
+	if sess.ModelConfig == "" {
+		return s.sender, model
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return s.sender, model
+	}
+	entry, ok := cfg.EntryByName(sess.ModelConfig)
+	if !ok {
+		return s.sender, model
+	}
+	if entry.Model != "" {
+		model = entry.Model
+	}
+
+	s.senderCacheMu.Lock()
+	defer s.senderCacheMu.Unlock()
+	if cached, ok := s.senderCache[entry.Name]; ok {
+		return cached, model
+	}
+	sender, err := senderForEntry(entry)
+	if err != nil {
+		return s.sender, model
+	}
+	if s.senderCache == nil {
+		s.senderCache = make(map[string]agent.Sender)
+	}
+	s.senderCache[entry.Name] = sender
+	return sender, model
+}
+
+// senderForEntry builds a sender from one config entry: env key first (same
+// rule as the default path), then the entry's stored key.
+func senderForEntry(entry config.ModelEntry) (agent.Sender, error) {
+	apiKey := os.Getenv(app.VendorAPIKeyEnvVar(entry.Provider))
+	if apiKey == "" {
+		apiKey = entry.APIKey
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("no API key for entry %q (provider %q)", entry.Name, entry.Provider)
+	}
+	return app.NewSender(app.SenderOptions{
+		Provider:        entry.Provider,
+		APIKey:          apiKey,
+		BaseURL:         entry.BaseURL,
+		ReasoningEffort: entry.ReasoningEffort,
+	})
+}
+
+// invalidateSenderCache drops every cached per-entry sender. Called on any
+// model-config mutation so edited credentials/endpoints take effect on the
+// next turn.
+func (s *Server) invalidateSenderCache() {
+	s.senderCacheMu.Lock()
+	s.senderCache = nil
+	s.senderCacheMu.Unlock()
 }
 
 // resolveAccessKey is a no-op: access-key authentication was removed in

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -727,7 +727,7 @@ func TestHandleUpdateSessionWorkingDir(t *testing.T) {
 	}
 }
 
-func TestHandleUpdateSessionModel(t *testing.T) {
+func TestHandleUpdateSessionModel_RawStringIsPerSession(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)
@@ -755,8 +755,91 @@ func TestHandleUpdateSessionModel(t *testing.T) {
 	if body["ok"] != true {
 		t.Fatalf("ok = %v, want true", body["ok"])
 	}
-	if srv.model != "kimi-for-coding" {
-		t.Fatalf("server model = %q, want kimi-for-coding", srv.model)
+
+	// The switch is per-session: the session carries the new model, the
+	// server default and the persisted config stay untouched.
+	got, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Model != "kimi-for-coding" || got.ModelConfig != "" {
+		t.Fatalf("session = (%q, %q), want (kimi-for-coding, \"\")", got.Model, got.ModelConfig)
+	}
+	if srv.model != "stub-model" {
+		t.Fatalf("server default model changed to %q — must stay stub-model", srv.model)
+	}
+	cfg, _ := config.Load()
+	if len(cfg.Models) != 0 {
+		t.Fatalf("global config written by a per-session switch: %+v", cfg.Models)
+	}
+}
+
+func TestHandleUpdateSessionModel_EntryNameBindsSession(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	seed := config.Config{
+		Models: []config.ModelEntry{
+			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			{Name: "kimi", Provider: "kimi", Model: "kimi-k2.6", APIKey: "sk-kimi"},
+		},
+		DefaultModel: "main",
+	}
+	if err := seed.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	sess := agent.NewSession("claude-sonnet-4-6", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	payload, _ := json.Marshal(updateSessionModelRequest{ModelID: "kimi"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/"+sess.ID+"/model?access_key="+srv.AccessKey(), bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	got, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ModelConfig != "kimi" || got.Model != "kimi-k2.6" {
+		t.Fatalf("session = (%q, %q), want (kimi-k2.6, kimi)", got.Model, got.ModelConfig)
+	}
+	cfg, _ := config.Load()
+	if cfg.DefaultModel != "main" {
+		t.Fatalf("global default changed to %q — must stay main", cfg.DefaultModel)
+	}
+
+	// The bound session's turns resolve to the entry's sender and model;
+	// an unbound session stays on the server default.
+	sender, model := srv.senderForSession(got)
+	if model != "kimi-k2.6" {
+		t.Errorf("senderForSession model = %q, want kimi-k2.6", model)
+	}
+	if sender == srv.sender {
+		t.Error("bound session must not ride the default sender")
+	}
+	plain := agent.NewSession("stub-model", "")
+	if sender2, model2 := srv.senderForSession(plain); sender2 != srv.sender || model2 != "stub-model" {
+		t.Errorf("unbound session = (%v, %q), want default sender + stub-model", sender2, model2)
+	}
+
+	// Deleting the bound entry degrades to the default sender instead of
+	// failing the turn.
+	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/kimi", ""); w.Code != http.StatusOK {
+		t.Fatalf("DELETE = %d: %s", w.Code, w.Body.String())
+	}
+	if sender3, _ := srv.senderForSession(got); sender3 != srv.sender {
+		t.Error("stale binding must fall back to the default sender")
 	}
 }
 


### PR DESCRIPTION
PR 2 of 3 implementing [dev-docs/multi-model-config-design.md](https://github.com/Leihb/octo-agent/blob/main/dev-docs/multi-model-config-design.md) (#592). Builds on #603.

## What

- **`Session.ModelConfig`**: sessions persist which config entry they're bound to. Follows the title-record pattern — appended without rewriting the transcript, folded into the meta header on rewrite/compaction. Old session files load unchanged (empty binding = default entry, exactly the previous behaviour).
- **Per-entry sender cache**: `senderForSession` resolves each turn's (sender, model); a session bound to an entry gets that entry's sender (provider + endpoint + key + reasoning effort), built lazily via `app.NewSender` and cached by entry name. Any `/api/config/models` mutation invalidates the cache so edited credentials take effect on the next turn.
- **`PATCH /api/sessions/{id}/model` is now truly per-session.** Previously it rewrote the *global* config and `s.model` — switching every session — while the UI presented it as a per-session action (the old handler comment admitted this). Now: entry name → bind this session; `"default"` → unbind; raw string → change this session's model only.
- **`POST /api/sessions`** with an entry id binds the session at creation. The new-session modal already sends entry ids — no frontend changes needed.
- **Degradation**: a binding whose entry was deleted falls back to the default sender instead of failing the turn. Channels and cron sessions stay on the default entry by design.
- **Edge fix**: `SetModelConfig` on a meta-only transcript (session saved before its first turn) rewrites the file in place — `persisted == 0` means no *messages* on disk, not no file, and the model-switch handler is load-modify-discard.

## What this PR does NOT do

- PR 3: lite-model compaction + `/api/config/models/{id}/lite` route.

## Tests

- `internal/agent`: binding round-trip (append + reload), unbind, rewrite/compaction survival, bind-before-first-save.
- `internal/server`: raw-string switch is per-session (global config + `s.model` untouched), entry-name switch binds and resolves to a non-default sender, stale binding degrades, create-with-entry-id binds, create-with-raw-string stays unbound.
- Full `go test -race ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)