### PR TITLE
fix(server): broadcast session_deleted when deleting sessions

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -589,6 +589,7 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 	tools.CloseSessionBackgroundManager(id) // reap the session's background daemons
 	tools.CloseSessionSubAgentManager(id)   // and its sub-agents
 	tools.CloseSessionWorkflowManager(id)   // and its background workflows
+	s.wsHub.broadcast("", wsEventSessionDeleted{Type: "session_deleted", SessionID: id})
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": []string{id}})
 }
 
@@ -620,6 +621,7 @@ func (s *Server) handleDeleteSessions(w http.ResponseWriter, r *http.Request) {
 		tools.CloseSessionBackgroundManager(id) // reap the session's background daemons
 		tools.CloseSessionSubAgentManager(id)   // and its sub-agents
 		tools.CloseSessionWorkflowManager(id)   // and its background workflows
+		s.wsHub.broadcast("", wsEventSessionDeleted{Type: "session_deleted", SessionID: id})
 		deleted = append(deleted, id)
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -92,6 +92,14 @@ func TestHandleDeleteSession(t *testing.T) {
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
+	// Register a fake connection to capture the global session_deleted broadcast.
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+
 	req := httptest.NewRequest(http.MethodDelete, "/api/sessions/"+sess.ID, nil)
 	w := httptest.NewRecorder()
 	serveLoopback(srv.mux, w, req)
@@ -101,6 +109,22 @@ func TestHandleDeleteSession(t *testing.T) {
 	}
 	if _, err := agent.LoadSession(sess.ID); err == nil {
 		t.Fatal("session still loadable after delete")
+	}
+
+	select {
+	case b := <-conn.send:
+		var ev map[string]any
+		if err := json.Unmarshal(b, &ev); err != nil {
+			t.Fatalf("broadcast event unmarshal: %v", err)
+		}
+		if ev["type"] != "session_deleted" {
+			t.Fatalf("broadcast type = %q, want session_deleted", ev["type"])
+		}
+		if got, want := ev["session_id"], sess.ID; got != want {
+			t.Fatalf("broadcast session_id = %q, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no session_deleted broadcast received")
 	}
 }
 
@@ -120,6 +144,14 @@ func TestHandleDeleteSessions_Batch(t *testing.T) {
 	}
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	// Register a fake connection to capture the global session_deleted broadcasts.
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
 
 	payload, _ := json.Marshal(deleteSessionsRequest{IDs: ids})
 	req := httptest.NewRequest(http.MethodPost, "/api/sessions/delete", bytes.NewReader(payload))
@@ -143,6 +175,29 @@ func TestHandleDeleteSessions_Batch(t *testing.T) {
 	for _, id := range ids {
 		if _, err := agent.LoadSession(id); err == nil {
 			t.Errorf("session %s still loadable after batch delete", id)
+		}
+	}
+
+	deletedBroadcasts := make(map[string]bool)
+	deadline := time.After(2 * time.Second)
+broadcastDrain:
+	for len(deletedBroadcasts) < len(ids) {
+		select {
+		case b := <-conn.send:
+			var ev map[string]any
+			if err := json.Unmarshal(b, &ev); err != nil {
+				continue
+			}
+			if ev["type"] == "session_deleted" {
+				deletedBroadcasts[ev["session_id"].(string)] = true
+			}
+		case <-deadline:
+			break broadcastDrain
+		}
+	}
+	for _, id := range ids {
+		if !deletedBroadcasts[id] {
+			t.Errorf("missing session_deleted broadcast for %s", id)
 		}
 	}
 }
@@ -300,6 +355,7 @@ func mustServer(t *testing.T, cfg Config) *Server {
 		sessionBindingLocks: map[string]*sync.Mutex{},
 		sessionAgents:       make(map[string]*agent.Agent),
 		steerQueues:         make(map[string][]agent.InboxItem),
+		wsHub:               newWSHub(),
 	}
 	srv.registerRoutes()
 	// Wrap with CORS middleware so tests that exercise CORS hit the right layer.


### PR DESCRIPTION
Commit 4b03467 added frontend handling for the `session_deleted` event so that deleting the active session from another entry resets the chat view and clears the force-bind banner. But the server never emitted that event, so cross-tab/cross-entry deletions still left the Web UI stuck on a phantom conversation.

Broadcast `session_deleted` globally from `handleDeleteSession` and `handleDeleteSessions` after the session file and runtime state are cleaned up. Also initialize `wsHub` in `mustServer` so handler tests can exercise the broadcast path.

`make test` passes.