### PR TITLE
feat(sub-agent): fork inherits the parent conversation

### DIFF
--- a/dev-docs/sub-agent-design.md
+++ b/dev-docs/sub-agent-design.md
@@ -90,7 +90,7 @@ child.Gate = parent.Gate                    // 续用同一权限门控
 child.MaxTurns = childMaxTurns              // child 专属 loop 预算
 ```
 
-- **隔离点**:fresh History(子 agent 看不到父对话)、自己的 loop 预算。
+- **隔离点**:自己的 loop 预算。History 视模式而定:**fork(省略 subagent_type)复制父此刻的对话**作为 child 起点(`req.ForkConversation`,`forkHistorySnapshot` 裁掉触发本次 spawn 的悬空 tool_use 回合);**带 subagent_type 的 fresh agent / workflow agent 仍是 fresh History**,看不到父对话。
 - **共享点**:Sender(一条连接)、System(同一身份,fork 时连 cache 一起共享)、Gate(同一权限——
   子 agent 不绕过权限)、计费(子 agent token 累加进父 session 总数,`/cost` 报合并数字)。
 - `req.Tools` 非空时与父 toolbelt 取交集;`req.DisallowedTools` 从继承集里减;`req.Model` 非空时覆盖父模型。调用层传的 tools/model 优先于 preset frontmatter,preset 只补调用没指定的部分。

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -83,6 +83,15 @@ func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.Spaw
 	child.LiteSender = s.parent.LiteSender
 	child.LiteModel = s.parent.LiteModel
 
+	// True fork: seed the child with the parent's conversation so far so it
+	// continues with full context. runChild then appends req.Prompt as the next
+	// user turn. The in-flight assistant turn that called sub_agent is trimmed
+	// (see forkHistorySnapshot) so the copied history doesn't end on a dangling
+	// tool_use the provider would reject.
+	if req.ForkConversation {
+		child.History.ReplaceAll(forkHistorySnapshot(s.parent.History.Snapshot()))
+	}
+
 	// Create the session dir before registering the child: a permissions
 	// failure here must abort the spawn, not leave a dead entry in the registry
 	// whose later Save() would silently fail.
@@ -309,6 +318,34 @@ func (lc *liveChild) syncSession() {
 // edit_file) are dropped too — used by read-only presets so the child keeps
 // terminal/MCP/codegraph but can't change files. The two filters compose: a
 // readOnly preset still honours allowed.
+// forkHistorySnapshot trims a parent-history snapshot for seeding a fork. The
+// parent is mid-turn: the assistant message that called sub_agent is already in
+// history, but its tool_result hasn't been produced. Copying it verbatim would
+// leave a trailing tool_use with no matching tool_result, which the provider
+// rejects. Drop trailing assistant turns carrying a tool_use so the seeded
+// history ends on a complete exchange; runChild then appends the fork prompt.
+func forkHistorySnapshot(msgs []agent.Message) []agent.Message {
+	for len(msgs) > 0 {
+		last := msgs[len(msgs)-1]
+		if last.Role == agent.RoleAssistant && messageHasToolUse(last) {
+			msgs = msgs[:len(msgs)-1]
+			continue
+		}
+		break
+	}
+	return msgs
+}
+
+// messageHasToolUse reports whether m carries any tool_use content block.
+func messageHasToolUse(m agent.Message) bool {
+	for _, b := range m.Blocks {
+		if b.Type == "tool_use" {
+			return true
+		}
+	}
+	return false
+}
+
 func filterChildTools(parent []agent.ToolDefinition, allowed, disallowed []string, readOnly bool) []agent.ToolDefinition {
 	var allowSet map[string]bool
 	if len(allowed) > 0 {

--- a/internal/app/spawner_test.go
+++ b/internal/app/spawner_test.go
@@ -403,6 +403,85 @@ func TestAgentSpawner_AppliesSystemSuffix(t *testing.T) {
 	}
 }
 
+func TestForkHistorySnapshot_TrimsTrailingToolUse(t *testing.T) {
+	toolUseTurn := agent.Message{Role: agent.RoleAssistant, Blocks: []agent.ContentBlock{
+		agent.NewToolUseBlock("tu_1", "sub_agent", map[string]any{"prompt": "go"}),
+	}}
+
+	// Trailing in-flight tool_use turn is dropped.
+	got := forkHistorySnapshot([]agent.Message{
+		agent.NewUserMessage("q"), agent.NewAssistantMessage("a"), toolUseTurn,
+	})
+	if len(got) != 2 || messageHasToolUse(got[len(got)-1]) {
+		t.Errorf("trailing tool_use not trimmed: %+v", got)
+	}
+
+	// A clean tail (no trailing tool_use) is left untouched.
+	clean := []agent.Message{agent.NewUserMessage("q"), agent.NewAssistantMessage("a")}
+	if got := forkHistorySnapshot(clean); len(got) != 2 {
+		t.Errorf("clean history should be untouched, got %+v", got)
+	}
+
+	// Empty in, empty out.
+	if got := forkHistorySnapshot(nil); len(got) != 0 {
+		t.Errorf("nil history should stay empty, got %+v", got)
+	}
+}
+
+func TestAgentSpawner_ForkSeedsConversation(t *testing.T) {
+	send := &subAgentSender{reply: "ok"}
+	parent := agent.New(send, "parent-model")
+	parent.System = "BASE"
+	parent.History.Append(agent.NewUserMessage("first question"))
+	parent.History.Append(agent.NewAssistantMessage("first answer"))
+	// In-flight turn that called sub_agent: an assistant message carrying a
+	// tool_use whose result doesn't exist yet.
+	parent.History.Append(agent.Message{Role: agent.RoleAssistant, Blocks: []agent.ContentBlock{
+		agent.NewToolUseBlock("tu_1", "sub_agent", map[string]any{"prompt": "go"}),
+	}})
+
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{Prompt: "go", ForkConversation: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs := sp.reg.m[onlyChildID(t, sp)].agent.History.Snapshot()
+	if len(msgs) < 2 || msgs[0].Content != "first question" || msgs[1].Content != "first answer" {
+		t.Fatalf("fork did not seed the parent conversation: %+v", msgs)
+	}
+	for _, m := range msgs {
+		if messageHasToolUse(m) {
+			t.Errorf("forked history must not carry the trailing tool_use turn: %+v", m)
+		}
+	}
+	foundPrompt := false
+	for _, m := range msgs {
+		if m.Role == agent.RoleUser && m.Content == "go" {
+			foundPrompt = true
+		}
+	}
+	if !foundPrompt {
+		t.Error("fork prompt should be appended after the seeded history")
+	}
+}
+
+func TestAgentSpawner_NoForkStartsFresh(t *testing.T) {
+	send := &subAgentSender{reply: "ok"}
+	parent := agent.New(send, "parent-model")
+	parent.History.Append(agent.NewUserMessage("secret parent context"))
+
+	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{Prompt: "go"}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, m := range sp.reg.m[onlyChildID(t, sp)].agent.History.Snapshot() {
+		if m.Content == "secret parent context" {
+			t.Error("non-fork child must not inherit the parent conversation")
+		}
+	}
+}
+
 // onlyChildID returns the single registered child id, failing if there isn't
 // exactly one.
 func onlyChildID(t *testing.T, sp *Spawner) string {

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -33,11 +33,12 @@ func (AgentTool) Definition() agent.ToolDefinition {
 			"Use when you need parallel investigation, a fresh context for an isolated " +
 			"sub-problem, or when the task is well-defined enough to delegate.\n\n" +
 			"Two modes:\n" +
-			"- **Fork** (omit subagent_type): the child inherits your system prompt — the " +
-			"shared harness identity (base rules, env, skills, memory) — and shares its " +
-			"prompt cache, so it's cheap. It does NOT see this conversation's messages, so " +
-			"still put everything the task needs in `prompt`. Use when the intermediate " +
-			"tool output isn't worth keeping in your context.\n" +
+			"- **Fork** (omit subagent_type): the child inherits your full conversation — your " +
+			"system prompt AND this conversation's messages so far — so it already has your " +
+			"context. Its own tool calls and output stay in its branch and never enter your " +
+			"context; only its final reply comes back. Use to offload a chunk of your own work " +
+			"(deep investigation, a focused edit) and get just the conclusion. `prompt` is the " +
+			"specific task to do now.\n" +
 			"- **Fresh agent** (set subagent_type): the child starts with zero context and a " +
 			"specialized persona. Provide a complete task description. Use when you want an " +
 			"independent read (e.g. code review).\n\n" +
@@ -59,7 +60,7 @@ func (AgentTool) Definition() agent.ToolDefinition {
 				},
 				"subagent_type": map[string]any{
 					"type":        "string",
-					"description": "Optional agent type. 'explore' (read-only research), 'plan' (read-only planning), 'general' (full toolbelt), 'code-review' (read-only review). Omit to fork yourself — the child inherits your system prompt (not this conversation's messages).",
+					"description": "Optional agent type. 'explore' (read-only research), 'plan' (read-only planning), 'general' (full toolbelt), 'code-review' (read-only review). Omit to fork yourself — the child inherits your full conversation (system prompt + messages so far).",
 				},
 				"run_in_background": map[string]any{
 					"type":        "boolean",
@@ -120,6 +121,8 @@ func (AgentTool) Execute(ctx context.Context, _ string, input map[string]any) (a
 		Prompt:      prompt,
 		Tools:       callTools,
 		Model:       callModel,
+		// No subagent_type → fork: seed the child with this conversation so far.
+		ForkConversation: subagentType == "",
 	}
 	if preset != nil {
 		req.SystemSuffix = preset.persona

--- a/internal/tools/spawner.go
+++ b/internal/tools/spawner.go
@@ -35,6 +35,13 @@ type SpawnRequest struct {
 	// Prompt is the sub-agent's user message. It carries the task.
 	Prompt string
 
+	// ForkConversation, when true, seeds the child's history with the parent's
+	// conversation so far (a true fork), rather than starting fresh. The
+	// spawner trims the in-flight tool_use turn that spawned the child so the
+	// copied history ends cleanly. Set by the sub_agent tool when no
+	// subagent_type is given; workflow agents leave it false.
+	ForkConversation bool
+
 	// Tools, when non-empty, restricts the child to this subset of the
 	// parent's tool list. nil/empty means "inherit all of parent's tools
 	// except Agent itself" — the spawn implementation handles the


### PR DESCRIPTION
## What

Aligns octo's **fork** mode (`sub_agent` with no `subagent_type`) with Claude Code's fork: the child now inherits the **parent's conversation so far**, not just the system prompt.

Previously a fork started with a fresh, empty history — it couldn't see the conversation, so the caller had to re-explain everything in `prompt`. Now the child continues with full context. Its own tool calls and output still stay in its branch; only the final reply returns to the parent (context isolation unchanged).

## Changes

- `SpawnRequest.ForkConversation`, set by the `sub_agent` tool when `subagent_type` is omitted. Workflow `agent()` leaves it false (those stay independent, fresh-history workers).
- `spawner.Spawn` seeds `child.History` from `parent.History.Snapshot()` before running the prompt.
- `forkHistorySnapshot` trims trailing assistant turns carrying a `tool_use` — the in-flight `sub_agent` call whose `tool_result` doesn't exist yet — so the seeded history doesn't end on a **dangling tool_use** the provider would reject. (This was the main implementation risk.)
- Rewrote the `sub_agent` Fork-mode description + `subagent_type` parenthetical to match.

## Tests

- `forkHistorySnapshot`: trims trailing tool_use turn, leaves a clean tail untouched, empty→empty.
- Fork spawn seeds the parent conversation and drops the dangling tool_use turn; the prompt lands as the next user turn.
- Non-fork spawn does **not** inherit the parent conversation.
- `go build/vet/test ./...` green, `gofmt` clean.

Design doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)