### PR TITLE
test(tools): skip browser tests on Chrome launch flake

### DIFF
--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -55,6 +55,15 @@ func TestBrowserTool_SearchDownloadFlow(t *testing.T) {
 
 	b, err := browser.Launch(ctx, browser.LaunchOptions{Headless: true})
 	if err != nil {
+		// A loaded CI runner ships Chrome (so ChromeAvailable passes) but
+		// launching it headless intermittently times out reading
+		// DevToolsActivePort — a runner-environment flake, not a code defect.
+		// Skip on that specific timeout; keep every other launch failure fatal
+		// so real regressions still fail the build. Mirrors newBrowser in the
+		// browser package's own tests.
+		if strings.Contains(err.Error(), "timed out reading DevToolsActivePort") {
+			t.Skipf("chrome launch flake on this runner: %v", err)
+		}
 		t.Fatalf("launch: %v", err)
 	}
 	page, err := b.NewPage(ctx, "about:blank")
@@ -117,6 +126,15 @@ func TestBrowserTool_RecordRunRoundTrip(t *testing.T) {
 
 	b, err := browser.Launch(ctx, browser.LaunchOptions{Headless: true})
 	if err != nil {
+		// A loaded CI runner ships Chrome (so ChromeAvailable passes) but
+		// launching it headless intermittently times out reading
+		// DevToolsActivePort — a runner-environment flake, not a code defect.
+		// Skip on that specific timeout; keep every other launch failure fatal
+		// so real regressions still fail the build. Mirrors newBrowser in the
+		// browser package's own tests.
+		if strings.Contains(err.Error(), "timed out reading DevToolsActivePort") {
+			t.Skipf("chrome launch flake on this runner: %v", err)
+		}
 		t.Fatalf("launch: %v", err)
 	}
 	page, err := b.NewPage(ctx, srv.URL)
@@ -181,6 +199,15 @@ func TestBrowserTool_CookiesIncludesHttpOnly(t *testing.T) {
 
 	b, err := browser.Launch(ctx, browser.LaunchOptions{Headless: true})
 	if err != nil {
+		// A loaded CI runner ships Chrome (so ChromeAvailable passes) but
+		// launching it headless intermittently times out reading
+		// DevToolsActivePort — a runner-environment flake, not a code defect.
+		// Skip on that specific timeout; keep every other launch failure fatal
+		// so real regressions still fail the build. Mirrors newBrowser in the
+		// browser package's own tests.
+		if strings.Contains(err.Error(), "timed out reading DevToolsActivePort") {
+			t.Skipf("chrome launch flake on this runner: %v", err)
+		}
 		t.Fatalf("launch: %v", err)
 	}
 	page, err := b.NewPage(ctx, "about:blank")
@@ -219,6 +246,15 @@ func TestBrowserTool_ObserveAndScreenshotVision(t *testing.T) {
 
 	b, err := browser.Launch(ctx, browser.LaunchOptions{Headless: true})
 	if err != nil {
+		// A loaded CI runner ships Chrome (so ChromeAvailable passes) but
+		// launching it headless intermittently times out reading
+		// DevToolsActivePort — a runner-environment flake, not a code defect.
+		// Skip on that specific timeout; keep every other launch failure fatal
+		// so real regressions still fail the build. Mirrors newBrowser in the
+		// browser package's own tests.
+		if strings.Contains(err.Error(), "timed out reading DevToolsActivePort") {
+			t.Skipf("chrome launch flake on this runner: %v", err)
+		}
 		t.Fatalf("launch: %v", err)
 	}
 	page, err := b.NewPage(ctx, "about:blank")


### PR DESCRIPTION
## What

Stop the four browser-tool tests in `internal/tools` from failing the build when Chrome flakes on launch.

## Why

`TestBrowserTool_SearchDownloadFlow` failed in PR #1019's CI on `ubuntu-latest`:

```
browser_test.go:58: launch: timed out reading DevToolsActivePort in /tmp/octo-chrome-...
```

A loaded CI runner ships Chrome — so `ChromeAvailable` passes — but launching it headless intermittently times out writing/reading `DevToolsActivePort`. It's a runner-environment flake, not a code defect (macOS and Windows passed the same run).

The `internal/browser` package's own tests already handle this exact case in `newBrowser`; the `internal/tools` tests just never got the same guard and treated every `Launch` error as `t.Fatalf`.

## Change

In all four browser-tool tests, skip on the specific `"timed out reading DevToolsActivePort"` error (`t.Skipf`); keep every other launch failure fatal so real regressions still fail the build. Mirrors the established `newBrowser` pattern.

## Verify

- `gofmt -l` clean, `go vet ./internal/tools/` clean
- `go test ./internal/tools/ -run TestBrowserTool_SearchDownloadFlow` passes locally (Chrome present → test actually runs, not skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)