### PR TITLE
test(scheduler): fix flaky bookkeeping persistence race

### DIFF
--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -247,8 +247,15 @@ func TestRunNowFiresDisabledTaskAndPersistsBookkeeping(t *testing.T) {
 	}
 
 	waitFor(t, "runner call", func() bool { return len(r.calls()) == 1 })
-	waitFor(t, "run bookkeeping", func() bool {
-		got, err := s.Get("t1")
+	// fire() updates the in-memory task before save() flushes to disk, so wait
+	// on the persisted state (via a fresh reload) rather than the in-memory
+	// copy — otherwise the reload below can race ahead of the disk write.
+	waitFor(t, "persisted bookkeeping", func() bool {
+		sr, err := New(dir, r)
+		if err != nil {
+			return false
+		}
+		got, err := sr.Get("t1")
 		return err == nil && !got.LastRun.IsZero() && got.SessionID == "sess_t1"
 	})
 


### PR DESCRIPTION
## What

`TestRunNowFiresDisabledTaskAndPersistsBookkeeping` flakes on CI (seen red on macOS in #922's run on `main`). Root cause is in the **test**, not production code.

`fire()` updates the in-memory task under lock, releases it, then calls `save()` to flush JSON to disk. The old `waitFor` only checked the **in-memory** copy via `s.Get`, so it returned as soon as `fire()` set `LastRun` — before `save()` had flushed. The test then reloaded from disk (`New(dir, r)`) and could race ahead of the pending write, observing zero bookkeeping.

## Fix

Wait on the **persisted** state: the `waitFor` now reloads from disk (`New(dir, r)`) inside the condition, so it only passes once the JSON write has landed. Production code is unchanged.

Verified locally 10/10 green on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)