### PR TITLE
feat(channel): add /new slash command and hint it when session is bound to another entry

### DIFF
--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -295,10 +295,12 @@ func (m *Manager) CommandRouter(ev InboundEvent) string {
 		return m.cmdList()
 	case "/clear":
 		return m.cmdClear(ev)
+	case "/new":
+		return m.cmdNew(ev)
 	case "/compact":
 		return m.cmdCompact(ev)
 	default:
-		return fmt.Sprintf("Unknown command: %s. Available: /bind [--force] <number|id>, /unbind, /list, /clear, /compact, /stop, /status", cmd)
+		return fmt.Sprintf("Unknown command: %s. Available: /bind [--force] <number|id>, /unbind, /list, /clear, /new, /compact, /stop, /status", cmd)
 	}
 }
 
@@ -359,6 +361,43 @@ func (m *Manager) cmdCompact(ev InboundEvent) string {
 		return fmt.Sprintf("Reclaimed stale tool output · ~%d → ~%d tokens", stats.BeforeTokens, stats.AfterTokens)
 	}
 	return fmt.Sprintf("Compacted context · folded %d message(s) · ~%d → ~%d tokens", stats.FoldedMsgs, stats.BeforeTokens, stats.AfterTokens)
+}
+
+// cmdNew creates a brand-new session and binds the current chat to it. The old
+// store (if any) is left on disk but detached from this chat, so /new is safe
+// to use even when another entry owns the chat's usual session.
+func (m *Manager) cmdNew(ev InboundEvent) string {
+	key := sessionKeyFor(m.mode, ev)
+
+	// Create a fresh session owned by channel.
+	st := agent.NewSession(m.agentModel(), "")
+	st.Source = "channel"
+	st.Bind(agent.EntryChannel, false)
+	if err := st.Save(); err != nil {
+		return fmt.Sprintf("Could not create new session: %v", err)
+	}
+
+	// Drop any existing override and point this chat at the new session.
+	if _, err := m.bindings.remove(key); err != nil {
+		return fmt.Sprintf("Could not clear old binding: %v", err)
+	}
+	if err := m.bindings.set(key, st.ID); err != nil {
+		return fmt.Sprintf("Could not attach chat to new session: %v", err)
+	}
+
+	// Evict the live session so the next message builds against the new store.
+	m.sessions.LoadAndDelete(key)
+
+	return fmt.Sprintf("Started a new session [%s]. Send a message to begin.", st.ShortID())
+}
+
+// agentModel returns the model name the factory uses, so /new can create a
+// session that matches the agent configuration without running a turn.
+func (m *Manager) agentModel() string {
+	if m.factory == nil {
+		return ""
+	}
+	return m.factory().Model
 }
 
 // cmdBind attaches the current chat to an existing session chosen from /list,

--- a/internal/channel/persist_test.go
+++ b/internal/channel/persist_test.go
@@ -334,6 +334,76 @@ func TestParseBindArgs(t *testing.T) {
 	}
 }
 
+// TestCmdNew_CreatesFreshSessionAndBindsChat: /new creates a brand-new session,
+// overrides the chat's binding, and evicts the live session so the next message
+// starts from the new store.
+func TestCmdNew_CreatesFreshSessionAndBindsChat(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+
+	m := testManager()
+	old := m.GetOrCreateSession(ev)
+	old.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "old context"})
+	if err := old.Persist(); err != nil {
+		t.Fatal(err)
+	}
+	oldID := old.Store.ID
+
+	reply := m.cmdNew(ev)
+	if !strings.Contains(strings.ToLower(reply), "started a new session") {
+		t.Fatalf("unexpected /new reply %q", reply)
+	}
+
+	// A fresh manager must resolve to the new session, not the old one.
+	m2 := testManager()
+	fresh := m2.GetOrCreateSession(ev)
+	if fresh.Store.ID == oldID {
+		t.Errorf("chat still resolves to old session %q after /new", oldID)
+	}
+	if !fresh.Store.BoundTo(agent.EntryChannel) {
+		t.Errorf("new session bound to %q, want %q", fresh.Store.BoundEntry, agent.EntryChannel)
+	}
+	if len(fresh.Agent.History.Snapshot()) != 0 {
+		t.Errorf("new session history = %d messages, want 0", len(fresh.Agent.History.Snapshot()))
+	}
+
+	// The old session file must still exist (history preserved, just detached).
+	path, err := agent.LoadSession(oldID)
+	if err != nil {
+		t.Errorf("old session file missing after /new: %v", err)
+	}
+	_ = path
+}
+
+// TestCmdNew_DetachesEvenWhenBoundToOtherEntry: /new is local to the chat and
+// does not need to steal the chat's usual session from another entry.
+func TestCmdNew_DetachesEvenWhenBoundToOtherEntry(t *testing.T) {
+	tempHome(t)
+
+	// Chat A owns a session that is now bound to web.
+	evA := InboundEvent{Platform: "feishu", ChatID: "cA", UserID: "uA"}
+	m := testManager()
+	sessA := m.GetOrCreateSession(evA)
+	sessA.Store.Bind(agent.EntryWeb, true)
+	if err := sessA.Store.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	reply := m.cmdNew(evA)
+	if !strings.Contains(strings.ToLower(reply), "started a new session") {
+		t.Fatalf("unexpected /new reply %q", reply)
+	}
+
+	m2 := testManager()
+	fresh := m2.GetOrCreateSession(evA)
+	if fresh.Store.ID == sessA.Store.ID {
+		t.Error("chat still resolves to the web-bound session after /new")
+	}
+	if !fresh.Store.BoundTo(agent.EntryChannel) {
+		t.Errorf("new session bound to %q, want %q", fresh.Store.BoundEntry, agent.EntryChannel)
+	}
+}
+
 // TestDeleteStore_TombstonesAgainstZombiePersist pins the clear-during-turn
 // contract: after deleteStore tombstones the store, a turn that finishes later
 // must not recreate the file via its post-turn Persist.

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -342,6 +342,63 @@ func TestHandleChannelMessage_WiresMemoryHooks(t *testing.T) {
 	}
 }
 
