### PR TITLE
chore(release): bump version to 1.2.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.2.0"
+var Version = "1.2.1"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary

Bump `internal/version.Version` from `1.2.0` to `1.2.1` for the patch release.

## Changes since v1.2.0

- fix(channel): suppress EventToolError chat messages in IM (#856)
- fix(channel): suppress file-path summary in IM (#857)

No new third-party dependencies.