### PR TITLE
feat(loop): /loop skill + schedule_wakeup tool (CC loop 1:1)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -635,6 +635,11 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		// bubbletea owns stdin and renders its own input; the asker and gate
 		// are wired to the TUI sink inside runTUI.
 		defer tools.SetAsker(nil)
+		// The interactive TUI can re-enter a live session, so advertise the
+		// schedule_wakeup tool (the loop skill's mechanism). The headless
+		// one-shot below leaves it off — a process that exits after one turn
+		// has no session to wake.
+		tools.SetWakerSupported(true)
 	} else {
 		// A TTY reader (a positional message typed at a terminal) makes
 		// permission / Ask prompts interactive. Over a pipe stdin is already

--- a/cmd/octo/loop_test.go
+++ b/cmd/octo/loop_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// armWakeupMsg (posted by the schedule_wakeup tool) arms the loop timer.
+func TestTUI_ArmWakeup(t *testing.T) {
+	m := newTestModel()
+	m.Update(armWakeupMsg{delay: time.Hour, prompt: "tick", repeat: true})
+	if !m.loopActive || m.wakeupTimer == nil {
+		t.Fatal("armWakeupMsg should arm the loop")
+	}
+	m.cancelWakeup()
+}
+
+// An armed wakeup that fires while idle starts a fresh turn; dynamic mode
+// (repeat=false) clears the loop so the model must re-arm to continue.
+func TestTUI_WakeupIdleStartsTurn(t *testing.T) {
+	m := newTestModel()
+	m.armWakeup(time.Hour, "tick", false)
+	m.Update(wakeupMsg{prompt: "tick", repeat: false, delay: time.Hour})
+	if !m.turnRunning {
+		t.Fatal("an idle wakeup should start a turn")
+	}
+	if m.loopActive {
+		t.Error("dynamic-mode wakeup should clear loopActive after firing")
+	}
+}
+
+// A wakeup that fires while the model is still busy must not start a second
+// turn; interval mode re-arms instead.
+func TestTUI_WakeupBusyReArms(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.armWakeup(time.Hour, "tick", true)
+	m.Update(wakeupMsg{prompt: "tick", repeat: true, delay: time.Hour})
+	if !m.loopActive || m.wakeupTimer == nil {
+		t.Error("a repeat wakeup arriving while busy should re-arm, not lapse")
+	}
+	m.cancelWakeup()
+}
+
+// A new user message cancels the loop (CC-style hand-back).
+func TestTUI_UserMessageCancelsLoop(t *testing.T) {
+	m := newTestModel()
+	m.armWakeup(time.Hour, "tick", true)
+	setInput(m, "do something else")
+	_, _ = m.submit()
+	if m.loopActive || m.wakeupTimer != nil {
+		t.Fatal("a user message should cancel the armed loop")
+	}
+}
+
+// An interrupt cancels the loop too.
+func TestTUI_InterruptCancelsLoop(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.cancelTurn = func() {}
+	m.armWakeup(time.Hour, "tick", true)
+	m.interrupt()
+	if m.loopActive || m.wakeupTimer != nil {
+		t.Fatal("an interrupt should cancel the armed loop")
+	}
+}

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -166,8 +166,19 @@ type mcpReadyMsg struct{ reg *mcp.Registry }                 // background MCP c
 type subAgentEventMsg struct{ ev tools.SubAgentEvent }       // a sub-agent's runtime activity (async)
 type workflowEventMsg struct{ ev tools.WorkflowEvent }       // a background workflow's runtime activity (async)
 type suggestionMsg struct{ text string }                     // an after-turn follow-up suggestion (async)
-type titleMsg struct{ text string }                          // a generated session title (async)
-type tickMsg struct{}                                        // animation tick while a turn runs
+type armWakeupMsg struct {                                   // schedule_wakeup tool asked to arm a loop (from the turn goroutine)
+	delay  time.Duration
+	prompt string
+	reason string
+	repeat bool
+}
+type wakeupMsg struct { // an armed loop wakeup fired (async, from the wakeup timer)
+	prompt string
+	repeat bool
+	delay  time.Duration
+}
+type titleMsg struct{ text string } // a generated session title (async)
+type tickMsg struct{}               // animation tick while a turn runs
 type askMsg struct {
 	prompt UserPrompt
 	resp   chan UserResponse
@@ -297,6 +308,13 @@ type tuiModel struct {
 	// turnRunning is true between starting a turn and turnFinishedMsg.
 	turnRunning bool
 	cancelTurn  context.CancelFunc
+
+	// wakeupTimer is the armed in-session loop wakeup (schedule_wakeup tool),
+	// nil when no loop is running. loopActive mirrors it for the activity line.
+	// A new user message or an interrupt cancels the loop (cancelWakeup) —
+	// matching Claude Code's loop, which yields control back to the user.
+	wakeupTimer *time.Timer
+	loopActive  bool
 
 	// echoPending is the user-message echo held in the live View() area instead
 	// of being committed straight to the scrollback. It commits on the turn's
@@ -585,6 +603,41 @@ func (m *tuiModel) connectMCPCmd() tea.Cmd {
 	}
 }
 
+// tuiWaker implements tools.Waker by posting an armWakeupMsg onto the bubbletea
+// program. The timer and all loop state live on the model (the UI goroutine);
+// only the program send crosses goroutines, the same goroutine-safe path the
+// background-process and sub-agent notices use.
+type tuiWaker struct {
+	prog interface{ Send(tea.Msg) }
+}
+
+func (w tuiWaker) ScheduleWakeup(delay time.Duration, prompt, reason string, repeat bool) error {
+	w.prog.Send(armWakeupMsg{delay: delay, prompt: prompt, reason: reason, repeat: repeat})
+	return nil
+}
+
+// armWakeup (re)starts the loop's wakeup timer, replacing any pending one — a
+// session holds at most one armed loop.
+func (m *tuiModel) armWakeup(delay time.Duration, prompt string, repeat bool) {
+	if m.wakeupTimer != nil {
+		m.wakeupTimer.Stop()
+	}
+	prog := m.sink.prog
+	wm := wakeupMsg{prompt: prompt, repeat: repeat, delay: delay}
+	m.wakeupTimer = time.AfterFunc(delay, func() { prog.Send(wm) })
+	m.loopActive = true
+}
+
+// cancelWakeup stops any armed loop. Called when the user steps in (a new
+// message) or interrupts — Claude Code's loop hands control back to the user.
+func (m *tuiModel) cancelWakeup() {
+	if m.wakeupTimer != nil {
+		m.wakeupTimer.Stop()
+		m.wakeupTimer = nil
+	}
+	m.loopActive = false
+}
+
 // startTurn launches a turn whose transcript echo is the submitted line itself.
 func (m *tuiModel) startTurn(line string) tea.Cmd {
 	return m.startTurnEcho(line, line)
@@ -637,6 +690,7 @@ func (m *tuiModel) startTurnEchoRestore(line, echo, restore string) tea.Cmd {
 	m.toolStreamName, m.toolStreamID, m.toolStreamBytes = "", "", 0
 	m.clearSuggestion() // a new turn supersedes any pending follow-up
 	ctx, cancel := context.WithCancel(context.Background())
+	ctx = tools.WithWaker(ctx, tuiWaker{prog: m.sink.prog})
 	m.cancelTurn = cancel
 	a := m.a
 	cfg := m.cfg
@@ -827,6 +881,38 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(tickCmd(), m.flushPrints())
 		}
 		return m, m.flushPrints()
+
+	case armWakeupMsg:
+		// schedule_wakeup fired from the turn goroutine: (re)arm the loop timer.
+		m.armWakeup(msg.delay, msg.prompt, msg.repeat)
+		cadence := "next in " + msg.delay.String()
+		if msg.repeat {
+			cadence = "every " + msg.delay.String()
+		}
+		note := "● Loop armed — " + cadence
+		if msg.reason != "" {
+			note += " · " + msg.reason
+		}
+		m.printlnBlock(noticeStyle.Render(note))
+		return m, m.flushPrints()
+
+	case wakeupMsg:
+		// An armed loop wakeup fired. Re-arm first for interval mode (so the
+		// cadence is independent of the turn's own duration), then — if the
+		// session is idle — run the loop prompt as a fresh turn. A new user
+		// message would already have called cancelWakeup, so reaching here while
+		// a turn runs or work is queued means the model itself is still busy:
+		// drop this fire (repeat already re-armed; dynamic mode re-arms in-turn).
+		if msg.repeat && m.loopActive {
+			m.armWakeup(msg.delay, msg.prompt, true)
+		} else {
+			m.cancelWakeup()
+		}
+		if m.turnRunning || len(m.queue) > 0 {
+			return m, m.flushPrints()
+		}
+		m.printlnBlock(noticeStyle.Render("● Loop tick"))
+		return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(msg.prompt, ""))
 
 	case suggestionMsg:
 		// Show the follow-up only while idle with an empty input — a new turn or

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -727,6 +727,8 @@ func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 	if text == "" && len(m.pendingAttachments) == 0 {
 		return m, nil
 	}
+	// A user message takes over: cancel any armed loop (CC-style hand-back).
+	m.cancelWakeup()
 	m.ta.Reset()
 	m.inputHistoryIdx = -1
 	m.clearPastes()
@@ -940,6 +942,7 @@ func (m *tuiModel) interrupt() {
 	if m.cancelTurn != nil {
 		m.cancelTurn()
 	}
+	m.cancelWakeup()
 	m.pendingSteer = nil
 }
 

--- a/internal/server/loop.go
+++ b/internal/server/loop.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// serverWaker implements tools.Waker for a server-managed session. On wakeup it
+// enqueues the loop prompt as a user steer and kicks an idle turn — the same
+// idle auto-turn path that background-process and sub-agent completion notes
+// use — so the model re-enters the loop without the user re-prompting. Interval
+// mode (repeat) re-arms the timer from inside the fired callback; a new user
+// turn or an interrupt cancels it (cancelWakeup), matching the TUI and Claude
+// Code's loop. It is stamped into the turn ctx in runAgentTurnLoop.
+type serverWaker struct {
+	s         *Server
+	sessionID string
+}
+
+func (w serverWaker) ScheduleWakeup(delay time.Duration, prompt, reason string, repeat bool) error {
+	w.s.armWakeup(w.sessionID, delay, prompt, repeat)
+	return nil
+}
+
+// armWakeup (re)starts the session's loop wakeup timer, replacing any pending
+// one — a session holds at most one armed wakeup at a time.
+func (s *Server) armWakeup(sessionID string, delay time.Duration, prompt string, repeat bool) {
+	s.wakeupMu.Lock()
+	defer s.wakeupMu.Unlock()
+	if t := s.wakeupTimers[sessionID]; t != nil {
+		t.Stop()
+	}
+	s.wakeupTimers[sessionID] = time.AfterFunc(delay, func() {
+		// Interval mode: re-arm for the next tick before delivering, so the
+		// cadence is independent of how long the woken turn runs. Dynamic mode
+		// fires once and is re-armed (or not) by the model's next turn.
+		if repeat {
+			s.armWakeup(sessionID, delay, prompt, true)
+		} else {
+			s.cancelWakeup(sessionID)
+		}
+		s.enqueueSteer(sessionID, agent.InboxItem{Text: prompt})
+		s.kickIdleSteerTurn(sessionID)
+	})
+}
+
+// cancelWakeup stops and forgets a session's pending loop wakeup, if any.
+// Called when the user takes over (a new message, a retry, or an interrupt).
+func (s *Server) cancelWakeup(sessionID string) {
+	s.wakeupMu.Lock()
+	defer s.wakeupMu.Unlock()
+	if t := s.wakeupTimers[sessionID]; t != nil {
+		t.Stop()
+		delete(s.wakeupTimers, sessionID)
+	}
+}
+
+// wakerFor returns the Waker stamped into a server session's turn ctx.
+func (s *Server) wakerFor(sessionID string) tools.Waker {
+	return serverWaker{s: s, sessionID: sessionID}
+}

--- a/internal/server/loop_test.go
+++ b/internal/server/loop_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// Long delays keep the timer from firing during the test, so we exercise the
+// arm/cancel bookkeeping without the live-session delivery path.
+
+func TestServerWaker_ArmAndCancel(t *testing.T) {
+	s := &Server{wakeupTimers: map[string]*time.Timer{}}
+	s.armWakeup("sid", time.Hour, "p", false)
+	if n := s.armedCount(); n != 1 {
+		t.Fatalf("expected 1 armed timer after arm, got %d", n)
+	}
+	s.cancelWakeup("sid")
+	if n := s.armedCount(); n != 0 {
+		t.Fatalf("cancel should remove the timer, got %d", n)
+	}
+}
+
+func TestServerWaker_ReArmReplaces(t *testing.T) {
+	s := &Server{wakeupTimers: map[string]*time.Timer{}}
+	s.armWakeup("sid", time.Hour, "p", false)
+	first := s.wakeupTimers["sid"]
+	s.armWakeup("sid", time.Hour, "p2", true)
+	if n := s.armedCount(); n != 1 {
+		t.Fatalf("re-arm should not add a second timer, got %d", n)
+	}
+	if s.wakeupTimers["sid"] == first {
+		t.Fatal("re-arm should replace the timer instance")
+	}
+	s.cancelWakeup("sid")
+}
+
+func TestServerWaker_ImplementsWaker(t *testing.T) {
+	s := &Server{wakeupTimers: map[string]*time.Timer{}}
+	var w tools.Waker = s.wakerFor("sid")
+	if err := w.ScheduleWakeup(time.Hour, "p", "r", false); err != nil {
+		t.Fatalf("ScheduleWakeup: %v", err)
+	}
+	if n := s.armedCount(); n != 1 {
+		t.Fatalf("ScheduleWakeup should arm a timer, got %d", n)
+	}
+	s.cancelWakeup("sid")
+}
+
+func (s *Server) armedCount() int {
+	s.wakeupMu.Lock()
+	defer s.wakeupMu.Unlock()
+	return len(s.wakeupTimers)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -170,6 +170,13 @@ type Server struct {
 	interrupts  map[string]context.CancelFunc
 	interruptMu sync.Mutex
 
+	// wakeupTimers holds the armed in-session loop wakeup per session
+	// (schedule_wakeup tool / loop skill), guarded by wakeupMu. A new user
+	// turn, a retry, or an interrupt cancels it; interval mode re-arms from the
+	// fired callback. See loop.go.
+	wakeupTimers map[string]*time.Timer
+	wakeupMu     sync.Mutex
+
 	// confirmation channels (from request_user_feedback in browser).
 	confirmations map[string]chan string
 	confirmMu     sync.Mutex
@@ -344,6 +351,7 @@ func New(cfg Config) (*Server, error) {
 		pendingConfirms:     make(map[string]wsEventRequestConfirmation),
 		askSlots:            make(map[string]chan struct{}),
 		sessionInjectors:    make(map[string]*memory.Injector),
+		wakeupTimers:        make(map[string]*time.Timer),
 	}
 
 	// Register the WebSocket-backed asker so ask_user_question appears in the
@@ -357,6 +365,11 @@ func New(cfg Config) (*Server, error) {
 	// (including the one calling the tool) before the worker exits with
 	// ExitRestart for the supervisor to respawn.
 	tools.SetRestarter(s.Restart)
+
+	// Server-managed sessions can be re-entered, so advertise schedule_wakeup
+	// (the loop skill's mechanism); the per-session Waker is stamped into each
+	// turn's ctx in runAgentTurnLoop.
+	tools.SetWakerSupported(true)
 
 	s.registerRoutes()
 	s.initWS()

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -339,6 +339,10 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 		return
 	}
 
+	// A user message takes over: cancel any armed loop so it hands control back
+	// (CC-style). The model can re-arm /loop later.
+	s.cancelWakeup(sid)
+
 	// Session-management slash commands handled inline (no model turn). Other
 	// "/..." text falls through to the model, matching the TUI where unknown
 	// slashes are ordinary input.
@@ -570,6 +574,8 @@ func (s *Server) wsToast(sid, message, level string) {
 // handleWSInterrupt sends an interrupt signal for a session and broadcasts
 // the interrupted event so the frontend shows the cancellation to the user.
 func (s *Server) handleWSInterrupt(sessionID string) {
+	// An interrupt also stops any armed loop wakeup (TUI / CC parity).
+	s.cancelWakeup(sessionID)
 	s.interruptMu.Lock()
 	if cancel, ok := s.interrupts[sessionID]; ok {
 		cancel()
@@ -630,6 +636,8 @@ func (s *Server) broadcastRollback(sessionID string) {
 // handleWSRetry re-runs the last turn by stripping the last assistant reply
 // from the session and resending the last user message.
 func (s *Server) handleWSRetry(conn *wsConn, sessionID string) {
+	// A retry is a user action: cancel any armed loop first.
+	s.cancelWakeup(sessionID)
 	sess, err := agent.LoadSession(sessionID)
 	if err != nil {
 		s.wsHub.broadcast(sessionID, map[string]string{
@@ -986,6 +994,10 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	}()
 
 	runCtx, cancel := context.WithCancel(context.WithValue(context.Background(), ctxKeySessionID{}, sess.ID))
+	// Stamp the per-session Waker so schedule_wakeup (the loop skill) can pace
+	// this and later turns — including the wakeup-injected turns kicked via
+	// kickIdleSteerTurn, which also flow through here.
+	runCtx = tools.WithWaker(runCtx, s.wakerFor(sess.ID))
 	s.registerInterrupt(sess.ID, cancel)
 	defer func() {
 		cancel()

--- a/internal/skills/defaults/loop/SKILL.md
+++ b/internal/skills/defaults/loop/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: loop
+description: Run a prompt or task repeatedly in the current session — on a fixed interval, or self-paced where you decide the cadence and when to stop. Use when the user wants something checked or run again and again without re-prompting each time, e.g. "/loop 5m check the deploy", "每隔几分钟跑一次", "keep running this until it's green", "poll the build every 2 minutes", "循环执行", "盯着这个直到完成". Trailing text after the interval is the task to loop. Do NOT use for a schedule that must survive a restart or run while the user is away — that's cron-task-creator.
+---
+
+# Loop a task in this session
+
+Keep running a task in the **current session** without the user re-prompting,
+by scheduling your own next turn with the **`schedule_wakeup`** tool. After a
+turn ends and the session goes idle, the system re-runs your `prompt` as a fresh
+user turn after the delay — so you come back, do the work again, and decide
+whether to continue.
+
+This is an **in-session** loop: it lives in this conversation and stops when the
+user steps in. For a schedule that must persist across restarts or fire while
+nobody is watching, use the **cron-task-creator** skill instead.
+
+## Read the invocation
+
+The text after `/loop` is `[interval] <task>`:
+
+- **Interval given** (`/loop 5m check the build`, `/loop 30s …`, `/loop 2h …`) →
+  **interval mode**. Parse the leading duration to seconds and run the task on
+  that fixed cadence.
+- **No interval** (`/loop keep refining the draft until it reads cleanly`) →
+  **dynamic mode**. You choose the cadence each turn and you decide when to stop.
+
+If the task itself is unclear, ask one clarifying question before starting — a
+loop that runs the wrong task wastes every iteration.
+
+## Interval mode — fixed cadence
+
+Do the task once, then call `schedule_wakeup` **with `repeat: true`** so the
+wakeup re-arms itself automatically:
+
+```
+schedule_wakeup(delay_seconds=300, repeat=true,
+                reason="polling the deploy every 5m until it's live",
+                prompt="<the task to run each tick>")
+```
+
+You only call it **once** — the cadence holds on its own. Each tick re-runs
+`prompt` as a fresh turn. The loop stops when the user sends a message or
+interrupts. Pass the task verbatim as `prompt` so every tick does the same work.
+
+## Dynamic mode — you set the pace
+
+Do the task, then call `schedule_wakeup` **with `repeat: false`** (the default)
+to come back later:
+
+```
+schedule_wakeup(delay_seconds=900, reason="<what you're waiting for>",
+                prompt="<the same task, so the next turn repeats it>")
+```
+
+In dynamic mode the wakeup fires **once** — to keep looping you must call
+`schedule_wakeup` again on the next turn. **Simply not calling it ends the
+loop.** This is how you stop: when the task is done (or can't make progress),
+finish your reply *without* scheduling a wakeup, and tell the user the loop is
+done and why.
+
+## Choosing the delay (cache-window aware)
+
+`delay_seconds` is clamped to **[60, 3600]**. The model's prompt cache has a
+~5-minute TTL, so:
+
+- **Under 5 minutes (60–270s)** — context stays warm. Right when you're actively
+  polling external state that changes on that scale: a CI run, a deploy, a queue.
+- **5 minutes to 1 hour (300–3600s)** — you pay a cache miss, but it's worth it
+  when there's genuinely nothing to check sooner.
+- **Avoid exactly 300s** — it pays the miss without amortizing it. Drop to ~270s
+  to stay warm, or commit to 1200s+ so one miss buys a long wait.
+- **Idle ticks with no specific signal** → default to **1200–1800s**.
+
+Think about *what you're waiting for*, not a round number of minutes. If you're
+polling an ~8-minute CI run, sleeping 60s burns the cache eight times before it
+finishes — sleep ~270s twice instead.
+
+## The `reason` field
+
+One short, specific sentence on what you're waiting for and why this cadence —
+it's shown to the user so they can see what the loop is doing. "watching CI run"
+beats "waiting".
+
+## Stopping
+
+- **Dynamic mode**: stop by *not* calling `schedule_wakeup` — say the loop is done.
+- **Interval mode**: it runs until the user interrupts or sends a message.
+- Either way, **a new user message cancels the loop** and hands control back to
+  the user. You can re-arm `/loop` later if asked.
+
+## Give every iteration a clear stop/idle condition
+
+An open-ended task makes each tick spin until it times out. Spell out what
+"nothing to do" looks like so a quiet tick is cheap:
+
+- Bad: "Check if the deploy is done."
+- Good: "Run `kubectl rollout status …` once. If it reports complete, say so and
+  STOP looping (don't schedule another wakeup). If still rolling out, reply with
+  the current status in one line and schedule the next check."

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -49,6 +49,7 @@ var allTools = []tool{
 	TaskUpdateTool{},
 	TaskListTool{},
 	RestartServerTool{},
+	ScheduleWakeupTool{},
 	BrowserTool{},
 }
 
@@ -238,6 +239,7 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 	askerOn := askerEnabled()
 	tasksOn := tasksEnabled()
 	restarterOn := restarterEnabled()
+	wakerOn := wakerEnabled()
 	browserOn := browserEnabled()
 	spawnerOn := spawnerEnabled()
 	defs := make([]agent.ToolDefinition, 0, len(allTools))
@@ -279,6 +281,9 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 			continue
 		}
 		if _, isRestart := t.(RestartServerTool); isRestart && !restarterOn {
+			continue
+		}
+		if _, isWakeup := t.(ScheduleWakeupTool); isWakeup && !wakerOn {
 			continue
 		}
 		if _, isBrowser := t.(BrowserTool); isBrowser && !browserOn {

--- a/internal/tools/schedule_wakeup.go
+++ b/internal/tools/schedule_wakeup.go
@@ -1,0 +1,165 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+// Waker schedules a delayed re-entry into the current interactive session: a
+// prompt delivered as a fresh user turn after a delay. It backs the loop
+// skill's two modes — dynamic (the model re-arms each turn) and interval (the
+// wakeup re-arms itself) — and is stamped into the turn ctx per surface. The
+// TUI (cmd/octo) and the HTTP/IM server (internal/server) each implement it
+// differently, the same ctx-scoping the Asker and ChannelFileSender use. A
+// headless one-shot turn stamps none, so schedule_wakeup reports a clean error
+// there rather than pretending to loop in a process that exits after one turn.
+type Waker interface {
+	// ScheduleWakeup arranges for prompt to run as a fresh user turn in the
+	// current session after delay. When repeat is true the wakeup re-arms on
+	// the same cadence (interval mode); otherwise it fires once and the model
+	// re-arms by calling the tool again (dynamic mode). reason is a short
+	// human-facing note. Any wakeup already pending for the session is
+	// replaced — a session has at most one armed wakeup at a time.
+	ScheduleWakeup(delay time.Duration, prompt, reason string, repeat bool) error
+}
+
+// ctxKeyWaker carries the turn-scoped Waker.
+type ctxKeyWaker struct{}
+
+// WithWaker stamps the session's Waker for the duration of an interactive turn.
+func WithWaker(ctx context.Context, w Waker) context.Context {
+	return context.WithValue(ctx, ctxKeyWaker{}, w)
+}
+
+// wakerFrom resolves the Waker for this turn, or nil on a surface that can't
+// wake a session (the headless one-shot).
+func wakerFrom(ctx context.Context) Waker {
+	if w, ok := ctx.Value(ctxKeyWaker{}).(Waker); ok && w != nil {
+		return w
+	}
+	return nil
+}
+
+// wakerSupported gates schedule_wakeup's advertisement in DefaultToolsFor. The
+// interactive surfaces (TUI, server) set it at startup; it stays false in the
+// headless one-shot process, where a loop has no live session to wake and the
+// tool could only error. Mirrors SetRestarter: process-global, set once.
+var wakerSupported bool
+
+// SetWakerSupported toggles whether schedule_wakeup is advertised. Pass true
+// from the TUI and server entry points; leave it false (the default) for the
+// headless one-shot.
+func SetWakerSupported(v bool) { wakerSupported = v }
+
+func wakerEnabled() bool { return wakerSupported }
+
+// Wakeup delay bounds, mirroring Claude Code's ScheduleWakeup: under a minute
+// is pointless churn, over an hour belongs in a persistent cron task
+// (cron-task-creator) rather than an in-session loop. The runtime clamps
+// rather than rejects, so a slightly-off value never costs the model a retry.
+const (
+	minWakeupDelay = 60 * time.Second
+	maxWakeupDelay = 3600 * time.Second
+)
+
+// ScheduleWakeupTool lets the model schedule its own next turn — the mechanism
+// behind the loop skill. The model calls it at the end of a turn to come back
+// later (dynamic, self-paced mode) or to keep a fixed cadence (repeat = interval
+// mode); NOT calling it ends the loop. It only works inside a live session that
+// can be re-entered — the interactive TUI or a server-managed web/IM session —
+// so it is withheld from the headless one-shot (wakerEnabled gates it in
+// DefaultToolsFor) and the per-session Waker is injected into the turn ctx.
+type ScheduleWakeupTool struct{}
+
+func (ScheduleWakeupTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "schedule_wakeup",
+		Description: "Schedule your own next turn — the mechanism behind the loop skill. After this " +
+			"turn ends and the session goes idle, the system re-runs `prompt` as a fresh user turn " +
+			"after `delay_seconds`. Use it to pace a recurring task without the user re-prompting.\n\n" +
+			"Two modes:\n" +
+			"- DYNAMIC (repeat=false, the default): fires once. To keep looping you must call this " +
+			"tool again on the next turn; simply NOT calling it ends the loop. Use when you decide " +
+			"the cadence turn-by-turn or want to stop once the task is done.\n" +
+			"- INTERVAL (repeat=true): the wakeup re-arms itself on the same cadence and keeps firing " +
+			"until the user interrupts or sends a new message. Use for a steady \"every N seconds\" loop.\n\n" +
+			"delay_seconds is clamped to [60, 3600]. Picking a cadence: the model's prompt cache has a " +
+			"~5-minute TTL, so a delay under 300s keeps context warm (right for actively polling " +
+			"external state like a CI run or a deploy), while 300s+ pays a cache miss (right when " +
+			"there's genuinely nothing to check sooner). Avoid exactly 300s — it pays the miss without " +
+			"amortizing it. For idle ticks with no specific signal to watch, default to 1200-1800s.\n\n" +
+			"A new user message cancels the loop and hands control back to the user; you can re-arm " +
+			"later. This is an in-session loop — for a schedule that must survive restarts or run " +
+			"while you're away, use the cron-task-creator skill instead.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"delay_seconds": map[string]any{
+					"type":        "integer",
+					"description": "Seconds until the wakeup fires. Clamped to [60, 3600].",
+				},
+				"reason": map[string]any{
+					"type":        "string",
+					"description": "One short sentence on what you're waiting for and why this cadence. Shown to the user. Be specific — \"watching CI run\" beats \"waiting\".",
+				},
+				"prompt": map[string]any{
+					"type":        "string",
+					"description": "The text delivered as a user turn on wakeup. Pass the same loop task verbatim each time so the next firing repeats the task.",
+				},
+				"repeat": map[string]any{
+					"type":        "boolean",
+					"description": "false (default) for dynamic mode (fires once; re-arm yourself to continue). true for interval mode (re-arms automatically on the same cadence).",
+				},
+			},
+			"required": []string{"delay_seconds", "reason", "prompt"},
+		},
+	}
+}
+
+func (ScheduleWakeupTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	w := wakerFrom(ctx)
+	if w == nil {
+		return agent.ToolResult{}, fmt.Errorf("schedule_wakeup: no live session to wake — the loop only runs in the interactive TUI or a server (web/IM) session")
+	}
+
+	prompt := strings.TrimSpace(stringArg(input, "prompt"))
+	if prompt == "" {
+		return agent.ToolResult{}, fmt.Errorf("schedule_wakeup: prompt is required (the task text to resume on wakeup)")
+	}
+	reason := strings.TrimSpace(stringArg(input, "reason"))
+
+	delay := time.Duration(intArg(input, "delay_seconds", 0)) * time.Second
+	if delay < minWakeupDelay {
+		delay = minWakeupDelay
+	}
+	if delay > maxWakeupDelay {
+		delay = maxWakeupDelay
+	}
+	repeat := boolArg(input, "repeat")
+
+	if err := w.ScheduleWakeup(delay, prompt, reason, repeat); err != nil {
+		return agent.ToolResult{}, fmt.Errorf("schedule_wakeup: %w", err)
+	}
+
+	cadence := fmt.Sprintf("once in %s", delay)
+	if repeat {
+		cadence = fmt.Sprintf("every %s", delay)
+	}
+	text := fmt.Sprintf("Wakeup scheduled %s.", cadence)
+	if reason != "" {
+		text += " " + reason
+	}
+	return agent.ToolResult{
+		Text: text,
+		UI: map[string]any{
+			"type":          "wakeup",
+			"delay_seconds": int(delay.Seconds()),
+			"repeat":        repeat,
+			"reason":        reason,
+		},
+	}, nil
+}

--- a/internal/tools/schedule_wakeup_test.go
+++ b/internal/tools/schedule_wakeup_test.go
@@ -1,0 +1,97 @@
+package tools
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+)
+
+type fakeWaker struct {
+	delay  time.Duration
+	prompt string
+	reason string
+	repeat bool
+	calls  int
+}
+
+func (w *fakeWaker) ScheduleWakeup(delay time.Duration, prompt, reason string, repeat bool) error {
+	w.delay, w.prompt, w.reason, w.repeat = delay, prompt, reason, repeat
+	w.calls++
+	return nil
+}
+
+func TestScheduleWakeup_ClampsDelay(t *testing.T) {
+	cases := []struct{ in, want int }{
+		{10, 60},     // below the floor → clamped up
+		{60, 60},     // at the floor
+		{600, 600},   // in range, untouched
+		{9999, 3600}, // above the ceiling → clamped down
+	}
+	for _, c := range cases {
+		fw := &fakeWaker{}
+		ctx := WithWaker(context.Background(), fw)
+		_, err := (ScheduleWakeupTool{}).Execute(ctx, "schedule_wakeup", map[string]any{
+			"delay_seconds": c.in, "prompt": "task", "reason": "r",
+		})
+		if err != nil {
+			t.Fatalf("delay %d: unexpected error %v", c.in, err)
+		}
+		if got := int(fw.delay.Seconds()); got != c.want {
+			t.Errorf("delay %d → %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestScheduleWakeup_NoWaker(t *testing.T) {
+	_, err := (ScheduleWakeupTool{}).Execute(context.Background(), "schedule_wakeup", map[string]any{
+		"delay_seconds": 60, "prompt": "x",
+	})
+	if err == nil {
+		t.Fatal("expected an error when no Waker is stamped (headless one-shot)")
+	}
+}
+
+func TestScheduleWakeup_RequiresPrompt(t *testing.T) {
+	ctx := WithWaker(context.Background(), &fakeWaker{})
+	_, err := (ScheduleWakeupTool{}).Execute(ctx, "schedule_wakeup", map[string]any{"delay_seconds": 60})
+	if err == nil {
+		t.Fatal("expected an error when prompt is missing")
+	}
+}
+
+func TestScheduleWakeup_ForwardsArgs(t *testing.T) {
+	fw := &fakeWaker{}
+	ctx := WithWaker(context.Background(), fw)
+	_, err := (ScheduleWakeupTool{}).Execute(ctx, "schedule_wakeup", map[string]any{
+		"delay_seconds": 120, "prompt": "do it", "reason": "why", "repeat": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fw.calls != 1 || !fw.repeat || fw.prompt != "do it" || fw.reason != "why" {
+		t.Fatalf("args not forwarded to the waker: %+v", fw)
+	}
+}
+
+func TestScheduleWakeup_AdvertisementGate(t *testing.T) {
+	SetWakerSupported(false)
+	if toolListed(DefaultTools(), "schedule_wakeup") {
+		t.Error("schedule_wakeup should be withheld when wakeups are unsupported")
+	}
+	SetWakerSupported(true)
+	defer SetWakerSupported(false)
+	if !toolListed(DefaultTools(), "schedule_wakeup") {
+		t.Error("schedule_wakeup should be advertised when wakeups are supported")
+	}
+}
+
+func toolListed(defs []agent.ToolDefinition, name string) bool {
+	for _, d := range defs {
+		if d.Name == name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
A 1:1 replica of Claude Code's `/loop` for octo's interactive TUI and server-managed web sessions.

## Mechanism (mirrors CC)
A `loop` **skill** orchestrates; a new **`schedule_wakeup` tool** mechanizes the self-pacing — the model schedules its own next turn back into the live session.

| CC | octo |
|---|---|
| `ScheduleWakeup` (dynamic) | `schedule_wakeup` `repeat:false` — fires once, model re-arms each turn, omit-to-stop |
| `CronCreate` self-bind (interval) | `schedule_wakeup` `repeat:true` — auto re-arms on a fixed cadence |
| fires a turn into the live session | ctx-scoped `tools.Waker` → TUI timer→`wakeupMsg` / serve `enqueueSteer`+`kickIdleSteerTurn` (existing idle-auto-turn path) |
| user takes over | a new user message / interrupt / retry **cancels the loop** |

CC's two backing tools collapse into one `schedule_wakeup` with a `repeat` flag — octo's live surfaces have no separate in-session cron, so one mechanism gives identical behavior on both. The persistent `~/.octo/tasks` scheduler is untouched (the skill points users there for restart-surviving schedules).

## What's wired
- **Tool** (`internal/tools/schedule_wakeup.go`): `delay_seconds` clamped `[60,3600]`, `reason`, `prompt`, `repeat`. ctx-scoped `Waker` (same pattern as Asker/ChannelFileSender); advertised only where a surface can re-enter a session (`wakerEnabled` gate — **off for headless one-shot**).
- **TUI** (`cmd/octo`): waker arms a timer that posts `wakeupMsg`; idle auto-turn injects the loop prompt (mirrors `bgExitMsg`). New user message / interrupt cancels.
- **serve** (`internal/server`): per-session timer → `enqueueSteer` + `kickIdleSteerTurn`; cancelled on new user message / retry / interrupt; interval mode re-arms from the fired callback. Wired on the web WS path.
- **Skill** (`internal/skills/defaults/loop/SKILL.md`): CC-compatible, both modes, cache-window cadence guidance (avoid 300s; idle default 1200–1800s), explicit stop conditions.

## Scope notes
- Headless one-shot deliberately does not advertise the tool.
- IM stamp/cancel deferred — the `serverWaker` is session-id-generic and IM's idle-kick path already works, so it's a small follow-up.

## Tests
Clamp/validation/advertisement-gate, TUI arm/fire/cancel/interrupt, serve timer bookkeeping. Full suite green under `-race`; `gofmt`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
