### PR TITLE
fix(seo): adjust meta description lengths

### DIFF
--- a/blog/src/content/posts/en/loop-engineering-practice.md
+++ b/blog/src/content/posts/en/loop-engineering-practice.md
@@ -1,6 +1,6 @@
 ---
 title: "Loop Engineering Series (2): In Practice — Using octo-agent to Automate an Open-Source Repository"
-description: "A full walkthrough of building three loops (issue triage, PR review, auto issue-fix) on the open-octo/octo-agent repository, with real flowcharts and lessons learned."
+description: "A walkthrough of building three loops (issue triage, PR review, auto issue-fix) on the open-octo/octo-agent repo, with flowcharts and lessons learned."
 pubDate: 2026-07-04
 author: "octo-agent team"
 tags: ["loop-engineering", "octo-agent", "workflow", "github-automation"]

--- a/blog/src/pages/index.astro
+++ b/blog/src/pages/index.astro
@@ -16,7 +16,7 @@ const siteUrl = 'https://octo-agent.dev';
 const canonicalUrl = `${siteUrl}/blog/`;
 const alternateUrl = `${siteUrl}/blog/en/`;
 const title = 'octo 博客';
-const description = 'octo-agent 团队的工程笔记、版本更新与技术深度文章。';
+const description = 'octo-agent 团队的工程笔记、版本更新与 AI Agent 技术深度文章，分享 Loop Engineering、工具链与实战经验。';
 const ogImage = `${siteUrl}/blog/og-default.svg`;
 ---
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Octo — A functionality-first AI agent</title>
-  <meta name="description" content="A single Go binary that brings AI agents to your terminal, browser, and chat apps. Anthropic + OpenAI native. Built-in tools, MCP, skills, sandboxing, and persistent memory.">
+  <meta name="description" content="A single Go binary that brings AI agents to your terminal, browser, and chat apps. Built-in tools, MCP, skills, and persistent memory.">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='22' fill='%232F54EB'/%3E%3Cpath fill='%23ffffff' d='M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z'/%3E%3Ccircle cx='40' cy='42' r='5' fill='%232F54EB'/%3E%3Ccircle cx='60' cy='42' r='5' fill='%232F54EB'/%3E%3C/svg%3E">
   <link rel="canonical" href="https://octo-agent.dev/">
   <meta property="og:title" content="Octo — A functionality-first AI agent">
@@ -15,7 +15,7 @@
   <meta property="og:site_name" content="Octo">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Octo — A functionality-first AI agent">
-  <meta name="twitter:description" content="A single Go binary that brings AI agents to your terminal, browser, and chat apps. Anthropic + OpenAI native. Built-in tools, MCP, skills, sandboxing, and persistent memory.">
+  <meta name="twitter:description" content="A single Go binary that brings AI agents to your terminal, browser, and chat apps. Built-in tools, MCP, skills, and persistent memory.">
   <meta name="twitter:image" content="https://octo-agent.dev/og-image.svg">
   <script type="application/ld+json">
   {


### PR DESCRIPTION
Fixes meta descriptions outside the recommended 50-160 character range.

Changes:
- `landing/index.html`: 173 → 134 characters
- `blog/src/pages/index.astro` (Chinese index): 31 → 70 characters
- `blog/src/content/posts/en/loop-engineering-practice.md`: 166 → 150 characters

Co-authored-by: octo-agent <no-reply@octo-agent.dev>