### PR TITLE
feat: 3-transport parity — IM persistence/freshness/steer/questions + always-allow everywhere

### DIFF
--- a/dev-docs/im-parity-design.md
+++ b/dev-docs/im-parity-design.md
@@ -21,21 +21,29 @@ config changes), every restart wiped every conversation.
   the web session list; the title defaults to the key.
 - **Restore is best-effort**: a corrupt or missing file degrades to a fresh
   conversation, never blocks the chat.
-- **`/unbind` and `/bind` delete the store.** Their contracts ("history
-  cleared", "start fresh") must hold across restarts too — without the
-  delete, `/bind`'s new session would just rehydrate the history the user
-  asked to drop. `/bind` also clears a leftover store when no live session
-  exists.
-- Persist failures are logged to the server console and never eat the reply
-  the user already received.
+- **`/unbind` and `/bind` delete the store — and tombstone it.** Their
+  contracts ("history cleared", "start fresh") must hold across restarts
+  too. Commands run on the adapter callback goroutine while a turn may
+  still be in flight, so `deleteStore` nils the store under a mutex: the
+  zombie turn's post-turn `Persist` observes the tombstone and no-ops
+  instead of recreating the just-deleted file. A failed delete is reported
+  in the chat rather than silently claiming the history is gone.
+- **Persist runs after every turn, including each chained steer turn** — a
+  crash costs at most one turn, not a whole chain. Failures are logged to
+  the server console and never eat the reply the user already received.
 
 ## Per-turn memory freshness
 
 `handleChannelMessage` recomposes the agent's system prompt (memory
-injection included) at the start of every turn. Web turns always had this —
-`buildAgent` runs per turn — but the IM factory composed the prompt once at
-session creation, so memory written mid-session was invisible to IM until a
-restart.
+injection and the skills manifest included) at the start of every turn. Web
+turns always had this — `buildAgent` runs per turn — but the IM factory
+composed the prompt once at session creation, so memory written and skills
+imported mid-session were invisible to IM until a restart.
+
+Known remaining gap: IM agents don't carry the L2 memory hooks
+(`UserInputHook` keyword reminders, `ToolResultHook` save-nudges) that
+`buildAgent` wires for web sessions — only the L1 system-prompt injection
+reaches IM.
 
 ## Mid-turn steer
 

