### PR TITLE
fix(channel): DRY up, lock, and cheapen the #1079 session-recreate fix

### DIFF
--- a/internal/channel/persist.go
+++ b/internal/channel/persist.go
@@ -39,6 +39,24 @@ func sessionStoreID(key SessionKey) string {
 	return fmt.Sprintf("im-%s-%08x", safe, h.Sum32())
 }
 
+// newChannelStore builds a fresh, persisted-shape store for a channel
+// session: source "channel", bound to EntryChannel, Title left empty so
+// DisplayTitle() falls back to the first user message snippet (truncated to
+// 60 chars) instead of showing the raw SessionKey (e.g.
+// "weixin:o9cq…@im.wechat:o9cq…@im.wechat"). Shared by restoreOrInitStore
+// (first-ever store for a session) and EnsureStoreExists (#1079 — recovering
+// after the file was deleted out from under an already-running session), so
+// both give a fresh channel session the exact same shape.
+func newChannelStore(id, model string) *agent.Session {
+	st := agent.NewSession(model, "")
+	st.ID = id
+	st.CreatedAt = time.Now()
+	st.Source = "channel"
+	st.BoundEntry = agent.EntryChannel
+	st.BoundAt = time.Now()
+	return st
+}
+
 // restoreOrInitStore attaches the persistent store to a freshly built
 // session: an existing file rehydrates the agent's history, otherwise a new
 // store is initialised. The store ID is resolved by the manager (a /bind
@@ -57,19 +75,42 @@ func (s *Session) restoreOrInitStore(id string) {
 		}
 		return
 	}
-	st := agent.NewSession(s.Agent.Model, "")
-	st.ID = id
-	st.CreatedAt = time.Now()
-	st.Source = "channel"
-	st.BoundEntry = agent.EntryChannel
-	st.BoundAt = time.Now()
-	// Leave Title empty so DisplayTitle() falls back to the first user message
-	// snippet (truncated to 60 chars) instead of showing the raw SessionKey
-	// (e.g. "weixin:o9cq…@im.wechat:o9cq…@im.wechat").
 	// Persist immediately so the entry binding is visible to other processes
 	// (and to the server's authoritative LoadSession in handleChannelMessage).
+	st := newChannelStore(id, s.Agent.Model)
 	_ = st.Save()
 	s.Store = st
+}
+
+// EnsureStoreExists recreates the backing store if its file was deleted out
+// from under this session (e.g. the user deleted it from the web UI) after
+// the session was already loaded into the manager's in-memory cache (#1079).
+// restoreOrInitStore only runs once, when a session is first created; a
+// session that then sits in the cache while its file disappears externally
+// keeps a stale Store pointer, and the server's authoritative reload
+// (acquireSessionBinding's LoadSession) fails with a confusing "session not
+// found" error instead of the chat just starting fresh.
+//
+// The existence check is a stat (SessionMTime), not a full LoadSession — this
+// runs on every inbound message, so it must not pay a full read-and-parse of
+// the session's history just to confirm the file is still there. That means
+// a corrupt-but-present file (rather than a deleted one) isn't recovered
+// here; it still surfaces as an error via acquireSessionBinding's own reload
+// immediately after this call, unchanged from before this fix. Only the
+// reported scenario — the file is gone — is what this recovers from.
+func (s *Session) EnsureStoreExists() {
+	s.storeMu.Lock()
+	defer s.storeMu.Unlock()
+	if s.Store == nil {
+		return
+	}
+	if _, err := agent.SessionMTime(s.Store.ID); err == nil {
+		return
+	}
+	st := newChannelStore(s.Store.ID, s.Agent.Model)
+	_ = st.Save()
+	s.Store = st
+	s.Agent.History = agent.NewHistory()
 }
 
 // Persist writes the agent's current history to the session store. Called by

--- a/internal/channel/persist_test.go
+++ b/internal/channel/persist_test.go
@@ -435,3 +435,87 @@ func TestDeleteStore_TombstonesAgainstZombiePersist(t *testing.T) {
 		t.Error("zombie turn resurrected the deleted history file")
 	}
 }
