### PR TITLE
feat(tui): Ctrl+T pins the task checklist in the live area

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -313,6 +313,11 @@ type tuiModel struct {
 	// modal, when non-nil, is an active Ask prompt (design §6).
 	modal *modalState
 
+	// showTasks pins the task checklist in the live area regardless of turn
+	// state (Ctrl+T toggle, Claude Code style). The pinned view also shows a
+	// fully-completed list (normally hidden once nothing is outstanding).
+	showTasks bool
+
 	width int
 	quit  bool
 

--- a/cmd/octo/tuirepl_tasks.go
+++ b/cmd/octo/tuirepl_tasks.go
@@ -31,16 +31,22 @@ var (
 const maxTaskRows = 8
 
 // taskListView renders the live task block shown under the activity spinner
-// while a turn runs. It returns "" when there's nothing worth showing: no
-// store, no tasks, or every task already completed — the block tracks
-// outstanding work, so an all-done list would just clutter the live area
-// (the committed transcript still holds the history).
+// while a turn runs, or pinned via Ctrl+T. Unpinned, it returns "" when
+// there's nothing worth showing: no store, no tasks, or every task already
+// completed — the block tracks outstanding work, so an all-done list would
+// just clutter the live area (the committed transcript still holds the
+// history). Pinned, the user asked for it explicitly: an all-done list still
+// renders, and an empty one shows a placeholder instead of silently nothing.
 func (m *tuiModel) taskListView() string {
 	store := tools.ActiveTaskStore()
-	if store == nil {
-		return ""
+	var items []tasks.Task
+	if store != nil {
+		items = store.List()
 	}
-	return renderTaskLines(store.List(), m.width)
+	if m.showTasks && len(items) == 0 {
+		return taskConnStyle.Render("└ no tasks")
+	}
+	return renderTaskLines(items, m.width, m.showTasks)
 }
 
 // activeTaskPhrase returns the in-progress task's present-continuous form (or
@@ -63,17 +69,24 @@ func (m *tuiModel) activeTaskPhrase() string {
 
 // renderTaskLines is the pure formatter behind taskListView, split out so it
 // can be tested without the global store. width <= 0 disables truncation.
-func renderTaskLines(items []tasks.Task, width int) string {
-	// Hide the block once nothing is outstanding (all completed / empty).
-	outstanding := false
-	for _, t := range items {
-		if t.Status == tasks.Pending || t.Status == tasks.InProgress {
-			outstanding = true
-			break
-		}
-	}
-	if !outstanding {
+// showAll renders a list with nothing outstanding too (the pinned Ctrl+T
+// view); otherwise such a list is hidden.
+func renderTaskLines(items []tasks.Task, width int, showAll bool) string {
+	if len(items) == 0 {
 		return ""
+	}
+	// Hide the block once nothing is outstanding (all completed).
+	if !showAll {
+		outstanding := false
+		for _, t := range items {
+			if t.Status == tasks.Pending || t.Status == tasks.InProgress {
+				outstanding = true
+				break
+			}
+		}
+		if !outstanding {
+			return ""
+		}
 	}
 
 	// Checklist order: by creation (ID), so the block reads top-to-bottom as

--- a/cmd/octo/tuirepl_tasks_test.go
+++ b/cmd/octo/tuirepl_tasks_test.go
@@ -5,18 +5,50 @@ import (
 	"testing"
 
 	"github.com/Leihb/octo-agent/internal/tasks"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestRenderTaskLines_HidesWhenNothingOutstanding(t *testing.T) {
-	if got := renderTaskLines(nil, 80); got != "" {
+	if got := renderTaskLines(nil, 80, false); got != "" {
 		t.Errorf("empty list: want \"\", got %q", got)
 	}
 	allDone := []tasks.Task{
 		{ID: 1, Subject: "a", Status: tasks.Completed},
 		{ID: 2, Subject: "b", Status: tasks.Completed},
 	}
-	if got := renderTaskLines(allDone, 80); got != "" {
+	if got := renderTaskLines(allDone, 80, false); got != "" {
 		t.Errorf("all-completed list should be hidden, got %q", got)
+	}
+}
+
+// The pinned (Ctrl+T) view renders an all-completed list instead of hiding it.
+func TestRenderTaskLines_ShowAllRendersCompleted(t *testing.T) {
+	allDone := []tasks.Task{
+		{ID: 1, Subject: "a", Status: tasks.Completed},
+		{ID: 2, Subject: "b", Status: tasks.Completed},
+	}
+	out := renderTaskLines(allDone, 80, true)
+	if !strings.Contains(out, "✓") || !strings.Contains(out, "a") {
+		t.Errorf("pinned view should render the completed list, got %q", out)
+	}
+	if got := renderTaskLines(nil, 80, true); got != "" {
+		t.Errorf("empty list renders nothing even pinned (taskListView shows the placeholder), got %q", got)
+	}
+}
+
+// Ctrl+T toggles the pin; the pinned empty view shows a placeholder.
+func TestTUI_CtrlTTogglesTaskPin(t *testing.T) {
+	m := newTestModel()
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlT})
+	if !m.showTasks {
+		t.Fatal("Ctrl+T should pin the task list")
+	}
+	if got := m.taskListView(); !strings.Contains(got, "no tasks") {
+		t.Errorf("pinned view with no store should show the placeholder, got %q", got)
+	}
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlT})
+	if m.showTasks {
+		t.Error("second Ctrl+T should unpin")
 	}
 }
 
@@ -29,7 +61,7 @@ func TestRenderTaskLines_Layout(t *testing.T) {
 		{ID: 3, Subject: "Add test", Status: tasks.Pending},
 		{ID: 1, Subject: "Update docs", Status: tasks.Completed},
 	}
-	out := renderTaskLines(items, 80)
+	out := renderTaskLines(items, 80, false)
 	lines := strings.Split(out, "\n")
 	if len(lines) != 3 {
 		t.Fatalf("want 3 rows, got %d:\n%s", len(lines), out)
@@ -59,7 +91,7 @@ func TestRenderTaskLines_FoldsCompletedHead(t *testing.T) {
 	for i := 7; i <= 12; i++ {
 		items = append(items, tasks.Task{ID: i, Subject: "todo", Status: tasks.Pending})
 	}
-	out := renderTaskLines(items, 80)
+	out := renderTaskLines(items, 80, false)
 	lines := strings.Split(out, "\n")
 	if len(lines) > maxTaskRows {
 		t.Fatalf("block must stay within %d lines, got %d:\n%s", maxTaskRows, len(lines), out)
@@ -79,7 +111,7 @@ func TestRenderTaskLines_CollapsesLongList(t *testing.T) {
 	for i := 1; i <= 12; i++ {
 		items = append(items, tasks.Task{ID: i, Subject: "task", Status: tasks.Pending})
 	}
-	out := renderTaskLines(items, 80)
+	out := renderTaskLines(items, 80, false)
 	lines := strings.Split(out, "\n")
 	if len(lines) != maxTaskRows {
 		t.Fatalf("want %d rows (capped), got %d:\n%s", maxTaskRows, len(lines), out)

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -170,6 +170,13 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// handled by the textarea, so this binding is free for image paste.
 		return m.pasteClipboardImage()
 
+	case tea.KeyCtrlT:
+		// Toggle the pinned task checklist (Claude Code's ctrl+t). While a turn
+		// runs the list shows anyway; the pin keeps it visible when idle and
+		// includes a fully-completed list.
+		m.showTasks = !m.showTasks
+		return m, nil
+
 	case tea.KeyShiftTab:
 		// Cycle permission mode: interactive → auto → interactive.
 		if m.cfg.permEngine != nil {
@@ -972,9 +979,9 @@ func (m *tuiModel) View() string {
 	}
 
 	// Live task list — attached under the activity area while a turn runs
-	// (Claude Code style). Hidden when idle, and self-suppressing when there's
-	// no outstanding work (see taskListView).
-	if m.turnRunning {
+	// (Claude Code style), or pinned via Ctrl+T. Self-suppressing when there's
+	// no outstanding work, unless pinned (see taskListView).
+	if m.turnRunning || m.showTasks {
 		if tl := m.taskListView(); tl != "" {
 			b.WriteString(tl)
 			b.WriteByte('\n')

--- a/dev-docs/tui-ux-upgrade-design.md
+++ b/dev-docs/tui-ux-upgrade-design.md
@@ -105,7 +105,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 | 富 spinner（Braille + 轮转提示词） | ✅ | `tuirepl_view.go:spinnerLine/thinkingPhrase`, `spinner.go` |
 | glamour markdown（流式 block 边界提交） | ✅ | `markdown.go` |
 | 面板化（队列/后台/模态） | ✅ | `internal/tui/theme.go:Panel/Box` |
-| Live 任务检查单（创建序 ✓/■/□，spinner 显示进行中任务 ActiveForm，超长先折叠已完成头部为「✓ N done」再尾部「… N more」） | ✅ | `tuirepl_tasks.go` |
+| Live 任务检查单（创建序 ✓/■/□，spinner 显示进行中任务 ActiveForm，超长先折叠已完成头部为「✓ N done」再尾部「… N more」；Ctrl+T 在空闲时也钉住显示，含全完成列表与「no tasks」占位） | ✅ | `tuirepl_tasks.go` |
 | 统一自适应主题 | ✅ | `internal/tui/theme.go` |
 | 章鱼像素-art 横幅 | ✅ | `internal/tui/theme.go:Banner`（Init 时打印一次） |
 | 卡片归属 TUI-only（plainView 纯文本） | ✅ | `toolcards.go`, `repl.go` |

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -67,7 +67,7 @@ var (
 // bottom status bar can stay free of a persistent hint line.
 var bannerHints = []string{
 	"Enter send · Shift+Enter/Ctrl+J newline · Ctrl+Q queue",
-	"Shift+Tab perm-mode · Esc interrupt · Ctrl+C quit",
+	"Shift+Tab perm-mode · Ctrl+T tasks · Esc interrupt · Ctrl+C quit",
 }
 
 // octopusASCII is the pixel-art octo mascot — a rounded octopus with a domed


### PR DESCRIPTION
## What

The live task checklist (#605) only appeared while a turn ran. This adds Claude Code's `ctrl+t` toggle:

- **Ctrl+T pins the checklist** in the live area regardless of turn state; press again to unpin.
- Pinned, the block also renders a **fully-completed list** (normally self-suppressing once nothing is outstanding) and shows a dim `└ no tasks` placeholder when empty — the toggle always has a visible effect.
- `renderTaskLines` gains a `showAll` flag (pure-function change; unpinned behaviour identical).
- Banner hints now include `Ctrl+T tasks`. Ctrl+T was previously unbound.

## Tests
- Ctrl+T toggles the pin + empty-store placeholder.
- `showAll` renders an all-completed list; unpinned still hides it.
- `go test -race` green on cmd/octo + internal/tui; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)