### PR TITLE
feat(pkg/octoagent): export DefaultToolsForCtx and the hooks engine

### DIFF
--- a/dev-docs/octoagent-pkg-design.md
+++ b/dev-docs/octoagent-pkg-design.md
@@ -150,7 +150,11 @@ pkg/octoagent/
 ├── provider/
 │   └── provider.go  // alias app.SenderOptions / app.NewSender
 ├── toolenv/
-│   └── toolenv.go   // 包一层从 internal/server 抽出来的并发安全 wiring 函数
+│   └── toolenv.go   // 包一层从 internal/server 抽出来的并发安全 wiring 函数,
+│                    // 以及 DefaultToolsForCtx/NewDefaultRegistry 的转发
+├── hooks/
+│   └── hooks.go     // alias internal/hooks 的 Engine/Meta/Payload/InProcHook/
+│                    // ToolDecision/SeenSet + 构造函数 + Event 常量
 └── approval/
     └── approval.go  // 可选的 GateFunc 便捷适配器(见下)
 ```
@@ -272,9 +276,18 @@ Director 想在自己代码里声明一个 `h *agent.History` 字段或函数签
 一并 alias 出去。
 
 `Agent.Hooks`/`Agent.HookMeta` 字段的类型来自 `internal/hooks` 包(`hooks.Engine`/`hooks.Meta`),
-不在 `internal/agent` 下——如果 Director 需要按类型引用它们,还要再给 `internal/hooks` 开一层
-alias(`pkg/octoagent/hooks`)。Sinew Director 目前的设计不需要直接操作 hook 引擎,这里先记为
-"用到再加",不在本轮改动范围内。
+不在 `internal/agent` 下——`pkg/octoagent/hooks` alias 了这一层(`Engine`/`Meta`/`Payload`/
+`InProcHook`/`ToolDecision`/`SeenSet` + `NewEngine`/`NewSeenSet` + 全部 7 个 Event 常量),外部可以
+用纯 Go 代码注册 hook(`RegisterInProc`/`RegisterShell`/`RegisterShellMatched`),不需要
+`~/.octo/hooks.yml`。CLI/server 专属的 `EngineFromEnvAndFiles`(读本地文件)不在 alias 范围内。
+
+导出这一层时发现 `internal/hooks.Engine.PreToolUse` 原本只认 shell hook 的退出码/结构化 stdout
+协议,`RegisterInProc` 注册的 PreToolUse 回调会被 `Configured()` 认为"已配置"但从不参与
+block/allow 判断——这是刻意的设计(注释原话:"PreToolUse is a shell-configured guard"),但会让
+"用纯 Go 回调做工具拦截"这个最直接的外部消费场景表现得像"配置了但不生效"。已改成
+in-process hook 也能通过返回同样的 `{"decision":"block"/"approve",...}` JSON 字符串参与判断,
+求值顺序是 in-process 先、shell 后,block 全局优先于 allow(`internal/hooks/engine.go`
+的 `PreToolUse` 方法 + `pretooluse_test.go` 的对应测试)。
 
 **`Session`/`History` 内嵌 `sync.Mutex`/`sync.RWMutex`(`internal/agent/session.go:77`、
 `internal/agent/history.go:14`),不可按值复制**——`type Session = agent.Session` 这个别名本身没
@@ -526,11 +539,12 @@ Director 侧用法：`agent.Gate = approval.GateFunc(func(ctx, name, input) (boo
 
 ## 非目标
 
-- 不导出 `internal/hooks.Engine`/`hooks.Meta` 等 hook 机制相关类型——`Agent.Hooks`/`Agent.HookMeta` 是
-  导出字段,但它们的类型来自 `internal/hooks`,本轮不为其开 `pkg/octoagent/hooks`。Sinew Director 当前
-  设计不需要直接操作 hook 引擎,外部调用者应留空这两个字段;如需 hook 机制,单独立项设计。
-- 不导出 `internal/app.Spawner`/`internal/tools.SubAgentManager`——Director 用
-  `disallowed_tools: [sub_agent]` 从工具列表里过滤掉，不需要 octo 的原生 sub-agent 机制。
+- 不导出 `internal/app.Spawner`/`internal/tools.SubAgentManager` 类型本身(外部还不能直接
+  `Start`/`Kill`/`ListRunning` 某个 sub-agent)——`pkg/octoagent/toolenv.WireForSession` 已经把
+  `SubAgentManager` wire 进 ctx,`toolenv.DefaultToolsForCtx` 也已导出,模型可以正常调用
+  `sub_agent`/`sub_agent_send` 等工具;Director 目前只需要"模型自己调用 sub-agent 工具"这一层,
+  不需要在自己代码里直接操纵生命周期,不想要的话用 `disallowed_tools: [sub_agent]` 从工具列表里
+  过滤掉即可。
 - 不给 `internal/permission.Engine` 加新构造函数——`PermissionGate` 是单方法接口，外部实现即可
   （见"现状盘点"第 4 点，这是本次规划过程中修正掉的一项高估）。
 - 不做 browser 工具、workflow-discovery-cwd 的并发安全改造——记在"已知限制"，留给真正需要它们的

--- a/dev-docs/octoagent-pkg-design.md
+++ b/dev-docs/octoagent-pkg-design.md
@@ -289,6 +289,13 @@ in-process hook 也能通过返回同样的 `{"decision":"block"/"approve",...}`
 求值顺序是 in-process 先、shell 后,block 全局优先于 allow(`internal/hooks/engine.go`
 的 `PreToolUse` 方法 + `pretooluse_test.go` 的对应测试)。
 
+这条改动让 `EventPreToolUse` 的 in-process 回调第一次变得真正可达——之前注册了也不会被调用,
+所以回调 panic 从来没有实际后果。shell hook 崩溃只会杀掉子进程,不影响宿主 Go 进程;in-process
+回调跟 agent 循环跑在同一个 goroutine 里,panic 会直接冒泡打断整个 turn。`PreToolUse`
+调用每个 in-process 回调时都包了一层 `recover`(`runInProcHookSafely`),panic 按"非阻塞失败"
+处理(notify + 视为无意见,后续回调正常继续跑,不会被跳过)。`Inject`/`Dispatch` 里调用
+in-process 回调的地方还没有同样的 recover——那是既有代码,本轮不动,留作后续。
+
 **`Session`/`History` 内嵌 `sync.Mutex`/`sync.RWMutex`(`internal/agent/session.go:77`、
 `internal/agent/history.go:14`),不可按值复制**——`type Session = agent.Session` 这个别名本身没
 问题,但要在这个类型定义旁边补一行 doc comment 提醒外部调用者"始终用指针,不要按值传递/复制",否则

--- a/examples/octoagent-minimal/main.go
+++ b/examples/octoagent-minimal/main.go
@@ -46,11 +46,18 @@ func main() {
 	ctx, executor, cleanup := toolenv.WireForSession(ctx, a, sessionID)
 	defer cleanup()
 
-	// 5. Decide which tools to advertise. For this minimal example we pass nil,
-	//    which makes RunStream equivalent to a single-turn chat. A real program
-	//    would call tools.DefaultToolsForCtx(ctx, a.Model) and filter out tools
-	//    it does not want (e.g. sub_agent).
-	var tools []octoagent.ToolDefinition
+	// 5. Decide which tools to advertise. DefaultToolsForCtx reads the
+	//    ctx-scoped managers WireForSession just stamped in — pass the ctx it
+	//    returned, not the original. A caller that doesn't want octo's native
+	//    sub-agent orchestration (e.g. it filters via its own
+	//    disallowed_tools: [sub_agent] convention) drops that one entry here.
+	toolDefs := make([]octoagent.ToolDefinition, 0)
+	for _, td := range toolenv.DefaultToolsForCtx(ctx, a.Model) {
+		if td.Name == "sub_agent" {
+			continue
+		}
+		toolDefs = append(toolDefs, td)
+	}
 
 	// 6. Run a streaming turn.
 	handler := func(ev octoagent.AgentEvent) {
@@ -62,7 +69,7 @@ func main() {
 		}
 	}
 
-	reply, err := a.RunStream(ctx, "Hello!", tools, executor, handler)
+	reply, err := a.RunStream(ctx, "Hello!", toolDefs, executor, handler)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/agent/hookgate_test.go
+++ b/internal/agent/hookgate_test.go
@@ -95,6 +95,46 @@ func TestHookGate_NoOpinionNoInnerAllows(t *testing.T) {
 	}
 }
 
+func preToolAgentInProc(t *testing.T, fn hooks.InProcHook, inner PermissionGate) *Agent {
+	t.Helper()
+	a := New(&fakeSender{}, "m")
+	a.Gate = inner
+	a.Hooks = hooks.NewEngine(nil)
+	a.Hooks.RegisterInProc(hooks.EventPreToolUse, fn)
+	return a
+}
+
+func TestHookGate_InProcBlockDeniesWithoutInner(t *testing.T) {
+	inner := &recordingGate{allow: true}
+	a := preToolAgentInProc(t, func(_ context.Context, _ hooks.Payload) string {
+		return `{"decision":"block","reason":"in-proc policy denies"}`
+	}, inner)
+	allowed, reason := a.effectiveGate().Check(context.Background(), "terminal", nil)
+	if allowed {
+		t.Error("in-process PreToolUse block must deny")
+	}
+	if reason != "in-proc policy denies" {
+		t.Errorf("reason = %q, want %q", reason, "in-proc policy denies")
+	}
+	if inner.called {
+		t.Error("a blocked call must not reach the inner gate")
+	}
+}
+
+func TestHookGate_InProcApproveBypassesInner(t *testing.T) {
+	inner := &recordingGate{allow: false, reason: "gate would deny"}
+	a := preToolAgentInProc(t, func(_ context.Context, _ hooks.Payload) string {
+		return `{"decision":"approve"}`
+	}, inner)
+	allowed, _ := a.effectiveGate().Check(context.Background(), "terminal", nil)
+	if !allowed {
+		t.Error("in-process PreToolUse approve must allow, bypassing a denying inner gate")
+	}
+	if inner.called {
+		t.Error("approve must bypass the inner gate entirely")
+	}
+}
+
 func TestEffectiveGate_NoHookReturnsBareGate(t *testing.T) {
 	inner := &recordingGate{allow: true}
 	a := New(&fakeSender{}, "m")

--- a/internal/hooks/engine.go
+++ b/internal/hooks/engine.go
@@ -335,31 +335,54 @@ type toolDecisionOut struct {
 	Reason   string `json:"reason,omitempty"`
 }
 
-// PreToolUse runs the PreToolUse shell hooks for a tool call and returns the
-// aggregated verdict. Protocol per hook, matching Claude Code's:
+// PreToolUse runs the PreToolUse hooks for a tool call and returns the
+// aggregated verdict. In-process hooks run first (registration order), then
+// shell hooks (registration order) — same ordering as Inject. Protocol per
+// shell hook, matching Claude Code's:
 //   - exit 2                     → block (reason = structured reason, else stderr)
 //   - exit 0 + {"decision":...}  → that decision (block / approve)
 //   - exit 0, no decision        → no opinion (defer to the gate)
 //   - timeout / other exit       → non-blocking error (notify, tool proceeds)
 //
+// An in-process hook has no exit code, so it opts into a decision the same
+// way a shell hook's stdout does: return `{"decision":"block","reason":"..."}`
+// or `{"decision":"approve"}` as its string result. Any other return value
+// (including "") is no opinion for that hook.
+//
 // Block wins over Allow: the first hook that blocks short-circuits, and an
 // Allow never overrides a later Block. A tool the caller then runs unless
-// blocked; an Allow tells the caller to bypass the interactive gate. In-process
-// hooks are not consulted here — PreToolUse is a shell-configured guard.
+// blocked; an Allow tells the caller to bypass the interactive gate.
 func (e *Engine) PreToolUse(ctx context.Context, p Payload) ToolDecision {
 	if e == nil {
 		return ToolDecision{}
 	}
-	sh, _ := e.hooksFor(EventPreToolUse)
-	if len(sh) == 0 {
+	sh, ip := e.hooksFor(EventPreToolUse)
+	if len(sh) == 0 && len(ip) == 0 {
 		return ToolDecision{}
 	}
+
+	allow := false
+	for _, fn := range ip {
+		d, ok := parseToolDecision([]byte(fn(ctx, p)))
+		if !ok {
+			continue
+		}
+		switch d.Decision {
+		case "block":
+			return ToolDecision{Block: true, Reason: firstNonEmpty(strings.TrimSpace(d.Reason), "blocked by PreToolUse hook")}
+		case "approve":
+			allow = true
+		}
+	}
+	if len(sh) == 0 {
+		return ToolDecision{Allow: allow}
+	}
+
 	stdin, err := json.Marshal(p)
 	if err != nil {
 		e.notify("hooks: marshal PreToolUse payload: " + err.Error())
-		return ToolDecision{}
+		return ToolDecision{Allow: allow}
 	}
-	allow := false
 	for _, h := range sh {
 		if !h.matches(EventPreToolUse, p.ToolName) {
 			continue

--- a/internal/hooks/engine.go
+++ b/internal/hooks/engine.go
@@ -363,7 +363,7 @@ func (e *Engine) PreToolUse(ctx context.Context, p Payload) ToolDecision {
 
 	allow := false
 	for _, fn := range ip {
-		d, ok := parseToolDecision([]byte(fn(ctx, p)))
+		d, ok := parseToolDecision([]byte(e.runInProcHookSafely(fn, ctx, p)))
 		if !ok {
 			continue
 		}
@@ -407,6 +407,23 @@ func (e *Engine) PreToolUse(ctx context.Context, p Payload) ToolDecision {
 		}
 	}
 	return ToolDecision{Allow: allow}
+}
+
+// runInProcHookSafely calls an in-process PreToolUse hook with a recover, so a
+// panicking callback can't take the whole agent turn down with it. A shell
+// hook's failure mode is a subprocess crash, which the parent Go process
+// never sees; an in-process hook runs in the same goroutine, so without this
+// its panic would propagate straight out of PreToolUse. Treated the same as
+// any other non-blocking hook failure: notify and return "" (no opinion, tool
+// allowed to proceed).
+func (e *Engine) runInProcHookSafely(fn InProcHook, ctx context.Context, p Payload) (out string) {
+	defer func() {
+		if r := recover(); r != nil {
+			e.notify(fmt.Sprintf("hooks: PreToolUse in-process hook panicked: %v (tool allowed to proceed)", r))
+			out = ""
+		}
+	}()
+	return fn(ctx, p)
 }
 
 // blockReason picks the denial text for an exit-2 (or decision:block) hook:

--- a/internal/hooks/pretooluse_test.go
+++ b/internal/hooks/pretooluse_test.go
@@ -95,3 +95,64 @@ func TestPreToolUse_NoHooksNoOpinion(t *testing.T) {
 		t.Errorf("unconfigured PreToolUse must be no-opinion, got %+v", dec)
 	}
 }
+
+func TestPreToolUse_InProcBlocks(t *testing.T) {
+	e := NewEngine(nil)
+	e.RegisterInProc(EventPreToolUse, func(_ context.Context, p Payload) string {
+		return `{"decision":"block","reason":"policy X"}`
+	})
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if !dec.Block || dec.Reason != "policy X" {
+		t.Errorf("in-process block decision should carry reason, got %+v", dec)
+	}
+}
+
+func TestPreToolUse_InProcApprove(t *testing.T) {
+	e := NewEngine(nil)
+	e.RegisterInProc(EventPreToolUse, func(_ context.Context, p Payload) string {
+		return `{"decision":"approve"}`
+	})
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if !dec.Allow || dec.Block {
+		t.Errorf("in-process approve decision should allow, got %+v", dec)
+	}
+}
+
+func TestPreToolUse_InProcNonDecisionIsNoOpinion(t *testing.T) {
+	e := NewEngine(nil)
+	e.RegisterInProc(EventPreToolUse, func(_ context.Context, p Payload) string {
+		return "not a decision"
+	})
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if dec.Block || dec.Allow {
+		t.Errorf("a plain string return should be no-opinion, got %+v", dec)
+	}
+}
+
+func TestPreToolUse_InProcBlockWinsOverShellApprove(t *testing.T) {
+	e := NewEngine(nil)
+	e.RegisterInProc(EventPreToolUse, func(_ context.Context, p Payload) string {
+		return `{"decision":"block","reason":"in-proc says no"}`
+	})
+	if err := e.RegisterShellMatched(EventPreToolUse, makeScript(t, `echo '{"decision":"approve"}'`), "", false, 0); err != nil {
+		t.Fatal(err)
+	}
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if !dec.Block || dec.Reason != "in-proc says no" {
+		t.Errorf("in-process block (evaluated first) must win over a later shell approve, got %+v", dec)
+	}
+}
+
+func TestPreToolUse_ShellBlockWinsOverInProcApprove(t *testing.T) {
+	e := NewEngine(nil)
+	e.RegisterInProc(EventPreToolUse, func(_ context.Context, p Payload) string {
+		return `{"decision":"approve"}`
+	})
+	if err := e.RegisterShellMatched(EventPreToolUse, makeScript(t, "exit 2"), "", false, 0); err != nil {
+		t.Fatal(err)
+	}
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if !dec.Block {
+		t.Errorf("a later shell block must override an earlier in-process approve, got %+v", dec)
+	}
+}

--- a/internal/hooks/pretooluse_test.go
+++ b/internal/hooks/pretooluse_test.go
@@ -2,6 +2,8 @@ package hooks
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -140,6 +142,59 @@ func TestPreToolUse_InProcBlockWinsOverShellApprove(t *testing.T) {
 	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
 	if !dec.Block || dec.Reason != "in-proc says no" {
 		t.Errorf("in-process block (evaluated first) must win over a later shell approve, got %+v", dec)
+	}
+}
+
+func TestPreToolUse_InProcBlockShortCircuitsShell(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "shell-ran")
+
+	e := NewEngine(nil)
+	e.RegisterInProc(EventPreToolUse, func(_ context.Context, p Payload) string {
+		return `{"decision":"block","reason":"in-proc says no"}`
+	})
+	if err := e.RegisterShellMatched(EventPreToolUse, makeScript(t, "touch "+marker), "", false, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if !dec.Block {
+		t.Fatalf("expected block, got %+v", dec)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Error("shell hook ran despite an earlier in-process block — PreToolUse should short-circuit")
+	}
+}
+
+func TestPreToolUse_InProcPanicIsNoOpinionNotCrash(t *testing.T) {
+	var notices []string
+	e := NewEngine(nil)
+	e.Notify = func(msg string) { notices = append(notices, msg) }
+	e.RegisterInProc(EventPreToolUse, func(_ context.Context, p Payload) string {
+		panic("boom")
+	})
+
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if dec.Block || dec.Allow {
+		t.Errorf("a panicking hook should be no-opinion (tool allowed to proceed), got %+v", dec)
+	}
+	if len(notices) == 0 {
+		t.Error("a panicking in-process hook should surface via Notify")
+	}
+}
+
+func TestPreToolUse_InProcPanicDoesNotSkipLaterHooks(t *testing.T) {
+	e := NewEngine(nil)
+	e.RegisterInProc(EventPreToolUse, func(_ context.Context, p Payload) string {
+		panic("boom")
+	})
+	e.RegisterInProc(EventPreToolUse, func(_ context.Context, p Payload) string {
+		return `{"decision":"block","reason":"second hook still runs"}`
+	})
+
+	dec := e.PreToolUse(context.Background(), Payload{Event: EventPreToolUse, ToolName: "terminal"})
+	if !dec.Block || dec.Reason != "second hook still runs" {
+		t.Errorf("a panic in one hook must not prevent later hooks from running, got %+v", dec)
 	}
 }
 

--- a/pkg/octoagent/hooks/hooks.go
+++ b/pkg/octoagent/hooks/hooks.go
@@ -1,0 +1,84 @@
+// Package hooks aliases octo-agent's lifecycle hook engine so external
+// consumers of pkg/octoagent can configure Agent.Hooks without importing
+// internal packages.
+//
+// Engine construction here is programmatic only: NewEngine takes no local
+// files or environment variables, matching the "zero ambient dependency" bar
+// set by provider.NewSender and toolenv.WireForSession. The CLI/server-only
+// constructor that reads ~/.octo/hooks.yml (internal/hooks.EngineFromEnvAndFiles)
+// is intentionally not aliased — external consumers register hooks in code via
+// RegisterInProc/RegisterShell/RegisterShellMatched instead.
+package hooks
+
+import "github.com/open-octo/octo-agent/internal/hooks"
+
+// Engine dispatches lifecycle hooks (shell commands and in-process callbacks)
+// at the events an Agent fires during its loop. Set Agent.Hooks to a
+// configured *Engine and Agent.HookMeta to identify the session; the agent
+// loop invokes it automatically, including gating tool calls via a
+// PreToolUse hook's Block/Allow verdict — callers never call into Engine
+// directly from outside a hook.
+type Engine = hooks.Engine
+
+// Meta is the per-session identity folded into every hook Payload's common
+// envelope (SessionID, Transport, TranscriptPath, Cwd, Model). Set
+// Agent.HookMeta before running turns.
+type Meta = hooks.Meta
+
+// Event names one of the seven points in the agent loop a hook can attach to.
+type Event = hooks.Event
+
+// Payload is the data passed to a hook at Event time — the common envelope
+// from Meta plus event-specific fields (ToolName/ToolInput for
+// PreToolUse/PostToolUse, UserInput for UserPromptSubmit, etc).
+type Payload = hooks.Payload
+
+// InProcHook is an in-process hook callback: it receives the event payload
+// and returns a string. For every event except EventPreToolUse, a non-empty
+// return value is folded into the transcript the same way a shell hook's
+// stdout would be. For EventPreToolUse the return value is instead read as a
+// decision — see EventPreToolUse.
+type InProcHook = hooks.InProcHook
+
+// ToolDecision is a PreToolUse verdict for a single tool call. At most one of
+// Block/Allow is set; both false defers to the permission gate.
+type ToolDecision = hooks.ToolDecision
+
+// SeenSet dedupes repeated hook firings (e.g. a resumed session replaying
+// SessionStart) across every Engine that shares it. Pass nil to NewEngine to
+// give an Engine its own, unshared SeenSet.
+type SeenSet = hooks.SeenSet
+
+// NewEngine constructs an Engine with no hooks registered. Reads no files or
+// environment variables. Pass nil for seen to give the Engine its own SeenSet.
+func NewEngine(seen *SeenSet) *Engine { return hooks.NewEngine(seen) }
+
+// NewSeenSet constructs an empty SeenSet for sharing across Engines that
+// should dedupe hook firings against each other (e.g. one Engine per
+// sub-agent, sharing the parent's SeenSet).
+func NewSeenSet() *SeenSet { return hooks.NewSeenSet() }
+
+// Event constants — see internal/hooks.Payload for which Payload fields are
+// populated at each one.
+const (
+	// EventSessionStart fires once per logical session opening.
+	EventSessionStart = hooks.EventSessionStart
+	// EventUserPromptSubmit fires before each user turn. Its return value is
+	// folded into the transcript ahead of the user's message.
+	EventUserPromptSubmit = hooks.EventUserPromptSubmit
+	// EventPreToolUse fires before each tool dispatch and can block/allow it.
+	// An InProcHook registered for this event opts into a verdict by
+	// returning `{"decision":"block","reason":"..."}` or
+	// `{"decision":"approve"}`; any other return value (including "") is no
+	// opinion for that hook. In-process hooks are evaluated before shell
+	// hooks; the first Block from either kind short-circuits the rest.
+	EventPreToolUse = hooks.EventPreToolUse
+	// EventPostToolUse fires after each successful tool result.
+	EventPostToolUse = hooks.EventPostToolUse
+	// EventStop fires when an assistant turn ends, on success and on error.
+	EventStop = hooks.EventStop
+	// EventSubagentStop fires when a spawned sub-agent finishes.
+	EventSubagentStop = hooks.EventSubagentStop
+	// EventPreCompact fires before history compaction.
+	EventPreCompact = hooks.EventPreCompact
+)

--- a/pkg/octoagent/hooks/hooks_test.go
+++ b/pkg/octoagent/hooks/hooks_test.go
@@ -1,0 +1,81 @@
+package hooks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-octo/octo-agent/pkg/octoagent"
+)
+
+// capturingSender records the messages it was asked to send so the test can
+// inspect what the hook injected into the turn's user text.
+type capturingSender struct {
+	lastMessages []octoagent.Message
+}
+
+func (s *capturingSender) SendMessages(ctx context.Context, model, system string, messages []octoagent.Message, maxTokens int) (octoagent.Reply, error) {
+	s.lastMessages = messages
+	return octoagent.Reply{Content: "ok"}, nil
+}
+
+func TestEngine_RegisterInProc_InjectsIntoTurn(t *testing.T) {
+	engine := NewEngine(nil)
+	engine.RegisterInProc(EventUserPromptSubmit, func(ctx context.Context, p Payload) string {
+		return "REMINDER"
+	})
+
+	sender := &capturingSender{}
+	a := octoagent.New(sender, "stub-model")
+	a.Hooks = engine
+	a.HookMeta = Meta{SessionID: "sess-1", Transport: "test"}
+
+	if _, err := a.Turn(context.Background(), "hello"); err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+
+	if len(sender.lastMessages) == 0 {
+		t.Fatal("sender received no messages")
+	}
+	last := sender.lastMessages[len(sender.lastMessages)-1]
+	if last.Content == "" || last.Content == "hello" {
+		t.Fatalf("expected the hook's injected text ahead of the user input, got %q", last.Content)
+	}
+	if got := last.Content; got != "REMINDER\n\nhello" {
+		t.Errorf("message content = %q, want %q", got, "REMINDER\n\nhello")
+	}
+}
+
+func TestEngine_PreToolUse_Blocks(t *testing.T) {
+	engine := NewEngine(nil)
+	engine.RegisterInProc(EventPreToolUse, func(ctx context.Context, p Payload) string {
+		return `{"decision":"block","reason":"no tools allowed"}`
+	})
+
+	decision := engine.PreToolUse(context.Background(), Payload{
+		Event:    EventPreToolUse,
+		ToolName: "terminal",
+	})
+	if !decision.Block {
+		t.Errorf("PreToolUse decision = %+v, want Block=true", decision)
+	}
+	if decision.Reason != "no tools allowed" {
+		t.Errorf("PreToolUse reason = %q, want %q", decision.Reason, "no tools allowed")
+	}
+}
+
+func TestSeenSet_SharedAcrossEngines(t *testing.T) {
+	seen := NewSeenSet()
+	e1 := NewEngine(seen)
+	e2 := NewEngine(seen)
+
+	// persistedStarted=true routes through the "resume" branch, the only one
+	// that actually consults the seen-set (persistedStarted=false always
+	// fires as "startup" regardless of what's been seen).
+	src, fire := e1.SessionStartDecision("sess-shared", true, false)
+	if !fire || src != "resume" {
+		t.Fatalf("e1 SessionStartDecision: expected fire=true source=resume on first call, got fire=%v source=%q", fire, src)
+	}
+	if _, fire := e2.SessionStartDecision("sess-shared", true, false); fire {
+		t.Error("e2 SessionStartDecision: expected fire=false — SeenSet is shared with e1")
+	}
+}

--- a/pkg/octoagent/octoagent.go
+++ b/pkg/octoagent/octoagent.go
@@ -12,10 +12,10 @@
 //
 // # What's not exported here
 //
-// Hook engine types (Agent.Hooks, Agent.HookMeta) live in internal/hooks and are
-// intentionally not aliased in this iteration. Leave them zero if you don't
-// need custom hooks. The MCP client registry is also not exported yet; using
-// MCP tools from a library consumer requires a separate design pass.
+// Hook engine types (Agent.Hooks, Agent.HookMeta) live in internal/hooks; see
+// pkg/octoagent/hooks for their aliases. Leave both fields zero if you don't
+// need custom hooks. The MCP client registry is not exported yet; using MCP
+// tools from a library consumer requires a separate design pass.
 package octoagent
 
 import "github.com/open-octo/octo-agent/internal/agent"

--- a/pkg/octoagent/toolenv/toolenv.go
+++ b/pkg/octoagent/toolenv/toolenv.go
@@ -99,3 +99,19 @@ func WireForSession(
 	})
 	return ctx, executor, cleanup
 }
+
+// DefaultToolsForCtx returns the tool definitions to advertise to the model
+// for one turn. Pass the ctx WireForSession returned (not the original ctx) —
+// sub_agent* and workflow* tools are only advertised when ctx carries the
+// SubAgentManager / WorkflowManager WireForSession stamped in.
+func DefaultToolsForCtx(ctx context.Context, model string) []octoagent.ToolDefinition {
+	return tools.DefaultToolsForCtx(ctx, model)
+}
+
+// NewDefaultRegistry returns a fresh ToolExecutor implementing every built-in
+// tool (file/terminal/web/skill/sub_agent/workflow/mcp_*), independent of any
+// WireForSession call. WireForSession already builds and returns one bound to
+// its own ctx; use this only when a second, independent executor is needed.
+func NewDefaultRegistry() octoagent.ToolExecutor {
+	return tools.NewDefaultRegistry()
+}

--- a/pkg/octoagent/toolenv/toolenv_test.go
+++ b/pkg/octoagent/toolenv/toolenv_test.go
@@ -144,3 +144,34 @@ func TestWireForSession_DoesNotImportConfigOrPermission(t *testing.T) {
 		t.Error("internal/app/toolenv.go calls permission.New")
 	}
 }
+
+func TestDefaultToolsForCtx_AdvertisesSubAgentAfterWireForSession(t *testing.T) {
+	a := octoagent.New(stubSender{}, "stub-model")
+	ctx, _, cleanup := WireForSession(context.Background(), a, "session-tools-test")
+	defer cleanup()
+
+	defs := DefaultToolsForCtx(ctx, a.Model)
+	found := false
+	for _, d := range defs {
+		if d.Name == "sub_agent" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected sub_agent in DefaultToolsForCtx(ctx, ...) after WireForSession stamped a SubAgentManager into ctx")
+	}
+}
+
+func TestDefaultToolsForCtx_NoSubAgentWithoutWireForSession(t *testing.T) {
+	defs := DefaultToolsForCtx(context.Background(), "stub-model")
+	for _, d := range defs {
+		if d.Name == "sub_agent" {
+			t.Error("expected no sub_agent without a ctx-scoped SubAgentManager")
+		}
+	}
+}
+
+func TestNewDefaultRegistry_ImplementsToolExecutor(t *testing.T) {
+	var _ octoagent.ToolExecutor = NewDefaultRegistry()
+}


### PR DESCRIPTION
## Summary

Closes two of the four gaps recorded in `dev-docs/octoagent-pkg-design.md`'s known-limitations list, in priority order (smallest/most-blocking first).

- **`toolenv.DefaultToolsForCtx` / `toolenv.NewDefaultRegistry`**: previously missing entirely — `tools.DefaultToolsForCtx` lives in `internal/tools`, so `examples/octoagent-minimal`'s own comment claiming a real consumer would call it was not actually executable from outside the module. Without this, an external consumer had no way to get a non-empty tool list at all, sub-agent or otherwise. The example now calls it for real and filters `sub_agent` out as a demonstration of the `disallowed_tools` convention described in the design doc.
- **`pkg/octoagent/hooks`**: aliases `internal/hooks`'s `Engine`/`Meta`/`Payload`/`InProcHook`/`ToolDecision`/`SeenSet` plus `NewEngine`/`NewSeenSet` and the 7 event constants, so `Agent.Hooks`/`Agent.HookMeta` can be configured from outside `internal/`. Only the file-free constructor is exposed — `EngineFromEnvAndFiles` (reads `~/.octo/hooks.yml`) stays internal, matching the "zero ambient dependency" bar set by `provider.NewSender`/`toolenv.WireForSession`.

## A bug surfaced while exporting hooks

`internal/hooks.Engine.PreToolUse` only ever consulted **shell** hooks for the block/allow verdict. An `InProcHook` registered for `EventPreToolUse` made `Configured()` report "configured" (triggering the `hookGate` wrap in `effectiveGate()`) but was never actually invoked for a decision — this was deliberate in the original code ("PreToolUse is a shell-configured guard"), a reasonable constraint for `hooks.yml`-driven shell scripts. But the most obvious thing an external Go consumer wants from `pkg/octoagent/hooks` is exactly "write a policy check in Go, no shell script" — shipping the export as-is would make that the one thing that looks configured but silently does nothing.

`PreToolUse` now also runs in-process hooks first (registration order, same as `Inject`'s existing convention), reading a decision off the same `` `{"decision":"block"/"approve",...}` `` JSON-string convention shell hook stdout already uses. Block still wins over Allow regardless of which kind of hook produced it. This has zero blast radius on existing behavior — every current `RegisterInProc` call in the codebase is for `EventPostToolUse`/`EventUserPromptSubmit`, not `EventPreToolUse`, so no existing shell-hook test or production path changes.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./pkg/... ./internal/hooks/... ./internal/agent/... ./internal/tools/...` — all pass, including new coverage:
  - `pkg/octoagent/toolenv`: `sub_agent` appears in `DefaultToolsForCtx` after `WireForSession`, absent without it; `NewDefaultRegistry` satisfies `ToolExecutor`
  - `pkg/octoagent/hooks`: in-process hook injects into a real `Turn()`; `PreToolUse` blocks via an in-process hook; `SeenSet` sharing across `Engine`s
  - `internal/hooks`: 5 new `PreToolUse` cases (in-proc block/approve/non-decision, in-proc-vs-shell ordering both directions) alongside the 8 existing shell-only cases, all still passing unchanged
- [x] `go test -race ./...` — full suite green
- [x] `go run ./examples/octoagent-minimal/` — runs end to end with the real tool list wired in