### PR TITLE
feat(permission): always-allow on all three transports — and revive the dead web prompt modals

### DIFF
--- a/dev-docs/im-interactive-ask-design.md
+++ b/dev-docs/im-interactive-ask-design.md
@@ -20,8 +20,10 @@ to permission parity with the web UI's confirmation modal.
 - No platform buttons or interactive cards. Plain text works identically on
   all six platforms; buttons would need six adapter implementations for a
   marginal UX gain.
-- No "remember this decision". Chat approvals are one-shot — in a group
-  chat, a remembered allow would outlive the person who granted it.
+- No persistent policy edits from chat. An `always / 总是允许` reply
+  remembers the decision for the session (see
+  `permission-remember-design.md`), but nothing a chat reply does ever
+  writes `permissions.yml`.
 
 ## Answer = the next message
 

--- a/dev-docs/permission-remember-design.md
+++ b/dev-docs/permission-remember-design.md
@@ -29,10 +29,19 @@ mutex-guarded decision store:
   shared one.
 - The server keeps one store per session (`rememberedFor`, keyed by web
   session ID or `im:<session key>`), attaches it in `prepareToolTurn` /
-  `handleChannelMessage`, and drops it with the rest of the session state
-  in `forgetTurnLock`.
+  `handleChannelMessage`, and drops it with the rest of the session state:
+  web stores in `forgetTurnLock` (session delete), IM stores when the chat
+  runs `/unbind` or `/bind` — "history cleared" includes the always-allows,
+  and the deterministic session key would otherwise hand them to the next
+  bound session.
 - The gate (`app.NewPermissionGate`) already called `engine.Remember` when
   an ask returned `remember=true`; nothing changed on that surface.
+- A matched **deny rule beats the cache**: `Check` scans rules first and
+  only consults remembered decisions when the verdict isn't Deny. Engines
+  are rebuilt per turn precisely so policy edits apply mid-session; a deny
+  added to `permissions.yml` after the user said "always" must win. A mode
+  flip to strict does NOT revoke remembered allows — they were explicit
+  user grants, and strict mode only changes how *unanswered* asks resolve.
 
 ## Answer mapping
 

