### PR TITLE
fix(agent): exempt observation tools from duplicate-tool-call stuck detector

### DIFF
--- a/dev-docs/terminal-tools.md
+++ b/dev-docs/terminal-tools.md
@@ -139,6 +139,14 @@ non-advancing snapshot.
 The model's concurrency is **process-parallel, turn-serial**: many background
 processes run at once, but the agent loop still takes one turn at a time.
 
+### Loop detection exemption
+
+`terminal_output` and `terminal_list` are exempt from the agent loop's
+duplicate-tool-call "stuck" detector. Repeatedly checking on the same background
+process is normal wait behaviour, and the loop should not stop the turn just
+because the model asked for another progress snapshot. The tools themselves still
+enforce their own anti-polling limits (see `background.go`).
+
 - `BackgroundManager` is a `map[id]*bgProcess` with two goroutines per process
   (reader + waiter), so N `run_in_background` launches run concurrently. The
   agent fires several off, continues other work, and reacts to each completion

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -263,11 +263,24 @@ func fingerprintToolUseBlock(b ContentBlock) toolCallFingerprint {
 	}
 }
 
+// observationToolNames are tools whose only purpose is to inspect state
+// started by earlier work (background process output, running process list).
+// Repeating them while waiting for a long-running process is normal behaviour,
+// not a stuck loop, so the stuck detector ignores them when fingerprinting a
+// batch. The tools themselves still have their own anti-polling guards.
+var observationToolNames = map[string]bool{
+	"terminal_output": true,
+	"terminal_list":   true,
+}
+
 // fingerprintToolUseBatch hashes an ordered slice of tool_use blocks.