+
+// #1079: if the session file is deleted externally (e.g. from the web UI)
+// while this IM session sits idle in the manager's cache, the in-memory
+// Store pointer goes stale. Without EnsureStoreExists, the next message from
+// that chat hit acquireSessionBinding's authoritative reload and failed with
+// a confusing "session ... not found" error instead of just starting fresh.
+func TestEnsureStoreExists_RecreatesDeletedFile(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+
+	m := testManager()
+	sess := m.GetOrCreateSession(ev)
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "hello"})
+	if err := sess.Persist(); err != nil {
+		t.Fatal(err)
+	}
+	oldID := sess.Store.ID
+	path, err := sess.Store.SavePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	sess.EnsureStoreExists()
+
+	if sess.Store == nil {
+		t.Fatal("Store is nil after EnsureStoreExists")
+	}
+	if sess.Store.ID != oldID {
+		t.Errorf("store ID changed: got %q, want %q (same key must map to the same store)", sess.Store.ID, oldID)
+	}
+	if sess.Store.Source != "channel" || sess.Store.BoundEntry != agent.EntryChannel {
+		t.Errorf("recreated store has wrong shape: source=%q boundEntry=%q", sess.Store.Source, sess.Store.BoundEntry)
+	}
+	if got := len(sess.Agent.History.Snapshot()); got != 0 {
+		t.Errorf("history not reset after store recreation: %d messages", got)
+	}
+	if _, err := agent.LoadSession(sess.Store.ID); err != nil {
+		t.Errorf("LoadSession still fails after EnsureStoreExists: %v", err)
+	}
+}
+
+func TestEnsureStoreExists_NoOpWhenFileStillExists(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+
+	m := testManager()
+	sess := m.GetOrCreateSession(ev)
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "hello"})
+	if err := sess.Persist(); err != nil {
+		t.Fatal(err)
+	}
+	before := sess.Store
+
+	sess.EnsureStoreExists()
+
+	if sess.Store != before {
+		t.Error("EnsureStoreExists replaced a Store whose file still exists")
+	}
+	if got := len(sess.Agent.History.Snapshot()); got != 1 {
+		t.Errorf("EnsureStoreExists wiped history when the file was intact: %d messages", got)
+	}
+}
+
+// A tombstoned store (deleteStore, used by /unbind and /bind) must stay nil —
+// EnsureStoreExists is not the right place to undo an explicit tombstone.
+func TestEnsureStoreExists_NoOpWhenStoreIsNil(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+	m := testManager()
+	sess := m.GetOrCreateSession(ev)
+	if err := sess.deleteStore(); err != nil {
+		t.Fatal(err)
+	}
+
+	sess.EnsureStoreExists()
+
+	if sess.Store != nil {
+		t.Error("EnsureStoreExists should not resurrect a tombstoned store")
+	}
+}

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -400,6 +400,52 @@ func TestHandleChannelMessage_RejectsTurnWhenBoundToOtherEntry(t *testing.T) {
 	t.Fatal("expected rejection text from adapter")
 }
 
+// TestHandleChannelMessage_RecoversWhenSessionFileDeletedExternally (#1079):
+// if the chat's bound session was deleted from the web UI while this IM
+// session sat idle in the manager's cache, the next message used to hit
+// acquireSessionBinding's authoritative LoadSession and fail outright with a
+// confusing "session ... not found" error — the reporter's expectation was
+// that the chat should just start fresh instead.
+func TestHandleChannelMessage_RecoversWhenSessionFileDeletedExternally(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	// Establish the chat's session and give it some history, exactly like an
+	// ordinary prior conversation.
+	sess := srv.channelMgr.GetOrCreateSession(evFor("seed"))
+	sess.Agent.History.Append(agent.Message{Role: agent.RoleUser, Content: "old message"})
+	if err := sess.Persist(); err != nil {
+		t.Fatal(err)
+	}
+	path, err := sess.Store.SavePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the web UI deleting the session file entirely — nothing else
+	// (no other entry's binding) takes its place.
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello again"))
+
+	waitFor(t, func() bool { return len(ad.texts()) > 0 })
+
+	for _, txt := range ad.texts() {
+		if strings.Contains(txt, "not found") {
+			t.Fatalf("turn surfaced the stale-session error instead of starting fresh: %q", txt)
+		}
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("session file was not recreated on disk: %v", err)
+	}
+}
+
 // TestHandleChannelMessage_BackgroundCompletionTriggersIdleTurn: when an
 // async background process finishes after the synchronous turn chain has
 // ended, the completion note is drained into a follow-up idle turn so the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2318,21 +2318,12 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	}
 
 	// If the session store file was deleted externally (e.g., from the web
