### PR TITLE
feat(workflow): ship embedded preset workflows (adversarial-review, parallel-understand, batch-migrate)

### DIFF
--- a/internal/tools/workflow_defaults/adversarial-review.rb
+++ b/internal/tools/workflow_defaults/adversarial-review.rb
@@ -1,0 +1,134 @@
+# @description Adversarial code review — fan out findings across dimensions, then kill false positives with independent skeptic votes. args (all optional): target (what to review, default = uncommitted diff), dimensions (array), votes (int, default 3).
+
+# ---- inputs -----------------------------------------------------------------
+a      = args || {}
+target = a["target"] || "the uncommitted changes (run `git diff HEAD`) in this repository"
+dims   = a["dimensions"] || ["correctness", "security", "performance", "tests"]
+votes  = (a["votes"] || 3).to_i
+votes  = 3 if votes < 1
+
+# Per-dimension focus. A dimension not listed here (passed via args) falls back
+# to reviewing for its own name.
+DIM_FOCUS = {
+  "correctness" => "logic errors, wrong conditionals, off-by-one, unhandled nil/error paths, broken edge cases",
+  "security"    => "injection, missing authorization, leaked secrets, unsafe deserialization, unvalidated input",
+  "performance" => "N+1 queries, needless allocation in hot paths, blocking calls, accidental O(n^2)",
+  "tests"       => "missing coverage for the change, assertions that can't fail, wrong expected values",
+}
+
+FINDINGS_SCHEMA = JSON.generate({
+  "type" => "object",
+  "properties" => {
+    "findings" => {
+      "type" => "array",
+      "items" => {
+        "type" => "object",
+        "properties" => {
+          "file"     => { "type" => "string" },
+          "line"     => { "type" => "integer" },
+          "severity" => { "type" => "string", "enum" => ["high", "medium", "low"] },
+          "title"    => { "type" => "string" },
+          "detail"   => { "type" => "string" },
+        },
+        "required" => ["file", "title", "detail"],
+      },
+    },
+  },
+  "required" => ["findings"],
+})
+
+VERDICT_SCHEMA = JSON.generate({
+  "type" => "object",
+  "properties" => {
+    "refuted" => { "type" => "boolean" },
+    "reason"  => { "type" => "string" },
+  },
+  "required" => ["refuted", "reason"],
+})
+
+# ---- helpers ----------------------------------------------------------------
+
+# find_stage runs one dimension's reviewer and returns its findings array.
+def find_stage(dim, focus, target)
+  prompt = [
+    "You are reviewing #{target}.",
+    "Inspect the diff yourself and read the surrounding code for context.",
+    "Report ONLY real defects in the *#{dim}* dimension: #{focus}.",
+    "Be conservative — do not invent issues to fill a quota; an empty list is a valid answer.",
+    "For each defect give: file, line (best estimate), severity, a one-line title, and a concrete failure scenario in detail.",
+  ].join("\n")
+  raw = agent(prompt, { "read_only" => true, "schema" => FINDINGS_SCHEMA })
+  (JSON.parse(raw)["findings"] || []) rescue []
+end
+
+# dedup collapses findings that point at the same file + title.
+def dedup(all)
+  seen = {}
+  out  = []
+  all.each do |f|
+    next unless f.is_a?(Hash)
+    key = "#{f["file"].to_s.downcase}::#{f["title"].to_s.downcase.strip}"
+    next if seen[key]
+    seen[key] = true
+    out << f
+  end
+  out
+end
+
+# survives? runs `votes` independent skeptics, each told to REFUTE the finding,
+# and keeps it only if a strict majority fail to refute it.
+def survives?(f, votes)
+  loc = f["line"] ? "#{f["file"]}:#{f["line"]}" : f["file"].to_s
+  claim = "#{loc} — #{f["title"]}: #{f["detail"]}"
+  verdicts = parallel((1..votes).to_a) do |_i|
+    prompt = [
+      "A reviewer claims this is a real defect:",
+      claim,
+      "Your job is to REFUTE it. Read the actual code to check.",
+      "It is refuted if it is wrong, already handled elsewhere, unreachable, or not actually a defect.",
+      "Default to refuted:true when uncertain — the bar to keep a finding is that it clearly survives scrutiny.",
+      "Return refuted (bool) and a one-line reason.",
+    ].join("\n")
+    raw = agent(prompt, { "read_only" => true, "schema" => VERDICT_SCHEMA })
+    (JSON.parse(raw)["refuted"] ? 1 : 0) rescue 1   # treat a broken verdict as "refuted"
+  end
+  kept = verdicts.select { |v| v == 0 }.size
+  kept > (votes / 2)
+end
+
+def sev_rank(s)
+  ({ "high" => 0, "medium" => 1, "low" => 2 }[s.to_s.downcase]) || 3
+end
+
+# ---- run --------------------------------------------------------------------
+
+phase "Review"
+per_dim = parallel(dims) { |d| find_stage(d, DIM_FOCUS[d] || d, target) }
+unique  = dedup(per_dim.flatten.compact)
+log "#{unique.size} candidate finding(s) after dedup across #{dims.size} dimension(s)"
+
+phase "Verify"
+survivors = []
+if unique.empty?
+  log "No candidates to verify."
+else
+  judged    = parallel(unique) { |f| { "f" => f, "keep" => survives?(f, votes) } }
+  survivors = judged.select { |r| r["keep"] }.map { |r| r["f"] }
+  log "#{survivors.size} of #{unique.size} finding(s) survived #{votes}-vote scrutiny."
+end
+
+phase "Report"
+if survivors.empty?
+  "No defects survived adversarial review (#{unique.size} candidate(s) raised, all refuted)."
+else
+  out = ["## Adversarial review — #{survivors.size} confirmed finding(s)", ""]
+  survivors.sort_by { |f| sev_rank(f["severity"]) }.each do |f|
+    loc = f["line"] ? "#{f["file"]}:#{f["line"]}" : f["file"].to_s
+    out << "### [#{(f["severity"] || "?").to_s.upcase}] #{f["title"]}"
+    out << "`#{loc}`"
+    out << ""
+    out << f["detail"].to_s
+    out << ""
+  end
+  out.join("\n")
+end

