### PR TITLE
fix: identity-file casing split (SOUL.md vs soul.md) broke onboarded identity on Linux

### DIFF
--- a/internal/prompt/identity_casing_test.go
+++ b/internal/prompt/identity_casing_test.go
@@ -1,0 +1,57 @@
+package prompt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestIdentityPath_LegacyUppercaseFallback: pre-0.19 onboarding wrote
+// SOUL.md/USER.md while composition reads soul.md/user.md — distinct files
+// on case-sensitive filesystems. IdentityPath must keep those users' files
+// readable. Assertions go through file content, not path equality, so the
+// test is meaningful on Linux and trivially consistent on case-insensitive
+// macOS.
+func TestIdentityPath_LegacyUppercaseFallback(t *testing.T) {
+	t.Run("legacy uppercase only", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "SOUL.md"), []byte("legacy soul"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(IdentityPath(dir, "soul.md"))
+		if err != nil {
+			t.Fatalf("legacy SOUL.md unreachable via IdentityPath: %v", err)
+		}
+		if string(got) != "legacy soul" {
+			t.Errorf("content = %q, want %q", got, "legacy soul")
+		}
+	})
+
+	t.Run("lowercase wins when both exist", func(t *testing.T) {
+		dir := t.TempDir()
+		// On case-insensitive filesystems the second write overwrites the
+		// first, so both spellings hold the canonical content — the
+		// assertion stays valid on every platform.
+		if err := os.WriteFile(filepath.Join(dir, "SOUL.md"), []byte("canonical"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "soul.md"), []byte("canonical"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(IdentityPath(dir, "soul.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "canonical" {
+			t.Errorf("content = %q, want %q", got, "canonical")
+		}
+	})
+
+	t.Run("neither exists returns canonical path", func(t *testing.T) {
+		dir := t.TempDir()
+		want := filepath.Join(dir, "user.md")
+		if got := IdentityPath(dir, "user.md"); got != want {
+			t.Errorf("IdentityPath = %q, want canonical %q", got, want)
+		}
+	})
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -121,6 +121,24 @@ func Compose(userSystem, cwd, env, skills, memory string, coauthor bool) string 
 	return strings.Join(layers, "\n\n---\n\n")
 }
 
+// IdentityPath resolves an identity file under dir, preferring the
+// canonical lowercase name and falling back to the legacy uppercase
+// spelling — pre-0.19 onboarding wrote SOUL.md/USER.md while composition
+// reads soul.md/user.md, which are distinct files on case-sensitive
+// filesystems. When neither exists, the canonical path is returned so
+// callers that create the file use the lowercase name.
+func IdentityPath(dir, lower string) string {
+	canonical := filepath.Join(dir, lower)
+	if _, err := os.Stat(canonical); err == nil {
+		return canonical
+	}
+	legacy := filepath.Join(dir, strings.ToUpper(strings.TrimSuffix(lower, ".md"))+".md")
+	if _, err := os.Stat(legacy); err == nil {
+		return legacy
+	}
+	return canonical
+}
+
 // soulPath and userProfilePath return the per-user identity files
 // (~/.octo/soul.md, ~/.octo/user.md), or "" when the home dir can't be
 // resolved. They're vars so tests can point them at temp files, mirroring
@@ -130,7 +148,7 @@ var soulPath = func() string {
 	if err != nil || home == "" {
 		return ""
 	}
-	return filepath.Join(home, ".octo", "soul.md")
+	return IdentityPath(filepath.Join(home, ".octo"), "soul.md")
 }
 
 var userProfilePath = func() string {
@@ -138,7 +156,7 @@ var userProfilePath = func() string {
 	if err != nil || home == "" {
 		return ""
 	}
-	return filepath.Join(home, ".octo", "user.md")
+	return IdentityPath(filepath.Join(home, ".octo"), "user.md")
 }
 
 // readSoul returns the trimmed, include-expanded contents of ~/.octo/soul.md

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/config"
+	"github.com/Leihb/octo-agent/internal/prompt"
 )
 
 // ─── Provider Presets ───────────────────────────────────────────────────────
@@ -87,7 +87,7 @@ func (s *Server) handleOnboardStatus(w http.ResponseWriter, r *http.Request) {
 // detectOnboardPhase determines whether first-run setup is needed.
 //
 //	"key_setup"  — no API key configured (hard block).
-//	"soul_setup" — key present but SOUL.md missing (soft nudge).
+//	"soul_setup" — key present but soul.md missing (soft nudge).
 //	""           — fully configured.
 func detectOnboardPhase() string {
 	cfg, _ := config.Load()
@@ -112,8 +112,8 @@ func detectOnboardPhase() string {
 		return "key_setup"
 	}
 
-	// Check SOUL.md.
-	soulPath := filepath.Join(octoDir(), "SOUL.md")
+	// Check soul.md (IdentityPath also finds a legacy uppercase SOUL.md).
+	soulPath := prompt.IdentityPath(octoDir(), "soul.md")
 	if _, err := os.Stat(soulPath); os.IsNotExist(err) {
 		return "soul_setup"
 	}

--- a/internal/server/profile_handler.go
+++ b/internal/server/profile_handler.go
@@ -6,32 +6,35 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Leihb/octo-agent/internal/prompt"
 	"github.com/Leihb/octo-agent/internal/trash"
 )
 
 // ─── Profile API ──────────────────────────────────────────────────────────
 
 func (s *Server) handleGetProfileSoul(w http.ResponseWriter, r *http.Request) {
-	content, err := readProfileFile("SOUL.md")
+	path := prompt.IdentityPath(octoDir(), "soul.md")
+	content, err := os.ReadFile(path)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "SOUL.md not found")
+		writeError(w, http.StatusNotFound, "soul.md not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{
-		"content": content,
-		"path":    filepath.Join(octoDir(), "SOUL.md"),
+		"content": string(content),
+		"path":    path,
 	})
 }
 
 func (s *Server) handleGetProfileUser(w http.ResponseWriter, r *http.Request) {
-	content, err := readProfileFile("USER.md")
+	path := prompt.IdentityPath(octoDir(), "user.md")
+	content, err := os.ReadFile(path)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "USER.md not found")
+		writeError(w, http.StatusNotFound, "user.md not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{
-		"content": content,
-		"path":    filepath.Join(octoDir(), "USER.md"),
+		"content": string(content),
+		"path":    path,
 	})
 }
 
