### PR TITLE
fix(tui): polish batch — read_file preview, Tab, hints, sprint, replay, modal input, Shift+Tab

### DIFF
--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -94,6 +94,18 @@ func renderToolCard(toolName string, input map[string]any, output string, isErr 
 		newS, _ := input["new_string"].(string)
 		return tui.RenderEditCard(path, oldS, newS, width)
 	}
+	if toolName == "read_file" && !isErr {
+		// A content preview here is usually the file's package/import
+		// boilerplate — near-zero information for the screen space it costs.
+		// A one-liner with the line count (and a click-to-open link to the
+		// full content, matching the #1093 fold-link pattern) is cheaper and
+		// no less useful (#1097).
+		link := ""
+		if path, err := tools.WriteCardSpill(toolName, output); err == nil {
+			link = tui.FileURI(path)
+		}
+		return tui.RenderReadFileStatus(cardTargetFor(toolName, input), readFileLineCount(output), formatElapsed(elapsed), link, width)
+	}
 	opts := tui.OutputCardOpts{
 		MaxLines: outputCardMaxLines,
 		Width:    width,
@@ -145,6 +157,22 @@ func nonBlankLineCount(s string) int {
 		if strings.TrimSpace(l) != "" {
 			n++
 		}
+	}
+	return n
+}
+
+// readFileLineCount counts the numbered content lines in a read_file result
+// ("%6d\t<line>", per internal/tools/read_file.go), excluding the bracketed
+// footer markers ("[end of file: …]", "[truncated: …]", "[empty file]") the
+// tool appends — those aren't file content and would otherwise inflate the
+// count by one.
+func readFileLineCount(output string) int {
+	n := 0
+	for _, l := range strings.Split(output, "\n") {
+		if l == "" || strings.HasPrefix(strings.TrimLeft(l, " "), "[") {
+			continue
+		}
+		n++
 	}
 	return n
 }

