### PR TITLE
feat(sub-agent): richer agent-definition frontmatter + project-level agents

### DIFF
--- a/dev-docs/sub-agent-design.md
+++ b/dev-docs/sub-agent-design.md
@@ -72,8 +72,11 @@ spawn 入口(`internal/tools/agent.go`),经 spawner 注册门控——未配置 
 | `general` | 否 | 全工具,端到端处理委派任务 |
 | `code-review` | 是 | 用 `git diff` 等审查改动 |
 
-用户可在 `~/.octo/agents/*.md` 用 frontmatter(name / description / tools / read_only / model + persona
-正文)自定义 preset,`discoverAgents` 在查找前刷新,覆盖/补充内置集。
+用户可用 `*.md` 文件自定义 preset:frontmatter 支持 `description`(必填)、`tools`(白名单)、
+`disallowed_tools`(从继承集里减)、`read_only`、`model`(默认 `inherit` = 空),markdown 正文是
+persona。文件名(去掉 `.md`)是权威触发名,frontmatter 的 `name` 被忽略。发现路径有两级:用户级
+`~/.octo/agents/` 和项目级 `<repo>/.octo/agents/`,同名时**项目级覆盖用户级**。`discoverAgents` 在
+查找前刷新,覆盖/补充内置集。
 
 ## 子 agent 的隔离与构造
 
@@ -90,7 +93,7 @@ child.MaxTurns = childMaxTurns              // child 专属 loop 预算
 - **隔离点**:fresh History(子 agent 看不到父对话)、自己的 loop 预算。
 - **共享点**:Sender(一条连接)、System(同一身份,fork 时连 cache 一起共享)、Gate(同一权限——
   子 agent 不绕过权限)、计费(子 agent token 累加进父 session 总数,`/cost` 报合并数字)。
-- `req.Tools` 非空时与父 toolbelt 取交集;`req.Model` 非空时覆盖父模型。
+- `req.Tools` 非空时与父 toolbelt 取交集;`req.DisallowedTools` 从继承集里减;`req.Model` 非空时覆盖父模型。调用层传的 tools/model 优先于 preset frontmatter,preset 只补调用没指定的部分。
 - **max-turns 不是失败**:child 跑到 `childMaxTurns` 上限时,`runChild` 返回**部分 reply** +
   `StopReason="max_turns"`(而非报错)。`sub_agent` 的同步结果和异步完成通知都会把它标成
   `[INCOMPLETE]`,这样父 agent 不会把半成品当完整答案——而不是静默丢掉这个信号。

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -57,7 +57,7 @@ const childMaxTurns = 100
 // a later Continue can resume it, runs the first prompt, and returns the
 // child's id alongside its reply.
 func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
