### PR TITLE
fix(channel): shared code-fence-aware splitter for all outbound adapters

### DIFF
--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -43,6 +43,11 @@ const (
 	msgTopic        = "/v1.0/im/bot/messages/get"
 	reconnectDelay  = 5 * time.Second
 	webhookSafetyMs = 5 * 60 * 1000 // 5 min in ms
+
+	// maxMessageBytes: DingTalk's custom-robot markdown message content is
+	// commonly documented at ~20000 bytes; SendText previously posted content
+	// as a single unbounded payload with no split at all (#1116).
+	maxMessageBytes = 20000
 )
 
 func init() {
@@ -201,12 +206,27 @@ func (a *Adapter) Stop() error {
 	return nil
 }
 
-// SendText sends a Markdown message via sessionWebhook or proactive OAPI.
+// SendText sends a Markdown message via sessionWebhook or proactive OAPI,
+// splitting content over maxMessageBytes into consecutive messages (#1116).
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
-	if url := a.resolveWebhook(chatID); url != "" {
-		return a.sendWebhook(url, text)
+	chunks := channel.SplitForSend(text, maxMessageBytes)
+	if len(chunks) == 0 {
+		return channel.SendResult{OK: true}
 	}
-	return a.sendProactive(chatID, text)
+
+	url := a.resolveWebhook(chatID)
+	var res channel.SendResult
+	for _, chunk := range chunks {
+		if url != "" {
+			res = a.sendWebhook(url, chunk)
+		} else {
+			res = a.sendProactive(chatID, chunk)
+		}
+		if !res.OK {
+			return res
+		}
+	}
+	return res
 }
 
 // SendFile uploads a file and sends it as a media message via OAPI.

--- a/internal/channel/adapters/dingtalk/dingtalk_test.go
+++ b/internal/channel/adapters/dingtalk/dingtalk_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -106,6 +107,48 @@ func TestSendText_ProactiveGroupPush(t *testing.T) {
 	}
 	if stub.sends[0].body["openConversationId"] != "cidAbC123==" {
 		t.Errorf("openConversationId = %v", stub.sends[0].body["openConversationId"])
+	}
+}
+
+// #1116: SendText posted content as a single unbounded payload — a reply
+// exceeding maxMessageBytes had no splitting to fall back on and would be
+// rejected or truncated outright by the platform.
+func TestSendText_SplitsLongMessages(t *testing.T) {
+	var mu sync.Mutex
+	var sent []string
+	wh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		md, _ := body["markdown"].(map[string]any)
+		text, _ := md["text"].(string)
+		mu.Lock()
+		sent = append(sent, text)
+		mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0})
+	}))
+	defer wh.Close()
+
+	stub := &stubAPI{}
+	ts := stub.server(t)
+	defer ts.Close()
+
+	a := testAdapter(ts)
+	a.webhooks["chat1"] = webhookEntry{URL: wh.URL, ExpiresAtMs: time.Now().Add(time.Hour).UnixMilli()}
+
+	long := strings.Repeat("word ", 5000) // ~25000 chars, over maxMessageBytes
+	if res := a.SendText("chat1", long, ""); !res.OK {
+		t.Fatalf("send: %s", res.Error)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(sent) < 2 {
+		t.Fatalf("expected split into >=2 messages, got %d", len(sent))
+	}
+	for _, text := range sent {
+		if len(text) > maxMessageBytes {
+			t.Fatalf("chunk exceeds cap: %d bytes", len(text))
+		}
 	}
 }
 

--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -48,6 +48,15 @@ const (
 	// readTimeout bounds a silent connection: heartbeat ACKs arrive at least
 	// every heartbeat interval (~41s), so 90s means two missed beats.
 	readTimeout = 90 * time.Second
+
+	// maxMessageBytes is Discord's hard per-message content cap (2000 UTF-16
+	// code units). #1116: SendText used to post content as-is — any reply
+	// over this limit got HTTP 400 and vanished entirely, with nothing
+	// telling the user why. Budgeting in bytes rather than characters is
+	// strictly conservative here: a string's UTF-8 byte length is never
+	// smaller than its UTF-16 code-unit count, so this can only split a
+	// little earlier than the real limit requires, never later.
+	maxMessageBytes = 2000
 )
 
 // fatalCloseCodes are gateway close codes that mean reconnecting cannot help
@@ -179,19 +188,30 @@ func (a *Adapter) Stop() error {
 	return nil
 }
 
-// SendText sends a message via the REST API.
+// SendText sends a message via the REST API, splitting content over
+// Discord's 2000-char cap into consecutive messages (#1116). Returns the
+// message ID of the last chunk.
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
-	payload := map[string]any{"content": text}
-	if replyTo != "" {
-		payload["message_reference"] = map[string]string{"message_id": replyTo}
+	chunks := channel.SplitForSend(text, maxMessageBytes)
+	if len(chunks) == 0 {
+		return channel.SendResult{OK: true}
 	}
-	var msg struct {
-		ID string `json:"id"`
+
+	var lastID string
+	for i, chunk := range chunks {
+		payload := map[string]any{"content": chunk}
+		if replyTo != "" && i == 0 {
+			payload["message_reference"] = map[string]string{"message_id": replyTo}
+		}
+		var msg struct {
+			ID string `json:"id"`
+		}
+		if err := a.rest(http.MethodPost, fmt.Sprintf("/channels/%s/messages", chatID), payload, &msg); err != nil {
+			return channel.SendResult{OK: false, Error: err.Error()}
+		}
+		lastID = msg.ID
 	}
-	if err := a.rest(http.MethodPost, fmt.Sprintf("/channels/%s/messages", chatID), payload, &msg); err != nil {
-		return channel.SendResult{OK: false, Error: err.Error()}
-	}
-	return channel.SendResult{OK: true, MessageID: msg.ID}
+	return channel.SendResult{OK: true, MessageID: lastID}
 }
 
 // SendFile uploads a file to a Discord channel using multipart form data.

--- a/internal/channel/adapters/discord/discord_test.go
+++ b/internal/channel/adapters/discord/discord_test.go
@@ -264,6 +264,34 @@ func TestSendText(t *testing.T) {
 	}
 }
 
