### PR TITLE
feat(skills): workflow-builder default skill (composable skills — guidance layer)

### DIFF
--- a/dev-docs/composable-skills-design.md
+++ b/dev-docs/composable-skills-design.md
@@ -119,17 +119,16 @@ func ReplaySkill(...) (modified bool, finalPage *Page, outputs map[string]any, e
 
 `ToolResult.UI` 富卡片**不做**(可选的后续增强):browser 工具其它 action 也都不出卡片,纯 JSON text 在 tool-result 区块本就可读,组合能力不依赖它。只有当 run_skill 成为"用户会长时间盯着看 outputs"的高频交互面时,再据实加一个列出产物的卡片(有 `uiHead`/`uiTail` helper,`project_tool_ui_payload`)。
 
-### A.4 普通技能:outputs 可选,CC 全兼容
+### A.4 普通技能:结构化输出靠调用点 schema,CC 全兼容
 
-SKILL.md 这侧**不加任何必填字段**——库存的 Claude Code 技能拿过来即插即用。它的结构化输出走 `workflow` 里 `agent(prompt, schema:)` 已有的 StructuredOutput 机制,而 schema **可选、且首选放在调用点**,skill 文件一个字不改:
+SKILL.md 这侧**不加任何必填字段**——库存的 Claude Code 技能即插即用。它的结构化输出走 `workflow` 里 `agent(prompt, schema:)` 已有的 StructuredOutput 机制,schema 放在**调用点**:
 
 1. **无 schema** —— 照跑,返回子 agent 的最终文本(`string`)。等价于 `agent()` 不带 schema。
-2. **调用点带 schema**(首选) —— `skill(name, params, {schema})` 起子 agent 时强制该 schema,返回校验过的对象。skill 文件保持纯 CC 形态,由 workflow 作者决定自己要的返回形状。
-3. **frontmatter 声明 outputs**(可选增强) —— octo 里自写的技能愿意的话可在 frontmatter 加 `outputs` schema 当默认,调用点就不用每次带。它是**额外 key,CC 解析时忽略**,所以带了它的技能仍能原样搬回 Claude Code。
+2. **调用点带 schema**(结构化的唯一途径) —— `skill(name, params, {schema})` 起子 agent 时强制该 schema,返回校验过的对象;skill 文件保持纯 CC 形态,由 workflow 作者(或 `workflow-builder`)推断并提议返回形状。
 
-优先级:**调用点 schema > frontmatter outputs > 无(返回文本)**。这不是新机制,就是 `agent(prompt, {schema})` 的那套。
+> **frontmatter 声明 outputs 未实现**:`skills.Skill` 没有 outputs 字段,`RenderManifest` 也不渲染它——所以 MD 技能的产出形状**不出现在系统提示里**。曾设想把它当"可选增强"(额外 key、CC 忽略),但至今没做;要结构化交接就在调用点带 schema。
 
-这带来一处与录制的**声明位置不对称**(对调用方透明):YAML 录制的 outputs 只能写在文件里(`download` 步的 `bind` 是引擎结构性绑定,没有"调用点 schema"能替代);MD 技能的 outputs 首选调用点、frontmatter 声明是锦上添花。两个引擎因此在"声明位置"不同,但对 `skill()` 的调用者行为一致、可预期。
+这带来一处与录制的**非对称**(对调用方透明):录制的 outputs 是引擎结构性绑定、且进 L1 清单可被发现;MD 技能没有 declared outputs,清单里只有名字 + 描述,结构化只能靠调用点 schema。`skill()` 的调用者行为仍一致可预期,但"看清一个技能的输出形状"这件事——录制强(清单直给)、MD 弱(靠推断 + 调用点 schema)。这正是 `workflow-builder`(D 层)接线步骤区别对待两类技能的原因。
 
 ### 验证 / 兼容
 

--- a/dev-docs/workflow-builder-design.md
+++ b/dev-docs/workflow-builder-design.md
@@ -26,7 +26,7 @@
    - **上游是 SKILL.md**:清单没有它的 outputs,模型只能从其**描述 / 正文推断**产出形状,并为该步**提议一个调用点 `schema`**(见 A.4:MD 的结构化输出靠调用点 schema),把推断出的形状交用户确认。这一档是"模型提议、人确认",比录制弱——不要伪装成清单驱动。
 3. **生成 Ruby** —— 用 `skill()` 串起来(**产物是 Ruby / mruby,不是 JS**:`skill("name", {"k"=>v}, schema: '…')`、`args["…"]` 读入参),给用户过目。few-shot 例子必须是 Ruby,别继承上游文档里的 JS 写法。
 4. **干跑校验(异步,要轮询)** —— `workflow` 工具是**后台执行**:调用返回一个 run id,得 `workflow_status(id)` 轮询到 done 才能判定接线通不通(设个轮询上限,别未完就报成功)。**且干跑会真的执行**:链里含录制,就会在**授权当下**驱动 Chrome——所以要么先要求接上 Chrome(端口 9222),要么只干跑 MD 尾段(用手喂的样例 `files`),录制那步单独用 `run_skill` 验证。
-5. **保存 + 指路** —— `workflow_save`(`name` / `scope`)。注意 `scope` 默认 `project` 且**不在 git 仓库里会报"no project root"**——所以先问/判断:仓库内用 `project`,否则用 `user`(`~/.octo/workflows`,跨项目可用)。存好后告诉用户三种跑法:会话点名调、CLI 点名、或用 `schedule` / `cron-task-creator` 配定时。
+5. **保存 + 指路** —— `workflow_save`(`name` / `scope`)。注意 `scope` 默认 `project` 且**不在 git 仓库里会报"no project root"**——所以先问/判断:仓库内用 `project`,否则用 `user`(`~/.octo/workflows`,跨项目可用)。存好后告诉用户三种跑法:会话点名调、CLI 点名、或用 `cron-task-creator` 配定时。
 6. **讲清约束** —— 含录制的 workflow 在 run / cron 时也需要活的 Chrome(headless 环境明确报错);MD 技能要可靠结构化交接就靠调用点 `schema`(第 2 步已提议)。
 
 ### 为什么"接线"是重点

--- a/dev-docs/workflow-builder-design.md
+++ b/dev-docs/workflow-builder-design.md
@@ -4,7 +4,9 @@
 
 可组合技能三层(见 `composable-skills-design.md`)修通了管道:录制声明 `outputs`、进 L1 清单可被发现、`skill()` 原语把录制 + SKILL.md 串成一条可 resume/定时/并行的 workflow。但还差交互的一层——**用户怎么造出那条 workflow**。
 
-关键判断:**不需要用户手写 mruby。** B 已把所有技能(名字 / params / outputs)暴露进系统提示,所以模型本就能按一句自然语言描述生成脚本并 `workflow_save`。缺的不是能力,是**可靠性**(模型每次都把接线、干跑、保存做全)和**触发点**(用户知道有这条路、且能唤起它)。
+关键判断:**不需要用户手写 mruby。** 模型本就能按一句自然语言描述生成脚本并 `workflow_save`。缺的不是能力,是**可靠性**(模型每次都把接线、干跑、保存做全)和**触发点**(用户知道有这条路、且能唤起它)。
+
+一个必须诚实面对的**非对称**:B 只把**浏览器录制**的 `params`/`outputs` 渲染进了系统提示(`RenderBrowserSkillsManifest`);**SKILL.md 技能在清单里只有 名字 + 描述**(`skills.RenderManifest` 不含 params/outputs——A.4 设想的 frontmatter outputs 目前未实现,`skills.Skill` 连字段都没有)。所以"看清一个技能的输出形状"这件事,录制是清单直给,MD 技能得靠**描述推断 + 调用点 schema**。这直接影响下面第 2 步的措辞,不能含糊。
 
 本方案加一个 `workflow-builder` 默认技能,对齐 octo 既有的"创建类技能"套路(`mcp-creator` / `skill-creator` / `web-artifacts-builder`),把授权流程固化成一段对话脚本。**纯 SKILL.md,不加任何核心代码或新工具**——复用已有的 `skill()` 原语、`workflow_save`、`workflow` 工具。
 
@@ -14,18 +16,22 @@
 
 一个默认技能 `internal/skills/defaults/workflow-builder/SKILL.md`,`go:embed` 进二进制、materialize 到 `~/.octo/skills-default`,和其它默认技能一样进 L1 清单。触发词:「串个流程 / 把这几个技能连起来 / 做个 workflow / 编排一下 / build a workflow」。
 
+**与 `skill-creator` 划清边界**(两者描述相邻,易误触):workflow-builder = 把**已有的**技能/录制**串成一条可运行的 saved workflow**;skill-creator = **写一个新的 SKILL.md**。两边描述都加上明确的 should-NOT-trigger 提示(builder 不写新技能;skill-creator 不做编排),降低误触/双触。
+
 ### 授权流程(SKILL.md 教模型走的步骤)
 
-1. **盘点可用技能** —— 从系统提示的 `# Available skills`(SKILL.md 技能)和 `# Browser recordings`(录制)两段读候选,把名字、`params`、`outputs` 摆给用户,问要串哪几个、什么顺序。*(依赖 B。)*
-2. **确认接线** —— 这是本技能的核心价值:模型**提议** step_i 的 `outputs` 如何喂 step_{i+1} 的 `params`(如 `dl["files"] → merge 的 inputs`),请用户确认或修正,而不是让用户自己在脑子里拼。*(依赖 A 的 `outputs` 声明。)*
-3. **生成 Ruby** —— 用 `skill()` 串起来,输入走 `args` 原语参数化(便于复用与定时),把脚本给用户过目。
-4. **干跑校验** —— 先用 `workflow` 工具跑一次(必要时用小样例)验证接线真能跑通;失败按报错修再跑。
-5. **保存 + 指路** —— `workflow_save`(`name` / `scope`),然后告诉用户三种跑法:会话里点名调、CLI 点名、或用 `schedule` / `cron-task-creator` 配定时。
-6. **讲清约束** —— 含浏览器录制的 workflow 需要一个**活的 Chrome**(headless / cron 环境里会明确报错);MD 技能要可靠的结构化交接,就在调用点带 `schema`(见 `composable-skills-design.md` A.4)。
+1. **盘点可用技能** —— 从系统提示的 `# Available skills`(SKILL.md 技能)和 `# Browser recordings`(录制)两段读候选,摆给用户,问要串哪几个、什么顺序。**顺带查重名**:一个名字若同时是录制和 MD 技能,C 的派发会报歧义错——这里就提示用户,并在生成脚本时用 `browser:` / `md:` 前缀消歧。
+2. **确认接线**(核心价值,但两类技能强度不同,如实说)——
+   - **上游是录制**:清单直给 `outputs`,模型据此提议 `step_i.outputs → step_{i+1}.params` 的映射(如 `dl["files"] → merge 的 inputs`),用户确认/修正。这一档是清单驱动、可靠。
+   - **上游是 SKILL.md**:清单没有它的 outputs,模型只能从其**描述 / 正文推断**产出形状,并为该步**提议一个调用点 `schema`**(见 A.4:MD 的结构化输出靠调用点 schema),把推断出的形状交用户确认。这一档是"模型提议、人确认",比录制弱——不要伪装成清单驱动。
+3. **生成 Ruby** —— 用 `skill()` 串起来(**产物是 Ruby / mruby,不是 JS**:`skill("name", {"k"=>v}, schema: '…')`、`args["…"]` 读入参),给用户过目。few-shot 例子必须是 Ruby,别继承上游文档里的 JS 写法。
+4. **干跑校验(异步,要轮询)** —— `workflow` 工具是**后台执行**:调用返回一个 run id,得 `workflow_status(id)` 轮询到 done 才能判定接线通不通(设个轮询上限,别未完就报成功)。**且干跑会真的执行**:链里含录制,就会在**授权当下**驱动 Chrome——所以要么先要求接上 Chrome(端口 9222),要么只干跑 MD 尾段(用手喂的样例 `files`),录制那步单独用 `run_skill` 验证。
+5. **保存 + 指路** —— `workflow_save`(`name` / `scope`)。注意 `scope` 默认 `project` 且**不在 git 仓库里会报"no project root"**——所以先问/判断:仓库内用 `project`,否则用 `user`(`~/.octo/workflows`,跨项目可用)。存好后告诉用户三种跑法:会话点名调、CLI 点名、或用 `schedule` / `cron-task-creator` 配定时。
+6. **讲清约束** —— 含录制的 workflow 在 run / cron 时也需要活的 Chrome(headless 环境明确报错);MD 技能要可靠结构化交接就靠调用点 `schema`(第 2 步已提议)。
 
 ### 为什么"接线"是重点
 
-第 2 步是把"两个技能怎么拼"从**用户脑内的隐性知识**变成**模型提议 + 用户确认的显式步骤**。它之所以能成立,正是因为 A 让每个技能声明了 `outputs`、B 把这些契约暴露在了系统提示里——三层在这一步合拢,builder 只是把它们用起来。
+第 2 步是把"两个技能怎么拼"从**用户脑内的隐性知识**变成**模型提议 + 用户确认的显式步骤**。对**录制**它是清单驱动的(A 声明 outputs、B 暴露契约,三层合拢);对 **MD 技能**它退化为"模型据描述推断 + 提议调用点 schema、人确认"——仍比让用户空想强,但强度不同,builder 的措辞和 few-shot 要如实区分两者,别对 MD 步骤假装有 outputs 可读。
 
 ## 不做的
 
@@ -50,4 +56,6 @@
 
 ## 落地
 
-单个 PR:新增 `internal/skills/defaults/workflow-builder/SKILL.md` + 一条 `defaults_test` 断言。属于可组合技能特性的引导层(D),独立于 A/B/C 的管道实现。
+前置:A(#1032)、B(#1038)、C(#1041)均已合入——`skill()` 原语、录制 outputs、清单发现都在,builder 是它们之上的引导层(D)。单个 PR:新增 `internal/skills/defaults/workflow-builder/SKILL.md` + 收紧 `skill-creator` 描述边界 + 一条 `defaults_test` 断言。
+
+已一并订正:`composable-skills-design.md` A.4 原把"MD frontmatter outputs"写成可选增强,但 `skills.Skill` 无该字段、`RenderManifest` 也不渲染——已改为"MD 结构化输出仅靠调用点 schema;frontmatter outputs 未实现"。

--- a/internal/skills/defaults/skill-creator/SKILL.md
+++ b/internal/skills/defaults/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Create new skills, modify existing skills, and help users turn repeatable workflows into reusable instructions. Use when the user wants to create a skill from scratch, edit or improve an existing skill, capture a workflow as a skill, or optimize a skill's description for better triggering accuracy.
+description: Create new skills, modify existing skills, and help users turn repeatable workflows into reusable instructions. Use when the user wants to create a skill from scratch, edit or improve an existing skill, capture a workflow as a skill, or optimize a skill's description for better triggering accuracy. Do NOT use to chain or orchestrate several EXISTING skills/recordings into a runnable saved workflow — that is workflow-builder.
 ---
 
 # Skill Creator

--- a/internal/skills/defaults/workflow-builder/SKILL.md
+++ b/internal/skills/defaults/workflow-builder/SKILL.md
@@ -88,7 +88,7 @@ projects). Ask the user if it's unclear. Confirm the name with them first.
 Then tell them the three ways to run it:
 - **In chat** — ask to run the workflow by name (passing `args`).
 - **CLI / headless** — run it by name.
-- **On a schedule** — use the `schedule` skill (or `cron-task-creator`).
+- **On a schedule** — use the `cron-task-creator` skill.
 
 ### 6. State the constraints
 - A workflow that includes a browser recording needs a live Chrome **every time

--- a/internal/skills/defaults/workflow-builder/SKILL.md
+++ b/internal/skills/defaults/workflow-builder/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: workflow-builder
+description: Chain existing skills and browser recordings into a runnable, reusable saved workflow through guided conversation — inventory the available skills, wire each one's output into the next's input, generate the Ruby workflow, dry-run it, and save it with workflow_save. Use when the user wants to combine / chain / orchestrate several EXISTING skills or recordings into one repeatable flow, e.g. "chain these skills", "把这几个技能连起来", "串个流程", "做个 workflow", "编排一下", "build a workflow". Do NOT use to author a single new skill (that is skill-creator) or to run one skill a single time (just call it).
+---
+
+# Build a saved workflow from existing skills
+
+A **saved workflow** is a small Ruby (mruby) script that calls existing skills in
+order, passing each one's outputs to the next, and reruns on demand or on a
+schedule. Your job is to guide the user from "chain these" to a saved, validated
+workflow. You are *composing skills that already exist* — you are not writing a
+new skill or new code.
+
+## The pieces you use
+
+- `skill(name, params = {}, opts = {})` — the workflow primitive: runs one skill
+  and returns its outputs as a Ruby `Hash`. A **browser recording** replays
+  deterministically; a **SKILL.md skill** runs as a sub-agent. `opts[:schema]`
+  (a JSON-schema string) makes a SKILL.md step return structured output.
+- `args` — the workflow's input, a Ruby `Hash`, so the saved workflow is
+  parameterizable and reusable.
+- `parallel` / `pipeline` — for fan-out or staged flows.
+- The `workflow` tool — runs a script (in the **background**: returns a run id).
+- `workflow_save` — persists the script as a named workflow.
+
+## Steps
+
+### 1. Inventory what's available
+Read the system prompt's `# Available skills` (SKILL.md skills) and
+`# Browser recordings` (recordings) sections. List the candidates relevant to the
+user's goal — with their params, and, for recordings, their outputs — and ask
+which ones, in what order.
+
+Check for a **name collision**: if one name is *both* a recording and a SKILL.md
+skill, `skill("that-name")` fails as ambiguous. Flag it and disambiguate with a
+`browser:` or `md:` prefix (e.g. `skill("browser:export")`).
+
+### 2. Wire outputs → inputs (the important step)
+For each adjacent pair, propose how the earlier step's output feeds the next
+step's params, then have the user confirm *before* you generate anything. Be
+honest that the two skill types give you different amounts to work with:
+
+- **Upstream is a browser recording** — its `outputs` are in the manifest
+  (`[outputs: files (file[])]`). Wire directly, e.g. `dl["files"]` → the next
+  step's `inputs`. This is manifest-driven and reliable.
+- **Upstream is a SKILL.md skill** — the manifest does **not** list its outputs.
+  Infer the likely output shape from the skill's description/body and **propose a
+  call-site `schema`** for that step so its reply comes back structured. Show the
+  user the shape you assumed and ask them to confirm or fix it. You are
+  proposing, not reading a declared contract — don't present it as certain.
+
+### 3. Generate the Ruby workflow
+The script is **Ruby (mruby), not JavaScript**. Read inputs via `args`. Show it
+to the user before running. Shape:
+
+```ruby
+# invoked as: workflow name=monthly-report, args={ "month" => "2026-06" }
+dl  = skill("download-excels", { "month" => args["month"] })        # recording → {"files"=>[...]}
+tbl = skill("merge-excels", { "inputs" => dl["files"] },            # SKILL.md, proposed schema
+            schema: '{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}')
+ppt = skill("excels-to-ppt", { "table" => tbl["path"] })            # SKILL.md
+ppt                                                                 # last expression = the result
+```
+
+A failed `skill()` raises and halts the run, so you don't have to check each
+result for errors.
+
+### 4. Dry-run to validate the wiring — it is asynchronous
+The `workflow` tool runs in the **background**: it returns a run id, and you must
+poll `workflow_status(id)` until the run reports done before judging it. Don't
+declare success before results land; cap how many times you poll.
+
+A dry-run **actually executes** the steps, and a browser recording drives a real
+Chrome *right now*. So if the chain contains a recording:
+- confirm Chrome is attached (port 9222) before dry-running, **or**
+- validate only the SKILL.md tail by hand-feeding a sample value for the
+  recording's output (e.g. pass a couple of file paths as `inputs`), and validate
+  the recording itself separately with the `browser` tool's `run_skill`.
+
+Fix any wiring error and re-run before saving.
+
+### 5. Save it and show how to run it
+Call `workflow_save(name, script, description, scope)`. `scope` defaults to
+`project` (`.octo/workflows`) and **errors when you're not inside a git repo** —
+if there's no repo, use `scope: "user"` (`~/.octo/workflows`, available across
+projects). Ask the user if it's unclear. Confirm the name with them first.
+
+Then tell them the three ways to run it:
+- **In chat** — ask to run the workflow by name (passing `args`).
+- **CLI / headless** — run it by name.
+- **On a schedule** — use the `schedule` skill (or `cron-task-creator`).
+
+### 6. State the constraints
+- A workflow that includes a browser recording needs a live Chrome **every time
+  it runs** — it errors clearly in a headless/cron run without one. Say so when
+  the flow has a recording in it.
+- A SKILL.md step's structured handoff depends on the call-site `schema` you
+  proposed in step 2; without one, that step returns free text.
+
+## Don't
+- Don't author a new SKILL.md — that is `skill-creator`.
+- Don't save before the user has confirmed the name and scope.
+- Don't report the dry-run as passing before `workflow_status` says done.

