### PR TITLE
feat(tui): replace banner mascot with block-pixel octopus

### DIFF
--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -70,26 +70,27 @@ var bannerHints = []string{
 	"Shift+Tab perm-mode · Ctrl+T tasks · Esc interrupt · Ctrl+C quit",
 }
 
-// octopusASCII is the pixel-art octo mascot — a bulbous octopus head with two
-// eyes and four pairs of curled tentacles fanning out below a small mantle.
-// The domed head and separated tentacles make it read as an octopus rather
-// than a blocky ape face. It renders in the terminal's default foreground colour.
+// octopusASCII is the pixel-art octo mascot built from full-width block chars,
+// giving it a crisp, high-contrast silhouette on both light and dark terminals.
 var octopusASCII = []string{
-	"       ▄▄██▄▄",
-	"     ▄████████▄",
-	"    ▐██ ●  ● ██▌",
-	"     ▀████████▀",
-	"       ▀██▀",
-	"    ▗▄      ▄▖",
-	"   ▐█ ▗▄  ▄▖ █▌",
+	"   █████████████",
+	"  ██ ██ ███ ██ ██",
+	" █████████████████",
+	"  ████ ███ ████",
+	"      █████",
+	"     ███████",
+	"   ███ █████ ███",
+	"  ██  ███████  ██",
+	" ██   ███████   ██",
+	"  █████████████",
 }
 
 // octoArtWidth is the column the banner text starts at — wide enough to clear
 // the widest art line plus a two-space gutter, so the title/info/hints align.
-const octoArtWidth = 18
+const octoArtWidth = 21
 
 // BannerHeight is the number of lines Banner renders (including the separator).
-const BannerHeight = 8
+const BannerHeight = 11
 
 // Banner renders the octo welcome header with pixel-art mascot.
 // The icon sits left of the title, Claude Code style.


### PR DESCRIPTION
Swap the rounded ASCII octopus for a higher-contrast full-width block pixel art version and update the layout constants (art width / banner height) accordingly.\n\n- 1 file changed: internal/tui/theme.go\n- make test green