### PR TITLE
feat(config)!: use model string as the entry id, drop the name field

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -552,7 +552,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// History compaction runs on the configured lite model when one is set.
 	// A build failure (missing key, unknown provider) just leaves the primary
 	// in charge — never fail startup over the lite entry.
-	if liteEntry, ok := cfg.EntryByName(cfg.LiteModel); ok && liteEntry.Model != "" {
+	if liteEntry, ok := cfg.EntryByModel(cfg.LiteModel); ok && liteEntry.Model != "" {
 		if liteSender, lerr := buildSender(liteEntry.Provider, liteEntry, io.Discard, senderTuning{}); lerr == nil {
 			a.LiteSender = liteSender
 			a.LiteModel = liteEntry.Model

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -37,7 +37,7 @@ func firstNonEmpty(vals ...string) string {
 // the resolved provider has no known default model (i.e. an unknown provider
 // with no explicit model) — the caller prints an error and exits.
 func resolveProviderModel(flagProvider, flagModel string, cfg config.Config) (provider, model string, entry config.ModelEntry, ok bool) {
-	if e, found := cfg.EntryByName(flagModel); found {
+	if e, found := cfg.EntryByModel(flagModel); found {
 		provider = firstNonEmpty(e.Provider, app.ProviderAnthropic)
 		model = firstNonEmpty(e.Model, defaultModels[provider])
 		return provider, model, e, model != ""
@@ -163,7 +163,7 @@ func runConfigShow(stdout, stderr io.Writer) int {
 	fmt.Fprintln(stdout)
 	if len(cfg.Models) > 1 {
 		fmt.Fprintf(stdout, "  models:    %d configured, default %q (others: %s)\n",
-			len(cfg.Models), entry.Name, otherEntryNames(cfg, entry.Name))
+			len(cfg.Models), entry.Model, otherEntryModels(cfg, entry.Model))
 	}
 	fmt.Fprintf(stdout, "  provider:  %s (%s)\n", provider, provSrc)
 	fmt.Fprintf(stdout, "  model:     %s (%s)\n", model, modelSrc)
@@ -201,12 +201,12 @@ func runConfigShow(stdout, stderr io.Writer) int {
 	return 0
 }
 
-// otherEntryNames lists the configured entry names besides skip, for display.
-func otherEntryNames(cfg config.Config, skip string) string {
+// otherEntryModels lists the configured entry models besides skip, for display.
+func otherEntryModels(cfg config.Config, skip string) string {
 	names := make([]string, 0, len(cfg.Models))
 	for _, e := range cfg.Models {
-		if e.Name != skip {
-			names = append(names, e.Name)
+		if e.Model != skip {
+			names = append(names, e.Model)
 		}
 	}
 	return strings.Join(names, ", ")

--- a/cmd/octo/config_test.go
+++ b/cmd/octo/config_test.go
@@ -13,10 +13,7 @@ import (
 // oneEntryConfig builds a Config whose default entry has the given fields —
 // the multi-model equivalent of the old top-level provider/model literals.
 func oneEntryConfig(e config.ModelEntry) config.Config {
-	if e.Name == "" {
-		e.Name = "default"
-	}
-	return config.Config{Models: []config.ModelEntry{e}, DefaultModel: e.Name}
+	return config.Config{Models: []config.ModelEntry{e}, DefaultModel: e.Model}
 }
 
 func TestResolveBaseURL_Precedence(t *testing.T) {
@@ -118,13 +115,13 @@ func TestResolveProviderModel_EntryNameSelectsWholeEntry(t *testing.T) {
 	t.Setenv("OCTO_PROVIDER", "")
 	cfg := config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Name: "kimi", Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://kimi.example", APIKey: "sk-kimi"},
+			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			{Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://kimi.example", APIKey: "sk-kimi"},
 		},
-		DefaultModel: "main",
+		DefaultModel: "claude-sonnet-4-6",
 	}
 
-	prov, model, entry, ok := resolveProviderModel("", "kimi", cfg)
+	prov, model, entry, ok := resolveProviderModel("", "kimi-k2.6", cfg)
 	if !ok || prov != "kimi" || model != "kimi-k2.6" {
 		t.Fatalf("named entry: got (%q,%q,%v), want (kimi, kimi-k2.6, true)", prov, model, ok)
 	}
@@ -133,7 +130,7 @@ func TestResolveProviderModel_EntryNameSelectsWholeEntry(t *testing.T) {
 	}
 	// The entry wins over an explicit --provider — the combination is
 	// meaningless and the entry is what the user named.
-	if p, _, _, _ := resolveProviderModel("anthropic", "kimi", cfg); p != "kimi" {
+	if p, _, _, _ := resolveProviderModel("anthropic", "kimi-k2.6", cfg); p != "kimi" {
 		t.Errorf("entry name should override --provider, got %q", p)
 	}
 	// A non-matching --model value stays a raw model string on the default entry.
@@ -216,10 +213,10 @@ func TestRunConfig_Wizard_PreservesOtherEntriesAndGlobals(t *testing.T) {
 
 	seed := config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Name: "kimi", Provider: "kimi", Model: "kimi-k2.6"},
+			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			{Provider: "kimi", Model: "kimi-k2.6"},
 		},
-		DefaultModel:   "main",
+		DefaultModel:   "claude-sonnet-4-6",
 		PermissionMode: "strict",
 	}
 	if err := seed.Save(); err != nil {
@@ -241,7 +238,7 @@ func TestRunConfig_Wizard_PreservesOtherEntriesAndGlobals(t *testing.T) {
 	if len(got.Models) != 2 {
 		t.Fatalf("wizard must not drop other entries: %+v", got.Models)
 	}
-	if _, ok := got.EntryByName("kimi"); !ok {
+	if _, ok := got.EntryByModel("kimi-k2.6"); !ok {
 		t.Error("kimi entry lost")
 	}
 	if got.PermissionMode != "strict" {

--- a/dev-docs/multi-model-config-design.md
+++ b/dev-docs/multi-model-config-design.md
@@ -1,29 +1,21 @@
 # Multi-Model Configuration
 
-`~/.octo/config.yml` holds a list of named model configurations instead of a
-single provider/model pair. One entry is the default for new sessions; each
-web session can switch to a different entry without affecting others; an
-optional lite entry serves history compaction. The file is renamed from
-`config.yaml` to `config.yml`, matching `permissions.yml` and `channels.yml`.
-
-This makes the existing web settings panel real: `settings.js` already renders
-multiple model cards with add/remove/set-default actions (a contract inherited
-from the Ruby frontend), but the Go backend collapses everything onto the
-single top-level config — saving a second card silently overwrites the first,
-and `POST /api/config/models/{id}/default` is a no-op.
+`~/.octo/config.yml` holds a list of model configurations rather than a single
+provider/model pair. One entry is the default for new sessions; each web
+session can switch to a different entry without affecting others; an optional
+lite entry serves history compaction. The file sits alongside
+`permissions.yml` and `channels.yml`.
 
 ## Goals
 
-- Persist multiple named model configs, each with its own provider, base URL,
-  API key, and reasoning settings.
-- Make the settings panel's multi-card CRUD and set-default work against real
+- Persist multiple model configs, each with its own provider, base URL, API
+  key, and reasoning settings.
+- Drive the settings panel's multi-card CRUD and set-default against real
   storage.
 - Per-session model selection: `POST /api/sessions` can name a config entry;
   `PATCH /api/sessions/{id}/model` switches that session only, not the global
   default.
-- Give the lite model its first runtime consumer: compaction summarisation
-  runs on the lite entry when one is configured.
-- Rename the config file to `config.yml` with a transparent migration.
+- Run compaction summarisation on the lite entry when one is configured.
 
 ## Non-goals
 
@@ -32,7 +24,7 @@ and `POST /api/config/models/{id}/default` is a no-op.
   sender, unchanged.
 - **Failover / load balancing** between entries. One session, one model.
 - **IM / cron model selection.** Channel and cron sessions use the default
-  entry; per-session switching is a web-UI affordance this round.
+  entry; per-session switching is a web-UI affordance.
 - **Merging config files.** `mcp.json`, `permissions.yml`, `channels.yml`
   stay separate (different writers, different lifecycles).
 
@@ -41,21 +33,19 @@ and `POST /api/config/models/{id}/default` is a no-op.
 ```yaml
 # ~/.octo/config.yml
 models:
-  - name: main                 # unique handle; API id and CLI --model target
-    provider: anthropic
-    model: claude-fable-5
+  - provider: anthropic
+    model: claude-fable-5                 # the entry's identity
     base_url: https://api.anthropic.com   # optional; empty = vendor default
     api_key: sk-...                       # optional; env var preferred
-    reasoning_effort: high               # optional, per-model
+    reasoning_effort: high                # optional, per-model
     show_reasoning: true                  # optional, per-model
-  - name: kimi
-    provider: kimi
+  - provider: kimi
     model: kimi-k2.6
 
-default_model: main      # entry used when nothing else selects one
-lite_model: ""           # optional entry name for cheap internal calls
+default_model: claude-fable-5   # entry used when nothing else selects one
+lite_model: ""                  # optional model for cheap internal calls
 
-# global fields, semantics unchanged:
+# global fields:
 permission_mode: interactive
 access_key: ...
 coauthor: true
@@ -67,107 +57,94 @@ tools:
 
 Decisions:
 
-- **`name` is the identity.** Unique, user-visible, stable across edits; the
-  HTTP API uses it as `{id}` and the CLI accepts it for `--model`. The server
-  generates one from the model string on create when the panel doesn't supply
-  it (deduplicated with a numeric suffix).
-- **`reasoning_effort` / `show_reasoning` move per-entry.** A reasoning model
+- **The model string is the identity.** `model` is unique across entries; the
+  HTTP API uses it as `{id}`, `--model` selects the whole entry by it, and
+  `default_model` / `lite_model` reference it. There is no separate name, so
+  editing a model is a single edit — nothing else to keep in sync. Two entries
+  may not share a model string; a create request for a model that already
+  exists is rejected.
+- **`reasoning_effort` / `show_reasoning` are per-entry.** A reasoning model
   and a non-reasoning model need different settings; `app.SenderOptions`
-  already carries both per-sender (`internal/app/sender.go`). The legacy
-  top-level values migrate into the synthesized entry.
-- **`permission_mode` stays global.** The current `saveModelRequest` mixes it
-  into the model card; the backend keeps applying it globally and the panel
-  field keeps working unchanged.
-- **default/lite are references, not entry types.** The panel's
+  carries both per-sender (`internal/app/sender.go`). The `show_reasoning` key
+  also exists globally as the default when an entry leaves it unset.
+- **`permission_mode` is global.** `saveModelRequest` carries it on the model
+  card, but the backend applies it globally.
+- **default / lite are references, not entry types.** The panel's
   `type: "default" | "lite"` badges are derived by the server from
   `default_model` / `lite_model` when building `GET /api/config`; nothing is
   stored per entry.
 
-## File rename and migration
+## File resolution and legacy migration
 
-- `config.Path()` returns `~/.octo/config.yml`. `Load()` reads it; when it
-  does not exist, `Load()` falls back to legacy `~/.octo/config.yaml`.
-- A legacy file (top-level `provider`/`model`/`base_url`/`api_key`/
-  `reasoning_effort`/`show_reasoning`, no `models:` block) is normalised in
-  memory: those fields become `models[0]` with `name: default`, and
-  `default_model: default`. Global fields pass through.
-- `Save()` always writes the new schema to `config.yml`. When a legacy
-  `config.yaml` exists at that moment it is renamed to `config.yaml.bak` —
+- `config.Path()` returns `~/.octo/config.yml`. `Load()` reads it, falling back
+  to legacy `~/.octo/config.yaml` when the new file is absent.
+- A legacy file (top-level `provider` / `model` / `base_url` / `api_key` /
+  `reasoning_effort`, no `models:` block) is normalised in memory: those fields
+  become `models[0]` and `default_model` is set to that model string. Global
+  fields pass through.
+- `Save()` always writes the `models:` schema to `config.yml`. A legacy
+  `config.yaml` present at save time is renamed to `config.yaml.bak` —
   non-destructive, and it can never shadow the new file because `config.yml`
   wins the read order.
-- Help text and the `octo config` wizard messages switch to the new path
-  (`cmd/octo/help.go`, `cmd/octo/config.go`, `cmd/octo/chat.go`,
-  `cmd/octo/init.go`).
-
-`config.Config` keeps the legacy top-level fields as yaml-tagged members so
-old files unmarshal, but they are write-once-migration inputs; new saves emit
-only the `models:` schema. A `cfg.DefaultModel()` accessor returns the
-resolved default entry so the many existing `cfg.Model` / `cfg.Provider`
-readers (`internal/server/server.go`, `cmd/octo/chat.go`,
-`internal/server/onboard_config_handlers.go` onboarding detection) migrate
-mechanically.
+- A stale `name:` on an entry in an older `config.yml` is ignored on load
+  (unknown YAML field). A `default_model` / `lite_model` that referenced such a
+  name no longer matches; `DefaultEntry` then falls back to the first entry.
 
 ## Resolution precedence (CLI)
 
-`resolveProviderModel` (`cmd/octo/chat.go`) gains one rule, the rest is
-today's order:
+`resolveProviderModel` (`cmd/octo/config.go`):
 
-1. `--model <value>`: when the value equals a config entry **name**, the whole
+1. `--model <value>`: when the value equals a config entry's model, the whole
    entry applies — provider, model, base URL, API key, reasoning settings.
    Otherwise the value is a raw model string under the separately-resolved
-   provider, exactly as today.
-2. Env vars (`OCTO_PROVIDER`, `<PROVIDER>_MODEL`, key env vars) unchanged.
-3. Otherwise the `default_model` entry.
+   provider.
+2. Env vars (`OCTO_PROVIDER`, `<PROVIDER>_MODEL`, key env vars).
+3. Otherwise the `default_model` entry, else the first entry.
 
 ## Server: per-session sender binding
 
-Today `internal/server/server.go` builds one global sender at startup
-(`resolveProviderAndModel` → `app.NewSender`); `handleCreateSession`
-(`internal/server/handlers.go`) accepts a raw model string but it rides the
-global sender, and `handleUpdateSessionModel` rewrites the global config while
-the UI presents it as per-session.
-
-Design:
-
-- `agent.Session` (`internal/agent/session.go`) gains
-  `ModelConfig string \`json:"model_config,omitempty"\`` — the config entry
-  name the session is bound to. Empty means "the default entry at turn time",
-  which is also the value for every pre-existing session on disk.
-- The server keeps a `senderCache map[string]agent.Sender` keyed by entry
-  name, built lazily via `app.NewSender` from the entry's fields. Any mutation
-  through `/api/config/models*` invalidates the whole cache; the next turn
-  rebuilds. The cache replaces the single `s.sender`/`s.model` pair as the
-  source for turn execution; the startup-time resolution remains only as the
-  onboarding-mode probe (no key → onboarding, unchanged).
-- The turn path resolves session → entry name → (sender, model string,
-  reasoning options) at the start of each turn, so a switch mid-session
-  applies from the next turn.
-- `PATCH /api/sessions/{id}/model`: `model_id` is an entry name; the handler
-  sets `session.ModelConfig` and persists the session. No global config write.
-  Unknown name → 400 listing valid names.
+- `agent.Session` (`internal/agent/session.go`) carries
+  `ModelConfig string \`json:"model_config,omitempty"\`` — the model string of
+  the config entry the session is bound to. Empty means "the default entry at
+  turn time", which is also the value for every session predating per-session
+  binding.
+- The server keeps a `senderCache map[string]agent.Sender` keyed by model,
+  built lazily via `app.NewSender` from the entry's fields. Any mutation through
+  `/api/config/models*` invalidates the cache; the next turn rebuilds. The
+  server's default `sender`/`model` pair serves unbound sessions and is rebuilt
+  from config on relevant changes; startup resolution doubles as the
+  onboarding-mode probe (no key → onboarding).
+- The turn path resolves session → entry (by model) → (sender, model string,
+  reasoning options) at the start of each turn, so a switch applies from the
+  next turn. A binding whose model no longer exists degrades to the default
+  sender rather than failing the turn.
+- `PATCH /api/sessions/{id}/model`: `model_id` naming a config entry binds the
+  session to it; any other value stays a raw model string on the default
+  sender. No global config write.
 - `POST /api/sessions`: `req.Model` naming a config entry binds the session to
-  it; a non-matching value keeps today's raw-model-string behaviour on the
-  default entry's provider.
+  it; a non-matching value keeps raw-model-string behaviour on the default
+  sender.
 
 ## Config CRUD API
 
-All five routes exist (`internal/server/server.go:406-409`); the handlers in
-`internal/server/onboard_config_handlers.go` become real:
+Handlers live in `internal/server/onboard_config_handlers.go`.
 
 | Route | Behaviour |
 |---|---|
-| `GET /api/config` | Full `models` list (id = name, keys masked via `maskKey`), real `default_model_idx`, `type` derived from `default_model`/`lite_model`. |
-| `POST /api/config/models` | Append a new entry; generate a unique name when absent; returns the id. |
-| `PATCH /api/config/models/{id}` | Update the named entry. Empty `api_key` in the request keeps the stored key (the panel echoes masked keys). |
-| `DELETE /api/config/models/{id}` | Remove the entry. Deleting the default reassigns `default_model` to the first remaining entry; deleting the lite entry clears `lite_model`. Sessions bound to the deleted name fall back to default on their next turn. |
-| `POST /api/config/models/{id}/default` | Set `default_model`. |
-| `POST /api/config/models/{id}/lite` | New: set (or clear, with empty id semantics via `DELETE`-style toggle) `lite_model`. |
+| `GET /api/config` | Full `models` list (`id` = model, keys masked via `maskKey`), `default_model_idx`, `type` derived from `default_model` / `lite_model`. |
+| `POST /api/config/models` | Append a new entry. A model that already exists is a `409` conflict. The first entry becomes the default. Returns the id (the model). |
+| `PATCH /api/config/models/{id}` | Update the entry with model `{id}`. An empty or masked `api_key` keeps the stored key (the panel echoes masked keys). Changing the model re-keys the entry — the id changes with it, a collision with another entry is a `409`, and `default_model` / `lite_model` references carry over. |
+| `DELETE /api/config/models/{id}` | Remove the entry. Deleting the default reassigns `default_model` to the first remaining entry; deleting the lite entry clears `lite_model`. Sessions bound to the deleted model fall back to the default sender on their next turn. |
+| `POST /api/config/models/{id}/default` | Set `default_model` to `{id}`. |
+| `POST /api/config/models/{id}/lite` | Toggle `lite_model`: set it to `{id}`, or clear it when it already points there. |
 
-`POST /api/config/test` is already entry-shaped and stays as is.
+`POST /api/config/test` validates a provider/base-URL/model/key combination
+against the live endpoint. An empty or masked key reuses the stored key of the
+matching entry, so testing an edited entry needs no re-typed key.
 
 ## Lite model → compaction
 
-`Agent` (`internal/agent/agent.go`) gains an optional pair set together:
+`Agent` (`internal/agent/agent.go`) carries an optional pair set together:
 
 ```go
 // LiteSender/LiteModel, when both set, run history summarisation on a
@@ -177,78 +154,64 @@ LiteModel  string
 ```
 
 `summarize` (`internal/agent/compaction.go`) sends on the lite pair when
-present — including its head-popping overflow protection, which must then size
-against `contextWindow(LiteModel)`, and the streaming path, which
-type-asserts the lite sender. On a lite-call error it retries once on the
-primary sender before giving up — a misconfigured lite entry must not break compaction, whose
-failure already aborts the turn's compact pass. Both `maybeCompact` and the
-overflow compact path go through `summarize`, so one change covers both;
-micro-compaction is string-level and unaffected.
+present — including its head-popping overflow protection, sized against
+`contextWindow(LiteModel)`, and the streaming path, which type-asserts the lite
+sender. On a lite-call error it retries once on the primary sender before giving
+up, so a misconfigured lite entry does not break compaction. Both `maybeCompact`
+and the overflow compact path go through `summarize`; micro-compaction is
+string-level and unaffected.
 
-Wiring: each transport that constructs an `Agent` resolves `lite_model` to an
-entry, builds its sender through the same cache/`app.NewSender` path, and sets
-the pair.
+Each transport that constructs an `Agent` resolves `lite_model` to an entry,
+builds its sender through the same cache / `app.NewSender` path, and sets the
+pair.
 
-**Implicit lite.** When no `lite_model` entry is configured, the vendor's
-registry `LiteModel` (e.g. deepseek → `deepseek-v4-flash`,
-anthropic → `claude-haiku-4-5`) serves as the lite model, riding the
-session's **own sender** — same endpoint, key, and prompt-cache routing, so
-no extra credentials and, where the backend caches by shared prefix, the
-summarisation call can hit the cache the conversation already built.
+**Implicit lite.** With no `lite_model` configured, the vendor's registry
+`LiteModel` (e.g. deepseek → `deepseek-v4-flash`, anthropic →
+`claude-haiku-4-5`) serves as the lite model, riding the session's **own
+sender** — same endpoint, key, and prompt-cache routing, so no extra
+credentials and, where the backend caches by shared prefix, the summarisation
+call can reuse the cache the conversation already built.
 `app.ImplicitLiteModel(provider, model, baseURL)` resolves it and returns
-nothing when the vendor is unknown or has no `LiteModel`, when the primary
-model already is the lite model, or when the base URL points off the
-vendor's own endpoints — a custom endpoint is a different backend wearing a
-compatible protocol, and its catalogue won't include the vendor's lite
-model (the primary-sender retry would catch the failure, but there's no
-point sending a doomed call). An explicitly configured `lite_model` entry
-always wins. For a session bound to a config entry, the implicit lookup
-uses that entry's vendor and endpoint.
+nothing when the vendor is unknown or has no `LiteModel`, when the primary model
+already is the lite model, or when the base URL points off the vendor's own
+endpoints (a custom endpoint is a different backend behind a compatible
+protocol; its catalogue won't include the vendor's lite model). An explicit
+`lite_model` entry always wins. For a session bound to a config entry, the
+implicit lookup uses that entry's vendor and endpoint.
 
 ## Frontend
 
-`internal/server/static/settings.js` already implements the multi-card panel
-(add, remove, per-card test, set-default, default/lite badges) against this
-exact API shape, so it needs only:
-
-- id-based addressing for PATCH/DELETE/set-default (it currently indexes by
-  position; ids arrive in `GET /api/config`),
-- a set-as-lite action symmetric to the existing set-default button,
-- the session info bar's model picker listing entries from `GET /api/config`
-  and sending the entry name to `PATCH /api/sessions/{id}/model`.
+The settings panel (`web/src/views/SettingsView.svelte`,
+`web/src/components/settings/ModelConfigForm.svelte`) renders one card per
+entry with add, remove, per-card test-connection, set-default, and set-lite
+actions, and default/lite badges. It addresses entries by the `id` returned in
+`GET /api/config` (the model string) for PATCH / DELETE / set-default / set-lite.
+The form has no name field: provider, model, base URL, and key are the only
+inputs, and the key is never prefilled (the masked value shows as a
+placeholder). The session info bar's model picker lists entries from
+`GET /api/config` and sends the model to `PATCH /api/sessions/{id}/model`.
 
 ## Compatibility
 
-- **Old `config.yaml` files** load unchanged (legacy fallback + in-memory
-  normalisation); the first save migrates to `config.yml` and parks the old
-  file as `config.yaml.bak`.
-- **Old session JSON** has no `model_config`; empty means default entry —
-  exactly the previous behaviour.
-- **API shapes are unchanged** — the frontend contract was multi-model all
-  along; only the backend semantics catch up. The one addition is the
-  `/lite` route.
-- **IM bridge, cron, headless `octo chat`** resolve through the default entry
-  with no behavioural change until the user adds entries.
-
-## Implementation split
-
-Three PRs, each independently shippable:
-
-1. **Config schema + rename + CRUD** — `internal/config`, migration,
-   `onboard_config_handlers.go`, settings panel id-addressing. After this the
-   panel stores multiple entries and set-default works; sessions still all use
-   the default entry.
-2. **Per-session binding** — session field, sender cache, create/switch
-   handlers, session info bar picker.
-3. **Lite compaction** — agent fields, `summarize` fallback, `/lite` route and
-   panel action, transport wiring.
+- **Old `config.yaml` files** load through the legacy fallback and in-memory
+  normalisation; the first save migrates to `config.yml` and parks the old file
+  as `config.yaml.bak`.
+- **Old `config.yml` with `name:` entries** load fine — the field is ignored.
+  A single-model config keeps working unchanged; a multi-model config whose
+  `default_model` / `lite_model` used custom names should repoint them at the
+  model strings.
+- **Old session JSON** has no `model_config`; empty means the default entry.
+- **IM bridge, cron, headless one-shot** resolve through the default entry with
+  no behavioural change until the user adds entries.
 
 ## Testing
 
-- `internal/config`: legacy-yaml → yml migration (load, save, `.bak` rename),
-  name uniqueness, default/lite reference repair on delete.
-- `internal/server`: CRUD handler tests against a temp home; per-session
+- `internal/config`: legacy-yaml → yml migration (load, save, `.bak` rename);
+  `EntryByModel` / `DefaultEntry` / `SetDefaultEntry` keyed by model, including
+  a floating default (empty model); default/lite reference repair on delete.
+- `internal/server`: CRUD against a temp home; duplicate-model rejection;
+  model-change re-keys the entry and repairs the default reference; per-session
   switch persists `model_config` and leaves global config untouched; create
-  with entry name vs raw model string.
-- `internal/agent`: compaction uses the lite sender when set, falls back to
+  with an entry model vs a raw model string.
+- `internal/agent`: compaction uses the lite sender when set and falls back to
   the primary on lite error (fake senders, no network — per `.octorules`).

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -32,9 +32,11 @@ type Session struct {
 	System    string    `json:"system,omitempty"`
 	Title     string    `json:"title,omitempty"`
 	Source    string    `json:"source,omitempty"` // how the session was created: "" (manual) | "cron" | "channel" | "setup"
-	// ModelConfig names the user-config model entry this session is bound to.
-	// Empty means "the default entry at turn time" — also the value for every
-	// session predating per-session model binding.
+	// ModelConfig is the model string of the config entry this session is bound
+	// to. Empty means "the default entry at turn time" — also the value for
+	// every session predating per-session model binding. (Sessions written
+	// before models were keyed by model may carry a legacy entry name here; it
+	// simply fails to match and falls back to the default sender.)
 	ModelConfig string    `json:"model_config,omitempty"`
 	Messages    []Message `json:"messages"`
 
@@ -518,12 +520,12 @@ func (s *Session) SetTitle(title string) error {
 	return nil
 }
 
-// SetModelConfig binds the session to a named config entry (empty name =
-// the default entry) and records the entry's model string so the session
-// displays and resumes on the right model. Like SetTitle, it appends a
-// record when the transcript is already on disk so the binding survives
-// without rewriting the file; a switch to the values already in place is a
-// no-op.
+// SetModelConfig binds the session to a config entry, identified by its model
+// string (empty = the default entry at turn time), and records that model so
+// the session displays and resumes on the right model. Like SetTitle, it
+// appends a record when the transcript is already on disk so the binding
+// survives without rewriting the file; a switch to the values already in place
+// is a no-op.
 func (s *Session) SetModelConfig(name, model string) error {
 	if name == s.ModelConfig && (model == "" || model == s.Model) {
 		return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -27,11 +26,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// ModelEntry is one named model configuration: everything needed to build a
-// sender for it. Name is the entry's identity — the HTTP API uses it as the
-// id and `--model <name>` selects the whole entry.
+// ModelEntry is one model configuration: everything needed to build a sender
+// for it. Model is the entry's identity — the HTTP API uses it as the id,
+// `--model <model>` selects the whole entry, and default_model / lite_model
+// reference it. Two entries may not share a model string.
 type ModelEntry struct {
-	Name     string `yaml:"name"`
 	Provider string `yaml:"provider,omitempty"`
 	Model    string `yaml:"model,omitempty"`
 	// BaseURL is an optional endpoint override; empty uses the vendor default.
@@ -132,21 +131,21 @@ func (c Config) EffectiveShowReasoning(entry *bool) bool {
 	return true
 }
 
-// ModelVision reports whether the named model accepts image content. name is
-// matched against each entry's Name or Model; an entry's explicit Vision wins,
+// ModelVision reports whether the named model accepts image content. model is
+// matched against each entry's Model; an entry's explicit Vision wins,
 // otherwise the capability is inferred from the model id (ModelSupportsVision)
-// so it tracks the model automatically. Unmatched names fall back to the same
+// so it tracks the model automatically. Unmatched models fall back to the same
 // inference.
-func (c Config) ModelVision(name string) bool {
+func (c Config) ModelVision(model string) bool {
 	for _, m := range c.Models {
-		if m.Name == name || m.Model == name {
+		if m.Model == model {
 			if m.Vision != nil {
 				return *m.Vision
 			}
 			return ModelSupportsVision(m.Model)
 		}
 	}
-	return ModelSupportsVision(name)
+	return ModelSupportsVision(model)
 }
 
 // ModelSupportsVision is a best-effort guess at whether a model id accepts
@@ -194,10 +193,10 @@ type ToolSearchConfig struct {
 	MaxSearchLimit int `yaml:"max_search_limit,omitempty"`
 }
 
-// DefaultEntry returns the entry named by DefaultModel, falling back to the
-// first entry, or a zero ModelEntry when none are configured.
+// DefaultEntry returns the entry whose model matches DefaultModel, falling
+// back to the first entry, or a zero ModelEntry when none are configured.
 func (c Config) DefaultEntry() ModelEntry {
-	if e, ok := c.EntryByName(c.DefaultModel); ok {
+	if e, ok := c.EntryByModel(c.DefaultModel); ok {
 		return e
 	}
 	if len(c.Models) > 0 {
@@ -206,61 +205,48 @@ func (c Config) DefaultEntry() ModelEntry {
 	return ModelEntry{}
 }
 
-// EntryByName returns the entry with the given name. An empty name never
-// matches.
-func (c Config) EntryByName(name string) (ModelEntry, bool) {
-	if name == "" {
+// EntryByModel returns the entry with the given model string. An empty model
+// never matches.
+func (c Config) EntryByModel(model string) (ModelEntry, bool) {
+	if model == "" {
 		return ModelEntry{}, false
 	}
 	for _, e := range c.Models {
-		if e.Name == name {
+		if e.Model == model {
 			return e, true
 		}
 	}
 	return ModelEntry{}, false
 }
 
-// SetDefaultEntry replaces the default entry in place (matching by its
-// current name), or appends it when no entry exists yet, and points
-// DefaultModel at it. Writers that previously mutated the top-level
-// provider/model fields go through this.
+// SetDefaultEntry replaces the current default entry in place, or appends it
+// when no entry exists yet, and points DefaultModel at it. The default entry is
+// located the same way DefaultEntry resolves it — by DefaultModel, else the
+// first entry — so it works even when that entry's model is empty (a floating
+// default). Writers that previously mutated the top-level provider/model fields
+// go through this.
 func (c *Config) SetDefaultEntry(e ModelEntry) {
-	if e.Name == "" {
-		e.Name = "default"
-	}
-	cur := c.DefaultEntry()
+	idx := -1
 	for i := range c.Models {
-		if c.Models[i].Name == cur.Name && cur.Name != "" {
-			// Renaming the default entry keeps references consistent.
-			if c.LiteModel == cur.Name {
-				c.LiteModel = e.Name
-			}
-			c.Models[i] = e
-			c.DefaultModel = e.Name
-			return
+		if c.DefaultModel != "" && c.Models[i].Model == c.DefaultModel {
+			idx = i
+			break
 		}
 	}
-	c.Models = append(c.Models, e)
-	c.DefaultModel = e.Name
-}
-
-// UniqueName derives an entry name from base (typically the model string)
-// that does not collide with any existing entry, appending -2, -3, … as
-// needed.
-func (c Config) UniqueName(base string) string {
-	base = strings.TrimSpace(base)
-	if base == "" {
-		base = "model"
+	if idx == -1 && len(c.Models) > 0 {
+		idx = 0 // DefaultEntry falls back to the first entry
 	}
-	if _, ok := c.EntryByName(base); !ok {
-		return base
+	if idx < 0 {
+		c.Models = append(c.Models, e)
+		c.DefaultModel = e.Model
+		return
 	}
-	for i := 2; ; i++ {
-		candidate := fmt.Sprintf("%s-%d", base, i)
-		if _, ok := c.EntryByName(candidate); !ok {
-			return candidate
-		}
+	// Changing the default entry's model keeps the lite reference consistent.
+	if c.LiteModel != "" && c.LiteModel == c.Models[idx].Model {
+		c.LiteModel = e.Model
 	}
+	c.Models[idx] = e
+	c.DefaultModel = e.Model
 }
 
 // Path returns the absolute path to the config file (~/.octo/config.yml).
@@ -310,7 +296,6 @@ func (f fileConfig) normalize() Config {
 		return c
 	}
 	c.Models = []ModelEntry{{
-		Name:            "default",
 		Provider:        f.LegacyProvider,
 		Model:           f.LegacyModel,
 		BaseURL:         f.LegacyBaseURL,
@@ -318,7 +303,7 @@ func (f fileConfig) normalize() Config {
 		ReasoningEffort: f.LegacyReasoningEffort,
 		ShowReasoning:   c.ShowReasoning,
 	}}
-	c.DefaultModel = "default"
+	c.DefaultModel = f.LegacyModel
 	return c
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,11 +45,11 @@ func TestSaveLoad_RoundTrip(t *testing.T) {
 
 	want := Config{
 		Models: []ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "claude-fable-5"},
-			{Name: "kimi", Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://x.example"},
+			{Provider: "anthropic", Model: "claude-fable-5"},
+			{Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://x.example"},
 		},
-		DefaultModel: "kimi",
-		LiteModel:    "main",
+		DefaultModel: "kimi-k2.6",
+		LiteModel:    "claude-fable-5",
 	}
 	if err := want.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -62,10 +62,10 @@ func TestSaveLoad_RoundTrip(t *testing.T) {
 	if len(got.Models) != 2 || got.Models[1] != want.Models[1] {
 		t.Errorf("round-trip models = %+v, want %+v", got.Models, want.Models)
 	}
-	if got.DefaultModel != "kimi" || got.LiteModel != "main" {
+	if got.DefaultModel != "kimi-k2.6" || got.LiteModel != "claude-fable-5" {
 		t.Errorf("round-trip refs = default %q lite %q", got.DefaultModel, got.LiteModel)
 	}
-	if e := got.DefaultEntry(); e.Name != "kimi" || e.BaseURL != "https://x.example" {
+	if e := got.DefaultEntry(); e.Model != "kimi-k2.6" || e.BaseURL != "https://x.example" {
 		t.Errorf("DefaultEntry = %+v, want kimi entry", e)
 	}
 }
@@ -83,12 +83,12 @@ func TestLoad_LegacyYAMLIsNormalised(t *testing.T) {
 		t.Fatalf("Models = %+v, want one synthesized entry", c.Models)
 	}
 	e := c.Models[0]
-	if e.Name != "default" || e.Provider != "openai" || e.Model != "gpt-4o-mini" ||
+	if e.Provider != "openai" || e.Model != "gpt-4o-mini" ||
 		e.BaseURL != "https://x.example" || e.APIKey != "sk-old" || e.ReasoningEffort != "high" {
 		t.Errorf("synthesized entry = %+v", e)
 	}
-	if c.DefaultModel != "default" {
-		t.Errorf("DefaultModel = %q, want default", c.DefaultModel)
+	if c.DefaultModel != "gpt-4o-mini" {
+		t.Errorf("DefaultModel = %q, want gpt-4o-mini", c.DefaultModel)
 	}
 	if c.PermissionMode != "strict" {
 		t.Errorf("global PermissionMode lost: %q", c.PermissionMode)
@@ -99,7 +99,7 @@ func TestLoad_NewFileShadowsLegacy(t *testing.T) {
 	home := setHome(t)
 	writeOcto(t, home, "config.yaml", "model: old-model\nprovider: openai\n")
 	writeOcto(t, home, "config.yml",
-		"models:\n  - name: main\n    provider: anthropic\n    model: new-model\ndefault_model: main\n")
+		"models:\n  - provider: anthropic\n    model: new-model\ndefault_model: new-model\n")
 
 	c, err := Load()
 	if err != nil {
@@ -146,7 +146,7 @@ func TestSave_FileMode0600(t *testing.T) {
 	}
 	home := setHome(t)
 
-	cfg := Config{Models: []ModelEntry{{Name: "main", APIKey: "sk-secret"}}}
+	cfg := Config{Models: []ModelEntry{{Model: "main", APIKey: "sk-secret"}}}
 	if err := cfg.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -172,67 +172,46 @@ func TestSetDefaultEntry(t *testing.T) {
 	var c Config
 
 	// Appends when empty.
-	c.SetDefaultEntry(ModelEntry{Name: "main", Model: "m1"})
-	if len(c.Models) != 1 || c.DefaultModel != "main" {
+	c.SetDefaultEntry(ModelEntry{Model: "m1"})
+	if len(c.Models) != 1 || c.DefaultModel != "m1" {
 		t.Fatalf("after first set: %+v", c)
 	}
 
-	// Replaces in place, including a rename, and keeps the lite reference.
-	c.LiteModel = "main"
-	c.SetDefaultEntry(ModelEntry{Name: "primary", Model: "m2"})
-	if len(c.Models) != 1 || c.Models[0].Name != "primary" || c.Models[0].Model != "m2" {
-		t.Fatalf("after rename: %+v", c.Models)
+	// Replaces the default in place when its model changes, carrying the lite
+	// reference over to the new model.
+	c.LiteModel = "m1"
+	c.SetDefaultEntry(ModelEntry{Model: "m2"})
+	if len(c.Models) != 1 || c.Models[0].Model != "m2" {
+		t.Fatalf("after model change: %+v", c.Models)
 	}
-	if c.DefaultModel != "primary" || c.LiteModel != "primary" {
+	if c.DefaultModel != "m2" || c.LiteModel != "m2" {
 		t.Errorf("references not updated: default %q lite %q", c.DefaultModel, c.LiteModel)
 	}
-
-	// Names an unnamed entry "default".
-	var c2 Config
-	c2.SetDefaultEntry(ModelEntry{Model: "m3"})
-	if c2.Models[0].Name != "default" || c2.DefaultModel != "default" {
-		t.Errorf("unnamed entry: %+v", c2)
-	}
 }
 
-func TestUniqueName(t *testing.T) {
-	c := Config{Models: []ModelEntry{{Name: "kimi-k2.6"}, {Name: "kimi-k2.6-2"}}}
-	if got := c.UniqueName("kimi-k2.6"); got != "kimi-k2.6-3" {
-		t.Errorf("UniqueName = %q, want kimi-k2.6-3", got)
-	}
-	if got := c.UniqueName("fresh"); got != "fresh" {
-		t.Errorf("UniqueName = %q, want fresh", got)
-	}
-	if got := c.UniqueName(" "); got != "model" {
-		t.Errorf("UniqueName(blank) = %q, want model", got)
-	}
-}
-
-func TestEntryByName_EmptyNeverMatches(t *testing.T) {
-	c := Config{Models: []ModelEntry{{Name: "", Model: "m"}}}
-	if _, ok := c.EntryByName(""); ok {
-		t.Error("EntryByName(\"\") matched, want no match")
+func TestEntryByModel_EmptyNeverMatches(t *testing.T) {
+	c := Config{Models: []ModelEntry{{Model: "m"}}}
+	if _, ok := c.EntryByModel(""); ok {
+		t.Error("EntryByModel(\"\") matched, want no match")
 	}
 }
 
 func TestModelVision(t *testing.T) {
 	yes, no := true, false
 	c := Config{Models: []ModelEntry{
-		{Name: "vl", Model: "qwen-vl-max", Vision: &yes},
-		{Name: "txt", Model: "qwen3.7-max", Vision: &no},
-		{Name: "unset", Model: "claude"},
+		{Model: "qwen-vl-max", Vision: &yes},
+		{Model: "qwen3.7-max", Vision: &no},
+		{Model: "claude"},
 	}}
 	cases := map[string]bool{
-		"vl":          true,  // explicit true (by Name)
-		"qwen-vl-max": true,  // explicit true (by Model id)
-		"txt":         false, // explicit false (by Name)
-		"qwen3.7-max": false, // explicit false (by Model id)
-		"unset":       true,  // no flag → default true
+		"qwen-vl-max": true,  // explicit true (by model)
+		"qwen3.7-max": false, // explicit false (by model)
+		"claude":      true,  // no flag → heuristic (claude → true)
 		"not-in-list": true,  // unknown → default true
 	}
-	for name, want := range cases {
-		if got := c.ModelVision(name); got != want {
-			t.Errorf("ModelVision(%q) = %v, want %v", name, got, want)
+	for model, want := range cases {
+		if got := c.ModelVision(model); got != want {
+			t.Errorf("ModelVision(%q) = %v, want %v", model, got, want)
 		}
 	}
 }
@@ -261,17 +240,17 @@ func TestModelSupportsVision(t *testing.T) {
 func TestModelVision_HeuristicFallback(t *testing.T) {
 	no := false
 	c := Config{Models: []ModelEntry{
-		{Name: "qwen3.7-max", Model: "qwen3.7-plus"},        // no override → heuristic(false)
-		{Name: "vl", Model: "qwen-vl-max"},                  // no override → heuristic(true)
-		{Name: "forced", Model: "qwen-vl-max", Vision: &no}, // override beats heuristic
+		{Model: "qwen3.7-plus"},        // no override → heuristic(false)
+		{Model: "qwen-vl-max"},         // no override → heuristic(true)
+		{Model: "gpt-4o", Vision: &no}, // override beats heuristic (gpt-4o infers true)
 	}}
-	if c.ModelVision("qwen3.7-max") != false {
+	if c.ModelVision("qwen3.7-plus") != false {
 		t.Error("qwen3.7-plus entry should infer vision=false")
 	}
-	if c.ModelVision("vl") != true {
+	if c.ModelVision("qwen-vl-max") != true {
 		t.Error("qwen-vl-max entry should infer vision=true")
 	}
-	if c.ModelVision("forced") != false {
+	if c.ModelVision("gpt-4o") != false {
 		t.Error("explicit Vision override should win over heuristic")
 	}
 }

--- a/internal/server/browser_vision_test.go
+++ b/internal/server/browser_vision_test.go
@@ -17,10 +17,10 @@ func TestPrepareToolTurn_WiresBrowserVision(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
 		Models: []config.ModelEntry{
-			{Name: "txt", Provider: "openai", Model: "qwen3.7-max"}, // heuristic → no vision
-			{Name: "vis", Provider: "openai", Model: "gpt-4o"},      // heuristic → vision
+			{Provider: "openai", Model: "qwen3.7-max"}, // heuristic → no vision
+			{Provider: "openai", Model: "gpt-4o"},      // heuristic → vision
 		},
-		DefaultModel: "txt",
+		DefaultModel: "qwen3.7-max",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -340,8 +340,8 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 		// entry so its turns run on the entry's sender. A non-matching value
 		// stays a raw model string on the default sender.
 		if cfg, err := config.Load(); err == nil {
-			if e, ok := cfg.EntryByName(req.Model); ok {
-				modelConfig = e.Name
+			if e, ok := cfg.EntryByModel(req.Model); ok {
+				modelConfig = e.Model
 				if e.Model != "" {
 					model = e.Model
 				}
@@ -1039,9 +1039,9 @@ func (s *Server) handleUpdateSessionModel(w http.ResponseWriter, r *http.Request
 
 	cfg, _ := config.Load()
 	var model string
-	if entry, ok := cfg.EntryByName(req.ModelID); ok {
+	if entry, ok := cfg.EntryByModel(req.ModelID); ok {
 		model = entry.Model
-		err = sess.SetModelConfig(entry.Name, entry.Model)
+		err = sess.SetModelConfig(entry.Model, entry.Model)
 	} else if req.ModelID == "default" {
 		// Legacy id for "the default entry". Unbind so the session follows
 		// whatever the default is at turn time.

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -155,11 +155,11 @@ type modelConfig struct {
 	ShowReasoning   *bool  `json:"show_reasoning,omitempty"`
 }
 
-// defaultEntryIdx returns the index of the default entry: the one named by
-// DefaultModel, else 0.
+// defaultEntryIdx returns the index of the default entry: the one whose model
+// matches DefaultModel, else 0.
 func defaultEntryIdx(cfg config.Config) int {
 	for i, e := range cfg.Models {
-		if e.Name == cfg.DefaultModel {
+		if e.Model == cfg.DefaultModel {
 			return i
 		}
 	}
@@ -174,7 +174,7 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 
 	for i, e := range cfg.Models {
 		m := modelConfig{
-			ID:              e.Name,
+			ID:              e.Model,
 			Model:           e.Model,
 			BaseURL:         e.BaseURL,
 			APIKeyMasked:    maskKey(e.APIKey),
@@ -187,7 +187,7 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 		case i == defaultIdx:
 			m.Type = "default"
 			m.PermissionMode = cfg.PermissionMode
-		case e.Name == cfg.LiteModel:
+		case e.Model == cfg.LiteModel:
 			m.Type = "lite"
 		}
 		models = append(models, m)
@@ -400,11 +400,15 @@ func (s *Server) handleSaveModelConfig(w http.ResponseWriter, r *http.Request) {
 
 	var entry config.ModelEntry
 	applyModelRequestToEntry(req, &entry)
-	entry.Name = cfg.UniqueName(req.Model)
+	// Model is the entry's identity, so it must be unique.
+	if _, exists := cfg.EntryByModel(entry.Model); exists {
+		writeError(w, http.StatusConflict, fmt.Sprintf("a model entry for %q already exists", entry.Model))
+		return
+	}
 	cfg.Models = append(cfg.Models, entry)
 	becameDefault := false
 	if cfg.DefaultModel == "" || len(cfg.Models) == 1 {
-		cfg.DefaultModel = entry.Name
+		cfg.DefaultModel = entry.Model
 		becameDefault = true
 	}
 	if req.PermissionMode != "" {
@@ -423,7 +427,7 @@ func (s *Server) handleSaveModelConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	s.invalidateSenderCache()
 
-	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": entry.Name})
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": entry.Model})
 }
 
 // handleUpdateModelConfig updates the entry named by {id}.
@@ -449,20 +453,24 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 	updated := false
 	newID := id
 	for i := range cfg.Models {
-		if cfg.Models[i].Name == id {
-			oldName, oldModel := cfg.Models[i].Name, cfg.Models[i].Model
+		if cfg.Models[i].Model == id {
 			applyModelRequestToEntry(req, &cfg.Models[i])
-			// If the name was auto-derived from the model (name == model), keep it
-			// tracking when the model changes, and repair the default/lite refs
-			// that pointed at the old name. A name the user set by hand stays put.
-			if oldName == oldModel && cfg.Models[i].Model != oldModel {
-				newID = cfg.UniqueName(cfg.Models[i].Model)
-				cfg.Models[i].Name = newID
-				if cfg.DefaultModel == oldName {
-					cfg.DefaultModel = newID
+			// Model is the entry id. When it changes, the id changes with it, so
+			// reject a collision with another entry and carry the default/lite
+			// refs that pointed at the old model over to the new one.
+			if newModel := cfg.Models[i].Model; newModel != id {
+				for j := range cfg.Models {
+					if j != i && cfg.Models[j].Model == newModel {
+						writeError(w, http.StatusConflict, fmt.Sprintf("a model entry for %q already exists", newModel))
+						return
+					}
 				}
-				if cfg.LiteModel == oldName {
-					cfg.LiteModel = newID
+				newID = newModel
+				if cfg.DefaultModel == id {
+					cfg.DefaultModel = newModel
+				}
+				if cfg.LiteModel == id {
+					cfg.LiteModel = newModel
 				}
 			}
 			updated = true
@@ -470,7 +478,7 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		}
 	}
 	if !updated {
-		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config named %q", id))
+		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config for %q", id))
 		return
 	}
 	if req.PermissionMode != "" {
@@ -483,8 +491,8 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 	}
 	s.invalidateSenderCache()
 
-	// id may have changed if the auto-derived name tracked a new model — return
-	// it so the client can refresh its reference.
+	// id may have changed if the model changed — return it so the client can
+	// refresh its reference.
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": newID})
 }
 
@@ -506,21 +514,21 @@ func (s *Server) handleDeleteModelConfig(w http.ResponseWriter, r *http.Request)
 	kept := cfg.Models[:0]
 	removed := false
 	for _, e := range cfg.Models {
-		if e.Name == id {
+		if e.Model == id {
 			removed = true
 			continue
 		}
 		kept = append(kept, e)
 	}
 	if !removed {
-		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config named %q", id))
+		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config for %q", id))
 		return
 	}
 	cfg.Models = kept
 	if cfg.DefaultModel == id {
 		cfg.DefaultModel = ""
 		if len(cfg.Models) > 0 {
-			cfg.DefaultModel = cfg.Models[0].Name
+			cfg.DefaultModel = cfg.Models[0].Model
 		}
 	}
 	if cfg.LiteModel == id {
@@ -551,7 +559,7 @@ func (s *Server) handleSetLiteModelConfig(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
 		return
 	}
-	if _, ok := cfg.EntryByName(id); !ok {
+	if _, ok := cfg.EntryByModel(id); !ok {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config named %q", id))
 		return
 	}
@@ -583,7 +591,7 @@ func (s *Server) handleSetDefaultModelConfig(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
 		return
 	}
-	if _, ok := cfg.EntryByName(id); !ok {
+	if _, ok := cfg.EntryByModel(id); !ok {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("no model config named %q", id))
 		return
 	}

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -43,12 +42,12 @@ func TestConfigModels_GetListsAllEntries(t *testing.T) {
 	tru := true
 	seedModels(t, config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-main-12345678"},
-			{Name: "kimi", Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://kimi.example", ShowReasoning: &tru},
-			{Name: "cheap", Provider: "deepseek", Model: "deepseek-chat"},
+			{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-main-12345678"},
+			{Provider: "kimi", Model: "kimi-k2.6", BaseURL: "https://kimi.example", ShowReasoning: &tru},
+			{Provider: "deepseek", Model: "deepseek-chat"},
 		},
-		DefaultModel: "kimi",
-		LiteModel:    "cheap",
+		DefaultModel: "kimi-k2.6",
+		LiteModel:    "deepseek-chat",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
@@ -63,13 +62,13 @@ func TestConfigModels_GetListsAllEntries(t *testing.T) {
 	for _, m := range resp.Models {
 		byID[m.ID] = m
 	}
-	if byID["kimi"].Type != "default" || byID["cheap"].Type != "lite" || byID["main"].Type != "" {
+	if byID["kimi-k2.6"].Type != "default" || byID["deepseek-chat"].Type != "lite" || byID["claude-sonnet-4-6"].Type != "" {
 		t.Errorf("type badges wrong: %+v", resp.Models)
 	}
-	if byID["main"].APIKeyMasked == "" || byID["main"].APIKeyMasked == "sk-main-12345678" {
-		t.Errorf("api_key_masked = %q, want masked non-empty", byID["main"].APIKeyMasked)
+	if byID["claude-sonnet-4-6"].APIKeyMasked == "" || byID["claude-sonnet-4-6"].APIKeyMasked == "sk-main-12345678" {
+		t.Errorf("api_key_masked = %q, want masked non-empty", byID["claude-sonnet-4-6"].APIKeyMasked)
 	}
-	if !byID["main"].AnthropicFormat || byID["cheap"].AnthropicFormat {
+	if !byID["claude-sonnet-4-6"].AnthropicFormat || byID["deepseek-chat"].AnthropicFormat {
 		t.Errorf("anthropic_format flags wrong: %+v", resp.Models)
 	}
 }
@@ -78,9 +77,9 @@ func TestConfig_ShowReasoningGlobalDefault(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
 		},
-		DefaultModel: "main",
+		DefaultModel: "claude-sonnet-4-6",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
@@ -116,9 +115,9 @@ func TestConfig_ShowReasoningReloadsDefaultSender(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-test"},
+			{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-test"},
 		},
-		DefaultModel: "main",
+		DefaultModel: "claude-sonnet-4-6",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
@@ -161,8 +160,8 @@ func TestConfig_ShowReasoningReloadsDefaultSender(t *testing.T) {
 func TestConfigModels_PostAppendsEntry(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
-		Models:       []config.ModelEntry{{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6"}},
-		DefaultModel: "main",
+		Models:       []config.ModelEntry{{Provider: "anthropic", Model: "claude-sonnet-4-6"}},
+		DefaultModel: "claude-sonnet-4-6",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
@@ -186,10 +185,10 @@ func TestConfigModels_PostAppendsEntry(t *testing.T) {
 	if len(cfg.Models) != 2 {
 		t.Fatalf("entries = %d, want 2 — the second card must not overwrite the first", len(cfg.Models))
 	}
-	if cfg.DefaultModel != "main" {
-		t.Errorf("default moved to %q, want main", cfg.DefaultModel)
+	if cfg.DefaultModel != "claude-sonnet-4-6" {
+		t.Errorf("default moved to %q, want claude-sonnet-4-6", cfg.DefaultModel)
 	}
-	added, ok := cfg.EntryByName(resp.ID)
+	added, ok := cfg.EntryByModel(resp.ID)
 	if !ok {
 		t.Fatalf("entry %q not stored", resp.ID)
 	}
@@ -219,7 +218,7 @@ func TestConfigModels_PostUnknownEndpointBecomesCompatibleVendor(t *testing.T) {
 	}
 
 	w = doJSON(t, srv, http.MethodPost, "/api/config/models",
-		`{"model":"my-model","base_url":"https://gw2.example","api_key":"sk-x","anthropic_format":true}`)
+		`{"model":"my-model-2","base_url":"https://gw2.example","api_key":"sk-x","anthropic_format":true}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("POST = %d: %s", w.Code, w.Body.String())
 	}
@@ -259,7 +258,7 @@ func TestConfigModels_PostFirstEntryBecomesDefault(t *testing.T) {
 		t.Fatalf("POST = %d: %s", w.Code, w.Body.String())
 	}
 	cfg, _ := config.Load()
-	if len(cfg.Models) != 1 || cfg.DefaultModel != cfg.Models[0].Name {
+	if len(cfg.Models) != 1 || cfg.DefaultModel != cfg.Models[0].Model {
 		t.Fatalf("first entry must become default: %+v", cfg)
 	}
 	if cfg.Models[0].Provider != "anthropic" {
@@ -271,21 +270,21 @@ func TestConfigModels_PatchUpdatesAndKeepsKey(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-keep-me"},
+			{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-keep-me"},
 		},
-		DefaultModel: "main",
+		DefaultModel: "claude-sonnet-4-6",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
 	// No api_key in the request → stored key survives. A still-masked echo is
 	// also treated as "no change".
-	w := doJSON(t, srv, http.MethodPatch, "/api/config/models/main",
+	w := doJSON(t, srv, http.MethodPatch, "/api/config/models/claude-sonnet-4-6",
 		`{"model":"claude-opus-4-7","base_url":"","api_key":"sk-k****1234"}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("PATCH = %d: %s", w.Code, w.Body.String())
 	}
 	cfg, _ := config.Load()
-	e, _ := cfg.EntryByName("main")
+	e, _ := cfg.EntryByModel("claude-opus-4-7")
 	if e.Model != "claude-opus-4-7" {
 		t.Errorf("model = %q, want claude-opus-4-7", e.Model)
 	}
@@ -307,25 +306,25 @@ func TestConfigModels_DeleteRepairsReferences(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "m1"},
-			{Name: "kimi", Provider: "kimi", Model: "m2"},
+			{Provider: "anthropic", Model: "m1"},
+			{Provider: "kimi", Model: "m2"},
 		},
-		DefaultModel: "main",
-		LiteModel:    "kimi",
+		DefaultModel: "m1",
+		LiteModel:    "m2",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
 	// Deleting the default reassigns it to the first remaining entry.
-	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/main", ""); w.Code != http.StatusOK {
+	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/m1", ""); w.Code != http.StatusOK {
 		t.Fatalf("DELETE = %d: %s", w.Code, w.Body.String())
 	}
 	cfg, _ := config.Load()
-	if len(cfg.Models) != 1 || cfg.DefaultModel != "kimi" {
+	if len(cfg.Models) != 1 || cfg.DefaultModel != "m2" {
 		t.Fatalf("after delete: %+v", cfg)
 	}
 
 	// Deleting the lite entry clears the lite reference.
-	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/kimi", ""); w.Code != http.StatusOK {
+	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/m2", ""); w.Code != http.StatusOK {
 		t.Fatalf("DELETE = %d: %s", w.Code, w.Body.String())
 	}
 	cfg, _ = config.Load()
@@ -342,19 +341,19 @@ func TestConfigModels_SetDefault(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "m1"},
-			{Name: "kimi", Provider: "kimi", Model: "m2"},
+			{Provider: "anthropic", Model: "m1"},
+			{Provider: "kimi", Model: "m2"},
 		},
-		DefaultModel: "main",
+		DefaultModel: "m1",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
-	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/kimi/default", ""); w.Code != http.StatusOK {
+	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/m2/default", ""); w.Code != http.StatusOK {
 		t.Fatalf("set-default = %d: %s", w.Code, w.Body.String())
 	}
 	cfg, _ := config.Load()
-	if cfg.DefaultModel != "kimi" {
-		t.Fatalf("default = %q, want kimi", cfg.DefaultModel)
+	if cfg.DefaultModel != "m2" {
+		t.Fatalf("default = %q, want m2", cfg.DefaultModel)
 	}
 	if srv.model != "m2" {
 		t.Errorf("runtime model = %q, want m2", srv.model)
@@ -365,31 +364,22 @@ func TestConfigModels_SetDefault(t *testing.T) {
 	}
 }
 
-func TestConfigModels_UniqueNameGeneration(t *testing.T) {
+func TestConfigModels_DuplicateModelRejected(t *testing.T) {
 	setTestHome(t)
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
-	ids := map[string]bool{}
-	for i := 0; i < 3; i++ {
-		w := doJSON(t, srv, http.MethodPost, "/api/config/models",
-			fmt.Sprintf(`{"model":"kimi-k2.6","api_key":"sk-%d"}`, i))
-		if w.Code != http.StatusOK {
-			t.Fatalf("POST #%d = %d: %s", i, w.Code, w.Body.String())
-		}
-		var resp struct {
-			ID string `json:"id"`
-		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatal(err)
-		}
-		if ids[resp.ID] {
-			t.Fatalf("duplicate id %q", resp.ID)
-		}
-		ids[resp.ID] = true
+	// Model is the entry id, so a second entry for the same model is a conflict.
+	if w := doJSON(t, srv, http.MethodPost, "/api/config/models",
+		`{"model":"kimi-k2.6","api_key":"sk-1"}`); w.Code != http.StatusOK {
+		t.Fatalf("first POST = %d: %s", w.Code, w.Body.String())
+	}
+	if w := doJSON(t, srv, http.MethodPost, "/api/config/models",
+		`{"model":"kimi-k2.6","api_key":"sk-2"}`); w.Code != http.StatusConflict {
+		t.Fatalf("duplicate POST = %d, want 409: %s", w.Code, w.Body.String())
 	}
 	cfg, _ := config.Load()
-	if len(cfg.Models) != 3 {
-		t.Fatalf("entries = %d, want 3", len(cfg.Models))
+	if len(cfg.Models) != 1 {
+		t.Fatalf("entries = %d, want 1 (duplicate rejected)", len(cfg.Models))
 	}
 }
 
@@ -397,14 +387,14 @@ func TestCreateSession_EntryIDBindsSession(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Name: "kimi", Provider: "kimi", Model: "kimi-k2.6"},
+			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			{Provider: "kimi", Model: "kimi-k2.6"},
 		},
-		DefaultModel: "main",
+		DefaultModel: "claude-sonnet-4-6",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
-	w := doJSON(t, srv, http.MethodPost, "/api/sessions", `{"model":"kimi"}`)
+	w := doJSON(t, srv, http.MethodPost, "/api/sessions", `{"model":"kimi-k2.6"}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("POST /api/sessions = %d: %s", w.Code, w.Body.String())
 	}
@@ -424,8 +414,8 @@ func TestCreateSession_EntryIDBindsSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if sess.ModelConfig != "kimi" {
-		t.Errorf("model_config = %q, want kimi", sess.ModelConfig)
+	if sess.ModelConfig != "kimi-k2.6" {
+		t.Errorf("model_config = %q, want kimi-k2.6", sess.ModelConfig)
 	}
 
 	// A raw model string stays unbound.
@@ -449,31 +439,31 @@ func TestConfigModels_SetLiteToggles(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "m1"},
-			{Name: "cheap", Provider: "deepseek", Model: "m2"},
+			{Provider: "anthropic", Model: "m1"},
+			{Provider: "deepseek", Model: "m2"},
 		},
-		DefaultModel: "main",
+		DefaultModel: "m1",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
 	// Set.
-	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/cheap/lite", ""); w.Code != http.StatusOK {
+	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/m2/lite", ""); w.Code != http.StatusOK {
 		t.Fatalf("set-lite = %d: %s", w.Code, w.Body.String())
 	}
 	cfg, _ := config.Load()
-	if cfg.LiteModel != "cheap" {
-		t.Fatalf("lite = %q, want cheap", cfg.LiteModel)
+	if cfg.LiteModel != "m2" {
+		t.Fatalf("lite = %q, want m2", cfg.LiteModel)
 	}
 	// The badge surfaces in GET /api/config.
 	resp := getConfigResponse(t, srv)
 	for _, m := range resp.Models {
-		if m.ID == "cheap" && m.Type != "lite" {
+		if m.ID == "m2" && m.Type != "lite" {
 			t.Errorf("cheap type = %q, want lite", m.Type)
 		}
 	}
 
 	// Toggle off.
-	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/cheap/lite", ""); w.Code != http.StatusOK {
+	if w := doJSON(t, srv, http.MethodPost, "/api/config/models/m2/lite", ""); w.Code != http.StatusOK {
 		t.Fatalf("unset-lite = %d: %s", w.Code, w.Body.String())
 	}
 	cfg, _ = config.Load()
@@ -515,11 +505,11 @@ func TestBuildAgent_ExplicitLiteBeatsImplicit(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "deepseek", Model: "deepseek-v4-pro", APIKey: "sk-x"},
-			{Name: "cheap", Provider: "kimi", Model: "kimi-k2.5", APIKey: "sk-y"},
+			{Provider: "deepseek", Model: "deepseek-v4-pro", APIKey: "sk-x"},
+			{Provider: "kimi", Model: "kimi-k2.5", APIKey: "sk-y"},
 		},
-		DefaultModel: "main",
-		LiteModel:    "cheap",
+		DefaultModel: "deepseek-v4-pro",
+		LiteModel:    "kimi-k2.5",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 	srv.provider = "deepseek"
@@ -539,17 +529,17 @@ func TestBuildAgent_ImplicitLiteForBoundSession(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-a"},
-			{Name: "ds", Provider: "deepseek", Model: "deepseek-v4-pro", APIKey: "sk-d"},
+			{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-a"},
+			{Provider: "deepseek", Model: "deepseek-v4-pro", APIKey: "sk-d"},
 		},
-		DefaultModel: "main",
+		DefaultModel: "claude-sonnet-4-6",
 	})
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 	srv.provider = "anthropic"
 	srv.model = "claude-sonnet-4-6"
 
 	sess := agent.NewSession("deepseek-v4-pro", "")
-	sess.ModelConfig = "ds"
+	sess.ModelConfig = "deepseek-v4-pro"
 	a := srv.buildAgent(sess)
 	if a.LiteModel != "deepseek-v4-flash" {
 		t.Errorf("LiteModel = %q, want deepseek-v4-flash from the bound entry's vendor", a.LiteModel)
@@ -559,15 +549,14 @@ func TestBuildAgent_ImplicitLiteForBoundSession(t *testing.T) {
 	}
 }
 
-// TestConfigModels_PatchRetracksAutoDerivedName: when an entry's name was
-// auto-derived from its model (name == model), changing the model re-derives
-// the name and repairs the default_model reference. A hand-set name stays put
-// (covered by TestConfigModels_PatchUpdatesAndKeepsKey, where name != model).
-func TestConfigModels_PatchRetracksAutoDerivedName(t *testing.T) {
+// TestConfigModels_PatchModelChangeRepairsDefault: model is the entry id, so
+// changing it re-keys the entry and repairs the default_model reference that
+// pointed at the old model.
+func TestConfigModels_PatchModelChangeRepairsDefault(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
 		Models: []config.ModelEntry{
-			{Name: "qwen3.7-max", Provider: "openai", Model: "qwen3.7-max", APIKey: "sk-x"},
+			{Provider: "openai", Model: "qwen3.7-max", APIKey: "sk-x"},
 		},
 		DefaultModel: "qwen3.7-max",
 	})
@@ -579,11 +568,11 @@ func TestConfigModels_PatchRetracksAutoDerivedName(t *testing.T) {
 		t.Fatalf("PATCH = %d: %s", w.Code, w.Body.String())
 	}
 	cfg, _ := config.Load()
-	if _, ok := cfg.EntryByName("qwen3.7-plus"); !ok {
-		t.Fatalf("name should track new model qwen3.7-plus: %+v", cfg.Models)
+	if _, ok := cfg.EntryByModel("qwen3.7-plus"); !ok {
+		t.Fatalf("entry should be re-keyed to new model qwen3.7-plus: %+v", cfg.Models)
 	}
-	if _, ok := cfg.EntryByName("qwen3.7-max"); ok {
-		t.Errorf("stale name qwen3.7-max should be gone")
+	if _, ok := cfg.EntryByModel("qwen3.7-max"); ok {
+		t.Errorf("stale model qwen3.7-max should be gone")
 	}
 	if cfg.DefaultModel != "qwen3.7-plus" {
 		t.Errorf("default_model = %q, want qwen3.7-plus (repaired)", cfg.DefaultModel)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -931,7 +931,7 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 			// lite model on the session's OWN sender, keeping compaction on
 			// the endpoint, key, and prompt cache the conversation uses.
 			prov, baseURL := s.getProvider(), resolveBaseURL(s.getProvider(), cfg)
-			if entry, ok := cfg.EntryByName(sess.ModelConfig); ok {
+			if entry, ok := cfg.EntryByModel(sess.ModelConfig); ok {
 				prov, baseURL = entry.Provider, entry.BaseURL
 			}
 			if lm := app.ImplicitLiteModel(prov, a.Model, baseURL); lm != "" {
@@ -1124,7 +1124,7 @@ func (s *Server) senderForSession(sess *agent.Session) (agent.Sender, string) {
 	if err != nil {
 		return defaultSender, model
 	}
-	entry, ok := cfg.EntryByName(sess.ModelConfig)
+	entry, ok := cfg.EntryByModel(sess.ModelConfig)
 	if !ok {
 		return defaultSender, model
 	}
@@ -1144,7 +1144,7 @@ func (s *Server) senderForSession(sess *agent.Session) (agent.Sender, string) {
 func (s *Server) cachedSenderForEntry(entry config.ModelEntry) (agent.Sender, error) {
 	s.senderCacheMu.Lock()
 	defer s.senderCacheMu.Unlock()
-	if cached, ok := s.senderCache[entry.Name]; ok {
+	if cached, ok := s.senderCache[entry.Model]; ok {
 		return cached, nil
 	}
 	sender, err := senderForEntry(entry)
@@ -1154,7 +1154,7 @@ func (s *Server) cachedSenderForEntry(entry config.ModelEntry) (agent.Sender, er
 	if s.senderCache == nil {
 		s.senderCache = make(map[string]agent.Sender)
 	}
-	s.senderCache[entry.Name] = sender
+	s.senderCache[entry.Model] = sender
 	return sender, nil
 }
 
@@ -1162,7 +1162,7 @@ func (s *Server) cachedSenderForEntry(entry config.ModelEntry) (agent.Sender, er
 // model) pair for compaction, or (nil, "") when none is configured or it
 // can't be built — the agent then compacts on its primary sender.
 func (s *Server) liteSenderFromConfig(cfg config.Config) (agent.Sender, string) {
-	entry, ok := cfg.EntryByName(cfg.LiteModel)
+	entry, ok := cfg.EntryByModel(cfg.LiteModel)
 	if !ok || entry.Model == "" {
 		return nil, ""
 	}
@@ -1181,7 +1181,7 @@ func senderForEntry(entry config.ModelEntry) (agent.Sender, error) {
 		apiKey = entry.APIKey
 	}
 	if apiKey == "" {
-		return nil, fmt.Errorf("no API key for entry %q (provider %q)", entry.Name, entry.Provider)
+		return nil, fmt.Errorf("no API key for model %q (provider %q)", entry.Model, entry.Provider)
 	}
 	cfg, _ := config.Load()
 	return app.NewSender(app.SenderOptions{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1150,10 +1150,10 @@ func TestHandleUpdateSessionModel_EntryNameBindsSession(t *testing.T) {
 
 	seed := config.Config{
 		Models: []config.ModelEntry{
-			{Name: "main", Provider: "anthropic", Model: "claude-sonnet-4-6"},
-			{Name: "kimi", Provider: "kimi", Model: "kimi-k2.6", APIKey: "sk-kimi"},
+			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			{Provider: "kimi", Model: "kimi-k2.6", APIKey: "sk-kimi"},
 		},
-		DefaultModel: "main",
+		DefaultModel: "claude-sonnet-4-6",
 	}
 	if err := seed.Save(); err != nil {
 		t.Fatal(err)
@@ -1166,7 +1166,7 @@ func TestHandleUpdateSessionModel_EntryNameBindsSession(t *testing.T) {
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
-	payload, _ := json.Marshal(updateSessionModelRequest{ModelID: "kimi"})
+	payload, _ := json.Marshal(updateSessionModelRequest{ModelID: "kimi-k2.6"})
 	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/"+sess.ID+"/model", bytes.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -1180,12 +1180,12 @@ func TestHandleUpdateSessionModel_EntryNameBindsSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.ModelConfig != "kimi" || got.Model != "kimi-k2.6" {
-		t.Fatalf("session = (%q, %q), want (kimi-k2.6, kimi)", got.Model, got.ModelConfig)
+	if got.ModelConfig != "kimi-k2.6" || got.Model != "kimi-k2.6" {
+		t.Fatalf("session = (%q, %q), want (kimi-k2.6, kimi-k2.6)", got.Model, got.ModelConfig)
 	}
 	cfg, _ := config.Load()
-	if cfg.DefaultModel != "main" {
-		t.Fatalf("global default changed to %q — must stay main", cfg.DefaultModel)
+	if cfg.DefaultModel != "claude-sonnet-4-6" {
+		t.Fatalf("global default changed to %q — must stay claude-sonnet-4-6", cfg.DefaultModel)
 	}
 
 	// The bound session's turns resolve to the entry's sender and model;
@@ -1204,7 +1204,7 @@ func TestHandleUpdateSessionModel_EntryNameBindsSession(t *testing.T) {
 
 	// Deleting the bound entry degrades to the default sender instead of
 	// failing the turn.
-	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/kimi", ""); w.Code != http.StatusOK {
+	if w := doJSON(t, srv, http.MethodDelete, "/api/config/models/kimi-k2.6", ""); w.Code != http.StatusOK {
 		t.Fatalf("DELETE = %d: %s", w.Code, w.Body.String())
 	}
 	if sender3, _ := srv.senderForSession(got); sender3 != srv.sender {


### PR DESCRIPTION
## Motivation

The model-config panel never exposed a `name` field, yet `config.yml` required one per entry. Editing a model by hand meant keeping `name` **and** the `default_model` / `lite_model` references in sync — change the model, and you had to change the name too.

This makes the **model string itself the entry's identity**. `name` is gone.

```yaml
# before
models:
  - name: default
    provider: deepseek
    model: deepseek-v4-flash
    ...
default_model: default

# after
models:
  - provider: deepseek
    model: deepseek-v4-flash
    ...
# default_model optional for a single model; use the model string for multi
```

## Changes

- **config**: drop `ModelEntry.Name`; `EntryByName` → `EntryByModel`; `DefaultEntry` / `SetDefaultEntry` / `ModelVision` key off `Model`; remove `UniqueName`. `SetDefaultEntry` locates the default by index (works even when its model is empty — a floating default). Legacy `normalize()` points `default_model` at the model.
- **server**: model-config CRUD keys entries by model; `POST` rejects a duplicate model with **409**; a `PATCH` that changes the model re-keys the entry and carries `default_model`/`lite_model` over; `senderCache` keyed by model.
- **cmd / session**: `--model` selects by model string; `octo config` show lists models; `SetModelConfig` binding value is the model.
- **web**: no change — the panel already keys off the API `id`, which is now the model.

**Breaking:** two entries may no longer share a model string.

## Backward compatibility

- A stale `name:` in an existing `config.yml` is ignored (unknown YAML field).
- **Single-model config** (the common case) keeps working with zero edits: a `default_model` naming the old entry no longer matches, so `DefaultEntry` falls back to the first (only) entry.
- **Multi-model config** whose `default_model`/`lite_model` used custom names should repoint them at the model strings (old names can't be auto-mapped — they're dropped on load).

## Tests

`go test -race ./...` green. Updated config/server/cmd tests to key by model; added `TestConfigModels_DuplicateModelRejected` (409 on duplicate) and reworked the model-change/vision tests. `SetDefaultEntry` index-based fix is covered by the wizard test (empty-model floating default).

## Follow-up

`dev-docs/multi-model-config-design.md` still documents the name-keyed schema — to be refreshed separately (via `/refine-design`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)