### PR TITLE
feat(agent): session goals — data model, status machine, usage accounting (PR1)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1676,19 +1676,25 @@ func (a *Agent) accrueUsage(reply Reply) {
 }
 
 // ResetGoalBaseline pins the goal-accounting baseline to the current session
-// counters, so the next accounting bills only usage from this point on.
-// Called at every turn start; the create_goal tool wiring also calls it when
-// a goal is created mid-turn, so the turn's pre-goal usage is not billed.
+// counters and restarts the goal wall clock, so the next accounting bills
+// only usage — tokens and seconds — from this point on. Called at every turn
+// start; the create_goal tool wiring also calls it when a goal is created
+// mid-turn, so the turn's pre-goal usage is not billed.
 func (a *Agent) ResetGoalBaseline() {
 	if a.GoalAcct == nil {
 		return
 	}
 	a.goalBaseIn, a.goalBaseOut = a.SessionTokens()
+	a.GoalAcct.ResetGoalWallClock()
 }
 
 // accountGoalUsage bills the session-counter delta since the last accounting
 // to the goal and emits EventGoalUpdated when the record changed. A nil
 // accountant or handler degrades gracefully (no accounting / no event).
+// The baseline advances even when the goal is not accruing (paused mid-turn),
+// so up to one LLM round of tokens straddling an external pause is dropped
+// rather than billed — paused means not billed, and re-billing them on
+// resume would be worse.
 func (a *Agent) accountGoalUsage(handler EventHandler) {
 	if a.GoalAcct == nil {
 		return

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -215,6 +215,20 @@ type Agent struct {
 	// Ruby octo's @inbox and keeps mid-turn input handling simple.
 	Inbox Inbox
 
+	// GoalAcct, when set, receives goal usage accounting after each LLM
+	// reply. Wired by the session-owning layer (Session implements
+	// GoalAccountant); nil disables goal accounting. The durable goal lives
+	// on the Session so per-turn Agents (serve rebuilds one each turn) all
+	// account into the same record.
+	GoalAcct GoalAccountant
+
+	// goalBaseIn/goalBaseOut snapshot the cumulative session counters at the
+	// last goal accounting, so each accounting bills only the delta. Reset at
+	// every turn start (and via ResetGoalBaseline when a goal is created
+	// mid-turn, so pre-goal usage in the same turn is not billed). Turn
+	// goroutine only.
+	goalBaseIn, goalBaseOut int
+
 	// Hooks is the per-Agent hook engine. It supersedes the old single-slot
 	// UserInputHook/ToolResultHook: the memory injector registers its reminder
 	// (UserPromptSubmit) and save-nudge (PostToolUse) as in-process hooks on it,
@@ -500,6 +514,7 @@ func (a *Agent) Turn(ctx context.Context, userInput string) (Reply, error) {
 	// Append user message first so the snapshot the Sender sees includes it.
 	a.appendUserInput(ctx, userInput)
 
+	a.ResetGoalBaseline()
 	reply, err := a.Sender.SendMessages(ctx, a.Model, a.System, a.History.Snapshot(), a.MaxTokens)
 	if err != nil {
 		// Pop the user message we just appended so retrying with the same
@@ -511,6 +526,7 @@ func (a *Agent) Turn(ctx context.Context, userInput string) (Reply, error) {
 
 	a.History.Append(assistantReplyMessage(reply))
 	a.accrueUsage(reply)
+	a.accountGoalUsage(nil)
 	return reply, nil
 }
 
@@ -531,6 +547,19 @@ func (a *Agent) TurnStream(
 	onChunk func(textDelta string),
 	onThinking func(thinkingDelta string),
 ) (Reply, error) {
+	return a.turnStream(ctx, userInput, onChunk, onThinking, nil)
+}
+
+// turnStream is TurnStream plus an optional event handler, so the RunStream
+// no-tools fallback keeps emitting EventGoalUpdated for goal accounting.
+// Direct TurnStream callers have no event channel and pass nil.
+func (a *Agent) turnStream(
+	ctx context.Context,
+	userInput string,
+	onChunk func(textDelta string),
+	onThinking func(thinkingDelta string),
+	handler EventHandler,
+) (Reply, error) {
 	if a.Sender == nil {
 		return Reply{}, fmt.Errorf("agent: no Sender configured")
 	}
@@ -543,6 +572,7 @@ func (a *Agent) TurnStream(
 
 	a.appendUserInput(ctx, userInput)
 
+	a.ResetGoalBaseline()
 	var (
 		reply Reply
 		err   error
@@ -565,6 +595,7 @@ func (a *Agent) TurnStream(
 
 	a.History.Append(assistantReplyMessage(reply))
 	a.accrueUsage(reply)
+	a.accountGoalUsage(handler)
 	return reply, nil
 }
 
@@ -679,7 +710,7 @@ func (a *Agent) RunStream(
 	// terminal EventTurnDone is fired here so the caller's contract is
 	// identical regardless of whether tools were used.
 	if len(tools) == 0 || executor == nil {
-		reply, err := a.TurnStream(ctx, userInput, onChunk, onThinking)
+		reply, err := a.turnStream(ctx, userInput, onChunk, onThinking, handler)
 		if err == nil && handler != nil {
 			r := reply
 			handler(AgentEvent{Kind: EventTurnDone, Reply: &r})
@@ -720,7 +751,7 @@ func (a *Agent) RunStream(
 
 	// Neither tool-aware interface available → plain TurnStream with the
 	// event-adapting onChunk. EventTurnDone fires on success.
-	reply, err = a.TurnStream(ctx, userInput, onChunk, onThinking)
+	reply, err = a.turnStream(ctx, userInput, onChunk, onThinking, handler)
 	if err == nil && handler != nil {
 		r := reply
 		handler(AgentEvent{Kind: EventTurnDone, Reply: &r})
@@ -743,6 +774,13 @@ func (a *Agent) runLoop(
 	handler EventHandler,
 	send func(ctx context.Context, msgs []Message, maxTokens int) (Reply, error),
 ) (Reply, error) {
+	// Goal accounting brackets the whole turn: the baseline reset pins the
+	// counters at turn start (usage accrued between turns is not goal work),
+	// and the deferred call catches the final reply and error/interrupt exits
+	// (the Codex TaskAborted accounting).
+	a.ResetGoalBaseline()
+	defer a.accountGoalUsage(handler)
+
 	// Compact older history before starting a new turn, if the last context
 	// crossed the threshold. Done here (a safe between-turns boundary, history
 	// ends on a complete assistant message) rather than mid-loop, where a
@@ -883,6 +921,11 @@ func (a *Agent) runLoop(
 				return Reply{}, fmt.Errorf("agent: loop[%d] escalate: %w", i, eerr)
 			}
 		}
+
+		// Bill this round's usage to the goal while the turn is still running,
+		// so a budget crossing surfaces (and, once wired, steers) mid-turn
+		// rather than only at the end.
+		a.accountGoalUsage(handler)
 
 		// ── Output-truncation recovery (layer 2) ──
 		// When escalation was attempted (cap raised) but the reply is still
@@ -1630,6 +1673,39 @@ func (a *Agent) accrueUsage(reply Reply) {
 	// three keeps the ctx-usage gauge honest; using InputTokens alone makes it
 	// read far too low once the cached prefix dominates.
 	a.lastInputTokens = reply.InputTokens + reply.CacheReadTokens + reply.CacheWriteTokens
+}
+
+// ResetGoalBaseline pins the goal-accounting baseline to the current session
+// counters, so the next accounting bills only usage from this point on.
+// Called at every turn start; the create_goal tool wiring also calls it when
+// a goal is created mid-turn, so the turn's pre-goal usage is not billed.
+func (a *Agent) ResetGoalBaseline() {
+	if a.GoalAcct == nil {
+		return
+	}
+	a.goalBaseIn, a.goalBaseOut = a.SessionTokens()
+}
+
+// accountGoalUsage bills the session-counter delta since the last accounting
+// to the goal and emits EventGoalUpdated when the record changed. A nil
+// accountant or handler degrades gracefully (no accounting / no event).
+func (a *Agent) accountGoalUsage(handler EventHandler) {
+	if a.GoalAcct == nil {
+		return
+	}
+	in, out := a.SessionTokens()
+	delta := int64(in-a.goalBaseIn) + int64(out-a.goalBaseOut)
+	if delta < 0 {
+		// Counters shrank (a fresh Agent was handed an old baseline —
+		// defensive; should not happen with turn-start resets).
+		delta = 0
+	}
+	a.goalBaseIn, a.goalBaseOut = in, out
+	goal, changed := a.GoalAcct.AccountGoalUsage(delta)
+	if changed && handler != nil {
+		g := goal
+		handler(AgentEvent{Kind: EventGoalUpdated, Goal: &g})
+	}
 }
 
 // SessionTokens returns the cumulative input and output token counts for all

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -92,6 +92,13 @@ const (
 	// compaction was a no-op (summarization failed or returned nothing) and the
 	// full history was kept. Observers should clear any compaction indicator.
 	EventCompactDone EventKind = "compact_done"
+
+	// EventGoalUpdated fires when the session goal record changes during a
+	// turn — usage accounting moved the counters or a budget crossing flipped
+	// the status. Goal carries the updated snapshot. Mutations made outside a
+	// turn (slash commands, HTTP API) don't flow through here; the mutating
+	// surface returns the Goal to its caller directly.
+	EventGoalUpdated EventKind = "goal_updated"
 )
 
 // EventToolOutputCap is the maximum length of the Output field emitted on
@@ -122,6 +129,7 @@ const EventToolOutputCap = 8 * 1024
 //   - EventCompactStarted:  Compact (BeforeTokens, FoldedMsgs, KeptTurns, MaxTokens)
 //   - EventCompactProgress: Chunk, Compact (SummaryTokens, MaxTokens)
 //   - EventCompactDone:     Compact (BeforeTokens, AfterTokens, FoldedMsgs)
+//   - EventGoalUpdated:     Goal
 //
 // JSON tags are included so HTTP/SSE transports (M8 web server) can
 // marshal events directly without an intermediate type.
@@ -143,6 +151,7 @@ type AgentEvent struct {
 	Reply    *Reply        `json:"reply,omitempty"`
 	Messages []string      `json:"messages,omitempty"`
 	Compact  *CompactStats `json:"compact,omitempty"`
+	Goal     *Goal         `json:"goal,omitempty"`
 
 	// Steer carries the full inbox items behind an EventSteerInjected —
 	// including attachment blocks — for handlers that render more than the

--- a/internal/agent/goal.go
+++ b/internal/agent/goal.go
@@ -90,6 +90,21 @@ type GoalAccountant interface {
 	// the elapsed wall-clock time into the goal, returning the updated goal
 	// and whether the record changed.
 	AccountGoalUsage(tokenDelta int64) (Goal, bool)
+	// ResetGoalWallClock re-baselines the wall clock at turn start, dropping
+	// the idle gap since the previous turn — idle time is not goal work.
+	ResetGoalWallClock()
+}
+
+// ResetGoalWallClock implements GoalAccountant: it restarts the wall-clock
+// baseline for an accruing goal so time that passed between turns is dropped
+// rather than billed. Called from the turn-start baseline reset; a stopped
+// goal (no baseline) is left alone.
+func (s *Session) ResetGoalWallClock() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.goalWallClockAt.IsZero() {
+		s.goalWallClockAt = time.Now()
+	}
 }
 
 // GoalSnapshot returns a copy of the session's goal, or ok=false when none
@@ -135,6 +150,9 @@ func (s *Session) ReplaceGoal(objective string, tokenBudget int64) (Goal, error)
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Bank the outgoing goal's wall-clock tail before discarding it — the
+	// tail is deliberately thrown away with the goal; accounting first keeps
+	// the invariant that a goal's counters are final at every observation.
 	s.accountGoalWallClockLocked()
 	return s.startGoalLocked(objective, tokenBudget), nil
 }
@@ -150,10 +168,15 @@ func (s *Session) startGoalLocked(objective string, tokenBudget int64) Goal {
 		UpdatedAt:   now,
 	}
 	s.goalWallClockAt = now
+	records := []sessionRecord{{Type: "goal", Goal: s.Goal}}
 	if s.Title == "" {
+		// Seed the title from the objective (the Codex thread-preview
+		// behavior). It needs its own record — a "goal" record doesn't carry
+		// the title, so without one the seed would vanish on reload.
 		s.Title = goalTitle(objective)
+		records = append(records, sessionRecord{Type: "title", Title: s.Title})
 	}
-	s.appendGoalRecordLocked()
+	s.appendRecordsLocked(records...)
 	return *s.Goal
 }
 
@@ -312,23 +335,40 @@ func goalTitle(objective string) string {
 }
 
 // appendGoalRecordLocked persists the current goal (nil = cleared) as an
-// append-only "goal" record, like lease records. When the transcript is not
-// yet on disk or is pending a rewrite, it does nothing: the meta header
-// written by the next Save carries the goal, and appending to an untrusted
-// tail would corrupt the file. Errors are swallowed for the same reason —
-// the in-memory goal is authoritative and the next rewrite folds it in.
+// append-only "goal" record, like lease records.
 func (s *Session) appendGoalRecordLocked() {
-	if s.persisted == 0 || s.forceRewrite {
+	s.appendRecordsLocked(sessionRecord{Type: "goal", Goal: s.Goal})
+}
+
+// appendRecordsLocked appends records to the transcript. When the file is
+// not on disk yet or is pending a rewrite, it does nothing: the meta header
+// written by the next Save carries the goal (and title), and appending to an
+// untrusted tail would corrupt the file. The on-disk check is by existence,
+// not persisted count — a meta-only transcript (saved before its first
+// message) has persisted == 0 but must still receive records, or a caller
+// that never Saves again loses the mutation (the SetModelConfig trap).
+// Errors are swallowed for the same reason the skip is safe: the in-memory
+// state is authoritative and the next rewrite folds it in.
+func (s *Session) appendRecordsLocked(records ...sessionRecord) {
+	if s.forceRewrite {
 		return
 	}
 	path, err := s.SavePath()
 	if err != nil {
 		return
 	}
+	if s.persisted == 0 {
+		if _, err := os.Stat(path); err != nil {
+			return // nothing on disk yet; the first Save writes the meta header
+		}
+	}
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return
 	}
 	defer f.Close()
-	_ = json.NewEncoder(f).Encode(sessionRecord{Type: "goal", Goal: s.Goal})
+	enc := json.NewEncoder(f)
+	for _, rec := range records {
+		_ = enc.Encode(rec)
+	}
 }

--- a/internal/agent/goal.go
+++ b/internal/agent/goal.go
@@ -1,0 +1,334 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// GoalStatus is the lifecycle state of a session goal. Ownership is the core
+// invariant: the user sets active/paused and clears; the model may only mark
+// complete or blocked (via the update_goal tool); the system sets
+// budget_limited (token budget crossed) and usage_limited (provider
+// quota/rate-limit hit during goal-driven work).
+type GoalStatus string
+
+const (
+	GoalActive        GoalStatus = "active"
+	GoalPaused        GoalStatus = "paused"
+	GoalBlocked       GoalStatus = "blocked"
+	GoalUsageLimited  GoalStatus = "usage_limited"
+	GoalBudgetLimited GoalStatus = "budget_limited"
+	GoalComplete      GoalStatus = "complete"
+)
+
+// MaxGoalObjectiveChars caps the objective length (in runes, matching the
+// Codex limit the feature is ported from).
+const MaxGoalObjectiveChars = 4000
+
+// Goal is a session's persistent objective: the agent keeps pursuing it
+// across turns until the status machine stops the continuation loop. At most
+// one goal exists per session; replacing it mints a new ID with fresh usage
+// counters.
+type Goal struct {
+	// ID identifies this goal instance. A replaced goal gets a new ID, which
+	// is what lets an in-flight continuation detect that the goal it queued
+	// for no longer exists.
+	ID        string     `json:"id"`
+	Objective string     `json:"objective"`
+	Status    GoalStatus `json:"status"`
+	// TokenBudget is the optional spend ceiling; 0 means unbudgeted.
+	TokenBudget int64 `json:"token_budget,omitempty"`
+	// TokensUsed accumulates non-cached input + output tokens while the goal
+	// was active (cache reads are deliberately free).
+	TokensUsed int64 `json:"tokens_used"`
+	// TimeUsedSeconds accumulates wall-clock seconds while the goal was active.
+	TimeUsedSeconds int64     `json:"time_used_seconds"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+// RemainingTokens reports the unspent budget, or -1 when unbudgeted.
+func (g *Goal) RemainingTokens() int64 {
+	if g.TokenBudget <= 0 {
+		return -1
+	}
+	if rem := g.TokenBudget - g.TokensUsed; rem > 0 {
+		return rem
+	}
+	return 0
+}
+
+// ValidateGoalObjective enforces the objective contract shared by every
+// mutation surface (slash commands, tools, HTTP API).
+func ValidateGoalObjective(objective string) error {
+	if objective == "" {
+		return fmt.Errorf("goal objective must not be empty")
+	}
+	if utf8.RuneCountInString(objective) > MaxGoalObjectiveChars {
+		return fmt.Errorf("goal objective must be at most %d characters", MaxGoalObjectiveChars)
+	}
+	return nil
+}
+
+func validateGoalBudget(tokenBudget int64) error {
+	if tokenBudget < 0 {
+		return fmt.Errorf("goal token budget must be positive when provided")
+	}
+	return nil
+}
+
+// GoalAccountant receives goal usage accounting from the agent loop after
+// each LLM reply. Implemented by Session; the session-owning layer wires it
+// into Agent.GoalAcct so per-turn Agents (serve rebuilds one per turn) all
+// account into the same durable record.
+type GoalAccountant interface {
+	// AccountGoalUsage folds a token delta (non-cached input + output) and
+	// the elapsed wall-clock time into the goal, returning the updated goal
+	// and whether the record changed.
+	AccountGoalUsage(tokenDelta int64) (Goal, bool)
+}
+
+// GoalSnapshot returns a copy of the session's goal, or ok=false when none
+// is set.
+func (s *Session) GoalSnapshot() (Goal, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Goal == nil {
+		return Goal{}, false
+	}
+	return *s.Goal, true
+}
+
+// CreateGoal starts a new active goal. It fails when any goal exists —
+// including a finished one; replacing is an explicit separate operation so
+// the model-facing create_goal tool can never silently discard a goal.
+func (s *Session) CreateGoal(objective string, tokenBudget int64) (Goal, error) {
+	objective = strings.TrimSpace(objective)
+	if err := ValidateGoalObjective(objective); err != nil {
+		return Goal{}, err
+	}
+	if err := validateGoalBudget(tokenBudget); err != nil {
+		return Goal{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Goal != nil {
+		return Goal{}, fmt.Errorf("session already has a goal; update or clear it first")
+	}
+	return s.startGoalLocked(objective, tokenBudget), nil
+}
+
+// ReplaceGoal discards any existing goal and starts a fresh active one with
+// a new ID and zeroed usage counters. Backs the user-confirmed
+// "/goal <objective>" replace path.
+func (s *Session) ReplaceGoal(objective string, tokenBudget int64) (Goal, error) {
+	objective = strings.TrimSpace(objective)
+	if err := ValidateGoalObjective(objective); err != nil {
+		return Goal{}, err
+	}
+	if err := validateGoalBudget(tokenBudget); err != nil {
+		return Goal{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.accountGoalWallClockLocked()
+	return s.startGoalLocked(objective, tokenBudget), nil
+}
+
+func (s *Session) startGoalLocked(objective string, tokenBudget int64) Goal {
+	now := time.Now()
+	s.Goal = &Goal{
+		ID:          "goal-" + randomSuffix(now),
+		Objective:   objective,
+		Status:      GoalActive,
+		TokenBudget: tokenBudget,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	s.goalWallClockAt = now
+	if s.Title == "" {
+		s.Title = goalTitle(objective)
+	}
+	s.appendGoalRecordLocked()
+	return *s.Goal
+}
+
+// EditGoalObjective rewrites the objective in place, preserving usage
+// counters and budget. A budget_limited or complete goal re-activates on
+// edit (the user is redefining what done means); other statuses are
+// preserved so editing a paused goal does not silently resume it.
+func (s *Session) EditGoalObjective(objective string) (Goal, error) {
+	objective = strings.TrimSpace(objective)
+	if err := ValidateGoalObjective(objective); err != nil {
+		return Goal{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Goal == nil {
+		return Goal{}, fmt.Errorf("no goal is currently set")
+	}
+	s.accountGoalWallClockLocked()
+	s.Goal.Objective = objective
+	if s.Goal.Status == GoalBudgetLimited || s.Goal.Status == GoalComplete {
+		s.setGoalStatusLocked(GoalActive)
+	}
+	s.Goal.UpdatedAt = time.Now()
+	s.appendGoalRecordLocked()
+	return *s.Goal, nil
+}
+
+// SetGoalStatus applies a status change. Which transitions a caller may
+// request is that caller's contract (slash commands pause/resume, the
+// update_goal tool completes/blocks, the runtime limits); this method owns
+// the invariants that hold regardless of caller: in-flight wall-clock time
+// is accounted first, re-activating starts a fresh wall-clock baseline, and
+// an already-over-budget goal cannot re-enter active.
+func (s *Session) SetGoalStatus(status GoalStatus) (Goal, error) {
+	switch status {
+	case GoalActive, GoalPaused, GoalBlocked, GoalUsageLimited, GoalBudgetLimited, GoalComplete:
+	default:
+		return Goal{}, fmt.Errorf("unknown goal status %q", status)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Goal == nil {
+		return Goal{}, fmt.Errorf("no goal is currently set")
+	}
+	s.accountGoalWallClockLocked()
+	s.setGoalStatusLocked(status)
+	s.Goal.UpdatedAt = time.Now()
+	s.appendGoalRecordLocked()
+	return *s.Goal, nil
+}
+
+// setGoalStatusLocked applies the status plus the budget invariant: a goal
+// at or over its budget cannot hold active — it lands on budget_limited.
+func (s *Session) setGoalStatusLocked(status GoalStatus) {
+	if status == GoalActive && goalOverBudget(s.Goal) {
+		status = GoalBudgetLimited
+	}
+	s.Goal.Status = status
+	if status == GoalActive || status == GoalBudgetLimited {
+		if s.goalWallClockAt.IsZero() {
+			s.goalWallClockAt = time.Now()
+		}
+	} else {
+		s.goalWallClockAt = time.Time{}
+	}
+}
+
+// ClearGoal deletes the goal. Reports whether one existed.
+func (s *Session) ClearGoal() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Goal == nil {
+		return false
+	}
+	s.accountGoalWallClockLocked()
+	s.Goal = nil
+	s.goalWallClockAt = time.Time{}
+	s.appendGoalRecordLocked()
+	return true
+}
+
+// AccountGoalUsage implements GoalAccountant: it folds a token delta and the
+// wall-clock time elapsed since the last accounting into the goal. Usage
+// accrues while the goal is active or budget_limited (in-flight work on a
+// just-limited goal still costs tokens), but only an active goal *crosses*
+// into budget_limited here. Persistence is best-effort — the mutation is
+// in-memory first and the meta header carries the goal on the next rewrite,
+// so a failed append loses durability, not state.
+func (s *Session) AccountGoalUsage(tokenDelta int64) (Goal, bool) {
+	if tokenDelta < 0 {
+		tokenDelta = 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Goal == nil || (s.Goal.Status != GoalActive && s.Goal.Status != GoalBudgetLimited) {
+		return Goal{}, false
+	}
+	timeDelta := s.goalWallClockDeltaLocked()
+	if tokenDelta == 0 && timeDelta == 0 {
+		return *s.Goal, false
+	}
+	s.Goal.TokensUsed += tokenDelta
+	s.Goal.TimeUsedSeconds += timeDelta
+	if s.Goal.Status == GoalActive && goalOverBudget(s.Goal) {
+		s.Goal.Status = GoalBudgetLimited
+	}
+	s.Goal.UpdatedAt = time.Now()
+	s.appendGoalRecordLocked()
+	return *s.Goal, true
+}
+
+// goalWallClockDeltaLocked returns whole elapsed seconds since the baseline
+// and advances it by exactly the amount returned, so sub-second remainders
+// carry over instead of being dropped on every accounting tick.
+func (s *Session) goalWallClockDeltaLocked() int64 {
+	if s.goalWallClockAt.IsZero() {
+		return 0
+	}
+	secs := int64(time.Since(s.goalWallClockAt) / time.Second)
+	if secs > 0 {
+		s.goalWallClockAt = s.goalWallClockAt.Add(time.Duration(secs) * time.Second)
+	}
+	return secs
+}
+
+// accountGoalWallClockLocked folds pending wall-clock time into the goal
+// before a mutation, so pausing or clearing does not lose the tail since the
+// last accounting.
+func (s *Session) accountGoalWallClockLocked() {
+	if s.Goal == nil || (s.Goal.Status != GoalActive && s.Goal.Status != GoalBudgetLimited) {
+		return
+	}
+	if secs := s.goalWallClockDeltaLocked(); secs > 0 {
+		s.Goal.TimeUsedSeconds += secs
+		s.Goal.UpdatedAt = time.Now()
+	}
+}
+
+func goalOverBudget(g *Goal) bool {
+	return g.TokenBudget > 0 && g.TokensUsed >= g.TokenBudget
+}
+
+// goalTitle derives a session title from the objective, mirroring how Codex
+// seeds the thread preview from the goal.
+func goalTitle(objective string) string {
+	const maxLen = 60
+	line := objective
+	if i := strings.IndexByte(line, '\n'); i >= 0 {
+		line = line[:i]
+	}
+	line = strings.TrimSpace(line)
+	if r := []rune(line); len(r) > maxLen {
+		return strings.TrimSpace(string(r[:maxLen-1])) + "…"
+	}
+	return line
+}
+
+// appendGoalRecordLocked persists the current goal (nil = cleared) as an
+// append-only "goal" record, like lease records. When the transcript is not
+// yet on disk or is pending a rewrite, it does nothing: the meta header
+// written by the next Save carries the goal, and appending to an untrusted
+// tail would corrupt the file. Errors are swallowed for the same reason —
+// the in-memory goal is authoritative and the next rewrite folds it in.
+func (s *Session) appendGoalRecordLocked() {
+	if s.persisted == 0 || s.forceRewrite {
+		return
+	}
+	path, err := s.SavePath()
+	if err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_ = json.NewEncoder(f).Encode(sessionRecord{Type: "goal", Goal: s.Goal})
+}

--- a/internal/agent/goal_test.go
+++ b/internal/agent/goal_test.go
@@ -1,0 +1,434 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateGoalObjective(t *testing.T) {
+	if err := ValidateGoalObjective(""); err == nil {
+		t.Error("empty objective should fail validation")
+	}
+	if err := ValidateGoalObjective(strings.Repeat("字", MaxGoalObjectiveChars+1)); err == nil {
+		t.Error("over-long objective should fail validation")
+	}
+	if err := ValidateGoalObjective(strings.Repeat("字", MaxGoalObjectiveChars)); err != nil {
+		t.Errorf("objective at the rune limit should pass, got %v", err)
+	}
+}
+
+func TestCreateGoal(t *testing.T) {
+	s := NewSession("m", "")
+	g, err := s.CreateGoal("  ship the release notes  ", 0)
+	if err != nil {
+		t.Fatalf("CreateGoal: %v", err)
+	}
+	if g.Status != GoalActive {
+		t.Errorf("status = %q, want active", g.Status)
+	}
+	if g.Objective != "ship the release notes" {
+		t.Errorf("objective not trimmed: %q", g.Objective)
+	}
+	if g.ID == "" || g.TokensUsed != 0 || g.TimeUsedSeconds != 0 {
+		t.Errorf("fresh goal has unexpected fields: %+v", g)
+	}
+	if s.Title != "ship the release notes" {
+		t.Errorf("empty title should be seeded from objective, got %q", s.Title)
+	}
+
+	// A second create fails regardless of status — even complete.
+	if _, err := s.CreateGoal("another", 0); err == nil {
+		t.Error("CreateGoal over an existing goal should fail")
+	}
+	if _, err := s.SetGoalStatus(GoalComplete); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CreateGoal("another", 0); err == nil {
+		t.Error("CreateGoal over a complete goal should still fail")
+	}
+}
+
+func TestCreateGoal_RejectsBadInput(t *testing.T) {
+	s := NewSession("m", "")
+	if _, err := s.CreateGoal("   ", 0); err == nil {
+		t.Error("whitespace objective should fail")
+	}
+	if _, err := s.CreateGoal("ok", -1); err == nil {
+		t.Error("negative budget should fail")
+	}
+	if _, ok := s.GoalSnapshot(); ok {
+		t.Error("failed create must not leave a goal behind")
+	}
+}
+
+func TestReplaceGoal_MintsNewIDAndFreshCounters(t *testing.T) {
+	s := NewSession("m", "")
+	old, err := s.CreateGoal("first", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Goal.TokensUsed = 500
+
+	g, err := s.ReplaceGoal("second", 100)
+	if err != nil {
+		t.Fatalf("ReplaceGoal: %v", err)
+	}
+	if g.ID == old.ID {
+		t.Error("replacement should mint a new goal ID")
+	}
+	if g.TokensUsed != 0 || g.Status != GoalActive || g.TokenBudget != 100 {
+		t.Errorf("replacement not fresh: %+v", g)
+	}
+}
+
+func TestEditGoalObjective(t *testing.T) {
+	s := NewSession("m", "")
+	if _, err := s.EditGoalObjective("x"); err == nil {
+		t.Error("edit with no goal should fail")
+	}
+	if _, err := s.CreateGoal("first", 200); err != nil {
+		t.Fatal(err)
+	}
+	s.Goal.TokensUsed = 150
+
+	g, err := s.EditGoalObjective("revised")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g.Objective != "revised" || g.TokensUsed != 150 || g.TokenBudget != 200 {
+		t.Errorf("edit should keep counters and budget: %+v", g)
+	}
+
+	// A paused goal stays paused on edit.
+	if _, err := s.SetGoalStatus(GoalPaused); err != nil {
+		t.Fatal(err)
+	}
+	if g, _ := s.EditGoalObjective("still paused"); g.Status != GoalPaused {
+		t.Errorf("paused goal should stay paused on edit, got %q", g.Status)
+	}
+
+	// A complete goal re-activates on edit.
+	if _, err := s.SetGoalStatus(GoalComplete); err != nil {
+		t.Fatal(err)
+	}
+	if g, _ := s.EditGoalObjective("more work"); g.Status != GoalActive {
+		t.Errorf("complete goal should re-activate on edit, got %q", g.Status)
+	}
+
+	// A budget_limited goal that is still over budget re-activates straight
+	// back into budget_limited.
+	s.Goal.TokensUsed = 250
+	if _, err := s.SetGoalStatus(GoalBudgetLimited); err != nil {
+		t.Fatal(err)
+	}
+	if g, _ := s.EditGoalObjective("over budget"); g.Status != GoalBudgetLimited {
+		t.Errorf("over-budget edit should land on budget_limited, got %q", g.Status)
+	}
+}
+
+func TestSetGoalStatus(t *testing.T) {
+	s := NewSession("m", "")
+	if _, err := s.SetGoalStatus(GoalPaused); err == nil {
+		t.Error("status change with no goal should fail")
+	}
+	if _, err := s.CreateGoal("g", 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SetGoalStatus(GoalStatus("bogus")); err == nil {
+		t.Error("unknown status should fail")
+	}
+
+	g, err := s.SetGoalStatus(GoalPaused)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g.Status != GoalPaused {
+		t.Errorf("status = %q, want paused", g.Status)
+	}
+	if !s.goalWallClockAt.IsZero() {
+		t.Error("pausing should stop the wall clock")
+	}
+
+	if g, _ = s.SetGoalStatus(GoalActive); g.Status != GoalActive {
+		t.Errorf("resume: status = %q, want active", g.Status)
+	}
+	if s.goalWallClockAt.IsZero() {
+		t.Error("resuming should restart the wall clock")
+	}
+}
+
+func TestSetGoalStatus_ActivatingOverBudgetGoalStaysBudgetLimited(t *testing.T) {
+	s := NewSession("m", "")
+	if _, err := s.CreateGoal("g", 100); err != nil {
+		t.Fatal(err)
+	}
+	s.Goal.TokensUsed = 100
+	if _, err := s.SetGoalStatus(GoalPaused); err != nil {
+		t.Fatal(err)
+	}
+	g, err := s.SetGoalStatus(GoalActive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g.Status != GoalBudgetLimited {
+		t.Errorf("activating an over-budget goal should land on budget_limited, got %q", g.Status)
+	}
+}
+
+func TestClearGoal(t *testing.T) {
+	s := NewSession("m", "")
+	if s.ClearGoal() {
+		t.Error("clearing with no goal should report false")
+	}
+	if _, err := s.CreateGoal("g", 0); err != nil {
+		t.Fatal(err)
+	}
+	if !s.ClearGoal() {
+		t.Error("clearing an existing goal should report true")
+	}
+	if _, ok := s.GoalSnapshot(); ok {
+		t.Error("goal should be gone after clear")
+	}
+}
+
+func TestAccountGoalUsage(t *testing.T) {
+	s := NewSession("m", "")
+
+	// No goal: nothing to account.
+	if _, changed := s.AccountGoalUsage(100); changed {
+		t.Error("accounting with no goal should report unchanged")
+	}
+
+	if _, err := s.CreateGoal("g", 1000); err != nil {
+		t.Fatal(err)
+	}
+	g, changed := s.AccountGoalUsage(400)
+	if !changed || g.TokensUsed != 400 || g.Status != GoalActive {
+		t.Errorf("after 400: changed=%v goal=%+v", changed, g)
+	}
+
+	// Crossing the budget flips active → budget_limited (>= semantics).
+	g, _ = s.AccountGoalUsage(600)
+	if g.TokensUsed != 1000 || g.Status != GoalBudgetLimited {
+		t.Errorf("crossing budget: goal=%+v", g)
+	}
+
+	// budget_limited keeps accruing in-flight usage but never un-flips.
+	g, changed = s.AccountGoalUsage(50)
+	if !changed || g.TokensUsed != 1050 || g.Status != GoalBudgetLimited {
+		t.Errorf("post-limit accrual: changed=%v goal=%+v", changed, g)
+	}
+
+	// Paused goals accrue nothing.
+	if _, err := s.SetGoalStatus(GoalPaused); err != nil {
+		t.Fatal(err)
+	}
+	if _, changed := s.AccountGoalUsage(100); changed {
+		t.Error("paused goal should not accrue usage")
+	}
+}
+
+func TestAccountGoalUsage_WallClock(t *testing.T) {
+	s := NewSession("m", "")
+	if _, err := s.CreateGoal("g", 0); err != nil {
+		t.Fatal(err)
+	}
+	s.goalWallClockAt = time.Now().Add(-3500 * time.Millisecond)
+
+	g, changed := s.AccountGoalUsage(0)
+	if !changed || g.TimeUsedSeconds != 3 {
+		t.Errorf("wall clock: changed=%v seconds=%d, want 3", changed, g.TimeUsedSeconds)
+	}
+	// The sub-second remainder carries over: the baseline advanced by exactly
+	// 3s, so ~500ms remain banked toward the next accounting.
+	if since := time.Since(s.goalWallClockAt); since < 400*time.Millisecond || since > 2*time.Second {
+		t.Errorf("baseline should advance by whole accounted seconds, remainder=%v", since)
+	}
+
+	// Zero tokens + zero elapsed seconds: unchanged.
+	if _, changed := s.AccountGoalUsage(0); changed {
+		t.Error("no delta should report unchanged")
+	}
+}
+
+func TestSetGoalStatus_AccountsWallClockTail(t *testing.T) {
+	s := NewSession("m", "")
+	if _, err := s.CreateGoal("g", 0); err != nil {
+		t.Fatal(err)
+	}
+	s.goalWallClockAt = time.Now().Add(-5 * time.Second)
+	g, err := s.SetGoalStatus(GoalPaused)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g.TimeUsedSeconds < 5 {
+		t.Errorf("pausing should bank the in-flight wall clock, got %ds", g.TimeUsedSeconds)
+	}
+}
+
+func TestGoal_PersistsAcrossSaveAndLoad(t *testing.T) {
+	// Goal created before the first Save rides the meta header.
+	setTempHome(t)
+
+	s := NewSession("m", "")
+	if _, err := s.CreateGoal("persisted objective", 500); err != nil {
+		t.Fatal(err)
+	}
+	s.Messages = []Message{NewUserMessage("ping")}
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, ok := got.GoalSnapshot()
+	if !ok {
+		t.Fatal("goal missing after reload")
+	}
+	if g.Objective != "persisted objective" || g.TokenBudget != 500 || g.Status != GoalActive {
+		t.Errorf("reloaded goal = %+v", g)
+	}
+	if got.goalWallClockAt.IsZero() {
+		t.Error("loading an active goal should restart the wall-clock baseline")
+	}
+}
+
+func TestGoal_AppendRecordAfterFirstSave(t *testing.T) {
+	// Mutations after the transcript exists append "goal" records; the last
+	// one wins on load, and a clear round-trips as goal-gone.
+	setTempHome(t)
+
+	s := NewSession("m", "")
+	s.Messages = []Message{NewUserMessage("ping")}
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.CreateGoal("first", 0); err != nil {
+		t.Fatal(err)
+	}
+	s.AccountGoalUsage(42)
+	if _, err := s.EditGoalObjective("second"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, ok := got.GoalSnapshot()
+	if !ok {
+		t.Fatal("goal missing after reload")
+	}
+	if g.Objective != "second" || g.TokensUsed != 42 {
+		t.Errorf("last goal record should win: %+v", g)
+	}
+
+	s.ClearGoal()
+	got, err = LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got.GoalSnapshot(); ok {
+		t.Error("cleared goal should stay cleared after reload")
+	}
+
+	// A paused goal must not restart the wall clock on load.
+	if _, err := s.CreateGoal("third", 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SetGoalStatus(GoalPaused); err != nil {
+		t.Fatal(err)
+	}
+	got, err = LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.goalWallClockAt.IsZero() {
+		t.Error("loading a paused goal must not start the wall clock")
+	}
+}
+
+func TestAgent_AccountsGoalUsagePerReply(t *testing.T) {
+	// The turn loop bills non-cached input + output to the session's goal and
+	// emits EventGoalUpdated; cache reads are free.
+	s := NewSession("m", "")
+	if _, err := s.CreateGoal("g", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	send := &fakeToolSender{replies: []Reply{
+		{Content: "done", StopReason: "end_turn", InputTokens: 300, OutputTokens: 70, CacheReadTokens: 5000},
+	}}
+	a := New(send, "claude-test")
+	a.GoalAcct = s
+
+	var goalEvents []Goal
+	_, err := a.RunStream(context.Background(), "go", nil, nil, func(ev AgentEvent) {
+		if ev.Kind == EventGoalUpdated && ev.Goal != nil {
+			goalEvents = append(goalEvents, *ev.Goal)
+		}
+	})
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+
+	g, _ := s.GoalSnapshot()
+	if g.TokensUsed != 370 {
+		t.Errorf("TokensUsed = %d, want 370 (cache reads must not be billed)", g.TokensUsed)
+	}
+	if len(goalEvents) == 0 {
+		t.Fatal("expected at least one EventGoalUpdated")
+	}
+	if last := goalEvents[len(goalEvents)-1]; last.TokensUsed != 370 {
+		t.Errorf("event TokensUsed = %d, want 370", last.TokensUsed)
+	}
+}
+
+func TestAgent_GoalBudgetCrossingFlipsMidTurn(t *testing.T) {
+	// A multi-round turn crosses the budget on round 1; the flip is visible
+	// in the emitted events before the turn ends.
+	s := NewSession("m", "")
+	if _, err := s.CreateGoal("g", 100); err != nil {
+		t.Fatal(err)
+	}
+
+	echo := ToolDefinition{Name: "echo", Description: "echo", Parameters: map[string]any{"type": "object"}}
+	send := &fakeToolSender{replies: []Reply{
+		{StopReason: "tool_use", InputTokens: 80, OutputTokens: 40,
+			Blocks: []ContentBlock{NewToolUseBlock("t1", "echo", map[string]any{})}},
+		{Content: "done", StopReason: "end_turn", InputTokens: 10, OutputTokens: 5},
+	}}
+	a := New(send, "claude-test")
+	a.GoalAcct = s
+
+	var statuses []GoalStatus
+	_, err := a.RunStream(context.Background(), "go", []ToolDefinition{echo}, &fakeExecutor{}, func(ev AgentEvent) {
+		if ev.Kind == EventGoalUpdated && ev.Goal != nil {
+			statuses = append(statuses, ev.Goal.Status)
+		}
+	})
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+
+	if len(statuses) == 0 || statuses[0] != GoalBudgetLimited {
+		t.Errorf("first accounting should flip to budget_limited, got %v", statuses)
+	}
+	g, _ := s.GoalSnapshot()
+	if g.TokensUsed != 135 || g.Status != GoalBudgetLimited {
+		t.Errorf("final goal = %+v", g)
+	}
+}
+
+func TestAgent_NoGoalAccountantIsANoOp(t *testing.T) {
+	send := &fakeSender{reply: Reply{Content: "hi", StopReason: "end_turn", InputTokens: 10, OutputTokens: 5}}
+	a := New(send, "claude-test")
+	if _, err := a.Turn(context.Background(), "hello"); err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+}

--- a/internal/agent/goal_test.go
+++ b/internal/agent/goal_test.go
@@ -432,3 +432,136 @@ func TestAgent_NoGoalAccountantIsANoOp(t *testing.T) {
 		t.Fatalf("Turn: %v", err)
 	}
 }
+
+func TestAgent_Turn_AccountsGoalUsage(t *testing.T) {
+	s := NewSession("m", "")
+	if _, err := s.CreateGoal("g", 0); err != nil {
+		t.Fatal(err)
+	}
+	send := &fakeSender{reply: Reply{Content: "hi", StopReason: "end_turn", InputTokens: 10, OutputTokens: 5}}
+	a := New(send, "claude-test")
+	a.GoalAcct = s
+	if _, err := a.Turn(context.Background(), "hello"); err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+	if g, _ := s.GoalSnapshot(); g.TokensUsed != 15 {
+		t.Errorf("TokensUsed = %d, want 15", g.TokensUsed)
+	}
+}
+
+func TestAgent_IdleTimeBetweenTurnsIsNotBilled(t *testing.T) {
+	// A stale wall-clock baseline (the session sat idle since the previous
+	// turn) is dropped by the turn-start reset, not banked into the goal.
+	s := NewSession("m", "")
+	if _, err := s.CreateGoal("g", 0); err != nil {
+		t.Fatal(err)
+	}
+	s.goalWallClockAt = time.Now().Add(-30 * time.Minute) // idle gap
+
+	send := &fakeSender{reply: Reply{Content: "hi", StopReason: "end_turn", InputTokens: 10, OutputTokens: 5}}
+	a := New(send, "claude-test")
+	a.GoalAcct = s
+	if _, err := a.Turn(context.Background(), "hello"); err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+	if g, _ := s.GoalSnapshot(); g.TimeUsedSeconds > 2 {
+		t.Errorf("idle gap was billed: TimeUsedSeconds = %d", g.TimeUsedSeconds)
+	}
+}
+
+func TestGoal_ConcurrentMutationAndAccounting(t *testing.T) {
+	// The turn goroutine accounts while another goroutine pauses/resumes/
+	// clears/recreates — the PR3/PR4 shape (slash commands during a turn).
+	// Exercised under -race; assertions are just sanity.
+	s := NewSession("m", "")
+	if _, err := s.CreateGoal("g", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 200; i++ {
+			switch i % 4 {
+			case 0:
+				s.SetGoalStatus(GoalPaused)
+			case 1:
+				s.SetGoalStatus(GoalActive)
+			case 2:
+				s.ClearGoal()
+			case 3:
+				s.CreateGoal("g", 0)
+			}
+			s.GoalSnapshot()
+		}
+	}()
+	for i := 0; i < 200; i++ {
+		s.AccountGoalUsage(1)
+		s.ResetGoalWallClock()
+	}
+	<-done
+}
+
+func TestGoal_MutationOnMetaOnlyTranscriptSurvivesReload(t *testing.T) {
+	// A transcript saved before its first message (meta-only, persisted == 0)
+	// must still receive goal records — a caller that never Saves again would
+	// otherwise lose the mutation.
+	setTempHome(t)
+
+	s := NewSession("m", "")
+	if err := s.Save(); err != nil { // meta-only file on disk
+		t.Fatal(err)
+	}
+	if _, err := s.CreateGoal("early goal", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, ok := got.GoalSnapshot()
+	if !ok || g.Objective != "early goal" {
+		t.Errorf("goal on meta-only transcript lost: ok=%v goal=%+v", ok, g)
+	}
+	if got.Title != "early goal" {
+		t.Errorf("seeded title not persisted, got %q", got.Title)
+	}
+}
+
+func TestGoal_MutationWhileRewritePendingSurvivesNextSave(t *testing.T) {
+	// With forceRewrite pending the append path must stay hands-off; the goal
+	// rides the meta header of the next Save instead.
+	setTempHome(t)
+
+	s := NewSession("m", "")
+	s.Messages = []Message{NewUserMessage("ping")}
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+	s.forceRewrite = true
+	if _, err := s.CreateGoal("pending goal", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Not on disk yet (append skipped)…
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got.GoalSnapshot(); ok {
+		t.Fatal("goal should not have been appended onto an untrusted tail")
+	}
+
+	// …but the next Save rewrites the file with the goal in the meta header.
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+	got, err = LoadSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g, ok := got.GoalSnapshot(); !ok || g.Objective != "pending goal" {
+		t.Errorf("goal lost across pending rewrite: ok=%v goal=%+v", ok, g)
+	}
+}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -92,6 +92,19 @@ type Session struct {
 	// re-attach resumes (SessionStart source=resume) rather than starting over.
 	// Set via MarkHookStarted.
 	HookStarted bool `json:"hook_started,omitempty"`
+
+	// Goal is the session's persistent objective (at most one). Guarded by mu —
+	// the turn goroutine accounts usage into it while user commands mutate it
+	// from other goroutines. Mutate only through the goal methods (goal.go);
+	// they keep the status invariants and persist via append-only "goal"
+	// records plus the meta header on rewrites.
+	Goal *Goal `json:"goal,omitempty"`
+
+	// goalWallClockAt is the baseline for wall-clock goal accounting: set when
+	// the goal (re)activates, advanced by exactly the seconds accounted. Zero
+	// while no goal is accruing time. Guarded by mu; not serialized — a
+	// resumed session restarts the clock so downtime is never billed.
+	goalWallClockAt time.Time
 }
 
 // Common entry names. Use these constants at call sites so typos are caught.
@@ -391,7 +404,7 @@ func (s *Session) ChunkDir() (string, error) {
 // type as authoritative; rewriteAll folds them back into the meta header when
 // compacting.
 type sessionRecord struct {
-	Type         string    `json:"type"` // "meta" | "message" | "title" | "model_config" | "working_dir" | "lease"
+	Type         string    `json:"type"` // "meta" | "message" | "title" | "model_config" | "working_dir" | "lease" | "goal"
 	ID           string    `json:"id,omitempty"`
 	CreatedAt    time.Time `json:"created_at,omitempty"`
 	Model        string    `json:"model,omitempty"`
@@ -406,10 +419,11 @@ type sessionRecord struct {
 	LeaseExpires time.Time `json:"lease_expires,omitempty"`
 	HookStarted  bool      `json:"hook_started,omitempty"`
 	Message      *Message  `json:"message,omitempty"`
+	Goal         *Goal     `json:"goal,omitempty"`
 }
 
 func (s *Session) metaRecord() sessionRecord {
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, WorkingDir: s.WorkingDir, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted}
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, WorkingDir: s.WorkingDir, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, Goal: s.Goal}
 }
 
 // MarkHookStarted records that SessionStart has fired for this session, so a
@@ -792,6 +806,7 @@ func LoadSession(id string) (*Session, error) {
 			s.BoundEntry = rec.BoundEntry
 			s.BoundAt = rec.BoundAt
 			s.HookStarted = rec.HookStarted
+			s.Goal = rec.Goal // a rewritten file carries the goal in its meta header
 			s.InFlight = 0
 		case "title":
 			s.Title = rec.Title // last one wins
@@ -810,6 +825,10 @@ func LoadSession(id string) (*Session, error) {
 			// Last lease record wins. An empty lease_entry clears the marker.
 			s.LeaseEntry = rec.LeaseEntry
 			s.LeaseExpires = rec.LeaseExpires
+		case "goal":
+			// Last goal record wins (it may also arrive via the meta header
+			// after a rewrite). A record with no goal payload is a clear.
+			s.Goal = rec.Goal
 		}
 	}
 	if err := sc.Err(); err != nil {
@@ -821,6 +840,11 @@ func LoadSession(id string) (*Session, error) {
 		s.ID = strings.TrimSuffix(filepath.Base(path), ".jsonl")
 	}
 	rehydrateImageBlocks(s.Messages)
+	// An accruing goal restarts its wall-clock baseline at load: the time the
+	// session spent on disk is downtime, not goal work.
+	if s.Goal != nil && (s.Goal.Status == GoalActive || s.Goal.Status == GoalBudgetLimited) {
+		s.goalWallClockAt = time.Now()
+	}
 	s.persisted = len(s.Messages) // a resumed session continues appending
 	s.forceRewrite = droppedTail
 	return s, nil

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -423,7 +423,18 @@ type sessionRecord struct {
 }
 
 func (s *Session) metaRecord() sessionRecord {
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, WorkingDir: s.WorkingDir, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, Goal: s.Goal}
+	// Snapshot the goal under mu: unlike the other meta fields (turn-goroutine
+	// serialized), *s.Goal is mutated in place by accounting while user
+	// commands may trigger a rewrite from another goroutine. Callers must not
+	// hold mu (only rewriteAll calls this, and never under the lock).
+	s.mu.Lock()
+	var goal *Goal
+	if s.Goal != nil {
+		g := *s.Goal
+		goal = &g
+	}
+	s.mu.Unlock()
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, WorkingDir: s.WorkingDir, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, Goal: goal}
 }
 
 // MarkHookStarted records that SessionStart has fired for this session, so a


### PR DESCRIPTION
## Summary

First slice of the `/goal` port (design: `dev-docs/goals-design.md`, #1049). Pure `internal/agent`; no transport or tool surface yet.

- **`Goal` on `Session`** — at most one per session; replacing mints a new ID with fresh counters. Persisted as append-only `goal` JSONL records (lease-record pattern) plus the meta header on rewrites; last record wins on load, a payload-less record is a clear.
- **Status machine** (`active/paused/blocked/usage_limited/budget_limited/complete`) with the ownership invariants from the design: mutation methods account in-flight wall-clock time first, re-activating restarts the wall clock, and an at-or-over-budget goal can never hold `active` (create/edit/resume all land it on `budget_limited`).
- **Usage accounting** — token delta = non-cached input + output (cache reads free), billed per LLM reply from all three turn paths via the `GoalAccountant` seam (`Session` implements it; per-turn Agents on serve all account into the same durable record). Wall-clock seconds accrue while active/budget_limited, with sub-second remainders carried over. Budget crossing flips `active → budget_limited` mid-turn.
- **`EventGoalUpdated`** — own event kind (per the #973 rule) carrying the goal snapshot, emitted whenever accounting changes the record. The RunStream no-tools fallback threads the handler through a new unexported `turnStream` so that path emits too.

Deviation from the design doc's slicing: the zero-progress guard moves to PR2 — it gates `GoalContinuation()`, which doesn't exist yet.

## Tests

`go test -race ./...` green; new coverage: validation, create/replace/edit/status transitions, budget-crossing semantics (incl. over-budget re-activation), wall-clock accounting + tail banking, JSONL round-trip (meta header, append records, clear, paused-vs-active wall-clock restore), turn-loop billing with cache reads excluded, mid-turn budget flip event ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)