### PR TITLE
fix(tui): permission prompt shows the full command / diff, keeps context visible

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -542,6 +542,14 @@ type modalState struct {
 	// free text inline inside the modal.
 	otherActive bool
 	otherInput  string
+	// detail caches the rendered permission body (detailWidth is the width it
+	// was rendered for; detailSet distinguishes "not rendered yet" from a
+	// legitimate width of 0). View() runs on every spinner tick while the
+	// prompt is open, and the edit_file detail reads the target file — the
+	// cache keeps that to once per width instead of ~8×/second.
+	detail      string
+	detailWidth int
+	detailSet   bool
 }
 
 func newTUIModel(cfg replConfig) *tuiModel {

--- a/cmd/octo/tuirepl_p5_test.go
+++ b/cmd/octo/tuirepl_p5_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	runewidth "github.com/mattn/go-runewidth"
 )
 
 func TestTUI_QueuePanelIsBordered(t *testing.T) {
@@ -97,5 +99,79 @@ func TestRenderPermissionDetail_GenericAndCaps(t *testing.T) {
 	block := renderPermissionDetail("terminal", map[string]any{"command": long}, 80)
 	if !strings.Contains(block, "… +4 more lines") {
 		t.Errorf("long command should fold with a marker; got:\n%s", block)
+	}
+}
+
+func TestRenderPermissionBlock_WrapsAtWidth(t *testing.T) {
+	// bubbletea's inline renderer truncates frame lines at terminal width with
+	// no marker — every character of a command being approved must land within
+	// the width or it silently vanishes.
+	cmd := "curl -s https://example.com/install.sh?" + strings.Repeat("k=v&", 100) + " | sh"
+	out := renderPermissionBlock(cmd, 40)
+	for _, line := range strings.Split(stripANSI(out), "\n") {
+		if w := runewidth.StringWidth(line); w > 40 {
+			t.Errorf("wrapped line exceeds width 40 (got %d): %q", w, line)
+		}
+	}
+	// Nothing may be lost: unwrapping (drop the "\n  " joints and the leading
+	// indent) must reproduce the command exactly.
+	if got := strings.ReplaceAll(out, "\n  ", ""); strings.TrimPrefix(got, "  ") != cmd {
+		t.Errorf("wrap lost content:\n%q", got)
+	}
+	// CJK: double-width runes measured by cell.
+	wide := renderPermissionBlock(strings.Repeat("宽", 60), 30)
+	for _, line := range strings.Split(stripANSI(wide), "\n") {
+		if w := runewidth.StringWidth(line); w > 30 {
+			t.Errorf("CJK wrapped line exceeds width 30 (got %d): %q", w, line)
+		}
+	}
+	// Width 0 (pre-WindowSizeMsg) passes through unwrapped.
+	if got := renderPermissionBlock("echo hi", 0); got != "  echo hi" {
+		t.Errorf("width 0 should not wrap, got %q", got)
+	}
+}
+
+func TestSanitizeForPrompt_NeutralizesControlBytes(t *testing.T) {
+	// \r must not survive — it would home the cursor and let the display
+	// overwrite the dangerous prefix of the command being approved.
+	got := sanitizeForPrompt("rm -rf ~ #\rgit status")
+	if strings.ContainsRune(got, '\r') {
+		t.Errorf("raw \\r survived: %q", got)
+	}
+	if !strings.Contains(got, "rm -rf ~") || !strings.Contains(got, "git status") {
+		t.Errorf("both halves must stay visible: %q", got)
+	}
+	// ESC renders in caret notation instead of starting an escape sequence.
+	got = sanitizeForPrompt("safe\x1b[2Kevil")
+	if strings.ContainsRune(got, 0x1b) {
+		t.Errorf("raw ESC survived: %q", got)
+	}
+	if !strings.Contains(got, "^[[2K") {
+		t.Errorf("ESC should render as ^[: %q", got)
+	}
+	// \r\n collapses to \n; tabs expand; DEL renders as ^?.
+	if got := sanitizeForPrompt("a\r\nb\tc\x7f"); got != "a\nb    c^?" {
+		t.Errorf("got %q", got)
+	}
+	// Clean text passes through untouched (same string, no realloc).
+	if got := sanitizeForPrompt("plain text"); got != "plain text" {
+		t.Errorf("clean text mangled: %q", got)
+	}
+}
+
+func TestTUI_QuestionModalKeepsBorder(t *testing.T) {
+	m := newTestModel()
+	m.openModal(askMsg{prompt: UserPrompt{
+		Kind: KindQuestion, Question: "Pick one", Options: []string{"a", "b"},
+	}, resp: make(chan UserResponse, 1)})
+	out := m.View()
+	if !strings.ContainsAny(out, "╭╮╰╯") {
+		t.Errorf("question modal should keep its bordered box; got:\n%s", out)
+	}
+}
+
+func TestRenderPermissionDetail_NilInput(t *testing.T) {
+	if got := renderPermissionDetail("terminal", nil, 0); !strings.Contains(got, "(no input)") {
+		t.Errorf("nil input should render the placeholder; got %q", got)
 	}
 }

--- a/cmd/octo/tuirepl_p5_test.go
+++ b/cmd/octo/tuirepl_p5_test.go
@@ -20,18 +20,82 @@ func TestTUI_QueuePanelIsBordered(t *testing.T) {
 	}
 }
 
