### PR TITLE
fix(mcp): surface OAuth reauth-required as panel status

### DIFF
--- a/internal/mcp/oauth.go
+++ b/internal/mcp/oauth.go
@@ -188,9 +188,23 @@ func (o *OAuthClient) Invalidate() {
 	}
 }
 
+// ErrReauthRequired is returned by authorize (and therefore Token) when the
+// cached/refreshed token is unusable and completing the device flow needs a
+// human — but no OAuthPrompt was supplied. Background connections (startup,
+// reload, panel-triggered reconnect) all construct their OAuthClient with a
+// nil prompt, since nobody is present to see a verification code. Without
+// this check, authorize would still run the full device flow and poll
+// silently for up to 5 minutes before timing out with a generic error;
+// callers can check for this sentinel via errors.Is to detect "this
+// connection needs an interactive re-authorization" without waiting.
+var ErrReauthRequired = errors.New("oauth: interactive re-authorization required")
+
 // authorize runs the full discovery + (maybe register) + device flow.
 // Caller holds o.mu.
 func (o *OAuthClient) authorize(ctx context.Context) error {
+	if o.prompt == nil {
+		return ErrReauthRequired
+	}
 	asMeta, prMeta, err := o.discover(ctx)
 	if err != nil {
 		return err

--- a/internal/mcp/oauth_test.go
+++ b/internal/mcp/oauth_test.go
@@ -478,6 +478,40 @@ func TestOAuth_MissingResourceInMetadata_FallsBackToConfiguredURL(t *testing.T) 
 	}
 }
 
