### PR TITLE
feat(agent): no-LLM reclamation of stale tool results (part 2/3)

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1058,9 +1058,16 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 		// Only announce a real reduction; a no-op (summary failed / unchanged)
 		// clears the indicator silently rather than implying work was done.
 		if c := ev.Compact; c != nil && c.AfterTokens > 0 && c.AfterTokens < c.BeforeTokens {
-			m.printlnBlock(noticeStyle.Render(fmt.Sprintf(
-				"✦ compacted context · folded %d message(s) · ~%s → ~%s tokens",
-				c.FoldedMsgs, humanTokens(c.BeforeTokens), humanTokens(c.AfterTokens))))
+			if c.FoldedMsgs == 0 && c.ReclaimedTokens > 0 {
+				// Cheap tier: stale tool output reclaimed without a summarize.
+				m.printlnBlock(noticeStyle.Render(fmt.Sprintf(
+					"✦ reclaimed stale tool output · ~%s → ~%s tokens",
+					humanTokens(c.BeforeTokens), humanTokens(c.AfterTokens))))
+			} else {
+				m.printlnBlock(noticeStyle.Render(fmt.Sprintf(
+					"✦ compacted context · folded %d message(s) · ~%s → ~%s tokens",
+					c.FoldedMsgs, humanTokens(c.BeforeTokens), humanTokens(c.AfterTokens))))
+			}
 		}
 		return
 

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -258,6 +258,23 @@ func (a *Agent) maybeCompact(ctx context.Context, handler EventHandler) error {
 		return nil
 	}
 
