### PR TITLE
feat(hooks): async durable queue for side-effect hooks (PR5)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -797,6 +797,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	projectHooksTrusted := resolveProjectHooksTrust(cwd, replReader, stdout, stderr)
 	hookEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen(), cwd, projectHooksTrusted)
 	hookEngine.Notify = func(m string) { fmt.Fprintln(stderr, "↳ hook: "+m) }
+	hooks.SetSpillNotify(func(m string) { fmt.Fprintln(stderr, "↳ hook: "+m) })
 	if memDir != "" {
 		rules := memory.ParseRules(memDir)
 		if homeMemDir != "" {

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Leihb/octo-agent/internal/agent"
 	"github.com/Leihb/octo-agent/internal/config"
+	"github.com/Leihb/octo-agent/internal/hooks"
 	"github.com/Leihb/octo-agent/internal/mcp"
 	"github.com/Leihb/octo-agent/internal/permission"
 	"github.com/Leihb/octo-agent/internal/skills"
@@ -110,6 +111,8 @@ func runOnce(cfg replConfig, prompt string, stream bool) int {
 
 	// Reap background processes the turn spawned so none outlive the run.
 	defer tools.KillAllBackground()
+	// Flush queued async hooks (retention) to disk so exit doesn't drop them.
+	defer hooks.DrainSpill(5 * time.Second)
 	defer tools.CleanSpillFiles()
 
 	// Sub-agent completions and background-process notices ride the inbox, so a

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Leihb/octo-agent/internal/agent"
+	"github.com/Leihb/octo-agent/internal/hooks"
 	"github.com/Leihb/octo-agent/internal/mcp"
 	"github.com/Leihb/octo-agent/internal/tools"
 	"github.com/Leihb/octo-agent/internal/tui"
@@ -38,6 +39,7 @@ import (
 func runTUI(cfg replConfig) int {
 	defer tools.KillAllBackground()
 	defer tools.CleanSpillFiles()
+	defer hooks.DrainSpill(5 * time.Second) // flush queued async hooks on exit
 	// MCP connects in the background (mcpBoot → connectMCPCmd → mcpReadyMsg),
 	// which installs the registry globally. Tear it down here on exit since the
 	// TUI path owns its lifecycle (chat.go only defers cleanup for the

--- a/internal/agent/hookgate_test.go
+++ b/internal/agent/hookgate_test.go
@@ -42,7 +42,7 @@ func preToolAgent(t *testing.T, body string, inner PermissionGate) *Agent {
 	a := New(&fakeSender{}, "m")
 	a.Gate = inner
 	a.Hooks = hooks.NewEngine(nil)
-	if err := a.Hooks.RegisterShellMatched(hooks.EventPreToolUse, mkScript(t, body), "", 0); err != nil {
+	if err := a.Hooks.RegisterShellMatched(hooks.EventPreToolUse, mkScript(t, body), "", false, 0); err != nil {
 		t.Fatal(err)
 	}
 	return a

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -27,11 +27,15 @@ type FileConfig struct {
 
 // HookSpec is one configured hook. Matcher is a regexp over the tool name,
 // honoured only for PreToolUse/PostToolUse. Timeout is a Go duration string
-// ("5s"); empty uses the package default.
+// ("5s"); empty uses the package default. Async runs the hook off the turn's
+// critical path via the durable queue — honoured only for the side-effect
+// events (Stop/SubagentStop/PreCompact); ignored where output is folded back
+// into the model stream.
 type HookSpec struct {
 	Command string `yaml:"command"`
 	Matcher string `yaml:"matcher,omitempty"`
 	Timeout string `yaml:"timeout,omitempty"`
+	Async   bool   `yaml:"async,omitempty"`
 }
 
 // UserConfigPath returns ~/.octo/hooks.yml, or "" when the home dir is
@@ -73,7 +77,7 @@ func (e *Engine) LoadConfig(fc FileConfig) error {
 			return fmt.Errorf("hooks: unknown event %q in hooks.yml", name)
 		}
 		for _, s := range specs {
-			if err := e.RegisterShellMatched(ev, s.Command, s.Matcher, parseTimeout(s.Timeout)); err != nil {
+			if err := e.RegisterShellMatched(ev, s.Command, s.Matcher, s.Async, parseTimeout(s.Timeout)); err != nil {
 				return fmt.Errorf("hooks: %s: invalid matcher %q: %w", name, s.Matcher, err)
 			}
 		}

--- a/internal/hooks/engine.go
+++ b/internal/hooks/engine.go
@@ -77,11 +77,14 @@ type InProcHook func(ctx context.Context, p Payload) string
 
 // shellHook is one configured shell command for an event. matcher, when set,
 // gates the hook on the tool name for the tool events (PreToolUse/PostToolUse);
-// it is ignored for the other events. Async execution lands in a later phase;
-// for now every shell hook runs synchronously.
+// it is ignored for the other events. async, honoured only for the side-effect
+// events dispatched via Dispatch (Stop/SubagentStop/PreCompact), runs the hook
+// off the turn's critical path through the durable spill queue; it is ignored
+// for injecting events, whose output must be produced synchronously.
 type shellHook struct {
 	command string
 	matcher *regexp.Regexp // nil → match every tool
+	async   bool
 	timeout time.Duration
 }
 
@@ -120,17 +123,18 @@ func NewEngine(seen *SeenSet) *Engine {
 	}
 }
 
-// RegisterShell adds a shell command hook for an event, matching every tool. A
-// zero timeout uses the package default.
+// RegisterShell adds a synchronous shell command hook for an event, matching
+// every tool. A zero timeout uses the package default.
 func (e *Engine) RegisterShell(event Event, command string, timeout time.Duration) {
-	_ = e.RegisterShellMatched(event, command, "", timeout)
+	_ = e.RegisterShellMatched(event, command, "", false, timeout)
 }
 
 // RegisterShellMatched adds a shell command hook whose matcher (a regexp over
 // the tool name, honoured only for PreToolUse/PostToolUse) gates whether it
-// runs. An empty matcher matches every tool. A zero timeout uses the package
+// runs. An empty matcher matches every tool. async runs it off the critical
+// path (honoured only for side-effect events). A zero timeout uses the package
 // default. Returns an error only when matcher is not a valid regexp.
-func (e *Engine) RegisterShellMatched(event Event, command, matcher string, timeout time.Duration) error {
+func (e *Engine) RegisterShellMatched(event Event, command, matcher string, async bool, timeout time.Duration) error {
 	command = strings.TrimSpace(command)
 	if e == nil || command == "" {
 		return nil
@@ -153,7 +157,7 @@ func (e *Engine) RegisterShellMatched(event Event, command, matcher string, time
 	if e.shell == nil {
 		e.shell = make(map[Event][]shellHook)
 	}
-	e.shell[event] = append(e.shell[event], shellHook{command: command, matcher: re, timeout: timeout})
+	e.shell[event] = append(e.shell[event], shellHook{command: command, matcher: re, async: async, timeout: timeout})
 	return nil
 }
 
@@ -220,8 +224,9 @@ func (e *Engine) Inject(ctx context.Context, p Payload) string {
 
 // Dispatch runs the hooks for a side-effect event (Stop / SubagentStop /
 // PreCompact): output is ignored, failures surface via Notify but never
-// propagate. Runs synchronously within each hook's timeout (async execution
-// lands in a later phase). No-op on a nil engine or an unconfigured event.
+// propagate. A hook marked async is handed to the durable spill queue and runs
+// off the critical path; the rest run synchronously within their timeout.
+// No-op on a nil engine or an unconfigured event.
 func (e *Engine) Dispatch(ctx context.Context, p Payload) {
 	if e == nil {
 		return
@@ -230,7 +235,26 @@ func (e *Engine) Dispatch(ctx context.Context, p Payload) {
 	for _, fn := range ip {
 		fn(ctx, p) // side-effect events ignore in-proc output
 	}
-	e.runShellHooks(ctx, sh, p)
+	if len(sh) == 0 {
+		return
+	}
+	stdin, err := json.Marshal(p)
+	if err != nil {
+		e.notify("hooks: marshal " + string(p.Event) + " payload: " + err.Error())
+		return
+	}
+	for _, h := range sh {
+		if !h.matches(p.Event, p.ToolName) {
+			continue
+		}
+		if h.async {
+			enqueueAsync(asyncItem{Command: h.command, Timeout: h.timeout, Payload: p})
+			continue
+		}
+		if _, rerr := execShell(ctx, h.command, stdin, h.timeout); rerr != nil {
+			e.notify(rerr.Error())
+		}
+	}
 }
 
 // runShellHooks marshals the payload once and runs each shell hook, joining the

--- a/internal/hooks/pretooluse_test.go
+++ b/internal/hooks/pretooluse_test.go
@@ -8,7 +8,7 @@ import (
 func preToolEngine(t *testing.T, body, matcher string) *Engine {
 	t.Helper()
 	e := NewEngine(nil)
-	if err := e.RegisterShellMatched(EventPreToolUse, makeScript(t, body), matcher, 0); err != nil {
+	if err := e.RegisterShellMatched(EventPreToolUse, makeScript(t, body), matcher, false, 0); err != nil {
 		t.Fatal(err)
 	}
 	return e
@@ -64,10 +64,10 @@ func TestPreToolUse_MatcherGates(t *testing.T) {
 func TestPreToolUse_BlockWinsOverAllow(t *testing.T) {
 	e := NewEngine(nil)
 	// First hook approves, second blocks — block must win.
-	if err := e.RegisterShellMatched(EventPreToolUse, makeScript(t, `echo '{"decision":"approve"}'`), "", 0); err != nil {
+	if err := e.RegisterShellMatched(EventPreToolUse, makeScript(t, `echo '{"decision":"approve"}'`), "", false, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := e.RegisterShellMatched(EventPreToolUse, makeScript(t, "exit 2"), "", 0); err != nil {
+	if err := e.RegisterShellMatched(EventPreToolUse, makeScript(t, "exit 2"), "", false, 0); err != nil {
 		t.Fatal(err)
 	}
 	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})

--- a/internal/hooks/spill.go
+++ b/internal/hooks/spill.go
@@ -1,0 +1,261 @@
+package hooks
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// Async hooks (Stop / PostToolUse / SubagentStop / PreCompact marked async in
+// hooks.yml) run off the turn's critical path so a slow retention script never
+// blocks the next prompt — the defect the synchronous post-turn hook had. But
+// retention must not be lost either, so the queue is durable at its edges: an
+// item that can't be handed to a worker in time (overflow, or a not-yet-run
+// backlog at process exit) is written to ~/.octo/hooks-pending/ and re-enqueued
+// by the next process to start. The common path stays in-memory; disk is only
+// touched under backpressure or shutdown.
+//
+// The queue is process-level (shared by every Engine, like the SeenSet): one
+// worker set, one pending dir. Multi-process safety rests on atomic-rename
+// claiming of pending files — at worst a retention hook runs twice, never zero
+// times.
+
+const (
+	spillWorkers   = 2  // concurrent async hook executions
+	spillChanDepth = 64 // in-memory backlog before overflow spills to disk
+)
+
+// asyncItem is one queued async hook: the command, its per-hook timeout, and
+// the stdin payload. Serialised to a pending file when spilled.
+type asyncItem struct {
+	Command string        `json:"command"`
+	Timeout time.Duration `json:"timeout"`
+	Payload Payload       `json:"payload"`
+}
+
+type spillQueue struct {
+	mu      sync.Mutex
+	ch      chan asyncItem
+	wg      sync.WaitGroup
+	started bool
+	closed  bool
+	dir     string
+	notify  func(string)
+}
+
+// sharedSpill is the one process-level async queue.
+var sharedSpill = &spillQueue{ch: make(chan asyncItem, spillChanDepth)}
+
+// SetSpillNotify sets the sink for async-hook errors/traces (process-global).
+// Nil-safe; last writer wins. Callers wire it to the same place a synchronous
+// hook's notice would go.
+func SetSpillNotify(fn func(string)) {
+	sharedSpill.mu.Lock()
+	sharedSpill.notify = fn
+	sharedSpill.mu.Unlock()
+}
+
+// enqueueAsync hands an async hook to the queue: in-memory when there's room,
+// otherwise spilled to disk (overflow never blocks the caller). Lazily starts
+// the workers and redelivers any pending files left by a prior process.
+func enqueueAsync(item asyncItem) {
+	sharedSpill.ensureStarted()
+	sharedSpill.offer(item)
+}
+
+// offer hands item to a worker if the in-memory backlog has room, else spills
+// it to disk — overflow (and post-Drain submission) never blocks the caller.
+func (q *spillQueue) offer(item asyncItem) {
+	q.mu.Lock()
+	closed := q.closed
+	q.mu.Unlock()
+	if closed {
+		q.spillToDisk(item)
+		return
+	}
+	select {
+	case q.ch <- item:
+	default:
+		q.spillToDisk(item) // backlog full → durable overflow
+	}
+}
+
+func (q *spillQueue) ensureStarted() {
+	q.mu.Lock()
+	if q.started {
+		q.mu.Unlock()
+		return
+	}
+	q.started = true
+	if q.dir == "" {
+		q.dir = pendingDir()
+	}
+	q.mu.Unlock()
+
+	for i := 0; i < spillWorkers; i++ {
+		q.wg.Add(1)
+		go q.worker()
+	}
+	// Redeliver anything a prior process spilled, in the background so startup
+	// isn't blocked on it.
+	go q.redeliverPending()
+}
+
+func (q *spillQueue) worker() {
+	defer q.wg.Done()
+	for item := range q.ch {
+		q.run(item)
+	}
+}
+
+// run executes one async hook. Errors are surfaced via notify but never
+// retried — a deterministically failing script shouldn't loop forever; the
+// durability guarantee is against crashes and overflow, not against a bad hook.
+func (q *spillQueue) run(item asyncItem) {
+	if _, err := execShell(context.Background(), item.Command, mustMarshal(item.Payload), item.Timeout); err != nil {
+		q.notifyMsg(err.Error())
+	}
+}
+
+func (q *spillQueue) notifyMsg(msg string) {
+	q.mu.Lock()
+	fn := q.notify
+	q.mu.Unlock()
+	if fn != nil {
+		fn(msg)
+	}
+}
+
+// Drain stops accepting new async work and waits up to deadline for the workers
+// to finish the in-memory backlog. Anything still queued when the deadline hits
+// is spilled to disk for the next process. Called from the CLI exit path and
+// the server's shutdown. Safe to call once.
+func (q *spillQueue) Drain(deadline time.Duration) {
+	q.mu.Lock()
+	if !q.started || q.closed {
+		q.closed = true
+		q.mu.Unlock()
+		return
+	}
+	q.closed = true
+	close(q.ch)
+	q.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() { q.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(deadline):
+	}
+	// Spill whatever the workers didn't pick up so it survives process exit.
+	// On the done path the workers already drained the channel (this loop finds
+	// it empty); on timeout, or when no workers were running, it flushes the
+	// backlog to disk. The channel is closed, so a receive never blocks: it
+	// yields buffered items, then (zero, false) to end the loop.
+	for {
+		item, ok := <-q.ch
+		if !ok {
+			return
+		}
+		q.spillToDisk(item)
+	}
+}
+
+// DrainSpill drains the process-level async queue. Entry points call it on the
+// way out so queued retention isn't dropped.
+func DrainSpill(deadline time.Duration) { sharedSpill.Drain(deadline) }
+
+func pendingDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "hooks-pending")
+}
+
+// spillToDisk writes item to a uniquely-named pending file (temp + atomic
+// rename). Best-effort: a write failure is surfaced but not fatal.
+func (q *spillQueue) spillToDisk(item asyncItem) {
+	if q.dir == "" {
+		q.dir = pendingDir()
+	}
+	if q.dir == "" {
+		q.notifyMsg("hooks: cannot spill async hook (no home dir); dropping")
+		return
+	}
+	if err := os.MkdirAll(q.dir, 0o755); err != nil {
+		q.notifyMsg("hooks: spill mkdir: " + err.Error())
+		return
+	}
+	b, err := json.Marshal(item)
+	if err != nil {
+		q.notifyMsg("hooks: spill marshal: " + err.Error())
+		return
+	}
+	id := randHex()
+	tmp := filepath.Join(q.dir, "."+id+".tmp")
+	final := filepath.Join(q.dir, id+".json")
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		q.notifyMsg("hooks: spill write: " + err.Error())
+		return
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		_ = os.Remove(tmp)
+		q.notifyMsg("hooks: spill rename: " + err.Error())
+	}
+}
+
+// redeliverPending re-enqueues pending files left by a prior process (or spilled
+// by this one). Each file is claimed by an atomic rename to a per-pid name so two
+// processes can't both run it; the claimer runs it and deletes it. A claim that
+// loses the race (rename fails) is simply skipped.
+func (q *spillQueue) redeliverPending() {
+	if q.dir == "" {
+		return
+	}
+	entries, err := os.ReadDir(q.dir)
+	if err != nil {
+		return
+	}
+	pid := os.Getpid()
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || filepath.Ext(name) != ".json" {
+			continue
+		}
+		src := filepath.Join(q.dir, name)
+		claimed := src + ".claimed." + strconv.Itoa(pid)
+		if err := os.Rename(src, claimed); err != nil {
+			continue // another process claimed it first
+		}
+		b, err := os.ReadFile(claimed)
+		if err != nil {
+			_ = os.Remove(claimed)
+			continue
+		}
+		var item asyncItem
+		if err := json.Unmarshal(b, &item); err != nil {
+			_ = os.Remove(claimed) // corrupt entry — drop it
+			continue
+		}
+		q.run(item)
+		_ = os.Remove(claimed)
+	}
+}
+
+func mustMarshal(p Payload) []byte {
+	b, _ := json.Marshal(p)
+	return b
+}
+
+func randHex() string {
+	var b [12]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}

--- a/internal/hooks/spill_test.go
+++ b/internal/hooks/spill_test.go
@@ -1,0 +1,113 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// waitFor polls until cond is true or the deadline elapses.
+func waitFor(t *testing.T, d time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+func fileExists(p string) bool { _, err := os.Stat(p); return err == nil }
+
+func TestSpill_ToDiskThenRedeliver(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "ran")
+	q := &spillQueue{ch: make(chan asyncItem, 1), dir: dir}
+
+	// Spill an item whose command touches a marker.
+	q.spillToDisk(asyncItem{Command: "touch " + marker, Timeout: DefaultTimeout, Payload: Payload{Event: EventStop}})
+
+	// A pending file now exists; the marker does not yet.
+	pend, _ := filepath.Glob(filepath.Join(dir, "*.json"))
+	if len(pend) != 1 {
+		t.Fatalf("expected 1 pending file, got %d", len(pend))
+	}
+	if fileExists(marker) {
+		t.Fatal("command must not have run yet")
+	}
+
+	// Redelivery claims, runs, and deletes it.
+	q.redeliverPending()
+	if !fileExists(marker) {
+		t.Error("redeliverPending should have run the spilled command")
+	}
+	if pend, _ = filepath.Glob(filepath.Join(dir, "*.json")); len(pend) != 0 {
+		t.Errorf("pending file should be deleted after redelivery, %d remain", len(pend))
+	}
+}
+
+func TestSpill_RunPipesPayloadToStdin(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "captured.json")
+	q := &spillQueue{ch: make(chan asyncItem, 1), dir: dir}
+	q.run(asyncItem{Command: "cat > " + out, Timeout: DefaultTimeout, Payload: Payload{Event: EventStop, AssistantReply: "hi there"}})
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"assistant_reply":"hi there"`) {
+		t.Errorf("payload not delivered on stdin: %s", b)
+	}
+}
+
+func TestSpill_OfferSpillsWhenBacklogFull(t *testing.T) {
+	dir := t.TempDir()
+	q := &spillQueue{ch: make(chan asyncItem, 1), dir: dir}
+	// Fill the single channel slot without a worker draining it.
+	q.ch <- asyncItem{Command: "true"}
+	// Next offer can't enqueue → must spill to disk.
+	q.offer(asyncItem{Command: "true", Payload: Payload{Event: EventStop}})
+	if pend, _ := filepath.Glob(filepath.Join(dir, "*.json")); len(pend) != 1 {
+		t.Errorf("a full backlog must spill to disk, got %d files", len(pend))
+	}
+}
+
+func TestSpill_OfferAfterCloseSpills(t *testing.T) {
+	dir := t.TempDir()
+	q := &spillQueue{ch: make(chan asyncItem, 4), dir: dir, started: true, closed: true}
+	q.offer(asyncItem{Command: "true", Payload: Payload{Event: EventStop}})
+	if pend, _ := filepath.Glob(filepath.Join(dir, "*.json")); len(pend) != 1 {
+		t.Errorf("offer after close must spill, got %d files", len(pend))
+	}
+}
+
+func TestSpill_AsyncRunsViaWorker(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "async-ran")
+	q := &spillQueue{ch: make(chan asyncItem, 4), dir: dir}
+	q.ensureStarted() // starts workers + (empty) redelivery
+	q.offer(asyncItem{Command: "touch " + marker, Timeout: DefaultTimeout, Payload: Payload{Event: EventStop}})
+	if !waitFor(t, 3*time.Second, func() bool { return fileExists(marker) }) {
+		t.Error("async worker should have run the hook")
+	}
+	q.Drain(time.Second)
+}
+
+func TestSpill_DrainSpillsUnrunBacklog(t *testing.T) {
+	dir := t.TempDir()
+	q := &spillQueue{ch: make(chan asyncItem, 8), dir: dir, started: true}
+	// Pre-load the channel WITHOUT starting workers, then drain with a zero
+	// deadline so nothing gets processed — everything must land on disk.
+	for i := 0; i < 5; i++ {
+		q.ch <- asyncItem{Command: "true", Payload: Payload{Event: EventStop}}
+	}
+	q.Drain(1 * time.Millisecond)
+	pend, _ := filepath.Glob(filepath.Join(dir, "*.json"))
+	if len(pend) != 5 {
+		t.Errorf("Drain must spill all %d unrun items; got %d", 5, len(pend))
+	}
+}

--- a/internal/hooks/spill_test.go
+++ b/internal/hooks/spill_test.go
@@ -3,10 +3,21 @@ package hooks
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 )
+
+// posixOnly skips tests that execute POSIX shell commands (touch/cat/…): the
+// hook runner uses PowerShell on Windows, where those commands don't exist.
+// Matches makeScript's Windows trade-off.
+func posixOnly(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("spill test runs POSIX shell commands; not portable to Windows")
+	}
+}
 
 // waitFor polls until cond is true or the deadline elapses.
 func waitFor(t *testing.T, d time.Duration, cond func() bool) bool {
@@ -24,6 +35,7 @@ func waitFor(t *testing.T, d time.Duration, cond func() bool) bool {
 func fileExists(p string) bool { _, err := os.Stat(p); return err == nil }
 
 func TestSpill_ToDiskThenRedeliver(t *testing.T) {
+	posixOnly(t)
 	dir := t.TempDir()
 	marker := filepath.Join(dir, "ran")
 	q := &spillQueue{ch: make(chan asyncItem, 1), dir: dir}
@@ -51,6 +63,7 @@ func TestSpill_ToDiskThenRedeliver(t *testing.T) {
 }
 
 func TestSpill_RunPipesPayloadToStdin(t *testing.T) {
+	posixOnly(t)
 	dir := t.TempDir()
 	out := filepath.Join(dir, "captured.json")
 	q := &spillQueue{ch: make(chan asyncItem, 1), dir: dir}
@@ -86,6 +99,7 @@ func TestSpill_OfferAfterCloseSpills(t *testing.T) {
 }
 
 func TestSpill_AsyncRunsViaWorker(t *testing.T) {
+	posixOnly(t)
 	dir := t.TempDir()
 	marker := filepath.Join(dir, "async-ran")
 	q := &spillQueue{ch: make(chan asyncItem, 4), dir: dir}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -292,6 +292,9 @@ func New(cfg Config) (*Server, error) {
 		return nil, err
 	}
 
+	// Surface async-hook (spill queue) errors through the server log.
+	hooks.SetSpillNotify(func(m string) { slog.Warn("hook", "err", m) })
+
 	cwd, _ := os.Getwd()
 	envCtx := buildEnvContext(cwd)
 
@@ -527,6 +530,9 @@ func (s *Server) doShutdown(ctx context.Context) error {
 	tools.KillAllSessionSubAgents()
 	tools.SetDefaultSubAgentManager(nil)
 	tools.SetTaskStore(nil)
+	// Flush any queued async hooks (retention) to disk so a restart/shutdown
+	// doesn't drop them; the next process redelivers.
+	hooks.DrainSpill(5 * time.Second)
 	if s.mcpCleanup != nil {
 		s.mcpCleanup()
 	}


### PR DESCRIPTION
Fifth PR of the hooks redesign. Builds on #1007.

Adds **async execution** for the side-effect events (\`Stop\`/\`SubagentStop\`/\`PreCompact\` marked \`async: true\`) so a slow retention script never blocks the next prompt — the core defect of the old synchronous post-turn hook — **without losing retention**.

## Design: durable queue (grill decision C — spill-to-disk)
Async hooks go to a process-level bounded worker set. Durability lives at the edges:
- **overflow** (in-memory backlog full) → the item is written to \`~/.octo/hooks-pending/\`;
- **shutdown** with work still queued → \`DrainSpill\` flushes the backlog to the same dir;
- **next process start** → pending files are redelivered.

Cross-process safety is atomic-rename **claiming** of pending files, so a retention hook runs **at most twice, never zero times**. The common path stays in-memory; disk is touched only under backpressure or shutdown.

## Implementation
- \`spill.go\` — the queue: \`offer\` (enqueue-or-spill), workers, \`spillToDisk\` (temp+atomic-rename), \`redeliverPending\` (claim+run+delete), \`Drain\`.
- \`Engine.Dispatch\` routes \`async\` shell hooks to the queue; sync hooks unchanged.
- \`DrainSpill(deadline)\` wired into server \`doShutdown\` and CLI \`runOnce\`/\`runTUI\`.
- \`SetSpillNotify\` surfaces async errors (CLI stderr / server slog).
- \`async\` added to \`HookSpec\` + \`shellHook\` (honoured only for side-effect events).

## Defects closed
**#6** (post-turn hook blocked the next prompt).

## Tests
Spill→redeliver round-trip, payload-on-stdin, overflow-spills, offer-after-close-spills, async-runs-via-worker, Drain-spills-unrun-backlog. Full \`go test -race ./...\` green (the queue is concurrent — race-clean).

## Remaining
Final PR: \`PreCompact\` insertion (#3 remainder) + \`octo hooks list\` observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)