### PR TITLE
fix(workflow): deliver completion notifications on all transports (CLI/TUI/IM)

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -127,6 +127,16 @@ func runOnce(cfg replConfig, prompt string, stream bool) int {
 	tools.SetBackgroundOnExit(func(e tools.BgExit) { a.Inbox.Enqueue(tools.FormatBgNote(e)) })
 	defer tools.SetBackgroundOnExit(nil)
 
+	// Background workflows ride the same inbox path, so a finished detached run
+	// is drained on a later iteration (or by idleInboxWait while idle).
+	tools.SetDefaultWorkflowOnDone(func(ev tools.WorkflowNotification) {
+		a.Inbox.Enqueue(tools.FormatWorkflowNote(ev))
+	})
+	defer func() {
+		tools.SetDefaultWorkflowOnDone(nil)
+		tools.KillDefaultWorkflows()
+	}()
+
 	// The view sink renders the turn (spinner, streamed text, tool-event lines,
 	// cache/error) and raises Ask prompts. With a TTY reader (a positional
 	// message typed at a terminal) permission prompts are interactive; over a

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -103,6 +103,17 @@ func runTUI(cfg replConfig) int {
 	})
 	defer tools.SetBackgroundOnExit(nil)
 
+	// Background-workflow completion notifications. A workflow runs detached, so
+	// without this its result is invisible until the model polls workflow_status.
+	tools.SetDefaultWorkflowOnDone(func(ev tools.WorkflowNotification) {
+		cfg.a.Inbox.Enqueue(tools.FormatWorkflowNote(ev))
+		p.Send(workflowNoteMsg{ev})
+	})
+	defer func() {
+		tools.SetDefaultWorkflowOnDone(nil)
+		tools.KillDefaultWorkflows()
+	}()
+
 	_, err := p.Run()
 	if err != nil {
 		fmt.Fprintf(cfg.stderr, "octo: tui: %v\n", err)
@@ -139,6 +150,7 @@ type turnFinishedMsg struct{ err error } // the turn goroutine returned
 type noticeMsg struct{ text string }
 type bgExitMsg struct{ e tools.BgExit }                      // a background process finished (async)
 type subAgentNoteMsg struct{ ev tools.SubAgentNotification } // a sub-agent completed (async)
+type workflowNoteMsg struct{ ev tools.WorkflowNotification } // a background workflow finished (async)
 type mcpReadyMsg struct{ reg *mcp.Registry }                 // background MCP connect finished (async)
 type subAgentEventMsg struct{ ev tools.SubAgentEvent }       // a sub-agent's runtime activity (async)
 type suggestionMsg struct{ text string }                     // an after-turn follow-up suggestion (async)
@@ -660,6 +672,23 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// inbox (which holds the full <system-reminder> notice) and start a
 		// turn so the model sees the completion immediately — matching the plain
 		// REPL's idleInboxWait behaviour.
+		if !m.turnRunning && len(m.queue) == 0 {
+			if items := m.a.Inbox.Drain(); len(items) > 0 {
+				s := strings.Join(agent.Texts(items), "\n\n")
+				return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(s, ""))
+			}
+		}
+		return m, m.flushPrints()
+
+	case workflowNoteMsg:
+		// Scrollback notice for the user; the full <system-reminder> rode the
+		// inbox for the model. Idle auto-turn mirrors bgExitMsg so the model
+		// reacts to a finished background workflow immediately.
+		status := msg.ev.Status
+		if status == "" {
+			status = "done"
+		}
+		m.printlnBlock(bgDoneStyle.Render(fmt.Sprintf("● Workflow %s (%s) %s", msg.ev.RunID, msg.ev.Description, status)))
 		if !m.turnRunning && len(m.queue) == 0 {
 			if items := m.a.Inbox.Drain(); len(items) > 0 {
 				s := strings.Join(agent.Texts(items), "\n\n")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1398,8 +1398,13 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 		})
 		ctx = tools.WithBackgroundManager(ctx, bgMgr)
 		// Per-chat workflow manager so background workflows are isolated per
-		// conversation (their own wf_N namespace and concurrency budget).
-		ctx = tools.WithWorkflowManager(ctx, tools.SessionWorkflowManager("im:"+string(sess.Key)))
+		// conversation (their own wf_N namespace and concurrency budget). Its
+		// completion hook nudges the model via the same Inbox path as bg/sub-agent.
+		wfMgr := tools.SessionWorkflowManager("im:" + string(sess.Key))
+		wfMgr.SetOnDone(func(ev tools.WorkflowNotification) {
+			sess.Agent.Inbox.Enqueue(tools.FormatWorkflowNote(ev))
+		})
+		ctx = tools.WithWorkflowManager(ctx, wfMgr)
 		// Turn-scoped asker: ask_user_question prompts in this chat instead
 		// of falling back to the process-global wsAsker, which broadcasts to
 		// browser tabs an IM session doesn't have (the question would hang

