### PR TITLE
fix(ci): copy landing robots.txt and og-image to Pages artifact

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           mkdir -p _site
           # Root: the hand-rolled landing page + install script, unchanged.
-          cp landing/index.html landing/CNAME landing/install.sh landing/.nojekyll _site/
+          cp landing/index.html landing/CNAME landing/install.sh landing/.nojekyll landing/robots.txt landing/og-image.svg _site/
           # /docs/*: the generated Starlight site (astro.config.mjs sets base: "/docs").
           mkdir -p _site/docs
           cp -r docs/dist/. _site/docs/


### PR DESCRIPTION
## Problem

After merging #1143, the Pages workflow deployed successfully but `https://octo-agent.dev/robots.txt` returns 404. The workflow only copied `index.html`, `CNAME`, `install.sh`, and `.nojekyll` from `landing/` into `_site/`, leaving the new `robots.txt` and `og-image.svg` behind.

## Fix

Copy `landing/robots.txt` and `landing/og-image.svg` during the "Assemble site" step so they are served from the root domain.

## Verification

- The blog and docs sitemaps are already live and returning 200.
- The blog hreflang alternate URL is now correct (`/blog/posts/en/...`, not `/blog/posts/en/en/...`).
- After this PR merges and Pages redeploys, `/robots.txt` and `/og-image.svg` should be reachable.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>