### PR TITLE
feat(browser): attach to a running logged-in Chrome (DevToolsActivePort)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -26,7 +26,7 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Browser, error) {
 	}
 	cli, err := dial(ctx, wsURL)
 	if err != nil {
-		cmd.Process.Kill()
+		killProcessGroup(cmd)
 		return nil, err
 	}
 	return &Browser{cmd: cmd, cli: cli, ownsProcess: true}, nil
@@ -96,7 +96,7 @@ func dial(ctx context.Context, wsURL string) (*cdpClient, error) {
 func (b *Browser) Close() error {
 	b.cli.close()
 	if b.ownsProcess && b.cmd != nil && b.cmd.Process != nil {
-		b.cmd.Process.Kill()
+		killProcessGroup(b.cmd)
 		b.cmd.Wait()
 	}
 	return nil

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -55,6 +55,32 @@ func ConnectByPort(ctx context.Context, port int) (*Browser, error) {
 	return Connect(ctx, wsURL)
 }
 
+// ConnectViaProfile attaches to a Chrome already running with remote debugging
+// by reading its profile's DevToolsActivePort — reusing the user's logged-in
+// session without relaunching, and without the /json HTTP endpoint.
+func ConnectViaProfile(ctx context.Context, userDataDir string) (*Browser, error) {
+	ws, ok := devToolsWS(userDataDir)
+	if !ok {
+		return nil, fmt.Errorf("no DevToolsActivePort in %s (is Chrome running with --remote-debugging-port?)", userDataDir)
+	}
+	return Connect(ctx, ws)
+}
+
+// DiscoverRunningChrome attaches to the first default-profile Chrome found
+// running with remote debugging.
+func DiscoverRunningChrome(ctx context.Context) (*Browser, error) {
+	for _, dir := range defaultProfileDirs() {
+		ws, ok := devToolsWS(dir)
+		if !ok {
+			continue
+		}
+		if b, err := Connect(ctx, ws); err == nil {
+			return b, nil
+		}
+	}
+	return nil, fmt.Errorf("no running Chrome with remote debugging found; launch Chrome with --remote-debugging-port or set browser.connect_port")
+}
+
 func dial(ctx context.Context, wsURL string) (*cdpClient, error) {
 	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsURL, nil)
 	if err != nil {

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -312,6 +312,50 @@ func TestSameOriginFrame(t *testing.T) {
 	}
 }
 
+// TestDevToolsWS parses the DevToolsActivePort file into a ws URL (no Chrome).
+func TestDevToolsWS(t *testing.T) {
+	dir := t.TempDir()
+	if _, ok := devToolsWS(dir); ok {
+		t.Fatal("expected not-ok with no DevToolsActivePort file")
+	}
+	if err := os.WriteFile(dir+"/DevToolsActivePort", []byte("9222\n/devtools/browser/abc-123\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ws, ok := devToolsWS(dir)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if ws != "ws://127.0.0.1:9222/devtools/browser/abc-123" {
+		t.Fatalf("ws = %q", ws)
+	}
+}
+
+// TestConnectViaProfile attaches to a running Chrome by reading its profile's
+// DevToolsActivePort — the path used to reuse a logged-in browser without
+// relaunching (and without /json, which recent Chrome disables).
+func TestConnectViaProfile(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if !ChromeAvailable("") {
+		t.Skip("chrome not available")
+	}
+	profile := t.TempDir()
+	launched, err := Launch(ctx, LaunchOptions{Headless: true, UserDataDir: profile})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	defer launched.Close()
+
+	attached, err := ConnectViaProfile(ctx, profile)
+	if err != nil {
+		t.Fatalf("connect via profile: %v", err)
+	}
+	defer attached.Close()
+	if _, err := attached.Pages(ctx); err != nil {
+		t.Fatalf("pages over attached connection: %v", err)
+	}
+}
+
 // TestPrimitives covers eval / screenshot / ax-tree / key on the fixture.
 func TestPrimitives(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -339,7 +339,14 @@ func TestConnectViaProfile(t *testing.T) {
 	if !ChromeAvailable("") {
 		t.Skip("chrome not available")
 	}
-	profile := t.TempDir()
+	// Not t.TempDir(): Chrome's profile dir may still be settling when the test
+	// ends, and t.TempDir's mandatory RemoveAll would fail the test. Clean up
+	// best-effort after Chrome is killed instead.
+	profile, err := os.MkdirTemp("", "octo-test-chrome-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(profile)
 	launched, err := Launch(ctx, LaunchOptions{Headless: true, UserDataDir: profile})
 	if err != nil {
 		t.Fatalf("launch: %v", err)

--- a/internal/browser/chrome.go
+++ b/internal/browser/chrome.go
@@ -175,6 +175,7 @@ func launchChrome(ctx context.Context, opts LaunchOptions) (*exec.Cmd, string, e
 	args = append(args, opts.ExtraArgs...)
 
 	cmd := exec.Command(exe, args...)
+	setProcessGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		if tempDir != "" {
 			os.RemoveAll(tempDir)
@@ -186,13 +187,13 @@ func launchChrome(ctx context.Context, opts LaunchOptions) (*exec.Cmd, string, e
 	if port == 0 {
 		port, err = readDevToolsPort(ctx, dataDir)
 		if err != nil {
-			cmd.Process.Kill()
+			killProcessGroup(cmd)
 			return nil, "", err
 		}
 	}
 	wsURL, err := browserWebSocketURL(ctx, port)
 	if err != nil {
-		cmd.Process.Kill()
+		killProcessGroup(cmd)
 		return nil, "", err
 	}
 	return cmd, wsURL, nil

--- a/internal/browser/chrome.go
+++ b/internal/browser/chrome.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -68,6 +69,57 @@ func chromePaths() []string {
 func ChromeAvailable(execPath string) bool {
 	_, err := findChrome(execPath)
 	return err == nil
+}
+
+// defaultProfileDirs lists the default Chrome/Chromium/Edge user-data
+// directories per platform — where DevToolsActivePort is written.
+func defaultProfileDirs() []string {
+	home, _ := os.UserHomeDir()
+	switch runtime.GOOS {
+	case "darwin":
+		base := filepath.Join(home, "Library/Application Support")
+		return []string{
+			filepath.Join(base, "Google/Chrome"),
+			filepath.Join(base, "Google/Chrome Canary"),
+			filepath.Join(base, "Chromium"),
+			filepath.Join(base, "Microsoft Edge"),
+		}
+	case "windows":
+		local := os.Getenv("LOCALAPPDATA")
+		return []string{
+			filepath.Join(local, `Google\Chrome\User Data`),
+			filepath.Join(local, `Chromium\User Data`),
+			filepath.Join(local, `Microsoft\Edge\User Data`),
+		}
+	default:
+		return []string{
+			filepath.Join(home, ".config/google-chrome"),
+			filepath.Join(home, ".config/chromium"),
+			filepath.Join(home, ".config/microsoft-edge"),
+		}
+	}
+}
+
+// devToolsWS reads <userDataDir>/DevToolsActivePort (line 1 = port, line 2 = ws
+// path) and builds the browser-level CDP websocket URL. Chrome writes this when
+// started with remote debugging; using it avoids the /json HTTP discovery
+// endpoint, which recent Chrome disables — this is how a running, logged-in
+// Chrome is attached without relaunching.
+func devToolsWS(userDataDir string) (string, bool) {
+	data, err := os.ReadFile(filepath.Join(userDataDir, "DevToolsActivePort"))
+	if err != nil {
+		return "", false
+	}
+	lines := strings.SplitN(strings.TrimSpace(string(data)), "\n", 2)
+	if len(lines) < 2 {
+		return "", false
+	}
+	port := strings.TrimSpace(lines[0])
+	path := strings.TrimSpace(lines[1])
+	if port == "" || path == "" {
+		return "", false
+	}
+	return fmt.Sprintf("ws://127.0.0.1:%s%s", port, path), true
 }
 
 // findChrome resolves the Chrome executable, honoring an explicit override.

--- a/internal/browser/process_unix.go
+++ b/internal/browser/process_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package browser
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup puts the launched Chrome in its own process group so the whole
+// tree (renderers, gpu, …) can be signalled together.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessGroup kills the entire Chrome process group, not just the parent —
+// otherwise child processes are orphaned and keep holding the profile dir.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}

--- a/internal/browser/process_windows.go
+++ b/internal/browser/process_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package browser
+
+import "os/exec"
+
+// setProcessGroup is a no-op on Windows; process-tree handling differs and the
+// plain Kill below is the pragmatic fallback.
+func setProcessGroup(cmd *exec.Cmd) {}
+
+// killProcessGroup kills the launched Chrome process.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,9 +93,14 @@ type Config struct {
 
 // BrowserConfig configures how the browser tool connects to Chrome.
 type BrowserConfig struct {
+	// AttachRunning attaches to the user's already-running Chrome (discovered via
+	// its default profile's DevToolsActivePort), reusing the logged-in session
+	// without relaunching. Requires that Chrome was started with remote
+	// debugging enabled.
+	AttachRunning bool `yaml:"attach_running,omitempty"`
 	// ConnectPort attaches to a Chrome already running with
-	// --remote-debugging-port=<port>, reusing its logged-in session. Preferred
-	// over launching a fresh instance.
+	// --remote-debugging-port=<port> via the /json HTTP endpoint. Use when the
+	// port is known and that endpoint is served.
 	ConnectPort int `yaml:"connect_port,omitempty"`
 	// UserDataDir is the Chrome profile dir used when launching (the fallback
 	// when no running Chrome is attached). Empty uses a throwaway profile.

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -47,7 +47,7 @@ func ResetBrowserSession() {
 // or an explicit debug port is configured.
 func browserEnabled() bool {
 	cfg, _ := config.Load()
-	return cfg.Browser.ConnectPort != 0 || browser.ChromeAvailable(cfg.Browser.ExecPath)
+	return cfg.Browser.ConnectPort != 0 || cfg.Browser.AttachRunning || browser.ChromeAvailable(cfg.Browser.ExecPath)
 }
 
 // browserPage returns the active page, connecting (or launching) Chrome on first
@@ -63,18 +63,25 @@ func browserPage(ctx context.Context) (*browser.Page, *browser.Browser, error) {
 
 	var b *browser.Browser
 	var err error
-	if bc.ConnectPort != 0 {
-		b, err = browser.ConnectByPort(ctx, bc.ConnectPort)
-		if err != nil {
+	switch {
+	case bc.ConnectPort != 0:
+		if b, err = browser.ConnectByPort(ctx, bc.ConnectPort); err != nil {
 			return nil, nil, fmt.Errorf("connect to Chrome on port %d: %w", bc.ConnectPort, err)
 		}
-	} else {
-		b, err = browser.Launch(ctx, browser.LaunchOptions{
+	case bc.AttachRunning && bc.UserDataDir != "":
+		if b, err = browser.ConnectViaProfile(ctx, bc.UserDataDir); err != nil {
+			return nil, nil, err
+		}
+	case bc.AttachRunning:
+		if b, err = browser.DiscoverRunningChrome(ctx); err != nil {
+			return nil, nil, err
+		}
+	default:
+		if b, err = browser.Launch(ctx, browser.LaunchOptions{
 			ExecPath:    bc.ExecPath,
 			UserDataDir: bc.UserDataDir,
 			Headless:    bc.Headless,
-		})
-		if err != nil {
+		}); err != nil {
 			return nil, nil, fmt.Errorf("launch Chrome: %w", err)
 		}
 	}


### PR DESCRIPTION
回答了「为什么 web-access 能直连我当前开着的 Chrome,octo 却让我重开」——并补齐这个能力。

## 根因

新版 Chrome **关闭了 `/json` HTTP 发现端点**,但保留了 WebSocket 端点。其端口 + browser GUID 写在 profile 的 `DevToolsActivePort` 文件里。web-access 读这个文件直接拼 `ws://host:port/devtools/browser/<guid>` 连接;octo 之前走 `/json/version`,在这种 Chrome 上拿不到,所以才要求重开。

(已在本机实测:读 DevToolsActivePort 直连,成功连上用户正在运行的、已登录的 Chrome 并列出标签页。)

## 内容

- `devToolsWS` 读 `DevToolsActivePort` → ws URL,绕过 `/json`;`defaultProfileDirs` 给出各平台 Chrome/Chromium/Edge profile 路径。
- `ConnectViaProfile(userDataDir)` 与 `DiscoverRunningChrome()`(扫默认 profile)。
- config 新增 `browser.attach_running`。工具连接优先级:`connect_port` → `attach_running`(指定 profile 或自动发现)→ 启动新实例。gating 也认 `attach_running`。

## 效果

设 `browser.attach_running: true` 后,octo **直连你当前登录态的 Chrome,无需重开**(对齐 web-access)。

## 测试

`devToolsWS` 解析单测(无需 Chrome);`ConnectViaProfile` 对一个启动的 profile 端到端连通;`-race` 干净;Chrome 缺失自动 skip。

🤖 Generated with [Claude Code](https://claude.com/claude-code)