### PR TITLE
docs(readme): honest open-source positioning vs Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,47 @@
   <a href="README.md">English</a> · <a href="README_CN.md">简体中文</a>
 </p>
 
-A functionality-first AI agent, distributed as a single Go binary. Speaks two native API protocols — **Anthropic Messages** and **OpenAI Chat Completions** — and works against any compatible third party (DeepSeek, Kimi, Bailian, OpenRouter, vLLM, …). Aims for three equal interfaces: **CLI**, **Web**, and **IM**.
+> An **MIT-licensed, single Go binary, zero-runtime** AI agent. It does what the big coding agents do —
+> skills, CLI / Web / phone-IM, browser control, an OS-level sandbox — but as an **open, self-contained
+> binary you fully own**, on **any model** (DeepSeek, Kimi, Anthropic, OpenAI, or anything compatible),
+> with the server and your data staying on your own machine. Reuse the skills already in `~/.claude/skills`.
+> It's both a **coding agent** (vs Claude Code) and a **general-purpose agent** (vs Hermes) — one binary for
+> both your coding and your everyday automation, instead of running two separate tools.
+
+<!-- TODO(demo): record a 15–30s hero GIF (one-line install → octo on DeepSeek → solve a real
+     coding task), drop it at docs/assets/demo.gif, and uncomment the block below. -->
+<!--
+<p align="center">
+  <img src="docs/assets/demo.gif" alt="octo demo" width="760">
+</p>
+-->
+
+```bash
+curl -fsSL https://octo-agent.dev/install.sh | sh     # single binary — no Node / Ruby / Python
+octo config                                            # pick a provider, paste a key (DeepSeek / Kimi / …)
+octo "Add a --json flag to 'octo config show' and run the tests"   # one prompt → full agentic loop
+```
+
+## Why octo — vs Claude Code
+
+octo isn't trying to out-feature the big agents; it's the **open, self-hostable, vendor-neutral** take on
+the same idea. If you're happy on a Claude subscription, Claude Code is great. octo is for when you'd
+rather own the whole thing and run it on your own models.
+
+|  | **octo-agent** | Claude Code |
+|---|---|---|
+| License / cost | **MIT, free, self-hosted** | proprietary; most surfaces need a Claude subscription |
+| Runtime | **one self-contained Go binary — no Node / Python / Ruby, no dependency tree** | native install tied to an Anthropic account |
+| Models | **both protocols + any compatible endpoint** (DeepSeek/Kimi/Bailian/OpenRouter/vLLM) | Anthropic-first (third-party providers on Terminal / VS Code) |
+| Deployment / data | **fully self-hosted — server and data stay yours** | Anthropic-managed for most surfaces |
+| Skills | reuse `~/.claude/skills` directly | native (the format's origin) |
+
+<sub>Claude Code details per its public docs (2026-07). It also has skills, MCP, sub-agents, an OS sandbox,
+browser / computer-use, and IM channels — octo covers the same ground. The difference above is openness,
+self-hosting, and model freedom, not a feature checklist.</sub>
+
+**In one line:** you want the Claude Code experience, but open-source, self-hostable, and not locked to a
+subscription or a single vendor — that's octo.
 
 ## Status
 
@@ -311,6 +351,18 @@ make fmt-check     # gofmt -l . must be empty
 ```
 
 Project conventions live in [`.octorules`](.octorules) (the human-facing rules); [`CLAUDE.md`](CLAUDE.md) expands them with the operational detail AI coding agents need in this repo. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the human PR workflow.
+
+## Prior art & acknowledgements
+
+octo stands on the shoulders of two projects and doesn't pretend otherwise:
+
+- **[Claude Code](https://code.claude.com)** — much of octo's internal design is modeled on how Claude Code
+  works: the agent loop, the tool set, the SKILL.md format, permission gating, and general harness behavior.
+  octo aims to be a compatible, open, self-hostable take on the same ideas.
+- **[OpenClacky](https://github.com/clacky-ai/openclacky)** — a large share of octo's UI and interaction
+  design is inspired by OpenClacky (itself a kindred open-source, BYOK agent).
+
+Any bugs or bad decisions are octo's own.
 
 ## License
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -9,7 +9,43 @@
   <a href="README.md">English</a> · <a href="README_CN.md">简体中文</a>
 </p>
 
-以功能为先的 AI Agent，单一 Go 二进制分发。原生支持两种 API 协议 —— **Anthropic Messages** 和 **OpenAI Chat Completions**，并能对接任何兼容这两种协议的第三方（DeepSeek、Kimi、百炼、OpenRouter、vLLM 等）。目标是 **CLI**、**Web**、**IM** 三种平等的交互界面。
+> 一个 **MIT 开源、单 Go 二进制、零运行时**的 AI Agent。大厂 coding agent 那套能力（skills、CLI / 网页 /
+> 手机 IM、浏览器操作、OS 级沙箱）它都有 —— 区别在于它**完全开源、自包含、不绑任何厂商**，DeepSeek /
+> Kimi / Anthropic / OpenAI 任意模型都能接，服务和数据都留在你自己机器上。直接复用你 `~/.claude/skills` 里的技能。
+> 它既是 **coding agent**（对标 Claude Code），也是**通用 agent**（对标 Hermes）—— 一个二进制同时接管你的编码
+> 和日常自动化，不必装两套工具。
+
+<!-- TODO(demo): 录一段 15–30s 首屏 GIF（装一行 → octo 接 DeepSeek → 解决一个真实编码任务），
+     放到 docs/assets/demo.gif，然后取消下面这段注释。 -->
+<!--
+<p align="center">
+  <img src="docs/assets/demo.gif" alt="octo 演示" width="760">
+</p>
+-->
+
+```bash
+curl -fsSL https://octo-agent.dev/install.sh | sh     # 单二进制，无需 Node / Ruby / Python 环境
+octo config                                            # 选 provider，填 key（DeepSeek / Kimi / 百炼 …）
+octo "给 octo config show 加一个 --json 参数并跑测试"   # 一句话 → 完整 agentic 工具循环
+```
+
+## 为什么用 octo（对比 Claude Code）
+
+octo 不打算在功能上卷赢大厂 agent；它是同一个想法的**开源、可自托管、不绑厂商**版本。如果你乐意用 Claude
+订阅，Claude Code 很好用。octo 是给「宁愿把整套东西攥在自己手里、跑自己的模型」的人准备的。
+
+|  | **octo-agent** | Claude Code |
+|---|---|---|
+| 授权 / 成本 | **MIT 开源，免费，自托管** | 专有，多数场景需 Claude 订阅 |
+| 运行时 | **单个自包含 Go 二进制 —— 无需 Node / Python / Ruby，没有依赖树** | 原生安装，绑定 Anthropic 账户 |
+| 模型 | **双协议原生 + 任意兼容端点**（DeepSeek/Kimi/百炼/OpenRouter/vLLM） | 以 Anthropic 为主（CLI / VS Code 可接第三方） |
+| 部署 / 数据 | **完全自托管，服务与数据都在你手里** | 多数场景由 Anthropic 托管 |
+| 技能 | 直接复用 `~/.claude/skills` | 原生（skills 的发源地） |
+
+<sub>Claude Code 信息据其公开文档（2026-07）。它同样具备 skills、MCP、子代理、OS 沙箱、浏览器 / computer-use、
+IM channels —— 这些 octo 也都有；上表的区别是开源、自托管与模型自由，而非功能清单。</sub>
+
+**一句话**：你想要 Claude Code 那种体验，但要开源、能自托管、不被订阅和单一厂商绑住 —— octo 就是为这个做的。
 
 ## 状态
 
@@ -256,6 +292,17 @@ make fmt-check     # gofmt -l . 必须为空
 ```
 
 项目约定写在 [`.octorules`](.octorules)（面向人类的规则）；[`CLAUDE.md`](CLAUDE.md) 在此基础上补充 AI 编程助手在本仓库工作所需的操作细节。[`CONTRIBUTING.md`](CONTRIBUTING.md) 是人类 PR 流程。
+
+## 致谢与前人工作
+
+octo 站在两个项目的肩膀上，这点不遮掩：
+
+- **[Claude Code](https://code.claude.com)** —— octo 的内部实现大量借鉴了 Claude Code 的做法：agent 循环、
+  工具集、SKILL.md 格式、权限门控、以及整体的 harness 行为。octo 想做的是一个兼容、开源、可自托管的同类实现。
+- **[OpenClacky](https://github.com/clacky-ai/openclacky)** —— octo 的 UI 与交互设计有很大一部分受 OpenClacky
+  启发（它本身也是一个开源、BYOK 的同类 agent）。
+
+有 bug 或者设计得不好的地方，都算 octo 自己的。
 
 ## 许可
 


### PR DESCRIPTION
## What

Rewrites the top of both `README.md` and `README_CN.md` from a generic *"functionality-first AI agent"* blurb into a positioning-first landing section:

- **One-line hook** — MIT, single zero-runtime Go binary, any model, self-hosted.
- **Hero-GIF slot** (commented out until recorded, so nothing renders broken).
- **3-line quick start** — install one-liner → `octo config` → one prompt.
- **A focused octo-vs-Claude-Code table** on the axes that genuinely differ.

Everything below `## Status` is unchanged.

## Why this framing

I fact-checked a wider 5-way table (vs Claude Code, OpenClaw, Hermes, OpenClacky) and the "octo has features others lack" angle **did not survive verification** — every peer now has browser/computer-use, an OS or container sandbox, IM channels, and (for two of them) Claude-Code-compatible skills. Claude Code in particular now ships a native binary, a built-in Seatbelt/bubblewrap sandbox, IM channels, computer-use, and third-party providers on Terminal/VS Code.

So the README leads with the one thing that **is** true and verifiable: octo is the **open-source, zero-runtime, self-hostable, vendor-neutral** take on the same idea. The table compares only against Claude Code, and a `<sub>` note explicitly states the rest is parity, not a feature win — to stay honest and preempt "but Claude Code has all that too" pushback.

### Verified against the codebase (octo's own column)
- Install one-liner `octo-agent.dev/install.sh` — real (`docs/install.sh`).
- DeepSeek / Kimi / Moonshot / Bailian / DashScope / OpenRouter / vLLM — all named in `internal/provider` + config.
- CC-skill compatibility + `~/.claude/skills` symlink — `internal/skills/skills.go`.
- 6 IM adapters — `internal/channel/adapters/{dingtalk,discord,feishu,wecom,weixin(iLink),telegram}`.
- Seatbelt / Landlock sandbox — `internal/sandbox/sandbox_{darwin,linux}.go`.

## Follow-ups (not in this PR)
- [ ] Record the hero GIF → `docs/assets/demo.gif`, then uncomment the image block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)