### PR TITLE
fix(tools): let ask_user_question accept 0/1 options instead of erroring

### DIFF
--- a/internal/tools/ask_user_question.go
+++ b/internal/tools/ask_user_question.go
@@ -114,10 +114,12 @@ func (AskUserQuestionTool) Definition() agent.ToolDefinition {
 			"or readability?\"), or scope (\"include the migration too?\"). Don't use it for " +
 			"information you could find in the repo or for questions you should have an opinion " +
 			"on yourself. Pass exactly one question in the `questions` array; fire another call if " +
-			"you need to ask more. Each question needs 2-4 mutually exclusive options; set " +
+			"you need to ask more. Prefer giving 2-4 mutually exclusive options; set " +
 			"multiSelect=true when the choices are NOT mutually exclusive and the user may pick " +
-			"several. An \"Other\" tail with a free-text follow-up is always added. Result text is " +
-			"shaped like 'User chose: <label>' or, for Other, 'User chose: Other — <free text>'.",
+			"several. When there are no natural choices to offer (e.g. \"what should we name it?\"), " +
+			"omit options for an open-ended free-text question. An \"Other\" free-text tail is " +
+			"always added either way. Result text is shaped like 'User chose: <label>' or, for a " +
+			"free-text answer, 'User chose: Other — <free text>'.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -143,7 +145,6 @@ func (AskUserQuestionTool) Definition() agent.ToolDefinition {
 							},
 							"options": map[string]any{
 								"type":     "array",
-								"minItems": 2,
 								"maxItems": 4,
 								"items": map[string]any{
 									"type": "object",
@@ -159,10 +160,10 @@ func (AskUserQuestionTool) Definition() agent.ToolDefinition {
 									},
 									"required": []string{"label"},
 								},
-								"description": "2-4 mutually exclusive choices.",
+								"description": "Up to 4 mutually exclusive choices. Omit for an open-ended free-text question.",
 							},
 						},
-						"required": []string{"question", "options"},
+						"required": []string{"question"},
 					},
 				},
 			},
