### PR TITLE
test(serve): add regression test for re-resolving executable path

### DIFF
--- a/cmd/octo/serve_supervisor.go
+++ b/cmd/octo/serve_supervisor.go
@@ -70,13 +70,20 @@ func superviseLoop(spawn func() (func() int, func(os.Signal), error), sigCh <-ch
 
 // spawnServeWorker returns the production spawn function for superviseLoop:
 // re-exec the current binary with `serve <args>` and the worker marker env.
-// The binary path is re-resolved on every spawn, so a binary replaced on disk
-// (e.g. by the web upgrade flow) takes effect on the next restart without the
-// supervisor itself changing. Resolving once at startup can leave a stale path
-// on platforms where the running image's filesystem identity is cached.
+// The binary path is re-resolved on every spawn so transient failures are not
+// cached forever and, on platforms where os.Executable() resolves by path
+// (not by inode), a binary replaced on disk takes effect on the next restart
+// without the supervisor itself changing.
 func spawnServeWorker(args []string, stdout, stderr io.Writer) func() (func() int, func(os.Signal), error) {
+	return spawnServeWorkerWithResolver(args, stdout, stderr, os.Executable)
+}
+
+// spawnServeWorkerWithResolver is the testable core of spawnServeWorker.
+// resolver is called on every worker spawn so tests can fake a changing binary
+// path without touching the real executable.
+func spawnServeWorkerWithResolver(args []string, stdout, stderr io.Writer, resolver func() (string, error)) func() (func() int, func(os.Signal), error) {
 	return func() (func() int, func(os.Signal), error) {
-		exe, err := os.Executable()
+		exe, err := resolver()
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/octo/serve_supervisor_test.go
+++ b/cmd/octo/serve_supervisor_test.go
@@ -145,6 +145,40 @@ func TestSuperviseLoop_SpawnErrorReturns1(t *testing.T) {
 	}
 }
 
+// TestSpawnServeWorker_ReResolvesExecutablePath verifies that each worker spawn
+// calls the resolver again, so a binary replaced on disk (e.g. by the web
+// upgrade flow) is picked up on the next restart on platforms where
+// os.Executable() resolves by path.
+func TestSpawnServeWorker_ReResolvesExecutablePath(t *testing.T) {
+	paths := []string{"/first/octo", "/second/octo", "/third/octo"}
+	calls := 0
+	resolver := func() (string, error) {
+		if calls >= len(paths) {
+			t.Fatalf("resolver called more than %d times", len(paths))
+		}
+		p := paths[calls]
+		calls++
+		return p, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	spawn := spawnServeWorkerWithResolver(nil, &stdout, &stderr, resolver)
+
+	// Three spawns; each should see the next resolved path. We do not actually
+	// start processes (the paths are fake) — we only verify that the resolver is
+	// consulted each time.
+	for i := 0; i < len(paths); i++ {
+		_, _, err := spawn()
+		if err == nil {
+			t.Fatalf("spawn %d: expected error from fake path, got nil", i)
+		}
+	}
+
+	if calls != len(paths) {
+		t.Errorf("resolver calls = %d, want %d", calls, len(paths))
+	}
+}
+
 func TestShouldSupervise(t *testing.T) {
 	cases := []struct {
 		noSupervisor bool


### PR DESCRIPTION
## Summary

Follow-up to #827. Adds an injectable resolver to `spawnServeWorker` and a regression test proving that each worker spawn re-resolves the executable path.

## Changes

- `cmd/octo/serve_supervisor.go`: split `spawnServeWorker` into a thin wrapper that passes `os.Executable` and a testable `spawnServeWorkerWithResolver` core.
- `cmd/octo/serve_supervisor_test.go`: add `TestSpawnServeWorker_ReResolvesExecutablePath` which verifies the resolver is consulted on every spawn.
- Qualify the function comment: re-resolution helps on platforms where `os.Executable()` resolves by path, not on Linux where `/proc/self/exe` follows the original inode.

## Verification

```bash
go test ./cmd/octo/... -v -run TestSpawnServeWorker_ReResolvesExecutablePath
go test ./cmd/octo/...
go build ./...
```

All pass.
