### PR TITLE
feat(hooks): PreToolUse blocking + permission-gate composition (PR3)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -958,7 +958,7 @@ func (a *Agent) runLoop(
 			// handler is threaded through to dispatchTools so streaming
 			// tools (StreamingToolExecutor) can fire EventToolProgress as
 			// output arrives mid-execution.
-			resultBlocks, err := dispatchTools(ctx, executor, reply.Blocks, handler, a.Gate)
+			resultBlocks, err := dispatchTools(ctx, executor, reply.Blocks, handler, a.effectiveGate())
 			if err != nil {
 				return Reply{}, fmt.Errorf("agent: dispatch tools[%d]: %w", i, err)
 			}

--- a/internal/agent/hookgate.go
+++ b/internal/agent/hookgate.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/Leihb/octo-agent/internal/hooks"
+)
+
+// hookGate composes a PreToolUse hook in front of the interactive permission
+// gate. It runs the hook first; a block denies the call outright, an allow
+// bypasses the inner gate entirely, and "no opinion" defers to the inner gate
+// (interactive prompt / always-allow rules). This is the hook-first, bidirectional
+// ordering: programmatic policy up front, human/rule gate as the fallback.
+//
+// Auto-allow bypassing the gate is why a project-level hooks.yml is gated behind
+// trust-on-first-use — an untrusted repo must not silently approve a tool.
+type hookGate struct {
+	engine *hooks.Engine
+	meta   hooks.Meta
+	inner  PermissionGate // may be nil (no interactive gate configured)
+}
+
+func (g *hookGate) Check(ctx context.Context, name string, input map[string]any) (bool, string) {
+	p := g.meta.Payload(hooks.EventPreToolUse)
+	p.ToolName = name
+	p.ToolInput = input
+	switch dec := g.engine.PreToolUse(ctx, p); {
+	case dec.Block:
+		reason := dec.Reason
+		if reason == "" {
+			reason = "blocked by PreToolUse hook"
+		}
+		return false, reason
+	case dec.Allow:
+		return true, "" // programmatic approval: skip the interactive gate
+	default:
+		if g.inner == nil {
+			return true, ""
+		}
+		return g.inner.Check(ctx, name, input)
+	}
+}
+
+// effectiveGate returns the permission gate dispatchTools should use: the bare
+// a.Gate when no PreToolUse hook is configured, or a hookGate wrapping it when
+// one is. Keeping the composition here means dispatchTools stays a plain
+// gate consumer.
+func (a *Agent) effectiveGate() PermissionGate {
+	if a.Hooks == nil || !a.Hooks.Configured(hooks.EventPreToolUse) {
+		return a.Gate
+	}
+	m := a.HookMeta
+	if m.Model == "" {
+		m.Model = a.Model
+	}
+	return &hookGate{engine: a.Hooks, meta: m, inner: a.Gate}
+}

