### PR TITLE
fix(test): eliminate Windows flaky TestWireBackgroundTaskNotices_BroadcastsExit

### DIFF
--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -87,12 +87,17 @@ func TestWireBackgroundTaskNotices_BroadcastsExit(t *testing.T) {
 
 	srv.wireBackgroundTaskNotices(sid)
 
-	if _, err := tools.SessionBackgroundManager(sid).Start("echo done"); err != nil {
-		t.Fatalf("start: %v", err)
-	}
+	// Trigger the exit hook directly rather than starting a real shell process.
+	// A real process requires PowerShell on Windows (slow startup, flaky on CI).
+	// wireBackgroundTaskNotices is what we're testing here — not the shell.
+	tools.SessionBackgroundManager(sid).FireExitHook(tools.BgExit{
+		ID:      "bg_1",
+		Command: "echo done",
+		Status:  "exited: 0",
+	})
 
 	var gotNotice, gotUpdate bool
-	deadline := time.After(5 * time.Second)
+	deadline := time.After(3 * time.Second)
 	for !(gotNotice && gotUpdate) {
 		select {
 		case b := <-conn.send:

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -255,6 +255,18 @@ func (m *BackgroundManager) SetOnExit(fn func(BgExit)) {
 	m.mu.Unlock()
 }
 
+// FireExitHook calls the onExit hook directly with e, as if a tracked process
+// had just exited. No-op when no hook is registered. Used in tests to trigger
+// the notification path without starting a real shell process.
+func (m *BackgroundManager) FireExitHook(e BgExit) {
+	m.mu.Lock()
+	hook := m.onExit
+	m.mu.Unlock()
+	if hook != nil {
+		hook(e)
+	}
+}
+
 // StartOption is a functional option for BackgroundManager.Start.
 type StartOption func(*bgProcess)
 


### PR DESCRIPTION
## Summary

`TestWireBackgroundTaskNotices_BroadcastsExit` 在 Windows CI 上偶发超时（5.77s > 5s deadline），根因是测试启动真实 PowerShell 进程（`echo done`），冷启动在 CI runner 上超时。

**修复**：`BackgroundManager` 新增 `FireExitHook(BgExit)` — 直接调用 onExit 回调，无需 shell 进程。测试改用该方法，只测试 `wireBackgroundTaskNotices` 的 hook wiring，与 shell 启动速度解耦。

- 测试时间：5s+ → 0.02s
- 三平台行为一致，不再 flaky

## Test plan

- [x] `go test ./internal/server/ -run TestWireBackgroundTaskNotices` 0.02s PASS
- [x] `go test ./internal/tools/ ./internal/server/` 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)