### PR TITLE
feat(browser): drop keyword-triggerable recordings (replay-only)

### DIFF
--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -160,7 +160,7 @@ func GenerateSkill(ctx context.Context, name, startURL string, events []Recorded
 		"(2) Drop redundant back-and-forth and retries; keep the intended linear path. " +
 		"(3) Replace user-specific input values with {{param}} and declare each in params (keep upload's {{file}}). " +
 		"(4) Preserve step order and all navigate steps. " +
-		"(5) Write description as a short statement of what the workflow does, then the natural phrases a user would say to invoke it — in the page's own language AND English (e.g. \"打开知乎热榜并点第一条。当用户说\\\"知乎热榜\\\"、\\\"zhihu hot\\\"时触发\"). This description is the auto-trigger cue, so make those phrases concrete. " +
+		"(5) Write description as a short statement of what the workflow does. " +
 		"Output ONLY the skill as YAML (keys: name, description, params, steps), no prose, no code fences."
 	user := fmt.Sprintf("Baseline (the only valid selectors are those here):\n%s\n\nRaw events in order:\n%s\n\nReturn the cleaned skill YAML.", baseYAML, renderTrace(events))
 

--- a/internal/server/browser_recordings_handlers.go
+++ b/internal/server/browser_recordings_handlers.go
@@ -137,8 +137,5 @@ func (s *Server) handleDeleteBrowserRecording(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("delete recording: %v", err))
 		return
 	}
-	// Drop the keyword-trigger companion SKILL.md too (only if we generated it),
-	// so deleting a recording doesn't leave a trigger that fails on replay.
-	tools.DeleteRecordingSkillDoc(name)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -52,13 +52,9 @@ type Registry struct {
 	cwd      string
 }
 
-// userSkillsRoot returns ~/.octo/skills (or $OCTO_SKILLS_DIR when set), or ""
-// when the home dir can't be resolved. It's a var so tests can point discovery
-// at a temp directory.
+// userSkillsRoot returns ~/.octo/skills, or "" when the home dir can't be
+// resolved. It's a var so tests can point discovery at a temp directory.
 var userSkillsRoot = func() string {
-	if d := os.Getenv("OCTO_SKILLS_DIR"); d != "" {
-		return d
-	}
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return ""

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/browser"
 	"github.com/Leihb/octo-agent/internal/config"
-	"github.com/Leihb/octo-agent/internal/skills"
 )
 
 // browserSession holds the per-session Chrome connection, reused across tool
@@ -100,58 +99,6 @@ func BrowserSkillsDir() string {
 	}
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".octo", "browser-skills")
-}
-
-// recordingSkillMarker tags the companion SKILL.md that record_stop generates
-// for a recording, so DeleteRecordingSkillDoc only ever removes our own file and
-// never a hand-authored skill that happens to share the recording's name.
-const recordingSkillMarker = "octo_recording: true"
-
-// recordingSkillDir is the companion skill directory (~/.octo/skills/<name>) for
-// a recording, "" when the user skills root can't be resolved.
-func recordingSkillDir(name string) string {
-	root := skills.UserRoot()
-	if root == "" {
-		return ""
-	}
-	return filepath.Join(root, name)
-}
-
-// WriteRecordingSkillDoc writes the companion SKILL.md that makes a recording
-// keyword-triggerable: a fresh session discovers it and, when the user's request
-// matches description, the model loads it and replays via run_skill. Best-effort.
-func WriteRecordingSkillDoc(name, description string) error {
-	dir := recordingSkillDir(name)
-	if dir == "" {
-		return fmt.Errorf("user skills dir unavailable")
-	}
-	if description == "" {
-		description = "Replay the recorded browser automation " + name + "."
-	}
-	body := fmt.Sprintf("---\nname: %s\ndescription: %s\n%s\n---\n\n"+
-		"# %s\n\nReplay the recorded browser automation %q with the browser tool:\n\n"+
-		"```\nbrowser action=run_skill name=%q\n```\n\n"+
-		"This deterministically replays the recorded steps (with selector self-healing). "+
-		"Pass any required values via params.\n", name, description, recordingSkillMarker, name, name, name)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(filepath.Join(dir, skills.SkillFile), []byte(body), 0o644)
-}
-
-// DeleteRecordingSkillDoc removes a recording's companion SKILL.md directory,
-// but only when it carries our generated marker — never a user-authored skill of
-// the same name. Best-effort; a no-op when nothing matches.
-func DeleteRecordingSkillDoc(name string) {
-	dir := recordingSkillDir(name)
-	if dir == "" {
-		return
-	}
-	data, err := os.ReadFile(filepath.Join(dir, skills.SkillFile))
-	if err != nil || !strings.Contains(string(data), recordingSkillMarker) {
-		return
-	}
-	_ = os.RemoveAll(dir)
 }
 
 // ResetBrowserSession closes and clears the active browser session.
