### PR TITLE
fix: Diagnostics button crashes with 400 (#1087)

### DIFF
--- a/internal/server/channels_handler.go
+++ b/internal/server/channels_handler.go
@@ -152,19 +152,22 @@ func (s *Server) handleDeleteChannel(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleTestChannel tests a connection to a platform with the given credentials.
+// Loads the saved config from ~/.octo/channels.yml rather than requiring a body,
+// since the frontend already stores the fields and just needs a validation trigger.
 func (s *Server) handleTestChannel(w http.ResponseWriter, r *http.Request) {
-	var req channelUpdateRequest
-	if err := readBodyJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	platform := r.PathValue("platform")
+
+	// Load the saved channel config and get the saved fields for this platform.
+	cfg, err := channel.LoadConfig()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load channel config: %v", err))
 		return
 	}
 
-	platform := r.PathValue("platform")
-
-	// Build PlatformConfig from request.
-	pc := make(channel.PlatformConfig)
-	for k, v := range req.Fields {
-		pc[k] = v
+	pc := cfg.Platform(platform)
+	if pc == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"ok": false, "error": "no configuration saved for this platform"})
+		return
 	}
 
 	ctor, err := channel.Find(platform)


### PR DESCRIPTION
## 根因

 的 Diagnostics 按钮调用  → ，发送的是 **POST 无 body** 请求。

而服务端  用  尝试解析 JSON body，空 body 导致  → 返回 **400 Bad Request**。

## 修复

让 handler 从  直接加载已保存的 channel 配置，不再依赖前端传 body。 方法已经能按 platform 名取出保存的字段。

## 影响范围

-  — 唯一改动文件，handler 逻辑调整为从本地配置加载
- 前端  和  无需改动

Closes #1087