### PR TITLE
fix(tui): clamp tool-card rows to width, show terminal output tail + exit code

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -503,7 +503,7 @@ func replToolEventHandler(stdout io.Writer, plain bool) func(agent.AgentEvent) {
 			fmt.Fprintf(stdout, "↳ %s: %s\n", ev.ToolName, summariseInput(ev.Input))
 
 		case agent.EventToolProgress:
-			fmt.Fprintf(stdout, "│ %s\n", ev.Chunk)
+			fmt.Fprintf(stdout, "│ %s\n", boundProgressChunk(ev.Chunk))
 
 		case agent.EventToolDone:
 			elapsed := time.Duration(0)
@@ -553,6 +553,21 @@ func summariseInput(input map[string]any) string {
 	}
 	joined := strings.Join(parts, " ")
 	return truncateRunes(joined, 60)
+}
+
+// progressLineCap bounds one streamed progress line's display length. The full
+// output still reaches the model; this only keeps a single enormous line (e.g.
+// minified JSON) from flooding the live transcript.
+const progressLineCap = 300
+
+// boundProgressChunk caps each line of a streamed tool-progress chunk at
+// progressLineCap runes for display.
+func boundProgressChunk(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i, l := range lines {
+		lines[i] = truncateRunes(l, progressLineCap)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // truncate1Line collapses a multi-line error to its first non-empty line and

--- a/cmd/octo/repl_test.go
+++ b/cmd/octo/repl_test.go
@@ -461,3 +461,26 @@ func (c *capturingSender) lastUserContent() string {
 	}
 	return ""
 }
+
+func TestBoundProgressChunk(t *testing.T) {
+	// A single enormous line is capped at progressLineCap runes for display.
+	long := strings.Repeat("x", progressLineCap+50)
+	if got := boundProgressChunk(long); len([]rune(got)) != progressLineCap {
+		t.Errorf("long line should cap at %d runes, got %d", progressLineCap, len([]rune(got)))
+	}
+	// Each line of a multi-line chunk is capped independently; short lines and
+	// the trailing newline trim are preserved.
+	chunk := "short\n" + long + "\nend\n"
+	got := boundProgressChunk(chunk)
+	lines := strings.Split(got, "\n")
+	if len(lines) != 3 || lines[0] != "short" || lines[2] != "end" {
+		t.Fatalf("multi-line chunk mangled: %q", got)
+	}
+	if len([]rune(lines[1])) != progressLineCap {
+		t.Errorf("middle line should cap at %d runes, got %d", progressLineCap, len([]rune(lines[1])))
+	}
+	// A short chunk passes through untouched.
+	if got := boundProgressChunk("plain"); got != "plain" {
+		t.Errorf("short chunk should be unchanged, got %q", got)
+	}
+}

--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -147,11 +147,12 @@ func splitTerminalExit(output string) (body, exit string) {
 }
 
 // formatElapsed renders a tool call's duration for the card header: "" when
-// unknown (<=0, e.g. history replay), sub-second precision while short, whole
-// seconds once rounding noise stops mattering.
+// unknown (<=0, e.g. history replay) or too quick to be worth annotating
+// (sub-100ms would render as a meaningless "0s"), sub-second precision while
+// short, whole seconds once rounding noise stops mattering.
 func formatElapsed(d time.Duration) string {
 	switch {
-	case d <= 0:
+	case d < 100*time.Millisecond:
 		return ""
 	case d < 10*time.Second:
 		return d.Round(100 * time.Millisecond).String()

--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"strings"
+	"time"
+
 	"github.com/open-octo/octo-agent/internal/tools"
 	"github.com/open-octo/octo-agent/internal/tui"
 )
@@ -78,8 +81,9 @@ func cardTargetFor(toolName string, input map[string]any) string {
 // renderToolCard returns the rich card for a finished tool call, or "" if the
 // tool isn't a card tool (caller falls back to a one-line status). edit_file
 // success renders a diff card; everything else (and edit_file errors) renders
-// an output-preview card. TUI-only — the plain path never calls this.
-func renderToolCard(toolName string, input map[string]any, output string, isErr bool) string {
+// an output-preview card. width clips card rows to the terminal; elapsed (>0)
+// is shown dimmed in the header. TUI-only — the plain path never calls this.
+func renderToolCard(toolName string, input map[string]any, output string, isErr bool, width int, elapsed time.Duration) string {
 	verb := cardVerbFor(toolName)
 	if verb == "" {
 		return ""
@@ -88,19 +92,81 @@ func renderToolCard(toolName string, input map[string]any, output string, isErr 
 		path, _ := input["path"].(string)
 		oldS, _ := input["old_string"].(string)
 		newS, _ := input["new_string"].(string)
-		return tui.RenderEditCard(path, oldS, newS)
+		return tui.RenderEditCard(path, oldS, newS, width)
 	}
-	lang := ""
-	if toolName == "read_file" || toolName == "write_file" {
+	opts := tui.OutputCardOpts{
+		MaxLines: outputCardMaxLines,
+		Width:    width,
+		IsErr:    isErr,
+		Meta:     formatElapsed(elapsed),
+	}
+	switch toolName {
+	case "read_file":
 		if p, _ := input["path"].(string); p != "" {
-			lang = tui.GuessLanguage(p)
+			opts.Language = tui.GuessLanguage(p)
 		}
-	}
-	if toolName == "write_file" {
+	case "write_file":
 		// write_file's own output is already a human-readable summary
 		// ("Wrote N bytes (M lines) to /path"); show that instead of a
 		// redundant content preview.
-		return tui.RenderOutputCard(verb, cardTargetFor(toolName, input), output, 0, isErr, "")
+		opts.MaxLines = 0
+	case "terminal":
+		// Command output: errors and summaries land at the bottom, so show the
+		// tail. A non-zero exit is reported as a trailing "[exit: …]" marker,
+		// not a tool error — lift it into the header (red bullet + meta) so a
+		// failed command never renders as a green card with the marker folded
+		// away.
+		opts.Tail = true
+		if body, exit := splitTerminalExit(output); exit != "" {
+			output = body
+			opts.IsErr = true
+			opts.Meta = joinMeta("exit "+exit, opts.Meta)
+		}
+	case "terminal_output", "kill_shell", "terminal_input":
+		opts.Tail = true
 	}
-	return tui.RenderOutputCard(verb, cardTargetFor(toolName, input), output, outputCardMaxLines, isErr, lang)
+	return tui.RenderOutputCard(verb, cardTargetFor(toolName, input), output, opts)
+}
+
+// splitTerminalExit detaches the trailing "[exit: …]" marker the terminal
+// tool appends on a non-zero exit (internal/tools/terminal.go). It returns
+// the output without the marker line plus the exit text ("1", "signal:
+// killed"), or (output, "") when no marker is present.
+func splitTerminalExit(output string) (body, exit string) {
+	trimmed := strings.TrimRight(output, "\n")
+	last := trimmed
+	if i := strings.LastIndexByte(trimmed, '\n'); i >= 0 {
+		last = trimmed[i+1:]
+	}
+	if !strings.HasPrefix(last, "[exit: ") || !strings.HasSuffix(last, "]") {
+		return output, ""
+	}
+	exit = strings.TrimSuffix(strings.TrimPrefix(last, "[exit: "), "]")
+	body = strings.TrimRight(trimmed[:len(trimmed)-len(last)], "\n")
+	return body, exit
+}
+
+// formatElapsed renders a tool call's duration for the card header: "" when
+// unknown (<=0, e.g. history replay), sub-second precision while short, whole
+// seconds once rounding noise stops mattering.
+func formatElapsed(d time.Duration) string {
+	switch {
+	case d <= 0:
+		return ""
+	case d < 10*time.Second:
+		return d.Round(100 * time.Millisecond).String()
+	default:
+		return d.Round(time.Second).String()
+	}
+}
+
+// joinMeta joins non-empty header annotations with " · ".
+func joinMeta(parts ...string) string {
+	kept := parts[:0]
+	for _, p := range parts {
+		if p != "" {
+			kept = append(kept, p)
+		}
+	}
+	return strings.Join(kept, " · ")
 }

--- a/cmd/octo/toolcards_test.go
+++ b/cmd/octo/toolcards_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCardVerbFor(t *testing.T) {
@@ -54,26 +55,100 @@ func TestRenderToolCard_Dispatch(t *testing.T) {
 	// edit_file success → diff card.
 	edit := renderToolCard("edit_file", map[string]any{
 		"path": "/tmp/nope.go", "old_string": "alpha", "new_string": "beta",
-	}, "", false)
+	}, "", false, 0, 0)
 	if !strings.Contains(edit, "Update(") || !strings.Contains(edit, "alpha") || !strings.Contains(edit, "beta") {
 		t.Errorf("edit_file should render a diff card; got:\n%s", edit)
 	}
 
 	// terminal → output card with the command + output.
-	run := renderToolCard("terminal", map[string]any{"command": "ls"}, "file_a\nfile_b", false)
+	run := renderToolCard("terminal", map[string]any{"command": "ls"}, "file_a\nfile_b", false, 0, 0)
 	if !strings.Contains(run, "Run(ls)") || !strings.Contains(run, "file_a") {
 		t.Errorf("terminal should render an output card; got:\n%s", run)
 	}
 
 	// terminal_output → snapshot card with status + tail.
-	out := renderToolCard("terminal_output", map[string]any{"id": "bg_1"}, "[status: running]\nstarting up", false)
+	out := renderToolCard("terminal_output", map[string]any{"id": "bg_1"}, "[status: running]\nstarting up", false, 0, 0)
 	if !strings.Contains(out, "starting up") {
 		t.Errorf("terminal_output should render an output card; got:\n%s", out)
 	}
 
 	// non-card tool → "".
-	if got := renderToolCard("sub_agent", map[string]any{}, "x", false); got != "" {
+	if got := renderToolCard("sub_agent", map[string]any{}, "x", false, 0, 0); got != "" {
 		t.Errorf("non-card tool should return \"\"; got %q", got)
+	}
+}
+
+func TestRenderToolCard_TerminalShowsTail(t *testing.T) {
+	// Command output is shown from the tail — the head is the least
+	// informative end (errors and summaries land at the bottom).
+	var lines []string
+	for i := 1; i <= 10; i++ {
+		lines = append(lines, strings.Repeat("x", 3)+"_line_"+string(rune('0'+i%10)))
+	}
+	got := renderToolCard("terminal", map[string]any{"command": "make test"}, strings.Join(lines, "\n"), false, 0, 0)
+	if strings.Contains(got, "xxx_line_1") {
+		t.Errorf("head line should be folded away in tail mode; got:\n%s", got)
+	}
+	if !strings.Contains(got, "xxx_line_0") { // the 10th (last) line
+		t.Errorf("last line should be visible in tail mode; got:\n%s", got)
+	}
+	if !strings.Contains(got, "… +6 lines") {
+		t.Errorf("fold marker missing; got:\n%s", got)
+	}
+	// Tail mode puts the marker ABOVE the body.
+	if strings.Index(got, "… +6 lines") > strings.Index(got, "xxx_line_0") {
+		t.Errorf("tail-mode marker should precede the body; got:\n%s", got)
+	}
+}
+
+func TestRenderToolCard_TerminalExitLiftedToHeader(t *testing.T) {
+	out := "compiling\nfailure detail\n[exit: 1]"
+	got := renderToolCard("terminal", map[string]any{"command": "make"}, out, false, 0, 1500*time.Millisecond)
+	if !strings.Contains(got, "exit 1") {
+		t.Errorf("exit code should surface in the header meta; got:\n%s", got)
+	}
+	if !strings.Contains(got, "1.5s") {
+		t.Errorf("elapsed should surface in the header meta; got:\n%s", got)
+	}
+	if strings.Contains(got, "[exit: 1]") {
+		t.Errorf("raw exit marker should be stripped from the body; got:\n%s", got)
+	}
+	if !strings.Contains(got, "failure detail") {
+		t.Errorf("body should keep the real output; got:\n%s", got)
+	}
+}
+
+func TestSplitTerminalExit(t *testing.T) {
+	cases := []struct{ in, wantBody, wantExit string }{
+		{"out\n[exit: 1]", "out", "1"},
+		{"out\n[exit: signal: killed]", "out", "signal: killed"},
+		{"[exit: 2]", "", "2"},
+		{"out\n[exit: 1]\ntrailing", "out\n[exit: 1]\ntrailing", ""}, // marker not last → untouched
+		{"plain output", "plain output", ""},
+		{"", "", ""},
+	}
+	for _, c := range cases {
+		body, exit := splitTerminalExit(c.in)
+		if body != c.wantBody || exit != c.wantExit {
+			t.Errorf("splitTerminalExit(%q) = (%q, %q), want (%q, %q)", c.in, body, exit, c.wantBody, c.wantExit)
+		}
+	}
+}
+
+func TestFormatElapsed(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, ""},
+		{-time.Second, ""},
+		{1234 * time.Millisecond, "1.2s"},
+		{94 * time.Second, "1m34s"},
+	}
+	for _, c := range cases {
+		if got := formatElapsed(c.in); got != c.want {
+			t.Errorf("formatElapsed(%v) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }
 

--- a/cmd/octo/toolcards_test.go
+++ b/cmd/octo/toolcards_test.go
@@ -142,6 +142,7 @@ func TestFormatElapsed(t *testing.T) {
 	}{
 		{0, ""},
 		{-time.Second, ""},
+		{30 * time.Millisecond, ""}, // would round to a meaningless "0s"
 		{1234 * time.Millisecond, "1.2s"},
 		{94 * time.Second, "1m34s"},
 	}

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1380,22 +1380,30 @@ func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
 		// Rich TUI: progress is deferred to the done card / status line so the
 		// transcript stays quiet; the live spinner already shows activity.
 		if m.cfg.plain {
-			m.commitToolLine("│ " + ev.Chunk)
+			m.commitToolLine("│ " + boundProgressChunk(ev.Chunk))
 		}
 		return
 
 	case agent.EventToolDone:
 		input := m.toolInput[ev.ToolID]
 		delete(m.toolInput, ev.ToolID)
+		elapsed := time.Duration(0)
+		if m.running != nil {
+			elapsed = time.Since(m.running.start)
+		}
 		m.running = nil // the finished card replaces the live indicator
-		m.commitToolLine(m.renderToolOutcome(ev.ToolName, input, ev.Output, false))
+		m.commitToolLine(m.renderToolOutcome(ev.ToolName, input, ev.Output, false, elapsed))
 		return
 
 	case agent.EventToolError:
 		input := m.toolInput[ev.ToolID]
 		delete(m.toolInput, ev.ToolID)
+		elapsed := time.Duration(0)
+		if m.running != nil {
+			elapsed = time.Since(m.running.start)
+		}
 		m.running = nil
-		m.commitToolLine(m.renderToolOutcome(ev.ToolName, input, firstNonEmpty(ev.Output, ev.Err), true))
+		m.commitToolLine(m.renderToolOutcome(ev.ToolName, input, firstNonEmpty(ev.Output, ev.Err), true, elapsed))
 		return
 
 	case agent.EventCompactStarted:
@@ -1479,12 +1487,13 @@ func (m *tuiModel) rendersCard(toolName string) bool {
 // renderToolOutcome produces the scrollback item for a finished tool call: a
 // rich card for card tools, a styled status line otherwise, or the dense
 // one-liner under --plain. resultText is the tool's output (or its error
-// message on failure). This is the single rendering path shared by the live
-// done/error events and resumed-history replay, so a resumed transcript looks
-// byte-for-byte like it did live.
-func (m *tuiModel) renderToolOutcome(toolName string, input map[string]any, resultText string, isErr bool) string {
+// message on failure); elapsed is the call's wall-clock duration (0 = unknown,
+// e.g. resumed-history replay, which doesn't record timings). This is the
+// single rendering path shared by the live done/error events and replay, so a
+// resumed transcript looks like it did live.
+func (m *tuiModel) renderToolOutcome(toolName string, input map[string]any, resultText string, isErr bool, elapsed time.Duration) string {
 	if m.rendersCard(toolName) {
-		return renderToolCard(toolName, input, resultText, isErr)
+		return renderToolCard(toolName, input, resultText, isErr, m.width, elapsed)
 	}
 	// show_artifact's whole point is "present this file to the user"; the web
 	// UI has the Artifacts panel, the TUI's equivalent is a click-to-open
@@ -1556,7 +1565,7 @@ func (m *tuiModel) replayHistoryLines() []string {
 					res := results[b.ID]
 					out = append(out, m.renderToolOutcome(
 						b.Name, b.Input,
-						agent.StripRemindersForDisplay(res.Result), res.IsError))
+						agent.StripRemindersForDisplay(res.Result), res.IsError, 0))
 				}
 			}
 		}

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -1122,7 +1122,7 @@ func TestTUI_RenderToolOutcome_ArtifactHyperlink(t *testing.T) {
 	}
 	input := map[string]any{"path": path}
 
-	got := m.renderToolOutcome("show_artifact", input, "Artifact presented: "+path+" (12 bytes)", false)
+	got := m.renderToolOutcome("show_artifact", input, "Artifact presented: "+path+" (12 bytes)", false, 0)
 	if !strings.Contains(got, "\x1b]8;;"+tui.FileURI(path)+"\x1b\\") {
 		t.Errorf("success line should carry an OSC 8 file:// hyperlink; got %q", got)
 	}
@@ -1132,16 +1132,16 @@ func TestTUI_RenderToolOutcome_ArtifactHyperlink(t *testing.T) {
 
 	// A relative path must NOT be linkified — re-resolving it at render time
 	// diverges from the execute-time cwd on resumed-history replay.
-	if got := m.renderToolOutcome("show_artifact", map[string]any{"path": "rel/report.html"}, "ok", false); strings.Contains(got, "\x1b]8;;") {
+	if got := m.renderToolOutcome("show_artifact", map[string]any{"path": "rel/report.html"}, "ok", false, 0); strings.Contains(got, "\x1b]8;;") {
 		t.Errorf("relative path should not render a hyperlink; got %q", got)
 	}
 
-	if got := m.renderToolOutcome("show_artifact", input, "boom", true); strings.Contains(got, "\x1b]8;;") {
+	if got := m.renderToolOutcome("show_artifact", input, "boom", true, 0); strings.Contains(got, "\x1b]8;;") {
 		t.Errorf("error outcome should not render a hyperlink; got %q", got)
 	}
 
 	m.cfg.plain = true
-	if got := m.renderToolOutcome("show_artifact", input, "ok", false); strings.Contains(got, "\x1b]8;;") {
+	if got := m.renderToolOutcome("show_artifact", input, "ok", false, 0); strings.Contains(got, "\x1b]8;;") {
 		t.Errorf("--plain outcome should not render a hyperlink; got %q", got)
 	}
 }

--- a/internal/tui/diffcard.go
+++ b/internal/tui/diffcard.go
@@ -42,6 +42,9 @@ type Card struct {
 	Removed  int
 	Lines    []Line
 	Language string
+	// Width, when >0, clips each row (header included) to the terminal width
+	// so a long source line can't soft-wrap the card into many screen rows.
+	Width int
 }
 
 // Render returns the card as an ANSI-coloured string. The trailing newline
@@ -50,12 +53,12 @@ func (c Card) Render() string {
 	var b strings.Builder
 
 	dark := IsDark() // probe once per card; threads to the row washes + Chroma style
-	b.WriteString(renderHeader(c.Verb, c.Path))
+	b.WriteString(renderHeader(c.Verb, c.Path, c.Width))
 	b.WriteString("\n")
 	b.WriteString(renderSummary(c.Added, c.Removed))
 	b.WriteString("\n")
 	for _, ln := range c.Lines {
-		b.WriteString(renderRow(ln, c.Language, dark))
+		b.WriteString(renderRow(ln, c.Language, dark, c.Width))
 		b.WriteString("\n")
 	}
 	return strings.TrimRight(b.String(), "\n")
@@ -75,7 +78,8 @@ const ellipsisKind = '…'
 // It reads filePath to compute the line number where newString lands; if
 // the read fails (file moved, perms, etc.) the card still renders, just
 // without line numbers. Language is inferred from the file extension.
-func RenderEditCard(filePath, oldString, newString string) string {
+// width > 0 clips each row to the terminal width.
+func RenderEditCard(filePath, oldString, newString string, width int) string {
 	added := nonEmptyLineCount(newString)
 	removed := nonEmptyLineCount(oldString)
 
@@ -97,6 +101,7 @@ func RenderEditCard(filePath, oldString, newString string) string {
 		Removed:  removed,
 		Lines:    lines,
 		Language: GuessLanguage(filePath),
+		Width:    width,
 	}
 	return c.Render()
 }
@@ -176,11 +181,8 @@ func chromaStyle(dark bool) string {
 	return "github"
 }
 
-func renderHeader(verb, path string) string {
-	return fmt.Sprintf("%s %s",
-		headerBullet,
-		headerVerb.Render(fmt.Sprintf("%s(%s)", verb, path)),
-	)
+func renderHeader(verb, path string, width int) string {
+	return fmt.Sprintf("%s %s", headerBullet, renderCardHeader(verb, path, "", width))
 }
 
 func renderSummary(added, removed int) string {
@@ -190,13 +192,20 @@ func renderSummary(added, removed int) string {
 	)
 }
 
-func renderRow(ln Line, language string, dark bool) string {
+// diffGutterWidth is the visible width of a diff row's prefix — leading
+// space, 4-cell line-number column, space, +/- mark, space — that the body
+// must share the terminal row with.
+const diffGutterWidth = 8
+
+func renderRow(ln Line, language string, dark bool, width int) string {
 	if ln.Kind == ellipsisKind {
 		return "  " + outMore.Render(ln.Text)
 	}
 	noCol := renderLineNo(ln)
 	mark := renderMark(ln.Kind)
-	body := expandTabs(ln.Text)
+	// Clip before highlighting — Chroma output is self-contained per token,
+	// so cutting afterwards could strand an open escape (see RenderOutputCard).
+	body := clipLine(expandTabs(ln.Text), width-diffGutterWidth)
 	if language != "" {
 		body = highlightLine(body, language, dark)
 	}

--- a/internal/tui/diffcard_test.go
+++ b/internal/tui/diffcard_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	rw "github.com/mattn/go-runewidth"
 )
 
 func TestCard_Render_Structure(t *testing.T) {
@@ -150,4 +152,17 @@ func equalSlices(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func TestRenderEditCard_ClampsRowWidth(t *testing.T) {
+	long := "x := " + strings.Repeat("longvalue+", 30)
+	out := RenderEditCard("/nonexistent/w.go", long, "y := 1", 50)
+	for _, line := range strings.Split(stripANSI(out), "\n") {
+		if w := rw.StringWidth(line); w > 50 {
+			t.Errorf("diff row exceeds width 50 (got %d): %q", w, line)
+		}
+	}
+	if !strings.Contains(stripANSI(out), "…") {
+		t.Errorf("clamped diff rows should end in an ellipsis; got:\n%s", out)
+	}
 }

--- a/internal/tui/diffcard_test.go
+++ b/internal/tui/diffcard_test.go
@@ -83,7 +83,7 @@ func TestRenderEditCard_NumbersFromFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out := RenderEditCard(path, "func Old() {}", "func New() {}")
+	out := RenderEditCard(path, "func Old() {}", "func New() {}", 0)
 	if !strings.Contains(out, "3") {
 		t.Errorf("expected line number 3 (location of the new function) in output:\n%s", out)
 	}
@@ -94,7 +94,7 @@ func TestRenderEditCard_NumbersFromFile(t *testing.T) {
 
 func TestRenderEditCard_FileMissing_StillRenders(t *testing.T) {
 	// File doesn't exist — card should still render (no line numbers).
-	out := RenderEditCard("/nonexistent/path/that/never/was.go", "alpha", "beta")
+	out := RenderEditCard("/nonexistent/path/that/never/was.go", "alpha", "beta", 0)
 	if !strings.Contains(out, "beta") {
 		t.Errorf("expected new_string in output even on missing file:\n%s", out)
 	}

--- a/internal/tui/outputcard.go
+++ b/internal/tui/outputcard.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	rw "github.com/mattn/go-runewidth"
+	"github.com/muesli/reflow/truncate"
 )
 
 var (
@@ -16,20 +18,44 @@ var (
 	outMore      = lipgloss.NewStyle().Foreground(ColMuted)
 )
 
+// OutputCardOpts controls how RenderOutputCard clips and annotates the body.
+type OutputCardOpts struct {
+	// MaxLines caps how many output lines the card shows (<=0 = no cap); the
+	// remainder collapses into an "… +N lines" marker.
+	MaxLines int
+	// Width, when >0, clips every rendered row (header included) to the
+	// terminal width so one long line can't soft-wrap into dozens of screen
+	// rows and defeat the MaxLines cap.
+	Width int
+	// Tail shows the LAST MaxLines instead of the first — the right end for
+	// command output, where errors and summaries land at the bottom. The
+	// "… +N lines" marker moves above the body.
+	Tail bool
+	// IsErr tints the bullet red.
+	IsErr bool
+	// Language, when non-empty, syntax-highlights each line with Chroma.
+	Language string
+	// Meta is a dim annotation appended to the header, e.g. "1.2s" or
+	// "exit 1 · 12s".
+	Meta string
+}
+
+// cardGutterWidth is the visible width of the "  │ " prefix each body row
+// carries; body lines are clipped to Width minus this.
+const cardGutterWidth = 4
+
 // RenderOutputCard renders a tool's textual output as a card: a header row
-// (● verb(target)) above the output, each line behind a "│" gutter, capped to
-// maxLines (<=0 = no cap) with an "… +N lines" marker for the remainder.
-// isErr tints the bullet red. Empty output renders "(no output)". The trailing
+// (● verb(target)) above the output, each line behind a "│" gutter, clipped
+// and capped per opts. Empty output renders "(no output)". The trailing
 // newline is omitted so callers control spacing (mirrors Card.Render).
-// When language is non-empty, each line is syntax-highlighted with Chroma.
-func RenderOutputCard(verb, target, output string, maxLines int, isErr bool, language string) string {
+func RenderOutputCard(verb, target, output string, opts OutputCardOpts) string {
 	bullet := outBullet
-	if isErr {
+	if opts.IsErr {
 		bullet = outBulletErr
 	}
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("%s %s", bullet, headerVerb.Render(fmt.Sprintf("%s(%s)", verb, target))))
+	b.WriteString(fmt.Sprintf("%s %s", bullet, renderCardHeader(verb, target, opts.Meta, opts.Width)))
 
 	all := splitLinesNoTrail(output)
 	// Blank lines waste preview slots without adding information; filter them
@@ -46,22 +72,63 @@ func RenderOutputCard(verb, target, output string, maxLines int, isErr bool, lan
 	}
 
 	shown, extra := lines, 0
-	if maxLines > 0 && len(lines) > maxLines {
-		shown, extra = lines[:maxLines], len(lines)-maxLines
+	if opts.MaxLines > 0 && len(lines) > opts.MaxLines {
+		extra = len(lines) - opts.MaxLines
+		if opts.Tail {
+			shown = lines[len(lines)-opts.MaxLines:]
+		} else {
+			shown = lines[:opts.MaxLines]
+		}
 	}
 
+	if extra > 0 && opts.Tail {
+		b.WriteString("\n  " + outMore.Render("… +"+pluralise(extra, "line")))
+	}
 	dark := IsDark()
 	for _, ln := range shown {
-		body := expandTabs(ln)
-		if language != "" {
-			body = highlightLine(body, language, dark)
+		// Clip the raw line before highlighting: Chroma output is
+		// self-contained (every token carries its own reset), whereas cutting
+		// an already-highlighted string mid-token would strand an open escape.
+		body := clipLine(expandTabs(ln), opts.Width-cardGutterWidth)
+		if opts.Language != "" {
+			body = highlightLine(body, opts.Language, dark)
 		}
 		b.WriteString("\n  " + outGutter.String() + " " + body)
 	}
-	if extra > 0 {
+	if extra > 0 && !opts.Tail {
 		b.WriteString("\n  " + outMore.Render("… +"+pluralise(extra, "line")))
 	}
 	return b.String()
+}
+
+// clipLine truncates s to at most limit terminal cells, ending in "…" when
+// truncation occurred. limit <= 0 (unknown width) leaves s untouched. Wide
+// (CJK) runes are measured by display width, not rune count.
+func clipLine(s string, limit int) string {
+	if limit <= 0 {
+		return s
+	}
+	return truncate.StringWithTail(s, uint(limit), "…")
+}
+
+// renderCardHeader renders "verb(target)" bold plus an optional dim "(meta)",
+// clipping target so the whole header fits in width (2 cells are reserved for
+// the caller's "● " bullet prefix).
+func renderCardHeader(verb, target, meta string, width int) string {
+	if width > 0 {
+		avail := width - 2 - rw.StringWidth(verb) - 2 // bullet+space, parens
+		if meta != "" {
+			avail -= rw.StringWidth(meta) + 3 // " (" + ")"
+		}
+		if avail > 3 {
+			target = clipLine(target, avail)
+		}
+	}
+	h := headerVerb.Render(fmt.Sprintf("%s(%s)", verb, target))
+	if meta != "" {
+		h += " " + outMore.Render("("+meta+")")
+	}
+	return h
 }
 
 // RenderToolStatus renders a tool call that has no body card as a single

--- a/internal/tui/outputcard.go
+++ b/internal/tui/outputcard.go
@@ -120,9 +120,12 @@ func renderCardHeader(verb, target, meta string, width int) string {
 		if meta != "" {
 			avail -= rw.StringWidth(meta) + 3 // " (" + ")"
 		}
-		if avail > 3 {
-			target = clipLine(target, avail)
+		// Floor at a few cells so a pathologically narrow terminal still gets
+		// a clipped target instead of an unclipped, overflowing one.
+		if avail < 3 {
+			avail = 3
 		}
+		target = clipLine(target, avail)
 	}
 	h := headerVerb.Render(fmt.Sprintf("%s(%s)", verb, target))
 	if meta != "" {

--- a/internal/tui/outputcard_test.go
+++ b/internal/tui/outputcard_test.go
@@ -1,12 +1,20 @@
 package tui
 
 import (
+	"regexp"
 	"strings"
 	"testing"
+
+	rw "github.com/mattn/go-runewidth"
 )
 
+// stripANSI removes CSI escape sequences so tests can measure visible width.
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+func stripANSI(s string) string { return ansiRE.ReplaceAllString(s, "") }
+
 func TestRenderOutputCard_HeaderAndBody(t *testing.T) {
-	got := RenderOutputCard("Run", "go test ./...", "ok  pkg/a  0.2s\nok  pkg/b  0.1s", 0, false, "")
+	got := RenderOutputCard("Run", "go test ./...", "ok  pkg/a  0.2s\nok  pkg/b  0.1s", OutputCardOpts{})
 	for _, want := range []string{"Run(go test ./...)", "ok  pkg/a  0.2s", "ok  pkg/b  0.1s"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing %q in:\n%s", want, got)
@@ -19,7 +27,7 @@ func TestRenderOutputCard_CapsWithMoreMarker(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		lines = append(lines, "line")
 	}
-	got := RenderOutputCard("Search", "foo", strings.Join(lines, "\n"), 5, false, "")
+	got := RenderOutputCard("Search", "foo", strings.Join(lines, "\n"), OutputCardOpts{MaxLines: 5})
 	if !strings.Contains(got, "… +15 lines") {
 		t.Errorf("expected '… +15 lines' marker; got:\n%s", got)
 	}
@@ -30,16 +38,62 @@ func TestRenderOutputCard_CapsWithMoreMarker(t *testing.T) {
 }
 
 func TestRenderOutputCard_EmptyOutput(t *testing.T) {
-	got := RenderOutputCard("Run", "true", "", 0, false, "")
+	got := RenderOutputCard("Run", "true", "", OutputCardOpts{})
 	if !strings.Contains(got, "(no output)") {
 		t.Errorf("expected '(no output)'; got:\n%s", got)
 	}
 }
 
 func TestRenderOutputCard_SingularMoreLine(t *testing.T) {
-	got := RenderOutputCard("Run", "x", "a\nb\nc", 2, false, "")
+	got := RenderOutputCard("Run", "x", "a\nb\nc", OutputCardOpts{MaxLines: 2})
 	if !strings.Contains(got, "… +1 line") || strings.Contains(got, "1 lines") {
 		t.Errorf("expected singular '… +1 line'; got:\n%s", got)
+	}
+}
+
+func TestRenderOutputCard_ClampsLineWidth(t *testing.T) {
+	long := strings.Repeat("x", 500)
+	cjk := strings.Repeat("宽", 200) // double-width runes
+	got := RenderOutputCard("Run", "cmd", long+"\n"+cjk, OutputCardOpts{Width: 40})
+	for _, line := range strings.Split(stripANSI(got), "\n") {
+		if w := rw.StringWidth(line); w > 40 {
+			t.Errorf("row exceeds width 40 (got %d): %q", w, line)
+		}
+	}
+	if !strings.Contains(got, "…") {
+		t.Errorf("clamped rows should end in an ellipsis; got:\n%s", got)
+	}
+}
+
+func TestRenderOutputCard_ClampsHeader(t *testing.T) {
+	target := strings.Repeat("a", 200)
+	got := RenderOutputCard("Run", target, "out", OutputCardOpts{Width: 40, Meta: "1.2s"})
+	header := strings.Split(stripANSI(got), "\n")[0]
+	if w := rw.StringWidth(header); w > 40 {
+		t.Errorf("header exceeds width 40 (got %d): %q", w, header)
+	}
+	if !strings.Contains(header, "(1.2s)") {
+		t.Errorf("meta should survive header clamping; got: %q", header)
+	}
+}
+
+func TestRenderOutputCard_TailMode(t *testing.T) {
+	got := RenderOutputCard("Run", "cmd", "first\nsecond\nthird\nfourth\nfifth", OutputCardOpts{MaxLines: 2, Tail: true})
+	if strings.Contains(got, "first") || !strings.Contains(got, "fifth") {
+		t.Errorf("tail mode should keep the last lines and fold the head; got:\n%s", got)
+	}
+	if !strings.Contains(got, "… +3 lines") {
+		t.Errorf("expected fold marker; got:\n%s", got)
+	}
+	if strings.Index(got, "… +3 lines") > strings.Index(got, "fourth") {
+		t.Errorf("tail-mode marker should precede the body; got:\n%s", got)
+	}
+}
+
+func TestRenderOutputCard_MetaInHeader(t *testing.T) {
+	got := RenderOutputCard("Run", "make", "ok", OutputCardOpts{Meta: "exit 1 · 12s"})
+	if !strings.Contains(got, "(exit 1 · 12s)") {
+		t.Errorf("meta annotation missing from header; got:\n%s", got)
 	}
 }
 
@@ -60,7 +114,7 @@ func TestRenderOutputCard_ExpandsTabs(t *testing.T) {
 	// bleed through. The renderer must expand every tab to spaces.
 	output := "     1\tpackage main\n     2\t\tfield int"
 	for _, lang := range []string{"", "go"} {
-		got := RenderOutputCard("Read", "main.go", output, 0, false, lang)
+		got := RenderOutputCard("Read", "main.go", output, OutputCardOpts{Language: lang})
 		if strings.ContainsRune(got, '\t') {
 			t.Errorf("lang=%q: rendered card still contains a raw tab:\n%q", lang, got)
 		}
@@ -69,7 +123,7 @@ func TestRenderOutputCard_ExpandsTabs(t *testing.T) {
 
 func TestRenderOutputCard_Highlight(t *testing.T) {
 	output := "package main\n\nfunc main() {}"
-	got := RenderOutputCard("Read", "main.go", output, 0, false, "go")
+	got := RenderOutputCard("Read", "main.go", output, OutputCardOpts{Language: "go"})
 	// Chroma highlighting should inject ANSI escape codes.
 	if !strings.Contains(got, "\x1b[") {
 		t.Errorf("expected ANSI escapes from Chroma highlighting; got:\n%s", got)


### PR DESCRIPTION
Fixes #1091.

## What changed

**`internal/tui/outputcard.go`** — `RenderOutputCard` now takes an `OutputCardOpts` struct:
- `Width` clips every row — header included — to the terminal width (CJK display-width aware via `reflow/truncate` + `go-runewidth`), so a single long line can no longer soft-wrap a "4-line" card into dozens of screen rows. Clipping happens on the raw line *before* Chroma highlighting, so no ANSI escape is ever cut mid-token.
- `Tail` shows the last `MaxLines` instead of the first, with the "… +N lines" marker moved above the body.
- `Meta` renders a dim annotation after the header, e.g. `(1.2s)` or `(exit 1 · 12s)`.

**`internal/tui/diffcard.go`** — `Card` gains `Width`; diff rows and the header clip to it (shared `clipLine`/`renderCardHeader` helpers).

**`cmd/octo/toolcards.go`**
- `terminal` / `terminal_output` / `kill_shell` / `terminal_input` render the output **tail** — errors and summaries land at the bottom (matches the Web UI's `uiTail` choice).
- `terminal` lifts a trailing `[exit: …]` marker into the header: red bullet + `exit N` meta, marker stripped from the body. A failed command no longer renders as a green card with its exit status folded away.
- Card headers show the call's elapsed time (live turns; replay passes 0 — history records no timing).

**`cmd/octo/repl.go` / `tuirepl.go`** — plain/headless progress lines bounded at 300 runes per line so one enormous streamed line can't flood the transcript (line *count* is intentionally left unbounded: the live feed is the plain path's feature, and terminal's own timeout + spill already bound totals).

## Sample render (width 60)

```
● Run(make test) (exit 1 · 12s)          ← red bullet
  … +2 lines
  │ step 3 ok
  │ step 4 ok
  │ compile error: very long detail very long detail very l…
  │ FAIL pkg/x 0.3s
```

## Testing

- `gofmt -l .` clean, `go vet ./...` clean, full `go test -race ./...` green.
- New tests: width clamping (ASCII + CJK), header clamping with meta, tail mode + marker position, exit-marker parsing table, elapsed formatting, terminal card integration (tail + exit lift).
- Manual render check of all four card shapes (tail+exit, CJK clamp, target clamp, head mode + highlight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)