### PR TITLE
docs: COMPATIBILITY.md — public-contract declaration (1.0 gap #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased — 0.19.0-dev]
 
+### Added
+- **`COMPATIBILITY.md` — the public-contract declaration ahead of 1.0.** Stable (SemVer-covered): config.yml / permissions.yml / mcp.json / channels.yml formats, the Claude-Code-compatible SKILL.md format, identity & memory files, a read guarantee on sessions and tasks, documented CLI commands + flags + exit codes (incl. serve's 42), and `OCTO_*` / vendor env vars. Best-effort: the embedded Web UI's HTTP API + WS events, default rules/skills content. Migration policy: auto-migrate on read, ≥1 minor deprecation window, removing read support = major. The policy is in force now; pre-1.0 minors may still break Stable surfaces with a CHANGELOG callout.
+
 ### Security
 - **Access-key authentication is back** (removed in v0.16.0): every API and WebSocket request from a non-loopback client must present the key (`Authorization: Bearer`, `X-Access-Key`, cookie, or `?access_key=` on `/ws` only). Loopback requests stay friction-free, but the exemption is now hardened against the browser: a foreign `Host` (DNS rebinding) or foreign/`null` `Origin` (CSRF) gets 403, and `--cors '*'` never widens those gates. The key resolves from `-access-key` / `OCTO_ACCESS_KEY` / `config.yml`, else it is auto-generated and persisted; an exposed bind prints a ready-to-open URL embedding it. `SECURITY.md` states the full threat model.
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,140 @@
+# Compatibility
+
+octo follows [Semantic Versioning](https://semver.org). This document
+declares which surfaces that promise covers: what you can build on, what is
+documented but may move, and what is internal. If a surface isn't listed
+here, assume Internal.
+
+**Status:** this policy is in force now (0.19). Until v1.0.0, a minor
+release may still break a Stable surface — always with a **Breaking** callout
+in the [CHANGELOG](CHANGELOG.md). From v1.0.0 the tiers below are a hard
+commitment: breaking a Stable surface requires a major version.
+
+## What the versions mean
+
+- **Major** — a Stable surface changed incompatibly (after the deprecation
+  window below).
+- **Minor** — new features; additive changes to Stable surfaces; any change
+  to Best-effort surfaces.
+- **Patch** — fixes; no surface changes.
+
+## Tiers
+
+- **Stable** — covered by SemVer. Changes are additive in minors; renames,
+  removals, and semantic changes happen only in a major, after a
+  deprecation window.
+- **Best-effort** — documented and real, but not covered. Changes land in
+  minors and are called out in the CHANGELOG.
+- **Internal** — implementation detail. May change in any release without
+  notice.
+
+## Stable surfaces
+
+### Configuration files
+
+| File | Format | The promise |
+|---|---|---|
+| `~/.octo/config.yml` | YAML, mode 0600 | Recognized fields keep their name and meaning (`models` list entries, `default_model`, `lite_model`, `permission_mode`, `access_key`, `tools.*`, …). New fields are optional with working defaults. Unknown fields are ignored, never an error. |
+| `~/.octo/permissions.yml` | YAML | The rule format: top-level keys are tool names, each holding an ordered list of `allow:` / `deny:` / `ask:` rules with `pattern` (terminal substring; a pattern ending in `/` or `~` anchors to an argument boundary), `hostname` (glob list), or `path` (glob list, `$CWD` expansion) matchers. Matching semantics — first match wins, no match → ask — are part of the contract. |
+| `~/.octo/mcp.json`, `.octo/mcp.json` | JSON | The `mcpServers` map: stdio entries (`command`, `args`, `env`) and HTTP entries (`url`, `headers`, `auth: "oauth"`), plus `disabled`. Project file overrides user file by server name. The shape stays compatible with the common `mcpServers` convention, so configs written for other MCP hosts keep loading. |
+| `~/.octo/channels.yml` | YAML | The `channels` map keyed by platform name; each platform's documented keys (and `enabled`) keep their meaning. |
+
+### Skills
+
+`SKILL.md` files — YAML frontmatter (`name`, `description`; unknown keys
+ignored) plus a markdown body — discovered from `~/.octo/skills/<name>/` and
+`.octo/skills/<name>/` (project wins). The format is Claude Code's: skills
+written for Claude Code load unmodified, including the tool-name bridge.
+Disabling via `tools.disabled_skills` in config.yml is part of the contract.
+
+### Custom sub-agents
+
+`~/.octo/agents/<name>.md` definitions — YAML frontmatter (`name`,
+`description`, `read_only`; unknown keys ignored) plus a markdown system
+prompt — keep loading with the same fields and discovery path.
+
+### Identity and memory files
+
+`~/.octo/soul.md`, `~/.octo/user.md`, `~/.octo/octorules.md`, and per-repo
+`.octorules` keep being read, with the same layering (later overrides
+earlier) and `@include` support. Cross-session memory keeps its layout:
+`~/.octo/memories/<slug>/MEMORY.md` as the always-injected index plus topic
+files loaded on demand. These are plain markdown you can edit by hand;
+upgrades never reformat them.
+
+### Saved state (read guarantee)
+
+Sessions (`~/.octo/sessions/*.jsonl`) and scheduler tasks (`~/.octo/tasks/`)
+carry a **read guarantee**: every 1.x release reads state written by any
+earlier 1.x release (and by 0.19+). The write format itself may evolve in
+minors — the promise is that your history and tasks survive upgrades, not
+that the bytes stay identical. Downgrades are not covered: state written by
+a newer octo may not load in an older one.
+
+### CLI
+
+- **Subcommands** (`serve`, `config`, `skills`, `memory`, `init`,
+  `completion`, `version`, `help`, and bare `octo` as chat) and their
+  **documented flags** keep their names and semantics. New flags are
+  additive; renames keep the old spelling working through the deprecation
+  window.
+- **Exit codes**: `0` success, `1` error, `2` usage/unknown-help, and `42`
+  from `octo serve` meaning "restart requested" (the supervisor contract —
+  external supervisors may rely on it).
+- **Not covered**: human-readable stdout/TUI text. Don't parse it; if you
+  need machine-readable output for a command that lacks it, that's a
+  feature request, not a stability bug.
+
+### Environment variables
+
+`OCTO_*` variables (e.g. `OCTO_ACCESS_KEY`, `OCTO_PROVIDER`,
+`OCTO_SERVE_WORKER`) and the per-vendor credential variables
+(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DEEPSEEK_API_KEY`, …, and the
+catch-all `OPENAI_COMPATIBLE_API_KEY` / `OPENAI_COMPATIBLE_BASE_URL` /
+`ANTHROPIC_COMPATIBLE_*` pair) keep their meaning. New variables are
+additive.
+
+## Best-effort surfaces
+
+- **The HTTP API (`/api/*`) and WebSocket events.** This is the embedded
+  Web UI's private API; the UI ships in the same binary, so they can never
+  drift apart. Scripting it with `curl` works and is documented behavior
+  (see [SECURITY.md](SECURITY.md) for authentication), but routes, fields,
+  and events may change in any minor — with a CHANGELOG callout. A
+  versioned `/api/v1` becomes worth doing when third-party integrations
+  exist; until then there is no API stability promise.
+- **Default content**: the embedded default permission rules, default
+  skills, and prompt composition are behavior tuning, not format — they
+  evolve in minors. (The *format* they're written in is Stable, above.)
+- **`GET /api/health` and `GET /api/version`** stay unauthenticated and
+  keep returning JSON, but their bodies may gain fields.
+
+## Internal
+
+Everything under `~/.octo/` not named above — including `tmp/`, `logs/`,
+`bin/`, `trash/`, `uploads/`, `mcp-tokens/`, `history/` —
+plus `~/.octo/skills-default/` (re-extracted per release), the
+`__`-prefixed CLI entrypoints (`__complete`, `__sandboxed-exec`,
+`__trash-backup`), dev-docs, and all Go packages. The module's Go API is
+not a supported surface: octo is distributed as a binary, and
+`internal/` packages carry no compatibility promise.
+
+## Migration policy
+
+- **Old formats migrate automatically on read.** When a format changes,
+  octo keeps reading the old shape and upgrades it on the next write — the
+  way the legacy flat `config.yaml` migrates into the `models:` list today
+  (the original is kept as `config.yaml.bak`). No manual migration step.
+- **Deprecation window**: a deprecated format or CLI spelling keeps working
+  for **at least one minor release** after the CHANGELOG announces it
+  (under a *Deprecated* heading, plus a runtime warning where feasible).
+- **Removing read support for an old format is a breaking change** and
+  happens only in a major release.
+- Auto-migration is one-way; where a file is rewritten, the original is
+  preserved with a `.bak` suffix when practical.
+
+## Reporting
+
+A Stable surface that broke without a major version (post-1.0) or without a
+CHANGELOG **Breaking** callout (pre-1.0) is a bug — please
+[open an issue](https://github.com/Leihb/octo-agent/issues).

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A functionality-first AI agent, distributed as a single Go binary. Speaks two na
 ## Status
 
 > **Pre-1.0.** All three interfaces are live: the CLI (an interactive TUI in a terminal, a headless agentic one-shot everywhere else), a local web server (`octo serve`), and an IM bridge (running inside `octo serve`; WeChat iLink, Feishu, DingTalk, WeCom, Discord, Telegram). On top of the agent loop there are skills, MCP clients, OS-level sandboxing, persistent memory, sub-agents, and a task graph for autonomous multi-step goals.
+>
+> What you can build on is declared in [COMPATIBILITY.md](COMPATIBILITY.md) (stable config formats, CLI, exit codes — and what isn't covered); the security boundary in [SECURITY.md](SECURITY.md).
 
 ## Install
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -14,6 +14,8 @@
 ## 状态
 
 > **Pre-1.0。** 三种界面均已上线：CLI（终端里是交互式 TUI，其余场景是 headless 的 agentic 单发）、本地 Web 服务（`octo serve`）、IM 桥接（随 `octo serve` 运行；微信 iLink、飞书、钉钉、企微、Discord、Telegram）。在 agent 循环之上还有 skills、MCP 客户端、操作系统级沙箱、持久化记忆、子代理，以及用于自主多步目标的任务图。
+>
+> 哪些接口可以放心依赖，见 [COMPATIBILITY.md](COMPATIBILITY.md)（稳定的配置格式、CLI、退出码，以及不在承诺范围内的部分）；安全边界见 [SECURITY.md](SECURITY.md)。
 
 ## 安装
 


### PR DESCRIPTION
## Summary

1.0 gap #2: with 1.0 the SemVer promise becomes real, so this declares **what it covers** before it does.

Tiering (confirmed with Roy):
- **Stable (SemVer-covered)**: config.yml / permissions.yml / mcp.json / channels.yml formats; SKILL.md (Claude-Code-compatible) and `~/.octo/agents/` sub-agent definitions; identity + memory files; a **read guarantee** on sessions (`*.jsonl`) and scheduler tasks; documented CLI commands + flags + **exit codes** (0/1/2 and serve's 42 supervisor contract); `OCTO_*` and vendor env vars.
- **Best-effort**: the embedded Web UI's HTTP API + WS events (same-binary UI, no third-party integrations yet — a versioned `/api/v1` waits until they exist); human-readable CLI output; default rules/skills content.
- **Internal**: everything else under `~/.octo/`, `__`-prefixed entrypoints, all Go packages.
- **Migration policy**: auto-migrate on read (the existing config.yaml→models-list behavior), ≥1 minor deprecation window with CHANGELOG *Deprecated* notices, removing read support = major. Policy in force now (0.19) with pre-1.0 escape hatch (Breaking callouts), hard commitment at v1.0.0.

Every concrete claim was fact-checked against the code by an isolated subagent (struct tags, matcher semantics incl. the `/`-anchor nuance, paths, exit codes, env vars, both README blockquotes). Three majors it caught are fixed in the doc: nonexistent `snapshots/` dir dropped, `~/.octo/agents/` added to Stable, and an overclaiming sentence about identity-file write flows removed.

## Follow-ups surfaced (not in this PR)

- **Bug (Linux):** onboarding writes `~/.octo/SOUL.md`/`USER.md` (uppercase — also read by the web profile API) while prompt composition reads lowercase `soul.md`/`user.md`; on case-sensitive filesystems the onboarded identity is never injected. Needs a casing unification + fallback read.
- `skills` subcommand is dispatched but missing from the `octo help` Commands list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)