### PR TITLE
fix(tui): start a new/replaced goal immediately instead of on the next message

### DIFF
--- a/cmd/octo/tuirepl_goal.go
+++ b/cmd/octo/tuirepl_goal.go
@@ -41,15 +41,10 @@ func (m *tuiModel) dispatchGoal(args string) (tea.Model, tea.Cmd) {
 		return m.applyGoalStatus(agent.GoalPaused)
 
 	case sub == "resume":
-		model, cmd := m.applyGoalStatus(agent.GoalActive)
+		m.applyGoalStatus(agent.GoalActive)
 		// Resuming re-enters the continuation loop right away when idle —
 		// the user just asked for the goal to keep going.
-		if g, ok := sess.GoalSnapshot(); ok && g.Status == agent.GoalActive {
-			if prompt, kick := m.goalContinuationKick(); kick {
-				return model, tea.Sequence(m.flushPrints(), m.startTurnEcho(prompt, ""))
-			}
-		}
-		return model, cmd
+		return m.startGoalNow()
 
 	case sub == "clear":
 		if sess.ClearGoal() {
@@ -90,7 +85,7 @@ func (m *tuiModel) dispatchGoal(args string) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.println(noticeStyle.Render("Goal replaced — " + goalOneLine(g)))
-		return m, nil
+		return m.startGoalNow()
 
 	default:
 		// "/goal <objective>": start a goal. A finished (complete) goal is
@@ -104,10 +99,11 @@ func (m *tuiModel) dispatchGoal(args string) (tea.Model, tea.Cmd) {
 			}
 			if ng, err := sess.ReplaceGoal(args, 0); err != nil {
 				m.println(errorStyle.Render("/goal: " + err.Error()))
+				return m, nil
 			} else {
 				m.println(noticeStyle.Render("Goal set — " + goalOneLine(ng)))
 			}
-			return m, nil
+			return m.startGoalNow()
 		}
 		g, err := sess.CreateGoal(args, 0)
 		if err != nil {
@@ -115,7 +111,7 @@ func (m *tuiModel) dispatchGoal(args string) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.println(noticeStyle.Render("Goal set — " + goalOneLine(g)))
-		return m, nil
+		return m.startGoalNow()
 	}
 }
 
@@ -126,10 +122,10 @@ func (m *tuiModel) applyGoalStatus(status agent.GoalStatus) (tea.Model, tea.Cmd)
 	g, err := m.cfg.session.SetGoalStatus(status)
 	if err != nil {
 		m.println(errorStyle.Render("/goal: " + err.Error()))
-		return m, nil
+		return m, m.flushPrints()
 	}
 	m.println(noticeStyle.Render("Goal " + goalStatusLabel(g.Status) + " — " + goalOneLine(g)))
-	return m, nil
+	return m, m.flushPrints()
 }
 
 // submitGoalEdit consumes the next submitted line as the edited objective.
@@ -146,6 +142,23 @@ func (m *tuiModel) submitGoalEdit(text string) (tea.Model, tea.Cmd) {
 	}
 	m.println(noticeStyle.Render("Goal updated — " + goalOneLine(g)))
 	return m, nil
+}
+
+// startGoalNow flushes any queued notices and, if the goal is active and
+// idle, immediately kicks off the continuation turn instead of waiting for
+// handleTurnFinished to pick it up after some unrelated turn completes.
+// Shared by create/replace/resume so a fresh or resumed goal starts right
+// away rather than on the user's next message. A turn already running is
+// left alone — dispatchGoal is only ever reached while idle in practice
+// (submit() queues slash commands mid-turn instead), so this is a defensive
+// no-op rather than a real production path.
+func (m *tuiModel) startGoalNow() (tea.Model, tea.Cmd) {
+	if !m.turnRunning {
+		if prompt, kick := m.goalContinuationKick(); kick {
+			return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(prompt, ""))
+		}
+	}
+	return m, m.flushPrints()
 }
 
 // goalContinuationKick asks the session whether an idle continuation turn