+// TestOAuth_NilPrompt_FailsFastWithoutPolling guards the fast-fail path for
+// a connection that needs interactive re-authorization but has no
+// OAuthPrompt — every background connect path (startup, reload, panel
+// enable-toggle) constructs its OAuthClient this way, since nobody is
+// present to see a verification code. Before this check, authorize() would
+// still run discovery/registration and poll the device-flow endpoint
+// silently for up to 5 minutes before timing out with a generic error.
+func TestOAuth_NilPrompt_FailsFastWithoutPolling(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	fs := newFakeAuthServer(t, 0)
+	defer fs.close()
+
+	oc, err := NewOAuthClient(fs.URL("/mcp_server/v1"), "fake-noprompt", "octo-test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	_, err = oc.Token(context.Background())
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrReauthRequired) {
+		t.Fatalf("Token error = %v, want ErrReauthRequired", err)
+	}
+	if elapsed > time.Second {
+		t.Errorf("Token took %v, want a near-instant fast-fail (no device-flow polling)", elapsed)
+	}
+	if fs.registrations != 0 {
+		t.Errorf("registrations = %d, want 0 — no prompt means no point attempting discovery/registration", fs.registrations)
+	}
+}
+
 func TestOAuth_InvalidateForces_FreshAuth(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -39,6 +39,36 @@ type Connection struct {
 	Tools     []Tool
 	Resources []Resource
 	Prompts   []Prompt
+
+	// reauthMu guards reauthErr, set by MarkReauthRequired when a call made
+	// through this (otherwise still "live") connection surfaces
+	// ErrReauthRequired — the OAuth token died and nobody was present to
+	// complete an interactive device flow. The connection object itself
+	// stays usable/registered; this flag is how a caller with visibility
+	// into Registry (e.g. the status endpoint) learns the connection is no
+	// longer actually authenticated without waiting for it to be torn down.
+	reauthMu  sync.Mutex
+	reauthErr error
+}
+
+// MarkReauthRequired records that a call through this connection hit
+// ErrReauthRequired. Safe for concurrent callers.
+func (c *Connection) MarkReauthRequired(err error) {
+	c.reauthMu.Lock()
+	c.reauthErr = err
+	c.reauthMu.Unlock()
+}
+
+// ReauthRequired reports the last error recorded by MarkReauthRequired, if
+// any. ok is false when no reauth failure has been observed on this
+// connection.
+func (c *Connection) ReauthRequired() (msg string, ok bool) {
+	c.reauthMu.Lock()
+	defer c.reauthMu.Unlock()
+	if c.reauthErr == nil {
+		return "", false
+	}
+	return c.reauthErr.Error(), true
 }
 
 // ConnectAll spins up one client per configured server, runs the

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -59,6 +59,18 @@ func (c *Connection) MarkReauthRequired(err error) {
 	c.reauthMu.Unlock()
 }
 
+// ClearReauthRequired forgets a previously recorded reauth failure. Callers
+// invoke this after a call through the connection succeeds, so a
+// transient failure (a momentary refresh hiccup, not a genuinely revoked
+// grant) doesn't leave the panel reporting "error" forever once the
+// connection is actually working again — the token is either still good
+// or a later real failure will re-flag it.
+func (c *Connection) ClearReauthRequired() {
+	c.reauthMu.Lock()
+	c.reauthErr = nil
+	c.reauthMu.Unlock()
+}
+
 // ReauthRequired reports the last error recorded by MarkReauthRequired, if
 // any. ok is false when no reauth failure has been observed on this
 // connection.

--- a/internal/mcp/registry_manage_test.go
+++ b/internal/mcp/registry_manage_test.go
@@ -130,6 +130,39 @@ func TestRegistryRemove(t *testing.T) {
 	r.Remove("fake") // unknown name: no-op, no panic
 }
 
+func TestConnection_ReauthRequired_RoundTrip(t *testing.T) {
+	srv := fakeMCPServer(t, "ping")
+	defer srv.Close()
+
+	r := NewRegistry()
+	defer r.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := r.Connect(ctx, "fake", ServerEntry{URL: srv.URL}, Implementation{Name: "test"}, nil, nil); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	conn := r.Get("fake")
+	if _, ok := conn.ReauthRequired(); ok {
+		t.Fatal("freshly connected connection must not report reauth required")
+	}
+
+	conn.MarkReauthRequired(ErrReauthRequired)
+	msg, ok := conn.ReauthRequired()
+	if !ok || msg == "" {
+		t.Fatalf("ReauthRequired = (%q, %v), want recorded error", msg, ok)
+	}
+
+	// A brand-new connection (as installed by a successful re-authorize)
+	// starts clean regardless of what the old one recorded.
+	if err := r.Connect(ctx, "fake", ServerEntry{URL: srv.URL}, Implementation{Name: "test"}, nil, nil); err != nil {
+		t.Fatalf("reconnect: %v", err)
+	}
+	if _, ok := r.Get("fake").ReauthRequired(); ok {
+		t.Error("a fresh connection replacing a flagged one must not inherit the flag")
+	}
+}
+
 func TestRegistryConnect_AfterCloseRejected(t *testing.T) {
 	srv := fakeMCPServer(t)
 	defer srv.Close()

--- a/internal/server/mcp_handlers.go
+++ b/internal/server/mcp_handlers.go
@@ -111,8 +111,18 @@ func (s *Server) mcpServerList() ([]mcpServerInfo, error) {
 		case m.Entry.Disabled:
 			info.Status = "disabled"
 		case reg != nil && reg.Get(m.Name) != nil:
-			info.Status = "connected"
-			info.Tools = len(reg.Get(m.Name).Tools)
+			conn := reg.Get(m.Name)
+			if msg, ok := conn.ReauthRequired(); ok {
+				// Connection is still registered but a call through it hit
+				// an OAuth failure nobody was present to fix — report it as
+				// an error so the panel's Authorize/Reconnect controls
+				// unlock instead of showing a falsely healthy "connected".
+				info.Status = "error"
+				info.Error = msg
+			} else {
+				info.Status = "connected"
+				info.Tools = len(conn.Tools)
+			}
 		default:
 			info.Status = "disconnected"
 			if reg != nil {
@@ -201,9 +211,14 @@ func (s *Server) handleGetMCPServer(w http.ResponseWriter, r *http.Request) {
 	default:
 		reg := tools.ActiveMCPRegistry()
 		if reg != nil && reg.Get(name) != nil {
-			info.Status = "connected"
 			conn := reg.Get(name)
-			info.Tools = len(conn.Tools)
+			if msg, ok := conn.ReauthRequired(); ok {
+				info.Status = "error"
+				info.Error = msg
+			} else {
+				info.Status = "connected"
+				info.Tools = len(conn.Tools)
+			}
 		} else {
 			info.Status = "disconnected"
 			if reg != nil {

--- a/internal/server/mcp_handlers.go
+++ b/internal/server/mcp_handlers.go
@@ -105,13 +105,16 @@ func (s *Server) mcpServerList() ([]mcpServerInfo, error) {
 			Headers:   m.Entry.Headers,
 			Auth:      m.Entry.Auth,
 		}
+		var conn *mcp.Connection
+		if reg != nil {
+			conn = reg.Get(m.Name)
+		}
 		switch {
 		case m.Invalid != "":
 			info.Status = "invalid"
 		case m.Entry.Disabled:
 			info.Status = "disabled"
-		case reg != nil && reg.Get(m.Name) != nil:
-			conn := reg.Get(m.Name)
+		case conn != nil:
 			if msg, ok := conn.ReauthRequired(); ok {
 				// Connection is still registered but a call through it hit
 				// an OAuth failure nobody was present to fix — report it as
@@ -210,8 +213,11 @@ func (s *Server) handleGetMCPServer(w http.ResponseWriter, r *http.Request) {
 		info.Status = "disabled"
 	default:
 		reg := tools.ActiveMCPRegistry()
-		if reg != nil && reg.Get(name) != nil {
-			conn := reg.Get(name)
+		var conn *mcp.Connection
+		if reg != nil {
+			conn = reg.Get(name)
+		}
+		if conn != nil {
 			if msg, ok := conn.ReauthRequired(); ok {
 				info.Status = "error"
 				info.Error = msg

--- a/internal/server/mcp_handlers_test.go
+++ b/internal/server/mcp_handlers_test.go
@@ -335,7 +335,7 @@ func TestMCPLifecycle_ReauthRequiredSurfacesAsError(t *testing.T) {
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
 
 	w := doJSON(t, srv, http.MethodPost, "/api/mcp/servers",
-		`{"name": "live", "server": {"url": "`+fake.URL+`"}}`)
+		`{"mcpServers": {"live": {"url": "`+fake.URL+`"}}}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("create: status = %d: %s", w.Code, w.Body.String())
 	}

--- a/internal/server/mcp_handlers_test.go
+++ b/internal/server/mcp_handlers_test.go
@@ -316,6 +316,61 @@ func TestMCPLiveConnect_FailureSurfacesAsStatus(t *testing.T) {
 	}
 }
 
+// TestMCPLifecycle_ReauthRequiredSurfacesAsError guards the panel-visible
+// side of the reauth fix: a connection that's still registered as "live"
+// but got flagged by MarkReauthRequired (because a tool call through it hit
+// mcp.ErrReauthRequired — the OAuth token died and nobody was present to
+// fix it interactively) must report as "error", not a falsely healthy
+// "connected", on both the list and single-server endpoints. Without this,
+// the panel's Authorize/Reconnect controls (gated on status != "connected")
+// would stay hidden/disabled forever.
+func TestMCPLifecycle_ReauthRequiredSurfacesAsError(t *testing.T) {
+	mcpTestHome(t, "")
+	t.Cleanup(app.ShutdownMCP)
+	tools.SetMCPRegistry(nil)
+
+	fake := fakeMCPServerForHandlers(t)
+	defer fake.Close()
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
+
+	w := doJSON(t, srv, http.MethodPost, "/api/mcp/servers",
+		`{"name": "live", "server": {"url": "`+fake.URL+`"}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create: status = %d: %s", w.Code, w.Body.String())
+	}
+	if servers := decodeServers(t, w); servers[0].Status != "connected" {
+		t.Fatalf("after create: %+v", servers[0])
+	}
+
+	conn := tools.ActiveMCPRegistry().Get("live")
+	if conn == nil {
+		t.Fatal("expected a live connection")
+	}
+	conn.MarkReauthRequired(mcp.ErrReauthRequired)
+
+	w = doJSON(t, srv, http.MethodGet, "/api/mcp/servers", "")
+	servers := decodeServers(t, w)
+	if servers[0].Status != "error" || servers[0].Error == "" {
+		t.Fatalf("list after MarkReauthRequired: %+v", servers[0])
+	}
+
+	w = doJSON(t, srv, http.MethodGet, "/api/mcp/servers/live", "")
+	var detail mcpServerDetail
+	if err := json.Unmarshal(w.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode: %v (body: %s)", err, w.Body.String())
+	}
+	if detail.Status != "error" || detail.Error == "" {
+		t.Fatalf("single-server get after MarkReauthRequired: %+v", detail)
+	}
+	// The connection itself must still be registered — this is a "live but
+	// unauthenticated" state, not a torn-down one; the Authorize button's
+	// re-auth flow needs the still-live registry entry to replace.
+	if tools.ActiveMCPRegistry().Get("live") == nil {
+		t.Error("MarkReauthRequired must not remove the connection from the registry")
+	}
+}
+
 func TestHandleGetMCPServer(t *testing.T) {
 	mcpTestHome(t, `{"mcpServers": {
 		"alpha": {"command": "echo"},

--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -146,6 +147,7 @@ func executeMCP(ctx context.Context, name string, input map[string]any) (out str
 		}
 		contents, err := conn.Client.ReadResource(ctx, uri)
 		if err != nil {
+			markIfReauthRequired(conn, err)
 			return "", true, err
 		}
 		return formatResourceContents(contents), true, nil
@@ -158,6 +160,7 @@ func executeMCP(ctx context.Context, name string, input map[string]any) (out str
 		argMap := convertStringMap(input["arguments"])
 		result, err := conn.Client.GetPrompt(ctx, promptName, argMap)
 		if err != nil {
+			markIfReauthRequired(conn, err)
 			return "", true, err
 		}
 		return formatPromptResult(result), true, nil
@@ -165,6 +168,7 @@ func executeMCP(ctx context.Context, name string, input map[string]any) (out str
 	default:
 		result, err := conn.Client.CallTool(ctx, tool, input)
 		if err != nil {
+			markIfReauthRequired(conn, err)
 			return "", true, err
 		}
 		out := formatToolResult(result)
@@ -175,6 +179,18 @@ func executeMCP(ctx context.Context, name string, input map[string]any) (out str
 			return out, true, fmt.Errorf("mcp tool error: %s", out)
 		}
 		return out, true, nil
+	}
+}
+
+// markIfReauthRequired flags conn when a call through it failed because its
+// OAuth token died and no interactive prompt was available to fix it (see
+// mcp.ErrReauthRequired). This is the only place that failure becomes
+// visible outside the tool call itself — the connection stays registered
+// and "live" otherwise, so without this the Web panel and CLI would keep
+// reporting it as connected indefinitely.
+func markIfReauthRequired(conn *mcp.Connection, err error) {
+	if errors.Is(err, mcp.ErrReauthRequired) {
+		conn.MarkReauthRequired(err)
 	}
 }
 

--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -150,6 +150,7 @@ func executeMCP(ctx context.Context, name string, input map[string]any) (out str
 			markIfReauthRequired(conn, err)
 			return "", true, err
 		}
+		conn.ClearReauthRequired()
 		return formatResourceContents(contents), true, nil
 
 	case "prompt_get":
@@ -163,6 +164,7 @@ func executeMCP(ctx context.Context, name string, input map[string]any) (out str
 			markIfReauthRequired(conn, err)
 			return "", true, err
 		}
+		conn.ClearReauthRequired()
 		return formatPromptResult(result), true, nil
 
 	default:
@@ -171,6 +173,7 @@ func executeMCP(ctx context.Context, name string, input map[string]any) (out str
 			markIfReauthRequired(conn, err)
 			return "", true, err
 		}
+		conn.ClearReauthRequired()
 		out := formatToolResult(result)
 		if result.IsError {
 			// The tool ran but reported an error in-band. Surface it as a

--- a/internal/tools/mcp_test.go
+++ b/internal/tools/mcp_test.go
@@ -1,6 +1,8 @@
 package tools
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -93,5 +95,38 @@ func TestMCPToolDefs_NilRegistryYieldsNone(t *testing.T) {
 	defer SetMCPRegistry(nil)
 	if defs := mcpToolDefs(); len(defs) != 0 {
 		t.Errorf("expected empty defs with no registry, got %d", len(defs))
+	}
+}
+
+func TestMarkIfReauthRequired_FlagsOnlyReauthErrors(t *testing.T) {
+	conn := &mcp.Connection{Name: "fake"}
+
+	markIfReauthRequired(conn, errors.New("some unrelated tool error"))
+	if _, ok := conn.ReauthRequired(); ok {
+		t.Error("a plain error must not flag the connection")
+	}
+
+	markIfReauthRequired(conn, mcp.ErrReauthRequired)
+	msg, ok := conn.ReauthRequired()
+	if !ok || msg == "" {
+		t.Fatalf("ReauthRequired = (%q, %v), want recorded error", msg, ok)
+	}
+
+	// A properly %w-wrapped error (matching how http.go's doRequest reports
+	// it: "mcp: oauth token: %w") must still be detected via errors.Is.
+	conn2 := &mcp.Connection{Name: "fake2"}
+	wrapped := fmt.Errorf("mcp: oauth token: %w", mcp.ErrReauthRequired)
+	markIfReauthRequired(conn2, wrapped)
+	if _, ok := conn2.ReauthRequired(); !ok {
+		t.Error("a %w-wrapped ErrReauthRequired must flag the connection")
+	}
+
+	// A merely string-matching but non-wrapped error must NOT match —
+	// guards against a naive strings.Contains-based implementation.
+	conn3 := &mcp.Connection{Name: "fake3"}
+	stringMatch := errors.New("mcp: oauth token: " + mcp.ErrReauthRequired.Error())
+	markIfReauthRequired(conn3, stringMatch)
+	if _, ok := conn3.ReauthRequired(); ok {
+		t.Error("a string-matching but non-wrapped error must not flag the connection")
 	}
 }

--- a/internal/tools/mcp_test.go
+++ b/internal/tools/mcp_test.go
@@ -1,10 +1,16 @@
 package tools
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/open-octo/octo-agent/internal/mcp"
 )
@@ -128,5 +134,77 @@ func TestMarkIfReauthRequired_FlagsOnlyReauthErrors(t *testing.T) {
 	markIfReauthRequired(conn3, stringMatch)
 	if _, ok := conn3.ReauthRequired(); ok {
 		t.Error("a string-matching but non-wrapped error must not flag the connection")
+	}
+}
+
+// fakeMCPServerForExecuteMCP speaks just enough JSON-RPC-over-HTTP for
+// executeMCP's default (tools/call) branch to succeed.
+func fakeMCPServerForExecuteMCP(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var in mcp.Message
+		_ = json.Unmarshal(body, &in)
+		if in.ID == nil {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		var result any
+		switch in.Method {
+		case "initialize":
+			result = mcp.InitializeResult{
+				ProtocolVersion: mcp.ProtocolVersion,
+				Capabilities:    mcp.ServerCapabilities{Tools: &mcp.ToolsCapability{}},
+				ServerInfo:      mcp.Implementation{Name: "fake", Version: "0"},
+			}
+		case "tools/list":
+			result = map[string]any{"tools": []mcp.Tool{{Name: "ping", InputSchema: json.RawMessage(`{"type":"object"}`)}}}
+		case "tools/call":
+			result = mcp.CallToolResult{Content: []mcp.Content{{Type: "text", Text: "pong"}}}
+		default:
+			result = map[string]any{}
+		}
+		raw, _ := json.Marshal(result)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mcp.Message{JSONRPC: "2.0", ID: in.ID, Result: raw})
+	}))
+}
+
+// TestExecuteMCP_SuccessfulCallClearsReauthFlag guards the self-heal half of
+// the reauth-status fix: a connection previously flagged by
+// MarkReauthRequired (e.g. from a transient refresh hiccup, not a
+// genuinely revoked grant) must not be stuck reporting "error" forever —
+// a subsequent successful call through the same *Connection has to clear
+// the flag, or the panel would show a falsely unhealthy connection
+// indefinitely even after the underlying issue resolved on its own.
+func TestExecuteMCP_SuccessfulCallClearsReauthFlag(t *testing.T) {
+	srv := fakeMCPServerForExecuteMCP(t)
+	defer srv.Close()
+
+	reg := mcp.NewRegistry()
+	defer reg.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := reg.Connect(ctx, "srv", mcp.ServerEntry{URL: srv.URL}, mcp.Implementation{Name: "test"}, nil, nil); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	SetMCPRegistry(reg)
+	defer SetMCPRegistry(nil)
+
+	conn := reg.Get("srv")
+	conn.MarkReauthRequired(mcp.ErrReauthRequired)
+	if _, ok := conn.ReauthRequired(); !ok {
+		t.Fatal("setup: expected connection to be pre-flagged")
+	}
+
+	out, ok, err := executeMCP(ctx, "mcp__srv__ping", map[string]any{})
+	if !ok {
+		t.Fatal("expected executeMCP to recognize the mcp__ tool name")
+	}
+	if err != nil {
+		t.Fatalf("executeMCP: %v (out=%q)", err, out)
+	}
+	if _, ok := conn.ReauthRequired(); ok {
+		t.Error("a successful call through the connection must clear the reauth flag")
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #1234 (RFC 8707 resource-binding fix). Answering "after a token expires, can the user re-authorize from the Web panel?" surfaced a real gap: when a live connection's OAuth token dies past the point a silent refresh can fix (refresh token revoked/expired), the panel had no way to let the user re-authorize.

- Background connect paths (startup, reload, panel enable-toggle, Reconnect) all build their `OAuthClient` with a `nil` `OAuthPrompt` — nobody is present to see a device-flow code. Before this change, hitting that case mid-connection made `authorize()` still run discovery/registration and poll the device-flow endpoint silently for up to 5 minutes before timing out with a generic error, and the failure never reached the `Registry` — the connection stayed registered as "live" and the panel kept reporting a falsely healthy `connected`, with the Authorize button hidden and Reconnect disabled (both gated on `status != "connected"`).
- `internal/mcp/oauth.go`: `authorize()` now returns a new `ErrReauthRequired` sentinel immediately when `o.prompt == nil`, instead of hanging.
- `internal/mcp/registry.go`: `Connection` gains `MarkReauthRequired`/`ReauthRequired` so code outside the tool-call stack (the status endpoint) can learn a "live" connection's auth actually died.
- `internal/tools/mcp.go`: the three MCP dispatch call sites (`resource_read`, `prompt_get`, tool call) flag the connection via a new `markIfReauthRequired` helper when a call surfaces `ErrReauthRequired`.
- `internal/server/mcp_handlers.go`: list/get status computation reports `"error"` for a flagged connection — reusing the existing status value, so the panel's existing Authorize/Reconnect gating unlocks with **zero frontend changes**.

Known limitation (documented in code, not fixed here): detection is lazy — it only happens on the next actual tool call through that server, not via active polling. A background health-checker was considered and rejected as disproportionate (added complexity + AS rate-limit risk) for this fix's scope.

## Test plan
- [x] `internal/mcp`: `TestOAuth_NilPrompt_FailsFastWithoutPolling` (fails immediately with `ErrReauthRequired`, zero discovery/registration calls), `TestConnection_ReauthRequired_RoundTrip`
- [x] `internal/tools`: `TestMarkIfReauthRequired_FlagsOnlyReauthErrors` (real `%w`-wrapped match, plain-error and string-match-but-unwrapped negatives)
- [x] `internal/server`: `TestMCPLifecycle_ReauthRequiredSurfacesAsError` (list + single-server endpoints both flip to `error` with a message; connection stays registered)
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test -race ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)