### PR TITLE
fix: resolve symlinks when comparing cwd to home for scope labeling

### DIFF
--- a/internal/mcp/manage.go
+++ b/internal/mcp/manage.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/open-octo/octo-agent/internal/pathutil"
 )
 
 // This file is the management view of the MCP config — what a settings UI
@@ -53,12 +55,13 @@ func LoadManaged(projectDir string) ([]ManagedServer, error) {
 	}
 
 	// If the server's cwd is the home directory itself (e.g. `octo serve`
-	// launched from ~), this resolves to the exact same file as userPath —
-	// re-reading it here would relabel every entry "project" and make a
-	// perfectly normal user config look read-only in the management UI.
+	// launched from ~, even through a symlinked $HOME), this resolves to the
+	// exact same file as userPath — re-reading it here would relabel every
+	// entry "project" and make a perfectly normal user config look read-only
+	// in the management UI.
 	if projectDir != "" {
 		projectPath := filepath.Join(projectDir, ".octo", "mcp.json")
-		if projectPath != userPath {
+		if !pathutil.SameDir(projectPath, userPath) {
 			cfg, err := readConfigFile(projectPath)
 			if err != nil {
 				return nil, err

--- a/internal/mcp/manage_test.go
+++ b/internal/mcp/manage_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -96,6 +97,38 @@ func TestLoadManaged_ProjectDirIsHome(t *testing.T) {
 	}
 	if managed[0].Source != "user" {
 		t.Errorf("source = %q, want user (cwd == home must not double-count as project)", managed[0].Source)
+	}
+}
+
+// Same collision as TestLoadManaged_ProjectDirIsHome, but $HOME is reached
+// through a symlink (e.g. a network home mount) while projectDir is passed as
+// the resolved real path — the raw string comparison this guards against
+// would see two different strings for the same directory.
+func TestLoadManaged_ProjectDirIsHome_ThroughSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on windows")
+	}
+	real := t.TempDir()
+	root := t.TempDir()
+	link := filepath.Join(root, "home-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	t.Setenv("HOME", link)
+	t.Setenv("USERPROFILE", link)
+	writeMCPFile(t, link, `{"mcpServers": {
+		"codegraph": {"command": "codegraph"}
+	}}`)
+
+	managed, err := LoadManaged(real)
+	if err != nil {
+		t.Fatalf("LoadManaged: %v", err)
+	}
+	if len(managed) != 1 {
+		t.Fatalf("got %d entries, want 1: %+v", len(managed), managed)
+	}
+	if managed[0].Source != "user" {
+		t.Errorf("source = %q, want user (symlinked home == cwd must not double-count as project)", managed[0].Source)
 	}
 }
 

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -1,0 +1,40 @@
+// Package pathutil holds small filesystem path helpers shared across
+// packages that need to compare directories without being fooled by
+// symlinks.
+package pathutil
+
+import "path/filepath"
+
+// SameDir reports whether a and b name the same directory once symlinks are
+// resolved. Byte-equal paths aren't enough: os.Getwd() can return a
+// symlink-resolved path (its syscall fallback when $PWD is unset or stale,
+// e.g. under a process supervisor with no controlling shell) while
+// os.UserHomeDir() returns $HOME verbatim, so a home directory reached
+// through a symlink compares unequal to itself with a raw string check.
+func SameDir(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	return resolveExisting(a) == resolveExisting(b)
+}
+
+// resolveExisting resolves symlinks in the longest existing ancestor of p and
+// reattaches whatever trailing components don't exist yet (e.g. a config
+// file that hasn't been created), since filepath.EvalSymlinks requires the
+// full path to exist.
+func resolveExisting(p string) string {
+	clean := filepath.Clean(p)
+	suffix := ""
+	cur := clean
+	for {
+		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
+			return filepath.Join(resolved, suffix)
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return clean
+		}
+		suffix = filepath.Join(filepath.Base(cur), suffix)
+		cur = parent
+	}
+}

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -1,0 +1,74 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestSameDir_IdenticalPaths(t *testing.T) {
+	dir := t.TempDir()
+	if !SameDir(dir, dir) {
+		t.Errorf("SameDir(%q, %q) = false, want true", dir, dir)
+	}
+}
+
+func TestSameDir_DifferentPaths(t *testing.T) {
+	a, b := t.TempDir(), t.TempDir()
+	if SameDir(a, b) {
+		t.Errorf("SameDir(%q, %q) = true, want false", a, b)
+	}
+}
+
+func TestSameDir_Empty(t *testing.T) {
+	if SameDir("", "") {
+		t.Error("SameDir(\"\", \"\") = true, want false")
+	}
+	if SameDir("", t.TempDir()) {
+		t.Error("SameDir(\"\", dir) = true, want false")
+	}
+}
+
+// A symlinked $HOME reached two different ways (once resolved, once not)
+// must still compare equal — this is the scenario that let a home-cwd
+// collision slip through a raw string comparison (os.Getwd()'s syscall
+// fallback returns a symlink-resolved path while os.UserHomeDir() returns
+// $HOME verbatim).
+func TestSameDir_ThroughSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on windows")
+	}
+	real := t.TempDir()
+	root := t.TempDir()
+	link := filepath.Join(root, "home-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	unresolved := filepath.Join(link, ".octo", "skills")
+	resolved := filepath.Join(real, ".octo", "skills")
+	if !SameDir(unresolved, resolved) {
+		t.Errorf("SameDir(%q, %q) = false, want true (same dir via symlink)", unresolved, resolved)
+	}
+}
+
+// The trailing subpath (e.g. ".octo/mcp.json") need not exist for the
+// comparison to still resolve the existing ancestor correctly.
+func TestSameDir_NonexistentSuffix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on windows")
+	}
+	real := t.TempDir()
+	root := t.TempDir()
+	link := filepath.Join(root, "home-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	unresolved := filepath.Join(link, ".octo", "mcp.json")
+	resolved := filepath.Join(real, ".octo", "mcp.json")
+	if !SameDir(unresolved, resolved) {
+		t.Errorf("SameDir(%q, %q) = false, want true (neither file exists yet)", unresolved, resolved)
+	}
+}

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/open-octo/octo-agent/internal/pathutil"
 	"github.com/open-octo/octo-agent/internal/trash"
 	"gopkg.in/yaml.v3"
 )
