### PR TITLE
feat(skills): add deep-research, grill-me, tech-design to default set

### DIFF
--- a/internal/server/attachments_test.go
+++ b/internal/server/attachments_test.go
@@ -285,4 +285,21 @@ drain:
 	if !foundBlock {
 		t.Error("no rehydratable image block persisted in session")
 	}
+
+	// Wait for the background turn goroutine to fully unwind before returning.
+	// It flips turnRunning back to false only after runAgentTurnLoop — and every
+	// Save it makes — has returned, so this is the point past which no goroutine
+	// still holds a session-file handle. Without the barrier, t.TempDir()'s
+	// RemoveAll races that handle on Windows and fails the test with "directory
+	// is not empty" even though every assertion above passed.
+	turnMu := srv.sessionTurnLock(sess.ID)
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
+		turnMu.Lock()
+		running := srv.turnRunning[sess.ID]
+		turnMu.Unlock()
+		if !running {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }

--- a/internal/skills/defaults/deep-research/SKILL.md
+++ b/internal/skills/defaults/deep-research/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: deep-research
+license: MIT
+description:
+  Deep, multi-source, fact-checked research on a topic — fan out searches, read
+  primary sources, adversarially verify each claim, and synthesize a cited report.
+  Use when the user wants a thorough research report rather than a quick answer,
+  e.g. "深度调研", "research this properly", "写一份调研报告", "帮我系统调研",
+  "多来源核实", "give me a researched writeup", "背景调查一下". BEFORE starting,
+  if the question is underspecified (scope, region, time window, use-case unclear),
+  ask 2-3 clarifying questions to narrow it. For a single quick lookup use
+  web_search directly; for a whole codebase/feature use the relevant dev skills.
+---
+
+# Skill: deep-research
+
+A harness for research you can trust: breadth first (many angles), then depth
+(primary sources), then an adversarial pass that tries to *break* each claim
+before it goes in the report. Built on octo's native tools — `web_search`,
+`web_fetch`, `sub_agent`, and (for login-gated / JS-rendered / anti-bot sites)
+the `browser` tool via the `web-access` skill. No external services.
+
+The goal is a **cited** report where every non-obvious claim traces to a source
+you actually read — not a plausible-sounding summary of search snippets.
+
+## 0. Scope before you search
+
+Research is only as good as the question. Before any tool call, confirm you can
+state the **deliverable**: what question, what decision it informs, what time
+window, what region/market, what depth. If any of these is missing and would
+change the answer, ask 2-3 sharp clarifying questions first — don't guess a
+scope and burn a fan-out on the wrong one.
+
+Then write down, in one line, what "done" looks like. That line is the acceptance
+criterion the final report is checked against.
+
+## 1. Fan out — breadth
+
+Decompose the question into 4-8 **independent** sub-questions, each attacking a
+different angle (definition, current state, competing views, data/numbers,
+history, criticisms, primary actors). Independence matters: overlapping
+sub-questions waste the fan-out.
+
+Dispatch them in parallel. `web_search` / `web_fetch` are stateless, so this is
+exactly the case sub-agents are for:
+
+- One `sub_agent` per sub-question. Prompt it **goal-first**, not step-first:
+  describe what to *find out*, not "search for X" — an anti-bot source may need
+  `browser` on the main site, and "search" would anchor the sub-agent to
+  `web_search`.
+- Tell each sub-agent to **load the `web-access` skill and follow it**, to return
+  findings *with source URLs*, and to flag anything it couldn't verify.
+- Do NOT parallelize `browser` work — the browser session is single-page and
+  process-shared; concurrent sub-agents fight over one page. Keep browser
+  interaction to a single sequence; parallelize only the stateless search/fetch.
+
+If `sub_agent` is unavailable in this session, run the sub-questions sequentially
+inline and say so.
+
+## 2. Go to the source — depth
+
+Search engines and aggregators are a **discovery entry point, not proof**. N
+outlets quoting the same wrong number is circular, not corroboration. For every
+claim that matters, reach the **primary source** and read it:
+
+| Claim type | Primary source |
+|------------|----------------|
+| Policy / regulation | Issuing body's official site |
+| Company announcement | The company's own newsroom / filing |
+| Academic / scientific | The original paper or the institution |
+| Product capability / API | Official docs or source, not blog posts |
+| Statistics | The dataset publisher, not the article citing it |
+
+Use `web_fetch` on the source URL to pull the page as clean Markdown (pass the
+raw URL — don't hand-build a `r.jina.ai/` prefix). When the source is behind a
+login, renders via JS, or blocks fetching, switch to `browser` per `web-access`.
+
+When no official source exists, an original report from an authoritative outlet
+(not a reprint) can serve as a secondary basis — but say so explicitly:
+"No official source found; the following relies on [outlet]'s reporting and may
+carry transcription error."
+
+## 3. Adversarial verify — try to break each claim
+
+This is what separates research from a summary. For each load-bearing claim,
+run a skeptical pass **before** trusting it:
+
+- Does the source actually say this, or is it the article's spin on it?
+- Is the source primary, or is it echoing someone else? Trace one hop back.
+- Is it current, or superseded? Note the date on every source.
+- Do independent sources *disagree*? Surface the disagreement — don't average it away.
+
+For high-stakes claims, dispatch a verifier `sub_agent` prompted to **refute**
+the claim (default to "unverified" when uncertain), not to confirm it. A claim
+that survives an honest attempt to break it is worth reporting; one that doesn't
+gets dropped or flagged as contested.
+
+Track claim → source as you go. Anything you can't attribute to a source you
+read does not enter the report as fact — at most as a clearly-labelled open
+question.
+
+## 4. Synthesize — the cited report
+
+Structure to the deliverable from step 0, not a fixed template. Typical shape:
+
+- **Bottom line** — the answer to the question, up front, in a few sentences.
+- **Findings** — organized by sub-question or theme, each key claim carrying an
+  inline source (title + URL). Present genuine disagreement as disagreement.
+- **Confidence & gaps** — what's well-established, what's thin or single-sourced,
+  what you couldn't resolve. State this honestly; a known gap is more useful than
+  false certainty.
+- **Sources** — the primary sources you actually read, deduped.
+
+Then check the report against the step-0 acceptance line. If it doesn't answer
+the question, name what's still missing rather than padding.
+
+## Completeness check
+
+Before finishing, ask: what's missing? A sub-question not run, a claim asserted
+but never traced to a source, a contradiction glossed over, a source cited but
+not read. Whatever that surfaces is the next round — loop back to step 1 for it,
+don't ship around it. Stop when the acceptance criterion is met, not before, and
+don't over-research past it.

--- a/internal/skills/defaults/grill-me/SKILL.md
+++ b/internal/skills/defaults/grill-me/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: grill-me
+license: MIT
+description:
+  Interview the user relentlessly about a plan or design until reaching shared
+  understanding, resolving each branch of the decision tree one at a time. Use
+  when the user wants to stress-test a plan, pressure-test a design before
+  building, or says "grill me", "拷问我", "帮我把方案想清楚", "挑战一下这个设计",
+  "review my plan before I build". Pairs with the tech-design skill: grill first,
+  then hand the resolved decisions to tech-design to write them up.
+metadata:
+  origin: adapted for octo — generic stack, octo-native codebase exploration
+---
+
+# Skill: grill-me
+
+Interview the user relentlessly about every aspect of a plan until you reach a
+shared, resolved understanding. You are the skeptic who surfaces the decisions
+they haven't made yet — not a note-taker.
+
+## ⚠️ Hard rule: ONE question per message
+
+This is the single most important rule of this skill. Even when you spot five
+things worth grilling on, send the first question, wait for the answer, then ask
+the next.
+
+**Why this matters**: a wall of five questions defeats the purpose. The user
+can't think hard about any single decision when faced with a multi-question pile
+— they'll skim and pick the easy ones, or push back asking "which first?". Both
+waste the session.
+
+**Anti-pattern**:
+> ❌ "Here are 5 things I want to grill on: 1. … 2. … 3. …"
+
+**Correct pattern**:
+> ✅ "[First question, with options + recommendation]"
+> [wait for answer]
+> "[Next question, informed by the previous answer]"
+
+If a topic has sub-questions, ask the top-level one first and drill in based on
+the answer. Don't pre-emptively enumerate every branch — the answer to question
+1 often kills questions 2-3.
+
+## Phase 0 — Context exploration
+
+Before asking any questions, do your homework:
+
+1. **Read the input** — the user may provide anything from a one-line idea to a
+   full PRD (local file, doc URL, or prose). Whatever the form, extract what you
+   can: problem statement, core user flow, scope boundaries. The less the user
+   gives, the more Phase 1 needs to cover.
+2. **Explore the codebase** — identify the existing services, data models, APIs,
+   message-queue topics, cache keys, and prior art relevant to the plan. Use
+   codegraph if the project has it indexed, otherwise search directly. Report key
+   findings to the user concisely before starting questions.
+
+This phase is silent work — don't ask the user things you can learn from the code.
+
+## Phase 1 — Grill
+
+Walk down each branch of the design tree, resolving dependencies between
+decisions one by one. If a question can be answered by exploring the codebase,
+explore instead of asking.
+
+### Question format
+
+For each non-trivial decision, structure the message as:
+
+1. **Set up the decision** — 1-2 sentences of context (what's at stake, why this
+   is a branch point)
+2. **Present 2-3 options** as A/B/C with a one-paragraph trade-off each (table if
+   complex)
+3. **State your recommendation** and why, grounded in the codebase findings
+4. **End with the question**
+
+Then stop and wait. Do not chain a second question after this one, even if it
+feels closely related — the answer to question 1 usually reshapes question 2.
+
+### Prefer multiple choice over open-ended
+
+A/B/C questions are easier to answer and give you concrete signal to continue
+from. Reserve open-ended for "what are you optimizing for?" / "what's the goal?"
+style questions where the option space is genuinely unknown to you.
+
+Simple yes/no or factual questions don't need the full options-and-recommendation
+treatment — use judgment.
+
+## Phase 2 — Coverage check
+
+Before wrapping up, verify no critical area was missed. Scan the decisions made
+so far against these domains:
+
+| Domain | Check |
+|---|---|
+| Architecture | Service boundaries, sync vs async, failure handling |
+| Data model | Tables/collections, columns, indexes, data volume, partitioning |
+| API design | Contracts, pagination, idempotency, breaking changes |
+| Messaging | Topics, schemas, consumer groups, retry/DLQ |
+| Caching | Key format, TTL, eviction, invalidation |
+| Configuration | Config / feature-flag keys, per-environment default differences, dynamic vs restart-to-apply, multi-key ordering |
+| Rollout & safety | Grayscale, feature flags, rollback, monitoring |
+
+For each domain relevant to the plan: if it was never discussed, ask about it now
+(**still one question at a time** — the temptation to batch returns here, resist
+it). If it was covered, skip it. Domains not applicable to the plan (e.g. no MQ
+involved) can be skipped entirely.
+
+## Phase 3 — Wrapping up
+
+When all major branches of the decision tree are resolved, stop and summarize:
+
+```
+All key branches resolved. Decision summary:
+
+1. [question] → [conclusion] ([rationale])
+2. …
+
+Want me to turn these into a technical design doc? (tech-design skill)
+```
+
+If the user says yes, invoke the tech-design skill. The decisions above stay in
+conversation context — tech-design uses them directly, so it won't re-grill.

--- a/internal/skills/defaults/tech-design/SKILL.md
+++ b/internal/skills/defaults/tech-design/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: tech-design
+license: MIT
+description:
+  Produce a complete backend technical design document from a PRD or feature
+  description — understand, explore the codebase, grill on decisions, write, and
+  self-review. Use when the user wants to write a tech design, technical
+  proposal, or backend design doc, e.g. "写技术方案", "出个设计文档", "tech design",
+  "technical proposal", "帮我写后端设计". For pressure-testing decisions first, use
+  the grill-me skill; to build from a finished design, use the implement skill.
+metadata:
+  origin: adapted for octo — generic stack, no org-internal KB/lint tooling
+---
+
+# Skill: tech-design
+
+Take a PRD (or feature description) and produce a complete backend technical
+design document through a structured process: **understand → explore → grill →
+write → self-review**.
+
+## Rules (the reason this skill exists)
+
+These five rules run through the whole process. Follow them while writing
+(Phase 4), then grep for violations in the self-review. Most rework on a design
+doc traces back to breaking one of them.
+
+### R1. Never invent placeholders (API / field / service / URL / enum)
+
+Every concrete technical name must be **grepped from real code, looked up in
+docs, or asked of the user** — never a plausible-sounding placeholder left for
+review to fix. Inventing `svc.GetBookingNotes` when no such method exists, or
+guessing a column is `matter_type` when it's really `ticket_type`, is the single
+most common source of production bugs that pass mocked tests.
+
+### R2. Never invent phasing
+
+The design scope is strictly equal to the PRD scope. There are only two legal
+sources of phasing: (a) the PRD itself marks priority (P1/P2 in the stories), or
+(b) the user explicitly said "do X first, not Y" during grilling. Otherwise, if
+the PRD lists N sub-scenarios, design N.
+
+**Do not use `P1/P2/P3` (or `Phase 1/2/3`) prefixes to label features, sections,
+or upstream links** — even as "neutral numbering". A P-prefix is always read as
+priority/phasing and manufactures an ordering the PRD never stated. Use the PRD's
+own section names instead. Real execution order belongs only in a "release order"
+section, and only when driven by a dependency chain, not by scope-cutting.
+
+### R3. Technical facts must be traceable
+
+Every concrete technical claim (DB column, URL prefix, field, API signature, enum
+value, cache key pattern, MQ topic) must come from one of: a **code location**
+(`file:line`), **project docs**, or a **grill answer** (quote the decision). Can't
+find a source → **ask the user** (they're online; asking is cheap). Never paper
+over a gap with a TODO.
+
+Decision-level choices (sync vs async, new table vs extend column) can rest on a
+grill answer plus explicit trade-off reasoning — but **factual assertions** must
+be greppable.
+
+**High-guess areas** (grilling usually misses these; handle by "check docs → check
+code → ask user"): compatibility design, security design, circuit-breaker
+thresholds, rollback plan, external dependency interface tables.
+
+### R4. The document must read context-free
+
+Write for a future reader who wasn't in this conversation. **Banned phrases**:
+grill-question references (`the Q3 decision`, `per the original Q3`), grill-option
+letters (`go with option A`, `path A` — the reader has no idea what A was; inline
+the actual content instead), conversation references (`after we discussed…`,
+`the earlier path`), and editing-process narration (`revised plan`, `originally
+we…`).
+
+Replace with the direct technical reason: "We use X rather than Y because … (name
+the actual X and Y, never bare option letters)."
+
+**Also context-bound: undefined jargon.** Any domain term or coined abbreviation
+must be defined on first use or in a glossary. Test: would someone who only reads
+this doc, wasn't in the conversation, and isn't deep in this domain know what the
+word means? If not, define it.
+
+Exception: a version-history changelog may say "X changed to Y", but must not
+reference a grill question.
+
+### R5. Examples must be empirical
+
+A concrete example ("service X runs on cluster Y", "call chain A→B→C", "this
+field is usually N") must be grepped / measured / confirmed from logs. Ask "can I
+reproduce this example?" — if not, don't write it. An honest "needs verification"
+beats a wrong example that a later reader treats as truth. An old default config
+existing ≠ the current fact being correct; infrastructure migrates.
+
+## Inputs
+
+The user provides one of: a doc URL containing the PRD, a local file path, or a
+prose description. If a URL is given, fetch and read it first.
+
+## Process
+
+### Phase 1 — Understand the problem
+
+Read the PRD thoroughly. Extract: **problem statement** (what pain is solved),
+**core user flow** (the happy path end-to-end), **scope boundaries** (explicitly
+in/out), **success metrics**. Summarize back to the user in 5-8 bullets and ask:
+"Did I get this right? Anything missing?"
+
+### Phase 2 — Explore the codebase
+
+Identify which existing services, modules, and data models are involved. Explore
+to understand current architecture and boundaries, existing schemas that will be
+touched, APIs to modify or depend on, relevant MQ topics / cache keys / cron
+jobs, and prior art — similar features already implemented that can inform the
+design. Use codegraph if indexed, otherwise search directly. Report key findings
+concisely (module names, key files, current behavior).
+
+### Phase 3 — Fill the write-specific gaps
+
+The general decision tree (architecture / data / API / MQ / config / rollout) is
+resolved by a prior **grill-me** session, and those decisions are already in
+context — **do not re-grill here**. This step only fills the concrete items a
+document needs but grilling usually misses — exactly the R3 high-guess areas:
+
+- **Compatibility**: old/new data, old/new interfaces, dual-run during grayscale
+- **Security**: auth, privilege escalation, sensitive fields
+- **High availability**: timeout / degradation / rate-limit thresholds (concrete
+  numbers)
+- **Rollback**: can code and data roll back independently?
+- **External dependencies**: for each HTTP/RPC/MQ upstream, the canonical
+  `file:line` plus verbatim field names (with serialization tags)
+
+Handle in R3 order — **check docs → check code → ask user**. Read from code what
+you can (upstream fields, URL prefixes); ask the user only for what's neither in
+code nor docs, one question at a time. When gaps are filled, confirm: "Decisions
+and the facts needed to write are all in — ready to write?"
+
+### Phase 4 — Write the tech design
+
+Structure to the change, not a fixed template. A **project-level** design (new
+feature/service/flow, multi-service, needs an architecture diagram and grayscale
+rollout) covers the full skeleton below. A **small iteration** (a field added, a
+branch extended, single service, architecture unchanged) keeps only the sections
+that actually change and drops the rest.
+
+Typical skeleton:
+
+- **Background & goals**, **Out of scope**, **Naming glossary** (if any jargon)
+- **Business flow** — a `flowchart TB` when the flow is non-trivial
+- **Architecture** — service boundaries and responsibilities
+- **Detailed design & sequence diagrams** — one `sequenceDiagram` per flow, not
+  one giant diagram; skip for pure field additions
+- **Data model** — table/collection schema, indexes, data-volume estimate,
+  backfill/migration if any
+- **API design** — every endpoint named, request/response with verbatim fields
+- **MQ design** — topic, schema, consumer group, retry/DLQ
+- **Cache design** — key format, TTL, eviction, invalidation
+- **Config design** — every config / feature-flag key, per-environment defaults,
+  dynamic vs restart-to-apply
+- **External dependency interfaces** — see below
+- **Test plan**, **Compatibility**, **Security**, **High availability**
+  (circuit-breaking / degradation / concurrency), **Monitoring & alerting**
+- **Release order** (when multiple repos), **Rollback** (code / data / config)
+
+**Empty sections**: in a project-level design, keep the section and write "N/A —
+[why]" so a reviewer sees each sanity-check area was considered; in a small
+iteration, delete sections that don't change. **The compatibility section is the
+exception** — always spell out *why* it's not affected, item by item, never a
+bare "N/A"; it's the most-missed area in self-review.
+
+**Style**: tables over paragraphs; concrete over abstract — real key formats,
+real SQL, real JSON, every cache key / MQ topic / API endpoint / DB column named,
+no hand-waving. Write in the user's language; keep code, field names, and types
+in their original form.
+
+**The external-dependency table is the worst offender for R1 + R3.** Every
+HTTP/RPC/MQ upstream call gets a row: canonical file path + line range + verbatim
+fields (with serialization tags). Do **not** write prose like "reads status /
+type / amount" — an implementer seeing a prose field name will guess the tag
+(`status` → `json:"status"` or `json:"status_text"`?), and one wrong character is
+a production bug that fake-client unit tests never catch. Filling this table with
+verbatim fields at design time is the only place that prevents the whole class.
+
+### Phase 5 — Self-review, then hand off
+
+Before showing the user, grep for rule violations:
+
+| Rule | Check | Fix |
+|---|---|---|
+| **R1** | Every API name / DB column / enum / URL has a `file:line` or doc source | Grep real code to verify; ask the user if not found — no plausible placeholders |
+| **R2** | `grep -E 'P1\|P2\|P3\|Phase\|阶段'` — any hit is suspect phasing | Can it point back to a PRD priority or an explicit "do X first" decision? If not, remove it and restore full-PRD scope. Even if it can, drop the P/Phase prefix and use the PRD's section name |
+| **R3** | `grep -E '通常\|一般\|应该是\|usually\|should be\|probably\|likely'` | Stop & verify: add `file:line` / doc reference, or ask the user — no TODO fallback |
+| **R4** | `grep -E 'Q\d+\|grill\|option [ABCD]\|方案 ?[ABCD]\|走 ?[ABCD] ?路'` | Rewrite as a direct technical statement; replace bare option letters with their actual content. Changelog is exempt |
+| **R4-jargon** | List domain jargon / coined abbreviations; confirm each is defined in the glossary or on first use | Define the undefined ones |
+| **R5** | Every concrete example (service/cluster/field value/call chain) is empirical | Can't reproduce → change to "needs verification" or delete |
+| **Completeness** | `grep -E 'TBD\|TODO\|待定'`; empty tables, placeholders | Every cache key / MQ topic / API endpoint / DB column must be concrete |
+| **Consistency** | Sequence-diagram field names vs API response fields vs DB columns aligned? MQ topic name producer == consumer? | Rename to align |
+
+Fix issues in place. Leave open questions that genuinely need user input for the
+hand-off. Present the draft, iterate on feedback until approved.
+
+## Output
+
+Write the final document to the location the user specifies (default:
+`tech-design.md` in the current directory). Once approved, the natural next step
+is the **implement** skill, which builds from the design slice by slice.

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -209,22 +209,25 @@ func TestKillShellTool(t *testing.T) {
 // background process — no kill, no restart. The agent receives partial output
 // plus the bg id.
 func TestTerminalTool_TimeoutPromotesToBackground(t *testing.T) {
-	// Use a short timeout so the test doesn't take 30 s.  500 ms is enough
-	// for POSIX `sh` and Windows PowerShell to start and emit a line, while
-	// keeping the test fast.
+	// Use a short timeout so the test doesn't take 30 s. The window must be
+	// long enough for the shell to cold-start AND emit its first line before
+	// the timeout fires — otherwise the promotion-to-background snapshot is
+	// taken before any partial output exists and the "partial" assert flakes.
+	// POSIX `sh` starts in a few ms; Windows PowerShell cold-start routinely
+	// exceeds 500 ms on CI, so give it a much wider window (and a proportionally
+	// longer sleep so the command is still running when the timeout fires).
+	timeout := 500 * time.Millisecond
+	cmd := "echo partial && sleep 2"
+	if runtime.GOOS == "windows" {
+		timeout = 4 * time.Second
+		cmd = "Write-Output partial; Start-Sleep -Seconds 8"
+	}
 	oldTimeout := TerminalTimeout
-	TerminalTimeout = 500 * time.Millisecond
+	TerminalTimeout = timeout
 	defer func() { TerminalTimeout = oldTimeout }()
 
 	m := NewBackgroundManager()
 	term := TerminalTool{mgr: m}
-
-	// Use `echo` (fast, cross-platform) piped to a long sleep.  On POSIX
-	// `sleep` is available; on Windows we use `Start-Sleep` via PowerShell.
-	cmd := "echo partial && sleep 1"
-	if runtime.GOOS == "windows" {
-		cmd = "Write-Output partial; Start-Sleep -Seconds 1"
-	}
 	res, err := term.Execute(context.Background(), "terminal", map[string]any{
 		"command": cmd,
 	})
@@ -248,10 +251,10 @@ func TestTerminalTool_TimeoutPromotesToBackground(t *testing.T) {
 		t.Errorf("result should warn against polling, got: %q", res.Text)
 	}
 
-	// The background process should eventually finish (sleep 0.5 + margin).
-	// Use a longer deadline than the default waitFor because CI under -race
-	// can be very slow.
-	deadline := time.Now().Add(10 * time.Second)
+	// The background process should eventually finish. Use a generous deadline:
+	// it must exceed the shell cold-start plus the sleep above (up to ~8 s on
+	// Windows), and CI under -race can be very slow on top of that.
+	deadline := time.Now().Add(25 * time.Second)
 	for time.Now().Before(deadline) {
 		_, s, _, _, _ := m.Read("bg_1")
 		if strings.HasPrefix(s, "exited") {


### PR DESCRIPTION
## What

Adds three more embedded default skills to the curated set (`internal/skills/defaults/`), materialized to `~/.octo/skills-default` on install like the rest.

| Skill | Purpose |
|---|---|
| **deep-research** | Multi-source, fact-checked research harness: fan-out searches → primary-source verification → adversarial claim-checking → cited synthesis. Built on octo-native `web_search`/`web_fetch`/`sub_agent`, falling back to `browser` via the web-access skill for login-gated / JS-rendered sources. |
| **grill-me** | One-question-at-a-time design interrogation that resolves each branch of the decision tree before building. |
| **tech-design** | PRD → backend design doc via understand → explore → grill → write → self-review, keeping the R1–R5 anti-fabrication rules and a grep-based self-review pass. |

The three compose into a chain: **grill-me → tech-design → implement**.

## Notes

- `grill-me` and `tech-design` are adapted from internal skills and **generalized for open source**: generic tech stack, octo-native codebase exploration (codegraph when indexed, else direct search), and **no org-internal KB / lint tooling** references.
- `deep-research` is octo-native (not a copy of any bundled harness) — uses octo's own tools and the existing web-access skill for browsing.
- **No registry changes** — `//go:embed defaults` picks up new directories automatically.

## Also: two Windows-only flaky-test fixes (2nd commit)

Pre-existing Windows flakes, unrelated to the skills change, but CI runs the whole suite on this branch so they must be fixed here to go green:

- **`TestTerminalTool_TimeoutPromotesToBackground`** — the 500ms promotion timeout was shorter than PowerShell's cold-start on CI, so `partial` hadn't been emitted when the background snapshot was taken. Widened the Windows timeout to 4s (longer sleep so the command is still running when it fires) and bumped the finish-wait deadline to 25s.
- **`TestHandleWSUserMessage_ImageOnly`** — `t.TempDir()`'s RemoveAll raced the background turn goroutine's still-open session-file handle on Windows (`directory is not empty`). Added a barrier that waits for `turnRunning` to flip back to false before cleanup.

## Test

- `go test ./internal/skills/` passes; `gofmt -l internal/skills/` clean
- Both fixed tests pass locally on macOS
- Verified all three skills materialize and are discovered via `Discover("")` with correctly parsed frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)