### PR TITLE
feat(server): IM turns carry the L2 memory hooks

### DIFF
--- a/dev-docs/im-parity-design.md
+++ b/dev-docs/im-parity-design.md
@@ -40,10 +40,13 @@ turns always had this — `buildAgent` runs per turn — but the IM factory
 composed the prompt once at session creation, so memory written and skills
 imported mid-session were invisible to IM until a restart.
 
-Known remaining gap: IM agents don't carry the L2 memory hooks
-(`UserInputHook` keyword reminders, `ToolResultHook` save-nudges) that
-`buildAgent` wires for web sessions — only the L1 system-prompt injection
-reaches IM.
+IM turns also carry the L2 memory hooks, the same pair `buildAgent` wires
+for web sessions: `UserInputHook` keyword reminders and the
+`ToolResultHook` save-nudge. The injector comes from the shared
+`injectorFor` store (keyed `im:<session key>`), is session-sticky — the
+once-per-session recall latch must survive turns — and is dropped on
+`/unbind` and `/bind` alongside the remembered-permission store, so a fresh
+session gets a fresh latch.
 
 ## Mid-turn steer
 

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -320,3 +320,44 @@ func TestHandleChannelMessage_RefreshesSystemPerTurn(t *testing.T) {
 		t.Error("system prompt not recomposed: memory written mid-session is invisible to IM turns")
 	}
 }
+
+// TestHandleChannelMessage_WiresMemoryHooks: IM turns carry the L2 memory
+// hooks (keyword reminders + save-nudge) like web turns do via buildAgent.
+func TestHandleChannelMessage_WiresMemoryHooks(t *testing.T) {
+	srv := chanServer(t)
+	srv.memDir = t.TempDir()
+	ad := &fullFakeAdapter{}
+
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+
+	sess := srv.channelMgr.GetSession(evFor("x"))
+	if sess.Agent.UserInputHook == nil {
+		t.Error("IM agent missing UserInputHook (keyword reminders)")
+	}
+	if sess.Agent.ToolResultHook == nil {
+		t.Error("IM agent missing ToolResultHook (save-nudge)")
+	}
+}
+
+// TestInjectorFor_SessionStickyAndDroppedOnUnbind: the injector's
+// once-per-session recall latch must survive turns but reset with /unbind.
+func TestInjectorFor_SessionStickyAndDroppedOnUnbind(t *testing.T) {
+	srv := chanServer(t)
+	srv.memDir = t.TempDir()
+	ad := &fullFakeAdapter{}
+	ev := evFor("/unbind")
+
+	key := "im:" + string(srv.channelMgr.KeyFor(ev))
+	first := srv.injectorFor(key)
+	if first == nil {
+		t.Fatal("injectorFor returned nil")
+	}
+	if srv.injectorFor(key) != first {
+		t.Error("injector must be sticky across turns in one session")
+	}
+
+	srv.handleChannelCommand(ad, ev)
+	if srv.injectorFor(key) == first {
+		t.Error("/unbind must drop the session injector (fresh recall latch)")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -643,21 +643,9 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
 
 	// L2: attention-layer rules injected per user turn (triggered keywords),
-	// plus the save-nudge appended to milestone tool results. The injector is
-	// created even when MEMORY.md has no structured rules — Reminder is silent
-	// then, but the nudge still needs the per-session latch.
+	// plus the save-nudge appended to milestone tool results.
 	if s.memDir != "" {
-		s.injectorMu.Lock()
-		inj, ok := s.sessionInjectors[sess.ID]
-		if !ok {
-			rules := memory.ParseRules(s.memDir)
-			if s.homeMemDir != "" {
-				rules.Merge(memory.ParseRules(s.homeMemDir))
-			}
-			inj = memory.NewInjector(rules)
-			s.sessionInjectors[sess.ID] = inj
-		}
-		s.injectorMu.Unlock()
+		inj := s.injectorFor(sess.ID)
 		a.UserInputHook = inj.Reminder
 		a.ToolResultHook = inj.SaveNudge
 	}
@@ -666,6 +654,30 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 		a.History = sess.ToHistory()
 	}
 	return a
+}
+
+// injectorFor returns the session's memory injector, creating it on first
+// use. The injector carries the once-per-session recall latch, so it must
+// survive turns; it is created even when MEMORY.md has no structured rules —
+// Reminder is silent then, but the save-nudge still needs the latch. Keyed
+// by web session ID or "im:<session key>"; dropped via forgetTurnLock (web)
+// or /unbind //bind (IM).
+func (s *Server) injectorFor(key string) *memory.Injector {
+	s.injectorMu.Lock()
+	defer s.injectorMu.Unlock()
+	if s.sessionInjectors == nil {
+		s.sessionInjectors = make(map[string]*memory.Injector)
+	}
+	inj, ok := s.sessionInjectors[key]
+	if !ok {
+		rules := memory.ParseRules(s.memDir)
+		if s.homeMemDir != "" {
+			rules.Merge(memory.ParseRules(s.homeMemDir))
+		}
+		inj = memory.NewInjector(rules)
+		s.sessionInjectors[key] = inj
+	}
+	return inj
 }
 
 // writeJSON is a convenience helper for JSON responses.
