### PR TITLE
feat(skills): office-xlsx skill (phase 1, skills-add distributable)

### DIFF
--- a/skills/office-xlsx/LICENSE.txt
+++ b/skills/office-xlsx/LICENSE.txt
@@ -1,0 +1,30 @@
+This skill is adapted from "xlsx-manipulation" in claude-office-skills/skills
+(https://github.com/claude-office-skills/skills), © 2026 Claude Office Skills
+Contributors, licensed under MIT. The two scripts under scripts/ were written
+from scratch for octo (the source skill ships no runnable scripts, only
+inline documentation examples); the openpyxl operations they cover, and the
+formatting/formula/chart conventions documented in SKILL.md, follow that
+source material.
+Modifications for octo (script implementation, PEP 723 self-install
+shebangs, JSON operation schema, uv-based preflight) © the octo-agent
+contributors, MIT.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/office-xlsx/PROVENANCE.md
+++ b/skills/office-xlsx/PROVENANCE.md
@@ -1,0 +1,122 @@
+# Provenance audit — office-xlsx
+
+## Sources compared
+
+- **Adapted from:** `claude-office-skills/skills`, path `xlsx-manipulation/SKILL.md`
+  (https://github.com/claude-office-skills/skills, commit `9c4c7d5`, MIT
+  license — root `LICENSE` file: "Copyright (c) 2026 Claude Office Skills
+  Contributors").
+- **Compared against (read-only, not copied from):** `anthropics/skills`,
+  path `skills/xlsx/` (https://github.com/anthropics/skills), the
+  no-redistribution Anthropic original this repo is legally barred from
+  vendoring (see `skills/xlsx/LICENSE.txt` in that repo: "© 2025 Anthropic,
+  PBC. All rights reserved" with an explicit no-derivative-works,
+  no-redistribution clause).
+
+## What each source actually is
+
+**claude-office-skills' `xlsx-manipulation/SKILL.md`** (495 lines, single
+file, no bundled scripts) is a prose knowledge-reference document aimed at
+having the model *write its own openpyxl code inline per request* ("Describe
+the spreadsheet you want... I'll generate openpyxl code and execute it"). It
+covers, as a cheatsheet: cell read/write, formulas, `Font`/`PatternFill`/
+`Border`/`Alignment` styling, number formats, conditional formatting,
+charts (`BarChart`/`LineChart`/`PieChart`), data validation, sheet
+management, row/column operations, and two worked examples (a budget
+tracker, a sales dashboard). It ships **no runnable scripts** — every code
+sample is an inline markdown fence meant to be retyped/adapted by the model
+each time, not executed as-is.
+
+**Anthropic's `skills/xlsx/`** (SKILL.md + `scripts/recalc.py` +
+`scripts/office/{pack,unpack,validate,soffice}.py` + a `helpers/` package +
+a bundled directory of ECMA-376/ISO-29500 OOXML XSD schemas, ~3,000 lines of
+Python across the scripts alone) takes a structurally different approach:
+direct OOXML XML manipulation (unpack/pack the .xlsx zip, validate against
+the bundled schemas), a LibreOffice headless-recalc pipeline
+(`scripts/recalc.py`, with `soffice.py` handling sandboxed Unix-socket
+restrictions) that actually evaluates formulas and reports `#REF!`/`#DIV/0!`
+etc. as structured JSON, and detailed financial-model formatting/color-coding
+policy in the prose (blue=input/black=formula/green=cross-sheet-link,
+number-format rules, a formula-error-prevention checklist).
+
+## Also found and explicitly excluded from this adaptation
+
+The source repo additionally contains `official-skills/xlsx-guide.md`, a
+short "quick reference" file whose own frontmatter reads
+`license: Proprietary (Anthropic)` and `source: https://github.com/anthropics/skills/tree/main/skills/xlsx`
+— i.e. the repo's own maintainers labeled that specific file as a pointer
+to Anthropic's proprietary skill, not as their MIT-licensed content. That
+file **was not used** as a source for this adaptation; only
+`xlsx-manipulation/SKILL.md` (plain `license: MIT` in its own frontmatter,
+no such proprietary flag) was adapted.
+
+## Comparison and conclusion
+
+| Aspect | claude-office-skills (source) | anthropics/skills (comparison only) | This adaptation |
+|---|---|---|---|
+| Delivery mechanism | Prose cheatsheet, model retypes code each time | Bundled Python scripts the model shells out to | Bundled Python scripts the model shells out to |
+| Formula evaluation | None (openpyxl never evaluates formulas; source doesn't mention this limitation) | `scripts/recalc.py` via headless LibreOffice, JSON error report | None (openpyxl-only; SKILL.md explicitly documents this limitation and tells the model not to fake computed values in Python) |
+| File manipulation approach | openpyxl object API only | Direct OOXML XML unpack/pack/validate against bundled XSD schemas | openpyxl object API only |
+| Runnable artifacts | None | 8 scripts + schema directory | 2 scripts (`xlsx_inspect.py`, `xlsx_edit.py`), written from scratch |
+| Structure of code | Ad hoc snippets per topic (formulas, charts, validation, ...) | Modular package (`office/helpers`, `office/validators`, `office/schemas`) | Two flat CLI scripts with a JSON operation-list dispatcher |
+| Financial-model formatting guidance | Not present | Detailed (color coding, number formats, sourcing comments, error-prevention checklist) | Summarized in SKILL.md, credited as "a common (not mandatory) color convention" — see below |
+
+**Finding: this is a genuine, independent adaptation of the MIT source, not
+a disguised republication of the Anthropic original.** The two differ in
+every dimension that matters for a copyright/derivative-work assessment:
+delivery mechanism (prose-for-the-model vs. bundled-scripts-for-the-model vs.
+this adaptation's bundled-scripts), the technical approach to formula
+handling (openpyxl-only vs. LibreOffice-recalc-with-XML-validation), the
+file-manipulation strategy (object API vs. raw OOXML XML), and the actual
+code (no source file in this skill contains code copied or lightly
+reworded from Anthropic's scripts — Anthropic's `recalc.py`/`pack.py`/
+`unpack.py`/`validate.py`/schema files have no analog here at all, since
+this skill deliberately does not implement recalculation).
+
+The overlap that does exist between all three (this skill, the MIT source,
+and the Anthropic original) is limited to facts about the openpyxl library
+itself — e.g. `Font(bold=True)`, `ws['A1'] = value`, `ws.merge_cells(...)`,
+`BarChart()`/`Reference(...)` — which is inevitable for any tool built on
+openpyxl's public API and appears near-identically in openpyxl's own
+official documentation and in hundreds of independent tutorials predating
+both repos. This is not the kind of similarity that indicates copying;
+it is the shape any code using this library takes.
+
+One point of genuine, acknowledged influence: the "financial-model
+conventions" section in this skill's SKILL.md (blue=input/black=formula/
+green=cross-sheet-link color coding) restates a color-coding practice that
+is a real, decades-old financial-modeling industry convention (documented
+in modeling texts and courses well before either skills repo existed, e.g.
+Wall Street Prep / Corporate Finance Institute style guides) and which
+Anthropic's own skill also documents. It is presented here as attributed,
+non-mandatory guidance ("a common (not mandatory) color convention"), not
+as a verbatim lift of Anthropic's specific checklist wording — this
+skill's version is three sentences, not Anthropic's multi-page ruleset
+(number-format tables, sourcing-comment format, the full error-prevention
+checklist), and the MIT source repo also independently mentions the same
+convention set at a similar level of generality via its
+`official-skills/xlsx-guide.md` (the file explicitly excluded above), which
+itself is presented as a proprietary-labeled pointer, not as this skill's
+content. Flagging this for visibility rather than treating it as a
+concern: color-by-role conventions for financial models are standard
+industry practice, not Anthropic IP.
+
+## What was NOT reused
+
+- No file from `anthropics/skills` was copied, read into an editor and
+  retyped, or used as a template for file/directory layout.
+- No prose from `anthropics/skills/skills/xlsx/SKILL.md` was paraphrased
+  into this skill's SKILL.md.
+- The formula-recalculation, OOXML-unpack/pack, and schema-validation
+  machinery from the Anthropic skill was deliberately **not** built here;
+  this skill is openpyxl-only and says so.
+
+## Scripts: written from scratch, not "adapted" line-by-line
+
+Because the MIT source ships no runnable scripts, `scripts/xlsx_inspect.py`
+and `scripts/xlsx_edit.py` are new code, written to cover the same
+*capabilities* the source's prose describes (read/write cells, formulas,
+styling, merges, sheets, charts, data validation) using a JSON
+operation-list design that has no counterpart in either source repo. This
+is noted as a deviation from a literal "adapt the actual Python script(s)"
+reading of the assignment, made necessary by the source's actual structure.

--- a/skills/office-xlsx/PROVENANCE.md
+++ b/skills/office-xlsx/PROVENANCE.md
@@ -82,24 +82,59 @@ official documentation and in hundreds of independent tutorials predating
 both repos. This is not the kind of similarity that indicates copying;
 it is the shape any code using this library takes.
 
-One point of genuine, acknowledged influence: the "financial-model
-conventions" section in this skill's SKILL.md (blue=input/black=formula/
-green=cross-sheet-link color coding) restates a color-coding practice that
-is a real, decades-old financial-modeling industry convention (documented
-in modeling texts and courses well before either skills repo existed, e.g.
-Wall Street Prep / Corporate Finance Institute style guides) and which
-Anthropic's own skill also documents. It is presented here as attributed,
-non-mandatory guidance ("a common (not mandatory) color convention"), not
-as a verbatim lift of Anthropic's specific checklist wording — this
-skill's version is three sentences, not Anthropic's multi-page ruleset
-(number-format tables, sourcing-comment format, the full error-prevention
-checklist), and the MIT source repo also independently mentions the same
-convention set at a similar level of generality via its
-`official-skills/xlsx-guide.md` (the file explicitly excluded above), which
-itself is presented as a proprietary-labeled pointer, not as this skill's
-content. Flagging this for visibility rather than treating it as a
-concern: color-by-role conventions for financial models are standard
-industry practice, not Anthropic IP.
+**Citation correction (post-review):** an earlier version of this document
+justified the "financial-model conventions" section's blue/black/green
+color-coding paragraph by pointing partly at the MIT source repo's
+`official-skills/xlsx-guide.md`. That was wrong on inspection: the actual
+adapted source, `xlsx-manipulation/SKILL.md`, contains **no color-coding
+convention at all** (checked directly — no mention of "blue", "black",
+"green", or any input/formula/link color mapping anywhere in that file).
+The three-color/three-role mapping appears only in `official-skills/
+xlsx-guide.md` and in Anthropic's own proprietary `skills/xlsx/SKILL.md` —
+i.e. exactly the file this document already excludes for being
+Anthropic-licensed. Citing it as support for this paragraph while
+excluding it elsewhere was an internal contradiction, not a defensible
+citation.
+
+The correct provenance for this one paragraph: it is **not** attributed to
+either skills repo. Blue-input/black-formula/green-link color coding is a
+public financial-modeling industry convention taught independently of
+both, verified directly (fetched, not taken on faith) during this
+correction:
+
+- Wall Street Prep's own financial modeling guide states the blue/black
+  half of the convention verbatim: "This blue text with a yellow
+  background is a standard practice across Wall Street... Corresponding
+  with this is the practice of using black text font and a clear
+  background to identify formulas in a financial model."
+  (https://www.wallstreetprep.com/knowledge/financial-modeling-techniques/,
+  fetched and confirmed 2026-07-02)
+- WallStreetMojo's reference page states the full blue/black/green/red
+  mapping verbatim: "Blue: For hardcoded (i.e. typed) inputs... Black: For
+  calculation & cell references within the same sheet... Green: For
+  references made to other sheets... Red: For external links outside the
+  working file."
+  (https://www.wallstreetmojo.com/financial-modeling-color-formatting/,
+  fetched and confirmed 2026-07-02)
+
+(A Corporate Finance Institute page was checked as a candidate third
+citation and dropped — the specific page found,
+`corporatefinanceinstitute.com/resources/financial-modeling/financial-modeling-code/`,
+covers general model-quality principles, not this color convention;
+citing it would have repeated the same unverified-citation mistake this
+correction exists to fix.)
+
+Both confirmed sources are public, unrelated to either skills repo, and
+independent of Anthropic's material. SKILL.md's wording has been updated
+to cite Wall Street Prep / WallStreetMojo directly instead of resting on
+the excluded file. The paragraph remains three sentences of attributed,
+non-mandatory guidance ("a common (not mandatory) color convention...
+from financial-modeling style guides"), not a lift of Anthropic's
+multi-page ruleset (number-format tables, sourcing-comment format, the
+full error-prevention checklist) — color-by-role conventions for
+financial models are standard industry practice belonging to no one, but
+the citation must point at that public
+practice directly rather than at a file this document itself excludes.
 
 ## What was NOT reused
 

--- a/skills/office-xlsx/SKILL.md
+++ b/skills/office-xlsx/SKILL.md
@@ -42,7 +42,7 @@ uv run <skill-dir>/scripts/xlsx_edit.py --output out.xlsx --ops ops.json
 uv run <skill-dir>/scripts/xlsx_edit.py --input existing.xlsx --output out.xlsx --ops ops.json
 ```
 
-- Omit `--input` to start from a blank workbook.
+- Omit `--input` to start from a blank workbook. Its one default sheet is named `Sheet` (not `Sheet1`) — the first `add_sheet` op on a blank workbook renames that default sheet instead of leaving an empty extra tab, so give it the name you actually want as your first sheet.
 - `--input` and `--output` may be the same path to edit in place.
 - `--ops` points to a JSON file (or pass inline JSON via `--ops-json '...'`) containing a list of operation objects, applied in order. Supported operations:
 

--- a/skills/office-xlsx/SKILL.md
+++ b/skills/office-xlsx/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: office-xlsx
+description: Create, read, and edit Excel (.xlsx) spreadsheets programmatically with openpyxl — cell values, formulas, styling (fonts/fills/borders/alignment/number formats), merged cells, multiple sheets, charts, and data validation. Use whenever the user wants a spreadsheet created, inspected, or modified, or references an .xlsx file by name or path.
+license: MIT (adapted from claude-office-skills/skills; complete terms in LICENSE.txt)
+---
+
+# XLSX Manipulation
+
+Two scripts drive this skill, both built on **openpyxl**:
+
+- `scripts/xlsx_inspect.py` — read a workbook and print its structure (sheets, dimensions, header row, sample rows, formulas, merged cells) as JSON. Use this first on any existing file so you know what you're working with before editing it.
+- `scripts/xlsx_edit.py` — create a new workbook or edit an existing one by applying a JSON list of operations (set cell values/formulas, styling, merges, column widths, new sheets, charts, data validation).
+
+Both scripts are self-contained: they declare their own dependency (`openpyxl`) via [PEP 723](https://peps.python.org/pep-0723/) inline metadata, so `uv run` installs it into an ephemeral environment automatically — no project venv, no `pip install` step, nothing left behind on the machine.
+
+## Preflight: check for `uv`
+
+Look at this session's toolchain note (or run `uv --version`) before the first script call:
+
+- **`uv` present** — run scripts directly: `uv run <skill-dir>/scripts/xlsx_inspect.py <args>`. Dependency install is automatic and silent; don't run a separate `pip install openpyxl` step, it isn't needed and may not even land in the environment `uv run` actually uses.
+- **`uv` absent** — do not assume `python3`/`pip` are available or silently install anything. Tell the user what's missing (`uv`, installable via `curl -LsSf https://astral.sh/uv/install.sh | sh` on macOS/Linux or the equivalent on Windows — see https://docs.astral.sh/uv/getting-started/installation/) and wait for their go-ahead before installing. If they'd rather not install `uv`, the fallback is a manual `python3 -m venv`/`pip install openpyxl` and running the scripts with `python3` instead of `uv run` — but only after checking with the user, and only if `python3`/`pip` are themselves confirmed present.
+
+Note: `<skill-dir>/scripts/...` paths are relative to this skill's own directory (its absolute path is in the location header injected when this skill is loaded) — they are not relative to the user's working directory. There is no persistent working directory across terminal calls; pass absolute paths for `--input`/`--output`/`--ops`.
+
+## Reading a spreadsheet
+
+```bash
+uv run <skill-dir>/scripts/xlsx_inspect.py path/to/file.xlsx
+```
+
+Options:
+- `--sheet NAME` — inspect one sheet only (default: all sheets)
+- `--rows N` — number of sample data rows to include per sheet (default: 5)
+- `--data-only` — read cached formula *results* instead of formula text (only meaningful if the file was last saved by Excel/LibreOffice; openpyxl never computes formulas itself, so a file saved by openpyxl-only edits has no cached values to show)
+
+Output is JSON: for each sheet, its dimensions, header row (best-effort: first non-empty row), sample rows, every formula cell found (address + formula text), and merged cell ranges. Read this before writing any edit operations so cell addresses and sheet names are correct.
+
+## Creating or editing a spreadsheet
+
+```bash
+uv run <skill-dir>/scripts/xlsx_edit.py --output out.xlsx --ops ops.json
+uv run <skill-dir>/scripts/xlsx_edit.py --input existing.xlsx --output out.xlsx --ops ops.json
+```
+
+- Omit `--input` to start from a blank workbook.
+- `--input` and `--output` may be the same path to edit in place.
+- `--ops` points to a JSON file (or pass inline JSON via `--ops-json '...'`) containing a list of operation objects, applied in order. Supported operations:
+
+| `op` | Fields | Effect |
+|---|---|---|
+| `add_sheet` | `name`, `index` (optional) | Create a new sheet |
+| `set_cell` | `sheet`, `cell`, `value` | Set one cell; a leading `=` makes it a formula |
+| `set_row` | `sheet`, `row`, `values` (list, appended starting at column A of that row) | Write a whole row at once |
+| `style` | `sheet`, `range` (single cell or `A1:C3`), `font` (bold/italic/size/color/name), `fill` (color, solid), `border` (true = thin box), `alignment` (horizontal/vertical/wrap_text), `number_format` | Apply formatting to a cell or range |
+| `merge` | `sheet`, `range` | Merge a cell range |
+| `column_width` | `sheet`, `column` (letter), `width` | Set column width |
+| `row_height` | `sheet`, `row`, `height` | Set row height |
+| `freeze_panes` | `sheet`, `cell` | Freeze rows/columns above/left of `cell` |
+| `data_validation` | `sheet`, `range`, `type`, `formula1`, `formula2` (optional), `allow_blank` (optional) | Add a validation rule (e.g. `type: "list"` with `formula1: '"Yes,No"'`) |
+| `chart` | `sheet`, `type` (`bar`\|`line`\|`pie`), `data_range`, `categories_range`, `title`, `anchor`, `titles_from_data` (optional, default true) | Add a chart built from a data range on the same sheet |
+
+Ranges and cell references use normal Excel A1 notation. `data_range`/`categories_range` are parsed as `Sheet!A1:B5` or, if the sheet is omitted, resolved against the chart's own `sheet`.
+
+**Formulas are not evaluated by openpyxl.** `set_cell` with a `=...` value writes the formula text; Excel, LibreOffice, or Google Sheets will compute it on open. If a user needs computed values back out of the script (rather than just handing the file to Excel), that requires a spreadsheet engine this skill doesn't bundle — say so rather than approximating a result in Python and hardcoding it into the cell, which would silently go stale the next time an input changes.
+
+## Financial-model conventions worth following
+
+When building anything that looks like a financial model (budgets, valuations, projections), keep the spreadsheet self-updating and readable:
+
+- Prefer formulas over Python-computed constants for anything derived from other cells — see the note above.
+- Use cell references for assumptions instead of hardcoding multipliers into formulas (`=B5*(1+$B$6)` rather than `=B5*1.05`), so a reader can find and change the assumption.
+- A common (not mandatory) color convention: blue text for hardcoded inputs, black for formulas, green for cross-sheet links — apply via the `style` op's `font.color` field if the user wants this or it matches an existing template's convention.
+- If editing an existing template, match its existing formatting/conventions rather than imposing a different style.
+
+## Limitations
+
+Inherited from openpyxl itself: no VBA macro execution, no live external data connections, and pivot tables/sparklines are not supported by these scripts.

--- a/skills/office-xlsx/SKILL.md
+++ b/skills/office-xlsx/SKILL.md
@@ -69,7 +69,7 @@ When building anything that looks like a financial model (budgets, valuations, p
 
 - Prefer formulas over Python-computed constants for anything derived from other cells — see the note above.
 - Use cell references for assumptions instead of hardcoding multipliers into formulas (`=B5*(1+$B$6)` rather than `=B5*1.05`), so a reader can find and change the assumption.
-- A common (not mandatory) color convention: blue text for hardcoded inputs, black for formulas, green for cross-sheet links — apply via the `style` op's `font.color` field if the user wants this or it matches an existing template's convention.
+- A common (not mandatory) color convention from financial-modeling style guides (e.g. Wall Street Prep): blue text for hardcoded inputs, black for formulas, green for cross-sheet links — apply via the `style` op's `font.color` field if the user wants this or it matches an existing template's convention.
 - If editing an existing template, match its existing formatting/conventions rather than imposing a different style.
 
 ## Limitations

--- a/skills/office-xlsx/scripts/xlsx_edit.py
+++ b/skills/office-xlsx/scripts/xlsx_edit.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = ["openpyxl"]
+# ///
+"""Create or edit an .xlsx workbook by applying a JSON list of operations.
+
+Usage:
+    uv run xlsx_edit.py --output out.xlsx --ops ops.json
+    uv run xlsx_edit.py --input existing.xlsx --output out.xlsx --ops ops.json
+    uv run xlsx_edit.py --output out.xlsx --ops-json '[{"op": "set_cell", ...}]'
+
+See the skill's SKILL.md for the full operation reference table. Operations
+are applied in the order given and the result is saved to --output (which
+may be the same path as --input to edit in place).
+"""
+
+import argparse
+import json
+import sys
+
+from openpyxl import Workbook, load_workbook
+from openpyxl.cell.cell import Cell, MergedCell
+from openpyxl.chart import BarChart, LineChart, PieChart, Reference
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
+from openpyxl.utils.cell import range_boundaries
+from openpyxl.worksheet.datavalidation import DataValidation
+
+
+class OpError(Exception):
+    """Raised for a malformed or inapplicable operation; caught at the top
+    level and reported without a Python traceback."""
+
+
+def flatten_cells(x):
+    """ws[range] returns a bare Cell for a single address, or arbitrarily
+    nested tuples of Cell/MergedCell for a range — normalize both to a flat
+    list. A MergedCell (any non-top-left cell inside a merged range) is not
+    itself iterable and carries no independent style, but styling it is
+    harmless — Excel only renders the top-left cell's style anyway."""
+    if isinstance(x, (Cell, MergedCell)):
+        return [x]
+    out = []
+    for item in x:
+        out.extend(flatten_cells(item))
+    return out
+
+
+def get_sheet(wb, name):
+    if name not in wb.sheetnames:
+        raise OpError(f"sheet {name!r} not found; available: {wb.sheetnames}")
+    return wb[name]
+
+
+def op_add_sheet(wb, op, state):
+    name = op["name"]
+    # A fresh workbook starts with one untouched default sheet named "Sheet".
+    # Renaming it into the first requested sheet (rather than leaving an
+    # empty "Sheet" alongside it) matches the common `ws.title = "..."`
+    # pattern instead of accumulating a stray blank tab.
+    if not state["renamed_default"] and wb.sheetnames == ["Sheet"] and state["is_new_workbook"]:
+        wb.active.title = name
+        state["renamed_default"] = True
+        return
+    wb.create_sheet(name, op.get("index"))
+
+
+def op_set_cell(wb, op, state):
+    ws = get_sheet(wb, op["sheet"])
+    ws[op["cell"]] = op["value"]
+
+
+def op_set_row(wb, op, state):
+    ws = get_sheet(wb, op["sheet"])
+    row = op["row"]
+    for i, value in enumerate(op["values"], start=1):
+        ws.cell(row=row, column=i, value=value)
+
+
+def op_style(wb, op, state):
+    ws = get_sheet(wb, op["sheet"])
+    cells = flatten_cells(ws[op["range"]])
+
+    font_spec = op.get("font")
+    fill_spec = op.get("fill")
+    border_spec = op.get("border")
+    align_spec = op.get("alignment")
+    number_format = op.get("number_format")
+
+    for cell in cells:
+        if font_spec:
+            kwargs = {}
+            for key in ("bold", "italic", "size", "name", "color"):
+                if key in font_spec:
+                    kwargs[key] = font_spec[key]
+            cell.font = Font(**kwargs)
+        if fill_spec:
+            color = fill_spec.get("color")
+            if color:
+                cell.fill = PatternFill(
+                    start_color=color, end_color=color, fill_type=fill_spec.get("fill_type", "solid")
+                )
+        if border_spec:
+            thin = Side(style="thin")
+            cell.border = Border(left=thin, right=thin, top=thin, bottom=thin)
+        if align_spec:
+            cell.alignment = Alignment(
+                horizontal=align_spec.get("horizontal"),
+                vertical=align_spec.get("vertical"),
+                wrap_text=align_spec.get("wrap_text", False),
+            )
+        if number_format:
+            cell.number_format = number_format
+
+
+def op_merge(wb, op, state):
+    ws = get_sheet(wb, op["sheet"])
+    ws.merge_cells(op["range"])
+
+
+def op_column_width(wb, op, state):
+    ws = get_sheet(wb, op["sheet"])
+    ws.column_dimensions[op["column"]].width = op["width"]
+
+
+def op_row_height(wb, op, state):
+    ws = get_sheet(wb, op["sheet"])
+    ws.row_dimensions[op["row"]].height = op["height"]
+
+
+def op_freeze_panes(wb, op, state):
+    ws = get_sheet(wb, op["sheet"])
+    ws.freeze_panes = op["cell"]
+
+
+def op_data_validation(wb, op, state):
+    ws = get_sheet(wb, op["sheet"])
+    dv = DataValidation(
+        type=op["type"],
+        formula1=op.get("formula1"),
+        formula2=op.get("formula2"),
+        allow_blank=op.get("allow_blank", True),
+    )
+    ws.add_data_validation(dv)
+    dv.add(op["range"])
+
+
+def parse_ref(wb, default_ws, ref_str):
+    """Parse "Sheet!A1:B5" (or plain "A1:B5", resolved against default_ws)
+    into an openpyxl Reference."""
+    if "!" in ref_str:
+        sheet_name, rng = ref_str.split("!", 1)
+        ws = get_sheet(wb, sheet_name)
+    else:
+        ws = default_ws
+        rng = ref_str
+    min_col, min_row, max_col, max_row = range_boundaries(rng)
+    return Reference(ws, min_col=min_col, min_row=min_row, max_col=max_col, max_row=max_row)
+
+
+_CHART_TYPES = {"bar": BarChart, "line": LineChart, "pie": PieChart}
+
+
+def op_chart(wb, op, state):
+    ws = get_sheet(wb, op["sheet"])
+    chart_type = op["type"]
+    if chart_type not in _CHART_TYPES:
+        raise OpError(f"chart type {chart_type!r} not supported; use one of {list(_CHART_TYPES)}")
+
+    chart = _CHART_TYPES[chart_type]()
+    if chart_type == "bar":
+        chart.type = "col"
+    if op.get("title"):
+        chart.title = op["title"]
+
+    data_ref = parse_ref(wb, ws, op["data_range"])
+    chart.add_data(data_ref, titles_from_data=op.get("titles_from_data", True))
+    if op.get("categories_range"):
+        chart.set_categories(parse_ref(wb, ws, op["categories_range"]))
+
+    ws.add_chart(chart, op.get("anchor", "E1"))
+
+
+_OPS = {
+    "add_sheet": op_add_sheet,
+    "set_cell": op_set_cell,
+    "set_row": op_set_row,
+    "style": op_style,
+    "merge": op_merge,
+    "column_width": op_column_width,
+    "row_height": op_row_height,
+    "freeze_panes": op_freeze_panes,
+    "data_validation": op_data_validation,
+    "chart": op_chart,
+}
+
+
+def apply_ops(wb, ops, is_new_workbook):
+    state = {"renamed_default": False, "is_new_workbook": is_new_workbook}
+    for i, op in enumerate(ops):
+        op_name = op.get("op")
+        handler = _OPS.get(op_name)
+        if handler is None:
+            raise OpError(f"op #{i}: unknown op {op_name!r}; supported: {list(_OPS)}")
+        try:
+            handler(wb, op, state)
+        except KeyError as e:
+            raise OpError(f"op #{i} ({op_name}): missing required field {e}") from e
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--input", help="existing .xlsx to load; omit to start from a blank workbook")
+    parser.add_argument("--output", required=True, help="path to save the result to")
+    ops_group = parser.add_mutually_exclusive_group(required=True)
+    ops_group.add_argument("--ops", help="path to a JSON file containing the operations list")
+    ops_group.add_argument("--ops-json", help="the operations list as an inline JSON string")
+    args = parser.parse_args()
+
+    if args.ops:
+        with open(args.ops) as f:
+            ops = json.load(f)
+    else:
+        ops = json.loads(args.ops_json)
+
+    if not isinstance(ops, list):
+        print("error: ops must be a JSON list of operation objects", file=sys.stderr)
+        sys.exit(1)
+
+    if args.input:
+        wb = load_workbook(args.input)
+        is_new_workbook = False
+    else:
+        wb = Workbook()
+        is_new_workbook = True
+
+    try:
+        apply_ops(wb, ops, is_new_workbook)
+    except OpError as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    wb.save(args.output)
+    print(json.dumps({"status": "ok", "output": args.output, "sheets": wb.sheetnames}))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/office-xlsx/scripts/xlsx_edit.py
+++ b/skills/office-xlsx/scripts/xlsx_edit.py
@@ -95,10 +95,11 @@ def op_style(wb, op, state):
             cell.font = Font(**kwargs)
         if fill_spec:
             color = fill_spec.get("color")
-            if color:
-                cell.fill = PatternFill(
-                    start_color=color, end_color=color, fill_type=fill_spec.get("fill_type", "solid")
-                )
+            if not color:
+                raise OpError(f"style op on {op['range']!r}: fill needs a \"color\" field")
+            cell.fill = PatternFill(
+                start_color=color, end_color=color, fill_type=fill_spec.get("fill_type", "solid")
+            )
         if border_spec:
             thin = Side(style="thin")
             cell.border = Border(left=thin, right=thin, top=thin, bottom=thin)
@@ -203,8 +204,40 @@ def apply_ops(wb, ops, is_new_workbook):
             raise OpError(f"op #{i}: unknown op {op_name!r}; supported: {list(_OPS)}")
         try:
             handler(wb, op, state)
+        except OpError:
+            raise
         except KeyError as e:
             raise OpError(f"op #{i} ({op_name}): missing required field {e}") from e
+        except Exception as e:
+            # Anything else an op handler can throw (bad range string, bad
+            # chart/validation type, ...) — wrap with the op's position so
+            # the message is actionable instead of a bare library traceback.
+            raise OpError(f"op #{i} ({op_name}): {e}") from e
+
+
+def load_ops(args):
+    """Load and parse the operations list from --ops or --ops-json, raising
+    OpError (not a bare exception) for any file/JSON problem so main() has a
+    single place that turns failures into a clean exit."""
+    if args.ops:
+        try:
+            with open(args.ops) as f:
+                text = f.read()
+        except OSError as e:
+            raise OpError(f"could not read --ops file {args.ops!r}: {e.strerror or e}") from e
+        source = f"--ops file {args.ops!r}"
+    else:
+        text = args.ops_json
+        source = "--ops-json"
+
+    try:
+        ops = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise OpError(f"{source} is not valid JSON: {e}") from e
+
+    if not isinstance(ops, list):
+        raise OpError(f"{source} must be a JSON list of operation objects")
+    return ops
 
 
 def main():
@@ -216,30 +249,31 @@ def main():
     ops_group.add_argument("--ops-json", help="the operations list as an inline JSON string")
     args = parser.parse_args()
 
-    if args.ops:
-        with open(args.ops) as f:
-            ops = json.load(f)
-    else:
-        ops = json.loads(args.ops_json)
-
-    if not isinstance(ops, list):
-        print("error: ops must be a JSON list of operation objects", file=sys.stderr)
-        sys.exit(1)
-
-    if args.input:
-        wb = load_workbook(args.input)
-        is_new_workbook = False
-    else:
-        wb = Workbook()
-        is_new_workbook = True
-
     try:
+        ops = load_ops(args)
+
+        if args.input:
+            try:
+                wb = load_workbook(args.input)
+            except FileNotFoundError:
+                raise OpError(f"no such file: {args.input}") from None
+            except Exception as e:
+                raise OpError(f"could not open {args.input}: {e}") from e
+            is_new_workbook = False
+        else:
+            wb = Workbook()
+            is_new_workbook = True
+
         apply_ops(wb, ops, is_new_workbook)
+
+        try:
+            wb.save(args.output)
+        except OSError as e:
+            raise OpError(f"could not save {args.output}: {e.strerror or e}") from e
     except OpError as e:
         print(f"error: {e}", file=sys.stderr)
         sys.exit(1)
 
-    wb.save(args.output)
     print(json.dumps({"status": "ok", "output": args.output, "sheets": wb.sheetnames}))
 
 

--- a/skills/office-xlsx/scripts/xlsx_inspect.py
+++ b/skills/office-xlsx/scripts/xlsx_inspect.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = ["openpyxl"]
+# ///
+"""Inspect the structure of an .xlsx workbook and print it as JSON.
+
+For each sheet: dimensions, a best-effort header row, a handful of sample
+data rows, every formula found (cell address + formula text), and merged
+cell ranges. Read this before writing xlsx_edit.py operations so cell
+addresses and sheet names are known to be correct.
+
+Usage:
+    uv run xlsx_inspect.py workbook.xlsx [--sheet NAME] [--rows N] [--data-only]
+"""
+
+import argparse
+import json
+import sys
+
+from openpyxl import load_workbook
+
+
+def first_non_empty_row(ws, max_scan=20):
+    """Return (row_number, values) for the first row with any non-empty
+    cell, scanning at most max_scan rows. (None, []) if the sheet is empty."""
+    scan_to = min(max_scan, ws.max_row or 1)
+    for row in ws.iter_rows(min_row=1, max_row=scan_to):
+        values = [c.value for c in row]
+        if any(v is not None for v in values):
+            return row[0].row, values
+    return None, []
+
+
+def inspect_sheet(ws, sample_rows, data_only):
+    header_row_num, header_values = first_non_empty_row(ws)
+    start = (header_row_num or 0) + 1
+
+    sample = []
+    if ws.max_row and start <= ws.max_row:
+        end = min(start + sample_rows - 1, ws.max_row)
+        for row in ws.iter_rows(min_row=start, max_row=end):
+            sample.append([c.value for c in row])
+
+    formulas = []
+    formulas_note = None
+    if data_only:
+        formulas_note = (
+            "formulas are not readable in --data-only mode "
+            "(cells hold cached values instead); re-run without it to see formula text"
+        )
+    else:
+        for row in ws.iter_rows():
+            for cell in row:
+                if isinstance(cell.value, str) and cell.value.startswith("="):
+                    formulas.append({"cell": cell.coordinate, "formula": cell.value})
+
+    merged = [str(r) for r in ws.merged_cells.ranges]
+
+    return {
+        "dimensions": ws.dimensions,
+        "max_row": ws.max_row,
+        "max_column": ws.max_column,
+        "header_row": header_row_num,
+        "header": header_values,
+        "sample_rows": sample,
+        "formulas": formulas,
+        "formulas_note": formulas_note,
+        "merged_cells": merged,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("input", help="path to the .xlsx file")
+    parser.add_argument("--sheet", help="inspect only this sheet (default: all sheets)")
+    parser.add_argument("--rows", type=int, default=5, help="sample data rows per sheet (default: 5)")
+    parser.add_argument(
+        "--data-only",
+        action="store_true",
+        help="read cached formula results instead of formula text "
+        "(only useful if the file was last saved by Excel/LibreOffice)",
+    )
+    args = parser.parse_args()
+
+    try:
+        wb = load_workbook(args.input, data_only=args.data_only)
+    except FileNotFoundError:
+        print(f"error: no such file: {args.input}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.sheet:
+        if args.sheet not in wb.sheetnames:
+            print(f"error: sheet {args.sheet!r} not found; available: {wb.sheetnames}", file=sys.stderr)
+            sys.exit(1)
+        sheet_names = [args.sheet]
+    else:
+        sheet_names = wb.sheetnames
+
+    result = {
+        "file": args.input,
+        "sheets": wb.sheetnames,
+        "active_sheet": wb.active.title,
+        "data": {name: inspect_sheet(wb[name], args.rows, args.data_only) for name in sheet_names},
+    }
+    print(json.dumps(result, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New `skills/office-xlsx/` at repo root (NOT embedded yet -- phase 1 of the office-doc-skills item in #1054, installable via `octo skills add open-octo/octo-agent/skills/office-xlsx`)
- Adapted from MIT-licensed `claude-office-skills/skills` (xlsx-manipulation), with LICENSE.txt attribution matching this repo's existing `find-skills` precedent
- `scripts/xlsx_inspect.py` / `xlsx_edit.py` are new code (source repo had no bundled scripts, only prose), using PEP 723 `uv run --script` inline deps -- zero manual `pip install` needed when `uv` is present
- `PROVENANCE.md` documents a provenance audit against `anthropics/skills/skills/xlsx` (read-only comparison, nothing copied) -- conclusion: genuine independent implementation, differs in delivery mechanism, formula handling, and code structure

## Review history
An isolated subagent review found two Important issues, both now fixed:
- `xlsx_edit.py` was leaking raw Python tracebacks (including local cache paths) on error paths instead of clean messages -- fixed: single `OpError` boundary in `main()`, all failure paths now print `error: ...` to stderr and exit 1
- The financial-model color-coding paragraph's citation traced through a file the audit itself excluded for being Anthropic-licensed -- fixed: rewrote the citation to rest on independently-fetched public sources (Wall Street Prep, WallStreetMojo), with a rejected-candidate-source noted for transparency

## Test plan
- [x] `uv run scripts/xlsx_edit.py` / `xlsx_inspect.py` exercised end-to-end against a real multi-sheet fixture (formulas, merged+styled header, chart, data-validation dropdown) -- confirmed zero manual `pip install`
- [x] Re-ran the four failure cases from review (missing file, malformed JSON, missing ops file, invalid range) -- all now produce a single clean `error: ...` line, exit 1, no traceback
- [x] `git status`/`gofmt -l .` confirm zero Go files touched
- [ ] Quality eval against a wider set of real-world .xlsx fixtures before this is promoted to an embedded default (phase 2, not this PR)

Part of #1054.

Generated with Claude Code