### PR TITLE
fix(provider): recover from mid-stream transport resets instead of failing the turn

### DIFF
--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -155,7 +155,11 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 
 		var ev streamEvent
 		if err := json.Unmarshal([]byte(data), &ev); err != nil {
-			return result, fmt.Errorf("anthropic: parse stream event: %w", err)
+			// A chunk that fails to parse is, in a streaming SSE context, a
+			// truncated final line from a cut stream (a healthy server sends
+			// complete JSON per data: line). Mark it transient so the agent loop
+			// re-issues the round, same as a boundary-aligned reset caught below.
+			return result, retry.AsTransientStream(fmt.Errorf("anthropic: parse stream event: %w", err))
 		}
 
 		switch ev.Type {
@@ -249,7 +253,11 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return result, fmt.Errorf("anthropic: stream read: %w", err)
+		// A mid-stream transport failure (HTTP/2 reset, connection drop) is
+		// recoverable: mark it transient so the agent loop re-issues the round
+		// instead of failing the turn. A caller cancellation passes through
+		// untouched (see retry.AsTransientStream).
+		return result, retry.AsTransientStream(fmt.Errorf("anthropic: stream read: %w", err))
 	}
 
 	// Build the final block list in order.

--- a/internal/provider/anthropic/stream_test.go
+++ b/internal/provider/anthropic/stream_test.go
@@ -366,3 +366,41 @@ func TestSendStream_ToolUseWithNonToolUseStopReason(t *testing.T) {
 		t.Error("expected an edit_file tool_use block")
 	}
 }
+
+// TestSendStream_MidStreamResetIsTransient verifies a connection reset mid-body
+// surfaces as a transient stream error so the agent loop re-issues the round.
+func TestSendStream_MidStreamResetIsTransient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Promise more body than we deliver, then close the socket mid-line: the
+		// client sees a cut stream whose truncated final SSE chunk fails to
+		// parse — the mid-line manifestation of a reset. (A reset at an event
+		// boundary instead surfaces via scanner.Err(); both are wrapped transient.)
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("server does not support hijacking")
+		}
+		conn, bufrw, err := hj.Hijack()
+		if err != nil {
+			t.Fatalf("hijack: %v", err)
+		}
+		_, _ = bufrw.WriteString("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: 4096\r\n\r\n")
+		_, _ = bufrw.WriteString("event: content_block_delta\n" +
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"par`)
+		_ = bufrw.Flush()
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	_, err := c.SendStream(context.Background(), provider.Request{
+		Model: "x", Messages: []agent.Message{agent.NewUserMessage("hi")},
+	}, provider.StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected an error from the reset stream")
+	}
+	var ts interface{ TransientStream() bool }
+	if !errors.As(err, &ts) || !ts.TransientStream() {
+		t.Errorf("mid-stream reset should be transient, got %v", err)
+	}
+}

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -148,7 +148,11 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 
 		var ch streamChunk
 		if err := json.Unmarshal([]byte(data), &ch); err != nil {
-			return result, fmt.Errorf("openai: parse stream chunk: %w", err)
+			// A chunk that fails to parse is, in a streaming SSE context, a
+			// truncated final line from a cut stream (a healthy server sends
+			// complete JSON per data: line). Mark it transient so the agent loop
+			// re-issues the round, same as a boundary-aligned reset caught below.
+			return result, retry.AsTransientStream(fmt.Errorf("openai: parse stream chunk: %w", err))
 		}
 
 		if result.Model == "" && ch.Model != "" {
@@ -224,7 +228,11 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return result, fmt.Errorf("openai: stream read: %w", err)
+		// A mid-stream transport failure (HTTP/2 reset, connection drop) is
+		// recoverable: mark it transient so the agent loop re-issues the round
+		// instead of failing the turn. A caller cancellation passes through
+		// untouched (see retry.AsTransientStream).
+		return result, retry.AsTransientStream(fmt.Errorf("openai: stream read: %w", err))
 	}
 
 	result.Content = contentB.String()

--- a/internal/provider/openai/stream_test.go
+++ b/internal/provider/openai/stream_test.go
@@ -519,3 +519,40 @@ func TestSendStream_ToolCallWithStopFinishReason(t *testing.T) {
 
 // Compile-time assertion.
 var _ provider.StreamingProvider = (*Client)(nil)
+
+// TestSendStream_MidStreamResetIsTransient verifies a connection reset mid-body
+// surfaces as a transient stream error so the agent loop re-issues the round.
+func TestSendStream_MidStreamResetIsTransient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Promise more body than we deliver, then close the socket mid-line: the
+		// client sees a cut stream whose truncated final SSE chunk fails to
+		// parse — the mid-line manifestation of a reset. (A reset at an event
+		// boundary instead surfaces via scanner.Err(); both are wrapped transient.)
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("server does not support hijacking")
+		}
+		conn, bufrw, err := hj.Hijack()
+		if err != nil {
+			t.Fatalf("hijack: %v", err)
+		}
+		_, _ = bufrw.WriteString("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: 4096\r\n\r\n")
+		_, _ = bufrw.WriteString(`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"par`)
+		_ = bufrw.Flush()
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	_, err := c.SendStream(context.Background(), provider.Request{
+		Model: "m", Messages: []agent.Message{agent.NewUserMessage("hi")},
+	}, provider.StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected an error from the reset stream")
+	}
+	var ts interface{ TransientStream() bool }
+	if !errors.As(err, &ts) || !ts.TransientStream() {
+		t.Errorf("mid-stream reset should be transient, got %v", err)
+	}
+}

