### PR TITLE
fix(im): interactive ask UX — rune-safe truncation + native buttons (Telegram/Discord/Feishu)

### DIFF
--- a/internal/channel/adapter.go
+++ b/internal/channel/adapter.go
@@ -37,6 +37,11 @@ type InboundEvent struct {
 	// echoing this on every outbound message).
 	ContextToken string
 
+	// ButtonID is set when the event originates from a button press rather
+	// than a plain-text message. The value matches the ID field of the Button
+	// that was pressed. Empty for ordinary messages.
+	ButtonID string
+
 	// Raw is the platform-native payload, kept for adapter-internal use.
 	Raw any
 }
@@ -57,6 +62,17 @@ type FileAttachment struct {
 
 	// DataURL is a base64 data URL (for inline images sent to vision models).
 	DataURL string
+}
+
+// Button describes one clickable button in an interactive ask prompt.
+// Platforms that support native buttons (Telegram inline keyboards, Discord
+// components, Feishu interactive cards) render these as tappable controls;
+// other platforms fall back to the text-only ask flow.
+type Button struct {
+	// ID is the callback data returned when the button is pressed.
+	ID string
+	// Label is the human-readable text shown on the button.
+	Label string
 }
 
 // SendResult is returned by outbound send operations.
@@ -92,6 +108,20 @@ type Adapter interface {
 
 	// UpdateMessage edits an existing message in-place. Returns true on success.
 	UpdateMessage(chatID, messageID, text string) bool
+
+	// SupportsButtons reports whether the platform can render interactive
+	// buttons inline in messages (Telegram inline keyboards, Discord components,
+	// Feishu interactive cards). When true, the permission ask sends buttons
+	// instead of relying on the next-plain-message contract, eliminating the
+	// swallowed-message trap (#1120).
+	SupportsButtons() bool
+
+	// SendButtons sends a message with interactive buttons attached. buttons
+	// must contain at least one entry. Platforms that do not support buttons
+	// (SupportsButtons returns false) are expected to fall back to SendText
+	// when called — callers SHOULD check SupportsButtons first. Returns the
+	// message ID of the sent message for correlation with button callbacks.
+	SendButtons(chatID, text string, buttons []Button, replyTo string) SendResult
 
 	// SupportsMessageUpdates reports whether the platform can edit sent messages.
 	SupportsMessageUpdates() bool

--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -280,6 +280,13 @@ func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
 // Flush — DingTalk has no outgoing buffer.
 func (a *Adapter) Flush(chatID string) {}
 
+func (a *Adapter) SupportsButtons() bool { return false }
+
+func (a *Adapter) SendButtons(chatID, text string, buttons []channel.Button, replyTo string) channel.SendResult {
+	// Fall back to plain text — DingTalk doesn't support interactive buttons.
+	return a.SendText(chatID, text, replyTo)
+}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	var errs []string

--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -336,6 +336,65 @@ func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
 // Flush — Discord has no outgoing buffer.
 func (a *Adapter) Flush(chatID string) {}
 
+func (a *Adapter) SupportsButtons() bool { return true }
+
+// SendButtons sends a text message with component buttons. Up to 5 buttons
+// per action row (Discord's limit); subsequent rows for more buttons.
+func (a *Adapter) SendButtons(chatID, text string, buttons []channel.Button, replyTo string) channel.SendResult {
+	chunks := channel.SplitForSend(text, maxMessageBytes)
+	if len(chunks) == 0 {
+		return channel.SendResult{OK: true, MessageID: ""}
+	}
+
+	var lastID string
+	for i, chunk := range chunks {
+		payload := map[string]any{
+			"content":          chunk,
+			"allowed_mentions": noMentionsParse,
+		}
+		if replyTo != "" && i == 0 {
+			payload["message_reference"] = map[string]string{"message_id": replyTo}
+		}
+		// Only the first chunk carries the buttons.
+		if i == 0 {
+			var rows []any
+			for j := 0; j < len(buttons); j += 5 {
+				end := j + 5
+				if end > len(buttons) {
+					end = len(buttons)
+				}
+				var comps []any
+				for _, b := range buttons[j:end] {
+					style := 1 // Primary (blue) by default
+					if b.ID == "deny" {
+						style = 4 // Danger (red)
+					}
+					comps = append(comps, map[string]any{
+						"type":      2, // Button
+						"style":     style,
+						"label":     b.Label,
+						"custom_id": b.ID,
+					})
+				}
+				rows = append(rows, map[string]any{
+					"type":       1, // ActionRow
+					"components": comps,
+				})
+			}
+			payload["components"] = rows
+		}
+
+		var msg struct {
+			ID string `json:"id"`
+		}
+		if err := a.rest(context.Background(), http.MethodPost, fmt.Sprintf("/channels/%s/messages", chatID), payload, &msg); err != nil {
+			return channel.SendResult{OK: false, Error: err.Error()}
+		}
+		lastID = msg.ID
+	}
+	return channel.SendResult{OK: true, MessageID: lastID}
+}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	var errs []string
@@ -676,7 +735,95 @@ func (a *Adapter) handleDispatch(typ string, data json.RawMessage, onMessage fun
 			return
 		}
 		a.handleMessage(&msg, onMessage)
+	case "INTERACTION_CREATE":
+		var interaction struct {
+			ID        string `json:"id"`
+			Type      int    `json:"type"`
+			Token     string `json:"token"`
+			ChannelID string `json:"channel_id"`
+			Member    *struct {
+				User dcUser `json:"user"`
+			} `json:"member"`
+			User *dcUser `json:"user"`
+			Data *struct {
+				CustomID string `json:"custom_id"`
+			} `json:"data"`
+			Message *dcMessage `json:"message"`
+		}
+		if err := json.Unmarshal(data, &interaction); err != nil {
+			return
+		}
+		// Only handle Message Component interactions (type 3).
+		if interaction.Type != 3 || interaction.Data == nil {
+			return
+		}
+		a.handleComponentInteraction(&interaction, onMessage)
 	}
