### PR TITLE
fix(upgrade): fall back to mirrors when resolving the latest version

### DIFF
--- a/dev-docs/octo-upgrade-design.md
+++ b/dev-docs/octo-upgrade-design.md
@@ -54,7 +54,11 @@ The logic lives in one package used by both the CLI and the server.
 - **`Check(ctx) (latest string, err error)`** — issues a no-redirect GET to
   `releases/latest` and parses the version out of the `Location` header.
   No GitHub API, no JSON, no rate-limit coupling. The base URL is a
-  package var so tests point it at `httptest`.
+  package var so tests point it at `httptest`. Falls back through
+  `MirrorBaseURLs` in order when `BaseURL` is unreachable — GitHub being
+  blocked outright, not just slow, has to be handled here too, or a
+  download-stage mirror fallback never gets a chance to run since
+  `Prepare` calls `Check` first.
 
 - **`Prepare(ctx, Options) (*Prepared, error)`** /
   **`Prepared.Install() error`** with

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -74,9 +75,18 @@ func (o Options) log(format string, args ...any) {
 	}
 }
 
-// Check resolves the latest released version (no leading "v") by following
-// none of the releases/latest redirect: the target tag is in the Location
-// header. No GitHub API, so no rate-limit coupling.
+// checkBodyCap limits how much of a 200 (non-redirect) response body gets
+// read when hunting for the release tag in HTML — a real release page is
+// ~200 KB.
+const checkBodyCap = 2 << 20 // 2 MiB
+
+// ogURLPattern extracts the path GitHub embeds in the release page's
+// og:url meta tag, e.g. `/open-octo/octo-agent/releases/tag/v1.8.3`.
+var ogURLPattern = regexp.MustCompile(`<meta\s+property="og:url"\s+content="([^"]+)"`)
+
+// Check resolves the latest released version (no leading "v") from the
+// releases/latest redirect: the target tag is in the Location header. No
+// GitHub API, so no rate-limit coupling.
 //
 // It honors the standard proxy environment variables (HTTP_PROXY,
 // HTTPS_PROXY, NO_PROXY) via http.ProxyFromEnvironment. When BaseURL is
@@ -96,6 +106,11 @@ func Check(ctx context.Context) (string, error) {
 	return "", lastErr
 }
 
