### PR TITLE
fix(web): hide Thoughts blocks when show_reasoning is disabled

### DIFF
--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -26,7 +26,7 @@ export function escapeHtml(s: string): string {
     .replace(/'/g, "&#39;")
 }
 
-export function renderMarkdown(text: string): string {
+export function renderMarkdown(text: string, showReasoning = true): string {
   if (!text) return ""
 
   // 1. Extract <think>...</think> blocks, replace with placeholders
@@ -34,6 +34,7 @@ export function renderMarkdown(text: string): string {
   const PLACEHOLDER = "\x00THINK_BLOCK_\x00"
 
   const textWithPlaceholders = text.replace(/<think>([\s\S]*?)<\/think>/g, (_match, content: string) => {
+    if (!showReasoning) return ""
     const index = thinkSegments.length
     thinkSegments.push(content)
     return `${PLACEHOLDER}${index}\x00`

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -75,6 +75,7 @@
   let currentSession = $derived($sessions.find(s => s.id === $activeSessionId) ?? null)
   let artifactCount  = $derived($artifacts.length)
   let wsDisconnected = $derived($wsState === 'disconnected')
+  let showReasoning  = $derived($chatShowReasoning[$activeSessionId ?? ''] ?? currentSession?.show_reasoning ?? true)
 
   // Session-level plan panel: collapsed by default so it never occludes the
   // message stream; the user can expand it into a floating dropdown.
@@ -1087,7 +1088,7 @@
                   {/if}
 
                   <!-- Thoughts / reasoning block -->
-                  {#if msg.thinking}
+                  {#if msg.thinking && showReasoning}
                     <details class="think-block">
                       <summary class="think-summary">
                         <iconify-icon icon="ant-design:bulb-outlined" width="13"></iconify-icon>
@@ -1104,7 +1105,7 @@
                       class="rich-answer"
                       use:setupAssistantEl
                     >
-                      {@html renderMarkdown(msg.content)}
+                      {@html renderMarkdown(msg.content, showReasoning)}
                     </div>
                   {/if}
 
@@ -1127,7 +1128,7 @@
                 </div>
               </div>
 
-            {:else if msg.type === 'thinking'}
+            {:else if msg.type === 'thinking' && showReasoning}
               <!-- Standalone Thoughts segment (reasoning before a tool round) -->
               <div class="msg-agent fadein">
                 <div class="agent-avatar"><OctoLogo size={18} /></div>
@@ -1169,7 +1170,7 @@
                   <iconify-icon icon="lucide:info" width="14"></iconify-icon>
                 </div>
                 <div class="agent-content">
-                  <div class="notice-line" data-level={msg.level}>{@html renderMarkdown(msg.content)}</div>
+                  <div class="notice-line" data-level={msg.level}>{@html renderMarkdown(msg.content, showReasoning)}</div>
                 </div>
               </div>
             {/if}
@@ -1186,7 +1187,7 @@
           {/if}
 
           <!-- Live thinking block while streaming -->
-          {#if streaming && thinking}
+          {#if streaming && thinking && showReasoning}
             <div class="msg-agent fadein">
               <div class="agent-avatar"><OctoLogo size={18} /></div>
               <div class="agent-content">
@@ -1196,7 +1197,7 @@
                     <span>{$t('chat.thinking')}</span>
                     <span class="think-meta mono">{fmtDur(thinkElapsed)}{#if thinkTokens > 0} · ↓ ~{fmtTokens(thinkTokens)} tokens{:else if ctxTokens > 0} · ↑ ~{fmtTokens(ctxTokens)} tokens{:else} · ↑{/if}</span>
                   </summary>
-                  <div class="think-body" use:setupAssistantEl>{@html renderMarkdown(thinking)}</div>
+                  <div class="think-body" use:setupAssistantEl>{@html renderMarkdown(thinking, showReasoning)}</div>
                 </details>
               </div>
             </div>


### PR DESCRIPTION
When "show reasoning" is toggled off, the backend stops streaming `thinking_delta` events, but the web UI still rendered reasoning that was already persisted or embedded in the final assistant message (`assistant_message.thinking`), standalone thinking segments, and `<think>...</think>` markdown blocks.

This change makes the web UI respect the effective `show_reasoning` flag for all rendering paths, so previously visible Thoughts blocks disappear immediately when the toggle is turned off.

- Add a reactive `showReasoning` flag derived from the live store / session state.
- Guard assistant thinking, standalone thinking messages, and live streaming thinking with the flag.
- Pass the flag into `renderMarkdown` so embedded `<think>` blocks are dropped when reasoning display is off.