### PR TITLE
fix(tools): anchor glob's walk to the pattern's literal path prefix

### DIFF
--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -97,7 +97,27 @@ func (GlobTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 		candidate := filepath.Join(absRoot, prefix)
 		switch _, statErr := os.Stat(candidate); {
 		case statErr == nil:
-			scanRoot = candidate
+			// os.Stat resolves case-insensitively on the filesystems most
+			// developers actually run this on (macOS APFS, Windows NTFS,
+			// both case-insensitive by default) — so a pattern whose
+			// casing doesn't match what's on disk (e.g. "Internal/*.go"
+			// against a real "internal/") would otherwise get pruned to
+			// that wrong-case candidate anyway, and rg would then report
+			// matches under the wrong-case path. glob's matching is
+			// documented as path.Match semantics, i.e. case-sensitive —
+			// on a case-sensitive filesystem (Linux) that mismatch would
+			// already fail the stat and never reach here, so only trust
+			// the prune once we've confirmed the same case-sensitive
+			// result by checking each segment's on-disk name byte-for-byte.
+			if onDiskCaseMatches(absRoot, prefix) {
+				scanRoot = candidate
+			}
+			// else: leave scanRoot as absRoot — the prune target only
+			// exists via a case-insensitive lookup, so pruning to it would
+			// make this pattern match when it shouldn't. Falling back to
+			// the unpruned walk keeps the pre-existing case-sensitive
+			// matching behavior; globMatch (still case-sensitive) will
+			// correctly find nothing.
 		case os.IsNotExist(statErr):
 			// The literal prefix doesn't exist on disk, so no file can
 			// possibly match — skip the rg subprocess and the walk
@@ -204,16 +224,60 @@ func (GlobTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 // "internal/tools/**/*.go" yields "internal/tools". Returns "" when the
 // pattern has no literal prefix (e.g. "**/*.go", "*.go"), in which case no
 // pruning is possible and the full root must be walked.
+//
+// A ".." segment stops collection (and is not itself included): unlike an
+// ordinary literal segment it doesn't name a real path component to anchor
+// on, it navigates to the parent directory. Treating it as literal would
+// let filepath.Join walk the prefix outside the caller's search root — no
+// on-disk path can ever contain a literal ".." segment, so a pattern like
+// "../sibling/*.go" can never actually match anything (a leftover ".."
+// segment always fails path.Match against a real path component), and
+// stopping here just preserves that: it neither prunes nor matches, same
+// as before this optimization existed. Empty segments (a leading "/") and
+// "." are skipped rather than stopping collection, since neither changes
+// which directory the rest of the prefix resolves to.
 func literalPathPrefix(pattern string) string {
 	segs := strings.Split(filepath.ToSlash(pattern), "/")
 	var lit []string
 	for _, seg := range segs {
-		if strings.ContainsAny(seg, "*?[") {
+		if seg == "" || seg == "." {
+			continue
+		}
+		if seg == ".." || strings.ContainsAny(seg, "*?[") {
 			break
 		}
 		lit = append(lit, seg)
 	}
 	return strings.Join(lit, "/")
+}
+
+// onDiskCaseMatches reports whether every segment of prefix (a "/"-joined
+// relative path, as returned by literalPathPrefix) matches the real on-disk
+// entry name byte-for-byte, walking down from base. It exists because
+// os.Stat alone can't tell a case-correct path from a case-mismatched one
+// on case-insensitive filesystems — this reads each directory's entries
+// and compares names directly, which is unaffected by filesystem case
+// folding.
+func onDiskCaseMatches(base, prefix string) bool {
+	dir := base
+	for _, seg := range strings.Split(prefix, "/") {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return false
+		}
+		found := false
+		for _, e := range entries {
+			if e.Name() == seg {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+		dir = filepath.Join(dir, seg)
+	}
+	return true
 }
 
 // listProjectFiles enumerates every file under root that ripgrep would search,

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -85,7 +85,38 @@ func (GlobTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 		return agent.ToolResult{Text: ""}, err
 	}
 
-	files, warning, err := listProjectFiles(ctx, absRoot)
+	// Anchor the walk to the pattern's literal (non-wildcard) leading path
+	// segments when it has any — e.g. "internal/tools/**/*.go" can only
+	// match under "internal/tools", so there's no reason to hand ripgrep
+	// the whole repo root and filter everything else out afterward. This
+	// is the difference between listing one subtree and listing the entire
+	// project on every single glob call, regardless of how specific the
+	// pattern is.
+	scanRoot := absRoot
+	if prefix := literalPathPrefix(pattern); prefix != "" {
+		candidate := filepath.Join(absRoot, prefix)
+		switch _, statErr := os.Stat(candidate); {
+		case statErr == nil:
+			scanRoot = candidate
+		case os.IsNotExist(statErr):
+			// The literal prefix doesn't exist on disk, so no file can
+			// possibly match — skip the rg subprocess and the walk
+			// entirely instead of confirming "nothing matched" the slow way.
+			text := fmt.Sprintf("(no matches for %q under %s)", pattern, absRoot)
+			return agent.ToolResult{Text: text, UI: map[string]any{
+				"type":    "file_list",
+				"path":    absRoot,
+				"entries": []map[string]any{},
+				"total":   0,
+			}}, nil
+		default:
+			// Ambiguous error (e.g. permission denied on an ancestor dir) —
+			// fall back to the unpruned walk rather than risk a false
+			// "no matches".
+		}
+	}
+
+	files, warning, err := listProjectFiles(ctx, scanRoot)
 	if err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("glob: %w", err)
 	}
@@ -164,6 +195,25 @@ func (GlobTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 		fmt.Fprintf(&out, "\n[warning: %s]\n", warning)
 	}
 	return agent.ToolResult{Text: out.String(), UI: ui}, nil
+}
+
+// literalPathPrefix returns the leading path segments of pattern that
+// contain no glob metacharacters, joined with "/". Every match for pattern
+// must live under this prefix, so callers use it to anchor the filesystem
+// walk to a subtree instead of the whole search root — e.g.
+// "internal/tools/**/*.go" yields "internal/tools". Returns "" when the
+// pattern has no literal prefix (e.g. "**/*.go", "*.go"), in which case no
+// pruning is possible and the full root must be walked.
+func literalPathPrefix(pattern string) string {
+	segs := strings.Split(filepath.ToSlash(pattern), "/")
+	var lit []string
+	for _, seg := range segs {
+		if strings.ContainsAny(seg, "*?[") {
+			break
+		}
+		lit = append(lit, seg)
+	}
+	return strings.Join(lit, "/")
 }
 
 // listProjectFiles enumerates every file under root that ripgrep would search,

--- a/internal/tools/glob_test.go
+++ b/internal/tools/glob_test.go
@@ -197,8 +197,8 @@ func TestLiteralPathPrefix(t *testing.T) {
 		{"**/*.go", ""},
 		{"*.go", ""},
 		{"src/*/foo.go", "src"},
-		{"../sibling/*.go", ""},        // ".." must never anchor outside the search root
-		{"foo/../bar/*.go", "foo"},     // stops at ".." rather than treating it as literal
+		{"../sibling/*.go", ""},                    // ".." must never anchor outside the search root
+		{"foo/../bar/*.go", "foo"},                 // stops at ".." rather than treating it as literal
 		{"/internal/tools/*.go", "internal/tools"}, // leading "/" doesn't shift the prefix
 		{"./internal/tools/*.go", "internal/tools"},
 	}

--- a/internal/tools/glob_test.go
+++ b/internal/tools/glob_test.go
@@ -197,6 +197,10 @@ func TestLiteralPathPrefix(t *testing.T) {
 		{"**/*.go", ""},
 		{"*.go", ""},
 		{"src/*/foo.go", "src"},
+		{"../sibling/*.go", ""},        // ".." must never anchor outside the search root
+		{"foo/../bar/*.go", "foo"},     // stops at ".." rather than treating it as literal
+		{"/internal/tools/*.go", "internal/tools"}, // leading "/" doesn't shift the prefix
+		{"./internal/tools/*.go", "internal/tools"},
 	}
 	for _, c := range cases {
 		if got := literalPathPrefix(c.pattern); got != c.want {
@@ -242,6 +246,67 @@ func TestGlob_PrunesToLiteralPrefix(t *testing.T) {
 	// "unreadable/" — no warning should surface.
 	if strings.Contains(out.Text, "[warning:") {
 		t.Errorf("pruned walk should not have visited the unreadable sibling dir:\n%s", out.Text)
+	}
+}
+
+// TestGlob_DotDotPatternNeverEscapesRoot is a regression test: an earlier
+// version of the pruning logic treated ".." as an ordinary literal path
+// segment, so a pattern like "../sibling/*.go" would get pruned to
+// filepath.Join(root, "../sibling") — a directory outside root — and
+// ripgrep would then walk and return files from there. Before pruning
+// existed at all, this pattern could never match anything (no real path
+// component is literally ".."), so the correct, safe behavior is "no
+// matches", not "leak the parent/sibling directory's contents".
+func TestGlob_DotDotPatternNeverEscapesRoot(t *testing.T) {
+	requireRg(t)
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	sibling := filepath.Join(base, "sibling")
+	writeTestFile(t, filepath.Join(root, "ok.go"), "")
+	writeTestFile(t, filepath.Join(sibling, "secret.go"), "")
+
+	out, err := GlobTool{}.Execute(context.Background(), "glob", map[string]any{
+		"pattern": "../sibling/*.go",
+		"path":    root,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(out.Text, "secret.go") {
+		t.Errorf("pattern with \"..\" must never match outside the search root:\n%s", out.Text)
+	}
+	if !strings.Contains(out.Text, "no matches") {
+		t.Errorf("expected 'no matches', got:\n%s", out.Text)
+	}
+}
+
+// TestGlob_CaseMismatchedPrefixDoesNotMatch is a regression test: os.Stat
+// resolves case-insensitively on the filesystems most developers actually
+// run this on (macOS APFS, Windows NTFS default), so an earlier version of
+// the pruning logic trusted a case-mismatched literal prefix (e.g.
+// "Readable/*.go" against a real "readable/") and pruned to it — silently
+// turning a case-sensitive glob into a case-insensitive one, and reporting
+// matches under a path whose casing doesn't exist on disk. On a
+// case-sensitive filesystem (Linux) this bug can't reproduce since the
+// os.Stat itself would fail — this test only exercises the code path, not
+// the specific filesystem-dependent symptom.
+func TestGlob_CaseMismatchedPrefixDoesNotMatch(t *testing.T) {
+	requireRg(t)
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "readable", "ok.go"), "")
+
+	out, err := GlobTool{}.Execute(context.Background(), "glob", map[string]any{
+		"pattern": "Readable/*.go",
+		"path":    dir,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(out.Text, "ok.go") {
+		t.Errorf("case-mismatched pattern must not match (glob is case-sensitive):\n%s", out.Text)
+	}
+	if !strings.Contains(out.Text, "no matches") {
+		t.Errorf("expected 'no matches', got:\n%s", out.Text)
 	}
 }
 

--- a/internal/tools/glob_test.go
+++ b/internal/tools/glob_test.go
@@ -186,6 +186,110 @@ func TestGlob_FileRoot(t *testing.T) {
 	}
 }
 
+func TestLiteralPathPrefix(t *testing.T) {
+	cases := []struct {
+		pattern string
+		want    string
+	}{
+		{"internal/tools/**/*.go", "internal/tools"},
+		{"cmd/octo/config.go", "cmd/octo/config.go"}, // fully literal, no wildcard at all
+		{"src/**/*.ts", "src"},
+		{"**/*.go", ""},
+		{"*.go", ""},
+		{"src/*/foo.go", "src"},
+	}
+	for _, c := range cases {
+		if got := literalPathPrefix(c.pattern); got != c.want {
+			t.Errorf("literalPathPrefix(%q) = %q, want %q", c.pattern, got, c.want)
+		}
+	}
+}
+
+// TestGlob_PrunesToLiteralPrefix verifies a pattern anchored under a literal
+// directory prefix never walks into an unrelated, unreadable sibling
+// directory. Before the pruning fix, glob always walked the whole root
+// (ripgrep has no reason to skip a dir it wasn't told to avoid), so the
+// unreadable sibling would trip the "partial results" warning even though
+// the pattern couldn't possibly match anything under it.
+func TestGlob_PrunesToLiteralPrefix(t *testing.T) {
+	requireRg(t)
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "readable", "ok.go"), "")
+	writeTestFile(t, filepath.Join(dir, "unreadable", "secret.go"), "")
+
+	unreadable := filepath.Join(dir, "unreadable")
+	if err := os.Chmod(unreadable, 0o000); err != nil {
+		t.Fatalf("chmod unreadable: %v", err)
+	}
+	defer os.Chmod(unreadable, 0o755)
+
+	if f, err := os.Open(unreadable); err == nil {
+		f.Close()
+		t.Skip("chmod 000 did not prevent directory listing; skipping permission test")
+	}
+
+	out, err := GlobTool{}.Execute(context.Background(), "glob", map[string]any{
+		"pattern": "readable/*.go",
+		"path":    dir,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.Text, "ok.go") {
+		t.Errorf("expected ok.go in output:\n%s", out.Text)
+	}
+	// The pattern is anchored to "readable/", so the walk should never touch
+	// "unreadable/" — no warning should surface.
+	if strings.Contains(out.Text, "[warning:") {
+		t.Errorf("pruned walk should not have visited the unreadable sibling dir:\n%s", out.Text)
+	}
+}
+
+// TestGlob_LiteralPrefixMissingSkipsWalk verifies that when the pattern's
+// literal prefix doesn't exist on disk, glob returns "no matches" without
+// invoking ripgrep at all. It deliberately does not call requireRg — if this
+// regresses to calling rg anyway, the test still passes as long as rg is
+// present, so the meaningful signal is that this test never needs it.
+func TestGlob_LiteralPrefixMissingSkipsWalk(t *testing.T) {
+	dir := t.TempDir()
+
+	out, err := GlobTool{}.Execute(context.Background(), "glob", map[string]any{
+		"pattern": "does-not-exist/*.go",
+		"path":    dir,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.Text, "no matches") {
+		t.Errorf("expected 'no matches' message: %q", out.Text)
+	}
+}
+
+// TestGlob_FullyLiteralPatternMatchesSingleFile exercises the fast path
+// where the entire pattern is a literal path (no wildcard characters at
+// all): literalPathPrefix returns the whole pattern, which resolves
+// straight to a single file instead of a directory to walk.
+func TestGlob_FullyLiteralPatternMatchesSingleFile(t *testing.T) {
+	requireRg(t)
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "pkg", "single.go"), "")
+	writeTestFile(t, filepath.Join(dir, "pkg", "other.go"), "")
+
+	out, err := GlobTool{}.Execute(context.Background(), "glob", map[string]any{
+		"pattern": "pkg/single.go",
+		"path":    dir,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.Text, "single.go") {
+		t.Errorf("expected single.go in output:\n%s", out.Text)
+	}
+	if strings.Contains(out.Text, "other.go") {
+		t.Errorf("other.go should not match a fully literal pattern:\n%s", out.Text)
+	}
+}
+
 func TestGlob_UnreadableSubdirReturnsPartialResults(t *testing.T) {
 	requireRg(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- `glob`'s file enumeration always walked the entire search root via `rg --files` before filtering matches in Go, so every call cost the same full-tree scan regardless of how specific the pattern was (e.g. `cmd/octo/config.go` cost the same as `**/*`). `grep` already hands its `include` glob to ripgrep's native `--glob` pruning; `glob` never did the equivalent.
- Added `literalPathPrefix(pattern)` to extract the pattern's leading non-wildcard path segments (e.g. `internal/tools` from `internal/tools/**/*.go`) and anchor the walk there instead of the whole root. A fully literal pattern with no wildcards resolves straight to a single file (O(1) via the existing non-directory-root path in `listProjectFiles`).
- When the literal prefix doesn't exist on disk at all, skip the `rg` subprocess entirely and return "no matches" directly.
- Sorting/truncation (stat + mtime sort before capping to 200) is unchanged — that's required for correct recency ranking, not part of the bug.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/tools/...` (all existing `TestGlob_*` pass unchanged)
- [x] New: `TestLiteralPathPrefix` — table test of the prefix-extraction helper
- [x] New: `TestGlob_PrunesToLiteralPrefix` — pattern anchored to one subdir + an unreadable sibling dir asserts no `[warning:` surfaces, proving the walk never touched the sibling (would have before this fix)
- [x] New: `TestGlob_LiteralPrefixMissingSkipsWalk` — nonexistent literal prefix returns "no matches" without needing `rg` on PATH at all
- [x] New: `TestGlob_FullyLiteralPatternMatchesSingleFile` — fully literal pattern matches exactly one file, not siblings