### PR TITLE
tools: make sub_agent/workflow advertisement ctx-aware (#1133)

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/config"
 	"github.com/open-octo/octo-agent/internal/tasks"
@@ -11,11 +13,15 @@ import (
 // loop dispatches tool calls through, the manager that tracks async sub-agents
 // (sub_agent), and a model-aware tool-list function. Call
 // ToolsFor again after MCP connects so the list (or its Tool Search bridge)
-// picks up the new surface.
+// picks up the new surface. ToolsFor takes a ctx (server/cron callers pass the
+// turn's ctx so tools.DefaultToolsForCtx can see that turn's ctx-scoped
+// sub-agent manager, #1133); the CLI/TUI's single-session path can pass any
+// ctx since it has no ctx-scoped manager and always resolves through the
+// process-global slots this function also registers.
 type ToolEnv struct {
 	Executor    tools.DefaultRegistry
 	SubAgentMgr *tools.SubAgentManager
-	ToolsFor    func() []agent.ToolDefinition
+	ToolsFor    func(ctx context.Context) []agent.ToolDefinition
 }
 
 // WireTools sets up the tool environment every full-loop entry point shares —
@@ -31,7 +37,7 @@ type ToolEnv struct {
 // MCP connection strategy — those legitimately differ per entry point.
 func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
 	executor := tools.NewDefaultRegistry()
-	toolsFor := func() []agent.ToolDefinition { return tools.DefaultToolsFor(a.Model) }
+	toolsFor := func(ctx context.Context) []agent.ToolDefinition { return tools.DefaultToolsForCtx(ctx, a.Model) }
 
 	spawner := NewSpawner(a, executor, toolsFor)
 	tools.SetSpawner(spawner)

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
@@ -26,7 +27,7 @@ func TestWireTools_SetsUpEnvAndCleansUp(t *testing.T) {
 	// The sub-agent manager must be registered globally so that DefaultToolsFor
 	// advertises the sub_agent tool to the LLM.
 	hasSubAgent := false
-	for _, d := range env.ToolsFor() {
+	for _, d := range env.ToolsFor(context.Background()) {
 		if d.Name == "sub_agent" {
 			hasSubAgent = true
 			break
@@ -39,7 +40,7 @@ func TestWireTools_SetsUpEnvAndCleansUp(t *testing.T) {
 		t.Fatal("WireTools should return a tool-list function")
 	}
 	// ToolsFor is model-aware and must at least return the core built-ins.
-	if len(env.ToolsFor()) == 0 {
+	if len(env.ToolsFor(context.Background())) == 0 {
 		t.Error("ToolsFor returned an empty tool list")
 	}
 
@@ -51,7 +52,7 @@ func TestWireTools_SetsUpEnvAndCleansUp(t *testing.T) {
 		t.Error("cleanup should reset the task store")
 	}
 	// After cleanup, the sub_agent tool should no longer be advertised.
-	for _, d := range env.ToolsFor() {
+	for _, d := range env.ToolsFor(context.Background()) {
 		if d.Name == "sub_agent" {
 			t.Error("cleanup should reset the sub-agent manager so sub_agent is no longer advertised")
 			break

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -24,14 +24,18 @@ import (
 // sub_agent tool_result; the child's token usage is rolled into the
 // parent's session totals so they report one consolidated number.
 //
-// toolsFn is a deferred lookup of the LLM-facing tool catalog (DefaultTools).
-// Resolving it on each Spawn — rather than capturing a slice at construction
-// — lets cmd/octo set up the spawner before computing the tool list, since
-// SetSpawner has to run first for sub_agent to appear in DefaultTools().
+// toolsFn is a deferred lookup of the LLM-facing tool catalog (DefaultTools),
+// given the ctx the child is being spawned under — so a server/cron caller
+// can pass tools.DefaultToolsForCtx and have the child's own tool list
+// reflect that turn's ctx-scoped sub-agent manager instead of depending on
+// process-global state (#1133). Resolving it on each Spawn — rather than
+// capturing a slice at construction — also lets cmd/octo set up the spawner
+// before computing the tool list, since SetSpawner has to run first for
+// sub_agent to appear in DefaultTools().
 type Spawner struct {
 	parent   *agent.Agent
 	executor agent.ToolExecutor
-	toolsFn  func() []agent.ToolDefinition
+	toolsFn  func(ctx context.Context) []agent.ToolDefinition
 	// reg keeps spawned children alive after Spawn returns so a later
 	// Continue can re-run them with their history intact. In-memory and
 	// session-scoped: it lives as long as this spawner (one per REPL session),
@@ -39,7 +43,7 @@ type Spawner struct {
 	reg *childRegistry
 }
 
-func NewSpawner(parent *agent.Agent, executor agent.ToolExecutor, toolsFn func() []agent.ToolDefinition) *Spawner {
+func NewSpawner(parent *agent.Agent, executor agent.ToolExecutor, toolsFn func(ctx context.Context) []agent.ToolDefinition) *Spawner {
 	return &Spawner{
 		parent:   parent,
 		executor: executor,
@@ -58,7 +62,7 @@ const childMaxTurns = 100
 // a later Continue can resume it, runs the first prompt, and returns the
 // child's id alongside its reply.
 func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
-	childTools := filterChildTools(s.toolsFn(), req.Tools, req.DisallowedTools, req.ReadOnly)
+	childTools := filterChildTools(s.toolsFn(ctx), req.Tools, req.DisallowedTools, req.ReadOnly)
 
 	// Pick the child's sender + model. A lean preset (explore/plan) runs on the
 	// parent's lite model when one is configured — its own cheaper sender, not

--- a/internal/app/spawner_schema_test.go
+++ b/internal/app/spawner_schema_test.go
@@ -46,7 +46,7 @@ func TestExtractJSON(t *testing.T) {
 func TestAgentSpawner_SchemaInjectsInstruction(t *testing.T) {
 	send := &subAgentSender{reply: `{"ok":true}`}
 	parent := agent.New(send, "parent-model")
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	_, err := sp.Spawn(context.Background(), tools.SpawnRequest{
 		Prompt: "extract the fields",
@@ -71,7 +71,7 @@ func TestAgentSpawner_SchemaRetriesOnInvalidJSON(t *testing.T) {
 		`{"ok":true}`,                      // retry: valid
 	}}
 	parent := agent.New(send, "parent-model")
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{
 		Prompt: "do it",
@@ -93,7 +93,7 @@ func TestAgentSpawner_SchemaRetriesOnInvalidJSON(t *testing.T) {
 func TestAgentSpawner_SchemaCleansFencesNoRetry(t *testing.T) {
 	send := &subAgentSender{reply: "```json\n{\"a\":1}\n```"}
 	parent := agent.New(send, "parent-model")
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{Prompt: "x", Schema: `{}`})
 	if err != nil {

--- a/internal/app/spawner_test.go
+++ b/internal/app/spawner_test.go
@@ -58,7 +58,7 @@ func TestAgentSpawner_RunsChildAndRollsTokensIntoParent(t *testing.T) {
 		{Name: "grep"},
 		{Name: "sub_agent"},
 	}
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return parentTools })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return parentTools })
 
 	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{
 		Description: "Investigate",
@@ -98,7 +98,7 @@ func TestAgentSpawner_AppliesToolAllowlist(t *testing.T) {
 		{Name: "terminal"},
 		{Name: "sub_agent"},
 	}
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return parentTools })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return parentTools })
 
 	// Allowlist restricts to read_file + grep. sub_agent always excluded.
 	got := filterChildTools(parentTools, []string{"read_file", "grep"}, nil, false)
@@ -136,7 +136,7 @@ func TestAgentSpawner_AppliesToolAllowlist(t *testing.T) {
 func TestAgentSpawner_ModelOverride(t *testing.T) {
 	send := &subAgentSender{reply: "ok"}
 	parent := agent.New(send, "parent-model")
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	_, err := sp.Spawn(context.Background(), tools.SpawnRequest{
 		Description: "x",
@@ -154,7 +154,7 @@ func TestAgentSpawner_ModelOverride(t *testing.T) {
 func TestAgentSpawner_SpawnReturnsIDAndContinueResumesSameChild(t *testing.T) {
 	send := &subAgentSender{reply: "round one", inputTokens: 200, outputTokens: 80}
 	parent := agent.New(send, "parent-model")
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{Description: "x", Prompt: "first task"})
 	if err != nil {
@@ -190,7 +190,7 @@ func TestAgentSpawner_SpawnReturnsIDAndContinueResumesSameChild(t *testing.T) {
 func TestSubAgentManager_SendResumesSameChildThroughSpawner(t *testing.T) {
 	send := &subAgentSender{reply: "round one", inputTokens: 100, outputTokens: 40}
 	parent := agent.New(send, "parent-model")
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	mgr := tools.NewSubAgentManager(sp)
 	notes := make(chan tools.SubAgentNotification, 4)
@@ -242,7 +242,7 @@ func TestSubAgentManager_SendResumesSameChildThroughSpawner(t *testing.T) {
 func TestAgentSpawner_ContinueAccruesOnlyDeltaTokens(t *testing.T) {
 	send := &subAgentSender{reply: "ok", inputTokens: 200, outputTokens: 80}
 	parent := agent.New(send, "parent-model")
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{Description: "x", Prompt: "go"})
 	if err != nil {
@@ -270,7 +270,7 @@ func TestAgentSpawner_ContinueAccruesOnlyDeltaTokens(t *testing.T) {
 func TestAgentSpawner_ContinueUnknownID(t *testing.T) {
 	send := &subAgentSender{reply: "ok"}
 	parent := agent.New(send, "parent-model")
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	_, err := sp.Continue(context.Background(), "nope", "hi")
 	if err == nil || !strings.Contains(err.Error(), "no longer alive") {
@@ -281,7 +281,7 @@ func TestAgentSpawner_ContinueUnknownID(t *testing.T) {
 func TestAgentSpawner_ConcurrentContinueSerialized(t *testing.T) {
 	send := &subAgentSender{reply: "ok", inputTokens: 10, outputTokens: 5}
 	parent := agent.New(send, "parent-model")
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{Description: "x", Prompt: "go"})
 	if err != nil {
@@ -385,7 +385,7 @@ func TestAgentSpawner_AppliesSystemSuffix(t *testing.T) {
 	send := &subAgentSender{reply: "ok"}
 	parent := agent.New(send, "parent-model")
 	parent.System = "BASE IDENTITY"
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{
 		Prompt:       "go",
@@ -440,7 +440,7 @@ func TestAgentSpawner_ForkSeedsConversation(t *testing.T) {
 		agent.NewToolUseBlock("tu_1", "sub_agent", map[string]any{"prompt": "go"}),
 	}})
 
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{Prompt: "go", ForkConversation: true}); err != nil {
 		t.Fatal(err)
 	}
@@ -474,7 +474,7 @@ func TestAgentSpawner_LeanUsesLiteModelAndSystem(t *testing.T) {
 	parent.LiteSender = lite
 	parent.LiteModel = "lite-model"
 
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{
 		Prompt: "go", LeanContext: true, SystemSuffix: "PERSONA",
 	}); err != nil {
@@ -497,7 +497,7 @@ func TestAgentSpawner_LeanFallsBackWithoutLiteModel(t *testing.T) {
 	parent := agent.New(main, "main-model")
 	parent.System = "FULL BASE" // no LeanSystem, no LiteSender/LiteModel
 
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{Prompt: "go", LeanContext: true}); err != nil {
 		t.Fatal(err)
 	}
@@ -516,7 +516,7 @@ func TestAgentSpawner_ExplicitModelWinsOverLean(t *testing.T) {
 	parent := agent.New(main, "main-model")
 	parent.LiteSender, parent.LiteModel = lite, "lite-model"
 
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{Prompt: "go", LeanContext: true, Model: "explicit"}); err != nil {
 		t.Fatal(err)
 	}
@@ -531,7 +531,7 @@ func TestAgentSpawner_NoForkStartsFresh(t *testing.T) {
 	parent := agent.New(send, "parent-model")
 	parent.History.Append(agent.NewUserMessage("secret parent context"))
 
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 	if _, err := sp.Spawn(context.Background(), tools.SpawnRequest{Prompt: "go"}); err != nil {
 		t.Fatal(err)
 	}
@@ -609,7 +609,7 @@ func TestChildRegistry_TTLEviction(t *testing.T) {
 func TestAgentSpawner_MarksContextSoRecursionRefused(t *testing.T) {
 	send := &subAgentSender{reply: "ok"}
 	parent := agent.New(send, "parent-model")
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	// Wire SpawnRequest into a real sub_agent tool that checks the sub-agent
 	// context flag. After Spawn returns, the OUTER context shouldn't be marked
@@ -635,7 +635,7 @@ func TestAgentSpawner_SessionDirPersistsTranscript(t *testing.T) {
 	tmp := t.TempDir()
 	send := &subAgentSender{reply: "sub-agent answer", inputTokens: 100, outputTokens: 40}
 	parent := agent.New(send, "parent-model")
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	res, err := sp.Spawn(context.Background(), tools.SpawnRequest{
 		Description: "Test",

--- a/internal/app/spawner_verify_test.go
+++ b/internal/app/spawner_verify_test.go
@@ -19,7 +19,7 @@ func TestVerify_AgentToolAsyncLaunchAndResume(t *testing.T) {
 	parent.System = "PARENT"
 
 	// Real spawner with the real childRegistry underneath.
-	sp := NewSpawner(parent, nilExecutor{}, func() []agent.ToolDefinition { return nil })
+	sp := NewSpawner(parent, nilExecutor{}, func(context.Context) []agent.ToolDefinition { return nil })
 
 	// Wire the manager exactly like cmd/octo/tuirepl.go does in production:
 	// SetDefaultSubAgentManager so the bare tools resolve it via t.manager().

--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -293,8 +293,11 @@ func TestPrepareToolTurn_SessionScopedAsyncManager(t *testing.T) {
 }
 
 // TestPrepareToolTurn_AdvertisesSubAgentAndWorkflow guards the core fix for
-// cron/server sessions: after prepareToolTurn, DefaultToolsFor must include
-// both sub_agent and workflow so the model can invoke them.
+// cron/server sessions: after prepareToolTurn, tools.DefaultToolsForCtx(ctx,
+// ...) — using the ctx prepareToolTurn returns — must include both sub_agent
+// and workflow so the model can invoke them, and (#1133) it must do so
+// without writing to the process-global spawner/sub-agent-manager slots,
+// since those are only meaningful for a single-session CLI process.
 func TestPrepareToolTurn_AdvertisesSubAgentAndWorkflow(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -308,7 +311,8 @@ func TestPrepareToolTurn_AdvertisesSubAgentAndWorkflow(t *testing.T) {
 		tools.SetDefaultSubAgentManager(prevMgr)
 	})
 
-	// Ensure we start from a clean slate; prepareToolTurn should install its own.
+	// Start from a clean slate: nothing but the ctx-scoped manager
+	// prepareToolTurn stamps into ctx should make the gate pass.
 	tools.SetSpawner(nil)
 	tools.SetDefaultSubAgentManager(nil)
 
@@ -317,25 +321,36 @@ func TestPrepareToolTurn_AdvertisesSubAgentAndWorkflow(t *testing.T) {
 	ctx := context.WithValue(context.Background(), ctxKeySessionID{}, "adv-test")
 	t.Cleanup(func() { tools.CloseSessionSubAgentManager("adv-test") })
 
-	_, _, _, cleanup, err := srv.prepareToolTurn(ctx, a, nil)
+	turnCtx, _, _, cleanup, err := srv.prepareToolTurn(ctx, a, nil)
 	if err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
 	defer cleanup()
 
-	names := toolNames(tools.DefaultToolsFor(a.Model))
+	names := toolNames(tools.DefaultToolsForCtx(turnCtx, a.Model))
 	if !slices.Contains(names, "sub_agent") {
-		t.Errorf("DefaultToolsFor missing sub_agent; got %v", names)
+		t.Errorf("DefaultToolsForCtx missing sub_agent; got %v", names)
 	}
 	if !slices.Contains(names, "workflow") {
-		t.Errorf("DefaultToolsFor missing workflow; got %v", names)
+		t.Errorf("DefaultToolsForCtx missing workflow; got %v", names)
+	}
+
+	// #1133's whole point: the turn must not have installed itself into the
+	// process-global slots to get there.
+	if tools.ActiveSpawner() != nil {
+		t.Error("prepareToolTurn must not write the process-global spawner")
+	}
+	if tools.DefaultSubAgentManager() != nil {
+		t.Error("prepareToolTurn must not write the process-global sub-agent manager")
 	}
 }
 
-// TestPrepareToolTurn_CleanupRestoresGlobalSpawner verifies that the cleanup
-// returned by prepareToolTurn restores the previous global spawner and
-// sub-agent manager, so later server turns or CLI paths see their own state.
-func TestPrepareToolTurn_CleanupRestoresGlobalSpawner(t *testing.T) {
+// TestPrepareToolTurn_DoesNotTouchGlobalSpawner (#1133) replaces the old
+// swap-and-restore contract: prepareToolTurn must leave the process-global
+// spawner/sub-agent-manager slots completely alone — not set them and
+// restore them, just never touch them — since a multi-session server can't
+// safely mutate process-global state per turn.
+func TestPrepareToolTurn_DoesNotTouchGlobalSpawner(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)
@@ -347,11 +362,11 @@ func TestPrepareToolTurn_CleanupRestoresGlobalSpawner(t *testing.T) {
 		tools.SetDefaultSubAgentManager(prevMgr)
 	})
 
-	// Pre-seed the global slots with sentinel values so we can prove restoration.
-	fake := &fakeGlobalSpawner{}
-	prevMgrForTest := tools.NewSubAgentManager(nil)
-	tools.SetSpawner(fake)
-	tools.SetDefaultSubAgentManager(prevMgrForTest)
+	// Pre-seed the global slots with sentinel values so any write during the
+	// turn (or its cleanup) would be observable.
+	sentinelMgr := tools.NewSubAgentManager(nil)
+	tools.SetSpawner(nil)
+	tools.SetDefaultSubAgentManager(sentinelMgr)
 
 	srv := mustServer(t, Config{Tools: true})
 	a := agent.New(&stubSender{}, "stub-model")
@@ -362,25 +377,21 @@ func TestPrepareToolTurn_CleanupRestoresGlobalSpawner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepareToolTurn: %v", err)
 	}
-	if tools.ActiveSpawner() == nil {
-		t.Error("global spawner should be set during the turn")
+	if tools.ActiveSpawner() != nil {
+		t.Error("prepareToolTurn wrote the process-global spawner during the turn")
 	}
-	if tools.DefaultSubAgentManager() == nil {
-		t.Error("global sub-agent manager should be set during the turn")
+	if tools.DefaultSubAgentManager() != sentinelMgr {
+		t.Error("prepareToolTurn overwrote the process-global sub-agent manager during the turn")
 	}
 
 	cleanup()
 
-	if tools.ActiveSpawner() != fake {
-		t.Error("cleanup did not restore previous global spawner")
+	if tools.ActiveSpawner() != nil {
+		t.Error("cleanup should not have touched the process-global spawner")
 	}
-	if tools.DefaultSubAgentManager() != prevMgrForTest {
-		t.Error("cleanup did not restore previous global sub-agent manager")
+	if tools.DefaultSubAgentManager() != sentinelMgr {
+		t.Error("cleanup should not have touched the process-global sub-agent manager")
 	}
-
-	// Restore the truly original values so the test cleanup doesn't leak.
-	tools.SetSpawner(prevSpawner)
-	tools.SetDefaultSubAgentManager(prevMgr)
 }
 
 func toolNames(defs []agent.ToolDefinition) []string {
@@ -389,15 +400,4 @@ func toolNames(defs []agent.ToolDefinition) []string {
 		names[i] = d.Name
 	}
 	return names
-}
-
-// fakeGlobalSpawner is a minimal Spawner used only to prove that
-// prepareToolTurn's cleanup restores the previous global value.
-type fakeGlobalSpawner struct{}
-
-func (fakeGlobalSpawner) Spawn(context.Context, tools.SpawnRequest) (tools.SpawnResult, error) {
-	return tools.SpawnResult{}, nil
-}
-func (fakeGlobalSpawner) Continue(context.Context, string, string) (tools.SpawnResult, error) {
-	return tools.SpawnResult{}, nil
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -771,7 +771,7 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 	}
 	defer cleanup()
 
-	reply, err := a.Run(ctx, userInput, tools.DefaultToolsFor(a.Model), executor)
+	reply, err := a.Run(ctx, userInput, tools.DefaultToolsForCtx(ctx, a.Model), executor)
 	if err != nil {
 		return "", err
 	}
@@ -881,8 +881,8 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 	a.Gate = app.NewPermissionGate(engine, ask)
 
 	mkSpawner := func() tools.Spawner {
-		return app.NewSpawner(a, executor, func() []agent.ToolDefinition {
-			return tools.DefaultToolsFor(a.Model)
+		return app.NewSpawner(a, executor, func(ctx context.Context) []agent.ToolDefinition {
+			return tools.DefaultToolsForCtx(ctx, a.Model)
 		})
 	}
 	var mgr *tools.SubAgentManager
@@ -930,25 +930,21 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 	ctx = tools.WithSubAgentManager(ctx, mgr)
 	ctx = tools.WithTaskStore(ctx, tasks.New())
 
-	// Temporarily install the turn's spawner/manager into the process-global
-	// slots so that DefaultToolsFor() advertises sub_agent and workflow. Save
-	// the previous values so callers can restore them after the turn.
-	prevSpawner := tools.ActiveSpawner()
-	prevSubAgentMgr := tools.DefaultSubAgentManager()
-	spawner := mgr.Spawner()
-	if spawner == nil {
-		spawner = mkSpawner()
-	}
-	tools.SetSpawner(spawner)
-	tools.SetDefaultSubAgentManager(mgr)
-	// Same save-and-restore shape for the workflow tool's Definition(), which
-	// takes no ctx and so can't see a.CWD directly — see workflow.go's
-	// ActiveWorkflowDiscoveryCWD doc comment.
+	// #1133: sub_agent/workflow advertisement no longer needs the turn's
+	// spawner/manager installed into the process-global slots — callers use
+	// tools.DefaultToolsForCtx(ctx, ...) with the ctx returned above, which
+	// sees the ctx-scoped manager just stamped in directly. That removes a
+	// data-race-prone per-turn mutation of process-global state on a server
+	// that's inherently multi-session; see tools.DefaultToolsForCtx's doc
+	// comment.
+	//
+	// The workflow tool's Definition(), unlike its Execute, takes no ctx and
+	// so can't see a.CWD directly — that one remains a save-and-restore
+	// process-global swap (a separate concern from advertisement gating; see
+	// workflow.go's ActiveWorkflowDiscoveryCWD doc comment).
 	prevWorkflowDiscoveryCWD := tools.ActiveWorkflowDiscoveryCWD()
 	tools.SetWorkflowDiscoveryCWD(a.CWD)
 	cleanup := func() {
-		tools.SetSpawner(prevSpawner)
-		tools.SetDefaultSubAgentManager(prevSubAgentMgr)
 		tools.SetWorkflowDiscoveryCWD(prevWorkflowDiscoveryCWD)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -532,8 +532,8 @@ func (s *Server) enableSubAgentTools() {
 	cfg, _ := config.Load() // zero value on error still resolves correctly via EffectiveCoauthor
 	template.System, template.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), memInjection, s.effectiveCoauthor(cfg))
 	executor := tools.NewDefaultRegistry()
-	spawner := app.NewSpawner(template, executor, func() []agent.ToolDefinition {
-		return tools.DefaultToolsFor(s.model)
+	spawner := app.NewSpawner(template, executor, func(ctx context.Context) []agent.ToolDefinition {
+		return tools.DefaultToolsForCtx(ctx, s.model)
 	})
 	mgr := tools.NewSubAgentManager(spawner)
 	mgr.SetSynchronous(true)
@@ -2567,11 +2567,11 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		// Per-message sub-agent manager bound to THIS chat's agent —
 		// synchronous, since a chat message is request/response with no
 		// follow-up channel for an async result.
-		spawner := app.NewSpawner(sess.Agent, executor, func() []agent.ToolDefinition {
+		spawner := app.NewSpawner(sess.Agent, executor, func(ctx context.Context) []agent.ToolDefinition {
 			if goalsOn {
-				return tools.DefaultToolsFor(sess.Agent.Model)
+				return tools.DefaultToolsForCtx(ctx, sess.Agent.Model)
 			}
-			return tools.WithoutGoalTools(tools.DefaultToolsFor(sess.Agent.Model))
+			return tools.WithoutGoalTools(tools.DefaultToolsForCtx(ctx, sess.Agent.Model))
 		})
 		subMgr := tools.NewSubAgentManager(spawner)
 		subMgr.SetSynchronous(true)

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -112,7 +112,7 @@ func (s *Server) handleTurnSSE(w http.ResponseWriter, r *http.Request) {
 			sseEvent(w, string(b))
 			return
 		}
-		toolDefs = tools.DefaultToolsFor(a.Model)
+		toolDefs = tools.DefaultToolsForCtx(runCtx, a.Model)
 	}
 
 	eventHandler := func(ev agent.AgentEvent) {

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -253,7 +253,7 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (string, erro
 			sw.error(perr.Error())
 			return sessionID, fmt.Errorf("prepare tools: %w", perr)
 		}
-		toolDefs = tools.DefaultToolsFor(a.Model)
+		toolDefs = tools.DefaultToolsForCtx(runCtx, a.Model)
 		s.wireBackgroundTaskNotices(sessionID)
 	}
 

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1094,7 +1094,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			sw.error(perr.Error())
 			return
 		}
-		toolDefs = tools.DefaultToolsFor(a.Model)
+		toolDefs = tools.DefaultToolsForCtx(runCtx, a.Model)
 		// Surface background-process completions (badge + chat notice).
 		s.wireBackgroundTaskNotices(sess.ID)
 	}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -233,11 +233,35 @@ func DefaultTools() []agent.ToolDefinition { return DefaultToolsFor("") }
 // SubAgentManager. Advertising a tool that can only error wastes a slot and
 // confuses the model.
 //
+// This is the process-global-only gate: it sees a session/turn's sub-agent
+// manager only if something wrote it into the CLI/TUI's process-wide slot
+// (tools.SetSpawner / tools.SetDefaultSubAgentManager), which is only correct
+// for a single-session process. Server/cron turns — inherently multi-session —
+// must use DefaultToolsForCtx instead so per-turn advertisement doesn't depend
+// on process-global state (#1133).
+//
 // MCP surfaces ride alongside the built-ins. When Tool Search is active for
 // this model (see toolSearchActive) the full per-tool catalog is replaced by
 // the three search/describe/call bridge tools, so the model's tools array
 // carries three small schemas instead of every MCP tool's schema every turn.
 func DefaultToolsFor(model string) []agent.ToolDefinition {
+	return defaultToolsFor(context.Background(), model)
+}
+
+// DefaultToolsForCtx is DefaultToolsFor, but also advertises sub_agent* and
+// workflow* when THIS turn has a ctx-scoped SubAgentManager (tools.
+// WithSubAgentManager) — even if no process-global spawner/manager is
+// registered. Server/cron turns each carry their own per-turn manager in ctx
+// (see prepareToolTurn); this lets them advertise correctly without the
+// per-turn tools.SetSpawner/tools.SetDefaultSubAgentManager swap-and-restore
+// that used to be required, which mutated process-global state on every turn
+// of an inherently multi-session process (#1133). CLI/TUI callers, which have
+// no ctx-scoped manager, see identical behavior to DefaultToolsFor.
+func DefaultToolsForCtx(ctx context.Context, model string) []agent.ToolDefinition {
+	return defaultToolsFor(ctx, model)
+}
+
+func defaultToolsFor(ctx context.Context, model string) []agent.ToolDefinition {
 	skillsOn := skillsEnabled()
 	mgrOn := subAgentManagerEnabled()
 	askerOn := askerEnabled()
@@ -248,6 +272,15 @@ func DefaultToolsFor(model string) []agent.ToolDefinition {
 	wakerOn := wakerEnabled()
 	browserOn := browserEnabled()
 	spawnerOn := spawnerEnabled()
+	// A ctx-scoped manager (per-turn, server/IM — see WithSubAgentManager)
+	// makes both gates true for this turn even when the process-global
+	// spawner/manager slots are untouched.
+	if ctxMgr := subAgentManagerFromContext(ctx); ctxMgr != nil {
+		mgrOn = true
+		if ctxMgr.Spawner() != nil {
+			spawnerOn = true
+		}
+	}
 	defs := make([]agent.ToolDefinition, 0, len(allTools))
 	for _, t := range allTools {
 		if _, isSendFile := t.(SendFileTool); isSendFile && !messengerOn {

--- a/internal/tools/registry_sync_test.go
+++ b/internal/tools/registry_sync_test.go
@@ -50,3 +50,72 @@ func (f *fakeSpawner) Spawn(_ context.Context, _ SpawnRequest) (SpawnResult, err
 func (f *fakeSpawner) Continue(_ context.Context, _, _ string) (SpawnResult, error) {
 	return SpawnResult{}, nil
 }
+
+// #1133: DefaultToolsForCtx must advertise sub_agent/workflow off a ctx-scoped
+// SubAgentManager alone — no process-global spawner/manager involved — so a
+// multi-session server can correctly gate advertisement per turn.
+func TestDefaultToolsForCtx_AdvertisesFromCtxScopedManager(t *testing.T) {
+	// Baseline: confirm the process-global slots are genuinely empty, so a
+	// pass here can only be explained by the ctx-scoped manager.
+	if spawnerEnabled() || subAgentManagerEnabled() {
+		t.Fatal("test setup: process-global spawner/manager must be unset")
+	}
+
+	mgr := NewSubAgentManager(&fakeSpawner{})
+	ctx := WithSubAgentManager(context.Background(), mgr)
+
+	names := map[string]bool{}
+	for _, d := range DefaultToolsForCtx(ctx, "") {
+		names[d.Name] = true
+	}
+	if !names["sub_agent"] {
+		t.Error("sub_agent should be advertised from a ctx-scoped manager alone")
+	}
+	if !names["workflow"] {
+		t.Error("workflow should be advertised from a ctx-scoped manager's spawner alone")
+	}
+
+	// A ctx with no manager at all must fall back to the (empty) global gate,
+	// exactly like DefaultToolsFor — ctx-awareness must not leak into an
+	// unrelated ctx.
+	plainNames := map[string]bool{}
+	for _, d := range DefaultToolsForCtx(context.Background(), "") {
+		plainNames[d.Name] = true
+	}
+	if plainNames["sub_agent"] || plainNames["workflow"] {
+		t.Error("a ctx with no scoped manager must not advertise sub_agent/workflow")
+	}
+}
+
+// A ctx-scoped manager with no spawner (nil) advertises sub_agent (it can
+// still track/report sub-agents) but not workflow, which specifically needs a
+// spawner to dispatch through.
+func TestDefaultToolsForCtx_NilSpawnerWithholdsWorkflow(t *testing.T) {
+	mgr := NewSubAgentManager(nil)
+	ctx := WithSubAgentManager(context.Background(), mgr)
+
+	names := map[string]bool{}
+	for _, d := range DefaultToolsForCtx(ctx, "") {
+		names[d.Name] = true
+	}
+	if !names["sub_agent"] {
+		t.Error("sub_agent should still be advertised without a spawner")
+	}
+	if names["workflow"] {
+		t.Error("workflow should be withheld when the ctx-scoped manager has no spawner")
+	}
+}
+
+// DefaultToolsFor(model) must remain exactly DefaultToolsForCtx(background, model).
+func TestDefaultToolsFor_MatchesCtxWithBackground(t *testing.T) {
+	got := DefaultToolsFor("some-model")
+	want := DefaultToolsForCtx(context.Background(), "some-model")
+	if len(got) != len(want) {
+		t.Fatalf("DefaultToolsFor returned %d tools, DefaultToolsForCtx(background) returned %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i].Name != want[i].Name {
+			t.Errorf("tool[%d] = %q, want %q", i, got[i].Name, want[i].Name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Replaces `prepareToolTurn`'s per-turn process-global spawner/manager swap-and-restore (added in #1131 to fix `sub_agent`/`workflow` not being advertised in server/cron sessions) with a ctx-aware advertisement path, per the issue's acceptance criteria: server/cron turns advertise both tools without writing to `tools.SetSpawner`/`tools.SetDefaultSubAgentManager`, and CLI/TUI paths are unchanged.

**`tools.DefaultToolsForCtx(ctx, model)`** is `DefaultToolsFor`, but also advertises `sub_agent*`/`workflow*` when `ctx` carries a per-turn `SubAgentManager` (`tools.WithSubAgentManager`) — which every server/cron turn already stamps into its ctx — even when no process-global spawner/manager is registered. `DefaultToolsFor(model)` is now a thin wrapper (`context.Background()`); CLI/TUI callers, which never carry a ctx-scoped manager, see identical behavior.

**`prepareToolTurn`** no longer calls `tools.SetSpawner`/`tools.SetDefaultSubAgentManager`, and `cleanup()` no longer restores them — it never wrote them in the first place now. The workflow tool's `Definition()` still needs the separate `ActiveWorkflowDiscoveryCWD` process-global swap (a different concern — it has no ctx to read `a.CWD` from), which is unchanged.

The 4 server/cron call sites that build a turn's tool list right after `prepareToolTurn` (REST `handlers.go`, SSE, WS, cron `tasks_handlers.go`) now call `DefaultToolsForCtx` with the ctx `prepareToolTurn` returned, instead of the ctx-blind `DefaultToolsFor`.

**A regression this refactor would otherwise introduce, caught in self-review**: `app.Spawner`'s `toolsFn` callback (used to list a *child's* available tools when a sub-agent itself spawns further children) previously called the ctx-blind `DefaultToolsFor`, relying on the process-global slots `prepareToolTurn` used to install. Removing that install would have silently stopped advertising `sub_agent`/`workflow` to spawned children's own tool lists. Fixed by threading the real ctx (`Spawn` already receives one) through `toolsFn`'s signature, so it can call `DefaultToolsForCtx` correctly. This touches all `NewSpawner` call sites (CLI `bootstrap.go`, `server.go`'s startup sentinel and IM per-message spawner, and `prepareToolTurn`'s `mkSpawner`) and their ~20 test call sites — mechanical signature updates, no behavior change for CLI/the startup sentinel (both still resolve through the process-global fallback, since neither has a ctx-scoped manager in their own call paths).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `go test -race ./...` (full suite green)
- [x] `TestPrepareToolTurn_AdvertisesSubAgentAndWorkflow` now asserts via `DefaultToolsForCtx` and additionally asserts the process-global spawner/manager slots are never written — the acceptance criterion this issue is about
- [x] `TestPrepareToolTurn_CleanupRestoresGlobalSpawner` (encoded the old swap-and-restore contract, now obsolete — it was passing for the wrong reason once the swap was removed) replaced by `TestPrepareToolTurn_DoesNotTouchGlobalSpawner`, which pre-seeds sentinel global values and asserts `prepareToolTurn`/`cleanup` never touch them
- [x] New `internal/tools/registry_sync_test.go` coverage for `DefaultToolsForCtx` directly: a ctx-scoped manager alone (verified-empty globals) advertises both tools; a ctx with no scoped manager falls back to the empty global gate (ctx-awareness doesn't leak into unrelated ctx); a ctx-scoped manager with a nil spawner advertises `sub_agent` but withholds `workflow`; `DefaultToolsFor(model) == DefaultToolsForCtx(background, model)`
- [x] Existing `TestSyncModeAdvertisesSubAgent`/`TestAsyncModeAdvertisesSubAgent` (CLI's global-gate path) still pass unchanged