### PR TITLE
docs(dev-docs): correct dynamic-workflow reference to Claude Code

### DIFF
--- a/dev-docs/ruby-workflow-design.md
+++ b/dev-docs/ruby-workflow-design.md
@@ -19,7 +19,7 @@
 
 octo-agent 目前只有**模型驱动**的编排面：`sub_agent`（异步 spawn）、`sub_agent_send/status/kill`、`task_create/update/list`。fan-out 的控制流全靠模型在多轮里自己决定——不可重复、不可确定、无法表达"先全部启动再等全部完成"这类并发结构。缺一个**确定性编排原语**：把"跑哪些 agent、怎么并行、结果怎么汇聚"写成一段可执行的脚本，由 runtime 保证执行。
 
-参考 MiMo Code 的 Dynamic Workflow（`agent()`/`parallel()`/`pipeline()` JS 原语）。本方案用 **Ruby DSL** 实现等价能力，载体是嵌入式 mruby 编译成 WebAssembly、跑在纯 Go 的 wazero 运行时里。
+参考 Claude Code 的 Dynamic Workflow（`agent()`/`parallel()`/`pipeline()` JS 原语）。本方案用 **Ruby DSL** 实现等价能力，载体是嵌入式 mruby 编译成 WebAssembly、跑在纯 Go 的 wazero 运行时里。
 
 ### 为什么是 mruby→WASM→wazero（而非 cgo）
 

--- a/dev-docs/workflow-named-args-design.md
+++ b/dev-docs/workflow-named-args-design.md
@@ -2,7 +2,7 @@
 
 ## 背景
 
-`internal/workflow` 已经能跑 `agent / parallel / pipeline / log / phase / budget_remaining`,`schema` / `isolation: worktree` / 后台运行 / journal 续跑都在。对照 MiMo/CC 的 workflow,还差三块,本方案一并补齐:
+`internal/workflow` 已经能跑 `agent / parallel / pipeline / log / phase / budget_remaining`,`schema` / `isolation: worktree` / 后台运行 / journal 续跑都在。对照 Claude Code 的 workflow,还差三块,本方案一并补齐:
 
 1. **脚本无法参数化** —— 脚本是一段 Ruby 文本,所有输入只能写死进 `script`。没有等价于 CC `args` 全局的入口。
 2. **没有命名/可复用工作流** —— 每次都重发整段脚本,无法把一条流水线存成一个可反复调用的单元。


### PR DESCRIPTION
## What
The Ruby-DSL dynamic-workflow design was modeled on **Claude Code**'s dynamic workflow (the `agent()`/`parallel()`/`pipeline()` orchestration primitives), not MiMo Code. Correct the attribution in both design docs:

- `dev-docs/ruby-workflow-design.md` — "参考 MiMo Code 的 Dynamic Workflow" → "参考 Claude Code 的 Dynamic Workflow"
- `dev-docs/workflow-named-args-design.md` — "对照 MiMo/CC 的 workflow" → "对照 Claude Code 的 workflow"

## Why
Doc-only accuracy fix; keeps the reference consistent with the actual prior art. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)