### PR TITLE
fix(tools): make edit_file matching more robust against LLM copy errors

### DIFF
--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -16,10 +16,10 @@ type EditFileTool struct{}
 
 // curly quote constants for normalization
 const (
-	leftSingleCurlyQuote  = '\u2018' // '
-	rightSingleCurlyQuote = '\u2019' // '
-	leftDoubleCurlyQuote  = '\u201c' // "
-	rightDoubleCurlyQuote = '\u201d' // "
+	leftSingleCurlyQuote  = '‘' // '
+	rightSingleCurlyQuote = '’' // '
+	leftDoubleCurlyQuote  = '“' // "
+	rightDoubleCurlyQuote = '”' // "
 )
 
 func (EditFileTool) Definition() agent.ToolDefinition {
@@ -27,6 +27,9 @@ func (EditFileTool) Definition() agent.ToolDefinition {
 		Name: "edit_file",
 		Description: "Replace an exact substring in an existing file. " +
 			"You MUST read the file with read_file before calling this tool. " +
+			"old_string must be the file's raw content — never include the line-number " +
+			"column (e.g. \"     3\\t\") that read_file prepends for display; that prefix " +
+			"is not part of the file and will cause a not-found error. " +
 			"old_string must appear exactly once (or set replace_all=true to swap every occurrence). " +
 			"The file must already exist — use write_file to create. " +
 			"Include enough surrounding context in old_string (typically 2-4 lines) " +
@@ -100,14 +103,28 @@ func stripTrailingWhitespace(s string) string {
 var indentWidths = []int{4, 8, 2}
 
 // findActualString attempts to locate the search string in the file content,
-// first with an exact match, then with quote-normalized match, and finally
-// with leading-whitespace normalization (tab → space expansion at several
-// widths) so that space-indented old_string from the LLM still matches
-// tab-indented files. Returns the actual string found in the file (preserving
-// original formatting) and the tab width that matched — 4, the default indent
-// unit, unless a wider/narrower expansion was what matched. Empty string means
-// not found.
+// first with the fallback chain in findActualStringCore (exact, quote
+// normalization, indent normalization, trailing-whitespace normalization),
+// and — only if the caller's search string looks like it was copied straight
+// out of read_file's "NNNNNN\t" line-number column — retries the whole chain
+// with that column stripped. Returns the actual string found in the file
+// (preserving original formatting) and the tab width that matched — 4, the
+// default indent unit, unless a wider/narrower expansion was what matched.
+// Empty string means not found.
 func findActualString(fileContent, searchString string) (string, int) {
+	if actual, w := findActualStringCore(fileContent, searchString); actual != "" {
+		return actual, w
+	}
+	if looksLikeLineNumberPrefixed(searchString) {
+		return findActualStringCore(fileContent, stripLineNumberPrefixes(searchString))
+	}
+	return "", 0
+}
+
+// findActualStringCore is the exact/quote/indent/trailing-whitespace fallback
+// chain. See findActualString for the line-number-prefix retry wrapped
+// around it.
+func findActualStringCore(fileContent, searchString string) (string, int) {
 	// First try exact match
 	if strings.Contains(fileContent, searchString) {
 		return searchString, defaultIndentWidth
@@ -170,14 +187,18 @@ func findActualString(fileContent, searchString string) (string, int) {
 	}
 
 	// Try with normalized leading whitespace (tab → space expansion).
-	// This is line-based because indentation differences only affect
-	// leading whitespace, and the matching needs to map lines back
-	// to the original file. Several widths are tried because the width the
-	// model assumed when it turned tabs into spaces is unknowable.
+	// Several widths are tried because the width the model assumed when it
+	// turned tabs into spaces is unknowable.
 	for _, w := range indentWidths {
 		if actual := findWithIndentNorm(fileContent, searchString, w); actual != "" {
 			return actual, w
 		}
+	}
+
+	// Try ignoring trailing whitespace per line — a model that visually
+	// copied a line rarely reproduces trailing spaces it can't see.
+	if actual := findWithTrailingWSNorm(fileContent, searchString); actual != "" {
+		return actual, defaultIndentWidth
 	}
 
 	return "", 0
@@ -210,11 +231,25 @@ func normalizeLeadingWhitespace(s string, width int) string {
 	return b.String()
 }
 
-// findWithIndentNorm matches searchString against fileContent after
-// normalizing leading whitespace in both at the given tab width. Returns the
-// corresponding substring from the original (unnormalized) fileContent so the
-// edit preserves the file's actual whitespace convention.
-func findWithIndentNorm(fileContent, searchString string, width int) string {
+// normalizeTrailingWhitespace strips trailing spaces/tabs/CR from every line.
+// Used to make a match tolerant of trailing whitespace on the file's side
+// that a model copying text by eye wouldn't have reproduced in old_string.
+func normalizeTrailingWhitespace(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t\r")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// findWithLineNorm matches searchString against fileContent after applying
+// normalize to both, and returns the corresponding substring from the
+// original (unnormalized) fileContent so the edit preserves the file's
+// actual formatting. The matching is line-based because both whitespace
+// normalizations in use here (leading-indent and trailing-whitespace) only
+// affect per-line content, and results need to map back to whole lines in
+// the original file.
+func findWithLineNorm(fileContent, searchString string, normalize func(string) string) string {
 	// The matching is line-based, so a trailing newline on the search string
 	// would otherwise become an empty last line that must equal the file's
 	// next line. Strip it for matching and restore it from the file after.
@@ -224,8 +259,8 @@ func findWithIndentNorm(fileContent, searchString string, width int) string {
 		search = strings.TrimSuffix(search, "\n")
 	}
 
-	normFile := normalizeLeadingWhitespace(fileContent, width)
-	normSearch := normalizeLeadingWhitespace(search, width)
+	normFile := normalize(fileContent)
+	normSearch := normalize(search)
 
 	if !strings.Contains(normFile, normSearch) {
 		return ""
@@ -270,6 +305,128 @@ func findWithIndentNorm(fileContent, searchString string, width int) string {
 	return actual
 }
 
+// findWithIndentNorm matches searchString against fileContent after
+// normalizing leading whitespace in both at the given tab width, so that
+// space-indented old_string from the LLM still matches tab-indented files.
+func findWithIndentNorm(fileContent, searchString string, width int) string {
+	return findWithLineNorm(fileContent, searchString, func(s string) string {
+		return normalizeLeadingWhitespace(s, width)
+	})
+}
+
+// findWithTrailingWSNorm matches searchString against fileContent ignoring
+// trailing whitespace differences per line.
+func findWithTrailingWSNorm(fileContent, searchString string) string {
+	return findWithLineNorm(fileContent, searchString, normalizeTrailingWhitespace)
+}
+
+// isAllDigits reports whether s is non-empty and every rune is 0-9.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// looksLikeLineNumberPrefixed reports whether every non-empty line of s
+// starts with a "digits + tab" prefix — the cat-n-style column read_file
+// prepends to every line for display (see ReadFileTool). A model that
+// pastes read_file's output straight into old_string instead of the file's
+// raw bytes produces exactly this shape; a real source or data file is very
+// unlikely to have every single line begin with bare digits then a tab.
+func looksLikeLineNumberPrefixed(s string) bool {
+	lines := strings.Split(s, "\n")
+	seenAny := false
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		tabIdx := strings.IndexByte(line, '\t')
+		if tabIdx <= 0 {
+			return false
+		}
+		if !isAllDigits(strings.TrimSpace(line[:tabIdx])) {
+			return false
+		}
+		seenAny = true
+	}
+	return seenAny
+}
+
+// stripLineNumberPrefixes removes a leading "digits + tab" column from every
+// line of s. Only call this once looksLikeLineNumberPrefixed has confirmed
+// the shape — it unconditionally cuts at the first tab on lines that have one.
+func stripLineNumberPrefixes(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if tabIdx := strings.IndexByte(line, '\t'); tabIdx > 0 {
+			lines[i] = line[tabIdx+1:]
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// normalizeCRLF collapses "\r\n" to "\n" so old_string — which is always LF,
+// since read_file's bufio.Scanner strips "\r" before the model ever sees a
+// line — can match a CRLF file. starts records, for every byte of norm, the
+// offset in body it came from; starts[len(norm)] == len(body). Any norm
+// range [a,b) therefore maps back to the original byte range
+// [starts[a], starts[b]), which Execute uses to splice the replacement
+// directly into the untouched original bytes instead of rewriting the whole
+// file through a global LF<->CRLF round trip — the latter used to flip the
+// line ending of every "\n" in the file just because *some* other line used
+// "\r\n" (see the edit_file audit's Bug 1: a mixed-line-ending file had
+// unrelated lines silently rewritten by every edit).
+func normalizeCRLF(body string) (norm string, starts []int) {
+	var b strings.Builder
+	b.Grow(len(body))
+	starts = make([]int, 0, len(body)+1)
+	i := 0
+	for i < len(body) {
+		starts = append(starts, i)
+		if body[i] == '\r' && i+1 < len(body) && body[i+1] == '\n' {
+			b.WriteByte('\n')
+			i += 2
+		} else {
+			b.WriteByte(body[i])
+			i++
+		}
+	}
+	starts = append(starts, len(body))
+	return b.String(), starts
+}
+
+// lineEndingAt reports the line-ending convention ("\n" or "\r\n") to apply
+// to any newline inside a replacement spliced into body at [origStart,
+// origEnd). It prefers the convention of the span being replaced, falling
+// back to the nearest neighboring line break, so only the edited region's
+// own convention is ever touched — never the rest of a mixed-line-ending
+// file.
+func lineEndingAt(body string, origStart, origEnd int) string {
+	if strings.Contains(body[origStart:origEnd], "\r\n") {
+		return "\r\n"
+	}
+	if idx := strings.IndexByte(body[origEnd:], '\n'); idx != -1 {
+		abs := origEnd + idx
+		if abs > 0 && body[abs-1] == '\r' {
+			return "\r\n"
+		}
+		return "\n"
+	}
+	if idx := strings.LastIndexByte(body[:origStart], '\n'); idx != -1 {
+		if idx > 0 && body[idx-1] == '\r' {
+			return "\r\n"
+		}
+		return "\n"
+	}
+	return "\n"
+}
+
 func (EditFileTool) Execute(ctx context.Context, _ string, input map[string]any) (agent.ToolResult, error) {
 	path, _ := input["path"].(string)
 	if strings.TrimSpace(path) == "" {
@@ -302,17 +459,11 @@ func (EditFileTool) Execute(ctx context.Context, _ string, input map[string]any)
 	}
 	body := string(data)
 
-	// CRLF handling: an LLM that read the file via read_file (which uses
-	// bufio.Scanner — strips `\r` from `\r\n` lines) and then copies a
-	// substring back into old_string would compare against `\n`-terminated
-	// lines, but the on-disk file may have `\r\n`. Match in normalized
-	// (LF) space; if the original was CRLF, restore on write so the file's
-	// line-ending convention isn't silently flipped.
-	hasCRLF := strings.Contains(body, "\r\n")
-	bodyForMatch := body
-	if hasCRLF {
-		bodyForMatch = strings.ReplaceAll(body, "\r\n", "\n")
-	}
+	// Match in \n-normalized space (see normalizeCRLF) while keeping starts[]
+	// to map any match back to the original bytes, so a mixed-line-ending
+	// file can be edited without flipping the ending of lines the edit never
+	// touched.
+	normBody, starts := normalizeCRLF(body)
 
 	// Strip trailing whitespace from new_string (except for markdown files
 	// where trailing double-space is a hard line break).
@@ -333,8 +484,9 @@ func (EditFileTool) Execute(ctx context.Context, _ string, input map[string]any)
 			"shape or create the file outside the agent.", secret)
 	}
 
-	// Use findActualString for quote- and indent-normalized matching.
-	actualOldStr, indentWidth := findActualString(bodyForMatch, oldStr)
+	// Use findActualString for quote-, indent-, and trailing-whitespace
+	// normalized matching, plus a line-number-prefix-stripped retry.
+	actualOldStr, indentWidth := findActualString(normBody, oldStr)
 	if actualOldStr == "" {
 		// Build a helpful error message showing what we tried
 		msg := fmt.Sprintf("edit_file: old_string not found in %s", path)
@@ -343,18 +495,42 @@ func (EditFileTool) Execute(ctx context.Context, _ string, input map[string]any)
 		if normalizeQuotes(oldStr) != oldStr {
 			msg += " (also tried with normalized quotes)"
 		}
+		if looksLikeLineNumberPrefixed(oldStr) {
+			msg += " (old_string looks like it includes read_file's line-number prefix — " +
+				"old_string must be the raw file content, without the \"NNNNNN\\t\" column " +
+				"read_file adds for display)"
+		}
 		return agent.ToolResult{Text: ""}, fmt.Errorf("%s", msg)
 	}
 
-	count := strings.Count(bodyForMatch, actualOldStr)
+	// Locate every occurrence's [start,end) in normBody up front: replace_all
+	// needs them all, and the "matches N times" error needs their line
+	// numbers so the caller can find the ambiguity without guessing.
+	var normRanges [][2]int
+	searchFrom := 0
+	for {
+		idx := strings.Index(normBody[searchFrom:], actualOldStr)
+		if idx == -1 {
+			break
+		}
+		start := searchFrom + idx
+		end := start + len(actualOldStr)
+		normRanges = append(normRanges, [2]int{start, end})
+		searchFrom = end
+	}
+	count := len(normRanges)
 	if count == 0 {
 		// Should not happen after findActualString succeeded, but be safe
 		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: old_string not found in %s", path)
 	}
 	if count > 1 && !replaceAll {
+		lineNos := make([]string, count)
+		for i, r := range normRanges {
+			lineNos[i] = fmt.Sprintf("%d", strings.Count(normBody[:r[0]], "\n")+1)
+		}
 		return agent.ToolResult{Text: ""}, fmt.Errorf(
-			"edit_file: old_string matches %d times — either include more context to make it unique, or set replace_all=true",
-			count,
+			"edit_file: old_string matches %d times (lines %s) — either include more context to make it unique, or set replace_all=true",
+			count, strings.Join(lineNos, ", "),
 		)
 	}
 
@@ -365,15 +541,24 @@ func (EditFileTool) Execute(ctx context.Context, _ string, input map[string]any)
 	// uses tabs but the LLM supplied space-indented new_string.
 	actualNewStr = preserveIndentStyle(actualOldStr, actualNewStr, indentWidth)
 
-	var updated string
-	if replaceAll {
-		updated = strings.ReplaceAll(bodyForMatch, actualOldStr, actualNewStr)
-	} else {
-		updated = strings.Replace(bodyForMatch, actualOldStr, actualNewStr, 1)
+	// Splice each occurrence directly into the original bytes, applying the
+	// line-ending convention local to that occurrence's own span — see
+	// lineEndingAt. Everything between occurrences (and before/after all of
+	// them) is copied through byte-for-byte from the original file.
+	var out strings.Builder
+	prevOrigEnd := 0
+	for _, r := range normRanges {
+		origStart, origEnd := starts[r[0]], starts[r[1]]
+		out.WriteString(body[prevOrigEnd:origStart])
+		repl := actualNewStr
+		if lineEndingAt(body, origStart, origEnd) == "\r\n" {
+			repl = strings.ReplaceAll(repl, "\n", "\r\n")
+		}
+		out.WriteString(repl)
+		prevOrigEnd = origEnd
 	}
-	if hasCRLF {
-		updated = strings.ReplaceAll(updated, "\n", "\r\n")
-	}
+	out.WriteString(body[prevOrigEnd:])
+	updated := out.String()
 
 	if err := os.WriteFile(abs, []byte(updated), 0o644); err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: write %q: %w", path, err)
@@ -448,7 +633,7 @@ func isOpeningContext(chars []rune, index int) bool {
 	prev := chars[index-1]
 	return prev == ' ' || prev == '\t' || prev == '\n' || prev == '\r' ||
 		prev == '(' || prev == '[' || prev == '{' ||
-		prev == '\u2014' || prev == '\u2013'
+		prev == '—' || prev == '–'
 }
 
 func applyCurlyDoubleQuotes(str string) string {

--- a/internal/tools/edit_file_test.go
+++ b/internal/tools/edit_file_test.go
@@ -541,3 +541,141 @@ func TestPreserveIndentStyle_LeavesTabLinesAlone(t *testing.T) {
 		t.Errorf("preserveIndentStyle = %q, want unchanged %q", got, in)
 	}
 }
+
+func TestEditFile_MixedLineEndings_UntouchedLinesPreserved(t *testing.T) {
+	// A file with some CRLF lines and some LF lines must not have its
+	// untouched lines' endings flipped by an edit elsewhere in the file —
+	// only the line(s) actually being replaced may change convention.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mixed.txt")
+	writeTestFile(t, path, "line one\r\nline two\nline three\r\n")
+
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       path,
+		"old_string": "line one",
+		"new_string": "LINE ONE",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := readTestFile(t, path)
+	want := "LINE ONE\r\nline two\nline three\r\n"
+	if got != want {
+		t.Errorf("file = %q, want %q (an untouched line's ending was flipped)", got, want)
+	}
+}
+
+func TestEditFile_MixedLineEndings_EditingLFLineStaysLF(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mixed.txt")
+	writeTestFile(t, path, "line one\r\nline two\nline three\r\n")
+
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       path,
+		"old_string": "line two",
+		"new_string": "LINE TWO",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := readTestFile(t, path)
+	want := "line one\r\nLINE TWO\nline three\r\n"
+	if got != want {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+}
+
+func TestEditFile_TrailingWhitespace_OldStringFallbackMatch(t *testing.T) {
+	// The file has a real trailing space the model wouldn't have seen when
+	// copying the line by eye; old_string omits it. Must still match.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "code.go")
+	writeTestFile(t, path, "func main() { \n\tprintln(\"hi\")\n}\n")
+
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       path,
+		"old_string": "func main() {\n\tprintln(\"hi\")\n}",
+		"new_string": "func main() {\n\tprintln(\"bye\")\n}",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := readTestFile(t, path)
+	// The matched line (including its trailing space) is entirely replaced —
+	// new_string doesn't have a trailing space, so the result doesn't either.
+	// What matters here is that the match succeeded at all.
+	want := "func main() {\n\tprintln(\"bye\")\n}\n"
+	if got != want {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+}
+
+func TestEditFile_LineNumberPrefix_StrippedAndMatched(t *testing.T) {
+	// A model that pasted read_file's cat-n output straight into old_string
+	// (line-number + tab prefix on every line) must still succeed.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "code.go")
+	writeTestFile(t, path, "package main\n\nfunc main() {}\n")
+
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       path,
+		"old_string": "     3\tfunc main() {}",
+		"new_string": "func main() { println(\"hi\") }",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := readTestFile(t, path)
+	want := "package main\n\nfunc main() { println(\"hi\") }\n"
+	if got != want {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+}
+
+func TestEditFile_LineNumberPrefix_NotFoundHintsAtCause(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "code.go")
+	writeTestFile(t, path, "package main\n")
+
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       path,
+		"old_string": "     1\tnonexistent line",
+		"new_string": "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "line-number prefix") {
+		t.Errorf("expected error hinting at line-number prefix, got %v", err)
+	}
+}
+
+func TestLooksLikeLineNumberPrefixed(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"     3\tfunc main() {}", true},
+		{"1\tfoo\n2\tbar", true},
+		{"foo\tbar", false},            // non-digit before tab
+		{"func main() {}", false},      // no tab at all
+		{"1\tfoo\nno tab here", false}, // mixed: one line lacks the prefix
+	}
+	for _, tc := range tests {
+		if got := looksLikeLineNumberPrefixed(tc.in); got != tc.want {
+			t.Errorf("looksLikeLineNumberPrefixed(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestEditFile_NonUnique_ErrorIncludesLineNumbers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "many.txt")
+	writeTestFile(t, path, "foo\nfoo\nbar\n")
+
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       path,
+		"old_string": "foo",
+		"new_string": "baz",
+	})
+	if err == nil || !strings.Contains(err.Error(), "lines 1, 2") {
+		t.Errorf("expected error to include matched line numbers, got %v", err)
+	}
+}

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -50,6 +50,8 @@ func (ReadFileTool) Definition() agent.ToolDefinition {
 		Name: "read_file",
 		Description: "Read a UTF-8 text file and return its content with cat-n-style " +
 			"line numbers. Up to 2000 lines per call — use offset/limit to paginate. " +
+			"The line-number column is for your reference only — it is not part of the " +
+			"file, so never copy it into edit_file's old_string. " +
 			"When the response includes '[end of file: N lines total]' the entire file " +
 			"has been read; do not call read_file again for the same path. " +
 			"Absolute paths are preferred; relative paths resolve against the current " +


### PR DESCRIPTION
## Summary
- Splice replacements directly into the original bytes instead of a global LF↔CRLF round trip, so a mixed-line-ending file no longer has unrelated lines' endings flipped by an unrelated edit (previously any file containing even one `\r\n` line would have every `\n` line coerced to `\r\n` on write).
- Add a trailing-whitespace-normalized fallback match: `old_string` missing a real trailing space/tab present in the file (invisible when a model copies a line by eye) now still matches instead of failing with "not found".
- Detect `old_string` that was pasted straight from `read_file`'s `cat -n`-style line-number column and retry the match with it stripped; the tool descriptions for both `read_file` and `edit_file` now explicitly warn against including that column, and the not-found error hints at the cause when stripping still doesn't help.
- The "old_string matches N times" error now lists the matched line numbers, so a non-unique match can be disambiguated without guessing.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./internal/tools/...` — all edit_file/read_file tests pass, including new regression tests for mixed line endings, trailing-whitespace fallback, and line-number-prefix stripping