### PR TITLE
feat(session): enforce single-entry ownership across CLI/TUI/Web/IM

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -732,6 +732,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 				fmt.Fprintf(stderr, "octo: %v\n", err)
 				return 1
 			}
+			if ok, msg, berr := sess.Bind(agent.EntryTUI, false); ok == agent.Rejected {
+				fmt.Fprintf(stderr, "octo: %v\n", berr)
+				return 1
+			} else if msg != "" && !*quietFlag {
+				fmt.Fprintln(stderr, "octo:", msg)
+			}
 			// Restore history and override model/system from saved session.
 			a.History = sess.ToHistory()
 			if sess.Model != "" {
@@ -742,6 +748,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			a.System = prompt.Compose(sess.System, cwd, env, skillsManifest, memInjection, coauthor)
 		} else {
 			sess = agent.NewSession(resolvedModel, *system)
+			sess.Bind(agent.EntryTUI, false)
 		}
 		// Persisted (non-ephemeral) sessions archive folded turns so the model
 		// can recall them with the read tool after a compaction.

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -120,13 +120,17 @@ func runTUI(cfg replConfig) int {
 		return 1
 	}
 
-	// Final save on exit (mirrors runREPL's exit save).
+	// Final save on exit (mirrors runREPL's exit save). Unbind before saving so
+	// other entries see the session as released once the TUI process exits.
 	if !cfg.noSave {
 		cfg.session.SyncFrom(cfg.a.History)
+		cfg.session.Unbind(agent.EntryTUI)
 		if err := cfg.session.Save(); err != nil {
 			fmt.Fprintf(cfg.stderr, "session save: %v\n", err)
 			return 1
 		}
+	} else {
+		cfg.session.Unbind(agent.EntryTUI)
 	}
 	if !cfg.verbosity.quiet() {
 		fmt.Fprintf(cfg.stdout, "\nResume: octo -c %s\n", cfg.session.ShortID())

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/trash"
@@ -50,6 +51,208 @@ type Session struct {
 	// longer match Messages, so the next Save must rewrite the whole file.
 	// Cleared by a successful rewriteAll. Not serialized.
 	forceRewrite bool
+
+	// mu guards runtime binding state (BoundEntry, InFlight) and is not
+	// serialized. Session methods that mutate bound state are goroutine-safe;
+	// Messages remain the caller's responsibility to serialise per-turn.
+	mu sync.Mutex
+
+	// BoundEntry is the entry (cli | tui | web | api | channel | cron | setup)
+	// that currently owns the session. Empty means unbound. Persisted so a
+	// resumed session remembers where it was created / last used.
+	BoundEntry string `json:"bound_entry,omitempty"`
+
+	// BoundAt records when BoundEntry was last set, used for diagnostics when
+	// another entry tries to take over.
+	BoundAt time.Time `json:"bound_at,omitempty"`
+
+	// LeaseEntry/LeaseExpires implement a cross-process "in-flight" lock. A
+	// turn writes a short-lived lease before starting and clears it on finish;
+	// another process loading the session can see the lease and refuse to steal
+	// the binding while it is still valid. The lease is stored as an append-only
+	// "lease" record so it can be updated without rewriting the whole file.
+	LeaseEntry   string    `json:"-"`
+	LeaseExpires time.Time `json:"-"`
+
+	// InFlight counts active turns on this session within the current process.
+	// It is not persisted; use LeaseEntry/LeaseExpires for cross-process checks.
+	InFlight int `json:"-"`
+}
+
+// Common entry names. Use these constants at call sites so typos are caught.
+const (
+	EntryCLI     = "cli"
+	EntryTUI     = "tui"
+	EntryWeb     = "web"
+	EntryAPI     = "api"
+	EntryChannel = "channel"
+	EntryCron    = "cron"
+	EntrySetup   = "setup"
+)
+
+// IsBound reports whether the session is bound to any entry.
+func (s *Session) IsBound() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.BoundEntry != ""
+}
+
+// BoundTo reports whether the session is currently bound to entry.
+func (s *Session) BoundTo(entry string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.BoundEntry == entry
+}
+
+// ErrSessionBoundToOther is returned when an entry tries to use a session
+// owned by another entry without permission to steal.
+var ErrSessionBoundToOther = fmt.Errorf("session is bound to another entry")
+
+// BindResult reports what happened in a Bind call.
+type BindResult int
+
+const (
+	// Bound indicates the session is now bound to the caller.
+	Bound BindResult = iota
+	// AlreadyBound indicates the caller already owns the binding.
+	AlreadyBound
+	// Stolen indicates the binding was taken from another entry.
+	Stolen
+	// Rejected indicates another entry owns the session and steal was false.
+	Rejected
+)
+
+// Bind binds the session to entry in memory. It does NOT persist the change;
+// callers must Save() before another process can see it. This makes the session
+// file the single source of truth for cross-process binding.
+func (s *Session) Bind(entry string, steal bool) (BindResult, string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.BoundEntry == "" {
+		s.BoundEntry = entry
+		s.BoundAt = time.Now()
+		s.forceRewrite = true
+		return Bound, fmt.Sprintf("session bound to %s", entry), nil
+	}
+	if s.BoundEntry == entry {
+		s.BoundAt = time.Now()
+		s.forceRewrite = true
+		return AlreadyBound, fmt.Sprintf("session already bound to %s", entry), nil
+	}
+	if !steal {
+		return Rejected, "", fmt.Errorf("%w: bound to %s since %s; close it or request takeover", ErrSessionBoundToOther, s.BoundEntry, s.BoundAt.Format(time.RFC3339))
+	}
+	if holder, active := s.leaseActiveLocked(); active && holder != entry {
+		return Rejected, "", fmt.Errorf("%w: bound to %s and a turn lease is active until %s; cannot take over while busy", ErrSessionBoundToOther, s.BoundEntry, s.LeaseExpires.Format(time.RFC3339))
+	}
+	prev := s.BoundEntry
+	s.BoundEntry = entry
+	s.BoundAt = time.Now()
+	s.forceRewrite = true
+	return Stolen, fmt.Sprintf("session taken over from %s by %s", prev, entry), nil
+}
+
+// Unbind releases the session from entry in memory. No-op if not bound to entry.
+// Callers must Save() to publish the change.
+func (s *Session) Unbind(entry string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.BoundEntry != entry {
+		return false
+	}
+	s.BoundEntry = ""
+	s.BoundAt = time.Time{}
+	s.forceRewrite = true
+	return true
+}
+
+// IncFlight increments the in-flight turn count. Caller must already hold the
+// binding; the increment is a no-op if the session is unbound.
+func (s *Session) IncFlight() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.InFlight++
+}
+
+// DecFlight decrements the in-flight turn count, guarding against underflow.
+func (s *Session) DecFlight() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.InFlight > 0 {
+		s.InFlight--
+	}
+}
+
+// SetBoundEntry writes the binding fields directly. Used by persistent stores
+// after reloading the authoritative record from disk.
+func (s *Session) SetBoundEntry(entry string, at time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.BoundEntry = entry
+	s.BoundAt = at
+}
+
+// leaseActiveLocked reports whether an unexpired lease is held by someone else
+// (or the caller). Caller must hold s.mu.
+func (s *Session) leaseActiveLocked() (string, bool) {
+	if s.LeaseEntry == "" || s.LeaseExpires.IsZero() {
+		return "", false
+	}
+	if time.Now().After(s.LeaseExpires) {
+		return "", false
+	}
+	return s.LeaseEntry, true
+}
+
+// LeaseActive reports whether the session has an unexpired turn lease and who
+// holds it.
+func (s *Session) LeaseActive() (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.leaseActiveLocked()
+}
+
+// WriteLease appends a lease record claiming this session for entry until
+// expires. It does not change the in-memory BoundEntry. The lease is visible
+// to other processes on the next LoadSession.
+func (s *Session) WriteLease(entry string, expires time.Time) error {
+	if entry == "" {
+		return fmt.Errorf("lease entry cannot be empty")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.appendLeaseRecordLocked(entry, expires)
+}
+
+// ClearLease appends an empty lease record, clearing the cross-process
+// in-flight marker.
+func (s *Session) ClearLease() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.appendLeaseRecordLocked("", time.Time{})
+}
+
+// appendLeaseRecordLocked writes a lease record to the transcript. Caller must
+// hold s.mu.
+func (s *Session) appendLeaseRecordLocked(entry string, expires time.Time) error {
+	path, err := s.SavePath()
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	rec := sessionRecord{Type: "lease", LeaseEntry: entry, LeaseExpires: expires}
+	enc := json.NewEncoder(f)
+	if err := enc.Encode(rec); err != nil {
+		return err
+	}
+	s.LeaseEntry = entry
+	s.LeaseExpires = expires
+	return nil
 }
 
 // NewSession creates a Session with an ID derived from the current time plus
