### PR TITLE
fix(ci): add Google Search Console verification file

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -51,8 +51,9 @@ jobs:
       - name: Assemble site
         run: |
           mkdir -p _site
-          # Root: the hand-rolled landing page + install script, unchanged.
-          cp landing/index.html landing/CNAME landing/install.sh landing/.nojekyll landing/robots.txt landing/og-image.svg _site/
+          # Root: copy all landing files so new files like robots.txt, OG images,
+          # and Google Search Console verification files are deployed automatically.
+          cp -a landing/. _site/
           # /docs/*: the generated Starlight site (astro.config.mjs sets base: "/docs").
           mkdir -p _site/docs
           cp -r docs/dist/. _site/docs/

--- a/landing/googlee8d3dda912b8c293.html
+++ b/landing/googlee8d3dda912b8c293.html
@@ -1,0 +1,1 @@
+google-site-verification: googlee8d3dda912b8c293.html


### PR DESCRIPTION
Adds the Google Search Console HTML verification file requested by the user.

Also changes the Pages workflow to copy the entire `landing/` directory into the deployed site root, instead of hard-coding a list of files. This avoids future 404s for any new files placed in `landing/` (e.g. `robots.txt`, `og-image.svg`, or verification files like this one).

Files added:
- `landing/googlee8d3dda912b8c293.html`

Co-authored-by: octo-agent <no-reply@octo-agent.dev>