### PR TITLE
fix(browser): widen WaitFor timeout in tests to de-flake Windows CI

### DIFF
--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -13,6 +13,13 @@ import (
 	"time"
 )
 
+// testWaitTimeout caps how long the browser tests wait for a selector to
+// appear. WaitFor returns the instant the element is present, so this ceiling
+// is free on a healthy run — it only matters when a slow/loaded CI runner
+// (Windows cold-starts Chrome notably slower) needs more than a few seconds to
+// finish the first navigation. 5s was too tight there and flaked TestUpload.
+const testWaitTimeout = 20 * time.Second
+
 // fixtureHTML reproduces the awkward shape of the real target system:
 //   - the download button only appears after a search (no pre-constructable URL)
 //   - clicking it generates the file client-side via a Blob (the server never
@@ -91,7 +98,7 @@ func TestSearchThenDownload(t *testing.T) {
 	if err := page.Navigate(ctx, srv.URL); err != nil {
 		t.Fatalf("navigate: %v", err)
 	}
-	if err := page.WaitFor(ctx, "#search", 5*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#search", testWaitTimeout); err != nil {
 		t.Fatalf("wait search: %v", err)
 	}
 
@@ -102,7 +109,7 @@ func TestSearchThenDownload(t *testing.T) {
 		t.Fatalf("click search: %v", err)
 	}
 	// The download button is absent until the (simulated) search completes.
-	if err := page.WaitFor(ctx, "#download", 5*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#download", testWaitTimeout); err != nil {
 		t.Fatalf("wait download button: %v", err)
 	}
 
@@ -143,7 +150,7 @@ func TestAttachExistingPage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new page: %v", err)
 	}
-	if err := opened.WaitFor(ctx, "#search", 5*time.Second); err != nil {
+	if err := opened.WaitFor(ctx, "#search", testWaitTimeout); err != nil {
 		t.Fatalf("wait: %v", err)
 	}
 
@@ -190,7 +197,7 @@ func TestUpload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new page: %v", err)
 	}
-	if err := page.WaitFor(ctx, "#f", 5*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#f", testWaitTimeout); err != nil {
 		t.Fatalf("wait: %v", err)
 	}
 
@@ -230,7 +237,7 @@ document.getElementById('t').addEventListener('mouseover',function(){window.hove
 	if err != nil {
 		t.Fatalf("new page: %v", err)
 	}
-	if err := page.WaitFor(ctx, "#t", 5*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#t", testWaitTimeout); err != nil {
 		t.Fatalf("wait: %v", err)
 	}
 	if err := page.Hover(ctx, "#t"); err != nil {
@@ -263,7 +270,7 @@ func TestSelectOption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new page: %v", err)
 	}
-	if err := page.WaitFor(ctx, "#s", 5*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#s", testWaitTimeout); err != nil {
 		t.Fatalf("wait: %v", err)
 	}
 	if err := page.SelectOption(ctx, "#s", "Banana"); err != nil {
@@ -309,7 +316,7 @@ func TestSameOriginFrame(t *testing.T) {
 		t.Fatalf("new page: %v", err)
 	}
 	// Frame-aware wait: the button lives inside the same-origin child frame.
-	if err := page.WaitFor(ctx, "#fr >>> #b", 5*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#fr >>> #b", testWaitTimeout); err != nil {
 		t.Fatalf("wait in frame: %v", err)
 	}
 	if err := page.Click(ctx, "#fr >>> #b"); err != nil {
@@ -449,7 +456,7 @@ func TestPrimitives(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new page: %v", err)
 	}
-	if err := page.WaitFor(ctx, "#search", 5*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#search", testWaitTimeout); err != nil {
 		t.Fatalf("wait: %v", err)
 	}
 

--- a/internal/browser/recorder_test.go
+++ b/internal/browser/recorder_test.go
@@ -27,7 +27,7 @@ func TestRecorderAnchorsSelectorAtNearestID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new page: %v", err)
 	}
-	if err := page.WaitFor(ctx, "#panel a", 5*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#panel a", testWaitTimeout); err != nil {
 		t.Fatalf("wait: %v", err)
 	}
 	rec := NewRecorder(page)
@@ -73,7 +73,7 @@ func TestRecorderCapturesActions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new page: %v", err)
 	}
-	if err := page.WaitFor(ctx, "#b", 5*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#b", testWaitTimeout); err != nil {
 		t.Fatalf("wait: %v", err)
 	}
 
@@ -120,7 +120,7 @@ func TestRecorderCapturesActions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fresh page: %v", err)
 	}
-	if err := fresh.WaitFor(ctx, "#b", 5*time.Second); err != nil {
+	if err := fresh.WaitFor(ctx, "#b", testWaitTimeout); err != nil {
 		t.Fatalf("wait fresh: %v", err)
 	}
 	if err := Replay(ctx, fresh, evs); err != nil {

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -79,7 +79,7 @@ func TestUploadViaChooser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new page: %v", err)
 	}
-	if err := page.WaitFor(ctx, "#btn", 5*time.Second); err != nil {
+	if err := page.WaitFor(ctx, "#btn", testWaitTimeout); err != nil {
 		t.Fatalf("wait: %v", err)
 	}
 	dir := t.TempDir()
@@ -228,7 +228,7 @@ func TestReplayClickFollowsNewTab(t *testing.T) {
 	if fp == page {
 		t.Fatal("replay did not follow the new tab opened by the click")
 	}
-	if err := fp.WaitFor(ctx, "#dest", 5*time.Second); err != nil {
+	if err := fp.WaitFor(ctx, "#dest", testWaitTimeout); err != nil {
 		t.Fatalf("final page is not the destination tab: %v", err)
 	}
 }


### PR DESCRIPTION
## 背景

PR #987 的 Windows CI 失败在 `internal/browser` 的 `TestUpload`：

```
browser_test.go:194: wait: wait for "#f": timed out after 5s
```

`#f` 就在初始 HTML 里,不是 DOM 时序问题——是 windows-latest 冷启动 Chrome + 首次导航偶发超过 5s,第一个 `WaitFor` 太紧导致 flaky。所有 13 处 `WaitFor` 都用 5s,这次撞在 `TestUpload`,下次可能撞别的。

## 修复

`WaitFor` 一旦命中元素立即返回,**放宽超时上限在通过的运行上零成本**,只给慢机器留余量。引入共享常量 `testWaitTimeout = 20s`,在所有 `WaitFor` 调用点统一使用。与 `WaitFor` 无关的 ctx 超时(`5*time.Second`)保持不动。

`newBrowser` 已对 "timed out reading DevToolsActivePort" 启动超时做跳过,但本次 flake 是 `WaitFor` 超时,不在其覆盖内——本 PR 补上这条路径。

## 验证

- `go vet ./internal/browser/` ✅
- `go test ./internal/browser/` ✅(本地有 Chrome,35s 全过)
- `gofmt -l` 干净 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)