### PR TITLE
fix(openai): compatibility with gateways proxying non-OpenAI backends

### DIFF
--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -119,7 +119,7 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		MaxTokens:       req.MaxTokens,
 		Messages:        msgs,
 		Tools:           toAPITools(req.Tools),
-		PromptCacheKey:  req.CacheKey,
+		PromptCacheKey:  c.promptCacheKey(req.CacheKey),
 		ReasoningEffort: req.ReasoningEffort,
 	}
 	if body.MaxTokens <= 0 {
@@ -202,8 +202,13 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 			}
 			blocks = append(blocks, agent.NewToolUseBlock(tc.ID, tc.Function.Name, input))
 		}
-		// Normalize finish_reason to Anthropic's naming.
-		if stopReason == "tool_calls" {
+		// A response carrying tool calls is a tool-use turn — dispatch them
+		// regardless of finish_reason. The expected signal is "tool_calls", but
+		// some OpenAI-compatible backends (e.g. a gateway proxying Gemini) emit
+		// the calls while reporting "stop"; trusting finish_reason alone would
+		// silently drop the call. Leave a genuine truncation ("max_tokens")
+		// intact, since a partial tool call is unsafe to dispatch.
+		if stopReason != "max_tokens" {
 			stopReason = "tool_use"
 		}
 	}
@@ -224,6 +229,19 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		// OpenAI/DeepSeek report only cached (read) input; no write count.
 		CacheReadTokens: apiResp.Usage.cachedTokens(),
 	}, nil
+}
+
+// promptCacheKey returns the prompt-cache routing key only when the client
+// targets the official OpenAI endpoint. prompt_cache_key is an OpenAI-proprietary
+// field: OpenAI-compatible gateways that proxy to other backends (e.g. AWS
+// Bedrock for Anthropic models) reject unknown body fields with a 400
+// ("Extra inputs are not permitted"), so it is omitted for any non-official
+// BaseURL while official OpenAI keeps its prompt-cache routing.
+func (c *Client) promptCacheKey(key string) string {
+	if c.BaseURL == "" || c.BaseURL == DefaultBaseURL {
+		return key
+	}
+	return ""
 }
 
 // endpointURL returns BaseURL + ChatCompletionsPath, applying defaults and

--- a/internal/provider/openai/client_test.go
+++ b/internal/provider/openai/client_test.go
@@ -55,9 +55,10 @@ func TestSend_Success(t *testing.T) {
 		if req.Messages[1].Role != "user" || req.Messages[1].Content != "hello" {
 			t.Errorf("second message = %+v, want {user, hello}", req.Messages[1])
 		}
-		// The prompt-cache key is forwarded for prefix-cache routing.
-		if req.PromptCacheKey != "octo-test-key" {
-			t.Errorf("prompt_cache_key = %q, want 'octo-test-key'", req.PromptCacheKey)
+		// prompt_cache_key is OpenAI-proprietary and omitted for non-official
+		// endpoints (this httptest server). See TestPromptCacheKey_GatedByBaseURL.
+		if req.PromptCacheKey != "" {
+			t.Errorf("prompt_cache_key = %q, want omitted for a non-official BaseURL", req.PromptCacheKey)
 		}
 
 		// Response
@@ -263,6 +264,78 @@ func TestSend_NoChoices(t *testing.T) {
 	})
 	if err == nil {
 		t.Error("expected error when response has no choices")
+	}
+}
+
+// TestPromptCacheKey_GatedByBaseURL verifies prompt_cache_key is sent only to
+// the official OpenAI endpoint. Compatible gateways that proxy to Bedrock reject
+// the unknown field with a 400, so it must be omitted for any custom BaseURL.
+func TestPromptCacheKey_GatedByBaseURL(t *testing.T) {
+	var gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req apiRequest
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &req)
+		gotKey = req.PromptCacheKey
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"x","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	// Custom (compatible) BaseURL → key omitted.
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	if _, err := c.Send(context.Background(), provider.Request{
+		Model: "m", Messages: []agent.Message{agent.NewUserMessage("hi")}, CacheKey: "should-be-dropped",
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if gotKey != "" {
+		t.Errorf("custom BaseURL: prompt_cache_key = %q, want omitted", gotKey)
+	}
+
+	// The gate itself: official endpoint keeps the key, custom drops it.
+	official := &Client{BaseURL: DefaultBaseURL}
+	if official.promptCacheKey("k1") != "k1" {
+		t.Error("official endpoint should forward prompt_cache_key")
+	}
+	empty := &Client{BaseURL: ""}
+	if empty.promptCacheKey("k2") != "k2" {
+		t.Error("empty BaseURL (defaults to official) should forward prompt_cache_key")
+	}
+	custom := &Client{BaseURL: "https://gateway.example/v1"}
+	if custom.promptCacheKey("k3") != "" {
+		t.Error("custom BaseURL should drop prompt_cache_key")
+	}
+}
+
+// TestSend_ToolCallWithStopFinishReason verifies a response carrying tool calls
+// is treated as a tool-use turn even when the backend reports finish_reason
+// "stop" (as a gateway proxying Gemini does) rather than "tool_calls".
+func TestSend_ToolCallWithStopFinishReason(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"edit_file","arguments":"{\"path\":\"a.go\"}"}}]},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	resp, err := c.Send(context.Background(), provider.Request{
+		Model: "m", Messages: []agent.Message{agent.NewUserMessage("edit it")},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if resp.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use (tool calls present despite finish_reason stop)", resp.StopReason)
+	}
+	gotTool := false
+	for _, b := range resp.Blocks {
+		if b.Type == "tool_use" && b.Name == "edit_file" {
+			gotTool = true
+		}
+	}
+	if !gotTool {
+		t.Error("expected an edit_file tool_use block")
 	}
 }
 

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -56,7 +56,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		Stream:          true,
 		StreamOptions:   &apiStreamOptions{IncludeUsage: true},
 		Tools:           toAPITools(req.Tools),
