### PR TITLE
feat(skills): tdd — red-green-refactor as a default skill

### DIFF
--- a/internal/skills/defaults/implement/SKILL.md
+++ b/internal/skills/defaults/implement/SKILL.md
@@ -89,6 +89,10 @@ PR is created, the next slice batch gets a new branch.
 
 ### The TDD cadence (every slice, no exceptions)
 
+(Test-quality standards — behavior over implementation, what to mock,
+wire-contract tests for boundary structs — live in the `tdd` skill; this
+section is the rhythm, that skill is the craft.)
+
 For EACH behavior in the slice:
 
 1. Write ONE failing test — actual test code, not a description.

--- a/internal/skills/defaults/tdd/SKILL.md
+++ b/internal/skills/defaults/tdd/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: tdd
+description: Test-driven development with red-green-refactor loop. Use when the user wants to build a feature or fix a bug test-first, mentions "red-green-refactor" or TDD, wants integration tests, or says "用 TDD 做", "测试先行", "红绿循环". For implementing a whole tech design slice-by-slice, use the implement skill instead — it embeds this cadence.
+---
+
+# Test-Driven Development
+
+## Philosophy
+
+**Core principle**: Tests should verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't.
+
+**Good tests** are integration-style: they exercise real code paths through public APIs. They describe _what_ the system does, not _how_ it does it. A good test reads like a specification - "user can checkout with valid cart" tells you exactly what capability exists. These tests survive refactors because they don't care about internal structure.
+
+**Bad tests** are coupled to implementation. They mock internal collaborators, test private methods, or verify through external means (like querying a database directly instead of using the interface). The warning sign: your test breaks when you refactor, but behavior hasn't changed. If you rename an internal function and tests fail, those tests were testing implementation, not behavior.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
+
+## Anti-Pattern: Horizontal Slices
+
+**DO NOT write all tests first, then all implementation.** This is "horizontal slicing" - treating RED as "write all tests" and GREEN as "write all code."
+
+This produces **crap tests**:
+
+- Tests written in bulk test _imagined_ behavior, not _actual_ behavior
+- You end up testing the _shape_ of things (data structures, function signatures) rather than user-facing behavior
+- Tests become insensitive to real changes - they pass when behavior breaks, fail when behavior is fine
+- You outrun your headlights, committing to test structure before understanding the implementation
+
+**Correct approach**: Vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behavior matters and how to verify it.
+
+```
+WRONG (horizontal):
+  RED:   test1, test2, test3, test4, test5
+  GREEN: impl1, impl2, impl3, impl4, impl5
+
+RIGHT (vertical):
+  RED→GREEN: test1→impl1
+  RED→GREEN: test2→impl2
+  RED→GREEN: test3→impl3
+  ...
+```
+
+## Workflow
+
+### 1. Planning
+
+When exploring the codebase, match the project's established vocabulary (a domain glossary or CONTEXT.md if one exists) so test names and interface terms speak the project's language, and respect any documented architecture decisions in the area you're touching.
+
+Before writing any code:
+
+- [ ] Confirm with user what interface changes are needed
+- [ ] Confirm with user which behaviors to test (prioritize)
+- [ ] Identify opportunities for [deep modules](deep-modules.md) (small interface, deep implementation)
+- [ ] Design interfaces for [testability](interface-design.md)
+- [ ] List the behaviors to test (not implementation steps)
+- [ ] **For any boundary code** (HTTP/gRPC client struct), plan at least one wire
+      contract test — real JSON fixture → `json.Unmarshal` → assert fields. See
+      [tests.md](tests.md) "System Boundary Contract Tests". Field-name bugs are
+      invisible to fake-client tests and only this class of test catches them.
+- [ ] Get user approval on the plan (use `ask_user_question` for genuine
+      either-or decisions: "What should the public interface look like?",
+      "Which behaviors matter most?")
+
+**You can't test everything.** Confirm with the user which behaviors matter most. Focus testing effort on critical paths and complex logic, not every possible edge case. If the user already told you to proceed autonomously, pick sensible answers and say which you picked.
+
+### 2. Tracer Bullet
+
+Write ONE test that confirms ONE thing about the system:
+
+```
+RED:   Write test for first behavior → test fails
+GREEN: Write minimal code to pass → test passes
+```
+
+This is your tracer bullet - proves the path works end-to-end.
+
+### 3. Incremental Loop
+
+For each remaining behavior:
+
+```
+RED:   Write next test → fails
+GREEN: Minimal code to pass → passes
+```
+
+Rules:
+
+- One test at a time
+- Only enough code to pass current test
+- Don't anticipate future tests
+- Keep tests focused on observable behavior
+
+### 4. Refactor
+
+After all tests pass, look for [refactor candidates](refactoring.md):
+
+- [ ] Extract duplication
+- [ ] Deepen modules (move complexity behind simple interfaces)
+- [ ] Apply SOLID principles where natural
+- [ ] Consider what new code reveals about existing code
+- [ ] Run tests after each refactor step
+
+**Never refactor while RED.** Get to GREEN first.
+
+## Checklist Per Cycle
+
+```
+[ ] Test describes behavior, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive internal refactor
+[ ] Code is minimal for this test
+[ ] No speculative features added
+```

