### PR TITLE
fix(tui): allow slash-command completion while a turn runs

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1451,6 +1451,14 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 	if len(m.queue) > 0 {
 		next := m.queue[0]
 		m.queue = m.queue[1:]
+		// A slash command queued mid-turn is dispatched now that we're idle.
+		if strings.HasPrefix(next.text, "/") && len(next.blocks) == 0 {
+			model, cmd := m.dispatchSlash(next.text)
+			if cmd == nil {
+				return model, m.flushPrints()
+			}
+			return model, tea.Sequence(m.flushPrints(), cmd)
+		}
 		return m, m.startQueued(next)
 	}
 	return m, nil

--- a/cmd/octo/tuirepl_completion.go
+++ b/cmd/octo/tuirepl_completion.go
@@ -47,11 +47,12 @@ func (m *tuiModel) slashCandidates() []complItem {
 
 // updateCompletion (re)computes the menu from the current input. It opens the
 // menu when the input is a bare "/command" token (a leading slash, no
-// whitespace yet) and the session is idle; otherwise it closes the menu.
+// whitespace yet); otherwise it closes the menu. The menu is available while a
+// turn runs so slash commands can be queued and executed once it finishes.
 // complIdx is clamped but not reset here — callers reset it on a fresh edit.
 func (m *tuiModel) updateCompletion() {
 	v := m.ta.Value()
-	if m.turnRunning || !strings.HasPrefix(v, "/") || strings.ContainsAny(v, " \t\n") {
+	if !strings.HasPrefix(v, "/") || strings.ContainsAny(v, " \t\n") {
 		m.complItems = nil
 		return
 	}

--- a/cmd/octo/tuirepl_completion_test.go
+++ b/cmd/octo/tuirepl_completion_test.go
@@ -65,8 +65,8 @@ func TestCompletion_ClosedConditions(t *testing.T) {
 	}
 	m.turnRunning = true
 	setInputAndComplete(m, "/")
-	if m.complItems != nil {
-		t.Errorf("menu should stay closed while a turn runs; got %v", complNames(m))
+	if len(m.complItems) != len(builtinSlashCommands) {
+		t.Errorf("menu should stay open while a turn runs; got %v", complNames(m))
 	}
 }
 

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -116,6 +116,21 @@ func TestTUI_RunningCtrlQQueues(t *testing.T) {
 	}
 }
 
+// A slash command submitted while a turn runs is queued, not dispatched or sent
+// as steer text. It runs once the current turn finishes.
+func TestTUI_RunningSlashQueues(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	setInput(m, "/clear")
+	_, _ = m.submit()
+	if len(m.queue) != 1 || m.queue[0].text != "/clear" {
+		t.Fatalf("slash command should queue, got %+v", m.queue)
+	}
+	if m.a.Inbox.HasPending() {
+		t.Error("slash command must not enqueue to inbox as steer text")
+	}
+}
+
 func TestTUI_EscInterruptsRunningTurn(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true
@@ -496,6 +511,24 @@ func TestTUI_TurnFinishedDequeuesNext(t *testing.T) {
 	// Dequeued and a new turn started.
 	if !m.turnRunning {
 		t.Fatal("a queued item should start the next turn")
+	}
+	if len(m.queue) != 0 {
+		t.Errorf("queue should be drained, got %+v", m.queue)
+	}
+}
+
+// A slash command queued mid-turn is dispatched once the turn finishes, not run
+// as a plain user message.
+func TestTUI_TurnFinishedDispatchesQueuedSlash(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.queue = []pendingItem{{text: "/clear"}}
+
+	_, _ = m.handleTurnFinished()
+
+	// /clear clears history and leaves the queue empty.
+	if m.a.History.Len() != 0 {
+		t.Errorf("queued /clear should have cleared history; len=%d", m.a.History.Len())
 	}
 	if len(m.queue) != 0 {
 		t.Errorf("queue should be drained, got %+v", m.queue)

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -590,7 +590,8 @@ func humanByteSize(n int) string {
 	}
 }
 
-// submit acts on Enter. Idle → start a turn. Running → steer. Empty input
+// submit acts on Enter. Idle → start a turn or dispatch a slash command.
+// Running → steer, queue a slash command, or queue plain text. Empty input
 // with no attachments is ignored.
 func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 	text := strings.TrimSpace(m.ta.Value())
@@ -606,12 +607,19 @@ func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 	}
 
 	// Slash commands are the TUI's alone — the plain REPL is a pure conversation
-	// loop. Only dispatched when idle; mid-turn input still steers / queues.
-	// A leading "/" with attachments is treated as ordinary text, not a command.
-	if !m.turnRunning {
-		if strings.HasPrefix(text, "/") && len(m.pendingAttachments) == 0 {
+	// loop. A leading "/" with attachments is treated as ordinary text, not a command.
+	if strings.HasPrefix(text, "/") && len(m.pendingAttachments) == 0 {
+		if !m.turnRunning {
 			return m.dispatchSlash(text)
 		}
+		// Mid-turn slash commands are queued so they run after the current turn
+		// finishes, instead of being misinterpreted as steer text.
+		m.queue = append(m.queue, pendingItem{text: text})
+		m.println(queueStyle.Render("＋ queued: " + text))
+		return m, nil
+	}
+
+	if !m.turnRunning {
 		// Fold any pending image attachments into this turn's user message.
 		echo := text
 		if len(m.pendingAttachments) > 0 {


### PR DESCRIPTION
## Problem

The TUI slash-command completion menu was suppressed whenever a turn was running (`turnRunning == true`), so users could not see available slash commands while the agent was working.

## Change

- Allow the slash-completion menu to open whenever the input is a bare `/` token, regardless of turn state.
- When a slash command is submitted mid-turn, queue it instead of dispatching immediately or misinterpreting it as steer text.
- When the current turn finishes, dequeue and dispatch any queued slash commands.

## Files changed

- `cmd/octo/tuirepl_completion.go`: remove `turnRunning` guard from `updateCompletion`
- `cmd/octo/tuirepl_view.go`: queue slash commands entered while a turn runs
- `cmd/octo/tuirepl.go`: dispatch queued slash commands in `handleTurnFinished`
- `cmd/octo/tuirepl_completion_test.go`, `cmd/octo/tuirepl_test.go`: update/add coverage

## Testing

`make test` (go test -race ./...) passes.