+// Observation-only tools are omitted from the fingerprint so that repeatedly
+// checking on a background process (e.g. terminal_output on the same id)
+// does not trip the duplicate-tool-call loop detector.
 func fingerprintToolUseBatch(blocks []ContentBlock) []toolCallFingerprint {
 	out := make([]toolCallFingerprint, 0, len(blocks))
 	for _, b := range blocks {
-		if b.Type == "tool_use" {
+		if b.Type == "tool_use" && !observationToolNames[b.Name] {
 			out = append(out, fingerprintToolUseBlock(b))
 		}
 	}
@@ -812,17 +825,23 @@ func (a *Agent) runLoop(
 			// stuck in a loop with no progress. Detect this early and stop
 			// gracefully so the caller can intervene instead of burning the
 			// full turn budget.
+			//
+			// Observation-only tools such as terminal_output are exempt: repeatedly
+			// checking on a long-running background process is expected behaviour,
+			// not a loop. Those tools still enforce their own anti-polling limits.
 			const stuckWindow = 4 // require 4 consecutive repeats (5 identical batches total)
 			fp := fingerprintToolUseBatch(reply.Blocks)
-			if hasConsecutiveDuplicates(a.recentToolCalls, fp, stuckWindow) {
+			if len(fp) > 0 && hasConsecutiveDuplicates(a.recentToolCalls, fp, stuckWindow) {
 				return a.budgetStop(handler, StopReasonStuck,
 					"[octo] Stopped: detected repeated tool calls without progress. "+
 						"The model appears to be stuck in a loop. "+
 						"Send another message to continue with a different approach.")
 			}
-			a.recentToolCalls = append(a.recentToolCalls, fp)
-			if len(a.recentToolCalls) > stuckWindow+1 {
-				a.recentToolCalls = a.recentToolCalls[len(a.recentToolCalls)-stuckWindow-1:]
+			if len(fp) > 0 {
+				a.recentToolCalls = append(a.recentToolCalls, fp)
+				if len(a.recentToolCalls) > stuckWindow+1 {
+					a.recentToolCalls = a.recentToolCalls[len(a.recentToolCalls)-stuckWindow-1:]
+				}
 			}
 
 			// Emit EventToolStarted before dispatch so observers see the

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -556,6 +556,36 @@ func TestAgent_Run_DuplicateToolCalls_StopsGracefully(t *testing.T) {
 	}
 }
 
+func TestAgent_Run_RepeatedTerminalOutput_DoesNotStop(t *testing.T) {
+	// Repeatedly checking the same background process with terminal_output is
+	// normal wait behaviour, not a stuck loop. The stuck detector must not fire
+	// just because the model polls for progress.
+	replies := []Reply{
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c1", "terminal_output", map[string]any{"id": "bg_1"})}},
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c2", "terminal_output", map[string]any{"id": "bg_1"})}},
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c3", "terminal_output", map[string]any{"id": "bg_1"})}},
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c4", "terminal_output", map[string]any{"id": "bg_1"})}},
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c5", "terminal_output", map[string]any{"id": "bg_1"})}},
+		{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock("c6", "terminal_output", map[string]any{"id": "bg_1"})}},
+		{Content: "done", StopReason: "end_turn"},
+	}
+	send := &fakeToolSender{replies: replies}
+	exec := &fakeExecutor{}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "terminal_output"}}
+
+	reply, err := a.Run(context.Background(), "go", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", reply.StopReason)
+	}
+	if send.calls != 7 {
+		t.Errorf("provider calls = %d, want 7 (stuck detector should not stop early)", send.calls)
+	}
+}
+
 func TestAgent_Run_StuckDetector_ResetsPerUserTurn(t *testing.T) {
 	// A new user turn ("continue") must give the model a fresh stuck-detector
 	// window. Without the per-turn reset the prior turn's fingerprints linger,


### PR DESCRIPTION
## Problem

When a long-running background process is launched with , the model often polls  to check progress. Because each  call has identical arguments, the agent loop's duplicate-tool-call "stuck" detector treats it as an infinite loop and stops the turn after 5 identical batches.

## Change

Exclude read-only observation tools (, ) from the stuck-detector fingerprint. Repeatedly checking on the same background process is normal wait behaviour, not a stuck loop. The tools still enforce their own anti-polling limits in .

- : add , skip them in ; only append/check fingerprints when non-empty.
- : add .
- : document the loop-detection exemption.

## Testing

-  passes.
- go test -race  -tags='' ./...
ok  	github.com/Leihb/octo-agent/cmd/octo	(cached)
ok  	github.com/Leihb/octo-agent/cmd/octo-eval	(cached)
ok  	github.com/Leihb/octo-agent/internal/agent	(cached)
ok  	github.com/Leihb/octo-agent/internal/app	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/dingtalk	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/discord	(cached)
?   	github.com/Leihb/octo-agent/internal/channel/adapters/feishu	[no test files]
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/telegram	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/wecom	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	(cached)
ok  	github.com/Leihb/octo-agent/internal/config	(cached)
ok  	github.com/Leihb/octo-agent/internal/eval	(cached)
ok  	github.com/Leihb/octo-agent/internal/hooks	(cached)
ok  	github.com/Leihb/octo-agent/internal/mcp	(cached)
ok  	github.com/Leihb/octo-agent/internal/memory	(cached)
ok  	github.com/Leihb/octo-agent/internal/permission	(cached)
ok  	github.com/Leihb/octo-agent/internal/prompt	(cached)
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/openai	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/retry	(cached)
ok  	github.com/Leihb/octo-agent/internal/sandbox	(cached)
ok  	github.com/Leihb/octo-agent/internal/scheduler	(cached)
ok  	github.com/Leihb/octo-agent/internal/server	(cached)
ok  	github.com/Leihb/octo-agent/internal/skills	(cached)
ok  	github.com/Leihb/octo-agent/internal/tasks	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools/rgembed	(cached)
ok  	github.com/Leihb/octo-agent/internal/trash	(cached)
ok  	github.com/Leihb/octo-agent/internal/tui	(cached)
ok  	github.com/Leihb/octo-agent/internal/upgrade	(cached)
ok  	github.com/Leihb/octo-agent/internal/version	(cached)
ok  	github.com/Leihb/octo-agent/internal/workflow	(cached) (ok  	github.com/Leihb/octo-agent/cmd/octo	(cached)
ok  	github.com/Leihb/octo-agent/cmd/octo-eval	(cached)
ok  	github.com/Leihb/octo-agent/internal/agent	(cached)
ok  	github.com/Leihb/octo-agent/internal/app	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/dingtalk	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/discord	(cached)
?   	github.com/Leihb/octo-agent/internal/channel/adapters/feishu	[no test files]
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/telegram	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/wecom	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	(cached)
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	(cached)
ok  	github.com/Leihb/octo-agent/internal/config	(cached)
ok  	github.com/Leihb/octo-agent/internal/eval	(cached)
ok  	github.com/Leihb/octo-agent/internal/hooks	(cached)
ok  	github.com/Leihb/octo-agent/internal/mcp	(cached)
ok  	github.com/Leihb/octo-agent/internal/memory	(cached)
ok  	github.com/Leihb/octo-agent/internal/permission	(cached)
ok  	github.com/Leihb/octo-agent/internal/prompt	(cached)
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/openai	(cached)
ok  	github.com/Leihb/octo-agent/internal/provider/retry	(cached)
ok  	github.com/Leihb/octo-agent/internal/sandbox	(cached)
ok  	github.com/Leihb/octo-agent/internal/scheduler	(cached)
ok  	github.com/Leihb/octo-agent/internal/server	(cached)
ok  	github.com/Leihb/octo-agent/internal/skills	(cached)
ok  	github.com/Leihb/octo-agent/internal/tasks	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools	(cached)
ok  	github.com/Leihb/octo-agent/internal/tools/rgembed	(cached)
ok  	github.com/Leihb/octo-agent/internal/trash	(cached)
ok  	github.com/Leihb/octo-agent/internal/tui	(cached)
ok  	github.com/Leihb/octo-agent/internal/upgrade	(cached)
ok  	github.com/Leihb/octo-agent/internal/version	(cached)
ok  	github.com/Leihb/octo-agent/internal/workflow	(cached)) passes.

Closes #793