### PR TITLE
feat(browser): recordings declare outputs; run_skill returns them (composable skills A)

### DIFF
--- a/dev-docs/composable-skills-design.md
+++ b/dev-docs/composable-skills-design.md
@@ -111,11 +111,13 @@ func ReplaySkill(...) (modified bool, finalPage *Page, outputs map[string]any, e
 `internal/tools/browser.go` 的 `run_skill` case(`internal/tools/browser.go:563`)从只返回一行文字,改为返回结构化结果:
 
 ```json
-{ "skill": "download-excels",
+{ "skill": "download-excels", "steps": 5,
   "outputs": { "files": ["/dl/order.xlsx", "/dl/refund.xlsx", "/dl/settle.xlsx"] } }
 ```
 
-`ToolResult.Text` 放这段 JSON(模型/脚本可解析),同时填 `ToolResult.UI` 走既有的 ui_payload 富卡片管线(`project_tool_ui_payload`)。自愈发生时(`modified`)仍照旧回写 YAML 并在 UI 注明,与现状一致。
+`ToolResult.Text` 放这段 JSON——模型/脚本可解析,这就是产物交接的载体。自愈发生时(`modified`)照旧回写 YAML,并在 envelope 里加 `"self_healed": true`(不再往 JSON 后面拼自然语言,以免破坏可解析性)。
+
+`ToolResult.UI` 富卡片**不做**(可选的后续增强):browser 工具其它 action 也都不出卡片,纯 JSON text 在 tool-result 区块本就可读,组合能力不依赖它。只有当 run_skill 成为"用户会长时间盯着看 outputs"的高频交互面时,再据实加一个列出产物的卡片(有 `uiHead`/`uiTail` helper,`project_tool_ui_payload`)。
 
 ### A.4 普通技能:outputs 可选,CC 全兼容
 

--- a/internal/browser/oopif_test.go
+++ b/internal/browser/oopif_test.go
@@ -61,7 +61,7 @@ func TestOOPIFReplay(t *testing.T) {
 	}
 
 	skill := &Skill{Name: "x", Steps: []Step{{Action: "click", Frame: "#f", Selector: "#go"}}}
-	if _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 15 * time.Second, Browser: b}); err != nil {
+	if _, _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 15 * time.Second, Browser: b}); err != nil {
 		t.Fatalf("replay: %v", err)
 	}
 	// The click must have run inside the OOPIF: #done appears there. WaitFor also
@@ -90,7 +90,7 @@ func TestOOPIFTypeReplay(t *testing.T) {
 	}
 
 	skill := &Skill{Name: "x", Steps: []Step{{Action: "type", Frame: "#f", Selector: "#q", Value: "hello"}}}
-	if _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 15 * time.Second}); err != nil {
+	if _, _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 15 * time.Second}); err != nil {
 		t.Fatalf("replay: %v", err)
 	}
 	cp, ok := page.oopifPage(ctx, "#f")

