### PR TITLE
feat(tui): render show_artifact as a click-to-open file:// hyperlink

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strconv"
@@ -1439,6 +1440,16 @@ func (m *tuiModel) rendersCard(toolName string) bool {
 func (m *tuiModel) renderToolOutcome(toolName string, input map[string]any, resultText string, isErr bool) string {
 	if m.rendersCard(toolName) {
 		return renderToolCard(toolName, input, resultText, isErr)
+	}
+	// show_artifact's whole point is "present this file to the user"; the web
+	// UI has the Artifacts panel, the TUI's equivalent is a click-to-open
+	// file:// hyperlink (plain text on terminals without OSC 8 support).
+	if toolName == "show_artifact" && !isErr && !m.cfg.plain {
+		if p, _ := input["path"].(string); strings.TrimSpace(p) != "" {
+			if abs, err := filepath.Abs(strings.TrimSpace(p)); err == nil {
+				return tui.RenderArtifactStatus(abs)
+			}
+		}
 	}
 	if m.cfg.plain {
 		if isErr {

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1444,11 +1444,12 @@ func (m *tuiModel) renderToolOutcome(toolName string, input map[string]any, resu
 	// show_artifact's whole point is "present this file to the user"; the web
 	// UI has the Artifacts panel, the TUI's equivalent is a click-to-open
 	// file:// hyperlink (plain text on terminals without OSC 8 support).
+	// Only absolute paths are linkified: a relative one re-resolved at render
+	// time can diverge from the execute-time cwd on resumed-history replay,
+	// producing a confident link to the wrong file.
 	if toolName == "show_artifact" && !isErr && !m.cfg.plain {
-		if p, _ := input["path"].(string); strings.TrimSpace(p) != "" {
-			if abs, err := filepath.Abs(strings.TrimSpace(p)); err == nil {
-				return tui.RenderArtifactStatus(abs)
-			}
+		if p, _ := input["path"].(string); filepath.IsAbs(strings.TrimSpace(p)) {
+			return tui.RenderArtifactStatus(strings.TrimSpace(p))
 		}
 	}
 	if m.cfg.plain {

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -1105,3 +1105,29 @@ func TestTUI_Paste_EscClears(t *testing.T) {
 		t.Errorf("box should be empty after Esc, got %q", m.ta.Value())
 	}
 }
+
+// show_artifact's whole point is presenting a file to the user; in the rich
+// TUI its status line carries an OSC 8 file:// hyperlink so the artifact is
+// click-to-open. Errors and --plain keep the generic status forms (no escapes
+// in the plain/headless transcript).
+func TestTUI_RenderToolOutcome_ArtifactHyperlink(t *testing.T) {
+	m := newTestModel()
+	input := map[string]any{"path": "/tmp/report.html"}
+
+	got := m.renderToolOutcome("show_artifact", input, "Artifact presented: /tmp/report.html (12 bytes)", false)
+	if !strings.Contains(got, "\x1b]8;;file:///tmp/report.html\x1b\\") {
+		t.Errorf("success line should carry an OSC 8 file:// hyperlink; got %q", got)
+	}
+	if !strings.Contains(got, "/tmp/report.html") {
+		t.Errorf("success line should show the path; got %q", got)
+	}
+
+	if got := m.renderToolOutcome("show_artifact", input, "boom", true); strings.Contains(got, "\x1b]8;;") {
+		t.Errorf("error outcome should not render a hyperlink; got %q", got)
+	}
+
+	m.cfg.plain = true
+	if got := m.renderToolOutcome("show_artifact", input, "ok", false); strings.Contains(got, "\x1b]8;;") {
+		t.Errorf("--plain outcome should not render a hyperlink; got %q", got)
+	}
+}

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"fmt"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/tui"
 )
 
 // fakeProg records messages the sink sends, standing in for *tea.Program.
@@ -1112,14 +1114,26 @@ func TestTUI_Paste_EscClears(t *testing.T) {
 // in the plain/headless transcript).
 func TestTUI_RenderToolOutcome_ArtifactHyperlink(t *testing.T) {
 	m := newTestModel()
-	input := map[string]any{"path": "/tmp/report.html"}
+	// Platform-appropriate absolute path: linkify is gated on filepath.IsAbs,
+	// and a rootless /tmp/... is NOT absolute on Windows.
+	path := "/tmp/report.html"
+	if runtime.GOOS == "windows" {
+		path = `C:\tmp\report.html`
+	}
+	input := map[string]any{"path": path}
 
-	got := m.renderToolOutcome("show_artifact", input, "Artifact presented: /tmp/report.html (12 bytes)", false)
-	if !strings.Contains(got, "\x1b]8;;file:///tmp/report.html\x1b\\") {
+	got := m.renderToolOutcome("show_artifact", input, "Artifact presented: "+path+" (12 bytes)", false)
+	if !strings.Contains(got, "\x1b]8;;"+tui.FileURI(path)+"\x1b\\") {
 		t.Errorf("success line should carry an OSC 8 file:// hyperlink; got %q", got)
 	}
-	if !strings.Contains(got, "/tmp/report.html") {
+	if !strings.Contains(got, path) {
 		t.Errorf("success line should show the path; got %q", got)
+	}
+
+	// A relative path must NOT be linkified — re-resolving it at render time
+	// diverges from the execute-time cwd on resumed-history replay.
+	if got := m.renderToolOutcome("show_artifact", map[string]any{"path": "rel/report.html"}, "ok", false); strings.Contains(got, "\x1b]8;;") {
+		t.Errorf("relative path should not render a hyperlink; got %q", got)
 	}
 
 	if got := m.renderToolOutcome("show_artifact", input, "boom", true); strings.Contains(got, "\x1b]8;;") {

--- a/internal/tools/artifact.go
+++ b/internal/tools/artifact.go
@@ -62,7 +62,8 @@ func (ShowArtifactTool) Definition() agent.ToolDefinition {
 			"heredoc/redirect like `cat > x.html`, a script, a build step, or a download). Files you " +
 			"create with write_file/edit_file are surfaced automatically and do NOT need this. In the " +
 			"web UI the file opens in the Artifacts panel (HTML renders in a sandboxed preview); in " +
-			"other clients the path is simply reported. The file must already exist.",
+			"the TUI the path renders as a click-to-open link; elsewhere the path is simply " +
+			"reported. The file must already exist.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tui/outputcard.go
+++ b/internal/tui/outputcard.go
@@ -90,14 +90,24 @@ func Hyperlink(uri, text string) string {
 
 // FileURI converts an absolute filesystem path to a file:// URI, percent-
 // encoding as needed. Windows drive paths gain the required leading slash
-// (C:\x → file:///C:/x).
+// (C:\x → file:///C:/x); UNC paths put the server in the URI authority
+// (\\server\share\x → file://server/share/x). Semicolons are percent-encoded
+// even though URIs allow them raw: the OSC 8 escape that carries this URI is
+// itself semicolon-delimited, and a raw one truncates the link in strict
+// terminal parsers.
 func FileURI(abs string) string {
 	p := filepath.ToSlash(abs)
-	if !strings.HasPrefix(p, "/") {
-		p = "/" + p
+	u := url.URL{Scheme: "file"}
+	if rest, ok := strings.CutPrefix(p, "//"); ok {
+		host, path, _ := strings.Cut(rest, "/")
+		u.Host, u.Path = host, "/"+path
+	} else {
+		if !strings.HasPrefix(p, "/") {
+			p = "/" + p
+		}
+		u.Path = p
 	}
-	u := url.URL{Scheme: "file", Path: p}
-	return u.String()
+	return strings.ReplaceAll(u.String(), ";", "%3B")
 }
 
 // RenderArtifactStatus renders show_artifact's success line: the path as an

--- a/internal/tui/outputcard.go
+++ b/internal/tui/outputcard.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"net/url"
+	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -75,4 +77,33 @@ func RenderToolStatus(name, target string, isErr bool, errText string) string {
 		s += " " + outMore.Render("— "+errText)
 	}
 	return s
+}
+
+var linkText = lipgloss.NewStyle().Underline(true)
+
+// Hyperlink wraps text in an OSC 8 terminal hyperlink. Terminals that support
+// OSC 8 (iTerm2, Windows Terminal, kitty, WezTerm) make the text click-to-open;
+// others ignore the escape sequences and show the plain text — a safe fallback.
+func Hyperlink(uri, text string) string {
+	return "\x1b]8;;" + uri + "\x1b\\" + text + "\x1b]8;;\x1b\\"
+}
+
+// FileURI converts an absolute filesystem path to a file:// URI, percent-
+// encoding as needed. Windows drive paths gain the required leading slash
+// (C:\x → file:///C:/x).
+func FileURI(abs string) string {
+	p := filepath.ToSlash(abs)
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	u := url.URL{Scheme: "file", Path: p}
+	return u.String()
+}
+
+// RenderArtifactStatus renders show_artifact's success line: the path as an
+// underlined click-to-open file:// hyperlink, so a TUI user can open the
+// artifact directly instead of hunting the file down by hand.
+func RenderArtifactStatus(absPath string) string {
+	return fmt.Sprintf("%s %s %s", outBullet, headerVerb.Render("Artifact"),
+		Hyperlink(FileURI(absPath), linkText.Render(absPath)))
 }

--- a/internal/tui/outputcard_test.go
+++ b/internal/tui/outputcard_test.go
@@ -83,6 +83,10 @@ func TestFileURI(t *testing.T) {
 		// A Windows drive path (already slashed — filepath.ToSlash converts the
 		// separators on Windows itself) gains the required leading slash.
 		{"C:/Users/a/chart.html", "file:///C:/Users/a/chart.html"},
+		// UNC: server goes in the URI authority, not a 4-slash legacy form.
+		{"//server/share/x.html", "file://server/share/x.html"},
+		// Raw ';' would truncate the OSC 8 escape in strict parsers.
+		{"/tmp/a;b.html", "file:///tmp/a%3Bb.html"},
 	}
 	for _, c := range cases {
 		if got := FileURI(c.in); got != c.want {

--- a/internal/tui/outputcard_test.go
+++ b/internal/tui/outputcard_test.go
@@ -75,3 +75,34 @@ func TestRenderOutputCard_Highlight(t *testing.T) {
 		t.Errorf("expected ANSI escapes from Chroma highlighting; got:\n%s", got)
 	}
 }
+
+func TestFileURI(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/tmp/report.html", "file:///tmp/report.html"},
+		{"/tmp/my report.html", "file:///tmp/my%20report.html"},
+		// A Windows drive path (already slashed — filepath.ToSlash converts the
+		// separators on Windows itself) gains the required leading slash.
+		{"C:/Users/a/chart.html", "file:///C:/Users/a/chart.html"},
+	}
+	for _, c := range cases {
+		if got := FileURI(c.in); got != c.want {
+			t.Errorf("FileURI(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRenderArtifactStatus(t *testing.T) {
+	got := RenderArtifactStatus("/tmp/report.html")
+	// OSC 8 open + URI, the visible path, and the OSC 8 close must all be there;
+	// terminals without OSC 8 support ignore the escapes and show the path.
+	for _, want := range []string{
+		"\x1b]8;;file:///tmp/report.html\x1b\\",
+		"/tmp/report.html",
+		"\x1b]8;;\x1b\\",
+		"Artifact",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("artifact status missing %q; got:\n%q", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

In the TUI, `show_artifact` printed only a bare status line with a path — the user had to find and open the file by hand (the tool description literally said "in other clients the path is simply reported"). The web UI gets the Artifacts panel; the TUI got nothing.

## Change

The TUI's equivalent of "present this file": the status line renders the absolute path as an **OSC 8 `file://` hyperlink** (underlined), click-to-open in iTerm2 / Windows Terminal / kitty / WezTerm. Terminals without OSC 8 support ignore the escape sequences and show the plain path — safe degradation, no capability detection needed.

- `tui.Hyperlink(uri, text)` + `tui.FileURI(abs)` (percent-encodes; Windows drive paths gain the leading slash: `C:\x` → `file:///C:/x`) + `tui.RenderArtifactStatus`.
- Special-cased in `renderToolOutcome` — success + rich TUI only. Errors keep the generic error status; `--plain` keeps the escape-free one-liner (headless transcript parity). Resumed-history replay shares the same path, so replayed sessions render identically.
- `show_artifact` tool description updated to state the TUI behavior.

Scope note: deliberately link-only (no auto-open of the default browser) — TUI users are assumed capable; discussed as option 2 of the usability review that produced #1054.

## Tests

`TestFileURI` (encoding + drive-path slash), `TestRenderArtifactStatus` (OSC 8 open/close framing), `TestTUI_RenderToolOutcome_ArtifactHyperlink` (success links; error and --plain don't). `go test -race ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)