### PR TITLE
fix(web): show_reasoning toggle silently no-ops for a non-default model

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -298,6 +298,22 @@ func (c *Config) SetDefaultEntry(e ModelEntry) {
 	c.DefaultModel = e.Model
 }
 
+// SetEntry replaces the entry matching e.Model in place. Unlike
+// SetDefaultEntry, it never appends a new entry and never touches
+// DefaultModel/LiteModel — it's for updating an already-configured entry by
+// name (e.g. a per-session setting change that should land on the specific
+// model that session runs, not necessarily the default one). Reports whether
+// a matching entry was found.
+func (c *Config) SetEntry(e ModelEntry) bool {
+	for i := range c.Models {
+		if c.Models[i].Model == e.Model {
+			c.Models[i] = e
+			return true
+		}
+	}
+	return false
+}
+
 // Path returns the absolute path to the config file (~/.octo/config.yml).
 func Path() (string, error) {
 	home, err := os.UserHomeDir()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -95,7 +95,7 @@ func (srv *Server) toSessionItem(s *agent.Session, source, agentProfile string) 
 	if name == "" {
 		name = s.DisplayTitle()
 	}
-	_, pm, re, sr, ctxUsage := srv.sessionStatusFields()
+	_, pm, re, sr, ctxUsage := srv.sessionStatusFields(s)
 	return sessionItem{
 		ID:              s.ID,
 		Name:            name,
@@ -117,17 +117,39 @@ func (srv *Server) toSessionItem(s *agent.Session, source, agentProfile string) 
 	}
 }
 
+// entryForSession returns the model-config entry that actually backs sess's
+// turns — the same resolution senderForSession uses (sess.ModelConfig when
+// set and still configured, else the default entry) — or the default entry
+// when sess is nil (no specific session in scope, e.g. the onboarding
+// response). Before this existed, every reasoning_effort/show_reasoning
+// status read and every "toggle it for this session" write resolved from
+// cfg.DefaultEntry() unconditionally: a session actually running a
+// non-default model (turns themselves were never affected — senderForSession
+// already resolved the right entry for those) still saw the WRONG value in
+// its own status bar, and toggling it via that session's Composer visibly
+// flipped the icon — since the read and the write both used the same wrong
+// entry — while never touching the entry that session's real turns read.
+func entryForSession(cfg config.Config, sess *agent.Session) config.ModelEntry {
+	if sess != nil && sess.ModelConfig != "" {
+		if e, ok := cfg.EntryByModel(sess.ModelConfig); ok {
+			return e
+		}
+	}
+	return cfg.DefaultEntry()
+}
+
 // sessionStatusFields returns the server-level session metadata (permission
 // mode, reasoning effort, show reasoning, current context usage) plus the
