### PR TITLE
fix(tui): remove double blank spacing + grep blank-line filter

### DIFF
--- a/cmd/octo/markdown.go
+++ b/cmd/octo/markdown.go
@@ -44,7 +44,7 @@ func (m *markdownRenderer) render(src string, width int) string {
 	if err != nil {
 		return strings.TrimRight(src, "\n")
 	}
-	return strings.TrimRight(out, "\n")
+	return strings.Trim(out, "\n")
 }
 
 // splitCommittableMarkdown splits a streamed assistant buffer into the prefix

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1336,22 +1336,13 @@ func (m *tuiModel) thinkingLine() string {
 		hintStyle.Render("("+meta+")"))
 }
 
-// injectAssistantPrefix inserts prefix just before the first non-space content
-// character in rendered, skipping any leading newlines glamour may prepend.
-// This aligns ◆ at the left edge, mirroring how "> " anchors user messages.
+// injectAssistantPrefix strips glamour's 2-space paragraph indent from the
+// first line and prepends prefix so ◆ aligns at column 0, mirroring "> ".
+// Leading newlines are already trimmed by markdownRenderer.render.
 func injectAssistantPrefix(rendered, prefix string) string {
-	// Skip leading newlines (glamour block margin), then leading spaces
-	// (glamour paragraph indent) on the first content line.
-	i := 0
-	for i < len(rendered) && rendered[i] == '\n' {
-		i++
+	trimmed := strings.TrimLeft(rendered, " ")
+	if trimmed == "" {
+		return rendered
 	}
-	j := i
-	for j < len(rendered) && rendered[j] == ' ' {
-		j++
-	}
-	if j >= len(rendered) {
-		return rendered // blank output — don't inject
-	}
-	return rendered[:i] + prefix + rendered[j:]
+	return prefix + trimmed
 }

--- a/internal/tui/outputcard.go
+++ b/internal/tui/outputcard.go
@@ -29,7 +29,15 @@ func RenderOutputCard(verb, target, output string, maxLines int, isErr bool, lan
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("%s %s", bullet, headerVerb.Render(fmt.Sprintf("%s(%s)", verb, target))))
 
-	lines := splitLinesNoTrail(output)
+	all := splitLinesNoTrail(output)
+	// Blank lines waste preview slots without adding information; filter them
+	// out so the cap applies to meaningful content only.
+	lines := all[:0]
+	for _, l := range all {
+		if strings.TrimSpace(l) != "" {
+			lines = append(lines, l)
+		}
+	}
 	if len(lines) == 0 {
 		b.WriteString("\n  " + outGutter.String() + " " + outMore.Render("(no output)"))
 		return b.String()


### PR DESCRIPTION
## Summary

两个 TUI 间距 bug：

**1. assistant 消息每段之间有两个空行**
- 原因：glamour 在段落首部添加 `\n`，`printlnBlock` 自己也加了一个 blank separator，叠加成两个空行
- 修复：`markdownRenderer.render` 改为 `strings.Trim(out, "\n")`（同时裁两端），让 `printlnBlock` 的分隔符是唯一的空行
- 同步简化 `injectAssistantPrefix` — leading `\n` 已不存在

**2. grep card 显示大量空白**
- 原因：grep 输出含空行，`RenderOutputCard` 把空行当作 preview slot，card 前几行全是空白
- 修复：`RenderOutputCard` 先过滤 whitespace-only 行，再应用 `maxLines` 上限，`… +N lines` 只计非空行

## Test plan

- [ ] assistant 多段落回复：段落间只有 1 个空行
- [ ] grep 有空白行输出时 card 只显示有内容的行
- [ ] `go test ./cmd/octo/ ./internal/tui/` 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)