### PR TITLE
ci: add svelte-check job to Go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,6 +17,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  svelte-check:
+    name: Svelte Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+      - name: Install web dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Run svelte-check
+        working-directory: web
+        run: npx svelte-check --tsconfig ./tsconfig.json
+
   test:
     name: Go ${{ matrix.go }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Adds a standalone **Svelte Check** job to the existing Go workflow so TypeScript type drift in the web frontend is caught in CI.

## Why
After fixing 17 pre-existing TypeScript errors in #792, we want to keep `svelte-check` green on every PR.

## What changed
- Added a `svelte-check` job to `.github/workflows/go.yml`.
- Uses Node 22 with npm caching keyed on `web/package-lock.json`.
- Runs `npm ci` and `npx svelte-check --tsconfig ./tsconfig.json` inside the `web/` directory.
- Kept independent of the Go matrix so it runs once on Ubuntu.

## Verification
- `go vet ./...` passes.
- `make test` passes (`go test -race ./...`).
- No new third-party dependencies.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
