### PR TITLE
feat(server): default visible workspace folder for web sessions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,6 +125,13 @@ type Config struct {
 	Browser BrowserConfig `yaml:"browser,omitempty"`
 	// Goal configures the session-goal feature (/goal and the goal tools).
 	Goal GoalConfig `yaml:"goal,omitempty"`
+	// WorkspaceDir sets the default working directory new web sessions are
+	// created with. Empty (default) changes nothing: a session still falls
+	// back to the server's own launch directory. "auto" resolves to
+	// ~/Desktop/octo (see tools.ResolveWorkspaceDir); anything else is used
+	// as a literal path. Does not affect CLI/TUI sessions or the server's
+	// own cwd, and composes with the per-session working_dir override.
+	WorkspaceDir string `yaml:"workspace_dir,omitempty"`
 }
 
 // GoalConfig configures session goals (persistent objectives the agent keeps

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -148,6 +148,27 @@ type skillInfo struct {
 	Enabled     bool   `json:"enabled"`
 }
 
+// applyDefaultWorkspaceDir sets sess's WorkingDir to the server's configured
+// default workspace dir (cfg.WorkspaceDir / tools.ResolveWorkspaceDir),
+// unless the session already has one of its own — so it composes with the
+// PATCH /api/sessions/{id}/working_dir override without special-casing. The
+// directory is created lazily here, the first time a session actually needs
+// it, rather than at server startup. A failure here is logged and otherwise
+// a no-op: the session just falls back to the server's launch directory,
+// exactly like before workspace_dir existed.
+func (s *Server) applyDefaultWorkspaceDir(sess *agent.Session) {
+	if s.workspaceDir == "" || sess.WorkingDir != "" {
+		return
+	}
+	if err := os.MkdirAll(s.workspaceDir, 0o755); err != nil {
+		slog.Warn("workspace dir: mkdir failed, session keeps using the launch directory", "dir", s.workspaceDir, "err", err)
+		return
+	}
+	if err := sess.SetWorkingDir(s.workspaceDir); err != nil {
+		slog.Warn("workspace dir: could not set session working dir", "err", err)
+	}
+}
+
 // ─── POST /api/chat ─────────────────────────────────────────────────────────
 
 func (s *Server) handleCreateChat(w http.ResponseWriter, r *http.Request) {
@@ -171,6 +192,7 @@ func (s *Server) handleCreateChat(w http.ResponseWriter, r *http.Request) {
 		model = req.Model
 	}
 	sess := agent.NewSession(model, s.system)
+	s.applyDefaultWorkspaceDir(sess)
 	sess.Bind(agent.EntryWeb, false)
 	if req.Name != "" {
 		_ = sess.SetTitle(req.Name)
@@ -370,6 +392,7 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sess := agent.NewSession(model, "")
+	s.applyDefaultWorkspaceDir(sess)
 	sess.Source = source
 	sess.ModelConfig = modelConfig
 	sess.Bind(agent.EntryWeb, false)

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
@@ -506,6 +508,73 @@ func TestCreateSession_EntryIDBindsSession(t *testing.T) {
 	}
 	if sess.ModelConfig != "" || sess.Model != "some-other-model" {
 		t.Errorf("raw session = (%q, %q), want (some-other-model, \"\")", sess.Model, sess.ModelConfig)
+	}
+}
+
+// Regression guard: with no workspace dir configured, a newly created
+// session's WorkingDir stays empty — the server's launch directory keeps
+// being the default, exactly like before workspace_dir existed.
+func TestCreateSession_NoWorkspaceDir_WorkingDirEmpty(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models:       []config.ModelEntry{{Provider: "anthropic", Model: "claude-sonnet-4-6"}},
+		DefaultModel: "claude-sonnet-4-6",
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/sessions", `{}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /api/sessions = %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Session struct {
+			ID string `json:"id"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := agent.LoadSession(resp.Session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.WorkingDir != "" {
+		t.Errorf("WorkingDir = %q, want \"\" (no workspace_dir configured)", sess.WorkingDir)
+	}
+}
+
+// With a configured workspace dir, a newly created session's WorkingDir
+// defaults to it (the caller requested no working dir of its own).
+func TestCreateSession_WorkspaceDirConfigured_SetsWorkingDir(t *testing.T) {
+	home := setTestHome(t)
+	seedModels(t, config.Config{
+		Models:       []config.ModelEntry{{Provider: "anthropic", Model: "claude-sonnet-4-6"}},
+		DefaultModel: "claude-sonnet-4-6",
+	})
+	wantDir := filepath.Join(home, "octo-workspace")
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", WorkspaceDir: wantDir})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/sessions", `{}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /api/sessions = %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Session struct {
+			ID string `json:"id"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := agent.LoadSession(resp.Session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.WorkingDir != wantDir {
+		t.Errorf("WorkingDir = %q, want %q", sess.WorkingDir, wantDir)
+	}
+	if st, err := os.Stat(wantDir); err != nil || !st.IsDir() {
+		t.Errorf("workspace dir %q was not created: %v", wantDir, err)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -86,6 +86,14 @@ type Config struct {
 	// constructor (tests included) stays network-silent and the endpoint
 	// degrades to "current is latest".
 	UpdateCheck bool
+
+	// WorkspaceDir overrides the default working directory new web sessions
+	// are created with (see config.Config.WorkspaceDir / tools.ResolveWorkspaceDir).
+	// Empty (default) falls back to ~/.octo/config.yml's workspace_dir, then
+	// to no override at all — unchanged from today's curCwd() behavior. No
+	// `octo serve` flag sets this; it exists mainly so tests can inject a
+	// literal path without touching the real config file.
+	WorkspaceDir string
 }
 
 // Server is the HTTP server skeleton. It owns the mux, the agent factory,
@@ -116,6 +124,13 @@ type Server struct {
 	cwdMu      sync.RWMutex
 	memDir     string
 	homeMemDir string
+
+	// workspaceDir is the resolved default WorkingDir new web sessions get
+	// when the caller requests none of their own (see cfg.WorkspaceDir /
+	// tools.ResolveWorkspaceDir). "" means no override — sessions keep
+	// falling back to cwd, exactly like before this field existed. Resolved
+	// once at New, like cwd, and never mutated afterward.
+	workspaceDir string
 
 	// session-scoped turn locks: one turn per session at a time.
 	turnLocks map[string]*sync.Mutex
@@ -332,6 +347,21 @@ func New(cfg Config) (*Server, error) {
 	skillsManifest := tools.SkillsManifest(skillReg)
 	tools.SetSkills(skillReg)
 
+	// Resolve the default workspace dir new web sessions get. cfg.WorkspaceDir
+	// (no `octo serve` flag sets it today) takes precedence so tests can inject
+	// a literal path without touching ~/.octo/config.yml; production falls back
+	// to the file config's workspace_dir. A resolve error (e.g. no home dir)
+	// degrades to "" — no override — rather than failing server startup.
+	rawWorkspaceDir := cfg.WorkspaceDir
+	if rawWorkspaceDir == "" {
+		rawWorkspaceDir = fileCfg.WorkspaceDir
+	}
+	workspaceDir, err := tools.ResolveWorkspaceDir(rawWorkspaceDir)
+	if err != nil {
+		slog.Warn("could not resolve workspace_dir; new sessions keep using the launch directory", "err", err)
+		workspaceDir = ""
+	}
+
 	accessKey, generatedKey := resolveAccessKey(cfg.AccessKey, fileCfg)
 	if generatedKey {
 		// Persist so the key survives restarts — in particular the
@@ -372,6 +402,7 @@ func New(cfg Config) (*Server, error) {
 		envCtx:              envCtx,
 		memDir:              memDir,
 		homeMemDir:          homeMemDir,
+		workspaceDir:        workspaceDir,
 		turnLocks:           map[string]*sync.Mutex{},
 		turnRunning:         make(map[string]bool),
 		entryBindings:       make(map[string]*cachedEntryBinding),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/config"
 	"github.com/open-octo/octo-agent/internal/skills"
+	"github.com/open-octo/octo-agent/internal/tools"
 	"github.com/open-octo/octo-agent/internal/upgrade"
 )
 
@@ -377,6 +378,13 @@ func mustAccessKey(cfg Config) string {
 	return key
 }
 
+// mustWorkspaceDir resolves the test server's default workspace dir straight
+// from cfg.WorkspaceDir, bypassing ~/.octo/config.yml — mirrors mustAccessKey.
+func mustWorkspaceDir(cfg Config) string {
+	dir, _ := tools.ResolveWorkspaceDir(cfg.WorkspaceDir)
+	return dir
+}
+
 // mustServer creates a Server for testing. It skips tests that need a real
 // provider by using a stub sender.
 func mustServer(t *testing.T, cfg Config) *Server {
@@ -392,6 +400,7 @@ func mustServer(t *testing.T, cfg Config) *Server {
 		skillsManifest:      "",
 		cwd:                 "",
 		envCtx:              "",
+		workspaceDir:        mustWorkspaceDir(cfg),
 		turnLocks:           map[string]*sync.Mutex{},
 		sender:              &stubSender{},
 		accessKey:           mustAccessKey(cfg),

--- a/internal/tools/workspacedir.go
+++ b/internal/tools/workspacedir.go
@@ -1,0 +1,13 @@
+package tools
+
+// ResolveWorkspaceDir turns the config workspace_dir value into the directory
+// path a newly created web session should default its WorkingDir to.
+//
+//   - "" (unset) -> "" — no override, session keeps today's behavior (the
+//     server's own launch directory).
+func ResolveWorkspaceDir(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	return raw, nil
+}

--- a/internal/tools/workspacedir.go
+++ b/internal/tools/workspacedir.go
@@ -1,13 +1,29 @@
 package tools
 
+import (
+	"os"
+	"path/filepath"
+)
+
 // ResolveWorkspaceDir turns the config workspace_dir value into the directory
 // path a newly created web session should default its WorkingDir to.
 //
 //   - "" (unset) -> "" — no override, session keeps today's behavior (the
 //     server's own launch directory).
+//   - "auto" -> ~/Desktop/octo, a discoverable default for non-technical
+//     users. Not created here — the caller MkdirAll's it lazily the first
+//     time a session actually needs it.
+//   - anything else -> returned as-is, a power-user literal path override.
 func ResolveWorkspaceDir(raw string) (string, error) {
 	if raw == "" {
 		return "", nil
 	}
-	return raw, nil
+	if raw != "auto" {
+		return raw, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Desktop", "octo"), nil
 }

--- a/internal/tools/workspacedir_test.go
+++ b/internal/tools/workspacedir_test.go
@@ -1,6 +1,9 @@
 package tools
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 // Unset config: no override, today's behavior (server launch dir) is untouched.
 func TestResolveWorkspaceDir_Empty(t *testing.T) {
@@ -23,5 +26,29 @@ func TestResolveWorkspaceDir_LiteralPath(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("ResolveWorkspaceDir(%q) = %q, want %q", want, got, want)
+	}
+}
+
+func setTestHomeDir(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	return tmp
+}
+
+// "auto" resolves to ~/Desktop/octo — a discoverable, non-technical-user
+// friendly default. No existence check: Desktop (and octo under it) is
+// created lazily via MkdirAll the first time a session actually needs it.
+func TestResolveWorkspaceDir_Auto(t *testing.T) {
+	home := setTestHomeDir(t)
+
+	got, err := ResolveWorkspaceDir("auto")
+	if err != nil {
+		t.Fatalf("ResolveWorkspaceDir(\"auto\") error = %v, want nil", err)
+	}
+	want := filepath.Join(home, "Desktop", "octo")
+	if got != want {
+		t.Fatalf("ResolveWorkspaceDir(\"auto\") = %q, want %q", got, want)
 	}
 }

--- a/internal/tools/workspacedir_test.go
+++ b/internal/tools/workspacedir_test.go
@@ -12,3 +12,16 @@ func TestResolveWorkspaceDir_Empty(t *testing.T) {
 		t.Fatalf("ResolveWorkspaceDir(\"\") = %q, want \"\"", got)
 	}
 }
+
+// A literal path (anything other than "" or "auto") is a power-user override:
+// returned unchanged.
+func TestResolveWorkspaceDir_LiteralPath(t *testing.T) {
+	const want = "/some/literal/path"
+	got, err := ResolveWorkspaceDir(want)
+	if err != nil {
+		t.Fatalf("ResolveWorkspaceDir(%q) error = %v, want nil", want, err)
+	}
+	if got != want {
+		t.Fatalf("ResolveWorkspaceDir(%q) = %q, want %q", want, got, want)
+	}
+}

--- a/internal/tools/workspacedir_test.go
+++ b/internal/tools/workspacedir_test.go
@@ -1,0 +1,14 @@
+package tools
+
+import "testing"
+
+// Unset config: no override, today's behavior (server launch dir) is untouched.
+func TestResolveWorkspaceDir_Empty(t *testing.T) {
+	got, err := ResolveWorkspaceDir("")
+	if err != nil {
+		t.Fatalf("ResolveWorkspaceDir(\"\") error = %v, want nil", err)
+	}
+	if got != "" {
+		t.Fatalf("ResolveWorkspaceDir(\"\") = %q, want \"\"", got)
+	}
+}

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -60,6 +60,22 @@ echo "octo uninstalled."
 UNINSTALL
 chmod +x "$app_dir/uninstall.sh"
 
+# Seed ~/.octo/config.yml with workspace_dir: auto on a genuinely fresh
+# install (no config.yml at all yet — not even one with just an access key,
+# which octo itself writes on first `serve` start). Must run before `octo
+# serve -d` below, or that first start would write an access-key-only
+# config.yml first and this step would then correctly no-op, leaving the
+# new-web-session default unset. An upgrade/reinstall over an existing
+# config.yml is always a no-op — never overwrite a user's existing settings.
+config_dir="$HOME/.octo"
+config_path="$config_dir/config.yml"
+if [ ! -f "$config_path" ]; then
+  mkdir -p "$config_dir"
+  chmod 700 "$config_dir"
+  printf 'workspace_dir: auto\n' > "$config_path"
+  chmod 600 "$config_path"
+fi
+
 # octo serve -d blocks until the server is accepting connections (or it times
 # out), so the browser opens against a live port rather than racing the bind.
 "$bin" serve -d >/dev/null 2>&1 || true

--- a/packaging/windows/octo.iss
+++ b/packaging/windows/octo.iss
@@ -111,6 +111,28 @@ begin
   RegWriteExpandStringValue(HKEY_CURRENT_USER, EnvKey, 'Path', Path);
 end;
 
+// WriteDefaultConfigIfMissing seeds ~/.octo/config.yml with workspace_dir:
+// auto on a genuinely fresh install (no config.yml at all yet — not even one
+// with just an access key, which octo itself writes on first `serve` start).
+// This must run before LaunchAndOpenDashboard's `octo serve -d`, or that
+// first start would write an access-key-only config.yml first and this step
+// would then correctly no-op, leaving the new-web-session default unset.
+// An upgrade/reinstall over an existing config.yml is always a no-op here —
+// the installer must never overwrite a user's existing settings.
+procedure WriteDefaultConfigIfMissing;
+var
+  ConfigDir, ConfigPath: string;
+begin
+  ConfigDir := ExpandConstant('{%USERPROFILE}') + '\.octo';
+  ConfigPath := ConfigDir + '\config.yml';
+  if FileExists(ConfigPath) then
+    exit;
+  if not DirExists(ConfigDir) then
+    if not CreateDir(ConfigDir) then
+      exit;
+  SaveStringToFile(ConfigPath, 'workspace_dir: auto' + #13#10, False);
+end;
+
 // LaunchAndOpenDashboard starts the background server and opens the onboarding
 // page. `octo serve -d` blocks until the server is accepting connections (or it
 // times out), so the browser opens against a live port rather than racing the
@@ -219,6 +241,7 @@ begin
     AddToPath;
     EnsurePowerShell7;
     WriteAutostartScript;
+    WriteDefaultConfigIfMissing;
     LaunchAndOpenDashboard;
   end;
 end;


### PR DESCRIPTION
## Summary
- Add opt-in `workspace_dir` config field (empty = unchanged behavior, `auto` = `~/Desktop/octo`, literal path = power-user override)
- New `internal/tools/workspacedir.go` `ResolveWorkspaceDir` helper, wired into `handleCreateChat`/`handleCreateSession` so new web sessions default their `WorkingDir` there instead of the server's launch-time cwd
- Directory is created lazily on first session use, not at server startup
- Windows/macOS installers seed `workspace_dir: auto` into a brand-new `config.yml` only on first install (never touches an existing user config on upgrade/reinstall)

Part of #1054 (P1: default visible workspace folder for non-technical Windows users).

## Test plan
- [x] `internal/tools/workspacedir_test.go` — 4 behaviors covering empty/literal/auto resolution
- [x] `internal/server/onboard_config_handlers_test.go` — regression guard (no workspace_dir configured -> session WorkingDir stays empty) + new-behavior test (configured -> session WorkingDir set), both exercised through the real HTTP handler path
- [x] `go test -race ./internal/tools/... ./internal/server/...`, `gofmt -l`, `go vet` all clean
- [x] Isolated subagent review: no critical/important findings, "ready to merge"
- [ ] Installer scripts (octo.iss, macOS postinstall) manually traced but not run through actual Inno Setup/pkgbuild - verify on a real Windows/macOS build before the next release

Generated with Claude Code