### PR TITLE
fix(onboard): break ensureSender self-deadlock that hung every turn after first-run setup

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1232,21 +1232,32 @@ func (s *Server) ensureSender() error {
 		return nil
 	}
 	s.senderMu.Lock()
-	defer s.senderMu.Unlock()
 	if s.sender != nil {
+		s.senderMu.Unlock()
 		return nil
 	}
 	sender, model, provName, err := resolveProviderAndModel(s.cfg.Provider, s.cfg.Model)
 	if err != nil {
+		s.senderMu.Unlock()
 		return err
 	}
 	if sender == nil {
+		s.senderMu.Unlock()
 		return fmt.Errorf("server not configured: complete setup via the Web UI")
 	}
 	s.sender = sender
 	s.model = model
 	s.provider = provName
-	if s.cfg.Tools {
+	enableTools := s.cfg.Tools
+	s.senderMu.Unlock()
+
+	// enableSubAgentTools reads the default sender via defaultSenderAndModel,
+	// which takes senderMu — so it MUST run after the unlock above. senderMu is
+	// not reentrant; calling it while still holding the lock self-deadlocks and
+	// hangs every subsequent turn. (The startup path in New() enables tools
+	// before any lock is held, which is why only this lazy onboarding-completion
+	// path hit the deadlock — and why restarting the server worked around it.)
+	if enableTools {
 		s.enableSubAgentTools()
 	}
 	return nil

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -488,6 +488,63 @@ func (s *recordingSender) StreamMessagesWithTools(_ context.Context, _, _ string
 	return agent.Reply{Content: "ok"}, nil
 }
 
+// TestEnsureSender_LazyInitDoesNotDeadlock guards the onboarding-completion
+// path: a server that booted without a key (sender nil) builds the sender on
+// the first turn via ensureSender. ensureSender holds senderMu while it sets
+// the sender, then enables the sub-agent tools — and enableSubAgentTools reads
+// the default sender back through defaultSenderAndModel, which also takes
+// senderMu. Because senderMu is not reentrant, doing that work while still
+// holding the lock self-deadlocks and hangs every subsequent turn (only the
+// lazy path; New() enables tools before locking, which is why restarting the
+// server worked around it). This test fails (times out) if the lock is held
+// across enableSubAgentTools again.
+func TestEnsureSender_LazyInitDoesNotDeadlock(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("OPENAI_API_KEY", "")
+
+	// Boot with no config → onboarding mode (sender nil), tools enabled so the
+	// ensureSender path reaches enableSubAgentTools.
+	srv, err := New(Config{Addr: "127.0.0.1:0", Tools: true, NoChannel: true, NoMemory: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if srv.getSender() != nil {
+		t.Fatal("expected nil sender on keyless start (onboarding mode)")
+	}
+
+	// Simulate onboard saving a keyed model, the way the setup form does.
+	cfgPath := filepath.Join(tmp, ".octo", "config.yml")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgYAML := "models:\n" +
+		"  - name: t\n" +
+		"    provider: openai\n" +
+		"    model: gpt-test\n" +
+		"    base_url: http://127.0.0.1:1/v1\n" +
+		"    api_key: sk-test\n" +
+		"default_model: t\n"
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- srv.ensureSender() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ensureSender: %v", err)
+		}
+		if srv.getSender() == nil {
+			t.Fatal("sender still nil after ensureSender")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ensureSender deadlocked (senderMu held across enableSubAgentTools)")
+	}
+}
+
 // ─── New API tests ──────────────────────────────────────────────────────────
 
 func TestHandleOnboardStatus(t *testing.T) {


### PR DESCRIPTION
## Symptom

After completing first-run onboarding in the Web UI (server booted **without** a key), the auto-sent `/onboard` — and in fact **every** message, even a plain "hi" — produced no response: status stuck on Idle, the WS turn never replies. **Restarting `octo serve` made it work again.** User-confirmed reproduction and fix.

## Root cause: `senderMu` self-deadlock

`octo serve` with no key starts in onboarding mode (nil sender); the sender is built lazily on the first turn in `ensureSender`. That path did:

```go
s.senderMu.Lock()
defer s.senderMu.Unlock()                    // holds senderMu
...
if s.cfg.Tools { s.enableSubAgentTools() }   // → defaultSenderAndModel → s.senderMu.Lock() AGAIN
```

`defaultSenderAndModel` takes `senderMu`, which `ensureSender` already holds. Go mutexes aren't reentrant → **permanent self-deadlock**, hanging that turn and every turn after it. Goroutine dump (`SIGQUIT`) of a reproduced hang:

```
goroutine [sync.Mutex.Lock]:
server.(*Server).defaultSenderAndModel
server.(*Server).enableSubAgentTools
server.(*Server).ensureSender
server.(*Server).handleCreateChat
```

`New()` calls `enableSubAgentTools()` *before* taking any lock, which is exactly why **restarting** (boot with the key present → non-lazy path) worked around it.

## Fix

In `ensureSender`, set the sender fields under the lock, **release it**, then enable the sub-agent tools. Those process-global managers are only fallback sentinels (every turn stamps its own ctx-scoped manager in `prepareToolTurn`), so enabling them just after the unlock is safe.

`TestEnsureSender_LazyInitDoesNotDeadlock` drives keyless-start → save-model → `ensureSender` and times out if the lock is held across `enableSubAgentTools` (fails on the old code, passes on the fix).

## Verification

Isolated repro (keyless start → save model → `/api/chat`):

| | before | after |
|---|---|---|
| turn | `HTTP 000`, **40s hang** | `HTTP 500`, **0.4s** (reaches provider; 401 only because the repro used a dummy key) |

`go test ./internal/server/` green; `gofmt`/`vet` clean.

## Context

Follow-up to #936, whose squash-merge captured only its first commit (the `ask_user_question` allow-list); this deadlock fix was pushed to that branch *after* auto-merge had already fired, so it never reached main. This PR carries it on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)