### PR TITLE
fix(server): pass ReasoningEffort and ShowReasoning in resolveProviderAndModel

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -775,9 +775,11 @@ func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, stri
 		return nil, model, provName, nil
 	}
 	sender, err := app.NewSender(app.SenderOptions{
-		Provider: provName,
-		APIKey:   apiKey,
-		BaseURL:  resolveBaseURL(provName, cfg),
+		Provider:        provName,
+		APIKey:          apiKey,
+		BaseURL:         resolveBaseURL(provName, cfg),
+		ReasoningEffort: entry.ReasoningEffort,
+		ShowReasoning:   entry.ShowReasoning == nil || *entry.ShowReasoning,
 	})
 	if err != nil {
 		return nil, "", "", err


### PR DESCRIPTION
The server's `resolveProviderAndModel` (used when creating the default sender at startup) was not forwarding the config entry's `ReasoningEffort` and `ShowReasoning` fields to `app.NewSender`. This meant the Web UI's default session ignored these settings until a per-entry sender was created via `senderForEntry`.