### PR TITLE
fix(tui,webui): make showReasoning config actually control thinking display

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -770,6 +770,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			reasoningEffort: resolvedEffort,
 			providerName:    provName,
 			configEntry:     entry,
+			showReasoning:   resolvedShowReasoning,
 		}
 		if toolsOn {
 			// Built-ins only at first paint — the MCP registry is still nil

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -66,6 +66,10 @@ type replConfig struct {
 	// configEntry is the config entry the session resolved at startup; sender
 	// rebuilds (e.g. /thinking) anchor base URL and stored key on it.
 	configEntry config.ModelEntry
+	// showReasoning controls whether the reasoning/thinking trace is displayed
+	// in the TUI (when true) or suppressed (when false). Mirrors the --show-reasoning
+	// flag and config file setting.
+	showReasoning bool
 }
 
 // mcpBootstrap carries the inputs runTUI needs to connect MCP servers from a

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -364,6 +364,12 @@ type tuiModel struct {
 	// line instead of stacking them edge-to-edge.
 	lastPrintBlank bool
 
+	// assistantFirstBlock is true from the start of a turn until the first
+	// assistant text block is committed to the scrollback. Used to prepend
+	// the ◆ indicator so the assistant's prose is visually anchored like the
+	// "> " prefix is for user messages.
+	assistantFirstBlock bool
+
 	// historyReplayed guards the one-time replay of a resumed session's prior
 	// turns into the scrollback. Done on the first WindowSizeMsg so markdown
 	// wraps to the real terminal width rather than the Init-time fallback.
@@ -599,6 +605,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleKey(msg)
 
 	case turnStartedMsg:
+		m.assistantFirstBlock = true
 		return m, m.flushPrints()
 
 	case tickMsg:
@@ -1172,6 +1179,10 @@ func (m *tuiModel) appendText(text string) {
 		complete := buf[:idx]
 		m.partial.Reset()
 		m.partial.WriteString(buf[idx+1:])
+		if m.assistantFirstBlock {
+			complete = assistantPrefixStyle.Render("◆ ") + complete
+			m.assistantFirstBlock = false
+		}
 		m.println(complete)
 		return
 	}
@@ -1182,7 +1193,12 @@ func (m *tuiModel) appendText(text string) {
 	}
 	m.partial.Reset()
 	m.partial.WriteString(rest)
-	m.printlnBlock(m.md.render(commit, m.width))
+	rendered := m.md.render(commit, m.width)
+	if m.assistantFirstBlock {
+		rendered = injectAssistantPrefix(rendered, assistantPrefixStyle.Render("◆ "))
+		m.assistantFirstBlock = false
+	}
+	m.printlnBlock(rendered)
 }
 
 // flushText commits whatever assistant text is still buffered (the final or
@@ -1207,9 +1223,18 @@ func (m *tuiModel) flushTextString() (string, bool) {
 	}
 	m.partial.Reset()
 	if m.cfg.plain {
+		if m.assistantFirstBlock {
+			p = assistantPrefixStyle.Render("◆ ") + p
+			m.assistantFirstBlock = false
+		}
 		return p, true
 	}
-	return m.md.render(p, m.width), true
+	rendered := m.md.render(p, m.width)
+	if m.assistantFirstBlock {
+		rendered = injectAssistantPrefix(rendered, assistantPrefixStyle.Render("◆ "))
+		m.assistantFirstBlock = false
+	}
+	return rendered, true
 }
 
 // commitToolLine flushes any in-progress text to the scrollback, then appends

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -318,6 +318,14 @@ type tuiModel struct {
 	// fully-completed list (normally hidden once nothing is outstanding).
 	showTasks bool
 
+	// showReasoning controls whether the reasoning/thinking trace is displayed
+	// in the live area (when true) or suppressed (when false). When false,
+	// thinking deltas still feed the live activity line's token count.
+	showReasoning bool
+	// thinkingPartial accumulates the reasoning trace when showReasoning is
+	// true, rendered dimmed in the live area above the normal partial text.
+	thinkingPartial strings.Builder
+
 	width int
 	quit  bool
 
@@ -457,7 +465,7 @@ func newTUIModel(cfg replConfig) *tuiModel {
 	if !tui.IsDark() {
 		style = "light"
 	}
-	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}, subAgentFocus: -1}
+	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}, subAgentFocus: -1, showReasoning: cfg.showReasoning}
 	_ = m.updateTextAreaHeight()
 	return m
 }