--- a/internal/browser/recorder.go
+++ b/internal/browser/recorder.go
@@ -271,7 +271,7 @@ func (r *Recorder) Events() []RecordedEvent {
 // no healer) — a convenience over the skill path for raw record→replay.
 func Replay(ctx context.Context, page *Page, events []RecordedEvent) error {
 	skill := CompileSkill("", "", "", events)
-	_, _, err := ReplaySkill(ctx, page, &skill, nil, ReplayOptions{})
+	_, _, _, err := ReplaySkill(ctx, page, &skill, nil, ReplayOptions{})
 	return err
 }
 

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -673,7 +673,10 @@ func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map
 		// Capture the file the trigger produces (client-side-generated files never
 		// appear as a plain HTTP response — only what lands on disk is the file).
 		// Resolve the trigger like a click (text/label first) so a drifted export
-		// button still fires; bind the saved path so it can flow downstream.
+		// button still fires. Unlike click this uses a plain page.Click, not
+		// clickTarget: a download trigger doesn't navigate, so there's no new tab
+		// to follow. Verify BEFORE bind so a verify-triggered retry (recoverStep
+		// re-runs the whole step) doesn't append the file to the output twice.
 		if b == nil {
 			return page, fmt.Errorf("download: no browser session")
 		}
@@ -689,11 +692,16 @@ func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map
 		if err != nil {
 			return page, err
 		}
+		if err := verify(ctx, page, step, params); err != nil {
+			return page, err
+		}
 		bind(binds, step.Bind, path)
+		return page, nil
 	case "extract":
 		// Read a value off the page (a report id, a status) and bind it — the
 		// scalar analogue of a download for feeding a downstream step. A JSON string
 		// result is unwrapped to its text; anything else is kept as its JSON form.
+		// Verify before bind for the same no-double-bind reason as download.
 		if strings.TrimSpace(step.JS) == "" {
 			return page, fmt.Errorf("extract: js is required")
 		}
@@ -706,7 +714,11 @@ func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map
 		if json.Unmarshal(raw, &s) == nil {
 			val = s
 		}
+		if err := verify(ctx, page, step, params); err != nil {
+			return page, err
+		}
 		bind(binds, step.Bind, val)
+		return page, nil
 	default:
 		return page, fmt.Errorf("unknown action %q", step.Action)
 	}

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -2,6 +2,7 @@ package browser
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -16,10 +17,11 @@ import (
 // serializes to YAML — human-readable, hand-editable, git-versionable — which is
 // the "editable steps" surface. Replay reads it back; self-heal writes it back.
 type Skill struct {
-	Name        string  `yaml:"name"`
-	Description string  `yaml:"description,omitempty"`
-	Params      []Param `yaml:"params,omitempty"`
-	Steps       []Step  `yaml:"steps"`
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description,omitempty"`
+	Params      []Param  `yaml:"params,omitempty"`
+	Outputs     []Output `yaml:"outputs,omitempty"`
+	Steps       []Step   `yaml:"steps"`
 }
 
 // Param is a replay-time input; {{name}} placeholders in step values/urls are
@@ -30,11 +32,21 @@ type Param struct {
 	Default     string `yaml:"default,omitempty"`
 }
 
+// Output is a value replay exposes to its caller — the handoff surface that lets
+// a recording feed a downstream step. Steps bind a produced value to an Output
+// by name via Step.Bind (a download binds the captured file path; an extract
+// binds the evaluated string). Type controls aggregation: "file[]" collects
+// every bound value in order; "file"/"string" (and anything else) take the last.
+type Output struct {
+	Name string `yaml:"name"`
+	Type string `yaml:"type,omitempty"` // file | file[] | string
+}
+
 // Step is one action. Selector is within its document; Frame (a same-origin
 // iframe selector) scopes it via the " >>> " convention. Label is a human note;
 // replay ignores it.
 type Step struct {
-	Action   string `yaml:"action"` // navigate | click | type | select | upload | wait
+	Action   string `yaml:"action"` // navigate | click | type | select | upload | wait | download | extract
 	URL      string `yaml:"url,omitempty"`
 	Frame    string `yaml:"frame,omitempty"`
 	Selector string `yaml:"selector,omitempty"`
@@ -46,6 +58,8 @@ type Step struct {
 	// before giving up to the healer — the field-input analogue of Label steering
 	// a click by visible text.
 	Hint      string  `yaml:"hint,omitempty"`
+	Bind      string  `yaml:"bind,omitempty"`       // download/extract: write the produced value into this named Output
+	JS        string  `yaml:"js,omitempty"`         // extract: expression whose value is bound
 	Network   bool    `yaml:"network,omitempty"`    // wait: settle for network (fetch/XHR) idle instead of a fixed delay
 	TimeoutMS int     `yaml:"timeout_ms,omitempty"` // wait: fixed delay (ms) when no selector; also caps the network-idle settle
 	Verify    *Verify `yaml:"verify,omitempty"`
@@ -421,11 +435,13 @@ func subst(s string, params map[string]string) string {
 // ReplayOptions tunes a replay. StepTimeout bounds the per-step wait for a
 // target to appear (default 15s — generous for slow back-ends). Healer, when
 // set, is consulted on a step failure. Browser, when set, lets a click follow a
-// new tab it opens (target=_blank / window.open).
+// new tab it opens (target=_blank / window.open). DownloadDir is where download
+// steps land their files (required only if the skill has download steps).
 type ReplayOptions struct {
 	StepTimeout time.Duration
 	Healer      Healer
 	Browser     *Browser
+	DownloadDir string
 }
 
 // ReplaySkill runs a skill deterministically (no LLM), substituting params. Each
@@ -434,27 +450,55 @@ type ReplayOptions struct {
 // healer repairs the step, replay continues and reports modified=true so the
 // caller can write the corrected skill back. A click that opens a new tab swaps
 // the active page for subsequent steps; finalPage is the page replay ended on
-// (so the caller can keep its session pointed at the right tab).
-func ReplaySkill(ctx context.Context, page *Page, skill *Skill, params map[string]string, opts ReplayOptions) (modified bool, finalPage *Page, err error) {
+// (so the caller can keep its session pointed at the right tab). outputs holds
+// the skill's declared Outputs as bound during replay (download paths, extracted
+// values) — the handoff surface for composing this recording with later steps.
+func ReplaySkill(ctx context.Context, page *Page, skill *Skill, params map[string]string, opts ReplayOptions) (modified bool, finalPage *Page, outputs map[string]any, err error) {
 	if opts.StepTimeout <= 0 {
 		opts.StepTimeout = 15 * time.Second
 	}
 	full := mergedParams(skill, params)
+	binds := map[string][]string{}
 	cur := page
 	for i := range skill.Steps {
-		np, runErr := runStep(ctx, opts.Browser, cur, &skill.Steps[i], full, opts.StepTimeout)
+		np, runErr := runStep(ctx, opts.Browser, cur, &skill.Steps[i], full, opts.StepTimeout, opts.DownloadDir, binds)
 		if runErr == nil {
 			cur = np
 			continue
 		}
-		np, healed, runErr := recoverStep(ctx, opts, cur, &skill.Steps[i], full, runErr, &modified)
+		np, healed, runErr := recoverStep(ctx, opts, cur, &skill.Steps[i], full, runErr, &modified, binds)
 		if runErr != nil {
-			return modified, cur, fmt.Errorf("step %d (%s): %w", i+1, skill.Steps[i].Action, runErr)
+			return modified, cur, nil, fmt.Errorf("step %d (%s): %w", i+1, skill.Steps[i].Action, runErr)
 		}
 		_ = healed
 		cur = np
 	}
-	return modified, cur, nil
+	return modified, cur, assembleOutputs(skill.Outputs, binds), nil
+}
+
+// assembleOutputs turns the ordered values bound during replay into the skill's
+// declared outputs. A "file[]" output yields the full ordered slice (empty slice
+// if never bound); every other type yields the last bound value ("" if never
+// bound). Only declared outputs surface — a stray bind to an undeclared name is
+// ignored, keeping the handoff contract exactly what the skill promised.
+func assembleOutputs(outs []Output, binds map[string][]string) map[string]any {
+	res := make(map[string]any, len(outs))
+	for _, o := range outs {
+		vals := binds[o.Name]
+		if o.Type == "file[]" {
+			if vals == nil {
+				vals = []string{}
+			}
+			res[o.Name] = vals
+			continue
+		}
+		if len(vals) > 0 {
+			res[o.Name] = vals[len(vals)-1]
+		} else {
+			res[o.Name] = ""
+		}
+	}
+	return res
 }
 
 // maxHealRounds bounds how many times the LLM healer is consulted for one step,
@@ -472,10 +516,10 @@ const maxHealRounds = 3
 // It returns the page to continue on, whether a heal mutated the step (for the
 // caller's write-back via *modified), and a non-nil error only if the step could
 // not be recovered.
-func recoverStep(ctx context.Context, opts ReplayOptions, page *Page, step *Step, params map[string]string, cause error, modified *bool) (*Page, bool, error) {
+func recoverStep(ctx context.Context, opts ReplayOptions, page *Page, step *Step, params map[string]string, cause error, modified *bool, binds map[string][]string) (*Page, bool, error) {
 	// 1. Structural: a blocking overlay is the most common non-selector failure.
 	if dismissed, _ := page.DismissOverlay(ctx); dismissed {
-		if np, err := runStep(ctx, opts.Browser, page, step, params, opts.StepTimeout); err == nil {
+		if np, err := runStep(ctx, opts.Browser, page, step, params, opts.StepTimeout, opts.DownloadDir, binds); err == nil {
 			return np, true, nil
 		}
 	}
@@ -488,7 +532,7 @@ func recoverStep(ctx context.Context, opts ReplayOptions, page *Page, step *Step
 		if herr := opts.Healer(ctx, page, step, cause); herr != nil {
 			return page, false, cause
 		}
-		np, retryErr := runStep(ctx, opts.Browser, page, step, params, opts.StepTimeout)
+		np, retryErr := runStep(ctx, opts.Browser, page, step, params, opts.StepTimeout, opts.DownloadDir, binds)
 		if retryErr == nil {
 			if *step != before {
 				*modified = true
@@ -519,7 +563,9 @@ func mergedParams(skill *Skill, params map[string]string) map[string]string {
 
 // runStep executes one step on page and returns the page subsequent steps should
 // run on — the same page, except a click that opens a new tab returns that tab.
-func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map[string]string, waitTimeout time.Duration) (*Page, error) {
+// A download/extract step records its produced value into binds under step.Bind;
+// downloadDir is where a download step lands its file.
+func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map[string]string, waitTimeout time.Duration, downloadDir string, binds map[string][]string) (*Page, error) {
 	target := step.target()
 	switch step.Action {
 	case "navigate":
@@ -623,10 +669,58 @@ func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map
 		if err := page.UploadViaChooser(ctx, target, []string{subst(step.Value, params)}); err != nil {
 			return page, err
 		}
+	case "download":
+		// Capture the file the trigger produces (client-side-generated files never
+		// appear as a plain HTTP response — only what lands on disk is the file).
+		// Resolve the trigger like a click (text/label first) so a drifted export
+		// button still fires; bind the saved path so it can flow downstream.
+		if b == nil {
+			return page, fmt.Errorf("download: no browser session")
+		}
+		if downloadDir == "" {
+			return page, fmt.Errorf("download: no download directory configured")
+		}
+		if a := strings.TrimSpace(step.Label); len(a) >= 2 {
+			target = page.resolveClickTarget(ctx, step.Frame, step.Selector, a, waitTimeout)
+		} else if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
+			return page, err
+		}
+		path, err := b.CaptureDownload(ctx, downloadDir, func() error { return page.Click(ctx, target) })
+		if err != nil {
+			return page, err
+		}
+		bind(binds, step.Bind, path)
+	case "extract":
+		// Read a value off the page (a report id, a status) and bind it — the
+		// scalar analogue of a download for feeding a downstream step. A JSON string
+		// result is unwrapped to its text; anything else is kept as its JSON form.
+		if strings.TrimSpace(step.JS) == "" {
+			return page, fmt.Errorf("extract: js is required")
+		}
+		var raw json.RawMessage
+		if err := page.Eval(ctx, subst(step.JS, params), &raw); err != nil {
+			return page, err
+		}
+		val := string(raw)
+		var s string
+		if json.Unmarshal(raw, &s) == nil {
+			val = s
+		}
+		bind(binds, step.Bind, val)
 	default:
 		return page, fmt.Errorf("unknown action %q", step.Action)
 	}
 	return page, verify(ctx, page, step, params)
+}
+
+// bind appends a produced value under name, tolerating a nil map (a direct
+// runStep caller that doesn't collect outputs) and an empty name (an unbound
+// download/extract step, which just discards its value).
+func bind(binds map[string][]string, name, value string) {
+	if binds == nil || name == "" {
+		return
+	}
+	binds[name] = append(binds[name], value)
 }
 
 // clickTarget clicks target on page, following a new tab the click opens when a

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -219,7 +219,7 @@ func TestReplayVerifyURLIgnoresHostInQueryParam(t *testing.T) {
 	skill := &Skill{Name: "x", Steps: []Step{
 		{Action: "navigate", URL: app.URL + "/start", Verify: &Verify{URL: appHost}},
 	}}
-	_, _, err = ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second})
+	_, _, _, err = ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second})
 	if err == nil {
 		t.Fatal("expected failure: bounced to the login host despite the app host appearing in a query param")
 	}

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -159,7 +159,7 @@ func TestReplayVerifyURLCatchesCrossHostRedirect(t *testing.T) {
 	skill := &Skill{Name: "x", Steps: []Step{
 		{Action: "navigate", URL: app.URL + "/start", Verify: &Verify{URL: appHost}},
 	}}
-	_, _, err = ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second})
+	_, _, _, err = ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second})
 	if err == nil {
 		t.Fatal("expected replay to fail: navigation bounced to a different host")
 	}
@@ -312,7 +312,7 @@ func TestGenerateSkillDistill(t *testing.T) {
 // time (the SPA-settling primitive) — and run_skill no longer rejects it.
 func TestRunStepWaitFixedDelay(t *testing.T) {
 	start := time.Now()
-	if _, err := runStep(context.Background(), nil, nil, &Step{Action: "wait", TimeoutMS: 80}, nil, time.Second); err != nil {
+	if _, err := runStep(context.Background(), nil, nil, &Step{Action: "wait", TimeoutMS: 80}, nil, time.Second, "", nil); err != nil {
 		t.Fatalf("wait step: %v", err)
 	}
 	if d := time.Since(start); d < 60*time.Millisecond {
@@ -351,7 +351,7 @@ func TestWaitForNetworkIdle(t *testing.T) {
 
 	skill := &Skill{Name: "x", Steps: []Step{{Action: "wait", Network: true, TimeoutMS: 10000}}}
 	start := time.Now()
-	if _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 15 * time.Second}); err != nil {
+	if _, _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 15 * time.Second}); err != nil {
 		t.Fatalf("replay: %v", err)
 	}
 	// The in-flight fetch (~600ms) must have settled before the wait returned.
@@ -396,7 +396,7 @@ func TestReplayClickFollowsNewTab(t *testing.T) {
 	}
 
 	skill := &Skill{Name: "x", Steps: []Step{{Action: "click", Selector: "#open"}}}
-	_, fp, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second, Browser: b})
+	_, fp, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second, Browser: b})
 	if err != nil {
 		t.Fatalf("replay: %v", err)
 	}
@@ -439,7 +439,7 @@ func TestReplayTextAnchorRecoversFromDrift(t *testing.T) {
 	skill := &Skill{Name: "x", Steps: []Step{
 		{Action: "click", Selector: "div > button:nth-of-type(1)", Label: "Book now"},
 	}}
-	if _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second}); err != nil {
+	if _, _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second}); err != nil {
 		t.Fatalf("replay: %v", err)
 	}
 	var hit string
@@ -483,7 +483,7 @@ func TestReplayFieldHintRecoversFromDrift(t *testing.T) {
 	skill := &Skill{Name: "x", Steps: []Step{
 		{Action: "type", Selector: "body > div:nth-of-type(9) > input", Hint: "q", Value: "hello"},
 	}}
-	if _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second}); err != nil {
+	if _, _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second}); err != nil {
 		t.Fatalf("replay: %v", err)
 	}
 	var got string
