### PR TITLE
fix(mcp): bind OAuth tokens to the resource via RFC 8707

### DIFF
--- a/internal/mcp/oauth.go
+++ b/internal/mcp/oauth.go
@@ -90,6 +90,18 @@ type oauthState struct {
 	RefreshToken string    `json:"refresh_token,omitempty"`
 	ExpiresAt    time.Time `json:"expires_at"`
 	TokenURL     string    `json:"token_url"`
+	// Resource is the RFC 8707 audience value echoed back on every token
+	// request (device authorization, token exchange, refresh) so an
+	// audience-checking authorization server issues a token scoped to this
+	// MCP endpoint rather than a generic one. Comes from the protected-
+	// resource metadata's "resource" field, falling back to ResourceURL if
+	// the server omits it.
+	Resource string `json:"resource,omitempty"`
+	// Scope is the space-separated scope string requested alongside the
+	// token, derived from the protected-resource metadata's
+	// "scopes_supported". Re-sent on refresh so a rotated token keeps the
+	// same grant.
+	Scope string `json:"scope,omitempty"`
 }
 
 // NewOAuthClient builds a provider for the given MCP resource URL.
@@ -163,10 +175,21 @@ func (o *OAuthClient) Invalidate() {
 // authorize runs the full discovery + (maybe register) + device flow.
 // Caller holds o.mu.
 func (o *OAuthClient) authorize(ctx context.Context) error {
-	asMeta, err := o.discover(ctx)
+	asMeta, prMeta, err := o.discover(ctx)
 	if err != nil {
 		return err
 	}
+	// RFC 8707 audience binding: bind the token to the resource the
+	// protected-resource metadata names, falling back to the configured
+	// URL if the server omits "resource" (non-compliant but seen in the
+	// wild). Without this, an audience-checking authorization server
+	// issues a token that authenticates fine but isn't authorized for this
+	// specific MCP endpoint, and every request 401s.
+	resource := prMeta.Resource
+	if resource == "" {
+		resource = o.resourceURL
+	}
+	scope := strings.Join(prMeta.ScopesSupported, " ")
 
 	clientID := ""
 	clientSecret := ""
@@ -175,7 +198,7 @@ func (o *OAuthClient) authorize(ctx context.Context) error {
 		clientSecret = o.state.ClientSecret
 	} else if asMeta.RegistrationEndpoint != "" {
 		// Public client + PKCE-friendly: no secret expected back.
-		id, secret, err := o.register(ctx, asMeta.RegistrationEndpoint)
+		id, secret, err := o.register(ctx, asMeta.RegistrationEndpoint, scope)
 		if err != nil {
 			return fmt.Errorf("oauth: dynamic client registration: %w", err)
 		}
@@ -185,7 +208,7 @@ func (o *OAuthClient) authorize(ctx context.Context) error {
 		return errors.New("oauth: server has no registration_endpoint and no cached client_id")
 	}
 
-	tok, err := o.deviceFlow(ctx, asMeta, clientID, clientSecret)
+	tok, err := o.deviceFlow(ctx, asMeta, clientID, clientSecret, resource, scope)
 	if err != nil {
 		return fmt.Errorf("oauth: device flow: %w", err)
 	}
@@ -197,6 +220,8 @@ func (o *OAuthClient) authorize(ctx context.Context) error {
 		RefreshToken: tok.RefreshToken,
 		ExpiresAt:    expiryFromSeconds(tok.ExpiresIn),
 		TokenURL:     asMeta.TokenEndpoint,
+		Resource:     resource,
+		Scope:        scope,
 	}
 	if err := saveOAuthState(o.storePath, o.state); err != nil {
 		// Persist failure is non-fatal — we still have the token in
@@ -219,6 +244,12 @@ func (o *OAuthClient) refresh(ctx context.Context) error {
 	form.Set("client_id", o.state.ClientID)
 	if o.state.ClientSecret != "" {
 		form.Set("client_secret", o.state.ClientSecret)
+	}
+	if o.state.Resource != "" {
+		form.Set("resource", o.state.Resource)
+	}
+	if o.state.Scope != "" {
+		form.Set("scope", o.state.Scope)
 	}
 	tok, err := o.postTokenEndpoint(ctx, o.state.TokenURL, form)
 	if err != nil {
@@ -251,39 +282,43 @@ type asMetadata struct {
 type prMetadata struct {
 	Resource             string   `json:"resource"`
 	AuthorizationServers []string `json:"authorization_servers"`
+	ScopesSupported      []string `json:"scopes_supported"`
 }
 
 // discover does the two-step RFC 9728 → 8414 hop. The 9728 metadata lives
 // at the protected resource's well-known path; it points at one or more
-// authorization servers. We pick the first.
-func (o *OAuthClient) discover(ctx context.Context) (*asMetadata, error) {
+// authorization servers. We pick the first. The protected-resource
+// metadata is also returned since its "resource"/"scopes_supported"
+// fields feed the RFC 8707 audience binding on every subsequent token
+// request.
+func (o *OAuthClient) discover(ctx context.Context) (*asMetadata, *prMetadata, error) {
 	prURL, err := buildPRMetadataURL(o.resourceURL)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var pr prMetadata
 	if err := o.getJSON(ctx, prURL, &pr); err != nil {
-		return nil, fmt.Errorf("protected-resource metadata: %w", err)
+		return nil, nil, fmt.Errorf("protected-resource metadata: %w", err)
 	}
 	if len(pr.AuthorizationServers) == 0 {
-		return nil, errors.New("oauth: no authorization_servers in protected-resource metadata")
+		return nil, nil, errors.New("oauth: no authorization_servers in protected-resource metadata")
 	}
 
 	asURL, err := buildASMetadataURL(pr.AuthorizationServers[0])
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var as asMetadata
 	if err := o.getJSON(ctx, asURL, &as); err != nil {
-		return nil, fmt.Errorf("authorization-server metadata: %w", err)
+		return nil, nil, fmt.Errorf("authorization-server metadata: %w", err)
 	}
 	if as.DeviceAuthorizationEndpoint == "" {
-		return nil, errors.New("oauth: server does not support device authorization grant")
+		return nil, nil, errors.New("oauth: server does not support device authorization grant")
 	}
 	if as.TokenEndpoint == "" {
-		return nil, errors.New("oauth: server has no token endpoint")
+		return nil, nil, errors.New("oauth: server has no token endpoint")
 	}
-	return &as, nil
+	return &as, &pr, nil
 }
 
 // buildPRMetadataURL constructs the RFC 9728 well-known URL by inserting
@@ -330,12 +365,15 @@ type registrationResponse struct {
 	ClientSecret string `json:"client_secret"`
 }
 
-func (o *OAuthClient) register(ctx context.Context, endpoint string) (clientID, clientSecret string, err error) {
+func (o *OAuthClient) register(ctx context.Context, endpoint, scope string) (clientID, clientSecret string, err error) {
 	body := map[string]any{
 		"client_name":                o.clientName,
 		"grant_types":                []string{"urn:ietf:params:oauth:grant-type:device_code", "refresh_token"},
 		"token_endpoint_auth_method": "none",
 		"application_type":           "native",
+	}
+	if scope != "" {
+		body["scope"] = scope
 	}
 	raw, err := json.Marshal(body)
 	if err != nil {
@@ -388,10 +426,16 @@ type tokenResponse struct {
 	ErrorDescription string `json:"error_description"`
 }
 
-func (o *OAuthClient) deviceFlow(ctx context.Context, as *asMetadata, clientID, clientSecret string) (*tokenResponse, error) {
+func (o *OAuthClient) deviceFlow(ctx context.Context, as *asMetadata, clientID, clientSecret, resource, scope string) (*tokenResponse, error) {
 	// 1. Kick off the device authorization.
 	form := url.Values{}
 	form.Set("client_id", clientID)
+	if resource != "" {
+		form.Set("resource", resource)
+	}
+	if scope != "" {
+		form.Set("scope", scope)
+	}
 	dcResp, err := o.startDevice(ctx, as.DeviceAuthorizationEndpoint, form)
 	if err != nil {
 		return nil, err
@@ -432,6 +476,12 @@ func (o *OAuthClient) deviceFlow(ctx context.Context, as *asMetadata, clientID, 
 		tokForm.Set("client_id", clientID)
 		if clientSecret != "" {
 			tokForm.Set("client_secret", clientSecret)
+		}
+		if resource != "" {
+			tokForm.Set("resource", resource)
+		}
+		if scope != "" {
+			tokForm.Set("scope", scope)
 		}
 		tok, err := o.postTokenEndpoint(ctx, as.TokenEndpoint, tokForm)
 		if err == nil {

--- a/internal/mcp/oauth.go
+++ b/internal/mcp/oauth.go
@@ -26,6 +26,13 @@ import (
 //     PKCE-friendly).
 //   - RFC 8628: device authorization grant. Right pick for a CLI — no
 //     local listener, just "open <uri> and enter <code>".
+//   - RFC 8707: bind the token to the resource named in the protected-
+//     resource metadata (falling back to the configured URL if the server
+//     omits it) via a "resource" form param on every device-authorization,
+//     token-exchange, and refresh request. Without this, an audience-
+//     checking authorization server issues a token that authenticates but
+//     isn't authorized for this specific MCP endpoint — every request
+//     401s even with a brand-new token.
 //   - Refresh-token flow on near-expiry + cached token persistence.
 //
 // What this skips
@@ -141,13 +148,22 @@ func (o *OAuthClient) Token(ctx context.Context) (string, error) {
 		}
 	})
 
+	// A cache written before RFC 8707 resource-binding was added has no
+	// Resource recorded. Its access token (and any token a refresh of it
+	// would yield) was never bound to this specific resource, so it's the
+	// same non-audience-bound token that caused the original 401 — reusing
+	// or refreshing it just reproduces the bug. Skip straight to a full
+	// re-authorize, which records Resource going forward.
+	stale := o.state != nil && o.state.Resource == "" &&
+		(o.state.AccessToken != "" || o.state.RefreshToken != "")
+
 	// 1. Cached + still valid (with a 60s slack for clock skew + round-trip).
-	if o.state != nil && o.state.AccessToken != "" &&
+	if !stale && o.state != nil && o.state.AccessToken != "" &&
 		o.state.ExpiresAt.After(time.Now().Add(60*time.Second)) {
 		return o.state.AccessToken, nil
 	}
 	// 2. Cached refresh token + token URL — try to refresh without bothering the user.
-	if o.state != nil && o.state.RefreshToken != "" && o.state.TokenURL != "" {
+	if !stale && o.state != nil && o.state.RefreshToken != "" && o.state.TokenURL != "" {
 		if err := o.refresh(ctx); err == nil {
 			return o.state.AccessToken, nil
 		}

--- a/internal/mcp/oauth_test.go
+++ b/internal/mcp/oauth_test.go
@@ -44,12 +44,15 @@ type fakeAuthServer struct {
 	srv            *httptest.Server
 	authorizeAfter int
 
-	mu            sync.Mutex
-	pollAttempts  int
-	registrations int
-	tokenIssued   string
-	refreshIssued string
-	deviceCode    string
+	mu              sync.Mutex
+	pollAttempts    int
+	registrations   int
+	tokenIssued     string
+	refreshIssued   string
+	deviceCode      string
+	lastDeviceForm  url.Values
+	lastTokenForm   url.Values
+	lastRefreshForm url.Values
 }
 
 func newFakeAuthServer(t *testing.T, authorizeAfter int) *fakeAuthServer {
@@ -95,6 +98,7 @@ func (f *fakeAuthServer) wire() {
 		_ = json.NewEncoder(w).Encode(prMetadata{
 			Resource:             f.URL("/mcp_server/v1"),
 			AuthorizationServers: []string{f.URL("/auth")},
+			ScopesSupported:      []string{"mcp:read", "mcp:write"},
 		})
 	})
 
@@ -127,7 +131,11 @@ func (f *fakeAuthServer) wire() {
 	// 5. Device authorization (RFC 8628). Interval=1 keeps the test
 	// runtime in milliseconds; the production default (5s when the
 	// server omits Interval) is exercised in a dedicated test.
-	f.mux.HandleFunc("/device", func(w http.ResponseWriter, _ *http.Request) {
+	f.mux.HandleFunc("/device", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		f.mu.Lock()
+		f.lastDeviceForm = r.Form
+		f.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(deviceCodeResponse{
 			DeviceCode:              f.deviceCode,
@@ -150,6 +158,7 @@ func (f *fakeAuthServer) wire() {
 			f.mu.Lock()
 			f.pollAttempts++
 			attempt := f.pollAttempts
+			f.lastTokenForm = r.Form
 			f.mu.Unlock()
 			if attempt <= f.authorizeAfter {
 				w.WriteHeader(http.StatusBadRequest)
@@ -167,6 +176,7 @@ func (f *fakeAuthServer) wire() {
 			// happened.
 			f.mu.Lock()
 			f.tokenIssued = "access-rotated-67890"
+			f.lastRefreshForm = r.Form
 			tok := f.tokenIssued
 			f.mu.Unlock()
 			_ = json.NewEncoder(w).Encode(tokenResponse{
@@ -272,6 +282,54 @@ func TestOAuth_RefreshOnExpiry(t *testing.T) {
 	}
 	if prompt.authorizations != 1 {
 		t.Errorf("refresh path should not re-prompt user; got %d prompts", prompt.authorizations)
+	}
+}
+
+// TestOAuth_SendsResourceAndScope guards against the audience-binding gap
+// that caused a fresh, otherwise-valid device-flow token to be rejected as
+// "401 unauthorized" by an audience-checking authorization server (RFC
+// 8707): the client must echo the protected-resource metadata's
+// "resource" and "scopes_supported" back to the AS on every device
+// authorization, token exchange, and refresh request — not just parse
+// them and discard them.
+func TestOAuth_SendsResourceAndScope(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	fs := newFakeAuthServer(t, 0)
+	defer fs.close()
+	fastPolling(t)
+
+	wantResource := fs.URL("/mcp_server/v1")
+	wantScope := "mcp:read mcp:write"
+
+	oc, _ := NewOAuthClient(wantResource, "fake", "octo-test", &stubPrompt{})
+	if _, err := oc.Token(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := fs.lastDeviceForm.Get("resource"); got != wantResource {
+		t.Errorf("device authorization resource = %q, want %q", got, wantResource)
+	}
+	if got := fs.lastDeviceForm.Get("scope"); got != wantScope {
+		t.Errorf("device authorization scope = %q, want %q", got, wantScope)
+	}
+	if got := fs.lastTokenForm.Get("resource"); got != wantResource {
+		t.Errorf("token exchange resource = %q, want %q", got, wantResource)
+	}
+	if got := fs.lastTokenForm.Get("scope"); got != wantScope {
+		t.Errorf("token exchange scope = %q, want %q", got, wantScope)
+	}
+
+	// Force a refresh and check the same params are re-sent.
+	oc.state.ExpiresAt = time.Now().Add(-1 * time.Hour)
+	if _, err := oc.Token(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := fs.lastRefreshForm.Get("resource"); got != wantResource {
+		t.Errorf("refresh resource = %q, want %q", got, wantResource)
+	}
+	if got := fs.lastRefreshForm.Get("scope"); got != wantScope {
+		t.Errorf("refresh scope = %q, want %q", got, wantScope)
 	}
 }
 

--- a/internal/mcp/oauth_test.go
+++ b/internal/mcp/oauth_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -44,15 +45,16 @@ type fakeAuthServer struct {
 	srv            *httptest.Server
 	authorizeAfter int
 
-	mu              sync.Mutex
-	pollAttempts    int
-	registrations   int
-	tokenIssued     string
-	refreshIssued   string
-	deviceCode      string
-	lastDeviceForm  url.Values
-	lastTokenForm   url.Values
-	lastRefreshForm url.Values
+	mu                sync.Mutex
+	pollAttempts      int
+	registrations     int
+	tokenIssued       string
+	refreshIssued     string
+	deviceCode        string
+	lastDeviceForm    url.Values
+	lastTokenForm     url.Values
+	lastRefreshForm   url.Values
+	lastRegisterScope string
 }
 
 func newFakeAuthServer(t *testing.T, authorizeAfter int) *fakeAuthServer {
@@ -117,8 +119,12 @@ func (f *fakeAuthServer) wire() {
 
 	// 4. Dynamic client registration (RFC 7591).
 	f.mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		scope, _ := body["scope"].(string)
 		f.mu.Lock()
 		f.registrations++
+		f.lastRegisterScope = scope
 		f.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -319,6 +325,9 @@ func TestOAuth_SendsResourceAndScope(t *testing.T) {
 	if got := fs.lastTokenForm.Get("scope"); got != wantScope {
 		t.Errorf("token exchange scope = %q, want %q", got, wantScope)
 	}
+	if got := fs.lastRegisterScope; got != wantScope {
+		t.Errorf("registration scope = %q, want %q", got, wantScope)
+	}
 
 	// Force a refresh and check the same params are re-sent.
 	oc.state.ExpiresAt = time.Now().Add(-1 * time.Hour)
@@ -330,6 +339,142 @@ func TestOAuth_SendsResourceAndScope(t *testing.T) {
 	}
 	if got := fs.lastRefreshForm.Get("scope"); got != wantScope {
 		t.Errorf("refresh scope = %q, want %q", got, wantScope)
+	}
+}
+
+// TestOAuth_StaleCacheWithoutResource_ForcesFreshAuth guards the upgrade
+// path: a cache written before RFC 8707 resource-binding was added has no
+// "resource" field, so its cached/refreshed access token was never bound
+// to this resource — exactly the token that produced the original 401.
+// Reusing or refreshing it after the fix ships would just reproduce the
+// bug for anyone who already hit it; the client must instead treat a
+// resource-less cache as stale and re-run the full device flow.
+func TestOAuth_StaleCacheWithoutResource_ForcesFreshAuth(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	fs := newFakeAuthServer(t, 0)
+	defer fs.close()
+	fastPolling(t)
+
+	prompt := &stubPrompt{}
+	oc, err := NewOAuthClient(fs.URL("/mcp_server/v1"), "fake", "octo-test", prompt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Pre-fix cache shape: valid-looking access + refresh token, no resource/scope.
+	legacy := `{
+		"resource_url": "` + fs.URL("/mcp_server/v1") + `",
+		"client_id": "legacy-client",
+		"access_token": "legacy-access-token",
+		"refresh_token": "legacy-refresh-token",
+		"expires_at": "` + time.Now().Add(1*time.Hour).Format(time.RFC3339) + `",
+		"token_url": "` + fs.URL("/token") + `"
+	}`
+	if err := os.WriteFile(oc.storePath, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tok, err := oc.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != fs.tokenIssued {
+		t.Errorf("token = %q, want fresh token %q (legacy cache should not be reused)", tok, fs.tokenIssued)
+	}
+	if prompt.authorizations != 1 {
+		t.Errorf("expected a fresh device-flow prompt for stale legacy cache, got %d", prompt.authorizations)
+	}
+	if oc.state.Resource == "" {
+		t.Error("expected Resource to be populated after re-authorize")
+	}
+}
+
+// TestOAuth_MissingResourceInMetadata_FallsBackToConfiguredURL covers the
+// case oauth.go's authorize() explicitly handles: a protected-resource
+// metadata document that omits "resource" (non-compliant but seen in the
+// wild). The client must fall back to the resource URL it was configured
+// with rather than sending an empty resource= or skipping the parameter.
+func TestOAuth_MissingResourceInMetadata_FallsBackToConfiguredURL(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	var mu sync.Mutex
+	var deviceForm, tokenForm url.Values
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Deliberately omit "resource".
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"authorization_servers": []string{srv.URL + "/auth"},
+		})
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server/auth", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(asMetadata{
+			TokenEndpoint:               srv.URL + "/token",
+			RegistrationEndpoint:        srv.URL + "/register",
+			DeviceAuthorizationEndpoint: srv.URL + "/device",
+		})
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"client_id": "client-1"})
+	})
+	mux.HandleFunc("/device", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		deviceForm = r.Form
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(deviceCodeResponse{
+			DeviceCode:      "dc-1",
+			UserCode:        "UC-1",
+			VerificationURI: srv.URL + "/auth",
+			ExpiresIn:       30,
+			Interval:        1,
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		tokenForm = r.Form
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken: "tok-1",
+			TokenType:   "Bearer",
+			ExpiresIn:   3600,
+		})
+	})
+
+	resourceURL := srv.URL + "/mcp_server/v1"
+	oc, err := NewOAuthClient(resourceURL, "fake-noresource", "octo-test", &stubPrompt{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := oc.Token(ctx); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := deviceForm.Get("resource"); got != resourceURL {
+		t.Errorf("device authorization resource = %q, want fallback %q", got, resourceURL)
+	}
+	if got := tokenForm.Get("resource"); got != resourceURL {
+		t.Errorf("token exchange resource = %q, want fallback %q", got, resourceURL)
+	}
+	if oc.state.Resource != resourceURL {
+		t.Errorf("cached Resource = %q, want fallback %q", oc.state.Resource, resourceURL)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The MCP device-flow OAuth client parsed the RFC 9728 protected-resource metadata's `resource` field but never sent it to the authorization server on any request — device authorization, token exchange, or refresh all omitted it, and `scopes_supported` was never requested as `scope` either.
- Against an audience-checking authorization server (this surfaced against the meegle/Lark project MCP endpoint), that means the client completes the full device-flow dance and gets back a token, but the token isn't bound to `https://project.larksuite.com/mcp_server/v1` — so the very first `initialize` call 401s with `{"error":"unauthorized"}` even though the token is brand new and the `Authorization: Bearer` header is set correctly.
- Fix: thread `resource` (and `scope`, from `scopes_supported`) through `authorize()` → `deviceFlow()`/`startDevice()`, the device-code token exchange, `register()`, and `refresh()`. Persist both in the cached `oauthState` so a refresh keeps requesting the same grant.

## Test plan
- [x] `go test ./internal/mcp/...` — all OAuth tests pass, including a new `TestOAuth_SendsResourceAndScope` regression test asserting `resource=`/`scope=` are present on the device-authorization, token-exchange, and refresh requests
- [x] `go vet ./...` and `gofmt -l .` clean
- [x] `go test -race ./...` — full suite green (one pre-existing, unrelated `cmd/octo` status-bar test fails only when run from this deeply-nested worktree path due to path-length truncation; verified it passes on the primary checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)