### PR TITLE
fix(weixin): decrypt downloaded media files

### DIFF
--- a/internal/channel/adapters/weixin/ilink/protocol.go
+++ b/internal/channel/adapters/weixin/ilink/protocol.go
@@ -281,17 +281,37 @@ func newUUID() string {
 		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16])
 }
 
-// DownloadMedia downloads a file from the WeChat CDN using the given CDNMedia reference.
-// If FullURL is set, it uses that directly. Otherwise constructs the URL from EncryptQueryParam.
+// DownloadMedia downloads and decrypts a file from the WeChat CDN using the
+// given CDNMedia reference. iLink media is always AES-128-ECB encrypted on
+// the CDN; the plaintext bytes are returned.
 func (c *Client) DownloadMedia(ctx context.Context, media *CDNMedia) ([]byte, error) {
 	if media == nil {
 		return nil, fmt.Errorf("nil CDN media")
 	}
-	if media.FullURL != "" {
-		return c.downloadRaw(ctx, media.FullURL)
+	if media.AESKey == "" {
+		return nil, fmt.Errorf("CDN media missing aes_key")
 	}
-	url := fmt.Sprintf("%s/downloadfile?%s", CDNBaseURL, media.EncryptQueryParam)
-	return c.downloadRaw(ctx, url)
+	key, err := DecodeAESKey(media.AESKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode aes_key: %w", err)
+	}
+
+	var url string
+	if media.FullURL != "" {
+		url = media.FullURL
+	} else {
+		url = fmt.Sprintf("%s/downloadfile?%s", CDNBaseURL, media.EncryptQueryParam)
+	}
+	ciphertext, err := c.downloadRaw(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext, err := DecryptAESECB(ciphertext, key)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt media: %w", err)
+	}
+	return plaintext, nil
 }
 
 func (c *Client) downloadRaw(ctx context.Context, url string) ([]byte, error) {

--- a/internal/channel/adapters/weixin/ilink/protocol_download_test.go
+++ b/internal/channel/adapters/weixin/ilink/protocol_download_test.go
@@ -1,0 +1,93 @@
+package ilink
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDownloadMedia_DecryptsPlaintext(t *testing.T) {
+	plaintext := []byte("hello from wechat file")
+	key, err := GenerateAESKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	ciphertext, err := EncryptAESECB(plaintext, key)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/downloadfile" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Write(ciphertext)
+	}))
+	defer ts.Close()
+
+	c := NewClient()
+	CDNBaseURL = ts.URL
+	defer func() { CDNBaseURL = "https://novac2c.cdn.weixin.qq.com/c2c" }()
+
+	got, err := c.DownloadMedia(context.Background(), &CDNMedia{
+		EncryptQueryParam: "p=1",
+		AESKey:            EncodeAESKeyBase64(key),
+	})
+	if err != nil {
+		t.Fatalf("DownloadMedia error: %v", err)
+	}
+	if string(got) != string(plaintext) {
+		t.Errorf("got %q, want %q", got, plaintext)
+	}
+}
+
+func TestDownloadMedia_UsesFullURL(t *testing.T) {
+	plaintext := []byte("full url payload")
+	key, err := GenerateAESKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	ciphertext, err := EncryptAESECB(plaintext, key)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(ciphertext)
+	}))
+	defer ts.Close()
+
+	c := NewClient()
+	got, err := c.DownloadMedia(context.Background(), &CDNMedia{
+		FullURL: ts.URL,
+		AESKey:  EncodeAESKeyBase64(key),
+	})
+	if err != nil {
+		t.Fatalf("DownloadMedia error: %v", err)
+	}
+	if string(got) != string(plaintext) {
+		t.Errorf("got %q, want %q", got, plaintext)
+	}
+}
+
+func TestDownloadMedia_MissingAESKey(t *testing.T) {
+	c := NewClient()
+	_, err := c.DownloadMedia(context.Background(), &CDNMedia{
+		EncryptQueryParam: "p=1",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing aes_key")
+	}
+}
+
+func TestDownloadMedia_InvalidAESKey(t *testing.T) {
+	c := NewClient()
+	_, err := c.DownloadMedia(context.Background(), &CDNMedia{
+		EncryptQueryParam: "p=1",
+		AESKey:            "not-a-key",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid aes_key")
+	}
+}


### PR DESCRIPTION
WeChat iLink stores media on the CDN encrypted with AES-128-ECB.

### Problem
DownloadMedia previously returned the raw ciphertext, so inbound files and images from WeChat were saved to disk as undecryptable binary blobs. For example, a received PDF was written as encrypted data and could not be opened.

### Fix
- Decode media.AESKey and decrypt the CDN payload with AES-128-ECB before returning it.
- Return an error when AESKey is missing instead of silently writing encrypted garbage.

### Tests
- Added protocol_download_test.go covering normal download/decrypt, FullURL path, missing AESKey, and invalid AESKey.

### Notes
- No new third-party dependencies.
- make test passes.