### PR TITLE
skill: document project-level skills in skill-creator

### DIFF
--- a/internal/skills/defaults/skill-creator/SKILL.md
+++ b/internal/skills/defaults/skill-creator/SKILL.md
@@ -41,9 +41,25 @@ Proactively ask about edge cases, input/output formats, example files, success c
 
 Check available skills and tools — if useful for research, use subagents to search docs or find similar skills in parallel.
 
+### Where the skill lives — user-level vs project-level
+
+A skill is a directory holding a `SKILL.md`. The loader scans two roots:
+
+- **User-level** `~/.octo/skills/<name>/SKILL.md` — available in every session.
+  The default home for a personal skill.
+- **Project-level** `<repo>/.octo/skills/<name>/SKILL.md` — discovered only when
+  octo runs inside that working directory, and it **takes precedence** over a
+  user-level skill of the same name. Use this when the skill is repo-specific or
+  should travel with the code and be shared with the team (commit it to the
+  repo). Ask which the user wants; default to user-level unless the skill is
+  clearly tied to one project.
+
+(`octo skills add` and the web Skills panel install to the user-level root; a
+project-level skill is just a directory you create under the repo.)
+
 ### Write the SKILL.md
 
-Skills live in `~/.octo/skills/<name>/SKILL.md` with YAML frontmatter:
+Both roots use the same format — a `SKILL.md` with YAML frontmatter:
 
 ```markdown
 ---


### PR DESCRIPTION
## Why

The skills loader scans two roots (`internal/skills/skills.go`):

- `~/.octo/skills/<name>/` — user-level, every session
- `<repo>/.octo/skills/<name>/` — project-level, **takes precedence** over a same-named user skill

But the `skill-creator` skill only ever documented the user-level path. A user wanting a repo-scoped skill — one that travels with the code and is shared with the team by committing it — was never told the project-level root exists, even though `Skill.Source` is literally `"project" | "user"`.

## What

Added a "Where the skill lives — user-level vs project-level" section to skill-creator: both roots, the precedence rule, when to pick each (default user-level; project-level when tied to one repo / shared with the team), and a note that `octo skills add` and the web panel install to the user root while a project-level skill is just a directory under the repo.

Came out of an audit of the skill subsystem (creator skill + web panel + server API). The panel and the `/api/skills` server surface (list/toggle/delete/import/export) were both found clean — this doc gap in the creator skill was the only real opportunity.

## Test
Docs-only change to a `go:embed`'d SKILL.md. `go build ./...` and `go test ./internal/skills/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)