### PR TITLE
fix(agent): raise default per-message turn cap 100 → 200

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -248,7 +248,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	verboseFlag := fs.Bool("verbose", false, "Print extra context (provider/model/endpoint, always-on cache line). Also OCTO_VERBOSITY=verbose.")
 	permMode := fs.String("permission-mode", "", "Tool permission handling: interactive (prompt on ask) | strict (deny on ask) | auto (allow on ask). Empty = use `octo config` value, else interactive.")
 	noCoauthor := fs.Bool("no-coauthor", false, "Disable appending Co-authored-by to git commit messages. Also OCTO_COAUTHOR=0.")
-	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = auto: 100 interactive, unlimited unattended/--prompt-file)")
+	maxTurns := fs.Int("max-turns", 0, "Max provider round-trips per message in the agentic loop (0 = auto: 200 interactive, unlimited unattended/--prompt-file)")
 	compactThreshold := fs.Int("compact-threshold", 0, "Compact older history once a turn's input crosses this many tokens; 0 = auto (percentage of the model's context window, settable via --compact-auto-pct or config), <0 = disabled")
 	compactAutoPct := fs.Int("compact-auto-pct", 0, "Auto-compaction threshold as a percentage of the model's context window (0 = use `octo config` or built-in default 75). Only used when --compact-threshold=0.")
 	compactBatchThreshold := fs.Int("compact-batch-threshold", 0, "Batch-level compaction: compact after a tool batch when context exceeds this many tokens; 0 = auto (~85% of the model's context window), <0 = disabled between batches")

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -370,7 +370,7 @@ func (a *Agent) TurnStream(
 // defaultMaxTurns is the fallback per-Run loop cap when Agent.MaxTurns is
 // unset (0). A "turn" here is one provider round-trip inside the agentic
 // loop; the cap stops a misbehaving model from looping on tools forever.
-const defaultMaxTurns = 100
+const defaultMaxTurns = 200
 
 // unlimitedTurns signals no cap (used for unattended runs).
 const unlimitedTurns = -1

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -46,7 +46,7 @@ func NewSpawner(parent *agent.Agent, executor agent.ToolExecutor, toolsFn func()
 }
 
 // childMaxTurns caps the sub-agent's tool loop per round. Deliberately lower
-// than the parent's defaultMaxTurns (100): a sub-task should make focused
+// than the parent's defaultMaxTurns (200): a sub-task should make focused
 // progress and check back rather than run unbounded. Each Continue re-arms
 // this budget for the next round.
 const childMaxTurns = 30


### PR DESCRIPTION
## What

Raises `defaultMaxTurns` **100 → 200** in `internal/agent/agent.go`.

## Why

`defaultMaxTurns` caps provider round-trips in a single interactive `Run`/`RunStream` — each round is one assistant turn that may dispatch tool calls. 100 was cutting off long agentic sequences (many sequential tool rounds) before they finished. The cap's only purpose is to stop a misbehaving model from looping forever, so 200 keeps that backstop while giving real work more headroom.

## Scope

| symbol | file | change |
|---|---|---|
| `defaultMaxTurns` | `internal/agent/agent.go` | 100 → 200 |
| `--max-turns` help text | `cmd/octo/chat.go` | "100 interactive" → "200 interactive" |
| `childMaxTurns` comment | `internal/app/spawner.go` | doc ref "(100)" → "(200)" |

`childMaxTurns` (sub-agent per-round budget, **30**) is intentionally left unchanged.

## Test

`go build ./...`, `go test` (agent / cmd / app), `go vet ./...`, `gofmt -l` — all clean. `TestRun_*` references `defaultMaxTurns` symbolically and adapts automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)