### PR TITLE
cli: novice-friendly first-run config wizard (key-first, validated, minimal)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -449,7 +449,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		if errors.Is(err, errMissingAPIKey) && stdinIsTTY(stdin) {
 			fmt.Fprintln(stderr, "No API key configured — let's set up octo first.")
 			fmt.Fprintln(stderr, "")
-			if runConfigWizard(stdin, stdout, stderr) != 0 {
+			if runConfigWizard(stdin, stdout, stderr, true) != 0 {
 				return 1
 			}
 			// Reload config and retry sender construction.

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/config"
 )
+
+// validateConnection probes a provider/model/key against the live endpoint.
+// Package var so tests substitute a fake (the real one makes a network call).
+var validateConnection = app.TestConnection
 
 // firstNonEmpty returns the first non-empty string, or "" if all are empty.
 func firstNonEmpty(vals ...string) string {
@@ -105,7 +111,8 @@ func runConfig(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	switch sub {
 	case "", "setup", "init":
-		return runConfigWizard(stdin, stdout, stderr)
+		// Explicit `octo config` is the full editor (expert prefs included).
+		return runConfigWizard(stdin, stdout, stderr, false)
 	case "show", "get":
 		return runConfigShow(stdout, stderr)
 	case "path":
@@ -223,7 +230,11 @@ func apiKeyStatus(provider string, entry config.ModelEntry) string {
 // runConfigWizard prompts for the persisted defaults and writes the file.
 // Existing values are offered as the default for each prompt so re-running it
 // edits rather than resets.
-func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
+// runConfigWizard walks the user through setting their default provider/model
+// and key. firstRun trims it to the essentials (provider → model → key) and
+// asks for the key directly, deferring expert prefs (coauthor, reasoning,
+// show-reasoning) to a later `octo config`; the full editor asks everything.
+func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer, firstRun bool) int {
 	full, _ := config.Load() // a malformed file is treated as empty here — the wizard overwrites it
 	existing := full.DefaultEntry()
 
@@ -383,67 +394,77 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 	outEntry.Model = model
 	outEntry.BaseURL = baseURL
 
-	// Co-authored-by: default on; ask once in wizard.
-	coauthorDefault := full.Coauthor == nil || *full.Coauthor
-	coauthorVal, ok := pickYesNo(tty, reader, stdin, stdout,
-		"Append Co-authored-by to git commits?", coauthorDefault)
-	if !ok {
-		return cancelWizard(stderr)
-	}
-	full.Coauthor = &coauthorVal
+	// ── API key — asked right after the model so a brand-new user reaches the
+	// one thing that actually unblocks them, not after a pile of expert
+	// questions. env stays the recommended home; we only prompt when it's empty.
+	keyEntered := collectAPIKey(&outEntry, existing, provider, firstRun, reader, stdout)
 
-	// Reasoning effort: off (empty) by default; offer the existing value.
-	if tty {
-		choice, ok := runSelect(stdin, stdout, "Reasoning effort", []selectItem{
-			{label: "Off", value: ""},
-			{label: "Low", value: "low"},
-			{label: "Medium", value: "medium"},
-			{label: "High", value: "high"},
-			{label: "Extra-high", value: "xhigh"},
-			{label: "Max", value: "max"},
-		}, existing.ReasoningEffort)
+	// Validate a freshly entered key against the live endpoint so a typo is
+	// caught here, not on the first turn. Interactive only (TTY) — piped runs and
+	// tests must not hit the network. First run loops on failure so the user can
+	// retry; the full editor just warns.
+	if keyEntered && tty {
+		for {
+			if reportConnectionCheck(stdout, stderr, provider, outEntry.APIKey, baseURL, model) {
+				break
+			}
+			if !firstRun {
+				break
+			}
+			again := strings.TrimSpace(promptDefault(reader, stdout,
+				"Re-enter API key (empty = keep it and continue)", ""))
+			if again == "" {
+				break
+			}
+			outEntry.APIKey = again
+		}
+	}
+
+	// Expert preferences — skipped on first run (sane defaults: coauthor on,
+	// reasoning off). They stay one `octo config` away.
+	if !firstRun {
+		// Co-authored-by: default on; ask once in wizard.
+		coauthorDefault := full.Coauthor == nil || *full.Coauthor
+		coauthorVal, ok := pickYesNo(tty, reader, stdin, stdout,
+			"Append Co-authored-by to git commits?", coauthorDefault)
 		if !ok {
 			return cancelWizard(stderr)
 		}
-		outEntry.ReasoningEffort = choice.value
-	} else {
-		effortAns := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
-			"Reasoning effort (low | medium | high | xhigh | max, empty = off)", existing.ReasoningEffort)))
-		if !validReasoningEffort(effortAns) {
-			fmt.Fprintf(stderr, "octo config: invalid reasoning effort %q (use 'low', 'medium', 'high', 'xhigh', 'max', or empty)\n", effortAns)
-			return 2
-		}
-		outEntry.ReasoningEffort = effortAns
-	}
+		full.Coauthor = &coauthorVal
 
-	// Surface the reasoning/thinking trace for the Web UI to display (the
-	// terminal never renders it): default off.
-	showDefault := existing.ShowReasoning != nil && *existing.ShowReasoning
-	showVal, ok := pickYesNo(tty, reader, stdin, stdout,
-		"Show the reasoning/thinking trace on the Web UI?", showDefault)
-	if !ok {
-		return cancelWizard(stderr)
-	}
-	outEntry.ShowReasoning = &showVal
-
-	// API key: env is the recommended home for it. Offer to store it only if
-	// the env var is empty, and make declining the obvious default.
-	envVar := app.VendorAPIKeyEnvVar(provider)
-	if envVar == "" {
-		envVar = strings.ToUpper(provider) + "_API_KEY"
-	}
-	// Prompt for key when env is empty AND (no stored key OR switching provider —
-	// a key stored for a different provider doesn't help the new one).
-	needsKeyPrompt := os.Getenv(envVar) == "" &&
-		(existing.APIKey == "" || existing.Provider != provider)
-	if needsKeyPrompt {
-		outEntry.APIKey = ""
-		ans := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
-			"Store the API key in this file? Not recommended — prefer "+envVar+" (y/N)", "n")))
-		if ans == "y" || ans == "yes" {
-			key := strings.TrimSpace(promptDefault(reader, stdout, "API key", ""))
-			outEntry.APIKey = key
+		// Reasoning effort: off (empty) by default; offer the existing value.
+		if tty {
+			choice, ok := runSelect(stdin, stdout, "Reasoning effort", []selectItem{
+				{label: "Off", value: ""},
+				{label: "Low", value: "low"},
+				{label: "Medium", value: "medium"},
+				{label: "High", value: "high"},
+				{label: "Extra-high", value: "xhigh"},
+				{label: "Max", value: "max"},
+			}, existing.ReasoningEffort)
+			if !ok {
+				return cancelWizard(stderr)
+			}
+			outEntry.ReasoningEffort = choice.value
+		} else {
+			effortAns := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
+				"Reasoning effort (low | medium | high | xhigh | max, empty = off)", existing.ReasoningEffort)))
+			if !validReasoningEffort(effortAns) {
+				fmt.Fprintf(stderr, "octo config: invalid reasoning effort %q (use 'low', 'medium', 'high', 'xhigh', 'max', or empty)\n", effortAns)
+				return 2
+			}
+			outEntry.ReasoningEffort = effortAns
 		}
