### PR TITLE
fix(server): log session title generation failures instead of swallowing them

### DIFF
--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -7,11 +7,32 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
 )
+
+// syncBuffer wraps bytes.Buffer with a mutex: the title-generation goroutine
+// writes to it (via slog) on its own goroutine while the test polls it by
+// reading, and bytes.Buffer itself has no concurrency guarantees.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 func TestIsAutoNamePlaceholder(t *testing.T) {
 	cases := []struct {
@@ -214,9 +235,9 @@ func TestDoAgentTurn_TitleGenerationFailureIsLogged(t *testing.T) {
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)
 
-	var logBuf bytes.Buffer
+	logBuf := &syncBuffer{}
 	prevLogger := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	slog.SetDefault(slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	t.Cleanup(func() { slog.SetDefault(prevLogger) })
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})

--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -1,7 +1,12 @@
 package server
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -149,5 +154,120 @@ wait:
 	}
 	if brief[0].Name != "stub reply" {
 		t.Errorf("Name = %q, want %q", brief[0].Name, "stub reply")
+	}
+}
+
+// titleFailSender behaves exactly like stubSender for a normal turn, but
+// returns an error specifically for GenerateTitle's throwaway prompt (its
+// message list always ends with the "Summarize this conversation..."
+// instruction) — simulating a provider/model that's misconfigured only for
+// this fire-and-forget call, e.g. a bad model alias or a rate limit hit on a
+// second request right after the main turn's.
+type titleFailSender struct{}
+
+func (titleFailSender) SendMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int) (agent.Reply, error) {
+	if isTitlePrompt(msgs) {
+		return agent.Reply{}, fmt.Errorf("stub: title provider error")
+	}
+	return agent.Reply{Content: "stub reply"}, nil
+}
+
+func (titleFailSender) StreamMessages(_ context.Context, _, _ string, _ []agent.Message, _ int, onChunk func(string), _ func(string)) (agent.Reply, error) {
+	if onChunk != nil {
+		onChunk("stub reply")
+	}
+	return agent.Reply{Content: "stub reply"}, nil
+}
+
+func (titleFailSender) SendMessagesWithTools(_ context.Context, _, _ string, msgs []agent.Message, _ int, _ []agent.ToolDefinition) (agent.Reply, error) {
+	if isTitlePrompt(msgs) {
+		return agent.Reply{}, fmt.Errorf("stub: title provider error")
+	}
+	return agent.Reply{Content: "stub reply"}, nil
+}
+
+func (titleFailSender) StreamMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, _ []agent.ToolDefinition, onChunk func(string), _ agent.ToolInputDeltaFunc, _ agent.ThinkingDeltaFunc) (agent.Reply, error) {
+	if onChunk != nil {
+		onChunk("stub reply")
+	}
+	return agent.Reply{Content: "stub reply"}, nil
+}
+
+// isTitlePrompt reports whether msgs is GenerateTitle's throwaway call
+// (identified by its trailing instruction, not by any dedicated flag — the
+// provider itself only ever sees an ordinary message list).
+func isTitlePrompt(msgs []agent.Message) bool {
+	if len(msgs) == 0 {
+		return false
+	}
+	return strings.Contains(msgs[len(msgs)-1].Content, "Summarize this conversation")
+}
+
+// TestDoAgentTurn_TitleGenerationFailureIsLogged is the regression guard for
+// a real production symptom: on an install where the title-generation call
+// fails every time (bad model config, rate limit, etc.), the sidebar title
+// never appears and — before this test — nothing anywhere recorded why. The
+// failure is still silent to the user by design (retried on the next turn),
+// but it must not be silent to the server operator.
+func TestDoAgentTurn_TitleGenerationFailureIsLogged(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.sender = &titleFailSender{}
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]agent.InboxItem)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	sess.Title = "Session 5"
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+
+	srv.doAgentTurn(sess, "hello there", nil, nil)
+
+	// The title goroutine is fire-and-forget, so there's no broadcast to wait
+	// on for the failure path — poll the captured log instead.
+	deadline := time.After(5 * time.Second)
+	for {
+		if strings.Contains(logBuf.String(), "session title generation failed") {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected a logged warning for the failed title generation; log so far:\n%s", logBuf.String())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	if !strings.Contains(logBuf.String(), sess.ID) {
+		t.Errorf("expected the session id in the log line; got:\n%s", logBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), "stub: title provider error") {
+		t.Errorf("expected the underlying error in the log line; got:\n%s", logBuf.String())
+	}
+
+	// And the title must genuinely still be unset — the failure path must not
+	// have persisted a garbage title.
+	loaded, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !isAutoNamePlaceholder(loaded.Title) {
+		t.Errorf("Title = %q, want it to remain a placeholder after a failed generation", loaded.Title)
 	}
 }

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
 	"sync"
