### PR TITLE
fix(channel): acknowledge unsupported media instead of silent drop

### DIFF
--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -48,6 +48,12 @@ const (
 	// commonly documented at ~20000 bytes; SendText previously posted content
 	// as a single unbounded payload with no split at all (#1116).
 	maxMessageBytes = 20000
+
+	// unsupportedMediaNotice is sent in place of silence (#1123) when a
+	// message is a msgtype we don't decode (voice, audio, video, …).
+	// Transcription/decoding can come later; going silent is the bug being
+	// fixed here.
+	unsupportedMediaNotice = "This message type isn't supported yet — please send text."
 )
 
 func init() {
@@ -603,9 +609,15 @@ func (a *Adapter) handleInbound(raw json.RawMessage, onMessage func(channel.Inbo
 		return
 	}
 
-	text, files := a.extractPayload(ev)
+	text, files, unsupported := a.extractPayload(ev)
 	// DT-005: guard changed to check both text and files.
 	if strings.TrimSpace(text) == "" && len(files) == 0 {
+		// #1123: an unsupported msgtype (voice, audio, video, …) used to
+		// drop here with only a server-side log — the user got no signal
+		// their message was even received.
+		if unsupported {
+			a.SendText(chatID, unsupportedMediaNotice, "")
+		}
 		return
 	}
 
@@ -628,8 +640,10 @@ func (a *Adapter) handleInbound(raw json.RawMessage, onMessage func(channel.Inbo
 }
 
 // extractPayload parses text and file attachments from an inbound event.
-// DT-005, DT-006: handles picture, file, and richText msgtypes.
-func (a *Adapter) extractPayload(ev dtEvent) (string, []channel.FileAttachment) {
+// DT-005, DT-006: handles picture, file, and richText msgtypes. The third
+// return value reports an unsupported msgtype (#1123), letting the caller
+// acknowledge instead of dropping silently.
+func (a *Adapter) extractPayload(ev dtEvent) (string, []channel.FileAttachment, bool) {
 	var text string
 	var files []channel.FileAttachment
 
@@ -712,9 +726,10 @@ func (a *Adapter) extractPayload(ev dtEvent) (string, []channel.FileAttachment) 
 
 	default:
 		log.Printf("[dingtalk] unsupported msgtype=%s, ignoring", ev.MsgType)
+		return text, files, true
 	}
 
-	return text, files
+	return text, files, false
 }
 
 // downloadDTFile fetches a file by downloadCode from the DingTalk robot API.

--- a/internal/channel/adapters/dingtalk/dingtalk_test.go
+++ b/internal/channel/adapters/dingtalk/dingtalk_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/open-octo/octo-agent/internal/channel"
 )
 
 // stubAPI fakes the DingTalk token + robot send endpoints and records the
@@ -179,5 +181,34 @@ func TestSendText_PrefersSessionWebhook(t *testing.T) {
 	defer stub.mu.Unlock()
 	if len(stub.sends) != 0 {
 		t.Fatalf("robot api sends = %d, want 0", len(stub.sends))
+	}
+}
+
+// #1123: an unsupported msgtype (voice, audio, video, …) used to drop at
+// extractPayload's default branch with only a server-side log — the user
+// got no signal their message was even received. It should now get a text
+// acknowledgement instead, and not be forwarded as an agent turn.
+func TestHandleInbound_UnsupportedMediaAcknowledged(t *testing.T) {
+	stub := &stubAPI{}
+	ts := stub.server(t)
+	defer ts.Close()
+
+	a := testAdapter(ts)
+	a.routes = make(map[string]routeEntry)
+
+	raw := []byte(`{"senderId": "user-1", "msgtype": "audio"}`)
+
+	gotEvent := false
+	a.handleInbound(raw, func(ev channel.InboundEvent) {
+		gotEvent = true
+	})
+
+	if gotEvent {
+		t.Fatal("expected no InboundEvent for an unsupported-media-only message")
+	}
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.sends) != 1 {
+		t.Fatalf("expected one acknowledgement to be sent, got %d", len(stub.sends))
 	}
 }

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -44,6 +44,12 @@ const (
 	// against silently failing on a truly pathological reply (#1116), not a
 	// limit anyone should expect to hit in practice.
 	maxMessageBytes = 20000
+
+	// unsupportedMediaNotice is sent in place of silence (#1123) when a
+	// message is a kind we don't decode (voice, post/rich-text video, …).
+	// Transcription/decoding can come later; going silent is the bug being
+	// fixed here.
+	unsupportedMediaNotice = "This message type isn't supported yet — please send text."
 )
 
 func init() {
@@ -531,6 +537,7 @@ func (a *Adapter) handleEvent(raw json.RawMessage, onMessage func(channel.Inboun
 
 	var text string
 	var files []channel.FileAttachment
+	unsupported := false
 
 	switch msg.MessageType {
 	case "text":
@@ -554,10 +561,18 @@ func (a *Adapter) handleEvent(raw json.RawMessage, onMessage func(channel.Inboun
 				files = append(files, fa)
 			}
 		}
+	default:
+		// #1123: voice, post (rich text/video), and other kinds we don't
+		// decode land here — used to fall straight through to the drop below
+		// with no signal to the user at all.
+		unsupported = true
 	}
 
 	// FEISHU-006: drop only if both text and files are empty.
 	if text == "" && len(files) == 0 {
+		if unsupported {
+			a.SendText(msg.ChatID, unsupportedMediaNotice, "")
+		}
 		return
 	}
 
@@ -649,7 +664,10 @@ func (a *Adapter) downloadResource(messageID, key, resourceType, fileName string
 }
 
 // enrichDocContent fetches inline Feishu doc content and appends it to the text.
-// FEISHU-011: silently skips on error.
+// #1123: a fetch failure used to only log server-side — the user pasted a
+// doc link, got an answer that silently ignored it, and no hint why. Now
+// appends a short note instead so the agent (and, through it, the user)
+// knows the doc couldn't be read.
 func (a *Adapter) enrichDocContent(text string) string {
 	matches := feishuDocURLRe.FindAllStringSubmatch(text, -1)
 	if len(matches) == 0 {
@@ -662,6 +680,7 @@ func (a *Adapter) enrichDocContent(text string) string {
 		content, err := a.fetchDocRawContent(docToken)
 		if err != nil {
 			log.Printf("[feishu] doc fetch failed for %s: %v", docToken, err)
+			sections = append(sections, fmt.Sprintf("[Couldn't read the linked doc %s]", m[0]))
 			continue
 		}
 		if content != "" {

--- a/internal/channel/adapters/feishu/feishu_test.go
+++ b/internal/channel/adapters/feishu/feishu_test.go
@@ -56,6 +56,18 @@ func newFakeFeishu(t *testing.T) *fakeFeishu {
 				"code": 0, "data": map[string]any{"message_id": "m-1"},
 			})
 		default:
+			if strings.HasPrefix(r.URL.Path, "/open-apis/docx/v1/documents/") {
+				// #1123: docToken "badtoken" simulates a failed doc fetch
+				// (deleted doc, no permission, …) — everything else succeeds.
+				if strings.Contains(r.URL.Path, "badtoken") {
+					json.NewEncoder(w).Encode(map[string]any{"code": 99999})
+					return
+				}
+				json.NewEncoder(w).Encode(map[string]any{
+					"code": 0, "data": map[string]any{"content": "doc body"},
+				})
+				return
+			}
 			w.WriteHeader(404)
 		}
 	}))
@@ -182,6 +194,79 @@ func TestSendFile_Missing(t *testing.T) {
 	res := a.SendFile("chat-1", "/no/such/file", "", "")
 	if res.OK {
 		t.Fatal("expected failure for missing file")
+	}
+}
+
+// #1123: a message of an unhandled type (voice, rich-post/video, …) used to
+// fall straight through to the drop with no signal to the user at all. It
+// should now get a text acknowledgement instead, and not be forwarded as an
+// agent turn.
+func TestHandleEvent_UnsupportedMediaAcknowledged(t *testing.T) {
+	f := newFakeFeishu(t)
+	a := newTestAdapter(t, f)
+
+	raw := []byte(`{
+		"schema": "2.0",
+		"header": {"event_type": "im.message.receive_v1"},
+		"event": {
+			"message": {
+				"message_id": "m-1",
+				"chat_id": "chat-1",
+				"chat_type": "p2p",
+				"message_type": "audio",
+				"content": "{}"
+			},
+			"sender": {"sender_id": {"open_id": "user-1"}}
+		}
+	}`)
+
+	gotEvent := false
+	a.handleEvent(raw, func(ev channel.InboundEvent) {
+		gotEvent = true
+	})
+
+	if gotEvent {
+		t.Fatal("expected no InboundEvent for an unsupported-media-only message")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sent) != 1 {
+		t.Fatalf("expected one acknowledgement to be sent, got %d", len(f.sent))
+	}
+	content, _ := f.sent[0]["content"].(string)
+	if !strings.Contains(content, unsupportedMediaNotice) {
+		t.Fatalf("expected the ack notice in sent content, got: %s", content)
+	}
+}
+
+// #1123: a doc-fetch failure used to only log server-side — the user pasted
+// a doc link, got an answer that silently ignored it, and no hint why.
+func TestEnrichDocContent_FetchFailureAppendsNote(t *testing.T) {
+	f := newFakeFeishu(t)
+	a := newTestAdapter(t, f)
+
+	text := "check this doc: https://example.feishu.cn/docx/badtoken"
+	got := a.enrichDocContent(text)
+
+	if !strings.Contains(got, "Couldn't read the linked doc") {
+		t.Fatalf("expected a failure note appended, got: %s", got)
+	}
+	if !strings.HasPrefix(got, text) {
+		t.Fatalf("expected the original text preserved, got: %s", got)
+	}
+}
+
+// A successful doc fetch should still just append the content, unaffected
+// by the failure-note path above.
+func TestEnrichDocContent_Success(t *testing.T) {
+	f := newFakeFeishu(t)
+	a := newTestAdapter(t, f)
+
+	text := "check this doc: https://example.feishu.cn/docx/goodtoken"
+	got := a.enrichDocContent(text)
+
+	if !strings.Contains(got, "doc body") {
+		t.Fatalf("expected fetched doc content appended, got: %s", got)
 	}
 }
 

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -46,6 +46,12 @@ const (
 	// counts bytes, not runes — for CJK text this is more conservative than
 	// the exact character cap requires, never less.
 	maxMessageBytes = 4000
+
+	// unsupportedMediaNotice is sent in place of silence (#1123) when a
+	// message contains only a kind we don't process (voice, video, sticker,
+	// location, …). Transcription/decoding can come later; going silent is
+	// the bug being fixed here.
+	unsupportedMediaNotice = "This message type isn't supported yet — please send text."
 )
 
 func init() {
@@ -545,6 +551,25 @@ type tgMessage struct {
 			ID int64 `json:"id"`
 		} `json:"from"`
 	} `json:"reply_to_message"`
+
+	// #1123: presence-only markers for message kinds we don't process (no
+	// transcription/decoding path) — used solely to tell "the user sent
+	// something we can't handle" apart from "the user sent nothing", so we
+	// can acknowledge instead of going silent. json.RawMessage is nil when
+	// the field is absent and non-nil (even "{}") when Telegram includes it.
+	Voice     json.RawMessage `json:"voice,omitempty"`
+	Audio     json.RawMessage `json:"audio,omitempty"`
+	Video     json.RawMessage `json:"video,omitempty"`
+	VideoNote json.RawMessage `json:"video_note,omitempty"`
+	Sticker   json.RawMessage `json:"sticker,omitempty"`
+	Location  json.RawMessage `json:"location,omitempty"`
+}
+
+// hasUnsupportedMedia reports whether the message carries a kind we
+// recognize but don't process (see the presence markers above).
+func (m *tgMessage) hasUnsupportedMedia() bool {
+	return m.Voice != nil || m.Audio != nil || m.Video != nil ||
+		m.VideoNote != nil || m.Sticker != nil || m.Location != nil
 }
 
 func (a *Adapter) callMessage(method string, params map[string]any) (*tgMessage, error) {
@@ -679,6 +704,14 @@ func (a *Adapter) processUpdate(upd tgUpdate, onMessage func(channel.InboundEven
 	}
 
 	if text == "" && len(files) == 0 {
+		// #1123: voice/audio/video/video_note/sticker/location arrive with no
+		// text and nothing we download, so this used to be a bare drop — the
+		// user sees the bot simply ignore them, indistinguishable from
+		// broken. Acknowledge instead of going silent; a legitimately empty
+		// message (no such marker) still drops with no reply, as before.
+		if msg.hasUnsupportedMedia() {
+			a.SendText(fmt.Sprintf("%d", msg.Chat.ID), unsupportedMediaNotice, fmt.Sprintf("%d", msg.MessageID))
+		}
 		return
 	}
 

--- a/internal/channel/adapters/telegram/telegram_test.go
+++ b/internal/channel/adapters/telegram/telegram_test.go
@@ -306,3 +306,58 @@ func TestSendTyping(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// #1123: a voice/video/sticker/location-only message used to be a bare drop
+// — the user got no signal it was even received. It should now get a text
+// acknowledgement instead, and not be forwarded as an agent turn.
+func TestProcessUpdate_UnsupportedMediaAcknowledged(t *testing.T) {
+	f := newFakeBotAPI(t)
+	a := newTestAdapter(t, f, nil)
+
+	var msg tgMessage
+	msg.MessageID = 1
+	msg.Chat.ID = 123
+	msg.Chat.Type = "private"
+	msg.From.ID = 42
+	msg.Voice = json.RawMessage(`{}`)
+
+	gotEvent := false
+	a.processUpdate(tgUpdate{UpdateID: 1, Message: &msg}, func(ev channel.InboundEvent) {
+		gotEvent = true
+	})
+
+	if gotEvent {
+		t.Fatal("expected no InboundEvent for an unsupported-media-only message")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sent) != 1 {
+		t.Fatalf("expected one acknowledgement to be sent, got %d", len(f.sent))
+	}
+	if f.sent[0]["text"] != unsupportedMediaNotice {
+		t.Fatalf("unexpected ack text: %v", f.sent[0]["text"])
+	}
+}
+
+// A legitimately empty message (no text, no attachment, no unsupported-media
+// marker) must keep dropping silently — the ack is specifically for
+// unsupported media, not every no-op update.
+func TestProcessUpdate_EmptyMessageStaysSilent(t *testing.T) {
+	f := newFakeBotAPI(t)
+	a := newTestAdapter(t, f, nil)
+
+	var msg tgMessage
+	msg.MessageID = 1
+	msg.Chat.ID = 123
+	msg.From.ID = 42
+
+	a.processUpdate(tgUpdate{UpdateID: 1, Message: &msg}, func(ev channel.InboundEvent) {
+		t.Fatal("unexpected event for an empty message")
+	})
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sent) != 0 {
+		t.Fatalf("expected no acknowledgement for a legitimately empty message, got %d", len(f.sent))
+	}
+}

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -60,6 +60,11 @@ const (
 	// 4096") — a hard, documented, byte-counted (not character-counted) cap.
 	// SendText previously sent content as a single unbounded payload (#1116).
 	maxMessageBytes = 4096
+
+	// unsupportedMediaNotice is sent in place of silence (#1123) when a
+	// message is a msgtype we don't decode (voice, video, …). Transcription/
+	// decoding can come later; going silent is the bug being fixed here.
+	unsupportedMediaNotice = "This message type isn't supported yet — please send text."
 )
 
 func init() {
@@ -812,13 +817,6 @@ func (a *Adapter) handleInbound(body json.RawMessage, onMessage func(channel.Inb
 		return
 	}
 
-	switch msg.MsgType {
-	case "text", "image", "file":
-		// handled below
-	default:
-		return
-	}
-
 	chatID := msg.ChatID
 	if chatID == "" {
 		chatID = msg.From.UserID
@@ -828,6 +826,18 @@ func (a *Adapter) handleInbound(body json.RawMessage, onMessage func(channel.Inb
 	}
 
 	if len(a.allowedUsers) > 0 && !a.allowedUsers[msg.From.UserID] {
+		return
+	}
+
+	switch msg.MsgType {
+	case "text", "image", "file":
+		// handled below
+	default:
+		// #1123: voice/video/other unsupported msgtypes used to bare-return
+		// here with not even a log line — the user had no idea their message
+		// was received at all.
+		log.Printf("[wecom] unsupported msgtype=%s from %s, acknowledging", msg.MsgType, msg.From.UserID)
+		a.SendText(chatID, unsupportedMediaNotice, "")
 		return
 	}
 

--- a/internal/channel/adapters/wecom/wecom_test.go
+++ b/internal/channel/adapters/wecom/wecom_test.go
@@ -194,6 +194,38 @@ func TestStart_AllowedUsersFilters(t *testing.T) {
 	}
 }
 
+// #1123: an unsupported msgtype (voice, video, …) used to hit a bare
+// `return` before chatID was even resolved — not even a log line, and
+// certainly no signal to the user their message was received. It should now
+// get a text acknowledgement instead, and not be forwarded as an agent turn.
+func TestStart_UnsupportedMediaAcknowledged(t *testing.T) {
+	f := newFakeWecom(t)
+	f.callbacks = []map[string]any{
+		{
+			"msgtype":  "voice",
+			"chatid":   "chat-1",
+			"chattype": "single",
+			"msgid":    "msg-1",
+			"from":     map[string]string{"userid": "user-7"},
+		},
+	}
+	a := newTestAdapter(t, f, nil)
+
+	// want=1 is unreachable (no InboundEvent should fire); collectEvents
+	// still returns once its internal 3s timeout elapses, by which point the
+	// ack round-trip below has long completed.
+	events := collectEvents(t, a, 1)
+	if len(events) != 0 {
+		t.Fatalf("expected no InboundEvent for an unsupported-media-only message, got %+v", events)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sent) != 1 {
+		t.Fatalf("expected one acknowledgement to be sent, got %d", len(f.sent))
+	}
+}
+
 func TestStart_AuthFailureIsFatal(t *testing.T) {
 	f := newFakeWecom(t)
 	cfg := channel.PlatformConfig{"bot_id": "aib123", "secret": "wrong", "ws_url": f.wsURL}


### PR DESCRIPTION
## Summary

Fixes #1123: voice/video/sticker/location messages vanished with zero
signal to the user across four of the six IM adapters — indistinguishable
from the bot being broken.

Verified against current `main` before fixing, not just the issue text
(which predates several unrelated refactors — see #1108 for why that check
matters): **Discord** already forwards these as a generic file attachment,
and **Weixin** already emits a `[语音]`-style placeholder text. Both fall
short of real transcription, but neither is silent, and the issue explicitly
defers transcription ("can come later"). **Telegram, Feishu, DingTalk, and
WeCom** genuinely dropped with nothing sent back — those four are what's
fixed here.

- **telegram.go**: `tgMessage` gained presence-only markers for voice/audio/
  video/video_note/sticker/location; hitting the existing empty-text-and-no-
  files drop now sends `unsupportedMediaNotice` when one of those markers is
  set, leaving a legitimately empty message's silent drop unchanged.
- **feishu.go**: the message-type switch's implicit fallthrough (no
  `default`) now marks `unsupported` and acknowledges under the same
  empty-drop guard. Also fixed the adjacent silent doc-fetch failure in
  `enrichDocContent` — a pasted doc link that fails to fetch now appends a
  "couldn't read the linked doc" note to the text instead of just logging
  server-side, so the agent (and through it, the user) knows enrichment
  didn't happen.
- **dingtalk.go**: `extractPayload`'s `default` branch now returns a third
  `unsupported bool` (previously just logged and returned empty text/files);
  the caller acknowledges when set.
- **wecom.go**: the earliest msgtype gate returned before `chatID` was even
  resolved, with not even a log line. Moved chatID resolution (and the
  `allowedUsers` check, so a disallowed user still doesn't get a reply)
  ahead of the gate so the default case can log and acknowledge.

## Verification
- [x] `go build ./...`, `go vet ./...`
- [x] `go test -race ./...` (full suite)
- [x] New tests per adapter confirming the ack fires for unsupported media
      and NOT for a legitimately empty message (telegram), plus feishu's
      doc-fetch failure-note and success paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>