### PR TITLE
test(server): de-flake TestHandleWSUserMessage_ImageOnly

### DIFF
--- a/internal/server/attachments_test.go
+++ b/internal/server/attachments_test.go
@@ -256,21 +256,29 @@ drain:
 		t.Error("history_user_message carried no /api/uploads/ image ref")
 	}
 
-	// The persisted session must carry the image block with its file path.
-	// doAgentTurn persists the turn before broadcasting "complete", so the
-	// session is on disk by the time the drain above returns. (mustServer's
-	// cleanup drains the turn goroutine before TempDir teardown.)
-	loaded, err := agent.LoadSession(sess.ID)
-	if err != nil {
-		t.Fatalf("reload: %v", err)
-	}
-	var foundBlock bool
-	for _, m := range loaded.Messages {
-		for _, blk := range m.Blocks {
-			if blk.Type == "image" && blk.ImagePath != "" && blk.Image != nil {
-				foundBlock = true
+	// The persisted session must carry the image block with its file path,
+	// rehydrated from disk. doAgentTurn persists before broadcasting "complete",
+	// but the turn runs on a background goroutine and the assert reads a file
+	// that goroutine just wrote; poll briefly so a loaded CI runner's scheduling
+	// jitter can't flake the read (it succeeds on the first iteration normally).
+	hasRehydratableImage := func() bool {
+		loaded, err := agent.LoadSession(sess.ID)
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		for _, m := range loaded.Messages {
+			for _, blk := range m.Blocks {
+				if blk.Type == "image" && blk.ImagePath != "" && blk.Image != nil {
+					return true
+				}
 			}
 		}
+		return false
+	}
+	foundBlock := hasRehydratableImage()
+	for deadline := time.Now().Add(2 * time.Second); !foundBlock && time.Now().Before(deadline); {
+		time.Sleep(20 * time.Millisecond)
+		foundBlock = hasRehydratableImage()
 	}
 	if !foundBlock {
 		t.Error("no rehydratable image block persisted in session")


### PR DESCRIPTION
## Flake

`TestHandleWSUserMessage_ImageOnly` failed once on **Go 1.25 (macos-latest)** with `no rehydratable image block persisted in session` (surfaced while #808's CI ran).

## Diagnosis

The turn runs on a **background goroutine** (`handleWSUserMessage` → `go runAgentTurnLoop`); the test syncs by draining until the `"complete"` event, then `LoadSession` + asserts a rehydratable image block (`Type==image && ImagePath!="" && Image!=nil`).

Walked the path:
- The image block is attached to the agent (`AttachUserBlocks`) and folded into the user turn, so `a.History` carries it; `SyncFrom` snapshots it; `doAgentTurn` `Save()`s it (twice) **before** broadcasting `"complete"`. So the block + `ImagePath` persist deterministically.
- `Image` is rehydrated on load by `ReadFile(ImagePath)`; the upload file is written synchronously in `handleWSUserMessage` and nothing deletes it.
- `Save` (1058) is ordered before `"complete"` (1095) in the turn goroutine, and the channel receive establishes happens-before to the test — so the read *should* be visible.

Could **not** reproduce in 50 serial runs nor 3× full-package `-race`. So this is a rare timing artifact on a loaded CI runner reading a file the turn goroutine just wrote — the known turn-goroutine flake class this package already hardens against (cf. #797).

## Fix

Poll the final `LoadSession` assertion for up to 2s (20ms steps) instead of reading exactly once. Succeeds on the first iteration normally; the retry only absorbs rare scheduling/filesystem jitter. **No production change** — this hardens the test rather than masking a confirmed bug (none found).

## Tests

Target test x30 + `-race`, full server package — all green; `gofmt`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)