### PR TITLE
feat(hooks): project-level hooks.yml + trust-on-first-use (PR4)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -77,6 +77,41 @@ func wireSessionHooks(a *agent.Agent, sess *agent.Session, transport string) {
 	a.OnSessionStart = func() { sess.MarkHookStarted() }
 }
 
+// resolveProjectHooksTrust decides whether the project-level <cwd>/.octo/hooks.yml
+// should be loaded, implementing trust-on-first-use. It returns false (skip)
+// when there is no project file. For an untrusted or changed file it prompts
+// once via reader; approving records the content fingerprint so it won't ask
+// again until the file changes. A non-interactive session (no reader / exhausted
+// stdin) declines — an untrusted repo never silently runs shell on startup.
+func resolveProjectHooksTrust(cwd string, reader lineReader, out, errOut io.Writer) bool {
+	path := hooks.ProjectConfigPath(cwd)
+	if path == "" {
+		return false
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false // no project hooks.yml (or unreadable) → nothing to trust
+	}
+	fp := hooks.Fingerprint(content)
+	if hooks.IsTrusted(path, fp) {
+		return true
+	}
+	if reader == nil {
+		fmt.Fprintf(errOut, "octo: project hooks %s is not trusted; skipped\n", path)
+		return false
+	}
+	fmt.Fprintf(out, "\n⚠ This repository defines hooks in %s that can run shell commands on your machine.\n", path)
+	line, ok := reader.ReadLine("  Trust and run this repo's hooks? [y/N]: ")
+	if ok && (strings.EqualFold(strings.TrimSpace(line), "y") || strings.EqualFold(strings.TrimSpace(line), "yes")) {
+		if rerr := hooks.RecordTrust(path, fp); rerr != nil {
+			fmt.Fprintf(errOut, "octo: could not persist hooks trust: %v\n", rerr)
+		}
+		return true
+	}
+	fmt.Fprintln(out, "  Skipped. Project hooks stay disabled until you trust them.")
+	return false
+}
+
 // errMissingAPIKey is returned by resolveAPIKey when no API key is available.
 // The caller (runChat) can detect this and auto-launch the config wizard on an
 // interactive terminal instead of failing silently.
@@ -759,7 +794,8 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// injector's reminder & save-nudge as in-process hooks, unified on one
 	// dispatch path that the agent core drives for every transport. Shares the
 	// process seen-set so SessionStart resume fires once per OS process.
