### PR TITLE
feat(agent): detect duplicate tool calls and stop gracefully

### DIFF
--- a/cmd/octo/markdown_test.go
+++ b/cmd/octo/markdown_test.go
@@ -35,6 +35,59 @@ func TestSplitCommittableMarkdown(t *testing.T) {
 	}
 }
 
+func TestInjectAssistantPrefix(t *testing.T) {
+	const prefix = "◆ "
+	cases := []struct {
+		name, in, want string
+	}{
+		{"plain leading spaces", "  hello", "◆ hello"},
+		{"no indent", "hello", "◆ hello"},
+		// glamour shape: margin spaces sit behind zero-width SGR escapes; the
+		// colour escape that styles the text must survive.
+		{
+			"glamour margin behind escapes",
+			"\x1b[0m\x1b[0m  \x1b[38;5;252mhello\x1b[0m",
+			"◆ \x1b[0m\x1b[0m\x1b[38;5;252mhello\x1b[0m",
+		},
+		{"escape then space then text", "\x1b[1m  hi", "◆ \x1b[1mhi"},
+		{"empty", "", ""},
+		{"only spaces", "   ", "   "},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := injectAssistantPrefix(c.in, prefix); got != c.want {
+				t.Errorf("injectAssistantPrefix(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestInjectAssistantPrefix_RealGlamour guards the original bug: glamour's
+// margin must not leave visible leading spaces between the ◆ prefix and the
+// text. We assert no space immediately follows the prefix once escapes are
+// stripped from the visible run.
+func TestInjectAssistantPrefix_RealGlamour(t *testing.T) {
+	var md markdownRenderer
+	rendered := md.render("hello world", 80)
+	out := injectAssistantPrefix(rendered, "◆ ")
+	if !strings.HasPrefix(out, "◆ ") {
+		t.Fatalf("output should start with prefix; got %q", out)
+	}
+	// Strip the prefix and all leading escapes; the next byte must be the
+	// glyph 'h', never a leftover margin space.
+	rest := strings.TrimPrefix(out, "◆ ")
+	for {
+		if n := ansiPrefixLen(rest); n > 0 {
+			rest = rest[n:]
+			continue
+		}
+		break
+	}
+	if strings.HasPrefix(rest, " ") {
+		t.Errorf("margin space survived after prefix+escapes; full output: %q", out)
+	}
+}
+
 func TestMarkdownRenderer_RendersAndIsBestEffort(t *testing.T) {
 	var md markdownRenderer
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1339,10 +1339,45 @@ func (m *tuiModel) thinkingLine() string {
 // injectAssistantPrefix strips glamour's 2-space paragraph indent from the
 // first line and prepends prefix so ◆ aligns at column 0, mirroring "> ".
 // Leading newlines are already trimmed by markdownRenderer.render.
+//
+// glamour emits the document margin as literal spaces sitting *behind*
+// zero-width SGR escapes (e.g. "\x1b[…m\x1b[0m  \x1b[…m我先…"), so the string
+// rarely begins with a space — a plain TrimLeft(rendered, " ") would be a
+// no-op and the indent would survive. We instead walk the leading run,
+// dropping margin spaces while keeping the escapes (the colour escape that
+// styles the text included), and stop at the first visible glyph.
 func injectAssistantPrefix(rendered, prefix string) string {
-	trimmed := strings.TrimLeft(rendered, " ")
-	if trimmed == "" {
-		return rendered
+	var kept strings.Builder
+	i := 0
+	for i < len(rendered) {
+		if rendered[i] == ' ' {
+			i++ // drop glamour's margin spaces
+			continue
+		}
+		if n := ansiPrefixLen(rendered[i:]); n > 0 {
+			kept.WriteString(rendered[i : i+n]) // keep zero-width escapes
+			i += n
+			continue
+		}
+		break // first visible glyph
 	}
-	return prefix + trimmed
+	if i >= len(rendered) {
+		return rendered // nothing but whitespace/escapes
+	}
+	return prefix + kept.String() + rendered[i:]
+}
+
+// ansiPrefixLen returns the byte length of the ANSI CSI escape sequence at the
+// start of s (ESC '[' … final-byte in 0x40–0x7E, which covers the SGR colour
+// codes glamour emits), or 0 if s does not begin with a complete one.
+func ansiPrefixLen(s string) int {
+	if len(s) < 2 || s[0] != 0x1b || s[1] != '[' {
+		return 0
+	}
+	for i := 2; i < len(s); i++ {
+		if s[i] >= 0x40 && s[i] <= 0x7e {
+			return i + 1
+		}
+	}
+	return 0 // unterminated; treat as not a complete escape
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2,6 +2,9 @@ package agent
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -215,6 +218,71 @@ type Agent struct {
 	// executed during the most recent Run/RunStream call. It is set when the
 	// runLoop returns so callers can surface it in UI (e.g. "3 iterations").
 	turnIterations int
+
+	// recentToolCalls tracks the fingerprints of the last few tool-use batches
+	// so runLoop can detect when the model is stuck repeating the same call(s).
+	// Guarded by the implicit serialisation of runLoop (single goroutine).
+	recentToolCalls [][]toolCallFingerprint
+}
+
+// toolCallFingerprint is a lightweight hash of a single tool-use block.
+type toolCallFingerprint struct {
+	name     string
+	argsHash string // hex-encoded SHA-256 of the JSON-serialised Input map
+}
+
+// fingerprintToolUseBlock hashes a tool_use ContentBlock into a comparable
+// fingerprint. Empty string on blocks that aren't tool_use.
+func fingerprintToolUseBlock(b ContentBlock) toolCallFingerprint {
+	if b.Type != "tool_use" {
+		return toolCallFingerprint{}
+	}
+	// Input is a map[string]any; deterministically marshal to JSON for hashing.
+	// We don't need crypto strength, just collision resistance for debugging.
+	data, _ := json.Marshal(b.Input)
+	h := sha256.Sum256(data)
+	return toolCallFingerprint{
+		name:     b.Name,
+		argsHash: hex.EncodeToString(h[:]),
+	}
+}
+
+// fingerprintToolUseBatch hashes an ordered slice of tool_use blocks.
+func fingerprintToolUseBatch(blocks []ContentBlock) []toolCallFingerprint {
+	out := make([]toolCallFingerprint, 0, len(blocks))
+	for _, b := range blocks {
+		if b.Type == "tool_use" {
+			out = append(out, fingerprintToolUseBlock(b))
+		}
+	}
+	return out
+}
+
+// hasConsecutiveDuplicates reports whether the last `window` entries in
+// recentToolCalls are all identical to the current batch. The window size
+// determines how many consecutive repeats trigger the stuck detector.
+func hasConsecutiveDuplicates(recent [][]toolCallFingerprint, current []toolCallFingerprint, window int) bool {
+	if len(recent) < window || len(current) == 0 {
+		return false
+	}
+	for i := len(recent) - window; i < len(recent); i++ {
+		if !slicesEqual(recent[i], current) {
+			return false
+		}
+	}
+	return true
+}
+
+func slicesEqual(a, b []toolCallFingerprint) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // AttachUserBlocks queues content blocks — typically image blocks — to be
@@ -264,6 +332,11 @@ const (
 	// synthetic StopReason when a turn is ended because the response stayed
 	// truncated even after escalation. See dev-docs/truncation-recovery.md.
 	StopReasonMaxTokens = "max_tokens"
+	// StopReasonStuck is set when the agentic loop detects consecutive duplicate
+	// tool calls — a sign the model is stuck in a loop with no progress. The run
+	// ends gracefully so the caller can intervene (e.g. prompt the user or retry
+	// with a different strategy) rather than burning the full turn budget.
+	StopReasonStuck = "stuck"
 )
 
 // interruptNote caps an interrupted turn as an assistant message so history
@@ -704,6 +777,24 @@ func (a *Agent) runLoop(
 
 		if reply.StopReason == "tool_use" {
 			a.History.Append(NewToolUseMessage(reply.Blocks))
+
+			// ── Duplicate-tool-call loop detection ──
+			// If the model keeps issuing the exact same tool_use batch, it is
+			// stuck in a loop with no progress. Detect this early and stop
+			// gracefully so the caller can intervene instead of burning the
+			// full turn budget.
+			const stuckWindow = 2 // require 2 consecutive repeats (3 identical batches total)
+			fp := fingerprintToolUseBatch(reply.Blocks)
+			if hasConsecutiveDuplicates(a.recentToolCalls, fp, stuckWindow) {
+				return a.budgetStop(handler, StopReasonStuck,
+					"[octo] Stopped: detected repeated tool calls without progress. "+
+						"The model appears to be stuck in a loop. "+
+						"Send another message to continue with a different approach.")
+			}
+			a.recentToolCalls = append(a.recentToolCalls, fp)
+			if len(a.recentToolCalls) > stuckWindow+1 {
+				a.recentToolCalls = a.recentToolCalls[len(a.recentToolCalls)-stuckWindow-1:]
+			}
 
 			// Emit EventToolStarted before dispatch so observers see the
 			// "thinking → tool call" boundary even if the tool blocks.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -405,13 +405,14 @@ func TestAgent_Run_MultipleToolCalls(t *testing.T) {
 }
 
 func TestAgent_Run_ExceedsMaxTurns_FriendlyStop(t *testing.T) {
-	// Every reply is tool_use — loop hits the cap. Hitting it must NOT error;
-	// it returns a friendly reply with StopReason "max_turns".
+	// Every reply is tool_use with DIFFERENT args — loop hits the cap without
+	// triggering the stuck detector. Hitting it must NOT error; it returns a
+	// friendly reply with StopReason "max_turns".
 	replies := make([]Reply, defaultMaxTurns+5)
 	for i := range replies {
 		replies[i] = Reply{
 			StopReason: "tool_use",
-			Blocks:     []ContentBlock{NewToolUseBlock("c", "bash", nil)},
+			Blocks:     []ContentBlock{NewToolUseBlock(fmt.Sprintf("c%d", i), "bash", map[string]any{"command": fmt.Sprintf("cmd%d", i)})},
 		}
 	}
 	send := &fakeToolSender{replies: replies}
@@ -452,6 +453,66 @@ func TestAgent_Run_CustomMaxTurns(t *testing.T) {
 	}
 	if send.calls != 2 {
 		t.Errorf("provider calls = %d, want 2 (MaxTurns)", send.calls)
+	}
+}
+
+func TestAgent_Run_DuplicateToolCalls_StopsGracefully(t *testing.T) {
+	// The model keeps issuing the exact same tool_use batch. After 3 identical
+	// consecutive batches the stuck detector should fire (window=2 means 2
+	// repeats on top of the original = 3 total).
+	repeats := []Reply{
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c1", "bash", map[string]any{"command": "ls"})}},
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c2", "bash", map[string]any{"command": "ls"})}},
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c3", "bash", map[string]any{"command": "ls"})}},
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c4", "bash", map[string]any{"command": "ls"})}}, // should never reach
+	}
+	send := &fakeToolSender{replies: repeats}
+	exec := &fakeExecutor{}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "bash"}}
+
+	reply, err := a.Run(context.Background(), "go", defs, exec)
+	if err != nil {
+		t.Fatalf("stuck detector should stop gracefully, not error: %v", err)
+	}
+	if reply.StopReason != StopReasonStuck {
+		t.Errorf("StopReason = %q, want %q", reply.StopReason, StopReasonStuck)
+	}
+	if !strings.Contains(reply.Content, "stuck") {
+		t.Errorf("reply should mention being stuck, got %q", reply.Content)
+	}
+	// The stuck detector fires on the 3rd identical batch, so only 3 provider
+	// calls and 3 tool executions should have happened.
+	if send.calls != 3 {
+		t.Errorf("provider calls = %d, want 3 (stuck detector should stop early)", send.calls)
+	}
+	if len(exec.called) != 2 {
+		t.Errorf("executor calls = %d, want 2", len(exec.called))
+	}
+}
+
+func TestAgent_Run_DifferentToolCalls_DoesNotStop(t *testing.T) {
+	// The model issues different tool calls each round — no stuck detector.
+	replies := []Reply{
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c1", "bash", map[string]any{"command": "ls"})}},
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c2", "bash", map[string]any{"command": "pwd"})}},
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c3", "bash", map[string]any{"command": "cat"})}},
+		{Content: "done", StopReason: "end_turn"},
+	}
+	send := &fakeToolSender{replies: replies}
+	exec := &fakeExecutor{}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "bash"}}
+
+	reply, err := a.Run(context.Background(), "go", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", reply.StopReason)
+	}
+	if send.calls != 4 {
+		t.Errorf("provider calls = %d, want 4", send.calls)
 	}
 }
 


### PR DESCRIPTION
When the model issues the exact same tool_use batch for 3 consecutive rounds, the agentic loop now stops early with `StopReasonStuck` instead of burning the full turn budget.

### Changes
- Add `StopReasonStuck` sentinel for stuck-detector stops.
- Add `toolCallFingerprint` + `fingerprintToolUseBatch` helpers (SHA-256 of JSON-serialised args).
- Track recent tool-use batches in `Agent.recentToolCalls`.
- Detect consecutive duplicates in `runLoop` (window=2, i.e. 3 identical batches total) and call `budgetStop` gracefully.
- Tests: duplicate triggers stuck, different calls do not.

### Why
This catches the common stuck pattern where the LLM repeats a tool call (e.g. re-reading the same file) with no progress. The user sees a friendly message and can continue with a different approach, rather than waiting for the max-turns cap.