### PR TITLE
feat(windows): installer auto-starts server + opens onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ in each release verifies the download.
 **Windows (double-click installer).** Download `octo-setup.exe` from the
 [latest release](https://github.com/Leihb/octo-agent/releases/latest) and
 double-click it. It installs per-user (no administrator prompt), puts `octo` on
-your `PATH`, and adds a Start-menu entry; open a **new** terminal afterward and
-run `octo`. The installer is not yet code-signed, so Windows SmartScreen shows
-"Windows protected your PC" on first launch — click **More info → Run anyway**.
+your `PATH`, and adds a Start-menu entry. When it finishes it starts the local
+server in the background (`octo serve -d`) and opens
+<http://127.0.0.1:8080> — a loopback address, so no access key is needed — to
+walk you through first-run onboarding (pick a provider, paste a key). For a
+terminal session afterward, open a **new** terminal and run `octo`. The
+installer is not yet code-signed, so Windows SmartScreen shows "Windows
+protected your PC" on first launch — click **More info → Run anyway**.
 Uninstall from "Add or remove programs" like any other app.
 
 **Upgrading:** `octo upgrade` installs the latest release in place (SHA-256

--- a/cmd/octo/serve_daemon.go
+++ b/cmd/octo/serve_daemon.go
@@ -3,11 +3,17 @@ package main
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+// daemonReadyTimeout bounds how long startDaemon waits for the spawned server
+// to begin accepting connections before it returns anyway.
+const daemonReadyTimeout = 15 * time.Second
 
 // daemonPidFile returns the path of the daemon PID file, creating ~/.octo if needed.
 func daemonPidFile() (string, error) {
@@ -54,7 +60,10 @@ func writePidFile(path string, pid int) error {
 }
 
 // startDaemon re-execs the current binary as a detached background process,
-// writes its PID, and returns immediately. serveArgs must not contain -d/--daemon.
+// writes its PID, and waits (up to daemonReadyTimeout) for it to start
+// accepting connections so callers — the Windows installer's post-install
+// launch, a shell one-liner — can open the dashboard the moment this returns.
+// serveArgs must not contain -d/--daemon.
 func startDaemon(serveArgs []string, stdout, stderr io.Writer) int {
 	pidFile, err := daemonPidFile()
 	if err != nil {
@@ -110,9 +119,68 @@ func startDaemon(serveArgs []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	fmt.Fprintf(stdout, "octo serve daemon started (pid %d)\n", pid)
+	// Wait for the server to bind so a caller that opens the dashboard right
+	// after this returns doesn't hit a not-yet-listening port. A bind failure
+	// (e.g. port in use) shows up as the child exiting during the wait.
+	addr := daemonDialAddr(serveArgs)
+	if waitDaemonReady(addr, pid, daemonReadyTimeout) {
+		fmt.Fprintf(stdout, "octo serve daemon started (pid %d), ready at http://%s\n", pid, addr)
+	} else if !isProcessAlive(pid) {
+		fmt.Fprintf(stderr, "octo serve: daemon exited during startup; see %s\n", logPath)
+		_ = os.Remove(pidFile)
+		return 1
+	} else {
+		fmt.Fprintf(stdout, "octo serve daemon started (pid %d); not yet accepting connections — check %s\n", pid, logPath)
+	}
 	fmt.Fprintf(stdout, "logs: %s\n", logPath)
 	return 0
+}
+
+// daemonDialAddr derives a loopback-dialable host:port from the serve --addr
+// flag (default 127.0.0.1:8080). A wildcard or empty host is dialed on
+// 127.0.0.1 — the server always listens there too.
+func daemonDialAddr(serveArgs []string) string {
+	addr := "127.0.0.1:8080"
+	for i, a := range serveArgs {
+		switch {
+		case a == "-addr" || a == "--addr":
+			if i+1 < len(serveArgs) {
+				addr = serveArgs[i+1]
+			}
+		case strings.HasPrefix(a, "-addr="):
+			addr = strings.TrimPrefix(a, "-addr=")
+		case strings.HasPrefix(a, "--addr="):
+			addr = strings.TrimPrefix(a, "--addr=")
+		}
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	switch host {
+	case "", "0.0.0.0", "::", "[::]":
+		host = "127.0.0.1"
+	}
+	return net.JoinHostPort(host, port)
+}
+
+// waitDaemonReady blocks until the daemon accepts a TCP connection on addr, the
+// child process dies, or timeout elapses. Returns true once a connection
+// succeeds.
+func waitDaemonReady(addr string, pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return true
+		}
+		if !isProcessAlive(pid) {
+			return false
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	return false
 }
 
 // stopDaemon reads the PID file and terminates the daemon process.

--- a/cmd/octo/serve_daemon_test.go
+++ b/cmd/octo/serve_daemon_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+func TestDaemonDialAddr(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"default", nil, "127.0.0.1:8080"},
+		{"separate flag", []string{"-addr", "127.0.0.1:3000"}, "127.0.0.1:3000"},
+		{"long separate flag", []string{"--addr", "127.0.0.1:3000"}, "127.0.0.1:3000"},
+		{"equals form", []string{"-addr=127.0.0.1:9000"}, "127.0.0.1:9000"},
+		{"long equals form", []string{"--addr=127.0.0.1:9000"}, "127.0.0.1:9000"},
+		{"wildcard host dialed on loopback", []string{"-addr", ":8080"}, "127.0.0.1:8080"},
+		{"0.0.0.0 dialed on loopback", []string{"-addr", "0.0.0.0:8081"}, "127.0.0.1:8081"},
+		{"ipv6 wildcard dialed on loopback", []string{"-addr", "[::]:8082"}, "127.0.0.1:8082"},
+		{"other flags ignored", []string{"--no-tools", "-addr", "127.0.0.1:7000", "--cors", "*"}, "127.0.0.1:7000"},
+		{"last addr wins", []string{"-addr", "127.0.0.1:1111", "-addr", "127.0.0.1:2222"}, "127.0.0.1:2222"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := daemonDialAddr(tc.args); got != tc.want {
+				t.Errorf("daemonDialAddr(%v) = %q, want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}

--- a/dev-docs/windows-onboarding-design.md
+++ b/dev-docs/windows-onboarding-design.md
@@ -23,8 +23,11 @@ A Windows user with no dev toolchain:
 3. The installer copies `octo.exe` to `%LOCALAPPDATA%\Programs\octo`, adds that
    directory to the user `PATH`, creates a Start-menu shortcut, and registers an
    entry in "Add or remove programs". No UAC prompt.
-4. Opens a **new** terminal, types `octo`, and it runs. First run launches the
-   existing config wizard.
+4. On finish, the installer starts the server in the background
+   (`octo serve -d`, which blocks until the port is listening) and opens
+   <http://127.0.0.1:8080> — loopback, so no access key — landing the user in
+   the web UI's first-run onboarding. For a terminal session, opening a **new**
+   terminal and typing `octo` launches the existing config wizard on first run.
 5. When a task needs a tool that isn't installed, the agent already knows it's
    missing (from part A) and uses the existing `ShellEnvNote()` guidance to walk
    the user through a `winget` install — instead of discovering the gap by

--- a/packaging/windows/octo.iss
+++ b/packaging/windows/octo.iss
@@ -101,10 +101,34 @@ begin
   RegWriteExpandStringValue(HKEY_CURRENT_USER, EnvKey, 'Path', Path);
 end;
 
+// LaunchAndOpenDashboard starts the background server and opens the onboarding
+// page. `octo serve -d` blocks until the server is accepting connections (or it
+// times out), so the browser opens against a live port rather than racing the
+// bind. The dashboard binds 127.0.0.1, which is exempt from access-key auth, so
+// the page loads without a key and goes straight into first-run onboarding.
+procedure LaunchAndOpenDashboard;
+var
+  ResultCode: Integer;
+begin
+  // Start the daemon and wait for it to return (ready or timed out). Hidden so
+  // no console window flashes; the daemon itself is detached and outlives this.
+  if not Exec(ExpandConstant('{app}\octo.exe'), 'serve -d', '',
+              SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+    exit;
+  // Open the onboarding page regardless of the exact exit code — if the server
+  // is up, this lands on onboarding; if it never bound, the browser shows a
+  // connection error the user can retry, which is no worse than not opening.
+  ShellExec('open', 'http://127.0.0.1:8080', '', '', SW_SHOWNORMAL,
+            ewNoWait, ResultCode);
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if CurStep = ssPostInstall then
+  begin
     AddToPath;
+    LaunchAndOpenDashboard;
+  end;
 end;
 
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);


### PR DESCRIPTION
After `octo-setup.exe` finishes, it now starts the local server in the background and opens the dashboard, so a non-developer lands straight in first-run onboarding — no terminal, no `PATH`, no manual `octo serve`.

## Changes
- **`serve_daemon.go`** — `octo serve -d` now **waits for readiness** before returning: it polls the bind port (derived from `--addr`, default `127.0.0.1:8080`) until the server accepts a connection, the child exits, or 15s elapses. Previously it returned the instant it forked, which would race a browser-open against an unbound port. A bind failure (e.g. port in use) now surfaces as the child exiting during the wait → exit 1. New pure helpers `daemonDialAddr` / `waitDaemonReady`.
- **`packaging/windows/octo.iss`** — at `ssPostInstall`, after adding to `PATH`: `Exec` `octo serve -d` hidden + waited, then `ShellExec` opens `http://127.0.0.1:8080`. Unconditional (no checkbox), per the chosen UX. Loopback is exempt from access-key auth, so the page loads key-free into the web UI's first-run onboarding.
- **README + `dev-docs/windows-onboarding-design.md`** updated to match.

## Why readiness matters
The browser must open against a live port. `serve -d` returning only once the port is listening makes the installer's `serve -d` → open-browser chain deterministic instead of racy. It also makes `octo serve -d` a better "ready" signal generally.

## Verified
- `go build` (host) + `GOOS=windows GOARCH=amd64 go build`: ok.
- `daemonDialAddr` unit test (10 cases incl. `--addr`, `-addr=`, wildcard/`0.0.0.0`/`[::]` → loopback): pass.
- `go test ./cmd/octo/`, gofmt, vet: clean.
- The `.iss` uses standard Inno Pascal-Script (`Exec`/`ShellExec`/`ExpandConstant`); the windows-installer CI job compiles it.

Note: this auto-start is install-time only — it does not configure start-on-login (the daemon won't survive a reboot). That's a deliberate, separate scope.