### PR TITLE
fix(tui): strip Go's "exit status" wrapper from the terminal card header

### DIFF
--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -120,7 +120,7 @@ func renderToolCard(toolName string, input map[string]any, output string, isErr 
 		if body, exit := splitTerminalExit(output); exit != "" {
 			output = body
 			opts.IsErr = true
-			opts.Meta = joinMeta("exit "+exit, opts.Meta)
+			opts.Meta = joinMeta(formatExitReason(exit), opts.Meta)
 		}
 	case "terminal_output", "kill_shell", "terminal_input":
 		opts.Tail = true
@@ -151,8 +151,11 @@ func nonBlankLineCount(s string) int {
 
 // splitTerminalExit detaches the trailing "[exit: …]" marker the terminal
 // tool appends on a non-zero exit (internal/tools/terminal.go). It returns
-// the output without the marker line plus the exit text ("1", "signal:
-// killed"), or (output, "") when no marker is present.
+// the output without the marker line plus the raw exit text embedded in the
+// marker — Go's *exec.ExitError.Error() string passed straight through,
+// e.g. "exit status 1" for a normal nonzero exit or "signal: killed" for a
+// killed process, never a bare code — or (output, "") when no marker is
+// present.
 func splitTerminalExit(output string) (body, exit string) {
 	trimmed := strings.TrimRight(output, "\n")
 	last := trimmed
@@ -165,6 +168,21 @@ func splitTerminalExit(output string) (body, exit string) {
 	exit = strings.TrimSuffix(strings.TrimPrefix(last, "[exit: "), "]")
 	body = strings.TrimRight(trimmed[:len(trimmed)-len(last)], "\n")
 	return body, exit
+}
+
+// formatExitReason turns splitTerminalExit's raw exit text into the card
+// header meta string. The text is Go's *exec.ExitError.Error() passed
+// through verbatim, so "exit status N" — not a bare "N" — is what a normal
+// nonzero exit actually looks like; without stripping that wrapper, the
+// header rendered the redundant "exit exit status 1" for every ordinary
+// failing command (#1146, found while fixing the identical bug in the web
+// client's equivalent card, #1106/#1145). "signal: NAME" already reads fine
+// standalone and is returned as-is, not double-prefixed with "exit ".
+func formatExitReason(exit string) string {
+	if code, ok := strings.CutPrefix(exit, "exit status "); ok {
+		return "exit " + code
+	}
+	return exit
 }
 
 // formatElapsed renders a tool call's duration for the card header: "" when

--- a/cmd/octo/toolcards_test.go
+++ b/cmd/octo/toolcards_test.go
@@ -106,19 +106,53 @@ func TestRenderToolCard_TerminalShowsTail(t *testing.T) {
 }
 
 func TestRenderToolCard_TerminalExitLiftedToHeader(t *testing.T) {
-	out := "compiling\nfailure detail\n[exit: 1]"
+	// "exit status 1" is the real marker shape terminal.go embeds — Go's
+	// *exec.ExitError.Error() passed through verbatim, not the bare "1"
+	// this test used before #1146. The bare-code fixture let the header
+	// silently render "exit exit status 1" for every real failing command
+	// while this test stayed green, since it never exercised the real shape.
+	out := "compiling\nfailure detail\n[exit: exit status 1]"
 	got := renderToolCard("terminal", map[string]any{"command": "make"}, out, false, 0, 1500*time.Millisecond)
 	if !strings.Contains(got, "exit 1") {
 		t.Errorf("exit code should surface in the header meta; got:\n%s", got)
 	}
+	if strings.Contains(got, "exit exit status 1") {
+		t.Errorf("header must not show the raw ExitError text verbatim; got:\n%s", got)
+	}
 	if !strings.Contains(got, "1.5s") {
 		t.Errorf("elapsed should surface in the header meta; got:\n%s", got)
 	}
-	if strings.Contains(got, "[exit: 1]") {
+	if strings.Contains(got, "[exit: exit status 1]") {
 		t.Errorf("raw exit marker should be stripped from the body; got:\n%s", got)
 	}
 	if !strings.Contains(got, "failure detail") {
 		t.Errorf("body should keep the real output; got:\n%s", got)
+	}
+}
+
+func TestRenderToolCard_TerminalKilledSignalInHeader(t *testing.T) {
+	out := "long output\n[exit: signal: killed]"
+	got := renderToolCard("terminal", map[string]any{"command": "sleep 999"}, out, false, 0, 0)
+	if !strings.Contains(got, "signal: killed") {
+		t.Errorf("signal text should surface in the header meta; got:\n%s", got)
+	}
+	if strings.Contains(got, "exit signal: killed") {
+		t.Errorf(`signal text should not be double-prefixed with "exit "; got:`+"\n%s", got)
+	}
+}
+
+func TestFormatExitReason(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"exit status 1", "exit 1"},
+		{"exit status 127", "exit 127"},
+		{"signal: killed", "signal: killed"},
+		{"signal: segmentation fault", "signal: segmentation fault"},
+		{"1", "1"}, // unrecognized/legacy shape: pass through, don't guess
+	}
+	for _, c := range cases {
+		if got := formatExitReason(c.in); got != c.want {
+			t.Errorf("formatExitReason(%q) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1146 — TUI counterpart of the web fix in #1106/#1145, same root cause.

The `[exit: …]` marker `internal/tools/terminal.go` appends on a non-zero exit embeds Go's `*exec.ExitError.Error()` text verbatim: `"exit status N"` for a normal nonzero exit, `"signal: NAME"` for a killed process — never a bare code. `cmd/octo/toolcards.go`'s card-header logic assumed a bare code and unconditionally prefixed it with `"exit "`, so the header rendered **`exit exit status 1`** for every ordinary failing command (`make test`, a failing script, anything with a plain nonzero exit).

`splitTerminalExit`'s own doc comment claimed the exit text was `"1"`, `"signal: killed"` — never actually true. Every existing test only exercised the synthetic `"[exit: 1]"` shape, not the real `"[exit: exit status 1]"` one, which is exactly why this shipped unnoticed when the terminal card work landed in #1098.

## Changes

- New `formatExitReason(exit string) string`: strips the `"exit status "` wrapper down to `"exit N"`; `"signal: NAME"` already reads fine standalone and passes through unchanged (not double-prefixed with `"exit "`).
- Fixed `splitTerminalExit`'s doc comment to describe the real marker shape.
- Replaced the bare-code fixture in `TestRenderToolCard_TerminalExitLiftedToHeader` with the real `"exit status 1"` marker.
- Added `TestRenderToolCard_TerminalKilledSignalInHeader` and `TestFormatExitReason` so a bare-code regression can't hide behind a fabricated fixture again.

Verified the fix is real with a standalone comparison of old vs. new formatting against both marker shapes: old renders `exit exit status 1` / `exit signal: killed`; new renders `exit 1` / `signal: killed`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] `go test -race ./cmd/octo/...`