### PR TITLE
fix(server): task.Directory only seeds session.WorkingDir at creation, not every run

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -814,8 +814,9 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 
 	// Anchor the gate at the agent's per-session cwd (not the server default) so
 	// $CWD path rules and relative-path resolution match where the tools
-	// actually run — buildAgent sets a.CWD before every prepareToolTurn call,
-	// and the task path applies its directory ahead of this too.
+	// actually run — buildAgent sets a.CWD from sess.WorkingDir before every
+	// prepareToolTurn call, cron-scheduled sessions included (task.Directory
+	// only ever seeds sess.WorkingDir once, at session creation).
 	engine, err := permission.New(permissionConfigPath(), a.CWD, resolvePermissionMode(), s.memDir, s.homeMemDir)
 	if err != nil {
 		return ctx, nil, nil, func() {}, fmt.Errorf("permission engine: %w", err)

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -94,11 +94,20 @@ func (s *Server) CreateSession(task scheduler.Task) (string, error) {
 		// for this task, never one that already exists.
 		if task.Directory != "" {
 			if err := seedSessionDirectory(sess, task.Directory); err != nil {
-				return sess.ID, err
+				// sess was never Saved — sess.ID names a session that exists
+				// only in memory, not on disk. Returning it here would let
+				// fire() (internal/scheduler/scheduler.go) persist it onto
+				// task.SessionID unconditionally (it doesn't check err before
+				// writing), permanently dangling the task on a session
+				// agent.LoadSession can never load — every subsequent cron
+				// tick would then hit this exact same error again with a
+				// fresh throwaway ID, forever. Return "" instead so a bad
+				// task.Directory can never leak into task.SessionID.
+				return "", err
 			}
 		}
 		if err := sess.Save(); err != nil {
-			return sess.ID, fmt.Errorf("save session: %w", err)
+			return "", fmt.Errorf("save session: %w", err)
 		}
 	}
 	return sess.ID, nil

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -83,14 +83,39 @@ func (s *Server) CreateSession(task scheduler.Task) (string, error) {
 		sess = agent.NewSession(model, s.system)
 		sess.Source = "cron"
 		sess.Title = task.Name
-		// task.Directory is applied at run time: buildAgent recomposes the
-		// system prompt from s.system every turn, so stashing it on sess.System
-		// here would be silently dropped.
+		// task.Directory only seeds the session's WorkingDir here, once, at
+		// creation. After that, sess.WorkingDir (editable any time via the
+		// web Composer's directory chip, PATCH /api/sessions/{id}/working_dir)
+		// is the single source of truth for where this session's tools run —
+		// buildAgent derives both a.CWD and the system prompt's "Working
+		// directory" note from it every turn, and prepareToolTurn wires
+		// tools.WithWorkingDir from a.CWD, so nothing else needs to touch it.
+		// Editing task.Directory later only affects the NEXT session created
+		// for this task, never one that already exists.
+		if task.Directory != "" {
+			if err := seedSessionDirectory(sess, task.Directory); err != nil {
+				return sess.ID, err
+			}
+		}
 		if err := sess.Save(); err != nil {
 			return sess.ID, fmt.Errorf("save session: %w", err)
 		}
 	}
 	return sess.ID, nil
+}
+
+// seedSessionDirectory validates dir and applies it as sess's working
+// directory (see CreateSession's doc comment for why this only ever happens
+// once, at session creation).
+func seedSessionDirectory(sess *agent.Session, dir string) error {
+	fi, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("task directory %q: %w", dir, err)
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("task directory %q is not a directory", dir)
+	}
+	return sess.SetWorkingDir(dir)
 }
 
 // RunTask implements scheduler.Runner. It executes a scheduled task by
@@ -196,16 +221,13 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 		"status":     "running",
 	})
 
+	// buildAgent derives a.CWD (and the system prompt's "Working directory"
+	// note) from sess.WorkingDir, which CreateSession seeded from
+	// task.Directory when this session was first created — nothing task-
+	// specific needs to happen here; prepareToolTurn below wires
+	// tools.WithWorkingDir from a.CWD the same way it does for every other
+	// session.
 	a := s.buildAgent(sess)
