### PR TITLE
fix(web): enable clipboard image paste in composer

### DIFF
--- a/internal/server/static/sessions.js
+++ b/internal/server/static/sessions.js
@@ -908,7 +908,10 @@ const Sessions = (() => {
         if (ACCEPTED_IMAGE_TYPES.includes(it.type)) return true;
         if (ACCEPTED_DOC_TYPES.includes(it.type))   return true;
         const f = it.getAsFile && it.getAsFile();
-        return f ? _hasAcceptedDocExt(f.name) : false;
+        if (!f) return false;
+        // Fallback: some browsers report empty type for clipboard images;
+        // check both image and document extensions via the file object.
+        return _isAcceptedImage(f) || _isAcceptedDoc(f);
       });
       if (attachItems.length === 0) return;
       e.preventDefault();

--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -41,6 +41,23 @@
     input.value = ''
   }
 
+  // Paste images from clipboard into the composer.
+  function onPaste(e: ClipboardEvent) {
+    const items = Array.from(e.clipboardData?.items ?? [])
+    const imageItems = items.filter(it => it.kind === 'file' && it.type.startsWith('image/'))
+    if (imageItems.length === 0) return
+    e.preventDefault()
+    for (const it of imageItems) {
+      const f = it.getAsFile()
+      if (!f) continue
+      const reader = new FileReader()
+      reader.onload = () => {
+        attachments = [...attachments, { name: f.name || 'pasted-image', data_url: String(reader.result), mime_type: f.type || it.type }]
+      }
+      reader.readAsDataURL(f)
+    }
+  }
+
   function removeAttachment(i: number) {
     attachments = attachments.filter((_, idx) => idx !== i)
   }
@@ -211,6 +228,7 @@
         placeholder={$t('chat.placeholder')}
         bind:value={text}
         onkeydown={onKeydown}
+        onpaste={onPaste}
       ></textarea>
       <input
         bind:this={fileInputEl}


### PR DESCRIPTION
The new Svelte/Vite web UI (Composer.svelte) had no paste handler at all, so copying an image to the clipboard and pressing Ctrl+V did nothing.

- Add onPaste handler to the textarea that reads image/* items from clipboardData, converts them to data URLs via FileReader, and appends them to the attachments array.
- Also tighten the legacy static/ paste fallback: when a clipboard item's type is empty (some browsers do this for pasted images), the old code only checked document extensions and silently dropped images. Now it falls back to _isAcceptedImage() as well.