### PR TITLE
release: 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] — 2026-07-01
+
+### Fixed
+- **Web Artifacts now run their JavaScript.** Interactive HTML artifacts (a
+  calculator, a demo, anything with `<script>`) rendered but stayed inert: the
+  preview iframe gated scripts behind a lock button that was off by default, and
+  toggling it did nothing anyway — changing an iframe's `sandbox` after load
+  doesn't re-run its scripts. The preview now always runs scripts, still
+  sandboxed to an opaque origin (no `allow-same-origin`), so an artifact can't
+  reach the host app's DOM, cookies, or storage (#1019).
+
 ## [1.5.1] — 2026-07-01
 
 ### Added

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.5.1"
+var Version = "1.5.2"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release over 1.5.1.

### Fixed
- **Web Artifacts now run their JavaScript by default** (#1019). Interactive HTML artifacts rendered but stayed inert — scripts were gated behind a lock button that was off by default and didn't work anyway (changing an iframe's `sandbox` after load doesn't re-run scripts). Preview now always runs scripts, still sandboxed to an opaque origin (no `allow-same-origin`).

Also on main since 1.5.1: CI reliability — browser-tool tests skip the intermittent Chrome `DevToolsActivePort` launch flake instead of failing the build (#1020, test-only, not in changelog).

- version.go → 1.5.2
- CHANGELOG.md 1.5.2 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)