### PR TITLE
feat(im): send_file to any chat (web parity with send_message)

### DIFF
--- a/internal/channel/notify.go
+++ b/internal/channel/notify.go
@@ -34,3 +34,31 @@ func SendOnce(platform, chatID, text string) error {
 	}
 	return nil
 }
+
+// SendFileOnce is the file counterpart to SendOnce: it delivers a single local
+// file to an IM chat by constructing the platform adapter from config on the
+// fly. Used as the fallback when no live adapter is running for the platform.
+// The adapter picks the wire type (image / video / file) from the extension.
+// The same per-platform credential/target rules as SendOnce apply.
+func SendFileOnce(platform, chatID, path, name string) error {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return err
+	}
+	pc, ok := cfg.Channels[platform]
+	if !ok {
+		return fmt.Errorf("channel %q not configured", platform)
+	}
+	ctor, err := Find(platform)
+	if err != nil {
+		return err
+	}
+	a, err := ctor(pc)
+	if err != nil {
+		return err
+	}
+	if res := a.SendFile(chatID, path, name, ""); !res.OK {
+		return fmt.Errorf("send file to %s chat %s: %s", platform, chatID, res.Error)
+	}
+	return nil
+}

--- a/internal/server/messenger.go
+++ b/internal/server/messenger.go
@@ -17,6 +17,11 @@ func (m serverMessenger) SendMessage(platform, chatID, text string) error {
 	return m.s.channelSend(platform, chatID, text)
 }
 
