### PR TITLE
fix(provider): don't truncate successful non-streaming responses

### DIFF
--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -170,12 +170,12 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		}
 		defer resp.Body.Close()
 
-		respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
-		if err != nil {
-			return provider.Response{}, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("anthropic: read response: %w", err)
-		}
-
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+			if err != nil {
+				return provider.Response{}, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("anthropic: read error response: %w", err)
+			}
+
 			dec := retry.Decision{Retry: retry.RetryableStatus(resp.StatusCode), RetryAfter: retry.RetryAfterHeader(resp.Header)}
 			var apiErr apiError
 			if jerr := json.Unmarshal(respBody, &apiErr); jerr == nil && apiErr.Error.Message != "" {
@@ -185,6 +185,11 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 				)
 			}
 			return provider.Response{}, dec, fmt.Errorf("anthropic: HTTP %d: %s", resp.StatusCode, string(respBody))
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return provider.Response{}, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("anthropic: read response: %w", err)
 		}
 
 		var apiResp apiResponse

--- a/internal/provider/anthropic/client_test.go
+++ b/internal/provider/anthropic/client_test.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -111,6 +112,43 @@ func TestSend_Success(t *testing.T) {
 	}
 	if resp.InputTokens != 12 || resp.OutputTokens != 7 {
 		t.Errorf("Usage = (%d, %d), want (12, 7)", resp.InputTokens, resp.OutputTokens)
+	}
+}
+
+// TestSend_LargeResponseBody verifies that successful responses larger than the
+// error-body cap are read in full, not truncated mid-JSON.
+func TestSend_LargeResponseBody(t *testing.T) {
+	longText := strings.Repeat("x", 5000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := fmt.Sprintf(`{
+			"id": "msg_large",
+			"type": "message",
+			"role": "assistant",
+			"model": "claude-haiku-4-5-20251001",
+			"content": [{"type": "text", "text": %q}],
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 10, "output_tokens": 100}
+		}`, longText)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer srv.Close()
+
+	c, err := New("test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.BaseURL = srv.URL
+
+	resp, err := c.Send(context.Background(), provider.Request{
+		Model:    "claude-haiku-4-5-20251001",
+		Messages: []agent.Message{agent.NewUserMessage("generate a long response")},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if resp.Content != longText {
+		t.Errorf("Content length = %d, want %d", len(resp.Content), len(longText))
 	}
 }
 

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -211,12 +211,12 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		}
 		defer resp.Body.Close()
 
-		respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
-		if err != nil {
-			return nil, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("openai: read response: %w", err)
-		}
-
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+			if err != nil {
+				return nil, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("openai: read error response: %w", err)
+			}
+
 			dec := retry.Decision{Retry: retry.RetryableStatus(resp.StatusCode), RetryAfter: retry.RetryAfterHeader(resp.Header)}
 			var apiErr apiError
 			if jerr := json.Unmarshal(respBody, &apiErr); jerr == nil && apiErr.Error.Message != "" {
@@ -226,6 +226,11 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 				)
 			}
 			return nil, dec, fmt.Errorf("openai: HTTP %d: %s", resp.StatusCode, string(respBody))
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, retry.Decision{Retry: retry.RetryableErr(ctx, err)}, fmt.Errorf("openai: read response: %w", err)
 		}
 		return respBody, retry.Decision{}, nil
 	})

--- a/internal/provider/openai/client_test.go
+++ b/internal/provider/openai/client_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -104,6 +105,45 @@ func TestSend_Success(t *testing.T) {
 	}
 	if resp.InputTokens != 12 || resp.OutputTokens != 7 {
 		t.Errorf("Usage = (%d, %d), want (12, 7)", resp.InputTokens, resp.OutputTokens)
+	}
+}
+
+// TestSend_LargeResponseBody verifies that successful responses larger than the
+// error-body cap are read in full, not truncated mid-JSON.
+func TestSend_LargeResponseBody(t *testing.T) {
+	longText := strings.Repeat("x", 5000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := fmt.Sprintf(`{
+			"id":"chatcmpl-large",
+			"object":"chat.completion",
+			"model":"gpt-4o-mini",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":%q},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":10,"completion_tokens":100,"total_tokens":110}
+		}`, longText)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer srv.Close()
+
+	c, err := New("test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.BaseURL = srv.URL
+
+	resp, err := c.Send(context.Background(), provider.Request{
+		Model:    "gpt-4o-mini",
+		Messages: []agent.Message{agent.NewUserMessage("generate a long response")},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if resp.Content != longText {
+		t.Errorf("Content length = %d, want %d", len(resp.Content), len(longText))
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where non-streaming LLM responses larger than 4 KiB were silently truncated, causing JSON decode failures such as:

```
anthropic: decode response: unexpected end of JSON input
```

This was most visible in cron tasks (which use the non-streaming `Send` path).

## Root cause

Both `internal/provider/anthropic/client.go` and `internal/provider/openai/client.go` read **every** HTTP response body through `io.LimitReader(resp.Body, maxErrorBodyBytes)` (4 KiB). That limit is only appropriate for error responses; successful model outputs are frequently larger than 4 KiB.

## Changes

- Error responses continue to be capped at 4 KiB for safe error message extraction.
- Successful (2xx) responses are now read in full with `io.ReadAll(resp.Body)`.
- Added `TestSend_LargeResponseBody` regression tests in both provider packages for response bodies larger than `maxErrorBodyBytes`.

## Verification

```bash
go test ./internal/provider/anthropic/... ./internal/provider/openai/...
go build ./...
```

All tests pass.
