### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased — 1.2.0-dev]
+## [1.2.0] — 2026-06-27
 
 ### Breaking
 - **Terminal `run_in_background` is now an enum (`"async"` / `"interactive"`).**


### PR DESCRIPTION
Release 1.2.0 — updates CHANGELOG for the new version.