### PR TITLE
fix(browser): per-action timeout + actionable invalid-selector error

### DIFF
--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -47,7 +47,8 @@ func (p *Page) elementCenter(ctx context.Context, selector string) (point, error
 		offset = fmt.Sprintf(`{const f=document.querySelector(%s); if(f){const fr=f.getBoundingClientRect(); ox=fr.x; oy=fr.y;}}`, jsString(frame))
 	}
 	expr := fmt.Sprintf(`(() => {
-		const el = %s;
+		let el;
+		try { el = %s; } catch (e) { return { badSelector: true }; }
 		if (!el) return null;
 		el.scrollIntoView({ block: 'center', inline: 'center' });
 		const r = el.getBoundingClientRect();
@@ -55,14 +56,20 @@ func (p *Page) elementCenter(ctx context.Context, selector string) (point, error
 		%s
 		return { x: ox + r.x + r.width / 2, y: oy + r.y + r.height / 2 };
 	})()`, elemRefJS(frame, elem), offset)
-	var pt *point
-	if err := p.Eval(ctx, expr, &pt); err != nil {
+	var res *struct {
+		X, Y        float64
+		BadSelector bool `json:"badSelector"`
+	}
+	if err := p.Eval(ctx, expr, &res); err != nil {
 		return point{}, err
 	}
-	if pt == nil {
+	if res == nil {
 		return point{}, fmt.Errorf("selector %q matched nothing", selector)
 	}
-	return *pt, nil
+	if res.BadSelector {
+		return point{}, fmt.Errorf("invalid CSS selector %q — :has-text/:contains are Playwright-only, not CSS; use a plain CSS selector (run the observe action to list valid ones)", selector)
+	}
+	return point{X: res.X, Y: res.Y}, nil
 }
 
 // Click performs a trusted browser-level click at the element's center.

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -526,3 +526,33 @@ func TestNewPageLeavesOtherTabsUntouched(t *testing.T) {
 		t.Errorf("user tab was disturbed: pathname = %q, want /user", userPath)
 	}
 }
+
+// TestClick_InvalidSelectorMessage: a Playwright-style :has-text selector is
+// not valid CSS; querySelector throws. We should surface an actionable message
+// (not a bare "eval threw: Uncaught") so the model switches to a CSS selector.
+func TestClick_InvalidSelectorMessage(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!doctype html><html><head><title>t</title></head><body><a href="#">x</a></body></html>`))
+	}))
+	defer srv.Close()
+
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	err = page.Click(ctx, `a:has-text("nope")`)
+	if err == nil {
+		t.Fatal("expected an error for an invalid (Playwright) selector")
+	}
+	if !strings.Contains(err.Error(), "invalid CSS selector") {
+		t.Errorf("error should name the invalid selector clearly; got: %v", err)
+	}
+}

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -208,6 +208,19 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 	if action == "" {
 		return agent.ToolResult{}, fmt.Errorf("browser: action is required")
 	}
+
+	// Bound every action so a CDP call a janky/loading page never acks (e.g. a
+	// mouseWheel scroll on a heavy SPA) fails with a timeout instead of hanging
+	// the whole turn. run_skill replays many steps and download waits for a file
+	// to finish, so they get a much longer ceiling.
+	timeout := 45 * time.Second
+	switch action {
+	case "run_skill", "download":
+		timeout = 5 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	page, b, err := browserPage(ctx)
 	if err != nil {
 		return agent.ToolResult{}, fmt.Errorf("browser: %w", err)


### PR DESCRIPTION
Two robustness gaps hit while driving a heavy SPA (zhihu).

## 1. Actions could hang forever

`scroll` (a `mouseWheel` CDP dispatch) — and any action — ran on the turn's **unbounded** context, so a call a janky/still-loading page never acks blocked the whole turn indefinitely (observed: "running" for 2m+). Every action is now bounded: **45s** default, **5min** for `run_skill`/`download` (which legitimately run long). A stuck call now fails with a timeout the model can react to.

## 2. Opaque error on a Playwright-style selector

`click` with `a:has-text("…")` failed with a bare `eval threw: Uncaught` — `document.querySelector` throws on non-CSS selectors (`:has-text`/`:contains` are Playwright-only). The element resolver now catches that and returns an **actionable** message naming the bad selector and pointing at `observe`, so the model switches to plain CSS in one step instead of guessing.

## Tests

`TestClick_InvalidSelectorMessage` — `a:has-text(...)` yields an error containing "invalid CSS selector" (real headless Chrome, skips when absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)