### PR TITLE
docs: document MCP Tool Search in README, site, and product help

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,29 @@ octo config path   # print the file location
 
 Precedence is **CLI flag > env var > `~/.octo/config.yaml` > built-in default**. API keys are read from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` first; the wizard can store one in the file (mode `0600`), but the env var is recommended.
 
+### MCP Tool Search
+
+When MCP servers expose many tools, uploading every tool schema on every turn wastes context and hurts accuracy. Tool Search keeps built-in tools visible but defers MCP schemas behind a small bridge:
+
+- `mcp_search` — find MCP tools by keyword (returns names + one-line descriptions).
+- `mcp_describe` — load the full JSON Schema for one discovered tool.
+- `mcp_call` — invoke the tool with arguments matching that schema.
+
+The model uses the same three-step flow automatically. Configure when the bridge activates in `~/.octo/config.yaml`:
+
+```yaml
+tools:
+  tool_search:
+    enabled: auto          # auto (default) | on | off
+    threshold_pct: 10      # auto: activate when deferred schemas ≥ N% of context window
+    search_default_limit: 5
+    max_search_limit: 20
+```
+
+- `auto` (default) — only enable when the deferred MCP schemas would occupy at least `threshold_pct` of the model's context window.
+- `on` — always defer MCP schemas when any MCP tool is connected.
+- `off` — upload all MCP schemas up front, as before.
+
 ## Skills
 
 Skills are reusable instruction sets in Claude Code's SKILL.md format, discovered from:
@@ -243,7 +266,7 @@ octo runs on Linux, macOS, and Windows. A few behaviors differ on Windows:
 | Memory & config | done | `~/.octo/octorules.md`, `.octorules`, `octo init`, `@include` |
 | Skills | done | Claude Code-compatible SKILL.md loader (`octo skills`, `/skills`, `/<name>`) |
 | Sandbox | done | OS-enforced `--sandbox` (macOS / Linux) |
-| MCP client | done | `mcp.json` stdio + Streamable HTTP servers, tools/resources/prompts, device-flow OAuth |
+| MCP client | done | `mcp.json` stdio + Streamable HTTP servers, tools/resources/prompts, device-flow OAuth; Tool Search defers large MCP schemas until needed |
 | Memory | done | Persistent cross-session memory under `~/.octo/memories/`, auto extract/consolidate |
 | Sub-agents | done | `sub_agent` fan-out, async + resumable (`sub_agent_send`, `sub_agent_status`, `sub_agent_kill`) |
 | Workflows | done | `workflow` tool — deterministic multi-agent orchestration (parallel/pipeline), background runs with liveness + `workflow_kill`, git worktree isolation, structured-output schema; JS or an embedded-Ruby DSL |

--- a/README_CN.md
+++ b/README_CN.md
@@ -148,6 +148,29 @@ octo config path   # 打印配置文件路径
 
 优先级：**命令行 flag > 环境变量 > `~/.octo/config.yaml` > 内置默认**。API key 优先从 `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` 读取；向导可选择把 key 存进文件（权限 `0600`），但推荐用环境变量。
 
+### MCP Tool Search
+
+当 MCP 服务暴露大量工具时，每轮请求都上传全部工具 schema 会浪费上下文并降低准确率。Tool Search 保留内置工具直接可见，但把 MCP 工具 schema 延迟到一个小型桥工具之后：
+
+- `mcp_search` —— 按关键词搜索 MCP 工具（返回名称 + 一行描述）。
+- `mcp_describe` —— 加载某个发现工具的完整 JSON Schema。
+- `mcp_call` —— 用匹配该 schema 的参数调用工具。
+
+模型会自动走这套三步协议。在 `~/.octo/config.yaml` 里配置桥工具的激活时机：
+
+```yaml
+tools:
+  tool_search:
+    enabled: auto          # auto（默认）| on | off
+    threshold_pct: 10      # auto：延迟 schema 占上下文窗口 N% 时启用
+    search_default_limit: 5
+    max_search_limit: 20
+```
+
+- `auto`（默认）—— 仅当延迟加载的 MCP schema 达到模型上下文窗口的 `threshold_pct` 时才启用。
+- `on` —— 只要连了 MCP 工具，就始终延迟加载 schema。
+- `off` —— 像之前一样，预先上传全部 MCP schema。
+
 ## Skills
 
 Skill 是采用 Claude Code SKILL.md 格式的可复用指令集，从以下位置发现：
@@ -190,7 +213,7 @@ octo --sandbox --sandbox-read /opt/data     # 额外可读目录（可重复）
 | 记忆与配置 | 完成 | `~/.octo/octorules.md`、`.octorules`、`octo init`、`@include` |
 | Skills | 完成 | 兼容 Claude Code 的 SKILL.md 加载器（`octo skills`、`/skills`、`/<name>`） |
 | 沙箱 | 完成 | 操作系统强制的 `--sandbox`（macOS / Linux） |
-| MCP 客户端 | 完成 | `mcp.json` 的 stdio + Streamable HTTP 服务，tools/resources/prompts，device-flow OAuth |
+| MCP 客户端 | 完成 | `mcp.json` 的 stdio + Streamable HTTP 服务，tools/resources/prompts，device-flow OAuth；Tool Search 按需延迟加载大量 MCP 工具 schema |
 | 记忆 | 完成 | `~/.octo/memories/` 下的跨会话持久化记忆，自动抽取/整合 |
 | 子代理 | 完成 | `sub_agent` 并行扇出，异步 + 可恢复（`sub_agent_send`、`sub_agent_status`、`sub_agent_kill`） |
 | 工作流 | 完成 | `workflow` 工具 —— 确定性多代理编排（parallel/pipeline）、后台运行带 liveness + `workflow_kill`、git worktree 隔离、结构化输出 schema；支持 JS 或内嵌 Ruby DSL |

--- a/docs/index.html
+++ b/docs/index.html
@@ -445,6 +445,12 @@
              data-zh="文件读/写/改、终端（含后台任务）、glob、grep、网页抓取/搜索。外加 MCP 服务与 Claude Code 格式的可复用 Skills。"></p>
         </div>
         <div class="feature reveal">
+          <span class="feature-icon">🔎</span>
+          <h3 data-en="MCP Tool Search" data-zh="MCP Tool Search"></h3>
+          <p data-en="Connect dozens of MCP tools without blowing the context window. Octo advertises a small search/describe/call bridge and loads each schema only when the model needs it."
+             data-zh="连接几十个 MCP 工具也不撑爆上下文。Octo 暴露小型 search/describe/call 桥，只在模型需要时才加载每个 schema。"></p>
+        </div>
+        <div class="feature reveal">
           <span class="feature-icon">🧠</span>
           <h3 data-en="Persistent memory" data-zh="持久化记忆"></h3>
           <p data-en="Octo remembers your preferences, project conventions, and past corrections across sessions — stored locally in ~/.octo/memories/, not in the cloud."

--- a/internal/skills/defaults/product_help/MCP.md
+++ b/internal/skills/defaults/product_help/MCP.md
@@ -105,6 +105,25 @@ Connected 2 MCP servers: fs, my-api
 
 If a server fails to connect, the error is printed to stderr and that server is skipped — the session continues with the others.
 
+## Tool Search
+
+MCP servers with many tools can push a lot of schema tokens into every request. Tool Search defers those schemas: built-in tools stay visible, but MCP tools are discovered through a small bridge (`mcp_search` → `mcp_describe` → `mcp_call`) and only loaded when the model needs them.
+
+Control it under `tools.tool_search` in `~/.octo/config.yaml`:
+
+```yaml
+tools:
+  tool_search:
+    enabled: auto          # auto | on | off
+    threshold_pct: 10      # auto: activate when deferred schemas >= N% of context window
+    search_default_limit: 5
+    max_search_limit: 20
+```
+
+- `auto` (default) — enable only when deferred MCP schemas would occupy at least `threshold_pct` of the model's context window.
+- `on` — always defer MCP schemas when any MCP tool is connected.
+- `off` — upload every MCP schema upfront (legacy behavior).
+
 ## Troubleshooting
 
 | Symptom | Fix |


### PR DESCRIPTION
Add user-facing docs for the existing Tool Search bridge.

- README.md / README_CN.md: feature matrix + config section
- docs/index.html: homepage feature card (EN/ZH)
- internal/skills/defaults/product_help/MCP.md: config reference

The bridge itself already exists; this only exposes it to users who read the README, the website, or the in-product MCP help skill.

Refs: dev-docs/tool-search-mcp.md