### PR TITLE
feat(browser): per-model vision flag; screenshot degrades on text-only models

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/config"
 	"github.com/Leihb/octo-agent/internal/tasks"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
@@ -41,11 +42,18 @@ func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
 	tools.SetBrowserSkillGenerator(makeSkillGenerator(a.Sender, a.Model))
 	tools.SetBrowserHealer(makeBrowserHealer(a.Sender, a.Model))
 
+	// Gate image content (browser screenshots) on the active model's vision
+	// capability so a text-only model isn't handed images its endpoint rejects.
+	if cfg, err := config.Load(); err == nil {
+		tools.SetBrowserVision(cfg.ModelVision(a.Model))
+	}
+
 	cleanup := func() {
 		tools.SetDefaultSubAgentManager(nil)
 		tools.SetSpawner(nil)
 		tools.SetBrowserSkillGenerator(nil)
 		tools.SetBrowserHealer(nil)
+		tools.SetBrowserVision(true)
 		tools.ResetBrowserSession()
 	}
 	if enableTasks {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,11 @@ type ModelEntry struct {
 	// streamed to the terminal (dimmed). nil means the built-in default
 	// (enabled).
 	ShowReasoning *bool `yaml:"show_reasoning,omitempty"`
+	// Vision controls whether tools may hand this model images (e.g. the
+	// browser tool's screenshot). nil means the built-in default (enabled).
+	// Set false for text-only models (e.g. qwen-max, as opposed to qwen-vl)
+	// so image content isn't sent and rejected.
+	Vision *bool `yaml:"vision,omitempty"`
 }
 
 // Config is the persisted set of CLI defaults. Every field is optional; a
@@ -123,6 +128,22 @@ func (c Config) EffectiveShowReasoning(entry *bool) bool {
 	}
 	if c.ShowReasoning != nil {
 		return *c.ShowReasoning
+	}
+	return true
+}
+
+// ModelVision reports whether the named model accepts image content. name is
+// matched against each entry's Name or Model; an entry's explicit Vision wins,
+// otherwise the default is true (assume vision-capable). Unknown models also
+// default to true — only an explicit `vision: false` opts out.
+func (c Config) ModelVision(name string) bool {
+	for _, m := range c.Models {
+		if m.Name == name || m.Model == name {
+			if m.Vision != nil {
+				return *m.Vision
+			}
+			return true
+		}
 	}
 	return true
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -214,3 +214,25 @@ func TestEntryByName_EmptyNeverMatches(t *testing.T) {
 		t.Error("EntryByName(\"\") matched, want no match")
 	}
 }
+
+func TestModelVision(t *testing.T) {
+	yes, no := true, false
+	c := Config{Models: []ModelEntry{
+		{Name: "vl", Model: "qwen-vl-max", Vision: &yes},
+		{Name: "txt", Model: "qwen3.7-max", Vision: &no},
+		{Name: "unset", Model: "claude"},
+	}}
+	cases := map[string]bool{
+		"vl":          true,  // explicit true (by Name)
+		"qwen-vl-max": true,  // explicit true (by Model id)
+		"txt":         false, // explicit false (by Name)
+		"qwen3.7-max": false, // explicit false (by Model id)
+		"unset":       true,  // no flag → default true
+		"not-in-list": true,  // unknown → default true
+	}
+	for name, want := range cases {
+		if got := c.ModelVision(name); got != want {
+			t.Errorf("ModelVision(%q) = %v, want %v", name, got, want)
+		}
+	}
+}

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -43,6 +43,15 @@ var (
 	browserSkillGen  browser.SkillGenerator
 )
 
+// browserVision gates whether the browser tool hands the model images. Default
+// true (vision-capable); app.WireTools sets it from the active model's config
+// so a text-only model (e.g. qwen-max) gets a text note instead of an image
+// content block that its endpoint would reject.
+var browserVision = func() *atomic.Bool { b := &atomic.Bool{}; b.Store(true); return b }()
+
+// SetBrowserVision enables/disables handing images to the model.
+func SetBrowserVision(on bool) { browserVision.Store(on) }
+
 // SetBrowserHealer injects the LLM-backed step healer used by run_skill.
 func SetBrowserHealer(h browser.Healer) {
 	recorderMu.Lock()
@@ -300,6 +309,11 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 			return agent.ToolResult{}, err
 		}
 		path := saveScreenshot(shot)
+		if !browserVision.Load() {
+			// Text-only model: handing it an image block would be rejected by the
+			// endpoint. Return the path and steer the model to the text channels.
+			return agent.ToolResult{Text: "screenshot saved to " + path + " (the current model can't view images — use observe/eval/ax to read the page instead)"}, nil
+		}
 		// Return the image as a vision block so the model actually sees the page
 		// (not just a file path), and keep the on-disk copy for artifacts.
 		return agent.ToolResult{

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -262,4 +262,19 @@ func TestBrowserTool_ObserveAndScreenshotVision(t *testing.T) {
 	if !strings.Contains(obs.Text, "#search") {
 		t.Errorf("observe text missing #search selector; got:\n%s", obs.Text)
 	}
+
+	// With vision disabled (text-only model), screenshot must degrade to a
+	// text note and NOT attach an image block the endpoint would reject.
+	SetBrowserVision(false)
+	defer SetBrowserVision(true)
+	noVis, err := tool.Execute(ctx, "browser", map[string]any{"action": "screenshot"})
+	if err != nil {
+		t.Fatalf("screenshot (vision off): %v", err)
+	}
+	if hasImage(noVis) {
+		t.Errorf("screenshot returned an image block while vision is disabled")
+	}
+	if !strings.Contains(noVis.Text, "saved to") {
+		t.Errorf("screenshot (vision off) should still report the saved path; got: %q", noVis.Text)
+	}
 }


### PR DESCRIPTION
## Bug

`browser screenshot` failed on qwen3.7-max with HTTP 400 `Unexpected item type in content`. qwen-**max** is text-only (vision is qwen-**vl**), so its endpoint rejects the image content the screenshot action returns — even as a user-message `image_url` (so #940's format fix wasn't enough; this is a *capability* limit, not format). The model autonomously picks `screenshot` to "look", and breaks the turn.

## Fix

A **per-model vision flag** — vision is a model property, so it switches automatically when you change models:

- `ModelEntry.Vision *bool` (nil = default on) + `Config.ModelVision(name)`, matched by entry `Name` or `Model`.
- `WireTools` resolves the active model's flag → `tools.SetBrowserVision(...)`.
- When **off**, `screenshot` saves the file and returns a **text note** (no image block), steering the model to `observe`/`eval`/`ax`. No image is ever sent → no 400.
- Default stays **on**, so Claude / GPT / qwen-vl are unaffected.

Config:
```yaml
models:
  - name: qwen3.7-max
    vision: false
```

## Tests

- `TestModelVision` — explicit true/false by Name and Model id; unset and unknown default to true.
- `TestBrowserTool_ObserveAndScreenshotVision` — with vision off, `screenshot` returns no image block but still reports the saved path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)