@@ -522,7 +522,7 @@ func TestReplayDismissesOverlayDeterministically(t *testing.T) {
 	// #go is absent until the overlay is dismissed; no healer is provided, so this
 	// exercises the deterministic structural recovery path.
 	skill := &Skill{Name: "x", Steps: []Step{{Action: "click", Selector: "#go"}}}
-	modified, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 2 * time.Second, Browser: b})
+	modified, _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 2 * time.Second, Browser: b})
 	if err != nil {
 		t.Fatalf("replay: %v", err)
 	}
@@ -572,7 +572,7 @@ func TestReplayMultiRoundHeal(t *testing.T) {
 		}
 		return nil
 	}
-	modified, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 2 * time.Second, Healer: heal, Browser: b})
+	modified, _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 2 * time.Second, Healer: heal, Browser: b})
 	if err != nil {
 		t.Fatalf("replay: %v", err)
 	}
@@ -626,7 +626,7 @@ func TestReplaySkillSelfHeal(t *testing.T) {
 		return context.DeadlineExceeded
 	}
 
-	modified, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 2 * time.Second, Healer: heal})
+	modified, _, _, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 2 * time.Second, Healer: heal})
 	if err != nil {
 		t.Fatalf("replay: %v", err)
 	}
@@ -645,5 +645,148 @@ func TestReplaySkillSelfHeal(t *testing.T) {
 	}
 	if clicks < 1 {
 		t.Fatalf("healed click did not register (clicks=%d)", clicks)
+	}
+}
+
+// TestAssembleOutputs: file[] collects every bound value in order; other types
+// take the last; a declared-but-unbound output defaults (empty slice / "").
+func TestAssembleOutputs(t *testing.T) {
+	outs := []Output{
+		{Name: "files", Type: "file[]"},
+		{Name: "id", Type: "string"},
+		{Name: "last", Type: "file"},
+		{Name: "missing", Type: "file[]"},
+	}
+	binds := map[string][]string{
+		"files": {"/a", "/b"},
+		"id":    {"RPT-1"},
+		"last":  {"/x", "/y"},
+		"stray": {"ignored"}, // undeclared → must not surface
+	}
+	got := assembleOutputs(outs, binds)
+	if f, ok := got["files"].([]string); !ok || len(f) != 2 || f[0] != "/a" || f[1] != "/b" {
+		t.Fatalf("files: %#v", got["files"])
+	}
+	if got["id"] != "RPT-1" {
+		t.Fatalf("id: %#v", got["id"])
+	}
+	if got["last"] != "/y" {
+		t.Fatalf("last (want last bound /y): %#v", got["last"])
+	}
+	if m, ok := got["missing"].([]string); !ok || len(m) != 0 {
+		t.Fatalf("missing file[] should be empty slice: %#v", got["missing"])
+	}
+	if _, ok := got["stray"]; ok {
+		t.Fatalf("undeclared bind leaked into outputs: %#v", got)
+	}
+}
+
+// TestSkillYAMLRoundTripOutputs: the new outputs/bind/js fields survive a
+// marshal → parse round-trip (so a hand-edited skill keeps its handoff contract).
+func TestSkillYAMLRoundTripOutputs(t *testing.T) {
+	s := Skill{
+		Name:    "r",
+		Outputs: []Output{{Name: "files", Type: "file[]"}, {Name: "url", Type: "string"}},
+		Steps: []Step{
+			{Action: "download", Selector: "#e", Bind: "files"},
+			{Action: "extract", JS: "location.href", Bind: "url"},
+		},
+	}
+	data, err := MarshalSkill(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"outputs:", "type: file[]", "action: download", "bind: files", "action: extract", "js: location.href"} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("yaml missing %q:\n%s", want, data)
+		}
+	}
+	back, err := ParseSkill(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(back.Outputs) != 2 || back.Outputs[0].Type != "file[]" {
+		t.Fatalf("outputs round-trip: %#v", back.Outputs)
+	}
+	if back.Steps[0].Bind != "files" || back.Steps[1].JS != "location.href" {
+		t.Fatalf("step round-trip: %#v", back.Steps)
+	}
+}
+
+// TestReplaySkillDownloadBindsOutputs: a download step captures the file the
+// trigger produces and binds its path into the skill's declared file[] output.
+func TestReplaySkillDownloadBindsOutputs(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/file.csv" {
+			w.Header().Set("Content-Disposition", `attachment; filename="report.csv"`)
+			w.Header().Set("Content-Type", "text/csv")
+			w.Write([]byte("a,b,c\n1,2,3\n"))
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!doctype html><title>dl</title><a id="dl" href="/file.csv" download>Export</a>`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#dl", testWaitTimeout); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	skill := &Skill{
+		Name:    "dl",
+		Outputs: []Output{{Name: "files", Type: "file[]"}},
+		Steps:   []Step{{Action: "download", Selector: "#dl", Bind: "files"}},
+	}
+	_, _, outputs, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second, Browser: b, DownloadDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	files, ok := outputs["files"].([]string)
+	if !ok || len(files) != 1 {
+		t.Fatalf("want 1 file in outputs, got %#v", outputs["files"])
+	}
+	if _, err := os.Stat(files[0]); err != nil {
+		t.Fatalf("downloaded file missing: %v", err)
+	}
+}
+
+// TestReplaySkillExtractBindsOutput: an extract step evaluates JS and binds the
+// (unwrapped) string result into a declared output.
+func TestReplaySkillExtractBindsOutput(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!doctype html><title>x</title><div id="rid">RPT-42</div>`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#rid", testWaitTimeout); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	skill := &Skill{
+		Name:    "x",
+		Outputs: []Output{{Name: "report_id", Type: "string"}},
+		Steps:   []Step{{Action: "extract", JS: "document.querySelector('#rid').textContent", Bind: "report_id"}},
+	}
+	_, _, outputs, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second, Browser: b})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if outputs["report_id"] != "RPT-42" {
+		t.Fatalf("want RPT-42, got %#v", outputs["report_id"])
 	}
 }

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -790,3 +790,63 @@ func TestReplaySkillExtractBindsOutput(t *testing.T) {
 		t.Fatalf("want RPT-42, got %#v", outputs["report_id"])
 	}
 }
