### PR TITLE
fix(agent,server): keep the memory save-nudge out of every UI surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Vendor registry refresh.** Added Bailian (Alibaba DashScope compatible mode, mainland/US endpoints, qwen3.5-flash lite compaction) and MiMo (Xiaomi); removed Groq and SiliconFlow. (#623)
 
 ### Fixed
+- The memory save-nudge no longer leaks into tool cards. The `<system-reminder>` the tool-result hook appends after `gh pr create`/`merge` is model-facing, but every UI surface rendered it verbatim — the TUI card, the headless one-shot output, the web's live `tool_result` broadcast, and the web history replay. Tool-result events and the replay now strip reminder spans for display; the persisted blocks keep them so the model still reads the nudge, including on session resume.
 - A bare `octo` with no API key no longer prints the manual export-a-key walkthrough right before auto-launching the config wizard — the wizard path shows one intro line; non-interactive runs keep the full actionable help. The help's numbered steps also no longer start at "2." for vendors without a key-management URL. (#625)
 
 ## [0.18.0] — 2026-06-11

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -699,8 +699,10 @@ func (a *Agent) runLoop(
 				return Reply{}, fmt.Errorf("agent: dispatch tools[%d]: %w", i, err)
 			}
 
-			// Decorate results before events and history so every surface
-			// (model, UI stream, persisted session) sees the same text.
+			// Decorate results before events and history so the model and
+			// the persisted session see the same text. UI events strip the
+			// <system-reminder> spans (emitToolResultEvents) — hook output
+			// is model-facing, not part of the tool's visible result.
 			applyToolResultHook(a.ToolResultHook, reply.Blocks, resultBlocks)
 
 			// Emit EventToolDone / EventToolError per result, pairing
@@ -1060,7 +1062,7 @@ func emitToolResultEvents(handler EventHandler, useBlocks, resultBlocks []Conten
 		ev := AgentEvent{
 			ToolID:   r.ToolUseID,
 			ToolName: nameByID[r.ToolUseID],
-			Output:   truncateOutput(r.Result),
+			Output:   truncateOutput(StripRemindersForDisplay(r.Result)),
 			UI:       r.UI,
 		}
 		if r.IsError {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -414,6 +414,19 @@ func StripSystemReminders(s string) string {
 	return s
 }
 
+// StripRemindersForDisplay removes <system-reminder> spans from a tool result
+// before it reaches a UI surface (event stream, web history replay). The spans
+// stay in the persisted blocks — the model must still read them — but a hook
+// like the memory save-nudge must not render in tool cards. Text without
+// reminders is returned byte-identical, so ordinary tool output is untouched.
+func StripRemindersForDisplay(s string) string {
+	stripped := StripSystemReminders(s)
+	if stripped == s {
+		return s
+	}
+	return strings.TrimRight(stripped, " \t\n")
+}
+
 // LoadSession reads ~/.octo/sessions/<id>.jsonl. id may be a bare session id,
 // an id with a .jsonl/.json suffix, or an absolute path to a transcript file.
 func LoadSession(id string) (*Session, error) {

--- a/internal/agent/toolresulthook_test.go
+++ b/internal/agent/toolresulthook_test.go
@@ -76,6 +76,46 @@ func TestToolResultHook_EmptyReturnLeavesResultUntouched(t *testing.T) {
 	}
 }
 
+// A <system-reminder> span appended by the hook (memory save-nudge) is
+// model-facing: it must stay on the persisted block but never reach the UI
+// event stream, where it would render inside the tool card.
+func TestToolResultHook_ReminderStrippedFromEventOutput(t *testing.T) {
+	uses := []ContentBlock{
+		NewToolUseBlock("call-1", "terminal", map[string]any{"command": "gh pr create"}),
+	}
+	results := []ContentBlock{NewToolResultBlock("call-1", "created PR #7", false)}
+	applyToolResultHook(func(string, map[string]any) string {
+		return "<system-reminder>\nsave a memory\n</system-reminder>"
+	}, uses, results)
+
+	if !strings.Contains(results[0].Result, "<system-reminder>") {
+		t.Fatalf("block must keep the reminder for the model: %q", results[0].Result)
+	}
+
+	var events []AgentEvent
+	emitToolResultEvents(func(ev AgentEvent) { events = append(events, ev) }, uses, results)
+	if len(events) != 1 || events[0].Kind != EventToolDone {
+		t.Fatalf("events = %+v, want one EventToolDone", events)
+	}
+	if strings.Contains(events[0].Output, "system-reminder") || strings.Contains(events[0].Output, "save a memory") {
+		t.Errorf("event Output leaks the reminder: %q", events[0].Output)
+	}
+	if want := "created PR #7"; events[0].Output != want {
+		t.Errorf("event Output = %q, want %q (no trailing blank lines)", events[0].Output, want)
+	}
+}
+
+func TestStripRemindersForDisplay(t *testing.T) {
+	clean := "plain output\nwith trailing newline\n"
+	if got := StripRemindersForDisplay(clean); got != clean {
+		t.Errorf("clean text must be byte-identical, got %q", got)
+	}
+	decorated := "merged\n\n<system-reminder>\nnudge\n</system-reminder>"
+	if got := StripRemindersForDisplay(decorated); got != "merged" {
+		t.Errorf("decorated = %q, want %q", got, "merged")
+	}
+}
+
 func TestApplyToolResultHook_SkipsErroredAndUnmatched(t *testing.T) {
 	uses := []ContentBlock{
 		NewToolUseBlock("ok", "terminal", map[string]any{"command": "gh pr create"}),

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -387,9 +387,13 @@ func (s *Server) handleGetSessionMessages(w http.ResponseWriter, r *http.Request
 			for _, b := range m.Blocks {
 				if b.Type == "tool_result" {
 					hasToolResult = true
+					// Persisted results may carry model-facing
+					// <system-reminder> spans appended by the tool-result
+					// hook (memory save-nudge) — strip them for display,
+					// matching the live EventToolDone path.
 					ev := map[string]any{
 						"type":   "tool_result",
-						"result": b.Result,
+						"result": agent.StripRemindersForDisplay(b.Result),
 					}
 					if b.UI != nil {
 						ev["ui_payload"] = b.UI

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -932,6 +932,10 @@ func TestHandleGetSessionMessages_MultiToolUse(t *testing.T) {
 	// surface the payload as ui_payload after the session JSON round-trip.
 	res1 := agent.NewToolResultBlock("call_1", "file.txt\n", false)
 	res1.UI = map[string]any{"type": "file_list", "total": 1}
+	// res2 carries a model-facing <system-reminder> appended by the
+	// tool-result hook (memory save-nudge); replay must strip it.
+	res2 := agent.NewToolResultBlock("call_2",
+		"file.txt:1:foo\n\n<system-reminder>\nsave a memory\n</system-reminder>", false)
 
 	sess := agent.NewSession("stub-model", "")
 	sess.Messages = []agent.Message{
@@ -942,7 +946,7 @@ func TestHandleGetSessionMessages_MultiToolUse(t *testing.T) {
 		}),
 		agent.NewToolResultMessage([]agent.ContentBlock{
 			res1,
-			agent.NewToolResultBlock("call_2", "file.txt:1:foo\n", false),
+			res2,
 		}),
 		agent.NewAssistantMessage("Found it"),
 	}
@@ -998,6 +1002,10 @@ func TestHandleGetSessionMessages_MultiToolUse(t *testing.T) {
 	}
 	if _, present := body.Events[5]["ui_payload"]; present {
 		t.Errorf("events[5].ui_payload present, want absent: %#v", body.Events[5]["ui_payload"])
+	}
+	// The save-nudge reminder on res2 is model-facing — replay must strip it.
+	if got, _ := body.Events[5]["result"].(string); got != "file.txt:1:foo" {
+		t.Errorf("events[5].result = %q, want reminder stripped", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

The memory save-nudge (#583) — "A pull request was just created or merged. If this work settled anything durable…" — rendered verbatim in the UI. The ToolResultHook appends it as a `<system-reminder>` span to the tool_result **before** events fire and history persists (deliberately, so model + persistence agree), but no UI path stripped it:

| Leak surface | Where |
|---|---|
| TUI tool card | `tuirepl.go` renders `ev.Output` raw |
| Headless one-shot | `repl.go` same |
| Web live turn | `ws_handlers.go` broadcasts `EventToolDone.Output` raw |
| Web history replay | `handlers.go` emits persisted `b.Result` raw |

## Fix

Split along the existing boundary — **blocks are model-facing, events are UI-facing**:

- `emitToolResultEvents` strips reminder spans from `AgentEvent.Output` via new `agent.StripRemindersForDisplay` — one change covers TUI, headless, and web live. Output without reminders stays byte-identical.
- Web history replay strips persisted tool_result content the same way.
- Persisted blocks keep the reminder: the model still reads the nudge in-turn and on session resume.

Any future hook/notice that rides a tool_result inside `<system-reminder>` is now UI-immune by construction.

## Tests

- `TestToolResultHook_ReminderStrippedFromEventOutput` — block keeps the span, event Output doesn't (no trailing blank lines either)
- `TestStripRemindersForDisplay` — clean text byte-identical; decorated text stripped + trimmed
- `TestHandleGetSessionMessages_MultiToolUse` extended — replayed `result` field is stripped
- Full `go test -race ./...`, vet, gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)