### PR TITLE
fix(tools): surface ripgrep stderr in glob/grep errors and tolerate partial glob results

### DIFF
--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -84,7 +85,7 @@ func (GlobTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 		return agent.ToolResult{Text: ""}, err
 	}
 
-	files, err := listProjectFiles(ctx, absRoot)
+	files, warning, err := listProjectFiles(ctx, absRoot)
 	if err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("glob: %w", err)
 	}
@@ -150,10 +151,17 @@ func (GlobTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 	}
 
 	if out.Len() == 0 {
-		return agent.ToolResult{Text: fmt.Sprintf("(no matches for %q under %s)", pattern, absRoot), UI: ui}, nil
+		text := fmt.Sprintf("(no matches for %q under %s)", pattern, absRoot)
+		if warning != "" {
+			text += fmt.Sprintf("\n[warning: %s]", warning)
+		}
+		return agent.ToolResult{Text: text, UI: ui}, nil
 	}
 	if truncated {
 		fmt.Fprintf(&out, "\n[truncated to first %d of %d matches]\n", GlobMaxResults, totalMatches)
+	}
+	if warning != "" {
+		fmt.Fprintf(&out, "\n[warning: %s]\n", warning)
 	}
 	return agent.ToolResult{Text: out.String(), UI: ui}, nil
 }
@@ -164,20 +172,60 @@ func (GlobTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 // can still find e.g. `.octorules`; `--null` separates paths with NUL so a
 // newline inside a filename can't split one path into two. A clean "no files"
 // (ripgrep exit code 1) returns an empty slice, not an error.
-func listProjectFiles(ctx context.Context, root string) ([]string, error) {
+//
+// The returned warning is non-empty when ripgrep exited with an error but still
+// produced a partial file list; callers should surface it alongside the results
+// rather than treating the call as a failure.
+func listProjectFiles(ctx context.Context, root string) ([]string, string, error) {
 	rgPath, err := rgembed.Path()
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	out, err := exec.CommandContext(ctx, rgPath, "--files", "--hidden", "--null", root).Output()
+
+	info, err := os.Stat(root)
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
-			return nil, nil // no files under root
-		}
-		return nil, fmt.Errorf("rg --files: %w", err)
+		return nil, "", fmt.Errorf("stat root %q: %w", root, err)
 	}
-	trimmed := strings.Trim(string(out), "\x00")
+	if !info.IsDir() {
+		// rg --files on a regular file emits that file and exits 0; mirror that
+		// without shelling out so non-directory roots don't produce a cryptic
+		// "not a directory" error from ripgrep.
+		return []string{root}, "", nil
+	}
+
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, rgPath, "--files", "--hidden", "--null", root)
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+
+	if err == nil {
+		files, parseErr := parseNullSeparatedPaths(out)
+		return files, "", parseErr
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return nil, "", nil // no files under root
+	}
+
+	// ripgrep exit code 2 means an error occurred while scanning. If it still
+	// managed to list some files, return those and let the caller surface the
+	// warning; failing entirely for a single unreadable directory is worse than
+	// returning partial results.
+	files, _ := parseNullSeparatedPaths(out)
+	if len(files) > 0 {
+		return files, strings.TrimSpace(stderr.String()), nil
+	}
+
+	if stderr.Len() > 0 {
+		return nil, "", fmt.Errorf("rg --files: %s", strings.TrimSpace(stderr.String()))
+	}
+	return nil, "", fmt.Errorf("rg --files: %w", err)
+}
+
+// parseNullSeparatedPaths splits rg --null output into individual paths.
+func parseNullSeparatedPaths(data []byte) ([]string, error) {
+	trimmed := strings.Trim(string(data), "\x00")
 	if trimmed == "" {
 		return nil, nil
 	}

--- a/internal/tools/glob_test.go
+++ b/internal/tools/glob_test.go
@@ -153,3 +153,72 @@ func TestGlob_RequiresPattern(t *testing.T) {
 		t.Fatal("missing pattern should error")
 	}
 }
