### PR TITLE
fix(install): auto-add install dir to PATH in shell rc file

### DIFF
--- a/landing/install.sh
+++ b/landing/install.sh
@@ -100,10 +100,54 @@ fi
 
 printf 'octo install: installed octo %s to %s/octo\n' "$version" "$dir"
 
-# --- PATH hint ---------------------------------------------------------------
+# --- PATH setup ---------------------------------------------------------------
 case ":$PATH:" in
   *":$dir:"*) ;;
-  *) printf 'octo install: %s is not on your PATH. Add it, e.g.:\n  export PATH="%s:$PATH"\n' "$dir" "$dir" ;;
+  *)
+    marker="# added by octo installer"
+
+    # Detect the user's shell and pick the right rc file
+    shell_name=$(basename "${SHELL:-}" 2>/dev/null || echo "")
+    case "$shell_name" in
+      zsh)
+        # macOS Terminal opens zsh as a login shell → .zprofile takes effect
+        # Linux interactive zsh → .zshrc
+        if [ "$os" = "darwin" ]; then
+          rc="$HOME/.zprofile"
+        else
+          rc="$HOME/.zshrc"
+        fi
+        ;;
+      bash)
+        # macOS bash as login → .bash_profile; Linux → .bashrc
+        if [ "$os" = "darwin" ]; then
+          rc="$HOME/.bash_profile"
+        else
+          rc="$HOME/.bashrc"
+        fi
+        ;;
+      *)
+        rc="$HOME/.profile"
+        ;;
+    esac
+
+    # Write to the primary rc file (idempotent — marker prevents duplication)
+    [ -f "$rc" ] || touch "$rc"
+    if ! grep -qF "$marker" "$rc" 2>/dev/null; then
+      printf '\nexport PATH="%s:$PATH"  %s\n' "$dir" "$marker" >> "$rc"
+      printf 'octo install: added %s to %s\n' "$dir" "$rc"
+    fi
+
+    # Also add to ~/.profile as a universal fallback (skip if same file already written)
+    if [ "$rc" != "$HOME/.profile" ]; then
+      [ -f "$HOME/.profile" ] || touch "$HOME/.profile"
+      if ! grep -qF "$marker" "$HOME/.profile" 2>/dev/null; then
+        printf '\nexport PATH="%s:$PATH"  %s\n' "$dir" "$marker" >> "$HOME/.profile"
+      fi
+    fi
+
+    printf 'octo install: restart your shell or run:\n  export PATH="%s:$PATH"\n' "$dir"
+    ;;
 esac
 
 # --- next steps --------------------------------------------------------------


### PR DESCRIPTION
## Problem

安装脚本在 `/usr/local/bin` 不可写时，会将 `octo` 安装到 `~/.local/bin`，但这个目录通常不在用户的 PATH 上。之前脚本只是打印了一行提示，用户很容易忽略，紧接着执行 `octo serve` 就报 `command not found`。

Fixes #1126

## Changes

修改 `landing/install.sh`，将原本的 PATH 提示逻辑替换为自动写入 shell rc 文件：

- 检测 `$SHELL` 自动选择 rc 文件：
  - macOS+zsh → `~/.zprofile`
  - Linux+zsh → `~/.zshrc`
  - macOS+bash → `~/.bash_profile`
  - Linux+bash → `~/.bashrc`
  - 其他 → `~/.profile`
- 额外写入 `~/.profile` 作为通用兜底
- 使用 marker 注释实现幂等（重复运行不会追加）
- 仍然打印提示信息，告知用户重启 shell 或手动 export
- 安装到 `/usr/local/bin`（已在 PATH 上）时完全跳过

## Verification

- `bash -n landing/install.sh` 语法检查通过
- 与 `packaging/macos/scripts/postinstall` 的 PATH 管理逻辑风格一致