--- a/cmd/octo/tuirepl_goal_test.go
+++ b/cmd/octo/tuirepl_goal_test.go
@@ -68,7 +68,12 @@ func TestDispatchGoal_CreateSummaryAndGuardedReplace(t *testing.T) {
 
 func TestDispatchGoal_PauseResumeClear(t *testing.T) {
 	m, sess := newGoalTestModel()
-	m.dispatchGoal("g")
+	// Seeded directly on the session so the fixture itself doesn't consume
+	// the continuation hand-out or leave a real turn goroutine running before
+	// the resume assertion below.
+	if _, err := sess.CreateGoal("g", 0); err != nil {
+		t.Fatal(err)
+	}
 
 	m.dispatchGoal("pause")
 	if g, _ := sess.GoalSnapshot(); g.Status != agent.GoalPaused {
@@ -103,7 +108,12 @@ func TestDispatchGoal_UnwiredIsDisabled(t *testing.T) {
 
 func TestGoalEditFlow(t *testing.T) {
 	m, sess := newGoalTestModel()
-	m.dispatchGoal("first objective")
+	// Seeded directly on the session (not via dispatchGoal) so creation's
+	// immediate continuation kick doesn't run a real turn concurrently with
+	// the deterministic AccountGoalUsage calls below.
+	if _, err := sess.CreateGoal("first objective", 0); err != nil {
+		t.Fatal(err)
+	}
 	sess.AccountGoalUsage(0) // consume the mid-turn-creation skip deterministically
 	sess.ResetGoalWallClock()
 	sess.AccountGoalUsage(42)
@@ -141,7 +151,12 @@ func TestGoalEdit_EmptySubmitCancels(t *testing.T) {
 
 func TestGoalEdit_EscCancelsViaKeyHandler(t *testing.T) {
 	m, sess := newGoalTestModel()
-	m.dispatchGoal("keep me")
+	// Seeded directly on the session (not via dispatchGoal) so creation's
+	// immediate continuation kick doesn't leave turnRunning true — this test
+	// exercises the idle Esc-cancel path, not goal creation.
+	if _, err := sess.CreateGoal("keep me", 0); err != nil {
+		t.Fatal(err)
+	}
 	m.dispatchGoal("edit")
 
 	m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
@@ -158,7 +173,12 @@ func TestGoalEdit_EscCancelsViaKeyHandler(t *testing.T) {
 
 func TestGoalEdit_SlashCommandCancelsAndDispatches(t *testing.T) {
 	m, sess := newGoalTestModel()
-	m.dispatchGoal("keep me")
+	// Seeded directly on the session (not via dispatchGoal) so creation's
+	// immediate continuation kick doesn't leave turnRunning true — that would
+	// make the "/goal" resubmit below queue instead of dispatch immediately.
+	if _, err := sess.CreateGoal("keep me", 0); err != nil {
+		t.Fatal(err)
+	}
 	m.dispatchGoal("edit")
 
 	// The user changed their mind mid-edit and typed a command instead.
@@ -201,8 +221,13 @@ func TestGoalEdit_AsyncTurnStartCancelsPendingEdit(t *testing.T) {
 }
 
 func TestHandleTurnFinished_KicksGoalContinuation(t *testing.T) {
-	m, _ := newGoalTestModel()
-	m.dispatchGoal("keep going")
+	m, sess := newGoalTestModel()
+	// Seeded directly on the session so this is the first GoalContinuation
+	// hand-out — going through dispatchGoal would consume it during creation
+	// and trip the zero-progress guard before handleTurnFinished gets a turn.
+	if _, err := sess.CreateGoal("keep going", 0); err != nil {
+		t.Fatal(err)
+	}
 	m.turnRunning = false
 
 	m.handleTurnFinished(nil)
@@ -215,8 +240,13 @@ func TestHandleTurnFinished_KicksGoalContinuation(t *testing.T) {
 }
 
 func TestHandleTurnFinished_QueuedInputBeatsContinuation(t *testing.T) {
-	m, _ := newGoalTestModel()
-	m.dispatchGoal("keep going")
+	m, sess := newGoalTestModel()
+	// Seeded directly on the session — dispatchGoal's immediate continuation
+	// kick would otherwise start a second, unawaited turn goroutine racing
+	// against the queued one started below.
+	if _, err := sess.CreateGoal("keep going", 0); err != nil {
+		t.Fatal(err)
+	}
 	m.turnRunning = false
 	m.queue = append(m.queue, pendingItem{text: "user question"})
 
@@ -228,7 +258,11 @@ func TestHandleTurnFinished_QueuedInputBeatsContinuation(t *testing.T) {
 
 func TestHandleTurnFinished_ErrorParksContinuation(t *testing.T) {
 	m, sess := newGoalTestModel()
-	m.dispatchGoal("keep going")
+	// Seeded directly on the session, matching the other handleTurnFinished
+	// fixtures — see TestHandleTurnFinished_KicksGoalContinuation.
+	if _, err := sess.CreateGoal("keep going", 0); err != nil {
+		t.Fatal(err)
+	}
 	m.turnRunning = false
 
 	m.handleTurnFinished(errors.New("anthropic: HTTP 500: overloaded"))
@@ -245,7 +279,11 @@ func TestHandleTurnFinished_ErrorParksContinuation(t *testing.T) {
 
 func TestHandleTurnFinished_RateLimitedContinuationParks(t *testing.T) {
 	m, sess := newGoalTestModel()
-	m.dispatchGoal("keep going")
+	// Seeded directly on the session so the precondition below is the first
+	// GoalContinuation hand-out — see TestHandleTurnFinished_KicksGoalContinuation.
+	if _, err := sess.CreateGoal("keep going", 0); err != nil {
+		t.Fatal(err)
+	}
 	m.turnRunning = false
 
 	// Hand out a continuation (pending), then its turn fails on a rate limit.


### PR DESCRIPTION
## Summary
- `/goal <objective>` and `/goal replace <objective>` only wrote session state and buffered a notice; nothing flushed the terminal buffer or kicked the continuation loop. The goal sat visibly idle until an unrelated turn finished and `handleTurnFinished` happened to pick it up as a side effect — reported as "goal doesn't run until I type something unrelated".
- `/goal resume` already had the correct pattern (flush notices + kick the continuation turn immediately). Factored that into a shared `startGoalNow()` helper and reuse it from create/replace so a fresh or replaced goal starts right away, matching resume's behavior.
- `/goal pause`/`resume` status notices (`applyGoalStatus`) are now flushed immediately too, instead of waiting on some later unrelated event.
- `startGoalNow()` skips kicking a new turn when one is already running — defensive, since `dispatchGoal` is only ever reached while idle in real usage (mid-turn slash commands are queued by `submit()` instead).

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./cmd/octo/...` (updated fixtures in `tuirepl_goal_test.go` that previously created goals via `dispatchGoal` — now seeded directly via `sess.CreateGoal` where the test's actual subject is unrelated to creation, avoiding a spurious real continuation turn racing with the behavior under test)
- [x] `go test -race ./...`
- [x] `gofmt -l .` clean