### PR TITLE
feat(browser): re-locate drifted form fields by accessible-name hint

### DIFF
--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -83,6 +83,71 @@ func (p *Page) resolveClickTarget(ctx context.Context, frame, elemSel, anchor st
 	}
 }
 
+// resolveFieldTarget picks the selector to act on for a type/select/upload step
+// whose recorded field carried an accessible-name hint (placeholder/name/
+// aria-label/id or its <label> text). Form fields have no visible textContent, so
+// the click text-anchor can't steer them; this is the field analogue. It polls up
+// to timeout for, in order: the original positional element (unchanged-page fast
+// path, exact original target), or any input/select/textarea whose accessible name
+// equals the hint (drift recovery), returning a freshly generated selector for it.
+// If neither appears it returns the positional selector unchanged, so a genuine
+// miss still fails and reaches the healer. hint must be non-empty.
+func (p *Page) resolveFieldTarget(ctx context.Context, frame, elemSel, hint string, timeout time.Duration) string {
+	posSel := elemSel
+	if frame != "" {
+		posSel = frame + frameDelim + elemSel
+	}
+	doc := "document"
+	if frame != "" {
+		doc = fmt.Sprintf("(document.querySelector(%s)||{}).contentDocument", jsString(frame))
+	}
+	check := fmt.Sprintf(`(()=>{
+	  var pos=null; try{pos=%s;}catch(e){}
+	  if(pos) return {mode:"pos"};
+	  var h=%s; var d=%s; if(!d) return {mode:"none"};
+	  function sel(el){
+	    if(el.id) return '#'+CSS.escape(el.id);
+	    for(var i=0;i<4;i++){var a=['data-testid','data-test','name','aria-label'][i];var v=el.getAttribute&&el.getAttribute(a);if(v)return el.tagName.toLowerCase()+'['+a+'="'+CSS.escape(v)+'"]';}
+	    var parts=[],node=el,depth=0;
+	    while(node&&node.nodeType===1&&node.tagName!=='BODY'&&depth<6){if(node.id){parts.unshift('#'+CSS.escape(node.id));return parts.join(' > ');}var part=node.tagName.toLowerCase();var p=node.parentElement;if(p){var same=[].slice.call(p.children).filter(function(c){return c.tagName===node.tagName;});if(same.length>1)part+=':nth-of-type('+(same.indexOf(node)+1)+')';}parts.unshift(part);node=p;depth++;}
+	    return parts.join(' > ');
+	  }
+	  var els=d.querySelectorAll('input,select,textarea,[contenteditable="true"],[contenteditable=""]');
+	  for(var i=0;i<els.length;i++){var el=els[i];
+	    var lbl=''; try{ if(el.labels&&el.labels.length) lbl=(el.labels[0].textContent||'').trim(); }catch(e){}
+	    if(el.placeholder===h||el.name===h||el.id===h||(el.getAttribute&&el.getAttribute('aria-label')===h)||lbl===h){ return {mode:"match", sel:sel(el)}; }
+	  }
+	  return {mode:"none"};
+	})()`, elemRefJS(frame, elemSel), jsString(hint), doc)
+
+	deadline := time.Now().Add(timeout)
+	for {
+		var res struct {
+			Mode string `json:"mode"`
+			Sel  string `json:"sel"`
+		}
+		if err := p.Eval(ctx, check, &res); err == nil {
+			switch {
+			case res.Mode == "pos":
+				return posSel
+			case res.Mode == "match" && res.Sel != "":
+				if frame != "" {
+					return frame + frameDelim + res.Sel
+				}
+				return res.Sel
+			}
+		}
+		if ctx.Err() != nil || !time.Now().Before(deadline) {
+			return posSel
+		}
+		select {
+		case <-ctx.Done():
+			return posSel
+		case <-time.After(150 * time.Millisecond):
+		}
+	}
+}
+
 // elementCenter scrolls an element into view and returns its viewport-center
 // point (adding the iframe's offset for framed targets), or an error if the
 // selector matches nothing.

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -33,12 +33,18 @@ type Param struct {
 // iframe selector) scopes it via the " >>> " convention. Label is a human note;
 // replay ignores it.
 type Step struct {
-	Action    string  `yaml:"action"` // navigate | click | type | select | upload | wait
-	URL       string  `yaml:"url,omitempty"`
-	Frame     string  `yaml:"frame,omitempty"`
-	Selector  string  `yaml:"selector,omitempty"`
-	Value     string  `yaml:"value,omitempty"`
-	Label     string  `yaml:"label,omitempty"`
+	Action   string `yaml:"action"` // navigate | click | type | select | upload | wait
+	URL      string `yaml:"url,omitempty"`
+	Frame    string `yaml:"frame,omitempty"`
+	Selector string `yaml:"selector,omitempty"`
+	Value    string `yaml:"value,omitempty"`
+	Label    string `yaml:"label,omitempty"`
+	// Hint is a form field's accessible name (placeholder/name/aria-label/id or
+	// its <label> text). It's the deterministic fallback for type/select/upload:
+	// when the positional Selector drifts, replay re-locates the field by Hint
+	// before giving up to the healer — the field-input analogue of Label steering
+	// a click by visible text.
+	Hint      string  `yaml:"hint,omitempty"`
 	TimeoutMS int     `yaml:"timeout_ms,omitempty"` // wait: fixed delay when no selector
 	Verify    *Verify `yaml:"verify,omitempty"`
 }
@@ -117,7 +123,7 @@ func CompileSkill(name, description, startURL string, events []RecordedEvent) Sk
 		if e.Selector == "" {
 			continue
 		}
-		st := Step{Frame: e.Frame, Selector: e.Selector, Label: e.Text}
+		st := Step{Frame: e.Frame, Selector: e.Selector, Label: e.Text, Hint: e.Field}
 		switch {
 		case e.Type == "click":
 			st.Action = "click"
@@ -478,7 +484,11 @@ func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map
 		}
 		page = np
 	case "type":
-		if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
+		// Re-locate the field by its accessible-name hint when the positional
+		// selector drifted (the type/select analogue of a text-anchored click).
+		if h := strings.TrimSpace(step.Hint); h != "" {
+			target = page.resolveFieldTarget(ctx, step.Frame, step.Selector, h, waitTimeout)
+		} else if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
 			return page, err
 		}
 		val := subst(step.Value, params)
