### PR TITLE
fix(workflow): make script errors actionable so the model retries

### DIFF
--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -126,11 +126,7 @@ func (WorkflowTool) ExecuteStream(ctx context.Context, _ string, input map[strin
 		ResumeFrom:    stringArg(input, "resume_from"),
 	})
 	if err != nil {
-		// Surface logs even on failure — they often explain how far it got.
-		if len(logs) > 0 {
-			return agent.ToolResult{}, fmt.Errorf("workflow: %w\n[log]\n%s", err, strings.Join(logs, "\n"))
-		}
-		return agent.ToolResult{}, fmt.Errorf("workflow: %w", err)
+		return agent.ToolResult{}, workflowError(err, res, logs)
 	}
 
 	text := res.Output
@@ -141,4 +137,36 @@ func (WorkflowTool) ExecuteStream(ctx context.Context, _ string, input map[strin
 		text += "\n\n[workflow run: " + res.RunID + "]"
 	}
 	return agent.ToolResult{Text: text}, nil
+}
+
+// workflowError turns a failed run into an actionable tool error. A script
+// error is the model's own Ruby — it must learn to fix the script and re-call
+// workflow rather than treat the failure as terminal — so the message says so
+// explicitly. When agents completed before the failure, their results are
+// journaled under res.RunID; surfacing it lets the retry pass resume_from to
+// skip the work already done. Logs are appended last since they often show how
+// far the run got.
+func workflowError(err error, res workflow.Result, logs []string) error {
+	var b strings.Builder
+	if strings.Contains(err.Error(), "script error") {
+		b.WriteString("workflow: the Ruby script you wrote failed to run. ")
+		b.WriteString("Fix the script and call workflow again.\n\n")
+		b.WriteString(err.Error())
+		// Resume hint only when at least one agent actually ran (tokens spent);
+		// a compile/syntax error journals nothing, so resume would be a no-op.
+		if res.RunID != "" && (res.OutputTokens > 0 || res.InputTokens > 0) {
+			b.WriteString(fmt.Sprintf(
+				"\n\nSome agents completed before the failure. To skip re-running them, "+
+					"pass resume_from: %q in the retry (only the agent() calls that didn't "+
+					"finish will run again).", res.RunID))
+		}
+	} else {
+		b.WriteString("workflow: ")
+		b.WriteString(err.Error())
+	}
+	if len(logs) > 0 {
+		b.WriteString("\n\n[workflow log]\n")
+		b.WriteString(strings.Join(logs, "\n"))
+	}
+	return fmt.Errorf("%s", b.String())
 }

--- a/internal/tools/workflow_test.go
+++ b/internal/tools/workflow_test.go
@@ -93,3 +93,44 @@ func TestWorkflowTool_RequiresScript(t *testing.T) {
 		t.Errorf("err = %v, want script-required", err)
 	}
 }
+
+// TestWorkflowTool_ScriptErrorIsActionable verifies a bad Ruby script comes
+// back as a fix-and-retry instruction (not an opaque failure) with the mruby
+// position noise stripped, so the model self-corrects instead of giving up.
+func TestWorkflowTool_ScriptErrorIsActionable(t *testing.T) {
+	SetSpawner(replySpawner{})
+	t.Cleanup(func() { SetSpawner(nil) })
+
+	_, err := WorkflowTool{}.Execute(context.Background(), "c",
+		map[string]any{"script": `this_is_not_defined(1)`})
+	if err == nil {
+		t.Fatal("expected an error from a bad script")
+	}
+	msg := err.Error()
+	for _, want := range []string{"Fix the script and call workflow again", "this_is_not_defined"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error = %q, want substring %q", msg, want)
+		}
+	}
+	if strings.Contains(msg, "(unknown)") {
+		t.Errorf("error leaks mruby position noise: %q", msg)
+	}
+}
+
+// TestWorkflowTool_PartialFailureSuggestsResume verifies that when agents run
+// before the script errors, the failure surfaces the run id with a resume_from
+// hint so the retry skips the completed work.
+func TestWorkflowTool_PartialFailureSuggestsResume(t *testing.T) {
+	SetSpawner(replySpawner{})
+	t.Cleanup(func() { SetSpawner(nil) })
+
+	// First agent() succeeds (spending tokens + journaling), then a bad call.
+	_, err := WorkflowTool{}.Execute(context.Background(), "c",
+		map[string]any{"script": `agent("ok"); this_is_not_defined(1)`})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "resume_from") {
+		t.Errorf("error should suggest resume_from after a partial run; got: %q", err.Error())
+	}
+}

