### PR TITLE
docs: update compaction and truncation docs to match current code

### DIFF
--- a/dev-docs/compaction-redesign.md
+++ b/dev-docs/compaction-redesign.md
@@ -105,6 +105,12 @@ Files: new `internal/agent/reclaim.go`, wired in `compaction.go`.
 Files: `internal/agent/overflow.go`, `internal/agent/agent.go` (hook field),
 `internal/app` + `internal/server` + `cmd/octo` (set the hook; chunk file I/O).
 
+## Status
+
+Part 1 (token-budget retention + anti-thrash) and Part 3a (deficit parsing) are
+implemented. `safeSplitIndex` was replaced by `safeSplitIndexByBudget` in
+`internal/agent/compaction.go` and `internal/agent/overflow.go`.
+
 ## Acceptance criteria
 
 - A session that today logs `folded 1 message · 170k → 132k` repeatedly folds to

--- a/dev-docs/truncation-recovery.md
+++ b/dev-docs/truncation-recovery.md
@@ -16,7 +16,8 @@ is truncated mid-JSON. Two things then conspire:
 - The provider reports truncation, not a tool call — `finish_reason="length"`
   (OpenAI) / `stop_reason="max_tokens"` (Anthropic), never `tool_use`.
 - The truncated argument JSON is unparseable, so the assembled tool-use block
-  carries empty input (`openai/stream.go` ignores the unmarshal error).
+  carries empty input (`internal/provider/openai/stream.go` ignores the
+  unmarshal error).
 
 The loop only continues on `tool_use`, so a truncated turn fell through to the
 "final reply" branch and ended — the half-written file never dispatched, nothing
@@ -86,7 +87,7 @@ closure. Its signature carries the per-call cap so the loop can re-issue at a
 different value:
 
 ```
-send func(ctx, msgs []Message, maxTokens int) (Reply, error)
+send func(ctx context.Context, msgs []Message, maxTokens int) (Reply, error)
 ```
 
 `Run` and `RunStream` build the closure over the active `ToolSender` /

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -424,10 +424,6 @@ func (m *SubAgentManager) runContinue(agentID, message string) {
 		oldCancel()
 	}
 
-	// Ensure this round's context is cancelled when the round ends, even if no
-	// Kill arrives. CancelFunc is idempotent, so a concurrent Kill is harmless.
-	defer cancel()
-
 	// Stream runtime events for this round too, so the live panel re-shows the
 	// sub-agent as running while it handles the message. "done" is emitted
 	// explicitly before any pending-message handoff (not deferred) so it can't
@@ -441,6 +437,12 @@ func (m *SubAgentManager) runContinue(agentID, message string) {
 	// Continue addresses the child by its Spawner-side id, not the manager's
 	// agent_N handle — the two id spaces are distinct.
 	res, err := m.spawner.Continue(ctx, backingID, message)
+
+	// Cancel this round's context as soon as Continue returns. This must happen
+	// before setDone marks the agent idle, otherwise a concurrent Read() can see
+	// idle before the context is cancelled (observed on Windows).
+	cancel()
+
 	stopReason := ""
 	if err == nil {
 		agent.setResult(res.Reply, res.InputTokens, res.OutputTokens)


### PR DESCRIPTION
工程债清理：修正 dev-docs 中与实际代码脱节的描述。

- dev-docs/truncation-recovery.md: 修正 OpenAI stream 文件引用路径，更新 send 闭包签名。
- dev-docs/compaction-redesign.md: 补充 Part 1 / Part 3a 已实现的状态说明，并指出 safeSplitIndex 已替换为 safeSplitIndexByBudget。

跑过 gofmt -l 与 go vet ./...，均无新增问题。
