### PR TITLE
fix(channel): stop Discord mass-pings, preserve Weixin link URLs

### DIFF
--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -196,6 +196,13 @@ func (a *Adapter) Stop() error {
 	return nil
 }
 
+// noMentionsParse suppresses Discord's default mention parsing on outbound
+// content. #1119: agent-generated text containing "@everyone", "@here", or a
+// raw <@id>/<@&id> mention used to actually ping the channel or those
+// users/roles — the model has no way to know that plain text in its output
+// carries that side effect. An empty "parse" list disables all of them.
+var noMentionsParse = map[string]any{"parse": []string{}}
+
 // SendText sends a message via the REST API, splitting content over
 // Discord's 2000-char cap into consecutive messages (#1116). Returns the
 // message ID of the last chunk.
@@ -207,7 +214,7 @@ func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 
 	var lastID string
 	for i, chunk := range chunks {
-		payload := map[string]any{"content": chunk}
+		payload := map[string]any{"content": chunk, "allowed_mentions": noMentionsParse}
 		if replyTo != "" && i == 0 {
 			payload["message_reference"] = map[string]string{"message_id": replyTo}
 		}
@@ -307,7 +314,7 @@ func (a *Adapter) SendFile(chatID, path, name, replyTo string) channel.SendResul
 // UpdateMessage edits an existing message.
 func (a *Adapter) UpdateMessage(chatID, messageID, text string) bool {
 	err := a.rest(context.Background(), http.MethodPatch, fmt.Sprintf("/channels/%s/messages/%s", chatID, messageID),
-		map[string]any{"content": text}, nil)
+		map[string]any{"content": text, "allowed_mentions": noMentionsParse}, nil)
 	if err != nil {
 		log.Printf("[discord] update_message failed: %v", err)
 		return false

--- a/internal/channel/adapters/discord/discord_test.go
+++ b/internal/channel/adapters/discord/discord_test.go
@@ -274,6 +274,26 @@ func TestSendText(t *testing.T) {
 	}
 }
 
+// #1119: content was sent with no allowed_mentions field, so agent-generated
+// text containing "@everyone", "@here", or a raw <@id> mention actually
+// pinged the channel or those users — the model has no way to know plain
+// text in its output carries that side effect.
+func TestSendText_SuppressesMentions(t *testing.T) {
+	f := newFakeDiscord(t)
+	a := newTestAdapter(t, f, nil)
+
+	if res := a.SendText("chan-1", "hey @everyone check this out", ""); !res.OK {
+		t.Fatalf("send failed: %+v", res)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	mentions, _ := f.sent[0]["allowed_mentions"].(map[string]any)
+	parse, ok := mentions["parse"].([]any)
+	if !ok || len(parse) != 0 {
+		t.Fatalf("expected allowed_mentions.parse to be an empty list, got: %+v", f.sent[0]["allowed_mentions"])
+	}
+}
+
 // #1118: a 429 used to fail SendText outright — with a multi-chunk message
 // that meant chunk 1 arrives and chunk 2 silently vanishes. It should now
 // honor retry_after and retry instead of dropping the chunk.
@@ -377,6 +397,15 @@ func TestUpdateMessageAndTyping(t *testing.T) {
 	}
 	if err := a.SendTyping("chan-1", ""); err != nil {
 		t.Fatal(err)
+	}
+
+	// #1119: an edit is as capable of pinging @everyone as an initial send.
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	mentions, _ := f.edited[0]["allowed_mentions"].(map[string]any)
+	parse, ok := mentions["parse"].([]any)
+	if !ok || len(parse) != 0 {
+		t.Fatalf("expected allowed_mentions.parse to be an empty list on edit, got: %+v", f.edited[0]["allowed_mentions"])
 	}
 }
 

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -949,8 +949,18 @@ func markdownToPlain(text string) string {
 	// Images.
 	text = regexp.MustCompile(`!\[[^\]]*\]\([^)]*\)`).ReplaceAllString(text, "")
 
-	// Links: keep text, drop URL.
-	text = regexp.MustCompile(`\[([^\]]+)\]\([^)]*\)`).ReplaceAllString(text, "$1")
+	// Links: Weixin has no clickable-link markdown, so render as "text (url)"
+	// instead of discarding the URL entirely (#1119) — "see [the doc](url)"
+	// used to arrive as just "see the doc", with no way to reach the doc.
+	linkRe := regexp.MustCompile(`\[([^\]]+)\]\(([^)]*)\)`)
+	text = linkRe.ReplaceAllStringFunc(text, func(m string) string {
+		parts := linkRe.FindStringSubmatch(m)
+		label, url := parts[1], parts[2]
+		if url == "" {
+			return label
+		}
+		return label + " (" + url + ")"
+	})
 
 	// Bold/italic markers.
 	text = regexp.MustCompile(`\*\*([^*]+)\*\*`).ReplaceAllString(text, "$1")

--- a/internal/channel/adapters/weixin/weixin_test.go
+++ b/internal/channel/adapters/weixin/weixin_test.go
@@ -436,6 +436,20 @@ func TestMarkdownToPlain(t *testing.T) {
 	if strings.Contains(plain, "[link]") {
 		t.Errorf("expected link text, got: %q", plain)
 	}
+	// #1119: Weixin has no clickable-link markdown, and the URL used to be
+	// discarded entirely — "see [the doc](url)" arrived as just "see the
+	// doc", with no way to reach the doc.
+	if !strings.Contains(plain, "link (http://x)") {
+		t.Errorf("expected the URL to be preserved as \"text (url)\", got: %q", plain)
+	}
+}
+
+// A link with an empty URL (`[text]()`) shouldn't render a dangling "()".
+func TestMarkdownToPlain_LinkWithEmptyURL(t *testing.T) {
+	plain := markdownToPlain("see [the doc]()")
+	if plain != "see the doc" {
+		t.Errorf("expected the empty URL to be omitted, got: %q", plain)
+	}
 }
 
 func TestAdapter_StartWithCredentials(t *testing.T) {


### PR DESCRIPTION
## Summary

Partial fix for #1119, scoped to the two changes the issue itself calls
"one-liners" (Discord `allowed_mentions`, Weixin URL preservation) —
Telegram's MarkdownV2 migration is explicitly called out there as "the
substantial one", and Feishu's inline-image stripping / table-detection
false positives need real design decisions (how to represent an image
reference in Feishu's message format, a better table heuristic than "any
line with 2+ pipes"). Neither is included here; will comment on the issue
to keep it open for that remaining scope.

- **discord.go**: `SendText` and `UpdateMessage` sent `content` with no
  `allowed_mentions` field. Discord's default is to parse every mention it
  finds — agent-generated text containing `"@everyone"`, `"@here"`, or a raw
  `<@id>`/`<@&id>` actually pinged the channel or those users/roles, with no
  way for the model to know plain text in its output carries that side
  effect. Both now send `allowed_mentions: {parse: []}`, disabling all
  mention parsing on outbound content.

- **weixin.go**: `markdownToPlain`'s link regex replaced `[text](url)` with
  just `text`, discarding the URL — "see [the doc](url)" arrived as "see the
  doc" with no way to reach the doc. Now renders `"text (url)"` (Weixin has
  no clickable-link markdown), falling back to bare text when the URL is
  empty.

## Verification
- [x] `go build ./...`, `go vet ./...`
- [x] `go test -race ./...` (full suite)
- [x] New tests: `TestSendText_SuppressesMentions` / `TestUpdateMessageAndTyping`'s
      extended assertion (discord), `TestMarkdownToPlain`'s extended
      assertion + `TestMarkdownToPlain_LinkWithEmptyURL` (weixin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>