### PR TITLE
fix(scheduler): retry rename to fix Windows save flake

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -383,5 +383,22 @@ func (s *Scheduler) save(task Task) error {
 	if err := os.WriteFile(tmp, data, 0600); err != nil {
 		return err
 	}
-	return os.Rename(tmp, p)
+	return renameWithRetry(tmp, p)
+}
+
+// renameWithRetry replaces newpath with oldpath, retrying briefly on transient
+// failures. On Windows, renaming onto an existing file fails with
+// ERROR_ACCESS_DENIED / ERROR_SHARING_VIOLATION when the destination is
+// momentarily open (a concurrent reader, an AV scan) — a flake we hit saving
+// task bookkeeping. POSIX rename is atomic and succeeds on the first try, so
+// this is a no-op cost there.
+func renameWithRetry(oldpath, newpath string) error {
+	var err error
+	for i := 0; i < 20; i++ {
+		if err = os.Rename(oldpath, newpath); err == nil {
+			return nil
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return err
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -3,11 +3,37 @@ package scheduler
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 )
+
+// TestRenameWithRetry overwrites an existing destination, the case that flakes
+// on Windows when the target is momentarily open.
+func TestRenameWithRetry(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "t.json")
+	if err := os.WriteFile(dst, []byte("old"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	tmp := dst + ".tmp"
+	if err := os.WriteFile(tmp, []byte("new"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := renameWithRetry(tmp, dst); err != nil {
+		t.Fatalf("renameWithRetry: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("content = %q, want %q", got, "new")
+	}
+}
 
 // recordRunner records every RunTask call for assertions.
 type recordRunner struct {


### PR DESCRIPTION
## Flake

`TestRunNowFiresDisabledTaskAndPersistsBookkeeping` fails intermittently on Windows CI:

```
[scheduler] save task "n": rename …t1.json.<ts>.tmp …t1.json: Access is denied.
scheduler_test.go: timed out waiting for persisted bookkeeping
```

On Windows, `os.Rename` onto an **existing** file transiently fails with `ERROR_ACCESS_DENIED` / `ERROR_SHARING_VIOLATION` when the destination is momentarily open (a concurrent reader, an AV scan). POSIX rename is atomic, so this never bites on Linux/macOS.

## Fix

`scheduler.save` now renames through `renameWithRetry` (20 × 20 ms). On POSIX it succeeds on the first try (no added cost); on Windows it rides out the brief lock. Added a happy-path test that overwrites an existing destination.

## Verification

- `go test ./internal/scheduler -run 'RenameWithRetry|RunNow'` — pass
- `go vet ./internal/scheduler` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)