### PR TITLE
chore(serve): change default port 8080 → 8088

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then start the local server and onboard in your browser:
 
 ```bash
 octo serve -d                  # run the local server in the background
-open http://127.0.0.1:8080     # Linux: xdg-open — opens the dashboard
+open http://127.0.0.1:8088     # Linux: xdg-open — opens the dashboard
 ```
 
 `127.0.0.1` is loopback, so no access key is needed; the page goes straight
@@ -46,7 +46,7 @@ if you'd rather grab one by hand.
 double-click it. It installs per-user (no administrator prompt), puts `octo` on
 your `PATH`, and adds a Start-menu entry. When it finishes it starts the local
 server in the background (`octo serve -d`) and opens
-<http://127.0.0.1:8080> — a loopback address, so no access key is needed — to
+<http://127.0.0.1:8088> — a loopback address, so no access key is needed — to
 walk you through first-run onboarding (pick a provider, paste a key). The
 server is also registered to start on each login (a per-user `Run` entry, no
 window), so the dashboard is up after a reboot; uninstalling removes it and
@@ -150,9 +150,9 @@ octo init
 # List discovered skills
 octo skills list
 
-# Web server + dashboard (binds 127.0.0.1:8080 by default)
+# Web server + dashboard (binds 127.0.0.1:8088 by default)
 octo serve
-octo serve -addr :8080   # expose on the LAN — non-localhost clients need the
+octo serve -addr :8088   # expose on the LAN — non-localhost clients need the
                          # access key; startup prints a ready-to-open URL
 
 # IM bridge (WeChat iLink): scan-to-login; channels run inside `octo serve`

--- a/README_CN.md
+++ b/README_CN.md
@@ -30,7 +30,7 @@ curl -fsSL https://octo-agent.dev/install.sh | sh
 
 ```bash
 octo serve -d                  # 后台运行本地服务
-open http://127.0.0.1:8080     # Linux 用 xdg-open —— 打开仪表盘
+open http://127.0.0.1:8088     # Linux 用 xdg-open —— 打开仪表盘
 ```
 
 `127.0.0.1` 是 loopback，无需 access key；页面直接进入首屏 onboarding（选
@@ -109,7 +109,7 @@ octo init
 octo skills list
 
 # Web 服务 + 仪表盘（默认绑定 localhost）
-octo serve --addr 127.0.0.1:8080
+octo serve --addr 127.0.0.1:8088
 
 # IM 桥接（微信 iLink）：扫码登录；渠道随 `octo serve` 一起运行
 octo serve   # 微信登录：在 Web UI 的 Channels 面板扫码

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,8 +15,8 @@ boundary sits, what protects it, and what is deliberately out of scope.
 - **Loopback is trusted.** Requests from `127.0.0.1`/`::1` are exempt from
   key authentication. Anything that can already run code as a local user on
   the machine is outside the boundary.
-- **Everything else needs the key.** The server binds to `127.0.0.1:8080` by
-  default; binding wider (`-addr :8080`) makes every API and WebSocket
+- **Everything else needs the key.** The server binds to `127.0.0.1:8088` by
+  default; binding wider (`-addr :8088`) makes every API and WebSocket
   request from a non-loopback client require the access key.
 
 ### What is defended
@@ -24,7 +24,7 @@ boundary sits, what protects it, and what is deliberately out of scope.
 | Threat | Defense |
 |---|---|
 | LAN / internet attacker calling an exposed API | Loopback-only default bind; 256-bit access key (constant-time compare) on every non-loopback request |
-| Malicious website CSRF-ing `http://localhost:8080` from your own browser | Browser-sent `Origin` must be local or `--cors`-allowlisted (a literal `*` is never honored); the auth cookie is `SameSite=Strict` |
+| Malicious website CSRF-ing `http://localhost:8088` from your own browser | Browser-sent `Origin` must be local or `--cors`-allowlisted (a literal `*` is never honored); the auth cookie is `SameSite=Strict` |
 | DNS rebinding (attacker domain resolving to 127.0.0.1) | The loopback exemption requires a local `Host` header |
 | Spoofed client IPs | `X-Forwarded-For` is never consulted for the loopback exemption |
 | XSSI reads of uploaded files | `X-Content-Type-Options: nosniff` on served uploads |

