### PR TITLE
refactor(tools): split terminal run_in_background into async/interactive enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased — 1.2.0-dev]
 
+### Breaking
+- **Terminal `run_in_background` is now an enum (`"async"` / `"interactive"`).**
+  The boolean `true` value is no longer accepted. `"async"` is for one-shot tasks
+  (tests, builds, installs) and rejects `terminal_output` / `terminal_input` —
+  completion is pushed automatically. `"interactive"` is for long-running services
+  and REPLs (servers, watchers, `rails c`, `octo serve`) and allows observation
+  and stdin input. Synchronous commands that time out are promoted to `async`.
+
 ## [1.1.0] — 2026-06-26
 
 ### Added

--- a/dev-docs/terminal-manual-promote.md
+++ b/dev-docs/terminal-manual-promote.md
@@ -51,7 +51,7 @@ func PromoteCurrentSync()
 
 ```go
 mgr := t.managerFor(ctx)
-id, _ := mgr.Start(command, WithOnLine(onLine), WithVisible(false))
+id, _ := mgr.Start(command, BgModeAsync, WithOnLine(onLine), WithVisible(false))
 
 sess := mgr.BeginSync()
 defer mgr.EndSync()
@@ -60,12 +60,12 @@ select {
 case <-sess.C():
     // User promoted — identical outcome to timer, different result text.
     mgr.Promote(id)
-    return ToolResult{Text: fmt.Sprintf("… [promoted to background process %s]\n\n%s", id, BgPollNotice)}
+    return ToolResult{Text: fmt.Sprintf("… [promoted to async background process %s]\n\n%s", id, AsyncModeNotice)}
 
 case <-timer.C:
     // Timer backstop — covers IM and forgotten browser tabs.
     mgr.Promote(id)
-    return ToolResult{Text: fmt.Sprintf("… [timeout: command exceeded %s …]\n\n%s", TerminalTimeout, BgPollNotice)}
+    return ToolResult{Text: fmt.Sprintf("… [timeout: command exceeded %s …]\n\n%s", TerminalTimeout, AsyncModeNotice)}
 
 case <-ctx.Done():
     // Kill on interrupt — unchanged.
@@ -138,4 +138,4 @@ No code changes. The `sess.C()` case is wired but nobody fires it; the 2-minute 
 - Partial output is returned on both promote paths.
 - `TerminalTimeout` (120 s) is unchanged.
 - `ctx.Done()` (kill) is unchanged.
-- `run_in_background:true` commands bypass `BeginSync` entirely — they're already async.
+- `run_in_background:"async"` / `"interactive"` commands bypass `BeginSync` entirely — they're already background tasks.

--- a/dev-docs/terminal-tools.md
+++ b/dev-docs/terminal-tools.md
@@ -9,10 +9,10 @@ through one `BackgroundManager`.
 
 | Tool | Purpose |
 |---|---|
-| `terminal` | Run a command. Synchronous, `run_in_background:true`, or `detached:true`. |
-| `terminal_output` | Snapshot the last N lines of a background process's output + status. |
-| `terminal_list` | List this session's background processes (id, status, elapsed, command). |
-| `terminal_input` | Write to a background process's stdin. |
+| `terminal` | Run a command. Synchronous, `run_in_background:"async"` / `"interactive"`, or `detached:true`. |
+| `terminal_output` | Snapshot the last N lines of an **interactive** background process's output + status. |
+| `terminal_list` | List this session's background processes (id, mode, status, elapsed, command). |
+| `terminal_input` | Write to an **interactive** background process's stdin. |
 | `kill_shell` | Signal/terminate a background process and return its final output. |
 
 `terminal` is the only one that starts work; the rest address an existing
@@ -33,15 +33,22 @@ process by the `bg_N` id `terminal` returns.
    wrapping and OS sandbox as any other command (detach controls lifetime, the
    sandbox controls what it may touch — orthogonal).
 
-2. **`run_in_background:true`** — a tracked background process. Returns a
-   `bg_N` id immediately, no timeout. Output is observable via
-   `terminal_output`, the process via `terminal_list` / `kill_shell`, and it is
+2. **`run_in_background:"async"`** — a tracked background process for **one-shot
+   tasks** (tests, builds, installs, CI checks). Returns a `bg_N` id immediately,
+   no timeout. The model **must not** call `terminal_output` or `terminal_input`;
+   completion is pushed automatically via `[BACKGROUND COMPLETED]`. The process is
    **killed when the session ends**.
 
-3. **Synchronous (default)** — runs with a 120 s timeout. Implemented as a
+3. **`run_in_background:"interactive"`** — a tracked background process for
+   **long-running services and REPLs** (servers, watchers, `rails c`, `octo
+   serve`). Returns a `bg_N` id immediately, no timeout. The model may use
+   `terminal_output` to inspect logs and `terminal_input` to send commands. The
+   process is **killed when the session ends**.
+
+4. **Synchronous (default)** — runs with a 120 s timeout. Implemented as a
    hidden (`visible:false`) background process so that on timeout it is simply
-   *promoted* to a visible background task (no kill, no restart) and its id
-   returned. On normal completion it is reaped (`Remove`).
+   *promoted* to a visible **async** background task (no kill, no restart) and its
+   id returned. On normal completion it is reaped (`Remove`).
 
 ## BackgroundManager and the process lifecycle
 
@@ -121,12 +128,14 @@ Two distinct needs, two distinct mechanisms:
   The hook reads via the cursor (`readNew`), so anything pushed is already
   consumed and won't reappear in a later read. Wired in the CLI/TUI REPL only.
 
-- **Progress is pulled, as a snapshot.** `terminal_output` returns the last N
-  lines (`lines`, default 50) plus status via `bgProcess.tail`, which does
-  **not** advance any cursor. Repeated calls return the same view, so there is
-  no "new since last call" to chase and no incentive to loop. `terminal_list`
-  is the other snapshot — the set of live/recent processes — for recovering a
-  lost id.
+- **Progress is pulled, as a snapshot — but only for interactive processes.**
+  `terminal_output` returns the last N lines (`lines`, default 50) plus status
+  via `bgProcess.tail`, which does **not** advance any cursor. Repeated calls
+  return the same view, so there is no "new since last call" to chase and no
+  incentive to loop. `terminal_output` is rejected for async processes; their
+  completion is pushed automatically. `terminal_list` is the other snapshot —
+  the set of live/recent processes, annotated with mode — for recovering a lost
+  id.
 
 The internal cursor read (`readNew`) still exists for the synchronous poll loop
 and the completion push; only the model-facing `terminal_output` uses the
@@ -147,9 +156,11 @@ enforce their own anti-polling limits (see `background.go`).
 
 - `BackgroundManager` is a `map[id]*bgProcess` with two goroutines per process
   (reader + waiter), so N `run_in_background` launches run concurrently. The
-  agent fires several off, continues other work, and reacts to each completion
-  as its push arrives — in completion order. Multiple completions drained in
-  one iteration are surfaced together.
+  launched process stores a `mode` (`async` or `interactive`) that gates whether
+  `terminal_output` / `terminal_input` are allowed. The agent fires several off,
+  continues other work, and reacts to each completion as its push arrives — in
+  completion order. Multiple completions drained in one iteration are surfaced
+  together.
 - Within a single tool batch, the agent loop dispatches calls concurrently
   **only when every call is read-only** (`readOnlyTools`: `read_file`, `glob`,
   `grep`, `web_fetch`, `web_search`) — see `dispatchTools` / `canParallelize`.

--- a/internal/permission/defaults.yml
+++ b/internal/permission/defaults.yml
@@ -88,9 +88,10 @@ read_file:
   - deny:  { path: ["**/.ssh/id_*", "**/id_rsa*", "**/id_ed25519*", "**/id_ecdsa*", "**/.env", "**/.env.*"] }
   - allow: { path: ["**"] }
 
-# terminal_output reads (and optionally kills) background processes started by
-# this same session via `terminal` run_in_background:true — low risk, so allow without
-# prompting. The launching `terminal` call is already gated above.
+# terminal_output reads background processes started by this same session via
+# `terminal` run_in_background:"interactive". Async processes reject reads; only
+# interactive services/REPLs are observable. Low risk, so allow without prompting.
+# The launching `terminal` call is already gated above.
 terminal_output:
   - allow: { pattern: "" }
 

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -74,22 +74,23 @@ Memories are snapshots and can be stale. If one names a file path, function, fla
 
 ## Background processes
 
-- **Never use `nohup` or shell `&` in a synchronous `terminal` call.** In sync mode the tool creates stdout/stderr pipes that are inherited by the forked child; `cmd.Wait()` does not return until all pipe write-ends are closed, so the command appears to hang until the background process exits. Always use `run_in_background:true` for anything that outlives the immediate turn.
-- **`run_in_background` vs `detached` — pick by lifecycle.** `run_in_background:true` is the default for work tied to this session (servers, watchers, one-shot builds): octo tracks it, you can read its output and kill it, and it is **stopped when the session ends**. Use `detached:true` ONLY when the user explicitly wants a process to **outlive octo** — e.g. exposing a port with `ngrok`, starting a standalone daemon. A detached process runs in its own session, is untracked (no `terminal_output` / `kill_shell`), is not killed on exit, and returns only its OS pid. Don't reach for `detached` to dodge the session timeout — that's what `run_in_background` is for. Never hand-roll `nohup`/`setsid`/`&`; set `detached:true` and the tool handles it.
+- **Never use `nohup` or shell `&` in a synchronous `terminal` call.** In sync mode the tool creates stdout/stderr pipes that are inherited by the forked child; `cmd.Wait()` does not return until all pipe write-ends are closed, so the command appears to hang until the background process exits. Always use `run_in_background` for anything that outlives the immediate turn.
+- **`run_in_background` vs `detached` — pick by lifecycle.** `run_in_background:"async"` / `"interactive"` is for work tied to this session: octo tracks it and kills it when the session ends. Use `run_in_background:"async"` for one-shot tasks (tests, builds, installs) — you may NOT use `terminal_output` or `terminal_input`; wait for the completion notification. Use `run_in_background:"interactive"` for long-running services and REPLs (servers, watchers, `rails c`, `octo serve`) — `terminal_output` and `terminal_input` are allowed. Use `detached:true` ONLY when the user explicitly wants a process to **outlive octo** — e.g. exposing a port with `ngrok`, starting a standalone daemon. A detached process runs in its own session, is untracked (no `terminal_output` / `kill_shell`), is not killed on exit, and returns only its OS pid. Don't reach for `detached` to dodge the session timeout — that's what `run_in_background` is for. Never hand-roll `nohup`/`setsid`/`&`; set `detached:true` and the tool handles it.
 
 ### One-shot tasks (compiles, tests, installs, builds, linting, CI checks)
 
-- Use `terminal` with `run_in_background:true`. Do not let a long command block the session.
-- After launching, **do not poll `terminal_output`**. The system will automatically notify you when the process finishes.
+- Use `terminal` with `run_in_background:"async"`. Do not let a long command block the session.
+- After launching, **do not call `terminal_output` or `terminal_input`**. The system will automatically notify you when the process finishes.
 - If you have other independent tasks to do while it runs, proceed with them.
 - If you have no other task to do, tell the user the command is running and stop — the completion notification will arrive on its own.
 - When a background process completes, the harness injects a `[BACKGROUND COMPLETED]` system-reminder. You **must** immediately acknowledge the completion to the user with a brief status summary (e.g. "CI passed, merging now" or "Build failed — see logs above"). Do not wait for the user to ask.
 
-### Long-running services (servers, watchers, docker compose up)
+### Long-running services and REPLs (servers, watchers, docker compose up, rails c, octo serve)
 
-- Use `terminal` with `run_in_background:true`.
+- Use `terminal` with `run_in_background:"interactive"`.
 - After launch, **verify the service with an external check** (e.g., `curl http://localhost:PORT`, `pgrep`, or reading a PID file) rather than polling `terminal_output`.
 - `terminal_output` is a **snapshot** of a process's last N lines, not a feed — call it on demand to inspect startup logs or check progress; repeated calls return the current tail, so there's nothing to gain from looping. Lost a process id? Use `terminal_list` to see what's running.