@@ -499,7 +509,9 @@ func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map
 			}
 		}
 	case "select":
-		if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
+		if h := strings.TrimSpace(step.Hint); h != "" {
+			target = page.resolveFieldTarget(ctx, step.Frame, step.Selector, h, waitTimeout)
+		} else if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
 			return page, err
 		}
 		if err := page.SelectOption(ctx, target, subst(step.Value, params)); err != nil {
@@ -507,9 +519,12 @@ func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map
 		}
 	case "upload":
 		// The upload trigger is a labeled control (e.g. "Choose file"), so prefer
-		// its text the same way clicks do.
+		// its visible text the same way clicks do, then its field hint, before
+		// falling back to the positional selector (→ healer).
 		if a := strings.TrimSpace(step.Label); len(a) >= 2 {
 			target = page.resolveClickTarget(ctx, step.Frame, step.Selector, a, waitTimeout)
+		} else if h := strings.TrimSpace(step.Hint); h != "" {
+			target = page.resolveFieldTarget(ctx, step.Frame, step.Selector, h, waitTimeout)
 		} else if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
 			return page, err
 		}

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -346,6 +346,50 @@ func TestReplayTextAnchorRecoversFromDrift(t *testing.T) {
 	}
 }
 
+// TestReplayFieldHintRecoversFromDrift: a recorded positional selector for a text
+// input no longer resolves after a layout change, but the field's accessible-name
+// hint (its name) re-locates it — so type lands in the right box instead of failing
+// into the healer.
+func TestReplayFieldHintRecoversFromDrift(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// The input sits at a different DOM path than the recorded positional
+		// selector expects, but keeps its name="q".
+		w.Write([]byte(`<!doctype html><meta charset="utf-8"><title>t</title>
+<header><nav><span>x</span></nav></header>
+<main><section><div><input name="q" placeholder="Search"></div></section></main>`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+
+	// A stale positional selector that matches nothing on the current page; the
+	// hint "q" (the field name) is the recovery signal.
+	skill := &Skill{Name: "x", Steps: []Step{
+		{Action: "type", Selector: "body > div:nth-of-type(9) > input", Hint: "q", Value: "hello"},
+	}}
+	if _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	var got string
+	if err := page.Eval(ctx, `document.querySelector('input[name="q"]').value`, &got); err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if got != "hello" {
+		t.Fatalf("field hint did not recover the drifted input: value=%q, want %q", got, "hello")
+	}
+}
+
 // TestReplaySkillSelfHeal: a step has a stale selector, the implicit wait fails,
 // the healer repairs the selector, replay retries and succeeds — and reports the
 // skill as modified so the caller can write the fix back.


### PR DESCRIPTION
Part 2/6 of the record-and-replay robustness work.

## Problem

Text-anchored click resolution already lets a click survive layout drift by its visible text. But form fields (`input`/`select`/`textarea`) have no `textContent`, so a drifted positional selector on them had **no deterministic fallback** — only the LLM healer could recover, turning a routine layout change into a model round-trip.

## Change

Add the field analogue of the click text-anchor: a `Step.Hint` carrying the field's accessible name (`placeholder` / `name` / `aria-label` / `id` or its `<label>` text — captured by the recorder as `RecordedEvent.Field`).

On `type` / `select` / `upload`, when the positional selector no longer resolves, replay re-locates the field by matching that hint and acts on a freshly generated selector for it, before falling back to the positional selector (→ healer). Per field step the effective candidate chain is now **positional → hint-match**, mirroring click's **positional → text-anchor**.

`resolveFieldTarget` polls exactly like `resolveClickTarget`: prefer the original positional element (unchanged-page fast path), else match by accessible name, else return positional so a genuine miss still reaches the healer.

## Tests

`TestReplayFieldHintRecoversFromDrift` — a stale positional selector for a text input that keeps its `name`; replay recovers and types into the right box. Full browser package passes with Chrome present.

Stacked on #1022 (merged); rebased onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)