+// SendFile delivers a local file to chatID on platform.
+func (m serverMessenger) SendFile(platform, chatID, path, name string) error {
+	return m.s.channelSendFile(platform, chatID, path, name)
+}
+
 // KnownChats lists the chats the bot can currently address, derived from the
 // channel manager's live sessions plus the persisted /bind table.
 func (m serverMessenger) KnownChats() []tools.KnownRecipient {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2127,13 +2127,12 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		// browser tabs an IM session doesn't have (the question would hang
 		// until /stop).
 		ctx = tools.WithAsker(ctx, s.channelAsker(sess, ad, ev))
-		// Turn-scoped file sender + the IM-only send_file tool: the model's
-		// reply carries text, so the only way to put a generated image / chart
-		// / document in front of the user is to push it through the adapter.
-		// Withheld from the shared default tool list (DefaultToolsFor); added
-		// here because only an IM turn has a chat to send to.
+		// Turn-scoped file sender for send_file's default (current-chat) mode:
+		// the model's reply carries only text, so a generated image / chart /
+		// document reaches this chat by pushing it through the adapter. The
+		// send_file tool itself is advertised via DefaultToolsFor (messenger
+		// registered); here we only pin which chat the no-target case sends to.
 		ctx = tools.WithChannelSender(ctx, channelFileSender{ad: ad, chatID: ev.ChatID, replyTo: ev.MessageID})
-		toolDefs = append(toolDefs, tools.SendFileToolDef())
 		// Per-chat Waker so schedule_wakeup (the loop skill) can pace this and
 		// later turns. On wakeup it routes through runChannelIdleTurn, which
 		// delivers via the adapter — including the wakeup-injected turns, which

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -346,6 +346,18 @@ func (s *Server) channelSend(platform, chatID, text string) error {
 	return channel.SendOnce(platform, chatID, text)
 }
 
+// channelSendFile is the file counterpart to channelSend: same live-adapter-then-
+// SendFileOnce fallback, delivering a local file instead of text.
+func (s *Server) channelSendFile(platform, chatID, path, name string) error {
+	if v, ok := s.runningAdapters.Load(platform); ok {
+		if res := v.(channel.Adapter).SendFile(chatID, path, name, ""); !res.OK {
+			return fmt.Errorf("send file to %s chat %s: %s", platform, chatID, res.Error)
+		}
+		return nil
+	}
+	return channel.SendFileOnce(platform, chatID, path, name)
+}
+
 func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
 	s.initScheduler()
 	if s.scheduler == nil {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -246,10 +246,10 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 	spawnerOn := spawnerEnabled()
 	defs := make([]agent.ToolDefinition, 0, len(allTools))
 	for _, t := range allTools {
-		if _, isSend := t.(SendFileTool); isSend {
-			// IM-only: advertised by runChannelTurns (which injects the
-			// per-chat sender), never in the shared default list — on a
-			// CLI/TUI/Web turn it has no chat to send to and could only error.
+		if _, isSendFile := t.(SendFileTool); isSendFile && !messengerOn {
+			// Needs a chat to push to, which only the server has (live adapters).
+			// Advertised alongside send_message when a messenger is registered
+			// (covers both web and IM turns); hidden in CLI/TUI.
 			continue
 		}
 		if _, isSkill := t.(SkillTool); isSkill && !skillsOn {

--- a/internal/tools/send_file.go
+++ b/internal/tools/send_file.go
@@ -38,32 +38,37 @@ func channelSenderFrom(ctx context.Context) ChannelFileSender {
 	return nil
 }
 
-// SendFileTool delivers a local file to the user through the active IM channel
-// (WeChat, Telegram, Discord, …). It is the only way the model can put a file
-// in front of an IM user: a chat reply carries text, so a generated image,
+// SendFileTool delivers a local file to a user through an IM channel (WeChat,
+// Telegram, Discord, …). A chat reply carries only text, so a generated image,
 // chart, document, or any other artifact must be pushed as a file.
 //
-// The tool lives in allTools so DefaultRegistry can dispatch it, but it is
-// withheld from the advertised tool list everywhere except IM turns — see
-// DefaultToolsFor, which always skips it, and runChannelTurns, which appends
-// its definition and injects the sender. On a non-IM turn channelSenderFrom
-// returns nil and the tool reports a clean, model-readable error.
+// Two modes, mirroring send_message:
+//   - On an IM turn it defaults to the CURRENT chat via the turn-scoped
+//     ChannelFileSender (runChannelTurns injects it with WithChannelSender).
+//   - With an explicit platform + chat_id it targets ANY reachable chat via the
+//     process-global ChannelMessenger — so a web/sub-agent turn can push a file
+//     to the user's WeChat even though it has no chat of its own.
+//
+// Advertised in DefaultToolsFor whenever a messenger is registered (the server),
+// so it is available on both web and IM turns; hidden in CLI/TUI.
 type SendFileTool struct{}
 
-// SendFileToolDef is the definition runChannelTurns appends to the IM tool
-// list. Exported so the server can advertise the tool without re-deriving it.
+// SendFileToolDef exposes the tool definition for callers that assemble a tool
+// list manually.
 func SendFileToolDef() agent.ToolDefinition { return SendFileTool{}.Definition() }
 
 func (SendFileTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name: "send_file",
-		Description: "Send a local file to the user through the current chat (image, video, " +
-			"document, or any file). Use this whenever the user should receive an actual file — " +
-			"a generated image or chart, a screenshot, a PDF or other document, a data export. " +
-			"A normal reply only carries text, so a file the user asked for MUST go through this " +
-			"tool. The wire type (image / video / file) is chosen automatically from the " +
-			"extension, so name images .png/.jpg and videos .mp4. The file must already exist on " +
-			"disk; create it first (write_file, a script, a download), then send it.",
+		Description: "Send a local file to a user over an IM channel (image, video, document, or any " +
+			"file). Use this whenever the user should receive an actual file — a generated image or " +
+			"chart, a screenshot, a PDF or other document, a data export. A normal reply only carries " +
+			"text, so a file MUST go through this tool. The wire type (image / video / file) is chosen " +
+			"automatically from the extension, so name images .png/.jpg and videos .mp4. The file must " +
+			"already exist on disk; create it first (write_file, a script, a download), then send it.\n\n" +
+			"Recipient: on an IM chat, omit platform/chat_id and it goes to the current chat. To send " +
+			"to a DIFFERENT chat (e.g. from the web UI to the user's WeChat), pass platform + chat_id; " +
+			"if you don't know the chat_id, pass just platform (or nothing) to list reachable chats.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -75,6 +80,14 @@ func (SendFileTool) Definition() agent.ToolDefinition {
 					"type":        "string",
 					"description": "Optional display filename shown to the user. Defaults to the file's basename.",
 				},
+				"platform": map[string]any{
+					"type":        "string",
+					"description": "Target IM platform (e.g. \"weixin\", \"telegram\"). Omit to send to the current IM chat; pass it to target another chat.",
+				},
+				"chat_id": map[string]any{
+					"type":        "string",
+					"description": "Target chat/user ID. Omit to send to the current IM chat, or (with platform) to list reachable chats.",
+				},
 			},
 			"required": []string{"path"},
 		},
@@ -82,11 +95,6 @@ func (SendFileTool) Definition() agent.ToolDefinition {
 }
 
 func (SendFileTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
-	sender := channelSenderFrom(ctx)
-	if sender == nil {
-		return agent.ToolResult{}, fmt.Errorf("send_file: no chat to send to — this tool only works while chatting over an IM channel")
-	}
-
 	path := strings.TrimSpace(stringArg(input, "path"))
 	if path == "" {
 		return agent.ToolResult{}, fmt.Errorf("send_file: path is required")
@@ -108,10 +116,47 @@ func (SendFileTool) Execute(ctx context.Context, _ string, input map[string]any)
 		name = filepath.Base(abs)
 	}
 
-	if err := sender.SendFile(abs, name); err != nil {
-		return agent.ToolResult{}, fmt.Errorf("send_file: %w", err)
+	platform := strings.TrimSpace(stringArg(input, "platform"))
+	chatID := strings.TrimSpace(stringArg(input, "chat_id"))
+
+	// Explicit cross-chat target → go through the messenger.
+	if platform != "" || chatID != "" {
+		m := activeMessenger
+		if m == nil {
+			return agent.ToolResult{}, fmt.Errorf("send_file: sending to another chat is only available on the server")
+		}
+		if chatID == "" {
+			cands := filterRecipients(m.KnownChats(), platform)
+			if len(cands) == 1 {
+				platform, chatID = cands[0].Platform, cands[0].ChatID
+			} else {
+				return listRecipients(cands, platform)
+			}
+		}
+		if platform == "" {
+			return agent.ToolResult{}, fmt.Errorf("send_file: platform is required when chat_id is given")
+		}
+		if err := m.SendFile(platform, chatID, abs, name); err != nil {
+			return agent.ToolResult{}, fmt.Errorf("send_file: %w", err)
+		}
+		return agent.ToolResult{
+			Text: fmt.Sprintf("Sent %s (%d bytes) to %s chat %s.", name, fi.Size(), platform, chatID),
+		}, nil
 	}
-	return agent.ToolResult{
-		Text: fmt.Sprintf("Sent %s (%d bytes) to the chat.", name, fi.Size()),
-	}, nil
+
+	// No explicit target: default to the current IM chat if this turn has one.
+	if sender := channelSenderFrom(ctx); sender != nil {
+		if err := sender.SendFile(abs, name); err != nil {
+			return agent.ToolResult{}, fmt.Errorf("send_file: %w", err)
+		}
+		return agent.ToolResult{
+			Text: fmt.Sprintf("Sent %s (%d bytes) to the chat.", name, fi.Size()),
+		}, nil
+	}
+
+	// Web/other server turn with no target: guide the model to pick a chat.
+	if m := activeMessenger; m != nil {
+		return listRecipients(m.KnownChats(), "")
+	}
+	return agent.ToolResult{}, fmt.Errorf("send_file: no chat to send to — specify platform + chat_id, or use this from an IM chat")
 }

--- a/internal/tools/send_file_test.go
+++ b/internal/tools/send_file_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -24,10 +25,11 @@ func (f *fakeSender) SendFile(path, name string) error {
 }
 
 func TestSendFileTool_RequiresSender(t *testing.T) {
-	// No sender in ctx → CLI/TUI/Web turn → clean error, no panic.
+	// No sender in ctx and no messenger (CLI/TUI) → clean error, no panic.
+	SetMessenger(nil)
 	_, err := SendFileTool{}.Execute(context.Background(), "send_file", map[string]any{"path": "/tmp/x.png"})
 	if err == nil {
-		t.Fatal("expected error when no channel sender is in ctx")
+		t.Fatal("expected error when no channel sender and no messenger")
 	}
 }
 
@@ -119,13 +121,124 @@ func TestSendFileTool_SenderError(t *testing.T) {
 	}
 }
 
-// send_file is IM-only: it must never appear in the shared default tool list,
-// or CLI/TUI/Web turns would advertise a tool that can only error.
-func TestSendFileTool_NotInDefaultTools(t *testing.T) {
+// send_file needs a chat to push to (server only): hidden without a messenger
+// (CLI/TUI), advertised with one (web + IM).
+func TestSendFileTool_DefaultToolsGating(t *testing.T) {
+	SetMessenger(nil)
 	for _, d := range DefaultToolsFor("") {
 		if d.Name == "send_file" {
-			t.Fatal("send_file must not be advertised in DefaultToolsFor")
+			t.Fatal("send_file must not be advertised without a messenger")
 		}
+	}
+
+	SetMessenger(&fakeMessenger{})
+	defer SetMessenger(nil)
+	var found bool
+	for _, d := range DefaultToolsFor("") {
+		if d.Name == "send_file" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("send_file should be advertised when a messenger is registered")
+	}
+}
+
+// Cross-chat mode: explicit platform + chat_id routes through the messenger,
+// not the current-chat sender.
+func TestSendFileTool_CrossChatSend(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "chart.png")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fm := &fakeMessenger{}
+	SetMessenger(fm)
+	defer SetMessenger(nil)
+
+	res, err := SendFileTool{}.Execute(context.Background(), "send_file",
+		map[string]any{"path": p, "platform": "weixin", "chat_id": "c1"})
+	if err != nil {
+		t.Fatalf("cross-chat send: %v", err)
+	}
+	if len(fm.sentFiles) != 1 || fm.sentFiles[0].platform != "weixin" || fm.sentFiles[0].chatID != "c1" {
+		t.Fatalf("sentFiles = %+v", fm.sentFiles)
+	}
+	if fm.sentFiles[0].name != "chart.png" {
+		t.Errorf("name = %q, want chart.png", fm.sentFiles[0].name)
+	}
+	if res.Text == "" {
+		t.Error("expected result text")
+	}
+}
+
+// Single known candidate on the platform + no chat_id → auto-targets it.
+func TestSendFileTool_CrossChatSingleCandidate(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.png")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fm := &fakeMessenger{chats: []KnownRecipient{{Platform: "weixin", ChatID: "only"}}}
+	SetMessenger(fm)
+	defer SetMessenger(nil)
+
+	if _, err := (SendFileTool{}).Execute(context.Background(), "send_file",
+		map[string]any{"path": p, "platform": "weixin"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if len(fm.sentFiles) != 1 || fm.sentFiles[0].chatID != "only" {
+		t.Fatalf("sentFiles = %+v", fm.sentFiles)
+	}
+}
+
+// Ambiguous platform (multiple candidates, no chat_id) → lists, does not send.
+func TestSendFileTool_CrossChatAmbiguousLists(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.png")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fm := &fakeMessenger{chats: []KnownRecipient{
+		{Platform: "weixin", ChatID: "c1"},
+		{Platform: "weixin", ChatID: "c2"},
+	}}
+	SetMessenger(fm)
+	defer SetMessenger(nil)
+
+	out, err := SendFileTool{}.Execute(context.Background(), "send_file",
+		map[string]any{"path": p, "platform": "weixin"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(fm.sentFiles) != 0 {
+		t.Fatalf("must not send when ambiguous; sentFiles = %+v", fm.sentFiles)
+	}
+	if !strings.Contains(out.Text, "c1") || !strings.Contains(out.Text, "c2") {
+		t.Fatalf("expected candidates listed, got %q", out.Text)
+	}
+}
+
+// Web turn (messenger, no ctx sender) with no target → lists reachable chats.
+func TestSendFileTool_WebNoTargetLists(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.png")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fm := &fakeMessenger{chats: []KnownRecipient{{Platform: "telegram", ChatID: "42"}}}
+	SetMessenger(fm)
+	defer SetMessenger(nil)
+
+	out, err := SendFileTool{}.Execute(context.Background(), "send_file", map[string]any{"path": p})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(fm.sentFiles) != 0 {
+		t.Fatal("must not send without a target")
+	}
+	if !strings.Contains(out.Text, "telegram") || !strings.Contains(out.Text, "42") {
+		t.Fatalf("expected discovery listing, got %q", out.Text)
 	}
 }
 

--- a/internal/tools/send_message.go
+++ b/internal/tools/send_message.go
@@ -28,6 +28,9 @@ type ChannelMessenger interface {
 	// SendMessage delivers text to chatID on platform, preferring a live
 	// adapter and falling back to a one-shot send from config.
 	SendMessage(platform, chatID, text string) error
+	// SendFile delivers a local file to chatID on platform, same live-adapter-
+	// then-one-shot fallback as SendMessage.
+	SendFile(platform, chatID, path, name string) error
 	// KnownChats lists the recipients the bot can currently address.
 	KnownChats() []KnownRecipient
 }
@@ -97,7 +100,7 @@ func (SendMessageTool) Execute(ctx context.Context, _ string, input map[string]a
 		if chatID == "" && text != "" && len(chats) == 1 {
 			return doSend(m, chats[0].Platform, chats[0].ChatID, text)
 		}
-		return listRecipients(chats, platform, text)
+		return listRecipients(chats, platform)
 	}
 
 	if platform == "" {
@@ -129,9 +132,9 @@ func filterRecipients(all []KnownRecipient, platform string) []KnownRecipient {
 }
 
 // listRecipients returns a model-readable roster of reachable chats. It is a
-// normal (non-error) result: the model reads it and calls send_message again
-// with a concrete chat_id.
-func listRecipients(chats []KnownRecipient, platform, text string) (agent.ToolResult, error) {
+// normal (non-error) result: the model reads it and calls the tool again with a
+// concrete platform + chat_id. Shared by send_message and send_file.
+func listRecipients(chats []KnownRecipient, platform string) (agent.ToolResult, error) {
 	if len(chats) == 0 {
 		scope := "any platform"
 		if platform != "" {
@@ -143,7 +146,7 @@ func listRecipients(chats []KnownRecipient, platform, text string) (agent.ToolRe
 		}, nil
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "Reachable chats (%d) — call send_message again with the chosen platform and chat_id:\n", len(chats))
+	fmt.Fprintf(&b, "Reachable chats (%d) — call again with the chosen platform and chat_id:\n", len(chats))
 	for _, r := range chats {
 		b.WriteString("  - platform=")
 		b.WriteString(r.Platform)
@@ -155,9 +158,6 @@ func listRecipients(chats []KnownRecipient, platform, text string) (agent.ToolRe
 			b.WriteString(")")
 		}
 		b.WriteString("\n")
-	}
-	if text != "" {
-		b.WriteString("\nThen resend with text set to your message.")
 	}
 	return agent.ToolResult{Text: strings.TrimRight(b.String(), "\n")}, nil
 }

--- a/internal/tools/send_message_test.go
+++ b/internal/tools/send_message_test.go
@@ -7,11 +7,13 @@ import (
 )
 
 type sentMsg struct{ platform, chatID, text string }
+type sentFile struct{ platform, chatID, path, name string }
 
 type fakeMessenger struct {
-	chats []KnownRecipient
-	sent  []sentMsg
-	err   error
+	chats     []KnownRecipient
+	sent      []sentMsg
+	sentFiles []sentFile
+	err       error
 }
 
 func (f *fakeMessenger) SendMessage(platform, chatID, text string) error {
@@ -19,6 +21,14 @@ func (f *fakeMessenger) SendMessage(platform, chatID, text string) error {
 		return f.err
 	}
 	f.sent = append(f.sent, sentMsg{platform, chatID, text})
+	return nil
+}
+
+func (f *fakeMessenger) SendFile(platform, chatID, path, name string) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.sentFiles = append(f.sentFiles, sentFile{platform, chatID, path, name})
 	return nil
 }
 


### PR DESCRIPTION
Follow-up to #1031. `send_file` was IM-only and hard-bound to the *current* chat, so a web (or sub-agent) turn could not push a generated file to, say, the user's WeChat. This unifies its recipient model with `send_message`.

## Behavior
`send_file` now has two modes:
- **Current chat (unchanged):** on an IM turn, omit `platform`/`chat_id` → the file goes to the chat you're talking to (turn-scoped `ChannelFileSender`).
- **Any chat (new):** pass `platform` + `chat_id` → routes through the process-global `ChannelMessenger` to any reachable chat. Pass just `platform` (or nothing) on a web turn → returns the discoverable chat list, same as `send_message`. A single candidate on a platform auto-targets.

## Wiring
- `ChannelMessenger` gains `SendFile`; server implements it via new `channelSendFile` (live adapter → `channel.SendFileOnce` fallback), mirroring `channelSend`.
- Advertised in `DefaultToolsFor` whenever a messenger is registered (i.e. the server) → available on **both web and IM**; hidden in CLI/TUI. Dropped the per-IM-turn manual append; kept `WithChannelSender` for the current-chat default.
- Shared `listRecipients` helper between the two tools.

## Availability after this PR
| tool | CLI/TUI | Web | IM |
|---|---|---|---|
| `send_message` | ❌ | ✅ | ✅ |
| `send_file` | ❌ | ✅ | ✅ |

## Tests
Cross-chat send, single-candidate auto-target, ambiguous listing, web no-target discovery, and gating (hidden without messenger, shown with). `go build`, `go vet`, gofmt, and `-race` on the send tools pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
