### PR TITLE
fix(server): advertise sub_agent and workflow tools in serve/cron turns

### DIFF
--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -289,4 +290,114 @@ func TestPrepareToolTurn_SessionScopedAsyncManager(t *testing.T) {
 	if anon == m1 {
 		t.Error("sid-less manager must not be the session-scoped one")
 	}
+}
+
+// TestPrepareToolTurn_AdvertisesSubAgentAndWorkflow guards the core fix for
+// cron/server sessions: after prepareToolTurn, DefaultToolsFor must include
+// both sub_agent and workflow so the model can invoke them.
+func TestPrepareToolTurn_AdvertisesSubAgentAndWorkflow(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	// Preserve and restore global state so this test doesn't leak to others.
+	prevSpawner := tools.ActiveSpawner()
+	prevMgr := tools.DefaultSubAgentManager()
+	t.Cleanup(func() {
+		tools.SetSpawner(prevSpawner)
+		tools.SetDefaultSubAgentManager(prevMgr)
+	})
+
+	// Ensure we start from a clean slate; prepareToolTurn should install its own.
+	tools.SetSpawner(nil)
+	tools.SetDefaultSubAgentManager(nil)
+
+	srv := mustServer(t, Config{Tools: true})
+	a := agent.New(&stubSender{}, "stub-model")
+	ctx := context.WithValue(context.Background(), ctxKeySessionID{}, "adv-test")
+	t.Cleanup(func() { tools.CloseSessionSubAgentManager("adv-test") })
+
+	_, _, _, cleanup, err := srv.prepareToolTurn(ctx, a, nil)
+	if err != nil {
+		t.Fatalf("prepareToolTurn: %v", err)
+	}
+	defer cleanup()
+
+	names := toolNames(tools.DefaultToolsFor(a.Model))
+	if !slices.Contains(names, "sub_agent") {
+		t.Errorf("DefaultToolsFor missing sub_agent; got %v", names)
+	}
+	if !slices.Contains(names, "workflow") {
+		t.Errorf("DefaultToolsFor missing workflow; got %v", names)
+	}
+}
+
+// TestPrepareToolTurn_CleanupRestoresGlobalSpawner verifies that the cleanup
+// returned by prepareToolTurn restores the previous global spawner and
+// sub-agent manager, so later server turns or CLI paths see their own state.
+func TestPrepareToolTurn_CleanupRestoresGlobalSpawner(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	prevSpawner := tools.ActiveSpawner()
+	prevMgr := tools.DefaultSubAgentManager()
+	t.Cleanup(func() {
+		tools.SetSpawner(prevSpawner)
+		tools.SetDefaultSubAgentManager(prevMgr)
+	})
+
+	// Pre-seed the global slots with sentinel values so we can prove restoration.
+	fake := &fakeGlobalSpawner{}
+	prevMgrForTest := tools.NewSubAgentManager(nil)
+	tools.SetSpawner(fake)
+	tools.SetDefaultSubAgentManager(prevMgrForTest)
+
+	srv := mustServer(t, Config{Tools: true})
+	a := agent.New(&stubSender{}, "stub-model")
+	ctx := context.WithValue(context.Background(), ctxKeySessionID{}, "cleanup-test")
+	t.Cleanup(func() { tools.CloseSessionSubAgentManager("cleanup-test") })
+
+	_, _, _, cleanup, err := srv.prepareToolTurn(ctx, a, nil)
+	if err != nil {
+		t.Fatalf("prepareToolTurn: %v", err)
+	}
+	if tools.ActiveSpawner() == nil {
+		t.Error("global spawner should be set during the turn")
+	}
+	if tools.DefaultSubAgentManager() == nil {
+		t.Error("global sub-agent manager should be set during the turn")
+	}
+
+	cleanup()
+
+	if tools.ActiveSpawner() != fake {
+		t.Error("cleanup did not restore previous global spawner")
+	}
+	if tools.DefaultSubAgentManager() != prevMgrForTest {
+		t.Error("cleanup did not restore previous global sub-agent manager")
+	}
+
+	// Restore the truly original values so the test cleanup doesn't leak.
+	tools.SetSpawner(prevSpawner)
+	tools.SetDefaultSubAgentManager(prevMgr)
+}
+
+func toolNames(defs []agent.ToolDefinition) []string {
+	names := make([]string, len(defs))
+	for i, d := range defs {
+		names[i] = d.Name
+	}
+	return names
+}
+
+// fakeGlobalSpawner is a minimal Spawner used only to prove that
+// prepareToolTurn's cleanup restores the previous global value.
+type fakeGlobalSpawner struct{}
+
+func (fakeGlobalSpawner) Spawn(context.Context, tools.SpawnRequest) (tools.SpawnResult, error) {
+	return tools.SpawnResult{}, nil
+}
+func (fakeGlobalSpawner) Continue(context.Context, string, string) (tools.SpawnResult, error) {
+	return tools.SpawnResult{}, nil
 }