+- Send interactive commands via `terminal_input` when appropriate (REPLs, servers that read stdin).
 - Stop with `kill_shell`. For servers and other services, prefer `signal: "SIGTERM"` for graceful shutdown. Use `signal: "SIGKILL"` (default) for forceful termination or when SIGTERM fails.
 
 ## Tool-use timing

--- a/internal/server/shutdown_background_test.go
+++ b/internal/server/shutdown_background_test.go
@@ -21,7 +21,7 @@ func TestShutdown_KillsBackgroundProcesses(t *testing.T) {
 	term := tools.TerminalTool{}
 	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
 		"command":           "sleep 60",
-		"run_in_background": true,
+		"run_in_background": "async",
 	}); err != nil {
 		t.Fatalf("start background: %v", err)
 	}

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -23,10 +23,26 @@ const maxBgOutputBytes = 1 << 20 // 1 MiB
 const pollWindow = 30 * time.Second
 const maxEmptyPolls = 3
 
+// BackgroundMode distinguishes the two kinds of tracked background processes
+// the terminal tool can launch. Async processes run a one-shot task and notify
+// the model on completion; interactive processes are long-running services or
+// REPLs that the model may observe or feed via terminal_output / terminal_input.
+type BackgroundMode string
+
+const (
+	// BgModeAsync is for one-shot tasks (tests, builds, installs). The model
+	// must not poll them; completion is pushed automatically.
+	BgModeAsync BackgroundMode = "async"
+	// BgModeInteractive is for long-running services and REPLs (rails c,
+	// octo serve). The model may use terminal_output and terminal_input.
+	BgModeInteractive BackgroundMode = "interactive"
+)
+
 // bgProcess tracks one detached command launched via BackgroundManager.
 type bgProcess struct {
 	id      string
 	command string
+	mode    BackgroundMode
 	cancel  context.CancelFunc
 	proc    *os.Process // set after Start; used for hard-kill
 	start   time.Time
@@ -321,8 +337,13 @@ func WithVisible(v bool) StartOption {
 
 // Start launches command detached (via `sh -c`), with no timeout, and returns
 // its background id. Output streams into a capped buffer; the process is killed
-// if its context is cancelled (Kill / KillAll).
-func (m *BackgroundManager) Start(command string, opts ...StartOption) (string, error) {
+// if its context is cancelled (Kill / KillAll). The mode argument determines
+// whether the process is an async one-shot task or an interactive service/REPL.
+func (m *BackgroundManager) Start(command string, mode BackgroundMode, opts ...StartOption) (string, error) {
+	if mode != BgModeAsync && mode != BgModeInteractive {
+		return "", fmt.Errorf("background: invalid mode %q (want %q or %q)", mode, BgModeAsync, BgModeInteractive)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd, err := shellCommand(ctx, command)
 	if err != nil {
@@ -357,7 +378,7 @@ func (m *BackgroundManager) Start(command string, opts ...StartOption) (string, 
 	m.mu.Lock()
 	m.seq++
 	id := fmt.Sprintf("bg_%d", m.seq)
-	p := &bgProcess{id: id, command: command, cancel: cancel, proc: cmd.Process, start: time.Now(), visible: true, stdin: stdinW}
+	p := &bgProcess{id: id, command: command, mode: mode, cancel: cancel, proc: cmd.Process, start: time.Now(), visible: true, stdin: stdinW}
 	for _, opt := range opts {
 		opt(p)
 	}
@@ -421,16 +442,17 @@ func (m *BackgroundManager) Start(command string, opts ...StartOption) (string, 
 // Read returns output produced since the last call for id, plus a status
 // string. found is false when id is unknown. blocked is true when the caller
 // has polled too many times without new output while the process is still
-// running — this forces the LLM to stop polling.
-func (m *BackgroundManager) Read(id string) (output, status string, found bool, blocked bool) {
+// running — this forces the LLM to stop polling. mode reports the process's
+// background mode (empty when not found).
+func (m *BackgroundManager) Read(id string) (output, status string, found bool, blocked bool, mode BackgroundMode) {
 	m.mu.Lock()
 	p := m.procs[id]
 	m.mu.Unlock()
 	if p == nil {
-		return "", "", false, false
+		return "", "", false, false, ""
 	}
 	out, st, blk := p.readNew()
-	return out, st, true, blk
+	return out, st, true, blk, p.mode
 }
 
 // Tail returns a non-destructive snapshot of the last `lines` lines of a
@@ -439,15 +461,27 @@ func (m *BackgroundManager) Read(id string) (output, status string, found bool, 
 // on-demand progress peeks (the terminal_output tool). repeated calls return
 // the same bytes, but repeated empty snapshots of a running process are counted
 // as polling; once blocked is true, callers should tell the model to stop.
-func (m *BackgroundManager) Tail(id string, lines int) (output, status string, found bool, blocked bool) {
+// mode reports the process's background mode (empty when not found).
+func (m *BackgroundManager) Tail(id string, lines int) (output, status string, found bool, blocked bool, mode BackgroundMode) {
 	m.mu.Lock()
 	p := m.procs[id]
 	m.mu.Unlock()
 	if p == nil {
-		return "", "", false, false
+		return "", "", false, false, ""
 	}
 	out, st, blk := p.tail(lines)
-	return out, st, true, blk
+	return out, st, true, blk, p.mode
+}
+
+// Mode returns the background mode for id, or ("", false) if unknown.
+func (m *BackgroundManager) Mode(id string) (BackgroundMode, bool) {
+	m.mu.Lock()
+	p := m.procs[id]
+	m.mu.Unlock()
+	if p == nil {
+		return "", false
+	}
+	return p.mode, true
 }
 
 // BgInfo is a snapshot of a tracked background process — used both by the TUI's
@@ -455,6 +489,7 @@ func (m *BackgroundManager) Tail(id string, lines int) (output, status string, f
 type BgInfo struct {
 	ID      string
 	Command string
+	Mode    BackgroundMode
 	Start   time.Time
 	Status  string // "running" / "exited: …"
 }
@@ -485,7 +520,7 @@ func (m *BackgroundManager) list(includeExited bool) []BgInfo {
 		p.mu.Lock()
 		done := p.done
 		visible := p.visible
-		info := BgInfo{ID: p.id, Command: p.command, Start: p.start, Status: p.statusLocked()}
+		info := BgInfo{ID: p.id, Command: p.command, Mode: p.mode, Start: p.start, Status: p.statusLocked()}
 		p.mu.Unlock()
 		if visible && (includeExited || !done) {
 			out = append(out, info)

--- a/internal/tools/background_integration_test.go
+++ b/internal/tools/background_integration_test.go
@@ -76,10 +76,11 @@ func main() {
 		t.Fatalf("server build failed: %s", resBuild.Text)
 	}
 
-	// Launch the server in the background.
+	// Launch the server in the background as an interactive process so we can
+	// inspect its startup logs via terminal_output.
 	resLaunch, err := term.Execute(ctx, "terminal", map[string]any{
 		"command":           fmt.Sprintf("%s %s", bin, port),
-		"run_in_background": true,
+		"run_in_background": "interactive",
 	})
 	if err != nil {
 		t.Fatalf("launch server: %v", err)

--- a/internal/tools/background_listrunning_test.go
+++ b/internal/tools/background_listrunning_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestBackgroundManager_ListRunning(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("sleep 2")
+	id, err := m.Start("sleep 2", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -18,6 +18,9 @@ func TestBackgroundManager_ListRunning(t *testing.T) {
 	}
 	if run[0].ID != id || run[0].Command != "sleep 2" {
 		t.Errorf("running entry = %+v, want id=%s command='sleep 2'", run[0], id)
+	}
+	if run[0].Mode != BgModeAsync {
+		t.Errorf("running entry mode = %q, want %q", run[0].Mode, BgModeAsync)
 	}
 	if run[0].Start.IsZero() {
 		t.Error("running entry has no Start time")
@@ -32,13 +35,13 @@ func TestBackgroundManager_ListRunning(t *testing.T) {
 
 func TestBackgroundManager_ListRunning_ExcludesExited(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("echo done")
+	id, err := m.Start("echo done", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	// Wait for it to finish (Read reports exited), then it must not be listed.
 	waitFor(t, "process to exit", func() bool {
-		_, status, _, _ := m.Read(id)
+		_, status, _, _, _ := m.Read(id)
 		return strings.HasPrefix(status, "exited")
 	})
 	if run := m.ListRunning(); len(run) != 0 {
@@ -55,7 +58,7 @@ func TestRunningBackground_DefaultManagerDelegates(t *testing.T) {
 // started with visible=false do not appear in ListRunning until Promoted.
 func TestBackgroundManager_ListRunning_ExcludesInvisible(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("sleep 2", WithVisible(false))
+	id, err := m.Start("sleep 2", BgModeAsync, WithVisible(false))
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/tools/background_onexit_test.go
+++ b/internal/tools/background_onexit_test.go
@@ -22,7 +22,7 @@ func TestBackgroundManager_OnExitHookFires(t *testing.T) {
 		}
 	})
 
-	id, err := m.Start("echo hi-from-bg")
+	id, err := m.Start("echo hi-from-bg", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestBackgroundManager_OnExitHookFires(t *testing.T) {
 
 	// Dedup: the hook already consumed the output via readNew, so a subsequent
 	// terminal_output-style poll must not re-report the same bytes.
-	o, _, found, _ := m.Read(id)
+	o, _, found, _, _ := m.Read(id)
 	if !found {
 		t.Fatal("process should still be known after exit")
 	}
@@ -62,13 +62,13 @@ func TestBackgroundManager_OnExitHookFires(t *testing.T) {
 // leaves the original poll-only behaviour intact — Start/Read still work.
 func TestBackgroundManager_NoHookByDefault(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("echo plain")
+	id, err := m.Start("echo plain", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	var out string
 	waitFor(t, "process to exit", func() bool {
-		o, s, f, _ := m.Read(id)
+		o, s, f, _, _ := m.Read(id)
 		out += o
 		return f && strings.HasPrefix(s, "exited")
 	})
@@ -94,14 +94,14 @@ func TestBackgroundManager_OnExitNotFiredForInvisibleProcess(t *testing.T) {
 	})
 
 	// Start invisible (visible=false), exactly like the sync path does.
-	id, err := m.Start("echo sync-done", WithVisible(false))
+	id, err := m.Start("echo sync-done", BgModeAsync, WithVisible(false))
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
 	// Wait for the process to finish.
 	waitFor(t, "process to exit", func() bool {
-		_, s, f, _ := m.Read(id)
+		_, s, f, _, _ := m.Read(id)
 		return f && strings.HasPrefix(s, "exited")
 	})
 
@@ -129,7 +129,7 @@ func TestBackgroundManager_OnExitFiresAfterPromote(t *testing.T) {
 	})
 
 	// Start invisible, then promote before it finishes.
-	id, err := m.Start("sleep 0.1", WithVisible(false))
+	id, err := m.Start("sleep 0.1", BgModeAsync, WithVisible(false))
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/tools/background_orphan_test.go
+++ b/internal/tools/background_orphan_test.go
@@ -16,12 +16,12 @@ import (
 // (the direct child / group leader) is SIGKILLed instead of the whole group.
 func startWithBackgroundChild(t *testing.T, mgr *BackgroundManager) (id string, childPID int) {
 	t.Helper()
-	id, err := mgr.Start("sleep 60 & echo $! ; wait")
+	id, err := mgr.Start("sleep 60 & echo $! ; wait", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	for i := 0; i < 50 && childPID == 0; i++ {
-		out, _, _, _ := mgr.Read(id)
+		out, _, _, _, _ := mgr.Read(id)
 		if fields := strings.Fields(strings.TrimSpace(out)); len(fields) > 0 {
 			if pid, perr := strconv.Atoi(fields[0]); perr == nil {
 				childPID = pid

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -33,7 +33,7 @@ func waitFor(t *testing.T, what string, fn func() bool) {
 
 func TestBackgroundManager_RunsAndReportsExit(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("echo hello")
+	id, err := m.Start("echo hello", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestBackgroundManager_RunsAndReportsExit(t *testing.T) {
 	var out, status string
 	waitFor(t, "process to exit", func() bool {
 		var found bool
-		o, s, f, _ := m.Read(id)
+		o, s, f, _, _ := m.Read(id)
 		found = f
 		if o != "" {
 			out += o // accumulate across reads (cursor advances)
@@ -60,31 +60,31 @@ func TestBackgroundManager_RunsAndReportsExit(t *testing.T) {
 
 func TestBackgroundManager_IncrementalRead(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("echo one; sleep 0.3; echo two")
+	id, err := m.Start("echo one; sleep 0.3; echo two", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
 	// First chunk: "one" before "two" is emitted.
 	waitFor(t, "first line", func() bool {
-		o, _, _, _ := m.Read(id)
+		o, _, _, _, _ := m.Read(id)
 		return strings.Contains(o, "one")
 	})
 	// A read right after consuming "one" should not re-return it.
-	o, _, _, _ := m.Read(id)
+	o, _, _, _, _ := m.Read(id)
 	if strings.Contains(o, "one") {
 		t.Errorf("second read re-returned old output: %q", o)
 	}
 	// Eventually "two" arrives as new output.
 	waitFor(t, "second line", func() bool {
-		o, _, _, _ := m.Read(id)
+		o, _, _, _, _ := m.Read(id)
 		return strings.Contains(o, "two")
 	})
 }
 
 func TestBackgroundManager_Kill(t *testing.T) {
 	m := NewBackgroundManager()
-	id, err := m.Start("sleep 30")
+	id, err := m.Start("sleep 30", BgModeAsync)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestBackgroundManager_Kill(t *testing.T) {
 		t.Fatal("Kill returned false for a live process")
 	}
 	waitFor(t, "killed process to report exit", func() bool {
-		_, s, _, _ := m.Read(id)
+		_, s, _, _, _ := m.Read(id)
 		return strings.HasPrefix(s, "exited")
 	})
 
@@ -106,13 +106,16 @@ func TestTerminalTool_BackgroundLaunch(t *testing.T) {
 	tool := TerminalTool{mgr: m}
 	resTool, err := tool.Execute(context.Background(), "terminal", map[string]any{
 		"command":           "echo hi",
-		"run_in_background": true,
+		"run_in_background": "async",
 	})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if !strings.Contains(resTool.Text, "bg_1") {
 		t.Errorf("result = %q, want it to mention the bg id", resTool.Text)
+	}
+	if !strings.Contains(resTool.Text, "async") {
+		t.Errorf("result = %q, want it to mention async mode", resTool.Text)
 	}
 }
 
@@ -133,7 +136,7 @@ func TestTerminalTool_SyncCommandIsReaped(t *testing.T) {
 		t.Errorf("result = %q, want it to contain the output", res.Text)
 	}
 	// bg_1 was the hidden process — after a clean sync exit it must be gone.
-	if _, _, found, _ := m.Read("bg_1"); found {
+	if _, _, found, _, _ := m.Read("bg_1"); found {
 		t.Error("synchronous command's process should have been reaped from the manager")
 	}
 	if got := m.ListRunning(); len(got) != 0 {
@@ -148,7 +151,7 @@ func TestTerminalOutputTool(t *testing.T) {
 
 	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
 		"command":           "echo from-bg",
-		"run_in_background": true,
+		"run_in_background": "interactive",
 	}); err != nil {
 		t.Fatalf("launch: %v", err)
 	}
@@ -183,7 +186,7 @@ func TestKillShellTool(t *testing.T) {
 
 	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
 		"command":           "sleep 30",
-		"run_in_background": true,
+		"run_in_background": "async",
 	}); err != nil {
 		t.Fatalf("launch: %v", err)
 	}
@@ -240,8 +243,8 @@ func TestTerminalTool_TimeoutPromotesToBackground(t *testing.T) {
 	if !strings.Contains(res.Text, "bg_1") {
 		t.Errorf("result should mention bg id, got: %q", res.Text)
 	}
-	// Should contain the anti-polling instruction.
-	if !strings.Contains(res.Text, "DO NOT poll") {
+	// Should contain the async notice warning against polling.
+	if !strings.Contains(res.Text, "ASYNC background process") {
 		t.Errorf("result should warn against polling, got: %q", res.Text)
 	}
 
@@ -250,7 +253,7 @@ func TestTerminalTool_TimeoutPromotesToBackground(t *testing.T) {
 	// can be very slow.
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		_, s, _, _ := m.Read("bg_1")
+		_, s, _, _, _ := m.Read("bg_1")
 		if strings.HasPrefix(s, "exited") {
 			return
 		}
@@ -271,7 +274,7 @@ func TestTerminalOutputTool_SnapshotIdempotent(t *testing.T) {
 
 	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
 		"command":           "sleep 30",
-		"run_in_background": true,
+		"run_in_background": "interactive",
 	}); err != nil {
 		t.Fatalf("launch: %v", err)
 	}
@@ -301,7 +304,7 @@ func TestTerminalOutputTool_AntiPollBlocksEmptySnapshots(t *testing.T) {
 
 	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
 		"command":           "sleep 30",
-		"run_in_background": true,
+		"run_in_background": "interactive",
 	}); err != nil {
 		t.Fatalf("launch: %v", err)
 	}
@@ -328,7 +331,7 @@ func TestTerminalOutputTool_ReadOnly(t *testing.T) {
 
 	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
 		"command":           "sleep 30",
-		"run_in_background": true,
+		"run_in_background": "interactive",
 	}); err != nil {
 		t.Fatalf("launch: %v", err)
 	}
@@ -344,7 +347,91 @@ func TestTerminalOutputTool_ReadOnly(t *testing.T) {
 	if strings.Contains(resOut.Text, "killed") {
 		t.Errorf("terminal_output must not kill, got %q", resOut.Text)
 	}
-	if _, status, _, _ := m.Read("bg_1"); status != "running" {
+	if _, status, _, _, _ := m.Read("bg_1"); status != "running" {
 		t.Errorf("process should still be running after terminal_output, status=%q", status)
+	}
+}
+
+// TestTerminalOutputTool_RejectsAsync verifies that terminal_output refuses to
+// observe async (one-shot) background tasks. The model must wait for the
+// automatic completion notification instead of polling.
+func TestTerminalOutputTool_RejectsAsync(t *testing.T) {
+	m := NewBackgroundManager()
+	term := TerminalTool{mgr: m}
+	outTool := TerminalOutputTool{mgr: m}
+
+	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
+		"command":           "sleep 30",
+		"run_in_background": "async",
+	}); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+
+	_, err := outTool.Execute(context.Background(), "terminal_output", map[string]any{"id": "bg_1"})
+	if err == nil {
+		t.Fatal("terminal_output should reject async processes")
+	}
+	if !strings.Contains(err.Error(), "async task") {
+		t.Errorf("error should explain async rejection, got: %v", err)
+	}
+}
+
+// TestTerminalInputTool_RejectsAsync verifies that terminal_input refuses to
+// send input to async (one-shot) background tasks.
+func TestTerminalInputTool_RejectsAsync(t *testing.T) {
+	m := NewBackgroundManager()
+	term := TerminalTool{mgr: m}
+	inTool := TerminalInputTool{mgr: m}
+
+	if _, err := term.Execute(context.Background(), "terminal", map[string]any{
+		"command":           "sleep 30",
+		"run_in_background": "async",
+	}); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+
+	_, err := inTool.Execute(context.Background(), "terminal_input", map[string]any{
+		"id":    "bg_1",
+		"input": "hello\n",
+	})
+	if err == nil {
+		t.Fatal("terminal_input should reject async processes")
+	}
+	if !strings.Contains(err.Error(), "async task") {
+		t.Errorf("error should explain async rejection, got: %v", err)
+	}
+}
+
+// TestTerminalTool_InvalidBackgroundMode verifies that invalid run_in_background
+// values (unknown strings, booleans, or boolean-like strings) surface as clear
+// tool errors mentioning the valid enum values.
+func TestTerminalTool_InvalidBackgroundMode(t *testing.T) {
+	m := NewBackgroundManager()
+	term := TerminalTool{mgr: m}
+
+	cases := []struct {
+		name string
+		val  any
+	}{
+		{"unknown string", "batch"},
+		{"boolean true", true},
+		{"boolean false", false},
+		{"string true", "true"},
+		{"string false", "false"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := term.Execute(context.Background(), "terminal", map[string]any{
+				"command":           "echo hi",
+				"run_in_background": tc.val,
+			})
+			if err == nil {
+				t.Fatal("invalid run_in_background mode should error")
+			}
+			if !strings.Contains(err.Error(), "async") || !strings.Contains(err.Error(), "interactive") {
+				t.Errorf("error should mention valid modes, got: %v", err)
+			}
+		})
 	}
 }

--- a/internal/tools/session_managers_posix_test.go
+++ b/internal/tools/session_managers_posix_test.go
@@ -21,7 +21,7 @@ func TestBackgroundManager_CtxScopedIsolatedAndReaped(t *testing.T) {
 	ctx := WithBackgroundManager(context.Background(), mA)
 	if _, err := (TerminalTool{}).Execute(ctx, "terminal", map[string]any{
 		"command":           "sleep 60",
-		"run_in_background": true,
+		"run_in_background": "async",
 	}); err != nil {
 		t.Fatalf("background launch: %v", err)
 	}

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -17,15 +17,15 @@ import (
 // synchronously before it is automatically promoted to a background process.
 var TerminalTimeout = 120 * time.Second
 
-// BgPollNotice is the model-facing instruction appended to a background-launch
-// tool result. Wrapped in <system-reminder> so StripRemindersForDisplay strips
-// it from UI cards (TUI and web) — it's noise for humans.
-const BgPollNotice = "<system-reminder>DO NOT poll terminal_output. The system will automatically notify you when this process finishes, carrying its final output. While it runs, you may continue with other independent tasks. If you have no other task to do, report the launch to the user and stop — do not spin in a polling loop.</system-reminder>"
+// AsyncModeNotice is the model-facing instruction appended to an async
+// background-launch tool result. Wrapped in <system-reminder> so
+// StripRemindersForDisplay strips it from UI cards (TUI and web).
+const AsyncModeNotice = "<system-reminder>This is an ASYNC background process (a one-shot task). DO NOT use terminal_output or terminal_input on it. The system will automatically notify you when it finishes, carrying its final output. While it runs, you may continue with other independent tasks. If you have no other task to do, report the launch to the user and stop — do not spin in a polling loop.</system-reminder>"
 
-// ServiceModeNotice is the model-facing instruction appended to a background
-// launch of a long-running service (servers, watchers, etc.). Wrapped in
-// <system-reminder> so UI card renderers strip it automatically.
-const ServiceModeNotice = "<system-reminder>After launching a long-running service, verify it with an external check (e.g., `curl http://localhost:PORT` or `pgrep`) rather than polling terminal_output. terminal_output is for inspecting startup logs or diagnosing issues — do not call it in a tight loop.</system-reminder>"
+// InteractiveModeNotice is the model-facing instruction appended to an
+// interactive background-launch tool result. Wrapped in <system-reminder> so UI
+// card renderers strip it automatically.
+const InteractiveModeNotice = "<system-reminder>This is an INTERACTIVE background process (a long-running service or REPL). You may use terminal_output to inspect its logs and terminal_input to send it commands. After launching a service, verify it with an external check (e.g., `curl http://localhost:PORT` or `pgrep`) rather than polling terminal_output in a tight loop.</system-reminder>"
 
 // TerminalTool is an agent.ToolExecutor that runs shell commands through the
 // system shell (`sh -c` on macOS/Linux, PowerShell on Windows; see
@@ -43,17 +43,48 @@ const ServiceModeNotice = "<system-reminder>After launching a long-running servi
 // exists so tests can inject an isolated manager.
 type TerminalTool struct{ mgr *BackgroundManager }
 
+// parseBackgroundMode interprets the run_in_background parameter, which is now
+// an enum string ("async" / "interactive") rather than a boolean. A missing
+// key or empty string means synchronous. Any other value (including the legacy
+// boolean true) surfaces as a tool error so the model gets immediate feedback.
+func parseBackgroundMode(input map[string]any) (mode BackgroundMode, useBg bool, err error) {
+	raw, ok := input["run_in_background"]
+	if !ok {
+		return "", false, nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", false, fmt.Errorf(
+			"terminal: run_in_background must be a string (\"async\" or \"interactive\"), got %T. "+
+				"Boolean values are no longer accepted.", raw)
+	}
+	if s == "" {
+		return "", false, nil
+	}
+	switch s {
+	case "async":
+		return BgModeAsync, true, nil
+	case "interactive":
+		return BgModeInteractive, true, nil
+	default:
+		return "", false, fmt.Errorf(
+			"terminal: run_in_background must be either \"async\" or \"interactive\" (got %q). "+
+				"Use \"async\" for one-shot tasks like tests/builds/installs, \"interactive\" for "+
+				"long-running services or REPLs. Omit it to run synchronously.", s)
+	}
+}
+
 func (t TerminalTool) managerFor(ctx context.Context) *BackgroundManager {
 	return resolveBackgroundManager(ctx, t.mgr)
 }
 
 // Definition returns the agent.ToolDefinition the LLM receives in the tools
 // list. The JSON Schema describes a required "command" string and an optional
-// "run_in_background" flag.
+// "run_in_background" enum.
 func (TerminalTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name:        "terminal",
-		Description: "Run a shell command in the system shell (POSIX sh on macOS/Linux, PowerShell on Windows — see the Shell line in the environment context) and return stdout+stderr. Use for file operations, running programs, etc. Prefer dedicated tools (read_file, write_file, edit_file, glob, grep) over raw shell commands when they exist.\n\nChoosing sync vs background:\n- Default (no run_in_background): runs synchronously with a 120s timeout. Use for fast commands whose output you need immediately (e.g. `ls`, `git status`, `grep`, short scripts).\n- run_in_background:true — ONE-SHOT tasks (compiling, testing, installing, building, linting, CI checks): detaches immediately, returns a process id. The system automatically notifies you on completion. DO NOT poll terminal_output.\n- run_in_background:true — LONG-RUNNING services (servers, watchers, docker compose up): detaches immediately, returns a process id. After launch, verify the service with an external check (e.g., `curl http://localhost:PORT`, `pgrep`) rather than polling terminal_output. Use terminal_output only to inspect startup logs or diagnose issues — do not call it in a tight loop.\n\nBuffering: the process is connected via pipes, not a terminal, so stdio block-buffers its output — a chatty program's logs can sit unflushed and invisible to terminal_output for a long time. On macOS/Linux, when you will want live logs, prefix the command with `stdbuf -oL` (e.g. `stdbuf -oL npm run dev`) to force line buffering.\n\nTo feed text to a command's stdin, pass it via the stdin parameter instead of embedding it in the command string — embedded text gets interpreted by the shell (backticks, quotes, $), stdin is delivered verbatim.\n\nNEVER put backticks (`) inside a quoted shell string: every shell mangles them — POSIX sh/bash run the backticked text as command substitution (you'll see 'command not found' / 'not found' noise), and PowerShell treats the backtick as an escape character and silently drops it or turns `n/`t into control chars (corrupting the text with no error). For PR/issue/commit bodies (or any text) that contain markdown code spans, ALWAYS pass the text through the stdin parameter with `--body-file -` / `-F -` rather than `--body \"...`...\"`.",
+		Description: "Run a shell command in the system shell (POSIX sh on macOS/Linux, PowerShell on Windows — see the Shell line in the environment context) and return stdout+stderr. Use for file operations, running programs, etc. Prefer dedicated tools (read_file, write_file, edit_file, glob, grep) over raw shell commands when they exist.\n\nChoosing sync vs background:\n- Default (no run_in_background): runs synchronously with a 120s timeout. Use for fast commands whose output you need immediately (e.g. `ls`, `git status`, `grep`, short scripts).\n- run_in_background:\"async\" — ONE-SHOT tasks (compiling, testing, installing, building, linting, CI checks): detaches immediately, returns a process id. The system automatically notifies you on completion. DO NOT use terminal_output or terminal_input; wait for the completion notification.\n- run_in_background:\"interactive\" — LONG-RUNNING services, REPLs, watchers, servers (e.g. `rails c`, `octo serve`, `docker compose up`): detaches immediately, returns a process id. You may use terminal_output to inspect logs and terminal_input to feed commands. Verify the service with an external check (e.g., `curl http://localhost:PORT`, `pgrep`) rather than polling terminal_output in a tight loop.\n\nBuffering: the process is connected via pipes, not a terminal, so stdio block-buffers its output — a chatty program's logs can sit unflushed and invisible to terminal_output for a long time. On macOS/Linux, when you will want live logs, prefix the command with `stdbuf -oL` (e.g. `stdbuf -oL npm run dev`) to force line buffering.\n\nTo feed text to a command's stdin, pass it via the stdin parameter instead of embedding it in the command string — embedded text gets interpreted by the shell (backticks, quotes, $), stdin is delivered verbatim.\n\nNEVER put backticks (`) inside a quoted shell string: every shell mangles them — POSIX sh/bash run the backticked text as command substitution (you'll see 'command not found' / 'not found' noise), and PowerShell treats the backtick as an escape character and silently drops it or turns `n/`t into control chars (corrupting the text with no error). For PR/issue/commit bodies (or any text) that contain markdown code spans, ALWAYS pass the text through the stdin parameter with `--body-file -` / `-F -` rather than `--body \"...`...\"`.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -66,8 +97,9 @@ func (TerminalTool) Definition() agent.ToolDefinition {
 					"description": "Text piped verbatim to the command's stdin, which is then closed (EOF). Use this — not interpolation into the command string — to pass long or special-character text (quotes, backticks, $) to commands that read stdin, e.g. `gh pr create --body-file -`, `git apply -`, `python script.py`.",
 				},
 				"run_in_background": map[string]any{
-					"type":        "boolean",
-					"description": "Run detached in the background (no 120s timeout, non-blocking). Returns a process id. Use for one-shot tasks that take more than a few seconds (compiling, testing, installing, building, CI checks) or for long-running services (servers, watchers). For one-shot tasks the system auto-notifies on completion. For long-running services, verify with an external check (e.g., curl, pgrep) rather than polling terminal_output. The process is tracked by octo and KILLED when the session ends — for a daemon meant to outlive octo, use detached:true instead.",
+					"type":        "string",
+					"enum":        []string{"async", "interactive"},
+					"description": "Run detached in the background (no 120s timeout, non-blocking). \"async\" for one-shot tasks like tests/builds/installs — the system auto-notifies on completion and terminal_output is not allowed. \"interactive\" for long-running services or REPLs — terminal_output and terminal_input are allowed. The process is tracked by octo and KILLED when the session ends — for a daemon meant to outlive octo, use detached:true instead.",
 				},
 				"detached": map[string]any{
 					"type":        "boolean",
@@ -141,10 +173,15 @@ func (t TerminalTool) ExecuteStream(
 		}, nil
 	}
 
+	bgMode, useBg, err := parseBackgroundMode(input)
+	if err != nil {
+		return agent.ToolResult{Text: ""}, err
+	}
+
 	// Background launch: detach, no timeout, return the id immediately. The
 	// guard above still applies, so dangerous commands are blocked either way.
-	if bg, _ := input["run_in_background"].(bool); bg {
-		id, err := t.managerFor(ctx).Start(command)
+	if useBg {
+		id, err := t.managerFor(ctx).Start(command, bgMode)
 		if err != nil {
 			return agent.ToolResult{Text: ""}, err
 		}
@@ -154,9 +191,13 @@ func (t TerminalTool) ExecuteStream(
 				stdinWarn = stdinWriteWarning(werr)
 			}
 		}
+		notice := AsyncModeNotice
+		if bgMode == BgModeInteractive {
+			notice = InteractiveModeNotice
+		}
 		return agent.ToolResult{
-			Text: fmt.Sprintf("Started background process %s.%s\n\n%s", id, stdinWarn, BgPollNotice),
-			UI:   terminalUI(command, "running", fmt.Sprintf("background process %s", id)),
+			Text: fmt.Sprintf("Started %s background process %s.%s\n\n%s", bgMode, id, stdinWarn, notice),
+			UI:   terminalUI(command, "running", fmt.Sprintf("%s background process %s", bgMode, id)),
 		}, nil
 	}
 
@@ -189,7 +230,7 @@ func (t TerminalTool) ExecuteStream(
 	}
 
 	mgr := t.managerFor(ctx)
-	id, err := mgr.Start(command, WithOnLine(onLine), WithVisible(false))
+	id, err := mgr.Start(command, BgModeAsync, WithOnLine(onLine), WithVisible(false))
 	if err != nil {
 		return agent.ToolResult{Text: ""}, err
 	}
@@ -242,7 +283,7 @@ func (t TerminalTool) ExecuteStream(
 			mgr.Promote(id)
 			body := MaybeSpillOutput(id, snapshot())
 			return agent.ToolResult{
-				Text: fmt.Sprintf("%s\n\n[promoted to background process %s]\n\n%s", body, id, BgPollNotice),
+				Text: fmt.Sprintf("%s\n\n[promoted to async background process %s]\n\n%s", body, id, AsyncModeNotice),
 				UI:   terminalUI(command, "running", body),
 			}, nil
 		case <-timer.C:
@@ -251,7 +292,7 @@ func (t TerminalTool) ExecuteStream(
 			mgr.Promote(id)
 			body := MaybeSpillOutput(id, snapshot())
 			return agent.ToolResult{
-				Text: fmt.Sprintf("%s\n\n[timeout: command exceeded %s and continues as background process %s]\n\n%s", body, TerminalTimeout, id, BgPollNotice),
+				Text: fmt.Sprintf("%s\n\n[timeout: command exceeded %s and continues as async background process %s]\n\n%s", body, TerminalTimeout, id, AsyncModeNotice),
 				UI:   terminalUI(command, "running", body),
 			}, nil
 		case <-ctx.Done():
@@ -267,7 +308,7 @@ func (t TerminalTool) ExecuteStream(
 		default:
 		}
 
-		_, status, _, _ := mgr.Read(id)
+		_, status, _, _, _ := mgr.Read(id)
 		if strings.HasPrefix(status, "exited") {
 			body := MaybeSpillOutput(id, snapshot())
 			// Reap the hidden process: its output has been captured and
@@ -323,9 +364,8 @@ func terminalUI(command, status, output string) map[string]any {
 	}
 }
 
-// TerminalOutputTool reads new output (and status) from a background process
-// started by TerminalTool with run_in_background:true — the counterpart that makes
-// detached commands useful. It can also kill the process.
+// TerminalOutputTool reads new output (and status) from an INTERACTIVE
+// background process launched with terminal run_in_background:"interactive".
 type TerminalOutputTool struct{ mgr *BackgroundManager }
 
 func (t TerminalOutputTool) managerFor(ctx context.Context) *BackgroundManager {
@@ -337,7 +377,7 @@ func (t TerminalOutputTool) managerFor(ctx context.Context) *BackgroundManager {
 func (TerminalOutputTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name:        "terminal_output",
-		Description: "Peek at the recent output of a background process (the id from terminal run_in_background:true): a snapshot of the last N lines plus its status (running / exited). Read-only; to stop the process use kill_shell.\n\nUse this to CHECK PROGRESS of a still-running process on demand — e.g. inspect a server's startup logs. You do NOT need it to learn that a process finished or to get its result: completion is pushed to you automatically, carrying the final output. This is a snapshot, not a feed — repeated calls return the current tail, there is no 'new since last call', so do not call it in a loop. Repeated empty snapshots of a running process are detected as polling and will trigger a hard STOP reminder. To find an id you've lost track of, use terminal_list.",
+		Description: "Peek at the recent output of an INTERACTIVE background process launched with terminal run_in_background:\"interactive\". Snapshots the last N lines plus its status (running / exited). Read-only; to stop the process use kill_shell.\n\nUse this to CHECK PROGRESS of a still-running interactive process on demand — e.g. inspect a server's startup logs. You may NOT use terminal_output on async processes; async tasks must not be polled, so wait for the [BACKGROUND COMPLETED] notification instead. This is a snapshot, not a feed — repeated calls return the current tail, so do not call it in a loop. Repeated empty snapshots of a running process are detected as polling and will trigger a hard STOP reminder. To find an id you've lost track of, use terminal_list.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -372,7 +412,15 @@ func (t TerminalOutputTool) Execute(ctx context.Context, _ string, input map[str
 	if v, ok := input["lines"].(float64); ok { // JSON numbers decode as float64
 		lines = int(v)
 	}
-	out, status, found, blocked := t.managerFor(ctx).Tail(id, lines)
+	mgr := t.managerFor(ctx)
+	mode, ok := mgr.Mode(id)
+	if !ok {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: no background process %q (it may have been reaped — use terminal_list to see live processes)", id)
+	}
+	if mode != BgModeInteractive {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: process %q is an async task; do not poll it. Wait for the [BACKGROUND COMPLETED] notification instead", id)
+	}
+	out, status, found, blocked, _ := mgr.Tail(id, lines)
 	if !found {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_output: no background process %q (it may have been reaped — use terminal_list to see live processes)", id)
 	}
@@ -401,10 +449,10 @@ func (t TerminalOutputTool) Execute(ctx context.Context, _ string, input map[str
 	return agent.ToolResult{Text: header + "\n" + MaybeSpillOutput(id, out)}, nil
 }
 
-// TerminalInputTool sends text to the stdin of a running background process
-// started by TerminalTool with run_in_background:true. Use to interact with
-// long-running interactive applications (REPLs, configuration wizards, servers
-// that accept commands via stdin).
+// TerminalInputTool sends text to the stdin of a running INTERACTIVE background
+// process launched with terminal run_in_background:"interactive". Use to
+// interact with long-running interactive applications (REPLs, configuration
+// wizards, servers that accept commands via stdin).
 type TerminalInputTool struct{ mgr *BackgroundManager }
 
 func (t TerminalInputTool) managerFor(ctx context.Context) *BackgroundManager {
@@ -415,7 +463,7 @@ func (t TerminalInputTool) managerFor(ctx context.Context) *BackgroundManager {
 func (TerminalInputTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name:        "terminal_input",
-		Description: "Send text input to the stdin of a running background process started by terminal with run_in_background:true. Use to interact with long-running interactive applications (e.g., REPLs, configuration wizards, servers that accept commands via stdin). The input is written verbatim — include a trailing newline (\\n) if the process expects line-based input.",
+		Description: "Send text input to the stdin of a running INTERACTIVE background process launched with terminal run_in_background:\"interactive\". Use to interact with long-running interactive applications (e.g., REPLs, configuration wizards, servers that accept commands via stdin). You may NOT use terminal_input on async processes. The input is written verbatim — include a trailing newline (\\n) if the process expects line-based input.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -434,6 +482,8 @@ func (TerminalInputTool) Definition() agent.ToolDefinition {
 }
 
 // Execute writes input to the process's stdin. Unknown or exited id is an error.
+// Reject async processes: terminal_input is only meaningful for interactive
+// background tasks.
 func (t TerminalInputTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	id, _ := input["id"].(string)
 	if id == "" {
@@ -443,16 +493,25 @@ func (t TerminalInputTool) Execute(ctx context.Context, _ string, input map[stri
 	if text == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_input: input is required")
 	}
-	if err := t.managerFor(ctx).WriteStdin(id, text); err != nil {
+	mgr := t.managerFor(ctx)
+	mode, ok := mgr.Mode(id)
+	if !ok {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_input: no background process %q", id)
+	}
+	if mode != BgModeInteractive {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_input: process %q is an async task; do not send input to it", id)
+	}
+	if err := mgr.WriteStdin(id, text); err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("terminal_input: %w", err)
 	}
 	return agent.ToolResult{Text: fmt.Sprintf("Sent to %s.", id)}, nil
 }
 
 // KillShellTool terminates a background process started by TerminalTool with
-// run_in_background:true and returns its final output — the counterpart to
-// terminal_output, which only reads. Split out from terminal_output's old
-// kill:true flag so "stop this process" is a first-class, obvious action.
+// run_in_background:"async" or "interactive" and returns its final output —
+// the counterpart to terminal_output, which only reads. Split out from
+// terminal_output's old kill:true flag so "stop this process" is a first-class,
+// obvious action.
 type KillShellTool struct{ mgr *BackgroundManager }
 
 func (t KillShellTool) managerFor(ctx context.Context) *BackgroundManager {
@@ -463,7 +522,7 @@ func (t KillShellTool) managerFor(ctx context.Context) *BackgroundManager {
 func (KillShellTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name:        "kill_shell",
-		Description: "Terminate a background process started by terminal with run_in_background:true (the id it returned), and return its final output. Use to stop a server, watcher, or other long-running command you no longer need. To read output without stopping it, use terminal_output.\n\nFor long-running services (servers, watchers), prefer signal 'SIGTERM' for graceful shutdown so the process can clean up connections and release ports. Use 'SIGKILL' (default) for one-shot tasks or when SIGTERM fails.",
+		Description: "Terminate a background process started by terminal with run_in_background:\"async\" or \"interactive\" (the id it returned), and return its final output. Use to stop a server, watcher, or other background command you no longer need. To read output without stopping it, use terminal_output.\n\nFor long-running services (servers, watchers), prefer signal 'SIGTERM' for graceful shutdown so the process can clean up connections and release ports. Use 'SIGKILL' (default) for one-shot tasks or when SIGTERM fails.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -501,7 +560,7 @@ func (t KillShellTool) Execute(ctx context.Context, _ string, input map[string]a
 	// Give the process a moment to flush and the waiter to record exit.
 	time.Sleep(50 * time.Millisecond)
 
-	out, status, _, _ := mgr.Read(id) // found guaranteed: Kill succeeded
+	out, status, _, _, _ := mgr.Read(id) // found guaranteed: Kill succeeded
 	header := "[killed] [status: " + status + "]"
 	if out == "" {
 		return agent.ToolResult{Text: header + "\n(no new output)"}, nil
@@ -524,7 +583,7 @@ func (t TerminalListTool) managerFor(ctx context.Context) *BackgroundManager {
 func (TerminalListTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name:        "terminal_list",
-		Description: "List this session's background processes — those started with terminal run_in_background:true — with their id, status (running / exited), elapsed time, and command. Use to recover a process id you've lost track of, or to see what is still running before checking its output (terminal_output) or stopping it (kill_shell). Detached processes (terminal detached:true) are NOT listed — they're untracked by design.",
+		Description: "List this session's background processes — those started with terminal run_in_background:\"async\" or \"interactive\" — with their id, mode, status (running / exited), elapsed time, and command. Use to recover a process id you've lost track of, or to see what is still running before checking its output (terminal_output) or stopping it (kill_shell). Detached processes (terminal detached:true) are NOT listed — they're untracked by design.",
 		Parameters: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},
@@ -541,7 +600,7 @@ func (t TerminalListTool) Execute(ctx context.Context, _ string, _ map[string]an
 	var b strings.Builder
 	for _, in := range infos {
 		elapsed := time.Since(in.Start).Round(time.Second)
-		fmt.Fprintf(&b, "%s  [%s]  %s  %s\n", in.ID, in.Status, elapsed, in.Command)
+		fmt.Fprintf(&b, "%s  [%s]  [%s]  %s  %s\n", in.ID, in.Mode, in.Status, elapsed, in.Command)
 	}
 	return agent.ToolResult{Text: strings.TrimRight(b.String(), "\n")}, nil
 }

--- a/internal/tools/terminal_observe_test.go
+++ b/internal/tools/terminal_observe_test.go
@@ -21,7 +21,7 @@ func TestTerminalListTool(t *testing.T) {
 
 	if _, err := term.Execute(ctx, "terminal", map[string]any{
 		"command":           "sleep 30",
-		"run_in_background": true,
+		"run_in_background": "async",
 	}); err != nil {
 		t.Fatalf("launch: %v", err)
 	}
@@ -36,6 +36,9 @@ func TestTerminalListTool(t *testing.T) {
 	if !strings.Contains(res.Text, "sleep 30") {
 		t.Errorf("list should include the command, got %q", res.Text)
 	}
+	if !strings.Contains(res.Text, "[async]") {
+		t.Errorf("list should include the mode, got %q", res.Text)
+	}
 }
 
 // TestTerminalOutputTool_LinesSnapshot verifies the lines param trims to the
@@ -49,12 +52,12 @@ func TestTerminalOutputTool_LinesSnapshot(t *testing.T) {
 	// Print 5 lines then exit; wait for completion.
 	if _, err := (TerminalTool{mgr: m}).Execute(ctx, "terminal", map[string]any{
 		"command":           "printf 'l1\\nl2\\nl3\\nl4\\nl5\\n'",
-		"run_in_background": true,
+		"run_in_background": "interactive",
 	}); err != nil {
 		t.Fatalf("launch: %v", err)
 	}
 	waitFor(t, "exit", func() bool {
-		_, s, _, _ := m.Read("bg_1")
+		_, s, _, _, _ := m.Read("bg_1")
 		return strings.HasPrefix(s, "exited")
 	})
 

--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -34,6 +34,17 @@ func TestTerminalTool_Definition(t *testing.T) {
 	if _, ok := props["stdin"]; !ok {
 		t.Error("Parameters.properties.stdin should exist — the executor reads it, so the schema must declare it or the model never sends it")
 	}
+	rib, ok := props["run_in_background"].(map[string]any)
+	if !ok {
+		t.Fatal("Parameters.properties.run_in_background should be a map")
+	}
+	if rib["type"] != "string" {
+		t.Errorf("run_in_background.type = %v, want string", rib["type"])
+	}
+	wantEnum := []string{"async", "interactive"}
+	if got, ok := rib["enum"].([]string); !ok || len(got) != len(wantEnum) {
+		t.Errorf("run_in_background.enum = %v, want %v", rib["enum"], wantEnum)
+	}
 	req, ok := def.Parameters["required"].([]string)
 	if !ok {
 		t.Fatal("Parameters.required is not []string")
@@ -324,7 +335,7 @@ func main() {
 		t.Fatalf("go build helper: %v\n%s", err, buildOut)
 	}
 
-	id, err := mgr.Start(bin)
+	id, err := mgr.Start(bin, BgModeInteractive)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -350,7 +361,7 @@ func main() {
 	// only the last one drops output that arrived before the exit was seen.
 	var out string
 	for i := 0; i < 100; i++ {
-		chunk, status, _, _ := mgr.Read(id)
+		chunk, status, _, _, _ := mgr.Read(id)
 		out += chunk
 		if strings.HasPrefix(status, "exited") {
 			break
@@ -371,13 +382,13 @@ func TestTerminalInputTool_ExitedProcess(t *testing.T) {
 	inputTool := TerminalInputTool{mgr: mgr}
 
 	// Start a trivial command that exits immediately.
-	id, err := mgr.Start("echo done")
+	id, err := mgr.Start("echo done", BgModeInteractive)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	// Wait for it to exit.
 	for i := 0; i < 50; i++ {
-		_, status, _, _ := mgr.Read(id)
+		_, status, _, _, _ := mgr.Read(id)
 		if strings.HasPrefix(status, "exited") {
 			break
 		}
@@ -508,17 +519,17 @@ func TestTerminalTool_Stdin_Background(t *testing.T) {
 
 	res, err := term.ExecuteStream(context.Background(), "terminal", map[string]any{
 		"command":           "cat",
-		"run_in_background": true,
+		"run_in_background": "async",
 		"stdin":             stdinBody,
 	}, nil)
 	if err != nil {
 		t.Fatalf("ExecuteStream bg: %v", err)
 	}
-	if !strings.Contains(res.Text, "Started background process") {
-		t.Fatalf("expected background start, got: %s", res.Text)
+	if !strings.Contains(res.Text, "Started async background process") {
+		t.Fatalf("expected async background start, got: %s", res.Text)
 	}
-	// Extract the process id from "Started background process <id>."
-	id := strings.TrimPrefix(res.Text, "Started background process ")
+	// Extract the process id from "Started async background process <id>."
+	id := strings.TrimPrefix(res.Text, "Started async background process ")
 	id = strings.SplitN(id, ".", 2)[0]
 
 	// Wait for the process to finish, accumulating output as we poll —
@@ -526,7 +537,7 @@ func TestTerminalTool_Stdin_Background(t *testing.T) {
 	var out string
 	exited := false
 	for i := 0; i < 100; i++ {
-		chunk, status, _, _ := mgr.Read(id)
+		chunk, status, _, _, _ := mgr.Read(id)
 		out += chunk
 		if strings.HasPrefix(status, "exited") {
 			exited = true


### PR DESCRIPTION
## Summary

Changes `terminal.run_in_background` from a boolean to an explicit enum (`"async"` / `"interactive"`) so the model can no longer confuse one-shot background tasks with long-running services/REPLs.

## Breaking change

The `terminal` tool no longer accepts `run_in_background: true`. Valid values are now:

- `"async"` — one-shot tasks (tests, builds, installs, CI checks). Completion is pushed automatically via `[BACKGROUND COMPLETED]`; `terminal_output` and `terminal_input` are rejected.
- `"interactive"` — long-running services and REPLs (servers, watchers, `rails c`, `octo serve`). `terminal_output` and `terminal_input` are allowed.

Synchronous commands that exceed the 120 s timeout are promoted to `async` background tasks.

## Implementation highlights

- `BackgroundManager.Start` now takes a `BackgroundMode` (`async` / `interactive`).
- Each `bgProcess` stores its mode; `terminal_output` / `terminal_input` check it and return a clear error for async tasks.
- `terminal_list` now prints the process mode alongside id, status, elapsed time, and command.
- Replaced the generic `BgPollNotice` / `ServiceModeNotice` with `AsyncModeNotice` / `InteractiveModeNotice` that explicitly tell the model what it may and may not do.
- Updated docs (`terminal-tools.md`, `terminal-manual-promote.md`), system prompt (`base.md`), permission comments (`defaults.yml`), and `CHANGELOG.md`.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -race ./...` ✅
- `gofmt -w` ✅

No new third-party dependencies.