### PR TITLE
feat(browser): vision screenshots + observe primitive (web-access parity ph1)

### DIFF
--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -228,7 +228,10 @@ func InteractiveDigest(ctx context.Context, page *Page, frame string, max int) (
 	if frame != "" {
 		doc = fmt.Sprintf("(document.querySelector(%s)||{}).contentDocument", jsString(frame))
 	}
-	expr := fmt.Sprintf(`JSON.stringify((function(){
+	// Eval uses returnByValue, so return the array directly — wrapping it in
+	// JSON.stringify would yield a JSON *string* that fails to unmarshal into
+	// []DigestElement.
+	expr := fmt.Sprintf(`(function(){
 	  var d = %s; if(!d) return [];
 	  function sel(el){
 	    if(el.id) return '#'+CSS.escape(el.id);
@@ -241,7 +244,7 @@ func InteractiveDigest(ctx context.Context, page *Page, frame string, max int) (
 	  var els=d.querySelectorAll('a,button,input,select,textarea,[role=button],[role=menuitem],[role=tab],label');
 	  for(var i=0;i<els.length && out.length<%d;i++){var el=els[i]; if(el.offsetParent===null) continue; var t=(el.textContent||el.value||el.getAttribute('aria-label')||el.getAttribute('placeholder')||'').trim().slice(0,50); out.push({text:t, selector:sel(el)});}
 	  return out;
-	})())`, doc, max)
+	})()`, doc, max)
 	var digest []DigestElement
 	if err := page.Eval(ctx, expr, &digest); err != nil {
 		return nil, err

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
@@ -152,8 +153,8 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 			"properties": map[string]any{
 				"action": map[string]any{
 					"type":        "string",
-					"enum":        []string{"navigate", "back", "click", "hover", "type", "select", "key", "scroll", "wait", "screenshot", "ax", "upload", "download", "pages", "select_page", "close", "eval", "record_start", "record_stop", "run_skill"},
-					"description": "The browser action to perform. record_start/record_stop capture a demonstration into an editable skill; run_skill replays one (deterministic, self-healing).",
+					"enum":        []string{"navigate", "back", "click", "hover", "type", "select", "key", "scroll", "wait", "screenshot", "observe", "ax", "upload", "download", "pages", "select_page", "close", "eval", "record_start", "record_stop", "run_skill"},
+					"description": "The browser action to perform. observe returns a screenshot the model can see plus a list of the page's interactable elements with selectors — the way to look at an unfamiliar page before acting. record_start/record_stop capture a demonstration into an editable skill; run_skill replays one (deterministic, self-healing).",
 				},
 				"name":       map[string]any{"type": "string", "description": "Skill name (record_stop / run_skill)."},
 				"params":     map[string]any{"type": "object", "description": "Param values for {{...}} placeholders (run_skill)."},
@@ -280,12 +281,44 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		if err != nil {
 			return agent.ToolResult{}, err
 		}
-		dir := downloadDir()
-		path := filepath.Join(dir, fmt.Sprintf("screenshot-%d.png", len(shot)))
-		if err := os.WriteFile(path, shot, 0o644); err != nil {
+		path := saveScreenshot(shot)
+		// Return the image as a vision block so the model actually sees the page
+		// (not just a file path), and keep the on-disk copy for artifacts.
+		return agent.ToolResult{
+			Text:   "screenshot saved to " + path,
+			Blocks: []agent.ContentBlock{agent.NewImageBlock("image/png", shot)},
+		}, nil
+
+	case "observe":
+		// "Look at this page": a screenshot the model can see + the interactable
+		// elements with selectors. This is the see-before-you-act primitive that
+		// keeps exploratory navigation from thrashing on unfamiliar pages.
+		shot, err := page.Screenshot(ctx)
+		if err != nil {
 			return agent.ToolResult{}, err
 		}
-		return agent.ToolResult{Text: "screenshot saved to " + path}, nil
+		frame := getStr(input, "frame")
+		digest, derr := browser.InteractiveDigest(ctx, page, frame, 60)
+		var sb strings.Builder
+		path := saveScreenshot(shot)
+		fmt.Fprintf(&sb, "screenshot saved to %s\n\ninteractable elements:\n", path)
+		if derr != nil {
+			fmt.Fprintf(&sb, "(could not read elements: %v)\n", derr)
+		} else if len(digest) == 0 {
+			sb.WriteString("(none found)\n")
+		} else {
+			for _, e := range digest {
+				if e.Text != "" {
+					fmt.Fprintf(&sb, "- %s  →  %s\n", e.Text, e.Selector)
+				} else {
+					fmt.Fprintf(&sb, "- %s\n", e.Selector)
+				}
+			}
+		}
+		return agent.ToolResult{
+			Text:   sb.String(),
+			Blocks: []agent.ContentBlock{agent.NewImageBlock("image/png", shot)},
+		}, nil
 
 	case "ax":
 		raw, err := page.AXTree(ctx)
@@ -486,6 +519,25 @@ func downloadDir() string {
 		return cfg.Browser.DownloadDir
 	}
 	return filepath.Join(os.TempDir(), "octo-browser-downloads")
+}
+
+// screenshotSeq disambiguates screenshot filenames within a session.
+var screenshotSeq atomic.Uint64
+
+// saveScreenshot writes a PNG to the download dir for artifact/preview use and
+// returns the path. Best-effort: a write failure yields a note instead of an
+// error, because the caller's vision image block — not the file — is what the
+// model relies on.
+func saveScreenshot(shot []byte) string {
+	dir := downloadDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "(not saved: " + err.Error() + ")"
+	}
+	path := filepath.Join(dir, fmt.Sprintf("screenshot-%d.png", screenshotSeq.Add(1)))
+	if err := os.WriteFile(path, shot, 0o644); err != nil {
+		return "(not saved: " + err.Error() + ")"
+	}
+	return path
 }
 
 // axNode is the subset of a CDP accessibility node the digest needs.

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/browser"
 )
 
@@ -160,5 +161,65 @@ func TestBrowserTool_RequiresAction(t *testing.T) {
 	_, err := BrowserTool{}.Execute(context.Background(), "browser", map[string]any{})
 	if err == nil {
 		t.Fatal("expected error for missing action")
+	}
+}
+
+// TestBrowserTool_ObserveAndScreenshotVision checks that screenshot and observe
+// hand the model an actual image block (not just a file path), and that observe
+// also lists the page's interactable elements with selectors.
+func TestBrowserTool_ObserveAndScreenshotVision(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60_000_000_000) // 60s
+	defer cancel()
+	if !browser.ChromeAvailable("") {
+		t.Skip("chrome not available")
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(toolFixtureHTML))
+	}))
+	defer srv.Close()
+
+	b, err := browser.Launch(ctx, browser.LaunchOptions{Headless: true})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	SetBrowserSession(b, page)
+	defer ResetBrowserSession()
+
+	tool := BrowserTool{}
+	if _, err := tool.Execute(ctx, "browser", map[string]any{"action": "navigate", "url": srv.URL}); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+
+	hasImage := func(res agent.ToolResult) bool {
+		for _, blk := range res.Blocks {
+			if blk.Type == "image" && blk.Image != nil && len(blk.Image.Data) > 0 {
+				return true
+			}
+		}
+		return false
+	}
+
+	shot, err := tool.Execute(ctx, "browser", map[string]any{"action": "screenshot"})
+	if err != nil {
+		t.Fatalf("screenshot: %v", err)
+	}
+	if !hasImage(shot) {
+		t.Errorf("screenshot returned no image block; blocks=%d text=%q", len(shot.Blocks), shot.Text)
+	}
+
+	obs, err := tool.Execute(ctx, "browser", map[string]any{"action": "observe"})
+	if err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	if !hasImage(obs) {
+		t.Errorf("observe returned no image block; blocks=%d", len(obs.Blocks))
+	}
+	// The fixture's #search button must surface in the interactable digest.
+	if !strings.Contains(obs.Text, "#search") {
+		t.Errorf("observe text missing #search selector; got:\n%s", obs.Text)
 	}
 }


