### PR TITLE
fix(config): don't silently save a rejected key in the setup wizard

### DIFF
--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -401,18 +402,24 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer, firstRun bool) i
 
 	// Validate a freshly entered key against the live endpoint so a typo is
 	// caught here, not on the first turn. Interactive only (TTY) — piped runs and
-	// tests must not hit the network. First run loops on failure so the user can
-	// retry; the full editor just warns.
+	// tests must not hit the network. The full editor only warns; first run keeps
+	// the user on a rejected key (which won't fix itself) but lets a network blip
+	// through, since that says nothing about whether the config is right.
 	if keyEntered && tty {
 		for {
-			if reportConnectionCheck(stdout, stderr, provider, outEntry.APIKey, baseURL, model) {
+			res := reportConnectionCheck(stdout, stderr, provider, outEntry.APIKey, baseURL, model)
+			if res == connOK || !firstRun {
 				break
 			}
-			if !firstRun {
+			if res == connNetwork {
+				fmt.Fprintln(stdout, "Couldn't verify the connection — looks like a network or endpoint issue, not the key. Saving anyway; if octo won't start, re-run `octo config`.")
 				break
 			}
+			// connRejected: the endpoint turned the request away, so the saved
+			// config would be unusable. Push the user to fix it; empty enter is an
+			// explicit, eyes-open choice to keep the rejected key.
 			again := strings.TrimSpace(promptDefault(reader, stdout,
-				"Re-enter API key (empty = keep it and continue)", ""))
+				"Re-enter API key (empty = save this rejected key anyway)", ""))
 			if again == "" {
 				break
 			}
@@ -521,10 +528,22 @@ func collectAPIKey(outEntry *config.ModelEntry, existing config.ModelEntry, prov
 	return false
 }
 
+// connResult classifies the outcome of a live connection probe. The wizard
+// treats the two failure classes differently: a rejected key/model/endpoint is
+// the user's config being wrong and won't fix itself, whereas a network blip is
+// orthogonal to whether the config is correct.
+type connResult int
+
+const (
+	connOK       connResult = iota // probe succeeded
+	connRejected                   // endpoint rejected the request (bad key/model/endpoint)
+	connNetwork                    // couldn't reach the endpoint (network/timeout/5xx/429)
+)
+
 // reportConnectionCheck tests the entered key against the endpoint, printing a
-// ✓/✗ line. Returns true on success. Resolves the vendor default model/base URL
-// when the user accepted the default (left them empty).
-func reportConnectionCheck(stdout, stderr io.Writer, provider, key, baseURL, model string) bool {
+// ✓/✗ line. Resolves the vendor default model/base URL when the user accepted
+// the default (left them empty).
+func reportConnectionCheck(stdout, stderr io.Writer, provider, key, baseURL, model string) connResult {
 	if model == "" {
 		model = app.VendorDefaultModel(provider)
 	}
@@ -536,10 +555,52 @@ func reportConnectionCheck(stdout, stderr io.Writer, provider, key, baseURL, mod
 	defer cancel()
 	if err := validateConnection(ctx, provider, key, baseURL, model); err != nil {
 		fmt.Fprintf(stderr, "✗ Couldn't connect: %v\n", err)
-		return false
+		return classifyConnErr(err)
 	}
 	fmt.Fprintln(stdout, "✓ Connected.")
-	return true
+	return connOK
+}
+
+// classifyConnErr decides whether a failed probe means the config is wrong or
+// the network just got in the way. Providers format API rejections as
+// "<vendor>: HTTP <code>: …" (see anthropic/openai client.go), so the status
+// code is the signal: 400/401/403/404 are the config being rejected; a missing
+// HTTP code (dial/timeout) or a transient status (408/409/425/429/5xx) is a
+// network problem the config can't be blamed for.
+func classifyConnErr(err error) connResult {
+	code, ok := httpStatusFromErr(err.Error())
+	if !ok {
+		return connNetwork // no HTTP response reached us at all
+	}
+	switch code {
+	case 400, 401, 403, 404:
+		return connRejected
+	default:
+		return connNetwork
+	}
+}
+
+// httpStatusFromErr extracts the status code from a provider error of the form
+// "…: HTTP <code>: …". Returns ok=false when no such marker is present.
+func httpStatusFromErr(msg string) (int, bool) {
+	const marker = "HTTP "
+	i := strings.Index(msg, marker)
+	if i < 0 {
+		return 0, false
+	}
+	rest := msg[i+len(marker):]
+	end := strings.IndexFunc(rest, func(r rune) bool { return r < '0' || r > '9' })
+	if end < 0 {
+		end = len(rest)
+	}
+	if end == 0 {
+		return 0, false
+	}
+	code, err := strconv.Atoi(rest[:end])
+	if err != nil {
+		return 0, false
+	}
+	return code, true
 }
 
 // customSentinel is the menu value standing in for "let me type my own". It

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -361,16 +361,19 @@ func TestReportConnectionCheck(t *testing.T) {
 	var gotModel, gotBase string
 	validateConnection = func(ctx context.Context, provider, key, baseURL, model string) error {
 		gotModel, gotBase = model, baseURL
-		if key == "bad" {
-			return errors.New("401 unauthorized")
+		switch key {
+		case "bad":
+			return errors.New("anthropic: HTTP 401: invalid x-api-key")
+		case "offline":
+			return errors.New("dial tcp: lookup api.anthropic.com: no such host")
 		}
 		return nil
 	}
 
 	var out, errb bytes.Buffer
 	// Empty model/baseURL must resolve to the vendor defaults before testing.
-	if ok := reportConnectionCheck(&out, &errb, "anthropic", "good", "", ""); !ok {
-		t.Fatalf("expected success; stderr=%q", errb.String())
+	if res := reportConnectionCheck(&out, &errb, "anthropic", "good", "", ""); res != connOK {
+		t.Fatalf("expected connOK; got %d, stderr=%q", res, errb.String())
 	}
 	if gotModel == "" || gotBase == "" {
 		t.Errorf("defaults not resolved: model=%q base=%q", gotModel, gotBase)
@@ -381,11 +384,40 @@ func TestReportConnectionCheck(t *testing.T) {
 
 	out.Reset()
 	errb.Reset()
-	if ok := reportConnectionCheck(&out, &errb, "anthropic", "bad", "", ""); ok {
-		t.Fatal("expected failure for bad key")
+	// A rejected key (HTTP 4xx) is the config being wrong.
+	if res := reportConnectionCheck(&out, &errb, "anthropic", "bad", "", ""); res != connRejected {
+		t.Fatalf("expected connRejected for bad key; got %d", res)
 	}
 	if !strings.Contains(errb.String(), "Couldn't connect") {
 		t.Errorf("missing failure line: %q", errb.String())
+	}
+
+	// A network error is orthogonal to whether the config is correct.
+	if res := reportConnectionCheck(&out, &errb, "anthropic", "offline", "", ""); res != connNetwork {
+		t.Fatalf("expected connNetwork for unreachable endpoint; got %d", res)
+	}
+}
+
+// TestClassifyConnErr pins the HTTP-status-based split between a rejected
+// config and a transient network failure.
+func TestClassifyConnErr(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want connResult
+	}{
+		{"anthropic: HTTP 401: invalid x-api-key", connRejected},
+		{"openai: HTTP 403: forbidden", connRejected},
+		{"openai: HTTP 400: bad request", connRejected},
+		{"anthropic: HTTP 404: model not found", connRejected},
+		{"openai: HTTP 429: rate limit exceeded", connNetwork},
+		{"anthropic: HTTP 500: internal error", connNetwork},
+		{"dial tcp 1.2.3.4:443: i/o timeout", connNetwork},
+		{"context deadline exceeded", connNetwork},
+	}
+	for _, c := range cases {
+		if got := classifyConnErr(errors.New(c.msg)); got != c.want {
+			t.Errorf("classifyConnErr(%q) = %d, want %d", c.msg, got, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

In the `octo config` first-run wizard, the live connection probe treated **every** failure identically: pressing empty-enter silently kept whatever key was typed and continued. A mistyped key therefore got saved into a config that can't run — and the error only resurfaced, more confusingly, on the first `octo` turn. As reported: *"我保存了一份不知道对不对的配置，后续也用不了啊"*.

But a blanket "block on any failure" is also wrong: offline first-run, corporate proxies, and gateway rate-limiting/quirks (documented in this repo's own CLAUDE.md) fail the probe while the config is perfectly fine.

## Fix

Split the probe outcome by **cause**. Provider errors are formatted as `<vendor>: HTTP <code>: …` (see `anthropic`/`openai` `client.go`), so:

- **`400/401/403/404` → rejected**: the key / model / endpoint is wrong and won't self-heal.
- **missing HTTP code (dial/timeout), or `408/409/425/429/5xx` → network**: orthogonal to whether the config is correct.

First-run behaviour:

| Outcome | Before | After |
|---|---|---|
| Rejected (4xx) | empty-enter silently saves junk | re-enter to fix; empty-enter is an explicit, reworded *"save this rejected key anyway"* |
| Network/transient | trapped in the same retry loop | clear *"couldn't verify — looks like network, saving anyway; re-run if octo won't start"* note, then proceeds |
| Full editor (non-first-run) | warn only | unchanged |

## Tests

- `TestReportConnectionCheck` updated to use real-format error strings and assert the three-state result.
- New `TestClassifyConnErr` pins the status-code boundary (incl. 429/5xx landing in the network class, not rejected).

gofmt / `go vet` / `go test ./cmd/octo/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)