### PR TITLE
feat(hooks): unified engine + agent-core dispatch (PR1: parity + memory migration + SessionStart/Stop)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -740,15 +740,21 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// result when a milestone-shaped command (gh pr create/merge) lands, so the
 	// injector is wired even when MEMORY.md has no structured rules — Reminder
 	// is silent then.
+	// Hook engine: shell hooks (from the OCTO_HOOK_* env shim) plus the memory
+	// injector's reminder & save-nudge as in-process hooks, unified on one
+	// dispatch path that the agent core drives for every transport. Shares the
+	// process seen-set so SessionStart resume fires once per OS process.
+	hookEngine := hooks.EngineFromEnv(hooks.SharedSeen())
+	hookEngine.Notify = func(m string) { fmt.Fprintln(stderr, "↳ hook: "+m) }
 	if memDir != "" {
 		rules := memory.ParseRules(memDir)
 		if homeMemDir != "" {
 			rules.Merge(memory.ParseRules(homeMemDir))
 		}
-		inj := memory.NewInjector(rules)
-		a.UserInputHook = inj.Reminder
-		a.ToolResultHook = inj.SaveNudge
+		memory.NewInjector(rules).RegisterHooks(hookEngine)
 	}
+	a.Hooks = hookEngine
+	a.HookMeta = hooks.Meta{Cwd: cwd}
 
 	// Permission engine — gates every tool call; shared by both paths. The
 	// memory directory (outside CWD) is whitelisted for writes so the agent can
@@ -810,9 +816,8 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			stderr:          stderr,
 			skillReg:        skillReg,
 			memDir:          memDir,
-			reader:          replReader,          // shared with the asker / permission gate
-			view:            replView,            // same surface for turn render + Ask prompts
-			hooks:           hooks.LoadFromEnv(), // C9 Phase 3: external retrieval layer hooks
+			reader:          replReader, // shared with the asker / permission gate
+			view:            replView,   // same surface for turn render + Ask prompts
 			permEngine:      permEngine,
 			mcpBoot:         mcpBoot, // nil unless tools on with servers configured
 			modelName:       resolvedModel,
@@ -857,7 +862,6 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		memDir:          memDir,
 		reader:          replReader,
 		view:            replView,
-		hooks:           hooks.LoadFromEnv(),
 		permEngine:      permEngine,
 		modelName:       resolvedModel,
 		reasoningEffort: resolvedEffort,

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -62,6 +62,21 @@ func offerOnboarding(reader lineReader, out io.Writer) bool {
 	}
 }
 
+// wireSessionHooks completes the agent's hook identity once the session exists:
+// the SessionID/transcript/transport the payload envelope carries, the durable
+// SessionStarted seed, and the persist callback the engine invokes when
+// SessionStart first fires (startup). Persistence rides the session layer's
+// existing post-turn Save — MarkHookStarted only marks the meta dirty.
+func wireSessionHooks(a *agent.Agent, sess *agent.Session, transport string) {
+	a.HookMeta.SessionID = sess.ID
+	a.HookMeta.Transport = transport
+	if p, err := sess.SavePath(); err == nil {
+		a.HookMeta.TranscriptPath = p
+	}
+	a.SessionStarted = sess.HookStarted
+	a.OnSessionStart = func() { sess.MarkHookStarted() }
+}
+
 // errMissingAPIKey is returned by resolveAPIKey when no API key is available.
 // The caller (runChat) can detect this and auto-launch the config wizard on an
 // interactive terminal instead of failing silently.
@@ -796,6 +811,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			sess = agent.NewSession(resolvedModel, *system)
 			sess.Bind(agent.EntryTUI, false)
 		}
