### PR TITLE
fix(app): resolve vendor default endpoint when base_url is empty

### DIFF
--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -2,6 +2,9 @@ package app
 
 import (
 	"testing"
+
+	"github.com/Leihb/octo-agent/internal/provider/anthropic"
+	"github.com/Leihb/octo-agent/internal/provider/openai"
 )
 
 func TestVendor_KimiCoding(t *testing.T) {
@@ -117,6 +120,36 @@ func TestBuildClient_CompatibleRequiresBaseURL(t *testing.T) {
 	// Pinned vendors still build with no override.
 	if _, err := buildClient("anthropic", "sk-dummy", ""); err != nil {
 		t.Errorf("buildClient(anthropic) without base URL: %v", err)
+	}
+}
+
+// An empty base-URL override must resolve to the vendor's registry endpoint,
+// not the wire client's built-in default (api.openai.com / api.anthropic.com).
+// Regression: a bailian config with no base_url sent its DashScope key to
+// OpenAI and got a foreign 401 back.
+func TestBuildClient_EmptyBaseURL_UsesVendorEndpoint(t *testing.T) {
+	for _, v := range Registry {
+		if v.CustomEndpoint {
+			continue
+		}
+		client, err := buildClient(v.ID, "sk-dummy", "")
+		if err != nil {
+			t.Errorf("buildClient(%s): %v", v.ID, err)
+			continue
+		}
+		var got string
+		switch c := client.(type) {
+		case *openai.Client:
+			got = c.BaseURL
+		case *anthropic.Client:
+			got = c.BaseURL
+		default:
+			t.Errorf("buildClient(%s): unexpected client type %T", v.ID, client)
+			continue
+		}
+		if got != v.DefaultBaseURL {
+			t.Errorf("buildClient(%s) BaseURL = %q, want vendor default %q", v.ID, got, v.DefaultBaseURL)
+		}
 	}
 }
 

--- a/internal/app/sender.go
+++ b/internal/app/sender.go
@@ -85,6 +85,13 @@ func buildClient(name, apiKey, baseURL string) (provider.Provider, error) {
 		return nil, fmt.Errorf("provider %q requires a base URL (set %s_BASE_URL or base_url in config)",
 			name, strings.ToUpper(name))
 	}
+	// An empty override means "the vendor's own endpoint". The wire clients'
+	// zero-value defaults point at api.openai.com / api.anthropic.com, which is
+	// wrong for every other vendor speaking the same protocol — so resolve the
+	// registry endpoint here instead of leaving it to the client.
+	if baseURL == "" {
+		baseURL = v.DefaultBaseURL
+	}
 
 	switch v.Protocol {
 	case "anthropic":


### PR DESCRIPTION
## Problem

Running the setup wizard, picking **Bailian** and entering a DashScope key, then chatting, fails with:

```
error: agent: loop[0]: openai: HTTP 401 (invalid_request_error): Incorrect API key provided: sk-c704c…e81a. You can find your API key at https://platform.openai.com/account/api-keys.
```

The 401 comes from **real OpenAI** — the request went to `api.openai.com`, not DashScope, and the Bailian key was sent to the wrong host.

## Root cause

`buildClient` only set the wire client's `BaseURL` when the override was non-empty:

```go
if baseURL != "" {
    client.BaseURL = baseURL
}
```

An empty override fell through to the wire clients' zero-value defaults (`api.openai.com` / `api.anthropic.com`). The registry's `DefaultBaseURL` was never consumed at construction time — only for display (`effectiveEndpoint`).

This was latent before #623: the old wizard asked for a free-text "Custom base URL", so kimi/deepseek users always had `base_url` populated. #623 pinned named vendors and made the wizard store `""` for "Default endpoint", turning the latent hole into a guaranteed miss for every pinned vendor whose endpoint differs from the protocol default (bailian, kimi, deepseek, glm, minimax, mistral, mimo, openrouter; kimi-coding on the anthropic side). All three transports plus `TestConnection` go through `buildClient`, so all were affected.

## Fix

Resolve the registry endpoint in `buildClient` when the override is empty (after the `CustomEndpoint` required-URL check, which still fires first):

```go
if baseURL == "" {
    baseURL = v.DefaultBaseURL
}
```

One spot covers CLI, server, IM bridge, and the web settings "test connection".

## Test

`TestBuildClient_EmptyBaseURL_UsesVendorEndpoint` walks every pinned vendor in the registry, builds a client with an empty override, and asserts the client's `BaseURL` equals the vendor's `DefaultBaseURL`. Fails before the fix (bailian → `api.openai.com`), passes after.

`go test -race ./...`, `go vet`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)