### PR TITLE
feat(agent): archive folded turns for read-tool recall (part 3b/3)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -743,6 +743,13 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		} else {
 			sess = agent.NewSession(resolvedModel, *system)
 		}
+		// Persisted (non-ephemeral) sessions archive folded turns so the model
+		// can recall them with the read tool after a compaction.
+		if !*noSave {
+			if dir, err := sess.ChunkDir(); err == nil {
+				a.ArchiveDir = dir
+			}
+		}
 
 		cfg := replConfig{
 			a:               a,

--- a/dev-docs/compaction-redesign.md
+++ b/dev-docs/compaction-redesign.md
@@ -139,17 +139,20 @@ Files: `internal/agent/overflow.go`, `internal/agent/agent.go` (hook field),
   tool_result content).
 - Part 2 reclamation and Part 3 archival are independently revertible.
 
-## Open decisions (need your call)
+## Settled parameters
 
-1. **keepBudget fraction** — 0.30 of window (recommended). Lower = rarer
-   compaction, less recent verbatim. Tie it to the trigger (e.g. always
-   `trigger − 0.4×window`) or keep independent?
-2. **Reclamation aggressiveness** — hot tail = 6 results, stale threshold = 4KB.
-   More aggressive (smaller threshold / shorter hot tail) reclaims more but elides
-   more recent tool output.
-3. **Part 2 data loss without archival** — ship Part 2 before Part 3b (eliding is
-   lossy until archival lands), or land 3b first so reclamation is always
-   recoverable? Recommended: land 3b before enabling lossy reclamation, or gate
-   reclamation on the hook being set.
-4. **Chunk format** — reuse Ruby's per-session chunk-MD layout, or a simpler
-   single append-only `.jsonl` per session?
+1. **keepBudget** = `CompactKeepFraction` × window, default **0.30**, independent
+   of the trigger but capped at half the trigger so a fold reliably clears it.
+2. **Reclamation** keeps the most recent **6** tool results inline; elides older
+   ones over **4KB**.
+3. **Reclamation recoverability** — reclamation elides in place with a "re-run to
+   view" placeholder, the same lossy-but-regenerable contract the write-time
+   `microCompact` backstop already ships, so it doesn't depend on archival.
+   Archival (3b) covers the genuinely-lost content: the turns the summarize path
+   folds away (their lossy summary is otherwise the only trace). The overflow
+   fallback path and reclamation placeholders are not archived.
+4. **Chunk format** — per-session `<id>.chunks/chunk-NNN.md`, a readable
+   Markdown transcript (so the recalled text is plain, not wire JSON). Archival
+   is best-effort: a write failure never breaks a compaction. CLI (persisted TUI
+   sessions) and the web server (`buildAgent`) set `Agent.ArchiveDir` via
+   `Session.ChunkDir`; one-shot/headless and the IM factory leave it unset.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -167,6 +167,14 @@ type Agent struct {
 	// compactKeepBudget and dev-docs/compaction-redesign.md.
 	CompactKeepFraction float64
 
+	// ArchiveDir, when non-empty, is the directory into which compaction writes
+	// the verbatim originals of folded turns (chunk-NNN.md) before replacing
+	// them with the summary, so the model can recall details with the read
+	// tool. Set by the session-owning layer (CLI/server) via Session.ChunkDir;
+	// empty disables archival. Archival is best-effort — a write failure never
+	// breaks a compaction. See dev-docs/compaction-redesign.md.
+	ArchiveDir string
+
 	// CompactBatchThreshold controls compaction after a tool batch, before the
 	// next LLM call. Semantics mirror CompactThreshold:
 	//   < 0  → disabled (never compact between batches)

--- a/internal/agent/chunk.go
+++ b/internal/agent/chunk.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// archiveChunk writes msgs to a new chunk-NNN.md file under a.ArchiveDir and
+// returns its absolute path, so a compaction summary can point the model at the
+// verbatim originals it folded away (recall via the read tool). Returns "" when
+// archival is disabled (no ArchiveDir) or fails — archival is best-effort and
+// must never break a compaction.
+//
+// The chunk index continues past any files already in the directory, so a
+// resumed session doesn't overwrite earlier chunks.
+func (a *Agent) archiveChunk(msgs []Message) string {
+	if a.ArchiveDir == "" || len(msgs) == 0 {
+		return ""
+	}
+	if err := os.MkdirAll(a.ArchiveDir, 0o755); err != nil {
+		return ""
+	}
+	existing, _ := filepath.Glob(filepath.Join(a.ArchiveDir, "chunk-*.md"))
+	path := filepath.Join(a.ArchiveDir, fmt.Sprintf("chunk-%03d.md", len(existing)+1))
+	if err := os.WriteFile(path, []byte(renderChunk(msgs)), 0o600); err != nil {
+		return ""
+	}
+	return path
+}
+
+// renderChunk turns folded messages into a readable Markdown transcript — what
+// the model sees when it reads the chunk back, so it stays plain text rather
+// than wire JSON.
+func renderChunk(msgs []Message) string {
+	var b strings.Builder
+	b.WriteString("# Archived conversation turns\n\n")
+	b.WriteString("> These turns were folded out of the live context during compaction. Read-only recall.\n")
+	for _, m := range msgs {
+		role := string(m.Role)
+		if len(m.Blocks) == 0 {
+			if strings.TrimSpace(m.Content) == "" {
+				continue
+			}
+			fmt.Fprintf(&b, "\n## %s\n\n%s\n", role, m.Content)
+			continue
+		}
+		fmt.Fprintf(&b, "\n## %s\n", role)
+		for _, blk := range m.Blocks {
+			switch blk.Type {
+			case "text":
+				if strings.TrimSpace(blk.Text) != "" {
+					fmt.Fprintf(&b, "\n%s\n", blk.Text)
+				}
+			case "tool_use":
+				args := ""
+				if len(blk.Input) > 0 {
+					if j, err := json.Marshal(blk.Input); err == nil {
+						args = " " + string(j)
+					}
+				}
+				fmt.Fprintf(&b, "\n**→ tool: %s**%s\n", blk.Name, args)
+			case "tool_result":
+				tag := "tool result"
+				if blk.IsError {
+					tag = "tool error"
+				}
+				fmt.Fprintf(&b, "\n**%s:**\n\n```\n%s\n```\n", tag, blk.Result)
+			case "thinking":
+				// reasoning trace is not part of the user-visible transcript
+			}
+		}
+	}
+	return b.String()
+}

--- a/internal/agent/chunk_test.go
+++ b/internal/agent/chunk_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestArchiveChunk(t *testing.T) {
+	a := New(&summarizeFake{}, "m")
+	a.ArchiveDir = t.TempDir()
+	msgs := []Message{
+		NewUserMessage("do the thing"),
+		{Role: RoleAssistant, Blocks: []ContentBlock{NewToolUseBlock("c1", "read_file", map[string]any{"path": "x.go"})}},
+		{Role: RoleUser, Blocks: []ContentBlock{NewToolResultBlock("c1", "file contents here", false)}},
+	}
+	ref := a.archiveChunk(msgs)
+	if ref == "" {
+		t.Fatal("expected a chunk path")
+	}
+	data, err := os.ReadFile(ref)
+	if err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{"do the thing", "read_file", "file contents here"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("chunk missing %q; got:\n%s", want, got)
+		}
+	}
+	// A second archive must not overwrite the first.
+	if ref2 := a.archiveChunk(msgs); ref2 == ref {
+		t.Errorf("second chunk should get a fresh path; both = %s", ref)
+	}
+}
+
+func TestArchiveChunk_DisabledWhenNoDir(t *testing.T) {
+	a := New(&summarizeFake{}, "m")
+	if ref := a.archiveChunk([]Message{NewUserMessage("x")}); ref != "" {
+		t.Errorf("no ArchiveDir → no archival, got %q", ref)
+	}
+}
+
+// maybeCompact archives the folded originals and points the summary at them.
+func TestMaybeCompact_ArchivesFoldedTurns(t *testing.T) {
+	f := &summarizeFake{summary: "GOAL: build X."}
+	a := New(f, "m")
+	a.CompactThreshold = 100
+	a.ArchiveDir = t.TempDir()
+
+	longMsg := strings.Repeat("x ", 500)
+	for i := 0; i < 6; i++ {
+		a.History.Append(NewUserMessage(longMsg))
+		a.History.Append(NewAssistantMessage(longMsg))
+	}
+	if err := a.maybeCompact(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	summary := a.History.Snapshot()[0].Content
+	if !strings.Contains(summary, "archived at") || !strings.Contains(summary, "read tool") {
+		t.Errorf("summary should reference the archive; got %q", summary)
+	}
+	entries, _ := os.ReadDir(a.ArchiveDir)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 chunk file, got %d", len(entries))
+	}
+}

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -309,9 +309,16 @@ func (a *Agent) maybeCompact(ctx context.Context, handler EventHandler) error {
 		return nil                                      // leave history alone
 	}
 
