### PR TITLE
app,cli: fix two latent audit lows (worktree leak, reflect panic guard)

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1305,7 +1305,15 @@ func (m *tuiModel) softWrappedRows() int {
 	// textarea will actually render. Fall back to newline counting if the
 	// internals ever change shape.
 	v := reflect.ValueOf(&m.ta).Elem()
-	width := int(v.FieldByName("width").Int())
+	// Guard the field lookup: if a bubbles upgrade renames/removes the
+	// unexported "width" field, FieldByName returns the zero Value and .Int()
+	// would panic, crashing the TUI on the next keystroke. Fall back to the
+	// newline count instead (same fallback the width<=0 branch already uses).
+	wf := v.FieldByName("width")
+	if !wf.IsValid() || wf.Kind() != reflect.Int {
+		return strings.Count(m.ta.Value(), "\n") + 1
+	}
+	width := int(wf.Int())
 	if width <= 0 {
 		return strings.Count(m.ta.Value(), "\n") + 1
 	}

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -159,6 +159,9 @@ func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.Spaw
 		if !json.Valid([]byte(cleaned)) {
 			r2, in2, out2, stop2, turns2, err2 := s.runChild(ctx, lc, schemaRetryPrompt)
 			if err2 != nil {
+				if wt != nil {
+					wt.finish() // reconcile/clean even on retry error so we don't leak the worktree
+				}
 				return tools.SpawnResult{}, err2
 			}
 			in, out, turns, stop = in+in2, out+out2, turns+turns2, stop2


### PR DESCRIPTION
Fixes audit bugs #10 and #11 — both low-severity / latent.

## 🟢 #10 — worktree leaked on schema-retry error (`internal/app/spawner.go`)
`Spawn` creates a git worktree, and both the first-runChild error path and the success path call `wt.finish()`. But when `Schema != ""` and the first reply is invalid JSON, a second (retry) round runs — and its error path returned without `wt.finish()`, leaking the worktree dir + `octo-wf/*` branch. Triggers only on the intersection of worktree isolation + schema + invalid first JSON + a hard error on the retry. Added the missing cleanup, mirroring the first-error path.

## 🟢 #11 — reflect panic guard in the TUI (`cmd/octo/tuirepl_view.go`)
`softWrappedRows` read the textarea's unexported `width` field via reflection and called `.Int()` with no `IsValid()` guard. If a future bubbles upgrade renamed/removed that field, `FieldByName` returns the zero `Value` and `.Int()` panics — crashing the TUI on the next keystroke, with the intended newline-count fallback unreachable. (Latent: bubbles v1.0.0 still has the field.) Guarded the lookup, matching the sibling reflection in `updateTextAreaHeight`.

`go build ./...`, `go test ./internal/app/ ./cmd/octo/`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)