### PR TITLE
chore: bump version to 1.8.3

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.8.2"
+var Version = "1.8.3"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Routine patch bump to release the fix merged since v1.8.2: session title generation failures are now logged instead of silently swallowed (#1214).

## Test plan
- [x] `go build ./...`