+}
+
+// handleComponentInteraction processes a Discord button click interaction:
+// acknowledges the interaction with a deferred response, then routes the
+// button press as an InboundEvent with ButtonID set.
+func (a *Adapter) handleComponentInteraction(interaction *struct {
+	ID        string `json:"id"`
+	Type      int    `json:"type"`
+	Token     string `json:"token"`
+	ChannelID string `json:"channel_id"`
+	Member    *struct {
+		User dcUser `json:"user"`
+	} `json:"member"`
+	User *dcUser `json:"user"`
+	Data *struct {
+		CustomID string `json:"custom_id"`
+	} `json:"data"`
+	Message *dcMessage `json:"message"`
+}, onMessage func(channel.InboundEvent)) {
+	userID := ""
+	if interaction.Member != nil {
+		userID = interaction.Member.User.ID
+	} else if interaction.User != nil {
+		userID = interaction.User.ID
+	}
+	if userID == "" {
+		return
+	}
+	if len(a.allowedUsers) > 0 && !a.allowedUsers[userID] {
+		return
+	}
+	if interaction.Data == nil || interaction.Data.CustomID == "" {
+		return
+	}
+
+	// Acknowledge the interaction with a deferred update (type 5) so the
+	// user sees the button press register and Discord doesn't timeout.
+	a.rest(context.Background(), http.MethodPost,
+		fmt.Sprintf("/interactions/%s/%s/callback", interaction.ID, interaction.Token),
+		map[string]any{"type": 5}, nil)
+
+	channelID := interaction.ChannelID
+	if channelID == "" && interaction.Message != nil {
+		channelID = interaction.Message.ChannelID
+	}
+	if channelID == "" {
+		return
+	}
+
+	msgID := interaction.ID
+	if interaction.Message != nil && interaction.Message.ID != "" {
+		msgID = interaction.Message.ID
+	}
+
+	log.Printf("[discord] button click from user %s: %s", userID, interaction.Data.CustomID)
+	onMessage(channel.InboundEvent{
+		Type:      "message",
+		Platform:  platformName,
+		ChatID:    channelID,
+		UserID:    userID,
+		MessageID: msgID,
+		ButtonID:  interaction.Data.CustomID,
+		ChatType:  "direct",
+		Raw:       interaction,
+	})
 }
 
 // discordCDNHosts are the only hosts Discord serves attachment content from.

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -284,6 +284,48 @@ func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
 // Flush — Feishu has no outgoing buffer.
 func (a *Adapter) Flush(chatID string) {}
 
