### PR TITLE
chore: bump version to 1.7.7

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.7.6"
+var Version = "1.7.7"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Bumps `internal/version.Version` 1.7.6 → 1.7.7 ahead of cutting a release. 32 commits landed since v1.7.6 (Telegram HTML markdown rendering, Feishu/Weixin/WeCom table & image fixes, session-recreate-on-delete fix, web history/subscribe race fix, TUI panel overflow fixes, ctx-aware tool advertisement refactor, IM polish batches, and more).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/version/...`