+	// Archive the verbatim originals before discarding them, so the model can
+	// recall details the lossy summary dropped (best-effort; "" when disabled).
+	body := "[Earlier conversation summary]\n\n" + summary
+	if ref := a.archiveChunk(msgs[:split]); ref != "" {
+		body += fmt.Sprintf("\n\n[Full originals of the summarized turns archived at %s — use the read tool to recall details.]", ref)
+	}
+
 	// Rebuild: one summary user-message, then the kept recent turns verbatim.
 	a.History.Reset()
-	a.History.Append(NewUserMessage("[Earlier conversation summary]\n\n" + summary))
+	a.History.Append(NewUserMessage(body))
 	for _, m := range msgs[split:] {
 		a.History.Append(m)
 	}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -151,6 +151,21 @@ func (s *Session) SavePath() (string, error) {
 	return filepath.Join(dir, s.ID+".jsonl"), nil
 }
 
+// ChunkDir returns the per-session directory where compaction archives the
+// verbatim originals of folded turns (chunk-NNN.md), so the model can recall
+// them with the read tool. Honors the Dir override like SavePath.
+func (s *Session) ChunkDir() (string, error) {
+	dir := s.Dir
+	if dir == "" {
+		var err error
+		dir, err = sessionsDir()
+		if err != nil {
+			return "", err
+		}
+	}
+	return filepath.Join(dir, s.ID+".chunks"), nil
+}
+
 // sessionRecord is one JSONL line. Type discriminates the meta header, a
 // message record, and a title record. The title is appended on its own line
 // (rather than rewriting the meta header) so the append-only path is preserved:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -702,6 +702,9 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	a := agent.New(sender, model)
 	a.CWD = s.cwd
 	a.MaxTokens = s.cfg.MaxTokens
