### PR TITLE
fix(tui): folded and non-card tool output reachable via spill-file hyperlinks

### DIFF
--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -125,7 +125,28 @@ func renderToolCard(toolName string, input map[string]any, output string, isErr 
 	case "terminal_output", "kill_shell", "terminal_input":
 		opts.Tail = true
 	}
+	// When the card will fold ("… +N lines"), persist the full output and
+	// hyperlink the marker to it — otherwise the folded content is
+	// unrecoverable in the TUI (issue #1093). Write failure degrades to the
+	// plain marker.
+	if opts.MaxLines > 0 && nonBlankLineCount(output) > opts.MaxLines {
+		if path, err := tools.WriteCardSpill(toolName, output); err == nil {
+			opts.FoldLink = tui.FileURI(path)
+		}
+	}
 	return tui.RenderOutputCard(verb, cardTargetFor(toolName, input), output, opts)
+}
+
+// nonBlankLineCount mirrors RenderOutputCard's blank-line filtering so the
+// caller can predict whether the card will fold before rendering it.
+func nonBlankLineCount(s string) int {
+	n := 0
+	for _, l := range strings.Split(s, "\n") {
+		if strings.TrimSpace(l) != "" {
+			n++
+		}
+	}
+	return n
 }
 
 // splitTerminalExit detaches the trailing "[exit: …]" marker the terminal

--- a/cmd/octo/toolcards_test.go
+++ b/cmd/octo/toolcards_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -169,5 +170,52 @@ func TestRendersCard_PlainDisablesCards(t *testing.T) {
 	// A non-card tool is never a card regardless of --plain.
 	if plainOff.rendersCard("sub_agent") {
 		t.Error("sub_agent is not a card tool")
+	}
+}
+
+func TestRenderToolCard_FoldedOutputGetsHyperlink(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	long := strings.TrimSuffix(strings.Repeat("row\n", 12), "\n")
+	got := renderToolCard("terminal", map[string]any{"command": "ls"}, long, false, 0, 0)
+	if !strings.Contains(got, "\x1b]8;;file://") {
+		t.Errorf("folded card should hyperlink the marker; got:\n%q", got)
+	}
+	// The linked file holds the complete output.
+	i := strings.Index(got, "file://")
+	uri := got[i:]
+	uri = uri[:strings.IndexByte(uri, 0x1b)]
+	path := strings.TrimPrefix(uri, "file://")
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != long {
+		t.Errorf("linked spill should hold the full output; err %v, got %q", err, data)
+	}
+	// An unfolded card gets no link.
+	short := renderToolCard("terminal", map[string]any{"command": "ls"}, "a\nb", false, 0, 0)
+	if strings.Contains(short, "\x1b]8;;") {
+		t.Errorf("unfolded card should not carry a link; got:\n%q", short)
+	}
+}
+
+func TestRenderToolOutcome_NonCardOutputVisible(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := newTestModel()
+	// Short single-line result rides the status line inline.
+	got := m.renderToolOutcome("mcp_thing", map[string]any{"q": "x"}, "42 rows", false, 0)
+	if !strings.Contains(got, "— 42 rows") {
+		t.Errorf("short result should show inline; got:\n%q", got)
+	}
+	if strings.Contains(got, "\x1b]8;;") {
+		t.Errorf("short result should not spill; got:\n%q", got)
+	}
+	// Multi-line result is persisted and linked.
+	long := strings.TrimSuffix(strings.Repeat("r\n", 6), "\n")
+	got = m.renderToolOutcome("mcp_thing", map[string]any{"q": "x"}, long, false, 0)
+	if !strings.Contains(got, "\x1b]8;;file://") || !strings.Contains(got, "output (6 lines)") {
+		t.Errorf("long result should be linked with a line count; got:\n%q", got)
+	}
+	// Errors keep the existing inline errText, no duplicate link.
+	got = m.renderToolOutcome("mcp_thing", map[string]any{"q": "x"}, "boom", true, 0)
+	if !strings.Contains(got, "— boom") || strings.Contains(got, "\x1b]8;;") {
+		t.Errorf("error line should stay as before; got:\n%q", got)
 	}
 }

