### PR TITLE
feat(packaging): double-click Windows installer (octo-setup.exe)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,11 @@ jobs:
       - name: Compile installer
         shell: pwsh
         run: |
+          # Source paths in the .iss resolve relative to the script's own dir,
+          # so SourceDir / OutputDir must be absolute.
+          $staging = Join-Path $PWD 'staging'
           & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" `
-            /DAppVersion=$env:version /DSourceDir=staging /Ostaging `
+            "/DAppVersion=$env:version" "/DSourceDir=$staging" "/O$staging" `
             packaging\windows\octo.iss
 
       - name: Attach installer to the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,45 @@ jobs:
           args: release --clean -p 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Build the double-click Windows installer (octo-setup.exe) from the binary
+  # goreleaser just published, and attach it to the same release. Kept separate
+  # from goreleaser because Inno Setup is a Windows-only toolchain. The MVP
+  # installer is unsigned — see dev-docs/windows-onboarding-design.md.
+  windows-installer:
+    name: windows installer
+    needs: goreleaser
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4 # for packaging/windows/octo.iss + LICENSE.txt
+
+      - name: Stage the released binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')
+          New-Item -ItemType Directory -Force -Path staging | Out-Null
+          gh release download "${{ github.ref_name }}" --pattern "octo_${version}_windows_amd64.zip" --dir dl
+          Expand-Archive -Path "dl\octo_${version}_windows_amd64.zip" -DestinationPath dl\extract -Force
+          $exe = Get-ChildItem -Path dl\extract -Recurse -Filter octo.exe | Select-Object -First 1
+          Copy-Item $exe.FullName staging\octo.exe
+          Copy-Item LICENSE.txt staging\LICENSE.txt
+          "version=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --no-progress -y # not preinstalled on the runner image
+
+      - name: Compile installer
+        shell: pwsh
+        run: |
+          & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" `
+            /DAppVersion=$env:version /DSourceDir=staging /Ostaging `
+            packaging\windows\octo.iss
+
+      - name: Attach installer to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: gh release upload "${{ github.ref_name }}" staging\octo-setup.exe --clobber

--- a/.github/workflows/windows-installer-check.yml
+++ b/.github/workflows/windows-installer-check.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Compile installer
         shell: pwsh
         run: |
+          # Source paths in the .iss resolve relative to the script's own dir,
+          # so SourceDir / OutputDir must be absolute.
+          $staging = Join-Path $PWD 'staging'
           & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" `
-            /DAppVersion=0.0.0-ci /DSourceDir=staging /Ostaging `
+            /DAppVersion=0.0.0-ci "/DSourceDir=$staging" "/O$staging" `
             packaging\windows\octo.iss
-          if (-not (Test-Path staging\octo-setup.exe)) { throw "installer was not produced" }
+          if (-not (Test-Path "$staging\octo-setup.exe")) { throw "installer was not produced" }

