### PR TITLE
fix(im): add reload before skill check, reserved commands guard (#1177 followup)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2249,11 +2249,19 @@ func (s *Server) handleChannelCommand(ad channel.Adapter, ev channel.InboundEven
 		s.handleChannelCompact(ad, ev)
 		return true
 	}
-	// Unknown slash tokens that match a skill name are passed through as
-	// normal user messages, same as the Web and TUI surfaces.
-	skillName := strings.TrimPrefix(cmd, "/")
-	if _, ok := s.skillReg.Get(skillName); ok {
-		return false
+	// Reserved commands must not be intercepted by a skill (matching
+	// the TUI reservedReplCommands pattern).
+	switch cmd {
+	case "/stop", "/bind", "/unbind", "/clear", "/new", "/status", "/list", "/help", "/goal", "/compact":
+		// fall through to CommandRouter
+	default:
+		// Unknown slash tokens that match a skill name are passed through as
+		// normal user messages, same as the Web and TUI surfaces.
+		skillName := strings.TrimPrefix(cmd, "/")
+		s.skillReg.Reload()
+		if _, ok := s.skillReg.Get(skillName); ok {
+			return false
+		}
 	}
 	if reply := s.channelMgr.CommandRouter(ev); reply != "" {
 		ad.SendText(ev.ChatID, reply, ev.MessageID)


### PR DESCRIPTION
## Problem

Two issues found during post-merge review of #1177:

### 1. No Reload before skill Get
Skills added to disk mid-server-start are invisible to IM until restart. The TUI calls `reg.Reload()` on miss before giving up; IM should match.

### 2. No reserved-command guard
A skill coincidentally named `stop` would intercept the interrupt command — the `/stop` handler cancels the wakeup but then falls through to the skill check. The TUI has a `reservedReplCommands` guard; IM now has the same: a `switch` before the skill check that lists all known commands (`/stop`, `/bind`, `/unbind`, `/clear`, `/new`, `/status`, `/list`, `/help`, `/goal`, `/compact`). Only truly unknown slash tokens reach the skill registry.

## Changes
Single file: `internal/server/server.go` — +13/-5 lines.

## Testing
- `go build ./internal/server/...` ✅
- `gofmt -d internal/server/server.go` ✅ (no diffs)
- `go test ./internal/server/... -run TestRouteChannel` ✅