### PR TITLE
tools: fix Brave search never decoding its gzip response

### DIFF
--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -200,7 +200,10 @@ func searchBrave(ctx context.Context, query string, max int) ([]WebSearchResult,
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	req.Header.Set("X-Subscription-Token", os.Getenv("BRAVE_SEARCH_API_KEY"))
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Accept-Encoding", "gzip")
+	// Do NOT set Accept-Encoding manually: Go's transport only performs
+	// transparent gunzip when it added the header itself. Setting it here would
+	// hand back raw gzip bytes that the JSON decoder below can't read, failing
+	// every real Brave call. Let the transport negotiate and decompress.
 
 	resp, err := webHTTPClient().Do(req)
 	if err != nil {

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -1,6 +1,8 @@
 package tools
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
@@ -78,6 +80,41 @@ func TestWebSearch_BravePreferred(t *testing.T) {
 	}
 	if ui["type"] != "web_search" || ui["query"] != "go generics" || ui["total"] != 2 {
 		t.Errorf("UI payload = %+v", ui)
+	}
+}
+
+// TestWebSearch_BraveGzipResponse reproduces the real Brave API, which honours
+// gzip. The transport must transparently decompress; manually setting
+// Accept-Encoding (the prior bug) disables that and fails the decode.
+func TestWebSearch_BraveGzipResponse(t *testing.T) {
+	clearSearchEnv(t)
+	resetDDGCooldown()
+	t.Setenv("BRAVE_SEARCH_API_KEY", "test-key")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, _ = gz.Write([]byte(`{"web":{"results":[{"title":"G1","url":"https://g1","description":"d"}]}}`))
+		_ = gz.Close()
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer srv.Close()
+	swapEndpoint(t, &braveEndpoint, srv.URL)
+
+	out, err := WebSearchTool{}.Execute(context.Background(), "web_search", map[string]any{
+		"query": "gzip handling",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var resp WebSearchResponse
+	if err := json.Unmarshal([]byte(out.Text), &resp); err != nil {
+		t.Fatalf("output isn't valid JSON: %v\n%s", err, out.Text)
+	}
+	if resp.Provider != "brave" || len(resp.Results) != 1 || resp.Results[0].URL != "https://g1" {
+		t.Errorf("gzip Brave response not decoded: provider=%q results=%+v", resp.Provider, resp.Results)
 	}
 }
 


### PR DESCRIPTION
## 🟡 MEDIUM — bug #3 from the cross-module audit

`searchBrave` set `Accept-Encoding: gzip` manually, then decoded JSON straight from `resp.Body`. Go's `net/http` transport only performs transparent gunzip when **it** added the header itself; setting it manually disables auto-decompression and hands back raw gzip bytes. Against the real Brave API (which honours gzip) the `json.Decode` failed every time. Brave is backend priority #1, and the error was swallowed into `lastErr` with silent fallthrough to Tavily → Serper → DDG → Bing — so a user who configured the paid Brave key never actually used it. The existing `TestWebSearch_BravePreferred` missed it because httptest served uncompressed JSON.

## Fix

Remove the manual `Accept-Encoding` header — let the transport negotiate and transparently decompress, consistent with the other backends and `web_fetch` (the documented inverse of the Bing pitfall).

## Test

`TestWebSearch_BraveGzipResponse` — serves a real gzip-encoded Brave body (`Content-Encoding: gzip`) and asserts the results decode. `go test ./internal/tools/`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)