### PR TITLE
feat(browser): deterministically auto-parameterize recorded type values

### DIFF
--- a/internal/browser/recorder.go
+++ b/internal/browser/recorder.go
@@ -17,6 +17,8 @@ type RecordedEvent struct {
 	Tag      string `json:"tag"`      // target tagName (SELECT/INPUT/…), so replay picks the right action
 	Value    string `json:"value"`    // input/select value (change events)
 	Text     string `json:"text"`     // element text, for context
+	Field    string `json:"field"`    // input's placeholder/name/aria-label/id — names the auto-param
+	Secret   bool   `json:"secret"`   // password input: don't persist the value as a param default
 	URL      string `json:"url"`      // document URL at capture time
 }
 
@@ -56,7 +58,8 @@ const captureScript = `(function(){
   }
   function report(type, e){
     try{var el=e.target; var fr=''; try{ if(window.frameElement) fr=sel(window.frameElement); }catch(_2){}
-      window.__octoRecord(JSON.stringify({type:type, selector:sel(el), frame:fr, tag:el.tagName, text:(el.textContent||'').trim().slice(0,40), value:(el.value!==undefined?(''+el.value).slice(0,200):''), url:location.href}));}catch(_){}
+      var field=((el.placeholder||el.name||(el.getAttribute?el.getAttribute('aria-label'):'')||el.id||'')+'').trim().slice(0,40);
+      window.__octoRecord(JSON.stringify({type:type, selector:sel(el), frame:fr, tag:el.tagName, text:(el.textContent||'').trim().slice(0,40), field:field, secret:(el.type==='password'), value:(el.value!==undefined?(''+el.value).slice(0,200):''), url:location.href}));}catch(_){}
   }
   document.addEventListener('click', function(e){report('click',e);}, true);
   document.addEventListener('change', function(e){var t=e.target; report((t&&t.type==='file')?'upload':'change', e);}, true);

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -66,7 +67,29 @@ func CompileSkill(name, description, startURL string, events []RecordedEvent) Sk
 	if startURL != "" && startURL != "about:blank" {
 		s.Steps = append(s.Steps, Step{Action: "navigate", URL: startURL})
 	}
-	hasUpload := false
+	// Deterministic auto-parameterization: every value the user typed becomes a
+	// declared {{param}} whose Default is the recorded value — so replay with no
+	// params reproduces the demonstration exactly, yet each input is now a named,
+	// overridable knob (no LLM distiller required). Password fields are declared
+	// without a Default so the secret never lands in the YAML.
+	seen := map[string]bool{}
+	addParam := func(hint, def, desc string, secret bool) string {
+		root := slugParam(hint)
+		if root == "" {
+			root = "value"
+		}
+		nm := root
+		for i := 2; seen[nm]; i++ {
+			nm = fmt.Sprintf("%s%d", root, i)
+		}
+		seen[nm] = true
+		p := Param{Name: nm, Description: desc}
+		if !secret {
+			p.Default = def
+		}
+		s.Params = append(s.Params, p)
+		return nm
+	}
 	for _, e := range events {
 		if e.Type == "navigate" {
 			// Skip an echo of the page we're already on (start URL or the prior nav).
@@ -81,14 +104,14 @@ func CompileSkill(name, description, startURL string, events []RecordedEvent) Sk
 			// clicks the control and feeds the file through the chooser, so the
 			// preceding click (the button) is the better trigger than the
 			// possibly-transient file input. The file itself can't be captured
-			// (browsers hide the path) so it's auto-parameterized.
-			up := Step{Action: "upload", Frame: e.Frame, Selector: e.Selector, Value: "{{file}}", Label: e.Text}
+			// (browsers hide the path) so it's auto-parameterized (no default).
+			fp := addParam("file", "", "path to the file to upload", true)
+			up := Step{Action: "upload", Frame: e.Frame, Selector: e.Selector, Value: "{{" + fp + "}}", Label: e.Text}
 			if n := len(s.Steps); n > 0 && s.Steps[n-1].Action == "click" {
 				up.Selector, up.Frame, up.Label = s.Steps[n-1].Selector, s.Steps[n-1].Frame, s.Steps[n-1].Label
 				s.Steps = s.Steps[:n-1]
 			}
 			s.Steps = append(s.Steps, up)
-			hasUpload = true
 			continue
 		}
 		if e.Selector == "" {
@@ -103,18 +126,63 @@ func CompileSkill(name, description, startURL string, events []RecordedEvent) Sk
 			st.Value = e.Value
 		case e.Type == "change":
 			st.Action = "type"
-			st.Value = e.Value
+			hint := e.Field
+			if hint == "" {
+				hint = hintFromSelector(e.Selector)
+			}
+			desc := ""
+			if e.Secret {
+				desc = "secret value (not stored; provide at replay)"
+			}
+			pn := addParam(hint, e.Value, desc, e.Secret)
+			st.Value = "{{" + pn + "}}"
 		default:
 			continue
 		}
 		s.Steps = append(s.Steps, st)
 	}
-	if hasUpload {
-		s.Params = append(s.Params, Param{Name: "file", Description: "path to the file to upload"})
-	}
 	s.Steps = dropConsecutiveDupeSteps(s.Steps)
 	return s
 }
+
+// slugParam reduces a field hint to a safe {{param}} identifier: lowercase, with
+// runs of non-alphanumerics collapsed to a single underscore and trimmed.
+func slugParam(s string) string {
+	var b strings.Builder
+	prevUnderscore := false
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevUnderscore = false
+		default:
+			if b.Len() > 0 && !prevUnderscore {
+				b.WriteByte('_')
+				prevUnderscore = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+// hintFromSelector recovers a naming hint from a selector when the recorder
+// captured no field name — pulling an id (#foo) or a stable attribute value
+// (name/aria-label/data-testid/data-test), else "".
+func hintFromSelector(sel string) string {
+	if m := selectorAttrRe.FindStringSubmatch(sel); m != nil {
+		return m[1]
+	}
+	if strings.HasPrefix(sel, "#") {
+		id := sel[1:]
+		if i := strings.IndexAny(id, " >.:["); i >= 0 {
+			id = id[:i]
+		}
+		return id
+	}
+	return ""
+}
+
+var selectorAttrRe = regexp.MustCompile(`\[(?:name|aria-label|data-testid|data-test)="([^"]+)"\]`)
 
 // dropConsecutiveDupeSteps removes a step identical to its immediate predecessor
 // (same action/frame/selector/value) — a double-fire the user didn't intend (a

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -40,6 +40,76 @@ func TestCompileAndRoundTrip(t *testing.T) {
 	}
 }
 
