### PR TITLE
tui: auto-fold large text pastes into inline placeholder tokens

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -207,6 +207,8 @@ func printTuiHelp(w io.Writer) {
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Keys:")
 	fmt.Fprintln(w, "  Ctrl+V      Paste an image from the clipboard (rides your next message; Esc discards)")
+	fmt.Fprintln(w, "  Paste       A large text paste collapses to a [#N pasted …] token; the full text is")
+	fmt.Fprintln(w, "              sent on submit. Tab folds/expands the whole box for long typed input.")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Type / to open the completion menu (Tab/↑↓ select, Enter complete) — it lists")
 	fmt.Fprintln(w, "every command and skill, so you don't have to remember names.")

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -360,6 +360,16 @@ type tuiModel struct {
 	// inputFoldedLines stores the line count when folded for display.
 	inputFoldedLines int
 
+	// pastedBlocks holds large bracketed-paste captures that were collapsed
+	// into inline "[#N pasted …]" placeholder tokens in the input box, keeping
+	// the box readable while composing. On submit/queue each token is expanded
+	// back to its full content before the message is sent. Cleared whenever the
+	// box is submitted, queued, or cleared.
+	pastedBlocks []pastedBlock
+	// pasteSeq numbers placeholder tokens within the current draft; reset to 0
+	// with pastedBlocks so a fresh draft starts numbering again at #1.
+	pasteSeq int
+
 	// modal, when non-nil, is an active Ask prompt (design §6).
 	modal *modalState
 

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"sync"
@@ -976,5 +977,131 @@ func TestTUI_InputFold_FourLinesNoFold(t *testing.T) {
 	m = m2.(*tuiModel)
 	if m.inputFolded {
 		t.Error("4-line input should not fold (threshold is 5)")
+	}
+}
+
+// pasteKey builds the bracketed-paste KeyMsg bubbletea delivers for a paste.
+func pasteKey(s string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s), Paste: true}
+}
+
+// TestTUI_Paste_LargeFoldsToToken: a big multi-line paste is replaced by a
+// "[#1 pasted N lines]" placeholder instead of dumping the raw text into the box.
+func TestTUI_Paste_LargeFoldsToToken(t *testing.T) {
+	m := newTestModel()
+	big := "a\nb\nc\nd\ne\nf"
+	m2, _ := m.handleKey(pasteKey(big))
+	m = m2.(*tuiModel)
+
+	if len(m.pastedBlocks) != 1 {
+		t.Fatalf("expected 1 pasted block, got %d", len(m.pastedBlocks))
+	}
+	if got := m.ta.Value(); got != "[#1 pasted 6 lines]" {
+		t.Errorf("box value = %q, want placeholder token", got)
+	}
+	if strings.Contains(m.ta.Value(), "\n") {
+		t.Error("raw multi-line paste must not land in the box")
+	}
+}
+
+// TestTUI_Paste_SmallInsertsVerbatim: a short paste below the threshold is
+// inserted as-is so brief snippets stay visible and editable.
+func TestTUI_Paste_SmallInsertsVerbatim(t *testing.T) {
+	m := newTestModel()
+	small := "one\ntwo"
+	m2, _ := m.handleKey(pasteKey(small))
+	m = m2.(*tuiModel)
+
+	if len(m.pastedBlocks) != 0 {
+		t.Errorf("small paste should not create a token, got %d blocks", len(m.pastedBlocks))
+	}
+	if m.ta.Value() != small {
+		t.Errorf("box value = %q, want %q", m.ta.Value(), small)
+	}
+}
+
+// TestTUI_Paste_LongSingleLineFoldsByChars: a single huge line (no newlines)
+// folds via the character threshold and labels itself in chars.
+func TestTUI_Paste_LongSingleLineFoldsByChars(t *testing.T) {
+	m := newTestModel()
+	long := strings.Repeat("x", pasteFoldMinChars)
+	m2, _ := m.handleKey(pasteKey(long))
+	m = m2.(*tuiModel)
+
+	if len(m.pastedBlocks) != 1 {
+		t.Fatalf("expected 1 pasted block, got %d", len(m.pastedBlocks))
+	}
+	want := fmt.Sprintf("[#1 pasted %d chars]", pasteFoldMinChars)
+	if m.ta.Value() != want {
+		t.Errorf("box value = %q, want %q", m.ta.Value(), want)
+	}
+}
+
+// TestTUI_Paste_SubmitExpands: submit restores the full pasted text (model +
+// history) while the scrollback echo keeps the collapsed token.
+func TestTUI_Paste_SubmitExpands(t *testing.T) {
+	m := newTestModel()
+	big := "x1\nx2\nx3\nx4\nx5\nx6"
+	m2, _ := m.handleKey(pasteKey(big))
+	m = m2.(*tuiModel)
+	// Type a prefix around the token.
+	setInput(m, "review this: "+m.ta.Value())
+
+	_, _ = m.submit()
+	if !m.turnRunning {
+		t.Fatal("submit should start a turn")
+	}
+	wantText := "review this: " + big
+	if len(m.inputHistory) != 1 || m.inputHistory[0] != wantText {
+		t.Errorf("history[0] = %q, want %q", m.inputHistory, wantText)
+	}
+	if len(m.pastedBlocks) != 0 {
+		t.Error("pasted blocks should be cleared after submit")
+	}
+	// Scrollback echo stays collapsed (token, not raw paste).
+	if !strings.Contains(m.echoPending, "[#1 pasted 6 lines]") {
+		t.Errorf("echo should show the collapsed token, got %q", m.echoPending)
+	}
+	if strings.Contains(m.echoPending, "x6") {
+		t.Errorf("echo must not dump the raw paste, got %q", m.echoPending)
+	}
+}
+
+// TestTUI_Paste_CtrlQQueuesExpanded: queuing mid-turn stores the full text.
+func TestTUI_Paste_CtrlQQueuesExpanded(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	big := "q1\nq2\nq3\nq4\nq5\nq6"
+	m2, _ := m.handleKey(pasteKey(big))
+	m = m2.(*tuiModel)
+
+	m2, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlQ})
+	m = m2.(*tuiModel)
+	if len(m.queue) != 1 || m.queue[0].text != big {
+		t.Errorf("queued text = %+v, want full paste", m.queue)
+	}
+	if len(m.pastedBlocks) != 0 {
+		t.Error("pasted blocks should be cleared after Ctrl+Q")
+	}
+}
+
+// TestTUI_Paste_EscClears: Esc on an idle box discards pending pastes.
+func TestTUI_Paste_EscClears(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = false
+	big := "e1\ne2\ne3\ne4\ne5\ne6"
+	m2, _ := m.handleKey(pasteKey(big))
+	m = m2.(*tuiModel)
+	if len(m.pastedBlocks) != 1 {
+		t.Fatalf("expected a pending paste, got %d", len(m.pastedBlocks))
+	}
+
+	m2, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	m = m2.(*tuiModel)
+	if len(m.pastedBlocks) != 0 {
+		t.Error("Esc should clear pending pastes")
+	}
+	if m.ta.Value() != "" {
+		t.Errorf("box should be empty after Esc, got %q", m.ta.Value())
 	}
 }

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -94,6 +94,14 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// A large bracketed paste is collapsed into an inline "[#N pasted …]" token
+	// so the box stays readable; the full text is restored on submit/queue.
+	// Small pastes fall through and insert verbatim so short snippets stay
+	// visible and editable.
+	if msg.Paste && shouldFoldPaste(string(msg.Runes)) {
+		return m.insertPasteToken(string(msg.Runes))
+	}
+
 	switch msg.Type {
 	case tea.KeyCtrlD:
 		m.quit = true
@@ -164,6 +172,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		// Idle: clear the input line and discard any pending attachments.
 		m.pendingAttachments = nil
+		m.clearPastes()
 		// Also clear folded state
 		if m.inputFolded {
 			m.inputFolded = false
@@ -192,16 +201,18 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if !m.turnRunning {
 			return m.submit()
 		}
-		text := m.ta.Value()
+		raw := m.ta.Value()
 		if m.inputFolded {
-			text = m.foldedFullText
+			raw = m.foldedFullText
 		}
-		text = strings.TrimSpace(text)
+		text := strings.TrimSpace(m.expandPastes(raw))
+		collapsed := strings.TrimSpace(raw)
 		if text == "" {
 			return m, nil
 		}
 		m.ta.Reset()
 		m.inputHistoryIdx = -1
+		m.clearPastes()
 		// Clear folded state
 		if m.inputFolded {
 			m.inputFolded = false
@@ -212,7 +223,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.inputHistory = append(m.inputHistory, text)
 		}
 		m.queue = append(m.queue, pendingItem{text: text})
-		m.println(queueStyle.Render("＋ queued: " + text))
+		m.println(queueStyle.Render("＋ queued: " + collapsed))
 		return m, nil
 
 	case tea.KeyCtrlX:
@@ -396,6 +407,71 @@ func (m *tuiModel) handleSubAgentPanelKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, nil
+}
+
+// pastedBlock is one large bracketed paste captured as an inline placeholder
+// token. placeholder is the exact text inserted into the textarea (e.g.
+// "[#1 pasted 123 lines]"); content is the full pasted text restored verbatim
+// on submit/queue.
+type pastedBlock struct {
+	placeholder string
+	content     string
+}
+
+const (
+	// pasteFoldMinLines / pasteFoldMinChars: a bracketed paste at least this big
+	// is collapsed into a placeholder token instead of being dumped into the box.
+	// The char threshold catches a single huge line (one long paragraph) that
+	// the line threshold alone would miss.
+	pasteFoldMinLines = 5
+	pasteFoldMinChars = 400
+)
+
+// shouldFoldPaste reports whether a pasted string is large enough to collapse
+// into a placeholder token rather than insert verbatim.
+func shouldFoldPaste(s string) bool {
+	if strings.Count(s, "\n")+1 >= pasteFoldMinLines {
+		return true
+	}
+	return len([]rune(s)) >= pasteFoldMinChars
+}
+
+// insertPasteToken records content as a pasted block and inserts a compact
+// "[#N pasted …]" placeholder at the cursor in place of the raw text.
+func (m *tuiModel) insertPasteToken(content string) (tea.Model, tea.Cmd) {
+	m.pasteSeq++
+	var label string
+	if lines := strings.Count(content, "\n") + 1; lines >= 2 {
+		label = fmt.Sprintf("[#%d pasted %d lines]", m.pasteSeq, lines)
+	} else {
+		label = fmt.Sprintf("[#%d pasted %d chars]", m.pasteSeq, len([]rune(content)))
+	}
+	m.pastedBlocks = append(m.pastedBlocks, pastedBlock{placeholder: label, content: content})
+	// Insert the token at the cursor exactly as if the label had been typed.
+	var cmd tea.Cmd
+	m.ta, cmd = m.ta.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(label)})
+	m.complIdx = 0
+	m.updateCompletion()
+	if hcmd := m.updateTextAreaHeight(); hcmd != nil {
+		cmd = tea.Batch(cmd, hcmd)
+	}
+	return m, cmd
+}
+
+// expandPastes replaces each placeholder token in text with its full pasted
+// content. A no-op when no pastes are pending or the tokens were edited away.
+func (m *tuiModel) expandPastes(text string) string {
+	for _, p := range m.pastedBlocks {
+		text = strings.ReplaceAll(text, p.placeholder, p.content)
+	}
+	return text
+}
+
+// clearPastes drops all pending pasted blocks and resets token numbering. Call
+// it whenever the input box content is consumed or discarded.
+func (m *tuiModel) clearPastes() {
+	m.pastedBlocks = nil
+	m.pasteSeq = 0
 }
 
 // imageExts are the file extensions tryAttachDroppedImage recognises.
