### PR TITLE
test(channel): isolate HOME for mock session tests

### DIFF
--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -100,6 +100,7 @@ func (f fakeSender) SendMessages(ctx context.Context, model, system string, mess
 }
 
 func TestManager_StartStop(t *testing.T) {
+	tempHome(t)
 	Register("mock", func(pc PlatformConfig) (Adapter, error) {
 		return &mockAdapter{platform: "mock"}, nil
 	})
@@ -207,6 +208,7 @@ func TestManager_CommandRouter(t *testing.T) {
 }
 
 func TestManager_StopInterruptsRunningTurn(t *testing.T) {
+	tempHome(t)
 	cfg := &Config{Channels: map[string]PlatformConfig{}}
 	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
 
@@ -274,6 +276,7 @@ func TestSession_InterruptIdleIsNoop(t *testing.T) {
 }
 
 func TestManager_AutoSessionCreation(t *testing.T) {
+	tempHome(t)
 	Register("mock2", func(pc PlatformConfig) (Adapter, error) {
 		return &mockAdapter{platform: "mock2"}, nil
 	})

--- a/internal/channel/session_tasks_test.go
+++ b/internal/channel/session_tasks_test.go
@@ -6,6 +6,7 @@ import "testing"
 // survives across messages in the same chat — so the IM bridge's task list
 // doesn't reset every turn. (A fresh per-message store would lose it.)
 func TestSessionTaskStorePersists(t *testing.T) {
+	tempHome(t)
 	cfg := &Config{Channels: map[string]PlatformConfig{"mock": {"enabled": true}}}
 	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
 


### PR DESCRIPTION
## 问题

几个 `internal/channel` 的 mock 测试在调用 `GetOrCreateSession` / `handleSessionMessage` 时没有隔离 `HOME`，导致测试创建出的 session 被持久化到真实的 `~/.octo/sessions` 目录，表现为会话列表里出现 `mock:c1:u1`、`mock:c2:u2`、`mock2:c1:u1` 等mock会话。

## 改动

为以下会触发持久化的测试补上 `tempHome(t)`：

- `TestManager_StartStop`
- `TestManager_StopInterruptsRunningTurn`
- `TestManager_AutoSessionCreation`
- `TestSessionTaskStorePersists`

这样这些测试产生的 session store 文件会落在 `t.TempDir()` 里，不再污染真实目录。

## 验证

```bash
go test ./internal/channel/
```

结果：ok