### PR TITLE
fix(web): make markdown code block copy button copy original text

### DIFF
--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -50,11 +50,10 @@ export function renderMarkdown(text: string): string {
     } else {
       highlighted = escapeHtml(codeText)
     }
-    const rawForCopy = escapeHtml(codeText)
     return `<div class="code-block">
   <div class="code-header">
     <span class="code-lang">${escapeHtml(language)}</span>
-    <button class="copy-btn" data-copy="${rawForCopy}">Copy</button>
+    <button class="copy-btn">Copy</button>
   </div>
   <pre><code class="hljs language-${escapeHtml(language)}">${highlighted}</code></pre>
 </div>`
@@ -102,18 +101,21 @@ export function renderMarkdown(text: string): string {
   return DOMPurify.sanitize(combined, { ADD_ATTR: ["target"] })
 }
 
-export function setupCopyButtons(el: HTMLElement): void {
-  const buttons = el.querySelectorAll<HTMLButtonElement>("button[data-copy]")
-  buttons.forEach((btn) => {
-    btn.addEventListener("click", () => {
-      const content = btn.dataset.copy ?? ""
-      navigator.clipboard.writeText(content).then(() => {
-        const original = btn.textContent
-        btn.textContent = "Copied!"
-        setTimeout(() => {
-          btn.textContent = original
-        }, 1500)
-      })
+export function setupCopyButtons(el: HTMLElement): { destroy: () => void } {
+  function onClick(e: MouseEvent) {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>("button.copy-btn")
+    if (!btn || !el.contains(btn)) return
+    const block = btn.closest(".code-block")
+    const code = block?.querySelector("pre code")
+    const content = code?.textContent ?? ""
+    navigator.clipboard.writeText(content).then(() => {
+      const original = btn.textContent
+      btn.textContent = "Copied!"
+      setTimeout(() => {
+        btn.textContent = original
+      }, 1500)
     })
-  })
+  }
+  el.addEventListener("click", onClick)
+  return { destroy: () => el.removeEventListener("click", onClick) }
 }

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -710,7 +710,7 @@
 
   // ── markdown copy buttons setup ────────────────────────────────────────────
   function setupAssistantEl(el: HTMLElement) {
-    setupCopyButtons(el)
+    return setupCopyButtons(el)
   }
 
   // ── edit a prior user message: load it back into the composer for resend ─────


### PR DESCRIPTION
## Problem

The Copy button on rendered markdown code blocks did not work reliably:

1. It stored the code in a `data-copy` attribute after `escapeHtml`, so copied text contained HTML entities (e.g. `&lt;` instead of `<`). This broke content like ASCII art and code with angle brackets.
2. `setupCopyButtons` only bound click listeners once when the assistant message container mounted. During streaming, new `<div class="code-block">` elements are injected into the container by `{@html ...}`, so their Copy buttons had no handler and appeared unresponsive.

## Change

- Remove the `data-copy` attribute from the generated code block header.
- Switch to event delegation on the container (`rich-answer` / `think-body`).
- On click, read the original code from the matching `<pre><code>` element's `textContent`.
- Return a Svelte action `destroy` object so the delegated listener is cleaned up when the container unmounts.

## Verification

- `go vet ./...` passes.
- `make test` (`go test -race ./...`) passes.
- `cd web && npx svelte-check` reports 0 errors.

No new third-party dependencies.