### PR TITLE
fix(config): reject empty model on PATCH and in the config wizard

### DIFF
--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -475,6 +475,15 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer, firstRun bool) i
 		outEntry.ShowReasoning = &showVal
 	}
 
+	// The model is the entry's identity; editing the default entry must not
+	// collide with a different existing entry (the HTTP API enforces this too).
+	for _, m := range full.Models {
+		if m.Model == outEntry.Model && m.Model != existing.Model {
+			fmt.Fprintf(stderr, "octo config: a model entry for %q already exists — pick a different model\n", outEntry.Model)
+			return 2
+		}
+	}
+
 	full.SetDefaultEntry(outEntry)
 	if err := full.Save(); err != nil {
 		fmt.Fprintf(stderr, "octo config: %v\n", err)

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -468,6 +468,12 @@ func (s *Server) handleUpdateModelConfig(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	// Model is the entry's identity; an empty one would re-key the entry to ""
+	// (unaddressable via the API), so reject it as POST does.
+	if req.Model == "" {
+		writeError(w, http.StatusBadRequest, "model is required")
+		return
+	}
 
 	cfg, err := config.Load()
 	if err != nil {

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -583,3 +583,26 @@ func TestConfigModels_PatchModelChangeRepairsDefault(t *testing.T) {
 		t.Errorf("default_model = %q, want qwen3.7-plus (repaired)", cfg.DefaultModel)
 	}
 }
+
+// An empty model in a PATCH would re-key the entry to "" — unaddressable via
+// the API and permanently orphaned. It must be rejected, leaving the entry
+// unchanged.
+func TestConfigModels_PatchEmptyModelRejected(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Provider: "anthropic", Model: "claude-sonnet-4-6", APIKey: "sk-x"},
+		},
+		DefaultModel: "claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	if w := doJSON(t, srv, http.MethodPatch, "/api/config/models/claude-sonnet-4-6",
+		`{"model":"","base_url":"","api_key":"sk-x****"}`); w.Code != http.StatusBadRequest {
+		t.Fatalf("PATCH empty model = %d, want 400: %s", w.Code, w.Body.String())
+	}
+	cfg, _ := config.Load()
+	if len(cfg.Models) != 1 || cfg.Models[0].Model != "claude-sonnet-4-6" || cfg.DefaultModel != "claude-sonnet-4-6" {
+		t.Fatalf("entry must be unchanged and addressable: %+v default=%q", cfg.Models, cfg.DefaultModel)
+	}
+}


### PR DESCRIPTION
Follow-up to #997 (model string is the entry id), addressing two findings from an isolated code review.

## 1. PATCH with an empty model orphaned the entry (regression)

`PATCH /api/config/models/{id}` had no empty-model guard, unlike `POST`. `applyModelRequestToEntry` sets `e.Model = req.Model` unconditionally, so `{"model":""}` re-keyed the entry to `""` — which every handler rejects as a 400 (`id == ""`). The entry became **unaddressable and permanently orphaned**: it could never be edited or deleted through the panel again. Under the old name-keyed model an empty PATCH left `name` intact, so this is a regression introduced by #997.

**Fix:** reject an empty `req.Model` with 400, mirroring the POST guard.

## 2. The `octo config` wizard could create duplicate models

The wizard edits the default entry in place via `SetDefaultEntry`, which has no duplicate-model check (the invariant is enforced in the HTTP POST/PATCH handlers but not here). Typing another existing entry's model string produced two entries sharing a model. Narrow path, but the one create/rename route where the invariant wasn't enforced.

**Fix:** the wizard rejects a collision with a different entry before saving.

## Tests

Added `TestConfigModels_PatchEmptyModelRejected` (400 + entry unchanged and still addressable). The wizard collision fix is a 3-line guard on a narrow CLI path; existing wizard tests cover the normal path for non-regression. `go test ./internal/config/ ./internal/server/ ./cmd/octo/` green.

## Not changed (from the same review)

- **Legacy multi-entry configs** whose `default_model`/`lite_model` used `-2`-suffixed or hand-set names lose that binding on load (falls back to first entry / disables lite). Known compatibility trade-off, noted in #997.
- **DELETE may set `default_model` to `""`** when the new first entry is a floating default — benign, `DefaultEntry` falls back to the first entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)