### PR TITLE
fix(server): clearer error when working_dir doesn't exist

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1442,6 +1442,10 @@ func (s *Server) handleUpdateSessionWorkingDir(w http.ResponseWriter, r *http.Re
 
 	dir := expandDir(req.WorkingDir)
 	info, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("working_dir does not exist: %s (create it first)", dir))
+		return
+	}
 	if err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid working_dir: %v", err))
 		return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1377,6 +1378,40 @@ func TestHandleUpdateSessionWorkingDir(t *testing.T) {
 	}
 	if srv.cwd == tmp {
 		t.Fatalf("server cwd = %q, should not equal the per-session dir", srv.cwd)
+	}
+}
+
+func TestHandleUpdateSessionWorkingDir_NotExist(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	missing := filepath.Join(tmp, "does-not-exist")
+	payload, _ := json.Marshal(updateSessionWorkingDirRequest{WorkingDir: missing})
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/"+sess.ID+"/working_dir", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	// The error should tell the user the dir doesn't exist and to create it
+	// first (#1073), not surface a raw os.Stat error string.
+	want := fmt.Sprintf("working_dir does not exist: %s (create it first)", missing)
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["error"] != want {
+		t.Fatalf("error = %q, want %q", body["error"], want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `PATCH /api/sessions/{id}/working_dir` requires the target directory to already exist (by design — see the handler's doc comment), but on failure it surfaced the raw `os.Stat` error verbatim: `invalid working_dir: stat /path: no such file or directory`. The frontend toasts this message as-is, giving the user no actionable hint.
- Detect the not-exist case specifically and return a clearer message: `working_dir does not exist: <path> (create it first)`. Other `os.Stat` failures (e.g. permission denied) keep the existing generic message.
- No behavior change — same validation, same 400 status, just a clearer message. (Explicitly scoped this way rather than auto-`mkdir`, to avoid the server silently creating directories anywhere on disk from user-typed paths.)

## Root cause
Reported in #1073 ("设置文件目录，接口报错") with a screenshot showing exactly this error after typing a working dir that didn't exist on the reporter's machine. The reporter never replied to repro-info requests, but the screenshot itself shows the raw stat error is genuinely confusing UX.

Fixes #1073

## Test plan
- [x] Added `TestHandleUpdateSessionWorkingDir_NotExist` asserting the new message on a missing directory
- [x] `go test ./internal/server/...`
- [x] `gofmt -l .` / `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)