### PR TITLE
fix(seo): canonical, sitemap, Open Graph, and hreflang fixes

### DIFF
--- a/blog/astro.config.mjs
+++ b/blog/astro.config.mjs
@@ -1,8 +1,17 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://octo-agent.dev',
 	base: '/blog',
+	integrations: [
+		sitemap({
+			customPages: [
+				'https://octo-agent.dev/blog/',
+				'https://octo-agent.dev/blog/en/',
+			],
+		}),
+	],
 });

--- a/blog/package-lock.json
+++ b/blog/package-lock.json
@@ -8,6 +8,7 @@
       "name": "octo-blog",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.3",
         "astro": "^7.0.2"
       }
     },
@@ -237,6 +238,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1984,6 +1996,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2032,6 +2062,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3730,6 +3766,25 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
@@ -3760,6 +3815,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -3883,6 +3944,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/blog/package.json
+++ b/blog/package.json
@@ -10,6 +10,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.3",
     "astro": "^7.0.2"
   }
 }

--- a/blog/public/og-default.svg
+++ b/blog/public/og-default.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#0b0f19"/>
+  <circle cx="600" cy="315" r="280" fill="#2F54EB" opacity="0.12"/>
+  <rect x="520" y="195" width="160" height="160" rx="40" fill="#2F54EB"/>
+  <path fill="#ffffff" d="M600 218c-16 0-24 12-24 26 0 10 6 16 10 18-2 8-8 16-16 20-2 1-2 4 0 6 2 1 5 1 7-1 6-4 12-11 15-19 2 1 5 2 8 2v12c0 3 3 5 6 4 2-1 3-3 2-5l-2-11c3 0 6-1 8-2 3 8 9 15 15 19 2 2 5 2 7 1 2-2 2-5 0-6-8-4-14-12-16-20 4-2 10-8 10-18 0-14-8-26-24-26z"/>
+  <circle cx="570" cy="242" r="5" fill="#2F54EB"/>
+  <circle cx="630" cy="242" r="5" fill="#2F54EB"/>
+  <text x="600" y="430" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="72" font-weight="700" fill="#f3f4f6" text-anchor="middle">octo blog</text>
+  <text x="600" y="490" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="32" fill="#9ca3af" text-anchor="middle">octo-agent engineering notes and deep dives</text>
+</svg>

--- a/blog/src/content.config.ts
+++ b/blog/src/content.config.ts
@@ -12,6 +12,7 @@ const postsCollection = defineCollection({
 		tags: z.array(z.string()).default([]),
 		draft: z.boolean().default(false),
 		locale: z.enum(['en', 'zh']).default('zh'),
+	image: z.string().optional(),
 		originalSlug: z.string().optional(),
 	}),
 });

--- a/blog/src/layouts/BlogPost.astro
+++ b/blog/src/layouts/BlogPost.astro
@@ -4,12 +4,19 @@ import '../styles/blog.css';
 
 type Props = CollectionEntry<'posts'>['data'] & { slug?: string; locale?: string; alternateSlug?: string };
 
-const { title, description, pubDate, updatedDate, author, tags, locale = 'zh', alternateSlug } = Astro.props;
+const { title, description, pubDate, updatedDate, author, tags, image, slug, locale = 'zh', alternateSlug } = Astro.props;
 const dateFormatter = new Intl.DateTimeFormat(locale === 'zh' ? 'zh-CN' : 'en-US', {
 	year: 'numeric',
 	month: 'long',
 	day: 'numeric',
 });
