### PR TITLE
feat(workflow): add phase() primitive for grouped progress

### DIFF
--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -46,6 +46,8 @@ func (WorkflowTool) Definition() agent.ToolDefinition {
 			"- `pipeline(items, stage1, stage2, ...) -> Array`: run each item through all " +
 			"stages; items flow independently (no barrier between stages). Stages are lambdas.\n" +
 			"- `log(msg)`: surface a progress line.\n" +
+			"- `phase(title)`: mark the start of a named stage; groups the progress " +
+			"stream into steps (cosmetic, does not affect scheduling).\n" +
 			"- `budget_remaining -> Integer`: remaining output-token budget.\n\n" +
 			"The script's final expression is returned as the result. Example:\n" +
 			"```ruby\n" +

--- a/internal/workflow/prelude.rb
+++ b/internal/workflow/prelude.rb
@@ -45,6 +45,15 @@ def budget_remaining
   __budget_remaining
 end
 
+# phase(title) marks the start of a named stage so a multi-stage run reads as
+# grouped steps in the progress stream instead of a flat log. It is purely
+# cosmetic — scheduling is unaffected; agent/parallel/pipeline behave the same
+# whether or not phases are declared. Returns nil.
+def phase(title)
+  __log("== phase: #{title}")
+  nil
+end
+
 # __run_fibers is the cooperative event loop: every item runs in its own fiber;
 # all branches are advanced to their first agent() call (so every job is in
 # flight) before any result is awaited; then completions are drained in finish

--- a/internal/workflow/runtime_test.go
+++ b/internal/workflow/runtime_test.go
@@ -231,6 +231,28 @@ func TestRun_AgentOptions(t *testing.T) {
 	}
 }
 
+func TestRun_Phase(t *testing.T) {
+	var lines []string
+	got, err := Run(context.Background(),
+		`phase("Review"); log("x"); phase("Verify"); "ok"`,
+		Options{Agent: echoAgent, Log: func(s string) { lines = append(lines, s) }})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.Output != "ok" {
+		t.Errorf("Output = %q", got.Output)
+	}
+	want := []string{"== phase: Review", "x", "== phase: Verify"}
+	if len(lines) != len(want) {
+		t.Fatalf("log lines = %v, want %v", lines, want)
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Errorf("line %d = %q, want %q", i, lines[i], want[i])
+		}
+	}
+}
+
 func TestRun_ExceptionHandling(t *testing.T) {
 	// Exercises mruby begin/rescue (setjmp/longjmp via the wasm EH proposal).
 	got, err := Run(context.Background(),


### PR DESCRIPTION
## Summary

Adds a `phase(title)` primitive to the workflow DSL. A model writing a workflow by analogy to common orchestration APIs (e.g. Claude Code's `phase()`) would reach for `phase("Review")` to label a stage — but it wasn't defined, so the call raised `NoMethodError` and failed the whole script.

`phase(title)` emits a `== phase: <title>` marker through the existing log channel, so a multi-stage run reads as grouped steps in the progress stream instead of a flat log. Purely cosmetic — scheduling is unaffected; `agent`/`parallel`/`pipeline` behave identically with or without phases.

Lives entirely in the prelude (`prelude.rb`) — **no wasm rebuild needed**. Advertised in the tool description so the model knows it exists.

Addresses deficiency #4 (no progress grouping) from the workflow gap analysis.

## Test plan

- [x] `go test ./internal/workflow/` — new `TestRun_Phase` passes
- [x] gofmt + go vet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)