### PR TITLE
fix(web/ui): raise tool event output cap and cap tool-output height

### DIFF
--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -92,7 +92,11 @@ const (
 // tool result going back into the conversation — this cap only applies to
 // what's surfaced to event observers (Web UI cards, IM previews), where a
 // 100KB shell dump would be useless noise.
-const EventToolOutputCap = 512
+//
+// 8KB is enough for web_fetch/read_file/grep previews (first ~40 lines) to
+// remain useful while keeping event payloads small; the frontend folds long
+// outputs anyway.
+const EventToolOutputCap = 8 * 1024
 
 // AgentEvent is the union shape carried over the EventHandler callback.
 //

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -382,6 +382,7 @@
   background: var(--bg-sidebar); font-size: 12px; line-height: 1.7;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   color: var(--text-secondary); overflow-x: auto; white-space: pre-wrap; word-break: break-word;
+  max-height: 420px; overflow-y: auto;
 }
 /* Chevron rotates from ▸ (collapsed) to ▾ (open). */
 .chev { transition: transform 0.15s ease; flex: 0 0 auto; }


### PR DESCRIPTION
## Problem

 spill previews were truncated to 512 bytes by , leaving the Web UI card showing only metadata +  and a large blank area below.

## Changes

- Raise  from 512 bytes to 8KB so // previews (first ~40 lines) remain useful.
- Add  to  so expanded tool cards don't produce excessive blank space.

## Verification

- ok  	github.com/Leihb/octo-agent/internal/agent	0.424s passes.