+
+const siteUrl = 'https://octo-agent.dev';
+const pageSlug = slug ?? '';
+const canonicalPath = pageSlug.startsWith('en/')
+	? `/blog/posts/${pageSlug}/`
+	: `/blog/posts/${pageSlug}/`;
+const canonicalUrl = `${siteUrl}${canonicalPath}`;
 
 const navLabels = {
 	en: { home: 'octo blog', docs: 'Docs', github: 'GitHub', lang: 'EN' },
@@ -19,9 +26,13 @@ const labels = navLabels[locale as keyof typeof navLabels] || navLabels.zh;
 
 const alternateLocale = locale === 'zh' ? 'en' : 'zh';
 const alternateUrl = alternateSlug
-	? `/blog/posts/${alternateLocale}/${alternateSlug}/`
-	: `/blog/${alternateLocale === 'zh' ? '' : 'en/'}`;
+	? `${siteUrl}/blog/posts/${alternateLocale === 'en' ? 'en/' : ''}${alternateSlug}/`
+	: `${siteUrl}/blog/${alternateLocale === 'zh' ? '' : 'en/'}`;
 const alternateLabel = locale === 'zh' ? 'English' : '中文';
+
+const ogImage = image ? (image.startsWith('http') ? image : `${siteUrl}${image}`) : `${siteUrl}/blog/og-default.svg`;
+const ogType = 'article';
+const siteName = locale === 'zh' ? 'octo 博客' : 'octo blog';
 ---
 
 <!DOCTYPE html>
@@ -29,10 +40,32 @@ const alternateLabel = locale === 'zh' ? 'English' : '中文';
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>{title} | octo blog</title>
+		<title>{title} | {siteName}</title>
 		<meta name="description" content={description} />
+		<link rel="canonical" href={canonicalUrl} />
 		<link rel="icon" type="image/svg+xml" href="/blog/favicon.svg" />
-		<link rel="alternate" hreflang={locale === 'zh' ? 'en' : 'zh-CN'} href={alternateUrl} />
+		<link rel="alternate" hreflang={alternateLocale} href={alternateUrl} />
+
+		<!-- Open Graph -->
+		<meta property="og:title" content={title} />
+		<meta property="og:description" content={description} />
+		<meta property="og:url" content={canonicalUrl} />
+		<meta property="og:type" content={ogType} />
+		<meta property="og:locale" content={locale === 'zh' ? 'zh-CN' : 'en'} />
+		<meta property="og:site_name" content={siteName} />
+		<meta property="og:image" content={ogImage} />
+
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content={title} />
+		<meta name="twitter:description" content={description} />
+		<meta name="twitter:image" content={ogImage} />
+
+		<!-- Article meta -->
+		<meta property="article:published_time" content={pubDate.toISOString()} />
+		{updatedDate && <meta property="article:modified_time" content={updatedDate.toISOString()} />}
+		<meta property="article:author" content={author} />
+		{tags.map((tag) => <meta property="article:tag" content={tag} />)}
 	</head>
 	<body>
 		<header class="site-header">

--- a/blog/src/pages/en/index.astro
+++ b/blog/src/pages/en/index.astro
@@ -11,6 +11,13 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 	month: 'long',
 	day: 'numeric',
 });
+
+const siteUrl = 'https://octo-agent.dev';
+const canonicalUrl = `${siteUrl}/blog/en/`;
+const alternateUrl = `${siteUrl}/blog/`;
+const title = 'octo blog';
+const description = 'Engineering notes, release updates, and deep dives from the octo-agent team.';
+const ogImage = `${siteUrl}/blog/og-default.svg`;
 ---
 
 <!DOCTYPE html>
@@ -18,13 +25,24 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>octo blog</title>
-		<meta
-			name="description"
-			content="Engineering notes, release updates, and deep dives from the octo-agent team."
-		/>
+		<title>{title}</title>
+		<meta name="description" content={description} />
+		<link rel="canonical" href={canonicalUrl} />
 		<link rel="icon" type="image/svg+xml" href="/blog/favicon.svg" />
-		<link rel="alternate" hreflang="zh-CN" href="/blog/" />
+		<link rel="alternate" hreflang="zh-CN" href={alternateUrl} />
+
+		<meta property="og:title" content={title} />
+		<meta property="og:description" content={description} />
+		<meta property="og:url" content={canonicalUrl} />
+		<meta property="og:type" content="website" />
+		<meta property="og:locale" content="en" />
+		<meta property="og:site_name" content={title} />
+		<meta property="og:image" content={ogImage} />
+
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content={title} />
+		<meta name="twitter:description" content={description} />
+		<meta name="twitter:image" content={ogImage} />
 	</head>
 	<body>
 		<header class="site-header">
@@ -33,7 +51,7 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 				<nav class="site-nav">
 					<a href="/docs/">Docs</a>
 					<a href="https://github.com/open-octo/octo-agent">GitHub</a>
-					<a class="lang-switch" href="/blog/" title="中文">中文</a>
+					<a class="lang-switch" href={alternateUrl} title="中文">中文</a>
 				</nav>
 			</div>
 		</header>
