### PR TITLE
fix(channels): code review follow-up — LimitReader, panic safety, reconnect fix, regexp hot path

### DIFF
--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -737,7 +737,7 @@ func (a *Adapter) downloadDTFile(downloadCode, robotCode string) ([]byte, string
 	}
 	defer fileResp.Body.Close()
 
-	data, err := io.ReadAll(fileResp.Body)
+	data, err := io.ReadAll(io.LimitReader(fileResp.Body, 50<<20)) // 50 MB cap
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -613,12 +613,12 @@ func (a *Adapter) processAttachments(atts []dcAttachment) []channel.FileAttachme
 		if att.URL == "" {
 			continue
 		}
-		resp, err := http.Get(att.URL) //nolint:noctx // Discord CDN is public; no auth needed
+		resp, err := a.http.Get(att.URL)
 		if err != nil {
 			log.Printf("[discord] attachment download failed (%s): %v", att.Filename, err)
 			continue
 		}
-		data, err := io.ReadAll(resp.Body)
+		data, err := io.ReadAll(io.LimitReader(resp.Body, 50<<20)) // 50 MB cap
 		resp.Body.Close()
 		if err != nil {
 			log.Printf("[discord] attachment read failed (%s): %v", att.Filename, err)
@@ -669,7 +669,7 @@ func (a *Adapter) handleMessage(msg *dcMessage, onMessage func(channel.InboundEv
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("[discord] panic in handleMessage: %v", r)
-			a.SendText(msg.ChannelID, fmt.Sprintf("Error: %v", r), "")
+			a.SendText(msg.ChannelID, "An internal error occurred.", "")
 		}
 	}()
 

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -49,6 +49,12 @@ const (
 	cfgAllowedUsers = "allowed_users"
 )
 
+// Package-level compiled regexps (avoids recompiling on every message send).
+var (
+	feishuStripImgRe = regexp.MustCompile(`!\[[^\]]*\]\([^)]*\)`)
+	feishuTableRe    = regexp.MustCompile(`\|.+\|`)
+)
+
 // Adapter implements channel.Adapter for Feishu.
 type Adapter struct {
 	appID        string
@@ -118,17 +124,17 @@ func (a *Adapter) Start(ctx context.Context, onMessage func(channel.InboundEvent
 		default:
 		}
 
-		if err := a.connectOnce(ctx, onMessage); err != nil {
-			if ctx.Err() != nil {
-				return nil
-			}
-			log.Printf("[feishu] connection lost: %v (reconnecting in %s)", err, reconnectDelay)
-		}
-
-		select {
-		case <-ctx.Done():
+		err := a.connectOnce(ctx, onMessage)
+		if ctx.Err() != nil {
 			return nil
-		case <-time.After(reconnectDelay):
+		}
+		if err != nil {
+			log.Printf("[feishu] connection lost: %v (reconnecting in %s)", err, reconnectDelay)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(reconnectDelay):
+			}
 		}
 	}
 }
@@ -534,7 +540,7 @@ func (a *Adapter) downloadResource(messageID, key, resourceType, fileName string
 		return channel.FileAttachment{}, fmt.Errorf("download %s: HTTP %d", resourceType, resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 50<<20)) // 50 MB cap
 	if err != nil {
 		return channel.FileAttachment{}, err
 	}
@@ -568,6 +574,7 @@ func (a *Adapter) downloadResource(messageID, key, resourceType, fileName string
 	}
 	if _, err := tmpFile.Write(data); err != nil {
 		tmpFile.Close()
+		os.Remove(tmpFile.Name())
 		return channel.FileAttachment{}, err
 	}
 	tmpFile.Close()
@@ -669,10 +676,10 @@ func stripAtMentions(text string) string {
 // FEISHU-010: uses "post" (md) for plain text, "interactive" (card) for code/tables.
 func buildMsgPayload(text string) (msgType, content string) {
 	// Strip image markdown before rendering.
-	cleaned := regexp.MustCompile(`!\[[^\]]*\]\([^)]*\)`).ReplaceAllString(text, "")
+	cleaned := feishuStripImgRe.ReplaceAllString(text, "")
 
 	hasCodeOrTable := strings.Contains(cleaned, "```") ||
-		regexp.MustCompile(`\|.+\|`).MatchString(cleaned)
+		feishuTableRe.MatchString(cleaned)
 
 	if hasCodeOrTable {
 		// Use interactive card (schema 2.0) with markdown element.

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -655,7 +655,7 @@ func (a *Adapter) processUpdate(upd tgUpdate, onMessage func(channel.InboundEven
 // downloadTGFile resolves file_id to a file_path via getFile, then downloads
 // the raw bytes. Returns (bytes, filePath, error).
 func (a *Adapter) downloadTGFile(fileID string) ([]byte, string, error) {
-	raw, err := a.call(nil, "getFile", map[string]any{"file_id": fileID}, a.http)
+	raw, err := a.call(context.Background(), "getFile", map[string]any{"file_id": fileID}, a.http)
 	if err != nil {
 		return nil, "", fmt.Errorf("getFile: %w", err)
 	}
@@ -681,7 +681,7 @@ func (a *Adapter) downloadTGFile(fileID string) ([]byte, string, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, "", fmt.Errorf("file download HTTP %d", resp.StatusCode)
 	}
-	data, err := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 50<<20)) // 50 MB cap
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -667,7 +667,7 @@ func downloadWCMedia(url, aeskey string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 50<<20)) // 50 MB cap
 	if err != nil {
 		return nil, err
 	}
@@ -694,7 +694,7 @@ func detectMIME(data []byte) string {
 	case bytes.HasPrefix(data, []byte("BM")):
 		return "image/bmp"
 	default:
-		return "image/jpeg"
+		return "application/octet-stream"
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #693. Fixes issues found in code review that weren't caught before the squash-merge.

- **Discord**: panic recovery in `handleMessage` was sending `fmt.Sprintf("Error: %v", r)` to the end user, potentially leaking internal paths or runtime detail. Changed to generic `"An internal error occurred."`.
- **All adapters (dingtalk/discord/feishu/telegram/wecom)**: remote file/attachment reads used unbounded `io.ReadAll`. Added `io.LimitReader(resp.Body, 50<<20)` (50 MB cap) on all remote body reads to prevent memory exhaustion from oversized or malicious payloads.
- **Discord**: `processAttachments` used package-level `http.Get` (no timeout) instead of `a.http.Get` (30s timeout) for CDN downloads.
- **Feishu**: reconnect loop slept `reconnectDelay` even when `connectOnce` returned `nil` (clean ctx cancellation), causing a 5s stall on graceful shutdown. Now only sleeps on `err != nil`.
- **Feishu**: `buildMsgPayload` compiled two regexps on every `SendText` call. Extracted to package-level `var`.
- **Feishu**: temp file created in `downloadResource` was not removed on write failure. Added `os.Remove`.
- **WeCom**: `detectMIME` default case returned `"image/jpeg"` for unrecognised non-image binary data. Changed to `"application/octet-stream"`.
- **Telegram**: `downloadTGFile` passed `nil` as context to `call()`. Changed to `context.Background()`.

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./internal/channel/...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)