### PR TITLE
fix(browser): stop near-miss run_skill replays via manifest guardrails

### DIFF
--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -310,17 +311,30 @@ func GenerateSkill(ctx context.Context, name, startURL string, events []Recorded
 
 	out, err := gen(ctx, system, user)
 	if err != nil {
+		slog.Warn("browser: skill distill failed, keeping deterministic baseline", "skill", name, "err", err)
 		return base
 	}
 	refined, err := ParseSkill([]byte(stripFences(out)))
 	if err != nil || len(refined.Steps) == 0 {
-		return base
+		slog.Warn("browser: skill distill output unusable, keeping deterministic baseline", "skill", name, "err", err, "steps", len(refined.Steps))
+		return withDescription(base, refined.Description)
 	}
 	refined.Name = name
 	if !selectorsSubset(refined, base) {
-		return base // precision guard: the model used a selector it wasn't given
+		// Precision guard: the model used a selector it wasn't given. The refined
+		// steps are untrustworthy, but the prose description still is — keep it so
+		// the skills manifest isn't left with a bare name.
+		slog.Warn("browser: skill distill used a selector not in the recording, keeping deterministic baseline", "skill", name)
+		return withDescription(base, refined.Description)
 	}
 	return refined
+}
+
+func withDescription(s Skill, desc string) Skill {
+	if desc != "" {
+		s.Description = desc
+	}
+	return s
 }
 
 func renderTrace(events []RecordedEvent) string {
@@ -363,6 +377,57 @@ func selectorsSubset(refined, base Skill) bool {
 		}
 	}
 	return true
+}
+
+// StepDigest renders a compact one-line summary of what a replay does, e.g.
+// `navigate www.zhihu.com → click "热榜" → click "日元跌破 1 美元兑 162 日元…"`.
+// The skills manifest uses it when a recording has no description, so the model
+// can still see the recording's full path — including its final step, which is
+// what tells it the replay ends somewhere specific.
+func (s Skill) StepDigest() string {
+	var parts []string
+	for _, st := range s.Steps {
+		switch st.Action {
+		case "wait":
+			continue
+		case "navigate":
+			parts = append(parts, "navigate "+truncRunes(digestURL(st.URL), 40))
+		default:
+			label := st.Label
+			if label == "" {
+				label = st.Hint
+			}
+			if label == "" {
+				label = st.Selector
+			}
+			if label == "" {
+				parts = append(parts, st.Action)
+				continue
+			}
+			parts = append(parts, fmt.Sprintf("%s %q", st.Action, truncRunes(label, 30)))
+		}
+	}
+	// Keep the head and the final step: the ending is the part a bare name hides.
+	if len(parts) > 8 {
+		parts = append(parts[:6], "…", parts[len(parts)-1])
+	}
+	return strings.Join(parts, " → ")
+}
+
+func digestURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return raw
+	}
+	return u.Host + strings.TrimSuffix(u.Path, "/")
+}
+
+func truncRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
 }
 
 // MarshalSkill renders the skill to YAML.

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -316,7 +316,7 @@ func GenerateSkill(ctx context.Context, name, startURL string, events []Recorded
 	}
 	refined, err := ParseSkill([]byte(stripFences(out)))
 	if err != nil || len(refined.Steps) == 0 {
-		slog.Warn("browser: skill distill output unusable, keeping deterministic baseline", "skill", name, "err", err, "steps", len(refined.Steps))
+		slog.Warn("browser: skill distill output unusable, keeping deterministic baseline steps", "skill", name, "err", err, "steps", len(refined.Steps))
 		return withDescription(base, refined.Description)
 	}
 	refined.Name = name
@@ -324,7 +324,7 @@ func GenerateSkill(ctx context.Context, name, startURL string, events []Recorded
 		// Precision guard: the model used a selector it wasn't given. The refined
 		// steps are untrustworthy, but the prose description still is — keep it so
 		// the skills manifest isn't left with a bare name.
-		slog.Warn("browser: skill distill used a selector not in the recording, keeping deterministic baseline", "skill", name)
+		slog.Warn("browser: skill distill used a selector not in the recording, keeping deterministic baseline steps", "skill", name)
 		return withDescription(base, refined.Description)
 	}
 	return refined