--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -136,16 +136,16 @@ Environment:
 func serveHelp(w io.Writer) {
 	fmt.Fprintln(w, `octo serve — start the HTTP server (REST API + SSE + Web UI).
 
-The server binds to localhost:8080 by default.
+The server binds to localhost:8088 by default.
 
 Examples:
-  octo serve                           Start on :8080
+  octo serve                           Start on :8088
   octo serve --addr 127.0.0.1:3000     Bind to a specific address
   octo serve --no-channel              Skip IM platform bridges
   octo serve --no-tools                Disable the agentic tool loop
 
 Common flags:
-  --addr <host:port>       Bind address (default :8080)
+  --addr <host:port>       Bind address (default :8088)
   --provider <name>        anthropic (default) | openai
   --model <name>           Override the default model
   --system <text>          Custom system prompt

--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -35,7 +35,7 @@ func serveLogLevel() slog.Level {
 func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	addr := fs.String("addr", "127.0.0.1:8080", "Bind address (e.g. 127.0.0.1:8080; :8080 to expose on all interfaces)")
+	addr := fs.String("addr", "127.0.0.1:8088", "Bind address (e.g. 127.0.0.1:8088; :8088 to expose on all interfaces)")
 	accessKey := fs.String("access-key", "", "Access key for non-localhost clients (default: from OCTO_ACCESS_KEY / config.yml, else auto-generated and persisted)")
 	provider := fs.String("provider", "", "Provider: anthropic | openai")
 	model := fs.String("model", "", "Model name")

--- a/cmd/octo/serve_daemon.go
+++ b/cmd/octo/serve_daemon.go
@@ -137,10 +137,10 @@ func startDaemon(serveArgs []string, stdout, stderr io.Writer) int {
 }
 
 // daemonDialAddr derives a loopback-dialable host:port from the serve --addr
-// flag (default 127.0.0.1:8080). A wildcard or empty host is dialed on
+// flag (default 127.0.0.1:8088). A wildcard or empty host is dialed on
 // 127.0.0.1 — the server always listens there too.
 func daemonDialAddr(serveArgs []string) string {
-	addr := "127.0.0.1:8080"
+	addr := "127.0.0.1:8088"
 	for i, a := range serveArgs {
 		switch {
 		case a == "-addr" || a == "--addr":

--- a/cmd/octo/serve_daemon_test.go
+++ b/cmd/octo/serve_daemon_test.go
@@ -8,7 +8,7 @@ func TestDaemonDialAddr(t *testing.T) {
 		args []string
 		want string
 	}{
-		{"default", nil, "127.0.0.1:8080"},
+		{"default", nil, "127.0.0.1:8088"},
 		{"separate flag", []string{"-addr", "127.0.0.1:3000"}, "127.0.0.1:3000"},
 		{"long separate flag", []string{"--addr", "127.0.0.1:3000"}, "127.0.0.1:3000"},
 		{"equals form", []string{"-addr=127.0.0.1:9000"}, "127.0.0.1:9000"},

--- a/cmd/octo/serve_test.go
+++ b/cmd/octo/serve_test.go
@@ -14,7 +14,7 @@ func TestServeDefaultAddrIsLoopback(t *testing.T) {
 	if code != 2 {
 		t.Fatalf("-h exit = %d, want 2", code)
 	}
-	if !strings.Contains(stderr.String(), `"127.0.0.1:8080"`) {
+	if !strings.Contains(stderr.String(), `"127.0.0.1:8088"`) {
 		t.Errorf("usage should show loopback default addr, got:\n%s", stderr.String())
 	}
 }

--- a/dev-docs/serve-auth-design.md
+++ b/dev-docs/serve-auth-design.md
@@ -11,7 +11,7 @@ public statement of this threat model.
 
 - **Zero-friction local default.** `octo serve` + a browser on the same
   machine works exactly as before: no key prompt, no setup.
-- **Exposure requires a secret.** Binding beyond loopback (`-addr :8080`,
+- **Exposure requires a secret.** Binding beyond loopback (`-addr :8088`,
   LAN, tailscale) makes every API and WebSocket request require the access
   key.
 - **Browser attacks blocked without the key.** CSRF simple requests and DNS
@@ -40,7 +40,7 @@ public statement of this threat model.
 | Actor | Vector | Defense |
 |---|---|---|
 | LAN / internet attacker | Direct API calls to an exposed bind | Loopback-only default bind; access key required for non-loopback clients |
-| Malicious website in the user's browser | CSRF simple request (form POST, no-cors fetch) to `http://localhost:8080` | Origin validation: browser-sent `Origin` must be local or in the `--cors` allowlist |
+| Malicious website in the user's browser | CSRF simple request (form POST, no-cors fetch) to `http://localhost:8088` | Origin validation: browser-sent `Origin` must be local or in the `--cors` allowlist |
 | Malicious website in the user's browser | DNS rebinding (attacker domain resolves to 127.0.0.1, request is then "same-origin") | Host validation: the loopback exemption requires a local `Host` header |
 | Malicious website in the user's browser | No-`Origin` subresource GETs (`<img>`, `<script src>`) to loopback | All mutations are POST/PATCH/DELETE (blocked by the Origin gate); GET responses are JSON with `X-Content-Type-Options: nosniff` — `/api/uploads/{name}` gains the same header to close the XSSI read channel |
 | IM platforms (Feishu, DingTalk, …) | Inbound messages driving the agent | Out of scope here — adapters hold outbound connections (no inbound HTTP routes) and are authenticated by bot credentials + the chat/user binding |
@@ -135,9 +135,9 @@ never write the user's config.
   falls back to a `<host>` placeholder:
 
   ```
-  octo server listening on http://0.0.0.0:8080
+  octo server listening on http://0.0.0.0:8088
   access key required for non-localhost clients
-  open: http://192.168.1.5:8080/?access_key=<key>
+  open: http://192.168.1.5:8088/?access_key=<key>
   ```
 
 ### Web UI (`auth.js`)
@@ -170,15 +170,15 @@ Everything else, including `POST /api/chat`, `POST /api/restart`, and
 
 ### Default bind change
 
-`octo serve -addr` defaults to `127.0.0.1:8080` (was `:8080`, all
+`octo serve -addr` defaults to `127.0.0.1:8088` (was `:8088`, all
 interfaces). **Breaking**: LAN/phone access now needs an explicit
-`-addr :8080`, which in turn activates the key requirement for those
+`-addr :8088`, which in turn activates the key requirement for those
 clients. Changelog calls out both.
 
 The previous exposure gate — `validateBindAddr` requiring
 `~/.octo/permissions.yml` to exist before a non-localhost bind — is
 retired. It was a weak proxy (file existence, not content) with a hole: the
-empty-host form `:8080` bypassed it entirely. The access key replaces it as
+empty-host form `:8088` bypassed it entirely. The access key replaces it as
 the exposure gate.
 
 ### Onboarding over a non-loopback bind
@@ -231,5 +231,5 @@ a separate-origin frontend authenticates with explicit headers.
 - CHANGELOG: two breaking entries (default bind, non-loopback auth) plus
   the permissions.yml bind-gate retirement.
 - README: serve quickstart shows the loopback default and the exposure
-  workflow (`-addr :8080` + printed bootstrap URL); the feature table
+  workflow (`-addr :8088` + printed bootstrap URL); the feature table
   points at SECURITY.md.

--- a/dev-docs/windows-onboarding-design.md
+++ b/dev-docs/windows-onboarding-design.md
@@ -25,7 +25,7 @@ A Windows user with no dev toolchain:
    entry in "Add or remove programs". No UAC prompt.
 4. On finish, the installer starts the server in the background
    (`octo serve -d`, which blocks until the port is listening) and opens
-   <http://127.0.0.1:8080> — loopback, so no access key — landing the user in
+   <http://127.0.0.1:8088> — loopback, so no access key — landing the user in
    the web UI's first-run onboarding. It also registers a per-user HKCU `Run`
    entry that re-launches the daemon on each login via a hidden `.vbs`
    (windowless `octo serve -d`), so the dashboard survives a reboot; uninstall

--- a/docs/index.html
+++ b/docs/index.html
@@ -489,8 +489,8 @@
         <div class="iface reveal">
           <div class="iface-icon">🌐</div>
           <h3 data-en="Web UI" data-zh="Web 界面"></h3>
-          <p data-en="Local dashboard at :8080. Browse sessions, inspect tool output, manage skills — same agent, richer visuals."
-             data-zh="本地仪表盘（:8080）。浏览会话、查看工具输出、管理 skills —— 同一个 agent，更丰富的可视化。"></p>
+          <p data-en="Local dashboard at :8088. Browse sessions, inspect tool output, manage skills — same agent, richer visuals."
+             data-zh="本地仪表盘（:8088）。浏览会话、查看工具输出、管理 skills —— 同一个 agent，更丰富的可视化。"></p>
         </div>
         <div class="iface reveal">
           <div class="iface-icon">💬</div>
@@ -533,7 +533,7 @@ echo <span class="arg">"Summarise the last commit"</span> | <span class="cmd">oc
           <div class="demo-header"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span data-en="Web, IM, and MCP" data-zh="Web、IM 与 MCP"></span></div>
           <pre class="demo-code"><span class="comment" data-en="# Local web dashboard + IM bridges (one process)" data-zh="# 本地 Web 仪表盘 + IM 桥接（同一进程）"></span>
 <span class="cmd">octo serve</span>
-<span class="cmd">octo serve</span> --addr :8080  <span class="comment" data-en="# expose on the LAN" data-zh="# 暴露到局域网"></span>
+<span class="cmd">octo serve</span> --addr :8088  <span class="comment" data-en="# expose on the LAN" data-zh="# 暴露到局域网"></span>
 
 <span class="comment" data-en="# Connect MCP servers; manage skills" data-zh="# 连接 MCP 服务；管理 skills"></span>
 <span class="cmd">octo mcp</span>
@@ -664,7 +664,7 @@ echo <span class="arg">"Summarise the last commit"</span> | <span class="cmd">oc
           cmd.textContent =
             'curl -fsSL https://octo-agent.dev/install.sh | sh\n' +
             'octo serve -d                       # start the local server\n' +
-            opener + ' http://127.0.0.1:8080      # open the dashboard, then onboard';
+            opener + ' http://127.0.0.1:8088      # open the dashboard, then onboard';
         }
         btns.forEach(function (b) { b.style.display = 'none'; });
         return;

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -114,7 +114,7 @@ cat <<EOF
 Next steps — start the server and onboard in your browser:
 
   octo serve -d                    # run the local server in the background
-  $opencmd http://127.0.0.1:8080   # open the dashboard → pick a provider, paste a key
+  $opencmd http://127.0.0.1:8088   # open the dashboard → pick a provider, paste a key
 
 127.0.0.1 is loopback, so no access key is needed. Stop it later with
 \`octo serve --stop\`. Or skip the web UI and run \`octo\` for the terminal.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -50,7 +50,7 @@ func getDefaultToolsFor(model string) []agent.ToolDefinition {
 
 // Config holds server-level settings.
 type Config struct {
-	// Bind address (e.g. ":8080", "127.0.0.1:8080").
+	// Bind address (e.g. ":8088", "127.0.0.1:8088").
 	Addr string
 
 	// Provider and model override; zero values fall back to env/config.

--- a/internal/skills/defaults/channel-manager/SKILL.md
+++ b/internal/skills/defaults/channel-manager/SKILL.md
@@ -185,7 +185,7 @@ Weixin uses a QR-code login — no app credentials needed.
 
 1. Start the QR login flow via the serve API (the response carries the QR link):
    ```bash
-   curl -s -X POST http://127.0.0.1:8080/api/channels/weixin/login
+   curl -s -X POST http://127.0.0.1:8088/api/channels/weixin/login
    # → {"status":"pending","qr_url":"https://…"}      (or "already_logged_in")
    ```
    Pass `-d '{"force":true}'` to re-login over existing credentials.
@@ -194,7 +194,7 @@ Weixin uses a QR-code login — no app credentials needed.
    > `<qr_url from the response>`
 3. Poll until the flow finishes (every ~3s, up to 5 minutes):
    ```bash
-   curl -s http://127.0.0.1:8080/api/channels/weixin/login
+   curl -s http://127.0.0.1:8088/api/channels/weixin/login
    ```
    - `"status":"done"` — credentials are saved to `~/.octo/weixin-credentials.json`. Continue.
    - `"status":"pending"` with a new `qr_url` — the QR expired and was refreshed; relay the new link.

--- a/internal/skills/defaults/cron-task-creator/SKILL.md
+++ b/internal/skills/defaults/cron-task-creator/SKILL.md
@@ -72,25 +72,25 @@ in the server's local timezone.
 
 ## API — one surface, all under `/api/tasks`
 
-Prefer the API whenever `octo serve` is up (default `:8080`): every change
+Prefer the API whenever `octo serve` is up (default `:8088`): every change
 reschedules the running process immediately.
 
 ```bash
 # Create — returns {"id":"task_..."}. Include any optional field (directory,
 # model, agent, notify) right here.
-curl -s -X POST http://127.0.0.1:8080/api/tasks \
+curl -s -X POST http://127.0.0.1:8088/api/tasks \
   -H 'Content-Type: application/json' \
   -d '{"name":"daily-report","cron":"0 0 9 * * *","prompt":"Summarize ...","directory":"/srv/repo"}'
 
-curl -s http://127.0.0.1:8080/api/tasks                      # list
-curl -s -X DELETE http://127.0.0.1:8080/api/tasks/{id}       # delete
+curl -s http://127.0.0.1:8088/api/tasks                      # list
+curl -s -X DELETE http://127.0.0.1:8088/api/tasks/{id}       # delete
 
 # Run now — prefer the scheduler panel's Run button (see the workflow). Only
 # call this when the user explicitly asks to trigger a run from here.
-curl -s -X POST http://127.0.0.1:8080/api/tasks/{id}/run
+curl -s -X POST http://127.0.0.1:8088/api/tasks/{id}/run
 
 # Edit any subset of fields — this is also how you enable/disable.
-curl -s -X PATCH http://127.0.0.1:8080/api/tasks/{id} \
+curl -s -X PATCH http://127.0.0.1:8088/api/tasks/{id} \
   -H 'Content-Type: application/json' \
   -d '{"prompt":"new prompt ...","enabled":false}'
 ```

--- a/internal/skills/defaults/product_help/README.md
+++ b/internal/skills/defaults/product_help/README.md
@@ -97,7 +97,7 @@ octo init
 octo skills list
 
 # Web server + dashboard (binds localhost by default)
-octo serve --addr 127.0.0.1:8080
+octo serve --addr 127.0.0.1:8088
 
 # IM bridge (WeChat iLink): scan-to-login; channels run inside `octo serve`
 octo serve   # WeChat login: Channels panel in the web UI (scan QR)

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -41,7 +41,7 @@ tail -f /tmp/octo-serve.log
 ```
 
 > Both templates default to a loopback bind. Exposing the server on a LAN/public
-> address requires `-addr :8080` (or similar) **and** an access key — see
+> address requires `-addr :8088` (or similar) **and** an access key — see
 > [SECURITY.md](../SECURITY.md).
 
 ## Windows installer

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,8 +10,8 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:8080',
-      '/ws':  { target: 'ws://localhost:8080', ws: true },
+      '/api': 'http://localhost:8088',
+      '/ws':  { target: 'ws://localhost:8088', ws: true },
     },
   },
 })


