### PR TITLE
fix(cmd/octo): stop the TUI spinner from spinning multiple times too fast during busy workflows

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -242,6 +242,24 @@ func tickCmd() tea.Cmd {
 	return tea.Tick(tickInterval, func(time.Time) tea.Msg { return tickMsg{} })
 }
 
+// startTicker begins the tickMsg->tickCmd animation chain if one isn't
+// already alive, else it's a no-op. Callers that might fire while a chain
+// from an earlier event is still running (subagent/workflow events arriving
+// between turns) must go through this rather than calling tickCmd() directly
+// — tea.Tick always starts a brand-new independent timer, so an unconditional
+// tickCmd() call would spawn a second, parallel chain alongside the existing
+// one, doubling spinnerFrame's effective advance rate (and tripling, etc. with
+// more redundant calls). The tickMsg handler in Update is the one place that
+// legitimately continues the already-active chain and calls tickCmd()
+// directly for that reason.
+func (m *tuiModel) startTicker() tea.Cmd {
+	if m.tickerActive {
+		return nil
+	}
+	m.tickerActive = true
+	return tickCmd()
+}
+
 // tuiSink implements ViewSink by sending each call onto the bubbletea program.
 // Ask blocks the calling (agent) goroutine until the modal is answered or the
 // turn's context is cancelled.
@@ -430,6 +448,16 @@ type tuiModel struct {
 	// spinnerFrame advances on every tickMsg while a turn runs, animating the
 	// thinking placeholder, the running-tool indicator, and the elapsed clock.
 	spinnerFrame int
+	// tickerActive is true while a tickMsg->tickCmd chain is alive. Every event
+	// that might need the ticker running (turn start, subagent/workflow events
+	// arriving between turns) used to unconditionally call tickCmd(), which — since
+	// tea.Tick always starts a brand-new independent timer — spawned a whole
+	// separate self-perpetuating chain each time. A busy background workflow
+	// firing many workflowEventMsg/subAgentEventMsg while idle between turns could
+	// accumulate dozens of parallel chains, each incrementing spinnerFrame every
+	// tickInterval, so the spinner visibly spun many times faster than intended.
+	// This flag ensures at most one chain is alive at a time.
+	tickerActive bool
 	// running, when non-nil, is a card tool executing right now — shown as a
 	// live spinner line until its done event commits the finished card. (Card
 	// tools suppress their started line, so without this they'd show nothing
@@ -814,7 +842,7 @@ func (m *tuiModel) startTurnEchoRestore(line, echo, restore string) tea.Cmd {
 		m.echoPending = userEchoStyle.Render("> ") + echo
 		m.echoRestore = restore
 	}
-	return tickCmd()
+	return m.startTicker()
 }
 
 // startCompact launches an explicit /compact in a background goroutine. It
@@ -844,7 +872,7 @@ func (m *tuiModel) startCompact() tea.Cmd {
 		}
 		prog.Send(turnFinishedMsg{err: err})
 	}()
-	return tickCmd()
+	return m.startTicker()
 }
 
 // commitEcho promotes the deferred user-message echo from the live View() area
@@ -896,6 +924,7 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// still going (so the live bottom panels keep ticking even between turns);
 		// let the ticker die once everything is quiet.
 		if !m.turnRunning && len(tools.RunningBackground()) == 0 && len(m.subAgents) == 0 && len(m.workflows) == 0 {
+			m.tickerActive = false
 			return m, m.flushPrints()
 		}
 		m.spinnerFrame++
@@ -969,17 +998,22 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case subAgentEventMsg:
 		m.handleSubAgentEvent(msg.ev)
 		// Ensure the animation ticker is running so the panel's spinner/elapsed
-		// updates even between turns.
+		// updates even between turns. startTicker is a no-op if a chain from an
+		// earlier event is already alive — a busy background subagent firing many
+		// of these while idle must not spawn a parallel tickMsg chain each time
+		// (that used to make the spinner spin several times faster than intended).
 		if !m.turnRunning {
-			return m, tea.Batch(tickCmd(), m.flushPrints())
+			return m, tea.Batch(m.startTicker(), m.flushPrints())
 		}
 		return m, m.flushPrints()
 
 	case workflowEventMsg:
 		m.handleWorkflowEvent(msg.ev)
-		// Keep the ticker alive for the workflow panel's spinner/elapsed clock.
+		// Keep the ticker alive for the workflow panel's spinner/elapsed clock —
+		// see the subAgentEventMsg case above for why this goes through
+		// startTicker rather than tickCmd() directly.
 		if !m.turnRunning {
-			return m, tea.Batch(tickCmd(), m.flushPrints())
+			return m, tea.Batch(m.startTicker(), m.flushPrints())
 		}
 		return m, m.flushPrints()
 