+
+// TestRunStepDownloadExtractGuards: the up-front validation on download/extract
+// fires before touching the page, so it needs no browser.
+func TestRunStepDownloadExtractGuards(t *testing.T) {
+	// download without a Browser session.
+	if _, err := runStep(context.Background(), nil, nil, &Step{Action: "download", Selector: "#x", Bind: "f"}, nil, time.Second, "/tmp", nil); err == nil || !strings.Contains(err.Error(), "no browser session") {
+		t.Fatalf("want no-browser-session error, got %v", err)
+	}
+	// extract with no JS.
+	if _, err := runStep(context.Background(), nil, nil, &Step{Action: "extract", Bind: "v"}, nil, time.Second, "", nil); err == nil || !strings.Contains(err.Error(), "js is required") {
+		t.Fatalf("want js-required error, got %v", err)
+	}
+}
+
+// TestReplaySkillDownloadNoDoubleBindOnHeal: a download step whose Verify fails
+// first, then passes after a heal, must bind the file exactly once — recoverStep
+// re-runs the whole step, so binding before Verify would double-count the output.
+func TestReplaySkillDownloadNoDoubleBindOnHeal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/file.csv" {
+			w.Header().Set("Content-Disposition", `attachment; filename="report.csv"`)
+			w.Header().Set("Content-Type", "text/csv")
+			w.Write([]byte("a,b\n1,2\n"))
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!doctype html><title>dl</title><a id="dl" href="/file.csv" download>Export</a>`))
+	}))
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#dl", testWaitTimeout); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	// The Verify requires #done, which doesn't exist yet; the healer injects it so
+	// the retry's Verify passes. (The healer leaves the step unchanged.)
+	heal := func(ctx context.Context, p *Page, _ *Step, _ error) error {
+		return p.Eval(ctx, "(function(){var d=document.createElement('div');d.id='done';document.body.appendChild(d);})()", nil)
+	}
+	skill := &Skill{
+		Name:    "dl",
+		Outputs: []Output{{Name: "files", Type: "file[]"}},
+		Steps:   []Step{{Action: "download", Selector: "#dl", Bind: "files", Verify: &Verify{Exists: "#done"}}},
+	}
+	_, _, outputs, err := ReplaySkill(ctx, page, skill, nil, ReplayOptions{StepTimeout: 5 * time.Second, Browser: b, DownloadDir: t.TempDir(), Healer: heal})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	files, ok := outputs["files"].([]string)
+	if !ok || len(files) != 1 {
+		t.Fatalf("download must bind exactly once across a heal retry, got %#v", outputs["files"])
+	}
+}

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -588,7 +588,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		recorderMu.Lock()
 		healer := browserHealer
 		recorderMu.Unlock()
-		modified, finalPage, err := browser.ReplaySkill(ctx, page, &skill, params, browser.ReplayOptions{Healer: healer, Browser: b})
+		modified, finalPage, outputs, err := browser.ReplaySkill(ctx, page, &skill, params, browser.ReplayOptions{Healer: healer, Browser: b, DownloadDir: downloadDir()})
 		if err != nil {
 			return agent.ToolResult{}, fmt.Errorf("browser: run_skill %q: %w", name, err)
 		}
@@ -597,13 +597,24 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		if finalPage != nil && finalPage != page {
 			setActivePage(b, finalPage)
 		}
-		msg := fmt.Sprintf("ran skill %q (%d steps)", name, len(skill.Steps))
+		// Return a structured envelope (not just a step count) so the skill's
+		// declared outputs — downloaded file paths, extracted values — can flow to
+		// a downstream step or be parsed by an orchestrating workflow.
+		env := map[string]any{
+			"skill":   name,
+			"steps":   len(skill.Steps),
+			"outputs": outputs,
+		}
 		if modified {
 			if werr := browser.SaveSkill(path, skill); werr == nil {
-				msg += " — self-healed, skill updated at " + path
+				env["self_healed"] = true
 			}
 		}
-		return agent.ToolResult{Text: msg}, nil
+		j, err := json.MarshalIndent(env, "", "  ")
+		if err != nil {
+			return agent.ToolResult{}, err
+		}
+		return agent.ToolResult{Text: string(j)}, nil
 
 	default:
 		return agent.ToolResult{}, fmt.Errorf("browser: unknown action %q", action)


### PR DESCRIPTION
Layer **A (contract)** of the composable-skills design (`dev-docs/composable-skills-design.md`, #1028). The 80%-value slice: make a browser recording produce a **typed handoff surface** so it can feed a downstream step, instead of being a replay-only dead end.

## What changed

- **`Skill.Outputs`** declares named results (`file` / `file[]` / `string`); **`Step.Bind`** writes a produced value into one.
- **Replay gains two step actions:**
  - `download` — captures the file the trigger produces (via `CaptureDownload`) and binds its path. A recorded export is no longer a blind click whose file vanishes.
  - `extract` — evaluates JS and binds the (unwrapped) string result (report id, status, …).
- **`ReplaySkill`** now returns the assembled `outputs` (`file[]` → ordered slice, else last bound value). `recoverStep` threads the bind map so a healed / overlay-retried step still records its output.
- **`run_skill`** returns a structured JSON envelope `{skill, steps, outputs, self_healed?}` instead of a bare step count — so outputs flow to the next step or an orchestrating workflow.

## Compatibility

Fully backward compatible: a recording with no `outputs` replays exactly as before and its envelope carries `outputs: {}`. The `ReplaySkill` signature gained a 4th return (`outputs`); all callers updated (matches the existing `modified, finalPage, err` multi-return convention).

Deferred (not this PR): the `ToolResult.UI` rich card for the envelope — the browser tool renders no cards for its other actions either, so text-JSON is consistent. Layers B (catalog in L1 manifest) and C (`skill()` workflow primitive) are separate follow-up PRs.

## Tests

- Pure: `assembleOutputs` aggregation (file[] order, last-value, unbound defaults, undeclared-bind isolation) + YAML round-trip of the new fields.
- Integration (httptest, skip without Chrome): `download` binds a captured file path; `extract` binds an evaluated value.
- `go test -race ./internal/browser/ ./internal/tools/` green; `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)