+// TestCompileAutoParamsTypeValues: every typed value becomes a declared {{param}}
+// whose Default is the recorded value, so a no-param replay reproduces the demo
+// exactly while each input is now an overridable knob — no LLM distiller needed.
+func TestCompileAutoParamsTypeValues(t *testing.T) {
+	events := []RecordedEvent{
+		{Type: "change", Selector: "#q", Tag: "INPUT", Field: "Search query", Value: "hello world"},
+		{Type: "change", Selector: `input[name="email"]`, Tag: "INPUT", Value: "a@b.com"},
+	}
+	s := CompileSkill("demo", "", "", events)
+	if len(s.Steps) != 2 {
+		t.Fatalf("want 2 type steps, got %d: %+v", len(s.Steps), s.Steps)
+	}
+	// Values are placeholders, not the literal recorded text.
+	for _, st := range s.Steps {
+		if !strings.HasPrefix(st.Value, "{{") || strings.Contains(st.Value, "hello") {
+			t.Fatalf("value not parameterized: %+v", st)
+		}
+	}
+	byName := map[string]Param{}
+	for _, p := range s.Params {
+		byName[p.Name] = p
+	}
+	// Field hint drives the name; selector name= is the fallback.
+	if p, ok := byName["search_query"]; !ok || p.Default != "hello world" {
+		t.Fatalf("search_query param wrong: %+v (params=%+v)", p, s.Params)
+	}
+	if p, ok := byName["email"]; !ok || p.Default != "a@b.com" {
+		t.Fatalf("email param wrong: %+v (params=%+v)", p, s.Params)
+	}
+	// Round-trip: with no params, replay substitutes the defaults back in.
+	full := mergedParams(&s, nil)
+	if full["search_query"] != "hello world" || full["email"] != "a@b.com" {
+		t.Fatalf("defaults not recoverable: %+v", full)
+	}
+}
+
+// TestCompileAutoParamsSecretNoDefault: a password field is parameterized without
+// a Default, so the plaintext never lands in the YAML.
+func TestCompileAutoParamsSecretNoDefault(t *testing.T) {
+	events := []RecordedEvent{
+		{Type: "change", Selector: "#pw", Tag: "INPUT", Field: "password", Secret: true, Value: "hunter2"},
+	}
+	s := CompileSkill("demo", "", "", events)
+	if len(s.Params) != 1 {
+		t.Fatalf("want 1 param, got %+v", s.Params)
+	}
+	if s.Params[0].Default != "" {
+		t.Fatalf("secret default must be empty, got %q", s.Params[0].Default)
+	}
+	if data, _ := MarshalSkill(s); strings.Contains(string(data), "hunter2") {
+		t.Fatalf("secret leaked into yaml:\n%s", data)
+	}
+}
+
+// TestCompileAutoParamsDedup: two inputs that reduce to the same name get distinct
+// params (foo, foo2) so neither value is lost.
+func TestCompileAutoParamsDedup(t *testing.T) {
+	events := []RecordedEvent{
+		{Type: "change", Selector: "#a", Tag: "INPUT", Field: "City", Value: "SFO"},
+		{Type: "change", Selector: "#b", Tag: "INPUT", Field: "City", Value: "LAX"},
+	}
+	s := CompileSkill("demo", "", "", events)
+	if len(s.Params) != 2 || s.Params[0].Name == s.Params[1].Name {
+		t.Fatalf("want two distinct params, got %+v", s.Params)
+	}
+	if s.Steps[0].Value == s.Steps[1].Value {
+		t.Fatalf("distinct inputs must map to distinct params: %+v", s.Steps)
+	}
+}
+
 // TestCompileUploadMerge: a click on the upload button followed by a file
 // selection compiles to a single upload step on the button, auto-parameterized.
 func TestCompileUploadMerge(t *testing.T) {


### PR DESCRIPTION
Part 1/6 of the record-and-replay robustness work.

## Problem

A recording's typed values were hardcoded unless the optional LLM distiller ran. A recorded search embedded your literal query; reuse meant hand-editing the YAML.

## Change

`CompileSkill` now turns every typed value into a declared `{{param}}` whose `Default` is the recorded value:

- **No behavior change without params** — replay uses the Default, reproducing the demonstration exactly, but each input is now a named, overridable knob (no LLM needed).
- **Good names** — the param name comes from the field's `placeholder` / `name` / `aria-label` / `id` (newly captured by the recorder as `RecordedEvent.Field`), falling back to a slug parsed from the selector (`name=` / `aria-label=` / `data-testid=` / `#id`).
- **Secrets stay out** — password inputs (`type=password`) are declared *without* a Default, so the plaintext never lands in the YAML.
- Upload's `{{file}}` param now flows through the same dedup path.

## Tests

`TestCompileAutoParamsTypeValues` (name from field/selector + Default round-trips), `TestCompileAutoParamsSecretNoDefault` (no plaintext in YAML), `TestCompileAutoParamsDedup` (collisions → distinct params). Full browser package passes with Chrome present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)