### PR TITLE
provider: extend prompt cache (Anthropic 1h TTL on static prefix, Mistral cache key)

### DIFF
--- a/internal/provider/anthropic/cache_test.go
+++ b/internal/provider/anthropic/cache_test.go
@@ -11,7 +11,7 @@ import (
 func TestCacheableRequest_SystemBreakpoint(t *testing.T) {
 	var body apiRequest
 	tools := toAPITools([]agent.ToolDefinition{{Name: "t1"}, {Name: "t2"}})
-	cacheableRequest(&body, "you are octo", tools)
+	cacheableRequest(&body, "you are octo", tools, ephemeral)
 
 	sysJSON, _ := json.Marshal(body.System)
 	if !strings.Contains(string(sysJSON), `"ephemeral"`) {
@@ -29,7 +29,7 @@ func TestCacheableRequest_SystemBreakpoint(t *testing.T) {
 func TestCacheableRequest_ToolFallbackWhenNoSystem(t *testing.T) {
 	var body apiRequest
 	tools := toAPITools([]agent.ToolDefinition{{Name: "t1"}, {Name: "t2"}})
-	cacheableRequest(&body, "", tools)
+	cacheableRequest(&body, "", tools, ephemeral)
 
 	if body.System != nil {
 		t.Errorf("empty system should serialize as nil/omitted, got %v", body.System)
@@ -45,7 +45,7 @@ func TestCacheableRequest_ToolFallbackWhenNoSystem(t *testing.T) {
 
 func TestCacheableRequest_NoSystemNoTools(t *testing.T) {
 	var body apiRequest
-	cacheableRequest(&body, "", nil)
+	cacheableRequest(&body, "", nil, ephemeral)
 	if body.System != nil {
 		t.Errorf("system should be nil")
 	}
@@ -116,11 +116,52 @@ func TestCacheableRequest_MarksHistory(t *testing.T) {
 		{Role: "user", Content: json.RawMessage(`"u0"`)},
 		{Role: "assistant", Content: json.RawMessage(`"a0"`)},
 	}}
-	cacheableRequest(&body, "sys", nil)
+	cacheableRequest(&body, "sys", nil, ephemeral)
 	// Both messages (last two of two) carry breakpoints; system too.
 	for i := range body.Messages {
 		if !strings.Contains(string(body.Messages[i].Content), `"ephemeral"`) {
 			t.Errorf("message %d should be cache-marked: %s", i, body.Messages[i].Content)
 		}
+	}
+}
+
+// TestStaticPrefixCache_TTLGating verifies the static system+tools prefix gets
+// the 1-hour TTL only on the official Anthropic endpoint, and that the rolling
+// message breakpoints stay 5-minute (no ttl) regardless of endpoint.
+func TestStaticPrefixCache_TTLGating(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseURL string
+		want1h  bool
+	}{
+		{"default endpoint", "", true},
+		{"official explicit", DefaultBaseURL, true},
+		{"official trailing slash", DefaultBaseURL + "/", true},
+		{"kimi coding shim", "https://api.kimi.com/coding", false},
+		{"deepseek anthropic shim", "https://api.deepseek.com/anthropic", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Client{BaseURL: tc.baseURL}
+			body := apiRequest{Messages: []apiMessage{
+				{Role: "user", Content: json.RawMessage(`"hi"`)},
+			}}
+			cacheableRequest(&body, "you are octo", nil, c.staticPrefixCache())
+
+			sysJSON, _ := json.Marshal(body.System)
+			has1h := strings.Contains(string(sysJSON), `"ttl":"1h"`)
+			if has1h != tc.want1h {
+				t.Errorf("system 1h TTL = %v, want %v: %s", has1h, tc.want1h, sysJSON)
+			}
+			// System always carries an ephemeral breakpoint either way.
+			if !strings.Contains(string(sysJSON), `"ephemeral"`) {
+				t.Errorf("system should always carry an ephemeral breakpoint: %s", sysJSON)
+			}
+			// The rolling message breakpoint is always 5m (never 1h).
+			lastMsg := string(body.Messages[len(body.Messages)-1].Content)
+			if strings.Contains(lastMsg, `"1h"`) {
+				t.Errorf("message breakpoints must stay 5-minute, got: %s", lastMsg)
+			}
+		})
 	}
 }

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -132,7 +132,7 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 		MaxTokens: req.MaxTokens,
 		Messages:  msgs,
 	}
-	cacheableRequest(&body, req.SystemPrompt, toAPITools(req.Tools))
+	cacheableRequest(&body, req.SystemPrompt, toAPITools(req.Tools), c.staticPrefixCache())
 	if body.MaxTokens <= 0 {
 		body.MaxTokens = DefaultMaxTokens
 	}
@@ -241,37 +241,59 @@ func (c *Client) endpointURL() string {
 	return strings.TrimRight(base, "/") + MessagesPath
 }
 
+// staticPrefixCache picks the cache_control marker for the static system+tools
+// prefix. The extended one-hour TTL is a documented GA feature only on the
+// official Anthropic endpoint; Anthropic-compatible gateways (Kimi …/coding,
+// DeepSeek …/anthropic, self-hosted shims set via BaseURL) either don't
+// implement it or may reject the unknown `ttl` field — so they fall back to the
+// default 5-minute marker. The rolling message breakpoints stay 5m everywhere.
+func (c *Client) staticPrefixCache() *cacheControl {
+	if c.isOfficialEndpoint() {
+		return ephemeral1h
+	}
+	return ephemeral
+}
+
+// isOfficialEndpoint reports whether the client targets api.anthropic.com (the
+// zero value defaults there too). Anything else is a compatible third party.
+func (c *Client) isOfficialEndpoint() bool {
+	base := strings.TrimRight(c.BaseURL, "/")
+	return base == "" || base == DefaultBaseURL
+}
+
 // buildSystem returns the value for the request's `system` field, placing a
 // cache breakpoint on it when non-empty. Because the cache prefix order is
 // tools → system → messages, a breakpoint on the system block also caches the
 // (stable, every-turn-identical) tools array that precedes it — capturing the
-// bulk of the per-turn input-token cost of an agentic loop. Returns nil for an
-// empty prompt so the field is omitted.
-func buildSystem(prompt string) any {
+// bulk of the per-turn input-token cost of an agentic loop. cc selects the
+// breakpoint's TTL. Returns nil for an empty prompt so the field is omitted.
+func buildSystem(prompt string, cc *cacheControl) any {
 	if prompt == "" {
 		return nil
 	}
-	return []apiSystemBlock{{Type: "text", Text: prompt, CacheControl: ephemeral}}
+	return []apiSystemBlock{{Type: "text", Text: prompt, CacheControl: cc}}
 }
 
-// markToolsCacheable puts a cache breakpoint on the LAST tool so the tools
-// array is cached even with no system prompt to anchor on. No-op when there
-// are no tools.
-func markToolsCacheable(tools []apiTool) []apiTool {
+// markToolsCacheable puts a cache breakpoint (with cc's TTL) on the LAST tool so
+// the tools array is cached even with no system prompt to anchor on. No-op when
+// there are no tools.
+func markToolsCacheable(tools []apiTool, cc *cacheControl) []apiTool {
 	if len(tools) > 0 {
-		tools[len(tools)-1].CacheControl = ephemeral
+		tools[len(tools)-1].CacheControl = cc
 	}
 	return tools
 }
 
 // cacheableRequest places all cache breakpoints on a request: the system/
 // tools prefix (via buildSystem / markToolsCacheable) and the conversation
-// history (via markMessagesCacheable). Shared by Send and SendStream so both
-// paths cache identically. body.Messages must already be populated.
-func cacheableRequest(body *apiRequest, systemPrompt string, tools []apiTool) {
-	body.System = buildSystem(systemPrompt)
+// history (via markMessagesCacheable). staticCC is the marker for the static
+// prefix — ephemeral1h on the official endpoint, ephemeral elsewhere; the
+// message breakpoints are always 5-minute. Shared by Send and SendStream so
+// both paths cache identically. body.Messages must already be populated.
+func cacheableRequest(body *apiRequest, systemPrompt string, tools []apiTool, staticCC *cacheControl) {
+	body.System = buildSystem(systemPrompt, staticCC)
 	if body.System == nil {
-		tools = markToolsCacheable(tools) // no system block to anchor on
+		tools = markToolsCacheable(tools, staticCC) // no system block to anchor on
 	}
 	body.Tools = tools
 	markMessagesCacheable(body.Messages)

--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -61,7 +61,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		Messages:  msgs,
 		Stream:    true,
 	}
-	cacheableRequest(&body, req.SystemPrompt, toAPITools(req.Tools))
+	cacheableRequest(&body, req.SystemPrompt, toAPITools(req.Tools), c.staticPrefixCache())
 	if body.MaxTokens <= 0 {
 		body.MaxTokens = DefaultMaxTokens
 	}

--- a/internal/provider/anthropic/types.go
+++ b/internal/provider/anthropic/types.go
@@ -9,13 +9,23 @@ import "encoding/json"
 // cacheControl marks a prompt-cache breakpoint. Anthropic caches the entire
 // prefix up to and including the block carrying this marker and reuses it on
 // later requests sharing that prefix (billed at the cheaper cached rate).
-// Only "ephemeral" exists today.
+// TTL selects the cache lifetime: empty means the default 5-minute window;
+// "1h" is the extended one-hour window (billed at a 2× write premium vs 1.25×
+// for 5m, but worth it for a prefix re-read across think-time gaps longer than
+// five minutes). Only "ephemeral" exists as a type today.
 type cacheControl struct {
-	Type string `json:"type"` // "ephemeral"
+	Type string `json:"type"`          // "ephemeral"
+	TTL  string `json:"ttl,omitempty"` // "" (5m default) | "1h"
 }
 
-// ephemeral is the shared marker; it's immutable so sharing the pointer is safe.
-var ephemeral = &cacheControl{Type: "ephemeral"}
+// ephemeral is the shared 5-minute marker; immutable so sharing the pointer is
+// safe. ephemeral1h is the one-hour variant used for the static system+tools
+// prefix on the official Anthropic endpoint, where the extended TTL is a
+// documented GA feature — see Client.staticPrefixCache.
+var (
+	ephemeral   = &cacheControl{Type: "ephemeral"}
+	ephemeral1h = &cacheControl{Type: "ephemeral", TTL: "1h"}
+)
 
 // apiSystemBlock is one element of the array form of the `system` field.
 // Anthropic accepts `system` as a plain string OR an array of text blocks;

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -294,14 +294,34 @@ func (c *Client) Send(ctx context.Context, req provider.Request) (provider.Respo
 	}, nil
 }
 
+// MistralBaseURL is Mistral's official API host. It speaks the OpenAI protocol
+// and, unlike the auto-caching backends (DeepSeek, GLM, Qwen-implicit, …),
+// caches a prompt prefix ONLY when the request carries a stable prompt_cache_key
+// — so the key must be forwarded there too, not just to OpenAI.
+const MistralBaseURL = "https://api.mistral.ai"
+
+// promptCacheKeyEndpoints is the set of base URLs known to accept the
+// prompt_cache_key field. prompt_cache_key originated as an OpenAI field; most
+// OpenAI-compatible gateways either ignore it or cache automatically without it,
+// and some that proxy other backends (e.g. AWS Bedrock for Anthropic models)
+// reject unknown body fields with a 400 ("Extra inputs are not permitted") — so
+// the key is sent only to endpoints that are known to honour it. Mistral is
+// included because it does not cache at all without the key.
+var promptCacheKeyEndpoints = map[string]bool{
+	DefaultBaseURL: true, // official OpenAI: prompt-cache routing
+	MistralBaseURL: true, // Mistral: prefix caching requires the key
+}
+
 // promptCacheKey returns the prompt-cache routing key only when the client
-// targets the official OpenAI endpoint. prompt_cache_key is an OpenAI-proprietary
-// field: OpenAI-compatible gateways that proxy to other backends (e.g. AWS
-// Bedrock for Anthropic models) reject unknown body fields with a 400
-// ("Extra inputs are not permitted"), so it is omitted for any non-official
-// BaseURL while official OpenAI keeps its prompt-cache routing.
+// targets an endpoint known to accept the prompt_cache_key field (see
+// promptCacheKeyEndpoints); it is omitted everywhere else to avoid a 400 from
+// strict gateways.
 func (c *Client) promptCacheKey(key string) string {
-	if c.BaseURL == "" || c.BaseURL == DefaultBaseURL {
+	base := strings.TrimRight(c.BaseURL, "/")
+	if base == "" {
+		base = DefaultBaseURL // zero value defaults to official OpenAI
+	}
+	if promptCacheKeyEndpoints[base] {
 		return key
 	}
 	return ""

--- a/internal/provider/openai/client_test.go
+++ b/internal/provider/openai/client_test.go
@@ -346,6 +346,15 @@ func TestPromptCacheKey_GatedByBaseURL(t *testing.T) {
 	if custom.promptCacheKey("k3") != "" {
 		t.Error("custom BaseURL should drop prompt_cache_key")
 	}
+	// Mistral requires the key to cache at all, so it's on the allowlist.
+	mistral := &Client{BaseURL: MistralBaseURL}
+	if mistral.promptCacheKey("k4") != "k4" {
+		t.Error("Mistral endpoint should forward prompt_cache_key")
+	}
+	mistralSlash := &Client{BaseURL: MistralBaseURL + "/"}
+	if mistralSlash.promptCacheKey("k5") != "k5" {
+		t.Error("Mistral endpoint with trailing slash should forward prompt_cache_key")
+	}
 }
 
 // TestSend_ToolCallWithStopFinishReason verifies a response carrying tool calls


### PR DESCRIPTION
## What

Two protocol-gated prompt-cache optimizations, both quality-neutral, pure token-cost reductions. Came out of a cache-utilization audit of every supported provider.

### Anthropic — 1h TTL on the static prefix
The composed `system` prompt + tools array is frozen for the whole session (date/git are start-of-session snapshots), but was cached at the default **5-minute** TTL. Any think-time gap >5min — common in IM-bridge and `serve` usage — re-wrote that 5k–10k-token prefix at **1.25×** instead of reading it at **0.1×**.

This gives the static prefix the documented **1-hour TTL** (`{"type":"ephemeral","ttl":"1h"}`): 2× write, but read cheap for an hour, which pays off after ≥3 reads in the window — essentially always in a multi-turn session.

**Gated to the official `api.anthropic.com` endpoint.** The extended TTL is unverified on Anthropic-compatible gateways (Kimi `…/coding`, DeepSeek `…/anthropic`, custom shims), and an unknown `ttl` field risks a 400 there — those fall back to the 5m marker. The **rolling message breakpoints stay 5-minute everywhere** (only the static prefix changes).

### OpenAI — forward `prompt_cache_key` to Mistral
`prompt_cache_key` was sent only to official OpenAI. The audit found that **Mistral, uniquely among the OpenAI-protocol vendors, caches a prefix only when a stable `prompt_cache_key` is present** — so octo was leaving Mistral entirely uncached. The key is now forwarded to Mistral too via an endpoint allowlist.

The auto-caching backends (DeepSeek disk cache, GLM native, Qwen implicit, MiniMax) cache without the key and are unaffected; strict gateways that 400 on unknown fields still don't receive it. (Also fixed a latent empty-`BaseURL` normalization edge in the gate.)

### Why nothing for the other providers
The 1h-TTL concept is Anthropic-protocol-specific. The OpenAI-protocol vendors cache **automatically** with server-controlled lifetimes and expose no client TTL knob — octo already captures that via its frozen prefix + deterministic tool ordering. Mistral was the one place a client lever was being left unused.

## Test
- New `TestStaticPrefixCache_TTLGating`: 5 endpoint cases verifying 1h applies only on the official endpoint and message breakpoints stay 5m.
- Mistral allowlist assertions added to `TestPromptCacheKey_GatedByBaseURL`.
- `gofmt -l` clean, `go build ./...`, `go vet`, `go test ./...` all green (35 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)