### PR TITLE
feat(browser): structural + multi-round recovery for failed replay steps

### DIFF
--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -83,6 +83,33 @@ func (p *Page) resolveClickTarget(ctx context.Context, frame, elemSel, anchor st
 	}
 }
 
+// DismissOverlay makes one deterministic attempt to clear a blocking overlay —
+// a cookie/consent banner or a modal whose backdrop intercepts clicks, the most
+// common non-selector reason a replay step suddenly fails. It clicks the first
+// visible control whose trimmed text or aria-label matches a small allowlist of
+// dismiss/accept affordances (never anything else, so it can't perform an
+// unintended destructive action), and reports whether it clicked something. No
+// LLM involved; safe to call speculatively before falling back to the healer.
+func (p *Page) DismissOverlay(ctx context.Context) (bool, error) {
+	const expr = `(function(){
+	  var ok=/^(accept|accept all|accept all cookies|agree|i agree|allow all|got it|ok|okay|close|dismiss|no thanks|continue)$/i;
+	  var lab=/(close|dismiss|accept|agree)/i;
+	  var els=document.querySelectorAll('button,[role="button"],a,[aria-label]');
+	  for(var i=0;i<els.length;i++){var el=els[i];
+	    if(!(el.offsetParent!==null||el.getClientRects().length)) continue; // visible only
+	    var t=(el.textContent||'').trim();
+	    var al=(el.getAttribute&&el.getAttribute('aria-label')||'').trim();
+	    if(ok.test(t) || (al && lab.test(al) && al.length<40)){ try{ el.click(); return true; }catch(e){} }
+	  }
+	  return false;
+	})()`
+	var clicked bool
+	if err := p.Eval(ctx, expr, &clicked); err != nil {
+		return false, err
+	}
+	return clicked, nil
+}
+
 // resolveFieldTarget picks the selector to act on for a type/select/upload step
 // whose recorded field carried an accessible-name hint (placeholder/name/
 // aria-label/id or its <label> text). Form fields have no visible textContent, so

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -433,23 +433,60 @@ func ReplaySkill(ctx context.Context, page *Page, skill *Skill, params map[strin
 			cur = np
 			continue
 		}
-		if opts.Healer == nil {
+		np, healed, runErr := recoverStep(ctx, opts, cur, &skill.Steps[i], full, runErr, &modified)
+		if runErr != nil {
 			return modified, cur, fmt.Errorf("step %d (%s): %w", i+1, skill.Steps[i].Action, runErr)
 		}
-		before := skill.Steps[i]
-		if herr := opts.Healer(ctx, cur, &skill.Steps[i], runErr); herr != nil {
-			return modified, cur, fmt.Errorf("step %d (%s): %w", i+1, skill.Steps[i].Action, runErr)
-		}
-		np, retryErr := runStep(ctx, opts.Browser, cur, &skill.Steps[i], full, opts.StepTimeout)
-		if retryErr != nil {
-			return modified, cur, fmt.Errorf("step %d (%s) after heal: %w", i+1, skill.Steps[i].Action, retryErr)
-		}
+		_ = healed
 		cur = np
-		if skill.Steps[i] != before {
-			modified = true
-		}
 	}
 	return modified, cur, nil
+}
+
+// maxHealRounds bounds how many times the LLM healer is consulted for one step,
+// so a healer that keeps returning a wrong selector can't loop indefinitely.
+const maxHealRounds = 3
+
+// recoverStep tries to get a failed step to pass, in escalating order:
+//  1. Deterministic structural recovery — dismiss a blocking overlay (a cookie/
+//     consent banner or modal covering the target) and retry. No LLM; works even
+//     when no healer is wired.
+//  2. The LLM healer, up to maxHealRounds times — each round may repair the
+//     selector differently as the page settles; the new error feeds the next
+//     round. Stops early when the healer makes no change or errors.
+//
+// It returns the page to continue on, whether a heal mutated the step (for the
+// caller's write-back via *modified), and a non-nil error only if the step could
+// not be recovered.
+func recoverStep(ctx context.Context, opts ReplayOptions, page *Page, step *Step, params map[string]string, cause error, modified *bool) (*Page, bool, error) {
+	// 1. Structural: a blocking overlay is the most common non-selector failure.
+	if dismissed, _ := page.DismissOverlay(ctx); dismissed {
+		if np, err := runStep(ctx, opts.Browser, page, step, params, opts.StepTimeout); err == nil {
+			return np, true, nil
+		}
+	}
+	if opts.Healer == nil {
+		return page, false, cause
+	}
+	// 2. LLM healer, multi-round.
+	for round := 0; round < maxHealRounds; round++ {
+		before := *step
+		if herr := opts.Healer(ctx, page, step, cause); herr != nil {
+			return page, false, cause
+		}
+		np, retryErr := runStep(ctx, opts.Browser, page, step, params, opts.StepTimeout)
+		if retryErr == nil {
+			if *step != before {
+				*modified = true
+			}
+			return np, true, nil
+		}
+		if *step == before {
+			return page, false, retryErr // healer made no change — further rounds won't help
+		}
+		cause = retryErr // feed the fresh failure to the next round
+	}
+	return page, false, cause
 }
 
 // mergedParams overlays caller params on declared defaults.

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -495,6 +495,98 @@ func TestReplayFieldHintRecoversFromDrift(t *testing.T) {
 	}
 }
 
