### PR TITLE
chore: bump version to 1.8.5

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.8.4"
+var Version = "1.8.5"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Patch release: two fixes landed since v1.8.4 (#1222 edit_file matching robustness, #1224 ask_user_question empty-options guard), no features — bumping patch per semver.

## Test plan
- [x] `make fmt-check` / build unaffected (version string only)