### PR TITLE
fix: i18n language persistence (#1074) and hardcoded strings (#1113)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,6 +132,9 @@ type Config struct {
 	// as a literal path. Does not affect CLI/TUI sessions or the server's
 	// own cwd, and composes with the per-session working_dir override.
 	WorkspaceDir string `yaml:"workspace_dir,omitempty"`
+	// Language persists the user's UI language preference ("en" | "zh").
+	// Empty means the default (English).
+	Language string `yaml:"language,omitempty"`
 }
 
 // GoalConfig configures session goals (persistent objectives the agent keeps

--- a/internal/server/onboard_config_handlers.go
+++ b/internal/server/onboard_config_handlers.go
@@ -226,7 +226,7 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 		Models:          models,
 		DefaultModelIdx: defaultIdx,
 		FontSize:        "medium",
-		Language:        "en",
+		Language:        cfg.Language,
 		ShowReasoning:   cfg.ShowReasoning,
 		Coauthor:        &effCoauthor,
 	})
@@ -324,6 +324,38 @@ func (s *Server) handlePutCoauthor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "coauthor": req.Coauthor})
+}
+
+// ─── PUT /api/config/language ────────────────────────────────────────────────
+
+type putLanguageRequest struct {
+	Language string `json:"language"`
+}
+
+func (s *Server) handlePutLanguage(w http.ResponseWriter, r *http.Request) {
+	var req putLanguageRequest
+	if err := readBodyJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Language != "en" && req.Language != "zh" {
+		writeError(w, http.StatusBadRequest, "language must be 'en' or 'zh'")
+		return
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load config: %v", err))
+		return
+	}
+
+	cfg.Language = req.Language
+	if err := cfg.Save(); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save config: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "language": req.Language})
 }
 
 // maskKey masks most of an API key, keeping the first and last four runes

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -738,6 +738,7 @@ func (s *Server) registerRoutes() {
 	s.api("GET /api/config", s.handleGetConfig)
 	s.api("PUT /api/config/show_reasoning", s.handlePutShowReasoning)
 	s.api("PUT /api/config/coauthor", s.handlePutCoauthor)
+	s.api("PUT /api/config/language", s.handlePutLanguage)
 	s.api("POST /api/config/test", s.handleTestConfig)
 	s.api("POST /api/config/models", s.handleSaveModelConfig)
 	s.api("PATCH /api/config/models/{id}", s.handleUpdateModelConfig)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -696,8 +696,8 @@ func TestHandleGetConfig(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
 		t.Fatal(err)
 	}
-	if body.Language != "en" {
-		t.Fatalf("language = %q, want en", body.Language)
+	if body.Language != "en" && body.Language != "" {
+		t.Fatalf("language = %q, want en or empty", body.Language)
 	}
 }
 

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte'
   import { view, sessions, activeSessionId, showToast, onboardPhase, openAgentSession, chatShowReasoning } from './lib/stores'
   import { ws, wsState } from './lib/ws'
-  import { locale, t } from './lib/i18n'
+  import { locale, t, setLocale } from './lib/i18n'
   import { checkAuth } from './lib/auth'
   import { get } from 'svelte/store'
   import * as api from './lib/api'
@@ -95,6 +95,12 @@
 
   function bootMain() {
     ws.connect()
+
+    // Restore the persisted UI language from server config so a refresh
+    // keeps the user's locale choice.
+    api.getConfig().then(cfg => {
+      if (cfg.language) setLocale(cfg.language)
+    }).catch(() => { /* non-critical */ })
 
     ws.on('session_list', (ev: any) => {
       const list = ev.sessions ?? []

--- a/web/src/components/ArtifactsPanel.svelte
+++ b/web/src/components/ArtifactsPanel.svelte
@@ -11,8 +11,8 @@
   // way, so it looked identical to success).
   function copyArtifact() {
     navigator.clipboard.writeText(cur?.code ?? '')
-      .then(() => showToast('Copied to clipboard'))
-      .catch(() => showToast('Copy failed — clipboard access denied', 'error'))
+      .then(() => showToast(tr('artifacts.copied')))
+      .catch(() => showToast(tr('artifacts.copy_failed'), 'error'))
   }
 
   function downloadArtifact() {

--- a/web/src/components/chat/BackgroundProcesses.svelte
+++ b/web/src/components/chat/BackgroundProcesses.svelte
@@ -17,7 +17,7 @@
     <details>
       <summary class="tray-summary">
         <span class="dot"></span>
-        <span class="lbl">{tasks.length} background {tasks.length === 1 ? 'process' : 'processes'}</span>
+        <span class="lbl">{$t('bgtask.n_processes').replace('{n}', String(tasks.length))}</span>
         <span style="margin-left:auto"></span>
         <iconify-icon icon="lucide:chevron-up" width="14" style="color:var(--text-tertiary)"></iconify-icon>
       </summary>
@@ -28,7 +28,7 @@
           <div class="proc-info">
             <span class="proc-cmd mono">{p.command}</span>
           </div>
-          <span class="proc-time">running · {fmtElapsed(p.elapsed)}</span>
+          <span class="proc-time">{$t('bgtask.running_elapsed').replace('{elapsed}', fmtElapsed(p.elapsed))}</span>
         </div>
         {/each}
       </div>

--- a/web/src/components/chat/BackgroundProcesses.svelte
+++ b/web/src/components/chat/BackgroundProcesses.svelte
@@ -17,7 +17,7 @@
     <details>
       <summary class="tray-summary">
         <span class="dot"></span>
-        <span class="lbl">{$t('bgtask.n_processes').replace('{n}', String(tasks.length))}</span>
+        <span class="lbl">{$t(tasks.length === 1 ? 'bgtask.n_process' : 'bgtask.n_processes').replace('{n}', String(tasks.length))}</span>
         <span style="margin-left:auto"></span>
         <iconify-icon icon="lucide:chevron-up" width="14" style="color:var(--text-tertiary)"></iconify-icon>
       </summary>

--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -255,7 +255,7 @@
     } else if (item.kind === 'mcp-server') {
       text = '/mcp/' + item.name + ' '
     } else if (item.kind === 'mcp-tool') {
-      text = `请帮我调用 mcp__${item.server}__${item.tool.name}，并说明需要什么参数`
+      text = $t('composer.mcp_tool_prompt').replace('{server}', item.server).replace('{tool}', item.tool.name)
     }
     hideSlashMenu()
     queueMicrotask(() => textareaEl?.focus())
@@ -615,7 +615,7 @@
                 {/if}
               {:else if item.kind === 'mcp-server'}
                 <span class="skill-name">/mcp/{item.name}</span>
-                <span class="skill-desc">MCP server</span>
+                <span class="skill-desc">{$t('composer.label_mcp_server')}</span>
               {:else}
                 <span class="skill-name">mcp__{item.server}__{item.tool.name}</span>
                 {#if item.tool.description}
@@ -625,7 +625,7 @@
             </button>
           {:else}
             <div class="skill-menu-empty">
-              {slashMode === 'skills' ? 'No matching skills' : slashMode === 'workflows' ? 'No matching workflows' : slashMode === 'mcp-servers' ? 'No matching MCP servers' : 'No tools found'}
+              {slashMode === 'skills' ? $t('composer.no_match_skills') : slashMode === 'workflows' ? $t('composer.no_match_workflows') : slashMode === 'mcp-servers' ? $t('composer.no_match_servers') : $t('composer.no_match_tools')}
             </div>
           {/each}
         </div>

--- a/web/src/components/chat/SubAgentsCard.svelte
+++ b/web/src/components/chat/SubAgentsCard.svelte
@@ -48,7 +48,7 @@
     {#if runningCount > 0}
       <span class="running-badge">
         <iconify-icon icon="ant-design:loading-outlined" width="12" style="animation:octo-spin 0.8s linear infinite"></iconify-icon>
-        {runningCount} running
+        {runningCount} {$t('tools.running')}
       </span>
     {:else}
       <span class="running-badge done">
@@ -75,12 +75,12 @@
         {#if a.status === 'running'}
           <span class="status-running">
             <iconify-icon icon="ant-design:loading-outlined" width="12" style="animation:octo-spin 0.8s linear infinite"></iconify-icon>
-            <span class="mono">{a.lastTool || $t('agent.working')} · {a.tools.length} tool{a.tools.length === 1 ? '' : 's'}</span>
+            <span class="mono">{a.lastTool || $t('agent.working')} · {$t('agent.n_tools').replace('{n}', String(a.tools.length))}</span>
           </span>
         {:else}
           <span class="status-done">
             <iconify-icon icon="ant-design:check-circle-outlined" width="13"></iconify-icon>
-            done · {a.tools.length} tool{a.tools.length === 1 ? '' : 's'}
+            {$t('agent.done_n_tools').replace('{n}', String(a.tools.length))}
           </span>
         {/if}
         <iconify-icon icon={(expanded[a.id] ?? (a.status === 'done')) ? 'lucide:chevron-down' : 'lucide:chevron-right'} width="13" style="color:var(--text-tertiary);flex:0 0 auto"></iconify-icon>

--- a/web/src/components/chat/SubAgentsCard.svelte
+++ b/web/src/components/chat/SubAgentsCard.svelte
@@ -48,7 +48,7 @@
     {#if runningCount > 0}
       <span class="running-badge">
         <iconify-icon icon="ant-design:loading-outlined" width="12" style="animation:octo-spin 0.8s linear infinite"></iconify-icon>
-        {runningCount} {$t('tools.running')}
+        {$t('agent.n_running').replace('{n}', String(runningCount))}
       </span>
     {:else}
       <span class="running-badge done">

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -232,7 +232,7 @@
   <div class="tool-group">
     <div class="group-header">
       <iconify-icon icon="ant-design:tool-outlined" width="14" style="color:var(--text-tertiary)"></iconify-icon>
-      <span class="hdr-label">{$t('tools.n_used').replace('{n}', String(tools.length))}</span>
+      <span class="hdr-label">{$t(tools.length === 1 ? 'tools.n_used_one' : 'tools.n_used').replace('{n}', String(tools.length))}</span>
       {#if groupStreaming}
         <span style="margin-left:auto;display:flex;align-items:center;gap:5px;font-size:12px;color:var(--blue-6)">
           <iconify-icon icon="ant-design:loading-outlined" width="13" style="animation:octo-spin 0.8s linear infinite"></iconify-icon>

--- a/web/src/components/chat/ToolGroup.svelte
+++ b/web/src/components/chat/ToolGroup.svelte
@@ -232,7 +232,7 @@
   <div class="tool-group">
     <div class="group-header">
       <iconify-icon icon="ant-design:tool-outlined" width="14" style="color:var(--text-tertiary)"></iconify-icon>
-      <span class="hdr-label">{tools.length} {tools.length === 1 ? 'tool' : 'tools'} used</span>
+      <span class="hdr-label">{$t('tools.n_used').replace('{n}', String(tools.length))}</span>
       {#if groupStreaming}
         <span style="margin-left:auto;display:flex;align-items:center;gap:5px;font-size:12px;color:var(--blue-6)">
           <iconify-icon icon="ant-design:loading-outlined" width="13" style="animation:octo-spin 0.8s linear infinite"></iconify-icon>
@@ -284,11 +284,11 @@
                 {$t('tools.running')}
                 {#if tool.name === 'terminal' || tool.name === 'bash'}
                   <button class="promote-btn" onclick={(e) => { e.preventDefault(); e.stopPropagation(); promoteTerminal() }}>
-                    Background
+                    {$t('tools.background')}
                   </button>
                 {:else if tool.name === 'sub_agent'}
                   <button class="promote-btn" onclick={(e) => { e.preventDefault(); e.stopPropagation(); promoteSubAgent() }}>
-                    Background
+                    {$t('tools.background')}
                   </button>
                 {/if}
               </span>
@@ -339,7 +339,7 @@
             {#if isTerm && fold.hidden > 0}
               <button class="fold-btn" onclick={() => expanded[tool.id] = true}>
                 <iconify-icon icon="lucide:chevron-up" width="13"></iconify-icon>
-                Show {fold.hidden} earlier lines
+                {$t('tools.show_earlier').replace('{n}', String(fold.hidden))}
               </button>
             {/if}
             <pre class="terminal-output">{#each fold.shown.split('\n') as line}{#if line.startsWith('$ ') || line === '$'}<span class="term-prompt">$</span>{line.slice(1)}{:else}{line}{/if}
@@ -347,7 +347,7 @@
             {#if !isTerm && fold.hidden > 0}
               <button class="fold-btn" onclick={() => expanded[tool.id] = true}>
                 <iconify-icon icon="lucide:chevron-down" width="13"></iconify-icon>
-                Show {fold.hidden} more lines
+                {$t('tools.show_more').replace('{n}', String(fold.hidden))}
               </button>
             {/if}
           </div>
@@ -371,7 +371,7 @@
             {#if tool.ui_payload.preview_truncated}
               <div class="fold-info">
                 <iconify-icon icon="lucide:chevron-down" width="13"></iconify-icon>
-                {tool.ui_payload.line_count - 30} more lines
+                {$t('tools.n_more_lines').replace('{n}', String(tool.ui_payload.line_count - 30))}
               </div>
             {/if}
           </div>
@@ -383,14 +383,14 @@
             {#if isTerm && fold.hidden > 0}
               <button class="fold-btn light" onclick={() => expanded[tool.id] = true}>
                 <iconify-icon icon="lucide:chevron-up" width="13"></iconify-icon>
-                Show {fold.hidden} earlier lines
+                {$t('tools.show_earlier').replace('{n}', String(fold.hidden))}
               </button>
             {/if}
             <pre class="tool-output">{fold.shown}</pre>
             {#if !isTerm && fold.hidden > 0}
               <button class="fold-btn light" onclick={() => expanded[tool.id] = true}>
                 <iconify-icon icon="lucide:chevron-down" width="13"></iconify-icon>
-                Show {fold.hidden} more lines
+                {$t('tools.show_more').replace('{n}', String(fold.hidden))}
               </button>
             {/if}
           </div>

--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -126,7 +126,7 @@
 
         {#if $selMode && Object.keys($sel).length > 0}
         <div class="batch-bar">
-          <span class="batch-count">{Object.keys($sel).length} selected</span>
+          <span class="batch-count">{$t('sidebar.n_selected').replace('{n}', String(Object.keys($sel).length))}</span>
           <button class="batch-del" onclick={delSelected}>
             <iconify-icon icon="ant-design:delete-outlined" width="12"></iconify-icon>
             {$t('common.delete')}

--- a/web/src/components/overlays/CommandPalette.svelte
+++ b/web/src/components/overlays/CommandPalette.svelte
@@ -116,7 +116,7 @@
     </div>
     <div class="results">
       {#if flatItems.length === 0}
-        <div class="empty">No matches for "{query}"</div>
+        <div class="empty">{$t('cmdk.no_matches').replace('{query}', query)}</div>
       {/if}
 
       {#if matchedSessions.length > 0}

--- a/web/src/components/overlays/FirstRunSetup.svelte
+++ b/web/src/components/overlays/FirstRunSetup.svelte
@@ -42,6 +42,8 @@
   // onboarding complete and hand off to the personalisation chat. The gate falls
   // through to the normal UI, where ChatView auto-sends the queued /onboard.
   async function finishOnboard() {
+    // Persist the language choice so a refresh lands on it.
+    await api.updateLanguage(lang).catch(() => {})
     await api.completeOnboard()
     await openAgentSession(`/onboard lang:${lang}`, '✨ Onboard')
     onboardPhase.set('')

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -505,6 +505,13 @@ export async function updateCoauthor(coauthor: boolean): Promise<{ ok: boolean; 
   })
 }
 
+export async function updateLanguage(language: string): Promise<{ ok: boolean; language?: string }> {
+  return request<{ ok: boolean; language?: string }>('/api/config/language', {
+    method: 'PUT',
+    ...json({ language }),
+  })
+}
+
 export async function getVersion(): Promise<unknown> {
   return request<unknown>('/api/version', { cache: 'no-store' })
 }

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -121,6 +121,63 @@ export const en: Record<string, string> = {
   "tools.results": "results",
   "tools.changes": "changes",
   "tools.matches": "matches",
+  // tool group (ToolGroup.svelte)
+  "tools.n_used": "{n} tools used",
+  "tools.n_used_one": "{n} tool used",
+  "tools.background": "Background",
+  "tools.show_earlier": "Show {n} earlier lines",
+  "tools.show_more": "Show {n} more lines",
+  "tools.n_more_lines": "{n} more lines",
+  // MCP view (McpView.svelte)
+  "mcp.toast_removed": "Server removed",
+  "mcp.toast_reconnecting": "Reconnecting",
+  "mcp.badge_project": "project",
+  "mcp.tool_count": "{n} tool(s)",
+  // Skills view
+  "skills.confirm_delete": "Delete skill \"{name}\"?",
+  "skills.toast_deleted": "Skill \"{name}\" deleted",
+  "skills.toast_imported": "Skill \"{name}\" imported",
+  // Tasks view
+  "tasks.toast_started": "Task started",
+  "tasks.toast_deleted": "Task deleted",
+  // Channels view
+  "channels.not_configured": "Not configured",
+  "status.stopped": "Stopped",
+  "channels.activity_running": "Adapter is running and accepting messages",
+  "channels.activity_enabled": "Enabled but not yet started — restart the server to activate",
+  // Profile view
+  "profile.n_entries": "{n} entries",
+  // File recall view
+  "files.confirm_empty_all": "Permanently delete all {n} files? This cannot be undone.",
+  "files.age_today": "Today",
+  "files.age_yesterday": "Yesterday",
+  "files.age_days_ago": "{n} days ago",
+  "files.count_files": "{n} files",
+  "files.count_file": "{n} file",
+  "files.count_orphans": "{n} orphans",
+  "files.count_orphan": "{n} orphan",
+  // Sidebar
+  "sidebar.n_selected": "{n} selected",
+  // Sub-agents card
+  "agent.n_running": "{n} running",
+  "agent.n_tools": "{n} tools",
+  "agent.done_n_tools": "done · {n} tools",
+  // Background processes
+  "bgtask.n_processes": "{n} background processes",
+  "bgtask.n_process": "{n} background process",
+  "bgtask.running_elapsed": "running · {elapsed}",
+  // Artifacts panel
+  "artifacts.copied": "Copied to clipboard",
+  "artifacts.copy_failed": "Copy failed — clipboard access denied",
+  // Command palette
+  "cmdk.no_matches": "No matches for \"{query}\"",
+  // Composer
+  "composer.mcp_tool_prompt": "Please help me call mcp__{server}__{tool} and explain what params are needed",
+  "composer.label_mcp_server": "MCP server",
+  "composer.no_match_skills": "No matching skills",
+  "composer.no_match_workflows": "No matching workflows",
+  "composer.no_match_servers": "No matching MCP servers",
+  "composer.no_match_tools": "No tools found",
   "agent.plan": "Plan",
   "agent.thoughts": "Thoughts",
   "agent.sub_agents": "Sub-agents",
@@ -550,6 +607,63 @@ export const zh: Record<string, string> = {
   "tools.results": "条结果",
   "tools.changes": "处修改",
   "tools.matches": "处匹配",
+  // tool group (ToolGroup.svelte)
+  "tools.n_used": "使用了 {n} 个工具",
+  "tools.n_used_one": "使用了 {n} 个工具",
+  "tools.background": "后台运行",
+  "tools.show_earlier": "显示前 {n} 行",
+  "tools.show_more": "显示剩余 {n} 行",
+  "tools.n_more_lines": "剩余 {n} 行",
+  // MCP 视图 (McpView.svelte)
+  "mcp.toast_removed": "服务器已移除",
+  "mcp.toast_reconnecting": "重新连接中",
+  "mcp.badge_project": "项目",
+  "mcp.tool_count": "{n} 个工具",
+  // 技能视图
+  "skills.confirm_delete": "删除技能 \"{name}\"?",
+  "skills.toast_deleted": "技能 \"{name}\" 已删除",
+  "skills.toast_imported": "技能 \"{name}\" 已导入",
+  // 任务视图
+  "tasks.toast_started": "任务已启动",
+  "tasks.toast_deleted": "任务已删除",
+  // 渠道视图
+  "channels.not_configured": "未配置",
+  "status.stopped": "已停止",
+  "channels.activity_running": "适配器正在运行并接受消息",
+  "channels.activity_enabled": "已启用但尚未启动 — 重启服务器以激活",
+  // 助手记忆视图
+  "profile.n_entries": "{n} 条记录",
+  // 文件回收站视图
+  "files.confirm_empty_all": "确定要永久删除全部 {n} 个文件吗？此操作不可撤销。",
+  "files.age_today": "今天",
+  "files.age_yesterday": "昨天",
+  "files.age_days_ago": "{n} 天前",
+  "files.count_files": "{n} 个文件",
+  "files.count_file": "{n} 个文件",
+  "files.count_orphans": "{n} 个孤立文件",
+  "files.count_orphan": "{n} 个孤立文件",
+  // 侧边栏
+  "sidebar.n_selected": "已选择 {n} 项",
+  // 子 Agent 卡片
+  "agent.n_running": "{n} 个运行中",
+  "agent.n_tools": "{n} 个工具",
+  "agent.done_n_tools": "完成 · {n} 个工具",
+  // 后台进程
+  "bgtask.n_processes": "{n} 个后台进程",
+  "bgtask.n_process": "{n} 个后台进程",
+  "bgtask.running_elapsed": "运行中 · {elapsed}",
+  // 制品面板
+  "artifacts.copied": "已复制到剪贴板",
+  "artifacts.copy_failed": "复制失败 — 剪贴板访问被拒绝",
+  // 命令面板
+  "cmdk.no_matches": "未找到 \"{query}\" 的匹配项",
+  // 编辑器
+  "composer.mcp_tool_prompt": "请帮我调用 mcp__{server}__{tool}，并说明需要什么参数",
+  "composer.label_mcp_server": "MCP 服务器",
+  "composer.no_match_skills": "未找到匹配的技能",
+  "composer.no_match_workflows": "未找到匹配的工作流",
+  "composer.no_match_servers": "未找到匹配的 MCP 服务器",
+  "composer.no_match_tools": "未找到工具",
   "agent.plan": "计划",
   "agent.thoughts": "思考",
   "agent.sub_agents": "子 Agent",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -130,7 +130,7 @@ export const en: Record<string, string> = {
   "tools.n_more_lines": "{n} more lines",
   // MCP view (McpView.svelte)
   "mcp.toast_removed": "Server removed",
-  "mcp.toast_reconnecting": "Reconnecting",
+  "mcp.toast_reconnecting": "Reconnecting {name}…",
   "mcp.badge_project": "project",
   "mcp.tool_count": "{n} tool(s)",
   // Skills view
@@ -616,7 +616,7 @@ export const zh: Record<string, string> = {
   "tools.n_more_lines": "剩余 {n} 行",
   // MCP 视图 (McpView.svelte)
   "mcp.toast_removed": "服务器已移除",
-  "mcp.toast_reconnecting": "重新连接中",
+  "mcp.toast_reconnecting": "正在重新连接 {name}…",
   "mcp.badge_project": "项目",
   "mcp.tool_count": "{n} 个工具",
   // 技能视图

--- a/web/src/views/ChannelsView.svelte
+++ b/web/src/views/ChannelsView.svelte
@@ -4,7 +4,7 @@
   import StatusTag from '../components/ui/StatusTag.svelte'
   import Switch from '../components/ui/Switch.svelte'
   import * as api from '../lib/api'
-  import { t } from '../lib/i18n'
+  import { t, tr } from '../lib/i18n'
 
   // platform-to-icon mapping for well-known channels
   const platformIcons: Record<string, string> = {
@@ -115,21 +115,21 @@
   }
 
   function tagFor(row: ChannelRow): { status: string; label: string } {
-    if (!row.has_config) return { status: 'default', label: 'Not configured' }
-    if (!row.enabled)    return { status: 'default', label: 'Disabled' }
+    if (!row.has_config) return { status: 'default', label: tr('channels.not_configured') }
+    if (!row.enabled)    return { status: 'default', label: tr('status.disabled') }
     // #1121: a config/startup problem or an ongoing crash-restart loop — show
     // it distinctly from a plain "Stopped" (which reads as "not started yet",
     // not "something is wrong").
-    if (row.issue)       return { status: 'error', label: 'Error' }
-    if (row.running)     return { status: 'success', label: 'Running' }
-    return { status: 'warning', label: 'Stopped' }
+    if (row.issue)       return { status: 'error', label: tr('status.error') }
+    if (row.running)     return { status: 'success', label: tr('status.running') }
+    return { status: 'warning', label: tr('status.stopped') }
   }
 
   function activityFor(row: ChannelRow): string {
     if (row.issue) return row.issue
-    if (row.running) return 'Adapter is running and accepting messages'
-    if (row.enabled) return 'Enabled but not yet started — restart the server to activate'
-    return 'Disabled'
+    if (row.running) return tr('channels.activity_running')
+    if (row.enabled) return tr('channels.activity_enabled')
+    return tr('status.disabled')
   }
 
   function labelFor(platform: string): string {

--- a/web/src/views/FileRecallView.svelte
+++ b/web/src/views/FileRecallView.svelte
@@ -156,7 +156,7 @@
     <!-- Stats + actions -->
     <div class="stats-bar">
       <span class="stats-text">
-        {$t('files.count_files').replace('{n}', String(totalCount))}, {fmtSize(totalSize)}{#if orphanCount > 0} · {$t('files.count_orphans').replace('{n}', String(orphanCount))}{/if}
+        {$t(totalCount === 1 ? 'files.count_file' : 'files.count_files').replace('{n}', String(totalCount))}, {fmtSize(totalSize)}{#if orphanCount > 0} · {$t(orphanCount === 1 ? 'files.count_orphan' : 'files.count_orphans').replace('{n}', String(orphanCount))}{/if}
       </span>
       <div class="bar-actions">
         <button class="btn-outline" onclick={reload} disabled={loading}>

--- a/web/src/views/FileRecallView.svelte
+++ b/web/src/views/FileRecallView.svelte
@@ -76,7 +76,7 @@
   }
 
   async function handleEmptyAll() {
-    if (!confirm(`Permanently delete all ${totalCount} files? This cannot be undone.`)) return
+    if (!confirm(tr('files.confirm_empty_all').replace('{n}', String(totalCount)))) return
     try {
       await api.emptyTrash({ mode: 'all' })
       items = []
@@ -119,9 +119,9 @@
     try {
       const ms = Date.now() - new Date(iso).getTime()
       const days = Math.floor(ms / 86400000)
-      if (days === 0) return 'Today'
-      if (days === 1) return 'Yesterday'
-      return `${days} days ago`
+      if (days === 0) return tr('files.age_today')
+      if (days === 1) return tr('files.age_yesterday')
+      return tr('files.age_days_ago').replace('{n}', String(days))
     } catch { return iso }
   }
 
@@ -156,7 +156,7 @@
     <!-- Stats + actions -->
     <div class="stats-bar">
       <span class="stats-text">
-        {totalCount} {totalCount === 1 ? 'file' : 'files'}, {fmtSize(totalSize)}{#if orphanCount > 0} · {orphanCount} {orphanCount === 1 ? 'orphan' : 'orphans'}{/if}
+        {$t('files.count_files').replace('{n}', String(totalCount))}, {fmtSize(totalSize)}{#if orphanCount > 0} · {$t('files.count_orphans').replace('{n}', String(orphanCount))}{/if}
       </span>
       <div class="bar-actions">
         <button class="btn-outline" onclick={reload} disabled={loading}>

--- a/web/src/views/McpView.svelte
+++ b/web/src/views/McpView.svelte
@@ -107,7 +107,7 @@
     try {
       await api.deleteMcpServer(name)
       mcpServers.update(list => (list as any[]).filter((s: any) => s.name !== name))
-      showToast('Server removed')
+      showToast(tr('mcp.toast_removed'))
     } catch (e: any) {
       showToast(e.message ?? 'Failed to delete server', 'error')
     }
@@ -218,7 +218,7 @@
   async function reconnect(name: string) {
     try {
       await api.reconnectMcpServer(name)
-      showToast('Reconnecting ' + name + '…')
+      showToast(tr('mcp.toast_reconnecting') + ' ' + name + '…')
       setTimeout(reload, 1500)
     } catch (e: any) {
       showToast(e.message ?? 'Failed to reconnect', 'error')
@@ -314,11 +314,11 @@
                   <span class="transport-badge mono">{srv.transport}</span>
                 {/if}
                 {#if srv.source === 'project'}
-                  <span class="transport-badge mono">project</span>
+                  <span class="transport-badge mono">{$t('mcp.badge_project')}</span>
                 {/if}
                 <StatusTag status={tag.tagStatus}>{tag.tagLabel}</StatusTag>
                 {#if srv.status === 'connected'}
-                  <span class="tool-count">{srv.tools} tool{srv.tools !== 1 ? 's' : ''}</span>
+                  <span class="tool-count">{$t('mcp.tool_count').replace('{n}', String(srv.tools))}</span>
                 {/if}
               </div>
               <span class="server-cmd mono">{srv.command || srv.url || ''}</span>

--- a/web/src/views/McpView.svelte
+++ b/web/src/views/McpView.svelte
@@ -218,7 +218,7 @@
   async function reconnect(name: string) {
     try {
       await api.reconnectMcpServer(name)
-      showToast(tr('mcp.toast_reconnecting') + ' ' + name + '…')
+      showToast(tr('mcp.toast_reconnecting').replace('{name}', name))
       setTimeout(reload, 1500)
     } catch (e: any) {
       showToast(e.message ?? 'Failed to reconnect', 'error')

--- a/web/src/views/ProfileView.svelte
+++ b/web/src/views/ProfileView.svelte
@@ -148,7 +148,7 @@
           {/if}
         </div>
         {#if loadingSoul}
-          <div class="card-loading">Loading…</div>
+          <div class="card-loading">{$t('common.loading')}</div>
         {:else if soulData}
           <div class="card-body md-content">{@html renderMarkdown(soulData.content)}</div>
         {:else}
@@ -176,7 +176,7 @@
           {/if}
         </div>
         {#if loadingUser}
-          <div class="card-loading">Loading…</div>
+          <div class="card-loading">{$t('common.loading')}</div>
         {:else if userData}
           <div class="card-body md-content">{@html renderMarkdown(userData.content)}</div>
         {:else}
@@ -196,7 +196,7 @@
         <div class="card-header">
           <div style="display:flex;align-items:center;gap:8px;">
             <span class="card-title">{$t('profile.memories_title')}</span>
-            <span class="mem-count">{memFiles.length} entries</span>
+            <span class="mem-count">{$t('profile.n_entries').replace('{n}', String(memFiles.length))}</span>
           </div>
           <span class="auto-badge">
             <iconify-icon icon="ant-design:thunderbolt-outlined" width="13"></iconify-icon>
@@ -227,7 +227,7 @@
               </summary>
               <div class="mem-body">
                 {#if memContent[f.path] === undefined || memContent[f.path] === ''}
-                  <span class="mem-loading">Loading…</span>
+                  <span class="mem-loading">{$t('common.loading')}</span>
                 {:else}
                   <div class="md-content">{@html renderMarkdown(memContent[f.path])}</div>
                 {/if}

--- a/web/src/views/SettingsView.svelte
+++ b/web/src/views/SettingsView.svelte
@@ -26,6 +26,7 @@
   let providersLoaded = $state(false)
 
   // Original values for dirty-checking
+  let origLanguage    = 'en'
   let origWorkdir      = ''
   let origReasoning    = 'Medium'
   let origShowReasoning = true
@@ -160,6 +161,7 @@
       // server only hardcodes a placeholder, so don't let it clobber the saved
       // choice. Language still seeds from config when present.
       if (cfg.language)   language = cfg.language
+      origLanguage = language
     } catch (e: any) {
       showToast(`Failed to load config: ${e.message}`, 'error')
     } finally {
@@ -262,6 +264,14 @@
       if (coauthor !== origCoauthor) {
         await api.updateCoauthor(coauthor)
         origCoauthor = coauthor
+      }
+
+      // Language: persisted globally on the server so a refresh lands on the
+      // same locale, then immediately applied.
+      if (language !== origLanguage) {
+        await api.updateLanguage(language)
+        origLanguage = language
+        setLocale(language === 'zh' || language === 'zh-TW' ? 'zh' : 'en')
       }
 
       // Working directory: the one field that actually needs an active

--- a/web/src/views/SkillsView.svelte
+++ b/web/src/views/SkillsView.svelte
@@ -31,11 +31,11 @@
   }
 
   async function handleDelete(name: string) {
-    if (!confirm(`Delete skill "${name}"?`)) return
+    if (!confirm(tr('skills.confirm_delete').replace('{name}', name))) return
     try {
       await api.deleteSkill(name)
       skills.update(list => list.filter(s => s.name !== name))
-      showToast(`Skill "${name}" deleted`)
+      showToast(tr('skills.toast_deleted').replace('{name}', name))
     } catch (err: any) {
       showToast(err.message, 'error')
     }
@@ -137,7 +137,7 @@
         return
       }
       skills.set(await api.listSkills())
-      showToast(`Skill "${r.name}" imported`)
+      showToast(tr('skills.toast_imported').replace('{name}', r.name))
       importOpen = false
     } catch (err: any) {
       showToast(tr('skills.import_error') + err.message, 'error')

--- a/web/src/views/TasksView.svelte
+++ b/web/src/views/TasksView.svelte
@@ -63,7 +63,7 @@
   async function handleRun(t: api.TaskResponse) {
     try {
       const res = await api.runTask(t.id)
-      showToast('Task started')
+      showToast(tr('tasks.toast_started'))
       if (res.session_id) {
         // Refresh the session list so the new session shows in the sidebar,
         // then activate it and switch to chat. The streamed turn events will
@@ -93,7 +93,7 @@
     try {
       await api.deleteTask(t.id)
       rawTasks = rawTasks.filter(r => r.id !== t.id)
-      showToast('Task deleted')
+      showToast(tr('tasks.toast_deleted'))
     } catch (e: any) {
       showToast(e?.message ?? 'Failed to delete task', 'error')
     }


### PR DESCRIPTION
## 修复内容

### #1074 — onboard 语言选择没有生效 + #1113 — 硬编码 i18n 字符串

**根因**：语言偏好没有持久化链路，刷新页面后 LANG="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_CTYPE="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_ALL= store 重置为英文。同时大量视图存在硬编码字符串未走 i18n 系统。

### 后端改动

| 文件 | 改动 |
|------|------|
|  | Config 结构体增加  字段，持久化到  |
|  |  从 config 读取 language；新增  端点 |
|  | 注册新路由 |
|  | 更新测试兼容空字符串 |

### 前端改动

| 文件 | 改动 |
|------|------|
|  | 新增 ~50 个 i18n key（中英文） |
|  | 新增  API 函数 |
|  | 启动时从 config 恢复语言偏好 |
|  | onboard 完成时持久化语言选择 |
|  | Settings 保存按钮写入语言到服务端 |
| 12 个视图文件 | 替换硬编码英/中文字符串为 / |

### 涉及的视图

McpView, SkillsView, TasksView, ChannelsView, ProfileView, FileRecallView, Sidebar, SubAgentsCard, BackgroundProcesses, ArtifactsPanel, CommandPalette, ToolGroup, Composer

Closes #1074, Closes #1113