### PR TITLE
ci: bump actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,9 +21,9 @@ jobs:
     name: Svelte Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm
@@ -48,15 +48,15 @@ jobs:
         go: ['1.25']
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
           cache: true
         env:
           # Opt into Node 24 early to silence deprecation warnings.
-          # Both actions/checkout@v4 and actions/setup-go@v5 support it.
+          # Both actions/checkout@v5 and actions/setup-go@v6 support it.
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       - name: go vet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
     name: goreleaser
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # full history + tags so goreleaser can build the changelog
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache: true
@@ -28,7 +28,7 @@ jobs:
           # Opt into Node 24 early to silence deprecation warnings.
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
           # -p 1 serializes builds: the per-target rg-embed hook writes a single
@@ -46,7 +46,7 @@ jobs:
     needs: goreleaser
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4 # for packaging/windows/octo.iss + LICENSE.txt
+      - uses: actions/checkout@v5 # for packaging/windows/octo.iss + LICENSE.txt
 
       - name: Stage the released binary
         env:
@@ -85,7 +85,7 @@ jobs:
       - name: Upload unsigned installer (for SignPath)
         if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' }}
         id: unsigned-installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: octo-setup-unsigned
           path: staging\octo-setup.exe

--- a/.github/workflows/windows-installer-check.yml
+++ b/.github/workflows/windows-installer-check.yml
@@ -20,9 +20,9 @@ jobs:
     name: compile installer
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache: true


### PR DESCRIPTION
Clears the **"Node.js 20 is deprecated … forced to run on Node.js 24"** warnings from the v1.1.0 release run.

Each action moves to the lowest major shipping a node24 runtime:

| action | from | to |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-go | v5 | v6 |
| actions/setup-node | v4 | v5 |
| actions/upload-artifact | v4 | v6 |
| goreleaser/goreleaser-action | v6 | v7 |

`upload-artifact` goes to v6 (v5 had only preliminary node24 support). goreleaser-action v7's `version`/`args` inputs are unchanged, so the `~> v2` pin and `release --clean -p 1` args still apply. SignPath action wasn't flagged and is left as-is.

Note: `go.yml` is exercised by this PR's CI; `release.yml` + `windows-installer-check.yml` actions only run on tag push, but these are wrapper-runtime bumps with no input changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)