### PR TITLE
chore: finish Leihb → open-octo rename after org transfer

### DIFF
--- a/dev-docs/windows-onboarding-design.md
+++ b/dev-docs/windows-onboarding-design.md
@@ -160,7 +160,7 @@ run `octo`. The bash/curl path stays for macOS/Linux.
 
 - **Code signing** — deferred; hook left in the workflow.
 - **winget channel** — complementary and planned next: a winget manifest points
-  `winget install Leihb.octo` at this same `octo-setup.exe`. Not this round.
+  `winget install open-octo.octo` at this same `octo-setup.exe`. Not this round.
 - **arm64-native installer** — amd64 installer covers ARM via emulation for now.
 - **macOS `.pkg` / Linux `.deb`/`.rpm`** — the symmetric idea for other
   platforms; not this round.

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -128,14 +128,14 @@ func TestDefaultRules_WebFetchIPv6LoopbackDenied(t *testing.T) {
 func TestDefaultRules_WebFetchPrivateRangeDenied(t *testing.T) {
 	e := newDefaultEngine(t)
 	cases := map[string]Decision{
-		"http://10.0.0.1/secret":          Deny,
-		"http://192.168.1.1/router":       Deny,
-		"http://127.0.0.1:8080/":          Deny,
-		"http://localhost/":               Deny,
-		"http://169.254.169.254/metadata": Deny, // AWS metadata
-		"https://github.com/Leihb/octo":   Allow,
-		"https://pkg.go.dev/net/url":      Allow,
-		"https://random.example.com/":     Ask,
+		"http://10.0.0.1/secret":                  Deny,
+		"http://192.168.1.1/router":               Deny,
+		"http://127.0.0.1:8080/":                  Deny,
+		"http://localhost/":                       Deny,
+		"http://169.254.169.254/metadata":         Deny, // AWS metadata
+		"https://github.com/open-octo/octo-agent": Allow,
+		"https://pkg.go.dev/net/url":              Allow,
+		"https://random.example.com/":             Ask,
 	}
 	for u, want := range cases {
 		got := e.Check("web_fetch", map[string]any{"url": u})

--- a/packaging/windows/octo.iss
+++ b/packaging/windows/octo.iss
@@ -24,7 +24,7 @@
 AppId={{8F2A6B1C-3D4E-4F50-9A6B-7C8D9E0F1A2B}
 AppName=octo
 AppVersion={#AppVersion}
-AppPublisher=Leihb
+AppPublisher=open-octo
 AppPublisherURL=https://github.com/open-octo/octo-agent
 DefaultDirName={userpf}\octo
 DisableProgramGroupPage=yes


### PR DESCRIPTION
## What
The repo moved to the `open-octo` org. `go.mod` and all imports are already on `github.com/open-octo/octo-agent`; this cleans up the last three stray `Leihb` references:

- `internal/permission/permission_test.go` — example GitHub URL in the `web_fetch` allow-rule test → `github.com/open-octo/octo-agent` (gofmt re-aligned the map; test passes)
- `packaging/windows/octo.iss` — `AppPublisher=Leihb` → `open-octo` (`AppPublisherURL` was already open-octo)
- `dev-docs/windows-onboarding-design.md` — `winget install Leihb.octo` → `open-octo.octo` in a future-note

## Deliberately not changed
- `LICENSE.txt` copyright line stays `Copyright (c) 2026 Leihb (roy)` — transferring the repo to an org does **not** reassign copyright. Change it only if you intend to hand copyright to the org (a legal decision, not a cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)