--- a/internal/tools/workflow_defaults/batch-migrate.rb
+++ b/internal/tools/workflow_defaults/batch-migrate.rb
@@ -1,0 +1,116 @@
+# @description Apply one mechanical change across many files — discover every site, then transform + verify each in its OWN git worktree so parallel edits never collide. args: change (required, what to apply), target (optional scope/paths to search), verify (optional shell command to run in each worktree, e.g. "go build ./...").
+
+# ---- inputs -----------------------------------------------------------------
+a       = args || {}
+change  = a["change"].to_s
+target  = a["target"].to_s
+verify  = a["verify"].to_s
+
+scope_line  = target.empty? ? "across the repository" : "within: #{target}"
+verify_line = verify.empty? ? "review that the edited file still reads/compiles correctly" : "run `#{verify}` and treat a non-zero exit as failure"
+
+DISCOVER_SCHEMA = JSON.generate({
+  "type" => "object",
+  "properties" => {
+    "sites" => {
+      "type" => "array",
+      "items" => {
+        "type" => "object",
+        "properties" => {
+          "file"   => { "type" => "string" },
+          "reason" => { "type" => "string" },
+        },
+        "required" => ["file"],
+      },
+    },
+  },
+  "required" => ["sites"],
+})
+
+MIGRATE_SCHEMA = JSON.generate({
+  "type" => "object",
+  "properties" => {
+    "file"     => { "type" => "string" },
+    "branch"   => { "type" => "string" },
+    "applied"  => { "type" => "boolean" },
+    "verified" => { "type" => "boolean" },
+    "summary"  => { "type" => "string" },
+  },
+  "required" => ["applied", "verified", "summary"],
+})
+
+def discover(change, scope_line, schema)
+  prompt = [
+    "Find every file that needs this change, #{scope_line}:",
+    change,
+    "Search the code yourself. Report only files that genuinely require the edit;",
+    "do not include files that already comply. For each give the file path and a",
+    "one-line reason it needs changing.",
+  ].join("\n")
+  raw   = agent(prompt, { "read_only" => true, "schema" => schema })
+  sites = (JSON.parse(raw)["sites"] || []) rescue []
+  sites.select { |s| s.is_a?(Hash) && !s["file"].to_s.empty? }
+end
+
+# migrate_one runs in a fresh, isolated git worktree so parallel edits to
+# different files never race on branch/index state; changes are left on a branch
+# named in the reply for the caller to review and merge.
+def migrate_one(file, change, verify_line, schema)
+  prompt = [
+    "You are in a fresh, isolated git worktree. Apply this change to `#{file}`:",
+    change,
+    "Then #{verify_line}.",
+    "If the change does not apply cleanly, set applied:false and explain why.",
+    "Report: file, the branch your changes are on, applied (bool), verified (bool),",
+    "and a one-line summary of what you did.",
+  ].join("\n")
+  raw = agent(prompt, { "isolation" => "worktree", "schema" => schema })
+  r = (JSON.parse(raw) rescue nil)
+  r = { "applied" => false, "verified" => false, "summary" => "agent returned no parseable result" } if r.nil?
+  r["file"] = file if r["file"].to_s.empty?
+  r
+end
+
+def render_report(results)
+  ok     = results.select { |r| r["applied"] && r["verified"] }
+  failed = results.select { |r| !(r["applied"] && r["verified"]) }
+  out = ["## batch-migrate — #{ok.size}/#{results.size} site(s) applied + verified", ""]
+  unless ok.empty?
+    out << "### ✅ Ready to merge"
+    ok.each do |r|
+      branch = r["branch"].to_s.empty? ? "(branch not reported)" : "`#{r["branch"]}`"
+      out << "- `#{r["file"]}` → #{branch} — #{r["summary"]}"
+    end
+    out << ""
+  end
+  unless failed.empty?
+    out << "### ⚠️ Needs attention"
+    failed.each do |r|
+      state = r["applied"] ? "applied but verify failed" : "not applied"
+      out << "- `#{r["file"]}` — #{state}: #{r["summary"]}"
+    end
+    out << ""
+  end
+  out << "Review each branch's diff before merging; nothing was merged automatically."
+  out.join("\n")
+end
+
+# ---- run --------------------------------------------------------------------
+if change.strip.empty?
+  # A migration with no described change is meaningless — fail loudly and early.
+  "batch-migrate: args[\"change\"] is required (describe the transformation to apply)."
+else
+  phase "Discover"
+  sites = discover(change, scope_line, DISCOVER_SCHEMA)
+  log "#{sites.size} site(s) need the change."
+
+  if sites.empty?
+    "batch-migrate: no sites require the change — nothing to do."
+  else
+    phase "Migrate"
+    results = parallel(sites) { |s| migrate_one(s["file"], change, verify_line, MIGRATE_SCHEMA) }.compact
+
+    phase "Report"
+    render_report(results)
+  end
+end

