### PR TITLE
fix(loop): coexist with user (not cancel) + IM channel parity

### DIFF
--- a/cmd/octo/loop_test.go
+++ b/cmd/octo/loop_test.go
@@ -42,18 +42,29 @@ func TestTUI_WakeupBusyReArms(t *testing.T) {
 	m.cancelWakeup()
 }
 
-// A new user message cancels the loop (CC-style hand-back).
-func TestTUI_UserMessageCancelsLoop(t *testing.T) {
+// A new user message does NOT cancel the loop — they coexist (CC-style).
+func TestTUI_UserMessageKeepsLoop(t *testing.T) {
 	m := newTestModel()
 	m.armWakeup(time.Hour, "tick", true)
 	setInput(m, "do something else")
 	_, _ = m.submit()
+	if !m.loopActive || m.wakeupTimer == nil {
+		t.Fatal("a user message must not cancel the armed loop (they coexist)")
+	}
+	m.cancelWakeup()
+}
+
+// schedule_wakeup(cancel=true) → cancelWakeupMsg stops the loop.
+func TestTUI_CancelWakeupMsgStopsLoop(t *testing.T) {
+	m := newTestModel()
+	m.armWakeup(time.Hour, "tick", true)
+	m.Update(cancelWakeupMsg{})
 	if m.loopActive || m.wakeupTimer != nil {
-		t.Fatal("a user message should cancel the armed loop")
+		t.Fatal("cancelWakeupMsg should stop the loop")
 	}
 }
 
-// An interrupt cancels the loop too.
+// An interrupt (Ctrl+C) is the hard manual stop.
 func TestTUI_InterruptCancelsLoop(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -177,6 +177,7 @@ type wakeupMsg struct { // an armed loop wakeup fired (async, from the wakeup ti
 	repeat bool
 	delay  time.Duration
 }
+type cancelWakeupMsg struct{}       // schedule_wakeup(cancel=true) asked to stop the loop
 type titleMsg struct{ text string } // a generated session title (async)
 type tickMsg struct{}               // animation tick while a turn runs
 type askMsg struct {
@@ -311,8 +312,8 @@ type tuiModel struct {
 
 	// wakeupTimer is the armed in-session loop wakeup (schedule_wakeup tool),
 	// nil when no loop is running. loopActive mirrors it for the activity line.
-	// A new user message or an interrupt cancels the loop (cancelWakeup) —
-	// matching Claude Code's loop, which yields control back to the user.
+	// The loop coexists with user messages (CC-style); it stops only on an
+	// explicit Ctrl+C or schedule_wakeup(cancel=true) — see cancelWakeup.
 	wakeupTimer *time.Timer
 	loopActive  bool
 
@@ -616,6 +617,11 @@ func (w tuiWaker) ScheduleWakeup(delay time.Duration, prompt, reason string, rep
 	return nil
 }
 
+func (w tuiWaker) CancelWakeup() error {
+	w.prog.Send(cancelWakeupMsg{})
+	return nil
+}
+
 // armWakeup (re)starts the loop's wakeup timer, replacing any pending one — a
 // session holds at most one armed loop.
 func (m *tuiModel) armWakeup(delay time.Duration, prompt string, repeat bool) {
@@ -628,8 +634,9 @@ func (m *tuiModel) armWakeup(delay time.Duration, prompt string, repeat bool) {
 	m.loopActive = true
 }
 
-// cancelWakeup stops any armed loop. Called when the user steps in (a new
-// message) or interrupts — Claude Code's loop hands control back to the user.
+// cancelWakeup stops any armed loop. The loop coexists with user messages
+// (CC-style), so this fires only on an explicit stop: Ctrl+C, or the model
+// calling schedule_wakeup(cancel=true) when the user asks to stop.
 func (m *tuiModel) cancelWakeup() {
 	if m.wakeupTimer != nil {
 		m.wakeupTimer.Stop()
@@ -897,22 +904,32 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.flushPrints()
 
 	case wakeupMsg:
-		// An armed loop wakeup fired. Re-arm first for interval mode (so the
-		// cadence is independent of the turn's own duration), then — if the
-		// session is idle — run the loop prompt as a fresh turn. A new user
-		// message would already have called cancelWakeup, so reaching here while
-		// a turn runs or work is queued means the model itself is still busy:
-		// drop this fire (repeat already re-armed; dynamic mode re-arms in-turn).
-		if msg.repeat && m.loopActive {
+		// An armed loop wakeup fired. The loop COEXISTS with the user, so a
+		// wakeup that lands while a turn is running (a user message, or the
+		// loop's own prior turn) is NOT dropped — re-arm it so the tick runs
+		// once the session is idle again. When idle, run the loop prompt as a
+		// fresh turn: interval mode re-arms for the next tick; dynamic mode
+		// clears, and the model re-arms inside the turn (or ends the loop by
+		// not calling schedule_wakeup).
+		if m.turnRunning || len(m.queue) > 0 {
+			m.armWakeup(msg.delay, msg.prompt, msg.repeat)
+			return m, m.flushPrints()
+		}
+		if msg.repeat {
 			m.armWakeup(msg.delay, msg.prompt, true)
 		} else {
 			m.cancelWakeup()
 		}
-		if m.turnRunning || len(m.queue) > 0 {
-			return m, m.flushPrints()
-		}
 		m.printlnBlock(noticeStyle.Render("● Loop tick"))
 		return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(msg.prompt, ""))
+
+	case cancelWakeupMsg:
+		// schedule_wakeup(cancel=true): the model stopped the loop on request.
+		if m.loopActive {
+			m.printlnBlock(noticeStyle.Render("● Loop stopped"))
+		}
+		m.cancelWakeup()
+		return m, m.flushPrints()
 
 	case suggestionMsg:
 		// Show the follow-up only while idle with an empty input — a new turn or

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -727,8 +727,9 @@ func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 	if text == "" && len(m.pendingAttachments) == 0 {
 		return m, nil
 	}
-	// A user message takes over: cancel any armed loop (CC-style hand-back).
-	m.cancelWakeup()
+	// Note: a user message does NOT cancel the loop — the loop coexists with
+	// the conversation (CC-style). Stopping is explicit: Ctrl+C, or the model
+	// calling schedule_wakeup(cancel=true) when the user asks to stop.
 	m.ta.Reset()
 	m.inputHistoryIdx = -1
 	m.clearPastes()

--- a/internal/server/loop.go
+++ b/internal/server/loop.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"context"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/channel"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
@@ -11,9 +13,10 @@ import (
 // enqueues the loop prompt as a user steer and kicks an idle turn — the same
 // idle auto-turn path that background-process and sub-agent completion notes
 // use — so the model re-enters the loop without the user re-prompting. Interval
-// mode (repeat) re-arms the timer from inside the fired callback; a new user
-// turn or an interrupt cancels it (cancelWakeup), matching the TUI and Claude
-// Code's loop. It is stamped into the turn ctx in runAgentTurnLoop.
+// mode (repeat) re-arms the timer from inside the fired callback. The loop
+// coexists with user messages (CC-style); it stops only on an explicit
+// interrupt or schedule_wakeup(cancel=true). Stamped into the turn ctx in
+// runAgentTurnLoop.
 type serverWaker struct {
 	s         *Server
 	sessionID string
@@ -24,30 +27,44 @@ func (w serverWaker) ScheduleWakeup(delay time.Duration, prompt, reason string, 
 	return nil
 }
 
-// armWakeup (re)starts the session's loop wakeup timer, replacing any pending
-// one — a session holds at most one armed wakeup at a time.
+func (w serverWaker) CancelWakeup() error {
+	w.s.cancelWakeup(w.sessionID)
+	return nil
+}
+
+// armWakeup (re)starts a web session's loop wakeup timer (keyed by session ID).
+// On fire it injects the loop prompt as a user steer and kicks an idle turn —
+// the same path background/sub-agent completion notes use.
 func (s *Server) armWakeup(sessionID string, delay time.Duration, prompt string, repeat bool) {
-	s.wakeupMu.Lock()
-	defer s.wakeupMu.Unlock()
-	if t := s.wakeupTimers[sessionID]; t != nil {
-		t.Stop()
-	}
-	s.wakeupTimers[sessionID] = time.AfterFunc(delay, func() {
-		// Interval mode: re-arm for the next tick before delivering, so the
-		// cadence is independent of how long the woken turn runs. Dynamic mode
-		// fires once and is re-armed (or not) by the model's next turn.
-		if repeat {
-			s.armWakeup(sessionID, delay, prompt, true)
-		} else {
-			s.cancelWakeup(sessionID)
-		}
+	s.armWakeupFn(sessionID, delay, repeat, func() {
 		s.enqueueSteer(sessionID, agent.InboxItem{Text: prompt})
 		s.kickIdleSteerTurn(sessionID)
 	})
 }
 
+// armWakeupFn (re)starts the loop wakeup timer for key, replacing any pending
+// one — a session holds at most one armed wakeup. fire is the surface-specific
+// delivery (web steer-kick, or IM Inbox + idle channel turn). Interval mode
+// (repeat) re-arms from inside the fired callback so the cadence is independent
+// of how long the woken turn runs; dynamic mode fires once.
+func (s *Server) armWakeupFn(key string, delay time.Duration, repeat bool, fire func()) {
+	s.wakeupMu.Lock()
+	defer s.wakeupMu.Unlock()
+	if t := s.wakeupTimers[key]; t != nil {
+		t.Stop()
+	}
+	s.wakeupTimers[key] = time.AfterFunc(delay, func() {
+		if repeat {
+			s.armWakeupFn(key, delay, repeat, fire)
+		} else {
+			s.cancelWakeup(key)
+		}
+		fire()
+	})
+}
+
 // cancelWakeup stops and forgets a session's pending loop wakeup, if any.
-// Called when the user takes over (a new message, a retry, or an interrupt).
+// Called on an explicit stop: an interrupt, or schedule_wakeup(cancel=true).
 func (s *Server) cancelWakeup(sessionID string) {
 	s.wakeupMu.Lock()
 	defer s.wakeupMu.Unlock()
@@ -57,7 +74,35 @@ func (s *Server) cancelWakeup(sessionID string) {
 	}
 }
 
-// wakerFor returns the Waker stamped into a server session's turn ctx.
+// wakerFor returns the Waker stamped into a web session's turn ctx.
 func (s *Server) wakerFor(sessionID string) tools.Waker {
 	return serverWaker{s: s, sessionID: sessionID}
+}
+
+// imWaker implements tools.Waker for an IM (channel) session. The reply must go
+// through the adapter, not the web wsHub, so on wakeup it enqueues the loop
+// prompt into the session's Inbox and launches a channel idle turn — the same
+// path async completion notes use to reach an IM user. Timers are keyed by the
+// session's "im:<key>" namespace so they never collide with web session IDs.
+type imWaker struct {
+	s    *Server
+	sess *channel.Session
+	ad   channel.Adapter
+	ev   channel.InboundEvent
+}
+
+func imWakeupKey(sess *channel.Session) string { return "im:" + string(sess.Key) }
+
+func (w imWaker) ScheduleWakeup(delay time.Duration, prompt, reason string, repeat bool) error {
+	sess, ad, ev := w.sess, w.ad, w.ev
+	w.s.armWakeupFn(imWakeupKey(sess), delay, repeat, func() {
+		sess.Agent.Inbox.Enqueue(prompt)
+		go w.s.runChannelIdleTurn(context.Background(), sess, ad, ev)
+	})
+	return nil
+}
+
+func (w imWaker) CancelWakeup() error {
+	w.s.cancelWakeup(imWakeupKey(w.sess))
+	return nil
 }

--- a/internal/server/loop_test.go
+++ b/internal/server/loop_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Leihb/octo-agent/internal/channel"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
@@ -45,7 +46,33 @@ func TestServerWaker_ImplementsWaker(t *testing.T) {
 	if n := s.armedCount(); n != 1 {
 		t.Fatalf("ScheduleWakeup should arm a timer, got %d", n)
 	}
-	s.cancelWakeup("sid")
+	if err := w.CancelWakeup(); err != nil {
+		t.Fatalf("CancelWakeup: %v", err)
+	}
+	if n := s.armedCount(); n != 0 {
+		t.Fatalf("CancelWakeup should clear the timer, got %d", n)
+	}
+}
+
+// imWaker arms under the "im:<key>" namespace and delivers through the channel
+// path. A long delay keeps the fire callback (which needs a live Agent) from
+// running, so we test the arm/cancel bookkeeping only.
+func TestIMWaker_ArmAndCancel(t *testing.T) {
+	s := &Server{wakeupTimers: map[string]*time.Timer{}}
+	sess := &channel.Session{Key: channel.SessionKey("k")}
+	var w tools.Waker = imWaker{s: s, sess: sess}
+	if err := w.ScheduleWakeup(time.Hour, "tick", "r", true); err != nil {
+		t.Fatalf("ScheduleWakeup: %v", err)
+	}
+	if _, ok := s.wakeupTimers["im:k"]; !ok {
+		t.Fatal("imWaker should arm a timer under the im: namespace")
+	}
+	if err := w.CancelWakeup(); err != nil {
+		t.Fatalf("CancelWakeup: %v", err)
+	}
+	if n := s.armedCount(); n != 0 {
+		t.Fatalf("CancelWakeup should clear the timer, got %d", n)
+	}
 }
 
 func (s *Server) armedCount() int {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1644,6 +1644,11 @@ func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEven
 		s.injectorMu.Lock()
 		delete(s.sessionInjectors, imKey)
 		s.injectorMu.Unlock()
+		// A fresh context drops any armed loop wakeup for this chat.
+		s.cancelWakeup(imKey)
+	case "/stop":
+		// /stop is the IM interrupt — also the hard stop for an armed loop.
+		s.cancelWakeup("im:" + string(s.channelMgr.KeyFor(ev)))
 	}
 	// /compact runs an LLM summarize, so it's handled out of the (synchronous,
 	// reply-string) CommandRouter: run it in a goroutine and report the result.
@@ -1949,6 +1954,11 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		// here because only an IM turn has a chat to send to.
 		ctx = tools.WithChannelSender(ctx, channelFileSender{ad: ad, chatID: ev.ChatID, replyTo: ev.MessageID})
 		toolDefs = append(toolDefs, tools.SendFileToolDef())
+		// Per-chat Waker so schedule_wakeup (the loop skill) can pace this and
+		// later turns. On wakeup it routes through runChannelIdleTurn, which
+		// delivers via the adapter — including the wakeup-injected turns, which
+		// flow back through here and re-stamp the waker so the loop continues.
+		ctx = tools.WithWaker(ctx, imWaker{s: s, sess: sess, ad: ad, ev: ev})
 	}
 
 	persist := func() {

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -339,9 +339,9 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 		return
 	}
 
-	// A user message takes over: cancel any armed loop so it hands control back
-	// (CC-style). The model can re-arm /loop later.
-	s.cancelWakeup(sid)
+	// Note: a user message does NOT cancel an armed loop — the loop coexists
+	// with the conversation (CC-style). It stops only on an explicit interrupt
+	// or schedule_wakeup(cancel=true).
 
 	// Session-management slash commands handled inline (no model turn). Other
 	// "/..." text falls through to the model, matching the TUI where unknown
@@ -636,8 +636,6 @@ func (s *Server) broadcastRollback(sessionID string) {
 // handleWSRetry re-runs the last turn by stripping the last assistant reply
 // from the session and resending the last user message.
 func (s *Server) handleWSRetry(conn *wsConn, sessionID string) {
-	// A retry is a user action: cancel any armed loop first.
-	s.cancelWakeup(sessionID)
 	sess, err := agent.LoadSession(sessionID)
 	if err != nil {
 		s.wsHub.broadcast(sessionID, map[string]string{

--- a/internal/skills/defaults/loop/SKILL.md
+++ b/internal/skills/defaults/loop/SKILL.md
@@ -40,8 +40,8 @@ schedule_wakeup(delay_seconds=300, repeat=true,
 ```
 
 You only call it **once** — the cadence holds on its own. Each tick re-runs
-`prompt` as a fresh turn. The loop stops when the user sends a message or
-interrupts. Pass the task verbatim as `prompt` so every tick does the same work.
+`prompt` as a fresh turn. Pass the task verbatim as `prompt` so every tick does
+the same work. The loop keeps ticking until it's stopped (see **Stopping**).
 
 ## Dynamic mode — you set the pace
 
@@ -84,10 +84,21 @@ beats "waiting".
 
 ## Stopping
 
-- **Dynamic mode**: stop by *not* calling `schedule_wakeup` — say the loop is done.
-- **Interval mode**: it runs until the user interrupts or sends a message.
-- Either way, **a new user message cancels the loop** and hands control back to
-  the user. You can re-arm `/loop` later if asked.
+The loop **coexists with the conversation**: the user can talk to you mid-loop —
+ask a question, give a side instruction — and the loop **keeps ticking**. A user
+message does *not* stop it. Stop it explicitly:
+
+- **Dynamic mode**: stop by *not* calling `schedule_wakeup` on a turn — say the
+  loop is done and why.
+- **Interval mode**: it re-arms on its own, so to stop it you must call
+  `schedule_wakeup(cancel=true)`. Do this **as soon as the user asks you to stop
+  or pause** ("停掉", "stop the loop", "够了"). Acknowledge that you've stopped it.
+- In the TUI the user can hard-stop any loop with **Ctrl+C**; over an IM
+  channel, `/stop` does the same.
+
+When the user interjects mid-loop, answer them normally — and unless they asked
+you to stop, the loop carries on; mention the next tick so they know it's still
+running.
 
 ## Give every iteration a clear stop/idle condition
 

--- a/internal/tools/schedule_wakeup.go
+++ b/internal/tools/schedule_wakeup.go
@@ -25,6 +25,11 @@ type Waker interface {
 	// human-facing note. Any wakeup already pending for the session is
 	// replaced — a session has at most one armed wakeup at a time.
 	ScheduleWakeup(delay time.Duration, prompt, reason string, repeat bool) error
+
+	// CancelWakeup stops any pending wakeup for the session — the explicit way
+	// to end an interval loop (the dynamic mode ends by simply not re-arming).
+	// No-op when nothing is armed.
+	CancelWakeup() error
 }
 
 // ctxKeyWaker carries the turn-scoped Waker.
@@ -86,15 +91,18 @@ func (ScheduleWakeupTool) Definition() agent.ToolDefinition {
 			"tool again on the next turn; simply NOT calling it ends the loop. Use when you decide " +
 			"the cadence turn-by-turn or want to stop once the task is done.\n" +
 			"- INTERVAL (repeat=true): the wakeup re-arms itself on the same cadence and keeps firing " +
-			"until the user interrupts or sends a new message. Use for a steady \"every N seconds\" loop.\n\n" +
+			"on schedule. Use for a steady \"every N seconds\" loop.\n\n" +
 			"delay_seconds is clamped to [60, 3600]. Picking a cadence: the model's prompt cache has a " +
 			"~5-minute TTL, so a delay under 300s keeps context warm (right for actively polling " +
 			"external state like a CI run or a deploy), while 300s+ pays a cache miss (right when " +
 			"there's genuinely nothing to check sooner). Avoid exactly 300s — it pays the miss without " +
 			"amortizing it. For idle ticks with no specific signal to watch, default to 1200-1800s.\n\n" +
-			"A new user message cancels the loop and hands control back to the user; you can re-arm " +
-			"later. This is an in-session loop — for a schedule that must survive restarts or run " +
-			"while you're away, use the cron-task-creator skill instead.",
+			"The loop COEXISTS with the user: a message from the user does NOT stop it — the user can " +
+			"chat with you while it keeps ticking. To STOP an interval loop, call this tool with " +
+			"cancel=true (do this when the user asks you to stop, or pause); a dynamic loop also stops " +
+			"by simply not re-arming. The user can also hard-stop with Ctrl+C. This is an in-session " +
+			"loop — for a schedule that must survive restarts or run while you're away, use the " +
+			"cron-task-creator skill instead.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -114,6 +122,10 @@ func (ScheduleWakeupTool) Definition() agent.ToolDefinition {
 					"type":        "boolean",
 					"description": "false (default) for dynamic mode (fires once; re-arm yourself to continue). true for interval mode (re-arms automatically on the same cadence).",
 				},
+				"cancel": map[string]any{
+					"type":        "boolean",
+					"description": "true to STOP the current loop (cancel any pending wakeup). Use when the user asks you to stop or pause. The other fields are ignored when cancel is true.",
+				},
 			},
 			"required": []string{"delay_seconds", "reason", "prompt"},
 		},
@@ -124,6 +136,17 @@ func (ScheduleWakeupTool) Execute(ctx context.Context, _ string, input map[strin
 	w := wakerFrom(ctx)
 	if w == nil {
 		return agent.ToolResult{}, fmt.Errorf("schedule_wakeup: no live session to wake — the loop only runs in the interactive TUI or a server (web/IM) session")
+	}
+
+	// Explicit stop: cancel any pending wakeup and ignore the other fields.
+	if boolArg(input, "cancel") {
+		if err := w.CancelWakeup(); err != nil {
+			return agent.ToolResult{}, fmt.Errorf("schedule_wakeup: %w", err)
+		}
+		return agent.ToolResult{
+			Text: "Loop stopped — no further wakeups scheduled.",
+			UI:   map[string]any{"type": "wakeup", "cancelled": true},
+		}, nil
 	}
 
 	prompt := strings.TrimSpace(stringArg(input, "prompt"))

--- a/internal/tools/schedule_wakeup_test.go
+++ b/internal/tools/schedule_wakeup_test.go
@@ -9,16 +9,22 @@ import (
 )
 
 type fakeWaker struct {
-	delay  time.Duration
-	prompt string
-	reason string
-	repeat bool
-	calls  int
+	delay     time.Duration
+	prompt    string
+	reason    string
+	repeat    bool
+	calls     int
+	cancelled int
 }
 
 func (w *fakeWaker) ScheduleWakeup(delay time.Duration, prompt, reason string, repeat bool) error {
 	w.delay, w.prompt, w.reason, w.repeat = delay, prompt, reason, repeat
 	w.calls++
+	return nil
+}
+
+func (w *fakeWaker) CancelWakeup() error {
+	w.cancelled++
 	return nil
 }
 
@@ -72,6 +78,18 @@ func TestScheduleWakeup_ForwardsArgs(t *testing.T) {
 	}
 	if fw.calls != 1 || !fw.repeat || fw.prompt != "do it" || fw.reason != "why" {
 		t.Fatalf("args not forwarded to the waker: %+v", fw)
+	}
+}
+
+func TestScheduleWakeup_Cancel(t *testing.T) {
+	fw := &fakeWaker{}
+	ctx := WithWaker(context.Background(), fw)
+	_, err := (ScheduleWakeupTool{}).Execute(ctx, "schedule_wakeup", map[string]any{"cancel": true})
+	if err != nil {
+		t.Fatalf("cancel should not error even without prompt: %v", err)
+	}
+	if fw.cancelled != 1 || fw.calls != 0 {
+		t.Fatalf("cancel=true should call CancelWakeup, not ScheduleWakeup: %+v", fw)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #949 with two corrections.

## 1. Loop coexists with the user (the actual CC behavior)
#949 made a new user message cancel the loop — that's **wrong**. CC's loop keeps ticking while you chat with it; stopping is explicit (`CronDelete`). Fixed:

- **A user message no longer cancels the loop** — removed cancel-on-message from `submit()` (TUI), `handleWSUserMessage`, and `handleWSRetry`. The user can talk mid-loop while it keeps running.
- **Explicit stop**:
  - `schedule_wakeup(cancel=true)` — the model stops the loop when the user asks ("停掉"/"stop"). The CronDelete equivalent; ignores the other fields.
  - **Ctrl+C** (TUI) / **`/stop`** (IM) — hard manual stop.
- TUI busy-collision now **re-arms** instead of dropping, so a user interjection never silently kills a loop.

## 2. IM channel parity
`schedule_wakeup` now works in IM (channel) sessions. An IM reply must go through the adapter, not the web `wsHub`, so a new **`imWaker`** enqueues the loop prompt into the session Inbox and launches `runChannelIdleTurn` (the same path async-completion notes use to reach an IM user). The wakeup-injected turn flows back through `runChannelTurns` and re-stamps the waker, so the loop continues.

`armWakeup` is refactored to `armWakeupFn(key, delay, repeat, fire)` — web and IM share the timer bookkeeping, only the delivery `fire` differs. IM timers live under the `im:<key>` namespace (no collision with web session IDs). `/stop` and `/clear|/new|/bind|/unbind` cancel an armed IM loop.

## Other
- `tools.Waker` gains `CancelWakeup()`.
- Skill, tool description, and tests updated (coexist assertion flipped; cancel + IM-waker tests added).

Full suite green under `-race`; `gofmt`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