+	if dir, err := sess.ChunkDir(); err == nil {
+		a.ArchiveDir = dir // recall folded turns via the read tool
+	}
 	if cfg, err := config.Load(); err == nil {
 		a.LiteSender, a.LiteModel = s.liteSenderFromConfig(cfg)
 		if a.LiteSender == nil {


### PR DESCRIPTION
Final part of the compaction rework (design: `dev-docs/compaction-redesign.md`). Builds on #724, #725. Independent of #726 (touches different files).

## Why

Compaction's summary is lossy — once the older turns are folded, their detail is gone. This persists the verbatim originals so the model can recall them on demand.

## Change

- **`Agent.ArchiveDir`** (set by the session layer via the new `Session.ChunkDir`): when set, `maybeCompact` writes the folded prefix to `<id>.chunks/chunk-NNN.md` — a readable Markdown transcript — before rebuilding, and the summary footer points the model at it: *"…archived at `<path>` — use the read tool to recall details."* `resolvePathIn` already allows reading absolute `~/.octo` paths, so recall needs **no new tool**.
- Best-effort: a write failure never breaks a compaction; the chunk index continues past existing files so a resumed session doesn't overwrite earlier chunks.
- Wired in the **CLI** (persisted TUI sessions) and the **web server** (`buildAgent`). One-shot/headless and the IM factory leave it unset.

## Scope

Archival covers the genuinely-lost content — the turns the **summarize** path folds away. Reclamation (part 2) keeps its "re-run to view" placeholder (that content is regenerable, so it isn't archived), and the rare overflow fallback path isn't archived either.

## Testing

- `go test -race ./...`, `go vet`, `gofmt -l` clean.
- New `TestArchiveChunk` (content rendered, no-overwrite), `TestArchiveChunk_DisabledWhenNoDir`, `TestMaybeCompact_ArchivesFoldedTurns` (summary references the archive; chunk file written).

## Series complete

1 (#724) token-budget retention + anti-thrash · 2 (#725) no-LLM reclamation · 3a (#726) deficit-aware recovery · **3b (this)** archival/recall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)