### PR TITLE
feat(hooks): user-level hooks.yml config + matchers + arrays (PR2)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -759,7 +759,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// injector's reminder & save-nudge as in-process hooks, unified on one
 	// dispatch path that the agent core drives for every transport. Shares the
 	// process seen-set so SessionStart resume fires once per OS process.
-	hookEngine := hooks.EngineFromEnv(hooks.SharedSeen())
+	hookEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen())
 	hookEngine.Notify = func(m string) { fmt.Fprintln(stderr, "↳ hook: "+m) }
 	if memDir != "" {
 		rules := memory.ParseRules(memDir)

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -1,0 +1,114 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FileConfig is the on-disk hooks.yml schema. It maps each event to a list of
+// hooks, so an event can fan out to several commands (unlike the env shim's one
+// command per event). The user-level file lives at ~/.octo/hooks.yml; a
+// project-level <cwd>/.octo/hooks.yml layers on top (later phase).
+//
+//	hooks:
+//	  UserPromptSubmit:
+//	    - command: "hindsight-retrieve"
+//	      timeout: 5s
+//	  PostToolUse:
+//	    - matcher: "terminal|write_file"   # regexp over the tool name
+//	      command: "audit-logger"
+type FileConfig struct {
+	Hooks map[string][]HookSpec `yaml:"hooks"`
+}
+
+// HookSpec is one configured hook. Matcher is a regexp over the tool name,
+// honoured only for PreToolUse/PostToolUse. Timeout is a Go duration string
+// ("5s"); empty uses the package default.
+type HookSpec struct {
+	Command string `yaml:"command"`
+	Matcher string `yaml:"matcher,omitempty"`
+	Timeout string `yaml:"timeout,omitempty"`
+}
+
+// UserConfigPath returns ~/.octo/hooks.yml, or "" when the home dir is
+// unavailable.
+func UserConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "hooks.yml")
+}
+
+// LoadFileConfig reads and parses a hooks.yml. A missing file returns an error
+// satisfying os.IsNotExist, which callers treat as "no config" rather than a
+// failure.
+func LoadFileConfig(path string) (FileConfig, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return FileConfig{}, err
+	}
+	var fc FileConfig
+	if err := yaml.Unmarshal(b, &fc); err != nil {
+		return FileConfig{}, fmt.Errorf("hooks: parse %s: %w", path, err)
+	}
+	return fc, nil
+}
+
+// LoadConfig registers every hook in fc on the engine, appending to whatever is
+// already registered (env shim, a prior file). A hook is validated as it lands:
+// an unknown event name or a bad matcher regexp is a hard error naming the
+// offending entry, so a typo surfaces instead of silently doing nothing.
+func (e *Engine) LoadConfig(fc FileConfig) error {
+	if e == nil {
+		return nil
+	}
+	for name, specs := range fc.Hooks {
+		ev := Event(name)
+		if !ev.valid() {
+			return fmt.Errorf("hooks: unknown event %q in hooks.yml", name)
+		}
+		for _, s := range specs {
+			if err := e.RegisterShellMatched(ev, s.Command, s.Matcher, parseTimeout(s.Timeout)); err != nil {
+				return fmt.Errorf("hooks: %s: invalid matcher %q: %w", name, s.Matcher, err)
+			}
+		}
+	}
+	return nil
+}
+
+// parseTimeout turns a duration string into a Duration, returning 0 (→ package
+// default, applied downstream) for empty or unparseable input.
+func parseTimeout(s string) time.Duration {
+	if s == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 0
+	}
+	return d
+}
+
+// EngineFromEnvAndFiles builds the production engine: the OCTO_HOOK_* env shim
+// plus the user-level ~/.octo/hooks.yml layered on top (append semantics). A
+// missing file is fine; a malformed file or a bad entry is surfaced via Notify
+// and otherwise ignored, so one broken hook never blocks the session.
+func EngineFromEnvAndFiles(seen *SeenSet) *Engine {
+	e := EngineFromEnv(seen)
+	if p := UserConfigPath(); p != "" {
+		switch fc, err := LoadFileConfig(p); {
+		case err == nil:
+			if cerr := e.LoadConfig(fc); cerr != nil {
+				e.notify(cerr.Error())
+			}
+		case !os.IsNotExist(err):
+			e.notify(err.Error())
+		}
+	}
+	return e
+}

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -1,0 +1,120 @@
+package hooks
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig_RegistersMultipleHooksPerEvent(t *testing.T) {
+	e := NewEngine(nil)
+	fc := FileConfig{Hooks: map[string][]HookSpec{
+		"UserPromptSubmit": {
+			{Command: makeScript(t, "echo one")},
+			{Command: makeScript(t, "echo two")},
+		},
+	}}
+	if err := e.LoadConfig(fc); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	got := e.Inject(context.Background(), Payload{Event: EventUserPromptSubmit})
+	if got != "one\n\ntwo" {
+		t.Errorf("both hooks should run in order: %q", got)
+	}
+}
+
+func TestLoadConfig_RejectsUnknownEvent(t *testing.T) {
+	e := NewEngine(nil)
+	err := e.LoadConfig(FileConfig{Hooks: map[string][]HookSpec{
+		"Nonsense": {{Command: "true"}},
+	}})
+	if err == nil {
+		t.Fatal("unknown event name must be rejected, not silently ignored")
+	}
+}
+
+func TestLoadConfig_RejectsBadMatcher(t *testing.T) {
+	e := NewEngine(nil)
+	err := e.LoadConfig(FileConfig{Hooks: map[string][]HookSpec{
+		"PostToolUse": {{Command: "true", Matcher: "("}}, // unbalanced paren
+	}})
+	if err == nil {
+		t.Fatal("an invalid matcher regexp must be a hard error")
+	}
+}
+
+func TestMatcher_GatesPostToolUseByToolName(t *testing.T) {
+	e := NewEngine(nil)
+	if err := e.LoadConfig(FileConfig{Hooks: map[string][]HookSpec{
+		"PostToolUse": {{Command: makeScript(t, "echo matched"), Matcher: "terminal"}},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Matching tool → hook runs.
+	if got := e.Inject(context.Background(), Payload{Event: EventPostToolUse, ToolName: "terminal"}); got != "matched" {
+		t.Errorf("matcher should run for terminal; got %q", got)
+	}
+	// Non-matching tool → skipped.
+	if got := e.Inject(context.Background(), Payload{Event: EventPostToolUse, ToolName: "read_file"}); got != "" {
+		t.Errorf("matcher should skip read_file; got %q", got)
+	}
+}
+
+func TestMatcher_IgnoredForNonToolEvents(t *testing.T) {
+	e := NewEngine(nil)
+	// A matcher on UserPromptSubmit is meaningless (no tool name); it must not
+	// suppress the hook.
+	if err := e.LoadConfig(FileConfig{Hooks: map[string][]HookSpec{
+		"UserPromptSubmit": {{Command: makeScript(t, "echo ran"), Matcher: "terminal"}},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.Inject(context.Background(), Payload{Event: EventUserPromptSubmit}); got != "ran" {
+		t.Errorf("matcher must be ignored for non-tool events; got %q", got)
+	}
+}
+
+func TestLoadFileConfig_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yml")
+	yaml := "hooks:\n  Stop:\n    - command: \"retain\"\n      timeout: 3s\n  PostToolUse:\n    - matcher: \"terminal\"\n      command: \"log\"\n"
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fc, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+	if len(fc.Hooks["Stop"]) != 1 || fc.Hooks["Stop"][0].Command != "retain" || fc.Hooks["Stop"][0].Timeout != "3s" {
+		t.Errorf("Stop hook parsed wrong: %+v", fc.Hooks["Stop"])
+	}
+	if fc.Hooks["PostToolUse"][0].Matcher != "terminal" {
+		t.Errorf("PostToolUse matcher parsed wrong: %+v", fc.Hooks["PostToolUse"])
+	}
+
+	e := NewEngine(nil)
+	if err := e.LoadConfig(fc); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !e.Configured(EventStop) || !e.Configured(EventPostToolUse) {
+		t.Error("engine should be configured for both events after load")
+	}
+}
+
+func TestLoadFileConfig_MissingIsNotExist(t *testing.T) {
+	_, err := LoadFileConfig(filepath.Join(t.TempDir(), "absent.yml"))
+	if !os.IsNotExist(err) {
+		t.Errorf("missing file should return an os.IsNotExist error, got %v", err)
+	}
+}
+
+func TestParseTimeout(t *testing.T) {
+	cases := map[string]bool{"5s": true, "": false, "garbage": false, "-1s": false}
+	for in, wantNonZero := range cases {
+		if got := parseTimeout(in); (got > 0) != wantNonZero {
+			t.Errorf("parseTimeout(%q) = %v", in, got)
+		}
+	}
+}

--- a/internal/hooks/engine.go
+++ b/internal/hooks/engine.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"context"
 	"encoding/json"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -73,11 +74,28 @@ func (s *SeenSet) markSeen(sessionID string) (already bool) {
 // is the surface the memory injector registers on.
 type InProcHook func(ctx context.Context, p Payload) string
 
-// shellHook is one configured shell command for an event. matcher/async land in
-// a later phase; for now every shell hook runs synchronously and unconditionally.
+// shellHook is one configured shell command for an event. matcher, when set,
+// gates the hook on the tool name for the tool events (PreToolUse/PostToolUse);
+// it is ignored for the other events. Async execution lands in a later phase;
+// for now every shell hook runs synchronously.
 type shellHook struct {
 	command string
+	matcher *regexp.Regexp // nil → match every tool
 	timeout time.Duration
+}
+
+// matches reports whether this hook should run for the given event/tool. A nil
+// matcher, or any non-tool event, matches unconditionally.
+func (h shellHook) matches(event Event, toolName string) bool {
+	if h.matcher == nil {
+		return true
+	}
+	switch event {
+	case EventPreToolUse, EventPostToolUse:
+		return h.matcher.MatchString(toolName)
+	default:
+		return true
+	}
 }
 
 // Session-start source labels (parity with Claude Code's SessionStart.source).
@@ -101,12 +119,28 @@ func NewEngine(seen *SeenSet) *Engine {
 	}
 }
 
-// RegisterShell adds a shell command hook for an event. A zero timeout uses the
-// package default.
+// RegisterShell adds a shell command hook for an event, matching every tool. A
+// zero timeout uses the package default.
 func (e *Engine) RegisterShell(event Event, command string, timeout time.Duration) {
+	_ = e.RegisterShellMatched(event, command, "", timeout)
+}
+
+// RegisterShellMatched adds a shell command hook whose matcher (a regexp over
+// the tool name, honoured only for PreToolUse/PostToolUse) gates whether it
+// runs. An empty matcher matches every tool. A zero timeout uses the package
+// default. Returns an error only when matcher is not a valid regexp.
+func (e *Engine) RegisterShellMatched(event Event, command, matcher string, timeout time.Duration) error {
 	command = strings.TrimSpace(command)
 	if e == nil || command == "" {
-		return
+		return nil
+	}
+	var re *regexp.Regexp
+	if m := strings.TrimSpace(matcher); m != "" {
+		compiled, err := regexp.Compile(m)
+		if err != nil {
+			return err
+		}
+		re = compiled
 	}
 	if timeout <= 0 {
 		timeout = DefaultTimeout
@@ -118,7 +152,8 @@ func (e *Engine) RegisterShell(event Event, command string, timeout time.Duratio
 	if e.shell == nil {
 		e.shell = make(map[Event][]shellHook)
 	}
-	e.shell[event] = append(e.shell[event], shellHook{command: command, timeout: timeout})
+	e.shell[event] = append(e.shell[event], shellHook{command: command, matcher: re, timeout: timeout})
+	return nil
 }
 
 // RegisterInProc adds an in-process hook for an event.
@@ -212,6 +247,9 @@ func (e *Engine) runShellHooks(ctx context.Context, hooks []shellHook, p Payload
 	}
 	var parts []string
 	for _, h := range hooks {
+		if !h.matches(p.Event, p.ToolName) {
+			continue
+		}
 		out, err := execShell(ctx, h.command, stdin, h.timeout)
 		if err != nil {
 			e.notify(err.Error())

--- a/internal/hooks/payload.go
+++ b/internal/hooks/payload.go
@@ -30,6 +30,18 @@ const (
 	EventPreCompact Event = "PreCompact"
 )
 
+// valid reports whether e is a known event name (used to reject typos in
+// hooks.yml rather than silently ignoring a misspelled event).
+func (e Event) valid() bool {
+	switch e {
+	case EventSessionStart, EventUserPromptSubmit, EventPreToolUse,
+		EventPostToolUse, EventStop, EventSubagentStop, EventPreCompact:
+		return true
+	default:
+		return false
+	}
+}
+
 // injects reports whether an event's hook stdout is folded back into the model
 // stream. Side-effect events (Stop/SubagentStop/PreCompact) discard stdout.
 func (e Event) injects() bool {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -953,7 +953,7 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	// tool results, plus any shell hooks (env/hooks.yml), unified on the agent's
 	// hook engine. Shares the process seen-set so SessionStart resume fires once
 	// per OS process across the serve process's many sessions.
-	hookEngine := hooks.EngineFromEnv(hooks.SharedSeen())
+	hookEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen())
 	hookEngine.Notify = func(m string) { slog.Warn("hook", "err", m) }
 	if s.memDir != "" {
 		s.injectorFor(sess.ID).RegisterHooks(hookEngine)
@@ -1916,7 +1916,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// L2 memory hooks + shell hooks, same engine buildAgent gives web turns,
 	// rebuilt per IM turn. The injector is session-sticky (recall latch) and
 	// dropped on /unbind; a fresh engine each turn just re-registers it.
-	imEngine := hooks.EngineFromEnv(hooks.SharedSeen())
+	imEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen())
 	imEngine.Notify = func(m string) { slog.Warn("hook", "err", m) }
 	if s.memDir != "" {
 		s.injectorFor("im:" + string(sess.Key)).RegisterHooks(imEngine)


### PR DESCRIPTION
Second PR of the hooks redesign (design: \`dev-docs/hooks-redesign.md\`). Builds on #1004.

Adds the **file-based config surface** so the events wired in PR1 (UserPromptSubmit, PostToolUse, Stop, SessionStart) are configurable beyond the \`OCTO_HOOK_*\` env shim — with per-event hook **arrays** and a tool-name **matcher**.

## What lands
- **\`hooks.yml\` schema** (\`FileConfig\`/\`HookSpec\`) + \`LoadFileConfig\` + \`Engine.LoadConfig\`. Unknown event names and invalid matcher regexps are hard errors that name the offending entry (a typo surfaces instead of silently no-op'ing).
- **Matcher** — \`shellHook\` gains a compiled regexp over the tool name, honoured only for \`PreToolUse\`/\`PostToolUse\`, ignored for other events. \`RegisterShellMatched\`.
- **Arrays** — an event fans out to multiple commands, run in order.
- **\`EngineFromEnvAndFiles\`** layers \`~/.octo/hooks.yml\` on top of the env shim (append). Missing file is fine; a malformed file/entry surfaces via \`Notify\` and is otherwise ignored so one broken hook never blocks the session.
- CLI + server (web+IM) construction sites load the user config.

\`\`\`yaml
hooks:
  UserPromptSubmit:
    - command: "hindsight-retrieve"
      timeout: 5s
  PostToolUse:
    - matcher: "terminal|write_file"
      command: "audit-logger"
\`\`\`

## Defects closed
**#4** (matchers + multi-hook arrays) · user-level half of **#5**.

## Scope note
Only the **user-level** \`~/.octo/hooks.yml\` (your own file — no trust prompt needed). The **project-level** \`<cwd>/.octo/hooks.yml\` + **trust-on-first-use** ships with **PreToolUse** in the next PR, so the supply-chain-sensitive surface (a cloned repo's hooks running shell) lands together with its guard.

## Tests
Config load/merge, unknown-event + bad-matcher rejection, matcher gating on tool name, matcher ignored for non-tool events, file round-trip, missing-file handling. \`go build\` + \`go vet\` + \`go test -race ./...\` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)