--- a/dev-docs/im-parity-design.md
+++ b/dev-docs/im-parity-design.md
@@ -1,0 +1,97 @@
+# IM Channel Parity
+
+Four capabilities the web transport had and the IM channel lacked, closed in
+one round: conversation persistence, per-turn memory freshness, mid-turn
+steering, and an in-chat `ask_user_question`. Together with the interactive
+permission ask (`im-interactive-ask-design.md`), IM turns now run with the
+same session machinery as web turns — only the prompt/reply surface differs.
+
+## Conversation persistence
+
+IM sessions back onto the same store web sessions use: `agent.Session` JSONL
+under `~/.octo/sessions`, written via `Session.Persist()` after every turn
+and reloaded on session creation. Before this, IM history lived only in
+process memory — and with self-restart making restarts routine (upgrades,
+config changes), every restart wiped every conversation.
+
+- **Deterministic store ID** (`internal/channel/persist.go`):
+  `im-<sanitized key>-<fnv32>`, derived from the session key
+  (`platform:chat:user`), so the first message after a restart finds its
+  file without any extra mapping state. `Source: "channel"` marks these in
+  the web session list; the title defaults to the key.
+- **Restore is best-effort**: a corrupt or missing file degrades to a fresh
+  conversation, never blocks the chat.
+- **`/unbind` and `/bind` delete the store.** Their contracts ("history
+  cleared", "start fresh") must hold across restarts too — without the
+  delete, `/bind`'s new session would just rehydrate the history the user
+  asked to drop. `/bind` also clears a leftover store when no live session
+  exists.
+- Persist failures are logged to the server console and never eat the reply
+  the user already received.
+
+## Per-turn memory freshness
+
+`handleChannelMessage` recomposes the agent's system prompt (memory
+injection included) at the start of every turn. Web turns always had this —
+`buildAgent` runs per turn — but the IM factory composed the prompt once at
+session creation, so memory written mid-session was invisible to IM until a
+restart.
+
+## Mid-turn steer
+
+A message arriving while a turn is running rides that turn instead of
+queueing a whole second turn behind `runMu` (web/CLI parity):
+
+- `routeChannelEvent` checks `Session.IsRunning()` (after the command and
+  pending-ask checks) and enqueues the text into the running turn's
+  `Agent.Inbox`, which the agent loop drains between iterations.
+- Items that arrive after the turn's final drain chain into follow-up turns
+  inside `handleChannelMessage`, still under `BeginRun`, mirroring the web's
+  `runAgentTurnLoop`.
+- Known small race: a turn that finishes between the `IsRunning` check and
+  the enqueue leaves the message in the Inbox until the chat's next turn —
+  delayed, not lost. Same acceptance class as the ask-reply race.
+
+## `ask_user_question` over chat
+
+The asker is now turn-scoped: `tools.WithAsker(ctx, …)` beats the
+process-global asker (the same ctx-scoping pattern as the sub-agent manager
+and task store). The server's global asker is the WebSocket one; an IM turn
+using it would broadcast the question to browser tabs the session doesn't
+have and hang until `/stop`. IM turns stamp `chatAsker` instead:
+
+```
+❓ [scope] Which environment?
+1. staging
+2. production
+Reply with a number — or free text for something else.
+```
+
+The answer arrives through the same session ask slot the permission prompt
+uses (`Session.BeginAsk`, requester-scoped, one at a time): a number picks
+its option, `1,3` selects several when multi-select, an exact label matches
+its option, anything else returns as the free-text "Other" answer, and the
+5-minute timeout cancels. Out-of-range numbers fall through to free text —
+over chat, a re-prompt loop is worse than letting the model read the raw
+reply.
+
+## Components
+
+| Piece | Where | What |
+|---|---|---|
+| Store | `internal/channel/persist.go` | deterministic ID, restore-or-init, `Persist`, store delete on /bind //unbind |
+| Steer intake | `internal/server/server.go` `routeChannelEvent` | command → ask → steer-if-running → turn |
+| Chained turns + persist + recompose | `internal/server/server.go` `handleChannelMessage` | leftover-inbox loop, per-turn `prompt.Compose`, post-turn `Persist` |
+| Ctx asker | `internal/tools/ask_user_question.go` | `WithAsker` / `askerFrom`, global fallback |
+| Chat asker | `internal/server/channel_ask.go` | numbered options, reply parsing, timeout |
+
+## Testing
+
+- Persistence: deterministic/safe ID, persist→restore across managers,
+  append across turns, `/unbind` and `/bind` delete, end-to-end through
+  `handleChannelMessage` with a stub sender.
+- Steer: blocking-sender test pins enqueue-while-running and the chained
+  drain reaching the model.
+- Freshness: memory file written between two turns is visible to the second.
+- Asker: ctx-beats-global, global fallback, reply parsing table, numbered
+  pick end-to-end, timeout cancel.

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -47,6 +47,11 @@ func sessionKeyFor(mode BindingMode, ev InboundEvent) SessionKey {
 type Session struct {
 	Key   SessionKey
 	Agent *agent.Agent
+
+	// Store is the on-disk history backing this conversation (persist.go).
+	// Loaded/initialised at session creation, written via Persist after
+	// each turn so the conversation survives server restarts.
+	Store *agent.Session
 	// Tasks is the conversation's task store. It lives as long as the session,
 	// so task_* state persists across messages within one chat (a fresh
 	// per-message store would reset the list every turn). Stamped into the turn
@@ -93,6 +98,15 @@ func (s *Session) BeginRun(ctx context.Context) (context.Context, func()) {
 	}
 }
 
+// IsRunning reports whether an agent turn is currently in flight. The
+// inbound dispatcher uses it to steer a mid-turn message into the running
+// turn's Inbox instead of queueing a whole new turn behind runMu.
+func (s *Session) IsRunning() bool {
+	s.cancelMu.Lock()
+	defer s.cancelMu.Unlock()
+	return s.runCancel != nil
+}
+
 // Interrupt cancels the session's in-flight agent turn, if any. It reports
 // whether a turn was actually running.
 func (s *Session) Interrupt() bool {
@@ -113,7 +127,7 @@ type AgentFactory func() *agent.Agent
 // store. Centralised so every binding path (explicit /bind, auto-create on
 // first message, GetOrCreateSession) wires sessions identically.
 func (m *Manager) newSession(key SessionKey, ev InboundEvent) *Session {
-	return &Session{
+	s := &Session{
 		Key:     key,
 		Agent:   m.factory(),
 		Tasks:   tasks.New(),
@@ -121,6 +135,8 @@ func (m *Manager) newSession(key SessionKey, ev InboundEvent) *Session {
 		UserID:  ev.UserID,
 		BoundAt: time.Now(),
 	}
+	s.restoreOrInitStore()
+	return s
 }
 
 // Manager owns the lifecycle of adapters and their bound sessions.
@@ -263,11 +279,17 @@ func (m *Manager) CommandRouter(ev InboundEvent) string {
 	}
 }
 
-// cmdBind explicitly binds the current chat/user to a new session.
+// cmdBind explicitly binds the current chat/user to a new session. The
+// persisted store is deleted first — /bind means "start fresh", and without
+// the delete the new session would just rehydrate the old history.
 func (m *Manager) cmdBind(ev InboundEvent, args []string) string {
 	key := sessionKeyFor(m.mode, ev)
-	if _, loaded := m.sessions.Load(key); loaded {
-		m.sessions.Delete(key)
+	if val, loaded := m.sessions.LoadAndDelete(key); loaded {
+		val.(*Session).deleteStore()
+	} else {
+		// No live session, but a persisted store from a previous process
+		// may still exist; /bind must clear that too.
+		_ = agent.DeleteSession(sessionStoreID(key))
 	}
 	sess := m.newSession(key, ev)
 	m.sessions.Store(key, sess)
@@ -293,12 +315,15 @@ func (m *Manager) cmdStop(ev InboundEvent) string {
 	return "No task is running."
 }
 
-// cmdUnbind deletes the current session and its history.
+// cmdUnbind deletes the current session and its history, including the
+// persisted store — "history cleared" must survive a restart too.
 func (m *Manager) cmdUnbind(ev InboundEvent) string {
 	key := sessionKeyFor(m.mode, ev)
-	if _, loaded := m.sessions.LoadAndDelete(key); !loaded {
+	val, loaded := m.sessions.LoadAndDelete(key)
+	if !loaded {
 		return "No active session for this context."
 	}
+	val.(*Session).deleteStore()
 	return "Session unbound and history cleared."
 }
 

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -3,6 +3,7 @@ package channel
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -50,8 +51,11 @@ type Session struct {
 
 	// Store is the on-disk history backing this conversation (persist.go).
 	// Loaded/initialised at session creation, written via Persist after
-	// each turn so the conversation survives server restarts.
-	Store *agent.Session
+	// each turn so the conversation survives server restarts. storeMu
+	// guards it: deleteStore tombstones the field while a turn may still
+	// be running, and that turn's Persist must observe the nil.
+	Store   *agent.Session
+	storeMu sync.Mutex
 	// Tasks is the conversation's task store. It lives as long as the session,
 	// so task_* state persists across messages within one chat (a fresh
 	// per-message store would reset the list every turn). Stamped into the turn
@@ -284,12 +288,18 @@ func (m *Manager) CommandRouter(ev InboundEvent) string {
 // the delete the new session would just rehydrate the old history.
 func (m *Manager) cmdBind(ev InboundEvent, args []string) string {
 	key := sessionKeyFor(m.mode, ev)
+	var delErr error
 	if val, loaded := m.sessions.LoadAndDelete(key); loaded {
-		val.(*Session).deleteStore()
+		delErr = val.(*Session).deleteStore()
 	} else {
 		// No live session, but a persisted store from a previous process
 		// may still exist; /bind must clear that too.
-		_ = agent.DeleteSession(sessionStoreID(key))
+		if err := agent.DeleteSession(sessionStoreID(key)); err != nil && !os.IsNotExist(err) {
+			delErr = err
+		}
+	}
+	if delErr != nil {
+		return fmt.Sprintf("Cannot start fresh: clearing the previous history failed: %v", delErr)
 	}
 	sess := m.newSession(key, ev)
 	m.sessions.Store(key, sess)
@@ -323,7 +333,9 @@ func (m *Manager) cmdUnbind(ev InboundEvent) string {
 	if !loaded {
 		return "No active session for this context."
 	}
-	val.(*Session).deleteStore()
+	if err := val.(*Session).deleteStore(); err != nil {
+		return fmt.Sprintf("Session unbound, but clearing the persisted history failed: %v", err)
+	}
 	return "Session unbound and history cleared."
 }
 

--- a/internal/channel/persist.go
+++ b/internal/channel/persist.go
@@ -3,6 +3,7 @@ package channel
 import (
 	"fmt"
 	"hash/fnv"
+	"os"
 	"strings"
 	"time"
 
@@ -64,7 +65,15 @@ func (s *Session) restoreOrInitStore() {
 // Persist writes the agent's current history to the session store. Called by
 // the server after each IM turn; errors are the caller's to log — losing one
 // round of persistence must not fail the chat reply.
+//
+// storeMu makes deleteStore a tombstone: /unbind and /bind run on the
+// adapter callback goroutine while a turn may still be in flight, and that
+// zombie turn's Persist would otherwise recreate the just-deleted file
+// (Save's append path opens with O_CREATE) — resurrecting history the user
+// explicitly cleared, as a malformed meta-less session file.
 func (s *Session) Persist() error {
+	s.storeMu.Lock()
+	defer s.storeMu.Unlock()
 	if s.Store == nil {
 		return nil
 	}
@@ -72,11 +81,20 @@ func (s *Session) Persist() error {
 	return s.Store.Save()
 }
 
-// deleteStore removes the persisted history; used by /unbind, whose contract
-// is "history cleared".
-func (s *Session) deleteStore() {
+// deleteStore removes the persisted history and tombstones the store so an
+// in-flight turn can't write it back; used by /unbind and /bind, whose
+// contracts are "history cleared" / "start fresh". Returns the delete error
+// for callers that want to warn the user (a missing file is not an error).
+func (s *Session) deleteStore() error {
+	s.storeMu.Lock()
+	defer s.storeMu.Unlock()
 	if s.Store == nil {
-		return
+		return nil
 	}
-	_ = agent.DeleteSession(s.Store.ID)
+	id := s.Store.ID
+	s.Store = nil
+	if err := agent.DeleteSession(id); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }

--- a/internal/channel/persist.go
+++ b/internal/channel/persist.go
@@ -1,0 +1,82 @@
+package channel
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strings"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// IM sessions persist their conversation history to the same store web
+// sessions use (~/.octo/sessions, agent.Session JSONL). The store ID is
+// derived deterministically from the session key, so after a server restart
+// the first message from a chat reloads its history — before this, IM
+// context lived only in process memory and a restart (now a routine event:
+// upgrades, config changes) wiped every conversation.
+
+// sessionStoreID maps a SessionKey onto a filename-safe, deterministic
+// agent.Session ID. The sanitized key keeps the file recognisable in the
+// sessions directory; the FNV suffix disambiguates keys that collide after
+// sanitization.
+func sessionStoreID(key SessionKey) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+
+	safe := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			return r
+		default:
+			return '-'
+		}
+	}, string(key))
+	if len(safe) > 48 {
+		safe = safe[:48]
+	}
+	return fmt.Sprintf("im-%s-%08x", safe, h.Sum32())
+}
+
+// restoreOrInitStore attaches the persistent store to a freshly built
+// session: an existing file rehydrates the agent's history, otherwise a new
+// store is initialised. Best-effort — a corrupt or unreadable file degrades
+// to a fresh conversation rather than blocking the chat.
+func (s *Session) restoreOrInitStore() {
+	id := sessionStoreID(s.Key)
+	if loaded, err := agent.LoadSession(id); err == nil {
+		s.Store = loaded
+		if len(loaded.Messages) > 0 {
+			s.Agent.History = loaded.ToHistory()
+		}
+		return
+	}
+	st := &agent.Session{
+		ID:        id,
+		CreatedAt: time.Now(),
+		Model:     s.Agent.Model,
+		Source:    "channel",
+		Title:     string(s.Key),
+	}
+	s.Store = st
+}
+
+// Persist writes the agent's current history to the session store. Called by
+// the server after each IM turn; errors are the caller's to log — losing one
+// round of persistence must not fail the chat reply.
+func (s *Session) Persist() error {
+	if s.Store == nil {
+		return nil
+	}
+	s.Store.SyncFrom(s.Agent.History)
+	return s.Store.Save()
+}
+
+// deleteStore removes the persisted history; used by /unbind, whose contract
+// is "history cleared".
+func (s *Session) deleteStore() {
+	if s.Store == nil {
+		return
+	}
+	_ = agent.DeleteSession(s.Store.ID)
+}

--- a/internal/channel/persist_test.go
+++ b/internal/channel/persist_test.go
@@ -133,3 +133,35 @@ func TestCmdBind_StartsFresh(t *testing.T) {
 		t.Errorf("history after /bind = %d messages, want 0 (fresh session)", got)
 	}
 }
+
+// TestDeleteStore_TombstonesAgainstZombiePersist pins the /unbind-during-turn
+// contract: a turn that finishes after the user cleared the history must not
+// recreate the file via its post-turn Persist.
+func TestDeleteStore_TombstonesAgainstZombiePersist(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+
+	m := testManager()
+	sess := m.GetOrCreateSession(ev)
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "private"})
+	if err := sess.Persist(); err != nil {
+		t.Fatal(err)
+	}
+	path, err := sess.Store.SavePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if reply := m.cmdUnbind(ev); !strings.Contains(reply, "cleared") {
+		t.Fatalf("unexpected unbind reply %q", reply)
+	}
+
+	// The zombie turn finishes now and persists — the tombstone must hold.
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleAssistant, Content: "late reply"})
+	if err := sess.Persist(); err != nil {
+		t.Fatalf("zombie Persist should no-op, got %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("zombie turn resurrected the deleted history file")
+	}
+}

--- a/internal/channel/persist_test.go
+++ b/internal/channel/persist_test.go
@@ -1,0 +1,135 @@
+package channel
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+func tempHome(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+}
+
+func testManager() *Manager {
+	return NewManager(&Config{}, func() *agent.Agent {
+		return agent.New(nil, "stub-model")
+	}, BindByChatUser)
+}
+
+func TestSessionStoreID_DeterministicAndSafe(t *testing.T) {
+	a := sessionStoreID(SessionKey("feishu:oc_4a/b#c:ou_x"))
+	b := sessionStoreID(SessionKey("feishu:oc_4a/b#c:ou_x"))
+	if a != b {
+		t.Errorf("same key produced different IDs: %q vs %q", a, b)
+	}
+	if c := sessionStoreID(SessionKey("feishu:oc_4a/b#c:ou_y")); c == a {
+		t.Error("different keys must produce different IDs")
+	}
+	for _, r := range a {
+		if !strings.ContainsRune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.", r) {
+			t.Fatalf("ID %q contains filename-unsafe rune %q", a, r)
+		}
+	}
+}
+
+func TestSession_PersistAndRestore(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1", Text: "hi"}
+
+	m1 := testManager()
+	sess := m1.GetOrCreateSession(ev)
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "remember the number 42"})
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleAssistant, Content: "noted: 42"})
+	if err := sess.Persist(); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+
+	// A fresh manager simulates the post-restart process: same event key must
+	// come back with the conversation history.
+	m2 := testManager()
+	restored := m2.GetOrCreateSession(ev)
+	msgs := restored.Agent.History.Snapshot()
+	if len(msgs) != 2 {
+		t.Fatalf("restored history has %d messages, want 2", len(msgs))
+	}
+	if msgs[1].Content != "noted: 42" {
+		t.Errorf("restored msg = %q, want %q", msgs[1].Content, "noted: 42")
+	}
+	if restored.Store.Source != "channel" {
+		t.Errorf("store source = %q, want channel", restored.Store.Source)
+	}
+}
+
+func TestSession_PersistAcrossTurnsAppends(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "tg", ChatID: "c", UserID: "u"}
+
+	m := testManager()
+	sess := m.GetOrCreateSession(ev)
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "one"})
+	if err := sess.Persist(); err != nil {
+		t.Fatal(err)
+	}
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleAssistant, Content: "two"})
+	if err := sess.Persist(); err != nil {
+		t.Fatal(err)
+	}
+
+	restored := testManager().GetOrCreateSession(ev)
+	if got := len(restored.Agent.History.Snapshot()); got != 2 {
+		t.Errorf("history after two persists = %d messages, want 2", got)
+	}
+}
+
+func TestCmdUnbind_DeletesStore(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+
+	m := testManager()
+	sess := m.GetOrCreateSession(ev)
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "secret"})
+	if err := sess.Persist(); err != nil {
+		t.Fatal(err)
+	}
+	path, err := sess.Store.SavePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("store file missing before unbind: %v", err)
+	}
+
+	if reply := m.cmdUnbind(ev); !strings.Contains(reply, "unbound") {
+		t.Fatalf("unexpected unbind reply %q", reply)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("/unbind must delete the persisted history")
+	}
+}
+
+// TestCmdBind_StartsFresh: /bind explicitly resets the conversation; the new
+// session must not rehydrate the previous history from disk.
+func TestCmdBind_StartsFresh(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+
+	m := testManager()
+	sess := m.GetOrCreateSession(ev)
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "old context"})
+	if err := sess.Persist(); err != nil {
+		t.Fatal(err)
+	}
+
+	if reply := m.cmdBind(ev, nil); !strings.Contains(reply, "bound") {
+		t.Fatalf("unexpected bind reply %q", reply)
+	}
+	fresh := m.GetSession(ev)
+	if got := len(fresh.Agent.History.Snapshot()); got != 0 {
+		t.Errorf("history after /bind = %d messages, want 0 (fresh session)", got)
+	}
+}