--- a/cmd/octo/toolcards.go
+++ b/cmd/octo/toolcards.go
@@ -100,11 +100,20 @@ func renderToolCard(toolName string, input map[string]any, output string, isErr 
 		// A one-liner with the line count (and a click-to-open link to the
 		// full content, matching the #1093 fold-link pattern) is cheaper and
 		// no less useful (#1097).
+		n := readFileLineCount(output)
 		link := ""
-		if path, err := tools.WriteCardSpill(toolName, output); err == nil {
-			link = tui.FileURI(path)
+		// Only spill to disk when there's actually folded content behind the
+		// link — same threshold the generic card path uses to decide whether
+		// to fold at all. Spilling every read unconditionally, even a 1-line
+		// read, would widen every file the agent touches into a plaintext
+		// copy under ~/.octo/tmp for no reason: nothing is hidden when the
+		// whole thing already fits in the one-liner.
+		if n > outputCardMaxLines {
+			if path, err := tools.WriteCardSpill(toolName, output); err == nil {
+				link = tui.FileURI(path)
+			}
 		}
-		return tui.RenderReadFileStatus(cardTargetFor(toolName, input), readFileLineCount(output), formatElapsed(elapsed), link, width)
+		return tui.RenderReadFileStatus(cardTargetFor(toolName, input), n, formatElapsed(elapsed), link, width)
 	}
 	opts := tui.OutputCardOpts{
 		MaxLines: outputCardMaxLines,

--- a/cmd/octo/toolcards_test.go
+++ b/cmd/octo/toolcards_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -97,6 +98,12 @@ func TestRenderToolCard_ReadFileIsOneLiner(t *testing.T) {
 	if strings.Contains(got, "package main") {
 		t.Errorf("should not preview file content anymore; got:\n%s", got)
 	}
+	// A read this small has nothing folded/hidden behind a link — spilling it
+	// to disk anyway would needlessly widen every file read into a plaintext
+	// copy under ~/.octo/tmp for no reason (#1097 review feedback).
+	if strings.Contains(got, "\x1b]8;;") {
+		t.Errorf("a short read should not spill to disk or link; got:\n%s", got)
+	}
 
 	// read_file errors keep the generic short-preview card (the output is an
 	// error message, not file content worth folding). Chroma highlights each
@@ -104,6 +111,24 @@ func TestRenderToolCard_ReadFileIsOneLiner(t *testing.T) {
 	errGot := renderToolCard("read_file", map[string]any{"path": "main.go"}, "no such file", true, 0, 0)
 	if !strings.Contains(errGot, "file") {
 		t.Errorf("error card should still show the error text; got:\n%s", errGot)
+	}
+}
+
+// TestRenderToolCard_ReadFileLargeGetsLink checks the flip side of the
+// gating above: a read past the fold threshold DOES get a click-to-open
+// link, since its content genuinely isn't visible in the one-liner.
+func TestRenderToolCard_ReadFileLargeGetsLink(t *testing.T) {
+	var lines []string
+	for i := 1; i <= 20; i++ {
+		lines = append(lines, fmt.Sprintf("%6d\tline %d", i, i))
+	}
+	output := strings.Join(lines, "\n") + "\n\n[end of file: 20 lines total]\n"
+	got := renderToolCard("read_file", map[string]any{"path": "big.go"}, output, false, 0, 0)
+	if !strings.Contains(got, "20 lines") {
+		t.Errorf("missing line count; got:\n%s", got)
+	}
+	if !strings.Contains(got, "\x1b]8;;") {
+		t.Errorf("a large read should link to the spilled full content; got:\n%s", got)
 	}
 }
 

--- a/cmd/octo/toolcards_test.go
+++ b/cmd/octo/toolcards_test.go
@@ -82,6 +82,48 @@ func TestRenderToolCard_Dispatch(t *testing.T) {
 	}
 }
 
+func TestRenderToolCard_ReadFileIsOneLiner(t *testing.T) {
+	// A content preview is near-zero information (usually package/imports);
+	// a successful read_file renders a one-line status with the line count
+	// instead (#1097).
+	output := "     1\tpackage main\n     2\t\n     3\tfunc main() {}\n\n[end of file: 3 lines total]\n"
+	got := renderToolCard("read_file", map[string]any{"path": "main.go"}, output, false, 0, 0)
+	if !strings.Contains(got, "Read(main.go)") {
+		t.Errorf("missing header; got:\n%s", got)
+	}
+	if !strings.Contains(got, "3 lines") {
+		t.Errorf("missing line count; got:\n%s", got)
+	}
+	if strings.Contains(got, "package main") {
+		t.Errorf("should not preview file content anymore; got:\n%s", got)
+	}
+
+	// read_file errors keep the generic short-preview card (the output is an
+	// error message, not file content worth folding). Chroma highlights each
+	// word separately, so check a single token rather than the full phrase.
+	errGot := renderToolCard("read_file", map[string]any{"path": "main.go"}, "no such file", true, 0, 0)
+	if !strings.Contains(errGot, "file") {
+		t.Errorf("error card should still show the error text; got:\n%s", errGot)
+	}
+}
+
+func TestReadFileLineCount(t *testing.T) {
+	cases := []struct {
+		name, output string
+		want         int
+	}{
+		{"normal", "     1\ta\n     2\tb\n\n[end of file: 2 lines total]\n", 2},
+		{"truncated", "     1\ta\n\n[truncated: shown lines 1-1. Next unread line is 2. Continue with offset=2 if needed.]\n", 1},
+		{"empty file", "[empty file]", 0},
+		{"past end", "[end of file: 5 lines total. Offset 9 is past the end — no more content to read.]", 0},
+	}
+	for _, c := range cases {
+		if got := readFileLineCount(c.output); got != c.want {
+			t.Errorf("%s: readFileLineCount = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
 func TestRenderToolCard_TerminalShowsTail(t *testing.T) {
 	// Command output is shown from the tail — the head is the least
 	// informative end (errors and summaries land at the bottom).

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/open-octo/octo-agent/internal/agent"
@@ -194,7 +195,9 @@ const tickInterval = 120 * time.Millisecond
 
 // answerSprintDur is how long the wait-on-model line holds the first answer
 // deltas while the ↓ token counter sprints, before releasing the prose.
-const answerSprintDur = 280 * time.Millisecond
+// Halved from an original 280ms (#1097): the flourish is still visible but
+// adds noticeably less perceived latency to the first answer tokens.
+const answerSprintDur = 140 * time.Millisecond
 
 // answerSprintMinChars gates the sprint: only turns with a real reasoning /
 // uplink phase get the flourish, so a quick direct reply isn't delayed.
@@ -539,9 +542,12 @@ type modalState struct {
 	options  []string // rendered option labels (questions only)
 	selected map[int]bool
 	// otherActive is true when the user has selected "Other" and is now typing
-	// free text inline inside the modal.
+	// free text inline inside the modal. otherInput is a real textinput.Model
+	// (not a hand-rolled append/backspace buffer) so it gets cursor movement,
+	// word-jump, and delete-forward for free, matching the main input box's
+	// editing quality (#1097).
 	otherActive bool
-	otherInput  string
+	otherInput  textinput.Model
 	// detail caches the rendered permission body (detailWidth is the width it
 	// was rendered for; detailSet distinguishes "not rendered yet" from a
 	// legitimate width of 0). View() runs on every spinner tick while the
@@ -1550,13 +1556,19 @@ func pluraliseLineCount(n int) string {
 	return fmt.Sprintf("%d lines", n)
 }
 
+// replayMaxTurns caps how many of a resumed session's most recent turns are
+// replayed into scrollback; older turns collapse into a single omission line.
+// Without a cap a few-hundred-turn session floods the terminal on resume,
+// before the user can even type (#1097).
+const replayMaxTurns = 20
+
 // replayHistoryLines renders a resumed session's prior turns into scrollback
 // lines exactly as they appeared live: user prompts and assistant replies
 // verbatim (markdown unless --plain), tool calls through the same
 // renderToolOutcome path as the live done/error events (rich cards, status
 // lines, full error text). Returns nil for a fresh session (empty history).
 func (m *tuiModel) replayHistoryLines() []string {
-	msgs := m.a.History.Snapshot()
+	msgs, omitted := recentTurns(m.a.History.Snapshot(), replayMaxTurns)
 	if len(msgs) == 0 {
 		return nil
 	}
@@ -1572,6 +1584,13 @@ func (m *tuiModel) replayHistoryLines() []string {
 	}
 
 	var out []string
+	if omitted > 0 {
+		word := "turn"
+		if omitted != 1 {
+			word = "turns"
+		}
+		out = append(out, hintStyle.Render(fmt.Sprintf("… earlier history omitted (%d %s)", omitted, word)))
+	}
 	for _, msg := range msgs {
 		switch msg.Role {
 		case agent.RoleUser:
@@ -1602,6 +1621,28 @@ func (m *tuiModel) replayHistoryLines() []string {
 		}
 	}
 	return out
+}
+
+// recentTurns splits msgs into turns — a RoleUser message plus everything
+// up to (not including) the next one — and returns only the last max turns,
+// plus how many leading turns were dropped. Any messages before the first
+// RoleUser message (there shouldn't be any in practice) are kept attached to
+// the first turn rather than silently dropped. max <= 0 disables the cap.
+func recentTurns(msgs []agent.Message, max int) ([]agent.Message, int) {
+	if max <= 0 || len(msgs) == 0 {
+		return msgs, 0
+	}
+	var bounds []int
+	for i, msg := range msgs {
+		if msg.Role == agent.RoleUser {
+			bounds = append(bounds, i)
+		}
+	}
+	if len(bounds) <= max {
+		return msgs, 0
+	}
+	start := bounds[len(bounds)-max]
+	return msgs[start:], len(bounds) - max
 }
 
 // renderReplayText styles one block of restored assistant/user prose: markdown

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -10,6 +10,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/permission"
 	"github.com/open-octo/octo-agent/internal/tui"
 )
 
@@ -476,6 +477,37 @@ func TestTUI_ReplayHistoryLines_FreshSessionEmpty(t *testing.T) {
 	}
 }
 
+// A resumed session with more than replayMaxTurns turns only replays the
+// most recent ones, plus a single omission line for the rest — otherwise a
+// few-hundred-turn session floods the terminal on resume (#1097).
+func TestTUI_ReplayHistoryLines_CapsOldTurns(t *testing.T) {
+	m := newTestModel()
+	m.width = 80
+	h := m.a.History
+	total := replayMaxTurns + 5
+	for i := 0; i < total; i++ {
+		h.Append(agent.NewUserMessage(fmt.Sprintf("turn %d", i)))
+		h.Append(agent.NewAssistantMessage(fmt.Sprintf("reply %d", i)))
+	}
+
+	joined := stripANSI(strings.Join(m.replayHistoryLines(), "\n"))
+
+	if !strings.Contains(joined, "earlier history omitted (5 turns)") {
+		t.Errorf("missing omission line for the 5 dropped turns; got:\n%s", joined)
+	}
+	// The oldest turns are gone...
+	if strings.Contains(joined, "turn 0") {
+		t.Errorf("oldest turn should have been dropped; got:\n%s", joined)
+	}
+	// ...but the most recent replayMaxTurns are kept.
+	if !strings.Contains(joined, fmt.Sprintf("turn %d", total-1)) {
+		t.Errorf("newest turn should be replayed; got:\n%s", joined)
+	}
+	if !strings.Contains(joined, fmt.Sprintf("turn %d", total-replayMaxTurns)) {
+		t.Errorf("first kept turn should be replayed; got:\n%s", joined)
+	}
+}
+
 // A failed tool call replays as its live error card, carrying the real error
 // message (the regression: the old collapsed line dropped it).
 func TestTUI_ReplayHistoryLines_ToolError(t *testing.T) {
@@ -657,6 +689,37 @@ func TestTUI_QuestionModalOtherFreeText(t *testing.T) {
 	}
 }
 
+// The "Other" free-text field is a real textinput.Model, not an
+// append/backspace-only buffer — it must support moving the cursor and
+// inserting/deleting in the middle of the text (#1097).
+func TestTUI_QuestionModalOtherCursorMovement(t *testing.T) {
+	m := newTestModel()
+	resp := make(chan UserResponse, 1)
+	m.openModal(askMsg{prompt: UserPrompt{
+		Kind:     KindQuestion,
+		Question: "pick",
+		Options:  []string{"alpha"},
+	}, resp: resp})
+
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyDown})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.modal.otherActive {
+		t.Fatal("selecting Other should activate free-text input")
+	}
+
+	// Type "acd", move left twice (cursor between 'a' and 'c'), insert 'b'.
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a', 'c', 'd'}})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyLeft})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyLeft})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}})
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	got := <-resp
+	if got.Custom != "abcd" {
+		t.Errorf("custom = %q, want abcd (cursor movement should allow mid-string insert)", got.Custom)
+	}
+}
+
 func TestTUI_QuestionModalOtherEmptyCancels(t *testing.T) {
 	m := newTestModel()
 	resp := make(chan UserResponse, 1)
@@ -829,6 +892,31 @@ func TestTUI_ThinkingNeverShownInTerminal(t *testing.T) {
 	}
 }
 
+// Shift+Tab must cycle through all three permission modes, including strict —
+// previously it only toggled interactive/auto, leaving strict unreachable
+// from the keyboard (#1097).
+func TestTUI_ShiftTabCyclesAllPermissionModes(t *testing.T) {
+	eng, err := permission.New("", t.TempDir(), permission.ModeInteractive)
+	if err != nil {
+		t.Fatalf("permission.New: %v", err)
+	}
+	m := newTestModel()
+	m.cfg.permEngine = eng
+
+	want := []permission.Mode{
+		permission.ModeAutoApprove,
+		permission.ModeStrict,
+		permission.ModeInteractive,
+	}
+	for _, w := range want {
+		m2, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyShiftTab})
+		m = m2.(*tuiModel)
+		if got := eng.GetMode(); got != w {
+			t.Errorf("mode = %q, want %q", got, w)
+		}
+	}
+}
+
 // TestTUI_InputFold_TabToggles tests that Tab toggles the folded state
 // when there are >= 5 lines of input.
 func TestTUI_InputFold_TabToggles(t *testing.T) {
@@ -866,6 +954,27 @@ func TestTUI_InputFold_TabToggles(t *testing.T) {
 	}
 	if m.foldedFullText != "" {
 		t.Error("foldedFullText should be cleared after expand")
+	}
+}
+
+// TestTUI_InputFold_NoStrayTab guards against Tab leaking a literal tab
+// character into foldedFullText: the fold check must run before the
+// keypress reaches the textarea, not after (#1097).
+func TestTUI_InputFold_NoStrayTab(t *testing.T) {
+	m := newTestModel()
+	multiLine := "line1\nline2\nline3\nline4\nline5"
+	setInput(m, multiLine)
+
+	m2, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyTab})
+	m = m2.(*tuiModel)
+	if !m.inputFolded {
+		t.Fatal("Tab should fold multi-line input")
+	}
+	if strings.Contains(m.foldedFullText, "\t") {
+		t.Errorf("foldedFullText contains a stray tab: %q", m.foldedFullText)
+	}
+	if m.foldedFullText != multiLine {
+		t.Errorf("foldedFullText = %q, want %q", m.foldedFullText, multiLine)
 	}
 }
 

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -508,6 +508,27 @@ func TestTUI_ReplayHistoryLines_CapsOldTurns(t *testing.T) {
 	}
 }
 
