### PR TITLE
fix(hooks): address review findings (spill race, trust, durability, security)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -73,17 +73,25 @@ func wireSessionHooks(a *agent.Agent, sess *agent.Session, transport string) {
 	if p, err := sess.SavePath(); err == nil {
 		a.HookMeta.TranscriptPath = p
 	}
-	a.SessionStarted = sess.HookStarted
+	// A session loaded with prior history has effectively been started before,
+	// even if it predates the persisted flag (upgraded sessions have no
+	// hook_started field) — treat it as resume, not startup, on first touch.
+	a.SessionStarted = sess.HookStarted || len(sess.Messages) > 0
 	a.OnSessionStart = func() { sess.MarkHookStarted() }
 }
 
 // resolveProjectHooksTrust decides whether the project-level <cwd>/.octo/hooks.yml
 // should be loaded, implementing trust-on-first-use. It returns false (skip)
 // when there is no project file. For an untrusted or changed file it prompts
-// once via reader; approving records the content fingerprint so it won't ask
-// again until the file changes. A non-interactive session (no reader / exhausted
-// stdin) declines — an untrusted repo never silently runs shell on startup.
-func resolveProjectHooksTrust(cwd string, reader lineReader, out, errOut io.Writer) bool {
+// once (when interactive, i.e. stdin is a TTY — works for both the TUI and a
+// one-shot at a terminal); approving records the content fingerprint so it won't
+// ask again until the file changes. A non-interactive session (piped/redirected
+// stdin) declines silently — an untrusted repo never runs shell unattended.
+//
+// The prompt reads a single line directly from stdin byte-by-byte, WITHOUT
+// buffering ahead, so it never swallows input meant for the REPL reader or the
+// bubbletea TUI that starts afterwards.
+func resolveProjectHooksTrust(cwd string, stdin io.Reader, interactive bool, out, errOut io.Writer) bool {
 	path := hooks.ProjectConfigPath(cwd)
 	if path == "" {
 		return false
@@ -96,20 +104,44 @@ func resolveProjectHooksTrust(cwd string, reader lineReader, out, errOut io.Writ
 	if hooks.IsTrusted(path, fp) {
 		return true
 	}
-	if reader == nil {
-		fmt.Fprintf(errOut, "octo: project hooks %s is not trusted; skipped\n", path)
-		return false
+	if !interactive {
+		return false // can't ask; leave project hooks disabled (no noise)
 	}
 	fmt.Fprintf(out, "\n⚠ This repository defines hooks in %s that can run shell commands on your machine.\n", path)
-	line, ok := reader.ReadLine("  Trust and run this repo's hooks? [y/N]: ")
-	if ok && (strings.EqualFold(strings.TrimSpace(line), "y") || strings.EqualFold(strings.TrimSpace(line), "yes")) {
+	fmt.Fprint(out, "  Trust and run this repo's hooks? [y/N]: ")
+	switch readTrustAnswer(stdin) {
+	case "y", "yes":
 		if rerr := hooks.RecordTrust(path, fp); rerr != nil {
 			fmt.Fprintf(errOut, "octo: could not persist hooks trust: %v\n", rerr)
 		}
 		return true
+	default:
+		fmt.Fprintln(out, "  Skipped. Project hooks stay disabled until you trust them.")
+		return false
 	}
-	fmt.Fprintln(out, "  Skipped. Project hooks stay disabled until you trust them.")
-	return false
+}
+
+// readTrustAnswer reads one newline-terminated line from r one byte at a time
+// (no read-ahead), returning the lowercased, trimmed answer. Byte-by-byte so it
+// consumes exactly the answer line and nothing the REPL/TUI will later read.
+func readTrustAnswer(r io.Reader) string {
+	var b []byte
+	buf := make([]byte, 1)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			if buf[0] == '\n' {
+				break
+			}
+			if buf[0] != '\r' {
+				b = append(b, buf[0])
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	return strings.ToLower(strings.TrimSpace(string(b)))
 }
 
 // errMissingAPIKey is returned by resolveAPIKey when no API key is available.
@@ -794,7 +826,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// injector's reminder & save-nudge as in-process hooks, unified on one
 	// dispatch path that the agent core drives for every transport. Shares the
 	// process seen-set so SessionStart resume fires once per OS process.
-	projectHooksTrusted := resolveProjectHooksTrust(cwd, replReader, stdout, stderr)
+	projectHooksTrusted := resolveProjectHooksTrust(cwd, stdin, stdinIsTTY(stdin), stdout, stderr)
 	hookEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen(), cwd, projectHooksTrusted)
 	hookEngine.Notify = func(m string) { fmt.Fprintln(stderr, "↳ hook: "+m) }
 	hooks.SetSpillNotify(func(m string) { fmt.Fprintln(stderr, "↳ hook: "+m) })

--- a/cmd/octo/hooks_test.go
+++ b/cmd/octo/hooks_test.go
@@ -36,6 +36,23 @@ func TestRunHooksList_ShowsUserConfig(t *testing.T) {
 	}
 }
 
+func TestReadTrustAnswer(t *testing.T) {
+	cases := map[string]string{
+		"y\n":      "y",
+		"YES\n":    "yes",
+		"n\n":      "n",
+		"\n":       "",
+		"  y  \n":  "y",
+		"yes\r\n":  "yes", // CRLF stripped
+		"no input": "no input",
+	}
+	for in, want := range cases {
+		if got := readTrustAnswer(strings.NewReader(in)); got != want {
+			t.Errorf("readTrustAnswer(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestRunHooks_UnknownSubcommand(t *testing.T) {
 	var out bytes.Buffer
 	if code := runHooks([]string{"frobnicate"}, &out, &out); code != 2 {

--- a/dev-docs/hooks-redesign.md
+++ b/dev-docs/hooks-redesign.md
@@ -182,6 +182,8 @@ hooks:
 
 现有 Hindsight 用户零改动,且因执行下沉 agent core,自动获得 web/IM 覆盖。
 
+**迁移注意(行为变更)**:`Stop` 现在**成功与失败/中断都触发**(旧的 post-turn 只在成功时触发),这是缺陷 #9 的修复。因此经 `OCTO_HOOK_POST_TURN` 接入的留存脚本现在也会在失败/被中断的回合上被调用,此时 `assistant_reply` 可能为空且 payload 带非空 `error` 字段。**留存脚本应检查 `error` 字段**,失败回合按需跳过索引,避免写入残缺记录。payload 是向后兼容的超集(新增 `error` / `tools_used`),只解析 `user_input`/`assistant_reply` 的旧脚本不会解析报错,仅是多了失败回合的调用。
+
 ---
 
 ## Hook 协议

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -466,6 +466,18 @@ func (s *Session) rewriteAll() error {
 			return fmt.Errorf("session: write message: %w", err)
 		}
 	}
+	// A turn lease lives only as an append-only "lease" record; truncating the
+	// file here would erase it (widening the cross-process binding-steal window
+	// mid-turn — e.g. when the first-turn MarkHookStarted forces this rewrite).
+	// Re-emit an active lease after the meta+messages so it survives the rewrite.
+	s.mu.Lock()
+	leaseEntry, leaseExpires := s.LeaseEntry, s.LeaseExpires
+	s.mu.Unlock()
+	if leaseEntry != "" && !leaseExpires.IsZero() && time.Now().Before(leaseExpires) {
+		if err := enc.Encode(sessionRecord{Type: "lease", LeaseEntry: leaseEntry, LeaseExpires: leaseExpires}); err != nil {
+			return fmt.Errorf("session: write lease: %w", err)
+		}
+	}
 	if err := w.Flush(); err != nil {
 		return fmt.Errorf("session: flush %s: %w", path, err)
 	}

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -72,6 +72,32 @@ func TestSessionHookStartedRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSessionLeaseSurvivesForcedRewrite(t *testing.T) {
+	setTempHome(t)
+	s := NewSession("m", "")
+	s.Messages = append(s.Messages, NewUserMessage("hi"))
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := s.WriteLease("web", time.Now().Add(time.Minute)); err != nil {
+		t.Fatalf("WriteLease: %v", err)
+	}
+	// MarkHookStarted (first-turn SessionStart) forces the next Save to rewrite
+	// the whole file, which must NOT drop the append-only lease record.
+	s.MarkHookStarted()
+	s.Messages = append(s.Messages, NewAssistantMessage("ok"))
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save (rewrite): %v", err)
+	}
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if holder, active := got.LeaseActive(); !active || holder != "web" {
+		t.Errorf("lease lost across forced rewrite: active=%v holder=%q, want active web", active, holder)
+	}
+}
+
 func TestSessionIDFormat(t *testing.T) {
 	s := NewSession("m", "")
 	// YYYYMMDD-HHMMSS-xxxxxxxx — 24 chars (15 timestamp + '-' + 8 hex suffix).

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -77,6 +77,9 @@ func (e *Engine) LoadConfig(fc FileConfig) error {
 			return fmt.Errorf("hooks: unknown event %q in hooks.yml", name)
 		}
 		for _, s := range specs {
+			if s.Async && ev.injects() {
+				return fmt.Errorf("hooks: %s: async is not supported for this event — its output is folded into the model stream and must run synchronously", name)
+			}
 			if err := e.RegisterShellMatched(ev, s.Command, s.Matcher, s.Async, parseTimeout(s.Timeout)); err != nil {
 				return fmt.Errorf("hooks: %s: invalid matcher %q: %w", name, s.Matcher, err)
 			}

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -34,6 +34,22 @@ func TestLoadConfig_RejectsUnknownEvent(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_RejectsAsyncOnInjectingEvent(t *testing.T) {
+	// PostToolUse is an injecting event — its output is folded into the result,
+	// so async must be rejected rather than silently ignored.
+	if err := NewEngine(nil).LoadConfig(FileConfig{Hooks: map[string][]HookSpec{
+		"PostToolUse": {{Command: "x", Async: true}},
+	}}); err == nil {
+		t.Error("async:true on PostToolUse (injecting) must be rejected")
+	}
+	// Stop is a side-effect event — async is allowed.
+	if err := NewEngine(nil).LoadConfig(FileConfig{Hooks: map[string][]HookSpec{
+		"Stop": {{Command: "x", Async: true}},
+	}}); err != nil {
+		t.Errorf("async:true on Stop (side-effect) should be allowed, got %v", err)
+	}
+}
+
 func TestLoadConfig_RejectsBadMatcher(t *testing.T) {
 	e := NewEngine(nil)
 	err := e.LoadConfig(FileConfig{Hooks: map[string][]HookSpec{

--- a/internal/hooks/engine.go
+++ b/internal/hooks/engine.go
@@ -238,22 +238,46 @@ func (e *Engine) Dispatch(ctx context.Context, p Payload) {
 	if len(sh) == 0 {
 		return
 	}
-	stdin, err := json.Marshal(p)
-	if err != nil {
-		e.notify("hooks: marshal " + string(p.Event) + " payload: " + err.Error())
-		return
-	}
+	stdin := e.lazyStdin(p)
 	for _, h := range sh {
 		if !h.matches(p.Event, p.ToolName) {
 			continue
 		}
 		if h.async {
-			enqueueAsync(asyncItem{Command: h.command, Timeout: h.timeout, Payload: p})
-			continue
+			enqueueAsync(asyncItem{Command: h.command, Timeout: h.timeout, Cwd: p.Cwd, Payload: p})
+			continue // async path carries the payload itself; no stdin marshal needed
 		}
-		if _, rerr := execShell(ctx, h.command, stdin, h.timeout); rerr != nil {
+		body, ok := stdin()
+		if !ok {
+			return
+		}
+		if _, rerr := execShell(ctx, h.command, body, h.timeout); rerr != nil {
 			e.notify(rerr.Error())
 		}
+	}
+}
+
+// lazyStdin returns a function that marshals p to hook-stdin JSON at most once,
+// on first call — so an event whose hooks are all filtered out by matcher (or
+// all async) never pays the marshal of a possibly-large payload. The second
+// return is false if marshalling failed (surfaced via Notify).
+func (e *Engine) lazyStdin(p Payload) func() ([]byte, bool) {
+	var (
+		body []byte
+		done bool
+		ok   bool
+	)
+	return func() ([]byte, bool) {
+		if !done {
+			done = true
+			b, err := json.Marshal(p)
+			if err != nil {
+				e.notify("hooks: marshal " + string(p.Event) + " payload: " + err.Error())
+			} else {
+				body, ok = b, true
+			}
+		}
+		return body, ok
 	}
 }
 
@@ -265,17 +289,17 @@ func (e *Engine) runShellHooks(ctx context.Context, hooks []shellHook, p Payload
 	if len(hooks) == 0 {
 		return ""
 	}
-	stdin, err := json.Marshal(p)
-	if err != nil {
-		e.notify("hooks: marshal " + string(p.Event) + " payload: " + err.Error())
-		return ""
-	}
+	stdin := e.lazyStdin(p)
 	var parts []string
 	for _, h := range hooks {
 		if !h.matches(p.Event, p.ToolName) {
 			continue
 		}
-		out, err := execShell(ctx, h.command, stdin, h.timeout)
+		body, ok := stdin()
+		if !ok {
+			return strings.Join(parts, "\n\n")
+		}
+		out, err := execShell(ctx, h.command, body, h.timeout)
 		if err != nil {
 			e.notify(err.Error())
 			continue
@@ -340,7 +364,7 @@ func (e *Engine) PreToolUse(ctx context.Context, p Payload) ToolDecision {
 		if !h.matches(EventPreToolUse, p.ToolName) {
 			continue
 		}
-		res := runShellRaw(ctx, h.command, stdin, h.timeout)
+		res := runShellRaw(ctx, h.command, stdin, h.timeout, "")
 		switch {
 		case res.timedOut:
 			e.notify(fmt.Sprintf("hooks: PreToolUse %s timed out after %s (tool allowed to proceed)", h.command, h.timeout))
@@ -448,7 +472,10 @@ func EngineFromEnv(seen *SeenSet) *Engine {
 		e.RegisterShell(EventUserPromptSubmit, r.PreTurnCmd, timeout)
 	}
 	if r.PostTurnCmd != "" {
-		e.RegisterShell(EventStop, r.PostTurnCmd, timeout)
+		// async so a slow retain script doesn't block the next prompt — the
+		// fire-and-forget the legacy post-turn hook intended (and what
+		// `octo hooks list` advertises for this shim).
+		_ = e.RegisterShellMatched(EventStop, r.PostTurnCmd, "", true, timeout)
 	}
 	return e
 }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -164,7 +164,15 @@ func (r *Runner) run(ctx context.Context, cmd string, stdin []byte) ([]byte, err
 // a timeout from a plain failure (with the stderr tail folded in) to help users
 // debug hook wiring.
 func execShell(ctx context.Context, cmd string, stdin []byte, deadline time.Duration) ([]byte, error) {
-	res := runShellRaw(ctx, cmd, stdin, deadline)
+	return execShellDir(ctx, cmd, stdin, deadline, "")
+}
+
+// execShellDir is execShell with an explicit working directory. An empty dir
+// inherits the process cwd. The async path passes the hook's originating cwd so
+// a relative command runs where it was configured, not in whatever process
+// later claims a spilled item.
+func execShellDir(ctx context.Context, cmd string, stdin []byte, deadline time.Duration, dir string) ([]byte, error) {
+	res := runShellRaw(ctx, cmd, stdin, deadline, dir)
 	if res.timedOut {
 		return res.stdout, fmt.Errorf("hooks: %s timed out after %s", cmd, deadline)
 	}
@@ -192,11 +200,14 @@ type shellResult struct {
 // runShellRaw runs cmd through the platform shell with stdin piped in, bounded
 // by deadline, and reports the full outcome. It is the single place the shell
 // selection, WaitDelay teardown, and timeout live.
-func runShellRaw(ctx context.Context, cmd string, stdin []byte, deadline time.Duration) shellResult {
+func runShellRaw(ctx context.Context, cmd string, stdin []byte, deadline time.Duration, dir string) shellResult {
 	rctx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()
 
 	c := shellCmd(rctx, cmd)
+	if dir != "" {
+		c.Dir = dir
+	}
 	c.Stdin = bytes.NewReader(stdin)
 	var out, errBuf bytes.Buffer
 	c.Stdout = &out

--- a/internal/hooks/spill.go
+++ b/internal/hooks/spill.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -31,11 +32,20 @@ const (
 	spillChanDepth = 64 // in-memory backlog before overflow spills to disk
 )
 
-// asyncItem is one queued async hook: the command, its per-hook timeout, and
-// the stdin payload. Serialised to a pending file when spilled.
+// staleClaimAge is how long a claimed-but-unfinished pending file must sit
+// before another process reclaims it. Set well past any hook's max runtime
+// (timeoutCeiling) so a live sibling's in-flight claim is never stolen; only a
+// crashed claimer's orphan is recovered.
+const staleClaimAge = 2 * timeoutCeiling
+
+// asyncItem is one queued async hook: the command, its per-hook timeout, the
+// originating working directory (so a relative command runs where it was
+// configured, not in whatever process later claims it), and the stdin payload.
+// Serialised to a pending file when spilled.
 type asyncItem struct {
 	Command string        `json:"command"`
 	Timeout time.Duration `json:"timeout"`
+	Cwd     string        `json:"cwd,omitempty"`
 	Payload Payload       `json:"payload"`
 }
 
@@ -71,19 +81,22 @@ func enqueueAsync(item asyncItem) {
 
 // offer hands item to a worker if the in-memory backlog has room, else spills
 // it to disk — overflow (and post-Drain submission) never blocks the caller.
+// The closed-check and the send are done under the SAME lock that Drain holds
+// while it closes the channel, so offer can never send on a closed channel
+// (which would panic). The send is non-blocking (select/default), so holding
+// the lock across it can't deadlock; spillToDisk runs after releasing it.
 func (q *spillQueue) offer(item asyncItem) {
 	q.mu.Lock()
-	closed := q.closed
+	if !q.closed {
+		select {
+		case q.ch <- item:
+			q.mu.Unlock()
+			return
+		default: // backlog full
+		}
+	}
 	q.mu.Unlock()
-	if closed {
-		q.spillToDisk(item)
-		return
-	}
-	select {
-	case q.ch <- item:
-	default:
-		q.spillToDisk(item) // backlog full → durable overflow
-	}
+	q.spillToDisk(item) // closed, or backlog full → durable overflow
 }
 
 func (q *spillQueue) ensureStarted() {
@@ -118,7 +131,7 @@ func (q *spillQueue) worker() {
 // retried — a deterministically failing script shouldn't loop forever; the
 // durability guarantee is against crashes and overflow, not against a bad hook.
 func (q *spillQueue) run(item asyncItem) {
-	if _, err := execShell(context.Background(), item.Command, mustMarshal(item.Payload), item.Timeout); err != nil {
+	if _, err := execShellDir(context.Background(), item.Command, mustMarshal(item.Payload), item.Timeout, item.Cwd); err != nil {
 		q.notifyMsg(err.Error())
 	}
 }
@@ -219,6 +232,7 @@ func (q *spillQueue) redeliverPending() {
 	if q.dir == "" {
 		return
 	}
+	q.reclaimStaleClaims()
 	entries, err := os.ReadDir(q.dir)
 	if err != nil {
 		return
@@ -234,6 +248,10 @@ func (q *spillQueue) redeliverPending() {
 		if err := os.Rename(src, claimed); err != nil {
 			continue // another process claimed it first
 		}
+		// Stamp the claim time so a crash mid-run leaves an orphan that
+		// reclaimStaleClaims recovers only after it's provably stale.
+		now := time.Now()
+		_ = os.Chtimes(claimed, now, now)
 		b, err := os.ReadFile(claimed)
 		if err != nil {
 			_ = os.Remove(claimed)
@@ -246,6 +264,31 @@ func (q *spillQueue) redeliverPending() {
 		}
 		q.run(item)
 		_ = os.Remove(claimed)
+	}
+}
+
+// reclaimStaleClaims renames orphaned "<id>.json.claimed.<pid>" files — left by
+// a claimer that crashed between claiming and deleting — back to "<id>.json" so
+// they're retried, but only once they're older than staleClaimAge (past any
+// hook's max runtime), so a live sibling's in-flight claim is never stolen.
+// This closes the "runs zero times" gap in the durability guarantee.
+func (q *spillQueue) reclaimStaleClaims() {
+	entries, err := os.ReadDir(q.dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		idx := strings.Index(name, ".json.claimed.")
+		if e.IsDir() || idx < 0 {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || time.Since(info.ModTime()) < staleClaimAge {
+			continue
+		}
+		orig := name[:idx] + ".json"
+		_ = os.Rename(filepath.Join(q.dir, name), filepath.Join(q.dir, orig))
 	}
 }
 

--- a/internal/hooks/spill_test.go
+++ b/internal/hooks/spill_test.go
@@ -5,9 +5,71 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
+
+// TestSpill_ConcurrentOfferDrainNoPanic guards the critical send-on-closed race:
+// many offers racing a Drain that closes the channel must never panic. Run under
+// -race. Pre-fix, an offer that passed the closed-check then sent after Drain's
+// close() would panic "send on closed channel".
+func TestSpill_ConcurrentOfferDrainNoPanic(t *testing.T) {
+	dir := t.TempDir()
+	q := &spillQueue{ch: make(chan asyncItem, 2), dir: dir, started: true}
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			q.offer(asyncItem{Command: "x", Payload: Payload{Event: EventStop}})
+		}()
+	}
+	q.Drain(20 * time.Millisecond) // closes q.ch while offers are in flight
+	wg.Wait()                      // no panic == pass
+}
+
+func TestSpill_ReclaimStaleClaim(t *testing.T) {
+	dir := t.TempDir()
+	q := &spillQueue{dir: dir}
+
+	// An orphaned claim aged past staleClaimAge is reclaimed to <id>.json.
+	stale := filepath.Join(dir, "abc.json.claimed.999")
+	if err := os.WriteFile(stale, []byte(`{"command":"x"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * staleClaimAge)
+	_ = os.Chtimes(stale, old, old)
+
+	// A fresh claim (a live sibling's in-flight work) must NOT be reclaimed.
+	fresh := filepath.Join(dir, "def.json.claimed.888")
+	if err := os.WriteFile(fresh, []byte(`{"command":"y"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	q.reclaimStaleClaims()
+
+	if fileExists(stale) {
+		t.Error("stale claim should have been reclaimed")
+	}
+	if !fileExists(filepath.Join(dir, "abc.json")) {
+		t.Error("stale claim should be renamed back to .json")
+	}
+	if !fileExists(fresh) {
+		t.Error("a fresh claim must not be reclaimed (would steal a live sibling's work)")
+	}
+}
+
+func TestSpill_RunUsesOriginatingCwd(t *testing.T) {
+	posixOnly(t)
+	runDir := t.TempDir()
+	q := &spillQueue{dir: t.TempDir()}
+	// Relative command; must execute in item.Cwd, not the process cwd.
+	q.run(asyncItem{Command: "touch marker", Timeout: DefaultTimeout, Cwd: runDir, Payload: Payload{Event: EventStop}})
+	if !fileExists(filepath.Join(runDir, "marker")) {
+		t.Error("async hook should run in item.Cwd (confused-deputy fix)")
+	}
+}
 
 // posixOnly skips tests that execute POSIX shell commands (touch/cat/…): the
 // hook runner uses PowerShell on Windows, where those commands don't exist.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -294,6 +294,18 @@ func New(cfg Config) (*Server, error) {
 
 	// Surface async-hook (spill queue) errors through the server log.
 	hooks.SetSpillNotify(func(m string) { slog.Warn("hook", "err", m) })
+	// Auto-trust the operator-chosen launch cwd's project hooks (a documented
+	// decision — the operator started serve here). Every later project-hook load
+	// is gated on IsTrusted, so switching working_dir into an untrusted repo does
+	// NOT load its hooks; trusting happens only for this launch dir (recorded) or
+	// dirs a CLI run trusted.
+	if cwd, err := os.Getwd(); err == nil {
+		if p := hooks.ProjectConfigPath(cwd); p != "" {
+			if b, rerr := os.ReadFile(p); rerr == nil {
+				_ = hooks.RecordTrust(p, hooks.Fingerprint(b))
+			}
+		}
+	}
 
 	cwd, _ := os.Getwd()
 	envCtx := buildEnvContext(cwd)
@@ -922,6 +934,23 @@ func resolveUnderCWD(cwd, path string) (string, bool) {
 
 // buildAgent creates a fresh agent for a turn. The caller must have locked
 // the session's turn mutex.
+// projectHooksTrusted reports whether the project-level hooks.yml at cwd is
+// trusted (its current content fingerprint is in the trust store). The launch
+// cwd is auto-trusted at New; other directories a session's working_dir is
+// switched into are trusted only if a prior CLI run approved them — so a
+// working_dir retarget can't silently load an untrusted repo's hooks.
+func (s *Server) projectHooksTrusted(cwd string) bool {
+	path := hooks.ProjectConfigPath(cwd)
+	if path == "" {
+		return false
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return hooks.IsTrusted(path, hooks.Fingerprint(b))
+}
+
 func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	sender, model := s.senderForSession(sess)
 	a := agent.New(sender, model)
@@ -959,7 +988,7 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	// tool results, plus any shell hooks (env/hooks.yml), unified on the agent's
 	// hook engine. Shares the process seen-set so SessionStart resume fires once
 	// per OS process across the serve process's many sessions.
-	hookEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen(), cwd, true)
+	hookEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen(), cwd, s.projectHooksTrusted(cwd))
 	hookEngine.Notify = func(m string) { slog.Warn("hook", "err", m) }
 	if s.memDir != "" {
 		s.injectorFor(sess.ID).RegisterHooks(hookEngine)
@@ -969,7 +998,7 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	if p, err := sess.SavePath(); err == nil {
 		a.HookMeta.TranscriptPath = p
 	}
-	a.SessionStarted = sess.HookStarted
+	a.SessionStarted = sess.HookStarted || len(sess.Messages) > 0
 	a.OnSessionStart = func() { sess.MarkHookStarted() }
 
 	if len(sess.Messages) > 0 {
@@ -1922,7 +1951,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// L2 memory hooks + shell hooks, same engine buildAgent gives web turns,
 	// rebuilt per IM turn. The injector is session-sticky (recall latch) and
 	// dropped on /unbind; a fresh engine each turn just re-registers it.
-	imEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen(), cwd, true)
+	imEngine := hooks.EngineFromEnvAndFiles(hooks.SharedSeen(), cwd, s.projectHooksTrusted(cwd))
 	imEngine.Notify = func(m string) { slog.Warn("hook", "err", m) }
 	if s.memDir != "" {
 		s.injectorFor("im:" + string(sess.Key)).RegisterHooks(imEngine)
@@ -1937,7 +1966,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		if p, err := st.SavePath(); err == nil {
 			sess.Agent.HookMeta.TranscriptPath = p
 		}
-		sess.Agent.SessionStarted = st.HookStarted
+		sess.Agent.SessionStarted = st.HookStarted || len(st.Messages) > 0
 		sess.Agent.OnSessionStart = func() { st.MarkHookStarted() }
 	}
 


### PR DESCRIPTION
Follow-up to the hooks-redesign review (the 5-dimension workflow over #1004–1009). Addresses all confirmed findings.

## Critical
- **`spill.go` send-on-closed panic** — `offer()` now holds `q.mu` across the non-blocking channel send, so a concurrent `Drain` `close()` can't panic the `serve` daemon. + a `-race` concurrent offer/Drain test.

## High
- **TUI trust unreachable** — `resolveProjectHooksTrust` now reads one line from stdin directly (byte-by-byte, no read-ahead so it can't steal input from the REPL/bubbletea that starts after), gated on `stdinIsTTY`. TUI and one-shot can both approve; non-interactive declines silently (no more per-startup "not trusted" warning).

## Medium
- **Orphaned `.claimed` durability gap** — startup reclaims stale `<id>.json.claimed.<pid>` orphans (crash between claim and delete) once past `staleClaimAge`; claim time is stamped so a live sibling's claim isn't stolen. Closes the "runs zero times" gap.
- **Confused-deputy cwd** — async items carry their originating cwd and run with `cmd.Dir` set (`execShellDir`), so a spilled relative command can't execute from a foreign repo's cwd.
- **`serve` working_dir retarget** — project hooks are trust-gated via `IsTrusted` instead of hardcoded `true`; the launch cwd is auto-trusted at `New`, so PATCHing `working_dir` into an untrusted dir no longer loads its hooks.
- **Session lease erased** — `rewriteAll` re-emits an active turn lease, so the first-turn `MarkHookStarted` forced rewrite no longer drops it (was widening the cross-process binding-steal window).

## Low / doc
- Reject `async:true` on injecting events (`config.go`).
- Env `OCTO_HOOK_POST_TURN`→Stop registered **async** (matches doc + the `octo hooks list` label); payload marshaled lazily.
- Seed `SessionStarted` from `len(Messages)>0` so an upgraded session resumes rather than "starts up".
- Migration note: Stop now fires on failed/interrupted turns (behavior **kept** — the intended #9 fix; env `POST_TURN` scripts should branch on `error`).

## Tests
Concurrent offer/Drain (no panic, -race), stale-claim reclaim + live-claim preservation, async cwd binding, reject-async-on-injecting, lease-survives-rewrite, `readTrustAnswer` parsing. `go build` + `go vet` + `go test -race ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)