### PR TITLE
feat(agent): compaction keeps a token-budget tail, not N user turns (part 1/3)

### DIFF
--- a/dev-docs/compaction-redesign.md
+++ b/dev-docs/compaction-redesign.md
@@ -1,0 +1,155 @@
+# Compaction redesign — token-budget retention, cheap reclamation, deficit-aware recovery
+
+## Problem
+
+In agentic sessions the compactor folds almost nothing per run and re-triggers
+nearly every turn. Observed: repeated `compacted context · folded 1 message(s) ·
+~170k → ~132k tokens` on consecutive turns (kimi-for-coding, 200k window, trigger
+150k). Each run reclaims a sliver, context climbs back over the trigger, and it
+compacts again — wasting an LLM summarize call almost every turn while never
+getting the context down.
+
+### Root cause
+
+`safeSplitIndex(msgs, compactKeepTurns=4)` (`internal/agent/compaction.go`)
+chooses what to keep verbatim by **plain user turns** — it keeps the last 4
+messages with `Role==user && !hasToolResult`, summarizing everything before. In
+an agentic session the token bulk is `tool_use`/`tool_result` pairs, and they
+all live *inside* the most recent few user turns. So the split lands at the
+oldest user turn (folding a tiny prefix) and the ~150k of recent tool output is
+never foldable. There is also no guard against compacting when the projected
+reduction is trivial, so it thrashes.
+
+## How other agents do it (research summary)
+
+| | retention unit | anti-thrash | cheap (no-LLM) tier | recall |
+|---|---|---|---|---|
+| octo (today) | last **4 user turns** | none | per-result 40KB cap at write time | none |
+| octo Ruby | last **≤20 messages** (tool pairs kept) | skip if reduction <10% | — | chunk MD + index, `file_reader` |
+| Claude Code | summarize whole body, keep ~0 verbatim | headroom trigger + 3-fail breaker | microcompact: stale tool results → cold storage, no LLM, cache-aware | re-read last 5 files |
+| Codex | last user messages up to **≤20k tokens** | none (hard-bounded result) | per-result middle-truncate (10KB) | — |
+
+Takeaway: every mature implementation bounds the kept-verbatim tail by **tokens
+(or message count)**, summarizes tool/assistant bulk regardless of recency, and
+has a cheap pre-pass and/or anti-thrash guard. octo's turn-count unit is the
+outlier and the bug.
+
+## Design
+
+Three parts, shipped as stacked PRs in order. Parts 1 and 2 are self-contained
+in `internal/agent`; part 3 spans the agent ↔ session layers.
+
+### Part 1 — token-budget retention + anti-thrash (the fix)
+
+Replace turn-count retention with token-budget retention, still splitting only on
+safe boundaries so `tool_use`/`tool_result` pairs are never severed and the kept
+tail always begins on a real user message.
+
+- New `safeSplitIndexByBudget(msgs, keepBudget int) int`: walk plain-user-turn
+  boundaries newest→oldest, accumulating the tail's estimated tokens; keep adding
+  turns while the tail stays ≤ `keepBudget`; split at the oldest kept boundary.
+  Always keep at least the most recent user turn (never split inside it).
+- `keepBudget = CompactKeepFraction × contextWindow(model)`, default
+  **0.30** (new `Agent.CompactKeepFraction`, 0 ⇒ default). kimi 200k ⇒ ~60k tail;
+  after a fold the context is `summary(~1–2k) + ~60k ≈ 62k` vs the 150k trigger —
+  a wide margin, so re-compaction is rare. Floor at 8k so tiny windows still keep
+  one real turn.
+- Anti-thrash guard in `maybeCompact`: if the projected fold would reclaim less
+  than **15%** of `before` (i.e. the bulk is all inside the kept tail and a
+  summarize wouldn't help), skip this round rather than burn an LLM call. Part 2
+  is what actually shrinks that case.
+- `CompactStats.KeptTurns` stays meaningful (report the number of user turns
+  kept); `FoldedMsgs` stays the split index (count of folded leading messages).
+  The TUI line `compacted context · folded N message(s)` (`cmd/octo/tuirepl.go`)
+  needs no change.
+
+Files: `internal/agent/compaction.go` (+ `overflow.go` uses the same split),
+`internal/agent/agent.go` (field), `cmd/octo/chat.go` + `config` (optional flag).
+
+### Part 2 — no-LLM stale-tool-result reclamation (cheap tier)
+
+A pre-pass that crushes the bulky-recent-turn case without an LLM call — the
+single-giant-turn case Part 1 alone can't fold.
+
+- New `reclaimStaleToolResults() (reclaimed int)`: keep the most recent
+  `hotToolResults` (default **6**) `tool_result` blocks inline; for older ones
+  whose content exceeds `staleToolResultMinBytes` (default **4_000**), replace the
+  block content with a placeholder `[elided N bytes — <tool> result; re-run to
+  view]`. IDs are preserved so tool_use/tool_result pairing stays valid. No model
+  call.
+- Wire into `maybeCompact` / between-batch path: when over trigger, run
+  reclamation **first**; recompute tokens; if now under `trigger − margin`, skip
+  the LLM summarize entirely. Otherwise fall through to Part 1's summarize.
+- Cache: rewriting old blocks invalidates the prompt-cache prefix from the first
+  rewritten message — still far cheaper than an LLM summarize + full rebuild.
+- Data-loss caveat: the elided original is gone from history. Mitigated by Part 3
+  archival when the hook is set; without it the placeholder says "re-run to view".
+
+Files: new `internal/agent/reclaim.go`, wired in `compaction.go`.
+
+### Part 3 — deficit-aware overflow recovery + chunk archival/recall
+
+- **3a. Parse the 413 deficit.** New `parseOverflowTokens(err) (have, max int,
+  ok bool)` for Anthropic `prompt is too long: N tokens > M maximum`, OpenAI
+  `maximum context length is M ... you requested N`, Qwen variants. In
+  `overflowRecovery.tryRecover`, when parseable, reclaim/fold to cover
+  `have − max + margin` instead of the current blind half pull-back.
+- **3b. Chunk archival + recall.** New `Agent.ArchiveHook func(msgs []Message)
+  (ref string, err error)`, set by the CLI/server (which own the session dir;
+  the agent layer must not). On summarize (Part 1) and on reclamation (Part 2),
+  the folded/elided originals are written to a session chunk file; the summary
+  message footer carries `[archived at <ref> — use the read tool to recall]`.
+  Recall reuses the existing `read` tool — no new tool. Hook nil (tests/headless)
+  ⇒ archival skipped, behaviour unchanged.
+
+Files: `internal/agent/overflow.go`, `internal/agent/agent.go` (hook field),
+`internal/app` + `internal/server` + `cmd/octo` (set the hook; chunk file I/O).
+
+## Acceptance criteria
+
+- A session that today logs `folded 1 message · 170k → 132k` repeatedly folds to
+  ~60k once and does not re-compact for many turns (Part 1).
+- A single huge agentic turn (one user message, 150k of tool output) is brought
+  under the trigger by reclamation with **no** summarize call (Part 2).
+- A real 413 is recovered by folding at least the parsed deficit, once, and the
+  turn retries successfully (Part 3a).
+- With an archive hook set, folded originals land in a chunk file and the summary
+  references it; `read`ing that path returns them (Part 3b).
+- `go test -race ./...`, `go vet`, `gofmt -l` all clean.
+
+## Test plan
+
+- `safeSplitIndexByBudget`: budget larger than whole history ⇒ split 0; budget
+  smaller than the most recent turn ⇒ keeps exactly that turn; mixed turns ⇒
+  splits at the right boundary; never splits inside a tool pair.
+- anti-thrash: bulk-in-tail history ⇒ `maybeCompact` is a no-op (no summarize call
+  on the fake sender).
+- `reclaimStaleToolResults`: hot tail preserved, old large results elided, IDs
+  intact, reclaimed-token count correct, small results untouched.
+- `parseOverflowTokens`: the real error strings in `overflow.go`'s comment table.
+- archival: hook receives exactly the folded messages; footer ref present; nil
+  hook ⇒ no-op.
+
+## Rollout / compatibility
+
+- Defaults preserve today's external knobs (`CompactThreshold` semantics
+  unchanged); only the retention *unit* changes. `compactKeepTurns` constant is
+  removed; `CompactKeepFraction` (new, default 0.30) replaces it.
+- Session JSON is unaffected (history shape unchanged; elided blocks are ordinary
+  tool_result content).
+- Part 2 reclamation and Part 3 archival are independently revertible.
+
+## Open decisions (need your call)
+
+1. **keepBudget fraction** — 0.30 of window (recommended). Lower = rarer
+   compaction, less recent verbatim. Tie it to the trigger (e.g. always
+   `trigger − 0.4×window`) or keep independent?
+2. **Reclamation aggressiveness** — hot tail = 6 results, stale threshold = 4KB.
+   More aggressive (smaller threshold / shorter hot tail) reclaims more but elides
+   more recent tool output.
+3. **Part 2 data loss without archival** — ship Part 2 before Part 3b (eliding is
+   lossy until archival lands), or land 3b first so reclamation is always
+   recoverable? Recommended: land 3b before enabling lossy reclamation, or gate
+   reclamation on the hook being set.
+4. **Chunk format** — reuse Ruby's per-session chunk-MD layout, or a simpler
+   single append-only `.jsonl` per session?

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -159,6 +159,14 @@ type Agent struct {
 	// the built-in default (0.75). Values outside 0–1 are clamped.
 	CompactAutoFraction float64
 
+	// CompactKeepFraction is the share (0.0–1.0) of the model's context window
+	// that compaction keeps verbatim as the recent tail; everything older is
+	// folded into the summary. Zero uses the built-in default (0.30). It is
+	// always capped below the trigger (at half the trigger) so a compaction can
+	// reliably bring the context under the trigger with headroom to spare. See
+	// compactKeepBudget and dev-docs/compaction-redesign.md.
+	CompactKeepFraction float64
+
 	// CompactBatchThreshold controls compaction after a tool batch, before the
 	// next LLM call. Semantics mirror CompactThreshold:
 	//   < 0  → disabled (never compact between batches)

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -7,9 +7,19 @@ import (
 	"unicode/utf8"
 )
 
-// compactKeepTurns is how many of the most recent user turns runLoop keeps
-// verbatim when it compacts; everything older is folded into one summary.
-const compactKeepTurns = 4
+// defaultCompactKeepFraction is the share of the model's context window that
+// compaction keeps verbatim as the recent tail (everything older is folded into
+// the summary) when Agent.CompactKeepFraction is unset. Chosen so a compaction
+// from the 75% trigger lands well below it, leaving wide headroom before the
+// next one.
+const defaultCompactKeepFraction = 0.30
+
+// minFoldPercent is the anti-thrash floor: maybeCompact skips the summarize call
+// unless the fold would reclaim at least this share of the current context. It
+// stops the "fold a sliver, re-trigger next turn" loop when the bulk is wedged
+// inside the kept tail (a single huge agentic turn) — reclamation, not a
+// summarize, is what shrinks that case.
+const minFoldPercent = 15
 
 // compactThresholdFraction is the share of the model's context window at which
 // auto-compaction (CompactThreshold == 0) triggers, leaving headroom for the
@@ -248,16 +258,26 @@ func (a *Agent) maybeCompact(ctx context.Context, handler EventHandler) error {
 		return nil
 	}
 
-	split := safeSplitIndex(msgs, compactKeepTurns)
+	split := safeSplitIndexByBudget(msgs, a.compactKeepBudget())
 	if split <= 0 {
 		return nil // not enough complete turns to safely compact yet
+	}
+
+	// Anti-thrash: skip the summarize when the fold would reclaim only a sliver
+	// (the bulk is wedged inside the kept tail — a single huge agentic turn).
+	// Reclamation, not a summarize, shrinks that case; burning an LLM call here
+	// would just re-trigger next turn. Measured in the estimate space so both
+	// sides of the ratio use the same units.
+	estBefore := estimateMessages(msgs)
+	if estFolded := estimateMessages(msgs[:split]); estBefore > 0 && estFolded*100 < estBefore*minFoldPercent {
+		return nil
 	}
 
 	if handler != nil {
 		handler(AgentEvent{Kind: EventCompactStarted, Compact: &CompactStats{
 			BeforeTokens: before,
 			FoldedMsgs:   split,
-			KeptTurns:    compactKeepTurns,
+			KeptTurns:    countKeptUserTurns(msgs, split),
 			MaxTokens:    summarizeMaxTokens,
 		}})
 	}
@@ -386,23 +406,69 @@ func (a *Agent) summarizeOn(ctx context.Context, sender Sender, model string, ms
 	return reply.Content, nil
 }
 
-// safeSplitIndex returns the history index at which compaction can split:
-// messages before it are summarized, messages from it onward are kept. The
-// split always lands on a plain user turn (RoleUser with no tool_result
-// blocks), so a tool_use and its tool_result are never separated. It keeps
-// the last keepTurns user turns; if there aren't more than that, it returns 0
-// (nothing safe to compact).
-func safeSplitIndex(msgs []Message, keepTurns int) int {
+// compactKeepBudget is the token budget for the verbatim recent tail that
+// compaction keeps. It is CompactKeepFraction of the model's window (default
+// 0.30), but never more than half the trigger — so a fold reliably brings the
+// context under the trigger with headroom, even when an explicit (small)
+// CompactThreshold is set.
+func (a *Agent) compactKeepBudget() int {
+	frac := a.CompactKeepFraction
+	if frac <= 0 {
+		frac = defaultCompactKeepFraction
+	}
+	if frac > 1 {
+		frac = 1
+	}
+	budget := int(float64(contextWindow(a.Model)) * frac)
+	if trig := a.compactTriggerTokens(); trig > 0 && budget > trig/2 {
+		budget = trig / 2
+	}
+	return budget
+}
+
+// safeSplitIndexByBudget returns the history index at which compaction splits:
+// messages before it are summarized, messages from it onward are kept verbatim.
+// The split always lands on a plain user turn (RoleUser with no tool_result
+// blocks), so a tool_use and its tool_result are never separated and the kept
+// tail always begins on a real user message.
+//
+// It keeps the largest suffix of user turns whose estimated token count stays
+// within keepBudget, and always keeps at least the most recent user turn (even
+// when that single turn alone exceeds the budget — we never split inside a
+// turn). Returns 0 when there aren't at least two user turns, or when nothing
+// older than the kept tail exists to fold.
+func safeSplitIndexByBudget(msgs []Message, keepBudget int) int {
 	var userTurns []int
 	for i, m := range msgs {
 		if m.Role == RoleUser && !hasToolResult(m) {
 			userTurns = append(userTurns, i)
 		}
 	}
-	if len(userTurns) <= keepTurns {
-		return 0
+	if len(userTurns) <= 1 {
+		return 0 // need ≥2 user turns: one (or more) to fold, one to keep
 	}
-	return userTurns[len(userTurns)-keepTurns]
+	// At minimum keep the most recent user turn; then walk older boundaries
+	// while the kept tail still fits the budget.
+	keptFrom := userTurns[len(userTurns)-1]
+	for k := len(userTurns) - 2; k >= 0; k-- {
+		if estimateMessages(msgs[userTurns[k]:]) > keepBudget {
+			break
+		}
+		keptFrom = userTurns[k]
+	}
+	return keptFrom
+}
+
+// countKeptUserTurns returns how many plain user turns sit at or after split —
+// i.e. how many recent turns compaction kept verbatim. For event stats only.
+func countKeptUserTurns(msgs []Message, split int) int {
+	n := 0
+	for i := split; i < len(msgs); i++ {
+		if msgs[i].Role == RoleUser && !hasToolResult(msgs[i]) {
+			n++
+		}
+	}
+	return n
 }
 
 // hasToolResult reports whether m carries any tool_result block (i.e. it's a

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -22,43 +22,60 @@ func (f *summarizeFake) SendMessages(_ context.Context, _, _ string, msgs []Mess
 	return Reply{Content: f.summary, InputTokens: 5, OutputTokens: 3}, nil
 }
 
-func TestSafeSplitIndex(t *testing.T) {
+func TestSafeSplitIndexByBudget(t *testing.T) {
 	u := NewUserMessage
 	a := NewAssistantMessage
-	toolResult := Message{Role: RoleUser, Blocks: []ContentBlock{NewToolResultBlock("c1", "out", false)}}
+	// big is ~100 tokens (400 ASCII chars / 4); a u()+a() turn is ~200 tokens.
+	big := strings.Repeat("x ", 200)
+	bigU := func() Message { return u(big) }
+	bigA := func() Message { return a(big) }
 
-	t.Run("not enough turns", func(t *testing.T) {
-		msgs := []Message{u("1"), a("r1"), u("2"), a("r2")}
-		if got := safeSplitIndex(msgs, 4); got != 0 {
-			t.Errorf("split = %d, want 0 (only 2 user turns, keep 4)", got)
+	t.Run("fewer than two user turns folds nothing", func(t *testing.T) {
+		msgs := []Message{bigU(), bigA()}
+		if got := safeSplitIndexByBudget(msgs, 10); got != 0 {
+			t.Errorf("split = %d, want 0 (only one user turn)", got)
 		}
 	})
 
-	t.Run("splits keeping last N user turns", func(t *testing.T) {
-		// 6 user turns at indices 0,2,4,6,8,10. Keep last 4 → split at index 4.
+	t.Run("budget keeps the last N turns that fit", func(t *testing.T) {
+		// 6 turns of ~200 tokens each at user indices 0,2,4,6,8,10.
 		var msgs []Message
 		for i := 0; i < 6; i++ {
-			msgs = append(msgs, u(fmt.Sprintf("u%d", i)), a(fmt.Sprintf("a%d", i)))
+			msgs = append(msgs, bigU(), bigA())
 		}
-		if got := safeSplitIndex(msgs, 4); got != 4 {
-			t.Errorf("split = %d, want 4", got)
+		// Budget ~450 tokens fits the last 2 turns (~400) but not 3 (~600),
+		// so the split keeps turns from user index 8.
+		if got := safeSplitIndexByBudget(msgs, 450); got != 8 {
+			t.Errorf("split = %d, want 8 (keep last 2 turns)", got)
 		}
 	})
 
-	t.Run("tool_result messages are not counted as user turns", func(t *testing.T) {
-		// Real user turns at 0 and 4; the tool_result at index 2 must NOT
-		// count, so with keep=1 the split lands on the second real turn (4),
-		// never on the tool_result.
-		msgs := []Message{
-			u("real-1"),       // 0  user turn
-			a("asst tooluse"), // 1
-			toolResult,        // 2  NOT a user turn
-			a("asst final"),   // 3
-			u("real-2"),       // 4  user turn
-			a("asst done"),    // 5
+	t.Run("a single oversized recent turn is still kept whole", func(t *testing.T) {
+		// Last turn alone (~200 tokens) exceeds a tiny budget; we never split
+		// inside a turn, so we keep just it (split at its user index).
+		var msgs []Message
+		for i := 0; i < 3; i++ {
+			msgs = append(msgs, bigU(), bigA())
 		}
-		if got := safeSplitIndex(msgs, 1); got != 4 {
-			t.Errorf("split = %d, want 4 (the second real user turn)", got)
+		if got := safeSplitIndexByBudget(msgs, 10); got != 4 {
+			t.Errorf("split = %d, want 4 (keep only the last turn)", got)
+		}
+	})
+
+	t.Run("tool_result messages are not split points", func(t *testing.T) {
+		toolResult := Message{Role: RoleUser, Blocks: []ContentBlock{NewToolResultBlock("c1", big, false)}}
+		msgs := []Message{
+			bigU(),     // 0  user turn
+			bigA(),     // 1  asst tool_use
+			toolResult, // 2  NOT a user turn
+			bigA(),     // 3  asst final
+			bigU(),     // 4  user turn
+			bigA(),     // 5
+		}
+		// Tiny budget keeps only the last turn; the split lands on the real
+		// user turn at 4, never on the tool_result at 2.
+		if got := safeSplitIndexByBudget(msgs, 10); got != 4 {
+			t.Errorf("split = %d, want 4 (second real user turn, not the tool_result)", got)
 		}
 	})
 }
@@ -170,6 +187,32 @@ func TestMaybeCompact_DisabledOrBelowThreshold(t *testing.T) {
 	}
 }
 
+// When the token bulk is wedged inside the most recent turn (a single huge
+// agentic turn), folding the older sliver wouldn't help, so maybeCompact must
+// skip the summarize call rather than thrash — reclamation handles that case.
+func TestMaybeCompact_AntiThrashSkipsSliverFold(t *testing.T) {
+	f := &summarizeFake{summary: "S"}
+	a := New(f, "m")
+	a.CompactThreshold = 100
+
+	// Turn 0 is tiny; turn 1 carries all the bulk. The split keeps the huge
+	// recent turn (can't fold inside it) and would fold only the tiny prefix.
+	a.History.Append(NewUserMessage("hi"))
+	a.History.Append(NewAssistantMessage("ok"))
+	a.History.Append(NewUserMessage("go"))
+	a.History.Append(NewAssistantMessage(strings.Repeat("x ", 5000))) // ~2500 tokens
+
+	if err := a.maybeCompact(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if f.calls != 0 {
+		t.Errorf("anti-thrash should skip the summarize; calls=%d", f.calls)
+	}
+	if a.History.Len() != 4 {
+		t.Errorf("history must be untouched; len=%d, want 4", a.History.Len())
+	}
+}
+
 func TestMaybeCompact_RewritesHistory(t *testing.T) {
 	f := &summarizeFake{summary: "GOAL: build X. Touched main.go."}
 	a := New(f, "m")
@@ -191,17 +234,19 @@ func TestMaybeCompact_RewritesHistory(t *testing.T) {
 	if snap[0].Role != RoleUser || !strings.Contains(snap[0].Content, "GOAL: build X") {
 		t.Errorf("first message should carry the summary, got %+v", snap[0])
 	}
-	// 6 user turns, keep last 4 → split at index 4; kept = msgs[4:] = 8
-	// messages, + 1 summary = 9.
-	if len(snap) != 9 {
-		t.Errorf("history len = %d, want 9", len(snap))
+	// With an explicit trigger of 100, keepBudget is capped at trigger/2 = 50
+	// tokens — smaller than one ~500-token turn — so only the most recent user
+	// turn (2 messages) is kept. Split at index 10; kept = msgs[10:] = 2
+	// messages, + 1 summary = 3.
+	if len(snap) != 3 {
+		t.Errorf("history len = %d, want 3", len(snap))
 	}
-	// The summarized side-call saw the dropped prefix (4 msgs) + 1 instruction.
+	// The summarized side-call saw the dropped prefix (10 msgs) + 1 instruction.
 	if f.calls != 1 {
 		t.Fatalf("summarize calls = %d, want 1", f.calls)
 	}
-	if len(f.gotMsgs) != 5 {
-		t.Errorf("summarize saw %d messages, want 5 (4 dropped + instruction)", len(f.gotMsgs))
+	if len(f.gotMsgs) != 11 {
+		t.Errorf("summarize saw %d messages, want 11 (10 dropped + instruction)", len(f.gotMsgs))
 	}
 	// The most-recent turn survived verbatim.
 	if snap[len(snap)-1].Content != longMsg {
@@ -266,8 +311,8 @@ func TestMaybeCompact_EmitsProgressEvents(t *testing.T) {
 	if first.Compact == nil || first.Compact.BeforeTokens <= 0 {
 		t.Errorf("started event missing BeforeTokens: %+v", first.Compact)
 	}
-	if first.Compact.KeptTurns != compactKeepTurns {
-		t.Errorf("started KeptTurns = %d, want %d", first.Compact.KeptTurns, compactKeepTurns)
+	if first.Compact.KeptTurns != 1 {
+		t.Errorf("started KeptTurns = %d, want 1 (tiny budget keeps one turn)", first.Compact.KeptTurns)
 	}
 	if first.Compact.MaxTokens != summarizeMaxTokens {
 		t.Errorf("started MaxTokens = %d, want %d", first.Compact.MaxTokens, summarizeMaxTokens)

--- a/internal/agent/overflow.go
+++ b/internal/agent/overflow.go
@@ -138,7 +138,8 @@ func (a *Agent) tryOverflowCompact(ctx context.Context, pullBackMode int, handle
 	}
 
 	// Find safe split point
-	split := safeSplitIndex(truncated.Snapshot(), compactKeepTurns)
+	tsnap := truncated.Snapshot()
+	split := safeSplitIndexByBudget(tsnap, a.compactKeepBudget())
 	if split <= 0 {
 		return false
 	}
@@ -148,20 +149,20 @@ func (a *Agent) tryOverflowCompact(ctx context.Context, pullBackMode int, handle
 		handler(AgentEvent{Kind: EventCompactStarted, Compact: &CompactStats{
 			BeforeTokens: before,
 			FoldedMsgs:   split,
-			KeptTurns:    compactKeepTurns,
+			KeptTurns:    countKeptUserTurns(tsnap, split),
 			MaxTokens:    summarizeMaxTokens,
 		}})
 	}
 
 	// Run compression side-call on truncated history
-	summary, err := a.summarize(ctx, truncated.Snapshot()[:split], handler)
+	summary, err := a.summarize(ctx, tsnap[:split], handler)
 	if err != nil || summary == "" {
 		emitCompactDone(handler, before, before, split) // no-op: clear the indicator
 		return false
 	}
 
 	// Rebuild: summary + kept recent + pulled_back
-	recent := truncated.Snapshot()[split:]
+	recent := tsnap[split:]
 
 	a.History.Reset()
 	a.History.Append(NewUserMessage("[Earlier conversation summary]\n\n" + summary))


### PR DESCRIPTION
First of three stacked PRs reworking compaction (design: `dev-docs/compaction-redesign.md`).

## Problem

In agentic sessions the compactor folded almost nothing per run and re-triggered nearly every turn — observed repeatedly as `compacted context · folded 1 message(s) · ~170k → ~132k tokens` on consecutive turns (kimi-for-coding, 200k window, 150k trigger). Each run reclaimed a sliver, the context climbed back over the trigger, and it compacted again — burning a summarize call almost every turn while never getting the context down.

## Root cause

`safeSplitIndex(msgs, compactKeepTurns=4)` chose what to keep verbatim by **plain user turns**. The token bulk in an agentic session is `tool_use`/`tool_result` pairs, and they all live *inside* the last few user turns — so the split folded only a tiny prefix and the ~150k of recent tool output was never foldable. No anti-thrash guard either.

## Change (part 1: the fix)

- **`safeSplitIndexByBudget`** keeps the largest suffix of user turns whose estimated tokens fit `keepBudget`, still splitting only on plain user turns (tool pairs never severed; kept tail begins on a real user message). Always keeps ≥ the most recent turn.
- **`keepBudget` = `CompactKeepFraction` × window** (default **0.30**, new `Agent.CompactKeepFraction`), capped at **half the trigger** so a fold reliably drops the context under the trigger with headroom — even with an explicit small `CompactThreshold`.
- **Anti-thrash guard**: skip the summarize when the fold would reclaim < **15%** of the context (the bulk is wedged in the kept tail — a single huge turn). Reclamation, not a summarize, shrinks that case — that's part 2.
- `overflow.go`'s 413-recovery path uses the same budget split.

Parts 2 (no-LLM stale-tool-result reclamation) and 3 (413-deficit-aware recovery + chunk archival/recall) follow as stacked PRs.

## Testing

- `go test -race ./...`, `go vet`, `gofmt -l` all clean.
- New `TestSafeSplitIndexByBudget` (budget boundaries, oversized-recent-turn kept whole, tool_result never a split point), `TestMaybeCompact_AntiThrashSkipsSliverFold`, and updated `TestMaybeCompact_*` for budget retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)