### PR TITLE
fix(agent,server): cap title/suggestion generation to low reasoning effort

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -61,6 +61,26 @@ type ToolSender interface {
 	) (Reply, error)
 }
 
+// LowEffortSender is implemented by a Sender that can produce a cheaper
+// variant of itself with reasoning effort capped to a small, fast budget.
+// GenerateTitle and Suggest use this: both deliberately reuse the turn's own
+// Sender (so the request shares the main conversation's prompt-cache
+// prefix — see their doc comments), but that Sender carries whatever
+// reasoning_effort the session happens to be configured with. A session
+// running "high"/"max" would otherwise pay the model's full reasoning
+// budget just to produce a 6-word title or a one-line suggestion, for no
+// benefit — and on a slower provider this reliably exceeds the throwaway
+// call's timeout every single time (a session stays on that effort level
+// across turns, so title generation would retry into the same failure on
+// every turn, never succeeding). LowEffort caps effort down rather than
+// disabling it outright — thinking stays nominally enabled, just with a
+// small budget, keeping the request shape consistent with earlier turns in
+// the same conversation that may already carry thinking blocks in history.
+type LowEffortSender interface {
+	Sender
+	LowEffort() Sender
+}
+
 // ToolInputDeltaFunc receives raw JSON fragments of a tool_use block's
 // arguments as they stream in. Fragments concatenate to form the final
 // JSON object. May be nil; implementations should treat nil as "don't
