### PR TITLE
feat(installer): auto-install PowerShell 7 via winget on Windows

### DIFF
--- a/packaging/windows/octo.iss
+++ b/packaging/windows/octo.iss
@@ -162,10 +162,15 @@ end;
 // EnsurePowerShell7 best-effort installs PowerShell 7 via winget when it is
 // missing. octo runs hook scripts and the terminal tool through pwsh (7+) when
 // present, falling back to the clumsier Windows PowerShell 5.1 otherwise, so a
-// present pwsh is a better default. Every failure path — pwsh already there,
-// no winget (older Windows / enterprise policy), declined UAC, no network — is
-// a silent no-op: octo simply keeps using 5.1. winget may raise one UAC prompt
-// for the machine-wide PowerShell MSI; that is the only elevation octo asks for.
+// present pwsh is a better default. Every skip/failure path — pwsh already
+// there, no winget (older Windows / enterprise policy), user declined, no
+// network — is a no-op: octo simply keeps using 5.1.
+//
+// The winget package is a machine-wide MSI, so Windows raises a UAC prompt.
+// Rather than let that prompt appear out of nowhere and alarm a non-technical
+// user, we explain up front what is about to happen and that the Windows
+// permission dialog is expected, and let them decline. This is the only
+// elevation the otherwise UAC-free per-user installer ever asks for.
 procedure EnsurePowerShell7;
 var
   ResultCode: Integer;
@@ -173,6 +178,18 @@ begin
   if CommandFound('pwsh') then
     exit;
   if not CommandFound('winget') then
+    exit;
+  if MsgBox(
+       'octo works best with PowerShell 7, which is not installed yet.' + #13#10#13#10 +
+       'Would you like to install it now? Windows will show a blue "User Account ' +
+       'Control" window asking for permission — this is normal and safe; just ' +
+       'choose "Yes" there.' + #13#10#13#10 +
+       'Choose "No" to skip — octo will still work using the built-in Windows ' +
+       'PowerShell.' + #13#10#13#10 +
+       'octo 建议使用 PowerShell 7。是否现在安装？期间 Windows 会弹出蓝色的' +
+       '"用户账户控制"授权窗口，这是正常且安全的，点"是"即可。选"否"可跳过，' +
+       'octo 仍可正常使用系统自带的 PowerShell。',
+       mbConfirmation, MB_YESNO) <> IDYES then
     exit;
   WizardForm.StatusLabel.Caption := 'Installing PowerShell 7 (recommended)...';
   Exec(ExpandConstant('{cmd}'),

--- a/packaging/windows/octo.iss
+++ b/packaging/windows/octo.iss
@@ -149,6 +149,39 @@ begin
   SaveStringToFile(ExpandConstant('{app}\octo-autostart.vbs'), Vbs, False);
 end;
 
+// CommandFound reports whether `where <name>` resolves, i.e. the CLI is on
+// PATH. Run through cmd so redirection hides its output and no window flashes.
+function CommandFound(const Name: string): Boolean;
+var
+  ResultCode: Integer;
+begin
+  Result := Exec(ExpandConstant('{cmd}'), '/C where ' + Name + ' >nul 2>&1', '',
+                 SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0);
+end;
+
+// EnsurePowerShell7 best-effort installs PowerShell 7 via winget when it is
+// missing. octo runs hook scripts and the terminal tool through pwsh (7+) when
+// present, falling back to the clumsier Windows PowerShell 5.1 otherwise, so a
+// present pwsh is a better default. Every failure path — pwsh already there,
+// no winget (older Windows / enterprise policy), declined UAC, no network — is
+// a silent no-op: octo simply keeps using 5.1. winget may raise one UAC prompt
+// for the machine-wide PowerShell MSI; that is the only elevation octo asks for.
+procedure EnsurePowerShell7;
+var
+  ResultCode: Integer;
+begin
+  if CommandFound('pwsh') then
+    exit;
+  if not CommandFound('winget') then
+    exit;
+  WizardForm.StatusLabel.Caption := 'Installing PowerShell 7 (recommended)...';
+  Exec(ExpandConstant('{cmd}'),
+       '/C winget install --id Microsoft.PowerShell --source winget --silent ' +
+       '--accept-package-agreements --accept-source-agreements', '',
+       SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  // Ignore ResultCode: a failed or declined install just leaves octo on 5.1.
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 var
   ResultCode: Integer;
@@ -167,6 +200,7 @@ begin
   if CurStep = ssPostInstall then
   begin
     AddToPath;
+    EnsurePowerShell7;
     WriteAutostartScript;
     LaunchAndOpenDashboard;
   end;


### PR DESCRIPTION
## Why

octo runs hook scripts and the `terminal` tool through **pwsh (7+)** when present, and only falls back to **Windows PowerShell 5.1** otherwise (`shellCmd` in `internal/hooks/hooks.go`, mirrored in `internal/tools`). 5.1 is the clumsier shell; giving fresh Windows installs pwsh 7 makes both paths use the better shell with zero code changes.

## What

`octo-setup.exe` now best-effort installs PowerShell 7 via winget during `ssPostInstall`:

- Skips if `pwsh` is already on PATH.
- Skips if `winget` is unavailable (older Windows builds, or enterprise policy).
- Otherwise runs `winget install --id Microsoft.PowerShell --silent --accept-package-agreements --accept-source-agreements` hidden, with a wizard status line.

**Every failure path is a silent no-op** — pwsh present, no winget, declined UAC, or no network all leave octo running on 5.1, exactly as today.

## Caveat

winget's `Microsoft.PowerShell` is a machine-wide MSI, so winget may raise **one UAC prompt** for it. That's the only elevation this otherwise UAC-free per-user installer asks for; declining it is handled (no-op → 5.1).

## Test plan

- Windows installer compile check (this PR touches `packaging/windows/**`, so `windows-installer-check.yml` compiles the .iss).
- Manual: fresh Win11 VM without pwsh → install → pwsh 7 present; VM with pwsh already → install skips it; VM with winget disabled → install no-ops, octo still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)