### PR TITLE
fix(test): drain turn goroutines in mustServer (Windows flake class)

### DIFF
--- a/internal/server/attachments_test.go
+++ b/internal/server/attachments_test.go
@@ -256,21 +256,10 @@ drain:
 		t.Error("history_user_message carried no /api/uploads/ image ref")
 	}
 
-	// The "complete" event is broadcast from inside runAgentTurnLoop, but the
-	// turn runs in a goroutine (handleWSUserMessage) whose deferred teardown —
-	// and any trailing session persist — finishes slightly later. Wait for the
-	// turn flag to clear so the session file is fully written and its handle
-	// closed before t.TempDir() cleanup runs; otherwise Windows refuses to
-	// RemoveAll a sessions dir whose file is still open ("directory is not
-	// empty").
-	waitFor(t, func() bool {
-		mu := srv.sessionTurnLock(sess.ID)
-		mu.Lock()
-		defer mu.Unlock()
-		return !srv.turnRunning[sess.ID]
-	})
-
 	// The persisted session must carry the image block with its file path.
+	// doAgentTurn persists the turn before broadcasting "complete", so the
+	// session is on disk by the time the drain above returns. (mustServer's
+	// cleanup drains the turn goroutine before TempDir teardown.)
 	loaded, err := agent.LoadSession(sess.ID)
 	if err != nil {
 		t.Fatalf("reload: %v", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -304,6 +304,32 @@ func mustServer(t *testing.T, cfg Config) *Server {
 	srv.registerRoutes()
 	// Wrap with CORS middleware so tests that exercise CORS hit the right layer.
 	srv.http = &http.Server{Handler: srv.corsMiddleware(srv.mux)}
+
+	// Drain in-flight turn goroutines before the test's t.TempDir()/t.Setenv()
+	// cleanups run. A WS turn (runAgentTurnLoop) persists the session and its
+	// fire-and-forget title goroutine writes the session file again — both can
+	// outlive the "complete" event a test waits on. If one is still writing
+	// when t.TempDir() runs RemoveAll, POSIX unlinks the open file fine but
+	// Windows refuses ("the directory is not empty"); a goroutine leaked past
+	// one test also corrupts the next test's session state. The turn loop is
+	// tracked by the drain gate (begin/end in runAgentTurnLoop); the title
+	// goroutine by titlePending. Restart tests that call drain.begin() to
+	// simulate a stuck turn already call end()/Restart() before returning, so
+	// this never blocks. With stub senders every goroutine finishes in
+	// milliseconds; the timeouts are just a backstop.
+	t.Cleanup(func() {
+		srv.drain.drain(10 * time.Second)
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			srv.titleMu.Lock()
+			pending := len(srv.titlePending)
+			srv.titleMu.Unlock()
+			if pending == 0 {
+				return
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	})
 	return srv
 }
 


### PR DESCRIPTION
Follow-up to the one-off patch in #786: fix the **whole class** of `internal/server` Windows flakes in one place instead of per-test.

## The class
Two distinct symptoms, one root cause — a server background goroutine outliving the test body:
- `TestHandleWSUserMessage_ImageOnly`: `t.TempDir()` `RemoveAll` → "the directory is not empty" (a turn or its title goroutine still writing the session file; Windows won't unlink an open file).
- `TestHandleChannelMessage_PersistsTurn`: "restored history has 0 messages" (a goroutine leaked from a *prior* test perturbed shared session state).

## Fix
`mustServer` now registers a `t.Cleanup` that drains in-flight turn goroutines before the test's `t.TempDir()`/`t.Setenv()` cleanups run:
- **turn loop** → waited via the existing **drain gate** (`begin`/`end` in `runAgentTurnLoop`),
- **title goroutine** → waited via **`titlePending`** (released after the title `SetTitle` persist).

Both reads are race-safe (`drain`'s mutex; `titleMu`) and bounded (10s backstop; stub-sender goroutines finish in ms). Restart tests that call `drain.begin()` to simulate a stuck turn already `end()`/`Restart()` before returning, so the cleanup never blocks.

Also **reverts #786's per-test `waitFor`** — `doAgentTurn` persists the turn *before* broadcasting `complete`, so the in-body assertion needs no wait, and teardown is now central.

## Verified
- Targeted tests + `TestRestart*` with `-race -count=3`: pass.
- Full `internal/server` with `-race`: pass in ~9s, no added delay, no hang.
- gofmt + vet clean.