### PR TITLE
fix(provider): raise default max_tokens 4096 → 16384

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -65,7 +65,7 @@ func resolveMaxTurns(flagVal int, seeded, interactive bool) int {
 // model whose ceiling is below the target backs off at the API (see the agent
 // loop's isMaxTokensTooLargeErr). See dev-docs/truncation-recovery.md.
 const (
-	escalateMaxTokensOpenAI    = 16384
+	escalateMaxTokensOpenAI    = 32768
 	escalateMaxTokensAnthropic = 32768
 )
 

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -34,8 +34,10 @@ const MessagesPath = "/v1/messages"
 const DefaultAPIVersion = "2023-06-01"
 
 // DefaultMaxTokens caps response length when a caller doesn't specify one.
-// 4096 is generous for chat-style replies and well below the model ceilings.
-const DefaultMaxTokens = 4096
+// 16384 leaves room for the large code edits agent turns routinely emit while
+// staying well below the model ceilings; truncation escalation (32768) sits on
+// top. See cmd/octo escalateMaxTokensAnthropic and dev-docs/truncation-recovery.md.
+const DefaultMaxTokens = 16384
 
 // DefaultStreamIdleTimeout bounds how long a streaming response may go silent
 // (no bytes received) before SendStream aborts it as a stall. The Messages API

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -28,10 +28,10 @@ const DefaultBaseURL = "https://api.openai.com"
 const ChatCompletionsPath = "/v1/chat/completions"
 
 // DefaultMaxTokens caps response length when a caller doesn't specify one.
-// 4096 mirrors the Anthropic provider's default so behaviour stays consistent
+// 16384 mirrors the Anthropic provider's default so behaviour stays consistent
 // across backends. OpenAI itself treats max_tokens as optional (model
-// maximum if omitted); we send 4096 anyway for predictability.
-const DefaultMaxTokens = 4096
+// maximum if omitted); we send 16384 anyway for predictability.
+const DefaultMaxTokens = 16384
 
 // DialectDeepSeek selects DeepSeek's reasoning quirks (the thinking on/off
 // toggle) on a Client. Assign it to Client.Dialect for the "deepseek" vendor;


### PR DESCRIPTION
## What

Bumps both providers' `DefaultMaxTokens` from **4096 → 16384**.

## Why

Agent turns that emit large code edits routinely hit the 4096 base output cap. When the truncation lands **mid-tool-call**, layer-2 prose-resume can't recover (partial `tool_use` is unsafe to resume), so the turn stops with *"the response was truncated at the output-token cap"* — even though every tool call before it succeeded. 4096 is simply too low a default for a coding agent.

## Connected change (required for correctness)

OpenAI-protocol escalate default was also `16384` (`escalateMaxTokensOpenAI`). Raising the base to 16384 would make `MaxTokensEscalate > MaxTokens` false → **layer-1 escalation silently stops firing for OpenAI backends** (`agent.go:643`). So this also raises `escalateMaxTokensOpenAI` **16384 → 32768** to preserve the gap. Anthropic's escalate (32768) already sits above the new base, unchanged.

## Scope

| const | file | before → after |
|---|---|---|
| `DefaultMaxTokens` | `internal/provider/anthropic/client.go` | 4096 → 16384 |
| `DefaultMaxTokens` | `internal/provider/openai/client.go` | 4096 → 16384 |
| `escalateMaxTokensOpenAI` | `cmd/octo/chat.go` | 16384 → 32768 |

## Test

`go build ./...`, affected-package `go test`, `go vet ./...`, `gofmt -l` — all clean. `TestSend_DefaultMaxTokens` references the constant symbolically and still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)