### PR TITLE
test(server): isolate HOME for all mustServer tests

### DIFF
--- a/internal/server/restart_test.go
+++ b/internal/server/restart_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestHandleRestart_Returns202AndMarksPending(t *testing.T) {
+	setTestHome(t)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/restart", nil)
@@ -38,6 +39,7 @@ func TestHandleRestart_Returns202AndMarksPending(t *testing.T) {
 }
 
 func TestRestart_Idempotent(t *testing.T) {
+	setTestHome(t)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	srv.Restart("first")
@@ -53,6 +55,7 @@ func TestRestart_Idempotent(t *testing.T) {
 // proves the process-global registry teardown is not executed twice in
 // parallel (the Restart-goroutine vs Ctrl-C-handler race).
 func TestShutdown_SingleFlight(t *testing.T) {
+	setTestHome(t)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	const callers = 4
@@ -76,6 +79,7 @@ func TestShutdown_SingleFlight(t *testing.T) {
 // ephemeral port, requests a restart, and verifies ListenAndServe comes back
 // with ErrRestartRequested rather than the plain http.ErrServerClosed.
 func TestListenAndServe_RestartReturnsSentinel(t *testing.T) {
+	setTestHome(t)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -100,6 +104,7 @@ func TestListenAndServe_RestartReturnsSentinel(t *testing.T) {
 // TestListenAndServe_PlainShutdownIsClean verifies a non-restart Shutdown
 // (the Ctrl-C path) does NOT surface as a restart request or an error.
 func TestListenAndServe_PlainShutdownIsClean(t *testing.T) {
+	setTestHome(t)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -128,6 +133,7 @@ func TestListenAndServe_PlainShutdownIsClean(t *testing.T) {
 // TestRestart_WaitsForInflightTurn: restart must not shut the server down
 // while a turn is active; it proceeds as soon as the turn ends.
 func TestRestart_WaitsForInflightTurn(t *testing.T) {
+	setTestHome(t)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -163,6 +169,7 @@ func TestRestart_WaitsForInflightTurn(t *testing.T) {
 // TestRestart_DrainTimeoutForcesShutdown: a turn that outlives the drain
 // timeout must not block the restart forever.
 func TestRestart_DrainTimeoutForcesShutdown(t *testing.T) {
+	setTestHome(t)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	srv.drainTimeout = 100 * time.Millisecond
 
@@ -193,6 +200,10 @@ func TestRestart_DrainTimeoutForcesShutdown(t *testing.T) {
 // TestHandleTurn_DrainingReturns503: new turn requests during a drain get a
 // retryable 503 instead of starting work that the shutdown would cut short.
 func TestHandleTurn_DrainingReturns503(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	sess := agent.NewSession("stub-model", "")
@@ -214,6 +225,7 @@ func TestHandleTurn_DrainingReturns503(t *testing.T) {
 
 // TestRunTask_DrainingRefused: scheduled task runs are refused during drain.
 func TestRunTask_DrainingRefused(t *testing.T) {
+	setTestHome(t)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	srv.drain.drain(0)
 
@@ -250,6 +262,7 @@ func (a *drainTestAdapter) texts() []string {
 // IM adapters stay up through the drain, and a message arriving mid-drain
 // gets an explicit "try again" reply instead of being dropped silently.
 func TestHandleChannelMessage_DrainingRepliesPolitely(t *testing.T) {
+	setTestHome(t)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	srv.drain.drain(0)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -30,6 +30,10 @@ func serveLoopback(h http.Handler, w http.ResponseWriter, req *http.Request) {
 }
 
 func TestHandleHealth(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
@@ -49,6 +53,10 @@ func TestHandleHealth(t *testing.T) {
 }
 
 func TestHandleListSessions(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
@@ -68,6 +76,10 @@ func TestHandleListSessions(t *testing.T) {
 }
 
 func TestHandleGetSession_NotFound(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/nonexistent", nil)
@@ -203,6 +215,10 @@ broadcastDrain:
 }
 
 func TestHandleDeleteSessions_EmptyIDs(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/sessions/delete", bytes.NewReader([]byte(`{"ids":[]}`)))
@@ -216,6 +232,10 @@ func TestHandleDeleteSessions_EmptyIDs(t *testing.T) {
 }
 
 func TestHandleCreateChat_MissingMessage(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	body := bytes.NewReader([]byte(`{}`))
@@ -230,6 +250,10 @@ func TestHandleCreateChat_MissingMessage(t *testing.T) {
 }
 
 func TestHandleTurn_MissingSession(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	body := bytes.NewReader([]byte(`{"message":"hello"}`))
@@ -244,6 +268,10 @@ func TestHandleTurn_MissingSession(t *testing.T) {
 }
 
 func TestStaticHandler_IndexFallback(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -266,6 +294,10 @@ func TestStaticHandler_IndexFallback(t *testing.T) {
 }
 
 func TestStaticHandler_APIFallback(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/unknown", nil)
@@ -279,6 +311,10 @@ func TestStaticHandler_APIFallback(t *testing.T) {
 }
 
 func TestCORS(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false, CORSOrigins: []string{"http://localhost:3000"}})
 
 	req := httptest.NewRequest(http.MethodOptions, "/api/health", nil)
@@ -295,6 +331,10 @@ func TestCORS(t *testing.T) {
 }
 
 func TestCORS_DisallowedOrigin(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false, CORSOrigins: []string{"http://localhost:3000"}})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
@@ -308,6 +348,10 @@ func TestCORS_DisallowedOrigin(t *testing.T) {
 }
 
 func TestCORS_WildcardDoesNotReflectOrigin(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false, CORSOrigins: []string{"*"}})
 
 	req := httptest.NewRequest(http.MethodOptions, "/api/health", nil)
@@ -447,6 +491,10 @@ func (s *recordingSender) StreamMessagesWithTools(_ context.Context, _, _ string
 // ─── New API tests ──────────────────────────────────────────────────────────
 
 func TestHandleOnboardStatus(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	req := httptest.NewRequest(http.MethodGet, "/api/onboard/status", nil)
 	w := httptest.NewRecorder()
@@ -464,6 +512,10 @@ func TestHandleOnboardStatus(t *testing.T) {
 }
 
 func TestHandleListProviders(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	req := httptest.NewRequest(http.MethodGet, "/api/providers", nil)
 	w := httptest.NewRecorder()
@@ -482,6 +534,10 @@ func TestHandleListProviders(t *testing.T) {
 }
 
 func TestHandleGetConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
 	w := httptest.NewRecorder()
@@ -499,6 +555,10 @@ func TestHandleGetConfig(t *testing.T) {
 }
 
 func TestHandleTestConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	payload, _ := json.Marshal(testConfigRequest{Model: "gpt-4", BaseURL: "https://api.openai.com/v1"})
 	req := httptest.NewRequest(http.MethodPost, "/api/config/test", bytes.NewReader(payload))
@@ -605,6 +665,10 @@ func TestHandleToggleSkill(t *testing.T) {
 }
 
 func TestHandleToggleSkill_NotFound(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	req := httptest.NewRequest(http.MethodPatch, "/api/skills/nonexistent/toggle", nil)
 	w := httptest.NewRecorder()
@@ -703,6 +767,10 @@ func TestHandleBenchmark_Success(t *testing.T) {
 }
 
 func TestHandleGetMemory_NotFound(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	req := httptest.NewRequest(http.MethodGet, "/api/memories/nonexistent.md", nil)
 	w := httptest.NewRecorder()
@@ -713,6 +781,10 @@ func TestHandleGetMemory_NotFound(t *testing.T) {
 }
 
 func TestHandleGetMemories_DedupesProjectAndHomeDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	// Simulate a setup where the project memory directory is the same as the
@@ -751,6 +823,10 @@ func TestHandleGetMemories_DedupesProjectAndHomeDir(t *testing.T) {
 }
 
 func TestHandleVersionUpgrade_AcceptedAndConflict(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	// While an upgrade runs, a second POST conflicts.
@@ -794,6 +870,10 @@ func TestHandleVersionUpgrade_AcceptedAndConflict(t *testing.T) {
 }
 
 func TestHandleVersion_NoUpdateCheck(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
 	w := httptest.NewRecorder()
@@ -822,6 +902,10 @@ func TestHandleVersion_NoUpdateCheck(t *testing.T) {
 }
 
 func TestHandleVersion_CacheHeaders(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
 	w := httptest.NewRecorder()
@@ -1507,6 +1591,10 @@ drainDedup:
 // tool_error) the stream writer must broadcast a fresh "thinking" progress
 // and keep it in live state for late-subscriber replay.
 func TestWSStreamWriter_ReseedsThinkingAfterTool(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 	srv.initWS()
 


### PR DESCRIPTION
## Problem

Running tests in `internal/server/` created blank session files (192 bytes, meta-only) in `~/.octo/sessions/` because tests called `mustServer()` which internally accesses the session store, but didn't redirect `HOME`/ `USERPROFILE` to temp directories.

## Root Cause

Tests like `TestHandleListSessions` call `agent.ListSessions()\) which writes blank session files to the real home directory.

## Solution

Add `t.Setenv("HOME", tmp)` and `t.Setenv("USERPROFILE", tmp)` at the start of all tests that call `mustServer()\). Reuse the existing `setTestHome()` helper from `onboard_config_handlers_test.go`.

## Files Changed

- `internal/server/server_test.go` - 17 tests fixed
- `internal/server/restart_test.go` - 9 tests fixed

## Verification

```
make test  # all green, no new blank session files in ~/.octo/sessions
```