### PR TITLE
fix(anthropic): treat tool_use blocks as tool-use turn regardless of stop_reason

### DIFF
--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -186,17 +186,37 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		}
 
 		blocks := fromAPIContentBlocks(apiResp.Content)
+		stopReason := apiResp.StopReason
+		// A response carrying tool_use blocks is a tool-use turn regardless of
+		// stop_reason. Real Anthropic always pairs them with "tool_use", but a
+		// misbehaving Anthropic-compatible gateway may report "end_turn"; trusting
+		// stop_reason alone would silently drop the call. A genuine truncation
+		// ("max_tokens") is left intact. Mirrors the streaming path and the
+		// openai adapter.
+		if stopReason != "max_tokens" && hasToolUseBlock(blocks) {
+			stopReason = "tool_use"
+		}
 		return provider.Response{
 			Content:          joinTextBlocks(apiResp.Content),
 			Blocks:           blocks,
 			Model:            apiResp.Model,
-			StopReason:       apiResp.StopReason,
+			StopReason:       stopReason,
 			InputTokens:      apiResp.Usage.InputTokens,
 			OutputTokens:     apiResp.Usage.OutputTokens,
 			CacheReadTokens:  apiResp.Usage.CacheReadInputTokens,
 			CacheWriteTokens: apiResp.Usage.CacheCreationInputTokens,
 		}, retry.Decision{}, nil
 	})
+}
+
+// hasToolUseBlock reports whether any block is a tool_use block.
+func hasToolUseBlock(blocks []agent.ContentBlock) bool {
+	for _, b := range blocks {
+		if b.Type == "tool_use" {
+			return true
+		}
+	}
+	return false
 }
 
 // endpointURL returns BaseURL + MessagesPath, applying defaults and trimming

--- a/internal/provider/anthropic/client_test.go
+++ b/internal/provider/anthropic/client_test.go
@@ -405,3 +405,34 @@ func TestSend_DoesNotRetryClientError(t *testing.T) {
 		t.Errorf("400 should not be retried; attempts=%d", got)
 	}
 }
+
+// TestSend_ToolUseWithNonToolUseStopReason verifies a response carrying a
+// tool_use block is treated as a tool-use turn even when a (misbehaving)
+// compatible backend reports stop_reason "end_turn" instead of "tool_use".
+func TestSend_ToolUseWithNonToolUseStopReason(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"msg","type":"message","role":"assistant","model":"x","content":[{"type":"tool_use","id":"toolu_1","name":"edit_file","input":{"path":"a.go"}}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New("test-key")
+	c.BaseURL = srv.URL
+	resp, err := c.Send(context.Background(), provider.Request{
+		Model: "x", Messages: []agent.Message{agent.NewUserMessage("edit it")},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if resp.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use (tool_use block present despite stop_reason end_turn)", resp.StopReason)
+	}
+	gotTool := false
+	for _, b := range resp.Blocks {
+		if b.Type == "tool_use" && b.Name == "edit_file" {
+			gotTool = true
+		}
+	}
+	if !gotTool {
+		t.Error("expected an edit_file tool_use block")
+	}
+}

--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -254,6 +254,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 
 	// Build the final block list in order.
 	var textB strings.Builder
+	hasToolUse := false
 	blocks := make([]agent.ContentBlock, 0, len(blockOrder))
 	for _, idx := range blockOrder {
 		acc, ok := accByIndex[idx]
@@ -276,7 +277,18 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 				_ = json.Unmarshal([]byte(s), &input)
 			}
 			blocks = append(blocks, agent.NewToolUseBlock(acc.id, acc.name, input))
+			hasToolUse = true
 		}
+	}
+
+	// A response carrying tool_use blocks is a tool-use turn — dispatch them
+	// regardless of stop_reason. Real Anthropic always pairs them with
+	// stop_reason "tool_use", but a misbehaving Anthropic-compatible gateway may
+	// report "end_turn" instead; trusting stop_reason alone would silently drop
+	// the call. A genuine truncation ("max_tokens") is left intact, since a
+	// partial tool call is unsafe to dispatch. Mirrors the openai adapter.
+	if hasToolUse && result.StopReason != "max_tokens" {
+		result.StopReason = "tool_use"
 	}
 
 	result.Content = textB.String()

