### PR TITLE
fix(web): tool card UI — edit_file diff, write_file preview, TS fix

### DIFF
--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -70,7 +70,24 @@ func (WriteFileTool) Execute(_ context.Context, _ string, input map[string]any) 
 	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
 		lineCount++
 	}
-	ui := map[string]any{"type": "write", "path": abs, "size_bytes": len(content)}
+
+	const previewLines = 30
+	lines := strings.Split(content, "\n")
+	preview := content
+	previewTruncated := false
+	if len(lines) > previewLines {
+		preview = strings.Join(lines[:previewLines], "\n")
+		previewTruncated = true
+	}
+
+	ui := map[string]any{
+		"type":              "write",
+		"path":              abs,
+		"size_bytes":        len(content),
+		"line_count":        lineCount,
+		"preview":           preview,
+		"preview_truncated": previewTruncated,
+	}
 	if memory.IsMemoryPath(abs) {
 		memCount := memory.CountMemories(content)
 		return agent.ToolResult{Text: fmt.Sprintf("Saved %d %s to %s", memCount, pluralize(memCount, "memory", "memories"), filepath.Base(abs)), UI: ui}, nil

--- a/web/node_modules
+++ b/web/node_modules
@@ -1,1 +1,0 @@
-/Users/roy.lei/Projects/github/octo-agent/web/node_modules

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -113,14 +113,18 @@
         return out ? `${nonEmptyLines(out)} lines` : ''
       }
       case 'edit_file': {
-        if (!tool.diff) return ''
-        const changes = tool.diff.split('\n').filter((l: string) => l.startsWith('+') || l.startsWith('-')).length
+        const diff = tool.ui_payload?.diff
+        if (!diff) return ''
+        const changes = diff.split('\n').filter((l: string) => l.startsWith('+') || l.startsWith('-')).length
         return changes ? `${changes} changes` : ''
       }
       case 'write_file': {
-        const bytes = res ? new Blob([res]).size : 0
-        if (!bytes) return ''
-        return bytes < 1024 ? `${bytes} B` : `${(bytes / 1024).toFixed(1)} KB`
+        const p = tool.ui_payload
+        if (!p) return ''
+        const lines = p.line_count ? `${p.line_count} lines` : ''
+        const b = p.size_bytes ?? 0
+        const bytes = b < 1024 ? `${b} B` : `${(b / 1024).toFixed(1)} KB`
+        return [lines, bytes].filter(Boolean).join(' · ')
       }
       default: return ''
     }
@@ -269,9 +273,9 @@
               </div>
             {/each}
           </div>
-        {:else if tool.diff}
+        {:else if tool.ui_payload?.diff}
           <div class="diff-block">
-            {#each tool.diff.split('\n') as line}
+            {#each tool.ui_payload.diff.split('\n') as line}
               {#if line.startsWith('@@')}
                 <div class="diff-hdr mono">{line}</div>
               {:else if line.startsWith('-')}
@@ -317,6 +321,16 @@
           <div class="html-frame-wrap">
             {#if hp && hp.meta}<div class="fetch-meta mono">{hp.meta}</div>{/if}
             <iframe srcdoc={hp?.html} sandbox="" class="html-frame" title="fetched page"></iframe>
+          </div>
+        {:else if tool.name === 'write_file' && tool.ui_payload?.preview != null}
+          <div class="term-wrap">
+            <pre class="tool-output">{tool.ui_payload.preview}</pre>
+            {#if tool.ui_payload.preview_truncated}
+              <div class="fold-info">
+                <iconify-icon icon="lucide:chevron-down" width="13"></iconify-icon>
+                {tool.ui_payload.line_count - 30} more lines
+              </div>
+            {/if}
           </div>
         {:else if tool.result}
           {@const pretty = prettyResult(tool.result)}
@@ -379,6 +393,11 @@ details[open] > summary .chev { transform: rotate(90deg); }
   gap: 6px; font-size: 12px; color: var(--blue-6); cursor: pointer; font-family: inherit;
 }
 .fold-btn:hover { background: var(--active-blue-bg); }
+.fold-info {
+  width: 100%; padding: 8px 12px; border-top: 1px solid var(--border-table);
+  background: var(--bg-table-header); display: flex; align-items: center; justify-content: center;
+  gap: 6px; font-size: 12px; color: var(--text-tertiary); font-family: inherit;
+}
 .term-prompt { color: var(--success); }
 .search-results {
   border-top: 1px solid var(--border-table); padding: 10px 14px;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Session, Skill, ScheduledTask, McpServer, Channel, Memory, RecallFile } from './types'
+import type { Session, Skill, ScheduledTask, McpServer, Channel, Memory, RecallFile, TagStatus } from './types'
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(path, init)
@@ -105,7 +105,7 @@ export async function listSkills(): Promise<Skill[]> {
   return (d.skills ?? []).map((s): Skill => {
     // Server source is "default" (built-in/system) | "project" | "user".
     const src = s.source ?? 'user'
-    const tag = src === 'project'
+    const tag: { tagStatus: TagStatus; tagLabel: string } = src === 'project'
       ? { tagStatus: 'info', tagLabel: 'Project' }
       : src === 'default'
         ? { tagStatus: 'default', tagLabel: 'System' }


### PR DESCRIPTION
## Summary

- **edit_file**: 展开后显示 diff（红 `-` / 绿 `+`），header meta 显示 `N changes`（之前 `tool.diff` 读错了字段，应为 `tool.ui_payload?.diff`）
- **write_file**: Go 侧 `ui_payload` 新增 `line_count` / `preview` / `preview_truncated`；前端展开后显示前 30 行预览 + 截断提示；header meta 从 `ui_payload` 读真实文件大小（之前计算的是结果摘要字符串的字节数）
- **TS fix**: `api.ts` 中 `tag.tagStatus` 推断为 `string`，加类型注解修复

## Test plan

- [ ] `edit_file` 执行后展开卡片，确认显示 diff 块而不是纯文本
- [ ] `write_file` 写入大文件后展开卡片，确认前 30 行预览 + `N more lines` 提示
- [ ] header meta 显示 `264 lines · 11.3 KB` 格式
- [ ] `npx tsc --noEmit` 0 错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)