### PR TITLE
tools: split camelCase in MCP tool search (mcp_search recall)

### DIFF
--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -401,10 +401,17 @@ func catalogText(d agent.ToolDefinition) string {
 	return b.String()
 }
 
-// tokenizeForSearch lower-cases and splits on non-alphanumeric runes, and also
-// splits snake_case / mcp__ separators (already covered by the underscore split)
-// and camelCase boundaries so "createIssue" matches "create" and "issue".
+// tokenizeForSearch splits s into search terms: it breaks on non-alphanumeric
+// runes (covering snake_case and the mcp__ separator) AND on camelCase
+// boundaries, then lower-cases. Each raw token contributes its whole lowercased
+// form plus its sub-words, so a query "table record" matches a tool named
+// "appTableRecord" (common in MCP servers like Lark/Feishu that mix snake_case
+// and camelCase, e.g. bitable_v1_appTableRecord_search). Splitting happens
+// before lower-casing — camelCase boundaries are invisible once everything is
+// lowercase.
 func tokenizeForSearch(s string) []string {
+	// Split on non-alphanumeric, preserving case so splitCamel can see the
+	// lower→upper boundaries.
 	var raw []string
 	cur := strings.Builder{}
 	flush := func() {
@@ -415,31 +422,55 @@ func tokenizeForSearch(s string) []string {
 	}
 	for _, r := range s {
 		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			cur.WriteRune(unicode.ToLower(r))
+			cur.WriteRune(r)
 		} else {
 			flush()
 		}
 	}
 	flush()
 
-	// Split camelCase tokens into their parts (kept alongside the whole token).
 	var out []string
 	for _, tok := range raw {
-		out = append(out, tok)
+		whole := strings.ToLower(tok)
+		out = append(out, whole)
 		for _, part := range splitCamel(tok) {
-			if part != tok {
-				out = append(out, part)
+			if p := strings.ToLower(part); p != whole {
+				out = append(out, p)
 			}
 		}
 	}
 	return out
 }
 
-// splitCamel breaks a token on lower→upper boundaries; here the input is
-// already lower-cased, so this only ever returns the token itself. Kept as a
-// hook so future tokenization (raw, pre-lowercase) can split camelCase without
-// touching callers.
-func splitCamel(tok string) []string { return []string{tok} }
+// splitCamel breaks a mixed-case token into its word parts on lower→upper
+// boundaries, treating an acronym run followed by a word as its own part
+// ("XMLParser" → "XML", "Parser"; "appTableRecord" → "app", "Table", "Record").
+// Parts are returned in their original case; the caller lower-cases them. A
+// token with no internal boundary returns a single element (itself), so callers
+// can dedupe against the whole-token form.
+func splitCamel(tok string) []string {
+	rs := []rune(tok)
+	if len(rs) < 2 {
+		return []string{tok}
+	}
+	var parts []string
+	start := 0
+	for i := 1; i < len(rs); i++ {
+		prev, curr := rs[i-1], rs[i]
+		// lower→upper (or digit→upper): "appTable" → app|Table.
+		lowerToUpper := !unicode.IsUpper(prev) && unicode.IsUpper(curr)
+		// acronym→word: the last upper of a run that's followed by a lower
+		// starts a new word, e.g. "XMLParser" → XML|Parser.
+		acronymBoundary := unicode.IsUpper(prev) && unicode.IsUpper(curr) &&
+			i+1 < len(rs) && unicode.IsLower(rs[i+1])
+		if lowerToUpper || acronymBoundary {
+			parts = append(parts, string(rs[start:i]))
+			start = i
+		}
+	}
+	parts = append(parts, string(rs[start:]))
+	return parts
+}
 
 func termFreq(toks []string) map[string]int {
 	m := make(map[string]int, len(toks))

--- a/internal/tools/tool_search_test.go
+++ b/internal/tools/tool_search_test.go
@@ -61,6 +61,42 @@ func TestBM25Search_SubstringFallback(t *testing.T) {
 	}
 }
 
+func TestSplitCamel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"appTableRecord", []string{"app", "Table", "Record"}},
+		{"createIssue", []string{"create", "Issue"}},
+		{"XMLParser", []string{"XML", "Parser"}},
+		{"lowercase", []string{"lowercase"}},
+		{"v1", []string{"v1"}}, // digit boundaries are left alone
+		{"", []string{""}},
+	}
+	for _, tc := range cases {
+		got := splitCamel(tc.in)
+		if strings.Join(got, "|") != strings.Join(tc.want, "|") {
+			t.Errorf("splitCamel(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestBM25Search_CamelCaseRecall is the regression guard for the camelCase
+// tokenization fix: a sub-word query must match a tool whose name embeds the
+// word in camelCase (as Lark/Feishu MCP tools do), not just snake_case.
+func TestBM25Search_CamelCaseRecall(t *testing.T) {
+	catalog := []agent.ToolDefinition{
+		{Name: "mcp__lark__bitable_v1_appTableRecord_search", Description: "Search records in a Bitable table",
+			Parameters: map[string]any{"type": "object", "properties": map[string]any{"app_token": map[string]any{"type": "string"}}}},
+		{Name: "mcp__slack__post_message", Description: "Post a message to a Slack channel",
+			Parameters: map[string]any{"type": "object", "properties": map[string]any{"channel": map[string]any{"type": "string"}}}},
+	}
+	hits := bm25Search(catalog, "table record", 5)
+	if len(hits) == 0 || hits[0].Name != "mcp__lark__bitable_v1_appTableRecord_search" {
+		t.Errorf("camelCase sub-word query should match appTableRecord; got %+v", hits)
+	}
+}
+
 func TestExecToolSearch_NoSchemaLeaked(t *testing.T) {
 	fakeCatalog(t, sampleCatalog())
 	res, err := execToolSearch(map[string]any{"query": "github issue"})


### PR DESCRIPTION
## Why

`mcp_search` (the Tool Search bridge over the deferred MCP catalog) ranks tools with BM25 over `tokenizeForSearch`. That function's comment claimed it "splits camelCase boundaries so `createIssue` matches `create` and `issue`" — but `splitCamel` was a **documented no-op**: `tokenizeForSearch` lower-cased each rune *before* calling it, so the lower→upper boundaries it needed were already gone. In practice the tokenizer only split on non-alphanumeric runes (snake_case and the `mcp__` separator); a camelCase word embedded in a tool name stayed one opaque token.

This silently hurt recall on MCP servers that mix snake_case and camelCase — notably **Lark/Feishu** tools like `bitable_v1_appTableRecord_search`. A query "table record" never matched, because `appTableRecord` lower-cased to the single token `apptablerecord`.

## What

Split **before** lower-casing:
- `tokenizeForSearch` keeps original case through the non-alphanumeric split, then lower-cases each token and its sub-words.
- `splitCamel` now actually breaks a token on lower→upper and acronym→word boundaries: `appTableRecord` → `app`/`Table`/`Record`, `XMLParser` → `XML`/`Parser`. A token with no boundary returns itself, so the whole-token form is preserved alongside the sub-words.

No behavior change for snake_case tools (already split on `_`); pure recall gain for camelCase names.

## Test
- `TestSplitCamel` — boundary cases (camel, acronym, lowercase, digit-left-alone, empty).
- `TestBM25Search_CamelCaseRecall` — regression guard: "table record" matches `…appTableRecord_search`.
- `gofmt -l` clean, `go build ./...`, `go test -race ./internal/tools/`, `go test ./...` all green (35 packages).

Came out of an MCP-module audit; the rest of the module (Tool Search auto-deferral, connection lifecycle, web-panel API, recent robustness hardening) was found in good shape — this tokenizer gap was the one concrete fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)