### PR TITLE
feat(browser): record/replay robustness round 2 (selectors, distill, type verify)

### DIFF
--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -207,6 +207,27 @@ func (p *Page) TypeText(ctx context.Context, selector, text string) error {
 	return err
 }
 
+// fieldNonEmpty reports whether a form field currently holds any value/text —
+// the post-type sanity check, since programmatic input can be silently swallowed
+// by a disabled, re-rendering, or framework-controlled input. It checks
+// non-empty (not an exact match) so masked/formatted inputs that transform the
+// typed value aren't mistaken for a failure.
+func (p *Page) fieldNonEmpty(ctx context.Context, selector string) bool {
+	frame, elem := splitFrame(selector)
+	expr := fmt.Sprintf(`(()=>{const el=%s; if(!el) return false; const v=('value' in el)?el.value:el.textContent; return !!(v&&(''+v).length);})()`, elemRefJS(frame, elem))
+	var ok bool
+	_ = p.Eval(ctx, expr, &ok)
+	return ok
+}
+
+// clearField empties an input/textarea/contenteditable and fires input so
+// framework bindings reset, before a re-type retry.
+func (p *Page) clearField(ctx context.Context, selector string) {
+	frame, elem := splitFrame(selector)
+	expr := fmt.Sprintf(`(()=>{const el=%s; if(!el) return; if('value' in el){el.value='';}else{el.textContent='';} el.dispatchEvent(new Event('input',{bubbles:true})); el.focus();})()`, elemRefJS(frame, elem))
+	_ = p.Eval(ctx, expr, nil)
+}
+
 // modifierBits maps modifier names to the CDP modifier bitmask.
 var modifierBits = map[string]int{"alt": 1, "ctrl": 2, "control": 2, "meta": 4, "cmd": 4, "command": 4, "shift": 8}
 

--- a/internal/browser/recorder.go
+++ b/internal/browser/recorder.go
@@ -43,7 +43,11 @@ const captureScript = `(function(){
     if(el.id) return '#'+CSS.escape(el.id);
     for(var i=0;i<4;i++){var a=['data-testid','data-test','name','aria-label'][i];var v=el.getAttribute&&el.getAttribute(a);if(v)return el.tagName.toLowerCase()+'['+a+'=\"'+CSS.escape(v)+'\"]';}
     var parts=[], node=el, depth=0;
-    while(node && node.nodeType===1 && node.tagName!=='BODY' && depth<5){
+    while(node && node.nodeType===1 && node.tagName!=='BODY' && depth<6){
+      // Anchor the path at the nearest ancestor carrying an id: short and stable,
+      // versus a free-floating nth-of-type chain from <body> that any layout
+      // shift breaks. (el itself has no id here — that returned above.)
+      if(node.id){ parts.unshift('#'+CSS.escape(node.id)); return parts.join(' > '); }
       var part=node.tagName.toLowerCase(); var p=node.parentElement;
       if(p){var same=[].slice.call(p.children).filter(function(c){return c.tagName===node.tagName;}); if(same.length>1){part+=':nth-of-type('+(same.indexOf(node)+1)+')';}}
       parts.unshift(part); node=p; depth++;

--- a/internal/browser/recorder_test.go
+++ b/internal/browser/recorder_test.go
@@ -4,9 +4,54 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
+
+// TestRecorderAnchorsSelectorAtNearestID: an element with no id of its own gets a
+// selector anchored at its nearest id-bearing ancestor, not a free nth-of-type
+// chain from <body> — shorter and far more stable across layout changes.
+func TestRecorderAnchorsSelectorAtNearestID(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<!doctype html><title>rec</title>
+<div><div id="panel"><div><span><a>Open</a></span></div></div></div>`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#panel a", 5*time.Second); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	rec := NewRecorder(page)
+	if err := rec.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := page.Click(ctx, "#panel a"); err != nil {
+		t.Fatalf("click: %v", err)
+	}
+	var evs []RecordedEvent
+	for i := 0; i < 30; i++ {
+		time.Sleep(100 * time.Millisecond)
+		if evs = rec.Events(); len(evs) >= 1 {
+			break
+		}
+	}
+	rec.Stop()
+	if len(evs) == 0 {
+		t.Fatal("no events captured")
+	}
+	if !strings.HasPrefix(evs[0].Selector, "#panel") {
+		t.Fatalf("selector should anchor at the nearest id (#panel), got %q", evs[0].Selector)
+	}
+}
 
 // TestRecorderCapturesActions records a demonstration: a click and a select are
 // driven via trusted input (standing in for a human), and the recorder must

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -100,7 +100,27 @@ func CompileSkill(name, description, startURL string, events []RecordedEvent) Sk
 	if hasUpload {
 		s.Params = append(s.Params, Param{Name: "file", Description: "path to the file to upload"})
 	}
+	s.Steps = dropConsecutiveDupeSteps(s.Steps)
 	return s