-
-	// Apply the task's working directory so the run actually happens there.
-	if task.Directory != "" {
-		var derr error
-		if runCtx, derr = applyTaskDirectory(runCtx, a, task.Directory); derr != nil {
-			sw.error(derr.Error())
-			return sessionID, derr
-		}
-	}
 
 	var toolDefs []agent.ToolDefinition
 	var executor agent.ToolExecutor
@@ -300,29 +322,6 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 		return sessionID, fmt.Errorf("run task: %w", err)
 	}
 	return sessionID, nil
-}
-
-// applyTaskDirectory roots a task run at dir: tools (terminal + file ops)
-// resolve relative paths against it via WorkingDir(ctx), the planner uses it
-// (a.CWD), and the model is told its cwd in both system-prompt variants (so a
-// lean explore sub-agent sees it too) — buildAgent composed System/LeanSystem
-// from the server cwd, so this note corrects it. Errors if dir isn't a usable
-// directory rather than running the whole turn against a broken root.
-func applyTaskDirectory(ctx context.Context, a *agent.Agent, dir string) (context.Context, error) {
-	fi, err := os.Stat(dir)
-	if err != nil {
-		return ctx, fmt.Errorf("task directory %q: %w", dir, err)
-	}
-	if !fi.IsDir() {
-		return ctx, fmt.Errorf("task directory %q is not a directory", dir)
-	}
-	a.CWD = dir
-	note := "Working directory: " + dir
-	a.System = note + "\n\n" + a.System
-	if a.LeanSystem != "" {
-		a.LeanSystem = note + "\n\n" + a.LeanSystem
-	}
-	return tools.WithWorkingDir(ctx, dir), nil
 }
 
 // notifyTaskResult pushes a task run's outcome to every configured IM notify

