### PR TITLE
fix(workflow): don't kill legitimate workflow_status checks; fix MCP stderr leak in one-shot

### DIFF
--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -776,35 +776,25 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "octo: mcp config: %v\n", err)
 		} else if len(mcpCfg.Servers) > 0 {
 			info := mcp.Implementation{Name: "octo", Version: version.Version}
+			// A stdio server's subprocess writes diagnostics to its stderr at
+			// arbitrary times, from an exec copy goroutine. Under the bubbletea
+			// TUI a direct terminal write corrupts the frame; in the headless
+			// one-shot it interleaves with the turn's own output (e.g. a
+			// file-watcher banner mid-turn). Route it to a log file in both
+			// modes (recoverable, never the screen). Connection warnings still
+			// reach the terminal via the warn writer. The file is closed when
+			// runChat returns.
+			var childStderr io.Writer
+			if f := openMCPLogFile(); f != nil {
+				childStderr = f
+				defer f.Close()
+			} else {
+				childStderr = io.Discard
+			}
 			if useTUI {
-				// A stdio server's subprocess writes diagnostics to its stderr at
-				// arbitrary times during the session, from an exec copy goroutine.
-				// Under the bubbletea TUI a direct terminal write corrupts the
-				// frame, so route it to a log file (recoverable, never the
-				// screen). The file is closed when runChat returns, i.e. after
-				// runTUI exits.
-				var childStderr io.Writer
-				if f := openMCPLogFile(); f != nil {
-					childStderr = f
-					defer f.Close()
-				} else {
-					childStderr = io.Discard
-				}
 				mcpBoot = &mcpBootstrap{cfg: mcpCfg, info: info, childErr: childStderr}
 			} else {
 				// Headless: connect now and register before the one-shot turn.
-				// A stdio server's subprocess writes diagnostics to its stderr at
-				// arbitrary times (e.g. a file-watcher banner mid-turn); routed to
-				// os.Stderr they interleave with the turn's own output, so send
-				// them to the MCP log file like the TUI does. Connection warnings
-				// still go to the terminal via the warn writer.
-				var childStderr io.Writer
-				if f := openMCPLogFile(); f != nil {
-					childStderr = f
-					defer f.Close()
-				} else {
-					childStderr = io.Discard
-				}
 				mcpReg := mcp.ConnectAll(
 					context.Background(),
 					mcpCfg,

--- a/cmd/octo/chat.go
+++ b/cmd/octo/chat.go
@@ -793,8 +793,18 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 				mcpBoot = &mcpBootstrap{cfg: mcpCfg, info: info, childErr: childStderr}
 			} else {
 				// Headless: connect now and register before the one-shot turn.
-				// Leave childStderr nil — the transport defaults to os.Stderr, the
-				// only writer safe for the copy goroutine to share concurrently.
+				// A stdio server's subprocess writes diagnostics to its stderr at
+				// arbitrary times (e.g. a file-watcher banner mid-turn); routed to
+				// os.Stderr they interleave with the turn's own output, so send
+				// them to the MCP log file like the TUI does. Connection warnings
+				// still go to the terminal via the warn writer.
+				var childStderr io.Writer
+				if f := openMCPLogFile(); f != nil {
+					childStderr = f
+					defer f.Close()
+				} else {
+					childStderr = io.Discard
+				}
 				mcpReg := mcp.ConnectAll(
 					context.Background(),
 					mcpCfg,
@@ -803,7 +813,7 @@ func runChat(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 						return newCLIOAuthPrompt(stdout, serverName)
 					},
 					stderr,
-					nil,
+					childStderr,
 				)
 				if mcpReg.Len() > 0 {
 					tools.SetMCPRegistry(mcpReg)

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -135,7 +135,9 @@ func runOnce(cfg replConfig, prompt string, stream bool) int {
 	defer tools.SetBackgroundOnExit(nil)
 
 	// Background workflows ride the same inbox path, so a finished detached run
-	// is drained on a later iteration (or by idleInboxWait while idle).
+	// is drained on a later iteration of the in-flight turn. Once the turn ends
+	// the one-shot exits (killing still-running workflows via the defer below) —
+	// there is no idle wait for background completions in this mode.
 	tools.SetDefaultWorkflowOnDone(func(ev tools.WorkflowNotification) {
 		a.Inbox.Enqueue(tools.FormatWorkflowNote(ev))
 	})

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -900,8 +900,8 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.printlnBlock(bgDoneStyle.Render(fmt.Sprintf("● Background `%s` %s", msg.e.Command, msg.e.Status)))
 		// Idle auto-turn: if no turn is running and nothing is queued, drain the
 		// inbox (which holds the full <system-reminder> notice) and start a
-		// turn so the model sees the completion immediately — matching the plain
-		// REPL's idleInboxWait behaviour.
+		// turn so the model sees the completion immediately instead of waiting
+		// for the next user message.
 		if !m.turnRunning && len(m.queue) == 0 {
 			if items := m.a.Inbox.Drain(); len(items) > 0 {
 				s := strings.Join(agent.Texts(items), "\n\n")

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -311,12 +311,13 @@ func fingerprintToolUseBlock(b ContentBlock) toolCallFingerprint {
 }
 
 // observationToolNames are tools whose only purpose is to inspect state
-// started by earlier work (background process output). Repeating them while
-// waiting for a long-running process is normal behaviour, not a stuck loop,
-// so the stuck detector ignores them when fingerprinting a batch. The tools
-// themselves still have their own anti-polling guards.
+// started by earlier work (background process output, detached workflow runs).
+// Repeating them while waiting for a long-running process is normal behaviour,
+// not a stuck loop, so the stuck detector ignores them when fingerprinting a
+// batch. The tools themselves still have their own anti-polling guards.
 var observationToolNames = map[string]bool{
 	"terminal_output": true,
+	"workflow_status": true,
 }
 
 // fingerprintToolUseBatch hashes an ordered slice of tool_use blocks.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -586,6 +586,35 @@ func TestAgent_Run_RepeatedTerminalOutput_DoesNotStop(t *testing.T) {
 	}
 }
 
+func TestAgent_Run_RepeatedWorkflowStatus_DoesNotStop(t *testing.T) {
+	// Checking on a detached background workflow with workflow_status is the
+	// same observation pattern as terminal_output: the run makes progress even
+	// though the tool input never changes, so the stuck detector must not fire.
+	// (The workflow_status tool enforces its own anti-polling guard.)
+	mk := func(id string) Reply {
+		return Reply{StopReason: "tool_use", Blocks: []ContentBlock{NewToolUseBlock(id, "workflow_status", map[string]any{"run_id": "wf_1"})}}
+	}
+	replies := []Reply{
+		mk("c1"), mk("c2"), mk("c3"), mk("c4"), mk("c5"), mk("c6"),
+		{Content: "done", StopReason: "end_turn"},
+	}
+	send := &fakeToolSender{replies: replies}
+	exec := &fakeExecutor{}
+	a := New(send, "m")
+	defs := []ToolDefinition{{Name: "workflow_status"}}
+
+	reply, err := a.Run(context.Background(), "go", defs, exec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reply.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", reply.StopReason)
+	}
+	if send.calls != 7 {
+		t.Errorf("provider calls = %d, want 7 (stuck detector should not stop early)", send.calls)
+	}
+}
+
 func TestAgent_Run_StuckDetector_ResetsPerUserTurn(t *testing.T) {
 	// A new user turn ("continue") must give the model a fresh stuck-detector
 	// window. Without the per-turn reset the prior turn's fingerprints linger,

--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -33,8 +33,9 @@ func (WorkflowTool) Definition() agent.ToolDefinition {
 			"Use when a task decomposes into many sub-agent calls with explicit control flow " +
 			"(fan-out, pipelines, loops, conditionals) that you want executed reliably rather " +
 			"than improvised across turns.\n\n" +
-			"Runs in the BACKGROUND: this call returns a run id immediately; collect the result " +
-			"later with the workflow_status tool. (A long multi-agent run won't block you or the " +
+			"Runs in the BACKGROUND: this call returns a run id immediately, and the system " +
+			"automatically notifies you with the result when the run finishes — do NOT poll " +
+			"workflow_status while it runs. (A long multi-agent run won't block you or the " +
 			"user while it executes.)\n\n" +
 			"The script runs in a sandboxed, IO-free mruby interpreter: only Array/Hash/String/" +
 			"Integer logic and JSON.parse/JSON.generate are available. There is NO File, Dir, " +
@@ -202,9 +203,13 @@ func (WorkflowTool) Execute(ctx context.Context, _ string, input map[string]any)
 		return agent.ToolResult{}, fmt.Errorf("workflow: %w", err)
 	}
 	return agent.ToolResult{Text: fmt.Sprintf(
-		"Workflow started in the background as %s. It runs while you continue; "+
-			"call workflow_status(%q) to check progress and collect the result "+
-			"(or workflow_status with no argument to list all runs).", runID, runID)}, nil
+		"Workflow started in the background as %s.\n"+
+			"<system-reminder>This run executes in the background. DO NOT poll workflow_status "+
+			"while it runs — the system will automatically notify you when it finishes, carrying "+
+			"the result. While it runs, you may continue with other independent tasks. If you have "+
+			"no other task to do, report the launch to the user and stop — do not spin in a "+
+			"polling loop. (workflow_status(%q) exists for on-demand progress checks, e.g. when "+
+			"the user asks.)</system-reminder>", runID, runID)}, nil
 }
 
 // encodeWorkflowArgs serializes the tool's `args` input to the JSON string the
@@ -230,7 +235,11 @@ func (WorkflowStatusTool) Definition() agent.ToolDefinition {
 		Name: "workflow_status",
 		Description: "Check background workflow runs started with the workflow tool. " +
 			"With no run_id: list this session's runs and their status (running/done/error). " +
-			"With a run_id: the full result (or error + how to fix/resume) plus the captured log.",
+			"With a run_id: the full result (or error + how to fix/resume) plus the captured log. " +
+			"Use this for ON-DEMAND checks (e.g. the user asks how a run is going) or to collect " +
+			"a result after the completion notification — do NOT call it in a polling loop; the " +
+			"system pushes a notification when a run finishes. Repeated still-running reads of " +
+			"the same run are detected as polling and trigger a hard STOP reminder.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -261,7 +270,18 @@ func (WorkflowStatusTool) Execute(ctx context.Context, _ string, input map[strin
 	if !ok {
 		return agent.ToolResult{}, fmt.Errorf("workflow_status: no run named %q in this session", runID)
 	}
-	return agent.ToolResult{Text: formatRunDetail(snap)}, nil
+	text := formatRunDetail(snap)
+	// Hard stop for models that keep polling a running workflow despite the
+	// "do not poll" instructions. The agent loop exempts workflow_status from
+	// its duplicate-tool-call detector (it is a legitimate observation tool),
+	// so this guard is what breaks a polling loop — mirroring terminal_output's
+	// empty-snapshot guard.
+	if mgr.RecordStatusRead(runID, snap.Status == "running") >= workflowPollStopThreshold {
+		text += "\n\n[STOP: repeated workflow_status polling detected. " +
+			"Do not poll this run again. The system will push a notification " +
+			"with the result when it finishes.]"
+	}
+	return agent.ToolResult{Text: text}, nil
 }
 
 // WorkflowKillTool cancels a running background workflow by id — for a run that

--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/workflow"
@@ -252,6 +253,15 @@ func (WorkflowStatusTool) Definition() agent.ToolDefinition {
 	}
 }
 
+// workflowPollStopText is the hard stop appended once a no-progress polling
+// streak crosses workflowPollStopThreshold. The agent loop exempts
+// workflow_status from its duplicate-tool-call detector (it is a legitimate
+// observation tool), so this guard is what breaks a polling loop — mirroring
+// terminal_output's empty-snapshot guard.
+const workflowPollStopText = "\n\n[STOP: repeated workflow_status polling detected. " +
+	"Do not poll again. The system will push a notification with the result " +
+	"when a run finishes.]"
+
 func (WorkflowStatusTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	mgr := resolveWorkflowManager(ctx)
 	runID := strings.TrimSpace(stringArg(input, "run_id"))
@@ -261,25 +271,32 @@ func (WorkflowStatusTool) Execute(ctx context.Context, _ string, input map[strin
 			return agent.ToolResult{Text: "No background workflows have been started in this session."}, nil
 		}
 		lines := make([]string, 0, len(runs))
+		var latest time.Time
+		anyRunning := false
 		for _, r := range runs {
 			lines = append(lines, statusLine(r))
+			if r.Status == "running" {
+				anyRunning = true
+				if r.LastActivity.After(latest) {
+					latest = r.LastActivity
+				}
+			}
 		}
-		return agent.ToolResult{Text: strings.Join(lines, "\n")}, nil
+		text := strings.Join(lines, "\n")
+		// The list form observes running work too; give it the same anti-poll
+		// escalation, keyed under "" off the freshest activity across running runs.
+		if mgr.RecordStatusRead("", anyRunning, latest) >= workflowPollStopThreshold {
+			text += workflowPollStopText
+		}
+		return agent.ToolResult{Text: text}, nil
 	}
 	snap, ok := mgr.Read(runID)
 	if !ok {
 		return agent.ToolResult{}, fmt.Errorf("workflow_status: no run named %q in this session", runID)
 	}
 	text := formatRunDetail(snap)
-	// Hard stop for models that keep polling a running workflow despite the
-	// "do not poll" instructions. The agent loop exempts workflow_status from
-	// its duplicate-tool-call detector (it is a legitimate observation tool),
-	// so this guard is what breaks a polling loop — mirroring terminal_output's
-	// empty-snapshot guard.
-	if mgr.RecordStatusRead(runID, snap.Status == "running") >= workflowPollStopThreshold {
-		text += "\n\n[STOP: repeated workflow_status polling detected. " +
-			"Do not poll this run again. The system will push a notification " +
-			"with the result when it finishes.]"
+	if mgr.RecordStatusRead(runID, snap.Status == "running", snap.LastActivity) >= workflowPollStopThreshold {
+		text += workflowPollStopText
 	}
 	return agent.ToolResult{Text: text}, nil
 }

--- a/internal/tools/workflow_manager.go
+++ b/internal/tools/workflow_manager.go
@@ -18,11 +18,11 @@ const maxConcurrentWorkflows = 4
 // maxWorkflowLogLines bounds the per-run log buffer retained for status reads.
 const maxWorkflowLogLines = 500
 
-// workflowPollStopThreshold is how many consecutive still-running
-// workflow_status reads of one run escalate to a hard "stop polling" reminder.
-// The first couple of checks are legitimate (a quick look after starting, a
-// user-prompted progress check); a third consecutive read of a run that hasn't
-// finished is a polling loop.
+// workflowPollStopThreshold is how many consecutive no-progress
+// workflow_status reads escalate to a hard "stop polling" reminder. A read
+// that observes fresh activity resets the count — spaced-out, user-prompted
+// progress checks are legitimate; a third consecutive read that saw nothing
+// new is a polling loop.
 const workflowPollStopThreshold = 3
 
 // WorkflowEvent is emitted as a background run progresses, for live display
@@ -163,9 +163,16 @@ type WorkflowManager struct {
 	seq     int
 	active  int
 	runs    map[string]*workflowRun
-	polls   map[string]int // consecutive workflow_status reads of a still-running run
+	polls   map[string]pollState // no-progress workflow_status read streaks, by run id
 	onEvent func(WorkflowEvent)
 	onDone  func(WorkflowNotification)
+}
+
+// pollState tracks one run's streak of workflow_status reads that observed no
+// new activity, for the anti-polling guard.
+type pollState struct {
+	count        int
+	lastActivity time.Time
 }
 
 // NewWorkflowManager returns an empty manager.
@@ -279,11 +286,14 @@ func (m *WorkflowManager) Start(req WorkflowRunRequest) (string, error) {
 	return id, nil
 }
 
-// RecordStatusRead tracks consecutive workflow_status reads of a still-running
-// run so the status tool can escalate to a hard "stop polling" reminder (the
-// workflow counterpart of terminal_output's empty-snapshot guard). Returns the
-// updated consecutive count. A read of a finished run resets its counter.
-func (m *WorkflowManager) RecordStatusRead(id string, running bool) int {
+// RecordStatusRead tracks workflow_status reads of a still-running run so the
+// status tool can escalate to a hard "stop polling" reminder — the workflow
+// counterpart of terminal_output's empty-snapshot guard. Only reads that
+// observe NO new activity since the previous read extend the streak; a read
+// that sees progress (lastActivity advanced) starts a fresh one, so spaced-out
+// user-prompted checks of a live run never escalate. Returns the streak count;
+// a read of a finished run resets its state.
+func (m *WorkflowManager) RecordStatusRead(id string, running bool, lastActivity time.Time) int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if !running {
@@ -291,10 +301,16 @@ func (m *WorkflowManager) RecordStatusRead(id string, running bool) int {
 		return 0
 	}
 	if m.polls == nil {
-		m.polls = map[string]int{}
+		m.polls = map[string]pollState{}
 	}
-	m.polls[id]++
-	return m.polls[id]
+	st := m.polls[id]
+	if lastActivity.After(st.lastActivity) {
+		st.count = 0
+		st.lastActivity = lastActivity
+	}
+	st.count++
+	m.polls[id] = st
+	return st.count
 }
 
 // Read returns a snapshot of one run.

--- a/internal/tools/workflow_manager.go
+++ b/internal/tools/workflow_manager.go
@@ -18,6 +18,13 @@ const maxConcurrentWorkflows = 4
 // maxWorkflowLogLines bounds the per-run log buffer retained for status reads.
 const maxWorkflowLogLines = 500
 
+// workflowPollStopThreshold is how many consecutive still-running
+// workflow_status reads of one run escalate to a hard "stop polling" reminder.
+// The first couple of checks are legitimate (a quick look after starting, a
+// user-prompted progress check); a third consecutive read of a run that hasn't
+// finished is a polling loop.
+const workflowPollStopThreshold = 3
+
 // WorkflowEvent is emitted as a background run progresses, for live display
 // (the web panel). Kind is "started" | "progress" | "done".
 type WorkflowEvent struct {
@@ -156,6 +163,7 @@ type WorkflowManager struct {
 	seq     int
 	active  int
 	runs    map[string]*workflowRun
+	polls   map[string]int // consecutive workflow_status reads of a still-running run
 	onEvent func(WorkflowEvent)
 	onDone  func(WorkflowNotification)
 }
@@ -202,7 +210,7 @@ func (m *WorkflowManager) Start(req WorkflowRunRequest) (string, error) {
 		n := m.active
 		m.mu.Unlock()
 		cancel()
-		return "", fmt.Errorf("too many background workflows running (%d/%d) — wait for one to finish (poll workflow_status) before starting more", n, maxConcurrentWorkflows)
+		return "", fmt.Errorf("too many background workflows running (%d/%d) — wait for a completion notification before starting more", n, maxConcurrentWorkflows)
 	}
 	m.active++
 	m.seq++
@@ -269,6 +277,24 @@ func (m *WorkflowManager) Start(req WorkflowRunRequest) (string, error) {
 	}()
 
 	return id, nil
+}
+
+// RecordStatusRead tracks consecutive workflow_status reads of a still-running
+// run so the status tool can escalate to a hard "stop polling" reminder (the
+// workflow counterpart of terminal_output's empty-snapshot guard). Returns the
+// updated consecutive count. A read of a finished run resets its counter.
+func (m *WorkflowManager) RecordStatusRead(id string, running bool) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !running {
+		delete(m.polls, id)
+		return 0
+	}
+	if m.polls == nil {
+		m.polls = map[string]int{}
+	}
+	m.polls[id]++
+	return m.polls[id]
 }
 
 // Read returns a snapshot of one run.
@@ -369,7 +395,7 @@ func formatRunDetail(s WorkflowRunSnapshot) string {
 		if idle > 2*time.Minute {
 			b.WriteString(" If the idle gap keeps growing it may be stuck — workflow_kill(run_id) cancels it.")
 		}
-		b.WriteString(" Poll again later to collect the result.")
+		b.WriteString(" You will be notified automatically when it finishes — do not poll.")
 		if n := len(s.Logs); n > 0 {
 			fmt.Fprintf(&b, "\n\n[progress]\n%s", strings.Join(s.Logs, "\n"))
 		}

--- a/internal/tools/workflow_test.go
+++ b/internal/tools/workflow_test.go
@@ -83,6 +83,11 @@ func TestWorkflowTool_StartsInBackground(t *testing.T) {
 	if !strings.Contains(res.Text, "background") || wfRunIDRe.FindString(res.Text) == "" {
 		t.Errorf("start result should name a background run id; got %q", res.Text)
 	}
+	// The behavioral steer the anti-poll design relies on: promise the
+	// completion notification and forbid polling.
+	if !strings.Contains(res.Text, "DO NOT poll") || !strings.Contains(res.Text, "automatically notify") {
+		t.Errorf("start result should forbid polling and promise the completion notification; got %q", res.Text)
+	}
 }
 
 // TestWorkflowTool_StatusCollectsResult drives the full async path: start, then
@@ -168,14 +173,53 @@ func TestWorkflowTool_Kill(t *testing.T) {
 	t.Fatal("killed workflow never left running")
 }
 
-// TestWorkflowStatus_AntiPollingGuard verifies that repeated status reads of a
-// still-running run escalate to a hard STOP reminder, and that a read of the
-// finished run carries no reminder (the counter resets).
-func TestWorkflowStatus_AntiPollingGuard(t *testing.T) {
+const wfStopMarker = "[STOP: repeated workflow_status polling detected"
+
+// TestWorkflowManager_RecordStatusRead pins the anti-poll streak semantics:
+// no-progress reads accumulate, a read that observes fresh activity restarts
+// the streak, a finished-run read clears it, and runs are counted independently.
+func TestWorkflowManager_RecordStatusRead(t *testing.T) {
+	m := NewWorkflowManager()
+	t0 := time.Now()
+
+	if got := m.RecordStatusRead("wf_1", true, t0); got != 1 {
+		t.Fatalf("first read = %d, want 1", got)
+	}
+	if got := m.RecordStatusRead("wf_1", true, t0); got != 2 {
+		t.Fatalf("no-progress read = %d, want 2", got)
+	}
+	// Another run's streak is independent.
+	if got := m.RecordStatusRead("wf_2", true, t0); got != 1 {
+		t.Fatalf("other run's first read = %d, want 1", got)
+	}
+	// Fresh activity restarts the streak — a spaced-out check of a live run
+	// must never escalate.
+	if got := m.RecordStatusRead("wf_1", true, t0.Add(time.Second)); got != 1 {
+		t.Fatalf("read after progress = %d, want 1", got)
+	}
+	if got := m.RecordStatusRead("wf_1", true, t0.Add(time.Second)); got != 2 {
+		t.Fatalf("no-progress read after reset = %d, want 2", got)
+	}
+	// A finished-run read clears the state.
+	if got := m.RecordStatusRead("wf_1", false, t0.Add(time.Second)); got != 0 {
+		t.Fatalf("finished read = %d, want 0", got)
+	}
+	if got := m.RecordStatusRead("wf_1", true, t0.Add(time.Second)); got != 1 {
+		t.Fatalf("read after finish-reset = %d, want 1", got)
+	}
+}
+
+// startBlockedRun starts a workflow whose single agent blocks until cancelled,
+// on an isolated manager, and waits for the launch progress line so
+// LastActivity is stable across subsequent status reads (a blocked agent emits
+// nothing further). Returns the ctx carrying the manager and the run id.
+func startBlockedRun(t *testing.T, mgr *WorkflowManager) (context.Context, string) {
+	t.Helper()
 	SetSpawner(ctxBlockingSpawner{})
 	t.Cleanup(func() { SetSpawner(nil) })
+	ctx := WithWorkflowManager(context.Background(), mgr)
 
-	res, err := WorkflowTool{}.Execute(context.Background(), "c", map[string]any{"script": `agent("x")`})
+	res, err := WorkflowTool{}.Execute(ctx, "c", map[string]any{"script": `agent("x")`})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -183,34 +227,50 @@ func TestWorkflowStatus_AntiPollingGuard(t *testing.T) {
 	if id == "" {
 		t.Fatalf("no run id in %q", res.Text)
 	}
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if snap, ok := mgr.Read(id); ok && len(snap.Logs) > 0 {
+			return ctx, id
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("workflow never logged its launch")
+	return ctx, id
+}
 
-	const stopMarker = "[STOP: repeated workflow_status polling detected"
+// TestWorkflowStatus_AntiPollingGuard verifies that repeated no-progress status
+// reads of a still-running run escalate to a hard STOP reminder, and that a
+// read of the finished run carries no reminder (the state resets).
+func TestWorkflowStatus_AntiPollingGuard(t *testing.T) {
+	mgr := NewWorkflowManager()
+	ctx, id := startBlockedRun(t, mgr)
+
 	for i := 1; i < workflowPollStopThreshold; i++ {
-		out, err := WorkflowStatusTool{}.Execute(context.Background(), "c", map[string]any{"run_id": id})
+		out, err := WorkflowStatusTool{}.Execute(ctx, "c", map[string]any{"run_id": id})
 		if err != nil {
 			t.Fatalf("workflow_status #%d: %v", i, err)
 		}
-		if strings.Contains(out.Text, stopMarker) {
+		if strings.Contains(out.Text, wfStopMarker) {
 			t.Fatalf("read #%d should not carry the STOP reminder yet: %q", i, out.Text)
 		}
 	}
-	out, err := WorkflowStatusTool{}.Execute(context.Background(), "c", map[string]any{"run_id": id})
+	out, err := WorkflowStatusTool{}.Execute(ctx, "c", map[string]any{"run_id": id})
 	if err != nil {
 		t.Fatalf("workflow_status at threshold: %v", err)
 	}
-	if !strings.Contains(out.Text, stopMarker) {
+	if !strings.Contains(out.Text, wfStopMarker) {
 		t.Errorf("read #%d should carry the STOP reminder; got %q", workflowPollStopThreshold, out.Text)
 	}
 
 	// Finish the run; a read of a completed run must not carry the reminder.
-	if _, err := (WorkflowKillTool{}).Execute(context.Background(), "c", map[string]any{"run_id": id}); err != nil {
+	if _, err := (WorkflowKillTool{}).Execute(ctx, "c", map[string]any{"run_id": id}); err != nil {
 		t.Fatalf("workflow_kill: %v", err)
 	}
 	deadline := time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) {
-		out, _ := WorkflowStatusTool{}.Execute(context.Background(), "c", map[string]any{"run_id": id})
+		out, _ := WorkflowStatusTool{}.Execute(ctx, "c", map[string]any{"run_id": id})
 		if !strings.Contains(out.Text, "[running]") {
-			if strings.Contains(out.Text, stopMarker) {
+			if strings.Contains(out.Text, wfStopMarker) {
 				t.Errorf("finished-run read should not carry the STOP reminder: %q", out.Text)
 			}
 			return
@@ -218,6 +278,32 @@ func TestWorkflowStatus_AntiPollingGuard(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatal("killed workflow never left running")
+}
+
+// TestWorkflowStatus_AntiPollingGuard_ListForm verifies the no-argument list
+// form escalates the same way — a model must not dodge the per-run guard by
+// polling the list instead.
+func TestWorkflowStatus_AntiPollingGuard_ListForm(t *testing.T) {
+	mgr := NewWorkflowManager()
+	ctx, id := startBlockedRun(t, mgr)
+	defer mgr.Kill(id)
+
+	for i := 1; i < workflowPollStopThreshold; i++ {
+		out, err := WorkflowStatusTool{}.Execute(ctx, "c", map[string]any{})
+		if err != nil {
+			t.Fatalf("workflow_status list #%d: %v", i, err)
+		}
+		if strings.Contains(out.Text, wfStopMarker) {
+			t.Fatalf("list read #%d should not carry the STOP reminder yet: %q", i, out.Text)
+		}
+	}
+	out, err := WorkflowStatusTool{}.Execute(ctx, "c", map[string]any{})
+	if err != nil {
+		t.Fatalf("workflow_status list at threshold: %v", err)
+	}
+	if !strings.Contains(out.Text, wfStopMarker) {
+		t.Errorf("list read #%d should carry the STOP reminder; got %q", workflowPollStopThreshold, out.Text)
+	}
 }
 
 // TestWorkflowKill_UnknownRun verifies the tool errors on an unknown id.

--- a/internal/tools/workflow_test.go
+++ b/internal/tools/workflow_test.go
@@ -168,6 +168,58 @@ func TestWorkflowTool_Kill(t *testing.T) {
 	t.Fatal("killed workflow never left running")
 }
 
+// TestWorkflowStatus_AntiPollingGuard verifies that repeated status reads of a
+// still-running run escalate to a hard STOP reminder, and that a read of the
+// finished run carries no reminder (the counter resets).
+func TestWorkflowStatus_AntiPollingGuard(t *testing.T) {
+	SetSpawner(ctxBlockingSpawner{})
+	t.Cleanup(func() { SetSpawner(nil) })
+
+	res, err := WorkflowTool{}.Execute(context.Background(), "c", map[string]any{"script": `agent("x")`})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	id := wfRunIDRe.FindString(res.Text)
+	if id == "" {
+		t.Fatalf("no run id in %q", res.Text)
+	}
+
+	const stopMarker = "[STOP: repeated workflow_status polling detected"
+	for i := 1; i < workflowPollStopThreshold; i++ {
+		out, err := WorkflowStatusTool{}.Execute(context.Background(), "c", map[string]any{"run_id": id})
+		if err != nil {
+			t.Fatalf("workflow_status #%d: %v", i, err)
+		}
+		if strings.Contains(out.Text, stopMarker) {
+			t.Fatalf("read #%d should not carry the STOP reminder yet: %q", i, out.Text)
+		}
+	}
+	out, err := WorkflowStatusTool{}.Execute(context.Background(), "c", map[string]any{"run_id": id})
+	if err != nil {
+		t.Fatalf("workflow_status at threshold: %v", err)
+	}
+	if !strings.Contains(out.Text, stopMarker) {
+		t.Errorf("read #%d should carry the STOP reminder; got %q", workflowPollStopThreshold, out.Text)
+	}
+
+	// Finish the run; a read of a completed run must not carry the reminder.
+	if _, err := (WorkflowKillTool{}).Execute(context.Background(), "c", map[string]any{"run_id": id}); err != nil {
+		t.Fatalf("workflow_kill: %v", err)
+	}
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		out, _ := WorkflowStatusTool{}.Execute(context.Background(), "c", map[string]any{"run_id": id})
+		if !strings.Contains(out.Text, "[running]") {
+			if strings.Contains(out.Text, stopMarker) {
+				t.Errorf("finished-run read should not carry the STOP reminder: %q", out.Text)
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("killed workflow never left running")
+}
+
 // TestWorkflowKill_UnknownRun verifies the tool errors on an unknown id.
 func TestWorkflowKill_UnknownRun(t *testing.T) {
 	SetSpawner(replySpawner{})

--- a/website/src/content/docs/reference/tools.md
+++ b/website/src/content/docs/reference/tools.md
@@ -56,7 +56,7 @@ first; there's no cap on how many background processes can run at once, and all 
 | `sub_agent` | spawn a sub-agent (sync or async) |
 | `sub_agent_send` / `sub_agent_status` / `sub_agent_kill` | follow up with, poll, or stop an async sub-agent |
 | `workflow` | run a deterministic multi-agent orchestration script |
-| `workflow_status` / `workflow_kill` | poll or stop a background workflow run |
+| `workflow_status` / `workflow_kill` | check on or stop a background workflow run (completion is pushed automatically — no polling) |
 | `workflow_save` | persist a script as a named, reusable workflow |
 | `task_create` / `task_update` / `task_list` | track discrete steps of a larger piece of work |
 | `schedule_wakeup` | ask to be resumed after a delay (used by `/loop`-style recurring work) |


### PR DESCRIPTION
## Problem

Starting a background workflow in a headless one-shot produced a guaranteed dead end (screenshot in the session that found this):

1. The `workflow` start result said "call workflow_status to check progress" — actively inviting polling, and never mentioning that a completion notification is already pushed through the inbox (`FormatWorkflowNote`, wired in all transports).
2. `workflow_status` was missing from the stuck detector's `observationToolNames` exemption, so 5 identical status checks of the same `run_id` killed the turn with "repeated tool calls without progress" — while the workflow was, in fact, progressing (the detector fingerprints inputs only).
3. Comments in `repl.go`/`tuirepl.go` referenced `idleInboxWait`, which no longer exists.

Separately, the headless one-shot path passed `childStderr = nil` to `mcp.ConnectAll`, so stdio MCP subprocess diagnostics (e.g. `[CodeGraph MCP] File watcher active…`) leaked straight into octo's terminal output.

## Fix

- Exempt `workflow_status` in `observationToolNames` (same class as `terminal_output`).
- Add an anti-poll guard on `workflow_status` itself, mirroring `terminal_output`'s empty-snapshot guard: ≥3 consecutive still-running reads of one run append a hard `[STOP: …]` reminder; reading a finished run resets the counter (`WorkflowManager.RecordStatusRead`).
- Rewrite the `workflow` start result + both tool descriptions + the running-status detail text to promise the automatic completion notification and forbid polling, AsyncModeNotice-style. Also fixed the two remaining "poll workflow_status" invitations in `workflow_manager.go`.
- Remove the stale `idleInboxWait` comments; the `repl.go` one now documents the real one-shot behavior (no idle wait; exit kills running workflows).
- Route headless one-shot MCP child stderr to `~/.octo/logs/mcp.log` (the TUI's existing sink) instead of `os.Stderr`.

Not addressed here (follow-up under discussion): in one-shot mode a background workflow still cannot deliver its result if the model ends the turn — the process exits and kills the run. Direction being evaluated: run `workflow` foreground-blocking in one-shot.

## Tests

- `TestAgent_Run_RepeatedWorkflowStatus_DoesNotStop` — stuck detector no longer fires on repeated status checks.
- `TestWorkflowStatus_AntiPollingGuard` — STOP reminder appears at the threshold, absent before it, and absent on finished-run reads.
- `go test -race ./...` green; `gofmt -l` clean; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
