### PR TITLE
fix: channel会话标题显示原始SessionKey

### DIFF
--- a/internal/channel/persist.go
+++ b/internal/channel/persist.go
@@ -63,7 +63,9 @@ func (s *Session) restoreOrInitStore(id string) {
 	st.Source = "channel"
 	st.BoundEntry = agent.EntryChannel
 	st.BoundAt = time.Now()
-	st.Title = string(s.Key)
+	// Leave Title empty so DisplayTitle() falls back to the first user message
+	// snippet (truncated to 60 chars) instead of showing the raw SessionKey
+	// (e.g. "weixin:o9cq…@im.wechat:o9cq…@im.wechat").
 	// Persist immediately so the entry binding is visible to other processes
 	// (and to the server's authoritative LoadSession in handleChannelMessage).
 	_ = st.Save()


### PR DESCRIPTION
## 问题
Channel会话的标题显示原始的SessionKey字符串，例如：
```
weixin:o9cq807MOxPwBofFldcjF4nh4dJI@im.wechat:o9cq807MOxPwBofFldcjF4nh4dJI@im.wechat
```

这个字符串太长且不可读，影响用户体验。

## 原因
在 `internal/channel/persist.go` 的 `restoreOrInitStore` 方法中，创建新会话时直接将会话标题设置为SessionKey：
```go
st.Title = string(s.Key)
```

## 修复
移除上述代码，让 `DisplayTitle()` 方法自动使用第一条用户消息的摘要作为标题（截断到60字符）。

## 测试
- 所有现有测试通过
- 新创建的channel会话会显示用户第一条消息的摘要
- 已有会话的标题不会自动改变（需要手动修改或创建新会话）

## 影响范围
- 仅影响新创建的channel会话的标题显示
- 不影响现有的会话数据
- 不影响Web UI、TUI等其他入口创建的会话