### PR TITLE
feat(channel): support /bind --force to take over sessions from other entries

### DIFF
--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -296,7 +296,7 @@ func (m *Manager) CommandRouter(ev InboundEvent) string {
 	case "/clear":
 		return m.cmdClear(ev)
 	default:
-		return fmt.Sprintf("Unknown command: %s. Available: /bind <number|id>, /unbind, /list, /clear, /compact, /stop, /status", cmd)
+		return fmt.Sprintf("Unknown command: %s. Available: /bind [--force] <number|id>, /unbind, /list, /clear, /compact, /stop, /status", cmd)
 	}
 }
 
@@ -321,18 +321,22 @@ func (m *Manager) cmdClear(ev InboundEvent) string {
 // by its list number or (short/full) ID. The redirection is recorded in the
 // persistent binding table so it survives a restart, and no history is
 // deleted — /bind switches conversations rather than starting a fresh one.
-// If the target session is bound to another entry, the bind is rejected so
-// IM cannot silently take over a session owned by CLI/TUI/Web.
+// By default, if the target session is bound to another entry, the bind is
+// rejected so IM cannot silently take over a session owned by CLI/TUI/Web.
+// Pass --force to take over a session whose turn lease has expired.
 func (m *Manager) cmdBind(ev InboundEvent, args []string) string {
-	if len(args) == 0 {
-		return "Usage: /bind <number|id> — run /list to see sessions, then attach this chat to one. History is preserved."
+	steal, targetArg, ok := parseBindArgs(args)
+	if !ok {
+		return "Usage: /bind [--force] <number|id> — run /list to see sessions, then attach this chat to one. History is preserved."
 	}
-	target := m.resolveBindTarget(args[0])
+	target := m.resolveBindTarget(targetArg)
 	if target == nil {
-		return fmt.Sprintf("No session matches %q. Run /list to see available sessions.", args[0])
+		return fmt.Sprintf("No session matches %q. Run /list to see available sessions.", targetArg)
 	}
 
-	if res, _, err := target.Bind(agent.EntryChannel, false); res == agent.Rejected {
+	previousEntry := target.BoundEntry
+	res, _, err := target.Bind(agent.EntryChannel, steal)
+	if res == agent.Rejected {
 		return fmt.Sprintf("Cannot bind: %v", err)
 	}
 	if err := target.Save(); err != nil {
@@ -351,7 +355,31 @@ func (m *Manager) cmdBind(ev InboundEvent, args []string) string {
 	// the old session keeps persisting to its own store — nothing is deleted.
 	m.sessions.LoadAndDelete(key)
 	m.sessions.Store(key, m.newSession(key, ev))
+	if res == agent.Stolen {
+		return fmt.Sprintf("Taken over %q [%s] from %s. History preserved.", target.DisplayTitle(), target.ShortID(), previousEntry)
+	}
 	return fmt.Sprintf("Bound to session %q [%s]. History preserved.", target.DisplayTitle(), target.ShortID())
+}
+
+// parseBindArgs extracts the optional --force flag and the target identifier
+// from /bind arguments. It accepts both "/bind --force <id>" and
+// "/bind <id> --force". The second return value is the target argument; the
+// third reports whether the args are well-formed.
+func parseBindArgs(args []string) (steal bool, target string, ok bool) {
+	for _, a := range args {
+		if strings.EqualFold(a, "--force") {
+			steal = true
+			continue
+		}
+		if target != "" {
+			return false, "", false
+		}
+		target = a
+	}
+	if target == "" {
+		return false, "", false
+	}
+	return steal, target, true
 }
 
 // resolveBindTarget maps a /bind argument to a persisted session: a 1-based

--- a/internal/channel/persist_test.go
+++ b/internal/channel/persist_test.go
@@ -183,6 +183,72 @@ func TestCmdBind_RejectedWhenBoundToOtherEntry(t *testing.T) {
 	}
 }
 
+// TestCmdBind_ForceTakesOverOtherEntry: /bind --force may take over a session
+// owned by another entry, as long as no turn lease is active.
+func TestCmdBind_ForceTakesOverOtherEntry(t *testing.T) {
+	tempHome(t)
+	m := testManager()
+
+	// A session owned by the web entry, with no active lease.
+	webSess := agent.NewSession("stub-model", "")
+	webSess.BoundEntry = agent.EntryWeb
+	webSess.BoundAt = time.Now()
+	webSess.Messages = []agent.Message{{Role: agent.RoleUser, Content: "web context"}}
+	if err := webSess.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	evB := InboundEvent{Platform: "feishu", ChatID: "cB", UserID: "uB"}
+	reply := m.cmdBind(evB, []string{"--force", webSess.ID})
+	if !strings.Contains(strings.ToLower(reply), "taken over") {
+		t.Fatalf("expected takeover success, got %q", reply)
+	}
+	if !strings.Contains(reply, agent.EntryWeb) {
+		t.Fatalf("expected reply to name previous owner %q, got %q", agent.EntryWeb, reply)
+	}
+
+	bound := m.GetSession(evB)
+	if bound == nil {
+		t.Fatal("expected a session after /bind --force")
+	}
+	if !bound.Store.BoundTo(agent.EntryChannel) {
+		t.Errorf("bound session entry = %q, want %q", bound.Store.BoundEntry, agent.EntryChannel)
+	}
+
+	// The binding is persisted: a fresh manager sees channel ownership.
+	m2 := testManager()
+	again := m2.GetOrCreateSession(evB)
+	if !again.Store.BoundTo(agent.EntryChannel) {
+		t.Errorf("persisted entry after takeover = %q, want %q", again.Store.BoundEntry, agent.EntryChannel)
+	}
+}
+
+// TestCmdBind_ForceRejectedWhenLeaseActive: /bind --force cannot steal a
+// session while another entry holds an active turn lease.
+func TestCmdBind_ForceRejectedWhenLeaseActive(t *testing.T) {
+	tempHome(t)
+	m := testManager()
+
+	webSess := agent.NewSession("stub-model", "")
+	webSess.BoundEntry = agent.EntryWeb
+	webSess.BoundAt = time.Now()
+	if err := webSess.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if err := webSess.WriteLease(agent.EntryWeb, time.Now().Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	evB := InboundEvent{Platform: "feishu", ChatID: "cB", UserID: "uB"}
+	reply := m.cmdBind(evB, []string{webSess.ID, "--force"})
+	if !strings.Contains(strings.ToLower(reply), "cannot bind") {
+		t.Fatalf("expected rejection due to active lease, got %q", reply)
+	}
+	if m.GetSession(evB) != nil {
+		t.Fatal("expected no session after rejected forced /bind")
+	}
+}
+
 // TestCmdUnbind_ReleasesBoundEntry: /unbind clears the IM entry binding so
 // other entries can use the session.
 func TestCmdUnbind_ReleasesBoundEntry(t *testing.T) {
@@ -240,6 +306,31 @@ func TestCmdClear_WipesHistoryKeepsStore(t *testing.T) {
 	}
 	if len(reloaded.Messages) != 0 {
 		t.Errorf("persisted history after /clear = %d, want 0", len(reloaded.Messages))
+	}
+}
+
+func TestParseBindArgs(t *testing.T) {
+	cases := []struct {
+		args       []string
+		wantSteal  bool
+		wantTarget string
+		wantOK     bool
+	}{
+		{args: []string{"abc"}, wantSteal: false, wantTarget: "abc", wantOK: true},
+		{args: []string{"--force", "abc"}, wantSteal: true, wantTarget: "abc", wantOK: true},
+		{args: []string{"abc", "--force"}, wantSteal: true, wantTarget: "abc", wantOK: true},
+		{args: []string{"--Force", "abc"}, wantSteal: true, wantTarget: "abc", wantOK: true},
+		{args: []string{}, wantOK: false},
+		{args: []string{"--force"}, wantOK: false},
+		{args: []string{"abc", "def"}, wantOK: false},
+		{args: []string{"abc", "--force", "def"}, wantOK: false},
+	}
+	for _, c := range cases {
+		steal, target, ok := parseBindArgs(c.args)
+		if steal != c.wantSteal || target != c.wantTarget || ok != c.wantOK {
+			t.Errorf("parseBindArgs(%v) = (%v, %q, %v), want (%v, %q, %v)",
+				c.args, steal, target, ok, c.wantSteal, c.wantTarget, c.wantOK)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

IM channel can now steal a session bound to CLI/TUI/Web/API/Cron when the holder's turn lease has expired. The default `/bind` behavior remains unchanged to prevent silent takeover.

## Changes

- Parse optional `--force` flag in both positions (`/bind --force <id>` and `/bind <id> --force`).
- Pass `steal=true` to `session.Bind` when `--force` is present.
- Surface takeover in the reply (`"Taken over ... from <entry>"`).
- Add tests for successful takeover, active-lease rejection, and argument parsing.

## Why

Before this change, if a session was owned by another entry (e.g., created in the Web UI), an IM user could not attach to it via `/bind` even after the other entry was idle. The only recovery path was to wait for lease expiry and then re-bind, or to release the binding from the owning entry. `/bind --force` makes this explicit and discoverable while still honoring the cross-process lease guard.

## Testing

- `go test -race ./internal/channel/...` ✅
- `make test` (full repo, `-race`) ✅

## Dependencies

No new third-party dependencies.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>