--- a/cmd/octo/tuirepl_p3_test.go
+++ b/cmd/octo/tuirepl_p3_test.go
@@ -86,9 +86,15 @@ func TestTUI_WorkflowEventsWhileIdleStartTickerOnce(t *testing.T) {
 
 	// Flood more progress events, as a busy workflow would, without letting a
 	// tickMsg run in between (turnRunning stays false throughout, mirroring
-	// idle time between turns). None of these may restart the chain.
+	// idle time between turns). None of these may restart the chain — capture
+	// each returned cmd (rather than discarding it) so a regression back to
+	// unconditional tickCmd() calls would actually be observed here, not just
+	// via the separate direct startTicker() check below.
 	for i := 0; i < 10; i++ {
-		m.Update(workflowEventMsg{ev: tools.WorkflowEvent{RunID: "wf_1", Kind: "progress", Line: "step"}})
+		_, cmd := m.Update(workflowEventMsg{ev: tools.WorkflowEvent{RunID: "wf_1", Kind: "progress", Line: "step"}})
+		if cmd != nil {
+			t.Fatalf("flood iteration %d: workflow event while ticker already active returned a non-nil cmd (a duplicate tick chain)", i)
+		}
 	}
 	if got := m.startTicker(); got != nil {
 		t.Error("flooding workflow events while idle spawned more than one live tick chain")
@@ -102,6 +108,48 @@ func TestTUI_WorkflowEventsWhileIdleStartTickerOnce(t *testing.T) {
 	}
 	if got := m.startTicker(); got != nil {
 		t.Error("a subagent event while the ticker is already active should not restart it")
+	}
+}
+
+// TestTUI_TickerRestartsAfterIdleViaRealUpdate drives the full round trip
+// through real Update() dispatch — unlike TestTUI_StartTicker_NoDoubleChain
+// and TestTUI_WorkflowEventsWhileIdleStartTickerOnce, which set
+// m.tickerActive=false directly to simulate "the chain has stopped". Here a
+// genuine idle tickMsg (the same message the running tea.Tick would deliver)
+// must clear the flag via the tickMsg case's own idle branch, and a
+// follow-up event must then be able to restart the chain — so the idle
+// condition in the tickMsg case and the guard in startTicker can't silently
+// drift out of sync with each other.
+func TestTUI_TickerRestartsAfterIdleViaRealUpdate(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = false
+
+	// Starts the chain. Kind "progress" for a run that was never "started"
+	// leaves m.workflows empty (handleWorkflowEvent only updates an existing
+	// entry on "progress"), so it doesn't itself trip tickMsg's idle check below.
+	if _, cmd := m.Update(workflowEventMsg{ev: tools.WorkflowEvent{RunID: "wf_1", Kind: "progress", Line: "x"}}); cmd == nil {
+		t.Fatal("workflow event while idle should start the ticker")
+	}
+	if !m.tickerActive {
+		t.Fatal("tickerActive should be true after starting")
+	}
+
+	// A real tickMsg, with everything else idle, must hit the idle branch and
+	// clear the flag — not just stop rescheduling.
+	if _, cmd := m.Update(tickMsg{}); cmd != nil {
+		t.Fatal("idle tickMsg should not reschedule")
+	}
+	if m.tickerActive {
+		t.Fatal("idle tickMsg should clear tickerActive so a later event can restart the chain")
+	}
+
+	// A follow-up event must be able to restart the chain now that the
+	// previous one has actually stopped.
+	if _, cmd := m.Update(workflowEventMsg{ev: tools.WorkflowEvent{RunID: "wf_1", Kind: "progress", Line: "y"}}); cmd == nil {
+		t.Error("a later workflow event should restart the ticker once the previous chain has stopped")
+	}
+	if !m.tickerActive {
+		t.Error("tickerActive should be true again after the restart")
 	}
 }
 

--- a/cmd/octo/tuirepl_p3_test.go
+++ b/cmd/octo/tuirepl_p3_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/tools"
 )
 
 func TestTUI_TickAdvancesOnlyWhileRunning(t *testing.T) {
@@ -29,6 +30,78 @@ func TestTUI_TickAdvancesOnlyWhileRunning(t *testing.T) {
 	}
 	if cmd != nil {
 		t.Error("tick should stop rescheduling once the turn ends")
+	}
+}
+
+// startTicker is the single choke point that prevents a busy background
+// workflow/subagent — which fires many events between turns — from spawning
+// a parallel tickMsg->tickCmd chain per event. Before this guard existed,
+// every such event unconditionally called tickCmd(), and since tea.Tick
+// always starts a brand-new independent timer, N events produced N live
+// chains all incrementing spinnerFrame every tickInterval — the spinner
+// visibly spun several times faster than intended the busier a workflow was.
+func TestTUI_StartTicker_NoDoubleChain(t *testing.T) {
+	m := newTestModel()
+
+	cmd1 := m.startTicker()
+	if cmd1 == nil {
+		t.Fatal("first startTicker call should start the chain")
+	}
+	if !m.tickerActive {
+		t.Fatal("tickerActive should be true once a chain has started")
+	}
+
+	// A second event arriving while the chain from the first is still alive
+	// (e.g. another workflowEventMsg before the next tickMsg fires) must not
+	// spawn a parallel chain.
+	if cmd2 := m.startTicker(); cmd2 != nil {
+		t.Error("startTicker should be a no-op while a chain is already active")
+	}
+
+	// Once the chain has actually stopped (tickMsg's idle branch clears
+	// tickerActive), a later event can start a fresh one again.
+	m.tickerActive = false
+	if cmd3 := m.startTicker(); cmd3 == nil {
+		t.Error("startTicker should restart the chain once the previous one has stopped")
+	}
+}
+
+// TestTUI_WorkflowEventsWhileIdleStartTickerOnce is the integration-level
+// counterpart to TestTUI_StartTicker_NoDoubleChain: it drives the real
+// workflowEventMsg/subAgentEventMsg branches of Update (not startTicker
+// directly) to confirm they're actually wired through the guard, matching a
+// real busy background workflow flooding the TUI with progress events while
+// no foreground turn is running.
+func TestTUI_WorkflowEventsWhileIdleStartTickerOnce(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = false
+
+	ev := tools.WorkflowEvent{RunID: "wf_1", Kind: "progress", Line: "step 1"}
+	if _, cmd := m.Update(workflowEventMsg{ev: ev}); cmd == nil {
+		t.Fatal("first workflow event while idle should start the ticker")
+	}
+	if !m.tickerActive {
+		t.Fatal("tickerActive should be true after the first workflow event")
+	}
+
+	// Flood more progress events, as a busy workflow would, without letting a
+	// tickMsg run in between (turnRunning stays false throughout, mirroring
+	// idle time between turns). None of these may restart the chain.
+	for i := 0; i < 10; i++ {
+		m.Update(workflowEventMsg{ev: tools.WorkflowEvent{RunID: "wf_1", Kind: "progress", Line: "step"}})
+	}
+	if got := m.startTicker(); got != nil {
+		t.Error("flooding workflow events while idle spawned more than one live tick chain")
+	}
+
+	// A subagent event is guarded the same way and shares the same flag.
+	m.tickerActive = false
+	sub := tools.SubAgentEvent{AgentID: "agent_1", Kind: "started"}
+	if _, cmd := m.Update(subAgentEventMsg{ev: sub}); cmd == nil {
+		t.Fatal("first subagent event while idle should start the ticker")
+	}
+	if got := m.startTicker(); got != nil {
+		t.Error("a subagent event while the ticker is already active should not restart it")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `subAgentEventMsg`/`workflowEventMsg` (and `startTurnEcho`/`startCompact`) each unconditionally called `tickCmd()` to (re)start the `spinnerFrame` animation chain. `tea.Tick` always starts a brand-new independent timer, so any of these firing while a `tickMsg`→`tickCmd` chain was already alive spawned a *parallel* chain instead of reusing it.
- A busy background workflow emits many `workflow_event` progress updates between turns — each one arriving while idle added another live chain, all incrementing the shared `spinnerFrame` every tick interval. The more active the workflow, the faster the bottom "Thinking…" spinner visibly spun — this is the reported bug.
- Fix: add a `tickerActive` flag and a `startTicker()` choke point in `cmd/octo/tuirepl.go` — it starts the chain only if none is alive, and is a no-op otherwise. The `tickMsg` handler's idle branch (where the chain naturally stops) clears the flag so a later event can start a fresh one.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test -race ./cmd/octo/...` — all pass, including pre-existing tick/spinner tests
- [x] New tests: `TestTUI_StartTicker_NoDoubleChain` (unit-level guard), `TestTUI_WorkflowEventsWhileIdleStartTickerOnce` (floods 10 idle-time workflow progress events and confirms only one tick chain starts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)