### PR TITLE
docs(dev-docs): session goals design — /goal 1:1 port from Codex

### DIFF
--- a/dev-docs/goals-design.md
+++ b/dev-docs/goals-design.md
@@ -165,12 +165,12 @@ retry forever — same motivation as `EventTurnError` being its own channel,
 #973). On such an error: set `usage_limited`, emit `EventGoalUpdated`, stop.
 `/goal resume` reactivates.
 
-**Safety net (deliberate addition)**: continuation reuses the
-`tools.MaxLoopLifetime` (12 h) bound that already caps `/loop` — measured from
-goal activation, a goal that ticks past it flips to `paused` with a notice.
-Codex has no such cap (it leans on account-level usage limits octo doesn't
-have); octo's own loop machinery already established this guard, so goals
-inherit it.
+No wall-clock lifetime cap, matching Codex: an unbudgeted active goal keeps
+continuing until the status machine stops it — long-running is the point of
+the feature. The zero-progress guard and the `usage_limited` mapping already
+cover the runaway modes a cap would (a spinning loop stops itself, a
+rate-limited loop parks itself); users who want a bound set a token budget.
+`tools.MaxLoopLifetime` stays a `/loop`-only concern.
 
 ### 3. Model-facing tools
 

--- a/dev-docs/goals-design.md
+++ b/dev-docs/goals-design.md
@@ -1,0 +1,350 @@
+# Session goals — /goal 1:1 port from Codex
+
+Port of Codex's thread-goal feature (`codex-rs` `core/src/goals.rs`,
+`tools/handlers/goal*`, TUI `/goal`) onto octo's existing session, tool, event,
+and idle-turn machinery. The feature: a session carries at most one persistent
+**goal** — an objective the agent keeps pursuing across turns without the user
+re-prompting, with optional token budget, usage accounting, and a strict
+status machine that decides when the auto-continuation loop runs and when it
+stops.
+
+## What the feature is (behavior spec, distilled from Codex)
+
+A goal is one record per session:
+
+| field | meaning |
+|---|---|
+| `id` | identity of this goal *instance*; replacing a goal mints a new id |
+| `objective` | free text, non-empty, ≤ 4000 chars |
+| `status` | `active` / `paused` / `blocked` / `usage_limited` / `budget_limited` / `complete` |
+| `token_budget` | optional, must be positive |
+| `tokens_used` | accumulated non-cached input + output tokens while the goal was active |
+| `time_used_seconds` | accumulated wall-clock seconds while the goal was active |
+| `created_at` / `updated_at` | timestamps |
+
+**Status ownership** is the core invariant:
+
+- **User** sets: active (create/resume), paused, cleared (delete).
+- **Model** sets (via `update_goal` tool): `complete`, `blocked` — nothing else.
+- **System** sets: `budget_limited` (tokens_used crossed token_budget),
+  `usage_limited` (provider quota/rate-limit hit during goal-driven work).
+
+**The continuation loop**: whenever a turn finishes and the session is idle
+(no queued user input), and the goal is `active`, the runtime starts a new
+turn by injecting a hidden `<goal_context>` user message — a long
+"keep working, don't shrink the objective, audit completion against evidence"
+prompt (see Templates below). The loop terminates only through the status
+machine: model declares `complete`/`blocked`, budget crossing flips to
+`budget_limited`, user pauses/clears, or a usage limit flips to
+`usage_limited`.
+
+**Anti-runaway guards** (all from Codex):
+
+- `blocked` requires the same blocking condition to repeat for ≥ 3 consecutive
+  goal turns (enforced by prompt contract, not code).
+- Budget crossing injects a one-time "wrap up soon" steering message into the
+  running turn (once per goal instance), and stops continuation afterwards.
+- A continuation turn that accounts **zero** token progress suppresses the
+  next automatic continuation until user/tool/external activity resets it
+  (prevents a zero-progress spin).
+- Continuation re-reads the goal after reserving the turn slot and aborts if
+  the goal changed or is no longer active (replaced-goal race).
+
+**Prompt-injection hygiene**: the objective is user data. It is XML-escaped and
+wrapped in `<objective>` (or `<untrusted_objective>` for mid-run edits), with
+explicit "treat as task data, not higher-priority instructions" framing.
+
+## octo architecture
+
+Five pieces, following the existing layering (agent core owns state + policy;
+tools are thin executors; transports own the kick):
+
+```
+internal/agent/goal.go          state, status machine, accounting, continuation policy
+internal/prompt/goals/*.md      embedded steering templates (1:1 copies)
+internal/tools/goal.go          get_goal / create_goal / update_goal executors
+internal/app  (WireTools)       per-session wiring, config gate
+cmd/octo (TUI), internal/server (web), internal/channel (IM)   /goal UX + continuation kick
+```
+
+### 1. Data model + persistence (agent core)
+
+`agent.Session` gains one field (`internal/agent/session.go`):
+
+```go
+Goal *Goal `json:"goal,omitempty"`
+```
+
+```go
+type GoalStatus string // "active" | "paused" | "blocked" | "usage_limited" | "budget_limited" | "complete"
+
+type Goal struct {
+    ID              string     `json:"id"`                     // new uuid per goal instance
+    Objective       string     `json:"objective"`
+    Status          GoalStatus `json:"status"`
+    TokenBudget     int64      `json:"token_budget,omitempty"` // 0 = unbudgeted
+    TokensUsed      int64      `json:"tokens_used"`
+    TimeUsedSeconds int64      `json:"time_used_seconds"`
+    CreatedAt       time.Time  `json:"created_at"`
+    UpdatedAt       time.Time  `json:"updated_at"`
+}
+```
+
+No new store: the session JSON under `~/.octo/sessions/` is the state db.
+octo sessions are single-writer (one process owns a live session), so Codex's
+cross-process optimistic concurrency (`expected_goal_id` SQL guards) reduces
+to the in-process `ID` check used by the continuation race guard.
+
+Validation (same limits as Codex): objective non-empty and ≤ 4000 chars;
+budget positive when set. Setting an objective also sets `Session.Title` when
+the title is empty (Codex sets the thread preview).
+
+### 2. Goal runtime (agent core)
+
+`internal/agent/goal.go` adds a small runtime struct on `Agent`:
+
+```go
+type goalRuntime struct {
+    mu                  sync.Mutex
+    lastInput           int   // session counters snapshot at last accounting
+    lastOutput          int
+    lastAccountedAt     time.Time // wall-clock baseline (only while active)
+    budgetSteerSent     bool      // once per goal instance
+    continuationTurn    bool      // current turn was started by continuation
+    suppressContinuation bool     // zero-progress guard
+}
+```
+
+**Token delta** per accounting point (matches Codex `goal_token_delta_for_usage`):
+Δ`sessionInputTokens` + Δ`sessionOutputTokens`. octo's `InputTokens` bucket is
+already the non-cached remainder (`CacheReadTokens` is a separate,
+non-overlapping bucket — see CLAUDE.md), so no subtraction is needed;
+cache reads are deliberately free, matching Codex.
+
+**Accounting points** — octo's turn loop has a natural grain of one LLM reply,
+which is exactly when usage counters move, so instead of Codex's per-tool-
+completion hook we account:
+
+- after each `addUsage` inside the `RunStream` loop (per reply),
+- at turn end (`EventTurnDone`) and on turn error/interrupt,
+- before any external mutation (slash command / API changing the goal).
+
+Each accounting: if goal is `active` or `budget_limited`, add token delta and
+wall-clock delta, bump `UpdatedAt`, persist (goals ride the existing
+round-granularity session persist — no extra fsync path), and emit
+`EventGoalUpdated`. Wall-clock baseline resets when a goal becomes active and
+clears when it stops, so idle time between turns is not billed (Codex
+semantics: `budget_limited` still accrues in-flight usage; only `active` can
+*transition* to `budget_limited`).
+
+**Budget crossing**: when an accounting step moves an `active` budgeted goal
+to `tokens_used ≥ token_budget`, set `budget_limited` and — once per goal
+instance — inject the `budget_limit` steering prompt into the running turn via
+the existing `Inbox` steer path (it lands before the next LLM call, same
+effect as Codex's `inject_response_items`).
+
+**Continuation policy** — one shared method, transports own the kick:
+
+```go
+// GoalContinuation returns the hidden continuation prompt when an idle
+// follow-up turn should start, applying all guards.
+func (a *Agent) GoalContinuation() (prompt string, ok bool)
+```
+
+Guards, in order (each mirrors a Codex guard): feature enabled; goal exists
+and `Status == active`; no queued inbox input; not suppressed by the
+zero-progress guard; goal `ID` unchanged since the check began. The zero-
+progress guard: when a continuation-started turn finishes having accounted 0
+tokens, set `suppressContinuation`; any user message, tool activity, or
+external goal mutation clears it.
+
+**Usage-limit mapping**: Codex flips to `usage_limited` on an explicit
+provider usage-limit event. octo's equivalent signal is a turn error of the
+rate-limit/quota class **on a continuation turn** (a failing loop must not
+retry forever — same motivation as `EventTurnError` being its own channel,
+#973). On such an error: set `usage_limited`, emit `EventGoalUpdated`, stop.
+`/goal resume` reactivates.
+
+**Safety net (deliberate addition)**: continuation reuses the
+`tools.MaxLoopLifetime` (12 h) bound that already caps `/loop` — measured from
+goal activation, a goal that ticks past it flips to `paused` with a notice.
+Codex has no such cap (it leans on account-level usage limits octo doesn't
+have); octo's own loop machinery already established this guard, so goals
+inherit it.
+
+### 3. Model-facing tools
+
+`internal/tools/goal.go` — three executors, 1:1 schemas and descriptions
+(including the "create only when explicitly requested", "blocked needs three
+consecutive turns", "cannot pause/resume via this tool" contract wording):
+
+- `get_goal` `{}` → JSON `{goal, remaining_tokens}`
+- `create_goal` `{objective, token_budget?}` → fails if a goal exists
+- `update_goal` `{status: "complete"|"blocked"}` → fails if no goal; a
+  completed budgeted goal's result carries the `completion_budget_report`
+  string instructing the model to report final usage to the user
+
+The executors hold a narrow interface implemented by `*agent.Agent`
+(`GetGoal/CreateGoal/UpdateGoalStatus`), constructed per session in
+`app.WireTools` — the same closure-wiring pattern as `sub_agent`/`workflow`.
+Registered in `DefaultTools` only when the feature is enabled. Rule from
+\#597/#600: every `input["…"]` read is declared in `Definition()`.
+
+`update_goal` marking `complete`/`blocked` also ends the continuation loop by
+plain status effect — no special-casing beyond suppressing the budget steer on
+that same accounting step (Codex `ToolCompletedGoal`).
+
+### 4. Prompts
+
+`internal/prompt/goals/` with `//go:embed`, rendered via `text/template` —
+three files copied 1:1 from Codex (`continuation.md`, `budget_limit.md`,
+`objective_updated.md`), variables `{{.Objective}} {{.TokensUsed}}
+{{.TokenBudget}} {{.RemainingTokens}} {{.TimeUsedSeconds}}`. The objective is
+XML-escaped before substitution. The rendered prompt is wrapped in
+`<goal_context>…</goal_context>` and enqueued as a user-role steer.
+
+The `update_plan` paragraph in the continuation template is reworded to
+octo's task tools; the progress-visibility contract itself is kept.
+
+**Display filtering**: `<goal_context>` spans are stripped at the event layer
+and web replay exactly like `<system-reminder>` (#634 pattern:
+blocks = model-facing, events = UI-facing). A continuation turn shows in the
+UI as an agent turn with no visible user bubble, matching Codex's hidden
+context items. The TUI/web instead show the goal indicator (below).
+
+### 5. Events
+
+New agent event kind (own channel, per the #973 rule):
+
+```go
+EventGoalUpdated EventKind = "goal_updated" // payload: the Goal snapshot
+```
+
+Emitted on every mutation and every accounting step that changed the record.
+Consumers:
+
+- **web**: WS event `goal_updated` → header status chip; history replay
+  re-derives current goal from the session on load.
+- **TUI**: status-line indicator — `goal: 63.9K/50K` (budgeted) or elapsed
+  time (unbudgeted) while active; `paused` / `blocked` / `limited by budget` /
+  `usage limited` / `complete ✓` otherwise. Elapsed ticks locally during an
+  active turn (Codex `GoalStatusState`).
+- **IM**: terminal transitions only (`complete`, `blocked`, `budget_limited`,
+  `usage_limited`) are pushed as chat messages — the user isn't watching a
+  status line; this mirrors how turn errors surface on IM.
+
+## User surface — `/goal` on all three transports
+
+Subcommand grammar is identical everywhere; presentation follows each
+transport's idiom.
+
+| input | behavior |
+|---|---|
+| `/goal` | summary: status, objective, time used, tokens used (+budget), command hints. No goal → usage hint. |
+| `/goal <objective>` | create an active goal. If an unfinished goal exists (any status except `complete`) → confirm "Replace current goal?"; replace = new goal `ID`, fresh usage counters. |
+| `/goal edit` | edit objective keeping usage/budget; `budget_limited`/`complete` re-activate on edit, other statuses are preserved. Mid-turn edits inject the `objective_updated` steering prompt. |
+| `/goal pause` | status → `paused` (accounts in-flight usage first). |
+| `/goal resume` | status → `active`; continuation kicks if idle. |
+| `/goal clear` | delete the goal (confirmation-free, like Codex). |
+
+Notes, all matching Codex: no budget parameter on `/goal` — budgets come from
+natural language via `create_goal` ("…with a 50k token budget") or the API;
+resuming a session whose goal is `paused`/`blocked`/`usage_limited` prompts
+"Resume paused goal?"; `/goal` before the session exists queues like other
+pre-session input.
+
+- **TUI** (`cmd/octo/tuirepl_view.go` switch): summary as printed lines,
+  replace/resume confirms via the existing selection prompt, edit via a
+  prefilled input prompt, indicator in the status line.
+- **web** (`internal/server/ws_handlers.go` `/clear`-`/compact` switch +
+  a small REST surface `GET/PUT/DELETE …/goal` mirroring Codex's
+  `thread/goal/get|set|clear`): confirms reuse the existing confirm-modal wire
+  (#942 `yes` semantics), chip in the session header. **webdist rebuild +
+  commit** required (#718 lesson).
+- **IM** (`internal/channel/manager.go` switch): summary as text; replace
+  confirmation via interactive next-message ask (#601); terminal-transition
+  notifications via the existing notice path.
+
+**Continuation kick per transport** — all three already have the idle
+auto-turn path built for `/loop` and background tasks; goals reuse it verbatim:
+
+- server: after a turn completes and the session is idle, if
+  `GoalContinuation()` fires → `enqueueSteer` + `kickIdleSteerTurn`
+  (`internal/server/loop.go` pattern).
+- TUI: post-turn hook posts the same steer through the `tuiWaker`/inbox path.
+- IM: idle channel-turn path (#613 machinery).
+
+The decision (should a turn start, with what prompt) lives once in agent core;
+transports only deliver — same split as `tools.Waker`.
+
+## Config
+
+```yaml
+goal:
+  enabled: true   # kill switch; hides /goal and the three tools
+```
+
+Codex gates behind a rollout feature flag; octo's equivalent is a config
+toggle. Default **on**: the feature is inert until a user explicitly creates a
+goal (the `create_goal` contract forbids the model inferring goals from
+ordinary tasks), so there is no default-behavior change for existing users.
+
+## Deliberately not replicated
+
+- **OTel metrics** (created/resumed/completed counters, token/duration
+  histograms) — octo has no metrics pipeline; `slog` lines at the same
+  transition points instead.
+- **SQLite state-db + rollout reconciliation** — octo's session JSON is the
+  store; no reconcile step exists or is needed.
+- **Ephemeral-thread errors** — every octo session is persisted; the error
+  path is dead weight here.
+- **Plan-mode gating** (Codex skips goal work in plan mode) — octo has no
+  plan mode; noted for when one appears.
+- **Side conversations** — no octo equivalent.
+- **Cross-process `expected_goal_id` SQL guards** — single-writer sessions;
+  the in-process `ID` check covers the continuation race.
+
+## Compaction interaction
+
+Goal accounting reads the monotonic session counters, so compaction (which
+itself calls `addUsage`) bills its tokens to the active goal. Codex does the
+same (compaction happens inside the turn). No special-casing.
+
+## Acceptance criteria
+
+- `/goal ship the release notes` on any transport creates an active goal;
+  after the turn ends the agent continues unprompted; `/goal` shows live
+  tokens/time; `update_goal complete` stops the loop and the completion
+  message reports usage.
+- A goal created with "…budget of 20k tokens" flips to `budget_limited` at
+  the crossing, the model receives the wrap-up steer exactly once, and no
+  further continuation turns start.
+- A continuation turn that accounts zero tokens does not trigger another
+  continuation; a user message re-enables it.
+- Replacing an unfinished goal asks for confirmation; a `complete` goal is
+  replaced silently with fresh counters.
+- Killing and resuming a session with a paused goal prompts to resume it;
+  resuming re-enters the continuation loop.
+- Continuation prompts never appear as user bubbles in TUI/web/IM history.
+- `goal.enabled: false` hides `/goal` and removes the three tools from the
+  schema sent to the LLM.
+- `go test -race ./...` green; no live network in tests (httptest only).
+
+## Implementation plan (PR slices)
+
+1. **PR1 — agent core**: `Goal` on `Session`, status machine + validation,
+   goal runtime accounting, `EventGoalUpdated`, zero-progress + lifetime
+   guards, persistence. Pure `internal/agent`, fully unit-testable.
+2. **PR2 — tools + prompts + continuation**: three executors, embedded
+   templates, `GoalContinuation()`, budget/objective-updated steering,
+   `<goal_context>` display stripping, `WireTools` + registry gating, config
+   key. Server continuation kick (smallest transport delta) lands here so the
+   loop is end-to-end testable.
+3. **PR3 — TUI**: `/goal` subcommands, summary, confirms, edit prompt,
+   status-line indicator, resume-paused prompt, TUI continuation kick.
+4. **PR4 — web + IM**: WS/REST surface, header chip, confirm modal wiring,
+   IM subcommands + terminal-transition notices, IM continuation kick,
+   webdist rebuild.
+
+Each PR branches off latest main, lands via squash-merge; auto-merge armed
+only after review is final (#990/#1043 rule).


### PR DESCRIPTION
## Summary

Design doc for porting Codex's thread-goal feature (`/goal`) onto octo: a session carries at most one persistent **goal** — an objective the agent keeps pursuing across turns without re-prompting, with optional token budget, usage accounting, and a status machine that decides when the auto-continuation loop runs and stops.

Researched against the Codex source (`codex-rs` `core/src/goals.rs`, `tools/handlers/goal*`, TUI `/goal`, state-db `thread_goals`).

## Key mappings onto existing octo machinery

- **Storage**: `Goal` field on `agent.Session` JSON — no new store; single-writer sessions reduce Codex's cross-process optimistic concurrency to an in-process ID check.
- **Continuation**: reuses the `/loop` idle auto-turn pipeline (`enqueueSteer` + `kickIdleSteerTurn` / `tuiWaker` / IM idle turn); policy lives once in agent core (`GoalContinuation()`), transports only deliver.
- **Tools**: `get_goal` / `create_goal` / `update_goal` via the WireTools closure pattern; steering prompts injected through the existing Inbox steer path, hidden from UI via the `<goal_context>` strip (same layering as `<system-reminder>`, #634).
- **Events**: new `EventGoalUpdated` channel (own kind per the #973 rule) → web chip / TUI status line / IM terminal-transition notices.
- **usage_limited**: mapped to rate-limit-class turn errors on continuation turns (octo has no account-level usage-limit signal).

Settled deviations: `goal.enabled: true` default (inert until explicitly created); no OTel metrics (slog). No wall-clock lifetime cap on continuation — matches Codex; zero-progress guard + usage_limited mapping cover runaway modes, token budget is the user-facing bound.

Implementation planned as 4 PR slices (agent core → tools+continuation → TUI → web+IM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)