+func (a *Adapter) SupportsButtons() bool { return true }
+
+// SendButtons sends an interactive card with button elements. Uses the
+// interactive card schema (same as SendText for code/table content) but
+// appends button elements to the card body.
+func (a *Adapter) SendButtons(chatID, text string, buttons []channel.Button, replyTo string) channel.SendResult {
+	// Build button elements.
+	var btnElements []any
+	for _, b := range buttons {
+		btnElements = append(btnElements, map[string]any{
+			"tag":  "button",
+			"text": map[string]any{"tag": "plain_text", "content": b.Label},
+			"type": "primary",
+			"value": map[string]string{
+				"button_id": b.ID,
+			},
+		})
+	}
+
+	// Build the card with text content + button group.
+	card := map[string]any{
+		"schema": "2.0",
+		"config": map[string]any{"wide_screen_mode": true},
+		"body": map[string]any{
+			"elements": []any{
+				map[string]any{"tag": "markdown", "content": text},
+				map[string]any{
+					"tag":     "action",
+					"actions": btnElements,
+				},
+			},
+		},
+	}
+	content, _ := json.Marshal(card)
+
+	msgID, err := a.sendRaw(chatID, "interactive", string(content), replyTo)
+	if err != nil {
+		return channel.SendResult{OK: false, Error: err.Error()}
+	}
+	return channel.SendResult{OK: true, MessageID: msgID}
+}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	var errs []string
@@ -482,14 +524,33 @@ type msgContent struct {
 // feishuDocURLRe matches Feishu document URLs (docx, docs, wiki).
 var feishuDocURLRe = regexp.MustCompile(`https://[^/]+\.feishu\.cn/(docx|docs|wiki)/([A-Za-z0-9]+)`)
 
+// fsEventHeader is the common header parsed from every Feishu event to
+// determine its type before dispatching to the specific handler.
+type fsEventHeader struct {
+	Header struct {
+		EventType string `json:"event_type"`
+	} `json:"header"`
+}
+
 func (a *Adapter) handleEvent(raw json.RawMessage, onMessage func(channel.InboundEvent)) {
-	var ev fsEvent
-	if err := json.Unmarshal(raw, &ev); err != nil {
-		log.Printf("[feishu] unmarshal event: %v", err)
+	var hdr fsEventHeader
+	if err := json.Unmarshal(raw, &hdr); err != nil {
+		log.Printf("[feishu] unmarshal event header: %v", err)
 		return
 	}
 
-	if ev.Header.EventType != "im.message.receive_v1" {
+	switch hdr.Header.EventType {
+	case "im.message.receive_v1":
+		a.handleMessageEvent(raw, onMessage)
+	case "card.action.trigger":
+		a.handleCardAction(raw, onMessage)
+	}
+}
+
+func (a *Adapter) handleMessageEvent(raw json.RawMessage, onMessage func(channel.InboundEvent)) {
+	var ev fsEvent
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		log.Printf("[feishu] unmarshal message event: %v", err)
 		return
 	}
 
@@ -590,6 +651,65 @@ func (a *Adapter) handleEvent(raw json.RawMessage, onMessage func(channel.Inboun
 		Files:     files,
 		MessageID: msg.MessageID,
 		ChatType:  chatType,
+		Raw:       ev,
+	})
+}
+
+// handleCardAction processes a Feishu card button press event. The event
+// payload carries the button's value (which includes button_id) and the
+// operator's identity. Routes the press as an InboundEvent with ButtonID set.
+func (a *Adapter) handleCardAction(raw json.RawMessage, onMessage func(channel.InboundEvent)) {
+	var ev struct {
+		Event struct {
+			Action struct {
+				Value map[string]string `json:"value"`
+				Tag   string            `json:"tag"`
+			} `json:"action"`
+			Operator struct {
+				OpenID string `json:"open_id"`
+			} `json:"operator"`
+			Message struct {
+				MessageID string `json:"message_id"`
+				ChatID    string `json:"chat_id"`
+			} `json:"message"`
+		} `json:"event"`
+	}
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		log.Printf("[feishu] unmarshal card action event: %v", err)
+		return
+	}
+
+	if ev.Event.Action.Tag != "button" {
+		return
+	}
+
+	senderID := ev.Event.Operator.OpenID
+	if senderID == "" {
+		return
+	}
+	if len(a.allowedUsers) > 0 && !a.allowedUsers[senderID] {
+		return
+	}
+
+	chatID := ev.Event.Message.ChatID
+	if chatID == "" {
+		return
+	}
+
+	buttonID := ev.Event.Action.Value["button_id"]
+	if buttonID == "" {
+		return
+	}
+
+	log.Printf("[feishu] card action from user %s: %s", senderID, buttonID)
+	onMessage(channel.InboundEvent{
+		Type:      "message",
+		Platform:  platformName,
+		ChatID:    chatID,
+		UserID:    senderID,
+		MessageID: ev.Event.Message.MessageID,
+		ButtonID:  buttonID,
+		ChatType:  "direct",
 		Raw:       ev,
 	})
 }

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -437,6 +437,69 @@ func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
 // Flush — Telegram has no outgoing buffer.
 func (a *Adapter) Flush(chatID string) {}
 
+func (a *Adapter) SupportsButtons() bool { return true }
+
+// SendButtons sends a text message with inline keyboard buttons. Up to 3
+// buttons per row; subsequent chunks (if the text exceeds maxMessageBytes)
+// are sent without buttons since only the first chunk carries the prompt.
+func (a *Adapter) SendButtons(chatID, text string, buttons []channel.Button, replyTo string) channel.SendResult {
+	// Build inline keyboard rows: up to 3 buttons per row.
+	var rows [][]map[string]any
+	for i := 0; i < len(buttons); i += 3 {
+		end := i + 3
+		if end > len(buttons) {
+			end = len(buttons)
+		}
+		row := make([]map[string]any, 0, end-i)
+		for _, b := range buttons[i:end] {
+			row = append(row, map[string]any{
+				"text":          b.Label,
+				"callback_data": b.ID,
+			})
+		}
+		rows = append(rows, row)
+	}
+
+	chunks := channel.SplitForSend(text, maxMessageBytes)
+	if len(chunks) == 0 {
+		return channel.SendResult{OK: true, MessageID: ""}
+	}
+
+	var lastID string
+	for i, chunk := range chunks {
+		body, mode := a.renderForSend(chunk)
+		params := map[string]any{
+			"chat_id":                  chatID,
+			"text":                     body,
+			"disable_web_page_preview": true,
+		}
+		if mode != "" {
+			params["parse_mode"] = mode
+		}
+		if replyTo != "" && i == 0 {
+			params["reply_to_message_id"] = replyTo
+		}
+		if i == 0 {
+			params["reply_markup"] = map[string]any{"inline_keyboard": rows}
+		}
+
+		msg, err := a.callMessage("sendMessage", params)
+		if err != nil {
+			if mode != "" && isParseError(err) {
+				log.Printf("[telegram] parse_mode failed, retrying as plain text: %v", err)
+				delete(params, "parse_mode")
+				params["text"] = chunk
+				msg, err = a.callMessage("sendMessage", params)
+			}
+			if err != nil {
+				return channel.SendResult{OK: false, Error: err.Error()}
+			}
+		}
+		lastID = fmt.Sprintf("%d", msg.MessageID)
+	}
+	return channel.SendResult{OK: true, MessageID: lastID}
+}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	var errs []string
@@ -641,15 +704,25 @@ func (a *Adapter) fetchBotIdentity(ctx context.Context) error {
 	return nil
 }
 
+type tgCallbackQuery struct {
+	ID   string `json:"id"`
+	From struct {
+		ID int64 `json:"id"`
+	} `json:"from"`
+	Message *tgMessage `json:"message"`
+	Data    string     `json:"data"`
+}
+
 type tgUpdate struct {
-	UpdateID int64      `json:"update_id"`
-	Message  *tgMessage `json:"message"`
+	UpdateID      int64            `json:"update_id"`
+	Message       *tgMessage       `json:"message"`
+	CallbackQuery *tgCallbackQuery `json:"callback_query"`
 }
 
 func (a *Adapter) getUpdates(ctx context.Context, offset int64) ([]tgUpdate, error) {
 	params := map[string]any{
 		"timeout":         int(longPollTimeout.Seconds()),
-		"allowed_updates": []string{"message"},
+		"allowed_updates": []string{"message", "callback_query"},
 	}
 	if offset > 0 {
 		params["offset"] = offset
@@ -668,6 +741,12 @@ func (a *Adapter) getUpdates(ctx context.Context, offset int64) ([]tgUpdate, err
 // ─── Inbound ────────────────────────────────────────────────────────────────
 
 func (a *Adapter) processUpdate(upd tgUpdate, onMessage func(channel.InboundEvent)) {
+	// Handle callback queries (inline keyboard button presses) first.
+	if cb := upd.CallbackQuery; cb != nil {
+		a.processCallbackQuery(cb, onMessage)
+		return
+	}
+
 	msg := upd.Message
 	if msg == nil || msg.Chat.ID == 0 || msg.From.ID == 0 {
 		return
@@ -768,6 +847,38 @@ func (a *Adapter) processUpdate(upd tgUpdate, onMessage func(channel.InboundEven
 		MessageID: fmt.Sprintf("%d", msg.MessageID),
 		ChatType:  chatType,
 		Raw:       msg,
+	})
+}
+
+// processCallbackQuery handles an inline keyboard button press. It answers
+// the callback query to dismiss the loading indicator, then routes the button
+// press as an InboundEvent with ButtonID set.
+func (a *Adapter) processCallbackQuery(cb *tgCallbackQuery, onMessage func(channel.InboundEvent)) {
+	// Answer the callback query so Telegram dismisses the loading UI.
+	a.call(nil, "answerCallbackQuery", map[string]any{
+		"callback_query_id": cb.ID,
+		// No text — we don't need to show a toast notification.
+	}, a.http)
+
+	if cb.Message == nil || cb.Data == "" {
+		return
+	}
+
+	userID := fmt.Sprintf("%d", cb.From.ID)
+	if len(a.allowedUsers) > 0 && !a.allowedUsers[userID] {
+		return
+	}
+
+	log.Printf("[telegram] callback from user %s: %s", userID, cb.Data)
+	onMessage(channel.InboundEvent{
+		Type:      "message",
+		Platform:  platformName,
+		ChatID:    fmt.Sprintf("%d", cb.Message.Chat.ID),
+		UserID:    userID,
+		MessageID: fmt.Sprintf("%d", cb.Message.MessageID),
+		ButtonID:  cb.Data,
+		ChatType:  "direct", // callback queries from groups still work per-user
+		Raw:       cb,
 	})
 }
 

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -437,6 +437,13 @@ func (a *Adapter) StopTyping(chatID, contextToken string) error { return nil }
 // Flush — WeCom has no outgoing buffer.
 func (a *Adapter) Flush(chatID string) {}
 
+func (a *Adapter) SupportsButtons() bool { return false }
+
+func (a *Adapter) SendButtons(chatID, text string, buttons []channel.Button, replyTo string) channel.SendResult {
+	// Fall back to plain text — WeCom doesn't support interactive buttons.
+	return a.SendText(chatID, text, replyTo)
+}
+
 // ValidateConfig checks required fields.
 func (a *Adapter) ValidateConfig(cfg channel.PlatformConfig) []string {
 	botID, _ := cfg[cfgBotID].(string)

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -635,6 +635,13 @@ func (a *Adapter) Flush(chatID string) {
 	}
 }
 
+func (a *Adapter) SupportsButtons() bool { return false }
+
+func (a *Adapter) SendButtons(chatID, text string, buttons []channel.Button, replyTo string) channel.SendResult {
+	// Fall back to plain text — Weixin doesn't support interactive buttons.
+	return a.SendText(chatID, text, replyTo)
+}
+
 // SendTyping triggers a typing indicator and starts keepalive.
 func (a *Adapter) SendTyping(chatID, contextToken string) error {
 	if a.bot == nil || a.bot.creds == nil {

--- a/internal/channel/ask.go
+++ b/internal/channel/ask.go
@@ -27,21 +27,54 @@ func (s *Session) BeginAsk(chatID, userID string) (<-chan string, func(), error)
 	ch := make(chan string, 1)
 	s.pendingAsk = ch
 	s.askChatID, s.askUserID = chatID, userID
+	s.askButtonsOnly = false
 	release := func() {
 		s.askMu.Lock()
 		if s.pendingAsk == ch {
 			s.pendingAsk = nil
+			s.askButtonsOnly = false
 		}
 		s.askMu.Unlock()
 	}
 	return ch, release, nil
 }
 
+// SetAskButtonsOnly marks the pending ask as button-only: DeliverAskReply will
+// NOT consume plain text messages — only DeliverAskButton can resolve. Must
+// be called after BeginAsk and before any reply arrives. Has no effect when no
+// ask is pending.
+func (s *Session) SetAskButtonsOnly() {
+	s.askMu.Lock()
+	s.askButtonsOnly = true
+	s.askMu.Unlock()
+}
+
 // DeliverAskReply routes text to a pending ask and reports whether it was
 // consumed. False means no ask is waiting (or the reply came from the wrong
 // chat or user) — the caller should treat the message as normal chat input.
+// When askButtonsOnly is true (button-based ask), returns false so plain text
+// messages stay as ordinary chat input instead of being swallowed (#1120).
 // Each ask consumes exactly one reply.
 func (s *Session) DeliverAskReply(chatID, userID, text string) bool {
+	s.askMu.Lock()
+	defer s.askMu.Unlock()
+	if s.pendingAsk == nil || s.askButtonsOnly {
+		return false
+	}
+	if chatID != s.askChatID || userID != s.askUserID {
+		return false
+	}
+	s.pendingAsk <- text // buffered (cap 1); never blocks
+	s.pendingAsk = nil
+	s.askButtonsOnly = false
+	return true
+}
+
+// DeliverAskButton routes a button press callback to a pending ask and reports
+// whether it was consumed. Works regardless of askButtonsOnly mode — this is
+// the intended resolution path for button-based asks. Each ask consumes
+// exactly one button press.
+func (s *Session) DeliverAskButton(chatID, userID, buttonID string) bool {
 	s.askMu.Lock()
 	defer s.askMu.Unlock()
 	if s.pendingAsk == nil {
@@ -50,7 +83,8 @@ func (s *Session) DeliverAskReply(chatID, userID, text string) bool {
 	if chatID != s.askChatID || userID != s.askUserID {
 		return false
 	}
-	s.pendingAsk <- text // buffered (cap 1); never blocks
+	s.pendingAsk <- buttonID // buffered (cap 1); never blocks
 	s.pendingAsk = nil
+	s.askButtonsOnly = false
 	return true
 }

--- a/internal/channel/ask_test.go
+++ b/internal/channel/ask_test.go
@@ -109,3 +109,118 @@ func TestSession_WrongUserOrChatNotConsumed(t *testing.T) {
 		t.Fatal("reply not delivered")
 	}
 }
+
+func TestSession_SetAskButtonsOnly_BlocksDeliverAskReply(t *testing.T) {
+	sess := &Session{}
+	replyCh, release, err := sess.BeginAsk("c1", "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	sess.SetAskButtonsOnly()
+
+	// DeliverAskReply must return false when askButtonsOnly is set.
+	if sess.DeliverAskReply("c1", "u1", "yes") {
+		t.Error("DeliverAskReply must return false when askButtonsOnly is true")
+	}
+
+	// DeliverAskButton must still work.
+	if !sess.DeliverAskButton("c1", "u1", "allow") {
+		t.Fatal("DeliverAskButton must consume when askButtonsOnly is set")
+	}
+	select {
+	case got := <-replyCh:
+		if got != "allow" {
+			t.Errorf("button reply = %q, want %q", got, "allow")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("button reply not delivered to the ask channel")
+	}
+}
+
+func TestSession_DeliverAskButton_Consumed(t *testing.T) {
+	sess := &Session{}
+	replyCh, release, err := sess.BeginAsk("c1", "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	if !sess.DeliverAskButton("c1", "u1", "allow") {
+		t.Fatal("DeliverAskButton should consume when ask is pending")
+	}
+	select {
+	case got := <-replyCh:
+		if got != "allow" {
+			t.Errorf("button reply = %q, want %q", got, "allow")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("button reply not delivered")
+	}
+}
+
+func TestSession_DeliverAskButton_WithoutPendingAsk(t *testing.T) {
+	sess := &Session{}
+	if sess.DeliverAskButton("c1", "u1", "allow") {
+		t.Error("DeliverAskButton must return false with no pending ask")
+	}
+}
+
+func TestSession_DeliverAskButton_WrongUserOrChat(t *testing.T) {
+	sess := &Session{}
+	replyCh, release, err := sess.BeginAsk("c1", "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	if sess.DeliverAskButton("c1", "u2", "allow") {
+		t.Error("another user's button press must not consume")
+	}
+	if sess.DeliverAskButton("c2", "u1", "allow") {
+		t.Error("a button press from another chat must not consume")
+	}
+	// The rightful answer still lands.
+	if !sess.DeliverAskButton("c1", "u1", "allow") {
+		t.Fatal("the requester's button press should be consumed")
+	}
+	select {
+	case got := <-replyCh:
+		if got != "allow" {
+			t.Errorf("button reply = %q, want allow", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("button reply not delivered")
+	}
+}
+
+func TestSession_AskButtonsOnlyReleased_BeforeNextAsk(t *testing.T) {
+	sess := &Session{}
+	_, release, err := sess.BeginAsk("c1", "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess.SetAskButtonsOnly()
+	release()
+
+	// Next ask (text mode) must work normally — askButtonsOnly should be false
+	// because the previous ask was released.
+	replyCh, release2, err := sess.BeginAsk("c1", "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release2()
+
+	if !sess.DeliverAskReply("c1", "u1", "yes") {
+		t.Error("DeliverAskReply must work after a released buttons-only ask")
+	}
+	select {
+	case got := <-replyCh:
+		if got != "yes" {
+			t.Errorf("reply = %q, want yes", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("reply not delivered")
+	}
+}

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -76,14 +76,18 @@ type Session struct {
 	cancelMu  sync.Mutex
 	runCancel context.CancelFunc
 
-	// pendingAsk, while non-nil, claims the session's next plain message as
+	// pendingAsk, while non-nil, claims the session's next message as
 	// the answer to an interactive permission prompt (see ask.go). Guarded by
 	// askMu, not runMu — the reply arrives while the asking turn holds runMu.
 	// askChatID/askUserID pin which chat+user may answer.
-	askMu      sync.Mutex
-	pendingAsk chan string
-	askChatID  string
-	askUserID  string
+	// askButtonsOnly, when true, prevents DeliverAskReply from consuming plain
+	// text messages — only button callbacks (via DeliverAskButton) resolve the
+	// ask (#1120).
+	askMu          sync.Mutex
+	pendingAsk     chan string
+	askChatID      string
+	askUserID      string
+	askButtonsOnly bool
 }
 
 // BeginRun prepares one agent turn: it blocks until any previous turn in this

--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -101,7 +101,11 @@ func (m *mockAdapter) SupportsMessageUpdates() bool                 { return !m.
 func (m *mockAdapter) SendTyping(chatID, contextToken string) error { return nil }
 func (m *mockAdapter) StopTyping(chatID, contextToken string) error { return nil }
 func (m *mockAdapter) Flush(chatID string)                          {}
-func (m *mockAdapter) ValidateConfig(cfg PlatformConfig) []string   { return m.validateErrs }
+func (m *mockAdapter) SupportsButtons() bool                        { return false }
+func (m *mockAdapter) SendButtons(chatID, text string, buttons []Button, replyTo string) SendResult {
+	return m.SendText(chatID, text, replyTo)
+}
+func (m *mockAdapter) ValidateConfig(cfg PlatformConfig) []string { return m.validateErrs }
 
 func (m *mockAdapter) sentTextCount() int {
 	m.mu.Lock()

--- a/internal/server/channel_ask.go
+++ b/internal/server/channel_ask.go
@@ -45,12 +45,15 @@ func isAlways(text string) bool {
 // approving. The IM transport shows no tool cards before the gate fires, so
 // without this the user would approve blind — "Allow terminal?" tells them
 // nothing about WHICH command. Known primary fields come first; anything
-// else falls back to a JSON head.
+// else falls back to a JSON head. Mirror #1101: budget large enough for
+// ~10 lines of content (600 runes) so the user can see the actual command
+// instead of a truncated snippet that hides the tail (approve-what-you-can't-
+// see concern from #1092/#1105).
 func askInputSummary(toolInput map[string]any) string {
-	const maxLen = 160
+	const maxRunes = 600
 	for _, key := range []string{"command", "path", "url", "reason", "pattern"} {
 		if v, ok := toolInput[key].(string); ok && strings.TrimSpace(v) != "" {
-			return truncateForAsk(v, maxLen)
+			return truncateForAsk(v, maxRunes)
 		}
 	}
 	if len(toolInput) == 0 {
@@ -60,24 +63,40 @@ func askInputSummary(toolInput map[string]any) string {
 	if err != nil {
 		return ""
 	}
-	return truncateForAsk(string(b), maxLen)
+	return truncateForAsk(string(b), maxRunes)
 }
 
-func truncateForAsk(s string, maxLen int) string {
-	if len(s) <= maxLen {
+// truncateForAsk truncates s to at most maxRunes runes, never mid-rune.
+// Uses rune-aware slicing so multi-byte CJK characters are never split
+// (byte-slicing a CJK string mid-rune would produce "�" replacement chars).
+func truncateForAsk(s string, maxRunes int) string {
+	r := []rune(s)
+	if len(r) <= maxRunes {
 		return s
 	}
-	return s[:maxLen] + "…"
+	return string(r[:maxRunes]) + "…"
 }
+
+// Button IDs used in IM permission ask prompts. When the platform supports
+// interactive buttons, these are sent as callback_data / custom_id / button
+// value; on text-only platforms the user types the corresponding keyword.
+const (
+	askButtonAllow  = "allow"
+	askButtonAlways = "always"
+	askButtonDeny   = "deny"
+)
 
 // channelPermissionAsk builds the app.PermissionAsk for one IM turn: it sends
 // a confirmation prompt into the chat and consumes the requesting user's next
-// plain message in that chat as the answer (routed by the inbound dispatcher
-// via DeliverAskReply, ahead of the turn path — see routeChannelEvent).
-// Approval requires an explicit affirmative; the "always" variants also
-// remember the decision in the session's Remembered store (exact tool+input
-// signature, session lifetime, never persisted to permissions.yml). Any
-// other reply, the turn being cancelled (/stop), or the timeout denies.
+// plain message or button press as the answer (routed by the inbound dispatcher
+// via DeliverAskReply or DeliverAskButton, ahead of the turn path — see
+// routeChannelEvent). On platforms with native button support (Telegram,
+// Discord, Feishu), buttons are used instead of the next-plain-message contract,
+// eliminating the swallowed-message trap (#1120). Approval requires an explicit
+// affirmative; the "always" variants also remember the decision in the session's
+// Remembered store (exact tool+input signature, session lifetime, never persisted
+// to permissions.yml). Any other reply, the turn being cancelled (/stop), or the
+// timeout denies.
 func (s *Server) channelPermissionAsk(sess *channel.Session, ad channel.Adapter, ev channel.InboundEvent) app.PermissionAsk {
 	return func(ctx context.Context, toolName string, toolInput map[string]any) (bool, bool, error) {
 		replyCh, release, err := sess.BeginAsk(ev.ChatID, ev.UserID)
@@ -90,10 +109,21 @@ func (s *Server) channelPermissionAsk(sess *channel.Session, ad channel.Adapter,
 		if detail := askInputSummary(toolInput); detail != "" {
 			what = fmt.Sprintf("%s — %q", toolName, detail)
 		}
-		prompt := fmt.Sprintf(
-			"⚠️ Allow %s? Reply yes / 允许 to approve once, always / 总是允许 to stop asking for this exact call — any other reply denies; only the requester's reply counts. (Auto-deny in %s; /stop cancels the task.)",
-			what, channelAskTimeout)
-		ad.SendText(ev.ChatID, prompt, ev.MessageID)
+
+		useButtons := ad.SupportsButtons()
+		if useButtons {
+			sess.SetAskButtonsOnly()
+			ad.SendButtons(ev.ChatID, fmt.Sprintf("⚠️ Allow %s?", what), []channel.Button{
+				{ID: askButtonAllow, Label: "✅ Allow once"},
+				{ID: askButtonAlways, Label: "🔄 Always allow"},
+				{ID: askButtonDeny, Label: "❌ Deny"},
+			}, ev.MessageID)
+		} else {
+			prompt := fmt.Sprintf(
+				"⚠️ Allow %s? Reply yes / 允许 to approve once, always / 总是允许 to stop asking for this exact call — any other reply denies; only the requester's reply counts. (Auto-deny in %s; /stop cancels the task.)",
+				what, channelAskTimeout)
+			ad.SendText(ev.ChatID, prompt, ev.MessageID)
+		}
 
 		timer := time.NewTimer(channelAskTimeout)
 		defer timer.Stop()

--- a/internal/server/channel_ask_test.go
+++ b/internal/server/channel_ask_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -221,5 +222,173 @@ func TestChannelAsker_TimeoutCancels(t *testing.T) {
 	}
 	if !res.Cancelled {
 		t.Error("timeout must report Cancelled")
+	}
+}
+
+// ─── Button tests ────────────────────────────────────────────────────────────
+
+// fakeButtonAdapter supports buttons and records SendButtons calls.
+type fakeButtonAdapter struct {
+	channel.Adapter
+	mu         sync.Mutex
+	sent       []string
+	buttonSent bool
+}
+
+func (a *fakeButtonAdapter) text() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.sent) == 0 {
+		return ""
+	}
+	return a.sent[0]
+}
+
+func (a *fakeButtonAdapter) Platform() string { return "button-fake" }
+func (a *fakeButtonAdapter) Start(ctx context.Context, _ func(channel.InboundEvent)) error {
+	<-ctx.Done()
+	return nil
+}
+func (a *fakeButtonAdapter) Stop() error { return nil }
+func (a *fakeButtonAdapter) SendText(chatID, text, replyTo string) channel.SendResult {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.sent = append(a.sent, text)
+	return channel.SendResult{OK: true, MessageID: "bt1"}
+}
+func (a *fakeButtonAdapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: true}
+}
+func (a *fakeButtonAdapter) UpdateMessage(chatID, messageID, text string) bool { return true }
+func (a *fakeButtonAdapter) SupportsMessageUpdates() bool                      { return false }
+func (a *fakeButtonAdapter) SupportsButtons() bool                             { return true }
+func (a *fakeButtonAdapter) SendButtons(chatID, text string, buttons []channel.Button, replyTo string) channel.SendResult {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.buttonSent = true
+	a.sent = append(a.sent, text)
+	_ = buttons
+	return channel.SendResult{OK: true, MessageID: "bb1"}
+}
+func (a *fakeButtonAdapter) SendTyping(chatID, contextToken string) error   { return nil }
+func (a *fakeButtonAdapter) StopTyping(chatID, contextToken string) error   { return nil }
+func (a *fakeButtonAdapter) Flush(chatID string)                            {}
+func (a *fakeButtonAdapter) ValidateConfig(channel.PlatformConfig) []string { return nil }
+
+func buttonAskEnv(t *testing.T) (*Server, *channel.Session, *fakeButtonAdapter, channel.InboundEvent) {
+	t.Helper()
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	sess := &channel.Session{}
+	ad := &fakeButtonAdapter{}
+	ev := channel.InboundEvent{ChatID: "c1", MessageID: "m1", Text: "original"}
+	return srv, sess, ad, ev
+}
+
+func TestChannelPermissionAsk_ButtonAllow(t *testing.T) {
+	srv, sess, ad, ev := buttonAskEnv(t)
+	ask := srv.channelPermissionAsk(sess, ad, ev)
+
+	done := make(chan struct{})
+	var allow, remember bool
+	var err error
+	go func() {
+		allow, remember, err = ask(context.Background(), "terminal", map[string]any{"command": "ls"})
+		close(done)
+	}()
+
+	waitFor(t, func() bool { return ad.text() != "" })
+	if !strings.Contains(ad.text(), "terminal") {
+		t.Errorf("prompt %q should name the tool", ad.text())
+	}
+	if !ad.buttonSent {
+		t.Error("SendButtons was never called")
+	}
+
+	if !sess.DeliverAskButton("c1", "", "allow") {
+		t.Fatal("ask slot should accept button press")
+	}
+	<-done
+	if err != nil {
+		t.Fatalf("ask: %v", err)
+	}
+	if !allow {
+		t.Error("allow button should allow")
+	}
+	if remember {
+		t.Error("allow button must not set remember")
+	}
+}
+
+func TestChannelPermissionAsk_ButtonAlways(t *testing.T) {
+	srv, sess, ad, ev := buttonAskEnv(t)
+	ask := srv.channelPermissionAsk(sess, ad, ev)
+
+	done := make(chan struct{})
+	var allow, remember bool
+	go func() {
+		allow, remember, _ = ask(context.Background(), "terminal", map[string]any{"command": "ls"})
+		close(done)
+	}()
+	waitFor(t, func() bool { return ad.text() != "" })
+
+	if !sess.DeliverAskButton("c1", "", "always") {
+		t.Fatal("ask slot should accept button press")
+	}
+	<-done
+	if !allow || !remember {
+		t.Error("always button should allow and remember")
+	}
+}
+
+func TestChannelPermissionAsk_ButtonDeny(t *testing.T) {
+	srv, sess, ad, ev := buttonAskEnv(t)
+	ask := srv.channelPermissionAsk(sess, ad, ev)
+
+	done := make(chan struct{})
+	var allow bool
+	go func() {
+		allow, _, _ = ask(context.Background(), "terminal", map[string]any{"command": "ls"})
+		close(done)
+	}()
+	waitFor(t, func() bool { return ad.text() != "" })
+
+	if !sess.DeliverAskButton("c1", "", "deny") {
+		t.Fatal("ask slot should accept button press")
+	}
+	<-done
+	if allow {
+		t.Error("deny button must deny")
+	}
+}
+
+func TestChannelPermissionAsk_ButtonIgnoresText(t *testing.T) {
+	// When buttons are active, a plain text message must NOT be consumed
+	// (the ask slot stays armed for a button press).
+	old := channelAskTimeout
+	channelAskTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { channelAskTimeout = old })
+
+	srv, sess, ad, ev := buttonAskEnv(t)
+	ask := srv.channelPermissionAsk(sess, ad, ev)
+
+	done := make(chan struct{})
+	var allow bool
+	go func() {
+		allow, _, _ = ask(context.Background(), "terminal", map[string]any{"command": "ls"})
+		close(done)
+	}()
+	waitFor(t, func() bool { return ad.text() != "" })
+
+	// DeliverAskReply must return false — text should NOT be consumed.
+	if sess.DeliverAskReply("c1", "", "yes") {
+		t.Error("text reply must NOT be consumed while buttons are active")
+	}
+	// The button press must still resolve the ask.
+	if !sess.DeliverAskButton("c1", "", "allow") {
+		t.Fatal("button press must be consumed after ignored text")
+	}
+	<-done
+	if !allow {
+		t.Error("allow button press should allow")
 	}
 }

--- a/internal/server/channel_restart_test.go
+++ b/internal/server/channel_restart_test.go
@@ -90,7 +90,11 @@ func (a *crashingFakeAdapter) SupportsMessageUpdates() bool                     
 func (a *crashingFakeAdapter) SendTyping(chatID, contextToken string) error      { return nil }
 func (a *crashingFakeAdapter) StopTyping(chatID, contextToken string) error      { return nil }
 func (a *crashingFakeAdapter) Flush(chatID string)                               {}
-func (a *crashingFakeAdapter) ValidateConfig(channel.PlatformConfig) []string    { return nil }
+func (a *crashingFakeAdapter) SupportsButtons() bool                             { return false }
+func (a *crashingFakeAdapter) SendButtons(chatID, text string, buttons []channel.Button, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: true}
+}
+func (a *crashingFakeAdapter) ValidateConfig(channel.PlatformConfig) []string { return nil }
 
 func writeChannelsYML(t *testing.T, yml string) {
 	t.Helper()
@@ -398,6 +402,10 @@ func (a *validatingFakeAdapter) SupportsMessageUpdates() bool                   
 func (a *validatingFakeAdapter) SendTyping(chatID, contextToken string) error      { return nil }
 func (a *validatingFakeAdapter) StopTyping(chatID, contextToken string) error      { return nil }
 func (a *validatingFakeAdapter) Flush(chatID string)                               {}
+func (a *validatingFakeAdapter) SupportsButtons() bool                             { return false }
+func (a *validatingFakeAdapter) SendButtons(chatID, text string, buttons []channel.Button, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: true}
+}
 func (a *validatingFakeAdapter) ValidateConfig(channel.PlatformConfig) []string {
 	return []string{"missing required field: token"}
 }

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -42,7 +42,11 @@ func (a *fullFakeAdapter) SupportsMessageUpdates() bool                      { r
 func (a *fullFakeAdapter) SendTyping(chatID, contextToken string) error      { return nil }
 func (a *fullFakeAdapter) StopTyping(chatID, contextToken string) error      { return nil }
 func (a *fullFakeAdapter) Flush(chatID string)                               {}
-func (a *fullFakeAdapter) ValidateConfig(channel.PlatformConfig) []string    { return nil }
+func (a *fullFakeAdapter) SupportsButtons() bool                             { return false }
+func (a *fullFakeAdapter) SendButtons(chatID, text string, buttons []channel.Button, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: true, MessageID: "f1"}
+}
+func (a *fullFakeAdapter) ValidateConfig(channel.PlatformConfig) []string { return nil }
 
 func (a *fullFakeAdapter) texts() []string {
 	a.mu.Lock()

--- a/internal/server/restart_test.go
+++ b/internal/server/restart_test.go
@@ -258,6 +258,25 @@ func (a *drainTestAdapter) texts() []string {
 	return append([]string(nil), a.sent...)
 }
 
+func (a *drainTestAdapter) Platform() string { return "drain" }
+func (a *drainTestAdapter) Start(context.Context, func(channel.InboundEvent)) error {
+	select {}
+}
+func (a *drainTestAdapter) Stop() error { return nil }
+func (a *drainTestAdapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
+	return channel.SendResult{}
+}
+func (a *drainTestAdapter) UpdateMessage(chatID, messageID, text string) bool { return false }
+func (a *drainTestAdapter) SupportsMessageUpdates() bool                      { return false }
+func (a *drainTestAdapter) SupportsButtons() bool                             { return false }
+func (a *drainTestAdapter) SendButtons(chatID, text string, buttons []channel.Button, replyTo string) channel.SendResult {
+	return channel.SendResult{}
+}
+func (a *drainTestAdapter) SendTyping(chatID, contextToken string) error       { return nil }
+func (a *drainTestAdapter) StopTyping(chatID, contextToken string) error       { return nil }
+func (a *drainTestAdapter) Flush(chatID string)                                {}
+func (a *drainTestAdapter) ValidateConfig(cfg channel.PlatformConfig) []string { return nil }
+
 // TestHandleChannelMessage_DrainingRepliesPolitely pins the design deviation:
 // IM adapters stay up through the drain, and a message arriving mid-drain
 // gets an explicit "try again" reply instead of being dropped silently.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2186,6 +2186,17 @@ func (s *Server) routeChannelEvent(ctx context.Context, ad channel.Adapter, ev c
 	if s.handleChannelCommand(ad, ev) {
 		return
 	}
+	// Button events (e.g. inline keyboard presses on Telegram, component
+	// clicks on Discord, card actions on Feishu) answer a pending ask directly,
+	// bypassing the text-based DeliverAskReply path. Button events are routed
+	// before plain text so they work even when askButtonsOnly is set.
+	if ev.ButtonID != "" {
+		if sess := s.channelMgr.GetSession(ev); sess != nil {
+			if sess.DeliverAskButton(ev.ChatID, ev.UserID, ev.ButtonID) {
+				return
+			}
+		}
+	}
 	// Text-less events (stickers, images, voice) never answer an ask or
 	// steer — an empty reply would consume the ask slot and deny for
 	// nothing, and an empty steer adds noise.


### PR DESCRIPTION
Fixes #1120

## Changes

### 1. Rune-safe truncation with larger budget
- `truncateForAsk` now uses `[]rune` slicing instead of byte slicing, so CJK characters are never split mid-byte (no more `�` chars)
- Budget increased from 160 bytes to **600 runes** (~10 lines), matching TUI/Web rules from #1101

### 2. Native buttons for permission asks (Telegram/Discord/Feishu)
- Added `Button` struct, `SendButtons()` and `SupportsButtons()` to the `Adapter` interface
- **Telegram**: sends inline keyboard with `callback_query` handling
- **Discord**: sends component ActionRows with `INTERACTION_CREATE` handling; Deny button uses danger (red) style
- **Feishu**: sends interactive card buttons with `card.action.trigger` handling
- Other platforms (Weixin, WeCom, DingTalk) fall back to plain text

### 3. Ask slot button-aware
- `SetAskButtonsOnly()` prevents `DeliverAskReply` from consuming plain messages when buttons are active
- `DeliverAskButton()` routes button press callbacks to the pending ask
- `channelPermissionAsk` automatically uses buttons when the adapter supports them

## Tests added
- `TestSession_*` — 5 new tests covering `DeliverAskButton`, `SetAskButtonsOnly` blocking text, wrong user/chat, and release behavior
- `TestChannelPermissionAsk_Button*` — 4 new tests covering "allow", "always", "deny" buttons and ensuring plain text is NOT consumed during button mode

## Design
On button platforms, the permission ask sends three buttons: ✅ Allow once, 🔄 Always allow, ❌ Deny. Button taps resolve the ask via `DeliverAskButton`; plain text messages during a pending ask stay as ordinary chat input (no more swallowed messages).

On text-only platforms, the existing next-plain-message contract continues unchanged.