+// TestHandleChannelMessage_RejectsTurnWhenBoundToOtherEntry: when the session
+// is owned by another entry, the channel turn is rejected and the reply hints
+// at /new and /bind --force.
+func TestHandleChannelMessage_RejectsTurnWhenBoundToOtherEntry(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	// Pre-create the chat's deterministic store and mark it web-bound.
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	storeID := sess.Store.ID
+	path, err := sess.Store.SavePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	webBound := agent.NewSession("stub-model", "")
+	webBound.ID = storeID
+	webBound.Source = "channel"
+	webBound.BoundEntry = agent.EntryWeb
+	webBound.BoundAt = time.Now()
+	if err := webBound.Save(); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := agent.LoadSession(storeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess.Store = loaded
+
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello again"))
+
+	waitFor(t, func() bool {
+		for _, txt := range ad.texts() {
+			if strings.Contains(txt, "bound to web") {
+				return true
+			}
+		}
+		return false
+	})
+
+	for _, txt := range ad.texts() {
+		if strings.Contains(txt, "bound to web") {
+			if !strings.Contains(txt, "/new") || !strings.Contains(txt, "/bind --force") {
+				t.Errorf("rejection message missing hints: %q", txt)
+			}
+			return
+		}
+	}
+	t.Fatal("expected rejection text from adapter")
+}
+
 // TestHandleChannelMessage_BackgroundCompletionTriggersIdleTurn: when an
 // async background process finishes after the synchronous turn chain has
 // ended, the completion note is drained into a follow-up idle turn so the
@@ -465,5 +522,25 @@ func TestInjectorFor_SessionStickyAndDroppedOnUnbind(t *testing.T) {
 	srv.handleChannelCommand(ad, ev)
 	if srv.injectorFor(key) == first {
 		t.Error("/unbind must drop the session injector (fresh recall latch)")
+	}
+}
+
+// TestInjectorFor_DroppedOnNew: the injector's once-per-session recall latch
+// must reset with /new, which creates a brand-new session.
+func TestInjectorFor_DroppedOnNew(t *testing.T) {
+	srv := chanServer(t)
+	srv.memDir = t.TempDir()
+	ad := &fullFakeAdapter{}
+	ev := evFor("/new")
+
+	key := "im:" + string(srv.channelMgr.KeyFor(ev))
+	first := srv.injectorFor(key)
+	if first == nil {
+		t.Fatal("injectorFor returned nil")
+	}
+
+	srv.handleChannelCommand(ad, ev)
+	if srv.injectorFor(key) == first {
+		t.Error("/new must drop the session injector (fresh recall latch)")
 	}
 }

--- a/internal/server/remembered_test.go
+++ b/internal/server/remembered_test.go
@@ -128,3 +128,21 @@ func TestChannelCommand_UnbindDropsRemembered(t *testing.T) {
 		t.Error("/unbind must drop the session's remembered permission store")
 	}
 }
