### PR TITLE
feat(browser): cookies action + default to logged-in Chrome (parity ph2)

### DIFF
--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -338,3 +338,34 @@ func (p *Page) AXTree(ctx context.Context) (json.RawMessage, error) {
 	}
 	return res, nil
 }
+
+// Cookie is one browser cookie, including HttpOnly ones JS can't read via
+// document.cookie — which is the point: a logged-in session token usually is
+// HttpOnly, so reuse/extraction needs CDP, not Eval.
+type Cookie struct {
+	Name     string  `json:"name"`
+	Value    string  `json:"value"`
+	Domain   string  `json:"domain"`
+	Path     string  `json:"path"`
+	Expires  float64 `json:"expires"`
+	HTTPOnly bool    `json:"httpOnly"`
+	Secure   bool    `json:"secure"`
+	SameSite string  `json:"sameSite,omitempty"`
+}
+
+// Cookies returns the cookies the current page can see (its URL + frames),
+// including HttpOnly. Network.enable is idempotent and a no-op once on.
+func (p *Page) Cookies(ctx context.Context) ([]Cookie, error) {
+	_, _ = p.cli.call(ctx, p.sessionID, "Network.enable", nil)
+	res, err := p.cli.call(ctx, p.sessionID, "Network.getCookies", nil)
+	if err != nil {
+		return nil, err
+	}
+	var r struct {
+		Cookies []Cookie `json:"cookies"`
+	}
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, err
+	}
+	return r.Cookies, nil
+}

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -112,12 +112,21 @@ func browserPage(ctx context.Context) (*browser.Page, *browser.Browser, error) {
 			return nil, nil, err
 		}
 	default:
-		if b, err = browser.Launch(ctx, browser.LaunchOptions{
-			ExecPath:    bc.ExecPath,
-			UserDataDir: bc.UserDataDir,
-			Headless:    bc.Headless,
-		}); err != nil {
-			return nil, nil, fmt.Errorf("launch Chrome: %w", err)
+		// No explicit attach config: prefer the user's logged-in Chrome if one
+		// is running with remote debugging. Discovery only succeeds when the
+		// user deliberately enabled it (the chrome://inspect toggle or
+		// --remote-debugging-port), so this never hijacks an ordinary browser —
+		// it just means `octo browser setup` users, and anyone who flipped the
+		// toggle, get their logged-in session without extra config. Falls back
+		// to a fresh throwaway Chrome.
+		if b, err = browser.DiscoverRunningChrome(ctx); err != nil {
+			if b, err = browser.Launch(ctx, browser.LaunchOptions{
+				ExecPath:    bc.ExecPath,
+				UserDataDir: bc.UserDataDir,
+				Headless:    bc.Headless,
+			}); err != nil {
+				return nil, nil, fmt.Errorf("launch Chrome: %w", err)
+			}
 		}
 	}
 
@@ -153,8 +162,8 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 			"properties": map[string]any{
 				"action": map[string]any{
 					"type":        "string",
-					"enum":        []string{"navigate", "back", "click", "hover", "type", "select", "key", "scroll", "wait", "screenshot", "observe", "ax", "upload", "download", "pages", "select_page", "close", "eval", "record_start", "record_stop", "run_skill"},
-					"description": "The browser action to perform. observe returns a screenshot the model can see plus a list of the page's interactable elements with selectors — the way to look at an unfamiliar page before acting. record_start/record_stop capture a demonstration into an editable skill; run_skill replays one (deterministic, self-healing).",
+					"enum":        []string{"navigate", "back", "click", "hover", "type", "select", "key", "scroll", "wait", "screenshot", "observe", "ax", "cookies", "upload", "download", "pages", "select_page", "close", "eval", "record_start", "record_stop", "run_skill"},
+					"description": "The browser action to perform. observe returns a screenshot the model can see plus a list of the page's interactable elements with selectors — the way to look at an unfamiliar page before acting. cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture a demonstration into an editable skill; run_skill replays one (deterministic, self-healing).",
 				},
 				"name":       map[string]any{"type": "string", "description": "Skill name (record_stop / run_skill)."},
 				"params":     map[string]any{"type": "object", "description": "Param values for {{...}} placeholders (run_skill)."},
@@ -326,6 +335,17 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 			return agent.ToolResult{}, err
 		}
 		return agent.ToolResult{Text: axDigest(raw)}, nil