+// TestReplayDismissesOverlayDeterministically: a step's target doesn't exist
+// until a consent overlay is accepted; replay recovers by clicking the allow-list
+// "Accept" control — no healer wired — then the retry succeeds.
+func TestReplayDismissesOverlayDeterministically(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// Accept injects the real target #go and removes itself.
+		w.Write([]byte(`<!doctype html><meta charset="utf-8"><title>t</title>
+<button id="accept" onclick="var g=document.createElement('button');g.id='go';g.textContent='Go';g.onclick=function(){window.hit=1};document.body.appendChild(g);this.remove();">Accept</button>`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+
+	// #go is absent until the overlay is dismissed; no healer is provided, so this
+	// exercises the deterministic structural recovery path.
+	skill := &Skill{Name: "x", Steps: []Step{{Action: "click", Selector: "#go"}}}
+	modified, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 2 * time.Second, Browser: b})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if modified {
+		t.Fatal("overlay dismissal is runtime-only; it must not mark the skill modified")
+	}
+	var hit int
+	if err := page.Eval(ctx, "window.hit||0", &hit); err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if hit != 1 {
+		t.Fatalf("target not clicked after overlay dismissal (hit=%d)", hit)
+	}
+}
+
+// TestReplayMultiRoundHeal: the healer needs two rounds — the first repair is
+// still wrong, the second is correct — and replay keeps consulting it (up to the
+// cap) instead of giving up after one attempt.
+func TestReplayMultiRoundHeal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<!doctype html><title>t</title>
+<button id="real">Go</button>
+<script>window.clicks=0;document.getElementById('real').addEventListener('click',function(){window.clicks++});</script>`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+
+	skill := &Skill{Name: "x", Steps: []Step{{Action: "click", Selector: "#stale"}}}
+	rounds := 0
+	heal := func(_ context.Context, _ *Page, step *Step, _ error) error {
+		rounds++
+		if rounds == 1 {
+			step.Selector = "#still-wrong" // a repair that still won't resolve
+		} else {
+			step.Selector = "#real"
+		}
+		return nil
+	}
+	modified, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 2 * time.Second, Healer: heal, Browser: b})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if rounds < 2 {
+		t.Fatalf("expected the healer to be consulted across rounds, got %d", rounds)
+	}
+	if !modified {
+		t.Fatal("expected modified=true after a successful heal")
+	}
+	if skill.Steps[0].Selector != "#real" {
+		t.Fatalf("step not corrected: %q", skill.Steps[0].Selector)
+	}
+}
+
 // TestReplaySkillSelfHeal: a step has a stale selector, the implicit wait fails,
 // the healer repairs the selector, replay retries and succeeds — and reports the
 // skill as modified so the caller can write the fix back.


### PR DESCRIPTION
Part 5/6 of the record-and-replay robustness work.

## Problem

Replay's recovery was a single healer call + one retry. Two gaps:
- a blocking overlay (cookie/consent banner or modal) dead-ended replay, even though it's trivially dismissable without an LLM;
- a healer that needed more than one attempt (page still settling, first repair still wrong) got only one shot.

## Change

`recoverStep` escalates:

1. **Deterministic structural recovery** — `DismissOverlay` clicks the first *visible* control whose text/aria-label matches a small dismiss/accept allow-list (`Accept`, `Agree`, `Got it`, `Close`, … — never anything else, so it can't fire an unintended destructive action) and retries. No LLM, so even a healer-less deterministic replay survives a consent modal. **Runtime-only**: it does not mutate or write back the skill, because the overlay is often intermittent (a persisted dismiss step would fail on the next run when the banner is already gone).
2. **Multi-round LLM healer** — up to `maxHealRounds` (3). Each round re-scans the page (`MakeBrowserHealer` re-fetches the interactive digest) and may repair differently as the page settles; the fresh error feeds the next round. Stops early when the healer makes no change or errors.

Keeps the deterministic core (per the design decision): the LLM stays a bounded, optional edge — this does not pull it deeper into the replay loop.

## Tests

`TestReplayDismissesOverlayDeterministically` (target hidden behind a consent overlay, recovered with no healer, skill not marked modified); `TestReplayMultiRoundHeal` (first repair still wrong, second correct, healer consulted across rounds). Full browser + app packages pass with Chrome present.

Stacked on #1022–#1025 (all merged); rebased onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)