### PR TITLE
fix(serve): route stdio MCP subprocess stderr into structured logging

### DIFF
--- a/internal/app/mcp.go
+++ b/internal/app/mcp.go
@@ -18,6 +18,18 @@ import (
 // rather than hanging startup.
 const mcpConnectTimeout = 60 * time.Second
 
+// mcpChildStderr is the sink for stdio MCP subprocess stderr (their diagnostic
+// logging). It defaults to nil, which the transport routes to os.Stderr — fine
+// for one-shot CLI use. Long-running hosts (the server) call SetMCPChildStderr
+// to redirect it into structured logging so a child's chatter (e.g. CodeGraph's
+// "[CodeGraph MCP] Auto-synced…") doesn't interleave with the host's own output.
+var mcpChildStderr io.Writer
+
+// SetMCPChildStderr sets the destination for stdio MCP subprocess stderr across
+// every app-level connect path (ConnectMCP, SwapMCP, ConnectMCPServer*). Pass
+// nil to restore the os.Stderr default. Set it before connecting.
+func SetMCPChildStderr(w io.Writer) { mcpChildStderr = w }
+
 // ConnectMCP loads the MCP server config under cwd, connects every server
 // non-interactively, and registers the resulting surface so DefaultToolsFor /
 // the tool executor pick it up. It is the server/IM counterpart to the CLI's
@@ -40,7 +52,7 @@ func ConnectMCP(ctx context.Context, cwd string, warn io.Writer) (func(), error)
 	connectCtx, cancel := context.WithTimeout(ctx, mcpConnectTimeout)
 	defer cancel() // only bounds the connect pass; live connections aren't tied to it
 
-	reg := mcp.ConnectAll(connectCtx, cfg, mcpInfo(), nil /* no interactive OAuth */, warn, nil)
+	reg := mcp.ConnectAll(connectCtx, cfg, mcpInfo(), nil /* no interactive OAuth */, warn, mcpChildStderr)
 	if reg.Len() == 0 {
 		reg.Close()
 		return func() {}, nil
@@ -79,7 +91,7 @@ func SwapMCP(ctx context.Context, cwd string, warn io.Writer) error {
 	if cfg != nil && len(cfg.Servers) > 0 {
 		connectCtx, cancel := context.WithTimeout(ctx, mcpConnectTimeout)
 		defer cancel()
-		reg = mcp.ConnectAll(connectCtx, cfg, mcpInfo(), nil /* no interactive OAuth */, warn, nil)
+		reg = mcp.ConnectAll(connectCtx, cfg, mcpInfo(), nil /* no interactive OAuth */, warn, mcpChildStderr)
 	}
 	tools.SetMCPRegistry(reg)
 	if old != nil {
@@ -118,6 +130,12 @@ func ConnectMCPServerAuth(ctx context.Context, name string, entry mcp.ServerEntr
 	}
 	connectCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
+	// Callers that don't care about a specific sink pass nil; route those to
+	// the app-wide default (the server's slog sink) so a reconnect from the
+	// management UI doesn't leak the child's stderr to the terminal.
+	if childStderr == nil {
+		childStderr = mcpChildStderr
+	}
 	return reg.Connect(connectCtx, name, entry, mcpInfo(), prompt, childStderr)
 }
 

--- a/internal/server/mcp_log.go
+++ b/internal/server/mcp_log.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// mcpStderrWriter adapts a stdio MCP subprocess's stderr stream into structured
+// logging. Each complete line becomes one slog Debug record tagged source=mcp,
+// so a child's diagnostics (e.g. CodeGraph's "[CodeGraph MCP] Auto-synced…")
+// land in the host's log pipeline at debug level instead of interleaving with
+// the server's own stderr output. At the default info level they stay quiet;
+// OCTO_LOG_LEVEL=debug surfaces them.
+//
+// Writes arrive concurrently from every stdio server's stderr-copy goroutine,
+// so access to the line buffer is mutex-guarded.
+type mcpStderrWriter struct {
+	mu  sync.Mutex
+	buf []byte
+	log *slog.Logger
+}
+
+func newMCPStderrWriter(log *slog.Logger) *mcpStderrWriter {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &mcpStderrWriter{log: log}
+}
+
+func (w *mcpStderrWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf = append(w.buf, p...)
+	for {
+		i := bytes.IndexByte(w.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := strings.TrimRight(string(w.buf[:i]), "\r")
+		w.buf = w.buf[i+1:]
+		if strings.TrimSpace(line) != "" {
+			w.log.Debug(line, "source", "mcp")
+		}
+	}
+	return len(p), nil
+}

--- a/internal/server/mcp_log_test.go
+++ b/internal/server/mcp_log_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestMCPStderrWriter_LineBuffering verifies the writer splits incoming bytes
+// into whole lines, drops blank ones, and tags each record source=mcp — even
+// when a single logical line is delivered across multiple Write calls.
+func TestMCPStderrWriter_LineBuffering(t *testing.T) {
+	var out bytes.Buffer
+	h := slog.NewTextHandler(&out, &slog.HandlerOptions{Level: slog.LevelDebug})
+	w := newMCPStderrWriter(slog.New(h))
+
+	// A full line, a blank line (should be dropped), and a line split across
+	// two writes with no trailing newline on the first chunk.
+	_, _ = w.Write([]byte("[CodeGraph MCP] Auto-synced 1 file\n\n"))
+	_, _ = w.Write([]byte("partial "))
+	_, _ = w.Write([]byte("line done\n"))
+
+	got := out.String()
+	if !strings.Contains(got, "Auto-synced 1 file") {
+		t.Errorf("missing first line; got %q", got)
+	}
+	if !strings.Contains(got, "partial line done") {
+		t.Errorf("split line not reassembled; got %q", got)
+	}
+	if !strings.Contains(got, "source=mcp") {
+		t.Errorf("missing source=mcp tag; got %q", got)
+	}
+	// The blank line between the two newlines must not produce a record.
+	if n := strings.Count(got, "source=mcp"); n != 2 {
+		t.Errorf("expected 2 logged lines, got %d: %q", n, got)
+	}
+}
+
+// TestMCPStderrWriter_NoTrailingNewline confirms a chunk without a newline is
+// buffered (not emitted) until the line completes.
+func TestMCPStderrWriter_NoTrailingNewline(t *testing.T) {
+	var out bytes.Buffer
+	h := slog.NewTextHandler(&out, &slog.HandlerOptions{Level: slog.LevelDebug})
+	w := newMCPStderrWriter(slog.New(h))
+
+	_, _ = w.Write([]byte("incomplete"))
+	if out.Len() != 0 {
+		t.Errorf("buffered partial line should not log yet; got %q", out.String())
+	}
+	_, _ = w.Write([]byte("\n"))
+	if !strings.Contains(out.String(), "incomplete") {
+		t.Errorf("completed line not logged; got %q", out.String())
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -385,6 +385,9 @@ func (s *Server) enableMCP() {
 	if cfg, err := config.Load(); err == nil {
 		tools.SetToolSearchConfig(app.ToolSearchConfigFrom(cfg.Tools.ToolSearch))
 	}
+	// Route stdio MCP subprocess stderr into structured logging (debug level)
+	// so a child's chatter doesn't interleave with the server's own output.
+	app.SetMCPChildStderr(newMCPStderrWriter(slog.Default()))
 	s.mcpMu.Lock()
 	defer s.mcpMu.Unlock()
 	if err := app.SwapMCP(context.Background(), s.cwd, os.Stderr); err != nil {


### PR DESCRIPTION
## 问题

`octo serve` 作为 MCP 客户端连接 stdio MCP server（如 CodeGraph）。stdio MCP 协议里 stdout 走 JSON-RPC、stderr 走子进程自己的日志。而 serve 连接路径把 `childStderr` 传成 `nil`，transport 回退到 `os.Stderr` —— 于是 CodeGraph 的 `[CodeGraph MCP] Auto-synced…` 混进了 octo serve 自己的终端输出。

（截图里 `level=INFO msg="[ws] read..."` 是 serve 自己的 slog，正常；`[CodeGraph MCP]` 那些才是泄漏的子进程日志。）

## 修复

- **app**：新增 `SetMCPChildStderr`，`ConnectMCP` / `SwapMCP` / `ConnectMCPServer*` 把子进程 stderr 路由到这个 app 级 sink（传 nil 仍是 `os.Stderr`，保留一次性 CLI 行为）。
- **server**：`newMCPStderrWriter` 把子进程 stderr 按行转成 slog **Debug** 记录，带 `source=mcp` 标签；行缓冲 + mutex 保护并发的 stderr-copy goroutine。在 `enableMCP` 接线。

默认 info 级终端干净；`OCTO_LOG_LEVEL=debug` 可见，且能被 service manager 收集。

## 测试

- 单测：`mcp_log_test.go`（行缓冲、跨 Write 拼行、空行丢弃、`source=mcp` 标签）—— PASS
- 端到端实测：info 级输出干净无 CodeGraph 噪音；debug 级出现 `level=DEBUG msg="[CodeGraph MCP] File watcher active…" source=mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)