### PR TITLE
fix(agent,provider): overflow clamp bounds and silent stream truncation

### DIFF
--- a/internal/agent/overflow.go
+++ b/internal/agent/overflow.go
@@ -242,7 +242,15 @@ func computePullBack(historyLen, mode int) int {
 	return clamp(half, 4, historyLen-2) // keep system + at least 1 message
 }
 
+// clamp bounds v to [min, max]. When the range is infeasible (max < min —
+// e.g. a small history where "keep at least 1 message" caps below the
+// aggressive-mode floor), max wins: it's the hard safety bound against
+// popping too much history, so returning it degrades gracefully instead of
+// handing back an out-of-range value the caller would reject outright.
 func clamp(v, min, max int) int {
+	if max < min {
+		return max
+	}
 	if v < min {
 		return min
 	}

--- a/internal/agent/overflow_test.go
+++ b/internal/agent/overflow_test.go
@@ -41,6 +41,21 @@ func TestParseOverflowTokens(t *testing.T) {
 	}
 }
 
+// TestComputePullBack_SmallHistoryStaysInBounds guards against a regression
+// where clamp(half, 4, historyLen-2) returned an out-of-range value (the
+// floor of 4) whenever historyLen-2 fell below it, which made the caller's
+// own "k >= len(msgs)-1" guard reject every aggressive pull-back attempt for
+// 4-5 message histories — silently disabling Layer 2 overflow recovery
+// exactly when the small, single-turn histories that trip it need it most.
+func TestComputePullBack_SmallHistoryStaysInBounds(t *testing.T) {
+	for historyLen := 4; historyLen <= 10; historyLen++ {
+		k := computePullBack(historyLen, pullBackAggressive)
+		if k <= 0 || k >= historyLen-1 {
+			t.Errorf("computePullBack(%d, aggressive) = %d, want in [1, %d]", historyLen, k, historyLen-2)
+		}
+	}
+}
+
 // dummyOverflowTools gives Run/RunStream enough reason to enter runLoop rather
 // than falling back to the plain Turn path.
 var dummyOverflowTools = []ToolDefinition{{Name: "bash", Description: "shell"}}

--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -126,6 +126,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		accByIndex = map[int]*blockAccumulator{}
 		// ordered list of block indices to preserve emission order
 		blockOrder  []int
+		sawEvent    bool // at least one event line was parsed (stream reached the server)
 		sawTerminal bool // message_delta carried a stop_reason, or message_stop arrived
 	)
 
@@ -162,6 +163,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 			// re-issues the round, same as a boundary-aligned reset caught below.
 			return result, retry.AsTransientStream(fmt.Errorf("anthropic: parse stream event: %w", err))
 		}
+		sawEvent = true
 
 		switch ev.Type {
 		case "message_start":
@@ -271,7 +273,11 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 	// dropped exactly on an SSE line boundary mid-generation (idle LB/proxy
 	// reset). Treating it as success would silently hand back garbled
 	// tool-call arguments or a truncated reply with no error and no retry.
-	if !sawTerminal && len(blockOrder) > 0 {
+	// Gated on sawEvent (not len(blockOrder)>0): a real response is never
+	// legitimately empty, so a drop right after message_start — before any
+	// content_block_start ever arrives — is truncation too, one event
+	// earlier than the block-accumulation case.
+	if !sawTerminal && sawEvent {
 		return result, retry.AsTransientStream(errors.New("anthropic: stream ended without a terminal event (truncated mid-generation)"))
 	}
 

--- a/internal/provider/anthropic/stream.go
+++ b/internal/provider/anthropic/stream.go
@@ -125,7 +125,8 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		result     provider.Response
 		accByIndex = map[int]*blockAccumulator{}
 		// ordered list of block indices to preserve emission order
-		blockOrder []int
+		blockOrder  []int
+		sawTerminal bool // message_delta carried a stop_reason, or message_stop arrived
 	)
 
 	// Guard the body read against a mid-stream stall: if the server stops
@@ -222,9 +223,13 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 				}
 			}
 
+		case "message_stop":
+			sawTerminal = true
+
 		case "message_delta":
 			if ev.Delta != nil && ev.Delta.StopReason != "" {
 				result.StopReason = ev.Delta.StopReason
+				sawTerminal = true
 			}
 			// Output token count refines as the stream progresses; the
 			// final message_delta carries the authoritative total.