--- a/internal/server/channel_ask.go
+++ b/internal/server/channel_ask.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/channel"
+	"github.com/Leihb/octo-agent/internal/tools"
 )
 
 // channelAskTimeout bounds how long an IM permission prompt waits for the
@@ -92,4 +94,94 @@ func (s *Server) channelPermissionAsk(sess *channel.Session, ad channel.Adapter,
 			return false, false, nil
 		}
 	}
+}
+
+// channelAsker adapts the chat into a tools.Asker for ask_user_question:
+// the question goes out as a numbered list, and the requesting user's next
+// message answers it through the same session ask slot the permission
+// prompt uses. Stamped into the turn ctx by handleChannelMessage
+// (tools.WithAsker), where it overrides the process-global wsAsker — which
+// would otherwise broadcast IM questions to browser tabs that don't exist.
+func (s *Server) channelAsker(sess *channel.Session, ad channel.Adapter, ev channel.InboundEvent) tools.Asker {
+	return chatAsker{sess: sess, ad: ad, ev: ev}
+}
+
+type chatAsker struct {
+	sess *channel.Session
+	ad   channel.Adapter
+	ev   channel.InboundEvent
+}
+
+func (c chatAsker) Ask(ctx context.Context, q tools.AskRequest) (tools.AskResponse, error) {
+	replyCh, release, err := c.sess.BeginAsk(c.ev.ChatID, c.ev.UserID)
+	if err != nil {
+		return tools.AskResponse{}, err
+	}
+	defer release()
+
+	var b strings.Builder
+	b.WriteString("❓ ")
+	if q.Header != "" {
+		fmt.Fprintf(&b, "[%s] ", q.Header)
+	}
+	b.WriteString(q.Question + "\n")
+	for i, opt := range q.Options {
+		fmt.Fprintf(&b, "%d. %s\n", i+1, opt)
+	}
+	if q.MultiSelect {
+		b.WriteString("Reply with number(s), e.g. 1,3 — or free text for something else.")
+	} else {
+		b.WriteString("Reply with a number — or free text for something else.")
+	}
+	c.ad.SendText(c.ev.ChatID, b.String(), c.ev.MessageID)
+
+	timer := time.NewTimer(channelAskTimeout)
+	defer timer.Stop()
+	select {
+	case text := <-replyCh:
+		return parseAskReply(text, q), nil
+	case <-ctx.Done():
+		return tools.AskResponse{Cancelled: true}, ctx.Err()
+	case <-timer.C:
+		return tools.AskResponse{Cancelled: true}, nil
+	}
+}
+
+// parseAskReply maps the chat reply onto the structured response: numbers
+// pick options (several for multi-select), an exact label matches its
+// option, anything else is a free-text "Other" answer. Out-of-range numbers
+// fall through to free text rather than erroring — over chat, re-prompting
+// loops are worse than letting the model see the raw reply.
+func parseAskReply(text string, q tools.AskRequest) tools.AskResponse {
+	t := strings.TrimSpace(text)
+	if t == "" {
+		return tools.AskResponse{Cancelled: true}
+	}
+
+	parts := strings.FieldsFunc(t, func(r rune) bool {
+		return r == ',' || r == '，' || r == '、' || r == ' '
+	})
+	var choices []string
+	numeric := len(parts) > 0
+	for _, p := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil || n < 1 || n > len(q.Options) {
+			numeric = false
+			break
+		}
+		choices = append(choices, q.Options[n-1])
+	}
+	if numeric {
+		if !q.MultiSelect && len(choices) > 1 {
+			choices = choices[:1]
+		}
+		return tools.AskResponse{Choices: choices}
+	}
+
+	for _, opt := range q.Options {
+		if strings.EqualFold(t, opt) {
+			return tools.AskResponse{Choices: []string{opt}}
+		}
+	}
+	return tools.AskResponse{Custom: t}
 }

