### PR TITLE
feat(browser): make recordings keyword-triggerable via a companion SKILL.md

### DIFF
--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -128,6 +128,7 @@ func GenerateSkill(ctx context.Context, name, startURL string, events []Recorded
 		"(2) Drop redundant back-and-forth and retries; keep the intended linear path. " +
 		"(3) Replace user-specific input values with {{param}} and declare each in params (keep upload's {{file}}). " +
 		"(4) Preserve step order and the leading navigate. " +
+		"(5) Write description as a short statement of what the workflow does, then the natural phrases a user would say to invoke it — in the page's own language AND English (e.g. \"打开知乎热榜并点第一条。当用户说\\\"知乎热榜\\\"、\\\"zhihu hot\\\"时触发\"). This description is the auto-trigger cue, so make those phrases concrete. " +
 		"Output ONLY the skill as YAML (keys: name, description, params, steps), no prose, no code fences."
 	user := fmt.Sprintf("Baseline (the only valid selectors are those here):\n%s\n\nRaw events in order:\n%s\n\nReturn the cleaned skill YAML.", baseYAML, renderTrace(events))
 

--- a/internal/server/browser_recordings_handlers.go
+++ b/internal/server/browser_recordings_handlers.go
@@ -137,5 +137,8 @@ func (s *Server) handleDeleteBrowserRecording(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("delete recording: %v", err))
 		return
 	}
+	// Drop the keyword-trigger companion SKILL.md too (only if we generated it),
+	// so deleting a recording doesn't leave a trigger that fails on replay.
+	tools.DeleteRecordingSkillDoc(name)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -52,9 +52,13 @@ type Registry struct {
 	cwd      string
 }
 
-// userSkillsRoot returns ~/.octo/skills, or "" when the home dir can't be
-// resolved. It's a var so tests can point discovery at a temp directory.
+// userSkillsRoot returns ~/.octo/skills (or $OCTO_SKILLS_DIR when set), or ""
+// when the home dir can't be resolved. It's a var so tests can point discovery
+// at a temp directory.
 var userSkillsRoot = func() string {
+	if d := os.Getenv("OCTO_SKILLS_DIR"); d != "" {
+		return d
+	}
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return ""

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/browser"
 	"github.com/Leihb/octo-agent/internal/config"
+	"github.com/Leihb/octo-agent/internal/skills"
 )
 
 // browserSession holds the per-session Chrome connection, reused across tool
@@ -90,6 +91,58 @@ func BrowserSkillsDir() string {
 	}
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".octo", "browser-skills")
+}
+
+// recordingSkillMarker tags the companion SKILL.md that record_stop generates
+// for a recording, so DeleteRecordingSkillDoc only ever removes our own file and
+// never a hand-authored skill that happens to share the recording's name.
+const recordingSkillMarker = "octo_recording: true"
+
+// recordingSkillDir is the companion skill directory (~/.octo/skills/<name>) for
+// a recording, "" when the user skills root can't be resolved.
+func recordingSkillDir(name string) string {
+	root := skills.UserRoot()
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, name)
+}
+
+// WriteRecordingSkillDoc writes the companion SKILL.md that makes a recording
+// keyword-triggerable: a fresh session discovers it and, when the user's request
+// matches description, the model loads it and replays via run_skill. Best-effort.
+func WriteRecordingSkillDoc(name, description string) error {
+	dir := recordingSkillDir(name)
+	if dir == "" {
+		return fmt.Errorf("user skills dir unavailable")
+	}
+	if description == "" {
+		description = "Replay the recorded browser automation " + name + "."
+	}
+	body := fmt.Sprintf("---\nname: %s\ndescription: %s\n%s\n---\n\n"+
+		"# %s\n\nReplay the recorded browser automation %q with the browser tool:\n\n"+
+		"```\nbrowser action=run_skill name=%q\n```\n\n"+
+		"This deterministically replays the recorded steps (with selector self-healing). "+
+		"Pass any required values via params.\n", name, description, recordingSkillMarker, name, name, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, skills.SkillFile), []byte(body), 0o644)
+}
+
+// DeleteRecordingSkillDoc removes a recording's companion SKILL.md directory,
+// but only when it carries our generated marker — never a user-authored skill of
+// the same name. Best-effort; a no-op when nothing matches.
+func DeleteRecordingSkillDoc(name string) {
+	dir := recordingSkillDir(name)
+	if dir == "" {
+		return
+	}
+	data, err := os.ReadFile(filepath.Join(dir, skills.SkillFile))
+	if err != nil || !strings.Contains(string(data), recordingSkillMarker) {
+		return
+	}
+	_ = os.RemoveAll(dir)
 }
 
 // ResetBrowserSession closes and clears the active browser session.
@@ -527,7 +580,14 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		if err := browser.SaveSkill(path, skill); err != nil {
 			return agent.ToolResult{}, err
 		}
