### PR TITLE
fix(windows): silent background daemon + stop the whole serve tree

### DIFF
--- a/cmd/octo/serve_daemon_windows.go
+++ b/cmd/octo/serve_daemon_windows.go
@@ -8,17 +8,21 @@ import (
 	"syscall"
 )
 
-// detachedProcess tells Windows to create the child without inheriting the
-// parent's console. Combined with stdout/stderr redirected to a log file, the
-// process runs silently in the background with no terminal window.
-const detachedProcess = 0x00000008
+// createNoWindow gives the child its own console but with no visible window.
+// We deliberately avoid DETACHED_PROCESS (0x8) here: a detached child has *no*
+// console at all, so when it spawns its own console-app children (the daemon
+// child is the supervisor, which spawns the serve worker) Windows allocates a
+// fresh *visible* console for each grandchild. With a windowless console the
+// grandchildren inherit it and stay invisible. Combined with stdout/stderr
+// redirected to a log file, the whole tree runs silently in the background.
+const createNoWindow = 0x08000000
 
-// setSysProcAttrDetach creates the child as a detached process so it does not
-// inherit the parent console and does not receive Ctrl-C signals sent to the
-// terminal.
+// setSysProcAttrDetach creates the child with a windowless console so neither it
+// nor any console-app grandchild it spawns pops a terminal window, and it does
+// not receive Ctrl-C signals sent to the parent's terminal.
 func setSysProcAttrDetach(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: detachedProcess,
+		CreationFlags: createNoWindow,
 	}
 }
 


### PR DESCRIPTION
两个 Windows serve daemon 的修复,都直接影响安装/升级体验,同文件改动,合并审阅。

## 1. 安装后弹 cmd 窗口

进后台的三个入口(安装时 `LaunchAndOpenDashboard`、开机自启 VBS、`octo upgrade` 重启)都走 `octo serve -d` → `startDaemon`,后者用 **`DETACHED_PROCESS`(0x8)** spawn supervisor。`DETACHED_PROCESS` 让 supervisor **完全没有 console**;当它接着 spawn serve worker(console 程序)时,按 `CreateProcess` 规则——父无 console → 系统给子进程**新分配可见 console 窗口**。这就是小白用户看到的 cmd 窗口。

而且不止首次启动:**每一次 worker 重启**(web 升级后的 restart、`/api/restart`、崩溃自愈)都会弹一个新窗口。

**修复**:改用 **`CREATE_NO_WINDOW`(0x08000000)**。supervisor 拿到一个无窗口 console,worker 及后续每次重启都继承它 → 整条进程树静默。前台 `octo serve` 不走这条路径,行为不变。

## 2. `serve --stop` 只杀了 supervisor,worker 被孤儿化

daemon 是进程树:pid 文件记的是 **supervisor**,它再 spawn **worker**(真正 bind :8080)。`stopDaemon` 只对 supervisor pid 做 `TerminateProcess`。

- POSIX:supervisor 捕获 SIGTERM 后 `forward()` 转发给 worker → 整树优雅退出 ✅
- Windows:`forward()` 是 no-op,且 stop 是硬 `TerminateProcess` → **worker 被孤儿化**,继续占 :8080、继续锁 octo.exe

这会让安装器的原地升级失败——`ssInstall` 跑 `serve --stop` 的全部目的就是在覆盖二进制+重启前释放文件锁和端口。

**修复**:用 **`taskkill /F /T`** 杀整棵树(repo 里 terminal 工具 `terminal_kill_windows.go` 已是这个套路),taskkill 不可用时回退到单进程 Kill。POSIX 不动。

## 验证
- `GOOS=windows / linux / darwin go build ./cmd/octo/` 全绿
- `gofmt -l` 干净
- `go test ./cmd/octo/`(daemon + supervisor)通过
- Windows 专属的 `taskkill` shell-out 与现有 `terminal_kill_windows.go` 一样无法在 darwin 单测,靠交叉编译保证

🤖 Generated with [Claude Code](https://claude.com/claude-code)