### PR TITLE
feat(workflow): liveness signal + workflow_kill for background runs

### DIFF
--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -42,6 +42,7 @@ var allTools = []tool{
 	AgentKillTool{},
 	WorkflowTool{},
 	WorkflowStatusTool{},
+	WorkflowKillTool{},
 	AskUserQuestionTool{},
 	TaskCreateTool{},
 	TaskUpdateTool{},
@@ -257,6 +258,9 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 			continue
 		}
 		if _, isWfStatus := t.(WorkflowStatusTool); isWfStatus && !spawnerOn {
+			continue
+		}
+		if _, isWfKill := t.(WorkflowKillTool); isWfKill && !spawnerOn {
 			continue
 		}
 		if _, isAsk := t.(AskUserQuestionTool); isAsk && !askerOn {

--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -173,3 +173,46 @@ func (WorkflowStatusTool) Execute(ctx context.Context, _ string, input map[strin
 	}
 	return agent.ToolResult{Text: formatRunDetail(snap)}, nil
 }
+
+// WorkflowKillTool cancels a running background workflow by id — for a run that
+// has stalled (workflow_status shows a large, growing "last activity" gap) or
+// is no longer wanted.
+type WorkflowKillTool struct{}
+
+func (WorkflowKillTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "workflow_kill",
+		Description: "Cancel a running background workflow by run id (e.g. \"wf_1\"). Use when " +
+			"workflow_status shows a run is stuck (a large, growing 'last activity' gap) or you " +
+			"no longer want its result. Cancellation propagates to the workflow's in-flight " +
+			"sub-agents. A run that already finished is left as-is.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"run_id": map[string]any{
+					"type":        "string",
+					"description": "The run id to cancel (from the workflow tool / workflow_status).",
+				},
+			},
+			"required": []string{"run_id"},
+		},
+	}
+}
+
+func (WorkflowKillTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	runID := strings.TrimSpace(stringArg(input, "run_id"))
+	if runID == "" {
+		return agent.ToolResult{}, fmt.Errorf("workflow_kill: run_id is required")
+	}
+	mgr := resolveWorkflowManager(ctx)
+	found, wasRunning := mgr.Kill(runID)
+	switch {
+	case !found:
+		return agent.ToolResult{}, fmt.Errorf("workflow_kill: no run named %q in this session", runID)
+	case !wasRunning:
+		return agent.ToolResult{Text: fmt.Sprintf("Workflow %s had already finished — nothing to cancel.", runID)}, nil
+	default:
+		return agent.ToolResult{Text: fmt.Sprintf("Cancelled workflow %s. It will report as killed shortly; "+
+			"workflow_status(%q) confirms.", runID, runID)}, nil
+	}
+}

--- a/internal/tools/workflow_manager.go
+++ b/internal/tools/workflow_manager.go
@@ -61,6 +61,10 @@ type WorkflowRunSnapshot struct {
 	JournalRunID string
 	Start        time.Time
 	End          time.Time
+	// LastActivity is when the run last emitted progress (a log line or an
+	// agent start/finish). A running run whose LastActivity is far in the past
+	// is likely stuck — the gap, not the total elapsed, is the liveness signal.
+	LastActivity time.Time
 }
 
 // workflowRun tracks one detached workflow.Run invocation.
@@ -77,15 +81,28 @@ type workflowRun struct {
 	logs         []string
 	journalRunID string
 	end          time.Time
+	lastActivity time.Time
+	killed       bool
 }
 
-func (r *workflowRun) appendLog(line string) {
+// appendLog records a progress line and marks the run live (updates
+// lastActivity). now is passed in so the caller controls the clock.
+func (r *workflowRun) appendLog(line string, now time.Time) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.logs = append(r.logs, line)
 	if n := len(r.logs) - maxWorkflowLogLines; n > 0 {
 		r.logs = r.logs[n:]
 	}
+	r.lastActivity = now
+}
+
+// markKilled flags the run as deliberately killed, so finish reports it as a
+// kill rather than a raw "context canceled" error.
+func (r *workflowRun) markKilled() {
+	r.mu.Lock()
+	r.killed = true
+	r.mu.Unlock()
 }
 
 func (r *workflowRun) finish(output, journalRunID, errMsg string, end time.Time) {
@@ -94,6 +111,11 @@ func (r *workflowRun) finish(output, journalRunID, errMsg string, end time.Time)
 	r.done = true
 	r.output = output
 	r.journalRunID = journalRunID
+	// A killed run comes back as "context canceled"; report it as a kill so the
+	// model doesn't read it as a spurious failure.
+	if r.killed {
+		errMsg = "workflow was killed (workflow_kill)"
+	}
 	r.errMsg = errMsg
 	r.end = end
 }
