### PR TITLE
fix(permission): block command-chain bypass, harden SSRF IPv6/IPv4-mapped deny, make mode access race-safe

### DIFF
--- a/internal/permission/defaults.yml
+++ b/internal/permission/defaults.yml
@@ -72,7 +72,9 @@ terminal:
 
 web_fetch:
   # Block private / link-local / loopback ranges — SSRF protection.
-  - deny:  { hostname: ["10.*", "192.168.*", "172.16.*", "172.17.*", "172.18.*", "172.19.*", "172.2*.*", "172.30.*", "172.31.*", "127.*", "169.254.*", "localhost", "*.local"] }
+  # IPv4 private + loopback, IPv6 loopback / link-local / IPv4-mapped loopback,
+  # and localhost names are all denied.
+  - deny:  { hostname: ["10.*", "192.168.*", "172.16.*", "172.17.*", "172.18.*", "172.19.*", "172.2*.*", "172.30.*", "172.31.*", "127.*", "169.254.*", "localhost", "*.local", "::1", "0:0:0:0:0:0:0:1", "::ffff:127.*", "::ffff:7f00:*", "fe80:*", "fc*:*", "fd*:*"] }
   # Pre-approved hosts known to be safe.
   - allow: { hostname: ["github.com", "*.github.com", "stackoverflow.com", "*.stackoverflow.com", "go.dev", "*.go.dev", "pkg.go.dev"] }
   # Other hosts fall through to ask.

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -88,8 +88,10 @@ type RuleSet map[string][]Rule
 // decisions for "always allow this" style answers.
 type Engine struct {
 	rules RuleSet
-	mode  Mode
 	cwd   string
+
+	modeMu sync.RWMutex
+	mode   Mode
 
 	mu       sync.Mutex
 	remember *Remembered // session decisions; swappable via AttachRemembered
@@ -161,6 +163,21 @@ func New(configPath string, cwd string, mode Mode, allowWriteRoots ...string) (*
 	}, nil
 }
 
+// Mode returns the engine's current mode (for callers that need to branch
+// on it, e.g. to decide whether to prompt the user).
+func (e *Engine) GetMode() Mode {
+	e.modeMu.RLock()
+	defer e.modeMu.RUnlock()
+	return e.mode
+}
+
+// SetMode changes the engine's mode at runtime (e.g. TUI shortcut).
+func (e *Engine) SetMode(mode Mode) {
+	e.modeMu.Lock()
+	defer e.modeMu.Unlock()
+	e.mode = mode
+}
+
 // Check evaluates the rules for one tool invocation. Returns Allow,
 // Deny, or Ask.
 //
@@ -207,13 +224,6 @@ func (e *Engine) Remember(toolName string, input map[string]any, decision Decisi
 	store.set(signature(toolName, input), decision)
 }
 
-// Mode returns the engine's current mode (for callers that need to branch
-// on it, e.g. to decide whether to prompt the user).
-func (e *Engine) GetMode() Mode { return e.mode }
-
-// SetMode changes the engine's mode at runtime (e.g. TUI shortcut).
-func (e *Engine) SetMode(mode Mode) { e.mode = mode }
-
 // DenialReason returns a human-readable explanation for why a tool call
 // was denied. Useful for surfacing to the LLM so it knows the failure
 // was a policy denial, not a tool malfunction.
@@ -237,6 +247,8 @@ func (e *Engine) applyMode(d Decision) Decision {
 	if d != Ask {
 		return d
 	}
+	e.modeMu.RLock()
+	defer e.modeMu.RUnlock()
 	switch e.mode {
 	case ModeAutoApprove:
 		return Allow
@@ -295,6 +307,11 @@ func (e *Engine) matches(toolName string, r Rule, input map[string]any) bool {
 			// that exposes the file via input["file"] still works.
 			cmd = stringifyInput(input)
 		}
+		// Allow rules on terminal must only match simple commands. A
+		// substring match on "ls" would otherwise allow "ls && ./pwn".
+		if r.Decision == Allow {
+			return allowPatternMatches(cmd, r.Pattern)
+		}
 		return patternMatches(cmd, r.Pattern)
 	}
 }