-	// UI), the in-memory Session still carries the old store ID. Recreate
-	// the file so acquireSessionBinding can verify the binding, and reset
-	// the agent History to match the empty store — the user deleted it for
-	// a reason.
-	if _, err := agent.LoadSession(sess.Store.ID); err != nil {
-		st := agent.NewSession(sess.Agent.Model, "")
-		st.ID = sess.Store.ID
-		st.CreatedAt = time.Now()
-		st.Source = "channel"
-		st.BoundEntry = agent.EntryChannel
-		st.BoundAt = time.Now()
-		sess.Store = st
-		sess.Agent.History = agent.NewHistory()
-		_ = st.Save()
-	}
+	// UI) since this in-memory Session was created, its Store pointer goes
+	// stale — acquireSessionBinding's authoritative reload below would
+	// otherwise fail with a confusing "session ... not found" error instead
+	// of the chat just starting fresh (#1079). Recreate the backing store to
+	// match.
+	sess.EnsureStoreExists()
 
 	// Enforce entry binding: the session file is the single source of truth.
 	// If another entry (web/tui/cli) owns this session, refuse to run the turn


### PR DESCRIPTION
## Summary

Follow-up to #1170 (issue #1079: auto-recreate a channel session's backing store when its file was deleted externally — e.g. from the web UI — instead of failing the next IM message with a confusing `session ... not found` error). #1170's fix works, but landed as an inline block in `handleChannelMessage` with three real gaps:

1. **Duplication**: the inline block hand-copied `restoreOrInitStore`'s exact fresh-store field construction (`Source`, `BoundEntry`, `BoundAt`, ...). Extracted a shared `newChannelStore(id, model)` helper so both places build a channel session's store identically and can't drift apart over time.
2. **Missing synchronization**: `channel.Session.Store` is documented as `storeMu`-guarded (see `Persist`/`GoalStore`/`deleteStore`, which all lock it) — the inline fix wrote `sess.Store` directly with no lock, racing against a concurrent `/unbind` or `/bind` on the same session. Moved the logic into a `channel.Session.EnsureStoreExists()` method (package `channel` can reach `storeMu`; `server.go`'s package cannot) that locks it like every other `Store` mutator.
3. **Cost**: the inline fix called `agent.LoadSession` on *every single* inbound IM message just to check the file still exists — a full read + JSONL parse of the entire session history, paid on every message forever. `EnsureStoreExists` checks via `agent.SessionMTime` (a stat) instead. A corrupt-but-present file (as opposed to a deleted one — not the reported scenario) still surfaces via `acquireSessionBinding`'s own reload right after, unchanged from before this fix.

`handleChannelMessage` now just calls `sess.EnsureStoreExists()`.

Behavior for the originally reported scenario is unchanged — this is a quality/correctness follow-up, not a behavior change.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `go test -race ./...` (full suite green)
- [x] New `internal/channel/persist_test.go` tests: recreates a deleted store file (same ID, correct shape, history reset, persisted to disk), no-ops when the file still exists (doesn't wipe live history), no-ops on a tombstoned (nil) `Store` from `/unbind`
- [x] New `internal/server/channel_route_test.go` test: end-to-end through `handleChannelMessage` — delete the session file, send another message, confirm no "not found" error reaches the user and the file is recreated on disk
- [x] Verified the regression test actually catches the bug: temporarily reverted the fix, confirmed the test reproduces the exact reported error text (`session "..." not found`), then restored it