### PR TITLE
web: unify favicon color with header logo (#2F54EB)

### DIFF
--- a/internal/server/webdist/favicon.svg
+++ b/internal/server/webdist/favicon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" rx="22" fill="#A371F7"/>
+  <rect width="100" height="100" rx="22" fill="#2F54EB"/>
   <path fill="#ffffff" d="M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z"/>
-  <circle cx="40" cy="42" r="5" fill="#A371F7"/>
-  <circle cx="60" cy="42" r="5" fill="#A371F7"/>
+  <circle cx="40" cy="42" r="5" fill="#2F54EB"/>
+  <circle cx="60" cy="42" r="5" fill="#2F54EB"/>
 </svg>

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" rx="22" fill="#A371F7"/>
+  <rect width="100" height="100" rx="22" fill="#2F54EB"/>
   <path fill="#ffffff" d="M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z"/>
-  <circle cx="40" cy="42" r="5" fill="#A371F7"/>
-  <circle cx="60" cy="42" r="5" fill="#A371F7"/>
+  <circle cx="40" cy="42" r="5" fill="#2F54EB"/>
+  <circle cx="60" cy="42" r="5" fill="#2F54EB"/>
 </svg>


### PR DESCRIPTION
Fix color inconsistency between favicon and header logo.\n\n## Root cause\n- Favicon used hard-coded purple `#A371F7`\n- `OctoLogo` component in header/sidebar uses `currentColor` which inherits `var(--blue-6)` = `#2F54EB`\n\n## Fix\nUpdate favicon to use the same blue color `#2F54EB` for visual consistency across the brand.\n\nCo-authored-by: octo-agent <no-reply@octo-agent.dev>