+
+// TestChannelCommand_NewDropsRemembered: /new starts a brand-new session, so
+// the previous session's always-allows must not leak into it.
+func TestChannelCommand_NewDropsRemembered(t *testing.T) {
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+	ev := evFor("/new")
+
+	key := "im:" + string(srv.channelMgr.KeyFor(ev))
+	before := srv.rememberedFor(key)
+
+	if !srv.handleChannelCommand(ad, ev) {
+		t.Fatal("/new not handled as a command")
+	}
+	if srv.rememberedFor(key) == before {
+		t.Error("/new must drop the session's remembered permission store")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1548,13 +1548,14 @@ func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEven
 		return false
 	}
 	// /bind switches the chat to a different session, /unbind reverts it to its
-	// default, and /clear wipes the conversation — all start a fresh context.
-	// The session's remembered permission allows and its memory-injector latch
-	// are scoped to the previous conversation, so drop them here: the manager
-	// owns session stores but not these server-side per-key latches.
+	// default, /clear wipes the conversation, and /new starts a brand-new one —
+	// all start a fresh context. The session's remembered permission allows and
+	// its memory-injector latch are scoped to the previous conversation, so drop
+	// them here: the manager owns session stores but not these server-side
+	// per-key latches.
 	cmd := strings.ToLower(strings.Fields(text)[0])
 	switch cmd {
-	case "/unbind", "/bind", "/clear":
+	case "/unbind", "/bind", "/clear", "/new":
 		imKey := "im:" + string(s.channelMgr.KeyFor(ev))
 		s.rememberedMu.Lock()
 		delete(s.rememberedStores, imKey)
@@ -1642,7 +1643,7 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	// rather than interleaving with it across processes.
 	storeID := sess.Store.ID
 	if ok, _, berr := s.acquireSessionBinding(storeID, agent.EntryChannel, false); !ok {
-		ad.SendText(ev.ChatID, "⚠️ "+berr.Error(), ev.MessageID)
+		ad.SendText(ev.ChatID, "⚠️ "+berr.Error()+"\nReply /new to start a fresh session, or /bind --force to take over.", ev.MessageID)
 		return
 	}
 	defer s.releaseSessionBinding(storeID, agent.EntryChannel)


### PR DESCRIPTION
This PR adds the /new slash command to IM channels.

### What changed
- New  command in : creates a fresh session, binds the current chat to it, and evicts the in-memory session. The old session file is preserved on disk but detached from the chat.
- Rejection message in  now suggests both  and  when a channel message is refused because the session is owned by another entry.

### Tests
- 
- 
- 

All tests pass with ok  	github.com/Leihb/octo-agent/cmd/octo	3.338s
ok  	github.com/Leihb/octo-agent/cmd/octo-eval	2.156s
ok  	github.com/Leihb/octo-agent/internal/agent	2.740s
ok  	github.com/Leihb/octo-agent/internal/app	3.576s
ok  	github.com/Leihb/octo-agent/internal/channel	3.487s
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/dingtalk	3.860s
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/discord	4.397s
?   	github.com/Leihb/octo-agent/internal/channel/adapters/feishu	[no test files]
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/telegram	4.861s
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/wecom	3.475s
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin	6.349s
ok  	github.com/Leihb/octo-agent/internal/channel/adapters/weixin/ilink	3.492s
ok  	github.com/Leihb/octo-agent/internal/config	3.481s
ok  	github.com/Leihb/octo-agent/internal/eval	6.052s
ok  	github.com/Leihb/octo-agent/internal/hooks	16.318s
ok  	github.com/Leihb/octo-agent/internal/mcp	15.006s
ok  	github.com/Leihb/octo-agent/internal/memory	3.893s
ok  	github.com/Leihb/octo-agent/internal/permission	3.762s
ok  	github.com/Leihb/octo-agent/internal/prompt	3.286s
?   	github.com/Leihb/octo-agent/internal/provider	[no test files]
ok  	github.com/Leihb/octo-agent/internal/provider/anthropic	3.936s
ok  	github.com/Leihb/octo-agent/internal/provider/openai	2.516s
ok  	github.com/Leihb/octo-agent/internal/provider/retry	2.745s
ok  	github.com/Leihb/octo-agent/internal/sandbox	3.040s
ok  	github.com/Leihb/octo-agent/internal/scheduler	3.433s
ok  	github.com/Leihb/octo-agent/internal/server	10.090s
ok  	github.com/Leihb/octo-agent/internal/skills	3.197s
ok  	github.com/Leihb/octo-agent/internal/tasks	3.138s
ok  	github.com/Leihb/octo-agent/internal/tools	44.469s
ok  	github.com/Leihb/octo-agent/internal/tools/rgembed	3.318s
ok  	github.com/Leihb/octo-agent/internal/trash	3.048s
ok  	github.com/Leihb/octo-agent/internal/tui	2.845s
ok  	github.com/Leihb/octo-agent/internal/upgrade	2.722s
ok  	github.com/Leihb/octo-agent/internal/version	2.884s
ok  	github.com/Leihb/octo-agent/internal/workflow	55.978s.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>