### PR TITLE
fix(server): acquire binding/lease for idle follow-up turns in web and IM

### DIFF
--- a/internal/server/bg_tasks.go
+++ b/internal/server/bg_tasks.go
@@ -96,10 +96,19 @@ func (s *Server) deliverModelNote(sessionID, note string) {
 // a turn is running (its chained loop drains the queue at turn end) or the
 // queue is already empty by the time the lock is held.
 func (s *Server) kickIdleSteerTurn(sessionID string) {
+	// Acquire the persistent binding before locking the turn: this keeps the
+	// same lock order as the user-initiated web path and prevents idle
+	// follow-up turns from interleaving with another entry (cli/tui/im) that
+	// has taken over the session while we were idle.
+	if ok, _, _ := s.acquireSessionBinding(sessionID, agent.EntryWeb, false); !ok {
+		return
+	}
+
 	mu := s.sessionTurnLock(sessionID)
 	mu.Lock()
 	if s.turnRunning[sessionID] {
 		mu.Unlock()
+		s.releaseSessionBinding(sessionID, agent.EntryWeb)
 		return
 	}
 	sess, err := agent.LoadSession(sessionID)
@@ -107,11 +116,13 @@ func (s *Server) kickIdleSteerTurn(sessionID string) {
 		// Session not loadable (deleted, or a transient read error) — leave
 		// the queue untouched; the next turn will pick the note up.
 		mu.Unlock()
+		s.releaseSessionBinding(sessionID, agent.EntryWeb)
 		return
 	}
 	items := s.drainSteer(sessionID)
 	if len(items) == 0 {
 		mu.Unlock()
+		s.releaseSessionBinding(sessionID, agent.EntryWeb)
 		return
 	}
 	s.turnRunning[sessionID] = true
@@ -130,6 +141,7 @@ func (s *Server) kickIdleSteerTurn(sessionID string) {
 			mu.Lock()
 			s.turnRunning[sessionID] = false
 			mu.Unlock()
+			s.releaseSessionBinding(sessionID, agent.EntryWeb)
 		}()
 		s.runAgentTurnLoop(sess, strings.Join(texts, "\n\n"), blocks, imageRefsFromBlocks(blocks))
 	}()

--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -211,6 +211,45 @@ func TestDeliverModelNote_IdleKicksTurn(t *testing.T) {
 	}
 }
 
+// TestKickIdleSteerTurn_SkipsWhenBoundToOtherEntry: if another entry has
+// taken over the session while we were idle, the idle follow-up turn must not
+// run; the note stays in the steer queue for the owning entry to drain.
+func TestKickIdleSteerTurn_SkipsWhenBoundToOtherEntry(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.wsHub = newWSHub()
+	srv.turnRunning = map[string]bool{}
+	srv.liveStates = map[string]*sessionLiveState{}
+	srv.interrupts = map[string]context.CancelFunc{}
+
+	sess := agent.NewSession("stub-model", "")
+	sess.BoundEntry = agent.EntryCLI
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	note := "<system-reminder>\n[BACKGROUND COMPLETED]\nBackground process bg_1 (`make build`) exited: 0.\n</system-reminder>"
+	srv.enqueueSteer(sess.ID, agent.InboxItem{Text: note})
+	srv.kickIdleSteerTurn(sess.ID)
+
+	// Give any goroutine time to start.
+	time.Sleep(100 * time.Millisecond)
+
+	mu := srv.sessionTurnLock(sess.ID)
+	mu.Lock()
+	running := srv.turnRunning[sess.ID]
+	mu.Unlock()
+	if running {
+		t.Fatal("idle turn should not start when session is bound to another entry")
+	}
+	if leftover := srv.drainSteer(sess.ID); len(leftover) != 1 {
+		t.Errorf("steer queue = %d items, want 1 (preserved for the owning entry)", len(leftover))
+	}
+}
+
 // prepareToolTurn must hand back the SAME session-scoped manager on every
 // turn of a session (async mode), so spawns survive turn boundaries — and a
 // sid-less context still gets the old per-turn synchronous manager.

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -394,6 +394,57 @@ func TestHandleChannelMessage_BackgroundCompletionTriggersIdleTurn(t *testing.T)
 	}
 }
 
