### PR TITLE
feat(browser): accept the common Playwright selector subset

### DIFF
--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -28,13 +28,15 @@ func splitFrame(selector string) (frame, elem string) {
 }
 
 // elemRefJS builds a JS expression evaluating to the target element, piercing a
-// same-origin iframe's contentDocument when a frame selector is given.
+// same-origin iframe's contentDocument when a frame selector is given. The
+// element selector may be plain CSS or the supported Playwright subset
+// (resolveSelectorJS).
 func elemRefJS(frame, elem string) string {
 	if frame == "" {
-		return fmt.Sprintf("document.querySelector(%s)", jsString(elem))
+		return resolveSelectorJS("document", elem)
 	}
-	return fmt.Sprintf("(()=>{const f=document.querySelector(%s);return f&&f.contentDocument?f.contentDocument.querySelector(%s):null;})()",
-		jsString(frame), jsString(elem))
+	return fmt.Sprintf("(()=>{const f=document.querySelector(%s);return f&&f.contentDocument?(%s):null;})()",
+		jsString(frame), resolveSelectorJS("f.contentDocument", elem))
 }
 
 // elementCenter scrolls an element into view and returns its viewport-center
@@ -67,7 +69,7 @@ func (p *Page) elementCenter(ctx context.Context, selector string) (point, error
 		return point{}, fmt.Errorf("selector %q matched nothing", selector)
 	}
 	if res.BadSelector {
-		return point{}, fmt.Errorf("invalid CSS selector %q — :has-text/:contains are Playwright-only, not CSS; use a plain CSS selector (run the observe action to list valid ones)", selector)
+		return point{}, fmt.Errorf("invalid selector %q — use plain CSS or a supported Playwright form (:has-text(\"…\"), text=…, :visible, xpath=…); run the observe action to list valid selectors", selector)
 	}
 	return point{X: res.X, Y: res.Y}, nil
 }

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -548,11 +548,56 @@ func TestClick_InvalidSelectorMessage(t *testing.T) {
 	if err := page.Navigate(ctx, srv.URL); err != nil {
 		t.Fatalf("navigate: %v", err)
 	}
-	err = page.Click(ctx, `a:has-text("nope")`)
+	// Genuinely malformed CSS (not a supported Playwright form) must still
+	// produce an actionable message, not a bare "eval threw".
+	err = page.Click(ctx, `a:not(`)
 	if err == nil {
-		t.Fatal("expected an error for an invalid (Playwright) selector")
+		t.Fatal("expected an error for a malformed selector")
 	}
-	if !strings.Contains(err.Error(), "invalid CSS selector") {
+	if !strings.Contains(err.Error(), "invalid selector") {
 		t.Errorf("error should name the invalid selector clearly; got: %v", err)
+	}
+}
+
+// TestClick_PlaywrightSelectors verifies the supported Playwright subset
+// actually resolves and clicks the right element.
+func TestClick_PlaywrightSelectors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!doctype html><html><head><title>t</title></head><body>
+<a id="a1" href="#" onclick="document.title='clicked-'+this.id;return false">Read the report</a>
+<a id="a2" href="#" onclick="document.title='clicked-'+this.id;return false">Other link</a>
+</body></html>`))
+	}))
+	defer srv.Close()
+
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+
+	cases := map[string]string{
+		`a:has-text("Read the report")`: "clicked-a1",
+		`text=Other link`:               "clicked-a2",
+		`xpath=//a[@id="a1"]`:           "clicked-a1",
+	}
+	for sel, wantTitle := range cases {
+		if err := page.Navigate(ctx, srv.URL); err != nil {
+			t.Fatalf("navigate: %v", err)
+		}
+		if err := page.Click(ctx, sel); err != nil {
+			t.Fatalf("click %q: %v", sel, err)
+		}
+		var title string
+		if err := page.Eval(ctx, "document.title", &title); err != nil {
+			t.Fatalf("read title: %v", err)
+		}
+		if title != wantTitle {
+			t.Errorf("selector %q clicked wrong element: title=%q, want %q", sel, title, wantTitle)
+		}
 	}
 }

