### PR TITLE
fix(channel): auto-recreate session store when deleted externally (#1079)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2317,6 +2317,23 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 		return
 	}
 
+	// If the session store file was deleted externally (e.g., from the web
+	// UI), the in-memory Session still carries the old store ID. Recreate
+	// the file so acquireSessionBinding can verify the binding, and reset
+	// the agent History to match the empty store — the user deleted it for
+	// a reason.
+	if _, err := agent.LoadSession(sess.Store.ID); err != nil {
+		st := agent.NewSession(sess.Agent.Model, "")
+		st.ID = sess.Store.ID
+		st.CreatedAt = time.Now()
+		st.Source = "channel"
+		st.BoundEntry = agent.EntryChannel
+		st.BoundAt = time.Now()
+		sess.Store = st
+		sess.Agent.History = agent.NewHistory()
+		_ = st.Save()
+	}
+
 	// Enforce entry binding: the session file is the single source of truth.
 	// If another entry (web/tui/cli) owns this session, refuse to run the turn
 	// rather than interleaving with it across processes.


### PR DESCRIPTION
## Problem

When an IM-bound session is deleted from the web UI, the in-memory `Session` object still exists with the old store ID. On the next IM message, `acquireSessionBinding` tries to reload the deleted file from disk and fails with:

> ⚠️ session "im-weixin-..." not found
> Reply /new to start a fresh session, or run /list then /bind --force \<number\> to take it over.

## Root Cause

`handleChannelMessage` (server.go:2305) calls `GetOrCreateSession` which returns the stale in-memory session. Its `Store.ID` points to the now-deleted file. `acquireSessionBinding` → `loadBoundSession` → `agent.LoadSession(id)` fails with ENOENT, and the error is surfaced to the user as-is.

## Fix

In `handleChannelMessage`, after `GetOrCreateSession` but before `acquireSessionBinding`, check if the store file still exists. If not:
1. Create a fresh `agent.Session` with the **same store ID** (so the IM binding remains valid)
2. Reset `Agent.History` to empty
3. Save the new store to disk

Then `acquireSessionBinding` loads the fresh file and proceeds normally.

## Testing

- `go build ./internal/server/...` ✅
- `go test ./internal/server/...` ✅ (all tests pass including channel handler tests)
- `go test ./internal/channel/...` ✅
- `go test ./internal/agent/...` ✅

Closes #1079