--- a/internal/tools/session_managers.go
+++ b/internal/tools/session_managers.go
@@ -132,6 +132,15 @@ func KillAllSessionSubAgents() {
 // the CLI/TUI, which never stamp a ctx-scoped manager.
 var defaultWorkflowMgr = NewWorkflowManager()
 
+// SetDefaultWorkflowOnDone wires the completion hook on the process-global
+// workflow manager so a finished background run reaches the CLI/TUI agent
+// (parity with SetBackgroundOnExit / SubAgentManager.SetOnExit). Pass nil to clear.
+func SetDefaultWorkflowOnDone(fn func(WorkflowNotification)) { defaultWorkflowMgr.SetOnDone(fn) }
+
+// KillDefaultWorkflows cancels every background workflow on the process-global
+// manager — called on CLI/TUI exit so a detached run doesn't linger.
+func KillDefaultWorkflows() { defaultWorkflowMgr.KillAll() }
+
 type workflowManagerCtxKey struct{}
 
 // WithWorkflowManager stamps ctx with the per-session workflow manager the

--- a/internal/tools/workflow_test.go
+++ b/internal/tools/workflow_test.go
@@ -178,6 +178,39 @@ func TestWorkflowKill_UnknownRun(t *testing.T) {
 	}
 }
 
+// TestDefaultWorkflowOnDone_FiresOnCompletion guards the CLI/TUI notification
+// path: a workflow started through the tool (which resolves to the default
+// manager) must fire the OnDone hook on completion. This is the wiring that was
+// missing — without it the agent never learns a background run finished.
+func TestDefaultWorkflowOnDone_FiresOnCompletion(t *testing.T) {
+	SetSpawner(replySpawner{})
+	t.Cleanup(func() { SetSpawner(nil) })
+
+	done := make(chan WorkflowNotification, 1)
+	SetDefaultWorkflowOnDone(func(ev WorkflowNotification) { done <- ev })
+	t.Cleanup(func() { SetDefaultWorkflowOnDone(nil) })
+
+	_, err := WorkflowTool{}.Execute(context.Background(), "c",
+		map[string]any{"script": `agent("x")`, "description": "notify-me"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	select {
+	case ev := <-done:
+		if ev.Status != "done" || ev.Description != "notify-me" {
+			t.Errorf("notification = %+v, want status=done description=notify-me", ev)
+		}
+		note := FormatWorkflowNote(ev)
+		for _, want := range []string{"<system-reminder>", "notify-me", "workflow_status"} {
+			if !strings.Contains(note, want) {
+				t.Errorf("FormatWorkflowNote missing %q; got:\n%s", want, note)
+			}
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("OnDone hook did not fire within the window")
+	}
+}
+
 func TestWorkflowTool_RefusesInSubAgent(t *testing.T) {
 	SetSpawner(replySpawner{})
 	t.Cleanup(func() { SetSpawner(nil) })


### PR DESCRIPTION
## The bug

A finished background workflow only notified the model on the **web** path — `handlers.go` wired the per-session manager's `OnDone` hook. But:

- **CLI/TUI** use the process-global `defaultWorkflowMgr`, which had **no `OnDone` at all**.
- **IM** stamped a per-session manager but **never set its hook**.

So a workflow run in the TUI (where the user hit this) or IM completed **silently** — the agent never learned it finished and had to blind-poll `workflow_status`.

## Fix

Wire the completion hook on every transport, mirroring the existing sub-agent / background-process notification paths:

- **tools**: `SetDefaultWorkflowOnDone` / `KillDefaultWorkflows` package setters on the process-global manager.
- **TUI** (`tuirepl.go`): `OnDone` enqueues `FormatWorkflowNote` to the agent `Inbox` and sends a `workflowNoteMsg`; the handler prints a scrollback notice and does the **same idle auto-turn as `bgExitMsg`**, so the model reacts immediately even when idle. Detached runs are reaped on exit.
- **plain REPL** (`repl.go`): `OnDone` enqueues to the `Inbox` (drained between loop steps / by `idleInboxWait`).
- **IM** (`server.go`): the per-chat manager's `OnDone` enqueues to the session agent's `Inbox`, like its background manager.

## Test plan

- [x] New `TestDefaultWorkflowOnDone_FiresOnCompletion` — a workflow started through the tool (→ default manager) fires `OnDone` on completion, and `FormatWorkflowNote` carries the `<system-reminder>` + run label + `workflow_status` hint. This guards the exact wiring that was missing.
- [x] `go test -race ./internal/tools/ ./internal/server/`, `go test ./cmd/octo/` — pass
- [x] `go build ./...`, `go vet`, gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)