### PR TITLE
feat(browser): network-idle wait primitive for SPA settling

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -154,7 +154,53 @@ func (b *Browser) AttachPage(ctx context.Context, targetID string) (*Page, error
 			return nil, fmt.Errorf("%s: %w", domain, err)
 		}
 	}
+	// Install the in-flight network monitor on this and every future document so
+	// WaitForNetworkIdle has data to poll (best-effort; failures are non-fatal).
+	_, _ = p.cli.call(ctx, p.sessionID, "Page.addScriptToEvaluateOnNewDocument", map[string]any{"source": netMonitorScript})
+	_ = p.Eval(ctx, netMonitorScript, nil)
 	return p, nil
+}
+
+// netMonitorScript maintains window.__octoNet.{n,idleSince} by wrapping fetch and
+// XMLHttpRequest, so replay can wait for XHR/fetch activity to settle. It counts
+// only fetch/XHR (not sub-resources) — which is what "the SPA finished loading
+// its data" means in practice — and resets naturally per document. Idempotent.
+const netMonitorScript = `(function(){
+  if(window.__octoNet) return;
+  var s=window.__octoNet={n:0, idleSince:Date.now()};
+  function inc(){ s.n++; s.idleSince=0; }
+  function dec(){ s.n=Math.max(0,s.n-1); if(s.n===0) s.idleSince=Date.now(); }
+  try{ var of=window.fetch; if(of){ window.fetch=function(){ inc(); return of.apply(this,arguments).then(function(r){dec();return r;},function(e){dec();throw e;}); }; } }catch(_){}
+  try{ var send=XMLHttpRequest.prototype.send; XMLHttpRequest.prototype.send=function(){ inc(); try{ this.addEventListener('loadend',function(){dec();}); }catch(_){ dec(); } return send.apply(this,arguments); }; }catch(_){}
+})();`
+
+// WaitForNetworkIdle is a best-effort settle: it returns once no fetch/XHR has
+// been in flight for `quiet`, or when `timeout` elapses — whichever comes first.
+// It never reports a failure (real pages with polling/keep-alive connections may
+// never go fully idle, and a settle helper must not turn that into a step error);
+// only ctx cancellation returns an error. If the monitor isn't present it returns
+// immediately.
+func (p *Page) WaitForNetworkIdle(ctx context.Context, quiet, timeout time.Duration) error {
+	if quiet <= 0 {
+		quiet = 500 * time.Millisecond
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		// Returns ms the network has been idle, or -1 while busy / unavailable.
+		var idleMS float64 = -1
+		_ = p.Eval(ctx, `(function(){var s=window.__octoNet; if(!s) return 1e9; return (s.n===0 && s.idleSince>0) ? (Date.now()-s.idleSince) : -1;})()`, &idleMS)
+		if idleMS >= float64(quiet/time.Millisecond) {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return nil // best-effort: proceed even if never fully idle
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
 }
 
 // ClickFollow clicks target on page and, if the click opened a new tab (a

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -46,7 +46,8 @@ type Step struct {
 	// before giving up to the healer — the field-input analogue of Label steering
 	// a click by visible text.
 	Hint      string  `yaml:"hint,omitempty"`
-	TimeoutMS int     `yaml:"timeout_ms,omitempty"` // wait: fixed delay when no selector
+	Network   bool    `yaml:"network,omitempty"`    // wait: settle for network (fetch/XHR) idle instead of a fixed delay
+	TimeoutMS int     `yaml:"timeout_ms,omitempty"` // wait: fixed delay (ms) when no selector; also caps the network-idle settle
 	Verify    *Verify `yaml:"verify,omitempty"`
 }
 
@@ -475,12 +476,20 @@ func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map
 			return page, err
 		}
 	case "wait":
-		// Wait for an element if a selector is given (the robust form), else a
-		// fixed delay — the natural primitive for letting an SPA settle between
-		// steps. Recordings/edits commonly need it; without it run_skill rejected
-		// the step as "unknown action".
+		// Wait for an element if a selector is given (the robust form); else settle
+		// for network idle when asked (the SPA-aware form — waits until fetch/XHR
+		// activity stops rather than guessing a delay); else a fixed delay. All
+		// three are natural primitives for letting a page settle between steps.
 		if target != "" {
 			if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
+				return page, err
+			}
+		} else if step.Network {
+			to := waitTimeout
+			if step.TimeoutMS > 0 {
+				to = time.Duration(step.TimeoutMS) * time.Millisecond
+			}
+			if err := page.WaitForNetworkIdle(ctx, 0, to); err != nil {
 				return page, err
 			}
 		} else {

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -320,6 +320,53 @@ func TestRunStepWaitFixedDelay(t *testing.T) {
 	}
 }
 
