### PR TITLE
fix(tui): keep input empty on Esc when a steer is pending

### DIFF
--- a/cmd/octo/steer_recall_test.go
+++ b/cmd/octo/steer_recall_test.go
@@ -69,6 +69,29 @@ func TestSteerRecall_AlreadyDrainedFallsThroughToHistory(t *testing.T) {
 	}
 }
 
+// With a pending steer, Esc interrupts the running turn and leaves the input
+// box empty: the steer stays in the inbox and runs as the next turn on its own
+// (handleTurnFinished drains it). Recalling it here would both run the steer AND
+// strand its text in the box.
+func TestSteerRecall_EscDoesNotRecallPendingSteer(t *testing.T) {
+	m := steerModel(t, "my steer")
+	cancelled := false
+	m.cancelTurn = func() { cancelled = true }
+
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if !cancelled {
+		t.Error("Esc should interrupt the running turn")
+	}
+	if m.ta.Value() != "" {
+		t.Errorf("input box should stay empty, got %q", m.ta.Value())
+	}
+	// The steer remains in the inbox so the next turn picks it up.
+	if !m.a.Inbox.HasPending() {
+		t.Error("steer should remain in the inbox to run as the next turn")
+	}
+}
+
 func TestSteerRecall_NoPendingUsesHistory(t *testing.T) {
 	m := newTestModel()
 	// An ordinary idle submit populates history but no pending steer.

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -137,7 +137,16 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// After output has streamed the echo is committed; Esc interrupts
 			// and recalls the last submitted message into the input box so the
 			// user can edit and resubmit without pressing ↑ manually.
+			//
+			// Pending steers are exempt: they stay in the inbox and run as the
+			// next turn on their own (handleTurnFinished drains it), so recalling
+			// them here would both run the steer AND strand its text in the box.
+			// Note interrupt() clears pendingSteer, so capture it first.
+			hadSteer := len(m.pendingSteer) > 0
 			m.interrupt()
+			if hadSteer {
+				return m, nil
+			}
 			if n := len(m.inputHistory); n > 0 && m.ta.Value() == "" {
 				m.ta.SetValue(m.inputHistory[n-1])
 				m.ta.CursorEnd()


### PR DESCRIPTION
## 问题

存在 steer 消息时按 ESC,steer 文本被塞回输入框。

按道理 ESC 应该:打断当前执行 → 开始处理 steer → 输入框留空。但实际 steer 既被执行,文本又残留在输入框里。

## 根因

turn 运行中输入 steer + Enter 时,`submit()` 把文本同时写进三处:`pendingSteer`、`Inbox`、`inputHistory`。按 ESC 后,因为 steer 不设 `echoPending`,逻辑落到 recall 分支,把 `inputHistory[n-1]`(就是那条 steer)回填进输入框;而 `handleTurnFinished` 又会从 `Inbox` drain 出这条 steer 当作下一轮执行。于是 steer 被**执行**的同时,文本还**残留**在输入框。

## 修复

ESC recall 分支里:有 pending steer 时只中断、直接返回,输入框留空——steer 仍在 `Inbox`,会被 `handleTurnFinished` drain 出来自动跑下一轮。

关键坑:`interrupt()` 自身会清空 `pendingSteer`,所以必须在调用前先捕获 `hadSteer`。

## 测试

新增 `TestSteerRecall_EscDoesNotRecallPendingSteer`;`go test`/`gofmt`/`go vet` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)