### PR TITLE
fix(browser): probe cached page for liveness (run_skill -32001 across sessions)

### DIFF
--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -99,12 +99,17 @@ func ResetBrowserSession() {
 	p := browserSession.page
 	browserSession.b, browserSession.page = nil, nil
 	browserSession.mu.Unlock()
+	closeSession(b, p)
+}
+
+// closeSession tears down a browser session. When we attached to the user's own
+// Chrome, Close() only drops the WS and leaves our tab behind, so close the tab
+// we opened too (don't litter the user's browser); if we launched Chrome
+// ourselves, Close() kills it whole. Safe to call with nils.
+func closeSession(b *browser.Browser, p *browser.Page) {
 	if b == nil {
 		return
 	}
-	// When we attached to the user's own Chrome, Close() only drops the WS and
-	// leaves our tab behind. Close the tab we opened so we don't litter the
-	// user's browser; if we launched Chrome ourselves, Close() kills it whole.
 	if !b.OwnsProcess() && p != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		_ = b.ClosePage(ctx, p.TargetID())
@@ -126,7 +131,19 @@ func browserPage(ctx context.Context) (*browser.Page, *browser.Browser, error) {
 	browserSession.mu.Lock()
 	defer browserSession.mu.Unlock()
 	if browserSession.page != nil {
-		return browserSession.page, browserSession.b, nil
+		// The session is package-global and shared across chat sessions, so a tab
+		// opened (and since navigated/closed) in an earlier session can leave a
+		// stale handle whose CDP target is gone — every action would then fail with
+		// "Session with given id not found" (-32001). Probe liveness before reusing
+		// it; if dead, tear it down (off the lock) and re-establish below.
+		probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		err := browserSession.page.Eval(probeCtx, "1", nil)
+		cancel()
+		if err == nil {
+			return browserSession.page, browserSession.b, nil
+		}
+		go closeSession(browserSession.b, browserSession.page)
+		browserSession.b, browserSession.page = nil, nil
 	}
 	cfg, _ := config.Load()
 	bc := cfg.Browser


### PR DESCRIPTION
## Bug

Recording a skill, then immediately opening a **new chat** and replaying it (`run_skill`) failed at the first step:

```
browser: run_skill "zhihu-hot-first": step 1 (navigate): Runtime.evaluate: cdp error -32001: Session with given id not found.
```

## Root cause

`browserSession` is a **package-global shared across all chat sessions**, and `browserPage` returned the cached `page` whenever it was non-nil — **without checking it was still alive**. A tab opened (and since navigated or closed) in an earlier session leaves a stale handle whose CDP target is gone, so every action in a later session fails with `-32001 Session with given id not found`.

`ResetBrowserSession` only runs at chat-session cleanup, so two overlapping sessions (record in A, replay in a fresh B while A is still open) share — and trip over — the same stale global handle.

## Fix

Probe the cached page with a cheap, short-timeout `Eval("1")` before reusing it. On failure, tear it down off the lock and fall through to the normal reconnect path (which opens a fresh tab). Factored the teardown out of `ResetBrowserSession` into a shared `closeSession` helper.

This keeps the global-session design (a per-chat-session browser is a larger refactor) but makes it self-heal instead of handing back a dead handle.

## Verification

- `go vet ./internal/tools/` — clean
- `go build ./...` — clean
- `go test ./internal/tools/ -run Browser` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)