### PR TITLE
openai: surface mid-stream error payloads instead of empty success

### DIFF
--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -155,6 +155,13 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 			return result, retry.AsTransientStream(fmt.Errorf("openai: parse stream chunk: %w", err))
 		}
 
+		// An OpenAI-compatible server can report a failure AFTER the 200 status
+		// as a `data: {"error": {...}}` line, then close the stream (often with
+		// no [DONE]). Surface it instead of treating the empty result as success,
+		// mirroring the anthropic adapter's `case "error"`.
+		if ch.Error != nil && ch.Error.Message != "" {
+			return result, fmt.Errorf("openai: stream error (%s): %s", ch.Error.Type, ch.Error.Message)
+		}
 		if result.Model == "" && ch.Model != "" {
 			result.Model = ch.Model
 		}

--- a/internal/provider/openai/stream_test.go
+++ b/internal/provider/openai/stream_test.go
@@ -556,3 +556,37 @@ func TestSendStream_MidStreamResetIsTransient(t *testing.T) {
 		t.Errorf("mid-stream reset should be transient, got %v", err)
 	}
 }
+
+// errorMidStream sends real content, then an `error` payload (after a 200), then
+// closes with no [DONE] — the shape some OpenAI-compatible gateways use to
+// report a mid-generation failure.
+const errorMidStreamOpenAI = "" +
+	`data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"}}]}` + "\n\n" +
+	`data: {"error":{"message":"upstream model overloaded","type":"server_error"}}` + "\n\n"
+
+// TestSendStream_MidStreamErrorSurfaces verifies a `data: {"error":...}` line
+// after a 200 surfaces as an error instead of being silently dropped and
+// returning the partial turn as success.
+func TestSendStream_MidStreamErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, errorMidStreamOpenAI)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	_, err := c.SendStream(context.Background(), provider.Request{
+		Model: "gpt-4o-mini", Messages: []agent.Message{agent.NewUserMessage("hi")},
+	}, provider.StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected an error from the mid-stream error payload, got nil")
+	}
+	if !strings.Contains(err.Error(), "upstream model overloaded") {
+		t.Errorf("error should carry the upstream message, got %v", err)
+	}
+}

--- a/internal/provider/openai/types.go
+++ b/internal/provider/openai/types.go
@@ -245,6 +245,14 @@ type streamChunk struct {
 	// most chunks have Usage zero; we keep the field so an upstream that
 	// chooses to emit it anyway still gets parsed.
 	Usage *apiUsage `json:"usage,omitempty"`
+	// Error is set when an OpenAI-compatible server reports a failure mid-stream
+	// (after a 200) as a `data: {"error": {...}}` line rather than a normal
+	// chunk. Without this the line parses as a chunk with zero choices and is
+	// silently skipped, so the turn returns empty as if it succeeded.
+	Error *struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error,omitempty"`
 }
 
 // streamChoice mirrors apiChoice but with Delta in place of Message.


### PR DESCRIPTION
## 🟡 MEDIUM — bug #2 from the cross-module audit

An OpenAI-compatible server (DashScope/DeepSeek/Kimi/gateways) can report a failure **after** the 200 status as a `data: {"error": {...}}` line, then close the stream (often with no `[DONE]`). `streamChunk` had no error field, so the line parsed as a chunk with **zero choices** and hit `if len(ch.Choices) == 0 { continue }` — silently skipped. The stream then hit EOF (treated as clean completion), and the turn returned **empty content as a success**: no error surfaced, no retry. The anthropic adapter already handles this via `case "error"`; the openai path didn't.

## Fix

- Add an `Error` field to `streamChunk`.
- After unmarshal, return `openai: stream error (type): message` if `ch.Error` is set, mirroring anthropic.

## Test

`TestSendStream_MidStreamErrorSurfaces` — streams real content then a `data: {"error":...}` line with no `[DONE]`, asserts `SendStream` returns an error carrying the upstream message. `go test ./internal/provider/openai/`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)