### PR TITLE
fix(installer): open the dashboard on :8088 after install

### DIFF
--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -168,7 +168,7 @@ func splitComma(s string) []string {
 }
 
 // bindIsLoopback reports whether a bind address only accepts loopback
-// clients. An empty host (":8080") and the wildcard addresses listen on all
+// clients. An empty host (":8088") and the wildcard addresses listen on all
 // interfaces, so they are not loopback.
 func bindIsLoopback(addr string) bool {
 	host, _, err := net.SplitHostPort(addr)

--- a/packaging/windows/octo.iss
+++ b/packaging/windows/octo.iss
@@ -128,7 +128,7 @@ begin
   // Open the onboarding page regardless of the exact exit code — if the server
   // is up, this lands on onboarding; if it never bound, the browser shows a
   // connection error the user can retry, which is no worse than not opening.
-  ShellExec('open', 'http://127.0.0.1:8080', '', '', SW_SHOWNORMAL,
+  ShellExec('open', 'http://127.0.0.1:8088', '', '', SW_SHOWNORMAL,
             ewNoWait, ResultCode);
 end;
 


### PR DESCRIPTION
## 背景

#987 把 \`octo serve\` 默认端口改到 8088,但 Windows 安装器漏改了——之前的端口扫描没覆盖 \`.iss\` 扩展名。

\`packaging/windows/octo.iss\` 装完后跑 \`octo serve -d\`(现在默认绑 **8088**),却 \`ShellExec\` 打开 \`http://127.0.0.1:8080\` → 落到死端口,用户看到连接错误。

## 修复

- \`octo.iss:131\` — 安装后打开的 URL 改成 \`http://127.0.0.1:8088\`,与 daemon 默认 bind 一致。
- \`cmd/octo/serve.go:171\` — \`bindIsLoopback\` 注释里过时的 \`":8080"\` 示例顺手统一为 \`":8088"\`。

## 验证

- \`go build ./cmd/octo/\` ✅,\`gofmt\` 干净 ✅
- 全量扫描确认仓库内无残留 8080(CHANGELOG 历史记录与鉴权测试夹具除外)
- daemon 默认 \`127.0.0.1:8088\` 与安装器打开的 URL 现已一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)