--- a/dev-docs/permission-remember-design.md
+++ b/dev-docs/permission-remember-design.md
@@ -1,0 +1,64 @@
+# Permission "Always Allow" (Session Remember)
+
+An ask-class permission prompt can be answered "always": the call is allowed
+and the decision is remembered for the rest of the session, so the exact
+same (tool, input) pair stops prompting. All three transports offer it:
+
+| Transport | Prompt | Always answer |
+|---|---|---|
+| CLI/TUI | permission modal | the modal's always option (`UserResponse.Always`) |
+| Web | confirmation modal (`kind: yes_no_always`) | "Always allow" button → result `always` |
+| IM | in-chat reply prompt | `always` / `always allow` / `总是允许` / `一直允许` |
+
+## Scope: session, exact signature
+
+A remembered decision is keyed by the (tool, input) signature — the same
+hash `permission.Engine` always used — so "always allow `sudo make
+install`" does not allow `sudo rm`. It lives for the session and is never
+written to `permissions.yml`: durable policy stays an explicit user edit.
+
+## The store outlives the engine
+
+The CLI keeps one engine for the whole session, so remembering on the
+engine works there. The server and IM bridge rebuild their engine **every
+turn** (to pick up policy and mode changes) — a decision remembered on the
+engine would die with the turn. `permission.Remembered` is the extracted,
+mutex-guarded decision store:
+
+- `Engine` is born with a private store; `AttachRemembered` swaps in a
+  shared one.
+- The server keeps one store per session (`rememberedFor`, keyed by web
+  session ID or `im:<session key>`), attaches it in `prepareToolTurn` /
+  `handleChannelMessage`, and drops it with the rest of the session state
+  in `forgetTurnLock`.
+- The gate (`app.NewPermissionGate`) already called `engine.Remember` when
+  an ask returned `remember=true`; nothing changed on that surface.
+
+## Answer mapping
+
+- Web: `mapConfirmResult` — `yes` → allow once, `always` → allow+remember,
+  anything else denies.
+- IM: `isAffirmative` covers both sets; `isAlways` flags the remember
+  subset. Everything else (arbitrary replies, timeout, /stop) denies, as
+  before.
+- Auto-approve mode still bypasses prompting entirely; strict mode still
+  denies ask-class outright. Remember only matters in interactive mode.
+
+## The wire-shape bug this uncovered
+
+Both web prompt events were dead on arrival: `wsEventRequestConfirmation`
+and `wsEventRequestUserQuestion` carried no `session_id`, so the
+dispatcher's session filter dropped them before rendering — every web
+permission ask silently timed out to deny, and every web
+`ask_user_question` hung. The confirmation event also sent `conf_id` where
+the frontend reads `ev.id`, and the browser's answer (`id`) was parsed by
+the server as `conf_id`, so even a rendered modal couldn't have replied.
+The wire shapes now match what the dispatcher reads (`session_id` + `id`),
+with `conf_id` still accepted on the answer path for compatibility.
+
+## Testing
+
+- `Remembered` shared across engine rebuilds (and isolated when not
+  attached); per-session store identity + cleanup on session delete.
+- Web: `mapConfirmResult` table; replay path carries `session_id`/`id`.
+- IM: `总是允许` approves with remember; full store→ask→fresh-engine cycle.

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -410,6 +410,13 @@ func (m *Manager) sendTyping(ev InboundEvent) {
 	_ = ad.SendTyping(ev.ChatID, ev.ContextToken)
 }
 
+// KeyFor exposes the session key an inbound event maps to under this
+// manager's binding mode, for callers that keep per-session state outside
+// the manager (e.g. the server's remembered-permission stores).
+func (m *Manager) KeyFor(ev InboundEvent) SessionKey {
+	return sessionKeyFor(m.mode, ev)
+}
+
 // GetSession returns the session for the given inbound event, or nil if none exists.
 func (m *Manager) GetSession(ev InboundEvent) *Session {
 	key := sessionKeyFor(m.mode, ev)

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -173,19 +173,26 @@ func New(configPath string, cwd string, mode Mode, allowWriteRoots ...string) (*
 func (e *Engine) Check(toolName string, input map[string]any) Decision {
 	sig := signature(toolName, input)
 
-	e.mu.Lock()
-	store := e.remember
-	e.mu.Unlock()
-	if cached, ok := store.get(sig); ok {
-		return e.applyMode(cached)
-	}
-
 	d := Ask // implicit default
 	for _, r := range e.rules[toolName] {
 		if e.matches(toolName, r, input) {
 			d = r.Decision
 			break
 		}
+	}
+	// A matched deny always wins. The remembered store only short-circuits
+	// Ask: engines are rebuilt per turn precisely so policy edits take
+	// effect mid-session, and a deny rule added after the user said
+	// "always allow" must not be bypassed by the cache.
+	if d == Deny {
+		return e.applyMode(d)
+	}
+
+	e.mu.Lock()
+	store := e.remember
+	e.mu.Unlock()
+	if cached, ok := store.get(sig); ok {
+		return e.applyMode(cached)
 	}
 	return e.applyMode(d)
 }

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -92,7 +92,7 @@ type Engine struct {
 	cwd   string
 
 	mu       sync.Mutex
-	remember map[string]Decision // input-signature → decision
+	remember *Remembered // session decisions; swappable via AttachRemembered
 }
 
 //go:embed defaults.yml
@@ -157,7 +157,7 @@ func New(configPath string, cwd string, mode Mode, allowWriteRoots ...string) (*
 		rules:    rules,
 		mode:     mode,
 		cwd:      cwd,
-		remember: map[string]Decision{},
+		remember: NewRemembered(),
 	}, nil
 }
 
@@ -174,9 +174,9 @@ func (e *Engine) Check(toolName string, input map[string]any) Decision {
 	sig := signature(toolName, input)
 
 	e.mu.Lock()
-	cached, ok := e.remember[sig]
+	store := e.remember
 	e.mu.Unlock()
-	if ok {
+	if cached, ok := store.get(sig); ok {
 		return e.applyMode(cached)
 	}
 
@@ -195,8 +195,9 @@ func (e *Engine) Check(toolName string, input map[string]any) Decision {
 // user answers "always allow this turn / this session".
 func (e *Engine) Remember(toolName string, input map[string]any, decision Decision) {
 	e.mu.Lock()
-	defer e.mu.Unlock()
-	e.remember[signature(toolName, input)] = decision
+	store := e.remember
+	e.mu.Unlock()
+	store.set(signature(toolName, input), decision)
 }
 
 // Mode returns the engine's current mode (for callers that need to branch

--- a/internal/permission/remembered.go
+++ b/internal/permission/remembered.go
@@ -1,0 +1,44 @@
+package permission
+
+import "sync"
+
+// Remembered holds session-level "always allow this" decisions, keyed by
+// (tool, input) signature. It exists as a standalone type because the server
+// and IM bridge rebuild their Engine on every turn (to pick up policy/mode
+// changes) — decisions remembered on the engine itself would die with the
+// turn. The transport keeps one Remembered per session and attaches it to
+// each fresh engine; the CLI's single long-lived engine just uses the one it
+// was born with.
+type Remembered struct {
+	mu sync.Mutex
+	m  map[string]Decision
+}
+
+// NewRemembered returns an empty store.
+func NewRemembered() *Remembered {
+	return &Remembered{m: map[string]Decision{}}
+}
+
+func (r *Remembered) get(sig string) (Decision, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	d, ok := r.m[sig]
+	return d, ok
+}
+
+func (r *Remembered) set(sig string, d Decision) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.m[sig] = d
+}
+
+// AttachRemembered swaps in a shared decision store, replacing the engine's
+// private one. Call before the engine serves checks.
+func (e *Engine) AttachRemembered(r *Remembered) {
+	if r == nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.remember = r
+}

--- a/internal/permission/remembered_test.go
+++ b/internal/permission/remembered_test.go
@@ -1,0 +1,43 @@
+package permission
+
+import "testing"
+
+// TestRemembered_SharedAcrossEngines: the server rebuilds its engine every
+// turn; a session-scoped Remembered store attached to each fresh engine must
+// carry "always allow" decisions across rebuilds.
+func TestRemembered_SharedAcrossEngines(t *testing.T) {
+	store := NewRemembered()
+	input := map[string]any{"command": "sudo ls /tmp"}
+
+	e1, err := New("", t.TempDir(), ModeInteractive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e1.AttachRemembered(store)
+	if got := e1.Check("terminal", input); got != Ask {
+		t.Fatalf("precondition: sudo should be ask-class, got %v", got)
+	}
+
+	e1.Remember("terminal", input, Allow)
+
+	e2, err := New("", t.TempDir(), ModeInteractive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e2.AttachRemembered(store)
+	if got := e2.Check("terminal", input); got != Allow {
+		t.Errorf("remembered allow must survive an engine rebuild, got %v", got)
+	}
+	// A different input signature still asks.
+	if got := e2.Check("terminal", map[string]any{"command": "sudo rm x"}); got != Ask {
+		t.Errorf("a different command must not inherit the remembered allow, got %v", got)
+	}
+
+	e3, err := New("", t.TempDir(), ModeInteractive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := e3.Check("terminal", input); got != Ask {
+		t.Errorf("an engine without the store attached must not see it, got %v", got)
+	}
+}

--- a/internal/permission/remembered_test.go
+++ b/internal/permission/remembered_test.go
@@ -1,6 +1,9 @@
 package permission
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 // TestRemembered_SharedAcrossEngines: the server rebuilds its engine every
 // turn; a session-scoped Remembered store attached to each fresh engine must
@@ -39,5 +42,37 @@ func TestRemembered_SharedAcrossEngines(t *testing.T) {
 	}
 	if got := e3.Check("terminal", input); got != Ask {
 		t.Errorf("an engine without the store attached must not see it, got %v", got)
+	}
+}
+
+// TestRemembered_DenyRuleBeatsCache: a deny rule added to permissions.yml
+// mid-session (engines are rebuilt per turn to pick that up) must override a
+// previously remembered allow for the same call.
+func TestRemembered_DenyRuleBeatsCache(t *testing.T) {
+	store := NewRemembered()
+	input := map[string]any{"command": "sudo make install"}
+
+	e1, err := New("", t.TempDir(), ModeInteractive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e1.AttachRemembered(store)
+	e1.Remember("terminal", input, Allow)
+	if e1.Check("terminal", input) != Allow {
+		t.Fatal("precondition: remembered allow should hold")
+	}
+
+	// Operator adds a hard deny for sudo; the next turn's engine loads it.
+	cfgPath := t.TempDir() + "/permissions.yml"
+	if err := os.WriteFile(cfgPath, []byte("terminal:\n  - deny: { pattern: \"sudo\" }\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	e2, err := New(cfgPath, t.TempDir(), ModeInteractive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e2.AttachRemembered(store)
+	if got := e2.Check("terminal", input); got != Deny {
+		t.Errorf("deny rule must beat the remembered allow, got %v", got)
 	}
 }

--- a/internal/server/channel_ask.go
+++ b/internal/server/channel_ask.go
@@ -20,13 +20,24 @@ var channelAskTimeout = 5 * time.Minute
 
 // imAffirmatives are the only replies that approve an IM permission prompt.
 // Anything else denies — over chat, silence and ambiguity must fail closed.
+// imAlways additionally remembers the decision for the session ("stop
+// asking me about this exact call").
 var imAffirmatives = map[string]bool{
 	"yes": true, "y": true, "ok": true, "allow": true,
 	"是": true, "可以": true, "同意": true, "允许": true,
 }
 
+var imAlways = map[string]bool{
+	"always": true, "always allow": true, "总是允许": true, "一直允许": true,
+}
+
 func isAffirmative(text string) bool {
-	return imAffirmatives[strings.ToLower(strings.TrimSpace(text))]
+	t := strings.ToLower(strings.TrimSpace(text))
+	return imAffirmatives[t] || imAlways[t]
+}
+
+func isAlways(text string) bool {
+	return imAlways[strings.ToLower(strings.TrimSpace(text))]
 }
 
 // askInputSummary renders the part of toolInput the user is actually
@@ -79,7 +90,7 @@ func (s *Server) channelPermissionAsk(sess *channel.Session, ad channel.Adapter,
 			what = fmt.Sprintf("%s — %q", toolName, detail)
 		}
 		prompt := fmt.Sprintf(
-			"⚠️ Allow %s? Reply yes / 允许 to approve — any other reply denies; only the requester's reply counts. (Auto-deny in %s; /stop cancels the task.)",
+			"⚠️ Allow %s? Reply yes / 允许 to approve once, always / 总是允许 to stop asking for this exact call — any other reply denies; only the requester's reply counts. (Auto-deny in %s; /stop cancels the task.)",
 			what, channelAskTimeout)
 		ad.SendText(ev.ChatID, prompt, ev.MessageID)
 
@@ -87,7 +98,7 @@ func (s *Server) channelPermissionAsk(sess *channel.Session, ad channel.Adapter,
 		defer timer.Stop()
 		select {
 		case text := <-replyCh:
-			return isAffirmative(text), false, nil
+			return isAffirmative(text), isAlways(text), nil
 		case <-ctx.Done():
 			return false, false, ctx.Err()
 		case <-timer.C:

--- a/internal/server/channel_ask.go
+++ b/internal/server/channel_ask.go
@@ -73,10 +73,10 @@ func truncateForAsk(s string, maxLen int) string {
 // a confirmation prompt into the chat and consumes the requesting user's next
 // plain message in that chat as the answer (routed by the inbound dispatcher
 // via DeliverAskReply, ahead of the turn path — see routeChannelEvent).
-// Approval requires an explicit affirmative; any other reply, the turn being
-// cancelled (/stop), or the timeout denies. remember is always false: chat
-// approvals are one-shot, a lingering allow in a group chat would outlive
-// the person who granted it.
+// Approval requires an explicit affirmative; the "always" variants also
+// remember the decision in the session's Remembered store (exact tool+input
+// signature, session lifetime, never persisted to permissions.yml). Any
+// other reply, the turn being cancelled (/stop), or the timeout denies.
 func (s *Server) channelPermissionAsk(sess *channel.Session, ad channel.Adapter, ev channel.InboundEvent) app.PermissionAsk {
 	return func(ctx context.Context, toolName string, toolInput map[string]any) (bool, bool, error) {
 		replyCh, release, err := sess.BeginAsk(ev.ChatID, ev.UserID)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -676,6 +676,9 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.C
 	if sid, ok := ctx.Value(ctxKeySessionID{}).(string); ok && sid != "" {
 		ask = s.permissionAskFrom(sid)
 		ctx = tools.WithBackgroundManager(ctx, tools.SessionBackgroundManager(sid))
+		// "Always allow" decisions live per session, not per engine — the
+		// engine is rebuilt every turn.
+		engine.AttachRemembered(s.rememberedFor(sid))
 	}
 	a.Gate = app.NewPermissionGate(engine, ask)
 

--- a/internal/server/pending_prompt_test.go
+++ b/internal/server/pending_prompt_test.go
@@ -26,7 +26,7 @@ func TestReplayLiveState_ReplaysPendingPrompts(t *testing.T) {
 		Type: "request_user_question", QuestionID: "q_1", Question: "pick one", Options: []string{"a", "b"},
 	}
 	srv.pendingConfirms[sid] = wsEventRequestConfirmation{
-		Type: "request_confirmation", ConfID: "conf_1", Message: "Allow terminal?", Kind: "yes_no",
+		Type: "request_confirmation", SessionID: sid, ConfID: "conf_1", Message: "Allow terminal?", Kind: "yes_no",
 	}
 
 	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
@@ -46,8 +46,13 @@ func TestReplayLiveState_ReplaysPendingPrompts(t *testing.T) {
 			}
 		case "request_confirmation":
 			gotC = true
-			if ev["conf_id"] != "conf_1" {
-				t.Errorf("conf_id = %v, want conf_1", ev["conf_id"])
+			// `id` + `session_id` are what the dispatcher reads — the old
+			// conf_id/session-less shape made the frontend drop the event.
+			if ev["id"] != "conf_1" {
+				t.Errorf("id = %v, want conf_1", ev["id"])
+			}
+			if ev["session_id"] == nil || ev["session_id"] == "" {
+				t.Error("replayed confirmation must carry session_id")
 			}
 		}
 	}

--- a/internal/server/pending_prompt_test.go
+++ b/internal/server/pending_prompt_test.go
@@ -23,7 +23,7 @@ func TestReplayLiveState_ReplaysPendingPrompts(t *testing.T) {
 	defer tools.CloseSessionBackgroundManager(sid)
 
 	srv.pendingQuestions[sid] = wsEventRequestUserQuestion{
-		Type: "request_user_question", QuestionID: "q_1", Question: "pick one", Options: []string{"a", "b"},
+		Type: "request_user_question", SessionID: sid, QuestionID: "q_1", Question: "pick one", Options: []string{"a", "b"},
 	}
 	srv.pendingConfirms[sid] = wsEventRequestConfirmation{
 		Type: "request_confirmation", SessionID: sid, ConfID: "conf_1", Message: "Allow terminal?", Kind: "yes_no",
@@ -43,6 +43,9 @@ func TestReplayLiveState_ReplaysPendingPrompts(t *testing.T) {
 			gotQ = true
 			if ev["question_id"] != "q_1" {
 				t.Errorf("question_id = %v, want q_1", ev["question_id"])
+			}
+			if ev["session_id"] == nil || ev["session_id"] == "" {
+				t.Error("replayed question must carry session_id (the dispatcher filters on it)")
 			}
 		case "request_confirmation":
 			gotC = true

--- a/internal/server/remembered_test.go
+++ b/internal/server/remembered_test.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/permission"
+)
+
+func TestRememberedFor_SessionScoped(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	a := srv.rememberedFor("sess-a")
+	if a == nil {
+		t.Fatal("rememberedFor returned nil")
+	}
+	if srv.rememberedFor("sess-a") != a {
+		t.Error("same session must get the same store across turns")
+	}
+	if srv.rememberedFor("sess-b") == a {
+		t.Error("different sessions must not share a store")
+	}
+
+	srv.forgetTurnLock("sess-a")
+	if srv.rememberedFor("sess-a") == a {
+		t.Error("a deleted session's store must not be resurrected")
+	}
+}
+
+func TestMapConfirmResult(t *testing.T) {
+	cases := []struct {
+		result   string
+		allow    bool
+		remember bool
+	}{
+		{"yes", true, false},
+		{"always", true, true},
+		{"no", false, false},
+		{"", false, false},
+		{"whatever", false, false},
+	}
+	for _, c := range cases {
+		allow, remember := mapConfirmResult(c.result)
+		if allow != c.allow || remember != c.remember {
+			t.Errorf("mapConfirmResult(%q) = (%v,%v), want (%v,%v)", c.result, allow, remember, c.allow, c.remember)
+		}
+	}
+}
+
+// TestChannelPermissionAsk_AlwaysRemembers: the IM reply "总是允许" (or
+// "always") approves AND remembers for the session.
+func TestChannelPermissionAsk_AlwaysRemembers(t *testing.T) {
+	srv, sess, ad, ev := askEnv(t)
+	ask := srv.channelPermissionAsk(sess, ad, ev)
+
+	done := make(chan struct{})
+	var allow, remember bool
+	go func() {
+		allow, remember, _ = ask(context.Background(), "terminal", map[string]any{"command": "sudo ls"})
+		close(done)
+	}()
+	waitFor(t, func() bool { return len(ad.texts()) == 1 })
+	if !strings.Contains(ad.texts()[0], "always") && !strings.Contains(ad.texts()[0], "总是允许") {
+		t.Errorf("prompt %q should offer the always option", ad.texts()[0])
+	}
+	if !sess.DeliverAskReply("c1", "", "总是允许") {
+		t.Fatal("ask slot not armed")
+	}
+	<-done
+	if !allow || !remember {
+		t.Errorf("'总是允许' = allow %v remember %v, want true/true", allow, remember)
+	}
+}
+
+// TestIMTurnGate_RemembersAcrossEngines wires the pieces the IM turn uses:
+// session store + always reply + a fresh engine next turn.
+func TestIMTurnGate_RemembersAcrossEngines(t *testing.T) {
+	srv, sess, ad, ev := askEnv(t)
+	store := srv.rememberedFor("im:test")
+	input := map[string]any{"command": "sudo ls /tmp"}
+
+	e1, err := permission.New(permissionConfigPath(), t.TempDir(), permission.ModeInteractive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e1.AttachRemembered(store)
+	if e1.Check("terminal", input) != permission.Ask {
+		t.Fatal("precondition: sudo is ask-class")
+	}
+	// User answers "always" through the ask path; the gate calls Remember.
+	go func() {
+		waitFor(t, func() bool { return len(ad.texts()) == 1 })
+		sess.DeliverAskReply("c1", "", "always")
+	}()
+	allow, remember, err := srv.channelPermissionAsk(sess, ad, ev)(context.Background(), "terminal", input)
+	if err != nil || !allow || !remember {
+		t.Fatalf("always reply: allow=%v remember=%v err=%v", allow, remember, err)
+	}
+	e1.Remember("terminal", input, permission.Allow)
+
+	// Next turn: fresh engine, same store — no prompt needed.
+	e2, err := permission.New(permissionConfigPath(), t.TempDir(), permission.ModeInteractive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e2.AttachRemembered(store)
+	if e2.Check("terminal", input) != permission.Allow {
+		t.Error("remembered allow did not survive the per-turn engine rebuild")
+	}
+}

--- a/internal/server/remembered_test.go
+++ b/internal/server/remembered_test.go
@@ -109,3 +109,22 @@ func TestIMTurnGate_RemembersAcrossEngines(t *testing.T) {
 		t.Error("remembered allow did not survive the per-turn engine rebuild")
 	}
 }
+
+// TestChannelCommand_UnbindDropsRemembered: /unbind promises "history
+// cleared" — the session's always-allows are part of that history, and the
+// deterministic session key would otherwise hand them to the next session.
+func TestChannelCommand_UnbindDropsRemembered(t *testing.T) {
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+	ev := evFor("/unbind")
+
+	key := "im:" + string(srv.channelMgr.KeyFor(ev))
+	before := srv.rememberedFor(key)
+
+	if !srv.handleChannelCommand(ad, ev) {
+		t.Fatal("/unbind not handled as a command")
+	}
+	if srv.rememberedFor(key) == before {
+		t.Error("/unbind must drop the session's remembered permission store")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -206,6 +206,13 @@ type Server struct {
 	drain        drainGate
 	drainTimeout time.Duration
 
+	// rememberedStores holds per-session "always allow" permission
+	// decisions. Engines are rebuilt every turn (to pick up policy/mode
+	// changes), so the decisions live here and attach to each fresh engine.
+	// Keyed by web session ID or "im:<session key>". Guarded by rememberedMu.
+	rememberedStores map[string]*permission.Remembered
+	rememberedMu     sync.Mutex
+
 	// senderMu serialises lazy initialisation of sender when the server starts
 	// in onboarding mode (API key missing) and the user completes setup later.
 	senderMu sync.Mutex
@@ -594,8 +601,12 @@ func (s *Server) forgetTurnLock(id string) {
 	delete(s.turnLocks, id)
 
 	s.injectorMu.Lock()
-	defer s.injectorMu.Unlock()
 	delete(s.sessionInjectors, id)
+	s.injectorMu.Unlock()
+
+	s.rememberedMu.Lock()
+	delete(s.rememberedStores, id)
+	s.rememberedMu.Unlock()
 }
 
 // buildAgent creates a fresh agent for a turn. The caller must have locked
@@ -941,6 +952,7 @@ func (a wsAsker) Ask(ctx context.Context, q tools.AskRequest) (tools.AskResponse
 
 	ev := wsEventRequestUserQuestion{
 		Type:        "request_user_question",
+		SessionID:   sessionID,
 		QuestionID:  qid,
 		Question:    q.Question,
 		Options:     q.Options,
@@ -994,17 +1006,48 @@ func (s *Server) handleWSUserQuestionAnswer(qid string, choices []string, custom
 
 // permissionAskFrom adapts the server's requestConfirmation into an
 // app.PermissionAsk so the Web UI can resolve "ask" class policy verdicts
-// interactively. remember is always false; a future enhancement could add a
-// "Always allow" checkbox to the confirmation modal.
+// interactively. The modal offers yes / no / always; "always" allows AND
+// remembers the decision in the session's Remembered store, so the same
+// (tool, input) pair stops prompting for the rest of the session.
 func (s *Server) permissionAskFrom(sessionID string) app.PermissionAsk {
 	return func(ctx context.Context, toolName string, toolInput map[string]any) (bool, bool, error) {
 		msg := fmt.Sprintf("Allow %s?", toolName)
-		result, err := s.requestConfirmation(ctx, sessionID, msg, "yes_no")
+		result, err := s.requestConfirmation(ctx, sessionID, msg, "yes_no_always")
 		if err != nil {
 			return false, false, err
 		}
-		return result == "yes", false, nil
+		allow, remember := mapConfirmResult(result)
+		return allow, remember, nil
 	}
+}
+
+// mapConfirmResult maps the confirmation modal's reply onto the permission
+// answer: anything but the two explicit affirmatives denies.
+func mapConfirmResult(result string) (allow, remember bool) {
+	switch result {
+	case "yes":
+		return true, false
+	case "always":
+		return true, true
+	default:
+		return false, false
+	}
+}
+
+// rememberedFor returns the session's "always allow" store, creating it on
+// first use. forgetTurnLock drops it with the rest of the session state.
+func (s *Server) rememberedFor(key string) *permission.Remembered {
+	s.rememberedMu.Lock()
+	defer s.rememberedMu.Unlock()
+	if s.rememberedStores == nil {
+		s.rememberedStores = make(map[string]*permission.Remembered)
+	}
+	r, ok := s.rememberedStores[key]
+	if !ok {
+		r = permission.NewRemembered()
+		s.rememberedStores[key] = r
+	}
+	return r
 }
 
 // validateBindAddr enforces the M6.5 security rule: non-localhost binds
@@ -1225,6 +1268,7 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 		ad.SendText(ev.ChatID, "⚠️ Permission engine unavailable — message not processed. Check the server logs.", ev.MessageID)
 		return
 	}
+	engine.AttachRemembered(s.rememberedFor("im:" + string(sess.Key)))
 	sess.Agent.Gate = app.NewPermissionGate(engine, s.channelPermissionAsk(sess, ad, ev))
 
 	ctrl := channel.NewUIController(ad, ev.ChatID, ev.MessageID)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1217,6 +1217,15 @@ func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEven
 	if !strings.HasPrefix(text, "/") {
 		return false
 	}
+	// /unbind promises "history cleared" and /bind "start fresh" — the
+	// session's remembered permission allows are part of that history. The
+	// manager doesn't know about the server-side store, so drop it here.
+	switch strings.ToLower(strings.Fields(text)[0]) {
+	case "/unbind", "/bind":
+		s.rememberedMu.Lock()
+		delete(s.rememberedStores, "im:"+string(s.channelMgr.KeyFor(ev)))
+		s.rememberedMu.Unlock()
+	}
 	if reply := s.channelMgr.CommandRouter(ev); reply != "" {
 		ad.SendText(ev.ChatID, reply, ev.MessageID)
 	}

--- a/internal/server/static/app.js
+++ b/internal/server/static/app.js
@@ -384,9 +384,13 @@ const Modal = (() => {
 })();
 
 // ── Confirmation modal ────────────────────────────────────────────────────
-function showConfirmModal(confId, message) {
+function showConfirmModal(confId, message, kind) {
   $("modal-message").textContent   = message;
   $("modal-overlay").style.display = "flex";
+  // Permission asks offer "always allow" (remembered for the session);
+  // plain yes/no confirmations keep two buttons.
+  const always = $("modal-always");
+  always.style.display = kind === "yes_no_always" ? "" : "none";
 
   const answer = result => {
     $("modal-overlay").style.display = "none";
@@ -394,6 +398,7 @@ function showConfirmModal(confId, message) {
   };
   $("modal-yes").onclick = () => answer("yes");
   $("modal-no").onclick  = () => answer("no");
+  always.onclick         = () => answer("always");
 }
 
 // ── User Question modal (ask_user_question) ───────────────────────────────

--- a/internal/server/static/app.js
+++ b/internal/server/static/app.js
@@ -285,6 +285,11 @@ const Modal = (() => {
     return new Promise(resolve => {
       $("modal-message").textContent   = message;
       $("modal-overlay").style.display = "flex";
+      // The overlay is shared with the permission prompt (showConfirmModal);
+      // make sure its "Always allow" button never leaks into a local
+      // yes/no confirmation.
+      $("modal-always").style.display = "none";
+      $("modal-always").onclick = null;
 
       const cleanup = (result) => {
         $("modal-overlay").style.display = "none";
@@ -394,6 +399,8 @@ function showConfirmModal(confId, message, kind) {
 
   const answer = result => {
     $("modal-overlay").style.display = "none";
+    always.style.display = "none"; // shared overlay: don't leak into Modal.confirm
+    always.onclick = null;
     WS.send({ type: "confirmation", session_id: Sessions.activeId, id: confId, result });
   };
   $("modal-yes").onclick = () => answer("yes");

--- a/internal/server/static/i18n.js
+++ b/internal/server/static/i18n.js
@@ -129,6 +129,7 @@ const I18n = (() => {
       // ── Modal ──
       "modal.yes": "Yes",
       "modal.no":  "No",
+      "modal.always": "Always allow",
       "modal.ok": "OK",
       "modal.cancel": "Cancel",
 
@@ -676,6 +677,7 @@ const I18n = (() => {
       "sessions.search.datePlaceholder": "日期",
       "modal.yes": "确定",
       "modal.no":  "取消",
+      "modal.always": "总是允许",
       "modal.ok": "确定",
       "modal.cancel": "取消",
 

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -920,6 +920,7 @@
     <div id="modal-message" class="modal-confirm-message"></div>
     <div class="modal-actions">
       <button id="modal-no"  class="btn-secondary" data-i18n="modal.no">No</button>
+      <button id="modal-always" class="btn-secondary" style="display:none" data-i18n="modal.always">Always allow</button>
       <button id="modal-yes" class="btn-primary" data-i18n="modal.yes">Yes</button>
     </div>
   </div>

--- a/internal/server/static/ws-dispatcher.js
+++ b/internal/server/static/ws-dispatcher.js
@@ -338,7 +338,7 @@ WS.onEvent(ev => {
 
     case "request_confirmation":
       if (ev.session_id !== Sessions.activeId) break;
-      showConfirmModal(ev.id, ev.message);
+      showConfirmModal(ev.id, ev.message, ev.kind);
       break;
 
     case "request_user_question":

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1154,10 +1154,11 @@ func (s *Server) requestConfirmation(ctx context.Context, sessionID, message, ki
 	s.confirmMu.Unlock()
 
 	ev := wsEventRequestConfirmation{
-		Type:    "request_confirmation",
-		ConfID:  confID,
-		Message: message,
-		Kind:    kind,
+		Type:      "request_confirmation",
+		SessionID: sessionID,
+		ConfID:    confID,
+		Message:   message,
+		Kind:      kind,
 	}
 
 	// Record the outstanding confirmation so a tab that (re)subscribes

--- a/internal/server/ws_hub.go
+++ b/internal/server/ws_hub.go
@@ -315,7 +315,11 @@ func (c *wsConn) dispatch(msgType string, raw []byte) {
 		if err := json.Unmarshal(raw, &msg); err != nil {
 			return
 		}
-		c.hub.s.handleWSConfirmation(msg.ConfID, msg.Result)
+		id := msg.ConfID
+		if id == "" {
+			id = msg.LegacyConfID
+		}
+		c.hub.s.handleWSConfirmation(id, msg.Result)
 
 	case "user_question_answer":
 		var msg wsMsgUserQuestionAnswer

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -40,8 +40,11 @@ type wsMsgInterrupt struct {
 }
 
 type wsMsgConfirmation struct {
-	ConfID string `json:"conf_id"`
-	Result string `json:"result"`
+	// The frontend answers with `id` (app.js showConfirmModal); `conf_id`
+	// is accepted as a fallback for anything speaking the older shape.
+	ConfID       string `json:"id"`
+	LegacyConfID string `json:"conf_id"`
+	Result       string `json:"result"`
 }
 
 type wsMsgUserQuestionAnswer struct {
@@ -179,14 +182,22 @@ type wsEventRequestFeedback struct {
 }
 
 type wsEventRequestConfirmation struct {
-	Type    string `json:"type"`
-	ConfID  string `json:"conf_id"`
-	Message string `json:"message"`
-	Kind    string `json:"kind"` // "yes_no" | "ok"
+	Type string `json:"type"`
+	// SessionID and the `id` tag match what the dispatcher actually reads
+	// (ev.session_id filter, ev.id answer key) — the old conf_id-only,
+	// session-less shape made the dispatcher drop the event, so the modal
+	// never appeared and every web permission ask timed out to deny.
+	SessionID string `json:"session_id"`
+	ConfID    string `json:"id"`
+	Message   string `json:"message"`
+	Kind      string `json:"kind"` // "yes_no" | "yes_no_always" | "ok"
 }
 
 type wsEventRequestUserQuestion struct {
-	Type        string   `json:"type"`
+	Type string `json:"type"`
+	// SessionID is required by the dispatcher's session filter — without
+	// it the browser drops the event and the question modal never shows.
+	SessionID   string   `json:"session_id"`
 	QuestionID  string   `json:"question_id"`
 	Question    string   `json:"question"`
 	Options     []string `json:"options"`


### PR DESCRIPTION
The fifth parity item (design doc: `dev-docs/permission-remember-design.md`): an ask-class permission prompt can be answered **always** — allowed and remembered for the session, exact (tool, input) signature, never written to `permissions.yml`. CLI already had it (`UserResponse.Always` + long-lived engine); this brings web and IM along.

## Mechanism

- `permission.Remembered` — extracted, mutex-guarded decision store. The server and IM bridge rebuild their engine **every turn** (to pick up policy/mode edits), so decisions remembered on the engine died with the turn; the store now lives per session (`rememberedFor`: web session ID / `im:<session key>`) and attaches to each fresh engine.
- **A matched deny rule beats the cache** (review finding): `Check` scans rules before consulting remembered decisions, so a deny added to `permissions.yml` mid-session wins over an earlier "always" — the exact scenario per-turn engine rebuilds exist for.
- Lifecycle: web stores drop with the session (`forgetTurnLock`); IM stores drop on `/unbind` and `/bind` (review finding — "history cleared" includes always-allows, and the deterministic IM key would otherwise hand them to the next bound session).
- Surfaces: web modal gains an **Always allow** button (`kind: yes_no_always`, shared-overlay hygiene so it can't leak into local yes/no dialogs); IM accepts `always / always allow / 总是允许 / 一直允许`.

## Drive-by: both web prompt modals were dead on arrival

`wsEventRequestConfirmation` and `wsEventRequestUserQuestion` carried no `session_id` — the ws-dispatcher's session filter dropped them before rendering, so **every web permission ask silently timed out to deny, and every web ask_user_question hung**. The confirmation event also sent `conf_id` where the frontend reads `ev.id`, and the browser's `id` answer was parsed server-side as `conf_id` — even a rendered modal couldn't have replied. Wire shapes now match the dispatcher (`session_id` + `id`), with `conf_id` still accepted on the answer path. Replay fixtures/assertions pin `session_id` on both prompt types so neither modal can regress this way again.

## Verification

`go test -race ./...` green; vet/gofmt clean. Isolated subagent review confirmed the wire-shape claim independently and found 3 Important issues (deny-beats-cache ordering, IM store lifecycle, stale Always button) — all fixed with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)