### PR TITLE
fix: address 7 confirmed bugs from parallel code review

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -541,6 +541,11 @@ func (a *Agent) runLoop(
 	// non-fatal — we log nothing and proceed with the full history.
 	_ = a.maybeCompact(ctx, handler)
 
+	// History length before this turn appended anything. Used to roll back
+	// cleanly on a first-iteration failure: the turn may append more than the
+	// user input (drained inbox messages), so truncating to this baseline is
+	// what restores the pre-turn state — popLast would only remove one message.
+	baseHistoryLen := a.History.Len()
 	a.appendUserInput(userInput)
 
 	limit := a.turnLimit()
@@ -617,7 +622,7 @@ func (a *Agent) runLoop(
 			}
 
 			if i == 0 {
-				a.History.popLast()
+				a.History.TruncateTo(baseHistoryLen)
 			}
 			return Reply{}, fmt.Errorf("agent: loop[%d]: %w", i, err)
 		}
@@ -651,7 +656,7 @@ func (a *Agent) runLoop(
 				// through to the graceful stop below.
 			default:
 				if i == 0 {
-					a.History.popLast()
+					a.History.TruncateTo(baseHistoryLen)
 				}
 				return Reply{}, fmt.Errorf("agent: loop[%d] escalate: %w", i, eerr)
 			}
