### PR TITLE
ci: drop now-redundant FORCE_JAVASCRIPT_ACTIONS_TO_NODE24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,8 +28,6 @@ jobs:
           node-version: '22'
           cache: npm
           cache-dependency-path: web/package-lock.json
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       - name: Install web dependencies
         working-directory: web
@@ -54,10 +52,6 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           cache: true
-        env:
-          # Opt into Node 24 early to silence deprecation warnings.
-          # Both actions/checkout@v5 and actions/setup-go@v6 support it.
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       - name: go vet
         run: go vet ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           go-version: '1.25'
           cache: true
-        env:
-          # Opt into Node 24 early to silence deprecation warnings.
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       - uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/windows-installer-check.yml
+++ b/.github/workflows/windows-installer-check.yml
@@ -26,8 +26,6 @@ jobs:
         with:
           go-version: '1.25'
           cache: true
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       - name: Build a binary to package
         shell: pwsh


### PR DESCRIPTION
Follow-up to #817. With the actions now on their node24 majors (checkout v5, setup-go v6, setup-node v5), `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` is a no-op — node24 is the default runtime. Removes the four overrides and their explanatory comments.

- `go.yml`: svelte-check (setup-node) + test (setup-go)
- `release.yml`: goreleaser (setup-go)
- `windows-installer-check.yml`: compile (setup-go)

No functional change; the deprecation warning was already cleared by #817. This just removes the now-dead opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)