### PR TITLE
feat(agent): implicit lite model from the vendor registry

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -529,6 +529,15 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			a.LiteModel = liteEntry.Model
 		}
 	}
+	if a.LiteSender == nil {
+		// No explicit lite entry — fall back to the vendor's registry lite
+		// model on the SAME sender, so compaction stays on the endpoint, key,
+		// and prompt cache the conversation is already using.
+		if lm := app.ImplicitLiteModel(provName, resolvedModel, resolveBaseURL(provName, entry)); lm != "" {
+			a.LiteSender = llmSender
+			a.LiteModel = lm
+		}
+	}
 
 	// Build the tool executor up-front (REPL mode only — single-turn mode
 	// doesn't dispatch tools) and register the sub-agent dispatcher BEFORE the

--- a/dev-docs/multi-model-config-design.md
+++ b/dev-docs/multi-model-config-design.md
@@ -187,8 +187,23 @@ micro-compaction is string-level and unaffected.
 
 Wiring: each transport that constructs an `Agent` resolves `lite_model` to an
 entry, builds its sender through the same cache/`app.NewSender` path, and sets
-the pair. No lite entry configured → fields stay nil and behaviour is
-identical to today.
+the pair.
+
+**Implicit lite.** When no `lite_model` entry is configured, the vendor's
+registry `LiteModel` (e.g. deepseek → `deepseek-v4-flash`,
+anthropic → `claude-haiku-4-5`) serves as the lite model, riding the
+session's **own sender** — same endpoint, key, and prompt-cache routing, so
+no extra credentials and, where the backend caches by shared prefix, the
+summarisation call can hit the cache the conversation already built.
+`app.ImplicitLiteModel(provider, model, baseURL)` resolves it and returns
+nothing when the vendor is unknown or has no `LiteModel`, when the primary
+model already is the lite model, or when the base URL points off the
+vendor's own endpoints — a custom endpoint is a different backend wearing a
+compatible protocol, and its catalogue won't include the vendor's lite
+model (the primary-sender retry would catch the failure, but there's no
+point sending a doomed call). An explicitly configured `lite_model` entry
+always wins. For a session bound to a config entry, the implicit lookup
+uses that entry's vendor and endpoint.
 
 ## Frontend
 

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -265,6 +265,26 @@ func IsKnownVendor(id string) bool {
 	return vendorByID(id) != nil
 }
 
+// ImplicitLiteModel returns the lite model a session should compact on when
+// the user configured none explicitly: the vendor's registry LiteModel,
+// served over the SAME sender as the primary model — same endpoint, key, and
+// prompt-cache routing. It returns "" (no implicit lite) when:
+//   - the vendor is unknown or has no LiteModel,
+//   - the primary model already IS the lite model, or
+//   - baseURL points off the vendor's own endpoints — a custom endpoint is a
+//     different backend wearing a compatible protocol, and its catalogue
+//     won't include the vendor's lite model.
+func ImplicitLiteModel(provider, model, baseURL string) string {
+	v := vendorByID(provider)
+	if v == nil || v.LiteModel == "" || v.LiteModel == model {
+		return ""
+	}
+	if baseURL != "" && VendorByBaseURL(baseURL) != provider {
+		return ""
+	}
+	return v.LiteModel
+}
+
 // VendorByBaseURL returns the vendor whose default endpoint or one of whose
 // regional variants equals baseURL (ignoring a trailing slash), or "". The
 // settings panel saves entries without naming a vendor, so the server infers

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -88,3 +88,35 @@ func TestVendorEnvVars(t *testing.T) {
 		}
 	}
 }
+
+func TestImplicitLiteModel(t *testing.T) {
+	cases := []struct {
+		name                     string
+		provider, model, baseURL string
+		want                     string
+	}{
+		{"deepseek pro gets flash", "deepseek", "deepseek-v4-pro", "", "deepseek-v4-flash"},
+		{"vendor default endpoint ok", "deepseek", "deepseek-v4-pro", "https://api.deepseek.com", "deepseek-v4-flash"},
+		{"anthropic gets haiku", "anthropic", "claude-sonnet-4-6", "", "claude-haiku-4-5"},
+		{"already on the lite model", "deepseek", "deepseek-v4-flash", "", ""},
+		{"custom endpoint is a different backend", "openai", "gpt-5.4", "https://dashscope.example/v1", ""},
+		{"unknown vendor", "bogus", "m", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ImplicitLiteModel(tc.provider, tc.model, tc.baseURL); got != tc.want {
+				t.Errorf("ImplicitLiteModel(%q, %q, %q) = %q, want %q", tc.provider, tc.model, tc.baseURL, got, tc.want)
+			}
+		})
+	}
+
+	// A vendor without a LiteModel in the registry yields no implicit lite.
+	for _, v := range Registry {
+		if v.LiteModel == "" {
+			if got := ImplicitLiteModel(v.ID, v.DefaultModel, ""); got != "" {
+				t.Errorf("vendor %q has no LiteModel but ImplicitLiteModel = %q", v.ID, got)
+			}
+			break
+		}
+	}
+}

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -354,3 +354,76 @@ func TestConfigModels_SetLiteToggles(t *testing.T) {
 		t.Errorf("set-lite unknown id = %d, want 404", w.Code)
 	}
 }
