### PR TITLE
feat(workflow): resume/journal

### DIFF
--- a/dev-docs/ruby-workflow-design.md
+++ b/dev-docs/ruby-workflow-design.md
@@ -5,6 +5,7 @@
 | 版本号 | 日期 | 修订人 | 描述 |
 |---|---|---|---|
 | 1.0 | 2026-06-12 | roy.lei | 初稿。基于 mruby→WASM→wazero 可行性验证（已落地为下列实现）。 |
+| 1.1 | 2026-06-13 | roy.lei | resume/journal 落地（`internal/workflow/journal.go`）。 |
 
 ## 相关文档
 
@@ -48,7 +49,7 @@ WASM 路线把 Ruby 解释器编成一个平台无关的 `.wasm` 工件，用纯
 | 专门的 workflow 进度树面板（TUI/web） | ⬜ 不做（投机性 UI；待真实使用频率证明需要再议） |
 | `agent` 富 opts（tools/model/schema/read_only） | ⬜ 设计完成，未实现（ABI 仅传 prompt 字符串） |
 | worktree 隔离 | ⬜ 设计完成，未实现 |
-| resume / journal | ⬜ 设计完成，未实现 |
+| resume / journal | ✅ 已实现（`internal/workflow/journal.go`：JSONL 落盘 + sha256 脚本 hash 校验；工具入参 `resume_from`；结果带 `[workflow run: wf-...]`） |
 
 ## Out of Scope
 

--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -60,6 +60,13 @@ func (WorkflowTool) Definition() agent.ToolDefinition {
 					"type":        "string",
 					"description": "Short human-readable label for this workflow (3-7 words). Shown in progress UI.",
 				},
+				"resume_from": map[string]any{
+					"type": "string",
+					"description": "Run ID of a prior workflow run to resume from " +
+						"(format: wf-YYYYMMDD-HHMMSS-xxxxxxxx, returned as \"[workflow run: ...]\" " +
+						"in a previous result). Completed agent() calls are replayed instantly " +
+						"without re-running. The script must be identical to the original run.",
+				},
 			},
 			"required": []string{"script"},
 		},
