### PR TITLE
fix(tui): show MCP-ready banner only in verbose mode

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -926,7 +926,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.cfg.executor != nil {
 				m.cfg.tools = tools.DefaultToolsFor(m.cfg.a.Model)
 			}
-			if !m.cfg.verbosity.quiet() {
+			if m.cfg.verbosity.verbose() {
 				m.printlnBlock(noticeStyle.Render(fmt.Sprintf("● MCP ready — %d server(s) connected", msg.reg.Len())))
 			}
 		}


### PR DESCRIPTION
## Summary
- TUI printed "● MCP ready — N server(s) connected" at default verbosity every time MCP servers finished connecting; the request was to only surface this on error.
- Connect failures already report unconditionally through `mcp.ConnectAll`'s `warn` writer (`internal/mcp/registry.go`), independent of this success banner, so gating the banner behind `--verbose` doesn't reduce error visibility.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/octo/...`
- [x] `gofmt -l cmd/octo/tuirepl.go` (clean)