### PR TITLE
fix(browser): reuse the browser connection so Chrome re-auths only once per process

### DIFF
--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -187,16 +187,30 @@ func browserPage(ctx context.Context) (*browser.Page, *browser.Browser, error) {
 		// The session is package-global and shared across chat sessions, so a tab
 		// opened (and since navigated/closed) in an earlier session can leave a
 		// stale handle whose CDP target is gone — every action would then fail with
-		// "Session with given id not found" (-32001). Probe liveness before reusing
-		// it; if dead, tear it down (off the lock) and re-establish below.
+		// "Session with given id not found" (-32001). Probe liveness before reusing.
 		probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 		err := browserSession.page.Eval(probeCtx, "1", nil)
 		cancel()
 		if err == nil {
 			return browserSession.page, browserSession.b, nil
 		}
-		go closeSession(browserSession.b, browserSession.page)
-		browserSession.b, browserSession.page = nil, nil
+		// The page's CDP target is gone, but the browser-level WS is almost always
+		// still fine. Drop ONLY the dead page and keep the connection — reopening a
+		// tab on it below needs no new WS dial. A fresh dial makes Chrome re-show
+		// its remote-debugging authorization prompt every single time, which is
+		// exactly what we must avoid within one process.
+		browserSession.page = nil
+	}
+	// Reuse the live browser connection if we have one: open a fresh tab on it
+	// (same WS → no re-auth). Only if that fails is the connection itself gone
+	// (Chrome closed/restarted), so drop it and fall through to a fresh connect.
+	if browserSession.b != nil {
+		if page, err := browserSession.b.NewPage(ctx, "about:blank"); err == nil {
+			browserSession.page = page
+			return page, browserSession.b, nil
+		}
+		go closeSession(browserSession.b, nil)
+		browserSession.b = nil
 	}
 	cfg, _ := config.Load()
 	bc := cfg.Browser


### PR DESCRIPTION
## Bug

Every browser execution re-popped Chrome's remote-debugging **authorization prompt**, even within one `octo serve` process.

## Root cause

`browserPage` cached the page, but when that page went stale (its CDP target gone — common across the global, cross-session browser state), the #965 liveness probe closed the **whole session** (`closeSession` drops the WS) and the next action **redialed** Chrome. Each fresh CDP dial triggers Chrome's "allow remote debugging" consent again → a prompt on every execution.

## Fix

Separate **page lifetime** from **connection lifetime**:

1. Cached page alive → reuse (unchanged).
2. Cached page dead → drop **only the page**, keep the browser WS, and open a fresh tab on the existing connection via `Target.createTarget` (same WS → **no new prompt**).
3. Only when opening a tab fails (the connection itself is gone — Chrome closed/restarted) do we drop it and redial.

So the browser is dialed **once per process** in the common case, and the authorization prompt appears once. Still self-heals the `-32001` stale-target case that #965 addressed — just without nuking the connection.

## Verification

- `go build ./...`, `go vet ./internal/tools` — clean
- `go test ./internal/tools -run 'Browser|Record'` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)