### PR TITLE
fix(server): make a scheduled task's Directory actually take effect

### DIFF
--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -84,10 +84,9 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 		sess.Source = "cron"
 		sess.Title = task.Name
 		task.SessionID = sess.ID
-		// If the task specifies a directory, note it in system prompt.
-		if task.Directory != "" {
-			sess.System = fmt.Sprintf("Working directory: %s\n%s", task.Directory, sess.System)
-		}
+		// task.Directory is applied at run time (see below): buildAgent recomposes
+		// the system prompt from s.system every turn, so stashing it on
+		// sess.System here would be silently dropped.
 		// Persist immediately: a task run can take many minutes, and until the
 		// session file exists the run is invisible in the web session list —
 		// clicking Run looked like it did nothing.
@@ -115,6 +114,14 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 
 	a := s.buildAgent(sess)
 
+	// Apply the task's working directory so the run actually happens there.
+	if task.Directory != "" {
+		var derr error
+		if ctx, derr = applyTaskDirectory(ctx, a, task.Directory); derr != nil {
+			return sess.ID, derr
+		}
+	}
+
 	var toolDefs []agent.ToolDefinition
 	var executor agent.ToolExecutor
 	if s.cfg.Tools {
@@ -141,6 +148,29 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 	}
 
 	return sess.ID, nil
+}
+
+// applyTaskDirectory roots a task run at dir: tools (terminal + file ops)
+// resolve relative paths against it via WorkingDir(ctx), the planner uses it
+// (a.CWD), and the model is told its cwd in both system-prompt variants (so a
+// lean explore sub-agent sees it too) — buildAgent composed System/LeanSystem
+// from the server cwd, so this note corrects it. Errors if dir isn't a usable
+// directory rather than running the whole turn against a broken root.
+func applyTaskDirectory(ctx context.Context, a *agent.Agent, dir string) (context.Context, error) {
+	fi, err := os.Stat(dir)
+	if err != nil {
+		return ctx, fmt.Errorf("task directory %q: %w", dir, err)
+	}
+	if !fi.IsDir() {
+		return ctx, fmt.Errorf("task directory %q is not a directory", dir)
+	}
+	a.CWD = dir
+	note := "Working directory: " + dir
+	a.System = note + "\n\n" + a.System
+	if a.LeanSystem != "" {
+		a.LeanSystem = note + "\n\n" + a.LeanSystem
+	}
+	return tools.WithWorkingDir(ctx, dir), nil
 }
 
 // notifyTaskResult pushes a task run's outcome to every configured IM notify

--- a/internal/server/tasks_handlers_test.go
+++ b/internal/server/tasks_handlers_test.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+func TestApplyTaskDirectory_RootsTheRun(t *testing.T) {
+	dir := t.TempDir()
+	a := agent.New(nil, "m")
+	a.System = "SYS"
+	a.LeanSystem = "LEAN"
+
+	ctx, err := applyTaskDirectory(context.Background(), a, dir)
+	if err != nil {
+		t.Fatalf("applyTaskDirectory: %v", err)
+	}
+	// Tools resolve against the dir.
+	if got := tools.WorkingDir(ctx); got != dir {
+		t.Errorf("WorkingDir(ctx) = %q, want %q", got, dir)
+	}
+	// Planner / project context use it.
+	if a.CWD != dir {
+		t.Errorf("a.CWD = %q, want %q", a.CWD, dir)
+	}
+	// The model is told its cwd in both system-prompt variants, and the
+	// original content is preserved.
+	want := "Working directory: " + dir
+	if !strings.HasPrefix(a.System, want) || !strings.HasSuffix(a.System, "SYS") {
+		t.Errorf("a.System = %q", a.System)
+	}
+	if !strings.HasPrefix(a.LeanSystem, want) || !strings.HasSuffix(a.LeanSystem, "LEAN") {
+		t.Errorf("a.LeanSystem = %q", a.LeanSystem)
+	}
+}
+
+func TestApplyTaskDirectory_EmptyLeanSystemUntouched(t *testing.T) {
+	a := agent.New(nil, "m")
+	a.System = "SYS"
+	// No LeanSystem (e.g. a path that didn't compose one).
+	if _, err := applyTaskDirectory(context.Background(), a, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	if a.LeanSystem != "" {
+		t.Errorf("empty LeanSystem should stay empty, got %q", a.LeanSystem)
+	}
+}
+
+func TestApplyTaskDirectory_InvalidDirErrors(t *testing.T) {
+	a := agent.New(nil, "m")
+	a.System = "SYS"
+
+	// Missing directory.
+	missing := filepath.Join(t.TempDir(), "nope")
+	if _, err := applyTaskDirectory(context.Background(), a, missing); err == nil {
+		t.Error("expected an error for a missing directory")
+	}
+
+	// A file, not a directory.
+	f := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := applyTaskDirectory(context.Background(), a, f); err == nil {
+		t.Error("expected an error when the path is a file, not a directory")
+	}
+
+	// A failed apply must not have mutated the system prompt.
+	if a.System != "SYS" {
+		t.Errorf("System mutated on error: %q", a.System)
+	}
+}


### PR DESCRIPTION
## Bug

A scheduled task's `Directory` was prepended to `sess.System` at session-creation time (`tasks_handlers.go`). But `buildAgent` recomposes `System`/`LeanSystem` from the **server cwd** every turn and never reads `sess.System` — so the working-directory hint was silently dropped. The task ran against the server's cwd for **both** its tools and its prompt; the `Directory` field had no effect.

(Found while reviewing the sub-agent PRs #802–#805 — pre-existing, unrelated to those, but surfaced by the `LeanSystem` work.)

## Fix

Apply the directory **at run time** via a new `applyTaskDirectory` helper:

- `ctx = tools.WithWorkingDir(ctx, dir)` — terminal + file ops resolve relative paths against it (the concrete "run here" behaviour, same mechanism worktree isolation uses).
- `a.CWD = dir` — planner / project-context resolution.
- prepend a `Working directory: <dir>` note to **both** `System` and `LeanSystem`, so the model (and a lean `explore` sub-agent) knows its cwd. buildAgent composed these from the server cwd, so the note corrects it — and keeping both in sync is exactly the earlier review observation, now that the note actually reaches the agent.
- a missing path / a file (not a dir) fails the run with a clear error instead of executing the whole turn against a broken root.

The dead `sess.System` prefix line is removed.

## Tests

`applyTaskDirectory`: roots the run (WorkingDir + a.CWD + system note in both variants, original content preserved); empty LeanSystem stays empty; invalid/missing/file paths error without mutating the prompt.

`go build/vet/test ./...` green, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)