@@ -258,6 +263,16 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		// instead of failing the turn. A caller cancellation passes through
 		// untouched (see retry.AsTransientStream).
 		return result, retry.AsTransientStream(fmt.Errorf("anthropic: stream read: %w", err))
+	}
+	// The scanner hit a clean EOF (no read error) without ever seeing
+	// message_stop or a message_delta carrying stop_reason. Each individual
+	// `data:` line was valid, self-contained JSON, so this isn't caught by
+	// the parse-error or scanner.Err() checks above — it's a connection that
+	// dropped exactly on an SSE line boundary mid-generation (idle LB/proxy
+	// reset). Treating it as success would silently hand back garbled
+	// tool-call arguments or a truncated reply with no error and no retry.
+	if !sawTerminal && len(blockOrder) > 0 {
+		return result, retry.AsTransientStream(errors.New("anthropic: stream ended without a terminal event (truncated mid-generation)"))
 	}
 
 	// Build the final block list in order.

--- a/internal/provider/anthropic/stream_test.go
+++ b/internal/provider/anthropic/stream_test.go
@@ -435,3 +435,33 @@ func TestSendStream_CleanCloseWithoutTerminalEvent_IsTransient(t *testing.T) {
 		t.Errorf("clean close without a terminal event should be transient, got %v", err)
 	}
 }
+
+// TestSendStream_CleanCloseBeforeAnyBlock_IsTransient covers the narrower
+// case the first guard's `len(blockOrder) > 0` condition missed: a connection
+// that drops right after message_start — before any content_block_start ever
+// arrives — with no terminal event. A real response is never legitimately
+// empty this way, so this is truncation too, one event earlier than dying
+// mid-block.
+func TestSendStream_CleanCloseBeforeAnyBlock_IsTransient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `data: {"type":"message_start","message":{"model":"claude-x","usage":{"input_tokens":10,"output_tokens":0}}}`+"\n\n")
+		// Connection closes cleanly here — before any content_block_start,
+		// no message_delta, no message_stop.
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	_, err := c.SendStream(context.Background(), provider.Request{
+		Model: "x", Messages: []agent.Message{agent.NewUserMessage("hi")},
+	}, provider.StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected an error from the terminated-before-any-block stream")
+	}
+	var ts interface{ TransientStream() bool }
+	if !errors.As(err, &ts) || !ts.TransientStream() {
+		t.Errorf("clean close before any block should be transient, got %v", err)
+	}
+}

--- a/internal/provider/anthropic/stream_test.go
+++ b/internal/provider/anthropic/stream_test.go
@@ -404,3 +404,34 @@ func TestSendStream_MidStreamResetIsTransient(t *testing.T) {
 		t.Errorf("mid-stream reset should be transient, got %v", err)
 	}
 }
+
+// TestSendStream_CleanCloseWithoutTerminalEvent_IsTransient covers a
+// connection that drops exactly on an SSE event boundary mid-tool-call:
+// content_block_start and an input_json_delta both arrive as complete, valid
+// JSON (so neither fails to parse nor trips scanner.Err()), but the stream
+// ends with no message_delta/stop_reason and no message_stop. Before this was
+// fixed, that silently produced a "successful" tool_use response with
+// nil/garbled arguments instead of an error the agent loop could retry.
+func TestSendStream_CleanCloseWithoutTerminalEvent_IsTransient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"edit_file"}}`+"\n\n")
+		_, _ = io.WriteString(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":"}}`+"\n\n")
+		// Connection closes cleanly here — no message_delta, no message_stop.
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	_, err := c.SendStream(context.Background(), provider.Request{
+		Model: "x", Messages: []agent.Message{agent.NewUserMessage("hi")},
+	}, provider.StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected an error from the terminated-without-terminal-event stream")
+	}
+	var ts interface{ TransientStream() bool }
+	if !errors.As(err, &ts) || !ts.TransientStream() {
+		t.Errorf("clean close without a terminal event should be transient, got %v", err)
+	}
+}

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -118,6 +118,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		result      provider.Response
 		toolStates  = map[int]*toolCallState{} // keyed by tool call index
 		toolOrder   []int                      // preserve order
+		sawEvent    bool                       // at least one chunk was parsed (stream reached the server)
 		sawTerminal bool                       // [DONE] or a finish_reason chunk was observed
 	)
 
