### PR TITLE
chore(tui): shorten session exit banner

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -118,7 +118,7 @@ func runTUI(cfg replConfig) int {
 		}
 	}
 	if !cfg.verbosity.quiet() {
-		fmt.Fprintf(cfg.stdout, "\nSession saved. Resume anytime with: octo -c %s\n", cfg.session.ShortID())
+		fmt.Fprintf(cfg.stdout, "\nResume: octo -c %s\n", cfg.session.ShortID())
 	}
 	return 0
 }


### PR DESCRIPTION
Before: `Session saved. Resume anytime with: octo -c ae8cb6be`\nAfter: `Resume: octo -c ae8cb6be`