--- a/internal/workflow/runtime.go
+++ b/internal/workflow/runtime.go
@@ -18,6 +18,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -177,7 +178,7 @@ func Run(ctx context.Context, script string, opt Options) (Result, error) {
 			if res.Canceled {
 				return res, context.Canceled
 			}
-			return res, fmt.Errorf("workflow: script error: %s", strings.TrimSpace(stderr.String()))
+			return res, fmt.Errorf("workflow: script error: %s", cleanScriptError(stderr.String()))
 		}
 		if res.Canceled || ctx.Err() != nil {
 			return res, context.Canceled
@@ -186,6 +187,43 @@ func Run(ctx context.Context, script string, opt Options) (Result, error) {
 	}
 	res.Output = strings.TrimRight(stdout.String(), "\n")
 	return res, nil
+}
+
+// mruby backtrace noise. The interpreter prepends a position prefix to every
+// error line, but the position is meaningless to the script author: the
+// filename is always "(unknown)", runtime errors report line/column "0", and
+// syntax-error line numbers count from the top of the Go-prepended prelude
+// (~86 lines) rather than the user's script — so surfacing them just misleads
+// the model into editing a line that doesn't exist. We strip the prefixes and
+// keep the human-readable message + error class.
+var (
+	mrubyPosPrefix = regexp.MustCompile(`(?m)^\s*(?:\(unknown\)|line \d+):\d+:(?:in [^:]*:)?\s*`)
+	mrubyTraceLine = regexp.MustCompile(`(?m)^\s*(?:trace \(most recent call last\):|\[\d+\] .*)\s*$`)
+)
+
+// cleanScriptError turns a raw mruby backtrace into a concise, author-facing
+// message by stripping the misleading position prefixes (see mrubyPosPrefix)
+// and the bare trace scaffolding, then collapsing blank/duplicate lines. The
+// error class (NoMethodError, SyntaxError, …) and message survive intact.
+func cleanScriptError(stderr string) string {
+	s := mrubyTraceLine.ReplaceAllString(stderr, "")
+	s = mrubyPosPrefix.ReplaceAllString(s, "")
+	// Collapse to non-empty, de-duplicated lines (mruby often repeats the
+	// SyntaxError summary on a second line).
+	seen := make(map[string]bool)
+	var out []string
+	for _, ln := range strings.Split(s, "\n") {
+		ln = strings.TrimSpace(ln)
+		if ln == "" || seen[ln] {
+			continue
+		}
+		seen[ln] = true
+		out = append(out, ln)
+	}
+	if len(out) == 0 {
+		return strings.TrimSpace(stderr) // never return empty — fall back to raw
+	}
+	return strings.Join(out, "; ")
 }
 
 // backend holds the host-side scheduler state for one Run.

--- a/internal/workflow/runtime_test.go
+++ b/internal/workflow/runtime_test.go
@@ -212,6 +212,45 @@ func TestRun_ScriptError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "script error") {
 		t.Errorf("err = %v, want script error", err)
 	}
+	// The misleading mruby position prefix ("(unknown):0:") must be stripped,
+	// while the method name and error class survive so the model can self-fix.
+	if strings.Contains(err.Error(), "(unknown)") {
+		t.Errorf("err leaks mruby position noise: %v", err)
+	}
+	for _, want := range []string{"this_method_does_not_exist", "NoMethodError"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, want it to contain %q", err.Error(), want)
+		}
+	}
+}
+
+func TestCleanScriptError(t *testing.T) {
+	cases := []struct {
+		name, in string
+		want     string // substring that must be present
+		absent   string // substring that must be gone
+	}{
+		{"nomethod", "(unknown):0: undefined method 'nope' for Object (NoMethodError)",
+			"undefined method 'nope'", "(unknown)"},
+		{"syntax", "line 90:0: syntax error, unexpected end of file\n(unknown):0: syntax error (SyntaxError)",
+			"unexpected end of file", "line 90"},
+		{"trace", "trace (most recent call last):\n(unknown):0:in +: String cannot be converted to Float (TypeError)",
+			"cannot be converted to Float", "trace (most recent"},
+	}
+	for _, c := range cases {
+		got := cleanScriptError(c.in)
+		if !strings.Contains(got, c.want) {
+			t.Errorf("%s: cleanScriptError(%q) = %q, want substring %q", c.name, c.in, got, c.want)
+		}
+		if c.absent != "" && strings.Contains(got, c.absent) {
+			t.Errorf("%s: cleanScriptError(%q) = %q, must not contain %q", c.name, c.in, got, c.absent)
+		}
+	}
+	// A non-blank input that is entirely position-noise must not vanish — it
+	// falls back to the raw stderr so the failure is never silently hidden.
+	if got := cleanScriptError("(unknown):0:"); got == "" {
+		t.Error("cleanScriptError of noise-only input returned empty string")
+	}
 }
 
 func TestRun_RequiresAgent(t *testing.T) {


### PR DESCRIPTION
## Summary

When a model-generated Ruby workflow script failed, the error was both **noisy** and **inert**, so the model couldn't recover:

- It surfaced mruby's position prefix — always `(unknown):0:` for runtime errors, or a prelude-relative `line 89:` for syntax errors (the user script is prepended with an ~86-line DSL prelude, and "unexpected end of file" points at EOF, not the real mistake).
- Nothing told the model the failure was *its own script* to fix — so it treated the failure as terminal instead of rewriting and re-running.

## Changes

1. **`cleanScriptError` (runtime.go)** strips the misleading position prefixes and bare trace scaffolding, keeping the message + error class (`NoMethodError` / `SyntaxError` / …). Falls back to raw stderr so a failure is never silently hidden.

2. **`workflowError` (tools/workflow.go)** wraps a script error with an explicit "Fix the script and call workflow again" instruction.

3. On a **partial failure** — agents completed before the script errored, their results journaled under `res.RunID` — the error surfaces the run id with a `resume_from` hint so the retry skips work already done. Gated on tokens-spent so a syntax error (nothing ran) doesn't suggest a no-op resume.

### Before / after (real mruby output)

| script | before | after |
|---|---|---|
| `nope(1)` | `(unknown):0: undefined method 'nope' for Object (NoMethodError)` | `Fix the script and call workflow again.\n\nworkflow: script error: undefined method 'nope' for Object (NoMethodError)` |
| `def foo(` | `line 89:0: syntax error, unexpected end of file…\n(unknown):0: syntax error (SyntaxError)` | `…syntax error, unexpected end of file, expecting ')'; syntax error (SyntaxError)` |

## Test plan

- [x] `go test ./internal/workflow/ ./internal/tools/` — all pass
- [x] New: `TestCleanScriptError`, `TestWorkflowTool_ScriptErrorIsActionable`, `TestWorkflowTool_PartialFailureSuggestsResume`, extended `TestRun_ScriptError`
- [x] gofmt + go vet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)