@@ -664,7 +669,20 @@ func (a *Agent) runLoop(
 		// cap. Limited to maxTruncationResumes to prevent infinite loops. Skipped
 		// for truncated tool_use blocks (partial tool calls are unsafe in
 		// OpenAI-protocol history) and when escalation is disabled.
-		if isTruncated(reply.StopReason) && a.MaxTokensEscalate > a.MaxTokens && reply.Content != "" && truncationResumes < maxTruncationResumes {
+		// A truncated reply can carry both leading text and a half-written
+		// tool_use block (providers keep StopReason "max_tokens" rather than
+		// normalising to "tool_use"). reply.Content holds only the text, so the
+		// prose-resume below would append the text and silently drop the partial
+		// tool call. Detect any tool_use block and fall through to the graceful
+		// stop instead — partial tool calls are unsafe to resume.
+		replyHasToolUse := false
+		for _, b := range reply.Blocks {
+			if b.Type == "tool_use" {
+				replyHasToolUse = true
+				break
+			}
+		}
+		if isTruncated(reply.StopReason) && a.MaxTokensEscalate > a.MaxTokens && !replyHasToolUse && reply.Content != "" && truncationResumes < maxTruncationResumes {
 			a.History.Append(NewAssistantMessage(reply.Content))
 			a.History.Append(NewUserMessage(truncationResumePrompt))
 			truncationResumes++

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1658,3 +1658,58 @@ func TestToolResultUIPayload_DroppedOnError(t *testing.T) {
 		t.Fatalf("error block UI = %#v, want nil", blocks[0].UI)
 	}
 }
+
+// A first-iteration send failure must roll the history back to the pre-turn
+// state, not just pop the last message. When a steer is drained at i==0 before
+// the failing send, both the steer and the user input were appended, so popping
+// only the last one would leave the user turn behind and duplicate it on retry.
+func TestAgent_RunLoop_FirstIterationErrorRollsBackFully(t *testing.T) {
+	send := &fakeToolSender{errs: []error{errors.New("boom")}}
+	a := New(send, "m")
+	a.Inbox.Enqueue("steer arriving as the turn starts")
+
+	_, err := a.Run(context.Background(), "hello", []ToolDefinition{{Name: "bash"}}, &fakeExecutor{})
+	if err == nil {
+		t.Fatal("expected error from failing send")
+	}
+	if n := a.History.Len(); n != 0 {
+		t.Fatalf("history length = %d after first-iteration failure, want 0 (full rollback)", n)
+	}
+}
+
+// A reply truncated mid tool_use carries leading text in Content alongside a
+// partial tool_use block. The layer-2 prose-resume must NOT fire — appending
+// only Content would silently drop the half-written tool call. The turn should
+// end with a graceful max_tokens budget stop instead.
+func TestAgent_RunLoop_TruncatedToolUseSkipsResume(t *testing.T) {
+	truncated := Reply{
+		Content:    "let me look that up",
+		StopReason: StopReasonMaxTokens,
+		Blocks: []ContentBlock{
+			NewTextBlock("let me look that up"),
+			NewToolUseBlock("c1", "bash", map[string]any{"command": "ls"}),
+		},
+	}
+	// Two identical truncated replies: the initial round and the escalation
+	// retry. A buggy resume path would loop and demand a third reply.
+	send := &fakeToolSender{replies: []Reply{truncated, truncated}}
+	a := New(send, "m")
+	a.MaxTokens = 100
+	a.MaxTokensEscalate = 200
+
+	reply, err := a.Run(context.Background(), "hello", []ToolDefinition{{Name: "bash"}}, &fakeExecutor{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.StopReason != StopReasonMaxTokens {
+		t.Fatalf("StopReason = %q, want %q (graceful budget stop)", reply.StopReason, StopReasonMaxTokens)
+	}
+	if send.calls != 2 {
+		t.Fatalf("sender calls = %d, want 2 (initial + escalation, no resume loop)", send.calls)
+	}
+	for _, m := range a.History.Snapshot() {
+		if hasToolUse(m) {
+			t.Errorf("history leaked a tool_use block from the truncated reply: %+v", m)
+		}
+	}
+}

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -45,9 +45,9 @@ func NewSpawner(parent *agent.Agent, executor agent.ToolExecutor, toolsFn func()
 	}
 }
 
-// childMaxTurns caps the sub-agent's tool loop.
-// Set to the same default as the parent (100) so sub-agents have enough
-// budget for complex sub-tasks. Each Continue re-arms
+// childMaxTurns caps the sub-agent's tool loop per round. Deliberately lower
+// than the parent's defaultMaxTurns (100): a sub-task should make focused
+// progress and check back rather than run unbounded. Each Continue re-arms
 // this budget for the next round.
 const childMaxTurns = 30
 
@@ -76,11 +76,19 @@ func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.Spaw
 	child.LiteSender = s.parent.LiteSender
 	child.LiteModel = s.parent.LiteModel
 
+	// Create the session dir before registering the child: a permissions
+	// failure here must abort the spawn, not leave a dead entry in the registry
+	// whose later Save() would silently fail.
+	if req.SessionDir != "" {
+		if err := os.MkdirAll(req.SessionDir, 0o755); err != nil {
+			return tools.SpawnResult{}, fmt.Errorf("spawner: create session dir: %w", err)
+		}
+	}
+
 	lc := &liveChild{agent: child, tools: childTools, executor: s.executor, sessionDir: req.SessionDir}
 	id := s.reg.put(lc)
 
 	if req.SessionDir != "" {
-		_ = os.MkdirAll(req.SessionDir, 0o755)
 		sess := agent.NewSession(child.Model, child.System)
 		sess.ID = id
 		sess.Dir = req.SessionDir
@@ -330,7 +338,11 @@ func (r *childRegistry) evictLocked() {
 func (r *childRegistry) freshIDLocked() string {
 	for {
 		var b [4]byte
-		_, _ = rand.Read(b[:]) // crypto/rand.Read effectively never fails
+		if _, err := rand.Read(b[:]); err != nil {
+			// crypto/rand.Read is documented never to fail; a failure means the
+			// OS entropy source is broken, so refuse to mint a predictable id.
+			panic(fmt.Sprintf("spawner: crypto/rand unavailable: %v", err))
+		}
 		id := hex.EncodeToString(b[:])
 		if _, taken := r.m[id]; !taken {
 			return id

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -305,6 +305,7 @@ func (m *BackgroundManager) Start(command string, opts ...StartOption) (string, 
 	if err != nil {
 		cancel()
 		_ = pw.Close()
+		_ = pr.Close()
 		return "", fmt.Errorf("terminal: create stdin pipe: %w", err)
 	}
 	cmd.Stdin = stdinR
@@ -312,7 +313,9 @@ func (m *BackgroundManager) Start(command string, opts ...StartOption) (string, 
 	if err := cmd.Start(); err != nil {
 		cancel()
 		_ = pw.Close()
+		_ = pr.Close()
 		_ = stdinW.Close()
+		_ = stdinR.Close()
 		return "", fmt.Errorf("terminal: start background: %w", err)
 	}
 
@@ -342,6 +345,11 @@ func (m *BackgroundManager) Start(command string, opts ...StartOption) (string, 
 			// Tabs break the TUI's cursor-position math; replace with spaces.
 			line = bytes.ReplaceAll(line, []byte{'\t'}, []byte("    "))
 			p.append(append(line, '\n')) // append copies
+		}
+		// A line exceeding the 1 MiB token cap (or any read error) stops the
+		// scan; without this, all remaining output would vanish silently.
+		if err := scanner.Err(); err != nil {
+			p.append([]byte("\n[... output truncated: " + err.Error() + " ...]\n"))
 		}
 	}()
 	// Waiter: wait for the process, close pipe so the reader sees EOF,


### PR DESCRIPTION
Fixes 7 bugs confirmed against the source (each verified, not taken from the report at face value) across the agent loop, background process manager, and sub-agent spawner.

## agent.go
- **runLoop rollback错位**: `popLast()` 只移除最后一条消息;当 i==0 这一轮 drain 了 inbox steer,失败的 send 会把 steer 弹掉、原始 user turn 留在 history → 重试重复。改为循环前 `baseHistoryLen := History.Len()`,失败时 `TruncateTo(baseHistoryLen)` 完整回滚本轮所有 append。
- **layer-2 截断 resume 丢工具调用**: 守卫用 `reply.Content != ""`,但截断回复可同时带 text + 半个 tool_use block(provider 在 `max_tokens` 时不归一成 `tool_use`),resume 只 append Content 文本、丢掉工具调用。增加 `!replyHasToolUse` 守卫,改走 graceful budget stop。

## background.go
- **reader 吞输出**: scanner 忽略 `scanner.Err()`,单行超 1 MiB 上限会静默丢掉后续**全部**输出。检查并追加截断标记。
- **fd 泄漏**: `Start()` 错误路径泄漏 pipe 读端(`pr` 内存、`stdinR` 真实 fd)。补关。

## spawner.go
- **注释与代码不符**: `childMaxTurns` 注释称 "same as parent (100)" 但常量是 `30`;parent 默认确为 100,child 刻意更小。修正注释(不改行为)。
- **MkdirAll 吞错**: session dir 创建失败被丢弃,后续 `Save()` 静默失败。前置到注册前并返回包装错误。
- **rand.Read 吞错**: `freshIDLocked` 忽略 crypto/rand 错误,失败时可能生成可预测/全零 id。改为显式 panic。

## Tests
新增两个回归测试(完整回滚、截断 tool_use 不 resume),均有区分度——旧代码会失败。

## Verification
- `go build ./...` / `gofmt -l` / `go vet` clean
- `make test` (whole repo, `-race`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)