### PR TITLE
test(tools): fix flaky onExit hook timeout on Windows CI

### DIFF
--- a/internal/tools/background_onexit_test.go
+++ b/internal/tools/background_onexit_test.go
@@ -1,10 +1,22 @@
 package tools
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 )
+
+// hookTimeout bounds how long a test waits for the onExit hook to fire.
+// Windows CI runners spawn PowerShell per command (see shellCommand in
+// sandbox.go), which is far slower to start than POSIX sh -c — the same
+// reason waitFor in background_test.go extends its own limit on Windows.
+func hookTimeout() time.Duration {
+	if runtime.GOOS == "windows" {
+		return 45 * time.Second
+	}
+	return 3 * time.Second
+}
 
 // TestBackgroundManager_OnExitHookFires verifies the completion hook fires once
 // with the final status and the still-unread output, and that consuming it via
@@ -30,8 +42,8 @@ func TestBackgroundManager_OnExitHookFires(t *testing.T) {
 	var got BgExit
 	select {
 	case got = <-fired:
-	case <-time.After(3 * time.Second):
-		t.Fatal("onExit hook did not fire within 3s")
+	case <-time.After(hookTimeout()):
+		t.Fatal("onExit hook did not fire in time")
 	}
 
 	if got.ID != id {
@@ -140,8 +152,8 @@ func TestBackgroundManager_OnExitFiresAfterPromote(t *testing.T) {
 	var got BgExit
 	select {
 	case got = <-fired:
-	case <-time.After(3 * time.Second):
-		t.Fatal("onExit hook did not fire after Promote within 3s")
+	case <-time.After(hookTimeout()):
+		t.Fatal("onExit hook did not fire after Promote in time")
 	}
 
 	if got.ID != id {


### PR DESCRIPTION
## Summary
- `TestBackgroundManager_OnExitHookFires` and `TestBackgroundManager_OnExitFiresAfterPromote` waited a flat 3s for the completion hook to fire after starting a background process.
- On Windows, every command spawns a fresh PowerShell process (`shellCommand` in `internal/tools/sandbox.go`), which is significantly slower to start than POSIX `sh -c` — especially under a loaded/shared CI runner. `waitFor` in `background_test.go` already extends its own polling limit to 45s on Windows for exactly this reason; these two hardcoded `time.After(3 * time.Second)` selects didn't get the same treatment.
- Added a `hookTimeout()` helper (3s normally, 45s on Windows) and used it in both places. No behavior change on macOS/Linux.

## Root cause
Windows CI job on #1189 failed with `onExit hook did not fire within 3s` in `TestBackgroundManager_OnExitHookFires` — unrelated to that PR's actual change (`internal/server`, which passed). Confirmed this is a timing/environment issue, not a product bug: the same class of Windows PowerShell-startup slowness is already worked around elsewhere in this same test file's sibling helper.

## Test plan
- [x] `go test ./internal/tools/... -race` passes locally (macOS)
- [x] `gofmt -l .` / `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)