### PR TITLE
feat(browser): surface recorded skills in the L1 manifest (composable skills B)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -578,7 +578,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// into the frozen system prompt (L1); the registry backs the `skill` tool so
 	// it can serve full bodies on demand (L2).
 	skillReg := skills.Discover(cwd)
-	skillsManifest := skills.RenderManifest(skillReg)
+	skillsManifest := tools.SkillsManifest(skillReg)
 	tools.SetSkills(skillReg)
 
 	// Cross-session memory (Claude Code model): a per-repo directory of markdown

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -389,6 +391,30 @@ func LoadSkill(path string) (Skill, error) {
 		return Skill{}, err
 	}
 	return ParseSkill(data)
+}
+
+// ListSkills reads every *.yaml recording in dir and returns them sorted by
+// name. A missing dir yields nil; an unreadable or unparseable file (a
+// half-written or hand-broken skill) is skipped rather than sinking the whole
+// list — this feeds the system-prompt manifest, which must stay robust.
+func ListSkills(dir string) []Skill {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var out []Skill
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		s, err := LoadSkill(filepath.Join(dir, e.Name()))
+		if err != nil || s.Name == "" {
+			continue
+		}
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
 }
 
 // DigestElement is one interactive element: its visible text and a generated

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -864,6 +864,35 @@ func TestRunStepDownloadExtractGuards(t *testing.T) {
 	}
 }
 