@@ -80,10 +81,10 @@ func Discover(cwd string) *Registry {
 		r.scanRoot(userRoot, "user")
 	}
 	// If cwd is the home directory itself, this resolves to the exact same
-	// directory as userRoot — re-scanning it would relabel every skill
-	// "project" for no reason.
+	// directory as userRoot (even reached through a symlinked $HOME) —
+	// re-scanning it would relabel every skill "project" for no reason.
 	if cwd != "" {
-		if projectRoot := filepath.Join(cwd, ".octo", "skills"); projectRoot != userRoot {
+		if projectRoot := filepath.Join(cwd, ".octo", "skills"); !pathutil.SameDir(projectRoot, userRoot) {
 			r.scanRoot(projectRoot, "project")
 		}
 	}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -3,6 +3,7 @@ package skills
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -125,6 +126,36 @@ func TestDiscover_CwdIsHomeDoesNotRelabelAsProject(t *testing.T) {
 	s, _ := r.Get("greet")
 	if s.Source != "user" {
 		t.Errorf("Source = %q, want user (cwd == home must not double-count as project)", s.Source)
+	}
+}
+
+// Same collision as TestDiscover_CwdIsHomeDoesNotRelabelAsProject, but the
+// home directory is reached through a symlink while cwd is passed as the
+// resolved real path — e.g. a network home mount, where os.Getwd()'s
+// syscall fallback (taken when $PWD is unset, as under a process
+// supervisor) returns the resolved path but userSkillsRoot's
+// os.UserHomeDir() returns $HOME verbatim. A raw string comparison would see
+// two different strings for the same directory.
+func TestDiscover_CwdIsHomeDoesNotRelabelAsProject_ThroughSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on windows")
+	}
+	real := t.TempDir()
+	root := t.TempDir()
+	link := filepath.Join(root, "home-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	useUserRoot(t, filepath.Join(link, ".octo", "skills"))
+	writeSkill(t, filepath.Join(link, ".octo", "skills"), "greet", "---\ndescription: hi\n---\nbody")
+
+	r := Discover(real)
+	if r.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", r.Len())
+	}
+	s, _ := r.Get("greet")
+	if s.Source != "user" {
+		t.Errorf("Source = %q, want user (symlinked home == cwd must not double-count as project)", s.Source)
 	}
 }
 