--- a/internal/agent/hookgate_test.go
+++ b/internal/agent/hookgate_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/hooks"
+)
+
+// mkScript writes an executable /bin/sh script and returns its path. Skips on
+// Windows, where the hook runner uses PowerShell rather than sh -c.
+func mkScript(t *testing.T, body string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("hook scripts use sh -c; not portable to Windows")
+	}
+	p := filepath.Join(t.TempDir(), "hook.sh")
+	if err := os.WriteFile(p, []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// recordingGate is a stub inner PermissionGate: it returns a fixed verdict and
+// records whether it was consulted.
+type recordingGate struct {
+	allow  bool
+	reason string
+	called bool
+}
+
+func (g *recordingGate) Check(_ context.Context, _ string, _ map[string]any) (bool, string) {
+	g.called = true
+	return g.allow, g.reason
+}
+
+func preToolAgent(t *testing.T, body string, inner PermissionGate) *Agent {
+	t.Helper()
+	a := New(&fakeSender{}, "m")
+	a.Gate = inner
+	a.Hooks = hooks.NewEngine(nil)
+	if err := a.Hooks.RegisterShellMatched(hooks.EventPreToolUse, mkScript(t, body), "", 0); err != nil {
+		t.Fatal(err)
+	}
+	return a
+}
+
+func TestHookGate_BlockDeniesWithoutInner(t *testing.T) {
+	inner := &recordingGate{allow: true}
+	a := preToolAgent(t, "echo nope >&2; exit 2", inner)
+	allowed, reason := a.effectiveGate().Check(context.Background(), "terminal", nil)
+	if allowed {
+		t.Error("PreToolUse block must deny")
+	}
+	if reason != "nope" {
+		t.Errorf("reason = %q, want stderr text", reason)
+	}
+	if inner.called {
+		t.Error("a blocked call must not reach the inner gate")
+	}
+}
+
+func TestHookGate_AllowBypassesInner(t *testing.T) {
+	// Inner gate would DENY, but the hook approves → tool runs, gate skipped.
+	inner := &recordingGate{allow: false, reason: "gate would deny"}
+	a := preToolAgent(t, `echo '{"decision":"approve"}'`, inner)
+	allowed, _ := a.effectiveGate().Check(context.Background(), "terminal", nil)
+	if !allowed {
+		t.Error("PreToolUse approve must allow, bypassing a denying inner gate")
+	}
+	if inner.called {
+		t.Error("approve must bypass the inner gate entirely")
+	}
+}
+
+func TestHookGate_NoOpinionDelegatesToInner(t *testing.T) {
+	inner := &recordingGate{allow: false, reason: "inner denies"}
+	a := preToolAgent(t, "exit 0", inner)
+	allowed, reason := a.effectiveGate().Check(context.Background(), "terminal", nil)
+	if !inner.called {
+		t.Error("no-opinion must delegate to the inner gate")
+	}
+	if allowed || reason != "inner denies" {
+		t.Errorf("inner verdict should pass through: allowed=%v reason=%q", allowed, reason)
+	}
+}
+
+func TestHookGate_NoOpinionNoInnerAllows(t *testing.T) {
+	a := preToolAgent(t, "exit 0", nil) // no inner gate
+	if allowed, _ := a.effectiveGate().Check(context.Background(), "terminal", nil); !allowed {
+		t.Error("no-opinion with no inner gate should allow")
+	}
+}
+
+func TestEffectiveGate_NoHookReturnsBareGate(t *testing.T) {
+	inner := &recordingGate{allow: true}
+	a := New(&fakeSender{}, "m")
+	a.Gate = inner
+	a.Hooks = hooks.NewEngine(nil) // no PreToolUse registered
+	if a.effectiveGate() != PermissionGate(inner) {
+		t.Error("with no PreToolUse hook, effectiveGate must return the bare gate")
+	}
+}

--- a/internal/hooks/engine.go
+++ b/internal/hooks/engine.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 	"sync"
@@ -268,6 +269,112 @@ func (e *Engine) notify(msg string) {
 	if e != nil && e.Notify != nil {
 		e.Notify(msg)
 	}
+}
+
+// ToolDecision is a PreToolUse verdict for a single tool call. At most one of
+// Block/Allow is set; both false means "no opinion" (defer to the permission
+// gate). Reason accompanies a Block, surfaced to the model as the denial text.
+type ToolDecision struct {
+	Block  bool
+	Allow  bool
+	Reason string
+}
+
+// toolDecisionOut is the optional structured stdout a PreToolUse hook may emit
+// to make an explicit allow/deny decision (beyond the exit-code protocol).
+type toolDecisionOut struct {
+	Decision string `json:"decision"` // "approve" | "block"
+	Reason   string `json:"reason,omitempty"`
+}
+
+// PreToolUse runs the PreToolUse shell hooks for a tool call and returns the
+// aggregated verdict. Protocol per hook, matching Claude Code's:
+//   - exit 2                     → block (reason = structured reason, else stderr)
+//   - exit 0 + {"decision":...}  → that decision (block / approve)
+//   - exit 0, no decision        → no opinion (defer to the gate)
+//   - timeout / other exit       → non-blocking error (notify, tool proceeds)
+//
+// Block wins over Allow: the first hook that blocks short-circuits, and an
+// Allow never overrides a later Block. A tool the caller then runs unless
+// blocked; an Allow tells the caller to bypass the interactive gate. In-process
+// hooks are not consulted here — PreToolUse is a shell-configured guard.
+func (e *Engine) PreToolUse(ctx context.Context, p Payload) ToolDecision {
+	if e == nil {
+		return ToolDecision{}
+	}
+	sh, _ := e.hooksFor(EventPreToolUse)
+	if len(sh) == 0 {
+		return ToolDecision{}
+	}
+	stdin, err := json.Marshal(p)
+	if err != nil {
+		e.notify("hooks: marshal PreToolUse payload: " + err.Error())
+		return ToolDecision{}
+	}
+	allow := false
+	for _, h := range sh {
+		if !h.matches(EventPreToolUse, p.ToolName) {
+			continue
+		}
+		res := runShellRaw(ctx, h.command, stdin, h.timeout)
+		switch {
+		case res.timedOut:
+			e.notify(fmt.Sprintf("hooks: PreToolUse %s timed out after %s (tool allowed to proceed)", h.command, h.timeout))
+		case res.exitCode == 2:
+			return ToolDecision{Block: true, Reason: blockReason(res)}
+		case res.exitCode == 0:
+			if d, ok := parseToolDecision(res.stdout); ok {
+				switch d.Decision {
+				case "block":
+					return ToolDecision{Block: true, Reason: firstNonEmpty(strings.TrimSpace(d.Reason), "blocked by PreToolUse hook")}
+				case "approve":
+					allow = true
+				}
+			}
+		default:
+			e.notify(fmt.Sprintf("hooks: PreToolUse %s: exit %d (tool allowed to proceed)", h.command, res.exitCode))
+		}
+	}
+	return ToolDecision{Allow: allow}
+}
+
+// blockReason picks the denial text for an exit-2 (or decision:block) hook:
+// the structured stdout reason if present, else the stderr tail, else a
+// default.
+func blockReason(res shellResult) string {
+	if d, ok := parseToolDecision(res.stdout); ok {
+		if r := strings.TrimSpace(d.Reason); r != "" {
+			return r
+		}
+	}
+	if tail := strings.TrimSpace(string(res.stderr)); tail != "" {
+		return oneLineCap(tail, 500)
+	}
+	return "blocked by PreToolUse hook"
+}
+
+// parseToolDecision tries to read a structured decision from a hook's stdout.
+// Returns ok=false when stdout isn't a JSON object with a recognised decision.
+func parseToolDecision(stdout []byte) (toolDecisionOut, bool) {
+	trimmed := strings.TrimSpace(string(stdout))
+	if !strings.HasPrefix(trimmed, "{") {
+		return toolDecisionOut{}, false
+	}
+	var d toolDecisionOut
+	if err := json.Unmarshal([]byte(trimmed), &d); err != nil {
+		return toolDecisionOut{}, false
+	}
+	if d.Decision != "approve" && d.Decision != "block" {
+		return toolDecisionOut{}, false
+	}
+	return d, true
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
 }
 
 // SessionStartDecision resolves the SessionStart source for a turn and reports

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -164,6 +164,35 @@ func (r *Runner) run(ctx context.Context, cmd string, stdin []byte) ([]byte, err
 // a timeout from a plain failure (with the stderr tail folded in) to help users
 // debug hook wiring.
 func execShell(ctx context.Context, cmd string, stdin []byte, deadline time.Duration) ([]byte, error) {
+	res := runShellRaw(ctx, cmd, stdin, deadline)
+	if res.timedOut {
+		return res.stdout, fmt.Errorf("hooks: %s timed out after %s", cmd, deadline)
+	}
+	if res.runErr != nil {
+		if tail := strings.TrimSpace(string(res.stderr)); tail != "" {
+			return res.stdout, fmt.Errorf("hooks: %s: %w (stderr: %s)", cmd, res.runErr, oneLineCap(tail, 200))
+		}
+		return res.stdout, fmt.Errorf("hooks: %s: %w", cmd, res.runErr)
+	}
+	return res.stdout, nil
+}
+
+// shellResult is the low-level outcome of running a hook command: captured
+// stdout/stderr, the process exit code, and flags distinguishing a deadline
+// kill from a normal non-zero exit. Callers that only need "did it succeed" use
+// execShell; the PreToolUse decision path needs the exit code (2 = block).
+type shellResult struct {
+	stdout   []byte
+	stderr   []byte
+	exitCode int  // 0 on success; the process code on a normal exit; -1 if it never ran
+	timedOut bool // the deadline fired and the process was killed
+	runErr   error
+}
+
+// runShellRaw runs cmd through the platform shell with stdin piped in, bounded
+// by deadline, and reports the full outcome. It is the single place the shell
+// selection, WaitDelay teardown, and timeout live.
+func runShellRaw(ctx context.Context, cmd string, stdin []byte, deadline time.Duration) shellResult {
 	rctx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()
 
@@ -178,17 +207,24 @@ func execShell(ctx context.Context, cmd string, stdin []byte, deadline time.Dura
 	// on the shell — Run hangs until the child terminates naturally. 1s
 	// is plenty for the kernel to tear down the process group.
 	c.WaitDelay = time.Second
-	if err := c.Run(); err != nil {
-		if errors.Is(rctx.Err(), context.DeadlineExceeded) {
-			return out.Bytes(), fmt.Errorf("hooks: %s timed out after %s", cmd, deadline)
-		}
-		stderrTail := strings.TrimSpace(errBuf.String())
-		if stderrTail != "" {
-			return out.Bytes(), fmt.Errorf("hooks: %s: %w (stderr: %s)", cmd, err, oneLineCap(stderrTail, 200))
-		}
-		return out.Bytes(), fmt.Errorf("hooks: %s: %w", cmd, err)
+	err := c.Run()
+	res := shellResult{stdout: out.Bytes(), stderr: errBuf.Bytes()}
+	if err == nil {
+		return res
 	}
-	return out.Bytes(), nil
+	if errors.Is(rctx.Err(), context.DeadlineExceeded) {
+		res.timedOut = true
+		res.runErr = err
+		return res
+	}
+	res.runErr = err
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		res.exitCode = ee.ExitCode()
+	} else {
+		res.exitCode = -1 // never started (e.g. shell not found)
+	}
+	return res
 }
 
 // shellCmd wraps cmd in the platform shell: PowerShell on Windows (preferring

--- a/internal/hooks/pretooluse_test.go
+++ b/internal/hooks/pretooluse_test.go
@@ -1,0 +1,97 @@
+package hooks
+
+import (
+	"context"
+	"testing"
+)
+
+func preToolEngine(t *testing.T, body, matcher string) *Engine {
+	t.Helper()
+	e := NewEngine(nil)
+	if err := e.RegisterShellMatched(EventPreToolUse, makeScript(t, body), matcher, 0); err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+func TestPreToolUse_Exit2Blocks(t *testing.T) {
+	e := preToolEngine(t, "echo 'rm is forbidden' >&2; exit 2", "")
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if !dec.Block {
+		t.Fatal("exit 2 must block")
+	}
+	if dec.Reason != "rm is forbidden" {
+		t.Errorf("reason should come from stderr: %q", dec.Reason)
+	}
+}
+
+func TestPreToolUse_Exit0NoOpinion(t *testing.T) {
+	e := preToolEngine(t, "exit 0", "")
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if dec.Block || dec.Allow {
+		t.Errorf("silent exit 0 should be no-opinion, got %+v", dec)
+	}
+}
+
+func TestPreToolUse_StructuredApprove(t *testing.T) {
+	e := preToolEngine(t, `echo '{"decision":"approve"}'`, "")
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if !dec.Allow || dec.Block {
+		t.Errorf("decision approve should allow, got %+v", dec)
+	}
+}
+
+func TestPreToolUse_StructuredBlockWithReason(t *testing.T) {
+	e := preToolEngine(t, `echo '{"decision":"block","reason":"policy X"}'`, "")
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if !dec.Block || dec.Reason != "policy X" {
+		t.Errorf("decision block should carry reason, got %+v", dec)
+	}
+}
+
+func TestPreToolUse_MatcherGates(t *testing.T) {
+	e := preToolEngine(t, "exit 2", "terminal")
+	// Non-matching tool → hook doesn't run → no opinion.
+	if dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "read_file"}); dec.Block {
+		t.Error("matcher should skip read_file")
+	}
+	// Matching tool → blocks.
+	if dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"}); !dec.Block {
+		t.Error("matcher should apply to terminal")
+	}
+}
+
+func TestPreToolUse_BlockWinsOverAllow(t *testing.T) {
+	e := NewEngine(nil)
+	// First hook approves, second blocks — block must win.
+	if err := e.RegisterShellMatched(EventPreToolUse, makeScript(t, `echo '{"decision":"approve"}'`), "", 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.RegisterShellMatched(EventPreToolUse, makeScript(t, "exit 2"), "", 0); err != nil {
+		t.Fatal(err)
+	}
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if !dec.Block {
+		t.Errorf("a later block must override an earlier approve, got %+v", dec)
+	}
+}
+
+func TestPreToolUse_OtherExitIsNonBlocking(t *testing.T) {
+	var notices int
+	e := preToolEngine(t, "echo boom >&2; exit 1", "")
+	e.Notify = func(string) { notices++ }
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if dec.Block || dec.Allow {
+		t.Errorf("exit 1 (not 2) must be non-blocking, got %+v", dec)
+	}
+	if notices == 0 {
+		t.Error("a non-blocking hook error should surface via Notify")
+	}
+}
+
+func TestPreToolUse_NoHooksNoOpinion(t *testing.T) {
+	e := NewEngine(nil)
+	if dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"}); dec.Block || dec.Allow {
+		t.Errorf("unconfigured PreToolUse must be no-opinion, got %+v", dec)
+	}
+}


### PR DESCRIPTION
Third PR of the hooks redesign (design: \`dev-docs/hooks-redesign.md\`). Builds on #1005.

Adds the **PreToolUse** event and its **blocking protocol**, composed in front of the interactive permission gate.

## Ordering (grill decision: hook-first, bidirectional)
\`hookGate\` wraps the existing \`PermissionGate\`:
- hook **block** → deny the tool, inner gate never consulted;
- hook **approve** → allow, **bypassing** the inner gate;
- hook **no opinion** → delegate to the inner gate (interactive prompt / always-allow rules).

So a hook is programmatic policy up front; the human/rule gate is the fallback.

## Protocol (parity with Claude Code)
Per PreToolUse hook:
| outcome | meaning |
|---|---|
| exit 2 | **block** — reason from structured stdout, else stderr |
| exit 0 + \`{"decision":"approve"\|"block","reason":...}\` | explicit approve / block |
| exit 0, silent | no opinion (defer to gate) |
| timeout / other exit | non-blocking error (notify, tool proceeds) |

Block wins over approve. Matchers (PR2) gate which tools each hook sees. Configured via the user-level \`~/.octo/hooks.yml\`.

## Implementation
- \`Engine.PreToolUse\` → \`ToolDecision\`; \`runShellRaw\` exposes the exit code (\`execShell\` keeps its error-string contract, so existing tests are unaffected).
- \`hookGate\` + \`a.effectiveGate()\`; \`dispatchTools\` stays a plain gate consumer.

## Defects closed
**#2** (PreToolUse blocking).

## Scope note (descope from the doc's PR3)
Only PreToolUse lands here, driven by the **user-level** \`hooks.yml\` (your own file — auto-allow is safe). **Project-level** \`<cwd>/.octo/hooks.yml\` + **trust-on-first-use** — where auto-allow from a cloned repo would be the risk — ships in a **follow-up PR** so the guard lands with the feature it guards. Nothing loads project-level hooks yet, so there's no new supply-chain surface in this PR.

## Tests
Engine protocol (exit 2 / structured approve+block / silent / matcher / block-wins / non-blocking error), gate composition (block-denies / approve-bypasses / no-opinion-delegates / no-inner-allows). \`go build\` + \`go vet\` + \`go test -race ./...\` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)