### PR TITLE
chore(release): bump version to 1.1.0-dev

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.0.0"
+var Version = "1.1.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Routine post-release bump after `v1.0.0`. `internal/version/version.go` → `1.1.0` (next-minor dev cycle); the `[Unreleased — 1.1.0-dev]` CHANGELOG header already landed in #783.

🤖 Generated with [Claude Code](https://claude.com/claude-code)