--- a/internal/tools/workflow_defaults/parallel-understand.rb
+++ b/internal/tools/workflow_defaults/parallel-understand.rb
@@ -1,0 +1,80 @@
+# @description Map a codebase in parallel — fan out one reader per subsystem, then synthesize a single architecture map. args (all optional): target (what to map, default = this repo), subsystems (array to skip auto-detection), focus (a question to bias the map toward).
+
+# ---- inputs -----------------------------------------------------------------
+a      = args || {}
+target = a["target"] || "this repository"
+focus  = a["focus"].to_s
+
+SUBSYS_SCHEMA = JSON.generate({
+  "type" => "object",
+  "properties" => {
+    "subsystems" => { "type" => "array", "items" => { "type" => "string" } },
+  },
+  "required" => ["subsystems"],
+})
+
+READER_SCHEMA = JSON.generate({
+  "type" => "object",
+  "properties" => {
+    "name"         => { "type" => "string" },
+    "purpose"      => { "type" => "string" },
+    "key_files"    => { "type" => "array", "items" => { "type" => "string" } },
+    "entry_points" => { "type" => "array", "items" => { "type" => "string" } },
+    "depends_on"   => { "type" => "array", "items" => { "type" => "string" } },
+    "notes"        => { "type" => "string" },
+  },
+  "required" => ["name", "purpose"],
+})
+
+# ---- 1. decide what the subsystems are --------------------------------------
+phase "Survey"
+subsystems = a["subsystems"]
+if !(subsystems.is_a?(Array)) || subsystems.empty?
+  prompt = [
+    "Identify the main subsystems / top-level modules of #{target} worth mapping separately.",
+    "Look at the directory layout and build files; group by responsibility, not by every folder.",
+    "Return up to ~12 of the most important, as an array of short names or paths.",
+  ].join("\n")
+  raw = agent(prompt, { "read_only" => true, "schema" => SUBSYS_SCHEMA })
+  subsystems = (JSON.parse(raw)["subsystems"] || []) rescue []
+end
+subsystems = subsystems.uniq
+log "Mapping #{subsystems.size} subsystem(s) of #{target}."
+
+# ---- 2. read each subsystem in parallel -------------------------------------
+phase "Read"
+focus_line = focus.empty? ? "" : "Pay special attention to: #{focus}."
+summaries = parallel(subsystems) do |s|
+  prompt = [
+    "Map the *#{s}* subsystem of #{target}. Read its code — do not guess.",
+    "Return: its purpose (1-2 sentences), key files (paths), entry points,",
+    "what it depends on (other subsystems / notable external deps), and any",
+    "notable patterns or gotchas a newcomer should know.",
+    focus_line,
+  ].join("\n")
+  raw = agent(prompt, { "read_only" => true, "schema" => READER_SCHEMA })
+  JSON.parse(raw) rescue nil
+end
+summaries = summaries.compact
+
+# ---- 3. synthesize one architecture map -------------------------------------
+phase "Synthesize"
+if summaries.empty?
+  "Could not map #{target}: no subsystems were identified or read."
+else
+  focus_hint = focus.empty? ? "" : "Frame the map around this question: #{focus}.\n"
+  prompt = [
+    "You are writing the architecture map for #{target}.",
+    focus_hint + "Below are structured summaries of each subsystem (JSON).",
+    "Synthesize ONE coherent markdown document, do not just concatenate them:",
+    "1. A one-paragraph overview of what the system is and how it's shaped.",
+    "2. A subsystem table: name | purpose | key entry point(s).",
+    "3. How the pieces connect — the main dependency / data-flow story.",
+    "4. \"Where to start reading\" — an ordered path for a newcomer.",
+    "Cite real file paths from the summaries. Do not invent components.",
+    "",
+    "Subsystem summaries:",
+    JSON.generate(summaries),
+  ].join("\n")
+  agent(prompt, { "read_only" => true })
+end

