### PR TITLE
fix(repl): truncate tool-input summaries on rune boundaries

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -519,16 +519,11 @@ func summariseInput(input map[string]any) string {
 	parts := make([]string, 0, len(keys))
 	for _, k := range keys {
 		v := fmt.Sprintf("%v", input[k])
-		if len(v) > 60 {
-			v = v[:57] + "..."
-		}
+		v = truncateRunes(v, 30)
 		parts = append(parts, fmt.Sprintf("%s=%s", k, v))
 	}
 	joined := strings.Join(parts, " ")
-	if len(joined) > 120 {
-		joined = joined[:117] + "..."
-	}
-	return joined
+	return truncateRunes(joined, 60)
 }
 
 // truncate1Line collapses a multi-line error to its first non-empty line and
@@ -539,10 +534,25 @@ func truncate1Line(s string) string {
 		if line == "" {
 			continue
 		}
-		if len(line) > 200 {
-			line = line[:197] + "..."
-		}
-		return line
+		return truncateRunes(line, 100)
 	}
 	return "(empty error)"
+}
+
+// truncateRunes returns s truncated to at most max runes. If truncation is
+// needed, the result ends with "..." and never splits a multi-byte UTF-8
+// character (byte slicing a CJK string in the middle of a rune produces the
+// replacement-character garbage users see as "�").
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	if max <= 3 {
+		return string(r[:max])
+	}
+	return string(r[:max-3]) + "..."
 }

--- a/cmd/octo/repl_test.go
+++ b/cmd/octo/repl_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 )
@@ -191,9 +192,21 @@ func TestSummariseInput_TruncatesLongValues(t *testing.T) {
 	if !strings.Contains(got, "...") {
 		t.Errorf("expected truncation marker, got %q", got)
 	}
-	// Output line itself capped at 120 chars.
-	if len(got) > 120 {
-		t.Errorf("line not capped: len=%d, got %q", len(got), got)
+	// Output line itself capped at 60 runes (byte length may be larger for CJK).
+	if utf8.RuneCountInString(got) > 60 {
+		t.Errorf("line not capped: runes=%d, got %q", utf8.RuneCountInString(got), got)
+	}
+}
+
+func TestSummariseInput_NoMojibakeOnCJK(t *testing.T) {
+	// Regression: byte-slicing a UTF-8 CJK string produced the replacement
+	// character "�". Truncation must happen on rune boundaries.
+	got := summariseInput(map[string]any{
+		"active_form": "修复 TUI agent 运行时 slash 命令补全",
+		"description": "agent 执行过程中输入 / 应弹出 slash 命令补全菜单",
+	})
+	if strings.ContainsRune(got, '\uFFFD') {
+		t.Errorf("got replacement character in %q", got)
 	}
 }
 
@@ -201,6 +214,40 @@ func TestTruncate1Line_CollapsesMultiline(t *testing.T) {
 	got := truncate1Line("\n\nfirst real line\nsecond line that gets dropped")
 	if got != "first real line" {
 		t.Errorf("truncate1Line = %q", got)
+	}
+}
+
+func TestTruncate1Line_NoMojibakeOnCJK(t *testing.T) {
+	got := truncate1Line("第一行\n第二行")
+	if strings.ContainsRune(got, '\uFFFD') {
+		t.Errorf("got replacement character in %q", got)
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	cases := []struct {
+		in   string
+		max  int
+		want string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 8, "hello..."},
+		{"你好世界", 3, "你好世"},
+		{"你好世界", 4, "你好世界"},
+		{"你好世界", 5, "你好世界"},
+		{"你好世界这是一段很长的中文", 10, "你好世界这是一..."},
+		{"", 5, ""},
+		{"abc", 0, ""},
+		{"ab", 2, "ab"},
+		{"abc", 3, "abc"},
+		{"abcd", 3, "abc"},
+		{"abcde", 4, "a..."},
+	}
+	for _, c := range cases {
+		got := truncateRunes(c.in, c.max)
+		if got != c.want {
+			t.Errorf("truncateRunes(%q, %d) = %q, want %q", c.in, c.max, got, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
 and  previously sliced strings by bytes, which splits multi-byte UTF-8 runes (notably CJK characters) and produces the "�" replacement character seen by users.

Replace byte slicing with a rune-aware  helper and add regression tests covering CJK input.