-	childTools := filterChildTools(s.toolsFn(), req.Tools, req.ReadOnly)
+	childTools := filterChildTools(s.toolsFn(), req.Tools, req.DisallowedTools, req.ReadOnly)
 
 	model := req.Model
 	if model == "" {
@@ -309,12 +309,19 @@ func (lc *liveChild) syncSession() {
 // edit_file) are dropped too — used by read-only presets so the child keeps
 // terminal/MCP/codegraph but can't change files. The two filters compose: a
 // readOnly preset still honours allowed.
-func filterChildTools(parent []agent.ToolDefinition, allowed []string, readOnly bool) []agent.ToolDefinition {
+func filterChildTools(parent []agent.ToolDefinition, allowed, disallowed []string, readOnly bool) []agent.ToolDefinition {
 	var allowSet map[string]bool
 	if len(allowed) > 0 {
 		allowSet = make(map[string]bool, len(allowed))
 		for _, a := range allowed {
 			allowSet[a] = true
+		}
+	}
+	var denySet map[string]bool
+	if len(disallowed) > 0 {
+		denySet = make(map[string]bool, len(disallowed))
+		for _, d := range disallowed {
+			denySet[d] = true
 		}
 	}
 	out := make([]agent.ToolDefinition, 0, len(parent))
@@ -326,6 +333,9 @@ func filterChildTools(parent []agent.ToolDefinition, allowed []string, readOnly 
 			continue
 		}
 		if allowSet != nil && !allowSet[td.Name] {
+			continue
+		}
+		if denySet[td.Name] {
 			continue
 		}
 		out = append(out, td)

--- a/internal/app/spawner_test.go
+++ b/internal/app/spawner_test.go
@@ -101,7 +101,7 @@ func TestAgentSpawner_AppliesToolAllowlist(t *testing.T) {
 	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return parentTools })
 
 	// Allowlist restricts to read_file + grep. sub_agent always excluded.
-	got := filterChildTools(parentTools, []string{"read_file", "grep"}, false)
+	got := filterChildTools(parentTools, []string{"read_file", "grep"}, nil, false)
 	if len(got) != 2 {
 		t.Fatalf("filtered tools len = %d, want 2: %+v", len(got), got)
 	}
@@ -111,7 +111,7 @@ func TestAgentSpawner_AppliesToolAllowlist(t *testing.T) {
 	}
 
 	// No allowlist → all parent tools minus sub_agent.
-	got = filterChildTools(parentTools, nil, false)
+	got = filterChildTools(parentTools, nil, nil, false)
 	if len(got) != 3 {
 		t.Errorf("nil allowlist should keep all non-sub_agent tools: %+v", got)
 	}
@@ -314,7 +314,7 @@ func TestFilterChildTools_DropsSendMessage(t *testing.T) {
 		{Name: "read_file"},
 		{Name: "sub_agent"},
 	}
-	got := filterChildTools(parentTools, nil, false)
+	got := filterChildTools(parentTools, nil, nil, false)
 	for _, td := range got {
 		if td.Name == "sub_agent" {
 			t.Errorf("child toolbelt must not contain %q", td.Name)
@@ -333,7 +333,7 @@ func TestFilterChildTools_ReadOnlyDropsMutators(t *testing.T) {
 		{Name: "write_file"},
 		{Name: "edit_file"},
 	}
-	got := filterChildTools(parentTools, nil, true)
+	got := filterChildTools(parentTools, nil, nil, true)
 	for _, td := range got {
 		if td.Name == "write_file" || td.Name == "edit_file" {
 			t.Errorf("read-only child must not contain %q", td.Name)
@@ -348,6 +348,36 @@ func TestFilterChildTools_ReadOnlyDropsMutators(t *testing.T) {
 		if !names[want] {
 			t.Errorf("read-only child should keep %q, got %+v", want, got)
 		}
+	}
+}
+
+func TestFilterChildTools_DisallowedSubtracted(t *testing.T) {
+	parentTools := []agent.ToolDefinition{
+		{Name: "read_file"},
+		{Name: "grep"},
+		{Name: "terminal"},
+		{Name: "write_file"},
+	}
+	// Denylist removes terminal even though it isn't a mutator and no allowlist
+	// is set; the rest survive.
+	got := filterChildTools(parentTools, nil, []string{"terminal"}, false)
+	names := map[string]bool{}
+	for _, td := range got {
+		names[td.Name] = true
+	}
+	if names["terminal"] {
+		t.Errorf("disallowed terminal must be removed: %+v", got)
+	}
+	for _, want := range []string{"read_file", "grep", "write_file"} {
+		if !names[want] {
+			t.Errorf("expected %q to survive denylist, got %+v", want, got)
+		}
+	}
+
+	// Denylist composes with an allowlist: allow read_file+grep, then deny grep.
+	got = filterChildTools(parentTools, []string{"read_file", "grep"}, []string{"grep"}, false)
+	if len(got) != 1 || got[0].Name != "read_file" {
+		t.Errorf("allow{read_file,grep} minus deny{grep} should leave read_file, got %+v", got)
 	}
 }
 

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -110,17 +110,27 @@ func (AgentTool) Execute(ctx context.Context, _ string, input map[string]any) (a
 		preset = &p
 	}
 
-	// Build the spawn request
+	// Build the spawn request. Call-level tools/model win over the preset's
+	// frontmatter defaults; the preset fills in what the call left unset.
+	callTools := stringSliceArg(input, "tools")
+	callModel := strings.TrimSpace(stringArg(input, "model"))
 	req := SpawnRequest{
 		Description: desc,
 		AgentType:   subagentType,
 		Prompt:      prompt,
-		Tools:       stringSliceArg(input, "tools"),
-		Model:       strings.TrimSpace(stringArg(input, "model")),
+		Tools:       callTools,
+		Model:       callModel,
 	}
 	if preset != nil {
 		req.SystemSuffix = preset.persona
 		req.ReadOnly = preset.readOnly
+		req.DisallowedTools = preset.disallowedTools
+		if len(callTools) == 0 {
+			req.Tools = preset.tools
+		}
+		if callModel == "" {
+			req.Model = preset.model
+		}
 	}
 
 	// Determine sync vs async

--- a/internal/tools/agent_presets.go
+++ b/internal/tools/agent_presets.go
@@ -9,6 +9,13 @@ type agentPreset struct {
 	description string
 	persona     string
 	readOnly    bool
+	// tools, when non-empty, is the agent's tool allowlist (frontmatter
+	// `tools`). disallowedTools (frontmatter `disallowed_tools`) is subtracted
+	// from the inherited set. model (frontmatter `model`, default "inherit")
+	// pins the child's model; empty means inherit the parent's.
+	tools           []string
+	disallowedTools []string
+	model           string
 }
 
 // builtInPresets is the canonical set of built-in agent types. These are

--- a/internal/tools/agents.go
+++ b/internal/tools/agents.go
@@ -6,15 +6,19 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Leihb/octo-agent/internal/memory"
 	"gopkg.in/yaml.v3"
 )
 
 // agentFrontmatter is the subset of an agent definition file's YAML frontmatter
 // that we consume. Unmapped keys are ignored.
 type agentFrontmatter struct {
-	Name        string `yaml:"name"`
-	Description string `yaml:"description"`
-	ReadOnly    bool   `yaml:"read_only"`
+	Name            string   `yaml:"name"`
+	Description     string   `yaml:"description"`
+	ReadOnly        bool     `yaml:"read_only"`
+	Tools           []string `yaml:"tools"`
+	DisallowedTools []string `yaml:"disallowed_tools"`
+	Model           string   `yaml:"model"`
 }
 
 // userAgentsRoot returns ~/.octo/agents, or "" when the home dir can't be
@@ -27,6 +31,22 @@ var userAgentsRoot = func() string {
 	return filepath.Join(home, ".octo", "agents")
 }
 
+// projectAgentsRoot returns <project-root>/.octo/agents for the current working
+// directory's repository, or "" when it can't be resolved. Project-level agents
+// override user-level ones of the same name (matching .claude/agents semantics).
+// A var so tests can point it at a temp directory.
+var projectAgentsRoot = func() string {
+	cwd, err := os.Getwd()
+	if err != nil || cwd == "" {
+		return ""
+	}
+	root := memory.ProjectRoot(cwd)
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, ".octo", "agents")
+}
+
 // discoveredAgents holds the last scanned user-defined agents.
 var (
 	discoveredAgentsMu sync.RWMutex
@@ -37,7 +57,20 @@ var (
 // discoveredAgents cache. It is safe to call concurrently; callers that need
 // the freshest set call it before lookupAgentPreset.
 func discoverAgents() {
-	root := userAgentsRoot()
+	fresh := make(map[string]agentPreset)
+	// User-level first, then project-level — project entries override
+	// user-level ones of the same name.
+	for _, root := range []string{userAgentsRoot(), projectAgentsRoot()} {
+		scanAgentsRoot(root, fresh)
+	}
+	discoveredAgentsMu.Lock()
+	discoveredAgents = fresh
+	discoveredAgentsMu.Unlock()
+}
+
+// scanAgentsRoot reads *.md agent definitions from root into dst (existing keys
+// are overwritten). A missing or unreadable root is a no-op.
+func scanAgentsRoot(root string, dst map[string]agentPreset) {
 	if root == "" {
 		return
 	}
@@ -45,7 +78,6 @@ func discoverAgents() {
 	if err != nil {
 		return // missing/unreadable root: nothing to add
 	}
-	fresh := make(map[string]agentPreset, len(entries))
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -60,11 +92,8 @@ func discoverAgents() {
 		}
 		// The file name (without .md) is the authoritative trigger name.
 		p.name = strings.TrimSuffix(name, ".md")
-		fresh[p.name] = p
+		dst[p.name] = p
 	}
-	discoveredAgentsMu.Lock()
-	discoveredAgents = fresh
-	discoveredAgentsMu.Unlock()
 }
 
 // parseAgentFile reads a single agent definition markdown file. It expects YAML
@@ -87,11 +116,19 @@ func parseAgentFile(path string) (agentPreset, bool) {
 	if fm.Description == "" {
 		return agentPreset{}, false
 	}
+	// "inherit" (CC's default) means no override — treat it as empty.
+	model := strings.TrimSpace(fm.Model)
+	if strings.EqualFold(model, "inherit") {
+		model = ""
+	}
 	return agentPreset{
-		name:        "", // filled by caller from file name
-		description: fm.Description,
-		persona:     strings.TrimSpace(body),
-		readOnly:    fm.ReadOnly,
+		name:            "", // filled by caller from file name
+		description:     fm.Description,
+		persona:         strings.TrimSpace(body),
+		readOnly:        fm.ReadOnly,
+		tools:           fm.Tools,
+		disallowedTools: fm.DisallowedTools,
+		model:           model,
 	}, true
 }
 

--- a/internal/tools/agents_test.go
+++ b/internal/tools/agents_test.go
@@ -15,6 +15,14 @@ func useAgentsRoot(t *testing.T, dir string) {
 	t.Cleanup(func() { userAgentsRoot = orig })
 }
 
+// useProjectAgentsRoot points projectAgentsRoot at dir for the test's duration.
+func useProjectAgentsRoot(t *testing.T, dir string) {
+	t.Helper()
+	orig := projectAgentsRoot
+	projectAgentsRoot = func() string { return dir }
+	t.Cleanup(func() { projectAgentsRoot = orig })
+}
+
 func writeAgentFile(t *testing.T, root, name, content string) {
 	t.Helper()
 	if err := os.MkdirAll(root, 0o755); err != nil {
@@ -159,6 +167,66 @@ func TestParseAgentFile_Valid(t *testing.T) {
 	}
 	if !strings.Contains(p.persona, "Be helpful.") {
 		t.Errorf("persona = %q", p.persona)
+	}
+}
+
+func TestParseAgentFile_ToolsModelDisallowed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scoped.md")
+	content := "---\ndescription: scoped agent\ntools: [read_file, grep]\ndisallowed_tools: [terminal]\nmodel: haiku\n---\nbody"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p, ok := parseAgentFile(path)
+	if !ok {
+		t.Fatal("parseAgentFile returned false")
+	}
+	if len(p.tools) != 2 || p.tools[0] != "read_file" || p.tools[1] != "grep" {
+		t.Errorf("tools = %v", p.tools)
+	}
+	if len(p.disallowedTools) != 1 || p.disallowedTools[0] != "terminal" {
+		t.Errorf("disallowedTools = %v", p.disallowedTools)
+	}
+	if p.model != "haiku" {
+		t.Errorf("model = %q, want haiku", p.model)
+	}
+}
+
+func TestParseAgentFile_ModelInheritIsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "inh.md")
+	if err := os.WriteFile(path, []byte("---\ndescription: d\nmodel: inherit\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p, ok := parseAgentFile(path)
+	if !ok {
+		t.Fatal("parseAgentFile returned false")
+	}
+	if p.model != "" {
+		t.Errorf("model = %q, want empty (inherit)", p.model)
+	}
+}
+
+func TestDiscoverAgents_ProjectOverridesUser(t *testing.T) {
+	userRoot := t.TempDir()
+	projRoot := t.TempDir()
+	useAgentsRoot(t, userRoot)
+	useProjectAgentsRoot(t, projRoot)
+
+	writeAgentFile(t, userRoot, "helper.md", "---\ndescription: user helper\n---\nuser body")
+	writeAgentFile(t, userRoot, "useronly.md", "---\ndescription: user only\n---\nbody")
+	writeAgentFile(t, projRoot, "helper.md", "---\ndescription: project helper\n---\nproject body")
+
+	discoverAgents()
+
+	p, ok := lookupAgentPreset("helper")
+	if !ok {
+		t.Fatal("helper not discovered")
+	}
+	if p.description != "project helper" {
+		t.Errorf("description = %q, want project-level override", p.description)
+	}
+	// User-only agents are still visible.
+	if _, ok := lookupAgentPreset("useronly"); !ok {
+		t.Error("user-only agent should remain discoverable")
 	}
 }
 

--- a/internal/tools/spawner.go
+++ b/internal/tools/spawner.go
@@ -41,6 +41,10 @@ type SpawnRequest struct {
 	// recursion filter, not the tool.
 	Tools []string
 
+	// DisallowedTools is subtracted from the child's inherited tool set
+	// (frontmatter `disallowed_tools`). Applied on top of Tools/ReadOnly.
+	DisallowedTools []string
+
 	// Model, when non-empty, overrides the parent's model for this child.
 	Model string
 


### PR DESCRIPTION
## What

Brings octo's custom agent definitions closer to Claude Code's: per-agent tool scoping + model in frontmatter, and a project-level agents directory.

## Changes

- **Frontmatter fields**: `tools` (allowlist), `disallowed_tools` (subtracted from the inherited set), `model` (default `inherit` → empty = inherit parent's model). `read_only` is retained and composes with `disallowed_tools`.
- **Two-level discovery**: scans user-level `~/.octo/agents/` then project-level `<repo>/.octo/agents/`; project entries **override** user-level ones of the same name (matching `.claude/agents` semantics). Project root resolved via `memory.ProjectRoot`.
- **Precedence**: call-level `tools`/`model` on the `sub_agent` tool still win; the preset only fills in what the call left unset.
- `SpawnRequest` gains `DisallowedTools`; `filterChildTools` subtracts the denylist on top of the allowlist and read-only mutator stripping.

The model-facing `subagent_type` tool param is unchanged — these fields are for users authoring agent files.

## Tests

- `parseAgentFile` tools/disallowed_tools/model parsing + `model: inherit` → empty.
- Project-level override of a same-named user agent; user-only agents remain visible.
- `filterChildTools` denylist subtraction, and denylist composing with an allowlist.
- `go build/vet/test ./...` green, `gofmt` clean.

Design doc `dev-docs/sub-agent-design.md` updated to the accurate current state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)