### PR TITLE
feat(tui): uplink/downlink arrows + answer hand-off token sprint

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -165,6 +165,14 @@ type askMsg struct {
 // without being wasteful; it only runs while a turn is in flight.
 const tickInterval = 120 * time.Millisecond
 
+// answerSprintDur is how long the wait-on-model line holds the first answer
+// deltas while the ↓ token counter sprints, before releasing the prose.
+const answerSprintDur = 280 * time.Millisecond
+
+// answerSprintMinChars gates the sprint: only turns with a real reasoning /
+// uplink phase get the flourish, so a quick direct reply isn't delayed.
+const answerSprintMinChars = 240
+
 // shiftEnterFilter intercepts Kitty-keyboard-protocol CSI sequences that
 // bubbletea v1 does not natively understand (e.g. Shift+Enter = \x1b[13;2u)
 // and converts them into plain KeyMsg events the rest of the app already
@@ -299,9 +307,20 @@ type tuiModel struct {
 	// turnOutChars counts this turn's streamed output characters (reasoning +
 	// answer text + tool arguments). The reasoning trace itself never lands in
 	// the scrollback — over a long agentic turn it would dominate the transcript
-	// — the count just feeds the activity line's "↑ ~N tokens" readout so the
+	// — the count just feeds the activity line's "↓ ~N tokens" readout so the
 	// wait still reads as progress (Claude Code style).
 	turnOutChars int
+
+	// answerSprint plays a brief accelerating token-counter flourish at the
+	// hand-off from the model's reasoning/uplink phase to its answer: the first
+	// answer deltas are held in sprintBuf for answerSprintDur while the ↓
+	// counter races up, then released so the prose streams. sprintStartTok is
+	// the token estimate when the sprint began; the displayed value eases from
+	// it up to the live estimate (which keeps climbing as held deltas arrive).
+	answerSprint   bool
+	sprintStart    time.Time
+	sprintStartTok int
+	sprintBuf      strings.Builder
 
 	// toolInput caches each tool call's input from EventToolStarted so the
 	// matching EventToolDone can render a card (tool_result events don't carry
@@ -556,6 +575,8 @@ func (m *tuiModel) startTurnEchoRestore(line, echo, restore string) tea.Cmd {
 	m.running = nil
 	m.partial.Reset()
 	m.turnOutChars = 0
+	m.answerSprint = false
+	m.sprintBuf.Reset()
 	m.toolStreamName, m.toolStreamID, m.toolStreamBytes = "", "", 0
 	m.clearSuggestion() // a new turn supersedes any pending follow-up
 	ctx, cancel := context.WithCancel(context.Background())
@@ -628,6 +649,12 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.flushPrints()
 		}
 		m.spinnerFrame++
+		// End the answer hand-off sprint once its window elapses: release the
+		// held prose so streaming resumes.
+		if m.answerSprint && time.Since(m.sprintStart) >= answerSprintDur {
+			m.flushSprint()
+			return m, tea.Batch(m.flushPrints(), tickCmd())
+		}
 		return m, tickCmd()
 
 	case agentEventMsg:
@@ -731,6 +758,9 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.flushPrints()
 
 	case turnEndedMsg:
+		// Release any answer text still held by an in-flight hand-off sprint so
+		// the trailing-block flush below sees it.
+		m.flushSprint()
 		// Commit a still-pending echo (a turn that produced no events — error,
 		// or Ctrl+C). The Esc take-back path clears it before cancelling, so this
 		// is a no-op there.
@@ -943,6 +973,12 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 	// Promote the deferred user echo above this turn's first output so the
 	// transcript order (your message → reply) is preserved.
 	m.commitEcho()
+	// Any event other than a continued answer delta ends a hand-off sprint and
+	// releases the held text first, so a following tool call / turn-end commits
+	// in the right order.
+	if ev.Kind != agent.EventTextDelta {
+		m.flushSprint()
+	}
 	switch ev.Kind {
 	case agent.EventThinkingDelta:
 		// The terminal never renders the reasoning trace — that display lives
@@ -967,6 +1003,25 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 
 	case agent.EventTextDelta:
 		m.turnOutChars += len(ev.Text)
+		if m.answerSprint {
+			// Mid-sprint: keep the prose held; the live count climbs as these
+			// held deltas land, which is what makes the ↓ counter race.
+			m.sprintBuf.WriteString(ev.Text)
+			return
+		}
+		// First answer text after a real reasoning/uplink phase: hold it for a
+		// brief window and let the ↓ counter sprint as a hand-off flourish. A
+		// quick direct reply (little prior output) skips the hold and streams
+		// immediately.
+		if m.assistantFirstBlock && m.partial.Len() == 0 &&
+			m.turnOutChars-len(ev.Text) >= answerSprintMinChars {
+			m.answerSprint = true
+			m.sprintStart = time.Now()
+			m.sprintStartTok = (m.turnOutChars - len(ev.Text)) / 4
+			m.sprintBuf.Reset()
+			m.sprintBuf.WriteString(ev.Text)
+			return
+		}
 		m.appendText(ev.Text)
 		return
 
@@ -1195,6 +1250,21 @@ func userMessageText(msg agent.Message) string {
 	return b.String()
 }
 
+// flushSprint ends the answer hand-off sprint, if one is active, and releases
+// the buffered answer text into the live partial so the prose resumes
+// streaming. Idempotent — safe to call on any event or turn boundary.
+func (m *tuiModel) flushSprint() {
+	if !m.answerSprint {
+		return
+	}
+	m.answerSprint = false
+	buf := m.sprintBuf.String()
+	m.sprintBuf.Reset()
+	if buf != "" {
+		m.appendText(buf)
+	}
+}
+
 // appendText buffers a streamed text delta into m.partial. The partial is
 // rendered live in View() so the user sees tokens arrive in real time. When a
 // complete block boundary is found (blank line outside a code fence), that
@@ -1316,6 +1386,7 @@ func (m *tuiModel) flushPrints() tea.Cmd {
 }
 
 func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
+	m.flushSprint() // safety net: never strand held answer text on interrupt
 	m.turnRunning = false
 	m.cancelTurn = nil
 	m.running = nil // clear any live tool indicator (e.g. on interrupt)

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -249,7 +249,7 @@ func TestTUI_ToolInputStreamProgress(t *testing.T) {
 }
 
 // The reasoning trace stays out of the scrollback — only its size feeds the
-// live activity line's "↑ ~N tokens" readout, so a long agentic turn doesn't
+// live activity line's "↓ ~N tokens" readout, so a long agentic turn doesn't
 // fill the transcript with thinking text.
 func TestTUI_ThinkingStaysOutOfScrollback(t *testing.T) {
 	m := newTestModel()
@@ -266,8 +266,92 @@ func TestTUI_ThinkingStaysOutOfScrollback(t *testing.T) {
 	}
 	// The wait-on-model activity line shows the running token estimate (chars/4).
 	out := m.View()
-	if !strings.Contains(out, "↑ ~1.0k tokens") {
+	if !strings.Contains(out, "↓ ~1.0k tokens") {
 		t.Errorf("view should show the output-token readout; got:\n%s", out)
+	}
+}
+
+// Before any token streams back the wait line shows the uplink ↑ (request still
+// going up); once tokens arrive it flips to the downlink ↓ with a count.
+func TestTUI_ThinkingArrowUplinkThenDownlink(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+
+	// Uplink: nothing received yet — up arrow, no count, no downlink arrow.
+	out := m.View()
+	if !strings.Contains(out, "· ↑") {
+		t.Errorf("uplink wait line should show ↑; got:\n%s", out)
+	}
+	if strings.Contains(out, "↓") {
+		t.Errorf("no downlink ↓ before any token; got:\n%s", out)
+	}
+
+	// Downlink: a reasoning delta arrives — flip to ↓ with the token readout.
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: strings.Repeat("x", 400)})
+	out = m.View()
+	if !strings.Contains(out, "↓ ~") {
+		t.Errorf("downlink wait line should show ↓ with a count; got:\n%s", out)
+	}
+}
+
+// After a real reasoning phase the first answer delta is held briefly (the
+// hand-off sprint) instead of streaming immediately; flushSprint releases it.
+func TestTUI_AnswerSprintHoldsThenReleases(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.assistantFirstBlock = true
+
+	// A reasoning phase ≥ the sprint threshold precedes the answer.
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: strings.Repeat("x", answerSprintMinChars)})
+
+	// First answer delta: held, not appended to the live partial.
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "Here is the answer."})
+	if !m.answerSprint {
+		t.Fatal("first answer delta after a reasoning phase should start the sprint")
+	}
+	if m.partial.Len() != 0 {
+		t.Errorf("answer text must be held during the sprint, not streamed; partial=%q", m.partial.String())
+	}
+
+	// Release: the sprint ends and the held text reaches the live partial.
+	m.flushSprint()
+	if m.answerSprint {
+		t.Error("flushSprint should end the sprint")
+	}
+	if m.partial.Len() == 0 && len(m.printlnBuf) == 0 {
+		t.Error("released answer text should reach the partial or scrollback")
+	}
+}
+
+// A direct reply with no meaningful reasoning phase must not be held back — the
+// sprint only kicks in after a real uplink/reasoning wait, so quick answers add
+// no latency.
+func TestTUI_QuickReplySkipsSprint(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.assistantFirstBlock = true
+
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "hi"})
+	if m.answerSprint {
+		t.Error("a direct reply with no reasoning phase must not sprint")
+	}
+}
+
+// A non-text event arriving mid-sprint (e.g. a tool call) releases the held
+// answer text first, so output commits in the right order.
+func TestTUI_SprintFlushedByNonTextEvent(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.assistantFirstBlock = true
+
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: strings.Repeat("x", answerSprintMinChars)})
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "partial answer"})
+	if !m.answerSprint {
+		t.Fatal("sprint should be active")
+	}
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventToolStarted, ToolID: "c1", ToolName: "mcp_thing", Input: map[string]any{"q": "x"}})
+	if m.answerSprint {
+		t.Error("a non-text event should flush and end the sprint")
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1048,7 +1048,7 @@ func (m *tuiModel) View() string {
 	// exit notice will land there too, so a per-command panel just repeats
 	// what's known.
 	if bg := tools.RunningBackground(); len(bg) > 0 && !m.turnRunning {
-		frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
+		frame := m.spinnerGlyph()
 		b.WriteString(hintStyle.Render(fmt.Sprintf("%c %s · %s",
 			frame, time.Since(bg[0].Start).Round(time.Second), shellCountLabel(len(bg)))))
 		b.WriteByte('\n')
@@ -1057,7 +1057,7 @@ func (m *tuiModel) View() string {
 	// Sub-agents panel — live tool-call chain of each running sub-agent
 	// (Claude-Code style), mirroring the background-processes panel.
 	if len(m.subAgentOrder) > 0 {
-		frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
+		frame := m.spinnerGlyph()
 		var lines strings.Builder
 		for i, id := range m.subAgentOrder {
 			sa := m.subAgents[id]
@@ -1297,33 +1297,74 @@ func (m *tuiModel) thinkingPhrase() string {
 	return thinkingPhrases[(m.spinnerFrame/16)%len(thinkingPhrases)]
 }
 
-// spinnerLine renders one animated activity line: a braille frame, a label,
+// tuiSpinnerFrames is the in-app activity spinner: a center-out "breathing"
+// star that grows then shrinks (Claude Code style) instead of a scattered
+// braille wheel. Adjacent glyphs differ only by one size step, so the motion
+// reads as a calm pulse rather than a flicker. (The headless one-shot spinner
+// keeps its own braille frames — see spinner.go.)
+var tuiSpinnerFrames = []rune{'·', '✢', '✳', '∗', '✻', '✽', '✻', '∗', '✳', '✢'}
+
+// spinnerGlyph returns the current activity-spinner frame. The visible frame
+// advances at half the tick rate (~240ms/frame) so the pulse stays unhurried
+// while the elapsed clock above it still updates every second.
+func (m *tuiModel) spinnerGlyph() rune {
+	return tuiSpinnerFrames[(m.spinnerFrame/2)%len(tuiSpinnerFrames)]
+}
+
+// spinnerLine renders one animated activity line: a spinner frame, a label,
 // and elapsed seconds since the given start.
 func (m *tuiModel) spinnerLine(label string, since time.Time) string {
-	frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
+	frame := m.spinnerGlyph()
 	return hintStyle.Render(fmt.Sprintf("%c %s (%s)", frame, label, time.Since(since).Round(time.Second)))
 }
 
 // thinkingLine is the wait-on-the-model activity line. Since the reasoning
 // trace itself is not shown, the line carries the turn's elapsed time and a
-// rough output-token count ("↑ ~N tokens", chars/4) so a long silent stretch
+// rough output-token count ("↓ ~N tokens", chars/4) so a long silent stretch
 // still reads as the model working, Claude Code style. When a task is in
 // progress its present-continuous form replaces the generic thinking verb
 // ("Migrating config readers…" instead of "Thinking…").
 func (m *tuiModel) thinkingLine() string {
-	frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
+	frame := m.spinnerGlyph()
 	phrase := m.activeTaskPhrase()
 	if phrase == "" {
 		phrase = m.thinkingPhrase()
 	}
 	meta := time.Since(m.turnStart).Round(time.Second).String()
-	if m.turnOutChars > 0 {
-		meta += fmt.Sprintf(" · ↑ ~%s tokens", humanTokens(m.turnOutChars/4))
+	if m.turnOutChars == 0 {
+		// Uplink: the request/context is still going up and nothing has
+		// streamed back yet — an up arrow, no count to show.
+		meta += " · ↑"
+	} else {
+		// Downlink: tokens are streaming back. At the hand-off to the answer
+		// the counter sprints (see answerSprint) as an accelerating flourish
+		// just before the prose appears.
+		meta += fmt.Sprintf(" · ↓ ~%s tokens", humanTokens(m.sprintTokens()))
 	}
 	return fmt.Sprintf("%s %s %s",
 		hintStyle.Render(string(frame)),
 		activityStyle.Render(phrase+"…"),
 		hintStyle.Render("("+meta+")"))
+}
+
+// sprintTokens is the token estimate shown on the downlink line. Normally it's
+// the live estimate (chars/4); during the answer hand-off sprint it eases from
+// the pre-sprint value up to the live estimate on an accelerating (ease-in)
+// curve, so the counter visibly races just before the answer drops in.
+func (m *tuiModel) sprintTokens() int {
+	live := m.turnOutChars / 4
+	if !m.answerSprint {
+		return live
+	}
+	frac := float64(time.Since(m.sprintStart)) / float64(answerSprintDur)
+	if frac < 0 {
+		frac = 0
+	}
+	if frac > 1 {
+		frac = 1
+	}
+	eased := frac * frac // ease-in: slow start, accelerating finish
+	return m.sprintStartTok + int(float64(live-m.sprintStartTok)*eased)
 }
 
 // injectAssistantPrefix strips glamour's 2-space paragraph indent from the


### PR DESCRIPTION
## What

Reworks the wait-on-model activity line in the TUI to follow the request's direction, Claude Code style, and adds a token-counter flourish at the reasoning→answer hand-off.

### Arrows
- **`↑` (uplink)** while the request/context is still going up and nothing has streamed back yet (`turnOutChars == 0`) — no count, since there's nothing to count.
- **`↓ ~N tokens` (downlink)** once the model starts streaming back.

### Answer hand-off sprint
When a turn has a real reasoning/uplink phase (`≥ answerSprintMinChars`), the first answer deltas are held for a brief window (`answerSprintDur = 280ms`) while the `↓` counter eases up on an accelerating (ease-in) curve — a visible "sprint" — then the held prose is released and streams normally.

- Quick replies with no meaningful reasoning phase skip the hold entirely, so they add **no latency**.
- `flushSprint` runs on every non-text event (e.g. a tool call), at turn end, and on interrupt, so held answer text is never stranded or committed out of order.

### Spinner calm-down
The scattered braille wheel becomes a center-out "breathing" star (`· ✢ ✳ ∗ ✻ ✽ …`) advancing at half the tick rate (~240ms/frame), unified through `spinnerGlyph`. The headless one-shot spinner (`spinner.go`) keeps its braille frames.

## Test
- New tests: uplink→downlink arrow flip, sprint hold/release, quick-reply skips sprint, non-text event flushes sprint.
- `go test -race ./cmd/octo/` green; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)