--- a/internal/skills/defaults/tdd/deep-modules.md
+++ b/internal/skills/defaults/tdd/deep-modules.md
@@ -1,0 +1,33 @@
+# Deep Modules
+
+From "A Philosophy of Software Design":
+
+**Deep module** = small interface + lots of implementation
+
+```
+┌─────────────────────┐
+│   Small Interface   │  ← Few methods, simple params
+├─────────────────────┤
+│                     │
+│                     │
+│  Deep Implementation│  ← Complex logic hidden
+│                     │
+│                     │
+└─────────────────────┘
+```
+
+**Shallow module** = large interface + little implementation (avoid)
+
+```
+┌─────────────────────────────────┐
+│       Large Interface           │  ← Many methods, complex params
+├─────────────────────────────────┤
+│  Thin Implementation            │  ← Just passes through
+└─────────────────────────────────┘
+```
+
+When designing interfaces, ask:
+
+- Can I reduce the number of methods?
+- Can I simplify the parameters?
+- Can I hide more complexity inside?

--- a/internal/skills/defaults/tdd/interface-design.md
+++ b/internal/skills/defaults/tdd/interface-design.md
@@ -1,0 +1,31 @@
+# Interface Design for Testability
+
+Good interfaces make testing natural:
+
+1. **Accept dependencies, don't create them**
+
+   ```typescript
+   // Testable
+   function processOrder(order, paymentGateway) {}
+
+   // Hard to test
+   function processOrder(order) {
+     const gateway = new StripeGateway();
+   }
+   ```
+
+2. **Return results, don't produce side effects**
+
+   ```typescript
+   // Testable
+   function calculateDiscount(cart): Discount {}
+
+   // Hard to test
+   function applyDiscount(cart): void {
+     cart.total -= discount;
+   }
+   ```
+
+3. **Small surface area**
+   - Fewer methods = fewer tests needed
+   - Fewer params = simpler test setup

--- a/internal/skills/defaults/tdd/mocking.md
+++ b/internal/skills/defaults/tdd/mocking.md
@@ -1,0 +1,59 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+  return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+  const client = new StripeClient(process.env.STRIPE_KEY);
+  return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint

--- a/internal/skills/defaults/tdd/refactoring.md
+++ b/internal/skills/defaults/tdd/refactoring.md
@@ -1,0 +1,10 @@
+# Refactor Candidates
+
+After TDD cycle, look for:
+
+- **Duplication** → Extract function/class
+- **Long methods** → Break into private helpers (keep tests on public interface)
+- **Shallow modules** → Combine or deepen
+- **Feature envy** → Move logic to where data lives
+- **Primitive obsession** → Introduce value objects
+- **Existing code** the new code reveals as problematic

