### PR TITLE
fix(web): dismiss question modal on timeout or agent context cancel

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1029,6 +1029,14 @@ func (a wsAsker) Ask(ctx context.Context, q tools.AskRequest) (tools.AskResponse
 	a.s.pendingQuestions[sessionID] = ev
 	a.s.pendingPromptMu.Unlock()
 
+	dismiss := func() {
+		a.s.wsHub.broadcast(sessionID, wsEventDismissUserQuestion{
+			Type:       "dismiss_user_question",
+			SessionID:  sessionID,
+			QuestionID: qid,
+		})
+	}
+
 	cleanup := func() {
 		a.s.questionMu.Lock()
 		delete(a.s.questionChans, qid)
@@ -1046,9 +1054,11 @@ func (a wsAsker) Ask(ctx context.Context, q tools.AskRequest) (tools.AskResponse
 		return res, nil
 	case <-ctx.Done():
 		cleanup()
+		dismiss()
 		return tools.AskResponse{Cancelled: true}, nil
 	case <-time.After(5 * time.Minute):
 		cleanup()
+		dismiss()
 		return tools.AskResponse{}, fmt.Errorf("ask_user_question: timed out waiting for user answer")
 	}
 }

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -214,6 +214,15 @@ type wsEventRequestUserQuestion struct {
 	Header      string   `json:"header,omitempty"`
 }
 
+// wsEventDismissUserQuestion tells the browser to close the question modal
+// that was opened by request_user_question. Sent when the question times out
+// or the agent context is cancelled before the user answers.
+type wsEventDismissUserQuestion struct {
+	Type       string `json:"type"`
+	SessionID  string `json:"session_id"`
+	QuestionID string `json:"question_id"`
+}
+
 type wsEventBackgroundTaskUpdate struct {
 	Type      string             `json:"type"`
 	SessionID string             `json:"session_id"`

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -329,6 +329,11 @@
       })
     }))
 
+    cleanups.push(ws.on('dismiss_user_question', (ev) => {
+      if ((ev as any).session_id && (ev as any).session_id !== sid) return
+      questionModal.set(null)
+    }))
+
     cleanups.push(ws.on('request_feedback', (ev) => {
       if ((ev as any).session_id && (ev as any).session_id !== sid) return
       feedbackModal.set({


### PR DESCRIPTION
## Problem

`ask_user_question` opens a modal via `request_user_question` WS event but never closes it when:
1. The server-side 5-minute timeout fires — agent continues, modal stays
2. The agent context is cancelled (e.g. user interrupts) — same issue

## Fix

- Added `wsEventDismissUserQuestion` (`dismiss_user_question`) WS event
- `wsAsker.Ask` broadcasts it on both the timeout and ctx-cancel exit paths (after `cleanup()`)
- `ChatView.svelte` listens for it and calls `questionModal.set(null)`

## Files

- `internal/server/ws_types.go` — new event struct
- `internal/server/server.go` — broadcast on timeout + ctx cancel
- `web/src/views/ChatView.svelte` — handle dismiss event

🤖 Generated with [Claude Code](https://claude.com/claude-code)