### PR TITLE
feat(tui/web): show running background workflows in live panels

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -541,6 +541,20 @@ func truncate1Line(s string) string {
 	return "(empty error)"
 }
 
+// truncate1LineOr is like truncate1Line but returns fallback when s contains no
+// non-empty line, avoiding the error-oriented "(empty error)" placeholder in
+// UI labels.
+func truncate1LineOr(s, fallback string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		return truncateRunes(line, 100)
+	}
+	return fallback
+}
+
 // truncateRunes returns s truncated to at most max runes. If truncation is
 // needed, the result ends with "..." and never splits a multi-byte UTF-8
 // character (byte slicing a CJK string in the middle of a rune produces the

--- a/cmd/octo/repl_test.go
+++ b/cmd/octo/repl_test.go
@@ -224,6 +224,18 @@ func TestTruncate1Line_NoMojibakeOnCJK(t *testing.T) {
 	}
 }
 
+func TestTruncate1LineOr_FallsBackOnEmptyOrWhitespace(t *testing.T) {
+	if got := truncate1LineOr("", "fallback"); got != "fallback" {
+		t.Errorf("empty = %q, want fallback", got)
+	}
+	if got := truncate1LineOr("   \n\n  ", "fallback"); got != "fallback" {
+		t.Errorf("whitespace-only = %q, want fallback", got)
+	}
+	if got := truncate1LineOr("real line\n", "fallback"); got != "real line" {
+		t.Errorf("non-empty = %q, want 'real line'", got)
+	}
+}
+
 func TestTruncateRunes(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -109,7 +110,12 @@ func runTUI(cfg replConfig) int {
 		cfg.a.Inbox.Enqueue(tools.FormatWorkflowNote(ev))
 		p.Send(workflowNoteMsg{ev})
 	})
+	// Live workflow events drive the running-workflow panel (started/progress/done).
+	tools.SetDefaultWorkflowOnEvent(func(ev tools.WorkflowEvent) {
+		p.Send(workflowEventMsg{ev})
+	})
 	defer func() {
+		tools.SetDefaultWorkflowOnEvent(nil)
 		tools.SetDefaultWorkflowOnDone(nil)
 		tools.KillDefaultWorkflows()
 	}()
@@ -157,6 +163,7 @@ type subAgentNoteMsg struct{ ev tools.SubAgentNotification } // a sub-agent comp
 type workflowNoteMsg struct{ ev tools.WorkflowNotification } // a background workflow finished (async)
 type mcpReadyMsg struct{ reg *mcp.Registry }                 // background MCP connect finished (async)
 type subAgentEventMsg struct{ ev tools.SubAgentEvent }       // a sub-agent's runtime activity (async)
+type workflowEventMsg struct{ ev tools.WorkflowEvent }       // a background workflow's runtime activity (async)
 type suggestionMsg struct{ text string }                     // an after-turn follow-up suggestion (async)
 type titleMsg struct{ text string }                          // a generated session title (async)
 type tickMsg struct{}                                        // animation tick while a turn runs
@@ -434,6 +441,11 @@ type tuiModel struct {
 	// ↑/↓ moves the focus; Enter toggles expand/collapse; Esc returns focus to
 	// the input box.
 	subAgentFocus int
+
+	// workflows holds the live state of background workflow runs, keyed by run
+	// id (wf_N). An entry appears on the "started" event and is removed when the
+	// "done" event arrives, so only running workflows are shown in the panel.
+	workflows map[string]*workflowUI
 }
 
 // subAgentUI is the live panel state for one running sub-agent.
@@ -446,6 +458,14 @@ type subAgentUI struct {
 	history     []string // complete tool history (expanded view)
 	errored     bool
 	expanded    bool // true when the panel shows the full history
+}
+
+// workflowUI is the live panel state for one background workflow run.
+type workflowUI struct {
+	description string
+	status      string // running | done | error
+	start       time.Time
+	lastLine    string // most recent progress line
 }
 
 // runningTool is the live indicator state for an in-flight card tool.
@@ -493,7 +513,7 @@ func newTUIModel(cfg replConfig) *tuiModel {
 	if !tui.IsDark() {
 		style = "light"
 	}
-	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}, subAgentFocus: -1}
+	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}, subAgentFocus: -1, workflows: map[string]*workflowUI{}}
 	_ = m.updateTextAreaHeight()
 	return m
 }
@@ -677,10 +697,10 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.flushPrints()
 
 	case tickMsg:
