### PR TITLE
fix(workflow): make the parallel/pipeline scheduler re-entrant

### DIFF
--- a/internal/workflow/prelude.rb
+++ b/internal/workflow/prelude.rb
@@ -8,6 +8,33 @@
 # pipeline, but run synchronously when called at top level (no fiber to yield).
 $__wf_sched = false
 
+# $__wf_ready buffers completions that arrived for a scheduler level other than
+# the one currently waiting. The host's __agent_wait_any returns *any* finished
+# agent from a single shared queue, but each parallel/pipeline level only knows
+# its own tokens. Without this buffer a nested parallel would consume (and then
+# mis-route) a token belonging to an outer level — corrupting the outer loop and
+# deadlocking it. With it, a level that pulls a foreign token stashes the result
+# here and keeps waiting; the level that actually owns the token finds it here
+# before blocking. This makes parallel/pipeline safely re-entrant (nestable).
+$__wf_ready = {}
+
+# __take_for drains agent completions until one whose token is in `pending`
+# arrives, returning [token, result]. Completions for other levels are stashed
+# in $__wf_ready (and consumed from the host immediately, so host state is freed
+# in finish order regardless of which level owns the token). Raises on cancel.
+def __take_for(pending)
+  pending.each_key do |t|
+    return [t, $__wf_ready.delete(t)] if $__wf_ready.key?(t)
+  end
+  loop do
+    token = __agent_wait_any
+    raise "workflow: canceled" if token == 0    # cancellation sentinel
+    result = __agent_take(token)
+    return [token, result] if pending.key?(token)
+    $__wf_ready[token] = result                 # belongs to an outer level
+  end
+end
+
 # agent(prompt, opts = {}) runs one sub-agent to completion and returns its
 # reply string. Inside parallel/pipeline it starts the work then yields its
 # fiber, so siblings run concurrently. At top level it starts then blocks for
@@ -34,9 +61,11 @@ def agent(prompt, opts = {})
   if $__wf_sched
     Fiber.yield(token)
   else
-    tok = __agent_wait_any
-    raise "workflow: canceled" if tok == 0
-    __agent_take(tok)
+    # Top level: no fiber to yield, so block for this one token. Route through
+    # __take_for so a stray completion from an unwound parallel (rescued mid-run)
+    # can't be mistaken for our result — we wait specifically for `token`.
+    _, result = __take_for({ token => true })
+    result
   end
 end
 
@@ -78,12 +107,10 @@ def __run_fibers(items)
       f.alive? ? (pending[r] = i) : (results[i] = r)
     end
     until pending.empty?
-      token = __agent_wait_any                   # blocks until some agent finishes
-      raise "workflow: canceled" if token == 0   # cancellation sentinel
+      token, result = __take_for(pending)         # next completion this level owns
       i      = pending.delete(token)
-      result = __agent_take(token)
       f      = fibers[i]
-      r      = f.resume(result)                   # agent() returns; fiber continues
+      r      = f.resume(result)                    # agent() returns; fiber continues
       f.alive? ? (pending[r] = i) : (results[i] = r)
     end
     results

--- a/internal/workflow/runtime_test.go
+++ b/internal/workflow/runtime_test.go
@@ -109,6 +109,80 @@ func TestRun_Pipeline(t *testing.T) {
 	}
 }
 
