### PR TITLE
fix(tui): restore the startup ASCII banner

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -20,6 +21,7 @@ import (
 	"github.com/open-octo/octo-agent/internal/mcp"
 	"github.com/open-octo/octo-agent/internal/tools"
 	"github.com/open-octo/octo-agent/internal/tui"
+	"golang.org/x/term"
 )
 
 // runTUI is the interactive bubbletea REPL: the TTY counterpart to runREPL's
@@ -594,7 +596,17 @@ func newTUIModel(cfg replConfig) *tuiModel {
 		style = "light"
 	}
 	historyFile := defaultInputHistoryFile()
-	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistory: loadInputHistory(historyFile), inputHistoryIdx: -1, historyFile: historyFile, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}, subAgentFocus: -1, workflows: map[string]*workflowUI{}}
+	// Bubbletea reports the real terminal size asynchronously via the first
+	// WindowSizeMsg, which arrives only after Init() has already run — too
+	// late for Init's banner print, which would otherwise always see width 0
+	// and fall back to the narrow-terminal text-only banner. Query it
+	// synchronously up front instead; the WindowSizeMsg handler still
+	// overwrites these on resize.
+	width, height := 80, 24
+	if w, h, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+		width, height = w, h
+	}
+	m := &tuiModel{cfg: cfg, a: cfg.a, cwd: abbreviateHome(workingDir()), ta: ta, inputHistory: loadInputHistory(historyFile), inputHistoryIdx: -1, historyFile: historyFile, md: markdownRenderer{style: style}, subAgents: map[string]*subAgentUI{}, subAgentFocus: -1, workflows: map[string]*workflowUI{}, width: width, height: height}
 	// Seed the last-seen goal status so a resumed session's first transition
 	// (e.g. the budget crossing) prints its notice instead of being treated
 	// as the baseline.

--- a/cmd/octo/tuirepl_p5_test.go
+++ b/cmd/octo/tuirepl_p5_test.go
@@ -46,6 +46,9 @@ func TestTUI_QueuePanelTruncatesLongMultilineItems(t *testing.T) {
 
 func TestTUI_PermissionPromptShowsFullCommand(t *testing.T) {
 	m := newTestModel()
+	// Wide enough that the command below renders on one line — this test
+	// checks against truncation, not the (separately-tested) line-wrapping.
+	m.width = 200
 	// A command long past the old 60-rune summary cap: every character must be
 	// visible — the user is authorizing it.
 	cmd := "git push --force origin main && rm -rf ./dist && echo " + strings.Repeat("x", 120)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/tetratelabs/wazero v1.12.0
 	github.com/yuin/goldmark v1.7.13
 	golang.org/x/sys v0.44.0
+	golang.org/x/term v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -45,6 +46,5 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/term v0.36.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 )


### PR DESCRIPTION
## Summary
- #1095/#1175 made `Banner()` fall back to a text-only header when the ASCII art doesn't fit the terminal width — but the only call site (`Init()`) always runs before bubbletea's first `WindowSizeMsg` arrives, so `m.width` was always `0` there. `0 < 104` (the art's minimum width), so the fallback fired on every single launch since 2026-07-05 — the octopus art silently stopped rendering entirely, regardless of actual terminal size.
- Fix: query the real terminal size synchronously via `golang.org/x/term.GetSize` when constructing the model (`newTUIModel`), so `Init()` sees the actual width instead of `0`. The async `WindowSizeMsg` handler still overwrites this on resize as before.
- `golang.org/x/term` was already an indirect dependency (pulled in by bubbletea); this just promotes it to direct — no new module fetched (`go.mod`/`go.sum` diff confirms this).
- `TestTUI_PermissionPromptShowsFullCommand` only passed before by accident: test models implicitly got `width=0`, and `wrapIndented` treats `<=0` as "don't wrap." With a realistic width now flowing through test models too, a very long test command started wrapping (not truncating — still fully visible, just across lines), breaking an exact-substring assertion. Pinned that one test's width explicitly so it verifies what it actually means to (no truncation) instead of depending on the incidental zero-width behavior.

## Verification
- Manual check: called `tui.Banner(..., width)` directly at width `0` (the bug — text-only), `60` (genuinely narrow — correctly still text-only), and `120` (a realistic terminal — full ASCII art renders). Confirms the fix without needing a live TTY in this environment.
- `make fmt-check`, `make vet`, `go build ./...`
- `go test ./cmd/octo/... ./internal/tui/...` — all pass
- `go test ./...` — one unrelated pre-existing failure (`TestDetectToolchain_PresentAndMissing`, fails identically on `main`, caused by this dev machine having `uv` installed in `PATH`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)