-// DEFAULT working dir. The Web UI mirrors the CLI bottom status bar, so these
-// values are surfaced on every session descriptor. Working dir is per-session:
-// callers with a session in hand override the returned value via sessionCwd /
-// sessionCwdByID; the default here is the fallback for sessions with none.
-func (srv *Server) sessionStatusFields() (workingDir, permissionMode, reasoningEffort string, showReasoning *bool, contextUsage int) {
+// DEFAULT working dir, resolved against sess's own model-config entry (see
+// entryForSession) — pass nil when no specific session is in scope. Working
+// dir is per-session regardless: callers with a session in hand override the
+// returned value via sessionCwd / sessionCwdByID; the default here is the
+// fallback for sessions with none.
+func (srv *Server) sessionStatusFields(sess *agent.Session) (workingDir, permissionMode, reasoningEffort string, showReasoning *bool, contextUsage int) {
 	workingDir = srv.cwd
 	permissionMode = string(resolvePermissionMode())
 	if cfg, err := config.Load(); err == nil {
-		entry := cfg.DefaultEntry()
+		entry := entryForSession(cfg, sess)
 		reasoningEffort = entry.ReasoningEffort
 		eff := cfg.EffectiveShowReasoning(entry.ShowReasoning)
 		showReasoning = &eff
@@ -1187,10 +1209,22 @@ func (s *Server) handleUpdateSessionReasoningEffort(w http.ResponseWriter, r *ht
 		return
 	}
 
+	sess, err := agent.LoadSession(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	// Resolve and mutate the entry THIS session actually runs on (see
+	// entryForSession) — not always the default entry, so a session pinned
+	// to a non-default model actually gets its own reasoning_effort changed
+	// instead of silently editing an unrelated model's config.
 	cfg, _ := config.Load()
-	entry := cfg.DefaultEntry()
+	entry := entryForSession(cfg, sess)
 	entry.ReasoningEffort = level
-	cfg.SetDefaultEntry(entry)
+	if !cfg.SetEntry(entry) {
+		cfg.SetDefaultEntry(entry)
+	}
 	if err := cfg.Save(); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return
@@ -1204,12 +1238,14 @@ func (s *Server) handleUpdateSessionReasoningEffort(w http.ResponseWriter, r *ht
 		slog.Error("reload default sender after reasoning_effort change", "err", err)
 	}
 
-	// Push the new effective reasoning_effort to every known session so the
-	// composer status bar refreshes immediately.
+	// Push each session's own effective reasoning_effort — resolved against
+	// ITS OWN model entry, not the one that just changed — so a toggle for
+	// this session's model doesn't paint every other open tab's status bar
+	// with this session's value.
 	if s.wsHub != nil {
-		_, pm, re, sr, _ := s.sessionStatusFields()
 		sessions, _ := agent.ListSessions(50)
 		for _, sess := range sessions {
+			_, pm, re, sr, _ := s.sessionStatusFields(sess)
 			s.wsHub.broadcast(sess.ID, map[string]any{
 				"type":             "session_update",
 				"session_id":       sess.ID,
@@ -1268,11 +1304,14 @@ func (s *Server) handleUpdateSessionPermissionMode(w http.ResponseWriter, r *htt
 
 	// Push the new mode to every known session so each composer status bar
 	// refreshes immediately. The engine reads cfg on its next turn, so no
-	// sender rebuild is needed here.
+	// sender rebuild is needed here. permission_mode itself has no per-entry
+	// variance, but reasoning_effort/show_reasoning do — resolve each per its
+	// own session (see entryForSession) so this broadcast doesn't paint every
+	// session with whichever model's values happen to be looked up first.
 	if s.wsHub != nil {
-		_, pm, re, sr, _ := s.sessionStatusFields()
 		sessions, _ := agent.ListSessions(50)
 		for _, sess := range sessions {
+			_, pm, re, sr, _ := s.sessionStatusFields(sess)
 			s.wsHub.broadcast(sess.ID, map[string]any{
 				"type":             "session_update",
 				"session_id":       sess.ID,
@@ -1296,9 +1335,15 @@ type updateSessionShowReasoningRequest struct {
 	ShowReasoning bool `json:"show_reasoning"`
 }
 
-// handleUpdateSessionShowReasoning updates whether reasoning traces are shown.
-// Like reasoning_effort, this is stored on the default model entry and
-// broadcast to all sessions so the composer status bar updates immediately.
+// handleUpdateSessionShowReasoning updates whether reasoning traces are shown
+// for the model THIS session actually runs on (see entryForSession) — not
+// always the default entry. Before this, the toggle always wrote to
+// cfg.DefaultEntry(): for a session pinned to a non-default model, the
+// Composer's eye icon still visibly flipped (the status read came from the
+// same wrong entry the write used), but the session's real turns — gated by
+// senderForSession's correct per-entry resolution — never actually changed,
+// so reasoning kept showing (or hiding) no matter how many times it was
+// toggled.
 func (s *Server) handleUpdateSessionShowReasoning(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
@@ -1312,28 +1357,39 @@ func (s *Server) handleUpdateSessionShowReasoning(w http.ResponseWriter, r *http
 		return
 	}
 
+	sess, err := agent.LoadSession(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
 	cfg, _ := config.Load()
-	entry := cfg.DefaultEntry()
+	entry := entryForSession(cfg, sess)
 	entry.ShowReasoning = &req.ShowReasoning
-	cfg.SetDefaultEntry(entry)
+	if !cfg.SetEntry(entry) {
+		cfg.SetDefaultEntry(entry)
+	}
 	if err := cfg.Save(); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
 		return
 	}
 
 	// The default sender embeds show_reasoning; rebuild it so existing
-	// unbound sessions pick up the new value on their next turn.
+	// unbound sessions pick up the new value on their next turn. Per-entry
+	// senders are rebuilt lazily via invalidateSenderCache.
 	s.invalidateSenderCache()
 	if err := s.reloadDefaultSender(); err != nil {
 		slog.Error("reload default sender after show_reasoning change", "err", err)
 	}
 
-	// Push the new effective show_reasoning to every known session so the
-	// composer status bar refreshes immediately.
+	// Push each session's own effective show_reasoning — resolved against ITS
+	// OWN model entry, not the one that just changed — so a toggle for this
+	// session's model doesn't paint every other open tab's status bar with
+	// this session's value.
 	if s.wsHub != nil {
-		_, pm, re, sr, _ := s.sessionStatusFields()
 		sessions, _ := agent.ListSessions(50)
 		for _, sess := range sessions {
+			_, pm, re, sr, _ := s.sessionStatusFields(sess)
 			s.wsHub.broadcast(sess.ID, map[string]any{
 				"type":             "session_update",
 				"session_id":       sess.ID,

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1185,7 +1185,10 @@ type updateSessionReasoningEffortRequest struct {
 	ReasoningEffort string `json:"reasoning_effort"`
 }
 
-// handleUpdateSessionReasoningEffort updates the global reasoning-effort tuning.
+// handleUpdateSessionReasoningEffort updates the reasoning-effort tuning for
+// the model THIS session actually runs on (see entryForSession) — not always
+// the default entry, for the same reason and by the same fix as
+// handleUpdateSessionShowReasoning's doc comment describes.
 // Valid levels: "off", "low", "medium", "high", "xhigh", "max". Empty is normalised to "off".
 func (s *Server) handleUpdateSessionReasoningEffort(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -259,22 +259,26 @@ func (s *Server) handlePutShowReasoning(w http.ResponseWriter, r *http.Request) 
 		log.Printf("[server] reload default sender after show_reasoning change: %v", err)
 	}
 
-	// Push the new effective default to every open session so the composer
-	// status bar refreshes immediately.
-	_, pm, re, sr, ctxUsage := s.sessionStatusFields()
-	if sr != nil {
-		sessions, _ := agent.ListSessions(50)
-		for _, sess := range sessions {
-			s.wsHub.broadcast(sess.ID, map[string]any{
-				"type":             "session_update",
-				"session_id":       sess.ID,
-				"working_dir":      s.sessionCwd(sess),
-				"permission_mode":  pm,
-				"reasoning_effort": re,
-				"show_reasoning":   *sr,
-				"context_usage":    ctxUsage,
-			})
+	// Push each session's own effective show_reasoning — resolved against ITS
+	// OWN model entry (see entryForSession), which falls back to this new
+	// global default only when that entry has no explicit override of its
+	// own — so this doesn't paint a session pinned to a model with its own
+	// show_reasoning: true/false with the new global value it's shielded from.
+	sessions, _ := agent.ListSessions(50)
+	for _, sess := range sessions {
+		_, pm, re, sr, ctxUsage := s.sessionStatusFields(sess)
+		if sr == nil {
+			continue
 		}
+		s.wsHub.broadcast(sess.ID, map[string]any{
+			"type":             "session_update",
+			"session_id":       sess.ID,
+			"working_dir":      s.sessionCwd(sess),
+			"permission_mode":  pm,
+			"reasoning_effort": re,
+			"show_reasoning":   *sr,
+			"context_usage":    ctxUsage,
+		})
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "show_reasoning": req.ShowReasoning})

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -153,7 +153,7 @@ func TestConfig_ShowReasoningReloadsDefaultSender(t *testing.T) {
 	}
 
 	// The effective show_reasoning broadcast value should reflect the new default.
-	_, _, _, sr, _ := srv.sessionStatusFields()
+	_, _, _, sr, _ := srv.sessionStatusFields(sess)
 	if sr == nil || *sr {
 		t.Fatalf("effective show_reasoning = %+v, want false", sr)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1145,6 +1145,144 @@ func TestHandleUpdateSessionReasoningEffort(t *testing.T) {
 	}
 }
 
+// A session pinned to a NON-default model must have ITS OWN entry's
+// reasoning_effort changed — not the unrelated default model's. Before this
+// was fixed, every PATCH landed on cfg.DefaultEntry() regardless of which
+// session triggered it, so a multi-model setup's per-session tuning silently
+// no-opped for any session not running the default model.
+func TestHandleUpdateSessionReasoningEffort_NonDefaultModel(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			{Provider: "deepseek", Model: "deepseek-v4-flash"},
+		},
+		DefaultModel: "claude-sonnet-4-6",
+	})
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	sess := agent.NewSession("deepseek-v4-flash", "")
+	sess.ModelConfig = "deepseek-v4-flash"
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	payload, _ := json.Marshal(updateSessionReasoningEffortRequest{ReasoningEffort: "xhigh"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/"+sess.ID+"/reasoning_effort", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, ok := cfg.EntryByModel("deepseek-v4-flash")
+	if !ok {
+		t.Fatal("deepseek-v4-flash entry vanished")
+	}
+	if e.ReasoningEffort != "xhigh" {
+		t.Errorf("deepseek-v4-flash reasoning_effort = %q, want xhigh (this session's own entry should change)", e.ReasoningEffort)
+	}
+	if def := cfg.DefaultEntry(); def.ReasoningEffort != "" {
+		t.Errorf("default entry (claude-sonnet-4-6) reasoning_effort = %q, want untouched (empty)", def.ReasoningEffort)
+	}
+}
+
+// The reported bug (#web show_reasoning field not respected): a session
+// pinned to a non-default model must have ITS OWN entry's show_reasoning
+// toggled. Before this fix, the toggle always wrote to cfg.DefaultEntry()
+// while the session's actual turns (senderForSession) already correctly
+// resolved the session's own entry — so the Composer's eye icon flipped
+// (read and write both hit the same wrong entry) while reasoning kept
+// showing/hiding no matter how many times it was toggled.
+func TestHandleUpdateSessionShowReasoning_NonDefaultModel(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models: []config.ModelEntry{
+			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			{Provider: "deepseek", Model: "deepseek-v4-flash"},
+		},
+		DefaultModel: "claude-sonnet-4-6",
+	})
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	sess := agent.NewSession("deepseek-v4-flash", "")
+	sess.ModelConfig = "deepseek-v4-flash"
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	payload, _ := json.Marshal(updateSessionShowReasoningRequest{ShowReasoning: false})
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/"+sess.ID+"/show_reasoning", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, ok := cfg.EntryByModel("deepseek-v4-flash")
+	if !ok {
+		t.Fatal("deepseek-v4-flash entry vanished")
+	}
+	if e.ShowReasoning == nil || *e.ShowReasoning {
+		t.Errorf("deepseek-v4-flash show_reasoning = %v, want false (this session's own entry should be toggled)", e.ShowReasoning)
+	}
+	if def := cfg.DefaultEntry(); def.ShowReasoning != nil {
+		t.Errorf("default entry (claude-sonnet-4-6) show_reasoning = %v, want untouched (nil)", def.ShowReasoning)
+	}
+
+	// senderForSession must resolve this session's turns against the SAME
+	// (now-updated) entry the toggle just wrote — proving the fix actually
+	// changes what the session's real turns do, not just what the config
+	// file happens to say.
+	if got := cfg.EffectiveShowReasoning(entryForSession(cfg, sess).ShowReasoning); got {
+		t.Error("entryForSession(sess) still resolves show_reasoning=true after toggling it off for this session")
+	}
+}
+
+// entryForSession must resolve the SAME entry senderForSession does: the
+// session's own ModelConfig when it's still configured, else the default
+// entry — including graceful fallback when a session references a model
+// that's since been removed from config.
+func TestEntryForSession(t *testing.T) {
+	cfg := config.Config{
+		Models: []config.ModelEntry{
+			{Model: "model-a"},
+			{Model: "model-b"},
+		},
+		DefaultModel: "model-a",
+	}
+
+	cases := []struct {
+		name      string
+		sess      *agent.Session
+		wantModel string
+	}{
+		{"nil session falls back to default", nil, "model-a"},
+		{"unbound session falls back to default", &agent.Session{}, "model-a"},
+		{"bound to a configured non-default model", &agent.Session{ModelConfig: "model-b"}, "model-b"},
+		{"bound to a since-deleted model falls back to default", &agent.Session{ModelConfig: "model-gone"}, "model-a"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := entryForSession(cfg, c.sess); got.Model != c.wantModel {
+				t.Errorf("entryForSession(...).Model = %q, want %q", got.Model, c.wantModel)
+			}
+		})
+	}
+}
+
 func TestHandleUpdateSessionPermissionMode(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -315,7 +315,7 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 			ctxPct = 100
 		}
 	}
-	_, pm, re, _, _ := s.sessionStatusFields()
+	_, pm, re, _, _ := s.sessionStatusFields(sess)
 	s.wsHub.broadcast(sessionID, map[string]any{
 		"type":             "session_update",
 		"session_id":       sessionID,

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -89,13 +89,13 @@ func (s *Server) listSessionsBrief() []wsSessionInfo {
 	if err != nil {
 		return nil
 	}
-	_, pm, re, sr, ctxUsage := s.sessionStatusFields()
 	out := make([]wsSessionInfo, 0, len(sessions))
 	for _, sess := range sessions {
 		source := sess.Source
 		if source == "" {
 			source = "manual"
 		}
+		_, pm, re, sr, ctxUsage := s.sessionStatusFields(sess)
 		out = append(out, wsSessionInfo{
 			ID:              sess.ID,
 			Name:            sess.DisplayTitle(),
@@ -132,18 +132,17 @@ func (s *Server) sendContextUsage(sessionID string, conn *wsConn) {
 	s.sessionAgentsMu.Lock()
 	a := s.sessionAgents[sessionID]
 	s.sessionAgentsMu.Unlock()
+	sess, _ := agent.LoadSession(sessionID)
 	if a != nil {
 		if used, window := a.ContextUsage(); window > 0 && used > 0 {
 			pct = used * 100 / window
 			usedTokens = used
 		}
 	}
-	if pct == 0 {
-		if sess, err := agent.LoadSession(sessionID); err == nil {
-			pct = estimateContextPct(sess)
-			// Cold/resumed session: only a % estimate is available, no exact
-			// token count — leave usedTokens 0 so the UI shows a bare arrow.
-		}
+	if pct == 0 && sess != nil {
+		pct = estimateContextPct(sess)
+		// Cold/resumed session: only a % estimate is available, no exact
+		// token count — leave usedTokens 0 so the UI shows a bare arrow.
 	}
 	if pct <= 0 {
 		return
@@ -151,7 +150,7 @@ func (s *Server) sendContextUsage(sessionID string, conn *wsConn) {
 	if pct > 100 {
 		pct = 100
 	}
-	_, pm, re, _, _ := s.sessionStatusFields()
+	_, pm, re, _, _ := s.sessionStatusFields(sess)
 	b, err := json.Marshal(map[string]any{
 		"type":             "session_update",
 		"session_id":       sessionID,
@@ -286,7 +285,8 @@ func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
 		_, stillLive := s.liveStates[sessionID]
 		s.liveStateMu.RUnlock()
 		if !stillLive {
-			_, pm, re, sr, _ := s.sessionStatusFields()
+			sess, _ := agent.LoadSession(sessionID)
+			_, pm, re, sr, _ := s.sessionStatusFields(sess)
 			if b, err := json.Marshal(map[string]any{
 				"type":             "session_update",
 				"session_id":       sessionID,
@@ -1201,7 +1201,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			ctxPct = 100
 		}
 	}
-	_, pm, re, _, _ := s.sessionStatusFields()
+	_, pm, re, _, _ := s.sessionStatusFields(sess)
 	s.wsHub.broadcast(sess.ID, map[string]any{
 		"type":             "session_update",
 		"session_id":       sess.ID,


### PR DESCRIPTION
## Summary

Reported: "web端没有尊重show_reasoning字段，始终展示Thoughts" (the web UI doesn't respect show_reasoning, Thoughts always show).

**Root cause**, confirmed against a live multi-model config: `PATCH /api/sessions/{id}/show_reasoning` always wrote to `cfg.DefaultEntry()`, regardless of which model the session at `{id}` actually runs on. A session's real turns are gated correctly — `senderForSession` already resolves the session's own entry via `sess.ModelConfig` — but the toggle endpoint never consulted that; it only ever edited the *default* model's `ShowReasoning` field. For a session pinned to any other configured model, toggling the Composer's eye icon edited an unrelated entry: the icon still visibly flipped (the status read used the same wrong entry the write did, so read and write stayed mutually consistent while both disagreeing with reality), while the session's actual reasoning gate never changed — reasoning kept showing (or hiding) no matter how many times it was toggled.

`handleUpdateSessionReasoningEffort` had the identical bug for the same reason; fixed alongside since it's the same root cause in an adjacent, structurally identical handler.

## Changes

- `config.SetEntry(e)` (new): replaces the entry matching `e.Model` in place, without `SetDefaultEntry`'s side effect of repointing `DefaultModel` — for writing to a specific, possibly-non-default entry.
- `entryForSession(cfg, sess)` (new, `internal/server`): resolves the entry that actually backs `sess`'s turns — `sess.ModelConfig` when set and still configured, else the default entry — mirroring `senderForSession`'s own resolution exactly, with a table-driven unit test.
- `sessionStatusFields` now takes a `*agent.Session` and resolves through `entryForSession` instead of always `cfg.DefaultEntry()` — every call site updated to pass the session in scope (`toSessionItem`, the show_reasoning/reasoning_effort/permission_mode PATCH broadcasts — moved inside their "every known session" loops so each session gets ITS OWN resolved values instead of one snapshot painted onto all of them — `RunTask`, `listSessionsBrief`, `sendContextUsage`, `replayLiveState`, the post-turn idle broadcast).
- `handleUpdateSessionShowReasoning` / `handleUpdateSessionReasoningEffort`: load the session, resolve its entry via `entryForSession`, mutate that entry, write back via `cfg.SetEntry` (falling back to `SetDefaultEntry` if the entry vanished from config concurrently).

## Test plan

- [x] New regression tests, verified failing against the pre-fix resolution and passing against the fix (temporarily reverted just the two resolution lines to confirm): a session pinned to a configured non-default model gets ITS OWN entry toggled for both `show_reasoning` and `reasoning_effort`, the unrelated default entry stays untouched, and `entryForSession`'s resolution is pinned directly (nil session, unbound session, bound-to-configured-model, bound-to-since-deleted-model)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] `go test -race ./internal/server/... ./internal/config/...`