### PR TITLE
fix(openai): tool-result images go on a trailing user message (browser observe on qwen)

### DIFF
--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -405,10 +405,12 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 		// role="user" message AFTER the tool outputs, which is the OpenAI-shaped
 		// equivalent of Anthropic's [tool_result…, text] user message.
 		//
-		// Image blocks following a tool_result are nested INTO that tool message's
-		// content array (OpenAI vision format). This preserves the tool_result/
-		// image association required by the API — without nesting, images between
-		// two tool_results would break the tool_call_id pairing.
+		// Image blocks (following a tool_result or standalone) become image_url
+		// parts on a single trailing role="user" message — a role="tool" message
+		// can't carry image content in the OpenAI protocol (DashScope rejects it
+		// with "Unexpected item type in content", and real OpenAI ignores it).
+		// Deferring images past all tool outputs keeps the tool_call→tool_result
+		// messages contiguous, which the API requires.
 		if m.Role == agent.RoleUser && len(m.Blocks) > 0 {
 			var steerText strings.Builder
 			var userImageParts []apiContentPart
@@ -417,37 +419,12 @@ func toAPIMessages(systemPrompt string, in []agent.Message) ([]apiMessage, error
 				b := m.Blocks[i]
 				switch b.Type {
 				case "tool_result":
-					// Collect following image blocks to nest inside this tool
-					// message's content. Text blocks are NOT nested — they become
-					// separate steer user messages after all tool outputs.
-					var imageParts []apiContentPart
-					j := i + 1
-					for j < len(m.Blocks) && m.Blocks[j].Type == "image" {
-						if m.Blocks[j].Image != nil {
-							dataURL := fmt.Sprintf("data:%s;base64,%s", m.Blocks[j].Image.MIMEType, base64.StdEncoding.EncodeToString(m.Blocks[j].Image.Data))
-							imageParts = append(imageParts, apiContentPart{
-								Type: "image_url",
-								ImageURL: &struct {
-									URL string `json:"url"`
-								}{URL: dataURL},
-							})
-						}
-						j++
-					}
-					msg := apiMessage{Role: "tool", ToolCallID: b.ToolUseID}
-					if len(imageParts) > 0 {
-						// Nest text + images into content array for vision support.
-						parts := make([]apiContentPart, 0, 1+len(imageParts))
-						if b.Result != "" {
-							parts = append(parts, apiContentPart{Type: "text", Text: b.Result})
-						}
-						parts = append(parts, imageParts...)
-						msg.ContentParts = parts
-					} else {
-						msg.Content = b.Result
-					}
-					out = append(out, msg)
-					i = j
+					// Tool messages carry STRING content only. Any image blocks the
+					// tool produced fall through to the "image" case below and are
+					// emitted as a trailing role="user" message — nesting an image
+					// part into a role="tool" message is rejected by the protocol.
+					out = append(out, apiMessage{Role: "tool", ToolCallID: b.ToolUseID, Content: b.Result})
+					i++
 				case "text":
 					if steerText.Len() > 0 {
 						steerText.WriteString("\n\n")

--- a/internal/provider/openai/tools_test.go
+++ b/internal/provider/openai/tools_test.go
@@ -434,29 +434,30 @@ func TestSend_ImageBlock_WireFormat(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 
-	// user, assistant(tool_call), tool(result with nested [text, image_url])
-	if len(wireReq.Messages) != 3 {
-		t.Fatalf("messages len = %d, want 3: %s", len(wireReq.Messages), capturedBody)
+	// user, assistant(tool_call), tool(result as STRING), user(image_url part).
+	// The image can't ride on the role="tool" message (the protocol rejects an
+	// image part there), so it lands on a separate trailing user message.
+	if len(wireReq.Messages) != 4 {
+		t.Fatalf("messages len = %d, want 4: %s", len(wireReq.Messages), capturedBody)
 	}
-	// msg[2] = tool result with nested content array
+	// msg[2] = tool result, string content (no nested array).
 	if wireReq.Messages[2].Role != "tool" || wireReq.Messages[2].ToolCallID != "call-1" {
 		t.Errorf("msg[2] = %+v, want tool/call-1", wireReq.Messages[2])
 	}
-	// Content should be an array with text + image_url parts.
-	parts, ok := wireReq.Messages[2].Content.([]any)
-	if !ok {
-		t.Fatalf("msg[2].content = %T, want []any (nested content array)", wireReq.Messages[2].Content)
+	if _, isStr := wireReq.Messages[2].Content.(string); !isStr {
+		t.Errorf("msg[2].content = %T, want string (tool messages can't carry images)", wireReq.Messages[2].Content)
 	}
-	if len(parts) != 2 {
-		t.Fatalf("content parts len = %d, want 2 (text + image_url)", len(parts))
+	// msg[3] = user message carrying the image as an image_url content part.
+	if wireReq.Messages[3].Role != "user" {
+		t.Fatalf("msg[3].role = %q, want user", wireReq.Messages[3].Role)
 	}
-	textPart, _ := parts[0].(map[string]any)
-	if textPart["type"] != "text" {
-		t.Errorf("parts[0].type = %v, want text", textPart["type"])
+	parts, ok := wireReq.Messages[3].Content.([]any)
+	if !ok || len(parts) != 1 {
+		t.Fatalf("msg[3].content = %T (len check), want []any with 1 image part: %s", wireReq.Messages[3].Content, capturedBody)
 	}
-	imgPart, _ := parts[1].(map[string]any)
+	imgPart, _ := parts[0].(map[string]any)
 	if imgPart["type"] != "image_url" {
-		t.Errorf("parts[1].type = %v, want image_url", imgPart["type"])
+		t.Errorf("parts[0].type = %v, want image_url", imgPart["type"])
 	}
 	imgURL, _ := imgPart["image_url"].(map[string]any)
 	url, _ := imgURL["url"].(string)


### PR DESCRIPTION
## Bug

`browser observe` / `screenshot` failed on OpenAI-protocol providers (qwen3.7-max via DashScope) with:

```
HTTP 400 (invalid_request_error): InternalError.Algo.InvalidParameter:
The provided messages input is invalid. The error info is [Unexpected item type in content.].
```

Those actions return a vision **image block** (added in the browser-parity work). The OpenAI adapter was nesting the `image_url` part **into the `role="tool"` message's content array** — but a tool message can't carry image content in the OpenAI protocol. DashScope rejects it with the 400 above; real OpenAI ignores it.

## Fix

Route tool-result images through the **same trailing `role="user"` message** the adapter already uses for standalone images and steer text:
- the `role="tool"` message carries **string** content (the tool's text);
- any images it produced follow on a `role="user"` message with `image_url` parts.

`tool_call → tool_result` messages stay contiguous (the API requires it); only the per-tool image association is dropped, which is fine for vision. This is the OpenAI-shaped equivalent of Anthropic's `[tool_result, image]`.

## Test

`TestSend_ImageBlock_WireFormat` now asserts the 4-message shape (user / assistant-tool_call / tool-string / user-image) — its own doc comment already described this; the old assertions tested the (buggy) nesting.

## Note

"Unexpected item type" is a *format* rejection, not a capability one ("vision not supported"), so qwen3.7-max should accept the user-message image and `observe` should now work. If a non-vision model is used, it'll return a clearer capability error — octo has no per-model vision flag to gate on yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)