### PR TITLE
feat(tools): workflow save-nudge (composable skills — discovery layer)

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -847,6 +847,9 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 		memory.NewInjector(rules).RegisterHooks(hookEngine)
 	}
+	// Suggest saving a workflow once the model chains >=2 skills by hand in a
+	// turn — independent of memory, so wired unconditionally.
+	tools.NewWorkflowNudger().RegisterHooks(hookEngine)
 	a.Hooks = hookEngine
 	a.HookMeta = hooks.Meta{Cwd: cwd}
 

--- a/dev-docs/workflow-save-nudge-design.md
+++ b/dev-docs/workflow-save-nudge-design.md
@@ -74,4 +74,4 @@ nudger 是 per-session 的(状态随会话),每个 session 注册自己的实例
 
 ## 落地
 
-单个 PR:`internal/tools/workflow_nudge.go` <!--lint:new-->(nudger + `RegisterHooks`)+ 三处 wiring + 单测。前置:workflow-builder(#1045,已合)——文案要指向它。
+单个 PR:`internal/tools/workflow_nudge.go`(nudger + `RegisterHooks`)+ 三处 wiring + 单测。前置:workflow-builder(#1045,已合)——文案要指向它。

--- a/dev-docs/workflow-save-nudge-design.md
+++ b/dev-docs/workflow-save-nudge-design.md
@@ -1,0 +1,77 @@
+# workflow save-nudge:手动串了几个技能后,建议存成 workflow
+
+## 背景
+
+`workflow-builder`(可组合技能 D 层)管「我想造一条流程」——主动编排。但用户常常是**先在会话里手动把几个技能跑通**,事后才意识到能固化。save-nudge 抓这个时机:一个 turn 内手动串了 **≥2 个技能**,就同 turn 提示一句"这条流程可以存成 saved workflow 复用"。它是 builder 的被动补充。
+
+octo 已有同形的机制可仿:`internal/memory/injector.go` 的 `SaveNudge` 是一个 **PostToolUse hook**,在里程碑命令(`gh pr create/merge`)后把一段 `<system-reminder>` 追加到该工具结果上,**每 turn 至多一次**(`UserPromptSubmit` 重新武装),且走 `<system-reminder>` 惯例被 UI 层剥离。workflow 版沿用这套骨架,只换触发信号与文案。
+
+## 方案
+
+### 触发信号(核心决策:什么算"手动串技能")
+
+一个 turn 内调用了 **≥2 个不同技能**(按名字去重),计入两类工具调用:
+
+- `skill` 工具 —— 加载一个 SKILL.md 技能(`input["name"]`);
+- `browser` 工具 `action=run_skill` —— 回放一个录制(`input["name"]`)。
+
+两类都算:旗舰流程(下载录制 + 合表 MD + 出 PPT MD)正好横跨录制与 MD。
+
+**排除 / 抑制**:
+
+- 排除 `workflow-builder` 自身(用户已经在造 workflow,别自我提示)。
+- 本 turn 若已出现 `workflow` 或 `workflow_save` 调用,则**整个 turn 抑制**——他们已经在做了。
+
+阈值固定 2,不做配置(YAGNI)。只看**单 turn 内**的串联,不跨 turn 累计。
+
+### 机制(仿 memory injector,但独立)
+
+不塞进 `internal/memory`(concern 不同)。新增一个小的、per-session 有状态的 nudger(落在 `internal/tools`,和 skill/workflow/browser 工具同包,能读工具名与输入):
+
+- **状态**:本 turn 见过的技能名集合 `seen`、是否已出现 workflow(_save) 的 `suppressed` 标志、`nudged` latch。
+- **PostToolUse hook**:
+  - `toolName == "workflow" | "workflow_save"` → 置 `suppressed`。
+  - `toolName == "skill"` 或(`toolName == "browser"` 且 `input["action"]=="run_skill"`)→ 取 `input["name"]`,非 `workflow-builder` 就加入 `seen`。
+  - 若 `!suppressed && !nudged && len(seen) >= 2` → 置 `nudged`,返回 `<system-reminder>` 文案。
+- **UserPromptSubmit hook**:清空 `seen`、`suppressed`、`nudged`(每 turn 重新武装)。
+- 串行调用(同 memory injector,来自 agent run loop),latch 无需加锁。
+
+复用 `<system-reminder>` 包裹 → 现有 `StripRemindersForDisplay` 自动把它挡在 UI 之外(模型看得到、用户面板看不到),与 memory nudge 一致。
+
+### 提示文案(要点)
+
+`<system-reminder>` 大意:本 turn 你已运行了多个技能。如果这是一条**可复用**的流程,可以用 `workflow-builder` 技能引导把它串成一个 saved workflow,或直接 `workflow_save` 存下来,以后点名 / 定时复跑。若只是一次性操作,忽略即可。措辞要克制——噪音会训练模型无视提示(memory nudge 的同款告诫)。
+
+### 三端接线(parity)
+
+和 memory injector 一样,在三处 per-session hook engine 上注册,一个 helper 三处共用(`tools.NewWorkflowNudger().RegisterHooks(engine)`):
+
+- CLI —— `cmd/octo/chat.go:848`(`memory.NewInjector(...).RegisterHooks(hookEngine)` 旁)。
+- Web —— `internal/server/server.go:1020`(`injectorFor(sess.ID).RegisterHooks(hookEngine)` 旁)。
+- IM —— `internal/server/server.go:2104`(`injectorFor("im:"+…).RegisterHooks(imEngine)` 旁)。
+
+nudger 是 per-session 的(状态随会话),每个 session 注册自己的实例,和 injector 的生命周期一致。
+
+## 不做的
+
+- 不加新工具;只是一个 hook + 小状态类型。
+- 不自动保存,只提示(保存仍走 workflow-builder / workflow_save 的显式确认)。
+- 阈值不可配、不跨 turn 累计。
+- 已在用 workflow 的 turn 不提示。
+- 不与 memory save-nudge 合并——触发信号与文案都不同,合并只会互相耦合;两者可在同一 turn 各自独立触发(一个盯 `gh pr`,一个盯技能串联),都走 PostToolUse + 每 turn 一次 + `<system-reminder>` 惯例。
+
+## 验证
+
+单测 nudger(纯状态机,无需真工具):
+
+- 1 个技能 → 静默;2 个**不同**技能 → 提示一次;第 3 个 → 不重复。
+- 同名技能两次 → 只算一个,不触发。
+- `UserPromptSubmit` 重置后 → 再次武装。
+- 计入 `browser` 仅当 `action==run_skill`(普通 `browser` navigate/click 不算)。
+- 排除 `workflow-builder`;本 turn 出现 `workflow_save` → 全程抑制。
+
+三端各加一处注册(编译期保证);CLI 路径可加一条集成味断言。
+
+## 落地
+
+单个 PR:`internal/tools/workflow_nudge.go` <!--lint:new-->(nudger + `RegisterHooks`)+ 三处 wiring + 单测。前置:workflow-builder(#1045,已合)——文案要指向它。

--- a/dev-docs/workflow-save-nudge-design.md
+++ b/dev-docs/workflow-save-nudge-design.md
@@ -46,11 +46,11 @@ octo 已有同形的机制可仿:`internal/memory/injector.go` 的 `SaveNudge` �
 
 和 memory injector 一样,在三处 per-session hook engine 上注册,一个 helper 三处共用(`tools.NewWorkflowNudger().RegisterHooks(engine)`):
 
-- CLI —— `cmd/octo/chat.go:848`(`memory.NewInjector(...).RegisterHooks(hookEngine)` 旁)。
-- Web —— `internal/server/server.go:1020`(`injectorFor(sess.ID).RegisterHooks(hookEngine)` 旁)。
-- IM —— `internal/server/server.go:2104`(`injectorFor("im:"+…).RegisterHooks(imEngine)` 旁)。
+- CLI —— `cmd/octo/chat.go`(`memory.NewInjector(...).RegisterHooks(hookEngine)` 旁)。
+- Web —— `internal/server/server.go`(`injectorFor(sess.ID).RegisterHooks(hookEngine)` 旁)。
+- IM —— `internal/server/server.go`(`injectorFor("im:"+…).RegisterHooks(imEngine)` 旁)。
 
-nudger 是 per-session 的(状态随会话),每个 session 注册自己的实例,和 injector 的生命周期一致。
+生命周期(两种,状态都是纯 per-turn,结果等价):**CLI** 整个会话一个 engine + 一个 nudger,靠 `UserPromptSubmit` 的 `reset()` 每 turn 重新武装。**Web/IM** 每 turn 重建 engine 并 `NewWorkflowNudger()`,新实例 latch 本就是零值,`reset()` 冗余但无害,per-turn 新鲜性天然隔离、不跨会话泄漏。注意这与 memory injector 不同——injector 经 `injectorFor(key)` 会话粘连(有 recall latch 要跨 turn 保),nudger 无跨 turn 状态,故不必粘连。
 
 ## 不做的
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1019,6 +1019,8 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	if s.memDir != "" {
 		s.injectorFor(sess.ID).RegisterHooks(hookEngine)
 	}
+	// Workflow save-nudge — memory-independent, wired for every session.
+	tools.NewWorkflowNudger().RegisterHooks(hookEngine)
 	a.Hooks = hookEngine
 	a.HookMeta = hooks.Meta{SessionID: sess.ID, Transport: sess.BoundEntry, Cwd: cwd}
 	if p, err := sess.SavePath(); err == nil {
@@ -2103,6 +2105,8 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	if s.memDir != "" {
 		s.injectorFor("im:" + string(sess.Key)).RegisterHooks(imEngine)
 	}
+	// Workflow save-nudge — memory-independent, wired for every IM session.
+	tools.NewWorkflowNudger().RegisterHooks(imEngine)
 	sess.Agent.Hooks = imEngine
 	sess.Agent.HookMeta = hooks.Meta{SessionID: string(sess.Key), Transport: agent.EntryChannel, Cwd: cwd}
 	// The persisted backing session (Store) carries the durable SessionStart

--- a/internal/tools/workflow_nudge.go
+++ b/internal/tools/workflow_nudge.go
@@ -75,6 +75,10 @@ func (n *WorkflowNudger) observe(toolName string, input map[string]any) string {
 func skillNameFromCall(toolName string, input map[string]any) string {
 	switch toolName {
 	case "skill":
+		// The skill tool loads a SKILL.md body — it doesn't by itself prove the
+		// skill ran to completion (not observable from tool calls). Loading two
+		// distinct skills is a good-enough "chaining" signal; the nudge is hedged
+		// and one-shot, so an occasional false positive is acceptable.
 		name, _ := input["name"].(string)
 		return name
 	case "browser":

--- a/internal/tools/workflow_nudge.go
+++ b/internal/tools/workflow_nudge.go
@@ -1,0 +1,103 @@
+package tools
+
+import (
+	"context"
+	"sync"
+
+	"github.com/open-octo/octo-agent/internal/hooks"
+)
+
+// workflowNudgeText is appended to the tool result of the second distinct skill
+// run by hand in one turn, nudging the model to offer capturing the sequence as
+// a reusable workflow. Wrapped in <system-reminder> so the display layer strips
+// it (same convention as the memory save-nudge).
+const workflowNudgeText = "<system-reminder>\n" +
+	"You've run more than one skill by hand this turn. If this is a repeatable flow, offer to capture it as a saved workflow — guide it with the workflow-builder skill, or write the script and persist it with workflow_save — so it can be rerun by name (and scheduled). If this was a one-off, ignore this.\n" +
+	"</system-reminder>"
+
+// WorkflowNudger suggests saving a reusable workflow once the model has manually
+// chained >=2 distinct skills within a single turn (the passive complement to
+// the workflow-builder skill). It mirrors memory.Injector's save-nudge but keys
+// off skill composition instead of a milestone command. One per session; its
+// latches re-arm on each user turn. A mutex guards the state so it is safe even
+// when a transport dispatches hooks off the serial run loop.
+type WorkflowNudger struct {
+	mu         sync.Mutex
+	seen       map[string]bool // distinct skill names invoked this turn
+	suppressed bool            // a workflow / workflow_save already ran this turn
+	nudged     bool            // nudge already emitted this turn
+}
+
+// NewWorkflowNudger returns a ready nudger.
+func NewWorkflowNudger() *WorkflowNudger {
+	return &WorkflowNudger{seen: map[string]bool{}}
+}
+
+// reset re-arms the nudger at the start of a user turn.
+func (n *WorkflowNudger) reset() {
+	n.mu.Lock()
+	n.seen = map[string]bool{}
+	n.suppressed = false
+	n.nudged = false
+	n.mu.Unlock()
+}
+
+// observe records one tool call and returns the nudge text when the second
+// distinct skill of the turn lands (at most once per turn); "" otherwise.
+func (n *WorkflowNudger) observe(toolName string, input map[string]any) string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	// Already orchestrating with workflows this turn — don't nudge.
+	if toolName == "workflow" || toolName == "workflow_save" {
+		n.suppressed = true
+		return ""
+	}
+
+	name := skillNameFromCall(toolName, input)
+	// workflow-builder is how you'd *build* a workflow, so running it isn't
+	// "manual chaining" worth nudging about.
+	if name == "" || name == "workflow-builder" {
+		return ""
+	}
+	n.seen[name] = true
+
+	if n.suppressed || n.nudged || len(n.seen) < 2 {
+		return ""
+	}
+	n.nudged = true
+	return workflowNudgeText
+}
+
+// skillNameFromCall extracts the skill name from a skill-running tool call: the
+// `skill` tool (loading a SKILL.md) or the browser tool's run_skill action
+// (replaying a recording). Any other call yields "".
+func skillNameFromCall(toolName string, input map[string]any) string {
+	switch toolName {
+	case "skill":
+		name, _ := input["name"].(string)
+		return name
+	case "browser":
+		if action, _ := input["action"].(string); action == "run_skill" {
+			name, _ := input["name"].(string)
+			return name
+		}
+	}
+	return ""
+}
+
+// RegisterHooks wires the nudger onto a session's hook engine: observe tool
+// calls on PostToolUse, re-arm on UserPromptSubmit. Independent of memory — wire
+// it whether or not a memory directory exists.
+func (n *WorkflowNudger) RegisterHooks(e *hooks.Engine) {
+	if n == nil || e == nil {
+		return
+	}
+	e.RegisterInProc(hooks.EventPostToolUse, func(_ context.Context, p hooks.Payload) string {
+		return n.observe(p.ToolName, p.ToolInput)
+	})
+	e.RegisterInProc(hooks.EventUserPromptSubmit, func(_ context.Context, _ hooks.Payload) string {
+		n.reset()
+		return ""
+	})
+}

--- a/internal/tools/workflow_nudge_test.go
+++ b/internal/tools/workflow_nudge_test.go
@@ -1,8 +1,11 @@
 package tools
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"github.com/open-octo/octo-agent/internal/hooks"
 )
 
 // obs is a shorthand for one skill-tool call.
@@ -90,6 +93,43 @@ func TestWorkflowNudger_SuppressedByWorkflowCall(t *testing.T) {
 	n.observe(skillCall("a"))
 	if got := n.observe(skillCall("b")); got == "" {
 		t.Fatalf("after reset (no workflow call) the nudge should fire")
+	}
+}
+
+// TestWorkflowNudger_HookPath drives the real hook engine (RegisterHooks +
+// Inject) rather than calling observe/reset directly, so a wiring mistake (wrong
+// event, wrong Payload field, missing reset) would be caught.
+func TestWorkflowNudger_HookPath(t *testing.T) {
+	e := hooks.NewEngine(nil)
+	NewWorkflowNudger().RegisterHooks(e)
+	ctx := context.Background()
+	post := func(name string) string {
+		return e.Inject(ctx, hooks.Payload{
+			Event:     hooks.EventPostToolUse,
+			ToolName:  "skill",
+			ToolInput: map[string]any{"name": name},
+		})
+	}
+
+	if got := post("a"); got != "" {
+		t.Fatalf("first skill via engine should be silent, got %q", got)
+	}
+	if got := post("b"); !strings.Contains(got, "workflow_save") {
+		t.Fatalf("second distinct skill via engine should nudge, got %q", got)
+	}
+	if got := post("c"); got != "" {
+		t.Fatalf("nudge must not repeat within a turn, got %q", got)
+	}
+
+	// A user turn boundary must re-arm the nudger through the engine.
+	if got := e.Inject(ctx, hooks.Payload{Event: hooks.EventUserPromptSubmit, UserInput: "next"}); got != "" {
+		t.Fatalf("UserPromptSubmit hook should contribute no text, got %q", got)
+	}
+	if got := post("a"); got != "" {
+		t.Fatalf("after re-arm, first skill silent, got %q", got)
+	}
+	if got := post("b"); !strings.Contains(got, "workflow_save") {
+		t.Fatalf("after re-arm, second distinct skill should nudge again, got %q", got)
 	}
 }
 

--- a/internal/tools/workflow_nudge_test.go
+++ b/internal/tools/workflow_nudge_test.go
@@ -1,0 +1,103 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// obs is a shorthand for one skill-tool call.
+func skillCall(name string) (string, map[string]any) {
+	return "skill", map[string]any{"name": name}
+}
+
+func TestWorkflowNudger_TwoDistinctSkillsNudgeOnce(t *testing.T) {
+	n := NewWorkflowNudger()
+
+	// First distinct skill — silent.
+	if got := n.observe(skillCall("download-excels")); got != "" {
+		t.Fatalf("first skill should be silent, got %q", got)
+	}
+	// Second distinct skill — nudge.
+	got := n.observe(skillCall("merge-excels"))
+	if !strings.Contains(got, "workflow_save") || !strings.Contains(got, "<system-reminder>") {
+		t.Fatalf("second distinct skill should nudge, got %q", got)
+	}
+	// Third — no repeat this turn.
+	if got := n.observe(skillCall("excels-to-ppt")); got != "" {
+		t.Fatalf("nudge must fire at most once per turn, got %q", got)
+	}
+
+	// New turn re-arms.
+	n.reset()
+	if got := n.observe(skillCall("a")); got != "" {
+		t.Fatalf("after reset, first skill silent, got %q", got)
+	}
+	if got := n.observe(skillCall("b")); got == "" {
+		t.Fatalf("after reset, second distinct skill should nudge again")
+	}
+}
+
+func TestWorkflowNudger_DedupsByName(t *testing.T) {
+	n := NewWorkflowNudger()
+	if got := n.observe(skillCall("same")); got != "" {
+		t.Fatalf("first: %q", got)
+	}
+	// Same skill again is not a second distinct skill.
+	if got := n.observe(skillCall("same")); got != "" {
+		t.Fatalf("same-name repeat must not count as a second skill, got %q", got)
+	}
+}
+
+func TestWorkflowNudger_BrowserOnlyRunSkillCounts(t *testing.T) {
+	n := NewWorkflowNudger()
+	// A plain browser action (not run_skill) doesn't count.
+	if got := n.observe("browser", map[string]any{"action": "navigate", "url": "x"}); got != "" {
+		t.Fatalf("browser navigate should not count, got %q", got)
+	}
+	// A recording replay counts as a skill.
+	if got := n.observe("browser", map[string]any{"action": "run_skill", "name": "rec-1"}); got != "" {
+		t.Fatalf("first (run_skill) should be silent, got %q", got)
+	}
+	// A second distinct skill (via the skill tool) trips the nudge — mixed sources.
+	if got := n.observe(skillCall("merge")); got == "" {
+		t.Fatalf("recording + skill should nudge (mixed sources)")
+	}
+}
+
+func TestWorkflowNudger_ExcludesWorkflowBuilder(t *testing.T) {
+	n := NewWorkflowNudger()
+	if got := n.observe(skillCall("workflow-builder")); got != "" {
+		t.Fatalf("workflow-builder itself must not count, got %q", got)
+	}
+	if got := n.observe(skillCall("real-skill")); got != "" {
+		t.Fatalf("only one countable skill so far, should be silent, got %q", got)
+	}
+	if got := n.observe(skillCall("another")); got == "" {
+		t.Fatalf("two countable skills should nudge")
+	}
+}
+
+func TestWorkflowNudger_SuppressedByWorkflowCall(t *testing.T) {
+	n := NewWorkflowNudger()
+	// The model is already orchestrating with a workflow this turn.
+	n.observe("workflow_save", map[string]any{"name": "x"})
+	n.observe(skillCall("a"))
+	if got := n.observe(skillCall("b")); got != "" {
+		t.Fatalf("a workflow/workflow_save call this turn must suppress the nudge, got %q", got)
+	}
+	// Next turn, without a workflow call, it nudges again.
+	n.reset()
+	n.observe(skillCall("a"))
+	if got := n.observe(skillCall("b")); got == "" {
+		t.Fatalf("after reset (no workflow call) the nudge should fire")
+	}
+}
+
+func TestWorkflowNudger_NonSkillToolsIgnored(t *testing.T) {
+	n := NewWorkflowNudger()
+	n.observe("terminal", map[string]any{"command": "ls"})
+	n.observe("read_file", map[string]any{"path": "x"})
+	if got := n.observe(skillCall("only-one")); got != "" {
+		t.Fatalf("non-skill tools must not count toward the threshold, got %q", got)
+	}
+}


### PR DESCRIPTION
**save-nudge** — the passive complement to `workflow-builder` (#1045). workflow-builder handles "I want to build a flow"; save-nudge catches "I just ran a few skills by hand" and offers to capture it. Design: `dev-docs/workflow-save-nudge-design.md` (in this PR).

## What

- **`internal/tools/workflow_nudge.go`** — `WorkflowNudger`: a per-session, mutex-guarded state machine. When the model runs **≥2 distinct skills** in one turn — `skill` tool loads + `browser` `run_skill` executions, deduped by name — a **PostToolUse** hook appends a one-shot `<system-reminder>` suggesting the sequence be saved as a workflow (via `workflow-builder` / `workflow_save`). **UserPromptSubmit** re-arms it each turn.
  - Excludes `workflow-builder` itself; **suppressed** if a `workflow`/`workflow_save` already ran that turn; threshold fixed at 2; single-turn only.
  - Reuses the `<system-reminder>` UI-strip convention (model sees it, transcript doesn't). Lives in `internal/tools`, not the memory package — different concern, same shape as `memory.Injector`'s save-nudge.
- **3-transport parity** — wired next to the memory injector at all three sites, **unconditionally** (memory-independent): CLI `chat.go`, web `server.go`, IM `server.go`.

## Tests

`internal/tools/workflow_nudge_test.go` — threshold (1 silent, 2nd distinct nudges once, 3rd silent), dedup by name, browser counts only on `run_skill`, mixed recording+skill sources, `workflow-builder` exclusion, `workflow_save` suppression, non-skill tools ignored, reset re-arms.

`go test -race ./internal/tools/ ./internal/server/` green; `vet` + `gofmt` clean; design doc lints clean.

This is the discovery half of the workflow-authoring UX; with workflow-builder (#1045) it covers both "build one" and "capture what I just did".

🤖 Generated with [Claude Code](https://claude.com/claude-code)