### PR TITLE
feat(browser): full cross-origin (OOPIF) iframe support for record + replay

### DIFF
--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -15,9 +15,11 @@ type point struct {
 	Y float64 `json:"y"`
 }
 
-// frameDelim separates a same-origin iframe selector from the element selector
-// inside it, e.g. "iframe#app >>> #download". One level; cross-origin OOPIFs
-// are not handled (their DOM lives in another process).
+// frameDelim separates an iframe selector from the element selector inside it,
+// e.g. "iframe#app >>> #download". One level. Same-origin frames resolve via
+// contentDocument; cross-origin OOPIFs (DOM in another process) are routed to the
+// frame's own CDP session by oopifPage — transparently, so callers use the same
+// "frame >>> element" convention regardless of origin.
 const frameDelim = " >>> "
 
 func splitFrame(selector string) (frame, elem string) {
@@ -49,6 +51,14 @@ func elemRefJS(frame, elem string) string {
 // it returns the positional selector unchanged, so a genuine miss still fails
 // and reaches the healer. anchor must be non-empty.
 func (p *Page) resolveClickTarget(ctx context.Context, frame, elemSel, anchor string, timeout time.Duration) string {
+	// For a cross-origin iframe, resolve inside the frame's own session (where the
+	// element lives at document root), then re-prefix the frame so the subsequent
+	// click re-routes there via the method-level redirect.
+	if frame != "" {
+		if cp, ok := p.oopifPage(ctx, frame); ok {
+			return frame + frameDelim + cp.resolveClickTarget(ctx, "", elemSel, anchor, timeout)
+		}
+	}
 	posSel := elemSel
 	if frame != "" {
 		posSel = frame + frameDelim + elemSel
@@ -120,6 +130,11 @@ func (p *Page) DismissOverlay(ctx context.Context) (bool, error) {
 // If neither appears it returns the positional selector unchanged, so a genuine
 // miss still fails and reaches the healer. hint must be non-empty.
 func (p *Page) resolveFieldTarget(ctx context.Context, frame, elemSel, hint string, timeout time.Duration) string {
+	if frame != "" {
+		if cp, ok := p.oopifPage(ctx, frame); ok {
+			return frame + frameDelim + cp.resolveFieldTarget(ctx, "", elemSel, hint, timeout)
+		}
+	}
 	posSel := elemSel
 	if frame != "" {
 		posSel = frame + frameDelim + elemSel
@@ -214,6 +229,11 @@ func (p *Page) elementCenter(ctx context.Context, selector string) (point, error
 // Trusted input (vs a JS .click()) counts as a real user gesture, which some
 // flows — file dialogs, download buttons — require, and is less detectable.
 func (p *Page) Click(ctx context.Context, selector string) error {
+	if frame, elem := splitFrame(selector); frame != "" {
+		if cp, ok := p.oopifPage(ctx, frame); ok {
+			return cp.Click(ctx, elem)
+		}
+	}
 	pt, err := p.elementCenter(ctx, selector)
 	if err != nil {
 		return err
@@ -237,6 +257,11 @@ func (p *Page) Click(ctx context.Context, selector string) error {
 // Synthetic JS events can't trigger CSS :hover reveals — only a genuine pointer
 // move does, which is what this dispatches.
 func (p *Page) Hover(ctx context.Context, selector string) error {
+	if frame, elem := splitFrame(selector); frame != "" {
+		if cp, ok := p.oopifPage(ctx, frame); ok {
+			return cp.Hover(ctx, elem)
+		}
+	}
 	pt, err := p.elementCenter(ctx, selector)
 	if err != nil {
 		return err
@@ -254,6 +279,11 @@ func (p *Page) Hover(ctx context.Context, selector string) error {
 // select popups are browser-drawn (not DOM), so this is the reliable path.
 func (p *Page) SelectOption(ctx context.Context, selector, value string) error {
 	frame, elem := splitFrame(selector)
+	if frame != "" {
+		if cp, ok := p.oopifPage(ctx, frame); ok {
+			return cp.SelectOption(ctx, elem, value)
+		}
+	}
 	expr := fmt.Sprintf(`(() => {
 		const el = %s;
 		if (!el || el.tagName !== 'SELECT') return 'no-select';
@@ -287,6 +317,11 @@ func (p *Page) SelectOption(ctx context.Context, selector, value string) error {
 // TypeText focuses the element matched by selector and types text into it.
 func (p *Page) TypeText(ctx context.Context, selector, text string) error {
 	frame, elem := splitFrame(selector)
+	if frame != "" {
+		if cp, ok := p.oopifPage(ctx, frame); ok {
+			return cp.TypeText(ctx, elem, text)
+		}
+	}
 	focus := fmt.Sprintf(`(() => { const el = %s; if (!el) return false; el.focus(); return true; })()`, elemRefJS(frame, elem))
 	var ok bool
 	if err := p.Eval(ctx, focus, &ok); err != nil {
@@ -306,6 +341,11 @@ func (p *Page) TypeText(ctx context.Context, selector, text string) error {
 // typed value aren't mistaken for a failure.
 func (p *Page) fieldNonEmpty(ctx context.Context, selector string) bool {
 	frame, elem := splitFrame(selector)
+	if frame != "" {
+		if cp, ok := p.oopifPage(ctx, frame); ok {
+			return cp.fieldNonEmpty(ctx, elem)
+		}
+	}
 	expr := fmt.Sprintf(`(()=>{const el=%s; if(!el) return false; const v=('value' in el)?el.value:el.textContent; return !!(v&&(''+v).length);})()`, elemRefJS(frame, elem))
 	var ok bool
 	_ = p.Eval(ctx, expr, &ok)
@@ -316,6 +356,12 @@ func (p *Page) fieldNonEmpty(ctx context.Context, selector string) bool {
 // framework bindings reset, before a re-type retry.
 func (p *Page) clearField(ctx context.Context, selector string) {
 	frame, elem := splitFrame(selector)
+	if frame != "" {
+		if cp, ok := p.oopifPage(ctx, frame); ok {
+			cp.clearField(ctx, elem)
+			return
+		}
+	}
 	expr := fmt.Sprintf(`(()=>{const el=%s; if(!el) return; if('value' in el){el.value='';}else{el.textContent='';} el.dispatchEvent(new Event('input',{bubbles:true})); el.focus();})()`, elemRefJS(frame, elem))
 	_ = p.Eval(ctx, expr, nil)
 }
@@ -454,6 +500,11 @@ func (p *Page) Upload(ctx context.Context, selector string, files []string) erro
 // case where there is no persistent <input type=file> to target directly. The
 // real Klook SD upload works this way.
 func (p *Page) UploadViaChooser(ctx context.Context, selector string, files []string) error {
+	if frame, elem := splitFrame(selector); frame != "" {
+		if cp, ok := p.oopifPage(ctx, frame); ok {
+			return cp.UploadViaChooser(ctx, elem, files)
+		}
+	}
 	if _, err := p.cli.call(ctx, p.sessionID, "Page.setInterceptFileChooserDialog", map[string]any{"enabled": true}); err != nil {
 		return err
 	}

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -16,6 +17,13 @@ type Browser struct {
 	cmd         *exec.Cmd
 	cli         *cdpClient
 	ownsProcess bool
+
+	// oopifs maps a cross-origin (out-of-process) iframe's frameId to its CDP
+	// session, populated by the target watcher. Cross-origin iframes live in a
+	// separate renderer, so their DOM is unreachable via the parent's
+	// contentDocument; interacting with them means routing to their own session.
+	oopifMu sync.Mutex
+	oopifs  map[string]string
 }
 
 // Launch starts a Chrome and connects to it.
@@ -29,7 +37,15 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Browser, error) {
 		killProcessGroup(cmd)
 		return nil, err
 	}
-	return &Browser{cmd: cmd, cli: cli, ownsProcess: true}, nil
+	return wrapBrowser(cli, cmd, true), nil
+}
+
+// wrapBrowser wraps a live CDP connection and starts the cross-origin iframe
+// target watcher.
+func wrapBrowser(cli *cdpClient, cmd *exec.Cmd, owns bool) *Browser {
+	b := &Browser{cmd: cmd, cli: cli, ownsProcess: owns, oopifs: map[string]string{}}
+	b.watchTargets()
+	return b
 }
 
 // Connect attaches to an already-running Chrome via its browser-level CDP
@@ -40,7 +56,7 @@ func Connect(ctx context.Context, wsURL string) (*Browser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Browser{cli: cli, ownsProcess: false}, nil
+	return wrapBrowser(cli, nil, false), nil
 }
 
 // ConnectByPort attaches to a Chrome already running with
@@ -112,6 +128,7 @@ type Page struct {
 	cli       *cdpClient
 	sessionID string
 	targetID  string
+	browser   *Browser // back-ref for cross-origin iframe session lookup; may be nil
 }
 
 // NewPage opens a fresh tab at url and attaches to it.
@@ -148,12 +165,19 @@ func (b *Browser) AttachPage(ctx context.Context, targetID string) (*Page, error
 	if err := json.Unmarshal(res, &attached); err != nil {
 		return nil, err
 	}
-	p := &Page{cli: b.cli, sessionID: attached.SessionID, targetID: targetID}
+	p := &Page{cli: b.cli, sessionID: attached.SessionID, targetID: targetID, browser: b}
 	for _, domain := range []string{"Page.enable", "Runtime.enable", "DOM.enable"} {
 		if _, err := p.cli.call(ctx, p.sessionID, domain, nil); err != nil {
 			return nil, fmt.Errorf("%s: %w", domain, err)
 		}
 	}
+	// Auto-attach to child targets (flatten) so a cross-origin iframe surfaces as
+	// its own CDP session the target watcher can register — the only way to reach
+	// an OOPIF's DOM. Best-effort: a backend that rejects it just means no
+	// cross-origin frame support.
+	_, _ = p.cli.call(ctx, p.sessionID, "Target.setAutoAttach", map[string]any{
+		"autoAttach": true, "waitForDebuggerOnStart": false, "flatten": true,
+	})
 	// Install the in-flight network monitor on this and every future document so
 	// WaitForNetworkIdle has data to poll (best-effort; failures are non-fatal).
 	_, _ = p.cli.call(ctx, p.sessionID, "Page.addScriptToEvaluateOnNewDocument", map[string]any{"source": netMonitorScript})
@@ -339,6 +363,11 @@ func (p *Page) Eval(ctx context.Context, expr string, out any) error {
 func (p *Page) WaitFor(ctx context.Context, selector string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	frame, elem := splitFrame(selector)
+	if frame != "" {
+		if cp, ok := p.oopifPage(ctx, frame); ok {
+			return cp.WaitFor(ctx, elem, timeout)
+		}
+	}
 	expr := "!!(" + elemRefJS(frame, elem) + ")"
 	for {
 		var present bool

--- a/internal/browser/cdp.go
+++ b/internal/browser/cdp.go
@@ -193,3 +193,8 @@ func (c *cdpClient) subscribe(method, sessionID string) (<-chan rpcResponse, fun
 }
 
 func (c *cdpClient) close() { c.shutdown(fmt.Errorf("closed by caller")) }
+
+// done returns a channel closed when the connection shuts down, so long-lived
+// event consumers (e.g. the OOPIF target watcher) can exit instead of blocking
+// forever on a subscription channel the shutdown never closes.
+func (c *cdpClient) done() <-chan struct{} { return c.closed }

--- a/internal/browser/oopif.go
+++ b/internal/browser/oopif.go
@@ -1,0 +1,274 @@
+package browser
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Cross-origin (out-of-process) iframe support.
+//
+// A same-origin iframe's DOM is reachable from its parent via
+// element.contentDocument, which is how the " >>> " frame convention resolves
+// (see elemRefJS). A cross-origin iframe (an OOPIF) lives in a separate renderer
+// process; contentDocument is null and the DOM is only reachable through the
+// iframe's own CDP session. The target watcher records those sessions by frameId,
+// and oopifPage resolves a frame selector to a Page bound to that session — after
+// which every existing Page operation works unchanged, because within the OOPIF's
+// session its document IS the frame (no contentDocument hop, and even coordinate
+// clicks dispatch correctly against the frame-local viewport).
+
+// watchTargets consumes Target.attachedToTarget / detachedFromTarget for the whole
+// connection and maintains the frameId→session map. It runs for the life of the
+// connection and exits when it closes.
+func (b *Browser) watchTargets() {
+	attached, _ := b.cli.subscribe("Target.attachedToTarget", "")
+	detached, _ := b.cli.subscribe("Target.detachedFromTarget", "")
+	go func() {
+		for {
+			select {
+			case <-b.cli.done():
+				return
+			case ev, ok := <-attached:
+				if !ok {
+					return
+				}
+				var p struct {
+					SessionID  string `json:"sessionId"`
+					TargetInfo struct {
+						Type string `json:"type"`
+					} `json:"targetInfo"`
+				}
+				if json.Unmarshal(ev.Params, &p) == nil && p.TargetInfo.Type == "iframe" && p.SessionID != "" {
+					go b.registerOOPIF(p.SessionID)
+				}
+			case ev, ok := <-detached:
+				if !ok {
+					return
+				}
+				var p struct {
+					SessionID string `json:"sessionId"`
+				}
+				if json.Unmarshal(ev.Params, &p) == nil {
+					b.forgetOOPIF(p.SessionID)
+				}
+			}
+		}
+	}()
+}
+
+// registerOOPIF prepares a freshly attached cross-origin iframe session (enables
+// the domains its Page operations need, cascades auto-attach for nested OOPIFs)
+// and records its frameId → session so oopifPage can find it.
+func (b *Browser) registerOOPIF(session string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	for _, d := range []string{"Page.enable", "Runtime.enable", "DOM.enable"} {
+		if _, err := b.cli.call(ctx, session, d, nil); err != nil {
+			return
+		}
+	}
+	// Cascade so a cross-origin iframe nested inside this one also attaches.
+	_, _ = b.cli.call(ctx, session, "Target.setAutoAttach", map[string]any{
+		"autoAttach": true, "waitForDebuggerOnStart": false, "flatten": true,
+	})
+	res, err := b.cli.call(ctx, session, "Page.getFrameTree", nil)
+	if err != nil {
+		return
+	}
+	var ft struct {
+		FrameTree struct {
+			Frame struct {
+				ID string `json:"id"`
+			} `json:"frame"`
+		} `json:"frameTree"`
+	}
+	if json.Unmarshal(res, &ft) != nil || ft.FrameTree.Frame.ID == "" {
+		return
+	}
+	b.oopifMu.Lock()
+	b.oopifs[ft.FrameTree.Frame.ID] = session
+	b.oopifMu.Unlock()
+}
+
+// forgetOOPIF drops any frame mapping for a detached session.
+func (b *Browser) forgetOOPIF(session string) {
+	b.oopifMu.Lock()
+	for fid, s := range b.oopifs {
+		if s == session {
+			delete(b.oopifs, fid)
+		}
+	}
+	b.oopifMu.Unlock()
+}
+
+// sessionForFrame returns the CDP session registered for a frameId, polling
+// briefly since attach can lag the parent's DOM being queryable.
+func (b *Browser) sessionForFrame(ctx context.Context, frameID string, timeout time.Duration) (string, bool) {
+	deadline := time.Now().Add(timeout)
+	for {
+		b.oopifMu.Lock()
+		s, ok := b.oopifs[frameID]
+		b.oopifMu.Unlock()
+		if ok {
+			return s, true
+		}
+		if !time.Now().Before(deadline) {
+			return "", false
+		}
+		select {
+		case <-ctx.Done():
+			return "", false
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// oopifPage resolves a frame selector to a Page bound to the cross-origin iframe's
+// own session, plus true. It returns (nil, false) when there is no frame, when the
+// frame is same-origin (contentDocument works — callers keep the existing path),
+// or when no OOPIF session can be found. The returned Page addresses the frame's
+// document as its root, so callers act on the bare element selector (no frame).
+func (p *Page) oopifPage(ctx context.Context, frame string) (*Page, bool) {
+	if frame == "" || p.browser == nil {
+		return nil, false
+	}
+	frameID, sameOrigin, ok := p.frameContentID(ctx, frame)
+	if !ok || sameOrigin || frameID == "" {
+		return nil, false
+	}
+	session, ok := p.browser.sessionForFrame(ctx, frameID, 3*time.Second)
+	if !ok {
+		return nil, false
+	}
+	return &Page{cli: p.cli, sessionID: session, targetID: "", browser: p.browser}, true
+}
+
+// frameSelectorFor finds, in pageSession's document, the <iframe> element whose
+// content frame is frameID and returns a generated CSS selector for it — the
+// reverse of oopifPage, used when recording to tag a cross-origin iframe's events
+// with the parent selector replay needs to route back into it. Returns "" if no
+// matching iframe is found (e.g. a nested OOPIF not present at the top level).
+func (b *Browser) frameSelectorFor(ctx context.Context, pageSession, frameID string) string {
+	doc, err := b.cli.call(ctx, pageSession, "DOM.getDocument", map[string]any{"depth": 0})
+	if err != nil {
+		return ""
+	}
+	var d struct {
+		Root struct {
+			NodeID int `json:"nodeId"`
+		} `json:"root"`
+	}
+	if json.Unmarshal(doc, &d) != nil {
+		return ""
+	}
+	qs, err := b.cli.call(ctx, pageSession, "DOM.querySelectorAll", map[string]any{"nodeId": d.Root.NodeID, "selector": "iframe,frame"})
+	if err != nil {
+		return ""
+	}
+	var q struct {
+		NodeIDs []int `json:"nodeIds"`
+	}
+	if json.Unmarshal(qs, &q) != nil {
+		return ""
+	}
+	const selFn = `function(){
+	  function sel(el){
+	    if(!el||el.nodeType!==1) return '';
+	    if(el.id) return '#'+CSS.escape(el.id);
+	    for(var i=0;i<4;i++){var a=['data-testid','data-test','name','aria-label'][i];var v=el.getAttribute&&el.getAttribute(a);if(v)return el.tagName.toLowerCase()+'['+a+'="'+CSS.escape(v)+'"]';}
+	    var parts=[],node=el,depth=0;
+	    while(node&&node.nodeType===1&&node.tagName!=='BODY'&&depth<6){if(node.id){parts.unshift('#'+CSS.escape(node.id));return parts.join(' > ');}var part=node.tagName.toLowerCase();var p=node.parentElement;if(p){var same=[].slice.call(p.children).filter(function(c){return c.tagName===node.tagName;});if(same.length>1)part+=':nth-of-type('+(same.indexOf(node)+1)+')';}parts.unshift(part);node=p;depth++;}
+	    return parts.join(' > ');
+	  }
+	  return sel(this);
+	}`
+	for _, nid := range q.NodeIDs {
+		dn, err := b.cli.call(ctx, pageSession, "DOM.describeNode", map[string]any{"nodeId": nid})
+		if err != nil {
+			continue
+		}
+		var node struct {
+			Node struct {
+				FrameID string `json:"frameId"`
+			} `json:"node"`
+		}
+		if json.Unmarshal(dn, &node) != nil || node.Node.FrameID != frameID {
+			continue
+		}
+		rn, err := b.cli.call(ctx, pageSession, "DOM.resolveNode", map[string]any{"nodeId": nid})
+		if err != nil {
+			return ""
+		}
+		var obj struct {
+			Object struct {
+				ObjectID string `json:"objectId"`
+			} `json:"object"`
+		}
+		if json.Unmarshal(rn, &obj) != nil || obj.Object.ObjectID == "" {
+			return ""
+		}
+		res, err := b.cli.call(ctx, pageSession, "Runtime.callFunctionOn", map[string]any{
+			"objectId": obj.Object.ObjectID, "functionDeclaration": selFn, "returnByValue": true,
+		})
+		if err != nil {
+			return ""
+		}
+		var r struct {
+			Result struct {
+				Value string `json:"value"`
+			} `json:"result"`
+		}
+		if json.Unmarshal(res, &r) == nil {
+			return r.Result.Value
+		}
+		return ""
+	}
+	return ""
+}
+
+// frameContentID inspects an iframe element in this page's document: it reports
+// whether the element's contentDocument is same-origin-accessible (in which case
+// no OOPIF routing is needed) and, when cross-origin, the content frameId used to
+// find the OOPIF's session.
+func (p *Page) frameContentID(ctx context.Context, frame string) (frameID string, sameOrigin bool, ok bool) {
+	var chk struct {
+		Found bool `json:"found"`
+		Same  bool `json:"same"`
+	}
+	expr := `(function(){var f=document.querySelector(` + jsString(frame) + `); if(!f) return {found:false}; var same=false; try{same=(f.contentDocument!=null);}catch(e){same=false;} return {found:true, same:same};})()`
+	if err := p.Eval(ctx, expr, &chk); err != nil || !chk.Found {
+		return "", false, false
+	}
+	if chk.Same {
+		return "", true, true
+	}
+	// Cross-origin: get the element's object handle, then its content frameId.
+	res, err := p.cli.call(ctx, p.sessionID, "Runtime.evaluate", map[string]any{
+		"expression": "document.querySelector(" + jsString(frame) + ")", "returnByValue": false,
+	})
+	if err != nil {
+		return "", false, false
+	}
+	var re struct {
+		Result struct {
+			ObjectID string `json:"objectId"`
+		} `json:"result"`
+	}
+	if json.Unmarshal(res, &re) != nil || re.Result.ObjectID == "" {
+		return "", false, false
+	}
+	dn, err := p.cli.call(ctx, p.sessionID, "DOM.describeNode", map[string]any{"objectId": re.Result.ObjectID})
+	if err != nil {
+		return "", false, false
+	}
+	var node struct {
+		Node struct {
+			FrameID string `json:"frameId"`
+		} `json:"node"`
+	}
+	if json.Unmarshal(dn, &node) != nil || node.Node.FrameID == "" {
+		return "", false, false
+	}
+	return node.Node.FrameID, false, true
+}

--- a/internal/browser/oopif_test.go
+++ b/internal/browser/oopif_test.go
@@ -1,0 +1,158 @@
+package browser
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// oopifServer serves a parent page embedding a cross-origin iframe. The iframe's
+// src uses a different host string (localhost vs 127.0.0.1) than the parent so
+// site isolation puts it in its own process — a real OOPIF, unreachable via the
+// parent's contentDocument. innerBody is the iframe document's <body> contents.
+func oopifServer(t *testing.T, innerBody string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/inner", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<!doctype html><meta charset="utf-8"><title>inner</title>%s`, innerBody)
+	})
+	var srv *httptest.Server
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		inner := strings.Replace(srv.URL, "127.0.0.1", "localhost", 1) + "/inner"
+		fmt.Fprintf(w, `<!doctype html><meta charset="utf-8"><title>outer</title>
+<div style="height:40px">header</div><iframe id="f" src=%q style="width:400px;height:300px;border:0"></iframe>`, inner)
+	})
+	srv = httptest.NewServer(mux)
+	return srv
+}
+
+func newOOPIFBrowser(t *testing.T, ctx context.Context) *Browser {
+	t.Helper()
+	b, err := Launch(ctx, LaunchOptions{Headless: true, ExtraArgs: []string{"--site-per-process"}})
+	if err != nil {
+		t.Skipf("chrome unavailable: %v", err)
+	}
+	return b
+}
+
+// TestOOPIFReplay: replay clicks a button inside a cross-origin iframe. The step's
+// frame selector routes into the OOPIF's own session; the click lands there, and a
+// verification WaitFor through the same frame path confirms it.
+func TestOOPIFReplay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := oopifServer(t, `<button id="go" onclick="var d=document.createElement('div');d.id='done';document.body.appendChild(d)">Go</button>`)
+	defer srv.Close()
+
+	b := newOOPIFBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+
+	skill := &Skill{Name: "x", Steps: []Step{{Action: "click", Frame: "#f", Selector: "#go"}}}
+	if _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 15 * time.Second, Browser: b}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	// The click must have run inside the OOPIF: #done appears there. WaitFor also
+	// routes through the frame, so a pass proves both directions work.
+	if err := page.WaitFor(ctx, "#f >>> #done", 10*time.Second); err != nil {
+		t.Fatalf("click did not land inside the cross-origin iframe: %v", err)
+	}
+}
+
+// TestOOPIFTypeReplay: type into a text input inside a cross-origin iframe, then
+// read it back through the frame path.
+func TestOOPIFTypeReplay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := oopifServer(t, `<input id="q" name="q">`)
+	defer srv.Close()
+
+	b := newOOPIFBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+
+	skill := &Skill{Name: "x", Steps: []Step{{Action: "type", Frame: "#f", Selector: "#q", Value: "hello"}}}
+	if _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 15 * time.Second}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	cp, ok := page.oopifPage(ctx, "#f")
+	if !ok {
+		t.Fatal("could not resolve the OOPIF page for verification")
+	}
+	var got string
+	if err := cp.Eval(ctx, `document.querySelector('#q').value`, &got); err != nil {
+		t.Fatalf("eval in oopif: %v", err)
+	}
+	if got != "hello" {
+		t.Fatalf("type did not land in the cross-origin input: value=%q", got)
+	}
+}
+
+// TestOOPIFRecord: a user gesture inside a cross-origin iframe is captured and
+// tagged with the parent iframe selector, so the recording replays back into it.
+func TestOOPIFRecord(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := oopifServer(t, `<button id="go">Go</button>`)
+	defer srv.Close()
+
+	b := newOOPIFBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.Navigate(ctx, srv.URL); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	// Ensure the OOPIF is attached/registered before recording starts.
+	if err := page.WaitFor(ctx, "#f >>> #go", 10*time.Second); err != nil {
+		t.Fatalf("oopif not ready: %v", err)
+	}
+
+	rec := NewRecorder(page)
+	if err := rec.Start(ctx); err != nil {
+		t.Fatalf("recorder start: %v", err)
+	}
+	// Stand in for the user: a trusted click inside the cross-origin iframe.
+	if err := page.Click(ctx, "#f >>> #go"); err != nil {
+		t.Fatalf("click: %v", err)
+	}
+
+	var evs []RecordedEvent
+	for i := 0; i < 40; i++ {
+		time.Sleep(100 * time.Millisecond)
+		if evs = rec.Events(); len(evs) >= 1 {
+			break
+		}
+	}
+	rec.Stop()
+
+	var found bool
+	for _, e := range evs {
+		if e.Type == "click" && e.Selector == "#go" && e.Frame == "#f" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("did not capture the cross-origin iframe click tagged with frame #f; got %+v", evs)
+	}
+}

--- a/internal/browser/recorder.go
+++ b/internal/browser/recorder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
+	"time"
 )
 
 // RecordedEvent is one captured user action during a demonstration. Each event
@@ -30,11 +31,90 @@ type Recorder struct {
 
 	mu     sync.Mutex
 	events []RecordedEvent
-	unsub  func()
+	unsubs []func()
+	seen   map[string]bool // sessions already instrumented (avoid double-install)
 }
 
 // NewRecorder creates a recorder bound to a page.
-func NewRecorder(page *Page) *Recorder { return &Recorder{page: page} }
+func NewRecorder(page *Page) *Recorder { return &Recorder{page: page, seen: map[string]bool{}} }
+
+// addEvent appends a captured event, forcing frame to frameSel when the event
+// came from a cross-origin iframe session (whose own window.frameElement is
+// unreadable, so the script couldn't tag it).
+func (r *Recorder) addEvent(re RecordedEvent, frameSel string) {
+	if frameSel != "" {
+		re.Frame = frameSel
+	}
+	r.mu.Lock()
+	r.events = append(r.events, re)
+	r.mu.Unlock()
+}
+
+// instrumentSession installs the capture binding + listeners on one CDP session
+// and streams its click/change events into the recording, tagged with frameSel.
+// Used for the top document (frameSel "") and each cross-origin iframe session.
+func (r *Recorder) instrumentSession(ctx context.Context, session, frameSel string) error {
+	if r.seen[session] {
+		return nil
+	}
+	r.seen[session] = true
+	if _, err := r.page.cli.call(ctx, session, "Runtime.addBinding", map[string]any{"name": "__octoRecord"}); err != nil {
+		return err
+	}
+	if _, err := r.page.cli.call(ctx, session, "Page.addScriptToEvaluateOnNewDocument", map[string]any{"source": captureScript}); err != nil {
+		return err
+	}
+	// Install into the already-loaded document too.
+	if _, err := r.page.cli.call(ctx, session, "Runtime.evaluate", map[string]any{"expression": captureScript}); err != nil {
+		return err
+	}
+	events, unsub := r.page.cli.subscribe("Runtime.bindingCalled", session)
+	r.mu.Lock()
+	r.unsubs = append(r.unsubs, unsub)
+	r.mu.Unlock()
+	go func() {
+		for ev := range events {
+			var b struct {
+				Name    string `json:"name"`
+				Payload string `json:"payload"`
+			}
+			if json.Unmarshal(ev.Params, &b) != nil || b.Name != "__octoRecord" {
+				continue
+			}
+			var re RecordedEvent
+			if json.Unmarshal([]byte(b.Payload), &re) != nil {
+				continue
+			}
+			r.addEvent(re, frameSel)
+		}
+	}()
+	return nil
+}
+
+// instrumentOOPIF resolves a cross-origin iframe session's parent selector and
+// instruments it, so gestures the user performs inside the frame are captured and
+// tagged with the frame replay needs to route back into.
+func (r *Recorder) instrumentOOPIF(ctx context.Context, session string) {
+	res, err := r.page.cli.call(ctx, session, "Page.getFrameTree", nil)
+	if err != nil {
+		return
+	}
+	var ft struct {
+		FrameTree struct {
+			Frame struct {
+				ID string `json:"id"`
+			} `json:"frame"`
+		} `json:"frameTree"`
+	}
+	if json.Unmarshal(res, &ft) != nil || ft.FrameTree.Frame.ID == "" {
+		return
+	}
+	frameSel := ""
+	if r.page.browser != nil {
+		frameSel = r.page.browser.frameSelectorFor(ctx, r.page.sessionID, ft.FrameTree.Frame.ID)
+	}
+	_ = r.instrumentSession(ctx, session, frameSel)
+}
 
 // captureScript installs capture-phase click/change listeners that report each
 // action (with a stable-ish selector) through the __octoRecord binding.
@@ -70,45 +150,55 @@ const captureScript = `(function(){
 // same-origin child frames are covered too).
 func (r *Recorder) Start(ctx context.Context) error {
 	p := r.page
-	if _, err := p.cli.call(ctx, p.sessionID, "Runtime.addBinding", map[string]any{"name": "__octoRecord"}); err != nil {
+	// Instrument the top document.
+	if err := r.instrumentSession(ctx, p.sessionID, ""); err != nil {
 		return err
 	}
-	if _, err := p.cli.call(ctx, p.sessionID, "Page.addScriptToEvaluateOnNewDocument", map[string]any{"source": captureScript}); err != nil {
-		return err
-	}
-	// Install into the already-loaded document too.
-	if err := p.Eval(ctx, captureScript, nil); err != nil {
-		return err
+	// Instrument cross-origin iframes: those already present, and any that attach
+	// during the demonstration (so gestures inside a payment/OAuth/captcha frame
+	// are captured, tagged with the parent selector replay routes back into).
+	if p.browser != nil {
+		p.browser.oopifMu.Lock()
+		sessions := make([]string, 0, len(p.browser.oopifs))
+		for _, s := range p.browser.oopifs {
+			sessions = append(sessions, s)
+		}
+		p.browser.oopifMu.Unlock()
+		for _, s := range sessions {
+			r.instrumentOOPIF(ctx, s)
+		}
+		attached, attachUnsub := p.cli.subscribe("Target.attachedToTarget", "")
+		r.mu.Lock()
+		r.unsubs = append(r.unsubs, attachUnsub)
+		r.mu.Unlock()
+		go func() {
+			for ev := range attached {
+				var a struct {
+					SessionID  string `json:"sessionId"`
+					TargetInfo struct {
+						Type string `json:"type"`
+					} `json:"targetInfo"`
+				}
+				if json.Unmarshal(ev.Params, &a) == nil && a.TargetInfo.Type == "iframe" && a.SessionID != "" {
+					// The browser watcher enables the child's domains; give it a
+					// moment, then instrument for recording.
+					ictx, icancel := context.WithTimeout(context.Background(), 10*time.Second)
+					r.instrumentOOPIF(ictx, a.SessionID)
+					icancel()
+				}
+			}
+		}()
 	}
 
-	events, unsub := p.cli.subscribe("Runtime.bindingCalled", p.sessionID)
 	// Also capture top-level navigations (address-bar, link, SPA history) so a
 	// multi-page demonstration replays from the right pages — otherwise the only
 	// navigate step is the synthesized start URL, and the recording loses every
 	// page the user moved to.
 	navEvents, navUnsub := p.cli.subscribe("Page.frameNavigated", p.sessionID)
 	r.mu.Lock()
-	r.unsub = func() { unsub(); navUnsub() }
+	r.unsubs = append(r.unsubs, navUnsub)
 	r.mu.Unlock()
 
-	go func() {
-		for ev := range events {
-			var b struct {
-				Name    string `json:"name"`
-				Payload string `json:"payload"`
-			}
-			if json.Unmarshal(ev.Params, &b) != nil || b.Name != "__octoRecord" {
-				continue
-			}
-			var re RecordedEvent
-			if json.Unmarshal([]byte(b.Payload), &re) != nil {
-				continue
-			}
-			r.mu.Lock()
-			r.events = append(r.events, re)
-			r.mu.Unlock()
-		}
-	}()
 	go func() {
 		for ev := range navEvents {
 			var b struct {
@@ -154,14 +244,16 @@ func Replay(ctx context.Context, page *Page, events []RecordedEvent) error {
 	return err
 }
 
-// Stop ends capture (the subscription is dropped; the page-side listeners are
+// Stop ends capture (all subscriptions are dropped; the page-side listeners are
 // harmless and go away on navigation/close).
 func (r *Recorder) Stop() {
 	r.mu.Lock()
-	unsub := r.unsub
-	r.unsub = nil
+	unsubs := r.unsubs
+	r.unsubs = nil
 	r.mu.Unlock()
-	if unsub != nil {
-		unsub()
+	for _, u := range unsubs {
+		if u != nil {
+			u()
+		}
 	}
 }

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -362,6 +362,13 @@ func InteractiveDigest(ctx context.Context, page *Page, frame string, max int) (
 	if max <= 0 {
 		max = 60
 	}
+	// A cross-origin iframe's elements are only enumerable in its own session; run
+	// the digest there (frame cleared) so the healer sees the OOPIF's real elements.
+	if frame != "" {
+		if cp, ok := page.oopifPage(ctx, frame); ok {
+			return InteractiveDigest(ctx, cp, "", max)
+		}
+	}
 	doc := "document"
 	if frame != "" {
 		doc = fmt.Sprintf("(document.querySelector(%s)||{}).contentDocument", jsString(frame))


### PR DESCRIPTION
Part 6/6 (final) of the record-and-replay robustness work.

## Problem

The `" >>> "` frame convention only reached **same-origin** iframes — it resolves via `element.contentDocument`, which is `null` for a cross-origin iframe whose DOM lives in a separate renderer (an OOPIF). Payment / OAuth / captcha embeds were invisible to both replay and recording. This was the record-and-replay review's #1 gap.

## Change

Cross-origin iframes are now first-class, **transparently** — callers still use the same `frame >>> element` selector regardless of origin:

- **Auto-attach + watcher**: `Target.setAutoAttach{flatten}` on each page; a connection-lifetime watcher records every attached iframe target's `frameId → CDP session` (enabling its domains, cascading auto-attach for nesting).
- **`oopifPage`** resolves a frame selector to a `Page` bound to the iframe's own session (contentDocument-null → `DOM.describeNode` frameId → session). Within that session the frame's document is the root, so **every existing `Page` operation works unchanged** — including coordinate clicks, which dispatch correctly against the frame-local viewport (verified). The frame-aware methods (`Click`/`Hover`/`TypeText`/`SelectOption`/`WaitFor`/upload/field helpers, `resolveClickTarget`/`resolveFieldTarget`, `InteractiveDigest`) route through it.
- **Recording** instruments each OOPIF session too and tags its events with the parent iframe selector (correlated via `frameId`), since a cross-origin frame's own `window.frameElement` is unreadable.

Design note: coordinate clicks dispatched on the OOPIF's *own* session with frame-local coordinates land correctly (confirmed by spike), so no cross-session coordinate composition is needed — which is what keeps this a localized change rather than a rewrite of the input path.

Scope matches the existing one-hop frame model (top → iframe), now origin-agnostic.

## Tests

New `oopif_test.go` drives **real** OOPIFs (site-isolated cross-origin iframes via `--site-per-process` + distinct loopback hosts):
- `TestOOPIFReplay` — click a button inside the frame, verified through the frame path
- `TestOOPIFTypeReplay` — type into a cross-origin input, read back
- `TestOOPIFRecord` — a gesture inside the frame is captured and tagged `frame: #f`

Full browser + tools + app packages pass with Chrome present.

Stacked on #1022–#1026 (all merged); rebased onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)