### PR TITLE
fix(tui): idle Ctrl+Q submits like Enter instead of trapping the message

### DIFF
--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -85,6 +85,24 @@ func TestTUI_CtrlXUnqueuesMostRecent(t *testing.T) {
 	}
 }
 
+// Idle, the queue key behaves exactly like Enter (design §7): nothing would
+// ever drain a queue with no running turn, so the message must start a turn
+// immediately instead of being trapped.
+func TestTUI_IdleCtrlQStartsTurn(t *testing.T) {
+	m := newTestModel()
+	setInput(m, "check recent PRs")
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlQ})
+	if !m.turnRunning {
+		t.Fatal("idle Ctrl+Q should start a turn, same as Enter")
+	}
+	if len(m.queue) != 0 {
+		t.Errorf("idle Ctrl+Q must not leave the message queued, got %+v", m.queue)
+	}
+	if m.ta.Value() != "" {
+		t.Errorf("input should clear, got %q", m.ta.Value())
+	}
+}
+
 func TestTUI_RunningCtrlQQueues(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -139,7 +139,13 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case tea.KeyCtrlQ:
-		// Queue the current input to run as a future turn.
+		// Queue the current input to run as a future turn. Idle, there is no
+		// turn to wait for and nothing ever drains the queue — the design
+		// table (dev-docs/tui-input-modes-design.md §7) makes the queue key
+		// behave exactly like Enter, so delegate to the same submit path.
+		if !m.turnRunning {
+			return m.submit()
+		}
 		text := strings.TrimSpace(m.ta.Value())
 		if text == "" {
 			return m, nil


### PR DESCRIPTION
## Problem

Pressing Ctrl+Q while the agent is idle queues the message — and it never runs. The queue's only drain point is `handleTurnFinished`, so with no turn running there is no trigger; the message sits in the queue panel until the user happens to start an unrelated turn with Enter.

## Design intent

`dev-docs/tui-input-modes-design.md` §7 specifies the queue key at idle as **"(同 Enter)"** — submit and start a new turn. The `KeyCtrlQ` handler ignored `turnRunning` and unconditionally appended to the queue.

## Fix

At idle, delegate to `submit()` — the exact Enter path, so slash-command dispatch and image-attachment folding behave identically. Mid-turn behaviour (queue for after the current turn) is unchanged. The task-list usage still works: the first Ctrl+Q starts a turn, subsequent ones queue against it.

## Test

`TestTUI_IdleCtrlQStartsTurn`: idle Ctrl+Q starts a turn, leaves the queue empty, clears the input. Existing `TestTUI_RunningCtrlQQueues` covers the unchanged mid-turn path.

`go test -race ./...`, `go vet`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)