### PR TITLE
feat(im): sustained typing keepalive during agentic turns

### DIFF
--- a/internal/channel/adapter.go
+++ b/internal/channel/adapter.go
@@ -143,18 +143,6 @@ type Adapter interface {
 	ValidateConfig(cfg PlatformConfig) []string
 }
 
-// SelfSustainingTyper is implemented by adapters whose SendTyping already
-// runs its own persistent keepalive after a single call (currently only
-// Weixin, whose iLink typing ticket has to be re-fetched and its internal
-// ticker restarted on every SendTyping call). A caller that re-invokes
-// SendTyping on a fixed interval (see internal/server's typing keepalive)
-// should check for this and skip the repeat calls — for a self-sustaining
-// adapter they'd just rack up redundant backend round-trips for no
-// additional user-visible effect.
-type SelfSustainingTyper interface {
-	SelfSustainingTyping() bool
-}
-
 // Registry maps platform names to adapter constructors.
 var registry = make(map[string]func(PlatformConfig) (Adapter, error))
 

--- a/internal/channel/adapter.go
+++ b/internal/channel/adapter.go
@@ -113,6 +113,18 @@ type Adapter interface {
 	ValidateConfig(cfg PlatformConfig) []string
 }
 
+// SelfSustainingTyper is implemented by adapters whose SendTyping already
+// runs its own persistent keepalive after a single call (currently only
+// Weixin, whose iLink typing ticket has to be re-fetched and its internal
+// ticker restarted on every SendTyping call). A caller that re-invokes
+// SendTyping on a fixed interval (see internal/server's typing keepalive)
+// should check for this and skip the repeat calls — for a self-sustaining
+// adapter they'd just rack up redundant backend round-trips for no
+// additional user-visible effect.
+type SelfSustainingTyper interface {
+	SelfSustainingTyping() bool
+}
+
 // Registry maps platform names to adapter constructors.
 var registry = make(map[string]func(PlatformConfig) (Adapter, error))
 

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -621,6 +621,12 @@ func (a *Adapter) UpdateMessage(chatID, messageID, text string) bool { return fa
 // SupportsMessageUpdates returns false.
 func (a *Adapter) SupportsMessageUpdates() bool { return false }
 
+// SelfSustainingTyping reports that a single SendTyping call already starts
+// a persistent internal keepalive (see startTypingKeepalive below) — callers
+// that re-invoke SendTyping on a fixed interval should skip the repeats for
+// this adapter (channel.SelfSustainingTyper).
+func (a *Adapter) SelfSustainingTyping() bool { return true }
+
 // StopTyping cancels the keepalive goroutine and sends sendtyping(status=2)
 // to clear the typing indicator in the WeChat client.
 func (a *Adapter) StopTyping(chatID, contextToken string) error {

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -44,9 +44,9 @@ const (
 	flushInterval      = 2 * time.Second
 	minSendInterval    = time.Second
 
-	// Typing keepalive (matches @tencent-weixin/openclaw-weixin npm package).
-	typingKeepaliveInterval = 5 * time.Second
-	typingTicketTTL         = 24 * time.Hour
+	// typingTicketTTL bounds how long a cached typing ticket is reused before
+	// SendTyping re-fetches one via GetConfig.
+	typingTicketTTL = 24 * time.Hour
 
 	// Error backoff.
 	reconnectDelay        = 5 * time.Second
@@ -241,8 +241,6 @@ type Adapter struct {
 
 	bot           *ilinkBot
 	sendQ         *sendQueue
-	keepalives    map[string]context.CancelFunc
-	keepalivesMu  sync.Mutex
 	typingTickets map[string]typingTicket
 	typingMu      sync.Mutex
 }
@@ -292,7 +290,6 @@ func New(cfg channel.PlatformConfig) (channel.Adapter, error) {
 		credPath:      credPath,
 		client:        client,
 		allowed:       allowed,
-		keepalives:    make(map[string]context.CancelFunc),
 		typingTickets: make(map[string]typingTicket),
 	}, nil
 }
@@ -395,7 +392,6 @@ func (a *Adapter) Stop() error {
 	if a.sendQ != nil {
 		a.sendQ.stop()
 	}
-	a.stopAllKeepalives()
 	return nil
 }
 
@@ -621,17 +617,22 @@ func (a *Adapter) UpdateMessage(chatID, messageID, text string) bool { return fa
 // SupportsMessageUpdates returns false.
 func (a *Adapter) SupportsMessageUpdates() bool { return false }
 
-// SelfSustainingTyping reports that a single SendTyping call already starts
-// a persistent internal keepalive (see startTypingKeepalive below) — callers
-// that re-invoke SendTyping on a fixed interval should skip the repeats for
-// this adapter (channel.SelfSustainingTyper).
-func (a *Adapter) SelfSustainingTyping() bool { return true }
-
-// StopTyping cancels the keepalive goroutine and sends sendtyping(status=2)
-// to clear the typing indicator in the WeChat client.
+// StopTyping sends sendtyping(status=2) to clear the typing indicator, using
+// the ticket cached by the last SendTyping call. A no-op if SendTyping was
+// never called for this chat (nothing to clear).
 func (a *Adapter) StopTyping(chatID, contextToken string) error {
-	a.stopTypingKeepalive(chatID)
-	return nil
+	if a.bot == nil || a.bot.creds == nil {
+		return nil
+	}
+	a.typingMu.Lock()
+	cached, ok := a.typingTickets[chatID]
+	a.typingMu.Unlock()
+	if !ok {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return a.bot.client.SendTyping(ctx, a.bot.creds.BaseURL, a.bot.creds.Token, chatID, cached.ticket, 2)
 }
 
 // Flush immediately drains any buffered outgoing messages for the chat.
@@ -648,34 +649,53 @@ func (a *Adapter) SendButtons(chatID, text string, buttons []channel.Button, rep
 	return a.SendText(chatID, text, replyTo)
 }
 
-// SendTyping triggers a typing indicator and starts keepalive.
+// SendTyping sends a single typing(status=1) ping using a cached ticket when
+// still fresh, or fetches a new one otherwise. Unlike the old implementation
+// this starts no background goroutine — the external typing keepalive
+// (internal/server) re-invokes SendTyping every 5s for the life of a turn,
+// uniformly across every adapter; the TTL cache here just keeps repeated
+// calls cheap (skipping the GetConfig round trip) instead of needing an
+// adapter-specific keepalive to avoid it.
 func (a *Adapter) SendTyping(chatID, contextToken string) error {
 	if a.bot == nil || a.bot.creds == nil {
 		return fmt.Errorf("not logged in")
 	}
 
+	ticket, err := a.typingTicketFor(chatID, contextToken)
+	if err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
+	return a.bot.client.SendTyping(ctx, a.bot.creds.BaseURL, a.bot.creds.Token, chatID, ticket, 1)
+}
 
+// typingTicketFor returns the cached typing ticket for chatID if it's still
+// within typingTicketTTL, fetching and caching a fresh one via GetConfig
+// otherwise.
+func (a *Adapter) typingTicketFor(chatID, contextToken string) (string, error) {
+	a.typingMu.Lock()
+	cached, ok := a.typingTickets[chatID]
+	a.typingMu.Unlock()
+	if ok && time.Since(cached.cachedAt) < typingTicketTTL {
+		return cached.ticket, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 	cfg, err := a.bot.client.GetConfig(ctx, a.bot.creds.BaseURL, a.bot.creds.Token, chatID, contextToken)
 	if err != nil {
-		return fmt.Errorf("getconfig: %w", err)
+		return "", fmt.Errorf("getconfig: %w", err)
 	}
 	if cfg.TypingTicket == "" {
-		return fmt.Errorf("no typing_ticket")
+		return "", fmt.Errorf("no typing_ticket")
 	}
 
-	// Cache the ticket.
 	a.typingMu.Lock()
 	a.typingTickets[chatID] = typingTicket{ticket: cfg.TypingTicket, cachedAt: time.Now()}
 	a.typingMu.Unlock()
-
-	// Send initial typing.
-	a.bot.client.SendTyping(ctx, a.bot.creds.BaseURL, a.bot.creds.Token, chatID, cfg.TypingTicket, 1)
-
-	// Start keepalive goroutine.
-	a.startTypingKeepalive(chatID, contextToken, cfg.TypingTicket)
-	return nil
+	return cfg.TypingTicket, nil
 }
 
 // ValidateConfig checks for token or credential file presence.
@@ -897,57 +917,6 @@ func detectImageMIME(raw []byte) string {
 		return "image/webp"
 	default:
 		return "image/jpeg"
-	}
-}
-
-// ─── Typing keepalive ────────────────────────────────────────────────────
-
-func (a *Adapter) startTypingKeepalive(userID, contextToken, ticket string) {
-	a.stopTypingKeepalive(userID)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	a.keepalivesMu.Lock()
-	a.keepalives[userID] = cancel
-	a.keepalivesMu.Unlock()
-
-	go func() {
-		ticker := time.NewTicker(typingKeepaliveInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				// Send status=2 (stop typing) on exit.
-				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Second)
-				a.bot.client.SendTyping(sctx, a.bot.creds.BaseURL, a.bot.creds.Token, userID, ticket, 2)
-				scancel()
-				return
-			case <-ticker.C:
-				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Second)
-				a.bot.client.SendTyping(sctx, a.bot.creds.BaseURL, a.bot.creds.Token, userID, ticket, 1)
-				scancel()
-			}
-		}
-	}()
-}
-
-func (a *Adapter) stopTypingKeepalive(userID string) {
-	a.keepalivesMu.Lock()
-	cancel, ok := a.keepalives[userID]
-	if ok {
-		delete(a.keepalives, userID)
-	}
-	a.keepalivesMu.Unlock()
-	if ok && cancel != nil {
-		cancel()
-	}
-}
-
-func (a *Adapter) stopAllKeepalives() {
-	a.keepalivesMu.Lock()
-	defer a.keepalivesMu.Unlock()
-	for userID, cancel := range a.keepalives {
-		cancel()
-		delete(a.keepalives, userID)
 	}
 }
 

--- a/internal/channel/ui_controller.go
+++ b/internal/channel/ui_controller.go
@@ -52,16 +52,31 @@ type UIController struct {
 	// inTool is true while we're between EventToolStarted and its matching done/error.
 	inTool bool
 
-	// sentTyping tracks whether we've already sent a typing indicator this turn.
-	sentTyping bool
+	// stopTyping cancels the caller's typing-keepalive ticker (see
+	// startTypingKeepalive in internal/server). Invoked once, the first time
+	// this turn's reply text is actually flushed to the adapter — the reply
+	// itself is then evidence the bot is alive, so there's no need to keep
+	// re-asserting typing for the rest of the turn or any turns chained after
+	// it (#1117). nil for callers that don't drive a keepalive (e.g. idle
+	// follow-up turns).
+	stopTyping func()
+
+	// typingStopped guards stopTyping so it fires at most once. Deliberately
+	// not reset by resetLocked: this controller is reused across chained
+	// turns within one inbound message, and once the user has seen a reply
+	// there's no need to re-arm typing for later turns in the same chain.
+	typingStopped bool
 }
 
 // NewUIController creates a controller bound to one chat conversation.
-func NewUIController(adapter Adapter, chatID, replyTo string) *UIController {
+// stopTyping, if non-nil, is invoked once on the first text this turn (or
+// any turn chained after it) flushes to the adapter.
+func NewUIController(adapter Adapter, chatID, replyTo string, stopTyping func()) *UIController {
 	return &UIController{
-		adapter: adapter,
-		chatID:  chatID,
-		replyTo: replyTo,
+		adapter:    adapter,
+		chatID:     chatID,
+		replyTo:    replyTo,
+		stopTyping: stopTyping,
 	}
 }
 
@@ -160,6 +175,13 @@ func (u *UIController) flushTextLocked() {
 	}
 	u.textBuf.Reset()
 
+	if !u.typingStopped {
+		u.typingStopped = true
+		if u.stopTyping != nil {
+			u.stopTyping()
+		}
+	}
+
 	// If the platform supports message updates and we already have a pending
 	// message, edit it in place with the FULL text streamed so far — the raw
 	// chunks are concatenated unmodified so paragraph breaks survive, and
@@ -218,7 +240,6 @@ func (u *UIController) resetLocked() {
 	u.fenceLang = ""
 	u.toolCount = 0
 	u.inTool = false
-	u.sentTyping = false
 }
 
 // shouldFlush returns true when the buffer should be sent.

--- a/internal/channel/ui_controller_test.go
+++ b/internal/channel/ui_controller_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestUIController_TextDeltaAccumulation(t *testing.T) {
 	mock := &mockAdapter{platform: "mock"}
-	ctrl := NewUIController(mock, "chat1", "msg1")
+	ctrl := NewUIController(mock, "chat1", "msg1", nil)
 	handler := ctrl.Handler()
 
 	// Simulate streaming text deltas.
@@ -39,7 +39,7 @@ func TestUIController_TextDeltaAccumulation(t *testing.T) {
 
 func TestUIController_ToolEventsSuppressed(t *testing.T) {
 	mock := &mockAdapter{platform: "mock"}
-	ctrl := NewUIController(mock, "chat1", "")
+	ctrl := NewUIController(mock, "chat1", "", nil)
 	handler := ctrl.Handler()
 
 	// Tool started — should not send anything.
@@ -64,7 +64,7 @@ func TestUIController_ToolEventsSuppressed(t *testing.T) {
 
 func TestUIController_ToolDoneSuppressed(t *testing.T) {
 	mock := &mockAdapter{platform: "mock"}
-	ctrl := NewUIController(mock, "chat1", "")
+	ctrl := NewUIController(mock, "chat1", "", nil)
 	handler := ctrl.Handler()
 
 	output := "Read file: /path/to/file.go\nContent: package main"
@@ -89,7 +89,7 @@ func TestUIController_ToolDoneSuppressed(t *testing.T) {
 
 func TestUIController_ToolErrorSuppressed(t *testing.T) {
 	mock := &mockAdapter{platform: "mock"}
-	ctrl := NewUIController(mock, "chat1", "")
+	ctrl := NewUIController(mock, "chat1", "", nil)
 	handler := ctrl.Handler()
 
 	handler(agent.AgentEvent{Kind: agent.EventToolStarted, ToolName: "read_file"})
@@ -146,7 +146,7 @@ func TestUIController_Truncate(t *testing.T) {
 
 func TestUIController_MessageUpdate(t *testing.T) {
 	mock := &mockAdapter{platform: "mock"}
-	ctrl := NewUIController(mock, "chat1", "")
+	ctrl := NewUIController(mock, "chat1", "", nil)
 	handler := ctrl.Handler()
 
 	// First delta — should send a new message.
@@ -159,7 +159,7 @@ func TestUIController_MessageUpdate(t *testing.T) {
 
 	// Reset and simulate a platform that supports updates.
 	mock = &mockAdapter{platform: "mock"}
-	ctrl = NewUIController(mock, "chat1", "")
+	ctrl = NewUIController(mock, "chat1", "", nil)
 	handler = ctrl.Handler()
 
 	// Simulate a large text that gets flushed mid-stream, then updated.
@@ -176,7 +176,7 @@ func TestUIController_MessageUpdate(t *testing.T) {
 
 func TestRunAgent(t *testing.T) {
 	mock := &mockAdapter{platform: "mock"}
-	ctrl := NewUIController(mock, "chat1", "")
+	ctrl := NewUIController(mock, "chat1", "", nil)
 
 	sess := &Session{
 		Key:    "test",
@@ -204,7 +204,7 @@ func TestRunAgent(t *testing.T) {
 // only the newest chunk would erase what the user already read (#1115).
 func TestUIController_UpdateCarriesFullText(t *testing.T) {
 	mock := &mockAdapter{platform: "mock", issueMsgIDs: true}
-	ctrl := NewUIController(mock, "chat1", "")
+	ctrl := NewUIController(mock, "chat1", "", nil)
 	handler := ctrl.Handler()
 
 	// First flush: paragraph break → new message with chunk 1.
@@ -250,7 +250,7 @@ func TestUIController_UpdateCarriesFullText(t *testing.T) {
 // subsequent edits target the new message with its own accumulated text.
 func TestUIController_UpdateFailureStartsFreshMessage(t *testing.T) {
 	mock := &mockAdapter{platform: "mock", issueMsgIDs: true, failUpdates: true}
-	ctrl := NewUIController(mock, "chat1", "")
+	ctrl := NewUIController(mock, "chat1", "", nil)
 	handler := ctrl.Handler()
 
 	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "One.\n\n"})
@@ -287,7 +287,7 @@ func TestUIController_UpdateFailureStartsFreshMessage(t *testing.T) {
 // its own message.
 func TestUIController_NoUpdatesPlatformSendsChunks(t *testing.T) {
 	mock := &mockAdapter{platform: "mock", issueMsgIDs: true, noUpdates: true}
-	ctrl := NewUIController(mock, "chat1", "")
+	ctrl := NewUIController(mock, "chat1", "", nil)
 	handler := ctrl.Handler()
 
 	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "One.\n\n"})
@@ -313,7 +313,7 @@ func TestUIController_NoUpdatesPlatformSendsChunks(t *testing.T) {
 // A new turn must not edit the previous turn's message.
 func TestUIController_NewTurnStartsNewMessage(t *testing.T) {
 	mock := &mockAdapter{platform: "mock", issueMsgIDs: true}
-	ctrl := NewUIController(mock, "chat1", "")
+	ctrl := NewUIController(mock, "chat1", "", nil)
 	handler := ctrl.Handler()
 
 	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "Turn one."})
@@ -337,7 +337,7 @@ func TestUIController_NewTurnStartsNewMessage(t *testing.T) {
 // with whatever text follows) on the next successful flush.
 func TestUIController_DoubleFailureRetriesChunk(t *testing.T) {
 	mock := &mockAdapter{platform: "mock", issueMsgIDs: true}
-	ctrl := NewUIController(mock, "chat1", "")
+	ctrl := NewUIController(mock, "chat1", "", nil)
 	handler := ctrl.Handler()
 
 	// Establish a pending message normally.
@@ -388,7 +388,7 @@ func TestUIController_DoubleFailureRetriesChunk(t *testing.T) {
 // unclosed code block and the second resumes mid-code with no fence at all.
 func TestUIController_NoUpdatesPlatformCarriesFenceAcrossFlushes(t *testing.T) {
 	mock := &mockAdapter{platform: "mock", issueMsgIDs: true, noUpdates: true}
-	ctrl := NewUIController(mock, "chat1", "")
+	ctrl := NewUIController(mock, "chat1", "", nil)
 	handler := ctrl.Handler()
 
 	// Flush 1 (paragraph-break heuristic fires mid-fence): the buffer has an
@@ -427,7 +427,7 @@ func TestUIController_NoUpdatesPlatformCarriesFenceAcrossFlushes(t *testing.T) {
 // via edits since and would be stale.
 func TestUIController_EditFailureRecomputesFenceFromFrozenText(t *testing.T) {
 	mock := &mockAdapter{platform: "mock", issueMsgIDs: true}
-	ctrl := NewUIController(mock, "chat1", "")
+	ctrl := NewUIController(mock, "chat1", "", nil)
 	handler := ctrl.Handler()
 
 	// Flush 1 (SendText — no pending message yet): plain text, no fence.
@@ -461,5 +461,53 @@ func TestUIController_EditFailureRecomputesFenceFromFrozenText(t *testing.T) {
 	}
 	if open, _ := fenceStateAfter(fallback, false, ""); open {
 		t.Errorf("fallback message ends with an unclosed fence: %q", fallback)
+	}
+}
+
+// stopTyping must fire exactly once, on the first flush that actually
+// delivers text — not on every flush, and not on a flush of an empty/
+// whitespace-only buffer (#1117).
+func TestUIController_StopTypingFiresOnceOnFirstFlush(t *testing.T) {
+	mock := &mockAdapter{platform: "mock"}
+	var stops int
+	ctrl := NewUIController(mock, "chat1", "", func() { stops++ })
+	handler := ctrl.Handler()
+
+	// A tool-only turn with no text must not fire stopTyping — there is
+	// nothing to show the user yet.
+	handler(agent.AgentEvent{Kind: agent.EventToolStarted, ToolName: "read_file"})
+	handler(agent.AgentEvent{Kind: agent.EventToolDone, ToolName: "read_file"})
+	if stops != 0 {
+		t.Fatalf("stopTyping fired before any text flushed, count = %d", stops)
+	}
+
+	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "One.\n\n"})
+	if stops != 1 {
+		t.Fatalf("stopTyping should fire on the first real flush, count = %d", stops)
+	}
+
+	// A later flush in the same turn, and a whole new chained turn, must not
+	// fire it again.
+	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "Two.\n\n"})
+	handler(agent.AgentEvent{Kind: agent.EventTurnDone, Reply: &agent.Reply{}})
+	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "Turn two."})
+	handler(agent.AgentEvent{Kind: agent.EventTurnDone, Reply: &agent.Reply{}})
+	if stops != 1 {
+		t.Fatalf("stopTyping should fire at most once across chained turns, count = %d", stops)
+	}
+}
+
+// A nil stopTyping (e.g. idle follow-up turns, which don't run a keepalive)
+// must not panic.
+func TestUIController_NilStopTypingIsSafe(t *testing.T) {
+	mock := &mockAdapter{platform: "mock"}
+	ctrl := NewUIController(mock, "chat1", "", nil)
+	handler := ctrl.Handler()
+
+	handler(agent.AgentEvent{Kind: agent.EventTextDelta, Text: "Hello"})
+	handler(agent.AgentEvent{Kind: agent.EventTurnDone, Reply: &agent.Reply{}})
+
+	if mock.sentTextCount() != 1 {
+		t.Fatalf("expected 1 sent text, got %d", mock.sentTextCount())
 	}
 }

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -18,8 +18,10 @@ import (
 // recording SendText calls — handleChannelMessage runs a real turn through
 // the UIController, which touches typing/update methods too.
 type fullFakeAdapter struct {
-	mu   sync.Mutex
-	sent []string
+	mu              sync.Mutex
+	sent            []string
+	sendTypingCount int
+	stopTypingCount int
 }
 
 func (a *fullFakeAdapter) Platform() string { return "fake" }
@@ -39,15 +41,31 @@ func (a *fullFakeAdapter) SendFile(chatID, path, name, replyTo string) channel.S
 }
 func (a *fullFakeAdapter) UpdateMessage(chatID, messageID, text string) bool { return true }
 func (a *fullFakeAdapter) SupportsMessageUpdates() bool                      { return false }
-func (a *fullFakeAdapter) SendTyping(chatID, contextToken string) error      { return nil }
-func (a *fullFakeAdapter) StopTyping(chatID, contextToken string) error      { return nil }
-func (a *fullFakeAdapter) Flush(chatID string)                               {}
-func (a *fullFakeAdapter) ValidateConfig(channel.PlatformConfig) []string    { return nil }
+func (a *fullFakeAdapter) SendTyping(chatID, contextToken string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.sendTypingCount++
+	return nil
+}
+func (a *fullFakeAdapter) StopTyping(chatID, contextToken string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stopTypingCount++
+	return nil
+}
+func (a *fullFakeAdapter) Flush(chatID string)                            {}
+func (a *fullFakeAdapter) ValidateConfig(channel.PlatformConfig) []string { return nil }
 
 func (a *fullFakeAdapter) texts() []string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return append([]string(nil), a.sent...)
+}
+
+func (a *fullFakeAdapter) typingCounts() (sendTyping, stopTyping int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.sendTypingCount, a.stopTypingCount
 }
 
 // chanServer returns a mustServer with a channel manager wired to stub agents.
@@ -148,6 +166,28 @@ func TestHandleChannelMessage_SetsPerTurnGate(t *testing.T) {
 
 	if sess.Agent.Gate == nil {
 		t.Error("handleChannelMessage must set a per-turn permission gate")
+	}
+}
+
+// TestHandleChannelMessage_TypingKeepaliveWired is an end-to-end regression
+// test for #1117: handleChannelMessage must start the typing keepalive
+// before running the turn and stop it exactly once by the time it returns.
+// This catches a future refactor silently dropping stopTyping somewhere in
+// the handleChannelMessage -> runChannelTurns -> NewUIController chain — the
+// unit tests for channel_typing.go and UIController's stopTyping callback
+// each pass even if the wiring between them breaks.
+func TestHandleChannelMessage_TypingKeepaliveWired(t *testing.T) {
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+
+	sendTyping, stopTyping := ad.typingCounts()
+	if sendTyping == 0 {
+		t.Error("handleChannelMessage must call SendTyping at least once")
+	}
+	if stopTyping != 1 {
+		t.Errorf("handleChannelMessage must call StopTyping exactly once, got %d", stopTyping)
 	}
 }
 

--- a/internal/server/channel_typing.go
+++ b/internal/server/channel_typing.go
@@ -17,9 +17,11 @@ const typingKeepaliveInterval = 5 * time.Second
 
 // startTypingKeepalive sends an initial typing indicator and re-sends it
 // every typingKeepaliveInterval until the returned stop func is called (safe
-// to call more than once — only the first call has an effect). Without this,
-// a long agentic turn goes dark to the user the moment the platform's own
-// typing indicator expires (or never showed one at all, e.g. Feishu),
+// to call more than once — only the first call has an effect; every call
+// blocks until the keepalive goroutine has actually invoked StopTyping, so
+// callers can rely on it being cleared by the time stop returns). Without
+// this, a long agentic turn goes dark to the user the moment the platform's
+// own typing indicator expires (or never showed one at all, e.g. Feishu),
 // reading as the bot having died (#1117).
 func startTypingKeepalive(ad channel.Adapter, chatID, contextToken string) (stop func()) {
 	return startTypingKeepaliveInterval(ad, chatID, contextToken, typingKeepaliveInterval)
@@ -29,8 +31,12 @@ func startTypingKeepalive(ad channel.Adapter, chatID, contextToken string) (stop
 // interval, so tests don't have to wait out the real 5s cadence.
 func startTypingKeepaliveInterval(ad channel.Adapter, chatID, contextToken string, interval time.Duration) (stop func()) {
 	done := make(chan struct{})
+	finished := make(chan struct{})
 	var once sync.Once
-	stop = func() { once.Do(func() { close(done) }) }
+	stop = func() {
+		once.Do(func() { close(done) })
+		<-finished
+	}
 
 	sendTyping := func() {
 		if err := ad.SendTyping(chatID, contextToken); err != nil {
@@ -40,6 +46,7 @@ func startTypingKeepaliveInterval(ad channel.Adapter, chatID, contextToken strin
 	sendTyping()
 
 	go func() {
+		defer close(finished)
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {

--- a/internal/server/channel_typing.go
+++ b/internal/server/channel_typing.go
@@ -9,11 +9,10 @@ import (
 )
 
 // typingKeepaliveInterval is how often SendTyping is re-invoked while a turn
-// is in flight, for adapters that need it. Telegram/Discord's typing
-// indicator expires client-side in 5-10s; Feishu/DingTalk/WeCom's SendTyping
-// is a no-op so repeating it costs nothing. Weixin sustains its own typing
-// indicator after a single call and opts out of the repeat entirely — see
-// channel.SelfSustainingTyper below.
+// is in flight. Telegram/Discord's typing indicator expires client-side in
+// 5-10s; Feishu/DingTalk/WeCom's SendTyping is a no-op so repeating it costs
+// nothing; Weixin caches its typing ticket (typingTicketTTL) so a repeat call
+// is a cheap wire ping, not a fresh GetConfig round trip.
 const typingKeepaliveInterval = 5 * time.Second
 
 // startTypingKeepalive sends an initial typing indicator and re-sends it
@@ -39,22 +38,6 @@ func startTypingKeepaliveInterval(ad channel.Adapter, chatID, contextToken strin
 		}
 	}
 	sendTyping()
-
-	// An adapter that already sustains its own typing indicator after one
-	// call (currently only Weixin) doesn't need — and shouldn't get —
-	// repeated SendTyping calls: each one re-fetches Weixin's typing ticket
-	// and restarts its internal keepalive goroutine, so ticking every 5s here
-	// would just rack up redundant backend round-trips for the whole turn
-	// with no additional user-visible effect.
-	if ss, ok := ad.(channel.SelfSustainingTyper); ok && ss.SelfSustainingTyping() {
-		go func() {
-			<-done
-			if err := ad.StopTyping(chatID, contextToken); err != nil {
-				slog.Debug("channel stopTyping", "platform", ad.Platform(), "err", err)
-			}
-		}()
-		return stop
-	}
 
 	go func() {
 		ticker := time.NewTicker(interval)

--- a/internal/server/channel_typing.go
+++ b/internal/server/channel_typing.go
@@ -9,10 +9,11 @@ import (
 )
 
 // typingKeepaliveInterval is how often SendTyping is re-invoked while a turn
-// is in flight. Telegram/Discord's typing indicator expires client-side in
-// 5-10s; Feishu/DingTalk/WeCom's SendTyping is a no-op so repeating it costs
-// nothing; Weixin's own SendTyping already runs a persistent per-chat
-// keepalive, so repeating it here just re-arms an already-idempotent ticker.
+// is in flight, for adapters that need it. Telegram/Discord's typing
+// indicator expires client-side in 5-10s; Feishu/DingTalk/WeCom's SendTyping
+// is a no-op so repeating it costs nothing. Weixin sustains its own typing
+// indicator after a single call and opts out of the repeat entirely — see
+// channel.SelfSustainingTyper below.
 const typingKeepaliveInterval = 5 * time.Second
 
 // startTypingKeepalive sends an initial typing indicator and re-sends it
@@ -34,10 +35,26 @@ func startTypingKeepaliveInterval(ad channel.Adapter, chatID, contextToken strin
 
 	sendTyping := func() {
 		if err := ad.SendTyping(chatID, contextToken); err != nil {
-			slog.Debug("channel sendTyping", "err", err)
+			slog.Debug("channel sendTyping", "platform", ad.Platform(), "err", err)
 		}
 	}
 	sendTyping()
+
+	// An adapter that already sustains its own typing indicator after one
+	// call (currently only Weixin) doesn't need — and shouldn't get —
+	// repeated SendTyping calls: each one re-fetches Weixin's typing ticket
+	// and restarts its internal keepalive goroutine, so ticking every 5s here
+	// would just rack up redundant backend round-trips for the whole turn
+	// with no additional user-visible effect.
+	if ss, ok := ad.(channel.SelfSustainingTyper); ok && ss.SelfSustainingTyping() {
+		go func() {
+			<-done
+			if err := ad.StopTyping(chatID, contextToken); err != nil {
+				slog.Debug("channel stopTyping", "platform", ad.Platform(), "err", err)
+			}
+		}()
+		return stop
+	}
 
 	go func() {
 		ticker := time.NewTicker(interval)
@@ -46,7 +63,7 @@ func startTypingKeepaliveInterval(ad channel.Adapter, chatID, contextToken strin
 			select {
 			case <-done:
 				if err := ad.StopTyping(chatID, contextToken); err != nil {
-					slog.Debug("channel stopTyping", "err", err)
+					slog.Debug("channel stopTyping", "platform", ad.Platform(), "err", err)
 				}
 				return
 			case <-ticker.C:

--- a/internal/server/channel_typing.go
+++ b/internal/server/channel_typing.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/open-octo/octo-agent/internal/channel"
+)
+
+// typingKeepaliveInterval is how often SendTyping is re-invoked while a turn
+// is in flight. Telegram/Discord's typing indicator expires client-side in
+// 5-10s; Feishu/DingTalk/WeCom's SendTyping is a no-op so repeating it costs
+// nothing; Weixin's own SendTyping already runs a persistent per-chat
+// keepalive, so repeating it here just re-arms an already-idempotent ticker.
+const typingKeepaliveInterval = 5 * time.Second
+
+// startTypingKeepalive sends an initial typing indicator and re-sends it
+// every typingKeepaliveInterval until the returned stop func is called (safe
+// to call more than once — only the first call has an effect). Without this,
+// a long agentic turn goes dark to the user the moment the platform's own
+// typing indicator expires (or never showed one at all, e.g. Feishu),
+// reading as the bot having died (#1117).
+func startTypingKeepalive(ad channel.Adapter, chatID, contextToken string) (stop func()) {
+	return startTypingKeepaliveInterval(ad, chatID, contextToken, typingKeepaliveInterval)
+}
+
+// startTypingKeepaliveInterval is startTypingKeepalive with an injectable
+// interval, so tests don't have to wait out the real 5s cadence.
+func startTypingKeepaliveInterval(ad channel.Adapter, chatID, contextToken string, interval time.Duration) (stop func()) {
+	done := make(chan struct{})
+	var once sync.Once
+	stop = func() { once.Do(func() { close(done) }) }
+
+	sendTyping := func() {
+		if err := ad.SendTyping(chatID, contextToken); err != nil {
+			slog.Debug("channel sendTyping", "err", err)
+		}
+	}
+	sendTyping()
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				if err := ad.StopTyping(chatID, contextToken); err != nil {
+					slog.Debug("channel stopTyping", "err", err)
+				}
+				return
+			case <-ticker.C:
+				sendTyping()
+			}
+		}
+	}()
+	return stop
+}

--- a/internal/server/channel_typing_test.go
+++ b/internal/server/channel_typing_test.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/open-octo/octo-agent/internal/channel"
+)
+
+// typingCountAdapter implements channel.Adapter with no-ops everywhere except
+// SendTyping/StopTyping, which it counts.
+type typingCountAdapter struct {
+	mu         sync.Mutex
+	sendTyping int
+	stopTyping int
+}
+
+func (a *typingCountAdapter) Platform() string { return "fake" }
+func (a *typingCountAdapter) Start(ctx context.Context, _ func(channel.InboundEvent)) error {
+	<-ctx.Done()
+	return nil
+}
+func (a *typingCountAdapter) Stop() error { return nil }
+func (a *typingCountAdapter) SendText(chatID, text, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: true}
+}
+func (a *typingCountAdapter) SendFile(chatID, path, name, replyTo string) channel.SendResult {
+	return channel.SendResult{OK: true}
+}
+func (a *typingCountAdapter) UpdateMessage(chatID, messageID, text string) bool { return true }
+func (a *typingCountAdapter) SupportsMessageUpdates() bool                      { return false }
+func (a *typingCountAdapter) SendTyping(chatID, contextToken string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.sendTyping++
+	return nil
+}
+func (a *typingCountAdapter) StopTyping(chatID, contextToken string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stopTyping++
+	return nil
+}
+func (a *typingCountAdapter) Flush(chatID string)                            {}
+func (a *typingCountAdapter) ValidateConfig(channel.PlatformConfig) []string { return nil }
+
+func (a *typingCountAdapter) counts() (sendTyping, stopTyping int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.sendTyping, a.stopTyping
+}
+
+func TestStartTypingKeepalive_RepeatsUntilStopped(t *testing.T) {
+	ad := &typingCountAdapter{}
+	stop := startTypingKeepaliveInterval(ad, "chat1", "", 20*time.Millisecond)
+
+	if send, _ := ad.counts(); send != 1 {
+		t.Fatalf("SendTyping should fire immediately, count = %d", send)
+	}
+
+	// Wait long enough for at least two more ticks.
+	time.Sleep(70 * time.Millisecond)
+	sendBefore, stopBefore := ad.counts()
+	if sendBefore < 3 {
+		t.Fatalf("expected SendTyping to repeat on the ticker, count = %d", sendBefore)
+	}
+	if stopBefore != 0 {
+		t.Fatalf("StopTyping should not fire before stop() is called, count = %d", stopBefore)
+	}
+
+	stop()
+	// Let the goroutine observe the close and call StopTyping.
+	time.Sleep(20 * time.Millisecond)
+	sendAfterStop, stopAfter := ad.counts()
+	if stopAfter != 1 {
+		t.Fatalf("StopTyping should fire exactly once after stop(), count = %d", stopAfter)
+	}
+
+	// No further SendTyping calls once stopped.
+	time.Sleep(50 * time.Millisecond)
+	sendFinal, stopFinal := ad.counts()
+	if sendFinal != sendAfterStop {
+		t.Fatalf("SendTyping fired after stop(): before=%d after=%d", sendAfterStop, sendFinal)
+	}
+	if stopFinal != 1 {
+		t.Fatalf("StopTyping fired more than once: %d", stopFinal)
+	}
+}
+
+func TestStartTypingKeepalive_StopIsIdempotent(t *testing.T) {
+	ad := &typingCountAdapter{}
+	stop := startTypingKeepaliveInterval(ad, "chat1", "", 10*time.Millisecond)
+
+	stop()
+	stop()
+	stop()
+	time.Sleep(20 * time.Millisecond)
+
+	if _, stopCount := ad.counts(); stopCount != 1 {
+		t.Fatalf("StopTyping should fire exactly once no matter how many times stop() is called, count = %d", stopCount)
+	}
+}

--- a/internal/server/channel_typing_test.go
+++ b/internal/server/channel_typing_test.go
@@ -102,3 +102,39 @@ func TestStartTypingKeepalive_StopIsIdempotent(t *testing.T) {
 		t.Fatalf("StopTyping should fire exactly once no matter how many times stop() is called, count = %d", stopCount)
 	}
 }
+
+// selfSustainingTypingCountAdapter is a typingCountAdapter that opts out of
+// repeated SendTyping calls via channel.SelfSustainingTyper, mirroring the
+// Weixin adapter (whose SendTyping already starts its own internal
+// keepalive, so repeat calls would just re-fetch its typing ticket and
+// restart that internal keepalive for no user-visible benefit).
+type selfSustainingTypingCountAdapter struct {
+	typingCountAdapter
+}
+
+func (a *selfSustainingTypingCountAdapter) SelfSustainingTyping() bool { return true }
+
+func TestStartTypingKeepalive_SelfSustainingAdapterSkipsRepeats(t *testing.T) {
+	ad := &selfSustainingTypingCountAdapter{}
+	stop := startTypingKeepaliveInterval(ad, "chat1", "", 10*time.Millisecond)
+
+	if send, _ := ad.counts(); send != 1 {
+		t.Fatalf("SendTyping should fire exactly once up front, count = %d", send)
+	}
+
+	// Long enough for several ticks of the (skipped) interval loop.
+	time.Sleep(50 * time.Millisecond)
+	if send, stopped := ad.counts(); send != 1 || stopped != 0 {
+		t.Fatalf("self-sustaining adapter should get no repeat SendTyping calls before stop, got send=%d stop=%d", send, stopped)
+	}
+
+	stop()
+	time.Sleep(20 * time.Millisecond)
+	send, stopped := ad.counts()
+	if send != 1 {
+		t.Fatalf("SendTyping should still be called only once total, got %d", send)
+	}
+	if stopped != 1 {
+		t.Fatalf("StopTyping should fire exactly once after stop(), got %d", stopped)
+	}
+}

--- a/internal/server/channel_typing_test.go
+++ b/internal/server/channel_typing_test.go
@@ -106,39 +106,3 @@ func TestStartTypingKeepalive_StopIsIdempotent(t *testing.T) {
 		t.Fatalf("StopTyping should fire exactly once no matter how many times stop() is called, count = %d", stopCount)
 	}
 }
-
-// selfSustainingTypingCountAdapter is a typingCountAdapter that opts out of
-// repeated SendTyping calls via channel.SelfSustainingTyper, mirroring the
-// Weixin adapter (whose SendTyping already starts its own internal
-// keepalive, so repeat calls would just re-fetch its typing ticket and
-// restart that internal keepalive for no user-visible benefit).
-type selfSustainingTypingCountAdapter struct {
-	typingCountAdapter
-}
-
-func (a *selfSustainingTypingCountAdapter) SelfSustainingTyping() bool { return true }
-
-func TestStartTypingKeepalive_SelfSustainingAdapterSkipsRepeats(t *testing.T) {
-	ad := &selfSustainingTypingCountAdapter{}
-	stop := startTypingKeepaliveInterval(ad, "chat1", "", 10*time.Millisecond)
-
-	if send, _ := ad.counts(); send != 1 {
-		t.Fatalf("SendTyping should fire exactly once up front, count = %d", send)
-	}
-
-	// Long enough for several ticks of the (skipped) interval loop.
-	time.Sleep(50 * time.Millisecond)
-	if send, stopped := ad.counts(); send != 1 || stopped != 0 {
-		t.Fatalf("self-sustaining adapter should get no repeat SendTyping calls before stop, got send=%d stop=%d", send, stopped)
-	}
-
-	stop()
-	time.Sleep(20 * time.Millisecond)
-	send, stopped := ad.counts()
-	if send != 1 {
-		t.Fatalf("SendTyping should still be called only once total, got %d", send)
-	}
-	if stopped != 1 {
-		t.Fatalf("StopTyping should fire exactly once after stop(), got %d", stopped)
-	}
-}

--- a/internal/server/channel_typing_test.go
+++ b/internal/server/channel_typing_test.go
@@ -74,9 +74,7 @@ func TestStartTypingKeepalive_RepeatsUntilStopped(t *testing.T) {
 		t.Fatalf("StopTyping should not fire before stop() is called, count = %d", stopBefore)
 	}
 
-	stop()
-	// Let the goroutine observe the close and call StopTyping.
-	time.Sleep(20 * time.Millisecond)
+	stop() // blocks until the keepalive goroutine has actually called StopTyping
 	sendAfterStop, stopAfter := ad.counts()
 	if stopAfter != 1 {
 		t.Fatalf("StopTyping should fire exactly once after stop(), count = %d", stopAfter)
@@ -100,7 +98,6 @@ func TestStartTypingKeepalive_StopIsIdempotent(t *testing.T) {
 	stop()
 	stop()
 	stop()
-	time.Sleep(20 * time.Millisecond)
 
 	if _, stopCount := ad.counts(); stopCount != 1 {
 		t.Fatalf("StopTyping should fire exactly once no matter how many times stop() is called, count = %d", stopCount)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2361,19 +2361,16 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	ctx, done := sess.BeginRun(ctx)
 	defer done()
 
-	// Start typing keepalive BEFORE sending any text. The WeChat iLink protocol
-	// cancels the typing indicator on sendmessage, so the keepalive must already
-	// be running when the acknowledgment message is sent so it can immediately
-	// re-assert the typing state. Other platforms treat this as a no-op or a
-	// self-expiring hint (Telegram, Discord) — safe to call universally.
-	if err := ad.SendTyping(ev.ChatID, ev.ContextToken); err != nil {
-		slog.Debug("channel sendTyping", "platform", ev.Platform, "err", err)
-	}
-	defer func() {
-		if err := ad.StopTyping(ev.ChatID, ev.ContextToken); err != nil {
-			slog.Debug("channel stopTyping", "platform", ev.Platform, "err", err)
-		}
-	}()
+	// Start a typing keepalive BEFORE sending any text — the WeChat iLink
+	// protocol cancels the typing indicator on sendmessage, so it must
+	// already be running when the acknowledgment message is sent so it can
+	// immediately re-assert the typing state. It re-fires every 5s for the
+	// rest of the turn — and any turns chained after it — so a multi-minute
+	// agentic turn never goes dark; ctrl (built in runChannelTurns) stops it
+	// early the moment the reply's first chunk actually reaches the user
+	// (#1117).
+	stopTyping := startTypingKeepalive(ad, ev.ChatID, ev.ContextToken)
+	defer stopTyping()
 
 	// Acknowledge receipt immediately so the user knows the message landed
 	// while the agent is working. Mirrors Ruby channel_manager behaviour.
@@ -2389,7 +2386,7 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 	// read_file-able path notes. Without this only ev.Text reaches the model.
 	content := s.attachInboundFiles(sess, ev)
 
-	s.runChannelTurns(ctx, sess, ad, ev, content)
+	s.runChannelTurns(ctx, sess, ad, ev, content, stopTyping)
 
 	// A steer that arrived during a restart drain would die with the
 	// process (the Inbox is memory-only) — give it the same retry notice a
@@ -2486,13 +2483,17 @@ func (s *Server) runChannelIdleTurn(ctx context.Context, sess *channel.Session, 
 		return
 	}
 
-	s.runChannelTurns(ctx, sess, ad, ev, strings.Join(agent.Texts(items), "\n\n"))
+	// No typing keepalive here: idle turns fire from a background completion,
+	// not a message the user is actively waiting on — nothing to reassure.
+	s.runChannelTurns(ctx, sess, ad, ev, strings.Join(agent.Texts(items), "\n\n"), nil)
 }
 
 // runChannelTurns executes one content-bearing turn plus any chained turns
 // drained from the agent's Inbox. It is shared between user-initiated and
-// idle-triggered channel turns.
-func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad channel.Adapter, ev channel.InboundEvent, content string) {
+// idle-triggered channel turns. stopTyping, if non-nil, cancels the caller's
+// typing-keepalive ticker the first time this chain's reply text reaches the
+// user (see channel.NewUIController).
+func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad channel.Adapter, ev channel.InboundEvent, content string, stopTyping func()) {
 	// Recompose the system prompt every turn so memory written and skills
 	// imported/toggled since server start are visible — web turns get this
 	// for free from buildAgent; the IM factory's compose-once snapshot went
@@ -2547,7 +2548,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	engine.AttachRemembered(s.rememberedFor("im:" + string(sess.Key)))
 	sess.Agent.Gate = app.NewPermissionGate(engine, s.channelPermissionAsk(sess, ad, ev))
 
-	ctrl := channel.NewUIController(ad, ev.ChatID, ev.MessageID)
+	ctrl := channel.NewUIController(ad, ev.ChatID, ev.MessageID, stopTyping)
 
 	// The persisted backing session carries the conversation's goal — the
 	// same record every transport bound to this session sees. Wire it as the


### PR DESCRIPTION
## Summary

For a long agentic turn, IM users previously got:
- One typing indicator at message receipt, self-expiring in ~5-10s (Telegram/Discord) — never refreshed.
- On Feishu, DingTalk, WeCom: nothing at all — `SendTyping` is a platform no-op.
- All tool activity suppressed by design, so no progress signal of any kind until the first text flush.

The user concludes the bot is dead and re-sends, which mid-turn becomes a steer (or, during a pending permission ask, gets consumed as a deny).

## Fix

- `internal/server/channel_typing.go`: `startTypingKeepalive` replaces the old one-shot `ad.SendTyping`/`defer ad.StopTyping` bracket in `handleChannelMessage` — it sends immediately, then re-invokes `SendTyping` every 5s until stopped, uniformly for every adapter. Feishu/DingTalk/WeCom's no-op `SendTyping` costs nothing to repeat; Telegram/Discord's self-expiring indicator gets refreshed exactly as their platforms expect.
- `internal/channel/adapters/weixin/weixin.go`: Weixin's `SendTyping` used to start its own internal keepalive goroutine (re-fetching its typing ticket and restarting that goroutine on every call). Rather than special-casing it against the new external keepalive, its `SendTyping` now caches the typing ticket for 24h (`typingTicketTTL`) and skips the `GetConfig` round trip on cache hits, with no background goroutine at all — `StopTyping` just sends the stop signal directly using the cached ticket. This makes Weixin behave like every other adapter from the caller's side, and it now does *fewer* `GetConfig` calls than before this whole feature (once per 24h window instead of once per external 5s tick).
- `internal/channel/ui_controller.go`: `UIController` now takes a `stopTyping func()`, invoked exactly once — the first time this turn's (or a chained turn's) reply text is actually flushed to the adapter. Once the user has seen real output, the keepalive stops early instead of running until the whole turn (possibly a multi-turn chain) ends. This finally gives the long-dead `sentTyping` field a real purpose — repurposed/renamed to `stopTyping`/`typingStopped`.
- Scoped to the user-initiated `handleChannelMessage` path. Idle follow-up turns (background task/workflow completions) pass a `nil` stopTyping and keep their existing no-typing-indicator behavior — they aren't a message the user is actively staring at waiting for a response.

## Not in scope (flagged, not fixed here)

The issue also mentions a related ask-UX problem — a re-sent message can get silently consumed as a deny of a pending permission ask (`internal/channel/ask.go`, `internal/server/channel_ask.go`). That's a separate, larger UX change and isn't addressed by this PR.

## Test plan
- [x] `internal/server/channel_typing_test.go`: `startTypingKeepaliveInterval` repeats on the ticker, `stop()` is idempotent and calls `StopTyping` exactly once, no further `SendTyping` after stop.
- [x] `internal/channel/ui_controller_test.go`: `stopTyping` fires exactly once on the first real text flush, not on tool-only activity, and not again across chained turns reusing the same controller; a `nil` stopTyping doesn't panic.
- [x] `internal/server/channel_route_test.go`: `TestHandleChannelMessage_TypingKeepaliveWired` — end-to-end through `handleChannelMessage`, asserting `SendTyping` fires and `StopTyping` fires exactly once.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test -race ./internal/channel/... ./internal/server/...` passes

## Review history

An isolated code review flagged two Important items:
1. Weixin's `SendTyping` restarting its own internal keepalive every 5s for no benefit — initially fixed via a `SelfSustainingTyper` opt-out interface, then simplified further per user request: instead of special-casing Weixin, its `SendTyping` was made cheap to call repeatedly (ticket caching, no goroutine), so the keepalive treats every adapter uniformly and `SelfSustainingTyper` was removed entirely.
2. Missing end-to-end wiring test — added `TestHandleChannelMessage_TypingKeepaliveWired`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)