### PR TITLE
tools: add anti-polling hard stop to terminal_output

### DIFF
--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -17,6 +17,12 @@ import (
 // is what matters); Read reports when earlier output was dropped.
 const maxBgOutputBytes = 1 << 20 // 1 MiB
 
+// Anti-polling window shared by Read and Tail. Within a 30-second window, 3 or
+// more empty reads on a running process trigger a block, giving the LLM a hard
+// hint to stop polling and wait for the automatic completion notification.
+const pollWindow = 30 * time.Second
+const maxEmptyPolls = 3
+
 // bgProcess tracks one detached command launched via BackgroundManager.
 type bgProcess struct {
 	id      string
@@ -37,6 +43,12 @@ type bgProcess struct {
 	// status checks on long-running services without penalising the model.
 	firstEmptyPoll time.Time
 	emptyPollCount int
+
+	// Anti-polling for Tail (terminal_output). Same window/count threshold as
+	// Read, but tracked independently because Tail snapshots the buffer without
+	// advancing the read cursor.
+	firstEmptyTailPoll time.Time
+	emptyTailPollCount int
 
 	onLine func(string) // optional real-time callback for sync-mode streaming
 
@@ -89,7 +101,12 @@ func (p *bgProcess) statusLocked() string {
 // non-destructive snapshot, so repeated calls return the same view and there is
 // no incentive to poll. A truncation marker is prefixed when output was dropped
 // (buffer cap or the n-line clamp).
-func (p *bgProcess) tail(n int) (output, status string) {
+//
+// To stop models that ignore the "do not poll" instructions, tail tracks empty
+// snapshot calls on a running process within the same anti-polling window used
+// by readNew. Once the threshold is exceeded, blocked is true and callers
+// should tell the model to stop polling and wait for the completion push.
+func (p *bgProcess) tail(n int) (output, status string, blocked bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -107,7 +124,27 @@ func (p *bgProcess) tail(n int) (output, status string) {
 	if truncated && out != "" {
 		out = "[... earlier output truncated ...]\n" + out
 	}
-	return out, p.statusLocked()
+	status = p.statusLocked()
+
+	// Anti-polling for terminal_output: repeated empty snapshots of a running
+	// process are almost always a polling loop. Count them in the same window as
+	// Read so the model gets a consistent hard stop.
+	if !p.done && out == "" {
+		now := time.Now()
+		if p.emptyTailPollCount == 0 || now.Sub(p.firstEmptyTailPoll) > pollWindow {
+			p.firstEmptyTailPoll = now
+			p.emptyTailPollCount = 1
+		} else {
+			p.emptyTailPollCount++
+			if p.emptyTailPollCount >= maxEmptyPolls {
+				blocked = true
+			}
+		}
+	} else {
+		p.emptyTailPollCount = 0
+		p.firstEmptyTailPoll = time.Time{}
+	}
+	return out, status, blocked
 }
 
 // readNew returns output produced since the last Read and the current status,
@@ -132,8 +169,6 @@ func (p *bgProcess) readNew() (string, string, bool) {
 	// empty reads on a running process trigger a block. This is lenient enough
 	// for occasional status checks on long-running services while still stopping
 	// tight polling loops on one-shot tasks.
-	const pollWindow = 30 * time.Second
-	const maxEmptyPolls = 3
 	blocked := false
 	if !p.done && len(out) == 0 {
 		now := time.Now()
@@ -401,17 +436,18 @@ func (m *BackgroundManager) Read(id string) (output, status string, found bool, 
 // Tail returns a non-destructive snapshot of the last `lines` lines of a
 // process's output (lines <= 0 = all retained), plus its status. found is false
 // when id is unknown. Unlike Read it does not advance the cursor — it's for
-// on-demand progress peeks (the terminal_output tool), so it never blocks and
-// repeated calls are idempotent.
-func (m *BackgroundManager) Tail(id string, lines int) (output, status string, found bool) {
+// on-demand progress peeks (the terminal_output tool). repeated calls return
+// the same bytes, but repeated empty snapshots of a running process are counted
+// as polling; once blocked is true, callers should tell the model to stop.
+func (m *BackgroundManager) Tail(id string, lines int) (output, status string, found bool, blocked bool) {
 	m.mu.Lock()
 	p := m.procs[id]
 	m.mu.Unlock()
 	if p == nil {
-		return "", "", false
+		return "", "", false, false
 	}
-	out, st := p.tail(lines)
-	return out, st, true
+	out, st, blk := p.tail(lines)
+	return out, st, true, blk
 }
 
 // BgInfo is a snapshot of a tracked background process — used both by the TUI's

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -164,11 +164,6 @@ func TestTerminalOutputTool(t *testing.T) {
 	waitFor(t, "terminal_output to show exit", func() bool {
 		rTool, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_1"})
 		if err != nil {
-			// Anti-polling block is temporary while the process is still running
-			// with no new output; retry until it exits.
-			if strings.Contains(err.Error(), "polling blocked") {
-				return false
-			}
 			t.Fatalf("terminal_output: %v", err)
 		}
 		res += rTool.Text
@@ -273,9 +268,9 @@ func TestTerminalTool_TimeoutPromotesToBackground(t *testing.T) {
 
 // TestTerminalOutputTool_SnapshotIdempotent verifies the snapshot semantics:
 // terminal_output is a non-advancing peek, so repeated calls on a running
-// process never error or "block" — they just return the current tail and
-// status. (Replaces the old delta + anti-polling behavior, which the snapshot
-// model removes by design.)
+// process return the current tail and status without error. Empty snapshots are
+// still counted for anti-polling, but that is surfaced as extra text in the
+// result, not as an error.
 func TestTerminalOutputTool_SnapshotIdempotent(t *testing.T) {
 	m := NewBackgroundManager()
 	term := TerminalTool{mgr: m}
@@ -288,8 +283,7 @@ func TestTerminalOutputTool_SnapshotIdempotent(t *testing.T) {
 		t.Fatalf("launch: %v", err)
 	}
 
-	// Many empty polls in a row: all succeed, none block, all report running.
-	for i := 1; i <= 5; i++ {
+	for i := 1; i <= 2; i++ {
 		res, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_1"})
 		if err != nil {
 			t.Fatalf("poll %d should never error in the snapshot model: %v", i, err)
@@ -297,6 +291,40 @@ func TestTerminalOutputTool_SnapshotIdempotent(t *testing.T) {
 		if !strings.Contains(res.Text, "[status: running]") {
 			t.Errorf("poll %d should report running, got %q", i, res.Text)
 		}
+		if strings.Contains(res.Text, "[STOP:") {
+			t.Errorf("poll %d should not be blocked yet, got %q", i, res.Text)
+		}
+	}
+}
+
+// TestTerminalOutputTool_AntiPollBlocksEmptySnapshots verifies that repeated
+// empty terminal_output calls on a running process eventually trigger a hard
+// "STOP" hint, teaching the model to wait for the automatic completion
+// notification instead of polling.
+func TestTerminalOutputTool_AntiPollBlocksEmptySnapshots(t *testing.T) {
+	m := NewBackgroundManager()
+	term := TerminalTool{mgr: m}
+	outTool := TerminalOutputTool{mgr: m}
+
+	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
+		"command":           "sleep 30",
+		"run_in_background": true,
+	}); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+
+	var blocked bool
+	for i := 1; i <= 3; i++ {
+		res, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_1"})
+		if err != nil {
+			t.Fatalf("poll %d should not error: %v", i, err)
+		}
+		if strings.Contains(res.Text, "[STOP:") {
+			blocked = true
+		}
+	}
+	if !blocked {
+		t.Errorf("expected anti-polling STOP after %d empty snapshots", 3)
 	}
 }
 

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -320,7 +320,7 @@ func (t TerminalOutputTool) managerFor(ctx context.Context) *BackgroundManager {
 func (TerminalOutputTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name:        "terminal_output",
-		Description: "Peek at the recent output of a background process (the id from terminal run_in_background:true): a snapshot of the last N lines plus its status (running / exited). Read-only; to stop the process use kill_shell.\n\nUse this to CHECK PROGRESS of a still-running process on demand — e.g. inspect a server's startup logs. You do NOT need it to learn that a process finished or to get its result: completion is pushed to you automatically, carrying the final output. This is a snapshot, not a feed — repeated calls return the current tail, there is no 'new since last call', so do not call it in a loop. To find an id you've lost track of, use terminal_list.",
+		Description: "Peek at the recent output of a background process (the id from terminal run_in_background:true): a snapshot of the last N lines plus its status (running / exited). Read-only; to stop the process use kill_shell.\n\nUse this to CHECK PROGRESS of a still-running process on demand — e.g. inspect a server's startup logs. You do NOT need it to learn that a process finished or to get its result: completion is pushed to you automatically, carrying the final output. This is a snapshot, not a feed — repeated calls return the current tail, there is no 'new since last call', so do not call it in a loop. Repeated empty snapshots of a running process are detected as polling and will trigger a hard STOP reminder. To find an id you've lost track of, use terminal_list.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -355,7 +355,7 @@ func (t TerminalOutputTool) Execute(ctx context.Context, _ string, input map[str
 	if v, ok := input["lines"].(float64); ok { // JSON numbers decode as float64
 		lines = int(v)
 	}
-	out, status, found := t.managerFor(ctx).Tail(id, lines)
+	out, status, found, blocked := t.managerFor(ctx).Tail(id, lines)
 	if !found {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: no background process %q (it may have been reaped — use terminal_list to see live processes)", id)
 	}
@@ -369,6 +369,15 @@ func (t TerminalOutputTool) Execute(ctx context.Context, _ string, input map[str
 			msg += "\n(if this persists for a process that should be logging, its stdio is likely " +
 				"block-buffered because it's piped — on macOS/Linux relaunch it as `stdbuf -oL <cmd>` " +
 				"to force line buffering)"
+		}
+		// Hard stop for models that keep polling despite the "do not poll"
+		// instructions. The agent loop's duplicate-tool-call detector would
+		// eventually kill the turn; this surfaces the problem directly in the
+		// tool result so the model sees why it must stop.
+		if blocked {
+			msg += "\n\n[STOP: repeated empty terminal_output calls detected. " +
+				"Do not poll this process again. The system will push a [BACKGROUND COMPLETED] " +
+				"notification when it finishes.]"
 		}
 		return agent.ToolResult{Text: msg}, nil
 	}


### PR DESCRIPTION
## Problem

kimi-coding repeatedly calls `terminal_output` on running background processes, gets `(no output yet)` each time, and trips the agent loop's duplicate-tool-call stop:

```
[octo] Stopped: detected repeated tool calls without progress. The model appears to be stuck in a loop.
```

## Root cause

`terminal_output` uses `BackgroundManager.Tail()`, which was intentionally a non-advancing, non-blocking snapshot. The anti-polling window only existed in `Read()`, so repeated empty `terminal_output` calls were never discouraged before the higher-level loop detector fired.

## Change

- Move the 30s / 3-empty-call anti-polling constants to package level.
- Add independent empty-snapshot tracking to `bgProcess.tail()` and return a `blocked` flag.
- Update `BackgroundManager.Tail()` to return `blocked`.
- When `terminal_output` sees an empty snapshot on a running process and `blocked` is true, append a hard `[STOP: ...]` reminder that completion is pushed automatically and the model must not poll.
- Update the `terminal_output` tool description to advertise this behavior.
- Add `TestTerminalOutputTool_AntiPollBlocksEmptySnapshots`.

## Verification

`make test` (`go test -race ./...`) passes locally.

No new third-party dependencies.