### PR TITLE
chore(release): bump version to 0.21.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased — 0.21.0-dev]
+
 ## [0.20.0] — 2026-06-12
 
 ### Added

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "0.20.0"
+var Version = "0.21.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Post-release bump following the v0.20.0 tag: `internal/version/version.go` → `0.21.0` (dev builds now report `0.21.0-dev`) and a fresh `## [Unreleased — 0.21.0-dev]` CHANGELOG header.

Mirrors #640 (the v0.19.0 → 0.20.0-dev bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)