### PR TITLE
feat(context): inject detected developer toolchain into session context

### DIFF
--- a/cmd/octo/envcontext.go
+++ b/cmd/octo/envcontext.go
@@ -38,6 +38,10 @@ func buildEnvContext(cwd string) string {
 	// on Windows, sudo/PATH/CLT traps on macOS) lives in internal/tools next
 	// to the shell selection itself, shared with the server's context builder.
 	b.WriteString(tools.ShellEnvNote())
+	// Which common developer tools are actually on PATH — so the agent doesn't
+	// discover python/node is missing by failing a command. Pairs with the
+	// install guidance above.
+	b.WriteString(tools.ToolchainNote())
 	return b.String()
 }
 

--- a/dev-docs/windows-onboarding-design.md
+++ b/dev-docs/windows-onboarding-design.md
@@ -1,0 +1,171 @@
+# Windows onboarding design
+
+Make octo installable and usable by a non-developer Windows user: download one
+file, double-click, and end up with `octo` permanently on `PATH` — then have the
+agent know which developer tools (python / node / …) are actually present so it
+stops blindly invoking ones that aren't.
+
+Two independent parts:
+
+- **A. Toolchain detection** — the agent learns, at context-build time, which
+  common runtimes exist on the machine. Cross-platform, small, in-binary.
+- **B. Windows installer** — a double-click `octo-setup.exe` that installs
+  per-user, writes `PATH`, and registers an uninstaller. Touches the release
+  pipeline.
+
+## Goal / acceptance
+
+A Windows user with no dev toolchain:
+
+1. Downloads `octo-setup.exe` from the GitHub Release.
+2. Double-clicks it. (Unsigned MVP: clicks through the SmartScreen "More info →
+   Run anyway" prompt — documented.)
+3. The installer copies `octo.exe` to `%LOCALAPPDATA%\Programs\octo`, adds that
+   directory to the user `PATH`, creates a Start-menu shortcut, and registers an
+   entry in "Add or remove programs". No UAC prompt.
+4. Opens a **new** terminal, types `octo`, and it runs. First run launches the
+   existing config wizard.
+5. When a task needs a tool that isn't installed, the agent already knows it's
+   missing (from part A) and uses the existing `ShellEnvNote()` guidance to walk
+   the user through a `winget` install — instead of discovering the gap by
+   failing a command.
+
+## Current state
+
+**Distribution.** goreleaser ships a per-platform archive; Windows gets a `.zip`
+containing `octo.exe`, `start-octo.cmd`, and the docs. There is no installer.
+The user either double-clicks `start-octo.cmd` — which puts octo on `PATH` for
+that one PowerShell session only — or manually edits `PATH`. Typing `octo` in a
+fresh terminal therefore fails until the user fixes `PATH` themselves. The
+README's install section is bash/curl-centric with no Windows unzip+PATH steps.
+
+**First run.** With no API key on an interactive terminal, octo auto-launches
+the config wizard (`runConfigWizard`, `cmd/octo/config.go`). `start-octo.cmd`
+prints "First run? type: octo config". The web UI has its own onboarding flow
+(`internal/server/onboard_config_handlers.go`).
+
+**Install guidance.** `internal/tools/envnote.go` (`ShellEnvNote()`) already
+injects solid platform guidance into the session context — PowerShell dialect,
+the mid-session `PATH`-refresh trap, the UAC dialog, `winget` vs. a download
+link for novices, and the `npm.ps1` execution-policy trap (use `npm.cmd`). What
+it lacks is knowledge of **what is actually installed** — so the agent gets
+"here's how to install on Windows" but not "python is missing".
+
+**Self-upgrade.** `octo upgrade` swaps the binary in place, SHA-256-verified
+(#633). On Windows it side-names the locked running image as
+`.old.<ts>.<pid>`.
+
+## Part A — Toolchain detection
+
+A new probe in `internal/tools` reports, presence-only, which common tools are
+on `PATH`:
+
+```go
+// DetectToolchain reports which of a curated set of developer tools resolve on
+// the current PATH. Presence-only: it uses exec.LookPath (a filesystem lookup,
+// no subprocess), so it is safe to call on every context build — including the
+// server's per-turn recompose. Versions are deliberately not probed; the agent
+// runs `<tool> --version` on demand when it actually needs one.
+func DetectToolchain() (present, missing []string)
+```
+
+Curated list (the tools an agent most often reaches for, kept tight to avoid
+noise): `git`, `gh`, `node`, `npm`, `python`/`python3`, `pip`/`pip3`, `uv`,
+`go`, `docker`, `make`. `python`/`python3` and `pip`/`pip3` collapse to one
+reported name each (present if either resolves).
+
+The CLI (`cmd/octo/envcontext.go`) and the server context builder
+(`internal/server/server.go`) both already call `ShellEnvNote()`; the detection
+block is injected in the same place, e.g.:
+
+```
+- Detected tools on PATH: git, node, npm, go.
+- Not found (install on demand if a task needs one): python, pip, uv, docker.
+```
+
+Paired with the existing `ShellEnvNote()` install guidance, the agent now knows
+both *what is missing* and *how to install it* on this platform.
+
+Cost: `len(list)` filesystem lookups per context build, no subprocess. Cheap
+enough that the server's per-turn recompose is unaffected — the reason versions
+are excluded.
+
+## Part B — Windows installer
+
+### Tool & install mode
+
+[Inno Setup](https://jrsoftware.org/isinfo.php). Script lives at
+`packaging/windows/octo.iss` next to the existing `start-octo.cmd`.
+
+Per-user, no administrator:
+
+- `PrivilegesRequired=lowest` — no UAC elevation.
+- `DefaultDirName={userpf}\octo` — `{userpf}` resolves to
+  `%LOCALAPPDATA%\Programs`, the per-user program location.
+- `PATH` is written to `HKCU\Environment` (user scope; no admin needed), with a
+  `[Code]` `NeedsAddPath` check so re-running the installer doesn't duplicate
+  the entry, and a `WM_SETTINGCHANGE` broadcast so already-open shells can pick
+  it up (new shells get it regardless).
+- A Start-menu shortcut that opens a terminal with octo ready.
+- The standard Inno uninstaller: removes files, the `PATH` entry, and the
+  shortcut, and appears in "Add or remove programs".
+
+Per-user (not `Program Files`) is the deliberate choice: it avoids UAC entirely
+and keeps the install directory user-writable, so **`octo upgrade` can overwrite
+the binary in place with no elevation** — the installer owns first install,
+`octo upgrade` owns updates, and they don't fight over a read-only location.
+Re-running a newer `octo-setup.exe` (same Inno `AppId`) also updates in place.
+
+Payload is just `octo.exe` (ripgrep is already embedded) plus `LICENSE.txt`.
+
+### CI integration
+
+A `windows-installer` job is added to `.github/workflows/release.yml`:
+
+- `needs: goreleaser`, runs on `windows-latest`.
+- Downloads the just-published `octo_<version>_windows_amd64.zip` from the
+  release (`gh release download`) and extracts `octo.exe` — reusing the
+  goreleaser-built binary (with its embedded ripgrep) rather than rebuilding.
+- Installs Inno Setup (it is **not** preinstalled on current runner images) via
+  the [Inno Setup Action](https://github.com/Minionguyjpro/Inno-Setup-Action)
+  or `choco install innosetup`, then compiles `packaging/windows/octo.iss` with
+  the tag version passed as `/DAppVersion=<version>`.
+- Uploads `octo-setup.exe` back to the same release via `gh release upload`.
+
+MVP ships the **amd64** installer only; it runs on Windows on ARM through x64
+emulation. An arm64-native installer is a later addition.
+
+### Signing (deferred)
+
+The MVP installer is **unsigned**. Double-clicking it raises Windows SmartScreen
+("Windows protected your PC" → "More info" → "Run anyway"); the README and the
+release notes document this click-through. The workflow leaves a clearly marked
+signing step as a no-op hook so a later change can drop in **Azure Trusted
+Signing** (~$10/mo) without restructuring the job.
+
+### Docs
+
+The README "Install" section gains a Windows subsection: download
+`octo-setup.exe`, double-click, click through SmartScreen, open a new terminal,
+run `octo`. The bash/curl path stays for macOS/Linux.
+
+## Out of scope
+
+- **Code signing** — deferred; hook left in the workflow.
+- **winget channel** — complementary and planned next: a winget manifest points
+  `winget install Leihb.octo` at this same `octo-setup.exe`. Not this round.
+- **arm64-native installer** — amd64 installer covers ARM via emulation for now.
+- **macOS `.pkg` / Linux `.deb`/`.rpm`** — the symmetric idea for other
+  platforms; not this round.
+- **Windows OS sandbox** — explicitly deferred; the permission engine remains
+  the safety layer on Windows.
+
+## Testing
+
+- **Toolchain detection** — unit test with a temp directory placed on `PATH`
+  holding fake executables, asserting the present/missing split; assert the env
+  context string contains the detection block.
+- **Installer** — `iscc packaging/windows/octo.iss` compiles in CI (build-time
+  validation). Manual acceptance on a Windows VM: install → `octo` resolves in a
+  fresh shell → `octo upgrade` still works against the per-user dir → uninstall
+  removes the binary, the `PATH` entry, and the Add/Remove-Programs entry.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -923,6 +923,9 @@ func buildEnvContext(cwd string) string {
 	// Platform-shell guidance (dialect + install/PATH traps), shared with the
 	// CLI builder so web sessions get the same orientation.
 	b.WriteString(tools.ShellEnvNote())
+	// Detected toolchain — same as the CLI builder, so web sessions know which
+	// runtimes are present without probing by trial and error.
+	b.WriteString(tools.ToolchainNote())
 	return b.String()
 }
 

--- a/internal/tools/toolchain.go
+++ b/internal/tools/toolchain.go
@@ -1,0 +1,68 @@
+package tools
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// toolchainProbes is the curated set of developer tools an agent reaches for
+// most often. Each entry maps a single reported name to the candidate
+// executables that satisfy it — `python` is satisfied by python3 or python,
+// `pip` by pip3 or pip — so the model sees one stable name regardless of which
+// variant is on PATH. Kept tight on purpose: a longer list is noise the model
+// pays for on every turn.
+var toolchainProbes = []struct {
+	name string
+	cmds []string
+}{
+	{"git", []string{"git"}},
+	{"gh", []string{"gh"}},
+	{"node", []string{"node"}},
+	{"npm", []string{"npm"}},
+	{"python", []string{"python3", "python"}},
+	{"pip", []string{"pip3", "pip"}},
+	{"uv", []string{"uv"}},
+	{"go", []string{"go"}},
+	{"docker", []string{"docker"}},
+	{"make", []string{"make"}},
+}
+
+// DetectToolchain reports which curated developer tools resolve on the current
+// PATH. Presence-only via exec.LookPath — a filesystem lookup, not a subprocess
+// — so it is cheap enough to call on every context build, including the
+// server's per-turn recompose. Versions are deliberately not probed; the agent
+// runs `<tool> --version` on demand when it actually needs one. On Windows
+// LookPath honours PATHEXT, so npm.cmd / npx.cmd resolve as expected.
+func DetectToolchain() (present, missing []string) {
+	for _, p := range toolchainProbes {
+		found := false
+		for _, c := range p.cmds {
+			if _, err := exec.LookPath(c); err == nil {
+				found = true
+				break
+			}
+		}
+		if found {
+			present = append(present, p.name)
+		} else {
+			missing = append(missing, p.name)
+		}
+	}
+	return present, missing
+}
+
+// ToolchainNote renders the detected/missing toolchain as a session-context
+// block, pairing with ShellEnvNote (which says how to install on this platform)
+// so the model knows both what is missing and how to add it. Returns "" only in
+// the degenerate case where nothing was probed.
+func ToolchainNote() string {
+	present, missing := DetectToolchain()
+	var b strings.Builder
+	if len(present) > 0 {
+		b.WriteString("- Detected tools on PATH: " + strings.Join(present, ", ") + ".\n")
+	}
+	if len(missing) > 0 {
+		b.WriteString("- Not found (install on demand if a task needs one): " + strings.Join(missing, ", ") + ".\n")
+	}
+	return b.String()
+}

--- a/internal/tools/toolchain_test.go
+++ b/internal/tools/toolchain_test.go
@@ -1,0 +1,87 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// fakeExe writes an executable-named file into dir. On Windows an entry needs a
+// PATHEXT extension to be found by exec.LookPath; elsewhere it needs the
+// execute bit.
+func fakeExe(t *testing.T, dir, name string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("x"), 0o755); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+}
+
+// withIsolatedPath points PATH at a single temp dir for the duration of the
+// test, so detection sees only the fakes we plant — not the host's real tools.
+func withIsolatedPath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	return dir
+}
+
+func TestDetectToolchain_PresentAndMissing(t *testing.T) {
+	dir := withIsolatedPath(t)
+	fakeExe(t, dir, "git")
+	fakeExe(t, dir, "node")
+	fakeExe(t, dir, "python3") // satisfies the "python" probe via its variant
+
+	present, missing := DetectToolchain()
+
+	wantPresent := map[string]bool{"git": true, "node": true, "python": true}
+	for _, p := range present {
+		if !wantPresent[p] {
+			t.Errorf("unexpected present tool %q", p)
+		}
+		delete(wantPresent, p)
+	}
+	if len(wantPresent) != 0 {
+		t.Errorf("missing expected-present tools: %v", wantPresent)
+	}
+
+	for _, m := range missing {
+		if m == "git" || m == "node" || m == "python" {
+			t.Errorf("%q reported missing but was planted", m)
+		}
+	}
+}
+
+func TestDetectToolchain_PythonVariantCollapses(t *testing.T) {
+	dir := withIsolatedPath(t)
+	fakeExe(t, dir, "python") // the non-3 variant alone must satisfy "python"
+
+	present, _ := DetectToolchain()
+	found := false
+	for _, p := range present {
+		if p == "python" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("bare `python` on PATH did not satisfy the python probe")
+	}
+}
+
+func TestToolchainNote_FormatsBothSections(t *testing.T) {
+	dir := withIsolatedPath(t)
+	fakeExe(t, dir, "go")
+
+	note := ToolchainNote()
+	if !strings.Contains(note, "Detected tools on PATH:") || !strings.Contains(note, "go") {
+		t.Errorf("note missing detected section: %q", note)
+	}
+	if !strings.Contains(note, "Not found") {
+		t.Errorf("note missing not-found section: %q", note)
+	}
+}


### PR DESCRIPTION
**Part A of `dev-docs/windows-onboarding-design.md`** (the design doc lands in this PR; Part B — the Windows installer — is a separate PR).

## What
The session env context already tells the model *how* to install tools per platform (`ShellEnvNote`), but never *what's actually present*. So the agent finds out python/node is missing by running a command and failing — wasting a turn.

This adds presence-only toolchain detection and injects it next to the existing guidance, so the agent knows both what's missing **and** how to add it.

## How
- `internal/tools/toolchain.go` — `DetectToolchain()` resolves a curated set via `exec.LookPath` (filesystem lookup, **no subprocess**): `git, gh, node, npm, python, pip, uv, go, docker, make`. Variants collapse to one reported name (`python` ← python3/python; `pip` ← pip3/pip). `ToolchainNote()` renders a `Detected / Not found` block.
- Wired into **both** context builders (`cmd/octo/envcontext.go` and `internal/server/server.go`), right after `ShellEnvNote()`.

Example block on a fresh Windows box:
```
- Detected tools on PATH: git, node, npm.
- Not found (install on demand if a task needs one): gh, python, pip, uv, docker.
```

## Why presence-only
`LookPath` is a filesystem lookup, cheap enough to run on every context build — including the server's per-turn recompose. Versions would mean N subprocess spawns per turn (slow on Windows); the agent runs `<tool> --version` on demand instead.

## Test
`internal/tools/toolchain_test.go` — isolates PATH to a temp dir with planted fakes, asserts the present/missing split, the python-variant collapse, and the note format. `make build` / `go vet` / `gofmt` clean; existing `cmd/octo` + `internal/server` tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)