### PR TITLE
fix(server): derive Anthropic thinking budget from reasoning_effort

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -191,25 +191,10 @@ func validReasoningEffort(e string) bool {
 }
 
 // anthropicThinkingBudget maps a unified reasoning-effort level to an Anthropic
-// thinking-token figure. "" (off) yields 0, which disables thinking. On modern
-// Claude models (adaptive thinking + output_config.effort) the provider uses
-// this only as a max_tokens floor; on older Claude / Kimi-for-coding it is the
-// literal thinking.budget_tokens. The provider bumps max_tokens to fit a value
-// larger than it, so the higher levels can outrun the default cap safely.
+// thinking-token figure. Delegates to app.AnthropicThinkingBudget so the CLI
+// and the server share one source of truth for the effort→budget mapping.
 func anthropicThinkingBudget(effort string) int {
-	switch effort {
-	case "low":
-		return 4096
-	case "medium":
-		return 16384
-	case "high":
-		return 32768
-	case "xhigh":
-		return 48000
-	case "max":
-		return 64000
-	}
-	return 0
+	return app.AnthropicThinkingBudget(effort)
 }
 
 // defaultModels maps each provider to the model used when `--model` isn't

--- a/internal/app/sender.go
+++ b/internal/app/sender.go
@@ -49,6 +49,28 @@ type SenderOptions struct {
 	ShowReasoning bool
 }
 
+// AnthropicThinkingBudget maps a unified reasoning-effort level to an Anthropic
+// thinking-token figure. "" (off) yields 0, which disables thinking. On modern
+// Claude models (adaptive thinking + output_config.effort) the provider uses
+// this only as a max_tokens floor; on older Claude / Kimi-for-coding it is the
+// literal thinking.budget_tokens. The provider bumps max_tokens to fit a value
+// larger than it, so the higher levels can outrun the default cap safely.
+func AnthropicThinkingBudget(effort string) int {
+	switch effort {
+	case "low":
+		return 4096
+	case "medium":
+		return 16384
+	case "high":
+		return 32768
+	case "xhigh":
+		return 48000
+	case "max":
+		return 64000
+	}
+	return 0
+}
+
 // NewSender builds the provider client for opts and wraps it as an agent.Sender.
 // It is the single entry point through which every transport obtains a sender.
 func NewSender(opts SenderOptions) (agent.Sender, error) {
@@ -56,10 +78,21 @@ func NewSender(opts SenderOptions) (agent.Sender, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Anthropic-protocol models on the legacy budget path (older Claude,
+	// Kimi-for-coding) enable thinking only from a positive ThinkingBudget and
+	// ignore the effort string entirely. Callers that set only ReasoningEffort
+	// (e.g. the server, which carries the persisted reasoning_effort) would
+	// otherwise never enable thinking — derive the budget from the effort here
+	// so every transport behaves like the CLI. An explicit budget wins; the
+	// figure is harmless to OpenAI-protocol vendors, which ignore it.
+	thinkingBudget := opts.ThinkingBudget
+	if thinkingBudget == 0 {
+		thinkingBudget = AnthropicThinkingBudget(opts.ReasoningEffort)
+	}
 	return sender{
 		p:               p,
 		cacheKey:        opts.CacheKey,
-		thinkingBudget:  opts.ThinkingBudget,
+		thinkingBudget:  thinkingBudget,
 		reasoningEffort: opts.ReasoningEffort,
 		showReasoning:   opts.ShowReasoning,
 	}, nil

--- a/internal/app/sender_test.go
+++ b/internal/app/sender_test.go
@@ -35,6 +35,41 @@ func TestSender_PassesRequestThrough(t *testing.T) {
 	}
 }
 
+// NewSender must derive a thinking budget from ReasoningEffort when no explicit
+// ThinkingBudget is given (the server path), so Anthropic-protocol legacy models
+// (Kimi-for-coding, older Claude) actually enable thinking. An explicit budget
+// wins.
+func TestNewSender_DerivesThinkingBudgetFromEffort(t *testing.T) {
+	cases := []struct {
+		name          string
+		effort        string
+		explicitBudg  int
+		wantThinkBudg int
+	}{
+		{"effort max, no explicit budget", "max", 0, 64000},
+		{"effort high, no explicit budget", "high", 0, 32768},
+		{"effort off → no thinking", "", 0, 0},
+		{"explicit budget wins over effort", "low", 50000, 50000},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s, err := NewSender(SenderOptions{
+				Provider:        "anthropic",
+				APIKey:          "test-key",
+				ReasoningEffort: c.effort,
+				ThinkingBudget:  c.explicitBudg,
+			})
+			if err != nil {
+				t.Fatalf("NewSender: %v", err)
+			}
+			got := s.(sender).thinkingBudget
+			if got != c.wantThinkBudg {
+				t.Errorf("thinkingBudget = %d, want %d", got, c.wantThinkBudg)
+			}
+		})
+	}
+}
+
 func TestSender_NilProvider(t *testing.T) {
 	s := sender{p: nil}
 	if _, err := s.SendMessages(context.Background(), "m", "", nil, 0); err == nil {


### PR DESCRIPTION
## Problem

The Web UI never showed the live thinking / Thoughts trace for `kimi-for-coding` (and other Anthropic-protocol legacy models), even with `reasoning_effort: max` and `show_reasoning: true`. Confirmed against a live server: every persisted `assistant_message` had `thinking_len=0` across 18 turns.

## Root cause

Anthropic-protocol **legacy** models (Kimi-for-coding, older Claude) enable extended thinking only from a positive `thinking.budget_tokens` — `applyReasoning` ignores the `effort` string on that path (`client.go`). The CLI computed a budget via `anthropicThinkingBudget()` and passed it through `senderTuning`, but the **server** (and any transport calling `app.NewSender` with only `ReasoningEffort` set) passed `ThinkingBudget: 0`. So thinking was never enabled server-side → no `thinking_delta` ever emitted → the Web UI had nothing to show.

This is independent of the frontend guard fixed in #719; both were needed.

## Fix

- Move the effort→budget mapping into `internal/app` as `AnthropicThinkingBudget` (single source of truth).
- `NewSender` now derives `ThinkingBudget` from `ReasoningEffort` when no explicit budget is given. `internal/app` is the single sender-construction point, so the server, IM bridge, and any future transport now behave like the CLI.
- An explicit `ThinkingBudget` still wins; OpenAI-protocol vendors ignore the figure (harmless).
- CLI's local `anthropicThinkingBudget` now delegates to the shared helper (no behavior change, no drift).

## Testing

- `go test -race ./...` green; `go vet`, `gofmt -l` clean.
- New `TestNewSender_DerivesThinkingBudgetFromEffort`: max→64000, high→32768, off→0, explicit-budget-wins.
- Pure backend change — no webdist rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)