@@ -1245,7 +1246,19 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 			defer cancel()
 			t, terr := a.GenerateTitle(ctx, toolDefs)
-			if terr != nil || strings.TrimSpace(t) == "" {
+			if terr != nil {
+				// Silent by design (retried after the next completed turn,
+				// per the comment above) — but silent must not mean
+				// invisible: without this, a persistently misconfigured
+				// model/provider on a given install never generates a
+				// title, and nothing anywhere records why, making the
+				// exact symptom "sidebar title never updates" unexplainable
+				// from the server side.
+				slog.Warn("session title generation failed", "session_id", sid, "err", terr)
+				return
+			}
+			if strings.TrimSpace(t) == "" {
+				slog.Warn("session title generation returned an empty title", "session_id", sid)
 				return
 			}
 			// Apply the title to a freshly loaded Session, not the live one —
@@ -1253,10 +1266,17 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			// goroutine, and Session isn't goroutine-safe. A load that races
 			// a concurrent append just errors out and a later turn retries.
 			fresh, lerr := agent.LoadSession(sid)
-			if lerr != nil || !isAutoNamePlaceholder(fresh.Title) {
+			if lerr != nil {
+				slog.Warn("session title generation: reload session failed", "session_id", sid, "err", lerr)
 				return
 			}
-			if fresh.SetTitle(t) != nil {
+			if !isAutoNamePlaceholder(fresh.Title) {
+				// Not an error: something else (the user, or an earlier
+				// retry) already gave the session a real title.
+				return
+			}
+			if err := fresh.SetTitle(t); err != nil {
+				slog.Warn("session title generation: save failed", "session_id", sid, "err", err)
 				return
 			}
 			// Global broadcast: the sidebar lists every session, so every


### PR DESCRIPTION
## Context

Investigating a report of "new session's sidebar title never auto-updates, only after a manual page refresh" on a freshly installed 1.8.2 on a different machine.

- Direct WS-level repro against this machine's own running 1.8.2 instance shows the backend contract works correctly end-to-end: `session_renamed` broadcasts ~a few seconds after the turn completes, and the frontend handler (`App.svelte`) + sidebar render (`Sidebar.svelte`) are wired correctly — all four historical fixes for this exact symptom (#533, #534, #762, #881) are present at HEAD.
- On the other machine, a direct WS inspection confirms `session_renamed` genuinely never arrives — this isn't a frontend rendering gap, the server never sends it.

## Root cause

`doAgentTurn`'s fire-and-forget title-generation goroutine (`internal/server/ws_handlers.go`) swallows every failure with a silent `return` — no log line, no signal anywhere. If title generation fails on every turn on a given install (bad model alias, missing credentials, rate limit, timeout, etc.), the symptom is indistinguishable from a UI bug: the title just never shows up, and there was nothing to diagnose from.

## Fix

Split the combined error/empty-title check and added `slog.Warn` at each failure point (title-gen error, empty title, session reload error, save error) — matching the existing `slog.Warn`/`slog.Error` convention already used elsewhere in this package (`handlers.go`, `server.go`). Retry-on-next-turn behavior is unchanged; this only makes the existing failure mode observable in the server log, so the next time this happens the operator can see *why*.

## Test plan
- [x] `go build ./...`
- [x] New: `TestDoAgentTurn_TitleGenerationFailureIsLogged` — a sender that errors specifically on the title-generation prompt (while succeeding on the main turn) triggers the expected `slog.Warn` line, carrying the session id and underlying error; asserts the title stays a placeholder (no garbage persisted)
- [x] Existing `TestDoAgentTurn_GeneratesSessionTitle` / `TestListSessionsBrief_ReflectsGeneratedTitle` / `TestIsAutoNamePlaceholder` unaffected
- [x] `go test ./internal/server/...` full package passes