### PR TITLE
tools,server: fix IM channel not advertising workflow, stale comments (#1133)

### DIFF
--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -446,6 +446,43 @@ func TestHandleChannelMessage_RecoversWhenSessionFileDeletedExternally(t *testin
 	}
 }
 
+// TestHandleChannelMessage_AdvertisesWorkflowToTopLevelTurn (#1133 follow-up):
+// runChannelTurns used to compute the top-level turn's tool list before
+// stamping the ctx-scoped sub-agent manager that carries its spawner, so
+// tools.DefaultToolsForCtx saw no manager yet for that call — the IM
+// channel's own turn never advertised workflow (only its spawned children
+// did, via their own ctx-threaded toolsFn), even though the IM path never
+// depended on prepareToolTurn's removed global swap in the first place (it
+// doesn't call prepareToolTurn at all — it builds its own sub-agent manager
+// inline).
+func TestHandleChannelMessage_AdvertisesWorkflowToTopLevelTurn(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	rec := &recordingSender{}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+		return agent.New(rec, "stub-model")
+	}, channel.BindByChat)
+
+	ad := &fullFakeAdapter{}
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+
+	waitFor(t, func() bool { return len(rec.lastTools) > 0 })
+
+	found := false
+	for _, d := range rec.lastTools {
+		if d.Name == "workflow" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("workflow not advertised to top-level IM turn; got %v", rec.lastTools)
+	}
+}
+
 // TestHandleChannelMessage_BackgroundCompletionTriggersIdleTurn: when an
 // async background process finishes after the synchronous turn chain has
 // ended, the completion note is drained into a follow-up idle turn so the

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -788,10 +788,14 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 // async sub-agent result — and each turn gets a private store, so concurrent
 // sessions never share sub-agent or task state.
 //
