### PR TITLE
feat(serve): structured logging + systemd/launchd service templates

### DIFF
--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/url"
 	"os"
@@ -15,6 +16,20 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/server"
 )
+
+// serveLogLevel reads OCTO_LOG_LEVEL (debug|info|warn|error); defaults to info.
+func serveLogLevel() slog.Level {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("OCTO_LOG_LEVEL"))) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
 
 // runServe handles `octo serve`.
 func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
@@ -41,6 +56,11 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		defer signal.Stop(sigCh)
 		return superviseLoop(spawnServeWorker(args, stdout, stderr), sigCh, stderr)
 	}
+
+	// Structured operational logging for the serve worker: slog text handler to
+	// stderr, level from OCTO_LOG_LEVEL. Capturing this output (a file, the
+	// systemd journal) is the service manager's job — see packaging/.
+	slog.SetDefault(slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: serveLogLevel()})))
 
 	var corsOrigins []string
 	if *cors != "" {

--- a/cmd/octo/serve_loglevel_test.go
+++ b/cmd/octo/serve_loglevel_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestServeLogLevel(t *testing.T) {
+	cases := map[string]slog.Level{
+		"":        slog.LevelInfo,
+		"info":    slog.LevelInfo,
+		"DEBUG":   slog.LevelDebug,
+		" warn ":  slog.LevelWarn,
+		"warning": slog.LevelWarn,
+		"error":   slog.LevelError,
+		"bogus":   slog.LevelInfo,
+	}
+	for in, want := range cases {
+		t.Setenv("OCTO_LOG_LEVEL", in)
+		if got := serveLogLevel(); got != want {
+			t.Errorf("serveLogLevel(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/internal/server/restart.go
+++ b/internal/server/restart.go
@@ -3,9 +3,8 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
+	"log/slog"
 	"net/http"
-	"os"
 	"time"
 )
 
@@ -37,14 +36,14 @@ func (s *Server) Restart(reason string) {
 	if !s.restartPending.CompareAndSwap(false, true) {
 		return
 	}
-	fmt.Fprintf(os.Stderr, "octo serve: restart requested (%s)\n", reason)
+	slog.Info("restart requested", "reason", reason)
 	go func() {
 		timeout := s.drainTimeout
 		if timeout <= 0 {
 			timeout = defaultDrainTimeout
 		}
 		if clean := s.drain.drain(timeout); !clean {
-			fmt.Fprintf(os.Stderr, "octo serve: drain timed out after %s; restarting with turns in flight\n", timeout)
+			slog.Warn("drain timed out; restarting with turns in flight", "timeout", timeout)
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -268,7 +269,7 @@ func New(cfg Config) (*Server, error) {
 		// works for this process lifetime.
 		fileCfg.AccessKey = accessKey
 		if err := fileCfg.Save(); err != nil {
-			fmt.Fprintf(os.Stderr, "octo serve: persist access key to config.yml: %v (a new key will be generated next start)\n", err)
+			slog.Warn("could not persist access key; a new one will be generated next start", "err", err)
 		}
 	}
 
@@ -387,7 +388,7 @@ func (s *Server) enableMCP() {
 	s.mcpMu.Lock()
 	defer s.mcpMu.Unlock()
 	if err := app.SwapMCP(context.Background(), s.cwd, os.Stderr); err != nil {
-		fmt.Fprintf(os.Stderr, "octo serve: mcp: %v\n", err)
+		slog.Error("mcp setup", "err", err)
 	}
 	s.mcpCleanup = func() {
 		s.mcpMu.Lock()
@@ -1124,7 +1125,7 @@ func (s *Server) initChannels() {
 	}
 	chCfg, err := channel.LoadConfig()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "octo serve: channel config: %v\n", err)
+		slog.Error("channel config", "err", err)
 		return
 	}
 	platforms := chCfg.EnabledPlatforms()
@@ -1162,7 +1163,7 @@ func (s *Server) initChannels() {
 	s.channelCfg = chCfg
 	s.channelMgr = channel.NewManager(chCfg, factory, channel.BindByChatUser)
 
-	fmt.Fprintf(os.Stderr, "octo serve: channels enabled: %s\n", strings.Join(platforms, ", "))
+	slog.Info("channels enabled", "platforms", strings.Join(platforms, ", "))
 }
 
 // startChannels launches all enabled channel adapters in background goroutines.
@@ -1181,17 +1182,17 @@ func (s *Server) startChannels() {
 		}
 		ctor, err := channel.Find(name)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "octo serve: channel %s: %v\n", name, err)
+			slog.Error("channel start failed", "channel", name, "err", err)
 			continue
 		}
 		ad, err := ctor(pc)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "octo serve: channel %s adapter: %v\n", name, err)
+			slog.Error("channel adapter failed", "channel", name, "err", err)
 			continue
 		}
 		if errs := ad.ValidateConfig(pc); len(errs) > 0 {
 			for _, e := range errs {
-				fmt.Fprintf(os.Stderr, "octo serve: channel %s config: %s\n", name, e)
+				slog.Warn("channel config issue", "channel", name, "detail", e)
 			}
 			continue
 		}
@@ -1322,7 +1323,7 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	if err != nil {
 		// Generic chat reply — err.Error() can leak local paths into a
 		// group chat; the operator gets the detail on the server console.
-		fmt.Fprintf(os.Stderr, "octo serve: channel %s: permission engine: %v\n", ev.Platform, err)
+		slog.Error("channel permission engine", "channel", ev.Platform, "err", err)
 		ad.SendText(ev.ChatID, "⚠️ Permission engine unavailable — message not processed. Check the server logs.", ev.MessageID)
 		return
 	}
@@ -1368,7 +1369,7 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 		// Persist the conversation so it survives server restarts. Failure
 		// must not eat the reply the user already got — log and move on.
 		if err := sess.Persist(); err != nil {
-			fmt.Fprintf(os.Stderr, "octo serve: channel %s: persist session: %v\n", ev.Platform, err)
+			slog.Error("channel persist session", "channel", ev.Platform, "err", err)
 		}
 	}
 

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -56,7 +57,7 @@ func (s *Server) initScheduler() {
 	dir := filepath.Join(home, ".octo", "tasks")
 	sch, err := scheduler.New(dir, s)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "octo serve: scheduler: %v\n", err)
+		slog.Error("scheduler", "err", err)
 		return
 	}
 	sch.Start()

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,51 @@
+# Packaging
+
+Service templates and OS packaging assets for running `octo serve` as a
+long-lived daemon.
+
+## Running octo serve as a service
+
+`octo serve` writes structured logs (Go `slog`, text format) to **stderr**;
+the level is set by `OCTO_LOG_LEVEL` (`debug` | `info` | `warn` | `error`,
+default `info`). It does not manage log files itself — the service manager
+captures stderr (systemd → the journal, launchd → `StandardErrorPath`).
+
+Run it under your init system with `--no-supervisor`: the init system is the
+supervisor. octo's own restart path (binary upgrade, startup-only config
+change) exits the worker with code **42**; `Restart=always` (systemd) /
+`KeepAlive` (launchd) respawn it from the on-disk binary, so the upgrade takes
+effect on restart.
+
+### Linux — systemd (user service)
+
+[`systemd/octo.service`](systemd/octo.service):
+
+```sh
+cp packaging/systemd/octo.service ~/.config/systemd/user/octo.service
+$EDITOR ~/.config/systemd/user/octo.service     # fix the ExecStart path
+$EDITOR ~/.octo/serve.env && chmod 600 ~/.octo/serve.env   # API key, access key
+systemctl --user daemon-reload
+systemctl --user enable --now octo
+journalctl --user -u octo -f
+```
+
+### macOS — launchd (user agent)
+
+[`launchd/dev.octo-agent.serve.plist`](launchd/dev.octo-agent.serve.plist):
+
+```sh
+cp packaging/launchd/dev.octo-agent.serve.plist ~/Library/LaunchAgents/
+$EDITOR ~/Library/LaunchAgents/dev.octo-agent.serve.plist   # fix path + env
+launchctl load ~/Library/LaunchAgents/dev.octo-agent.serve.plist
+tail -f /tmp/octo-serve.log
+```
+
+> Both templates default to a loopback bind. Exposing the server on a LAN/public
+> address requires `-addr :8080` (or similar) **and** an access key — see
+> [SECURITY.md](../SECURITY.md).
+
+## Windows installer
+
+The double-click `octo-setup.exe` is built from
+[`windows/octo.iss`](windows/octo.iss) by the release workflow. See the README's
+Install section.

