### PR TITLE
fix(server): emit complete when a turn ends in an error

### DIFF
--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1011,17 +1011,11 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			// so turn_done + assistant_message were broadcast by the handler.
 			// Nothing more for the reply itself.
 		} else {
-			wd, pm, re, _, _ := s.sessionStatusFields()
+			// Surface the error, then fall through to the common complete +
+			// session_update tail. Returning here would skip `complete`, leaving
+			// the web UI's streaming flag (and its caret) stuck on forever; the
+			// tail's session_update is a superset of what we'd emit here.
 			sw.error(err.Error())
-			s.wsHub.broadcast(sess.ID, map[string]any{
-				"type":             "session_update",
-				"session_id":       sess.ID,
-				"status":           "idle",
-				"working_dir":      wd,
-				"permission_mode":  pm,
-				"reasoning_effort": re,
-			})
-			return
 		}
 	} else {
 		// Normal completion: emit the final turn_done explicitly so the


### PR DESCRIPTION
## Problem

The non-canceled turn-error path in `doAgentTurn` (`internal/server/ws_handlers.go`) broadcast `tool_error` + a `session_update` and then **returned**, skipping the common `complete` broadcast. The web UI clears its per-session `chatStreaming` flag (and the streaming caret) only on `complete`, so a turn that ended in an error left the UI stuck "streaming" indefinitely.

Found while wiring the remaining WS-event handlers (#763); flagged there as out-of-scope.

## Fix

Remove the early `return` (and the redundant `session_update` — the common tail already emits a superset including `context_usage`) so `sw.error()` is followed by the shared `complete` + `session_update` tail. Now success, interrupt, and error all end with `complete`.

## Testing

- `go build ./internal/server/` ✓
- `go test ./internal/server/ -run 'Turn|Complete|Interrupt|WSUser|Error'` ✓
- Server-only change — no `webdist` rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)