### PR TITLE
fix(channel): fix inconsistent group-chat @-mention gating

### DIFF
--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -590,7 +590,12 @@ func (a *Adapter) handleInbound(raw json.RawMessage, onMessage func(channel.Inbo
 	}
 	a.routeMu.Unlock()
 
-	// Group chat: only @-mention.
+	// Group chat: only @-mention. #1122: this used to also pass on any
+	// message containing a bare "@" character (e.g. "@someone-else 帮我看下"),
+	// which let the bot barge into unrelated group conversations. AtUsers
+	// already carries the precisely-mentioned staff IDs from the webhook, so
+	// there is no need for — and no correctness reason to keep — the
+	// substring fallback.
 	if ev.ConversationType == "2" {
 		mentioned := false
 		for _, u := range ev.AtUsers {
@@ -599,8 +604,7 @@ func (a *Adapter) handleInbound(raw json.RawMessage, onMessage func(channel.Inbo
 				break
 			}
 		}
-		content := ev.Text.Content
-		if !mentioned && !strings.Contains(content, "@") {
+		if !mentioned {
 			return
 		}
 	}

--- a/internal/channel/adapters/dingtalk/dingtalk_test.go
+++ b/internal/channel/adapters/dingtalk/dingtalk_test.go
@@ -212,3 +212,75 @@ func TestHandleInbound_UnsupportedMediaAcknowledged(t *testing.T) {
 		t.Fatalf("expected one acknowledgement to be sent, got %d", len(stub.sends))
 	}
 }
+
+// #1122: a group message containing a bare "@" character (mentioning someone
+// else entirely) used to pass the gate anyway via a loose substring match —
+// the bot barged into unrelated group conversations. AtUsers is the real
+// signal and should be the only one consulted.
+func TestHandleInbound_GroupRequiresRealMention(t *testing.T) {
+	stub := &stubAPI{}
+	ts := stub.server(t)
+	defer ts.Close()
+
+	a := testAdapter(ts)
+	a.routes = make(map[string]routeEntry)
+
+	raw := []byte(`{
+		"senderId": "user-1",
+		"conversationId": "conv-1",
+		"conversationType": "2",
+		"chatbotUserId": "bot-1",
+		"msgtype": "text",
+		"text": {"content": "@someone-else 帮我看下"},
+		"atUsers": [{"dingtalkId": "someone-else"}]
+	}`)
+
+	gotEvent := false
+	a.handleInbound(raw, func(ev channel.InboundEvent) {
+		gotEvent = true
+	})
+
+	if gotEvent {
+		t.Fatal("expected the message to be dropped — the bot wasn't actually @-mentioned")
+	}
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.sends) != 0 {
+		t.Fatalf("expected no send for a dropped group message, got %d", len(stub.sends))
+	}
+}
+
+// A group message that genuinely @-mentions the bot (its ID present in
+// atUsers) should still pass through normally.
+func TestHandleInbound_GroupRealMentionPasses(t *testing.T) {
+	stub := &stubAPI{}
+	ts := stub.server(t)
+	defer ts.Close()
+
+	a := testAdapter(ts)
+	a.routes = make(map[string]routeEntry)
+
+	raw := []byte(`{
+		"senderId": "user-1",
+		"conversationId": "conv-1",
+		"conversationType": "2",
+		"chatbotUserId": "bot-1",
+		"msgtype": "text",
+		"text": {"content": "@octo 帮我看下"},
+		"atUsers": [{"dingtalkId": "bot-1"}]
+	}`)
+
+	var got channel.InboundEvent
+	gotEvent := false
+	a.handleInbound(raw, func(ev channel.InboundEvent) {
+		gotEvent = true
+		got = ev
+	})
+
+	if !gotEvent {
+		t.Fatal("expected the message to be delivered — the bot was actually @-mentioned")
+	}
+	if got.ChatType != "group" {
+		t.Fatalf("expected group chat type, got %+v", got)
+	}
+}

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -852,13 +852,19 @@ func (a *Adapter) handleInbound(body json.RawMessage, onMessage func(channel.Inb
 	// configured; without it, behavior is unchanged from before this fix.
 	if msg.ChatType == "group" && a.botNickname != "" {
 		mention := "@" + a.botNickname
-		if !strings.Contains(msg.Text.Content, mention) {
+		// Case-insensitive, matching Telegram's own text-based mention
+		// comparison (strings.EqualFold on @username) — a user typing
+		// "@Octo" instead of "@octo" shouldn't silently fail to reach the bot.
+		idx := strings.Index(strings.ToLower(msg.Text.Content), strings.ToLower(mention))
+		if idx < 0 {
 			return
 		}
-		// Strip the literal "@<nickname>" from the text that reaches the
-		// agent, same as Telegram/Feishu/DingTalk already do for their own
-		// mention syntax — it's UI-level addressing, not part of the query.
-		msg.Text.Content = strings.TrimSpace(strings.Replace(msg.Text.Content, mention, "", 1))
+		// Strip the literal mention from the text that reaches the agent,
+		// same as Telegram/Feishu/DingTalk already do for their own mention
+		// syntax — it's UI-level addressing, not part of the query. Slicing
+		// by byte offset (not strings.Replace) preserves the original
+		// casing of whatever text remains.
+		msg.Text.Content = strings.TrimSpace(msg.Text.Content[:idx] + msg.Text.Content[idx+len(mention):])
 	}
 
 	switch msg.MsgType {

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -850,8 +850,15 @@ func (a *Adapter) handleInbound(body json.RawMessage, onMessage func(channel.Inb
 	// aibot_msg_callback carries no structured "was the bot mentioned" field
 	// (see cfgBotNickname), so this only engages when bot_nickname is
 	// configured; without it, behavior is unchanged from before this fix.
-	if msg.ChatType == "group" && a.botNickname != "" && !strings.Contains(msg.Text.Content, "@"+a.botNickname) {
-		return
+	if msg.ChatType == "group" && a.botNickname != "" {
+		mention := "@" + a.botNickname
+		if !strings.Contains(msg.Text.Content, mention) {
+			return
+		}
+		// Strip the literal "@<nickname>" from the text that reaches the
+		// agent, same as Telegram/Feishu/DingTalk already do for their own
+		// mention syntax — it's UI-level addressing, not part of the query.
+		msg.Text.Content = strings.TrimSpace(strings.Replace(msg.Text.Content, mention, "", 1))
 	}
 
 	switch msg.MsgType {

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -82,6 +82,15 @@ const (
 	cfgWebhookKey = "webhook_key"
 	// cfgWSURL is a test seam, not user-facing config.
 	cfgWSURL = "ws_url"
+	// cfgBotNickname is the bot's display name as it appears in a group
+	// chat's roster — #1122: WeCom's aibot_msg_callback carries no
+	// structured "was the bot mentioned" field for group messages (unlike
+	// Telegram/Discord/Feishu entity metadata or DingTalk's atUsers); per
+	// WeCom's own docs example ("@RobotA hello robot"), the only signal is
+	// the literal "@<nickname>" text in the message. Without this configured
+	// there is nothing to match against, so group gating stays off (matches
+	// pre-#1122 behavior) rather than silently blocking every group message.
+	cfgBotNickname = "bot_nickname"
 )
 
 // defaultWebhookBase is the group-robot webhook endpoint webhook_key expands to.
@@ -94,6 +103,10 @@ type Adapter struct {
 	wsURL        string
 	webhookURL   string
 	allowedUsers map[string]bool
+	// botNickname is the bot's group-chat display name, used to detect a
+	// literal "@<nickname>" mention in group message text (see cfgBotNickname
+	// for why). Empty means group gating stays off.
+	botNickname string
 
 	conn   *websocket.Conn
 	connMu sync.Mutex // guards conn pointer and writes
@@ -139,12 +152,15 @@ func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
 		}
 	}
 
+	botNickname, _ := cfg[cfgBotNickname].(string)
+
 	return &Adapter{
 		botID:        botID,
 		secret:       secret,
 		wsURL:        wsURL,
 		webhookURL:   webhookURL,
 		allowedUsers: allowed,
+		botNickname:  botNickname,
 		pendingAcks:  make(map[string]chan *wsFrame),
 		http:         &http.Client{Timeout: 30 * time.Second},
 	}, nil
@@ -826,6 +842,15 @@ func (a *Adapter) handleInbound(body json.RawMessage, onMessage func(channel.Inb
 	}
 
 	if len(a.allowedUsers) > 0 && !a.allowedUsers[msg.From.UserID] {
+		return
+	}
+
+	// #1122: group chats had no @-mention gate at all — every message from an
+	// allowlisted user was processed regardless of chat type. WeCom's
+	// aibot_msg_callback carries no structured "was the bot mentioned" field
+	// (see cfgBotNickname), so this only engages when bot_nickname is
+	// configured; without it, behavior is unchanged from before this fix.
+	if msg.ChatType == "group" && a.botNickname != "" && !strings.Contains(msg.Text.Content, "@"+a.botNickname) {
 		return
 	}
 

--- a/internal/channel/adapters/wecom/wecom_test.go
+++ b/internal/channel/adapters/wecom/wecom_test.go
@@ -196,7 +196,9 @@ func TestStart_GroupChatType_NoNicknameConfiguredNoGate(t *testing.T) {
 
 // #1122: with bot_nickname configured, a group message that doesn't mention
 // the bot is dropped — previously every group message was processed
-// regardless of chat type.
+// regardless of chat type. The mention itself is stripped from the text
+// that reaches the agent, matching Telegram/Feishu/DingTalk's own handling
+// of their mention syntax.
 func TestStart_GroupRequiresMentionWhenNicknameConfigured(t *testing.T) {
 	f := newFakeWecom(t)
 	f.callbacks = []map[string]any{
@@ -209,8 +211,8 @@ func TestStart_GroupRequiresMentionWhenNicknameConfigured(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected only the @-mentioning message to pass, got %+v", events)
 	}
-	if events[0].Text != "@octo help me with this" {
-		t.Fatalf("unexpected event text: %+v", events[0])
+	if events[0].Text != "help me with this" {
+		t.Fatalf("expected the mention to be stripped from the forwarded text, got: %+v", events[0])
 	}
 }
 

--- a/internal/channel/adapters/wecom/wecom_test.go
+++ b/internal/channel/adapters/wecom/wecom_test.go
@@ -216,6 +216,23 @@ func TestStart_GroupRequiresMentionWhenNicknameConfigured(t *testing.T) {
 	}
 }
 
+// The mention match is case-insensitive, matching Telegram's own
+// text-based mention comparison (strings.EqualFold) — a user typing
+// "@Octo" instead of the configured "octo" should still reach the bot.
+func TestStart_GroupMentionMatchIsCaseInsensitive(t *testing.T) {
+	f := newFakeWecom(t)
+	f.callbacks = []map[string]any{textCallback("chat-g", "group", "user-7", "@Octo help me with this")}
+	a := newTestAdapter(t, f, map[string]any{"bot_nickname": "octo"})
+
+	events := collectEvents(t, a, 1)
+	if len(events) != 1 {
+		t.Fatalf("expected the differently-cased mention to still pass, got %+v", events)
+	}
+	if events[0].Text != "help me with this" {
+		t.Fatalf("expected the mention to be stripped regardless of case, got: %+v", events[0])
+	}
+}
+
 // A single (non-group) chat should never be mention-gated, even with
 // bot_nickname configured — the gate only applies to groups.
 func TestStart_SingleChatNeverMentionGated(t *testing.T) {

--- a/internal/channel/adapters/wecom/wecom_test.go
+++ b/internal/channel/adapters/wecom/wecom_test.go
@@ -180,6 +180,53 @@ func TestStart_GroupChatType(t *testing.T) {
 	}
 }
 
+// #1122: without bot_nickname configured, group gating stays off — matches
+// pre-fix behavior so existing deployments that haven't set it don't
+// suddenly go silent in every group.
+func TestStart_GroupChatType_NoNicknameConfiguredNoGate(t *testing.T) {
+	f := newFakeWecom(t)
+	f.callbacks = []map[string]any{textCallback("chat-g", "group", "user-7", "hi, no mention here")}
+	a := newTestAdapter(t, f, nil)
+
+	events := collectEvents(t, a, 1)
+	if len(events) != 1 {
+		t.Fatalf("expected the ungated group message to pass through, got %+v", events)
+	}
+}
+
+// #1122: with bot_nickname configured, a group message that doesn't mention
+// the bot is dropped — previously every group message was processed
+// regardless of chat type.
+func TestStart_GroupRequiresMentionWhenNicknameConfigured(t *testing.T) {
+	f := newFakeWecom(t)
+	f.callbacks = []map[string]any{
+		textCallback("chat-g", "group", "user-7", "hi everyone, no mention here"),
+		textCallback("chat-g", "group", "user-7", "@octo help me with this"),
+	}
+	a := newTestAdapter(t, f, map[string]any{"bot_nickname": "octo"})
+
+	events := collectEvents(t, a, 1)
+	if len(events) != 1 {
+		t.Fatalf("expected only the @-mentioning message to pass, got %+v", events)
+	}
+	if events[0].Text != "@octo help me with this" {
+		t.Fatalf("unexpected event text: %+v", events[0])
+	}
+}
+
+// A single (non-group) chat should never be mention-gated, even with
+// bot_nickname configured — the gate only applies to groups.
+func TestStart_SingleChatNeverMentionGated(t *testing.T) {
+	f := newFakeWecom(t)
+	f.callbacks = []map[string]any{textCallback("user-7", "single", "user-7", "no mention needed here")}
+	a := newTestAdapter(t, f, map[string]any{"bot_nickname": "octo"})
+
+	events := collectEvents(t, a, 1)
+	if len(events) != 1 {
+		t.Fatalf("expected the DM to pass through ungated, got %+v", events)
+	}
+}
+
 func TestStart_AllowedUsersFilters(t *testing.T) {
 	f := newFakeWecom(t)
 	f.callbacks = []map[string]any{


### PR DESCRIPTION
## Summary

Fixes #1122: DingTalk and WeCom's group-chat gates let the bot barge into
conversations it wasn't actually part of.

- **dingtalk.go**: the group gate was `!mentioned && !strings.Contains(content, "@")`
  — a message wasn't dropped if it merely contained an "@" character
  anywhere, e.g. "@someone-else 帮我看下". `atUsers` already carries the
  precisely-mentioned staff IDs from the webhook (the `mentioned` loop
  already existed), so the substring fallback was pure liability with no
  correctness upside. Removed it; the gate is now `atUsers`-only, matching
  how Telegram/Discord/Feishu already do it via their own mention metadata.

- **wecom.go**: there was no group gate at all — every message from an
  allowlisted user was processed regardless of chat type. Verified against
  WeCom's own aibot docs before implementing: their sample shows group
  messages arrive as literal `"@RobotA hello robot"` text, with no
  structured "was the bot mentioned" field to check instead (unlike
  DingTalk's `atUsers` or Telegram/Discord/Feishu's entity metadata). Since
  matching that text requires knowing the bot's own display name, and
  nothing in config carried it, added `bot_nickname` as a new **optional**
  config key: when set, a group message must contain `"@<nickname>"` to
  pass; when unset, group gating stays off (matches pre-fix behavior, so
  existing deployments don't go silent in every group they're already in).

Not changed: the issue's aside about a non-allowlisted Telegram user's
silent drop being worth a first-contact hint — that's a separate UX
enhancement, not part of the gating-inconsistency bug.

## Verification
- [x] `go build ./...`, `go vet ./...`
- [x] `go test -race ./...` (full suite)
- [x] New tests: DingTalk mention-required vs. real-mention-passes; WeCom
      no-nickname-configured (ungated, unchanged), nickname-configured group
      gating, and single-chat never gated regardless of nickname config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>