### PR TITLE
chore: bump version to 1.8.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.8.1"
+var Version = "1.8.2"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Routine patch bump to release the fixes merged since v1.8.1: the Astro/Shiki Mermaid selector fix (#1212) and the terminal-tool async-overuse nudge (#1211).

## Test plan
- [x] `go build ./...`