### PR TITLE
fix(im): persist session history incrementally per event, not just per turn

### DIFF
--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -582,10 +582,7 @@ func (m *Manager) cmdUnbind(ev InboundEvent) string {
 
 	released := false
 	if val, ok := m.sessions.Load(key); ok {
-		if ch := val.(*Session); ch.Store != nil {
-			released = ch.Store.Unbind(agent.EntryChannel)
-			_ = ch.Store.Save()
-		}
+		released = val.(*Session).UnbindStore(agent.EntryChannel)
 	}
 
 	hadOverride, err := m.bindings.remove(key)

--- a/internal/channel/persist.go
+++ b/internal/channel/persist.go
@@ -132,6 +132,23 @@ func (s *Session) Persist() error {
 	return s.Store.Save()
 }
 
+// UnbindStore releases the store's entry binding and persists the change.
+// Guarded by storeMu like Persist/deleteStore: /unbind runs on the adapter
+// callback goroutine while a turn may still be in flight, and that turn's
+// Persist (now called per event, not just once at turn end) mutates the same
+// *agent.Session fields (Messages, persisted) with no locking of its own —
+// storeMu is what serializes the two callers.
+func (s *Session) UnbindStore(entry string) bool {
+	s.storeMu.Lock()
+	defer s.storeMu.Unlock()
+	if s.Store == nil {
+		return false
+	}
+	released := s.Store.Unbind(entry)
+	_ = s.Store.Save()
+	return released
+}
+
 // GoalStore returns the persisted backing session, which carries the
 // conversation's goal, or nil when a concurrent /unbind tombstoned it.
 // Accessor because Store mutates under storeMu.

--- a/internal/channel/ui_controller.go
+++ b/internal/channel/ui_controller.go
@@ -283,7 +283,23 @@ func truncate(s string, maxLen int) string {
 	return string(r[:maxLen]) + "…"
 }
 
-// RunAgent executes the agent run loop for a session and bridges events to the IM adapter.
+// RunAgent executes the agent run loop for a session and bridges events to the
+// IM adapter. It also persists the turn's progress incrementally: after any
+// event that grows or rewrites history, history is flushed to disk right
+// away, so a process crash mid-turn loses at most the round in flight, not
+// the whole turn — parity with the web WS handler's persistTurnProgress. The
+// length/dirty gate keeps the per-event calls free when nothing changed.
 func RunAgent(ctx context.Context, sess *Session, tools []agent.ToolDefinition, executor agent.ToolExecutor, ctrl *UIController, userInput string) (agent.Reply, error) {
-	return sess.Agent.RunStream(ctx, userInput, tools, executor, ctrl.Handler())
+	a := sess.Agent
+	forward := ctrl.Handler()
+	lastSavedLen := -1
+	handler := func(ev agent.AgentEvent) {
+		forward(ev)
+		if n := a.History.Len(); n != lastSavedLen || a.History.RewriteDirty() {
+			if sess.Persist() == nil {
+				lastSavedLen = n
+			}
+		}
+	}
+	return a.RunStream(ctx, userInput, tools, executor, handler)
 }

--- a/internal/channel/ui_controller_test.go
+++ b/internal/channel/ui_controller_test.go
@@ -199,6 +199,96 @@ func TestRunAgent(t *testing.T) {
 	}
 }
 