@@ -611,14 +558,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		if err := browser.SaveSkill(path, skill); err != nil {
 			return agent.ToolResult{}, err
 		}
-		// Also write a companion SKILL.md so the recording is keyword-triggerable:
-		// a new session discovers it and the model replays via run_skill when the
-		// user's request matches. Best-effort — never fail the recording over it.
-		trigger := ""
-		if err := WriteRecordingSkillDoc(name, skill.Description); err == nil {
-			trigger = fmt.Sprintf("\nIt's also a keyword-triggerable skill now — in a new session, just say what it does (per its description: %q) and the model will replay it; no need to spell out run_skill.", skill.Description)
-		}
-		return agent.ToolResult{Text: fmt.Sprintf("recorded %d step(s) → %s\nReview/edit it there (set params, fix selectors), then replay with action=run_skill name=%q.%s", len(skill.Steps), path, name, trigger)}, nil
+		return agent.ToolResult{Text: fmt.Sprintf("recorded %d step(s) → %s\nReview/edit it there (set params, fix selectors). Replay it with the Replay button in the Browser view, or action=run_skill name=%q. (Recordings are NOT keyword-triggerable — they only run when explicitly replayed.)", len(skill.Steps), path, name)}, nil
 
 	case "run_skill":
 		name := getStr(input, "name")

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -5,14 +5,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/browser"
-	"github.com/Leihb/octo-agent/internal/skills"
 )
 
 // toolFixtureHTML mirrors the awkward target system: the download button only
@@ -111,7 +109,6 @@ func TestBrowserTool_RecordRunRoundTrip(t *testing.T) {
 		t.Skip("chrome not available")
 	}
 	t.Setenv("OCTO_BROWSER_SKILLS_DIR", t.TempDir())
-	t.Setenv("OCTO_SKILLS_DIR", t.TempDir())
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`<!doctype html><title>rr</title><button id="b">Go</button>
 <script>window.clicks=0;document.getElementById('b').addEventListener('click',function(){window.clicks++});</script>`))
@@ -144,20 +141,6 @@ func TestBrowserTool_RecordRunRoundTrip(t *testing.T) {
 	time.Sleep(300 * time.Millisecond) // let the capture event arrive
 	if _, err := run(map[string]any{"action": "record_stop", "name": "demo"}); err != nil {
 		t.Fatalf("record_stop: %v", err)
-	}
-
-	// record_stop also writes a keyword-trigger companion SKILL.md so a fresh
-	// session can auto-replay the recording.
-	doc := filepath.Join(os.Getenv("OCTO_SKILLS_DIR"), "demo", skills.SkillFile)
-	if data, err := os.ReadFile(doc); err != nil {
-		t.Fatalf("companion SKILL.md not written: %v", err)
-	} else if !strings.Contains(string(data), recordingSkillMarker) {
-		t.Fatalf("companion SKILL.md missing generated marker")
-	}
-	// DeleteRecordingSkillDoc removes only our generated companion.
-	DeleteRecordingSkillDoc("demo")
-	if _, err := os.Stat(doc); !os.IsNotExist(err) {
-		t.Fatalf("companion SKILL.md not cleaned up by DeleteRecordingSkillDoc")
 	}
 
 	// Replay: navigates back to the start URL (reset clicks) and re-clicks.


### PR DESCRIPTION
The companion-`SKILL.md` keyword-trigger feature (#966) was unreliable, and it led the agent to (over)promise "open a new session, say the keyword, it replays" — which often didn't actually fire. Per user decision: **recordings run only when explicitly replayed** (the Replay button, or `action=run_skill`). Clearer model, no surprise auto-execution.

Removes the whole companion mechanism:
- `WriteRecordingSkillDoc` / `DeleteRecordingSkillDoc` + the `octo_recording` marker (tools).
- `record_stop` no longer writes a companion or claims keyword triggering; its result now says to replay via the Replay button / `run_skill` and that recordings are **not** keyword-triggerable.
- delete handler no longer removes a companion (server).
- distill prompt reverts to a plain "what it does" description (no trigger phrases).
- removes the now-unused `OCTO_SKILLS_DIR` override (skills).

Backend-only; no web changes.

## Verification
- `go build ./...`, `go vet ./internal/{browser,tools,skills,server}` — clean
- `go test ./internal/skills`, `./internal/tools -run RecordRun`, `./internal/browser -run 'Distill|CompileSkill'` — pass

Note: legacy companion SKILL.md files from before this change remain on disk; they're inert recordings-as-skills the user can delete manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)