### PR TITLE
fix(seo): add internal links to landing page

### DIFF
--- a/blog/src/layouts/BlogPost.astro
+++ b/blog/src/layouts/BlogPost.astro
@@ -19,8 +19,8 @@ const canonicalPath = pageSlug.startsWith('en/')
 const canonicalUrl = `${siteUrl}${canonicalPath}`;
 
 const navLabels = {
-	en: { home: 'octo blog', docs: 'Docs', github: 'GitHub', lang: 'EN' },
-	zh: { home: 'octo 博客', docs: '文档', github: 'GitHub', lang: '中文' },
+	en: { home: 'octo blog', landing: 'Octo', docs: 'Docs', github: 'GitHub', lang: 'EN' },
+	zh: { home: 'octo 博客', landing: 'Octo', docs: '文档', github: 'GitHub', lang: '中文' },
 };
 const labels = navLabels[locale as keyof typeof navLabels] || navLabels.zh;
 
@@ -72,6 +72,7 @@ const siteName = locale === 'zh' ? 'octo 博客' : 'octo blog';
 			<div class="container">
 				<a href={locale === 'zh' ? '/blog/' : '/blog/en/'} class="site-title">{labels.home}</a>
 				<nav class="site-nav">
+					<a href="https://octo-agent.dev/">{labels.landing}</a>
 					<a href="/docs/">{labels.docs}</a>
 					<a href="https://github.com/open-octo/octo-agent">{labels.github}</a>
 					<a class="lang-switch" href={alternateUrl} title={alternateLabel}>{alternateLabel}</a>
@@ -112,7 +113,7 @@ const siteName = locale === 'zh' ? 'octo 博客' : 'octo blog';
 		<footer class="site-footer">
 			<div class="container">
 				<p>
-					© {new Date().getFullYear()} octo-agent. Built with <a href="https://astro.build">Astro</a>.
+					© {new Date().getFullYear()} <a href="https://octo-agent.dev/">octo-agent</a>. Built with <a href="https://astro.build">Astro</a>.
 				</p>
 			</div>
 		</footer>

--- a/blog/src/pages/en/index.astro
+++ b/blog/src/pages/en/index.astro
@@ -49,6 +49,7 @@ const ogImage = `${siteUrl}/blog/og-default.svg`;
 			<div class="container">
 				<a href="/blog/en/" class="site-title">octo blog</a>
 				<nav class="site-nav">
+					<a href="https://octo-agent.dev/">Octo</a>
 					<a href="/docs/">Docs</a>
 					<a href="https://github.com/open-octo/octo-agent">GitHub</a>
 					<a class="lang-switch" href={alternateUrl} title="中文">中文</a>
@@ -97,7 +98,7 @@ const ogImage = `${siteUrl}/blog/og-default.svg`;
 		<footer class="site-footer">
 			<div class="container">
 				<p>
-					© {new Date().getFullYear()} octo-agent. Built with <a href="https://astro.build">Astro</a>.
+					© {new Date().getFullYear()} <a href="https://octo-agent.dev/">octo-agent</a>. Built with <a href="https://astro.build">Astro</a>.
 				</p>
 			</div>
 		</footer>

--- a/blog/src/pages/index.astro
+++ b/blog/src/pages/index.astro
@@ -49,6 +49,7 @@ const ogImage = `${siteUrl}/blog/og-default.svg`;
 			<div class="container">
 				<a href="/blog/" class="site-title">octo 博客</a>
 				<nav class="site-nav">
+					<a href="https://octo-agent.dev/">Octo</a>
 					<a href="/docs/">文档</a>
 					<a href="https://github.com/open-octo/octo-agent">GitHub</a>
 					<a class="lang-switch" href={alternateUrl} title="English">English</a>
@@ -97,7 +98,7 @@ const ogImage = `${siteUrl}/blog/og-default.svg`;
 		<footer class="site-footer">
 			<div class="container">
 				<p>
-					© {new Date().getFullYear()} octo-agent. Built with <a href="https://astro.build">Astro</a>.
+					© {new Date().getFullYear()} <a href="https://octo-agent.dev/">octo-agent</a>. Built with <a href="https://astro.build">Astro</a>.
 				</p>
 			</div>
 		</footer>

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -29,6 +29,12 @@ export default defineConfig({
 			},
 			sidebar: [
 				{
+					label: 'Home',
+					translations: { 'zh-CN': '首页' },
+					link: 'https://octo-agent.dev/',
+					attrs: { target: '_blank' },
+				},
+				{
 					label: 'Blog',
 					translations: { 'zh-CN': '博客' },
 					link: 'https://octo-agent.dev/blog/',


### PR DESCRIPTION
Improve internal link structure so search engines can discover the landing page from the blog and docs sub-sites.

Changes:
- `docs/astro.config.mjs`: add a "Home" item to the Starlight sidebar that links to `https://octo-agent.dev/`.
- `blog/src/layouts/BlogPost.astro`: add an "Octo" link in post navigation and link the footer `octo-agent` text to the landing page.
- `blog/src/pages/index.astro` and `blog/src/pages/en/index.astro`: add an "Octo" link in the index page navigation and link the footer text.

This complements the sitemap entries by adding explicit crawl paths between docs/blog and the landing page.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>