### PR TITLE
server: fix four concurrency bugs (cwd race, parallel turns, lost note, sync.Map)

### DIFF
--- a/internal/server/bg_tasks.go
+++ b/internal/server/bg_tasks.go
@@ -83,13 +83,18 @@ func (s *Server) notifySubAgentExit(sessionID string, ev tools.SubAgentNotificat
 // does. The note is a <system-reminder> block, so the web transcript never
 // renders it as user speech.
 func (s *Server) deliverModelNote(sessionID, note string) {
+	// Enqueue into the running Agent's Inbox while STILL holding sessionAgentsMu
+	// so this can't interleave with the turn-teardown defer, which drains the
+	// Inbox and deregisters the agent under the same lock. Otherwise a note
+	// landing between the drain and the deregister reaches an Inbox nothing will
+	// drain again — silently lost.
 	s.sessionAgentsMu.Lock()
-	a := s.sessionAgents[sessionID]
-	s.sessionAgentsMu.Unlock()
-	if a != nil {
+	if a := s.sessionAgents[sessionID]; a != nil {
 		a.Inbox.Enqueue(note)
+		s.sessionAgentsMu.Unlock()
 		return
 	}
+	s.sessionAgentsMu.Unlock()
 	s.enqueueSteer(sessionID, agent.InboxItem{Text: note})
 	s.kickIdleSteerTurn(sessionID)
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -257,6 +257,16 @@ func (s *Server) handleTurn(w http.ResponseWriter, r *http.Request) {
 		s.releaseSessionBinding(id, agent.EntryWeb)
 	}()
 
+	// A WS turn runs in a goroutine after releasing this mutex, guarded only by
+	// turnRunning. Without this check a REST turn would acquire the (free) mutex
+	// and run concurrently with that WS turn — both Save() the same session file,
+	// clobbering history. Honour turnRunning like the WS path does. (deferred
+	// unlock + binding release handle cleanup on this early return.)
+	if s.turnRunning[id] {
+		writeError(w, http.StatusConflict, "a turn is already running for this session")
+		return
+	}
+
 	sess, err = agent.LoadSession(id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
@@ -724,7 +734,7 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.Context, agent.ToolExecutor, *tools.SubAgentManager, error) {
 	executor := tools.NewDefaultRegistry()
 
-	engine, err := permission.New(permissionConfigPath(), s.cwd, resolvePermissionMode(), s.memDir, s.homeMemDir)
+	engine, err := permission.New(permissionConfigPath(), s.curCwd(), resolvePermissionMode(), s.memDir, s.homeMemDir)
 	if err != nil {
 		return ctx, nil, nil, fmt.Errorf("permission engine: %w", err)
 	}
@@ -867,7 +877,7 @@ func (s *Server) handleFileAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	abs, ok := resolveUnderCWD(s.cwd, req.Path)
+	abs, ok := resolveUnderCWD(s.curCwd(), req.Path)
 	if !ok {
 		writeError(w, http.StatusForbidden, "path is outside the working directory")
 		return
@@ -1209,11 +1219,10 @@ func (s *Server) handleUpdateSessionWorkingDir(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	s.cwd = req.WorkingDir
-	s.envCtx = buildEnvContext(s.cwd)
+	s.setCwd(req.WorkingDir)
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"ok":          true,
-		"working_dir": s.cwd,
+		"working_dir": s.curCwd(),
 	})
 }

--- a/internal/server/mcp_handlers.go
+++ b/internal/server/mcp_handlers.go
@@ -85,7 +85,7 @@ type mcpServerDetail struct {
 // mcpServerList builds the management view: configured entries joined with
 // live-registry state.
 func (s *Server) mcpServerList() ([]mcpServerInfo, error) {
-	managed, err := mcp.LoadManaged(s.cwd)
+	managed, err := mcp.LoadManaged(s.curCwd())
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (s *Server) handleListMCPServers(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleGetMCPServer(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 
-	managed, err := mcp.LoadManaged(s.cwd)
+	managed, err := mcp.LoadManaged(s.curCwd())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -296,7 +296,7 @@ func (s *Server) handleCreateMCPServer(w http.ResponseWriter, r *http.Request) {
 			s.connectIfLive(r, name, e)
 		}
 	case req.Name != "" && req.Server != nil:
-		managed, err := mcp.LoadManaged(s.cwd)
+		managed, err := mcp.LoadManaged(s.curCwd())
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
@@ -333,7 +333,7 @@ func (s *Server) handleCreateMCPServer(w http.ResponseWriter, r *http.Request) {
 // project-level entries (read-only from the web UI). Writes the HTTP error
 // itself; the second return is false when the caller should stop.
 func (s *Server) userManagedServer(w http.ResponseWriter, name string) (mcp.ManagedServer, bool) {
-	managed, err := mcp.LoadManaged(s.cwd)
+	managed, err := mcp.LoadManaged(s.curCwd())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return mcp.ManagedServer{}, false
@@ -445,7 +445,7 @@ func (s *Server) handleReconnectMCPServer(w http.ResponseWriter, r *http.Request
 	s.mcpMu.Lock()
 	defer s.mcpMu.Unlock()
 
-	managed, err := mcp.LoadManaged(s.cwd)
+	managed, err := mcp.LoadManaged(s.curCwd())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -489,7 +489,7 @@ func (s *Server) handleReloadMCP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusConflict, "tools are disabled on this server")
 		return
 	}
-	if err := app.SwapMCP(r.Context(), s.cwd, nil); err != nil {
+	if err := app.SwapMCP(r.Context(), s.curCwd(), nil); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}

--- a/internal/server/mcp_oauth_handlers.go
+++ b/internal/server/mcp_oauth_handlers.go
@@ -91,7 +91,7 @@ func (s *Server) handleStartMCPOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	managed, err := mcp.LoadManaged(s.cwd)
+	managed, err := mcp.LoadManaged(s.curCwd())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,10 +105,15 @@ type Server struct {
 	// data race between the mutation handlers and concurrent turns.
 	skillsManifest string
 	skillsMu       sync.RWMutex
-	cwd            string
-	envCtx         string
-	memDir         string
-	homeMemDir     string
+	// cwd/envCtx are the server's working directory and its derived env-context
+	// string. They are mutated by the working_dir handler while read on every
+	// turn (prompt composition, permission engine, file/mcp handlers), so cwdMu
+	// guards them — the same pattern as skillsManifest/skillsMu above.
+	cwd        string
+	envCtx     string
+	cwdMu      sync.RWMutex
+	memDir     string
+	homeMemDir string
 
 	// session-scoped turn locks: one turn per session at a time.
 	turnLocks map[string]*sync.Mutex
@@ -378,7 +383,8 @@ func (s *Server) enableSubAgentTools() {
 	if s.memDir != "" {
 		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
 	}
-	template.System, template.LeanSystem = prompt.ComposePair(s.system, s.cwd, s.envCtx, s.curSkillsManifest(), memInjection, true)
+	cwd, envCtx := s.curCwdEnv()
+	template.System, template.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), memInjection, true)
 	executor := tools.NewDefaultRegistry()
 	spawner := app.NewSpawner(template, executor, func() []agent.ToolDefinition {
 		return tools.DefaultToolsFor(s.model)
@@ -408,7 +414,7 @@ func (s *Server) enableMCP() {
 	app.SetMCPChildStderr(newMCPStderrWriter(slog.Default()))
 	s.mcpMu.Lock()
 	defer s.mcpMu.Unlock()
-	if err := app.SwapMCP(context.Background(), s.cwd, os.Stderr); err != nil {
+	if err := app.SwapMCP(context.Background(), s.curCwd(), os.Stderr); err != nil {
 		slog.Error("mcp setup", "err", err)
 	}
 	s.mcpCleanup = func() {
@@ -877,7 +883,8 @@ func resolveUnderCWD(cwd, path string) (string, bool) {
 func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	sender, model := s.senderForSession(sess)
 	a := agent.New(sender, model)
-	a.CWD = s.cwd
+	cwd, envCtx := s.curCwdEnv()
+	a.CWD = cwd
 	a.MaxTokens = s.cfg.MaxTokens
 	if dir, err := sess.ChunkDir(); err == nil {
 		a.ArchiveDir = dir // recall folded turns via the read tool
@@ -904,7 +911,7 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	if s.memDir != "" {
 		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
 	}
-	a.System, a.LeanSystem = prompt.ComposePair(s.system, s.cwd, s.envCtx, s.curSkillsManifest(), memInjection, true)
+	a.System, a.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), memInjection, true)
 
 	// L2: attention-layer rules injected per user turn (triggered keywords),
 	// plus the save-nudge appended to milestone tool results.
@@ -1175,6 +1182,31 @@ func (s *Server) setSkillsManifest(m string) {
 	s.skillsMu.Unlock()
 }
 
+// curCwd returns the server's working directory under a read lock.
+func (s *Server) curCwd() string {
+	s.cwdMu.RLock()
+	defer s.cwdMu.RUnlock()
+	return s.cwd
+}
+
+// curCwdEnv returns the working directory and its env-context string atomically
+// under a single read lock, so callers that need both (prompt composition)
+// never observe a torn pair across a concurrent setCwd.
+func (s *Server) curCwdEnv() (string, string) {
+	s.cwdMu.RLock()
+	defer s.cwdMu.RUnlock()
+	return s.cwd, s.envCtx
+}
+
+// setCwd replaces the working directory and recomputes its env context under a
+// write lock. Called by the working_dir handler.
+func (s *Server) setCwd(dir string) {
+	s.cwdMu.Lock()
+	s.cwd = dir
+	s.envCtx = buildEnvContext(dir)
+	s.cwdMu.Unlock()
+}
+
 // buildEnvContext mirrors cmd/octo's env context builder.
 func buildEnvContext(cwd string) string {
 	var b strings.Builder
@@ -1439,9 +1471,10 @@ func (s *Server) initChannels() {
 	factory := func() *agent.Agent {
 		defaultSender, model := s.defaultSenderAndModel()
 		a := agent.New(defaultSender, model)
-		a.CWD = s.cwd
+		cwd, envCtx := s.curCwdEnv()
+		a.CWD = cwd
 		a.MaxTokens = s.cfg.MaxTokens
-		a.System, a.LeanSystem = prompt.ComposePair(s.system, s.cwd, s.envCtx, s.curSkillsManifest(), memInjection, true)
+		a.System, a.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), memInjection, true)
 		if cfg, err := config.Load(); err == nil {
 			a.LiteSender, a.LiteModel = s.liteSenderFromConfig(cfg)
 			if a.LiteSender == nil {
@@ -1801,7 +1834,8 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	if s.memDir != "" {
 		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
 	}
-	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(s.system, s.cwd, s.envCtx, s.curSkillsManifest(), memInjection, true)
+	cwd, envCtx := s.curCwdEnv()
+	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), memInjection, true)
 
 	// L2 memory hooks, same pair buildAgent gives web turns: keyword
 	// reminders on user input, save-nudge on milestone tool results. The
@@ -1817,7 +1851,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// and consumes the next message as the answer. Built after BeginRun so
 	// it can't race the previous turn's gate. An engine failure aborts the
 	// turn — running ungated is never an acceptable fallback.
-	engine, err := permission.New(permissionConfigPath(), s.cwd, resolvePermissionMode(), s.memDir, s.homeMemDir)
+	engine, err := permission.New(permissionConfigPath(), cwd, resolvePermissionMode(), s.memDir, s.homeMemDir)
 	if err != nil {
 		// Generic chat reply — err.Error() can leak local paths into a
 		// group chat; the operator gets the detail on the server console.
@@ -1904,5 +1938,12 @@ func (s *Server) stopChannels() {
 	if s.channelMgr != nil {
 		_ = s.channelMgr.Stop()
 	}
-	s.runningAdapters = sync.Map{}
+	// Clear entries in place rather than reassigning the sync.Map: a concurrent
+	// HTTP handler (handleListChannels/handleGetChannel → isAdapterRunning) may
+	// be calling Load() during shutdown, and a sync.Map must not be copied or
+	// replaced after first use. Range+Delete is safe under concurrent access.
+	s.runningAdapters.Range(func(k, _ any) bool {
+		s.runningAdapters.Delete(k)
+		return true
+	})
 }

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -57,6 +57,15 @@ func (s *Server) handleTurnSSE(w http.ResponseWriter, r *http.Request) {
 		s.releaseSessionBinding(id, agent.EntryWeb)
 	}()
 
+	// A WS turn runs in a goroutine after releasing this mutex, guarded only by
+	// turnRunning; refuse to start a concurrent SSE turn that would Save() the
+	// same session file in parallel and clobber history. (deferred unlock +
+	// binding release handle cleanup on this early return.)
+	if s.turnRunning[id] {
+		writeError(w, http.StatusConflict, "a turn is already running for this session")
+		return
+	}
+
 	sess, err := agent.LoadSession(id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err.Error())

--- a/internal/server/turn_guard_test.go
+++ b/internal/server/turn_guard_test.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// TestHandleTurn_RejectsWhenTurnRunning: a REST turn must refuse (409) when a
+// turn is already running for the session — otherwise it would run concurrently
+// with the in-flight WS turn (which holds only the turnRunning flag, not the
+// mutex) and both would Save() the same session file, clobbering history.
+func TestHandleTurn_RejectsWhenTurnRunning(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a WS turn already in flight for this session.
+	if srv.turnRunning == nil {
+		srv.turnRunning = make(map[string]bool)
+	}
+	srv.turnRunning[sess.ID] = true
+
+	body := bytes.NewBufferString(`{"message":"hello"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/"+sess.ID+"/turn", body)
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 when a turn is already running (body: %s)", w.Code, w.Body.String())
+	}
+}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1019,20 +1019,21 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	s.sessionAgentsMu.Lock()
 	s.sessionAgents[sess.ID] = a
 	s.sessionAgentsMu.Unlock()
+	// Teardown: drain any messages still in the Inbox (they arrived during the
+	// final LLM round, or the turn errored before draining them) back to the
+	// steer queue, then deregister — BOTH under sessionAgentsMu so a concurrent
+	// deliverModelNote (background/sub-agent exit hook) either enqueues before
+	// the drain (caught here) or, if it runs after, sees the agent already gone
+	// and routes to the steer queue itself. Splitting these into two locked
+	// sections left a gap where a note enqueued between the drain and the
+	// deregister was silently lost.
 	defer func() {
 		s.sessionAgentsMu.Lock()
-		delete(s.sessionAgents, sess.ID)
-		s.sessionAgentsMu.Unlock()
-	}()
-	// Messages still in the Inbox when the turn ends — they arrived during the
-	// final LLM round, or the turn errored out before draining them — go back
-	// to the steer queue so runAgentTurnLoop chains them into the next turn,
-	// which answers, broadcasts, and persists them exactly once. (Runs before
-	// the deregistration defer above, so no message slips past both homes.)
-	defer func() {
 		if items := a.Inbox.Drain(); len(items) > 0 {
 			s.enqueueSteer(sess.ID, items...)
 		}
+		delete(s.sessionAgents, sess.ID)
+		s.sessionAgentsMu.Unlock()
 	}()
 
 	var toolDefs []agent.ToolDefinition


### PR DESCRIPTION
Fixes audit bugs #4, #5, #8, #9 (all in `internal/server`).

## 🟡 #4 — `s.cwd`/`s.envCtx` data race
Mutated by the `working_dir` handler with no lock while read on every turn (prompt composition, permission engine, file/mcp handlers). Guarded with `cwdMu` + `curCwd`/`curCwdEnv`/`setCwd` accessors — the same pattern as the adjacent `skillsManifest`/`skillsMu`. All read sites routed through the getters; pairs that need both fields read them atomically.

## 🟡 #5 — concurrent turns clobber the session file
A WS turn runs in a goroutine guarded only by `turnRunning` (it releases the turn mutex immediately), while `handleTurn`/`handleTurnSSE` relied solely on the mutex and never consulted `turnRunning`. So a REST/SSE turn could run **in parallel** with the WS turn — both `Save()` the same session file, last-writer-wins history loss. Both REST paths now return **409** when `turnRunning` is set. New test `TestHandleTurn_RejectsWhenTurnRunning`.

## 🟢 #8 — lost background/sub-agent completion note
Teardown drained the Inbox and deregistered the agent in **two** separate locked sections; a completion note enqueued in the gap reached an Inbox nothing drains again. Now drain+deregister is one critical section under `sessionAgentsMu`, and `deliverModelNote` enqueues under the same lock — so they can't interleave.

## 🟢 #9 — `sync.Map` reassigned under concurrent Load
`stopChannels` did `s.runningAdapters = sync.Map{}` while shutdown-concurrent handlers call `Load()` on it (a `sync.Map` must not be copied after first use). Cleared in place with `Range`+`Delete`.

`go test -race ./internal/server/`, `go vet`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)