### PR TITLE
docs: sync CLAUDE.md/.octorules and fix README's mischaracterization of them

### DIFF
--- a/.octorules
+++ b/.octorules
@@ -6,6 +6,21 @@ The canonical project guidance for contributors and AI coding agents. Keep this 
 
 `octo-agent` is a Go AI agent CLI (Go 1.22+, single binary). Module path `github.com/open-octo/octo-agent`. Ships as CLI + embedded Web UI + IM bridges (see `octo serve`).
 
+## Commands
+
+```bash
+make build                                                  # ./octo (or set VERSION=0.x.y for releases)
+make test                                                   # go test -race ./...
+make vet                                                    # go vet ./...
+make fmt-check                                              # gofmt -l . must print nothing
+make fmt                                                    # gofmt -w .
+make tidy                                                   # go mod tidy
+
+go test ./internal/agent/                                   # single package
+go test ./internal/provider/anthropic/ -run TestSendStream  # single test
+go test -race -v ./internal/tools/                          # verbose race
+```
+
 ## Layering
 
 ```
@@ -43,6 +58,21 @@ Dependency direction is one-way: `provider → agent`, `tools → agent`, never 
 
 - `make test` runs `go test -race ./...` — must be green before pushing.
 - Integration tests against real provider APIs are run by hand with a real key, not in CI.
+
+## Common pitfalls (from prior incidents)
+
+- **`Accept-Encoding: gzip` on Bing's HTML search endpoint** returns a JS skeleton instead of the real results page — `web_search` must omit that header.
+- **OpenAI streaming needs `stream_options.include_usage=true`.** DashScope (Bailian) and real OpenAI emit no usage chunk without it (streamed turn reports zero tokens); DeepSeek sends usage regardless either way.
+- **Cache token semantics differ by protocol, not vendor.** Anthropic-protocol endpoints report `input_tokens` as the uncached remainder with `cache_read_input_tokens` separate; OpenAI-protocol endpoints report `prompt_tokens` as the whole input with `cached_tokens` a subset. `InputTokens`/`CacheReadTokens` must stay non-overlapping buckets — the openai adapter subtracts cached from prompt, the anthropic adapter needs no adjustment.
+- **OpenAI tool-call arguments stream as JSON fragments** across multiple chunks, keyed by `tool_calls[i].index` — concatenate before parsing.
+- **`finish_reason: "tool_calls"` (OpenAI) vs `stop_reason: "tool_use"` (Anthropic)** — normalize to `"tool_use"` at the provider adapter; the agent loop must never branch on the OpenAI spelling.
+
+See `CLAUDE.md` for the full write-up of each incident.
+
+## When in doubt
+
+- Verify external claims (API endpoints, third-party SDK existence, dates) before committing them.
+- If `go test ./...` fails because of an environment issue (missing key, blocked network), say so explicitly rather than commenting out the test.
 
 ## What lives in `dev-docs/`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,12 @@ Five-layer stack with one-directional dependencies:
    - `terminal.go` — current canonical example. Tool name `terminal` rather than `bash` because the implementation shells out via the platform shell — `sh -c` on macOS/Linux, PowerShell (`pwsh`, else `powershell`) on Windows — not a hard `/bin/bash` dependency. The shell is selected in one place: `shellCommand` in `sandbox.go`. The model is told which shell it's on via the environment context (`cmd/octo/envcontext.go`).
    - `DefaultRegistry` dispatches by tool name. `DefaultTools()` returns the set sent to the LLM (tools are on by default; `--no-tools` disables them).
 
+## Adding capability
+
+- **New provider** — implement `provider.Provider` (required) and optionally `provider.StreamingProvider`, `provider.ToolProvider`, `provider.ToolStreamingProvider`. Put it under `internal/provider/<name>/`. Each protocol's wire-format quirks are isolated inside the package; the agent layer must not learn about them.
+- **New tool** — implement `agent.ToolExecutor` and `Definition() agent.ToolDefinition` returning the JSON Schema the LLM sees. Place it under `internal/tools/<name>.go`. Register it in `tools.DefaultRegistry` and add it to `tools.DefaultTools()` if it belongs in the default set.
+- **New skill** — `~/.octo/skills/<name>/SKILL.md` with the same frontmatter format Claude Code uses. The skill loader composes existing tools — adding a skill should not require new tool code.
+
 ## Conventions
 
 From `.octorules`:
@@ -57,6 +63,9 @@ From `.octorules`:
 - **Comments in English.** Prefer self-documenting names; only comment the **why**, not the **what**.
 - **gofmt is the formatter.** `gofmt -l .` must be empty before push.
 - **Branch off latest main.** Never commit directly on `main`. Squash-and-merge is the default.
+- **No new third-party dependencies** without justification in the PR description.
+- **One concept per PR.** Mass mechanical changes (rename, move) can ride together but should be a single self-contained change set.
+- **Commit messages and PR descriptions in English.**
 
 ## Common pitfalls (from prior incidents)
 

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ make vet           # go vet ./...
 make fmt-check     # gofmt -l . must be empty
 ```
 
-Project conventions live in [`.octorules`](.octorules) (the human-facing rules); [`CLAUDE.md`](CLAUDE.md) expands them with the operational detail AI coding agents need in this repo. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the human PR workflow.
+Project conventions live in both [`CLAUDE.md`](CLAUDE.md) and [`.octorules`](.octorules) — parallel files carrying the same guidance for two different AI coding tools (Claude Code reads the former; octo reads the latter as a system-prompt layer, see Configuration above). See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the human PR workflow.
 
 ## Prior art & acknowledgements
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -327,7 +327,7 @@ make vet           # go vet ./...
 make fmt-check     # gofmt -l . 必须为空
 ```
 
-项目约定写在 [`.octorules`](.octorules)（面向人类的规则）；[`CLAUDE.md`](CLAUDE.md) 在此基础上补充 AI 编程助手在本仓库工作所需的操作细节。[`CONTRIBUTING.md`](CONTRIBUTING.md) 是人类 PR 流程。
+项目约定同时写在 [`CLAUDE.md`](CLAUDE.md) 和 [`.octorules`](.octorules) 里——这是两份内容对等的文件，分别服务两个不同的 AI 编程工具（Claude Code 读前者；octo 把后者当作系统提示词的一层来读，见上面的"配置"一节）。人类的 PR 流程见 [`CONTRIBUTING.md`](CONTRIBUTING.md)。
 
 ## 致谢与前人工作
 


### PR DESCRIPTION
## Summary
- `CLAUDE.md` and `.octorules` had drifted apart: `CLAUDE.md` had the Commands block, per-file architecture breakdown, Common pitfalls, and When-in-doubt sections that `.octorules` lacked; `.octorules` had an "Adding capability" section and a few PR-hygiene rules (no unjustified deps, one concept per PR, English commit messages) that `CLAUDE.md` lacked. Ported each side's unique content to the other — pitfalls condensed to fit `.octorules`'s own "keep this short" mandate, pointing back to `CLAUDE.md` for the full write-ups.
- Fixes `README.md`'s Development section (and the same line in `README_CN.md`), which described `.octorules` as "the human-facing rules" that `CLAUDE.md` "expands." Both claims were wrong: `.octorules` is a real system-prompt layer octo reads at runtime (per the README's own Configuration section), not a human doc, and neither file was a strict superset of the other. Reworded to describe them as parallel files serving two different AI coding tools (Claude Code reads `CLAUDE.md`; octo reads `.octorules`).

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l .` (clean — docs-only change, no Go touched besides sanity check)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>