@@ -639,16 +715,21 @@ func humanByteSize(n int) string {
 // with no attachments is ignored.
 func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 	// If folded, expand to get the full text for submission.
-	text := m.ta.Value()
+	raw := m.ta.Value()
 	if m.inputFolded {
-		text = m.foldedFullText
+		raw = m.foldedFullText
 	}
-	text = strings.TrimSpace(text)
+	// text is what the model and history see (paste tokens restored to full
+	// content); collapsed is what the scrollback echo shows, keeping any large
+	// paste folded as "[#N pasted …]" rather than dumping it verbatim.
+	text := strings.TrimSpace(m.expandPastes(raw))
+	collapsed := strings.TrimSpace(raw)
 	if text == "" && len(m.pendingAttachments) == 0 {
 		return m, nil
 	}
 	m.ta.Reset()
 	m.inputHistoryIdx = -1
+	m.clearPastes()
 	// Clear folded state after submit
 	if m.inputFolded {
 		m.inputFolded = false
@@ -676,14 +757,14 @@ func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 
 	if !m.turnRunning {
 		// Fold any pending image attachments into this turn's user message.
-		echo := text
+		echo := collapsed
 		if len(m.pendingAttachments) > 0 {
 			blocks := make([]agent.ContentBlock, 0, len(m.pendingAttachments))
 			for _, a := range m.pendingAttachments {
 				blocks = append(blocks, a.block)
 			}
 			m.a.AttachUserBlocks(blocks)
-			echo = strings.TrimSpace(text + "  " + m.attachmentChips())
+			echo = strings.TrimSpace(collapsed + "  " + m.attachmentChips())
 			m.pendingAttachments = nil
 		}
 		return m, m.startTurnEcho(text, echo)


### PR DESCRIPTION
## What

Pasting a large block into the TUI input box used to dump the raw text in, growing the box to 6 rows + internal scroll — messy and disorienting.

Now a bracketed paste of **≥5 lines or ≥400 chars** is collapsed into an inline `[#N pasted L lines]` placeholder token (single huge line → `[#N pasted C chars]`). The full text is restored when the message is **submitted or queued**; the scrollback echo keeps the collapsed token so the transcript stays tidy. Small pastes still insert verbatim, and you can type around multiple numbered tokens.

## Details

- Intercepts bubbletea's `msg.Paste` event in `handleInputKey` before it reaches the textarea.
- `expandPastes` restores tokens → full content on submit / `Ctrl+Q`; history (↑ recall) stores the full text so a recalled message is self-contained.
- Pending pastes are cleared and numbering reset on submit, queue, and Esc.
- Existing manual `Tab` whole-box fold is kept unchanged (for long typed/recalled input); the token model handles the paste case so the two don't conflict.
- `/help` gains a line documenting paste folding + the Tab fold.

## Tests

6 new tests in `tuirepl_test.go`: large fold, small verbatim, long-single-line char threshold, submit expands (model+history get full text, echo stays collapsed), Ctrl+Q queues expanded, Esc clears. `go test ./cmd/octo/`, `go vet`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)