--- a/internal/provider/anthropic/stream_test.go
+++ b/internal/provider/anthropic/stream_test.go
@@ -314,3 +314,55 @@ func TestSendStream_KimiNoSpaceAndDeltaCache(t *testing.T) {
 // Compile-time assertion: *Client implements provider.StreamingProvider in the
 // test package too, in case future refactors split the file layout.
 var _ provider.StreamingProvider = (*Client)(nil)
+
+// toolUseEndTurnStream streams a tool_use block but reports stop_reason
+// "end_turn" in message_delta — the Anthropic-protocol analog of a gateway
+// mislabeling a tool call.
+const toolUseEndTurnStream = "" +
+	"event: message_start\n" +
+	`data: {"type":"message_start","message":{"id":"m","model":"x","usage":{"input_tokens":1,"output_tokens":0}}}` + "\n\n" +
+	"event: content_block_start\n" +
+	`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"edit_file","input":{}}}` + "\n\n" +
+	"event: content_block_delta\n" +
+	`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"a.go\"}"}}` + "\n\n" +
+	"event: content_block_stop\n" +
+	`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+	"event: message_delta\n" +
+	`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":0,"output_tokens":3}}` + "\n\n" +
+	"event: message_stop\n" +
+	`data: {"type":"message_stop"}` + "\n\n"
+
+// TestSendStream_ToolUseWithNonToolUseStopReason verifies the streaming path
+// treats an accumulated tool_use block as a tool-use turn even when stop_reason
+// is "end_turn".
+func TestSendStream_ToolUseWithNonToolUseStopReason(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, toolUseEndTurnStream)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	c, _ := New("test-key")
+	c.BaseURL = srv.URL
+	resp, err := c.SendStream(context.Background(), provider.Request{
+		Model: "x", Messages: []agent.Message{agent.NewUserMessage("edit it")},
+	}, provider.StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("SendStream: %v", err)
+	}
+	if resp.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use (tool_use block present despite stop_reason end_turn)", resp.StopReason)
+	}
+	gotTool := false
+	for _, b := range resp.Blocks {
+		if b.Type == "tool_use" && b.Name == "edit_file" {
+			gotTool = true
+		}
+	}
+	if !gotTool {
+		t.Error("expected an edit_file tool_use block")
+	}
+}


### PR DESCRIPTION
Symmetric follow-up to #646 (the openai-compat fixes). Hardens the **anthropic** adapter against the same class of gateway misbehavior.

## Why
The agent loop dispatches tools only when `StopReason == "tool_use"`. Real Anthropic always pairs tool_use blocks with `stop_reason:"tool_use"`, so this never bites there — but octo's `anthropic_compatible` catch-all vendor can point at any Anthropic-protocol gateway. A misbehaving one could return `stop_reason:"end_turn"` with tool_use blocks present, and the call would be silently dropped — exactly the Gemini-via-gateway failure mode fixed for the openai side in #646.

## Fix
Trust the presence of `tool_use` blocks over `stop_reason`: if the response carries tool_use blocks, it's a tool-use turn, in both the streaming and non-streaming paths. A genuine truncation (`max_tokens`) is left intact (a partial tool call is unsafe to dispatch).

## Deliberately NOT done: gating cache_control
The `prompt_cache_key` analog here is `cache_control: ephemeral`. Unlike the OpenAI-proprietary field (which **no** non-OpenAI backend uses, so gating it off was free), `cache_control` is **standard in the Anthropic Messages API** and supported by the compatible endpoints octo targets (Bedrock-Claude, Kimi `…/coding`, DeepSeek `…/anthropic`). Gating it off would regress prompt caching for no benefit. Left as-is; revisit only if a specific endpoint rejects it.

## Tests
Non-streaming and streaming: a tool_use block arriving with `stop_reason:"end_turn"` yields `StopReason "tool_use"` and the tool block is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)