### PR TITLE
fix(agent,tools): stabilize overflow snapshot, reset recovery per turn, cancel leaked sub-agent contexts

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -630,6 +630,10 @@ func (a *Agent) runLoop(
 	// non-fatal — we log nothing and proceed with the full history.
 	_ = a.maybeCompact(ctx, handler)
 
+	// Reset per-turn overflow state so a previous turn's failed recovery does
+	// not permanently disable overflow recovery for this agent.
+	a.overflow.reset()
+
 	// History length before this turn appended anything. Used to roll back
 	// cleanly on a first-iteration failure: the turn may append more than the
 	// user input (drained inbox messages), so truncating to this baseline is

--- a/internal/agent/overflow.go
+++ b/internal/agent/overflow.go
@@ -191,9 +191,9 @@ func (a *Agent) tryOverflowCompact(ctx context.Context, pullBackMode int, handle
 		truncated.Append(m)
 	}
 
-	// Find safe split point
-	tsnap := truncated.Snapshot()
-	split := safeSplitIndexByBudget(tsnap, a.compactKeepBudget())
+	// Find safe split point on a stable snapshot.
+	truncatedSnap := truncated.Snapshot()
+	split := safeSplitIndexByBudget(truncatedSnap, a.compactKeepBudget())
 	if split <= 0 {
 		return false
 	}
@@ -203,20 +203,21 @@ func (a *Agent) tryOverflowCompact(ctx context.Context, pullBackMode int, handle
 		handler(AgentEvent{Kind: EventCompactStarted, Compact: &CompactStats{
 			BeforeTokens: before,
 			FoldedMsgs:   split,
-			KeptTurns:    countKeptUserTurns(tsnap, split),
+			KeptTurns:    countKeptUserTurns(truncatedSnap, split),
 			MaxTokens:    summarizeMaxTokens,
 		}})
 	}
 
-	// Run compression side-call on truncated history
-	summary, err := a.summarize(ctx, tsnap[:split], handler)
+	// Run compression side-call on the stable snapshot of the truncated prefix.
+	summary, err := a.summarize(ctx, truncatedSnap[:split], handler)
 	if err != nil || summary == "" {
 		emitCompactDone(handler, before, before, split) // no-op: clear the indicator
 		return false
 	}
 
-	// Rebuild: summary + kept recent + pulled_back
-	recent := tsnap[split:]
+	// Rebuild: summary + kept recent + pulled_back. Use the same snapshot so
+	// recent and prefix are consistent.
+	recent := truncatedSnap[split:]
 
 	a.History.Reset()
 	a.History.Append(NewUserMessage("[Earlier conversation summary]\n\n" + summary))

--- a/internal/agent/overflow_test.go
+++ b/internal/agent/overflow_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
@@ -37,5 +38,58 @@ func TestParseOverflowTokens(t *testing.T) {
 					c.msg, have, max, ok, c.have, c.max, c.ok)
 			}
 		})
