### PR TITLE
web: remove brand logo and name from sidebar header

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -4,7 +4,6 @@
   import * as api from '../../lib/api'
   import { t } from '../../lib/i18n'
   import VersionBadge from './VersionBadge.svelte'
-  import OctoLogo from './OctoLogo.svelte'
 
   // Real count of configured MCP servers for the nav badge. Seeded here so the
   // badge is correct before the user ever opens the MCP panel; McpView keeps the
@@ -110,10 +109,6 @@
 
   {#if $sidebar === 'full'}
   <div class="full">
-    <div class="brand">
-      <OctoLogo size={26} />
-      <span class="brand-name">Octo</span>
-    </div>
     <div class="new-btn-wrap">
       <button class="new-btn" onclick={newSession}>
         <iconify-icon icon="ant-design:plus-outlined" width="14"></iconify-icon>
@@ -280,12 +275,6 @@
 
 <style>
 .full { width: 256px; height: 100%; display: flex; flex-direction: column; min-height: 0; }
-.brand {
-  display: flex; align-items: center; gap: 10px;
-  padding: 16px 12px 8px;
-}
-.brand :global(svg) { color: var(--blue-6); flex: 0 0 auto; }
-.brand-name { font-size: 15px; font-weight: 600; color: var(--text-heading); }
 .new-btn-wrap { padding: 0 12px 8px; }
 .new-btn {
   width: 100%; height: 32px; border: none; border-radius: 6px;


### PR DESCRIPTION
Remove the Octo logo and brand name from the sidebar header.

## Changes
- Remove `OctoLogo` component import and usage
- Remove brand `<div>` container with logo and 'Octo' text
- Clean up unused CSS styles (`.brand`, `.brand-name`, `.brand :global(svg)`)

## Result
Sidebar now starts directly with the '+ New Session' button.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>