### PR TITLE
fix(tools): forbid packing multiple questions into one ask_user_question string

### DIFF
--- a/internal/tools/ask_user_question.go
+++ b/internal/tools/ask_user_question.go
@@ -133,7 +133,7 @@ func (AskUserQuestionTool) Definition() agent.ToolDefinition {
 						"properties": map[string]any{
 							"question": map[string]any{
 								"type":        "string",
-								"description": "The question to ask, complete with punctuation. Should be one sentence; if you need more context, put it in the option labels instead of the question itself.",
+								"description": "The question to ask, complete with punctuation. Should be ONE sentence asking ONE thing. Do not pack multiple questions (\"1) … 2) …\") into a single string — ask one, then fire a separate call for the next. If you need more context, put it in the option labels instead of the question itself.",
 							},
 							"header": map[string]any{
 								"type":        "string",


### PR DESCRIPTION
## Why

`ask_user_question` already caps the `questions` array at one entry (`maxItems:1`), so the model can only send one *question object* per call. But that constraint doesn't stop it from cramming several sub-questions into the **single `question` string** — e.g. `"请输入两个信息: 1) … 2) …"` with empty options. That renders as one prompt with a lone free-text box, forcing the user to answer multiple things in one field (and, before #985, the long string got truncated).

The only guard against this was a soft `"Should be one sentence"` hint, which the model overran.

## Change

Strengthen the `question` field description to explicitly forbid multi-question strings and point the model at the right pattern (one question per call):

> The question to ask, complete with punctuation. Should be **ONE sentence asking ONE thing**. Do not pack multiple questions (`"1) … 2) …"`) into a single string — ask one, then fire a separate call for the next. If you need more context, put it in the option labels instead of the question itself.

Description-only; no behavior/schema change. `go vet` + build clean; no test pins the old string.

Companion to #985 (which fixes the web modal so the full question is always shown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)