### PR TITLE
fix(server): clear turnRunning after the lease write, not before

### DIFF
--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -438,11 +438,17 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 
 	go func() {
 		defer func() {
+			// Release the binding — which reloads the session and appends a
+			// lease-clear record, writing the session file — BEFORE clearing
+			// turnRunning. That flag is the "turn fully wound down" barrier
+			// (tests and drain logic wait on it); flipping it while a session
+			// write is still pending lets t.TempDir() cleanup race the open
+			// handle on Windows ("directory is not empty").
+			sess.DecFlight()
+			s.releaseSessionBinding(sid, agent.EntryWeb)
 			mu.Lock()
 			s.turnRunning[sid] = false
 			mu.Unlock()
-			sess.DecFlight()
-			s.releaseSessionBinding(sid, agent.EntryWeb)
 		}()
 		s.runAgentTurnLoop(sess, content, att.blocks, att.images)
 	}()


### PR DESCRIPTION
## Problem

`TestHandleWSUserMessage_ImageOnly` flakes on Windows CI with:

```
TempDir RemoveAll cleanup: unlinkat ...\.octo\sessions: The directory is not empty.
```

The test asserts pass; only `t.TempDir()` cleanup fails because a background write to the session file is still in flight.

## Root cause

The web turn goroutine's deferred cleanup (`ws_handlers.go`) flipped `turnRunning=false` **first**, then called `releaseSessionBinding`, which reloads the session and appends a lease-clear record — a write to `.octo/sessions/<id>.jsonl`.

The test (and drain logic) treat `turnRunning=false` as the barrier meaning "turn fully wound down, no session-file handle held". Clearing it before the lease write let `t.TempDir()` cleanup race that open handle — which Windows can't delete out from under, hence "directory is not empty".

## Fix

Reorder the defer so the binding/lease write completes **before** `turnRunning` is cleared, making the flag a truthful barrier. Turn-gating stays safe: a concurrent turn seeing `turnRunning=true` while the binding is already released is just rejected conservatively.

## Verification

- `go test -race -count=5 -run TestHandleWSUserMessage_ImageOnly ./internal/server/`: pass
- `go test -race ./internal/server/`: pass

## Note

This was committed to #1042's branch but the armed auto-merge squashed that PR at its first green commit (the frontend fix) before this landed, orphaning it. Recovered here as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)