### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.7.8"
+var Version = "1.8.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Version bump for the 1.8.0 release, tagged right after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)