### PR TITLE
fix(tools): guard quoted sed, respect context deadline, expand secret guard

### DIFF
--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -220,7 +220,17 @@ func (t TerminalTool) ExecuteStream(
 	}
 
 	// Poll until the process exits, the user promotes it, or the timeout fires.
-	timer := time.NewTimer(TerminalTimeout)
+	// Honour the caller's context deadline if it is sooner than TerminalTimeout.
+	timeout := TerminalTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining < timeout {
+			timeout = remaining
+			if timeout <= 0 {
+				timeout = 1 * time.Millisecond
+			}
+		}
+	}
+	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
 	for {

--- a/internal/tools/terminal_guard.go
+++ b/internal/tools/terminal_guard.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 // sedInPlace matches an invocation of `sed` with an in-place edit flag
@@ -23,10 +24,47 @@ var sedInPlace = regexp.MustCompile(`\bsed\b[^|;&\n]*\s-(?:-in-place\b|[a-z]*i\b
 // into an IsError tool_result, so the model reads the hint and retries with
 // edit_file.
 func guardCommand(command string) error {
-	if sedInPlace.MatchString(command) {
+	if sedInPlace.MatchString(maskQuoted(command)) {
 		return fmt.Errorf("refusing in-place `sed` edit: use the edit_file tool instead, " +
 			"so the change is permission-checked, shown as a diff, and tracked for " +
 			"read-before-write")
 	}
 	return nil
+}
+
+// maskQuoted replaces single- and double-quoted substrings with spaces so
+// regex-based guards don't false-positive on literal text inside quotes
+// (e.g. `echo "sed -i"`). It does not attempt full shell parsing; nested
+// quotes and backslash escapes are ignored, which is sufficient for guarding
+// against accidental sed flags in quoted arguments.
+func maskQuoted(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	inSingle, inDouble := false, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case 0x27:
+			if !inDouble {
+				inSingle = !inSingle
+				b.WriteByte(c)
+			} else {
+				b.WriteByte(' ')
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+				b.WriteByte(c)
+			} else {
+				b.WriteByte(' ')
+			}
+		default:
+			if inSingle || inDouble {
+				b.WriteByte(' ')
+			} else {
+				b.WriteByte(c)
+			}
+		}
+	}
+	return b.String()
 }

--- a/internal/tools/terminal_guard_test.go
+++ b/internal/tools/terminal_guard_test.go
@@ -47,3 +47,18 @@ func TestTerminalTool_RefusesSedInPlace(t *testing.T) {
 		t.Errorf("terminal should refuse sed -i with an edit_file hint, got %v", err)
 	}
 }
+
+// guardCommand is regex-based, so it must not be tripped by literal "sed -i"
+// inside a quoted argument (e.g. an echo example).
+func TestGuardCommand_DoesNotCrossQuotes(t *testing.T) {
+	ok := []string{
+		`echo "sed -i 's/a/b/' file.txt"`,
+		`echo 'sed -i file'`,
+		`python -c "print('sed -i')"`,
+	}
+	for _, cmd := range ok {
+		if err := guardCommand(cmd); err != nil {
+			t.Errorf("expected %q to be allowed, got %v", cmd, err)
+		}
+	}
+}

--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -230,6 +230,29 @@ var _ agent.StreamingToolExecutor = TerminalTool{}
 
 // ─── TerminalInputTool tests ────────────────────────────────────────────────
 
+// TestTerminalTool_RespectsContextDeadline verifies that the synchronous terminal
+// path shortens its timeout to the caller's context deadline, so a turn-level
+// timeout is honoured even when TerminalTimeout is longer.
+func TestTerminalTool_RespectsContextDeadline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell only")
+	}
+	tool := TerminalTool{}
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := tool.ExecuteStream(ctx, "terminal", map[string]any{"command": "sleep 30"}, nil)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("ExecuteStream: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("elapsed %s — context deadline was not respected", elapsed)
+	}
+}
+
 func TestTerminalInputTool_Definition(t *testing.T) {
 	def := TerminalInputTool{}.Definition()
 	if def.Name != "terminal_input" {

--- a/internal/tools/write_guard.go
+++ b/internal/tools/write_guard.go
@@ -18,6 +18,13 @@ var secretPatterns = []struct {
 	{"GitHub token", regexp.MustCompile(`\b(?:ghp|gho|ghu|ghs|ghr)_[0-9A-Za-z]{36}\b`)},
 	{"GitHub fine-grained token", regexp.MustCompile(`\bgithub_pat_[0-9A-Za-z_]{60,}\b`)},
 	{"Slack token", regexp.MustCompile(`\bxox[baprs]-[0-9A-Za-z-]{10,}`)},
+	{"OpenAI API key", regexp.MustCompile(`\bsk-[a-zA-Z0-9]{20,}\b`)},
+	{"Anthropic API key", regexp.MustCompile(`\bsk-ant-[a-zA-Z0-9_-]{20,}\b`)},
+	{"Google API key", regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{30,}\b`)},
+	{"JWT", regexp.MustCompile(`\beyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*\b`)},
+	{"generic API key", regexp.MustCompile(`(?i)\b(?:api[_-]?key|apikey|secret[_-]?key)\s*[=:]\s*['"]?[a-zA-Z0-9_\-]{16,}\b`)},
+	{"JWT", regexp.MustCompile(`\beyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*\b`)},
+	{"generic API key", regexp.MustCompile(`(?i)\b(?:api[_-]?key|apikey|secret[_-]?key)\s*[=:]\s*['"]?[a-zA-Z0-9_\-]{16,}\b`)},
 }
 
 // scanForSecrets returns the name of the first secret shape detected in

--- a/internal/tools/write_guard_test.go
+++ b/internal/tools/write_guard_test.go
@@ -29,11 +29,27 @@ func TestScanForSecrets_AllowsOrdinaryContent(t *testing.T) {
 		"# README\n\nThis project does things.\n",
 		"AKIAIOSFODNN7EXAMPLE",                                       // AWS docs example access-key ID — not secret, must not trip
 		"the aws_secret_access_key is configured in the environment", // prose, no value
-		"ghp_short", // too short to be a real token
+		"ghp_short",           // too short to be a real token
+		"API_KEY=placeholder", // generic key label with too-short value
 	}
 	for _, content := range ok {
 		if got := scanForSecrets(content); got != "" {
 			t.Errorf("ordinary content flagged as %q: %q", got, content)
+		}
+	}
+}
+
+func TestScanForSecrets_DetectsAdditionalKeys(t *testing.T) {
+	cases := map[string]string{
+		"openai":    "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH",
+		"anthropic": "ANTHROPIC_API_KEY=sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789AB",
+		"google":    "GOOGLE_API_KEY=AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abc",
+		"jwt":       "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjMifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+		"generic":   "api_key=abcdefghijklmnopqrstuvwxyz0123456789",
+	}
+	for label, content := range cases {
+		if got := scanForSecrets(content); got == "" {
+			t.Errorf("%s: expected a secret to be detected", label)
 		}
 	}
 }


### PR DESCRIPTION
修复 tools 层审查问题：\n\n- terminal_guard 在扫描 sed in-place 前先 mask 引号内容，避免 echo 示例被误拦截。\n- TerminalTool.ExecuteStream 的同步路径现在会取 TerminalTimeout 与 caller context deadline 的较小值，尊重 turn 级别超时。\n- write_guard 增加 OpenAI / Anthropic / Google API key、JWT、generic api_key/secret_key 检测。\n\n新增/扩展对应测试。