### PR TITLE
fix(channels): fix missing icons for DingTalk/Feishu/WeCom, stable sort order

### DIFF
--- a/internal/channel/adapter.go
+++ b/internal/channel/adapter.go
@@ -3,6 +3,7 @@ package channel
 import (
 	"context"
 	"fmt"
+	"sort"
 )
 
 // InboundEvent is the standardized event yielded by every adapter when a
@@ -120,11 +121,12 @@ func Find(name string) (func(PlatformConfig) (Adapter, error), error) {
 	return ctor, nil
 }
 
-// RegisteredPlatforms returns all platform names in the registry.
+// RegisteredPlatforms returns all platform names in the registry, sorted alphabetically.
 func RegisteredPlatforms() []string {
 	out := make([]string, 0, len(registry))
 	for k := range registry {
 		out = append(out, k)
 	}
+	sort.Strings(out)
 	return out
 }

--- a/web/src/views/ChannelsView.svelte
+++ b/web/src/views/ChannelsView.svelte
@@ -10,9 +10,9 @@
   const platformIcons: Record<string, string> = {
     telegram: 'logos:telegram',
     discord:  'logos:discord-icon',
-    feishu:   'simple-icons:lark',
-    dingtalk: 'simple-icons:dingtalk',
-    wecom:    'simple-icons:wechat',
+    feishu:   'mdi:feather',
+    dingtalk: 'ant-design:dingtalk-outlined',
+    wecom:    'mdi:briefcase-outline',
     weixin:   'simple-icons:wechat',
   }
 


### PR DESCRIPTION
## Summary

- **DingTalk**: `simple-icons:dingtalk` isn't in Iconify → replaced with `ant-design:dingtalk-outlined` (Ant Design has official DingTalk icon)
- **Feishu**: `simple-icons:lark` isn't in Iconify → replaced with `mdi:feather` (thematically fits 飞书/Lark)
- **WeCom**: was sharing `simple-icons:wechat` with WeChat → replaced with `mdi:briefcase-outline` to visually distinguish enterprise variant
- **Sort order**: `RegisteredPlatforms()` iterated a Go map (random order), now calls `sort.Strings` for stable alphabetical order

## Test plan

- [ ] Channels page shows distinct icons for all 6 platforms
- [ ] DingTalk, Feishu, WeCom no longer show empty light-blue circles
- [ ] WeChat and WeCom have visually different icons
- [ ] Refreshing the page keeps channels in the same order

🤖 Generated with [Claude Code](https://claude.com/claude-code)