--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -264,11 +264,11 @@ func TestPrepareToolTurn_SessionScopedAsyncManager(t *testing.T) {
 	ctx := context.WithValue(context.Background(), ctxKeySessionID{}, "sess-mgr-test")
 	t.Cleanup(func() { tools.CloseSessionSubAgentManager("sess-mgr-test") })
 
-	_, _, m1, err := srv.prepareToolTurn(ctx, a, nil)
+	_, _, m1, _, err := srv.prepareToolTurn(ctx, a, nil)
 	if err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
-	_, _, m2, err := srv.prepareToolTurn(ctx, a, nil)
+	_, _, m2, _, err := srv.prepareToolTurn(ctx, a, nil)
 	if err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
@@ -279,7 +279,7 @@ func TestPrepareToolTurn_SessionScopedAsyncManager(t *testing.T) {
 		t.Error("session-scoped manager should be async")
 	}
 
-	_, _, anon, err := srv.prepareToolTurn(context.Background(), a, nil)
+	_, _, anon, _, err := srv.prepareToolTurn(context.Background(), a, nil)
 	if err != nil {
 		t.Fatalf("prepareToolTurn (no sid): %v", err)
 	}

--- a/internal/server/browser_helpers_test.go
+++ b/internal/server/browser_helpers_test.go
@@ -21,7 +21,7 @@ func TestPrepareToolTurn_WiresBrowserLLMHelpers(t *testing.T) {
 	tools.SetBrowserSkillGenerator(nil)
 
 	a := agent.New(&stubSender{}, "stub-model")
-	if _, _, _, err := srv.prepareToolTurn(context.Background(), a, nil); err != nil {
+	if _, _, _, _, err := srv.prepareToolTurn(context.Background(), a, nil); err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
 	if !tools.BrowserHealerSet() {

--- a/internal/server/browser_vision_test.go
+++ b/internal/server/browser_vision_test.go
@@ -25,7 +25,7 @@ func TestPrepareToolTurn_WiresBrowserVision(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
 	tools.SetBrowserVision(true) // start opposite of expected to prove it's set
-	if _, _, _, err := srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "qwen3.7-max"), nil); err != nil {
+	if _, _, _, _, err := srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "qwen3.7-max"), nil); err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
 	if tools.BrowserVisionEnabled() {
@@ -33,7 +33,7 @@ func TestPrepareToolTurn_WiresBrowserVision(t *testing.T) {
 	}
 
 	tools.SetBrowserVision(false)
-	if _, _, _, err := srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "gpt-4o"), nil); err != nil {
+	if _, _, _, _, err := srv.prepareToolTurn(context.Background(), agent.New(&stubSender{}, "gpt-4o"), nil); err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
 	if !tools.BrowserVisionEnabled() {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -743,10 +743,11 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 
 	// Tool-enabled path: wire the per-turn tool environment (gate + ctx-scoped
 	// sub-agent manager + task store) bound to this turn's agent.
-	ctx, executor, _, err := s.prepareToolTurn(ctx, a, sess)
+	ctx, executor, _, cleanup, err := s.prepareToolTurn(ctx, a, sess)
 	if err != nil {
 		return "", err
 	}
+	defer cleanup()
 
 	reply, err := a.Run(ctx, userInput, tools.DefaultToolsFor(a.Model), executor)
 	if err != nil {
@@ -763,9 +764,13 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 // dispatch to them rather than the process-global gating sentinels. The manager
 // runs synchronously — a request/response turn has no follow-up channel for an
 // async sub-agent result — and each turn gets a private store, so concurrent
-// sessions never share sub-agent or task state. Returns the augmented ctx, the
-// executor, and the manager so callers can wire live-panel event hooks.
-func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agent.Session) (context.Context, agent.ToolExecutor, *tools.SubAgentManager, error) {
+// sessions never share sub-agent or task state.
+//
+// It also temporarily installs the turn's spawner / sub-agent manager into the
+// process-global slots so that tools.DefaultToolsFor() advertises the sub_agent
+// and workflow tools to the model for this turn. The returned cleanup restores
+// the previous global values and must be deferred by the caller.
+func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agent.Session) (context.Context, agent.ToolExecutor, *tools.SubAgentManager, func(), error) {
 	executor := tools.NewDefaultRegistry()
 
 	// Goal tools dispatch to the turn's session on every tool-enabled path
@@ -798,7 +803,7 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 	// and the task path applies its directory ahead of this too.
 	engine, err := permission.New(permissionConfigPath(), a.CWD, resolvePermissionMode(), s.memDir, s.homeMemDir)
 	if err != nil {
-		return ctx, nil, nil, fmt.Errorf("permission engine: %w", err)
+		return ctx, nil, nil, func() {}, fmt.Errorf("permission engine: %w", err)
 	}
 	// Wire interactive permission confirmation when we know the session, and
 	// scope background processes to a per-session manager so one session's
@@ -887,7 +892,23 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 	ctx = tools.WithSubAgentManager(ctx, mgr)
 	ctx = tools.WithTaskStore(ctx, tasks.New())
 
-	return ctx, executor, mgr, nil
+	// Temporarily install the turn's spawner/manager into the process-global
+	// slots so that DefaultToolsFor() advertises sub_agent and workflow. Save
+	// the previous values so callers can restore them after the turn.
+	prevSpawner := tools.ActiveSpawner()
+	prevSubAgentMgr := tools.DefaultSubAgentManager()
+	spawner := mgr.Spawner()
+	if spawner == nil {
+		spawner = mkSpawner()
+	}
+	tools.SetSpawner(spawner)
+	tools.SetDefaultSubAgentManager(mgr)
+	cleanup := func() {
+		tools.SetSpawner(prevSpawner)
+		tools.SetDefaultSubAgentManager(prevSubAgentMgr)
+	}
+
+	return ctx, executor, mgr, cleanup, nil
 }
 
 func permissionConfigPath() string {

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -97,9 +97,15 @@ func (s *Server) handleTurnSSE(w http.ResponseWriter, r *http.Request) {
 	var toolDefs []agent.ToolDefinition
 	var executor agent.ToolExecutor
 	var mgr *tools.SubAgentManager
+	var cleanup func()
+	defer func() {
+		if cleanup != nil {
+			cleanup()
+		}
+	}()
 	if s.cfg.Tools {
 		var perr error
-		runCtx, executor, mgr, perr = s.prepareToolTurn(runCtx, a, sess)
+		runCtx, executor, mgr, cleanup, perr = s.prepareToolTurn(runCtx, a, sess)
 		if perr != nil {
 			ev := agent.AgentEvent{Kind: agent.EventToolError, Err: perr.Error()}
 			b, _ := json.Marshal(ev)

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -209,9 +209,15 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 
 	var toolDefs []agent.ToolDefinition
 	var executor agent.ToolExecutor
+	var cleanup func()
+	defer func() {
+		if cleanup != nil {
+			cleanup()
+		}
+	}()
 	if s.cfg.Tools {
 		var perr error
-		runCtx, executor, _, perr = s.prepareToolTurn(runCtx, a, sess)
+		runCtx, executor, _, cleanup, perr = s.prepareToolTurn(runCtx, a, sess)
 		if perr != nil {
 			sw.error(perr.Error())
 			return sessionID, fmt.Errorf("prepare tools: %w", perr)

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1081,9 +1081,15 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	var executor agent.ToolExecutor
 	if s.cfg.Tools {
 		var perr error
+		var cleanup func()
+		defer func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		}()
 		// prepareToolTurn wires the session-scoped sub-agent manager's hooks
 		// (live-panel events + completion notes to the model).
-		runCtx, executor, _, perr = s.prepareToolTurn(runCtx, a, sess)
+		runCtx, executor, _, cleanup, perr = s.prepareToolTurn(runCtx, a, sess)
 		if perr != nil {
 			sw.error(perr.Error())
 			return

--- a/internal/tools/spawner.go
+++ b/internal/tools/spawner.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"sync"
 )
 
 // Spawner runs one sub-agent task to completion and returns the final reply.
@@ -107,16 +108,31 @@ type SpawnResult struct {
 // advertisement in DefaultTools. Set once at session start via SetSpawner.
 // Nil disables sub-agent dispatch — the tool stays out of the LLM-facing
 // schema and Execute errors.
-var activeSpawner Spawner
+var (
+	activeSpawnerMu sync.RWMutex
+	activeSpawner   Spawner
+)
 
 // SetSpawner registers the function the Agent tool delegates to. Pass
 // nil to disable (the tool then doesn't appear in DefaultTools).
-func SetSpawner(s Spawner) { activeSpawner = s }
+func SetSpawner(s Spawner) {
+	activeSpawnerMu.Lock()
+	activeSpawner = s
+	activeSpawnerMu.Unlock()
+}
 
 // ActiveSpawner returns the currently registered Spawner, or nil if none.
-func ActiveSpawner() Spawner { return activeSpawner }
+func ActiveSpawner() Spawner {
+	activeSpawnerMu.RLock()
+	defer activeSpawnerMu.RUnlock()
+	return activeSpawner
+}
 
-func spawnerEnabled() bool { return activeSpawner != nil }
+func spawnerEnabled() bool {
+	activeSpawnerMu.RLock()
+	defer activeSpawnerMu.RUnlock()
+	return activeSpawner != nil
+}
 
 // subAgentCtxKey marks a context as belonging to a sub-agent's run. The
 // Agent tool checks for it to refuse recursive nesting.

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -116,19 +116,34 @@ func truncateSubAgentResult(s string) string {
 
 // defaultSubAgentMgr is the process-wide manager used by the built-in tools
 // when no manager is injected.
-var defaultSubAgentMgr *SubAgentManager
+var (
+	defaultSubAgentMgrMu sync.RWMutex
+	defaultSubAgentMgr   *SubAgentManager
+)
 
 // SetDefaultSubAgentManager registers the global manager used by AgentTool
 // when no local manager is set.
-func SetDefaultSubAgentManager(m *SubAgentManager) { defaultSubAgentMgr = m }
+func SetDefaultSubAgentManager(m *SubAgentManager) {
+	defaultSubAgentMgrMu.Lock()
+	defaultSubAgentMgr = m
+	defaultSubAgentMgrMu.Unlock()
+}
 
 // DefaultSubAgentManager returns the process-wide manager currently
 // registered, or nil if none.
-func DefaultSubAgentManager() *SubAgentManager { return defaultSubAgentMgr }
+func DefaultSubAgentManager() *SubAgentManager {
+	defaultSubAgentMgrMu.RLock()
+	defer defaultSubAgentMgrMu.RUnlock()
+	return defaultSubAgentMgr
+}
 
 // subAgentManagerEnabled reports whether a SubAgentManager is registered,
 // which is required for the Agent tool.
-func subAgentManagerEnabled() bool { return defaultSubAgentMgr != nil }
+func subAgentManagerEnabled() bool {
+	defaultSubAgentMgrMu.RLock()
+	defer defaultSubAgentMgrMu.RUnlock()
+	return defaultSubAgentMgr != nil
+}
 
 // maxConcurrentSubAgents caps how many async sub-agents may run at once, so a
 // model that fires off a large fan-out of run_in_background:true calls can't

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -122,6 +122,10 @@ var defaultSubAgentMgr *SubAgentManager
 // when no local manager is set.
 func SetDefaultSubAgentManager(m *SubAgentManager) { defaultSubAgentMgr = m }
 
+// DefaultSubAgentManager returns the process-wide manager currently
+// registered, or nil if none.
+func DefaultSubAgentManager() *SubAgentManager { return defaultSubAgentMgr }
+
 // subAgentManagerEnabled reports whether a SubAgentManager is registered,
 // which is required for the Agent tool.
 func subAgentManagerEnabled() bool { return defaultSubAgentMgr != nil }
@@ -158,6 +162,15 @@ func NewSubAgentManager(spawner Spawner) *SubAgentManager {
 		agents:  map[string]*asyncSubAgent{},
 		spawner: spawner,
 	}
+}
+
+// Spawner returns the spawner backing this manager. Exposed so tools that
+// delegate to sub-agents (e.g. workflow) can resolve the spawner from the
+// ctx-scoped manager rather than relying on the process-global singleton.
+func (m *SubAgentManager) Spawner() Spawner {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.spawner
 }
 
 // SetSynchronous selects the sub_agent dispatch model. The default (false)

--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -176,7 +176,17 @@ func (WorkflowTool) Execute(ctx context.Context, _ string, input map[string]any)
 		}
 	}
 
-	spawner := ActiveSpawner()
+	// Prefer the ctx-scoped SubAgentManager (server/IM per-turn/per-session) so a
+	// workflow spawned by one session doesn't accidentally use another session's
+	// global Spawner under concurrency. Fall back to the process-global Spawner
+	// for CLI/TUI paths that never stamp a ctx manager.
+	var spawner Spawner
+	if mgr := resolveSubAgentManager(ctx, nil); mgr != nil {
+		spawner = mgr.Spawner()
+	}
+	if spawner == nil {
+		spawner = ActiveSpawner()
+	}
 	if spawner == nil {
 		return agent.ToolResult{}, fmt.Errorf("workflow: sub-agent dispatch is not configured for this session")
 	}


### PR DESCRIPTION
### Problem
Cron and other server-mode turns did not advertise the  and  tools to the model because  only stamped the per-turn Spawner/SubAgentManager into , while  gates those tools on the process-global  / .

### Fix
- Temporarily install the turn's spawner and sub-agent manager into the global slots in , returning a  that restores the previous values.
- Update all callers (, SSE, WS, , and tests) to .
- Make  prefer the ctx-scoped 's spawner so concurrent sessions don't cross-pollinate through the global slot.

### Verification
-  passes
-  passes
- ok  	github.com/open-octo/octo-agent/internal/tools	34.953s
ok  	github.com/open-octo/octo-agent/internal/tools/rgembed	0.466s
ok  	github.com/open-octo/octo-agent/internal/server	9.425s passes

### Notes
This is a minimal server-side wiring fix; no CLI/TUI behavior changes.