### PR TITLE
ci(release): wire SignPath signing for the Windows installer + code-signing policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,37 @@ jobs:
             "/DAppVersion=$env:version" "/DSourceDir=$staging" "/O$staging" `
             packaging\windows\octo.iss
 
+      # Authenticode signing via SignPath Foundation (free for open source).
+      # Dormant until SignPath is configured: set repo variables
+      # SIGNPATH_ORGANIZATION_ID / SIGNPATH_PROJECT_SLUG /
+      # SIGNPATH_SIGNING_POLICY_SLUG and the secret SIGNPATH_API_TOKEN. Until
+      # then these steps skip and the release ships the unsigned installer.
+      # See the README "Code signing policy" section.
+      - name: Upload unsigned installer (for SignPath)
+        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' }}
+        id: unsigned-installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: octo-setup-unsigned
+          path: staging\octo-setup.exe
+
+      - name: Sign installer (SignPath)
+        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' }}
+        uses: SignPath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          github-artifact-id: ${{ steps.unsigned-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed
+
+      - name: Swap in the signed installer
+        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' }}
+        shell: pwsh
+        run: Copy-Item signed\octo-setup.exe staging\octo-setup.exe -Force
+
       - name: Attach installer to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -45,6 +45,29 @@ Uninstall from "Add or remove programs" like any other app.
 verified against `checksums.txt`); `octo upgrade --check` only compares
 versions. The web UI's version badge offers the same flow.
 
+### Code signing policy
+
+octo's Windows installer (`octo-setup.exe`) is signed through the free
+open-source program of the [SignPath Foundation](https://signpath.org/),
+which issues the certificate; the signing key is held by SignPath and never
+leaves their infrastructure.
+
+- **What is signed:** the `octo-setup.exe` installer attached to each GitHub
+  release. The release archives themselves are integrity-checked via the
+  `checksums.txt` published alongside them.
+- **How:** the installer is built in CI (`.github/workflows/release.yml`) and
+  submitted to SignPath for signing as part of the release. Every signing
+  request is approved by a project maintainer before it is signed.
+- **Who can approve:** the repository maintainers. Anyone with signing-request
+  approval or repository write access uses multi-factor authentication on both
+  GitHub and SignPath.
+- **Verifying:** right-click the installer → *Properties → Digital Signatures*
+  to confirm the publisher.
+
+Signing is being rolled out via the SignPath Foundation; until the certificate
+is provisioned, released installers may be **unsigned**, in which case Windows
+SmartScreen shows "Windows protected your PC" — click **More info → Run anyway**.
+
 **From Go:**
 
 ```bash


### PR DESCRIPTION
Pushes Windows code signing forward via the **SignPath Foundation** free open-source program (no cost; OV-level cert; key held by SignPath; builds SmartScreen reputation).

## What's in this PR (the parts I can land now)
- **`release.yml`** — gated SignPath signing steps in the `windows-installer` job: upload the built `octo-setup.exe` as an artifact → `SignPath/github-action-submit-signing-request@v2` → swap the signed exe back before the release upload. **Dormant until configured**: every step keys off `vars.SIGNPATH_ORGANIZATION_ID`, so with it unset the steps skip and the release ships the unsigned installer exactly as today (no breakage). `actionlint` clean.
- **README "Code signing policy"** section — a SignPath Foundation **application requirement** (must be on the project home page; names who approves signing requests + the MFA expectation).

## Activation (no code change needed)
Once the Foundation approves the project, set repo **variables** `SIGNPATH_ORGANIZATION_ID`, `SIGNPATH_PROJECT_SLUG`, `SIGNPATH_SIGNING_POLICY_SLUG` and the **secret** `SIGNPATH_API_TOKEN`. The next tagged release then signs automatically.

## Remaining (maintainer, external — can't be done in-repo)
1. Apply to the SignPath Foundation (OSS program).
2. Enable MFA on GitHub + SignPath for anyone with signing approval.
3. Create the SignPath project, then set the variables/secret above.

Note: SignPath issues an **OV** cert — SmartScreen reputation builds over downloads (not instant-zero-warning like EV), but the publisher is verified from day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)