### PR TITLE
fix(tools): freeze elapsed time for exited background processes in terminal_list

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -375,5 +376,12 @@ func (s *Scheduler) save(task Task) error {
 		return err
 	}
 	p := filepath.Join(s.dir, task.ID+".json")
-	return os.WriteFile(p, data, 0600)
+	// Write to a unique temporary file and rename into place. A unique tmp name
+	// prevents two concurrent saves of the same task from corrupting each
+	// other's temp file before the rename.
+	tmp := p + "." + strconv.FormatInt(time.Now().UnixNano(), 10) + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, p)
 }

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -52,6 +52,7 @@ type bgProcess struct {
 	produced int64  // total bytes ever written to the logical stream
 	readOff  int64  // absolute offset already returned by Read
 	done     bool
+	end      time.Time // set when the process exits; used for accurate elapsed time in listings
 	exitErr  error
 
 	// Anti-polling: time-window based. Within a 30-second window, 3 or more
@@ -96,6 +97,7 @@ func (p *bgProcess) append(b []byte) {
 func (p *bgProcess) finish(err error) {
 	p.mu.Lock()
 	p.done = true
+	p.end = time.Now()
 	p.exitErr = err
 	p.mu.Unlock()
 }
@@ -491,7 +493,8 @@ type BgInfo struct {
 	Command string
 	Mode    BackgroundMode
 	Start   time.Time
-	Status  string // "running" / "exited: …"
+	End     time.Time // zero value while running; set when the process exits
+	Status  string    // "running" / "exited: …"
 }
 
 // ListRunning returns the visible processes that haven't exited yet, oldest first.
@@ -521,12 +524,20 @@ func (m *BackgroundManager) list(includeExited bool) []BgInfo {
 		done := p.done
 		visible := p.visible
 		info := BgInfo{ID: p.id, Command: p.command, Mode: p.mode, Start: p.start, Status: p.statusLocked()}
+		if done {
+			info.End = p.end
+		}
 		p.mu.Unlock()
 		if visible && (includeExited || !done) {
 			out = append(out, info)
 		}
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Start.Before(out[j].Start) })
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].Start.Equal(out[j].Start) {
+			return out[i].Start.Before(out[j].Start)
+		}
+		return out[i].ID < out[j].ID
+	})
 	return out
 }
 

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -598,9 +598,17 @@ func (t TerminalListTool) Execute(ctx context.Context, _ string, _ map[string]an
 		return agent.ToolResult{Text: "No background processes."}, nil
 	}
 	var b strings.Builder
+	now := time.Now()
 	for _, in := range infos {
-		elapsed := time.Since(in.Start).Round(time.Second)
-		fmt.Fprintf(&b, "%s  [%s]  [%s]  %s  %s\n", in.ID, in.Mode, in.Status, elapsed, in.Command)
+		var elapsed time.Duration
+		if in.Status == "running" {
+			elapsed = now.Sub(in.Start)
+		} else {
+			// Use the recorded end time so exited processes don't appear to keep
+			// running every time terminal_list is called.
+			elapsed = in.End.Sub(in.Start)
+		}
+		fmt.Fprintf(&b, "%s  [%s]  [%s]  %s  %s\n", in.ID, in.Mode, in.Status, elapsed.Round(time.Second), in.Command)
 	}
 	return agent.ToolResult{Text: strings.TrimRight(b.String(), "\n")}, nil
 }

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -582,8 +582,9 @@ func (t TerminalListTool) managerFor(ctx context.Context) *BackgroundManager {
 // Definition takes no parameters.
 func (TerminalListTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
-		Name:        "terminal_list",
-		Description: "List this session's background processes — those started with terminal run_in_background:\"async\" or \"interactive\" — with their id, mode, status (running / exited), elapsed time, and command. Use to recover a process id you've lost track of, or to see what is still running before checking its output (terminal_output) or stopping it (kill_shell). Detached processes (terminal detached:true) are NOT listed — they're untracked by design.",
+		Name: "terminal_list",
+		Description: "List this session's background processes — those started with terminal run_in_background:\"async\" or \"interactive\" — with their id, mode, status (running / exited), elapsed time, and command. Use to recover a process id you've lost track of, or to see what is still running before checking its output (terminal_output) or stopping it (kill_shell).\n\n" +
+			"Do NOT call terminal_list in a loop to wait for async background processes to finish. Their completion is pushed automatically via a [BACKGROUND COMPLETED] system notification; polling terminal_list will not make them finish faster and wastes turns.",
 		Parameters: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},
@@ -599,16 +600,23 @@ func (t TerminalListTool) Execute(ctx context.Context, _ string, _ map[string]an
 	}
 	var b strings.Builder
 	now := time.Now()
+	runningAsync := 0
 	for _, in := range infos {
 		var elapsed time.Duration
 		if in.Status == "running" {
 			elapsed = now.Sub(in.Start)
+			if in.Mode == BgModeAsync {
+				runningAsync++
+			}
 		} else {
 			// Use the recorded end time so exited processes don't appear to keep
 			// running every time terminal_list is called.
 			elapsed = in.End.Sub(in.Start)
 		}
 		fmt.Fprintf(&b, "%s  [%s]  [%s]  %s  %s\n", in.ID, in.Mode, in.Status, elapsed.Round(time.Second), in.Command)
+	}
+	if runningAsync > 0 {
+		fmt.Fprintf(&b, "\n<system-reminder>%d async background task(s) are still running. Do not poll terminal_list; the system will push a [BACKGROUND COMPLETED] notification when each finishes.</system-reminder>", runningAsync)
 	}
 	return agent.ToolResult{Text: strings.TrimRight(b.String(), "\n")}, nil
 }