--- a/internal/server/channel_ask_test.go
+++ b/internal/server/channel_ask_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/channel"
+	"github.com/Leihb/octo-agent/internal/tools"
 )
 
 func TestIsAffirmative(t *testing.T) {
@@ -146,4 +147,79 @@ func waitFor(t *testing.T, cond func() bool) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatal("condition not met within 2s")
+}
+
+func TestParseAskReply(t *testing.T) {
+	q := tools.AskRequest{Question: "q", Options: []string{"Alpha", "Beta", "Gamma"}}
+	multi := tools.AskRequest{Question: "q", Options: []string{"Alpha", "Beta", "Gamma"}, MultiSelect: true}
+
+	cases := []struct {
+		req     tools.AskRequest
+		text    string
+		choices []string
+		custom  string
+		cancel  bool
+	}{
+		{q, "2", []string{"Beta"}, "", false},
+		{q, " 1 ", []string{"Alpha"}, "", false},
+		{q, "beta", []string{"Beta"}, "", false},        // label match, case-insensitive
+		{q, "do it my way", nil, "do it my way", false}, // free text
+		{q, "9", nil, "9", false},                       // out of range → custom text
+		{q, "", nil, "", true},
+		{multi, "1,3", []string{"Alpha", "Gamma"}, "", false},
+		{multi, "1、3", []string{"Alpha", "Gamma"}, "", false},
+	}
+	for _, c := range cases {
+		got := parseAskReply(c.text, c.req)
+		if got.Cancelled != c.cancel {
+			t.Errorf("parse(%q) cancelled = %v, want %v", c.text, got.Cancelled, c.cancel)
+			continue
+		}
+		if strings.Join(got.Choices, "|") != strings.Join(c.choices, "|") || got.Custom != c.custom {
+			t.Errorf("parse(%q) = choices %v custom %q, want %v %q", c.text, got.Choices, got.Custom, c.choices, c.custom)
+		}
+	}
+}
+
+func TestChannelAsker_NumberPicksOption(t *testing.T) {
+	srv, sess, ad, ev := askEnv(t)
+	asker := srv.channelAsker(sess, ad, ev)
+
+	done := make(chan tools.AskResponse, 1)
+	go func() {
+		res, _ := asker.Ask(context.Background(), tools.AskRequest{
+			Question: "Deploy where?", Options: []string{"staging", "production"},
+		})
+		done <- res
+	}()
+	waitFor(t, func() bool { return len(ad.texts()) == 1 })
+	prompt := ad.texts()[0]
+	if !strings.Contains(prompt, "Deploy where?") || !strings.Contains(prompt, "1. staging") {
+		t.Errorf("prompt %q must show the question and numbered options", prompt)
+	}
+	if !sess.DeliverAskReply("c1", "", "2") {
+		t.Fatal("ask slot not armed")
+	}
+	res := <-done
+	if len(res.Choices) != 1 || res.Choices[0] != "production" {
+		t.Errorf("choices = %v, want [production]", res.Choices)
+	}
+}
+
+func TestChannelAsker_TimeoutCancels(t *testing.T) {
+	old := channelAskTimeout
+	channelAskTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { channelAskTimeout = old })
+
+	srv, sess, ad, ev := askEnv(t)
+	_ = sess
+	_ = ad
+	asker := srv.channelAsker(sess, ad, ev)
+	res, err := asker.Ask(context.Background(), tools.AskRequest{Question: "q", Options: []string{"a", "b"}})
+	if err != nil {
+		t.Fatalf("timeout should cancel without error, got %v", err)
+	}
+	if !res.Cancelled {
+		t.Error("timeout must report Cancelled")
+	}
 }

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -190,5 +191,129 @@ func TestRouteChannelEvent_EmptyTextNeverAnswers(t *testing.T) {
 	case got := <-replyCh:
 		t.Fatalf("empty text %q answered the ask", got)
 	default:
+	}
+}
+
+// blockingSender lets a test hold a turn open: the first call blocks until
+// release is closed; inputs records the last user message of each call.
+type blockingSender struct {
+	mu      sync.Mutex
+	calls   int
+	inputs  []string
+	started chan struct{} // signalled once per call
+	release chan struct{} // first call blocks on this
+}
+
+func (b *blockingSender) record(msgs []agent.Message) (first bool) {
+	b.mu.Lock()
+	b.calls++
+	first = b.calls == 1
+	if len(msgs) > 0 {
+		last := msgs[len(msgs)-1]
+		text := last.Content
+		if text == "" {
+			for _, blk := range last.Blocks {
+				if blk.Type == "text" {
+					text = blk.Text
+				}
+			}
+		}
+		b.inputs = append(b.inputs, text)
+	}
+	b.mu.Unlock()
+	b.started <- struct{}{}
+	return first
+}
+
+func (b *blockingSender) SendMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int) (agent.Reply, error) {
+	if b.record(msgs) {
+		<-b.release
+	}
+	return agent.Reply{Content: "blocking reply"}, nil
+}
+
+func (b *blockingSender) StreamMessages(ctx context.Context, model, system string, msgs []agent.Message, maxTokens int, onChunk func(string), _ func(string)) (agent.Reply, error) {
+	return b.SendMessages(ctx, model, system, msgs, maxTokens)
+}
+
+func (b *blockingSender) snapshot() (int, []string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.calls, append([]string(nil), b.inputs...)
+}
+
+// TestRouteChannelEvent_MidTurnMessageSteers: a message during a running IM
+// turn rides the turn's Inbox and chains into a follow-up turn — it must not
+// queue as an independent second turn, and it must not be lost.
+func TestRouteChannelEvent_MidTurnMessageSteers(t *testing.T) {
+	sender := &blockingSender{started: make(chan struct{}, 8), release: make(chan struct{})}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+		return agent.New(sender, "stub-model")
+	}, channel.BindByChat)
+	ad := &fullFakeAdapter{}
+
+	srv.routeChannelEvent(context.Background(), ad, evFor("first message"))
+	<-sender.started // turn 1 is now blocked inside the sender
+
+	srv.routeChannelEvent(context.Background(), ad, evFor("steer me in"))
+	sess := srv.channelMgr.GetSession(evFor("x"))
+	if !sess.Agent.Inbox.HasPending() {
+		t.Fatal("mid-turn message did not land in the running turn's Inbox")
+	}
+
+	close(sender.release) // let turn 1 finish; the leftover steers must chain
+	<-sender.started      // the chained turn hit the sender
+
+	waitFor(t, func() bool { calls, _ := sender.snapshot(); return calls >= 2 })
+	_, inputs := sender.snapshot()
+	found := false
+	for _, in := range inputs {
+		if strings.Contains(in, "steer me in") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("steer text never reached the model; inputs = %q", inputs)
+	}
+}
+
+// TestHandleChannelMessage_PersistsTurn: an IM turn's history must land on
+// disk so a fresh manager (post-restart) restores the conversation.
+func TestHandleChannelMessage_PersistsTurn(t *testing.T) {
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	srv.handleChannelMessage(context.Background(), ad, evFor("please remember 42"))
+
+	fresh := channel.NewManager(&channel.Config{}, func() *agent.Agent {
+		return agent.New(&stubSender{}, "stub-model")
+	}, channel.BindByChat)
+	restored := fresh.GetOrCreateSession(evFor("x"))
+	msgs := restored.Agent.History.Snapshot()
+	if len(msgs) < 2 {
+		t.Fatalf("restored history has %d messages, want >=2 (user+assistant)", len(msgs))
+	}
+}
+
+// TestHandleChannelMessage_RefreshesSystemPerTurn: memory written after the
+// session was created must be visible on the next turn without a restart.
+func TestHandleChannelMessage_RefreshesSystemPerTurn(t *testing.T) {
+	srv := chanServer(t)
+	srv.memDir = t.TempDir()
+	ad := &fullFakeAdapter{}
+
+	srv.handleChannelMessage(context.Background(), ad, evFor("turn one"))
+	sess := srv.channelMgr.GetSession(evFor("x"))
+	if strings.Contains(sess.Agent.System, "fresh-fact-9000") {
+		t.Fatal("memory marker present before it was written")
+	}
+
+	if err := os.WriteFile(srv.memDir+"/MEMORY.md", []byte("- fresh-fact-9000"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	srv.handleChannelMessage(context.Background(), ad, evFor("turn two"))
+	if !strings.Contains(sess.Agent.System, "fresh-fact-9000") {
+		t.Error("system prompt not recomposed: memory written mid-session is invisible to IM turns")
 	}
 }

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -281,6 +281,9 @@ func TestRouteChannelEvent_MidTurnMessageSteers(t *testing.T) {
 // TestHandleChannelMessage_PersistsTurn: an IM turn's history must land on
 // disk so a fresh manager (post-restart) restores the conversation.
 func TestHandleChannelMessage_PersistsTurn(t *testing.T) {
+	tmp := t.TempDir() // isolated HOME: deterministic store IDs cross-pollinate otherwise
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	srv := chanServer(t)
 	ad := &fullFakeAdapter{}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1141,6 +1141,11 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 			sess.Agent.Inbox.Enqueue(tools.FormatBgNote(e))
 		})
 		ctx = tools.WithBackgroundManager(ctx, bgMgr)
+		// Turn-scoped asker: ask_user_question prompts in this chat instead
+		// of falling back to the process-global wsAsker, which broadcasts to
+		// browser tabs an IM session doesn't have (the question would hang
+		// until /stop).
+		ctx = tools.WithAsker(ctx, s.channelAsker(sess, ad, ev))
 	}
 
 	_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, ev.Text)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1045,7 +1045,11 @@ func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev c
 			// handleChannelMessage) — web/CLI parity, instead of queueing a
 			// whole second turn. Known small race: a turn that finishes
 			// between this check and the enqueue leaves the message in the
