### PR TITLE
feat(tui): recall last message after Esc interrupt

### DIFF
--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -164,21 +164,39 @@ func TestTUI_EscTakesBackBeforeOutput(t *testing.T) {
 }
 
 // Once output has streamed the echo is already committed (echoPending == ""), so
-// Esc just interrupts and leaves the input box untouched.
+// Esc interrupts and recalls the last submitted message from history.
 func TestTUI_EscAfterOutputJustInterrupts(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true
 	cancelled := false
 	m.cancelTurn = func() { cancelled = true }
 	// echoPending already committed by the first output event.
+	m.inputHistory = []string{"fix the bug"}
 
 	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
 
 	if !cancelled {
 		t.Error("Esc should still interrupt once output has started")
 	}
+	if m.ta.Value() != "fix the bug" {
+		t.Errorf("input box should recall last message, got %q", m.ta.Value())
+	}
+}
+
+// Esc after output with empty history leaves the input box untouched.
+func TestTUI_EscAfterOutputEmptyHistory(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	cancelled := false
+	m.cancelTurn = func() { cancelled = true }
+
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if !cancelled {
+		t.Error("Esc should interrupt")
+	}
 	if m.ta.Value() != "" {
-		t.Errorf("input box should stay empty mid-stream, got %q", m.ta.Value())
+		t.Errorf("input box should stay empty with no history, got %q", m.ta.Value())
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -105,7 +105,8 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// and restore the typed text to the input box for editing — the agent's
 			// interrupt rolls the unanswered user message back out of history, so
 			// it leaves no trace in the scrollback. Once output has streamed the
-			// echo is already committed (echoPending == "") and Esc just interrupts.
+			// echo is already committed (echoPending == "") and Esc interrupts +
+			// recalls the last submitted message from history.
 			if m.echoPending != "" {
 				restore := m.echoRestore
 				m.echoPending = ""
@@ -119,7 +120,16 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 				return m, nil
 			}
+			// After output has streamed the echo is committed; Esc interrupts
+			// and recalls the last submitted message into the input box so the
+			// user can edit and resubmit without pressing ↑ manually.
 			m.interrupt()
+			if n := len(m.inputHistory); n > 0 && m.ta.Value() == "" {
+				m.ta.SetValue(m.inputHistory[n-1])
+				m.ta.CursorEnd()
+				m.inputHistoryIdx = -1
+				return m, m.updateTextAreaHeight()
+			}
 			return m, nil
 		}
 		// Idle: clear the input line and discard any pending attachments.


### PR DESCRIPTION
## Problem

When Esc interrupts a running turn **after output has already started streaming**, the user's last message is gone from the input box. They have to press ↑ to recall it from history before editing and resubmitting.

## Solution

After interrupting, automatically restore the most recent entry from `inputHistory` into the input box (only when the input is empty, so it never overwrites text the user is already editing).

The "take-back" path (Esc before any output) is unchanged — it still restores the typed text via `echoRestore`.

## Changes

- `cmd/octo/tuirepl_view.go`: recall `inputHistory[n-1]` into textarea after Esc interrupt when `echoPending == ""`
- `cmd/octo/tuirepl_test.go`: update `TestTUI_EscAfterOutputJustInterrupts` to verify recall, add `TestTUI_EscAfterOutputEmptyHistory` for empty-history case