### PR TITLE
feat(terminal): manual sync→async promotion — Ctrl+B (TUI) + button (Web)

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -95,6 +95,14 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.quit = true
 		return m, tea.Quit
 
+	case tea.KeyCtrlB:
+		// Background the current sync terminal, if one is running.
+		// No-op when no sync terminal is polling.
+		if m.turnRunning && tools.HasActiveSync() {
+			tools.PromoteCurrentSync()
+		}
+		return m, nil
+
 	case tea.KeyCtrlC:
 		if m.turnRunning {
 			m.interrupt()
@@ -910,6 +918,9 @@ func (m *tuiModel) liveHeight() int {
 	if m.running != nil || (m.turnRunning && m.partial.Len() == 0) {
 		h++
 	}
+	if m.running != nil && tools.HasActiveSync() {
+		h++ // Ctrl+B hint line
+	}
 	if n := len(m.pendingSteer); n > 0 {
 		h += n // one line per pending steer message
 	}
@@ -980,6 +991,10 @@ func (m *tuiModel) View() string {
 	} else if m.running != nil {
 		b.WriteString(m.spinnerLine(m.running.verb+"("+m.running.target+")", m.running.start))
 		b.WriteByte('\n')
+		if tools.HasActiveSync() {
+			b.WriteString(hintStyle.Render("  [Ctrl+B] background  [Esc] kill"))
+			b.WriteByte('\n')
+		}
 	} else if m.turnRunning && m.toolStreamName != "" {
 		// The model is streaming a tool call's arguments (e.g. a large
 		// write_file body). Show a live byte counter so a multi-second argument

--- a/internal/server/ws_hub.go
+++ b/internal/server/ws_hub.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Leihb/octo-agent/internal/tools"
 	"github.com/gorilla/websocket"
 )
 
@@ -333,6 +334,13 @@ func (c *wsConn) dispatch(msgType string, raw []byte) {
 			return
 		}
 		c.hub.s.handleWSUserQuestionAnswer(msg.QuestionID, msg.Choices, msg.Custom, msg.Cancelled)
+
+	case "promote_sync_terminal":
+		var msg wsInPromoteSyncTerminal
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			return
+		}
+		tools.SessionBackgroundManager(msg.SessionID).PromoteSync()
 
 	default:
 		log.Printf("[ws] unknown message type: %q", msgType)

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -264,3 +264,9 @@ type wsEventShellPreview struct {
 	Type    string `json:"type"`
 	Command string `json:"command"`
 }
+
+// wsInPromoteSyncTerminal is sent by the browser when the user clicks the
+// "Background" button on a running terminal tool card.
+type wsInPromoteSyncTerminal struct {
+	SessionID string `json:"session_id"`
+}

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -165,6 +165,22 @@ type BgExit struct {
 	NewOutput string
 }
 
+// SyncSession is the promote handle for one in-flight synchronous terminal
+// command. Closing the channel (via Signal) unblocks the polling loop so the
+// process is promoted to a visible background task before the timer fires.
+// safe for concurrent calls (sync.Once).
+type SyncSession struct {
+	ch   chan struct{}
+	once sync.Once
+}
+
+// Signal closes the channel, unblocking any select waiting on C(). Safe to
+// call multiple times — only the first call takes effect.
+func (s *SyncSession) Signal() { s.once.Do(func() { close(s.ch) }) }
+
+// C returns the receive-only channel the terminal polling loop selects on.
+func (s *SyncSession) C() <-chan struct{} { return s.ch }
+
 // BackgroundManager owns the set of detached background processes for a
 // session. Methods are safe for concurrent use.
 type BackgroundManager struct {
@@ -172,12 +188,60 @@ type BackgroundManager struct {
 	procs  map[string]*bgProcess
 	seq    int
 	onExit func(BgExit) // optional; fired from the waiter goroutine on completion
+
+	syncMu   sync.Mutex
+	syncSess *SyncSession // non-nil while a sync terminal is polling
 }
 
 // NewBackgroundManager returns an empty manager.
 func NewBackgroundManager() *BackgroundManager {
 	return &BackgroundManager{procs: map[string]*bgProcess{}}
 }
+
+// BeginSync registers a new SyncSession for the current synchronous terminal
+// command. Call EndSync (via defer) when the command finishes or is promoted.
+// At most one sync terminal runs per manager at a time — the agent loop is
+// serial — so there is only one slot.
+func (m *BackgroundManager) BeginSync() *SyncSession {
+	s := &SyncSession{ch: make(chan struct{})}
+	m.syncMu.Lock()
+	m.syncSess = s
+	m.syncMu.Unlock()
+	return s
+}
+
+// EndSync clears the current SyncSession.
+func (m *BackgroundManager) EndSync() {
+	m.syncMu.Lock()
+	m.syncSess = nil
+	m.syncMu.Unlock()
+}
+
+// HasSync reports whether a sync terminal is currently polling.
+func (m *BackgroundManager) HasSync() bool {
+	m.syncMu.Lock()
+	defer m.syncMu.Unlock()
+	return m.syncSess != nil
+}
+
+// PromoteSync signals the current sync terminal to promote itself to a visible
+// background process. No-op if no sync terminal is running.
+func (m *BackgroundManager) PromoteSync() {
+	m.syncMu.Lock()
+	s := m.syncSess
+	m.syncMu.Unlock()
+	if s != nil {
+		s.Signal()
+	}
+}
+
+// HasActiveSync reports whether the default manager has a sync terminal polling.
+// Used by the TUI to conditionally show the Ctrl+B hint.
+func HasActiveSync() bool { return defaultBg.HasSync() }
+
+// PromoteCurrentSync signals the default manager's sync terminal to promote.
+// Called by the TUI Ctrl+B handler.
+func PromoteCurrentSync() { defaultBg.PromoteSync() }
 
 // SetOnExit registers a completion hook fired once per process when it exits,
 // carrying its final status and any output not yet read. Pass nil to clear.

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -189,16 +189,22 @@ func (t TerminalTool) ExecuteStream(
 		}
 	}
 
-	id, err := t.managerFor(ctx).Start(command, WithOnLine(onLine), WithVisible(false))
+	mgr := t.managerFor(ctx)
+	id, err := mgr.Start(command, WithOnLine(onLine), WithVisible(false))
 	if err != nil {
 		return agent.ToolResult{Text: ""}, err
 	}
 	var stdinWarn string
 	if stdinText != "" {
-		if werr := t.managerFor(ctx).WriteStdinAndClose(id, stdinText); werr != nil {
+		if werr := mgr.WriteStdinAndClose(id, stdinText); werr != nil {
 			stdinWarn = stdinWriteWarning(werr)
 		}
 	}
+
+	// Register a SyncSession so TUI (Ctrl+B) and Web ("Background" button)
+	// can promote this process before the timer fires.
+	sess := mgr.BeginSync()
+	defer mgr.EndSync()
 
 	// snapshot returns the collected output so far, tab-expanded and with the
 	// truncation marker prepended when the cap dropped earlier bytes. The
@@ -215,18 +221,25 @@ func (t TerminalTool) ExecuteStream(
 		return body + stdinWarn
 	}
 
-	// Poll until the process exits or the timeout fires.
+	// Poll until the process exits, the user promotes it, or the timeout fires.
 	timer := time.NewTimer(TerminalTimeout)
 	defer timer.Stop()
 
 	for {
 		select {
+		case <-sess.C():
+			// User promoted (Ctrl+B in TUI / button in Web): make the process
+			// visible in the background panel and return. NOT reaped.
+			mgr.Promote(id)
+			body := MaybeSpillOutput(id, snapshot())
+			return agent.ToolResult{
+				Text: fmt.Sprintf("%s\n\n[promoted to background process %s]\n\n%s", body, id, BgPollNotice),
+				UI:   terminalUI(command, "running", body),
+			}, nil
 		case <-timer.C:
-			// Timeout: promote the hidden process to visible so it shows up
-			// in the TUI "background (N running)" panel, then return. NOT
-			// reaped — it's now a real background task and its output must stay
-			// readable via terminal_output.
-			t.managerFor(ctx).Promote(id)
+			// Timer backstop: covers IM channels and forgotten browser tabs.
+			// Identical outcome to the manual promote path.
+			mgr.Promote(id)
 			body := MaybeSpillOutput(id, snapshot())
 			return agent.ToolResult{
 				Text: fmt.Sprintf("%s\n\n[timeout: command exceeded %s and continues as background process %s]\n\n%s", body, TerminalTimeout, id, BgPollNotice),
@@ -235,9 +248,9 @@ func (t TerminalTool) ExecuteStream(
 		case <-ctx.Done():
 			// User cancelled (Esc / Ctrl-C): kill the hidden process and reap
 			// it — the output is returned here and now, nothing will poll it.
-			t.managerFor(ctx).Kill(id)
+			mgr.Kill(id)
 			body := snapshot()
-			t.managerFor(ctx).Remove(id)
+			mgr.Remove(id)
 			return agent.ToolResult{
 				Text: body + "\n[exit: signal: killed]",
 				UI:   terminalUI(command, "failed", body+"\n[exit: signal: killed]"),
@@ -245,12 +258,12 @@ func (t TerminalTool) ExecuteStream(
 		default:
 		}
 
-		_, status, _, _ := t.managerFor(ctx).Read(id)
+		_, status, _, _ := mgr.Read(id)
 		if strings.HasPrefix(status, "exited") {
 			body := MaybeSpillOutput(id, snapshot())
 			// Reap the hidden process: its output has been captured and
 			// returned, so the bgProcess (and its retained buffer) can go.
-			t.managerFor(ctx).Remove(id)
+			mgr.Remove(id)
 			if status != "exited: 0" {
 				text := body + "\n[exit: " + strings.TrimPrefix(status, "exited: ") + "]"
 				return agent.ToolResult{Text: text, UI: terminalUI(command, "failed", text)}, nil

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { t } from '../../lib/i18n'
+  import { activeSessionId } from '../../lib/stores'
+  import { ws } from '../../lib/ws'
   // A collapsible group of tool calls for one agent turn.
   // Accepts optional `tools` + `streaming` props for real data;
   // falls back to static prototype content when called without props.
@@ -8,6 +10,11 @@
     tools?: any[] | null,
     streaming?: boolean,
   } = $props()
+
+  function promoteTerminal() {
+    const sid = $activeSessionId
+    if (sid) ws.promoteSyncTerminal(sid)
+  }
 
   const TOOL_ICONS: Record<string, string> = {
     grep: 'ant-design:search-outlined',
@@ -240,9 +247,14 @@
             {:else if tool.done}
               <iconify-icon icon="ant-design:check-circle-outlined" width="14" style="color:var(--success)"></iconify-icon>
             {:else}
-              <span style="display:flex;align-items:center;gap:4px;font-size:12px;color:var(--blue-6)">
+              <span style="display:flex;align-items:center;gap:6px;font-size:12px;color:var(--blue-6)">
                 <iconify-icon icon="ant-design:loading-outlined" width="13" style="animation:octo-spin 0.8s linear infinite"></iconify-icon>
                 {$t('tools.running')}
+                {#if tool.name === 'terminal' || tool.name === 'bash'}
+                  <button class="promote-btn" onclick={(e) => { e.preventDefault(); e.stopPropagation(); promoteTerminal() }}>
+                    Background
+                  </button>
+                {/if}
               </span>
             {/if}
           </span>
@@ -427,4 +439,11 @@ details[open] > summary .chev { transform: rotate(90deg); }
 .html-frame {
   border: 0; width: 100%; height: 400px; display: block; background: var(--bg-container);
 }
+.promote-btn {
+  height: 20px; padding: 0 8px;
+  border: 1px solid var(--blue-6); background: transparent;
+  border-radius: 3px; font-size: 11px; color: var(--blue-6);
+  cursor: pointer; font-family: inherit; line-height: 1;
+}
+.promote-btn:hover { background: var(--blue-1); }
 </style>

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -119,6 +119,10 @@ export class WsManager {
     });
   }
 
+  promoteSyncTerminal(sessionId: string): void {
+    this.send({ type: "promote_sync_terminal", session_id: sessionId });
+  }
+
   retry(sessionId: string): void {
     this.send({ type: "retry", session_id: sessionId });
   }


### PR DESCRIPTION
## Summary

Replaces the surprise 2-minute auto-promote with explicit user intent on TUI and Web. IM keeps the timer as its only mechanism.

- **New `SyncSession` primitive** on `BackgroundManager`: `BeginSync`/`EndSync` bracket the sync polling loop; `PromoteSync`/`HasSync` let callers signal it
- **Terminal `ExecuteStream`** adds a third `select` case `<-sess.C()` alongside the existing timer and ctx-cancel paths
- **TUI**: `Ctrl+B` calls `tools.PromoteCurrentSync()`; hint `[Ctrl+B] background  [Esc] kill` appears on the activity line only while a sync terminal is polling
- **Web**: "Background" button on running `terminal`/`bash` tool cards sends `promote_sync_terminal` over WS → `SessionBackgroundManager(sid).PromoteSync()`
- **IM**: no code changes — timer fires at 120 s as before

## Test plan

- [ ] `go test ./internal/tools/ -race` passes
- [ ] `go build ./...` clean
- [ ] TUI: run a slow command (`sleep 30`), press `Ctrl+B` before 2 min — process promoted, agent continues
- [ ] TUI: run a slow command, press `Esc` — process killed as before
- [ ] Web: run a slow command, click "Background" button on the tool card — process promoted
- [ ] IM: run a slow command — timer fires at 120 s, auto-promotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)