-		PromptCacheKey:  req.CacheKey,
+		PromptCacheKey:  c.promptCacheKey(req.CacheKey),
 		ReasoningEffort: req.ReasoningEffort,
 	}
 	if body.MaxTokens <= 0 {
@@ -241,6 +241,15 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 			_ = json.Unmarshal([]byte(s), &input)
 		}
 		blocks = append(blocks, agent.NewToolUseBlock(st.id, st.name, input))
+	}
+	// Accumulated tool calls make this a tool-use turn — dispatch them
+	// regardless of finish_reason. Some OpenAI-compatible backends (e.g. a
+	// gateway proxying Gemini) stream the calls but report finish_reason "stop"
+	// instead of "tool_calls"; trusting finish_reason alone would silently drop
+	// the call. A genuine truncation ("max_tokens") is left intact, since a
+	// partial tool call is unsafe to dispatch.
+	if len(toolOrder) > 0 && result.StopReason != "max_tokens" {
+		result.StopReason = "tool_use"
 	}
 	attachReasoning(blocks, reasoningB.String())
 	if len(blocks) > 0 {

--- a/internal/provider/openai/stream_test.go
+++ b/internal/provider/openai/stream_test.go
@@ -475,5 +475,47 @@ func TestSendStream_Kimi_ChoiceUsage(t *testing.T) {
 	}
 }
 
+// toolCallStopStream mimics a gateway proxying Gemini: a tool call streams in,
+// but the final chunk reports finish_reason "stop" instead of "tool_calls".
+const toolCallStopStream = "" +
+	`data: {"id":"c1","object":"chat.completion.chunk","model":"gemini","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"edit_file","arguments":""}}]}}]}` + "\n\n" +
+	`data: {"id":"c1","object":"chat.completion.chunk","model":"gemini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"path\":\"a.go\"}"}}]}}]}` + "\n\n" +
+	`data: {"id":"c1","object":"chat.completion.chunk","model":"gemini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n" +
+	"data: [DONE]\n\n"
+
+// TestSendStream_ToolCallWithStopFinishReason verifies the streaming path treats
+// accumulated tool calls as a tool-use turn even when finish_reason is "stop".
+func TestSendStream_ToolCallWithStopFinishReason(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, toolCallStopStream)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	resp, err := c.SendStream(context.Background(), provider.Request{
+		Model: "gemini", Messages: []agent.Message{agent.NewUserMessage("edit it")},
+	}, provider.StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("SendStream: %v", err)
+	}
+	if resp.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use (tool call present despite finish_reason stop)", resp.StopReason)
+	}
+	gotTool := false
+	for _, b := range resp.Blocks {
+		if b.Type == "tool_use" && b.Name == "edit_file" {
+			gotTool = true
+		}
+	}
+	if !gotTool {
+		t.Error("expected an edit_file tool_use block")
+	}
+}
+
 // Compile-time assertion.
 var _ provider.StreamingProvider = (*Client)(nil)


### PR DESCRIPTION
Found while running octo against an OpenAI-compatible **LiteLLM gateway** that proxies Anthropic models to **AWS Bedrock** and Gemini models to **Vertex**. Both are octo-side compatibility bugs (gateway behavior is the trigger; the fix belongs in octo).

## Bug 1 — `prompt_cache_key` rejected by Bedrock
octo sent the OpenAI-proprietary `prompt_cache_key` on every request. Bedrock-backed models reject unknown body fields: `400 ... prompt_cache_key: Extra inputs are not permitted` → the whole turn errors. (Models with no gateway fallback scored 0; models with a fallback silently answered via a GPT fallback — so the Anthropic numbers were never real.)

**Fix:** gate it — send `prompt_cache_key` only when targeting the official OpenAI endpoint (`BaseURL` empty/default), omit it for any custom/compatible `BaseURL`. Official OpenAI keeps prompt-cache routing; no other backend uses the field, so nothing is lost.

## Bug 2 — tool calls dropped when `finish_reason` is `"stop"`
The gateway returns a valid tool call for Gemini but reports `finish_reason:"stop"` (not `"tool_calls"`). The adapter left `StopReason` as `"stop"`, so the agent loop (which dispatches on `StopReason=="tool_use"`) never executed the call — the turn ended silently with the tool call ignored.

**Fix:** trust the accumulated tool calls over `finish_reason` — a response carrying tool calls is a tool-use turn, in both the streaming and non-streaming paths. A genuine truncation (`max_tokens`) is left intact, since a partial tool call is unsafe to dispatch.

## Verification (against the real gateway)
Both previously scored 0/7; with the fixes, `fix-off-by-one` now resolves:
- `claude-sonnet-4-6` ✓ (was prompt_cache_key 400)
- `gemini-3.5-flash` ✓ (was the dropped tool call)

A full re-test of the Anthropic/Gemini models is running.

## Tests
- `prompt_cache_key` gating: official forwards, custom/compatible omits (+ direct `promptCacheKey()` unit check).
- Tool call arriving with `finish_reason:"stop"` → `StopReason "tool_use"` in both the non-streaming and streaming paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)