### PR TITLE
feat(channel): let the agent send & receive media over IM

### DIFF
--- a/internal/server/channel_ask.go
+++ b/internal/server/channel_ask.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -121,6 +122,27 @@ type chatAsker struct {
 	sess *channel.Session
 	ad   channel.Adapter
 	ev   channel.InboundEvent
+}
+
+// channelFileSender adapts the platform adapter into a tools.ChannelFileSender
+// for the send_file tool: it pins the inbound chat + reply context so the
+// model can push a file to the user it is talking to. Stamped into the turn
+// ctx by runChannelTurns (tools.WithChannelSender).
+type channelFileSender struct {
+	ad      channel.Adapter
+	chatID  string
+	replyTo string
+}
+
+func (s channelFileSender) SendFile(path, name string) error {
+	res := s.ad.SendFile(s.chatID, path, name, s.replyTo)
+	if !res.OK {
+		if res.Error != "" {
+			return errors.New(res.Error)
+		}
+		return errors.New("the channel rejected the file")
+	}
+	return nil
 }
 
 func (c chatAsker) Ask(ctx context.Context, q tools.AskRequest) (tools.AskResponse, error) {

--- a/internal/server/channel_attach_test.go
+++ b/internal/server/channel_attach_test.go
@@ -48,9 +48,12 @@ func TestAttachInboundFiles_DocumentNote(t *testing.T) {
 }
 
 func TestAttachInboundFiles_Image(t *testing.T) {
-	// Redirect ~/.octo/uploads into a temp HOME so the test doesn't touch the
+	// Redirect ~/.octo/uploads into a temp home so the test doesn't touch the
 	// real home dir (saveImageAttachment persists the decoded bytes there).
-	t.Setenv("HOME", t.TempDir())
+	// Both vars: os.UserHomeDir reads HOME on unix, USERPROFILE on Windows.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
 
 	s := &Server{}
 	sess := newAttachSession()
@@ -65,7 +68,7 @@ func TestAttachInboundFiles_Image(t *testing.T) {
 		t.Errorf("content = %q, want %q", got, "what is this")
 	}
 	// A copy of the image should have been persisted under ~/.octo/uploads.
-	dir := filepath.Join(os.Getenv("HOME"), ".octo", "uploads")
+	dir := filepath.Join(tmpHome, ".octo", "uploads")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("uploads dir not created: %v", err)

--- a/internal/server/channel_attach_test.go
+++ b/internal/server/channel_attach_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/channel"
+)
+
+// 1x1 transparent PNG, base64.
+const tinyPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pdkAAAAAElFTkSuQmCC"
+
+func newAttachSession() *channel.Session {
+	return &channel.Session{Agent: agent.New(&stubSender{}, "stub-model")}
+}
+
+func TestAttachInboundFiles_TextOnly(t *testing.T) {
+	s := &Server{}
+	sess := newAttachSession()
+	ev := channel.InboundEvent{Platform: "weixin", Text: "hello"}
+	if got := s.attachInboundFiles(sess, ev); got != "hello" {
+		t.Errorf("content = %q, want %q", got, "hello")
+	}
+}
+
+func TestAttachInboundFiles_DocumentNote(t *testing.T) {
+	s := &Server{}
+	sess := newAttachSession()
+	doc := filepath.Join(t.TempDir(), "report.pdf")
+	if err := os.WriteFile(doc, []byte("%PDF"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ev := channel.InboundEvent{
+		Platform: "feishu",
+		Text:     "see attached",
+		Files:    []channel.FileAttachment{{Type: "file", Name: "report.pdf", Path: doc}},
+	}
+	got := s.attachInboundFiles(sess, ev)
+	if !strings.Contains(got, "see attached") {
+		t.Errorf("content lost the original text: %q", got)
+	}
+	if !strings.Contains(got, doc) {
+		t.Errorf("content missing the file path note: %q", got)
+	}
+}
+
+func TestAttachInboundFiles_Image(t *testing.T) {
+	// Redirect ~/.octo/uploads into a temp HOME so the test doesn't touch the
+	// real home dir (saveImageAttachment persists the decoded bytes there).
+	t.Setenv("HOME", t.TempDir())
+
+	s := &Server{}
+	sess := newAttachSession()
+	dataURL := "data:image/png;base64," + tinyPNG
+	ev := channel.InboundEvent{
+		Platform: "telegram",
+		Text:     "what is this",
+		Files:    []channel.FileAttachment{{Type: "image", Name: "pic.png", MimeType: "image/png", DataURL: dataURL}},
+	}
+	// Image rides as a vision block, not in the text — content stays the caption.
+	if got := s.attachInboundFiles(sess, ev); got != "what is this" {
+		t.Errorf("content = %q, want %q", got, "what is this")
+	}
+	// A copy of the image should have been persisted under ~/.octo/uploads.
+	dir := filepath.Join(os.Getenv("HOME"), ".octo", "uploads")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("uploads dir not created: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Error("expected the inbound image to be persisted under uploads")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1683,7 +1683,12 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	// after the synchronous turn chain has finished can kick an idle turn.
 	s.wireChannelCompletionHooks(sess, ad, ev)
 
-	s.runChannelTurns(ctx, sess, ad, ev, ev.Text)
+	// Bridge inbound attachments (images, documents) into the turn before it
+	// runs — images become vision blocks on the user message, documents become
+	// read_file-able path notes. Without this only ev.Text reaches the model.
+	content := s.attachInboundFiles(sess, ev)
+
+	s.runChannelTurns(ctx, sess, ad, ev, content)
 
 	// A steer that arrived during a restart drain would die with the
 	// process (the Inbox is memory-only) — give it the same retry notice a
@@ -1693,6 +1698,41 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 		sess.Agent.Inbox.Drain()
 		ad.SendText(ev.ChatID, "The server is restarting — please send that again in a moment.", ev.MessageID)
 	}
+}
+
+// attachInboundFiles bridges an inbound event's attachments into the agent
+// turn, mirroring the web composer's parseUserFiles. Images (delivered as data
+// URLs by the adapters) are decoded, persisted under ~/.octo/uploads, and
+// queued as vision blocks merged into the next user message; documents
+// (delivered as a local Path) become "[Attached file: <path>]" notes so the
+// model can open them with read_file. Per-file failures are logged and
+// skipped. Returns the content to run with any file notes folded in.
+func (s *Server) attachInboundFiles(sess *channel.Session, ev channel.InboundEvent) string {
+	content := ev.Text
+	var blocks []agent.ContentBlock
+	var notes []string
+	for _, f := range ev.Files {
+		switch {
+		case f.DataURL != "":
+			block, _, err := saveImageAttachment(f.Name, f.DataURL)
+			if err != nil {
+				slog.Debug("channel image attachment", "platform", ev.Platform, "name", f.Name, "err", err)
+				continue
+			}
+			blocks = append(blocks, block)
+		case f.Path != "":
+			notes = append(notes, fmt.Sprintf("[Attached file: %s]", f.Path))
+		}
+	}
+	if len(blocks) > 0 {
+		// Consumed once by the first RunAgent's appendUserInput; chained turns
+		// in runChannelTurns won't re-attach them.
+		sess.Agent.AttachUserBlocks(blocks)
+	}
+	if len(notes) > 0 {
+		content = strings.TrimSpace(content + "\n\n" + strings.Join(notes, "\n"))
+	}
+	return content
 }
 
 // wireChannelCompletionHooks registers per-session hooks for background
@@ -1820,6 +1860,13 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		// browser tabs an IM session doesn't have (the question would hang
 		// until /stop).
 		ctx = tools.WithAsker(ctx, s.channelAsker(sess, ad, ev))
+		// Turn-scoped file sender + the IM-only send_file tool: the model's
+		// reply carries text, so the only way to put a generated image / chart
+		// / document in front of the user is to push it through the adapter.
+		// Withheld from the shared default tool list (DefaultToolsFor); added
+		// here because only an IM turn has a chat to send to.
+		ctx = tools.WithChannelSender(ctx, channelFileSender{ad: ad, chatID: ev.ChatID, replyTo: ev.MessageID})
+		toolDefs = append(toolDefs, tools.SendFileToolDef())
 	}
 
 	persist := func() {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -30,6 +30,7 @@ var allTools = []tool{
 	WriteFileTool{},
 	EditFileTool{},
 	ShowArtifactTool{},
+	SendFileTool{},
 	GlobTool{},
 	GrepTool{},
 	WebFetchTool{},
@@ -238,6 +239,12 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 	spawnerOn := spawnerEnabled()
 	defs := make([]agent.ToolDefinition, 0, len(allTools))
 	for _, t := range allTools {
+		if _, isSend := t.(SendFileTool); isSend {
+			// IM-only: advertised by runChannelTurns (which injects the
+			// per-chat sender), never in the shared default list — on a
+			// CLI/TUI/Web turn it has no chat to send to and could only error.
+			continue
+		}
 		if _, isSkill := t.(SkillTool); isSkill && !skillsOn {
 			continue
 		}

--- a/internal/tools/send_file.go
+++ b/internal/tools/send_file.go
@@ -1,0 +1,117 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// ChannelFileSender delivers a local file to the IM chat the current turn is
+// bound to. It is implemented by the server (wrapping the platform adapter's
+// SendFile) and stamped into the turn ctx via WithChannelSender — the same
+// ctx-scoping pattern as Asker, since only IM turns have a chat to push to.
+type ChannelFileSender interface {
+	// SendFile uploads path to the bound chat under the display name name
+	// (empty name falls back to the file's basename). The adapter picks the
+	// wire type (image / video / file) from the extension.
+	SendFile(path, name string) error
+}
+
+// ctxKeyChannelSender carries the turn-scoped ChannelFileSender.
+type ctxKeyChannelSender struct{}
+
+// WithChannelSender stamps the file sender for the duration of an IM turn.
+func WithChannelSender(ctx context.Context, s ChannelFileSender) context.Context {
+	return context.WithValue(ctx, ctxKeyChannelSender{}, s)
+}
+
+// channelSenderFrom resolves the file sender for this turn, or nil when the
+// turn is not bound to an IM chat (CLI / TUI / Web).
+func channelSenderFrom(ctx context.Context) ChannelFileSender {
+	if s, ok := ctx.Value(ctxKeyChannelSender{}).(ChannelFileSender); ok && s != nil {
+		return s
+	}
+	return nil
+}
+
+// SendFileTool delivers a local file to the user through the active IM channel
+// (WeChat, Telegram, Discord, …). It is the only way the model can put a file
+// in front of an IM user: a chat reply carries text, so a generated image,
+// chart, document, or any other artifact must be pushed as a file.
+//
+// The tool lives in allTools so DefaultRegistry can dispatch it, but it is
+// withheld from the advertised tool list everywhere except IM turns — see
+// DefaultToolsFor, which always skips it, and runChannelTurns, which appends
+// its definition and injects the sender. On a non-IM turn channelSenderFrom
+// returns nil and the tool reports a clean, model-readable error.
+type SendFileTool struct{}
+
+// SendFileToolDef is the definition runChannelTurns appends to the IM tool
+// list. Exported so the server can advertise the tool without re-deriving it.
+func SendFileToolDef() agent.ToolDefinition { return SendFileTool{}.Definition() }
+
+func (SendFileTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "send_file",
+		Description: "Send a local file to the user through the current chat (image, video, " +
+			"document, or any file). Use this whenever the user should receive an actual file — " +
+			"a generated image or chart, a screenshot, a PDF or other document, a data export. " +
+			"A normal reply only carries text, so a file the user asked for MUST go through this " +
+			"tool. The wire type (image / video / file) is chosen automatically from the " +
+			"extension, so name images .png/.jpg and videos .mp4. The file must already exist on " +
+			"disk; create it first (write_file, a script, a download), then send it.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Absolute path of the file to send.",
+				},
+				"name": map[string]any{
+					"type":        "string",
+					"description": "Optional display filename shown to the user. Defaults to the file's basename.",
+				},
+			},
+			"required": []string{"path"},
+		},
+	}
+}
+
+func (SendFileTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	sender := channelSenderFrom(ctx)
+	if sender == nil {
+		return agent.ToolResult{}, fmt.Errorf("send_file: no chat to send to — this tool only works while chatting over an IM channel")
+	}
+
+	path := strings.TrimSpace(stringArg(input, "path"))
+	if path == "" {
+		return agent.ToolResult{}, fmt.Errorf("send_file: path is required")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return agent.ToolResult{}, fmt.Errorf("send_file: %w", err)
+	}
+	fi, err := os.Stat(abs)
+	if err != nil {
+		return agent.ToolResult{}, fmt.Errorf("send_file: %w", err)
+	}
+	if fi.IsDir() {
+		return agent.ToolResult{}, fmt.Errorf("send_file: %q is a directory", abs)
+	}
+
+	name := strings.TrimSpace(stringArg(input, "name"))
+	if name == "" {
+		name = filepath.Base(abs)
+	}
+
+	if err := sender.SendFile(abs, name); err != nil {
+		return agent.ToolResult{}, fmt.Errorf("send_file: %w", err)
+	}
+	return agent.ToolResult{
+		Text: fmt.Sprintf("Sent %s (%d bytes) to the chat.", name, fi.Size()),
+	}, nil
+}

--- a/internal/tools/send_file_test.go
+++ b/internal/tools/send_file_test.go
@@ -1,0 +1,148 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeSender records the last SendFile call and can be made to fail.
+type fakeSender struct {
+	gotPath string
+	gotName string
+	err     error
+	calls   int
+}
+
+func (f *fakeSender) SendFile(path, name string) error {
+	f.calls++
+	f.gotPath = path
+	f.gotName = name
+	return f.err
+}
+
+func TestSendFileTool_RequiresSender(t *testing.T) {
+	// No sender in ctx → CLI/TUI/Web turn → clean error, no panic.
+	_, err := SendFileTool{}.Execute(context.Background(), "send_file", map[string]any{"path": "/tmp/x.png"})
+	if err == nil {
+		t.Fatal("expected error when no channel sender is in ctx")
+	}
+}
+
+func TestSendFileTool_SendsFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "chart.png")
+	if err := os.WriteFile(p, []byte("PNGDATA"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fs := &fakeSender{}
+	ctx := WithChannelSender(context.Background(), fs)
+
+	res, err := SendFileTool{}.Execute(ctx, "send_file", map[string]any{"path": p})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fs.calls != 1 {
+		t.Fatalf("expected SendFile called once, got %d", fs.calls)
+	}
+	if fs.gotPath != p {
+		t.Errorf("path = %q, want %q", fs.gotPath, p)
+	}
+	// Display name defaults to the basename.
+	if fs.gotName != "chart.png" {
+		t.Errorf("name = %q, want %q", fs.gotName, "chart.png")
+	}
+	if res.Text == "" {
+		t.Error("expected a non-empty result text")
+	}
+}
+
+func TestSendFileTool_CustomName(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "tmp123.png")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fs := &fakeSender{}
+	ctx := WithChannelSender(context.Background(), fs)
+
+	if _, err := (SendFileTool{}).Execute(ctx, "send_file", map[string]any{"path": p, "name": "report.png"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fs.gotName != "report.png" {
+		t.Errorf("name = %q, want %q", fs.gotName, "report.png")
+	}
+}
+
+func TestSendFileTool_MissingFile(t *testing.T) {
+	fs := &fakeSender{}
+	ctx := WithChannelSender(context.Background(), fs)
+	if _, err := (SendFileTool{}).Execute(ctx, "send_file", map[string]any{"path": "/no/such/file.png"}); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if fs.calls != 0 {
+		t.Error("SendFile must not be called for a missing file")
+	}
+}
+
+func TestSendFileTool_Directory(t *testing.T) {
+	fs := &fakeSender{}
+	ctx := WithChannelSender(context.Background(), fs)
+	if _, err := (SendFileTool{}).Execute(ctx, "send_file", map[string]any{"path": t.TempDir()}); err == nil {
+		t.Fatal("expected error for a directory")
+	}
+	if fs.calls != 0 {
+		t.Error("SendFile must not be called for a directory")
+	}
+}
+
+func TestSendFileTool_EmptyPath(t *testing.T) {
+	ctx := WithChannelSender(context.Background(), &fakeSender{})
+	if _, err := (SendFileTool{}).Execute(ctx, "send_file", map[string]any{"path": "  "}); err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestSendFileTool_SenderError(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.pdf")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fs := &fakeSender{err: errors.New("not logged in")}
+	ctx := WithChannelSender(context.Background(), fs)
+	_, err := SendFileTool{}.Execute(ctx, "send_file", map[string]any{"path": p})
+	if err == nil {
+		t.Fatal("expected the sender's error to propagate")
+	}
+}
+
+// send_file is IM-only: it must never appear in the shared default tool list,
+// or CLI/TUI/Web turns would advertise a tool that can only error.
+func TestSendFileTool_NotInDefaultTools(t *testing.T) {
+	for _, d := range DefaultToolsFor("") {
+		if d.Name == "send_file" {
+			t.Fatal("send_file must not be advertised in DefaultToolsFor")
+		}
+	}
+}
+
+// But DefaultRegistry must still be able to dispatch it (runChannelTurns adds
+// the def per IM turn; the executor scans allTools to run it).
+func TestSendFileTool_DispatchableViaRegistry(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.png")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fs := &fakeSender{}
+	ctx := WithChannelSender(context.Background(), fs)
+	if _, err := NewDefaultRegistry().Execute(ctx, "send_file", map[string]any{"path": p}); err != nil {
+		t.Fatalf("registry could not dispatch send_file: %v", err)
+	}
+	if fs.calls != 1 {
+		t.Fatalf("expected the registry to route to SendFileTool, calls=%d", fs.calls)
+	}
+}


### PR DESCRIPTION
## Problem

Over IM (the screenshot was WeChat) the agent claimed *"WeChat only supports text, can't send images"* — a hallucination. The bridge was **text-only in both directions**, yet the adapters already implement the media plumbing:

- **Outbound**: every adapter implements `SendFile` (weixin CDN upload, telegram photo/document, discord multipart, …) but it was **called nowhere** — the model had no tool to push a file, so it guessed.
- **Inbound**: adapters download images (as data URLs) and documents (to disk) into `ev.Files`, but `runChannelTurns` passed only `ev.Text` to the agent — **attachments were silently dropped** (you send a photo, the agent never sees it).

## Fix — two media-type-agnostic pipes

The adapters already abstract media type (`mediaTypeForFile` routes `.png`→image, `.mp4`→video, else→file), so this models **two pipes**, not 4 media × 2 directions:

1. **`send_file` tool** (outbound). IM-only: it lives in `allTools` so `DefaultRegistry` can dispatch it, is withheld from `DefaultToolsFor` (CLI/TUI/Web have no chat to send to), and is advertised + given a per-chat sender by `runChannelTurns`. ctx-scoped sender mirrors the `Asker` pattern. Images, videos and documents all flow through this one tool.
2. **`attachInboundFiles`** (inbound). Mirrors the web composer's `parseUserFiles`: inbound images → vision blocks on the user message; documents → `[Attached file: <path>]` notes the model can `read_file`.

## Scope (deliberate)

- ✅ image + file, both directions, all platforms that expose them
- ✅ video (outbound) and weixin voice (inbound, transcribed into text) fall out for free
- ❌ outbound TTS / inbound non-weixin voice transcription / video understanding — out of scope
- `feishu` `SendFile` is still a stub; its outbound returns a clean, model-readable error (not a crash)

## Tests

- `internal/tools/send_file_test.go` — no-sender error, send, custom name, missing file, directory, empty path, sender-error propagation, **not in DefaultToolsFor**, dispatchable via registry
- `internal/server/channel_attach_test.go` — text-only passthrough, document note folding, image persisted + caption preserved

`go test -race ./...`, `go vet ./...`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)