+// TestListSkills: reads *.yaml recordings sorted by name, skipping a nameless
+// skill and non-yaml files; a missing dir yields nil.
+func TestListSkills(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveSkill(dir+"/bravo.yaml", Skill{Name: "bravo", Steps: []Step{{Action: "navigate", URL: "x"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveSkill(dir+"/alpha.yaml", Skill{Name: "alpha", Steps: []Step{{Action: "navigate", URL: "x"}}}); err != nil {
+		t.Fatal(err)
+	}
+	// A parseable YAML with no name (skipped) and a non-yaml file (ignored).
+	if err := os.WriteFile(dir+"/noname.yaml", []byte("description: has no name\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+"/notes.txt", []byte("ignore me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := ListSkills(dir)
+	if len(got) != 2 {
+		t.Fatalf("want 2 skills (nameless + non-yaml skipped), got %d: %+v", len(got), got)
+	}
+	if got[0].Name != "alpha" || got[1].Name != "bravo" {
+		t.Fatalf("want sorted [alpha bravo], got [%s %s]", got[0].Name, got[1].Name)
+	}
+	if ListSkills(dir+"/nope") != nil {
+		t.Fatal("missing dir should yield nil")
+	}
+}
+
 // TestReplaySkillDownloadNoDoubleBindOnHeal: a download step whose Verify fails
 // first, then passes after a heal, must bind the file exactly once — recoverStep
 // re-runs the whole step, so binding before Verify would double-count the output.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -17,7 +17,6 @@ import (
 	"github.com/open-octo/octo-agent/internal/app"
 	"github.com/open-octo/octo-agent/internal/config"
 	"github.com/open-octo/octo-agent/internal/permission"
-	"github.com/open-octo/octo-agent/internal/skills"
 	"github.com/open-octo/octo-agent/internal/tasks"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
@@ -666,7 +665,7 @@ func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
 	s.skillReg.Reload()
 	// Refresh the manifest for sessions built after this point, same as the
 	// toggle/delete handlers do.
-	s.setSkillsManifest(skills.RenderManifest(s.skillReg))
+	s.setSkillsManifest(tools.SkillsManifest(s.skillReg))
 	list := s.skillReg.All()
 	out := make([]skillInfo, 0, len(list))
 	for _, sk := range list {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -324,7 +324,7 @@ func New(cfg Config) (*Server, error) {
 	skillReg := skills.Discover(cwd)
 	fileCfg, _ := config.Load()
 	skillReg.SetDisabled(fileCfg.Tools.DisabledSkills)
-	skillsManifest := skills.RenderManifest(skillReg)
+	skillsManifest := tools.SkillsManifest(skillReg)
 	tools.SetSkills(skillReg)
 
 	accessKey, generatedKey := resolveAccessKey(cfg.AccessKey, fileCfg)

--- a/internal/server/skill_import_handler.go
+++ b/internal/server/skill_import_handler.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/open-octo/octo-agent/internal/skills"
+	"github.com/open-octo/octo-agent/internal/tools"
 )
 
 // ─── POST /api/skills/import ────────────────────────────────────────────────
@@ -52,7 +53,7 @@ func (s *Server) handleImportSkill(w http.ResponseWriter, r *http.Request) {
 	// Refresh the registry and manifest so the list — and new sessions — see
 	// the skill immediately (same pattern as toggle/delete).
 	s.skillReg.Reload()
-	s.setSkillsManifest(skills.RenderManifest(s.skillReg))
+	s.setSkillsManifest(tools.SkillsManifest(s.skillReg))
 
 	writeJSON(w, http.StatusOK, map[string]any{"name": name, "description": desc})
 }

--- a/internal/server/skill_toggle_handler.go
+++ b/internal/server/skill_toggle_handler.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/open-octo/octo-agent/internal/config"
-	"github.com/open-octo/octo-agent/internal/skills"
+	"github.com/open-octo/octo-agent/internal/tools"
 )
 
 // ─── PATCH /api/skills/{name}/toggle ────────────────────────────────────────
@@ -67,7 +67,7 @@ func (s *Server) handleToggleSkill(w http.ResponseWriter, r *http.Request) {
 
 	// Update in-memory state so new sessions see the change immediately.
 	s.skillReg.SetDisabled(cfg.Tools.DisabledSkills)
-	s.setSkillsManifest(skills.RenderManifest(s.skillReg))
+	s.setSkillsManifest(tools.SkillsManifest(s.skillReg))
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"name":    name,
@@ -103,7 +103,7 @@ func (s *Server) handleDeleteSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update in-memory manifest so new sessions see the change immediately.
-	s.setSkillsManifest(skills.RenderManifest(s.skillReg))
+	s.setSkillsManifest(tools.SkillsManifest(s.skillReg))
 
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": name})
 }

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -101,6 +101,50 @@ func BrowserSkillsDir() string {
 	return filepath.Join(home, ".octo", "browser-skills")
 }
 
+// RenderBrowserSkillsManifest lists recorded browser skills for the L1 system-
+// prompt manifest, so the model can discover and replay them in a normal
+// conversation instead of the user having to name one explicitly. Returns "" when
+// there are none. Unlike SKILL.md skills, these are replayed via the browser tool
+// (run_skill), not loaded via the skill tool — the note says so.
+func RenderBrowserSkillsManifest() string {
+	list := browser.ListSkills(BrowserSkillsDir())
+	if len(list) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("# Browser recordings\n\n")
+	b.WriteString("Recorded browser workflows. Replay one with the `browser` tool " +
+		"(action=run_skill, name=<name>, params as declared); it returns the skill's " +
+		"declared outputs (downloaded files, extracted values) as JSON. These are " +
+		"replayed, not loaded via the `skill` tool.\n\n")
+	for _, s := range list {
+		fmt.Fprintf(&b, "- %s", s.Name)
+		if s.Description != "" {
+			fmt.Fprintf(&b, ": %s", s.Description)
+		}
+		if len(s.Params) > 0 {
+			names := make([]string, len(s.Params))
+			for i, p := range s.Params {
+				names[i] = p.Name
+			}
+			fmt.Fprintf(&b, " [params: %s]", strings.Join(names, ", "))
+		}
+		if len(s.Outputs) > 0 {
+			outs := make([]string, len(s.Outputs))
+			for i, o := range s.Outputs {
+				if o.Type != "" {
+					outs[i] = fmt.Sprintf("%s (%s)", o.Name, o.Type)
+				} else {
+					outs[i] = o.Name
+				}
+			}
+			fmt.Fprintf(&b, " [outputs: %s]", strings.Join(outs, ", "))
+		}
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
 // ResetBrowserSession closes and clears the active browser session.
 func ResetBrowserSession() {
 	browserSession.mu.Lock()

--- a/internal/tools/browser_manifest_test.go
+++ b/internal/tools/browser_manifest_test.go
@@ -1,0 +1,56 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/browser"
+)
+
+// TestRenderBrowserSkillsManifest: an empty recordings dir renders nothing; a
+// recording renders its name, description, params, and outputs plus the run_skill
+// invocation note.
+func TestRenderBrowserSkillsManifest(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OCTO_BROWSER_SKILLS_DIR", dir)
+
+	if m := RenderBrowserSkillsManifest(); m != "" {
+		t.Fatalf("empty dir should render empty, got %q", m)
+	}
+
+	if err := browser.SaveSkill(dir+"/download-excels.yaml", browser.Skill{
+		Name:        "download-excels",
+		Description: "download the monthly reports",
+		Params:      []browser.Param{{Name: "month"}},
+		Outputs:     []browser.Output{{Name: "files", Type: "file[]"}},
+		Steps:       []browser.Step{{Action: "navigate", URL: "x"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m := RenderBrowserSkillsManifest()
+	for _, want := range []string{
+		"# Browser recordings", "run_skill", "download-excels",
+		"download the monthly reports", "[params: month]", "[outputs: files (file[])]",
+	} {
+		if !strings.Contains(m, want) {
+			t.Fatalf("manifest missing %q:\n%s", want, m)
+		}
+	}
+}
+
+// TestSkillsManifestIncludesBrowserRecordings: the combiner appends the browser
+// section even when there are no SKILL.md skills (a nil registry renders "").
+func TestSkillsManifestIncludesBrowserRecordings(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OCTO_BROWSER_SKILLS_DIR", dir)
+	if err := browser.SaveSkill(dir+"/dl.yaml", browser.Skill{
+		Name:  "dl",
+		Steps: []browser.Step{{Action: "navigate", URL: "x"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m := SkillsManifest(nil)
+	if !strings.Contains(m, "# Browser recordings") || !strings.Contains(m, "- dl") {
+		t.Fatalf("SkillsManifest should include browser recordings with a nil registry:\n%s", m)
+	}
+}

--- a/internal/tools/browser_manifest_test.go
+++ b/internal/tools/browser_manifest_test.go
@@ -27,14 +27,27 @@ func TestRenderBrowserSkillsManifest(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	// A second recording whose output declares no type — it should render as a
+	// bare name (no parens), exercising the type-less branch.
+	if err := browser.SaveSkill(dir+"/grab-id.yaml", browser.Skill{
+		Name:    "grab-id",
+		Outputs: []browser.Output{{Name: "raw"}},
+		Steps:   []browser.Step{{Action: "navigate", URL: "x"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
 	m := RenderBrowserSkillsManifest()
 	for _, want := range []string{
 		"# Browser recordings", "run_skill", "download-excels",
 		"download the monthly reports", "[params: month]", "[outputs: files (file[])]",
+		"grab-id", "[outputs: raw]",
 	} {
 		if !strings.Contains(m, want) {
 			t.Fatalf("manifest missing %q:\n%s", want, m)
 		}
+	}
+	if strings.Contains(m, "raw (") {
+		t.Fatalf("type-less output must render as a bare name, got:\n%s", m)
 	}
 }
 

--- a/internal/tools/skill.go
+++ b/internal/tools/skill.go
@@ -18,6 +18,23 @@ var activeSkills *skills.Registry
 // start. Pass nil (or an empty registry) to disable.
 func SetSkills(r *skills.Registry) { activeSkills = r }
 
+// SkillsManifest is the full L1 skills section for the system prompt: the
+// SKILL.md skills (skills.RenderManifest) plus recorded browser skills
+// (RenderBrowserSkillsManifest). Every caller uses this instead of
+// skills.RenderManifest directly so browser recordings are always discoverable
+// and never drop out when the manifest is rebuilt (e.g. on a server-side skill
+// toggle/import). Returns "" when both are empty.
+func SkillsManifest(r *skills.Registry) string {
+	m := skills.RenderManifest(r)
+	if b := RenderBrowserSkillsManifest(); b != "" {
+		if m != "" {
+			m += "\n\n"
+		}
+		m += b
+	}
+	return m
+}
+
 // skillsEnabled reports whether any skill was discovered — the gate for both
 // advertising and dispatching the skill tool.
 func skillsEnabled() bool { return activeSkills != nil && activeSkills.Len() > 0 }


### PR DESCRIPTION
Layer **B (catalog)** of the composable-skills design (`dev-docs/composable-skills-design.md`). Builds on Layer A (#1032). Makes recorded browser skills **discoverable in a normal conversation** — the model sees them in the system-prompt manifest and can pick/replay one without the user naming it.

## What changed

- **`browser.ListSkills(dir)`** — reads every `*.yaml` recording, sorted by name; skips nameless / non-yaml / unparseable files (the manifest must stay robust to a half-written skill); missing dir → nil.
- **`tools.RenderBrowserSkillsManifest()`** — renders an L1 `# Browser recordings` section: each recording's name, description, `[params: …]`, `[outputs: … (type)]`, plus a note that these are replayed via the `browser` tool (`run_skill`), **not** loaded via the `skill` tool.
- **`tools.SkillsManifest(reg)`** — the single combiner (SKILL.md skills + browser recordings). All six manifest call sites route through it: CLI (`chat.go`), server initial build (`server.go`), and the four server refresh handlers (skill import/toggle). This is why it's a combiner and not an append-in-one-place: `server.go` builds the manifest directly into the struct while the handlers go through `setSkillsManifest`, so a single choke point doesn't exist — routing every site through `SkillsManifest` guarantees recordings never drop out when the manifest is rebuilt on a skill toggle/import.

## Layering

`skills` gains no import of `browser`/`tools` (no cycle). The combining lives in `tools`, which already imports both `skills` and `browser`.

## Tests

- `browser.TestListSkills` — sorting + skip rules (nameless, non-yaml, missing dir).
- `tools.TestRenderBrowserSkillsManifest` — empty dir → "", populated → name/desc/params/outputs/note.
- `tools.TestSkillsManifestIncludesBrowserRecordings` — browser section present even with a nil/empty skills registry.
- `go test -race ./internal/browser/ ./internal/tools/ ./internal/server/` green; `vet` + `gofmt` clean.

Next: Layer C (`skill()` workflow primitive) — separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)