@@ -916,9 +924,13 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 	m.commitEcho()
 	switch ev.Kind {
 	case agent.EventThinkingDelta:
-		// The reasoning trace stays out of the scrollback; only its size feeds
-		// the live activity line's token readout.
+		// When showReasoning is true, the thinking trace is streamed to the
+		// live area (dimmed, like the plain REPL). When false, it stays out
+		// of the live area and only feeds the activity line's token readout.
 		m.turnOutChars += len(ev.Text)
+		if m.showReasoning {
+			m.thinkingPartial.WriteString(ev.Text)
+		}
 		return
 
 	case agent.EventToolInputDelta:
@@ -1286,6 +1298,7 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 	m.turnRunning = false
 	m.cancelTurn = nil
 	m.running = nil // clear any live tool indicator (e.g. on interrupt)
+	m.thinkingPartial.Reset()
 
 	// Any steer messages that weren't drained via EventSteerInjected during
 	// the turn (e.g. typed after the last loop iteration) are printed now so

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -682,3 +682,26 @@ func TestTUI_SubmitSavesToHistory(t *testing.T) {
 		t.Errorf("history after new line = %v, want [hello world]", m.inputHistory)
 	}
 }
+
+// When showReasoning is true, thinking deltas are rendered in the live area
+// (dimmed) instead of being suppressed.
+func TestTUI_ThinkingShownWhenEnabled(t *testing.T) {
+	m := newTestModel()
+	m.showReasoning = true
+	m.turnRunning = true
+
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: "let me think"})
+
+	// Thinking should not reach scrollback (printlnBuf) — it's live-only.
+	if joined := strings.Join(m.printlnBuf, "\n"); joined != "" {
+		t.Fatalf("thinking must not reach the scrollback; got %q", joined)
+	}
+	// But it should appear in the live View.
+	out := m.View()
+	if !strings.Contains(out, "let me think") {
+		t.Errorf("view should contain thinking text when showReasoning=true; got:\n%s", out)
+	}
+	if m.turnOutChars != 12 {
+		t.Errorf("turnOutChars = %d, want 12", m.turnOutChars)
+	}
+}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -28,20 +28,21 @@ func min(a, b int) int {
 }
 
 var (
-	promptStyle       = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
-	noticeStyle       = lipgloss.NewStyle().Foreground(tui.ColMuted)
-	errorStyle        = lipgloss.NewStyle().Foreground(tui.ColDanger)
-	toolErrStyle      = lipgloss.NewStyle().Foreground(tui.ColDanger)
-	queueStyle        = lipgloss.NewStyle().Foreground(tui.ColAccent)
-	modalStyle        = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
-	hintStyle         = lipgloss.NewStyle().Foreground(tui.ColDimmer).Italic(true)
-	activityStyle     = lipgloss.NewStyle().Foreground(tui.ColBrand)
+	promptStyle          = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	noticeStyle          = lipgloss.NewStyle().Foreground(tui.ColMuted)
+	errorStyle           = lipgloss.NewStyle().Foreground(tui.ColDanger)
+	toolErrStyle         = lipgloss.NewStyle().Foreground(tui.ColDanger)
+	queueStyle           = lipgloss.NewStyle().Foreground(tui.ColAccent)
+	modalStyle           = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	hintStyle            = lipgloss.NewStyle().Foreground(tui.ColDimmer).Italic(true)
+	activityStyle        = lipgloss.NewStyle().Foreground(tui.ColBrand)
 	userEchoStyle        = lipgloss.NewStyle().Foreground(tui.ColUserMsg).Bold(true)
 	assistantPrefixStyle = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
-	pendingSteerStyle = lipgloss.NewStyle().Foreground(tui.ColMuted)
-	complSelStyle     = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
-	complNameStyle    = lipgloss.NewStyle().Foreground(tui.ColAccent)
-	bgDoneStyle       = lipgloss.NewStyle().Foreground(tui.ColAccent)
+	pendingSteerStyle    = lipgloss.NewStyle().Foreground(tui.ColMuted)
+	complSelStyle        = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	complNameStyle       = lipgloss.NewStyle().Foreground(tui.ColAccent)
+	bgDoneStyle          = lipgloss.NewStyle().Foreground(tui.ColAccent)
+	thinkingStyle        = lipgloss.NewStyle().Foreground(tui.ColDimmer).Italic(true)
 )
 
 func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -734,7 +735,7 @@ func (m *tuiModel) dispatchThinking(level string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	tuning := senderTuning{}
+	tuning := senderTuning{showReasoning: m.cfg.showReasoning}
 	if level != "off" {
 		tuning.reasoningEffort = level
 		tuning.thinkingBudget = anthropicThinkingBudget(level)
@@ -916,7 +917,10 @@ func (m *tuiModel) liveHeight() int {
 	if m.partial.String() != "" {
 		h++
 	}
-	if m.running != nil || (m.turnRunning && m.partial.Len() == 0) {
+	if m.thinkingPartial.String() != "" {
+		h++
+	}
+	if m.running != nil || (m.turnRunning && m.partial.Len() == 0 && m.thinkingPartial.Len() == 0) {
 		h++
 	}
 	if m.running != nil && tools.HasActiveSync() {
@@ -967,6 +971,12 @@ func (m *tuiModel) View() string {
 		b.WriteByte('\n')
 	}
 
+	// Live thinking trace (shown when showReasoning is true).
+	if t := m.thinkingPartial.String(); t != "" {
+		b.WriteString(thinkingStyle.Render("💭 " + t))
+		b.WriteByte('\n')
+	}
+
 	// Live partial assistant text
 	if p := m.partial.String(); p != "" {
 		rendered := m.md.render(p, m.width)
@@ -1008,7 +1018,7 @@ func (m *tuiModel) View() string {
 		label := fmt.Sprintf("%s… %s", streamVerbFor(m.toolStreamName), humanByteSize(m.toolStreamBytes))
 		b.WriteString(m.spinnerLine(label, m.turnStart))
 		b.WriteByte('\n')
-	} else if m.turnRunning && m.partial.Len() == 0 {
+	} else if m.turnRunning && m.partial.Len() == 0 && m.thinkingPartial.Len() == 0 {
 		// Turn is running but nothing is on the activity line right now — no
 		// live tool and no streaming text. That's the wait on the model
 		// (initial prompt, or between steps after a tool result). Show the

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -36,7 +36,8 @@ var (
 	modalStyle        = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
 	hintStyle         = lipgloss.NewStyle().Foreground(tui.ColDimmer).Italic(true)
 	activityStyle     = lipgloss.NewStyle().Foreground(tui.ColBrand)
-	userEchoStyle     = lipgloss.NewStyle().Foreground(tui.ColUserMsg).Bold(true)
+	userEchoStyle        = lipgloss.NewStyle().Foreground(tui.ColUserMsg).Bold(true)
+	assistantPrefixStyle = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
 	pendingSteerStyle = lipgloss.NewStyle().Foreground(tui.ColMuted)
 	complSelStyle     = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
 	complNameStyle    = lipgloss.NewStyle().Foreground(tui.ColAccent)
@@ -968,7 +969,11 @@ func (m *tuiModel) View() string {
 
 	// Live partial assistant text
 	if p := m.partial.String(); p != "" {
-		b.WriteString(m.md.render(p, m.width))
+		rendered := m.md.render(p, m.width)
+		if m.assistantFirstBlock {
+			rendered = injectAssistantPrefix(rendered, assistantPrefixStyle.Render("◆ "))
+		}
+		b.WriteString(rendered)
 		b.WriteByte('\n')
 	}
 
@@ -1319,4 +1324,24 @@ func (m *tuiModel) thinkingLine() string {
 		hintStyle.Render(string(frame)),
 		activityStyle.Render(phrase+"…"),
 		hintStyle.Render("("+meta+")"))
+}
+
+// injectAssistantPrefix inserts prefix just before the first non-space content
+// character in rendered, skipping any leading newlines glamour may prepend.
+// This aligns ◆ at the left edge, mirroring how "> " anchors user messages.
+func injectAssistantPrefix(rendered, prefix string) string {
+	// Skip leading newlines (glamour block margin), then leading spaces
+	// (glamour paragraph indent) on the first content line.
+	i := 0
+	for i < len(rendered) && rendered[i] == '\n' {
+		i++
+	}
+	j := i
+	for j < len(rendered) && rendered[j] == ' ' {
+		j++
+	}
+	if j >= len(rendered) {
+		return rendered // blank output — don't inject
+	}
+	return rendered[:i] + prefix + rendered[j:]
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -904,11 +904,16 @@ func senderForEntry(entry config.ModelEntry) (agent.Sender, error) {
 	if apiKey == "" {
 		return nil, fmt.Errorf("no API key for entry %q (provider %q)", entry.Name, entry.Provider)
 	}
+	showReasoning := true
+	if entry.ShowReasoning != nil {
+		showReasoning = *entry.ShowReasoning
+	}
 	return app.NewSender(app.SenderOptions{
 		Provider:        entry.Provider,
 		APIKey:          apiKey,
 		BaseURL:         entry.BaseURL,
 		ReasoningEffort: entry.ReasoningEffort,
+		ShowReasoning:   showReasoning,
 	})
 }
 


### PR DESCRIPTION
The `showReasoning` config flag existed in config/onboard and the `--show-reasoning` CLI flag, but it was only respected by the plain REPL. Both TUI and WebUI ignored it.

**WebUI**: `senderForEntry()` never passed `ShowReasoning` to `app.NewSender`, so the provider always surfaced thinking and the frontend always displayed it.

**TUI**: `EventThinkingDelta` was always discarded (design intent for 'denoised' mode), so even with `showReasoning=true` the trace was invisible.

### Changes
- WebUI server: `senderForEntry()` now reads `entry.ShowReasoning` and passes it to `app.NewSender` (defaults to true when unset).
- TUI: `replConfig` gains `showReasoning`; `tuiModel` gains `showReasoning` and `thinkingPartial` fields. When `showReasoning=true`, thinking deltas accumulate in `thinkingPartial` and render dimmed (💭 prefix) in the live area above the normal partial text.
- TUI `/thinking` command: preserves `showReasoning` when rebuilding sender.
- TUI liveHeight/View: account for `thinkingPartial` height and suppress the generic spinner when thinking text is being displayed.
- Add test `TestTUI_ThinkingShownWhenEnabled`.