@@ -157,6 +158,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 			// re-issues the round, same as a boundary-aligned reset caught below.
 			return result, retry.AsTransientStream(fmt.Errorf("openai: parse stream chunk: %w", err))
 		}
+		sawEvent = true
 
 		// An OpenAI-compatible server can report a failure AFTER the 200 status
 		// as a `data: {"error": {...}}` line, then close the stream (often with
@@ -252,7 +254,12 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 	// an SSE line boundary mid-generation (idle LB/proxy reset). Treating it
 	// as success would silently hand back garbled tool-call arguments or a
 	// truncated reply with no error and no retry.
-	if !sawTerminal && (contentB.Len() > 0 || reasoningB.Len() > 0 || len(toolOrder) > 0) {
+	// Gated on sawEvent (not accumulated content/tool length): a real
+	// response is never legitimately empty, so a drop right after a
+	// role-only first chunk — before any content or tool-call text ever
+	// arrives — is truncation too, one chunk earlier than the
+	// content-accumulation case.
+	if !sawTerminal && sawEvent {
 		return result, retry.AsTransientStream(errors.New("openai: stream ended without a terminal event (truncated mid-generation)"))
 	}
 

--- a/internal/provider/openai/stream.go
+++ b/internal/provider/openai/stream.go
@@ -113,11 +113,12 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 	defer resp.Body.Close()
 
 	var (
-		contentB   strings.Builder
-		reasoningB strings.Builder
-		result     provider.Response
-		toolStates = map[int]*toolCallState{} // keyed by tool call index
-		toolOrder  []int                      // preserve order
+		contentB    strings.Builder
+		reasoningB  strings.Builder
+		result      provider.Response
+		toolStates  = map[int]*toolCallState{} // keyed by tool call index
+		toolOrder   []int                      // preserve order
+		sawTerminal bool                       // [DONE] or a finish_reason chunk was observed
 	)
 
 	// Guard the body read against a mid-stream stall: if the server stops
@@ -142,7 +143,9 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		}
 		if data == "[DONE]" {
 			// Terminal sentinel. Some compatible servers omit it; we treat
-			// EOF as equivalent.
+			// EOF as equivalent as long as a finish_reason chunk landed first
+			// (see sawTerminal check after the loop).
+			sawTerminal = true
 			break
 		}
 
@@ -232,6 +235,7 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 				stopReason = "max_tokens"
 			}
 			result.StopReason = stopReason
+			sawTerminal = true
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -240,6 +244,16 @@ func (c *Client) SendStream(ctx context.Context, req provider.Request, cb provid
 		// instead of failing the turn. A caller cancellation passes through
 		// untouched (see retry.AsTransientStream).
 		return result, retry.AsTransientStream(fmt.Errorf("openai: stream read: %w", err))
+	}
+	// The scanner hit a clean EOF (no read error) without ever seeing a
+	// finish_reason chunk or [DONE]. Each individual `data:` line was valid,
+	// self-contained JSON, so this isn't caught by the parse-error or
+	// scanner.Err() checks above — it's a connection that dropped exactly on
+	// an SSE line boundary mid-generation (idle LB/proxy reset). Treating it
+	// as success would silently hand back garbled tool-call arguments or a
+	// truncated reply with no error and no retry.
+	if !sawTerminal && (contentB.Len() > 0 || reasoningB.Len() > 0 || len(toolOrder) > 0) {
+		return result, retry.AsTransientStream(errors.New("openai: stream ended without a terminal event (truncated mid-generation)"))
 	}
 
 	result.Content = contentB.String()

--- a/internal/provider/openai/stream_test.go
+++ b/internal/provider/openai/stream_test.go
@@ -557,6 +557,36 @@ func TestSendStream_MidStreamResetIsTransient(t *testing.T) {
 	}
 }
 