+	// Cheap tier first: reclaim stale tool-result bulk with no LLM call. Often
+	// this alone drops the context under the trigger (especially the single
+	// huge agentic turn the summarize path can't fold), saving a summarize.
+	if reclaimed := a.reclaimStaleToolResults(); reclaimed > 0 {
+		a.resetContextTrigger() // the real lastInputTokens count is now stale
+		msgs = a.History.Snapshot()
+		if afterReclaim := estimateMessages(msgs); afterReclaim < trigger {
+			if handler != nil {
+				handler(AgentEvent{Kind: EventCompactDone, Compact: &CompactStats{
+					BeforeTokens: before, AfterTokens: afterReclaim, ReclaimedTokens: reclaimed,
+				}})
+			}
+			return nil
+		}
+		before = estimateMessages(msgs)
+	}
+
 	split := safeSplitIndexByBudget(msgs, a.compactKeepBudget())
 	if split <= 0 {
 		return nil // not enough complete turns to safely compact yet

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -155,6 +155,11 @@ type CompactStats struct {
 	// SummaryTokens is the running estimate of the summary generated so far
 	// (progress only).
 	SummaryTokens int `json:"summary_tokens,omitempty"`
+	// ReclaimedTokens is how many tokens the no-LLM stale-tool-result
+	// reclamation pass freed (done only). When set with FoldedMsgs == 0 the
+	// compaction was handled entirely by the cheap reclamation tier — no
+	// summarize call was made.
+	ReclaimedTokens int `json:"reclaimed_tokens,omitempty"`
 	// MaxTokens is the summary's output-token cap, for a "N / max" readout.
 	MaxTokens int `json:"max_tokens,omitempty"`
 }

--- a/internal/agent/reclaim.go
+++ b/internal/agent/reclaim.go
@@ -1,0 +1,82 @@
+package agent
+
+import "fmt"
+
+// hotToolResults is how many of the most recent tool_result blocks reclamation
+// keeps inline verbatim. Older results are candidates for eliding — the model
+// rarely needs the raw bytes of a tool call it made many steps ago.
+const hotToolResults = 6
+
+// staleToolResultMinBytes is the size below which a stale tool_result is left
+// alone: small results aren't worth the cache cost of a rewrite.
+const staleToolResultMinBytes = 4_000
+
+// reclaimStaleToolResults rewrites old, large tool_result blocks to a compact
+// placeholder, freeing context without an LLM call. This is the cheap tier that
+// shrinks a single huge agentic turn — the case the summarize path deliberately
+// skips (one user turn holding ~150k of tool output can't be folded on a
+// user-turn boundary, but its stale tool results can be elided in place).
+//
+// The most recent hotToolResults tool results are kept inline verbatim; older
+// ones whose Result exceeds staleToolResultMinBytes are elided, preserving the
+// tool_use pairing (ToolUseID/IsError) so the wire structure stays valid. The
+// elided originals are regenerable by re-running the tool — the placeholder
+// says so, mirroring the write-time microCompact backstop.
+//
+// Returns the estimated tokens reclaimed (0 if nothing changed). It rebuilds
+// history via ReplaceAll, which invalidates the prompt-cache prefix from the
+// first rewrite — still far cheaper than an LLM summarize.
+func (a *Agent) reclaimStaleToolResults() int {
+	msgs := a.History.Snapshot()
+
+	// Map tool_use ID → tool name (for friendlier placeholders) and locate
+	// every tool_result block in order.
+	names := map[string]string{}
+	type loc struct{ mi, bi int }
+	var locs []loc
+	for mi := range msgs {
+		for bi, b := range msgs[mi].Blocks {
+			switch b.Type {
+			case "tool_use":
+				names[b.ID] = b.Name
+			case "tool_result":
+				locs = append(locs, loc{mi, bi})
+			}
+		}
+	}
+	if len(locs) <= hotToolResults {
+		return 0
+	}
+
+	// Snapshot copies Message structs but their Blocks slices still alias the
+	// live history, so copy-on-write each message we touch before mutating.
+	cloned := map[int]bool{}
+	reclaimed := 0
+	for _, l := range locs[:len(locs)-hotToolResults] {
+		if len(msgs[l.mi].Blocks[l.bi].Result) < staleToolResultMinBytes {
+			continue
+		}
+		if !cloned[l.mi] {
+			cp := make([]ContentBlock, len(msgs[l.mi].Blocks))
+			copy(cp, msgs[l.mi].Blocks)
+			msgs[l.mi].Blocks = cp
+			cloned[l.mi] = true
+		}
+		b := &msgs[l.mi].Blocks[l.bi]
+		name := names[b.ToolUseID]
+		if name == "" {
+			name = "tool"
+		}
+		freed := estimateText(b.Result)
+		b.Result = fmt.Sprintf(
+			"[%d bytes elided by octo to save context — earlier %s result; re-run the tool to view it again]",
+			len(b.Result), name)
+		b.UI = nil // the structured card no longer matches the elided text
+		reclaimed += freed - estimateText(b.Result)
+	}
+	if reclaimed <= 0 {
+		return 0
+	}
+	a.History.ReplaceAll(msgs)
+	return reclaimed
+}

--- a/internal/agent/reclaim_test.go
+++ b/internal/agent/reclaim_test.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// toolRound appends an assistant tool_use + its user tool_result to h.
+func toolRound(h *History, id, tool, result string) {
+	h.Append(Message{Role: RoleAssistant, Blocks: []ContentBlock{NewToolUseBlock(id, tool, map[string]any{"path": "x"})}})
+	h.Append(Message{Role: RoleUser, Blocks: []ContentBlock{NewToolResultBlock(id, result, false)}})
+}
+
+func toolResults(msgs []Message) []ContentBlock {
+	var out []ContentBlock
+	for _, m := range msgs {
+		for _, b := range m.Blocks {
+			if b.Type == "tool_result" {
+				out = append(out, b)
+			}
+		}
+	}
+	return out
+}
+
+func TestReclaimStaleToolResults(t *testing.T) {
+	a := New(&summarizeFake{}, "m")
+	big := strings.Repeat("y", 5000)
+	const small = "ok"
+
+	a.History.Append(NewUserMessage("start"))
+	ids := make([]string, 10)
+	for i := 0; i < 10; i++ {
+		ids[i] = fmt.Sprintf("c%d", i)
+		content := big
+		if i == 0 {
+			content = small // oldest is small → must NOT be elided
+		}
+		toolRound(a.History, ids[i], "read_file", content)
+	}
+
+	reclaimed := a.reclaimStaleToolResults()
+	if reclaimed <= 0 {
+		t.Fatalf("expected reclaim > 0, got %d", reclaimed)
+	}
+
+	got := toolResults(a.History.Snapshot())
+	if len(got) != 10 {
+		t.Fatalf("tool_result count = %d, want 10", len(got))
+	}
+	// Candidates are the oldest 4 (10 − hotToolResults=6). Index 0 is small and
+	// must survive; 1..3 are big and must be elided. 4..9 are the hot tail.
+	if got[0].Result != small {
+		t.Errorf("small old result must be untouched, got %q", got[0].Result)
+	}
+	for i := 1; i <= 3; i++ {
+		if !strings.Contains(got[i].Result, "elided") || !strings.Contains(got[i].Result, "read_file") {
+			t.Errorf("result %d should be an elided read_file placeholder, got %q", i, got[i].Result)
+		}
+		if got[i].ToolUseID != ids[i] {
+			t.Errorf("result %d lost its ToolUseID: %q != %q", i, got[i].ToolUseID, ids[i])
+		}
+	}
+	for i := 4; i < 10; i++ {
+		if got[i].Result != big {
+			t.Errorf("hot-tail result %d must be verbatim", i)
+		}
+	}
+}
+
+func TestReclaimStaleToolResults_NoopWhenFew(t *testing.T) {
+	a := New(&summarizeFake{}, "m")
+	big := strings.Repeat("y", 5000)
+	for i := 0; i < hotToolResults; i++ { // exactly the hot-tail count → nothing stale
+		toolRound(a.History, fmt.Sprintf("c%d", i), "read_file", big)
+	}
+	if got := a.reclaimStaleToolResults(); got != 0 {
+		t.Errorf("reclaim with ≤hot results should be a no-op, got %d", got)
+	}
+}
+
+// When stale-tool-result reclamation alone drops the context under the trigger,
+// maybeCompact must skip the summarize call and emit a reclaim-only done event.
+func TestMaybeCompact_ReclaimOnlySkipsSummarize(t *testing.T) {
+	f := &summarizeFake{summary: "S"}
+	a := New(f, "m")
+	a.CompactThreshold = 10_000 // explicit trigger above the hot-tail size
+
+	big := strings.Repeat("y", 5000) // ~1250 tokens each
+	a.History.Append(NewUserMessage("start"))
+	for i := 0; i < 12; i++ {
+		toolRound(a.History, fmt.Sprintf("c%d", i), "read_file", big)
+	}
+
+	var events []AgentEvent
+	if err := a.maybeCompact(context.Background(), func(ev AgentEvent) { events = append(events, ev) }); err != nil {
+		t.Fatal(err)
+	}
+	if f.calls != 0 {
+		t.Errorf("reclaim-only path must not summarize; calls=%d", f.calls)
+	}
+	var done *CompactStats
+	for _, ev := range events {
+		if ev.Kind == EventCompactDone {
+			done = ev.Compact
+		}
+	}
+	if done == nil {
+		t.Fatal("expected a compact_done event")
+	}
+	if done.ReclaimedTokens <= 0 || done.FoldedMsgs != 0 {
+		t.Errorf("done should be reclaim-only: reclaimed=%d folded=%d", done.ReclaimedTokens, done.FoldedMsgs)
+	}
+	if done.AfterTokens >= done.BeforeTokens {
+		t.Errorf("reclamation should reduce tokens: %d → %d", done.BeforeTokens, done.AfterTokens)
+	}
+}


### PR DESCRIPTION
Second of three stacked PRs reworking compaction (design: `dev-docs/compaction-redesign.md`). Builds on #724.

## Why

Part 1's summarize path deliberately skips the **single huge agentic turn** — one user turn holding ~150k of tool output can't be folded on a user-turn boundary, and the anti-thrash guard bails rather than burn a useless summarize. This PR adds the cheap tier that shrinks exactly that case **without an LLM call**.

## Change

- **`reclaimStaleToolResults`** keeps the most recent **6** `tool_result` blocks inline and rewrites older ones whose `Result` exceeds **4KB** to a compact placeholder, preserving `tool_use` pairing (`ToolUseID`/`IsError`) so the wire structure stays valid. Copy-on-write per message so the shallow `Snapshot` never aliases live history.
- **`maybeCompact` runs reclamation first** when over the trigger; if it alone drops the context under the trigger, it **skips the summarize entirely** and emits a reclaim-only done event (`FoldedMsgs==0`, `ReclaimedTokens>0`). The TUI shows `✦ reclaimed stale tool output · ~X → ~Y tokens`.

## On data safety

The elided originals are **regenerable by re-running the tool** — the placeholder says so. This is the same "lossy but re-runnable" contract octo already ships in the write-time `microCompact` backstop (40KB middle-truncate, "re-run with a narrower query"), now applied to stale *history*. Part 3b (chunk archival) will additionally persist the originals for `read`-tool recall.

## Testing

- `go test -race ./...`, `go vet`, `gofmt -l` clean.
- New `TestReclaimStaleToolResults` (hot tail verbatim, old large elided, small untouched, IDs intact), `TestReclaimStaleToolResults_NoopWhenFew`, `TestMaybeCompact_ReclaimOnlySkipsSummarize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)