### PR TITLE
feat(config): infer vision from model id + track auto-derived name on model change

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,15 +134,37 @@ func (c Config) EffectiveShowReasoning(entry *bool) bool {
 
 // ModelVision reports whether the named model accepts image content. name is
 // matched against each entry's Name or Model; an entry's explicit Vision wins,
-// otherwise the default is true (assume vision-capable). Unknown models also
-// default to true — only an explicit `vision: false` opts out.
+// otherwise the capability is inferred from the model id (ModelSupportsVision)
+// so it tracks the model automatically. Unmatched names fall back to the same
+// inference.
 func (c Config) ModelVision(name string) bool {
 	for _, m := range c.Models {
 		if m.Name == name || m.Model == name {
 			if m.Vision != nil {
 				return *m.Vision
 			}
+			return ModelSupportsVision(m.Model)
+		}
+	}
+	return ModelSupportsVision(name)
+}
+
+// ModelSupportsVision is a best-effort guess at whether a model id accepts
+// image input, used when an entry doesn't set Vision explicitly so vision
+// tracks the model automatically. It errs toward true (most frontier chat
+// models are multimodal); only well-known text-only families return false. An
+// explicit vision marker (e.g. qwen-vl) wins over its text-only family. The
+// heuristic is necessarily incomplete — ModelEntry.Vision is the override.
+func ModelSupportsVision(model string) bool {
+	m := strings.ToLower(model)
+	for _, mark := range []string{"-vl", "vl-", "vision", "-omni", "gpt-4o", "gpt-4.1", "claude-3", "claude-4", "claude-opus", "claude-sonnet", "claude-haiku", "gemini", "pixtral", "llava", "internvl"} {
+		if strings.Contains(m, mark) {
 			return true
+		}
+	}
+	for _, textOnly := range []string{"qwen", "deepseek", "kimi", "moonshot", "baichuan", "ernie", "glm-", "spark", "abab", "yi-"} {
+		if strings.Contains(m, textOnly) {
+			return false
 		}
 	}
 	return true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -236,3 +236,42 @@ func TestModelVision(t *testing.T) {
 		}
 	}
 }
+
+func TestModelSupportsVision(t *testing.T) {
+	cases := map[string]bool{
+		"qwen3.7-max":       false, // text-only qwen
+		"qwen3.7-plus":      false,
+		"qwen-vl-max":       true, // vision marker wins over qwen family
+		"qwen-omni":         true,
+		"deepseek-chat":     false,
+		"gpt-4o":            true,
+		"gpt-4.1-mini":      true,
+		"claude-sonnet-4-6": true,
+		"gemini-2.0-flash":  true,
+		"o3":                true, // unknown family → default true
+		"some-new-llm":      true,
+	}
+	for model, want := range cases {
+		if got := ModelSupportsVision(model); got != want {
+			t.Errorf("ModelSupportsVision(%q) = %v, want %v", model, got, want)
+		}
+	}
+}
+
+func TestModelVision_HeuristicFallback(t *testing.T) {
+	no := false
+	c := Config{Models: []ModelEntry{
+		{Name: "qwen3.7-max", Model: "qwen3.7-plus"},        // no override → heuristic(false)
+		{Name: "vl", Model: "qwen-vl-max"},                  // no override → heuristic(true)
+		{Name: "forced", Model: "qwen-vl-max", Vision: &no}, // override beats heuristic
+	}}
+	if c.ModelVision("qwen3.7-max") != false {
+		t.Error("qwen3.7-plus entry should infer vision=false")
+	}
+	if c.ModelVision("vl") != true {
+		t.Error("qwen-vl-max entry should infer vision=true")
+	}
+	if c.ModelVision("forced") != false {
+		t.Error("explicit Vision override should win over heuristic")
+	}
+}

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -447,9 +447,24 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 	}
 
 	updated := false