--- a/internal/skills/defaults_test.go
+++ b/internal/skills/defaults_test.go
@@ -42,6 +42,10 @@ func TestMaterializeDefaults_WritesEmbeddedAndStamps(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(root, "implement", "SKILL.md")); err != nil {
 		t.Fatalf("expected implement/SKILL.md materialized: %v", err)
 	}
+	// The workflow-builder skill ships in the default set.
+	if _, err := os.Stat(filepath.Join(root, "workflow-builder", "SKILL.md")); err != nil {
+		t.Fatalf("expected workflow-builder/SKILL.md materialized: %v", err)
+	}
 	// tdd bundles four companion references — all must materialize.
 	for _, f := range []string{"SKILL.md", "tests.md", "mocking.md", "deep-modules.md", "interface-design.md", "refactoring.md"} {
 		if _, err := os.Stat(filepath.Join(root, "tdd", f)); err != nil {


### PR DESCRIPTION
Layer **D (guidance)** of the composable-skills feature — implements the design in `dev-docs/workflow-builder-design.md` (#1043). Builds on A #1032 / B #1038 / C #1041.

## What

A `workflow-builder` **default skill** (pure SKILL.md, no new code) that guides a user from "chain these skills" to a saved, validated workflow through conversation:

1. **Inventory** available skills (`# Available skills` + `# Browser recordings` manifest sections); flag name collisions (`browser:`/`md:`).
2. **Wire outputs → inputs** — *honestly asymmetric*: recordings expose outputs in the manifest (wire directly); SKILL.md skills don't, so the builder infers the shape and **proposes a call-site `schema`** for the user to confirm.
3. **Generate the Ruby** (`skill()` calls, `args`-parameterized) — Ruby/mruby, not JS.
4. **Dry-run** — noting it's **async** (`workflow` runs in the background → poll `workflow_status`) and that a recording drives Chrome **at authoring time** (require Chrome up front, or validate the MD tail with a sample arg + `run_skill` the recording separately).
5. **Save** with `workflow_save` (scope=project errors outside a repo → choose user/project) and show the three ways to run it (chat / CLI / `schedule`).
6. **Constraints** — recordings need a live Chrome at run time; MD structured handoff rides the call-site schema.

Reuses `skill()` / `workflow` / `workflow_save` — no core code.

## Also

- Sharpened `skill-creator`'s description so it doesn't trigger on "chain existing skills into a workflow" (that's workflow-builder) — reduces double-trigger between the two creation skills.
- `defaults_test` asserts `workflow-builder` materializes; verified it parses + is discovered (frontmatter round-trips through `Discover`).

`go test ./internal/skills/` green; `vet` + `gofmt` clean.

This is the last planned layer. With A+B+C+D, a user's "download 3 excels → merge → PPT" goes from three isolated skills to one saved, rerunnable workflow they were guided to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)