### PR TITLE
feat(im): send_message tool, channel hot-reload, and octo-serve self-kill guard

### DIFF
--- a/internal/channel/bindings.go
+++ b/internal/channel/bindings.go
@@ -82,6 +82,17 @@ func (b *bindingStore) get(key SessionKey) (string, bool) {
 	return id, ok
 }
 
+// keys returns a snapshot of the bound session keys, for enumeration.
+func (b *bindingStore) keys() []SessionKey {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]SessionKey, 0, len(b.m))
+	for k := range b.m {
+		out = append(out, k)
+	}
+	return out
+}
+
 // set records a binding and persists the table.
 func (b *bindingStore) set(key SessionKey, id string) error {
 	b.mu.Lock()

--- a/internal/channel/config.go
+++ b/internal/channel/config.go
@@ -87,6 +87,11 @@ func (c *Config) Platform(name string) PlatformConfig {
 	return c.Channels[name]
 }
 
+// IsEnabled reports whether the named platform is present and enabled.
+func (c *Config) IsEnabled(name string) bool {
+	return isEnabled(c.Channels[name])
+}
+
 // SetPlatform merges fields into a platform's config, creating it if needed.
 // Automatically sets enabled: true unless explicitly provided.
 func (c *Config) SetPlatform(name string, fields map[string]any) {

--- a/internal/channel/known_chats_test.go
+++ b/internal/channel/known_chats_test.go
@@ -1,0 +1,55 @@
+package channel
+
+import "testing"
+
+func TestSplitSessionKey(t *testing.T) {
+	cases := []struct {
+		key                 SessionKey
+		wantP, wantC, wantU string
+	}{
+		{"feishu:c1:u1", "feishu", "c1", "u1"},
+		{"telegram:42", "telegram", "42", ""},
+		{"weixin", "weixin", "", ""},
+	}
+	for _, c := range cases {
+		p, ch, u := splitSessionKey(c.key)
+		if p != c.wantP || ch != c.wantC || u != c.wantU {
+			t.Errorf("splitSessionKey(%q) = (%q,%q,%q), want (%q,%q,%q)",
+				c.key, p, ch, u, c.wantP, c.wantC, c.wantU)
+		}
+	}
+}
+
+// TestManager_KnownChats merges a live session with a persisted /bind entry and
+// checks both surface with the right flags.
+func TestManager_KnownChats(t *testing.T) {
+	tempHome(t)
+	mgr := NewManager(&Config{}, fakeAgentFactory, BindByChatUser)
+
+	// A live session (this process run) → Active.
+	mgr.GetOrCreateSession(InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"})
+	// A persisted binding for a different chat → Bound.
+	if err := mgr.bindings.set(SessionKey("telegram:42:u2"), "sess-x"); err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	byChat := map[string]KnownChat{}
+	for _, kc := range mgr.KnownChats() {
+		byChat[kc.Platform+":"+kc.ChatID] = kc
+	}
+	if len(byChat) != 2 {
+		t.Fatalf("want 2 known chats, got %d: %+v", len(byChat), byChat)
+	}
+
+	live, ok := byChat["feishu:c1"]
+	if !ok || !live.Active {
+		t.Fatalf("feishu:c1 should be present and Active: %+v", live)
+	}
+	bound, ok := byChat["telegram:42"]
+	if !ok || !bound.Bound {
+		t.Fatalf("telegram:42 should be present and Bound: %+v", bound)
+	}
+	if bound.UserID != "u2" {
+		t.Errorf("telegram user recovered from key = %q, want u2", bound.UserID)
+	}
+}

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -652,3 +652,79 @@ func (m *Manager) SessionCount() int {
 	})
 	return count
 }
+
+// KnownChat identifies an IM chat the bot can proactively push to: either a
+// live session this process is serving, or a chat explicitly attached via
+// /bind (persisted across restarts). It is the recipient set the send_message
+// tool offers when the model has no bound chat of its own (e.g. a web turn
+// asked to message the user's WeChat).
+type KnownChat struct {
+	Platform string
+	ChatID   string
+	UserID   string
+	Active   bool // a live session in this process run
+	Bound    bool // has an explicit /bind
+}
+
+// KnownChats enumerates the chats the bot can address, merging live sessions
+// with the persisted /bind table. Entries are deduplicated by
+// (platform, chatID, userID); a chat that is both active and bound reports
+// both flags. Chat/user IDs are recovered from the session key, whose format
+// depends on the binding mode (see sessionKeyFor).
+func (m *Manager) KnownChats() []KnownChat {
+	idx := map[SessionKey]*KnownChat{}
+	upsert := func(key SessionKey, chatID, userID string) *KnownChat {
+		if kc, ok := idx[key]; ok {
+			return kc
+		}
+		p, c, u := splitSessionKey(key)
+		if chatID == "" {
+			chatID = c
+		}
+		if userID == "" {
+			userID = u
+		}
+		kc := &KnownChat{Platform: p, ChatID: chatID, UserID: userID}
+		idx[key] = kc
+		return kc
+	}
+
+	m.sessions.Range(func(k, v any) bool {
+		key, _ := k.(SessionKey)
+		sess, _ := v.(*Session)
+		var chatID, userID string
+		if sess != nil {
+			chatID, userID = sess.ChatID, sess.UserID
+		}
+		upsert(key, chatID, userID).Active = true
+		return true
+	})
+	for _, key := range m.bindings.keys() {
+		upsert(key, "", "").Bound = true
+	}
+
+	out := make([]KnownChat, 0, len(idx))
+	for _, kc := range idx {
+		if kc.Platform == "" || kc.ChatID == "" {
+			continue
+		}
+		out = append(out, *kc)
+	}
+	return out
+}
+
+// splitSessionKey recovers (platform, chatID, userID) from a session key.
+// Keys are "platform:chatID[:userID]" (sessionKeyFor); a platform never
+// contains a colon, so the first segment is unambiguous, and the remainder is
+// split once more for the optional user segment.
+func splitSessionKey(key SessionKey) (platform, chatID, userID string) {
+	parts := strings.SplitN(string(key), ":", 3)
+	switch len(parts) {
+	case 3:
+		return parts[0], parts[1], parts[2]
+	case 2:
+		return parts[0], parts[1], ""
+	default:
+		return string(key), "", ""
+	}
+}

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -667,10 +667,11 @@ type KnownChat struct {
 }
 
 // KnownChats enumerates the chats the bot can address, merging live sessions
-// with the persisted /bind table. Entries are deduplicated by
-// (platform, chatID, userID); a chat that is both active and bound reports
-// both flags. Chat/user IDs are recovered from the session key, whose format
-// depends on the binding mode (see sessionKeyFor).
+// with the persisted /bind table. Entries are deduplicated by session key
+// (which, under the server's BindByChatUser mode, is platform:chatID:userID); a
+// chat that is both active and bound reports both flags. Chat/user IDs are
+// recovered from the session key, whose format depends on the binding mode
+// (see sessionKeyFor).
 func (m *Manager) KnownChats() []KnownChat {
 	idx := map[SessionKey]*KnownChat{}
 	upsert := func(key SessionKey, chatID, userID string) *KnownChat {

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -103,6 +103,7 @@ Memories are snapshots and can be stale. If one names a file path, function, fla
 - `terminal_output` is a **snapshot** of a process's last N lines, not a feed — call it on demand to inspect startup logs or check progress; repeated calls return the current tail, so there's nothing to gain from looping.
 - Send interactive commands via `terminal_input` when appropriate (REPLs, servers that read stdin).
 - Stop with `kill_shell`. For servers and other services, prefer `signal: "SIGTERM"` for graceful shutdown. Use `signal: "SIGKILL"` (default) for forceful termination or when SIGTERM fails.
+- **Never kill the octo server that is hosting this session.** When you are running inside `octo serve` (a web or IM turn, indicated by the `restart_server` tool being available), do NOT `kill`/`pkill`/`killall` the `octo serve` process, and do NOT try to stop and relaunch it from `terminal` — that would terminate the process mid-turn and drop the user's session. To pick up a new binary or a startup-only config change, call the `restart_server` tool instead: it drains in-flight turns and lets the supervisor respawn the server. (The terminal tool actively refuses commands that would kill the hosting server.)
 
 ## Tool-use timing
 

--- a/internal/server/channel_reload_test.go
+++ b/internal/server/channel_reload_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/channel"
+)
+
+// TestReloadChannel_StartAndStop verifies a channel config change is hot-applied
+// without a full server restart: enabling starts the adapter, disabling stops
+// it, and the manager is built lazily on first reload (mustServer leaves it nil).
+func TestReloadChannel_StartAndStop(t *testing.T) {
+	channel.Register("reloadfake", func(channel.PlatformConfig) (channel.Adapter, error) {
+		return &fullFakeAdapter{}, nil
+	})
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	cfgDir := filepath.Join(tmp, ".octo")
+	if err := os.MkdirAll(cfgDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(cfgDir, "channels.yml")
+	write := func(yml string) {
+		if err := os.WriteFile(cfgPath, []byte(yml), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	t.Cleanup(srv.stopChannels)
+
+	// Fresh add + enable → adapter starts, manager built lazily.
+	write("channels:\n  reloadfake:\n    enabled: true\n")
+	srv.reloadChannel("reloadfake")
+	if srv.channelMgr == nil {
+		t.Fatal("manager should be built on first reload")
+	}
+	if !srv.isAdapterRunning("reloadfake") {
+		t.Fatal("adapter should be running after enable + reload")
+	}
+
+	// Disable → adapter stops.
+	write("channels:\n  reloadfake:\n    enabled: false\n")
+	srv.reloadChannel("reloadfake")
+	if srv.isAdapterRunning("reloadfake") {
+		t.Fatal("adapter should stop after disable + reload")
+	}
+}
+
+// TestReloadChannel_SkippedWhenNoChannel: --no-channel disables hot-reload too.
+func TestReloadChannel_SkippedWhenNoChannel(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", NoChannel: true})
+	srv.reloadChannel("anything") // must be a no-op, not panic
+	if srv.channelMgr != nil {
+		t.Fatal("no manager should be built when NoChannel is set")
+	}
+}

--- a/internal/server/channel_reload_test.go
+++ b/internal/server/channel_reload_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/channel"
@@ -49,6 +50,48 @@ func TestReloadChannel_StartAndStop(t *testing.T) {
 	if srv.isAdapterRunning("reloadfake") {
 		t.Fatal("adapter should stop after disable + reload")
 	}
+}
+
+// TestReloadChannel_ConcurrentKnownChats guards the data race the lazy
+// channelMgr build could introduce: reloadChannel writes s.channelMgr while the
+// send_message tool reads it via serverMessenger.KnownChats on another
+// goroutine. Run with -race; must be clean.
+func TestReloadChannel_ConcurrentKnownChats(t *testing.T) {
+	channel.Register("reloadrace", func(channel.PlatformConfig) (channel.Adapter, error) {
+		return &fullFakeAdapter{}, nil
+	})
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	cfgDir := filepath.Join(tmp, ".octo")
+	if err := os.MkdirAll(cfgDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "channels.yml"),
+		[]byte("channels:\n  reloadrace:\n    enabled: true\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	t.Cleanup(srv.stopChannels)
+	msgr := serverMessenger{s: srv}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			srv.reloadChannel("reloadrace")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			_ = msgr.KnownChats()
+		}
+	}()
+	wg.Wait()
 }
 
 // TestReloadChannel_SkippedWhenNoChannel: --no-channel disables hot-reload too.

--- a/internal/server/channels_handler.go
+++ b/internal/server/channels_handler.go
@@ -110,6 +110,10 @@ func (s *Server) handleSaveChannel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Hot-apply the change so a newly configured (or re-credentialed) channel
+	// starts serving immediately — no manual server restart.
+	s.reloadChannel(platform)
+
 	writeJSON(w, http.StatusOK, map[string]string{"status": "saved"})
 }
 
@@ -132,6 +136,9 @@ func (s *Server) handleDeleteChannel(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return
 	}
+
+	// Stop the adapter now that its config is gone — no manual restart.
+	s.reloadChannel(platform)
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }

--- a/internal/server/messenger.go
+++ b/internal/server/messenger.go
@@ -20,10 +20,11 @@ func (m serverMessenger) SendMessage(platform, chatID, text string) error {
 // KnownChats lists the chats the bot can currently address, derived from the
 // channel manager's live sessions plus the persisted /bind table.
 func (m serverMessenger) KnownChats() []tools.KnownRecipient {
-	if m.s.channelMgr == nil {
+	mgr := m.s.channelManager()
+	if mgr == nil {
 		return nil
 	}
-	known := m.s.channelMgr.KnownChats()
+	known := mgr.KnownChats()
 	out := make([]tools.KnownRecipient, 0, len(known))
 	for _, kc := range known {
 		var tags []string

--- a/internal/server/messenger.go
+++ b/internal/server/messenger.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/open-octo/octo-agent/internal/tools"
+)
+
+// serverMessenger backs the send_message tool (tools.ChannelMessenger): it
+// lets any turn — web, IM, or a sub-agent — push a text message to an IM chat
+// the server can reach. Registered at server start via tools.SetMessenger.
+type serverMessenger struct{ s *Server }
+
+// SendMessage delivers text to chatID on platform, reusing the same
+// live-adapter-then-SendOnce path as scheduled-task notifications.
+func (m serverMessenger) SendMessage(platform, chatID, text string) error {
+	return m.s.channelSend(platform, chatID, text)
+}
+
+// KnownChats lists the chats the bot can currently address, derived from the
+// channel manager's live sessions plus the persisted /bind table.
+func (m serverMessenger) KnownChats() []tools.KnownRecipient {
+	if m.s.channelMgr == nil {
+		return nil
+	}
+	known := m.s.channelMgr.KnownChats()
+	out := make([]tools.KnownRecipient, 0, len(known))
+	for _, kc := range known {
+		var tags []string
+		if kc.Active {
+			tags = append(tags, "active")
+		}
+		if kc.Bound {
+			tags = append(tags, "bound")
+		}
+		out = append(out, tools.KnownRecipient{
+			Platform: kc.Platform,
+			ChatID:   kc.ChatID,
+			UserID:   kc.UserID,
+			Label:    strings.Join(tags, ","),
+		})
+	}
+	return out
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -221,6 +221,16 @@ type Server struct {
 	channelCancel   context.CancelFunc
 	runningAdapters sync.Map // string -> channel.Adapter
 
+	// channelMu guards channel (re)start bookkeeping — startChannels runs at
+	// boot, stopChannels at shutdown, and reloadChannel from an HTTP handler
+	// after a config save; they must not race. channelCtx is the base context
+	// all adapter goroutines derive from (cancelled by stopChannels);
+	// adapterCancels holds each running adapter's own cancel so a single
+	// platform can be stopped and restarted without touching the others.
+	channelMu      sync.Mutex
+	channelCtx     context.Context
+	adapterCancels map[string]context.CancelFunc
+
 	// weixinLogin tracks the in-flight web QR login flow (one at a time).
 	weixinLogin weixinLoginFlow
 
@@ -385,6 +395,15 @@ func New(cfg Config) (*Server, error) {
 	// ExitRestart for the supervisor to respawn.
 	tools.SetRestarter(s.Restart)
 
+	// Advertise send_message so a turn on any surface (web, IM, sub-agent) can
+	// proactively push to an IM chat it isn't currently talking to — e.g. a web
+	// session asked to message the user's WeChat.
+	tools.SetMessenger(serverMessenger{s})
+
+	// Guard the hosting process: the agent must not kill its own octo server
+	// (it would drop the live session); restart_server is the graceful path.
+	tools.SetServerGuard(true)
+
 	// Server-managed sessions can be re-entered, so advertise schedule_wakeup
 	// (the loop skill's mechanism); the per-session Waker is stamped into each
 	// turn's ctx in runAgentTurnLoop.
@@ -542,6 +561,8 @@ func (s *Server) doShutdown(ctx context.Context) error {
 	tools.KillAllSessionSubAgents()
 	tools.SetDefaultSubAgentManager(nil)
 	tools.SetTaskStore(nil)
+	tools.SetMessenger(nil)
+	tools.SetServerGuard(false)
 	// Flush any queued async hooks (retention) to disk so a restart/shutdown
 	// doesn't drop them; the next process redelivers.
 	hooks.DrainSpill(5 * time.Second)
@@ -1559,22 +1580,31 @@ func (s *Server) initChannels() {
 		slog.Error("channel config", "err", err)
 		return
 	}
+	s.channelMu.Lock()
+	defer s.channelMu.Unlock()
+	s.channelCfg = chCfg
 	platforms := chCfg.EnabledPlatforms()
 	if len(platforms) == 0 {
+		// Nothing enabled yet. Keep channelCfg so reloadChannel can lazily
+		// build the manager when the user adds a channel later — no full
+		// server restart needed.
 		return
 	}
+	s.channelMgr = channel.NewManager(chCfg, s.buildChannelFactory(), channel.BindByChatUser)
+	slog.Info("channels enabled", "platforms", strings.Join(platforms, ", "))
+}
 
-	// Build agent factory that mirrors the server's agent setup. No gate is
-	// set here: handleChannelMessage builds a fresh per-turn gate (configured
-	// mode + chat-interactive ask), the same shape prepareToolTurn gives web
-	// turns. A factory-time gate would freeze one policy snapshot for the
-	// session's whole life — and the old `gate, _ :=` form silently ran turns
-	// ungated when engine construction failed.
+// buildChannelFactory returns the agent factory the channel manager uses to
+// spin up a fresh agent per IM session. No gate is set here: handleChannelMessage
+// builds a fresh per-turn gate (configured mode + chat-interactive ask), the
+// same shape prepareToolTurn gives web turns. A factory-time gate would freeze
+// one policy snapshot for the session's whole life.
+func (s *Server) buildChannelFactory() func() *agent.Agent {
 	var memInjection string
 	if s.memDir != "" {
 		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
 	}
-	factory := func() *agent.Agent {
+	return func() *agent.Agent {
 		defaultSender, model := s.defaultSenderAndModel()
 		a := agent.New(defaultSender, model)
 		cwd, envCtx := s.curCwdEnv()
@@ -1592,51 +1622,117 @@ func (s *Server) initChannels() {
 		}
 		return a
 	}
-
-	s.channelCfg = chCfg
-	s.channelMgr = channel.NewManager(chCfg, factory, channel.BindByChatUser)
-
-	slog.Info("channels enabled", "platforms", strings.Join(platforms, ", "))
 }
 
 // startChannels launches all enabled channel adapters in background goroutines.
 func (s *Server) startChannels() {
+	s.channelMu.Lock()
+	defer s.channelMu.Unlock()
 	if s.channelMgr == nil {
 		return
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	s.channelCancel = cancel
-
-	// For each enabled platform, create adapter and start it.
 	for _, name := range s.channelCfg.EnabledPlatforms() {
-		pc := s.channelCfg.Platform(name)
-		if pc == nil {
-			continue
-		}
-		ctor, err := channel.Find(name)
-		if err != nil {
-			slog.Error("channel start failed", "channel", name, "err", err)
-			continue
-		}
-		ad, err := ctor(pc)
-		if err != nil {
-			slog.Error("channel adapter failed", "channel", name, "err", err)
-			continue
-		}
-		if errs := ad.ValidateConfig(pc); len(errs) > 0 {
-			for _, e := range errs {
-				slog.Warn("channel config issue", "channel", name, "detail", e)
-			}
-			continue
-		}
+		s.startOneChannelLocked(name)
+	}
+}
 
-		s.runningAdapters.Store(name, ad)
-		go func(a channel.Adapter, platform string) {
-			_ = a.Start(ctx, func(ev channel.InboundEvent) {
-				ev.Platform = platform
-				s.routeChannelEvent(ctx, a, ev)
-			})
-		}(ad, name)
+// channelBaseCtxLocked returns the base context every adapter goroutine derives
+// from, creating it on first use. stopChannels cancels it to bring them all
+// down. Caller holds channelMu.
+func (s *Server) channelBaseCtxLocked() context.Context {
+	if s.channelCtx == nil {
+		ctx, cancel := context.WithCancel(context.Background())
+		s.channelCtx = ctx
+		s.channelCancel = cancel
+	}
+	return s.channelCtx
+}
+
+// startOneChannelLocked builds and launches a single platform adapter from the
+// current channelCfg, tracking its own cancel so it can be stopped
+// independently. No-op if it is already running or its config is missing/
+// invalid. Caller holds channelMu.
+func (s *Server) startOneChannelLocked(name string) {
+	if _, ok := s.runningAdapters.Load(name); ok {
+		return // already running
+	}
+	pc := s.channelCfg.Platform(name)
+	if pc == nil {
+		return
+	}
+	ctor, err := channel.Find(name)
+	if err != nil {
+		slog.Error("channel start failed", "channel", name, "err", err)
+		return
+	}
+	ad, err := ctor(pc)
+	if err != nil {
+		slog.Error("channel adapter failed", "channel", name, "err", err)
+		return
+	}
+	if errs := ad.ValidateConfig(pc); len(errs) > 0 {
+		for _, e := range errs {
+			slog.Warn("channel config issue", "channel", name, "detail", e)
+		}
+		return
+	}
+
+	ctx, cancel := context.WithCancel(s.channelBaseCtxLocked())
+	if s.adapterCancels == nil {
+		s.adapterCancels = make(map[string]context.CancelFunc)
+	}
+	s.adapterCancels[name] = cancel
+	s.runningAdapters.Store(name, ad)
+	go func(a channel.Adapter, platform string) {
+		_ = a.Start(ctx, func(ev channel.InboundEvent) {
+			ev.Platform = platform
+			s.routeChannelEvent(ctx, a, ev)
+		})
+	}(ad, name)
+}
+
+// stopOneChannelLocked stops a single running adapter (cancel its context and
+// call Stop). No-op if it isn't running. Caller holds channelMu.
+func (s *Server) stopOneChannelLocked(name string) {
+	if cancel, ok := s.adapterCancels[name]; ok {
+		cancel()
+		delete(s.adapterCancels, name)
+	}
+	if v, ok := s.runningAdapters.Load(name); ok {
+		_ = v.(channel.Adapter).Stop()
+		s.runningAdapters.Delete(name)
+	}
+}
+
+// reloadChannel applies a saved config change for one platform without a full
+// server restart: it re-reads channels.yml, stops the platform's adapter if
+// running, then starts it again when the new config has it enabled. It handles
+// a fresh add (manager built lazily), a credential change (stop + start), and
+// a disable/delete (stop only). Called from the channels REST handlers after a
+// successful save.
+func (s *Server) reloadChannel(platform string) {
+	if s.cfg.NoChannel || s.getSender() == nil {
+		return
+	}
+	chCfg, err := channel.LoadConfig()
+	if err != nil {
+		slog.Error("channel reload: load config", "channel", platform, "err", err)
+		return
+	}
+
+	s.channelMu.Lock()
+	defer s.channelMu.Unlock()
+	s.channelCfg = chCfg
+	if s.channelMgr == nil {
+		s.channelMgr = channel.NewManager(chCfg, s.buildChannelFactory(), channel.BindByChatUser)
+	}
+
+	s.stopOneChannelLocked(platform)
+	if chCfg.IsEnabled(platform) {
+		s.startOneChannelLocked(platform)
+		slog.Info("channel reloaded", "channel", platform)
+	} else {
+		slog.Info("channel stopped", "channel", platform)
 	}
 }
 
@@ -2069,8 +2165,13 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 
 // stopChannels shuts down all channel adapters and their sessions.
 func (s *Server) stopChannels() {
+	s.channelMu.Lock()
+	defer s.channelMu.Unlock()
 	if s.channelCancel != nil {
 		s.channelCancel()
+	}
+	for name := range s.adapterCancels {
+		delete(s.adapterCancels, name)
 	}
 	if s.channelMgr != nil {
 		_ = s.channelMgr.Stop()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1636,6 +1636,19 @@ func (s *Server) startChannels() {
 	}
 }
 
+// channelManager returns the channel manager under channelMu. reloadChannel can
+// build it lazily at runtime, so readers on other goroutines (notably the
+// send_message tool via serverMessenger) must snapshot it through here rather
+// than touching the field directly — a plain read would race the lazy write.
+// Adapter-path reads (routeChannelEvent/handleChannelMessage) are exempt: their
+// goroutines are only spawned after the manager is set under the same lock, so
+// the write happens-before those reads.
+func (s *Server) channelManager() *channel.Manager {
+	s.channelMu.Lock()
+	defer s.channelMu.Unlock()
+	return s.channelMgr
+}
+
 // channelBaseCtxLocked returns the base context every adapter goroutine derives
 // from, creating it on first use. stopChannels cancels it to bring them all
 // down. Caller holds channelMu.

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -31,6 +31,7 @@ var allTools = []tool{
 	EditFileTool{},
 	ShowArtifactTool{},
 	SendFileTool{},
+	SendMessageTool{},
 	GlobTool{},
 	GrepTool{},
 	WebFetchTool{},
@@ -239,6 +240,7 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 	askerOn := askerEnabled()
 	tasksOn := tasksEnabled()
 	restarterOn := restarterEnabled()
+	messengerOn := messengerEnabled()
 	wakerOn := wakerEnabled()
 	browserOn := browserEnabled()
 	spawnerOn := spawnerEnabled()
@@ -281,6 +283,9 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 			continue
 		}
 		if _, isRestart := t.(RestartServerTool); isRestart && !restarterOn {
+			continue
+		}
+		if _, isSendMsg := t.(SendMessageTool); isSendMsg && !messengerOn {
 			continue
 		}
 		if _, isWakeup := t.(ScheduleWakeupTool); isWakeup && !wakerOn {

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -92,6 +92,9 @@ const windowsSafeRmWrapper = `function Remove-Item {
 // Shell by platform: POSIX `sh -c` on macOS/Linux; PowerShell on Windows (the
 // OS sandbox is macOS/Linux-only, so the Windows branch is never sandboxed).
 func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
+	if err := guardServerSelfKill(command); err != nil {
+		return nil, err
+	}
 	if activeSandbox != nil {
 		cmd, err := sandbox.Command(ctx, command, *activeSandbox)
 		if err == nil && cmd != nil {

--- a/internal/tools/send_message.go
+++ b/internal/tools/send_message.go
@@ -1,0 +1,163 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+)
+
+// KnownRecipient is one IM chat the send_message tool can push to. The server
+// derives the list from live channel sessions plus the persisted /bind table;
+// the tool surfaces it so the model can resolve a request like "message my
+// WeChat" to a concrete platform + chat_id even from a web turn with no chat
+// of its own.
+type KnownRecipient struct {
+	Platform string `json:"platform"`
+	ChatID   string `json:"chat_id"`
+	UserID   string `json:"user_id,omitempty"`
+	Label    string `json:"label,omitempty"`
+}
+
+// ChannelMessenger backs the send_message tool. It is implemented by the
+// server (the only process that runs channel adapters) and registered via
+// SetMessenger, mirroring SetRestarter: process-global, set once at server
+// start, nil everywhere else so the tool stays hidden in CLI/TUI.
+type ChannelMessenger interface {
+	// SendMessage delivers text to chatID on platform, preferring a live
+	// adapter and falling back to a one-shot send from config.
+	SendMessage(platform, chatID, text string) error
+	// KnownChats lists the recipients the bot can currently address.
+	KnownChats() []KnownRecipient
+}
+
+var activeMessenger ChannelMessenger
+
+// SetMessenger registers the messenger the send_message tool delegates to.
+// Pass nil to disable (the tool then doesn't appear in DefaultToolsFor).
+func SetMessenger(m ChannelMessenger) { activeMessenger = m }
+
+func messengerEnabled() bool { return activeMessenger != nil }
+
+// SendMessageTool lets the model send a plain-text message to an IM chat
+// (WeChat, Telegram, Discord, …) from any turn — including a web session with
+// no chat of its own. This is the proactive-push counterpart to a normal chat
+// reply, which only reaches whoever the current turn is already talking to.
+type SendMessageTool struct{}
+
+func (SendMessageTool) Definition() agent.ToolDefinition {
+	return agent.ToolDefinition{
+		Name: "send_message",
+		Description: "Send a text message to a user or group over an IM channel (WeChat, Telegram, " +
+			"Discord, Feishu, DingTalk, WeCom). Use this to proactively reach a chat that is NOT " +
+			"the current conversation — e.g. the user is on the web UI and asks you to message " +
+			"their WeChat. A normal reply only reaches the current chat, so a message to any other " +
+			"chat MUST go through this tool.\n\n" +
+			"Identify the recipient with platform + chat_id. If you don't know the chat_id, call " +
+			"the tool with just the platform (or no arguments) and it returns the list of chats the " +
+			"bot can reach, so you can pick one and call again. The recipient must have messaged " +
+			"the bot at least once (that is how the bot learns the chat_id).",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"platform": map[string]any{
+					"type":        "string",
+					"description": "IM platform, e.g. \"weixin\" (WeChat), \"telegram\", \"discord\", \"feishu\", \"dingtalk\", \"wecom\". Omit to list reachable chats across all platforms.",
+				},
+				"chat_id": map[string]any{
+					"type":        "string",
+					"description": "Target chat/user ID on the platform. Omit to list the reachable chats instead of sending.",
+				},
+				"text": map[string]any{
+					"type":        "string",
+					"description": "Message body to send. Required when actually sending.",
+				},
+			},
+			"required": []string{},
+		},
+	}
+}
+
+func (SendMessageTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
+	m := activeMessenger
+	if m == nil {
+		return agent.ToolResult{}, fmt.Errorf("send_message: not available in this mode (server only)")
+	}
+
+	platform := strings.TrimSpace(stringArg(input, "platform"))
+	chatID := strings.TrimSpace(stringArg(input, "chat_id"))
+	text := strings.TrimSpace(stringArg(input, "text"))
+
+	// No target yet, or an explicit discovery call (no text): list reachable
+	// chats so the model can pick one.
+	if chatID == "" || text == "" {
+		chats := filterRecipients(m.KnownChats(), platform)
+		// Exactly one candidate + text present → unambiguous, just send.
+		if chatID == "" && text != "" && len(chats) == 1 {
+			return doSend(m, chats[0].Platform, chats[0].ChatID, text)
+		}
+		return listRecipients(chats, platform, text)
+	}
+
+	if platform == "" {
+		return agent.ToolResult{}, fmt.Errorf("send_message: platform is required when chat_id is given")
+	}
+	return doSend(m, platform, chatID, text)
+}
+
+func doSend(m ChannelMessenger, platform, chatID, text string) (agent.ToolResult, error) {
+	if err := m.SendMessage(platform, chatID, text); err != nil {
+		return agent.ToolResult{}, fmt.Errorf("send_message: %w", err)
+	}
+	return agent.ToolResult{
+		Text: fmt.Sprintf("Message sent to %s chat %s.", platform, chatID),
+	}, nil
+}
+
+func filterRecipients(all []KnownRecipient, platform string) []KnownRecipient {
+	if platform == "" {
+		return all
+	}
+	out := make([]KnownRecipient, 0, len(all))
+	for _, r := range all {
+		if r.Platform == platform {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// listRecipients returns a model-readable roster of reachable chats. It is a
+// normal (non-error) result: the model reads it and calls send_message again
+// with a concrete chat_id.
+func listRecipients(chats []KnownRecipient, platform, text string) (agent.ToolResult, error) {
+	if len(chats) == 0 {
+		scope := "any platform"
+		if platform != "" {
+			scope = platform
+		}
+		return agent.ToolResult{
+			Text: fmt.Sprintf("No reachable chats on %s. The recipient must message the bot at "+
+				"least once before it can push to them; ask the user to do so, or provide a chat_id.", scope),
+		}, nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Reachable chats (%d) — call send_message again with the chosen platform and chat_id:\n", len(chats))
+	for _, r := range chats {
+		b.WriteString("  - platform=")
+		b.WriteString(r.Platform)
+		b.WriteString(" chat_id=")
+		b.WriteString(r.ChatID)
+		if r.Label != "" {
+			b.WriteString(" (")
+			b.WriteString(r.Label)
+			b.WriteString(")")
+		}
+		b.WriteString("\n")
+	}
+	if text != "" {
+		b.WriteString("\nThen resend with text set to your message.")
+	}
+	return agent.ToolResult{Text: strings.TrimRight(b.String(), "\n")}, nil
+}

--- a/internal/tools/send_message_test.go
+++ b/internal/tools/send_message_test.go
@@ -1,0 +1,139 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type sentMsg struct{ platform, chatID, text string }
+
+type fakeMessenger struct {
+	chats []KnownRecipient
+	sent  []sentMsg
+	err   error
+}
+
+func (f *fakeMessenger) SendMessage(platform, chatID, text string) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.sent = append(f.sent, sentMsg{platform, chatID, text})
+	return nil
+}
+
+func (f *fakeMessenger) KnownChats() []KnownRecipient { return f.chats }
+
+func runSendMessage(t *testing.T, input map[string]any) (string, error) {
+	t.Helper()
+	res, err := SendMessageTool{}.Execute(context.Background(), "send_message", input)
+	return res.Text, err
+}
+
+func TestSendMessage_NoMessenger(t *testing.T) {
+	SetMessenger(nil)
+	if messengerEnabled() {
+		t.Fatal("messenger should be disabled")
+	}
+	if _, err := runSendMessage(t, map[string]any{"platform": "weixin", "chat_id": "c1", "text": "hi"}); err == nil {
+		t.Fatal("want error with no messenger registered")
+	}
+	// And the tool must not be advertised.
+	for _, d := range DefaultToolsFor("") {
+		if d.Name == "send_message" {
+			t.Fatal("send_message must not be advertised without a messenger")
+		}
+	}
+}
+
+func TestSendMessage_AdvertisedWhenEnabled(t *testing.T) {
+	SetMessenger(&fakeMessenger{})
+	defer SetMessenger(nil)
+	var found bool
+	for _, d := range DefaultToolsFor("") {
+		if d.Name == "send_message" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("send_message should be advertised when a messenger is registered")
+	}
+}
+
+func TestSendMessage_ExplicitSend(t *testing.T) {
+	fm := &fakeMessenger{}
+	SetMessenger(fm)
+	defer SetMessenger(nil)
+
+	out, err := runSendMessage(t, map[string]any{"platform": "weixin", "chat_id": "c1", "text": "hello"})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if len(fm.sent) != 1 || fm.sent[0] != (sentMsg{"weixin", "c1", "hello"}) {
+		t.Fatalf("sent = %+v", fm.sent)
+	}
+	if !strings.Contains(out, "weixin") || !strings.Contains(out, "c1") {
+		t.Fatalf("result text = %q", out)
+	}
+}
+
+func TestSendMessage_SingleCandidateAutoSends(t *testing.T) {
+	fm := &fakeMessenger{chats: []KnownRecipient{{Platform: "weixin", ChatID: "c1", Label: "active"}}}
+	SetMessenger(fm)
+	defer SetMessenger(nil)
+
+	// No chat_id, but exactly one weixin chat known → send straight to it.
+	if _, err := runSendMessage(t, map[string]any{"platform": "weixin", "text": "hi"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if len(fm.sent) != 1 || fm.sent[0].chatID != "c1" {
+		t.Fatalf("sent = %+v", fm.sent)
+	}
+}
+
+func TestSendMessage_MultipleCandidatesList(t *testing.T) {
+	fm := &fakeMessenger{chats: []KnownRecipient{
+		{Platform: "weixin", ChatID: "c1"},
+		{Platform: "weixin", ChatID: "c2"},
+	}}
+	SetMessenger(fm)
+	defer SetMessenger(nil)
+
+	out, err := runSendMessage(t, map[string]any{"platform": "weixin", "text": "hi"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(fm.sent) != 0 {
+		t.Fatalf("must not send when the recipient is ambiguous; sent = %+v", fm.sent)
+	}
+	if !strings.Contains(out, "c1") || !strings.Contains(out, "c2") {
+		t.Fatalf("expected both candidates listed, got %q", out)
+	}
+}
+
+func TestSendMessage_DiscoveryNoArgs(t *testing.T) {
+	fm := &fakeMessenger{chats: []KnownRecipient{{Platform: "telegram", ChatID: "42"}}}
+	SetMessenger(fm)
+	defer SetMessenger(nil)
+
+	out, err := runSendMessage(t, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(out, "telegram") || !strings.Contains(out, "42") {
+		t.Fatalf("discovery should list known chats, got %q", out)
+	}
+}
+
+func TestSendMessage_NoReachableChats(t *testing.T) {
+	SetMessenger(&fakeMessenger{})
+	defer SetMessenger(nil)
+
+	out, err := runSendMessage(t, map[string]any{"platform": "weixin", "text": "hi"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(out), "no reachable chats") {
+		t.Fatalf("expected a no-recipient hint, got %q", out)
+	}
+}

--- a/internal/tools/server_guard.go
+++ b/internal/tools/server_guard.go
@@ -1,0 +1,74 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync/atomic"
+)
+
+// serverGuardOn, when set, means this process is an octo server (octo serve).
+// The terminal tool then refuses shell commands that would kill the server
+// itself — the model must use the restart_server tool for a graceful restart
+// instead of terminating the process out from under its own turn (which also
+// drops the user's web/IM session).
+var serverGuardOn atomic.Bool
+
+// serverSelfPID / serverSuperPID are the process and its parent (the restart
+// supervisor, when present). Killing either takes the service down, so both
+// are protected. Captured once at package init — a process never changes its
+// own or parent PID.
+var (
+	serverSelfPID  = os.Getpid()
+	serverSuperPID = os.Getppid()
+)
+
+// SetServerGuard enables or disables the octo-serve self-kill guard. The
+// server turns it on at start and off at shutdown.
+func SetServerGuard(on bool) { serverGuardOn.Store(on) }
+
+var (
+	// pkill/killall … octo — signalling octo processes by name. The \bkill\b
+	// word boundary does not match inside "pkill"/"killall", so reKill below
+	// stays limited to a bare `kill`.
+	reKillByName = regexp.MustCompile(`(?i)\b(pkill|killall)\b[^|;&\n]*octo`)
+	// A bare `kill [-SIG] <pid> …` command; its argument tail is scanned for
+	// the protected PIDs.
+	reKill = regexp.MustCompile(`(?i)\bkill\b([^|;&\n]*)`)
+	reNum  = regexp.MustCompile(`\b\d+\b`)
+)
+
+// guardServerSelfKill returns a non-nil error when command, run inside an octo
+// server process, would terminate that server (or its supervisor). It is a
+// best-effort textual guard over the common vectors — `pkill/killall octo` and
+// `kill <server-pid>` — not a sandbox; it exists to stop the model from
+// reflexively killing the process it is hosted by.
+func guardServerSelfKill(command string) error {
+	if !serverGuardOn.Load() {
+		return nil
+	}
+	if reKillByName.MatchString(command) {
+		return errServerSelfKill
+	}
+	// `kill $(pgrep octo)` / `kill $(pidof octo)` — resolve-then-kill by name.
+	if reKill.MatchString(command) && strings.Contains(command, "octo") &&
+		(strings.Contains(command, "pgrep") || strings.Contains(command, "pidof")) {
+		return errServerSelfKill
+	}
+	self := strconv.Itoa(serverSelfPID)
+	super := strconv.Itoa(serverSuperPID)
+	for _, seg := range reKill.FindAllStringSubmatch(command, -1) {
+		for _, n := range reNum.FindAllString(seg[1], -1) {
+			if n == self || n == super {
+				return errServerSelfKill
+			}
+		}
+	}
+	return nil
+}
+
+var errServerSelfKill = fmt.Errorf("refusing to kill the octo server process that is hosting this " +
+	"session — use the restart_server tool for a graceful restart (it drains in-flight turns and lets " +
+	"the supervisor respawn the server)")

--- a/internal/tools/server_guard.go
+++ b/internal/tools/server_guard.go
@@ -30,10 +30,11 @@ var (
 func SetServerGuard(on bool) { serverGuardOn.Store(on) }
 
 var (
-	// pkill/killall … octo — signalling octo processes by name. The \bkill\b
-	// word boundary does not match inside "pkill"/"killall", so reKill below
-	// stays limited to a bare `kill`.
-	reKillByName = regexp.MustCompile(`(?i)\b(pkill|killall)\b[^|;&\n]*octo`)
+	// pkill/killall … octo — signalling octo processes by name. `\bocto\b`
+	// matches "octo", "octo serve", and "octo-agent" but not unrelated names
+	// like "octoprint"/"octopus". The `\bkill\b` word boundary does not match
+	// inside "pkill"/"killall", so reKill below stays limited to a bare `kill`.
+	reKillByName = regexp.MustCompile(`(?i)\b(pkill|killall)\b[^|;&\n]*\bocto\b`)
 	// A bare `kill [-SIG] <pid> …` command; its argument tail is scanned for
 	// the protected PIDs.
 	reKill = regexp.MustCompile(`(?i)\bkill\b([^|;&\n]*)`)

--- a/internal/tools/server_guard_test.go
+++ b/internal/tools/server_guard_test.go
@@ -48,6 +48,7 @@ func TestGuardServerSelfKill_Allows(t *testing.T) {
 		"git status",
 		"kill 999999999",          // some unrelated pid, not ours
 		"pkill -f my-test-server", // not octo
+		"killall octoprint",       // 'octo' substring, not the octo binary
 		"echo skill",              // 'skill' must not trip the \bkill\b rule
 		"kill %1",                 // job spec, no pid
 		"grep octo README.md",     // mentions octo but no kill

--- a/internal/tools/server_guard_test.go
+++ b/internal/tools/server_guard_test.go
@@ -1,0 +1,76 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+func TestGuardServerSelfKill_Disabled(t *testing.T) {
+	// Guard off (CLI/TUI): even a self-kill command is allowed to build.
+	SetServerGuard(false)
+	cmd := fmt.Sprintf("kill %d", serverSelfPID)
+	if err := guardServerSelfKill(cmd); err != nil {
+		t.Fatalf("guard off should permit %q, got %v", cmd, err)
+	}
+}
+
+func TestGuardServerSelfKill_Blocks(t *testing.T) {
+	SetServerGuard(true)
+	defer SetServerGuard(false)
+
+	self := strconv.Itoa(serverSelfPID)
+	super := strconv.Itoa(serverSuperPID)
+	blocked := []string{
+		`pkill -f "octo serve"`,
+		"pkill octo",
+		"killall octo",
+		"kill " + self,
+		"kill -9 " + self,
+		"kill -TERM " + super,
+		"kill $(pgrep octo)",
+		"kill $(pidof octo)",
+	}
+	for _, c := range blocked {
+		if err := guardServerSelfKill(c); err == nil {
+			t.Errorf("want %q blocked, got nil", c)
+		}
+	}
+}
+
+func TestGuardServerSelfKill_Allows(t *testing.T) {
+	SetServerGuard(true)
+	defer SetServerGuard(false)
+
+	allowed := []string{
+		"ls -la",
+		"git status",
+		"kill 999999999",          // some unrelated pid, not ours
+		"pkill -f my-test-server", // not octo
+		"echo skill",              // 'skill' must not trip the \bkill\b rule
+		"kill %1",                 // job spec, no pid
+		"grep octo README.md",     // mentions octo but no kill
+		"systemctl restart myapp", // unrelated
+	}
+	for _, c := range allowed {
+		if err := guardServerSelfKill(c); err != nil {
+			t.Errorf("want %q allowed, got %v", c, err)
+		}
+	}
+}
+
+// TestGuardServerSelfKill_ViaShellCommand confirms the guard fires at the
+// single command-execution chokepoint, so terminal / background / detached all
+// inherit it.
+func TestGuardServerSelfKill_ViaShellCommand(t *testing.T) {
+	SetServerGuard(true)
+	defer SetServerGuard(false)
+
+	if _, err := shellCommand(context.Background(), "pkill octo"); err == nil {
+		t.Fatal("shellCommand should refuse to build a self-kill command")
+	}
+	if _, err := shellCommand(context.Background(), "echo hi"); err != nil {
+		t.Fatalf("shellCommand should build a benign command, got %v", err)
+	}
+}


### PR DESCRIPTION
Three IM-channel fixes reported from a web session.

## 1. `send_message` tool
The agent had no way to send text to an IM chat it wasn't already in — `send_file` is IM-turn-only and `SendOnce`/`channelSend` were internal-only. So "from the web UI, message my WeChat" was impossible.

New `send_message` tool (server-only, gated like `restart_server`/`send_file`), available on **any** surface — web, IM, sub-agent:
- Discoverable recipients: call with just a `platform` (or no args) to list reachable chats, then send with `platform` + `chat_id`. A single match on a platform sends one-shot.
- Reachable chats = live channel sessions + the persisted `/bind` table, via new `Manager.KnownChats()`.
- Delivery reuses `channelSend` (live adapter → `SendOnce` fallback).

## 2. Channels hot-reload on save
`startChannels` ran once at boot; saving a channel via the web panel only wrote `channels.yml`, so a manual restart was needed. Refactored into per-adapter `startOneChannelLocked`/`stopOneChannelLocked` (each with its own cancel) + a new `reloadChannel(platform)` called from the save/delete REST handlers. Handles fresh add (manager built lazily), credential change (stop+start), and disable/delete (stop only).

**Caveat:** reload triggers on the REST save path, not on hand-edits to `~/.octo/channels.yml` — those still need `restart_server`.

## 3. Guard against killing the hosting `octo serve`
The prompt actively told the model `octo serve` was a killable service, and nothing stopped it from terminating the process hosting its own turn. Added a best-effort guard at the terminal chokepoint (`shellCommand`) that refuses `pkill/killall octo`, `kill <server/supervisor pid>`, and `kill $(pgrep/pidof octo)` when running inside the server, directing it to `restart_server`. Plus explicit `base.md` guidance.

## Tests
New tests for the kill guard, the `send_message` tool (gating, discovery, single-candidate auto-send, explicit send, no-recipient), `KnownChats`/`splitSessionKey`, and `reloadChannel` (start/stop, NoChannel skip). `go build ./...`, `go vet ./...`, gofmt, and `-race` tests on all changed packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
