### PR TITLE
fix(tui): persist input history across sessions

### DIFF
--- a/cmd/octo/inputhistory.go
+++ b/cmd/octo/inputhistory.go
@@ -44,19 +44,25 @@ func loadInputHistory(path string) []string {
 	}
 	defer f.Close()
 
+	// bufio.Reader.ReadString, not Scanner: a Scanner aborts the whole read
+	// (dropping every entry after the bad line, including the newest ones)
+	// the moment one physical line exceeds its buffer cap — a real risk here
+	// since a folded multi-line paste is stored as a single JSON-encoded
+	// line. ReadString has no such limit, so one oversized entry just gets
+	// skipped instead of truncating the load.
 	var lines []string
-	sc := bufio.NewScanner(f)
-	sc.Buffer(make([]byte, 64*1024), 1024*1024)
-	for sc.Scan() {
-		raw := strings.TrimSpace(sc.Text())
-		if raw == "" {
-			continue
+	r := bufio.NewReader(f)
+	for {
+		raw, readErr := r.ReadString('\n')
+		if trimmed := strings.TrimSpace(raw); trimmed != "" {
+			var entry string
+			if err := json.Unmarshal([]byte(trimmed), &entry); err == nil {
+				lines = append(lines, entry)
+			} // skip corrupt/foreign/oversized lines rather than failing the load
 		}
-		var entry string
-		if err := json.Unmarshal([]byte(raw), &entry); err != nil {
-			continue // skip corrupt/foreign lines rather than failing the load
+		if readErr != nil {
+			break // EOF, or an I/O error — either way, stop with what was read
 		}
-		lines = append(lines, entry)
 	}
 	if len(lines) <= inputHistoryCap {
 		return lines
@@ -68,7 +74,9 @@ func loadInputHistory(path string) []string {
 
 // rewriteInputHistory overwrites the history file with exactly entries, used
 // to enforce inputHistoryCap on load. Best-effort: failures are ignored, same
-// as appendInputHistoryLine.
+// as appendInputHistoryLine. Not coordinated with a concurrent process's
+// O_APPEND writes (individually atomic, but this truncate+rewrite isn't) —
+// last writer wins, same tolerance as the plain REPL's readline history.
 func rewriteInputHistory(path string, entries []string) {
 	if path == "" {
 		return

--- a/cmd/octo/inputhistory.go
+++ b/cmd/octo/inputhistory.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// inputHistoryCap bounds how many entries the TUI's persisted input history
+// file keeps. Applied on load, so the file is trimmed once per session start
+// rather than rewritten on every submit.
+const inputHistoryCap = 1000
+
+// defaultInputHistoryFile resolves the path used to persist the TUI's ↑/↓
+// input-recall history across restarts. OCTO_INPUT_HISTORY_FILE wins so
+// users (and tests) can redirect it. Empty return disables persistence.
+//
+// Entries are stored one JSON-encoded string per line (JSONL) rather than
+// raw text, since a queued or pasted entry can itself contain newlines.
+func defaultInputHistoryFile() string {
+	if env := os.Getenv("OCTO_INPUT_HISTORY_FILE"); env != "" {
+		return env
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "input_history")
+}
+
+// loadInputHistory reads the persisted history, oldest first, capped to the
+// most recent inputHistoryCap entries. A missing file or unreadable entries
+// are non-fatal — the TUI just starts with less (or no) history. If the file
+// on disk exceeds the cap, it is rewritten trimmed as a side effect.
+func loadInputHistory(path string) []string {
+	if path == "" {
+		return nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var lines []string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 64*1024), 1024*1024)
+	for sc.Scan() {
+		raw := strings.TrimSpace(sc.Text())
+		if raw == "" {
+			continue
+		}
+		var entry string
+		if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+			continue // skip corrupt/foreign lines rather than failing the load
+		}
+		lines = append(lines, entry)
+	}
+	if len(lines) <= inputHistoryCap {
+		return lines
+	}
+	trimmed := lines[len(lines)-inputHistoryCap:]
+	rewriteInputHistory(path, trimmed)
+	return trimmed
+}
+
+// rewriteInputHistory overwrites the history file with exactly entries, used
+// to enforce inputHistoryCap on load. Best-effort: failures are ignored, same
+// as appendInputHistoryLine.
+func rewriteInputHistory(path string, entries []string) {
+	if path == "" {
+		return
+	}
+	var sb strings.Builder
+	for _, e := range entries {
+		b, err := json.Marshal(e)
+		if err != nil {
+			continue
+		}
+		sb.Write(b)
+		sb.WriteByte('\n')
+	}
+	_ = os.WriteFile(path, []byte(sb.String()), 0o600)
+}
+
+// appendInputHistoryLine persists one submitted/queued line to path. Errors
+// are non-fatal — a read-only or missing ~/.octo just means the session's
+// history doesn't survive restart, same tolerance as the plain REPL's
+// readline history file.
+func appendInputHistoryLine(path, line string) {
+	if path == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	b, err := json.Marshal(line)
+	if err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	b = append(b, '\n')
+	_, _ = f.Write(b)
+}

--- a/cmd/octo/inputhistory_test.go
+++ b/cmd/octo/inputhistory_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -73,6 +74,32 @@ func TestInputHistory_LoadCapsAndTrimsFile(t *testing.T) {
 	got2 := loadInputHistory(path)
 	if len(got2) != inputHistoryCap {
 		t.Fatalf("second load returned %d entries, want cap %d", len(got2), inputHistoryCap)
+	}
+}
+
+// TestInputHistory_OversizedLineDoesNotTruncateLoad guards against
+// bufio.Scanner's buffer-cap failure mode: a Scanner aborts the whole read
+// the instant one physical line is too long, silently dropping every entry
+// after it — including the newest ones. A folded multi-line paste is stored
+// as a single JSON-encoded line and can plausibly exceed a fixed buffer, so
+// the loader must not lose newer entries just because an older one is huge.
+func TestInputHistory_OversizedLineDoesNotTruncateLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "input_history")
+	appendInputHistoryLine(path, "before")
+	// Bigger than bufio.Scanner's typical max-token-size caps (well past 1MB).
+	huge := strings.Repeat("x", 2*1024*1024)
+	appendInputHistoryLine(path, huge)
+	appendInputHistoryLine(path, "after")
+
+	got := loadInputHistory(path)
+	want := []string{"before", huge, "after"}
+	if len(got) != len(want) {
+		t.Fatalf("loadInputHistory returned %d entries, want %d — an oversized line must not truncate the rest of the file", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d mismatch (got len=%d, want len=%d)", i, len(got[i]), len(want[i]))
+		}
 	}
 }
 

--- a/cmd/octo/inputhistory_test.go
+++ b/cmd/octo/inputhistory_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInputHistory_LoadMissingFile(t *testing.T) {
+	if got := loadInputHistory(filepath.Join(t.TempDir(), "nope")); got != nil {
+		t.Errorf("loadInputHistory(missing) = %v, want nil", got)
+	}
+}
+
+func TestInputHistory_EmptyPathDisablesPersistence(t *testing.T) {
+	if got := loadInputHistory(""); got != nil {
+		t.Errorf("loadInputHistory(\"\") = %v, want nil", got)
+	}
+	// Must not panic or create anything relative to cwd.
+	appendInputHistoryLine("", "should be a no-op")
+}
+
+func TestInputHistory_AppendThenLoadRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "input_history")
+	appendInputHistoryLine(path, "first line")
+	appendInputHistoryLine(path, "second line")
+
+	got := loadInputHistory(path)
+	want := []string{"first line", "second line"}
+	if len(got) != len(want) {
+		t.Fatalf("loadInputHistory = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestInputHistory_MultilineEntryRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "input_history")
+	multi := "line one\nline two\nline three"
+	appendInputHistoryLine(path, multi)
+
+	got := loadInputHistory(path)
+	if len(got) != 1 || got[0] != multi {
+		t.Fatalf("loadInputHistory = %q, want single entry %q", got, multi)
+	}
+	// The file itself must stay one physical line per entry.
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := countLines(string(b)); n != 1 {
+		t.Errorf("history file has %d physical lines, want 1 (JSON-encoded)", n)
+	}
+}
+
+func TestInputHistory_LoadCapsAndTrimsFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "input_history")
+	total := inputHistoryCap + 50
+	for i := 0; i < total; i++ {
+		appendInputHistoryLine(path, "entry")
+	}
+
+	got := loadInputHistory(path)
+	if len(got) != inputHistoryCap {
+		t.Fatalf("loadInputHistory returned %d entries, want cap %d", len(got), inputHistoryCap)
+	}
+
+	// The on-disk file should have been rewritten down to the cap too, so a
+	// second load (simulating a restart) doesn't keep re-trimming.
+	got2 := loadInputHistory(path)
+	if len(got2) != inputHistoryCap {
+		t.Fatalf("second load returned %d entries, want cap %d", len(got2), inputHistoryCap)
+	}
+}
+
+func TestInputHistory_SkipsCorruptLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "input_history")
+	if err := os.WriteFile(path, []byte("not json\n\"valid\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := loadInputHistory(path)
+	if len(got) != 1 || got[0] != "valid" {
+		t.Fatalf("loadInputHistory = %v, want [valid]", got)
+	}
+}
+
+func countLines(s string) int {
+	n := 0
+	for _, r := range s {
+		if r == '\n' {
+			n++
+		}
+	}
+	return n
+}

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -295,9 +295,11 @@ type tuiModel struct {
 	// ta is the multi-line text input (bubbles/textarea).
 	ta textarea.Model
 
-	// inputHistory stores submitted lines for ↑/↓ recall.
+	// inputHistory stores submitted lines for ↑/↓ recall, seeded from and
+	// appended to historyFile so it survives restart.
 	inputHistory    []string
-	inputHistoryIdx int // -1 = not browsing, 0..len-1 = browsing
+	inputHistoryIdx int    // -1 = not browsing, 0..len-1 = browsing
+	historyFile     string // path from defaultInputHistoryFile(); "" disables persistence
 	// inputDraft holds the text that was in the input box before the user
 	// started browsing history with ↑, so ↓ can restore it.
 	inputDraft string
@@ -575,7 +577,8 @@ func newTUIModel(cfg replConfig) *tuiModel {
 	if !tui.IsDark() {
 		style = "light"
 	}
-	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistoryIdx: -1, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}, subAgentFocus: -1, workflows: map[string]*workflowUI{}}
+	historyFile := defaultInputHistoryFile()
+	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistory: loadInputHistory(historyFile), inputHistoryIdx: -1, historyFile: historyFile, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}, subAgentFocus: -1, workflows: map[string]*workflowUI{}}
 	// Seed the last-seen goal status so a resumed session's first transition
 	// (e.g. the budget crossing) prints its notice instead of being treated
 	// as the baseline.

