### PR TITLE
chore: clean up three small debt items (skillsManifest race, ws session_id, help env)

### DIFF
--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -158,6 +158,8 @@ Environment:
   OPENAI_API_KEY           Required when --provider=openai
   ANTHROPIC_BASE_URL       Override the Anthropic endpoint
   OPENAI_BASE_URL          Override the OpenAI endpoint
+  OPENAI_COMPATIBLE_API_KEY / OPENAI_COMPATIBLE_BASE_URL          Self-hosted / third-party OpenAI-protocol endpoint
+  ANTHROPIC_COMPATIBLE_API_KEY / ANTHROPIC_COMPATIBLE_BASE_URL    ... Anthropic-protocol endpoint
 
 Run "octo serve --help" for the full flag list.`)
 }

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -135,6 +135,8 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "Environment:")
 	fmt.Fprintln(w, "  ANTHROPIC_API_KEY / OPENAI_API_KEY      Required for the chosen provider")
 	fmt.Fprintln(w, "  ANTHROPIC_BASE_URL / OPENAI_BASE_URL    Override the endpoint (proxies, compatible servers)")
+	fmt.Fprintln(w, "  OPENAI_COMPATIBLE_API_KEY  + _BASE_URL  Self-hosted / third-party OpenAI-protocol endpoint")
+	fmt.Fprintln(w, "  ANTHROPIC_COMPATIBLE_API_KEY + _BASE_URL  ... Anthropic-protocol endpoint")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Run `octo help <command>` for examples + env vars (e.g. `octo help mcp`),")
 	fmt.Fprintln(w, "`octo <command> --help` for a command's flags, or `octo -help` for all session flags.")

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -591,7 +591,7 @@ func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
 	s.skillReg.Reload()
 	// Refresh the manifest for sessions built after this point, same as the
 	// toggle/delete handlers do.
-	s.skillsManifest = skills.RenderManifest(s.skillReg)
+	s.setSkillsManifest(skills.RenderManifest(s.skillReg))
 	list := s.skillReg.All()
 	out := make([]skillInfo, 0, len(list))
 	for _, sk := range list {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -93,12 +93,16 @@ type Server struct {
 	http *http.Server
 
 	// agent factory state (resolved once at start)
-	sender         agent.Sender
-	model          string
-	provider       string
-	system         string
-	skillReg       *skills.Registry
+	sender   agent.Sender
+	model    string
+	provider string
+	system   string
+	skillReg *skills.Registry
+	// skillsManifest is recomposed when skills are toggled/imported (write) and
+	// read on every turn's prompt.Compose; skillsMu guards the two against a
+	// data race between the mutation handlers and concurrent turns.
 	skillsManifest string
+	skillsMu       sync.RWMutex
 	cwd            string
 	envCtx         string
 	memDir         string
@@ -355,7 +359,7 @@ func (s *Server) enableSubAgentTools() {
 	if s.memDir != "" {
 		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
 	}
-	template.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
+	template.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.curSkillsManifest(), memInjection, true)
 	executor := tools.NewDefaultRegistry()
 	spawner := app.NewSpawner(template, executor, func() []agent.ToolDefinition {
 		return tools.DefaultToolsFor(s.model)
@@ -669,7 +673,7 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	if s.memDir != "" {
 		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
 	}
-	a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
+	a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.curSkillsManifest(), memInjection, true)
 
 	// L2: attention-layer rules injected per user turn (triggered keywords),
 	// plus the save-nudge appended to milestone tool results.
@@ -912,6 +916,21 @@ func (s *Server) invalidateSenderCache() {
 	s.senderCacheMu.Unlock()
 }
 
+// curSkillsManifest returns the current skills manifest under a read lock.
+func (s *Server) curSkillsManifest() string {
+	s.skillsMu.RLock()
+	defer s.skillsMu.RUnlock()
+	return s.skillsManifest
+}
+
+// setSkillsManifest replaces the skills manifest under a write lock. Called by
+// the skill toggle/import handlers when the enabled set changes.
+func (s *Server) setSkillsManifest(m string) {
+	s.skillsMu.Lock()
+	s.skillsManifest = m
+	s.skillsMu.Unlock()
+}
+
 // buildEnvContext mirrors cmd/octo's env context builder.
 func buildEnvContext(cwd string) string {
 	var b strings.Builder
@@ -1127,7 +1146,7 @@ func (s *Server) initChannels() {
 		a := agent.New(s.sender, s.model)
 		a.CWD = s.cwd
 		a.MaxTokens = s.cfg.MaxTokens
-		a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
+		a.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.curSkillsManifest(), memInjection, true)
 		if cfg, err := config.Load(); err == nil {
 			a.LiteSender, a.LiteModel = s.liteSenderFromConfig(cfg)
 			if a.LiteSender == nil {
@@ -1283,7 +1302,7 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	if s.memDir != "" {
 		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
 	}
-	sess.Agent.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.skillsManifest, memInjection, true)
+	sess.Agent.System = prompt.Compose(s.system, s.cwd, s.envCtx, s.curSkillsManifest(), memInjection, true)
 
 	// L2 memory hooks, same pair buildAgent gives web turns: keyword
 	// reminders on user input, save-nudge on milestone tool results. The

--- a/internal/server/skill_import_handler.go
+++ b/internal/server/skill_import_handler.go
@@ -52,7 +52,7 @@ func (s *Server) handleImportSkill(w http.ResponseWriter, r *http.Request) {
 	// Refresh the registry and manifest so the list — and new sessions — see
 	// the skill immediately (same pattern as toggle/delete).
 	s.skillReg.Reload()
-	s.skillsManifest = skills.RenderManifest(s.skillReg)
+	s.setSkillsManifest(skills.RenderManifest(s.skillReg))
 
 	writeJSON(w, http.StatusOK, map[string]any{"name": name, "description": desc})
 }

--- a/internal/server/skill_toggle_handler.go
+++ b/internal/server/skill_toggle_handler.go
@@ -67,7 +67,7 @@ func (s *Server) handleToggleSkill(w http.ResponseWriter, r *http.Request) {
 
 	// Update in-memory state so new sessions see the change immediately.
 	s.skillReg.SetDisabled(cfg.Tools.DisabledSkills)
-	s.skillsManifest = skills.RenderManifest(s.skillReg)
+	s.setSkillsManifest(skills.RenderManifest(s.skillReg))
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"name":    name,
@@ -103,7 +103,7 @@ func (s *Server) handleDeleteSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update in-memory manifest so new sessions see the change immediately.
-	s.skillsManifest = skills.RenderManifest(s.skillReg)
+	s.setSkillsManifest(skills.RenderManifest(s.skillReg))
 
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": name})
 }

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -179,10 +179,15 @@ type wsEventSessionDeleted struct {
 }
 
 type wsEventRequestFeedback struct {
-	Type     string   `json:"type"`
-	Question string   `json:"question"`
-	Context  string   `json:"context,omitempty"`
-	Options  []string `json:"options,omitempty"`
+	Type string `json:"type"`
+	// SessionID is required: the ws-dispatcher drops any event whose session_id
+	// doesn't match the active session, so without it a request_feedback event
+	// would always be discarded — the same session-less footgun #613 fixed for
+	// request_confirmation.
+	SessionID string   `json:"session_id"`
+	Question  string   `json:"question"`
+	Context   string   `json:"context,omitempty"`
+	Options   []string `json:"options,omitempty"`
 }
 
 type wsEventRequestConfirmation struct {


### PR DESCRIPTION
A small cleanup sweep of three latent issues.

- **skillsManifest data race** — read on every turn's `prompt.Compose`, rewritten by the skill toggle/import handlers, unguarded. Add `skillsMu` (RWMutex) with `curSkillsManifest()`/`setSkillsManifest()` accessors. Verified under `go test -race ./internal/server/`.
- **`wsEventRequestFeedback` missing `session_id`** — the ws-dispatcher drops any event whose `session_id` ≠ the active session, so a `request_feedback` event (the frontend handler exists) would always be discarded — the session-less footgun #613 fixed for `request_confirmation`. Add the field.
- **`octo help` omitted the compatible catch-all vendors** — the Environment sections listed only `ANTHROPIC_*`/`OPENAI_*`; add `OPENAI_COMPATIBLE_API_KEY`/`_BASE_URL` and `ANTHROPIC_COMPATIBLE_API_KEY`/`_BASE_URL` (from #623).

**Deliberately skipped**: the channel manager's hardcoded `BindByChatUser` — it carries a "revisit if the server ever stops hardcoding" marker; an intentional decision with no current driver, so not worth churning.

`go test -race ./internal/server/` + `go test ./cmd/octo/` green; vet/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)