-	hookEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen())
+	projectHooksTrusted := resolveProjectHooksTrust(cwd, replReader, stdout, stderr)
+	hookEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen(), cwd, projectHooksTrusted)
 	hookEngine.Notify = func(m string) { fmt.Fprintln(stderr, "↳ hook: "+m) }
 	if memDir != "" {
 		rules := memory.ParseRules(memDir)

--- a/dev-docs/hooks-redesign.md
+++ b/dev-docs/hooks-redesign.md
@@ -9,7 +9,7 @@ octo 当前有两套互不相干的 hook 机制:
 
 两套机制叠加暴露出 11 个缺陷(见附录「缺陷映射」)。本设计把它们合并为**一个下沉到 agent core 的 hook 引擎**,统一分发,一次性关闭全部缺陷,并把能力面对齐 Claude Code 的 hook 模型(7 事件 + matcher + 阻断)作为 octo 原生特性。
 
-核心判断:agent 循环本身已经具备所有需要的插桩点。只要把 hook 执行从 CLI 层挪进 agent core,并让 `internal/app` 在构造每个 Agent 时挂上同一个引擎,三端(CLI/TUI、serve web/SSE/WS、IM)与子 agent 就全部自动继承 hook,无需在每个入口各自接线。
+核心判断:agent 循环本身已经具备所有需要的插桩点。只要把 hook 执行从 CLI 层挪进 agent core,并在构造每个 Agent 时挂上一个 Engine(各 Engine 共享进程级 `SeenSet`),三端(CLI/TUI、serve web/SSE/WS、IM)与子 agent 就全部自动继承 hook,无需在每个入口各自实现分发逻辑。
 
 ### 运行时事实(设计前提)
 
@@ -61,7 +61,7 @@ internal/hooks/
   spill.go       // async 落盘队列 + 启动补投(多进程安全)
 ```
 
-`hooks.Runner` 升级为 `hooks.Engine`。`Engine` 是唯一的 hook 执行入口,由 `internal/app` 在 bootstrap 时构造一次,通过新字段 `Agent.Hooks *hooks.Engine` 挂到每个 Agent 上(nil-safe,零值为 no-op)。
+`hooks.Runner` 升级为 `hooks.Engine`。`Engine` 是唯一的 hook 执行入口,通过新字段 `Agent.Hooks *hooks.Engine` 挂到每个 Agent 上(nil-safe,零值为 no-op)。**每个 Agent 持有自己的 Engine**——因为 memory injector 携带每会话状态(recall/nudge 锁存),in-proc hook 必须按会话隔离;但所有 Engine **共享同一个进程级 `SeenSet`**(`hooks.SharedSeen()`),这正是 SessionStart `resume` 每进程只触发一次的依据。Engine 在各入口的会话构造处组装(CLI 的 `runChat`、server 的 `buildAgent` 与 IM 回合刷新),而非单一 bootstrap 点。
 
 现有 `Agent.UserInputHook` / `Agent.ToolResultHook` 两个单槽字段**删除**,其职责(memory 提醒)改为引擎里注册的内置 in-process hook,与 shell hook 走同一条分发路径。
 

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -94,21 +94,35 @@ func parseTimeout(s string) time.Duration {
 	return d
 }
 
-// EngineFromEnvAndFiles builds the production engine: the OCTO_HOOK_* env shim
-// plus the user-level ~/.octo/hooks.yml layered on top (append semantics). A
-// missing file is fine; a malformed file or a bad entry is surfaced via Notify
-// and otherwise ignored, so one broken hook never blocks the session.
-func EngineFromEnvAndFiles(seen *SeenSet) *Engine {
+// EngineFromEnvAndFiles builds the production engine: the OCTO_HOOK_* env shim,
+// the user-level ~/.octo/hooks.yml, and — when loadProject is true — the
+// project-level <cwd>/.octo/hooks.yml, layered in that order (append semantics,
+// so project hooks run after user hooks). The caller decides loadProject: the
+// CLI resolves trust-on-first-use (prompting for an untrusted project file); a
+// server auto-trusts its operator-chosen cwd. A missing file is fine; a
+// malformed file or bad entry surfaces via Notify and is otherwise ignored, so
+// one broken hook never blocks the session.
+func EngineFromEnvAndFiles(seen *SeenSet, cwd string, loadProject bool) *Engine {
 	e := EngineFromEnv(seen)
-	if p := UserConfigPath(); p != "" {
-		switch fc, err := LoadFileConfig(p); {
-		case err == nil:
-			if cerr := e.LoadConfig(fc); cerr != nil {
-				e.notify(cerr.Error())
-			}
-		case !os.IsNotExist(err):
-			e.notify(err.Error())
-		}
+	e.loadFile(UserConfigPath())
+	if loadProject {
+		e.loadFile(ProjectConfigPath(cwd))
 	}
 	return e
+}
+
+// loadFile parses one hooks.yml and registers its hooks, tolerating a missing
+// file and surfacing parse/validation errors via Notify.
+func (e *Engine) loadFile(path string) {
+	if path == "" {
+		return
+	}
+	switch fc, err := LoadFileConfig(path); {
+	case err == nil:
+		if cerr := e.LoadConfig(fc); cerr != nil {
+			e.notify(cerr.Error())
+		}
+	case !os.IsNotExist(err):
+		e.notify(err.Error())
+	}
 }

--- a/internal/hooks/trust.go
+++ b/internal/hooks/trust.go
@@ -1,0 +1,92 @@
+package hooks
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Project-level hooks.yml is loaded from a repo the user may have just cloned,
+// so its shell commands are untrusted by default: a malicious repo could run
+// arbitrary commands (or, once PreToolUse is configured, auto-approve dangerous
+// tools) the moment octo starts in that directory. Trust-on-first-use gates
+// this — the first time a project hooks.yml (or a changed one) is seen, the
+// user is asked once; the approved content's fingerprint is remembered so it
+// never re-prompts until the file changes. The user-level ~/.octo/hooks.yml is
+// the user's own and needs no such gate.
+
+// ProjectConfigPath returns <cwd>/.octo/hooks.yml, mirroring the project-level
+// skills/agents layout.
+func ProjectConfigPath(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+	return filepath.Join(cwd, ".octo", "hooks.yml")
+}
+
+// Fingerprint is the content hash a trust decision is keyed on, so editing a
+// trusted project hooks.yml re-triggers the prompt.
+func Fingerprint(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+// trustStoreMu serialises read-modify-write of the on-disk trust store within
+// this process. Cross-process races are benign (last writer wins; a lost record
+// just re-prompts once).
+var trustStoreMu sync.Mutex
+
+// trustStorePath returns ~/.octo/hooks-trust.json, or "" when home is
+// unavailable.
+func trustStorePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "hooks-trust.json")
+}
+
+func loadTrustStore() map[string]string {
+	m := map[string]string{}
+	p := trustStorePath()
+	if p == "" {
+		return m
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return m
+	}
+	_ = json.Unmarshal(b, &m) // a corrupt store degrades to "nothing trusted"
+	return m
+}
+
+// IsTrusted reports whether path's current fingerprint has been approved.
+func IsTrusted(path, fingerprint string) bool {
+	trustStoreMu.Lock()
+	defer trustStoreMu.Unlock()
+	return loadTrustStore()[path] == fingerprint
+}
+
+// RecordTrust persists approval of path at the given fingerprint. Best-effort:
+// a write failure just means the user is asked again next time.
+func RecordTrust(path, fingerprint string) error {
+	trustStoreMu.Lock()
+	defer trustStoreMu.Unlock()
+	p := trustStorePath()
+	if p == "" {
+		return nil
+	}
+	m := loadTrustStore()
+	m[path] = fingerprint
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, b, 0o600)
+}

--- a/internal/hooks/trust_test.go
+++ b/internal/hooks/trust_test.go
@@ -1,0 +1,98 @@
+package hooks
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// tempHome points HOME/USERPROFILE at a sandbox so the trust store and user
+// config path stay inside the test.
+func tempHome(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	return tmp
+}
+
+func TestFingerprint_StableAndContentSensitive(t *testing.T) {
+	a := Fingerprint([]byte("hooks: {}"))
+	if a != Fingerprint([]byte("hooks: {}")) {
+		t.Error("fingerprint must be stable for identical content")
+	}
+	if a == Fingerprint([]byte("hooks: {Stop: []}")) {
+		t.Error("fingerprint must change when content changes")
+	}
+}
+
+func TestTrustStore_RoundTrip(t *testing.T) {
+	tempHome(t)
+	path := "/some/repo/.octo/hooks.yml"
+	fp := Fingerprint([]byte("x"))
+
+	if IsTrusted(path, fp) {
+		t.Fatal("nothing should be trusted initially")
+	}
+	if err := RecordTrust(path, fp); err != nil {
+		t.Fatalf("RecordTrust: %v", err)
+	}
+	if !IsTrusted(path, fp) {
+		t.Error("recorded fingerprint must be trusted")
+	}
+	// A changed file (new fingerprint) is no longer trusted.
+	if IsTrusted(path, Fingerprint([]byte("y"))) {
+		t.Error("a changed fingerprint must not be trusted")
+	}
+}
+
+func writeProjectHooks(t *testing.T, cwd, body string) {
+	t.Helper()
+	dir := filepath.Join(cwd, ".octo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "hooks.yml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEngineFromEnvAndFiles_ProjectLoadGatedByFlag(t *testing.T) {
+	tempHome(t)
+	t.Setenv("OCTO_HOOK_PRE_TURN", "")
+	t.Setenv("OCTO_HOOK_POST_TURN", "")
+	cwd := t.TempDir()
+	writeProjectHooks(t, cwd, "hooks:\n  Stop:\n    - command: \"retain\"\n")
+
+	// loadProject=false → project file ignored.
+	if e := EngineFromEnvAndFiles(NewSeenSet(), cwd, false); e.Configured(EventStop) {
+		t.Error("project hooks must not load when loadProject is false")
+	}
+	// loadProject=true → project file applied.
+	if e := EngineFromEnvAndFiles(NewSeenSet(), cwd, true); !e.Configured(EventStop) {
+		t.Error("project hooks must load when loadProject is true")
+	}
+}
+
+func TestProjectConfigPath(t *testing.T) {
+	if got := ProjectConfigPath("/repo"); got != filepath.Join("/repo", ".octo", "hooks.yml") {
+		t.Errorf("ProjectConfigPath = %q", got)
+	}
+	if ProjectConfigPath("") != "" {
+		t.Error("empty cwd → empty path")
+	}
+}
+
+// Sanity: a project-level hook actually dispatches once loaded.
+func TestEngineFromEnvAndFiles_ProjectHookRuns(t *testing.T) {
+	tempHome(t)
+	t.Setenv("OCTO_HOOK_PRE_TURN", "")
+	t.Setenv("OCTO_HOOK_POST_TURN", "")
+	cwd := t.TempDir()
+	writeProjectHooks(t, cwd, "hooks:\n  UserPromptSubmit:\n    - command: \""+makeScript(t, "echo proj")+"\"\n")
+	e := EngineFromEnvAndFiles(NewSeenSet(), cwd, true)
+	if got := e.Inject(context.Background(), Payload{Event: EventUserPromptSubmit}); got != "proj" {
+		t.Errorf("project UserPromptSubmit hook should run; got %q", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -953,7 +953,7 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	// tool results, plus any shell hooks (env/hooks.yml), unified on the agent's
 	// hook engine. Shares the process seen-set so SessionStart resume fires once
 	// per OS process across the serve process's many sessions.
-	hookEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen())
+	hookEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen(), cwd, true)
 	hookEngine.Notify = func(m string) { slog.Warn("hook", "err", m) }
 	if s.memDir != "" {
 		s.injectorFor(sess.ID).RegisterHooks(hookEngine)
@@ -1916,7 +1916,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// L2 memory hooks + shell hooks, same engine buildAgent gives web turns,
 	// rebuilt per IM turn. The injector is session-sticky (recall latch) and
 	// dropped on /unbind; a fresh engine each turn just re-registers it.
-	imEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen())
+	imEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen(), cwd, true)
 	imEngine.Notify = func(m string) { slog.Warn("hook", "err", m) }
 	if s.memDir != "" {
 		s.injectorFor("im:" + string(sess.Key)).RegisterHooks(imEngine)


### PR DESCRIPTION
Fourth PR of the hooks redesign. Builds on #1006.

Loads the **project-level** \`<cwd>/.octo/hooks.yml\` (layered on the user-level file, append), gated by **trust-on-first-use** so a cloned repo can't silently run shell commands — or, now that PreToolUse exists, auto-approve tools — the moment octo starts in it.

## Trust model (grill decision)
- **User-level** \`~/.octo/hooks.yml\` — your own file, loaded unconditionally.
- **Project-level** \`<cwd>/.octo/hooks.yml\` — untrusted by default. The CLI prompts **once** when it sees a new or changed project file; approving records the content **fingerprint** (sha256) in \`~/.octo/hooks-trust.json\` and it won't ask again until the file changes. A non-interactive session (no reader / piped stdin) **declines** — an untrusted repo never runs hooks unattended. A server **auto-trusts** its operator-chosen cwd.

## Implementation
- \`trust.go\` — \`Fingerprint\`, \`IsTrusted\`/\`RecordTrust\` over the JSON store, \`ProjectConfigPath\`.
- \`EngineFromEnvAndFiles(seen, cwd, loadProject)\` — caller decides \`loadProject\`; CLI resolves trust in \`resolveProjectHooksTrust\` (prompt via the reader, already set up before engine construction), server passes \`true\`.
- Design-doc correction: **per-Agent engine sharing a process-level \`SeenSet\`** (the memory injector's per-session state rules out one engine per process), assembled at each session-setup site.

## Defects closed
**#5** (project-level file + trust-on-first-use) — completes the config surface.

## Tests
Fingerprint stability/sensitivity, trust store round-trip + change-invalidation, project load gated by the flag, project hook actually dispatches. \`go build\` + \`go vet\` + \`go test -race ./...\` all green.

## Remaining
One PR left: **async spill-to-disk** (#6), **PreCompact** (#3 remainder), and \`octo hooks list\` + observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)