-		return agent.ToolResult{Text: fmt.Sprintf("recorded %d step(s) → %s\nReview/edit it there (set params, fix selectors), then replay with action=run_skill name=%q.", len(skill.Steps), path, name)}, nil
+		// Also write a companion SKILL.md so the recording is keyword-triggerable:
+		// a new session discovers it and the model replays via run_skill when the
+		// user's request matches. Best-effort — never fail the recording over it.
+		trigger := ""
+		if err := WriteRecordingSkillDoc(name, skill.Description); err == nil {
+			trigger = fmt.Sprintf("\nIt's also a keyword-triggerable skill now — in a new session, just say what it does (per its description: %q) and the model will replay it; no need to spell out run_skill.", skill.Description)
+		}
+		return agent.ToolResult{Text: fmt.Sprintf("recorded %d step(s) → %s\nReview/edit it there (set params, fix selectors), then replay with action=run_skill name=%q.%s", len(skill.Steps), path, name, trigger)}, nil
 
 	case "run_skill":
 		name := getStr(input, "name")

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/browser"
+	"github.com/Leihb/octo-agent/internal/skills"
 )
 
 // toolFixtureHTML mirrors the awkward target system: the download button only
@@ -109,6 +111,7 @@ func TestBrowserTool_RecordRunRoundTrip(t *testing.T) {
 		t.Skip("chrome not available")
 	}
 	t.Setenv("OCTO_BROWSER_SKILLS_DIR", t.TempDir())
+	t.Setenv("OCTO_SKILLS_DIR", t.TempDir())
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>rr</title><button id="b">Go</button>
 <script>window.clicks=0;document.getElementById('b').addEventListener('click',function(){window.clicks++});</script>`))
@@ -141,6 +144,20 @@ func TestBrowserTool_RecordRunRoundTrip(t *testing.T) {
 	time.Sleep(300 * time.Millisecond) // let the capture event arrive
 	if _, err := run(map[string]any{"action": "record_stop", "name": "demo"}); err != nil {
 		t.Fatalf("record_stop: %v", err)
+	}
+
+	// record_stop also writes a keyword-trigger companion SKILL.md so a fresh
+	// session can auto-replay the recording.
+	doc := filepath.Join(os.Getenv("OCTO_SKILLS_DIR"), "demo", skills.SkillFile)
+	if data, err := os.ReadFile(doc); err != nil {
+		t.Fatalf("companion SKILL.md not written: %v", err)
+	} else if !strings.Contains(string(data), recordingSkillMarker) {
+		t.Fatalf("companion SKILL.md missing generated marker")
+	}
+	// DeleteRecordingSkillDoc removes only our generated companion.
+	DeleteRecordingSkillDoc("demo")
+	if _, err := os.Stat(doc); !os.IsNotExist(err) {
+		t.Fatalf("companion SKILL.md not cleaned up by DeleteRecordingSkillDoc")
 	}
 
 	// Replay: navigates back to the start URL (reset clicks) and re-clicks.


### PR DESCRIPTION
## Why

After recording, the agent told the user *"just say 知乎热榜 to replay it"* — but that was a hallucination: a recording is only a YAML in `~/.octo/browser-skills`, replayable via `run_skill` / the Replay button, and a fresh session has no idea it exists. Keyword triggering simply didn't work.

This makes it real (the user-approved direction).

## How

`record_stop` now also writes a **companion `~/.octo/skills/<name>/SKILL.md`**, so a new session discovers the recording as a first-class skill: when the user's request matches its `description`, the model loads it and replays via `run_skill` — no explicit `run_skill` needed.

- **Distill prompt** (`internal/browser/skill.go`): `description` must state what the workflow does **and** the natural phrases that invoke it (page language + English). That one line is the L1 auto-trigger cue, so it must carry concrete trigger phrases.
- **`internal/tools/browser.go`**: `WriteRecordingSkillDoc` (frontmatter `name`/`description` + a generated marker + a body that calls `run_skill`) and `DeleteRecordingSkillDoc` (removes the companion **only** when it carries our marker — never a user-authored same-name skill). `record_stop` writes it best-effort and reports it.
- **`internal/server/browser_recordings_handlers.go`**: `DELETE /api/browser/recordings/{name}` also drops the companion, so a deleted recording leaves no orphaned trigger that would fail on replay.
- **`internal/skills/skills.go`**: `userSkillsRoot` honors `$OCTO_SKILLS_DIR` (mirrors `OCTO_BROWSER_SKILLS_DIR`) for isolation/testing.

Pairs with the run_skill stale-session fix (#965) — together the record → keyword-trigger → replay loop works end to end.

## Verification

- `go build ./...`, `go vet ./internal/{tools,browser,skills,server}` — clean
- `go test ./internal/skills ./internal/browser` — pass
- `go test ./internal/tools -run 'Browser|Record'` — pass (round-trip test now also asserts the companion SKILL.md is written with the marker and cleaned up by DeleteRecordingSkillDoc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)