### PR TITLE
telegram: switch default parse_mode to HTML with AST-based rendering (#1119)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/rivo/uniseg v0.4.7
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/tetratelabs/wazero v1.12.0
+	github.com/yuin/goldmark v1.7.13
 	golang.org/x/sys v0.44.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -42,7 +43,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	github.com/yuin/goldmark v1.7.13 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/term v0.36.0 // indirect

--- a/internal/channel/adapters/telegram/markdown.go
+++ b/internal/channel/adapters/telegram/markdown.go
@@ -1,0 +1,207 @@
+package telegram
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	east "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+// markdown.go converts agent-authored Markdown into the small HTML subset
+// Telegram's Bot API accepts under parse_mode=HTML.
+//
+// Why HTML instead of hand-rolling MarkdownV2's escaping (#1119): MarkdownV2
+// requires escaping ~18 reserved characters throughout the text, and any
+// single miss makes Telegram reject the *entire* chunk — exactly the "one
+// unbalanced '*' loses all formatting" failure mode this issue is about.
+// HTML mode only requires escaping &, <, > in literal text. Because we parse
+// the real Markdown with goldmark first (already an indirect dependency via
+// glamour, used for TUI rendering in cmd/octo/markdown.go) rather than
+// pattern-matching on the raw string, a stray '*' in the model's output is
+// just literal text to us — never a broken parse.
+var telegramMarkdown = goldmark.New(
+	goldmark.WithExtensions(extension.Strikethrough, extension.Linkify),
+)
+
+// renderTelegramHTML converts src into Telegram-safe HTML. It never errors:
+// anything goldmark doesn't recognize as a supported construct is emitted as
+// escaped literal text, so worst case the output is over-literal, never
+// malformed.
+func renderTelegramHTML(src string) string {
+	source := []byte(src)
+	doc := telegramMarkdown.Parser().Parse(text.NewReader(source))
+	return strings.TrimSpace(renderBlockChildren(doc, source))
+}
+
+func renderBlockChildren(n ast.Node, source []byte) string {
+	var blocks []string
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		if s := renderBlock(c, source); s != "" {
+			blocks = append(blocks, s)
+		}
+	}
+	return strings.Join(blocks, "\n\n")
+}
+
+// renderBlock renders a single block-level node. Telegram's HTML subset has
+// no block tags beyond <blockquote> and <pre>, so headings/thematic breaks
+// degrade to plain text conventions rather than being dropped.
+func renderBlock(n ast.Node, source []byte) string {
+	switch node := n.(type) {
+	case *ast.Paragraph, *ast.TextBlock:
+		return renderInlineChildren(n, source)
+	case *ast.Heading:
+		return "<b>" + renderInlineChildren(n, source) + "</b>"
+	case *ast.Blockquote:
+		return "<blockquote>" + renderBlockChildren(n, source) + "</blockquote>"
+	case *ast.List:
+		return renderList(node, source)
+	case *ast.CodeBlock:
+		return renderCodeBlock("", node.Lines().Value(source))
+	case *ast.FencedCodeBlock:
+		return renderCodeBlock(string(node.Language(source)), node.Lines().Value(source))
+	case *ast.ThematicBreak:
+		return "──────────"
+	case *ast.HTMLBlock:
+		// The model's raw HTML is untrusted input to Telegram's parser
+		// (unsupported tags make the whole message fail); render it as
+		// literal escaped text instead of passing it through.
+		return htmlEscapeBytes(node.Lines().Value(source))
+	default:
+		return renderBlockChildren(n, source)
+	}
+}
+
+func renderList(list *ast.List, source []byte) string {
+	var items []string
+	for i, item := 0, list.FirstChild(); item != nil; item = item.NextSibling() {
+		li, ok := item.(*ast.ListItem)
+		if !ok {
+			continue
+		}
+		marker := "• "
+		if list.IsOrdered() {
+			marker = strconv.Itoa(list.Start+i) + ". "
+		}
+		items = append(items, marker+strings.TrimSpace(renderBlockChildren(li, source)))
+		i++
+	}
+	return strings.Join(items, "\n")
+}
+
+func renderCodeBlock(lang string, code []byte) string {
+	body := strings.TrimRight(htmlEscapeBytes(code), "\n")
+	if lang == "" {
+		return "<pre><code>" + body + "</code></pre>"
+	}
+	return `<pre><code class="language-` + htmlEscapeString(lang) + `">` + body + "</code></pre>"
+}
+
+func renderInlineChildren(n ast.Node, source []byte) string {
+	var b strings.Builder
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		renderInline(&b, c, source)
+	}
+	return b.String()
+}
+
+func renderInline(b *strings.Builder, n ast.Node, source []byte) {
+	switch node := n.(type) {
+	case *ast.Text:
+		b.WriteString(htmlEscapeBytes(node.Segment.Value(source)))
+		if node.SoftLineBreak() || node.HardLineBreak() {
+			b.WriteString("\n")
+		}
+	case *ast.String:
+		b.WriteString(htmlEscapeBytes(node.Value))
+	case *ast.Emphasis:
+		tag := "i"
+		if node.Level >= 2 {
+			tag = "b"
+		}
+		b.WriteString("<" + tag + ">")
+		renderInlineInto(b, n, source)
+		b.WriteString("</" + tag + ">")
+	case *ast.CodeSpan:
+		b.WriteString("<code>")
+		b.WriteString(htmlEscapeString(codeSpanText(node, source)))
+		b.WriteString("</code>")
+	case *ast.Link:
+		b.WriteString(`<a href="`)
+		b.WriteString(htmlEscapeBytes(util.URLEscape(node.Destination, true)))
+		b.WriteString(`">`)
+		renderInlineInto(b, n, source)
+		b.WriteString("</a>")
+	case *ast.AutoLink:
+		b.WriteString(`<a href="`)
+		b.WriteString(htmlEscapeBytes(util.URLEscape(node.URL(source), true)))
+		b.WriteString(`">`)
+		b.WriteString(htmlEscapeBytes(node.Label(source)))
+		b.WriteString("</a>")
+	case *ast.Image:
+		// Telegram HTML has no inline image tag; keep the alt text and
+		// surface the URL rather than silently dropping the reference.
+		b.WriteString(htmlEscapeString(plainText(n, source)))
+		if len(node.Destination) > 0 {
+			b.WriteString(" (")
+			b.WriteString(htmlEscapeBytes(node.Destination))
+			b.WriteString(")")
+		}
+	case *ast.RawHTML:
+		b.WriteString(htmlEscapeBytes(node.Segments.Value(source)))
+	case *east.Strikethrough:
+		b.WriteString("<s>")
+		renderInlineInto(b, n, source)
+		b.WriteString("</s>")
+	default:
+		renderInlineInto(b, n, source)
+	}
+}
+
+func renderInlineInto(b *strings.Builder, n ast.Node, source []byte) {
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		renderInline(b, c, source)
+	}
+}
+
+// codeSpanText concatenates a CodeSpan's text children. Per CommonMark, code
+// spans can't contain nested inline formatting, only Text nodes.
+func codeSpanText(n *ast.CodeSpan, source []byte) string {
+	var b strings.Builder
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		if t, ok := c.(*ast.Text); ok {
+			b.Write(t.Segment.Value(source))
+		}
+	}
+	return b.String()
+}
+
+// plainText flattens a node's text content, ignoring formatting — used for
+// image alt text where Telegram has nowhere to render nested markup.
+func plainText(n ast.Node, source []byte) string {
+	var b strings.Builder
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		switch t := c.(type) {
+		case *ast.Text:
+			b.Write(t.Segment.Value(source))
+		case *ast.String:
+			b.Write(t.Value)
+		default:
+			b.WriteString(plainText(c, source))
+		}
+	}
+	return b.String()
+}
+
+func htmlEscapeBytes(v []byte) string {
+	return string(util.EscapeHTML(v))
+}
+
+func htmlEscapeString(s string) string {
+	return htmlEscapeBytes([]byte(s))
+}