-			// Inbox until the chat's next turn — delayed, not lost.
+			// Inbox until the chat's next turn — delayed, not lost. Under
+			// shared-session bindings (BindByChat/BindByUser) this folds
+			// OTHER users' messages into the running turn too — coherent
+			// for a shared conversation, but a behavior those modes should
+			// revisit if the server ever stops hardcoding BindByChatUser.
 			if sess.IsRunning() {
 				sess.Agent.Inbox.Enqueue(ev.Text)
 				return
@@ -1090,13 +1094,16 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	ctx, done := sess.BeginRun(ctx)
 	defer done()
 
-	// Recompose the system prompt every turn so memory written since server
-	// start is visible — web turns get this for free from buildAgent; the IM
-	// factory's compose-once snapshot went stale until restart.
+	// Recompose the system prompt every turn so memory written and skills
+	// imported/toggled since server start are visible — web turns get this
+	// for free from buildAgent; the IM factory's compose-once snapshot went
+	// stale until restart. Unconditional: the skills manifest changes at
+	// runtime even when memory is disabled.
+	var memInjection string
 	if s.memDir != "" {
-		memInjection := memory.RenderInjection(s.memDir, s.homeMemDir)
-		sess.Agent.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
+		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
 	}
+	sess.Agent.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
 
 	// Per-turn permission gate, the same shape prepareToolTurn gives web
 	// turns: configured mode + an interactive ask that prompts in the chat
@@ -1148,23 +1155,39 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 		ctx = tools.WithAsker(ctx, s.channelAsker(sess, ad, ev))
 	}
 
