### PR TITLE
feat(browser): text-anchored replay — stop trusting drift-prone positional selectors

### DIFF
--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -39,6 +39,50 @@ func elemRefJS(frame, elem string) string {
 		jsString(frame), resolveSelectorJS("f.contentDocument", elem))
 }
 
+// resolveClickTarget picks the selector to act on for a click whose recorded
+// element had stable visible text (anchor). Positional selectors drift, and
+// worse, after a layout change can silently match the WRONG node — so the
+// recorded text is the reliable signal. It polls up to timeout for, in order of
+// preference: the original positional element when its text still contains the
+// anchor (the unchanged-page fast path, preserving the exact original target),
+// or any element carrying the anchor text (drift recovery). If neither appears
+// it returns the positional selector unchanged, so a genuine miss still fails
+// and reaches the healer. anchor must be non-empty.
+func (p *Page) resolveClickTarget(ctx context.Context, frame, elemSel, anchor string, timeout time.Duration) string {
+	posSel := elemSel
+	if frame != "" {
+		posSel = frame + frameDelim + elemSel
+	}
+	textElem := lastTagOf(elemSel) + `:has-text("` + escapeTextArg(anchor) + `")`
+	textSel := textElem
+	if frame != "" {
+		textSel = frame + frameDelim + textElem
+	}
+	check := fmt.Sprintf(`(()=>{let pos=null,txt=null;try{pos=%s;}catch(e){}try{txt=%s;}catch(e){}var a=%s;if(pos&&(pos.textContent||"").trim().includes(a))return "pos";if(txt)return "text";return "";})()`,
+		elemRefJS(frame, elemSel), elemRefJS(frame, textElem), jsString(anchor))
+
+	deadline := time.Now().Add(timeout)
+	for {
+		var choice string
+		if err := p.Eval(ctx, check, &choice); err == nil {
+			switch choice {
+			case "pos":
+				return posSel
+			case "text":
+				return textSel
+			}
+		}
+		if ctx.Err() != nil || !time.Now().Before(deadline) {
+			return posSel
+		}
+		select {
+		case <-ctx.Done():
+			return posSel
+		case <-time.After(150 * time.Millisecond):
+		}
+	}
+}
+
 // elementCenter scrolls an element into view and returns its viewport-center
 // point (adding the iframe's offset for framed targets), or an error if the
 // selector matches nothing.

--- a/internal/browser/selector.go
+++ b/internal/browser/selector.go
@@ -80,6 +80,36 @@ func unquote(s string) (string, bool) {
 	return s, false
 }
 
+// lastTagOf extracts the bare tag name of a CSS selector's last segment, so a
+// recorded positional selector like "div > a:nth-of-type(3) > h2" yields "h2" to
+// scope a text-anchored fallback (h2:has-text(...)). Falls back to "*".
+func lastTagOf(sel string) string {
+	if i := strings.LastIndex(sel, ">"); i >= 0 {
+		sel = sel[i+1:]
+	}
+	sel = strings.TrimSpace(sel)
+	var b strings.Builder
+	for _, r := range sel {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			b.WriteRune(r)
+			continue
+		}
+		break
+	}
+	if b.Len() == 0 {
+		return "*"
+	}
+	return strings.ToLower(b.String())
+}
+
+// escapeTextArg escapes a string for embedding inside a :has-text("...") arg.
+// Only the quote needs escaping — unquote (used when resolving) reverses \" — so
+// a backslash is left as-is (literal backslashes in visible UI text are absent
+// in practice).
+func escapeTextArg(s string) string {
+	return strings.ReplaceAll(s, `"`, `\"`)
+}
+
 // scanJS builds a JS query that walks base-CSS matches and returns the first
 // (or, when filtering by text, the tightest — shortest textContent) element
 // passing the visibility and text filters.

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -329,11 +329,22 @@ func runStep(ctx context.Context, page *Page, step *Step, params map[string]stri
 			return err
 		}
 	case "click":