--- a/.github/workflows/windows-installer-check.yml
+++ b/.github/workflows/windows-installer-check.yml
@@ -1,0 +1,45 @@
+name: Windows installer check
+
+# Compile the Inno Setup script whenever a PR touches it, so a broken installer
+# surfaces here instead of at release time — release.yml only builds it on a
+# tag push. Path-filtered, so it costs nothing on PRs that don't touch the
+# installer.
+on:
+  pull_request:
+    paths:
+      - 'packaging/windows/**'
+      - '.github/workflows/windows-installer-check.yml'
+  workflow_dispatch:
+
+jobs:
+  compile:
+    name: compile installer
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+      - name: Build a binary to package
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path staging | Out-Null
+          go build -o staging\octo.exe ./cmd/octo # plain build; embedded rg is irrelevant to packaging
+          Copy-Item LICENSE.txt staging\LICENSE.txt
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --no-progress -y
+
+      - name: Compile installer
+        shell: pwsh
+        run: |
+          & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" `
+            /DAppVersion=0.0.0-ci /DSourceDir=staging /Ostaging `
+            packaging\windows\octo.iss
+          if (-not (Test-Path staging\octo-setup.exe)) { throw "installer was not produced" }

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ octo version
 Archives ship for linux / darwin / windows on amd64 + arm64; `checksums.txt`
 in each release verifies the download.
 
+**Windows (double-click installer).** Download `octo-setup.exe` from the
+[latest release](https://github.com/Leihb/octo-agent/releases/latest) and
+double-click it. It installs per-user (no administrator prompt), puts `octo` on
+your `PATH`, and adds a Start-menu entry; open a **new** terminal afterward and
+run `octo`. The installer is not yet code-signed, so Windows SmartScreen shows
+"Windows protected your PC" on first launch — click **More info → Run anyway**.
+Uninstall from "Add or remove programs" like any other app.
+
 **Upgrading:** `octo upgrade` installs the latest release in place (SHA-256
 verified against `checksums.txt`); `octo upgrade --check` only compares
 versions. The web UI's version badge offers the same flow.

--- a/packaging/windows/octo.iss
+++ b/packaging/windows/octo.iss
@@ -1,0 +1,114 @@
+; octo-setup — per-user Windows installer for octo.
+;
+; Installs octo.exe to %LOCALAPPDATA%\Programs\octo, adds that directory to the
+; user PATH (HKCU — no administrator, no UAC), creates a Start-menu shortcut,
+; and registers an uninstaller in "Add or remove programs". Per-user is
+; deliberate: the install directory stays user-writable, so `octo upgrade` can
+; overwrite the binary in place without elevation.
+;
+; Compiled in CI by .github/workflows/release.yml. Two defines are passed in:
+;   AppVersion — the release version, e.g. 0.20.0
+;   SourceDir  — the folder holding octo.exe and LICENSE.txt
+; Compile locally:  ISCC.exe /DAppVersion=0.0.0 /DSourceDir=path\to\bits octo.iss
+
+#ifndef AppVersion
+  #define AppVersion "0.0.0-dev"
+#endif
+#ifndef SourceDir
+  #define SourceDir "."
+#endif
+
+[Setup]
+; A stable AppId so re-running a newer installer updates in place rather than
+; stacking a second copy. Never change this value.
+AppId={{8F2A6B1C-3D4E-4F50-9A6B-7C8D9E0F1A2B}
+AppName=octo
+AppVersion={#AppVersion}
+AppPublisher=Leihb
+AppPublisherURL=https://github.com/Leihb/octo-agent
+DefaultDirName={userpf}\octo
+DisableProgramGroupPage=yes
+DisableDirPage=yes
+PrivilegesRequired=lowest
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+OutputBaseFilename=octo-setup
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+; Broadcast WM_SETTINGCHANGE after install so Explorer-launched shells pick up
+; the new PATH without a logout.
+ChangesEnvironment=yes
+UninstallDisplayName=octo {#AppVersion}
+
+[Files]
+Source: "{#SourceDir}\octo.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourceDir}\LICENSE.txt"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+; Open a console with octo started. Invoked by full path so it works even
+; before the new PATH propagates.
+Name: "{userprograms}\octo"; Filename: "{cmd}"; \
+  Parameters: "/k ""{app}\octo.exe"" chat"; WorkingDir: "{userdocs}"; \
+  Comment: "Start an octo session"
+
+[Code]
+const
+  EnvKey = 'Environment';
+
+// PathContains reports whether Entry appears as a complete ;-delimited element
+// of Path (case-insensitive), so a prefix like C:\octo doesn't match C:\octo2.
+function PathContains(const Path, Entry: string): Boolean;
+begin
+  Result := Pos(';' + Lowercase(Entry) + ';', ';' + Lowercase(Path) + ';') > 0;
+end;
+
+procedure AddToPath;
+var
+  Path, Entry: string;
+begin
+  Entry := ExpandConstant('{app}');
+  if not RegQueryStringValue(HKEY_CURRENT_USER, EnvKey, 'Path', Path) then
+    Path := '';
+  if PathContains(Path, Entry) then
+    exit;
+  if (Path <> '') and (Path[Length(Path)] <> ';') then
+    Path := Path + ';';
+  RegWriteExpandStringValue(HKEY_CURRENT_USER, EnvKey, 'Path', Path + Entry);
+end;
+
+// RemoveFromPath strips exactly our {app} element, preserving the case of the
+// rest. It works on a ';'-padded copy so the first/last elements are bounded
+// like any other, then trims the padding back off.
+procedure RemoveFromPath;
+var
+  Path, Padded, EntryLower: string;
+  P: Integer;
+begin
+  if not RegQueryStringValue(HKEY_CURRENT_USER, EnvKey, 'Path', Path) then
+    exit;
+  Padded := ';' + Path + ';';
+  EntryLower := ';' + Lowercase(ExpandConstant('{app}')) + ';';
+  P := Pos(EntryLower, Lowercase(Padded));
+  if P = 0 then
+    exit;
+  // Drop the leading ';' + entry, keeping the trailing ';' as the separator.
+  Delete(Padded, P, Length(EntryLower) - 1);
+  if Length(Padded) >= 2 then
+    Path := Copy(Padded, 2, Length(Padded) - 2)
+  else
+    Path := '';
+  RegWriteExpandStringValue(HKEY_CURRENT_USER, EnvKey, 'Path', Path);
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+    AddToPath;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usUninstall then
+    RemoveFromPath;
+end;


### PR DESCRIPTION
**Part B of `dev-docs/windows-onboarding-design.md`** (Part A — toolchain detection — merged in #641).

## What
A non-developer Windows user can download **`octo-setup.exe`** and double-click it, instead of unzipping and hand-editing `PATH` (today's only options).

## How
- **`packaging/windows/octo.iss`** — Inno Setup script:
  - Per-user install to `%LOCALAPPDATA%\Programs\octo` (`PrivilegesRequired=lowest` → **no UAC**).
  - Adds the install dir to the **user** `PATH` (`HKCU\Environment`), with a de-dupe check on install and surgical, case-preserving removal on uninstall. `ChangesEnvironment=yes` broadcasts `WM_SETTINGCHANGE`.
  - Start-menu shortcut + "Add or remove programs" uninstaller.
  - **Per-user is deliberate**: the dir stays user-writable, so `octo upgrade` swaps the binary in place without elevation — no fight with a read-only `Program Files`.
- **`release.yml`** — a `windows-installer` job (`needs: goreleaser`) downloads the just-published `windows_amd64` zip, installs Inno Setup via `choco`, compiles the script, and attaches `octo-setup.exe` to the same release.
- **`windows-installer-check.yml`** — path-filtered PR check that compiles the installer on a Windows runner, so a broken `.iss` is caught here, not at tag time. **This PR triggers it** (it touches `packaging/windows/**`).
- **README** — Windows "double-click installer" subsection.

## Scope / deferrals (per the design doc)
- **Unsigned MVP** → SmartScreen "Run anyway" click-through, documented. The release job leaves room for an Azure Trusted Signing step later.
- amd64 installer only (runs on Windows-on-ARM via x64 emulation); winget channel and arm64-native are follow-ups.

## Validation
`actionlint` clean on both workflows. The `.iss` can't compile on macOS, so the new path-filtered check compiles it on `windows-latest` as part of this PR. Manual VM acceptance (install → `octo` on PATH in a fresh shell → `octo upgrade` → uninstall removes binary + PATH entry) per the design doc's test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)