### PR TITLE
feat(browser): browser tool wired into the agent (computer-use slice 2)

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -40,6 +40,7 @@ func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
 	cleanup := func() {
 		tools.SetDefaultSubAgentManager(nil)
 		tools.SetSpawner(nil)
+		tools.ResetBrowserSession()
 	}
 	if enableTasks {
 		tools.SetTaskStore(tasks.New())

--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -57,6 +57,56 @@ func (p *Page) Click(ctx context.Context, selector string) error {
 	return nil
 }
 
+// Hover moves the pointer over an element with a real (trusted) mouse move.
+// Synthetic JS events can't trigger CSS :hover reveals — only a genuine pointer
+// move does, which is what this dispatches.
+func (p *Page) Hover(ctx context.Context, selector string) error {
+	pt, err := p.elementCenter(ctx, selector)
+	if err != nil {
+		return err
+	}
+	_, err = p.cli.call(ctx, p.sessionID, "Input.dispatchMouseEvent", map[string]any{
+		"type": "mouseMoved",
+		"x":    pt.X,
+		"y":    pt.Y,
+	})
+	return err
+}
+
+// SelectOption picks an <option> of a native <select> by its value, visible
+// text, or label, then fires input+change so framework bindings react. Native
+// select popups are browser-drawn (not DOM), so this is the reliable path.
+func (p *Page) SelectOption(ctx context.Context, selector, value string) error {
+	expr := fmt.Sprintf(`(() => {
+		const el = document.querySelector(%s);
+		if (!el || el.tagName !== 'SELECT') return 'no-select';
+		let idx = -1;
+		for (let i = 0; i < el.options.length; i++) {
+			const o = el.options[i];
+			if (o.value === %s || o.text === %s || o.label === %s) { idx = i; break; }
+		}
+		if (idx < 0) return 'no-option';
+		el.selectedIndex = idx;
+		el.dispatchEvent(new Event('input', { bubbles: true }));
+		el.dispatchEvent(new Event('change', { bubbles: true }));
+		return 'ok';
+	})()`, jsString(selector), jsString(value), jsString(value), jsString(value))
+	var status string
+	if err := p.Eval(ctx, expr, &status); err != nil {
+		return err
+	}
+	switch status {
+	case "ok":
+		return nil
+	case "no-select":
+		return fmt.Errorf("select: %q is not a <select> element", selector)
+	case "no-option":
+		return fmt.Errorf("select: no option matching %q in %s", value, selector)
+	default:
+		return fmt.Errorf("select: unexpected status %q", status)
+	}
+}
+
 // TypeText focuses the element matched by selector and types text into it.
 func (p *Page) TypeText(ctx context.Context, selector, text string) error {
 	focus := fmt.Sprintf(`(() => { const el = document.querySelector(%s); if (!el) return false; el.focus(); return true; })()`, jsString(selector))

--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -169,6 +169,49 @@ func (p *Page) Screenshot(ctx context.Context) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(r.Data)
 }
 
+// Upload sets the files on a file <input> matched by selector, without the OS
+// file-picker dialog (CDP DOM.setFileInputFiles). Paths should be absolute.
+func (p *Page) Upload(ctx context.Context, selector string, files []string) error {
+	docRes, err := p.cli.call(ctx, p.sessionID, "DOM.getDocument", map[string]any{"depth": 0})
+	if err != nil {
+		return err
+	}
+	var doc struct {
+		Root struct {
+			NodeID int `json:"nodeId"`
+		} `json:"root"`
+	}
+	if err := json.Unmarshal(docRes, &doc); err != nil {
+		return err
+	}
+	selRes, err := p.cli.call(ctx, p.sessionID, "DOM.querySelector", map[string]any{
+		"nodeId":   doc.Root.NodeID,
+		"selector": selector,
+	})
+	if err != nil {
+		return err
+	}
+	var node struct {
+		NodeID int `json:"nodeId"`
+	}
+	if err := json.Unmarshal(selRes, &node); err != nil {
+		return err
+	}
+	if node.NodeID == 0 {
+		return fmt.Errorf("upload: selector %q matched no file input", selector)
+	}
+	_, err = p.cli.call(ctx, p.sessionID, "DOM.setFileInputFiles", map[string]any{
+		"nodeId": node.NodeID,
+		"files":  files,
+	})
+	return err
+}
+
+// Back navigates one entry back in history.
+func (p *Page) Back(ctx context.Context) error {
+	return p.Eval(ctx, "window.history.back()", nil)
+}
+
 // AXTree returns the full accessibility tree as raw CDP node JSON — the Tier-2
 // semantic layer used for target resolution and verification.
 func (p *Page) AXTree(ctx context.Context) (json.RawMessage, error) {

--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -14,22 +14,52 @@ type point struct {
 	Y float64 `json:"y"`
 }
 
+// frameDelim separates a same-origin iframe selector from the element selector
+// inside it, e.g. "iframe#app >>> #download". One level; cross-origin OOPIFs
+// are not handled (their DOM lives in another process).
+const frameDelim = " >>> "
+
+func splitFrame(selector string) (frame, elem string) {
+	if i := strings.Index(selector, frameDelim); i >= 0 {
+		return selector[:i], selector[i+len(frameDelim):]
+	}
+	return "", selector
+}
+
+// elemRefJS builds a JS expression evaluating to the target element, piercing a
+// same-origin iframe's contentDocument when a frame selector is given.
+func elemRefJS(frame, elem string) string {
+	if frame == "" {
+		return fmt.Sprintf("document.querySelector(%s)", jsString(elem))
+	}
+	return fmt.Sprintf("(()=>{const f=document.querySelector(%s);return f&&f.contentDocument?f.contentDocument.querySelector(%s):null;})()",
+		jsString(frame), jsString(elem))
+}
+
 // elementCenter scrolls an element into view and returns its viewport-center
-// point, or an error if the selector matches nothing.
+// point (adding the iframe's offset for framed targets), or an error if the
+// selector matches nothing.
 func (p *Page) elementCenter(ctx context.Context, selector string) (point, error) {
+	frame, elem := splitFrame(selector)
+	offset := ""
+	if frame != "" {
+		offset = fmt.Sprintf(`{const f=document.querySelector(%s); if(f){const fr=f.getBoundingClientRect(); ox=fr.x; oy=fr.y;}}`, jsString(frame))
+	}
 	expr := fmt.Sprintf(`(() => {
-		const el = document.querySelector(%s);
+		const el = %s;
 		if (!el) return null;
 		el.scrollIntoView({ block: 'center', inline: 'center' });
 		const r = el.getBoundingClientRect();
-		return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
-	})()`, jsString(selector))
+		let ox = 0, oy = 0;
+		%s
+		return { x: ox + r.x + r.width / 2, y: oy + r.y + r.height / 2 };
+	})()`, elemRefJS(frame, elem), offset)
 	var pt *point
 	if err := p.Eval(ctx, expr, &pt); err != nil {
 		return point{}, err
 	}
 	if pt == nil {
-		return point{}, fmt.Errorf("click: selector %q matched nothing", selector)
+		return point{}, fmt.Errorf("selector %q matched nothing", selector)
 	}
 	return *pt, nil
 }
@@ -77,8 +107,9 @@ func (p *Page) Hover(ctx context.Context, selector string) error {
 // text, or label, then fires input+change so framework bindings react. Native
 // select popups are browser-drawn (not DOM), so this is the reliable path.
 func (p *Page) SelectOption(ctx context.Context, selector, value string) error {
+	frame, elem := splitFrame(selector)
 	expr := fmt.Sprintf(`(() => {
-		const el = document.querySelector(%s);
+		const el = %s;
 		if (!el || el.tagName !== 'SELECT') return 'no-select';
 		let idx = -1;
 		for (let i = 0; i < el.options.length; i++) {
@@ -90,7 +121,7 @@ func (p *Page) SelectOption(ctx context.Context, selector, value string) error {
 		el.dispatchEvent(new Event('input', { bubbles: true }));
 		el.dispatchEvent(new Event('change', { bubbles: true }));
 		return 'ok';
-	})()`, jsString(selector), jsString(value), jsString(value), jsString(value))
+	})()`, elemRefJS(frame, elem), jsString(value), jsString(value), jsString(value))
 	var status string
 	if err := p.Eval(ctx, expr, &status); err != nil {
 		return err
@@ -109,7 +140,8 @@ func (p *Page) SelectOption(ctx context.Context, selector, value string) error {
 
 // TypeText focuses the element matched by selector and types text into it.
 func (p *Page) TypeText(ctx context.Context, selector, text string) error {
-	focus := fmt.Sprintf(`(() => { const el = document.querySelector(%s); if (!el) return false; el.focus(); return true; })()`, jsString(selector))
+	frame, elem := splitFrame(selector)
+	focus := fmt.Sprintf(`(() => { const el = %s; if (!el) return false; el.focus(); return true; })()`, elemRefJS(frame, elem))
 	var ok bool
 	if err := p.Eval(ctx, focus, &ok); err != nil {
 		return err
@@ -221,38 +253,31 @@ func (p *Page) Screenshot(ctx context.Context) ([]byte, error) {
 
 // Upload sets the files on a file <input> matched by selector, without the OS
 // file-picker dialog (CDP DOM.setFileInputFiles). Paths should be absolute.
+// Resolving the input by JS object (rather than a DOM nodeId) lets it pierce a
+// same-origin iframe via the same frame convention as the other actions.
 func (p *Page) Upload(ctx context.Context, selector string, files []string) error {
-	docRes, err := p.cli.call(ctx, p.sessionID, "DOM.getDocument", map[string]any{"depth": 0})
-	if err != nil {
-		return err
-	}
-	var doc struct {
-		Root struct {
-			NodeID int `json:"nodeId"`
-		} `json:"root"`
-	}
-	if err := json.Unmarshal(docRes, &doc); err != nil {
-		return err
-	}
-	selRes, err := p.cli.call(ctx, p.sessionID, "DOM.querySelector", map[string]any{
-		"nodeId":   doc.Root.NodeID,
-		"selector": selector,
+	frame, elem := splitFrame(selector)
+	res, err := p.cli.call(ctx, p.sessionID, "Runtime.evaluate", map[string]any{
+		"expression":    elemRefJS(frame, elem),
+		"returnByValue": false,
 	})
 	if err != nil {
 		return err
 	}
-	var node struct {
-		NodeID int `json:"nodeId"`
+	var r struct {
+		Result struct {
+			ObjectID string `json:"objectId"`
+		} `json:"result"`
 	}
-	if err := json.Unmarshal(selRes, &node); err != nil {
+	if err := json.Unmarshal(res, &r); err != nil {
 		return err
 	}
-	if node.NodeID == 0 {
+	if r.Result.ObjectID == "" {
 		return fmt.Errorf("upload: selector %q matched no file input", selector)
 	}
 	_, err = p.cli.call(ctx, p.sessionID, "DOM.setFileInputFiles", map[string]any{
-		"nodeId": node.NodeID,
-		"files":  files,
+		"objectId": r.Result.ObjectID,
+		"files":    files,
 	})
 	return err
 }

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -126,6 +126,15 @@ func (b *Browser) AttachPage(ctx context.Context, targetID string) (*Page, error
 	return p, nil
 }
 
+// ClosePage closes a page target by id.
+func (b *Browser) ClosePage(ctx context.Context, targetID string) error {
+	_, err := b.cli.call(ctx, "", "Target.closeTarget", map[string]any{"targetId": targetID})
+	return err
+}
+
+// TargetID returns the page's target id (for close/switch).
+func (p *Page) TargetID() string { return p.targetID }
+
 // TargetInfo describes an open browser target (tab).
 type TargetInfo struct {
 	TargetID string `json:"targetId"`

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -217,7 +217,8 @@ func (p *Page) Eval(ctx context.Context, expr string, out any) error {
 // is the verify primitive for "the download button appeared after search".
 func (p *Page) WaitFor(ctx context.Context, selector string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	expr := fmt.Sprintf("!!document.querySelector(%s)", jsString(selector))
+	frame, elem := splitFrame(selector)
+	expr := "!!(" + elemRefJS(frame, elem) + ")"
 	for {
 		var present bool
 		if err := p.Eval(ctx, expr, &present); err != nil {

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -43,6 +43,18 @@ func Connect(ctx context.Context, wsURL string) (*Browser, error) {
 	return &Browser{cli: cli, ownsProcess: false}, nil
 }
 
+// ConnectByPort attaches to a Chrome already running with
+// --remote-debugging-port=<port>, resolving the browser-level CDP endpoint from
+// the debug HTTP server. This is how a user's existing, logged-in Chrome is
+// reused.
+func ConnectByPort(ctx context.Context, port int) (*Browser, error) {
+	wsURL, err := browserWebSocketURL(ctx, port)
+	if err != nil {
+		return nil, err
+	}
+	return Connect(ctx, wsURL)
+}
+
 func dial(ctx context.Context, wsURL string) (*cdpClient, error) {
 	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsURL, nil)
 	if err != nil {
@@ -86,8 +98,14 @@ func (b *Browser) NewPage(ctx context.Context, url string) (*Page, error) {
 	if err := json.Unmarshal(res, &created); err != nil {
 		return nil, err
 	}
-	res, err = b.cli.call(ctx, "", "Target.attachToTarget", map[string]any{
-		"targetId": created.TargetID,
+	return b.AttachPage(ctx, created.TargetID)
+}
+
+// AttachPage attaches to an existing page target by id (e.g. the user's already-
+// open, logged-in tab discovered via Pages).
+func (b *Browser) AttachPage(ctx context.Context, targetID string) (*Page, error) {
+	res, err := b.cli.call(ctx, "", "Target.attachToTarget", map[string]any{
+		"targetId": targetID,
 		"flatten":  true,
 	})
 	if err != nil {
@@ -99,13 +117,43 @@ func (b *Browser) NewPage(ctx context.Context, url string) (*Page, error) {
 	if err := json.Unmarshal(res, &attached); err != nil {
 		return nil, err
 	}
-	p := &Page{cli: b.cli, sessionID: attached.SessionID, targetID: created.TargetID}
+	p := &Page{cli: b.cli, sessionID: attached.SessionID, targetID: targetID}
 	for _, domain := range []string{"Page.enable", "Runtime.enable", "DOM.enable"} {
 		if _, err := p.cli.call(ctx, p.sessionID, domain, nil); err != nil {
 			return nil, fmt.Errorf("%s: %w", domain, err)
 		}
 	}
 	return p, nil
+}
+
+// TargetInfo describes an open browser target (tab).
+type TargetInfo struct {
+	TargetID string `json:"targetId"`
+	Type     string `json:"type"`
+	Title    string `json:"title"`
+	URL      string `json:"url"`
+}
+
+// Pages lists the open page targets — used to attach to an existing logged-in
+// tab rather than opening a fresh one.
+func (b *Browser) Pages(ctx context.Context) ([]TargetInfo, error) {
+	res, err := b.cli.call(ctx, "", "Target.getTargets", nil)
+	if err != nil {
+		return nil, err
+	}
+	var r struct {
+		TargetInfos []TargetInfo `json:"targetInfos"`
+	}
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, err
+	}
+	pages := r.TargetInfos[:0]
+	for _, ti := range r.TargetInfos {
+		if ti.Type == "page" {
+			pages = append(pages, ti)
+		}
+	}
+	return pages, nil
 }
 
 // Navigate loads url and waits for the page load event.

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -272,6 +272,46 @@ func TestSelectOption(t *testing.T) {
 	}
 }
 
+// TestSameOriginFrame drives an element inside a same-origin iframe via the
+// " >>> " piercing convention (wait, then a trusted click that lands through
+// the computed frame offset). Same-origin as in Klook's admin system.
+func TestSameOriginFrame(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/child" {
+			w.Write([]byte(`<!doctype html><title>child</title>
+<button id="b" style="position:absolute;left:30px;top:30px;width:120px;height:40px">Go</button>
+<script>document.getElementById('b').addEventListener('click',function(){document.body.setAttribute('data-clicked','1')});</script>`))
+			return
+		}
+		w.Write([]byte(`<!doctype html><title>parent</title>
+<iframe id="fr" src="/child" style="position:absolute;left:50px;top:60px;width:400px;height:300px;border:0"></iframe>`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	// Frame-aware wait: the button lives inside the same-origin child frame.
+	if err := page.WaitFor(ctx, "#fr >>> #b", 5*time.Second); err != nil {
+		t.Fatalf("wait in frame: %v", err)
+	}
+	if err := page.Click(ctx, "#fr >>> #b"); err != nil {
+		t.Fatalf("click in frame: %v", err)
+	}
+	var clicked string
+	if err := page.Eval(ctx, "document.querySelector('#fr').contentDocument.body.getAttribute('data-clicked')", &clicked); err != nil {
+		t.Fatalf("eval pierce: %v", err)
+	}
+	if clicked != "1" {
+		t.Fatalf("frame click did not register (data-clicked=%q)", clicked)
+	}
+}
+
 // TestPrimitives covers eval / screenshot / ax-tree / key on the fixture.
 func TestPrimitives(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -199,6 +199,79 @@ func TestUpload(t *testing.T) {
 	}
 }
 
+// TestHover verifies a trusted pointer move fires real hover DOM events (which
+// synthetic JS events / CSS :hover can't be driven by otherwise).
+func TestHover(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<!doctype html><title>h</title>
+<div id="t" style="width:100px;height:40px">target</div>
+<script>window.hovered=false;
+document.getElementById('t').addEventListener('mouseover',function(){window.hovered=true});</script>`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#t", 5*time.Second); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if err := page.Hover(ctx, "#t"); err != nil {
+		t.Fatalf("hover: %v", err)
+	}
+	var hovered bool
+	if err := page.Eval(ctx, "window.hovered", &hovered); err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if !hovered {
+		t.Fatal("hover did not fire mouseover")
+	}
+}
+
+// TestSelectOption picks a native <select> option and verifies the value + that
+// change fired.
+func TestSelectOption(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<!doctype html><title>s</title>
+<select id="s"><option value="a">Apple</option><option value="b">Banana</option></select>
+<script>window.changed='';document.getElementById('s').addEventListener('change',function(e){window.changed=e.target.value});</script>`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#s", 5*time.Second); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if err := page.SelectOption(ctx, "#s", "Banana"); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	var value, changed string
+	if err := page.Eval(ctx, "document.querySelector('#s').value", &value); err != nil {
+		t.Fatalf("eval value: %v", err)
+	}
+	if err := page.Eval(ctx, "window.changed", &changed); err != nil {
+		t.Fatalf("eval changed: %v", err)
+	}
+	if value != "b" {
+		t.Fatalf("select value = %q, want b", value)
+	}
+	if changed != "b" {
+		t.Fatalf("change event value = %q, want b", changed)
+	}
+}
+
 // TestPrimitives covers eval / screenshot / ax-tree / key on the fixture.
 func TestPrimitives(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -162,6 +162,43 @@ func TestAttachExistingPage(t *testing.T) {
 	}
 }
 
+// TestUpload sets a file on a file input via DOM.setFileInputFiles (no OS
+// dialog) and verifies the page sees it — the upload primitive.
+func TestUpload(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<!doctype html><title>up</title><input type="file" id="f">`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#f", 5*time.Second); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	dir := t.TempDir()
+	xlsx := dir + "/report.xlsx"
+	if err := os.WriteFile(xlsx, []byte("data"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := page.Upload(ctx, "#f", []string{xlsx}); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	var name string
+	if err := page.Eval(ctx, "document.querySelector('#f').files[0].name", &name); err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if name != "report.xlsx" {
+		t.Fatalf("uploaded file name = %q, want report.xlsx", name)
+	}
+}
+
 // TestPrimitives covers eval / screenshot / ax-tree / key on the fixture.
 func TestPrimitives(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -113,6 +113,55 @@ func TestSearchThenDownload(t *testing.T) {
 	}
 }
 
+// TestAttachExistingPage covers the real-use path: discover an already-open tab
+// and attach to it (rather than opening a fresh one), as when reusing the user's
+// logged-in session.
+func TestAttachExistingPage(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(fixtureHTML))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+
+	opened, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := opened.WaitFor(ctx, "#search", 5*time.Second); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	pages, err := b.Pages(ctx)
+	if err != nil {
+		t.Fatalf("pages: %v", err)
+	}
+	var targetID string
+	for _, p := range pages {
+		if strings.HasPrefix(p.URL, srv.URL) {
+			targetID = p.TargetID
+		}
+	}
+	if targetID == "" {
+		t.Fatalf("fixture tab not found among %d pages", len(pages))
+	}
+
+	page, err := b.AttachPage(ctx, targetID)
+	if err != nil {
+		t.Fatalf("attach existing: %v", err)
+	}
+	var title string
+	if err := page.Eval(ctx, "document.title", &title); err != nil {
+		t.Fatalf("eval on attached page: %v", err)
+	}
+	if title != "fixture" {
+		t.Fatalf("attached page title = %q, want fixture", title)
+	}
+}
+
 // TestPrimitives covers eval / screenshot / ax-tree / key on the fixture.
 func TestPrimitives(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/internal/browser/chrome.go
+++ b/internal/browser/chrome.go
@@ -63,6 +63,13 @@ func chromePaths() []string {
 	}
 }
 
+// ChromeAvailable reports whether a Chrome executable can be located, so the
+// browser tool is only advertised on setups where it could work.
+func ChromeAvailable(execPath string) bool {
+	_, err := findChrome(execPath)
+	return err == nil
+}
+
 // findChrome resolves the Chrome executable, honoring an explicit override.
 func findChrome(override string) (string, error) {
 	if override != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,6 +87,26 @@ type Config struct {
 	// thinking trace is surfaced. Individual model entries can override this.
 	// nil means the built-in default (enabled).
 	ShowReasoning *bool `yaml:"show_reasoning,omitempty"`
+	// Browser configures the built-in browser automation backend.
+	Browser BrowserConfig `yaml:"browser,omitempty"`
+}
+
+// BrowserConfig configures how the browser tool connects to Chrome.
+type BrowserConfig struct {
+	// ConnectPort attaches to a Chrome already running with
+	// --remote-debugging-port=<port>, reusing its logged-in session. Preferred
+	// over launching a fresh instance.
+	ConnectPort int `yaml:"connect_port,omitempty"`
+	// UserDataDir is the Chrome profile dir used when launching (the fallback
+	// when no running Chrome is attached). Empty uses a throwaway profile.
+	UserDataDir string `yaml:"user_data_dir,omitempty"`
+	// ExecPath overrides Chrome executable auto-detection.
+	ExecPath string `yaml:"exec_path,omitempty"`
+	// Headless launches Chrome headless. Interactive workflows want this off so
+	// the user can watch and intervene.
+	Headless bool `yaml:"headless,omitempty"`
+	// DownloadDir is where captured downloads are written. Empty uses a temp dir.
+	DownloadDir string `yaml:"download_dir,omitempty"`
 }
 
 // EffectiveShowReasoning resolves the effective show-reasoning flag for a

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -116,6 +116,7 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 				},
 				"url":        map[string]any{"type": "string", "description": "Target URL (navigate)."},
 				"selector":   map[string]any{"type": "string", "description": "CSS selector of the target element (click/hover/type/select/scroll/wait/upload/download)."},
+				"frame":      map[string]any{"type": "string", "description": "Optional CSS selector of a same-origin iframe to scope the selector into (e.g. iframe#app)."},
 				"text":       map[string]any{"type": "string", "description": "Text to type (type)."},
 				"value":      map[string]any{"type": "string", "description": "Option value, text, or label to pick in a <select> (select)."},
 				"keys":       map[string]any{"type": "string", "description": "Key or combo, e.g. enter, escape, ctrl+a (key)."},
@@ -159,7 +160,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		return agent.ToolResult{Text: "navigated back"}, nil
 
 	case "click":
-		sel := getStr(input, "selector")
+		sel := targetSelector(input)
 		if sel == "" {
 			return agent.ToolResult{}, fmt.Errorf("browser: click requires selector")
 		}
@@ -169,7 +170,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		return agent.ToolResult{Text: "clicked " + sel}, nil
 
 	case "hover":
-		sel := getStr(input, "selector")
+		sel := targetSelector(input)
 		if sel == "" {
 			return agent.ToolResult{}, fmt.Errorf("browser: hover requires selector")
 		}
@@ -179,7 +180,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		return agent.ToolResult{Text: "hovered " + sel}, nil
 
 	case "select":
-		sel, val := getStr(input, "selector"), getStr(input, "value")
+		sel, val := targetSelector(input), getStr(input, "value")
 		if sel == "" {
 			return agent.ToolResult{}, fmt.Errorf("browser: select requires selector")
 		}
@@ -189,7 +190,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		return agent.ToolResult{Text: fmt.Sprintf("selected %q in %s", val, sel)}, nil
 
 	case "type":
-		sel, text := getStr(input, "selector"), getStr(input, "text")
+		sel, text := targetSelector(input), getStr(input, "text")
 		if sel == "" {
 			return agent.ToolResult{}, fmt.Errorf("browser: type requires selector")
 		}
@@ -209,7 +210,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		return agent.ToolResult{Text: "pressed " + combo}, nil
 
 	case "scroll":
-		sel := getStr(input, "selector")
+		sel := targetSelector(input)
 		dx, _ := input["dx"].(float64)
 		dy, _ := input["dy"].(float64)
 		if err := page.Scroll(ctx, sel, dx, dy); err != nil {
@@ -218,7 +219,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		return agent.ToolResult{Text: "scrolled"}, nil
 
 	case "wait":
-		sel := getStr(input, "selector")
+		sel := targetSelector(input)
 		if sel == "" {
 			return agent.ToolResult{}, fmt.Errorf("browser: wait requires selector")
 		}
@@ -251,7 +252,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		return agent.ToolResult{Text: axDigest(raw)}, nil
 
 	case "upload":
-		sel := getStr(input, "selector")
+		sel := targetSelector(input)
 		if sel == "" {
 			return agent.ToolResult{}, fmt.Errorf("browser: upload requires selector (the file input)")
 		}
@@ -265,7 +266,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		return agent.ToolResult{Text: fmt.Sprintf("set %d file(s) on %s", len(files), sel)}, nil
 
 	case "download":
-		sel := getStr(input, "selector")
+		sel := targetSelector(input)
 		if sel == "" {
 			return agent.ToolResult{}, fmt.Errorf("browser: download requires selector (the element that starts the download)")
 		}
@@ -331,6 +332,16 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 func getStr(input map[string]any, key string) string {
 	s, _ := input[key].(string)
 	return s
+}
+
+// targetSelector returns the element selector, scoped into a same-origin iframe
+// when a frame is given (via the backend's " >>> " piercing convention).
+func targetSelector(input map[string]any) string {
+	sel := getStr(input, "selector")
+	if frame := getStr(input, "frame"); frame != "" && sel != "" {
+		return frame + " >>> " + sel
+	}
+	return sel
 }
 
 func getStrings(input map[string]any, key string) []string {

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -111,12 +111,13 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 			"properties": map[string]any{
 				"action": map[string]any{
 					"type":        "string",
-					"enum":        []string{"navigate", "back", "click", "type", "key", "scroll", "wait", "screenshot", "ax", "upload", "download", "pages", "select_page", "close", "eval"},
+					"enum":        []string{"navigate", "back", "click", "hover", "type", "select", "key", "scroll", "wait", "screenshot", "ax", "upload", "download", "pages", "select_page", "close", "eval"},
 					"description": "The browser action to perform.",
 				},
 				"url":        map[string]any{"type": "string", "description": "Target URL (navigate)."},
-				"selector":   map[string]any{"type": "string", "description": "CSS selector of the target element (click/type/scroll/wait/upload/download)."},
+				"selector":   map[string]any{"type": "string", "description": "CSS selector of the target element (click/hover/type/select/scroll/wait/upload/download)."},
 				"text":       map[string]any{"type": "string", "description": "Text to type (type)."},
+				"value":      map[string]any{"type": "string", "description": "Option value, text, or label to pick in a <select> (select)."},
 				"keys":       map[string]any{"type": "string", "description": "Key or combo, e.g. enter, escape, ctrl+a (key)."},
 				"js":         map[string]any{"type": "string", "description": "JavaScript expression to evaluate (eval)."},
 				"files":      map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Absolute file paths to set on a file <input> (upload)."},
@@ -166,6 +167,26 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 			return agent.ToolResult{}, err
 		}
 		return agent.ToolResult{Text: "clicked " + sel}, nil
+
+	case "hover":
+		sel := getStr(input, "selector")
+		if sel == "" {
+			return agent.ToolResult{}, fmt.Errorf("browser: hover requires selector")
+		}
+		if err := page.Hover(ctx, sel); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: "hovered " + sel}, nil
+
+	case "select":
+		sel, val := getStr(input, "selector"), getStr(input, "value")
+		if sel == "" {
+			return agent.ToolResult{}, fmt.Errorf("browser: select requires selector")
+		}
+		if err := page.SelectOption(ctx, sel, val); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: fmt.Sprintf("selected %q in %s", val, sel)}, nil
 
 	case "type":
 		sel, text := getStr(input, "selector"), getStr(input, "text")

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -1,0 +1,313 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/browser"
+	"github.com/Leihb/octo-agent/internal/config"
+)
+
+// browserSession holds the per-session Chrome connection, reused across tool
+// calls so navigate→click→download share one page. Package-global to match the
+// codebase's session-resource pattern (task store, sub-agent manager); reset by
+// app.WireTools cleanup at session end.
+var browserSession struct {
+	mu   sync.Mutex
+	b    *browser.Browser
+	page *browser.Page
+}
+
+// SetBrowserSession injects a pre-connected session (tests).
+func SetBrowserSession(b *browser.Browser, p *browser.Page) {
+	browserSession.mu.Lock()
+	defer browserSession.mu.Unlock()
+	browserSession.b, browserSession.page = b, p
+}
+
+// ResetBrowserSession closes and clears the active browser session.
+func ResetBrowserSession() {
+	browserSession.mu.Lock()
+	b := browserSession.b
+	browserSession.b, browserSession.page = nil, nil
+	browserSession.mu.Unlock()
+	if b != nil {
+		b.Close()
+	}
+}
+
+// browserEnabled gates the tool: advertised only when a Chrome can be located
+// or an explicit debug port is configured.
+func browserEnabled() bool {
+	cfg, _ := config.Load()
+	return cfg.Browser.ConnectPort != 0 || browser.ChromeAvailable(cfg.Browser.ExecPath)
+}
+
+// browserPage returns the active page, connecting (or launching) Chrome on first
+// use according to config.
+func browserPage(ctx context.Context) (*browser.Page, *browser.Browser, error) {
+	browserSession.mu.Lock()
+	defer browserSession.mu.Unlock()
+	if browserSession.page != nil {
+		return browserSession.page, browserSession.b, nil
+	}
+	cfg, _ := config.Load()
+	bc := cfg.Browser
+
+	var b *browser.Browser
+	var err error
+	if bc.ConnectPort != 0 {
+		b, err = browser.ConnectByPort(ctx, bc.ConnectPort)
+		if err != nil {
+			return nil, nil, fmt.Errorf("connect to Chrome on port %d: %w", bc.ConnectPort, err)
+		}
+	} else {
+		b, err = browser.Launch(ctx, browser.LaunchOptions{
+			ExecPath:    bc.ExecPath,
+			UserDataDir: bc.UserDataDir,
+			Headless:    bc.Headless,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("launch Chrome: %w", err)
+		}
+	}
+
+	// Prefer an already-open tab (the user's logged-in page) when attaching;
+	// otherwise open a blank one.
+	var page *browser.Page
+	if pages, perr := b.Pages(ctx); perr == nil && len(pages) > 0 {
+		page, err = b.AttachPage(ctx, pages[0].TargetID)
+	} else {
+		page, err = b.NewPage(ctx, "about:blank")
+	}
+	if err != nil {
+		b.Close()
+		return nil, nil, fmt.Errorf("attach page: %w", err)
+	}
+	browserSession.b, browserSession.page = b, page
+	return page, b, nil
+}
+
+// BrowserTool drives a real Chrome over CDP: navigate, click, type, wait,
+// capture downloads, etc. One tool, action-multiplexed, like computer-use.
+type BrowserTool struct{}
+
+func (BrowserTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "browser",
+		Description: "Drive a real Chrome browser to automate a web task: navigate, " +
+			"click elements, type, wait for elements, capture file downloads, screenshot, " +
+			"and inspect the page. Reuses the user's logged-in session. Use only when the " +
+			"task genuinely needs operating a web UI (no API available).",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"action": map[string]any{
+					"type":        "string",
+					"enum":        []string{"navigate", "click", "type", "key", "scroll", "wait", "screenshot", "ax", "download", "pages", "eval"},
+					"description": "The browser action to perform.",
+				},
+				"url":        map[string]any{"type": "string", "description": "Target URL (navigate)."},
+				"selector":   map[string]any{"type": "string", "description": "CSS selector of the target element (click/type/scroll/wait/download)."},
+				"text":       map[string]any{"type": "string", "description": "Text to type (type)."},
+				"keys":       map[string]any{"type": "string", "description": "Key or combo, e.g. enter, escape, ctrl+a (key)."},
+				"js":         map[string]any{"type": "string", "description": "JavaScript expression to evaluate (eval)."},
+				"timeout_ms": map[string]any{"type": "integer", "description": "Wait timeout in ms (wait); default 10000."},
+				"dx":         map[string]any{"type": "number", "description": "Horizontal scroll delta (scroll)."},
+				"dy":         map[string]any{"type": "number", "description": "Vertical scroll delta (scroll)."},
+			},
+			"required": []string{"action"},
+		},
+	}
+}
+
+func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	action, _ := input["action"].(string)
+	if action == "" {
+		return agent.ToolResult{}, fmt.Errorf("browser: action is required")
+	}
+	page, b, err := browserPage(ctx)
+	if err != nil {
+		return agent.ToolResult{}, fmt.Errorf("browser: %w", err)
+	}
+
+	switch action {
+	case "navigate":
+		url := getStr(input, "url")
+		if url == "" {
+			return agent.ToolResult{}, fmt.Errorf("browser: navigate requires url")
+		}
+		if err := page.Navigate(ctx, url); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: "navigated to " + url}, nil
+
+	case "click":
+		sel := getStr(input, "selector")
+		if sel == "" {
+			return agent.ToolResult{}, fmt.Errorf("browser: click requires selector")
+		}
+		if err := page.Click(ctx, sel); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: "clicked " + sel}, nil
+
+	case "type":
+		sel, text := getStr(input, "selector"), getStr(input, "text")
+		if sel == "" {
+			return agent.ToolResult{}, fmt.Errorf("browser: type requires selector")
+		}
+		if err := page.TypeText(ctx, sel, text); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: fmt.Sprintf("typed %q into %s", text, sel)}, nil
+
+	case "key":
+		combo := getStr(input, "keys")
+		if combo == "" {
+			return agent.ToolResult{}, fmt.Errorf("browser: key requires keys")
+		}
+		if err := page.Key(ctx, combo); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: "pressed " + combo}, nil
+
+	case "scroll":
+		sel := getStr(input, "selector")
+		dx, _ := input["dx"].(float64)
+		dy, _ := input["dy"].(float64)
+		if err := page.Scroll(ctx, sel, dx, dy); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: "scrolled"}, nil
+
+	case "wait":
+		sel := getStr(input, "selector")
+		if sel == "" {
+			return agent.ToolResult{}, fmt.Errorf("browser: wait requires selector")
+		}
+		timeout := 10 * time.Second
+		if ms, ok := input["timeout_ms"].(float64); ok && ms > 0 {
+			timeout = time.Duration(ms) * time.Millisecond
+		}
+		if err := page.WaitFor(ctx, sel, timeout); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: sel + " appeared"}, nil
+
+	case "screenshot":
+		shot, err := page.Screenshot(ctx)
+		if err != nil {
+			return agent.ToolResult{}, err
+		}
+		dir := downloadDir()
+		path := filepath.Join(dir, fmt.Sprintf("screenshot-%d.png", len(shot)))
+		if err := os.WriteFile(path, shot, 0o644); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: "screenshot saved to " + path}, nil
+
+	case "ax":
+		raw, err := page.AXTree(ctx)
+		if err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: axDigest(raw)}, nil
+
+	case "download":
+		sel := getStr(input, "selector")
+		if sel == "" {
+			return agent.ToolResult{}, fmt.Errorf("browser: download requires selector (the element that starts the download)")
+		}
+		path, err := b.CaptureDownload(ctx, downloadDir(), func() error { return page.Click(ctx, sel) })
+		if err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: "downloaded to " + path}, nil
+
+	case "pages":
+		pages, err := b.Pages(ctx)
+		if err != nil {
+			return agent.ToolResult{}, err
+		}
+		var sb strings.Builder
+		for _, p := range pages {
+			fmt.Fprintf(&sb, "- %s — %s\n", p.Title, p.URL)
+		}
+		return agent.ToolResult{Text: sb.String()}, nil
+
+	case "eval":
+		js := getStr(input, "js")
+		if js == "" {
+			return agent.ToolResult{}, fmt.Errorf("browser: eval requires js")
+		}
+		var raw json.RawMessage
+		if err := page.Eval(ctx, js, &raw); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: string(raw)}, nil
+
+	default:
+		return agent.ToolResult{}, fmt.Errorf("browser: unknown action %q", action)
+	}
+}
+
+func getStr(input map[string]any, key string) string {
+	s, _ := input[key].(string)
+	return s
+}
+
+// downloadDir resolves the configured download directory, falling back to a
+// temp dir under the OS temp root.
+func downloadDir() string {
+	cfg, _ := config.Load()
+	if cfg.Browser.DownloadDir != "" {
+		return cfg.Browser.DownloadDir
+	}
+	return filepath.Join(os.TempDir(), "octo-browser-downloads")
+}
+
+// axNode is the subset of a CDP accessibility node the digest needs.
+type axNode struct {
+	Role struct {
+		Value string `json:"value"`
+	} `json:"role"`
+	Name struct {
+		Value string `json:"value"`
+	} `json:"name"`
+	Ignored bool `json:"ignored"`
+}
+
+// axDigest reduces a full AX tree to a bounded list of named, non-ignored
+// elements — the selection-friendly semantic view, not the raw firehose.
+func axDigest(raw json.RawMessage) string {
+	var tree struct {
+		Nodes []axNode `json:"nodes"`
+	}
+	if err := json.Unmarshal(raw, &tree); err != nil {
+		return "(ax tree unavailable)"
+	}
+	var sb strings.Builder
+	count := 0
+	for _, n := range tree.Nodes {
+		if n.Ignored || n.Name.Value == "" {
+			continue
+		}
+		fmt.Fprintf(&sb, "%s: %s\n", n.Role.Value, n.Name.Value)
+		if count++; count >= 100 {
+			fmt.Fprintf(&sb, "… (%d more nodes)\n", len(tree.Nodes)-count)
+			break
+		}
+	}
+	if count == 0 {
+		return "(no named elements)"
+	}
+	return sb.String()
+}

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -111,14 +111,16 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 			"properties": map[string]any{
 				"action": map[string]any{
 					"type":        "string",
-					"enum":        []string{"navigate", "click", "type", "key", "scroll", "wait", "screenshot", "ax", "download", "pages", "eval"},
+					"enum":        []string{"navigate", "back", "click", "type", "key", "scroll", "wait", "screenshot", "ax", "upload", "download", "pages", "select_page", "close", "eval"},
 					"description": "The browser action to perform.",
 				},
 				"url":        map[string]any{"type": "string", "description": "Target URL (navigate)."},
-				"selector":   map[string]any{"type": "string", "description": "CSS selector of the target element (click/type/scroll/wait/download)."},
+				"selector":   map[string]any{"type": "string", "description": "CSS selector of the target element (click/type/scroll/wait/upload/download)."},
 				"text":       map[string]any{"type": "string", "description": "Text to type (type)."},
 				"keys":       map[string]any{"type": "string", "description": "Key or combo, e.g. enter, escape, ctrl+a (key)."},
 				"js":         map[string]any{"type": "string", "description": "JavaScript expression to evaluate (eval)."},
+				"files":      map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Absolute file paths to set on a file <input> (upload)."},
+				"index":      map[string]any{"type": "integer", "description": "Page index from the pages list to switch to (select_page)."},
 				"timeout_ms": map[string]any{"type": "integer", "description": "Wait timeout in ms (wait); default 10000."},
 				"dx":         map[string]any{"type": "number", "description": "Horizontal scroll delta (scroll)."},
 				"dy":         map[string]any{"type": "number", "description": "Vertical scroll delta (scroll)."},
@@ -148,6 +150,12 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 			return agent.ToolResult{}, err
 		}
 		return agent.ToolResult{Text: "navigated to " + url}, nil
+
+	case "back":
+		if err := page.Back(ctx); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: "navigated back"}, nil
 
 	case "click":
 		sel := getStr(input, "selector")
@@ -221,6 +229,20 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		}
 		return agent.ToolResult{Text: axDigest(raw)}, nil
 
+	case "upload":
+		sel := getStr(input, "selector")
+		if sel == "" {
+			return agent.ToolResult{}, fmt.Errorf("browser: upload requires selector (the file input)")
+		}
+		files := getStrings(input, "files")
+		if len(files) == 0 {
+			return agent.ToolResult{}, fmt.Errorf("browser: upload requires files")
+		}
+		if err := page.Upload(ctx, sel, files); err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: fmt.Sprintf("set %d file(s) on %s", len(files), sel)}, nil
+
 	case "download":
 		sel := getStr(input, "selector")
 		if sel == "" {
@@ -238,10 +260,36 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 			return agent.ToolResult{}, err
 		}
 		var sb strings.Builder
-		for _, p := range pages {
-			fmt.Fprintf(&sb, "- %s — %s\n", p.Title, p.URL)
+		for i, p := range pages {
+			fmt.Fprintf(&sb, "%d. %s — %s\n", i, p.Title, p.URL)
 		}
 		return agent.ToolResult{Text: sb.String()}, nil
+
+	case "select_page":
+		idx := 0
+		if v, ok := input["index"].(float64); ok {
+			idx = int(v)
+		}
+		pages, err := b.Pages(ctx)
+		if err != nil {
+			return agent.ToolResult{}, err
+		}
+		if idx < 0 || idx >= len(pages) {
+			return agent.ToolResult{}, fmt.Errorf("browser: page index %d out of range (%d pages)", idx, len(pages))
+		}
+		np, err := b.AttachPage(ctx, pages[idx].TargetID)
+		if err != nil {
+			return agent.ToolResult{}, err
+		}
+		setBrowserPage(np)
+		return agent.ToolResult{Text: "switched to page " + pages[idx].URL}, nil
+
+	case "close":
+		if err := b.ClosePage(ctx, page.TargetID()); err != nil {
+			return agent.ToolResult{}, err
+		}
+		setBrowserPage(nil)
+		return agent.ToolResult{Text: "closed page"}, nil
 
 	case "eval":
 		js := getStr(input, "js")
@@ -262,6 +310,27 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 func getStr(input map[string]any, key string) string {
 	s, _ := input[key].(string)
 	return s
+}
+
+func getStrings(input map[string]any, key string) []string {
+	raw, ok := input[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// setBrowserPage swaps the active page, keeping the same browser connection.
+func setBrowserPage(p *browser.Page) {
+	browserSession.mu.Lock()
+	browserSession.page = p
+	browserSession.mu.Unlock()
 }
 
 // downloadDir resolves the configured download directory, falling back to a

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -1,0 +1,108 @@
+package tools
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/browser"
+)
+
+// toolFixtureHTML mirrors the awkward target system: the download button only
+// appears after a search, and the file is produced client-side via a Blob.
+const toolFixtureHTML = `<!doctype html><html><head><meta charset="utf-8"><title>fixture</title></head>
+<body>
+<input id="q" />
+<button id="search">Search</button>
+<div id="results"></div>
+<script>
+document.getElementById('search').addEventListener('click', function () {
+  setTimeout(function () {
+    var btn = document.createElement('button');
+    btn.id = 'download';
+    btn.textContent = 'Download Excel';
+    btn.addEventListener('click', function () {
+      var blob = new Blob([new Uint8Array([1,2,3,4])], { type: 'application/octet-stream' });
+      var a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'report.xlsx';
+      document.body.appendChild(a);
+      a.click();
+    });
+    document.getElementById('results').appendChild(btn);
+  }, 200);
+});
+</script>
+</body></html>`
+
+// TestBrowserTool_SearchDownloadFlow drives the wife's workflow shape through
+// the browser tool's action dispatch (navigate→type→click→wait→download).
+func TestBrowserTool_SearchDownloadFlow(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60_000_000_000) // 60s
+	defer cancel()
+	if !browser.ChromeAvailable("") {
+		t.Skip("chrome not available")
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(toolFixtureHTML))
+	}))
+	defer srv.Close()
+
+	b, err := browser.Launch(ctx, browser.LaunchOptions{Headless: true})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	SetBrowserSession(b, page)
+	defer ResetBrowserSession()
+
+	tool := BrowserTool{}
+	run := func(input map[string]any) (string, error) {
+		res, err := tool.Execute(ctx, "browser", input)
+		return res.Text, err
+	}
+
+	if _, err := run(map[string]any{"action": "navigate", "url": srv.URL}); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	if _, err := run(map[string]any{"action": "wait", "selector": "#search"}); err != nil {
+		t.Fatalf("wait search: %v", err)
+	}
+	if _, err := run(map[string]any{"action": "type", "selector": "#q", "text": "alpha"}); err != nil {
+		t.Fatalf("type: %v", err)
+	}
+	if _, err := run(map[string]any{"action": "click", "selector": "#search"}); err != nil {
+		t.Fatalf("click: %v", err)
+	}
+	if _, err := run(map[string]any{"action": "wait", "selector": "#download"}); err != nil {
+		t.Fatalf("wait download: %v", err)
+	}
+	out, err := run(map[string]any{"action": "download", "selector": "#download"})
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	path := strings.TrimPrefix(out, "downloaded to ")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat downloaded %q: %v", path, err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("downloaded file %q is empty", path)
+	}
+	os.Remove(path)
+}
+
+// TestBrowserTool_UnknownAction surfaces a clean error (no Chrome needed since
+// it should fail before connecting only if a session exists; guard with skip).
+func TestBrowserTool_RequiresAction(t *testing.T) {
+	_, err := BrowserTool{}.Execute(context.Background(), "browser", map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for missing action")
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -49,6 +49,7 @@ var allTools = []tool{
 	TaskUpdateTool{},
 	TaskListTool{},
 	RestartServerTool{},
+	BrowserTool{},
 }
 
 // DefaultRegistry is the agent.ToolExecutor used when `octo --tools` is
@@ -237,6 +238,7 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 	askerOn := askerEnabled()
 	tasksOn := tasksEnabled()
 	restarterOn := restarterEnabled()
+	browserOn := browserEnabled()
 	spawnerOn := spawnerEnabled()
 	defs := make([]agent.ToolDefinition, 0, len(allTools))
 	for _, t := range allTools {
@@ -277,6 +279,9 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 			continue
 		}
 		if _, isRestart := t.(RestartServerTool); isRestart && !restarterOn {
+			continue
+		}
+		if _, isBrowser := t.(BrowserTool); isBrowser && !browserOn {
 			continue
 		}
 		if _, isTaskCreate := t.(TaskCreateTool); isTaskCreate && !tasksOn {


### PR DESCRIPTION
浏览器 computer-use 支柱 slice 2(承接 #918 的自有 CDP backend;设计 #917)。

**让 agent 能现场驱动浏览器。**

## 内容

- **`internal/browser`**:`ConnectByPort` / `Pages` / `AttachPage`——接管用户自己启动的 debug Chrome,并接管**已打开的登录态标签页**(而非另开空白页)。
- **`internal/tools/browser.go`**:单个 action 多路复用的 `browser` 工具(navigate / click / type / key / scroll / wait / screenshot / ax / download / pages / eval),对齐 computer-use 与 octo 的 terminal 形态。会话级 Chrome 持有者(包级,仿 task store / sub-agent manager),首动作按 config 懒连接:有 `browser.connect_port` 就接管 debug Chrome(复用登录态),否则用配置 profile 启动。`download` 走 `CaptureDownload`。
- **`internal/config`**:`BrowserConfig`(connect_port / user_data_dir / exec_path / headless / download_dir)。
- **registry**:仅当能定位 Chrome 或设了端口时才 advertise `browser` 工具。
- **`app.WireTools` cleanup**:`ResetBrowserSession()` 会话结束关闭连接。权限搭现有 gate(按 name+input 审批),工具 input 带「action+目标」摘要让审批可读。

## 验收

通过 `browser` 工具的 action 分发,端到端跑通 fixture 的整套流程(navigate→type→click→**等搜索后才出现的下载按钮**→捕获**前端 Blob 现做**的下载)。`-race` 干净;Chrome 缺失自动 skip。

**真·贝壳系统**由用户手动连 debug Chrome 验收(够不到内网)。

## 范围

slice 2 到此(agent 能现场驱动)。**录制 + 过滤循环 + 技能产物 = slice 3**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)