### PR TITLE
feat(install): macOS/Linux install script + serve/onboard guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,27 @@ A functionality-first AI agent, distributed as a single Go binary. Speaks two na
 
 ## Install
 
-**Prebuilt binary (no Go toolchain needed).** Grab the archive for your OS/arch
-from the [latest release](https://github.com/Leihb/octo-agent/releases/latest),
-unpack it, and put `octo` on your `PATH`:
+**macOS / Linux (install script).** Detects your OS/arch, downloads the matching
+release, verifies its SHA-256, and installs `octo` to your `PATH`:
 
 ```bash
-# macOS (Apple Silicon) example — swap the asset name for your platform
-curl -sSL https://github.com/Leihb/octo-agent/releases/latest/download/octo_<version>_darwin_arm64.tar.gz | tar xz
-sudo mv octo /usr/local/bin/
-octo version
+curl -fsSL https://octo-agent.dev/install.sh | sh
 ```
 
-Archives ship for linux / darwin / windows on amd64 + arm64; `checksums.txt`
-in each release verifies the download.
+Then start the local server and onboard in your browser:
+
+```bash
+octo serve -d                  # run the local server in the background
+open http://127.0.0.1:8080     # Linux: xdg-open — opens the dashboard
+```
+
+`127.0.0.1` is loopback, so no access key is needed; the page goes straight
+into first-run onboarding (pick a provider, paste a key). Stop the server later
+with `octo serve --stop`. Prefer the terminal? Just run `octo`.
+
+Prebuilt archives (linux / darwin / windows × amd64 + arm64) and `checksums.txt`
+are on the [latest release](https://github.com/Leihb/octo-agent/releases/latest)
+if you'd rather grab one by hand.
 
 **Windows (double-click installer).** Download `octo-setup.exe` from the
 [latest release](https://github.com/Leihb/octo-agent/releases/latest) and

--- a/README_CN.md
+++ b/README_CN.md
@@ -19,18 +19,25 @@
 
 ## 安装
 
-**预编译二进制（无需 Go 工具链）。** 从 [最新 release](https://github.com/Leihb/octo-agent/releases/latest)
-下载对应 OS/架构的压缩包，解压后把 `octo` 放进 `PATH`：
+**macOS / Linux（安装脚本）。** 自动识别 OS/架构，下载对应 release，校验
+SHA-256，并把 `octo` 装进 `PATH`：
 
 ```bash
-# macOS (Apple Silicon) 示例 —— 按你的平台替换文件名
-curl -sSL https://github.com/Leihb/octo-agent/releases/latest/download/octo_<version>_darwin_arm64.tar.gz | tar xz
-sudo mv octo /usr/local/bin/
-octo version
+curl -fsSL https://octo-agent.dev/install.sh | sh
 ```
 
-提供 linux / darwin / windows × amd64 + arm64 的压缩包；每个 release 附带的
-`checksums.txt` 可校验下载完整性。
+然后启动本地服务、在浏览器里 onboard：
+
+```bash
+octo serve -d                  # 后台运行本地服务
+open http://127.0.0.1:8080     # Linux 用 xdg-open —— 打开仪表盘
+```
+
+`127.0.0.1` 是 loopback，无需 access key；页面直接进入首屏 onboarding（选
+provider、贴 key）。之后用 `octo serve --stop` 停服务。想用终端?直接跑 `octo`。
+
+想手动取包的话，linux / darwin / windows × amd64 + arm64 的压缩包和
+`checksums.txt` 都在 [最新 release](https://github.com/Leihb/octo-agent/releases/latest)。
 
 **升级：**`octo upgrade` 原地安装最新 release（SHA-256 对照 `checksums.txt`
 校验）；`octo upgrade --check` 仅比较版本。Web UI 的版本徽标提供同样的流程。

--- a/docs/index.html
+++ b/docs/index.html
@@ -130,7 +130,7 @@
       margin-top: 2rem;
       display: inline-block;
     }
-    .install-hint code {
+    .install-hint code, .install-cmd {
       font-family: "SF Mono", Menlo, Consolas, monospace;
       font-size: 0.85rem;
       background: var(--code-bg);
@@ -138,6 +138,15 @@
       padding: 0.5rem 1rem;
       border-radius: var(--radius-sm);
       border: 1px solid var(--border);
+    }
+    .install-cmd {
+      margin: 0;
+      padding: 0.75rem 1.1rem;
+      text-align: left;
+      white-space: pre;
+      overflow-x: auto;
+      line-height: 1.7;
+      max-width: 100%;
     }
 
     /* Layout */
@@ -402,8 +411,8 @@
       <p class="all-builds">
         <a href="https://github.com/Leihb/octo-agent/releases/latest" data-en="Other platforms &amp; checksums →" data-zh="其他平台与校验和 →"></a>
       </p>
-      <div class="install-hint">
-        <code>go install github.com/Leihb/octo-agent/cmd/octo@latest</code>
+      <div class="install-hint" id="install-block">
+        <pre class="install-cmd" id="install-cmd">curl -fsSL https://octo-agent.dev/install.sh | sh</pre>
       </div>
     </div>
   </header>
@@ -630,39 +639,53 @@ echo <span class="arg">"Summarise the last commit"</span> | <span class="cmd">oc
     // fallback href — the releases page — so they always work.
     (function initDownload() {
       var btns = document.querySelectorAll('.js-download');
-      if (!btns.length) return;
+      var block = document.getElementById('install-block');
+      var cmd = document.getElementById('install-cmd');
 
       var ua = navigator.userAgent || '';
       var plat = (navigator.platform || '') + ' ' + ua;
       var arch = /arm64|aarch64/i.test(ua) ? 'arm64' : 'amd64';
       var target = null;
       if (/Win/i.test(plat)) target = { os: 'windows' };
-      else if (/Mac/i.test(plat)) target = { os: 'darwin', arch: 'arm64' }; // modern Macs; Intel users use "Other platforms"
+      else if (/Mac/i.test(plat)) target = { os: 'darwin' };
       else if (/Linux|X11/i.test(plat) && !/Android/i.test(ua)) target = { os: 'linux', arch: arch };
-      if (!target) return;
 
-      var labels = {
-        windows: { en: '⬇️ Download for Windows', zh: '⬇️ 下载 Windows 安装器' },
-        darwin:  { en: '⬇️ Download for macOS',   zh: '⬇️ 下载 macOS 版' },
-        linux:   { en: '⬇️ Download for Linux',   zh: '⬇️ 下载 Linux 版' }
-      };
-      var matches = target.os === 'windows'
-        ? function (n) { return n === 'octo-setup.exe'; }
-        : function (n) { return n.indexOf('_' + target.os + '_' + target.arch) !== -1 && /\.(tar\.gz|zip)$/i.test(n); };
+      // macOS / Linux: lead with the install script and the steps to start the
+      // server — these platforms have no auto-starting installer, so the user
+      // runs `octo serve -d` and opens the dashboard themselves.
+      if (target && (target.os === 'darwin' || target.os === 'linux')) {
+        var opener = target.os === 'darwin' ? 'open    ' : 'xdg-open';
+        if (cmd) {
+          cmd.textContent =
+            'curl -fsSL https://octo-agent.dev/install.sh | sh\n' +
+            'octo serve -d                       # start the local server\n' +
+            opener + ' http://127.0.0.1:8080      # open the dashboard, then onboard';
+        }
+        btns.forEach(function (b) { b.style.display = 'none'; });
+        return;
+      }
 
+      // Windows: the Download button is the installer, which starts the server
+      // and opens the dashboard itself — so hide the command box.
+      if (target && target.os === 'windows' && block) block.style.display = 'none';
+
+      // Unknown OS: leave the releases-page button and the curl one-liner both
+      // visible so every visitor has a working path.
+      if (!btns.length || !target) return;
+
+      // Windows: point the Download buttons straight at the installer asset.
       fetch('https://api.github.com/repos/Leihb/octo-agent/releases/latest', {
         headers: { 'Accept': 'application/vnd.github+json' }
       }).then(function (r) {
         if (!r.ok) throw new Error('release lookup failed');
         return r.json();
       }).then(function (data) {
-        var asset = (data.assets || []).filter(function (a) { return matches(a.name); })[0];
+        var asset = (data.assets || []).filter(function (a) { return a.name === 'octo-setup.exe'; })[0];
         if (!asset) return;
-        var lbl = labels[target.os];
         btns.forEach(function (b) {
           b.setAttribute('href', asset.browser_download_url);
-          b.setAttribute('data-en', lbl.en);
-          b.setAttribute('data-zh', lbl.zh);
+          b.setAttribute('data-en', '⬇️ Download for Windows');
+          b.setAttribute('data-zh', '⬇️ 下载 Windows 安装器');
         });
         applyLang(currentLang);
       }).catch(function () { /* keep the releases-page fallback */ });

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+# octo installer for macOS and Linux.
+#
+#   curl -fsSL https://octo-agent.dev/install.sh | sh
+#
+# Detects your OS/arch, downloads the matching release archive, verifies its
+# SHA-256 against the release's checksums.txt, and installs the `octo` binary
+# to a directory on your PATH (default /usr/local/bin, else ~/.local/bin).
+#
+# Overrides (env):
+#   OCTO_INSTALL_DIR=/path   install here instead of the default
+#   OCTO_VERSION=1.2.3       install this version instead of the latest
+#
+# Windows users: download the double-click installer (octo-setup.exe) from
+# https://github.com/Leihb/octo-agent/releases/latest instead.
+
+set -eu
+
+REPO="Leihb/octo-agent"
+
+err() { printf 'octo install: %s\n' "$1" >&2; exit 1; }
+
+# --- need curl and tar -------------------------------------------------------
+command -v curl >/dev/null 2>&1 || err "curl is required"
+command -v tar  >/dev/null 2>&1 || err "tar is required"
+
+# --- detect OS ---------------------------------------------------------------
+os=$(uname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')
+case "$os" in
+  linux)  os=linux ;;
+  darwin) os=darwin ;;
+  *) err "unsupported OS '$os' — see https://github.com/$REPO/releases" ;;
+esac
+
+# --- detect arch -------------------------------------------------------------
+arch=$(uname -m 2>/dev/null)
+case "$arch" in
+  x86_64|amd64)  arch=amd64 ;;
+  arm64|aarch64) arch=arm64 ;;
+  *) err "unsupported architecture '$arch' — see https://github.com/$REPO/releases" ;;
+esac
+
+# --- resolve version ---------------------------------------------------------
+version="${OCTO_VERSION:-}"
+if [ -z "$version" ]; then
+  # Read the latest tag from the GitHub API and strip the leading "v" so it
+  # matches the goreleaser archive name ({{.Version}}, e.g. 1.0.0).
+  version=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+    | grep '"tag_name"' | head -n1 | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/')
+fi
+[ -n "$version" ] || err "could not determine the latest version"
+
+archive="octo_${version}_${os}_${arch}.tar.gz"
+base="https://github.com/$REPO/releases/download/v${version}"
+
+# --- download into a temp dir ------------------------------------------------
+tmp=$(mktemp -d 2>/dev/null || mktemp -d -t octo)
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+printf 'octo install: downloading %s\n' "$archive"
+curl -fSL "$base/$archive"     -o "$tmp/$archive"     || err "download failed: $base/$archive"
+curl -fsSL "$base/checksums.txt" -o "$tmp/checksums.txt" || err "could not fetch checksums.txt"
+
+# --- verify SHA-256 ----------------------------------------------------------
+want=$(grep " $archive\$" "$tmp/checksums.txt" | awk '{print $1}' | head -n1)
+[ -n "$want" ] || err "no checksum listed for $archive"
+if command -v sha256sum >/dev/null 2>&1; then
+  got=$(sha256sum "$tmp/$archive" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  got=$(shasum -a 256 "$tmp/$archive" | awk '{print $1}')
+else
+  err "need sha256sum or shasum to verify the download"
+fi
+[ "$got" = "$want" ] || err "checksum mismatch for $archive (expected $want, got $got)"
+
+# --- extract -----------------------------------------------------------------
+tar -xzf "$tmp/$archive" -C "$tmp" octo || err "could not extract octo from $archive"
+chmod +x "$tmp/octo"
+
+# --- choose install dir ------------------------------------------------------
+dir="${OCTO_INSTALL_DIR:-}"
+if [ -z "$dir" ]; then
+  if [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
+    dir=/usr/local/bin
+  else
+    dir="$HOME/.local/bin"
+  fi
+fi
+mkdir -p "$dir" || err "cannot create install dir $dir"
+
+# --- install -----------------------------------------------------------------
+if mv "$tmp/octo" "$dir/octo" 2>/dev/null; then
+  :
+elif command -v sudo >/dev/null 2>&1; then
+  printf 'octo install: %s is not writable; using sudo\n' "$dir"
+  sudo mv "$tmp/octo" "$dir/octo" || err "could not install to $dir"
+else
+  err "cannot write to $dir (set OCTO_INSTALL_DIR to a writable directory)"
+fi
+
+printf 'octo install: installed octo %s to %s/octo\n' "$version" "$dir"
+
+# --- PATH hint ---------------------------------------------------------------
+case ":$PATH:" in
+  *":$dir:"*) ;;
+  *) printf 'octo install: %s is not on your PATH. Add it, e.g.:\n  export PATH="%s:$PATH"\n' "$dir" "$dir" ;;
+esac
+
+# --- next steps --------------------------------------------------------------
+opencmd="open"
+[ "$os" = "linux" ] && opencmd="xdg-open"
+cat <<EOF
+
+Next steps — start the server and onboard in your browser:
+
+  octo serve -d                    # run the local server in the background
+  $opencmd http://127.0.0.1:8080   # open the dashboard → pick a provider, paste a key
+
+127.0.0.1 is loopback, so no access key is needed. Stop it later with
+\`octo serve --stop\`. Or skip the web UI and run \`octo\` for the terminal.
+EOF


### PR DESCRIPTION
Windows users get the double-click installer (auto-starts the server, opens the dashboard). macOS/Linux users are developers who'd rather `curl | sh` than download-untar-mv — and they need the post-install steps spelled out, since there's no auto-starting installer on those platforms.

## What
- **`docs/install.sh`** (served at `https://octo-agent.dev/install.sh`) — detects OS/arch, resolves the latest version via the GitHub API, downloads the matching archive, **verifies SHA-256** against `checksums.txt`, installs `octo` to `/usr/local/bin` (falls back to `~/.local/bin` with a PATH hint; `OCTO_INSTALL_DIR`/`OCTO_VERSION` overrides), then prints the next steps:
  ```
  octo serve -d                    # run the local server in the background
  open http://127.0.0.1:8080       # (xdg-open on Linux) → onboarding
  ```
- **Website** — OS-aware: Windows shows the direct **Download** button (installer); macOS/Linux hide it and show the install command **plus the `serve -d` / open-dashboard steps**; unknown OS keeps both the releases button and the curl one-liner. Bilingual labels preserved.
- **README / README_CN** — replace the manual `<version>` tarball example with the install script and spell out `octo serve -d` + `http://127.0.0.1:8080`.

## Verified
- `sh -n` clean; ran the script end to end on macOS — downloaded v1.0.0, checksum verified, installed, `octo 1.0.0 (e781bf7)` runs; PATH hint fires for a non-PATH dir.
- HTML well-formed; `data-en`/`data-zh` balanced (67/67).
- Docs-only; `docs/` is GitHub Pages with `.nojekyll`, so `install.sh` is served verbatim for `curl | sh`, and the `api.github.com` fetch is allowed (no strict CSP).

Note: `curl | sh` fetches from the project's own Pages domain and SHA-256-verifies the binary; users can read the script first at the same URL.