### PR TITLE
fix(discord): validate attachment URL host before fetch (SSRF)

### DIFF
--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -23,6 +23,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -604,6 +605,24 @@ func (a *Adapter) handleDispatch(typ string, data json.RawMessage, onMessage fun
 	}
 }
 
+// discordCDNHosts are the only hosts Discord serves attachment content from.
+// The attachment URL arrives in the (user-originated) gateway message, so it
+// is validated against this allowlist before any fetch to prevent the bot from
+// being coerced into requesting arbitrary internal URLs (SSRF).
+var discordCDNHosts = map[string]bool{
+	"cdn.discordapp.com":   true,
+	"media.discordapp.net": true,
+}
+
+// allowedAttachmentURL reports whether u is an https URL on a Discord CDN host.
+func allowedAttachmentURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "https" && discordCDNHosts[u.Hostname()]
+}
+
 // processAttachments downloads Discord CDN attachments and returns them as
 // channel.FileAttachment values. Images are base64-encoded into a data URL;
 // other files are saved to a temp file.
@@ -611,6 +630,10 @@ func (a *Adapter) processAttachments(atts []dcAttachment) []channel.FileAttachme
 	var files []channel.FileAttachment
 	for _, att := range atts {
 		if att.URL == "" {
+			continue
+		}
+		if !allowedAttachmentURL(att.URL) {
+			log.Printf("[discord] skipping attachment with non-CDN URL (%s)", att.Filename)
 			continue
 		}
 		resp, err := a.http.Get(att.URL)


### PR DESCRIPTION
## Summary

CodeQL flagged a **critical** `go/request-forgery` (SSRF) alert on the Discord attachment download added in #693/#694. The fix commit didn't make it into #694 before auto-merge, so this addresses it directly on top of current main.

`processAttachments` fetched `att.URL` — a value that arrives in the user-originated Discord gateway message — without validating its host. A crafted message could coerce the bot into requesting arbitrary internal URLs.

## Fix

Added `allowedAttachmentURL()`: only fetches `https` URLs whose host is a known Discord CDN (`cdn.discordapp.com` / `media.discordapp.net`). Discord only ever serves attachment content from these hosts, so this is both the correct domain constraint and the SSRF sanitizer CodeQL needs.

## Test plan
- [x] `go build ./internal/channel/adapters/discord/...`
- [x] `go test ./internal/channel/adapters/discord/...`
- [x] `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)