@@ -1215,12 +1235,17 @@ func (a *Agent) Suggest(ctx context.Context, tools []ToolDefinition) (string, er
 	msgs = append(msgs, snap...)
 	msgs = append(msgs, NewUserMessage(suggestInstruction))
 
+	sender := a.Sender
+	if le, ok := sender.(LowEffortSender); ok {
+		sender = le.LowEffort()
+	}
+
 	var reply Reply
 	var err error
-	if ts, ok := a.Sender.(ToolSender); ok && len(tools) > 0 {
+	if ts, ok := sender.(ToolSender); ok && len(tools) > 0 {
 		reply, err = ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, suggestMaxTokens, tools)
 	} else {
-		reply, err = a.Sender.SendMessages(ctx, a.Model, a.System, msgs, suggestMaxTokens)
+		reply, err = sender.SendMessages(ctx, a.Model, a.System, msgs, suggestMaxTokens)
 	}
 	if err != nil {
 		return "", err
@@ -1256,12 +1281,17 @@ func (a *Agent) GenerateTitle(ctx context.Context, tools []ToolDefinition) (stri
 	msgs = append(msgs, snap...)
 	msgs = append(msgs, NewUserMessage(titleInstruction))
 
+	sender := a.Sender
+	if le, ok := sender.(LowEffortSender); ok {
+		sender = le.LowEffort()
+	}
+
 	var reply Reply
 	var err error
-	if ts, ok := a.Sender.(ToolSender); ok && len(tools) > 0 {
+	if ts, ok := sender.(ToolSender); ok && len(tools) > 0 {
 		reply, err = ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, titleMaxTokens, tools)
 	} else {
-		reply, err = a.Sender.SendMessages(ctx, a.Model, a.System, msgs, titleMaxTokens)
+		reply, err = sender.SendMessages(ctx, a.Model, a.System, msgs, titleMaxTokens)
 	}
 	if err != nil {
 		return "", err

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -31,6 +31,16 @@ func (f *fakeSender) SendMessages(_ context.Context, model, system string, messa
 	return f.reply, nil
 }
 
+// fakeLowEffortSender additionally implements LowEffortSender: LowEffort()
+// hands back a distinct sender (low) so a test can assert GenerateTitle/
+// Suggest actually swap to it instead of using the main sender directly.
+type fakeLowEffortSender struct {
+	fakeSender
+	low *fakeSender
+}
+
+func (f *fakeLowEffortSender) LowEffort() Sender { return f.low }
+
 func TestAgent_Turn_HappyPath(t *testing.T) {
 	send := &fakeSender{reply: Reply{Content: "hi from agent", Model: "m", StopReason: "end_turn"}}
 	a := New(send, "claude-test")
@@ -1761,6 +1771,34 @@ func TestAgent_Suggest_NotConfigured(t *testing.T) {
 	}
 }
 
+// TestAgent_Suggest_UsesLowEffortSenderWhenAvailable mirrors the GenerateTitle
+// guard: Suggest is the same kind of throwaway call and must not pay the
+// session's full reasoning budget either.
+func TestAgent_Suggest_UsesLowEffortSenderWhenAvailable(t *testing.T) {
+	low := &fakeSender{reply: Reply{Content: "low effort suggestion"}}
+	main := &fakeLowEffortSender{
+		fakeSender: fakeSender{reply: Reply{Content: "should not be used"}},
+		low:        low,
+	}
+	a := New(main, "m")
+	a.History.Append(NewUserMessage("do X"))
+	a.History.Append(NewAssistantMessage("did X"))
+
+	s, err := a.Suggest(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Suggest: %v", err)
+	}
+	if s != "low effort suggestion" {
+		t.Errorf("suggestion = %q, want the low-effort sender's reply", s)
+	}
+	if len(main.gotMessages) != 0 {
+		t.Errorf("main sender should not have been called; got %d messages", len(main.gotMessages))
+	}
+	if len(low.gotMessages) == 0 {
+		t.Error("low-effort sender was never called")
+	}
+}
+
 func TestAgent_GenerateTitle(t *testing.T) {
 	send := &fakeSender{reply: Reply{Content: "\"Fix the login redirect bug\"."}}
 	a := New(send, "m")
@@ -1799,6 +1837,37 @@ func TestAgent_GenerateTitle_NotConfigured(t *testing.T) {
 	a := New(nil, "")
 	if _, err := a.GenerateTitle(context.Background(), nil); err == nil {
 		t.Error("GenerateTitle with no sender/model should error")
+	}
+}
+
+// TestAgent_GenerateTitle_UsesLowEffortSenderWhenAvailable guards the actual
+// fix for a confirmed production failure: a session running reasoning_effort
+// "max" paid the model's full reasoning budget just to produce a 6-word
+// title, reliably exceeding the throwaway call's timeout. When the Sender
+// implements LowEffortSender, GenerateTitle must route through the
+// low-effort variant instead of the session's main sender.
+func TestAgent_GenerateTitle_UsesLowEffortSenderWhenAvailable(t *testing.T) {
+	low := &fakeSender{reply: Reply{Content: "Low effort title"}}
+	main := &fakeLowEffortSender{
+		fakeSender: fakeSender{reply: Reply{Content: "should not be used"}},
+		low:        low,
+	}
+	a := New(main, "m")
+	a.History.Append(NewUserMessage("do X"))
+	a.History.Append(NewAssistantMessage("did X"))
+
+	title, err := a.GenerateTitle(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GenerateTitle: %v", err)
+	}
+	if title != "Low effort title" {
+		t.Errorf("title = %q, want the low-effort sender's reply", title)
+	}
+	if len(main.gotMessages) != 0 {
+		t.Errorf("main sender should not have been called; got %d messages", len(main.gotMessages))
+	}
+	if len(low.gotMessages) == 0 {
+		t.Error("low-effort sender was never called")
 	}
 }
 

--- a/internal/app/sender.go
+++ b/internal/app/sender.go
@@ -180,6 +180,21 @@ type sender struct {
 	showReasoning   bool
 }
 
+// LowEffort implements agent.LowEffortSender: it returns a copy of s with
+// reasoning effort capped to "low" — the cheapest non-zero budget — rather
+// than disabled outright. Effort is lowered, not removed, so the request
+// shape stays consistent with earlier turns in the same conversation that
+// may already carry thinking blocks in history (a live check against
+// kimi-for-coding confirmed mixing enabled-thinking history with a
+// disabled-thinking request doesn't actually error there, but "low" is the
+// safer choice across every Anthropic-protocol-compatible backend, tested
+// or not, and it fully solves the latency/cost problem this exists for).
+func (s sender) LowEffort() agent.Sender {
+	s.reasoningEffort = "low"
+	s.thinkingBudget = AnthropicThinkingBudget("low")
+	return s
+}
+
 // reasoningSink returns the OnThinking callback to hand the provider: the
 // agent's onThinking when reasoning display is enabled, else nil so the
 // provider skips surfacing reasoning entirely.

--- a/internal/app/sender_test.go
+++ b/internal/app/sender_test.go
@@ -70,6 +70,48 @@ func TestNewSender_DerivesThinkingBudgetFromEffort(t *testing.T) {
 	}
 }
 
+// TestSender_LowEffort_CapsReasoningRegardlessOfOriginal guards the fix for a
+// confirmed production failure: a session running reasoning_effort "max" paid
+// the model's full reasoning budget for GenerateTitle/Suggest's throwaway
+// calls, reliably exceeding their timeout. sender.LowEffort() must always cap
+// to "low" — never inherit whatever the session was actually configured
+// with — and must leave the original sender (and its caller-visible
+// reasoningEffort/thinkingBudget) untouched, since it's a value receiver
+// returning a modified copy, not a mutation.
+func TestSender_LowEffort_CapsReasoningRegardlessOfOriginal(t *testing.T) {
+	for _, original := range []string{"", "low", "medium", "high", "xhigh", "max"} {
+		t.Run("from "+original, func(t *testing.T) {
+			fake := &mockProvider{reply: provider.Response{Content: "ok"}}
+			s := sender{p: fake, reasoningEffort: original, thinkingBudget: AnthropicThinkingBudget(original)}
+
+			low := s.LowEffort()
+			if _, err := low.SendMessages(context.Background(), "m", "", []agent.Message{agent.NewUserMessage("hi")}, 0); err != nil {
+				t.Fatalf("SendMessages: %v", err)
+			}
+			if fake.gotReq.ReasoningEffort != "low" {
+				t.Errorf("ReasoningEffort sent = %q, want %q", fake.gotReq.ReasoningEffort, "low")
+			}
+			if want := AnthropicThinkingBudget("low"); fake.gotReq.ThinkingBudget != want {
+				t.Errorf("ThinkingBudget sent = %d, want %d", fake.gotReq.ThinkingBudget, want)
+			}
+
+			// The original sender must be unaffected (value receiver).
+			if s.reasoningEffort != original {
+				t.Errorf("original sender's reasoningEffort mutated: got %q, want %q", s.reasoningEffort, original)
+			}
+		})
+	}
+}
+
+// TestSender_ImplementsLowEffortSender is a compile-time-adjacent guard: if
+// sender's method set ever drifts (e.g. LowEffort renamed or given a pointer
+// receiver that breaks the value-type assertion agent.go relies on),
+// GenerateTitle/Suggest would silently stop capping effort with no test
+// failure elsewhere to catch it.
+func TestSender_ImplementsLowEffortSender(t *testing.T) {
+	var _ agent.LowEffortSender = sender{}
+}
+
 func TestSender_NilProvider(t *testing.T) {
 	s := sender{p: nil}
 	if _, err := s.SendMessages(context.Background(), "m", "", nil, 0); err == nil {

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1243,7 +1243,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		sid := sess.ID
 		go func() {
 			defer s.releaseTitleGeneration(sid)
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), throwawayGenerationTimeout)
 			defer cancel()
 			t, terr := a.GenerateTitle(ctx, toolDefs)
 			if terr != nil {
@@ -1294,7 +1294,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// Fire-and-forget: the frontend shows it as ghost text; failures are silent.
 	if err == nil {
 		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), throwawayGenerationTimeout)
 			defer cancel()
 			text, serr := a.Suggest(ctx, toolDefs)
 			if serr != nil || strings.TrimSpace(text) == "" {
@@ -1308,6 +1308,19 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		}()
 	}
 }
+
+// throwawayGenerationTimeout bounds the title- and suggestion-generation
+// calls above. Both reuse the turn's own Agent/Sender, which means they
+// inherit that session's reasoning_effort — a session running at "high" or
+// "max" pays the model's full reasoning budget even for a 6-word title, and
+// with a slower provider that reliably blows past a short deadline: a
+// confirmed field failure hit exactly this ("anthropic: send: ... context
+// deadline exceeded") at the previous 20s timeout under reasoning_effort
+// "max". Both calls are fire-and-forget and non-blocking for the user, so a
+// generous timeout costs nothing but a longer wait for a background
+// goroutine — better than the call being silently doomed to always miss a
+// too-short deadline on some installs.
+const throwawayGenerationTimeout = 60 * time.Second
 
 // sessionPlaceholderRe matches the frontend's auto-assigned "Session N"
 // default name on freshly created web sessions.

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1310,17 +1310,17 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 }
 
 // throwawayGenerationTimeout bounds the title- and suggestion-generation
-// calls above. Both reuse the turn's own Agent/Sender, which means they
-// inherit that session's reasoning_effort — a session running at "high" or
-// "max" pays the model's full reasoning budget even for a 6-word title, and
-// with a slower provider that reliably blows past a short deadline: a
-// confirmed field failure hit exactly this ("anthropic: send: ... context
-// deadline exceeded") at the previous 20s timeout under reasoning_effort
-// "max". Both calls are fire-and-forget and non-blocking for the user, so a
-// generous timeout costs nothing but a longer wait for a background
-// goroutine — better than the call being silently doomed to always miss a
-// too-short deadline on some installs.
-const throwawayGenerationTimeout = 60 * time.Second
+// calls above. A confirmed field failure hit "anthropic: send: ... context
+// deadline exceeded" on every attempt at the previous 20s timeout: both
+// calls reuse the turn's own Agent/Sender and inherited that session's
+// reasoning_effort ("max"), paying the model's full reasoning budget even
+// for a 6-word title. The real fix is agent.LowEffortSender (both calls now
+// cap effort to "low" instead of inheriting the session's), which removes
+// most of that latency at the source — this timeout is only the remaining
+// safety margin for normal network/provider variance, not a substitute for
+// the effort cap, so it stays modest rather than papering over a slow call
+// with a long wait.
+const throwawayGenerationTimeout = 30 * time.Second
 
 // sessionPlaceholderRe matches the frontend's auto-assigned "Session N"
 // default name on freshly created web sessions.


### PR DESCRIPTION
## Root cause (confirmed via #1214's new logging + a live repro)

A real install reported this after upgrading to pick up #1214's logging:

```
level=WARN msg="session title generation failed" session_id=... err="anthropic: send: Post \"https://api.kimi.com/coding/v1/messages\": context deadline exceeded"
```

`GenerateTitle` and `Suggest` both reuse the turn's own `Agent`/`Sender` (deliberately, to share the main conversation's prompt-cache prefix), so they also inherit that session's configured `reasoning_effort`. That session ran `reasoning_effort: max` — so even a throwaway "summarize this in 6 words" call paid the model's full reasoning budget. Combined with provider/network latency, it reliably blew past the original 20s deadline on every attempt (title generation retries every turn, so this was permanent, not a blip).

## Fix (two layers)

1. **Root cause**: added `agent.LowEffortSender`, an optional interface a `Sender` can implement to hand back a cheaper variant of itself. `GenerateTitle`/`Suggest` now use it instead of the session's main sender when available. `internal/app`'s `sender` implements it via `LowEffort()`, capping effort to `"low"` — not disabling it outright. I considered fully disabling reasoning for these calls, but `internal/provider/anthropic/client.go`'s own comment notes thinking blocks must generally accompany an enabled-thinking request, and history may already carry thinking blocks from earlier high-effort turns in the same conversation. A live check against kimi-for-coding confirmed mixing enabled-thinking history with a disabled-thinking request doesn't actually error there — but `"low"` (thinking nominally still on, tiny budget) is the safer choice across every Anthropic-protocol-compatible backend, tested or not, and it fully solves the latency/cost problem.
2. **Safety margin**: `throwawayGenerationTimeout` moves from the original 20s to 30s (this PR previously bumped it to 60s as a first pass — dropped back down now that the effort cap does the real work; 30s is headroom for normal variance, not a substitute for it).

## Test plan
- [x] `go build ./...`
- [x] New: `TestAgent_GenerateTitle_UsesLowEffortSenderWhenAvailable` / `TestAgent_Suggest_UsesLowEffortSenderWhenAvailable` — with a `LowEffortSender`-implementing fake, the low-effort variant is called, not the main sender
- [x] New: `TestSender_LowEffort_CapsReasoningRegardlessOfOriginal` — table test over every effort level ("" through "max"), asserts the wire request always carries `"low"` + its thinking budget, and that the original sender's fields are untouched (value-receiver copy, not mutation)
- [x] New: `TestSender_ImplementsLowEffortSender` — static interface-satisfaction guard
- [x] `go test ./internal/agent/... ./internal/app/... ./internal/server/... -race` all pass