+
+		// Surface the reasoning/thinking trace for the Web UI to display (the
+		// terminal never renders it): default off.
+		showDefault := existing.ShowReasoning != nil && *existing.ShowReasoning
+		showVal, ok := pickYesNo(tty, reader, stdin, stdout,
+			"Show the reasoning/thinking trace on the Web UI?", showDefault)
+		if !ok {
+			return cancelWizard(stderr)
+		}
+		outEntry.ShowReasoning = &showVal
 	}
 
 	full.SetDefaultEntry(outEntry)
@@ -454,12 +475,71 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer) int {
 	path, _ := config.Path()
 	fmt.Fprintln(stdout)
 	fmt.Fprintf(stdout, "Saved %s\n", path)
-	if outEntry.APIKey == "" && os.Getenv(envVar) == "" {
-		fmt.Fprintf(stdout, "Next: export %s=... (or re-run `octo config` to store it), then `octo`.\n", envVar)
+	if outEntry.APIKey == "" && os.Getenv(apiKeyEnvVar(provider)) == "" {
+		fmt.Fprintf(stdout, "Next: export %s=... (or re-run `octo config` to store it), then `octo`.\n", apiKeyEnvVar(provider))
 	} else {
 		fmt.Fprintln(stdout, "Run `octo` to start.")
 	}
 	return 0
+}
+
+// apiKeyEnvVar is the conventional env var holding a provider's key.
+func apiKeyEnvVar(provider string) string {
+	if v := app.VendorAPIKeyEnvVar(provider); v != "" {
+		return v
+	}
+	return strings.ToUpper(provider) + "_API_KEY"
+}
+
+// collectAPIKey prompts for the provider key when none is reachable (env empty
+// and no usable stored key), returning whether a non-empty key was just entered.
+// First run asks for the key directly and stores it — the wizard auto-launched
+// precisely because no key exists, so a "store in file? (not recommended)"
+// double-negative that dead-ends in an env-var detour helps nobody. The full
+// editor keeps that opt-in prompt (env is the recommended home there).
+func collectAPIKey(outEntry *config.ModelEntry, existing config.ModelEntry, provider string, firstRun bool, reader lineReader, stdout io.Writer) bool {
+	if os.Getenv(apiKeyEnvVar(provider)) != "" {
+		return false
+	}
+	// A key stored for a different provider is useless for the new one.
+	if existing.APIKey != "" && existing.Provider == provider {
+		return false
+	}
+	outEntry.APIKey = ""
+	if firstRun {
+		key := strings.TrimSpace(promptDefault(reader, stdout, "Paste your "+app.VendorDisplayName(provider)+" API key", ""))
+		outEntry.APIKey = key
+		return key != ""
+	}
+	ans := strings.ToLower(strings.TrimSpace(promptDefault(reader, stdout,
+		"Store the API key in this file? Not recommended — prefer "+apiKeyEnvVar(provider)+" (y/N)", "n")))
+	if ans == "y" || ans == "yes" {
+		key := strings.TrimSpace(promptDefault(reader, stdout, "API key", ""))
+		outEntry.APIKey = key
+		return key != ""
+	}
+	return false
+}
+
+// reportConnectionCheck tests the entered key against the endpoint, printing a
+// ✓/✗ line. Returns true on success. Resolves the vendor default model/base URL
+// when the user accepted the default (left them empty).
+func reportConnectionCheck(stdout, stderr io.Writer, provider, key, baseURL, model string) bool {
+	if model == "" {
+		model = app.VendorDefaultModel(provider)
+	}
+	if baseURL == "" {
+		baseURL = app.DefaultBaseURL(provider)
+	}
+	fmt.Fprintln(stdout, "Testing connection…")
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	if err := validateConnection(ctx, provider, key, baseURL, model); err != nil {
+		fmt.Fprintf(stderr, "✗ Couldn't connect: %v\n", err)
+		return false
+	}
+	fmt.Fprintln(stdout, "✓ Connected.")
+	return true
 }
 
 // customSentinel is the menu value standing in for "let me type my own". It

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -290,10 +292,11 @@ func TestRunConfig_Wizard_SwitchesProviderAndPromptsForKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Answers: provider=openai, model=(default), coauthor=y,
-	// reasoning-effort=(off), show-reasoning=(default), store_key=y,
-	// key=new-openai-key. No endpoint question for a pinned vendor.
-	in := strings.NewReader("openai\n\ny\n\n\ny\nnew-openai-key\n")
+	// Answers (key now comes right after model): provider=openai,
+	// model=(default), store_key=y, key=new-openai-key, coauthor=y,
+	// reasoning-effort=(off), show-reasoning=(default). No endpoint question for
+	// a pinned vendor.
+	in := strings.NewReader("openai\n\ny\nnew-openai-key\ny\n\n\n")
 	var stdout, stderr bytes.Buffer
 	if code := runConfig(nil, in, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
@@ -309,6 +312,80 @@ func TestRunConfig_Wizard_SwitchesProviderAndPromptsForKey(t *testing.T) {
 	}
 	if entry.APIKey != "new-openai-key" {
 		t.Errorf("APIKey = %q, want new-openai-key", entry.APIKey)
+	}
+}
+
+// TestRunConfigWizard_FirstRun_MinimalAndKeyDirect verifies the first-run path:
+// it asks for the key directly (not the "store? (y/N)" double-negative), stores
+// it, and skips the expert questions (coauthor / reasoning / show-reasoning).
+func TestRunConfigWizard_FirstRun_MinimalAndKeyDirect(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+
+	// Answers: provider=openai, model=(default), key=sk-first-run. That's all a
+	// first run asks (non-TTY → no live validation).
+	in := strings.NewReader("openai\n\nsk-first-run\n")
+	var stdout, stderr bytes.Buffer
+	if code := runConfigWizard(in, &stdout, &stderr, true); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+
+	got, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := got.DefaultEntry()
+	if entry.Provider != "openai" {
+		t.Errorf("provider = %q, want openai", entry.Provider)
+	}
+	if entry.APIKey != "sk-first-run" {
+		t.Errorf("APIKey = %q, want sk-first-run stored directly", entry.APIKey)
+	}
+	out := stdout.String()
+	for _, q := range []string{"Co-authored", "Reasoning effort", "thinking trace", "Store the API key"} {
+		if strings.Contains(out, q) {
+			t.Errorf("first run must not ask %q; got:\n%s", q, out)
+		}
+	}
+}
+
+// TestReportConnectionCheck exercises the live-key validation helper with a
+// stubbed connector (no network), both success and failure.
+func TestReportConnectionCheck(t *testing.T) {
+	orig := validateConnection
+	defer func() { validateConnection = orig }()
+
+	var gotModel, gotBase string
+	validateConnection = func(ctx context.Context, provider, key, baseURL, model string) error {
+		gotModel, gotBase = model, baseURL
+		if key == "bad" {
+			return errors.New("401 unauthorized")
+		}
+		return nil
+	}
+
+	var out, errb bytes.Buffer
+	// Empty model/baseURL must resolve to the vendor defaults before testing.
+	if ok := reportConnectionCheck(&out, &errb, "anthropic", "good", "", ""); !ok {
+		t.Fatalf("expected success; stderr=%q", errb.String())
+	}
+	if gotModel == "" || gotBase == "" {
+		t.Errorf("defaults not resolved: model=%q base=%q", gotModel, gotBase)
+	}
+	if !strings.Contains(out.String(), "Connected") {
+		t.Errorf("missing success line: %q", out.String())
+	}
+
+	out.Reset()
+	errb.Reset()
+	if ok := reportConnectionCheck(&out, &errb, "anthropic", "bad", "", ""); ok {
+		t.Fatal("expected failure for bad key")
+	}
+	if !strings.Contains(errb.String(), "Couldn't connect") {
+		t.Errorf("missing failure line: %q", errb.String())
 	}
 }
 


### PR DESCRIPTION
## Why

From a TUI/Web first-run usability review: the auto-launched config wizard front-loaded **expert questions** (co-authored-by, reasoning effort, show-reasoning trace) *before* the API key, and its key step defaulted to **"don't store it (N)"** — dead-ending a new user into an env-var + process-restart detour. A first-timer has no basis to answer the expert questions and just wants to start.

## What

`runConfigWizard` gains a `firstRun` flag:

- **First run** (auto-launched from `chat` on a missing key): `provider → model → key`, done.
  - Key asked **directly** ("Paste your <vendor> API key") and stored — no more "store in file? (not recommended)" double-negative.
  - Expert prefs **skipped** (sane defaults: coauthor on, reasoning off); still one `octo config` away.
- **`octo config`**: unchanged full editor, but the **key now comes right after the model** (not last) for everyone.

**Live key validation:** a freshly entered key is tested against the endpoint via `app.TestConnection`, so a typo is caught at setup instead of on the first turn. **TTY-only** — piped/script runs and tests never hit the network (honours the no-live-network test rule). First run loops on failure to let the user retry; the full editor warns once. `validateConnection` is a package var so tests stub it.

## Tests
- New: first-run path stores the key directly and omits the expert questions; `reportConnectionCheck` success/failure with a stubbed connector (no network).
- Updated `..._SwitchesProviderAndPromptsForKey` for the new prompt order.
- `go test ./cmd/octo/` green · `go vet` clean · `gofmt` clean · `go build ./...` OK.

Follow-up to #933 (browser settings). Web onboarding was already key-first with inline validation; this brings the TUI closer to that bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)