### PR TITLE
fix(weixin): fix 7 channel bugs — throttle lock, typing lifecycle, Thinking ack, Flush, channel_version

### DIFF
--- a/internal/channel/adapter.go
+++ b/internal/channel/adapter.go
@@ -95,9 +95,18 @@ type Adapter interface {
 	// SupportsMessageUpdates reports whether the platform can edit sent messages.
 	SupportsMessageUpdates() bool
 
-	// SendTyping sends a typing indicator to the chat.
+	// SendTyping sends a typing indicator to the chat and, for platforms that
+	// require a keepalive (e.g. Weixin iLink), starts the background keepalive.
 	// The contextToken is the platform-specific reply context from the inbound event.
 	SendTyping(chatID, contextToken string) error
+
+	// StopTyping cancels the typing indicator and any keepalive goroutine for
+	// the chat. Must be called after the agent turn completes.
+	StopTyping(chatID, contextToken string) error
+
+	// Flush forces any buffered outgoing messages for a chat to be delivered
+	// immediately. Adapters without an outgoing buffer implement this as a no-op.
+	Flush(chatID string)
 
 	// ValidateConfig returns a list of human-readable errors; empty means valid.
 	ValidateConfig(cfg PlatformConfig) []string

--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -173,6 +173,12 @@ func (a *Adapter) SupportsMessageUpdates() bool { return false }
 // SendTyping sends a typing indicator. DingTalk Stream Mode does not support this.
 func (a *Adapter) SendTyping(chatID, contextToken string) error { return nil }
 
+// StopTyping — no-op for DingTalk.
+func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
+
+// Flush — DingTalk has no outgoing buffer.
+func (a *Adapter) Flush(chatID string) {}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	var errs []string

--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -209,6 +209,12 @@ func (a *Adapter) SendTyping(chatID, contextToken string) error {
 	return a.rest(http.MethodPost, fmt.Sprintf("/channels/%s/typing", chatID), nil, nil)
 }
 
+// StopTyping — Discord's typing indicator expires automatically; nothing to cancel.
+func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
+
+// Flush — Discord has no outgoing buffer.
+func (a *Adapter) Flush(chatID string) {}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	var errs []string

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -158,6 +158,12 @@ func (a *Adapter) SupportsMessageUpdates() bool { return true }
 // SendTyping — Feishu does not have a typing indicator API.
 func (a *Adapter) SendTyping(chatID, contextToken string) error { return nil }
 
+// StopTyping — no-op for Feishu.
+func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
+
+// Flush — Feishu has no outgoing buffer.
+func (a *Adapter) Flush(chatID string) {}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	var errs []string

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -247,6 +247,12 @@ func (a *Adapter) SendTyping(chatID, contextToken string) error {
 	return err
 }
 
+// StopTyping — Telegram's typing action expires automatically; nothing to cancel.
+func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
+
+// Flush — Telegram has no outgoing buffer.
+func (a *Adapter) Flush(chatID string) {}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	var errs []string

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -241,6 +241,12 @@ func (a *Adapter) SupportsMessageUpdates() bool { return false }
 // SendTyping — the aibot protocol has no typing indicator.
 func (a *Adapter) SendTyping(chatID, contextToken string) error { return nil }
 
+// StopTyping — no-op for WeCom.
+func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
+
+// Flush — WeCom has no outgoing buffer.
+func (a *Adapter) Flush(chatID string) {}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	botID, _ := cfg[cfgBotID].(string)

--- a/internal/channel/adapters/weixin/ilink/protocol.go
+++ b/internal/channel/adapters/weixin/ilink/protocol.go
@@ -23,8 +23,8 @@ import (
 const (
 	// DefaultBaseURL is the iLink API host.
 	DefaultBaseURL = "https://ilinkai.weixin.qq.com"
-	// ChannelVersion is the protocol version.
-	ChannelVersion = "0.1.0"
+	// ChannelVersion is the protocol version (matches @tencent-weixin/openclaw-weixin).
+	ChannelVersion = "1.0.2"
 	// iLinkAppID is the iLink-App-Id header value.
 	iLinkAppID = "bot"
 	// iLinkClientVer is the iLink-App-ClientVersion header value (0x00MMNNPP for 0.1.0 = 256).

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -64,10 +64,12 @@ type sendQueue struct {
 	baseURL string
 	token   string
 
-	mu      sync.Mutex
+	mu      sync.Mutex // guards buffers only
 	buffers map[string][]sendEntry
-	lastAt  time.Time
 	stopCh  chan struct{}
+
+	lastMu sync.Mutex // guards lastAt only — separate from buffers so throttle
+	lastAt time.Time  // sleep never blocks enqueue callers (BUG-1 fix)
 }
 
 type sendEntry struct {
@@ -177,13 +179,15 @@ func (q *sendQueue) sendBatch(chatID string, entries []sendEntry) {
 }
 
 func (q *sendQueue) throttle() {
-	q.mu.Lock()
-	defer q.mu.Unlock()
+	q.lastMu.Lock()
 	wait := minSendInterval - time.Since(q.lastAt)
 	if wait > 0 {
+		q.lastMu.Unlock()  // release while sleeping so enqueue is never blocked
 		time.Sleep(wait)
+		q.lastMu.Lock()
 	}
 	q.lastAt = time.Now()
+	q.lastMu.Unlock()
 }
 
 func (q *sendQueue) sendWithRetry(chatID, text, contextToken string) {
@@ -599,6 +603,20 @@ func (a *Adapter) UpdateMessage(chatID, messageID, text string) bool { return fa
 
 // SupportsMessageUpdates returns false.
 func (a *Adapter) SupportsMessageUpdates() bool { return false }
+
+// StopTyping cancels the keepalive goroutine and sends sendtyping(status=2)
+// to clear the typing indicator in the WeChat client.
+func (a *Adapter) StopTyping(chatID, contextToken string) error {
+	a.stopTypingKeepalive(chatID)
+	return nil
+}
+
+// Flush immediately drains any buffered outgoing messages for the chat.
+func (a *Adapter) Flush(chatID string) {
+	if a.sendQ != nil {
+		a.sendQ.flush(chatID)
+	}
+}
 
 // SendTyping triggers a typing indicator and starts keepalive.
 func (a *Adapter) SendTyping(chatID, contextToken string) error {

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -182,7 +182,7 @@ func (q *sendQueue) throttle() {
 	q.lastMu.Lock()
 	wait := minSendInterval - time.Since(q.lastAt)
 	if wait > 0 {
-		q.lastMu.Unlock()  // release while sleeping so enqueue is never blocked
+		q.lastMu.Unlock() // release while sleeping so enqueue is never blocked
 		time.Sleep(wait)
 		q.lastMu.Lock()
 	}

--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -71,6 +71,8 @@ func (m *mockAdapter) UpdateMessage(chatID, messageID, text string) bool {
 }
 func (m *mockAdapter) SupportsMessageUpdates() bool                 { return true }
 func (m *mockAdapter) SendTyping(chatID, contextToken string) error { return nil }
+func (m *mockAdapter) StopTyping(chatID, contextToken string) error { return nil }
+func (m *mockAdapter) Flush(chatID string)                          {}
 func (m *mockAdapter) ValidateConfig(cfg PlatformConfig) []string   { return m.validateErrs }
 
 func (m *mockAdapter) sentTextCount() int {

--- a/internal/channel/ui_controller.go
+++ b/internal/channel/ui_controller.go
@@ -130,14 +130,16 @@ func (u *UIController) onToolError(toolName, errMsg, output string) {
 }
 
 // onTurnDone finalizes the turn: flushes remaining text, sends file previews,
-// and resets state for the next turn.
+// resets state, then force-drains any adapter send queue so the final message
+// is delivered immediately instead of waiting for the background flush timer.
 func (u *UIController) onTurnDone(reply *agent.Reply) {
 	u.mu.Lock()
-	defer u.mu.Unlock()
-
 	u.flushTextLocked()
 	u.flushFilesLocked()
 	u.resetLocked()
+	u.mu.Unlock() // explicit unlock before Flush — Flush may block during send
+
+	u.adapter.Flush(u.chatID)
 }
 
 // flushTextLocked sends the accumulated text buffer to the adapter.

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -38,6 +38,8 @@ func (a *fullFakeAdapter) SendFile(chatID, path, name, replyTo string) channel.S
 func (a *fullFakeAdapter) UpdateMessage(chatID, messageID, text string) bool { return true }
 func (a *fullFakeAdapter) SupportsMessageUpdates() bool                      { return false }
 func (a *fullFakeAdapter) SendTyping(chatID, contextToken string) error      { return nil }
+func (a *fullFakeAdapter) StopTyping(chatID, contextToken string) error      { return nil }
+func (a *fullFakeAdapter) Flush(chatID string)                               {}
 func (a *fullFakeAdapter) ValidateConfig(channel.PlatformConfig) []string    { return nil }
 
 func (a *fullFakeAdapter) texts() []string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1315,6 +1315,24 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	ctx, done := sess.BeginRun(ctx)
 	defer done()
 
+	// Start typing keepalive BEFORE sending any text. The WeChat iLink protocol
+	// cancels the typing indicator on sendmessage, so the keepalive must already
+	// be running when the acknowledgment message is sent so it can immediately
+	// re-assert the typing state. Other platforms treat this as a no-op or a
+	// self-expiring hint (Telegram, Discord) — safe to call universally.
+	if err := ad.SendTyping(ev.ChatID, ev.ContextToken); err != nil {
+		slog.Debug("channel sendTyping", "platform", ev.Platform, "err", err)
+	}
+	defer func() {
+		if err := ad.StopTyping(ev.ChatID, ev.ContextToken); err != nil {
+			slog.Debug("channel stopTyping", "platform", ev.Platform, "err", err)
+		}
+	}()
+
+	// Acknowledge receipt immediately so the user knows the message landed
+	// while the agent is working. Mirrors Ruby channel_manager behaviour.
+	ad.SendText(ev.ChatID, "Thinking…", ev.MessageID)
+
 	// Recompose the system prompt every turn so memory written and skills
 	// imported/toggled since server start are visible — web turns get this
 	// for free from buildAgent; the IM factory's compose-once snapshot went


### PR DESCRIPTION
## Summary

Fixes all 7 defects found in the WeChat iLink channel adapter by comparison with the `archive/ruby` baseline.

- **BUG-1 (Critical)** `sendQueue.throttle()` held `q.mu` for up to 1s while sleeping, blocking `enqueue()` callers on the same lock and stalling the streaming event handler. Introduced a separate `lastMu` for the throttle clock, matching the Ruby implementation's `@last_mutex`.

- **BUG-2 (Critical)** `server.routeChannelEvent` called `go handleChannelMessage` directly, bypassing `manager.handleInbound` and its `sendTyping` call entirely — typing was never triggered. Added `ad.SendTyping` at the top of `handleChannelMessage` (after `BeginRun`, before `RunAgent`).

- **BUG-3 (High)** The typing keepalive goroutine was never stopped after a turn completed — `stopTypingKeepalive` was only called on `adapter.Stop()`. Added `defer ad.StopTyping(...)` in `handleChannelMessage`; implemented `StopTyping` on the weixin adapter to call `stopTypingKeepalive`.

- **BUG-4 (High)** No "Thinking…" acknowledgment was sent. Added `ad.SendText(ev.ChatID, "Thinking…", …)` after `SendTyping` starts the keepalive (same ordering as Ruby: keepalive first, then text, so the keepalive can re-assert typing after `sendmessage` cancels it).

- **BUG-5 (Medium)** `UIController.onTurnDone` only enqueued the final message; it never force-flushed the sendQueue, so short final messages sat in the buffer for up to 800ms. Added `Flush(chatID string)` to the `Adapter` interface; `onTurnDone` now calls it after releasing `mu`. Weixin's `Flush` calls `sendQ.flush(chatID)`.

- **BUG-6 (Medium)** `Adapter` interface had `SendTyping` but no `StopTyping` or `Flush`, making it impossible for the UIController/server to stop typing through the generic interface. Both methods added; all adapters implement stubs (no-op or delegate).

- **BUG-7 (Low)** `ChannelVersion = "0.1.0"` diverged from Ruby's `"1.0.2"` (source: `@tencent-weixin/openclaw-weixin`). Updated.

## Test plan

- [x] `go test -race ./...` — all pass
- [x] All adapters compile with new interface methods
- [ ] Manual: send a message to WeChat bot — verify typing bubble appears immediately, "Thinking…" arrives, output streams without 1s stalls, typing clears when reply is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)