### PR TITLE
refactor(skills): slim web-access to its unique knowledge; point to it from the browser tool

### DIFF
--- a/internal/skills/defaults/web-access/README.md
+++ b/internal/skills/defaults/web-access/README.md
@@ -1,13 +1,13 @@
 # web-access (octo-native)
 
-octo 的联网总入口 skill：把内置的 `web_search` / `web_fetch` 与原生 `browser` 工具按场景编排，并跨 session 积累站点经验。详见 [SKILL.md](./SKILL.md)。
+复杂 web 任务的方法论 skill：把内置的 `web_search` / `web_fetch` 与 `browser` 工具按场景编排，并跨 session 积累站点经验。详见 [SKILL.md](./SKILL.md)。
 
 ## 与上游的区别
 
 浏览方法论改编自 [web-access](https://github.com/eze-is/web-access)（一泽 Eze，MIT）。本版本把执行层从 Node CDP proxy（`cdp-proxy.mjs` + `curl localhost:3456`）换成 octo 原生的 `browser` 工具（纯 Go CDP，`CGO_ENABLED=0`），因此：
 
 - **无 Node 依赖** — 不再需要 Node.js 22+、`check-deps.mjs` 或常驻 proxy。
-- **浏览器操作走 `browser` 工具** — `observe` / `eval` / `click` / `type` / `scroll` / `screenshot` / `upload` / `download` / `cookies`（含 HttpOnly）/ `record_start`+`run_skill`（录制回放自愈，上游没有的能力）。
+- **浏览器操作走 `browser` 工具** — action 级用法以工具自身 schema 为准（避免此处随工具演进而过时）；相比上游额外提供 `cookies`（含 HttpOnly）与 `record_start`+`run_skill` 录制回放自愈。
 - **连接** — 在 `chrome://inspect` / `edge://inspect` 勾选 "Allow remote debugging for this browser instance"，或运行 `octo browser setup`。无配置时 `browser` 会自动连上你已开启远程调试的、已登录的浏览器。
 
 ## 站点经验

--- a/internal/skills/defaults/web-access/SKILL.md
+++ b/internal/skills/defaults/web-access/SKILL.md
@@ -5,7 +5,7 @@ description:
   复杂 web 任务的方法论与跨 session 站点经验库。Use when：抓取反爬或需登录态的平台（小红书、微信公众号、微博、推特、知乎等）、
   目标站点结构未知需要边看边探索、多来源交叉核实信息、分析页面里的图片/视频内容、并行调研多个独立来源、
   或 web_search/web_fetch 拿不到目标内容需要升级到真实浏览器时。
-  简单的已知 URL 抓取或单步页面操作不需要加载本 skill——直接用 web_fetch / browser 工具即可。
+  简单的已知 URL 抓取或单步页面操作（无登录/反爬因素）不需要加载本 skill——直接用 web_fetch / browser 工具即可。
 metadata:
   origin: 浏览方法论改编自 web-access（一泽 Eze，MIT）；执行层改用 octo 原生 browser 工具，无 Node 依赖
 ---

--- a/internal/skills/defaults/web-access/SKILL.md
+++ b/internal/skills/defaults/web-access/SKILL.md
@@ -2,17 +2,17 @@
 name: web-access
 license: MIT
 description:
-  所有联网操作的统一入口，包括：搜索、网页抓取、浏览器自动化、登录后操作、网络交互等。
-  触发场景：用户要求搜索信息、查看网页内容、操控浏览器操作网页界面、访问需要登录的网站、抓取社交媒体内容（小红书、微博、推特等）、读取动态渲染页面、以及任何需要真实浏览器环境的网络任务。
+  复杂 web 任务的方法论与跨 session 站点经验库。Use when：抓取反爬或需登录态的平台（小红书、微信公众号、微博、推特、知乎等）、
+  目标站点结构未知需要边看边探索、多来源交叉核实信息、分析页面里的图片/视频内容、并行调研多个独立来源、
+  或 web_search/web_fetch 拿不到目标内容需要升级到真实浏览器时。
+  简单的已知 URL 抓取或单步页面操作不需要加载本 skill——直接用 web_fetch / browser 工具即可。
 metadata:
   origin: 浏览方法论改编自 web-access（一泽 Eze，MIT）；执行层改用 octo 原生 browser 工具，无 Node 依赖
 ---
 
 # Skill: web-access
 
-octo 的联网总入口：把内置的 `web_search` / `web_fetch` 与原生 `browser` 工具（纯 Go CDP，驱动你日常的、已登录的 Chrome/Edge）按场景编排起来，并跨 session 积累站点经验。
-
-无需 Node、无需独立 proxy——浏览器操作全部通过 `browser` 工具完成。
+复杂 web 任务的方法论：把内置的 `web_search` / `web_fetch` 与 `browser` 工具（驱动你日常的、已登录的 Chrome/Edge）按场景编排起来，并跨 session 积累站点经验。
 
 ## 前置：浏览器自动化
 
@@ -57,37 +57,12 @@ octo 的联网总入口：把内置的 `web_search` / `web_fetch` 与原生 `bro
 
 `web_search` / `web_fetch` / curl 都不处理登录态。`browser` 不要求 URL 已知——可从任意入口出发，靠页面内搜索、点击、跳转找到目标。
 
-## browser 工具
+## browser 工具要点
 
-一个 action 复用的工具，驱动一个真实 Chrome 会话（navigate→click→download 共享同一页面）。
+action 级用法（observe / click / eval / record / run_skill 等的参数与语义）以 `browser` 工具自身的 schema 描述为准，此处不重复。schema 之外的判断准则：
 
-**看**
-- `observe` — 截图（模型能直接看见）+ 当前页可交互元素清单（带选择器）。看陌生页面、决定下一步的首选。
-- `screenshot` — 仅截图（视觉识别、视频帧）。
-- `eval`（`js`）— 执行任意 JS：读写 DOM、提取数据、操控元素、提交表单、调用内部方法。递归遍历可穿透 Shadow DOM / iframe 等选择器跨不过的边界。
-- `ax` — 无障碍树摘要（语义视图）。
-- `pages` / `select_page`（`index`）— 列出 / 切换标签页。
-
-**做**
-- `navigate`（`url`）、`back`
-- `click`（`selector`，可选 `frame`）— 真实鼠标手势（CDP），能触发文件对话框等。
-- `hover` / `type`（`selector`,`text`）/ `select`（`selector`,`value`）/ `key`（`keys`，如 `enter`、`ctrl+a`）
-- `scroll`（`selector`,`dx`,`dy`）— 触发懒加载。
-- `wait`（`selector`,`timeout_ms`）— 等元素出现（动态页面的校验原语）。
-- `upload`（`selector`,`files`）— 给 file input 设本地路径，绕过文件对话框。
-- `download`（`selector`）— 点击触发并捕获客户端生成的下载文件（落盘）。
-
-**登录态 / 数据**
-- `cookies` — 当前页 cookie，**含 HttpOnly**（`document.cookie`/eval 读不到的那些）。提取/复用登录会话、OAuth token 用它。
-
-**录制 / 回放（web-access 没有的能力）**
-- `record_start` / `record_stop`（`name`）— 把**用户本人**的一次真实演示录成可编辑的 skill。录制只捕获用户在浏览器里的真实手势（点击/输入），**不录你自己的工具动作**。所以正确姿势是：`record_start` 之后**把控制权交还用户**——告诉用户「录制已开始，请你在浏览器里完成这些操作，做完告诉我」，等用户说完成，再 `record_stop`。**录制期间不要自己 navigate/click/type**：那不是演示，而且会跳转的点击极易丢失，录出来是空的。
-- `run_skill`（`name`,`params`）— 确定性回放，自带按步隐式等待与选择器自愈。重复性流程（批量操作、定期取数）优先录制回放，而非每次盲驱动。
-
-**收尾**
-- `close` — 关闭自己开的标签页，保留用户原有标签页。
-
-> 同源 iframe：给需要进 iframe 的动作传 `frame`（iframe 的 CSS 选择器）。跨域 iframe 暂不支持。
+- 重复性流程（批量操作、定期取数）优先录制回放（record → run_skill），而非每次盲驱动。
+- 收尾用 `close` 关闭自己开的标签页，保留用户原有标签页。
 
 ### 程序化 vs GUI 交互
 

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -283,7 +283,11 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 		Description: "Drive a real Chrome browser to automate a web task: navigate, " +
 			"click elements, type, wait for elements, capture file downloads, screenshot, " +
 			"and inspect the page. Reuses the user's logged-in session. Use only when the " +
-			"task genuinely needs operating a web UI (no API available).",
+			"task genuinely needs operating a web UI (no API available); for a known URL's " +
+			"public content, web_fetch is cheaper. Before a nontrivial web task — an " +
+			"anti-bot platform, a login wall, an unfamiliar site to explore, multi-source " +
+			"research — load the web-access skill first (via the skill tool, when listed): " +
+			"it carries tool-routing rules and per-site experience notes from past sessions.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -286,7 +286,8 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 			"task genuinely needs operating a web UI (no API available); for a known URL's " +
 			"public content, web_fetch is cheaper. Before a nontrivial web task — an " +
 			"anti-bot platform, a login wall, an unfamiliar site to explore, multi-source " +
-			"research — load the web-access skill first (via the skill tool, when listed): " +
+			"research — load the web-access skill first (via the skill tool, if it appears " +
+			"under Available skills): " +
 			"it carries tool-routing rules and per-site experience notes from past sessions.",
 		Parameters: map[string]any{
 			"type": "object",
@@ -294,7 +295,7 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 				"action": map[string]any{
 					"type":        "string",
 					"enum":        []string{"navigate", "back", "click", "hover", "type", "select", "key", "scroll", "wait", "screenshot", "observe", "ax", "cookies", "upload", "download", "pages", "select_page", "close", "eval", "record_start", "record_stop", "run_skill"},
-					"description": "The browser action to perform. observe lists the page's URL/title and interactable elements with selectors (text only) — the cheap way to look at an unfamiliar page before acting; works on any model. screenshot returns an image of the page for a vision-capable model to actually see (use when content is visual). cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture the USER's own demonstration into an editable skill — record_start only installs listeners, so after it you MUST hand control to the user: tell them to perform the actions themselves in their browser and to say when they're done, then call record_stop. Do NOT drive the page yourself (navigate/click/type) while recording — your tool actions are not the demonstration and a click that navigates is easily lost; only the user's real gestures are captured. run_skill replays a recording (deterministic, self-healing).",
+					"description": "The browser action to perform. observe lists the page's URL/title and interactable elements with selectors (text only) — the cheap way to look at an unfamiliar page before acting; works on any model. screenshot returns an image of the page for a vision-capable model to actually see (use when content is visual). ax returns an accessibility-tree digest (roles and names) — a semantic text view of the page, an alternative to observe when document structure matters more than selectors. pages lists open tabs; select_page switches between them. cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture the USER's own demonstration into an editable skill — record_start only installs listeners, so after it you MUST hand control to the user: tell them to perform the actions themselves in their browser and to say when they're done, then call record_stop. Do NOT drive the page yourself (navigate/click/type) while recording — your tool actions are not the demonstration and a click that navigates is easily lost; only the user's real gestures are captured. run_skill replays a recording (deterministic, self-healing).",
 				},
 				"name":         map[string]any{"type": "string", "description": "Skill name (record_stop / run_skill)."},
 				"params":       map[string]any{"type": "object", "description": "Param values for {{...}} placeholders (run_skill)."},
@@ -305,8 +306,8 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 				"text":         map[string]any{"type": "string", "description": "Text to type (type)."},
 				"value":        map[string]any{"type": "string", "description": "Option value, text, or label to pick in a <select> (select)."},
 				"keys":         map[string]any{"type": "string", "description": "Key or combo, e.g. enter, escape, ctrl+a (key)."},
-				"js":           map[string]any{"type": "string", "description": "JavaScript expression to evaluate (eval)."},
-				"files":        map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Absolute file paths to set on a file <input> (upload)."},
+				"js":           map[string]any{"type": "string", "description": "JavaScript expression to evaluate (eval). Runs with full page access — use it to recursively traverse shadow roots or read DOM state that CSS selectors can't reach (click/type don't pierce shadow DOM)."},
+				"files":        map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Absolute file paths to set on a file <input> (upload). Use this instead of clicking an upload button — a click opens a native file dialog that cannot be driven."},
 				"index":        map[string]any{"type": "integer", "description": "Page index from the pages list to switch to (select_page)."},
 				"timeout_ms":   map[string]any{"type": "integer", "description": "Wait timeout in ms (wait); default 10000."},
 				"dx":           map[string]any{"type": "number", "description": "Horizontal scroll delta (scroll)."},


### PR DESCRIPTION
## Problem

The model routinely skipped the `web-access` skill and drove the `browser` tool directly. Structural, not a model quirk:

- The tool schema is always in context and self-sufficient (observe/record/run_skill guidance moved there in #960), so the model never feels it's missing knowledge — loading a skill is an extra step with no perceived payoff.
- The skill's L1 description ("所有联网操作的统一入口") was positioning, not a trigger condition — nothing for task-matching to latch onto.
- Its genuinely unique content (tool routing, cross-session site-patterns store, login/anti-bot judgment) was buried under a ~40-line browser action reference that duplicated the tool description and drifts as the tool evolves.

## Changes

Principle: **short, always-applicable guidance goes on the tool description (always in context); long, situational knowledge goes in the skill (loaded on demand).**

- `web-access/SKILL.md`: drop the browser action reference (schema is authoritative; kept two judgment rules — prefer record→run_skill for repetitive flows, close own tabs). Rewrite the L1 description trigger-style: concrete platforms (小红书/公众号/微博/知乎), concrete scenarios (unfamiliar-site exploration, multi-source verification, media analysis), plus an explicit "simple known-URL fetch / single-step page op does NOT need this skill". Drop ported-from-Node provenance prose (zero information for the model). 175 → 148 lines.
- `browser` tool description: route known-URL public content to `web_fetch`, and point to loading `web-access` first for nontrivial tasks (anti-bot platforms, login walls, unfamiliar sites, multi-source research).

## Tests

`go test ./internal/skills/ ./internal/tools/` green (no code paths changed; Go change is a description string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)