--- a/internal/provider/retry/transient.go
+++ b/internal/provider/retry/transient.go
@@ -1,0 +1,34 @@
+package retry
+
+import (
+	"context"
+	"errors"
+)
+
+// transientStreamErr wraps a mid-stream transport failure — an HTTP/2 stream
+// reset (INTERNAL_ERROR / GOAWAY), a connection drop, or an unexpected EOF
+// while reading the SSE body — so the agent loop recognises it as recoverable
+// (via the same TransientStream() interface streamIdleError uses) and re-issues
+// the round from unchanged history. Like the idle case, the partial reply was
+// never committed, so the retry is safe.
+type transientStreamErr struct{ err error }
+
+func (e transientStreamErr) Error() string       { return e.err.Error() }
+func (e transientStreamErr) Unwrap() error       { return e.err }
+func (transientStreamErr) TransientStream() bool { return true }
+
+// AsTransientStream marks a mid-stream read failure as a recoverable transient
+// stream error, EXCEPT a genuine context cancellation or deadline — that's the
+// caller stopping the turn (a user interrupt or an overall timeout), which must
+// not be auto-retried. err==nil passes through as nil. Providers wrap the error
+// from a mid-stream body read with this so a flaky gateway/proxy that resets a
+// long stream is retried instead of failing the turn.
+func AsTransientStream(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return transientStreamErr{err}
+}

--- a/internal/provider/retry/transient_test.go
+++ b/internal/provider/retry/transient_test.go
@@ -1,0 +1,55 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+func hasTransientStream(err error) bool {
+	var t interface{ TransientStream() bool }
+	return errors.As(err, &t) && t.TransientStream()
+}
+
+func TestAsTransientStream(t *testing.T) {
+	if AsTransientStream(nil) != nil {
+		t.Error("nil should pass through as nil")
+	}
+
+	// Transport-level mid-stream failures are transient.
+	if got := AsTransientStream(io.ErrUnexpectedEOF); !hasTransientStream(got) {
+		t.Errorf("ErrUnexpectedEOF should be transient, got %v", got)
+	}
+	if got := AsTransientStream(errors.New("stream ID 3; INTERNAL_ERROR; received from peer")); !hasTransientStream(got) {
+		t.Errorf("HTTP/2 reset should be transient, got %v", got)
+	}
+
+	// Caller cancellation / deadline must NOT be retried.
+	if got := AsTransientStream(context.Canceled); hasTransientStream(got) {
+		t.Error("context.Canceled must not be transient")
+	}
+	if got := AsTransientStream(context.DeadlineExceeded); hasTransientStream(got) {
+		t.Error("context.DeadlineExceeded must not be transient")
+	}
+	// Wrapped cancellation is still recognised through the chain.
+	if got := AsTransientStream(errors.New("read: " + context.Canceled.Error())); !hasTransientStream(got) {
+		// A string-only mention isn't a real wrap; this should be transient.
+		// (Guards against matching by message instead of errors.Is.)
+		t.Error("a non-wrapping mention of cancellation should still be transient")
+	}
+	if got := AsTransientStream(wrapErr{context.Canceled}); hasTransientStream(got) {
+		t.Error("a genuinely wrapped context.Canceled must not be transient")
+	}
+
+	// Unwrap exposes the original error.
+	orig := io.ErrUnexpectedEOF
+	if !errors.Is(AsTransientStream(orig), orig) {
+		t.Error("AsTransientStream should preserve the wrapped error for errors.Is")
+	}
+}
+
+type wrapErr struct{ e error }
+
+func (w wrapErr) Error() string { return "wrapped: " + w.e.Error() }
+func (w wrapErr) Unwrap() error { return w.e }


### PR DESCRIPTION
Follow-up to the gateway-compat work (#646/#647). Found while baselining models through a flaky LiteLLM gateway: **sonnet-4-6 scored 0 on every generative task** because the gateway reset the HTTP/2 stream mid-way through a large `index.html` write (`stream error: INTERNAL_ERROR; received from peer`), and octo failed the whole turn.

## The gap
octo already recovers an **idle-timeout stall** (`streamIdleError` carries `TransientStream()==true`, and the agent loop re-issues the round). But a **mid-stream transport reset** — HTTP/2 RST, connection drop, or a truncated final chunk — was surfaced as a plain error and failed the turn.

A cut stream surfaces **two ways** depending on where it lands:
- reset at an SSE **event boundary** → empty buffer → `scanner.Err()`
- reset **mid-line** → truncated final chunk → JSON parse error (`bufio.Scanner` flushes the partial line on *any* read error, not just `io.EOF`)

## Fix
`retry.AsTransientStream(err)` marks an error `TransientStream()==true` **except** a genuine `context.Canceled`/`DeadlineExceeded` (a caller stop — never retried). Both stream-read paths in **both** the openai and anthropic adapters are wrapped with it, so the agent loop re-issues the round. Safe: the partial reply was never committed to history, and `maxStreamStalls` bounds the retries.

A truncated/malformed SSE chunk is treated as transient too: in a streaming context a chunk that fails to parse is, in practice, a cut stream (a healthy server sends complete JSON per `data:` line).

## Tests
- `retry.AsTransientStream`: transport error / unexpected-EOF → transient; `context.Canceled`/`DeadlineExceeded` (incl. wrapped) → not.
- A mid-stream socket close yields a transient error from `SendStream`, in both providers.

## Impact
Re-tested against the gateway: sonnet-4-6's generative tasks recover (verification in the next comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)