### PR TITLE
fix(channel): log skips, surface issues, and retry crashed adapters

### DIFF
--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -224,7 +224,12 @@ func (m *Manager) Start(ctx context.Context) error {
 	for _, name := range m.cfg.EnabledPlatforms() {
 		pc := m.cfg.Platform(name)
 		if pc == nil {
-			continue // not in Config.Channels at all — EnabledPlatforms shouldn't produce this, but no name to log against either way
+			// Shouldn't happen — EnabledPlatforms is derived from Config.Channels,
+			// so every name it yields should resolve back to a config here — but
+			// log it like every other skip in this loop rather than silently
+			// continuing, in case that invariant is ever violated.
+			slog.Error("channel start failed: enabled platform has no config", "channel", name)
+			continue
 		}
 		ctor, err := Find(name)
 		if err != nil {

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -3,6 +3,7 @@ package channel
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"sync"
@@ -223,26 +224,41 @@ func (m *Manager) Start(ctx context.Context) error {
 	for _, name := range m.cfg.EnabledPlatforms() {
 		pc := m.cfg.Platform(name)
 		if pc == nil {
-			continue
+			continue // not in Config.Channels at all — EnabledPlatforms shouldn't produce this, but no name to log against either way
 		}
 		ctor, err := Find(name)
 		if err != nil {
-			continue // adapter not registered, skip
+			slog.Error("channel start failed: adapter not registered", "channel", name, "err", err)
+			continue
 		}
 		ad, err := ctor(pc)
 		if err != nil {
-			continue // construction failed, skip
+			slog.Error("channel start failed: construction failed", "channel", name, "err", err)
+			continue
 		}
 		if errs := ad.ValidateConfig(pc); len(errs) > 0 {
-			continue // invalid config, skip
+			for _, e := range errs {
+				slog.Warn("channel config issue", "channel", name, "detail", e)
+			}
+			continue
 		}
 		m.adapters.Store(name, ad)
 
+		// #1121: the run error used to be discarded (`_ = a.Start(...)`), so
+		// an adapter crash mid-session (auth revoked, websocket dies
+		// unrecoverably) went dead with zero diagnostics — the only symptom
+		// was "the bot never replies". Logging it here at least gets the
+		// reason into octo serve's own log; internal/server's parallel
+		// startOneChannelLocked/runChannelWithRestart (the path octo serve
+		// actually runs) goes further and also retries with backoff and
+		// records the reason somewhere queryable (GET /api/channels).
 		go func(a Adapter, platform string) {
-			_ = a.Start(ctx, func(ev InboundEvent) {
+			if err := a.Start(ctx, func(ev InboundEvent) {
 				ev.Platform = platform
 				m.handleInbound(ctx, ev)
-			})
+			}); err != nil && ctx.Err() == nil {
+				slog.Error("channel adapter exited unexpectedly", "channel", platform, "err", err)
+			}
 		}(ad, name)
 	}
 

--- a/internal/server/channel_restart_test.go
+++ b/internal/server/channel_restart_test.go
@@ -22,6 +22,14 @@ type crashingAdapterState struct {
 	failCount   int32   // Start fails this many times total, across all instances
 	constructed int32   // instances built so far
 	startedOn   []int32 // construction id Start was invoked on, in call order
+
+	// gateConstruction/ctorGate let a test deterministically land a restart
+	// loop's rebuild inside its ctor(pc) call — the one gap that doesn't
+	// observe ctx cancellation — so a concurrent stop/reload can race it.
+	// The construction with id == gateConstruction blocks until ctorGate is
+	// closed; every other construction proceeds immediately.
+	gateConstruction int32
+	ctorGate         chan struct{}
 }
 
 // crashingFakeAdapter fails its first N Start calls (simulating a crash —
@@ -42,7 +50,12 @@ func newCrashingAdapterCtorWithState(state *crashingAdapterState, failCount int3
 		state.mu.Lock()
 		state.constructed++
 		id := state.constructed
+		gate := state.ctorGate
+		gateID := state.gateConstruction
 		state.mu.Unlock()
+		if gate != nil && id == gateID {
+			<-gate
+		}
 		return &crashingFakeAdapter{id: id, state: state}, nil
 	}
 }
@@ -159,6 +172,110 @@ func TestChannelRestart_RecoversFromTransientCrash(t *testing.T) {
 			t.Errorf("instance %d had Start called on it more than once — should rebuild fresh each retry", id)
 		}
 		seen[id] = true
+	}
+}
+
+// A crashed adapter's restart loop rebuilds via ctor(pc) — a call that does
+// not observe ctx cancellation — before writing the fresh instance back to
+// runningAdapters. If an operator stops/reloads the same platform while that
+// rebuild is still in flight (entirely plausible: this fix is what makes the
+// crash visible as an "Error" status in the Channels view in the first
+// place, which is exactly what would prompt someone to intervene), the
+// generation check added alongside runningAdapters.Store must detect it's
+// been superseded and discard the stale instance instead of clobbering the
+// reload's fresh one.
+func TestChannelRestart_ConcurrentReloadDuringRebuildDiscardsStaleInstance(t *testing.T) {
+	orig := channelRestartDelays
+	channelRestartDelays = []time.Duration{time.Millisecond}
+	t.Cleanup(func() { channelRestartDelays = orig })
+
+	state := &crashingAdapterState{}
+	// Instance #1's Start crashes once; instance #2 (the stale rebuild) is
+	// gated so the test can hold it inside ctor(pc); instance #3 (the
+	// reload's fresh start) must succeed and keep running.
+	channel.Register("crashfake-superseded", newCrashingAdapterCtorWithState(state, 1))
+	state.ctorGate = make(chan struct{})
+	state.gateConstruction = 2
+
+	writeChannelsYML(t, "channels:\n  crashfake-superseded:\n    enabled: true\n")
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	t.Cleanup(func() {
+		srv.stopChannels()
+		srv.channelWG.Wait()
+	})
+
+	srv.reloadChannel("crashfake-superseded")
+
+	// Wait until the restart loop's rebuild (construction #2) has started
+	// and is blocked in ctor(pc) — state.constructed is bumped before the
+	// gate wait, so seeing it reach 2 proves the goroutine is parked there.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		state.mu.Lock()
+		constructed := state.constructed
+		state.mu.Unlock()
+		if constructed >= 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	state.mu.Lock()
+	constructed := state.constructed
+	state.mu.Unlock()
+	if constructed < 2 {
+		t.Fatal("restart loop never reached the gated rebuild (construction #2)")
+	}
+
+	// Simulate an operator reacting to the crash-loop: reload the platform
+	// while the stale rebuild is still parked in ctor(pc). This stops
+	// generation 1 (cancelling its ctx, which the parked ctor call can't see)
+	// and starts generation 2 with a fresh instance #3.
+	srv.reloadChannel("crashfake-superseded")
+
+	// Now release the stale rebuild. Without the generation check, it would
+	// go on to overwrite runningAdapters with instance #2 (never Started).
+	close(state.ctorGate)
+
+	// Poll for the state to settle: exactly instance #3 owns runningAdapters,
+	// and it never moves off that once settled.
+	var stableSince time.Time
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		v, ok := srv.runningAdapters.Load("crashfake-superseded")
+		fa, isFake := v.(*crashingFakeAdapter)
+		if ok && isFake && fa.id == 3 {
+			if stableSince.IsZero() {
+				stableSince = time.Now()
+			}
+			if time.Since(stableSince) > 100*time.Millisecond {
+				break // held steady long enough to be confident it's final
+			}
+		} else {
+			stableSince = time.Time{}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	v, ok := srv.runningAdapters.Load("crashfake-superseded")
+	if !ok {
+		t.Fatal("expected an adapter running after reload, found none")
+	}
+	fa, isFake := v.(*crashingFakeAdapter)
+	if !isFake {
+		t.Fatalf("runningAdapters holds unexpected type %T", v)
+	}
+	if fa.id != 3 {
+		t.Errorf("runningAdapters holds instance %d, want instance 3 (the reload's fresh start) — "+
+			"the stale rebuild (instance 2) must have clobbered it", fa.id)
+	}
+
+	state.mu.Lock()
+	startedOn := append([]int32(nil), state.startedOn...)
+	state.mu.Unlock()
+	for _, id := range startedOn {
+		if id == 2 {
+			t.Error("instance 2 (the discarded stale rebuild) had Start called on it — it should have been discarded unstarted")
+		}
 	}
 }
 

--- a/internal/server/channel_restart_test.go
+++ b/internal/server/channel_restart_test.go
@@ -1,0 +1,286 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/open-octo/octo-agent/internal/channel"
+)
+
+// crashingAdapterState is shared across every instance one test's
+// constructor produces — each restart attempt builds a fresh
+// *crashingFakeAdapter (matching production's rebuild-on-restart behavior),
+// so per-instance state can't track "how many times has this platform
+// failed overall" on its own.
+type crashingAdapterState struct {
+	mu          sync.Mutex
+	failCount   int32   // Start fails this many times total, across all instances
+	constructed int32   // instances built so far
+	startedOn   []int32 // construction id Start was invoked on, in call order
+}
+
+// crashingFakeAdapter fails its first N Start calls (simulating a crash —
+// returns a non-nil error before ctx is ever cancelled), then behaves like a
+// normal adapter (blocks on ctx.Done()).
+type crashingFakeAdapter struct {
+	id    int32 // this instance's construction sequence number
+	state *crashingAdapterState
+}
+
+func newCrashingAdapterCtorWithState(state *crashingAdapterState, failCount int32) func(channel.PlatformConfig) (channel.Adapter, error) {
+	state.failCount = failCount
+	return func(channel.PlatformConfig) (channel.Adapter, error) {
+		// Guarded by state.mu (not atomic) so it's synchronized with the
+		// mutex-protected reads/writes of the other fields below — mixing
+		// atomic and mutex-guarded access to the same field isn't safe even
+		// though each individual access looks correct in isolation.
+		state.mu.Lock()
+		state.constructed++
+		id := state.constructed
+		state.mu.Unlock()
+		return &crashingFakeAdapter{id: id, state: state}, nil
+	}
+}
+
+func (a *crashingFakeAdapter) Platform() string { return "crashfake" }
+
+func (a *crashingFakeAdapter) Start(ctx context.Context, _ func(channel.InboundEvent)) error {
+	a.state.mu.Lock()
+	a.state.startedOn = append(a.state.startedOn, a.id)
+	shouldFail := a.state.failCount > 0
+	if shouldFail {
+		a.state.failCount--
+	}
+	a.state.mu.Unlock()
+
+	if shouldFail {
+		return fmt.Errorf("simulated crash (instance %d)", a.id)
+	}
+	<-ctx.Done()
+	return nil
+}
+
+func (a *crashingFakeAdapter) Stop() error { return nil }
+func (a *crashingFakeAdapter) SendText(chatID, text, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: true}
+}
+func (a *crashingFakeAdapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: true}
+}
+func (a *crashingFakeAdapter) UpdateMessage(chatID, messageID, text string) bool { return true }
+func (a *crashingFakeAdapter) SupportsMessageUpdates() bool                      { return false }
+func (a *crashingFakeAdapter) SendTyping(chatID, contextToken string) error      { return nil }
+func (a *crashingFakeAdapter) StopTyping(chatID, contextToken string) error      { return nil }
+func (a *crashingFakeAdapter) Flush(chatID string)                               {}
+func (a *crashingFakeAdapter) ValidateConfig(channel.PlatformConfig) []string    { return nil }
+
+func writeChannelsYML(t *testing.T, yml string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	cfgDir := filepath.Join(tmp, ".octo")
+	if err := os.MkdirAll(cfgDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "channels.yml"), []byte(yml), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// #1121: a crashing adapter used to go permanently, silently dead — `_ =
+// a.Start(...)` discarded the error and nothing ever ran again. This pins
+// that a transient crash is retried (with a fresh adapter instance each
+// time, since Start isn't guaranteed reentrant) until it recovers.
+func TestChannelRestart_RecoversFromTransientCrash(t *testing.T) {
+	orig := channelRestartDelays
+	channelRestartDelays = []time.Duration{time.Millisecond}
+	t.Cleanup(func() { channelRestartDelays = orig })
+
+	state := &crashingAdapterState{}
+	channel.Register("crashfake-recovers", newCrashingAdapterCtorWithState(state, 2))
+
+	writeChannelsYML(t, "channels:\n  crashfake-recovers:\n    enabled: true\n")
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	// Wait for the restart-loop goroutine to actually return (not just for its
+	// context to be cancelled) before the channelRestartDelays cleanup above
+	// restores the package-level var out from under it — otherwise the
+	// goroutine's still-live read of that slice races the restore.
+	t.Cleanup(func() {
+		srv.stopChannels()
+		srv.channelWG.Wait()
+	})
+
+	srv.reloadChannel("crashfake-recovers")
+
+	// Poll until a 3rd instance has actually been constructed (initial +
+	// 2 crash-retries), not just until isAdapterRunning()+channelIssue=="" —
+	// that pair is also (mis)true for an instant right after the very first
+	// construction, before its Start() has even run once, since the adapter
+	// is stored in runningAdapters synchronously before the goroutine that
+	// calls Start gets scheduled.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		state.mu.Lock()
+		constructed := state.constructed
+		state.mu.Unlock()
+		if constructed >= 3 && srv.isAdapterRunning("crashfake-recovers") && srv.channelIssue("crashfake-recovers") == "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !srv.isAdapterRunning("crashfake-recovers") {
+		t.Fatal("adapter should be running again after recovering from 2 simulated crashes")
+	}
+	if issue := srv.channelIssue("crashfake-recovers"); issue != "" {
+		t.Errorf("channelIssue = %q, want cleared after recovery", issue)
+	}
+
+	state.mu.Lock()
+	constructed := state.constructed
+	startedOn := append([]int32(nil), state.startedOn...)
+	state.mu.Unlock()
+	if constructed < 3 {
+		t.Errorf("constructed = %d, want at least 3 (initial + 2 retries)", constructed)
+	}
+	if len(startedOn) < 3 {
+		t.Errorf("Start was called %d times, want at least 3", len(startedOn))
+	}
+	// Every Start call must have run on a distinct, freshly-constructed
+	// instance — never the same crashed one twice.
+	seen := map[int32]bool{}
+	for _, id := range startedOn {
+		if seen[id] {
+			t.Errorf("instance %d had Start called on it more than once — should rebuild fresh each retry", id)
+		}
+		seen[id] = true
+	}
+}
+
+// A platform that keeps crashing past maxChannelRestarts must be marked with
+// a clear "gave up" reason and left stopped, not retried forever.
+func TestChannelRestart_GivesUpAfterMaxRestarts(t *testing.T) {
+	orig := channelRestartDelays
+	channelRestartDelays = []time.Duration{time.Millisecond}
+	t.Cleanup(func() { channelRestartDelays = orig })
+
+	state := &crashingAdapterState{}
+	channel.Register("crashfake-giveup", newCrashingAdapterCtorWithState(state, maxChannelRestarts+5))
+
+	writeChannelsYML(t, "channels:\n  crashfake-giveup:\n    enabled: true\n")
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	// Wait for the restart-loop goroutine to actually return (not just for its
+	// context to be cancelled) before the channelRestartDelays cleanup above
+	// restores the package-level var out from under it — otherwise the
+	// goroutine's still-live read of that slice races the restore.
+	t.Cleanup(func() {
+		srv.stopChannels()
+		srv.channelWG.Wait()
+	})
+
+	srv.reloadChannel("crashfake-giveup")
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if issue := srv.channelIssue("crashfake-giveup"); issue != "" && !srv.isAdapterRunning("crashfake-giveup") {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if srv.isAdapterRunning("crashfake-giveup") {
+		t.Fatal("adapter should not be marked running after exceeding the restart limit")
+	}
+	issue := srv.channelIssue("crashfake-giveup")
+	if issue == "" {
+		t.Fatal("expected a recorded issue after giving up")
+	}
+	t.Logf("recorded issue: %s", issue)
+}
+
+// The Channels REST API surfaces the recorded issue (#1121's "somewhere
+// queryable" requirement) instead of leaving the only diagnostic in server logs.
+func TestChannelIssue_SurfacedViaListChannels(t *testing.T) {
+	orig := channelRestartDelays
+	channelRestartDelays = []time.Duration{time.Millisecond}
+	t.Cleanup(func() { channelRestartDelays = orig })
+
+	state := &crashingAdapterState{}
+	channel.Register("crashfake-api", newCrashingAdapterCtorWithState(state, maxChannelRestarts+5))
+
+	writeChannelsYML(t, "channels:\n  crashfake-api:\n    enabled: true\n")
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	// Wait for the restart-loop goroutine to actually return (not just for its
+	// context to be cancelled) before the channelRestartDelays cleanup above
+	// restores the package-level var out from under it — otherwise the
+	// goroutine's still-live read of that slice races the restore.
+	t.Cleanup(func() {
+		srv.stopChannels()
+		srv.channelWG.Wait()
+	})
+	srv.reloadChannel("crashfake-api")
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && srv.channelIssue("crashfake-api") == "" {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	info := channelInfo{Platform: "crashfake-api"}
+	info.Running = srv.isAdapterRunning("crashfake-api")
+	info.Issue = srv.channelIssue("crashfake-api")
+	if info.Issue == "" {
+		t.Fatal("expected channelInfo.Issue to carry the recorded reason")
+	}
+}
+
+// A config validation failure must be recorded immediately (no restart loop
+// needed — it will never succeed until the config changes).
+func TestChannelIssue_RecordedOnInvalidConfig(t *testing.T) {
+	channel.Register("invalidcfg-fake", func(channel.PlatformConfig) (channel.Adapter, error) {
+		return &validatingFakeAdapter{}, nil
+	})
+
+	writeChannelsYML(t, "channels:\n  invalidcfg-fake:\n    enabled: true\n")
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	t.Cleanup(func() {
+		srv.stopChannels()
+		srv.channelWG.Wait()
+	})
+	srv.reloadChannel("invalidcfg-fake")
+
+	if srv.isAdapterRunning("invalidcfg-fake") {
+		t.Fatal("adapter with invalid config should not be running")
+	}
+	if issue := srv.channelIssue("invalidcfg-fake"); issue == "" {
+		t.Fatal("expected an invalid-config issue to be recorded")
+	}
+}
+
+// validatingFakeAdapter always fails ValidateConfig, for
+// TestChannelIssue_RecordedOnInvalidConfig.
+type validatingFakeAdapter struct{}
+
+func (a *validatingFakeAdapter) Platform() string { return "invalidcfg-fake" }
+func (a *validatingFakeAdapter) Start(ctx context.Context, _ func(channel.InboundEvent)) error {
+	<-ctx.Done()
+	return nil
+}
+func (a *validatingFakeAdapter) Stop() error { return nil }
+func (a *validatingFakeAdapter) SendText(chatID, text, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: true}
+}
+func (a *validatingFakeAdapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: true}
+}
+func (a *validatingFakeAdapter) UpdateMessage(chatID, messageID, text string) bool { return true }
+func (a *validatingFakeAdapter) SupportsMessageUpdates() bool                      { return false }
+func (a *validatingFakeAdapter) SendTyping(chatID, contextToken string) error      { return nil }
+func (a *validatingFakeAdapter) StopTyping(chatID, contextToken string) error      { return nil }
+func (a *validatingFakeAdapter) Flush(chatID string)                               {}
+func (a *validatingFakeAdapter) ValidateConfig(channel.PlatformConfig) []string {
+	return []string{"missing required field: token"}
+}

