### PR TITLE
fix(security): close path-injection vectors flagged by CodeQL

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -782,19 +782,24 @@ func imageMIMEFromPath(path string) string {
 	}
 }
 
-// resolveSessionPath maps an id (bare, suffixed, or absolute path) to the
-// transcript file path.
+// resolveSessionPath maps an id (bare or with a .jsonl/.json suffix) to the
+// transcript file path under ~/.octo/sessions. The id reaches here straight
+// from HTTP/WS requests, so it must be a plain filename stem: absolute paths,
+// path separators, and "." / ".." components are all rejected so a
+// caller-supplied id can never escape the sessions directory.
 func resolveSessionPath(id string) (string, error) {
-	if filepath.IsAbs(id) {
-		return id, nil
+	stem := strings.TrimSuffix(strings.TrimSuffix(id, ".jsonl"), ".json")
+	if stem == "" {
+		return "", fmt.Errorf("session id is empty")
 	}
-	id = strings.TrimSuffix(id, ".jsonl")
-	id = strings.TrimSuffix(id, ".json")
+	if filepath.IsAbs(id) || stem != filepath.Base(stem) || strings.Contains(stem, "..") {
+		return "", fmt.Errorf("invalid session id %q", id)
+	}
 	dir, err := sessionsDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, id+".jsonl"), nil
+	return filepath.Join(dir, stem+".jsonl"), nil
 }
 
 // SessionMTime returns the file mtime of the session whose id is given.
@@ -835,7 +840,7 @@ func ListSessions(n int) ([]*Session, error) {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
 			continue
 		}
-		s, err := LoadSession(filepath.Join(dir, e.Name()))
+		s, err := LoadSession(strings.TrimSuffix(e.Name(), ".jsonl"))
 		if err != nil {
 			continue // skip corrupt files
 		}

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -372,6 +372,25 @@ func TestLoadSession_NotFound(t *testing.T) {
 	}
 }
 
+func TestLoadSession_RejectsTraversal(t *testing.T) {
+	setTempHome(t)
+
+	// Session ids reach LoadSession straight from HTTP/WS requests, so a
+	// traversal payload must be refused before it can resolve outside
+	// ~/.octo/sessions (go/path-injection).
+	for _, id := range []string{
+		"../../../etc/passwd",
+		"..",
+		"foo/bar",
+		"/etc/passwd",
+		"",
+	} {
+		if _, err := LoadSession(id); err == nil {
+			t.Errorf("LoadSession(%q): expected rejection, got nil error", id)
+		}
+	}
+}
+
 func TestLoadSession_StripDotJSON(t *testing.T) {
 	setTempHome(t)
 

--- a/internal/server/artifact_handler.go
+++ b/internal/server/artifact_handler.go
@@ -55,11 +55,15 @@ func (s *Server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "session not found")
 		return
 	}
-	if !sessionWrotePath(sess, abs) {
+	// served is the path as recorded in the transcript, not the request-derived
+	// value: it only matches when the agent itself wrote it, and using the
+	// transcript's copy keeps the file ops off the raw user-supplied path.
+	served, ok := sessionWrotePath(sess, abs)
+	if !ok {
 		writeError(w, http.StatusNotFound, "path was not written by this session")
 		return
 	}
-	fi, err := os.Stat(abs)
+	fi, err := os.Stat(served)
 	if err != nil || fi.IsDir() {
 		writeError(w, http.StatusNotFound, "file not found")
 		return
@@ -69,7 +73,7 @@ func (s *Server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	f, err := os.Open(abs)
+	f, err := os.Open(served)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -85,12 +89,14 @@ func (s *Server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 	_, _ = io.Copy(w, f)
 }
 
-// sessionWrotePath reports whether the transcript contains a write_file,
-// edit_file, or show_artifact tool_use whose path input matches reqPath
-// (after Clean on both sides — the payloads carry absolute paths, so no
-// base-dir join is needed). show_artifact is how script-produced files
-// (built rather than written through the file tools) enter the whitelist.
-func sessionWrotePath(sess *agent.Session, reqPath string) bool {
+// sessionWrotePath looks for a write_file, edit_file, or show_artifact tool_use
+// in the transcript whose path input matches reqPath (after Clean on both
+// sides — the payloads carry absolute paths, so no base-dir join is needed).
+// show_artifact is how script-produced files (built rather than written through
+// the file tools) enter the whitelist. On a match it returns the transcript's
+// own copy of the path so callers serve a value sourced from what the agent
+// recorded rather than from the raw request.
+func sessionWrotePath(sess *agent.Session, reqPath string) (string, bool) {
 	want := filepath.Clean(reqPath)
 	for _, m := range sess.Messages {
 		for _, b := range m.Blocks {
@@ -98,12 +104,14 @@ func sessionWrotePath(sess *agent.Session, reqPath string) bool {
 				continue
 			}
 			p, ok := b.Input["path"].(string)
-			if ok && filepath.Clean(p) == want {
-				return true
+			if ok {
+				if clean := filepath.Clean(p); clean == want {
+					return clean, true
+				}
 			}
 		}
 	}
-	return false
+	return "", false
 }
 
 // resolveArtifactPath validates a path from a tool UI payload. UI payloads carry


### PR DESCRIPTION
Fixes the three open `go/path-injection` code-scanning alerts (severity: error).

## Changes

**`internal/agent/session.go` — session id traversal (alert #70)**
`resolveSessionPath` is the choke point for `LoadSession`/`SavePath`, and session ids arrive straight from HTTP/WS requests across the server handlers. It used to return absolute paths verbatim and `filepath.Join` relative ids without rejecting `..`, so a crafted id like `../../../etc/passwd` could escape `~/.octo/sessions`. It now accepts only a plain filename stem (absolute paths, separators, and `..` rejected), mirroring the existing `DeleteSession` guard. `ListSessions` — the only caller of the removed absolute-path branch — now passes the bare stem.

**`internal/server/artifact_handler.go` — artifact serve (alerts #68, #69)**
The handler was already guarded by an abs-only check plus a transcript whitelist, but `os.Stat`/`os.Open` still ran on the raw query-derived path. `sessionWrotePath` now returns the path *as recorded in the transcript* on a match, and the handler serves that — so the value handed to the file ops provably originates from what the agent itself wrote, not the request.

## Tests
- Adds `TestLoadSession_RejectsTraversal` covering traversal payloads.
- `go test -race ./...`, `gofmt -l`, `go vet` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)