--- a/internal/tools/workflow_registry.go
+++ b/internal/tools/workflow_registry.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"embed"
 	"os"
 	"path/filepath"
 	"sort"
@@ -9,6 +10,15 @@ import (
 
 	"github.com/open-octo/octo-agent/internal/memory"
 )
+
+// defaultWorkflowsFS holds the workflows shipped with the binary — the curated
+// set every install gets out of the box. Unlike default skills they are not
+// materialized to disk (there is no on-disk workflows CLI to list/edit them):
+// discoverWorkflows merges them in-memory as the lowest priority, so a
+// same-named user- or project-level file transparently overrides one.
+//
+//go:embed workflow_defaults
+var defaultWorkflowsFS embed.FS
 
 // savedWorkflow is one named workflow script loaded from a registry directory.
 // The script is the full file content (the @description comment is valid Ruby
@@ -51,18 +61,46 @@ var (
 	discoveredWorkflows   map[string]savedWorkflow
 )
 
-// discoverWorkflows scans the user- then project-level registries and refreshes
-// the package-level cache. Project entries override user-level ones of the same
-// name. Safe to call concurrently; callers that need the freshest set call it
-// before lookupWorkflow / listWorkflows.
+// discoverWorkflows seeds the embedded default workflows, then scans the user-
+// and project-level registries, refreshing the package-level cache. Precedence
+// is embedded < user < project: a same-named file at a higher level overrides
+// the one below. Safe to call concurrently; callers that need the freshest set
+// call it before lookupWorkflow / listWorkflows.
 func discoverWorkflows() {
 	fresh := make(map[string]savedWorkflow)
+	scanEmbeddedWorkflows(fresh)
 	for _, root := range []string{userWorkflowsRoot(), projectWorkflowsRoot()} {
 		scanWorkflowsRoot(root, fresh)
 	}
 	discoveredWorkflowsMu.Lock()
 	discoveredWorkflows = fresh
 	discoveredWorkflowsMu.Unlock()
+}
+
+// scanEmbeddedWorkflows loads the binary's built-in *.rb workflows into dst.
+// Their file name (without .rb) is the authoritative name, matching on-disk
+// discovery so a user/project file of the same name overrides the default.
+func scanEmbeddedWorkflows(dst map[string]savedWorkflow) {
+	entries, err := defaultWorkflowsFS.ReadDir("workflow_defaults")
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".rb") {
+			continue
+		}
+		b, err := defaultWorkflowsFS.ReadFile("workflow_defaults/" + e.Name())
+		if err != nil {
+			continue
+		}
+		content := string(b)
+		name := strings.TrimSuffix(e.Name(), ".rb")
+		dst[name] = savedWorkflow{
+			name:        name,
+			description: workflowDescription(content),
+			script:      content,
+		}
+	}
 }
 
 // scanWorkflowsRoot reads *.rb workflow scripts from root into dst (existing

