### PR TITLE
feat(cli): octo browser setup — enable browser automation

### DIFF
--- a/cmd/octo/browser.go
+++ b/cmd/octo/browser.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/browser"
+	"github.com/Leihb/octo-agent/internal/config"
+)
+
+// defaultDebugPort is the conventional Chrome remote-debugging port. The
+// chrome://inspect "Allow remote debugging" toggle serves the CDP endpoint
+// here, and it's the documented value users paste into --remote-debugging-port.
+const defaultDebugPort = 9222
+
+// attachProbe attempts to attach to a running, remote-debugging-enabled Chrome
+// on the given port and verifies a page-level CDP call works. It is a package
+// variable so tests can substitute a fake (the real one needs a live browser).
+// The detail string is shown to the user: open-tab count on success, the
+// failure reason otherwise.
+var attachProbe = realAttachProbe
+
+// runBrowser dispatches `octo browser <subcommand>`. Today the only real
+// subcommand is `setup`; bare `octo browser` runs it too.
+func runBrowser(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	sub := ""
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	switch sub {
+	case "", "setup":
+		return runBrowserSetup(stdin, stdout, stderr)
+	case "-h", "--help", "help":
+		browserHelp(stdout)
+		return 0
+	default:
+		fmt.Fprintf(stderr, "octo browser: unknown subcommand %q\n", sub)
+		fmt.Fprintln(stderr, "Run `octo browser --help` for usage.")
+		return 2
+	}
+}
+
+// runBrowserSetup walks the user through enabling Chrome remote debugging so
+// the `browser` tool can drive their already-logged-in browser, then verifies
+// the connection and wires browser.connect_port into the config on success.
+func runBrowserSetup(stdin io.Reader, stdout, stderr io.Writer) int {
+	cfg, _ := config.Load()
+	port := cfg.Browser.ConnectPort
+	if port == 0 {
+		port = defaultDebugPort
+	}
+
+	printBrowserSetupSteps(stdout, port)
+
+	reader := newScannerLineReader(stdin, stdout)
+	for {
+		ok, detail := attachProbe(port)
+		if ok {
+			fmt.Fprintf(stdout, "\n✓ Connected to your Chrome on port %d (%s).\n", port, detail)
+			if err := wireConnectPort(&cfg, port); err != nil {
+				fmt.Fprintf(stderr, "  (couldn't save config: %v — set `browser: { connect_port: %d }` yourself)\n", err, port)
+			} else {
+				fmt.Fprintf(stdout, "  Saved browser.connect_port: %d to your config.\n", port)
+			}
+			fmt.Fprintln(stdout, "\nAll set — the `browser` tool will now attach to this Chrome.")
+			return 0
+		}
+
+		fmt.Fprintf(stdout, "\n✗ Couldn't attach on port %d yet: %s\n", port, detail)
+		line, ok := reader.ReadLine("Enable the toggle above (restart the browser if asked), then press Enter to retry — or 'q' to quit: ")
+		if !ok || strings.EqualFold(strings.TrimSpace(line), "q") {
+			fmt.Fprintln(stdout, "Setup paused — run `octo browser setup` again whenever you're ready.")
+			return 1
+		}
+	}
+}
+
+// printBrowserSetupSteps explains why remote debugging is needed and how to
+// turn it on per browser. The chrome://inspect toggle is the primary path: it
+// keeps the user's logged-in session and survives Chrome's recent lockdown of
+// remote debugging on the default profile.
+func printBrowserSetupSteps(w io.Writer, port int) {
+	fmt.Fprintln(w, `Browser automation lets octo drive your real, logged-in browser — clicking,
+typing, uploading, and replaying recorded workflows on sites you're signed into.
+
+To allow that, turn on remote debugging in the browser you want octo to use:
+
+  Chrome   open  chrome://inspect/#remote-debugging
+  Edge     open  edge://inspect/#remote-debugging
+
+  Then tick "Allow remote debugging for this browser instance".
+  (You may need to restart the browser for it to take effect.)`)
+	fmt.Fprintf(w, "\nOnce enabled, the browser serves its debug endpoint on 127.0.0.1:%d.\n", port)
+	fmt.Fprintln(w, "I'll check the connection now.")
+}
+
+// wireConnectPort persists browser.connect_port so the tool reuses this Chrome
+// on every future session. No-op (no rewrite) when it's already set.
+func wireConnectPort(cfg *config.Config, port int) error {
+	if cfg.Browser.ConnectPort == port {
+		return nil
+	}
+	cfg.Browser.ConnectPort = port
+	return cfg.Save()
+}
+
+// realAttachProbe attaches the way the browser tool does — connect_port first
+// (the chrome://inspect path, via /json/version), then default-profile
+// discovery — and confirms a page-level CDP call works, since a browser-level
+// connect can succeed while page CDP doesn't on recent Chrome.
+func realAttachProbe(port int) (bool, string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	b, err := browser.ConnectByPort(ctx, port)
+	if err != nil {
+		var derr error
+		if b, derr = browser.DiscoverRunningChrome(ctx); derr != nil {
+			return false, err.Error()
+		}
+	}
+	defer b.Close()
+
+	pages, err := b.Pages(ctx)
+	if err != nil {
+		return false, fmt.Sprintf("connected, but a CDP call failed: %v", err)
+	}
+	return true, fmt.Sprintf("%d open tab(s)", len(pages))
+}
+
+func browserHelp(w io.Writer) {
+	fmt.Fprintln(w, `octo browser — set up browser automation.
+
+The `+"`browser`"+` tool drives your real, logged-in browser over the Chrome
+DevTools Protocol — clicking, typing, uploading, and replaying recorded
+workflows. It needs remote debugging enabled on the browser you point it at.
+
+Usage:
+  octo browser setup    Guide you through enabling remote debugging, verify
+                        the connection, and wire it into your config.
+
+Enabling remote debugging:
+  Chrome   chrome://inspect/#remote-debugging
+  Edge     edge://inspect/#remote-debugging
+  Tick "Allow remote debugging for this browser instance" (restart if asked).
+
+This serves a debug endpoint on 127.0.0.1:9222; setup saves
+browser.connect_port so the tool reuses your logged-in session every run.`)
+}

