### PR TITLE
ci: run the race detector on ubuntu only

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,5 +49,10 @@ jobs:
       - name: go build
         run: go build ./...
 
+      # Data races are OS-independent, so the detector only runs on ubuntu (where
+      # it's cheapest). Windows/macOS run a plain `go test` — fast, and still
+      # catches platform-specific failures (path handling, process spawning, the
+      # GOOS-guarded cases). The race pass on Windows was the CI bottleneck
+      # (~150s of a ~220s job) thanks to instrumentation + costly process spawns.
       - name: go test
-        run: go test -race ./...
+        run: go test ${{ matrix.os == 'ubuntu-latest' && '-race' || '' }} ./...


### PR DESCRIPTION
## Why

`go test -race ./...` is the CI bottleneck. On a recent run the **Windows** job spent **~150s of ~220s** in the test step:
- the race detector instruments every memory access (several-fold slowdown), and
- the suite spawns many subprocesses (terminal / background / sub-agent / workflow / MCP tests), which are far costlier to start on Windows (PowerShell + Defender) than Linux's fork.

## Change

Run `-race` on **ubuntu only** (cheapest there). Windows/macOS run a plain `go test`.

Data races are OS-independent logic bugs, so detecting them on one platform suffices. Windows/macOS still run the full suite (just uninstrumented), so they keep catching platform-specific failures — path handling, `exec`, the GOOS-guarded cases.

```yaml
run: go test ${{ matrix.os == 'ubuntu-latest' && '-race' || '' }} ./...
```

Expected: Windows job drops from ~3.6 min to well under 1.5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)