### PR TITLE
chore: bump version to 1.7.8

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.7.7"
+var Version = "1.7.8"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Routine patch bump to release the fixes merged since v1.7.7: the `ask_user_question` modal spacing/width fix (#1090) and the glob-tool literal-prefix pruning fix + traversal/case-mismatch hardening (#1185).

## Test plan
- [x] `go build ./...`