### PR TITLE
fix(webui): frontend guards thinking display with show_reasoning config

### DIFF
--- a/cmd/octo/markdown.go
+++ b/cmd/octo/markdown.go
@@ -44,7 +44,7 @@ func (m *markdownRenderer) render(src string, width int) string {
 	if err != nil {
 		return strings.TrimRight(src, "\n")
 	}
-	return strings.TrimRight(out, "\n")
+	return strings.Trim(out, "\n")
 }
 
 // splitCommittableMarkdown splits a streamed assistant buffer into the prefix

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1336,22 +1336,13 @@ func (m *tuiModel) thinkingLine() string {
 		hintStyle.Render("("+meta+")"))
 }
 
-// injectAssistantPrefix inserts prefix just before the first non-space content
-// character in rendered, skipping any leading newlines glamour may prepend.
-// This aligns ◆ at the left edge, mirroring how "> " anchors user messages.
+// injectAssistantPrefix strips glamour's 2-space paragraph indent from the
+// first line and prepends prefix so ◆ aligns at column 0, mirroring "> ".
+// Leading newlines are already trimmed by markdownRenderer.render.
 func injectAssistantPrefix(rendered, prefix string) string {
-	// Skip leading newlines (glamour block margin), then leading spaces
-	// (glamour paragraph indent) on the first content line.
-	i := 0
-	for i < len(rendered) && rendered[i] == '\n' {
-		i++
+	trimmed := strings.TrimLeft(rendered, " ")
+	if trimmed == "" {
+		return rendered
 	}
-	j := i
-	for j < len(rendered) && rendered[j] == ' ' {
-		j++
-	}
-	if j >= len(rendered) {
-		return rendered // blank output — don't inject
-	}
-	return rendered[:i] + prefix + rendered[j:]
+	return prefix + trimmed
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -57,6 +57,7 @@ type sessionItem struct {
 	WorkingDir      string    `json:"working_dir,omitempty"`
 	PermissionMode  string    `json:"permission_mode,omitempty"`
 	ReasoningEffort string    `json:"reasoning_effort,omitempty"`
+	ShowReasoning   *bool     `json:"show_reasoning,omitempty"`
 	ContextUsage    int       `json:"context_usage,omitempty"`
 }
 
@@ -94,7 +95,7 @@ func (srv *Server) toSessionItem(s *agent.Session, source, agentProfile string) 
 	if name == "" {
 		name = s.DisplayTitle()
 	}
-	wd, pm, re, ctxUsage := srv.sessionStatusFields()
+	wd, pm, re, sr, ctxUsage := srv.sessionStatusFields()
 	return sessionItem{
 		ID:              s.ID,
 		Name:            name,
@@ -111,21 +112,24 @@ func (srv *Server) toSessionItem(s *agent.Session, source, agentProfile string) 
 		WorkingDir:      wd,
 		PermissionMode:  pm,
 		ReasoningEffort: re,
+		ShowReasoning:   sr,
 		ContextUsage:    ctxUsage,
 	}
 }
 
 // sessionStatusFields returns the server-level session metadata that is shared
-// across all sessions (cwd, permission mode, reasoning effort, current context
-// usage). The Web UI mirrors the CLI bottom status bar, so these values are
-// surfaced on every session descriptor.
-func (srv *Server) sessionStatusFields() (workingDir, permissionMode, reasoningEffort string, contextUsage int) {
+// across all sessions (cwd, permission mode, reasoning effort, show reasoning,
+// current context usage). The Web UI mirrors the CLI bottom status bar, so
+// these values are surfaced on every session descriptor.
+func (srv *Server) sessionStatusFields() (workingDir, permissionMode, reasoningEffort string, showReasoning *bool, contextUsage int) {
 	workingDir = srv.cwd
 	permissionMode = string(resolvePermissionMode())
 	if cfg, err := config.Load(); err == nil {
-		reasoningEffort = cfg.DefaultEntry().ReasoningEffort
+		entry := cfg.DefaultEntry()
+		reasoningEffort = entry.ReasoningEffort
+		showReasoning = entry.ShowReasoning
 	}
-	return workingDir, permissionMode, reasoningEffort, 0
+	return workingDir, permissionMode, reasoningEffort, showReasoning, 0
 }
 
 type toolInfo struct {

--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -3611,9 +3611,14 @@ const Sessions = (() => {
     // Append a thinking/reasoning trace delta.
     // Shown dimmed and italic, matching the TUI's thinkingStyle.
     // Thinking blocks are collected above the main answer.
+    // Guarded by show_reasoning: if the config is off, the server shouldn't
+    // send these, but we drop them defensively in case it does.
     appendThinkingDelta(text) {
       const sid = _activeId;
       if (!sid) return;
+
+      const session = Sessions.find(sid);
+      if (session && session.show_reasoning === false) return;
 
       const state = Sessions._getLiveAssistant(sid);
       const messages = $("messages");
@@ -3656,7 +3661,9 @@ const Sessions = (() => {
         state.thinkingEl.remove();
       }
 
-      const thinkingHtml = thinking ? _buildThinkingBlock(_markedParse(thinking)) : "";
+      const session = Sessions.find(sid);
+      const showThinking = !session || session.show_reasoning !== false;
+      const thinkingHtml = (showThinking && thinking) ? _buildThinkingBlock(_markedParse(thinking)) : "";
       const contentHtml = _renderMarkdown(content || "");
       const finalHtml = thinkingHtml + contentHtml;
 
@@ -3674,7 +3681,7 @@ const Sessions = (() => {
 
       // No live bubble (non-streaming path or late subscribe) — create fresh
       Sessions._clearLiveAssistant(sid);
-      if (thinking) {
+      if (showThinking && thinking) {
         const messages = $("messages");
         const el = document.createElement("div");
         el.className = "msg msg-assistant";

--- a/internal/server/static/ws-dispatcher.js
+++ b/internal/server/static/ws-dispatcher.js
@@ -122,6 +122,7 @@ WS.onEvent(ev => {
         if (ev.working_dir !== undefined) patch.working_dir = ev.working_dir;
         if (ev.permission_mode !== undefined) patch.permission_mode = ev.permission_mode;
         if (ev.reasoning_effort !== undefined) patch.reasoning_effort = ev.reasoning_effort;
+        if (ev.show_reasoning !== undefined) patch.show_reasoning = ev.show_reasoning;
       }
       if (!sid) break;
       Sessions.patch(sid, patch);

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -89,7 +89,7 @@ func (s *Server) listSessionsBrief() []wsSessionInfo {
 	if err != nil {
 		return nil
 	}
-	wd, pm, re, ctxUsage := s.sessionStatusFields()
+	wd, pm, re, sr, ctxUsage := s.sessionStatusFields()
 	out := make([]wsSessionInfo, 0, len(sessions))
 	for _, sess := range sessions {
 		source := sess.Source
@@ -107,6 +107,7 @@ func (s *Server) listSessionsBrief() []wsSessionInfo {
 			WorkingDir:      wd,
 			PermissionMode:  pm,
 			ReasoningEffort: re,
+			ShowReasoning:   sr,
 			ContextUsage:    ctxUsage,
 		})
 	}
@@ -146,7 +147,7 @@ func (s *Server) sendContextUsage(sessionID string, conn *wsConn) {
 	if pct > 100 {
 		pct = 100
 	}
-	wd, pm, re, _ := s.sessionStatusFields()
+	wd, pm, re, _, _ := s.sessionStatusFields()
 	b, err := json.Marshal(map[string]any{
 		"type":             "session_update",
 		"session_id":       sessionID,
@@ -876,7 +877,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			// so turn_done + assistant_message were broadcast by the handler.
 			// Nothing more for the reply itself.
 		} else {
-			wd, pm, re, _ := s.sessionStatusFields()
+			wd, pm, re, _, _ := s.sessionStatusFields()
 			sw.error(err.Error())
 			s.wsHub.broadcast(sess.ID, map[string]any{
 				"type":             "session_update",
@@ -915,7 +916,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			ctxPct = 100
 		}
 	}
-	wd, pm, re, _ := s.sessionStatusFields()
+	wd, pm, re, _, _ := s.sessionStatusFields()
 	s.wsHub.broadcast(sess.ID, map[string]any{
 		"type":             "session_update",
 		"session_id":       sess.ID,

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -95,6 +95,7 @@ type wsSessionInfo struct {
 	WorkingDir      string `json:"working_dir,omitempty"`
 	PermissionMode  string `json:"permission_mode,omitempty"`
 	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	ShowReasoning   *bool  `json:"show_reasoning,omitempty"`
 	ContextUsage    int    `json:"context_usage,omitempty"`
 }
 

--- a/internal/tui/outputcard.go
+++ b/internal/tui/outputcard.go
@@ -29,7 +29,15 @@ func RenderOutputCard(verb, target, output string, maxLines int, isErr bool, lan
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("%s %s", bullet, headerVerb.Render(fmt.Sprintf("%s(%s)", verb, target))))
 
-	lines := splitLinesNoTrail(output)
+	all := splitLinesNoTrail(output)
+	// Blank lines waste preview slots without adding information; filter them
+	// out so the cap applies to meaningful content only.
+	lines := all[:0]
+	for _, l := range all {
+		if strings.TrimSpace(l) != "" {
+			lines = append(lines, l)
+		}
+	}
 	if len(lines) == 0 {
 		b.WriteString("\n  " + outGutter.String() + " " + outMore.Render("(no output)"))
 		return b.String()


### PR DESCRIPTION
The server already filters  events based on , but the frontend should also check defensively rather than rendering unconditionally.

### Backend changes
-  and  gain  field
-  returns  from 
- , , and  broadcasts include 

### Frontend changes
-  extracts  from  events
-  drops thinking deltas when 
-  suppresses the collapsed thinking block when  is false