### PR TITLE
chore(release): bump version to 0.19.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased — 0.19.0-dev]
+
 ## [0.18.0] — 2026-06-11
 
 ### Added

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "0.18.0"
+var Version = "0.19.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Post-release housekeeping after v0.18.0 (tagged, goreleaser running): `version.go` → 0.19.0 (dev builds render as `0.19.0-dev`) and a fresh `Unreleased — 0.19.0-dev` changelog section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)