+
+func TestBuildAgent_ImplicitLiteFromVendorRegistry(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.provider = "deepseek"
+	srv.model = "deepseek-v4-pro"
+
+	// Unbound session, no explicit lite entry → vendor's registry lite model
+	// on the same (default) sender.
+	sess := agent.NewSession("deepseek-v4-pro", "")
+	a := srv.buildAgent(sess)
+	if a.LiteModel != "deepseek-v4-flash" {
+		t.Errorf("LiteModel = %q, want deepseek-v4-flash", a.LiteModel)
+	}
+	if a.LiteSender == nil || a.LiteSender != srv.sender {
+		t.Error("implicit lite must reuse the session's own sender")
+	}
+
+	// Already on the lite model → no implicit lite.
+	srv.model = "deepseek-v4-flash"
+	sess2 := agent.NewSession("deepseek-v4-flash", "")
+	if a2 := srv.buildAgent(sess2); a2.LiteSender != nil {
+		t.Errorf("no implicit lite expected when primary IS the lite model, got %q", a2.LiteModel)
+	}
+}
+
+func TestBuildAgent_ExplicitLiteBeatsImplicit(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Name: "main", Provider: "deepseek", Model: "deepseek-v4-pro", APIKey: "sk-x"},
+			{Name: "cheap", Provider: "kimi", Model: "kimi-k2.5", APIKey: "sk-y"},
+		},
+		DefaultModel: "main",
+		LiteModel:    "cheap",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.provider = "deepseek"
+	srv.model = "deepseek-v4-pro"
+
+	sess := agent.NewSession("deepseek-v4-pro", "")
+	a := srv.buildAgent(sess)
+	if a.LiteModel != "kimi-k2.5" {
+		t.Errorf("LiteModel = %q, want the explicit entry kimi-k2.5", a.LiteModel)
+	}
+	if a.LiteSender == srv.sender {
+		t.Error("explicit lite entry must get its own sender, not the default one")
+	}
+}
+
+func TestBuildAgent_ImplicitLiteForBoundSession(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-a"},
+			{Name: "ds", Provider: "deepseek", Model: "deepseek-v4-pro", APIKey: "sk-d"},
+		},
+		DefaultModel: "main",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.provider = "anthropic"
+	srv.model = "claude-sonnet-4-6"
+
+	sess := agent.NewSession("deepseek-v4-pro", "")
+	sess.ModelConfig = "ds"
+	a := srv.buildAgent(sess)
+	if a.LiteModel != "deepseek-v4-flash" {
+		t.Errorf("LiteModel = %q, want deepseek-v4-flash from the bound entry's vendor", a.LiteModel)
+	}
+	if a.LiteSender == nil || a.LiteSender != a.Sender {
+		t.Error("bound session's implicit lite must reuse that session's sender")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -90,6 +90,7 @@ type Server struct {
 	// agent factory state (resolved once at start)
 	sender         agent.Sender
 	model          string
+	provider       string
 	system         string
 	skillReg       *skills.Registry
 	skillsManifest string
@@ -218,7 +219,7 @@ func New(cfg Config) (*Server, error) {
 		return nil, err
 	}
 
-	sender, model, err := resolveProviderAndModel(cfg.Provider, cfg.Model)
+	sender, model, provName, err := resolveProviderAndModel(cfg.Provider, cfg.Model)
 	if err != nil {
 		return nil, err
 	}
@@ -254,6 +255,7 @@ func New(cfg Config) (*Server, error) {
 		mux:              http.NewServeMux(),
 		sender:           sender,
 		model:            model,
+		provider:         provName,
 		system:           cfg.System,
 		skillReg:         skillReg,
 		skillsManifest:   skillsManifest,
@@ -607,6 +609,19 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	a.MaxTokens = s.cfg.MaxTokens
 	if cfg, err := config.Load(); err == nil {
 		a.LiteSender, a.LiteModel = s.liteSenderFromConfig(cfg)
+		if a.LiteSender == nil {
+			// No explicit lite entry — fall back to the vendor's registry
+			// lite model on the session's OWN sender, keeping compaction on
+			// the endpoint, key, and prompt cache the conversation uses.
+			prov, baseURL := s.provider, resolveBaseURL(s.provider, cfg)
+			if entry, ok := cfg.EntryByName(sess.ModelConfig); ok {
+				prov, baseURL = entry.Provider, entry.BaseURL
+			}
+			if lm := app.ImplicitLiteModel(prov, a.Model, baseURL); lm != "" {
+				a.LiteSender = sender
+				a.LiteModel = lm
+			}
+		}
 	}
 
 	// L1: project memory embedded in the system prompt (stable across turns).
@@ -666,10 +681,10 @@ func readBodyJSON(r *http.Request, v any) error {
 // the result to app.NewSender — internal/app is the single place that builds the
 // vendor client, so the server no longer imports internal/provider.
 
-func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, string, error) {
+func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, string, string, error) {
 	cfg, err := config.Load()
 	if err != nil {
-		return nil, "", fmt.Errorf("load config: %w", err)
+		return nil, "", "", fmt.Errorf("load config: %w", err)
 	}
 
 	entry := cfg.DefaultEntry()
@@ -685,18 +700,18 @@ func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, stri
 		model = defaultModelFor(provName)
 	}
 	if model == "" {
-		return nil, "", fmt.Errorf("unknown provider %q", provName)
+		return nil, "", "", fmt.Errorf("unknown provider %q", provName)
 	}
 
 	apiKey, err := resolveAPIKey(provName, cfg)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	if apiKey == "" {
 		// No API key configured yet — server starts in onboarding mode.
 		// Chat endpoints will retry on every request until the user completes
 		// setup via the Web UI.
-		return nil, model, nil
+		return nil, model, provName, nil
 	}
 	sender, err := app.NewSender(app.SenderOptions{
 		Provider: provName,
@@ -704,9 +719,9 @@ func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, stri
 		BaseURL:  resolveBaseURL(provName, cfg),
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
-	return sender, model, nil
+	return sender, model, provName, nil
 }
 
 // resolveAPIKey returns the API key for the vendor: the provider's env var,
@@ -881,7 +896,7 @@ func (s *Server) ensureSender() error {
 	if s.sender != nil {
 		return nil
 	}
-	sender, model, err := resolveProviderAndModel(s.cfg.Provider, s.cfg.Model)
+	sender, model, provName, err := resolveProviderAndModel(s.cfg.Provider, s.cfg.Model)
 	if err != nil {
 		return err
 	}
@@ -890,6 +905,7 @@ func (s *Server) ensureSender() error {
 	}
 	s.sender = sender
 	s.model = model
+	s.provider = provName
 	if s.cfg.Tools {
 		s.enableSubAgentTools()
 	}
@@ -1077,6 +1093,12 @@ func (s *Server) initChannels() {
 		a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
 		if cfg, err := config.Load(); err == nil {
 			a.LiteSender, a.LiteModel = s.liteSenderFromConfig(cfg)
+			if a.LiteSender == nil {
+				if lm := app.ImplicitLiteModel(s.provider, s.model, resolveBaseURL(s.provider, cfg)); lm != "" {
+					a.LiteSender = s.sender
+					a.LiteModel = lm
+				}
+			}
 		}
 		return a
 	}


### PR DESCRIPTION
Follow-up to the multi-model config series (#603/#606/#608, design #592): the lite model no longer requires explicit configuration.

## What

With no `lite_model` entry configured, compaction now falls back to the vendor's registry `LiteModel` — main model `deepseek-v4-pro` compacts on `deepseek-v4-flash`, `claude-sonnet-4-6` on `claude-haiku-4-5` — **on the session's own sender**: same endpoint, same key, same prompt-cache routing. No extra credentials, and where the backend caches by shared prefix, the summarisation call (history prefix + compression instruction) can hit the cache the conversation already built.

`app.ImplicitLiteModel(provider, model, baseURL)` returns nothing when:
- the vendor is unknown or has no `LiteModel` (e.g. kimi),
- the primary model already **is** the lite model, or
- the base URL points off the vendor's own endpoints — a custom endpoint (DashScope behind the openai provider, say) is a different backend whose catalogue won't include the vendor's lite model. The primary-sender retry from #608 would catch the failure anyway, but there's no point sending a doomed call.

Precedence: explicit `lite_model` entry > implicit vendor lite > primary-only. A session bound to a config entry resolves through that entry's vendor/endpoint. Wired in CLI chat, server `buildAgent`, and the channel factory; sub-agents inherit via the spawner as before.

## Tests

- `internal/app`: table test over the guard conditions + registry sweep for no-LiteModel vendors.
- `internal/server`: unbound session gets vendor lite on the default sender; primary-is-lite gets none; explicit entry beats implicit (own sender, not the default); bound session resolves via its entry's vendor on its own sender.
- Full `go test -race ./...` green. Design doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)