### PR TITLE
fix(config): treat all non-transient 4xx as a rejected config, anchor probe parse

### DIFF
--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -412,7 +412,8 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer, firstRun bool) i
 				break
 			}
 			if res == connNetwork {
-				fmt.Fprintln(stdout, "Couldn't verify the connection — looks like a network or endpoint issue, not the key. Saving anyway; if octo won't start, re-run `octo config`.")
+				// Same stream as the ✗ line it explains, so the two stay together.
+				fmt.Fprintln(stderr, "Couldn't verify the connection — looks like a network or endpoint issue, not the key. Saving anyway; if octo won't start, re-run `octo config`.")
 				break
 			}
 			// connRejected: the endpoint turned the request away, so the saved
@@ -564,26 +565,33 @@ func reportConnectionCheck(stdout, stderr io.Writer, provider, key, baseURL, mod
 // classifyConnErr decides whether a failed probe means the config is wrong or
 // the network just got in the way. Providers format API rejections as
 // "<vendor>: HTTP <code>: …" (see anthropic/openai client.go), so the status
-// code is the signal: 400/401/403/404 are the config being rejected; a missing
-// HTTP code (dial/timeout) or a transient status (408/409/425/429/5xx) is a
-// network problem the config can't be blamed for.
+// code is the signal. A client-error status (4xx) means the request itself was
+// turned away — wrong key/model/endpoint — and won't fix itself, EXCEPT the
+// transient 4xx (408/409/425/429) which, like every 5xx and every error with no
+// HTTP code at all (dial/timeout), is a network problem the config can't be
+// blamed for.
 func classifyConnErr(err error) connResult {
 	code, ok := httpStatusFromErr(err.Error())
 	if !ok {
 		return connNetwork // no HTTP response reached us at all
 	}
-	switch code {
-	case 400, 401, 403, 404:
-		return connRejected
+	switch {
+	case code == 408 || code == 409 || code == 425 || code == 429:
+		return connNetwork // transient — retrying may well succeed
+	case code >= 400 && code < 500:
+		return connRejected // request rejected: bad key/model/endpoint
 	default:
-		return connNetwork
+		return connNetwork // 5xx and anything non-4xx: server-side / unverified
 	}
 }
 
 // httpStatusFromErr extracts the status code from a provider error of the form
-// "…: HTTP <code>: …". Returns ok=false when no such marker is present.
+// "…: HTTP <code>: …". The ": HTTP " marker (with the leading colon-space the
+// providers emit) anchors to the real status prefix, so a status code echoed
+// later inside the response body can't be mistaken for it. Returns ok=false
+// when no such marker is present.
 func httpStatusFromErr(msg string) (int, bool) {
-	const marker = "HTTP "
+	const marker = ": HTTP "
 	i := strings.Index(msg, marker)
 	if i < 0 {
 		return 0, false

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -409,14 +409,46 @@ func TestClassifyConnErr(t *testing.T) {
 		{"openai: HTTP 403: forbidden", connRejected},
 		{"openai: HTTP 400: bad request", connRejected},
 		{"anthropic: HTTP 404: model not found", connRejected},
+		// Non-transient 4xx a compatible gateway may use for a bad model/path —
+		// still the config being wrong, must not be saved as a "network blip".
+		{"openai: HTTP 422: unknown model", connRejected},
+		{"openai: HTTP 405: method not allowed", connRejected},
+		{"openai: HTTP 402: payment required", connRejected},
+		// Transient codes: retrying may succeed, so they're network-class.
 		{"openai: HTTP 429: rate limit exceeded", connNetwork},
+		{"openai: HTTP 408: request timeout", connNetwork},
 		{"anthropic: HTTP 500: internal error", connNetwork},
+		{"openai: HTTP 503: service unavailable", connNetwork},
 		{"dial tcp 1.2.3.4:443: i/o timeout", connNetwork},
 		{"context deadline exceeded", connNetwork},
+		// A status echoed inside the body must not be mistaken for the real one.
+		{`openai: HTTP 401: {"detail":"upstream returned HTTP 503"}`, connRejected},
 	}
 	for _, c := range cases {
 		if got := classifyConnErr(errors.New(c.msg)); got != c.want {
 			t.Errorf("classifyConnErr(%q) = %d, want %d", c.msg, got, c.want)
+		}
+	}
+}
+
+// TestHTTPStatusFromErr covers the parsing edge cases directly: the body-echo
+// guard, a malformed marker, and a non-numeric code.
+func TestHTTPStatusFromErr(t *testing.T) {
+	cases := []struct {
+		msg      string
+		wantCode int
+		wantOK   bool
+	}{
+		{"anthropic: HTTP 401: invalid x-api-key", 401, true},
+		{`openai: HTTP 500: {"err":"saw HTTP 200 upstream"}`, 500, true},
+		{"dial tcp: no such host", 0, false},
+		{"weird: HTTP : missing code", 0, false},
+		{"weird: HTTP abc: not a number", 0, false},
+	}
+	for _, c := range cases {
+		code, ok := httpStatusFromErr(c.msg)
+		if code != c.wantCode || ok != c.wantOK {
+			t.Errorf("httpStatusFromErr(%q) = (%d, %v), want (%d, %v)", c.msg, code, ok, c.wantCode, c.wantOK)
 		}
 	}
 }


### PR DESCRIPTION
## Why this exists

These are the code-review follow-ups to #990. They were committed to that PR's branch **after** auto-merge had already squash-merged the first commit, so they never landed on `main` — this PR recovers them.

## Changes

- **`classifyConnErr`**: previously only `400/401/403/404` mapped to "rejected" and every other 4xx fell into the network class. A compatible gateway answering **422** for an unknown model (or 402/405/…) would be reported as a network blip and the broken config saved silently — exactly what #990 set out to prevent. Now every 4xx except the transient ones (`408/409/425/429`) is a rejection; 5xx, transient 4xx, and no-HTTP-code errors stay network. This also reconciles the code with its own comment.
- **`httpStatusFromErr`**: anchor to the `": HTTP "` marker (the colon-space the providers emit) so a status code echoed inside the response body can't be mistaken for the real one.
- **first-run loop**: route the "saving anyway" network note to `stderr`, alongside the `✗` line it explains.
- **tests**: 4xx-band + body-echo cases in `TestClassifyConnErr`; new `TestHTTPStatusFromErr` for the parse edge cases (body echo, malformed marker, non-numeric code).

gofmt / `go vet` / `go test ./cmd/octo/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)