--- a/cmd/octo/toolcards_test.go
+++ b/cmd/octo/toolcards_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"net/url"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -173,8 +176,32 @@ func TestRendersCard_PlainDisablesCards(t *testing.T) {
 	}
 }
 
+// setSpillHome points the spill dir at a temp home on every platform
+// (os.UserHomeDir reads HOME on unix, USERPROFILE on Windows).
+func setSpillHome(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+}
+
+// spillURIToPath converts the file:// URI embedded in an OSC 8 escape back to
+// a filesystem path, undoing FileURI's percent-encoding and Windows shaping.
+func spillURIToPath(t *testing.T, uri string) string {
+	t.Helper()
+	u, err := url.Parse(uri)
+	if err != nil {
+		t.Fatalf("bad spill URI %q: %v", uri, err)
+	}
+	p := u.Path
+	if runtime.GOOS == "windows" {
+		p = filepath.FromSlash(strings.TrimPrefix(p, "/"))
+	}
+	return p
+}
+
 func TestRenderToolCard_FoldedOutputGetsHyperlink(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setSpillHome(t)
 	long := strings.TrimSuffix(strings.Repeat("row\n", 12), "\n")
 	got := renderToolCard("terminal", map[string]any{"command": "ls"}, long, false, 0, 0)
 	if !strings.Contains(got, "\x1b]8;;file://") {
@@ -184,8 +211,7 @@ func TestRenderToolCard_FoldedOutputGetsHyperlink(t *testing.T) {
 	i := strings.Index(got, "file://")
 	uri := got[i:]
 	uri = uri[:strings.IndexByte(uri, 0x1b)]
-	path := strings.TrimPrefix(uri, "file://")
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(spillURIToPath(t, uri))
 	if err != nil || string(data) != long {
 		t.Errorf("linked spill should hold the full output; err %v, got %q", err, data)
 	}
@@ -196,8 +222,26 @@ func TestRenderToolCard_FoldedOutputGetsHyperlink(t *testing.T) {
 	}
 }
 
+func TestRenderToolCard_BlankHeavyOutputNoSpill(t *testing.T) {
+	// Blank lines don't count toward the fold; an output that renders without
+	// folding must not leave a spill file behind (prediction/render parity).
+	setSpillHome(t)
+	out := "a\n\n\n\nb\n\n\n\nc\n\n"
+	got := renderToolCard("terminal", map[string]any{"command": "ls"}, out, false, 0, 0)
+	if strings.Contains(got, "\x1b]8;;") || strings.Contains(got, "…") {
+		t.Errorf("blank-heavy output should neither fold nor link; got:\n%q", got)
+	}
+	home, _ := os.UserHomeDir()
+	entries, _ := os.ReadDir(filepath.Join(home, ".octo", "tmp"))
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "card-") {
+			t.Errorf("no spill file expected, found %s", e.Name())
+		}
+	}
+}
+
 func TestRenderToolOutcome_NonCardOutputVisible(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setSpillHome(t)
 	m := newTestModel()
 	// Short single-line result rides the status line inline.
 	got := m.renderToolOutcome("mcp_thing", map[string]any{"q": "x"}, "42 rows", false, 0)
@@ -217,5 +261,19 @@ func TestRenderToolOutcome_NonCardOutputVisible(t *testing.T) {
 	got = m.renderToolOutcome("mcp_thing", map[string]any{"q": "x"}, "boom", true, 0)
 	if !strings.Contains(got, "— boom") || strings.Contains(got, "\x1b]8;;") {
 		t.Errorf("error line should stay as before; got:\n%q", got)
+	}
+}
+
+func TestRenderToolOutcome_InlineResultSanitized(t *testing.T) {
+	setSpillHome(t)
+	m := newTestModel()
+	// A \r (no \n, under 80 runes) passes the inline check but must not reach
+	// the terminal raw — it would let the result overwrite the status line.
+	got := m.renderToolOutcome("mcp_thing", map[string]any{}, "ok\rSPOOFED", false, 0)
+	if strings.ContainsRune(got, '\r') {
+		t.Errorf("raw \\r reached the status line: %q", got)
+	}
+	if !strings.Contains(got, "SPOOFED") || !strings.Contains(got, "ok") {
+		t.Errorf("sanitized content should keep both halves visible: %q", got)
 	}
 }

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1524,7 +1524,20 @@ func (m *tuiModel) renderToolOutcome(toolName string, input map[string]any, resu
 	if isErr {
 		errText = truncate1Line(resultText)
 	}
-	return tui.RenderToolStatus(toolName, summariseInput(input), isErr, errText)
+	status := tui.RenderToolStatus(toolName, summariseInput(input), isErr, errText)
+	// Non-card tools (MCP included) show only their input on the status line —
+	// the result itself is invisible to the user (issue #1093). A short result
+	// rides the line inline; anything longer is persisted and linked so it
+	// stays reachable. Errors already carry their first line via errText.
+	if trimmed := strings.TrimSpace(resultText); trimmed != "" && !isErr {
+		if lines := strings.Count(trimmed, "\n") + 1; lines == 1 && len([]rune(trimmed)) <= 80 {
+			status += " " + hintStyle.Render("— "+trimmed)
+		} else if path, err := tools.WriteCardSpill(toolName, resultText); err == nil {
+			label := fmt.Sprintf("output (%d lines) ↗", lines)
+			status += " " + tui.Hyperlink(tui.FileURI(path), hintStyle.Underline(true).Render(label))
+		}
+	}
+	return status
 }
 
 // replayHistoryLines renders a resumed session's prior turns into scrollback

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1527,17 +1527,27 @@ func (m *tuiModel) renderToolOutcome(toolName string, input map[string]any, resu
 	status := tui.RenderToolStatus(toolName, summariseInput(input), isErr, errText)
 	// Non-card tools (MCP included) show only their input on the status line —
 	// the result itself is invisible to the user (issue #1093). A short result
-	// rides the line inline; anything longer is persisted and linked so it
-	// stays reachable. Errors already carry their first line via errText.
-	if trimmed := strings.TrimSpace(resultText); trimmed != "" && !isErr {
+	// rides the line inline (control bytes neutralized: this is model-supplied
+	// text going straight to the terminal, the same injection surface the
+	// permission prompt sanitizes); anything longer is persisted and linked so
+	// it stays reachable. Errors already carry their first line via errText.
+	if trimmed := strings.TrimSpace(sanitizeForPrompt(resultText)); trimmed != "" && !isErr {
 		if lines := strings.Count(trimmed, "\n") + 1; lines == 1 && len([]rune(trimmed)) <= 80 {
 			status += " " + hintStyle.Render("— "+trimmed)
 		} else if path, err := tools.WriteCardSpill(toolName, resultText); err == nil {
-			label := fmt.Sprintf("output (%d lines) ↗", lines)
+			label := "output (" + pluraliseLineCount(lines) + ") ↗"
 			status += " " + tui.Hyperlink(tui.FileURI(path), hintStyle.Underline(true).Render(label))
 		}
 	}
 	return status
+}
+
+// pluraliseLineCount renders "1 line" / "N lines" for the status-line link.
+func pluraliseLineCount(n int) string {
+	if n == 1 {
+		return "1 line"
+	}
+	return fmt.Sprintf("%d lines", n)
 }
 
 // replayHistoryLines renders a resumed session's prior turns into scrollback

--- a/internal/tools/spill.go
+++ b/internal/tools/spill.go
@@ -169,15 +169,20 @@ var cardSpillSeq atomic.Int64
 // a folded card's "… +N lines" marker to it. Unlike the model-facing spills,
 // these files survive session exit — the link lives in the terminal
 // scrollback, which outlives the process — and are reclaimed by the age
-// sweep instead of CleanSpillFiles. Returns the absolute path.
+// sweep instead of CleanSpillFiles. The deliberate consequence: tool output
+// (secrets included) persists on disk up to spillMaxAge after the session
+// ends, where term-/webfetch- spills die at shutdown. Returns the absolute
+// path. The timestamp in the name keeps a recycled pid from overwriting a
+// previous session's file while its scrollback link is still alive.
 func WriteCardSpill(toolName, body string) (string, error) {
 	dir, err := spillDir()
 	if err != nil {
 		return "", err
 	}
 	sweepOldSpillFiles(dir)
-	name := fmt.Sprintf("%s%s-%d-%d.log",
-		cardSpillPrefix, sanitizeSpillID(toolName), os.Getpid(), cardSpillSeq.Add(1))
+	name := fmt.Sprintf("%s%s-%d-%d-%d.log",
+		cardSpillPrefix, sanitizeSpillID(toolName), os.Getpid(),
+		time.Now().UnixNano(), cardSpillSeq.Add(1))
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		return "", err

--- a/internal/tools/spill.go
+++ b/internal/tools/spill.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -27,13 +28,20 @@ const (
 // only catches the leftovers of a crashed session.
 const spillMaxAge = 24 * time.Hour
 
-// spillPrefixes are the filename prefixes used by everything that writes into
-// ~/.octo/tmp: terminal output (`term-`) and web_fetch bodies (`webfetch-`).
-// Both the age-sweep and the shutdown clean must cover every prefix, else a
-// kind whose prefix is missing leaks files forever.
+// spillPrefixes are the filename prefixes of model-facing spill files in
+// ~/.octo/tmp — terminal output (`term-`) and web_fetch bodies (`webfetch-`).
+// These are session-scoped: removed on clean shutdown (CleanSpillFiles) and
+// age-swept as crash leftovers.
 var spillPrefixes = []string{"term-", "webfetch-"}
 
-// hasSpillPrefix reports whether name is one of our spill files.
+// cardSpillPrefix marks user-facing spill files: the full output behind a
+// folded TUI card, hyperlinked from the scrollback. The scrollback outlives
+// the process, so these deliberately survive shutdown and are reclaimed only
+// by the age sweep.
+const cardSpillPrefix = "card-"
+
+// hasSpillPrefix reports whether name is a session-scoped spill file (the
+// kind CleanSpillFiles removes on exit).
 func hasSpillPrefix(name string) bool {
 	for _, p := range spillPrefixes {
 		if strings.HasPrefix(name, p) {
@@ -41,6 +49,12 @@ func hasSpillPrefix(name string) bool {
 		}
 	}
 	return false
+}
+
+// isSweepable reports whether name is any spill file the age sweep may
+// reclaim — session-scoped ones and card spills alike.
+func isSweepable(name string) bool {
+	return hasSpillPrefix(name) || strings.HasPrefix(name, cardSpillPrefix)
 }
 
 // MaybeSpillOutput returns body unchanged when it is small enough to give the
@@ -134,7 +148,7 @@ func sweepOldSpillFiles(dir string) {
 	}
 	cutoff := time.Now().Add(-spillMaxAge)
 	for _, e := range entries {
-		if e.IsDir() || !hasSpillPrefix(e.Name()) {
+		if e.IsDir() || !isSweepable(e.Name()) {
 			continue
 		}
 		info, err := e.Info()
@@ -145,6 +159,30 @@ func sweepOldSpillFiles(dir string) {
 			_ = os.Remove(filepath.Join(dir, e.Name()))
 		}
 	}
+}
+
+// cardSpillSeq numbers card spills within this process so two folds in the
+// same session never collide on a filename.
+var cardSpillSeq atomic.Int64
+
+// WriteCardSpill persists a tool call's full output so the TUI can hyperlink
+// a folded card's "… +N lines" marker to it. Unlike the model-facing spills,
+// these files survive session exit — the link lives in the terminal
+// scrollback, which outlives the process — and are reclaimed by the age
+// sweep instead of CleanSpillFiles. Returns the absolute path.
+func WriteCardSpill(toolName, body string) (string, error) {
+	dir, err := spillDir()
+	if err != nil {
+		return "", err
+	}
+	sweepOldSpillFiles(dir)
+	name := fmt.Sprintf("%s%s-%d-%d.log",
+		cardSpillPrefix, sanitizeSpillID(toolName), os.Getpid(), cardSpillSeq.Add(1))
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 // CleanSpillFiles removes this process's spill files. Wire it into session

--- a/internal/tools/spill_card_test.go
+++ b/internal/tools/spill_card_test.go
@@ -1,0 +1,66 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteCardSpill_PathAndContent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	path, err := WriteCardSpill("mcp_thing", "line1\nline2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(filepath.Base(path), "card-mcp_thing-") {
+		t.Errorf("unexpected spill name: %s", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "line1\nline2" {
+		t.Errorf("spill content = %q, err %v", data, err)
+	}
+	// A second write in the same process must not collide.
+	path2, err := WriteCardSpill("mcp_thing", "other")
+	if err != nil || path2 == path {
+		t.Errorf("second spill should get a fresh name: %s vs %s (err %v)", path, path2, err)
+	}
+}
+
+func TestCleanSpillFiles_KeepsCardSpills(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cardPath, err := WriteCardSpill("terminal", "full output")
+	if err != nil {
+		t.Fatal(err)
+	}
+	termPath, err := writeSpillFile("bg_1", "model-facing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	CleanSpillFiles()
+	if _, err := os.Stat(termPath); !os.IsNotExist(err) {
+		t.Error("session-scoped term- spill should be removed on exit")
+	}
+	// The card spill is hyperlinked from the terminal scrollback, which
+	// outlives the process — it must survive shutdown.
+	if _, err := os.Stat(cardPath); err != nil {
+		t.Errorf("card spill should survive CleanSpillFiles: %v", err)
+	}
+}
+
+func TestSweepReclaimsOldCardSpills(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	path, err := WriteCardSpill("terminal", "old")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := time.Now().Add(-2 * spillMaxAge)
+	if err := os.Chtimes(path, stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	sweepOldSpillFiles(filepath.Dir(path))
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("age sweep should reclaim old card spills")
+	}
+}

--- a/internal/tools/spill_card_test.go
+++ b/internal/tools/spill_card_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestWriteCardSpill_PathAndContent(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	path, err := WriteCardSpill("mcp_thing", "line1\nline2")
 	if err != nil {
 		t.Fatal(err)
@@ -29,7 +31,9 @@ func TestWriteCardSpill_PathAndContent(t *testing.T) {
 }
 
 func TestCleanSpillFiles_KeepsCardSpills(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	cardPath, err := WriteCardSpill("terminal", "full output")
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +54,9 @@ func TestCleanSpillFiles_KeepsCardSpills(t *testing.T) {
 }
 
 func TestSweepReclaimsOldCardSpills(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	path, err := WriteCardSpill("terminal", "old")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/tui/outputcard.go
+++ b/internal/tui/outputcard.go
@@ -38,6 +38,10 @@ type OutputCardOpts struct {
 	// Meta is a dim annotation appended to the header, e.g. "1.2s" or
 	// "exit 1 · 12s".
 	Meta string
+	// FoldLink, when non-empty, is a URI (usually file://) holding the full
+	// output; the "… +N lines" fold marker becomes a click-to-open OSC 8
+	// hyperlink to it. Terminals without OSC 8 show the plain marker.
+	FoldLink string
 }
 
 // cardGutterWidth is the visible width of the "  │ " prefix each body row
@@ -82,7 +86,7 @@ func RenderOutputCard(verb, target, output string, opts OutputCardOpts) string {
 	}
 
 	if extra > 0 && opts.Tail {
-		b.WriteString("\n  " + outMore.Render("… +"+pluralise(extra, "line")))
+		b.WriteString("\n  " + foldMarker(extra, opts.FoldLink))
 	}
 	dark := IsDark()
 	for _, ln := range shown {
@@ -96,9 +100,19 @@ func RenderOutputCard(verb, target, output string, opts OutputCardOpts) string {
 		b.WriteString("\n  " + outGutter.String() + " " + body)
 	}
 	if extra > 0 && !opts.Tail {
-		b.WriteString("\n  " + outMore.Render("… +"+pluralise(extra, "line")))
+		b.WriteString("\n  " + foldMarker(extra, opts.FoldLink))
 	}
 	return b.String()
+}
+
+// foldMarker renders the "… +N lines" collapse marker; with a link it becomes
+// an underlined click-to-open hyperlink to the full output.
+func foldMarker(extra int, link string) string {
+	text := "… +" + pluralise(extra, "line")
+	if link == "" {
+		return outMore.Render(text)
+	}
+	return Hyperlink(link, outMore.Underline(true).Render(text+" ↗"))
 }
 
 // clipLine truncates s to at most limit terminal cells, ending in "…" when


### PR DESCRIPTION
First tier of #1093 (the issue notes this tier is worth shipping alone; Ctrl+O transcript view and richer MCP cards remain follow-ups).

## What changed

**Folded cards** (`cmd/octo/toolcards.go`, `internal/tui/outputcard.go`): when a card folds output behind "… +N lines", the full output is written to a spill file and the marker renders as an underlined OSC 8 hyperlink — `… +N lines ↗` — that opens the file. Terminals without OSC 8 support show the plain text unchanged. Spill-write failure degrades to today's plain marker.

**Non-card tools** (`cmd/octo/tuirepl.go` `renderToolOutcome`): every MCP tool and other non-card tool used to render input-only — the result was invisible to the user. Now a short single-line result rides the status line inline (`● mcp_thing(q=x) — 42 rows`); anything longer is persisted and linked (`output (6 lines) ↗`). Error lines keep their existing inline first-line text.

**Spill lifetime** (`internal/tools/spill.go`): card spills use a new `card-` prefix under `~/.octo/tmp`. Unlike the model-facing `term-`/`webfetch-` spills they deliberately **survive session exit** — the hyperlink lives in the terminal scrollback, which outlives the process — and are reclaimed by the existing 24h age sweep. `WriteCardSpill` is sequence-numbered so same-session folds never collide.

Resumed-session replay re-renders through the same path, so replayed transcripts get working links too (at the cost of re-writing spill files on resume; bounded by history length and age-swept).

## Testing

- `gofmt` clean, `go vet` clean, full `go test -race ./...` green.
- New tests: spill path/content/no-collision; `CleanSpillFiles` keeps `card-` files while removing `term-`; age sweep reclaims old card spills; folded card carries a `file://` link whose target holds the complete output (and unfolded cards carry none); non-card short-inline / long-linked / error-unchanged status lines.
- Manual render check of the OSC 8 escape structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-ups (commit 2)

- Inline `— result` text is model-supplied and went to the terminal raw — the same control-byte injection surface #1101 closed for the permission prompt; it now runs through `sanitizeForPrompt` (test pins `\r` neutralization).
- Tests were Windows-hostile (`HOME`-only isolation, naive `file://` prefix-stripping); they now set `USERPROFILE` too and parse the URI properly per-platform.
- Card spill names gain a timestamp: a recycled pid can no longer overwrite a previous session's file while its scrollback link is still alive.
- `output (1 lines)` grammar fixed; the secrets-persist-up-to-24h-after-exit tradeoff is documented on `WriteCardSpill`; a parity test pins that blank-heavy unfolded output leaves no spill file behind.