+// TestTUI_ReplayHistoryLines_SingularOmission checks the omission line's
+// singular/plural wording at the exact cap+1 boundary ("1 turn", not "1 turns").
+func TestTUI_ReplayHistoryLines_SingularOmission(t *testing.T) {
+	m := newTestModel()
+	m.width = 80
+	h := m.a.History
+	total := replayMaxTurns + 1
+	for i := 0; i < total; i++ {
+		h.Append(agent.NewUserMessage(fmt.Sprintf("turn %d", i)))
+		h.Append(agent.NewAssistantMessage(fmt.Sprintf("reply %d", i)))
+	}
+
+	joined := stripANSI(strings.Join(m.replayHistoryLines(), "\n"))
+	if !strings.Contains(joined, "earlier history omitted (1 turn)") {
+		t.Errorf("want singular '1 turn' in omission line; got:\n%s", joined)
+	}
+	if strings.Contains(joined, "1 turns") {
+		t.Errorf("wrong plural for a single omitted turn; got:\n%s", joined)
+	}
+}
+
 // A failed tool call replays as its live error card, carrying the real error
 // message (the regression: the old collapsed line dropped it).
 func TestTUI_ReplayHistoryLines_ToolError(t *testing.T) {
@@ -1088,6 +1109,26 @@ func TestTUI_InputFold_FourLinesNoFold(t *testing.T) {
 	m = m2.(*tuiModel)
 	if m.inputFolded {
 		t.Error("4-line input should not fold (threshold is 5)")
+	}
+}
+
+// TestTUI_InputFold_ShortTextTabFallsThroughToTextarea guards the non-fold
+// path after the #1097 reorder: Tab on short (<5 line) input must still
+// reach the textarea's own Update instead of being swallowed entirely by
+// the fold-check, leaving the value unchanged and unfolded.
+func TestTUI_InputFold_ShortTextTabFallsThroughToTextarea(t *testing.T) {
+	m := newTestModel()
+	setInput(m, "short")
+	before := m.ta.Value()
+
+	m2, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyTab})
+	m = m2.(*tuiModel)
+
+	if m.inputFolded {
+		t.Error("short input should not fold")
+	}
+	if m.ta.Value() != before {
+		t.Errorf("textarea value = %q, want unchanged %q", m.ta.Value(), before)
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -13,6 +13,7 @@ import (
 	"unicode"
 	"unsafe"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	rw "github.com/mattn/go-runewidth"
@@ -258,12 +259,17 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyShiftTab:
-		// Cycle permission mode: interactive → auto → interactive.
+		// Cycle permission mode: interactive → auto → strict → interactive.
+		// Previously only interactive/auto were reachable from the keyboard,
+		// leaving strict mode unreachable without a restart (#1097).
 		if m.cfg.permEngine != nil {
 			var next permission.Mode
-			if m.cfg.permEngine.GetMode() == permission.ModeInteractive {
+			switch m.cfg.permEngine.GetMode() {
+			case permission.ModeInteractive:
 				next = permission.ModeAutoApprove
-			} else {
+			case permission.ModeAutoApprove:
+				next = permission.ModeStrict
+			default:
 				next = permission.ModeInteractive
 			}
 			m.cfg.permEngine.SetMode(next)
@@ -344,14 +350,11 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Everything else (typing, left/right, backspace, word movement, etc.)
-	// is handled by bubbles/textarea.
-	var cmd tea.Cmd
-	m.ta, cmd = m.ta.Update(msg)
-
 	// Folded state toggle: Tab expands/collapses when there's multi-line content.
-	// This check runs before the image-path detection so it works even when
-	// folded. Tab is only captured when the completion menu is not open.
+	// Checked before the textarea ever sees the keypress — handing Tab to the
+	// textarea first inserts a literal tab into its value, which then leaked
+	// into foldedFullText on collapse (#1097). Tab is only captured when the
+	// completion menu is not open (a non-empty menu already returned above).
 	if msg.Type == tea.KeyTab && len(m.complItems) == 0 {
 		if m.inputFolded {
 			// Expand: restore the full text
@@ -368,6 +371,11 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	}
+
+	// Everything else (typing, left/right, backspace, word movement, etc.)
+	// is handled by bubbles/textarea.
+	var cmd tea.Cmd
+	m.ta, cmd = m.ta.Update(msg)
 
 	// Detect a dropped image file path (some terminals paste the path as text
 	// when a file is dragged in). If the input box now holds a single image
@@ -982,7 +990,8 @@ func (m *tuiModel) openModal(msg askMsg) {
 	}
 	st.cursor = 0
 	st.otherActive = false
-	st.otherInput = ""
+	st.otherInput = textinput.New()
+	st.otherInput.Prompt = ""
 	m.modal = st
 }
 
@@ -1012,27 +1021,30 @@ func (m *tuiModel) handleModalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Inline free-text input for the "Other" option.
+	// Inline free-text input for the "Other" option, backed by a real
+	// textinput.Model so it gets cursor movement, word-jump, and
+	// delete-forward for free — the same editing quality as the main input
+	// box, instead of a hand-rolled append/backspace-only buffer (#1097).
+	// Esc/Enter are intercepted before reaching the widget: Esc always
+	// cancels the modal (textinput has no cancel key of its own), and Enter
+	// confirms rather than inserting (textinput is single-line and ignores
+	// Enter anyway, but intercepting keeps the intent explicit).
 	if st.otherActive {
 		switch msg.Type {
 		case tea.KeyEsc:
 			m.answerModal(UserResponse{Cancelled: true})
+			return m, nil
 		case tea.KeyEnter:
-			if trimmed := strings.TrimSpace(st.otherInput); trimmed != "" {
+			if trimmed := strings.TrimSpace(st.otherInput.Value()); trimmed != "" {
 				m.answerModal(UserResponse{Custom: trimmed})
 			} else {
 				m.answerModal(UserResponse{Cancelled: true})
 			}
-		case tea.KeyBackspace:
-			if len(st.otherInput) > 0 {
-				// Remove the last UTF-8 rune.
-				r := []rune(st.otherInput)
-				st.otherInput = string(r[:len(r)-1])
-			}
-		case tea.KeyRunes:
-			st.otherInput += string(msg.Runes)
+			return m, nil
 		}
-		return m, nil
+		var cmd tea.Cmd
+		st.otherInput, cmd = st.otherInput.Update(msg)
+		return m, cmd
 	}
 
 	// Question modal: arrow/j-k to move, space to toggle (multi), enter to
@@ -1079,6 +1091,7 @@ func (m *tuiModel) confirmQuestion(st *modalState) {
 		wantOther := st.selected[otherIdx]
 		if wantOther {
 			st.otherActive = true
+			st.otherInput.Focus()
 			return
 		}
 		var picks []string
@@ -1100,6 +1113,7 @@ func (m *tuiModel) confirmQuestion(st *modalState) {
 
 	if st.cursor == otherIdx {
 		st.otherActive = true
+		st.otherInput.Focus()
 		return
 	}
 	m.answerModal(UserResponse{Choices: []string{st.prompt.Options[st.cursor]}})
@@ -1189,7 +1203,7 @@ func (m *tuiModel) View() string {
 		b.WriteString(m.spinnerLine(m.running.verb+"("+m.running.target+")", m.running.start))
 		b.WriteByte('\n')
 		if tools.HasActiveSync() || tools.HasActiveSubAgentSync() {
-			b.WriteString(hintStyle.Render("  [Ctrl+B] background  [Esc] kill"))
+			b.WriteString(hintStyle.Render("  [Ctrl+B] background  [Esc] interrupt"))
 			b.WriteByte('\n')
 		}
 	} else if m.turnRunning && m.toolStreamName != "" {
@@ -1544,8 +1558,8 @@ func (m *tuiModel) modalView() string {
 		b.WriteString(fmt.Sprintf("  %s%s%s\n", cursor, mark, opt))
 	}
 	if st.otherActive {
-		b.WriteString("  Other: " + st.otherInput + "▋" + "\n")
-		b.WriteString(hintStyle.Render("Enter confirm · Esc cancel · Backspace delete"))
+		b.WriteString("  Other: " + st.otherInput.View() + "\n")
+		b.WriteString(hintStyle.Render("Enter confirm · Esc cancel"))
 		return tui.Box(b.String())
 	}
 	hint := "↑/↓ move · Enter select · Esc cancel"

--- a/internal/tui/outputcard.go
+++ b/internal/tui/outputcard.go
@@ -148,6 +148,24 @@ func renderCardHeader(verb, target, meta string, width int) string {
 	return h
 }
 
+// RenderReadFileStatus renders a completed read_file call as a one-line
+// status — "● Read(path) — 234 lines" — instead of a multi-line content
+// preview (#1097). lineCount is the number of lines the call returned; link,
+// when non-empty, hyperlinks the count to the full content (from
+// WriteCardSpill) so it stays reachable on demand, matching the fold-link
+// pattern RenderOutputCard uses for folded card bodies (#1093).
+func RenderReadFileStatus(path string, lineCount int, meta, link string, width int) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%s %s", outBullet, renderCardHeader("Read", path, meta, width)))
+	text := "— " + pluralise(lineCount, "line")
+	if link != "" {
+		b.WriteString(" " + Hyperlink(link, outMore.Underline(true).Render(text+" ↗")))
+	} else {
+		b.WriteString(" " + outMore.Render(text))
+	}
+	return b.String()
+}
+
 // RenderToolStatus renders a tool call that has no body card as a single
 // header-style line — "● name(target)" — so card and non-card tools share one
 // visual language. isErr tints the bullet red and appends errText dimmed.


### PR DESCRIPTION
## Summary
Closes #1097 — seven small, independently-shippable TUI UX fixes bundled as they were filed:

1. **read_file card is now a one-liner.** `● Read(path) — 234 lines` with a click-to-open link to the full content (reusing the #1093 fold-link pattern), instead of previewing the file's first 4 lines — usually package/import boilerplate with near-zero information.
2. **Tab no longer leaks a stray tab into folded input.** The fold/expand check now runs *before* the keypress reaches the textarea, not after.
3. **Hint wording fix.** `[Ctrl+B] background [Esc] kill` → `[Esc] interrupt` (Esc interrupts the whole turn, not just the running command).
4. **answerSprint latency halved.** 280ms → 140ms artificial hold before the first answer tokens stream.
5. **Resume replay is capped.** Only the most recent 20 turns replay into scrollback on resume; older turns collapse into one `… earlier history omitted (N turns)` line instead of flooding the terminal.
6. **Question modal "Other" field upgraded.** Was a hand-rolled append/backspace-only buffer; now a real `textinput.Model` (bubbles, already a dependency) with cursor movement, word-jump, delete-forward.
7. **Shift+Tab reaches all three permission modes.** Was interactive ⇄ auto only; now interactive → auto → strict → interactive.

## Test plan
- [x] `go test ./cmd/octo/... ./internal/tui/...` and `go test -race ./...` (full repo) pass
- [x] New/updated tests per item: `TestRenderToolCard_ReadFileIsOneLiner` + `TestReadFileLineCount`; `TestTUI_InputFold_NoStrayTab`; `TestTUI_ReplayHistoryLines_CapsOldTurns`; `TestTUI_QuestionModalOtherCursorMovement`; `TestTUI_ShiftTabCyclesAllPermissionModes`. Existing fold/modal/replay tests pass unchanged.
- [x] `gofmt -l .` clean, `go vet ./...` clean