### PR TITLE
fix(browser): replace initial about:blank on first navigation (back no longer overshoots)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -196,11 +196,21 @@ func (b *Browser) Pages(ctx context.Context) ([]TargetInfo, error) {
 	return pages, nil
 }
 
-// Navigate loads url and waits for the page load event.
+// Navigate loads url and waits for the page load event. When the page is still
+// on the initial about:blank (the tab octo opened), it replaces that history
+// entry instead of pushing one — otherwise a later Back() lands the model back
+// on the blank tab. Navigation between real pages keeps normal history.
 func (p *Page) Navigate(ctx context.Context, url string) error {
 	events, unsub := p.cli.subscribe("Page.loadEventFired", p.sessionID)
 	defer unsub()
-	if _, err := p.cli.call(ctx, p.sessionID, "Page.navigate", map[string]any{"url": url}); err != nil {
+
+	var cur string
+	_ = p.Eval(ctx, "location.href", &cur)
+	if cur == "" || cur == "about:blank" {
+		if err := p.Eval(ctx, fmt.Sprintf("(()=>{location.replace(%s);return true})()", jsString(url)), nil); err != nil {
+			return err
+		}
+	} else if _, err := p.cli.call(ctx, p.sessionID, "Page.navigate", map[string]any{"url": url}); err != nil {
 		return err
 	}
 	select {

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -601,3 +601,46 @@ func TestClick_PlaywrightSelectors(t *testing.T) {
 		}
 	}
 }
+
+// TestNavigate_ReplacesInitialBlank: the first navigation off about:blank must
+// replace that entry, so going Back from a later page lands on the first real
+// page — not the blank tab octo opened.
+func TestNavigate_ReplacesInitialBlank(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte("<!doctype html><html><head><title>" + r.URL.Path + "</title></head><body>" + r.URL.Path + "</body></html>"))
+	}))
+	defer srv.Close()
+
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL+"/first"); err != nil {
+		t.Fatalf("navigate first: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL+"/second"); err != nil {
+		t.Fatalf("navigate second: %v", err)
+	}
+	if err := page.Back(ctx); err != nil {
+		t.Fatalf("back: %v", err)
+	}
+	// Back should settle on /first, not about:blank. history.back() is async, so
+	// poll briefly.
+	deadline := time.Now().Add(5 * time.Second)
+	var path string
+	for time.Now().Before(deadline) {
+		_ = page.Eval(ctx, "location.pathname", &path)
+		if path == "/first" {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if path != "/first" {
+		t.Errorf("after back, pathname = %q, want /first (about:blank should not be in history)", path)
+	}
+}


### PR DESCRIPTION
## What

octo opens its working tab at `about:blank`, so the first `navigate` pushed a history entry — and a later `back` could land the model back on the blank tab (observed: it overshot to about:blank, then had to re-navigate).

`Navigate` now uses `location.replace` when the current page is still `about:blank`, so the blank never enters history. Real page-to-page navigation keeps normal `back` behavior (CDP `Page.navigate`).

This is the "#1, pure win" from the fluidity discussion — removes one self-inflicted failure mode with zero added round-trips on the hot path. (We deliberately did **not** force observe-before-click, which would have *added* a heavy round-trip per click and made the agent feel more janky now that `:has-text`/`text=` selectors work.)

## Test

`TestNavigate_ReplacesInitialBlank` — about:blank → /first → /second → back lands on **/first**, not about:blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)