@@ -120,6 +142,7 @@ func (r *workflowRun) snapshot() WorkflowRunSnapshot {
 		JournalRunID: r.journalRunID,
 		Start:        r.start,
 		End:          r.end,
+		LastActivity: r.lastActivity,
 	}
 }
 
@@ -182,7 +205,8 @@ func (m *WorkflowManager) Start(req WorkflowRunRequest) (string, error) {
 	m.active++
 	m.seq++
 	id := fmt.Sprintf("wf_%d", m.seq)
-	run := &workflowRun{id: id, description: req.Description, cancel: cancel, start: time.Now()}
+	now := time.Now()
+	run := &workflowRun{id: id, description: req.Description, cancel: cancel, start: now, lastActivity: now}
 	m.runs[id] = run
 	m.mu.Unlock()
 
@@ -197,10 +221,13 @@ func (m *WorkflowManager) Start(req WorkflowRunRequest) (string, error) {
 		res, err := workflow.Run(ctx, req.Script, workflow.Options{
 			Agent: req.Agent,
 			Log: func(s string) {
-				run.appendLog(s)
+				run.appendLog(s, time.Now())
 				m.emit(WorkflowEvent{RunID: id, Kind: "progress", Line: s})
 			},
+			// Agent lifecycle ("→ start" / "✓ done") is also captured + counts as
+			// activity, so a workflow with no log() calls still shows it's alive.
 			Progress: func(s string) {
+				run.appendLog(s, time.Now())
 				m.emit(WorkflowEvent{RunID: id, Kind: "progress", Line: s})
 			},
 			MaxConcurrent: req.MaxConcurrent,
@@ -268,6 +295,28 @@ func (m *WorkflowManager) List() []WorkflowRunSnapshot {
 	return out
 }
 
+// Kill cancels one running workflow by id. Returns (found, wasRunning): found
+// is false for an unknown id; wasRunning is false when the run had already
+// finished (a no-op cancel). The run's detached context is cancelled, which
+// propagates to its in-flight sub-agents and unwinds the script.
+func (m *WorkflowManager) Kill(id string) (found, wasRunning bool) {
+	m.mu.Lock()
+	run := m.runs[id]
+	m.mu.Unlock()
+	if run == nil {
+		return false, false
+	}
+	run.mu.Lock()
+	done := run.done
+	run.mu.Unlock()
+	if done {
+		return true, false
+	}
+	run.markKilled()
+	run.cancel()
+	return true, true
+}
+
 // KillAll cancels every running workflow this manager owns. Called on session
 // close so a detached run doesn't outlive its conversation.
 func (m *WorkflowManager) KillAll() {
@@ -282,7 +331,9 @@ func (m *WorkflowManager) KillAll() {
 	}
 }
 
-// statusLine renders a one-line summary of a run for listings.
+// statusLine renders a one-line summary of a run for listings. For a running
+// run it appends how long since the last activity, so a stalled run (large
+// idle gap) is distinguishable from one making steady progress.
 func statusLine(s WorkflowRunSnapshot) string {
 	elapsed := time.Since(s.Start)
 	if s.Status != "running" {
@@ -292,7 +343,11 @@ func statusLine(s WorkflowRunSnapshot) string {
 	if desc == "" {
 		desc = "(workflow)"
 	}
-	return fmt.Sprintf("%s  [%s]  %s  (%s)", s.ID, s.Status, desc, elapsed.Round(time.Second))
+	line := fmt.Sprintf("%s  [%s]  %s  (%s)", s.ID, s.Status, desc, elapsed.Round(time.Second))
+	if s.Status == "running" && !s.LastActivity.IsZero() {
+		line += fmt.Sprintf("  · last activity %s ago", time.Since(s.LastActivity).Round(time.Second))
+	}
+	return line
 }
 
 // formatRunDetail renders a single run's full status for workflow_status.
@@ -301,7 +356,16 @@ func formatRunDetail(s WorkflowRunSnapshot) string {
 	fmt.Fprintf(&b, "%s\n", statusLine(s))
 	switch s.Status {
 	case "running":
-		b.WriteString("Still running. Poll again later.")
+		idle := time.Since(s.LastActivity)
+		if s.LastActivity.IsZero() {
+			idle = 0
+		}
+		fmt.Fprintf(&b, "Still running — last activity %s ago, %d progress line(s) so far.",
+			idle.Round(time.Second), len(s.Logs))
+		if idle > 2*time.Minute {
+			b.WriteString(" If the idle gap keeps growing it may be stuck — workflow_kill(run_id) cancels it.")
+		}
+		b.WriteString(" Poll again later to collect the result.")
 		if n := len(s.Logs); n > 0 {
 			fmt.Fprintf(&b, "\n\n[progress]\n%s", strings.Join(s.Logs, "\n"))
 		}

--- a/internal/tools/workflow_manager_test.go
+++ b/internal/tools/workflow_manager_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -113,4 +114,60 @@ func TestWorkflowManager_ConcurrencyCap(t *testing.T) {
 	}
 	close(block) // unblock so the goroutines exit
 	_ = started
+}
+
+// ctxBlockingAgent blocks until the context is cancelled, then returns the
+// cancellation error — so a Kill of the workflow actually unwinds it.
+func ctxBlockingAgent(ctx context.Context, _ string, _ workflow.AgentOptions) workflow.AgentResult {
+	<-ctx.Done()
+	return workflow.AgentResult{Err: ctx.Err()}
+}
+
+// TestWorkflowManager_Kill verifies a running workflow can be cancelled by id
+// and reports as killed.
+func TestWorkflowManager_Kill(t *testing.T) {
+	m := NewWorkflowManager()
+	id, err := m.Start(WorkflowRunRequest{Script: `agent("x")`, Agent: ctxBlockingAgent})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	found, wasRunning := m.Kill(id)
+	if !found || !wasRunning {
+		t.Fatalf("Kill = (found=%v, wasRunning=%v), want (true, true)", found, wasRunning)
+	}
+	snap := waitForDone(t, m, id)
+	if snap.Status != "error" || !strings.Contains(snap.ErrMsg, "killed") {
+		t.Errorf("after kill: status=%q errMsg=%q, want error + 'killed'", snap.Status, snap.ErrMsg)
+	}
+}
+
+// TestWorkflowManager_KillUnknownAndFinished covers the non-running cases.
+func TestWorkflowManager_KillUnknownAndFinished(t *testing.T) {
+	m := NewWorkflowManager()
+	if found, _ := m.Kill("wf_999"); found {
+		t.Error("Kill of unknown id should report found=false")
+	}
+	id, err := m.Start(WorkflowRunRequest{Script: `agent("x")`, Agent: echoAgentOpts})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForDone(t, m, id)
+	found, wasRunning := m.Kill(id)
+	if !found || wasRunning {
+		t.Errorf("Kill of finished run = (found=%v, wasRunning=%v), want (true, false)", found, wasRunning)
+	}
+}
+
+// TestWorkflowManager_LastActivity verifies progress advances the liveness
+// timestamp (so a stalled run is distinguishable from a busy one).
+func TestWorkflowManager_LastActivity(t *testing.T) {
+	m := NewWorkflowManager()
+	id, err := m.Start(WorkflowRunRequest{Script: `log("step"); agent("x")`, Agent: echoAgentOpts})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	snap := waitForDone(t, m, id)
+	if snap.LastActivity.IsZero() || snap.LastActivity.Before(snap.Start) {
+		t.Errorf("LastActivity = %v, want a time at/after start %v", snap.LastActivity, snap.Start)
+	}
 }

--- a/internal/tools/workflow_test.go
+++ b/internal/tools/workflow_test.go
@@ -15,12 +15,14 @@ func TestDefaultTools_WorkflowGatedOnSpawner(t *testing.T) {
 	SetSpawner(nil)
 	t.Cleanup(func() { SetSpawner(nil) })
 
-	if advertisedNames()["workflow"] || advertisedNames()["workflow_status"] {
+	if advertisedNames()["workflow"] || advertisedNames()["workflow_status"] || advertisedNames()["workflow_kill"] {
 		t.Error("workflow tools should be absent when no Spawner is configured")
 	}
 	SetSpawner(&fakeSpawner{})
-	if !advertisedNames()["workflow"] || !advertisedNames()["workflow_status"] {
-		t.Error("workflow + workflow_status should appear once a Spawner is registered")
+	for _, name := range []string{"workflow", "workflow_status", "workflow_kill"} {
+		if !advertisedNames()[name] {
+			t.Errorf("%s should appear once a Spawner is registered", name)
+		}
 	}
 }
 
@@ -112,6 +114,67 @@ func TestWorkflowTool_StatusListsRuns(t *testing.T) {
 	}
 	if !strings.Contains(out.Text, "list me") {
 		t.Errorf("listing should include the run description; got %q", out.Text)
+	}
+}
+
+// ctxBlockingSpawner blocks each Spawn until the context is cancelled, so a
+// workflow built on it stays running until killed (and unwinds cleanly on kill).
+type ctxBlockingSpawner struct{}
+
+func (ctxBlockingSpawner) Spawn(ctx context.Context, _ SpawnRequest) (SpawnResult, error) {
+	<-ctx.Done()
+	return SpawnResult{}, ctx.Err()
+}
+func (ctxBlockingSpawner) Continue(_ context.Context, _, _ string) (SpawnResult, error) {
+	return SpawnResult{}, nil
+}
+
+// TestWorkflowTool_Kill drives the full kill path through the tools: start a
+// workflow whose agent blocks, cancel it with workflow_kill, and confirm
+// workflow_status reports it killed.
+func TestWorkflowTool_Kill(t *testing.T) {
+	SetSpawner(ctxBlockingSpawner{})
+	t.Cleanup(func() { SetSpawner(nil) })
+
+	res, err := WorkflowTool{}.Execute(context.Background(), "c", map[string]any{"script": `agent("x")`})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	id := wfRunIDRe.FindString(res.Text)
+	if id == "" {
+		t.Fatalf("no run id in %q", res.Text)
+	}
+
+	kr, err := WorkflowKillTool{}.Execute(context.Background(), "c", map[string]any{"run_id": id})
+	if err != nil {
+		t.Fatalf("workflow_kill: %v", err)
+	}
+	if !strings.Contains(kr.Text, "Cancelled") {
+		t.Errorf("kill result = %q, want a cancellation confirmation", kr.Text)
+	}
+
+	// Poll until it leaves running, then confirm it reads as killed.
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		out, _ := WorkflowStatusTool{}.Execute(context.Background(), "c", map[string]any{"run_id": id})
+		if !strings.Contains(out.Text, "[running]") {
+			if !strings.Contains(out.Text, "killed") {
+				t.Errorf("final status = %q, want it to mention 'killed'", out.Text)
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("killed workflow never left running")
+}
+
+// TestWorkflowKill_UnknownRun verifies the tool errors on an unknown id.
+func TestWorkflowKill_UnknownRun(t *testing.T) {
+	SetSpawner(replySpawner{})
+	t.Cleanup(func() { SetSpawner(nil) })
+	_, err := WorkflowKillTool{}.Execute(context.Background(), "c", map[string]any{"run_id": "wf_nope_999"})
+	if err == nil || !strings.Contains(err.Error(), "no run named") {
+		t.Errorf("err = %v, want unknown-run error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Answers two real gaps in background workflows: **how does the agent know a run is alive vs stuck, and how does it kill one?**

### Liveness (is it running or stuck?)
Each run now tracks `lastActivity`, advanced on **every** progress event — a `log()` line *or* an agent start/finish — so even a run with no `log()` calls shows it's alive. `workflow_status` reports:

```
wf_1  [running]  audit modules  (3m12s)  · last activity 4s ago
Still running — last activity 4s ago, 27 progress line(s) so far. Poll again later…
```

The **idle gap** (not total elapsed) is the stuck signal. Once the gap exceeds ~2 min, the status text points the model at `workflow_kill`.

### workflow_kill(run_id)
Cancels one running workflow by id. The detached context is cancelled, which propagates to its in-flight sub-agents and unwinds the script. The run then reports as **killed** (a clear message, not a spurious error). Unknown id → error; an already-finished run → no-op. Gated on the spawner like the other workflow tools.

## Notes
- Backend-only — **no wasm rebuild, no web change**.
- A killed run surfaces as status `error` with message "workflow was killed (workflow_kill)" (kept to the existing 3 statuses to avoid rippling a new state into the web panel).

## Test plan
- [x] `go test -race ./internal/tools/` — pass
- [x] New: manager `Kill` (cancels a running run → killed), unknown/finished cases, `lastActivity` advances; tool end-to-end kill via `workflow_kill` (start blocking → kill → status shows killed), unknown-run error; gate test covers `workflow_kill`
- [x] `go build ./...`, `go vet`, gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)