### PR TITLE
fix(tools,server): harden sub-agent promote lifecycle and WS safety

### DIFF
--- a/internal/server/ws_hub.go
+++ b/internal/server/ws_hub.go
@@ -348,8 +348,11 @@ func (c *wsConn) dispatch(msgType string, raw []byte) {
 			return
 		}
 		// The session's sub-agent manager is created on the first tool turn;
-		// by the time a sync sub-agent is running it must exist.
-		tools.SessionSubAgentManager(msg.SessionID, nil).PromoteSync()
+		// by the time a sync sub-agent is running it must exist. If the session
+		// has never started a sub-agent, the message is a no-op.
+		if mgr := tools.SessionSubAgentManager(msg.SessionID, nil); mgr != nil {
+			mgr.PromoteSync()
+		}
 
 	default:
 		log.Printf("[ws] unknown message type: %q", msgType)

--- a/internal/tools/session_managers.go
+++ b/internal/tools/session_managers.go
@@ -88,11 +88,14 @@ var (
 // SessionSubAgentManager returns the per-session sub-agent manager for id,
 // creating it via mkSpawner on first use. Subsequent calls reuse the existing
 // manager (and its spawner), so mkSpawner is only invoked once per session.
+// If mkSpawner is nil and no manager exists for id, nil is returned — callers
+// that only need to signal an already-running sync sub-agent (e.g. a WebSocket
+// promote message) can use this safely without constructing a manager.
 func SessionSubAgentManager(id string, mkSpawner func() Spawner) *SubAgentManager {
 	sessionSubMgrsMu.Lock()
 	defer sessionSubMgrsMu.Unlock()
 	m := sessionSubMgrs[id]
-	if m == nil {
+	if m == nil && mkSpawner != nil {
 		m = NewSubAgentManager(mkSpawner())
 		sessionSubMgrs[id] = m
 	}

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -190,9 +190,9 @@ func subAgentsSynchronous() bool {
 }
 
 // BeginSync registers a new SyncSession for the current synchronous sub-agent
-// run. Call EndSync (via defer) when the run finishes or is promoted. At most
-// one synchronous sub-agent runs per manager at a time — the agent loop is
-// serial — so there is only one slot.
+// run. Call EndSync with the returned session (via defer) when the run finishes
+// or is promoted. At most one synchronous sub-agent runs per manager at a time —
+// the agent loop is serial — so there is only one slot.
 func (m *SubAgentManager) BeginSync() *SyncSession {
 	s := &SyncSession{ch: make(chan struct{})}
 	m.syncMu.Lock()
@@ -201,10 +201,14 @@ func (m *SubAgentManager) BeginSync() *SyncSession {
 	return s
 }
 
-// EndSync clears the current SyncSession.
-func (m *SubAgentManager) EndSync() {
+// EndSync clears the current SyncSession only if it is still the one returned
+// by BeginSync. This protects against a deferred EndSync racing with a later
+// synchronous run in tests or if the manager is ever used concurrently.
+func (m *SubAgentManager) EndSync(s *SyncSession) {
 	m.syncMu.Lock()
-	m.syncSess = nil
+	if m.syncSess == s {
+		m.syncSess = nil
+	}
 	m.syncMu.Unlock()
 }
 
@@ -255,6 +259,11 @@ func (m *SubAgentManager) RunSync(ctx context.Context, req SpawnRequest) (SpawnR
 		return SpawnResult{}, fmt.Errorf("subagent: no spawner configured")
 	}
 
+	// Run the spawn on a background context so a user promotion can detach it
+	// from the turn context and let it keep running. Create the context first
+	// so the agent entry is never observed with a nil cancel func.
+	spawnCtx, cancel := context.WithCancel(context.Background())
+
 	// Allocate a real agent_N id up front. If the user promotes this sync run,
 	// the same id becomes the background handle; if it completes inline, the
 	// temporary entry is reaped.
@@ -265,18 +274,12 @@ func (m *SubAgentManager) RunSync(ctx context.Context, req SpawnRequest) (SpawnR
 		id:          id,
 		description: req.Description,
 		agentType:   req.AgentType,
+		cancel:      cancel,
 		start:       time.Now(),
 		busy:        true,
 	}
 	m.agents[id] = a
 	m.mu.Unlock()
-
-	// Run the spawn on a background context so a user promotion can detach it
-	// from the turn context and let it keep running.
-	spawnCtx, cancel := context.WithCancel(context.Background())
-	a.mu.Lock()
-	a.cancel = cancel
-	a.mu.Unlock()
 
 	sink := m.eventSink(id, req.Description, req.AgentType)
 	if sink != nil {
@@ -285,7 +288,7 @@ func (m *SubAgentManager) RunSync(ctx context.Context, req SpawnRequest) (SpawnR
 	}
 
 	sess := m.BeginSync()
-	defer m.EndSync()
+	defer m.EndSync(sess)
 
 	type outcome struct {
 		res SpawnResult
@@ -329,13 +332,18 @@ func (m *SubAgentManager) RunSync(ctx context.Context, req SpawnRequest) (SpawnR
 		m.mu.Unlock()
 
 		go func() {
+			defer func() {
+				m.mu.Lock()
+				m.activeAsync--
+				m.mu.Unlock()
+			}()
 			o := <-done
+			// Spawn has finished; cancel its context to release resources.
 			a.mu.Lock()
 			a.cancel()
 			a.mu.Unlock()
 
 			m.mu.Lock()
-			m.activeAsync--
 			hook := m.onExit
 			m.mu.Unlock()
 


### PR DESCRIPTION
## Why

This is a follow-up hardening PR for the synchronous sub-agent "promote to background" feature that was merged via another branch. The original implementation had a few lifecycle/safety issues found during review.

## Changes

- **`internal/tools/session_managers.go`**: `SessionSubAgentManager` now returns `nil` when the manager does not exist **and** `mkSpawner == nil`. This prevents WebSocket promote messages from accidentally creating a manager or panicking on a nil factory.
- **`internal/server/ws_hub.go`**: the `promote_sync_sub_agent` WS handler now checks for a nil manager and treats it as a no-op.
- **`internal/tools/subagent_manager.go`**:
  - `EndSync(s *SyncSession)` only clears the sync slot if it still owns the given session, preventing a deferred `EndSync` from wiping a newer session.
  - `RunSync` creates the spawn context and cancel func **before** registering the agent entry, eliminating the window where `Kill`/`KillAll` could observe a nil `cancel`.
  - The promote-to-background goroutine uses `defer` to decrement `activeAsync`, keeping the concurrency counter correct even on panic paths.

## Verification

```bash
go test ./internal/tools/ ./cmd/octo/ ./internal/server/ -count=1   # pass
```