--- a/internal/skills/defaults/tdd/tests.md
+++ b/internal/skills/defaults/tdd/tests.md
@@ -1,0 +1,119 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test("user can checkout with valid cart", async () => {
+  const cart = createCart();
+  cart.add(product);
+  const result = await checkout(cart, paymentMethod);
+  expect(result.status).toBe("confirmed");
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test("checkout calls paymentService.process", async () => {
+  const mockPayment = jest.mock(paymentService);
+  await checkout(cart, payment);
+  expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test("createUser makes user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  const retrieved = await getUser(user.id);
+  expect(retrieved.name).toBe("Alice");
+});
+```
+
+## System Boundary Contract Tests (MANDATORY for HTTP/gRPC client structs)
+
+Tests that construct a struct directly and feed it to a fake client are **field-name
+self-consistent** — if the JSON tag on the struct is wrong, the test still passes
+because the fake produces the same wrong struct the consumer reads.
+
+**This entire test class is invisible to the wire contract.** Field-name bugs ship
+silently and only surface in production when the real upstream returns real JSON.
+
+Every HTTP/gRPC client struct must have at least one test that exercises the
+JSON boundary directly — feed a real-looking JSON byte string through
+`json.Unmarshal` (or your language's equivalent) into the struct and assert the
+fields populated.
+
+```go
+// BAD: Struct constructed in-test, fake returns it verbatim. Field-name mismatch
+// vs upstream is invisible — the test loop never touches JSON.
+func TestListRefundProgress_Bad(t *testing.T) {
+    fake := &fakeClient{resp: &Resp{Steps: []*Step{
+        {EventType: 6, Time: "...", Description: "Refund complete"},
+    }}}
+    out, _ := repo.ListProgress(ctx, "O-1")
+    if out[0].Description != "Refund complete" { t.Fail() }
+    // ← passes even if `json:"description"` is actually `json:"remark"` on the wire
+}
+
+// GOOD: Real JSON bytes → Unmarshal → assert fields populated.
+// If a JSON tag drifts, this test catches it. Pair with a fixture taken from
+// the upstream's canonical example, curl capture, or a sibling team's test fixture.
+func TestRefundProgressStep_WireContract(t *testing.T) {
+    raw := []byte(`{
+        "id": 101,
+        "description": "Cash auto refunded.",
+        "time": "2026-04-21 12:00:00 +00:00",
+        "is_current": true,
+        "event_type": 6
+    }`)
+    var s RefundProgressStep
+    if err := json.Unmarshal(raw, &s); err != nil { t.Fatal(err) }
+    if s.Description != "Cash auto refunded." {
+        t.Errorf("description: got %q (json tag wrong?)", s.Description)
+    }
+    if s.ID != 101 || s.EventType != 6 || !s.IsCurrent {
+        t.Errorf("other fields: %+v", s)
+    }
+}
+```
+
+**Rules:**
+- Fixture source order: canonical example > sibling team's test fixture > real curl
+  capture > hand-typed from upstream handler code. Do NOT hand-type the fixture from
+  your own struct definition — that defeats the point.
+- One contract test per struct is enough; you're locking the wire format, not
+  enumerating business cases.
+- Construct-and-fake tests can complement, never replace, the contract test.
+- If a struct has no contract test and the slice modified boundary code, the slice
+  is not done.

--- a/internal/skills/defaults_test.go
+++ b/internal/skills/defaults_test.go
@@ -42,6 +42,12 @@ func TestMaterializeDefaults_WritesEmbeddedAndStamps(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(root, "implement", "SKILL.md")); err != nil {
 		t.Fatalf("expected implement/SKILL.md materialized: %v", err)
 	}
+	// tdd bundles four companion references — all must materialize.
+	for _, f := range []string{"SKILL.md", "tests.md", "mocking.md", "deep-modules.md", "interface-design.md", "refactoring.md"} {
+		if _, err := os.Stat(filepath.Join(root, "tdd", f)); err != nil {
+			t.Fatalf("expected tdd/%s materialized: %v", f, err)
+		}
+	}
 	// code-review bundles a companion template — both files must materialize.
 	for _, f := range []string{"SKILL.md", "code-reviewer.md"} {
 		if _, err := os.Stat(filepath.Join(root, "code-review", f)); err != nil {


### PR DESCRIPTION
Second default-skill port (after implement, #615): the TDD skill, for the lighter entry point — building one feature or fixing one bug test-first, without implement's decompose/state-file machinery.

## What ships

`internal/skills/defaults/tdd/` — SKILL.md + four companion references (progressive disclosure, same shape as code-review's companion):
- **SKILL.md**: behavior-through-public-interfaces philosophy, the horizontal-slicing anti-pattern (all tests then all code → tests of imagined behavior), tracer bullet → incremental one-test-one-impl loop → refactor only on GREEN, per-cycle checklist.
- **tests.md**: good/bad test examples + the mandatory wire-contract test class for HTTP/gRPC boundary structs (construct-and-fake tests are field-name self-consistent and can't catch JSON tag drift).
- **mocking.md** (boundaries only, DI, SDK-style interfaces), **deep-modules.md**, **interface-design.md**, **refactoring.md**.

## octo adaptations

- Plan-gate questions go through `ask_user_question`, with an explicit autonomous-mode escape hatch (pick sensible answers and say which).
- Company-agnostic wording for project vocabulary (domain glossary/CONTEXT.md if present).
- Bidirectional cross-refs with `implement`: its TDD section now points here for test-quality standards ("rhythm vs craft"); tdd's description points big design work at implement.

Verification: defaults materialization test asserts all six files; `octo skills list` shows `/tdd [default]`; `go test -race` green on skills + cmd. Instruction-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)