### PR TITLE
agent: fix compaction overflow loop discarding the folded chunk

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -506,7 +506,12 @@ func (a *Agent) summarizeOn(ctx context.Context, sender Sender, model string, ms
 	// summarising model's — the lite model may be smaller than the primary.
 	window := contextWindow(model)
 	for {
-		est := a.historyTokens(msgs)
+		// Measure THIS slice, not the whole live history. historyTokens returns
+		// the provider-reported lastInputTokens (full prior prompt) whenever it
+		// is set, which here is the primary model's ~75%-of-window count — using
+		// it would ignore msgs entirely and pop the chunk down to 2 messages when
+		// the summarising (lite) model's window is smaller than the primary's.
+		est := estimateMessages(msgs)
 		if est < window {
 			break
 		}

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -509,6 +509,44 @@ func (f *modelRecordingFake) SendMessages(_ context.Context, model, _ string, _ 
 	return Reply{Content: f.summary}, nil
 }
 
+// msgCountRecordingFake records how many messages the last call received.
+type msgCountRecordingFake struct {
+	summary string
+	lastN   int
+}
+
+func (f *msgCountRecordingFake) SendMessages(_ context.Context, _, _ string, msgs []Message, _ int) (Reply, error) {
+	f.lastN = len(msgs)
+	return Reply{Content: f.summary}, nil
+}
+
+// TestSummarizeOn_OverflowMeasuresSlice guards against measuring the overflow
+// loop with the full-history token count instead of the slice being summarised.
+// With lastInputTokens set high (the primary model's ~75%-of-window prompt
+// count) and a smaller summarising window, the loop must NOT pop a slice that
+// already fits — doing so would discard nearly the whole chunk.
+func TestSummarizeOn_OverflowMeasuresSlice(t *testing.T) {
+	lite := &msgCountRecordingFake{summary: "s"}
+	a := New(&modelRecordingFake{summary: "p"}, "claude-opus-4")
+	// Simulate the provider having reported a huge full-history prompt size.
+	a.lastInputTokens = 5_000_000 // >> defaultContextWindow (128k)
+
+	// A small slice that easily fits the summarising window.
+	msgs := []Message{
+		NewUserMessage("a"), NewAssistantMessage("b"),
+		NewUserMessage("c"), NewAssistantMessage("d"),
+		NewUserMessage("e"), NewAssistantMessage("f"),
+	}
+	if _, err := a.summarizeOn(context.Background(), lite, "lite-model", msgs, nil); err != nil {
+		t.Fatal(err)
+	}
+	// summarizeOn appends one compression prompt, so a slice that fits yields
+	// len(msgs)+1 messages. The bug popped the slice down to 2 (sending 3).
+	if lite.lastN < len(msgs)+1 {
+		t.Errorf("summariser received %d messages; the overflow loop wrongly popped a fitting slice (want %d). lastInputTokens must not size a sub-slice.", lite.lastN, len(msgs)+1)
+	}
+}
+
 func TestSummarize_UsesLiteModelWhenSet(t *testing.T) {
 	primary := &modelRecordingFake{summary: "primary summary"}
 	lite := &modelRecordingFake{summary: "lite summary"}


### PR DESCRIPTION
## 🔴 HIGH — bug #1 from the cross-module audit

`summarizeOn`'s overflow-protection loop (`internal/agent/compaction.go`) sized the slice with `a.historyTokens(msgs)`, which returns the provider-reported `lastInputTokens` (the **primary** model's full ~75%-of-window prompt count) and **ignores its `msgs` argument**.

When the summarising (lite) model's window is smaller than the primary's — the default `claude-opus-4` (1M) + lite `claude-haiku-4-5` (256k) pairing — `est` stayed at ~750k every iteration and the loop popped the folded chunk down to **2 messages**. The summary was then generated from almost nothing while `archiveChunk` still stored the full chunk: **silent, severe context loss on every auto-compaction** (masked only when stale-tool reclamation had reset `lastInputTokens` to 0).

## Fix

Measure the actual slice with `estimateMessages(msgs)` in the overflow loop. `historyTokens` is only correct for the whole live history, never an arbitrary sub-slice.

## Test

`TestSummarizeOn_OverflowMeasuresSlice` — sets `lastInputTokens` high and a small summarising window, asserts a fitting slice is **not** popped (the bug sent 3 messages; the fix sends all 7). `go test ./internal/agent/`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)