@@ -181,9 +182,15 @@ func (AskUserQuestionTool) Execute(ctx context.Context, _ string, input map[stri
 	if question == "" {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("ask_user_question: question is required")
 	}
+	// Options are advisory, not required: every asker appends an "Other"
+	// free-text tail, so zero options degrades to a pure free-text prompt and
+	// one option to a single choice + free text. We don't reject on count —
+	// the model used to error out (and re-ask in prose) when it wanted an
+	// open-ended answer but the tool demanded 2-4 choices. We only trim an
+	// over-long list so the prompt UI stays compact.
 	options := optionLabels(input["options"])
-	if len(options) < 2 || len(options) > 4 {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("ask_user_question: options must have 2-4 entries (got %d)", len(options))
+	if len(options) > 4 {
+		options = options[:4]
 	}
 	multi := askBool(input, "multi_select") || askBool(input, "multiSelect")
 	header := strings.TrimSpace(stringArg(input, "header"))

--- a/internal/tools/ask_user_question_test.go
+++ b/internal/tools/ask_user_question_test.go
@@ -55,8 +55,12 @@ func TestAskUserQuestionTool_Schema(t *testing.T) {
 		}
 	}
 	itemReq, _ := item["required"].([]string)
-	if !sliceContains(itemReq, "question") || !sliceContains(itemReq, "options") {
-		t.Errorf("question + options should be required on the item, got %v", itemReq)
+	if !sliceContains(itemReq, "question") {
+		t.Errorf("question should be required on the item, got %v", itemReq)
+	}
+	// options is advisory now — a free-text question omits it entirely.
+	if sliceContains(itemReq, "options") {
+		t.Errorf("options should NOT be required on the item, got %v", itemReq)
 	}
 }
 
@@ -318,27 +322,71 @@ func TestAskUserQuestionTool_Execute_NoAsker(t *testing.T) {
 func TestAskUserQuestionTool_Execute_Validation(t *testing.T) {
 	useAsker(t, &stubAsker{resp: AskResponse{Choices: []string{"a"}}})
 
-	// Missing question.
+	// Missing question is still the one hard error: there is nothing to ask.
 	if _, err := (AskUserQuestionTool{}).Execute(context.Background(), "ask_user_question", map[string]any{
 		"options": []any{"a", "b"},
 	}); err == nil || !strings.Contains(err.Error(), "question is required") {
 		t.Errorf("missing question should error, got %v", err)
 	}
+}
 
-	// Too few options.
-	if _, err := (AskUserQuestionTool{}).Execute(context.Background(), "ask_user_question", map[string]any{
-		"question": "Q?",
-		"options":  []any{"only"},
-	}); err == nil || !strings.Contains(err.Error(), "2-4 entries") {
-		t.Errorf("single option should error, got %v", err)
+// Zero options is a valid open-ended free-text question: the askers all append
+// an "Other" tail, so it degrades to a plain input box. The model used to be
+// forced to invent a placeholder option (and the call failed); now it can just
+// omit options. Regression guard for that reported failure.
+func TestAskUserQuestionTool_Execute_NoOptionsFreeText(t *testing.T) {
+	stub := &stubAsker{resp: AskResponse{Custom: "zhihu-hot-first"}}
+	useAsker(t, stub)
+
+	out, err := AskUserQuestionTool{}.Execute(context.Background(), "ask_user_question", map[string]any{
+		"question": "What should we name the skill?",
+	})
+	if err != nil {
+		t.Fatalf("an option-less question should succeed, got error: %v", err)
 	}
+	if !stub.called {
+		t.Fatal("asker was never invoked")
+	}
+	if len(stub.lastReq.Options) != 0 {
+		t.Errorf("want no options forwarded, got %v", stub.lastReq.Options)
+	}
+	if out.Text != "User chose: Other — zhihu-hot-first" {
+		t.Errorf("Execute result = %q", out.Text)
+	}
+}
 
-	// Too many options.
+// A single option is valid too — it renders as one choice plus the free-text
+// tail. This is the exact shape that produced the "options must have 2-4
+// entries (got 1)" error before.
+func TestAskUserQuestionTool_Execute_SingleOption(t *testing.T) {
+	stub := &stubAsker{resp: AskResponse{Choices: []string{"zhihu-hot-first"}}}
+	useAsker(t, stub)
+
+	if _, err := (AskUserQuestionTool{}).Execute(context.Background(), "ask_user_question", map[string]any{
+		"question": "Name it this?",
+		"options":  []any{"zhihu-hot-first"},
+	}); err != nil {
+		t.Fatalf("a single option should succeed, got error: %v", err)
+	}
+	if len(stub.lastReq.Options) != 1 {
+		t.Errorf("want 1 option forwarded, got %v", stub.lastReq.Options)
+	}
+}
+
+// More than four options is trimmed to four rather than rejected, keeping the
+// prompt UI compact while never erroring on count.
+func TestAskUserQuestionTool_Execute_TooManyOptionsTrimmed(t *testing.T) {
+	stub := &stubAsker{resp: AskResponse{Choices: []string{"a"}}}
+	useAsker(t, stub)
+
 	if _, err := (AskUserQuestionTool{}).Execute(context.Background(), "ask_user_question", map[string]any{
 		"question": "Q?",
 		"options":  []any{"a", "b", "c", "d", "e"},
-	}); err == nil || !strings.Contains(err.Error(), "2-4 entries") {
-		t.Errorf("5 options should error, got %v", err)
+	}); err != nil {
+		t.Fatalf("5 options should be trimmed, not rejected, got error: %v", err)
+	}
+	if len(stub.lastReq.Options) != 4 {
+		t.Errorf("want options trimmed to 4, got %d: %v", len(stub.lastReq.Options), stub.lastReq.Options)
 	}
 }
 


### PR DESCRIPTION
## 问题

模型用 `ask_user_question` 问开放式问题(如"skill 叫什么名字?")时报错:

```
ask_user_question: options must have 2-4 entries (got 1)
```

工具硬性要求 2-4 个互斥选项,但模型想要的是自由文本回答,于是塞了个占位选项凑数 → 撞上校验失败 → prompt 永远到不了用户,模型只能退化成散文提问,结构化工具形同虚设。

## 根因

挡路的只有 `internal/tools/ask_user_question.go` 两处:`Execute` 的 `len(options) < 2 || len(options) > 4` 硬校验,和 schema 的 `options.minItems: 2`。

四个渲染端(CLI plainView / TUI / IM chatAsker / web QuestionModal)**早就**能优雅处理 0/1 个选项——它们都无条件追加一个 "Other" 自由文本尾巴,0 个选项就退化成纯输入框。所以无需任何 asker / 前端改动。

## 改动

- `Execute`:去掉数量 reject。0 个选项 = 纯自由文本,1 个 = 单选 + 自由文本,>4 个截断到 4。唯一硬错误仍是 `question` 缺失。
- schema:`options` 去掉 `minItems`、从 item 的 `required` 移除;描述仍引导模型"优先给 2-4 个互斥选项,没有自然选项时省略 options 走开放式提问"。
- 测试:更新 schema/validation 断言,新增 0 选项(复现原 bug)、1 选项、>4 截断三个用例。

`go test ./internal/tools/ ./cmd/octo/ ./internal/server/` 全绿,gofmt / vet 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)