### PR TITLE
fix(server): scope the read-before-write tracker to the session, not the turn

### DIFF
--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -289,6 +291,77 @@ func TestPrepareToolTurn_SessionScopedAsyncManager(t *testing.T) {
 	}
 	if anon == m1 {
 		t.Error("sid-less manager must not be the session-scoped one")
+	}
+}
+
+// prepareToolTurn used to build a fresh DefaultRegistry (and so a fresh
+// ReadTracker) on every call, so a file read_file'd in one turn looked
+// unread to write_file/edit_file in the next turn of the SAME session. The
+// executor must now share a session-scoped tracker across turns, while a
+// different session id must not see another session's reads.
+func TestPrepareToolTurn_ReadTrackerPersistsAcrossTurns(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Tools: true})
+	a := agent.New(&stubSender{}, "stub-model")
+
+	sid := "sess-read-tracker-turn-test"
+	ctx := context.WithValue(context.Background(), ctxKeySessionID{}, sid)
+	t.Cleanup(func() {
+		tools.CloseSessionSubAgentManager(sid)
+		tools.CloseSessionReadTracker(sid)
+	})
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Turn 1: fresh executor from prepareToolTurn reads the file.
+	_, exec1, _, _, err := srv.prepareToolTurn(ctx, a, nil)
+	if err != nil {
+		t.Fatalf("prepareToolTurn: %v", err)
+	}
+	if _, err := exec1.Execute(ctx, "read_file", map[string]any{"path": p}); err != nil {
+		t.Fatalf("read_file: %v", err)
+	}
+
+	// Turn 2: a NEW executor (as prepareToolTurn builds every turn) must
+	// still honor the read recorded in turn 1.
+	_, exec2, _, _, err := srv.prepareToolTurn(ctx, a, nil)
+	if err != nil {
+		t.Fatalf("prepareToolTurn: %v", err)
+	}
+	if _, err := exec2.Execute(ctx, "edit_file", map[string]any{
+		"path": p, "old_string": "package x", "new_string": "package y",
+	}); err != nil {
+		t.Errorf("edit in a later turn of the same session should see the earlier turn's read: %v", err)
+	}
+
+	// A different session must not inherit that read — reuse the SAME path p
+	// (already read by session sid above) rather than an untouched file, so
+	// this actually exercises isolation instead of trivially failing because
+	// nobody ever read the path. CheckWritable runs before the tool body, so
+	// this fails on "not been read" before old_string matching is even
+	// reached, regardless of p's content having changed in turn 2.
+	otherSid := "sess-read-tracker-other"
+	otherCtx := context.WithValue(context.Background(), ctxKeySessionID{}, otherSid)
+	t.Cleanup(func() {
+		tools.CloseSessionSubAgentManager(otherSid)
+		tools.CloseSessionReadTracker(otherSid)
+	})
+	_, exec3, _, _, err := srv.prepareToolTurn(otherCtx, a, nil)
+	if err != nil {
+		t.Fatalf("prepareToolTurn: %v", err)
+	}
+	_, err = exec3.Execute(otherCtx, "edit_file", map[string]any{
+		"path": p, "old_string": "package y", "new_string": "package z",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not been read") {
+		t.Errorf("a different session should not inherit another session's read, got %v", err)
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -641,6 +641,7 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 	tools.CloseSessionBackgroundManager(id) // reap the session's background daemons
 	tools.CloseSessionSubAgentManager(id)   // and its sub-agents
 	tools.CloseSessionWorkflowManager(id)   // and its background workflows
+	tools.CloseSessionReadTracker(id)       // and its read-before-write tracker
 	s.wsHub.broadcast("", wsEventSessionDeleted{Type: "session_deleted", SessionID: id})
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": []string{id}})
 }
@@ -673,6 +674,7 @@ func (s *Server) handleDeleteSessions(w http.ResponseWriter, r *http.Request) {
 		tools.CloseSessionBackgroundManager(id) // reap the session's background daemons
 		tools.CloseSessionSubAgentManager(id)   // and its sub-agents
 		tools.CloseSessionWorkflowManager(id)   // and its background workflows
+		tools.CloseSessionReadTracker(id)       // and its read-before-write tracker
 		s.wsHub.broadcast("", wsEventSessionDeleted{Type: "session_deleted", SessionID: id})
 		deleted = append(deleted, id)
 	}

--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -29,7 +29,20 @@ import (
 // (see its doc comment — a different concern, since WorkflowTool.Definition()
 // has no ctx to read a.CWD from).
 func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agent.Session) (context.Context, agent.ToolExecutor, *tools.SubAgentManager, func(), error) {
-	executor := tools.NewDefaultRegistry()
+	sid, hasSession := ctx.Value(ctxKeySessionID{}).(string)
+
+	// A session-scoped tracker (keyed by sid, cached across turns like the
+	// background/sub-agent/workflow managers below) so a file read_file'd in
+	// one turn is still "read" when a later turn in the same conversation
+	// writes it — a per-turn tracker would forget every read as soon as the
+	// turn ended. One-shot paths with no session identity keep a fresh
+	// per-call tracker (nothing to persist it against).
+	var executor tools.DefaultRegistry
+	if hasSession && sid != "" {
+		executor = tools.NewDefaultRegistryWithTracker(tools.SessionReadTracker(sid))
+	} else {
+		executor = tools.NewDefaultRegistry()
+	}
 
 	// Goal tools dispatch to the turn's session on every tool-enabled path
 	// (WS, REST, scheduled) — advertising them (SetGoalsEnabled) while
@@ -70,7 +83,6 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 	}
 
 	var ask app.PermissionAsk
-	sid, hasSession := ctx.Value(ctxKeySessionID{}).(string)
 	if hasSession && sid != "" {
 		ask = s.permissionAskFrom(sid)
 		engine.AttachRemembered(s.rememberedFor(sid))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2601,7 +2601,12 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	var toolDefs []agent.ToolDefinition
 	var executor agent.ToolExecutor
 	if s.cfg.Tools {
-		executor = tools.NewDefaultRegistry()
+		// Session-scoped tracker (same "im:"+sess.Key identity used for the
+		// background/workflow managers below) so a file read_file'd in one chat
+		// message is still "read" when a later message in the same conversation
+		// writes it — a fresh-per-message tracker would forget every read as
+		// soon as the message finished, same bug prepareToolTurn had for web.
+		executor = tools.NewDefaultRegistryWithTracker(tools.SessionReadTracker("im:" + string(sess.Key)))
 
 		// Per-message sub-agent manager bound to THIS chat's agent —
 		// synchronous, since a chat message is request/response with no

--- a/internal/tools/read_tracker_test.go
+++ b/internal/tools/read_tracker_test.go
@@ -121,6 +121,75 @@ func TestRegistry_WriteThenEdit_NoRedundantRead(t *testing.T) {
 	}
 }
 
+func TestSessionReadTracker_PersistsAcrossSimulatedTurns(t *testing.T) {
+	sid := "sess-read-tracker-test"
+	t.Cleanup(func() { CloseSessionReadTracker(sid) })
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Turn 1: a fresh registry built from the session's tracker (mirrors
+	// prepareToolTurn building a new DefaultRegistry every turn) reads the file.
+	turn1 := NewDefaultRegistryWithTracker(SessionReadTracker(sid))
+	if _, err := turn1.Execute(context.Background(), "read_file", map[string]any{"path": p}); err != nil {
+		t.Fatalf("read_file: %v", err)
+	}
+
+	// Turn 2: a DIFFERENT DefaultRegistry value, but backed by the same
+	// session tracker — the earlier read must still count.
+	turn2 := NewDefaultRegistryWithTracker(SessionReadTracker(sid))
+	if _, err := turn2.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "package x", "new_string": "package y",
+	}); err != nil {
+		t.Errorf("edit in a later turn of the same session should see the earlier turn's read: %v", err)
+	}
+}
+
+func TestSessionReadTracker_IsolatedAcrossSessions(t *testing.T) {
+	sidA, sidB := "sess-a", "sess-b"
+	t.Cleanup(func() { CloseSessionReadTracker(sidA); CloseSessionReadTracker(sidB) })
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	regA := NewDefaultRegistryWithTracker(SessionReadTracker(sidA))
+	if _, err := regA.Execute(context.Background(), "read_file", map[string]any{"path": p}); err != nil {
+		t.Fatalf("read_file: %v", err)
+	}
+
+	regB := NewDefaultRegistryWithTracker(SessionReadTracker(sidB))
+	_, err := regB.Execute(context.Background(), "edit_file", map[string]any{
+		"path": p, "old_string": "package x", "new_string": "package y",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not been read") {
+		t.Errorf("session B should not inherit session A's read, got %v", err)
+	}
+}
+
+func TestCloseSessionReadTracker_DropsState(t *testing.T) {
+	sid := "sess-close-test"
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	if err := os.WriteFile(p, []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	SessionReadTracker(sid).RecordRead(p)
+	CloseSessionReadTracker(sid)
+	t.Cleanup(func() { CloseSessionReadTracker(sid) })
+
+	// A fresh tracker under the same id after close must not remember the read.
+	if err := SessionReadTracker(sid).CheckWritable(p); err == nil {
+		t.Errorf("tracker state should not survive CloseSessionReadTracker")
+	}
+}
+
 func TestRegistry_ZeroValue_NoEnforcement(t *testing.T) {
 	// DefaultRegistry{} (nil tracker) must behave as before — no
 	// read-before-write gating.

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -65,15 +65,28 @@ var allTools = []tool{
 // edit_file calls to an existing file are refused unless the file was read
 // (and is unchanged) this session. The zero value (DefaultRegistry{}) has a
 // nil tracker and so enforces nothing — preserved for tests and callers that
-// don't want the discipline. Use NewDefaultRegistry for the enforced variant.
+// don't want the discipline. Use NewDefaultRegistry (fresh tracker) or
+// NewDefaultRegistryWithTracker (caller-supplied, e.g. session-scoped) for
+// the enforced variant.
 type DefaultRegistry struct {
 	tracker *ReadTracker
 }
 
 // NewDefaultRegistry returns a registry with read-before-write enforcement
-// backed by a fresh per-session ReadTracker.
+// backed by a fresh ReadTracker. Callers that need the tracker to survive
+// across turns (web/IM, keyed by session id) should use
+// NewDefaultRegistryWithTracker(tools.SessionReadTracker(id)) instead.
 func NewDefaultRegistry() DefaultRegistry {
 	return DefaultRegistry{tracker: NewReadTracker()}
+}
+
+// NewDefaultRegistryWithTracker returns a registry with read-before-write
+// enforcement backed by the given tracker, e.g. a session-scoped tracker
+// obtained from SessionReadTracker so reads recorded in one turn are still
+// honored in a later turn of the same conversation. A nil tracker behaves
+// like the zero value DefaultRegistry{} — enforcement disabled.
+func NewDefaultRegistryWithTracker(tracker *ReadTracker) DefaultRegistry {
+	return DefaultRegistry{tracker: tracker}
 }
 
 // Execute implements agent.ToolExecutor.

--- a/internal/tools/session_managers.go
+++ b/internal/tools/session_managers.go
@@ -202,6 +202,42 @@ func CloseSessionWorkflowManager(id string) {
 	}
 }
 
+// ─── Read trackers ──────────────────────────────────────────────────────
+
+// Per-session read-before-write trackers, keyed like the background/sub-agent
+// managers. A tracker built fresh per turn (as prepareToolTurn used to do)
+// forgets every read the moment the turn ends, so a file read_file'd in one
+// web/IM turn still looks unread to write_file/edit_file in the next turn of
+// the same conversation — unlike the CLI, where app.WireTools builds one
+// registry (and tracker) for the whole process session. Keying by session id
+// here gives web/IM the same across-turn memory. Reaped on session delete
+// (CloseSessionReadTracker).
+var (
+	sessionReadTrackersMu sync.Mutex
+	sessionReadTrackers   = map[string]*ReadTracker{}
+)
+
+// SessionReadTracker returns the per-session ReadTracker for id, creating it
+// on first use.
+func SessionReadTracker(id string) *ReadTracker {
+	sessionReadTrackersMu.Lock()
+	defer sessionReadTrackersMu.Unlock()
+	t := sessionReadTrackers[id]
+	if t == nil {
+		t = NewReadTracker()
+		sessionReadTrackers[id] = t
+	}
+	return t
+}
+
+// CloseSessionReadTracker drops the per-session tracker for id. No-op for an
+// unknown id.
+func CloseSessionReadTracker(id string) {
+	sessionReadTrackersMu.Lock()
+	delete(sessionReadTrackers, id)
+	sessionReadTrackersMu.Unlock()
+}
+
 // allBackgroundManagers returns defaultBg plus every live per-session manager,
 // so process-wide operations (shutdown reap) cover every tracked process.
 func allBackgroundManagers() []*BackgroundManager {


### PR DESCRIPTION
## Summary
- `prepareToolTurn` (web/WS) and the IM channel turn handler each built a fresh `DefaultRegistry` — and so a fresh `ReadTracker` — on every single turn, so a file `read_file`'d in one turn looked unread to `write_file`/`edit_file` in the next turn of the same conversation. The CLI never hit this since `app.WireTools` builds one registry for the whole process session.
- Key the tracker by session id instead (`tools.SessionReadTracker`/`CloseSessionReadTracker` in `internal/tools/session_managers.go`), following the existing `SessionBackgroundManager`/`SessionSubAgentManager`/`SessionWorkflowManager` pattern, and reap it on session delete.
- Adds `tools.NewDefaultRegistryWithTracker` so callers can inject an existing (e.g. session-scoped) tracker instead of always getting a fresh one.
- Wires the fix into both the web REST/WS path (`handlers_prepare_toolturn.go`) and the IM channel path (`server.go`, keyed the same way as its existing per-chat background/workflow managers).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test -race ./internal/tools/... ./internal/server/...` — all pass
- [x] New tests: `TestSessionReadTracker_PersistsAcrossSimulatedTurns`, `TestSessionReadTracker_IsolatedAcrossSessions`, `TestCloseSessionReadTracker_DropsState` (internal/tools), `TestPrepareToolTurn_ReadTrackerPersistsAcrossTurns` (internal/server, exercises the actual `prepareToolTurn` path and confirms cross-session isolation against the same file path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)