### PR TITLE
test(tools): fix flaky TestSend_CancelsSpawnContext on Windows

### DIFF
--- a/internal/tools/subagent_manager_test.go
+++ b/internal/tools/subagent_manager_test.go
@@ -113,6 +113,20 @@ func waitForStatus(t *testing.T, m *SubAgentManager, id, want string) {
 	}
 }
 
+// waitForCancel waits until ctx is cancelled. runContinue cancels the round's
+// context via a deferred call that fires when the round goroutine returns —
+// which happens slightly after the status flips to "idle" (setDone runs first,
+// then the exit hook/sink, then the defer). So a bare ctx.Err() read right
+// after waitForStatus races that defer; poll instead.
+func waitForCancel(t *testing.T, ctx context.Context, what string) {
+	t.Helper()
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Errorf("%s context was not cancelled", what)
+	}
+}
+
 // TestSend_CancelsSpawnContext verifies that runContinue cancels the previous
 // round's context (from Spawn) before starting the Continue round, and cancels
 // the Continue context when the round ends. Without this, CancelFuncs pile up
@@ -151,7 +165,5 @@ func TestSend_CancelsSpawnContext(t *testing.T) {
 	sp.continueReturnCh <- SpawnResult{Reply: "continued"}
 	waitForStatus(t, m, id, "idle")
 
-	if ctx2.Err() == nil {
-		t.Error("Continue context was not cancelled after the round ended")
-	}
+	waitForCancel(t, ctx2, "Continue")
 }


### PR DESCRIPTION
## Problem

`TestSend_CancelsSpawnContext` (in `internal/tools/`) fails intermittently on **windows-latest** CI (e.g. it blocked #747, which only touches `cmd/octo/` and is otherwise unrelated). ubuntu/macOS and `main` are green.

## Root cause

A test race, not a product bug. In `runContinue`, the round's context is cancelled by a deferred `cancel()` that fires when the goroutine *returns*. That return happens **after** `setDone` has already flipped the agent status to `"idle"` (setDone → exit hook → sink → defer). The test did:

```go
waitForStatus(t, m, id, "idle")
if ctx2.Err() == nil { t.Error(...) }   // races the deferred cancel
```

So once `idle` is observable, `ctx2` may not be cancelled yet. On slower Windows runners the window is wide enough to fail.

## Fix

Replace the one-shot `ctx2.Err()` read with a polling `waitForCancel` helper (2s deadline, same style as the existing `waitForStatus`). Product code is unchanged.

Verified: `go test ./internal/tools/ -run TestSend_CancelsSpawnContext -race -count=20` passes; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)