### PR TITLE
fix(channel): retry 429s and log discarded send failures

### DIFF
--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -150,7 +150,7 @@ func (a *Adapter) Platform() string { return platformName }
 func (a *Adapter) Start(ctx context.Context, onMessage func(channel.InboundEvent)) error {
 	ctx, a.cancel = context.WithCancel(ctx)
 
-	me, err := a.usersMe()
+	me, err := a.usersMe(ctx)
 	if err != nil {
 		return fmt.Errorf("discord: /users/@me: %w", err)
 	}
@@ -214,7 +214,7 @@ func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 		var msg struct {
 			ID string `json:"id"`
 		}
-		if err := a.rest(http.MethodPost, fmt.Sprintf("/channels/%s/messages", chatID), payload, &msg); err != nil {
+		if err := a.rest(context.Background(), http.MethodPost, fmt.Sprintf("/channels/%s/messages", chatID), payload, &msg); err != nil {
 			return channel.SendResult{OK: false, Error: err.Error()}
 		}
 		lastID = msg.ID
@@ -306,7 +306,7 @@ func (a *Adapter) SendFile(chatID, path, name, replyTo string) channel.SendResul
 
 // UpdateMessage edits an existing message.
 func (a *Adapter) UpdateMessage(chatID, messageID, text string) bool {
-	err := a.rest(http.MethodPatch, fmt.Sprintf("/channels/%s/messages/%s", chatID, messageID),
+	err := a.rest(context.Background(), http.MethodPatch, fmt.Sprintf("/channels/%s/messages/%s", chatID, messageID),
 		map[string]any{"content": text}, nil)
 	if err != nil {
 		log.Printf("[discord] update_message failed: %v", err)
@@ -320,7 +320,7 @@ func (a *Adapter) SupportsMessageUpdates() bool { return true }
 
 // SendTyping triggers the "is typing…" indicator (expires after ~10s).
 func (a *Adapter) SendTyping(chatID, contextToken string) error {
-	return a.rest(http.MethodPost, fmt.Sprintf("/channels/%s/typing", chatID), nil, nil)
+	return a.rest(context.Background(), http.MethodPost, fmt.Sprintf("/channels/%s/typing", chatID), nil, nil)
 }
 
 // StopTyping — Discord's typing indicator expires automatically; nothing to cancel.
@@ -344,7 +344,23 @@ func userAgent() string {
 	return "DiscordBot (https://github.com/open-octo/octo-agent, " + version.String() + ")"
 }
 
-func (a *Adapter) rest(method, path string, payload, out any) error {
+// waitForRetry sleeps for d (capped and floored by the caller), honoring ctx
+// cancellation. Returns false if ctx was cancelled first. Mirrors the
+// telegram adapter's helper of the same name — kept as a per-package copy
+// since the two callers differ (Discord's retry_after is a fractional-second
+// float already converted to a Duration by the caller; Telegram's is a bare
+// integer of seconds), not shared plumbing worth a common package for two
+// call sites.
+func waitForRetry(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-time.After(d):
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (a *Adapter) rest(ctx context.Context, method, path string, payload, out any) error {
 	var bodyBytes []byte
 	if payload != nil {
 		bodyBytes, _ = json.Marshal(payload)
@@ -355,7 +371,7 @@ func (a *Adapter) rest(method, path string, payload, out any) error {
 		if bodyBytes != nil {
 			body = bytes.NewReader(bodyBytes)
 		}
-		req, err := http.NewRequest(method, a.apiBase+path, body)
+		req, err := http.NewRequestWithContext(ctx, method, a.apiBase+path, body)
 		if err != nil {
 			return err
 		}
@@ -387,7 +403,9 @@ func (a *Adapter) rest(method, path string, payload, out any) error {
 			if wait > maxRateLimitWait {
 				wait = maxRateLimitWait
 			}
-			time.Sleep(wait)
+			if !waitForRetry(ctx, wait) {
+				return ctx.Err()
+			}
 			continue
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -413,9 +431,9 @@ type dcUser struct {
 	Bot      bool   `json:"bot"`
 }
 
-func (a *Adapter) usersMe() (*dcUser, error) {
+func (a *Adapter) usersMe(ctx context.Context) (*dcUser, error) {
 	var me dcUser
-	if err := a.rest(http.MethodGet, "/users/@me", nil, &me); err != nil {
+	if err := a.rest(ctx, http.MethodGet, "/users/@me", nil, &me); err != nil {
 		return nil, err
 	}
 	if me.ID == "" {

--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -57,6 +57,14 @@ const (
 	// smaller than its UTF-16 code-unit count, so this can only split a
 	// little earlier than the real limit requires, never later.
 	maxMessageBytes = 2000
+
+	// #1118: a 429 used to fail the REST call outright — with SendText's
+	// per-chunk loop, that meant "chunk 1 arrives, chunk 3 silently missing"
+	// partial delivery on any burst. Discord reports how long to back off in
+	// the response body's retry_after (seconds, fractional), so honor it with
+	// a small bounded retry instead of dropping the chunk.
+	maxRateLimitRetries = 3
+	maxRateLimitWait    = 30 * time.Second
 )
 
 // fatalCloseCodes are gateway close codes that mean reconnecting cannot help
@@ -337,45 +345,66 @@ func userAgent() string {
 }
 
 func (a *Adapter) rest(method, path string, payload, out any) error {
-	var body io.Reader
+	var bodyBytes []byte
 	if payload != nil {
-		b, _ := json.Marshal(payload)
-		body = bytes.NewReader(b)
-	}
-	req, err := http.NewRequest(method, a.apiBase+path, body)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", "Bot "+a.token)
-	req.Header.Set("User-Agent", userAgent())
-	if payload != nil {
-		req.Header.Set("Content-Type", "application/json")
+		bodyBytes, _ = json.Marshal(payload)
 	}
 
-	resp, err := a.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
+	for attempt := 0; ; attempt++ {
+		var body io.Reader
+		if bodyBytes != nil {
+			body = bytes.NewReader(bodyBytes)
+		}
+		req, err := http.NewRequest(method, a.apiBase+path, body)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bot "+a.token)
+		req.Header.Set("User-Agent", userAgent())
+		if payload != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
 
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		var e struct {
-			Message string `json:"message"`
+		resp, err := a.http.Do(req)
+		if err != nil {
+			return err
 		}
-		_ = json.Unmarshal(data, &e)
-		if e.Message == "" {
-			e.Message = strings.TrimSpace(string(data))
+		data, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return err
 		}
-		return fmt.Errorf("discord API %d: %s", resp.StatusCode, e.Message)
+
+		if resp.StatusCode == http.StatusTooManyRequests && attempt < maxRateLimitRetries {
+			var e struct {
+				RetryAfter float64 `json:"retry_after"`
+			}
+			_ = json.Unmarshal(data, &e)
+			wait := time.Duration(e.RetryAfter * float64(time.Second))
+			if wait <= 0 {
+				wait = time.Second
+			}
+			if wait > maxRateLimitWait {
+				wait = maxRateLimitWait
+			}
+			time.Sleep(wait)
+			continue
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			var e struct {
+				Message string `json:"message"`
+			}
+			_ = json.Unmarshal(data, &e)
+			if e.Message == "" {
+				e.Message = strings.TrimSpace(string(data))
+			}
+			return fmt.Errorf("discord API %d: %s", resp.StatusCode, e.Message)
+		}
+		if out != nil && len(data) > 0 {
+			return json.Unmarshal(data, out)
+		}
+		return nil
 	}
-	if out != nil && len(data) > 0 {
-		return json.Unmarshal(data, out)
-	}
-	return nil
 }
 
 type dcUser struct {

--- a/internal/channel/adapters/discord/discord_test.go
+++ b/internal/channel/adapters/discord/discord_test.go
@@ -18,17 +18,18 @@ import (
 // WebSocket that runs hello → identify → READY → one MESSAGE_CREATE per
 // queued message.
 type fakeDiscord struct {
-	mu        sync.Mutex
-	sent      []map[string]any
-	edited    []map[string]any
-	messages  []dcMessage
-	srv       *httptest.Server
-	wsURL     string
-	rateLimit int // return 429 for the first N message sends
+	mu             sync.Mutex
+	sent           []map[string]any
+	edited         []map[string]any
+	messages       []dcMessage
+	srv            *httptest.Server
+	wsURL          string
+	rateLimit      int     // return 429 for the first N message sends
+	rateLimitAfter float64 // retry_after seconds reported on those 429s
 }
 
 func newFakeDiscord(t *testing.T) *fakeDiscord {
-	f := &fakeDiscord{}
+	f := &fakeDiscord{rateLimitAfter: 0.01}
 	upgrader := websocket.Upgrader{}
 
 	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -54,9 +55,10 @@ func newFakeDiscord(t *testing.T) *fakeDiscord {
 			f.mu.Lock()
 			if f.rateLimit > 0 {
 				f.rateLimit--
+				retryAfter := f.rateLimitAfter
 				f.mu.Unlock()
 				w.WriteHeader(http.StatusTooManyRequests)
-				json.NewEncoder(w).Encode(map[string]any{"message": "You are being rate limited.", "retry_after": 0.01})
+				json.NewEncoder(w).Encode(map[string]any{"message": "You are being rate limited.", "retry_after": retryAfter})
 				return
 			}
 			var p map[string]any
@@ -301,6 +303,37 @@ func TestSendText_GivesUpAfterMaxRateLimitRetries(t *testing.T) {
 	res := a.SendText("chan-1", "hello", "")
 	if res.OK {
 		t.Fatalf("expected send to fail after exhausting retries, got %+v", res)
+	}
+}
+
+// The retry wait must actually be cancellable — the point of threading ctx
+// through rest() rather than a bare time.Sleep. A long retry_after (5s) that
+// gets interrupted well before it elapses (ctx cancelled at ~50ms) proves the
+// wait was really interrupted rather than just being short.
+func TestRest_CancelsDuringRateLimitWait(t *testing.T) {
+	f := newFakeDiscord(t)
+	f.rateLimit = 1
+	f.rateLimitAfter = 5
+	a := newTestAdapter(t, f, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	var msg struct {
+		ID string `json:"id"`
+	}
+	err := a.rest(ctx, http.MethodPost, "/channels/chan-1/messages", map[string]any{"content": "hello"}, &msg)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from the cancelled wait")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("expected the wait to be interrupted well under the 5s retry_after, took %v", elapsed)
 	}
 }
 

--- a/internal/channel/adapters/discord/discord_test.go
+++ b/internal/channel/adapters/discord/discord_test.go
@@ -18,12 +18,13 @@ import (
 // WebSocket that runs hello → identify → READY → one MESSAGE_CREATE per
 // queued message.
 type fakeDiscord struct {
-	mu       sync.Mutex
-	sent     []map[string]any
-	edited   []map[string]any
-	messages []dcMessage
-	srv      *httptest.Server
-	wsURL    string
+	mu        sync.Mutex
+	sent      []map[string]any
+	edited    []map[string]any
+	messages  []dcMessage
+	srv       *httptest.Server
+	wsURL     string
+	rateLimit int // return 429 for the first N message sends
 }
 
 func newFakeDiscord(t *testing.T) *fakeDiscord {
@@ -50,9 +51,16 @@ func newFakeDiscord(t *testing.T) *fakeDiscord {
 			}
 			json.NewEncoder(w).Encode(dcUser{ID: "bot-1", Username: "octo"})
 		case strings.HasSuffix(r.URL.Path, "/messages") && r.Method == http.MethodPost:
+			f.mu.Lock()
+			if f.rateLimit > 0 {
+				f.rateLimit--
+				f.mu.Unlock()
+				w.WriteHeader(http.StatusTooManyRequests)
+				json.NewEncoder(w).Encode(map[string]any{"message": "You are being rate limited.", "retry_after": 0.01})
+				return
+			}
 			var p map[string]any
 			json.NewDecoder(r.Body).Decode(&p)
-			f.mu.Lock()
 			f.sent = append(f.sent, p)
 			f.mu.Unlock()
 			json.NewEncoder(w).Encode(map[string]any{"id": "m-1"})
@@ -261,6 +269,38 @@ func TestSendText(t *testing.T) {
 	}
 	if f.sent[0]["message_reference"] == nil {
 		t.Fatal("expected message_reference for reply")
+	}
+}
+
+// #1118: a 429 used to fail SendText outright — with a multi-chunk message
+// that meant chunk 1 arrives and chunk 2 silently vanishes. It should now
+// honor retry_after and retry instead of dropping the chunk.
+func TestSendText_RetriesOnRateLimit(t *testing.T) {
+	f := newFakeDiscord(t)
+	f.rateLimit = 1
+	a := newTestAdapter(t, f, nil)
+
+	res := a.SendText("chan-1", "hello", "")
+	if !res.OK {
+		t.Fatalf("expected retry to succeed, got %+v", res)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sent) != 1 {
+		t.Fatalf("expected exactly one delivered message after the retry, got %d", len(f.sent))
+	}
+}
+
+// #1118: retries are bounded — a channel that's rate-limited past the retry
+// budget must still surface a real error, not hang or silently swallow it.
+func TestSendText_GivesUpAfterMaxRateLimitRetries(t *testing.T) {
+	f := newFakeDiscord(t)
+	f.rateLimit = maxRateLimitRetries + 1
+	a := newTestAdapter(t, f, nil)
+
+	res := a.SendText("chan-1", "hello", "")
+	if res.OK {
+		t.Fatalf("expected send to fail after exhausting retries, got %+v", res)
 	}
 }
 

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -423,6 +423,35 @@ func isParseError(err error) bool {
 	return strings.Contains(d, "can't parse entities") || strings.Contains(d, "markdown")
 }
 
+// #1118: a 429 used to just fail the call outright — with SendText's
+// per-chunk loop, that meant "chunk 1 arrives, chunk 3 silently missing"
+// partial delivery on any burst. Telegram reports how long to back off in
+// parameters.retry_after, so honor it with a small bounded retry instead of
+// dropping the chunk.
+const (
+	maxRateLimitRetries = 3
+	maxRateLimitWait    = 30 * time.Second
+)
+
+// waitForRetry sleeps for the API's requested backoff (capped, and floored at
+// one second when the server didn't say), honoring ctx cancellation. Returns
+// false if ctx was cancelled first.
+func waitForRetry(ctx context.Context, seconds int) bool {
+	d := time.Duration(seconds) * time.Second
+	if d <= 0 {
+		d = time.Second
+	}
+	if d > maxRateLimitWait {
+		d = maxRateLimitWait
+	}
+	select {
+	case <-time.After(d):
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 // call POSTs JSON to /bot<TOKEN>/<method> and returns the raw `result`.
 // A nil ctx means context.Background(); the long-poll path passes the Start
 // context so Stop cancels an in-flight getUpdates promptly.
@@ -432,35 +461,50 @@ func (a *Adapter) call(ctx context.Context, method string, params map[string]any
 	}
 	b, _ := json.Marshal(params)
 	url := fmt.Sprintf("%s/bot%s/%s", a.baseURL, a.token, method)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
+	for attempt := 0; ; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
 
-	var r struct {
-		OK          bool            `json:"ok"`
-		Result      json.RawMessage `json:"result"`
-		ErrorCode   int             `json:"error_code"`
-		Description string          `json:"description"`
-	}
-	if err := json.Unmarshal(body, &r); err != nil {
-		return nil, fmt.Errorf("invalid JSON response: %w", err)
-	}
-	if !r.OK {
+		var r struct {
+			OK          bool            `json:"ok"`
+			Result      json.RawMessage `json:"result"`
+			ErrorCode   int             `json:"error_code"`
+			Description string          `json:"description"`
+			Parameters  *struct {
+				RetryAfter int `json:"retry_after"`
+			} `json:"parameters"`
+		}
+		if err := json.Unmarshal(body, &r); err != nil {
+			return nil, fmt.Errorf("invalid JSON response: %w", err)
+		}
+		if r.OK {
+			return r.Result, nil
+		}
+		if r.ErrorCode == http.StatusTooManyRequests && attempt < maxRateLimitRetries {
+			wait := 0
+			if r.Parameters != nil {
+				wait = r.Parameters.RetryAfter
+			}
+			if !waitForRetry(ctx, wait) {
+				return nil, ctx.Err()
+			}
+			continue
+		}
 		return nil, &apiError{Code: r.ErrorCode, Description: r.Description}
 	}
-	return r.Result, nil
 }
 
 type tgPhotoSize struct {

--- a/internal/channel/adapters/telegram/telegram_test.go
+++ b/internal/channel/adapters/telegram/telegram_test.go
@@ -21,6 +21,7 @@ type fakeBotAPI struct {
 	served    bool
 	sent      []map[string]any
 	sendFail  int // fail the first N sendMessage calls with a parse error
+	rateLimit int // return 429 for the first N sendMessage calls
 	srv       *httptest.Server
 	botUserID int64
 }
@@ -48,6 +49,11 @@ func newFakeBotAPI(t *testing.T) *fakeBotAPI {
 		case strings.HasSuffix(r.URL.Path, "/sendMessage"):
 			f.mu.Lock()
 			defer f.mu.Unlock()
+			if f.rateLimit > 0 {
+				f.rateLimit--
+				writeRateLimited(w, 1)
+				return
+			}
 			if f.sendFail > 0 && params["parse_mode"] != nil {
 				f.sendFail--
 				writeError(w, 400, "Bad Request: can't parse entities")
@@ -73,6 +79,15 @@ func writeResult(w http.ResponseWriter, result any) {
 
 func writeError(w http.ResponseWriter, code int, desc string) {
 	json.NewEncoder(w).Encode(map[string]any{"ok": false, "error_code": code, "description": desc})
+}
+
+func writeRateLimited(w http.ResponseWriter, retryAfter int) {
+	json.NewEncoder(w).Encode(map[string]any{
+		"ok":          false,
+		"error_code":  429,
+		"description": "Too Many Requests: retry after",
+		"parameters":  map[string]any{"retry_after": retryAfter},
+	})
 }
 
 func newTestAdapter(t *testing.T, f *fakeBotAPI, extra map[string]any) *Adapter {
@@ -191,6 +206,38 @@ func TestStart_AllowedUsersFilters(t *testing.T) {
 	events := collectEvents(t, a, 1)
 	if len(events) != 1 || events[0].Text != "friend" {
 		t.Fatalf("allowed_users not enforced: %+v", events)
+	}
+}
+
+// #1118: a 429 used to fail SendText outright — with a multi-chunk message
+// that meant chunk 1 arrives and chunk 2 silently vanishes. It should now
+// honor retry_after and retry instead of dropping the chunk.
+func TestSendText_RetriesOnRateLimit(t *testing.T) {
+	f := newFakeBotAPI(t)
+	f.rateLimit = 1
+	a := newTestAdapter(t, f, nil)
+
+	res := a.SendText("123", "hello", "")
+	if !res.OK {
+		t.Fatalf("expected retry to succeed, got %+v", res)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sent) != 1 {
+		t.Fatalf("expected exactly one delivered message after the retry, got %d", len(f.sent))
+	}
+}
+
+// #1118: retries are bounded — a chat that's rate-limited past the retry
+// budget must still surface a real error, not hang or silently swallow it.
+func TestSendText_GivesUpAfterMaxRateLimitRetries(t *testing.T) {
+	f := newFakeBotAPI(t)
+	f.rateLimit = maxRateLimitRetries + 1
+	a := newTestAdapter(t, f, nil)
+
+	res := a.SendText("123", "hello", "")
+	if res.OK {
+		t.Fatalf("expected send to fail after exhausting retries, got %+v", res)
 	}
 }
 

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -211,8 +211,15 @@ func (q *sendQueue) sendWithRetry(chatID, text, contextToken string) {
 			return
 		}
 		apiErr, ok := err.(*ilink.APIError)
-		if ok && apiErr.ErrCode == -2 && i < len(retryDelays)-1 {
-			log.Printf("[weixin] rate-limited for %s, retry in %v (%d/%d)", chatID, delay, i+1, len(retryDelays))
+		// -2 is iLink's own rate-limit code. #1118: anything that ISN'T a
+		// recognized iLink error — a network timeout, connection reset, DNS
+		// hiccup — used to skip the retry loop entirely and drop the reply on
+		// the first attempt; those are exactly the transient failures a retry
+		// is for. A recognized API error with some other code is presumed
+		// permanent (bad request, etc.) and still fails fast.
+		retryable := (ok && apiErr.ErrCode == -2) || !ok
+		if retryable && i < len(retryDelays)-1 {
+			log.Printf("[weixin] send failed for %s, retry in %v (%d/%d): %v", chatID, delay, i+1, len(retryDelays), err)
 			time.Sleep(delay)
 			continue
 		}

--- a/internal/channel/adapters/weixin/weixin_test.go
+++ b/internal/channel/adapters/weixin/weixin_test.go
@@ -153,6 +153,54 @@ func TestAdapter_SendText_BufferedMerge(t *testing.T) {
 	}
 }
 
+// #1118: a transient network failure (not iLink's own -2 rate-limit code)
+// used to skip the retry loop entirely and drop the message on the first
+// attempt. sendWithRetry now retries any error that isn't a recognized
+// *ilink.APIError too.
+func TestSendQueue_RetriesOnNetworkError(t *testing.T) {
+	var mu sync.Mutex
+	attempts := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ilink/bot/sendmessage" {
+			return
+		}
+		mu.Lock()
+		attempts++
+		n := attempts
+		mu.Unlock()
+		if n == 1 {
+			// Simulate a transient network failure: hijack and close the
+			// connection without responding, producing a plain client error
+			// (not an *ilink.APIError).
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("ResponseWriter does not support hijacking")
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Fatal(err)
+			}
+			conn.Close()
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ret": 0})
+	}))
+	defer ts.Close()
+
+	q := newSendQueue(ilink.NewClient(), ts.URL, "tok")
+	defer q.stop()
+
+	q.sendWithRetry("user1", "hello", "ctx1")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts < 2 {
+		t.Fatalf("expected the network failure to trigger a retry (>=2 attempts), got %d", attempts)
+	}
+}
+
 func TestAdapter_SendFile(t *testing.T) {
 	// Create a real temp file to upload.
 	tmpFile, err := os.CreateTemp(t.TempDir(), "test*.txt")

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -657,7 +657,13 @@ func (m *Manager) sendReply(ev InboundEvent, text string) {
 		return
 	}
 	ad := val.(Adapter)
-	ad.SendText(ev.ChatID, text, ev.MessageID)
+	// #1118: the SendResult was previously discarded — a failed /list or
+	// /bind confirmation just evaporated with nothing in the logs to explain
+	// why the user never saw it. There's no in-band way to notify the user
+	// here (this send *is* the notification), so log loudly instead.
+	if res := ad.SendText(ev.ChatID, text, ev.MessageID); !res.OK {
+		slog.Error("channel reply send failed", "platform", ev.Platform, "chat_id", ev.ChatID, "err", res.Error)
+	}
 }
 
 // sendTyping sends a typing indicator to the chat.

--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -1,8 +1,10 @@
 package channel
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -356,6 +358,41 @@ func TestManager_SendReply(t *testing.T) {
 	last := mock.lastSentText()
 	if last.text != "hello back" || last.chatID != "c1" {
 		t.Fatalf("unexpected sent text: %+v", last)
+	}
+}
+
+// #1118: a failed reply send used to just evaporate — the SendResult was
+// discarded with nothing logged, so a broken /list or /bind confirmation
+// left no trace explaining why the user never saw it.
+func TestManager_SendReply_LogsFailure(t *testing.T) {
+	tempHome(t)
+	mock := &mockAdapter{platform: "mock4", failSends: true}
+	Register("mock4", func(pc PlatformConfig) (Adapter, error) {
+		return mock, nil
+	})
+
+	cfg := &Config{
+		Channels: map[string]PlatformConfig{
+			"mock4": {"enabled": true},
+		},
+	}
+	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
+	mgr.adapters.Store("mock4", mock)
+
+	var buf bytes.Buffer
+	orig := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	ev := InboundEvent{Platform: "mock4", ChatID: "c1", MessageID: "m1"}
+	mgr.sendReply(ev, "hello back")
+
+	if mock.sentTextCount() != 0 {
+		t.Fatalf("expected no delivered text on a failed send, got %d", mock.sentTextCount())
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "channel reply send failed") || !strings.Contains(logged, "mock4") {
+		t.Fatalf("expected the failed send to be logged, got: %s", logged)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1118: IM send failures were silently dropped across the board.

1. **Telegram** (`telegram.go`): a 429 from `sendMessage` failed the call
   outright. `SendText`'s per-chunk loop meant a rate-limited burst dropped
   chunks mid-message — "chunk 1 arrives, chunk 3 silently missing." `call()`
   now parses Telegram's `parameters.retry_after` and retries (bounded at 3
   attempts, capped at 30s per wait) instead of giving up on the first 429.

2. **Discord** (`discord.go`): `rest()` had no 429 handling at all — same
   silent drop, same partial-delivery failure mode. Added the same bounded
   retry, honoring the response body's `retry_after` (a float, unlike
   Telegram's integer seconds).

3. **Weixin** (`weixin.go`): `sendWithRetry` only retried iLink's own
   rate-limit code (`errcode == -2`); a plain network error (timeout,
   connection reset) isn't a `*ilink.APIError`, so it fell through and
   dropped the message on the first attempt instead of getting the same
   retry a transient failure deserves.

4. **manager.go**: `sendReply` discarded the `SendResult` from every
   adapter's `SendText` — a failed `/list` or `/bind` confirmation reply just
   evaporated with nothing in the logs explaining why. There's no in-band way
   to notify the user here (this send *is* the notification), so it now logs
   loudly via `slog` on failure instead.

Not in scope: the issue's proposed per-chat send queue for in-order delivery
across concurrent sends. Telegram/Discord already send a single message's
chunks sequentially within one `SendText` call, so the queue's main value
(protecting against interleaving between *separate* concurrent `SendText`
calls to the same chat) isn't evidenced as broken today — a bigger, separate
change if it turns out to be needed.

## Verification
- [x] `go build ./...`, `go vet ./...`
- [x] `go test -race ./...` (full suite, matching CI's ubuntu-latest job)
- [x] New tests: `TestSendText_RetriesOnRateLimit` /
      `_GivesUpAfterMaxRateLimitRetries` (telegram + discord),
      `TestSendQueue_RetriesOnNetworkError` (weixin),
      `TestManager_SendReply_LogsFailure` (manager)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>