### PR TITLE
fix(ask_user_question): accept object-shaped options

### DIFF
--- a/internal/tools/ask_user_question.go
+++ b/internal/tools/ask_user_question.go
@@ -148,7 +148,7 @@ func (AskUserQuestionTool) Execute(ctx context.Context, _ string, input map[stri
 	if question == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("ask_user_question: question is required")
 	}
-	options := stringSliceArg(input, "options")
+	options := optionLabels(input["options"])
 	if len(options) < 2 || len(options) > 4 {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("ask_user_question: options must have 2-4 entries (got %d)", len(options))
 	}
@@ -184,4 +184,51 @@ func formatAskResponse(r AskResponse) string {
 		return "(user cancelled)" // defensive: no choices and no custom → nothing to report
 	}
 	return "User chose: " + strings.Join(r.Choices, ", ")
+}
+
+// optionLabels extracts the option labels from the tool input, tolerating both
+// shapes the model emits. The schema asks for an array of strings, but Claude
+// models trained on Claude Code's AskUserQuestion habitually send an array of
+// {label, description} objects instead; a strict string-only parse drops those
+// silently and the tool fails with "got 0 options". So we accept either:
+//
+//	["A", "B"]                                          → "A", "B"
+//	[{"label":"A","description":"short"}, {"label":"B"}] → "A — short", "B"
+//
+// For object options a non-empty description is folded into the displayed label
+// so the extra context the model provided still reaches the user.
+func optionLabels(raw any) []string {
+	items, ok := raw.([]any)
+	if !ok {
+		// Already-typed []string (e.g. from tests) takes the simple path.
+		if ss, ok := raw.([]string); ok {
+			out := make([]string, 0, len(ss))
+			for _, s := range ss {
+				if s = strings.TrimSpace(s); s != "" {
+					out = append(out, s)
+				}
+			}
+			return out
+		}
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		switch v := it.(type) {
+		case string:
+			if s := strings.TrimSpace(v); s != "" {
+				out = append(out, s)
+			}
+		case map[string]any:
+			label := strings.TrimSpace(stringArg(v, "label"))
+			if label == "" {
+				continue
+			}
+			if desc := strings.TrimSpace(stringArg(v, "description")); desc != "" {
+				label += " — " + desc
+			}
+			out = append(out, label)
+		}
+	}
+	return out
 }

--- a/internal/tools/ask_user_question_test.go
+++ b/internal/tools/ask_user_question_test.go
@@ -69,6 +69,69 @@ func TestAskUserQuestionTool_Execute_SingleChoice(t *testing.T) {
 	}
 }
 
+// Claude models trained on Claude Code's AskUserQuestion send options as
+// {label, description} objects rather than bare strings. The tool must accept
+// that shape instead of dropping every entry and failing with "got 0".
+func TestAskUserQuestionTool_Execute_ObjectOptions(t *testing.T) {
+	stub := &stubAsker{resp: AskResponse{Choices: []string{"简洁型 — 极度简短"}}}
+	useAsker(t, stub)
+
+	out, err := AskUserQuestionTool{}.Execute(context.Background(), "ask_user_question", map[string]any{
+		"question": "什么风格?",
+		"options": []any{
+			map[string]any{"label": "简洁型", "description": "极度简短"},
+			map[string]any{"label": "专业型", "description": "精准、结构化"},
+			map[string]any{"label": "友好型"}, // description omitted
+		},
+	})
+	if err != nil {
+		t.Fatalf("object-shaped options should parse, got error: %v", err)
+	}
+	if len(stub.lastReq.Options) != 3 {
+		t.Fatalf("want 3 options forwarded, got %d: %v", len(stub.lastReq.Options), stub.lastReq.Options)
+	}
+	// Description is folded into the label so its context still reaches the user.
+	if stub.lastReq.Options[0] != "简洁型 — 极度简短" {
+		t.Errorf("option[0] = %q, want label folded with description", stub.lastReq.Options[0])
+	}
+	// A label without a description stays bare.
+	if stub.lastReq.Options[2] != "友好型" {
+		t.Errorf("option[2] = %q, want bare label", stub.lastReq.Options[2])
+	}
+	_ = out
+}
+
+func TestOptionLabels(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want []string
+	}{
+		{"string []any", []any{"a", "b"}, []string{"a", "b"}},
+		{"typed []string", []string{"a", "b"}, []string{"a", "b"}},
+		{"objects with label", []any{
+			map[string]any{"label": "a"},
+			map[string]any{"label": "b", "description": "d"},
+		}, []string{"a", "b — d"}},
+		{"blank entries dropped", []any{"a", "  ", map[string]any{"label": ""}}, []string{"a"}},
+		{"nil", nil, nil},
+		{"not a slice", "oops", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := optionLabels(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestAskUserQuestionTool_Execute_MultiChoice(t *testing.T) {
 	stub := &stubAsker{resp: AskResponse{Choices: []string{"OAuth", "API key"}}}
 	useAsker(t, stub)


### PR DESCRIPTION
## Problem

`ask_user_question` failed with `options must have 2-4 entries (got 0)` whenever the model passed options as `{label, description}` objects — the shape Claude models habitually emit (trained on Claude Code's `AskUserQuestion`) even though our schema asks for bare strings. The string-only parser silently dropped every object entry, so the tool errored *before any prompt could render*. The user pressed `a` at the permission modal (which worked), then saw `(got 0)` and reasonably read it as "my input was ignored".

This affected **all three transports** (CLI / web / IM) because option parsing lives in the shared `Execute`; web/IM askers consume the already-parsed `AskRequest.Options` and never re-parse.

## Fix

`optionLabels` accepts `[]string`, `[]any` of strings, and `[]any` of `{label, description}` maps. A non-empty `description` is folded into the displayed label (`"简洁型 — 极度简短"`) so the context the model provided still reaches the user. Back-compatible with the bare-string shape.

> The companion permission allow-list for `ask_user_question` (so the tool isn't gated behind a redundant prompt / silently denied on non-interactive transports) landed separately in #936. This PR is now scoped to the parsing fix only.

## Tests

- `TestAskUserQuestionTool_Execute_ObjectOptions` — the real-world failure (object options + description folding + bare label).
- `TestOptionLabels` — table-driven over all input shapes.

`go test -race ./...` green; `go vet` + `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)