### PR TITLE
feat(browser): owned Go-native CDP backend (computer-use slice 1)

### DIFF
--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -1,0 +1,182 @@
+package browser
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// point is a viewport coordinate.
+type point struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+}
+
+// elementCenter scrolls an element into view and returns its viewport-center
+// point, or an error if the selector matches nothing.
+func (p *Page) elementCenter(ctx context.Context, selector string) (point, error) {
+	expr := fmt.Sprintf(`(() => {
+		const el = document.querySelector(%s);
+		if (!el) return null;
+		el.scrollIntoView({ block: 'center', inline: 'center' });
+		const r = el.getBoundingClientRect();
+		return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+	})()`, jsString(selector))
+	var pt *point
+	if err := p.Eval(ctx, expr, &pt); err != nil {
+		return point{}, err
+	}
+	if pt == nil {
+		return point{}, fmt.Errorf("click: selector %q matched nothing", selector)
+	}
+	return *pt, nil
+}
+
+// Click performs a trusted browser-level click at the element's center.
+// Trusted input (vs a JS .click()) counts as a real user gesture, which some
+// flows — file dialogs, download buttons — require, and is less detectable.
+func (p *Page) Click(ctx context.Context, selector string) error {
+	pt, err := p.elementCenter(ctx, selector)
+	if err != nil {
+		return err
+	}
+	for _, typ := range []string{"mousePressed", "mouseReleased"} {
+		_, err := p.cli.call(ctx, p.sessionID, "Input.dispatchMouseEvent", map[string]any{
+			"type":       typ,
+			"x":          pt.X,
+			"y":          pt.Y,
+			"button":     "left",
+			"clickCount": 1,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TypeText focuses the element matched by selector and types text into it.
+func (p *Page) TypeText(ctx context.Context, selector, text string) error {
+	focus := fmt.Sprintf(`(() => { const el = document.querySelector(%s); if (!el) return false; el.focus(); return true; })()`, jsString(selector))
+	var ok bool
+	if err := p.Eval(ctx, focus, &ok); err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("type: selector %q matched nothing", selector)
+	}
+	_, err := p.cli.call(ctx, p.sessionID, "Input.insertText", map[string]any{"text": text})
+	return err
+}
+
+// modifierBits maps modifier names to the CDP modifier bitmask.
+var modifierBits = map[string]int{"alt": 1, "ctrl": 2, "control": 2, "meta": 4, "cmd": 4, "command": 4, "shift": 8}
+
+// namedKeys maps a few common keys to their CDP descriptors.
+var namedKeys = map[string]struct {
+	key, code string
+	vk        int
+}{
+	"enter":     {"Enter", "Enter", 13},
+	"return":    {"Enter", "Enter", 13},
+	"escape":    {"Escape", "Escape", 27},
+	"esc":       {"Escape", "Escape", 27},
+	"tab":       {"Tab", "Tab", 9},
+	"backspace": {"Backspace", "Backspace", 8},
+	"delete":    {"Delete", "Delete", 46},
+	"space":     {" ", "Space", 32},
+	"arrowdown": {"ArrowDown", "ArrowDown", 40},
+	"arrowup":   {"ArrowUp", "ArrowUp", 38},
+}
+
+// Key presses a single key or modifier+key combo, e.g. "enter", "escape",
+// "ctrl+a", "cmd+shift+s".
+func (p *Page) Key(ctx context.Context, combo string) error {
+	parts := strings.Split(strings.ToLower(combo), "+")
+	mods := 0
+	keyName := parts[len(parts)-1]
+	for _, m := range parts[:len(parts)-1] {
+		bit, ok := modifierBits[strings.TrimSpace(m)]
+		if !ok {
+			return fmt.Errorf("key: unknown modifier %q", m)
+		}
+		mods |= bit
+	}
+
+	var key, code string
+	var vk int
+	if nk, ok := namedKeys[strings.TrimSpace(keyName)]; ok {
+		key, code, vk = nk.key, nk.code, nk.vk
+	} else if len(keyName) == 1 {
+		c := keyName[0]
+		key = keyName
+		code = "Key" + strings.ToUpper(keyName)
+		vk = int(strings.ToUpper(keyName)[0])
+		_ = c
+	} else {
+		return fmt.Errorf("key: unsupported key %q", keyName)
+	}
+
+	for _, typ := range []string{"keyDown", "keyUp"} {
+		_, err := p.cli.call(ctx, p.sessionID, "Input.dispatchKeyEvent", map[string]any{
+			"type":                  typ,
+			"modifiers":             mods,
+			"key":                   key,
+			"code":                  code,
+			"windowsVirtualKeyCode": vk,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Scroll dispatches a wheel event. If selector is empty it scrolls at the
+// viewport origin.
+func (p *Page) Scroll(ctx context.Context, selector string, dx, dy float64) error {
+	pt := point{X: 10, Y: 10}
+	if selector != "" {
+		var err error
+		if pt, err = p.elementCenter(ctx, selector); err != nil {
+			return err
+		}
+	}
+	_, err := p.cli.call(ctx, p.sessionID, "Input.dispatchMouseEvent", map[string]any{
+		"type":   "mouseWheel",
+		"x":      pt.X,
+		"y":      pt.Y,
+		"deltaX": dx,
+		"deltaY": dy,
+	})
+	return err
+}
+
+// Screenshot captures the current viewport as PNG bytes.
+func (p *Page) Screenshot(ctx context.Context) ([]byte, error) {
+	res, err := p.cli.call(ctx, p.sessionID, "Page.captureScreenshot", map[string]any{"format": "png"})
+	if err != nil {
+		return nil, err
+	}
+	var r struct {
+		Data string `json:"data"`
+	}
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, err
+	}
+	return base64.StdEncoding.DecodeString(r.Data)
+}
+
+// AXTree returns the full accessibility tree as raw CDP node JSON — the Tier-2
+// semantic layer used for target resolution and verification.
+func (p *Page) AXTree(ctx context.Context) (json.RawMessage, error) {
+	// Enable is idempotent; ignore its error so a re-enable is harmless.
+	_, _ = p.cli.call(ctx, p.sessionID, "Accessibility.enable", nil)
+	res, err := p.cli.call(ctx, p.sessionID, "Accessibility.getFullAXTree", nil)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1,0 +1,187 @@
+package browser
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Browser is a CDP connection to a Chrome instance, optionally one this process
+// launched.
+type Browser struct {
+	cmd         *exec.Cmd
+	cli         *cdpClient
+	ownsProcess bool
+}
+
+// Launch starts a Chrome and connects to it.
+func Launch(ctx context.Context, opts LaunchOptions) (*Browser, error) {
+	cmd, wsURL, err := launchChrome(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	cli, err := dial(ctx, wsURL)
+	if err != nil {
+		cmd.Process.Kill()
+		return nil, err
+	}
+	return &Browser{cmd: cmd, cli: cli, ownsProcess: true}, nil
+}
+
+// Connect attaches to an already-running Chrome via its browser-level CDP
+// websocket URL (e.g. one the user started with --remote-debugging-port so
+// their logged-in session is reused).
+func Connect(ctx context.Context, wsURL string) (*Browser, error) {
+	cli, err := dial(ctx, wsURL)
+	if err != nil {
+		return nil, err
+	}
+	return &Browser{cli: cli, ownsProcess: false}, nil
+}
+
+func dial(ctx context.Context, wsURL string) (*cdpClient, error) {
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("dial cdp %s: %w", wsURL, err)
+	}
+	// Screenshots and full AX trees can be large; lift the read cap.
+	conn.SetReadLimit(64 << 20)
+	return newCDPClient(conn), nil
+}
+
+// Close tears down the connection and, if this process launched Chrome, the
+// Chrome process too.
+func (b *Browser) Close() error {
+	b.cli.close()
+	if b.ownsProcess && b.cmd != nil && b.cmd.Process != nil {
+		b.cmd.Process.Kill()
+		b.cmd.Wait()
+	}
+	return nil
+}
+
+// Page is one attached page target (a flattened CDP session).
+type Page struct {
+	cli       *cdpClient
+	sessionID string
+	targetID  string
+}
+
+// NewPage opens a fresh tab at url and attaches to it.
+func (b *Browser) NewPage(ctx context.Context, url string) (*Page, error) {
+	if url == "" {
+		url = "about:blank"
+	}
+	res, err := b.cli.call(ctx, "", "Target.createTarget", map[string]any{"url": url})
+	if err != nil {
+		return nil, err
+	}
+	var created struct {
+		TargetID string `json:"targetId"`
+	}
+	if err := json.Unmarshal(res, &created); err != nil {
+		return nil, err
+	}
+	res, err = b.cli.call(ctx, "", "Target.attachToTarget", map[string]any{
+		"targetId": created.TargetID,
+		"flatten":  true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var attached struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(res, &attached); err != nil {
+		return nil, err
+	}
+	p := &Page{cli: b.cli, sessionID: attached.SessionID, targetID: created.TargetID}
+	for _, domain := range []string{"Page.enable", "Runtime.enable", "DOM.enable"} {
+		if _, err := p.cli.call(ctx, p.sessionID, domain, nil); err != nil {
+			return nil, fmt.Errorf("%s: %w", domain, err)
+		}
+	}
+	return p, nil
+}
+
+// Navigate loads url and waits for the page load event.
+func (p *Page) Navigate(ctx context.Context, url string) error {
+	events, unsub := p.cli.subscribe("Page.loadEventFired", p.sessionID)
+	defer unsub()
+	if _, err := p.cli.call(ctx, p.sessionID, "Page.navigate", map[string]any{"url": url}); err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-events:
+		return nil
+	case <-time.After(30 * time.Second):
+		return fmt.Errorf("navigate %s: timed out waiting for load", url)
+	}
+}
+
+// Eval runs a JS expression in the page and unmarshals its return value into
+// out (pass nil to ignore the value). The expression may be a Promise.
+func (p *Page) Eval(ctx context.Context, expr string, out any) error {
+	res, err := p.cli.call(ctx, p.sessionID, "Runtime.evaluate", map[string]any{
+		"expression":    expr,
+		"returnByValue": true,
+		"awaitPromise":  true,
+	})
+	if err != nil {
+		return err
+	}
+	var r struct {
+		Result struct {
+			Value json.RawMessage `json:"value"`
+		} `json:"result"`
+		ExceptionDetails *struct {
+			Text string `json:"text"`
+		} `json:"exceptionDetails"`
+	}
+	if err := json.Unmarshal(res, &r); err != nil {
+		return err
+	}
+	if r.ExceptionDetails != nil {
+		return fmt.Errorf("eval threw: %s", r.ExceptionDetails.Text)
+	}
+	if out != nil && len(r.Result.Value) > 0 {
+		return json.Unmarshal(r.Result.Value, out)
+	}
+	return nil
+}
+
+// WaitFor polls until a CSS selector matches an element, or the timeout. This
+// is the verify primitive for "the download button appeared after search".
+func (p *Page) WaitFor(ctx context.Context, selector string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	expr := fmt.Sprintf("!!document.querySelector(%s)", jsString(selector))
+	for {
+		var present bool
+		if err := p.Eval(ctx, expr, &present); err != nil {
+			return err
+		}
+		if present {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("wait for %q: timed out after %s", selector, timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// jsString encodes s as a JS string literal via JSON (valid JS string syntax).
+func jsString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -1,0 +1,162 @@
+package browser
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixtureHTML reproduces the awkward shape of the real target system:
+//   - the download button only appears after a search (no pre-constructable URL)
+//   - clicking it generates the file client-side via a Blob (the server never
+//     returns the final file), so the only way to obtain it is to drive the
+//     real page and capture what lands on disk.
+const fixtureHTML = `<!doctype html><html><head><meta charset="utf-8"><title>fixture</title></head>
+<body>
+<input id="q" />
+<button id="search">Search</button>
+<div id="results"></div>
+<script>
+document.getElementById('search').addEventListener('click', function () {
+  var r = document.getElementById('results');
+  r.innerHTML = '';
+  setTimeout(function () {
+    var btn = document.createElement('button');
+    btn.id = 'download';
+    btn.textContent = 'Download Excel';
+    btn.addEventListener('click', function () {
+      var bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 1, 2, 3, 4]);
+      var blob = new Blob([bytes], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+      var a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'report-' + (document.getElementById('q').value || 'x') + '.xlsx';
+      document.body.appendChild(a);
+      a.click();
+    });
+    r.appendChild(btn);
+  }, 300);
+});
+</script>
+</body></html>`
+
+// newBrowser launches a headless Chrome, skipping the test when Chrome is not
+// installed (so CI without a browser stays green).
+func newBrowser(t *testing.T, ctx context.Context) *Browser {
+	t.Helper()
+	if _, err := findChrome(""); err != nil {
+		t.Skipf("chrome not available: %v", err)
+	}
+	b, err := Launch(ctx, LaunchOptions{Headless: true})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	return b
+}
+
+// TestSearchThenDownload exercises the wife's workflow shape end-to-end against
+// the owned backend: search, wait for the dynamically-appearing button, click
+// it, and capture the client-side-generated file.
+func TestSearchThenDownload(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(fixtureHTML))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#search", 5*time.Second); err != nil {
+		t.Fatalf("wait search: %v", err)
+	}
+
+	if err := page.TypeText(ctx, "#q", "alpha"); err != nil {
+		t.Fatalf("type: %v", err)
+	}
+	if err := page.Click(ctx, "#search"); err != nil {
+		t.Fatalf("click search: %v", err)
+	}
+	// The download button is absent until the (simulated) search completes.
+	if err := page.WaitFor(ctx, "#download", 5*time.Second); err != nil {
+		t.Fatalf("wait download button: %v", err)
+	}
+
+	dir := t.TempDir()
+	path, err := b.CaptureDownload(ctx, dir, func() error {
+		return page.Click(ctx, "#download")
+	})
+	if err != nil {
+		t.Fatalf("capture download: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat download %q: %v", path, err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("download %q is empty", path)
+	}
+	if !strings.Contains(info.Name(), "report-alpha") || !strings.HasSuffix(info.Name(), ".xlsx") {
+		t.Fatalf("unexpected download name %q", info.Name())
+	}
+}
+
+// TestPrimitives covers eval / screenshot / ax-tree / key on the fixture.
+func TestPrimitives(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(fixtureHTML))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#search", 5*time.Second); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	var title string
+	if err := page.Eval(ctx, "document.title", &title); err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if title != "fixture" {
+		t.Fatalf("title = %q, want fixture", title)
+	}
+
+	shot, err := page.Screenshot(ctx)
+	if err != nil {
+		t.Fatalf("screenshot: %v", err)
+	}
+	if len(shot) == 0 {
+		t.Fatal("empty screenshot")
+	}
+
+	ax, err := page.AXTree(ctx)
+	if err != nil {
+		t.Fatalf("ax tree: %v", err)
+	}
+	if len(ax) == 0 {
+		t.Fatal("empty ax tree")
+	}
+
+	if err := page.Key(ctx, "escape"); err != nil {
+		t.Fatalf("key: %v", err)
+	}
+}

--- a/internal/browser/cdp.go
+++ b/internal/browser/cdp.go
@@ -1,0 +1,195 @@
+// Package browser is octo's owned, in-binary browser automation backend. It
+// drives a real Chrome over the Chrome DevTools Protocol (CDP) — websocket +
+// JSON — with no Node and no external proxy. CDP is the only native surface;
+// the Chrome itself is the sole runtime dependency.
+//
+// cdp.go holds the transport: a minimal JSON-RPC client over a single
+// websocket, multiplexing commands and events across flattened target
+// sessions. Higher-level actions (navigate, click, …) live in browser.go.
+package browser
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gorilla/websocket"
+)
+
+// cdpClient is a JSON-RPC client over one CDP websocket. Commands carry an
+// auto-incrementing id and an optional sessionId (flatten mode); responses are
+// routed back by id, events are fanned out to subscribers by (method,
+// sessionId).
+type cdpClient struct {
+	conn *websocket.Conn
+
+	writeMu sync.Mutex // gorilla requires serialized writes
+	nextID  int64
+
+	pendingMu sync.Mutex
+	pending   map[int64]chan rpcResponse
+
+	subsMu  sync.Mutex
+	subs    map[int]*subscription
+	nextSub int
+
+	closeOnce sync.Once
+	closed    chan struct{}
+	closeErr  error
+}
+
+type rpcRequest struct {
+	ID        int64  `json:"id"`
+	Method    string `json:"method"`
+	Params    any    `json:"params,omitempty"`
+	SessionID string `json:"sessionId,omitempty"`
+}
+
+type rpcResponse struct {
+	ID        int64           `json:"id"`
+	Result    json.RawMessage `json:"result"`
+	Error     *cdpError       `json:"error"`
+	Method    string          `json:"method"`
+	Params    json.RawMessage `json:"params"`
+	SessionID string          `json:"sessionId"`
+}
+
+type cdpError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *cdpError) Error() string { return fmt.Sprintf("cdp error %d: %s", e.Code, e.Message) }
+
+// subscription receives events whose method and (when set) sessionId match.
+type subscription struct {
+	method    string
+	sessionID string
+	ch        chan rpcResponse
+}
+
+func newCDPClient(conn *websocket.Conn) *cdpClient {
+	c := &cdpClient{
+		conn:    conn,
+		pending: make(map[int64]chan rpcResponse),
+		subs:    make(map[int]*subscription),
+		closed:  make(chan struct{}),
+	}
+	go c.readLoop()
+	return c
+}
+
+func (c *cdpClient) readLoop() {
+	for {
+		_, data, err := c.conn.ReadMessage()
+		if err != nil {
+			c.shutdown(err)
+			return
+		}
+		var msg rpcResponse
+		if err := json.Unmarshal(data, &msg); err != nil {
+			continue
+		}
+		if msg.ID != 0 {
+			c.pendingMu.Lock()
+			ch := c.pending[msg.ID]
+			delete(c.pending, msg.ID)
+			c.pendingMu.Unlock()
+			if ch != nil {
+				ch <- msg
+			}
+			continue
+		}
+		// Event: fan out to matching subscribers without blocking the reader.
+		c.subsMu.Lock()
+		for _, s := range c.subs {
+			if s.method != msg.Method {
+				continue
+			}
+			if s.sessionID != "" && s.sessionID != msg.SessionID {
+				continue
+			}
+			select {
+			case s.ch <- msg:
+			default:
+			}
+		}
+		c.subsMu.Unlock()
+	}
+}
+
+func (c *cdpClient) shutdown(err error) {
+	c.closeOnce.Do(func() {
+		c.closeErr = err
+		close(c.closed)
+		c.conn.Close()
+		c.pendingMu.Lock()
+		for id, ch := range c.pending {
+			close(ch)
+			delete(c.pending, id)
+		}
+		c.pendingMu.Unlock()
+	})
+}
+
+// call sends a command and waits for its response. sessionID may be empty for
+// browser-level commands.
+func (c *cdpClient) call(ctx context.Context, sessionID, method string, params any) (json.RawMessage, error) {
+	id := atomic.AddInt64(&c.nextID, 1)
+	ch := make(chan rpcResponse, 1)
+	c.pendingMu.Lock()
+	c.pending[id] = ch
+	c.pendingMu.Unlock()
+
+	req := rpcRequest{ID: id, Method: method, Params: params, SessionID: sessionID}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	c.writeMu.Lock()
+	err = c.conn.WriteMessage(websocket.TextMessage, payload)
+	c.writeMu.Unlock()
+	if err != nil {
+		return nil, fmt.Errorf("cdp write %s: %w", method, err)
+	}
+
+	select {
+	case <-ctx.Done():
+		c.pendingMu.Lock()
+		delete(c.pending, id)
+		c.pendingMu.Unlock()
+		return nil, ctx.Err()
+	case <-c.closed:
+		return nil, fmt.Errorf("cdp connection closed: %w", c.closeErr)
+	case resp, ok := <-ch:
+		if !ok {
+			return nil, fmt.Errorf("cdp connection closed: %w", c.closeErr)
+		}
+		if resp.Error != nil {
+			return nil, fmt.Errorf("%s: %w", method, resp.Error)
+		}
+		return resp.Result, nil
+	}
+}
+
+// subscribe registers interest in an event method (optionally scoped to a
+// session) and returns the channel plus an unsubscribe func. The buffer is
+// generous; the reader drops on overflow rather than blocking, so callers must
+// subscribe before triggering the action that emits the event.
+func (c *cdpClient) subscribe(method, sessionID string) (<-chan rpcResponse, func()) {
+	c.subsMu.Lock()
+	defer c.subsMu.Unlock()
+	id := c.nextSub
+	c.nextSub++
+	s := &subscription{method: method, sessionID: sessionID, ch: make(chan rpcResponse, 32)}
+	c.subs[id] = s
+	return s.ch, func() {
+		c.subsMu.Lock()
+		delete(c.subs, id)
+		c.subsMu.Unlock()
+	}
+}
+
+func (c *cdpClient) close() { c.shutdown(fmt.Errorf("closed by caller")) }

--- a/internal/browser/chrome.go
+++ b/internal/browser/chrome.go
@@ -1,0 +1,193 @@
+package browser
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+// LaunchOptions controls how a Chrome instance is started or located.
+type LaunchOptions struct {
+	// ExecPath overrides Chrome auto-detection.
+	ExecPath string
+	// UserDataDir is the Chrome profile directory. Empty launches a throwaway
+	// temp profile (no login state) — fine for tests. Real workflows point this
+	// at the user's profile so logged-in sessions are reused.
+	UserDataDir string
+	// Port is the remote-debugging port. 0 lets Chrome pick one, which is then
+	// read back from the DevToolsActivePort file in the profile dir.
+	Port int
+	// Headless runs Chrome with --headless=new. Real interactive workflows want
+	// this false so the user can watch and intervene.
+	Headless bool
+	// DownloadDir, when set, is where the page's downloads are directed.
+	DownloadDir string
+	// ExtraArgs are appended verbatim.
+	ExtraArgs []string
+}
+
+// chromePaths lists the default Chrome executable locations per platform,
+// most-preferred first.
+func chromePaths() []string {
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{
+			"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+			"/Applications/Chromium.app/Contents/MacOS/Chromium",
+			"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+		}
+	case "windows":
+		pf := os.Getenv("ProgramFiles")
+		pfx86 := os.Getenv("ProgramFiles(x86)")
+		local := os.Getenv("LOCALAPPDATA")
+		return []string{
+			filepath.Join(pf, `Google\Chrome\Application\chrome.exe`),
+			filepath.Join(pfx86, `Google\Chrome\Application\chrome.exe`),
+			filepath.Join(local, `Google\Chrome\Application\chrome.exe`),
+			filepath.Join(pfx86, `Microsoft\Edge\Application\msedge.exe`),
+		}
+	default: // linux and friends
+		return []string{
+			"/usr/bin/google-chrome",
+			"/usr/bin/google-chrome-stable",
+			"/usr/bin/chromium",
+			"/usr/bin/chromium-browser",
+			"/usr/bin/microsoft-edge",
+		}
+	}
+}
+
+// findChrome resolves the Chrome executable, honoring an explicit override.
+func findChrome(override string) (string, error) {
+	if override != "" {
+		if _, err := os.Stat(override); err != nil {
+			return "", fmt.Errorf("chrome exec %q: %w", override, err)
+		}
+		return override, nil
+	}
+	for _, p := range chromePaths() {
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+	if p, err := exec.LookPath("google-chrome"); err == nil {
+		return p, nil
+	}
+	if p, err := exec.LookPath("chromium"); err == nil {
+		return p, nil
+	}
+	return "", fmt.Errorf("chrome not found; set LaunchOptions.ExecPath")
+}
+
+// launchChrome starts Chrome and returns the running process plus the browser-
+// level CDP websocket URL.
+func launchChrome(ctx context.Context, opts LaunchOptions) (*exec.Cmd, string, error) {
+	exe, err := findChrome(opts.ExecPath)
+	if err != nil {
+		return nil, "", err
+	}
+	dataDir := opts.UserDataDir
+	tempDir := ""
+	if dataDir == "" {
+		tempDir, err = os.MkdirTemp("", "octo-chrome-")
+		if err != nil {
+			return nil, "", err
+		}
+		dataDir = tempDir
+	}
+
+	args := []string{
+		fmt.Sprintf("--remote-debugging-port=%d", opts.Port),
+		"--user-data-dir=" + dataDir,
+		"--no-first-run",
+		"--no-default-browser-check",
+		"--disable-gpu",
+		"about:blank",
+	}
+	if opts.Headless {
+		args = append([]string{"--headless=new"}, args...)
+	}
+	args = append(args, opts.ExtraArgs...)
+
+	cmd := exec.Command(exe, args...)
+	if err := cmd.Start(); err != nil {
+		if tempDir != "" {
+			os.RemoveAll(tempDir)
+		}
+		return nil, "", fmt.Errorf("start chrome: %w", err)
+	}
+
+	port := opts.Port
+	if port == 0 {
+		port, err = readDevToolsPort(ctx, dataDir)
+		if err != nil {
+			cmd.Process.Kill()
+			return nil, "", err
+		}
+	}
+	wsURL, err := browserWebSocketURL(ctx, port)
+	if err != nil {
+		cmd.Process.Kill()
+		return nil, "", err
+	}
+	return cmd, wsURL, nil
+}
+
+// readDevToolsPort waits for Chrome to write its chosen debug port to the
+// DevToolsActivePort file in the profile dir (first line is the port).
+func readDevToolsPort(ctx context.Context, dataDir string) (int, error) {
+	path := filepath.Join(dataDir, "DevToolsActivePort")
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if data, err := os.ReadFile(path); err == nil {
+			var port int
+			if _, err := fmt.Sscanf(string(data), "%d", &port); err == nil && port > 0 {
+				return port, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return 0, fmt.Errorf("timed out reading DevToolsActivePort in %s", dataDir)
+		}
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// browserWebSocketURL fetches the browser-level CDP endpoint from the debug
+// HTTP server, retrying until Chrome is ready.
+func browserWebSocketURL(ctx context.Context, port int) (string, error) {
+	url := fmt.Sprintf("http://127.0.0.1:%d/json/version", port)
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			var v struct {
+				WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+			}
+			dec := json.NewDecoder(resp.Body)
+			derr := dec.Decode(&v)
+			resp.Body.Close()
+			if derr == nil && v.WebSocketDebuggerURL != "" {
+				return v.WebSocketDebuggerURL, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("timed out fetching CDP endpoint on port %d", port)
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}

--- a/internal/browser/download.go
+++ b/internal/browser/download.go
@@ -1,0 +1,116 @@
+package browser
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// CaptureDownload directs downloads to dir, runs trigger (which should click
+// the thing that starts a download), and waits for the download to finish —
+// returning the saved file's path.
+//
+// This is required for systems where the file is produced client-side: the raw
+// HTTP response is not the file, so the only way to obtain it is to let the page
+// generate it and capture what lands on disk.
+func (b *Browser) CaptureDownload(ctx context.Context, dir string, trigger func() error) (string, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	willBegin, unsub1 := b.cli.subscribe("Browser.downloadWillBegin", "")
+	defer unsub1()
+	progress, unsub2 := b.cli.subscribe("Browser.downloadProgress", "")
+	defer unsub2()
+
+	if _, err := b.cli.call(ctx, "", "Browser.setDownloadBehavior", map[string]any{
+		"behavior":      "allow",
+		"downloadPath":  dir,
+		"eventsEnabled": true,
+	}); err != nil {
+		return "", fmt.Errorf("set download behavior: %w", err)
+	}
+
+	if err := trigger(); err != nil {
+		return "", err
+	}
+
+	// Identify the download (guid + suggested filename).
+	var guid, filename string
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case ev := <-willBegin:
+		var w struct {
+			GUID              string `json:"guid"`
+			SuggestedFilename string `json:"suggestedFilename"`
+		}
+		if err := json.Unmarshal(ev.Params, &w); err != nil {
+			return "", err
+		}
+		guid, filename = w.GUID, w.SuggestedFilename
+	case <-time.After(30 * time.Second):
+		return "", fmt.Errorf("download did not begin within 30s")
+	}
+
+	// Wait for completion of that download.
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case ev := <-progress:
+			var pr struct {
+				GUID  string `json:"guid"`
+				State string `json:"state"`
+			}
+			if err := json.Unmarshal(ev.Params, &pr); err != nil {
+				return "", err
+			}
+			if pr.GUID != guid {
+				continue
+			}
+			switch pr.State {
+			case "completed":
+				return resolveDownloadPath(dir, filename), nil
+			case "canceled":
+				return "", fmt.Errorf("download %s canceled", filename)
+			}
+		case <-time.After(60 * time.Second):
+			return "", fmt.Errorf("download %s did not complete within 60s", filename)
+		}
+	}
+}
+
+// resolveDownloadPath returns dir/filename when it exists, otherwise the newest
+// file in dir (a fallback for Chrome versions that name the file differently).
+func resolveDownloadPath(dir, filename string) string {
+	candidate := filepath.Join(dir, filename)
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return candidate
+	}
+	var newest string
+	var newestMod time.Time
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(newestMod) {
+			newestMod = info.ModTime()
+			newest = filepath.Join(dir, e.Name())
+		}
+	}
+	if newest != "" {
+		return newest
+	}
+	return candidate
+}


### PR DESCRIPTION
浏览器 computer-use 支柱的第一块砖(设计:`dev-docs/browser-computer-use-design.md`,#917)。

**自有、进二进制的浏览器自动化后端**:纯 Go 经 CDP 直驱真实 Chrome——无 Node、无外部 proxy。Chrome 是唯一运行时依赖;CDP 客户端复用已有的 `gorilla/websocket`,**go.mod 零新增依赖**。

## 内容(`internal/browser/`)

- **cdp.go**:手写 JSON-RPC 客户端,单 websocket 多路复用命令/事件,跨 flatten 的 target session。
- **chrome.go**:按平台发现/启动 Chrome(exec 路径、`DevToolsActivePort` + `/json/version`),支持指向用户 profile 以复用登录态。
- **browser.go**:Browser/Page 生命周期、Navigate、Eval、WaitFor(Verify 原语)。
- **actions.go**:可信 Click(`Input.dispatchMouseEvent`,真实用户手势)、TypeText、Key、Scroll、Screenshot、AXTree(Tier-2 语义层)。
- **download.go**:`CaptureDownload`——把下载导到指定目录并等待完成。**这是关键**:目标系统的最终文件由前端现做,重放 HTTP 请求拿不到,只能驱动真页面捕获落盘文件。

## 验收

本地 fixture 复刻了目标系统的硬骨头:**下载按钮搜索后才出现**、**文件由前端 Blob 现做**。端到端测试跑通(搜索→等动态按钮→可信点击→捕获下载),`-race` 干净。Chrome 不存在时测试自动 skip(CI 不挂)。

## 范围

这是 **slice 1**,纯后端库,**尚不可被 agent 调用**。slice 2 接入:agent 工具、过滤条件循环、录制技能产物、真实登录态 Chrome 接管(届时用我太太那套真实系统做验收)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)