### PR TITLE
fix(cli): clean missing-key UX — no duplicate walkthrough before the auto-wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Custom base URLs are now exclusive to two catch-all vendors.** New `openai_compatible` / `anthropic_compatible` providers take — and require — a free-form `base_url`; every other vendor is pinned to its official endpoint plus declared regional variants, so the config wizard and web settings no longer offer free-text URLs for them. Existing configs with a custom `base_url` on a named vendor (and `<PROVIDER>_BASE_URL` env vars) keep working on read. An unknown endpoint saved from the web now classifies as the protocol-matching compatible vendor instead of masquerading as real `openai`/`anthropic`. (#623)
 - **Vendor registry refresh.** Added Bailian (Alibaba DashScope compatible mode, mainland/US endpoints, qwen3.5-flash lite compaction) and MiMo (Xiaomi); removed Groq and SiliconFlow. (#623)
 
+### Fixed
+- A bare `octo` with no API key no longer prints the manual export-a-key walkthrough right before auto-launching the config wizard — the wizard path shows one intro line; non-interactive runs keep the full actionable help. The help's numbered steps also no longer start at "2." for vendors without a key-management URL. (#625)
+
 ## [0.18.0] — 2026-06-11
 
 ### Added

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -409,7 +410,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 	}
 
-	llmSender, err := buildSender(provName, entry, stderr, senderTuning{
+	// Buffer the first attempt's diagnostics: when a missing key sends us into
+	// the config wizard below, the manual export-a-key walkthrough would only
+	// duplicate (and contradict) the wizard — it's shown solely when the
+	// wizard can't run.
+	var senderDiag bytes.Buffer
+	llmSender, err := buildSender(provName, entry, &senderDiag, senderTuning{
 		thinkingBudget:  anthropicThinkingBudget(resolvedEffort),
 		reasoningEffort: resolvedEffort,
 		showReasoning:   resolvedShowReasoning,
@@ -419,8 +425,8 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		// interactive terminal, run the config wizard automatically rather than
 		// leaving the user to figure out `octo config` on their own.
 		if errors.Is(err, errMissingAPIKey) && stdinIsTTY(stdin) {
+			fmt.Fprintln(stderr, "No API key configured — let's set up octo first.")
 			fmt.Fprintln(stderr, "")
-			fmt.Fprintln(stderr, "No API key configured. Let's set up octo first.")
 			if runConfigWizard(stdin, stdout, stderr) != 0 {
 				return 1
 			}
@@ -440,6 +446,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 				return 1
 			}
 		} else {
+			stderr.Write(senderDiag.Bytes())
 			return 1
 		}
 	}
@@ -878,10 +885,12 @@ func resolveAPIKey(name string, entry config.ModelEntry, stderr io.Writer) (stri
 		fmt.Fprintf(stderr, "octo: %s is not set.\n", envVar)
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintf(stderr, "To use %s:\n", app.VendorDisplayName(name))
+		step := 1
 		if url := app.VendorWebsiteURL(name); url != "" {
-			fmt.Fprintf(stderr, "  1. Get a key at %s\n", url)
+			fmt.Fprintf(stderr, "  %d. Get a key at %s\n", step, url)
+			step++
 		}
-		fmt.Fprintf(stderr, "  2. export %s=sk-...\n", envVar)
+		fmt.Fprintf(stderr, "  %d. export %s=sk-...\n", step, envVar)
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Or run `octo config` to save a default provider/key.")
 		fmt.Fprintln(stderr, "")

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -305,6 +305,12 @@ func TestRunChat_OpenAI_EndToEnd(t *testing.T) {
 }
 
 func TestRunChat_OpenAI_MissingAPIKey(t *testing.T) {
+	// Isolate $HOME: the developer's real ~/.octo/config.yml may hold a stored
+	// key (or a base URL pointing somewhere live), which would turn this
+	// missing-key test into a real network call.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("OPENAI_API_KEY", "")
 	var stdout, stderr bytes.Buffer
 	code := runChat([]string{"--provider", "openai", "hello"}, strings.NewReader(""), &stdout, &stderr)


### PR DESCRIPTION
## What

Bare `octo` with no API key printed the full manual walkthrough (`export ANTHROPIC_API_KEY=...` etc.) and then immediately auto-launched the config wizard — two contradictory instruction sets stacked on screen.

- The first `buildSender` attempt now writes diagnostics to a buffer. Entering the wizard discards them and shows a single intro line (`No API key configured — let's set up octo first.`); any other failure (non-TTY, non-key error) flushes the buffer verbatim, so scripts and pipes keep the actionable help.
- Missing-key help steps no longer start at "2." for vendors without a `WebsiteURL`.
- `TestRunChat_OpenAI_MissingAPIKey` isolates `$HOME` — it previously read the developer's real `~/.octo/config.yml`, turning a missing-key test into a live network call (failed on any machine with a stored key; this was the known local-only red on main).

## Verified

- `go test -race ./...` fully green locally now (previously red on this machine because of the HOME leak).
- Built binary, non-TTY: prints the walkthrough exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)