### PR TITLE
fix(server): clarify IM rejection hint when session is bound to another entry

### DIFF
--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -390,7 +390,7 @@ func TestHandleChannelMessage_RejectsTurnWhenBoundToOtherEntry(t *testing.T) {
 
 	for _, txt := range ad.texts() {
 		if strings.Contains(txt, "bound to web") {
-			if !strings.Contains(txt, "/new") || !strings.Contains(txt, "/bind --force") {
+			if !strings.Contains(txt, "/new") || !strings.Contains(txt, "/list") || !strings.Contains(txt, "/bind --force <number>") {
 				t.Errorf("rejection message missing hints: %q", txt)
 			}
 			return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1643,7 +1643,7 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	// rather than interleaving with it across processes.
 	storeID := sess.Store.ID
 	if ok, _, berr := s.acquireSessionBinding(storeID, agent.EntryChannel, false); !ok {
-		ad.SendText(ev.ChatID, "⚠️ "+berr.Error()+"\nReply /new to start a fresh session, or /bind --force to take over.", ev.MessageID)
+		ad.SendText(ev.ChatID, "⚠️ "+berr.Error()+"\nReply /new to start a fresh session, or run /list then /bind --force <number> to take it over.", ev.MessageID)
 		return
 	}
 	defer s.releaseSessionBinding(storeID, agent.EntryChannel)


### PR DESCRIPTION
When an IM channel sends a message to a session owned by web (or any
other entry), the rejection now tells the user to run /list first and
then /bind --force <number> to take it over, instead of the ambiguous
"/bind --force to take over".

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
