### PR TITLE
fix(server): wire browser self-heal + skill-distill in serve

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -39,8 +39,8 @@ func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
 	tools.SetDefaultSubAgentManager(mgr)
 
 	// LLM-backed distill (record_stop) + self-heal (run_skill) for browser skills.
-	tools.SetBrowserSkillGenerator(makeSkillGenerator(a.Sender, a.Model))
-	tools.SetBrowserHealer(makeBrowserHealer(a.Sender, a.Model))
+	tools.SetBrowserSkillGenerator(MakeSkillGenerator(a.Sender, a.Model))
+	tools.SetBrowserHealer(MakeBrowserHealer(a.Sender, a.Model))
 
 	// Gate image content (browser screenshots) on the active model's vision
 	// capability so a text-only model isn't handed images its endpoint rejects.

--- a/internal/app/browser_heal.go
+++ b/internal/app/browser_heal.go
@@ -9,14 +9,14 @@ import (
 	"github.com/Leihb/octo-agent/internal/browser"
 )
 
-// makeBrowserHealer builds the LLM-backed step healer used by the browser tool's
+// MakeBrowserHealer builds the LLM-backed step healer used by the browser tool's
 // run_skill. When a recorded step fails (e.g. a drifted selector), it shows the
 // model the page's current interactive elements (a text digest — model-agnostic,
 // no vision needed when the DOM/AX is reachable) and asks for the corrected
 // selector, which it writes into the step for retry + write-back.
 //
 // Returns nil when no sender is configured, so run_skill stays deterministic.
-func makeBrowserHealer(sender agent.Sender, model string) browser.Healer {
+func MakeBrowserHealer(sender agent.Sender, model string) browser.Healer {
 	if sender == nil {
 		return nil
 	}
@@ -55,11 +55,11 @@ func makeBrowserHealer(sender agent.Sender, model string) browser.Healer {
 	}
 }
 
-// makeSkillGenerator builds the LLM-backed skill distiller for record_stop. It
+// MakeSkillGenerator builds the LLM-backed skill distiller for record_stop. It
 // refines the deterministic baseline into a clean optimal-path skill, grounded
 // in the captured selectors (the engine enforces the selector constraint).
 // Returns nil when no sender is configured, so generation stays deterministic.
-func makeSkillGenerator(sender agent.Sender, model string) browser.SkillGenerator {
+func MakeSkillGenerator(sender agent.Sender, model string) browser.SkillGenerator {
 	if sender == nil {
 		return nil
 	}

--- a/internal/server/browser_helpers_test.go
+++ b/internal/server/browser_helpers_test.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/tools"
+)
+
+// TestPrepareToolTurn_WiresBrowserLLMHelpers guards the serve path: record_stop
+// distillation and run_skill self-heal need a model, and serve wires tools in
+// prepareToolTurn (not app.WireTools), so it must install the healer + skill
+// generator — otherwise the web UI silently has no self-heal / LLM distill.
+func TestPrepareToolTurn_WiresBrowserLLMHelpers(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	// Clear them, then confirm a tool turn installs them from the agent's sender.
+	tools.SetBrowserHealer(nil)
+	tools.SetBrowserSkillGenerator(nil)
+
+	a := agent.New(&stubSender{}, "stub-model")
+	if _, _, _, err := srv.prepareToolTurn(context.Background(), a); err != nil {
+		t.Fatalf("prepareToolTurn: %v", err)
+	}
+	if !tools.BrowserHealerSet() {
+		t.Error("run_skill self-heal helper not wired in serve")
+	}
+	if !tools.BrowserSkillGeneratorSet() {
+		t.Error("record_stop skill generator not wired in serve")
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -743,6 +743,13 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent) (context.C
 		tools.SetBrowserVision(cfg.ModelVision(a.Model))
 	}
 
+	// Same omission for the LLM-backed browser helpers: record_stop's skill
+	// distillation and run_skill's selector self-heal need a model. WireTools
+	// installs these for the CLI; serve must too, or the web UI silently falls
+	// back to deterministic compilation and no self-heal.
+	tools.SetBrowserSkillGenerator(app.MakeSkillGenerator(a.Sender, a.Model))
+	tools.SetBrowserHealer(app.MakeBrowserHealer(a.Sender, a.Model))
+
 	engine, err := permission.New(permissionConfigPath(), s.curCwd(), resolvePermissionMode(), s.memDir, s.homeMemDir)
 	if err != nil {
 		return ctx, nil, nil, fmt.Errorf("permission engine: %w", err)

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -55,6 +55,19 @@ func SetBrowserVision(on bool) { browserVision.Store(on) }
 // BrowserVisionEnabled reports the current setting (for tests/diagnostics).
 func BrowserVisionEnabled() bool { return browserVision.Load() }
 
+// BrowserHealerSet / BrowserSkillGeneratorSet report whether the LLM-backed
+// browser helpers are wired (for tests/diagnostics).
+func BrowserHealerSet() bool {
+	recorderMu.Lock()
+	defer recorderMu.Unlock()
+	return browserHealer != nil
+}
+func BrowserSkillGeneratorSet() bool {
+	recorderMu.Lock()
+	defer recorderMu.Unlock()
+	return browserSkillGen != nil
+}
+
 // SetBrowserHealer injects the LLM-backed step healer used by run_skill.
 func SetBrowserHealer(h browser.Healer) {
 	recorderMu.Lock()


### PR DESCRIPTION
## Bug

`record_stop`'s LLM skill **distillation** and `run_skill`'s selector **self-heal** were installed only by `app.WireTools` (the CLI path). The server wires tools in `prepareToolTurn` and never set them, so under **`octo serve`** (the web UI):
- `record_stop` silently fell back to deterministic compilation (no LLM-distilled optimal path),
- `run_skill` had **no self-heal** (a drifted selector just failed instead of being repaired).

Same class of omission as the vision flag (#954).

## Fix

Export `MakeBrowserHealer` / `MakeSkillGenerator` from `internal/app` and install them in `prepareToolTurn` from the turn agent's `Sender`+`Model` (re-set per turn, idempotent — matches the vision wiring). The CLI callsites in `WireTools` now use the exported names.

## Test

`TestPrepareToolTurn_WiresBrowserLLMHelpers` — after a tool turn, both the healer and skill generator are wired (added `tools.BrowserHealerSet`/`BrowserSkillGeneratorSet`).

## Note

The healer/distiller call the model synchronously during the tool turn (same as the CLI). Self-heal model behavior still isn't exercised in CI (no live network) — the seams are tested with fakes; real behavior is what you're about to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)