-	_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, ev.Text)
+	persist := func() {
+		// Persist the conversation so it survives server restarts. Failure
+		// must not eat the reply the user already got — log and move on.
+		if err := sess.Persist(); err != nil {
+			fmt.Fprintf(os.Stderr, "octo serve: channel %s: persist session: %v\n", ev.Platform, err)
+		}
+	}
+
+	_, runErr := channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, ev.Text)
+	persist()
 
 	// Steer messages that arrived after the turn's final inbox drain chain
 	// into follow-up turns (web runAgentTurnLoop parity). Still inside
-	// BeginRun, so no new turn can interleave.
-	for ctx.Err() == nil {
+	// BeginRun, so no new turn can interleave. Persist after each chained
+	// turn — one crash must cost at most one turn, not the whole chain. A
+	// chained error stops the chain (its rollback already dropped the steer
+	// message; looping would re-fail forever).
+	for runErr == nil && ctx.Err() == nil {
 		items := sess.Agent.Inbox.Drain()
 		if len(items) == 0 {
 			break
 		}
-		_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, strings.Join(agent.Texts(items), "\n\n"))
+		_, runErr = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, strings.Join(agent.Texts(items), "\n\n"))
+		persist()
 	}
 
-	// Persist the conversation so it survives server restarts. Failure must
-	// not eat the reply the user already got — log and move on.
-	if err := sess.Persist(); err != nil {
-		fmt.Fprintf(os.Stderr, "octo serve: channel %s: persist session: %v\n", ev.Platform, err)
+	// A steer that arrived during a restart drain would die with the
+	// process (the Inbox is memory-only) — give it the same retry notice a
+	// non-steered message gets. Leftovers outside a drain stay queued for
+	// the chat's next turn: delayed, not lost.
+	if s.drain.isDraining() && sess.Agent.Inbox.HasPending() {
+		sess.Agent.Inbox.Drain()
+		ad.SendText(ev.ChatID, "The server is restarting — please send that again in a moment.", ev.MessageID)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1032,11 +1032,24 @@ func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev c
 	if s.handleChannelCommand(ad, ev) {
 		return
 	}
-	// Text-less events (stickers, images, voice) never answer an ask — an
-	// empty reply would consume the slot and deny for nothing.
+	// Text-less events (stickers, images, voice) never answer an ask or
+	// steer — an empty reply would consume the ask slot and deny for
+	// nothing, and an empty steer adds noise.
 	if strings.TrimSpace(ev.Text) != "" {
-		if sess := s.channelMgr.GetSession(ev); sess != nil && sess.DeliverAskReply(ev.ChatID, ev.UserID, ev.Text) {
-			return
+		if sess := s.channelMgr.GetSession(ev); sess != nil {
+			if sess.DeliverAskReply(ev.ChatID, ev.UserID, ev.Text) {
+				return
+			}
+			// Steer: a message arriving mid-turn rides the running turn's
+			// Inbox (drained between loop iterations; leftovers chain in
+			// handleChannelMessage) — web/CLI parity, instead of queueing a
+			// whole second turn. Known small race: a turn that finishes
+			// between this check and the enqueue leaves the message in the
+			// Inbox until the chat's next turn — delayed, not lost.
+			if sess.IsRunning() {
+				sess.Agent.Inbox.Enqueue(ev.Text)
+				return
+			}
 		}
 	}
 	go s.handleChannelMessage(ctx, ad, ev)
@@ -1076,6 +1089,14 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	// cancellable by /stop (Session.Interrupt).
 	ctx, done := sess.BeginRun(ctx)
 	defer done()
+
+	// Recompose the system prompt every turn so memory written since server
+	// start is visible — web turns get this for free from buildAgent; the IM
+	// factory's compose-once snapshot went stale until restart.
+	if s.memDir != "" {
+		memInjection := memory.RenderInjection(s.memDir, s.homeMemDir)
+		sess.Agent.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
+	}
 
 	// Per-turn permission gate, the same shape prepareToolTurn gives web
 	// turns: configured mode + an interactive ask that prompts in the chat
@@ -1123,6 +1144,23 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	}
 
 	_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, ev.Text)
+
+	// Steer messages that arrived after the turn's final inbox drain chain
+	// into follow-up turns (web runAgentTurnLoop parity). Still inside
+	// BeginRun, so no new turn can interleave.
+	for ctx.Err() == nil {
+		items := sess.Agent.Inbox.Drain()
+		if len(items) == 0 {
+			break
+		}
+		_, _ = channel.RunAgent(ctx, sess, toolDefs, executor, ctrl, strings.Join(agent.Texts(items), "\n\n"))
+	}
+
+	// Persist the conversation so it survives server restarts. Failure must
+	// not eat the reply the user already got — log and move on.
+	if err := sess.Persist(); err != nil {
+		fmt.Fprintf(os.Stderr, "octo serve: channel %s: persist session: %v\n", ev.Platform, err)
+	}
 }
 
 // stopChannels shuts down all channel adapters and their sessions.

