### PR TITLE
test(workflow): widen nested-parallel deadlock watchdog 5s→30s (de-flake)

### DIFF
--- a/internal/workflow/runtime_test.go
+++ b/internal/workflow/runtime_test.go
@@ -154,7 +154,12 @@ func TestRun_NestedParallelDeadlock(t *testing.T) {
 		if got.res.Output != want {
 			t.Errorf("Output = %q, want %q", got.res.Output, want)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second):
+		// A real re-entrancy regression hangs forever, so this watchdog only
+		// needs to fail faster than the package-level `go test` timeout — not
+		// race the work. The job is ~80ms of agent sleeps; 5s tripped as a
+		// false positive on a heavily-loaded CI core (goroutine wakeups delayed
+		// under contention). 30s keeps the guard effective without flaking.
 		t.Fatal("workflow deadlocked on nested parallel (re-entrant scheduler regression)")
 	}
 }


### PR DESCRIPTION
## What

`TestRun_NestedParallelDeadlock` intermittently failed CI with *"workflow deadlocked on nested parallel (re-entrant scheduler regression)"*. **It is not a real deadlock** — it's the test's own 5s watchdog firing as a false positive on a slammed CI core.

## Investigation

- The test (added in #767) guards the `$__wf_ready` re-entrancy fix: with nested `parallel`, the outer branch's token arrives at the *inner* level's `wait_any` first; the buffer must re-route it to the outer level. I traced the exact interleaving — the routing is correct and the script produces the right output.
- #915 rebuilt `mruby.wasm` (mruby-json gem + `args()`) but **did not touch the scheduler logic** in `prelude.rb` / `runtime.go`.
- `done` is buffered (1024), so delivery never blocks; the only concurrency is Go goroutines feeding that channel, and Ruby fibers are cooperative (single-threaded) — no data race on the scheduler globals.
- **Could not reproduce** in 190+ local runs (`-count`, `-race`, `GOMAXPROCS=1`) nor under 6× parallel full-package saturation with all cores pegged.

The failing run's package took **88s** — the runner was heavily loaded. The job is ~80ms of agent sleeps; under contention, goroutine wakeups stall and 5s is too tight.

## Fix

Widen the watchdog 5s → 30s. A genuine re-entrancy regression hangs *forever*, so the guard only needs to fail faster than the package-level `go test` timeout (10 min) — not race the work. 30s still catches a true deadlock promptly while removing the slowness false positive. **No scheduler/production code changed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)