### PR TITLE
fix(agent): reset stuck-detector per user turn + actionable empty-command error

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -634,6 +634,15 @@ func (a *Agent) runLoop(
 	// not permanently disable overflow recovery for this agent.
 	a.overflow.reset()
 
+	// Reset the duplicate-tool-call detector at the start of each user turn.
+	// The detector is meant to catch a model looping *within* one turn; letting
+	// its fingerprint history bleed across turns means a fresh user message
+	// (often "continue") that produces even a single repeat of the prior call
+	// trips the stuck-stop immediately, so the user can never break out. A new
+	// user turn is a fresh intent — give the model the full within-turn window
+	// again.
+	a.recentToolCalls = nil
+
 	// History length before this turn appended anything. Used to roll back
 	// cleanly on a first-iteration failure: the turn may append more than the
 	// user input (drained inbox messages), so truncating to this baseline is

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -556,6 +556,51 @@ func TestAgent_Run_DuplicateToolCalls_StopsGracefully(t *testing.T) {
 	}
 }
 
+func TestAgent_Run_StuckDetector_ResetsPerUserTurn(t *testing.T) {
+	// A new user turn ("continue") must give the model a fresh stuck-detector
+	// window. Without the per-turn reset the prior turn's fingerprints linger,
+	// so a single repeated call on the second turn would trip the stuck-stop
+	// immediately — leaving the user unable to break out by sending another
+	// message.
+	mk := func(id string) Reply {
+		return Reply{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock(id, "bash", map[string]any{"command": "ls"})}}
+	}
+	// 5 identical batches per turn → stuck stop on the 5th. Two turns' worth.
+	replies := []Reply{
+		mk("a1"), mk("a2"), mk("a3"), mk("a4"), mk("a5"),
+		mk("b1"), mk("b2"), mk("b3"), mk("b4"), mk("b5"),
+		mk("c1"), // should never be reached
+	}
+	send := &fakeToolSender{replies: replies}
+	exec := &fakeExecutor{}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "bash"}}
+
+	r1, err := a.Run(context.Background(), "go", defs, exec)
+	if err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	if r1.StopReason != StopReasonStuck {
+		t.Fatalf("turn 1 StopReason = %q, want %q", r1.StopReason, StopReasonStuck)
+	}
+	if send.calls != 5 {
+		t.Fatalf("turn 1 provider calls = %d, want 5", send.calls)
+	}
+
+	// Second user turn: detector must start fresh, so it again takes 5 identical
+	// batches (calls 6..10) to stop — not a single call.
+	r2, err := a.Run(context.Background(), "继续", defs, exec)
+	if err != nil {
+		t.Fatalf("turn 2: %v", err)
+	}
+	if r2.StopReason != StopReasonStuck {
+		t.Fatalf("turn 2 StopReason = %q, want %q", r2.StopReason, StopReasonStuck)
+	}
+	if send.calls != 10 {
+		t.Errorf("provider calls after 2 turns = %d, want 10 (detector reset → 5 per turn)", send.calls)
+	}
+}
+
 func TestAgent_Run_DifferentToolCalls_DoesNotStop(t *testing.T) {
 	// The model issues different tool calls each round — no stuck detector.
 	replies := []Reply{

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -116,7 +116,11 @@ func (t TerminalTool) ExecuteStream(
 ) (agent.ToolResult, error) {
 	command, _ := input["command"].(string)
 	if command == "" {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal: command is required")
+		return agent.ToolResult{Text: ""}, fmt.Errorf(
+			"terminal: the required \"command\" argument was empty or missing. " +
+				"Put the shell command in the tool's JSON arguments as the \"command\" field, " +
+				`e.g. {"command": "go test ./..."}. Do not call this tool with empty arguments — ` +
+				"if you have nothing to run, respond with text instead.")
 	}
 	stdinText, _ := input["stdin"].(string)
 	if err := guardCommand(command); err != nil {

--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -90,7 +90,12 @@ func TestTerminalTool_Execute_EmptyCommand(t *testing.T) {
 		"command": "",
 	})
 	if err == nil {
-		t.Error("empty command should return error")
+		t.Fatal("empty command should return error")
+	}
+	// The error is fed back to the model verbatim, so it must explain how to
+	// retry — naming the "command" argument — rather than just stating a fact.
+	if !strings.Contains(err.Error(), `"command"`) {
+		t.Errorf("error should name the \"command\" argument to guide retry, got %q", err.Error())
 	}
 }
 


### PR DESCRIPTION
## 背景

截图里的现象：模型反复用空 `command` 调 `terminal`，触发 `terminal: command is required`，循环检测停掉 → 用户每打一次「继续」，只出现一次 `Run(command=)` 就立即 `Stopped`，永远跳不出去。

根因有两层：
- **根本（模型侧，未改）**：eval 那个网关模型生成空参数的 `terminal` tool_use。
- **恢复失败（本 PR 修）**：octo 侧让「继续」无法脱困，且错误提示不可操作。

## 改动

1. **`internal/agent/agent.go`** — 卡死检测器 `recentToolCalls` 是 `Agent` 上的持久字段，从不在回合边界重置，指纹会跨回合残留。在 `runLoop` 每个用户回合开始处 `a.recentToolCalls = nil`：新用户消息是全新意图，重新获得满 5 次的回合内窗口；**回合内**的卡死检测保持不变。

2. **`internal/tools/terminal.go`** — 空 `command` 的报错从干巴巴的 `command is required` 改成可操作的重试指引（该错误以 `is_error=true` 原样回传给模型），点名 `"command"` JSON 参数，并告诉它没事可做就用文本回复。

## 测试

- 新增 `TestAgent_Run_StuckDetector_ResetsPerUserTurn`：连跑两次 `Run` 模拟两次「继续」，断言第二回合重新需要 5 次调用才停（共 10 次）。临时移除修复行后该测试失败（第二回合 6 次就停），证明它真的卡住这个 bug。
- 加强 `TestTerminalTool_Execute_EmptyCommand`：断言错误里点名 `"command"` 参数。
- `make test`（`go test -race ./...`）全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)