### PR TITLE
mcp: fix Close-vs-in-flight panic and unbounded deadline-free Calls

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -8,7 +8,17 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 )
+
+// defaultCallTimeout bounds a single request/response when the caller's context
+// carries no deadline of its own. Without it, a server that accepts a request
+// but never sends a response frame (and keeps the transport open, so no EOF)
+// would block Call — and the agent turn — forever. Handshake/list calls in
+// connectOne already impose their own deadlines, so this only affects runtime
+// calls (CallTool/ReadResource/GetPrompt) invoked with a deadline-free ctx.
+// A var (not const) so tests can shrink it.
+var defaultCallTimeout = 60 * time.Second
 
 // Client is a single MCP server connection: one transport, one initialize
 // handshake, request/response dispatch by ID. It's safe for concurrent
@@ -115,6 +125,15 @@ func (c *Client) Instructions() string { return c.instructions }
 func (c *Client) Call(ctx context.Context, method string, params, result any) error {
 	if c.closed.Load() {
 		return errors.New("mcp: client closed")
+	}
+	// Bound the call when the caller gave no deadline, so a server that never
+	// replies can't wedge the turn indefinitely (stdio's Receive can't be
+	// interrupted by ctx once it blocks in Decode — only Close or a deadline
+	// unblocks the waiting caller).
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultCallTimeout)
+		defer cancel()
 	}
 	id := c.nextID.Add(1)
 	idBytes := []byte(strconv.FormatUint(id, 10))

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -335,6 +335,37 @@ func TestClient_CallAfterCloseFails(t *testing.T) {
 	}
 }
 
+// TestClient_DefaultTimeoutWhenNoDeadline verifies a Call with a deadline-free
+// context still returns (rather than hanging forever) when the server never
+// replies — the internal defaultCallTimeout kicks in.
+func TestClient_DefaultTimeoutWhenNoDeadline(t *testing.T) {
+	old := defaultCallTimeout
+	defaultCallTimeout = 50 * time.Millisecond
+	defer func() { defaultCallTimeout = old }()
+
+	srv := newMockServer(t)
+	srv.start()
+
+	c := NewClient(srv.tx, Implementation{Name: "test", Version: "0.1"})
+	if err := c.Initialize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// Stop the server so the next call gets no reply, and call with a
+	// deadline-free context — the default timeout must unblock it.
+	srv.stop()
+
+	done := make(chan error, 1)
+	go func() { _, err := c.ListTools(context.Background()); done <- err }()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected a timeout error from the default deadline")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Call hung past the default timeout — no internal deadline applied")
+	}
+}
+
 func TestClient_ContextCancellation(t *testing.T) {
 	srv := newMockServer(t)
 	srv.start()

--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -49,7 +49,12 @@ type HTTPTransport struct {
 	// inbox queues the response of each Send so Receive can hand it back.
 	// Buffered so a Send never blocks (paired with one Receive per Send,
 	// the channel never grows unboundedly).
-	inbox  chan *Message
+	inbox chan *Message
+	// done is closed by Close to signal shutdown. We never close inbox itself:
+	// an in-flight doRequest may still be about to send on it, and a send on a
+	// closed channel panics (and would crash the process). Producers and Receive
+	// select on done instead.
+	done   chan struct{}
 	closed atomic.Bool
 }
 
@@ -81,6 +86,7 @@ func NewHTTPTransport(cfg HTTPConfig) (*HTTPTransport, error) {
 		// has one outstanding response, but headroom protects against any
 		// pipelining we might add later.
 		inbox: make(chan *Message, 16),
+		done:  make(chan struct{}),
 	}, nil
 }
 
@@ -202,6 +208,10 @@ func (t *HTTPTransport) doRequest(ctx context.Context, body []byte, forceFreshTo
 	}
 	select {
 	case t.inbox <- &m:
+	case <-t.done:
+		// Transport closed while this request was in flight — drop the response
+		// rather than send on a channel teardown is tearing down.
+		return false, errors.New("mcp: http transport: closed")
 	case <-ctx.Done():
 		return false, ctx.Err()
 	}