@@ -167,25 +370,29 @@ func (s *Session) ChunkDir() (string, error) {
 }
 
 // sessionRecord is one JSONL line. Type discriminates the meta header, a
-// message record, and a title record. The title is appended on its own line
-// (rather than rewriting the meta header) so the append-only path is preserved:
-// it's generated after the first turn, by which point the meta line is already
-// on disk. LoadSession takes the last title record as authoritative; rewriteAll
-// also folds the title back into the meta header so a compacted file keeps it.
+// message record, a title record, and a lease record. The title/lease are
+// appended on their own lines (rather than rewriting the meta header) so the
+// append-only path is preserved. LoadSession takes the last record of each
+// type as authoritative; rewriteAll folds them back into the meta header when
+// compacting.
 type sessionRecord struct {
-	Type        string    `json:"type"` // "meta" | "message" | "title" | "model_config"
-	ID          string    `json:"id,omitempty"`
-	CreatedAt   time.Time `json:"created_at,omitempty"`
-	Model       string    `json:"model,omitempty"`
-	System      string    `json:"system,omitempty"`
-	Title       string    `json:"title,omitempty"`
-	Source      string    `json:"source,omitempty"`
-	ModelConfig string    `json:"model_config,omitempty"`
-	Message     *Message  `json:"message,omitempty"`
+	Type         string    `json:"type"` // "meta" | "message" | "title" | "model_config" | "lease"
+	ID           string    `json:"id,omitempty"`
+	CreatedAt    time.Time `json:"created_at,omitempty"`
+	Model        string    `json:"model,omitempty"`
+	System       string    `json:"system,omitempty"`
+	Title        string    `json:"title,omitempty"`
+	Source       string    `json:"source,omitempty"`
+	ModelConfig  string    `json:"model_config,omitempty"`
+	BoundEntry   string    `json:"bound_entry,omitempty"`
+	BoundAt      time.Time `json:"bound_at,omitempty"`
+	LeaseEntry   string    `json:"lease_entry,omitempty"`
+	LeaseExpires time.Time `json:"lease_expires,omitempty"`
+	Message      *Message  `json:"message,omitempty"`
 }
 
 func (s *Session) metaRecord() sessionRecord {
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig}
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt}
 }
 
 func messageRecord(m Message) sessionRecord {
@@ -496,6 +703,9 @@ func LoadSession(id string) (*Session, error) {
 			s.Title = rec.Title // a compacted file carries the title in its meta header
 			s.Source = rec.Source
 			s.ModelConfig = rec.ModelConfig
+			s.BoundEntry = rec.BoundEntry
+			s.BoundAt = rec.BoundAt
+			s.InFlight = 0
 		case "title":
 			s.Title = rec.Title // last one wins
 		case "model_config":
@@ -507,6 +717,10 @@ func LoadSession(id string) (*Session, error) {
 			if rec.Message != nil {
 				s.Messages = append(s.Messages, *rec.Message)
 			}
+		case "lease":
+			// Last lease record wins. An empty lease_entry clears the marker.
+			s.LeaseEntry = rec.LeaseEntry
+			s.LeaseExpires = rec.LeaseExpires
 		}
 	}
 	if err := sc.Err(); err != nil {

--- a/internal/agent/session_persist_test.go
+++ b/internal/agent/session_persist_test.go
@@ -162,6 +162,30 @@ func TestLoadSession_DropsPartialTail(t *testing.T) {
 	}
 }
 
+// TestSessionBoundRoundTrip checks that BoundEntry and BoundAt survive a save/load cycle.
+func TestSessionBoundRoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := NewSession("m", "")
+	sess.Bind(EntryTUI, false)
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !loaded.BoundTo(EntryTUI) {
+		t.Fatalf("bound entry = %q, want %q", loaded.BoundEntry, EntryTUI)
+	}
+	if loaded.BoundAt.IsZero() {
+		t.Fatal("BoundAt not persisted")
+	}
+}
+
 // TestSetTitle_RewritesAfterPartialTail: SetTitle appends a raw title record;
 // after a crash left a partial tail it must rewrite instead, or the title
 // record fuses with the dangling bytes into one corrupt line.

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -571,6 +572,52 @@ func contains(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+func TestSessionBind(t *testing.T) {
+	s := NewSession("m", "")
+
+	res, msg, err := s.Bind(EntryTUI, false)
+	if res != Bound || err != nil {
+		t.Fatalf("bind new: %v %v %v", res, msg, err)
+	}
+
+	res, msg, err = s.Bind(EntryTUI, false)
+	if res != AlreadyBound || err != nil {
+		t.Fatalf("bind same: %v %v %v", res, msg, err)
+	}
+
+	res, _, err = s.Bind(EntryWeb, false)
+	if res != Rejected || !errors.Is(err, ErrSessionBoundToOther) {
+		t.Fatalf("bind other without steal: %v %v", res, err)
+	}
+
+	res, msg, err = s.Bind(EntryWeb, true)
+	if res != Stolen || err != nil {
+		t.Fatalf("steal idle: %v %v %v", res, msg, err)
+	}
+	if !s.BoundTo(EntryWeb) {
+		t.Fatal("expected web binding after steal")
+	}
+
+	// Simulate an active turn lease from the current owner; stealing must fail.
+	s.LeaseEntry = EntryWeb
+	s.LeaseExpires = time.Now().Add(time.Minute)
+	res, _, err = s.Bind(EntryTUI, true)
+	if res != Rejected || err == nil {
+		t.Fatalf("steal with active lease should fail: %v %v", res, err)
+	}
+	s.LeaseExpires = time.Time{}
+
+	if !s.Unbind(EntryWeb) {
+		t.Fatal("Unbind should succeed for current entry")
+	}
+	if s.IsBound() {
+		t.Fatal("expected unbound after Unbind")
+	}
+	if s.Unbind(EntryTUI) {
+		t.Fatal("Unbind should fail for non-current entry")
+	}
 }
 
 func TestSession_UsedTools_PlainMessagesIsFalse(t *testing.T) {

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -321,6 +321,8 @@ func (m *Manager) cmdClear(ev InboundEvent) string {
 // by its list number or (short/full) ID. The redirection is recorded in the
 // persistent binding table so it survives a restart, and no history is
 // deleted — /bind switches conversations rather than starting a fresh one.
+// If the target session is bound to another entry, the bind is rejected so
+// IM cannot silently take over a session owned by CLI/TUI/Web.
 func (m *Manager) cmdBind(ev InboundEvent, args []string) string {
 	if len(args) == 0 {
 		return "Usage: /bind <number|id> — run /list to see sessions, then attach this chat to one. History is preserved."
@@ -330,8 +332,18 @@ func (m *Manager) cmdBind(ev InboundEvent, args []string) string {
 		return fmt.Sprintf("No session matches %q. Run /list to see available sessions.", args[0])
 	}
 
+	if res, _, err := target.Bind(agent.EntryChannel, false); res == agent.Rejected {
+		return fmt.Sprintf("Cannot bind: %v", err)
+	}
+	if err := target.Save(); err != nil {
+		return fmt.Sprintf("Could not persist entry binding: %v", err)
+	}
+
 	key := sessionKeyFor(m.mode, ev)
 	if err := m.bindings.set(key, target.ID); err != nil {
+		// Roll back the entry binding so we don't leave the session claimed.
+		target.Unbind(agent.EntryChannel)
+		_ = target.Save()
 		return fmt.Sprintf("Could not save the binding: %v", err)
 	}
 	// Drop any live session for this key, then rebuild it against the newly
@@ -379,11 +391,21 @@ func (m *Manager) cmdStop(ev InboundEvent) string {
 	return "No task is running."
 }
 
-// cmdUnbind detaches the chat from a session it was bound to via /bind,
-// reverting it to its own default session. No history is deleted — the bound
-// session's transcript is left intact so it can be re-attached later.
+// cmdUnbind detaches the chat from its current session. If the chat was
+// explicitly /bind-ed to another session, that override is dropped; if the
+// chat owned its automatically-created session's entry binding, that binding
+// is released so other entries can use it. No history is deleted.
 func (m *Manager) cmdUnbind(ev InboundEvent) string {
 	key := sessionKeyFor(m.mode, ev)
+
+	released := false
+	if val, ok := m.sessions.Load(key); ok {
+		if ch := val.(*Session); ch.Store != nil {
+			released = ch.Store.Unbind(agent.EntryChannel)
+			_ = ch.Store.Save()
+		}
+	}
+
 	hadOverride, err := m.bindings.remove(key)
 	if err != nil {
 		return fmt.Sprintf("Could not clear the binding: %v", err)
@@ -391,7 +413,7 @@ func (m *Manager) cmdUnbind(ev InboundEvent) string {
 	// Detach the live session without touching any store; the next message
 	// re-attaches this chat to its own default session.
 	m.sessions.LoadAndDelete(key)
-	if hadOverride {
+	if hadOverride || released {
 		return "Unbound. This chat reverted to its own session; the bound session's history was kept."
 	}
 	return "This chat wasn't bound to another session. Reset to its default session; no history was deleted."

--- a/internal/channel/persist.go
+++ b/internal/channel/persist.go
@@ -45,6 +45,10 @@ func sessionStoreID(key SessionKey) string {
 // override or the deterministic default) and passed in. Best-effort — a
 // corrupt or unreadable file degrades to a fresh conversation rather than
 // blocking the chat.
+//
+// For a restored session the existing BoundEntry is preserved; the caller
+// (Manager) must explicitly Bind(EntryChannel) before using it, so entry
+// ownership is enforced consistently across CLI/TUI/Web/IM.
 func (s *Session) restoreOrInitStore(id string) {
 	if loaded, err := agent.LoadSession(id); err == nil {
 		s.Store = loaded
@@ -53,13 +57,16 @@ func (s *Session) restoreOrInitStore(id string) {
 		}
 		return
 	}
-	st := &agent.Session{
-		ID:        id,
-		CreatedAt: time.Now(),
-		Model:     s.Agent.Model,
-		Source:    "channel",
-		Title:     string(s.Key),
-	}
+	st := agent.NewSession(s.Agent.Model, "")
+	st.ID = id
+	st.CreatedAt = time.Now()
+	st.Source = "channel"
+	st.BoundEntry = agent.EntryChannel
+	st.BoundAt = time.Now()
+	st.Title = string(s.Key)
+	// Persist immediately so the entry binding is visible to other processes
+	// (and to the server's authoritative LoadSession in handleChannelMessage).
+	_ = st.Save()
 	s.Store = st
 }
 

--- a/internal/channel/persist_test.go
+++ b/internal/channel/persist_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 )
@@ -145,12 +146,64 @@ func TestCmdBind_AttachesToExistingSession(t *testing.T) {
 	if bound.Store.ID != targetID {
 		t.Errorf("bound session store = %q, want %q", bound.Store.ID, targetID)
 	}
+	if !bound.Store.BoundTo(agent.EntryChannel) {
+		t.Errorf("bound session entry = %q, want %q", bound.Store.BoundEntry, agent.EntryChannel)
+	}
 
 	// The binding survives a rebuild (persisted): a fresh manager re-attaches.
 	m2 := testManager()
 	again := m2.GetOrCreateSession(evB)
 	if again.Store.ID != targetID {
 		t.Errorf("binding did not persist: store = %q, want %q", again.Store.ID, targetID)
+	}
+}
+
+// TestCmdBind_RejectedWhenBoundToOtherEntry: /bind must not silently take over
+// a session owned by web/tui/cli.
+func TestCmdBind_RejectedWhenBoundToOtherEntry(t *testing.T) {
+	tempHome(t)
+	m := testManager()
+
+	// A session owned by the web entry.
+	webSess := agent.NewSession("stub-model", "")
+	webSess.BoundEntry = agent.EntryWeb
+	webSess.BoundAt = time.Now()
+	webSess.Messages = []agent.Message{{Role: agent.RoleUser, Content: "web context"}}
+	if err := webSess.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	evB := InboundEvent{Platform: "feishu", ChatID: "cB", UserID: "uB"}
+	reply := m.cmdBind(evB, []string{webSess.ID})
+	if !strings.Contains(strings.ToLower(reply), "cannot bind") {
+		t.Fatalf("expected rejection, got %q", reply)
+	}
+	if m.GetSession(evB) != nil {
+		t.Fatal("expected no session after rejected /bind")
+	}
+}
+
+// TestCmdUnbind_ReleasesBoundEntry: /unbind clears the IM entry binding so
+// other entries can use the session.
+func TestCmdUnbind_ReleasesBoundEntry(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+
+	m := testManager()
+	sess := m.GetOrCreateSession(ev)
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "secret"})
+	if err := sess.Persist(); err != nil {
+		t.Fatal(err)
+	}
+
+	m.cmdUnbind(ev)
+
+	reloaded, err := agent.LoadSession(sess.Store.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.BoundEntry != "" {
+		t.Errorf("BoundEntry = %q after unbind, want empty", reloaded.BoundEntry)
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -168,13 +168,17 @@ func (s *Server) handleCreateChat(w http.ResponseWriter, r *http.Request) {
 		model = req.Model
 	}
 	sess := agent.NewSession(model, s.system)
+	sess.Bind(agent.EntryWeb, false)
 	if req.Name != "" {
 		_ = sess.SetTitle(req.Name)
 	}
 
 	mu := s.sessionTurnLock(sess.ID)
 	mu.Lock()
-	defer mu.Unlock()
+	defer func() {
+		mu.Unlock()
+		s.releaseSessionBinding(sess.ID, agent.EntryWeb)
+	}()
 
 	reply, err := s.runTurn(r.Context(), sess, req.Message)
 	if errors.Is(err, errDraining) {
@@ -236,9 +240,26 @@ func (s *Server) handleTurn(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mu := s.sessionTurnLock(sess.ID)
+	if ok, msg, berr := s.acquireSessionBinding(id, agent.EntryWeb, false); !ok {
+		writeError(w, http.StatusConflict, berr.Error())
+		return
+	} else if msg != "" {
+		// TODO: surface takeover notice to the client via an event.
+		_ = msg
+	}
+
+	mu := s.sessionTurnLock(id)
 	mu.Lock()
-	defer mu.Unlock()
+	defer func() {
+		mu.Unlock()
+		s.releaseSessionBinding(id, agent.EntryWeb)
+	}()
+
+	sess, err = agent.LoadSession(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
 
 	reply, err := s.runTurn(r.Context(), sess, req.Message)
 	if errors.Is(err, errDraining) {
@@ -338,6 +359,7 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 	sess := agent.NewSession(model, "")
 	sess.Source = source
 	sess.ModelConfig = modelConfig
+	sess.Bind(agent.EntryWeb, false)
 	if req.Name != "" {
 		sess.Title = req.Name
 	}
@@ -958,6 +980,19 @@ func (s *Server) handleUpdateSessionModel(w http.ResponseWriter, r *http.Request
 	}
 
 	sess, err := agent.LoadSession(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	if ok, _, berr := s.acquireSessionBinding(id, agent.EntryWeb, false); !ok {
+		writeError(w, http.StatusConflict, berr.Error())
+		return
+	}
+	defer s.releaseSessionBinding(id, agent.EntryWeb)
+
+	// Reload after acquiring the binding in case another process saved.
+	sess, err = agent.LoadSession(id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
 		return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -123,6 +123,20 @@ type Server struct {
 	// Guarded by the session's turnLocks mutex.
 	turnRunning map[string]bool
 
+	// entryBindings is a short-lease cache of the authoritative binding state
+	// stored in each session file. It is only an optimisation within this
+	// process: the session file's BoundEntry field is the single source of
+	// truth, so a server restart or a concurrent CLI/TUI process always sees
+	// the persisted value.
+	entryBindings   map[string]*cachedEntryBinding
+	entryBindingsMu sync.Mutex
+
+	// sessionBindingLocks serialises the load→bind→save sequence for each
+	// session inside this process, so two goroutines cannot both read an
+	// unbound file and write conflicting bindings.
+	sessionBindingLocks   map[string]*sync.Mutex
+	sessionBindingLocksMu sync.Mutex
+
 	// steerQueues holds mid-turn user messages (steer) that arrive while a
 	// turn is in flight.  Consumed by the turn loop after each iteration.
 	steerQueues map[string][]agent.InboxItem
@@ -290,28 +304,30 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	s := &Server{
-		cfg:              cfg,
-		mux:              http.NewServeMux(),
-		sender:           sender,
-		model:            model,
-		provider:         provName,
-		system:           cfg.System,
-		skillReg:         skillReg,
-		skillsManifest:   skillsManifest,
-		cwd:              cwd,
-		envCtx:           envCtx,
-		memDir:           memDir,
-		homeMemDir:       homeMemDir,
-		turnLocks:        map[string]*sync.Mutex{},
-		turnRunning:      make(map[string]bool),
-		steerQueues:      make(map[string][]agent.InboxItem),
-		sessionAgents:    make(map[string]*agent.Agent),
-		accessKey:        accessKey,
-		confirmations:    make(map[string]chan string),
-		questionChans:    make(map[string]chan tools.AskResponse),
-		pendingQuestions: make(map[string]wsEventRequestUserQuestion),
-		pendingConfirms:  make(map[string]wsEventRequestConfirmation),
-		sessionInjectors: make(map[string]*memory.Injector),
+		cfg:                 cfg,
+		mux:                 http.NewServeMux(),
+		sender:              sender,
+		model:               model,
+		provider:            provName,
+		system:              cfg.System,
+		skillReg:            skillReg,
+		skillsManifest:      skillsManifest,
+		cwd:                 cwd,
+		envCtx:              envCtx,
+		memDir:              memDir,
+		homeMemDir:          homeMemDir,
+		turnLocks:           map[string]*sync.Mutex{},
+		turnRunning:         make(map[string]bool),
+		entryBindings:       make(map[string]*cachedEntryBinding),
+		sessionBindingLocks: map[string]*sync.Mutex{},
+		steerQueues:         make(map[string][]agent.InboxItem),
+		sessionAgents:       make(map[string]*agent.Agent),
+		accessKey:           accessKey,
+		confirmations:       make(map[string]chan string),
+		questionChans:       make(map[string]chan tools.AskResponse),
+		pendingQuestions:    make(map[string]wsEventRequestUserQuestion),
+		pendingConfirms:     make(map[string]wsEventRequestConfirmation),
+		sessionInjectors:    make(map[string]*memory.Injector),
 	}
 
 	// Register the WebSocket-backed asker so ask_user_question appears in the
@@ -663,6 +679,144 @@ func (s *Server) forgetTurnLock(id string) {
 	s.rememberedMu.Lock()
 	delete(s.rememberedStores, id)
 	s.rememberedMu.Unlock()
+
+	s.entryBindingsMu.Lock()
+	delete(s.entryBindings, id)
+	s.entryBindingsMu.Unlock()
+}
+
+// cachedEntryBinding is a short-lease, in-process cache of a session's binding.
+// The session file is the single source of truth; this cache only avoids
+// reloading the file on every turn within one server process.
+type cachedEntryBinding struct {
+	entry   string
+	expires time.Time
+}
+
+// entryBindingCacheLease is how long the in-process cache remains valid without
+// being renewed. The on-disk lease is written for entryBindingLease (longer) so
+// a cached owner can keep working without touching the file on every request.
+const entryBindingCacheLease = 30 * time.Second
+
+// entryBindingLease is how long a turn lease written to the session file
+// remains authoritative. It must be long enough to cover most turns, short
+// enough that a crashed process releases the binding quickly.
+const entryBindingLease = 2 * time.Minute
+
+// loadBoundSession reloads the session from disk and returns its authoritative
+// BoundEntry. The returned session is always a fresh object.
+func (s *Server) loadBoundSession(id string) (*agent.Session, error) {
+	return agent.LoadSession(id)
+}
+
+// sessionBindingLock returns the mutex that serialises load→bind→save for id.
+func (s *Server) sessionBindingLock(id string) *sync.Mutex {
+	s.sessionBindingLocksMu.Lock()
+	defer s.sessionBindingLocksMu.Unlock()
+	if mu, ok := s.sessionBindingLocks[id]; ok {
+		return mu
+	}
+	mu := &sync.Mutex{}
+	s.sessionBindingLocks[id] = mu
+	return mu
+}
+
+// acquireSessionBinding claims the session for entry. It always reloads the
+// session from disk first so the session file is the single source of truth.
+// A local cache with a short lease avoids repeated disk reads for the same
+// owner within this process. On success the binding and a turn lease are
+// persisted, and the cache is refreshed. The load→bind→save sequence is
+// serialised per session id.
+func (s *Server) acquireSessionBinding(id, entry string, steal bool) (bool, string, error) {
+	mu := s.sessionBindingLock(id)
+	mu.Lock()
+	defer mu.Unlock()
+
+	s.entryBindingsMu.Lock()
+	cache := s.entryBindings[id]
+	s.entryBindingsMu.Unlock()
+
+	now := time.Now()
+	if cache != nil && cache.entry == entry && cache.expires.After(now) {
+		// This process already owns an unexpired cache entry; just renew it.
+		s.entryBindingsMu.Lock()
+		s.entryBindings[id] = &cachedEntryBinding{entry: entry, expires: now.Add(entryBindingCacheLease)}
+		s.entryBindingsMu.Unlock()
+		return true, "", nil
+	}
+
+	// Authoritative check: reload from disk.
+	sess, err := s.loadBoundSession(id)
+	if err != nil {
+		return false, "", err
+	}
+
+	bound := sess.BoundEntry
+	if bound == "" || bound == entry {
+		// Own it. Write back immediately so other processes see it.
+		sess.Bind(entry, false)
+		if err := sess.Save(); err != nil {
+			return false, "", fmt.Errorf("persist binding: %w", err)
+		}
+		if err := sess.WriteLease(entry, now.Add(entryBindingLease)); err != nil {
+			return false, "", fmt.Errorf("write lease: %w", err)
+		}
+		s.entryBindingsMu.Lock()
+		s.entryBindings[id] = &cachedEntryBinding{entry: entry, expires: now.Add(entryBindingCacheLease)}
+		s.entryBindingsMu.Unlock()
+		return true, "", nil
+	}
+
+	if !steal {
+		return false, "", fmt.Errorf("session is bound to %s since %s; close the other entry first", bound, sess.BoundAt.Format(time.RFC3339))
+	}
+
+	// Respect the in-memory cache when we have seen this binding recently; the
+	// authoritative owner in another process may still be alive.
+	if cache != nil && cache.entry == bound && cache.expires.After(now) {
+		return false, "", fmt.Errorf("session is bound to %s and the local lease has not expired; cannot take over yet", bound)
+	}
+	// Respect the persisted turn lease: if another entry holds an unexpired
+	// lease, refuse to steal even if our cache has expired.
+	if holder, active := sess.LeaseActive(); active && holder != entry {
+		return false, "", fmt.Errorf("session is bound to %s and a turn lease is active until %s; cannot take over while busy", bound, sess.LeaseExpires.Format(time.RFC3339))
+	}
+
+	sess.Bind(entry, true)
+	if err := sess.Save(); err != nil {
+		return false, "", fmt.Errorf("persist stolen binding: %w", err)
+	}
+	if err := sess.WriteLease(entry, now.Add(entryBindingLease)); err != nil {
+		return false, "", fmt.Errorf("write stolen lease: %w", err)
+	}
+	s.entryBindingsMu.Lock()
+	s.entryBindings[id] = &cachedEntryBinding{entry: entry, expires: now.Add(entryBindingCacheLease)}
+	s.entryBindingsMu.Unlock()
+	return true, fmt.Sprintf("session taken over from %s", bound), nil
+}
+
+// releaseSessionBinding clears the binding when this process owns it. It
+// reloads the session from disk first to avoid clobbering a binding set by
+// another process after the turn started. The turn lease is also cleared.
+func (s *Server) releaseSessionBinding(id, entry string) {
+	mu := s.sessionBindingLock(id)
+	mu.Lock()
+	defer mu.Unlock()
+
+	sess, err := s.loadBoundSession(id)
+	if err != nil {
+		return
+	}
+	if sess.BoundEntry != entry {
+		return
+	}
+	_ = sess.ClearLease()
+	sess.Unbind(entry)
+	_ = sess.Save()
+
+	s.entryBindingsMu.Lock()
+	delete(s.entryBindings, id)
+	s.entryBindingsMu.Unlock()
 }
 
 // resolveUnderCWD joins path with cwd and checks that the resulting absolute
@@ -1368,7 +1522,19 @@ func (s *Server) handleChannelCompact(ad channel.Adapter, ev channel.InboundEven
 		ad.SendText(ev.ChatID, "A task is running — try /compact again once it finishes.", ev.MessageID)
 		return
 	}
+
+	storeID := sess.Store.ID
+	if ok, _, berr := s.acquireSessionBinding(storeID, agent.EntryChannel, false); !ok {
+		ad.SendText(ev.ChatID, "⚠️ "+berr.Error(), ev.MessageID)
+		return
+	}
+
+	if fresh, err := agent.LoadSession(storeID); err == nil {
+		sess.Store = fresh
+	}
+
 	go func() {
+		defer s.releaseSessionBinding(storeID, agent.EntryChannel)
 		ctx, done := sess.BeginRun(context.Background())
 		defer done()
 		stats, err := sess.Agent.ForceCompact(ctx, nil)
@@ -1401,6 +1567,23 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	sess := s.channelMgr.GetOrCreateSession(ev)
 	if sess == nil {
 		return
+	}
+
+	// Enforce entry binding: the session file is the single source of truth.
+	// If another entry (web/tui/cli) owns this session, refuse to run the turn
+	// rather than interleaving with it across processes.
+	storeID := sess.Store.ID
+	if ok, _, berr := s.acquireSessionBinding(storeID, agent.EntryChannel, false); !ok {
+		ad.SendText(ev.ChatID, "⚠️ "+berr.Error(), ev.MessageID)
+		return
+	}
+	defer s.releaseSessionBinding(storeID, agent.EntryChannel)
+
+	// Reload the authoritative session after acquiring the binding. Another
+	// process may have saved since the manager restored it, and we must not
+	// persist through a stale Store pointer.
+	if fresh, err := agent.LoadSession(storeID); err == nil {
+		sess.Store = fresh
 	}
 
 	// Waits for any in-flight turn in this session, then makes this turn

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -285,19 +285,21 @@ func mustServer(t *testing.T, cfg Config) *Server {
 
 	// Create a minimal server with stubbed provider.
 	srv := &Server{
-		cfg:            cfg,
-		mux:            http.NewServeMux(),
-		model:          "stub-model",
-		system:         "",
-		skillReg:       skills.Discover(""),
-		skillsManifest: "",
-		cwd:            "",
-		envCtx:         "",
-		turnLocks:      map[string]*sync.Mutex{},
-		sender:         &stubSender{},
-		accessKey:      mustAccessKey(cfg),
-		sessionAgents:  make(map[string]*agent.Agent),
-		steerQueues:    make(map[string][]agent.InboxItem),
+		cfg:                 cfg,
+		mux:                 http.NewServeMux(),
+		model:               "stub-model",
+		system:              "",
+		skillReg:            skills.Discover(""),
+		skillsManifest:      "",
+		cwd:                 "",
+		envCtx:              "",
+		turnLocks:           map[string]*sync.Mutex{},
+		sender:              &stubSender{},
+		accessKey:           mustAccessKey(cfg),
+		entryBindings:       make(map[string]*cachedEntryBinding),
+		sessionBindingLocks: map[string]*sync.Mutex{},
+		sessionAgents:       make(map[string]*agent.Agent),
+		steerQueues:         make(map[string][]agent.InboxItem),
 	}
 	srv.registerRoutes()
 	// Wrap with CORS middleware so tests that exercise CORS hit the right layer.

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -37,20 +37,31 @@ func (s *Server) handleTurnSSE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if ok, msg, berr := s.acquireSessionBinding(id, agent.EntryWeb, false); !ok {
+		writeError(w, http.StatusConflict, berr.Error())
+		return
+	} else if msg != "" {
+		_ = msg
+	}
+
+	if err := s.ensureSender(); err != nil {
+		s.releaseSessionBinding(id, agent.EntryWeb)
+		writeError(w, http.StatusServiceUnavailable, err.Error())
+		return
+	}
+
+	mu := s.sessionTurnLock(id)
+	mu.Lock()
+	defer func() {
+		mu.Unlock()
+		s.releaseSessionBinding(id, agent.EntryWeb)
+	}()
+
 	sess, err := agent.LoadSession(id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
 		return
 	}
-
-	if err := s.ensureSender(); err != nil {
-		writeError(w, http.StatusServiceUnavailable, err.Error())
-		return
-	}
-
-	mu := s.sessionTurnLock(sess.ID)
-	mu.Lock()
-	defer mu.Unlock()
 
 	// Refuse new turns during a restart drain — after the turn lock (so a
 	// queued SSE turn admitted before the drain doesn't slip through) but

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -96,9 +96,22 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 		}
 	}
 
+	if ok, _, berr := s.acquireSessionBinding(sess.ID, agent.EntryCron, false); !ok {
+		return sess.ID, fmt.Errorf("acquire binding: %w", berr)
+	}
+
 	mu := s.sessionTurnLock(sess.ID)
 	mu.Lock()
-	defer mu.Unlock()
+	defer func() {
+		mu.Unlock()
+		s.releaseSessionBinding(sess.ID, agent.EntryCron)
+	}()
+
+	// Reload the authoritative session after acquiring the binding.
+	sess, err = agent.LoadSession(sess.ID)
+	if err != nil {
+		return sess.ID, fmt.Errorf("reload session: %w", err)
+	}
 
 	a := s.buildAgent(sess)
 

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -332,24 +332,33 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 		return
 	}
 
-	mu := s.sessionTurnLock(sess.ID)
+	if ok, _, berr := s.acquireSessionBinding(sid, agent.EntryWeb, false); !ok {
+		s.wsHub.broadcast(sid, map[string]string{
+			"type":    "error",
+			"message": berr.Error(),
+		})
+		return
+	}
+
+	mu := s.sessionTurnLock(sid)
 	mu.Lock()
 
-	if s.turnRunning[sess.ID] {
+	if s.turnRunning[sid] {
 		mu.Unlock()
-		// A mid-turn message has exactly one home: the running Agent's Inbox
-		// when it is registered (the runLoop drains it between iterations —
-		// attachment blocks and all), the steer queue otherwise (consumed by
-		// runAgentTurnLoop as the next chained turn). Enqueueing into both,
-		// as this branch once did, processed the same message twice.
+		// The current Web entry already owns the binding; a mid-turn message
+		// has exactly one home: the running Agent's Inbox when it is registered
+		// (the runLoop drains it between iterations — attachment blocks and
+		// all), the steer queue otherwise (consumed by runAgentTurnLoop as the
+		// next chained turn). Enqueueing into both, as this branch once did,
+		// processed the same message twice.
 		s.sessionAgentsMu.Lock()
-		a := s.sessionAgents[sess.ID]
+		a := s.sessionAgents[sid]
 		if a != nil {
 			a.Inbox.EnqueueWithBlocks(content, att.blocks)
 		}
 		s.sessionAgentsMu.Unlock()
 		if a == nil {
-			s.enqueueSteer(sess.ID, agent.InboxItem{Text: content, Blocks: att.blocks})
+			s.enqueueSteer(sid, agent.InboxItem{Text: content, Blocks: att.blocks})
 		}
 		// The frontend already rendered a ghost bubble in _sendMessage;
 		// history_user_message (broadcast when the turn drains steer) will
@@ -357,14 +366,30 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 		return
 	}
 
-	s.turnRunning[sess.ID] = true
+	// Reload the authoritative session after acquiring the binding so the turn
+	// works on the latest persisted state (another process may have saved).
+	sess, err = agent.LoadSession(sid)
+	if err != nil {
+		mu.Unlock()
+		s.releaseSessionBinding(sid, agent.EntryWeb)
+		s.wsHub.broadcast(sid, map[string]string{
+			"type":    "error",
+			"message": fmt.Sprintf("session not found: %s", sid),
+		})
+		return
+	}
+
+	sess.IncFlight()
+	s.turnRunning[sid] = true
 	mu.Unlock()
 
 	go func() {
 		defer func() {
 			mu.Lock()
-			s.turnRunning[sess.ID] = false
+			s.turnRunning[sid] = false
 			mu.Unlock()
+			sess.DecFlight()
+			s.releaseSessionBinding(sid, agent.EntryWeb)
 		}()
 		s.runAgentTurnLoop(sess, content, att.blocks, att.images)
 	}()


### PR DESCRIPTION
## Summary

This PR adds per-session entry binding so a session can be actively used from only one entry (cli/tui/web/api/channel/cron/setup) at a time. The session file is the single source of truth; each `octo serve` process keeps a short-lease read cache to avoid reloading on every turn.

## Changes

- **agent.Session**: add `BoundEntry`, `BoundAt`, `InFlight`, and `Bind`/`Unbind`/`BindTo`/`IsBound`. Binding changes set `forceRewrite` so the next `Save` rewrites the meta record.
- **cmd/octo (TUI)**: bind on create/resume, unbind on exit.
- **server**: `acquireSessionBinding` reloads from disk, claims/releases the binding, and rejects or steals (when idle) based on the persisted `BoundEntry`. Applied to `POST /api/chat`, `/api/chat/:id/turn`, SSE, WebSocket turns, cron tasks, `/compact`, and IM channel messages.
- **IM channel**: `/bind` rejects occupied sessions; `/unbind` releases `BoundEntry`; new sessions persist `BoundEntry=channel` immediately so other entries see it.
- **Tests**: binding round-trips, rejection, stealing, and IM `/bind`/`/unbind`.

## Notes

- `make test` passes (`go test -race ./...`).
- No new third-party dependencies.