### PR TITLE
fix(browser): review follow-ups — secret leak, recorder race, goroutine leak, over-eager overlay dismiss

### DIFF
--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -102,8 +102,11 @@ func (p *Page) resolveClickTarget(ctx context.Context, frame, elemSel, anchor st
 // LLM involved; safe to call speculatively before falling back to the healer.
 func (p *Page) DismissOverlay(ctx context.Context) (bool, error) {
 	const expr = `(function(){
-	  var ok=/^(accept|accept all|accept all cookies|agree|i agree|allow all|got it|ok|okay|close|dismiss|no thanks|continue)$/i;
-	  var lab=/(close|dismiss|accept|agree)/i;
+	  // Consent/dismiss affordances only. Deliberately NOT ok/okay/continue/submit/
+	  // next — those are commonly a flow's PRIMARY action, and clicking one on a
+	  // transient (non-overlay) failure would advance/submit the page unintended.
+	  var ok=/^(accept|accept all|accept all cookies|accept cookies|agree|i agree|allow all|got it|close|dismiss)$/i;
+	  var lab=/(close|dismiss)/i;
 	  var els=document.querySelectorAll('button,[role="button"],a,[aria-label]');
 	  for(var i=0;i<els.length;i++){var el=els[i];
 	    if(!(el.offsetParent!==null||el.getClientRects().length)) continue; // visible only

--- a/internal/browser/cdp.go
+++ b/internal/browser/cdp.go
@@ -185,10 +185,20 @@ func (c *cdpClient) subscribe(method, sessionID string) (<-chan rpcResponse, fun
 	c.nextSub++
 	s := &subscription{method: method, sessionID: sessionID, ch: make(chan rpcResponse, 32)}
 	c.subs[id] = s
+	var once sync.Once
 	return s.ch, func() {
-		c.subsMu.Lock()
-		delete(c.subs, id)
-		c.subsMu.Unlock()
+		once.Do(func() {
+			// Delete then close under the same lock the reader holds while sending,
+			// so a `for ev := range ch` consumer actually terminates (unsub used to
+			// only delete, leaving such goroutines blocked forever). readLoop only
+			// sends to subs still in the map and only under subsMu, so closing here
+			// can never race a send onto the closed channel. sync.Once guards against
+			// a double unsub closing twice.
+			c.subsMu.Lock()
+			delete(c.subs, id)
+			close(s.ch)
+			c.subsMu.Unlock()
+		})
 	}
 }
 

--- a/internal/browser/recorder.go
+++ b/internal/browser/recorder.go
@@ -38,6 +38,27 @@ type Recorder struct {
 // NewRecorder creates a recorder bound to a page.
 func NewRecorder(page *Page) *Recorder { return &Recorder{page: page, seen: map[string]bool{}} }
 
+// claimSession atomically records a session as instrumented, returning false if
+// it already was — the guarded compare-and-set that lets Start and the
+// attach-watcher goroutine race safely.
+func (r *Recorder) claimSession(session string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.seen[session] {
+		return false
+	}
+	r.seen[session] = true
+	return true
+}
+
+// releaseSession undoes a claim so a session whose instrumentation failed can be
+// retried on a later attach event.
+func (r *Recorder) releaseSession(session string) {
+	r.mu.Lock()
+	delete(r.seen, session)
+	r.mu.Unlock()
+}
+
 // addEvent appends a captured event, forcing frame to frameSel when the event
 // came from a cross-origin iframe session (whose own window.frameElement is
 // unreadable, so the script couldn't tag it).
@@ -54,19 +75,28 @@ func (r *Recorder) addEvent(re RecordedEvent, frameSel string) {
 // and streams its click/change events into the recording, tagged with frameSel.
 // Used for the top document (frameSel "") and each cross-origin iframe session.
 func (r *Recorder) instrumentSession(ctx context.Context, session, frameSel string) error {
-	if r.seen[session] {
+	// Claim the session under the lock: instrumentSession runs concurrently from
+	// Start (main) and the attach-watcher goroutine, so an unguarded seen map is a
+	// data race (concurrent map writes → panic). Claiming also dedups. Release on
+	// failure so a session that failed to install can be retried later.
+	if !r.claimSession(session) {
 		return nil
 	}
-	r.seen[session] = true
-	if _, err := r.page.cli.call(ctx, session, "Runtime.addBinding", map[string]any{"name": "__octoRecord"}); err != nil {
+	release := func(err error) error {
+		if err != nil {
+			r.releaseSession(session)
+		}
 		return err
 	}
+	if _, err := r.page.cli.call(ctx, session, "Runtime.addBinding", map[string]any{"name": "__octoRecord"}); err != nil {
+		return release(err)
+	}
 	if _, err := r.page.cli.call(ctx, session, "Page.addScriptToEvaluateOnNewDocument", map[string]any{"source": captureScript}); err != nil {
-		return err
+		return release(err)
 	}
 	// Install into the already-loaded document too.
 	if _, err := r.page.cli.call(ctx, session, "Runtime.evaluate", map[string]any{"expression": captureScript}); err != nil {
-		return err
+		return release(err)
 	}
 	events, unsub := r.page.cli.subscribe("Runtime.bindingCalled", session)
 	r.mu.Lock()
@@ -139,7 +169,8 @@ const captureScript = `(function(){
   function report(type, e){
     try{var el=e.target; var fr=''; try{ if(window.frameElement) fr=sel(window.frameElement); }catch(_2){}
       var field=((el.placeholder||el.name||(el.getAttribute?el.getAttribute('aria-label'):'')||el.id||'')+'').trim().slice(0,40);
-      window.__octoRecord(JSON.stringify({type:type, selector:sel(el), frame:fr, tag:el.tagName, text:(el.textContent||'').trim().slice(0,40), field:field, secret:(el.type==='password'), value:(el.value!==undefined?(''+el.value).slice(0,200):''), url:location.href}));}catch(_){}
+      var secret=(el.type==='password');
+      window.__octoRecord(JSON.stringify({type:type, selector:sel(el), frame:fr, tag:el.tagName, text:(el.textContent||'').trim().slice(0,40), field:field, secret:secret, value:(secret?'':(el.value!==undefined?(''+el.value).slice(0,200):'')), url:location.href}));}catch(_){}
   }
   document.addEventListener('click', function(e){report('click',e);}, true);
   document.addEventListener('change', function(e){var t=e.target; report((t&&t.type==='file')?'upload':'change', e);}, true);

--- a/internal/browser/review_fixes_test.go
+++ b/internal/browser/review_fixes_test.go
@@ -1,0 +1,86 @@
+package browser
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestUnsubClosesChannel: a subscription's unsub closes its channel so a
+// `for ev := range ch` consumer terminates (it used to only delete from the map,
+// leaving such goroutines blocked forever). Double-unsub must not panic.
+func TestUnsubClosesChannel(t *testing.T) {
+	c := &cdpClient{subs: map[int]*subscription{}}
+	ch, unsub := c.subscribe("Some.event", "")
+	unsub()
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected the channel to be closed after unsub")
+		}
+	default:
+		t.Fatal("channel was not closed by unsub")
+	}
+	unsub() // sync.Once: must be a no-op, not a close-of-closed panic
+}
+
+// TestClaimSessionRaceFree: concurrent claimSession calls for one session yield
+// exactly one winner (the guarded compare-and-set the recorder relies on), and a
+// released session can be claimed again. Run with -race to catch unguarded map
+// access.
+func TestClaimSessionRaceFree(t *testing.T) {
+	r := NewRecorder(&Page{})
+	var wins int64
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if r.claimSession("sess-1") {
+				atomic.AddInt64(&wins, 1)
+			}
+		}()
+	}
+	wg.Wait()
+	if wins != 1 {
+		t.Fatalf("expected exactly one claim to win, got %d", wins)
+	}
+	if r.claimSession("sess-1") {
+		t.Fatal("already-claimed session should not be claimable again")
+	}
+	r.releaseSession("sess-1")
+	if !r.claimSession("sess-1") {
+		t.Fatal("released session should be claimable again")
+	}
+}
+
+// TestRenderTraceRedactsSecret: the LLM distiller prompt never carries a secret
+// field's value, even if one reached RecordedEvent.Value — so the plaintext can't
+// be transmitted off-machine or re-inlined into the saved skill.
+func TestRenderTraceRedactsSecret(t *testing.T) {
+	events := []RecordedEvent{
+		{Type: "change", Selector: "#u", Tag: "INPUT", Field: "user", Value: "alice"},
+		{Type: "change", Selector: "#pw", Tag: "INPUT", Field: "password", Secret: true, Value: "hunter2"},
+	}
+	// renderTrace directly.
+	if tr := renderTrace(events); strings.Contains(tr, "hunter2") {
+		t.Fatalf("renderTrace leaked the secret value:\n%s", tr)
+	}
+	// End to end: whatever prompt GenerateSkill would send the model.
+	var captured string
+	gen := func(_ context.Context, _, user string) (string, error) {
+		captured = user
+		return "", fmt.Errorf("stop") // force fallback to the deterministic baseline
+	}
+	GenerateSkill(context.Background(), "demo", "https://x/start", events, gen)
+	if strings.Contains(captured, "hunter2") {
+		t.Fatalf("secret value reached the LLM distiller prompt:\n%s", captured)
+	}
+	// The non-secret value is still present (redaction is targeted).
+	if !strings.Contains(captured, "alice") {
+		t.Fatalf("expected the non-secret value to remain in the prompt:\n%s", captured)
+	}
+}

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -287,7 +287,14 @@ func GenerateSkill(ctx context.Context, name, startURL string, events []Recorded
 func renderTrace(events []RecordedEvent) string {
 	var sb strings.Builder
 	for i, e := range events {
-		fmt.Fprintf(&sb, "%d. %s selector=%q frame=%q tag=%s text=%q value=%q\n", i+1, e.Type, e.Selector, e.Frame, e.Tag, e.Text, e.Value)
+		// Never put a secret field's value in the prompt sent to the LLM distiller.
+		// (The recorder already captures it empty; this is defense in depth so the
+		// plaintext can't reach an off-machine provider or be re-inlined.)
+		val := e.Value
+		if e.Secret {
+			val = "[secret]"
+		}
+		fmt.Fprintf(&sb, "%d. %s selector=%q frame=%q tag=%s text=%q value=%q\n", i+1, e.Type, e.Selector, e.Frame, e.Tag, e.Text, val)
 	}
 	return sb.String()
 }


### PR DESCRIPTION
Follow-up to the record/replay hardening (#1022–#1027). An adversarial multi-agent review surfaced four real defects; this fixes them.

## 1. 🔴 Secret leak via the LLM distiller (high)

PR #1022 claimed a password "never lands in the YAML", but that held only on the deterministic (`gen==nil`) path. The recorder captured the password value unconditionally, and `renderTrace` put **every** value into the distiller prompt — so with the default LLM distiller wired, the plaintext was (a) transmitted off-machine to the provider and (b) could be re-inlined by the model into the saved skill (only selectors are guarded). The secret test only exercised the deterministic path, so it passed while the live path leaked.

**Fix**: the capture script records an **empty** value for `type=password`; `renderTrace` redacts any secret event's value (`[secret]`) as defense in depth.

## 2. 🔴 Data race on the recorder's `seen` map (can panic)

`instrumentSession` runs concurrently from `Start` and the attach-watcher goroutine and read/wrote the `seen` map **unlocked** — a concurrent map write, which panics. **Fix**: a mutex-guarded claim/release compare-and-set (also fixes marking a session seen *before* instrumentation succeeds — now released on failure so it can retry).

## 3. 🟠 Goroutine leak on Stop()

`subscribe`'s unsub only deleted from the subscription map; it never closed the channel, so every `for ev := range ch` consumer (recorder per-session + nav + attach watcher) blocked forever after `Stop()`. **Fix**: unsub now closes the channel (delete+close under the reader's lock, `sync.Once`-guarded so a double unsub is a no-op). Also fixes the pre-existing 2-goroutine leak.

## 4. 🟠 Over-eager overlay dismissal

`DismissOverlay`'s allow-list included `ok`/`okay`/`continue`/`no thanks` — commonly a flow's **primary** action. On a transient (non-overlay) step failure it could click Continue/OK and advance/submit the page. **Fix**: narrowed to consent/dismiss affordances only (`accept`/`agree`/`got it`/`close`/`dismiss`/…).

## Tests

New pure-Go tests (run in CI without Chrome, under `-race`):
- `TestUnsubClosesChannel` — unsub closes the channel; double-unsub is safe
- `TestClaimSessionRaceFree` — concurrent claims → exactly one winner; release re-enables
- `TestRenderTraceRedactsSecret` — the distiller prompt (and `renderTrace`) never carry a secret value, non-secret values remain

Full `internal/browser` suite passes under `-race` with Chrome present.

## Review process note

The review's *finder* phase (explicit `git diff <sha>` range) was accurate. Its *verify* phase initially read a working tree that was several PRs behind and wrongly refuted 6 findings as "code doesn't exist"; re-verified against the correct tree, they were real. Lesson for review workflows: finder and verifier must read the **same** revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)