### PR DESCRIPTION
## What

`octo serve` 默认端口 **8080 → 8088**。8080 太容易和其它软件撞车；8088 既贴 octo 定位（octo = 八），又是经典的 Intel 8088 CPU 型号，好记，且不在常见开发端口（3000/5000/5173/8000/8888/9000）之列。

## Changes

**代码默认值**
- `cmd/octo/serve.go` — `--addr` 默认 `127.0.0.1:8088`
- `cmd/octo/serve_daemon.go` — daemon 回拨地址默认值 + 注释
- `cmd/octo/help.go` — `octo serve` 帮助文本
- `internal/server/server.go` — Bind 字段注释示例
- `cmd/octo/serve_test.go` / `serve_daemon_test.go` — 两处断言默认值的测试同步更新

**前端 / 官网 / 文档**
- `web/vite.config.ts` — dev 代理 `/api`、`/ws` → :8088（否则 `npm run dev` 连不上本地服务）
- `docs/index.html`、`docs/install.sh` — 官网
- `README.md`、`README_CN.md`、`SECURITY.md`、`packaging/README.md`
- `dev-docs/serve-auth-design.md`、`dev-docs/windows-onboarding-design.md`
- `internal/skills/defaults/product_help/README.md`、`cron-task-creator/SKILL.md`、`channel-manager/SKILL.md`

## 刻意没动

- `CHANGELOG.md` 历史发布记录（历史事实，不改写）
- `auth_test.go` / `permission_test.go` / `oauth_test.go` / `server_test.go` 中把 `:8080` 当任意 host:port 测逻辑的夹具

## Verification

- `go build ./...` ✅
- `go test ./cmd/octo/` ✅
- `gofmt -l .` 干净 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)