+}
+
+// dropConsecutiveDupeSteps removes a step identical to its immediate predecessor
+// (same action/frame/selector/value) — a double-fire the user didn't intend (a
+// jittery double-click, a re-dispatched event). Conservative on purpose: only
+// exact consecutive duplicates, never reordering or dropping distinct steps, so
+// it can't strip a step the workflow actually needs. navigate is exempt.
+func dropConsecutiveDupeSteps(steps []Step) []Step {
+	out := make([]Step, 0, len(steps))
+	for i, st := range steps {
+		if i > 0 {
+			p := steps[i-1]
+			if st.Action != "navigate" && st.Action == p.Action && st.Frame == p.Frame && st.Selector == p.Selector && st.Value == p.Value {
+				continue
+			}
+		}
+		out = append(out, st)
+	}
+	return out
 }
 
 // SkillGenerator asks an LLM to refine a recording into a clean skill. It is a
@@ -350,8 +370,22 @@ func runStep(ctx context.Context, page *Page, step *Step, params map[string]stri
 		if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
 			return err
 		}
-		if err := page.TypeText(ctx, target, subst(step.Value, params)); err != nil {
+		val := subst(step.Value, params)
+		if err := page.TypeText(ctx, target, val); err != nil {
 			return err
+		}
+		// If a non-empty value didn't land, a disabled/re-rendering/framework input
+		// swallowed the programmatic insert — clear and retry once before failing
+		// into the healer. Checks non-empty (not exact match) so masked/formatted
+		// inputs that transform the value aren't wrongly flagged.
+		if val != "" && !page.fieldNonEmpty(ctx, target) {
+			page.clearField(ctx, target)
+			if err := page.TypeText(ctx, target, val); err != nil {
+				return err
+			}
+			if !page.fieldNonEmpty(ctx, target) {
+				return fmt.Errorf("type: %q did not accept input", target)
+			}
 		}
 	case "select":
 		if err := page.WaitFor(ctx, target, waitTimeout); err != nil {

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -99,6 +99,28 @@ func TestUploadViaChooser(t *testing.T) {
 	}
 }
 
+// TestCompileSkillDropsConsecutiveDupes: a jittery double-fire of the same click
+// is collapsed to one step; distinct steps (and a legitimate repeat of the same
+// selector that is separated by another action) are preserved.
+func TestCompileSkillDropsConsecutiveDupes(t *testing.T) {
+	events := []RecordedEvent{
+		{Type: "click", Selector: "#go", Tag: "BUTTON", Text: "Go"},
+		{Type: "click", Selector: "#go", Tag: "BUTTON", Text: "Go"}, // immediate dup → dropped
+		{Type: "change", Selector: "#q", Tag: "INPUT", Value: "x"},
+		{Type: "click", Selector: "#go", Tag: "BUTTON", Text: "Go"}, // same selector but not consecutive → kept
+	}
+	s := CompileSkill("demo", "", "", events)
+	clicks := 0
+	for _, st := range s.Steps {
+		if st.Action == "click" && st.Selector == "#go" {
+			clicks++
+		}
+	}
+	if clicks != 2 {
+		t.Fatalf("expected 2 #go clicks (one dup dropped), got %d: %+v", clicks, s.Steps)
+	}
+}
+
 // TestGenerateSkillDistill: the LLM distiller drops a fumble (a wrong click +
 // going back) and parameterizes a value — and the precision guard rejects any
 // output that invents a selector, falling back to the deterministic baseline.


### PR DESCRIPTION
Three independent hardening passes on top of text-anchored replay (#974). Each is small, conservative, and separately valuable.

### 1. Better capture selectors — anchor at the nearest id
`recorder.go` `sel()` previously fell back to a free `nth-of-type` chain from `<body>` (e.g. `div:nth-of-type(4)`). Now it walks up and anchors the path at the nearest id-bearing ancestor → `#panel > div > a`: shorter and far more stable. The recorded **text** still leads at replay (#974); this just makes the positional fallback much better.

### 2. Deterministic distill cleanup
`CompileSkill` now drops a step identical to its immediate predecessor (same action/frame/selector/value) — a jittery double-fire the user didn't intend. Runs **independent of the LLM distiller**, which no-ops on weak/text-only models and leaves the raw noisy baseline. Conservative: only exact consecutive dupes, never reordering or dropping distinct steps, so it can't strip a needed step.

### 3. Post-type verification
Replay now checks a `type` actually landed: if a non-empty value left the field empty — a disabled/re-rendering/framework-controlled input silently swallowing the programmatic insert — it clears and re-types once before failing into the healer. Deliberately a **non-empty** check, not an exact match, so masked/formatted inputs (which transform the typed value) aren't wrongly flagged.

### Verification
- `go test ./internal/browser -run 'CompileSkill|Distill|TextAnchor|RecorderAnchors|RecorderCaptures|Primitives|Upload|SelectOption'` — pass, incl. new tests for id-anchored capture and consecutive-dup drop.
- `go test ./internal/tools -run RecordRun` — pass (record→replay round-trip unchanged).
- `go vet ./internal/browser` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)