-// It also temporarily installs the turn's spawner / sub-agent manager into the
-// process-global slots so that tools.DefaultToolsFor() advertises the sub_agent
-// and workflow tools to the model for this turn. The returned cleanup restores
-// the previous global values and must be deferred by the caller.
+// Callers must build this turn's tool list with tools.DefaultToolsForCtx(ctx,
+// ...) — using the ctx returned here — rather than the ctx-blind
+// tools.DefaultToolsFor, so sub_agent/workflow are advertised off the
+// ctx-scoped manager just stamped in above (#1133). prepareToolTurn no longer
+// touches the process-global spawner/sub-agent-manager slots at all; the
+// returned cleanup only restores the separate ActiveWorkflowDiscoveryCWD swap
+// (see its doc comment — a different concern, since WorkflowTool.Definition()
+// has no ctx to read a.CWD from).
 func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agent.Session) (context.Context, agent.ToolExecutor, *tools.SubAgentManager, func(), error) {
 	executor := tools.NewDefaultRegistry()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2558,15 +2558,16 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	var executor agent.ToolExecutor
 	if s.cfg.Tools {
 		executor = tools.NewDefaultRegistry()
-		toolDefs = tools.DefaultToolsFor(sess.Agent.Model)
-		if !goalsOn {
-			// Advertising a tool this turn can't execute is the #597 class.
-			toolDefs = tools.WithoutGoalTools(toolDefs)
-		}
 
 		// Per-message sub-agent manager bound to THIS chat's agent —
 		// synchronous, since a chat message is request/response with no
-		// follow-up channel for an async result.
+		// follow-up channel for an async result. Stamped into ctx BEFORE
+		// toolDefs is computed below (#1133 follow-up) — the process-global
+		// spawner slot is never set in server mode (only
+		// SetDefaultSubAgentManager is, in enableSubAgentTools), so without
+		// this ordering the top-level turn's own toolDefs would never
+		// advertise workflow, even though this chat's spawned children (via
+		// this spawner's own toolsFn) correctly would.
 		spawner := app.NewSpawner(sess.Agent, executor, func(ctx context.Context) []agent.ToolDefinition {
 			if goalsOn {
 				return tools.DefaultToolsForCtx(ctx, sess.Agent.Model)
@@ -2576,6 +2577,13 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		subMgr := tools.NewSubAgentManager(spawner)
 		subMgr.SetSynchronous(true)
 		ctx = tools.WithSubAgentManager(ctx, subMgr)
+
+		toolDefs = tools.DefaultToolsForCtx(ctx, sess.Agent.Model)
+		if !goalsOn {
+			// Advertising a tool this turn can't execute is the #597 class.
+			toolDefs = tools.WithoutGoalTools(toolDefs)
+		}
+
 		// The task store lives on the session, so the task list persists
 		// across messages in this chat.
 		ctx = tools.WithTaskStore(ctx, sess.Tasks)

--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -35,19 +35,20 @@ func SetWorkflowForeground(v bool) { workflowForeground.Store(v) }
 // agent.ToolDefinition's Definition() method takes no context — there is no
 // way for it to see a specific turn's WithWorkingDir value directly — so
 // prepareToolTurn (regular sessions) and the scheduled-task runner (cron
-// tasks) stamp this process-global right before building tool definitions
-// for their turn, mirroring the existing SetSpawner/SetDefaultSubAgentManager
-// save-and-restore pattern in prepareToolTurn. Empty (the zero value) falls
-// back to the process CWD, matching every caller that never sets it (CLI,
-// tests).
+// tasks) stamp this process-global right before building tool definitions for
+// their turn, restoring the previous value once the turn ends (see
+// SetWorkflowDiscoveryCWD). This is the one process-global swap-and-restore
+// prepareToolTurn still does — sub_agent/workflow advertisement itself moved
+// to the ctx-aware DefaultToolsForCtx and no longer needs one (#1133). Empty
+// (the zero value) falls back to the process CWD, matching every caller that
+// never sets it (CLI, tests).
 var workflowDiscoveryCWD atomic.Value // string
 
 // SetWorkflowDiscoveryCWD records the directory the next Definition()-driven
 // workflow listing (the `workflow` tool's `name` parameter description, and
 // ListNamedWorkflows for the web panel) should resolve project-level
 // workflows from. Callers should restore the previous value (via
-// ActiveWorkflowDiscoveryCWD, read before overwriting) once their turn ends,
-// the same way prepareToolTurn restores the spawner/sub-agent-manager globals.
+// ActiveWorkflowDiscoveryCWD, read before overwriting) once their turn ends.
 func SetWorkflowDiscoveryCWD(cwd string) { workflowDiscoveryCWD.Store(cwd) }
 
 // ActiveWorkflowDiscoveryCWD returns the cwd most recently set by


### PR DESCRIPTION
## Summary

Follow-up from an independent code review of #1179 (issue #1133's ctx-aware tool advertisement refactor). I ran a dedicated review subagent against the merged diff and verified each of its findings before fixing anything.

**Important — IM channel turn never advertised `workflow`:** `internal/server/server.go`'s `runChannelTurns` computed the top-level turn's `toolDefs` via `DefaultToolsFor` *before* stamping the ctx-scoped sub-agent manager into `ctx`, so `DefaultToolsForCtx` saw no manager for that call. This isn't a regression from #1179's global-swap removal — the IM path never goes through `prepareToolTurn` at all, so it never depended on that swap — but #1179 made an existing asymmetry worse: the chat's spawned children (via their own ctx-threaded `toolsFn`) now correctly see `workflow`, while the top-level turn that owns them still didn't, despite the IM path explicitly wiring a per-chat `WithWorkflowManager`. Fixed by stamping `WithSubAgentManager` before computing `toolDefs`, matching the order every other transport (REST/SSE/WS/cron) already uses.

**Minor — two stale comments** left over from #1179: `prepareToolTurn`'s doc comment in `handlers.go` still described the removed "temporarily installs into process-global slots" behavior; `workflow.go`'s `ActiveWorkflowDiscoveryCWD` comments cited the removed `SetSpawner`/`SetDefaultSubAgentManager` pattern as a live precedent. Both reworded to describe the current state.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `go test -race ./...` (full suite green)
- [x] New `TestHandleChannelMessage_AdvertisesWorkflowToTopLevelTurn` — verified it actually fails against the old ordering (temporarily reverted the fix, confirmed the test catches it) before restoring the fix