### PR TITLE
fix(channel): suppress EventToolError chat messages in IM

### DIFF
--- a/internal/channel/ui_controller.go
+++ b/internal/channel/ui_controller.go
@@ -2,7 +2,6 @@ package channel
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"sync"
 
@@ -69,7 +68,10 @@ func (u *UIController) handleEvent(ev agent.AgentEvent) {
 	case agent.EventToolDone:
 		u.onToolDone(ev.ToolName, ev.Output)
 	case agent.EventToolError:
-		u.onToolError(ev.ToolName, ev.Err, ev.Output)
+		// Suppress tool errors in IM — the model sees the error result in
+		// context and can explain it in its own reply; a separate ❌ message
+		// is noisy and can leak implementation details into group chats.
+		u.onToolError(ev.ToolName)
 	case agent.EventTurnDone:
 		u.onTurnDone(ev.Reply)
 	case agent.EventToolInputDelta:
@@ -116,17 +118,13 @@ func (u *UIController) onToolDone(toolName, output string) {
 	u.fileBuf = append(u.fileBuf, files...)
 }
 
-// onToolError handles failed tool execution. We flush any pending text, then
-// send a concise error summary.
-func (u *UIController) onToolError(toolName, errMsg, output string) {
+// onToolError notes that a tool failed. The error is not surfaced as a chat
+// message; the model receives the error in the tool result and can address it
+// in its reply.
+func (u *UIController) onToolError(toolName string) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	u.inTool = false
-
-	u.flushTextLocked()
-
-	msg := fmt.Sprintf("❌ Tool %q failed: %s", toolName, truncate(errMsg, 200))
-	u.sendText(msg)
 }
 
 // onTurnDone finalizes the turn: flushes remaining text, sends file previews,

--- a/internal/channel/ui_controller_test.go
+++ b/internal/channel/ui_controller_test.go
@@ -97,7 +97,7 @@ func TestUIController_ToolDoneBuffersFiles(t *testing.T) {
 	}
 }
 
-func TestUIController_ToolErrorSendsError(t *testing.T) {
+func TestUIController_ToolErrorSuppressed(t *testing.T) {
 	mock := &mockAdapter{platform: "mock"}
 	ctrl := NewUIController(mock, "chat1", "")
 	handler := ctrl.Handler()
@@ -105,12 +105,8 @@ func TestUIController_ToolErrorSendsError(t *testing.T) {
 	handler(agent.AgentEvent{Kind: agent.EventToolStarted, ToolName: "read_file"})
 	handler(agent.AgentEvent{Kind: agent.EventToolError, ToolName: "read_file", Err: "permission denied", Output: ""})
 
-	if mock.sentTextCount() != 1 {
-		t.Fatalf("expected 1 error message, got %d", mock.sentTextCount())
-	}
-	last := mock.lastSentText()
-	if !strings.Contains(last.text, "failed") {
-		t.Fatalf("expected error message to contain 'failed', got: %q", last.text)
+	if mock.sentTextCount() != 0 {
+		t.Fatalf("expected no chat message for tool error, got %d", mock.sentTextCount())
 	}
 }
 


### PR DESCRIPTION
## Summary

Stop forwarding `EventToolError` to IM adapters. The model already sees the error in the tool result and can explain it in its own reply; a separate ❌ message is noisy and can leak implementation details into group chats.

## Changes

- `internal/channel/ui_controller.go`: `onToolError` now only resets `inTool` state instead of sending a chat message. Removed unused `fmt` import.
- `internal/channel/ui_controller_test.go`: Renamed `TestUIController_ToolErrorSendsError` → `TestUIController_ToolErrorSuppressed` and asserted zero adapter messages.

## Verification

- `gofmt -w`
- `go vet ./internal/channel/...`
- `make test` (race) ✅

No new third-party dependencies.