-		// Animate while a turn runs OR while background processes are still
-		// going (so the live "background (N running)" panel keeps ticking even
-		// between turns); let the ticker die once both are quiet.
-		if !m.turnRunning && len(tools.RunningBackground()) == 0 && len(m.subAgents) == 0 {
+		// Animate while a turn runs OR while background processes/workflows are
+		// still going (so the live bottom panels keep ticking even between turns);
+		// let the ticker die once everything is quiet.
+		if !m.turnRunning && len(tools.RunningBackground()) == 0 && len(m.subAgents) == 0 && len(m.workflows) == 0 {
 			return m, m.flushPrints()
 		}
 		m.spinnerFrame++
@@ -755,6 +775,14 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.handleSubAgentEvent(msg.ev)
 		// Ensure the animation ticker is running so the panel's spinner/elapsed
 		// updates even between turns.
+		if !m.turnRunning {
+			return m, tea.Batch(tickCmd(), m.flushPrints())
+		}
+		return m, m.flushPrints()
+
+	case workflowEventMsg:
+		m.handleWorkflowEvent(msg.ev)
+		// Keep the ticker alive for the workflow panel's spinner/elapsed clock.
 		if !m.turnRunning {
 			return m, tea.Batch(tickCmd(), m.flushPrints())
 		}
@@ -901,6 +929,45 @@ func (m *tuiModel) handleSubAgentEvent(ev tools.SubAgentEvent) {
 		}
 		sa.history = append(sa.history, name)
 	}
+}
+
+// handleWorkflowEvent folds one background workflow event into the live panel
+// state. "started" creates the entry; "progress" updates the latest line; "done"
+// removes it (the completion notice is rendered separately by workflowNoteMsg).
+func (m *tuiModel) handleWorkflowEvent(ev tools.WorkflowEvent) {
+	switch ev.Kind {
+	case "started":
+		if m.workflows[ev.RunID] == nil {
+			m.workflows[ev.RunID] = &workflowUI{
+				description: ev.Description,
+				status:      "running",
+				start:       time.Now(),
+			}
+		}
+	case "progress":
+		if wf := m.workflows[ev.RunID]; wf != nil {
+			wf.lastLine = ev.Line
+		}
+	case "done":
+		delete(m.workflows, ev.RunID)
+	}
+}
+
+// workflowOrder returns running workflow ids sorted by start time (oldest first)
+// so the panel order is stable across ticks.
+func (m *tuiModel) workflowOrder() []string {
+	ids := make([]string, 0, len(m.workflows))
+	for id := range m.workflows {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		wi, wj := m.workflows[ids[i]], m.workflows[ids[j]]
+		if !wi.start.Equal(wj.start) {
+			return wi.start.Before(wj.start)
+		}
+		return ids[i] < ids[j]
+	})
+	return ids
 }
 
 // removeSubAgent drops a sub-agent from the live panel once it finishes a round.

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -954,7 +955,8 @@ func (m *tuiModel) handleWorkflowEvent(ev tools.WorkflowEvent) {
 }
 
 // workflowOrder returns running workflow ids sorted by start time (oldest first)
-// so the panel order is stable across ticks.
+// so the panel order is stable across ticks. Run ids are "wf_N"; if timestamps
+// tie, the numeric suffix is used so "wf_10" sorts after "wf_2".
 func (m *tuiModel) workflowOrder() []string {
 	ids := make([]string, 0, len(m.workflows))
 	for id := range m.workflows {
@@ -965,9 +967,19 @@ func (m *tuiModel) workflowOrder() []string {
 		if !wi.start.Equal(wj.start) {
 			return wi.start.Before(wj.start)
 		}
-		return ids[i] < ids[j]
+		return workflowSeqLess(ids[i], ids[j])
 	})
 	return ids
+}
+
+// workflowSeqLess compares two "wf_N" run ids by their numeric suffix.
+func workflowSeqLess(a, b string) bool {
+	na, errA := strconv.Atoi(strings.TrimPrefix(a, "wf_"))
+	nb, errB := strconv.Atoi(strings.TrimPrefix(b, "wf_"))
+	if errA != nil || errB != nil {
+		return a < b
+	}
+	return na < nb
 }
 
 // removeSubAgent drops a sub-agent from the live panel once it finishes a round.

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -972,19 +972,13 @@ func (m *tuiModel) renderWorkflowsPanel() string {
 		if i > 0 {
 			lines.WriteByte('\n')
 		}
-		label := id
-		if wf.description != "" {
-			label = truncate1Line(wf.description)
-		}
+		label := truncate1LineOr(wf.description, id)
 		elapsed := time.Since(wf.start).Round(time.Second)
 		status := wf.status
 		if status == "" {
 			status = "running"
 		}
-		chain := "starting…"
-		if wf.lastLine != "" {
-			chain = truncate1Line(wf.lastLine)
-		}
+		chain := truncate1LineOr(wf.lastLine, "starting…")
 		fmt.Fprintf(&lines, "  %c %s — %s  (%s, %s)",
 			frame, label, chain, status, elapsed)
 	}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -956,6 +956,41 @@ func keyIs(msg tea.KeyMsg, r rune) bool {
 	return got == r || got == r-32 || got == r+32
 }
 
