### PR TITLE
fix(server): serialize interactive prompts per session (concurrent-ask hang)

### DIFF
--- a/internal/server/pending_prompt_test.go
+++ b/internal/server/pending_prompt_test.go
@@ -106,3 +106,76 @@ func TestWSAsker_RegistersAndClearsPendingQuestion(t *testing.T) {
 		t.Fatal("pending question not cleared after answer")
 	}
 }
+
+// TestAcquireAskSlot_Serializes is the regression guard for the concurrent-
+// prompt clobber: two askers for the same session must not both hold the slot,
+// so a parallel workflow agent / background task can't overwrite an in-flight
+// prompt's pending slot and frontend modal (orphaning the first asker until its
+// timeout — a hang).
+func TestAcquireAskSlot_Serializes(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	const sid = "serialize-session"
+
+	rel1, err := srv.acquireAskSlot(context.Background(), sid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	acquired := make(chan struct{})
+	go func() {
+		rel2, err := srv.acquireAskSlot(context.Background(), sid)
+		if err == nil {
+			rel2()
+		}
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second acquire returned while the slot was still held")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	rel1()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("second acquire never proceeded after release")
+	}
+}
+
+// Serialization is per-session: a different session has an independent slot.
+func TestAcquireAskSlot_PerSession(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	rel1, err := srv.acquireAskSlot(context.Background(), "sess-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rel1()
+
+	rel2, err := srv.acquireAskSlot(context.Background(), "sess-b")
+	if err != nil {
+		t.Fatalf("a different session must not block on a held slot: %v", err)
+	}
+	rel2()
+}
+
+// A cancelled ctx returns an error instead of waiting behind a held slot, so a
+// cancelled turn doesn't block until the prompt's own timeout.
+func TestAcquireAskSlot_CtxCancel(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	const sid = "cancel-session"
+
+	rel1, err := srv.acquireAskSlot(context.Background(), sid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rel1()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := srv.acquireAskSlot(ctx, sid); err == nil {
+		t.Fatal("cancelled ctx should not acquire a held slot")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -185,6 +185,16 @@ type Server struct {
 	pendingConfirms  map[string]wsEventRequestConfirmation
 	pendingPromptMu  sync.Mutex
 
+	// askSlots serializes interactive prompts per session: at most one
+	// confirmation or question may be outstanding at a time. Concurrent askers
+	// for the same session — parallel workflow agents, background tasks, all
+	// sharing the session's gate — would otherwise each broadcast a prompt and
+	// clobber the single pending* slot and the single frontend modal; only the
+	// last is answerable, and every earlier asker's goroutine blocks until its
+	// timeout (a hang). Each value is a cap-1 channel used as a lock.
+	askSlots   map[string]chan struct{}
+	askSlotsMu sync.Mutex
+
 	// live state tracking per session for WS replay on subscribe.
 	liveStates  map[string]*sessionLiveState
 	liveStateMu sync.RWMutex
@@ -332,6 +342,7 @@ func New(cfg Config) (*Server, error) {
 		questionChans:       make(map[string]chan tools.AskResponse),
 		pendingQuestions:    make(map[string]wsEventRequestUserQuestion),
 		pendingConfirms:     make(map[string]wsEventRequestConfirmation),
+		askSlots:            make(map[string]chan struct{}),
 		sessionInjectors:    make(map[string]*memory.Injector),
 	}
 
@@ -692,6 +703,10 @@ func (s *Server) forgetTurnLock(id string) {
 	s.entryBindingsMu.Lock()
 	delete(s.entryBindings, id)
 	s.entryBindingsMu.Unlock()
+
+	s.askSlotsMu.Lock()
+	delete(s.askSlots, id)
+	s.askSlotsMu.Unlock()
 }
 
 // cachedEntryBinding is a short-lease, in-process cache of a session's binding.
@@ -1323,6 +1338,15 @@ func (a wsAsker) Ask(ctx context.Context, q tools.AskRequest) (tools.AskResponse
 	if !ok || sessionID == "" {
 		return tools.AskResponse{}, fmt.Errorf("ask_user_question: no active WebSocket session")
 	}
+
+	// Serialize against other interactive prompts for this session (the same
+	// slot requestConfirmation uses) so concurrent askers don't clobber the
+	// single pending slot / frontend modal.
+	release, err := a.s.acquireAskSlot(ctx, sessionID)
+	if err != nil {
+		return tools.AskResponse{Cancelled: true}, nil
+	}
+	defer release()
 
 	qid := fmt.Sprintf("q_%d", time.Now().UnixNano())
 	ch := make(chan tools.AskResponse, 1)

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1520,9 +1520,40 @@ func (s *Server) sessionStatus(sessionID string) string {
 	return "idle"
 }
 
+// acquireAskSlot blocks until this session's interactive-prompt slot is free,
+// then returns a release func. Only one confirmation or question is outstanding
+// per session at a time, so concurrent askers queue instead of clobbering each
+// other (see Server.askSlots). It respects ctx cancellation so a cancelled turn
+// doesn't wait behind a prompt that may sit until its timeout.
+func (s *Server) acquireAskSlot(ctx context.Context, sessionID string) (func(), error) {
+	s.askSlotsMu.Lock()
+	if s.askSlots == nil {
+		s.askSlots = make(map[string]chan struct{})
+	}
+	sem, ok := s.askSlots[sessionID]
+	if !ok {
+		sem = make(chan struct{}, 1)
+		s.askSlots[sessionID] = sem
+	}
+	s.askSlotsMu.Unlock()
+
+	select {
+	case sem <- struct{}{}:
+		return func() { <-sem }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 // Request confirmation from user (blocks until user responds in browser or ctx
 // is cancelled).
 func (s *Server) requestConfirmation(ctx context.Context, sessionID, message, kind string) (string, error) {
+	release, err := s.acquireAskSlot(ctx, sessionID)
+	if err != nil {
+		return "", fmt.Errorf("confirmation cancelled")
+	}
+	defer release()
+
 	confID := fmt.Sprintf("conf_%d", time.Now().UnixNano())
 	ch := make(chan string, 1)
 


### PR DESCRIPTION
## Problem

When multiple askers for the **same session** prompt at once, only the last prompt is answerable; every earlier asker's goroutine blocks until its 5-minute timeout — a hang.

Interactive prompts record a **single pending slot per session** (`pendingQuestions` / `pendingConfirms`) and the frontend renders a **single modal store**. Concurrent prompts clobber that slot, so the earlier ones are orphaned.

### Where the concurrency comes from
- `workflow`'s `parallel()` / `pipeline()` spawn multiple agents concurrently, all sharing the session's gate.
- Background tasks (`TaskCreate`) run concurrently with the main turn under the same session id.

Sub-agents on the server run **synchronously** (`SetSynchronous(true)`) and are already serial, so they were never a source. A single assistant message with multiple tool_use blocks is also serial (the gate runs serially in `dispatchTools`).

## Fix

A **per-session slot** — a cap-1 channel used as a lock. `acquireAskSlot` is taken at the top of `requestConfirmation` and `wsAsker.Ask` and released when the prompt resolves, so at most one confirmation/question is outstanding per session and concurrent prompts **queue** instead of overwriting each other. The acquire respects `ctx` cancellation so a cancelled turn doesn't wait behind a prompt sitting until its timeout. The slot map is cleaned up in `forgetTurnLock`. **No frontend change.**

## Verification

- New tests (`-race`): `TestAcquireAskSlot_Serializes` (second acquire blocks until release), `_PerSession` (independent per session), `_CtxCancel` (cancel returns instead of waiting).
- `go test ./internal/server/` green; `go vet`, `gofmt -l`, `go build ./...` clean.

## Related
Companion to #942 (confirm-result wire fix) — that fixed the serial-path "Allow → deny" loop; this fixes the genuinely-concurrent clobber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)