### PR TITLE
tui: delete dead liveHeight, bound queue/status-bar/banner rendering (#1095)

### DIFF
--- a/cmd/octo/subagent_panel_test.go
+++ b/cmd/octo/subagent_panel_test.go
@@ -179,20 +179,3 @@ func TestSubAgentPanel_RemoveAdjustsFocus(t *testing.T) {
 		t.Errorf("focus = %d, want -1 (none left)", m.subAgentFocus)
 	}
 }
-
-func TestSubAgentPanel_LiveHeightExpanded(t *testing.T) {
-	m := newPanelModel()
-	m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "started"})
-	for i := 0; i < 5; i++ {
-		m.handleSubAgentEvent(tools.SubAgentEvent{AgentID: "agent_1", Kind: "tool", ToolName: "t"})
-	}
-	m.subAgents["agent_1"].expanded = true
-
-	// liveHeight includes textarea + status bar even on an empty model.
-	// We only care that expansion adds len(history) extra lines.
-	collapsedH := m.liveHeight()
-	m.subAgents["agent_1"].expanded = false
-	if got := m.liveHeight(); got != collapsedH-5 {
-		t.Errorf("collapsed liveHeight = %d, want %d (diff should be 5 history lines)", got, collapsedH-5)
-	}
-}

--- a/cmd/octo/tuirepl_completion.go
+++ b/cmd/octo/tuirepl_completion.go
@@ -100,16 +100,6 @@ func (m *tuiModel) complWindow() (start, end int) {
 	return start, start + maxComplVisible
 }
 