+
+func TestGlob_NonExistentRoot(t *testing.T) {
+	requireRg(t)
+	_, err := GlobTool{}.Execute(context.Background(), "glob", map[string]any{
+		"pattern": "*.go",
+		"path":    filepath.Join(t.TempDir(), "does-not-exist"),
+	})
+	if err == nil {
+		t.Fatal("expected error for non-existent root")
+	}
+	if !strings.Contains(err.Error(), "stat root") {
+		t.Errorf("error should mention stat root, got: %v", err)
+	}
+}
+
+func TestGlob_FileRoot(t *testing.T) {
+	requireRg(t)
+	dir := t.TempDir()
+	single := filepath.Join(dir, "single.go")
+	writeTestFile(t, single, "")
+
+	out, err := GlobTool{}.Execute(context.Background(), "glob", map[string]any{
+		"pattern": "*.go",
+		"path":    single,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.Text, "single.go") {
+		t.Errorf("expected single.go in output:\n%s", out.Text)
+	}
+}
+
+func TestGlob_UnreadableSubdirReturnsPartialResults(t *testing.T) {
+	requireRg(t)
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "readable", "ok.go"), "")
+	writeTestFile(t, filepath.Join(dir, "unreadable", "secret.go"), "")
+
+	unreadable := filepath.Join(dir, "unreadable")
+	if err := os.Chmod(unreadable, 0o000); err != nil {
+		t.Fatalf("chmod unreadable: %v", err)
+	}
+	defer os.Chmod(unreadable, 0o755) // ensure cleanup can remove the tree
+
+	// Permission restrictions may not be enforced (e.g. root on Unix, some Windows
+	// configurations). If we can still list the directory, the test premise fails.
+	if f, err := os.Open(unreadable); err == nil {
+		f.Close()
+		t.Skip("chmod 000 did not prevent directory listing; skipping permission test")
+	}
+
+	out, err := GlobTool{}.Execute(context.Background(), "glob", map[string]any{
+		"pattern": "**/*.go",
+		"path":    dir,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.Text, "ok.go") {
+		t.Errorf("expected ok.go from readable subdir:\n%s", out.Text)
+	}
+	if strings.Contains(out.Text, "secret.go") {
+		t.Errorf("secret.go should not be readable:\n%s", out.Text)
+	}
+	if !strings.Contains(out.Text, "[warning:") {
+		t.Errorf("expected a warning about the unreadable subdir:\n%s", out.Text)
+	}
+}

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -150,13 +151,19 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 		args = append(args, abs)
 	}
 
-	out, err := exec.CommandContext(ctx, rgPath, args...).Output()
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, rgPath, args...)
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
 		// ripgrep exits 1 when nothing matched. That's not an error from
 		// the LLM's perspective — surface it as a normal result.
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 			return agent.ToolResult{Text: "(no matches)", UI: grepUIEmpty(pattern)}, nil
+		}
+		if stderr.Len() > 0 {
+			return agent.ToolResult{Text: ""}, fmt.Errorf("grep: rg failed: %s", strings.TrimSpace(stderr.String()))
 		}
 		return agent.ToolResult{Text: ""}, fmt.Errorf("grep: rg failed: %w", err)
 	}

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -215,5 +216,36 @@ func TestGrep_TruncatesLongMatchingLines(t *testing.T) {
 	// The old unhelpful marker should no longer appear.
 	if strings.Contains(out.Text, "Omitted long matching line") {
 		t.Errorf("old full-omission marker should not appear; output:\n%s", out.Text)
+	}
+}
+
+func TestGrep_IncludesStderrOnError(t *testing.T) {
+	requireRg(t)
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "readable", "ok.go"), "needle\n")
+	writeTestFile(t, filepath.Join(dir, "unreadable", "secret.go"), "needle\n")
+
+	unreadable := filepath.Join(dir, "unreadable")
+	if err := os.Chmod(unreadable, 0o000); err != nil {
+		t.Fatalf("chmod unreadable: %v", err)
+	}
+	defer os.Chmod(unreadable, 0o755) // ensure cleanup can remove the tree
+
+	// Permission restrictions may not be enforced (e.g. root on Unix, some Windows
+	// configurations). If we can still list the directory, the test premise fails.
+	if f, err := os.Open(unreadable); err == nil {
+		f.Close()
+		t.Skip("chmod 000 did not prevent directory listing; skipping permission test")
+	}
+
+	_, err := GrepTool{}.Execute(context.Background(), "grep", map[string]any{
+		"pattern": "needle",
+		"path":    dir,
+	})
+	if err == nil {
+		t.Fatal("expected error when rg cannot scan an unreadable directory")
+	}
+	if !strings.Contains(err.Error(), "Permission denied") && !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("error should include rg's stderr message, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Problem

`Glob` and `Grep` wrap `ripgrep` but discard its stderr. When `rg` exits 2 (e.g. unreadable subdirectory), the agent only sees an opaque error like:

```
glob: rg --files: exit status 2
```

This makes the tool look broken and prevents the agent from understanding what went wrong.

## Changes

- **Capture stderr** in both `glob` and `grep` and include it in the returned error so agents see e.g. `Permission denied (os error 13)`.
- **Stat the search root before invoking `rg`** in `glob` so non-existent directories produce a clear `stat root "...": no such file or directory` error instead of an opaque exit status 2.
- **Treat a file root as a single-file enumeration** in `glob`, matching `rg --files` behavior without shelling out.
- **Tolerate partial `glob` results** when `rg` exits 2 but still emitted some paths (e.g. one unreadable subdirectory); return the partial list with a `[warning: ...]` annotation.

## Tests

- `TestGlob_NonExistentRoot`
- `TestGlob_FileRoot`
- `TestGlob_UnreadableSubdirReturnsPartialResults`
- `TestGrep_IncludesStderrOnError`

Permission-based tests skip when the OS ignores `chmod 000` (e.g. running as root).

## Verification

- `make test` (`go test -race ./...`) passes.
- `gofmt -w` applied.
- `go vet ./...` passes.

No new third-party dependencies.