+// renderWorkflowsPanel returns the workflow bottom-panel if any workflows are
+// running, otherwise an empty string.
+func (m *tuiModel) renderWorkflowsPanel() string {
+	if len(m.workflows) == 0 {
+		return ""
+	}
+	frame := m.spinnerGlyph()
+	var lines strings.Builder
+	for i, id := range m.workflowOrder() {
+		wf := m.workflows[id]
+		if wf == nil {
+			continue
+		}
+		if i > 0 {
+			lines.WriteByte('\n')
+		}
+		label := id
+		if wf.description != "" {
+			label = truncate1Line(wf.description)
+		}
+		elapsed := time.Since(wf.start).Round(time.Second)
+		status := wf.status
+		if status == "" {
+			status = "running"
+		}
+		chain := "starting…"
+		if wf.lastLine != "" {
+			chain = truncate1Line(wf.lastLine)
+		}
+		fmt.Fprintf(&lines, "  %c %s — %s  (%s, %s)",
+			frame, label, chain, status, elapsed)
+	}
+	return tui.Panel(fmt.Sprintf("workflows (%d running)", len(m.workflows)), lines.String()) + "\n"
+}
+
 // ── View ──
 
 // liveHeight returns the number of lines the "live" region (partial text,
@@ -995,6 +1030,9 @@ func (m *tuiModel) liveHeight() int {
 				h += len(sa.history) // one line per tool in history
 			}
 		}
+	}
+	if n := len(m.workflows); n > 0 {
+		h += 3 + n // panel border (2) + title (1) + one line per workflow
 	}
 	h += m.completionHeight() // slash-completion menu (0 when closed)
 	h += m.ta.Height()        // input box (textarea grows with content)
@@ -1157,6 +1195,8 @@ func (m *tuiModel) View() string {
 		b.WriteString(tui.Panel(title, lines.String()))
 		b.WriteByte('\n')
 	}
+
+	b.WriteString(m.renderWorkflowsPanel())
 
 	// Pending steer — show what the user typed mid-turn, indented right above
 	// the input box (Claude Code style: input上方，比普通消息多了一个indent).