@@ -217,6 +227,8 @@ func (t *HTTPTransport) Receive(ctx context.Context) (*Message, error) {
 			return nil, io.EOF
 		}
 		return m, nil
+	case <-t.done:
+		return nil, io.EOF
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
@@ -228,7 +240,7 @@ func (t *HTTPTransport) Close() error {
 	if !t.closed.CompareAndSwap(false, true) {
 		return nil
 	}
-	close(t.inbox)
+	close(t.done)
 	return nil
 }
 

--- a/internal/mcp/http_test.go
+++ b/internal/mcp/http_test.go
@@ -137,3 +137,40 @@ func TestNewHTTPTransport_EmptyURLRejected(t *testing.T) {
 		t.Error("expected error for empty URL")
 	}
 }
+
+// TestHTTPTransport_CloseDoesNotCloseInbox guards the panic fix: Close must not
+// close the inbox channel, because an in-flight doRequest may still be about to
+// send on it (a send on a closed channel panics and crashes the process). The
+// fix closes a separate done channel instead. Sending on inbox after Close must
+// therefore NOT panic.
+func TestHTTPTransport_CloseDoesNotCloseInbox(t *testing.T) {
+	tr, err := NewHTTPTransport(HTTPConfig{URL: "http://example.invalid"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tr.Close()
+	_ = tr.Close() // idempotent — must not panic
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("inbox was closed by Close(); send panicked: %v", r)
+		}
+	}()
+	tr.inbox <- &Message{} // buffered; would panic if Close had closed it
+}
+
+// TestHTTPTransport_ReceiveAfterCloseEOF: a pending Receive is unblocked with
+// io.EOF after Close (via the done channel), preserving the prior contract.
+func TestHTTPTransport_ReceiveAfterCloseEOF(t *testing.T) {
+	tr, err := NewHTTPTransport(HTTPConfig{URL: "http://example.invalid"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tr.Close()
+	if _, err := tr.Receive(context.Background()); err != io.EOF {
+		t.Fatalf("Receive after Close = %v, want io.EOF", err)
+	}
+	if err := tr.Send(context.Background(), &Message{}); err == nil {
+		t.Fatal("Send after Close should return an error")
+	}
+}


### PR DESCRIPTION
Fixes audit bugs #6 and #7 (`internal/mcp`).

## 🟡 #6 — `HTTPTransport.Close()` could panic (process crash)
`Close()` did `close(t.inbox)`, but `doRequest` sends the decoded response on `t.inbox` **after** the HTTP round-trip. A concurrent `Close()` (session end, `/mcp remove`, reconnect/swap) racing an in-flight request made that send hit a **closed channel → panic → whole process crashes**. (stdio's analogous Close is benign because its op returns an error; a channel send panics.)

Fix: close a separate `done` channel instead. `doRequest`'s send and `Receive` both `select` on `done`; `inbox` is never closed, so an in-flight send can never panic.

## 🟡 #7 — a non-responding MCP server wedges the turn forever
`Client.Call` waited on the response with only the caller's ctx to escape. `connectOne` wraps handshake/list calls in a timeout, but runtime `CallTool`/`ReadResource`/`GetPrompt` pass the agent's **deadline-free** ctx straight through. A server that accepts a request but never replies (keeping the transport open, so no EOF) blocks `Call` — and the turn — indefinitely; stdio's `Receive` can't be interrupted by ctx once it blocks in `Decode`. Unattended (server/IM/cron) turns never recover.

Fix: `Call` applies a 60s default deadline when the incoming ctx carries none. Handshake/list calls already have their own deadlines, so they're unaffected.

## Tests
`TestHTTPTransport_CloseDoesNotCloseInbox`, `TestHTTPTransport_ReceiveAfterCloseEOF`, `TestClient_DefaultTimeoutWhenNoDeadline`. `go test -race ./internal/mcp/`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)