### PR TITLE
fix(seo): add Bing Webmaster Tools verification file

### DIFF
--- a/landing/BingSiteAuth.xml
+++ b/landing/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>1D930922065AE46B05B9FDCD5571E308</user>
+</users>


### PR DESCRIPTION
Adds BingSiteAuth.xml to landing/ for Bing Webmaster Tools ownership verification.

The Pages workflow already copies all of `landing/` to the deployed site root, so no workflow changes are needed.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>