-// completionHeight is the row count completionView occupies, so liveHeight can
-// reserve space in the inline layout.
-func (m *tuiModel) completionHeight() int {
-	if len(m.complItems) == 0 {
-		return 0
-	}
-	start, end := m.complWindow()
-	return (end - start) + 1 // rows + the hint line
-}
-
 // completionView renders the menu: one row per candidate (name + description),
 // the selection marked, and a key-hint footer.
 func (m *tuiModel) completionView() string {

--- a/cmd/octo/tuirepl_completion_test.go
+++ b/cmd/octo/tuirepl_completion_test.go
@@ -95,9 +95,6 @@ func TestCompletion_ViewRendersMenuAndHint(t *testing.T) {
 	if !strings.Contains(out, "Enter run") {
 		t.Errorf("View should render the completion key hint; got:\n%s", out)
 	}
-	if h := m.completionHeight(); h != 2 { // 1 row + hint line
-		t.Errorf("completionHeight for one match = %d, want 2", h)
-	}
 }
 
 func TestCompletion_NavigationCycles(t *testing.T) {

--- a/cmd/octo/tuirepl_p5_test.go
+++ b/cmd/octo/tuirepl_p5_test.go
@@ -22,6 +22,28 @@ func TestTUI_QueuePanelIsBordered(t *testing.T) {
 	}
 }
 
+// #1095: a long or multi-line queued message used to render verbatim, which
+// could blow the panel border apart. Each item must collapse to one bounded
+// line.
+func TestTUI_QueuePanelTruncatesLongMultilineItems(t *testing.T) {
+	m := newTestModel()
+	longLine := strings.Repeat("x", 200)
+	m.queue = []pendingItem{
+		{text: "first line\nsecond line\nthird line"},
+		{text: longLine},
+	}
+	out := m.View()
+	if strings.Contains(out, "second line") || strings.Contains(out, "third line") {
+		t.Errorf("multi-line queued item should collapse to its first line; got:\n%s", out)
+	}
+	if !strings.Contains(out, "first line") {
+		t.Errorf("queue should still show the item's first line; got:\n%s", out)
+	}
+	if strings.Contains(out, longLine) {
+		t.Errorf("a 200-char queued item should be truncated, not rendered in full; got:\n%s", out)
+	}
+}
+
 func TestTUI_PermissionPromptShowsFullCommand(t *testing.T) {
 	m := newTestModel()
 	// A command long past the old 60-rune summary cap: every character must be

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1145,53 +1145,6 @@ func (m *tuiModel) renderWorkflowsPanel() string {
 
 // ── View ──
 
-// liveHeight returns the number of lines the "live" region (partial text,
-// spinner, queue, background, input box, status bar) occupies.
-func (m *tuiModel) liveHeight() int {
-	h := 0
-	if m.echoPending != "" {
-		h += strings.Count(m.echoPending, "\n") + 1
-	}
-	if m.partial.String() != "" {
-		h++
-	}
-	if m.running != nil || (m.turnRunning && m.partial.Len() == 0) {
-		h++
-	}
-	if m.running != nil && (tools.HasActiveSync() || tools.HasActiveSubAgentSync()) {
-		h++ // Ctrl+B hint line
-	}
-	if n := len(m.pendingSteer); n > 0 {
-		h += n // one line per pending steer message
-	}
-	if n := len(m.queue); n > 0 {
-		h += 3 + n // panel border (2) + title (1) + n body lines
-	}
-	if !m.turnRunning && len(tools.RunningBackground()) > 0 {
-		h++ // single idle "N shells still running" line
-	}
-	if n := len(m.subAgentOrder); n > 0 {
-		h += 3 // panel border (2) + title (1)
-		for _, id := range m.subAgentOrder {
-			sa := m.subAgents[id]
-			if sa == nil {
-				continue
-			}
-			h++ // header line
-			if sa.expanded {
-				h += len(sa.history) // one line per tool in history
-			}
-		}
-	}
-	if n := len(m.workflows); n > 0 {
-		h += 3 + n // panel border (2) + title (1) + one line per workflow
-	}
-	h += m.completionHeight() // slash-completion menu (0 when closed)
-	h += m.ta.Height()        // input box (textarea grows with content)
-	h += 2                    // status bar: separator + segments (no hint line)
-	return h
-}
-
 func (m *tuiModel) View() string {
 	if m.quit {
 		return ""
@@ -1275,7 +1228,10 @@ func (m *tuiModel) View() string {
 			if i > 0 {
 				items.WriteByte('\n')
 			}
-			items.WriteString(queueStyle.Render(fmt.Sprintf("%d. %s", i+1, q.text)))
+			// A queued item is user-typed and can be arbitrarily long or
+			// span multiple lines; render it as one bounded line so it
+			// can't blow apart the panel border (#1095).
+			items.WriteString(queueStyle.Render(fmt.Sprintf("%d. %s", i+1, truncate1Line(q.text))))
 		}
 		b.WriteString(tui.Panel(fmt.Sprintf("queue (%d)", len(m.queue)), items.String()))
 		b.WriteByte('\n')

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -103,16 +103,25 @@ func Banner(version, model, cwd string, width int) string {
 		hintStyle.Render(hints[1]),
 	)
 
-	// Horizontal join: art + 2-space gutter + info
+	// Horizontal join: art + 2-space gutter + info. Below ~75 columns this
+	// join no longer fits the terminal width and lipgloss.JoinHorizontal
+	// doesn't wrap — the result would wrap unpredictably wherever the
+	// terminal itself line-wraps, misaligning the art and info block against
+	// each other (#1095). Fall back to a text-only banner instead; the
+	// width<20 floor above already keeps that block itself from being
+	// squeezed further than makes sense.
 	art := strings.TrimSpace(octoASCII)
-	banner := lipgloss.JoinHorizontal(lipgloss.Top, art, "  ", infoBlock)
+	const gutter = 2
+	var banner string
+	if lipgloss.Width(art)+gutter+lipgloss.Width(infoBlock) <= width {
+		banner = lipgloss.JoinHorizontal(lipgloss.Top, art, "  ", infoBlock)
+	} else {
+		banner = infoBlock
+	}
 
 	// Outer padding: 1 line top/bottom for breathing room
 	return lipgloss.NewStyle().Padding(1, 0).Render(banner)
 }
-
-// BannerHeight is the number of lines Banner renders.
-const BannerHeight = 9
 
 // ── Status bar ─────────────────────────────────────────────────────────────
 
@@ -128,6 +137,7 @@ var (
 // StatusBar renders the bottom status line with styled segments.
 // Each segment is a [label, value] pair; the hint is shown on a second line.
 func StatusBar(segments [][2]string, hint string, width int) string {
+	segments = clampSegmentsToWidth(segments, width)
 	var b strings.Builder
 	if width > 3 {
 		b.WriteString(statusBarStyle.Render(strings.Repeat("─", width)))
@@ -156,4 +166,72 @@ func StatusBar(segments [][2]string, hint string, width int) string {
 		b.WriteString(statusHintStyle.Render(hint))
 	}
 	return b.String()
+}
+
+// clampSegmentsToWidth shortens the "cwd" segment's value — the one whose
+// length varies most and is the most tolerant of abbreviation — so the
+// segment line fits within width instead of silently wrapping onto a second
+// line on a deep working directory (#1095). Other segments (model, ctx%,
+// perm, ...) are short, fixed-shape labels and are left alone.
+func clampSegmentsToWidth(segments [][2]string, width int) [][2]string {
+	if width <= 0 {
+		return segments
+	}
+	over := segmentsWidth(segments) - width
+	if over <= 0 {
+		return segments
+	}
+	out := make([][2]string, len(segments))
+	copy(out, segments)
+	for i, seg := range out {
+		if seg[0] != "cwd" {
+			continue
+		}
+		budget := lipgloss.Width(seg[1]) - over
+		if budget < 1 {
+			budget = 1
+		}
+		out[i] = [2]string{seg[0], shortenMiddle(seg[1], budget)}
+		break
+	}
+	return out
+}
+
+// segmentsWidth measures the plain display width the segment line will
+// render at: each segment's value (labels aren't rendered, only used to pick
+// a style) plus a " · " separator between segments.
+func segmentsWidth(segments [][2]string) int {
+	w := 0
+	for i, seg := range segments {
+		if i > 0 {
+			w += 3 // " · "
+		}
+		w += lipgloss.Width(seg[1])
+	}
+	return w
+}
+
+// shortenMiddle shortens s to at most maxW display columns by cutting from
+// the middle and inserting "…", keeping both the start and the end visible
+// (e.g. "~/Projects/github/octo-agent" → "~/Pro…/octo-agent") — the leaf
+// directory name is usually the most useful part of a path, and padCol's
+// tail-truncation would hide it entirely.
+func shortenMiddle(s string, maxW int) string {
+	if maxW <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= maxW {
+		return s
+	}
+	if maxW == 1 {
+		return "…"
+	}
+	r := []rune(s)
+	avail := maxW - 1 // reserve 1 column for "…"
+	left := avail / 2
+	right := avail - left
+	if left+right >= len(r) {
+		return s
+	}
+	return string(r[:left]) + "…" + string(r[len(r)-right:])
 }

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 func TestPanel_BordersTitleAndBody(t *testing.T) {
@@ -71,6 +73,33 @@ func TestBanner_MinWidth(t *testing.T) {
 	}
 }
 
+// #1095: below ~104 columns (the art + gutter + info block's combined
+// width) the two no longer fit side by side, and lipgloss.JoinHorizontal
+// doesn't wrap — it would print past the terminal's actual width and let the
+// terminal itself wrap unpredictably, misaligning the art against the info
+// block. A comfortably wide terminal should still show the full art+info
+// layout.
+func TestBanner_ShowsArtWhenWide(t *testing.T) {
+	out := Banner("v1.0", "claude", "~/proj", 110)
+	if !strings.Contains(out, "██████") {
+		t.Errorf("Banner should show ASCII art at a wide width; got:\n%s", out)
+	}
+}
+
+// Below the combined width, Banner falls back to a text-only layout — no
+// art, but the title/info/hints must still render.
+func TestBanner_HidesArtWhenNarrow(t *testing.T) {
+	out := Banner("v1.0", "claude", "~/proj", 60)
+	if strings.Contains(out, "██████") {
+		t.Errorf("Banner should drop ASCII art below the fit width; got:\n%s", out)
+	}
+	for _, want := range []string{"◆ octo", "claude", "~/proj"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("narrow Banner missing %q in:\n%s", want, out)
+		}
+	}
+}
+
 func TestStatusBar_SegmentsAndHint(t *testing.T) {
 	segs := [][2]string{{"model", "gpt-4"}, {"cost", "$0.01"}}
 	out := StatusBar(segs, "Enter send", 30)
@@ -85,5 +114,59 @@ func TestStatusBar_ZeroWidth(t *testing.T) {
 	out := StatusBar(nil, "hint", 0)
 	if !strings.Contains(out, "hint") {
 		t.Errorf("StatusBar should still render hint at width 0; got:\n%s", out)
+	}
+}
+
+// #1095: a deep cwd used to make the segment line overflow width with no
+// clamping at all, wrapping the status bar onto two lines.
+func TestStatusBar_ClampsLongCwd(t *testing.T) {
+	longCwd := "/Users/someone/Projects/very/deeply/nested/path/to/octo-agent"
+	segs := [][2]string{{"model", "gpt-4"}, {"cwd", longCwd}}
+	out := StatusBar(segs, "", 40)
+	for _, line := range strings.Split(out, "\n") {
+		if w := lipgloss.Width(line); w > 40 {
+			t.Errorf("status bar line exceeds width 40 (got %d): %q", w, line)
+		}
+	}
+	if strings.Contains(out, longCwd) {
+		t.Error("expected the long cwd to be shortened, found it unshortened")
+	}
+	// The leaf directory name is the most useful part of a path — it must
+	// survive the shortening, not just the drive/root end.
+	if !strings.Contains(out, "octo-agent") {
+		t.Errorf("expected the cwd's leaf directory to survive shortening; got:\n%s", out)
+	}
+}
+
+// A short cwd that already fits must render unmodified.
+func TestStatusBar_ShortCwdUnclamped(t *testing.T) {
+	segs := [][2]string{{"model", "gpt-4"}, {"cwd", "~/proj"}}
+	out := StatusBar(segs, "", 60)
+	if !strings.Contains(out, "~/proj") {
+		t.Errorf("short cwd should render unmodified; got:\n%s", out)
+	}
+}
+
+func TestShortenMiddle(t *testing.T) {
+	// A string that already fits within maxW must render unchanged.
+	in := "~/Projects/github/octo-agent"
+	if got := shortenMiddle(in, 100); got != in {
+		t.Errorf("shortenMiddle(%q, 100) = %q, want unchanged", in, got)
+	}
+
+	// Shortened form must respect the width budget, keep the "…" marker, and
+	// preserve a prefix and a suffix of the original (not just truncate the tail).
+	got := shortenMiddle(in, 15)
+	if w := lipgloss.Width(got); w > 15 {
+		t.Errorf("shortenMiddle result exceeds budget: %d > 15 (%q)", w, got)
+	}
+	if !strings.Contains(got, "…") {
+		t.Errorf("shortenMiddle result missing ellipsis: %q", got)
+	}
+	if !strings.HasPrefix(got, "~/") {
+		t.Errorf("shortenMiddle should keep the path's start: %q", got)
+	}
+	if !strings.HasSuffix(got, "agent") {
+		t.Errorf("shortenMiddle should keep the path's end: %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Covers items 2-4 of #1095, plus resolves item 1 by deletion rather than implementation — see discussion on the issue for the scope call: wiring `liveHeight` into a real fold-by-priority height budget would be a substantially larger, more speculative change (deciding what folds first, restructuring `View()` around a live budget) than the panel-correctness bugs below, which are self-contained and low-risk.

- **`liveHeight` was dead code**: zero production callers — `View()` never consulted it, only a test exercised its own line-counting math. Deleted it, along with `completionHeight` (existed solely to feed `liveHeight`, so it became dead in the same stroke) and the already-uncalled `BannerHeight` constant (doubly inaccurate now given the `Banner` change below).
- **Queue panel**: a queued item is raw user-typed text and could be arbitrarily long or span multiple lines, blowing the panel border apart. Now rendered through the existing `truncate1Line` helper (already used elsewhere for this exact "collapse to one bounded line" need).
- **Status bar**: the segment line had no width clamping at all — a deep `cwd` would wrap the bar onto a second line. Added `clampSegmentsToWidth`, which shortens only the `cwd` segment (the one whose length varies and is most tolerant of abbreviation) via a new `shortenMiddle` helper — middle-out truncation with an ellipsis, so the path's leaf directory (usually the most useful part) survives instead of being cut off the way tail-truncation would.
- **Banner**: below ~104 columns (the ASCII art + gutter + info block's combined width) `lipgloss.JoinHorizontal` no longer fits the terminal and doesn't wrap on its own — the render would wrap wherever the terminal itself line-wraps, misaligning the art against the info block. Falls back to a text-only banner (info block alone) below that width.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `go test -race ./...` (full suite green)
- [x] New tests: `TestTUI_QueuePanelTruncatesLongMultilineItems` (multi-line and 200-char items collapse to one bounded line), `TestBanner_ShowsArtWhenWide` / `TestBanner_HidesArtWhenNarrow` (art appears/disappears at the right width threshold, title+info survive either way), `TestStatusBar_ClampsLongCwd` / `TestStatusBar_ShortCwdUnclamped` (every rendered line respects the width budget, leaf directory name survives shortening, a short cwd is left untouched), `TestShortenMiddle` (unit coverage of the new truncation helper: unchanged when it fits, respects the budget, keeps both a prefix and a suffix)