### PR TITLE
fix(tui): stop echoing permission-mode/thinking toggles to scrollback

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -275,7 +275,6 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				next = permission.ModeInteractive
 			}
 			m.cfg.permEngine.SetMode(next)
-			m.println(noticeStyle.Render("Permission mode: " + string(next)))
 		}
 		return m, nil
 
@@ -1002,10 +1001,6 @@ func (m *tuiModel) dispatchThinking(level string) (tea.Model, tea.Cmd) {
 
 	m.a.Sender = newSender
 	m.cfg.reasoningEffort = level
-	if level == "off" {
-		level = "off"
-	}
-	m.println(noticeStyle.Render(fmt.Sprintf("Thinking: %s", level)))
 	return m, nil
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -965,7 +965,6 @@ func (m *tuiModel) dispatchModel(name string) (tea.Model, tea.Cmd) {
 	if m.cfg.tools != nil {
 		m.cfg.tools = tools.DefaultToolsFor(name)
 	}
-	m.println(noticeStyle.Render(fmt.Sprintf("Model: %s", name)))
 	return m, nil
 }
 


### PR DESCRIPTION
## Summary
- Cycling permission mode (Shift+Tab), running `/thinking <level>`, and running `/model <name>` each printed a scrollback notice every time — repeated toggling piles up redundant lines in the transcript.
- All three values are already live in the status bar (`model`/`think`/`perm` segments read `m.cfg.modelName` / `m.cfg.reasoningEffort` / `m.cfg.permEngine.GetMode()` directly), so the scrollback echo added no information.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/octo/...`
- [x] `go test ./cmd/octo/...`
- [x] `gofmt -l cmd/octo/tuirepl_view.go` (clean)