@@ -161,15 +164,6 @@ func (s *Server) handleDeleteTrash(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeError(w, http.StatusNotFound, "trash entry not found")
-}
-
-func readProfileFile(name string) (string, error) {
-	p := filepath.Join(octoDir(), name)
-	data, err := os.ReadFile(p)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
 }
 
 func octoDir() string {

--- a/internal/server/profile_handler_test.go
+++ b/internal/server/profile_handler_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestHandleGetProfileSoul_LegacyUppercase: pre-0.19 onboarding wrote
+// ~/.octo/SOUL.md; the profile API must keep serving it. Content-based
+// assertions keep the test meaningful on case-sensitive filesystems and
+// trivially consistent elsewhere.
+func TestHandleGetProfileSoul_LegacyUppercase(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, ".octo"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".octo", "SOUL.md"), []byte("legacy soul"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	req := httptest.NewRequest(http.MethodGet, "/api/profile/soul", nil)
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["content"] != "legacy soul" {
+		t.Errorf("content = %q, want %q", body["content"], "legacy soul")
+	}
+}
+
+func TestHandleGetProfileUser_CanonicalLowercase(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, ".octo"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".octo", "user.md"), []byte("me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	req := httptest.NewRequest(http.MethodGet, "/api/profile/user", nil)
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["content"] != "me" {
+		t.Errorf("content = %q, want %q", body["content"], "me")
+	}
+	if filepath.Base(body["path"]) != "user.md" {
+		t.Errorf("path = %q, want canonical user.md basename", body["path"])
+	}
+}
+
+func TestHandleGetProfileSoul_Missing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	req := httptest.NewRequest(http.MethodGet, "/api/profile/soul", nil)
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}