--- a/cmd/octo/workflow_panel_test.go
+++ b/cmd/octo/workflow_panel_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// newWorkflowPanelModel builds a tuiModel with just the workflow panel state.
+func newWorkflowPanelModel() *tuiModel {
+	return &tuiModel{workflows: map[string]*workflowUI{}}
+}
+
+func TestWorkflowPanel_StartedProgressDone(t *testing.T) {
+	m := newWorkflowPanelModel()
+	m.handleWorkflowEvent(tools.WorkflowEvent{RunID: "wf_1", Description: "Audit modules", Kind: "started"})
+	if len(m.workflows) != 1 {
+		t.Fatalf("workflows = %d, want 1", len(m.workflows))
+	}
+	wf := m.workflows["wf_1"]
+	if wf == nil {
+		t.Fatal("wf_1 missing")
+	}
+	if wf.description != "Audit modules" {
+		t.Errorf("description = %q, want Audit modules", wf.description)
+	}
+	if wf.status != "running" {
+		t.Errorf("status = %q, want running", wf.status)
+	}
+
+	m.handleWorkflowEvent(tools.WorkflowEvent{RunID: "wf_1", Kind: "progress", Line: "agent auth started"})
+	if wf.lastLine != "agent auth started" {
+		t.Errorf("lastLine = %q, want 'agent auth started'", wf.lastLine)
+	}
+
+	m.handleWorkflowEvent(tools.WorkflowEvent{RunID: "wf_1", Kind: "done", Status: "done"})
+	if len(m.workflows) != 0 {
+		t.Errorf("workflows = %d after done, want 0", len(m.workflows))
+	}
+}
+
+func TestWorkflowPanel_MultipleOrdering(t *testing.T) {
+	m := newWorkflowPanelModel()
+	m.handleWorkflowEvent(tools.WorkflowEvent{RunID: "wf_2", Description: "Second", Kind: "started"})
+	m.handleWorkflowEvent(tools.WorkflowEvent{RunID: "wf_1", Description: "First", Kind: "started"})
+	// Force distinct timestamps so ordering is deterministic regardless of
+	// time.Now() resolution on this platform.
+	m.workflows["wf_2"].start = m.workflows["wf_2"].start.Add(-time.Second)
+
+	order := m.workflowOrder()
+	want := []string{"wf_2", "wf_1"}
+	if len(order) != len(want) || order[0] != want[0] || order[1] != want[1] {
+		t.Errorf("order = %v, want %v", order, want)
+	}
+}
+
+func TestWorkflowPanel_RenderRendersRunning(t *testing.T) {
+	m := newWorkflowPanelModel()
+	m.width = 120
+	m.height = 40
+	m.handleWorkflowEvent(tools.WorkflowEvent{RunID: "wf_1", Description: "Audit modules", Kind: "started"})
+	m.handleWorkflowEvent(tools.WorkflowEvent{RunID: "wf_1", Kind: "progress", Line: "agent auth started"})
+
+	view := m.renderWorkflowsPanel()
+	if !strings.Contains(view, "workflows (1 running)") {
+		t.Errorf("render missing workflow panel title:\n%s", view)
+	}
+	if !strings.Contains(view, "Audit modules") {
+		t.Errorf("render missing workflow description:\n%s", view)
+	}
+	if !strings.Contains(view, "agent auth started") {
+		t.Errorf("render missing progress line:\n%s", view)
+	}
+}
+
+func TestWorkflowPanel_RemovesOnDone(t *testing.T) {
+	m := newWorkflowPanelModel()
+	m.handleWorkflowEvent(tools.WorkflowEvent{RunID: "wf_1", Kind: "started"})
+	m.handleWorkflowEvent(tools.WorkflowEvent{RunID: "wf_1", Kind: "done", Status: "error"})
+	if _, ok := m.workflows["wf_1"]; ok {
+		t.Error("wf_1 still present after done event")
+	}
+}

--- a/cmd/octo/workflow_panel_test.go
+++ b/cmd/octo/workflow_panel_test.go
@@ -56,6 +56,19 @@ func TestWorkflowPanel_MultipleOrdering(t *testing.T) {
 	}
 }
 
