### PR TITLE
fix(provider,mcp): cap error body reads, validate MCP URL scheme

### DIFF
--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // Config is the parsed view of one mcp.json file. The wire format mirrors
@@ -97,7 +98,17 @@ func (e ServerEntry) Validate(name string) error {
 	if e.Auth != "" && e.Command != "" {
 		return fmt.Errorf("mcp server %q: auth applies to http servers only", name)
 	}
+	if e.URL != "" && !isAllowedURLScheme(e.URL) {
+		return fmt.Errorf("mcp server %q: url must use http:// or https:// scheme", name)
+	}
 	return nil
+}
+
+// isAllowedURLScheme reports whether rawURL starts with an acceptable scheme.
+// MCP HTTP transports require a network endpoint; file:// and javascript: would
+// not make sense and could be used to bypass intended reachability controls.
+func isAllowedURLScheme(rawURL string) bool {
+	return strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://")
 }
 
 // LoadConfig reads + merges the user-global config and the project-local

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -133,6 +133,20 @@ func TestLoadConfig_ValidationRejectsNeither(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_RejectsBadURLScheme(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	writeFile(t, filepath.Join(tmp, ".octo", "mcp.json"), `{
+        "mcpServers": {
+          "bad": {"url": "file:///etc/passwd"}
+        }
+    }`)
+	if _, err := LoadConfig(""); err == nil {
+		t.Fatal("expected validation error for non-http url")
+	}
+}
+
 func TestConfig_ServerNames_Sorted(t *testing.T) {
 	c := &Config{Servers: map[string]ServerEntry{
 		"z": {Command: "a"},

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -49,6 +49,11 @@ const DefaultMaxTokens = 16384
 // the agent loop (see isTransientStreamErr), not surfaced as a turn error.
 const DefaultStreamIdleTimeout = 5 * time.Minute
 
+// maxErrorBodyBytes caps how much of a non-2xx response body we read for an
+// error message. Provider error bodies are usually small JSON objects; this
+// avoids memory pressure if a misbehaving endpoint streams a huge HTML page.
+const maxErrorBodyBytes = 4096
+
 // Client talks to an Anthropic-compatible Messages API. Construct via New();
 // zero values are not valid because APIKey is required.
 //
@@ -165,7 +170,7 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		}
 		defer resp.Body.Close()
 
-		respBody, err := io.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 		if err != nil {
 			return provider.Response{}, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("anthropic: read response: %w", err)
 		}

--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -102,7 +102,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 			return nil, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("anthropic: send stream: %w", err)
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			respBody, _ := io.ReadAll(resp.Body)
+			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 			resp.Body.Close()
 			dec := retry.Decision{Retry: retry.RetryableStatus(resp.StatusCode), RetryAfter: retry.RetryAfterHeader(resp.Header)}
 			var apiErr apiError

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -53,6 +53,11 @@ const DialectOpenAI = "openai"
 // turn error.
 const DefaultStreamIdleTimeout = 5 * time.Minute
 
+// maxErrorBodyBytes caps how much of a non-2xx response body we read for an
+// error message. Provider error bodies are usually small JSON objects; this
+// avoids memory pressure if a misbehaving endpoint streams a huge HTML page.
+const maxErrorBodyBytes = 4096
+
 // Client talks to an OpenAI-compatible Chat Completions API. Construct via
 // New(); zero values are not valid because APIKey is required.
 //
@@ -206,7 +211,7 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		}
 		defer resp.Body.Close()
 
-		respBody, err := io.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 		if err != nil {
 			return nil, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("openai: read response: %w", err)
 		}

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -93,7 +93,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 			return nil, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("openai: send stream: %w", err)
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			respBody, _ := io.ReadAll(resp.Body)
+			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 			resp.Body.Close()
 			dec := retry.Decision{Retry: retry.RetryableStatus(resp.StatusCode), RetryAfter: retry.RetryAfterHeader(resp.Header)}
 			var apiErr apiError


### PR DESCRIPTION
修复 provider/MCP 协议层审查问题：\n\n- Anthropic / OpenAI 的非流式与流式请求，在收到非 2xx 响应时最多读取 4 KiB 错误 body，避免异常大页面导致内存暴涨。\n- MCP ServerEntry.Validate 增加 URL scheme 校验，拒绝 http/https 之外的 scheme（如 file://、javascript:）。\n\n新增 MCP URL scheme 校验测试。