+// checkAt resolves the latest tag from a single base URL. Most mirrors
+// forward GitHub's redirect as-is, so the tag comes from the Location
+// header; a few (e.g. gh.ddlc.top) instead follow the redirect themselves
+// and hand back the release page, so a 200 response is scanned for the
+// og:url meta tag GitHub embeds in that page.
 func checkAt(ctx context.Context, base string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/releases/latest", nil)
 	if err != nil {
@@ -111,13 +126,32 @@ func checkAt(ctx context.Context, base string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+
+	switch {
+	case resp.StatusCode >= 300 && resp.StatusCode < 400:
+		return tagFromPath(resp.Header.Get("Location"))
+	case resp.StatusCode == http.StatusOK:
+		body, err := io.ReadAll(io.LimitReader(resp.Body, checkBodyCap))
+		if err != nil {
+			return "", fmt.Errorf("releases/latest: read body: %w", err)
+		}
+		m := ogURLPattern.FindSubmatch(body)
+		if m == nil {
+			return "", fmt.Errorf("releases/latest: got 200 with no recognizable release tag")
+		}
+		return tagFromPath(string(m[1]))
+	default:
 		return "", fmt.Errorf("releases/latest: expected redirect, got %s", resp.Status)
 	}
-	loc := resp.Header.Get("Location")
+}
+
+// tagFromPath pulls the "v1.2.3" (returned without the leading "v") out of
+// a path or URL ending in "/tag/v1.2.3", as found in both a redirect's
+// Location header and a release page's og:url meta tag.
+func tagFromPath(loc string) (string, error) {
 	i := strings.LastIndex(loc, "/tag/")
 	if i < 0 {
-		return "", fmt.Errorf("releases/latest: unexpected redirect target %q", loc)
+		return "", fmt.Errorf("releases/latest: unrecognized release location %q", loc)
 	}
 	tag := strings.TrimPrefix(loc[i+len("/tag/"):], "v")
 	if tag == "" {

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -79,9 +79,25 @@ func (o Options) log(format string, args ...any) {
 // header. No GitHub API, so no rate-limit coupling.
 //
 // It honors the standard proxy environment variables (HTTP_PROXY,
-// HTTPS_PROXY, NO_PROXY) via http.ProxyFromEnvironment.
+// HTTPS_PROXY, NO_PROXY) via http.ProxyFromEnvironment. When BaseURL is
+// unreachable (e.g. GitHub is blocked outright, not merely slow, so no proxy
+// is configured), it falls back to MirrorBaseURLs in order — otherwise a
+// download-stage mirror fallback never gets a chance to run, because Prepare
+// calls Check first.
 func Check(ctx context.Context) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, BaseURL+"/releases/latest", nil)
+	var lastErr error
+	for _, base := range append([]string{BaseURL}, MirrorBaseURLs...) {
+		tag, err := checkAt(ctx, base)
+		if err == nil {
+			return tag, nil
+		}
+		lastErr = err
+	}
+	return "", lastErr
+}
+
+func checkAt(ctx context.Context, base string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/releases/latest", nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -176,6 +176,36 @@ func TestCheck_FallsBackToMirror(t *testing.T) {
 	}
 }
 
+func TestCheck_MirrorFollowsRedirectItself(t *testing.T) {
+	// Some mirrors (e.g. gh.ddlc.top) don't forward GitHub's 302 as-is —
+	// they follow it server-side and hand back the release page instead,
+	// with GitHub's own og:url meta tag intact.
+	mirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<!DOCTYPE html><html><head>`+
+			`<title>Release v0.19.0 · open-octo/octo-agent · GitHub</title>`+
+			`<meta property="og:url" content="/open-octo/octo-agent/releases/tag/v0.19.0" />`+
+			`</head><body></body></html>`)
+	}))
+	t.Cleanup(mirror.Close)
+
+	origBase := BaseURL
+	BaseURL = mirror.URL
+	origMirrors := MirrorBaseURLs
+	MirrorBaseURLs = nil
+	t.Cleanup(func() {
+		BaseURL = origBase
+		MirrorBaseURLs = origMirrors
+	})
+
+	got, err := Check(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "0.19.0" {
+		t.Errorf("Check = %q, want 0.19.0", got)
+	}
+}
+
 func TestCheck_AllUnreachableReturnsLastError(t *testing.T) {
 	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "primary down", http.StatusServiceUnavailable)

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -148,6 +148,58 @@ func TestCheck_NoRedirect(t *testing.T) {
 	}
 }
 
+func TestCheck_FallsBackToMirror(t *testing.T) {
+	// Primary server: releases/latest is unreachable (simulating GitHub
+	// being blocked outright, not just slow).
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "blocked", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(primary.Close)
+
+	mirror := fakeRelease(t, "0.19.0", "bin", "")
+
+	origBase := BaseURL
+	BaseURL = primary.URL
+	origMirrors := MirrorBaseURLs
+	MirrorBaseURLs = []string{mirror.URL}
+	t.Cleanup(func() {
+		BaseURL = origBase
+		MirrorBaseURLs = origMirrors
+	})
+
+	got, err := Check(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "0.19.0" {
+		t.Errorf("Check = %q, want 0.19.0", got)
+	}
+}
+
+func TestCheck_AllUnreachableReturnsLastError(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "primary down", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(primary.Close)
+	mirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "mirror down", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(mirror.Close)
+
+	origBase := BaseURL
+	BaseURL = primary.URL
+	origMirrors := MirrorBaseURLs
+	MirrorBaseURLs = []string{mirror.URL}
+	t.Cleanup(func() {
+		BaseURL = origBase
+		MirrorBaseURLs = origMirrors
+	})
+
+	if _, err := Check(context.Background()); err == nil {
+		t.Fatal("expected error when base and all mirrors are unreachable")
+	}
+}
+
 func TestRun_FallsBackToMirror(t *testing.T) {
 	asRelease(t, "0.18.0", "abc1234")
 	ver := "0.19.0"


### PR DESCRIPTION
## Summary
- `Check()` (used by both `octo upgrade` and the web UI's upgrade badge) only ever hit `BaseURL` directly to resolve the latest version tag; on networks where `github.com` is unreachable outright it failed before `Prepare` ever got to the mirror-aware archive/checksums download step, so `MirrorBaseURLs` (`ghproxy.net`, `gh-proxy.com`, `gh.ddlc.top`) were configured but never actually reached.
- `Check` now tries `BaseURL` then each of `MirrorBaseURLs` in order, same pattern as the existing `downloadWithMirrors`/`releaseURLs` fallback for the archive download.
- Updated `dev-docs/octo-upgrade-design.md` to describe the fallback.

## Test plan
- [x] `go test ./internal/upgrade/... -run TestCheck -v` — new `TestCheck_FallsBackToMirror` and `TestCheck_AllUnreachableReturnsLastError` pass alongside existing `TestCheck`/`TestCheck_NoRedirect`
- [x] `go test -race ./internal/upgrade/... ./internal/server/...`
- [x] `make fmt-check`, `go vet ./...`