### PR TITLE
chore(release): bump version to 1.2.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.1.0"
+var Version = "1.2.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Post-v1.1.0 development bump. `version.go` → 1.2.0 (plain next-minor per convention); CHANGELOG `[Unreleased — 1.2.0-dev]` header already added in the release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)