### PR TITLE
fix(server): stop working_dir PATCH leaking raw stat errors

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -1278,12 +1279,18 @@ func (s *Server) handleUpdateSessionWorkingDir(w http.ResponseWriter, r *http.Re
 
 	dir := expandDir(req.WorkingDir)
 	info, err := os.Stat(dir)
-	if os.IsNotExist(err) {
+	switch {
+	case os.IsNotExist(err):
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("working_dir does not exist: %s (create it first)", dir))
 		return
-	}
-	if err != nil {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid working_dir: %v", err))
+	case os.IsPermission(err):
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("working_dir is not accessible: %s (permission denied)", dir))
+		return
+	case err != nil:
+		// Neither IsNotExist nor IsPermission — e.g. a path component that
+		// exists but isn't a directory (ENOTDIR). Report the reason without
+		// the raw "stat <path>:" prefix, which just repeats dir.
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid working_dir: %s (%v)", dir, unwrapPathError(err)))
 		return
 	}
 	if !info.IsDir() {
@@ -1326,6 +1333,16 @@ func (s *Server) handleUpdateSessionWorkingDir(w http.ResponseWriter, r *http.Re
 		"ok":          true,
 		"working_dir": dir,
 	})
+}
+
+// unwrapPathError strips the "stat <path>:" wrapper os.Stat adds so the
+// error message doesn't repeat the path the caller already reports.
+func unwrapPathError(err error) error {
+	var pe *fs.PathError
+	if errors.As(err, &pe) {
+		return pe.Err
+	}
+	return err
 }
 
 // expandDir resolves a user-entered path to an absolute one: a leading ~ (or

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1436,6 +1436,47 @@ func TestHandleUpdateSessionWorkingDir_NotExist(t *testing.T) {
 	}
 }
 
+func TestHandleUpdateSessionWorkingDir_NotADirectory(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	// A regular file sitting where a directory component is expected trips
+	// ENOTDIR, which os.IsNotExist does not recognize (#1237) — the handler
+	// must still report a clean message instead of a raw "stat ...: not a
+	// directory" dump.
+	filePath := filepath.Join(tmp, "not-a-dir")
+	if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(filePath, "child")
+
+	payload, _ := json.Marshal(updateSessionWorkingDirRequest{WorkingDir: nested})
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/"+sess.ID+"/working_dir", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	errMsg, _ := body["error"].(string)
+	if !strings.Contains(errMsg, nested) || strings.Contains(errMsg, "stat "+nested) {
+		t.Fatalf("error = %q, want it to name %q without echoing the raw stat prefix", errMsg, nested)
+	}
+}
+
 func TestHandleUpdateSessionModel_RawStringIsPerSession(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)


### PR DESCRIPTION
## Summary
- `handleUpdateSessionWorkingDir` only special-cased `os.IsNotExist(err)`; a path with a non-directory component (ENOTDIR) or a permission error (EACCES) fell through to a branch that returned the raw `stat <path>: ...` Go error string as-is.
- Verified locally: `os.Stat` on a path through a file component returns `"not a directory"`, and on a permission-denied dir returns `"permission denied"` — neither satisfies `os.IsNotExist`.
- Adds an `os.IsPermission` branch and strips the redundant `stat <path>:` prefix from the remaining generic branch via a new `unwrapPathError` helper.

Closes #1237 (the screenshot in that issue shows this exact raw-stat-error response for a `working_dir` PATCH attempt — the visible failure is a 400, not the 404 in the issue title; I couldn't find a code path today where the session file itself is missing for an actively-open session, so this PR only fixes the confirmable defect).

## Test plan
- [x] `go test ./internal/server/... -run TestHandleUpdateSessionWorkingDir -v`
- [x] `go test -race ./internal/server/...`
- [x] `gofmt -l` / `go vet ./internal/server/...`