### PR TITLE
fix(landing): point Changelog links at GitHub Releases

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -618,7 +618,7 @@ echo <span class="arg">"Summarise the last commit"</span> | <span class="cmd">oc
         <div style="display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap;">
           <a class="btn btn-primary js-download" href="https://github.com/open-octo/octo-agent/releases/latest" data-en="⬇️ Download" data-zh="⬇️ 下载"></a>
           <a class="btn btn-secondary" href="https://github.com/open-octo/octo-agent" style="display:inline-flex;align-items:center;gap:6px;"><svg width="16" height="16" viewBox="0 0 100 100" style="flex:0 0 16px;"><rect width="100" height="100" rx="22" fill="#2F54EB"/><path fill="#ffffff" d="M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z"/><circle cx="40" cy="42" r="5" fill="#2F54EB"/><circle cx="60" cy="42" r="5" fill="#2F54EB"/></svg> GitHub</a>
-          <a class="btn btn-secondary" href="https://github.com/open-octo/octo-agent/blob/main/CHANGELOG.md" data-en="📋 Changelog" data-zh="📋 更新日志"></a>
+          <a class="btn btn-secondary" href="https://github.com/open-octo/octo-agent/releases" data-en="📋 Changelog" data-zh="📋 更新日志"></a>
         </div>
       </div>
     </div>
@@ -630,7 +630,7 @@ echo <span class="arg">"Summarise the last commit"</span> | <span class="cmd">oc
       <a href="/docs/" data-href-en="/docs/" data-href-zh="/docs/zh/" data-en="Docs" data-zh="文档"></a>
       <a href="/blog/" data-en="Blog" data-zh="博客"></a>
       <a href="https://github.com/open-octo/octo-agent/blob/main/README.md" data-href-en="https://github.com/open-octo/octo-agent/blob/main/README.md" data-href-zh="https://github.com/open-octo/octo-agent/blob/main/README_CN.md">README</a>
-      <a href="https://github.com/open-octo/octo-agent/blob/main/CHANGELOG.md" data-en="Changelog" data-zh="更新日志"></a>
+      <a href="https://github.com/open-octo/octo-agent/releases" data-en="Changelog" data-zh="更新日志"></a>
       <a href="https://github.com/open-octo/octo-agent/blob/main/LICENSE.txt" data-en="License" data-zh="许可"></a>
     </div>
     <p data-en="MIT licensed · Built with curiosity and a lot of ☕" data-zh="MIT 许可 · 用好奇心和大量 ☕ 打造"></p>


### PR DESCRIPTION
## Summary
- #1202 removed CHANGELOG.md but missed the marketing landing page's two hardcoded links to it (hero "📋 Changelog" button + footer link) — both now 404.
- Repointed both to https://github.com/open-octo/octo-agent/releases, matching the docs site pages fixed in #1202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)