### PR TITLE
fix(skills): map invalid-skill-content errors to 400 instead of 500

### DIFF
--- a/internal/server/skill_import_handler.go
+++ b/internal/server/skill_import_handler.go
@@ -42,7 +42,7 @@ func (s *Server) handleImportSkill(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, skills.ErrExists):
 			writeError(w, http.StatusConflict, err.Error())
-		case errors.Is(err, errBadImportSource):
+		case errors.Is(err, errBadImportSource), errors.Is(err, skills.ErrInvalidSkill):
 			writeError(w, http.StatusBadRequest, err.Error())
 		default:
 			writeError(w, http.StatusInternalServerError, err.Error())

--- a/internal/server/skill_import_handler_test.go
+++ b/internal/server/skill_import_handler_test.go
@@ -120,6 +120,42 @@ func TestHandleImportSkill_LocalDir(t *testing.T) {
 	}
 }
 
+// TestHandleImportSkill_InvalidZipContent covers #1236: an uploaded zip that
+// isn't a skill (no SKILL.md) is a client mistake, not a server failure, so
+// it must map to 400 rather than 500.
+func TestHandleImportSkill_InvalidZipContent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	uploadsDir := filepath.Join(tmp, ".octo", "uploads")
+	if err := os.MkdirAll(uploadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("readme.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("not a skill")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	base := "not_a_skill.zip"
+	if err := os.WriteFile(filepath.Join(uploadsDir, base), buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	w2 := postImport(t, srv, `{"source":"/api/uploads/`+base+`"}`)
+	if w2.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w2.Code, w2.Body.String())
+	}
+}
+
 func TestHandleImportSkill_BadSources(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -143,6 +143,12 @@ func Install(src Source, destRoot string, force bool) (name, desc string, err er
 // --force hint, the web API maps it to HTTP 409.
 var ErrExists = fmt.Errorf("skill already exists")
 
+// ErrInvalidSkill reports that the source content itself isn't a valid
+// skill (no SKILL.md, missing frontmatter, malformed archive) as opposed to
+// an install-time I/O failure. Callers branch on it: the web API maps it to
+// HTTP 400 rather than 500, since the fix is a different source, not a retry.
+var ErrInvalidSkill = fmt.Errorf("invalid skill")
+
 // placeStaged validates a fully-staged skill directory (tmp must contain
 // SKILL.md) and renames it to destRoot/<name>. The name comes from the
 // SKILL.md frontmatter, falling back to fallbackName. Shared by the GitHub,
@@ -150,18 +156,18 @@ var ErrExists = fmt.Errorf("skill already exists")
 func placeStaged(tmp, destRoot, fallbackName string, force bool) (name, desc string, err error) {
 	b, err := os.ReadFile(filepath.Join(tmp, SkillFile))
 	if err != nil {
-		return "", "", fmt.Errorf("no readable %s — not a skill directory", SkillFile)
+		return "", "", fmt.Errorf("%w: no readable %s — not a skill directory", ErrInvalidSkill, SkillFile)
 	}
 	fmName, fmDesc, ok := parseNamed(b)
 	if !ok || fmDesc == "" {
-		return "", "", fmt.Errorf("%s is missing frontmatter name/description", SkillFile)
+		return "", "", fmt.Errorf("%w: %s is missing frontmatter name/description", ErrInvalidSkill, SkillFile)
 	}
 	name = fmName
 	if name == "" {
 		name = fallbackName
 	}
 	if name == "" || name == "." || name == "/" {
-		return "", "", fmt.Errorf("cannot determine a skill name")
+		return "", "", fmt.Errorf("%w: cannot determine a skill name", ErrInvalidSkill)
 	}
 
 	dest := filepath.Join(destRoot, name)
@@ -258,7 +264,7 @@ func extractSubdir(r io.Reader, subpath, dest string) error {
 		found = true
 	}
 	if !found {
-		return fmt.Errorf("no files found under %q in the repository tarball", subpath)
+		return fmt.Errorf("%w: no files found under %q in the repository tarball", ErrInvalidSkill, subpath)
 	}
 	return nil
 }

--- a/internal/skills/install_local.go
+++ b/internal/skills/install_local.go
@@ -19,7 +19,7 @@ import (
 func InstallZip(zipPath, destRoot string, force bool) (name, desc string, err error) {
 	zr, err := zip.OpenReader(zipPath)
 	if err != nil {
-		return "", "", fmt.Errorf("open %s: %w", zipPath, err)
+		return "", "", fmt.Errorf("%w: open %s: %v", ErrInvalidSkill, zipPath, err)
 	}
 	defer zr.Close()
 
@@ -78,7 +78,7 @@ func zipSkillPrefix(zr *zip.Reader) (string, error) {
 			return dir, nil
 		}
 	}
-	return "", fmt.Errorf("no %s at the archive root or in a single top-level folder", SkillFile)
+	return "", fmt.Errorf("%w: no %s at the archive root or in a single top-level folder", ErrInvalidSkill, SkillFile)
 }
 
 func writeZipEntry(f *zip.File, target string) error {


### PR DESCRIPTION
## Summary
- Importing an uploaded/local zip (or GitHub source) that isn't a valid skill — no `SKILL.md`, missing frontmatter, a corrupt archive — surfaced as a generic HTTP 500 from `/api/skills/import`, even though the problem is the source content, not the server.
- Adds `skills.ErrInvalidSkill`, wraps it into the relevant validation errors in `internal/skills/install.go` and `install_local.go`, and has `handleImportSkill` map it to HTTP 400 alongside the existing `errBadImportSource` case.

## Root cause
The uploaded file in #1236 was a zip without a `SKILL.md` at its root or in a single top-level folder. `zipSkillPrefix` correctly rejected it, but the resulting error wasn't recognized by `handleImportSkill`'s error switch, so it fell through to the 500 default branch.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/skills/... ./internal/server/...`
- [x] Added `TestHandleImportSkill_InvalidZipContent`, reproducing #1236 (uploads a zip with no `SKILL.md`), asserting 400 instead of 500.

Fixes #1236