+// TestWaitForNetworkIdle: a wait{network:true} step blocks until an in-flight
+// fetch the page kicked off completes, then returns — the SPA-settle primitive.
+func TestWaitForNetworkIdle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(600 * time.Millisecond)
+		w.Write([]byte(`{"ok":true}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// On load, fire a slow fetch that flips window.done when it resolves.
+		w.Write([]byte(`<!doctype html><meta charset="utf-8"><title>t</title>
+<script>window.done=false;fetch('/slow').then(function(){window.done=true;});</script>`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+
+	skill := &Skill{Name: "x", Steps: []Step{{Action: "wait", Network: true, TimeoutMS: 10000}}}
+	start := time.Now()
+	if _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 15 * time.Second}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	// The in-flight fetch (~600ms) must have settled before the wait returned.
+	var done bool
+	if err := page.Eval(ctx, "window.done===true", &done); err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if !done {
+		t.Fatal("network-idle wait returned before the in-flight fetch completed")
+	}
+	if d := time.Since(start); d < 500*time.Millisecond {
+		t.Fatalf("network-idle wait returned suspiciously fast (%v) — did it settle?", d)
+	}
+}
+
 // TestReplayClickFollowsNewTab: a click on a target=_blank link is followed to
 // the tab it opens (the Zhihu-hot-item failure mode), and ReplaySkill returns
 // that tab as the final page.

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -239,20 +239,21 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 					"enum":        []string{"navigate", "back", "click", "hover", "type", "select", "key", "scroll", "wait", "screenshot", "observe", "ax", "cookies", "upload", "download", "pages", "select_page", "close", "eval", "record_start", "record_stop", "run_skill"},
 					"description": "The browser action to perform. observe lists the page's URL/title and interactable elements with selectors (text only) — the cheap way to look at an unfamiliar page before acting; works on any model. screenshot returns an image of the page for a vision-capable model to actually see (use when content is visual). cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture the USER's own demonstration into an editable skill — record_start only installs listeners, so after it you MUST hand control to the user: tell them to perform the actions themselves in their browser and to say when they're done, then call record_stop. Do NOT drive the page yourself (navigate/click/type) while recording — your tool actions are not the demonstration and a click that navigates is easily lost; only the user's real gestures are captured. run_skill replays a recording (deterministic, self-healing).",
 				},
-				"name":       map[string]any{"type": "string", "description": "Skill name (record_stop / run_skill)."},
-				"params":     map[string]any{"type": "object", "description": "Param values for {{...}} placeholders (run_skill)."},
-				"url":        map[string]any{"type": "string", "description": "Target URL (navigate)."},
-				"selector":   map[string]any{"type": "string", "description": "Target element selector (click/hover/type/select/scroll/wait/upload/download). Plain CSS, or a Playwright-style form: :has-text(\"…\")/:text(\"…\")/:contains(\"…\"), text=…, :visible, xpath=…, css=…. Use observe to see real selectors."},
-				"frame":      map[string]any{"type": "string", "description": "Optional CSS selector of a same-origin iframe to scope the selector into (e.g. iframe#app)."},
-				"text":       map[string]any{"type": "string", "description": "Text to type (type)."},
-				"value":      map[string]any{"type": "string", "description": "Option value, text, or label to pick in a <select> (select)."},
-				"keys":       map[string]any{"type": "string", "description": "Key or combo, e.g. enter, escape, ctrl+a (key)."},
-				"js":         map[string]any{"type": "string", "description": "JavaScript expression to evaluate (eval)."},
-				"files":      map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Absolute file paths to set on a file <input> (upload)."},
-				"index":      map[string]any{"type": "integer", "description": "Page index from the pages list to switch to (select_page)."},
-				"timeout_ms": map[string]any{"type": "integer", "description": "Wait timeout in ms (wait); default 10000."},
-				"dx":         map[string]any{"type": "number", "description": "Horizontal scroll delta (scroll)."},
-				"dy":         map[string]any{"type": "number", "description": "Vertical scroll delta (scroll)."},
+				"name":         map[string]any{"type": "string", "description": "Skill name (record_stop / run_skill)."},
+				"params":       map[string]any{"type": "object", "description": "Param values for {{...}} placeholders (run_skill)."},
+				"url":          map[string]any{"type": "string", "description": "Target URL (navigate)."},
+				"selector":     map[string]any{"type": "string", "description": "Target element selector (click/hover/type/select/scroll/wait/upload/download). Plain CSS, or a Playwright-style form: :has-text(\"…\")/:text(\"…\")/:contains(\"…\"), text=…, :visible, xpath=…, css=…. Use observe to see real selectors."},
+				"network_idle": map[string]any{"type": "boolean", "description": "wait with no selector: settle until fetch/XHR activity stops (bounded by timeout_ms) instead of a fixed delay — the robust way to wait for an SPA's data to finish loading."},
+				"frame":        map[string]any{"type": "string", "description": "Optional CSS selector of a same-origin iframe to scope the selector into (e.g. iframe#app)."},
+				"text":         map[string]any{"type": "string", "description": "Text to type (type)."},
+				"value":        map[string]any{"type": "string", "description": "Option value, text, or label to pick in a <select> (select)."},
+				"keys":         map[string]any{"type": "string", "description": "Key or combo, e.g. enter, escape, ctrl+a (key)."},
+				"js":           map[string]any{"type": "string", "description": "JavaScript expression to evaluate (eval)."},
+				"files":        map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Absolute file paths to set on a file <input> (upload)."},
+				"index":        map[string]any{"type": "integer", "description": "Page index from the pages list to switch to (select_page)."},
+				"timeout_ms":   map[string]any{"type": "integer", "description": "Wait timeout in ms (wait); default 10000."},
+				"dx":           map[string]any{"type": "number", "description": "Horizontal scroll delta (scroll)."},
+				"dy":           map[string]any{"type": "number", "description": "Vertical scroll delta (scroll)."},
 			},
 			"required": []string{"action"},
 		},
@@ -367,13 +368,21 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		return agent.ToolResult{Text: "scrolled"}, nil
 
 	case "wait":
-		sel := targetSelector(input)
-		if sel == "" {
-			return agent.ToolResult{}, fmt.Errorf("browser: wait requires selector")
-		}
 		timeout := 10 * time.Second
 		if ms, ok := input["timeout_ms"].(float64); ok && ms > 0 {
 			timeout = time.Duration(ms) * time.Millisecond
+		}
+		sel := targetSelector(input)
+		if sel == "" {
+			// No selector: settle for network idle when asked (SPA data loads), a
+			// robust alternative to guessing a fixed delay.
+			if ni, _ := input["network_idle"].(bool); ni {
+				if err := page.WaitForNetworkIdle(ctx, 0, timeout); err != nil {
+					return agent.ToolResult{}, err
+				}
+				return agent.ToolResult{Text: "network idle"}, nil
+			}
+			return agent.ToolResult{}, fmt.Errorf("browser: wait requires selector or network_idle=true")
 		}
 		if err := page.WaitFor(ctx, sel, timeout); err != nil {
 			return agent.ToolResult{}, err


### PR DESCRIPTION
Part 4/6 of the record-and-replay robustness work.

## Problem

Replay's only settle option between steps was a blind fixed delay. An SPA that renders an element before its data (or the element itself) has finished loading could flake.

## Change

A best-effort network-idle wait:

- An injected monitor wraps `fetch`/`XMLHttpRequest` to maintain `window.__octoNet.{n,idleSince}` (installed at page attach via `addScriptToEvaluateOnNewDocument`, same pattern as the recorder). `Page.WaitForNetworkIdle` polls "no in-flight fetch/XHR for N ms".
- **Best-effort by design**: real pages with polling / keep-alive connections never go fully idle, so on timeout it *proceeds* rather than failing the step (only ctx cancellation returns an error). A settle helper must not turn "the network never went quiet" into a spurious step failure. It counts fetch/XHR, not sub-resources — which is what "the SPA finished loading its data" means in practice.
- Surfaces two ways: a skill `wait` step gains `network: true`; the browser tool's `wait` action gains `network_idle: true` (with no selector) as a direct primitive for the model.

## Tests

`TestWaitForNetworkIdle` — a page fires a ~600ms fetch on load; `wait{network:true}` blocks until it resolves (asserts both that the fetch completed and that the wait didn't return early). Full browser + tools packages pass with Chrome present.

Stacked on #1022–#1024 (all merged); rebased onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)