--- a/cmd/octo/tuirepl_goal_test.go
+++ b/cmd/octo/tuirepl_goal_test.go
@@ -13,6 +13,7 @@ import (
 // newGoalTestModel builds a TUI model with goals wired: the session is both
 // the store and the accountant, exactly like chat.go's TUI path.
 func newGoalTestModel() (*tuiModel, *agent.Session) {
+	isolateTestInputHistory()
 	sess := agent.NewSession("m", "")
 	a := agent.New(&stubSender{reply: "ok"}, "m")
 	a.GoalAcct = sess

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -25,7 +28,30 @@ func (f *fakeProg) Send(m tea.Msg) {
 	f.mu.Unlock()
 }
 
+var (
+	testHistoryDirOnce sync.Once
+	testHistoryDir     string
+	testHistorySeq     atomic.Int64
+)
+
+// isolateTestInputHistory points OCTO_INPUT_HISTORY_FILE at a fresh,
+// nonexistent path per call, so newTestModel never reads or writes the
+// developer's real ~/.octo/input_history, and successive tests in this
+// package don't leak history entries into each other.
+func isolateTestInputHistory() {
+	testHistoryDirOnce.Do(func() {
+		if d, err := os.MkdirTemp("", "octo-tui-test-history"); err == nil {
+			testHistoryDir = d
+		}
+	})
+	if testHistoryDir == "" {
+		return
+	}
+	os.Setenv("OCTO_INPUT_HISTORY_FILE", filepath.Join(testHistoryDir, fmt.Sprintf("h%d", testHistorySeq.Add(1))))
+}
+
 func newTestModel() *tuiModel {
+	isolateTestInputHistory()
 	a := agent.New(&stubSender{reply: "ok"}, "m")
 	m := newTUIModel(replConfig{a: a, noSave: true})
 	m.sink = &tuiSink{prog: &fakeProg{}}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -228,6 +228,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if len(m.inputHistory) == 0 || m.inputHistory[len(m.inputHistory)-1] != text {
 			m.inputHistory = append(m.inputHistory, text)
+			appendInputHistoryLine(m.historyFile, text)
 		}
 		m.queue = append(m.queue, pendingItem{text: text})
 		m.println(queueStyle.Render("＋ queued: " + collapsed))
@@ -764,6 +765,7 @@ func (m *tuiModel) submit() (tea.Model, tea.Cmd) {
 	// Skip empty text (an image-only submit has nothing to recall).
 	if text != "" && (len(m.inputHistory) == 0 || m.inputHistory[len(m.inputHistory)-1] != text) {
 		m.inputHistory = append(m.inputHistory, text)
+		appendInputHistoryLine(m.historyFile, text)
 	}
 
 	// Slash commands are the TUI's alone — the plain REPL is a pure conversation


### PR DESCRIPTION
## Summary
- Persist the TUI's ↑/↓ input-recall history to `~/.octo/input_history` (JSONL, one JSON-encoded string per line so multi-line/pasted entries round-trip correctly).
- Load it back on start, capped to the most recent 1000 entries (older entries are trimmed from disk too, so the file doesn't grow unbounded).
- Consecutive-duplicate dedup is preserved (existing in-memory check on submit/queue also gates the disk append).
- `OCTO_INPUT_HISTORY_FILE` env var overrides the path, mirroring the existing `OCTO_HISTORY_FILE` pattern used by the plain REPL's readline history.

Closes #1096. (Ctrl+R-style reverse search from the issue's "optional follow-up" is left for a separate issue if wanted.)

## Test plan
- [x] `go test ./cmd/octo/...` and `go test -race ./...` pass
- [x] New `inputhistory_test.go`: missing file, empty-path no-op, append→load round trip, multi-line entry round trip (still one physical line on disk), cap+trim on load, corrupt-line skip
- [x] `newTestModel()` isolates each test's history to a fresh temp file (via `OCTO_INPUT_HISTORY_FILE`) so the suite never touches a real `~/.octo/input_history` and tests don't leak entries into each other
- [x] `gofmt -l .` clean, `go vet ./...` clean