### PR TITLE
chore: bump version to 1.8.6

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.8.5"
+var Version = "1.8.6"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release covering:
- fix(server): scope the read-before-write tracker to the session, not the turn (#1229)
- fix(cmd/octo): stop the TUI spinner from spinning multiple times too fast during busy workflows (#1230)

🤖 Generated with [Claude Code](https://claude.com/claude-code)