### PR TITLE
channel: lossless image/table handling for Feishu/Weixin/WeCom (#1119)

### DIFF
--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -64,11 +64,11 @@ const (
 	cfgAllowedUsers = "allowed_users"
 )
 
-// Package-level compiled regexps (avoids recompiling on every message send).
-var (
-	feishuStripImgRe = regexp.MustCompile(`!\[[^\]]*\]\([^)]*\)`)
-	feishuTableRe    = regexp.MustCompile(`\|.+\|`)
-)
+// feishuImageRe matches Markdown image syntax so it can be converted to a
+// clickable link (#1119) — Feishu's markdown renderer (both the "post" md
+// tag and the card "markdown" element) has no inline-image tag, so
+// "![alt](url)" used to be stripped entirely, losing the URL along with it.
+var feishuImageRe = regexp.MustCompile(`!\[([^\]]*)\]\(([^)]*)\)`)
 
 // Adapter implements channel.Adapter for Feishu.
 type Adapter struct {
@@ -751,11 +751,27 @@ func stripAtMentions(text string) string {
 // buildMsgPayload selects msg_type and content based on text content.
 // FEISHU-010: uses "post" (md) for plain text, "interactive" (card) for code/tables.
 func buildMsgPayload(text string) (msgType, content string) {
-	// Strip image markdown before rendering.
-	cleaned := feishuStripImgRe.ReplaceAllString(text, "")
+	// Feishu's markdown has no inline-image tag, so a "![alt](url)" reference
+	// is rewritten as a clickable "[alt](url)" link instead of being dropped
+	// (#1119) — links render fine in both the "post" and card paths below.
+	cleaned := feishuImageRe.ReplaceAllStringFunc(text, func(m string) string {
+		parts := feishuImageRe.FindStringSubmatch(m)
+		alt, url := parts[1], parts[2]
+		if url == "" {
+			return alt
+		}
+		if alt == "" {
+			alt = "image"
+		}
+		return "[" + alt + "](" + url + ")"
+	})
 
+	// #1119: a naive "line has 2+ pipes" check false-positived on ordinary
+	// prose that happens to contain "|", flipping the message into card
+	// rendering for text that isn't a table at all. LooksLikeMarkdownTable
+	// requires an actual header-separator row.
 	hasCodeOrTable := strings.Contains(cleaned, "```") ||
-		feishuTableRe.MatchString(cleaned)
+		channel.LooksLikeMarkdownTable(cleaned)
 
 	if hasCodeOrTable {
 		// Use interactive card (schema 2.0) with markdown element.

--- a/internal/channel/adapters/feishu/feishu_test.go
+++ b/internal/channel/adapters/feishu/feishu_test.go
@@ -281,3 +281,67 @@ func TestFeishuFileType(t *testing.T) {
 		}
 	}
 }
+
+// #1119: an inline image reference used to be stripped entirely — not even
+// the URL survived. It should become a clickable link instead, since
+// Feishu's markdown has no inline-image tag but does render links.
+func TestBuildMsgPayload_ImageBecomesLink(t *testing.T) {
+	msgType, content := buildMsgPayload("see ![a diagram](https://example.com/d.png) below")
+	if msgType != "post" {
+		t.Fatalf("expected post msg_type for plain text, got %q", msgType)
+	}
+	if !strings.Contains(content, "[a diagram](https://example.com/d.png)") {
+		t.Fatalf("expected image to become a link, got: %s", content)
+	}
+	if strings.Contains(content, "![") {
+		t.Fatalf("expected the image marker to be gone, got: %s", content)
+	}
+}
+
+// An image with no alt text still needs a non-empty link label.
+func TestBuildMsgPayload_ImageWithNoAltGetsPlaceholderLabel(t *testing.T) {
+	_, content := buildMsgPayload("![](https://example.com/d.png)")
+	if !strings.Contains(content, "[image](https://example.com/d.png)") {
+		t.Fatalf("expected a placeholder label, got: %s", content)
+	}
+}
+
+// An image with no URL at all degrades to just the alt text (nothing to link to).
+func TestBuildMsgPayload_ImageWithNoURLDegradesToAltText(t *testing.T) {
+	msgType, content := buildMsgPayload("![a diagram]()")
+	if msgType != "post" {
+		t.Fatalf("expected post msg_type, got %q", msgType)
+	}
+	if !strings.Contains(content, "a diagram") || strings.Contains(content, "![") {
+		t.Fatalf("expected bare alt text, got: %s", content)
+	}
+}
+
+// #1119: prose containing "|" characters (but no real table) must not flip
+// the message into card rendering — the previous \|.+\| regex false-positived
+// on any line with two pipes.
+func TestBuildMsgPayload_PipeInProseDoesNotTriggerCardMode(t *testing.T) {
+	msgType, _ := buildMsgPayload("the pattern is a | b | c, not a table")
+	if msgType != "post" {
+		t.Fatalf("expected plain post rendering for prose with pipes, got %q", msgType)
+	}
+}
+
+// A genuine Markdown table (header row + separator row) must still trigger
+// card rendering, since that's how Feishu actually renders tables.
+func TestBuildMsgPayload_RealTableTriggersCardMode(t *testing.T) {
+	msgType, content := buildMsgPayload("| A | B |\n| --- | --- |\n| 1 | 2 |")
+	if msgType != "interactive" {
+		t.Fatalf("expected interactive (card) rendering for a real table, got %q", msgType)
+	}
+	if !strings.Contains(content, "| A | B |") {
+		t.Fatalf("expected the table markdown to be preserved in the card content, got: %s", content)
+	}
+}
+
+func TestBuildMsgPayload_CodeFenceTriggersCardMode(t *testing.T) {
+	msgType, _ := buildMsgPayload("```go\nfmt.Println(1)\n```")
+	if msgType != "interactive" {
+		t.Fatalf("expected interactive (card) rendering for a code fence, got %q", msgType)
+	}
+}

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -218,7 +218,18 @@ func (a *Adapter) Stop() error {
 // Content over maxMessageBytes is split into consecutive messages (#1116):
 // WeCom rejects an oversized markdown payload outright (errcode 40058)
 // rather than truncating it, so an unsplit long reply was dropped entirely.
+//
+// WeCom's "markdown" msgtype (the only one this adapter sends) supports only
+// a documented subset — headings, bold, links, inline code spans, quotes,
+// and 3 built-in font colors (#1119). Notably unsupported: tables, lists,
+// and multi-line fenced code blocks (only single-line inline code works) —
+// a fenced ```block``` arrives with its fence markers rendered as literal
+// text. Pipe tables are flattened to readable lines before sending rather
+// than left as raw "| a | b |" rows with no table rendering to give them
+// structure; code fences are sent through unchanged since there's no lossless
+// plain-text substitute for them worth the added complexity here.
 func (a *Adapter) SendText(chatID, text, replyTo string) channel.SendResult {
+	text = channel.FlattenPipeTables(text)
 	chunks := channel.SplitForSend(text, maxMessageBytes)
 	if len(chunks) == 0 {
 		return channel.SendResult{OK: true}

--- a/internal/channel/adapters/wecom/wecom_test.go
+++ b/internal/channel/adapters/wecom/wecom_test.go
@@ -341,6 +341,43 @@ func TestSendText_WaitsForAck(t *testing.T) {
 	}
 }
 
+// #1119: WeCom's markdown renderer has no table support — raw "| a | b |"
+// rows used to arrive completely unrendered, separator row and all.
+func TestSendText_FlattensPipeTables(t *testing.T) {
+	f := newFakeWecom(t)
+	a := newTestAdapter(t, f, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go a.Start(ctx, func(channel.InboundEvent) {})
+
+	table := "| Name | Age |\n| --- | --- |\n| Alice | 30 |"
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		res := a.SendText("chat-1", table, "")
+		if res.OK {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("send never succeeded: %+v", res)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sent) == 0 {
+		t.Fatal("no aibot_send_msg frame received")
+	}
+	last := f.sent[len(f.sent)-1]
+	md, _ := last["markdown"].(map[string]any)
+	content, _ := md["content"].(string)
+	want := "Name | Age\nAlice | 30"
+	if content != want {
+		t.Fatalf("content = %q, want %q", content, want)
+	}
+}
+
 // #1116: SendText previously sent content as a single unbounded payload.
 // WeCom rejects markdown content over 4096 bytes outright (errcode 40058)
 // rather than truncating it, so an unsplit long reply was dropped entirely.

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -974,6 +974,11 @@ func markdownToPlain(text string) string {
 	// Horizontal rules.
 	text = regexp.MustCompile(`(?m)^[-*_]{3,}\s*$`).ReplaceAllString(text, "")
 
+	// Pipe tables: WeChat has no table rendering, so raw "| a | b |" rows
+	// used to arrive completely unrendered (#1119). Flatten to readable
+	// "a | b" lines instead of dropping the structure entirely.
+	text = channel.FlattenPipeTables(text)
+
 	return strings.TrimSpace(text)
 }
 

--- a/internal/channel/adapters/weixin/weixin_test.go
+++ b/internal/channel/adapters/weixin/weixin_test.go
@@ -452,6 +452,17 @@ func TestMarkdownToPlain_LinkWithEmptyURL(t *testing.T) {
 	}
 }
 
+// #1119: WeChat has no table rendering — raw "| a | b |" rows used to arrive
+// completely unrendered, separator row and all.
+func TestMarkdownToPlain_FlattensPipeTables(t *testing.T) {
+	md := "| Name | Age |\n| --- | --- |\n| Alice | 30 |"
+	plain := markdownToPlain(md)
+	want := "Name | Age\nAlice | 30"
+	if plain != want {
+		t.Errorf("markdownToPlain(%q) = %q, want %q", md, plain, want)
+	}
+}
+
 func TestAdapter_StartWithCredentials(t *testing.T) {
 	// Create a mock iLink server.
 	var mu sync.Mutex

--- a/internal/channel/markdown.go
+++ b/internal/channel/markdown.go
@@ -1,0 +1,72 @@
+package channel
+
+import (
+	"regexp"
+	"strings"
+)
+
+// tableSeparatorRe matches a GFM table's header-separator row: two or more
+// "---", ":---", "---:", or ":---:" cells joined by "|", with optional
+// leading/trailing pipes. Requiring at least one internal "|" (i.e. at least
+// two columns) keeps this from ever matching a plain "---" horizontal rule,
+// which has no pipe at all.
+var tableSeparatorRe = regexp.MustCompile(`^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$`)
+
+// FlattenPipeTables converts Markdown pipe tables into plain, readable lines
+// for platforms with no table rendering (Weixin, WeCom — #1119). The
+// separator row ("| --- | --- |") is dropped as pure clutter, and each
+// remaining row's cells are trimmed and rejoined with " | " so uneven source
+// padding doesn't carry through. Without this, a table arrives as raw
+// "| a | b |" lines with no visual structure at all.
+//
+// A line only counts as a table row if it's immediately followed by a real
+// separator row, so ordinary prose that happens to contain a "|" character
+// is left untouched.
+func FlattenPipeTables(text string) string {
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+
+	for i := 0; i < len(lines); {
+		if strings.Contains(lines[i], "|") && i+1 < len(lines) && tableSeparatorRe.MatchString(lines[i+1]) {
+			out = append(out, flattenTableRow(lines[i]))
+			i += 2 // drop the separator row
+			for i < len(lines) && strings.Contains(lines[i], "|") {
+				out = append(out, flattenTableRow(lines[i]))
+				i++
+			}
+			continue
+		}
+		out = append(out, lines[i])
+		i++
+	}
+	return strings.Join(out, "\n")
+}
+
+// LooksLikeMarkdownTable reports whether text contains a genuine GFM pipe
+// table: a row containing "|" immediately followed by a valid header-
+// separator row (#1119). A naive "does any line contain two pipes" check
+// (the previous approach) false-positives on ordinary prose that happens to
+// use "|" — e.g. as a delimiter in a sentence — flipping rendering modes for
+// text that isn't a table at all.
+func LooksLikeMarkdownTable(text string) bool {
+	lines := strings.Split(text, "\n")
+	for i := 0; i+1 < len(lines); i++ {
+		if strings.Contains(lines[i], "|") && tableSeparatorRe.MatchString(lines[i+1]) {
+			return true
+		}
+	}
+	return false
+}
+
+// flattenTableRow strips a row's leading/trailing pipe and rejoins its cells
+// (trimmed) with " | ".
+func flattenTableRow(line string) string {
+	trimmed := strings.TrimSpace(line)
+	trimmed = strings.TrimPrefix(trimmed, "|")
+	trimmed = strings.TrimSuffix(trimmed, "|")
+	cells := strings.Split(trimmed, "|")
+	for i, c := range cells {
+		cells[i] = strings.TrimSpace(c)
+	}
+	return strings.Join(cells, " | ")
+}

--- a/internal/channel/markdown_test.go
+++ b/internal/channel/markdown_test.go
@@ -1,0 +1,86 @@
+package channel
+
+import "testing"
+
+func TestFlattenPipeTables(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "basic table",
+			in:   "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |",
+			want: "Name | Age\nAlice | 30\nBob | 25",
+		},
+		{
+			name: "aligned separator variants",
+			in:   "| Name | Age |\n|:---|---:|\n| Alice | 30 |",
+			want: "Name | Age\nAlice | 30",
+		},
+		{
+			name: "no leading/trailing pipes",
+			in:   "Name | Age\n--- | ---\nAlice | 30",
+			want: "Name | Age\nAlice | 30",
+		},
+		{
+			name: "uneven padding is normalized",
+			in:   "|Name|Age|\n|---|---|\n|Alice   |30|",
+			want: "Name | Age\nAlice | 30",
+		},
+		{
+			name: "prose with a pipe is left alone (no separator row follows)",
+			in:   "cost is a|b comparison",
+			want: "cost is a|b comparison",
+		},
+		{
+			name: "plain horizontal rule is not mistaken for a table separator",
+			in:   "above\n\n---\n\nbelow",
+			want: "above\n\n---\n\nbelow",
+		},
+		{
+			name: "table followed by prose",
+			in:   "| A | B |\n| --- | --- |\n| 1 | 2 |\nsome trailing text",
+			want: "A | B\n1 | 2\nsome trailing text",
+		},
+		{
+			name: "text with no table is unchanged",
+			in:   "just some plain text\nwith multiple lines",
+			want: "just some plain text\nwith multiple lines",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FlattenPipeTables(tc.in)
+			if got != tc.want {
+				t.Errorf("FlattenPipeTables(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLooksLikeMarkdownTable(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"real table", "| A | B |\n| --- | --- |\n| 1 | 2 |", true},
+		{"real table no outer pipes", "A | B\n--- | ---\n1 | 2", true},
+		{"aligned separator", "| A | B |\n|:--|--:|\n| 1 | 2 |", true},
+		{"prose with two pipes, no separator row", "this | is | prose", false},
+		{"prose with pipe followed by unrelated text", "a | b\nnot a separator", false},
+		{"plain horizontal rule", "above\n\n---\n\nbelow", false},
+		{"no pipes at all", "just plain text", false},
+		{"empty string", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := LooksLikeMarkdownTable(tc.in)
+			if got != tc.want {
+				t.Errorf("LooksLikeMarkdownTable(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Completes the remaining scope of #1119 (the Telegram half was already fixed in #1169).

**Feishu:**
- Inline image markdown (`![alt](url)`) was stripped from outgoing messages with nothing left behind — not even the URL survived. Feishu's markdown has no inline-image tag but does render links, so images are now rewritten as clickable `[alt](url)` links (empty alt → `image` placeholder; empty URL → bare alt text, since there's nothing to link to).
- Table detection was `\|.+\|` — any prose line with two pipes flipped the whole message into card rendering. Replaced with `channel.LooksLikeMarkdownTable`, which requires an actual GFM header-separator row (`| --- | --- |`) after the pipe-containing line, so it only fires on real tables.

**Weixin & WeCom:** both send plain markdown to platforms with no table rendering, so a pipe table arrived as raw `| a | b |` rows — separator row and all, zero visual structure. Both now run outgoing text through a new `channel.FlattenPipeTables`, which drops the separator row and rejoins each row's cells as readable `a | b` lines. Also added an accurate doc comment on WeCom's `SendText` about its actual supported markdown subset (verified against WeCom's docs — no tables/lists, and only single-line inline code, not multi-line fenced blocks).

**New `internal/channel/markdown.go`** holds the shared table-handling logic (`FlattenPipeTables`, `LooksLikeMarkdownTable`) since Weixin and WeCom hit the identical "flatten pipe tables for a plain-text-only renderer" problem — same sharing pattern as `chunking.go`'s `SplitForSend`, already used by every adapter.

Not in scope here (per the issue, doc-note-only / already covered): Discord `allowed_mentions` and Weixin link-URL preservation were fixed earlier in #1168; Telegram's parse-mode migration was fixed in #1169.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `go test -race ./...` (full suite green)
- [x] New `internal/channel/markdown_test.go`: table flattening (basic, aligned separators, uneven padding, no outer pipes) and false-positive guards (prose with a pipe, a plain `---` horizontal rule not mistaken for a separator row)
- [x] New Feishu tests: image → link conversion (with/without alt, with/without URL), pipe-in-prose no longer triggers card mode, a real table still does, a code fence still does
- [x] New Weixin/WeCom tests: a pipe table is flattened to readable lines end-to-end through `markdownToPlain` / `SendText`