### PR TITLE
fix(im): add /help, route skills via slash, enrich /status (#1124)

### DIFF
--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -342,8 +342,10 @@ func (m *Manager) CommandRouter(ev InboundEvent) string {
 		return m.cmdCompact(ev)
 	case "/goal":
 		return m.cmdGoal(ev, strings.Join(args, " "))
+	case "/help":
+		return "Available: /bind [--force] <number|id>, /unbind, /list, /clear, /new, /compact, /goal, /stop, /status, /help"
 	default:
-		return fmt.Sprintf("Unknown command: %s. Available: /bind [--force] <number|id>, /unbind, /list, /clear, /new, /compact, /goal, /stop, /status", cmd)
+		return fmt.Sprintf("Unknown command: %s", cmd)
 	}
 }
 
@@ -604,8 +606,17 @@ func (m *Manager) cmdStatus(ev InboundEvent) string {
 	}
 	sess := val.(*Session)
 	inTok, outTok := sess.Agent.SessionTokens()
-	return fmt.Sprintf("Session active since %s. Input: %d tokens, Output: %d tokens.",
-		sess.BoundAt.Format("15:04:05"), inTok, outTok)
+	model := sess.Agent.Model
+	status := "idle"
+	if sess.IsRunning() {
+		status = "running"
+	}
+	title := sess.Store.Title
+	if title == "" {
+		title = sess.Store.DisplayTitle()
+	}
+	return fmt.Sprintf("Session: %s | Model: %s | Status: %s | Since: %s | Tokens: %d in / %d out",
+		title, model, status, sess.BoundAt.Format("15:04:05"), inTok, outTok)
 }
 
 // cmdList shows the persisted sessions a chat can attach to with /bind,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2249,6 +2249,12 @@ func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEven
 		s.handleChannelCompact(ad, ev)
 		return true
 	}
+	// Unknown slash tokens that match a skill name are passed through as
+	// normal user messages, same as the Web and TUI surfaces.
+	skillName := strings.TrimPrefix(cmd, "/")
+	if _, ok := s.skillReg.Get(skillName); ok {
+		return false
+	}
 	if reply := s.channelMgr.CommandRouter(ev); reply != "" {
 		ad.SendText(ev.ChatID, reply, ev.MessageID)
 	}


### PR DESCRIPTION
## Changes

Three items from issue #1124's IM command & misc polish batch:

### 1. `/help` command
New dedicated command listing available commands. The old inline list in the "Unknown command" error is removed — `/help` is the canonical way to discover commands now.

### 2. Skills invocable via slash
`handleChannelCommand` now checks unknown slash tokens against the skill registry. If `/<name>` matches a skill, the message passes through as a normal user message — same behavior as Web and TUI surfaces. Fixes `/deploy` → "Unknown command" for any installed skill.

### 3. Rich `/status`
Before: `Session active since 14:30:00. Input: 1234 tokens, Output: 567 tokens.`
After: `Session: Code Review | Model: claude-sonnet-4-5 | Status: idle | Since: 14:30:00 | Tokens: 1234 in / 567 out`

Adds session title, model name, and running status.

## Files changed

- `internal/channel/manager.go` — +14 lines: `/help` case, richer `cmdStatus`
- `internal/server/server.go` — +6 lines: skill name check before `CommandRouter`

## Testing
- `go build ./internal/channel/... ./internal/server/...` ✅
- `go test ./internal/channel/...` ✅ (all 8 adapter suites pass)
- `go test ./internal/server/...` ✅

Closes #1124 (items 1-3; items 4-7 are platform-specific and lower priority)