### PR TITLE
fix(browser): open our own tab, never hijack the user's existing tab

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -91,6 +91,11 @@ func dial(ctx context.Context, wsURL string) (*cdpClient, error) {
 	return newCDPClient(conn), nil
 }
 
+// OwnsProcess reports whether this process launched the Chrome (true) or merely
+// attached to an already-running one (false). Callers use it to decide whether
+// teardown may kill the browser or must only close the tabs it opened.
+func (b *Browser) OwnsProcess() bool { return b.ownsProcess }
+
 // Close tears down the connection and, if this process launched Chrome, the
 // Chrome process too.
 func (b *Browser) Close() error {

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -480,3 +480,49 @@ func TestPrimitives(t *testing.T) {
 		t.Fatalf("key: %v", err)
 	}
 }
+
+// TestNewPageLeavesOtherTabsUntouched locks the invariant the browser tool
+// relies on: octo opens its own tab and never disturbs tabs the user already
+// has open. Regression guard for the bug where attaching to a running Chrome
+// hijacked pages[0] (the octo web UI itself) and navigated it away.
+func TestNewPageLeavesOtherTabsUntouched(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	b := newBrowser(t, ctx)
+	defer b.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte("<!doctype html><html><head><title>t</title></head><body>" + r.URL.Path + "</body></html>"))
+	}))
+	defer srv.Close()
+
+	// The user's tab, sitting on /user.
+	userPage, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("user page: %v", err)
+	}
+	if err := userPage.Navigate(ctx, srv.URL+"/user"); err != nil {
+		t.Fatalf("navigate user: %v", err)
+	}
+
+	// octo's own tab, driven to /octo — must not affect the user's tab.
+	octoPage, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("octo page: %v", err)
+	}
+	if octoPage.TargetID() == userPage.TargetID() {
+		t.Fatal("octo reused the user's tab instead of opening its own")
+	}
+	if err := octoPage.Navigate(ctx, srv.URL+"/octo"); err != nil {
+		t.Fatalf("navigate octo: %v", err)
+	}
+
+	var userPath string
+	if err := userPage.Eval(ctx, "location.pathname", &userPath); err != nil {
+		t.Fatalf("eval user path: %v", err)
+	}
+	if userPath != "/user" {
+		t.Errorf("user tab was disturbed: pathname = %q, want /user", userPath)
+	}
+}

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -71,11 +71,21 @@ func browserSkillsDir() string {
 func ResetBrowserSession() {
 	browserSession.mu.Lock()
 	b := browserSession.b
+	p := browserSession.page
 	browserSession.b, browserSession.page = nil, nil
 	browserSession.mu.Unlock()
-	if b != nil {
-		b.Close()
+	if b == nil {
+		return
 	}
+	// When we attached to the user's own Chrome, Close() only drops the WS and
+	// leaves our tab behind. Close the tab we opened so we don't litter the
+	// user's browser; if we launched Chrome ourselves, Close() kills it whole.
+	if !b.OwnsProcess() && p != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = b.ClosePage(ctx, p.TargetID())
+		cancel()
+	}
+	b.Close()
 }
 
 // browserEnabled gates the tool: advertised only when a Chrome can be located
@@ -130,17 +140,16 @@ func browserPage(ctx context.Context) (*browser.Page, *browser.Browser, error) {
 		}
 	}
 
-	// Prefer an already-open tab (the user's logged-in page) when attaching;
-	// otherwise open a blank one.
-	var page *browser.Page
-	if pages, perr := b.Pages(ctx); perr == nil && len(pages) > 0 {
-		page, err = b.AttachPage(ctx, pages[0].TargetID)
-	} else {
-		page, err = b.NewPage(ctx, "about:blank")
-	}
+	// Always open our own fresh tab — never hijack a tab the user already has
+	// open. When attached to the user's real Chrome, pages[0] could be anything
+	// they're using (including the octo web UI itself), and navigating it away
+	// would clobber their session. Cookies/login are profile-wide, so a new tab
+	// still carries the logged-in session. To drive an existing tab, the model
+	// uses the pages/select_page actions explicitly.
+	page, err := b.NewPage(ctx, "about:blank")
 	if err != nil {
 		b.Close()
-		return nil, nil, fmt.Errorf("attach page: %w", err)
+		return nil, nil, fmt.Errorf("open page: %w", err)
 	}
 	browserSession.b, browserSession.page = b, page
 	return page, b, nil


### PR DESCRIPTION
## Bug

With the browser tool attached to the user's running Chrome (the default since the parity work), the first `navigate` **replaced the user's current tab** instead of opening a new one — and when that tab was the **octo web UI** (same browser), the UI vanished mid-session.

Root cause: `browserPage` did `AttachPage(pages[0])` on connect — grabbing the user's *first existing tab* — then drove it away on the first navigation.

## Fix

- **Always open octo's own fresh tab** (`NewPage`) instead of attaching `pages[0]`. Cookies/login are profile-wide, so a new tab in the attached Chrome still has the logged-in session. To act on an existing tab, the model uses the `pages`/`select_page` actions explicitly.
- **Close that tab on session end when attached.** For an attached browser, `Close()` only drops the WS (it can't kill a browser it doesn't own), so octo's tab would otherwise linger. Added `Browser.OwnsProcess()` to gate the cleanup; a launched (owned) browser is still killed wholesale.

## Test

`TestNewPageLeavesOtherTabsUntouched`: open a "user" tab on `/user`, then open octo's tab and navigate it to `/octo`; assert the user tab's pathname is still `/user` and the target IDs differ. Real headless Chrome (skips when absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)