--- a/internal/tools/terminal_observe_test.go
+++ b/internal/tools/terminal_observe_test.go
@@ -44,6 +44,46 @@ func TestTerminalListTool(t *testing.T) {
 	}
 }
 
+// TestTerminalListTool_RunningAsyncReminder verifies that terminal_list adds
+// a system-reminder telling the model not to poll when async tasks are still
+// running. Interactive-only lists do not trigger the reminder.
+func TestTerminalListTool_RunningAsyncReminder(t *testing.T) {
+	m := NewBackgroundManager()
+	term := TerminalTool{mgr: m}
+	listTool := TerminalListTool{mgr: m}
+	ctx := context.Background()
+
+	// Interactive-only list: no reminder.
+	if _, err := term.Execute(ctx, "terminal", map[string]any{
+		"command":           "sleep 30",
+		"run_in_background": "interactive",
+	}); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	res, err := listTool.Execute(ctx, "terminal_list", nil)
+	if err != nil {
+		t.Fatalf("terminal_list: %v", err)
+	}
+	if strings.Contains(res.Text, "[BACKGROUND COMPLETED]") {
+		t.Errorf("interactive-only list should not include the async reminder, got %q", res.Text)
+	}
+
+	// Adding a running async task triggers the reminder.
+	if _, err := term.Execute(ctx, "terminal", map[string]any{
+		"command":           "sleep 30",
+		"run_in_background": "async",
+	}); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	res2, err := listTool.Execute(ctx, "terminal_list", nil)
+	if err != nil {
+		t.Fatalf("terminal_list: %v", err)
+	}
+	if !strings.Contains(res2.Text, "[BACKGROUND COMPLETED]") {
+		t.Errorf("running async process should trigger a reminder not to poll, got %q", res2.Text)
+	}
+}
+
 // TestTerminalListTool_ExitedElapsedFrozen verifies that once a background
 // process exits, terminal_list reports its actual lifetime rather than the time
 // elapsed since the process started.