--- a/cmd/octo/browser_test.go
+++ b/cmd/octo/browser_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/config"
+)
+
+// withFakeProbe swaps attachProbe for the duration of a test.
+func withFakeProbe(t *testing.T, fn func(port int) (bool, string)) {
+	t.Helper()
+	orig := attachProbe
+	attachProbe = fn
+	t.Cleanup(func() { attachProbe = orig })
+}
+
+// isolateHome points config.Load/Save at a temp HOME (and USERPROFILE on
+// Windows, where os.UserHomeDir reads that instead).
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
+}
+
+func TestBrowserSetup_SuccessSavesPort(t *testing.T) {
+	home := isolateHome(t)
+	withFakeProbe(t, func(port int) (bool, string) { return true, "2 open tab(s)" })
+
+	var out strings.Builder
+	code := runBrowser([]string{"setup"}, strings.NewReader(""), &out, &out)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; output:\n%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "✓ Connected") {
+		t.Errorf("missing success line; got:\n%s", out.String())
+	}
+
+	// The connect port must be persisted so the tool reuses this Chrome.
+	cfgPath := filepath.Join(home, ".octo", "config.yml")
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if cfg.Browser.ConnectPort != defaultDebugPort {
+		t.Errorf("ConnectPort = %d, want %d (config at %s)", cfg.Browser.ConnectPort, defaultDebugPort, cfgPath)
+	}
+}
+
+func TestBrowserSetup_RetryThenQuit(t *testing.T) {
+	isolateHome(t)
+	calls := 0
+	withFakeProbe(t, func(port int) (bool, string) {
+		calls++
+		return false, "no Chrome with remote debugging"
+	})
+
+	var out strings.Builder
+	// First probe fails → prompt → user presses Enter (retry) → fails again →
+	// "q" quits.
+	code := runBrowser([]string{"setup"}, strings.NewReader("\nq\n"), &out, &out)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; output:\n%s", code, out.String())
+	}
+	if calls != 2 {
+		t.Errorf("probe calls = %d, want 2 (initial + one retry)", calls)
+	}
+	if !strings.Contains(out.String(), "Setup paused") {
+		t.Errorf("missing paused line; got:\n%s", out.String())
+	}
+}
+
+func TestBrowserSetup_EOFDoesNotLoopForever(t *testing.T) {
+	isolateHome(t)
+	withFakeProbe(t, func(port int) (bool, string) { return false, "nope" })
+
+	var out strings.Builder
+	// Empty stdin: the first probe fails, the prompt read hits EOF → quit.
+	code := runBrowser([]string{"setup"}, strings.NewReader(""), &out, &out)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}
+
+func TestBrowserSetup_HonorsConfiguredPort(t *testing.T) {
+	isolateHome(t)
+	cfg := config.Config{Browser: config.BrowserConfig{ConnectPort: 9333}}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	var gotPort int
+	withFakeProbe(t, func(port int) (bool, string) { gotPort = port; return true, "1 open tab(s)" })
+
+	var out strings.Builder
+	if code := runBrowser([]string{"setup"}, strings.NewReader(""), &out, &out); code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if gotPort != 9333 {
+		t.Errorf("probed port = %d, want 9333 (from config)", gotPort)
+	}
+}
+
+func TestBrowser_UnknownSubcommand(t *testing.T) {
+	var out strings.Builder
+	if code := runBrowser([]string{"frobnicate"}, strings.NewReader(""), &out, &out); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}
+
+func TestBrowser_Help(t *testing.T) {
+	var out strings.Builder
+	if code := runBrowser([]string{"--help"}, strings.NewReader(""), &out, &out); code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "chrome://inspect") {
+		t.Errorf("help should mention chrome://inspect; got:\n%s", out.String())
+	}
+}