@@ -63,10 +81,10 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 									</time>
 									{' · '}
 									{post.data.tags.slice(0, 3).map((tag, i) => (
-										<>
-											{i > 0 && ', '}
-											<span class="tag">{tag}</span>
-										</>
+											<>
+												{i > 0 && ', '}
+												<span class="tag">{tag}</span>
+											</>
 									))}
 								</p>
 							</li>

--- a/blog/src/pages/index.astro
+++ b/blog/src/pages/index.astro
@@ -11,6 +11,13 @@ const dateFormatter = new Intl.DateTimeFormat('zh-CN', {
 	month: 'long',
 	day: 'numeric',
 });
+
+const siteUrl = 'https://octo-agent.dev';
+const canonicalUrl = `${siteUrl}/blog/`;
+const alternateUrl = `${siteUrl}/blog/en/`;
+const title = 'octo 博客';
+const description = 'octo-agent 团队的工程笔记、版本更新与技术深度文章。';
+const ogImage = `${siteUrl}/blog/og-default.svg`;
 ---
 
 <!DOCTYPE html>
@@ -18,13 +25,24 @@ const dateFormatter = new Intl.DateTimeFormat('zh-CN', {
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>octo 博客</title>
-		<meta
-			name="description"
-			content="octo-agent 团队的工程笔记、版本更新与技术深度文章。"
-		/>
+		<title>{title}</title>
+		<meta name="description" content={description} />
+		<link rel="canonical" href={canonicalUrl} />
 		<link rel="icon" type="image/svg+xml" href="/blog/favicon.svg" />
-		<link rel="alternate" hreflang="en" href="/blog/en/" />
+		<link rel="alternate" hreflang="en" href={alternateUrl} />
+
+		<meta property="og:title" content={title} />
+		<meta property="og:description" content={description} />
+		<meta property="og:url" content={canonicalUrl} />
+		<meta property="og:type" content="website" />
+		<meta property="og:locale" content="zh-CN" />
+		<meta property="og:site_name" content={title} />
+		<meta property="og:image" content={ogImage} />
+
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content={title} />
+		<meta name="twitter:description" content={description} />
+		<meta name="twitter:image" content={ogImage} />
 	</head>
 	<body>
 		<header class="site-header">
@@ -33,7 +51,7 @@ const dateFormatter = new Intl.DateTimeFormat('zh-CN', {
 				<nav class="site-nav">
 					<a href="/docs/">文档</a>
 					<a href="https://github.com/open-octo/octo-agent">GitHub</a>
-					<a class="lang-switch" href="/blog/en/" title="English">English</a>
+					<a class="lang-switch" href={alternateUrl} title="English">English</a>
 				</nav>
 			</div>
 		</header>

--- a/blog/src/pages/posts/[...slug].astro
+++ b/blog/src/pages/posts/[...slug].astro
@@ -13,17 +13,21 @@ export async function getStaticPaths() {
 				p.data.originalSlug === post.data.originalSlug &&
 				p.data.locale !== locale,
 		);
+		const alternateSlug = alternate?.id.startsWith('zh/') || alternate?.id.startsWith('en/')
+			? alternate.id.slice(3)
+			: alternate?.id;
 		return {
 			params: { slug },
-			props: { post, alternateSlug: alternate?.id.startsWith('zh/') ? alternate.id.slice(3) : alternate?.id },
+			props: { post, alternateSlug },
 		};
 	});
 }
 
 const { post, alternateSlug } = Astro.props;
+const slug = Astro.params.slug;
 const { Content } = await render(post);
 ---
 
-<BlogPost {...post.data} slug={post.id} locale={post.data.locale} alternateSlug={alternateSlug}>
+<BlogPost {...post.data} slug={slug} locale={post.data.locale} alternateSlug={alternateSlug}>
 	<Content />
 </BlogPost>

--- a/landing/index.html
+++ b/landing/index.html
@@ -6,6 +6,35 @@
   <title>Octo — A functionality-first AI agent</title>
   <meta name="description" content="A single Go binary that brings AI agents to your terminal, browser, and chat apps. Anthropic + OpenAI native. Built-in tools, MCP, skills, sandboxing, and persistent memory.">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='22' fill='%232F54EB'/%3E%3Cpath fill='%23ffffff' d='M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z'/%3E%3Ccircle cx='40' cy='42' r='5' fill='%232F54EB'/%3E%3Ccircle cx='60' cy='42' r='5' fill='%232F54EB'/%3E%3C/svg%3E">
+  <link rel="canonical" href="https://octo-agent.dev/">
+  <meta property="og:title" content="Octo — A functionality-first AI agent">
+  <meta property="og:description" content="A single Go binary that brings AI agents to your terminal, browser, and chat apps. Anthropic + OpenAI native. Built-in tools, MCP, skills, sandboxing, and persistent memory.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://octo-agent.dev/">
+  <meta property="og:image" content="https://octo-agent.dev/og-image.svg">
+  <meta property="og:site_name" content="Octo">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Octo — A functionality-first AI agent">
+  <meta name="twitter:description" content="A single Go binary that brings AI agents to your terminal, browser, and chat apps. Anthropic + OpenAI native. Built-in tools, MCP, skills, sandboxing, and persistent memory.">
+  <meta name="twitter:image" content="https://octo-agent.dev/og-image.svg">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Octo",
+    "description": "A functionality-first AI agent in a single Go binary. Bring it to your terminal, browser, or chat app.",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "macOS, Linux, Windows",
+    "license": "https://github.com/open-octo/octo-agent/blob/main/LICENSE.txt",
+    "url": "https://octo-agent.dev/",
+    "codeRepository": "https://github.com/open-octo/octo-agent",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    }
+  }
+  </script>
   <style>
     :root {
       --bg: #fafafa;

--- a/landing/og-image.svg
+++ b/landing/og-image.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#fafafa"/>
+  <circle cx="600" cy="315" r="280" fill="#4f46e5" opacity="0.08"/>
+  <rect x="520" y="195" width="160" height="160" rx="40" fill="#2F54EB"/>
+  <path fill="#ffffff" d="M600 218c-16 0-24 12-24 26 0 10 6 16 10 18-2 8-8 16-16 20-2 1-2 4 0 6 2 1 5 1 7-1 6-4 12-11 15-19 2 1 5 2 8 2v12c0 3 3 5 6 4 2-1 3-3 2-5l-2-11c3 0 6-1 8-2 3 8 9 15 15 19 2 2 5 2 7 1 2-2 2-5 0-6-8-4-14-12-16-20 4-2 10-8 10-18 0-14-8-26-24-26z"/>
+  <circle cx="570" cy="242" r="5" fill="#2F54EB"/>
+  <circle cx="630" cy="242" r="5" fill="#2F54EB"/>
+  <text x="600" y="430" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="72" font-weight="700" fill="#111827" text-anchor="middle">Octo</text>
+  <text x="600" y="490" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="32" fill="#374151" text-anchor="middle">A functionality-first AI agent</text>
+</svg>

--- a/landing/robots.txt
+++ b/landing/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://octo-agent.dev/docs/sitemap-index.xml
+Sitemap: https://octo-agent.dev/blog/sitemap-index.xml


### PR DESCRIPTION
## Summary

Fixes across the three public sites deployed to `octo-agent.dev` (landing, docs, blog).

## Changes

- **Landing**: add canonical, Open Graph, Twitter Card, and JSON-LD `SoftwareApplication` structured data; add a default OG image.
- **Landing**: add `/robots.txt` pointing to docs and blog sitemaps so search engines can discover all sub-sites.
- **Blog**: fix the broken hreflang alternate URL that had a duplicate `/en/` segment (`/blog/posts/en/en/...`).
- **Blog**: add canonical, Open Graph, Twitter Card, and article meta tags to posts and both index pages; support per-post `og:image` via frontmatter `image`.
- **Blog**: add `@astrojs/sitemap` so posts and index pages are exposed via `/blog/sitemap-index.xml`.
- **Docs**: already generated a sitemap via Starlight; no code changes needed.

## Verification

- `cd blog && npm run build` succeeds and generates `dist/sitemap-index.xml`.
- `cd docs && npm install && npm run build` succeeds and generates `dist/sitemap-index.xml`.

## Notes

The default OG images are SVG. They are valid image URLs, but some social platforms (e.g. X/Twitter) prefer PNG/JPEG. If sharing traction becomes important, we can convert them to PNG later.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>