### PR TITLE
fix(onboard): break ensureSender self-deadlock that hung every turn after first-run setup

### DIFF
--- a/internal/permission/defaults.yml
+++ b/internal/permission/defaults.yml
@@ -129,6 +129,15 @@ task_update:
 task_list:
   - allow: { pattern: "" }
 
+# ask_user_question solicits a choice from the user and waits — it has no side
+# effect of its own, and it IS the interaction, so routing it through a separate
+# permission prompt is both redundant (interactive) and fatal everywhere else: a
+# non-interactive transport resolves the implicit ask to deny, silently killing
+# the question — which strands the onboard flow (its first step) and any skill
+# that asks a question. Allow without prompting, like the other control tools.
+ask_user_question:
+  - allow: { pattern: "" }
+
 # Skill invocation is a dispatch to a markdown instruction file — no direct side
 # effect beyond what the skill's own tools (already gated) do. Allow without
 # prompting so the onboard and other skill flows work over HTTP / IM.

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -258,6 +258,27 @@ func TestStrictMode_TurnsAskIntoDeny(t *testing.T) {
 	}
 }
 
+// TestDefaultRules_ControlToolsAllowedEvenInStrict guards that control-plane /
+// UX tools are explicitly allow-listed rather than left to the implicit ask.
+// ask_user_question is the load-bearing case: it is the onboard flow's first
+// step, and without an allow rule a non-interactive transport resolves its ask
+// to deny — silently stranding onboarding (the regression that prompted this).
+func TestDefaultRules_ControlToolsAllowedEvenInStrict(t *testing.T) {
+	e, err := New("", "/work", ModeStrict)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tool := range []string{
+		"ask_user_question", "skill",
+		"sub_agent", "sub_agent_send", "sub_agent_status", "sub_agent_kill",
+		"task_create", "task_update", "task_list",
+	} {
+		if got := e.Check(tool, map[string]any{}); got != Allow {
+			t.Errorf("%s: got %s, want Allow (must not fall through to implicit ask→deny)", tool, got)
+		}
+	}
+}
+
 // ─── Remember cache ────────────────────────────────────────────────────────
 
 func TestRemember_ShortCircuits(t *testing.T) {

--- a/internal/skills/defaults/onboard/SKILL.md
+++ b/internal/skills/defaults/onboard/SKILL.md
@@ -124,7 +124,7 @@ Parse freely. Store the user's name as `user.name` (default `"老大"` for zh, `
 
 ### A.6. Collect behaviour preferences
 
-These three settings are saved to `~/.octo/config.yaml` and affect every session.
+These three settings are saved to `~/.octo/config.yml` and affect every session.
 All have fixed choices with a sensible default, so present each as an
 `ask_user_question` (clickable cards) — make the default option's label say
 "(default)". Do NOT print a markdown list and tell the user to "press Enter" to
@@ -255,9 +255,9 @@ zh template:
 [1–2 句话，根据用户目标和背景量身定制。]
 ```
 
-### A.10. Update config.yaml
+### A.10. Update config.yml
 
-Read `~/.octo/config.yaml` (it already exists — the setup panel wrote provider/model/base_url/api_key earlier).
+Read `~/.octo/config.yml` (it already exists — the setup panel wrote provider/model/base_url/api_key earlier).
 Use `write_file` to rewrite it with the behaviour-preference fields appended:
 
 - `permission_mode` — `prefs.permission_mode` (or omit if default `"interactive"`)


### PR DESCRIPTION
## Symptom

After completing first-run onboarding in the Web UI (server booted without a key), the auto-sent `/onboard` — and in fact **every** message, even a plain \"hi\" — produced no response: status stuck on `空闲`/Idle, WS turn never replies. **Restarting `octo serve` made it work again.**

## Root cause (the real one): senderMu self-deadlock

`octo serve` with no key starts in onboarding mode (nil sender); the sender is built lazily on the first turn in `ensureSender`. That path did:

```go
s.senderMu.Lock()
defer s.senderMu.Unlock()
...
if s.cfg.Tools { s.enableSubAgentTools() }   // ← enableSubAgentTools → defaultSenderAndModel → s.senderMu.Lock() AGAIN
```

`defaultSenderAndModel` takes `senderMu`, which `ensureSender` already holds. Go mutexes aren't reentrant → **permanent self-deadlock**, hanging that turn and every turn after it. Goroutine dump (`SIGQUIT`) of a reproduced hang:

```
goroutine [sync.Mutex.Lock]:
server.(*Server).defaultSenderAndModel
server.(*Server).enableSubAgentTools
server.(*Server).ensureSender
server.(*Server).handleCreateChat
```

The startup path in `New()` calls `enableSubAgentTools()` *before* taking any lock, which is exactly why **restarting** (boot with the key present → non-lazy path) worked around it.

### Fix
In `ensureSender`, set the sender fields under the lock, **release it**, then enable the sub-agent tools. Those process-global managers are only fallback sentinels (every turn stamps its own ctx-scoped manager in `prepareToolTurn`), so enabling them just after the unlock is safe.

Regression test `TestEnsureSender_LazyInitDoesNotDeadlock` drives keyless-start → save-model → `ensureSender` and times out if the lock is held across `enableSubAgentTools` (verified: fails on the old code, passes on the fix).

**End-to-end:** before, a post-onboarding `/api/chat` turn hangs the full 40s curl cap (`HTTP 000`); after, it returns in ~0.4s (reaching the provider call).

## Also in this PR (smaller, related onboard fixes)

- **`ask_user_question` allow-listed** in `permission/defaults.yml`. It was missing, so it fell through to the implicit `ask` — redundant in interactive mode and fatal in strict (non-interactive transports resolve ask→deny, killing the onboard flow's first question). It's a control/UX tool like `skill`/`sub_agent`/`task_*`. + regression test that these stay `Allow` even under strict mode.
- **`onboard/SKILL.md`**: `~/.octo/config.yaml` → `~/.octo/config.yml` (3 spots; `.yaml` is the legacy pre-rename name).

## Test
`go test ./internal/server/ ./internal/permission/ ./internal/skills/` — green; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)