--- a/internal/server/static/i18n.js
+++ b/internal/server/static/i18n.js
@@ -243,7 +243,7 @@ const I18n = (() => {
       "trash.orphansCleaned": "Cleaned {{count}} orphan entries, freed {{size}}. ({{failed}} failed)",
       "trash.nothingOld":  "No files older than 7 days.",
 
-      // ── Profile (unified read-only view of USER.md / SOUL.md / memories) ──
+      // ── Profile (unified read-only view of user.md / soul.md / memories) ──
       "profile.title":         "Assistant Memory",
       "profile.subtitle":      "A window into the assistant's inner life: who it is, who you are, and what it remembers about your work together.",
       "profile.whoIAm":        "Who I am",
@@ -499,7 +499,7 @@ const I18n = (() => {
       "settings.models.errorPrefix":       "Error: ",
       "settings.models.confirmRemove":     "Remove model \"{{model}}\"?",
       "settings.personalize.title":        "Personalize",
-      "settings.personalize.desc":         "Re-run the onboarding to update your assistant's personality and user profile (SOUL.md & USER.md).",
+      "settings.personalize.desc":         "Re-run the onboarding to update your assistant's personality and user profile (soul.md & user.md).",
       "settings.personalize.btn":          "✨ Re-run Onboard",
       "settings.personalize.btn.starting": "Starting…",
       "settings.personalize.btn.rerun":    "✨ Re-run Onboard",
@@ -792,7 +792,7 @@ const I18n = (() => {
       "trash.orphansCleaned": "已清理 {{count}} 条孤儿，释放 {{size}}。（失败 {{failed}}）",
       "trash.nothingOld":  "没有超过 7 天的文件。",
 
-      // ── Profile (助理记忆 — USER.md / SOUL.md / 记忆 统一只读视图) ──
+      // ── Profile (助理记忆 — user.md / soul.md / 记忆 统一只读视图) ──
       "profile.title":         "助理记忆",
       "profile.subtitle":      "这是一扇通往 AI 内心的窗口：它是谁、你是谁、以及它在和你共事中记住了什么。",
       "profile.whoIAm":        "我是谁",
@@ -1047,7 +1047,7 @@ const I18n = (() => {
       "settings.models.errorPrefix":       "错误：",
       "settings.models.confirmRemove":     "删除模型「{{model}}」？",
       "settings.personalize.title":        "个性化",
-      "settings.personalize.desc":         "重新运行引导流程，更新助手的个性和用户档案（SOUL.md & USER.md）。",
+      "settings.personalize.desc":         "重新运行引导流程，更新助手的个性和用户档案（soul.md & user.md）。",
       "settings.personalize.btn":          "✨ 重新引导",
       "settings.personalize.btn.starting": "启动中…",
       "settings.personalize.btn.rerun":    "✨ 重新引导",

--- a/internal/server/static/onboard.js
+++ b/internal/server/static/onboard.js
@@ -6,7 +6,7 @@
 //                Hard block: nothing works without an API key.
 //                On success, automatically launches the /onboard session.
 //
-//   soul_setup → API key is already configured, SOUL.md is missing.
+//   soul_setup → API key is already configured, soul.md is missing.
 //                Automatically creates an /onboard session and boots the UI —
 //                no blocking panel shown, user lands directly in the session.
 //

--- a/internal/server/static/profile.js
+++ b/internal/server/static/profile.js
@@ -3,8 +3,8 @@
 // Three tabs, all read-only views with single-action buttons that delegate to
 // the agent via slash-commands:
 //
-//   🧬 Soul      — SOUL.md rendered. Button opens /onboard scope:soul.
-//   👤 User      — USER.md rendered. Button opens /onboard scope:user.
+//   🧬 Soul      — soul.md rendered. Button opens /onboard scope:soul.
+//   👤 User      — user.md rendered. Button opens /onboard scope:user.
 //   🧠 Memories  — list of ~/.octo/memories/*.md, sorted by updated_at desc.
 //                  Per-card "Curate" opens /onboard path:<abs>.
 //                  Per-card "Delete" calls DELETE /api/memories/:filename

--- a/internal/skills/defaults/onboard/SKILL.md
+++ b/internal/skills/defaults/onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboard
-description: Onboard a new user OR curate a single piece of the assistant's inner state. Without arguments, runs the full first-run ceremony (AI name, personality, user profile, SOUL.md + USER.md). With `scope:soul` or `scope:user`, runs a quick chat to update just that one profile file. With `path:<abs>`, runs a quick chat to update / keep / delete one memory file under ~/.octo/memories/.
+description: Onboard a new user OR curate a single piece of the assistant's inner state. Without arguments, runs the full first-run ceremony (AI name, personality, user profile, soul.md + user.md). With `scope:soul` or `scope:user`, runs a quick chat to update just that one profile file. With `path:<abs>`, runs a quick chat to update / keep / delete one memory file under ~/.octo/memories/.
 ---
 
 # Skill: onboard
@@ -13,9 +13,9 @@ This single skill covers three modes, dispatched by the invocation arguments:
 
 | Args                      | Mode                | What it does                                               |
 |---------------------------|---------------------|------------------------------------------------------------|
-| *(none)*                  | **first-run**       | Full intro: name the AI, pick personality, learn user, write SOUL.md + USER.md. |
-| `scope:soul`              | **curate SOUL**     | Short chat to tweak `~/.octo/SOUL.md` only.                |
-| `scope:user`              | **curate USER**     | Short chat to tweak `~/.octo/USER.md` only.                |
+| *(none)*                  | **first-run**       | Full intro: name the AI, pick personality, learn user, write soul.md + user.md. |
+| `scope:soul`              | **curate SOUL**     | Short chat to tweak `~/.octo/soul.md` only.                |
+| `scope:user`              | **curate USER**     | Short chat to tweak `~/.octo/user.md` only.                |
 | `path:<abs>`              | **curate memory**   | Short chat to update / keep / delete one memory file at the given path. |
 
 `lang:zh` or `lang:en` may be combined with any mode to pin the language.
@@ -38,7 +38,7 @@ Look for `lang:zh` / `lang:en` anywhere in the same line and use it to set the l
 ### A.1. Detect language
 
 Check for `lang:zh` or `lang:en` in the invocation:
-- `lang:zh` → conduct the **entire** onboard in **Chinese**, write SOUL.md & USER.md in Chinese.
+- `lang:zh` → conduct the **entire** onboard in **Chinese**, write soul.md & user.md in Chinese.
 - Otherwise (or if missing) → use **English** throughout.
 
 If the `lang:` argument is absent, infer from the user's first reply; default to English.
@@ -166,9 +166,9 @@ Store as `prefs.show_reasoning` boolean (default `true`).
 For each URL, use `web_fetch` to gather bio / projects / interests / writing style.
 Silently skip unreachable links.
 
-### A.8. Write SOUL.md
+### A.8. Write soul.md
 
-Write to `~/.octo/SOUL.md`. Shape by `ai.name` + `ai.personality`.
+Write to `~/.octo/soul.md`. Shape by `ai.name` + `ai.personality`.
 Write in the chosen language. If `zh`, add a line near the top of Identity:
 `**始终用中文回复用户。**`
 
@@ -203,9 +203,9 @@ I am [AI Name], a personal assistant and technical co-founder.
 [2–3 sentences about how I approach tasks, matching the personality.]
 ```
 
-### A.9. Write USER.md
+### A.9. Write user.md
 
-Write to `~/.octo/USER.md`.
+Write to `~/.octo/user.md`.
 
 en template:
 ```markdown
@@ -297,8 +297,8 @@ conversation and a clean write.
 
 ### B.1. Resolve target
 
-- `scope:soul` → target file is `~/.octo/SOUL.md`, topic is the AI's personality
-- `scope:user` → target file is `~/.octo/USER.md`, topic is the user's profile
+- `scope:soul` → target file is `~/.octo/soul.md`, topic is the AI's personality
+- `scope:user` → target file is `~/.octo/user.md`, topic is the user's profile
 
 Language:
 - `lang:zh` / `lang:en` → use that
@@ -486,7 +486,7 @@ One short line. No summary, no celebration. Examples:
 ### C.8. Curate-memory notes
 
 - **Do not** create new memory files here — different flow.
-- **Do not** edit any other file (SOUL.md, USER.md, other memories).
+- **Do not** edit any other file (soul.md, user.md, other memories).
 - Keep it tight: one summary, one question, at most one follow-up.
 - Memory files are personal; never share contents with external tools
   (web search, web_fetch, etc.).


### PR DESCRIPTION
## Summary

Found by the COMPATIBILITY.md fact-check (#627): onboarding writes `~/.octo/SOUL.md`/`USER.md` (uppercase — also read by `GET /api/profile/*` and the soul_setup nudge), but prompt composition reads lowercase `soul.md`/`user.md`. On case-insensitive filesystems (macOS) they're the same file, so it always worked; **on Linux the onboarded identity was never injected into the system prompt**, and a hand-written `soul.md` was invisible to the web profile page.

Fix — lowercase is canonical (what README and COMPATIBILITY.md document):

- New `prompt.IdentityPath(dir, lower)`: prefers the lowercase name, falls back to the legacy uppercase spelling, returns the canonical path when neither exists. Used by prompt composition, `GET /api/profile/soul|user`, and the onboard-phase detector — so existing Linux users' `SOUL.md` starts loading everywhere with no migration step.
- The onboard skill now writes `soul.md`/`user.md`; web UI strings/comments updated to match.

## Tests

- `prompt`: legacy-uppercase-only readable via `IdentityPath`; lowercase wins when both exist; canonical path returned when absent (content-based assertions — meaningful on the Linux CI leg, trivially consistent on case-insensitive macOS).
- `server`: profile API serves a legacy `SOUL.md` (200 + content), canonical `user.md` (200 + lowercase path in response), 404 when missing.
- `make test` (-race) / vet / fmt-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)