+// TestRun_NestedParallelDeadlock is the regression guard for the re-entrant
+// scheduler. One outer branch keeps a top-level agent in flight (fast) while a
+// sibling branch sits inside a nested parallel (slow). The nested level's
+// wait_any therefore receives the OUTER branch's token first. Before the
+// $__wf_ready buffer, the nested loop mis-routed that foreign token —
+// __agent_take'ing the outer result and resuming a nil fiber — which crashed
+// the script and deadlocked the outer loop (its token never came back). The
+// slow/fast skew makes the cross-level arrival deterministic; the watchdog
+// turns a regression into a fast failure instead of a hung test.
+func TestRun_NestedParallelDeadlock(t *testing.T) {
+	agent := func(_ context.Context, p string, _ AgentOptions) AgentResult {
+		if strings.Contains(p, "outer") {
+			time.Sleep(10 * time.Millisecond) // completes first → lands in the nested level's wait
+		} else {
+			time.Sleep(80 * time.Millisecond)
+		}
+		return AgentResult{Reply: "r<" + p + ">"}
+	}
+	script := `
+		parallel([1, 2]) do |i|
+			if i == 1
+				agent("outer")
+			else
+				parallel([1, 2]) { |j| agent("inner#{j}") }.join("+")
+			end
+		end.join(",")
+	`
+	type out struct {
+		res Result
+		err error
+	}
+	ch := make(chan out, 1)
+	go func() {
+		r, e := Run(context.Background(), script, Options{Agent: agent})
+		ch <- out{r, e}
+	}()
+	select {
+	case got := <-ch:
+		if got.err != nil {
+			t.Fatalf("Run: %v", got.err)
+		}
+		want := "r<outer>,r<inner1>+r<inner2>"
+		if got.res.Output != want {
+			t.Errorf("Output = %q, want %q", got.res.Output, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("workflow deadlocked on nested parallel (re-entrant scheduler regression)")
+	}
+}
+
+// TestRun_NestedPipelineInParallel exercises a pipeline nested inside parallel
+// — the "judge panel" shape from the docs — and checks every result threads
+// through correctly across the two scheduler levels.
+func TestRun_NestedPipelineInParallel(t *testing.T) {
+	agent := func(_ context.Context, p string, _ AgentOptions) AgentResult {
+		return AgentResult{Reply: p}
+	}
+	script := `
+		parallel([1, 2]) do |i|
+			s1 = ->(x) { agent("p#{x}") }
+			s2 = ->(prev) { prev + "!" }
+			pipeline([i, i + 10], s1, s2).join(",")
+		end.join(" | ")
+	`
+	got, err := Run(context.Background(), script, Options{Agent: agent})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := "p1!,p11! | p2!,p12!"
+	if got.Output != want {
+		t.Errorf("Output = %q, want %q", got.Output, want)
+	}
+}
+
 func TestRun_Cancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	blocked := func(c context.Context, _ string, _ AgentOptions) AgentResult {


### PR DESCRIPTION
## Problem

`workflow` could deadlock/crash when a script **nested** `parallel`/`pipeline`. The cooperative event loop in `prelude.rb` shares a single host completion queue (`__agent_wait_any` drains one `done` channel), but each `__run_fibers` level only knows its own `pending` tokens. When a nested level's wait received a token belonging to an **outer** level:

```ruby
i = pending.delete(token)   # foreign token → nil
result = __agent_take(token) # consumes the outer level's result
f = fibers[nil]              # nil
f.resume(result)             # NoMethodError → script error
```

…and even short of the crash, the outer fiber waiting on that token was never resumed → permanent block. Nesting is a shape the model naturally reaches for (e.g. per-finding judge panels / dimension verification) and had **no test coverage**.

## Fix

Make the scheduler re-entrant with a cross-level `$__wf_ready` buffer (`prelude.rb`):

- New `__take_for(pending)` helper drains completions until one the current level owns; foreign completions are `__agent_take`'d immediately (host state freed in finish order) and stashed in `$__wf_ready`. The owning level finds its result there before blocking.
- `__run_fibers`'s wait loop and the top-level `agent()` synchronous branch both route through `__take_for`. The top-level path now waits for *its specific token*, closing a latent hole where a stray completion from a rescued/unwound `parallel` could be mistaken for its result.

No host-side (`runtime.go`) changes needed.

## Tests

- **`TestRun_NestedParallelDeadlock`** — deterministic repro (slow/fast skew forces the outer token into the nested level's wait) + 5s watchdog. Verified to **fail on the old prelude** with the exact `nil cannot be converted to Integer` error, pass after the fix.
- **`TestRun_NestedPipelineInParallel`** — pipeline-inside-parallel ("judge panel" shape); checks results thread correctly across both levels.

`go test -race ./internal/workflow/ ./internal/tools/` green; `go vet` + `gofmt` clean.

## Known limitation (unchanged, out of scope)

A nested `parallel` still blocks its outer fiber rather than yielding up, so nesting **serializes** the outer level (correct results, no hang — just no outer-level overlap). True nested concurrency needs a unified event loop and is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)