+
+	case "cookies":
+		cookies, err := page.Cookies(ctx)
+		if err != nil {
+			return agent.ToolResult{}, err
+		}
+		j, err := json.MarshalIndent(cookies, "", "  ")
+		if err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: fmt.Sprintf("%d cookie(s) for the current page (HttpOnly included):\n%s", len(cookies), j)}, nil
 
 	case "upload":
 		sel := targetSelector(input)

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -164,6 +164,45 @@ func TestBrowserTool_RequiresAction(t *testing.T) {
 	}
 }
 
+// TestBrowserTool_CookiesIncludesHttpOnly verifies the cookies action returns
+// the current page's cookies including HttpOnly ones (which document.cookie via
+// eval cannot see) — the reason this needs CDP.
+func TestBrowserTool_CookiesIncludesHttpOnly(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60_000_000_000) // 60s
+	defer cancel()
+	if !browser.ChromeAvailable("") {
+		t.Skip("chrome not available")
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "sess", Value: "secret123", Path: "/", HttpOnly: true})
+		w.Write([]byte("<!doctype html><html><head><title>c</title></head><body>hi</body></html>"))
+	}))
+	defer srv.Close()
+
+	b, err := browser.Launch(ctx, browser.LaunchOptions{Headless: true})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	SetBrowserSession(b, page)
+	defer ResetBrowserSession()
+
+	tool := BrowserTool{}
+	if _, err := tool.Execute(ctx, "browser", map[string]any{"action": "navigate", "url": srv.URL}); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	res, err := tool.Execute(ctx, "browser", map[string]any{"action": "cookies"})
+	if err != nil {
+		t.Fatalf("cookies: %v", err)
+	}
+	if !strings.Contains(res.Text, "sess") || !strings.Contains(res.Text, "secret123") {
+		t.Errorf("cookies missing the HttpOnly session cookie; got:\n%s", res.Text)
+	}
+}
+
 // TestBrowserTool_ObserveAndScreenshotVision checks that screenshot and observe
 // hand the model an actual image block (not just a file path), and that observe
 // also lists the page's interactable elements with selectors.


### PR DESCRIPTION
## Why

Phase 2 of retiring `web-access`. Closes two gaps the investigation found between the Go-native `browser` tool and the Node skill: cookie/session extraction, and reusing the logged-in browser by default.

## What

- **`cookies` action** — returns the current page's cookies via CDP `Network.getCookies`, **including HttpOnly** ones that `document.cookie`/`eval` cannot read. That's the whole point: a logged-in session token is usually HttpOnly, so the Klook-OAuth / cookie-extraction use case web-access handled needs CDP, not Eval.
- **Default to logged-in Chrome** — with no explicit attach config, the tool now tries `DiscoverRunningChrome` first and only launches a throwaway profile if none is found. Discovery succeeds **only** when remote debugging was deliberately enabled (the chrome://inspect toggle or `--remote-debugging-port`), so it never hijacks an ordinary browser — it just gives `octo browser setup` users (and anyone who flipped the toggle) their logged-in session with zero extra config. That's login + anti-detection in one (web-access's "anti-detection" was just using the real profile).

## Behavior note

The default-connection change is a deliberate behavior shift: previously the no-config path always launched a fresh anonymous Chrome. Now it attaches to a debug-enabled running Chrome when present. Gated by the user having enabled remote debugging, so it's opt-in by construction.

## Tests

`TestBrowserTool_CookiesIncludesHttpOnly` (real headless Chrome, skips when absent): an httptest fixture sets an HttpOnly `Set-Cookie`; asserts the cookies action surfaces it.

## Next

3. Node-free replacement skill (methodology on the Go tool + `web_search`/`web_fetch`). 4. Validate real flows, delete web-access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)