### PR TITLE
fix(blog): stop mermaid.render() from deleting its own container

### DIFF
--- a/blog/src/layouts/BlogPost.astro
+++ b/blog/src/layouts/BlogPost.astro
@@ -125,12 +125,15 @@ const siteName = locale === 'zh' ? 'octo 博客' : 'octo blog';
 			blocks.forEach((pre) => {
 				const code = pre.querySelector('code');
 				const source = code ? (code.textContent || '') : '';
-				const id = 'mermaid-' + Math.random().toString(36).slice(2, 9);
+				const suffix = Math.random().toString(36).slice(2, 9);
 				const container = document.createElement('div');
 				container.className = 'mermaid-diagram';
-				container.id = id;
+				container.id = 'mermaid-container-' + suffix;
 				pre.replaceWith(container);
-				mermaid.render(id, source).then(({ svg }) => {
+				// mermaid.render() creates and then removes a temporary DOM node
+				// with this id internally, so it must differ from container.id
+				// or mermaid ends up deleting our own container instead.
+				mermaid.render('mermaid-render-' + suffix, source).then(({ svg }) => {
 					container.innerHTML = svg;
 				}).catch((err) => {
 					container.innerHTML = '<pre class="mermaid-error">' + (err?.message || 'Mermaid render failed') + '</pre>';


### PR DESCRIPTION
## Summary
- Blog post flowcharts (mermaid diagrams) were silently failing to render: the layout reused the same `id` for the persistent container `div` and for the `mermaid.render(id, source)` call, and mermaid internally creates+removes a node keyed by that id as part of its render/cleanup — deleting the real container right after a successful render, with no console error.
- Give the container (`mermaid-container-<suffix>`) and the render call (`mermaid-render-<suffix>`) distinct ids so the container survives and `container.innerHTML = svg` actually lands.

## Test plan
- [x] Reproduced with a headless Chrome + real mermaid CDN render: before the fix, all 5 flowcharts in `loop-engineering-practice` disappeared (`diagramsWithSvg: 0`, no console errors); after the fix, all 5 render (`diagramsWithSvg: 5`).
- [x] `npm run build` in `blog/` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)