### PR TITLE
chore: bump version to 1.9.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.8.6"
+var Version = "1.9.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Minor bump for the release cut: main has one feat commit since v1.8.6 (#1244, drop mcp_search / always list MCP tool names in the system prompt) alongside several fixes, following this repo's feat-triggers-minor convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)