+// queuedToolSender returns a scripted Reply sequence, repeating the last one
+// once exhausted.
+type queuedToolSender struct {
+	i       int
+	replies []agent.Reply
+}
+
+func (q *queuedToolSender) SendMessages(ctx context.Context, model, system string, messages []agent.Message, maxTokens int) (agent.Reply, error) {
+	return q.next(), nil
+}
+
+func (q *queuedToolSender) SendMessagesWithTools(ctx context.Context, model, system string, messages []agent.Message, maxTokens int, tools []agent.ToolDefinition) (agent.Reply, error) {
+	return q.next(), nil
+}
+
+func (q *queuedToolSender) next() agent.Reply {
+	r := q.replies[q.i]
+	if q.i < len(q.replies)-1 {
+		q.i++
+	}
+	return r
+}
+
+// recordingExecutor asserts, at the moment a tool call actually runs, that
+// its triggering tool_use block is already durably saved to disk — the
+// crash-safety guarantee RunAgent's incremental persistence exists for.
+type recordingExecutor struct {
+	t       *testing.T
+	storeID string
+	ran     bool
+}
+
+func (e *recordingExecutor) Execute(ctx context.Context, name string, input map[string]any) (agent.ToolResult, error) {
+	e.ran = true
+	reloaded, err := agent.LoadSession(e.storeID)
+	if err != nil {
+		e.t.Fatalf("LoadSession before tool executed: %v", err)
+	}
+	for _, m := range reloaded.Messages {
+		for _, b := range m.Blocks {
+			if b.Type == "tool_use" && b.Name == name {
+				return agent.ToolResult{Text: "done"}, nil
+			}
+		}
+	}
+	e.t.Fatalf("tool_use for %q not found on disk before the tool executed", name)
+	return agent.ToolResult{}, nil
+}
+
+// TestRunAgent_PersistsToolUseBeforeToolExecutes verifies the incremental
+// persistence RunAgent now does: a tool_use block must be flushed to disk
+// before the tool it names actually runs, so a process crash mid-turn loses
+// at most the round in flight, not evidence of tool calls whose side effects
+// already happened.
+func TestRunAgent_PersistsToolUseBeforeToolExecutes(t *testing.T) {
+	tempHome(t)
+	mock := &mockAdapter{platform: "mock"}
+	ctrl := NewUIController(mock, "chat1", "", nil)
+
+	store := agent.NewSession("test-model", "")
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	sess := &Session{
+		Key: "test",
+		Agent: agent.New(&queuedToolSender{replies: []agent.Reply{
+			{StopReason: "tool_use", Blocks: []agent.ContentBlock{
+				{Type: "tool_use", ID: "call1", Name: "test_tool", Input: map[string]any{}},
+			}},
+			{Content: "done", StopReason: "end_turn"},
+		}}, "test-model"),
+		Store:  store,
+		ChatID: "chat1",
+	}
+	exec := &recordingExecutor{t: t, storeID: store.ID}
+	tools := []agent.ToolDefinition{{Name: "test_tool", Description: "test", Parameters: map[string]any{"type": "object"}}}
+
+	reply, err := RunAgent(context.Background(), sess, tools, exec, ctrl, "hello")
+	if err != nil {
+		t.Fatalf("RunAgent error: %v", err)
+	}
+	if reply.Content != "done" {
+		t.Fatalf("unexpected reply: %q", reply.Content)
+	}
+	if !exec.ran {
+		t.Fatal("tool executor never ran")
+	}
+}
+
 // A multi-flush reply on an update-capable platform (Telegram/Discord/Feishu)
 // must edit the message with the FULL text streamed so far — an edit carrying
 // only the newest chunk would erase what the user already read (#1115).


### PR DESCRIPTION
## Summary
- IM channels (`channel.RunAgent`) previously only flushed conversation history to disk once the whole turn (all tool round-trips) finished — unlike the web WS handler's `persistTurnProgress`. A process crash mid-turn lost the user's triggering message and every completed tool_use/tool_result pair, even though the tools' real side effects had already happened.
- `RunAgent` now saves after every `agent.AgentEvent`, gated on `History.Len()`/`RewriteDirty()` so it's a no-op between history-growth points — same cost profile and crash-safety guarantee as `ws_handlers.go`'s `persistTurnProgress`.
- Fixing this raises how often `Session.Persist()` (holds `storeMu`) runs during a turn, which turns a pre-existing latent race in `cmdUnbind` into one a user can trigger: it mutated the shared `*agent.Session` via `Store.Save()` without taking `storeMu`, racing an in-flight turn's per-event persist. Added `Session.UnbindStore()` to route it through the same lock (mirrors `Persist`/`deleteStore`/`GoalStore`).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on changed files (clean)
- [x] `go test -race ./internal/channel/... ./internal/server/...`
- [x] Added `TestRunAgent_PersistsToolUseBeforeToolExecutes`, which asserts a tool_use block is durably on disk before the tool it names executes; verified it fails against the old post-turn-only persistence and passes against this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)