### PR TITLE
feat(hooks): PreCompact event + octo hooks list (PR6, final)

### DIFF
--- a/cmd/octo/hooks.go
+++ b/cmd/octo/hooks.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/Leihb/octo-agent/internal/hooks"
+)
+
+// runHooks backs `octo hooks <subcommand>`. Today it's just `list` — a
+// read-only view of what's configured across the env shim, the user-level
+// hooks.yml, and the project-level hooks.yml (with its trust status), so a 7-
+// event hook surface with blocking and async is inspectable rather than opaque.
+func runHooks(args []string, stdout, stderr io.Writer) int {
+	sub := "list"
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	switch sub {
+	case "list":
+		return runHooksList(stdout)
+	default:
+		fmt.Fprintf(stderr, "octo hooks: unknown subcommand %q (try: list)\n", sub)
+		return 2
+	}
+}
+
+func runHooksList(out io.Writer) int {
+	printed := false
+
+	// env shim.
+	if r := hooks.LoadFromEnv(); r.Configured() {
+		fmt.Fprintln(out, "Environment (OCTO_HOOK_*):")
+		if r.PreTurnCmd != "" {
+			fmt.Fprintf(out, "  UserPromptSubmit  %s\n", r.PreTurnCmd)
+		}
+		if r.PostTurnCmd != "" {
+			fmt.Fprintf(out, "  Stop              %s  (async)\n", r.PostTurnCmd)
+		}
+		printed = true
+	}
+
+	// User-level ~/.octo/hooks.yml.
+	if p := hooks.UserConfigPath(); p != "" {
+		if printFileHooks(out, p, "User ("+p+"):", "") {
+			printed = true
+		}
+	}
+
+	// Project-level <cwd>/.octo/hooks.yml, annotated with trust status.
+	if cwd, err := os.Getwd(); err == nil {
+		if p := hooks.ProjectConfigPath(cwd); p != "" {
+			if b, rerr := os.ReadFile(p); rerr == nil {
+				status := "UNTRUSTED — run octo in this repo and approve to enable"
+				if hooks.IsTrusted(p, hooks.Fingerprint(b)) {
+					status = "trusted"
+				}
+				if printFileHooks(out, p, "Project ("+p+"):", status) {
+					printed = true
+				}
+			}
+		}
+	}
+
+	fmt.Fprintln(out, "Built-in: memory reminder (UserPromptSubmit) + save-nudge (PostToolUse) when a memory directory is present.")
+	if !printed {
+		fmt.Fprintln(out, "No shell hooks configured. See dev-docs/hooks-redesign.md for the hooks.yml schema.")
+	}
+	return 0
+}
+
+// printFileHooks prints the hooks in one hooks.yml. Returns whether anything
+// was printed. A parse error is reported but not fatal (list keeps going).
+func printFileHooks(out io.Writer, path, header, status string) bool {
+	fc, err := hooks.LoadFileConfig(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(out, "%s\n  (unreadable: %v)\n", header, err)
+		}
+		return false
+	}
+	if len(fc.Hooks) == 0 {
+		return false
+	}
+	if status != "" {
+		fmt.Fprintf(out, "%s  [%s]\n", header, status)
+	} else {
+		fmt.Fprintln(out, header)
+	}
+	events := make([]string, 0, len(fc.Hooks))
+	for ev := range fc.Hooks {
+		events = append(events, ev)
+	}
+	sort.Strings(events)
+	for _, ev := range events {
+		for _, h := range fc.Hooks[ev] {
+			line := fmt.Sprintf("  %-16s %s", ev, h.Command)
+			if h.Matcher != "" {
+				line += "  matcher=" + h.Matcher
+			}
+			if h.Async {
+				line += "  (async)"
+			}
+			fmt.Fprintln(out, line)
+		}
+	}
+	return true
+}

--- a/cmd/octo/hooks_test.go
+++ b/cmd/octo/hooks_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunHooksList_ShowsUserConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("OCTO_HOOK_PRE_TURN", "")
+	t.Setenv("OCTO_HOOK_POST_TURN", "")
+
+	dir := filepath.Join(home, ".octo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "hooks:\n  Stop:\n    - command: \"retain\"\n      async: true\n  PostToolUse:\n    - matcher: \"terminal\"\n      command: \"audit\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "hooks.yml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if code := runHooks([]string{"list"}, &out, &out); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	s := out.String()
+	for _, want := range []string{"Stop", "retain", "(async)", "PostToolUse", "audit", "matcher=terminal"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q in:\n%s", want, s)
+		}
+	}
+}
+
+func TestRunHooks_UnknownSubcommand(t *testing.T) {
+	var out bytes.Buffer
+	if code := runHooks([]string{"frobnicate"}, &out, &out); code != 2 {
+		t.Errorf("unknown subcommand exit = %d, want 2", code)
+	}
+}

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -75,6 +75,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return runSessions(args[1:], stdout, stderr)
 	case "skills":
 		return runSkills(args[1:], stdout, stderr)