+	newID := id
 	for i := range cfg.Models {
 		if cfg.Models[i].Name == id {
+			oldName, oldModel := cfg.Models[i].Name, cfg.Models[i].Model
 			applyModelRequestToEntry(req, &cfg.Models[i])
+			// If the name was auto-derived from the model (name == model), keep it
+			// tracking when the model changes, and repair the default/lite refs
+			// that pointed at the old name. A name the user set by hand stays put.
+			if oldName == oldModel && cfg.Models[i].Model != oldModel {
+				newID = cfg.UniqueName(cfg.Models[i].Model)
+				cfg.Models[i].Name = newID
+				if cfg.DefaultModel == oldName {
+					cfg.DefaultModel = newID
+				}
+				if cfg.LiteModel == oldName {
+					cfg.LiteModel = newID
+				}
+			}
 			updated = true
 			break
 		}
@@ -468,7 +483,9 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 	}
 	s.invalidateSenderCache()
 
-	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	// id may have changed if the auto-derived name tracked a new model — return
+	// it so the client can refresh its reference.
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": newID})
 }
 
 // handleDeleteModelConfig removes the entry named by {id} and repairs the

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -558,3 +558,34 @@ func TestBuildAgent_ImplicitLiteForBoundSession(t *testing.T) {
 		t.Error("bound session's implicit lite must reuse that session's sender")
 	}
 }
+
+// TestConfigModels_PatchRetracksAutoDerivedName: when an entry's name was
+// auto-derived from its model (name == model), changing the model re-derives
+// the name and repairs the default_model reference. A hand-set name stays put
+// (covered by TestConfigModels_PatchUpdatesAndKeepsKey, where name != model).
+func TestConfigModels_PatchRetracksAutoDerivedName(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Name: "qwen3.7-max", Provider: "openai", Model: "qwen3.7-max", APIKey: "sk-x"},
+		},
+		DefaultModel: "qwen3.7-max",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPatch, "/api/config/models/qwen3.7-max",
+		`{"model":"qwen3.7-plus","base_url":"","api_key":"sk-x****","provider":"openai"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH = %d: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	if _, ok := cfg.EntryByName("qwen3.7-plus"); !ok {
+		t.Fatalf("name should track new model qwen3.7-plus: %+v", cfg.Models)
+	}
+	if _, ok := cfg.EntryByName("qwen3.7-max"); ok {
+		t.Errorf("stale name qwen3.7-max should be gone")
+	}
+	if cfg.DefaultModel != "qwen3.7-plus" {
+		t.Errorf("default_model = %q, want qwen3.7-plus (repaired)", cfg.DefaultModel)
+	}
+}


### PR DESCRIPTION
Two model-config papercuts surfaced when switching models in the web UI.

## 1. vision should follow the model

`ModelVision` now infers capability from the model id via a new `ModelSupportsVision` heuristic when `ModelEntry.Vision` is unset — so changing the model auto-updates vision, no manual edit. An explicit `vision:` still overrides.

Heuristic (best-effort; override is the escape hatch): vision markers (`-vl`, `gpt-4o`, `claude-3/4`, `gemini`, `pixtral`, …) → true even within a text-only family; known text-only families (`qwen`-max/plus, `deepseek`, `kimi`, `glm-`, …) → false; everything else defaults to true (most frontier models are multimodal).

## 2. editing a model left the name stale

`handleUpdateModelConfig` previously changed only `e.Model`, so an entry created as `qwen3.7-max` kept that name after its model became `qwen3.7-plus`. Now, when the name was **auto-derived** (`name == old model`), it re-derives the name to track the new model and repairs the `default_model` / `lite_model` references. A name the user set by hand is left alone. The (possibly new) id is returned so the client can refresh its reference.

## Tests

- `TestModelSupportsVision` + `TestModelVision_HeuristicFallback` — marker/family/default cases; override wins.
- `TestConfigModels_PatchRetracksAutoDerivedName` — auto-derived name tracks the new model and `default_model` is repaired (and the existing keep-the-key test confirms a hand-set name stays put).

Backend-only; no web rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)