### PR TITLE
feat(serve): built-in daemon mode — -d / --stop / --status

### DIFF
--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -46,8 +46,22 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	noChannel := fs.Bool("no-channel", false, "Disable IM channel (DingTalk, Feishu)")
 	noMemory := fs.Bool("no-memory", false, "Disable cross-session memory injection")
 	noSupervisor := fs.Bool("no-supervisor", false, "Run the server directly, without the self-restart supervisor (exit code 42 still signals a restart request to an external supervisor)")
+	daemon := fs.Bool("d", false, "Run as a background daemon (writes pid to ~/.octo/serve.pid, logs to ~/.octo/serve.log)")
+	fs.BoolVar(daemon, "daemon", false, "Run as a background daemon")
+	stop := fs.Bool("stop", false, "Stop the background daemon")
+	status := fs.Bool("status", false, "Show daemon status")
 	if err := fs.Parse(args); err != nil {
 		return 2
+	}
+
+	if *stop {
+		return stopDaemon(stdout, stderr)
+	}
+	if *status {
+		return statusDaemon(stdout, stderr)
+	}
+	if *daemon {
+		return startDaemon(filterDaemonFlags(args), stdout, stderr)
 	}
 
 	if shouldSupervise(*noSupervisor, os.Getenv(serveWorkerEnv)) {

--- a/cmd/octo/serve_daemon.go
+++ b/cmd/octo/serve_daemon.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// daemonPidFile returns the path of the daemon PID file, creating ~/.octo if needed.
+func daemonPidFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".octo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "serve.pid"), nil
+}
+
+// daemonLogFile returns the path of the daemon log file, creating ~/.octo if needed.
+func daemonLogFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".octo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "serve.log"), nil
+}
+
+// readPidFile reads an integer PID from path.
+func readPidFile(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	var pid int
+	if _, err := fmt.Sscan(strings.TrimSpace(string(data)), &pid); err != nil {
+		return 0, fmt.Errorf("invalid pid file: %w", err)
+	}
+	return pid, nil
+}
+
+// writePidFile writes pid to path.
+func writePidFile(path string, pid int) error {
+	return os.WriteFile(path, []byte(fmt.Sprintf("%d\n", pid)), 0o644)
+}
+
+// startDaemon re-execs the current binary as a detached background process,
+// writes its PID, and returns immediately. serveArgs must not contain -d/--daemon.
+func startDaemon(serveArgs []string, stdout, stderr io.Writer) int {
+	pidFile, err := daemonPidFile()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo serve: daemon: %v\n", err)
+		return 1
+	}
+
+	// Refuse to start a second daemon if one is already running.
+	if pid, err := readPidFile(pidFile); err == nil && isProcessAlive(pid) {
+		fmt.Fprintf(stderr, "octo serve: daemon already running (pid %d)\n", pid)
+		return 1
+	}
+	_ = os.Remove(pidFile) // remove stale pid file if present
+
+	logPath, err := daemonLogFile()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo serve: daemon: %v\n", err)
+		return 1
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		fmt.Fprintf(stderr, "octo serve: daemon: open log: %v\n", err)
+		return 1
+	}
+	defer logFile.Close()
+
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo serve: daemon: %v\n", err)
+		return 1
+	}
+
+	// The child runs as the supervisor (no --no-supervisor), logging to logFile.
+	// We pass --no-supervisor so the child IS the top-level process we track via
+	// the pid file — it owns its own worker subprocess internally via the
+	// existing supervisor loop.  Passing the args as-is (minus -d) is correct:
+	// the child's own supervisor will spawn a grandchild worker.
+	cmd := exec.Command(exe, append([]string{"serve"}, serveArgs...)...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.Stdin = nil
+	setSysProcAttrDetach(cmd) // platform-specific: detach from terminal
+
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(stderr, "octo serve: daemon: start: %v\n", err)
+		return 1
+	}
+
+	pid := cmd.Process.Pid
+	if err := writePidFile(pidFile, pid); err != nil {
+		fmt.Fprintf(stderr, "octo serve: daemon: write pid: %v\n", err)
+		_ = cmd.Process.Kill()
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "octo serve daemon started (pid %d)\n", pid)
+	fmt.Fprintf(stdout, "logs: %s\n", logPath)
+	return 0
+}
+
+// stopDaemon reads the PID file and terminates the daemon process.
+func stopDaemon(stdout, stderr io.Writer) int {
+	pidFile, err := daemonPidFile()
+	if err != nil {
+		fmt.Fprintf(stderr, "octo serve: %v\n", err)
+		return 1
+	}
+	pid, err := readPidFile(pidFile)
+	if err != nil {
+		fmt.Fprintf(stderr, "octo serve: daemon not running\n")
+		return 1
+	}
+	if !isProcessAlive(pid) {
+		fmt.Fprintf(stderr, "octo serve: daemon not running (stale pid %d)\n", pid)
+		_ = os.Remove(pidFile)
+		return 1
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		fmt.Fprintf(stderr, "octo serve: find process: %v\n", err)
+		return 1
+	}
+	if err := terminateProcess(proc); err != nil {
+		fmt.Fprintf(stderr, "octo serve: stop: %v\n", err)
+		return 1
+	}
+	_ = os.Remove(pidFile)
+	fmt.Fprintf(stdout, "octo serve daemon stopped (pid %d)\n", pid)
+	return 0
+}
+
+// statusDaemon reports whether the daemon is running.
+func statusDaemon(stdout, _ io.Writer) int {
+	pidFile, err := daemonPidFile()
+	if err != nil || func() bool { _, e := os.Stat(pidFile); return e != nil }() {
+		fmt.Fprintln(stdout, "octo serve daemon: not running")
+		return 0
+	}
+	pid, err := readPidFile(pidFile)
+	if err != nil {
+		fmt.Fprintln(stdout, "octo serve daemon: not running")
+		return 0
+	}
+	if isProcessAlive(pid) {
+		fmt.Fprintf(stdout, "octo serve daemon: running (pid %d)\n", pid)
+	} else {
+		fmt.Fprintf(stdout, "octo serve daemon: dead (stale pid %d)\n", pid)
+		_ = os.Remove(pidFile)
+	}
+	return 0
+}
+
+// filterDaemonFlags strips -d / --daemon from the arg list before passing it
+// to the detached child so the child doesn't try to daemonize again.
+func filterDaemonFlags(args []string) []string {
+	out := make([]string, 0, len(args))
+	for _, a := range args {
+		if a == "-d" || a == "--daemon" || a == "-daemon" {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}

--- a/cmd/octo/serve_daemon_posix.go
+++ b/cmd/octo/serve_daemon_posix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// setSysProcAttrDetach creates a new session so the child is not attached to
+// the parent's controlling terminal. The child becomes its own session leader.
+func setSysProcAttrDetach(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+// isProcessAlive sends signal 0 to the process — this checks whether the
+// process exists without disturbing it.
+func isProcessAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+// terminateProcess sends SIGTERM for a graceful shutdown.
+func terminateProcess(proc *os.Process) error {
+	return proc.Signal(syscall.SIGTERM)
+}

--- a/cmd/octo/serve_daemon_windows.go
+++ b/cmd/octo/serve_daemon_windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// detachedProcess tells Windows to create the child without inheriting the
+// parent's console. Combined with stdout/stderr redirected to a log file, the
+// process runs silently in the background with no terminal window.
+const detachedProcess = 0x00000008
+
+// setSysProcAttrDetach creates the child as a detached process so it does not
+// inherit the parent console and does not receive Ctrl-C signals sent to the
+// terminal.
+func setSysProcAttrDetach(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: detachedProcess,
+	}
+}
+
+// isProcessAlive opens the process with PROCESS_QUERY_LIMITED_INFORMATION and
+// calls GetExitCodeProcess; a return code of STILL_ACTIVE (259) means the
+// process is alive.
+func isProcessAlive(pid int) bool {
+	const processQueryLimitedInformation = 0x1000
+	const stillActive = 259
+	handle, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer syscall.CloseHandle(handle)
+	var code uint32
+	if err := syscall.GetExitCodeProcess(handle, &code); err != nil {
+		return false
+	}
+	return code == stillActive
+}
+
+// terminateProcess kills the process. Windows has no SIGTERM equivalent that
+// provides a graceful shutdown via the standard API, so we use Kill which
+// sends WM_CLOSE / TerminateProcess. The server's graceful shutdown on
+// interrupt is still reachable via /api/restart or the web UI stop button.
+func terminateProcess(proc *os.Process) error {
+	return proc.Kill()
+}


### PR DESCRIPTION
## Summary

三平台统一的 daemon 模式，不再依赖 launchd/systemd 手动配置。

- `octo serve -d` / `--daemon` — 以后台 daemon 启动，父进程立即退出
  - PID 写入 `~/.octo/serve.pid`
  - 日志追加写入 `~/.octo/serve.log`
  - 内部仍走现有 supervisor 循环（exit 42 自动重启保留）
- `octo serve --stop` — 读 pid 文件，优雅终止 daemon
- `octo serve --status` — 显示 daemon 是否运行及 PID

**平台实现**
| 平台 | 文件 | 脱终端方式 | 进程存活检测 | 终止方式 |
|------|------|-----------|-------------|---------|
| macOS/Linux | `serve_daemon_posix.go` | `Setsid: true` | `kill -0` | `SIGTERM` |
| Windows | `serve_daemon_windows.go` | `DETACHED_PROCESS` | `OpenProcess` + `GetExitCodeProcess` | `TerminateProcess` |

## Test plan

- [x] `octo serve -d --addr :18080` → 打印 pid 和日志路径，父进程退出
- [x] `octo serve --status` → `running (pid N)`
- [x] `octo serve --stop` → `stopped (pid N)`
- [x] `octo serve --status` → `not running`
- [x] `go test ./cmd/octo/` 全绿
- [ ] Windows 编译验证（CI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)