### PR TITLE
feat(browser): observe is text-only; vision decoupled into screenshot

### DIFF
--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -172,7 +172,7 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 				"action": map[string]any{
 					"type":        "string",
 					"enum":        []string{"navigate", "back", "click", "hover", "type", "select", "key", "scroll", "wait", "screenshot", "observe", "ax", "cookies", "upload", "download", "pages", "select_page", "close", "eval", "record_start", "record_stop", "run_skill"},
-					"description": "The browser action to perform. observe returns a screenshot the model can see plus a list of the page's interactable elements with selectors — the way to look at an unfamiliar page before acting. cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture a demonstration into an editable skill; run_skill replays one (deterministic, self-healing).",
+					"description": "The browser action to perform. observe lists the page's URL/title and interactable elements with selectors (text only) — the cheap way to look at an unfamiliar page before acting; works on any model. screenshot returns an image of the page for a vision-capable model to actually see (use when content is visual). cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture a demonstration into an editable skill; run_skill replays one (deterministic, self-healing).",
 				},
 				"name":       map[string]any{"type": "string", "description": "Skill name (record_stop / run_skill)."},
 				"params":     map[string]any{"type": "object", "description": "Param values for {{...}} placeholders (run_skill)."},
@@ -308,18 +308,22 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		}, nil
 
 	case "observe":
-		// "Look at this page": a screenshot the model can see + the interactable
-		// elements with selectors. This is the see-before-you-act primitive that
-		// keeps exploratory navigation from thrashing on unfamiliar pages.
-		shot, err := page.Screenshot(ctx)
-		if err != nil {
-			return agent.ToolResult{}, err
-		}
+		// Text-only "look at this page": the current URL/title + the page's
+		// interactable elements with selectors. This is the see-before-you-act
+		// primitive and works on any model. Vision is decoupled — call screenshot
+		// to actually see pixels (and only a multimodal model can use that).
 		frame := getStr(input, "frame")
+		var meta struct {
+			URL   string `json:"url"`
+			Title string `json:"title"`
+		}
+		_ = page.Eval(ctx, `({url: location.href, title: document.title})`, &meta)
 		digest, derr := browser.InteractiveDigest(ctx, page, frame, 60)
 		var sb strings.Builder
-		path := saveScreenshot(shot)
-		fmt.Fprintf(&sb, "screenshot saved to %s\n\ninteractable elements:\n", path)
+		if meta.URL != "" {
+			fmt.Fprintf(&sb, "page: %s — %s\n\n", meta.Title, meta.URL)
+		}
+		sb.WriteString("interactable elements:\n")
 		if derr != nil {
 			fmt.Fprintf(&sb, "(could not read elements: %v)\n", derr)
 		} else if len(digest) == 0 {
@@ -333,10 +337,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 				}
 			}
 		}
-		return agent.ToolResult{
-			Text:   sb.String(),
-			Blocks: []agent.ContentBlock{agent.NewImageBlock("image/png", shot)},
-		}, nil
+		return agent.ToolResult{Text: sb.String()}, nil
 
 	case "ax":
 		raw, err := page.AXTree(ctx)

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -203,9 +203,9 @@ func TestBrowserTool_CookiesIncludesHttpOnly(t *testing.T) {
 	}
 }
 
-// TestBrowserTool_ObserveAndScreenshotVision checks that screenshot and observe
-// hand the model an actual image block (not just a file path), and that observe
-// also lists the page's interactable elements with selectors.
+// TestBrowserTool_ObserveAndScreenshotVision checks the decoupling: screenshot
+// returns a vision image block, while observe is text-only (URL/title + the
+// interactable elements with selectors) so it works on any model.
 func TestBrowserTool_ObserveAndScreenshotVision(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60_000_000_000) // 60s
 	defer cancel()
@@ -254,8 +254,9 @@ func TestBrowserTool_ObserveAndScreenshotVision(t *testing.T) {
 	if err != nil {
 		t.Fatalf("observe: %v", err)
 	}
-	if !hasImage(obs) {
-		t.Errorf("observe returned no image block; blocks=%d", len(obs.Blocks))
+	// observe is text-only — no image block (it must work on non-vision models).
+	if hasImage(obs) {
+		t.Errorf("observe should not return an image block (vision is decoupled to screenshot)")
 	}
 	// The fixture's #search button must surface in the interactable digest.
 	if !strings.Contains(obs.Text, "#search") {


### PR DESCRIPTION
## Why

`observe` bundled a vision **image block** on every call. That forced an image onto every look-at-the-page step — expensive in tokens, unusable on non-vision models, and the source of the cross-provider format friction (#940). Vision isn't required to *drive* a browser: the interactable-element digest + `eval`/`ax` is the workhorse and works on **any** model.

## What

- **`observe` is now text-only**: the current URL/title + the page's interactable elements with selectors. The cheap, universal see-before-act primitive.
- **Vision is opt-in via `screenshot`** (unchanged — still returns an image block). The model calls it only when content is genuinely visual, and only a multimodal model can use it.

Net effect: image is never forced; it's requested explicitly when wanted.

## Test

`TestBrowserTool_ObserveAndScreenshotVision` now asserts `screenshot` returns an image block while `observe` returns **no** image (and still surfaces the fixture's `#search` selector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)