### PR TITLE
fix(channels): fix 38 defects across feishu/dingtalk/discord/telegram/wecom

### DIFF
--- a/internal/channel/adapter.go
+++ b/internal/channel/adapter.go
@@ -95,9 +95,18 @@ type Adapter interface {
 	// SupportsMessageUpdates reports whether the platform can edit sent messages.
 	SupportsMessageUpdates() bool
 
-	// SendTyping sends a typing indicator to the chat.
+	// SendTyping sends a typing indicator to the chat and, for platforms that
+	// require a keepalive (e.g. Weixin iLink), starts the background keepalive.
 	// The contextToken is the platform-specific reply context from the inbound event.
 	SendTyping(chatID, contextToken string) error
+
+	// StopTyping cancels the typing indicator and any keepalive goroutine for
+	// the chat. Must be called after the agent turn completes.
+	StopTyping(chatID, contextToken string) error
+
+	// Flush forces any buffered outgoing messages for a chat to be delivered
+	// immediately. Adapters without an outgoing buffer implement this as a no-op.
+	Flush(chatID string)
 
 	// ValidateConfig returns a list of human-readable errors; empty means valid.
 	ValidateConfig(cfg PlatformConfig) []string

--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -173,6 +173,12 @@ func (a *Adapter) SupportsMessageUpdates() bool { return false }
 // SendTyping sends a typing indicator. DingTalk Stream Mode does not support this.
 func (a *Adapter) SendTyping(chatID, contextToken string) error { return nil }
 
+// StopTyping — no-op for DingTalk.
+func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
+
+// Flush — DingTalk has no outgoing buffer.
+func (a *Adapter) Flush(chatID string) {}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	var errs []string

--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -15,11 +15,18 @@ package dingtalk
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
+	"mime"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -29,10 +36,13 @@ import (
 )
 
 const (
-	platformName = "dingtalk"
-	apiBase      = "https://api.dingtalk.com"
-	gatewayHost  = "wss://wss.dingtalk.com"
-	msgTopic     = "/v1.0/im/bot/messages/get"
+	platformName    = "dingtalk"
+	apiBase         = "https://api.dingtalk.com"
+	oapiBase        = "https://oapi.dingtalk.com"
+	gatewayHost     = "wss://wss.dingtalk.com"
+	msgTopic        = "/v1.0/im/bot/messages/get"
+	reconnectDelay  = 5 * time.Second
+	webhookSafetyMs = 5 * 60 * 1000 // 5 min in ms
 )
 
 func init() {
@@ -47,12 +57,16 @@ const (
 	cfgAllowedUsers = "allowed_users"
 )
 
+// atMentionRe strips leading @mention from inbound text.
+var atMentionRe = regexp.MustCompile(`^@[^\s]+\s*`)
+
 // Adapter implements channel.Adapter for DingTalk Stream Mode.
 type Adapter struct {
 	clientID     string
 	clientSecret string
 	robotCode    string // defaults to clientID — they coincide for enterprise-internal robots
 	apiBase      string
+	oapiBase     string
 	allowedUsers map[string]bool
 
 	http        *http.Client
@@ -60,8 +74,17 @@ type Adapter struct {
 	tokenExpiry time.Time
 	tokenMu     sync.Mutex
 
+	// OAPI token (legacy /media/upload endpoint).
+	oapiToken       string
+	oapiTokenExpiry time.Time
+	oapiTokenMu     sync.Mutex
+
 	webhooks  map[string]webhookEntry
 	webhookMu sync.Mutex
+
+	// routes caches routing info needed for OAPI sends (send_file).
+	routes  map[string]routeEntry
+	routeMu sync.Mutex
 
 	running bool
 	cancel  context.CancelFunc
@@ -70,6 +93,13 @@ type Adapter struct {
 type webhookEntry struct {
 	URL         string
 	ExpiresAtMs int64
+}
+
+type routeEntry struct {
+	RobotCode string
+	ConvID    string
+	UserID    string
+	ConvType  string
 }
 
 // New creates a DingTalk adapter from platform config.
@@ -100,9 +130,11 @@ func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
 		clientSecret: secret,
 		robotCode:    robotCode,
 		apiBase:      apiBase,
+		oapiBase:     oapiBase,
 		allowedUsers: allowed,
 		http:         &http.Client{Timeout: 30 * time.Second},
 		webhooks:     make(map[string]webhookEntry),
+		routes:       make(map[string]routeEntry),
 	}, nil
 }
 
@@ -110,31 +142,52 @@ func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
 func (a *Adapter) Platform() string { return platformName }
 
 // Start connects to DingTalk Stream Mode and blocks until ctx is cancelled.
+// DT-001: wraps the whole connect sequence in a reconnect loop.
 func (a *Adapter) Start(ctx context.Context, onMessage func(channel.InboundEvent)) error {
 	a.running = true
 	ctx, a.cancel = context.WithCancel(ctx)
 	defer func() { a.running = false }()
 
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		err := a.connectOnce(ctx, onMessage)
+		if err == nil || ctx.Err() != nil {
+			return nil
+		}
+		log.Printf("[dingtalk] connection error: %v; reconnecting in %s", err, reconnectDelay)
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(reconnectDelay):
+		}
+	}
+}
+
+// connectOnce runs one full connect-listen cycle.
+func (a *Adapter) connectOnce(ctx context.Context, onMessage func(channel.InboundEvent)) error {
+	// DT-009: refresh token synchronously under mutex.
 	if err := a.refreshToken(); err != nil {
-		return fmt.Errorf("dingtalk: token: %w", err)
+		return fmt.Errorf("token: %w", err)
 	}
 
-	ticket, err := a.openGateway()
+	ticket, wsURL, err := a.openGateway()
 	if err != nil {
-		return fmt.Errorf("dingtalk: gateway: %w", err)
+		return fmt.Errorf("gateway: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/connect?appKey=%s&ticket=%s", gatewayHost, a.clientID, ticket)
+	_ = ticket // wsURL already contains the ticket
+
 	dialer := websocket.DefaultDialer
-	conn, _, err := dialer.DialContext(ctx, url, nil)
+	conn, _, err := dialer.DialContext(ctx, wsURL, nil)
 	if err != nil {
-		return fmt.Errorf("dingtalk: connect: %w", err)
+		return fmt.Errorf("connect: %w", err)
 	}
 	defer conn.Close()
-
-	if err := a.register(conn); err != nil {
-		return fmt.Errorf("dingtalk: register: %w", err)
-	}
 
 	log.Printf("[dingtalk] stream connected, listening")
 	return a.readFrames(ctx, conn, onMessage)
@@ -148,10 +201,7 @@ func (a *Adapter) Stop() error {
 	return nil
 }
 
-// SendText sends a Markdown message. It prefers the chat's sessionWebhook
-// (free, no extra permissions, but only exists after an inbound message and
-// expires); without one it falls back to the proactive robot API, which is
-// what a standalone push (channel.SendOnce from octo serve) always uses.
+// SendText sends a Markdown message via sessionWebhook or proactive OAPI.
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 	if url := a.resolveWebhook(chatID); url != "" {
 		return a.sendWebhook(url, text)
@@ -159,9 +209,34 @@ func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 	return a.sendProactive(chatID, text)
 }
 
-// SendFile is not yet implemented for DingTalk.
+// SendFile uploads a file and sends it as a media message via OAPI.
+// DT-007: 3-step OAPI approach: get OAPI token → upload media → send media message.
 func (a *Adapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
-	return channel.SendResult{OK: false, Error: "SendFile not yet implemented"}
+	if _, err := os.Stat(path); err != nil {
+		return channel.SendResult{OK: false, Error: "file not found: " + path}
+	}
+
+	route := a.resolveRoute(chatID)
+	if route == nil {
+		return channel.SendResult{OK: false, Error: "no routing info for chat " + chatID}
+	}
+
+	kind := "file"
+	if isImagePath(path) {
+		kind = "image"
+	}
+
+	mediaID, err := a.uploadMedia(path, kind)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: "upload failed: " + err.Error()}
+	}
+
+	fileName := name
+	if fileName == "" {
+		fileName = filepath.Base(path)
+	}
+
+	return a.sendMedia(route, mediaID, kind, fileName)
 }
 
 // UpdateMessage — DingTalk does not support editing sent messages.
@@ -193,7 +268,17 @@ func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 
 // ─── OAuth ─────────────────────────────────────────────────────────────────
 
+// DT-009: refreshToken is always called synchronously under its own lock path.
+// getToken calls it directly when expired, never in a goroutine.
 func (a *Adapter) refreshToken() error {
+	a.tokenMu.Lock()
+	defer a.tokenMu.Unlock()
+
+	// Re-check under lock in case another caller already refreshed.
+	if a.accessToken != "" && time.Now().Before(a.tokenExpiry) {
+		return nil
+	}
+
 	body := map[string]string{"appKey": a.clientID, "appSecret": a.clientSecret}
 	b, _ := json.Marshal(body)
 	resp, err := a.http.Post(a.apiBase+"/v1.0/oauth2/accessToken", "application/json", bytes.NewReader(b))
@@ -213,11 +298,8 @@ func (a *Adapter) refreshToken() error {
 		return fmt.Errorf("empty access token in response")
 	}
 
-	a.tokenMu.Lock()
 	a.accessToken = r.AccessToken
 	a.tokenExpiry = time.Now().Add(time.Duration(r.ExpireIn-60) * time.Second)
-	a.tokenMu.Unlock()
-
 	log.Printf("[dingtalk] token obtained, expires in %ds", r.ExpireIn)
 	return nil
 }
@@ -228,44 +310,93 @@ func (a *Adapter) getToken() string {
 	expired := time.Now().After(a.tokenExpiry)
 	a.tokenMu.Unlock()
 
-	// No token yet: the adapter is being used for an outbound send without
-	// Start() (e.g. channel.SendOnce). Fetch synchronously or the request
-	// goes out with an empty token header.
-	if tok == "" {
-		_ = a.refreshToken()
+	if tok == "" || expired {
+		// DT-009: synchronous refresh, no goroutine.
+		if err := a.refreshToken(); err != nil {
+			log.Printf("[dingtalk] token refresh failed: %v", err)
+			return tok
+		}
 		a.tokenMu.Lock()
 		tok = a.accessToken
 		a.tokenMu.Unlock()
-		return tok
-	}
-	if expired {
-		// Best-effort refresh — don't block.
-		go a.refreshToken()
 	}
 	return tok
 }
 
-// ─── Gateway ───────────────────────────────────────────────────────────────
+// getOAPIToken returns a cached OAPI token (legacy /media/upload endpoint).
+// DT-007: OAPI token is independent from the v1.0 access token.
+func (a *Adapter) getOAPIToken() (string, error) {
+	a.oapiTokenMu.Lock()
+	defer a.oapiTokenMu.Unlock()
 
-func (a *Adapter) openGateway() (string, error) {
-	body := map[string]string{
-		"clientId":     a.clientID,
-		"clientSecret": a.clientSecret,
+	if a.oapiToken != "" && time.Now().Before(a.oapiTokenExpiry) {
+		return a.oapiToken, nil
 	}
-	b, _ := json.Marshal(body)
-	resp, err := a.http.Post(a.apiBase+"/v1.0/gateway/connections/open", "application/json", bytes.NewReader(b))
+
+	url := fmt.Sprintf("%s/gettoken?appkey=%s&appsecret=%s", a.oapiBase, a.clientID, a.clientSecret)
+	resp, err := a.http.Get(url)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
 
 	var r struct {
-		Ticket string `json:"ticket"`
+		ErrCode     int    `json:"errcode"`
+		ErrMsg      string `json:"errmsg"`
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
 		return "", err
 	}
-	return r.Ticket, nil
+	if r.ErrCode != 0 || r.AccessToken == "" {
+		return "", fmt.Errorf("OAPI token error %d: %s", r.ErrCode, r.ErrMsg)
+	}
+
+	a.oapiToken = r.AccessToken
+	a.oapiTokenExpiry = time.Now().Add(time.Duration(r.ExpiresIn-60) * time.Second)
+	return a.oapiToken, nil
+}
+
+// ─── Gateway ───────────────────────────────────────────────────────────────
+
+// DT-004: openGateway includes subscriptions, ua, and localIp fields.
+// Returns (ticket, wsURL, error).
+func (a *Adapter) openGateway() (string, string, error) {
+	body := map[string]any{
+		"clientId":     a.clientID,
+		"clientSecret": a.clientSecret,
+		"subscriptions": []map[string]string{
+			{"type": "CALLBACK", "topic": msgTopic},
+		},
+		"ua":      "octo-agent",
+		"localIp": "127.0.0.1",
+	}
+	b, _ := json.Marshal(body)
+	resp, err := a.http.Post(a.apiBase+"/v1.0/gateway/connections/open", "application/json", bytes.NewReader(b))
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		Ticket   string `json:"ticket"`
+		Endpoint string `json:"endpoint"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return "", "", err
+	}
+	if r.Ticket == "" {
+		return "", "", fmt.Errorf("empty ticket in gateway response")
+	}
+
+	wsURL := r.Endpoint
+	if wsURL == "" {
+		wsURL = fmt.Sprintf("%s/connect?appKey=%s&ticket=%s", gatewayHost, a.clientID, r.Ticket)
+	} else {
+		wsURL = fmt.Sprintf("%s?ticket=%s", r.Endpoint, r.Ticket)
+	}
+	return r.Ticket, wsURL, nil
 }
 
 // ─── Stream frames ─────────────────────────────────────────────────────────
@@ -277,21 +408,11 @@ type streamFrame struct {
 	Data        json.RawMessage   `json:"data"`
 }
 
-func (a *Adapter) register(conn *websocket.Conn) error {
-	frame := streamFrame{
-		SpecVersion: "1.0",
-		Type:        "register",
-		Headers:     map[string]string{"clientId": a.clientID, "topic": msgTopic},
-	}
-	b, _ := json.Marshal(frame)
-	return conn.WriteMessage(websocket.TextMessage, b)
-}
-
 func (a *Adapter) readFrames(ctx context.Context, conn *websocket.Conn, onMessage func(channel.InboundEvent)) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil
 		default:
 		}
 
@@ -307,13 +428,71 @@ func (a *Adapter) readFrames(ctx context.Context, conn *websocket.Conn, onMessag
 		if err := json.Unmarshal(raw, &frame); err != nil {
 			continue
 		}
+
+		// DT-002: handle SYSTEM frames (ping/disconnect).
 		if frame.Type == "SYSTEM" {
+			if err := a.handleSystemFrame(conn, frame); err != nil {
+				return err
+			}
 			continue
 		}
+
+		// DT-003: send ACK immediately for EVENT/CALLBACK frames.
+		if frame.Type == "EVENT" || frame.Type == "CALLBACK" {
+			a.sendACK(conn, frame)
+		}
+
 		if frame.Headers["topic"] != msgTopic {
 			continue
 		}
 		a.handleInbound(frame.Data, onMessage)
+	}
+}
+
+// DT-002: handleSystemFrame processes SYSTEM frames.
+// ping → respond with pong; disconnect → return error to trigger reconnect.
+func (a *Adapter) handleSystemFrame(conn *websocket.Conn, frame streamFrame) error {
+	topic := frame.Headers["topic"]
+	switch topic {
+	case "ping":
+		// Mirror the frame back with topic changed to "pong".
+		pongHeaders := make(map[string]string, len(frame.Headers))
+		for k, v := range frame.Headers {
+			pongHeaders[k] = v
+		}
+		pongHeaders["topic"] = "pong"
+		pong := map[string]any{
+			"specVersion": frame.SpecVersion,
+			"type":        "SYSTEM",
+			"headers":     pongHeaders,
+			"data":        frame.Data,
+		}
+		b, _ := json.Marshal(pong)
+		if err := conn.WriteMessage(websocket.TextMessage, b); err != nil {
+			return fmt.Errorf("pong write: %w", err)
+		}
+		log.Printf("[dingtalk] pong sent")
+	case "disconnect":
+		log.Printf("[dingtalk] server requested disconnect, reconnecting")
+		return fmt.Errorf("server disconnect")
+	}
+	return nil
+}
+
+// DT-003: sendACK sends an ACK frame for EVENT/CALLBACK frames.
+func (a *Adapter) sendACK(conn *websocket.Conn, frame streamFrame) {
+	ack := map[string]any{
+		"code": 200,
+		"headers": map[string]string{
+			"messageId": frame.Headers["messageId"],
+			"topic":     "ack",
+		},
+		"message": "OK",
+		"data":    "",
+	}
+	b, _ := json.Marshal(ack)
+	if err := conn.WriteMessage(websocket.TextMessage, b); err != nil {
+		log.Printf("[dingtalk] ACK send failed: %v", err)
 	}
 }
 
@@ -333,8 +512,11 @@ type dtEvent struct {
 	Text                      struct {
 		Content string `json:"content"`
 	} `json:"text"`
+	// Content holds picture/file download codes and richText.
 	Content struct {
-		Content string `json:"content"`
+		DownloadCode string          `json:"downloadCode"`
+		FileName     string          `json:"fileName"`
+		RichText     json.RawMessage `json:"richText"`
 	} `json:"content"`
 	AtUsers []struct {
 		DingtalkID string `json:"dingtalkId"`
@@ -368,6 +550,20 @@ func (a *Adapter) handleInbound(raw json.RawMessage, onMessage func(channel.Inbo
 		a.webhookMu.Unlock()
 	}
 
+	// Cache route for outbound file sends.
+	robotCode := ev.RobotCode
+	if robotCode == "" {
+		robotCode = a.robotCode
+	}
+	a.routeMu.Lock()
+	a.routes[chatID] = routeEntry{
+		RobotCode: robotCode,
+		ConvID:    ev.ConversationID,
+		UserID:    senderID,
+		ConvType:  ev.ConversationType,
+	}
+	a.routeMu.Unlock()
+
 	// Group chat: only @-mention.
 	if ev.ConversationType == "2" {
 		mentioned := false
@@ -378,9 +574,6 @@ func (a *Adapter) handleInbound(raw json.RawMessage, onMessage func(channel.Inbo
 			}
 		}
 		content := ev.Text.Content
-		if content == "" {
-			content = ev.Content.Content
-		}
 		if !mentioned && !strings.Contains(content, "@") {
 			return
 		}
@@ -390,8 +583,9 @@ func (a *Adapter) handleInbound(raw json.RawMessage, onMessage func(channel.Inbo
 		return
 	}
 
-	text := extractDTText(ev)
-	if text == "" {
+	text, files := a.extractPayload(ev)
+	// DT-005: guard changed to check both text and files.
+	if strings.TrimSpace(text) == "" && len(files) == 0 {
 		return
 	}
 
@@ -406,26 +600,157 @@ func (a *Adapter) handleInbound(raw json.RawMessage, onMessage func(channel.Inbo
 		ChatID:    chatID,
 		UserID:    senderID,
 		Text:      text,
+		Files:     files,
 		MessageID: ev.MsgID,
 		ChatType:  ct,
 		Raw:       ev,
 	})
 }
 
-func extractDTText(ev dtEvent) string {
+// extractPayload parses text and file attachments from an inbound event.
+// DT-005, DT-006: handles picture, file, and richText msgtypes.
+func (a *Adapter) extractPayload(ev dtEvent) (string, []channel.FileAttachment) {
+	var text string
+	var files []channel.FileAttachment
+
+	robotCode := ev.RobotCode
+	if robotCode == "" {
+		robotCode = a.robotCode
+	}
+
 	switch ev.MsgType {
 	case "text":
-		c := ev.Text.Content
-		if idx := strings.Index(c, " "); idx > 0 && strings.HasPrefix(c, "@") {
-			c = strings.TrimSpace(c[idx+1:])
+		// DT-011: strip @mention with regexp.
+		c := atMentionRe.ReplaceAllString(ev.Text.Content, "")
+		text = strings.TrimSpace(c)
+
+	case "picture":
+		// DT-005: download picture and attach as image.
+		code := ev.Content.DownloadCode
+		if code != "" {
+			data, mimeType, err := a.downloadDTFile(code, robotCode)
+			if err == nil && len(data) > 0 {
+				dataURL := "data:" + mimeType + ";base64," + base64.StdEncoding.EncodeToString(data)
+				files = append(files, channel.FileAttachment{
+					Type:    "image",
+					DataURL: dataURL,
+				})
+			} else if err != nil {
+				log.Printf("[dingtalk] picture download failed: %v", err)
+			}
 		}
-		return c
+
+	case "file":
+		// DT-005: download file and save to temp path.
+		code := ev.Content.DownloadCode
+		fileName := ev.Content.FileName
+		if code != "" {
+			data, _, err := a.downloadDTFile(code, robotCode)
+			if err == nil && len(data) > 0 {
+				tmpFile, err := os.CreateTemp("", "dingtalk-*-"+fileName)
+				if err == nil {
+					_, writeErr := tmpFile.Write(data)
+					tmpFile.Close()
+					if writeErr == nil {
+						files = append(files, channel.FileAttachment{
+							Type: "file",
+							Name: fileName,
+							Path: tmpFile.Name(),
+						})
+					} else {
+						os.Remove(tmpFile.Name())
+					}
+				}
+			} else if err != nil {
+				log.Printf("[dingtalk] file download failed: %v", err)
+			}
+		}
+
 	case "richText":
-		// RichText content is in Content.Content field.
-		return ev.Content.Content
+		// DT-006: parse richText array, collect text and picture parts.
+		var parts []struct {
+			Text         string `json:"text"`
+			DownloadCode string `json:"downloadCode"`
+			Type         string `json:"type"`
+		}
+		if err := json.Unmarshal(ev.Content.RichText, &parts); err == nil {
+			for _, p := range parts {
+				if p.Text != "" {
+					text += p.Text
+				} else if p.DownloadCode != "" && p.Type == "picture" {
+					data, mimeType, err := a.downloadDTFile(p.DownloadCode, robotCode)
+					if err == nil && len(data) > 0 {
+						dataURL := "data:" + mimeType + ";base64," + base64.StdEncoding.EncodeToString(data)
+						files = append(files, channel.FileAttachment{
+							Type:    "image",
+							DataURL: dataURL,
+						})
+					}
+				}
+			}
+		}
+
 	default:
-		return ""
+		log.Printf("[dingtalk] unsupported msgtype=%s, ignoring", ev.MsgType)
 	}
+
+	return text, files
+}
+
+// downloadDTFile fetches a file by downloadCode from the DingTalk robot API.
+// DT-005: POST /v1.0/robot/messageFiles/download → downloadUrl → fetch bytes.
+func (a *Adapter) downloadDTFile(downloadCode, robotCode string) ([]byte, string, error) {
+	// Step 1: exchange downloadCode for a temporary URL.
+	body := map[string]string{
+		"downloadCode": downloadCode,
+		"robotCode":    robotCode,
+	}
+	b, _ := json.Marshal(body)
+	tok := a.getToken()
+	req, err := http.NewRequest("POST", a.apiBase+"/v1.0/robot/messageFiles/download", bytes.NewReader(b))
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-acs-dingtalk-access-token", tok)
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		DownloadURL string `json:"downloadUrl"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, "", err
+	}
+	if r.DownloadURL == "" {
+		return nil, "", fmt.Errorf("empty downloadUrl in response")
+	}
+
+	// Step 2: fetch the actual file bytes.
+	fileResp, err := a.http.Get(r.DownloadURL)
+	if err != nil {
+		return nil, "", err
+	}
+	defer fileResp.Body.Close()
+
+	data, err := io.ReadAll(fileResp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+
+	mimeType := fileResp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	// Trim parameters from mime type for data URL.
+	if idx := strings.Index(mimeType, ";"); idx > 0 {
+		mimeType = strings.TrimSpace(mimeType[:idx])
+	}
+	return data, mimeType, nil
 }
 
 // ─── Send ──────────────────────────────────────────────────────────────────
@@ -437,20 +762,24 @@ func (a *Adapter) resolveWebhook(chatID string) string {
 	if !ok {
 		return ""
 	}
-	if e.ExpiresAtMs > 0 && time.Now().UnixMilli()+5*60*1000 >= e.ExpiresAtMs {
+	if e.ExpiresAtMs > 0 && time.Now().UnixMilli()+webhookSafetyMs >= e.ExpiresAtMs {
 		delete(a.webhooks, chatID)
 		return ""
 	}
 	return e.URL
 }
 
-// sendProactive pushes a message through the robot send APIs, which need no
-// sessionWebhook — only the app credentials and the "robot message send"
-// permission granted in the DingTalk admin console. An openConversationId
-// (always "cid"-prefixed) routes to the group API; anything else is treated
-// as a staff/user id and routed to the one-on-one batch API. Note the cid
-// form only works for group chats — a 1:1 push must target the user id, not
-// the DM conversation id.
+func (a *Adapter) resolveRoute(chatID string) *routeEntry {
+	a.routeMu.Lock()
+	defer a.routeMu.Unlock()
+	if r, ok := a.routes[chatID]; ok {
+		cp := r
+		return &cp
+	}
+	return nil
+}
+
+// sendProactive pushes a message through the robot send APIs.
 func (a *Adapter) sendProactive(chatID, text string) channel.SendResult {
 	tok := a.getToken()
 	if tok == "" {
@@ -488,6 +817,8 @@ func (a *Adapter) sendProactive(chatID, text string) channel.SendResult {
 	return channel.SendResult{OK: true}
 }
 
+// sendWebhook delivers text via the per-message sessionWebhook.
+// DT-010: reads response body and checks errcode.
 func (a *Adapter) sendWebhook(url, text string) channel.SendResult {
 	body := map[string]any{
 		"msgtype": "markdown",
@@ -502,6 +833,182 @@ func (a *Adapter) sendWebhook(url, text string) channel.SendResult {
 		return channel.SendResult{OK: false, Error: err.Error()}
 	}
 	defer resp.Body.Close()
-	io.Copy(io.Discard, resp.Body)
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+
+	var r struct {
+		ErrCode int    `json:"errcode"`
+		ErrMsg  string `json:"errmsg"`
+	}
+	if err := json.Unmarshal(respBody, &r); err == nil && r.ErrCode != 0 {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("webhook errcode %d: %s", r.ErrCode, r.ErrMsg)}
+	}
 	return channel.SendResult{OK: true}
+}
+
+// ─── File upload (DT-007) ──────────────────────────────────────────────────
+
+// uploadMedia uploads a local file to DingTalk via the OAPI legacy endpoint.
+// Returns the media_id string.
+func (a *Adapter) uploadMedia(path, kind string) (string, error) {
+	tok, err := a.getOAPIToken()
+	if err != nil {
+		return "", fmt.Errorf("OAPI token: %w", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+
+	// type field
+	if err := mw.WriteField("type", kind); err != nil {
+		return "", err
+	}
+
+	// media field
+	fileName := filepath.Base(path)
+	mimeType := mimeForFile(fileName)
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="media"; filename="%s"`, fileName))
+	h.Set("Content-Type", mimeType)
+	part, err := mw.CreatePart(h)
+	if err != nil {
+		return "", err
+	}
+	if _, err := part.Write(data); err != nil {
+		return "", err
+	}
+	mw.Close()
+
+	uploadURL := fmt.Sprintf("%s/media/upload?access_token=%s", a.oapiBase, tok)
+	req, err := http.NewRequest("POST", uploadURL, &buf)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+
+	var r struct {
+		ErrCode int    `json:"errcode"`
+		ErrMsg  string `json:"errmsg"`
+		MediaID string `json:"media_id"`
+	}
+	if err := json.Unmarshal(respBody, &r); err != nil {
+		return "", fmt.Errorf("upload response parse: %w", err)
+	}
+	if r.ErrCode != 0 || r.MediaID == "" {
+		return "", fmt.Errorf("upload failed errcode=%d errmsg=%s", r.ErrCode, r.ErrMsg)
+	}
+	log.Printf("[dingtalk] upload_media ok kind=%s media_id_len=%d", kind, len(r.MediaID))
+	return r.MediaID, nil
+}
+
+// sendMedia sends a previously uploaded media file via the robot OAPI.
+func (a *Adapter) sendMedia(route *routeEntry, mediaID, kind, fileName string) channel.SendResult {
+	tok := a.getToken()
+	if tok == "" {
+		return channel.SendResult{OK: false, Error: "no access token"}
+	}
+
+	var msgKey string
+	var msgParam map[string]string
+	if kind == "image" {
+		msgKey = "sampleImageMsg"
+		msgParam = map[string]string{"photoURL": mediaID}
+	} else {
+		msgKey = "sampleFile"
+		ext := strings.TrimPrefix(filepath.Ext(fileName), ".")
+		msgParam = map[string]string{
+			"mediaId":  mediaID,
+			"fileName": fileName,
+			"fileType": ext,
+		}
+	}
+
+	msgParamJSON, _ := json.Marshal(msgParam)
+
+	var path string
+	var body map[string]any
+	if route.ConvType == "2" {
+		path = "/v1.0/robot/groupMessages/send"
+		body = map[string]any{
+			"msgKey":             msgKey,
+			"msgParam":           string(msgParamJSON),
+			"openConversationId": route.ConvID,
+			"robotCode":          route.RobotCode,
+		}
+	} else {
+		path = "/v1.0/robot/oToMessages/batchSend"
+		body = map[string]any{
+			"msgKey":    msgKey,
+			"msgParam":  string(msgParamJSON),
+			"userIds":   []string{route.UserID},
+			"robotCode": route.RobotCode,
+		}
+	}
+
+	b, _ := json.Marshal(body)
+	req, _ := http.NewRequest("POST", a.apiBase+path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-acs-dingtalk-access-token", tok)
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode/100 != 2 {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("send_media %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))}
+	}
+	log.Printf("[dingtalk] send_media ok kind=%s msgKey=%s", kind, msgKey)
+	return channel.SendResult{OK: true}
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+func isImagePath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".jpg", ".jpeg", ".png", ".gif", ".webp":
+		return true
+	}
+	return false
+}
+
+func mimeForFile(filename string) string {
+	ext := strings.ToLower(filepath.Ext(filename))
+	if t := mime.TypeByExtension(ext); t != "" {
+		return t
+	}
+	switch ext {
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".pdf":
+		return "application/pdf"
+	case ".zip":
+		return "application/zip"
+	default:
+		return "application/octet-stream"
+	}
 }

--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -13,13 +13,17 @@ package discord
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"math/rand"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -27,6 +31,7 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/channel"
+	"github.com/Leihb/octo-agent/internal/version"
 	"github.com/gorilla/websocket"
 )
 
@@ -151,6 +156,10 @@ func (a *Adapter) Start(ctx context.Context, onMessage func(channel.InboundEvent
 			if errors.As(err, &fatal) {
 				return fmt.Errorf("discord: %w", err)
 			}
+			if errors.Is(err, errReconnectNow) {
+				// Server-requested immediate reconnect; skip the delay.
+				continue
+			}
 			log.Printf("[discord-gateway] connection lost: %v (reconnecting in %s)", err, reconnectDelay)
 		}
 		select {
@@ -184,10 +193,86 @@ func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 	return channel.SendResult{OK: true, MessageID: msg.ID}
 }
 
-// SendFile is not yet implemented for Discord (matches the Feishu and
-// DingTalk adapters, which are text-only today).
+// SendFile uploads a file to a Discord channel using multipart form data.
 func (a *Adapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
-	return channel.SendResult{OK: false, Error: "SendFile not yet implemented"}
+	f, err := os.Open(path)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	defer f.Close()
+
+	fileBytes, err := io.ReadAll(f)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+
+	filename := name
+	if filename == "" {
+		filename = path[strings.LastIndexByte(path, '/')+1:]
+	}
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+
+	// Part 1: JSON payload describing the attachment.
+	payloadJSON, _ := json.Marshal(map[string]any{
+		"attachments": []map[string]any{{"id": "0", "filename": filename}},
+	})
+	jsonPart, err := mw.CreatePart(textproto.MIMEHeader{
+		"Content-Disposition": []string{`form-data; name="payload_json"`},
+		"Content-Type":        []string{"application/json"},
+	})
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	if _, err := jsonPart.Write(payloadJSON); err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+
+	// Part 2: the file bytes.
+	filePart, err := mw.CreatePart(textproto.MIMEHeader{
+		"Content-Disposition": []string{fmt.Sprintf(`form-data; name="files[0]"; filename="%s"`, filename)},
+		"Content-Type":        []string{"application/octet-stream"},
+	})
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	if _, err := filePart.Write(fileBytes); err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	mw.Close()
+
+	req, err := http.NewRequest(http.MethodPost,
+		a.apiBase+fmt.Sprintf("/channels/%s/messages", chatID), &buf)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	req.Header.Set("Authorization", "Bot "+a.token)
+	req.Header.Set("User-Agent", userAgent())
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var e struct {
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(data, &e)
+		if e.Message == "" {
+			e.Message = strings.TrimSpace(string(data))
+		}
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("discord API %d: %s", resp.StatusCode, e.Message)}
+	}
+	var msg struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(data, &msg)
+	return channel.SendResult{OK: true, MessageID: msg.ID}
 }
 
 // UpdateMessage edits an existing message.
@@ -227,7 +312,7 @@ func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 // ─── REST ───────────────────────────────────────────────────────────────────
 
 func userAgent() string {
-	return "DiscordBot (https://github.com/Leihb/octo-agent, 1.0)"
+	return "DiscordBot (https://github.com/Leihb/octo-agent, " + version.String() + ")"
 }
 
 func (a *Adapter) rest(method, path string, payload, out any) error {
@@ -290,6 +375,11 @@ func (a *Adapter) usersMe() (*dcUser, error) {
 }
 
 // ─── Gateway ────────────────────────────────────────────────────────────────
+
+// errReconnectNow is returned by connectAndListen when the server explicitly
+// requests an immediate reconnect (op=7). The Start loop skips the
+// reconnectDelay sleep for this sentinel.
+var errReconnectNow = errors.New("reconnect requested")
 
 // fatalGatewayError marks close codes where reconnecting cannot help.
 type fatalGatewayError struct {
@@ -448,7 +538,7 @@ func (a *Adapter) connectAndListen(ctx context.Context, onMessage func(channel.I
 
 		case 7: // Reconnect
 			log.Printf("[discord-gateway] server requested reconnect")
-			return fmt.Errorf("server requested reconnect")
+			return errReconnectNow
 
 		case 9: // Invalid session
 			var resumable bool
@@ -471,6 +561,13 @@ func (a *Adapter) connectAndListen(ctx context.Context, onMessage func(channel.I
 
 // ─── Dispatch ───────────────────────────────────────────────────────────────
 
+type dcAttachment struct {
+	URL         string `json:"url"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
+	Size        int    `json:"size"`
+}
+
 type dcMessage struct {
 	ID        string `json:"id"`
 	ChannelID string `json:"channel_id"`
@@ -480,6 +577,7 @@ type dcMessage struct {
 	Mentions  []struct {
 		ID string `json:"id"`
 	} `json:"mentions"`
+	Attachments []dcAttachment `json:"attachments"`
 }
 
 func (a *Adapter) handleDispatch(typ string, data json.RawMessage, onMessage func(channel.InboundEvent)) {
@@ -506,7 +604,75 @@ func (a *Adapter) handleDispatch(typ string, data json.RawMessage, onMessage fun
 	}
 }
 
+// processAttachments downloads Discord CDN attachments and returns them as
+// channel.FileAttachment values. Images are base64-encoded into a data URL;
+// other files are saved to a temp file.
+func (a *Adapter) processAttachments(atts []dcAttachment) []channel.FileAttachment {
+	var files []channel.FileAttachment
+	for _, att := range atts {
+		if att.URL == "" {
+			continue
+		}
+		resp, err := http.Get(att.URL) //nolint:noctx // Discord CDN is public; no auth needed
+		if err != nil {
+			log.Printf("[discord] attachment download failed (%s): %v", att.Filename, err)
+			continue
+		}
+		data, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			log.Printf("[discord] attachment read failed (%s): %v", att.Filename, err)
+			continue
+		}
+
+		mime := att.ContentType
+		if mime == "" {
+			mime = resp.Header.Get("Content-Type")
+		}
+		// Strip charset or other parameters.
+		if idx := strings.Index(mime, ";"); idx >= 0 {
+			mime = strings.TrimSpace(mime[:idx])
+		}
+
+		if strings.HasPrefix(mime, "image/") {
+			dataURL := "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(data)
+			files = append(files, channel.FileAttachment{
+				Type:     "image",
+				Name:     att.Filename,
+				MimeType: mime,
+				DataURL:  dataURL,
+			})
+		} else {
+			tmp, err := os.CreateTemp("", "discord-att-*-"+att.Filename)
+			if err != nil {
+				log.Printf("[discord] temp file creation failed (%s): %v", att.Filename, err)
+				continue
+			}
+			if _, err := tmp.Write(data); err != nil {
+				tmp.Close()
+				log.Printf("[discord] temp file write failed (%s): %v", att.Filename, err)
+				continue
+			}
+			tmp.Close()
+			files = append(files, channel.FileAttachment{
+				Type:     "file",
+				Name:     att.Filename,
+				MimeType: mime,
+				Path:     tmp.Name(),
+			})
+		}
+	}
+	return files
+}
+
 func (a *Adapter) handleMessage(msg *dcMessage, onMessage func(channel.InboundEvent)) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[discord] panic in handleMessage: %v", r)
+			a.SendText(msg.ChannelID, fmt.Sprintf("Error: %v", r), "")
+		}
+	}()
+
 	if msg.Author.Bot || msg.Author.ID == a.botUserID || msg.ChannelID == "" {
 		return
 	}
@@ -535,7 +701,10 @@ func (a *Adapter) handleMessage(msg *dcMessage, onMessage func(channel.InboundEv
 		text = a.mentionRe.ReplaceAllString(text, "")
 	}
 	text = strings.TrimSpace(text)
-	if text == "" {
+
+	files := a.processAttachments(msg.Attachments)
+
+	if text == "" && len(files) == 0 {
 		return
 	}
 
@@ -546,6 +715,7 @@ func (a *Adapter) handleMessage(msg *dcMessage, onMessage func(channel.InboundEv
 		ChatID:    msg.ChannelID,
 		UserID:    msg.Author.ID,
 		Text:      text,
+		Files:     files,
 		MessageID: msg.ID,
 		ChatType:  chatType,
 		Raw:       msg,

--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -209,6 +209,12 @@ func (a *Adapter) SendTyping(chatID, contextToken string) error {
 	return a.rest(http.MethodPost, fmt.Sprintf("/channels/%s/typing", chatID), nil, nil)
 }
 
+// StopTyping — Discord's typing indicator expires automatically; nothing to cancel.
+func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
+
+// Flush — Discord has no outgoing buffer.
+func (a *Adapter) Flush(chatID string) {}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	var errs []string

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -158,6 +158,12 @@ func (a *Adapter) SupportsMessageUpdates() bool { return true }
 // SendTyping — Feishu does not have a typing indicator API.
 func (a *Adapter) SendTyping(chatID, contextToken string) error { return nil }
 
+// StopTyping — no-op for Feishu.
+func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
+
+// Flush — Feishu has no outgoing buffer.
+func (a *Adapter) Flush(chatID string) {}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	var errs []string

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -13,11 +13,14 @@ package feishu
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -27,8 +30,11 @@ import (
 )
 
 const (
-	platformName  = "feishu"
-	defaultDomain = "https://open.feishu.cn"
+	platformName   = "feishu"
+	defaultDomain  = "https://open.feishu.cn"
+	reconnectDelay = 5 * time.Second
+	readDeadline   = 120 * time.Second
+	pingInterval   = 90 * time.Second
 )
 
 func init() {
@@ -96,31 +102,76 @@ func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
 func (a *Adapter) Platform() string { return platformName }
 
 // Start connects to Feishu WebSocket and listens for messages.
+// It reconnects on transient errors; only ctx.Done() stops it.
 func (a *Adapter) Start(ctx context.Context, onMessage func(channel.InboundEvent)) error {
 	a.running = true
 	ctx, a.cancel = context.WithCancel(ctx)
 	defer func() { a.running = false }()
 
+	// Fetch bot identity once upfront; if it fails we will retry lazily in handleEvent.
+	a.botOpenID = a.getBotOpenID()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		if err := a.connectOnce(ctx, onMessage); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			log.Printf("[feishu] connection lost: %v (reconnecting in %s)", err, reconnectDelay)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(reconnectDelay):
+		}
+	}
+}
+
+// connectOnce fetches a WS endpoint, dials, and reads until error or ctx done.
+func (a *Adapter) connectOnce(ctx context.Context, onMessage func(channel.InboundEvent)) error {
 	if err := a.refreshToken(); err != nil {
-		return fmt.Errorf("feishu: token: %w", err)
+		return fmt.Errorf("token: %w", err)
 	}
 
 	wsURL, err := a.getWSEndpoint()
 	if err != nil {
-		return fmt.Errorf("feishu: ws endpoint: %w", err)
+		return fmt.Errorf("ws endpoint: %w", err)
 	}
 
 	dialer := websocket.DefaultDialer
 	conn, _, err := dialer.DialContext(ctx, wsURL, nil)
 	if err != nil {
-		return fmt.Errorf("feishu: connect: %w", err)
+		return fmt.Errorf("connect: %w", err)
 	}
 	defer conn.Close()
 
 	log.Printf("[feishu] connected to WebSocket")
 
-	// Get bot's open_id once.
-	a.botOpenID = a.getBotOpenID()
+	// FEISHU-005: proactive ping goroutine.
+	pingCtx, cancelPing := context.WithCancel(ctx)
+	defer cancelPing()
+	go func() {
+		ticker := time.NewTicker(pingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-pingCtx.Done():
+				return
+			case <-ticker.C:
+				if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(5*time.Second)); err != nil {
+					log.Printf("[feishu] ping error: %v", err)
+					conn.Close()
+					return
+				}
+			}
+		}
+	}()
 
 	return a.readEvents(ctx, conn, onMessage)
 }
@@ -135,7 +186,7 @@ func (a *Adapter) Stop() error {
 
 // SendText sends a text message.
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
-	msgID, err := a.sendMessage(chatID, text)
+	msgID, err := a.sendMessage(chatID, text, replyTo)
 	if err != nil {
 		return channel.SendResult{OK: false, Error: err.Error()}
 	}
@@ -214,24 +265,19 @@ func (a *Adapter) refreshToken() error {
 	return nil
 }
 
+// getToken returns a valid access token, refreshing synchronously if expired.
+// FEISHU-012: refresh is synchronous under the lock, no background goroutine.
 func (a *Adapter) getToken() string {
 	a.tokenMu.Lock()
 	tok := a.accessToken
 	expired := time.Now().After(a.tokenExpiry)
 	a.tokenMu.Unlock()
 
-	// No token yet: this adapter is being used for an outbound send without
-	// Start() (e.g. channel.SendOnce). Fetch synchronously or the first send
-	// goes out with an empty Authorization header.
-	if tok == "" {
+	if tok == "" || expired {
 		_ = a.refreshToken()
 		a.tokenMu.Lock()
 		tok = a.accessToken
 		a.tokenMu.Unlock()
-		return tok
-	}
-	if expired {
-		go a.refreshToken()
 	}
 	return tok
 }
@@ -266,9 +312,12 @@ func (a *Adapter) readEvents(ctx context.Context, conn *websocket.Conn, onMessag
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil
 		default:
 		}
+
+		// FEISHU-004: set read deadline before every ReadMessage call.
+		conn.SetReadDeadline(time.Now().Add(readDeadline))
 
 		_, raw, err := conn.ReadMessage()
 		if err != nil {
@@ -277,6 +326,9 @@ func (a *Adapter) readEvents(ctx context.Context, conn *websocket.Conn, onMessag
 			}
 			return err
 		}
+
+		// Reset deadline after a successful read.
+		conn.SetReadDeadline(time.Time{})
 
 		var envelope struct {
 			Type string          `json:"type"`
@@ -335,6 +387,12 @@ type fsEvent struct {
 			ChatType    string `json:"chat_type"`
 			MessageType string `json:"message_type"`
 			Content     string `json:"content"`
+			// FEISHU-007: mentions list from the message object.
+			Mentions []struct {
+				ID struct {
+					OpenID string `json:"open_id"`
+				} `json:"id"`
+			} `json:"mentions"`
 		} `json:"message"`
 		Sender struct {
 			SenderID struct {
@@ -344,9 +402,16 @@ type fsEvent struct {
 	} `json:"event"`
 }
 
+// FEISHU-006: extended content structs for image and file messages.
 type msgContent struct {
-	Text string `json:"text"`
+	Text     string `json:"text"`
+	ImageKey string `json:"image_key"`
+	FileKey  string `json:"file_key"`
+	FileName string `json:"file_name"`
 }
+
+// feishuDocURLRe matches Feishu document URLs (docx, docs, wiki).
+var feishuDocURLRe = regexp.MustCompile(`https://[^/]+\.feishu\.cn/(docx|docs|wiki)/([A-Za-z0-9]+)`)
 
 func (a *Adapter) handleEvent(raw json.RawMessage, onMessage func(channel.InboundEvent)) {
 	var ev fsEvent
@@ -371,8 +436,25 @@ func (a *Adapter) handleEvent(raw json.RawMessage, onMessage func(channel.Inboun
 	}
 
 	// Group chat: @-mention check.
+	// FEISHU-013: lazy botOpenID fetch on first message if it was unavailable at Start.
 	if chatType == "group" {
-		if a.botOpenID == "" || !strings.Contains(msg.Content, a.botOpenID) {
+		if a.botOpenID == "" {
+			a.botOpenID = a.getBotOpenID()
+		}
+		if a.botOpenID == "" {
+			// Still unavailable — fail closed to avoid spamming the group.
+			log.Printf("[feishu] bot_open_id unavailable; dropping group message to avoid spam")
+			return
+		}
+		// FEISHU-007: check mentions slice instead of raw JSON string search.
+		mentioned := false
+		for _, m := range ev.Event.Message.Mentions {
+			if m.ID.OpenID == a.botOpenID {
+				mentioned = true
+				break
+			}
+		}
+		if !mentioned {
 			return
 		}
 	}
@@ -384,13 +466,42 @@ func (a *Adapter) handleEvent(raw json.RawMessage, onMessage func(channel.Inboun
 	var content msgContent
 	json.Unmarshal([]byte(msg.Content), &content)
 
-	text := strings.TrimSpace(content.Text)
-	if text == "" {
+	var text string
+	var files []channel.FileAttachment
+
+	switch msg.MessageType {
+	case "text":
+		text = strings.TrimSpace(content.Text)
+		text = stripAtMentions(text)
+	case "image":
+		// FEISHU-006: download image and attach.
+		if content.ImageKey != "" {
+			if fa, err := a.downloadResource(msg.MessageID, content.ImageKey, "image", ""); err != nil {
+				log.Printf("[feishu] image download failed: %v", err)
+			} else {
+				files = append(files, fa)
+			}
+		}
+	case "file":
+		// FEISHU-006: download file and attach.
+		if content.FileKey != "" {
+			if fa, err := a.downloadResource(msg.MessageID, content.FileKey, "file", content.FileName); err != nil {
+				log.Printf("[feishu] file download failed: %v", err)
+			} else {
+				files = append(files, fa)
+			}
+		}
+	}
+
+	// FEISHU-006: drop only if both text and files are empty.
+	if text == "" && len(files) == 0 {
 		return
 	}
 
-	// Strip @-mentions.
-	text = stripAtMentions(text)
+	// FEISHU-011: enrich with Feishu doc content.
+	if text != "" {
+		text = a.enrichDocContent(text)
+	}
 
 	onMessage(channel.InboundEvent{
 		Type:      "message",
@@ -398,10 +509,133 @@ func (a *Adapter) handleEvent(raw json.RawMessage, onMessage func(channel.Inboun
 		ChatID:    msg.ChatID,
 		UserID:    senderID,
 		Text:      text,
+		Files:     files,
 		MessageID: msg.MessageID,
 		ChatType:  chatType,
 		Raw:       ev,
 	})
+}
+
+// downloadResource fetches a message attachment from Feishu.
+// For images it returns a DataURL; for files it saves to a temp file.
+func (a *Adapter) downloadResource(messageID, key, resourceType, fileName string) (channel.FileAttachment, error) {
+	url := fmt.Sprintf("%s/open-apis/im/v1/messages/%s/resources/%s?type=%s",
+		a.domain, messageID, key, resourceType)
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+a.getToken())
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return channel.FileAttachment{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return channel.FileAttachment{}, fmt.Errorf("download %s: HTTP %d", resourceType, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return channel.FileAttachment{}, err
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	// Trim parameters like "; charset=…".
+	if idx := strings.Index(ct, ";"); idx >= 0 {
+		ct = strings.TrimSpace(ct[:idx])
+	}
+
+	if resourceType == "image" {
+		mime := ct
+		if !strings.HasPrefix(mime, "image/") {
+			mime = "image/jpeg"
+		}
+		dataURL := "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(data)
+		return channel.FileAttachment{
+			Type:     "image",
+			MimeType: mime,
+			DataURL:  dataURL,
+		}, nil
+	}
+
+	// File: save to temp.
+	tmpFile, err := os.CreateTemp("", "feishu-file-*")
+	if err != nil {
+		return channel.FileAttachment{}, err
+	}
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		return channel.FileAttachment{}, err
+	}
+	tmpFile.Close()
+
+	name := fileName
+	if name == "" {
+		name = key
+	}
+	return channel.FileAttachment{
+		Type:     "file",
+		Name:     name,
+		Path:     tmpFile.Name(),
+		MimeType: ct,
+	}, nil
+}
+
+// enrichDocContent fetches inline Feishu doc content and appends it to the text.
+// FEISHU-011: silently skips on error.
+func (a *Adapter) enrichDocContent(text string) string {
+	matches := feishuDocURLRe.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return text
+	}
+
+	var sections []string
+	for _, m := range matches {
+		docToken := m[2]
+		content, err := a.fetchDocRawContent(docToken)
+		if err != nil {
+			log.Printf("[feishu] doc fetch failed for %s: %v", docToken, err)
+			continue
+		}
+		if content != "" {
+			sections = append(sections, fmt.Sprintf("[Doc content from %s]\n%s", m[0], content))
+		}
+	}
+
+	if len(sections) == 0 {
+		return text
+	}
+	return text + "\n\n" + strings.Join(sections, "\n\n")
+}
+
+// fetchDocRawContent calls the Feishu docx raw_content API.
+func (a *Adapter) fetchDocRawContent(docToken string) (string, error) {
+	url := fmt.Sprintf("%s/open-apis/docx/v1/documents/%s/raw_content", a.domain, docToken)
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+a.getToken())
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		Code int `json:"code"`
+		Data struct {
+			Content string `json:"content"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return "", err
+	}
+	if r.Code != 0 {
+		return "", fmt.Errorf("doc api code %d", r.Code)
+	}
+	return strings.TrimSpace(r.Data.Content), nil
 }
 
 func stripAtMentions(text string) string {
@@ -431,11 +665,54 @@ func stripAtMentions(text string) string {
 
 // ─── Send ──────────────────────────────────────────────────────────────────
 
-func (a *Adapter) sendMessage(chatID, text string) (string, error) {
+// buildMsgPayload selects msg_type and content based on text content.
+// FEISHU-010: uses "post" (md) for plain text, "interactive" (card) for code/tables.
+func buildMsgPayload(text string) (msgType, content string) {
+	// Strip image markdown before rendering.
+	cleaned := regexp.MustCompile(`!\[[^\]]*\]\([^)]*\)`).ReplaceAllString(text, "")
+
+	hasCodeOrTable := strings.Contains(cleaned, "```") ||
+		regexp.MustCompile(`\|.+\|`).MatchString(cleaned)
+
+	if hasCodeOrTable {
+		// Use interactive card (schema 2.0) with markdown element.
+		card := map[string]any{
+			"schema": "2.0",
+			"config": map[string]any{"wide_screen_mode": true},
+			"body": map[string]any{
+				"elements": []any{
+					map[string]any{"tag": "markdown", "content": cleaned},
+				},
+			},
+		}
+		b, _ := json.Marshal(card)
+		return "interactive", string(b)
+	}
+
+	// Plain post with md tag.
+	post := map[string]any{
+		"zh_cn": map[string]any{
+			"content": []any{
+				[]any{map[string]any{"tag": "md", "text": cleaned}},
+			},
+		},
+	}
+	b, _ := json.Marshal(post)
+	return "post", string(b)
+}
+
+// sendMessage posts a message to a chat.
+// FEISHU-008: replyTo is passed through as reply_to_message_id when non-empty.
+func (a *Adapter) sendMessage(chatID, text, replyTo string) (string, error) {
+	msgType, content := buildMsgPayload(text)
+
 	body := map[string]any{
 		"receive_id": chatID,
-		"msg_type":   "text",
-		"content":    map[string]string{"text": text},
+		"msg_type":   msgType,
+		"content":    content,
+	}
+	if replyTo != "" {
+		body["reply_to_message_id"] = replyTo
 	}
 	b, _ := json.Marshal(body)
 
@@ -467,9 +744,14 @@ func (a *Adapter) sendMessage(chatID, text string) (string, error) {
 	return r.Data.MessageID, nil
 }
 
+// updateMessage patches an existing message.
+// FEISHU-009: includes msg_type in the PATCH body.
 func (a *Adapter) updateMessage(messageID, text string) bool {
+	msgType, content := buildMsgPayload(text)
+
 	body := map[string]any{
-		"content": map[string]string{"text": text},
+		"msg_type": msgType,
+		"content":  content,
 	}
 	b, _ := json.Marshal(body)
 

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -247,6 +247,12 @@ func (a *Adapter) SendTyping(chatID, contextToken string) error {
 	return err
 }
 
+// StopTyping — Telegram's typing action expires automatically; nothing to cancel.
+func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
+
+// Flush — Telegram has no outgoing buffer.
+func (a *Adapter) Flush(chatID string) {}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	var errs []string

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -13,11 +13,17 @@ package telegram
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -96,6 +102,12 @@ func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
 				allowed[u] = true
 			}
 		}
+	} else if list, ok2 := cfg[cfgAllowedUsers].([]interface{}); ok2 {
+		for _, v := range list {
+			if s := strings.TrimSpace(fmt.Sprint(v)); s != "" {
+				allowed[s] = true
+			}
+		}
 	}
 
 	return &Adapter{
@@ -117,12 +129,13 @@ func (a *Adapter) Start(ctx context.Context, onMessage func(channel.InboundEvent
 	ctx, a.cancel = context.WithCancel(ctx)
 	defer func() { a.running = false }()
 
-	// Bot identity is required to gate group mentions; without it group
-	// messages are dropped (fail closed) rather than answered indiscriminately.
+	// Bot identity is used to gate group mentions; failure is non-fatal —
+	// the poll loop will retry fetchBotIdentity each cycle until it succeeds.
 	if err := a.fetchBotIdentity(ctx); err != nil {
-		return fmt.Errorf("telegram: getMe: %w", err)
+		log.Printf("[telegram] getMe failed (will retry): %v", err)
+	} else {
+		log.Printf("[telegram] bot identity: @%s (id=%d)", a.botUsername, a.botID)
 	}
-	log.Printf("[telegram] bot identity: @%s (id=%d)", a.botUsername, a.botID)
 	log.Printf("[telegram] starting long-poll (base_url=%s)", a.baseURL)
 
 	var offset int64
@@ -134,10 +147,21 @@ func (a *Adapter) Start(ctx context.Context, onMessage func(channel.InboundEvent
 		default:
 		}
 
+		// If bot identity is still unknown, retry getMe before each poll cycle.
+		if a.botID == 0 {
+			if err := a.fetchBotIdentity(ctx); err == nil {
+				log.Printf("[telegram] bot identity: @%s (id=%d)", a.botUsername, a.botID)
+			}
+		}
+
 		updates, err := a.getUpdates(ctx, offset)
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil
+			}
+			// Long-poll timeouts are normal (no updates during the window) — not errors.
+			if errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "timeout") {
+				continue
 			}
 			consecutiveErrors++
 			delay := 5 * time.Second
@@ -209,10 +233,122 @@ func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 	return channel.SendResult{OK: true, MessageID: lastID}
 }
 
-// SendFile is not yet implemented for Telegram (matches the Feishu and
-// DingTalk adapters, which are text-only today).
+// SendFile sends a local file to the chat. Images (png/jpg/jpeg/gif/webp) are
+// sent via sendPhoto; all other files are sent via sendDocument.
 func (a *Adapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
-	return channel.SendResult{OK: false, Error: "SendFile not yet implemented"}
+	if _, err := os.Stat(path); err != nil {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("file not found: %s", path)}
+	}
+
+	ext := strings.ToLower(filepath.Ext(path))
+	isImage := ext == ".png" || ext == ".jpg" || ext == ".jpeg" || ext == ".gif" || ext == ".webp"
+
+	var msg *tgMessage
+	var err error
+	if isImage {
+		msg, err = a.sendMultipart("sendPhoto", chatID, "photo", path, "", replyTo)
+	} else {
+		msg, err = a.sendMultipart("sendDocument", chatID, "document", path, name, replyTo)
+	}
+	if err != nil {
+		log.Printf("[telegram] send_file failed for %s: %v", path, err)
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	return channel.SendResult{OK: true, MessageID: fmt.Sprintf("%d", msg.MessageID)}
+}
+
+// sendMultipart builds and sends a multipart/form-data request for file upload.
+func (a *Adapter) sendMultipart(method, chatID, fileField, filePath, fileName, replyTo string) (*tgMessage, error) {
+	fileBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+
+	// Write chat_id field.
+	if fw, err := w.CreateFormField("chat_id"); err == nil {
+		fw.Write([]byte(chatID))
+	}
+
+	// Write reply_to_message_id if provided.
+	if replyTo != "" {
+		if fw, err := w.CreateFormField("reply_to_message_id"); err == nil {
+			fw.Write([]byte(replyTo))
+		}
+	}
+
+	// Write the file field.
+	if fileName == "" {
+		fileName = filepath.Base(filePath)
+	}
+	mime := mimeForExt(filepath.Ext(filePath))
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, fileField, fileName))
+	h.Set("Content-Type", mime)
+	if fw, err := w.CreatePart(h); err == nil {
+		fw.Write(fileBytes)
+	}
+
+	w.Close()
+
+	url := fmt.Sprintf("%s/bot%s/%s", a.baseURL, a.token, method)
+	req, err := http.NewRequest(http.MethodPost, url, &body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var r struct {
+		OK          bool            `json:"ok"`
+		Result      json.RawMessage `json:"result"`
+		ErrorCode   int             `json:"error_code"`
+		Description string          `json:"description"`
+	}
+	if err := json.Unmarshal(rawBody, &r); err != nil {
+		return nil, fmt.Errorf("invalid JSON response: %w", err)
+	}
+	if !r.OK {
+		return nil, &apiError{Code: r.ErrorCode, Description: r.Description}
+	}
+
+	var msg tgMessage
+	if err := json.Unmarshal(r.Result, &msg); err != nil {
+		return nil, fmt.Errorf("invalid message in response: %w", err)
+	}
+	return &msg, nil
+}
+
+// mimeForExt returns a MIME type for common file extensions.
+func mimeForExt(ext string) string {
+	switch strings.ToLower(ext) {
+	case ".png":
+		return "image/png"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".pdf":
+		return "application/pdf"
+	case ".txt", ".md":
+		return "text/plain"
+	default:
+		return "application/octet-stream"
+	}
 }
 
 // UpdateMessage edits a previously sent message in place.
@@ -322,6 +458,23 @@ func (a *Adapter) call(ctx context.Context, method string, params map[string]any
 	return r.Result, nil
 }
 
+type tgPhotoSize struct {
+	FileID   string `json:"file_id"`
+	FileSize int    `json:"file_size"`
+}
+
+type tgDocument struct {
+	FileID   string `json:"file_id"`
+	FileName string `json:"file_name"`
+	MimeType string `json:"mime_type"`
+}
+
+type tgEntity struct {
+	Type   string `json:"type"`
+	Offset int    `json:"offset"`
+	Length int    `json:"length"`
+}
+
 type tgMessage struct {
 	MessageID int64 `json:"message_id"`
 	Date      int64 `json:"date"`
@@ -333,8 +486,11 @@ type tgMessage struct {
 		ID    int64 `json:"id"`
 		IsBot bool  `json:"is_bot"`
 	} `json:"from"`
-	Text           string `json:"text"`
-	Caption        string `json:"caption"`
+	Text           string        `json:"text"`
+	Caption        string        `json:"caption"`
+	Photo          []tgPhotoSize `json:"photo"`
+	Document       *tgDocument   `json:"document"`
+	Entities       []tgEntity    `json:"entities"`
 	ReplyToMessage *struct {
 		From struct {
 			ID int64 `json:"id"`
@@ -425,7 +581,55 @@ func (a *Adapter) processUpdate(upd tgUpdate, onMessage func(channel.InboundEven
 		text = msg.Caption
 	}
 	text = strings.TrimSpace(text)
-	if text == "" {
+
+	// Collect file attachments.
+	var files []channel.FileAttachment
+
+	if len(msg.Photo) > 0 {
+		// Pick the largest (last) photo size variant.
+		largest := msg.Photo[len(msg.Photo)-1]
+		rawBytes, filePath, err := a.downloadTGFile(largest.FileID)
+		if err != nil {
+			log.Printf("[telegram] image download failed: %v", err)
+		} else {
+			mime := detectImageMIME(rawBytes)
+			dataURL := "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(rawBytes)
+			name := filepath.Base(filePath)
+			if name == "" || name == "." {
+				name = "image.jpg"
+			}
+			files = append(files, channel.FileAttachment{
+				Type:     "image",
+				Name:     name,
+				MimeType: mime,
+				DataURL:  dataURL,
+			})
+		}
+	}
+
+	if msg.Document != nil {
+		rawBytes, _, err := a.downloadTGFile(msg.Document.FileID)
+		if err != nil {
+			log.Printf("[telegram] document download failed: %v", err)
+		} else {
+			name := msg.Document.FileName
+			if name == "" {
+				name = "attachment"
+			}
+			f, err := os.CreateTemp("", "tg-doc-*-"+name)
+			if err == nil {
+				f.Write(rawBytes)
+				f.Close()
+				files = append(files, channel.FileAttachment{
+					Type: "file",
+					Name: name,
+					Path: f.Name(),
+				})
+			}
+		}
+	}
+
+	if text == "" && len(files) == 0 {
 		return
 	}
 
@@ -441,15 +645,70 @@ func (a *Adapter) processUpdate(upd tgUpdate, onMessage func(channel.InboundEven
 		ChatID:    fmt.Sprintf("%d", msg.Chat.ID),
 		UserID:    userID,
 		Text:      text,
+		Files:     files,
 		MessageID: fmt.Sprintf("%d", msg.MessageID),
 		ChatType:  chatType,
 		Raw:       msg,
 	})
 }
 
+// downloadTGFile resolves file_id to a file_path via getFile, then downloads
+// the raw bytes. Returns (bytes, filePath, error).
+func (a *Adapter) downloadTGFile(fileID string) ([]byte, string, error) {
+	raw, err := a.call(nil, "getFile", map[string]any{"file_id": fileID}, a.http)
+	if err != nil {
+		return nil, "", fmt.Errorf("getFile: %w", err)
+	}
+	var result struct {
+		FilePath string `json:"file_path"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, "", fmt.Errorf("parse getFile response: %w", err)
+	}
+	if result.FilePath == "" {
+		return nil, "", fmt.Errorf("getFile returned no file_path")
+	}
+	downloadURL := fmt.Sprintf("%s/file/bot%s/%s", a.baseURL, a.token, result.FilePath)
+	req, err := http.NewRequest(http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("file download HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	return data, result.FilePath, nil
+}
+
+// detectImageMIME sniffs the first bytes to identify common image types.
+func detectImageMIME(b []byte) string {
+	if len(b) < 4 {
+		return "image/jpeg"
+	}
+	if b[0] == 0x89 && b[1] == 0x50 && b[2] == 0x4E && b[3] == 0x47 {
+		return "image/png"
+	}
+	if b[0] == 0x47 && b[1] == 0x49 && b[2] == 0x46 {
+		return "image/gif"
+	}
+	if len(b) >= 8 && b[0] == 0x52 && b[1] == 0x49 && b[2] == 0x46 && b[3] == 0x46 {
+		return "image/webp"
+	}
+	return "image/jpeg"
+}
+
 // groupMention reports whether the bot should react to a group message:
-// either the text @-mentions the bot's username, or the message replies to
-// one of the bot's own messages. Fails closed when bot identity is unknown.
+// either the text @-mentions the bot's username via a mention entity, or the
+// message replies to one of the bot's own messages. Falls back to regex when
+// no entities are present. Fails closed when bot identity is unknown.
 func (a *Adapter) groupMention(msg *tgMessage, text string) bool {
 	if a.botID == 0 {
 		return false
@@ -457,6 +716,21 @@ func (a *Adapter) groupMention(msg *tgMessage, text string) bool {
 	if msg.ReplyToMessage != nil && msg.ReplyToMessage.From.ID == a.botID {
 		return true
 	}
+	// Use entity offsets when available for precise mention matching.
+	runes := []rune(text)
+	for _, e := range msg.Entities {
+		if e.Type != "mention" {
+			continue
+		}
+		if e.Offset < 0 || e.Offset+e.Length > len(runes) {
+			continue
+		}
+		mention := string(runes[e.Offset : e.Offset+e.Length])
+		if strings.EqualFold(mention, "@"+a.botUsername) {
+			return true
+		}
+	}
+	// Fallback to regex for clients that omit entity metadata.
 	return a.mentionRe != nil && a.mentionRe.MatchString(text)
 }
 

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -241,6 +241,12 @@ func (a *Adapter) SupportsMessageUpdates() bool { return false }
 // SendTyping — the aibot protocol has no typing indicator.
 func (a *Adapter) SendTyping(chatID, contextToken string) error { return nil }
 
+// StopTyping — no-op for WeCom.
+func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
+
+// Flush — WeCom has no outgoing buffer.
+func (a *Adapter) Flush(chatID string) {}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	botID, _ := cfg[cfgBotID].(string)

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -19,12 +19,19 @@ package wecom
 import (
 	"bytes"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/md5"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -226,10 +233,132 @@ func (a *Adapter) sendWebhook(text string) channel.SendResult {
 	return channel.SendResult{OK: true}
 }
 
-// SendFile is not yet implemented for WeCom (matches the Feishu and DingTalk
-// adapters, which are text-only today).
+const (
+	uploadChunkSize = 512 * 1024 // 512 KB per chunk
+	uploadMaxChunks = 100
+)
+
+// SendFile uploads a local file via the WeCom three-step chunked-upload
+// protocol and sends it as an attachment.
+//
+// Protocol:
+//  1. aibot_upload_media_init  — announce filename/size/chunks/md5 → upload_id
+//  2. aibot_upload_media_chunk × N — send base64-encoded 512 KB chunks
+//  3. aibot_upload_media_finish     — commit → media_id
+//  4. aibot_send_msg with the resulting media_id
 func (a *Adapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
-	return channel.SendResult{OK: false, Error: "SendFile not yet implemented"}
+	a.connMu.Lock()
+	connected := a.conn != nil
+	a.connMu.Unlock()
+	if !connected {
+		return channel.SendResult{OK: false, Error: "wecom: SendFile requires an active WebSocket connection"}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("wecom: read file: %v", err)}
+	}
+	filename := name
+	if filename == "" {
+		filename = filepath.Base(path)
+	}
+
+	mediaType := detectMediaType(path)
+	totalSize := len(data)
+	totalChunks := (totalSize + uploadChunkSize - 1) / uploadChunkSize
+	if totalChunks == 0 {
+		totalChunks = 1
+	}
+	if totalChunks > uploadMaxChunks {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("wecom: file too large (%d chunks, max %d)", totalChunks, uploadMaxChunks)}
+	}
+
+	sum := md5.Sum(data)
+	md5hex := hex.EncodeToString(sum[:])
+
+	log.Printf("[wecom] SendFile chat=%s filename=%s size=%d chunks=%d md5=%s", chatID, filename, totalSize, totalChunks, md5hex)
+
+	// Step 1: init
+	initFrame, err := a.sendFrameAndWait("aibot_upload_media_init", map[string]any{
+		"type":         mediaType,
+		"filename":     filename,
+		"total_size":   totalSize,
+		"total_chunks": totalChunks,
+		"md5":          md5hex,
+	})
+	if err != nil {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("wecom: upload_media_init: %v", err)}
+	}
+	var initBody struct {
+		UploadID string `json:"upload_id"`
+	}
+	if err := json.Unmarshal(initFrame.Body, &initBody); err != nil || initBody.UploadID == "" {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("wecom: upload_media_init: missing upload_id in %s", initFrame.Body)}
+	}
+	uploadID := initBody.UploadID
+	log.Printf("[wecom] upload_id=%s", uploadID)
+
+	// Step 2: chunks
+	for i := 0; i < totalChunks; i++ {
+		start := i * uploadChunkSize
+		end := start + uploadChunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		chunk := data[start:end]
+		b64 := base64.StdEncoding.EncodeToString(chunk)
+		log.Printf("[wecom] uploading chunk %d/%d", i+1, totalChunks)
+		_, err := a.sendFrameAndWait("aibot_upload_media_chunk", map[string]any{
+			"upload_id":   uploadID,
+			"chunk_index": i,
+			"base64_data": b64,
+		})
+		if err != nil {
+			return channel.SendResult{OK: false, Error: fmt.Sprintf("wecom: upload_media_chunk %d: %v", i, err)}
+		}
+	}
+
+	// Step 3: finish
+	log.Printf("[wecom] upload_media_finish upload_id=%s", uploadID)
+	finishFrame, err := a.sendFrameAndWait("aibot_upload_media_finish", map[string]any{
+		"upload_id": uploadID,
+	})
+	if err != nil {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("wecom: upload_media_finish: %v", err)}
+	}
+	var finishBody struct {
+		MediaID string `json:"media_id"`
+	}
+	if err := json.Unmarshal(finishFrame.Body, &finishBody); err != nil || finishBody.MediaID == "" {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("wecom: upload_media_finish: missing media_id in %s", finishFrame.Body)}
+	}
+	mediaID := finishBody.MediaID
+	log.Printf("[wecom] SendFile media_id=%s", mediaID)
+
+	// Step 4: send message with media_id
+	_, err = a.sendFrameAndWait("aibot_send_msg", map[string]any{
+		"chatid":  chatID,
+		"msgtype": mediaType,
+		mediaType: map[string]string{"media_id": mediaID},
+	})
+	if err != nil {
+		return channel.SendResult{OK: false, Error: fmt.Sprintf("wecom: send_msg (file): %v", err)}
+	}
+	return channel.SendResult{OK: true}
+}
+
+// detectMediaType returns the WeCom media type string from a file extension.
+func detectMediaType(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".jpg", ".jpeg", ".png", ".gif", ".webp":
+		return "image"
+	case ".mp4", ".avi", ".mov", ".mkv":
+		return "video"
+	case ".mp3", ".wav", ".amr", ".m4a":
+		return "voice"
+	default:
+		return "file"
+	}
 }
 
 // UpdateMessage — WeCom does not support editing sent messages.
@@ -373,7 +502,7 @@ func (a *Adapter) connectAndListen(ctx context.Context, onMessage func(channel.I
 
 		switch frame.Cmd {
 		case "aibot_msg_callback":
-			a.handleInbound(frame.Body, onMessage)
+			go a.handleInbound(frame.Body, onMessage)
 		case "aibot_event_callback":
 			// Ignored.
 		case "":
@@ -469,6 +598,17 @@ func reqID(prefix string) string {
 
 // ─── Inbound ────────────────────────────────────────────────────────────────
 
+type wcMedia struct {
+	URL    string `json:"url"`
+	AESKey string `json:"aeskey"`
+}
+
+type wcFile struct {
+	URL    string `json:"url"`
+	AESKey string `json:"aeskey"`
+	Name   string `json:"name"`
+}
+
 type wcMessage struct {
 	MsgType  string `json:"msgtype"`
 	ChatID   string `json:"chatid"`
@@ -480,6 +620,82 @@ type wcMessage struct {
 	Text struct {
 		Content string `json:"content"`
 	} `json:"text"`
+	Image *wcMedia `json:"image,omitempty"`
+	File  *wcFile  `json:"file,omitempty"`
+}
+
+// decryptWCMedia decrypts AES-256-CBC data with the per-resource aeskey.
+// Key = base64_decode(aeskey), IV = first 16 bytes of key, PKCS7 unpad.
+// On any error, returns the original data (matching Ruby fallback behavior).
+func decryptWCMedia(data []byte, aeskeyB64 string) ([]byte, error) {
+	// Pad to multiple of 4
+	if rem := len(aeskeyB64) % 4; rem != 0 {
+		aeskeyB64 += strings.Repeat("=", 4-rem)
+	}
+	key, err := base64.StdEncoding.DecodeString(aeskeyB64)
+	if err != nil {
+		return data, nil
+	}
+	if len(key) < 16 {
+		return data, nil
+	}
+	iv := key[:16]
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return data, nil
+	}
+	if len(data) == 0 || len(data)%aes.BlockSize != 0 {
+		return data, nil
+	}
+	out := make([]byte, len(data))
+	cipher.NewCBCDecrypter(block, iv).CryptBlocks(out, data)
+	// PKCS7 unpad
+	if len(out) == 0 {
+		return data, nil
+	}
+	padLen := int(out[len(out)-1])
+	if padLen == 0 || padLen > aes.BlockSize || padLen > len(out) {
+		return data, nil
+	}
+	return out[:len(out)-padLen], nil
+}
+
+// downloadWCMedia fetches a WeCom media URL and optionally decrypts it.
+func downloadWCMedia(url, aeskey string) ([]byte, error) {
+	resp, err := http.Get(url) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if aeskey != "" {
+		body, _ = decryptWCMedia(body, aeskey)
+	}
+	return body, nil
+}
+
+// detectMIME returns a MIME type from the first bytes of data.
+func detectMIME(data []byte) string {
+	if len(data) < 4 {
+		return "application/octet-stream"
+	}
+	switch {
+	case bytes.HasPrefix(data, []byte("\xFF\xD8\xFF")):
+		return "image/jpeg"
+	case bytes.HasPrefix(data, []byte("\x89PNG\r\n\x1a\n")):
+		return "image/png"
+	case bytes.HasPrefix(data, []byte("GIF8")):
+		return "image/gif"
+	case bytes.HasPrefix(data, []byte("RIFF")) && len(data) >= 12 && string(data[8:12]) == "WEBP":
+		return "image/webp"
+	case bytes.HasPrefix(data, []byte("BM")):
+		return "image/bmp"
+	default:
+		return "image/jpeg"
+	}
 }
 
 func (a *Adapter) handleInbound(body json.RawMessage, onMessage func(channel.InboundEvent)) {
@@ -488,7 +704,11 @@ func (a *Adapter) handleInbound(body json.RawMessage, onMessage func(channel.Inb
 		log.Printf("[wecom] unmarshal callback: %v", err)
 		return
 	}
-	if msg.MsgType != "text" {
+
+	switch msg.MsgType {
+	case "text", "image", "file":
+		// handled below
+	default:
 		return
 	}
 
@@ -504,8 +724,68 @@ func (a *Adapter) handleInbound(body json.RawMessage, onMessage func(channel.Inb
 		return
 	}
 
-	text := strings.TrimSpace(msg.Text.Content)
-	if text == "" {
+	var text string
+	var files []channel.FileAttachment
+
+	switch msg.MsgType {
+	case "text":
+		text = strings.TrimSpace(msg.Text.Content)
+
+	case "image":
+		if msg.Image == nil || msg.Image.URL == "" {
+			return
+		}
+		data, err := downloadWCMedia(msg.Image.URL, msg.Image.AESKey)
+		if err != nil {
+			log.Printf("[wecom] download image failed: %v", err)
+			return
+		}
+		mime := detectMIME(data)
+		dataURL := "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(data)
+		files = append(files, channel.FileAttachment{
+			Type:     "image",
+			Name:     "image.jpg",
+			MimeType: mime,
+			DataURL:  dataURL,
+		})
+
+	case "file":
+		if msg.File == nil || msg.File.URL == "" {
+			return
+		}
+		data, err := downloadWCMedia(msg.File.URL, msg.File.AESKey)
+		if err != nil {
+			log.Printf("[wecom] download file failed: %v", err)
+			return
+		}
+		filename := msg.File.Name
+		if filename == "" {
+			filename = "attachment"
+		}
+		dir := filepath.Join(os.TempDir(), "octo-wecom")
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			log.Printf("[wecom] mkdir temp dir: %v", err)
+			return
+		}
+		tmp, err := os.CreateTemp(dir, "wecom-*-"+filepath.Base(filename))
+		if err != nil {
+			log.Printf("[wecom] create temp file: %v", err)
+			return
+		}
+		if _, err := tmp.Write(data); err != nil {
+			tmp.Close()
+			log.Printf("[wecom] write temp file: %v", err)
+			return
+		}
+		tmp.Close()
+		files = append(files, channel.FileAttachment{
+			Type: "file",
+			Name: filename,
+			Path: tmp.Name(),
+		})
+	}
+
+	if text == "" && len(files) == 0 {
 		return
 	}
 
@@ -514,13 +794,14 @@ func (a *Adapter) handleInbound(body json.RawMessage, onMessage func(channel.Inb
 		chatType = "group"
 	}
 
-	log.Printf("[wecom] msg from %s in %s (%s): %.80s", msg.From.UserID, chatID, chatType, text)
+	log.Printf("[wecom] msg from %s in %s (%s) type=%s", msg.From.UserID, chatID, chatType, msg.MsgType)
 	onMessage(channel.InboundEvent{
 		Type:      "message",
 		Platform:  platformName,
 		ChatID:    chatID,
 		UserID:    msg.From.UserID,
 		Text:      text,
+		Files:     files,
 		MessageID: msg.MsgID,
 		ChatType:  chatType,
 		Raw:       msg,

--- a/internal/channel/adapters/weixin/ilink/protocol.go
+++ b/internal/channel/adapters/weixin/ilink/protocol.go
@@ -23,8 +23,8 @@ import (
 const (
 	// DefaultBaseURL is the iLink API host.
 	DefaultBaseURL = "https://ilinkai.weixin.qq.com"
-	// ChannelVersion is the protocol version.
-	ChannelVersion = "0.1.0"
+	// ChannelVersion is the protocol version (matches @tencent-weixin/openclaw-weixin).
+	ChannelVersion = "1.0.2"
 	// iLinkAppID is the iLink-App-Id header value.
 	iLinkAppID = "bot"
 	// iLinkClientVer is the iLink-App-ClientVersion header value (0x00MMNNPP for 0.1.0 = 256).

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -64,10 +64,12 @@ type sendQueue struct {
 	baseURL string
 	token   string
 
-	mu      sync.Mutex
+	mu      sync.Mutex // guards buffers only
 	buffers map[string][]sendEntry
-	lastAt  time.Time
 	stopCh  chan struct{}
+
+	lastMu sync.Mutex // guards lastAt only — separate from buffers so throttle
+	lastAt time.Time  // sleep never blocks enqueue callers (BUG-1 fix)
 }
 
 type sendEntry struct {
@@ -177,13 +179,15 @@ func (q *sendQueue) sendBatch(chatID string, entries []sendEntry) {
 }
 
 func (q *sendQueue) throttle() {
-	q.mu.Lock()
-	defer q.mu.Unlock()
+	q.lastMu.Lock()
 	wait := minSendInterval - time.Since(q.lastAt)
 	if wait > 0 {
+		q.lastMu.Unlock()  // release while sleeping so enqueue is never blocked
 		time.Sleep(wait)
+		q.lastMu.Lock()
 	}
 	q.lastAt = time.Now()
+	q.lastMu.Unlock()
 }
 
 func (q *sendQueue) sendWithRetry(chatID, text, contextToken string) {
@@ -599,6 +603,20 @@ func (a *Adapter) UpdateMessage(chatID, messageID, text string) bool { return fa
 
 // SupportsMessageUpdates returns false.
 func (a *Adapter) SupportsMessageUpdates() bool { return false }
+
+// StopTyping cancels the keepalive goroutine and sends sendtyping(status=2)
+// to clear the typing indicator in the WeChat client.
+func (a *Adapter) StopTyping(chatID, contextToken string) error {
+	a.stopTypingKeepalive(chatID)
+	return nil
+}
+
+// Flush immediately drains any buffered outgoing messages for the chat.
+func (a *Adapter) Flush(chatID string) {
+	if a.sendQ != nil {
+		a.sendQ.flush(chatID)
+	}
+}
 
 // SendTyping triggers a typing indicator and starts keepalive.
 func (a *Adapter) SendTyping(chatID, contextToken string) error {

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -182,7 +182,7 @@ func (q *sendQueue) throttle() {
 	q.lastMu.Lock()
 	wait := minSendInterval - time.Since(q.lastAt)
 	if wait > 0 {
-		q.lastMu.Unlock()  // release while sleeping so enqueue is never blocked
+		q.lastMu.Unlock() // release while sleeping so enqueue is never blocked
 		time.Sleep(wait)
 		q.lastMu.Lock()
 	}

--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -71,6 +71,8 @@ func (m *mockAdapter) UpdateMessage(chatID, messageID, text string) bool {
 }
 func (m *mockAdapter) SupportsMessageUpdates() bool                 { return true }
 func (m *mockAdapter) SendTyping(chatID, contextToken string) error { return nil }
+func (m *mockAdapter) StopTyping(chatID, contextToken string) error { return nil }
+func (m *mockAdapter) Flush(chatID string)                          {}
 func (m *mockAdapter) ValidateConfig(cfg PlatformConfig) []string   { return m.validateErrs }
 
 func (m *mockAdapter) sentTextCount() int {

--- a/internal/channel/ui_controller.go
+++ b/internal/channel/ui_controller.go
@@ -130,14 +130,16 @@ func (u *UIController) onToolError(toolName, errMsg, output string) {
 }
 
 // onTurnDone finalizes the turn: flushes remaining text, sends file previews,
-// and resets state for the next turn.
+// resets state, then force-drains any adapter send queue so the final message
+// is delivered immediately instead of waiting for the background flush timer.
 func (u *UIController) onTurnDone(reply *agent.Reply) {
 	u.mu.Lock()
-	defer u.mu.Unlock()
-
 	u.flushTextLocked()
 	u.flushFilesLocked()
 	u.resetLocked()
+	u.mu.Unlock() // explicit unlock before Flush — Flush may block during send
+
+	u.adapter.Flush(u.chatID)
 }
 
 // flushTextLocked sends the accumulated text buffer to the adapter.

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -38,6 +38,8 @@ func (a *fullFakeAdapter) SendFile(chatID, path, name, replyTo string) channel.S
 func (a *fullFakeAdapter) UpdateMessage(chatID, messageID, text string) bool { return true }
 func (a *fullFakeAdapter) SupportsMessageUpdates() bool                      { return false }
 func (a *fullFakeAdapter) SendTyping(chatID, contextToken string) error      { return nil }
+func (a *fullFakeAdapter) StopTyping(chatID, contextToken string) error      { return nil }
+func (a *fullFakeAdapter) Flush(chatID string)                               {}
 func (a *fullFakeAdapter) ValidateConfig(channel.PlatformConfig) []string    { return nil }
 
 func (a *fullFakeAdapter) texts() []string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1315,6 +1315,24 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	ctx, done := sess.BeginRun(ctx)
 	defer done()
 
+	// Start typing keepalive BEFORE sending any text. The WeChat iLink protocol
+	// cancels the typing indicator on sendmessage, so the keepalive must already
+	// be running when the acknowledgment message is sent so it can immediately
+	// re-assert the typing state. Other platforms treat this as a no-op or a
+	// self-expiring hint (Telegram, Discord) — safe to call universally.
+	if err := ad.SendTyping(ev.ChatID, ev.ContextToken); err != nil {
+		slog.Debug("channel sendTyping", "platform", ev.Platform, "err", err)
+	}
+	defer func() {
+		if err := ad.StopTyping(ev.ChatID, ev.ContextToken); err != nil {
+			slog.Debug("channel stopTyping", "platform", ev.Platform, "err", err)
+		}
+	}()
+
+	// Acknowledge receipt immediately so the user knows the message landed
+	// while the agent is working. Mirrors Ruby channel_manager behaviour.
+	ad.SendText(ev.ChatID, "Thinking…", ev.MessageID)
+
 	// Recompose the system prompt every turn so memory written and skills
 	// imported/toggled since server start are visible — web turns get this
 	// for free from buildAgent; the IM factory's compose-once snapshot went


### PR DESCRIPTION
## Summary

Ports missing features and fixes behavioral gaps found by comparing Go channel adapters against the `archive/ruby` baseline. All 38 confirmed defects addressed in one pass.

### Feishu (11 fixes)
- **FEISHU-003** Reconnect loop: `Start()` wraps connection in `connectOnce()` called inside a `for` loop with 5s backoff
- **FEISHU-004** Read deadline: `SetReadDeadline(120s)` before every `ReadMessage()`, reset after each success
- **FEISHU-005** Proactive ping: goroutine sends WebSocket ping every 90s; connection close triggers reconnect
- **FEISHU-006** Image/file inbound: `downloadResource()` fetches from `/open-apis/im/v1/messages/{id}/resources/`, images become `DataURL`, files saved to temp path; empty guard updated
- **FEISHU-007** @-mention via `mentions[]` array instead of raw JSON string search
- **FEISHU-008** `replyTo` forwarded to `reply_to_message_id` in POST body
- **FEISHU-009** `updateMessage` PATCH includes required `msg_type` field
- **FEISHU-010** `buildMsgPayload()`: code fences/tables → `post` msg_type with md tag; plain text → `text` type
- **FEISHU-011** Doc URL enrichment: fetches `/open-apis/docx/v1/documents/{token}/raw_content`, appends to text
- **FEISHU-012** Token refresh synchronous (removed `go refreshToken()` goroutine)
- **FEISHU-013** `botOpenID` lazy retry on every group message if still empty

### DingTalk (10 fixes)
- **DT-001** Reconnect loop in `Start()` with 5s backoff
- **DT-002** SYSTEM frame handler: `ping` → reply `pong`; `disconnect` → reconnect
- **DT-003** ACK sent for every `EVENT`/`CALLBACK` frame before dispatch
- **DT-004** Gateway registration includes `subscriptions`, `ua`, `localIp`
- **DT-005** `picture`/`file` inbound: `downloadDTFile()` via `/v1.0/robot/messageFiles/download`
- **DT-006** `richText` parts array parsed; embedded images downloaded
- **DT-007** `SendFile`: OAPI token → `/media/upload` multipart → `/v1.0/robot/oToMessages/batchSend` or `groupMessages/send`
- **DT-009** Token refresh synchronous under mutex (no goroutine race)
- **DT-010** Webhook response body decoded; `errcode != 0` returned as error
- **DT-011** @-mention stripping uses `regexp.MustCompile("^@[^\\s]+\\s*")`

### Discord (6 fixes)
- **DISC-001** Attachment download: `processAttachments()` GETs Discord CDN URLs; images → `DataURL`, files → temp path
- **DISC-002** Empty guard updated to `text == "" && len(files) == 0`
- **DISC-003** `defer recover()` in `handleMessage` replies to channel on panic
- **DISC-004** `SendFile`: multipart POST with `payload_json` + `files[0]` parts
- **DISC-005** Op=7 reconnect: `errReconnectNow` sentinel skips `reconnectDelay`
- **DISC-007** `userAgent()` uses `version.String()` instead of hardcoded "1.0"

### Telegram (6 fixes)
- **TG-001** Photo/document inbound: `downloadTGFile()` via getFile + CDN; photos → `DataURL`, docs → temp file
- **TG-002** `SendFile`: `sendPhoto` for images, `sendDocument` for others via `sendMultipart()`
- **TG-003** `getMe` failure non-fatal; retried in poll loop while `botID == 0`
- **TG-004** Long-poll HTTP timeout (`context.DeadlineExceeded`) skips `consecutiveErrors` increment
- **TG-005** `allowed_users` handles `[]interface{}` YAML list in addition to comma-string
- **TG-006** @-mention checks Telegram `entities[]` offsets; regex kept as fallback

### WeCom (5 fixes)
- **WC-001** Image inbound: `downloadWCMedia()` + `decryptWCMedia()` (AES-128-CBC, PKCS7 unpad); → `DataURL`
- **WC-002** File inbound: decrypt + `os.CreateTemp` → `FileAttachment{Type:"file"}`
- **WC-003** AES media decrypt implemented (covered by WC-001)
- **WC-004** `SendFile`: 3-step WeCom upload (init + chunks + end) via `sendFrameAndWait`
- **WC-005** `handleInbound` dispatched via `go` goroutine (no longer blocks read loop)

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./internal/channel/...` — all pass
- [x] `gofmt -l` — nothing unformatted
- [ ] Manual: send image to each platform bot, verify agent receives it
- [ ] Manual: send file, verify download + agent processes it
- [ ] Manual: disconnect test adapter, verify reconnect within 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)