### PR TITLE
fix(web): strip BgPollNotice/ServiceModeNotice from UI tool cards

### DIFF
--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/Leihb/octo-agent/internal/tools"
 	"github.com/Leihb/octo-agent/internal/tui"
@@ -96,12 +95,6 @@ func renderToolCard(toolName string, input map[string]any, output string, isErr 
 		if p, _ := input["path"].(string); p != "" {
 			lang = tui.GuessLanguage(p)
 		}
-	}
-	if toolName == "terminal" {
-		// The background-launch result carries a model-only "don't poll"
-		// instruction appended after a blank line. It's noise for the human, so
-		// drop it from the card — the "Started background process N" line stays.
-		output = strings.TrimRight(strings.TrimSuffix(output, tools.BgPollNotice), "\n")
 	}
 	if toolName == "write_file" {
 		// write_file's own output is already a human-readable summary

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -18,16 +18,14 @@ import (
 var TerminalTimeout = 120 * time.Second
 
 // BgPollNotice is the model-facing instruction appended to a background-launch
-// tool result. It steers the model away from polling terminal_output and
-// carries no information for the human, so the TUI strips it from result cards
-// (see renderToolCard) rather than printing it to the scrollback.
-const BgPollNotice = "DO NOT poll terminal_output. The system will automatically notify you when this process finishes, carrying its final output. While it runs, you may continue with other independent tasks. If you have no other task to do, report the launch to the user and stop — do not spin in a polling loop."
+// tool result. Wrapped in <system-reminder> so StripRemindersForDisplay strips
+// it from UI cards (TUI and web) — it's noise for humans.
+const BgPollNotice = "<system-reminder>DO NOT poll terminal_output. The system will automatically notify you when this process finishes, carrying its final output. While it runs, you may continue with other independent tasks. If you have no other task to do, report the launch to the user and stop — do not spin in a polling loop.</system-reminder>"
 
 // ServiceModeNotice is the model-facing instruction appended to a background
-// launch of a long-running service (servers, watchers, etc.). It tells the
-// model to verify the service externally (curl, pgrep) rather than polling
-// terminal_output.
-const ServiceModeNotice = "After launching a long-running service, verify it with an external check (e.g., `curl http://localhost:PORT` or `pgrep`) rather than polling terminal_output. terminal_output is for inspecting startup logs or diagnosing issues — do not call it in a tight loop."
+// launch of a long-running service (servers, watchers, etc.). Wrapped in
+// <system-reminder> so UI card renderers strip it automatically.
+const ServiceModeNotice = "<system-reminder>After launching a long-running service, verify it with an external check (e.g., `curl http://localhost:PORT` or `pgrep`) rather than polling terminal_output. terminal_output is for inspecting startup logs or diagnosing issues — do not call it in a tight loop.</system-reminder>"
 
 // TerminalTool is an agent.ToolExecutor that runs shell commands through the
 // system shell (`sh -c` on macOS/Linux, PowerShell on Windows; see


### PR DESCRIPTION
## Problem

`BgPollNotice` and `ServiceModeNotice` in `terminal.go` are plain strings — not wrapped in `<system-reminder>` tags. `StripRemindersForDisplay` (called in `emitToolResultEvents`) only strips `<system-reminder>` spans, so these model-only instructions leaked into web UI tool cards (and would show in TUI cards too if the ad-hoc `TrimSuffix` missed them).

## Fix

Wrap both constants in `<system-reminder>` tags, consistent with `FormatBgNote` (completion notices). This makes `StripRemindersForDisplay` strip them automatically at the event-emission layer for all consumers (TUI, web, IM).

Remove the now-redundant `strings.TrimSuffix(output, tools.BgPollNotice)` special-case in `toolcards.go` — the stripping happens upstream before `ev.Output` reaches `renderToolCard`.

## Test plan

- [x] `go test ./internal/tools/... ./cmd/octo/...` passes
- [x] `go vet` clean
- [ ] Manual: launch a background process in web UI, verify card shows only "Started background process bg_N." with no "DO NOT poll" text

🤖 Generated with [Claude Code](https://claude.com/claude-code)