--- a/internal/channel/adapters/telegram/markdown_test.go
+++ b/internal/channel/adapters/telegram/markdown_test.go
@@ -1,0 +1,127 @@
+package telegram
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderTelegramHTML(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bold", "**bold**", "<b>bold</b>"},
+		{"italic underscore", "_italic_", "<i>italic</i>"},
+		{"italic star", "*italic*", "<i>italic</i>"},
+		{"inline code", "use `go build`", "use <code>go build</code>"},
+		{"strikethrough", "~~gone~~", "<s>gone</s>"},
+		{"link", "[docs](https://example.com/a)", `<a href="https://example.com/a">docs</a>`},
+		{"nested bold in italic", "*_x_*", "<i><i>x</i></i>"},
+		{
+			"escapes literal html-significant chars",
+			"a < b & c > d",
+			"a &lt; b &amp; c &gt; d",
+		},
+		{
+			"unbalanced asterisk stays literal, no crash",
+			"cost is *not* balanced * here",
+			"cost is <i>not</i> balanced * here",
+		},
+		{
+			"fenced code block",
+			"```go\nfmt.Println(1 < 2)\n```",
+			`<pre><code class="language-go">fmt.Println(1 &lt; 2)</code></pre>`,
+		},
+		{
+			"fenced code block no language",
+			"```\nraw & <text>\n```",
+			"<pre><code>raw &amp; &lt;text&gt;</code></pre>",
+		},
+		{
+			"unordered list",
+			"- a\n- b\n",
+			"• a\n• b",
+		},
+		{
+			"ordered list",
+			"1. a\n2. b\n",
+			"1. a\n2. b",
+		},
+		{
+			"blockquote",
+			"> quoted",
+			"<blockquote>quoted</blockquote>",
+		},
+		{
+			"bare url autolinked",
+			"see https://example.com/x for details",
+			`see <a href="https://example.com/x">https://example.com/x</a> for details`,
+		},
+		{
+			"heading becomes bold",
+			"# Title",
+			"<b>Title</b>",
+		},
+		{
+			"raw inline html escaped, not passed through",
+			"click <b>here</b>",
+			"click &lt;b&gt;here&lt;/b&gt;",
+		},
+		{
+			"image degrades to alt text plus url",
+			"![alt text](https://example.com/img.png)",
+			"alt text (https://example.com/img.png)",
+		},
+		{
+			"multiple paragraphs separated by blank line",
+			"first\n\nsecond",
+			"first\n\nsecond",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := renderTelegramHTML(tc.in)
+			if got != tc.want {
+				t.Errorf("renderTelegramHTML(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// A single unbalanced special character must never take down formatting for
+// the rest of the message — the exact #1119 failure mode under legacy
+// Markdown mode, where the whole chunk fell back to plain text.
+func TestRenderTelegramHTML_UnbalancedCharDoesNotBreakRestOfMessage(t *testing.T) {
+	in := "**bold works** but here is a stray * and then **more bold**"
+	got := renderTelegramHTML(in)
+	want := "<b>bold works</b> but here is a stray * and then <b>more bold</b>"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderTelegramHTML_NeverPanics(t *testing.T) {
+	inputs := []string{
+		"",
+		"*",
+		"**",
+		"***",
+		"[broken(",
+		"```unterminated fence",
+		"<script>alert(1)</script>",
+		"a &amp; b",
+		strings.Repeat("*", 500),
+	}
+	for _, in := range inputs {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("renderTelegramHTML(%q) panicked: %v", in, r)
+				}
+			}()
+			renderTelegramHTML(in)
+		}()
+	}
+}

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -47,6 +47,13 @@ const (
 	// the exact character cap requires, never less.
 	maxMessageBytes = 4000
 
+	// telegramHardCap is Telegram's actual message length limit. HTML
+	// rendering (see markdown.go) adds tag overhead on top of the
+	// maxMessageBytes-capped plain-text chunk, so a heavily-formatted chunk
+	// can occasionally cross 4096 even though the source didn't. renderForSend
+	// checks against this before deciding whether to send the rendered HTML.
+	telegramHardCap = 4096
+
 	// unsupportedMediaNotice is sent in place of silence (#1123) when a
 	// message contains only a kind we don't process (voice, video, sticker,
 	// location, …). Transcription/decoding can come later; going silent is
@@ -98,8 +105,14 @@ func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
 	}
 	baseURL = strings.TrimSuffix(baseURL, "/")
 
-	// Default Markdown; an explicit empty parse_mode disables formatting.
-	parseMode := "Markdown"
+	// Default HTML (#1119): legacy Markdown mode is Telegram's strictest and
+	// most fragile parser — any unbalanced/unescaped reserved character fails
+	// the whole chunk. HTML only requires escaping &, <, > in literal text,
+	// and our renderer (markdown.go) produces well-formed tags from the real
+	// parsed Markdown AST, so a single stray '*' in the model's output can no
+	// longer take down the entire message's formatting. An explicit empty
+	// parse_mode disables formatting.
+	parseMode := "HTML"
 	if v, ok := cfg[cfgParseMode].(string); ok {
 		parseMode = v
 	}
@@ -214,13 +227,14 @@ func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 
 	var lastID string
 	for i, chunk := range chunks {
+		body, mode := a.renderForSend(chunk)
 		params := map[string]any{
 			"chat_id":                  chatID,
-			"text":                     chunk,
+			"text":                     body,
 			"disable_web_page_preview": true,
 		}
-		if a.parseMode != "" {
-			params["parse_mode"] = a.parseMode
+		if mode != "" {
+			params["parse_mode"] = mode
 		}
 		if replyTo != "" && i == 0 {
 			params["reply_to_message_id"] = replyTo
@@ -228,10 +242,12 @@ func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 
 		msg, err := a.callMessage("sendMessage", params)
 		if err != nil {
-			// Markdown parse failures fall back to plain text — the usual cause
-			// is unescaped Markdown reserved chars in the agent's output.
-			if a.parseMode != "" && isParseError(err) {
+			// Parse failures fall back to the original plain chunk — the usual
+			// cause is a construct our renderer/the configured parse_mode
+			// doesn't handle the way Telegram expects.
+			if mode != "" && isParseError(err) {
 				log.Printf("[telegram] parse_mode failed, retrying as plain text: %v", err)
+				params["text"] = chunk
 				delete(params, "parse_mode")
 				msg, err = a.callMessage("sendMessage", params)
 			}
@@ -242,6 +258,25 @@ func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
 		lastID = fmt.Sprintf("%d", msg.MessageID)
 	}
 	return channel.SendResult{OK: true, MessageID: lastID}
+}
+
+// renderForSend converts chunk for the wire according to a.parseMode. HTML
+// mode runs it through the goldmark-based renderer in markdown.go (#1119);
+// other modes (legacy Markdown, MarkdownV2, or "" for plain text) are sent
+// as-is, unchanged from before this fix. If the rendered HTML would cross
+// Telegram's real 4096-char hard cap — formatting tags add overhead on top of
+// the plain-text byte budget chunks are split on — fall back to the plain
+// chunk rather than risk an oversized request.
+func (a *Adapter) renderForSend(chunk string) (body, mode string) {
+	if a.parseMode != "HTML" {
+		return chunk, a.parseMode
+	}
+	rendered := renderTelegramHTML(chunk)
+	if len(rendered) > telegramHardCap {
+		log.Printf("[telegram] rendered HTML (%d bytes) exceeds hard cap, sending plain", len(rendered))
+		return chunk, ""
+	}
+	return rendered, "HTML"
 }
 
 // SendFile sends a local file to the chat. Images (png/jpg/jpeg/gif/webp) are
@@ -364,17 +399,19 @@ func mimeForExt(ext string) string {
 
 // UpdateMessage edits a previously sent message in place.
 func (a *Adapter) UpdateMessage(chatID, messageID, text string) bool {
+	body, mode := a.renderForSend(text)
 	params := map[string]any{
 		"chat_id":                  chatID,
 		"message_id":               messageID,
-		"text":                     text,
+		"text":                     body,
 		"disable_web_page_preview": true,
 	}
-	if a.parseMode != "" {
-		params["parse_mode"] = a.parseMode
+	if mode != "" {
+		params["parse_mode"] = mode
 	}
 	_, err := a.callMessage("editMessageText", params)
-	if err != nil && a.parseMode != "" && isParseError(err) {
+	if err != nil && mode != "" && isParseError(err) {
+		params["text"] = text
 		delete(params, "parse_mode")
 		_, err = a.callMessage("editMessageText", params)
 	}

--- a/internal/channel/adapters/telegram/telegram_test.go
+++ b/internal/channel/adapters/telegram/telegram_test.go
@@ -20,6 +20,7 @@ type fakeBotAPI struct {
 	updates   []tgUpdate
 	served    bool
 	sent      []map[string]any
+	edited    []map[string]any
 	sendFail  int // fail the first N sendMessage calls with a parse error
 	rateLimit int // return 429 for the first N sendMessage calls
 	srv       *httptest.Server
@@ -62,6 +63,9 @@ func newFakeBotAPI(t *testing.T) *fakeBotAPI {
 			f.sent = append(f.sent, params)
 			writeResult(w, map[string]any{"message_id": 100 + len(f.sent)})
 		case strings.HasSuffix(r.URL.Path, "/editMessageText"):
+			f.mu.Lock()
+			f.edited = append(f.edited, params)
+			f.mu.Unlock()
 			writeResult(w, map[string]any{"message_id": 7})
 		case strings.HasSuffix(r.URL.Path, "/sendChatAction"):
 			writeResult(w, true)
@@ -278,6 +282,73 @@ func TestSendText_SplitsLongMessages(t *testing.T) {
 	}
 }
 
+// #1119: HTML is now the default parse_mode, and outgoing text is rendered
+// through the goldmark-based converter before it's sent.
+func TestSendText_DefaultsToRenderedHTML(t *testing.T) {
+	f := newFakeBotAPI(t)
+	a := newTestAdapter(t, f, nil)
+
+	res := a.SendText("123", "**bold** and _italic_", "")
+	if !res.OK {
+		t.Fatalf("send failed: %+v", res)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sent) != 1 {
+		t.Fatalf("expected one message, got %d", len(f.sent))
+	}
+	if f.sent[0]["parse_mode"] != "HTML" {
+		t.Fatalf("expected parse_mode=HTML, got %v", f.sent[0]["parse_mode"])
+	}
+	want := "<b>bold</b> and <i>italic</i>"
+	if f.sent[0]["text"] != want {
+		t.Fatalf("text = %q, want %q", f.sent[0]["text"], want)
+	}
+}
+
+// An explicit parse_mode override (legacy Markdown, MarkdownV2, or "" for
+// plain text) must bypass the HTML renderer entirely and go out unchanged,
+// same as before #1119.
+func TestSendText_ExplicitParseModeBypassesRenderer(t *testing.T) {
+	f := newFakeBotAPI(t)
+	a := newTestAdapter(t, f, map[string]any{"parse_mode": ""})
+
+	res := a.SendText("123", "**not rendered**", "")
+	if !res.OK {
+		t.Fatalf("send failed: %+v", res)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.sent[0]["parse_mode"] != nil {
+		t.Fatalf("expected no parse_mode, got %v", f.sent[0]["parse_mode"])
+	}
+	if f.sent[0]["text"] != "**not rendered**" {
+		t.Fatalf("text was rendered despite explicit plain parse_mode: %v", f.sent[0]["text"])
+	}
+}
+
+// If tag overhead pushes a rendered chunk past Telegram's real 4096-char hard
+// cap, renderForSend must fall back to the plain chunk rather than send an
+// oversized (or truncated) request.
+func TestRenderForSend_FallsBackWhenRenderedExceedsHardCap(t *testing.T) {
+	a := &Adapter{parseMode: "HTML"}
+
+	// Each word individually bolded inflates size well past the plain length.
+	var sb strings.Builder
+	for i := 0; i < 600; i++ {
+		sb.WriteString("**w** ")
+	}
+	chunk := sb.String()
+
+	body, mode := a.renderForSend(chunk)
+	if mode != "" {
+		t.Fatalf("expected fallback to drop parse_mode, got %q", mode)
+	}
+	if body != chunk {
+		t.Fatalf("expected fallback to send the original plain chunk unchanged")
+	}
+}
+
 func TestValidateConfig(t *testing.T) {
 	a := &Adapter{}
 	if errs := a.ValidateConfig(channel.PlatformConfig{}); len(errs) != 1 {
@@ -296,6 +367,26 @@ func TestUpdateMessage(t *testing.T) {
 	}
 	if !a.SupportsMessageUpdates() {
 		t.Fatal("telegram supports message updates")
+	}
+}
+
+// #1119: streamed edits go through the same HTML renderer as SendText.
+func TestUpdateMessage_RendersHTML(t *testing.T) {
+	f := newFakeBotAPI(t)
+	a := newTestAdapter(t, f, nil)
+	if !a.UpdateMessage("1", "7", "**bold** edit") {
+		t.Fatal("expected update to succeed")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.edited) != 1 {
+		t.Fatalf("expected one edit, got %d", len(f.edited))
+	}
+	if f.edited[0]["parse_mode"] != "HTML" {
+		t.Fatalf("expected parse_mode=HTML, got %v", f.edited[0]["parse_mode"])
+	}
+	if f.edited[0]["text"] != "<b>bold</b> edit" {
+		t.Fatalf("text = %v, want rendered HTML", f.edited[0]["text"])
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the Telegram half of #1119 — the "substantial" item, per the issue itself.

Legacy Markdown mode is Telegram's strictest parser: any single unescaped/unbalanced reserved character (an unmatched `*`, a literal `_` in a variable name, etc.) fails the **entire chunk**, and the existing fallback then resends the whole chunk as plain text. One stray character anywhere in a long agent response silently strips all formatting from it.

- `parse_mode` now defaults to `"HTML"`. HTML mode only requires escaping `&`, `<`, `>` in literal text.
- Outgoing text is rendered through a new AST-based converter (`markdown.go`) using `goldmark` — already an indirect dependency via `glamour`'s TUI renderer, promoted to direct, **no new dependency added**. Because goldmark parses the real Markdown grammar instead of pattern-matching the raw string, a stray `*` is just literal text to it — never a broken parse.
- Supports: bold/italic, strikethrough, inline code, fenced/indented code blocks (with `<pre><code class="language-x">` when a language is given — Telegram's documented syntax-highlighting format), links/autolinks (bare URLs auto-link too), lists, and graceful degradation for constructs Telegram's HTML has no tag for (headings/blockquotes → plain-text conventions, images → `alt (url)`, raw inline HTML → escaped literal text so it can't break Telegram's parser).
- An explicit `parse_mode` config override (legacy `Markdown`, `MarkdownV2`, or `""` for plain text) bypasses the renderer entirely — unchanged from before this fix.
- Guards the one real edge case this introduces: HTML tags add overhead beyond the plain-text byte budget chunks are split on, so a heavily-formatted chunk could in principle cross Telegram's real 4096-char hard cap even though the source didn't. `renderForSend` checks the rendered length and falls back to the plain chunk if so.
- Kept the existing parse-error-retry-as-plain-text fallback as a safety net for any construct that still trips Telegram's parser.

Remaining #1119 scope (Weixin pipe-tables, Feishu inline-image stripping, Feishu table false-positive detection, WeCom doc note) is tracked separately in the issue.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `go test -race ./...` (full suite green)
- [x] New `markdown_test.go`: bold/italic/strikethrough/code/links/lists/headings/blockquotes/images/autolinks, literal `&<>` escaping, an unbalanced-asterisk case proving the rest of the message keeps its formatting (the exact #1119 failure mode), and a fuzz-ish never-panics test over malformed inputs (unterminated fences, raw `<script>`, bare `*`, etc.)
- [x] Extended `telegram_test.go`: default parse_mode is HTML with rendered content sent, explicit `parse_mode` override still bypasses rendering, `UpdateMessage` also renders, and a hard-cap-overflow case falls back to the plain chunk