@@ -337,7 +354,52 @@ func patternMatches(cmd, pattern string) bool {
 // isArgBoundary reports whether c ends a shell argument for the purposes of
 // patternMatches' root/home anchoring.
 func isArgBoundary(c byte) bool {
-	return c == ' ' || c == '\t' || c == '\n' || c == '*'
+	return c == ' ' || c == '\t' || c == '\n' || c == '*' ||
+		c == ';' || c == '&' || c == '|' || c == '(' || c == ')'
+}
+
+// shellControlChars lists characters that start a new command or shell
+// construct. Allow rules must never match a command containing any of them,
+// otherwise "ls && ./untrusted" would be auto-approved by the "ls" rule.
+var shellControlChars = []byte(";|&$()<>" + "`" + "\n")
+
+// containsShellControl reports whether cmd contains a shell metacharacter
+// that would let one command chain into another.
+func containsShellControl(cmd string) bool {
+	for i := 0; i < len(cmd); i++ {
+		for _, c := range shellControlChars {
+			if cmd[i] == c {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// allowPatternMatches is the stricter matcher used for terminal allow rules.
+// It requires the command to start with the pattern (after optional leading
+// whitespace), the pattern to end at a command boundary, and the whole
+// command to contain no shell chaining metacharacters.
+func allowPatternMatches(cmd, pattern string) bool {
+	cmd = strings.TrimLeft(cmd, " \t\n")
+	if pattern == "" {
+		return true
+	}
+	// Trailing whitespace in the pattern is a stylistic way to avoid prefix
+	// matches (e.g. "cat " vs "catapult"). For boundary checking we ignore it.
+	pattern = strings.TrimRight(pattern, " \t\n")
+	if !strings.HasPrefix(cmd, pattern) {
+		return false
+	}
+	if containsShellControl(cmd) {
+		return false
+	}
+	// The character after the pattern must be a boundary (end of command or
+	// start of arguments), not a continuation of the command word.
+	if end := len(pattern); end < len(cmd) && !isArgBoundary(cmd[end]) {
+		return false
+	}
+	return true
 }
 
 // signature returns a stable hash of (tool, input) for the remember

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -85,6 +85,46 @@ func TestDefaultRules_TerminalCredentialPathsBeatSafeVerb(t *testing.T) {
 	}
 }
 
+func TestDefaultRules_TerminalAllowCannotChain(t *testing.T) {
+	// Allow-list entries like "ls" must not auto-approve a command that
+	// chains into something else. The safe command can have arguments but no
+	// shell control characters.
+	e := newDefaultEngine(t)
+	cases := map[string]Decision{
+		"ls -la":               Allow,
+		"  ls -la":             Allow, // leading whitespace is fine
+		"ls && ./untrusted":    Ask,   // chain bypass attempt
+		"go test ./...; ./pwn": Ask,   // chain bypass attempt
+		"cat file | grep x":    Ask,   // pipe is chaining
+		"echo $(id)":           Ask,   // command substitution
+		"echo `id`":            Ask,   // backtick substitution
+		"git status\ngit push": Ask,   // newline separates commands
+		"catapult README.md":   Ask,   // prefix of "cat" must not match
+		"echo ls":              Allow, // starts with "echo" allow pattern
+	}
+	for cmd, want := range cases {
+		if got := e.Check("terminal", map[string]any{"command": cmd}); got != want {
+			t.Errorf("terminal %q: got %s, want %s", cmd, got, want)
+		}
+	}
+}
+
+func TestDefaultRules_WebFetchIPv6LoopbackDenied(t *testing.T) {
+	e := newDefaultEngine(t)
+	cases := map[string]Decision{
+		"http://[::1]/":              Deny,
+		"http://[::ffff:127.0.0.1]/": Deny,
+		"http://[::ffff:7f00:1]/":    Deny,
+		"http://[fe80::1]/":          Deny,
+		"https://github.com/":        Allow,
+	}
+	for u, want := range cases {
+		if got := e.Check("web_fetch", map[string]any{"url": u}); got != want {
+			t.Errorf("web_fetch %q: got %s, want %s", u, got, want)
+		}
+	}
+}
+
 func TestDefaultRules_WebFetchPrivateRangeDenied(t *testing.T) {
 	e := newDefaultEngine(t)
 	cases := map[string]Decision{


### PR DESCRIPTION
修复 Permission 系统安全 Critical/Important 问题：\n\n- Terminal allow 规则要求命令以 pattern 开头、在参数边界结束、且不含 shell 元字符，防止 CHANGELOG.md
CLAUDE.md
cmd
CODE_OF_CONDUCT.md
commit-msg.txt
COMPATIBILITY.md
CONTRIBUTING.md
dev-docs
docs
evals
go.mod
go.sum
internal
LICENSE.txt
Makefile
packaging
PRODUCT.md
README_CN.md
README.md
scripts
SECURITY.md
web 这类命令链绕过。\n- web_fetch 默认 deny 增加 IPv6 loopback、IPv4-mapped loopback、link-local、unique-local 等 SSRF 风险地址。\n- Engine.mode 访问加 RWMutex，避免并发 GetMode/SetMode/Check 竞态。\n\n新增命令链绕过与 IPv6 SSRF 相关测试。