### PR TITLE
feat(browser): make record/replay reliable (popup-follow, nav capture, wait step)

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -157,6 +157,40 @@ func (b *Browser) AttachPage(ctx context.Context, targetID string) (*Page, error
 	return p, nil
 }
 
+// ClickFollow clicks target on page and, if the click opened a new tab (a
+// target=_blank link or window.open — common on SPAs whose results open in a new
+// tab, e.g. Zhihu hot items), switches to it. Returns the page to continue on:
+// the new tab when one opened, otherwise the same page. Without this a click that
+// spawns a tab looks like it "did nothing" because the original page is unchanged.
+func (b *Browser) ClickFollow(ctx context.Context, page *Page, target string) (*Page, error) {
+	before := map[string]bool{}
+	if ps, err := b.Pages(ctx); err == nil {
+		for _, p := range ps {
+			before[p.TargetID] = true
+		}
+	}
+	if err := page.Click(ctx, target); err != nil {
+		return page, err
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if ps, err := b.Pages(ctx); err == nil {
+			for _, ti := range ps {
+				if before[ti.TargetID] || ti.TargetID == page.TargetID() {
+					continue
+				}
+				if np, aerr := b.AttachPage(ctx, ti.TargetID); aerr == nil {
+					return np, nil
+				}
+			}
+		}
+		if ctx.Err() != nil || !time.Now().Before(deadline) {
+			return page, nil
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
 // ClosePage closes a page target by id.
 func (b *Browser) ClosePage(ctx context.Context, targetID string) error {
 	_, err := b.cli.call(ctx, "", "Target.closeTarget", map[string]any{"targetId": targetID})

--- a/internal/browser/recorder.go
+++ b/internal/browser/recorder.go
@@ -11,7 +11,7 @@ import (
 // the value for inputs). Frame is set when the element lives in a same-origin
 // iframe, so replay can pierce it via the " >>> " convention.
 type RecordedEvent struct {
-	Type     string `json:"type"`     // click | change
+	Type     string `json:"type"`     // click | change | upload | navigate
 	Selector string `json:"selector"` // best-effort CSS selector within its document
 	Frame    string `json:"frame"`    // iframe selector when the target is in a child frame
 	Tag      string `json:"tag"`      // target tagName (SELECT/INPUT/…), so replay picks the right action
@@ -79,8 +79,13 @@ func (r *Recorder) Start(ctx context.Context) error {
 	}
 
 	events, unsub := p.cli.subscribe("Runtime.bindingCalled", p.sessionID)
+	// Also capture top-level navigations (address-bar, link, SPA history) so a
+	// multi-page demonstration replays from the right pages — otherwise the only
+	// navigate step is the synthesized start URL, and the recording loses every
+	// page the user moved to.
+	navEvents, navUnsub := p.cli.subscribe("Page.frameNavigated", p.sessionID)
 	r.mu.Lock()
-	r.unsub = unsub
+	r.unsub = func() { unsub(); navUnsub() }
 	r.mu.Unlock()
 
 	go func() {
@@ -101,6 +106,31 @@ func (r *Recorder) Start(ctx context.Context) error {
 			r.mu.Unlock()
 		}
 	}()
+	go func() {
+		for ev := range navEvents {
+			var b struct {
+				Frame struct {
+					URL      string `json:"url"`
+					ParentID string `json:"parentId"`
+				} `json:"frame"`
+			}
+			if json.Unmarshal(ev.Params, &b) != nil || b.Frame.ParentID != "" {
+				continue // ignore subframe navigations
+			}
+			u := b.Frame.URL
+			if u == "" || u == "about:blank" {
+				continue
+			}
+			r.mu.Lock()
+			n := len(r.events)
+			if n > 0 && r.events[n-1].Type == "navigate" && r.events[n-1].URL == u {
+				r.mu.Unlock()
+				continue // collapse the initial-load echo / repeat
+			}
+			r.events = append(r.events, RecordedEvent{Type: "navigate", URL: u})
+			r.mu.Unlock()
+		}
+	}()
 	return nil
 }
 
@@ -117,7 +147,7 @@ func (r *Recorder) Events() []RecordedEvent {
 // no healer) — a convenience over the skill path for raw record→replay.
 func Replay(ctx context.Context, page *Page, events []RecordedEvent) error {
 	skill := CompileSkill("", "", "", events)
-	_, err := ReplaySkill(ctx, page, &skill, nil, ReplayOptions{})
+	_, _, err := ReplaySkill(ctx, page, &skill, nil, ReplayOptions{})
 	return err
 }
 

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -32,13 +32,14 @@ type Param struct {
 // iframe selector) scopes it via the " >>> " convention. Label is a human note;
 // replay ignores it.
 type Step struct {
-	Action   string  `yaml:"action"` // navigate | click | type | select | upload
-	URL      string  `yaml:"url,omitempty"`
-	Frame    string  `yaml:"frame,omitempty"`
-	Selector string  `yaml:"selector,omitempty"`
-	Value    string  `yaml:"value,omitempty"`
-	Label    string  `yaml:"label,omitempty"`
-	Verify   *Verify `yaml:"verify,omitempty"`
+	Action    string  `yaml:"action"` // navigate | click | type | select | upload | wait
+	URL       string  `yaml:"url,omitempty"`
+	Frame     string  `yaml:"frame,omitempty"`
+	Selector  string  `yaml:"selector,omitempty"`
+	Value     string  `yaml:"value,omitempty"`
+	Label     string  `yaml:"label,omitempty"`
+	TimeoutMS int     `yaml:"timeout_ms,omitempty"` // wait: fixed delay when no selector
+	Verify    *Verify `yaml:"verify,omitempty"`
 }
 
 // Verify is an optional post-step assertion. Exists waits for a selector; Text
@@ -55,15 +56,26 @@ type Verify struct {
 // an LLM-backed healer); the engine itself stays LLM-free.
 type Healer func(ctx context.Context, page *Page, step *Step, cause error) error
 
-// CompileSkill turns a recording into an editable Skill. The first step
-// navigates to the start URL; subsequent steps come from the captured events.
+// CompileSkill turns a recording into an editable Skill. It seeds a leading
+// navigate from the start URL (when it's a real page, not the about:blank tab
+// octo opens) and then walks the captured events in order — including the
+// top-level navigations the recorder captured, so a multi-page demonstration
+// replays from the right pages.
 func CompileSkill(name, description, startURL string, events []RecordedEvent) Skill {
 	s := Skill{Name: name, Description: description}
-	if startURL != "" {
+	if startURL != "" && startURL != "about:blank" {
 		s.Steps = append(s.Steps, Step{Action: "navigate", URL: startURL})
 	}
 	hasUpload := false
 	for _, e := range events {
+		if e.Type == "navigate" {
+			// Skip an echo of the page we're already on (start URL or the prior nav).
+			if n := len(s.Steps); n > 0 && s.Steps[n-1].Action == "navigate" && s.Steps[n-1].URL == e.URL {
+				continue
+			}
+			s.Steps = append(s.Steps, Step{Action: "navigate", URL: e.URL})
+			continue
+		}
 		if e.Type == "upload" {
 			// The user clicked an upload control, then picked a file. Replay
 			// clicks the control and feeds the file through the chooser, so the
@@ -147,7 +159,7 @@ func GenerateSkill(ctx context.Context, name, startURL string, events []Recorded
 		"RULES: (1) Use ONLY CSS selectors that appear in the provided baseline — never invent or alter a selector. " +
 		"(2) Drop redundant back-and-forth and retries; keep the intended linear path. " +
 		"(3) Replace user-specific input values with {{param}} and declare each in params (keep upload's {{file}}). " +
-		"(4) Preserve step order and the leading navigate. " +
+		"(4) Preserve step order and all navigate steps. " +
 		"(5) Write description as a short statement of what the workflow does, then the natural phrases a user would say to invoke it — in the page's own language AND English (e.g. \"打开知乎热榜并点第一条。当用户说\\\"知乎热榜\\\"、\\\"zhihu hot\\\"时触发\"). This description is the auto-trigger cue, so make those phrases concrete. " +
 		"Output ONLY the skill as YAML (keys: name, description, params, steps), no prose, no code fences."
 	user := fmt.Sprintf("Baseline (the only valid selectors are those here):\n%s\n\nRaw events in order:\n%s\n\nReturn the cleaned skill YAML.", baseYAML, renderTrace(events))
@@ -289,42 +301,50 @@ func subst(s string, params map[string]string) string {
 
 // ReplayOptions tunes a replay. StepTimeout bounds the per-step wait for a
 // target to appear (default 15s — generous for slow back-ends). Healer, when
-// set, is consulted on a step failure.
+// set, is consulted on a step failure. Browser, when set, lets a click follow a
+// new tab it opens (target=_blank / window.open).
 type ReplayOptions struct {
 	StepTimeout time.Duration
 	Healer      Healer
+	Browser     *Browser
 }
 
 // ReplaySkill runs a skill deterministically (no LLM), substituting params. Each
 // step implicitly waits for its target to appear (handling slow loads) and
 // checks any explicit Verify. On a step failure it calls the healer; if the
 // healer repairs the step, replay continues and reports modified=true so the
-// caller can write the corrected skill back.
-func ReplaySkill(ctx context.Context, page *Page, skill *Skill, params map[string]string, opts ReplayOptions) (modified bool, err error) {
+// caller can write the corrected skill back. A click that opens a new tab swaps
+// the active page for subsequent steps; finalPage is the page replay ended on
+// (so the caller can keep its session pointed at the right tab).
+func ReplaySkill(ctx context.Context, page *Page, skill *Skill, params map[string]string, opts ReplayOptions) (modified bool, finalPage *Page, err error) {
 	if opts.StepTimeout <= 0 {
 		opts.StepTimeout = 15 * time.Second
 	}
 	full := mergedParams(skill, params)
+	cur := page
 	for i := range skill.Steps {
-		runErr := runStep(ctx, page, &skill.Steps[i], full, opts.StepTimeout)
+		np, runErr := runStep(ctx, opts.Browser, cur, &skill.Steps[i], full, opts.StepTimeout)
 		if runErr == nil {
+			cur = np
 			continue
 		}
 		if opts.Healer == nil {
-			return modified, fmt.Errorf("step %d (%s): %w", i+1, skill.Steps[i].Action, runErr)
+			return modified, cur, fmt.Errorf("step %d (%s): %w", i+1, skill.Steps[i].Action, runErr)
 		}
 		before := skill.Steps[i]
-		if herr := opts.Healer(ctx, page, &skill.Steps[i], runErr); herr != nil {
-			return modified, fmt.Errorf("step %d (%s): %w", i+1, skill.Steps[i].Action, runErr)
+		if herr := opts.Healer(ctx, cur, &skill.Steps[i], runErr); herr != nil {
+			return modified, cur, fmt.Errorf("step %d (%s): %w", i+1, skill.Steps[i].Action, runErr)
 		}
-		if retryErr := runStep(ctx, page, &skill.Steps[i], full, opts.StepTimeout); retryErr != nil {
-			return modified, fmt.Errorf("step %d (%s) after heal: %w", i+1, skill.Steps[i].Action, retryErr)
+		np, retryErr := runStep(ctx, opts.Browser, cur, &skill.Steps[i], full, opts.StepTimeout)
+		if retryErr != nil {
+			return modified, cur, fmt.Errorf("step %d (%s) after heal: %w", i+1, skill.Steps[i].Action, retryErr)
 		}
+		cur = np
 		if skill.Steps[i] != before {
 			modified = true
 		}
 	}
-	return modified, nil
+	return modified, cur, nil
 }
 
 // mergedParams overlays caller params on declared defaults.
@@ -341,38 +361,61 @@ func mergedParams(skill *Skill, params map[string]string) map[string]string {
 	return out
 }
 
-func runStep(ctx context.Context, page *Page, step *Step, params map[string]string, waitTimeout time.Duration) error {
+// runStep executes one step on page and returns the page subsequent steps should
+// run on — the same page, except a click that opens a new tab returns that tab.
+func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map[string]string, waitTimeout time.Duration) (*Page, error) {
 	target := step.target()
 	switch step.Action {
 	case "navigate":
 		if err := page.Navigate(ctx, subst(step.URL, params)); err != nil {
-			return err
+			return page, err
+		}
+	case "wait":
+		// Wait for an element if a selector is given (the robust form), else a
+		// fixed delay — the natural primitive for letting an SPA settle between
+		// steps. Recordings/edits commonly need it; without it run_skill rejected
+		// the step as "unknown action".
+		if target != "" {
+			if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
+				return page, err
+			}
+		} else {
+			ms := step.TimeoutMS
+			if ms <= 0 {
+				ms = 1000
+			}
+			if ms > 30000 {
+				ms = 30000
+			}
+			select {
+			case <-ctx.Done():
+				return page, ctx.Err()
+			case <-time.After(time.Duration(ms) * time.Millisecond):
+			}
 		}
 	case "click":
 		// When the recording captured the element's visible text, resolve by text
 		// (verifying or replacing the drift-prone positional selector) — this is
 		// what makes replay survive layout changes and stops silent wrong-element
-		// clicks. resolveClickTarget already polled for existence, so click directly.
+		// clicks. resolveClickTarget already polled for existence.
 		if a := strings.TrimSpace(step.Label); len(a) >= 2 {
 			target = page.resolveClickTarget(ctx, step.Frame, step.Selector, a, waitTimeout)
-			if err := page.Click(ctx, target); err != nil {
-				return err
-			}
-		} else {
-			if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
-				return err
-			}
-			if err := page.Click(ctx, target); err != nil {
-				return err
-			}
+		} else if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
+			return page, err
 		}
+		// Follow a new tab the click may open (target=_blank / SPA window.open).
+		np, err := clickTarget(ctx, b, page, target)
+		if err != nil {
+			return page, err
+		}
+		page = np
 	case "type":
 		if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
-			return err
+			return page, err
 		}
 		val := subst(step.Value, params)
 		if err := page.TypeText(ctx, target, val); err != nil {
-			return err
+			return page, err
 		}
 		// If a non-empty value didn't land, a disabled/re-rendering/framework input
 		// swallowed the programmatic insert — clear and retry once before failing
@@ -381,18 +424,18 @@ func runStep(ctx context.Context, page *Page, step *Step, params map[string]stri
 		if val != "" && !page.fieldNonEmpty(ctx, target) {
 			page.clearField(ctx, target)
 			if err := page.TypeText(ctx, target, val); err != nil {
-				return err
+				return page, err
 			}
 			if !page.fieldNonEmpty(ctx, target) {
-				return fmt.Errorf("type: %q did not accept input", target)
+				return page, fmt.Errorf("type: %q did not accept input", target)
 			}
 		}
 	case "select":
 		if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
-			return err
+			return page, err
 		}
 		if err := page.SelectOption(ctx, target, subst(step.Value, params)); err != nil {
-			return err
+			return page, err
 		}
 	case "upload":
 		// The upload trigger is a labeled control (e.g. "Choose file"), so prefer
@@ -400,17 +443,30 @@ func runStep(ctx context.Context, page *Page, step *Step, params map[string]stri
 		if a := strings.TrimSpace(step.Label); len(a) >= 2 {
 			target = page.resolveClickTarget(ctx, step.Frame, step.Selector, a, waitTimeout)
 		} else if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
-			return err
+			return page, err
 		}
 		// Click the upload control and feed the file through the chooser — works
 		// for both a button that opens a chooser and a direct file input.
 		if err := page.UploadViaChooser(ctx, target, []string{subst(step.Value, params)}); err != nil {
-			return err
+			return page, err
 		}
 	default:
-		return fmt.Errorf("unknown action %q", step.Action)
+		return page, fmt.Errorf("unknown action %q", step.Action)
 	}
-	return verify(ctx, page, step, params)
+	return page, verify(ctx, page, step, params)
+}
+
+// clickTarget clicks target on page, following a new tab the click opens when a
+// Browser is available (replay/tools path). Without a Browser it is a plain
+// click on the same page.
+func clickTarget(ctx context.Context, b *Browser, page *Page, target string) (*Page, error) {
+	if b != nil {
+		return b.ClickFollow(ctx, page, target)
+	}
+	if err := page.Click(ctx, target); err != nil {
+		return page, err
+	}
+	return page, nil
 }
 
 func verify(ctx context.Context, page *Page, step *Step, params map[string]string) error {

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -121,6 +121,27 @@ func TestCompileSkillDropsConsecutiveDupes(t *testing.T) {
 	}
 }
 
+// TestCompileSkillCapturesNavigations: navigations recorded during the demo
+// become navigate steps in order; an about:blank start URL is dropped (it's the
+// throwaway tab octo opened, not where the user worked).
+func TestCompileSkillCapturesNavigations(t *testing.T) {
+	events := []RecordedEvent{
+		{Type: "navigate", URL: "https://www.zhihu.com/hot"},
+		{Type: "navigate", URL: "https://www.zhihu.com/hot"}, // initial-load echo → collapsed
+		{Type: "click", Selector: "section a", Tag: "A", Text: "Top story"},
+	}
+	s := CompileSkill("demo", "", "about:blank", events)
+	if len(s.Steps) != 2 {
+		t.Fatalf("want navigate+click (blank dropped, echo collapsed), got %d: %+v", len(s.Steps), s.Steps)
+	}
+	if s.Steps[0].Action != "navigate" || s.Steps[0].URL != "https://www.zhihu.com/hot" {
+		t.Fatalf("step 0 = %+v, want navigate to /hot", s.Steps[0])
+	}
+	if s.Steps[1].Action != "click" {
+		t.Fatalf("step 1 = %+v, want click", s.Steps[1])
+	}
+}
+
 // TestGenerateSkillDistill: the LLM distiller drops a fumble (a wrong click +
 // going back) and parameterizes a value — and the precision guard rejects any
 // output that invents a selector, falling back to the deterministic baseline.
@@ -159,6 +180,59 @@ func TestGenerateSkillDistill(t *testing.T) {
 	}
 }
 
+// TestRunStepWaitFixedDelay: a wait step with no selector sleeps the requested
+// time (the SPA-settling primitive) — and run_skill no longer rejects it.
+func TestRunStepWaitFixedDelay(t *testing.T) {
+	start := time.Now()
+	if _, err := runStep(context.Background(), nil, nil, &Step{Action: "wait", TimeoutMS: 80}, nil, time.Second); err != nil {
+		t.Fatalf("wait step: %v", err)
+	}
+	if d := time.Since(start); d < 60*time.Millisecond {
+		t.Fatalf("wait returned too fast: %v", d)
+	}
+}
+
+// TestReplayClickFollowsNewTab: a click on a target=_blank link is followed to
+// the tab it opens (the Zhihu-hot-item failure mode), and ReplaySkill returns
+// that tab as the final page.
+func TestReplayClickFollowsNewTab(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/dest", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!doctype html><meta charset="utf-8"><title>dest</title><h1 id="dest">DEST</h1>`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!doctype html><meta charset="utf-8"><title>home</title><a id="open" href="/dest" target="_blank">Open</a>`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+
+	skill := &Skill{Name: "x", Steps: []Step{{Action: "click", Selector: "#open"}}}
+	_, fp, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second, Browser: b})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if fp == page {
+		t.Fatal("replay did not follow the new tab opened by the click")
+	}
+	if err := fp.WaitFor(ctx, "#dest", 5*time.Second); err != nil {
+		t.Fatalf("final page is not the destination tab: %v", err)
+	}
+}
+
 // TestReplayTextAnchorRecoversFromDrift: a recorded positional selector now
 // points at the WRONG element after a layout change, but the recorded text steers
 // replay to the right one — instead of silently clicking the wrong node.
@@ -190,7 +264,7 @@ func TestReplayTextAnchorRecoversFromDrift(t *testing.T) {
 	skill := &Skill{Name: "x", Steps: []Step{
 		{Action: "click", Selector: "div > button:nth-of-type(1)", Label: "Book now"},
 	}}
-	if _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second}); err != nil {
+	if _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second}); err != nil {
 		t.Fatalf("replay: %v", err)
 	}
 	var hit string
@@ -241,7 +315,7 @@ func TestReplaySkillSelfHeal(t *testing.T) {
 		return context.DeadlineExceeded
 	}
 
-	modified, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 2 * time.Second, Healer: heal})
+	modified, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 2 * time.Second, Healer: heal})
 	if err != nil {
 		t.Fatalf("replay: %v", err)
 	}

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -34,6 +34,15 @@ func SetBrowserSession(b *browser.Browser, p *browser.Page) {
 	browserSession.b, browserSession.page = b, p
 }
 
+// setActivePage repoints the package-global session at a new tab — e.g. after a
+// click (or a replayed skill) opened and switched to one — so subsequent tool
+// calls act on the page the user actually ended up on.
+func setActivePage(b *browser.Browser, p *browser.Page) {
+	browserSession.mu.Lock()
+	defer browserSession.mu.Unlock()
+	browserSession.b, browserSession.page = b, p
+}
+
 // Recording + self-heal state. browserHealer is injected by app.WireTools (it
 // needs a model Sender, which tools can't import directly).
 var (
@@ -348,10 +357,18 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		if sel == "" {
 			return agent.ToolResult{}, fmt.Errorf("browser: click requires selector")
 		}
-		if err := page.Click(ctx, sel); err != nil {
+		// Follow a new tab the click may open (target=_blank / SPA window.open) so
+		// the click doesn't silently look like a no-op on the old page.
+		np, err := b.ClickFollow(ctx, page, sel)
+		if err != nil {
 			return agent.ToolResult{}, err
 		}
-		return agent.ToolResult{Text: "clicked " + sel}, nil
+		text := "clicked " + sel
+		if np != page {
+			setActivePage(b, np)
+			text += " (followed to a new tab)"
+		}
+		return agent.ToolResult{Text: text}, nil
 
 	case "hover":
 		sel := targetSelector(input)
@@ -622,9 +639,14 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		recorderMu.Lock()
 		healer := browserHealer
 		recorderMu.Unlock()
-		modified, err := browser.ReplaySkill(ctx, page, &skill, params, browser.ReplayOptions{Healer: healer})
+		modified, finalPage, err := browser.ReplaySkill(ctx, page, &skill, params, browser.ReplayOptions{Healer: healer, Browser: b})
 		if err != nil {
 			return agent.ToolResult{}, fmt.Errorf("browser: run_skill %q: %w", name, err)
+		}
+		// A click in the skill may have opened (and switched to) a new tab; keep
+		// the session pointed there so follow-up actions act on the right page.
+		if finalPage != nil && finalPage != page {
+			setActivePage(b, finalPage)
 		}
 		msg := fmt.Sprintf("ran skill %q (%d steps)", name, len(skill.Steps))
 		if modified {


### PR DESCRIPTION
Session `20260630-193123-fa421eb5` (recording a Zhihu skill) exposed why one-shot record→replay was basically impossible. Three root causes, fixed here, plus the missing `wait` step.

### 1. Clicks didn't follow new tabs — the real Zhihu failure
Zhihu hot-list items are `target=_blank`. The CDP click **did** work — it opened the article in a **new tab** — but octo stayed on the hot page, so it looked like the click did nothing (the session model even concluded "manual click doesn't jump" and gave up). 

`Browser.ClickFollow` now snapshots open tabs, clicks, and if a new tab appears switches to it. `ReplaySkill` threads the `*Browser`, swaps the active page mid-replay, and returns the final page; the tool's `click` action and `run_skill` repoint the session at the new tab so follow-up `observe`/steps act on the right page.

### 2. Recordings didn't capture navigations
The recorder only listened for click/change, so the **only** navigate step was the synthesized start URL — a "go to /hot, click item" demo lost the `/hot` navigation (the session model had to hand-write it repeatedly). The recorder now subscribes to `Page.frameNavigated` (top frame only) and records navigate events; `CompileSkill` turns them into ordered navigate steps and collapses initial-load echoes.

### 3. `about:blank` start URL
`record_start` captured `location.href` = `about:blank` (the throwaway tab octo opens) as step 1, so replay navigated to a blank page. `CompileSkill` now drops an `about:blank` start URL and relies on the captured real navigations.

### 4. `wait` step
`run_skill` rejected a `wait` step as "unknown action", though it's the obvious SPA-settling primitive (the session model reached for it). Added: `wait` waits for a selector, or a fixed `timeout_ms`.

## Net effect
Recording "navigate to /hot → click first item" now compiles to `navigate /hot · click` (no about:blank), and replay navigates, clicks, and **follows the article tab** — one shot.

## Verification
- `go test ./internal/browser` — pass, incl. new tests: click follows a `target=_blank` tab; navigations compile to steps with about:blank dropped; fixed-delay wait.
- `go test ./internal/tools -run 'RecordRun|Browser'` — pass (round-trips unchanged).
- `go build ./...`, `go vet` — clean.

Known limitation (not addressed): actions performed **inside** a new tab *during recording* aren't captured (the recorder stays attached to the original target). The common "click opens article" flow is covered because the click itself is captured on the origin page and replay follows the popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)