+// #1116: SendText used to post content as-is with no cap at all — any reply
+// over Discord's 2000-char limit got HTTP 400 and the entire message
+// vanished, with nothing telling the user why.
+func TestSendText_SplitsLongMessages(t *testing.T) {
+	f := newFakeDiscord(t)
+	a := newTestAdapter(t, f, nil)
+
+	long := strings.Repeat("word ", 500) // ~2500 chars
+	res := a.SendText("chan-1", long, "")
+	if !res.OK {
+		t.Fatalf("send failed: %+v", res)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sent) < 2 {
+		t.Fatalf("expected split into >=2 messages, got %d", len(f.sent))
+	}
+	for _, p := range f.sent {
+		if len(p["content"].(string)) > maxMessageBytes {
+			t.Fatalf("chunk exceeds cap: %d bytes", len(p["content"].(string)))
+		}
+	}
+	// replyTo should only attach to the first chunk, not every one.
+	if f.sent[0]["message_reference"] != nil {
+		t.Fatalf("no replyTo was passed, but message_reference is set on chunk 0")
+	}
+}
+
 func TestUpdateMessageAndTyping(t *testing.T) {
 	f := newFakeDiscord(t)
 	a := newTestAdapter(t, f, nil)

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -37,6 +37,13 @@ const (
 	reconnectDelay = 5 * time.Second
 	readDeadline   = 120 * time.Second
 	pingInterval   = 90 * time.Second
+
+	// maxMessageBytes: Feishu's documented per-message content limits are far
+	// larger than any normal agentic reply (custom-bot webhook guidance is
+	// "JSON under ~30KB"), so this exists purely as a conservative backstop
+	// against silently failing on a truly pathological reply (#1116), not a
+	// limit anyone should expect to hit in practice.
+	maxMessageBytes = 20000
 )
 
 func init() {
@@ -192,13 +199,31 @@ func (a *Adapter) Stop() error {
 	return nil
 }
 
-// SendText sends a text message.
+// SendText sends a text (or, for code/tables, interactive card) message,
+// splitting content that exceeds maxMessageBytes into consecutive messages
+// (#1116). Returns the message ID of the last chunk. replyTo is only
+// attached to the first chunk — attaching it to every chunk would render as
+// several bubbles all "replying to" the same original message instead of a
+// natural sequential thread.
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
-	msgID, err := a.sendMessage(chatID, text, replyTo)
-	if err != nil {
-		return channel.SendResult{OK: false, Error: err.Error()}
+	chunks := channel.SplitForSend(text, maxMessageBytes)
+	if len(chunks) == 0 {
+		return channel.SendResult{OK: true}
 	}
-	return channel.SendResult{OK: true, MessageID: msgID}
+
+	var lastID string
+	for i, chunk := range chunks {
+		rt := ""
+		if i == 0 {
+			rt = replyTo
+		}
+		msgID, err := a.sendMessage(chatID, chunk, rt)
+		if err != nil {
+			return channel.SendResult{OK: false, Error: err.Error()}
+		}
+		lastID = msgID
+	}
+	return channel.SendResult{OK: true, MessageID: lastID}
 }
 
 // SendFile uploads a local file to Feishu and sends it to the chat.

--- a/internal/channel/adapters/feishu/feishu_test.go
+++ b/internal/channel/adapters/feishu/feishu_test.go
@@ -103,7 +103,10 @@ func TestSendText_SplitsLongMessages(t *testing.T) {
 			t.Fatalf("chunk wildly exceeds cap: %d bytes", len(content))
 		}
 	}
-	// replyTo should only attach to the first chunk, not every one.
+	// replyTo should attach to the first chunk only, not every one.
+	if f.sent[0]["reply_to_message_id"] != "m-0" {
+		t.Fatalf("expected reply_to_message_id on chunk 0, got: %+v", f.sent[0])
+	}
 	if _, ok := f.sent[1]["reply_to_message_id"]; ok {
 		t.Fatalf("reply_to_message_id should only be set on chunk 0, found on chunk 1: %+v", f.sent[1])
 	}

--- a/internal/channel/adapters/feishu/feishu_test.go
+++ b/internal/channel/adapters/feishu/feishu_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -72,6 +73,40 @@ func newTestAdapter(t *testing.T, f *fakeFeishu) *Adapter {
 		t.Fatalf("New: %v", err)
 	}
 	return a.(*Adapter)
+}
+
+// #1116: SendText posted content as a single unbounded payload with no
+// split at all; a reply exceeding maxMessageBytes would fail outright with
+// no chunking to fall back on.
+func TestSendText_SplitsLongMessages(t *testing.T) {
+	f := newFakeFeishu(t)
+	a := newTestAdapter(t, f)
+
+	long := strings.Repeat("word ", 5000) // ~25000 chars, over maxMessageBytes
+	res := a.SendText("chat-1", long, "m-0")
+	if !res.OK {
+		t.Fatalf("send failed: %+v", res)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sent) < 2 {
+		t.Fatalf("expected split into >=2 messages, got %d", len(f.sent))
+	}
+	for _, p := range f.sent {
+		// p["content"] is the JSON-marshaled post/card envelope, not the raw
+		// chunk — it carries a small, fixed structural overhead (tag/key
+		// names) on top of the actual text, so allow slack rather than
+		// asserting the exact raw-chunk cap here (that's what
+		// chunking_test.go pins directly against SplitForSend).
+		content, _ := p["content"].(string)
+		if len(content) > maxMessageBytes+200 {
+			t.Fatalf("chunk wildly exceeds cap: %d bytes", len(content))
+		}
+	}
+	// replyTo should only attach to the first chunk, not every one.
+	if _, ok := f.sent[1]["reply_to_message_id"]; ok {
+		t.Fatalf("reply_to_message_id should only be set on chunk 0, found on chunk 1: %+v", f.sent[1])
+	}
 }
 
 func TestSendFile_Image(t *testing.T) {

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -194,9 +194,11 @@ func (a *Adapter) Stop() error {
 }
 
 // SendText sends a message, splitting content over Telegram's length cap into
-// consecutive messages. Returns the message ID of the last chunk.
+// consecutive messages (#1116: shared with every other adapter via
+// channel.SplitForSend, which is also code-fence-aware — see chunking.go).
+// Returns the message ID of the last chunk.
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
-	chunks := splitMessage(text, maxMessageChars)
+	chunks := channel.SplitForSend(text, maxMessageChars)
 	if len(chunks) == 0 {
 		return channel.SendResult{OK: true}
 	}
@@ -742,39 +744,8 @@ func (a *Adapter) stripBotMention(text string) string {
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
-
-// splitMessage splits text at the length cap, preferring paragraph / line /
-// space boundaries and hard-cutting as a last resort.
-func splitMessage(text string, limit int) []string {
-	if text == "" {
-		return nil
-	}
-	runes := []rune(text)
-	if len(runes) <= limit {
-		return []string{text}
-	}
-
-	var chunks []string
-	for len(runes) > limit {
-		window := string(runes[:limit])
-		cut := strings.LastIndex(window, "\n\n")
-		if cut <= 0 {
-			cut = strings.LastIndex(window, "\n")
-		}
-		if cut <= 0 {
-			cut = strings.LastIndex(window, " ")
-		}
-		if cut <= 0 {
-			cut = limit
-		} else {
-			// LastIndex returned a byte offset into window; convert to runes.
-			cut = len([]rune(window[:cut]))
-		}
-		chunks = append(chunks, strings.TrimRight(string(runes[:cut]), " \n"))
-		runes = []rune(strings.TrimLeft(string(runes[cut:]), " \n"))
-	}
-	if len(runes) > 0 {
-		chunks = append(chunks, string(runes))
-	}
-	return chunks
-}
+//
+// The length-cap splitter used to live here (splitMessage); it's now
+// channel.SplitForSend, shared by every adapter (#1116) — see
+// internal/channel/chunking.go and its tests for the splitting behavior
+// itself.

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -41,8 +41,11 @@ const (
 	// don't tear down healthy connections mid-poll.
 	pollHTTPTimeout = longPollTimeout + 10*time.Second
 
-	// maxMessageChars leaves a margin under Telegram's 4096-char cap.
-	maxMessageChars = 4000
+	// maxMessageBytes leaves a margin under Telegram's 4096-char cap. Named
+	// "Bytes" (not "Chars", its pre-#1116 name) because channel.SplitForSend
+	// counts bytes, not runes — for CJK text this is more conservative than
+	// the exact character cap requires, never less.
+	maxMessageBytes = 4000
 )
 
 func init() {
@@ -198,7 +201,7 @@ func (a *Adapter) Stop() error {
 // channel.SplitForSend, which is also code-fence-aware — see chunking.go).
 // Returns the message ID of the last chunk.
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
-	chunks := channel.SplitForSend(text, maxMessageChars)
+	chunks := channel.SplitForSend(text, maxMessageBytes)
 	if len(chunks) == 0 {
 		return channel.SendResult{OK: true}
 	}

--- a/internal/channel/adapters/telegram/telegram_test.go
+++ b/internal/channel/adapters/telegram/telegram_test.go
@@ -231,24 +231,6 @@ func TestSendText_SplitsLongMessages(t *testing.T) {
 	}
 }
 
-func TestSplitMessage_Boundaries(t *testing.T) {
-	if got := splitMessage("", 10); got != nil {
-		t.Fatalf("empty input: %v", got)
-	}
-	if got := splitMessage("short", 10); len(got) != 1 || got[0] != "short" {
-		t.Fatalf("short input: %v", got)
-	}
-	chunks := splitMessage("para one\n\npara two\n\npara three", 12)
-	if len(chunks) != 3 {
-		t.Fatalf("expected paragraph split, got %v", chunks)
-	}
-	// Hard cut when no boundary exists.
-	chunks = splitMessage(strings.Repeat("x", 25), 10)
-	if len(chunks) != 3 {
-		t.Fatalf("expected hard cut into 3, got %v", chunks)
-	}
-}
-
 func TestValidateConfig(t *testing.T) {
 	a := &Adapter{}
 	if errs := a.ValidateConfig(channel.PlatformConfig{}); len(errs) != 1 {

--- a/internal/channel/adapters/telegram/telegram_test.go
+++ b/internal/channel/adapters/telegram/telegram_test.go
@@ -225,8 +225,8 @@ func TestSendText_SplitsLongMessages(t *testing.T) {
 		t.Fatalf("expected split into >=2 messages, got %d", len(f.sent))
 	}
 	for _, p := range f.sent {
-		if len([]rune(p["text"].(string))) > maxMessageChars {
-			t.Fatalf("chunk exceeds cap: %d chars", len(p["text"].(string)))
+		if len(p["text"].(string)) > maxMessageBytes {
+			t.Fatalf("chunk exceeds cap: %d bytes", len(p["text"].(string)))
 		}
 	}
 }

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -54,6 +54,12 @@ const (
 	readTimeout = 75 * time.Second
 	// ackTimeout bounds send_frame_and_wait round-trips.
 	ackTimeout = 30 * time.Second
+
+	// maxMessageBytes: WeCom rejects a markdown message whose content exceeds
+	// 4096 bytes with errcode 40058 ("markdown.content exceed max length
+	// 4096") — a hard, documented, byte-counted (not character-counted) cap.
+	// SendText previously sent content as a single unbounded payload (#1116).
+	maxMessageBytes = 4096
 )
 
 func init() {
@@ -187,24 +193,41 @@ func (a *Adapter) Stop() error {
 // connected. Without a connection — channel.SendOnce from octo serve, which
 // runs no inbound adapters — it falls back to the group-robot webhook, which
 // delivers to the webhook's bound group (chatID cannot select a chat there).
+//
+// Content over maxMessageBytes is split into consecutive messages (#1116):
+// WeCom rejects an oversized markdown payload outright (errcode 40058)
+// rather than truncating it, so an unsplit long reply was dropped entirely.
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
+	chunks := channel.SplitForSend(text, maxMessageBytes)
+	if len(chunks) == 0 {
+		return channel.SendResult{OK: true}
+	}
+
 	a.connMu.Lock()
 	connected := a.conn != nil
 	a.connMu.Unlock()
 
-	if !connected {
-		return a.sendWebhook(text)
+	var res channel.SendResult
+	for _, chunk := range chunks {
+		if !connected {
+			res = a.sendWebhook(chunk)
+		} else {
+			_, err := a.sendFrameAndWait("aibot_send_msg", map[string]any{
+				"chatid":   chatID,
+				"msgtype":  "markdown",
+				"markdown": map[string]string{"content": chunk},
+			})
+			if err != nil {
+				res = channel.SendResult{OK: false, Error: err.Error()}
+			} else {
+				res = channel.SendResult{OK: true}
+			}
+		}
+		if !res.OK {
+			return res
+		}
 	}
-
-	_, err := a.sendFrameAndWait("aibot_send_msg", map[string]any{
-		"chatid":   chatID,
-		"msgtype":  "markdown",
-		"markdown": map[string]string{"content": text},
-	})
-	if err != nil {
-		return channel.SendResult{OK: false, Error: err.Error()}
-	}
-	return channel.SendResult{OK: true}
+	return res
 }
 
 // sendWebhook posts a markdown message to the configured group-robot webhook.

--- a/internal/channel/adapters/wecom/wecom_test.go
+++ b/internal/channel/adapters/wecom/wecom_test.go
@@ -243,6 +243,45 @@ func TestSendText_WaitsForAck(t *testing.T) {
 	}
 }
 
+// #1116: SendText previously sent content as a single unbounded payload.
+// WeCom rejects markdown content over 4096 bytes outright (errcode 40058)
+// rather than truncating it, so an unsplit long reply was dropped entirely.
+func TestSendText_SplitsLongMessages(t *testing.T) {
+	f := newFakeWecom(t)
+	a := newTestAdapter(t, f, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go a.Start(ctx, func(channel.InboundEvent) {})
+
+	long := strings.Repeat("word ", 1500) // ~7500 bytes, over maxMessageBytes
+	deadline := time.Now().Add(2 * time.Second)
+	var res channel.SendResult
+	for {
+		res = a.SendText("chat-1", long, "")
+		if res.OK {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("send never succeeded: %+v", res)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sent) < 2 {
+		t.Fatalf("expected split into >=2 messages, got %d", len(f.sent))
+	}
+	for _, frame := range f.sent {
+		md, _ := frame["markdown"].(map[string]any)
+		content, _ := md["content"].(string)
+		if len(content) > maxMessageBytes {
+			t.Fatalf("chunk exceeds cap: %d bytes", len(content))
+		}
+	}
+}
+
 func TestValidateConfig(t *testing.T) {
 	a := &Adapter{}
 	if errs := a.ValidateConfig(channel.PlatformConfig{}); len(errs) != 1 {

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -171,7 +171,14 @@ func (q *sendQueue) sendBatch(chatID string, entries []sendEntry) {
 	// Use the last entry's context_token.
 	ctoken := entries[len(entries)-1].contextToken
 
-	chunks := smartChunkText(combined, maxChunkChars)
+	// #1116: was smartChunkText, a local implementation that converted a
+	// byte offset from strings.LastIndex directly into a rune-slice index —
+	// for CJK text (3 bytes/rune in UTF-8) with a separator late in the
+	// window, that byte offset could exceed len(runes) entirely, panicking
+	// with "slice bounds out of range". channel.SplitForSend cuts on byte
+	// offsets throughout (backing up to a rune boundary only for the final
+	// hard-cut fallback), so this class of bug can't recur.
+	chunks := channel.SplitForSend(combined, maxChunkChars)
 	for _, chunk := range chunks {
 		q.throttle()
 		q.sendWithRetry(chatID, chunk, ctoken)
@@ -950,37 +957,12 @@ func markdownToPlain(text string) string {
 	return strings.TrimSpace(text)
 }
 
-// smartChunkText splits text into ≤N Unicode character chunks, preferring
-// paragraph (double-newline), then line, then space boundaries.
-func smartChunkText(text string, maxChars int) []string {
-	runes := []rune(text)
-	if len(runes) <= maxChars {
-		return []string{text}
-	}
-	var chunks []string
-	for len(runes) > 0 {
-		if len(runes) <= maxChars {
-			chunks = append(chunks, string(runes))
-			break
-		}
-		window := string(runes[:maxChars])
-		cut := maxChars
-		// Prefer \n\n, then \n, then space.
-		for _, sep := range []string{"\n\n", "\n", " "} {
-			if idx := strings.LastIndex(window, sep); idx > 0 {
-				cut = idx + len(sep)
-				break
-			}
-		}
-		chunks = append(chunks, strings.TrimSpace(string(runes[:cut])))
-		runes = runes[cut:]
-		// Trim leading whitespace of remainder.
-		for len(runes) > 0 && (runes[0] == ' ' || runes[0] == '\n') {
-			runes = runes[1:]
-		}
-	}
-	return chunks
-}
+// The length-cap chunker used to live here (smartChunkText); it's now
+// channel.SplitForSend, shared by every adapter (#1116) — see
+// internal/channel/chunking.go. The local version converted a byte offset
+// from strings.LastIndex directly into a rune-slice index, which could
+// panic ("slice bounds out of range") on CJK text with a separator late in
+// the chunk window; SplitForSend cuts on byte offsets throughout instead.
 
 func truncate(s string, max int) string {
 	runes := []rune(s)

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -53,8 +53,11 @@ const (
 	maxBackoff            = 30 * time.Second
 	sessionExpiredBackoff = 60 * time.Second
 
-	// Max text chunk size (Unicode chars, per iLink recommendation).
-	maxChunkChars = 2000
+	// maxChunkBytes: max text chunk size (per iLink recommendation). Named
+	// "Bytes" (not "Chars", its pre-#1116 name) because channel.SplitForSend
+	// counts bytes, not runes — for CJK text (weixin's primary use case)
+	// this is more conservative than a character cap, never less.
+	maxChunkBytes = 2000
 )
 
 // sendQueue buffers outgoing text per chat, flushes on threshold/interval,
@@ -178,7 +181,7 @@ func (q *sendQueue) sendBatch(chatID string, entries []sendEntry) {
 	// with "slice bounds out of range". channel.SplitForSend cuts on byte
 	// offsets throughout (backing up to a rune boundary only for the final
 	// hard-cut fallback), so this class of bug can't recur.
-	chunks := channel.SplitForSend(combined, maxChunkChars)
+	chunks := channel.SplitForSend(combined, maxChunkBytes)
 	for _, chunk := range chunks {
 		q.throttle()
 		q.sendWithRetry(chatID, chunk, ctoken)

--- a/internal/channel/adapters/weixin/weixin_test.go
+++ b/internal/channel/adapters/weixin/weixin_test.go
@@ -379,18 +379,6 @@ func TestExtractText_QuotedMessage(t *testing.T) {
 	}
 }
 
-func TestSmartChunkText(t *testing.T) {
-	chunks := smartChunkText("hello", 10)
-	if len(chunks) != 1 || chunks[0] != "hello" {
-		t.Fatalf("unexpected chunks: %v", chunks)
-	}
-
-	chunks = smartChunkText("hello world foo bar", 5)
-	if len(chunks) < 2 {
-		t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
-	}
-}
-
 func TestMarkdownToPlain(t *testing.T) {
 	md := "**bold** and *italic* and [link](http://x)"
 	plain := markdownToPlain(md)

--- a/internal/channel/chunking.go
+++ b/internal/channel/chunking.go
@@ -1,0 +1,150 @@
+package channel
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// maxFenceLangRunes bounds how much of a code fence's language tag
+// (```python, ```go, …) we echo back when reopening it across a chunk
+// boundary — a model could in principle put something absurdly long after
+// the backticks, and that string factors directly into fenceOverhead below.
+const maxFenceLangRunes = 20
+
+// fenceOverhead reserves room, inside each chunk's byte budget, for the
+// synthetic markdown a straddled code fence needs: a closing "\n```" (4
+// bytes) at the end of one chunk and a reopening "```lang\n" line at the
+// start of the next. Sized for the worst case (a maxFenceLangRunes-rune
+// language tag, ASCII) plus slack.
+const fenceOverhead = 4 + 3 + maxFenceLangRunes + 1 + 8
+
+// SplitForSend splits text into chunks whose UTF-8 byte length does not
+// exceed limit, for handing to a channel adapter's SendText where the
+// platform enforces a hard per-message size cap (Discord: 2000, WeCom's
+// markdown content: 4096 bytes, …). Without this, a reply longer than the
+// cap either gets rejected outright (Discord) or silently truncated
+// server-side — the routine case of a long agentic answer just never
+// arrives, with nothing telling the user why (#1116).
+//
+// Cuts prefer a paragraph break, then a line break, then a space, and only
+// hard-cut (always at a valid UTF-8 rune boundary — never a valid char is
+// split) as a last resort.
+//
+// limit is a byte count, not a rune count: WeCom's cap is documented in
+// bytes, and measuring in bytes is a strict superset of safety for
+// platforms whose real limit is characters or UTF-16 units (Discord,
+// Telegram) — the byte count of any string is never smaller than its
+// UTF-16-unit or rune count, so this can only split a bit earlier than a
+// character-counting platform strictly requires, never later.
+//
+// If a fenced code block (```lang ... ```) straddles a cut point, the fence
+// is closed at the end of one chunk and reopened with the same language tag
+// at the start of the next, so every chunk is complete, valid markdown on
+// its own instead of rendering as a permanently-broken code block split
+// across two IM messages.
+func SplitForSend(text string, limit int) []string {
+	if text == "" {
+		return nil
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	if len(text) <= limit {
+		return []string{text}
+	}
+
+	var chunks []string
+	fenceOpen := false
+	fenceLang := ""
+
+	for len(text) > 0 {
+		budget := limit
+		if fenceOpen {
+			budget -= fenceOverhead
+			if budget < 1 {
+				budget = 1
+			}
+		}
+		if len(text) <= budget {
+			chunks = append(chunks, reopenFence(fenceOpen, fenceLang, text))
+			break
+		}
+
+		cut := cutPoint(text, budget)
+		piece := text[:cut]
+		rest := strings.TrimLeft(text[cut:], " \n")
+
+		open, lang := fenceStateAfter(piece, fenceOpen, fenceLang)
+		chunk := reopenFence(fenceOpen, fenceLang, piece)
+		if open {
+			chunk = strings.TrimRight(chunk, "\n") + "\n```"
+		}
+		chunks = append(chunks, strings.TrimRight(chunk, " \n"))
+
+		fenceOpen, fenceLang = open, lang
+		text = rest
+	}
+	return chunks
+}
+
+// cutPoint returns a byte offset within the first limit bytes of text to
+// cut at, preferring (in order) the last paragraph break, line break, or
+// space in that window; falling back to a hard cut at limit. The hard-cut
+// fallback always lands on a valid UTF-8 rune boundary and always makes
+// forward progress (at least one full rune), even if limit is smaller than
+// that rune's encoded size.
+func cutPoint(text string, limit int) int {
+	if limit >= len(text) {
+		return len(text)
+	}
+	window := text[:limit]
+	for _, sep := range []string{"\n\n", "\n", " "} {
+		if idx := strings.LastIndex(window, sep); idx > 0 {
+			return idx + len(sep)
+		}
+	}
+	cut := limit
+	for cut > 0 && !utf8.RuneStart(text[cut]) {
+		cut--
+	}
+	if cut == 0 {
+		_, size := utf8.DecodeRuneInString(text)
+		cut = size
+	}
+	return cut
+}
+
+// fenceStateAfter reports whether a ``` code fence is still open after
+// text, given it started in state (startOpen, startLang). Fence markers are
+// recognized on their own (trimmed) line starting with "```", matching the
+// common case every LLM-generated markdown fence uses — it does not track
+// fence length (````-nested fences) or ~~~ fences, both rare enough in
+// agent output that the added complexity isn't worth it here.
+func fenceStateAfter(text string, startOpen bool, startLang string) (open bool, lang string) {
+	open, lang = startOpen, startLang
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "```") {
+			continue
+		}
+		if open {
+			open, lang = false, ""
+			continue
+		}
+		open = true
+		lang = strings.TrimSpace(strings.TrimPrefix(trimmed, "```"))
+		if r := []rune(lang); len(r) > maxFenceLangRunes {
+			lang = string(r[:maxFenceLangRunes])
+		}
+	}
+	return open, lang
+}
+
+// reopenFence prepends a "```lang\n" line to body when a fence is open;
+// returns body unchanged otherwise.
+func reopenFence(open bool, lang, body string) string {
+	if !open {
+		return body
+	}
+	return "```" + lang + "\n" + body
+}

--- a/internal/channel/chunking.go
+++ b/internal/channel/chunking.go
@@ -8,15 +8,12 @@ import (
 // maxFenceLangRunes bounds how much of a code fence's language tag
 // (```python, ```go, …) we echo back when reopening it across a chunk
 // boundary — a model could in principle put something absurdly long after
-// the backticks, and that string factors directly into fenceOverhead below.
+// the backticks.
 const maxFenceLangRunes = 20
 
-// fenceOverhead reserves room, inside each chunk's byte budget, for the
-// synthetic markdown a straddled code fence needs: a closing "\n```" (4
-// bytes) at the end of one chunk and a reopening "```lang\n" line at the
-// start of the next. Sized for the worst case (a maxFenceLangRunes-rune
-// language tag, ASCII) plus slack.
-const fenceOverhead = 4 + 3 + maxFenceLangRunes + 1 + 8
+// closeMarkerBytes is the exact byte cost of the synthetic "\n```" appended
+// when a piece ends with a fence still open.
+const closeMarkerBytes = len("\n```")
 
 // SplitForSend splits text into chunks whose UTF-8 byte length does not
 // exceed limit, for handing to a channel adapter's SendText where the
@@ -41,7 +38,15 @@ const fenceOverhead = 4 + 3 + maxFenceLangRunes + 1 + 8
 // is closed at the end of one chunk and reopened with the same language tag
 // at the start of the next, so every chunk is complete, valid markdown on
 // its own instead of rendering as a permanently-broken code block split
-// across two IM messages.
+// across two IM messages. The reopen/close overhead is reserved from the
+// budget dynamically (based on the real byte length of whatever's actually
+// being reopened/closed), not a fixed guess, so this holds regardless of
+// the fence's language tag — see the retry inside the loop below.
+//
+// limit is assumed to be at least a few dozen bytes, matching every current
+// adapter (smallest is Discord's 2000) — for a limit small enough that even
+// one rune plus fence markup can't fit, individual chunks can exceed limit;
+// that's an intentionally unhandled degenerate case, not a realistic one.
 func SplitForSend(text string, limit int) []string {
 	if text == "" {
 		return nil
@@ -58,13 +63,19 @@ func SplitForSend(text string, limit int) []string {
 	fenceLang := ""
 
 	for len(text) > 0 {
-		budget := limit
+		// Reserve room for reopening a fence carried over from the previous
+		// chunk (exact byte cost of "```" + the actual tag + "\n" — computed
+		// from the real fenceLang bytes, not an assumed-ASCII estimate, so a
+		// multi-byte-rune tag is budgeted correctly too).
+		reopenCost := 0
 		if fenceOpen {
-			budget -= fenceOverhead
-			if budget < 1 {
-				budget = 1
-			}
+			reopenCost = len("```") + len(fenceLang) + len("\n")
 		}
+		budget := limit - reopenCost
+		if budget < 1 {
+			budget = 1
+		}
+
 		if len(text) <= budget {
 			chunks = append(chunks, reopenFence(fenceOpen, fenceLang, text))
 			break
@@ -72,9 +83,30 @@ func SplitForSend(text string, limit int) []string {
 
 		cut := cutPoint(text, budget)
 		piece := text[:cut]
-		rest := strings.TrimLeft(text[cut:], " \n")
-
 		open, lang := fenceStateAfter(piece, fenceOpen, fenceLang)
+
+		// A fence can open for the FIRST time inside this very piece — not
+		// just carry over from the previous chunk — and budget above didn't
+		// reserve for that case. If the piece still ends open (whether it
+		// started that way or opened partway through), re-cut with the
+		// closing "\n```" reserved too, so the synthetic closer this loop is
+		// about to append never pushes the chunk past limit. cutPoint with a
+		// smaller budget always returns a cut at or before the original (its
+		// search window is a byte-for-byte prefix of the wider one), so this
+		// single retry is enough — no risk of looping.
+		if open {
+			closeBudget := budget - closeMarkerBytes
+			if closeBudget < 1 {
+				closeBudget = 1
+			}
+			if closeBudget < cut {
+				cut = cutPoint(text, closeBudget)
+				piece = text[:cut]
+				open, lang = fenceStateAfter(piece, fenceOpen, fenceLang)
+			}
+		}
+
+		rest := strings.TrimLeft(text[cut:], " \n")
 		chunk := reopenFence(fenceOpen, fenceLang, piece)
 		if open {
 			chunk = strings.TrimRight(chunk, "\n") + "\n```"

--- a/internal/channel/chunking_test.go
+++ b/internal/channel/chunking_test.go
@@ -90,11 +90,18 @@ func isValidUTF8Chunk(s string) bool {
 func TestSplitForSend_ClosesAndReopensStraddledFence(t *testing.T) {
 	code := strings.Repeat("line_of_code()\n", 100)
 	text := "intro\n\n```go\n" + code + "```\n\nend"
-	chunks := SplitForSend(text, 400)
+	const limit = 400
+	chunks := SplitForSend(text, limit)
 	if len(chunks) < 2 {
 		t.Fatalf("expected the fence to force multiple chunks, got %d", len(chunks))
 	}
 	for i, c := range chunks {
+		// The synthetic close/reopen markup must never push a chunk over the
+		// requested limit — see TestSplitForSend_FenceOverheadNeverExceedsLimit
+		// for the case that caught this as a real bug.
+		if len(c) > limit {
+			t.Errorf("chunk %d is %d bytes, over the %d limit:\n%s", i, len(c), limit, c)
+		}
 		open, _ := fenceStateAfter(c, false, "")
 		if open {
 			t.Errorf("chunk %d ends with an unclosed fence:\n%s", i, c)
@@ -110,6 +117,42 @@ func TestSplitForSend_ClosesAndReopensStraddledFence(t *testing.T) {
 	for i := 1; i < len(chunks)-1; i++ {
 		if !strings.HasPrefix(chunks[i], "```go\n") {
 			t.Errorf("chunk %d should reopen the go fence, got prefix %q", i, chunks[i][:min(20, len(chunks[i]))])
+		}
+	}
+}
+
+// #1116 review finding: a fence that opens for the FIRST TIME inside the
+// current piece (not carried over from a previous chunk) wasn't budgeted
+// for — cutPoint picked a cut using the full, unreserved limit, and only
+// afterward did the code discover the piece ends mid-fence and append a
+// synthetic "\n```" that pushed the chunk past limit. Reproduced directly
+// against the fix in code review before this test existed: with the bug,
+// chunk 0 below came out at 52 bytes against a 50-byte limit.
+func TestSplitForSend_FenceOverheadNeverExceedsLimit(t *testing.T) {
+	text := "```go\n" + strings.Repeat("a", 42) + "\n" + strings.Repeat("bcdefghij", 20) + "\n```\n\nend"
+	const limit = 50
+	chunks := SplitForSend(text, limit)
+	for i, c := range chunks {
+		if len(c) > limit {
+			t.Errorf("chunk %d is %d bytes, over the %d limit: %q", i, len(c), limit, c)
+		}
+	}
+	if !strings.Contains(strings.Join(chunks, ""), "end") {
+		t.Fatal("lost trailing content after the fence closes")
+	}
+}
+
+// A language tag longer than maxFenceLangRunes must still be reserved for
+// correctly — the overhead calculation must use the ALREADY-TRUNCATED tag's
+// real byte length, not the model's original (possibly much longer) one.
+func TestSplitForSend_LongLanguageTagStillRespectsLimit(t *testing.T) {
+	longTag := strings.Repeat("x", 100) // far past maxFenceLangRunes (20)
+	text := "```" + longTag + "\n" + strings.Repeat("code line\n", 50) + "```\n"
+	const limit = 100
+	chunks := SplitForSend(text, limit)
+	for i, c := range chunks {
+		if len(c) > limit {
+			t.Errorf("chunk %d is %d bytes, over the %d limit: %q", i, len(c), limit, c)
 		}
 	}
 }

--- a/internal/channel/chunking_test.go
+++ b/internal/channel/chunking_test.go
@@ -1,0 +1,153 @@
+package channel
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplitForSend_UnderLimit(t *testing.T) {
+	got := SplitForSend("hello", 100)
+	if len(got) != 1 || got[0] != "hello" {
+		t.Fatalf("got %#v, want a single unmodified chunk", got)
+	}
+}
+
+func TestSplitForSend_Empty(t *testing.T) {
+	if got := SplitForSend("", 100); got != nil {
+		t.Fatalf("got %#v, want nil", got)
+	}
+}
+
+// #1116: Discord's SendText posted content as-is with no cap at all — any
+// reply over 2000 chars got HTTP 400 and vanished entirely. This pins that
+// oversized text now comes back as multiple chunks, each within the limit.
+func TestSplitForSend_OversizedTextProducesMultipleChunksWithinLimit(t *testing.T) {
+	text := strings.Repeat("a paragraph of plain prose. ", 200) // ~5800 bytes
+	chunks := SplitForSend(text, 2000)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	for i, c := range chunks {
+		if len(c) > 2000 {
+			t.Errorf("chunk %d is %d bytes, over the 2000 limit", i, len(c))
+		}
+	}
+	// Splitting must not lose or duplicate content.
+	if got := strings.Join(chunks, " "); strings.ReplaceAll(got, " ", "") != strings.ReplaceAll(text, " ", "") {
+		// Whitespace at cut points is normalized (trimmed), so compare with
+		// spaces stripped rather than asserting byte-identical rejoin.
+		t.Fatalf("rejoined chunks lost or altered content")
+	}
+}
+
+func TestSplitForSend_PrefersParagraphOverHardCut(t *testing.T) {
+	text := strings.Repeat("x", 50) + "\n\n" + strings.Repeat("y", 50)
+	chunks := SplitForSend(text, 60)
+	if len(chunks) != 2 {
+		t.Fatalf("got %d chunks, want 2", len(chunks))
+	}
+	if chunks[0] != strings.Repeat("x", 50) {
+		t.Errorf("chunk 0 = %q, want the first paragraph cleanly", chunks[0])
+	}
+	if chunks[1] != strings.Repeat("y", 50) {
+		t.Errorf("chunk 1 = %q, want the second paragraph cleanly", chunks[1])
+	}
+}
+
+// A cut point landing mid-multi-byte-rune must back up to a full rune —
+// this is the exact class of bug found in weixin.go's smartChunkText, which
+// converts a byte offset from strings.LastIndex into a rune count without
+// re-deriving it correctly for the *hard-cut* fallback path.
+func TestSplitForSend_NeverSplitsARuneInHalf(t *testing.T) {
+	text := strings.Repeat("中文字符测试", 100) // no spaces/newlines — forces hard cuts
+	chunks := SplitForSend(text, 50)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	for i, c := range chunks {
+		if !isValidUTF8Chunk(c) {
+			t.Errorf("chunk %d is not valid UTF-8: %q", i, c)
+		}
+	}
+	if strings.Join(chunks, "") != text {
+		t.Fatalf("rejoined chunks (no separators to trim here) must equal the original exactly")
+	}
+}
+
+func isValidUTF8Chunk(s string) bool {
+	for _, r := range s {
+		if r == '�' {
+			return false
+		}
+	}
+	return true
+}
+
+// #1116, item 3: a code fence straddling a cut point must close at the end
+// of one chunk and reopen (same language tag) at the start of the next,
+// instead of leaving an unclosed fence in one message and an un-opened
+// continuation in another.
+func TestSplitForSend_ClosesAndReopensStraddledFence(t *testing.T) {
+	code := strings.Repeat("line_of_code()\n", 100)
+	text := "intro\n\n```go\n" + code + "```\n\nend"
+	chunks := SplitForSend(text, 400)
+	if len(chunks) < 2 {
+		t.Fatalf("expected the fence to force multiple chunks, got %d", len(chunks))
+	}
+	for i, c := range chunks {
+		open, _ := fenceStateAfter(c, false, "")
+		if open {
+			t.Errorf("chunk %d ends with an unclosed fence:\n%s", i, c)
+		}
+		trimmed := strings.TrimSpace(c)
+		if strings.Contains(trimmed, "```") && !strings.HasPrefix(trimmed, "```") {
+			// fine — a fence can close mid-chunk (the final one, "```\n\nend")
+			continue
+		}
+	}
+	// Every chunk after the first that contains code lines must open with a
+	// reopened ```go fence (not resume mid-code with no fence marker at all).
+	for i := 1; i < len(chunks)-1; i++ {
+		if !strings.HasPrefix(chunks[i], "```go\n") {
+			t.Errorf("chunk %d should reopen the go fence, got prefix %q", i, chunks[i][:min(20, len(chunks[i]))])
+		}
+	}
+}
+
+func TestFenceStateAfter(t *testing.T) {
+	cases := []struct {
+		name     string
+		text     string
+		wantOpen bool
+		wantLang string
+	}{
+		{"no fence", "plain text", false, ""},
+		{"opens untagged", "```\ncode", true, ""},
+		{"opens tagged", "```python\ncode", true, "python"},
+		{"opens and closes", "```go\ncode\n```", false, ""},
+		{"already open, closes", "code\n```", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			open, lang := fenceStateAfter(c.text, false, "")
+			if c.name == "already open, closes" {
+				open, lang = fenceStateAfter(c.text, true, "go")
+			}
+			if open != c.wantOpen || lang != c.wantLang {
+				t.Errorf("got (%v, %q), want (%v, %q)", open, lang, c.wantOpen, c.wantLang)
+			}
+		})
+	}
+}
+
+func TestReopenFence(t *testing.T) {
+	if got := reopenFence(false, "go", "body"); got != "body" {
+		t.Errorf("closed fence should not modify body, got %q", got)
+	}
+	if got := reopenFence(true, "go", "body"); got != "```go\nbody" {
+		t.Errorf("got %q, want reopened fence prefix", got)
+	}
+	if got := reopenFence(true, "", "body"); got != "```\nbody" {
+		t.Errorf("got %q, want bare reopened fence prefix", got)
+	}
+}

--- a/internal/channel/ui_controller.go
+++ b/internal/channel/ui_controller.go
@@ -34,6 +34,18 @@ type UIController struct {
 	// only the newest chunk would erase what the user already read.
 	sentText string
 
+	// fenceOpen/fenceLang track a ``` code fence left open by the last text
+	// actually handed to adapter.SendText (#1116). Every SendText call
+	// produces its own standalone IM message — unlike UpdateMessage, which
+	// redraws the full cumulative text each time and so "sees" the true,
+	// complete fence state on its own. A fence opened in one flush and
+	// closed in a later one would otherwise render as a permanently broken
+	// code block on any platform without in-place edits (DingTalk/WeCom/
+	// Weixin: every flush is a SendText call), or after an edit-size-cap
+	// fallback freezes an edit-capable platform's message mid-fence.
+	fenceOpen bool
+	fenceLang string
+
 	// toolCount tracks how many tools have started (for suppression heuristics).
 	toolCount int
 
@@ -160,21 +172,40 @@ func (u *UIController) flushTextLocked() {
 		}
 		// Edit failed (platform edit-size cap, message deleted): fall through
 		// and continue in a fresh message carrying just the not-yet-shown
-		// chunk. The old message keeps its last successfully edited content,
-		// so nothing the user saw is lost.
+		// chunk. The old message keeps its last successfully edited content —
+		// u.sentText, pre-delta — and that's now frozen, so recompute the
+		// fence state from that actual displayed text (#1116). u.fenceOpen
+		// only ever tracked SendText calls, which for an edit-capable
+		// platform means it's stale by everything shown via edits since.
+		u.fenceOpen, u.fenceLang = fenceStateAfter(u.sentText, false, "")
 	}
 
-	res := u.adapter.SendText(u.chatID, strings.TrimSpace(chunk), u.replyTo)
+	// #1116: this chunk becomes its own standalone message. If a fence was
+	// left open by whatever was last actually sent — the previous flush's
+	// SendText, or the frozen content of a message an edit-cap fallback just
+	// abandoned above — reopen it here, and close it again if this chunk
+	// itself ends mid-fence, so a code block spanning two messages still
+	// renders as valid markdown in both.
+	trimmed := strings.TrimSpace(chunk)
+	sendText := reopenFence(u.fenceOpen, u.fenceLang, trimmed)
+	open, lang := fenceStateAfter(trimmed, u.fenceOpen, u.fenceLang)
+	if open {
+		sendText = strings.TrimRight(sendText, "\n") + "\n```"
+	}
+
+	res := u.adapter.SendText(u.chatID, sendText, u.replyTo)
 	if res.OK {
 		u.pendingTextMsgID = res.MessageID
 		u.sentText = chunk
+		u.fenceOpen, u.fenceLang = open, lang
 		return
 	}
 	// Both the edit (if attempted) and the fresh send failed. Put the chunk
-	// back into the buffer instead of dropping it forever: pendingTextMsgID
-	// and sentText are left untouched (still tracking the old message's true
-	// last-shown content), and the next flush — a later delta, or the
-	// turn-end flush — retries this text along with whatever comes after it.
+	// back into the buffer instead of dropping it forever: pendingTextMsgID,
+	// sentText, and the fence state are left untouched (still tracking the
+	// old message's true last-shown content), and the next flush — a later
+	// delta, or the turn-end flush — retries this text along with whatever
+	// comes after it.
 	u.textBuf.WriteString(chunk)
 }
 
@@ -183,6 +214,8 @@ func (u *UIController) resetLocked() {
 	u.textBuf.Reset()
 	u.pendingTextMsgID = ""
 	u.sentText = ""
+	u.fenceOpen = false
+	u.fenceLang = ""
 	u.toolCount = 0
 	u.inTool = false
 	u.sentTyping = false
@@ -203,6 +236,15 @@ func shouldFlush(buf string) bool {
 	if n := len(buf); n > 2 {
 		c := buf[n-2]
 		if (c == '.' || c == '!' || c == '?') && (buf[n-1] == ' ' || buf[n-1] == '\n') {
+			return true
+		}
+	}
+	// #1116: the check above is ASCII-only, so CJK prose never flushed on a
+	// sentence boundary — only on \n\n or the 800-byte cap. Chinese/Japanese
+	// sentence-ending punctuation (。！？) isn't followed by a space the way
+	// English is; the punctuation itself is the boundary.
+	for _, p := range [...]string{"。", "！", "？"} {
+		if strings.HasSuffix(buf, p) {
 			return true
 		}
 	}

--- a/internal/channel/ui_controller_test.go
+++ b/internal/channel/ui_controller_test.go
@@ -118,6 +118,21 @@ func TestUIController_ShouldFlush(t *testing.T) {
 	if shouldFlush("Hel") {
 		t.Error("expected no flush on short text")
 	}
+	// #1116: the ASCII-only sentence check never flushed CJK prose, which
+	// doesn't put a space after 。！？ the way English does after . ! ? —
+	// only the 800-byte cap or \n\n ever flushed Chinese/Japanese text.
+	if !shouldFlush("你好，世界。") {
+		t.Error("expected flush on CJK period 。")
+	}
+	if !shouldFlush("太好了！") {
+		t.Error("expected flush on CJK exclamation ！")
+	}
+	if !shouldFlush("真的吗？") {
+		t.Error("expected flush on CJK question mark ？")
+	}
+	if shouldFlush("还没说完") {
+		t.Error("expected no flush on CJK text with no sentence-ending punctuation")
+	}
 }
 
 func TestUIController_Truncate(t *testing.T) {
@@ -363,5 +378,88 @@ func TestUIController_DoubleFailureRetriesChunk(t *testing.T) {
 	}
 	if want := "One.\n\nTwo.\n\nThree."; updates[0].text != want {
 		t.Fatalf("retried chunk must survive:\nwant %q\ngot  %q", want, updates[0].text)
+	}
+}
+
+// #1116: on a platform without in-place edits, every flush is its own
+// standalone IM message. A code fence spanning two flushes must close at
+// the end of the first message and reopen (same language tag) at the start
+// of the second — otherwise the first message renders a permanently
+// unclosed code block and the second resumes mid-code with no fence at all.
+func TestUIController_NoUpdatesPlatformCarriesFenceAcrossFlushes(t *testing.T) {
+	mock := &mockAdapter{platform: "mock", issueMsgIDs: true, noUpdates: true}
+	ctrl := NewUIController(mock, "chat1", "")
+	handler := ctrl.Handler()
+
+	// Flush 1 (paragraph-break heuristic fires mid-fence): the buffer has an
+	// opened but not yet closed ```go block.
+	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "```go\nline1\n\n"})
+	// Flush 2 (turn end): the fence closes here, with more text after it.
+	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "line2\n```\n\nDone"})
+	handler(agent.AgentEvent{Kind: agent.EventTurnDone, Reply: &agent.Reply{}})
+
+	mock.mu.Lock()
+	texts := make([]string, len(mock.sentTexts))
+	for i, s := range mock.sentTexts {
+		texts[i] = s.text
+	}
+	mock.mu.Unlock()
+	if len(texts) != 2 {
+		t.Fatalf("expected 2 messages, got %d: %v", len(texts), texts)
+	}
+	if want := "```go\nline1\n```"; texts[0] != want {
+		t.Errorf("message 1:\nwant %q\ngot  %q", want, texts[0])
+	}
+	if want := "```go\nline2\n```\n\nDone"; texts[1] != want {
+		t.Errorf("message 2:\nwant %q\ngot  %q", want, texts[1])
+	}
+	for i, text := range texts {
+		if open, _ := fenceStateAfter(text, false, ""); open {
+			t.Errorf("message %d ends with an unclosed fence: %q", i, text)
+		}
+	}
+}
+
+// #1116: when an in-place edit fails partway through a code block, the
+// fallback to a fresh SendText message must reopen the fence based on the
+// FROZEN message's actual content (u.sentText) — not on some earlier
+// SendText call's fence state, which predates everything the user has seen
+// via edits since and would be stale.
+func TestUIController_EditFailureRecomputesFenceFromFrozenText(t *testing.T) {
+	mock := &mockAdapter{platform: "mock", issueMsgIDs: true}
+	ctrl := NewUIController(mock, "chat1", "")
+	handler := ctrl.Handler()
+
+	// Flush 1 (SendText — no pending message yet): plain text, no fence.
+	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "Intro.\n\n"})
+	// Flush 2 (successful edit): opens a fence inside the edited message.
+	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "```go\nfunc foo() {\n\n"})
+
+	mock.mu.Lock()
+	if len(mock.sentTexts) != 1 {
+		t.Fatalf("expected exactly 1 SendText (the first message), got %d", len(mock.sentTexts))
+	}
+	if len(mock.updatedMsgs) != 1 {
+		t.Fatalf("expected exactly 1 successful edit, got %d", len(mock.updatedMsgs))
+	}
+	// Now the edit-size cap kicks in for the next flush.
+	mock.failUpdates = true
+	mock.mu.Unlock()
+
+	// Flush 3 (turn end, edit fails): closes the fence and adds trailing text.
+	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "more code\n```\n\nDone"})
+	handler(agent.AgentEvent{Kind: agent.EventTurnDone, Reply: &agent.Reply{}})
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.sentTexts) != 2 {
+		t.Fatalf("expected a second standalone message after the edit failed, got %d sends", len(mock.sentTexts))
+	}
+	fallback := mock.sentTexts[1].text
+	if want := "```go\nmore code\n```\n\nDone"; fallback != want {
+		t.Errorf("fallback message:\nwant %q\ngot  %q", want, fallback)
+	}
+	if open, _ := fenceStateAfter(fallback, false, ""); open {
+		t.Errorf("fallback message ends with an unclosed fence: %q", fallback)
 	}
 }


### PR DESCRIPTION
## Summary
- **Discord's `SendText` had no length cap at all** — any reply over 2000 chars got HTTP 400 and vanished entirely, with no user-visible error. Feishu, DingTalk, and WeCom had the same gap; only Telegram and Weixin split at all, each with its own local implementation.
- Added `channel.SplitForSend` (`internal/channel/chunking.go`) — one splitter shared by every adapter, parameterized per platform's cap:
  - Discord 2000 / WeCom 4096 — both hard, documented **byte** limits (WeCom: errcode 40058 past 4096 bytes)
  - Telegram 4000 / Weixin 2000 — kept as-is
  - Feishu / DingTalk — conservative 20000-byte backstop (their real limits are far larger than any normal reply)
  - Measures in **bytes**, not runes: byte-counting is a strict superset of safety for platforms whose real limit is characters or UTF-16 units.
  - If a ` ``` ` fence straddles a cut point, it's closed at the end of one chunk and reopened with the same language tag at the start of the next — every chunk is complete, valid markdown on its own.
- **Migrating Telegram and Weixin to the shared splitter surfaced a latent, reproducible panic**: Weixin's `smartChunkText` converted a byte offset from `strings.LastIndex` directly into a rune-slice index. For CJK text (3 bytes/rune in UTF-8) with a separator late in the chunk window, that byte offset can exceed `len(runes)` — `slice bounds out of range`. Verified with a throwaway repro before writing the fix (not included in the diff). `SplitForSend` cuts on byte offsets throughout, only converting to a rune boundary for the final hard-cut fallback, so this class of bug can't recur.
- Extended the same fence-awareness to `internal/channel/ui_controller.go`, which decides when to flush the *live* streaming buffer — a separate layer from the length-cap splitter. On platforms without in-place message edits (DingTalk/WeCom/Weixin), every flush is its own permanent standalone message, so a fence opened in one flush and closed in a later one needs the same close/reopen treatment. On edit-capable platforms this is normally a no-op (edits redraw the full cumulative text, so a transient open fence self-heals) — except right after an edit-size-cap failure freezes a message mid-fence, where the fallback recomputes fence state from the actual frozen text rather than any earlier `SendText` call's tracked state (which would be stale).
- Added CJK sentence-ending punctuation (。！？) to `shouldFlush`'s boundary check, which was ASCII-only — Chinese/Japanese prose doesn't put a space after 。！？ the way English does after `. ! ?`, so it previously only flushed on `\n\n` or the 800-byte cap.

Fixes #1116

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — full repo green
- [x] New: `internal/channel/chunking_test.go` — `SplitForSend` byte-capping, paragraph/line/space cut preference, rune-boundary safety on hard cuts, fence close/reopen across a straddled cut
- [x] New: per-adapter `TestSendText_SplitsLongMessages` for Discord/Feishu/DingTalk/WeCom (Telegram/Weixin already had integration coverage through the public `SendText` API, unaffected by the internal swap)
- [x] New: `TestUIController_NoUpdatesPlatformCarriesFenceAcrossFlushes`, `TestUIController_EditFailureRecomputesFenceFromFrozenText` — pin the two fence-carrying scenarios at the streaming-flush layer
- [x] Extended `TestUIController_ShouldFlush` with CJK punctuation cases
- [ ] Manual: send an agent reply longer than 2000 chars to a real Discord channel — confirm it now arrives (previously silently dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)