--- a/internal/tools/terminal_observe_test.go
+++ b/internal/tools/terminal_observe_test.go
@@ -2,8 +2,11 @@ package tools
 
 import (
 	"context"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestTerminalListTool lists running background processes so the model can
@@ -39,6 +42,79 @@ func TestTerminalListTool(t *testing.T) {
 	if !strings.Contains(res.Text, "[async]") {
 		t.Errorf("list should include the mode, got %q", res.Text)
 	}
+}
+
+// TestTerminalListTool_ExitedElapsedFrozen verifies that once a background
+// process exits, terminal_list reports its actual lifetime rather than the time
+// elapsed since the process started.
+func TestTerminalListTool_ExitedElapsedFrozen(t *testing.T) {
+	m := NewBackgroundManager()
+	term := TerminalTool{mgr: m}
+	listTool := TerminalListTool{mgr: m}
+	ctx := context.Background()
+
+	if _, err := term.Execute(ctx, "terminal", map[string]any{
+		"command":           "sleep 0.1",
+		"run_in_background": "async",
+	}); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+
+	waitFor(t, "exit", func() bool {
+		_, s, _, _, _ := m.Read("bg_1")
+		return strings.HasPrefix(s, "exited")
+	})
+
+	first := listAndParseElapsed(t, listTool, ctx, "bg_1")
+
+	// Wait and list again: the elapsed time for an exited process should not
+	// grow, because it is computed from the recorded end time.
+	time.Sleep(200 * time.Millisecond)
+	second := listAndParseElapsed(t, listTool, ctx, "bg_1")
+
+	if second != first {
+		t.Errorf("exited process elapsed should be frozen, got %v then %v", first, second)
+	}
+
+	res, err := listTool.Execute(ctx, "terminal_list", nil)
+	if err != nil {
+		t.Fatalf("terminal_list: %v", err)
+	}
+	if !strings.Contains(res.Text, "exited:") {
+		t.Errorf("list should show exited status, got %q", res.Text)
+	}
+}
+
+// listAndParseElapsed runs terminal_list and extracts the elapsed duration for
+// the given process id. It expects lines of the form:
+//
+//	bg_1  [async]  [exited: 0]  100ms  sleep 0.1
+var elapsedRE = regexp.MustCompile(`^(\S+)\s+\[[^\]]+\]\s+\[[^\]]+\]\s+(\S+)\s+`)
+
+func listAndParseElapsed(t *testing.T, listTool TerminalListTool, ctx context.Context, id string) time.Duration {
+	t.Helper()
+	res, err := listTool.Execute(ctx, "terminal_list", nil)
+	if err != nil {
+		t.Fatalf("terminal_list: %v", err)
+	}
+	for _, line := range strings.Split(res.Text, "\n") {
+		m := elapsedRE.FindStringSubmatch(line)
+		if m == nil || m[1] != id {
+			continue
+		}
+		d, err := time.ParseDuration(m[2])
+		if err == nil {
+			return d
+		}
+		// go's time.Duration String() may return values like "0s"; try strconv
+		// for seconds in case the format ever changes.
+		if s, convErr := strconv.ParseFloat(m[2], 64); convErr == nil {
+			return time.Duration(s * float64(time.Second))
+		}
+		t.Fatalf("could not parse elapsed %q: %v", m[2], err)
+	}
+	t.Fatalf("process %q not found in list output: %q", id, res.Text)
+	return 0
 }
 
 // TestTerminalOutputTool_LinesSnapshot verifies the lines param trims to the


### PR DESCRIPTION
## Problem

1. `terminal_list` reported elapsed time with `time.Since(in.Start)` for every process, including exited ones. After a process finished, every subsequent `terminal_list` call made it look like the process was still running longer and longer.

2. Models were observed calling `terminal_list` in a loop to wait for async background tasks to finish, especially after `terminal_output` refused to report on an async task. The tool description did not explicitly tell them not to.

3. CI on this PR surfaced a pre-existing flaky failure in `internal/scheduler`: `TestRunNowFiresDisabledTaskAndPersistsBookkeeping` occasionally failed with `unexpected end of JSON input` because two concurrent `save` calls wrote to the same fixed temp file.

## Change

### terminal_list
- Record the actual exit time in `bgProcess.finish()`.
- Expose it through `BgInfo.End`.
- In `TerminalListTool.Execute`, compute elapsed as:
  - `time.Since(Start)` for running processes.
  - `End - Start` for exited processes.
- Make list ordering stable by adding process ID as a secondary sort key.
- Update the `terminal_list` description to explicitly discourage polling for async completion.
- Append a `<system-reminder>` to the result when running async tasks are present, steering the model to wait for `[BACKGROUND COMPLETED]`.

### scheduler
- Use a unique temp file name in `Scheduler.save` so concurrent saves of the same task cannot corrupt each other's temp file before the atomic rename.

### tests
- `TestTerminalListTool_ExitedElapsedFrozen`
- `TestTerminalListTool_RunningAsyncReminder`

## Verification

- `go test ./internal/tools/ -run TestTerminalList -v` passes.
- `go test -race -count=5 ./internal/scheduler/ -run TestRunNowFiresDisabledTaskAndPersistsBookkeeping` passes.
- `go vet ./internal/tools/` and `go vet ./internal/scheduler/` pass.
- `gofmt -w` applied.