### PR TITLE
fix(channel): suppress file-path summary in IM

### DIFF
--- a/internal/channel/ui_controller.go
+++ b/internal/channel/ui_controller.go
@@ -9,8 +9,8 @@ import (
 )
 
 // UIController bridges agent.AgentEvent stream to IM platform messages.
-// It suppresses noisy tool-call events, buffers file previews, and forwards
-// meaningful events (text deltas, tool results, completion) to the adapter.
+// It suppresses noisy tool-call events and forwards only the model's text
+// reply to the adapter.
 type UIController struct {
 	adapter Adapter
 	chatID  string
@@ -26,9 +26,6 @@ type UIController struct {
 	// pendingTextMsgID is the message ID of the last text message we sent,
 	// used for in-place updates on platforms that support it.
 	pendingTextMsgID string
-
-	// fileBuf accumulates file paths mentioned in tool results for batch preview.
-	fileBuf []string
 
 	// toolCount tracks how many tools have started (for suppression heuristics).
 	toolCount int
@@ -66,7 +63,7 @@ func (u *UIController) handleEvent(ev agent.AgentEvent) {
 	case agent.EventToolProgress:
 		// Suppress progress noise in IM — too chatty.
 	case agent.EventToolDone:
-		u.onToolDone(ev.ToolName, ev.Output)
+		u.onToolDone(ev.ToolName)
 	case agent.EventToolError:
 		// Suppress tool errors in IM — the model sees the error result in
 		// context and can explain it in its own reply; a separate ❌ message
@@ -106,16 +103,12 @@ func (u *UIController) onToolStarted(toolName string) {
 	u.inTool = true
 }
 
-// onToolDone handles successful tool completion. We extract file references from
-// the output and buffer them for a batched preview at turn end.
-func (u *UIController) onToolDone(toolName, output string) {
+// onToolDone notes that a tool completed successfully. Tool output is not
+// surfaced as a separate chat message; only the model's text reply is shown.
+func (u *UIController) onToolDone(toolName string) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	u.inTool = false
-
-	// Extract file paths from tool output for potential preview.
-	files := extractFilePaths(output)
-	u.fileBuf = append(u.fileBuf, files...)
 }
 
 // onToolError notes that a tool failed. The error is not surfaced as a chat
@@ -127,13 +120,12 @@ func (u *UIController) onToolError(toolName string) {
 	u.inTool = false
 }
 
-// onTurnDone finalizes the turn: flushes remaining text, sends file previews,
-// resets state, then force-drains any adapter send queue so the final message
-// is delivered immediately instead of waiting for the background flush timer.
+// onTurnDone finalizes the turn: flushes remaining text, resets state, then
+// force-drains any adapter send queue so the final message is delivered
+// immediately instead of waiting for the background flush timer.
 func (u *UIController) onTurnDone(reply *agent.Reply) {
 	u.mu.Lock()
 	u.flushTextLocked()
-	u.flushFilesLocked()
 	u.resetLocked()
 	u.mu.Unlock() // explicit unlock before Flush — Flush may block during send
 
@@ -164,47 +156,9 @@ func (u *UIController) flushTextLocked() {
 	}
 }
 
-// flushFilesLocked sends batched file previews. Must be called with mu held.
-func (u *UIController) flushFilesLocked() {
-	if len(u.fileBuf) == 0 {
-		return
-	}
-	// Deduplicate.
-	seen := make(map[string]bool, len(u.fileBuf))
-	unique := make([]string, 0, len(u.fileBuf))
-	for _, f := range u.fileBuf {
-		if !seen[f] {
-			seen[f] = true
-			unique = append(unique, f)
-		}
-	}
-	u.fileBuf = u.fileBuf[:0]
-
-	// Send a summary message with file references.
-	if len(unique) > 0 {
-		var sb strings.Builder
-		sb.WriteString("📎 Files:\n")
-		for _, f := range unique {
-			sb.WriteString("• ")
-			sb.WriteString(f)
-			sb.WriteByte('\n')
-		}
-		u.sendText(strings.TrimSpace(sb.String()))
-	}
-}
-
-// sendText sends a text message through the adapter (unlocked helper).
-func (u *UIController) sendText(text string) {
-	if text == "" {
-		return
-	}
-	u.adapter.SendText(u.chatID, text, u.replyTo)
-}
-
 // resetLocked clears per-turn state. Must be called with mu held.
 func (u *UIController) resetLocked() {
 	u.textBuf.Reset()
-	u.fileBuf = u.fileBuf[:0]
 	u.pendingTextMsgID = ""
 	u.toolCount = 0
 	u.inTool = false
@@ -230,27 +184,6 @@ func shouldFlush(buf string) bool {
 		}
 	}
 	return false
-}
-
-// extractFilePaths scans tool output for likely file path references.
-// This is a heuristic — it looks for lines that look like file operations.
-func extractFilePaths(output string) []string {
-	var paths []string
-	for _, line := range strings.Split(output, "\n") {
-		line = strings.TrimSpace(line)
-		// Simple heuristic: lines containing "/" that don't look like URLs.
-		if strings.Contains(line, "/") && !strings.HasPrefix(line, "http") {
-			// Take the last word as the path candidate.
-			fields := strings.Fields(line)
-			if len(fields) > 0 {
-				candidate := fields[len(fields)-1]
-				if strings.Contains(candidate, "/") && !strings.Contains(candidate, "://") {
-					paths = append(paths, candidate)
-				}
-			}
-		}
-	}
-	return paths
 }
 
 // truncate limits a string to maxLen, adding an ellipsis if truncated.

--- a/internal/channel/ui_controller_test.go
+++ b/internal/channel/ui_controller_test.go
@@ -62,7 +62,7 @@ func TestUIController_ToolEventsSuppressed(t *testing.T) {
 
 }
 
-func TestUIController_ToolDoneBuffersFiles(t *testing.T) {
+func TestUIController_ToolDoneSuppressed(t *testing.T) {
 	mock := &mockAdapter{platform: "mock"}
 	ctrl := NewUIController(mock, "chat1", "")
 	handler := ctrl.Handler()
@@ -71,29 +71,19 @@ func TestUIController_ToolDoneBuffersFiles(t *testing.T) {
 	handler(agent.AgentEvent{Kind: agent.EventToolStarted, ToolName: "read_file"})
 	handler(agent.AgentEvent{Kind: agent.EventToolDone, ToolName: "read_file", Output: output})
 
-	// Files should be buffered, not sent yet.
 	if mock.sentTextCount() != 0 {
-		t.Fatalf("expected no message yet, got %d", mock.sentTextCount())
+		t.Fatalf("expected no message for tool done, got %d", mock.sentTextCount())
 	}
 
-	// End turn flushes files.
+	// End turn should only flush the model's reply text, not a file summary.
+	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "Done"})
 	handler(agent.AgentEvent{Kind: agent.EventTurnDone, Reply: &agent.Reply{Content: "Done"}})
 
-	// Should have sent the reply text and a file summary.
-	if mock.sentTextCount() < 1 {
-		t.Fatalf("expected at least 1 sent text, got %d", mock.sentTextCount())
+	if mock.sentTextCount() != 1 {
+		t.Fatalf("expected 1 reply text, got %d", mock.sentTextCount())
 	}
-
-	// Check that file summary was sent.
-	found := false
-	for _, st := range mock.sentTexts {
-		if strings.Contains(st.text, "file.go") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("expected file summary in sent messages, got: %+v", mock.sentTexts)
+	if strings.Contains(mock.lastSentText().text, "file.go") {
+		t.Fatalf("expected no file summary, got: %q", mock.lastSentText().text)
 	}
 }
 
@@ -127,20 +117,6 @@ func TestUIController_ShouldFlush(t *testing.T) {
 	// Short incomplete sentence does not flush.
 	if shouldFlush("Hel") {
 		t.Error("expected no flush on short text")
-	}
-}
-
-func TestUIController_ExtractFilePaths(t *testing.T) {
-	output := "Read file: /path/to/file.go\nWrote /another/file.txt\nURL: http://example.com"
-	paths := extractFilePaths(output)
-	if len(paths) != 2 {
-		t.Fatalf("expected 2 paths, got %d: %v", len(paths), paths)
-	}
-	if paths[0] != "/path/to/file.go" {
-		t.Errorf("unexpected path[0]: %q", paths[0])
-	}
-	if paths[1] != "/another/file.txt" {
-		t.Errorf("unexpected path[1]: %q", paths[1])
 	}
 }
 


### PR DESCRIPTION
## Summary

IM channel should only show the model's text reply. The `📎 Files:` summary that was sent after `EventToolDone` is now suppressed.

## Rationale

- Tool output is already present in the conversation context for the model.
- File references in tool output are not meaningful as a separate chat message.
- Group chats especially suffer from noisy tool metadata messages.

## Changes

- `internal/channel/ui_controller.go`:
  - Removed `fileBuf`, `flushFilesLocked`, `extractFilePaths`, and the `📎 Files:` summary.
  - `onToolDone` now only resets `inTool` state.
  - `onTurnDone` only flushes text and resets state.
- `internal/channel/ui_controller_test.go`:
  - Renamed `TestUIController_ToolDoneBuffersFiles` → `TestUIController_ToolDoneSuppressed`.
  - Removed `TestUIController_ExtractFilePaths`.

## Verification

- `gofmt -w`
- `go vet ./internal/channel/...`
- `make test` (race) ✅

No new third-party dependencies.