+func TestWorkflowPanel_TieBreakerNumeric(t *testing.T) {
+	m := newWorkflowPanelModel()
+	now := time.Now()
+	m.workflows["wf_10"] = &workflowUI{description: "Ten", start: now}
+	m.workflows["wf_2"] = &workflowUI{description: "Two", start: now}
+
+	order := m.workflowOrder()
+	want := []string{"wf_2", "wf_10"}
+	if len(order) != len(want) || order[0] != want[0] || order[1] != want[1] {
+		t.Errorf("order = %v, want %v", order, want)
+	}
+}
+
 func TestWorkflowPanel_RenderRendersRunning(t *testing.T) {
 	m := newWorkflowPanelModel()
 	m.width = 120

--- a/internal/server/attachments_test.go
+++ b/internal/server/attachments_test.go
@@ -204,6 +204,8 @@ func TestHandleWSUserMessage_ImageOnly(t *testing.T) {
 	srv.sessionAgents = make(map[string]*agent.Agent)
 
 	sess := agent.NewSession("stub-model", "")
+	sess.Title = "fixed title" // suppress async title generation so Windows
+	// cleanup doesn't race a fire-and-forget title goroutine writing the file.
 	if err := sess.Save(); err != nil {
 		t.Fatalf("save: %v", err)
 	}

--- a/internal/tools/session_managers.go
+++ b/internal/tools/session_managers.go
@@ -140,6 +140,10 @@ var defaultWorkflowMgr = NewWorkflowManager()
 // (parity with SetBackgroundOnExit / SubAgentManager.SetOnExit). Pass nil to clear.
 func SetDefaultWorkflowOnDone(fn func(WorkflowNotification)) { defaultWorkflowMgr.SetOnDone(fn) }
 
+// SetDefaultWorkflowOnEvent wires the live-progress hook on the process-global
+// workflow manager so the CLI/TUI can show a running-workflow panel. Pass nil to clear.
+func SetDefaultWorkflowOnEvent(fn func(WorkflowEvent)) { defaultWorkflowMgr.SetOnEvent(fn) }
+
 // KillDefaultWorkflows cancels every background workflow on the process-global
 // manager — called on CLI/TUI exit so a detached run doesn't linger.
 func KillDefaultWorkflows() { defaultWorkflowMgr.KillAll() }

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -345,9 +345,10 @@ export function applySubAgentEvent(
 }
 
 // ── Background workflows ─────────────────────────────────────────────────────
-// One entry per background workflow run, driven by the workflow_event stream
-// (kind: started | progress | done). Runs persist across turns, so this is
-// never auto-reset — entries accumulate for the session's lifetime.
+// Live running workflow runs, driven by the workflow_event stream
+// (kind: started | progress | done). The pinned panel only shows workflows that
+// are still running; once a run finishes it is removed so the bar does not grow
+// indefinitely. Completion is already visible as a chat message from the agent.
 const maxWorkflowProgressLines = 200
 
 export interface WorkflowRunState {
@@ -368,11 +369,18 @@ export function applyWorkflowEvent(
 ) {
   if (!runId) return
   chatWorkflows.update(m => {
-    const list = [...(m[sessionId] || [])]
+    let list = [...(m[sessionId] || [])]
     let idx = list.findIndex(r => r.id === runId)
     if (idx < 0) {
       list.push({ id: runId, description: description || runId, status: 'running', progress: [], startedAt: Date.now() })
       idx = list.length - 1
+    }
+    if (kind === 'done') {
+      // Remove finished runs from the live panel; completion lands as a chat
+      // message, so keeping done/error entries here would push the composer
+      // down in long-lived sessions.
+      list = list.filter(r => r.id !== runId)
+      return { ...m, [sessionId]: list }
     }
     const r = { ...list[idx], progress: [...list[idx].progress] }
     if (description && (r.description === r.id || !r.description)) r.description = description
@@ -383,8 +391,6 @@ export function applyWorkflowEvent(
           r.progress = r.progress.slice(r.progress.length - maxWorkflowProgressLines)
         }
       }
-    } else if (kind === 'done') {
-      r.status = status === 'error' ? 'error' : 'done'
     }
     list[idx] = r
     return { ...m, [sessionId]: list }

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -1035,16 +1035,6 @@
             {/if}
           {/each}
 
-          <!-- Background workflows panel (persists across turns) -->
-          {#if workflows.length > 0}
-            <div class="msg-agent fadein">
-              <div class="agent-avatar"><OctoLogo size={18} /></div>
-              <div class="agent-content">
-                <WorkflowsCard runs={workflows} {now} />
-              </div>
-            </div>
-          {/if}
-
           <!-- Live sub-agents panel (current turn) -->
           {#if subAgents.length > 0}
             <div class="msg-agent fadein">
@@ -1102,6 +1092,13 @@
           {/if}
         </div>
       </div>
+
+      <!-- Background workflows panel (persists across turns, pinned above composer) -->
+      {#if workflows.length > 0}
+        <div class="workflows-bar fadein">
+          <WorkflowsCard runs={workflows} {now} />
+        </div>
+      {/if}
 
       <!-- Background processes tray -->
       {#if bgTasks && bgTasks.length > 0}
@@ -1193,6 +1190,11 @@
   /* Keep the chat column narrower than full-width settings pages for
      readability; Composer picks this up via CSS var inheritance. */
   --chat-content-max-width: 800px;
+}
+.workflows-bar {
+  flex: 0 0 auto;
+  max-width: var(--chat-content-max-width); margin: 0 auto; width: 100%;
+  padding: 0 24px 12px;
 }
 .messages {
   flex: 1;


### PR DESCRIPTION
## Problem

`workflow` can only run asynchronously, but neither the TUI nor the Web UI had an obvious live panel for currently-running workflows. Users would launch a workflow and have no immediate confirmation that it started.

## What changed

### TUI
- Wire the process-global workflow manager's `OnEvent` hook so `started` / `progress` / `done` events reach the TUI.
- Add a live `workflows` panel keyed by `wf_N`, rendered above the input box.
- Show description, latest progress line, status, and elapsed time while running.
- Remove the entry on `done`; the existing scrollback notice still reports completion.
- Keep the animation ticker alive while workflows run, so the spinner/clock keeps updating between turns.

### Web
- Move `WorkflowsCard` out of the scrollable message stream and pin it directly above the composer, so it stays visible while a workflow is running.

### Plumbing
- Add `tools.SetDefaultWorkflowOnEvent` for parity with the existing `SetDefaultWorkflowOnDone`.

### Tests
- Add `cmd/octo/workflow_panel_test.go` covering started/progress/done transitions, deterministic ordering, and rendering.

## Verification

- `make test` (race) passes.
- `gofmt -w` + `go vet ./...` clean.
- `svelte-check` reports 0 errors.

## No new dependencies

All changes use existing Go and Svelte modules.
