### PR TITLE
fix(blog): correct Mermaid selector for Astro 7 Shiki output

### DIFF
--- a/blog/src/layouts/BlogPost.astro
+++ b/blog/src/layouts/BlogPost.astro
@@ -121,10 +121,10 @@ const siteName = locale === 'zh' ? 'octo 博客' : 'octo blog';
 		<script type="module">
 			import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
 			mermaid.initialize({ startOnLoad: false, theme: 'default' });
-			const blocks = document.querySelectorAll('pre code.language-mermaid');
-			blocks.forEach((block) => {
-				const pre = block.parentElement;
-				const source = block.textContent || '';
+			const blocks = document.querySelectorAll('pre[data-language="mermaid"]');
+			blocks.forEach((pre) => {
+				const code = pre.querySelector('code');
+				const source = code ? (code.textContent || '') : '';
 				const id = 'mermaid-' + Math.random().toString(36).slice(2, 9);
 				const container = document.createElement('div');
 				container.className = 'mermaid-diagram';


### PR DESCRIPTION
## Problem

The octo blog's Mermaid flowcharts were not rendering. The client-side script in `blog/src/layouts/BlogPost.astro` was looking for `pre code.language-mermaid`, but Astro 7's default Shiki syntax highlighter renders ````mermaid` code blocks as:

```html
<pre class="astro-code github-dark" data-language="mermaid">
  <code><span class="line">flowchart TD...</span></code>
</pre>
```

So the selector matched nothing and diagrams stayed as raw code.

## Change

Update the selector to target the `<pre>` element by its `data-language` attribute and read the source from the nested `<code>` element:

```js
const blocks = document.querySelectorAll('pre[data-language="mermaid"]');
blocks.forEach((pre) => {
    const code = pre.querySelector('code');
    const source = code ? (code.textContent || '') : '';
    // ... render with mermaid
});
```

## Verification

- `npm run build` passes in `blog/`.
- Generated `_astro/BlogPost.astro_*.js` contains the updated selector.

## Scope

Only affects `blog/src/layouts/BlogPost.astro`.