--- a/packaging/launchd/dev.octo-agent.serve.plist
+++ b/packaging/launchd/dev.octo-agent.serve.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  octo serve — launchd user agent (macOS).
+
+  Install (per-user, no root):
+    cp packaging/launchd/dev.octo-agent.serve.plist ~/Library/LaunchAgents/
+    # edit the octo path + env values below, then:
+    launchctl load ~/Library/LaunchAgents/dev.octo-agent.serve.plist
+    tail -f ~/.octo/logs/serve.log      # octo logs to stderr → StandardErrorPath
+
+  octo serve runs with --no-supervisor: launchd is the supervisor. The worker
+  requests a restart by exiting 42; KeepAlive respawns it from the on-disk
+  binary, so binary upgrades / config changes take effect on restart.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.octo-agent.serve</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/octo</string>
+    <string>serve</string>
+    <string>--no-supervisor</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>OCTO_LOG_LEVEL</key>
+    <string>info</string>
+    <!-- Set secrets here, or keep them in the user keychain / a sourced file.
+         ANTHROPIC_API_KEY / OPENAI_API_KEY / OCTO_ACCESS_KEY -->
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/octo-serve.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/octo-serve.log</string>
+</dict>
+</plist>

--- a/packaging/systemd/octo.service
+++ b/packaging/systemd/octo.service
@@ -1,0 +1,31 @@
+# octo serve — systemd user service.
+#
+# Install (per-user, no root):
+#   cp packaging/systemd/octo.service ~/.config/systemd/user/octo.service
+#   # edit ExecStart path + create the env file below, then:
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now octo
+#   journalctl --user -u octo -f      # follow logs (octo logs to stderr → journal)
+#
+# octo serve runs with --no-supervisor here: systemd is the supervisor. The
+# worker requests a restart (binary upgrade / config change) by exiting 42;
+# Restart=always covers that, so systemd respawns it from the on-disk binary.
+[Unit]
+Description=octo agent server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/octo serve --no-supervisor
+Restart=always
+RestartSec=2
+# Secrets (API key, access key) live in an env file, not this unit. chmod 600 it.
+#   OCTO_ACCESS_KEY=...
+#   ANTHROPIC_API_KEY=...   (or OPENAI_API_KEY=..., etc.)
+#   OCTO_LOG_LEVEL=info
+EnvironmentFile=-%h/.octo/serve.env
+WorkingDirectory=%h
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
The serve "ops surface" 🟡 item: `octo serve` logged via ad-hoc `fmt.Fprintf(os.Stderr, "octo serve: ...")` with no levels/structure, and shipped no service-manager templates.

## Structured logging
- Configure `slog` (text handler → stderr) in the serve worker; level from `OCTO_LOG_LEVEL` (`debug|info|warn|error`, default `info`).
- Migrate the 12 operational log sites (channel start/config, mcp, scheduler, restart/drain, access-key persist) to `slog.Info/Warn/Error` with structured fields.
- The stdout startup banner (`listening on …`, access-key URL) stays — it's user-facing CLI, not ops logs.
- Per the agreed scope: **text only** (no JSON), **no `--log-file`** (the service manager captures stderr), **no per-request access log** (serve events only).

Example:
```
time=2026-06-12T20:49:43+08:00 level=ERROR msg="channel config" err="…did not find expected key"
```

## Service templates
- `packaging/systemd/octo.service` (user unit) and `packaging/launchd/dev.octo-agent.serve.plist`, both `octo serve --no-supervisor` so the init system supervises — the worker's **exit-42 restart request** is covered by `Restart=always` / `KeepAlive`.
- `packaging/README.md` documents install + the loopback-bind / access-key caveat.

## Test
`serveLogLevel` unit test; `go test ./internal/server/ ./cmd/octo/` green; vet/fmt clean. Boot smoke verified (health 200; a malformed channels.yml produces the slog-formatted line above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)