### PR DESCRIPTION
## Why

Phase 1 of retiring the Node-based `web-access` skill in favor of octo's Go-native `browser` tool. The investigation showed the tool's primitive surface already *exceeds* web-access's CDP proxy — the one real blocker for exploratory ("see → decide → act") browsing was **perception**: `screenshot` saved a PNG and returned only a file path, so the model drove blind and thrashed on unfamiliar/dynamic pages.

## What

- **`screenshot` now returns a vision image block** (`NewImageBlock`) so the model actually sees the page; the on-disk PNG is kept for artifacts.
- **New `observe` action** = viewport screenshot (vision block) + the page's interactable elements with generated selectors. This is the "look at this page" primitive — what stops blind DOM driving.
- **Bonus bug fix:** `InteractiveDigest` wrapped its result in `JSON.stringify`, but `Page.Eval` uses `returnByValue` and unmarshals the value directly — so it returned a JSON *string* that failed to decode into `[]DigestElement`. The self-healer relies on the same function; its model calls aren't in CI, so this was latent. Fixed by returning the array directly.

## Tests

`TestBrowserTool_ObserveAndScreenshotVision` (real headless Chrome, skips when absent): asserts both `screenshot` and `observe` return an image block, and that `observe` lists the fixture's `#search` selector.

## Next phases (not in this PR)

2. `cookies` action (CDP `Network.getCookies`, incl. httpOnly) + default-to-logged-in-Chrome. 3. Node-free replacement skill encoding web-access's methodology on the Go tool + built-in `web_search`/`web_fetch`. 4. Validate on real flows, then delete web-access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)