### PR TITLE
fix(tui): strip injected \u003csystem-reminder\u003e from user message display

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1270,18 +1270,22 @@ func (m *tuiModel) renderReplayText(s string) string {
 }
 
 // userMessageText returns a user message's human-typed text, ignoring
-// tool_result carriers and non-text (e.g. image) blocks.
+// tool_result carriers, non-text (e.g. image) blocks, and any
+// model-facing <system-reminder> spans the harness injected into the turn.
 func userMessageText(msg agent.Message) string {
+	var s string
 	if len(msg.Blocks) == 0 {
-		return msg.Content
-	}
-	var b strings.Builder
-	for _, blk := range msg.Blocks {
-		if blk.Type == "text" {
-			b.WriteString(blk.Text)
+		s = msg.Content
+	} else {
+		var b strings.Builder
+		for _, blk := range msg.Blocks {
+			if blk.Type == "text" {
+				b.WriteString(blk.Text)
+			}
 		}
+		s = b.String()
 	}
-	return b.String()
+	return strings.TrimSpace(agent.StripSystemReminders(s))
 }
 
 // flushSprint ends the answer hand-off sprint, if one is active, and releases


### PR DESCRIPTION
When resuming a session with `octo -c`, harness-injected `\u003csystem-reminder\u003e` blocks (memory rules, background-process completion notes, etc.) were being printed verbatim in the TUI user bubble because `userMessageText` returned them as user-typed text.

Strip these model-facing spans with `agent.StripSystemReminders` so only the human's actual input is rendered, matching how other UI surfaces (web transcript, tool cards) already treat reminder spans.

- `make test` green (`go test -race ./...`)
- No new third-party dependencies

Co-authored-by: octo-agent \u003cno-reply@octo-agent.dev\u003e