### PR TITLE
fix(test): drain turn goroutine before TempDir cleanup (Windows flake)

### DIFF
--- a/internal/server/attachments_test.go
+++ b/internal/server/attachments_test.go
@@ -256,6 +256,20 @@ drain:
 		t.Error("history_user_message carried no /api/uploads/ image ref")
 	}
 
+	// The "complete" event is broadcast from inside runAgentTurnLoop, but the
+	// turn runs in a goroutine (handleWSUserMessage) whose deferred teardown —
+	// and any trailing session persist — finishes slightly later. Wait for the
+	// turn flag to clear so the session file is fully written and its handle
+	// closed before t.TempDir() cleanup runs; otherwise Windows refuses to
+	// RemoveAll a sessions dir whose file is still open ("directory is not
+	// empty").
+	waitFor(t, func() bool {
+		mu := srv.sessionTurnLock(sess.ID)
+		mu.Lock()
+		defer mu.Unlock()
+		return !srv.turnRunning[sess.ID]
+	})
+
 	// The persisted session must carry the image block with its file path.
 	loaded, err := agent.LoadSession(sess.ID)
 	if err != nil {


### PR DESCRIPTION
## Symptom
`TestHandleWSUserMessage_ImageOnly` failed intermittently on the `windows-latest` job (it failed on #785, a one-line version bump that cannot affect it):

```
testing.go:1369: TempDir RemoveAll cleanup: unlinkat ...\.octo\sessions: The directory is not empty.
```

## Root cause
`handleWSUserMessage` runs the turn in a **goroutine**, and `runAgentTurnLoop` broadcasts the `complete` WS event from *inside* it. The test drained only until `complete`, then returned — but the goroutine's deferred teardown (and its trailing session persist) finishes a hair later. So `t.TempDir()` cleanup could run `RemoveAll` while a session file was still open. POSIX happily unlinks an open file; **Windows refuses**, hence the flake. Not a product bug — test teardown ordering.

## Fix
After the drain loop, wait for `turnRunning[sid]` to clear — the goroutine sets it `false` in its `defer`, strictly after `runAgentTurnLoop` returns and the final persist closes the file. Uses the existing `waitFor` helper. Same goroutine-drain family as #682 / #755.

Verified: passes `-count=3` locally; gofmt + vet clean.