### PR TITLE
fix(security): resolve CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Least-privilege default: jobs only check out and build, no write access.
+permissions:
+  contents: read
+
 # Run a fresh job per push to the same branch and cancel any in-flight one,
 # saves CI minutes during rapid iteration.
 concurrency:

--- a/.github/workflows/windows-installer-check.yml
+++ b/.github/workflows/windows-installer-check.yml
@@ -11,6 +11,10 @@ on:
       - '.github/workflows/windows-installer-check.yml'
   workflow_dispatch:
 
+# Least-privilege default: this job only checks out and compiles.
+permissions:
+  contents: read
+
 jobs:
   compile:
     name: compile installer

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -660,9 +661,38 @@ func decryptWCMedia(data []byte, aeskeyB64 string) ([]byte, error) {
 	return out[:len(out)-padLen], nil
 }
 
+// wcMediaHostSuffixes are the Tencent/WeCom CDN host suffixes that serve
+// media for inbound messages. The media URL arrives in the (user-originated)
+// callback frame, so it is validated against this allowlist before any fetch
+// to prevent the bot from being coerced into requesting arbitrary internal
+// URLs (SSRF).
+var wcMediaHostSuffixes = []string{
+	".qq.com",
+	".qpic.cn",
+	".weixinbridge.com",
+}
+
+// allowedWCMediaURL reports whether raw is an https URL on a WeCom media host.
+func allowedWCMediaURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "https" {
+		return false
+	}
+	host := u.Hostname()
+	for _, suf := range wcMediaHostSuffixes {
+		if host == suf[1:] || strings.HasSuffix(host, suf) {
+			return true
+		}
+	}
+	return false
+}
+
 // downloadWCMedia fetches a WeCom media URL and optionally decrypts it.
-func downloadWCMedia(url, aeskey string) ([]byte, error) {
-	resp, err := http.Get(url) //nolint:gosec
+func downloadWCMedia(mediaURL, aeskey string) ([]byte, error) {
+	if !allowedWCMediaURL(mediaURL) {
+		return nil, fmt.Errorf("wecom: refusing to fetch non-allowlisted media URL")
+	}
+	resp, err := http.Get(mediaURL)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -229,17 +229,18 @@ func extractSubdir(r io.Reader, subpath, dest string) error {
 			}
 			rel = strings.TrimPrefix(rel, subpath+"/")
 		}
-		// Reject entries that would land outside dest. path.Clean plus the
-		// separator check covers ".." chains and absolute names.
-		clean := path.Clean(rel)
-		if clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
+		// Reject entries that would land outside dest. filepath.IsLocal
+		// rejects absolute paths, ".." chains, and (on Windows) reserved
+		// names — anything that would escape the destination directory.
+		clean := filepath.FromSlash(path.Clean(rel))
+		if !filepath.IsLocal(clean) {
 			return fmt.Errorf("tar entry %q escapes the skill directory", hdr.Name)
 		}
 		total += hdr.Size
 		if total > installMaxBytes {
 			return fmt.Errorf("tarball exceeds %d MB extraction cap", installMaxBytes>>20)
 		}
-		target := filepath.Join(dest, filepath.FromSlash(clean))
+		target := filepath.Join(dest, clean)
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 			return err
 		}

--- a/internal/skills/install_local.go
+++ b/internal/skills/install_local.go
@@ -46,15 +46,15 @@ func InstallZip(zipPath, destRoot string, force bool) (name, desc string, err er
 		if rel == "" {
 			continue
 		}
-		clean := path.Clean(rel)
-		if clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
+		clean := filepath.FromSlash(path.Clean(rel))
+		if !filepath.IsLocal(clean) {
 			return "", "", fmt.Errorf("zip entry %q escapes the skill directory", f.Name)
 		}
 		total += int64(f.UncompressedSize64)
 		if total > installMaxBytes {
 			return "", "", fmt.Errorf("archive exceeds %d MB extraction cap", installMaxBytes>>20)
 		}
-		if err := writeZipEntry(f, filepath.Join(tmp, filepath.FromSlash(clean))); err != nil {
+		if err := writeZipEntry(f, filepath.Join(tmp, clean)); err != nil {
 			return "", "", err
 		}
 	}


### PR DESCRIPTION
## 背景

GitHub code scanning 报了 60 个 open 告警。逐个切分后:**33 个改代码消除,27 个 dismiss**(已有防护的误报 + CLI agent 设计意图)。

## 改代码消除(33)

| 改动 | 消除 |
|---|---|
| 删除 legacy `internal/server/static/`(旧版手写 Web UI,本番走 go:embed 的 `webdist/`,static 是死代码) | 27 `js/incomplete-html-attribute-sanitization` + 1 `js/xss-through-dom` |
| wecom 媒体下载加腾讯 CDN host 白名单(https + `*.qq.com`/`*.qpic.cn`/`*.weixinbridge.com`),参照 discord 适配器 | 1 `go/request-forgery` (SSRF) |
| skills 解压把手写 `..`/`IsAbs` 检查换成 `filepath.IsLocal`(CodeQL 认可的 sanitizer,逻辑等价更强) | 2 `go/zipslip` |
| Go / windows-installer-check workflow 加 `permissions: contents: read` | 2 `actions/missing-workflow-permissions` |

`staticHandler` 现在只服务 `webdist/`,assets 缺失(未 build 的 checkout)时回退占位页 —— 本番行为不变。

## 余下 27 个在扫描 UI dismiss(不改代码)

- **false positive(代码已有防护)**: discord 附件下载(已有 CDN allowlist)、discord gateway URL(来自 Discord API)、server 上传路径(已 `filepath.Base`)。
- **won't fix(CLI agent 设计意图)**: `read_file`/`write_file`/`edit_file`/`terminal`/`detached`、session 持久化、skill 本地安装、weixin config stat、working-dir 设置、mcp stdio(用户自配 server,等同 Claude Code)。这些以用户自身权限执行用户指示的操作,加 `..` 拦截会破坏功能。

## 验证

`make build` / `go vet ./...` / `gofmt -l .` / `go test -race ./...` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)