--- a/internal/browser/selector.go
+++ b/internal/browser/selector.go
@@ -1,0 +1,93 @@
+package browser
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Playwright-flavored selector support. Models trained on Playwright frequently
+// emit its selector dialect, so rather than reject it we translate the common
+// subset to a CDP-evaluable JS query. Covered: the text engines
+// (:has-text / :text / :contains / :text-is and the `text=` prefix), the
+// :visible pseudo, and the `xpath=` / `css=` engine prefixes. :has() is native
+// CSS (Chrome supports it) so it needs no handling. Layout selectors (:near,
+// :right-of …), role=, `>>` engine chaining, and :nth-match are intentionally
+// out of scope — rare in model output and disproportionate to implement.
+
+var (
+	// matches :has-text("x") / :text('x') / :contains(x) / :text-is("x"); the
+	// arg is a single/double-quoted string (with escapes) or bare up to ')'.
+	textPseudoRe    = regexp.MustCompile(`:(has-text|text-is|text|contains)\(\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^)]*?)\s*\)`)
+	visiblePseudoRe = regexp.MustCompile(`:visible\b`)
+)
+
+// resolveSelectorJS returns a JS expression — evaluated against doc, e.g.
+// "document" or a frame's "f.contentDocument" — that yields the first matching
+// element, or null. Plain CSS falls through to querySelector unchanged so the
+// invalid-selector path (a real CSS typo throwing) still works.
+func resolveSelectorJS(doc, sel string) string {
+	sel = strings.TrimSpace(sel)
+	if rest, ok := strings.CutPrefix(sel, "xpath="); ok {
+		// 9 = XPathResult.FIRST_ORDERED_NODE_TYPE.
+		return fmt.Sprintf(`(()=>{try{return document.evaluate(%s,%s,null,9,null).singleNodeValue;}catch(e){return null;}})()`, jsString(rest), doc)
+	}
+	if rest, ok := strings.CutPrefix(sel, "css="); ok {
+		sel = strings.TrimSpace(rest)
+	} else if rest, ok := strings.CutPrefix(sel, "text="); ok {
+		// `text="x"` is exact; `text=x` is a substring match.
+		needle, quoted := unquote(strings.TrimSpace(rest))
+		return scanJS(doc, "*", needle, quoted, false)
+	}
+
+	base, needle, exact, visible := extractPseudos(sel)
+	if needle == "" && !visible {
+		return fmt.Sprintf("%s.querySelector(%s)", doc, jsString(base))
+	}
+	if strings.TrimSpace(base) == "" {
+		base = "*"
+	}
+	return scanJS(doc, base, needle, exact, visible)
+}
+
+// extractPseudos pulls the text and :visible pseudos out of a selector,
+// returning the remaining base CSS plus what was found. The text needle is the
+// (unquoted) argument; exact is true only for :text-is.
+func extractPseudos(sel string) (base, needle string, exact, visible bool) {
+	base = sel
+	if m := textPseudoRe.FindStringSubmatch(base); m != nil {
+		needle, _ = unquote(m[2])
+		exact = m[1] == "text-is"
+		base = textPseudoRe.ReplaceAllString(base, "")
+	}
+	if visiblePseudoRe.MatchString(base) {
+		visible = true
+		base = visiblePseudoRe.ReplaceAllString(base, "")
+	}
+	return strings.TrimSpace(base), needle, exact, visible
+}
+
+// unquote strips one layer of matching quotes (unescaping the delimiter) and
+// reports whether the value was quoted.
+func unquote(s string) (string, bool) {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		q := s[0]
+		if (q == '"' || q == '\'') && s[len(s)-1] == q {
+			return strings.ReplaceAll(s[1:len(s)-1], `\`+string(q), string(q)), true
+		}
+	}
+	return s, false
+}
+
+// scanJS builds a JS query that walks base-CSS matches and returns the first
+// (or, when filtering by text, the tightest — shortest textContent) element
+// passing the visibility and text filters.
+func scanJS(doc, base, needle string, exact, visible bool) string {
+	hasNeedle := needle != ""
+	return fmt.Sprintf(`(()=>{var els=%s.querySelectorAll(%s);var best=null,bl=Infinity;for(var i=0;i<els.length;i++){var el=els[i];if(%t&&!(el.offsetParent!==null||el.getClientRects().length))continue;var t=el.textContent||"";if(%t){if(!(%t?t.trim()===%s:t.includes(%s)))continue;}if(!%t)return el;if(t.length<bl){best=el;bl=t.length;}}return best;})()`,
+		doc, jsString(base),
+		visible,
+		hasNeedle, exact, jsString(needle), jsString(needle),
+		hasNeedle)
+}

--- a/internal/browser/selector_test.go
+++ b/internal/browser/selector_test.go
@@ -1,0 +1,71 @@
+package browser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractPseudos(t *testing.T) {
+	cases := []struct {
+		in      string
+		base    string
+		needle  string
+		exact   bool
+		visible bool
+	}{
+		{`a`, `a`, ``, false, false},
+		{`a:has-text("Buy now")`, `a`, `Buy now`, false, false},
+		{`div > a:contains('提交')`, `div > a`, `提交`, false, false},
+		{`button:text-is("OK")`, `button`, `OK`, true, false},
+		{`a:has-text("x"):visible`, `a`, `x`, false, true},
+		{`button:visible`, `button`, ``, false, true},
+		{`:has-text("only text")`, ``, `only text`, false, false},
+		{`a:has-text("with (paren)")`, `a`, `with (paren)`, false, false},
+	}
+	for _, c := range cases {
+		base, needle, exact, visible := extractPseudos(c.in)
+		if base != c.base || needle != c.needle || exact != c.exact || visible != c.visible {
+			t.Errorf("extractPseudos(%q) = (%q,%q,%v,%v), want (%q,%q,%v,%v)",
+				c.in, base, needle, exact, visible, c.base, c.needle, c.exact, c.visible)
+		}
+	}
+}
+
+func TestResolveSelectorJS_Routing(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string // a fragment the generated JS must contain
+	}{
+		{`#id`, `document.querySelector(`},                 // plain CSS untouched
+		{`a:has-text("hi")`, `querySelectorAll(`},          // text → scan
+		{`text=Login`, `querySelectorAll("*")`},            // text= engine
+		{`xpath=//a[@id]`, `document.evaluate(`},           // xpath engine
+		{`css=div.card`, `document.querySelector("div.card")`}, // css= prefix stripped
+		{`button:visible`, `getClientRects`},               // :visible → scan w/ visibility
+	}
+	for _, c := range cases {
+		got := resolveSelectorJS("document", c.in)
+		if !strings.Contains(got, c.want) {
+			t.Errorf("resolveSelectorJS(%q) = %q, want substring %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestUnquote(t *testing.T) {
+	cases := []struct {
+		in     string
+		out    string
+		quoted bool
+	}{
+		{`"x"`, `x`, true},
+		{`'y'`, `y`, true},
+		{`bare`, `bare`, false},
+		{`"a\"b"`, `a"b`, true},
+	}
+	for _, c := range cases {
+		out, q := unquote(c.in)
+		if out != c.out || q != c.quoted {
+			t.Errorf("unquote(%q) = (%q,%v), want (%q,%v)", c.in, out, q, c.out, c.quoted)
+		}
+	}
+}

--- a/internal/browser/selector_test.go
+++ b/internal/browser/selector_test.go
@@ -36,12 +36,12 @@ func TestResolveSelectorJS_Routing(t *testing.T) {
 		in   string
 		want string // a fragment the generated JS must contain
 	}{
-		{`#id`, `document.querySelector(`},                 // plain CSS untouched
-		{`a:has-text("hi")`, `querySelectorAll(`},          // text → scan
-		{`text=Login`, `querySelectorAll("*")`},            // text= engine
-		{`xpath=//a[@id]`, `document.evaluate(`},           // xpath engine
+		{`#id`, `document.querySelector(`},                     // plain CSS untouched
+		{`a:has-text("hi")`, `querySelectorAll(`},              // text → scan
+		{`text=Login`, `querySelectorAll("*")`},                // text= engine
+		{`xpath=//a[@id]`, `document.evaluate(`},               // xpath engine
 		{`css=div.card`, `document.querySelector("div.card")`}, // css= prefix stripped
-		{`button:visible`, `getClientRects`},               // :visible → scan w/ visibility
+		{`button:visible`, `getClientRects`},                   // :visible → scan w/ visibility
 	}
 	for _, c := range cases {
 		got := resolveSelectorJS("document", c.in)

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -186,7 +186,7 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 				"name":       map[string]any{"type": "string", "description": "Skill name (record_stop / run_skill)."},
 				"params":     map[string]any{"type": "object", "description": "Param values for {{...}} placeholders (run_skill)."},
 				"url":        map[string]any{"type": "string", "description": "Target URL (navigate)."},
-				"selector":   map[string]any{"type": "string", "description": "CSS selector of the target element (click/hover/type/select/scroll/wait/upload/download)."},
+				"selector":   map[string]any{"type": "string", "description": "Target element selector (click/hover/type/select/scroll/wait/upload/download). Plain CSS, or a Playwright-style form: :has-text(\"…\")/:text(\"…\")/:contains(\"…\"), text=…, :visible, xpath=…, css=…. Use observe to see real selectors."},
 				"frame":      map[string]any{"type": "string", "description": "Optional CSS selector of a same-origin iframe to scope the selector into (e.g. iframe#app)."},
 				"text":       map[string]any{"type": "string", "description": "Text to type (type)."},
 				"value":      map[string]any{"type": "string", "description": "Option value, text, or label to pick in a <select> (select)."},


### PR DESCRIPTION
## Why

Models trained on Playwright keep emitting its selector dialect (`a:has-text("…")` etc.). Before, that hit an "invalid selector" error and the model burned a turn falling back to plain CSS. Rather than fight the model's tendency, **accept the common subset** and translate it to a CDP query.

## What (curated subset)

- **Text engines**: `:has-text("…")` / `:text("…")` / `:contains("…")` / `:text-is("…")` and the `text=` prefix (quoted = exact, bare = substring). Scans the base-CSS matches and picks the **tightest** (shortest-textContent) element.
- **`:visible`** pseudo — filters via `offsetParent` / `getClientRects()`.
- **Engine prefixes** `xpath=…` and `css=…`.
- `:has()` needs nothing — it's native CSS in Chrome.

**Out of scope** (rare in LLM output, disproportionate to build): layout selectors (`:near`/`:right-of`), `role=`, `>>` engine chaining, `:nth-match`. A genuinely malformed selector still returns an actionable *"invalid selector"* message pointing at `observe`.

This is the "curated subset" option — not the full Playwright engine, which would mean vendoring/porting its selector engine (size + maintenance + licensing, against octo's minimal-deps ethos).

## Tests

- `selector_test.go` — pure unit tests for `extractPseudos`, routing (`resolveSelectorJS`), and `unquote`. No browser.
- Integration (real headless Chrome): `:has-text`, `text=`, and `xpath=` each click the right element; a malformed selector yields the actionable error.

Also documents the supported forms in the `selector` param description so the model uses them confidently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)