--- a/internal/tools/workflow_registry.go
+++ b/internal/tools/workflow_registry.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/open-octo/octo-agent/internal/memory"
+	"github.com/open-octo/octo-agent/internal/pathutil"
 	"github.com/open-octo/octo-agent/internal/trash"
 )
 
@@ -91,9 +92,10 @@ func discoverWorkflows(cwd string) map[string]savedWorkflow {
 	userRoot := userWorkflowsRoot()
 	scanWorkflowsRoot(userRoot, "user", fresh)
 	// projectWorkflowsRoot falls back to cwd itself when cwd isn't inside a
-	// git repo, which resolves to the same path as userRoot when cwd is the
-	// home directory — re-scanning it would relabel every workflow "project".
-	if projectRoot := projectWorkflowsRoot(cwd); projectRoot != userRoot {
+	// git repo, which resolves to the same directory as userRoot when cwd is
+	// the home directory (even through a symlinked $HOME or a git-resolved
+	// worktree path) — re-scanning it would relabel every workflow "project".
+	if projectRoot := projectWorkflowsRoot(cwd); !pathutil.SameDir(projectRoot, userRoot) {
 		scanWorkflowsRoot(projectRoot, "project", fresh)
 	}
 	return fresh

--- a/internal/tools/workflow_registry_test.go
+++ b/internal/tools/workflow_registry_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"testing"
 
@@ -83,6 +84,34 @@ func TestLookupWorkflow_SameUserAndProjectRootStaysUser(t *testing.T) {
 	}
 	if w.source != "user" {
 		t.Errorf("source = %q, want user (cwd == home must not double-count as project)", w.source)
+	}
+}
+
+// Same collision as TestLookupWorkflow_SameUserAndProjectRootStaysUser, but
+// the two roots are reached through a symlink on one side only — e.g. a
+// network home mount, where os.Getwd()'s syscall fallback (taken when $PWD
+// is unset, as under a process supervisor) returns the resolved path while
+// userWorkflowsRoot's os.UserHomeDir() returns $HOME verbatim. A raw string
+// comparison would see two different strings for the same directory.
+func TestLookupWorkflow_SameUserAndProjectRootStaysUser_ThroughSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on windows")
+	}
+	real := t.TempDir()
+	root := t.TempDir()
+	link := filepath.Join(root, "home-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	useWorkflowRoots(t, link, real)
+	writeWorkflowFile(t, real, "solo.rb", "# @description only copy\n\"x\"\n")
+
+	w, ok := lookupWorkflow(context.Background(), "solo")
+	if !ok {
+		t.Fatal("lookupWorkflow: not found")
+	}
+	if w.source != "user" {
+		t.Errorf("source = %q, want user (symlinked home == cwd must not double-count as project)", w.source)
 	}
 }
 


### PR DESCRIPTION
## Summary
- PR #1233 fixed the Skills/MCP/Workflows panels mislabeling user-scoped config as "project" when `octo serve`'s cwd equals home, but the guard compared raw path strings.
- `os.Getwd()` can return a symlink-resolved path (its syscall fallback when `$PWD` is unset, e.g. a supervisor-launched process with no controlling shell) while `os.UserHomeDir()` returns `$HOME` verbatim — so a symlinked home directory (network home mount, dotfiles-as-git-repo) made the strings differ and the mislabel bug reappeared.
- Adds `internal/pathutil.SameDir`, which resolves symlinks on the longest existing ancestor of each path (handling the case where the trailing config file doesn't exist yet) before comparing, and swaps it in at all three call sites: `skills.Discover`, `mcp.LoadManaged`, `workflow_registry.discoverWorkflows`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `go test ./...`
- [x] `go test -race ./internal/skills/... ./internal/mcp/... ./internal/tools/... ./internal/pathutil/...`
- [x] New regression tests reproducing the symlinked-home scenario in `internal/pathutil/pathutil_test.go` and one `_ThroughSymlink` case added to each of the three affected packages' existing home-cwd tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)