### PR TITLE
web: fix rail mode + button not creating new session

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -248,7 +248,7 @@
   {#if $sidebar === 'rail'}
   <div class="rail">
     <div style="padding:16px 0 8px 0;">
-      <button class="rail-btn primary" title={$t('nav.new_session')} onclick={() => view.set('chat')}>
+      <button class="rail-btn primary" title={$t('nav.new_session')} onclick={newSession}>
         <iconify-icon icon="ant-design:plus-outlined" width="16"></iconify-icon>
       </button>
     </div>


### PR DESCRIPTION
Fix the + button in collapsed sidebar (rail mode) not creating a new session.\n\n## Root cause\nThe button's onclick handler was only calling `view.set('chat')` without actually creating a new session.\n\n## Fix\nChange onclick to call `newSession()` instead, matching the behavior of the full sidebar mode.\n\nCo-authored-by: octo-agent <no-reply@octo-agent.dev>