+	}
+}
+
+// dummyOverflowTools gives Run/RunStream enough reason to enter runLoop rather
+// than falling back to the plain Turn path.
+var dummyOverflowTools = []ToolDefinition{{Name: "bash", Description: "shell"}}
+
+// TestOverflow_ResetAtStartOfRun verifies that runLoop resets the per-turn
+// overflow recovery state before starting a new turn. Without this reset, a
+// previous run that set attempted=true (e.g. because recovery itself failed or
+// the run errored out after recovery started) would permanently disable
+// overflow recovery for the agent.
+func TestOverflow_ResetAtStartOfRun(t *testing.T) {
+	send := &fakeToolSender{
+		replies: []Reply{{Content: "ok", StopReason: "end_turn"}},
+	}
+	a := New(send, "m")
+	a.overflow.attempted = true
+
+	if _, err := a.Run(context.Background(), "hello", dummyOverflowTools, &fakeExecutor{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if a.overflow.attempted {
+		t.Error("overflow.attempted was not reset at the start of the run")
+	}
+}
+
+// TestOverflow_RetriesAfterFailedRun verifies that a run which fails with a
+// context-too-long error leaves attempted=true, and that the *next* run resets
+// it so recovery can be attempted again if needed.
+func TestOverflow_RetriesAfterFailedRun(t *testing.T) {
+	send := &fakeToolSender{
+		errs: []error{errors.New("prompt is too long: 99999 tokens > 200000 maximum")},
+	}
+	a := New(send, "m")
+
+	if _, err := a.Run(context.Background(), "hello", dummyOverflowTools, &fakeExecutor{}); err == nil {
+		t.Fatal("expected error from context-too-long")
+	}
+	if !a.overflow.attempted {
+		t.Error("overflow.attempted should be true after a recovery attempt")
+	}
+
+	// A subsequent run must be able to attempt recovery again.
+	send.errs = nil
+	send.replies = []Reply{{Content: "ok", StopReason: "end_turn"}}
+	send.calls = 0
+	if _, err := a.Run(context.Background(), "hello again", dummyOverflowTools, &fakeExecutor{}); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if a.overflow.attempted {
+		t.Error("overflow.attempted was not reset on the subsequent run")
 	}
 }

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -410,12 +410,23 @@ func (m *SubAgentManager) runContinue(agentID, message string) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	// Replace the agent's cancel so Kill targets the current operation.
+
+	// Replace the agent's cancel so Kill targets the current operation. Call the
+	// previous cancel to release the context resources from the Spawn (or an
+	// earlier Continue round); each round owns exactly one live context at a time.
 	agent.mu.Lock()
+	oldCancel := agent.cancel
 	agent.cancel = cancel
 	backingID := agent.backingID
 	desc := agent.description
 	agent.mu.Unlock()
+	if oldCancel != nil {
+		oldCancel()
+	}
+
+	// Ensure this round's context is cancelled when the round ends, even if no
+	// Kill arrives. CancelFunc is idempotent, so a concurrent Kill is harmless.
+	defer cancel()
 
 	// Stream runtime events for this round too, so the live panel re-shows the
 	// sub-agent as running while it handles the message. "done" is emitted

--- a/internal/tools/subagent_manager_test.go
+++ b/internal/tools/subagent_manager_test.go
@@ -75,3 +75,83 @@ func TestStart_EmitsDoneOnCompletion(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+// cancelRecordingSpawner captures the contexts passed to Spawn/Continue so tests
+// can assert they are cancelled at the right boundaries.
+type cancelRecordingSpawner struct {
+	spawnCtxCh       chan context.Context
+	spawnReturnCh    chan SpawnResult
+	continueCtxCh    chan context.Context
+	continueReturnCh chan SpawnResult
+}
+
+func (s *cancelRecordingSpawner) Spawn(ctx context.Context, _ SpawnRequest) (SpawnResult, error) {
+	s.spawnCtxCh <- ctx
+	return <-s.spawnReturnCh, nil
+}
+
+func (s *cancelRecordingSpawner) Continue(ctx context.Context, _, _ string) (SpawnResult, error) {
+	s.continueCtxCh <- ctx
+	return <-s.continueReturnCh, nil
+}
+
+func waitForStatus(t *testing.T, m *SubAgentManager, id, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_, status, found := m.Read(id)
+		if !found {
+			t.Fatalf("agent %q not found", id)
+		}
+		if status == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("agent %q status = %q, want %q", id, status, want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestSend_CancelsSpawnContext verifies that runContinue cancels the previous
+// round's context (from Spawn) before starting the Continue round, and cancels
+// the Continue context when the round ends. Without this, CancelFuncs pile up
+// and the initial Spawn context leaks until garbage collection.
+func TestSend_CancelsSpawnContext(t *testing.T) {
+	sp := &cancelRecordingSpawner{
+		spawnCtxCh:       make(chan context.Context, 1),
+		spawnReturnCh:    make(chan SpawnResult, 1),
+		continueCtxCh:    make(chan context.Context, 1),
+		continueReturnCh: make(chan SpawnResult, 1),
+	}
+	m := NewSubAgentManager(sp)
+
+	id, err := m.Start(SpawnRequest{Description: "d"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx1 := <-sp.spawnCtxCh
+	sp.spawnReturnCh <- SpawnResult{Reply: "spawned", AgentID: "child-1"}
+	waitForStatus(t, m, id, "idle")
+
+	go m.Send(id, "continue")
+
+	var ctx2 context.Context
+	select {
+	case ctx2 = <-sp.continueCtxCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Continue")
+	}
+
+	if ctx1.Err() == nil {
+		t.Error("Spawn context was not cancelled before Continue started")
+	}
+
+	sp.continueReturnCh <- SpawnResult{Reply: "continued"}
+	waitForStatus(t, m, id, "idle")
+
+	if ctx2.Err() == nil {
+		t.Error("Continue context was not cancelled after the round ended")
+	}
+}


### PR DESCRIPTION
修复 agent 层代码审查发现的并发/正确性问题：\n\n- overflow recovery 现在对 History.Snapshot() 只调用一次，避免两次切片访问之间被并发修改导致 prefix/recent 不一致。\n- 每次 runLoop 开始时重置 overflow.attempted，防止上一 turn 的失败永久禁用上下文溢出恢复。\n- subagent manager 在 runContinue 替换 agent.cancel 时调用旧 cancel，并在本轮结束时取消当前 context，避免 CancelFunc 泄漏。\n\n新增 overflow 与 subagent context cancel 回归测试。