-func TestTUI_PermissionModalIsBordered(t *testing.T) {
+func TestTUI_PermissionPromptShowsFullCommand(t *testing.T) {
 	m := newTestModel()
+	// A command long past the old 60-rune summary cap: every character must be
+	// visible — the user is authorizing it.
+	cmd := "git push --force origin main && rm -rf ./dist && echo " + strings.Repeat("x", 120)
 	m.modal = &modalState{prompt: UserPrompt{
 		Kind:      KindPermission,
 		ToolName:  "terminal",
-		ToolInput: map[string]any{"command": "rm -rf /"},
+		ToolInput: map[string]any{"command": cmd},
 	}}
 	out := m.View()
-	if !strings.ContainsAny(out, "╭╮╰╯") {
-		t.Errorf("permission modal should be a bordered box; got:\n%s", out)
-	}
 	if !strings.Contains(out, "permission") {
-		t.Errorf("modal should show its heading; got:\n%s", out)
+		t.Errorf("prompt should show its heading; got:\n%s", out)
+	}
+	if !strings.Contains(out, cmd) {
+		t.Errorf("prompt must show the full command, untruncated; got:\n%s", out)
+	}
+}
+
+func TestTUI_PermissionPromptKeepsContextVisible(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	// A single token survives glamour's markdown re-wrapping intact.
+	m.partial.WriteString("pushing RELEASETOKEN now")
+	m.modal = &modalState{prompt: UserPrompt{
+		Kind:      KindPermission,
+		ToolName:  "terminal",
+		ToolInput: map[string]any{"command": "git push"},
+	}}
+	out := m.View()
+	if !strings.Contains(out, "RELEASETOKEN") {
+		t.Errorf("streaming context should stay visible above the prompt; got:\n%s", out)
+	}
+	if !strings.Contains(out, "git push") {
+		t.Errorf("prompt body missing; got:\n%s", out)
+	}
+}
+
+func TestTUI_PermissionPromptEditFileShowsDiff(t *testing.T) {
+	m := newTestModel()
+	m.modal = &modalState{prompt: UserPrompt{
+		Kind:     KindPermission,
+		ToolName: "edit_file",
+		ToolInput: map[string]any{
+			"path": "/nonexistent/x.go", "old_string": "alpha_old", "new_string": "beta_new",
+		},
+	}}
+	out := m.View()
+	for _, want := range []string{"Update(", "alpha_old", "beta_new"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("edit_file prompt should render the diff card (missing %q); got:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderPermissionDetail_GenericAndCaps(t *testing.T) {
+	// Generic tools render sorted key: value lines with per-value caps.
+	got := renderPermissionDetail("mcp_thing", map[string]any{
+		"query": "orders",
+		"body":  "line1\nline2\nline3\nline4\nline5\nline6",
+	}, 80)
+	if !strings.Contains(got, "query: orders") {
+		t.Errorf("generic detail should list key: value; got:\n%s", got)
+	}
+	// Multi-line values show their head (4 lines) then fold.
+	if !strings.Contains(got, "line4") || strings.Contains(got, "line5") || !strings.Contains(got, "… +2 more lines") {
+		t.Errorf("multi-line values should show 4 head lines + fold marker; got:\n%s", got)
+	}
+	// Empty input.
+	if got := renderPermissionDetail("mcp_thing", map[string]any{}, 80); !strings.Contains(got, "(no input)") {
+		t.Errorf("empty input should say so; got:\n%s", got)
+	}
+	// Long commands fold beyond the line cap.
+	long := strings.TrimSuffix(strings.Repeat("echo hi\n", 14), "\n")
+	block := renderPermissionDetail("terminal", map[string]any{"command": long}, 80)
+	if !strings.Contains(block, "… +4 more lines") {
+		t.Errorf("long command should fold with a marker; got:\n%s", block)
 	}
 }

--- a/cmd/octo/tuirepl_p5_test.go
+++ b/cmd/octo/tuirepl_p5_test.go
@@ -175,3 +175,27 @@ func TestRenderPermissionDetail_NilInput(t *testing.T) {
 		t.Errorf("nil input should render the placeholder; got %q", got)
 	}
 }
+
+func TestRenderPermissionGeneric_SanitizesKeys(t *testing.T) {
+	// Keys come from the model's tool-call JSON too — the same injection
+	// surface as values.
+	got := renderPermissionDetail("mcp_thing", map[string]any{"a\x1b[2Kb": "v"}, 0)
+	if strings.ContainsRune(got, 0x1b) {
+		t.Errorf("raw ESC in an input KEY survived: %q", got)
+	}
+	if !strings.Contains(got, "^[[2K") {
+		t.Errorf("key should render in caret notation: %q", got)
+	}
+}
+
+func TestSanitizeForPrompt_C1Controls(t *testing.T) {
+	// Decoded C1 (U+009B = CSI) is interpreted by xterm-lineage emulators;
+	// it must not reach the terminal raw.
+	got := sanitizeForPrompt("a\u009bb")
+	if strings.ContainsRune(got, '\u009b') {
+		t.Errorf("decoded C1 survived: %q", got)
+	}
+	if got != "a�b" {
+		t.Errorf("C1 should become a visible placeholder, got %q", got)
+	}
+}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 	"unicode"
@@ -1195,9 +1196,6 @@ func (m *tuiModel) View() string {
 	if m.quit {
 		return ""
 	}
-	if m.modal != nil {
-		return m.modalView()
-	}
 
 	var b strings.Builder
 
@@ -1368,6 +1366,15 @@ func (m *tuiModel) View() string {
 		b.WriteByte('\n')
 	}
 
+	// An active Ask prompt (permission / question) takes the input box's place
+	// while everything above — streaming text, activity spinner, task list,
+	// panels — stays visible, so the user decides with the model's reasoning
+	// still on screen instead of a bare full-screen dialog.
+	if m.modal != nil {
+		b.WriteString(m.modalView())
+		return b.String()
+	}
+
 	// Slash-command completion menu, right above the input box (Claude Code style).
 	b.WriteString(m.completionView())
 
@@ -1520,17 +1527,32 @@ func abbreviateHome(path string) string {
 	return path
 }
 
+// permissionDetailMaxLines caps the command / input preview inside the
+// permission prompt. Most real commands fit; the fold marker makes a longer
+// one visible as "there is more you haven't seen" rather than silently hiding it.
+const permissionDetailMaxLines = 10
+
+// permissionValueCap bounds one input value's preview in the generic
+// key: value rendering. Generous — the point of the prompt is that the user
+// sees what they're approving.
+const permissionValueCap = 200
+
 func (m *tuiModel) modalView() string {
 	st := m.modal
 	var b strings.Builder
 
 	if st.prompt.Kind == KindPermission {
-		b.WriteString(modalStyle.Render("⚠ permission"))
+		// Unboxed on purpose: the body must show the full command / diff, and
+		// long unclipped lines inside a lipgloss border make the box wider
+		// than the terminal and garble it. A clipped body would be worse — a
+		// permission prompt that hides the tail of the command it's asking
+		// about. Natural wrapping keeps every character visible.
+		b.WriteString(modalStyle.Render("⚠ permission — " + st.prompt.ToolName))
 		b.WriteByte('\n')
-		b.WriteString(fmt.Sprintf("%s wants to run\n", st.prompt.ToolName))
-		b.WriteString(fmt.Sprintf("  %s\n", summariseInput(st.prompt.ToolInput)))
+		b.WriteString(renderPermissionDetail(st.prompt.ToolName, st.prompt.ToolInput, m.width))
+		b.WriteByte('\n')
 		b.WriteString(hintStyle.Render("[y]es · [a]lways this session · [n]o/Esc"))
-		return tui.Box(b.String())
+		return b.String()
 	}
 
 	header := st.prompt.Header
@@ -1566,6 +1588,94 @@ func (m *tuiModel) modalView() string {
 	}
 	b.WriteString(hintStyle.Render(hint))
 	return tui.Box(b.String())
+}
+
+// renderPermissionDetail renders what a permission prompt is actually asking
+// to do: the full command for terminal, the diff for edit_file, and a
+// key: value listing for everything else. Every path favours visibility over
+// tidiness — the user is authorizing this content, so nothing load-bearing
+// may be truncated to a one-line summary (the pre-#1092 behaviour capped the
+// whole thing at 60 runes).
+func renderPermissionDetail(toolName string, input map[string]any, width int) string {
+	switch toolName {
+	case "terminal":
+		if cmd, _ := input["command"].(string); strings.TrimSpace(cmd) != "" {
+			return renderPermissionBlock(cmd)
+		}
+	case "edit_file":
+		path, _ := input["path"].(string)
+		oldS, _ := input["old_string"].(string)
+		newS, _ := input["new_string"].(string)
+		if path != "" {
+			return tui.RenderEditCard(path, oldS, newS, width)
+		}
+	}
+	if len(input) == 0 {
+		return hintStyle.Render("  (no input)")
+	}
+	keys := make([]string, 0, len(input))
+	for k := range input {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	shown := keys
+	if len(shown) > permissionDetailMaxLines {
+		shown = shown[:permissionDetailMaxLines]
+	}
+	for i, k := range shown {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		v := fmt.Sprintf("%v", input[k])
+		lines := strings.Split(v, "\n")
+		if len(lines) == 1 {
+			b.WriteString("  " + k + ": " + truncateRunes(v, permissionValueCap))
+			continue
+		}
+		// Multi-line values (SQL, write_file content, MCP payloads) show their
+		// head — enough to judge what's being approved — then fold, so one
+		// value can't swallow the whole prompt. The rune cap bounds long lines.
+		const perValueLines = 4
+		vshown := lines
+		if len(lines) > perValueLines {
+			vshown = lines[:perValueLines]
+		}
+		b.WriteString("  " + k + ":")
+		for _, l := range vshown {
+			b.WriteString("\n    " + truncateRunes(l, permissionValueCap))
+		}
+		if extra := len(lines) - len(vshown); extra > 0 {
+			b.WriteString("\n    " + hintStyle.Render(fmt.Sprintf("… +%d more lines", extra)))
+		}
+	}
+	if extra := len(keys) - len(shown); extra > 0 {
+		b.WriteString("\n  " + hintStyle.Render(fmt.Sprintf("… +%d more", extra)))
+	}
+	return b.String()
+}
+
+// renderPermissionBlock renders a multi-line text body (a shell command)
+// indented, capped at permissionDetailMaxLines with a fold marker. Lines are
+// NOT width-clipped: a permission prompt hiding the tail of a long command
+// would be approving blind; letting the terminal wrap keeps it all visible.
+func renderPermissionBlock(text string) string {
+	lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	shown, extra := lines, 0
+	if len(lines) > permissionDetailMaxLines {
+		shown, extra = lines[:permissionDetailMaxLines], len(lines)-permissionDetailMaxLines
+	}
+	var b strings.Builder
+	for i, l := range shown {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString("  " + l)
+	}
+	if extra > 0 {
+		b.WriteString("\n  " + hintStyle.Render(fmt.Sprintf("… +%d more lines", extra)))
+	}
+	return b.String()
 }
 
 // cacheLine formats the per-turn cache footer, or "" when nothing to show.

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1621,8 +1621,12 @@ func renderPermissionDetail(toolName string, input map[string]any, width int) st
 		newS, _ := input["new_string"].(string)
 		if path != "" {
 			// Tabs stay intact: the card expands them itself, and new_string
-			// must match the file bytes for the card's line-number lookup.
-			return tui.RenderEditCard(path, sanitizeControls(oldS, false), sanitizeControls(newS, false), width)
+			// must match the file bytes for the card's line-number lookup
+			// (the card normalizes CRLF on its side, matching the \r drop here).
+			// The path is sanitized too — it renders in the card header, the
+			// same display surface as the rest of the prompt.
+			return tui.RenderEditCard(sanitizeControls(path, false),
+				sanitizeControls(oldS, false), sanitizeControls(newS, false), width)
 		}
 	}
 	return renderPermissionGeneric(input, width)
@@ -1662,9 +1666,12 @@ func renderPermissionGeneric(input map[string]any, width int) string {
 			b.WriteByte('\n')
 		}
 		v := sanitizeForPrompt(fmt.Sprintf("%v", input[k]))
+		// Keys come from the model's tool-call JSON too — the same injection
+		// surface as values.
+		key := sanitizeForPrompt(k)
 		lines := strings.Split(v, "\n")
 		if len(lines) == 1 {
-			b.WriteString(wrapIndented(k+": "+truncateRunes(v, permissionValueCap), "  ", width))
+			b.WriteString(wrapIndented(key+": "+truncateRunes(v, permissionValueCap), "  ", width))
 			continue
 		}
 		const perValueLines = 4
@@ -1672,7 +1679,7 @@ func renderPermissionGeneric(input map[string]any, width int) string {
 		if len(lines) > perValueLines {
 			vshown = lines[:perValueLines]
 		}
-		b.WriteString("  " + k + ":")
+		b.WriteString(wrapIndented(key+":", "  ", width))
 		for _, l := range vshown {
 			b.WriteString("\n" + wrapIndented(truncateRunes(l, permissionValueCap), "    ", width))
 		}
@@ -1725,7 +1732,10 @@ func sanitizeForPrompt(s string) string { return sanitizeControls(s, true) }
 // intact for consumers that expand them themselves and need byte-exact text
 // (the edit_file diff card's line-number lookup).
 func sanitizeControls(s string, expandTab bool) string {
-	if !strings.ContainsFunc(s, func(r rune) bool { return (r < 0x20 && r != '\n' && r != '\t') || r == 0x7f }) {
+	hazard := func(r rune) bool {
+		return (r < 0x20 && r != '\n' && r != '\t') || r == 0x7f || (r >= 0x80 && r <= 0x9f)
+	}
+	if !strings.ContainsFunc(s, hazard) {
 		if !expandTab || !strings.ContainsRune(s, '\t') {
 			return s
 		}
@@ -1750,6 +1760,11 @@ func sanitizeControls(s string, expandTab bool) string {
 			b.WriteByte(byte(r) ^ 0x40)
 		case r == 0x7f:
 			b.WriteString("^?")
+		case r >= 0x80 && r <= 0x9f:
+			// Decoded C1 controls (e.g. U+009B = CSI): inert on most modern
+			// emulators but xterm-lineage ones interpret them. Replace with a
+			// visible placeholder.
+			b.WriteRune('�')
 		default:
 			b.WriteRune(r)
 		}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1543,13 +1543,23 @@ func (m *tuiModel) modalView() string {
 
 	if st.prompt.Kind == KindPermission {
 		// Unboxed on purpose: the body must show the full command / diff, and
-		// long unclipped lines inside a lipgloss border make the box wider
-		// than the terminal and garble it. A clipped body would be worse — a
-		// permission prompt that hides the tail of the command it's asking
-		// about. Natural wrapping keeps every character visible.
+		// long lines inside a lipgloss border make the box wider than the
+		// terminal and garble it. Lines are hard-wrapped to the width here —
+		// bubbletea's inline renderer truncates every frame line at terminal
+		// width with NO marker, so anything past the width would silently
+		// vanish from an approval prompt.
+		//
+		// The rendered detail is cached on the modal: View() runs on every
+		// ~120ms spinner tick while the prompt is open, and the edit_file
+		// path reads the target file each time it renders.
+		if !st.detailSet || st.detailWidth != m.width {
+			st.detail = renderPermissionDetail(st.prompt.ToolName, st.prompt.ToolInput, m.width)
+			st.detailWidth = m.width
+			st.detailSet = true
+		}
 		b.WriteString(modalStyle.Render("⚠ permission — " + st.prompt.ToolName))
 		b.WriteByte('\n')
-		b.WriteString(renderPermissionDetail(st.prompt.ToolName, st.prompt.ToolInput, m.width))
+		b.WriteString(st.detail)
 		b.WriteByte('\n')
 		b.WriteString(hintStyle.Render("[y]es · [a]lways this session · [n]o/Esc"))
 		return b.String()
@@ -1590,6 +1600,9 @@ func (m *tuiModel) modalView() string {
 	return tui.Box(b.String())
 }
 
+// permissionMaxKeys caps how many input keys the generic listing shows.
+const permissionMaxKeys = 10
+
 // renderPermissionDetail renders what a permission prompt is actually asking
 // to do: the full command for terminal, the diff for edit_file, and a
 // key: value listing for everything else. Every path favours visibility over
@@ -1600,16 +1613,37 @@ func renderPermissionDetail(toolName string, input map[string]any, width int) st
 	switch toolName {
 	case "terminal":
 		if cmd, _ := input["command"].(string); strings.TrimSpace(cmd) != "" {
-			return renderPermissionBlock(cmd)
+			return renderPermissionBlock(cmd, width)
 		}
 	case "edit_file":
 		path, _ := input["path"].(string)
 		oldS, _ := input["old_string"].(string)
 		newS, _ := input["new_string"].(string)
 		if path != "" {
-			return tui.RenderEditCard(path, oldS, newS, width)
+			// Tabs stay intact: the card expands them itself, and new_string
+			// must match the file bytes for the card's line-number lookup.
+			return tui.RenderEditCard(path, sanitizeControls(oldS, false), sanitizeControls(newS, false), width)
 		}
 	}
+	return renderPermissionGeneric(input, width)
+}
+
+// plainPermissionDetail is renderPermissionDetail for the plain/stdin prompt:
+// same visibility guarantees, but edit_file falls back to the generic listing
+// (the ANSI diff card is TUI-only) and width 0 skips wrapping — the plain
+// path writes to a real terminal, which wraps naturally.
+func plainPermissionDetail(toolName string, input map[string]any) string {
+	if cmd, _ := input["command"].(string); toolName == "terminal" && strings.TrimSpace(cmd) != "" {
+		return renderPermissionBlock(cmd, 0)
+	}
+	return renderPermissionGeneric(input, 0)
+}
+
+// renderPermissionGeneric lists a tool's input as sorted "key: value" lines.
+// Multi-line values (SQL, write_file content, MCP payloads) show their first
+// few lines — enough to judge what's being approved — then fold, so one value
+// can't swallow the whole prompt; the rune cap bounds a single long line.
+func renderPermissionGeneric(input map[string]any, width int) string {
 	if len(input) == 0 {
 		return hintStyle.Render("  (no input)")
 	}
@@ -1620,22 +1654,19 @@ func renderPermissionDetail(toolName string, input map[string]any, width int) st
 	sort.Strings(keys)
 	var b strings.Builder
 	shown := keys
-	if len(shown) > permissionDetailMaxLines {
-		shown = shown[:permissionDetailMaxLines]
+	if len(shown) > permissionMaxKeys {
+		shown = shown[:permissionMaxKeys]
 	}
 	for i, k := range shown {
 		if i > 0 {
 			b.WriteByte('\n')
 		}
-		v := fmt.Sprintf("%v", input[k])
+		v := sanitizeForPrompt(fmt.Sprintf("%v", input[k]))
 		lines := strings.Split(v, "\n")
 		if len(lines) == 1 {
-			b.WriteString("  " + k + ": " + truncateRunes(v, permissionValueCap))
+			b.WriteString(wrapIndented(k+": "+truncateRunes(v, permissionValueCap), "  ", width))
 			continue
 		}
-		// Multi-line values (SQL, write_file content, MCP payloads) show their
-		// head — enough to judge what's being approved — then fold, so one
-		// value can't swallow the whole prompt. The rune cap bounds long lines.
 		const perValueLines = 4
 		vshown := lines
 		if len(lines) > perValueLines {
@@ -1643,7 +1674,7 @@ func renderPermissionDetail(toolName string, input map[string]any, width int) st
 		}
 		b.WriteString("  " + k + ":")
 		for _, l := range vshown {
-			b.WriteString("\n    " + truncateRunes(l, permissionValueCap))
+			b.WriteString("\n" + wrapIndented(truncateRunes(l, permissionValueCap), "    ", width))
 		}
 		if extra := len(lines) - len(vshown); extra > 0 {
 			b.WriteString("\n    " + hintStyle.Render(fmt.Sprintf("… +%d more lines", extra)))
@@ -1657,10 +1688,13 @@ func renderPermissionDetail(toolName string, input map[string]any, width int) st
 
 // renderPermissionBlock renders a multi-line text body (a shell command)
 // indented, capped at permissionDetailMaxLines with a fold marker. Lines are
-// NOT width-clipped: a permission prompt hiding the tail of a long command
-// would be approving blind; letting the terminal wrap keeps it all visible.
-func renderPermissionBlock(text string) string {
-	lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+// hard-wrapped to width rather than clipped: bubbletea's inline renderer
+// truncates frame lines at terminal width with no marker, and a permission
+// prompt hiding the tail of a long command would be approving blind. The line
+// cap applies to logical lines only — a single long wrapped line stays fully
+// visible.
+func renderPermissionBlock(text string, width int) string {
+	lines := strings.Split(strings.TrimRight(sanitizeForPrompt(text), "\n"), "\n")
 	shown, extra := lines, 0
 	if len(lines) > permissionDetailMaxLines {
 		shown, extra = lines[:permissionDetailMaxLines], len(lines)-permissionDetailMaxLines
@@ -1670,10 +1704,90 @@ func renderPermissionBlock(text string) string {
 		if i > 0 {
 			b.WriteByte('\n')
 		}
-		b.WriteString("  " + l)
+		b.WriteString(wrapIndented(l, "  ", width))
 	}
 	if extra > 0 {
 		b.WriteString("\n  " + hintStyle.Render(fmt.Sprintf("… +%d more lines", extra)))
+	}
+	return b.String()
+}
+
+// sanitizeForPrompt neutralizes control characters in model-supplied text
+// before it is shown in an approval prompt, so what the user reads is what
+// executes: a raw \r would reposition the cursor and let a command overwrite
+// its own dangerous prefix on screen; a raw ESC could inject cursor-movement
+// or erase sequences. Newlines survive, tabs expand (RuneWidth counts \t as 0,
+// which would break the wrap math), \r is dropped, and every other C0/DEL
+// byte renders in caret notation (ESC → ^[).
+func sanitizeForPrompt(s string) string { return sanitizeControls(s, true) }
+
+// sanitizeControls is sanitizeForPrompt's core; expandTab=false keeps tabs
+// intact for consumers that expand them themselves and need byte-exact text
+// (the edit_file diff card's line-number lookup).
+func sanitizeControls(s string, expandTab bool) string {
+	if !strings.ContainsFunc(s, func(r rune) bool { return (r < 0x20 && r != '\n' && r != '\t') || r == 0x7f }) {
+		if !expandTab || !strings.ContainsRune(s, '\t') {
+			return s
+		}
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == '\n':
+			b.WriteRune(r)
+		case r == '\t':
+			if expandTab {
+				b.WriteString("    ")
+			} else {
+				b.WriteRune(r)
+			}
+		case r == '\r':
+			// Dropped: mid-line it would home the cursor; as part of \r\n it
+			// is redundant with the surviving \n.
+		case r < 0x20:
+			b.WriteByte('^')
+			b.WriteByte(byte(r) ^ 0x40)
+		case r == 0x7f:
+			b.WriteString("^?")
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// wrapIndented prefixes line with indent and hard-wraps it to width display
+// cells, indenting continuation rows the same amount. width <= 0 (unknown)
+// emits a single indented line. Wrapping is by display width (CJK = 2 cells),
+// character-exact — an approval prompt must show every character, and
+// bubbletea would otherwise truncate the overflow invisibly.
+func wrapIndented(line, indent string, width int) string {
+	avail := width - rw.StringWidth(indent)
+	if width <= 0 || avail < 1 || rw.StringWidth(line) <= avail {
+		return indent + line
+	}
+	var b strings.Builder
+	var cur strings.Builder
+	w := 0
+	flush := func() {
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(indent + cur.String())
+		cur.Reset()
+		w = 0
+	}
+	for _, r := range line {
+		rw_ := rw.RuneWidth(r)
+		if w+rw_ > avail && cur.Len() > 0 {
+			flush()
+		}
+		cur.WriteRune(r)
+		w += rw_
+	}
+	if cur.Len() > 0 {
+		flush()
 	}
 	return b.String()
 }

--- a/cmd/octo/turncore.go
+++ b/cmd/octo/turncore.go
@@ -175,7 +175,7 @@ func (v *plainView) Ask(_ context.Context, p UserPrompt) (UserResponse, error) {
 // anything else (incl. empty / N / no reader) → deny.
 func (v *plainView) askPermission(p UserPrompt) UserResponse {
 	fmt.Fprintf(v.out, "\n⚠ permission: %s wants to run\n", p.ToolName)
-	fmt.Fprintf(v.out, "    %s\n", summariseInput(p.ToolInput))
+	fmt.Fprintf(v.out, "%s\n", plainPermissionDetail(p.ToolName, p.ToolInput))
 
 	answer := ""
 	if v.reader != nil {

--- a/cmd/octo/turncore_permission_test.go
+++ b/cmd/octo/turncore_permission_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestPlainAskPermission_ShowsFullCommand(t *testing.T) {
+	var out bytes.Buffer
+	v := newPlainView(nil, &out, &out, verbosityNormal, true)
+	cmd := "git push --force origin main && echo " + strings.Repeat("y", 150)
+	resp, err := v.Ask(context.Background(), UserPrompt{
+		Kind:      KindPermission,
+		ToolName:  "terminal",
+		ToolInput: map[string]any{"command": cmd},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Allow {
+		t.Error("nil reader must deny")
+	}
+	if !strings.Contains(out.String(), cmd) {
+		t.Errorf("plain prompt must show the full command; got:\n%s", out.String())
+	}
+}

--- a/internal/tui/diffcard.go
+++ b/internal/tui/diffcard.go
@@ -85,7 +85,11 @@ func RenderEditCard(filePath, oldString, newString string, width int) string {
 
 	startLine := 0
 	if data, err := os.ReadFile(filePath); err == nil {
-		if idx := bytes.Index(data, []byte(newString)); idx >= 0 {
+		// Normalize CRLF so a \n-only needle (callers may strip \r for
+		// display safety) still locates its line in a CRLF file.
+		data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+		needle := []byte(strings.ReplaceAll(newString, "\r\n", "\n"))
+		if idx := bytes.Index(data, needle); idx >= 0 {
 			startLine = 1 + bytes.Count(data[:idx], []byte("\n"))
 		}
 	}

--- a/internal/tui/diffcard_test.go
+++ b/internal/tui/diffcard_test.go
@@ -172,12 +172,17 @@ func TestRenderEditCard_CRLFFileStillNumbersLines(t *testing.T) {
 	// normalizes CRLF on its side so the line-number lookup still lands.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "w.go")
-	content := "package main\r\nfunc A() {}\r\nfunc B() {}\r\n"
+	content := "package main\r\nfunc A() {}\r\nfunc B() {}\r\nfunc C() {}\r\n"
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	out := RenderEditCard(path, "func OLD() {}", "func B() {}", 0)
-	if !strings.Contains(stripANSI(out), "3") {
-		t.Errorf("CRLF file should still get line numbers; got:\n%s", out)
+	// The needle must span a line break: an LF-only multi-line needle can
+	// only match a CRLF file via the normalization; a single-line needle
+	// would match with or without it.
+	out := RenderEditCard(path, "func OLD() {}", "func B() {}\nfunc C() {}", 0)
+	// Assert the number in its row, not a bare "3" — the temp-dir path in the
+	// header contains random digits that a bare Contains could match.
+	if !strings.Contains(stripANSI(out), "3 + func B() {}") {
+		t.Errorf("CRLF file should still get line numbers; got:\n%s", stripANSI(out))
 	}
 }

--- a/internal/tui/diffcard_test.go
+++ b/internal/tui/diffcard_test.go
@@ -166,3 +166,18 @@ func TestRenderEditCard_ClampsRowWidth(t *testing.T) {
 		t.Errorf("clamped diff rows should end in an ellipsis; got:\n%s", out)
 	}
 }
+
+func TestRenderEditCard_CRLFFileStillNumbersLines(t *testing.T) {
+	// Callers may strip \r from new_string for display safety; the card
+	// normalizes CRLF on its side so the line-number lookup still lands.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "w.go")
+	content := "package main\r\nfunc A() {}\r\nfunc B() {}\r\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := RenderEditCard(path, "func OLD() {}", "func B() {}", 0)
+	if !strings.Contains(stripANSI(out), "3") {
+		t.Errorf("CRLF file should still get line numbers; got:\n%s", out)
+	}
+}


### PR DESCRIPTION
Fixes #1092.

## What changed

**Prompt content** (`cmd/octo/tuirepl_view.go` — `renderPermissionDetail`):
- `terminal`: full command, multi-line, capped at 10 lines with an "… +N more lines" fold marker. Deliberately **not** width-clipped — the user is authorizing this text, so the tail must not be hidden; the terminal wraps long lines instead.
- `edit_file`: renders the real diff card (`tui.RenderEditCard`) so the user approves what they can see.
- Everything else (incl. MCP tools): sorted `key: value` lines; multi-line values (SQL, file content) show their first 4 lines then fold; 200-rune per-line cap. Previously the whole input was `summariseInput`'d to 60 runes.

**Prompt placement** (`View()`): the modal now renders in the live region in place of the input box + status bar, instead of replacing the entire view. Streaming assistant text, the activity spinner, task list, and sub-agent/workflow panels stay visible above it — the user decides with the model's reasoning still on screen.

**Presentation note**: the permission prompt is unboxed (the question modal keeps its border). Long unclipped lines inside a lipgloss rounded border make the box wider than the terminal and garble the borders; an unboxed block with the `⚠ permission — <tool>` heading + key hints wraps gracefully at any width.

## Sample renders (width 70)

```
⚠ permission — terminal
  cd /app && make build \
    && make test \
    && git push --force origin main
[y]es · [a]lways this session · [n]o/Esc
```

```
⚠ permission — mcp_dwh_query
  env: prod
  limit: 100
  sql:
    SELECT *
    FROM orders
    WHERE d>1
[y]es · [a]lways this session · [n]o/Esc
```

edit_file shows the standard `● Update(path)` diff card with red/green washes.

## Testing

- `gofmt` clean, `go vet` clean, full `go test -race ./...` green.
- New tests: full-command visibility (120+ rune command asserted verbatim), context-above-prompt visibility, edit_file diff card in prompt, generic key/value rendering + multi-line fold + empty input + long-command fold marker.
- Manual render check of all three prompt shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review hardening (commits 2-4)

Two isolated-review passes drove the follow-ups:

- **Hard-wrap instead of "let the terminal wrap"** — bubbletea's inline renderer truncates every frame line at terminal width with **no marker** (`standard_renderer.go`: `ansi.Truncate(line, r.width, "")`), so unwrapped long lines would still be approved blind. All prompt detail lines now hard-wrap to the width (display-cell exact, CJK aware, continuation indent).
- **Control-byte sanitization** — a `\r` in a command would home the cursor and let the display overwrite its own dangerous prefix; raw ESC could inject erase sequences. C0/DEL now render in caret notation (`^[`), decoded C1 (U+0080–U+009F) as a visible placeholder. Applied to commands, generic keys AND values, and edit_file path/old/new (tabs kept byte-exact for the card's line-number lookup; the card normalizes CRLF so \r-stripping doesn't cost CRLF files their line numbers).
- **Per-tick recompute fixed** — the rendered detail is cached on the modal (View() runs ~8×/s on spinner ticks; the edit_file path reads the target file each render).
- **Plain/stdin path fixed too** — it had the same 60-rune cap; it now shares the block/generic rendering.
