### PR TITLE
fix(tui): never render reasoning trace in the terminal; web-only, default off

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -151,8 +151,10 @@ func resolveCoauthor(noCoauthorFlag bool, cfg config.Config) bool {
 }
 
 // resolveShowReasoning determines whether the reasoning/thinking trace is
-// streamed to the terminal. Precedence: an explicit --show-reasoning flag >
-// config file > default (true).
+// surfaced (i.e. requested from the provider). The terminal never renders it —
+// this only governs whether the trace is fetched at all, which the Web UI then
+// displays. Precedence: an explicit --show-reasoning flag > config file >
+// default (false).
 func resolveShowReasoning(flagSet, flagVal bool, entry config.ModelEntry) bool {
 	if flagSet {
 		return flagVal
@@ -160,7 +162,7 @@ func resolveShowReasoning(flagSet, flagVal bool, entry config.ModelEntry) bool {
 	if entry.ShowReasoning != nil {
 		return *entry.ShowReasoning
 	}
-	return true
+	return false
 }
 
 // toolSearchConfigFrom maps the persisted tools.tool_search block onto the
@@ -257,7 +259,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	compactAutoPct := fs.Int("compact-auto-pct", 0, "Auto-compaction threshold as a percentage of the model's context window (0 = use `octo config` or built-in default 75). Only used when --compact-threshold=0.")
 	compactBatchThreshold := fs.Int("compact-batch-threshold", 0, "Batch-level compaction: compact after a tool batch when context exceeds this many tokens; 0 = auto (~85% of the model's context window), <0 = disabled between batches")
 	reasoningEffort := fs.String("reasoning-effort", "", "Reasoning intensity: low | medium | high | xhigh | max (empty = off). OpenAI → reasoning_effort; Anthropic → adaptive thinking + effort. Also from `octo config`.")
-	showReasoning := fs.Bool("show-reasoning", true, "Stream the reasoning/thinking trace to the terminal (dimmed). Use --show-reasoning=false to hide it. Also from `octo config`.")
+	showReasoning := fs.Bool("show-reasoning", false, "Surface the reasoning/thinking trace for the Web UI (octo serve) to display. The terminal never renders it. Default off; also from `octo config`.")
 	useSandbox := fs.Bool("sandbox", false, "Confine terminal commands to the project dir + tmp with no network (OS-enforced; macOS/Linux). Fails closed if unavailable.")
 	sandboxAllowNet := fs.Bool("sandbox-allow-net", false, "Under --sandbox, permit network access (default: denied)")
 	var sandboxWrite, sandboxRead stringList

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -212,7 +212,7 @@ func TestResolveShowReasoning(t *testing.T) {
 		entry   config.ModelEntry
 		want    bool
 	}{
-		{"default on", false, true, config.ModelEntry{}, true},
+		{"default off", false, true, config.ModelEntry{}, false},
 		{"config off", false, true, config.ModelEntry{ShowReasoning: &fls}, false},
 		{"config on", false, true, config.ModelEntry{ShowReasoning: &tru}, true},
 		{"flag off beats config on", true, false, config.ModelEntry{ShowReasoning: &tru}, false},

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -179,7 +179,7 @@ func runConfigShow(stdout, stderr io.Writer) int {
 		effortStatus = entry.ReasoningEffort + " (config)"
 	}
 	fmt.Fprintf(stdout, "  reasoning: %s\n", effortStatus)
-	showStatus := "on (default)"
+	showStatus := "off (default)"
 	if entry.ShowReasoning != nil {
 		if *entry.ShowReasoning {
 			showStatus = "on (config)"
@@ -187,7 +187,7 @@ func runConfigShow(stdout, stderr io.Writer) int {
 			showStatus = "off (config)"
 		}
 	}
-	fmt.Fprintf(stdout, "  show trace: %s\n", showStatus)
+	fmt.Fprintf(stdout, "  show trace (web): %s\n", showStatus)
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "CLI flags (--provider, --model, --system) and env vars override this file per run.")
 	return 0
@@ -416,10 +416,11 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 		outEntry.ReasoningEffort = effortAns
 	}
 
-	// Show the reasoning/thinking trace: default on.
-	showDefault := existing.ShowReasoning == nil || *existing.ShowReasoning
+	// Surface the reasoning/thinking trace for the Web UI to display (the
+	// terminal never renders it): default off.
+	showDefault := existing.ShowReasoning != nil && *existing.ShowReasoning
 	showVal, ok := pickYesNo(tty, reader, stdin, stdout,
-		"Show the reasoning/thinking trace while streaming?", showDefault)
+		"Show the reasoning/thinking trace on the Web UI?", showDefault)
 	if !ok {
 		return cancelWizard(stderr)
 	}

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -432,29 +432,12 @@ func replToolEventHandler(stdout io.Writer, plain bool) func(agent.AgentEvent) {
 	// Count of `·` typing-indicator dots emitted while the LLM streams the
 	// in-flight tool's input arguments. Reset on tool_started.
 	inputDots := 0
-	// thinkingOpen tracks the dimmed reasoning trace: opened on the first
-	// thinking delta (ESC[2m + 💭), closed (ESC[0m + newline) before the first
-	// non-thinking output so the answer starts clean and undimmed.
-	thinkingOpen := false
-	closeThinking := func() {
-		if thinkingOpen {
-			fmt.Fprint(stdout, "\x1b[0m\n")
-			thinkingOpen = false
-		}
-	}
 
 	return func(ev agent.AgentEvent) {
-		// Any non-thinking event ends the dimmed trace first.
-		if ev.Kind != agent.EventThinkingDelta {
-			closeThinking()
-		}
 		switch ev.Kind {
 		case agent.EventThinkingDelta:
-			if !thinkingOpen {
-				fmt.Fprint(stdout, "\x1b[2m\U0001F4AD ")
-				thinkingOpen = true
-			}
-			fmt.Fprint(stdout, ev.Text)
+			// The terminal never renders the reasoning trace — that display
+			// lives only on the Web UI (gated by show_reasoning). Drop it here.
 
 		case agent.EventTextDelta:
 			fmt.Fprint(stdout, ev.Text)

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -330,14 +330,6 @@ type tuiModel struct {
 	// fully-completed list (normally hidden once nothing is outstanding).
 	showTasks bool
 
-	// showReasoning controls whether the reasoning/thinking trace is displayed
-	// in the live area (when true) or suppressed (when false). When false,
-	// thinking deltas still feed the live activity line's token count.
-	showReasoning bool
-	// thinkingPartial accumulates the reasoning trace when showReasoning is
-	// true, rendered dimmed in the live area above the normal partial text.
-	thinkingPartial strings.Builder
-
 	width int
 	quit  bool
 
@@ -477,7 +469,7 @@ func newTUIModel(cfg replConfig) *tuiModel {
 	if !tui.IsDark() {
 		style = "light"
 	}
-	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}, subAgentFocus: -1, showReasoning: cfg.showReasoning}
+	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}, subAgentFocus: -1}
 	_ = m.updateTextAreaHeight()
 	return m
 }
@@ -953,13 +945,11 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 	m.commitEcho()
 	switch ev.Kind {
 	case agent.EventThinkingDelta:
-		// When showReasoning is true, the thinking trace is streamed to the
-		// live area (dimmed, like the plain REPL). When false, it stays out
-		// of the live area and only feeds the activity line's token readout.
+		// The terminal never renders the reasoning trace — that display lives
+		// only on the Web UI (gated by show_reasoning). Here the delta only
+		// feeds the activity line's output-token readout, so a long agentic
+		// turn still reads as progress without spilling thinking into the TUI.
 		m.turnOutChars += len(ev.Text)
-		if m.showReasoning {
-			m.thinkingPartial.WriteString(ev.Text)
-		}
 		return
 
 	case agent.EventToolInputDelta:
@@ -983,7 +973,6 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 	case agent.EventToolStarted:
 		// Args finished streaming; the tool now executes. Clear the stream
 		// readout so the running-card spinner (or one-line status) takes over.
-		m.thinkingPartial.Reset() // thinking phase ended; tool call is next
 		m.toolStreamName, m.toolStreamID, m.toolStreamBytes = "", "", 0
 		if m.toolInput == nil {
 			m.toolInput = map[string]map[string]any{}
@@ -1328,7 +1317,6 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 	m.turnRunning = false
 	m.cancelTurn = nil
 	m.running = nil // clear any live tool indicator (e.g. on interrupt)
-	m.thinkingPartial.Reset()
 
 	// Any steer messages that weren't drained via EventSteerInjected during
 	// the turn (e.g. typed after the last loop iteration) are printed now so

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -683,23 +683,20 @@ func TestTUI_SubmitSavesToHistory(t *testing.T) {
 	}
 }
 
-// When showReasoning is true, thinking deltas are rendered in the live area
-// (dimmed) instead of being suppressed.
-func TestTUI_ThinkingShownWhenEnabled(t *testing.T) {
+// The terminal never renders the reasoning trace — that display is web-only.
+// A thinking delta must not appear in the live View (nor the scrollback); it
+// only feeds the activity line's output-token readout.
+func TestTUI_ThinkingNeverShownInTerminal(t *testing.T) {
 	m := newTestModel()
-	m.showReasoning = true
 	m.turnRunning = true
 
 	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: "let me think"})
 
-	// Thinking should not reach scrollback (printlnBuf) — it's live-only.
 	if joined := strings.Join(m.printlnBuf, "\n"); joined != "" {
 		t.Fatalf("thinking must not reach the scrollback; got %q", joined)
 	}
-	// But it should appear in the live View.
-	out := m.View()
-	if !strings.Contains(out, "let me think") {
-		t.Errorf("view should contain thinking text when showReasoning=true; got:\n%s", out)
+	if out := m.View(); strings.Contains(out, "let me think") {
+		t.Errorf("view must NOT contain thinking text; got:\n%s", out)
 	}
 	if m.turnOutChars != 12 {
 		t.Errorf("turnOutChars = %d, want 12", m.turnOutChars)

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -42,7 +42,6 @@ var (
 	complSelStyle        = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
 	complNameStyle       = lipgloss.NewStyle().Foreground(tui.ColAccent)
 	bgDoneStyle          = lipgloss.NewStyle().Foreground(tui.ColAccent)
-	thinkingStyle        = lipgloss.NewStyle().Foreground(tui.ColDimmer).Italic(true)
 )
 
 func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -917,10 +916,7 @@ func (m *tuiModel) liveHeight() int {
 	if m.partial.String() != "" {
 		h++
 	}
-	if t := m.thinkingPartial.String(); t != "" {
-		h += strings.Count(t, "\n") + 1
-	}
-	if m.running != nil || (m.turnRunning && m.partial.Len() == 0 && m.thinkingPartial.Len() == 0) {
+	if m.running != nil || (m.turnRunning && m.partial.Len() == 0) {
 		h++
 	}
 	if m.running != nil && tools.HasActiveSync() {
@@ -971,12 +967,6 @@ func (m *tuiModel) View() string {
 		b.WriteByte('\n')
 	}
 
-	// Live thinking trace (shown when showReasoning is true).
-	if t := m.thinkingPartial.String(); t != "" {
-		b.WriteString(thinkingStyle.Render("💭 " + t))
-		b.WriteByte('\n')
-	}
-
 	// Live partial assistant text
 	if p := m.partial.String(); p != "" {
 		rendered := m.md.render(p, m.width)
@@ -1018,7 +1008,7 @@ func (m *tuiModel) View() string {
 		label := fmt.Sprintf("%s… %s", streamVerbFor(m.toolStreamName), humanByteSize(m.toolStreamBytes))
 		b.WriteString(m.spinnerLine(label, m.turnStart))
 		b.WriteByte('\n')
-	} else if m.turnRunning && m.partial.Len() == 0 && m.thinkingPartial.Len() == 0 {
+	} else if m.turnRunning && m.partial.Len() == 0 {
 		// Turn is running but nothing is on the activity line right now — no
 		// live tool and no streaming text. That's the wait on the model
 		// (initial prompt, or between steps after a tool result). Show the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -779,7 +779,7 @@ func resolveProviderAndModel(flagProvider, flagModel string) (agent.Sender, stri
 		APIKey:          apiKey,
 		BaseURL:         resolveBaseURL(provName, cfg),
 		ReasoningEffort: entry.ReasoningEffort,
-		ShowReasoning:   entry.ShowReasoning == nil || *entry.ShowReasoning,
+		ShowReasoning:   entry.ShowReasoning != nil && *entry.ShowReasoning,
 	})
 	if err != nil {
 		return nil, "", "", err
@@ -906,7 +906,7 @@ func senderForEntry(entry config.ModelEntry) (agent.Sender, error) {
 	if apiKey == "" {
 		return nil, fmt.Errorf("no API key for entry %q (provider %q)", entry.Name, entry.Provider)
 	}
-	showReasoning := true
+	showReasoning := false
 	if entry.ShowReasoning != nil {
 		showReasoning = *entry.ShowReasoning
 	}

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -177,9 +177,10 @@
 
     cleanups.push(ws.on('thinking_delta', (ev) => {
       if ((ev as any).session_id && (ev as any).session_id !== sid) return
-      // Respect show_reasoning: undefined/true → show; false → discard.
+      // Respect show_reasoning: only an explicit true shows the trace
+      // (default off). The terminal never displays it — this is web-only.
       const sess = get(sessions).find((s: any) => s.id === sid) as any
-      if (sess?.show_reasoning === false) return
+      if (sess?.show_reasoning !== true) return
       chatThinking.update(tt => ({ ...tt, [sid]: (tt[sid] ?? '') + ((ev as any).text ?? '') }))
     }))
 


### PR DESCRIPTION
## Problem

The reasoning/thinking trace (`reasoning_content`) cluttered the TUI live area — long, unformatted, dimmed text interleaved with the spinner and partial output. `--show-reasoning` also defaulted **on**, so everyone saw it.

## Change

Make the reasoning trace a **Web-UI-only** feature, **default off**:

- **Terminal never displays it.** Removed the live `💭` block + `thinkingPartial` accumulation in the rich TUI (`tuirepl.go`/`tuirepl_view.go`), and the dimmed `💭` trace in the plain REPL handler (`repl.go`). The TUI still counts thinking-delta size into the activity line's output-token readout (`turnOutChars`).
- **Default off everywhere:** `--show-reasoning` flag, `octo config` wizard, server sender construction, and `resolveShowReasoning` fallback all default `false`.
- `show_reasoning` now only gates whether the trace is *surfaced* (fetched from the provider) for the Web UI to display. Web frontend (`ChatView.svelte`) shows it on an **explicit `true`** only.
- The flag/config remain settable so the Web UI can opt in.

## Scope note

Per "只在 web 端展示", this removes the trace from **both** terminal surfaces — the rich TUI *and* the plain/headless REPL. If plain/headless should keep piping reasoning when explicitly enabled, that part can be reverted.

## Testing

- `go test -race ./...` green; `go vet`, `gofmt -l` clean.
- Updated `TestResolveShowReasoning` (default → false) and replaced `TestTUI_ThinkingShownWhenEnabled` with `TestTUI_ThinkingNeverShownInTerminal` (asserts the trace never reaches the View).
- Web: one-line condition flip in `ChatView.svelte`; `npx svelte-check` failures in this worktree are pre-existing / missing-`node_modules` only and don't reference the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)