--- a/internal/tools/workflow_registry_test.go
+++ b/internal/tools/workflow_registry_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 )
 
@@ -78,7 +79,49 @@ func TestListWorkflows_SortedUnionOfRoots(t *testing.T) {
 	writeWorkflowFile(t, user, "ignored.txt", "not a workflow")
 
 	got := listWorkflows()
-	if len(got) != 2 || got[0].name != "alpha" || got[1].name != "zeta" {
-		t.Errorf("listWorkflows = %+v, want [alpha zeta]", got)
+	names := make([]string, len(got))
+	for i, w := range got {
+		names[i] = w.name
+	}
+	if !sort.StringsAreSorted(names) {
+		t.Errorf("listWorkflows not sorted: %v", names)
+	}
+	// The union includes the on-disk files plus every embedded default.
+	for _, want := range []string{"alpha", "zeta"} {
+		if !containsName(names, want) {
+			t.Errorf("listWorkflows = %v, missing %q", names, want)
+		}
+	}
+}
+
+func containsName(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLookupWorkflow_EmbeddedDefaultAlwaysAvailable(t *testing.T) {
+	// No user/project roots: the built-in preset must still resolve.
+	useWorkflowRoots(t, "", "")
+	w, ok := lookupWorkflow("adversarial-review")
+	if !ok {
+		t.Fatal("embedded default adversarial-review not found")
+	}
+	if w.script == "" || w.description == "" {
+		t.Errorf("embedded workflow = %+v, want non-empty script and description", w)
+	}
+}
+
+func TestLookupWorkflow_UserOverridesEmbeddedDefault(t *testing.T) {
+	user := t.TempDir()
+	useWorkflowRoots(t, user, "")
+	writeWorkflowFile(t, user, "adversarial-review.rb", "# @description my override\n\"x\"\n")
+
+	w, ok := lookupWorkflow("adversarial-review")
+	if !ok || w.description != "my override" {
+		t.Errorf("workflow = %+v, ok = %v; want the user file to override the embedded default", w, ok)
 	}
 }

--- a/internal/tools/workflow_registry_test.go
+++ b/internal/tools/workflow_registry_test.go
@@ -104,14 +104,17 @@ func containsName(names []string, want string) bool {
 }
 
 func TestLookupWorkflow_EmbeddedDefaultAlwaysAvailable(t *testing.T) {
-	// No user/project roots: the built-in preset must still resolve.
+	// No user/project roots: every built-in preset must still resolve.
 	useWorkflowRoots(t, "", "")
-	w, ok := lookupWorkflow("adversarial-review")
-	if !ok {
-		t.Fatal("embedded default adversarial-review not found")
-	}
-	if w.script == "" || w.description == "" {
-		t.Errorf("embedded workflow = %+v, want non-empty script and description", w)
+	for _, name := range []string{"adversarial-review", "parallel-understand", "batch-migrate"} {
+		w, ok := lookupWorkflow(name)
+		if !ok {
+			t.Errorf("embedded default %q not found", name)
+			continue
+		}
+		if w.script == "" || w.description == "" {
+			t.Errorf("embedded workflow %q = %+v, want non-empty script and description", name, w)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Adds **binary-embedded preset workflows** plus three curated presets, runnable anywhere with `workflow(name: "...")` — no disk file, offline, version-locked to the binary.

Each preset teaches a **distinct DSL pattern**, so the set spans the archetypes without overlapping each other or any existing skill:

| preset | pattern | args (optional unless noted) |
|---|---|---|
| `adversarial-review` | find → dedup → N-vote adversarial refute → report | `target`, `dimensions`, `votes` |
| `parallel-understand` | fan-out one reader per subsystem → synthesize one architecture map | `target`, `subsystems`, `focus` |
| `batch-migrate` | discover sites → transform + verify each in its **own git worktree** | `change` (**required**), `target`, `verify` |

- **adversarial-review** kills false-positive findings that don't survive independent skeptic votes (skeptics default to `refuted:true` when uncertain). Distinct from the `code-review` skill: that gives an *unbiased* single review; this gives *verified* findings.
- **parallel-understand** maps a codebase by reading each subsystem in parallel then synthesizing — no skill does parallel codebase mapping.
- **batch-migrate** is the only preset that demonstrates `isolation:"worktree"`: each site is edited in a fresh worktree so parallel writes never race; changes are left on branches for review (nothing auto-merged).

## The embed mechanism

- `//go:embed workflow_defaults` bakes every `*.rb` preset into the binary — dropping a new `.rb` in the dir is all it takes to add one.
- `discoverWorkflows()` seeds embedded defaults **first**, then user, then project — precedence **embedded < user < project**, so a same-named file in `~/.octo/workflows` or `.octo/workflows` transparently overrides a preset.
- Unlike default skills, presets are **not** materialized to disk. Workflows have no on-disk CLI (reached only through the `workflow` tool), so an in-memory merge suffices. `workflow_save` still only ever writes to the user/project registries.

## Tests

- `TestLookupWorkflow_EmbeddedDefaultAlwaysAvailable` — all three presets resolve with no disk roots.
- `TestLookupWorkflow_UserOverridesEmbeddedDefault` — a user file shadows a preset.
- `TestListWorkflows_SortedUnionOfRoots` — defaults are part of the sorted union.
- All three scripts were validated end-to-end against the real mruby runtime (fan-out, worktree-isolation flag propagation, N-vote survival, early-exit guards).

`go test ./internal/tools/ ./internal/workflow/` green; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)