+	case "hooks":
+		return runHooks(args[1:], stdout, stderr)
 	case "serve":
 		return runServe(args[1:], stdin, stdout, stderr)
 	case "completion":

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1546,6 +1546,18 @@ func (a *Agent) fireStop(userInput string, reply Reply, err error) {
 	a.Hooks.Dispatch(context.Background(), p)
 }
 
+// firePreCompact dispatches the PreCompact hook just before a real compaction
+// fold. Called only once the compaction paths have committed to summarizing
+// (past the reclaim-only and anti-thrash no-op returns), so it doesn't fire on
+// every near-threshold turn. Pure side-effect (notify / archive) — it cannot
+// veto the compaction. Background context so it isn't cancelled with the turn.
+func (a *Agent) firePreCompact() {
+	if a.Hooks == nil || !a.Hooks.Configured(hooks.EventPreCompact) {
+		return
+	}
+	a.Hooks.Dispatch(context.Background(), a.hookPayload(hooks.EventPreCompact))
+}
+
 // flattenResults collapses a per-tool slice-of-slices into a single flat slice.
 func flattenResults(slices [][]ContentBlock) []ContentBlock {
 	var total int

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -339,6 +339,7 @@ func (a *Agent) maybeCompact(ctx context.Context, handler EventHandler) error {
 		return nil
 	}
 
+	a.firePreCompact()
 	if handler != nil {
 		handler(AgentEvent{Kind: EventCompactStarted, Compact: &CompactStats{
 			BeforeTokens: before,
@@ -415,6 +416,7 @@ func (a *Agent) ForceCompact(ctx context.Context, handler EventHandler) (Compact
 		return stats, nil
 	}
 
+	a.firePreCompact()
 	if handler != nil {
 		handler(AgentEvent{Kind: EventCompactStarted, Compact: &CompactStats{
 			BeforeTokens: before,

--- a/internal/agent/precompact_test.go
+++ b/internal/agent/precompact_test.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Leihb/octo-agent/internal/hooks"
+)
+
+func TestFirePreCompact_DispatchesWhenConfigured(t *testing.T) {
+	a := New(&fakeSender{}, "m")
+	a.Hooks = hooks.NewEngine(nil)
+	fired := 0
+	a.Hooks.RegisterInProc(hooks.EventPreCompact, func(_ context.Context, p hooks.Payload) string {
+		if p.Event != hooks.EventPreCompact {
+			t.Errorf("payload event = %q", p.Event)
+		}
+		fired++
+		return ""
+	})
+	a.firePreCompact()
+	if fired != 1 {
+		t.Errorf("PreCompact hook fired %d times, want 1", fired)
+	}
+}
+
+func TestFirePreCompact_NoopWhenUnconfigured(t *testing.T) {
+	a := New(&fakeSender{}, "m")
+	a.Hooks = hooks.NewEngine(nil) // no PreCompact hook
+	a.firePreCompact()             // must not panic / no-op
+	a.Hooks = nil
+	a.firePreCompact() // nil engine must not panic
+}


### PR DESCRIPTION
Final PR of the hooks redesign. Builds on #1008.

## What lands
- **PreCompact** — fires from \`maybeCompact\`/\`ForceCompact\` just before the summarize fold, past the reclaim-only and anti-thrash no-op returns, so it only fires on a real compaction (not every near-threshold turn). Pure side-effect via the async-capable \`Dispatch\`; it cannot veto the compaction. This completes the **7-event set**.
- **\`octo hooks list\`** — a read-only view of the configured shell hooks across the env shim, user-level \`hooks.yml\`, and project-level \`hooks.yml\` (with trust status), plus a note about the built-in memory hooks. Makes a 7-event surface with matchers/blocking/async inspectable.

## Defects closed
**#3** (lifecycle points — the full 7 events now exist) + the observability surface.

## Tests
firePreCompact dispatch + nil/unconfigured no-op; \`octo hooks list\` output (async/matcher rendering) + unknown-subcommand exit. \`go build\` + \`go vet\` + \`go test -race ./...\` all green.

---

## 🎉 Hooks redesign complete — all 11 defects closed
| # | defect | PR |
|---|---|---|
| 1 | shell hooks CLI-only (no web/IM parity) | #1004 |
| 2 | pre-turn couldn't block | #1006 |
| 3 | too few lifecycle points / two split mechanisms | #1004 #1006 #1008 #1007 + this |
| 4 | one command per hook, no matcher | #1005 |
| 5 | env-only, no project file / trust | #1005 #1007 |
| 6 | post-turn blocked the next prompt | #1008 |
| 7 | thin hook context | #1004 |
| 8 | assistant_reply only final text | #1004 |
| 9 | Stop fired only on success | #1004 |
| 10 | in-agent hooks single-slot | #1004 |
| 11 | sub-agents/workflows ran no hooks | #1004 |

Design: \`dev-docs/hooks-redesign.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)