### PR TITLE
feishu: implement SendFile (image + file upload)

### DIFF
--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -18,8 +18,10 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime/multipart"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -199,9 +201,39 @@ func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 	return channel.SendResult{OK: true, MessageID: msgID}
 }
 
-// SendFile is not yet implemented for Feishu.
+// SendFile uploads a local file to Feishu and sends it to the chat.
+// Images go through the image-upload endpoint and are sent as "image"
+// messages; everything else is uploaded as a generic file and sent as a
+// "file" message.
 func (a *Adapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
-	return channel.SendResult{OK: false, Error: "SendFile not yet implemented"}
+	if _, err := os.Stat(path); err != nil {
+		return channel.SendResult{OK: false, Error: "file not found: " + path}
+	}
+
+	var msgType, content string
+	var err error
+	if isImagePath(path) {
+		var imageKey string
+		if imageKey, err = a.uploadImage(path); err == nil {
+			b, _ := json.Marshal(map[string]string{"image_key": imageKey})
+			msgType, content = "image", string(b)
+		}
+	} else {
+		var fileKey string
+		if fileKey, err = a.uploadFile(path, name); err == nil {
+			b, _ := json.Marshal(map[string]string{"file_key": fileKey})
+			msgType, content = "file", string(b)
+		}
+	}
+	if err != nil {
+		return channel.SendResult{OK: false, Error: "upload failed: " + err.Error()}
+	}
+
+	msgID, err := a.sendRaw(chatID, msgType, content, replyTo)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	return channel.SendResult{OK: true, MessageID: msgID}
 }
 
 // UpdateMessage edits an existing message.
@@ -708,11 +740,147 @@ func buildMsgPayload(text string) (msgType, content string) {
 	return "post", string(b)
 }
 
-// sendMessage posts a message to a chat.
+// ─── Upload ────────────────────────────────────────────────────────────────
+
+// uploadImage uploads an image and returns its image_key.
+func (a *Adapter) uploadImage(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	if err := mw.WriteField("image_type", "message"); err != nil {
+		return "", err
+	}
+	part, err := mw.CreateFormFile("image", filepath.Base(path))
+	if err != nil {
+		return "", err
+	}
+	if _, err := part.Write(data); err != nil {
+		return "", err
+	}
+	mw.Close()
+
+	req, _ := http.NewRequest("POST", a.domain+"/open-apis/im/v1/images", &buf)
+	req.Header.Set("Authorization", "Bearer "+a.getToken())
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			ImageKey string `json:"image_key"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return "", err
+	}
+	if r.Code != 0 {
+		return "", fmt.Errorf("upload image %d: %s", r.Code, r.Msg)
+	}
+	return r.Data.ImageKey, nil
+}
+
+// uploadFile uploads a generic file and returns its file_key.
+func (a *Adapter) uploadFile(path, name string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	fileName := name
+	if fileName == "" {
+		fileName = filepath.Base(path)
+	}
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	if err := mw.WriteField("file_type", feishuFileType(fileName)); err != nil {
+		return "", err
+	}
+	if err := mw.WriteField("file_name", fileName); err != nil {
+		return "", err
+	}
+	part, err := mw.CreateFormFile("file", fileName)
+	if err != nil {
+		return "", err
+	}
+	if _, err := part.Write(data); err != nil {
+		return "", err
+	}
+	mw.Close()
+
+	req, _ := http.NewRequest("POST", a.domain+"/open-apis/im/v1/files", &buf)
+	req.Header.Set("Authorization", "Bearer "+a.getToken())
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var r struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			FileKey string `json:"file_key"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return "", err
+	}
+	if r.Code != 0 {
+		return "", fmt.Errorf("upload file %d: %s", r.Code, r.Msg)
+	}
+	return r.Data.FileKey, nil
+}
+
+func isImagePath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp":
+		return true
+	}
+	return false
+}
+
+// feishuFileType maps a filename to one of Feishu's accepted file_type values.
+// Unknown extensions fall back to "stream".
+func feishuFileType(name string) string {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".mp4":
+		return "mp4"
+	case ".opus":
+		return "opus"
+	case ".pdf":
+		return "pdf"
+	case ".doc", ".docx":
+		return "doc"
+	case ".xls", ".xlsx":
+		return "xls"
+	case ".ppt", ".pptx":
+		return "ppt"
+	default:
+		return "stream"
+	}
+}
+
+// sendMessage posts a text message to a chat.
 // FEISHU-008: replyTo is passed through as reply_to_message_id when non-empty.
 func (a *Adapter) sendMessage(chatID, text, replyTo string) (string, error) {
 	msgType, content := buildMsgPayload(text)
+	return a.sendRaw(chatID, msgType, content, replyTo)
+}
 