-		if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
-			return err
-		}
-		if err := page.Click(ctx, target); err != nil {
-			return err
+		// When the recording captured the element's visible text, resolve by text
+		// (verifying or replacing the drift-prone positional selector) — this is
+		// what makes replay survive layout changes and stops silent wrong-element
+		// clicks. resolveClickTarget already polled for existence, so click directly.
+		if a := strings.TrimSpace(step.Label); len(a) >= 2 {
+			target = page.resolveClickTarget(ctx, step.Frame, step.Selector, a, waitTimeout)
+			if err := page.Click(ctx, target); err != nil {
+				return err
+			}
+		} else {
+			if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
+				return err
+			}
+			if err := page.Click(ctx, target); err != nil {
+				return err
+			}
 		}
 	case "type":
 		if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
@@ -350,7 +361,11 @@ func runStep(ctx context.Context, page *Page, step *Step, params map[string]stri
 			return err
 		}
 	case "upload":
-		if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
+		// The upload trigger is a labeled control (e.g. "Choose file"), so prefer
+		// its text the same way clicks do.
+		if a := strings.TrimSpace(step.Label); len(a) >= 2 {
+			target = page.resolveClickTarget(ctx, step.Frame, step.Selector, a, waitTimeout)
+		} else if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
 			return err
 		}
 		// Click the upload control and feed the file through the chooser — works

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -137,6 +137,49 @@ func TestGenerateSkillDistill(t *testing.T) {
 	}
 }
 
+// TestReplayTextAnchorRecoversFromDrift: a recorded positional selector now
+// points at the WRONG element after a layout change, but the recorded text steers
+// replay to the right one — instead of silently clicking the wrong node.
+func TestReplayTextAnchorRecoversFromDrift(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!doctype html><meta charset="utf-8"><title>t</title>
+<div>
+  <button onclick="window.hit='wrong'">Cancel</button>
+  <button onclick="window.hit='right'">Book now</button>
+</div>`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+
+	// The positional selector resolves to the first button ("Cancel") — the wrong
+	// one — but the recorded Label is the second button's text.
+	skill := &Skill{Name: "x", Steps: []Step{
+		{Action: "click", Selector: "div > button:nth-of-type(1)", Label: "Book now"},
+	}}
+	if _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	var hit string
+	if err := page.Eval(ctx, "window.hit||''", &hit); err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if hit != "right" {
+		t.Fatalf("text anchor did not override the drifted selector: window.hit=%q, want %q", hit, "right")
+	}
+}
+
 // TestReplaySkillSelfHeal: a step has a stale selector, the implicit wait fails,
 // the healer repairs the selector, replay retries and succeeds — and reports the
 // skill as modified so the caller can write the fix back.


### PR DESCRIPTION
## Why record/replay was fragile

Recordings on sites without stable `id`/`data-testid`/`name`/`aria-label` (i.e. most consumer sites — Zhihu, Klook) capture **positional** selectors like `div:nth-of-type(4)` or `div > a:nth-of-type(3) > h2`. Two failure modes:

1. They break on any layout change.
2. **Worse:** after drift they can *silently match a different element*. `runStep` only ever did `WaitFor(selector)` → `Click(selector)` and **ignored the element's recorded text** (it sat unused in `Step.Label`, "replay ignores"). So a selector that now resolves to the wrong node clicks it with no error — the healer (which only fires on a hard miss) never gets a chance.

## Fix — text-anchored replay

The recorder already captures each element's visible text; the replay engine already resolves elements by text (`:has-text` / `text=`, added in #952). This wires the two together.

For `click`/`upload` steps that carry recorded text, `resolveClickTarget` polls up to the step timeout and picks, in order of preference:
1. the **original positional element** when its text still contains the anchor — unchanged-page fast path, preserves the exact original target;
2. otherwise **any element carrying the anchor text** (scoped to the recorded tag) — drift recovery;
3. otherwise the positional selector unchanged, so a genuine miss still fails and reaches the LLM healer.

Net effect: positional selectors are no longer blindly trusted, silent wrong-element clicks are gone, and layout drift self-corrects **without** even needing the LLM healer.

No recorder or YAML-schema change — **existing recordings benefit immediately** (their `label:` text is now load-bearing).

## Verification

- `go test ./internal/browser -run 'TextAnchor|Distill|Click|Primitives'` — pass, incl. a new live test where a positional selector pointing at the wrong button after a layout change still clicks the right one via its text.
- `go test ./internal/tools -run RecordRun` — pass (happy-path record→replay unchanged).
- `go vet ./internal/browser` — clean.

Follow-ups if still fragile: smarter selector generation at capture, and deterministic distill cleanup of junk steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)