### PR TITLE
cli: add --take-over flag for resuming a bound session

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -227,6 +227,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	stream := fs.Bool("stream", true, "Stream the reply (chunks printed as they arrive); --stream=false buffers")
 	continueID := fs.String("c", "", "Resume a session — accepts 'last', a short ID, or a substring of an ID; omit the value to pick from a list")
 	continueIDLong := fs.String("continue", "", "Resume a session — accepts 'last', a short ID, or a substring of an ID; omit the value to pick from a list")
+	takeOver := fs.Bool("take-over", false, "When resuming (-c), take over a session currently bound to another entry")
 	noSave := fs.Bool("no-save", false, "Disable session auto-save in the interactive TUI (headless one-shots never persist)")
 	enableTools := fs.Bool("tools", true, "Built-in tools (terminal, edit_file, …) for the agentic loop. On by default; use --no-tools to disable.")
 	noTools := fs.Bool("no-tools", false, "Disable the built-in tools (and MCP/skill execution) — plain chat only")
@@ -339,6 +340,12 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// Single-turn mode requires a message.
 	if !isREPL && resumeID != "" {
 		fmt.Fprintln(stderr, "octo: -c/--continue requires interactive mode (omit the message argument)")
+		return 2
+	}
+
+	// --take-over only makes sense when resuming an existing session.
+	if *takeOver && resumeID == "" {
+		fmt.Fprintln(stderr, "octo: --take-over requires -c/--continue")
 		return 2
 	}
 
@@ -732,7 +739,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 				fmt.Fprintf(stderr, "octo: %v\n", err)
 				return 1
 			}
-			if ok, msg, berr := sess.Bind(agent.EntryTUI, false); ok == agent.Rejected {
+			if ok, msg, berr := sess.Bind(agent.EntryTUI, *takeOver); ok == agent.Rejected {
 				fmt.Fprintf(stderr, "octo: %v\n", berr)
 				return 1
 			} else if msg != "" && !*quietFlag {

--- a/cmd/octo/chat_test.go
+++ b/cmd/octo/chat_test.go
@@ -179,6 +179,44 @@ func TestRunChat_PromptFile_SingleTurn(t *testing.T) {
 	}
 }
 
+// TestRunChat_TakeOverFlagUsage checks --take-over is rejected without -c
+// and accepted when paired with it. The actual TUI resume path requires a tty,
+// so the second case fails earlier at session resolution, not at flag parsing.
+func TestRunChat_TakeOverFlagUsage(t *testing.T) {
+	t.Run("without continue", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := runChat([]string{"--take-over"}, strings.NewReader(""), &stdout, &stderr)
+		if code != 2 {
+			t.Errorf("exit code = %d, want 2", code)
+		}
+		if !strings.Contains(stderr.String(), "--take-over requires -c") {
+			t.Errorf("stderr should reject --take-over without -c, got: %q", stderr.String())
+		}
+	})
+
+	t.Run("with continue accepted", func(t *testing.T) {
+		// Isolate HOME so a local ~/.octo/sessions cannot accidentally match
+		// the nonexistent ID and change the exit path.
+		tmp := t.TempDir()
+		t.Setenv("HOME", tmp)
+		t.Setenv("USERPROFILE", tmp)
+
+		var stdout, stderr bytes.Buffer
+		code := runChat([]string{"--take-over", "-c", "nonexistent-id"}, strings.NewReader(""), &stdout, &stderr)
+		// --take-over is accepted with -c; resolve runs before the TUI gate, so
+		// we expect a "no session matches" error rather than flag validation.
+		if code != 2 {
+			t.Errorf("exit code = %d, want 2 (session resolve failure)", code)
+		}
+		if strings.Contains(stderr.String(), "--take-over requires -c") {
+			t.Errorf("flag should be accepted with -c, got: %q", stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "no session matches") {
+			t.Errorf("expected session resolve error, got: %q", stderr.String())
+		}
+	})
+}
+
 func TestResolveMaxTurns(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -111,6 +111,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Common flags:")
 	fmt.Fprintln(w, "  -c, --continue [id]      Resume a session — 'last', short ID, or substring; no ID = pick from a list")
+	fmt.Fprintln(w, "  --take-over              When resuming, take over a session bound to another entry")
 	fmt.Fprintln(w, "  --no-tools               Disable built-in tools (terminal, edit_file, …) + MCP/skills")
 	fmt.Fprintln(w, "  --provider <name>        anthropic (default) | openai")
 	fmt.Fprintln(w, "  --model <name>           Override the default model for the provider")


### PR DESCRIPTION
Adds `octo -c <id> --take-over` to allow TUI resume to steal a session currently bound to another entry (e.g. channel). The flag is rejected unless `-c/--continue` is also provided. The underlying `Session.Bind(entry, steal=true)` semantics are unchanged.

Changes:
- `cmd/octo/chat.go`: new `--take-over` flag, validation, pass steal to `Session.Bind`
- `cmd/octo/main.go`: include flag in top-level usage
- `cmd/octo/chat_test.go`: flag usage tests

Verification:
- `gofmt -w`
- `go vet ./cmd/octo/...`
- `go test -race ./cmd/octo/...`
- `make test` (full suite green)

No new third-party dependencies.