+		wireSessionHooks(a, sess, agent.EntryTUI)
 		// Persisted (non-ephemeral) sessions archive folded turns so the model
 		// can recall them with the read tool after a compaction.
 		if !*noSave {
@@ -849,9 +865,11 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// ── Headless one-shot (claude -p) ─────────────────────────────────────────
 	// One agentic turn, then exit. The session is ephemeral — one-shot runs are
 	// not persisted (resuming with -c stays a TUI affordance).
+	oneShotSess := agent.NewSession(resolvedModel, *system)
+	wireSessionHooks(a, oneShotSess, agent.EntryCLI)
 	replCfg := replConfig{
 		a:               a,
-		session:         agent.NewSession(resolvedModel, *system),
+		session:         oneShotSess,
 		noSave:          true,
 		plain:           *plain,
 		verbosity:       resolveVerbosity(*quietFlag, *verboseFlag),

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/config"
-	"github.com/Leihb/octo-agent/internal/hooks"
 	"github.com/Leihb/octo-agent/internal/mcp"
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/skills"
@@ -38,7 +37,6 @@ type replConfig struct {
 	subAgentMgr *tools.SubAgentManager // nil → sub-agent tools disabled
 	skillReg    *skills.Registry       // discovered skills; backs /skills and /<name>
 	memDir      string                 // per-repo memory directory; backs /memory ("" → disabled)
-	hooks       *hooks.Runner          // C9 Phase 3 pre/post-turn hooks; nil-safe via Configured()
 	// reader, when non-nil, is the line reader to use instead of building
 	// one fresh inside runREPL. Set by cmd/octo so the same instance is
 	// shared with the permission gate and the ask_user_question asker.

--- a/cmd/octo/turncore.go
+++ b/cmd/octo/turncore.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
-	"github.com/Leihb/octo-agent/internal/hooks"
 )
 
 // ViewSink is the render-decoupling seam between the turn orchestration core
@@ -64,16 +63,9 @@ func runTurn(ctx context.Context, a *agent.Agent, cfg replConfig, sink ViewSink,
 		turnInput = strings.Join(agent.Texts(pending), "\n\n") + "\n\n" + turnInput
 	}
 
-	// Pre-turn hook: feed the raw user input to an external retrieval layer;
-	// whatever it returns is folded into the user message. Hook errors are
-	// surfaced but never block the turn.
-	if cfg.hooks.Configured() {
-		extra, herr := cfg.hooks.Pre(ctx, line)
-		if herr != nil {
-			sink.Notice(fmt.Sprintf("↳ pre-turn hook: %v", herr))
-		}
-		turnInput = hooks.InjectContext(turnInput, extra)
-	}
+	// UserPromptSubmit / Stop hooks now fire inside the agent core (Agent.Hooks),
+	// so every transport — not just this CLI path — runs them; runTurn no longer
+	// invokes hooks itself.
 
 	sink.TurnStarted()
 
@@ -85,15 +77,6 @@ func runTurn(ctx context.Context, a *agent.Agent, cfg replConfig, sink ViewSink,
 	reply, err := a.RunStream(ctx, turnInput, cfg.tools, cfg.executor, sink.Emit)
 
 	sink.TurnEnded(reply, err)
-
-	// Post-turn hook: fire-and-forget the finished turn at the retain side.
-	// Runs only on success so interrupts/errors don't pollute the index. Uses
-	// a fresh context so an interrupt of the turn doesn't cancel retention.
-	if err == nil && cfg.hooks.Configured() {
-		if herr := cfg.hooks.Post(context.Background(), line, reply.Content); herr != nil {
-			sink.Notice(fmt.Sprintf("↳ post-turn hook: %v", herr))
-		}
-	}
 	return reply, err
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+
+	"github.com/Leihb/octo-agent/internal/hooks"
 )
 
 // Sender is the minimal slice of provider.Provider the Agent depends on:
@@ -212,23 +214,24 @@ type Agent struct {
 	// Ruby octo's @inbox and keeps mid-turn input handling simple.
 	Inbox Inbox
 
-	// UserInputHook, when set, is called with each user input just before it is
-	// appended to history. A non-empty return is prepended to the user message
-	// (separated by a blank line). It exists to re-surface memory rules at the
-	// point of action without touching the cached system prompt; the reminder
-	// rides the message stream instead. The hook must not mutate state the
-	// caller relies on elsewhere — it's invoked once per appended user turn.
-	UserInputHook func(userInput string) string
+	// Hooks is the per-Agent hook engine. It supersedes the old single-slot
+	// UserInputHook/ToolResultHook: the memory injector registers its reminder
+	// (UserPromptSubmit) and save-nudge (PostToolUse) as in-process hooks on it,
+	// and any shell hooks (env or hooks.yml) live here too, so every transport
+	// runs one dispatch path. The engine shares a process-level seen-set so
+	// SessionStart resume fires once per OS process. Nil is a no-op.
+	Hooks *hooks.Engine
 
-	// ToolResultHook, when set, is called once per successfully executed tool
-	// call, after the whole batch has been dispatched. A non-empty return is
-	// appended to that call's tool_result text (separated by a blank line) —
-	// the channel for surfacing a reminder at the exact moment an action
-	// completed (e.g. the memory save-nudge after a PR merge). It is invoked
-	// serially from the run loop even when the batch itself ran in parallel,
-	// so implementations need no locking of their own. Denied and errored
-	// calls are skipped — a failed action is not a milestone.
-	ToolResultHook func(name string, input map[string]any) string
+	// HookMeta carries the session identity (id, transport, transcript, cwd,
+	// model) folded into every hook Payload. Set by the session-owning layer
+	// before a run, alongside ArchiveDir. Model falls back to a.Model when
+	// unset.
+	HookMeta hooks.Meta
+
+	// turnTools accumulates the tool names dispatched during the current turn,
+	// surfaced to the Stop hook as tools_used. Reset at each turn's first user
+	// input; read and cleared when Stop fires.
+	turnTools []string
 
 	// pendingUserBlocks holds content blocks (e.g. images pasted in the TUI)
 	// to merge into the next user message. Set via AttachUserBlocks and
@@ -327,14 +330,30 @@ func (a *Agent) AttachUserBlocks(blocks []ContentBlock) {
 	a.pendingUserBlocks = blocks
 }
 
+// hookPayload seeds a hook Payload from the Agent's HookMeta, defaulting Model
+// to the live a.Model when the session layer left it unset.
+func (a *Agent) hookPayload(event hooks.Event) hooks.Payload {
+	m := a.HookMeta
+	if m.Model == "" {
+		m.Model = a.Model
+	}
+	return m.Payload(event)
+}
+
 // appendUserInput appends userInput to history, first prepending any
-// UserInputHook output. It stays a single appended message so the error-path
-// popLast contract in Turn/TurnStream/runLoop still removes exactly one turn.
-func (a *Agent) appendUserInput(userInput string) {
+// UserPromptSubmit hook output (the memory reminder + any shell retrieval
+// context, unified through the engine). It stays a single appended message so
+// the error-path popLast contract in Turn/TurnStream/runLoop still removes
+// exactly one turn. It also re-arms per-turn hook state (the tools_used
+// accumulator surfaced to Stop).
+func (a *Agent) appendUserInput(ctx context.Context, userInput string) {
+	a.turnTools = nil
 	text := userInput
-	if a.UserInputHook != nil {
-		if reminder := a.UserInputHook(userInput); reminder != "" {
-			text = reminder + "\n\n" + userInput
+	if a.Hooks != nil {
+		p := a.hookPayload(hooks.EventUserPromptSubmit)
+		p.UserInput = userInput
+		if extra := a.Hooks.Inject(ctx, p); extra != "" {
+			text = extra + "\n\n" + userInput
 		}
 	}
 	// Attachments (e.g. a pasted image) ride on the same user turn as the
@@ -403,7 +422,7 @@ func (a *Agent) Turn(ctx context.Context, userInput string) (Reply, error) {
 	}
 
 	// Append user message first so the snapshot the Sender sees includes it.
-	a.appendUserInput(userInput)
+	a.appendUserInput(ctx, userInput)
 
 	reply, err := a.Sender.SendMessages(ctx, a.Model, a.System, a.History.Snapshot(), a.MaxTokens)
 	if err != nil {
@@ -446,7 +465,7 @@ func (a *Agent) TurnStream(
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
 
-	a.appendUserInput(userInput)
+	a.appendUserInput(ctx, userInput)
 
 	var (
 		reply Reply
@@ -501,7 +520,7 @@ const truncationResumePrompt = "You were cut off mid-thought. Continue exactly w
 //
 // If tools is nil or executor is nil, Run is equivalent to Turn (single-turn,
 // no tool dispatch).
-func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinition, executor ToolExecutor) (Reply, error) {
+func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinition, executor ToolExecutor) (reply Reply, err error) {
 	if a.Sender == nil {
 		return Reply{}, fmt.Errorf("agent: no Sender configured")
 	}
@@ -511,6 +530,11 @@ func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinitio
 	if userInput == "" && len(a.pendingUserBlocks) == 0 {
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
+
+	// Fire Stop once the turn concludes — success or failure. Registered after
+	// validation so config errors (no turn ran) don't emit a spurious Stop. The
+	// closure reads the final named returns.
+	defer func() { a.fireStop(userInput, reply, err) }()
 
 	// No tools (or a Sender that can't do tools) → plain Turn.
 	if len(tools) == 0 || executor == nil {
@@ -542,7 +566,7 @@ func (a *Agent) RunStream(
 	tools []ToolDefinition,
 	executor ToolExecutor,
 	handler EventHandler,
-) (Reply, error) {
+) (reply Reply, err error) {
 	if a.Sender == nil {
 		return Reply{}, fmt.Errorf("agent: no Sender configured")
 	}
@@ -552,6 +576,9 @@ func (a *Agent) RunStream(
 	if userInput == "" && len(a.pendingUserBlocks) == 0 {
 		return Reply{}, fmt.Errorf("agent: userInput must be non-empty")
 	}
+
+	// Fire Stop once the turn concludes — success or failure. See Run.
+	defer func() { a.fireStop(userInput, reply, err) }()
 
 	// onChunk adapts text deltas from provider streams into EventTextDelta
 	// events. Nil-safe; empty deltas are silently dropped.
@@ -617,7 +644,7 @@ func (a *Agent) RunStream(
 
 	// Neither tool-aware interface available → plain TurnStream with the
 	// event-adapting onChunk. EventTurnDone fires on success.
-	reply, err := a.TurnStream(ctx, userInput, onChunk, onThinking)
+	reply, err = a.TurnStream(ctx, userInput, onChunk, onThinking)
 	if err == nil && handler != nil {
 		r := reply
 		handler(AgentEvent{Kind: EventTurnDone, Reply: &r})
@@ -665,7 +692,7 @@ func (a *Agent) runLoop(
 	// user input (drained inbox messages), so truncating to this baseline is
 	// what restores the pre-turn state — popLast would only remove one message.
 	baseHistoryLen := a.History.Len()
-	a.appendUserInput(userInput)
+	a.appendUserInput(ctx, userInput)
 
 	limit := a.turnLimit()
 	streamStalls := 0      // transient mid-stream stalls re-issued for the current round
@@ -860,11 +887,19 @@ func (a *Agent) runLoop(
 				return Reply{}, fmt.Errorf("agent: dispatch tools[%d]: %w", i, err)
 			}
 
+			// Record the tool names dispatched this turn for the Stop hook's
+			// tools_used field.
+			for _, b := range reply.Blocks {
+				if b.Type == "tool_use" {
+					a.turnTools = append(a.turnTools, b.Name)
+				}
+			}
+
 			// Decorate results before events and history so the model and
 			// the persisted session see the same text. UI events strip the
 			// <system-reminder> spans (emitToolResultEvents) — hook output
 			// is model-facing, not part of the tool's visible result.
-			applyToolResultHook(a.ToolResultHook, reply.Blocks, resultBlocks)
+			a.applyPostToolUse(ctx, reply.Blocks, resultBlocks)
 
 			// Emit EventToolDone / EventToolError per result, pairing
 			// each result with the originating tool_use block so ToolName
@@ -1374,13 +1409,14 @@ func toolResultBlocks(id string, result ToolResult, err error) []ContentBlock {
 	return blocks
 }
 
-// applyToolResultHook appends the hook's output to each matching successful
-// tool_result block. It runs serially after dispatchTools returns — never
-// inside the parallel read-only batch — so a stateful hook (the memory
-// save-nudge latch) needs no locking. Denied and errored calls carry
-// IsError=true and are skipped.
-func applyToolResultHook(hook func(name string, input map[string]any) string, uses, results []ContentBlock) {
-	if hook == nil {
+// applyPostToolUse fires the PostToolUse hook for each successful tool result
+// and appends any output to that tool_result block. It runs serially after
+// dispatchTools returns — never inside the parallel read-only batch — so a
+// stateful in-process hook (the memory save-nudge latch) needs no locking.
+// Denied and errored calls carry IsError=true and are skipped: a failed action
+// is not a milestone.
+func (a *Agent) applyPostToolUse(ctx context.Context, uses, results []ContentBlock) {
+	if a.Hooks == nil || !a.Hooks.Configured(hooks.EventPostToolUse) {
 		return
 	}
 	byID := make(map[string]*ContentBlock, len(results))
@@ -1397,7 +1433,11 @@ func applyToolResultHook(hook func(name string, input map[string]any) string, us
 		if rb == nil {
 			continue
 		}
-		if extra := hook(u.Name, u.Input); extra != "" {
+		p := a.hookPayload(hooks.EventPostToolUse)
+		p.ToolName = u.Name
+		p.ToolInput = u.Input
+		p.ToolResult = rb.Result
+		if extra := a.Hooks.Inject(ctx, p); extra != "" {
 			if rb.Result == "" {
 				rb.Result = extra
 			} else {
@@ -1405,6 +1445,29 @@ func applyToolResultHook(hook func(name string, input map[string]any) string, us
 			}
 		}
 	}
+}
+
+// fireStop dispatches the Stop hook at a turn's conclusion — on success AND on
+// failure/interrupt alike, since a retention layer wants both (a non-nil err
+// populates the payload's error field so a script can choose to skip failures).
+// userInput is the turn's original input; reply.Content is the final assistant
+// text; tools_used is drained from the per-turn accumulator. Dispatch uses a
+// background context so interrupting the turn (ctx cancelled) doesn't also
+// cancel retention — mirroring the pre-redesign post-turn hook.
+func (a *Agent) fireStop(userInput string, reply Reply, err error) {
+	tools := a.turnTools
+	a.turnTools = nil
+	if a.Hooks == nil || !a.Hooks.Configured(hooks.EventStop) {
+		return
+	}
+	p := a.hookPayload(hooks.EventStop)
+	p.UserInput = userInput
+	p.AssistantReply = reply.Content
+	p.ToolsUsed = tools
+	if err != nil {
+		p.Error = err.Error()
+	}
+	a.Hooks.Dispatch(context.Background(), p)
 }
 
 // flattenResults collapses a per-tool slice-of-slices into a single flat slice.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Leihb/octo-agent/internal/hooks"
 )
@@ -233,10 +234,34 @@ type Agent struct {
 	// input; read and cleared when Stop fires.
 	turnTools []string
 
+	// SessionStarted mirrors the session's durable "SessionStart has fired"
+	// flag, seeded by the session-owning layer before the run. The engine's
+	// SessionStartDecision uses it (with the process seen-set) to pick
+	// startup vs resume; the agent flips it and calls OnSessionStart when
+	// startup fires so the layer can persist it.
+	SessionStarted bool
+
+	// HookClear, when true, makes the next turn's SessionStart fire with
+	// source=clear (set by the session layer right after a /clear). Consumed
+	// once, on the next appended user turn.
+	HookClear bool
+
+	// OnSessionStart, if set, is invoked when SessionStart fires with
+	// source=startup — the seam the session layer uses to persist the durable
+	// flag (Session.MarkHookStarted). Runs on the turn goroutine.
+	OnSessionStart func()
+
 	// pendingUserBlocks holds content blocks (e.g. images pasted in the TUI)
 	// to merge into the next user message. Set via AttachUserBlocks and
 	// consumed exactly once by the next appendUserInput, alongside the text.
 	pendingUserBlocks []ContentBlock
+
+	// pendingUserCreatedAt, when non-zero, is the timestamp the next appended
+	// user message must carry instead of a fresh time.Now(). Set via
+	// AttachUserCreatedAt by a caller (the web server) that already stamped the
+	// same message for a live broadcast, so the persisted copy shares that exact
+	// created_at — the dedup key the frontend matches on. Consumed once.
+	pendingUserCreatedAt time.Time
 
 	// turnIterations is the number of provider round-trips (loop iterations)
 	// executed during the most recent Run/RunStream call. It is set when the
@@ -330,6 +355,15 @@ func (a *Agent) AttachUserBlocks(blocks []ContentBlock) {
 	a.pendingUserBlocks = blocks
 }
 
+// AttachUserCreatedAt pins the timestamp the next appended user message will
+// carry, so a caller that pre-stamped the same message (the web server, which
+// broadcasts a live created_at before the turn) gets an identical persisted
+// timestamp rather than a second, later time.Now(). Consumed once by the next
+// appendUserInput. Mirrors AttachUserBlocks.
+func (a *Agent) AttachUserCreatedAt(t time.Time) {
+	a.pendingUserCreatedAt = t
+}
+
 // hookPayload seeds a hook Payload from the Agent's HookMeta, defaulting Model
 // to the live a.Model when the session layer left it unset.
 func (a *Agent) hookPayload(event hooks.Event) hooks.Payload {
@@ -348,12 +382,52 @@ func (a *Agent) hookPayload(event hooks.Event) hooks.Payload {
 // accumulator surfaced to Stop).
 func (a *Agent) appendUserInput(ctx context.Context, userInput string) {
 	a.turnTools = nil
+	// Stamp the turn's timestamp BEFORE any hook work. The server pre-builds the
+	// same user message to broadcast a live created_at and relies on this
+	// appended copy carrying an identical timestamp (the WS dedup key); letting
+	// hook-dispatch latency sit between them would push this stamp into a later
+	// millisecond and double-render the message. See ws_handlers user-message
+	// build. When a caller pre-stamped the message (AttachUserCreatedAt) reuse
+	// that exact timestamp; otherwise stamp now.
+	createdAt := a.pendingUserCreatedAt
+	a.pendingUserCreatedAt = time.Time{}
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
 	text := userInput
 	if a.Hooks != nil {
-		p := a.hookPayload(hooks.EventUserPromptSubmit)
-		p.UserInput = userInput
-		if extra := a.Hooks.Inject(ctx, p); extra != "" {
-			text = extra + "\n\n" + userInput
+		var injected []string
+
+		// SessionStart fires once per session opening. SessionStartDecision
+		// self-gates on the process seen-set + the durable SessionStarted flag,
+		// so attempting it every turn is cheap and only fires on the first
+		// (startup/resume) or after a /clear. Its output rides this first user
+		// message and thus persists — which is what makes it visible on later
+		// turns even though serve rebuilds the Agent each turn.
+		if src, fire := a.Hooks.SessionStartDecision(a.HookMeta.SessionID, a.SessionStarted, a.HookClear); fire {
+			a.HookClear = false
+			if src == hooks.SourceStartup {
+				a.SessionStarted = true
+				if a.OnSessionStart != nil {
+					a.OnSessionStart()
+				}
+			}
+			sp := a.hookPayload(hooks.EventSessionStart)
+			sp.Source = src
+			if s := a.Hooks.Inject(ctx, sp); s != "" {
+				injected = append(injected, s)
+			}
+		}
+
+		// UserPromptSubmit fires every turn (fresh retrieval / memory reminder).
+		up := a.hookPayload(hooks.EventUserPromptSubmit)
+		up.UserInput = userInput
+		if s := a.Hooks.Inject(ctx, up); s != "" {
+			injected = append(injected, s)
+		}
+
+		if len(injected) > 0 {
+			text = strings.Join(injected, "\n\n") + "\n\n" + userInput
 		}
 	}
 	// Attachments (e.g. a pasted image) ride on the same user turn as the
@@ -366,10 +440,12 @@ func (a *Agent) appendUserInput(ctx context.Context, userInput string) {
 		}
 		blocks = append(blocks, a.pendingUserBlocks...)
 		a.pendingUserBlocks = nil
-		a.History.Append(Message{Role: RoleUser, Blocks: blocks})
+		a.History.Append(Message{Role: RoleUser, Blocks: blocks, CreatedAt: createdAt})
 		return
 	}
-	a.History.Append(NewUserMessage(text))
+	msg := NewUserMessage(text)
+	msg.CreatedAt = createdAt
+	a.History.Append(msg)
 }
 
 // StopReason sentinels set on the Reply when a loop budget is exhausted.
@@ -1579,6 +1655,11 @@ func (a *Agent) addUsage(inputTokens, outputTokens int) {
 func (a *Agent) ClearHistory() {
 	a.History.Reset()
 	a.resetContextTrigger()
+	// A wiped conversation is a fresh opening: re-arm SessionStart so the next
+	// turn fires with source=clear. Effective on transports that keep the Agent
+	// across turns (CLI/TUI/IM); serve rebuilds the Agent per turn, so its /clear
+	// re-opening is governed by the persisted flag instead.
+	a.HookClear = true
 }
 
 // resetContextTrigger zeroes the compaction-trigger context size under the

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -79,6 +79,12 @@ type Session struct {
 	// InFlight counts active turns on this session within the current process.
 	// It is not persisted; use LeaseEntry/LeaseExpires for cross-process checks.
 	InFlight int `json:"-"`
+
+	// HookStarted records that the SessionStart hook has fired for this session.
+	// Persisted in the meta line and shared across all three transports, so a
+	// re-attach resumes (SessionStart source=resume) rather than starting over.
+	// Set via MarkHookStarted.
+	HookStarted bool `json:"hook_started,omitempty"`
 }
 
 // Common entry names. Use these constants at call sites so typos are caught.
@@ -390,11 +396,27 @@ type sessionRecord struct {
 	BoundAt      time.Time `json:"bound_at,omitempty"`
 	LeaseEntry   string    `json:"lease_entry,omitempty"`
 	LeaseExpires time.Time `json:"lease_expires,omitempty"`
+	HookStarted  bool      `json:"hook_started,omitempty"`
 	Message      *Message  `json:"message,omitempty"`
 }
 
 func (s *Session) metaRecord() sessionRecord {
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt}
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted}
+}
+
+// MarkHookStarted records that SessionStart has fired for this session, so a
+// later attach (new process, or a resumed session) resumes rather than starting
+// over. The flag lives in the meta line, so it forces the next Save to rewrite
+// the file — a one-time O(n) cost per session. Idempotent; safe to call every
+// turn. Persistence rides the session layer's existing post-turn Save.
+func (s *Session) MarkHookStarted() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.HookStarted {
+		return
+	}
+	s.HookStarted = true
+	s.forceRewrite = true
 }
 
 func messageRecord(m Message) sessionRecord {
@@ -707,6 +729,7 @@ func LoadSession(id string) (*Session, error) {
 			s.ModelConfig = rec.ModelConfig
 			s.BoundEntry = rec.BoundEntry
 			s.BoundAt = rec.BoundAt
+			s.HookStarted = rec.HookStarted
 			s.InFlight = 0
 		case "title":
 			s.Title = rec.Title // last one wins

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -50,6 +50,28 @@ func TestSessionSourceRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSessionHookStartedRoundTrip(t *testing.T) {
+	setTempHome(t)
+	s := NewSession("m", "")
+	if s.HookStarted {
+		t.Fatal("new session must start with HookStarted=false")
+	}
+	s.MarkHookStarted()
+	if !s.HookStarted || !s.forceRewrite {
+		t.Fatalf("MarkHookStarted should set the flag and force a rewrite; got started=%v forceRewrite=%v", s.HookStarted, s.forceRewrite)
+	}
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if !got.HookStarted {
+		t.Fatal("HookStarted did not survive the round trip")
+	}
+}
+
 func TestSessionIDFormat(t *testing.T) {
 	s := NewSession("m", "")
 	// YYYYMMDD-HHMMSS-xxxxxxxx — 24 chars (15 timestamp + '-' + 8 hex suffix).

--- a/internal/agent/sessionstart_test.go
+++ b/internal/agent/sessionstart_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/hooks"
+)
+
+// sessionStartAgent builds an agent with an isolated hook engine carrying a
+// single in-process SessionStart hook that records the source it saw and
+// returns injected text.
+func sessionStartAgent(t *testing.T, id, inject string, sawSource *string) *Agent {
+	t.Helper()
+	send := &fakeSender{reply: Reply{Content: "ok"}}
+	a := New(send, "m")
+	a.HookMeta = hooks.Meta{SessionID: id}
+	a.Hooks = hooks.NewEngine(nil) // private seen-set → test isolation
+	a.Hooks.RegisterInProc(hooks.EventSessionStart, func(_ context.Context, p hooks.Payload) string {
+		*sawSource = p.Source
+		return inject
+	})
+	return a
+}
+
+func TestSessionStart_StartupFiresPersistsAndFolds(t *testing.T) {
+	var src string
+	a := sessionStartAgent(t, "s-startup", "[warmup]", &src)
+	var persisted bool
+	a.OnSessionStart = func() { persisted = true }
+
+	if _, err := a.Turn(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if src != hooks.SourceStartup {
+		t.Errorf("source = %q, want startup", src)
+	}
+	if !persisted {
+		t.Error("OnSessionStart must fire on startup so the layer persists the flag")
+	}
+	if !a.SessionStarted {
+		t.Error("SessionStarted must be set after startup")
+	}
+	send := a.Sender.(*fakeSender)
+	got := userText(send.gotMessages[0])
+	if !strings.Contains(got, "[warmup]") || !strings.HasSuffix(got, "hello") {
+		t.Errorf("SessionStart output not folded into the first user message: %q", got)
+	}
+}
+
+func TestSessionStart_ResumeWhenAlreadyStarted(t *testing.T) {
+	var src string
+	a := sessionStartAgent(t, "s-resume", "", &src)
+	a.SessionStarted = true // durable flag: started in a prior process
+
+	if _, err := a.Turn(context.Background(), "hi"); err != nil {
+		t.Fatal(err)
+	}
+	if src != hooks.SourceResume {
+		t.Errorf("source = %q, want resume (started before, first touch this process)", src)
+	}
+}
+
+func TestSessionStart_FiresOncePerAgent(t *testing.T) {
+	var src string
+	fires := 0
+	send := &fakeSender{reply: Reply{Content: "ok"}}
+	a := New(send, "m")
+	a.HookMeta = hooks.Meta{SessionID: "s-once"}
+	a.Hooks = hooks.NewEngine(nil)
+	a.Hooks.RegisterInProc(hooks.EventSessionStart, func(_ context.Context, p hooks.Payload) string {
+		fires++
+		src = p.Source
+		return ""
+	})
+
+	for i := 0; i < 3; i++ {
+		if _, err := a.Turn(context.Background(), "msg"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if fires != 1 {
+		t.Errorf("SessionStart fired %d times across 3 turns, want 1 (startup then quiet)", fires)
+	}
+	if src != hooks.SourceStartup {
+		t.Errorf("first fire source = %q, want startup", src)
+	}
+}
+
+func TestSessionStart_ClearReopensAsClear(t *testing.T) {
+	var src string
+	a := sessionStartAgent(t, "s-clear", "", &src)
+	a.SessionStarted = true // already open
+
+	a.ClearHistory() // arms HookClear
+	if _, err := a.Turn(context.Background(), "again"); err != nil {
+		t.Fatal(err)
+	}
+	if src != hooks.SourceClear {
+		t.Errorf("source after /clear = %q, want clear", src)
+	}
+	if a.HookClear {
+		t.Error("HookClear must be consumed after firing")
+	}
+}

--- a/internal/agent/toolresulthook_test.go
+++ b/internal/agent/toolresulthook_test.go
@@ -4,9 +4,21 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/Leihb/octo-agent/internal/hooks"
 )
 
-func TestToolResultHook_AppendsToMatchingResult(t *testing.T) {
+// postToolUseEngine returns an engine with a single in-process PostToolUse hook,
+// the shape the memory save-nudge takes after the redesign.
+func postToolUseEngine(fn func(name string, input map[string]any) string) *hooks.Engine {
+	e := hooks.NewEngine(nil)
+	e.RegisterInProc(hooks.EventPostToolUse, func(_ context.Context, p hooks.Payload) string {
+		return fn(p.ToolName, p.ToolInput)
+	})
+	return e
+}
+
+func TestPostToolUse_AppendsToMatchingResult(t *testing.T) {
 	send := &fakeToolSender{
 		replies: []Reply{
 			{
@@ -20,7 +32,7 @@ func TestToolResultHook_AppendsToMatchingResult(t *testing.T) {
 	}
 	exec := &fakeExecutor{results: map[string]string{"terminal": "merged"}}
 	a := New(send, "m")
-	a.ToolResultHook = func(name string, input map[string]any) string {
+	a.Hooks = postToolUseEngine(func(name string, input map[string]any) string {
 		if name != "terminal" {
 			t.Errorf("hook saw tool %q, want terminal", name)
 		}
@@ -28,7 +40,7 @@ func TestToolResultHook_AppendsToMatchingResult(t *testing.T) {
 			t.Errorf("hook saw command %q", cmd)
 		}
 		return "<nudge>"
-	}
+	})
 
 	if _, err := a.Run(context.Background(), "merge it", []ToolDefinition{{Name: "terminal"}}, exec); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -48,7 +60,7 @@ func TestToolResultHook_AppendsToMatchingResult(t *testing.T) {
 	}
 }
 
-func TestToolResultHook_EmptyReturnLeavesResultUntouched(t *testing.T) {
+func TestPostToolUse_EmptyReturnLeavesResultUntouched(t *testing.T) {
 	send := &fakeToolSender{
 		replies: []Reply{
 			{
@@ -62,7 +74,7 @@ func TestToolResultHook_EmptyReturnLeavesResultUntouched(t *testing.T) {
 	}
 	exec := &fakeExecutor{results: map[string]string{"terminal": "files"}}
 	a := New(send, "m")
-	a.ToolResultHook = func(string, map[string]any) string { return "" }
+	a.Hooks = postToolUseEngine(func(string, map[string]any) string { return "" })
 
 	if _, err := a.Run(context.Background(), "list", []ToolDefinition{{Name: "terminal"}}, exec); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -79,14 +91,16 @@ func TestToolResultHook_EmptyReturnLeavesResultUntouched(t *testing.T) {
 // A <system-reminder> span appended by the hook (memory save-nudge) is
 // model-facing: it must stay on the persisted block but never reach the UI
 // event stream, where it would render inside the tool card.
-func TestToolResultHook_ReminderStrippedFromEventOutput(t *testing.T) {
+func TestPostToolUse_ReminderStrippedFromEventOutput(t *testing.T) {
 	uses := []ContentBlock{
 		NewToolUseBlock("call-1", "terminal", map[string]any{"command": "gh pr create"}),
 	}
 	results := []ContentBlock{NewToolResultBlock("call-1", "created PR #7", false)}
-	applyToolResultHook(func(string, map[string]any) string {
+	a := New(&fakeSender{}, "m")
+	a.Hooks = postToolUseEngine(func(string, map[string]any) string {
 		return "<system-reminder>\nsave a memory\n</system-reminder>"
-	}, uses, results)
+	})
+	a.applyPostToolUse(context.Background(), uses, results)
 
 	if !strings.Contains(results[0].Result, "<system-reminder>") {
 		t.Fatalf("block must keep the reminder for the model: %q", results[0].Result)
@@ -116,7 +130,7 @@ func TestStripRemindersForDisplay(t *testing.T) {
 	}
 }
 
-func TestApplyToolResultHook_SkipsErroredAndUnmatched(t *testing.T) {
+func TestApplyPostToolUse_SkipsErroredAndUnmatched(t *testing.T) {
 	uses := []ContentBlock{
 		NewToolUseBlock("ok", "terminal", map[string]any{"command": "gh pr create"}),
 		NewToolUseBlock("bad", "terminal", map[string]any{"command": "gh pr merge"}),
@@ -126,11 +140,13 @@ func TestApplyToolResultHook_SkipsErroredAndUnmatched(t *testing.T) {
 		NewToolResultBlock("bad", "denied", true),
 	}
 	var seen []string
-	applyToolResultHook(func(name string, input map[string]any) string {
+	a := New(&fakeSender{}, "m")
+	a.Hooks = postToolUseEngine(func(name string, input map[string]any) string {
 		cmd, _ := input["command"].(string)
 		seen = append(seen, cmd)
 		return "N"
-	}, uses, results)
+	})
+	a.applyPostToolUse(context.Background(), uses, results)
 
 	if len(seen) != 1 || seen[0] != "gh pr create" {
 		t.Errorf("hook calls = %v, want only the successful call", seen)

--- a/internal/agent/userinputhook_test.go
+++ b/internal/agent/userinputhook_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/Leihb/octo-agent/internal/hooks"
 )
 
 // userText returns the plain text of a user message regardless of whether it's
@@ -21,31 +23,41 @@ func userText(m Message) string {
 	return ""
 }
 
-func TestUserInputHook_PrependsReminderAsSingleMessage(t *testing.T) {
+// promptSubmitEngine returns an engine with a single in-process UserPromptSubmit
+// hook, the shape the memory injector's reminder takes after the redesign.
+func promptSubmitEngine(fn func(userInput string) string) *hooks.Engine {
+	e := hooks.NewEngine(nil)
+	e.RegisterInProc(hooks.EventUserPromptSubmit, func(_ context.Context, p hooks.Payload) string {
+		return fn(p.UserInput)
+	})
+	return e
+}
+
+func TestUserPromptSubmit_PrependsInjectionAsSingleMessage(t *testing.T) {
 	send := &fakeSender{reply: Reply{Content: "ok"}}
 	a := New(send, "m")
-	a.UserInputHook = func(in string) string { return "<reminder>" + in + "</reminder>" }
+	a.Hooks = promptSubmitEngine(func(in string) string { return "<reminder>" + in + "</reminder>" })
 
 	if _, err := a.Turn(context.Background(), "deploy please"); err != nil {
 		t.Fatalf("Turn: %v", err)
 	}
 
 	if len(send.gotMessages) != 1 {
-		t.Fatalf("sender saw %d messages, want 1 (reminder must fold into the user turn)", len(send.gotMessages))
+		t.Fatalf("sender saw %d messages, want 1 (injection must fold into the user turn)", len(send.gotMessages))
 	}
 	got := userText(send.gotMessages[0])
 	if !strings.Contains(got, "<reminder>deploy please</reminder>") {
-		t.Errorf("reminder not prepended: %q", got)
+		t.Errorf("injection not prepended: %q", got)
 	}
 	if !strings.HasSuffix(got, "deploy please") {
 		t.Errorf("original input not preserved at the end: %q", got)
 	}
 }
 
-func TestUserInputHook_EmptyReturnLeavesInputUntouched(t *testing.T) {
+func TestUserPromptSubmit_EmptyReturnLeavesInputUntouched(t *testing.T) {
 	send := &fakeSender{reply: Reply{Content: "ok"}}
 	a := New(send, "m")
-	a.UserInputHook = func(string) string { return "" }
+	a.Hooks = promptSubmitEngine(func(string) string { return "" })
 
 	if _, err := a.Turn(context.Background(), "hello"); err != nil {
 		t.Fatalf("Turn: %v", err)
@@ -55,10 +67,10 @@ func TestUserInputHook_EmptyReturnLeavesInputUntouched(t *testing.T) {
 	}
 }
 
-func TestUserInputHook_ErrorPathPopsCombinedMessage(t *testing.T) {
+func TestUserPromptSubmit_ErrorPathPopsCombinedMessage(t *testing.T) {
 	send := &fakeSender{err: errors.New("boom")}
 	a := New(send, "m")
-	a.UserInputHook = func(in string) string { return "REMINDER\n\n" + in }
+	a.Hooks = promptSubmitEngine(func(in string) string { return "REMINDER\n\n" + in })
 
 	if _, err := a.Turn(context.Background(), "hi"); err == nil {
 		t.Fatal("expected error")

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/hooks"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
@@ -314,7 +315,25 @@ func (s *Spawner) runChild(ctx context.Context, lc *liveChild, prompt string) (r
 	s.parent.AccrueChildUsage(in, out)
 
 	lc.syncSession()
+	s.fireSubagentStop(r.Content)
 	return r.Content, in, out, r.StopReason, turns, nil
+}
+
+// fireSubagentStop dispatches the parent's SubagentStop hook after a child round
+// completes — the top-level session's signal that a spawned agent finished. Uses
+// the parent's hook identity (a child's own turns fire Stop separately if the
+// child has an engine). Background context so a cancelled parent turn doesn't
+// abort retention. No-op when the parent has no engine.
+func (s *Spawner) fireSubagentStop(reply string) {
+	if s.parent == nil || s.parent.Hooks == nil {
+		return
+	}
+	p := s.parent.HookMeta.Payload(hooks.EventSubagentStop)
+	if p.Model == "" {
+		p.Model = s.parent.Model
+	}
+	p.AssistantReply = reply
+	s.parent.Hooks.Dispatch(context.Background(), p)
 }
 
 // syncSession persists the child's conversation to disk when sessionDir was

--- a/internal/hooks/engine.go
+++ b/internal/hooks/engine.go
@@ -1,0 +1,285 @@
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Engine is the single hook-dispatch surface. It supersedes Runner: instead of
+// two hard-coded shell hooks (pre/post-turn) wired only in the CLI, it holds a
+// set of hooks per Event and is invoked from the agent core, so every transport
+// (CLI/TUI, serve web+IM, sub-agents) shares one dispatch path. It also carries
+// in-process hooks (Go funcs), which is how the memory injector's reminder /
+// save-nudge fold into the same pipeline the shell hooks use.
+//
+// One Engine per process, constructed in internal/app and attached to every
+// Agent (Agent.Hooks). The zero value is a valid no-op — Dispatch/Inject return
+// cleanly with no work done, so callers never branch on "are hooks configured".
+type Engine struct {
+	mu     sync.Mutex
+	shell  map[Event][]shellHook
+	inproc map[Event][]InProcHook
+
+	// seen is the process-level SessionStart seen-set. It is SHARED across every
+	// Engine in the process (serve rebuilds the Agent — and thus its Engine —
+	// every turn, and hosts many sessions), which is what makes resume fire once
+	// per OS process rather than once per turn. Never nil after NewEngine.
+	seen *SeenSet
+
+	// Notify surfaces hook failures / traces as REPL notices. Nil-safe.
+	Notify func(string)
+}
+
+// SeenSet records which sessions a process instance has already fired
+// SessionStart for. It is shared by pointer across all Engines in a process
+// (each Engine otherwise owns per-session in-process hooks) and carries its own
+// lock so that sharing is goroutine-safe independent of any Engine's lock.
+type SeenSet struct {
+	mu sync.Mutex
+	m  map[string]bool
+}
+
+// NewSeenSet returns an empty seen-set. Tests pass their own for isolation;
+// production engines share the process singleton via SharedSeen.
+func NewSeenSet() *SeenSet {
+	return &SeenSet{m: make(map[string]bool)}
+}
+
+// sharedSeen is the one process-level seen-set. SessionStart resume dedup is
+// inherently process-global (serve rebuilds the Agent every turn and hosts many
+// sessions), so every production Engine shares this instance.
+var sharedSeen = NewSeenSet()
+
+// SharedSeen returns the process-level seen-set. Pass it to NewEngine/
+// EngineFromEnv at every production construction site so resume fires once per
+// OS process rather than once per turn.
+func SharedSeen() *SeenSet { return sharedSeen }
+
+// markSeen records sessionID and reports whether it was already present.
+func (s *SeenSet) markSeen(sessionID string) (already bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	already = s.m[sessionID]
+	s.m[sessionID] = true
+	return already
+}
+
+// InProcHook is an in-process hook: a Go func invoked with the same Payload a
+// shell hook would receive on stdin. For injecting events it returns the text
+// to fold in ("" = nothing); for side-effect events the return is ignored. This
+// is the surface the memory injector registers on.
+type InProcHook func(ctx context.Context, p Payload) string
+
+// shellHook is one configured shell command for an event. matcher/async land in
+// a later phase; for now every shell hook runs synchronously and unconditionally.
+type shellHook struct {
+	command string
+	timeout time.Duration
+}
+
+// Session-start source labels (parity with Claude Code's SessionStart.source).
+const (
+	SourceStartup = "startup"
+	SourceResume  = "resume"
+	SourceClear   = "clear"
+)
+
+// NewEngine returns an empty engine ready for RegisterShell/RegisterInProc,
+// sharing the given process-level seen-set. Pass nil for a standalone engine
+// (tests, or a context with no cross-Agent sharing) and it allocates its own.
+func NewEngine(seen *SeenSet) *Engine {
+	if seen == nil {
+		seen = NewSeenSet()
+	}
+	return &Engine{
+		shell:  make(map[Event][]shellHook),
+		inproc: make(map[Event][]InProcHook),
+		seen:   seen,
+	}
+}
+
+// RegisterShell adds a shell command hook for an event. A zero timeout uses the
+// package default.
+func (e *Engine) RegisterShell(event Event, command string, timeout time.Duration) {
+	command = strings.TrimSpace(command)
+	if e == nil || command == "" {
+		return
+	}
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	} else if timeout > timeoutCeiling {
+		timeout = timeoutCeiling
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.shell == nil {
+		e.shell = make(map[Event][]shellHook)
+	}
+	e.shell[event] = append(e.shell[event], shellHook{command: command, timeout: timeout})
+}
+
+// RegisterInProc adds an in-process hook for an event.
+func (e *Engine) RegisterInProc(event Event, fn InProcHook) {
+	if e == nil || fn == nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.inproc == nil {
+		e.inproc = make(map[Event][]InProcHook)
+	}
+	e.inproc[event] = append(e.inproc[event], fn)
+}
+
+// Configured reports whether any hook (shell or in-process) is registered for
+// event. Callers use it to skip payload construction on the common no-hook path.
+func (e *Engine) Configured(event Event) bool {
+	if e == nil {
+		return false
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.shell[event]) > 0 || len(e.inproc[event]) > 0
+}
+
+// hooksFor snapshots the registered hooks for an event under the lock so
+// dispatch runs without holding it (a shell hook can block for its timeout).
+func (e *Engine) hooksFor(event Event) ([]shellHook, []InProcHook) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	sh := append([]shellHook(nil), e.shell[event]...)
+	ip := append([]InProcHook(nil), e.inproc[event]...)
+	return sh, ip
+}
+
+// Inject runs the hooks registered for an injecting event (SessionStart /
+// UserPromptSubmit / PostToolUse) and returns their combined output to fold into
+// the model stream. In-process hooks run first, then shell hooks, in
+// registration order; non-empty outputs are joined with a blank line. A shell
+// hook failure is surfaced via Notify and contributes no text — it never blocks
+// the turn. Returns "" when nothing was produced (or the engine is nil / the
+// event isn't an injecting one).
+func (e *Engine) Inject(ctx context.Context, p Payload) string {
+	if e == nil || !p.Event.injects() {
+		return ""
+	}
+	sh, ip := e.hooksFor(p.Event)
+	if len(sh) == 0 && len(ip) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, fn := range ip {
+		if out := strings.TrimSpace(fn(ctx, p)); out != "" {
+			parts = append(parts, out)
+		}
+	}
+	if out := e.runShellHooks(ctx, sh, p); out != "" {
+		parts = append(parts, out)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// Dispatch runs the hooks for a side-effect event (Stop / SubagentStop /
+// PreCompact): output is ignored, failures surface via Notify but never
+// propagate. Runs synchronously within each hook's timeout (async execution
+// lands in a later phase). No-op on a nil engine or an unconfigured event.
+func (e *Engine) Dispatch(ctx context.Context, p Payload) {
+	if e == nil {
+		return
+	}
+	sh, ip := e.hooksFor(p.Event)
+	for _, fn := range ip {
+		fn(ctx, p) // side-effect events ignore in-proc output
+	}
+	e.runShellHooks(ctx, sh, p)
+}
+
+// runShellHooks marshals the payload once and runs each shell hook, joining the
+// stdout of injecting events (parsed for the additional_context envelope) with
+// blank lines. Side-effect events discard the joined result. Failures go to
+// Notify.
+func (e *Engine) runShellHooks(ctx context.Context, hooks []shellHook, p Payload) string {
+	if len(hooks) == 0 {
+		return ""
+	}
+	stdin, err := json.Marshal(p)
+	if err != nil {
+		e.notify("hooks: marshal " + string(p.Event) + " payload: " + err.Error())
+		return ""
+	}
+	var parts []string
+	for _, h := range hooks {
+		out, err := execShell(ctx, h.command, stdin, h.timeout)
+		if err != nil {
+			e.notify(err.Error())
+			continue
+		}
+		if p.Event.injects() {
+			if txt := parsePreOutput(out); txt != "" {
+				parts = append(parts, txt)
+			}
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func (e *Engine) notify(msg string) {
+	if e != nil && e.Notify != nil {
+		e.Notify(msg)
+	}
+}
+
+// SessionStartDecision resolves the SessionStart source for a turn and reports
+// whether the event should fire, updating the process-level seen-set. Inputs:
+//
+//	persistedStarted — the session's durable "SessionStart has fired before"
+//	                   flag (shared across all three transports).
+//	isClear          — this turn follows a /clear (ClearHistory).
+//
+// Semantics (see the design doc's SessionStart section):
+//   - isClear                     → (clear, fire)
+//   - never started before        → (startup, fire)  [caller then persists the flag]
+//   - started, unseen this process → (resume, fire)   [a new OS process attached]
+//   - started, already seen        → ("", don't fire) [same process, later turn]
+//
+// The seen-set is why click-around / subsequent messages in one serve process
+// don't re-fire resume, while a process restart (empty seen-set) does.
+func (e *Engine) SessionStartDecision(sessionID string, persistedStarted, isClear bool) (source string, fire bool) {
+	if e == nil {
+		return "", false
+	}
+	switch {
+	case isClear:
+		e.seen.markSeen(sessionID)
+		return SourceClear, true
+	case !persistedStarted:
+		e.seen.markSeen(sessionID)
+		return SourceStartup, true
+	default:
+		if already := e.seen.markSeen(sessionID); !already {
+			return SourceResume, true
+		}
+		return "", false
+	}
+}
+
+// EngineFromEnv builds an Engine from the legacy OCTO_HOOK_* env vars, mapping
+// the pre-turn hook to UserPromptSubmit and the post-turn hook to Stop. This is
+// the compatibility shim: existing Hindsight wiring keeps working unchanged and
+// — because the engine is invoked in the agent core — now also fires on the web
+// and IM transports, not just the CLI. Always returns a usable engine.
+func EngineFromEnv(seen *SeenSet) *Engine {
+	e := NewEngine(seen)
+	r := LoadFromEnv() // reuse the env parsing + timeout ceiling
+	timeout := r.Timeout
+	if r.PreTurnCmd != "" {
+		e.RegisterShell(EventUserPromptSubmit, r.PreTurnCmd, timeout)
+	}
+	if r.PostTurnCmd != "" {
+		e.RegisterShell(EventStop, r.PostTurnCmd, timeout)
+	}
+	return e
+}

--- a/internal/hooks/engine_test.go
+++ b/internal/hooks/engine_test.go
@@ -1,0 +1,143 @@
+package hooks
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestEngine_NilSafe(t *testing.T) {
+	var e *Engine
+	if e.Configured(EventStop) {
+		t.Error("nil engine should report not configured")
+	}
+	if got := e.Inject(context.Background(), Payload{Event: EventUserPromptSubmit}); got != "" {
+		t.Errorf("nil engine Inject = %q; want empty", got)
+	}
+	e.Dispatch(context.Background(), Payload{Event: EventStop}) // must not panic
+	if src, fire := e.SessionStartDecision("s", false, false); fire || src != "" {
+		t.Errorf("nil engine SessionStartDecision = (%q,%v); want ('',false)", src, fire)
+	}
+}
+
+func TestEngine_InjectInProcThenShellOrder(t *testing.T) {
+	e := NewEngine(nil)
+	e.RegisterInProc(EventUserPromptSubmit, func(_ context.Context, _ Payload) string { return "from-inproc" })
+	e.RegisterShell(EventUserPromptSubmit, makeScript(t, "echo from-shell"), 0)
+
+	got := e.Inject(context.Background(), Payload{Event: EventUserPromptSubmit, UserInput: "hi"})
+	if got != "from-inproc\n\nfrom-shell" {
+		t.Errorf("Inject order/join wrong: %q", got)
+	}
+}
+
+func TestEngine_InjectShellStructuredEnvelope(t *testing.T) {
+	e := NewEngine(nil)
+	e.RegisterShell(EventUserPromptSubmit, makeScript(t, `echo '{"additional_context":"ctx"}'`), 0)
+	if got := e.Inject(context.Background(), Payload{Event: EventUserPromptSubmit}); got != "ctx" {
+		t.Errorf("structured envelope not parsed: %q", got)
+	}
+}
+
+func TestEngine_InjectShellFailureIsNonBlocking(t *testing.T) {
+	e := NewEngine(nil)
+	var notices []string
+	e.Notify = func(m string) { notices = append(notices, m) }
+	e.RegisterInProc(EventUserPromptSubmit, func(_ context.Context, _ Payload) string { return "kept" })
+	e.RegisterShell(EventUserPromptSubmit, makeScript(t, "echo boom >&2; exit 1"), 0)
+
+	got := e.Inject(context.Background(), Payload{Event: EventUserPromptSubmit})
+	if got != "kept" {
+		t.Errorf("failing shell hook should not drop in-proc output; got %q", got)
+	}
+	if len(notices) != 1 || !strings.Contains(notices[0], "boom") {
+		t.Errorf("shell failure should surface via Notify: %v", notices)
+	}
+}
+
+func TestEngine_InjectIgnoresSideEffectEvent(t *testing.T) {
+	e := NewEngine(nil)
+	e.RegisterShell(EventStop, makeScript(t, "echo should-not-inject"), 0)
+	if got := e.Inject(context.Background(), Payload{Event: EventStop}); got != "" {
+		t.Errorf("Inject on a side-effect event must return empty; got %q", got)
+	}
+}
+
+func TestEngine_DispatchRunsSideEffectAndIgnoresOutput(t *testing.T) {
+	e := NewEngine(nil)
+	dir := t.TempDir()
+	marker := dir + "/ran"
+	e.RegisterShell(EventStop, makeScript(t, "touch "+marker), 0)
+	e.Dispatch(context.Background(), Payload{Event: EventStop, AssistantReply: "done"})
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("side-effect hook did not run: %v", err)
+	}
+}
+
+func TestEngine_PostToolUsePayloadReachesStdin(t *testing.T) {
+	e := NewEngine(nil)
+	dir := t.TempDir()
+	out := dir + "/captured.json"
+	e.RegisterShell(EventPostToolUse, makeScript(t, "cat > "+out), 0)
+	e.Inject(context.Background(), Payload{
+		Event:     EventPostToolUse,
+		ToolName:  "terminal",
+		ToolInput: map[string]any{"command": "ls"},
+	})
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"event":"PostToolUse"`, `"tool_name":"terminal"`, `"command":"ls"`} {
+		if !strings.Contains(string(b), want) {
+			t.Errorf("payload missing %q in:\n%s", want, b)
+		}
+	}
+}
+
+func TestEngine_SessionStartDecision(t *testing.T) {
+	e := NewEngine(nil)
+
+	// /clear always wins.
+	if src, fire := e.SessionStartDecision("c", true, true); !fire || src != SourceClear {
+		t.Errorf("clear = (%q,%v); want (clear,true)", src, fire)
+	}
+
+	// Never started → startup, once.
+	if src, fire := e.SessionStartDecision("a", false, false); !fire || src != SourceStartup {
+		t.Errorf("first = (%q,%v); want (startup,true)", src, fire)
+	}
+	// Same process, later turn → no fire even though it "started".
+	if src, fire := e.SessionStartDecision("a", true, false); fire || src != "" {
+		t.Errorf("seen-again = (%q,%v); want ('',false)", src, fire)
+	}
+}
+
+func TestEngine_ResumeOncePerProcess(t *testing.T) {
+	e := NewEngine(nil)
+	// A previously-started session first touched by THIS process → resume.
+	if src, fire := e.SessionStartDecision("b", true, false); !fire || src != SourceResume {
+		t.Errorf("first-touch of started session = (%q,%v); want (resume,true)", src, fire)
+	}
+	// Subsequent turns in the same process → no fire.
+	if src, fire := e.SessionStartDecision("b", true, false); fire || src != "" {
+		t.Errorf("resume should fire once per process; got (%q,%v)", src, fire)
+	}
+}
+
+func TestEngineFromEnv_MapsPreAndPost(t *testing.T) {
+	t.Setenv("OCTO_HOOK_PRE_TURN", "/bin/pre")
+	t.Setenv("OCTO_HOOK_POST_TURN", "/bin/post")
+	t.Setenv("OCTO_HOOK_TIMEOUT", "")
+	e := EngineFromEnv(nil)
+	if !e.Configured(EventUserPromptSubmit) {
+		t.Error("PRE_TURN should map to UserPromptSubmit")
+	}
+	if !e.Configured(EventStop) {
+		t.Error("POST_TURN should map to Stop")
+	}
+	if e.Configured(EventPreToolUse) {
+		t.Error("nothing should be registered for PreToolUse")
+	}
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -154,7 +154,16 @@ func (r *Runner) Post(ctx context.Context, userInput, assistantReply string) err
 // write `OCTO_HOOK_PRE_TURN="./script | filter"` pipelines without quoting the
 // shell themselves, in that platform's syntax.
 func (r *Runner) run(ctx context.Context, cmd string, stdin []byte) ([]byte, error) {
-	deadline := r.timeout()
+	return execShell(ctx, cmd, stdin, r.timeout())
+}
+
+// execShell runs cmd through the platform shell with stdin piped in, bounded by
+// deadline. Shared by the legacy Runner and the Engine so the timeout/kill/
+// stderr-tail behaviour stays identical across both. On a non-zero exit it
+// returns whatever stdout was captured plus an error whose wording distinguishes
+// a timeout from a plain failure (with the stderr tail folded in) to help users
+// debug hook wiring.
+func execShell(ctx context.Context, cmd string, stdin []byte, deadline time.Duration) ([]byte, error) {
 	rctx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()
 
@@ -170,9 +179,6 @@ func (r *Runner) run(ctx context.Context, cmd string, stdin []byte) ([]byte, err
 	// is plenty for the kernel to tear down the process group.
 	c.WaitDelay = time.Second
 	if err := c.Run(); err != nil {
-		// Distinguish timeout from a script that just exit-1'd. Either
-		// way the caller will surface the message but the wording
-		// helps the user debug Hindsight wiring.
 		if errors.Is(rctx.Err(), context.DeadlineExceeded) {
 			return out.Bytes(), fmt.Errorf("hooks: %s timed out after %s", cmd, deadline)
 		}

--- a/internal/hooks/payload.go
+++ b/internal/hooks/payload.go
@@ -1,0 +1,101 @@
+package hooks
+
+// Event names the lifecycle points at which the engine dispatches hooks. The
+// set and semantics mirror Claude Code's hook model (so a CC hook script ports
+// with only field-name changes), but the stdin/stdout field names are
+// octo-native (see payload.go / the design doc's "Parity 定位").
+type Event string
+
+const (
+	// EventSessionStart fires once per logical session opening (see
+	// SessionStartSource for the startup/resume/clear discrimination). Its
+	// stdout is injected into the first user message and thus persisted.
+	EventSessionStart Event = "SessionStart"
+	// EventUserPromptSubmit fires before each user turn. Its stdout is folded
+	// into that turn's user message (fresh every turn, persisted per-turn).
+	EventUserPromptSubmit Event = "UserPromptSubmit"
+	// EventPreToolUse fires before each tool dispatch. It can block/allow a
+	// tool (blocking protocol lands in a later phase).
+	EventPreToolUse Event = "PreToolUse"
+	// EventPostToolUse fires after each successful tool result. Its stdout is
+	// appended to that tool_result's text.
+	EventPostToolUse Event = "PostToolUse"
+	// EventStop fires when an assistant turn ends — on success AND on
+	// failure/interrupt. Side-effect only (retention); stdout ignored.
+	EventStop Event = "Stop"
+	// EventSubagentStop fires when a spawned sub-agent finishes. Side-effect
+	// only.
+	EventSubagentStop Event = "SubagentStop"
+	// EventPreCompact fires before history compaction. Side-effect only.
+	EventPreCompact Event = "PreCompact"
+)
+
+// injects reports whether an event's hook stdout is folded back into the model
+// stream. Side-effect events (Stop/SubagentStop/PreCompact) discard stdout.
+func (e Event) injects() bool {
+	switch e {
+	case EventSessionStart, EventUserPromptSubmit, EventPostToolUse:
+		return true
+	default:
+		return false
+	}
+}
+
+// Payload is the JSON envelope written to a hook's stdin. Every event carries
+// the common fields (session_id / cwd / transcript_path / model / transport);
+// event-specific fields are populated only for the events that define them and
+// omitted otherwise. This is the surface external retrieval layers key on — the
+// pre-redesign hooks passed only user_input, which is why a hook couldn't tell
+// which session or transport it was serving.
+type Payload struct {
+	Event          Event  `json:"event"`
+	SessionID      string `json:"session_id,omitempty"`
+	Cwd            string `json:"cwd,omitempty"`
+	TranscriptPath string `json:"transcript_path,omitempty"`
+	Model          string `json:"model,omitempty"`
+	Transport      string `json:"transport,omitempty"`
+
+	// SessionStart.
+	Source string `json:"source,omitempty"` // startup | resume | clear
+
+	// UserPromptSubmit / Stop.
+	UserInput string `json:"user_input,omitempty"`
+
+	// PreToolUse / PostToolUse.
+	ToolName  string         `json:"tool_name,omitempty"`
+	ToolInput map[string]any `json:"tool_input,omitempty"`
+
+	// PostToolUse.
+	ToolResult string `json:"tool_result,omitempty"`
+
+	// Stop.
+	AssistantReply string   `json:"assistant_reply,omitempty"`
+	ToolsUsed      []string `json:"tools_used,omitempty"`
+	Error          string   `json:"error,omitempty"` // set on a failed/interrupted turn; empty on success
+}
+
+// Meta is the per-session identity the agent folds into every hook Payload's
+// common envelope. The session-owning layer (CLI/server) sets it on the Agent
+// before a run, the way Session.ChunkDir sets the archive dir; the agent then
+// stamps the event-specific fields per call. Keeping it in one struct means the
+// agent's insertion points don't each re-plumb five identity fields.
+type Meta struct {
+	SessionID      string
+	Transport      string // cli | tui | web | im | subagent
+	TranscriptPath string
+	Cwd            string
+	Model          string
+}
+
+// Payload seeds a Payload for event with the common envelope from m. Callers
+// fill in the event-specific fields (UserInput, ToolName, …) afterwards.
+func (m Meta) Payload(event Event) Payload {
+	return Payload{
+		Event:          event,
+		SessionID:      m.SessionID,
+		Cwd:            m.Cwd,
+		TranscriptPath: m.TranscriptPath,
+		Model:          m.Model,
+		Transport:      m.Transport,
+	}
+}

--- a/internal/memory/injector.go
+++ b/internal/memory/injector.go
@@ -12,8 +12,11 @@ package memory
 // memory directory while the moment is still in front of it.
 
 import (
+	"context"
 	"regexp"
 	"strings"
+
+	"github.com/Leihb/octo-agent/internal/hooks"
 )
 
 // Injector holds session-scoped recall state for a parsed rule set.
@@ -160,8 +163,9 @@ const saveNudgeText = "<system-reminder>\n" +
 	"A pull request was just created or merged. If this work settled anything durable — a decision (especially an approach ruled OUT), a milestone, or a constraint future sessions must respect — record it in your memory directory now, per the Memory section of your instructions. The diff and git log already hold WHAT changed; memory is for the why, the alternatives rejected, and the don't-redo-this. If nothing here is durable, carry on.\n" +
 	"</system-reminder>"
 
-// SaveNudge is the agent's ToolResultHook: it returns the save-nudge reminder
-// when toolName/input is a milestone-shaped terminal command, at most once per
+// SaveNudge backs the PostToolUse hook (see RegisterHooks): it returns the
+// save-nudge reminder when toolName/input is a milestone-shaped terminal
+// command, at most once per
 // user turn (Reminder re-arms it). It is called serially from the agent run
 // loop, so the latch needs no locking.
 func (in *Injector) SaveNudge(toolName string, input map[string]any) string {
@@ -174,4 +178,23 @@ func (in *Injector) SaveNudge(toolName string, input map[string]any) string {
 	}
 	in.nudged = true
 	return saveNudgeText
+}
+
+// RegisterHooks wires the injector into a hook engine as in-process hooks: the
+// per-turn reminder on UserPromptSubmit and the milestone save-nudge on
+// PostToolUse. This replaces the old direct assignment to the Agent's
+// single-slot UserInputHook/ToolResultHook, so the memory reminders flow through
+// the same dispatch path as shell hooks. The injector's per-session latches
+// (recall map, nudge flag) live on the receiver, so each session registers its
+// own injector on its own engine.
+func (in *Injector) RegisterHooks(e *hooks.Engine) {
+	if in == nil || e == nil {
+		return
+	}
+	e.RegisterInProc(hooks.EventUserPromptSubmit, func(_ context.Context, p hooks.Payload) string {
+		return in.Reminder(p.UserInput)
+	})
+	e.RegisterInProc(hooks.EventPostToolUse, func(_ context.Context, p hooks.Payload) string {
+		return in.SaveNudge(p.ToolName, p.ToolInput)
+	})
 }

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/channel"
+	"github.com/Leihb/octo-agent/internal/hooks"
 	"github.com/Leihb/octo-agent/internal/tools"
 )
 
@@ -334,11 +335,11 @@ func TestHandleChannelMessage_WiresMemoryHooks(t *testing.T) {
 	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
 
 	sess := srv.channelMgr.GetSession(evFor("x"))
-	if sess.Agent.UserInputHook == nil {
-		t.Error("IM agent missing UserInputHook (keyword reminders)")
+	if !sess.Agent.Hooks.Configured(hooks.EventUserPromptSubmit) {
+		t.Error("IM agent missing UserPromptSubmit hook (keyword reminders)")
 	}
-	if sess.Agent.ToolResultHook == nil {
-		t.Error("IM agent missing ToolResultHook (save-nudge)")
+	if !sess.Agent.Hooks.Configured(hooks.EventPostToolUse) {
+		t.Error("IM agent missing PostToolUse hook (save-nudge)")
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/app"
 	"github.com/Leihb/octo-agent/internal/channel"
+	"github.com/Leihb/octo-agent/internal/hooks"
 
 	// The IM adapters self-register into the channel registry at init time.
 	// The server is what runs them (startChannels) and looks them up by name
@@ -948,13 +949,17 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	}
 	a.System, a.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), memInjection, true)
 
-	// L2: attention-layer rules injected per user turn (triggered keywords),
-	// plus the save-nudge appended to milestone tool results.
+	// L2: attention-layer rules (triggered keywords) + save-nudge on milestone
+	// tool results, plus any shell hooks (env/hooks.yml), unified on the agent's
+	// hook engine. Shares the process seen-set so SessionStart resume fires once
+	// per OS process across the serve process's many sessions.
+	hookEngine := hooks.EngineFromEnv(hooks.SharedSeen())
+	hookEngine.Notify = func(m string) { slog.Warn("hook", "err", m) }
 	if s.memDir != "" {
-		inj := s.injectorFor(sess.ID)
-		a.UserInputHook = inj.Reminder
-		a.ToolResultHook = inj.SaveNudge
+		s.injectorFor(sess.ID).RegisterHooks(hookEngine)
 	}
+	a.Hooks = hookEngine
+	a.HookMeta = hooks.Meta{SessionID: sess.ID, Transport: sess.BoundEntry, Cwd: cwd}
 
 	if len(sess.Messages) > 0 {
 		a.History = sess.ToHistory()
@@ -1903,14 +1908,16 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	cwd, envCtx := s.curCwdEnv()
 	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), memInjection, true)
 
-	// L2 memory hooks, same pair buildAgent gives web turns: keyword
-	// reminders on user input, save-nudge on milestone tool results. The
-	// injector is session-sticky (recall latch) and dropped on /unbind.
+	// L2 memory hooks + shell hooks, same engine buildAgent gives web turns,
+	// rebuilt per IM turn. The injector is session-sticky (recall latch) and
+	// dropped on /unbind; a fresh engine each turn just re-registers it.
+	imEngine := hooks.EngineFromEnv(hooks.SharedSeen())
+	imEngine.Notify = func(m string) { slog.Warn("hook", "err", m) }
 	if s.memDir != "" {
-		inj := s.injectorFor("im:" + string(sess.Key))
-		sess.Agent.UserInputHook = inj.Reminder
-		sess.Agent.ToolResultHook = inj.SaveNudge
+		s.injectorFor("im:" + string(sess.Key)).RegisterHooks(imEngine)
 	}
+	sess.Agent.Hooks = imEngine
+	sess.Agent.HookMeta = hooks.Meta{SessionID: string(sess.Key), Transport: agent.EntryChannel, Cwd: cwd}
 
 	// Per-turn permission gate, the same shape prepareToolTurn gives web
 	// turns: configured mode + an interactive ask that prompts in the chat

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -960,6 +960,11 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	}
 	a.Hooks = hookEngine
 	a.HookMeta = hooks.Meta{SessionID: sess.ID, Transport: sess.BoundEntry, Cwd: cwd}
+	if p, err := sess.SavePath(); err == nil {
+		a.HookMeta.TranscriptPath = p
+	}
+	a.SessionStarted = sess.HookStarted
+	a.OnSessionStart = func() { sess.MarkHookStarted() }
 
 	if len(sess.Messages) > 0 {
 		a.History = sess.ToHistory()
@@ -1918,6 +1923,17 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	}
 	sess.Agent.Hooks = imEngine
 	sess.Agent.HookMeta = hooks.Meta{SessionID: string(sess.Key), Transport: agent.EntryChannel, Cwd: cwd}
+	// The persisted backing session (Store) carries the durable SessionStart
+	// flag + transcript path; IM persists it after each turn, so MarkHookStarted
+	// rides that Save. Store can be tombstoned by a concurrent /unbind — nil-skip.
+	if st := sess.Store; st != nil {
+		sess.Agent.HookMeta.SessionID = st.ID
+		if p, err := st.SavePath(); err == nil {
+			sess.Agent.HookMeta.TranscriptPath = p
+		}
+		sess.Agent.SessionStarted = st.HookStarted
+		sess.Agent.OnSessionStart = func() { st.MarkHookStarted() }
+	}
 
 	// Per-turn permission gate, the same shape prepareToolTurn gives web
 	// turns: configured mode + an interactive ask that prompts in the chat

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1018,6 +1018,11 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		// RunStream appends the user input.
 		a.AttachUserBlocks(blocks)
 	}
+	// The persisted user message RunStream appends must carry the SAME created_at
+	// we broadcast live above, or the frontend double-renders it. Hand the
+	// pre-stamped timestamp to the turn rather than letting appendUserInput mint
+	// a second, later one.
+	a.AttachUserCreatedAt(userMsg.CreatedAt)
 
 	// Flush any steer messages that arrived before the Agent was built into
 	// the Agent's Inbox so the runLoop can drain them between iterations.


### PR DESCRIPTION
First implementation PR of the hooks redesign (design: `dev-docs/hooks-redesign.md`, #1001).

Merges octo's two disjoint hook mechanisms — env-configured shell pre/post-turn + hard-wired in-agent Go-func hooks — into **one `hooks.Engine` invoked from the agent core**, so every transport (CLI/TUI, serve web+IM, sub-agents) shares one dispatch path.

## What lands
- **`hooks.Engine`** — one dispatch surface for shell hooks (env shim) and in-process hooks (memory reminder + save-nudge); rich `Payload` envelope (session_id/cwd/transcript/model/transport + per-event fields); process-shared `SeenSet`.
- **Agent-core insertion** — `UserPromptSubmit` (at `appendUserInput`), `PostToolUse` (tool-result site), `Stop` (turn end, **success AND failure**, with `tools_used`/`error`), `SessionStart` (startup/resume/clear), `SubagentStop` (from the parent when a child finishes).
- **SessionStart semantics** — durable `Session.HookStarted` flag (persisted in JSONL meta) + process seen-set: `startup` once ever, `resume` once per OS process, `clear` after `/clear`. Output folds into the first user message so it survives serve's per-turn Agent rebuild.
- **Memory migration** — `Injector.RegisterHooks` moves reminder/save-nudge onto the engine; the Agent's single-slot `UserInputHook`/`ToolResultHook` are removed.
- **Env shim** — `OCTO_HOOK_PRE_TURN`→UserPromptSubmit, `POST_TURN`→Stop; existing Hindsight wiring keeps working and now fires on web+IM too.
- **Latent flake fix** — the web turn hands its pre-stamped user-message `created_at` to the turn (`AttachUserCreatedAt`) so the live broadcast and persisted copy share one dedup key deterministically.

## Defects closed (of the 11 in the design)
#1 three-transport parity · #3 (partial: 5 of 7 events) · #7 rich context · #8 tools_used · #9 Stop-on-failure · #10 single-slot→engine · #11 sub-agent coverage.

Remaining for later PRs: #2 blocking (PreToolUse), #4 matchers/arrays, #5 project `hooks.yml` + trust-on-first-use, #6 async spill-to-disk, #3 remainder (PreToolUse/PreCompact).

## Design refinement vs the doc
The doc said "one Engine per process"; implementation is **per-Agent engine sharing a process-level `SeenSet`**, because the memory injector carries per-session state. Behaviour matches the design; I'll touch up that one line in the doc.

## Tests
New engine unit tests, agent-level SessionStart tests, session `HookStarted` round-trip, migrated UserPromptSubmit/PostToolUse tests. `go build` + `go vet` + `go test -race ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)