### PR TITLE
docs: unify octo logo on official website (#2F54EB)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Octo — A functionality-first AI agent</title>
   <meta name="description" content="A single Go binary that brings AI agents to your terminal, browser, and chat apps. Anthropic + OpenAI native. Built-in tools, MCP, skills, sandboxing, and persistent memory.">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ctext y='52' font-size='52'%3E🐙%3C/text%3E%3C/svg%3E">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='22' fill='%232F54EB'/%3E%3Cpath fill='%23ffffff' d='M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z'/%3E%3Ccircle cx='40' cy='42' r='5' fill='%232F54EB'/%3E%3Ccircle cx='60' cy='42' r='5' fill='%232F54EB'/%3E%3C/svg%3E">
   <style>
     :root {
       --bg: #fafafa;
@@ -73,8 +73,8 @@
     }
     .hero-inner { position: relative; max-width: 720px; margin: 0 auto; }
     .hero-logo {
-      font-size: 4rem;
-      line-height: 1;
+      width: 80px;
+      height: 80px;
       margin-bottom: 1.25rem;
       display: inline-block;
       animation: float 4s ease-in-out infinite;
@@ -398,7 +398,12 @@
   <!-- Hero -->
   <header class="hero">
     <div class="hero-inner">
-      <div class="hero-logo">🐙</div>
+      <svg class="hero-logo" width="80" height="80" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+        <rect width="100" height="100" rx="22" fill="#2F54EB"/>
+        <path fill="#ffffff" d="M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z"/>
+        <circle cx="40" cy="42" r="5" fill="#2F54EB"/>
+        <circle cx="60" cy="42" r="5" fill="#2F54EB"/>
+      </svg>
       <h1><span data-en="Meet " data-zh="认识 "></span><span class="accent">Octo</span></h1>
       <p class="hero-tagline"
          data-en="A functionality-first AI agent in a single Go binary. Bring it to your terminal, browser, or chat app — it speaks Anthropic and OpenAI natively, and actually gets things done."
@@ -588,7 +593,7 @@ echo <span class="arg">"Summarise the last commit"</span> | <span class="cmd">oc
         <p style="color: var(--muted); margin-bottom: 1.5rem;" data-en="Install in seconds, configure in a minute, ship in an hour." data-zh="几秒安装，一分钟配置，一小时交付。"></p>
         <div style="display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap;">
           <a class="btn btn-primary js-download" href="https://github.com/Leihb/octo-agent/releases/latest" data-en="⬇️ Download" data-zh="⬇️ 下载"></a>
-          <a class="btn btn-secondary" href="https://github.com/Leihb/octo-agent" data-en="🐙 GitHub" data-zh="🐙 GitHub"></a>
+          <a class="btn btn-secondary" href="https://github.com/Leihb/octo-agent" style="display:inline-flex;align-items:center;gap:6px;"><svg width="16" height="16" viewBox="0 0 100 100" style="flex:0 0 16px;"><rect width="100" height="100" rx="22" fill="#2F54EB"/><path fill="#ffffff" d="M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z"/><circle cx="40" cy="42" r="5" fill="#2F54EB"/><circle cx="60" cy="42" r="5" fill="#2F54EB"/></svg> GitHub</a>
           <a class="btn btn-secondary" href="https://github.com/Leihb/octo-agent/blob/main/CHANGELOG.md" data-en="📋 Changelog" data-zh="📋 更新日志"></a>
         </div>
       </div>

--- a/internal/server/webdist/favicon.svg
+++ b/internal/server/webdist/favicon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" rx="22" fill="#A371F7"/>
+  <rect width="100" height="100" rx="22" fill="#2F54EB"/>
   <path fill="#ffffff" d="M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z"/>
-  <circle cx="40" cy="42" r="5" fill="#A371F7"/>
-  <circle cx="60" cy="42" r="5" fill="#A371F7"/>
+  <circle cx="40" cy="42" r="5" fill="#2F54EB"/>
+  <circle cx="60" cy="42" r="5" fill="#2F54EB"/>
 </svg>

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" rx="22" fill="#A371F7"/>
+  <rect width="100" height="100" rx="22" fill="#2F54EB"/>
   <path fill="#ffffff" d="M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z"/>
-  <circle cx="40" cy="42" r="5" fill="#A371F7"/>
-  <circle cx="60" cy="42" r="5" fill="#A371F7"/>
+  <circle cx="40" cy="42" r="5" fill="#2F54EB"/>
+  <circle cx="60" cy="42" r="5" fill="#2F54EB"/>
 </svg>


### PR DESCRIPTION
Replace the octopus emoji 🐙 with the blue Octo brand mark across the official website (octo-agent.dev).

## Changes
- **Favicon**: Use the same SVG as `web/public/favicon.svg`
- **Hero logo**: Replace emoji with inline SVG, adjust CSS for proper SVG sizing
- **GitHub CTA button**: Embed small SVG icon instead of emoji

## Result
All three locations now use the consistent blue brand color `#2F54EB`, matching the favicon and `OctoLogo` component in the Web UI.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>