--- a/internal/tools/ask_user_question.go
+++ b/internal/tools/ask_user_question.go
@@ -65,6 +65,28 @@ func SetAsker(a Asker) { activeAsker = a }
 
 func askerEnabled() bool { return activeAsker != nil }
 
+// ctxKeyAsker carries a turn-scoped Asker. The process-global asker is wrong
+// for transports that share the process but not the prompt surface: the
+// server's global asker broadcasts to browser tabs, which an IM turn doesn't
+// have — its questions must go to the chat instead. Same ctx-scoping pattern
+// as the sub-agent manager and task store.
+type ctxKeyAsker struct{}
+
+// WithAsker stamps a turn-scoped asker that takes precedence over the
+// process-global one for the duration of this turn.
+func WithAsker(ctx context.Context, a Asker) context.Context {
+	return context.WithValue(ctx, ctxKeyAsker{}, a)
+}
+
+// askerFrom resolves the asker for this turn: ctx-scoped first, then the
+// process-global fallback (CLI/web).
+func askerFrom(ctx context.Context) Asker {
+	if a, ok := ctx.Value(ctxKeyAsker{}).(Asker); ok && a != nil {
+		return a
+	}
+	return activeAsker
+}
+
 // AskUserQuestionTool lets the model ask the user a single structured
 // clarifying question. The point isn't to chat with the user — it's to
 // resolve a branch where the model genuinely doesn't have enough