--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -24,6 +24,8 @@ func printCommandHelp(name string, w io.Writer) bool {
 		mcpHelp(w)
 	case "serve":
 		serveHelp(w)
+	case "browser":
+		browserHelp(w)
 	default:
 		return false
 	}

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -81,6 +81,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return runCompletion(args[1:], stdout, stderr)
 	case "upgrade":
 		return runUpgrade(args[1:], stdout, stderr)
+	case "browser":
+		return runBrowser(args[1:], stdin, stdout, stderr)
 	case "__complete":
 		// Hidden subcommand the shell-completion scripts call back into.
 		// Prints newline-separated candidates for the current command line.
@@ -128,6 +130,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  memory     Manage cross-session memory (e.g. `octo memory list`)")
 	fmt.Fprintln(w, "  sessions   List recent saved sessions (resume with `octo -c <id>`)")
 	fmt.Fprintln(w, "  skills     Manage skills (`octo skills list | add | update | path`)")
+	fmt.Fprintln(w, "  browser    Set up browser automation (attach to your logged-in Chrome)")
 	fmt.Fprintln(w, "  upgrade    Download and install the latest release (--check to only compare)")
 	fmt.Fprintln(w, "  completion Print shell-completion snippet (bash | zsh | fish)")
 	fmt.Fprintln(w, "  version    Print the version and exit")

--- a/internal/skills/defaults/onboard/SKILL.md
+++ b/internal/skills/defaults/onboard/SKILL.md
@@ -302,6 +302,10 @@ Do NOT open a new session — the UI handles navigation after the skill finishes
 - Keep both files under 300 words each.
 - Do not ask follow-up questions beyond the cards above.
 - Work with whatever the user provides; fill in sensible defaults.
+- If the user mentioned browser automation, RPA, scraping, or repetitive web
+  tasks (in their profile or links), add one closing line after A.11 pointing
+  them to `octo browser setup` — it connects the `browser` tool to their
+  logged-in Chrome. Skip it otherwise; don't bloat the ceremony for everyone.
 
 ---
 


### PR DESCRIPTION
## What

Adds `octo browser setup`: a doctor-style helper that gets the `browser` tool attached to the user's **already-logged-in** Chrome/Edge.

The browser pillar's biggest value is driving a real signed-in browser, but that requires remote debugging — and recent Chrome locked it down on the default profile. The modern path is the **chrome://inspect toggle**, which most users won't discover on their own.

`octo browser setup`:
1. Prints the per-browser steps — `chrome://inspect/#remote-debugging` / `edge://inspect/#remote-debugging` → tick **"Allow remote debugging for this browser instance"** (restart if asked).
2. **Verifies** octo can attach: tries `connect_port` (the `/json/version` path the toggle serves) first, then default-profile discovery, and confirms a **page-level** CDP call works — a browser-level connect can succeed while page CDP fails on recent Chrome, so this guards against a false "connected".
3. On success, persists `browser.connect_port` so the tool reuses the logged-in session every run.
4. On failure, loops: re-check after the user flips the toggle, or `q` to quit.

## Onboarding

Per design, the `/onboard` ceremony stays a tight identity flow. It only **points** to `octo browser setup` (one closing line) when the user mentions browser/RPA/web-automation work — no bloat for everyone else.

## Tests

`cmd/octo/browser_test.go` fakes the attach probe (real one needs a live browser, and CI has no GUI Chrome) and covers: success → port saved, retry-then-quit, EOF doesn't hang, configured-port honored, unknown subcommand, help mentions chrome://inspect.

## Notes

Verified by the user that octo attaches end-to-end via the chrome://inspect toggle. The runtime tool already branches on `connect_port` (`internal/tools/browser.go`), so saving it is what makes the next session attach automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)