@@ -1240,13 +1252,18 @@ func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEven
 		return false
 	}
 	// /unbind promises "history cleared" and /bind "start fresh" — the
-	// session's remembered permission allows are part of that history. The
-	// manager doesn't know about the server-side store, so drop it here.
+	// session's remembered permission allows and its memory-injector latch
+	// are part of that history. The manager doesn't know about the
+	// server-side stores, so drop them here.
 	switch strings.ToLower(strings.Fields(text)[0]) {
 	case "/unbind", "/bind":
+		imKey := "im:" + string(s.channelMgr.KeyFor(ev))
 		s.rememberedMu.Lock()
-		delete(s.rememberedStores, "im:"+string(s.channelMgr.KeyFor(ev)))
+		delete(s.rememberedStores, imKey)
 		s.rememberedMu.Unlock()
+		s.injectorMu.Lock()
+		delete(s.sessionInjectors, imKey)
+		s.injectorMu.Unlock()
 	}
 	if reply := s.channelMgr.CommandRouter(ev); reply != "" {
 		ad.SendText(ev.ChatID, reply, ev.MessageID)
@@ -1285,6 +1302,15 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
 	}
 	sess.Agent.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
+
+	// L2 memory hooks, same pair buildAgent gives web turns: keyword
+	// reminders on user input, save-nudge on milestone tool results. The
+	// injector is session-sticky (recall latch) and dropped on /unbind.
+	if s.memDir != "" {
+		inj := s.injectorFor("im:" + string(sess.Key))
+		sess.Agent.UserInputHook = inj.Reminder
+		sess.Agent.ToolResultHook = inj.SaveNudge
+	}
 
 	// Per-turn permission gate, the same shape prepareToolTurn gives web
 	// turns: configured mode + an interactive ask that prompts in the chat


### PR DESCRIPTION
Closes the last known gap from `dev-docs/im-parity-design.md`: IM agents now get the same L2 memory pair web sessions have had since #583 — `UserInputHook` keyword reminders and the `ToolResultHook` save-nudge.

- The injector get-or-create moved from `buildAgent` into a shared `injectorFor(key)` (lazy-init, mutex-guarded); web keys by session ID as before, IM keys by `im:<session key>`.
- The injector is session-sticky — its once-per-session recall latch must survive turns — and `/unbind` / `/bind` drop it alongside the remembered-permission store, so a fresh session gets a fresh latch.
- Design doc updated: the known-gap paragraph is now a description of the wiring.

Verification: `go test -race ./...` green, vet/gofmt clean; tests pin hook presence on IM turns, injector stickiness across turns, and the /unbind drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)