+// sendRaw posts a pre-built message (any msg_type) to a chat.
+func (a *Adapter) sendRaw(chatID, msgType, content, replyTo string) (string, error) {
 	body := map[string]any{
 		"receive_id": chatID,
 		"msg_type":   msgType,

--- a/internal/channel/adapters/feishu/feishu_test.go
+++ b/internal/channel/adapters/feishu/feishu_test.go
@@ -1,0 +1,160 @@
+package feishu
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/channel"
+)
+
+// fakeFeishu serves the token, upload and message-send REST endpoints.
+type fakeFeishu struct {
+	mu          sync.Mutex
+	sent        []map[string]any
+	uploadType  string // "image" or "file" of the last upload
+	gotFileType string // file_type form field seen on a file upload
+	srv         *httptest.Server
+}
+
+func newFakeFeishu(t *testing.T) *fakeFeishu {
+	f := &fakeFeishu{}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/open-apis/auth/v3/tenant_access_token/internal":
+			json.NewEncoder(w).Encode(map[string]any{
+				"code": 0, "tenant_access_token": "tok", "expire": 7200,
+			})
+		case "/open-apis/im/v1/images":
+			f.mu.Lock()
+			f.uploadType = "image"
+			f.mu.Unlock()
+			json.NewEncoder(w).Encode(map[string]any{
+				"code": 0, "data": map[string]any{"image_key": "img-key-1"},
+			})
+		case "/open-apis/im/v1/files":
+			r.ParseMultipartForm(1 << 20)
+			f.mu.Lock()
+			f.uploadType = "file"
+			f.gotFileType = r.FormValue("file_type")
+			f.mu.Unlock()
+			json.NewEncoder(w).Encode(map[string]any{
+				"code": 0, "data": map[string]any{"file_key": "file-key-1"},
+			})
+		case "/open-apis/im/v1/messages":
+			var p map[string]any
+			json.NewDecoder(r.Body).Decode(&p)
+			f.mu.Lock()
+			f.sent = append(f.sent, p)
+			f.mu.Unlock()
+			json.NewEncoder(w).Encode(map[string]any{
+				"code": 0, "data": map[string]any{"message_id": "m-1"},
+			})
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func newTestAdapter(t *testing.T, f *fakeFeishu) *Adapter {
+	a, err := New(channel.PlatformConfig{
+		cfgAppID:     "app",
+		cfgAppSecret: "secret",
+		cfgDomain:    f.srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return a.(*Adapter)
+}
+
+func TestSendFile_Image(t *testing.T) {
+	f := newFakeFeishu(t)
+	a := newTestAdapter(t, f)
+
+	path := filepath.Join(t.TempDir(), "pic.png")
+	if err := os.WriteFile(path, []byte("\x89PNG\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res := a.SendFile("chat-1", path, "", "reply-0")
+	if !res.OK || res.MessageID != "m-1" {
+		t.Fatalf("send failed: %+v", res)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.uploadType != "image" {
+		t.Fatalf("expected image upload, got %q", f.uploadType)
+	}
+	if len(f.sent) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(f.sent))
+	}
+	if f.sent[0]["msg_type"] != "image" {
+		t.Errorf("msg_type = %v, want image", f.sent[0]["msg_type"])
+	}
+	if f.sent[0]["content"] != `{"image_key":"img-key-1"}` {
+		t.Errorf("content = %v", f.sent[0]["content"])
+	}
+	if f.sent[0]["reply_to_message_id"] != "reply-0" {
+		t.Errorf("reply_to_message_id = %v, want reply-0", f.sent[0]["reply_to_message_id"])
+	}
+}
+
+func TestSendFile_File(t *testing.T) {
+	f := newFakeFeishu(t)
+	a := newTestAdapter(t, f)
+
+	path := filepath.Join(t.TempDir(), "report.pdf")
+	if err := os.WriteFile(path, []byte("%PDF-1.4"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res := a.SendFile("chat-1", path, "report.pdf", "")
+	if !res.OK || res.MessageID != "m-1" {
+		t.Fatalf("send failed: %+v", res)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.uploadType != "file" {
+		t.Fatalf("expected file upload, got %q", f.uploadType)
+	}
+	if f.gotFileType != "pdf" {
+		t.Errorf("file_type = %q, want pdf", f.gotFileType)
+	}
+	if f.sent[0]["msg_type"] != "file" {
+		t.Errorf("msg_type = %v, want file", f.sent[0]["msg_type"])
+	}
+	if f.sent[0]["content"] != `{"file_key":"file-key-1"}` {
+		t.Errorf("content = %v", f.sent[0]["content"])
+	}
+}
+
+func TestSendFile_Missing(t *testing.T) {
+	f := newFakeFeishu(t)
+	a := newTestAdapter(t, f)
+
+	res := a.SendFile("chat-1", "/no/such/file", "", "")
+	if res.OK {
+		t.Fatal("expected failure for missing file")
+	}
+}
+
+func TestFeishuFileType(t *testing.T) {
+	cases := map[string]string{
+		"a.mp4": "mp4", "a.pdf": "pdf", "a.docx": "doc",
+		"a.xlsx": "xls", "a.pptx": "ppt", "a.bin": "stream", "noext": "stream",
+	}
+	for name, want := range cases {
+		if got := feishuFileType(name); got != want {
+			t.Errorf("feishuFileType(%q) = %q, want %q", name, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Implements the Feishu adapter's `SendFile`, which was the sole genuine placeholder among the 6 IM channels (it returned `"SendFile not yet implemented"`).

- **Images** (`.png/.jpg/.jpeg/.gif/.webp/.bmp`) → uploaded via `POST /open-apis/im/v1/images`, sent as an `image` message.
- **Other files** → uploaded via `POST /open-apis/im/v1/files` with `file_type` mapped by extension (`mp4/opus/pdf/doc/xls/ppt`, default `stream`), sent as a `file` message.
- Extracted `sendRaw` so the image/file send path is shared with the existing text send.
- `replyTo` is honored (passed as `reply_to_message_id`).

## Why not the other no-ops

`SendTyping`/`StopTyping`/`Flush` remain no-ops — Feishu bots have no typing-indicator API and no outgoing buffer. dingtalk/wecom no-op them identically, so these are platform limitations, not placeholders.

## Tests

New `feishu_test.go` (the package had none): httptest-backed coverage for image send, file send (asserts `file_type=pdf`), missing-file failure, and the `feishuFileType` mapping. `make fmt-check`, `go vet`, and `go test ./internal/channel/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)