### PR TITLE
fix(server): wire browser vision in serve (per-model vision had no effect in web UI)

### DIFF
--- a/internal/server/browser_vision_test.go
+++ b/internal/server/browser_vision_test.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/config"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// TestPrepareToolTurn_WiresBrowserVision guards the serve path: unlike the CLI
+// (app.WireTools), the server wires tools in prepareToolTurn, so it must set the
+// browser vision flag from the active model — otherwise a text-only model gets
+// handed a screenshot it rejects (HTTP 400).
+func TestPrepareToolTurn_WiresBrowserVision(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Name: "txt", Provider: "openai", Model: "qwen3.7-max"}, // heuristic → no vision
+			{Name: "vis", Provider: "openai", Model: "gpt-4o"},      // heuristic → vision
+		},
+		DefaultModel: "txt",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	tools.SetBrowserVision(true) // start opposite of expected to prove it's set
+	if _, _, _, err := srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "qwen3.7-max")); err != nil {
+		t.Fatalf("prepareToolTurn: %v", err)
+	}
+	if tools.BrowserVisionEnabled() {
+		t.Error("vision should be OFF for a text-only model (qwen3.7-max)")
+	}
+
+	tools.SetBrowserVision(false)
+	if _, _, _, err := srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "gpt-4o")); err != nil {
+		t.Fatalf("prepareToolTurn: %v", err)
+	}
+	if !tools.BrowserVisionEnabled() {
+		t.Error("vision should be ON for a vision model (gpt-4o)")
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -734,6 +734,15 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.Context, agent.ToolExecutor, *tools.SubAgentManager, error) {
 	executor := tools.NewDefaultRegistry()
 
+	// Gate browser image content on the active model's vision capability. Unlike
+	// the CLI (which goes through app.WireTools), the server wires tools here, so
+	// this is the only place serve learns whether the model can take images — a
+	// text-only model would otherwise be handed a screenshot it rejects (HTTP
+	// 400). Re-evaluated per turn so a mid-session model switch takes effect.
+	if cfg, err := config.Load(); err == nil {
+		tools.SetBrowserVision(cfg.ModelVision(a.Model))
+	}
+
 	engine, err := permission.New(permissionConfigPath(), s.curCwd(), resolvePermissionMode(), s.memDir, s.homeMemDir)
 	if err != nil {
 		return ctx, nil, nil, fmt.Errorf("permission engine: %w", err)

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -52,6 +52,9 @@ var browserVision = func() *atomic.Bool { b := &atomic.Bool{}; b.Store(true); re
 // SetBrowserVision enables/disables handing images to the model.
 func SetBrowserVision(on bool) { browserVision.Store(on) }
 
+// BrowserVisionEnabled reports the current setting (for tests/diagnostics).
+func BrowserVisionEnabled() bool { return browserVision.Load() }
+
 // SetBrowserHealer injects the LLM-backed step healer used by run_skill.
 func SetBrowserHealer(h browser.Healer) {
 	recorderMu.Lock()


### PR DESCRIPTION
## Bug

`screenshot` still 400'd in the **web UI** (`octo serve`) on a text-only model even with `vision: false` in config.

Root cause: the per-model vision gate (#947/#948) calls `tools.SetBrowserVision` only inside `app.WireTools` — which is the **CLI** path (`cmd/octo/chat.go`). The server wires tools in `prepareToolTurn` and **never called it**, so `browserVision` stayed at its default `true` under `octo serve`. A text-only model (qwen-max/plus) was thus still handed a screenshot image block, and DashScope rejected it with HTTP 400 *"Unexpected item type in content"* — regardless of config.

## Fix

`prepareToolTurn` now sets `tools.SetBrowserVision(cfg.ModelVision(a.Model))` each turn (idempotent; re-evaluated so a mid-session model switch takes effect). Added `tools.BrowserVisionEnabled()` for the test.

## Test

`TestPrepareToolTurn_WiresBrowserVision` — a text-only model (`qwen3.7-max`) leaves vision off, a vision model (`gpt-4o`) turns it on, after `prepareToolTurn`.

## Note

The server's `prepareToolTurn` also doesn't wire the browser self-heal / skill-distill helpers that `WireTools` does (record_stop distill + run_skill heal won't use the model under serve). Separate, pre-existing gap — those need app-exported helpers; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)