### PR TITLE
fix(serve): re-resolve os.Executable() on every worker spawn

### DIFF
--- a/cmd/octo/serve_supervisor.go
+++ b/cmd/octo/serve_supervisor.go
@@ -70,14 +70,15 @@ func superviseLoop(spawn func() (func() int, func(os.Signal), error), sigCh <-ch
 
 // spawnServeWorker returns the production spawn function for superviseLoop:
 // re-exec the current binary with `serve <args>` and the worker marker env.
-// The binary path is resolved once at supervisor start and re-opened by the
-// OS on every spawn, so a binary replaced on disk takes effect on the next
-// restart without the supervisor itself changing.
+// The binary path is re-resolved on every spawn, so a binary replaced on disk
+// (e.g. by the web upgrade flow) takes effect on the next restart without the
+// supervisor itself changing. Resolving once at startup can leave a stale path
+// on platforms where the running image's filesystem identity is cached.
 func spawnServeWorker(args []string, stdout, stderr io.Writer) func() (func() int, func(os.Signal), error) {
-	exe, exeErr := os.Executable()
 	return func() (func() int, func(os.Signal), error) {
-		if exeErr != nil {
-			return nil, nil, exeErr
+		exe, err := os.Executable()
+		if err != nil {
+			return nil, nil, err
 		}
 		cmd := exec.Command(exe, append([]string{"serve"}, args...)...)
 		cmd.Stdout = stdout


### PR DESCRIPTION
## Summary

Fixes a race where the supervisor's first worker respawn after a web upgrade could still launch the old binary, requiring a second restart before the new code took effect.

## Root cause

`spawnServeWorker` resolved `os.Executable()` once when the supervisor started and reused that path for every worker respawn. On some platforms (observed on macOS), a binary replaced on disk via `rename(2)` during the web upgrade flow could leave the supervisor with a stale resolved path. The first restart after upgrade would then re-exec the old image, while a subsequent restart eventually picked up the new one.

## Changes

- Move `os.Executable()` inside the spawn closure so it is re-evaluated every time the supervisor respawns a worker.
- Update the function comment to reflect the new behavior.

## Verification

```bash
go test ./cmd/octo/...
go build ./...
```

All existing supervisor tests pass.
