### PR TITLE
fix: forget memory does not update MEMORY.md index (#1089)

### DIFF
--- a/internal/server/memory_handler.go
+++ b/internal/server/memory_handler.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"bufio"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/open-octo/octo-agent/internal/memory"
 	"github.com/open-octo/octo-agent/internal/trash"
 )
 
@@ -65,6 +68,31 @@ func (s *Server) handleDeleteMemory(w http.ResponseWriter, r *http.Request) {
 	if err := trash.Move(p, filepath.Dir(p)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
+	}
+
+	// Update MEMORY.md in the same directory: remove any lines that reference
+	// the deleted topic file, so the index stays consistent.
+	memDir := filepath.Dir(p)
+	indexPath := filepath.Join(memDir, memory.IndexFile)
+	if idxData, err := os.ReadFile(indexPath); err == nil {
+		var outLines []string
+		sc := bufio.NewScanner(strings.NewReader(string(idxData)))
+		for sc.Scan() {
+			line := sc.Text()
+			// Skip lines that reference the deleted filename (e.g.
+			// "- [topic](topic.md)" or "topic.md inline reference").
+			if strings.Contains(line, fname) {
+				continue
+			}
+			outLines = append(outLines, line)
+		}
+		if err := sc.Err(); err == nil && len(outLines) > 0 {
+			cleaned := strings.Join(outLines, "\n") + "\n"
+			// Only write if we actually removed something.
+			if cleaned != string(idxData) {
+				_ = os.WriteFile(indexPath, []byte(cleaned), 0o600)
+			}
+		}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})


### PR DESCRIPTION
## 根因

 只把 topic 文件移到了回收站，但从未更新同目录下的 MEMORY.md 索引。导致下一次会话加载时，agent 会在索引中看到一个指向已删除文件的无效引用。

## 修复

在  之后，从同一个 memory 目录读取 MEMORY.md，过滤掉所有包含被删除文件名的行，然后写回。采用 best-effort 策略（失败静默忽略），因为 topic 文件已被正确处理，MEMORY.md 不一致不会造成数据丢失。

## 改动范围

只改了  一个文件，新增 ~20 行。

Closes #1089