### PR TITLE
fix(packaging): use relative install-location for macOS per-user pkg

### DIFF
--- a/.github/workflows/macos-installer-check.yml
+++ b/.github/workflows/macos-installer-check.yml
@@ -64,6 +64,18 @@ jobs:
           test -x expanded/octo-component.pkg/Scripts/postinstall
           test -x expanded/octo-component.pkg/Payload/bin/octo
 
+      - name: Verify the package installs under the user's real home directory
+        run: |
+          install_loc=$(sed -n 's/.*install-location="\([^"]*\)".*/\1/p' expanded/octo-component.pkg/PackageInfo)
+          echo "install-location: $install_loc"
+          [ "$install_loc" = "Library/Application Support/octo" ] || { echo "expected install-location 'Library/Application Support/octo', got: $install_loc"; exit 1; }
+          case "$install_loc" in
+            *~*)
+              echo "install-location must not contain a literal '~': $install_loc"
+              exit 1
+              ;;
+          esac
+
       - name: Run preinstall + postinstall against a scratch HOME
         run: |
           fake="$RUNNER_TEMP/fake-home"

--- a/packaging/macos/build.sh
+++ b/packaging/macos/build.sh
@@ -44,12 +44,17 @@ for tool in uv; do
   fi
 done
 
+# The distribution is currentUserHome-only, so the target volume is the
+# installing user's home directory. --install-location must be a path relative
+# to that volume; pkgbuild does NOT expand '~', so a literal '~/Library...'
+# would create a directory named '~' instead of installing into the user's
+# real Library folder.
 pkgbuild \
   --root "$payload" \
   --scripts "$script_dir/scripts" \
   --identifier dev.octo-agent.octo \
   --version "$AppVersion" \
-  --install-location '~/Library/Application Support/octo' \
+  --install-location 'Library/Application Support/octo' \
   "$work/octo-component.pkg"
 
 distribution="$work/distribution.xml"


### PR DESCRIPTION
Fixes open-octo/octo-agent#1127.

pkgbuild's --install-location does not expand '~'; with currentUserHome-only distribution, the correct path must be relative to the user's home volume. The previous '~/Library/...' value caused files to be extracted into a literal 'Users/<user>/~/Library/...' directory instead of the intended user home.

Changes:
- Use a relative --install-location 'Library/Application Support/octo'.
- Add a CI assertion in macos-installer-check.yml to guard against a literal '~' in PackageInfo.