--- a/internal/server/tasks_handlers_test.go
+++ b/internal/server/tasks_handlers_test.go
@@ -92,8 +92,17 @@ func TestCreateSession_InvalidDirectoryErrors(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
 
 	missing := filepath.Join(t.TempDir(), "nope")
-	if _, err := srv.CreateSession(scheduler.Task{Name: "t", Directory: missing}); err == nil {
-		t.Error("expected an error for a missing task directory")
+	sessionID, err := srv.CreateSession(scheduler.Task{Name: "t", Directory: missing})
+	if err == nil {
+		t.Fatal("expected an error for a missing task directory")
+	}
+	// The failed seed means sess.Save() was never called — sess.ID names a
+	// session that exists only in memory. Returning it anyway would let
+	// scheduler.fire() (which persists task.SessionID unconditionally,
+	// without checking RunTask's error) permanently dangle the task on a
+	// session ID agent.LoadSession can never load.
+	if sessionID != "" {
+		t.Errorf("sessionID = %q, want empty on error (must not return an unsaved session's ID)", sessionID)
 	}
 }
 

--- a/internal/server/tasks_handlers_test.go
+++ b/internal/server/tasks_handlers_test.go
@@ -1,64 +1,31 @@
 package server
 
 import (
-	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
-	"github.com/open-octo/octo-agent/internal/tools"
+	"github.com/open-octo/octo-agent/internal/scheduler"
 )
 
-func TestApplyTaskDirectory_RootsTheRun(t *testing.T) {
+func TestSeedSessionDirectory_SetsWorkingDir(t *testing.T) {
 	dir := t.TempDir()
-	a := agent.New(nil, "m")
-	a.System = "SYS"
-	a.LeanSystem = "LEAN"
-
-	ctx, err := applyTaskDirectory(context.Background(), a, dir)
-	if err != nil {
-		t.Fatalf("applyTaskDirectory: %v", err)
+	sess := agent.NewSession("m", "")
+	if err := seedSessionDirectory(sess, dir); err != nil {
+		t.Fatalf("seedSessionDirectory: %v", err)
 	}
-	// Tools resolve against the dir.
-	if got := tools.WorkingDir(ctx); got != dir {
-		t.Errorf("WorkingDir(ctx) = %q, want %q", got, dir)
-	}
-	// Planner / project context use it.
-	if a.CWD != dir {
-		t.Errorf("a.CWD = %q, want %q", a.CWD, dir)
-	}
-	// The model is told its cwd in both system-prompt variants, and the
-	// original content is preserved.
-	want := "Working directory: " + dir
-	if !strings.HasPrefix(a.System, want) || !strings.HasSuffix(a.System, "SYS") {
-		t.Errorf("a.System = %q", a.System)
-	}
-	if !strings.HasPrefix(a.LeanSystem, want) || !strings.HasSuffix(a.LeanSystem, "LEAN") {
-		t.Errorf("a.LeanSystem = %q", a.LeanSystem)
+	if sess.WorkingDir != dir {
+		t.Errorf("sess.WorkingDir = %q, want %q", sess.WorkingDir, dir)
 	}
 }
 
-func TestApplyTaskDirectory_EmptyLeanSystemUntouched(t *testing.T) {
-	a := agent.New(nil, "m")
-	a.System = "SYS"
-	// No LeanSystem (e.g. a path that didn't compose one).
-	if _, err := applyTaskDirectory(context.Background(), a, t.TempDir()); err != nil {
-		t.Fatal(err)
-	}
-	if a.LeanSystem != "" {
-		t.Errorf("empty LeanSystem should stay empty, got %q", a.LeanSystem)
-	}
-}
-
-func TestApplyTaskDirectory_InvalidDirErrors(t *testing.T) {
-	a := agent.New(nil, "m")
-	a.System = "SYS"
+func TestSeedSessionDirectory_InvalidDirErrors(t *testing.T) {
+	sess := agent.NewSession("m", "")
 
 	// Missing directory.
 	missing := filepath.Join(t.TempDir(), "nope")
-	if _, err := applyTaskDirectory(context.Background(), a, missing); err == nil {
+	if err := seedSessionDirectory(sess, missing); err == nil {
 		t.Error("expected an error for a missing directory")
 	}
 
@@ -67,12 +34,102 @@ func TestApplyTaskDirectory_InvalidDirErrors(t *testing.T) {
 	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := applyTaskDirectory(context.Background(), a, f); err == nil {
+	if err := seedSessionDirectory(sess, f); err == nil {
 		t.Error("expected an error when the path is a file, not a directory")
 	}
 
-	// A failed apply must not have mutated the system prompt.
-	if a.System != "SYS" {
-		t.Errorf("System mutated on error: %q", a.System)
+	// A failed seed must not have mutated WorkingDir.
+	if sess.WorkingDir != "" {
+		t.Errorf("WorkingDir mutated on error: %q", sess.WorkingDir)
+	}
+}
+
+// task.Directory only seeds a NEW session's WorkingDir, once, at creation
+// (see CreateSession's doc comment) — this pins that behavior end to end.
+func TestCreateSession_SeedsWorkingDirFromTaskDirectory(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	dir := t.TempDir()
+	sessionID, err := srv.CreateSession(scheduler.Task{Name: "t", Directory: dir})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	sess, err := agent.LoadSession(sessionID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if sess.WorkingDir != dir {
+		t.Errorf("sess.WorkingDir = %q, want %q", sess.WorkingDir, dir)
+	}
+}
+
+// No Directory set on the task → the session is created with no WorkingDir
+// of its own, falling back to the server default like any other session.
+func TestCreateSession_NoDirectoryLeavesWorkingDirEmpty(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	sessionID, err := srv.CreateSession(scheduler.Task{Name: "t"})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	sess, err := agent.LoadSession(sessionID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if sess.WorkingDir != "" {
+		t.Errorf("sess.WorkingDir = %q, want empty", sess.WorkingDir)
+	}
+}
+
+// An invalid task.Directory must fail session creation outright rather than
+// silently falling back to the server default — the same standard
+// applyTaskDirectory used to hold before this was moved to creation time.
+func TestCreateSession_InvalidDirectoryErrors(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	missing := filepath.Join(t.TempDir(), "nope")
+	if _, err := srv.CreateSession(scheduler.Task{Name: "t", Directory: missing}); err == nil {
+		t.Error("expected an error for a missing task directory")
+	}
+}
+
+// Once a session exists for a task, re-running CreateSession (as every
+// subsequent cron fire does) must reuse it untouched — task.Directory plays
+// no further role, even if it was edited via PATCH /api/tasks/{id} in the
+// meantime. This is the behavior change from the old "apply task.Directory
+// fresh on every run" design: editing a task's directory only affects the
+// NEXT session created for it, never one that's already running.
+func TestCreateSession_ReusesExistingSession_LaterDirectoryEditIgnored(t *testing.T) {
+	setTestHome(t)
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	firstDir := t.TempDir()
+	sessionID, err := srv.CreateSession(scheduler.Task{Name: "t", Directory: firstDir})
+	if err != nil {
+		t.Fatalf("CreateSession (first): %v", err)
+	}
+
+	// Simulate the task being edited (PATCH /api/tasks/{id}) to point at a
+	// different directory, then firing again with the existing SessionID —
+	// exactly what every real cron trigger after the first does.
+	secondDir := t.TempDir()
+	sessionID2, err := srv.CreateSession(scheduler.Task{Name: "t", Directory: secondDir, SessionID: sessionID})
+	if err != nil {
+		t.Fatalf("CreateSession (reuse): %v", err)
+	}
+	if sessionID2 != sessionID {
+		t.Fatalf("expected the existing session to be reused, got a new id %q", sessionID2)
+	}
+
+	sess, err := agent.LoadSession(sessionID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if sess.WorkingDir != firstDir {
+		t.Errorf("sess.WorkingDir = %q, want unchanged %q (task.Directory edits shouldn't touch an existing session)", sess.WorkingDir, firstDir)
 	}
 }


### PR DESCRIPTION
## Summary

No linked issue — came out of a design discussion about scheduled-task working directories: the old design had two competing "where does this session run" fields (`task.Directory` and `sess.WorkingDir`) that silently fought each other.

Previously `RunTask` applied `task.Directory` fresh on **every** cron run (`applyTaskDirectory`), overriding `a.CWD`/the system prompt/`tools.WithWorkingDir` unconditionally whenever it was set — regardless of the session's own `WorkingDir`. Meanwhile the web Composer's directory chip (`PATCH /api/sessions/{id}/working_dir`) already lets you view/edit `sess.WorkingDir` for *any* session, cron-created or not. Result: editing a cron session's directory via the Composer had zero effect on its next scheduled run whenever `task.Directory` was set, with no UI indication that a second, higher-priority field existed.

This simplifies to one concept: `task.Directory` now only **seeds** `sess.WorkingDir` once, when `CreateSession` creates a brand-new session for a task. After that, `sess.WorkingDir` is the sole source of truth — editable any time via the Composer, exactly like any other session. Editing `task.Directory` via `PATCH /api/tasks/{id}` only affects the *next* session created for that task, never one that's already running.

`RunTask` no longer needs any task-specific directory logic at all: `buildAgent` already derives `a.CWD` and the system prompt's "Working directory" note from `sess.WorkingDir` (`sessionCwdEnv` → `buildEnvContext`), and `prepareToolTurn` already wires `tools.WithWorkingDir` from `a.CWD` for every session (fixed generally by #1140). Once `sess.WorkingDir` is seeded correctly, the existing machinery just works — no parallel code path needed. `applyTaskDirectory` is deleted entirely.

**Intentional behavior change**: editing a task's `Directory` after its session already exists no longer affects that session — previously it did, on every subsequent run.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] `go test -race ./internal/server/...`
- [x] Replaced the old `TestApplyTaskDirectory_*` tests (which tested the deleted function directly) with tests covering `seedSessionDirectory` and `CreateSession`'s seed-once / reuse-untouched / invalid-directory-errors behavior end to end