+// TestSendStream_CleanCloseWithoutTerminalEvent_IsTransient covers a
+// connection that drops exactly on an SSE line boundary mid-tool-call: every
+// `data:` line received is complete, valid JSON (so it doesn't fail to parse
+// and doesn't trip scanner.Err()), but the stream ends with no finish_reason
+// chunk and no [DONE]. Before this was fixed, that silently produced a
+// "successful" tool_use response with nil/garbled arguments instead of an
+// error the agent loop could retry.
+func TestSendStream_CleanCloseWithoutTerminalEvent_IsTransient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"edit_file","arguments":"{\"path\":"}}]}}]}`+"\n\n")
+		// Connection closes cleanly here — no finish_reason, no [DONE].
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	_, err := c.SendStream(context.Background(), provider.Request{
+		Model: "m", Messages: []agent.Message{agent.NewUserMessage("hi")},
+	}, provider.StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected an error from the terminated-without-terminal-event stream")
+	}
+	var ts interface{ TransientStream() bool }
+	if !errors.As(err, &ts) || !ts.TransientStream() {
+		t.Errorf("clean close without a terminal event should be transient, got %v", err)
+	}
+}
+
 // errorMidStream sends real content, then an `error` payload (after a 200), then
 // closes with no [DONE] — the shape some OpenAI-compatible gateways use to
 // report a mid-generation failure.

--- a/internal/provider/openai/stream_test.go
+++ b/internal/provider/openai/stream_test.go
@@ -587,6 +587,36 @@ func TestSendStream_CleanCloseWithoutTerminalEvent_IsTransient(t *testing.T) {
 	}
 }
 
+// TestSendStream_CleanCloseBeforeAnyContent_IsTransient covers the narrower
+// case the first guard's `contentB.Len() > 0 || ...` condition missed: a
+// connection that drops after only a role-only first chunk (no content, no
+// reasoning, no tool calls yet) and no terminal event. A real response is
+// never legitimately empty this way, so this is truncation just as much as
+// dying mid-content — it must not be silently treated as a valid empty reply.
+func TestSendStream_CleanCloseBeforeAnyContent_IsTransient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n\n")
+		// Connection closes cleanly here — before any content/tool-call text,
+		// no finish_reason, no [DONE].
+	}))
+	defer srv.Close()
+
+	c, _ := New("k")
+	c.BaseURL = srv.URL
+	_, err := c.SendStream(context.Background(), provider.Request{
+		Model: "m", Messages: []agent.Message{agent.NewUserMessage("hi")},
+	}, provider.StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected an error from the terminated-before-any-content stream")
+	}
+	var ts interface{ TransientStream() bool }
+	if !errors.As(err, &ts) || !ts.TransientStream() {
+		t.Errorf("clean close before any content should be transient, got %v", err)
+	}
+}
+
 // errorMidStream sends real content, then an `error` payload (after a 200), then
 // closes with no [DONE] — the shape some OpenAI-compatible gateways use to
 // report a mid-generation failure.


### PR DESCRIPTION
## Summary
- `internal/agent/overflow.go`: `clamp(v,min,max)` returned `min` even when `max<min` (small 4-5 message histories), which the caller's own bounds guard (`k >= len(msgs)-1`) then rejected — making Layer-2 aggressive overflow recovery a permanent no-op and wedging small/single-turn sessions that 413 on an oversized tool_result. `clamp` now treats `max` as the hard safety bound and degrades gracefully instead of returning an out-of-range value.
- `internal/provider/openai/stream.go` + `internal/provider/anthropic/stream.go`: a clean SSE close with no terminal event (no `[DONE]`/`finish_reason` for OpenAI, no `message_stop`/stop_reason `message_delta` for Anthropic) was treated the same as a normal sentinel-less end, silently returning a "successful" `tool_use` response with `nil`/garbled arguments or a truncated reply presented as final — no retry, no error. Both adapters now track whether a terminal event was actually observed and return a retryable transient error otherwise.

Found via a free-exploration bug hunt across the codebase (goals feature, provider streaming, compaction/history, browser guardrails); these two were the highest-confidence, highest-severity findings — both can silently corrupt or wedge a live session with no visible error.

## Test plan
- [x] New regression test `TestComputePullBack_SmallHistoryStaysInBounds` (internal/agent/overflow_test.go) — verifies `computePullBack` stays in bounds for histories of length 4-10
- [x] New regression test `TestSendStream_CleanCloseWithoutTerminalEvent_IsTransient` in both `internal/provider/openai/stream_test.go` and `internal/provider/anthropic/stream_test.go` — reproduces a clean close mid-tool-call with no terminal event and asserts a transient error
- [x] `go vet ./...` clean
- [x] `go test -race ./...` clean (full suite)
- [x] `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)