### PR TITLE
test(channel): isolate HOME in remaining manager tests

### DIFF
--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -305,6 +305,7 @@ func TestManager_AutoSessionCreation(t *testing.T) {
 }
 
 func TestManager_SendReply(t *testing.T) {
+	tempHome(t)
 	mock := &mockAdapter{platform: "mock3"}
 	Register("mock3", func(pc PlatformConfig) (Adapter, error) {
 		return mock, nil
@@ -333,6 +334,7 @@ func TestManager_SendReply(t *testing.T) {
 }
 
 func TestManager_UnknownCommand(t *testing.T) {
+	tempHome(t)
 	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
 	ev := InboundEvent{Text: "/foobar"}
 	reply := mgr.CommandRouter(ev)


### PR DESCRIPTION
## 问题

上一轮修复给大部分会创建 session 的 channel 测试补了 `tempHome(t)`，但审计发现 `TestManager_SendReply` 和 `TestManager_UnknownCommand` 仍然在没有隔离 `HOME` 的情况下构造了 `Manager`。`NewManager` 会通过 `os.UserHomeDir()` 立即加载 `~/.octo/im-bindings.json`，所以这两个测试仍可能读写真实 HOME 目录。

## 改动

- `TestManager_SendReply` 开头加 `tempHome(t)`
- `TestManager_UnknownCommand` 开头加 `tempHome(t)`

## 验证

```bash
go test ./internal/channel/ ./internal/agent/
```

结果：ok