### PR TITLE
fix(browser): clear the P3 review nits — URL verify, OOPIF race, XHR count, type dedup

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -195,7 +195,7 @@ const netMonitorScript = `(function(){
   function inc(){ s.n++; s.idleSince=0; }
   function dec(){ s.n=Math.max(0,s.n-1); if(s.n===0) s.idleSince=Date.now(); }
   try{ var of=window.fetch; if(of){ window.fetch=function(){ inc(); return of.apply(this,arguments).then(function(r){dec();return r;},function(e){dec();throw e;}); }; } }catch(_){}
-  try{ var send=XMLHttpRequest.prototype.send; XMLHttpRequest.prototype.send=function(){ inc(); try{ this.addEventListener('loadend',function(){dec();}); }catch(_){ dec(); } return send.apply(this,arguments); }; }catch(_){}
+  try{ var send=XMLHttpRequest.prototype.send; XMLHttpRequest.prototype.send=function(){ inc(); try{ this.addEventListener('loadend',function(){dec();},{once:true}); }catch(_){ dec(); } return send.apply(this,arguments); }; }catch(_){}
 })();`
 
 // WaitForNetworkIdle is a best-effort settle: it returns once no fetch/XHR has

--- a/internal/browser/recorder.go
+++ b/internal/browser/recorder.go
@@ -125,6 +125,14 @@ func (r *Recorder) instrumentSession(ctx context.Context, session, frameSel stri
 // instruments it, so gestures the user performs inside the frame are captured and
 // tagged with the frame replay needs to route back into.
 func (r *Recorder) instrumentOOPIF(ctx context.Context, session string) {
+	// Enable the domains ourselves rather than depend on the browser watcher's
+	// async registerOOPIF having run first — otherwise getFrameTree/addBinding
+	// below could race it and fail, leaving the frame uninstrumented. Idempotent.
+	for _, d := range []string{"Page.enable", "Runtime.enable", "DOM.enable"} {
+		if _, err := r.page.cli.call(ctx, session, d, nil); err != nil {
+			return
+		}
+	}
 	res, err := r.page.cli.call(ctx, session, "Page.getFrameTree", nil)
 	if err != nil {
 		return

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -75,6 +75,11 @@ type Healer func(ctx context.Context, page *Page, step *Step, cause error) error
 // top-level navigations the recorder captured, so a multi-page demonstration
 // replays from the right pages.
 func CompileSkill(name, description, startURL string, events []RecordedEvent) Skill {
+	// Collapse consecutive identical raw events (a jittery double-fire / re-
+	// dispatched event) BEFORE parameterization. dropConsecutiveDupeSteps can't
+	// catch a repeated `type` afterwards, because each gets a distinct {{param}}
+	// placeholder as its value — so a spurious extra param+step would survive.
+	events = dedupeConsecutiveEvents(events)
 	s := Skill{Name: name, Description: description}
 	if startURL != "" && startURL != "about:blank" {
 		s.Steps = append(s.Steps, navStep(startURL))
@@ -220,6 +225,24 @@ func hintFromSelector(sel string) string {
 }
 
 var selectorAttrRe = regexp.MustCompile(`\[(?:name|aria-label|data-testid|data-test)="([^"]+)"\]`)
+
+// dedupeConsecutiveEvents drops a raw event identical to its immediate
+// predecessor (same type/selector/frame/value/tag) — a double-fire or a
+// framework's re-dispatched event. navigate is exempt (CompileSkill collapses
+// navigate echoes itself). Conservative: only exact consecutive duplicates.
+func dedupeConsecutiveEvents(events []RecordedEvent) []RecordedEvent {
+	out := make([]RecordedEvent, 0, len(events))
+	for i, e := range events {
+		if i > 0 && e.Type != "navigate" {
+			p := events[i-1]
+			if e.Type == p.Type && e.Selector == p.Selector && e.Frame == p.Frame && e.Value == p.Value && e.Tag == p.Tag {
+				continue
+			}
+		}
+		out = append(out, e)
+	}
+	return out
+}
 
 // dropConsecutiveDupeSteps removes a step identical to its immediate predecessor
 // (same action/frame/selector/value) — a double-fire the user didn't intend (a
@@ -678,10 +701,18 @@ func verify(ctx context.Context, page *Page, step *Step, params map[string]strin
 	}
 	if want := subst(step.Verify.URL, params); want != "" {
 		// Poll: a redirect (e.g. to a login/error host) may resolve a beat after
-		// the load event. Substring (not prefix) match so it's scheme-agnostic —
-		// an http→https upgrade must not read as a wrong-page failure.
+		// the load event. A bare host (no '/', the auto-generated form) is matched
+		// against location's actual host, so a bounce to a different host whose URL
+		// merely echoes ours in a query param (…/login?return_to=ourhost) doesn't
+		// falsely pass; a hand-authored fragment containing '/' falls back to a
+		// scheme-agnostic href substring. Either form ignores an http→https upgrade.
 		deadline := time.Now().Add(10 * time.Second)
-		expr := fmt.Sprintf("(location.href||'').indexOf(%s) >= 0", jsString(want))
+		var expr string
+		if strings.Contains(want, "/") {
+			expr = fmt.Sprintf("(location.href||'').indexOf(%s) >= 0", jsString(want))
+		} else {
+			expr = fmt.Sprintf("(function(){try{return new URL(location.href).host===%s}catch(e){return (location.href||'').indexOf(%s)>=0}})()", jsString(want), jsString(want))
+		}
 		for {
 			var ok bool
 			if err := page.Eval(ctx, expr, &ok); err != nil {

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -168,6 +168,66 @@ func TestReplayVerifyURLCatchesCrossHostRedirect(t *testing.T) {
 	}
 }
 
+// TestCompileDedupesRepeatedType: a re-dispatched identical `change` event no
+// longer survives parameterization as a spurious extra param+step (the guard that
+// value-placeholders had defeated).
+func TestCompileDedupesRepeatedType(t *testing.T) {
+	events := []RecordedEvent{
+		{Type: "change", Selector: "#q", Tag: "INPUT", Field: "query", Value: "abc"},
+		{Type: "change", Selector: "#q", Tag: "INPUT", Field: "query", Value: "abc"}, // re-dispatched dup
+	}
+	s := CompileSkill("demo", "", "", events)
+	types := 0
+	for _, st := range s.Steps {
+		if st.Action == "type" {
+			types++
+		}
+	}
+	if types != 1 {
+		t.Fatalf("want 1 type step after dedup, got %d: %+v", types, s.Steps)
+	}
+	if len(s.Params) != 1 {
+		t.Fatalf("want 1 param after dedup, got %+v", s.Params)
+	}
+}
+
+// TestReplayVerifyURLIgnoresHostInQueryParam: a bounce to a different host whose
+// URL merely echoes the expected host in a query param must still fail the host
+// verify (exact host match, not a naive href substring).
+func TestReplayVerifyURLIgnoresHostInQueryParam(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	var app *httptest.Server
+	login := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!doctype html><title>login</title><h1>Sign in</h1>`))
+	}))
+	defer login.Close()
+	app = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Bounce to the login host, echoing the app host in a query param.
+		http.Redirect(w, r, login.URL+"/?return_to="+app.URL+"%2Fcart", http.StatusFound)
+	}))
+	defer app.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	appHost := strings.TrimPrefix(app.URL, "http://")
+	skill := &Skill{Name: "x", Steps: []Step{
+		{Action: "navigate", URL: app.URL + "/start", Verify: &Verify{URL: appHost}},
+	}}
+	_, _, err = ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second})
+	if err == nil {
+		t.Fatal("expected failure: bounced to the login host despite the app host appearing in a query param")
+	}
+	if !strings.Contains(err.Error(), "verify url") {
+		t.Fatalf("expected a url-verify failure, got: %v", err)
+	}
+}
+
 // TestCompileUploadMerge: a click on the upload button followed by a file
 // selection compiles to a single upload step on the button, auto-parameterized.
 func TestCompileUploadMerge(t *testing.T) {


### PR DESCRIPTION
The four low-severity findings from the record/replay review (#1029 covered the P1/P2 set).

## 5. URL verify: host echoed in a query param falsely passed
The host check was a naive `location.href` substring, so a bounce to a different host whose URL echoed ours in a query param (`…/login?return_to=ourhost`) passed — missing the bounce. A **bare host** (the auto-generated form) now matches `new URL(location.href).host` exactly; a hand-authored fragment containing `/` still uses a substring. Both still ignore an http→https upgrade.

## 6. OOPIF recording raced the watcher's domain-enable
`instrumentOOPIF` called `getFrameTree`/`addBinding` on the child session assuming the browser watcher's async `registerOOPIF` had already enabled its domains. If it hadn't, instrumentation failed and the frame was never captured. Now `instrumentOOPIF` enables the child's `Page`/`Runtime`/`DOM` itself (idempotent), removing the timing dependency.

## 7. Network monitor over-counted a reused XHR
The monitor added a fresh `loadend` listener on every `send()`, so a reused `XMLHttpRequest` object fired all accumulated listeners on each completion → the in-flight counter dropped too far → premature idle. The listener is now `{once:true}`.

## 8. Auto-parameterization defeated `dropConsecutiveDupeSteps`
A re-dispatched identical `type` event survived as a spurious extra param+step, because each got a distinct `{{param}}` placeholder as its value so the step-level dedup no longer saw them as equal. Consecutive identical raw events are now collapsed **before** parameterization.

## Tests
- `TestCompileDedupesRepeatedType` — a re-dispatched type → 1 step, 1 param
- `TestReplayVerifyURLIgnoresHostInQueryParam` — bounce to a login host that echoes the app host in `?return_to=` still fails the verify
- Full `internal/browser` suite passes with Chrome present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)