### PR TITLE
feat(provider): compatible catch-all vendors + registry refresh (Bailian/MiMo in, Groq/SiliconFlow out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased — 0.19.0-dev]
 
+### Changed
+- **Custom base URLs are now exclusive to two catch-all vendors.** New `openai_compatible` / `anthropic_compatible` providers take — and require — a free-form `base_url`; every other vendor is pinned to its official endpoint plus declared regional variants, so the config wizard and web settings no longer offer free-text URLs for them. Existing configs with a custom `base_url` on a named vendor (and `<PROVIDER>_BASE_URL` env vars) keep working on read. An unknown endpoint saved from the web now classifies as the protocol-matching compatible vendor instead of masquerading as real `openai`/`anthropic`. (#623)
+- **Vendor registry refresh.** Added Bailian (Alibaba DashScope compatible mode, mainland/US endpoints, qwen3.5-flash lite compaction) and MiMo (Xiaomi); removed Groq and SiliconFlow. (#623)
+
 ## [0.18.0] — 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ octo --stream=false "..."
 # OpenAI / DeepSeek / Bailian (OpenAI-compatible)
 octo --provider openai --model gpt-4o-mini "..."
 
-# Anthropic-compatible third parties (DeepSeek, Kimi, etc.)
-ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic \
-  octo --model deepseek-chat "..."
+# Anthropic-compatible third parties (DeepSeek, Kimi, etc.) — the
+# *_compatible catch-all vendors are the ones that take a custom base URL
+ANTHROPIC_COMPATIBLE_BASE_URL=https://api.deepseek.com/anthropic \
+ANTHROPIC_COMPATIBLE_API_KEY=sk-... \
+  octo --provider anthropic_compatible --model deepseek-chat "..."
 
 # Extended reasoning: set the intensity (Anthropic thinking / OpenAI reasoning_effort)
 # and stream the dimmed thinking trace. --show-reasoning=false hides the trace.

--- a/README_CN.md
+++ b/README_CN.md
@@ -73,9 +73,11 @@ octo --stream=false "..."
 # OpenAI / DeepSeek / 百炼（OpenAI 兼容）
 octo --provider openai --model gpt-4o-mini "..."
 
-# Anthropic 协议兼容的第三方（DeepSeek、Kimi 等）
-ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic \
-  octo --model deepseek-chat "..."
+# Anthropic 协议兼容的第三方（DeepSeek、Kimi 等）——自定义 base URL
+# 走 *_compatible 万能 vendor（也只有它们接受自定义端点）
+ANTHROPIC_COMPATIBLE_BASE_URL=https://api.deepseek.com/anthropic \
+ANTHROPIC_COMPATIBLE_API_KEY=sk-... \
+  octo --provider anthropic_compatible --model deepseek-chat "..."
 
 # 扩展推理：设置思考强度（Anthropic thinking / OpenAI reasoning_effort），
 # 并以暗色流式显示思考轨迹。--show-reasoning=false 可隐藏轨迹。

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -275,12 +275,30 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 	}
 
-	// Model.
+	// sameProvider gates reuse of the existing entry's model/base URL — values
+	// stored for one vendor must not seed prompts for a different one.
+	sameProvider := existing.Provider == provider
+
+	// Model. Compatible (custom-endpoint) vendors have no catalogue or default,
+	// so the model is a required free-text answer.
 	var model string
-	if tty {
+	if app.VendorCustomEndpoint(provider) {
+		def := ""
+		if sameProvider {
+			def = existing.Model
+		}
+		model = strings.TrimSpace(promptDefault(reader, stdout, "Model (required)", def))
+		if model == "" {
+			fmt.Fprintf(stderr, "octo config: provider %q has no default model — enter one\n", provider)
+			return 2
+		}
+		if tty {
+			fmt.Fprintf(stdout, "Model: %s\n\n", model)
+		}
+	} else if tty {
 		def := defaultModels[provider]
 		startVal := def
-		if existing.Provider == provider && existing.Model != "" {
+		if sameProvider && existing.Model != "" {
 			startVal = existing.Model
 		}
 		items := buildModelItems(app.VendorModels(provider), def, startVal)
@@ -308,32 +326,54 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 		model = ""
 	}
 
-	// Base URL / endpoint. Vendors with regional variants get a menu; everyone
-	// else is offered a free-text custom URL.
-	baseURL := existing.BaseURL
+	// Base URL / endpoint. Compatible (custom-endpoint) vendors require a
+	// free-text URL; vendors with regional variants get a fixed menu; everyone
+	// else is pinned to the default endpoint — no question asked. A legacy
+	// custom URL already stored for the same vendor is preserved as-is.
+	baseURL := ""
+	if sameProvider {
+		baseURL = existing.BaseURL
+	}
 	variants := app.VendorEndpointVariants(provider)
-	if tty && len(variants) > 0 {
+	switch {
+	case app.VendorCustomEndpoint(provider):
+		baseURL = strings.TrimSpace(promptDefault(reader, stdout, "Base URL (required)", baseURL))
+		if baseURL == "" {
+			fmt.Fprintf(stderr, "octo config: provider %q requires a base URL\n", provider)
+			return 2
+		}
+		if tty {
+			fmt.Fprintf(stdout, "Endpoint: %s\n\n", baseURL)
+		}
+	case tty && len(variants) > 0:
 		items := []selectItem{{label: "Default endpoint", desc: app.DefaultBaseURL(provider), value: ""}}
 		for _, v := range variants {
 			items = append(items, selectItem{label: v.Label, desc: v.BaseURL, value: v.BaseURL})
 		}
-		items = append(items, selectItem{label: "Custom base URL…", desc: "enter a URL", value: customSentinel})
-		choice, ok := runSelect(stdin, stdout, "Endpoint", items, existing.BaseURL)
+		choice, ok := runSelect(stdin, stdout, "Endpoint", items, baseURL)
 		if !ok {
 			return cancelWizard(stderr)
 		}
-		if choice.value == customSentinel {
-			baseURL = strings.TrimSpace(promptDefault(reader, stdout, "Custom base URL", existing.BaseURL))
-		} else {
-			baseURL = choice.value
-		}
+		baseURL = choice.value
 		if baseURL == "" {
 			fmt.Fprintf(stdout, "Endpoint: default\n\n")
 		} else {
 			fmt.Fprintf(stdout, "Endpoint: %s\n\n", baseURL)
 		}
-	} else {
-		baseURL = strings.TrimSpace(promptDefault(reader, stdout, "Custom base URL (optional, for DeepSeek/Kimi/etc.)", existing.BaseURL))
+	case len(variants) > 0:
+		// A stale value that is no longer a vendor endpoint must not become the
+		// press-Enter default — it would fail validation below.
+		def := ""
+		if app.VendorByBaseURL(baseURL) == provider {
+			def = baseURL
+		}
+		ans := strings.TrimSpace(promptDefault(reader, stdout, "Endpoint URL (empty = default)", def))
+		if ans != "" && app.VendorByBaseURL(ans) != provider {
+			fmt.Fprintf(stderr, "octo config: %q is not an endpoint of %s — for a custom endpoint use the %s or %s provider\n",
+				ans, app.VendorDisplayName(provider), app.ProviderOpenAICompatible, app.ProviderAnthropicCompatible)
+			return 2
+		}
+		baseURL = ans
 	}
 
 	// The wizard edits the default entry in place; other entries and global

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -178,8 +178,9 @@ func TestRunConfig_Wizard_WritesFile(t *testing.T) {
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("ANTHROPIC_API_KEY", "set-so-wizard-skips-key-prompt")
 
-	// Answers: provider=openai, model=(default), base_url=(blank).
-	in := strings.NewReader("openai\n\n\n")
+	// Answers: provider=openai, model=(default). openai is pinned to its
+	// default endpoint, so the wizard no longer asks for a base URL.
+	in := strings.NewReader("openai\n\n")
 	var stdout, stderr bytes.Buffer
 	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
@@ -199,6 +200,9 @@ func TestRunConfig_Wizard_WritesFile(t *testing.T) {
 	}
 	if entry.APIKey != "" {
 		t.Errorf("APIKey should not be stored when env var is set; got %q", entry.APIKey)
+	}
+	if strings.Contains(stdout.String(), "base URL") || strings.Contains(stdout.String(), "Endpoint") {
+		t.Errorf("pinned vendor must not be asked about its endpoint; got:\n%s", stdout.String())
 	}
 }
 
@@ -220,8 +224,9 @@ func TestRunConfig_Wizard_PreservesOtherEntriesAndGlobals(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Answers: provider=openai, model=(default), base_url=(blank).
-	in := strings.NewReader("openai\n\n\n")
+	// Answers: provider=openai, model=(default). No endpoint question for a
+	// pinned vendor.
+	in := strings.NewReader("openai\n\n")
 	var stdout, stderr bytes.Buffer
 	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
@@ -285,9 +290,10 @@ func TestRunConfig_Wizard_SwitchesProviderAndPromptsForKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Answers: provider=openai, model=(default), base_url=(blank), coauthor=y,
-	// reasoning-effort=(off), show-reasoning=(default), store_key=y, key=new-openai-key.
-	in := strings.NewReader("openai\n\n\ny\n\n\ny\nnew-openai-key\n")
+	// Answers: provider=openai, model=(default), coauthor=y,
+	// reasoning-effort=(off), show-reasoning=(default), store_key=y,
+	// key=new-openai-key. No endpoint question for a pinned vendor.
+	in := strings.NewReader("openai\n\ny\n\n\ny\nnew-openai-key\n")
 	var stdout, stderr bytes.Buffer
 	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
@@ -303,6 +309,76 @@ func TestRunConfig_Wizard_SwitchesProviderAndPromptsForKey(t *testing.T) {
 	}
 	if entry.APIKey != "new-openai-key" {
 		t.Errorf("APIKey = %q, want new-openai-key", entry.APIKey)
+	}
+}
+
+func TestRunConfig_Wizard_CompatibleProviderRequiresModelAndBaseURL(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "set-so-wizard-skips-key-prompt")
+
+	// Answers: provider, model, base URL — both free-text fields are required.
+	in := strings.NewReader("openai_compatible\ndeepseek-chat\nhttps://gw.example/v1\n")
+	var stdout, stderr bytes.Buffer
+	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+
+	got, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load after wizard: %v", err)
+	}
+	entry := got.DefaultEntry()
+	if entry.Provider != "openai_compatible" || entry.Model != "deepseek-chat" || entry.BaseURL != "https://gw.example/v1" {
+		t.Errorf("entry = %+v, want openai_compatible/deepseek-chat/https://gw.example/v1", entry)
+	}
+
+	// An empty base URL is a hard error, not a silent default.
+	in = strings.NewReader("openai_compatible\ndeepseek-chat\n\n")
+	stdout.Reset()
+	stderr.Reset()
+	// Wipe the entry so its stored URL doesn't become the press-Enter default.
+	if err := (config.Config{}).Save(); err != nil {
+		t.Fatal(err)
+	}
+	if code := runConfig(nil, in, &stdout, &stderr); code != 2 {
+		t.Errorf("empty base URL: exit = %d, want 2 (stderr=%q)", code, stderr.String())
+	}
+
+	// An empty model is equally a hard error.
+	in = strings.NewReader("openai_compatible\n\nhttps://gw.example/v1\n")
+	if code := runConfig(nil, in, &stdout, &stderr); code != 2 {
+		t.Errorf("empty model: exit = %d, want 2 (stderr=%q)", code, stderr.String())
+	}
+}
+
+func TestRunConfig_Wizard_PinnedVendorRejectsForeignEndpoint(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("MOONSHOT_API_KEY", "set-so-wizard-skips-key-prompt")
+
+	// kimi has regional variants: a variant URL is accepted…
+	in := strings.NewReader("kimi\n\nhttps://api.moonshot.ai\n")
+	var stdout, stderr bytes.Buffer
+	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
+		t.Fatalf("variant URL: exit = %d, stderr=%q", code, stderr.String())
+	}
+	got, _ := config.Load()
+	if got.DefaultEntry().BaseURL != "https://api.moonshot.ai" {
+		t.Errorf("base URL = %q, want the picked variant", got.DefaultEntry().BaseURL)
+	}
+
+	// …but an arbitrary URL is rejected with a pointer to the catch-alls.
+	in = strings.NewReader("kimi\n\nhttps://evil.example\n")
+	stdout.Reset()
+	stderr.Reset()
+	if code := runConfig(nil, in, &stdout, &stderr); code != 2 {
+		t.Errorf("foreign URL: exit = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "openai_compatible") {
+		t.Errorf("error should point at the compatible catch-alls; got %q", stderr.String())
 	}
 }
 

--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -178,7 +178,12 @@ Usage:
 File (~/.octo/config.yml):
   provider: openai
   model: gpt-4o-mini
-  base_url: https://api.deepseek.com   # optional, for compatible 3rd parties
+
+Self-hosted / third-party endpoints use the compatible catch-all vendors —
+the only providers that take a base_url (and require one):
+  provider: openai_compatible          # or anthropic_compatible
+  model: deepseek-chat
+  base_url: https://my-gateway.example
 
 Environment:
   ANTHROPIC_API_KEY / OPENAI_API_KEY    Override any stored key, per run.`)

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -32,6 +32,10 @@ type Vendor struct {
 	APIKeyEnvVar     string            // environment variable name for the key
 	WebsiteURL       string            // link to the key-management page
 	EndpointVariants []EndpointVariant // regional endpoint alternatives
+	// CustomEndpoint marks a vendor with no fixed endpoint: the user must
+	// supply a base URL. Vendors without it are pinned to DefaultBaseURL
+	// (plus EndpointVariants) — they don't take arbitrary URLs.
+	CustomEndpoint bool
 }
 
 // Registry is the ordered list of supported vendors.  The order is the
@@ -150,15 +154,20 @@ var Registry = []Vendor{
 		WebsiteURL:     "https://console.anthropic.com/settings/keys",
 	},
 	{
-		ID:             "siliconflow",
-		DisplayName:    "SiliconFlow",
+		ID:             "bailian",
+		DisplayName:    "Bailian (Alibaba)",
 		Protocol:       "openai",
 		API:            "openai-completions",
-		DefaultBaseURL: "https://api.siliconflow.cn",
-		DefaultModel:   "deepseek-ai/DeepSeek-V3",
-		Models:         []string{"deepseek-ai/DeepSeek-V3", "deepseek-ai/DeepSeek-R1"},
-		APIKeyEnvVar:   "SILICONFLOW_API_KEY",
-		WebsiteURL:     "https://cloud.siliconflow.cn/account/ak",
+		DefaultBaseURL: "https://dashscope.aliyuncs.com/compatible-mode",
+		DefaultModel:   "qwen3.5-plus",
+		Models:         []string{"qwen3.7-max", "qwen3.5-plus", "qwen3.5-flash"},
+		LiteModel:      "qwen3.5-flash",
+		APIKeyEnvVar:   "DASHSCOPE_API_KEY",
+		WebsiteURL:     "https://bailian.console.aliyun.com",
+		EndpointVariants: []EndpointVariant{
+			{Label: "Mainland China", LabelKey: "settings.models.baseurl.variant.mainland_cn", BaseURL: "https://dashscope.aliyuncs.com/compatible-mode", Region: "cn"},
+			{Label: "International", LabelKey: "settings.models.baseurl.variant.international", BaseURL: "https://dashscope-us.aliyuncs.com/compatible-mode", Region: "intl"},
+		},
 	},
 	{
 		ID:             "mistral",
@@ -172,16 +181,49 @@ var Registry = []Vendor{
 		WebsiteURL:     "https://console.mistral.ai/api-keys/",
 	},
 	{
-		ID:             "groq",
-		DisplayName:    "Groq",
+		ID:             "mimo",
+		DisplayName:    "MiMo (Xiaomi)",
 		Protocol:       "openai",
 		API:            "openai-completions",
-		DefaultBaseURL: "https://api.groq.com/openai",
-		DefaultModel:   "llama-4-scout",
-		Models:         []string{"llama-4-scout", "llama-4-maverick"},
-		APIKeyEnvVar:   "GROQ_API_KEY",
-		WebsiteURL:     "https://console.groq.com/keys",
+		DefaultBaseURL: "https://api.xiaomimimo.com",
+		DefaultModel:   "mimo-v2.5-pro",
+		Models:         []string{"mimo-v2.5-pro"},
+		APIKeyEnvVar:   "MIMO_API_KEY",
+		WebsiteURL:     "https://platform.xiaomimimo.com/#/console/api-keys",
 	},
+	{
+		ID:             ProviderOpenAICompatible,
+		DisplayName:    "OpenAI Compatible",
+		Protocol:       "openai",
+		API:            "openai-completions",
+		APIKeyEnvVar:   "OPENAI_COMPATIBLE_API_KEY",
+		CustomEndpoint: true,
+	},
+	{
+		ID:             ProviderAnthropicCompatible,
+		DisplayName:    "Anthropic Compatible",
+		Protocol:       "anthropic",
+		API:            "anthropic-messages",
+		APIKeyEnvVar:   "ANTHROPIC_COMPATIBLE_API_KEY",
+		CustomEndpoint: true,
+	},
+}
+
+// Catch-all vendor IDs for self-hosted / third-party endpoints speaking a
+// compatible protocol. They are the only vendors that accept a free-form
+// base URL (CustomEndpoint); a base URL is required to build their client.
+const (
+	ProviderOpenAICompatible    = "openai_compatible"
+	ProviderAnthropicCompatible = "anthropic_compatible"
+)
+
+// VendorCustomEndpoint reports whether the vendor has no fixed endpoint and
+// requires a user-supplied base URL.
+func VendorCustomEndpoint(id string) bool {
+	if v := vendorByID(id); v != nil {
+		return v.CustomEndpoint
+	}
+	return false
 }
 
 // vendorByID returns the vendor with the given ID, or nil if unknown.

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -60,7 +60,8 @@ func TestVendor_KimiCoding_BuildClient_CustomBaseURL(t *testing.T) {
 func TestIsKnownVendor(t *testing.T) {
 	for _, id := range []string{
 		"openrouter", "deepseek", "minimax", "kimi", "kimi-coding",
-		"glm", "openai", "anthropic", "siliconflow", "mistral", "groq",
+		"glm", "openai", "anthropic", "bailian", "mistral", "mimo",
+		"openai_compatible", "anthropic_compatible",
 	} {
 		if !IsKnownVendor(id) {
 			t.Errorf("IsKnownVendor(%q) = false, want true", id)
@@ -68,6 +69,54 @@ func TestIsKnownVendor(t *testing.T) {
 	}
 	if IsKnownVendor("bogus") {
 		t.Error("IsKnownVendor(bogus) = true, want false")
+	}
+}
+
+func TestVendor_CompatibleCatchAlls(t *testing.T) {
+	cases := []struct {
+		id, protocol, api, envVar string
+	}{
+		{ProviderOpenAICompatible, "openai", "openai-completions", "OPENAI_COMPATIBLE_API_KEY"},
+		{ProviderAnthropicCompatible, "anthropic", "anthropic-messages", "ANTHROPIC_COMPATIBLE_API_KEY"},
+	}
+	for _, tc := range cases {
+		v := vendorByID(tc.id)
+		if v == nil {
+			t.Fatalf("%s not found in registry", tc.id)
+		}
+		if !v.CustomEndpoint {
+			t.Errorf("%s: CustomEndpoint = false, want true", tc.id)
+		}
+		if v.Protocol != tc.protocol || v.API != tc.api {
+			t.Errorf("%s: protocol/api = %q/%q, want %q/%q", tc.id, v.Protocol, v.API, tc.protocol, tc.api)
+		}
+		if v.DefaultBaseURL != "" || v.DefaultModel != "" || len(v.Models) != 0 {
+			t.Errorf("%s: catch-all must not carry a fixed endpoint or model catalogue: %+v", tc.id, v)
+		}
+		if v.APIKeyEnvVar != tc.envVar {
+			t.Errorf("%s: APIKeyEnvVar = %q, want %q", tc.id, v.APIKeyEnvVar, tc.envVar)
+		}
+	}
+	// Every other vendor is pinned: it must declare a fixed endpoint.
+	for _, v := range Registry {
+		if !v.CustomEndpoint && v.DefaultBaseURL == "" {
+			t.Errorf("vendor %q has neither a fixed endpoint nor CustomEndpoint", v.ID)
+		}
+	}
+}
+
+func TestBuildClient_CompatibleRequiresBaseURL(t *testing.T) {
+	for _, id := range []string{ProviderOpenAICompatible, ProviderAnthropicCompatible} {
+		if _, err := buildClient(id, "sk-dummy", ""); err == nil {
+			t.Errorf("buildClient(%s) without base URL must fail", id)
+		}
+		if _, err := buildClient(id, "sk-dummy", "https://gw.example/v1"); err != nil {
+			t.Errorf("buildClient(%s) with base URL: %v", id, err)
+		}
+	}
+	// Pinned vendors still build with no override.
+	if _, err := buildClient("anthropic", "sk-dummy", ""); err != nil {
+		t.Errorf("buildClient(anthropic) without base URL: %v", err)
 	}
 }
 
@@ -80,6 +129,8 @@ func TestVendorEnvVars(t *testing.T) {
 		{"deepseek", "DEEPSEEK_API_KEY"},
 		{"openai", "OPENAI_API_KEY"},
 		{"anthropic", "ANTHROPIC_API_KEY"},
+		{"bailian", "DASHSCOPE_API_KEY"},
+		{"mimo", "MIMO_API_KEY"},
 	}
 	for _, tc := range tests {
 		got := VendorAPIKeyEnvVar(tc.id)

--- a/internal/app/sender.go
+++ b/internal/app/sender.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/provider"
@@ -79,6 +80,10 @@ func buildClient(name, apiKey, baseURL string) (provider.Provider, error) {
 	v := vendorByID(name)
 	if v == nil {
 		return nil, fmt.Errorf("unknown provider %q", name)
+	}
+	if v.CustomEndpoint && baseURL == "" {
+		return nil, fmt.Errorf("provider %q requires a base URL (set %s_BASE_URL or base_url in config)",
+			name, strings.ToUpper(name))
 	}
 
 	switch v.Protocol {

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -34,6 +34,7 @@ type providerPreset struct {
 	LiteModel        string            `json:"lite_model,omitempty"`
 	EndpointVariants []endpointVariant `json:"endpoint_variants,omitempty"`
 	WebsiteURL       string            `json:"website_url,omitempty"`
+	CustomEndpoint   bool              `json:"custom_endpoint,omitempty"`
 }
 
 // buildProviderPresets builds the response for GET /api/providers from the
@@ -61,6 +62,7 @@ func buildProviderPresets() []providerPreset {
 			LiteModel:        v.LiteModel,
 			EndpointVariants: variants,
 			WebsiteURL:       v.WebsiteURL,
+			CustomEndpoint:   v.CustomEndpoint,
 		})
 	}
 	return presets
@@ -212,6 +214,7 @@ type testConfigRequest struct {
 	Model           string `json:"model"`
 	BaseURL         string `json:"base_url"`
 	APIKey          string `json:"api_key"`
+	Provider        string `json:"provider,omitempty"`
 	Index           int    `json:"index"`
 	AnthropicFormat bool   `json:"anthropic_format"`
 }
@@ -239,12 +242,15 @@ func (s *Server) handleTestConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	providerName := app.ProviderOpenAI
+	// Resolve the vendor: explicit request field > known endpoint > the
+	// protocol-matching compatible catch-all (the URL is custom by then).
+	providerName := app.ProviderOpenAICompatible
 	if req.AnthropicFormat {
-		providerName = app.ProviderAnthropic
+		providerName = app.ProviderAnthropicCompatible
 	}
-	// The panel doesn't name a vendor; a known endpoint pins the protocol.
-	if v := app.VendorByBaseURL(req.BaseURL); v != "" {
+	if req.Provider != "" && app.IsKnownVendor(req.Provider) {
+		providerName = req.Provider
+	} else if v := app.VendorByBaseURL(req.BaseURL); v != "" {
 		providerName = v
 	}
 
@@ -289,10 +295,19 @@ func applyModelRequestToEntry(req saveModelRequest, e *config.ModelEntry) {
 		e.Provider = req.Provider
 	case app.VendorByBaseURL(req.BaseURL) != "":
 		e.Provider = app.VendorByBaseURL(req.BaseURL)
-	case e.Provider == "" && req.AnthropicFormat:
-		e.Provider = app.ProviderAnthropic
-	case e.Provider == "":
-		e.Provider = app.ProviderOpenAI
+	case e.Provider != "":
+		// keep the entry's current vendor
+	case req.BaseURL == "":
+		// No endpoint signal at all — fall back to the protocol root.
+		if req.AnthropicFormat {
+			e.Provider = app.ProviderAnthropic
+		} else {
+			e.Provider = app.ProviderOpenAI
+		}
+	case req.AnthropicFormat:
+		e.Provider = app.ProviderAnthropicCompatible
+	default:
+		e.Provider = app.ProviderOpenAICompatible
 	}
 	if req.ReasoningEffort != "" {
 		e.ReasoningEffort = req.ReasoningEffort

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -118,6 +118,53 @@ func TestConfigModels_PostAppendsEntry(t *testing.T) {
 	}
 }
 
+func TestConfigModels_PostUnknownEndpointBecomesCompatibleVendor(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	// A hand-typed endpoint that matches no vendor preset lands on the
+	// protocol-matching compatible catch-all, not the real openai/anthropic.
+	w := doJSON(t, srv, http.MethodPost, "/api/config/models",
+		`{"model":"my-model","base_url":"https://gw.example/v1","api_key":"sk-x"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	if got := cfg.Models[0].Provider; got != "openai_compatible" {
+		t.Errorf("provider = %q, want openai_compatible", got)
+	}
+
+	w = doJSON(t, srv, http.MethodPost, "/api/config/models",
+		`{"model":"my-model","base_url":"https://gw2.example","api_key":"sk-x","anthropic_format":true}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ = config.Load()
+	if got := cfg.Models[1].Provider; got != "anthropic_compatible" {
+		t.Errorf("anthropic_format provider = %q, want anthropic_compatible", got)
+	}
+}
+
+func TestListProviders_MarksCompatibleCatchAlls(t *testing.T) {
+	presets := buildProviderPresets()
+	byID := map[string]providerPreset{}
+	for _, p := range presets {
+		byID[p.ID] = p
+	}
+	for _, id := range []string{"openai_compatible", "anthropic_compatible"} {
+		p, ok := byID[id]
+		if !ok {
+			t.Fatalf("%s missing from /api/providers presets", id)
+		}
+		if !p.CustomEndpoint || p.BaseURL != "" {
+			t.Errorf("%s: CustomEndpoint=%v BaseURL=%q, want true/empty", id, p.CustomEndpoint, p.BaseURL)
+		}
+	}
+	if byID["deepseek"].CustomEndpoint {
+		t.Error("deepseek must not be flagged custom_endpoint")
+	}
+}
+
 func TestConfigModels_PostFirstEntryBecomesDefault(t *testing.T) {
 	setTestHome(t)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})

--- a/internal/server/static/onboard.js
+++ b/internal/server/static/onboard.js
@@ -281,6 +281,7 @@ const Onboard = (() => {
         // Custom: clear presets so the user can fill in their own values
         $("setup-model").value    = "";
         $("setup-base-url").value = "";
+        $("setup-base-url").readOnly = false;
         _updateSetupModelDropdown([]);
         _updateSetupBaseUrlDropdown(null);
         if (getApiKeyLink) getApiKeyLink.style.display = "none";
@@ -290,6 +291,9 @@ const Onboard = (() => {
         if (preset) {
           $("setup-model").value    = preset.default_model || "";
           $("setup-base-url").value = preset.base_url      || "";
+          // Catalogue vendors are pinned to their endpoint (+ variants via
+          // the dropdown); only custom_endpoint providers take a typed URL.
+          $("setup-base-url").readOnly = !preset.custom_endpoint;
           _updateSetupModelDropdown(preset.models || []);
           _updateSetupBaseUrlDropdown(preset);
           // Show "how to get" link if provider has a website_url
@@ -396,15 +400,17 @@ const Onboard = (() => {
     const preset = providerValue && providerValue !== '__custom__'
       ? _providers.find(p => p.id === providerValue)
       : null;
-    const providerID = preset ? preset.id : 'openai';
-    const anthropicFormat = preset && preset.api === 'anthropic-messages';
+    // No preset means a hand-typed endpoint — that's the OpenAI-compatible
+    // catch-all vendor, not the real OpenAI.
+    const providerID = preset ? preset.id : 'openai_compatible';
+    const anthropicFormat = !!(preset && preset.api === 'anthropic-messages');
 
     // Step 1: test connection
     try {
       const res  = await fetch("/api/config/test", {
         method:  "POST",
         headers: { "Content-Type": "application/json" },
-        body:    JSON.stringify({ model, base_url: baseUrl, api_key: apiKey, index: 0, anthropic_format: anthropicFormat })
+        body:    JSON.stringify({ model, base_url: baseUrl, api_key: apiKey, provider: providerID, index: 0, anthropic_format: anthropicFormat })
       });
       const data = await res.json();
       if (!data.ok) {

--- a/internal/server/static/settings.js
+++ b/internal/server/static/settings.js
@@ -221,6 +221,7 @@ const Settings = (() => {
         } else {
           if (getApiKeyLink) getApiKeyLink.style.display = "none";
         }
+        if (card._applyEndpointLock) card._applyEndpointLock();
       });
     });
 
@@ -450,6 +451,22 @@ const Settings = (() => {
     document.addEventListener("click", () => {
       baseUrlDropdown.style.display = "none";
     });
+
+    // Endpoint editability: catalogue vendors are pinned to their default
+    // endpoint plus declared variants (picked via the dropdown) — only
+    // custom_endpoint providers and unrecognized legacy URLs take free-form
+    // input.
+    const _applyEndpointLock = () => {
+      const p = _currentProvider();
+      baseUrlInput.readOnly = !!(p && !p.custom_endpoint);
+    };
+    if (baseUrlInput) {
+      baseUrlInput.addEventListener("blur", _applyEndpointLock);
+    }
+    // Quick Setup picks change the active provider after this binding ran —
+    // expose the hook so that handler can re-evaluate the lock.
+    card._applyEndpointLock = _applyEndpointLock;
+    _applyEndpointLock();
   }
 
   // ── Read form values from a card ────────────────────────────────────────────
@@ -457,8 +474,13 @@ const Settings = (() => {
   function _readCard(index) {
     const card = document.querySelector(`.model-card[data-index="${index}"]`);
     if (!card) return null;
+    // Vendor: the Quick Setup pick for a new card, else the stored provider.
+    // Sent explicitly so the server doesn't have to reverse-map the base_url.
+    const qsId = card.querySelector(".custom-select-option.selected")?.dataset.value;
+    const provider = (qsId && qsId !== "custom") ? qsId : (_models[index]?.provider || "");
     return {
       index,
+      provider,
       model:            card.querySelector(`[data-key="model"]`).value.trim(),
       base_url:         card.querySelector(`[data-key="base_url"]`).value.trim(),
       api_key:          card.querySelector(`[data-key="api_key"]`).value.trim(),
@@ -520,6 +542,7 @@ const Settings = (() => {
     // never be sent as api_key — the server treats it as "no change"
     // defensively, but the cleanest path is simply to omit it.
     const payload = {
+      provider:         updated.provider,
       model:            updated.model,
       base_url:         updated.base_url,
       anthropic_format: updated.anthropic_format,


### PR DESCRIPTION
## What

**1. Custom base URLs move to dedicated catch-all vendors.**

- New `openai_compatible` / `anthropic_compatible` registry entries (`CustomEndpoint: true`): the only vendors that accept a free-form `base_url`, and they *require* one (`buildClient` errors otherwise). Key env vars: `OPENAI_COMPATIBLE_API_KEY` / `ANTHROPIC_COMPATIBLE_API_KEY`; endpoint via `*_BASE_URL` or config.
- Every other vendor is pinned to its official endpoint + declared regional variants:
  - `octo config` wizard: no endpoint question for fixed-endpoint vendors; variant vendors (kimi/minimax/glm/bailian) get a menu without the free-text option (non-TTY answers are validated against the variant set); compatible vendors get required model + base URL prompts.
  - Web settings / onboarding: base-URL field becomes read-only for catalogue vendors (variants still selectable via dropdown); editable only for the compatible vendors and unrecognized legacy URLs.
- **Backward compat (read-only):** existing `base_url` on named vendor config entries and `<PROVIDER>_BASE_URL` env vars keep working at resolve time; the UIs just no longer offer new ones.
- Server: an unknown endpoint now classifies as the protocol-matching compatible vendor instead of masquerading as real `openai`/`anthropic`; both frontends send the vendor id explicitly on test/save (`provider` field), so the server no longer has to reverse-map URLs.

**2. Registry refresh.**

- **Added** `bailian` — Alibaba DashScope OpenAI-compatible mode (`dashscope.aliyuncs.com/compatible-mode`, US variant `dashscope-us`; Singapore's legacy `dashscope-intl` host is deprecated upstream and deliberately not listed), models qwen3.7-max / qwen3.5-plus / qwen3.5-flash, lite = qwen3.5-flash, key via `DASHSCOPE_API_KEY`.
- **Added** `mimo` — Xiaomi MiMo open platform (`api.xiaomimimo.com`, OpenAI protocol), model mimo-v2.5-pro, key via `MIMO_API_KEY`.
- **Removed** `groq`, `siliconflow`.

Endpoints/models verified against the vendors' live docs (Alibaba Model Studio OpenAI-compatibility page; platform.xiaomimimo.com quick-start).

## Tests

- `internal/app`: catch-all registry shape (no fixed endpoint/catalogue, every pinned vendor must declare an endpoint), `buildClient` base-URL requirement, env-var mapping for the new vendors.
- `cmd/octo`: wizard — compatible vendor requires model+URL (empty → exit 2), pinned vendor skips the endpoint question, variant vendor accepts a variant URL and rejects a foreign one with a pointer to the catch-alls.
- `internal/server`: unknown endpoint lands on `openai_compatible` (`anthropic_format` → `anthropic_compatible`); `/api/providers` flags `custom_endpoint`.

Note: `TestRunChat_OpenAI_MissingAPIKey` fails on this machine **and on main** — it doesn't isolate `$HOME`, so a real `~/.octo/config.yml` leaks in. Pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)