### PR TITLE
feat(windows): login autostart + safe installer-upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ double-click it. It installs per-user (no administrator prompt), puts `octo` on
 your `PATH`, and adds a Start-menu entry. When it finishes it starts the local
 server in the background (`octo serve -d`) and opens
 <http://127.0.0.1:8080> — a loopback address, so no access key is needed — to
-walk you through first-run onboarding (pick a provider, paste a key). For a
-terminal session afterward, open a **new** terminal and run `octo`. The
+walk you through first-run onboarding (pick a provider, paste a key). The
+server is also registered to start on each login (a per-user `Run` entry, no
+window), so the dashboard is up after a reboot; uninstalling removes it and
+stops the daemon. For a terminal session, open a **new** terminal and run
+`octo`. The
 installer is not yet code-signed, so Windows SmartScreen shows "Windows
 protected your PC" on first launch — click **More info → Run anyway**.
 Uninstall from "Add or remove programs" like any other app.

--- a/dev-docs/windows-onboarding-design.md
+++ b/dev-docs/windows-onboarding-design.md
@@ -26,8 +26,12 @@ A Windows user with no dev toolchain:
 4. On finish, the installer starts the server in the background
    (`octo serve -d`, which blocks until the port is listening) and opens
    <http://127.0.0.1:8080> — loopback, so no access key — landing the user in
-   the web UI's first-run onboarding. For a terminal session, opening a **new**
-   terminal and typing `octo` launches the existing config wizard on first run.
+   the web UI's first-run onboarding. It also registers a per-user HKCU `Run`
+   entry that re-launches the daemon on each login via a hidden `.vbs`
+   (windowless `octo serve -d`), so the dashboard survives a reboot; uninstall
+   stops the daemon and removes both the `Run` entry and the script. For a
+   terminal session, opening a **new** terminal and typing `octo` launches the
+   existing config wizard on first run.
 5. When a task needs a tool that isn't installed, the agent already knows it's
    missing (from part A) and uses the existing `ShellEnvNote()` guidance to walk
    the user through a `winget` install — instead of discovering the gap by

--- a/packaging/windows/octo.iss
+++ b/packaging/windows/octo.iss
@@ -52,6 +52,16 @@ Name: "{userprograms}\octo"; Filename: "{cmd}"; \
   Parameters: "/k ""{app}\octo.exe"" chat"; WorkingDir: "{userdocs}"; \
   Comment: "Start an octo session"
 
+[Registry]
+; Start the background server on each login. Per-user (HKCU — no admin, no
+; UAC), matching the per-user install. The value runs a hidden .vbs launcher
+; (written in [Code]) so `octo serve -d` starts with no console window on the
+; desktop. uninsdeletevalue removes the entry on uninstall.
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; \
+  ValueType: string; ValueName: "octo"; \
+  ValueData: "wscript.exe //B //Nologo ""{app}\octo-autostart.vbs"""; \
+  Flags: uninsdeletevalue
+
 [Code]
 const
   EnvKey = 'Environment';
@@ -122,17 +132,59 @@ begin
             ewNoWait, ResultCode);
 end;
 
-procedure CurStepChanged(CurStep: TSetupStep);
+// WriteAutostartScript drops a tiny VBScript beside octo.exe that launches
+// `octo serve -d` with a hidden window (WScript.Shell.Run window style 0). The
+// HKCU Run entry invokes it on each login, so the daemon returns after a reboot
+// with no console window flashing on the desktop. `octo serve -d` refuses to
+// start a second daemon, so a login while one is already running is a no-op.
+// The exe path is baked in (quoted) to survive a username with spaces.
+procedure WriteAutostartScript;
+var
+  Vbs: string;
 begin
+  Vbs :=
+    'Set sh = CreateObject("WScript.Shell")' + #13#10 +
+    'exe = "' + ExpandConstant('{app}\octo.exe') + '"' + #13#10 +
+    'sh.Run """" & exe & """ serve -d", 0, False' + #13#10;
+  SaveStringToFile(ExpandConstant('{app}\octo-autostart.vbs'), Vbs, False);
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  ResultCode: Integer;
+begin
+  // Before overwriting files on an in-place upgrade, stop a running daemon —
+  // install-time launch and the login Run entry mean octo.exe is very likely
+  // running, and Windows can't replace an in-use image. Harmless no-op on a
+  // first install (no octo.exe yet). ssPostInstall then starts the new build.
+  if CurStep = ssInstall then
+  begin
+    if FileExists(ExpandConstant('{app}\octo.exe')) then
+      Exec(ExpandConstant('{app}\octo.exe'), 'serve --stop', '',
+           SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  end;
+
   if CurStep = ssPostInstall then
   begin
     AddToPath;
+    WriteAutostartScript;
     LaunchAndOpenDashboard;
   end;
 end;
 
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  ResultCode: Integer;
 begin
   if CurUninstallStep = usUninstall then
+  begin
+    // Stop the running daemon first so its octo.exe isn't locked when the
+    // uninstaller removes it (Windows can't delete an in-use image).
+    Exec(ExpandConstant('{app}\octo.exe'), 'serve --stop', '',
+         SW_HIDE, ewWaitUntilTerminated, ResultCode);
     RemoveFromPath;
+    // Remove the launcher we wrote at install time; it isn't in the [Files]
+    // log, so the uninstaller won't clean it up on its own.
+    DeleteFile(ExpandConstant('{app}\octo-autostart.vbs'));
+  end;
 end;


### PR DESCRIPTION
Follow-up to #798. Install-time launch died on reboot; this adds per-user login autostart and makes re-running the installer a clean in-place upgrade.

## Changes (all in `packaging/windows/octo.iss`)
- **Login autostart** — an HKCU `…\Run` entry (`octo`) runs `wscript.exe //B` against a hidden `.vbs` that launches `octo serve -d` with **no console window**. Per-user, no admin. `serve -d` refuses a second daemon, so a login while one is already running is a no-op. Removed on uninstall (`uninsdeletevalue` + explicit `.vbs` delete).
- **Safe in-place upgrade** — at `ssInstall`, stop a running daemon before files are overwritten (Windows can't replace an in-use `octo.exe`). `FileExists`-guarded → no-op on first install. `ssPostInstall` then starts the new build.
- **Clean uninstall** — stop the daemon (frees the locked image) and remove the `.vbs`.
- README + `dev-docs/windows-onboarding-design.md` updated.

## No Go change
`octo serve -d` / `octo serve --stop` already exist. The `.iss` uses standard Inno Pascal-Script (`Exec`/`ShellExec`/`SaveStringToFile`/`FileExists`); the windows-installer CI job compiles it (passed for #798).

## Interaction with `octo upgrade` (self-upgrade)
No conflict: `octo upgrade` swaps the binary in place and leaves the `Run` entry / `PATH` / `.vbs` intact (they point at the same path, so autostart keeps working with the new binary). The only wrinkle is cosmetic — Add/Remove Programs keeps showing the installer's version after a self-upgrade. Re-running the installer reconciles it (via `ignoreversion`) and now stops the daemon first so the overwrite succeeds.