@@ -417,6 +417,9 @@ func (s Skill) StepDigest() string {
 func digestURL(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil || u.Host == "" {
+		// Hand-edited relative/malformed URL: still never let a query string
+		// (which can carry session tokens) into the system prompt.
+		raw, _, _ = strings.Cut(raw, "?")
 		return raw
 	}
 	return u.Host + strings.TrimSuffix(u.Path, "/")

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -2,6 +2,7 @@ package browser
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -356,15 +357,48 @@ func TestGenerateSkillDistill(t *testing.T) {
 		t.Fatalf("value not parameterized: %+v", s.Steps[2])
 	}
 
-	// A generator that invents a selector not in the recording -> must be rejected.
+	// A generator that invents a selector not in the recording -> must be rejected,
+	// but its prose description is still trustworthy and must survive the fallback
+	// (an empty description leaves the skills manifest with a bare, matchable name).
 	cheat := func(_ context.Context, _, _ string) (string, error) {
-		return "name: x\nsteps:\n  - {action: click, selector: '#invented'}\n", nil
+		return "name: x\ndescription: open the search page\nsteps:\n  - {action: click, selector: '#invented'}\n", nil
 	}
 	s2 := GenerateSkill(ctx, "demo", "https://x/start", events, cheat)
 	for _, st := range s2.Steps {
 		if st.Selector == "#invented" {
 			t.Fatal("precision guard failed: accepted an invented selector")
 		}
+	}
+	if s2.Description != "open the search page" {
+		t.Fatalf("guard fallback should keep the distilled description, got %q", s2.Description)
+	}
+}
+
+// TestStepDigest: the digest names each step by its label (falling back to hint,
+// then selector), renders navigates as host+path, skips waits, and when long
+// keeps the head plus the FINAL step — the ending is what a bare name hides.
+func TestStepDigest(t *testing.T) {
+	s := Skill{Steps: []Step{
+		{Action: "navigate", URL: "https://www.zhihu.com/hot/"},
+		{Action: "wait", TimeoutMS: 500},
+		{Action: "click", Label: "热榜"},
+		{Action: "type", Hint: "search"},
+		{Action: "click", Selector: "#go"},
+		{Action: "click", Label: "日元跌破 1 美元兑 162 日元关口，创下近 40 年来新低，日本央行已加息"},
+	}}
+	got := s.StepDigest()
+	want := `navigate www.zhihu.com/hot → click "热榜" → type "search" → click "#go" → click "日元跌破 1 美元兑 162 日元关口，创下近 40 年来新…"`
+	if got != want {
+		t.Fatalf("digest = %q\nwant %q", got, want)
+	}
+
+	long := Skill{}
+	for i := 0; i < 11; i++ {
+		long.Steps = append(long.Steps, Step{Action: "click", Label: fmt.Sprintf("s%d", i)})
+	}
+	d := long.StepDigest()
+	if !strings.Contains(d, "…") || !strings.Contains(d, `"s10"`) {
+		t.Fatalf("long digest must elide the middle but keep the final step, got %q", d)
 	}
 }
 

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -372,6 +372,19 @@ func TestGenerateSkillDistill(t *testing.T) {
 	if s2.Description != "open the search page" {
 		t.Fatalf("guard fallback should keep the distilled description, got %q", s2.Description)
 	}
+
+	// A generator whose output has a description but no usable steps -> baseline
+	// steps, distilled description.
+	descOnly := func(_ context.Context, _, _ string) (string, error) {
+		return "name: x\ndescription: search for an order\n", nil
+	}
+	s3 := GenerateSkill(ctx, "demo", "https://x/start", events, descOnly)
+	if len(s3.Steps) == 0 {
+		t.Fatal("steps-empty fallback should keep the baseline steps")
+	}
+	if s3.Description != "search for an order" {
+		t.Fatalf("steps-empty fallback should keep the distilled description, got %q", s3.Description)
+	}
 }
 
 // TestStepDigest: the digest names each step by its label (falling back to hint,
@@ -399,6 +412,20 @@ func TestStepDigest(t *testing.T) {
 	d := long.StepDigest()
 	if !strings.Contains(d, "…") || !strings.Contains(d, `"s10"`) {
 		t.Fatalf("long digest must elide the middle but keep the final step, got %q", d)
+	}
+
+	// Exactly 8 significant steps is the no-elision boundary.
+	eight := Skill{}
+	for i := 0; i < 8; i++ {
+		eight.Steps = append(eight.Steps, Step{Action: "click", Label: fmt.Sprintf("s%d", i)})
+	}
+	if d := eight.StepDigest(); strings.Contains(d, "…") {
+		t.Fatalf("8 steps must not be elided, got %q", d)
+	}
+
+	// A skill with only waits digests to "" (the manifest then shows a bare name).
+	if d := (Skill{Steps: []Step{{Action: "wait", TimeoutMS: 100}}}).StepDigest(); d != "" {
+		t.Fatalf("wait-only skill should digest to empty, got %q", d)
 	}
 }
 

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -119,8 +119,8 @@ func RenderBrowserSkillsManifest() string {
 		"replayed, not loaded via the `skill` tool. A replay executes every recorded " +
 		"step verbatim, end to end — it cannot be partially applied or adapted beyond " +
 		"its declared params. Only replay a recording when the request matches what " +
-		"it does exactly; if any detail differs (a different item, target, or date), " +
-		"drive the browser directly instead.\n\n")
+		"it does end to end; if any detail not covered by a declared param differs " +
+		"(a different item or target), drive the browser directly instead.\n\n")
 	for _, s := range list {
 		fmt.Fprintf(&b, "- %s", s.Name)
 		if s.Description != "" {
@@ -620,7 +620,14 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		if err := browser.SaveSkill(path, skill); err != nil {
 			return agent.ToolResult{}, err
 		}
-		return agent.ToolResult{Text: fmt.Sprintf("recorded %d step(s) → %s\nReview/edit it there (set params, fix selectors). Replay it with the Replay button in the Browser view, or action=run_skill name=%q. (Recordings are NOT keyword-triggerable — they only run when explicitly replayed.)", len(skill.Steps), path, name)}, nil
+		msg := fmt.Sprintf("recorded %d step(s) → %s\nReview/edit it there (set params, fix selectors). Replay it with the Replay button in the Browser view, or action=run_skill name=%q. (Recordings are NOT keyword-triggerable — they only run when explicitly replayed.)", len(skill.Steps), path, name)
+		if skill.Description == "" {
+			// The LLM distill fell back (or omitted a description). Surface it here
+			// — the stderr warning never reaches the model — so the skill doesn't
+			// silently stay a bare name in the manifest.
+			msg += "\nNo description was distilled; the skills manifest will show a step digest instead. Add a description: line to the YAML to improve discovery."
+		}
+		return agent.ToolResult{Text: msg}, nil
 
 	case "run_skill":
 		name := getStr(input, "name")

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -116,11 +116,20 @@ func RenderBrowserSkillsManifest() string {
 	b.WriteString("Recorded browser workflows. Replay one with the `browser` tool " +
 		"(action=run_skill, name=<name>, params as declared); it returns the skill's " +
 		"declared outputs (downloaded files, extracted values) as JSON. These are " +
-		"replayed, not loaded via the `skill` tool.\n\n")
+		"replayed, not loaded via the `skill` tool. A replay executes every recorded " +
+		"step verbatim, end to end — it cannot be partially applied or adapted beyond " +
+		"its declared params. Only replay a recording when the request matches what " +
+		"it does exactly; if any detail differs (a different item, target, or date), " +
+		"drive the browser directly instead.\n\n")
 	for _, s := range list {
 		fmt.Fprintf(&b, "- %s", s.Name)
 		if s.Description != "" {
 			fmt.Fprintf(&b, ": %s", s.Description)
+		} else if d := s.StepDigest(); d != "" {
+			// No description (e.g. the LLM distill fell back at record time): show
+			// the step path instead, so the model can judge fit — especially the
+			// final step, which a bare name hides.
+			fmt.Fprintf(&b, ": steps: %s", d)
 		}
 		if len(s.Params) > 0 {
 			names := make([]string, len(s.Params))

--- a/internal/tools/browser_manifest_test.go
+++ b/internal/tools/browser_manifest_test.go
@@ -28,11 +28,17 @@ func TestRenderBrowserSkillsManifest(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A second recording whose output declares no type — it should render as a
-	// bare name (no parens), exercising the type-less branch.
+	// bare name (no parens), exercising the type-less branch. It also has no
+	// description, so the manifest must fall back to a step digest: without one
+	// the model only sees the name and replays near-miss recordings (a recording
+	// named for item 1 got replayed for a request about item 2).
 	if err := browser.SaveSkill(dir+"/grab-id.yaml", browser.Skill{
 		Name:    "grab-id",
 		Outputs: []browser.Output{{Name: "raw"}},
-		Steps:   []browser.Step{{Action: "navigate", URL: "x"}},
+		Steps: []browser.Step{
+			{Action: "navigate", URL: "https://example.com/hot"},
+			{Action: "click", Selector: "#a", Label: "第一条"},
+		},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -41,6 +47,10 @@ func TestRenderBrowserSkillsManifest(t *testing.T) {
 		"# Browser recordings", "run_skill", "download-excels",
 		"download the monthly reports", "[params: month]", "[outputs: files (file[])]",
 		"grab-id", "[outputs: raw]",
+		// the all-or-nothing usage boundary
+		"verbatim", "drive the browser directly",
+		// the digest fallback for a description-less recording
+		`grab-id: steps: navigate example.com/hot → click "第一条"`,
 	} {
 		if !strings.Contains(m, want) {
 			t.Fatalf("manifest missing %q:\n%s", want, m)


### PR DESCRIPTION
## Problem

"打开知乎热榜的第二条" mis-triggered `run_skill name=zhihu-hot-first` — a recording whose final step clicks item **1**'s link. Replay is verbatim, so the browser landed on the wrong question page and the model had to recover by navigating back.

Two stacked causes:

1. **The manifest line was a bare name.** `zhihu-hot-first.yaml` has no `description`, so the model saw only `- zhihu-hot-first` and pattern-matched a near-miss request onto it, with no way to know the recording ends on a specific item.
2. **Descriptions silently go missing.** `GenerateSkill` falls back to the deterministic baseline (which never has a description) on *any* distill failure — LLM error, unparseable output, or the exact-string selector guard — with zero logging. Wiring was verified fine (both `WireTools` and `prepareToolTurn` install the generator since #956, before this recording was made); the fallback itself is the culprit, and post-hoc it's impossible to tell which branch fired.

## Changes

- **Manifest preamble** now states the usage boundary: a replay executes every recorded step verbatim, end to end — only replay when the request matches exactly; if any detail differs (different item/target/date), drive the browser directly.
- **Step-digest fallback**: a description-less recording renders its step path (`navigate www.zhihu.com → click "热榜" → click "日元跌破 1 美元兑 162 日元关口，创下近 40 年来新…"`), keeping the head plus the *final* step. Works for existing YAMLs — no re-recording needed.
- **GenerateSkill observability**: each fallback branch logs a `slog.Warn` with the reason, and when only the selector precision guard trips, the distilled *description* (plain prose, not selector-constrained) is kept on the baseline.

## Tests

`TestStepDigest` (labels/hint/selector fallback, rune-safe truncation, middle elision keeping the final step), distill-guard description retention in `TestGenerateSkillDistill`, manifest digest + boundary wording in `TestRenderBrowserSkillsManifest`. Full `go test -race ./...` green; verified rendering against the real `~/.octo/browser-skills` dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)