--- a/internal/server/channels_handler.go
+++ b/internal/server/channels_handler.go
@@ -17,6 +17,12 @@ type channelInfo struct {
 	Running   bool              `json:"running"`
 	HasConfig bool              `json:"has_config"`
 	Fields    map[string]string `json:"fields"`
+	// Issue is why the adapter isn't healthy — a startup skip reason
+	// (unregistered / construction failed / invalid config) or the latest
+	// crash-and-restart status — omitted when there's none recorded (#1121:
+	// previously the only symptom of any of these was "the bot never
+	// replies", with no queryable reason anywhere).
+	Issue string `json:"issue,omitempty"`
 }
 
 var secretKeys = map[string]bool{
@@ -40,6 +46,7 @@ func (s *Server) handleListChannels(w http.ResponseWriter, r *http.Request) {
 	for name, pc := range cfg.Channels {
 		info := platformToInfo(name, pc)
 		info.Running = s.isAdapterRunning(name)
+		info.Issue = s.channelIssue(name)
 		out = append(out, info)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"channels": out})
@@ -67,6 +74,7 @@ func (s *Server) handleGetChannel(w http.ResponseWriter, r *http.Request) {
 
 	info := platformToInfo(platform, pc)
 	info.Running = s.isAdapterRunning(platform)
+	info.Issue = s.channelIssue(platform)
 	writeJSON(w, http.StatusOK, info)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -262,6 +262,27 @@ type Server struct {
 	channelCtx     context.Context
 	adapterCancels map[string]context.CancelFunc
 
+	// channelIssues records, per platform, why its adapter isn't healthy: a
+	// startup skip reason (unregistered/construction failed/invalid config)
+	// or the latest crash-and-restart status (#1121 — these used to be
+	// logged, if at all, with no queryable record, so a misconfigured or
+	// crashing platform's only visible symptom was "the bot never replies").
+	// Absent (or "") means healthy. Guarded by its own mutex rather than
+	// channelMu since it's read from the REST handlers on any goroutine,
+	// independent of the (re)start bookkeeping channelMu protects.
+	channelIssuesMu sync.Mutex
+	channelIssues   map[string]string
+
+	// channelWG tracks every runChannelWithRestart goroutine currently in
+	// flight. Nothing in production Waits on it — stopChannels/reloadChannel
+	// only cancel the relevant context(s) and return, which is enough for
+	// correct shutdown behavior. It exists so tests can deterministically
+	// block until a stopped adapter's goroutine has actually returned before
+	// tearing down state that goroutine still reads (e.g. restoring a
+	// package-level test override), instead of racing a fire-and-forget
+	// background goroutine against test cleanup.
+	channelWG sync.WaitGroup
+
 	// weixinLogin tracks the in-flight web QR login flow (one at a time).
 	weixinLogin weixinLoginFlow
 
@@ -1902,17 +1923,20 @@ func (s *Server) startOneChannelLocked(name string) {
 	ctor, err := channel.Find(name)
 	if err != nil {
 		slog.Error("channel start failed", "channel", name, "err", err)
+		s.recordChannelIssue(name, "adapter not registered: "+err.Error())
 		return
 	}
 	ad, err := ctor(pc)
 	if err != nil {
 		slog.Error("channel adapter failed", "channel", name, "err", err)
+		s.recordChannelIssue(name, "construction failed: "+err.Error())
 		return
 	}
 	if errs := ad.ValidateConfig(pc); len(errs) > 0 {
 		for _, e := range errs {
 			slog.Warn("channel config issue", "channel", name, "detail", e)
 		}
+		s.recordChannelIssue(name, "invalid config: "+strings.Join(errs, "; "))
 		return
 	}
 
@@ -1922,12 +1946,113 @@ func (s *Server) startOneChannelLocked(name string) {
 	}
 	s.adapterCancels[name] = cancel
 	s.runningAdapters.Store(name, ad)
-	go func(a channel.Adapter, platform string) {
-		_ = a.Start(ctx, func(ev channel.InboundEvent) {
-			ev.Platform = platform
-			s.routeChannelEvent(ctx, a, ev)
+	s.clearChannelIssue(name)
+	s.channelWG.Add(1)
+	go s.runChannelWithRestart(ctx, name, pc, ctor, ad)
+}
+
+// channelRestartDelays bounds how aggressively a crashed adapter retries: a
+// short delay for the first attempt (a transient network blip recovers
+// fast), backing off so a persistently broken platform (revoked auth, a dead
+// endpoint) doesn't hot-loop.
+var channelRestartDelays = []time.Duration{
+	2 * time.Second, 5 * time.Second, 15 * time.Second, 30 * time.Second, time.Minute,
+}
+
+// maxChannelRestarts caps how many times a crashing adapter is restarted
+// before giving up — still crashing after this many attempts means something
+// structurally broken (revoked credentials, a permanently unreachable
+// endpoint), not a transient blip, and endless retries would just spam logs
+// forever with nothing for the user to act on differently.
+const maxChannelRestarts = 10
+
+// runChannelWithRestart runs ad to completion, then — unless ctx was
+// cancelled deliberately (Stop()/reloadChannel) — logs the crash, records it
+// where the Channels web view and the channel-manager skill's doctor flow
+// can see it (recordChannelIssue), and retries with backoff instead of
+// leaving the platform silently dead (#1121: previously `_ = a.Start(...)`
+// discarded the error entirely and nothing ever ran again). Each retry
+// rebuilds a fresh adapter instance via ctor rather than reusing the crashed
+// one — Start isn't guaranteed reentrant (each adapter owns its own
+// connections, goroutines, and internal queues), so a clean instance is the
+// only safe way to retry, matching what a full server restart would do
+// anyway. Config is not re-validated on retries: ValidateConfig failures are
+// a permanent skip (startOneChannelLocked never reaches this function for
+// those), not something a backoff loop should keep re-attempting.
+func (s *Server) runChannelWithRestart(ctx context.Context, name string, pc channel.PlatformConfig, ctor func(channel.PlatformConfig) (channel.Adapter, error), ad channel.Adapter) {
+	defer s.channelWG.Done()
+	restarts := 0
+	for {
+		err := ad.Start(ctx, func(ev channel.InboundEvent) {
+			ev.Platform = name
+			s.routeChannelEvent(ctx, ad, ev)
 		})
-	}(ad, name)
+		if ctx.Err() != nil {
+			return // deliberate stop, not a crash
+		}
+
+		restarts++
+		slog.Error("channel adapter exited unexpectedly", "channel", name, "err", err, "restart_attempt", restarts)
+		if restarts > maxChannelRestarts {
+			slog.Error("channel adapter exceeded restart limit — giving up", "channel", name, "restarts", restarts)
+			s.recordChannelIssue(name, fmt.Sprintf("gave up after %d crashes: %v", restarts, err))
+			s.channelMu.Lock()
+			s.runningAdapters.Delete(name)
+			delete(s.adapterCancels, name)
+			s.channelMu.Unlock()
+			return
+		}
+		s.recordChannelIssue(name, fmt.Sprintf("restarting (%d/%d) after crash: %v", restarts, maxChannelRestarts, err))
+
+		delay := channelRestartDelays[len(channelRestartDelays)-1]
+		if restarts-1 < len(channelRestartDelays) {
+			delay = channelRestartDelays[restarts-1]
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+
+		newAd, cerr := ctor(pc)
+		if cerr != nil {
+			slog.Error("channel restart: rebuild failed", "channel", name, "err", cerr, "restart_attempt", restarts)
+			s.recordChannelIssue(name, fmt.Sprintf("restart %d/%d rebuild failed: %v", restarts, maxChannelRestarts, cerr))
+			continue // try again next loop, same restart budget and backoff schedule
+		}
+		ad = newAd
+		s.channelMu.Lock()
+		s.runningAdapters.Store(name, ad)
+		s.channelMu.Unlock()
+		s.clearChannelIssue(name)
+	}
+}
+
+// recordChannelIssue notes why a platform's adapter isn't healthy (a startup
+// skip reason, or a crash/restart status), queryable via GET /api/channels
+// and the channel-manager skill's doctor flow.
+func (s *Server) recordChannelIssue(name, reason string) {
+	s.channelIssuesMu.Lock()
+	if s.channelIssues == nil {
+		s.channelIssues = make(map[string]string)
+	}
+	s.channelIssues[name] = reason
+	s.channelIssuesMu.Unlock()
+}
+
+// clearChannelIssue marks a platform healthy again (a (re)start succeeded).
+func (s *Server) clearChannelIssue(name string) {
+	s.channelIssuesMu.Lock()
+	delete(s.channelIssues, name)
+	s.channelIssuesMu.Unlock()
+}
+
+// channelIssue returns the recorded reason a platform isn't healthy, or ""
+// when it's never had one recorded (running fine, or never started).
+func (s *Server) channelIssue(name string) string {
+	s.channelIssuesMu.Lock()
+	defer s.channelIssuesMu.Unlock()
+	return s.channelIssues[name]
 }
 
 // stopOneChannelLocked stops a single running adapter (cancel its context and
@@ -1941,6 +2066,10 @@ func (s *Server) stopOneChannelLocked(name string) {
 		_ = v.(channel.Adapter).Stop()
 		s.runningAdapters.Delete(name)
 	}
+	// A deliberate stop (disable/delete/reload) isn't a health problem — clear
+	// any crash/restart status left over from before it, so re-enabling later
+	// starts from a clean slate instead of showing a stale crash reason.
+	s.clearChannelIssue(name)
 }
 
 // reloadChannel applies a saved config change for one platform without a full

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -262,6 +262,20 @@ type Server struct {
 	channelCtx     context.Context
 	adapterCancels map[string]context.CancelFunc
 
+	// channelGen bumps every time startOneChannelLocked (re)starts a platform
+	// from scratch, and is handed to that start's runChannelWithRestart
+	// goroutine as a snapshot. A crashed adapter's restart loop rebuilds a
+	// fresh instance via ctor(pc) — a call that does not observe ctx
+	// cancellation — so a concurrent stop/reload/restart of the SAME
+	// platform (e.g. an operator reacting to the crash-loop this fix makes
+	// visible in the Channels view) can advance the generation while that
+	// ctor(pc) call is still in flight. Before writing anything back to
+	// runningAdapters/adapterCancels, the restart loop re-checks its
+	// snapshot against the current generation under channelMu; a mismatch
+	// means another goroutine now owns this platform name, so it discards
+	// its work instead of clobbering the new owner's bookkeeping.
+	channelGen map[string]uint64
+
 	// channelIssues records, per platform, why its adapter isn't healthy: a
 	// startup skip reason (unregistered/construction failed/invalid config)
 	// or the latest crash-and-restart status (#1121 — these used to be
@@ -1944,11 +1958,16 @@ func (s *Server) startOneChannelLocked(name string) {
 	if s.adapterCancels == nil {
 		s.adapterCancels = make(map[string]context.CancelFunc)
 	}
+	if s.channelGen == nil {
+		s.channelGen = make(map[string]uint64)
+	}
+	s.channelGen[name]++
+	gen := s.channelGen[name]
 	s.adapterCancels[name] = cancel
 	s.runningAdapters.Store(name, ad)
 	s.clearChannelIssue(name)
 	s.channelWG.Add(1)
-	go s.runChannelWithRestart(ctx, name, pc, ctor, ad)
+	go s.runChannelWithRestart(ctx, name, gen, pc, ctor, ad)
 }
 
 // channelRestartDelays bounds how aggressively a crashed adapter retries: a
@@ -1979,7 +1998,13 @@ const maxChannelRestarts = 10
 // anyway. Config is not re-validated on retries: ValidateConfig failures are
 // a permanent skip (startOneChannelLocked never reaches this function for
 // those), not something a backoff loop should keep re-attempting.
-func (s *Server) runChannelWithRestart(ctx context.Context, name string, pc channel.PlatformConfig, ctor func(channel.PlatformConfig) (channel.Adapter, error), ad channel.Adapter) {
+//
+// gen is the generation snapshot startOneChannelLocked captured when it
+// launched this goroutine (see channelGen's doc comment) — every write back
+// to runningAdapters/adapterCancels re-checks it first, since a concurrent
+// stop/reload/restart of this same platform can slip in during the ctor(pc)
+// call below, which does not observe ctx cancellation.
+func (s *Server) runChannelWithRestart(ctx context.Context, name string, gen uint64, pc channel.PlatformConfig, ctor func(channel.PlatformConfig) (channel.Adapter, error), ad channel.Adapter) {
 	defer s.channelWG.Done()
 	restarts := 0
 	for {
@@ -1997,8 +2022,10 @@ func (s *Server) runChannelWithRestart(ctx context.Context, name string, pc chan
 			slog.Error("channel adapter exceeded restart limit — giving up", "channel", name, "restarts", restarts)
 			s.recordChannelIssue(name, fmt.Sprintf("gave up after %d crashes: %v", restarts, err))
 			s.channelMu.Lock()
-			s.runningAdapters.Delete(name)
-			delete(s.adapterCancels, name)
+			if s.channelGen[name] == gen {
+				s.runningAdapters.Delete(name)
+				delete(s.adapterCancels, name)
+			}
 			s.channelMu.Unlock()
 			return
 		}
@@ -2022,6 +2049,15 @@ func (s *Server) runChannelWithRestart(ctx context.Context, name string, pc chan
 		}
 		ad = newAd
 		s.channelMu.Lock()
+		if s.channelGen[name] != gen {
+			// Superseded while ctor(pc) was in flight — a concurrent
+			// stop/reload/restart now owns this platform name. ad was never
+			// Start()-ed, so there's nothing to Stop(); just discard it and
+			// let this goroutine end without touching the new owner's state.
+			s.channelMu.Unlock()
+			slog.Warn("channel restart: superseded during rebuild, discarding stale instance", "channel", name)
+			return
+		}
 		s.runningAdapters.Store(name, ad)
 		s.channelMu.Unlock()
 		s.clearChannelIssue(name)

--- a/internal/skills/defaults/channel-manager/SKILL.md
+++ b/internal/skills/defaults/channel-manager/SKILL.md
@@ -347,6 +347,11 @@ Check each item, report ✅ / ❌ with remediation:
 7. **Telegram credentials** (if enabled) — run the `getMe` curl from Telegram setup step 2; `"ok":true` → ✅, else ❌ "Telegram token rejected by getMe — re-run setup".
 8. **WeCom credentials** (if enabled) — no public REST validation endpoint; check the `octo serve` output for `[wecom] authentication failed` → ❌ "WeCom credentials incorrect — re-run setup", or `[wecom] connected, authenticating` with no auth error → ✅.
 9. **Serve process** — `pgrep -f "octo.*serve"`; if no enabled platform, skip; if enabled but not running, ❌ "Run `octo serve`" (and ask to start it if the user agrees).
+10. **Recorded issue** (if serve is running) — query the live status instead of only grepping logs:
+    ```bash
+    curl -s http://127.0.0.1:8088/api/channels
+    ```
+    Each entry's `issue` field (omitted when healthy) carries the exact reason the adapter isn't running: an unregistered/misconfigured/invalid-config skip at startup, or a crash-and-restart status such as `restarting (2/10) after crash: ...` or `gave up after 11 crashes: ...`. A non-empty `issue` → ❌, quote it verbatim, and point at the matching setup step; a "gave up" issue means retries are exhausted and the platform needs `enable`/`disable` (or a config fix + `restart_server`) to try again — it will not recover on its own.
 
 ---
 

--- a/web/src/views/ChannelsView.svelte
+++ b/web/src/views/ChannelsView.svelte
@@ -22,6 +22,9 @@
     running: boolean
     has_config: boolean
     fields: Record<string, string>
+    // #1121: why the adapter isn't healthy — a startup skip reason or the
+    // latest crash/restart status. Absent when healthy.
+    issue?: string
   }
 
   let rows = $state<ChannelRow[]>([])
@@ -114,11 +117,16 @@
   function tagFor(row: ChannelRow): { status: string; label: string } {
     if (!row.has_config) return { status: 'default', label: 'Not configured' }
     if (!row.enabled)    return { status: 'default', label: 'Disabled' }
+    // #1121: a config/startup problem or an ongoing crash-restart loop — show
+    // it distinctly from a plain "Stopped" (which reads as "not started yet",
+    // not "something is wrong").
+    if (row.issue)       return { status: 'error', label: 'Error' }
     if (row.running)     return { status: 'success', label: 'Running' }
     return { status: 'warning', label: 'Stopped' }
   }
 
   function activityFor(row: ChannelRow): string {
+    if (row.issue) return row.issue
     if (row.running) return 'Adapter is running and accepting messages'
     if (row.enabled) return 'Enabled but not yet started — restart the server to activate'
     return 'Disabled'


### PR DESCRIPTION
## Summary

Fixes #1121. `internal/channel/manager.go`'s `Start` (cited by the issue) skips an unregistered/misconfigured/invalid-config platform with a bare `continue` and no log, and discards the adapter's run error entirely (`_ = a.Start(...)`) — a crashed adapter went permanently, silently dead with zero diagnostics. That `Manager.Start` code path turned out to be dead in production (only `manager_test.go` calls it) — the real path `octo serve` runs is `internal/server/server.go`'s own parallel start/stop implementation, which had the exact same gaps and is where the real fix lives.

- `internal/channel/manager.go`: log every skip reason and the adapter's run error (matching the issue's literal ask), without adding a restart loop to code nothing in production calls.
- `internal/server/server.go`:
  - New `channelIssues` map recording why a platform isn't healthy — a startup skip reason, or the latest crash/restart status — queryable and cleared on deliberate stop or recovery.
  - New `runChannelWithRestart`: on crash, logs + records the issue, and retries with backoff (capped at 10 restarts) instead of leaving the platform dead. Each retry rebuilds a fresh adapter instance (`Start` isn't guaranteed reentrant), and `runningAdapters` is kept pointed at the live instance so proactive sends keep working.
  - New `channelWG` so tests can deterministically wait for a stopped adapter's goroutine to actually exit.
- `internal/server/channels_handler.go`: `GET /api/channels` (list + get) now returns an `issue` field — the "somewhere queryable" the issue asks for.
- `web/src/views/ChannelsView.svelte`: a channel with a recorded issue now shows an "Error" tag + the reason, instead of reading as a plain "Stopped".
- `internal/skills/defaults/channel-manager/SKILL.md`: `doctor` flow gains a step that queries `GET /api/channels` for the recorded issue instead of only grepping server logs.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] `go test -race ./internal/channel/... ./internal/server/...` (run 3x, stable)
- [x] `npx svelte-check` — 0 errors
- [x] New `internal/server/channel_restart_test.go`:
  - recovers from a transient crash, rebuilding a fresh instance each retry (never restarting the same crashed one)
  - gives up after `maxChannelRestarts` with a recorded reason, adapter left stopped
  - the recorded issue surfaces through `channelInfo`/`GET /api/channels`
  - an invalid-config skip is recorded immediately, without ever entering the restart loop