### PR TITLE
chore: bump version to 1.8.4

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.8.3"
+var Version = "1.8.4"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Routine patch bump to release fixes merged since v1.8.3: title/suggestion generation now capped to low reasoning effort instead of inheriting the session's (#1217), TUI MCP-ready banner only in verbose mode (#1218), TUI stops echoing permission-mode/thinking toggles to scrollback (#1219), upgrade check falls back to mirrors when resolving the latest version (#1216).

## Test plan
- [x] `go build ./...`