@@ -116,6 +123,7 @@ func (WorkflowTool) ExecuteStream(ctx context.Context, _ string, input map[strin
 		},
 		Progress:      progress,
 		MaxConcurrent: defaultWorkflowConcurrency,
+		ResumeFrom:    stringArg(input, "resume_from"),
 	})
 	if err != nil {
 		// Surface logs even on failure — they often explain how far it got.
@@ -128,6 +136,9 @@ func (WorkflowTool) ExecuteStream(ctx context.Context, _ string, input map[strin
 	text := res.Output
 	if len(logs) > 0 {
 		text += "\n\n[workflow log]\n" + strings.Join(logs, "\n")
+	}
+	if res.RunID != "" {
+		text += "\n\n[workflow run: " + res.RunID + "]"
 	}
 	return agent.ToolResult{Text: text}, nil
 }

--- a/internal/tools/workflow_test.go
+++ b/internal/tools/workflow_test.go
@@ -44,8 +44,8 @@ func TestWorkflowTool_Execute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if res.Text != "R[a],R[b],R[c]" {
-		t.Errorf("Text = %q, want R[a],R[b],R[c]", res.Text)
+	if !strings.HasPrefix(res.Text, "R[a],R[b],R[c]") {
+		t.Errorf("Text = %q, want R[a],R[b],R[c] prefix", res.Text)
 	}
 }
 

--- a/internal/workflow/journal.go
+++ b/internal/workflow/journal.go
@@ -52,7 +52,7 @@ func journalsDir() (string, error) {
 
 // JournalEntry records one completed agent() call.
 type JournalEntry struct {
-	Seq          int    `json:"seq"`   // 0-based call index (tok-1)
+	Seq          int    `json:"seq"` // 0-based call index (tok-1)
 	Prompt       string `json:"prompt"`
 	Reply        string `json:"reply"`
 	InputTokens  int    `json:"input_tokens"`

--- a/internal/workflow/journal.go
+++ b/internal/workflow/journal.go
@@ -1,0 +1,205 @@
+package workflow
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// scriptHash returns a hex SHA-256 of the user script. Used to validate that a
+// resume_from journal was created from the same script as the current run.
+func scriptHash(script string) string {
+	sum := sha256.Sum256([]byte(script))
+	return hex.EncodeToString(sum[:])
+}
+
+// NewRunID returns a unique run ID for a new workflow journal.
+// Format: wf-YYYYMMDD-HHMMSS-xxxxxxxx.
+func NewRunID() string {
+	now := time.Now()
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		b = [4]byte{
+			byte(now.Nanosecond()),
+			byte(now.Nanosecond() >> 8),
+			byte(now.Nanosecond() >> 16),
+			byte(now.Nanosecond() >> 24),
+		}
+	}
+	return "wf-" + now.Format("20060102-150405") + "-" + hex.EncodeToString(b[:])
+}
+
+// journalsDir returns (and creates if needed) ~/.octo/workflow-journals.
+func journalsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("workflow: home dir: %w", err)
+	}
+	dir := filepath.Join(home, ".octo", "workflow-journals")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("workflow: mkdir %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
+// JournalEntry records one completed agent() call.
+type JournalEntry struct {
+	Seq          int    `json:"seq"`   // 0-based call index (tok-1)
+	Prompt       string `json:"prompt"`
+	Reply        string `json:"reply"`
+	InputTokens  int    `json:"input_tokens"`
+	OutputTokens int    `json:"output_tokens"`
+	ErrMsg       string `json:"error,omitempty"`
+}
+
+// Journal appends completed agent() results to a JSONL file so a workflow can
+// be resumed after a partial run. Each entry is flushed to disk immediately so
+// a crash mid-run leaves a consistent record of all completed calls.
+// Journal is safe for concurrent Append calls from multiple goroutines.
+type Journal struct {
+	mu  sync.Mutex
+	f   *os.File
+	buf *bufio.Writer
+	enc *json.Encoder
+}
+
+// journalFileMeta is the first record in a journal JSONL file.
+type journalFileMeta struct {
+	Type       string    `json:"type"` // "meta"
+	RunID      string    `json:"run_id"`
+	ScriptHash string    `json:"script_hash"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// journalFileEntry is a data record in a journal JSONL file.
+type journalFileEntry struct {
+	Type         string `json:"type"` // "agent"
+	Seq          int    `json:"seq"`
+	Prompt       string `json:"prompt"`
+	Reply        string `json:"reply"`
+	InputTokens  int    `json:"input_tokens"`
+	OutputTokens int    `json:"output_tokens"`
+	ErrMsg       string `json:"error,omitempty"`
+}
+
+// CreateJournal creates a new journal file at dir/runID.jsonl and writes the
+// meta header. The caller must Close it when done.
+func CreateJournal(dir, runID, hash string) (*Journal, error) {
+	path := filepath.Join(dir, runID+".jsonl")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("workflow: create journal %s: %w", path, err)
+	}
+	buf := bufio.NewWriter(f)
+	enc := json.NewEncoder(buf)
+	j := &Journal{f: f, buf: buf, enc: enc}
+	meta := journalFileMeta{
+		Type:       "meta",
+		RunID:      runID,
+		ScriptHash: hash,
+		CreatedAt:  time.Now(),
+	}
+	if err := enc.Encode(meta); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("workflow: journal meta: %w", err)
+	}
+	if err := buf.Flush(); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("workflow: journal flush: %w", err)
+	}
+	return j, nil
+}
+
+// Append writes one completed agent() call to the journal and flushes to disk.
+// Safe for concurrent calls from multiple goroutines.
+func (j *Journal) Append(e JournalEntry) error {
+	rec := journalFileEntry{
+		Type:         "agent",
+		Seq:          e.Seq,
+		Prompt:       e.Prompt,
+		Reply:        e.Reply,
+		InputTokens:  e.InputTokens,
+		OutputTokens: e.OutputTokens,
+		ErrMsg:       e.ErrMsg,
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if err := j.enc.Encode(rec); err != nil {
+		return err
+	}
+	return j.buf.Flush()
+}
+
+// Close flushes and closes the underlying file.
+func (j *Journal) Close() error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	_ = j.buf.Flush()
+	return j.f.Close()
+}
+
+// LoadJournal reads dir/runID.jsonl and returns the recorded entries and the
+// script hash from the meta header. Incomplete tail lines (from a crash
+// mid-write) are silently dropped — the same approach as agent/session.go.
+func LoadJournal(dir, runID string) (entries []JournalEntry, hash string, err error) {
+	path := filepath.Join(dir, runID+".jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, "", fmt.Errorf("workflow: journal %q not found", runID)
+		}
+		return nil, "", fmt.Errorf("workflow: read journal %s: %w", path, err)
+	}
+	// Drop incomplete tail (a crash may leave a partial final record).
+	if n := bytes.LastIndexByte(data, '\n'); n >= 0 {
+		data = data[:n+1]
+	} else {
+		data = nil
+	}
+
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	sc.Buffer(make([]byte, 4096), 4*1024*1024)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		// Use a generic map to discriminate on "type" before parsing the rest.
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(line, &raw); err != nil {
+			continue // skip corrupt lines
+		}
+		var recType string
+		if t, ok := raw["type"]; ok {
+			_ = json.Unmarshal(t, &recType)
+		}
+		switch recType {
+		case "meta":
+			var m journalFileMeta
+			if err := json.Unmarshal(line, &m); err == nil {
+				hash = m.ScriptHash
+			}
+		case "agent":
+			var e journalFileEntry
+			if err := json.Unmarshal(line, &e); err == nil {
+				entries = append(entries, JournalEntry{
+					Seq:          e.Seq,
+					Prompt:       e.Prompt,
+					Reply:        e.Reply,
+					InputTokens:  e.InputTokens,
+					OutputTokens: e.OutputTokens,
+					ErrMsg:       e.ErrMsg,
+				})
+			}
+		}
+	}
+	return entries, hash, sc.Err()
+}

--- a/internal/workflow/journal_test.go
+++ b/internal/workflow/journal_test.go
@@ -1,0 +1,221 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// newTestCtx returns a background context (a no-op helper that keeps test
+// bodies readable while leaving room for per-test deadline control later).
+func newTestCtx(t *testing.T) context.Context {
+	t.Helper()
+	return context.Background()
+}
+
+func TestNewRunID_Format(t *testing.T) {
+	id := NewRunID()
+	if !strings.HasPrefix(id, "wf-") {
+		t.Errorf("RunID %q does not start with wf-", id)
+	}
+	// wf-YYYYMMDD-HHMMSS-xxxxxxxx = 3+8+1+6+1+8 = 27 chars
+	if len(id) != 27 {
+		t.Errorf("RunID %q has unexpected length %d, want 27", id, len(id))
+	}
+}
+
+func TestCreateAndLoadJournal(t *testing.T) {
+	dir := t.TempDir()
+	hash := scriptHash(`agent("hi")`)
+
+	j, err := CreateJournal(dir, "wf-test-001", hash)
+	if err != nil {
+		t.Fatalf("CreateJournal: %v", err)
+	}
+	entries := []JournalEntry{
+		{Seq: 0, Prompt: "alpha", Reply: "r-alpha", InputTokens: 10, OutputTokens: 20},
+		{Seq: 1, Prompt: "beta", Reply: "r-beta", InputTokens: 5, OutputTokens: 15},
+	}
+	for _, e := range entries {
+		if err := j.Append(e); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+	if err := j.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	got, gotHash, err := LoadJournal(dir, "wf-test-001")
+	if err != nil {
+		t.Fatalf("LoadJournal: %v", err)
+	}
+	if gotHash != hash {
+		t.Errorf("hash = %q, want %q", gotHash, hash)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(entries) = %d, want 2", len(got))
+	}
+	if got[0].Prompt != "alpha" || got[0].Reply != "r-alpha" {
+		t.Errorf("entry[0] = %+v", got[0])
+	}
+	if got[1].Prompt != "beta" || got[1].OutputTokens != 15 {
+		t.Errorf("entry[1] = %+v", got[1])
+	}
+}
+
+func TestLoadJournal_NotFound(t *testing.T) {
+	_, _, err := LoadJournal(t.TempDir(), "wf-nonexistent")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("err = %v, want not-found", err)
+	}
+}
+
+func TestRun_JournalCreatedOnCompletion(t *testing.T) {
+	dir := t.TempDir()
+	res, err := Run(newTestCtx(t), `agent("hello")`, Options{
+		Agent:      echoAgent,
+		JournalDir: dir,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.RunID == "" {
+		t.Fatal("Result.RunID is empty")
+	}
+	if !strings.HasPrefix(res.RunID, "wf-") {
+		t.Errorf("RunID = %q, want wf- prefix", res.RunID)
+	}
+
+	entries, hash, err := LoadJournal(dir, res.RunID)
+	if err != nil {
+		t.Fatalf("LoadJournal: %v", err)
+	}
+	if hash != scriptHash(`agent("hello")`) {
+		t.Errorf("journal script hash mismatch")
+	}
+	if len(entries) != 1 || entries[0].Prompt != "hello" {
+		t.Errorf("entries = %v", entries)
+	}
+}
+
+func TestRun_ResumeSkipsCachedCall(t *testing.T) {
+	dir := t.TempDir()
+	script := `agent("hi")`
+	hash := scriptHash(script)
+
+	j, err := CreateJournal(dir, "wf-cached", hash)
+	if err != nil {
+		t.Fatalf("CreateJournal: %v", err)
+	}
+	_ = j.Append(JournalEntry{Seq: 0, Prompt: "hi", Reply: "cached-reply"})
+	_ = j.Close()
+
+	var callCount int
+	res, err := Run(newTestCtx(t), script, Options{
+		Agent: func(_ context.Context, _ string) AgentResult {
+			callCount++
+			return AgentResult{Reply: "fresh-reply"}
+		},
+		JournalDir: dir,
+		ResumeFrom: "wf-cached",
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if callCount != 0 {
+		t.Errorf("Agent called %d times, want 0 (should replay from journal)", callCount)
+	}
+	if res.Output != "cached-reply" {
+		t.Errorf("Output = %q, want cached-reply", res.Output)
+	}
+}
+
+func TestRun_ResumeContinuesFromCrashPoint(t *testing.T) {
+	dir := t.TempDir()
+	script := `parallel(["a","b","c"]) { |it| agent(it) }.join(",")`
+	hash := scriptHash(script)
+
+	// Only "a" is cached; "b" and "c" must run fresh.
+	j, err := CreateJournal(dir, "wf-partial", hash)
+	if err != nil {
+		t.Fatalf("CreateJournal: %v", err)
+	}
+	_ = j.Append(JournalEntry{Seq: 0, Prompt: "a", Reply: "C[a]"})
+	_ = j.Close()
+
+	// parallel() calls Agent concurrently, so guard the slice with a mutex.
+	var mu sync.Mutex
+	var called []string
+	res, err := Run(newTestCtx(t), script, Options{
+		Agent: func(_ context.Context, prompt string) AgentResult {
+			mu.Lock()
+			called = append(called, prompt)
+			mu.Unlock()
+			return AgentResult{Reply: "F[" + prompt + "]"}
+		},
+		JournalDir: dir,
+		ResumeFrom: "wf-partial",
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for _, p := range called {
+		if p == "a" {
+			t.Errorf("Agent called for cached prompt %q", p)
+		}
+	}
+	if !strings.Contains(res.Output, "C[a]") {
+		t.Errorf("cached result missing from output: %q", res.Output)
+	}
+	if !strings.Contains(res.Output, "F[b]") || !strings.Contains(res.Output, "F[c]") {
+		t.Errorf("fresh results missing from output: %q", res.Output)
+	}
+}
+
+func TestRun_ResumeScriptMismatch(t *testing.T) {
+	dir := t.TempDir()
+	j, _ := CreateJournal(dir, "wf-old", scriptHash(`agent("original")`))
+	_ = j.Close()
+
+	_, err := Run(newTestCtx(t), `agent("different")`, Options{
+		Agent:      echoAgent,
+		JournalDir: dir,
+		ResumeFrom: "wf-old",
+	})
+	if err == nil || !strings.Contains(err.Error(), "different script") {
+		t.Errorf("err = %v, want different-script error", err)
+	}
+}
+
+func TestRun_NewJournalCreatedOnResume(t *testing.T) {
+	dir := t.TempDir()
+	script := `agent("x")`
+	hash := scriptHash(script)
+
+	j, _ := CreateJournal(dir, "wf-first", hash)
+	_ = j.Append(JournalEntry{Seq: 0, Prompt: "x", Reply: "R[x]"})
+	_ = j.Close()
+
+	res, err := Run(newTestCtx(t), script, Options{
+		Agent:      echoAgent,
+		JournalDir: dir,
+		ResumeFrom: "wf-first",
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.RunID == "" || res.RunID == "wf-first" {
+		t.Errorf("RunID = %q; want a fresh run ID distinct from wf-first", res.RunID)
+	}
+	// New journal is self-contained: it must include the replayed entry.
+	entries, _, err := LoadJournal(dir, res.RunID)
+	if err != nil {
+		t.Fatalf("LoadJournal new: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Reply != "R[x]" {
+		t.Errorf("new journal entries = %v, want replayed entry", entries)
+	}
+}

--- a/internal/workflow/runtime.go
+++ b/internal/workflow/runtime.go
@@ -64,6 +64,14 @@ type Options struct {
 	Budget int64
 	// MaxConcurrent caps in-flight agent() calls; <= 0 = unlimited.
 	MaxConcurrent int
+
+	// JournalDir is the directory for workflow journal files. When empty,
+	// Run uses ~/.octo/workflow-journals/. Pass a temp dir in tests.
+	JournalDir string
+	// ResumeFrom, when non-empty, is the RunID of a prior run whose journal
+	// provides cached results for already-completed agent() calls. The script
+	// must match the original run's script exactly; a mismatch returns an error.
+	ResumeFrom string
 }
 
 // Result is a finished workflow run.
@@ -72,6 +80,10 @@ type Result struct {
 	InputTokens  int
 	OutputTokens int
 	Canceled     bool
+	// RunID identifies the journal written for this run. Pass it as
+	// Options.ResumeFrom to replay completed calls on a subsequent run.
+	// Empty when journaling is disabled or the journal directory is unavailable.
+	RunID string
 }
 
 // cancelToken is the sentinel agent_wait_any returns when ctx is canceled; the
@@ -84,7 +96,51 @@ func Run(ctx context.Context, script string, opt Options) (Result, error) {
 	if opt.Agent == nil {
 		return Result{}, fmt.Errorf("workflow: Options.Agent is required")
 	}
-	be := newBackend(ctx, opt)
+
+	hash := scriptHash(script)
+
+	// Resolve the journal directory (best-effort; journaling is non-fatal).
+	jDir := opt.JournalDir
+	if jDir == "" {
+		if d, err := journalsDir(); err == nil {
+			jDir = d
+		}
+	}
+
+	// Load cached entries from a prior run when resuming.
+	var cached []JournalEntry
+	if opt.ResumeFrom != "" {
+		if jDir == "" {
+			return Result{}, fmt.Errorf("workflow: resume_from requires a writable journal directory")
+		}
+		entries, prevHash, err := LoadJournal(jDir, opt.ResumeFrom)
+		if err != nil {
+			return Result{}, fmt.Errorf("workflow: load resume journal: %w", err)
+		}
+		if prevHash != hash {
+			return Result{}, fmt.Errorf("workflow: resume_from %q was created with a different script; omit resume_from to start fresh", opt.ResumeFrom)
+		}
+		cached = entries
+	}
+
+	// Create a fresh journal for this run. Pre-populate with the replayed
+	// entries so the new run ID is self-contained.
+	runID := NewRunID()
+	var j *Journal
+	if jDir != "" {
+		var err error
+		j, err = CreateJournal(jDir, runID, hash)
+		if err == nil && len(cached) > 0 {
+			for _, e := range cached {
+				_ = j.Append(e) // copy replayed entries; best-effort
+			}
+		}
+		if err != nil {
+			j = nil // journaling unavailable; run without it
+		}
+	}
+
+	be := newBackend(ctx, opt, cached, j)
 
 	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
 		WithCoreFeatures(api.CoreFeaturesV2|experimental.CoreFeaturesExceptionHandling))
@@ -103,8 +159,12 @@ func Run(ctx context.Context, script string, opt Options) (Result, error) {
 		WithStderr(&stderr)
 
 	_, err := r.InstantiateWithConfig(ctx, mrubyWasm, mc)
+	if j != nil {
+		_ = j.Close()
+	}
+
 	in, out := be.usage()
-	res := Result{InputTokens: in, OutputTokens: out, Canceled: be.canceled()}
+	res := Result{InputTokens: in, OutputTokens: out, Canceled: be.canceled(), RunID: runID}
 
 	if err != nil {
 		var ee *sys.ExitError
@@ -143,15 +203,24 @@ type backend struct {
 	inTok     int
 	outTok    int
 	wasCancel bool
+
+	// cached holds pre-loaded results from a resume_from journal. Tokens
+	// 1..len(cached) map to cached[tok-1]; tokens beyond that are fresh.
+	cached []JournalEntry
+	// journal, when non-nil, receives a record for every fresh (non-replayed)
+	// agent() call as it completes.
+	journal *Journal
 }
 
-func newBackend(ctx context.Context, opt Options) *backend {
+func newBackend(ctx context.Context, opt Options, cached []JournalEntry, j *Journal) *backend {
 	b := &backend{
 		ctx:     ctx,
 		opt:     opt,
 		done:    make(chan uint32, 1024),
 		results: map[uint32]AgentResult{},
 		prompts: map[uint32]string{},
+		cached:  cached,
+		journal: j,
 	}
 	if opt.MaxConcurrent > 0 {
 		b.sem = make(chan struct{}, opt.MaxConcurrent)
@@ -180,8 +249,10 @@ func (b *backend) register(ctx context.Context, r wazero.Runtime) (api.Module, e
 		Instantiate(ctx)
 }
 
-// agentStart kicks off one agent() call on a goroutine and returns its token
-// immediately (non-blocking). Returns -1 (cast) when the budget is exhausted.
+// agentStart kicks off one agent() call and returns its token immediately
+// (non-blocking). When the call maps to a cached journal entry it delivers the
+// stored result on a goroutine without invoking Agent. Returns -1 (cast) when
+// the budget is exhausted.
 func (b *backend) agentStart(_ context.Context, mod api.Module, ptr, length uint32) uint32 {
 	promptBytes, _ := mod.Memory().Read(ptr, length)
 	prompt := string(promptBytes)
@@ -193,11 +264,29 @@ func (b *backend) agentStart(_ context.Context, mod api.Module, ptr, length uint
 	}
 	b.next++
 	tok := b.next
+	seq := int(tok) - 1
 	b.prompts[tok] = prompt
 	b.mu.Unlock()
 
 	if b.opt.Progress != nil {
 		b.opt.Progress("→ " + label(prompt))
+	}
+
+	if seq < len(b.cached) {
+		// Replayed from journal: deliver without calling Agent.
+		ce := b.cached[seq]
+		go func() {
+			var res AgentResult
+			if ce.ErrMsg != "" {
+				res.Err = errors.New(ce.ErrMsg)
+			} else {
+				res.Reply = ce.Reply
+				res.InputTokens = ce.InputTokens
+				res.OutputTokens = ce.OutputTokens
+			}
+			b.deliver(tok, res)
+		}()
+		return tok
 	}
 
 	go func() {
@@ -221,7 +310,24 @@ func (b *backend) deliver(tok uint32, res AgentResult) {
 	b.results[tok] = res
 	b.inTok += res.InputTokens
 	b.outTok += res.OutputTokens
+	prompt := b.prompts[tok]
 	b.mu.Unlock()
+
+	// Journal fresh (non-replayed) calls so they can be resumed later.
+	if b.journal != nil && int(tok) > len(b.cached) {
+		e := JournalEntry{
+			Seq:          int(tok) - 1,
+			Prompt:       prompt,
+			Reply:        res.Reply,
+			InputTokens:  res.InputTokens,
+			OutputTokens: res.OutputTokens,
+		}
+		if res.Err != nil {
+			e.ErrMsg = res.Err.Error()
+		}
+		_ = b.journal.Append(e) // best-effort; a write failure doesn't break the run
+	}
+
 	b.done <- tok
 }
 


### PR DESCRIPTION
## Summary

- Every workflow run writes a JSONL journal to `~/.octo/workflow-journals/<run-id>.jsonl`
- The tool result now includes `[workflow run: wf-YYYYMMDD-HHMMSS-xxxxxxxx]` so the model can extract the run ID
- Pass that ID as `resume_from` on re-run to replay completed `agent()` calls instantly without re-running them
- Script hash (sha256) is stored in the journal meta; a mismatch returns an error before any agent runs
- New journal created on every run is self-contained: replayed entries are copied in, so you only ever need the most recent run ID

**New file:** `internal/workflow/journal.go` — Journal (mutex-safe concurrent Append), NewRunID, CreateJournal, LoadJournal, scriptHash

**Changed:**
- `runtime.go`: Options.JournalDir / ResumeFrom, Result.RunID, backend.cached/journal; agentStart short-circuits on cached seq; deliver appends fresh results
- `tools/workflow.go`: reads `resume_from` input, appends run ID footer to output
- Tests: journal round-trip, resume-skips-cached, resume-continues-from-crash, script-mismatch, self-containment

## Test plan

- [ ] `go test -race ./internal/workflow/ ./internal/tools/` passes (all green in CI)
- [ ] Run a workflow that calls `parallel(["a","b","c"]) { |it| agent(it) }`, grab the run ID from `[workflow run: ...]`, kill mid-run and re-run with `resume_from=<id>` — only un-cached agents should re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)