### PR TITLE
feat(tui): /goal surface, status-bar segment, continuation kick (PR3)

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -568,6 +568,14 @@ func newTUIModel(cfg replConfig) *tuiModel {
 		style = "light"
 	}
 	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}, subAgentFocus: -1, workflows: map[string]*workflowUI{}}
+	// Seed the last-seen goal status so a resumed session's first transition
+	// (e.g. the budget crossing) prints its notice instead of being treated
+	// as the baseline.
+	if m.goalsWired() {
+		if g, ok := cfg.session.GoalSnapshot(); ok {
+			m.goalLastStatus = g.Status
+		}
+	}
 	_ = m.updateTextAreaHeight()
 	return m
 }
@@ -725,6 +733,14 @@ func (m *tuiModel) startTurnEcho(line, echo string) tea.Cmd {
 // Pass "" for turns that aren't a verbatim typed message (skills, /init,
 // dequeued items) — those can't be meaningfully restored.
 func (m *tuiModel) startTurnEchoRestore(line, echo, restore string) tea.Cmd {
+	// Any turn start cancels a pending /goal edit — async idle auto-turns
+	// (background exits, sub-agent notes, loop wakeups) can fire while the
+	// edit is armed, and a stale flag would silently consume the user's next
+	// unrelated message as the objective.
+	if m.goalEditPending {
+		m.goalEditPending = false
+		m.printlnBlock(noticeStyle.Render("Goal edit cancelled"))
+	}
 	m.turnRunning = true
 	m.turnStart = time.Now()
 	m.spinnerFrame = 0
@@ -1040,7 +1056,18 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// error/interrupt.
 		if msg.err == nil {
 			cmds := []tea.Cmd{m.flushPrints()}
-			if m.cfg.suggest {
+			// While a goal is active the continuation kick starts the next
+			// turn immediately and would discard the suggestion unread — on
+			// an unbounded loop that is one paid throwaway call per
+			// iteration. An active goal makes "suggest my next message"
+			// noise anyway; skip it.
+			goalActive := false
+			if m.goalsWired() {
+				if g, ok := m.cfg.session.GoalSnapshot(); ok && g.Status == agent.GoalActive {
+					goalActive = true
+				}
+			}
+			if m.cfg.suggest && !goalActive {
 				cmds = append(cmds, m.suggestCmd())
 			}
 			if c := m.titleCmd(); c != nil {

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -367,6 +367,13 @@ type tuiModel struct {
 	// queue holds Ctrl+Q messages to run as future turns (design §8/§10).
 	queue []pendingItem
 
+	// goalEditPending marks that /goal edit armed the input: the next
+	// submitted line is the edited objective, not a message.
+	goalEditPending bool
+	// goalLastStatus is the last goal status seen via EventGoalUpdated, so
+	// only transitions print a notice.
+	goalLastStatus agent.GoalStatus
+
 	// pendingSteer holds steer messages typed during a running turn that
 	// haven't been drained yet. Shown in the live View area (below the
 	// scrollback) so the user sees immediate feedback without breaking
@@ -570,10 +577,16 @@ func newTUIModel(cfg replConfig) *tuiModel {
 type autoSubmitMsg struct{ text string }
 
 func (m *tuiModel) Init() tea.Cmd {
-	boot := tea.Sequence(
-		tea.Println(tui.Banner("", m.a.Model, m.cwd, m.width)),
-		textarea.Blink,
-	)
+	bootCmds := []tea.Cmd{tea.Println(tui.Banner("", m.a.Model, m.cwd, m.width))}
+	// A resumed session carrying a goal gets a one-line reminder under the
+	// banner (the Codex resume-paused prompt, as a hint instead of a modal).
+	if m.goalsWired() {
+		if notice := goalStartupNotice(m.cfg.session); notice != "" {
+			bootCmds = append(bootCmds, tea.Println(notice))
+		}
+	}
+	bootCmds = append(bootCmds, textarea.Blink)
+	boot := tea.Sequence(bootCmds...)
 	cmds := []tea.Cmd{boot}
 	// Connect MCP concurrently with the first paint (tea.Batch, not Sequence)
 	// so the banner + input appear immediately and the servers' handshake cost
@@ -1038,7 +1051,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.flushPrints()
 
 	case turnFinishedMsg:
-		return m.handleTurnFinished()
+		return m.handleTurnFinished(msg.err)
 
 	case askMsg:
 		m.openModal(msg)
@@ -1395,6 +1408,10 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 		}
 		return
 
+	case agent.EventGoalUpdated:
+		m.handleGoalUpdated(ev.Goal)
+		return
+
 	case agent.EventSteerInjected:
 		// Inbox drained mid-turn: print the steer messages to the scrollback
 		// immediately so they appear in chronological order (before the next
@@ -1405,11 +1422,12 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 		if s, ok := m.flushTextString(); ok {
 			m.printlnBlock(s)
 		}
-		// Skip <system-reminder> blocks (model-facing context) and empty text
-		// (an image-only steer carries its payload in blocks, not Messages).
+		// Skip injected model-facing spans (<system-reminder>, <goal_context>)
+		// and empty text (an image-only steer carries its payload in blocks,
+		// not Messages).
 		for _, s := range ev.Messages {
-			if s != "" && !strings.HasPrefix(s, "<system-reminder>") {
-				m.printlnBlock(userEchoStyle.Render("> ") + s)
+			if visible := strings.TrimSpace(agent.StripSystemReminders(s)); visible != "" {
+				m.printlnBlock(userEchoStyle.Render("> ") + visible)
 			}
 		}
 		// pendingSteer is FIFO and mirrors the inbox, so the drained messages
@@ -1685,7 +1703,7 @@ func (m *tuiModel) flushPrints() tea.Cmd {
 	return tea.Sequence(cmds...)
 }
 
-func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
+func (m *tuiModel) handleTurnFinished(err error) (tea.Model, tea.Cmd) {
 	m.flushSprint() // safety net: never strand held answer text on interrupt
 	m.turnRunning = false
 	m.cancelTurn = nil
@@ -1705,13 +1723,31 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 		_ = m.cfg.session.Save()
 	}
 
+	// An aborted or errored turn parks the goal-continuation loop: an
+	// interrupt means the user said stop, and chaining onto a persistent
+	// error is unbounded paid retries. The zero-progress audit can't catch
+	// either (partial replies were already billed). A rate-limited
+	// continuation turn parks harder — usage_limited persists until
+	// /goal resume.
+	if err != nil && m.goalsWired() {
+		if m.cfg.session.GoalContinuationPending() && agent.IsRateLimitErr(err) {
+			if g, gerr := m.cfg.session.SetGoalStatus(agent.GoalUsageLimited); gerr == nil {
+				m.printlnBlock(noticeStyle.Render("● Goal usage limited (provider rate limit) — /goal resume to retry"))
+				m.goalLastStatus = g.Status
+			}
+		}
+		m.cfg.session.SuppressGoalContinuation()
+	}
+
 	// Drain any inbox messages that weren't consumed during the turn and
-	// run them as the next turn, ahead of explicitly-queued items.
+	// run them as the next turn, ahead of explicitly-queued items. Injected
+	// model-facing spans (<system-reminder>, <goal_context>) are not user
+	// speech — strip them from the echo, and skip lines that were nothing else.
 	if items := m.a.Inbox.Drain(); len(items) > 0 {
 		it := pendingFromInbox(items)
 		for _, line := range strings.Split(it.text, "\n\n") {
-			if line != "" && !strings.HasPrefix(line, "<system-reminder>") {
-				m.printlnBlock(userEchoStyle.Render("> ") + line)
+			if visible := strings.TrimSpace(agent.StripSystemReminders(line)); visible != "" {
+				m.printlnBlock(userEchoStyle.Render("> ") + visible)
 			}
 		}
 		m.queue = append([]pendingItem{it}, m.queue...)
@@ -1730,6 +1766,15 @@ func (m *tuiModel) handleTurnFinished() (tea.Model, tea.Cmd) {
 			return model, tea.Sequence(m.flushPrints(), cmd)
 		}
 		return m, m.startQueued(next)
+	}
+
+	// Idle with nothing queued: an active goal keeps going. The session owns
+	// the policy (status, zero-progress suppression); user input always won
+	// above by reaching the queue/inbox branches first.
+	if err == nil {
+		if prompt, ok := m.goalContinuationKick(); ok {
+			return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(prompt, ""))
+		}
 	}
 	return m, nil
 }

--- a/cmd/octo/tuirepl_completion.go
+++ b/cmd/octo/tuirepl_completion.go
@@ -22,6 +22,7 @@ var builtinSlashCommands = []complItem{
 	{"/model", "Switch to another model"},
 	{"/thinking", "Set reasoning effort (off/low/medium/high/xhigh/max)"},
 	{"/compact", "Summarize older history to free up context"},
+	{"/goal", "Set or view the session goal (edit/pause/resume/clear)"},
 	{"/clear", "Wipe the conversation and start fresh"},
 	{"/skills", "List discovered skills"},
 	{"/mcp", "List connected MCP servers"},

--- a/cmd/octo/tuirepl_goal.go
+++ b/cmd/octo/tuirepl_goal.go
@@ -12,7 +12,7 @@ import (
 // goalsWired reports whether the session-goal feature is wired for this TUI
 // session (chat.go sets the accountant only when goal.enabled and the session
 // persists).
-func (m *tuiModel) goalsWired() bool { return m.a.GoalAcct != nil }
+func (m *tuiModel) goalsWired() bool { return m.a.GoalAcct != nil && m.cfg.session != nil }
 
 const goalUsage = "Usage: /goal <objective> · /goal edit|pause|resume|clear · /goal replace <objective>"
 
@@ -66,10 +66,20 @@ func (m *tuiModel) dispatchGoal(args string) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		// Next submitted line becomes the new objective (usage counters and
-		// budget survive an edit). Esc or an empty submit cancels.
+		// budget survive an edit). Esc, an empty submit, or a slash command
+		// cancels; any turn start (async auto-turns included) cancels too.
 		m.goalEditPending = true
 		m.ta.SetValue(g.Objective)
+		m.ta.CursorEnd()
 		m.println(noticeStyle.Render("Editing goal — change the objective and press Enter (Esc to cancel)"))
+		return m, m.updateTextAreaHeight()
+
+	case sub == "replace":
+		m.println(noticeStyle.Render("Usage: /goal replace <objective>"))
+		return m, nil
+
+	case strings.HasPrefix(sub, "edit "):
+		m.println(noticeStyle.Render("Usage: /goal edit — takes no arguments; it prefills the input for editing"))
 		return m, nil
 
 	case strings.HasPrefix(sub, "replace "):
@@ -188,6 +198,9 @@ func goalStartupNotice(sess *agent.Session) string {
 	case agent.GoalPaused, agent.GoalBlocked, agent.GoalUsageLimited:
 		return noticeStyle.Render("● Goal " + goalStatusLabel(g.Status) + ": " + goalTitleLine(g.Objective) +
 			" — /goal resume to continue")
+	case agent.GoalBudgetLimited:
+		return noticeStyle.Render("● Goal " + goalStatusLabel(g.Status) + ": " + goalTitleLine(g.Objective) +
+			" — /goal edit to keep going, /goal clear to drop it")
 	case agent.GoalActive:
 		return noticeStyle.Render("● Goal active: " + goalTitleLine(g.Objective) + " — continues after your next message")
 	}

--- a/cmd/octo/tuirepl_goal.go
+++ b/cmd/octo/tuirepl_goal.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+)
+
+// goalsWired reports whether the session-goal feature is wired for this TUI
+// session (chat.go sets the accountant only when goal.enabled and the session
+// persists).
+func (m *tuiModel) goalsWired() bool { return m.a.GoalAcct != nil }
+
+const goalUsage = "Usage: /goal <objective> · /goal edit|pause|resume|clear · /goal replace <objective>"
+
+// dispatchGoal handles "/goal [...]" when the session is idle.
+func (m *tuiModel) dispatchGoal(args string) (tea.Model, tea.Cmd) {
+	if !m.goalsWired() {
+		m.println(noticeStyle.Render("/goal: goals are disabled (goal.enabled) or unavailable in this session"))
+		return m, nil
+	}
+	sess := m.cfg.session
+	args = strings.TrimSpace(args)
+	sub := strings.ToLower(args)
+
+	switch {
+	case args == "":
+		g, ok := sess.GoalSnapshot()
+		if !ok {
+			m.println(noticeStyle.Render(goalUsage))
+			m.println(noticeStyle.Render("No goal is currently set. Example: /goal improve benchmark coverage"))
+			return m, nil
+		}
+		m.printlnBlock(goalSummary(g))
+		return m, nil
+
+	case sub == "pause":
+		return m.applyGoalStatus(agent.GoalPaused)
+
+	case sub == "resume":
+		model, cmd := m.applyGoalStatus(agent.GoalActive)
+		// Resuming re-enters the continuation loop right away when idle —
+		// the user just asked for the goal to keep going.
+		if g, ok := sess.GoalSnapshot(); ok && g.Status == agent.GoalActive {
+			if prompt, kick := m.goalContinuationKick(); kick {
+				return model, tea.Sequence(m.flushPrints(), m.startTurnEcho(prompt, ""))
+			}
+		}
+		return model, cmd
+
+	case sub == "clear":
+		if sess.ClearGoal() {
+			m.println(noticeStyle.Render("Goal cleared"))
+		} else {
+			m.println(noticeStyle.Render("No goal to clear"))
+		}
+		return m, nil
+
+	case sub == "edit":
+		g, ok := sess.GoalSnapshot()
+		if !ok {
+			m.println(noticeStyle.Render("No goal is currently set. Create one first: /goal <objective>"))
+			return m, nil
+		}
+		// Next submitted line becomes the new objective (usage counters and
+		// budget survive an edit). Esc or an empty submit cancels.
+		m.goalEditPending = true
+		m.ta.SetValue(g.Objective)
+		m.println(noticeStyle.Render("Editing goal — change the objective and press Enter (Esc to cancel)"))
+		return m, nil
+
+	case strings.HasPrefix(sub, "replace "):
+		objective := strings.TrimSpace(args[len("replace "):])
+		g, err := sess.ReplaceGoal(objective, 0)
+		if err != nil {
+			m.println(errorStyle.Render("/goal replace: " + err.Error()))
+			return m, nil
+		}
+		m.println(noticeStyle.Render("Goal replaced — " + goalOneLine(g)))
+		return m, nil
+
+	default:
+		// "/goal <objective>": start a goal. A finished (complete) goal is
+		// replaced silently; an unfinished one needs the explicit replace
+		// subcommand so a typo can't discard live work.
+		if g, ok := sess.GoalSnapshot(); ok {
+			if g.Status != agent.GoalComplete {
+				m.printlnBlock(goalSummary(g))
+				m.println(noticeStyle.Render("A goal already exists — /goal replace <objective> to replace it, or /goal clear"))
+				return m, nil
+			}
+			if ng, err := sess.ReplaceGoal(args, 0); err != nil {
+				m.println(errorStyle.Render("/goal: " + err.Error()))
+			} else {
+				m.println(noticeStyle.Render("Goal set — " + goalOneLine(ng)))
+			}
+			return m, nil
+		}
+		g, err := sess.CreateGoal(args, 0)
+		if err != nil {
+			m.println(errorStyle.Render("/goal: " + err.Error()))
+			return m, nil
+		}
+		m.println(noticeStyle.Render("Goal set — " + goalOneLine(g)))
+		return m, nil
+	}
+}
+
+// applyGoalStatus routes a user pause/resume through the session and reports
+// the outcome (which may differ from the request — resuming an over-budget
+// goal lands on budget_limited).
+func (m *tuiModel) applyGoalStatus(status agent.GoalStatus) (tea.Model, tea.Cmd) {
+	g, err := m.cfg.session.SetGoalStatus(status)
+	if err != nil {
+		m.println(errorStyle.Render("/goal: " + err.Error()))
+		return m, nil
+	}
+	m.println(noticeStyle.Render("Goal " + goalStatusLabel(g.Status) + " — " + goalOneLine(g)))
+	return m, nil
+}
+
+// submitGoalEdit consumes the next submitted line as the edited objective.
+func (m *tuiModel) submitGoalEdit(text string) (tea.Model, tea.Cmd) {
+	m.goalEditPending = false
+	if text == "" {
+		m.println(noticeStyle.Render("Goal edit cancelled"))
+		return m, nil
+	}
+	g, err := m.cfg.session.EditGoalObjective(text)
+	if err != nil {
+		m.println(errorStyle.Render("/goal edit: " + err.Error()))
+		return m, nil
+	}
+	m.println(noticeStyle.Render("Goal updated — " + goalOneLine(g)))
+	return m, nil
+}
+
+// goalContinuationKick asks the session whether an idle continuation turn
+// should start. Split from the call sites (turn end, /goal resume) so both
+// share the notice.
+func (m *tuiModel) goalContinuationKick() (string, bool) {
+	if !m.goalsWired() {
+		return "", false
+	}
+	prompt, ok := m.cfg.session.GoalContinuation()
+	if !ok {
+		return "", false
+	}
+	m.printlnBlock(noticeStyle.Render("● Goal continues — /goal pause to stop"))
+	return prompt, true
+}
+
+// handleGoalUpdated reacts to in-turn accounting events: the status segment
+// re-renders from the session on every frame, so only status *transitions*
+// need a scrollback notice.
+func (m *tuiModel) handleGoalUpdated(g *agent.Goal) {
+	if g == nil {
+		return
+	}
+	prev := m.goalLastStatus
+	m.goalLastStatus = g.Status
+	if prev == g.Status || prev == "" {
+		return
+	}
+	switch g.Status {
+	case agent.GoalBudgetLimited:
+		m.printlnBlock(noticeStyle.Render(fmt.Sprintf("● Goal budget reached (%s/%s tokens) — wrapping up",
+			compactCount(g.TokensUsed), compactCount(g.TokenBudget))))
+	case agent.GoalComplete:
+		m.printlnBlock(noticeStyle.Render("● Goal complete — " + goalUsageSummary(g)))
+	case agent.GoalBlocked:
+		m.printlnBlock(noticeStyle.Render("● Goal blocked — the agent is at an impasse; /goal resume to retry"))
+	}
+}
+
+// goalStartupNotice returns the line printed under the banner when a resumed
+// session carries a goal that isn't running — the Codex resume-paused prompt,
+// as a hint instead of a modal.
+func goalStartupNotice(sess *agent.Session) string {
+	g, ok := sess.GoalSnapshot()
+	if !ok {
+		return ""
+	}
+	switch g.Status {
+	case agent.GoalPaused, agent.GoalBlocked, agent.GoalUsageLimited:
+		return noticeStyle.Render("● Goal " + goalStatusLabel(g.Status) + ": " + goalTitleLine(g.Objective) +
+			" — /goal resume to continue")
+	case agent.GoalActive:
+		return noticeStyle.Render("● Goal active: " + goalTitleLine(g.Objective) + " — continues after your next message")
+	}
+	return ""
+}
+
+// ─── formatting helpers ─────────────────────────────────────────────────────
+
+func goalStatusLabel(status agent.GoalStatus) string {
+	switch status {
+	case agent.GoalActive:
+		return "active"
+	case agent.GoalPaused:
+		return "paused"
+	case agent.GoalBlocked:
+		return "blocked"
+	case agent.GoalUsageLimited:
+		return "usage limited"
+	case agent.GoalBudgetLimited:
+		return "limited by budget"
+	case agent.GoalComplete:
+		return "complete"
+	}
+	return string(status)
+}
+
+// goalStatusSegment is the compact status-bar value: usage while active,
+// the status label otherwise.
+func goalStatusSegment(g agent.Goal) string {
+	switch g.Status {
+	case agent.GoalActive:
+		if g.TokenBudget > 0 {
+			return compactCount(g.TokensUsed) + "/" + compactCount(g.TokenBudget)
+		}
+		return goalElapsed(g.TimeUsedSeconds)
+	case agent.GoalBudgetLimited:
+		if g.TokenBudget > 0 {
+			return "budget " + compactCount(g.TokensUsed) + "/" + compactCount(g.TokenBudget)
+		}
+	}
+	return goalStatusLabel(g.Status)
+}
+
+func goalSummary(g agent.Goal) string {
+	var b strings.Builder
+	b.WriteString("Goal\n")
+	fmt.Fprintf(&b, "  Status:      %s\n", goalStatusLabel(g.Status))
+	fmt.Fprintf(&b, "  Objective:   %s\n", g.Objective)
+	fmt.Fprintf(&b, "  Time used:   %s\n", goalElapsed(g.TimeUsedSeconds))
+	fmt.Fprintf(&b, "  Tokens used: %s", compactCount(g.TokensUsed))
+	if g.TokenBudget > 0 {
+		fmt.Fprintf(&b, "\n  Budget:      %s (%s remaining)", compactCount(g.TokenBudget), compactCount(g.RemainingTokens()))
+	}
+	b.WriteString("\n\n  ")
+	switch g.Status {
+	case agent.GoalActive:
+		b.WriteString("Commands: /goal edit · /goal pause · /goal clear")
+	case agent.GoalPaused, agent.GoalBlocked, agent.GoalUsageLimited:
+		b.WriteString("Commands: /goal edit · /goal resume · /goal clear")
+	default:
+		b.WriteString("Commands: /goal edit · /goal clear")
+	}
+	return b.String()
+}
+
+func goalOneLine(g agent.Goal) string {
+	s := goalTitleLine(g.Objective)
+	if g.TokenBudget > 0 {
+		s += fmt.Sprintf(" (budget %s tokens)", compactCount(g.TokenBudget))
+	}
+	return s
+}
+
+func goalUsageSummary(g *agent.Goal) string {
+	parts := []string{}
+	if g.TimeUsedSeconds > 0 {
+		parts = append(parts, goalElapsed(g.TimeUsedSeconds))
+	}
+	if g.TokenBudget > 0 {
+		parts = append(parts, compactCount(g.TokensUsed)+"/"+compactCount(g.TokenBudget)+" tokens")
+	} else if g.TokensUsed > 0 {
+		parts = append(parts, compactCount(g.TokensUsed)+" tokens")
+	}
+	if len(parts) == 0 {
+		return "no usage recorded"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// goalTitleLine clips an objective to one status-line-friendly line.
+func goalTitleLine(objective string) string {
+	line := objective
+	if i := strings.IndexByte(line, '\n'); i >= 0 {
+		line = line[:i]
+	}
+	if r := []rune(line); len(r) > 60 {
+		return strings.TrimSpace(string(r[:59])) + "…"
+	}
+	return line
+}
+
+// goalElapsed renders whole seconds compactly: 45s, 12m, 1h 30m, 2d 3h 5m.
+func goalElapsed(seconds int64) string {
+	if seconds < 0 {
+		seconds = 0
+	}
+	if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+	minutes := seconds / 60
+	if minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	hours := minutes / 60
+	remMin := minutes % 60
+	if hours >= 24 {
+		return fmt.Sprintf("%dd %dh %dm", hours/24, hours%24, remMin)
+	}
+	if remMin == 0 {
+		return fmt.Sprintf("%dh", hours)
+	}
+	return fmt.Sprintf("%dh %dm", hours, remMin)
+}
+
+// compactCount renders a token count compactly: 950, 12.5K, 1.2M.
+func compactCount(n int64) string {
+	switch {
+	case n >= 1_000_000:
+		return trimZero(fmt.Sprintf("%.1fM", float64(n)/1_000_000))
+	case n >= 1_000:
+		return trimZero(fmt.Sprintf("%.1fK", float64(n)/1_000))
+	default:
+		return fmt.Sprintf("%d", n)
+	}
+}
+
+func trimZero(s string) string {
+	return strings.Replace(s, ".0", "", 1)
+}

--- a/cmd/octo/tuirepl_goal_test.go
+++ b/cmd/octo/tuirepl_goal_test.go
@@ -289,10 +289,14 @@ func TestGoalStatusSegmentAndStartupNotice(t *testing.T) {
 }
 
 func TestGoalStatusBar_IncludesGoalSegment(t *testing.T) {
-	m, _ := newGoalTestModel()
-	m.dispatchGoal("visible goal")
-	if out := m.renderStatusBar(); !strings.Contains(out, "goal") {
-		t.Errorf("status bar should carry the goal segment:\n%s", out)
+	// StatusBar renders segment VALUES only (labels pick styles), so assert
+	// on a value no other segment can produce: the budgeted-goal usage.
+	m, sess := newGoalTestModel()
+	if _, err := sess.CreateGoal("visible goal", 50000); err != nil {
+		t.Fatal(err)
+	}
+	if out := m.renderStatusBar(); !strings.Contains(out, "0/50K") {
+		t.Errorf("status bar should carry the goal usage segment:\n%s", out)
 	}
 }
 

--- a/cmd/octo/tuirepl_goal_test.go
+++ b/cmd/octo/tuirepl_goal_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/open-octo/octo-agent/internal/agent"
 )
 
@@ -128,13 +130,72 @@ func TestGoalEdit_EmptySubmitCancels(t *testing.T) {
 	m.dispatchGoal("edit")
 	m.ta.Reset()
 	m.submit()
-	// An empty submit is a no-op in submit(); the flag must survive only
-	// until an explicit cancel — emulate Esc.
 	if m.goalEditPending {
-		m.goalEditPending = false // what the Esc handler does
+		t.Error("clearing the prefill and pressing Enter must cancel the edit")
 	}
 	if g, _ := sess.GoalSnapshot(); g.Objective != "keep me" {
 		t.Errorf("cancelled edit must not change the objective: %+v", g)
+	}
+}
+
+func TestGoalEdit_EscCancelsViaKeyHandler(t *testing.T) {
+	m, sess := newGoalTestModel()
+	m.dispatchGoal("keep me")
+	m.dispatchGoal("edit")
+
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.goalEditPending {
+		t.Error("Esc must cancel a pending goal edit")
+	}
+	// The next submit is an ordinary message again, not an objective.
+	setInput(m, "unrelated message")
+	m.submit()
+	if g, _ := sess.GoalSnapshot(); g.Objective != "keep me" {
+		t.Errorf("post-cancel submit must not touch the goal: %+v", g)
+	}
+}
+
+func TestGoalEdit_SlashCommandCancelsAndDispatches(t *testing.T) {
+	m, sess := newGoalTestModel()
+	m.dispatchGoal("keep me")
+	m.dispatchGoal("edit")
+
+	// The user changed their mind mid-edit and typed a command instead.
+	setInput(m, "/goal")
+	m.submit()
+	if m.goalEditPending {
+		t.Error("a slash command must cancel the pending edit")
+	}
+	if g, _ := sess.GoalSnapshot(); g.Objective != "keep me" {
+		t.Errorf("the command text must not become the objective: %+v", g)
+	}
+	if !strings.Contains(printed(m), "keep me") {
+		t.Errorf("the /goal command should still have dispatched (summary):\n%s", printed(m))
+	}
+}
+
+func TestGoalEdit_AsyncTurnStartCancelsPendingEdit(t *testing.T) {
+	// Regression: an async idle auto-turn (background exit note, loop wakeup)
+	// starting while /goal edit is armed must cancel the edit — otherwise the
+	// user's next unrelated message is silently consumed as the objective.
+	m, sess := newGoalTestModel()
+	m.dispatchGoal("keep me")
+	m.dispatchGoal("edit")
+
+	m.startTurnEcho("background note turn", "")
+	if m.goalEditPending {
+		t.Fatal("a turn start must cancel the pending goal edit")
+	}
+
+	// While that auto-turn runs, the user's text goes out as an ordinary
+	// steer — not as the objective (the exact leak this guards against).
+	setInput(m, "unrelated message")
+	m.submit()
+	if g, _ := sess.GoalSnapshot(); g.Objective != "keep me" {
+		t.Errorf("mid-auto-turn submit must not become the objective: %+v", g)
+	}
+	if len(m.pendingSteer) != 1 || m.pendingSteer[0] != "unrelated message" {
+		t.Errorf("the text should have routed to the steer path, got %v", m.pendingSteer)
 	}
 }
 

--- a/cmd/octo/tuirepl_goal_test.go
+++ b/cmd/octo/tuirepl_goal_test.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+)
+
+// newGoalTestModel builds a TUI model with goals wired: the session is both
+// the store and the accountant, exactly like chat.go's TUI path.
+func newGoalTestModel() (*tuiModel, *agent.Session) {
+	sess := agent.NewSession("m", "")
+	a := agent.New(&stubSender{reply: "ok"}, "m")
+	a.GoalAcct = sess
+	m := newTUIModel(replConfig{a: a, session: sess, noSave: true})
+	m.sink = &tuiSink{prog: &fakeProg{}}
+	return m, sess
+}
+
+func printed(m *tuiModel) string { return strings.Join(m.printlnBuf, "\n") }
+
+func TestDispatchGoal_CreateSummaryAndGuardedReplace(t *testing.T) {
+	m, sess := newGoalTestModel()
+
+	m.dispatchGoal("ship the release")
+	g, ok := sess.GoalSnapshot()
+	if !ok || g.Status != agent.GoalActive || g.Objective != "ship the release" {
+		t.Fatalf("create failed: %+v", g)
+	}
+
+	// Bare /goal shows the summary.
+	m.printlnBuf = nil
+	m.dispatchGoal("")
+	if out := printed(m); !strings.Contains(out, "ship the release") || !strings.Contains(out, "active") {
+		t.Errorf("summary missing fields:\n%s", out)
+	}
+
+	// A new objective over an unfinished goal is refused with a hint.
+	m.printlnBuf = nil
+	m.dispatchGoal("something else")
+	if g2, _ := sess.GoalSnapshot(); g2.Objective != "ship the release" {
+		t.Error("unfinished goal must not be silently replaced")
+	}
+	if !strings.Contains(printed(m), "/goal replace") {
+		t.Errorf("refusal must hint at /goal replace:\n%s", printed(m))
+	}
+
+	// Explicit replace mints a fresh goal.
+	m.dispatchGoal("replace something else")
+	if g3, _ := sess.GoalSnapshot(); g3.Objective != "something else" || g3.ID == g.ID {
+		t.Errorf("replace failed: %+v", g3)
+	}
+
+	// A complete goal is replaced without ceremony.
+	if _, err := sess.SetGoalStatus(agent.GoalComplete); err != nil {
+		t.Fatal(err)
+	}
+	m.dispatchGoal("next objective")
+	if g4, _ := sess.GoalSnapshot(); g4.Objective != "next objective" || g4.Status != agent.GoalActive {
+		t.Errorf("complete goal should be replaced silently: %+v", g4)
+	}
+}
+
+func TestDispatchGoal_PauseResumeClear(t *testing.T) {
+	m, sess := newGoalTestModel()
+	m.dispatchGoal("g")
+
+	m.dispatchGoal("pause")
+	if g, _ := sess.GoalSnapshot(); g.Status != agent.GoalPaused {
+		t.Errorf("pause: %+v", g)
+	}
+
+	// Resume re-activates AND kicks the continuation loop immediately.
+	m.dispatchGoal("resume")
+	if g, _ := sess.GoalSnapshot(); g.Status != agent.GoalActive {
+		t.Errorf("resume: %+v", g)
+	}
+	if !m.turnRunning {
+		t.Error("resume should kick an idle continuation turn")
+	}
+
+	m.turnRunning = false
+	m.dispatchGoal("clear")
+	if _, ok := sess.GoalSnapshot(); ok {
+		t.Error("clear left a goal behind")
+	}
+}
+
+func TestDispatchGoal_UnwiredIsDisabled(t *testing.T) {
+	m := newTestModel() // no GoalAcct, no session
+	if _, cmd := m.dispatchGoal("anything"); cmd != nil {
+		t.Error("unwired /goal must not start anything")
+	}
+	if !strings.Contains(printed(m), "disabled") {
+		t.Errorf("unwired /goal should say so:\n%s", printed(m))
+	}
+}
+
+func TestGoalEditFlow(t *testing.T) {
+	m, sess := newGoalTestModel()
+	m.dispatchGoal("first objective")
+	sess.AccountGoalUsage(0) // consume the mid-turn-creation skip deterministically
+	sess.ResetGoalWallClock()
+	sess.AccountGoalUsage(42)
+
+	m.dispatchGoal("edit")
+	if !m.goalEditPending || m.ta.Value() != "first objective" {
+		t.Fatalf("edit should arm and prefill, pending=%v input=%q", m.goalEditPending, m.ta.Value())
+	}
+
+	// The next submit is the edited objective; counters survive.
+	setInput(m, "revised objective")
+	m.submit()
+	if m.goalEditPending {
+		t.Error("submit should consume the edit")
+	}
+	g, _ := sess.GoalSnapshot()
+	if g.Objective != "revised objective" || g.TokensUsed != 42 {
+		t.Errorf("edit lost state: %+v", g)
+	}
+}
+
+func TestGoalEdit_EmptySubmitCancels(t *testing.T) {
+	m, sess := newGoalTestModel()
+	m.dispatchGoal("keep me")
+	m.dispatchGoal("edit")
+	m.ta.Reset()
+	m.submit()
+	// An empty submit is a no-op in submit(); the flag must survive only
+	// until an explicit cancel — emulate Esc.
+	if m.goalEditPending {
+		m.goalEditPending = false // what the Esc handler does
+	}
+	if g, _ := sess.GoalSnapshot(); g.Objective != "keep me" {
+		t.Errorf("cancelled edit must not change the objective: %+v", g)
+	}
+}
+
+func TestHandleTurnFinished_KicksGoalContinuation(t *testing.T) {
+	m, _ := newGoalTestModel()
+	m.dispatchGoal("keep going")
+	m.turnRunning = false
+
+	m.handleTurnFinished(nil)
+	if !m.turnRunning {
+		t.Fatal("idle turn end with an active goal should start a continuation turn")
+	}
+	// The "Goal continues" notice was already flushed into the returned
+	// tea.Sequence (flushPrints drains the buffer), so the buffer is empty
+	// here — the kick itself (turnRunning) is the observable effect.
+}
+
+func TestHandleTurnFinished_QueuedInputBeatsContinuation(t *testing.T) {
+	m, _ := newGoalTestModel()
+	m.dispatchGoal("keep going")
+	m.turnRunning = false
+	m.queue = append(m.queue, pendingItem{text: "user question"})
+
+	m.handleTurnFinished(nil)
+	if strings.Contains(printed(m), "Goal continues") {
+		t.Error("queued user input must run before any continuation")
+	}
+}
+
+func TestHandleTurnFinished_ErrorParksContinuation(t *testing.T) {
+	m, sess := newGoalTestModel()
+	m.dispatchGoal("keep going")
+	m.turnRunning = false
+
+	m.handleTurnFinished(errors.New("anthropic: HTTP 500: overloaded"))
+	if m.turnRunning {
+		t.Fatal("an errored turn must not chain a continuation")
+	}
+	if _, ok := sess.GoalContinuation(); ok {
+		t.Error("continuation must stay suppressed after an errored turn")
+	}
+	if g, _ := sess.GoalSnapshot(); g.Status != agent.GoalActive {
+		t.Errorf("plain errors must not change goal status: %+v", g)
+	}
+}
+
+func TestHandleTurnFinished_RateLimitedContinuationParks(t *testing.T) {
+	m, sess := newGoalTestModel()
+	m.dispatchGoal("keep going")
+	m.turnRunning = false
+
+	// Hand out a continuation (pending), then its turn fails on a rate limit.
+	if _, ok := sess.GoalContinuation(); !ok {
+		t.Fatal("precondition: continuation fires")
+	}
+	m.handleTurnFinished(errors.New("openai: HTTP 429: rate limited"))
+	if g, _ := sess.GoalSnapshot(); g.Status != agent.GoalUsageLimited {
+		t.Errorf("rate-limited continuation should park usage_limited: %+v", g)
+	}
+}
+
+func TestGoalStatusSegmentAndStartupNotice(t *testing.T) {
+	seg := goalStatusSegment(agent.Goal{Status: agent.GoalActive, TokenBudget: 50000, TokensUsed: 12500})
+	if seg != "12.5K/50K" {
+		t.Errorf("budgeted active segment = %q", seg)
+	}
+	seg = goalStatusSegment(agent.Goal{Status: agent.GoalActive, TimeUsedSeconds: 5400})
+	if seg != "1h 30m" {
+		t.Errorf("unbudgeted active segment = %q", seg)
+	}
+	if seg = goalStatusSegment(agent.Goal{Status: agent.GoalPaused}); seg != "paused" {
+		t.Errorf("paused segment = %q", seg)
+	}
+
+	sess := agent.NewSession("m", "")
+	if goalStartupNotice(sess) != "" {
+		t.Error("no goal → no startup notice")
+	}
+	if _, err := sess.CreateGoal("obj", 0); err != nil {
+		t.Fatal(err)
+	}
+	if n := goalStartupNotice(sess); !strings.Contains(n, "active") {
+		t.Errorf("active goal notice = %q", n)
+	}
+	if _, err := sess.SetGoalStatus(agent.GoalPaused); err != nil {
+		t.Fatal(err)
+	}
+	if n := goalStartupNotice(sess); !strings.Contains(n, "/goal resume") {
+		t.Errorf("paused goal notice should hint resume, got %q", n)
+	}
+}
+
+func TestGoalStatusBar_IncludesGoalSegment(t *testing.T) {
+	m, _ := newGoalTestModel()
+	m.dispatchGoal("visible goal")
+	if out := m.renderStatusBar(); !strings.Contains(out, "goal") {
+		t.Errorf("status bar should carry the goal segment:\n%s", out)
+	}
+}
+
+func TestCompactCountAndElapsed(t *testing.T) {
+	for n, want := range map[int64]string{950: "950", 1200: "1.2K", 50000: "50K", 1_500_000: "1.5M"} {
+		if got := compactCount(n); got != want {
+			t.Errorf("compactCount(%d) = %q, want %q", n, got, want)
+		}
+	}
+	for s, want := range map[int64]string{45: "45s", 720: "12m", 5400: "1h 30m", 7200: "2h", 183900: "2d 3h 5m"} {
+		if got := goalElapsed(s); got != want {
+			t.Errorf("goalElapsed(%d) = %q, want %q", s, got, want)
+		}
+	}
+}

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -509,7 +509,7 @@ func TestTUI_TurnFinishedDequeuesNext(t *testing.T) {
 	m.turnRunning = true
 	m.queue = []pendingItem{{text: "next task"}}
 
-	_, _ = m.handleTurnFinished()
+	_, _ = m.handleTurnFinished(nil)
 
 	// Dequeued and a new turn started.
 	if !m.turnRunning {
@@ -527,7 +527,7 @@ func TestTUI_TurnFinishedDispatchesQueuedSlash(t *testing.T) {
 	m.turnRunning = true
 	m.queue = []pendingItem{{text: "/clear"}}
 
-	_, _ = m.handleTurnFinished()
+	_, _ = m.handleTurnFinished(nil)
 
 	// /clear clears history and leaves the queue empty.
 	if m.a.History.Len() != 0 {
@@ -544,7 +544,7 @@ func TestTUI_DegradedInboxRunsBeforeQueue(t *testing.T) {
 	m.a.Inbox.Enqueue("degraded inbox") // never drained during turn → pending at turn end
 	m.queue = []pendingItem{{text: "queued"}}
 
-	_, _ = m.handleTurnFinished()
+	_, _ = m.handleTurnFinished(nil)
 
 	// The degraded inbox message is prepended, so it's the one that starts running and
 	// "queued" remains in the queue.

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -730,6 +730,20 @@ func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 	// paste folded as "[#N pasted …]" rather than dumping it verbatim.
 	text := strings.TrimSpace(m.expandPastes(raw))
 	collapsed := strings.TrimSpace(raw)
+	// A pending /goal edit consumes this submit first: empty text cancels,
+	// a slash command cancels and dispatches normally (the user changed
+	// their mind), anything else is the edited objective. Checked before
+	// the empty early-return so clearing the prefill + Enter cancels.
+	if m.goalEditPending {
+		if !strings.HasPrefix(text, "/") {
+			m.ta.Reset()
+			m.inputHistoryIdx = -1
+			m.clearPastes()
+			return m.submitGoalEdit(text)
+		}
+		m.goalEditPending = false
+		m.println(noticeStyle.Render("Goal edit cancelled"))
+	}
 	if text == "" && len(m.pendingAttachments) == 0 {
 		return m, nil
 	}
@@ -749,12 +763,6 @@ func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 	// Skip empty text (an image-only submit has nothing to recall).
 	if text != "" && (len(m.inputHistory) == 0 || m.inputHistory[len(m.inputHistory)-1] != text) {
 		m.inputHistory = append(m.inputHistory, text)
-	}
-
-	// /goal edit armed the input: this line is the edited objective, not a
-	// message. Consumed idle-only (the flag is only set while idle).
-	if m.goalEditPending && !m.turnRunning {
-		return m.submitGoalEdit(text)
 	}
 
 	// Slash commands are the TUI's alone — the plain REPL is a pure conversation

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -171,6 +171,12 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		// Idle: clear the input line and discard any pending attachments.
+		// A pending /goal edit is cancelled too — otherwise the next
+		// unrelated submit would silently become the objective.
+		if m.goalEditPending {
+			m.goalEditPending = false
+			m.println(noticeStyle.Render("Goal edit cancelled"))
+		}
 		m.pendingAttachments = nil
 		m.clearPastes()
 		// Also clear folded state
@@ -745,6 +751,12 @@ func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 		m.inputHistory = append(m.inputHistory, text)
 	}
 
+	// /goal edit armed the input: this line is the edited objective, not a
+	// message. Consumed idle-only (the flag is only set while idle).
+	if m.goalEditPending && !m.turnRunning {
+		return m.submitGoalEdit(text)
+	}
+
 	// Slash commands are the TUI's alone — the plain REPL is a pure conversation
 	// loop. A leading "/" with attachments is treated as ordinary text, not a command.
 	if strings.HasPrefix(text, "/") && len(m.pendingAttachments) == 0 {
@@ -827,6 +839,8 @@ func (m *tuiModel) dispatchSlash(text string) (tea.Model, tea.Cmd) {
 		return m.dispatchThinking(strings.TrimSpace(strings.TrimPrefix(text, first)))
 	case "/clear":
 		return m.dispatchClear()
+	case "/goal":
+		return m.dispatchGoal(strings.TrimSpace(strings.TrimPrefix(text, first)))
 	case "/compact":
 		if m.turnRunning {
 			m.println(noticeStyle.Render("/compact: wait for the current turn to finish"))
@@ -1444,6 +1458,11 @@ func (m *tuiModel) renderStatusBar() string {
 	}
 	if m.cfg.permEngine != nil {
 		segs = append(segs, [2]string{"perm", string(m.cfg.permEngine.GetMode())})
+	}
+	if m.goalsWired() {
+		if g, ok := m.cfg.session.GoalSnapshot(); ok {
+			segs = append(segs, [2]string{"goal", goalStatusSegment(g)})
+		}
 	}
 	if n := len(tools.RunningBackground()); n > 0 {
 		label := "1 shell"

--- a/dev-docs/goals-design.md
+++ b/dev-docs/goals-design.md
@@ -257,7 +257,8 @@ transport's idiom.
 | input | behavior |
 |---|---|
 | `/goal` | summary: status, objective, time used, tokens used (+budget), command hints. No goal → usage hint. |
-| `/goal <objective>` | create an active goal. If an unfinished goal exists (any status except `complete`) → confirm "Replace current goal?"; replace = new goal `ID`, fresh usage counters. |
+| `/goal <objective>` | create an active goal. Over an unfinished goal (any status except `complete`) it refuses with a hint; a `complete` goal is replaced silently. |
+| `/goal replace <objective>` | explicit replacement: new goal `ID`, fresh usage counters. (Codex uses a confirm popup; octo's idle command line has no confirm primitive, so destructive replace is its own subcommand a typo can't reach.) |
 | `/goal edit` | edit objective keeping usage/budget; `budget_limited`/`complete` re-activate on edit, other statuses are preserved. Mid-turn edits inject the `objective_updated` steering prompt. |
 | `/goal pause` | status → `paused` (accounts in-flight usage first). |
 | `/goal resume` | status → `active`; continuation kicks if idle. |
@@ -269,9 +270,19 @@ resuming a session whose goal is `paused`/`blocked`/`usage_limited` prompts
 "Resume paused goal?"; `/goal` before the session exists queues like other
 pre-session input.
 
-- **TUI** (`cmd/octo/tuirepl_view.go` switch): summary as printed lines,
-  replace/resume confirms via the existing selection prompt, edit via a
-  prefilled input prompt, indicator in the status line.
+- **TUI** (`cmd/octo/tuirepl_goal.go`): summary as printed lines; `/goal edit`
+  arms the input with the current objective prefilled — the next submitted
+  line is the edited objective (Esc cancels), the next-message-as-answer
+  idiom the IM ask flow established. A `goal` status-bar segment shows
+  `tokens/budget` (budgeted) or elapsed time while active and the status
+  label otherwise; it refreshes on every accounting event rather than
+  ticking locally per second (deviation from Codex's `GoalStatusState` —
+  accounting events arrive every LLM reply, which is live enough for a
+  terminal strip). A resumed session with a non-running goal prints a
+  one-line "● Goal paused … /goal resume" hint under the banner instead of
+  a modal. Interrupted or errored turns park continuation, and a
+  rate-limited continuation turn lands on `usage_limited`, matching the
+  server.
 - **web** (`internal/server/ws_handlers.go` `/clear`-`/compact` switch +
   a small REST surface `GET/PUT/DELETE …/goal` mirroring Codex's
   `thread/goal/get|set|clear`): confirms reuse the existing confirm-modal wire

--- a/internal/agent/goal.go
+++ b/internal/agent/goal.go
@@ -397,6 +397,24 @@ func (s *Session) SuppressGoalContinuation() {
 	s.goalContSuppressed = true
 }
 
+// IsRateLimitErr classifies a turn error as a provider rate/quota limit.
+// Provider adapters surface non-2xx responses as "<vendor>: HTTP <code>: ..."
+// (the retry layer has already retried transient 429s by the time one
+// reaches here), so a sustained limit is matched on the status code plus the
+// common textual variants gateways use. Transports use it to park a failing
+// goal-continuation turn as usage_limited.
+func IsRateLimitErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "http 429") ||
+		strings.Contains(msg, "rate limit") ||
+		strings.Contains(msg, "rate_limit") ||
+		strings.Contains(msg, "too many requests") ||
+		strings.Contains(msg, "quota")
+}
+
 // Markers wrapping every runtime-owned goal steering prompt injected as a
 // user message. Model-facing; every UI surface strips them (see
 // StripSystemReminders).

--- a/internal/agent/goal_continuation_test.go
+++ b/internal/agent/goal_continuation_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -173,5 +174,27 @@ func TestStripSystemReminders_StripsGoalContext(t *testing.T) {
 	mixed := "<system-reminder>note</system-reminder><goal_context>steer</goal_context>"
 	if got := strings.TrimSpace(StripSystemReminders(mixed)); got != "" {
 		t.Errorf("pure injected content should strip to empty, got %q", got)
+	}
+}
+
+func TestIsRateLimitErr(t *testing.T) {
+	for _, err := range []error{
+		errors.New("anthropic: HTTP 429: rate limited"),
+		errors.New("openai: HTTP 429 (insufficient_quota): You exceeded your current quota"),
+		errors.New("agent: loop[3]: send: Rate limit reached for requests"),
+		errors.New("gateway: too many requests"),
+	} {
+		if !IsRateLimitErr(err) {
+			t.Errorf("should classify as rate limit: %v", err)
+		}
+	}
+	for _, err := range []error{
+		nil,
+		errors.New("anthropic: HTTP 500: overloaded"),
+		errors.New("context deadline exceeded"),
+	} {
+		if IsRateLimitErr(err) {
+			t.Errorf("should NOT classify as rate limit: %v", err)
+		}
 	}
 }

--- a/internal/server/goal.go
+++ b/internal/server/goal.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"strings"
-
 	"github.com/open-octo/octo-agent/internal/agent"
 )
 
@@ -28,21 +26,4 @@ func (s *Server) broadcastGoalUpdated(sessionID string, g agent.Goal) {
 		"session_id": sessionID,
 		"goal":       g,
 	})
-}
-
-// isRateLimitErr classifies a turn error as a provider rate/quota limit.
-// Provider adapters surface non-2xx responses as "<vendor>: HTTP <code>: …"
-// (the retry layer has already retried transient 429s by the time one
-// reaches here), so a sustained limit is matched on the status code plus the
-// common textual variants gateways use.
-func isRateLimitErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "http 429") ||
-		strings.Contains(msg, "rate limit") ||
-		strings.Contains(msg, "rate_limit") ||
-		strings.Contains(msg, "too many requests") ||
-		strings.Contains(msg, "quota")
 }

--- a/internal/server/goal_test.go
+++ b/internal/server/goal_test.go
@@ -10,28 +10,6 @@ import (
 	"github.com/open-octo/octo-agent/internal/agent"
 )
 
-func TestIsRateLimitErr(t *testing.T) {
-	for _, err := range []error{
-		errors.New("anthropic: HTTP 429: rate limited"),
-		errors.New("openai: HTTP 429 (insufficient_quota): You exceeded your current quota"),
-		errors.New("agent: loop[3]: send: Rate limit reached for requests"),
-		errors.New("gateway: too many requests"),
-	} {
-		if !isRateLimitErr(err) {
-			t.Errorf("should classify as rate limit: %v", err)
-		}
-	}
-	for _, err := range []error{
-		nil,
-		errors.New("anthropic: HTTP 500: overloaded"),
-		errors.New("context deadline exceeded"),
-	} {
-		if isRateLimitErr(err) {
-			t.Errorf("should NOT classify as rate limit: %v", err)
-		}
-	}
-}
-
 // goalRoundSender replies (or errs) per main-loop round, recording each call's
 // message snapshot. Mutex-guarded — the after-turn suggest goroutine calls the
 // sender concurrently. Rounds beyond the script error out as a fail-safe so a

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1147,7 +1147,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			// continuation still parks: pending is stale there, but the next
 			// continuation would hit the same limit, so parking early is the
 			// cheaper outcome.)
-			if s.goalsEnabled && goalContWasPending && isRateLimitErr(err) {
+			if s.goalsEnabled && goalContWasPending && agent.IsRateLimitErr(err) {
 				if g, gerr := sess.SetGoalStatus(agent.GoalUsageLimited); gerr == nil {
 					s.broadcastGoalUpdated(sess.ID, g)
 				}


### PR DESCRIPTION
## Summary

Third slice of the `/goal` port (design: `dev-docs/goals-design.md`; PR1 #1051, PR2 #1056). Goals become fully usable from the TUI.

### `/goal` subcommands (`cmd/octo/tuirepl_goal.go`)
Bare summary · create · `replace` · `edit` · `pause` · `resume` (kicks continuation immediately) · `clear`. Two deliberate adaptations from Codex's popup UX, both documented in the design doc:
- **Replace is its own subcommand**: `/goal <objective>` over an unfinished goal refuses with a hint instead of opening a confirm popup — the TUI's idle command line has no confirm primitive, and a typo must not be able to discard live work. A `complete` goal is replaced silently (Codex parity).
- **Edit uses next-message-as-answer**: `/goal edit` prefills the input with the current objective; the next submit is the edit, Esc cancels — the idiom the IM ask flow (#601) established.

### Status-bar segment + notices
`goal` segment shows `12.5K/50K` (budgeted) or elapsed time while active, the status label otherwise. It refreshes on every accounting event (`EventGoalUpdated` arrives per LLM reply) rather than ticking locally per second — live enough for a terminal strip. Status transitions print scrollback notices (budget reached / complete / blocked). Resumed sessions with a non-running goal get a one-line `● Goal paused … /goal resume` hint under the banner.

### Continuation kick + parking (server parity)
`handleTurnFinished` chains a continuation turn when idle — queued input and inbox always win. Interrupted or errored turns park continuation (`SuppressGoalContinuation`), and a rate-limited continuation turn lands on `usage_limited`. `IsRateLimitErr` moves to the agent package so TUI and server share one classifier.

### Hidden-span hygiene
Steer echoes and leftover-inbox prints now strip injected spans via `StripSystemReminders` instead of a `<system-reminder>` prefix check, so `<goal_context>` prompts never render as user speech in the transcript.

## Tests
`go test -race ./...` green. New: create/refuse/replace/complete-silent-replace, pause/resume(+kick)/clear, unwired-disabled, edit flow (prefill, consume, counters survive, cancel), turn-finished kick, queued-input priority, error parking, rate-limit parking, status segment / startup notice / compact formatting.

## Not in this slice
Web chip + REST + confirm modal, IM surface + kick (PR4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)