### PR TITLE
fix(server): model-config panel — live default sender + reuse stored key on Test

### DIFF
--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -402,10 +402,8 @@ func (s *Server) handleSaveModelConfig(w http.ResponseWriter, r *http.Request) {
 	applyModelRequestToEntry(req, &entry)
 	entry.Name = cfg.UniqueName(req.Model)
 	cfg.Models = append(cfg.Models, entry)
-	becameDefault := false
 	if cfg.DefaultModel == "" || len(cfg.Models) == 1 {
 		cfg.DefaultModel = entry.Name
-		becameDefault = true
 	}
 	if req.PermissionMode != "" {
 		cfg.PermissionMode = req.PermissionMode
@@ -415,13 +413,12 @@ func (s *Server) handleSaveModelConfig(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return
 	}
-	// When this entry becomes the default (e.g. the first model saved during
-	// first-run onboard), point new sessions at it — otherwise handleCreateSession
-	// keeps using the stale startup s.model. Mirrors handleSetDefaultModelConfig.
-	if becameDefault {
-		s.model = entry.Model
-	}
+	// Rebuild the default sender/model so new unbound sessions pick up the new
+	// entry (e.g. the first model saved during onboard, or a changed default).
 	s.invalidateSenderCache()
+	if err := s.reloadDefaultSender(); err != nil {
+		log.Printf("[server] reload default sender after saving model config: %v", err)
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": entry.Name})
 }
@@ -481,7 +478,12 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return
 	}
+	// Editing the default entry (provider/model/endpoint/key) must rebuild the
+	// default sender, or new unbound sessions keep using the stale startup one.
 	s.invalidateSenderCache()
+	if err := s.reloadDefaultSender(); err != nil {
+		log.Printf("[server] reload default sender after updating model config: %v", err)
+	}
 
 	// id may have changed if the auto-derived name tracked a new model — return
 	// it so the client can refresh its reference.
@@ -531,7 +533,12 @@ func (s *Server) handleDeleteModelConfig(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return
 	}
+	// Deleting an entry may have repaired the default; rebuild the default
+	// sender so new unbound sessions follow the new default.
 	s.invalidateSenderCache()
+	if err := s.reloadDefaultSender(); err != nil {
+		log.Printf("[server] reload default sender after deleting model config: %v", err)
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
@@ -594,9 +601,12 @@ func (s *Server) handleSetDefaultModelConfig(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// The next agent turn should pick up the new default.
-	s.model = cfg.DefaultEntry().Model
+	// The next agent turn should pick up the new default: rebuild the default
+	// sender/model under senderMu so new unbound sessions follow it.
 	s.invalidateSenderCache()
+	if err := s.reloadDefaultSender(); err != nil {
+		log.Printf("[server] reload default sender after setting default model: %v", err)
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -282,6 +282,27 @@ type testConfigRequest struct {
 	AnthropicFormat bool   `json:"anthropic_format"`
 }
 
+// storedAPIKey returns the saved key of the config entry that best matches
+// (provider, baseURL): an exact provider+endpoint match wins, else the first
+// entry on the same provider. Empty when none is stored. Lets a connection
+// test reuse the stored key when the provider is unchanged.
+func storedAPIKey(cfg config.Config, provider, baseURL string) string {
+	nb := strings.TrimRight(baseURL, "/")
+	var sameProvider string
+	for _, e := range cfg.Models {
+		if e.APIKey == "" || e.Provider != provider {
+			continue
+		}
+		if strings.TrimRight(e.BaseURL, "/") == nb {
+			return e.APIKey
+		}
+		if sameProvider == "" {
+			sameProvider = e.APIKey
+		}
+	}
+	return sameProvider
+}
+
 func (s *Server) handleTestConfig(w http.ResponseWriter, r *http.Request) {
 	var req testConfigRequest
 	if err := readBodyJSON(r, &req); err != nil {
@@ -290,18 +311,6 @@ func (s *Server) handleTestConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Model == "" || req.BaseURL == "" {
 		writeJSON(w, http.StatusOK, map[string]any{"ok": false, "message": "model and base_url are required"})
-		return
-	}
-
-	key := req.APIKey
-	if key == "" {
-		key = os.Getenv("ANTHROPIC_API_KEY")
-		if key == "" {
-			key = os.Getenv("OPENAI_API_KEY")
-		}
-	}
-	if key == "" {
-		writeJSON(w, http.StatusOK, map[string]any{"ok": false, "message": "no API key provided"})
 		return
 	}
 
@@ -315,6 +324,25 @@ func (s *Server) handleTestConfig(w http.ResponseWriter, r *http.Request) {
 		providerName = req.Provider
 	} else if v := app.VendorByBaseURL(req.BaseURL); v != "" {
 		providerName = v
+	}
+
+	// Resolve the key. An empty or still-masked field means "unchanged" — the
+	// panel never prefills the key input, so editing a model and hitting Test
+	// sends no key. Reuse the stored key of the matching entry instead of
+	// demanding a re-type; fall back to the vendor's env var last.
+	key := req.APIKey
+	if key == "" || strings.Contains(key, "****") {
+		key = ""
+		if cfg, err := config.Load(); err == nil {
+			key = storedAPIKey(cfg, providerName, req.BaseURL)
+		}
+	}
+	if key == "" {
+		key = os.Getenv(app.VendorAPIKeyEnvVar(providerName))
+	}
+	if key == "" {
+		writeJSON(w, http.StatusOK, map[string]any{"ok": false, "message": "no API key provided"})
+		return
 	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -297,6 +297,11 @@ func TestConfigModels_PatchUpdatesAndKeepsKey(t *testing.T) {
 	if e.Provider != "anthropic" {
 		t.Errorf("provider = %q, want anthropic preserved", e.Provider)
 	}
+	// Editing the default entry must rebuild the runtime default sender/model,
+	// or new unbound sessions keep using the stale startup model.
+	if srv.model != "claude-opus-4-7" {
+		t.Errorf("runtime default model = %q, want claude-opus-4-7 after editing default entry", srv.model)
+	}
 
 	if w := doJSON(t, srv, http.MethodPatch, "/api/config/models/ghost", `{"model":"x"}`); w.Code != http.StatusNotFound {
 		t.Errorf("PATCH unknown id = %d, want 404", w.Code)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1313,26 +1313,24 @@ func (s *Server) getProvider() string {
 	return s.provider
 }
 
-// reloadDefaultSender rebuilds the server's default sender from current config.
-// It is used when global settings (e.g. show_reasoning) change so existing
-// sessions pick up the new defaults on their next turn. If the server is still
-// in onboarding mode (nil sender) the call is a no-op.
+// reloadDefaultSender rebuilds the server's default sender and model from the
+// current config so existing unbound sessions pick up the change on their next
+// turn. Called whenever a global setting or a model-config entry changes. In
+// onboarding mode (no API key yet) the sender stays nil, but s.model is still
+// refreshed from config so a session created before ensureSender runs uses the
+// right model.
 func (s *Server) reloadDefaultSender() error {
 	s.senderMu.Lock()
 	defer s.senderMu.Unlock()
-	if s.sender == nil {
-		return nil
-	}
 	sender, model, provName, err := resolveProviderAndModel(s.cfg.Provider, s.cfg.Model)
 	if err != nil {
 		return err
 	}
-	if sender == nil {
-		return nil
-	}
-	s.sender = sender
 	s.model = model
-	s.provider = provName
+	if sender != nil {
+		s.sender = sender
+		s.provider = provName
+	}
 	return nil
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -635,6 +635,44 @@ func TestHandleTestConfig(t *testing.T) {
 	}
 }
 
+// Editing a model and hitting Test sends no api_key (the panel never prefills
+// the key input). The server must reuse the stored key of the matching entry
+// instead of failing with "no API key provided".
+func TestHandleTestConfig_ReusesStoredKey(t *testing.T) {
+	setTestHome(t)
+
+	var gotAuth string
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer mock.Close()
+
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Name: "main", Provider: "openai", Model: "gpt-4o-mini", BaseURL: mock.URL, APIKey: "stored-key"},
+		},
+		DefaultModel: "main",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/config/test",
+		`{"model":"gpt-4o-mini","base_url":"`+mock.URL+`","provider":"openai"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["ok"] != true {
+		t.Fatalf("ok = %v, want true (should reuse stored key); msg=%v", body["ok"], body["message"])
+	}
+	if gotAuth != "Bearer stored-key" {
+		t.Errorf("Authorization = %q, want Bearer stored-key (stored key reused)", gotAuth)
+	}
+}
+
 func TestHandleSaveModelConfig(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)


### PR DESCRIPTION
Two fixes to the `octo serve` model-config panel, both about a change in the UI not taking effect without re-entering data.

## 1. Changing the model config doesn't apply to new sessions

**Symptom:** after changing the model in the UI, every new session errored (e.g. `openai: HTTP 404: No endpoints found for owl-alpha`); only manually switching the model at the bottom of a session worked.

**Cause:** new/unbound sessions run on the server's default sender/model (`s.sender`/`s.model`), built once at `octo serve` startup. The four `/api/config/models*` mutation handlers only called `invalidateSenderCache()` (per-entry cache), never rebuilding the default sender. `handleUpdateModelConfig` (editing the default entry) touched neither `s.sender` nor `s.model`; `setDefault`/`save` set `s.model` without `senderMu` (racy) and never rebuilt `s.sender`.

**Fix:** all four handlers now call `s.reloadDefaultSender()` after `cfg.Save()`, replacing the ad-hoc unlocked `s.model = …` writes. `reloadDefaultSender` also refreshes `s.model` in onboarding mode (sender still nil). Note: it resolves from `s.cfg.Provider/Model` (startup flags) — flag-less `octo serve` reads the current config default and is fully fixed; an explicit `--model` still wins (expected).

## 2. "Test connection" demands the key again on an unchanged provider

**Symptom:** editing a model and hitting Test reported no API key, even though the entry has a stored key.

**Cause:** the panel never prefills the key input, so Test sends an empty `api_key`. `handleTestConfig` only looked at the request field and two hardcoded env vars → "no API key provided".

**Fix:** resolve the provider first, then reuse the stored key of the matching entry (exact provider+endpoint, else same provider) when the request key is empty or masked — mirroring the save path. Env fallback now uses the vendor's own env var.

## Tests

- `TestConfigModels_PatchUpdatesAndKeepsKey`: editing the default entry updates the runtime default model. Fails before fix (`stub-model`), passes after.
- `TestHandleTestConfig_ReusesStoredKey`: Test with empty key reuses the stored key (httptest endpoint, asserts `Bearer stored-key`). Fails before fix (`no API key provided`), passes after.

`go test -race ./internal/server/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)