+// TestRunChannelIdleTurn_SkipsWhenBoundToOtherEntry: if another entry has
+// taken over the session while the IM chat was idle, the idle follow-up turn
+// must not run.
+func TestRunChannelIdleTurn_SkipsWhenBoundToOtherEntry(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+		return agent.New(&stubSender{}, "stub-model")
+	}, channel.BindByChat)
+	ad := &fullFakeAdapter{}
+	ev := evFor("hello")
+
+	// Pre-create the store file bound to web so the idle turn sees the
+	// authoritative binding and refuses to run.
+	// First create the channel session to learn its deterministic store ID,
+	// then overwrite the file with a web-bound meta record.
+	sess := srv.channelMgr.GetOrCreateSession(ev)
+	storeID := sess.Store.ID
+	path, err := sess.Store.SavePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	webBound := agent.NewSession("stub-model", "")
+	webBound.ID = storeID
+	webBound.Source = "channel"
+	webBound.BoundEntry = agent.EntryWeb
+	webBound.BoundAt = time.Now()
+	if err := webBound.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reload so the in-memory store reflects the web-bound file.
+	loaded, err := agent.LoadSession(storeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess.Store = loaded
+
+	sess.Agent.Inbox.Enqueue("<system-reminder>[BACKGROUND COMPLETED] bg done.</system-reminder>")
+	srv.runChannelIdleTurn(context.Background(), sess, ad, ev)
+
+	// The adapter must not have sent a reply from the idle turn.
+	for _, txt := range ad.texts() {
+		if strings.Contains(txt, "stub reply") {
+			t.Fatal("idle turn ran while session was bound to another entry")
+		}
+	}
+}
+
 // TestInjectorFor_SessionStickyAndDroppedOnUnbind: the injector's
 // once-per-session recall latch must survive turns but reset with /unbind.
 func TestInjectorFor_SessionStickyAndDroppedOnUnbind(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1701,6 +1701,23 @@ func (s *Server) wireChannelCompletionHooks(sess *channel.Session, ad channel.Ad
 // arrived while the session was idle. It competes with the synchronous turn
 // path for the session's runMu; BeginRun serialises them, so only one wins.
 func (s *Server) runChannelIdleTurn(ctx context.Context, sess *channel.Session, ad channel.Adapter, ev channel.InboundEvent) {
+	// Acquire the persistent binding before locking the turn: this matches the
+	// user-initiated IM path and prevents idle follow-up turns from
+	// interleaving with another entry (web/cli/tui) that has taken over the
+	// session while we were idle.
+	storeID := sess.Store.ID
+	if ok, _, _ := s.acquireSessionBinding(storeID, agent.EntryChannel, false); !ok {
+		return
+	}
+	defer s.releaseSessionBinding(storeID, agent.EntryChannel)
+
+	// Enroll in the drain gate so graceful shutdown waits for idle follow-up
+	// turns just like user-initiated channel turns and web turns.
+	if err := s.drain.begin(); err != nil {
+		return
+	}
+	defer s.drain.end()
+
 	ctx, done := sess.BeginRun(ctx)
 	defer done()
 
@@ -1708,10 +1725,6 @@ func (s *Server) runChannelIdleTurn(ctx context.Context, sess *channel.Session, 
 	if len(items) == 0 {
 		return
 	}
-
-	// Re-wire hooks in case this is the first idle turn after a process
-	// restart or the session was recreated while we were waiting.
-	s.wireChannelCompletionHooks(sess, ad, ev)
 
 	s.runChannelTurns(ctx, sess, ad, ev, strings.Join(agent.Texts(items), "\n\n"))
 }


### PR DESCRIPTION
## Summary

Both `kickIdleSteerTurn` (web) and `runChannelIdleTurn` (IM) previously started follow-up turns using only the in-process turn lock. This left a window where another entry could take over the session between the initial turn ending and the idle turn starting.

This PR makes idle follow-up turns acquire and release the persistent session binding/lease, matching user-initiated turns.

## Changes

- `kickIdleSteerTurn`: calls `acquireSessionBinding(..., EntryWeb, false)` before locking the turn; releases after the turn.
- `runChannelIdleTurn`: calls `acquireSessionBinding(..., EntryChannel, false)` before locking the turn; releases after the turn.
- `runChannelIdleTurn` enrolled in `drainGate` for graceful shutdown parity.
- Added tests for both paths skipping when the session is bound to another entry.

## Behaviour on conflict

- **Web**: the completion note stays in the steer queue for the owning entry to drain.
- **IM**: the note stays in the agent's Inbox for the next bound turn.

## Testing

- `go test -race ./internal/server/...` ✅
- `make test` (full repo, `-race`) ✅

## Dependencies

No new third-party dependencies.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>