### PR TITLE
fix(agent): persist final-turn thinking so web replay survives refresh

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -381,7 +381,7 @@ func (a *Agent) Turn(ctx context.Context, userInput string) (Reply, error) {
 		return Reply{}, fmt.Errorf("agent: send: %w", err)
 	}
 
-	a.History.Append(NewAssistantMessage(reply.Content))
+	a.History.Append(assistantReplyMessage(reply))
 	a.accrueUsage(reply)
 	return reply, nil
 }
@@ -435,7 +435,7 @@ func (a *Agent) TurnStream(
 		return Reply{}, fmt.Errorf("agent: stream: %w", err)
 	}
 
-	a.History.Append(NewAssistantMessage(reply.Content))
+	a.History.Append(assistantReplyMessage(reply))
 	a.accrueUsage(reply)
 	return reply, nil
 }
@@ -835,7 +835,7 @@ func (a *Agent) runLoop(
 		if content == "" {
 			content = textFromBlocks(reply.Blocks)
 		}
-		a.History.Append(NewAssistantMessage(content))
+		a.History.Append(assistantReplyMessage(reply))
 		reply.Content = content
 
 		// A mid-turn steer (text and/or pasted images) arrived while the model
@@ -1366,6 +1366,37 @@ func flattenResults(slices [][]ContentBlock) []ContentBlock {
 		out = append(out, s...)
 	}
 	return out
+}
+
+// assistantReplyMessage builds the assistant history message for a completed
+// turn, preserving any reasoning trace (a "thinking" block with its signature)
+// so a web client that replays history after a refresh still shows the thinking
+// — the live stream surfaces it from reply.Blocks, but a text-only message drops
+// it. Anthropic-protocol models return the final turn as [thinking, text];
+// round-tripping those blocks is the same contract already honored for tool-use
+// turns, and the OpenAI adapter ignores the thinking block and falls back to
+// Content. Plain replies with no thinking keep the lightweight Content form.
+func assistantReplyMessage(reply Reply) Message {
+	content := reply.Content
+	if content == "" {
+		content = textFromBlocks(reply.Blocks)
+	}
+	msg := NewAssistantMessage(content)
+	if hasThinkingBlock(reply.Blocks) {
+		msg.Blocks = reply.Blocks
+	}
+	return msg
+}
+
+// hasThinkingBlock reports whether blocks carries a reasoning trace worth
+// persisting (a non-empty Anthropic-protocol "thinking" block).
+func hasThinkingBlock(blocks []ContentBlock) bool {
+	for _, b := range blocks {
+		if b.Type == "thinking" && b.Thinking != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // textFromBlocks joins text from all "text" content blocks.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -184,6 +184,69 @@ func TestAgent_TurnStream_HappyPath(t *testing.T) {
 	}
 }
 
+func TestAgent_TurnStream_PersistsThinkingBlock(t *testing.T) {
+	// An Anthropic-protocol final turn returns [thinking, text]. The persisted
+	// assistant message must keep the thinking block (with its signature) so a
+	// web client replaying history after a refresh still sees the reasoning —
+	// not just the live stream.
+	send := &fakeStreamSender{
+		emittedReply: Reply{
+			Content:    "the answer",
+			Model:      "m",
+			StopReason: "end_turn",
+			Blocks: []ContentBlock{
+				NewThinkingBlock("let me reason", "SIG123"),
+				NewTextBlock("the answer"),
+			},
+		},
+	}
+	a := New(send, "m")
+
+	if _, err := a.TurnStream(context.Background(), "hello", nil, nil); err != nil {
+		t.Fatalf("TurnStream: %v", err)
+	}
+
+	snap := a.History.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("History len = %d, want 2", len(snap))
+	}
+	asst := snap[1]
+	if asst.Role != RoleAssistant {
+		t.Fatalf("last message role = %q, want assistant", asst.Role)
+	}
+	// Content stays populated for backward-compatible display/replay.
+	if asst.Content != "the answer" {
+		t.Errorf("Content = %q, want %q", asst.Content, "the answer")
+	}
+	// Blocks must carry the thinking trace + its signature.
+	if len(asst.Blocks) != 2 || asst.Blocks[0].Type != "thinking" {
+		t.Fatalf("Blocks = %+v, want [thinking, text]", asst.Blocks)
+	}
+	if asst.Blocks[0].Thinking != "let me reason" || asst.Blocks[0].Signature != "SIG123" {
+		t.Errorf("thinking block = %+v, want thinking text + signature preserved", asst.Blocks[0])
+	}
+}
+
+func TestAgent_TurnStream_NoThinkingStaysTextOnly(t *testing.T) {
+	// A plain reply with no thinking block keeps the lightweight Content-only
+	// form (no Blocks), so we don't bloat history for non-reasoning turns.
+	send := &fakeStreamSender{
+		emittedReply: Reply{Content: "plain", Model: "m", StopReason: "end_turn"},
+	}
+	a := New(send, "m")
+
+	if _, err := a.TurnStream(context.Background(), "hi", nil, nil); err != nil {
+		t.Fatalf("TurnStream: %v", err)
+	}
+	asst := a.History.Snapshot()[1]
+	if len(asst.Blocks) != 0 {
+		t.Errorf("Blocks = %+v, want none for a no-thinking reply", asst.Blocks)
+	}
+	if asst.Content != "plain" {
+		t.Errorf("Content = %q, want %q", asst.Content, "plain")
+	}
+}
+
 func TestAgent_TurnStream_NilCallback(t *testing.T) {
 	send := &fakeStreamSender{
 		chunks:       []string{"a", "b"},


### PR DESCRIPTION
## 问题

Web 端实时会话能看到 thinking,但刷新后 thoughts 就没了。

根因:最终一轮 assistant 回复用 `NewAssistantMessage(content)` 持久化,**只存了文本,丢弃了 thinking block**。

- **实时**:`EventTurnDone` 携带 `reply.Blocks`,WS 层经 `extractThinking(ev.Reply)` 取出 → 能看到。
- **刷新**:页面从落盘的 session 回放;`handlers.go` 在保存的消息里找不到 thinking block → 渲染为空。

中间(工具调用)轮次本就保留 thinking(`NewToolUseMessage(reply.Blocks)`,Anthropic 签名 round-trip 必需),只有**最终轮**丢了。

## 修复

最终轮在存在 thinking block 时持久化 `[thinking, text]`,统一走新的 `assistantReplyMessage(reply)` helper,应用到全部三个 final-append 点(web 用的 tool-loop 路径,以及 no-tools 的 `Turn`/`TurnStream`)。无 thinking 的普通回复仍保持 Content-only,不给历史增重。

线上协议影响已对照 `claude-api` reference 核实:
- Anthropic 协议(Claude/kimi):前轮 thinking block 在新 user message 之后是**允许**的;同模型按原样(含签名)回传。与代码里工具轮已有的 round-trip 是同一契约(`TestSend_ThinkingBlock_RoundTrips`),无新风险。
- OpenAI adapter 编码历史时忽略 `thinking` 类型 block、回退到 text,安全无回归。

## 行为变化

thinking 现在会落到 session JSON,并在下一轮回传给模型(标准的上下文连续性行为)。这是"刷新后仍可见"的必要代价,且只影响**回放持久化**,不影响 TUI 显示(TUI 仍不渲染 thinking)。

## 测试

新增 `TestAgent_TurnStream_PersistsThinkingBlock` 和 `..._NoThinkingStaysTextOnly`;agent + 两个 provider + server 测试全绿,`gofmt`/`go vet` 干净。无需重建 webdist(纯 server 端改动)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)