@@ -118,7 +140,8 @@ func (AskUserQuestionTool) Definition() agent.ToolDefinition {
 }
 
 func (AskUserQuestionTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
-	if !askerEnabled() {
+	asker := askerFrom(ctx)
+	if asker == nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("ask_user_question: not available in this mode (REPL only)")
 	}
 	question := strings.TrimSpace(stringArg(input, "question"))
@@ -132,7 +155,7 @@ func (AskUserQuestionTool) Execute(ctx context.Context, _ string, input map[stri
 	multi, _ := input["multi_select"].(bool)
 	header := strings.TrimSpace(stringArg(input, "header"))
 
-	res, err := activeAsker.Ask(ctx, AskRequest{
+	res, err := asker.Ask(ctx, AskRequest{
 		Question:    question,
 		Options:     options,
 		MultiSelect: multi,

--- a/internal/tools/ask_user_question_ctx_test.go
+++ b/internal/tools/ask_user_question_ctx_test.go
@@ -1,0 +1,66 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// recordingAsker captures the request and returns a canned response.
+type recordingAsker struct {
+	got  *AskRequest
+	resp AskResponse
+}
+
+func (r *recordingAsker) Ask(_ context.Context, q AskRequest) (AskResponse, error) {
+	r.got = &q
+	return r.resp, nil
+}
+
+// TestAskUserQuestion_CtxAskerOverridesGlobal: a ctx-scoped asker (stamped by
+// the IM turn) must win over the process-global one (the server's wsAsker) —
+// otherwise IM questions broadcast to browser tabs that don't exist.
+func TestAskUserQuestion_CtxAskerOverridesGlobal(t *testing.T) {
+	global := &recordingAsker{resp: AskResponse{Choices: []string{"globalpick"}}}
+	SetAsker(global)
+	t.Cleanup(func() { SetAsker(nil) })
+
+	ctxAsker := &recordingAsker{resp: AskResponse{Choices: []string{"ctxpick"}}}
+	ctx := WithAsker(context.Background(), ctxAsker)
+
+	res, err := AskUserQuestionTool{}.Execute(ctx, "ask_user_question", map[string]any{
+		"question": "Which one?",
+		"options":  []any{"A", "B"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if ctxAsker.got == nil {
+		t.Fatal("ctx asker was not used")
+	}
+	if global.got != nil {
+		t.Error("global asker must not be consulted when a ctx asker is present")
+	}
+	if !strings.Contains(res.Text, "ctxpick") {
+		t.Errorf("result %q should carry the ctx asker's answer", res.Text)
+	}
+}
+
+// TestAskUserQuestion_GlobalFallback: without a ctx asker the global one
+// still serves (CLI/web behavior unchanged).
+func TestAskUserQuestion_GlobalFallback(t *testing.T) {
+	global := &recordingAsker{resp: AskResponse{Choices: []string{"globalpick"}}}
+	SetAsker(global)
+	t.Cleanup(func() { SetAsker(nil) })
+
+	res, err := AskUserQuestionTool{}.Execute(context.Background(), "ask_user_question", map[string]any{
+		"question": "Which one?",
+		"options":  []any{"A", "B"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res.Text, "globalpick") {
+		t.Errorf("result %q should carry the global asker's answer", res.Text)
+	}
+}


### PR DESCRIPTION
Closes four IM/web parity gaps (design doc: `dev-docs/im-parity-design.md`). Together with #601, IM turns now run the same session machinery as web turns — only the prompt/reply surface differs.

1. **Conversation persistence** — IM sessions back onto `agent.Session` JSONL (deterministic `im-<key>-<fnv>` ID, `Source: channel`), persisted after every turn (incl. each chained steer turn), restored on the first message after a restart. `/unbind` and `/bind` delete **and tombstone** the store so a zombie in-flight turn can't resurrect cleared history.
2. **Per-turn memory/skills freshness** — `handleChannelMessage` recomposes the system prompt every turn.
3. **Mid-turn steer** — messages during a running IM turn ride the turn's Inbox; leftovers chain into follow-up turns under `runMu` (web parity). A steer caught by a restart drain gets the retry notice.
4. **`ask_user_question` over chat** — `tools.WithAsker` ctx-scoping; IM turns stamp a chat asker (numbered options). Previously IM questions broadcast to nonexistent browser tabs and hung until `/stop`.

(The permission always-allow work continues in a follow-up PR — this PR merged at the IM-parity boundary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)