### PR TITLE
feat(workflow): required-arg prompting, on-disk defaults, journal retention

### DIFF
--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -16,7 +16,9 @@ import (
 
 	"github.com/open-octo/octo-agent/internal/sandbox"
 	"github.com/open-octo/octo-agent/internal/skills"
+	"github.com/open-octo/octo-agent/internal/tools"
 	"github.com/open-octo/octo-agent/internal/version"
+	"github.com/open-octo/octo-agent/internal/workflow"
 )
 
 func main() {
@@ -30,11 +32,14 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return runChat(args, stdin, stdout, stderr)
 	}
 
-	// Materialize the binary's default skills to ~/.octo/skills-default so
-	// they're discoverable like any user skill. Best-effort and a fast no-op
-	// once current; skipped for the internal fast-path commands.
+	// Materialize the binary's default skills/workflows to ~/.octo/skills-default
+	// and ~/.octo/workflows-default so they're discoverable like any user
+	// skill/workflow, and prune stale workflow run journals. Best-effort and a
+	// fast no-op/pass once current; skipped for the internal fast-path commands.
 	if args[0] != "__sandboxed-exec" && args[0] != "__complete" {
 		_ = skills.MaterializeDefaults(version.Version)
+		_ = tools.MaterializeDefaultWorkflows(version.Version)
+		_ = workflow.PruneJournals()
 	}
 
 	switch args[0] {
@@ -134,7 +139,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  memory     Manage cross-session memory (e.g. `octo memory list`)")
 	fmt.Fprintln(w, "  sessions   List recent saved sessions (resume with `octo -c <id>`)")
 	fmt.Fprintln(w, "  skills     Manage skills (`octo skills list | add | update | path`)")
-	fmt.Fprintln(w, "  workflows  List saved workflows (`octo workflows list | path`)")
+	fmt.Fprintln(w, "  workflows  List saved workflows (`octo workflows list | path | update`)")
 	fmt.Fprintln(w, "  browser    Set up browser automation (attach to your logged-in Chrome)")
 	fmt.Fprintln(w, "  upgrade    Download and install the latest release (--check to only compare)")
 	fmt.Fprintln(w, "  completion Print shell-completion snippet (bash | zsh | fish)")

--- a/cmd/octo/workflows_cmd.go
+++ b/cmd/octo/workflows_cmd.go
@@ -7,12 +7,14 @@ import (
 	"sort"
 
 	"github.com/open-octo/octo-agent/internal/tools"
+	"github.com/open-octo/octo-agent/internal/version"
 )
 
-// runWorkflows handles `octo workflows [list|path]`. Bare `octo workflows`
-// defaults to list. Read-only, unlike `octo skills`: a saved workflow is
-// created/edited conversationally (the workflow_save tool, guided by the
-// workflow-creator skill), so there's no CLI writer to mirror.
+// runWorkflows handles `octo workflows [list|path|update]`. Bare
+// `octo workflows` defaults to list. Aside from refreshing the default set,
+// it's read-only unlike `octo skills`: a saved workflow is created/edited
+// conversationally (the workflow_save tool, guided by the workflow-creator
+// skill), so there's no CLI writer to mirror.
 func runWorkflows(args []string, stdout, stderr io.Writer) int {
 	sub := "list"
 	if len(args) > 0 {
@@ -23,8 +25,10 @@ func runWorkflows(args []string, stdout, stderr io.Writer) int {
 		return workflowsList(stdout)
 	case "path":
 		return workflowsPath(stdout)
+	case "update":
+		return workflowsUpdate(stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "octo workflows: unknown subcommand %q (want list | path)\n", sub)
+		fmt.Fprintf(stderr, "octo workflows: unknown subcommand %q (want list | path | update)\n", sub)
 		return 2
 	}
 }
@@ -54,8 +58,17 @@ func workflowsList(stdout io.Writer) int {
 func workflowsPath(stdout io.Writer) int {
 	cwd, _ := os.Getwd()
 	fmt.Fprintln(stdout, "Workflow roots (lowest → highest precedence):")
-	fmt.Fprintln(stdout, "  default  (embedded in the binary, not on disk)")
+	fmt.Fprintf(stdout, "  default  %s\n", tools.DefaultWorkflowsRoot())
 	fmt.Fprintf(stdout, "  user     %s\n", tools.UserWorkflowsRoot())
 	fmt.Fprintf(stdout, "  project  %s\n", tools.ProjectWorkflowsRoot(cwd))
+	return 0
+}
+
+func workflowsUpdate(stdout, stderr io.Writer) int {
+	if err := tools.UpdateDefaultWorkflows(version.Version); err != nil {
+		fmt.Fprintf(stderr, "octo workflows update: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Default workflows refreshed → %s\n", tools.DefaultWorkflowsRoot())
 	return 0
 }

--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -734,6 +734,15 @@ func unresolvedPlaceholders(skill *Skill, full map[string]string) []string {
 	return missing
 }
 
+// MissingRequiredParams reports which {{name}} placeholders in skill's steps
+// remain unresolved after overlaying params on the skill's declared defaults
+// — the same check ReplaySkill performs internally before running any step,
+// exposed so a caller can prompt for the missing values (e.g. via a UI or an
+// interactive asker) instead of letting ReplaySkill fail outright.
+func MissingRequiredParams(skill *Skill, params map[string]string) []string {
+	return unresolvedPlaceholders(skill, mergedParams(skill, params))
+}
+
 // mergedParams overlays caller params on declared defaults.
 func mergedParams(skill *Skill, params map[string]string) map[string]string {
 	out := map[string]string{}

--- a/internal/browser/skill_test.go
+++ b/internal/browser/skill_test.go
@@ -284,6 +284,24 @@ func TestReplaySkill_DefaultAndSuppliedParamsResolve(t *testing.T) {
 	}
 }
 
+// TestMissingRequiredParams exposes the same check ReplaySkill performs
+// internally, so a caller (the tools package's run_skill) can prompt for a
+// value instead of letting ReplaySkill fail outright.
+func TestMissingRequiredParams(t *testing.T) {
+	skill := &Skill{Name: "checkout", Params: []Param{
+		{Name: "city", Default: "sfo"},
+		{Name: "item"},
+	}, Steps: []Step{
+		{Action: "navigate", URL: "https://example.com/{{city}}/{{item}}"},
+	}}
+	if missing := MissingRequiredParams(skill, nil); len(missing) != 1 || missing[0] != "item" {
+		t.Fatalf("MissingRequiredParams = %v, want [item] (city has a default)", missing)
+	}
+	if missing := MissingRequiredParams(skill, map[string]string{"item": "widget"}); len(missing) != 0 {
+		t.Fatalf("MissingRequiredParams = %v, want none once item is supplied", missing)
+	}
+}
+
 // TestCompileUploadMerge: a click on the upload button followed by a file
 // selection compiles to a single upload step on the button, auto-parameterized.
 func TestCompileUploadMerge(t *testing.T) {

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -298,7 +298,7 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 					"description": "The browser action to perform. observe lists the page's URL/title and interactable elements with selectors (text only) — the cheap way to look at an unfamiliar page before acting; works on any model. screenshot returns an image of the page for a vision-capable model to actually see (use when content is visual). ax returns an accessibility-tree digest (roles and names) — a semantic text view of the page, an alternative to observe when document structure matters more than selectors. pages lists open tabs; select_page switches between them. cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture the USER's own demonstration into an editable skill — record_start only installs listeners, so after it you MUST hand control to the user: tell them to perform the actions themselves in their browser and to say when they're done, then call record_stop. Do NOT drive the page yourself (navigate/click/type) while recording — your tool actions are not the demonstration and a click that navigates is easily lost; only the user's real gestures are captured. run_skill replays a recording (deterministic, self-healing).",
 				},
 				"name":         map[string]any{"type": "string", "description": "Skill name (record_stop / run_skill)."},
-				"params":       map[string]any{"type": "object", "description": "Param values for {{...}} placeholders (run_skill)."},
+				"params":       map[string]any{"type": "object", "description": "Param values for {{...}} placeholders (run_skill). Omit a value the skill requires (no recorded default, e.g. a secret) and, in interactive modes, the user is prompted for it instead of the call failing."},
 				"url":          map[string]any{"type": "string", "description": "Target URL (navigate)."},
 				"selector":     map[string]any{"type": "string", "description": "Target element selector (click/hover/type/select/scroll/wait/upload/download). Plain CSS, or a Playwright-style form: :has-text(\"…\")/:text(\"…\")/:contains(\"…\"), text=…, :visible, xpath=…, css=…. Use observe to see real selectors."},
 				"network_idle": map[string]any{"type": "boolean", "description": "wait with no selector: settle until fetch/XHR activity stops (bounded by timeout_ms) instead of a fixed delay — the robust way to wait for an SPA's data to finish loading."},
@@ -650,6 +650,9 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 				params[k] = fmt.Sprintf("%v", v)
 			}
 		}
+		if err := resolveMissingSkillParams(ctx, &skill, name, params); err != nil {
+			return agent.ToolResult{}, err
+		}
 		recorderMu.Lock()
 		healer := browserHealer
 		recorderMu.Unlock()
@@ -684,6 +687,47 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 	default:
 		return agent.ToolResult{}, fmt.Errorf("browser: unknown action %q", action)
 	}
+}
+
+// resolveMissingSkillParams checks skill's {{...}} placeholders against the
+// caller-supplied params and, for any ReplaySkill would otherwise reject as
+// unresolved, prompts the user for a value via the same Asker
+// ask_user_question uses — mirroring ensureRequiredWorkflowParams in
+// workflow.go — rather than letting ReplaySkill fail with a bare "missing
+// required param(s)" error the model has no way to act on. params is mutated
+// in place. When no asker is available (headless/unattended modes),
+// ReplaySkill's own error still fires, so behavior there is unchanged.
+func resolveMissingSkillParams(ctx context.Context, skill *browser.Skill, skillName string, params map[string]string) error {
+	missing := browser.MissingRequiredParams(skill, params)
+	if len(missing) == 0 {
+		return nil
+	}
+	asker := askerFrom(ctx)
+	if asker == nil {
+		return nil
+	}
+	descByName := make(map[string]string, len(skill.Params))
+	for _, p := range skill.Params {
+		descByName[p.Name] = p.Description
+	}
+	for _, pname := range missing {
+		question := fmt.Sprintf("Skill %q needs a value for %q", skillName, pname)
+		if d := descByName[pname]; d != "" {
+			question += ": " + d
+		}
+		res, err := asker.Ask(ctx, AskRequest{Question: question, Header: pname})
+		if err != nil {
+			return fmt.Errorf("browser: %w", err)
+		}
+		if res.Cancelled {
+			return fmt.Errorf("browser: run_skill %q: user cancelled while providing param %q", skillName, pname)
+		}
+		// AskRequest carries no Options, so this is always a free-text prompt —
+		// res.Choices is documented to stay empty in that case (AskResponse),
+		// leaving res.Custom as the only place the answer can land.
+		params[pname] = res.Custom
+	}
+	return nil
 }
 
 func getStr(input map[string]any, key string) string {

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -174,6 +174,90 @@ func TestBrowserTool_RecordRunRoundTrip(t *testing.T) {
 	}
 }
 
+// TestResolveMissingSkillParams_PromptsForMissingRequired verifies a param
+// with no default and no caller-supplied value triggers a user prompt (via
+// the same Asker ask_user_question uses) instead of silently proceeding or
+// only failing once ReplaySkill runs.
+func TestResolveMissingSkillParams_PromptsForMissingRequired(t *testing.T) {
+	skill := browser.Skill{
+		Name:   "demo",
+		Params: []browser.Param{{Name: "username", Description: "login name"}},
+		Steps:  []browser.Step{{Action: "type", Selector: "#u", Value: "{{username}}"}},
+	}
+	stub := &stubAsker{resp: AskResponse{Custom: "alice"}}
+	useAsker(t, stub)
+
+	params := map[string]string{}
+	if err := resolveMissingSkillParams(context.Background(), &skill, "demo", params); err != nil {
+		t.Fatalf("resolveMissingSkillParams: %v", err)
+	}
+	if !stub.called {
+		t.Fatal("expected a prompt for the missing param")
+	}
+	if !strings.Contains(stub.lastReq.Question, "username") || !strings.Contains(stub.lastReq.Question, "login name") {
+		t.Errorf("question = %q, want it to mention the param name and description", stub.lastReq.Question)
+	}
+	if params["username"] != "alice" {
+		t.Errorf("params[username] = %q, want alice", params["username"])
+	}
+}
+
+// TestResolveMissingSkillParams_NoPromptWhenProvided verifies an
+// already-supplied value skips the prompt entirely.
+func TestResolveMissingSkillParams_NoPromptWhenProvided(t *testing.T) {
+	skill := browser.Skill{
+		Name:   "demo",
+		Params: []browser.Param{{Name: "username"}},
+		Steps:  []browser.Step{{Action: "type", Selector: "#u", Value: "{{username}}"}},
+	}
+	stub := &stubAsker{}
+	useAsker(t, stub)
+
+	params := map[string]string{"username": "bob"}
+	if err := resolveMissingSkillParams(context.Background(), &skill, "demo", params); err != nil {
+		t.Fatalf("resolveMissingSkillParams: %v", err)
+	}
+	if stub.called {
+		t.Error("should not prompt when the param is already provided")
+	}
+}
+
+// TestResolveMissingSkillParams_NoAskerLeavesGapForReplaySkillToReject
+// verifies headless/unattended modes are left unchanged: with no asker
+// registered, resolveMissingSkillParams is a no-op so ReplaySkill's own
+// "missing required param(s)" error still fires downstream.
+func TestResolveMissingSkillParams_NoAskerLeavesGapForReplaySkillToReject(t *testing.T) {
+	SetAsker(nil)
+	skill := browser.Skill{
+		Name:   "demo",
+		Params: []browser.Param{{Name: "username"}},
+		Steps:  []browser.Step{{Action: "type", Selector: "#u", Value: "{{username}}"}},
+	}
+	params := map[string]string{}
+	if err := resolveMissingSkillParams(context.Background(), &skill, "demo", params); err != nil {
+		t.Fatalf("resolveMissingSkillParams: %v", err)
+	}
+	if _, ok := params["username"]; ok {
+		t.Error("params should be untouched when no asker is available")
+	}
+}
+
+// TestResolveMissingSkillParams_CancelledPromptErrors verifies a cancelled
+// prompt aborts with an error instead of proceeding with a blank value.
+func TestResolveMissingSkillParams_CancelledPromptErrors(t *testing.T) {
+	skill := browser.Skill{
+		Name:   "demo",
+		Params: []browser.Param{{Name: "username"}},
+		Steps:  []browser.Step{{Action: "type", Selector: "#u", Value: "{{username}}"}},
+	}
+	useAsker(t, &stubAsker{resp: AskResponse{Cancelled: true}})
+	params := map[string]string{}
+	err := resolveMissingSkillParams(context.Background(), &skill, "demo", params)
+	if err == nil || !strings.Contains(err.Error(), "cancelled") {
+		t.Errorf("err = %v, want a cancellation error", err)
+	}
+}
+
 // TestBrowserTool_RequiresAction surfaces a clean error for a missing action.
 func TestBrowserTool_RequiresAction(t *testing.T) {
 	_, err := BrowserTool{}.Execute(context.Background(), "browser", map[string]any{})

--- a/internal/tools/main_test.go
+++ b/internal/tools/main_test.go
@@ -12,9 +12,30 @@ import (
 // __sandboxed-exec subcommand, and under `go test` that executable IS this test
 // binary. Without this dispatch the re-exec would recurse into the test suite.
 // On macOS (sandbox-exec, no re-exec) the arg never appears, so this is a no-op.
+//
+// It also neutralizes the default-workflows root and the workflow journal
+// directory for the whole package so tests never touch the real
+// ~/.octo/workflows-default or ~/.octo/workflow-journals (which an installed
+// binary populates and every workflow run appends to) — mirrors
+// internal/skills/defaults_test.go's TestMain. Without the journal redirect,
+// every test that runs a workflow (most of workflow_test.go) leaves a .jsonl
+// file in the developer's real journal directory forever, since nothing
+// prunes it mid-session. Tests that exercise the default-workflows tier opt
+// in via useWorkflowRoots, which points defaultWorkflowsRoot at a freshly
+// materialized temp dir.
 func TestMain(m *testing.M) {
 	if len(os.Args) > 1 && os.Args[1] == "__sandboxed-exec" {
 		os.Exit(sandbox.ShimMain())
 	}
-	os.Exit(m.Run())
+	defaultsTmp, _ := os.MkdirTemp("", "octo-workflows-default-empty")
+	defaultWorkflowsRoot = func() string { return defaultsTmp }
+	journalsTmp, _ := os.MkdirTemp("", "octo-workflow-journals-test")
+	SetWorkflowJournalDir(journalsTmp)
+	code := m.Run()
+	for _, tmp := range []string{defaultsTmp, journalsTmp} {
+		if tmp != "" {
+			_ = os.RemoveAll(tmp)
+		}
+	}
+	os.Exit(code)
 }

--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -58,6 +58,25 @@ func ActiveWorkflowDiscoveryCWD() string {
 	return v
 }
 
+// workflowJournalDir overrides the workflow runtime's journal directory
+// (~/.octo/workflow-journals by default, resolved by internal/workflow).
+// Empty (the zero value) leaves the runtime default in place — every real
+// entry point (CLI, server, IM) never sets this. Tests point it at a temp dir
+// so running the suite doesn't write into a developer's real journal
+// directory.
+var workflowJournalDir atomic.Value // string
+
+// SetWorkflowJournalDir overrides the workflow runtime's journal directory for
+// this process. Pass "" to restore the default.
+func SetWorkflowJournalDir(dir string) { workflowJournalDir.Store(dir) }
+
+// ActiveWorkflowJournalDir returns the dir set by SetWorkflowJournalDir, or ""
+// (the runtime default) if never set.
+func ActiveWorkflowJournalDir() string {
+	v, _ := workflowJournalDir.Load().(string)
+	return v
+}
+
 // WorkflowTool runs a Ruby (mruby) orchestration script in an embedded wasm
 // interpreter. The script drives sub-agents through the agent() / parallel() /
 // pipeline() primitives; each agent() call delegates to the same Spawner that
@@ -173,13 +192,86 @@ func savedWorkflowsParamDesc() string {
 	}
 	b.WriteString(" Available:")
 	for _, w := range saved {
+		line := "\n- " + w.name
 		if w.description != "" {
-			fmt.Fprintf(&b, "\n- %s — %s", w.name, w.description)
-		} else {
-			fmt.Fprintf(&b, "\n- %s", w.name)
+			line += " — " + w.description
 		}
+		if req := requiredParamNames(w.params); len(req) > 0 {
+			line += " (requires: " + strings.Join(req, ", ") + ")"
+		}
+		b.WriteString(line)
 	}
 	return b.String()
+}
+
+// requiredParamNames returns the names of params marked required, in
+// declaration order.
+func requiredParamNames(params []workflowParam) []string {
+	var out []string
+	for _, p := range params {
+		if p.required {
+			out = append(out, p.name)
+		}
+	}
+	return out
+}
+
+// ensureRequiredWorkflowParams checks a saved workflow's declared `# @param
+// name required ...` inputs against the tool's `args` input. Any that are
+// missing are filled by prompting the user (via the same Asker the
+// ask_user_question tool uses) rather than letting the script hit a nil
+// args[...] lookup at runtime. Returns the args map to use when at least one
+// value was filled in (nil, nil when nothing was missing), or an error if a
+// required value couldn't be obtained (no asker available, or the user
+// cancelled).
+func ensureRequiredWorkflowParams(ctx context.Context, workflowName string, params []workflowParam, args map[string]any) (map[string]any, error) {
+	var missing []workflowParam
+	for _, p := range params {
+		if !p.required {
+			continue
+		}
+		if v, ok := args[p.name]; ok && v != nil && v != "" {
+			continue
+		}
+		missing = append(missing, p)
+	}
+	if len(missing) == 0 {
+		return nil, nil
+	}
+
+	asker := askerFrom(ctx)
+	if asker == nil {
+		names := make([]string, len(missing))
+		for i, p := range missing {
+			names[i] = p.name
+		}
+		return nil, fmt.Errorf("workflow %q is missing required arg(s) %s and no user is available to "+
+			"ask for them in this mode — pass them in `args` instead", workflowName, strings.Join(names, ", "))
+	}
+
+	filled := make(map[string]any, len(args)+len(missing))
+	for k, v := range args {
+		filled[k] = v
+	}
+	for _, p := range missing {
+		question := fmt.Sprintf("Workflow %q needs a value for %q", workflowName, p.name)
+		if p.description != "" {
+			question += ": " + p.description
+		}
+		res, err := asker.Ask(ctx, AskRequest{Question: question, Header: p.name})
+		if err != nil {
+			return nil, fmt.Errorf("workflow: %w", err)
+		}
+		if res.Cancelled {
+			return nil, fmt.Errorf("workflow %q: user cancelled while providing required arg %q", workflowName, p.name)
+		}
+		value := res.Custom
+		if value == "" && len(res.Choices) > 0 {
+			value = res.Choices[0]
+		}
+		filled[p.name] = value
+	}
+	return filled, nil
 }
 
 // Execute runs the workflow: detached with a run handle in background mode,
@@ -205,6 +297,16 @@ func (WorkflowTool) Execute(ctx context.Context, _ string, input map[string]any)
 		script = w.script
 		if description == "" {
 			description = w.description
+		}
+		if len(w.params) > 0 {
+			argsMap, _ := input["args"].(map[string]any)
+			filled, err := ensureRequiredWorkflowParams(ctx, name, w.params, argsMap)
+			if err != nil {
+				return agent.ToolResult{}, err
+			}
+			if filled != nil {
+				input["args"] = filled
+			}
 		}
 	}
 

--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -265,11 +265,10 @@ func ensureRequiredWorkflowParams(ctx context.Context, workflowName string, para
 		if res.Cancelled {
 			return nil, fmt.Errorf("workflow %q: user cancelled while providing required arg %q", workflowName, p.name)
 		}
-		value := res.Custom
-		if value == "" && len(res.Choices) > 0 {
-			value = res.Choices[0]
-		}
-		filled[p.name] = value
+		// AskRequest carries no Options, so this is always a free-text prompt —
+		// res.Choices is documented to stay empty in that case (AskResponse),
+		// leaving res.Custom as the only place the answer can land.
+		filled[p.name] = res.Custom
 	}
 	return filled, nil
 }

--- a/internal/tools/workflow_defaults.go
+++ b/internal/tools/workflow_defaults.go
@@ -1,0 +1,86 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// defaultWorkflowsRoot returns ~/.octo/workflows-default — a dedicated,
+// octo-managed directory kept separate from ~/.octo/workflows so refreshing
+// the defaults never touches a user's own saved workflows. A var so tests can
+// redirect it. Mirrors internal/skills/defaults.go's defaultSkillsRoot.
+var defaultWorkflowsRoot = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "workflows-default")
+}
+
+// DefaultWorkflowsRoot is the on-disk location of the materialized default
+// workflows (~/.octo/workflows-default), exported for `octo workflows path`.
+func DefaultWorkflowsRoot() string { return defaultWorkflowsRoot() }
+
+// defaultWorkflowStampFile records which binary version last materialized the
+// default workflows, so MaterializeDefaultWorkflows can no-op until the
+// version changes.
+const defaultWorkflowStampFile = ".octo-version"
+
+// MaterializeDefaultWorkflows writes the embedded default workflows to
+// ~/.octo/workflows-default when the on-disk version stamp doesn't match
+// version, so they're discoverable, listable and overridable on disk like any
+// saved workflow, instead of only living inside the binary. It's a fast no-op
+// once the install is current (a single stamp read). Best-effort: the caller
+// should ignore the error so a read-only HOME never blocks a session.
+func MaterializeDefaultWorkflows(version string) error {
+	return materializeDefaultWorkflows(defaultWorkflowsRoot(), version, false)
+}
+
+// UpdateDefaultWorkflows forces a rewrite regardless of the stamp — backs
+// `octo workflows update`.
+func UpdateDefaultWorkflows(version string) error {
+	return materializeDefaultWorkflows(defaultWorkflowsRoot(), version, true)
+}
+
+func materializeDefaultWorkflows(root, version string, force bool) error {
+	if root == "" {
+		return nil
+	}
+	if !force {
+		if b, err := os.ReadFile(filepath.Join(root, defaultWorkflowStampFile)); err == nil &&
+			strings.TrimSpace(string(b)) == version {
+			return nil // already current
+		}
+	}
+
+	// The default root is exclusively octo-managed (users override in
+	// ~/.octo/workflows), so a wholesale wipe-and-rewrite is safe and keeps the
+	// set in lockstep with the binary — stale workflows removed, renames handled.
+	if err := os.RemoveAll(root); err != nil {
+		return err
+	}
+	entries, err := defaultWorkflowsFS.ReadDir("workflow_defaults")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".rb") {
+			continue
+		}
+		data, err := defaultWorkflowsFS.ReadFile("workflow_defaults/" + e.Name())
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(root, e.Name()), data, 0o644); err != nil {
+			return err
+		}
+	}
+
+	// Stamp last: if a write above failed mid-way the stamp is absent/stale, so
+	// the next run retries rather than trusting a partial materialization.
+	return os.WriteFile(filepath.Join(root, defaultWorkflowStampFile), []byte(version), 0o644)
+}

--- a/internal/tools/workflow_defaults/batch-migrate.rb
+++ b/internal/tools/workflow_defaults/batch-migrate.rb
@@ -1,7 +1,7 @@
 # @description Apply one mechanical change across many files — discover every site, then transform + verify each in its OWN git worktree so parallel edits never collide. args: change (required, what to apply), target (optional scope/paths to search), verify (optional shell command to run in each worktree, e.g. "go build ./...").
-# @param change required What to apply, e.g. "rename foo() to bar()".
-# @param target Scope/paths to search (optional — defaults to the whole repo).
-# @param verify Shell command to run in each worktree to check the change, e.g. "go build ./..." (optional).
+# @param change required: What to apply, e.g. "rename foo() to bar()".
+# @param target: Scope/paths to search (optional — defaults to the whole repo).
+# @param verify: Shell command to run in each worktree to check the change, e.g. "go build ./..." (optional).
 
 # ---- inputs -----------------------------------------------------------------
 a       = args || {}

--- a/internal/tools/workflow_defaults/batch-migrate.rb
+++ b/internal/tools/workflow_defaults/batch-migrate.rb
@@ -1,4 +1,7 @@
 # @description Apply one mechanical change across many files — discover every site, then transform + verify each in its OWN git worktree so parallel edits never collide. args: change (required, what to apply), target (optional scope/paths to search), verify (optional shell command to run in each worktree, e.g. "go build ./...").
+# @param change required What to apply, e.g. "rename foo() to bar()".
+# @param target Scope/paths to search (optional — defaults to the whole repo).
+# @param verify Shell command to run in each worktree to check the change, e.g. "go build ./..." (optional).
 
 # ---- inputs -----------------------------------------------------------------
 a       = args || {}

--- a/internal/tools/workflow_defaults/daily-triage.rb
+++ b/internal/tools/workflow_defaults/daily-triage.rb
@@ -1,6 +1,6 @@
 # @description Run a daily triage loop: discover open issues and recent CI failures, categorize them, draft safe fixes in isolated git worktrees, verify them with a second agent, and write a state report. args: repo (optional path to git repo, defaults to current directory), since (optional "Nh" or "Nd" lookback, e.g. "24h" or "1d", default "1d").
-# @param repo Path to the git repo (optional — defaults to the current directory).
-# @param since Lookback window, e.g. "24h" or "1d" (optional — defaults to "1d").
+# @param repo: Path to the git repo (optional — defaults to the current directory).
+# @param since: Lookback window, e.g. "24h" or "1d" (optional — defaults to "1d").
 
 # ---- inputs -----------------------------------------------------------------
 a          = args || {}

--- a/internal/tools/workflow_defaults/daily-triage.rb
+++ b/internal/tools/workflow_defaults/daily-triage.rb
@@ -1,4 +1,6 @@
 # @description Run a daily triage loop: discover open issues and recent CI failures, categorize them, draft safe fixes in isolated git worktrees, verify them with a second agent, and write a state report. args: repo (optional path to git repo, defaults to current directory), since (optional "Nh" or "Nd" lookback, e.g. "24h" or "1d", default "1d").
+# @param repo Path to the git repo (optional — defaults to the current directory).
+# @param since Lookback window, e.g. "24h" or "1d" (optional — defaults to "1d").
 
 # ---- inputs -----------------------------------------------------------------
 a          = args || {}

--- a/internal/tools/workflow_defaults/parallel-understand.rb
+++ b/internal/tools/workflow_defaults/parallel-understand.rb
@@ -1,7 +1,7 @@
 # @description Map a codebase in parallel — fan out one reader per subsystem, then synthesize a single architecture map. args (all optional): target (what to map, default = this repo), subsystems (array to skip auto-detection), focus (a question to bias the map toward).
-# @param target What to map (optional — defaults to this repository).
-# @param subsystems Array of subsystem names, to skip auto-detection (optional).
-# @param focus A question to bias the map toward (optional).
+# @param target: What to map (optional — defaults to this repository).
+# @param subsystems: Array of subsystem names, to skip auto-detection (optional).
+# @param focus: A question to bias the map toward (optional).
 
 # ---- inputs -----------------------------------------------------------------
 a      = args || {}

--- a/internal/tools/workflow_defaults/parallel-understand.rb
+++ b/internal/tools/workflow_defaults/parallel-understand.rb
@@ -1,4 +1,7 @@
 # @description Map a codebase in parallel — fan out one reader per subsystem, then synthesize a single architecture map. args (all optional): target (what to map, default = this repo), subsystems (array to skip auto-detection), focus (a question to bias the map toward).
+# @param target What to map (optional — defaults to this repository).
+# @param subsystems Array of subsystem names, to skip auto-detection (optional).
+# @param focus A question to bias the map toward (optional).
 
 # ---- inputs -----------------------------------------------------------------
 a      = args || {}

--- a/internal/tools/workflow_defaults_test.go
+++ b/internal/tools/workflow_defaults_test.go
@@ -1,0 +1,107 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMaterializeDefaultWorkflows_WritesEmbeddedAndStamps(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workflows-default")
+
+	if err := materializeDefaultWorkflows(root, "v1", false); err != nil {
+		t.Fatalf("materializeDefaultWorkflows: %v", err)
+	}
+	for _, name := range []string{"batch-migrate.rb", "daily-triage.rb", "parallel-understand.rb"} {
+		if _, err := os.Stat(filepath.Join(root, name)); err != nil {
+			t.Errorf("expected %s materialized: %v", name, err)
+		}
+	}
+	b, err := os.ReadFile(filepath.Join(root, defaultWorkflowStampFile))
+	if err != nil || string(b) != "v1" {
+		t.Fatalf("stamp = %q, %v; want v1", string(b), err)
+	}
+}
+
+func TestMaterializeDefaultWorkflows_NoOpWhenCurrent(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workflows-default")
+	if err := materializeDefaultWorkflows(root, "v1", false); err != nil {
+		t.Fatal(err)
+	}
+	// Drop a sentinel; a no-op (same version) must not wipe the dir.
+	sentinel := filepath.Join(root, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := materializeDefaultWorkflows(root, "v1", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("same-version call should be a no-op, but the dir was rewritten")
+	}
+
+	// A version bump (or force, e.g. UpdateDefaultWorkflows) re-materializes,
+	// wiping stale files.
+	if err := materializeDefaultWorkflows(root, "v2", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Errorf("version bump should wipe-and-rewrite the default root")
+	}
+}
+
+func TestMaterializeDefaultWorkflows_ForceRewritesRegardlessOfStamp(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workflows-default")
+	if err := materializeDefaultWorkflows(root, "v1", false); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(root, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := materializeDefaultWorkflows(root, "v1", true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Errorf("force should wipe-and-rewrite even at the same version")
+	}
+}
+
+func TestMaterializeDefaultWorkflows_EmptyRootIsNoOp(t *testing.T) {
+	if err := materializeDefaultWorkflows("", "v1", false); err != nil {
+		t.Errorf("empty root should be a no-op, got %v", err)
+	}
+}
+
+func TestDiscoverWorkflows_DefaultSurfacesAndIsOverridable(t *testing.T) {
+	defaultRoot := filepath.Join(t.TempDir(), "workflows-default")
+	orig := defaultWorkflowsRoot
+	defaultWorkflowsRoot = func() string { return defaultRoot }
+	t.Cleanup(func() { defaultWorkflowsRoot = orig })
+	if err := materializeDefaultWorkflows(defaultRoot, "v1", false); err != nil {
+		t.Fatal(err)
+	}
+
+	userRoot := t.TempDir()
+	ou, op := userWorkflowsRoot, projectWorkflowsRoot
+	userWorkflowsRoot = func() string { return userRoot }
+	projectWorkflowsRoot = func(_ string) string { return "" }
+	t.Cleanup(func() { userWorkflowsRoot, projectWorkflowsRoot = ou, op })
+
+	// Default-only: batch-migrate is discovered with source "default".
+	w, ok := lookupWorkflow(context.Background(), "batch-migrate")
+	if !ok {
+		t.Fatal("default batch-migrate not discovered")
+	}
+	if w.source != "default" {
+		t.Errorf("source = %q, want default", w.source)
+	}
+
+	// A user workflow of the same name overrides the default.
+	writeWorkflowFile(t, userRoot, "batch-migrate.rb", "# @description my override\n\"x\"\n")
+	w, ok = lookupWorkflow(context.Background(), "batch-migrate")
+	if !ok || w.source != "user" || w.description != "my override" {
+		t.Errorf("user workflow should override default, got %+v, ok=%v", w, ok)
+	}
+}

--- a/internal/tools/workflow_execution_test.go
+++ b/internal/tools/workflow_execution_test.go
@@ -94,8 +94,9 @@ func TestEmbeddedDefaultWorkflows_Execute(t *testing.T) {
 				t.Fatalf("lookupWorkflow(%q): not found", r.name)
 			}
 			got, err := workflow.Run(context.Background(), w.script, workflow.Options{
-				Agent: schemaFakeAgent,
-				Args:  r.args,
+				Agent:      schemaFakeAgent,
+				Args:       r.args,
+				JournalDir: ActiveWorkflowJournalDir(),
 			})
 			if err != nil {
 				t.Fatalf("workflow.Run(%q, args=%s): %v", r.name, r.args, err)
@@ -139,8 +140,9 @@ func TestLoopEngineeringTemplates_Execute(t *testing.T) {
 				t.Fatalf("reading template %q: %v", path, err)
 			}
 			got, err := workflow.Run(context.Background(), string(script), workflow.Options{
-				Agent: schemaFakeAgent,
-				Args:  r.args,
+				Agent:      schemaFakeAgent,
+				Args:       r.args,
+				JournalDir: ActiveWorkflowJournalDir(),
 			})
 			if err != nil {
 				t.Fatalf("workflow.Run(%q, args=%s): %v", r.name, r.args, err)

--- a/internal/tools/workflow_manager.go
+++ b/internal/tools/workflow_manager.go
@@ -71,6 +71,12 @@ type WorkflowRunRequest struct {
 	// was fixed to honor the caller's cwd, but a script's own internal calls
 	// were still losing it here).
 	WorkingDir string
+	// JournalDir overrides the workflow runtime's journal directory
+	// (~/.octo/workflow-journals by default). Empty leaves the runtime
+	// default in place — real entry points never set this; tests point it at
+	// a temp dir so running the suite doesn't write into a developer's real
+	// journal directory (see ActiveWorkflowJournalDir).
+	JournalDir string
 }
 
 // WorkflowRunSnapshot is a point-in-time view of a background run for listing
@@ -256,6 +262,17 @@ func (m *WorkflowManager) Start(req WorkflowRunRequest) (string, error) {
 
 	m.emit(WorkflowEvent{RunID: id, Description: req.Description, Kind: "started"})
 
+	// req.JournalDir is an explicit per-request override; ActiveWorkflowJournalDir
+	// is the process-wide one (empty outside tests). Resolving the fallback here,
+	// not in every caller that builds a WorkflowRunRequest, means a caller that
+	// forgets to set it (or builds the request directly, bypassing WorkflowTool)
+	// still respects the override — the tools package's tests rely on this to
+	// avoid writing into a developer's real ~/.octo/workflow-journals.
+	journalDir := req.JournalDir
+	if journalDir == "" {
+		journalDir = ActiveWorkflowJournalDir()
+	}
+
 	go func() {
 		defer func() {
 			m.mu.Lock()
@@ -278,6 +295,7 @@ func (m *WorkflowManager) Start(req WorkflowRunRequest) (string, error) {
 			MaxConcurrent: req.MaxConcurrent,
 			ResumeFrom:    req.ResumeFrom,
 			Args:          req.Args,
+			JournalDir:    journalDir,
 		})
 
 		errMsg := ""

--- a/internal/tools/workflow_registry.go
+++ b/internal/tools/workflow_registry.go
@@ -23,26 +23,42 @@ var (
 	ErrBuiltinWorkflow  = errors.New("cannot delete a built-in workflow")
 )
 
-// defaultWorkflowsFS holds the workflows shipped with the binary — the curated
-// set every install gets out of the box. Unlike default skills they are not
-// materialized to disk: discoverWorkflows merges them in-memory as the lowest
-// priority on every read, so a same-named user- or project-level file
-// transparently overrides one. `octo workflows` and the web panel read this
-// same in-memory merge (via ListNamedWorkflows/GetNamedWorkflow) rather than
-// scanning a materialized directory, so there's nothing to keep in sync.
+// defaultWorkflowsFS holds the workflows shipped with the binary — the
+// curated set every install gets out of the box. discoverWorkflows seeds the
+// "default" tier from this embed.FS directly, so the built-in set is always
+// available even in a process that never calls MaterializeDefaultWorkflows
+// (a library consumer of this package, or a test). MaterializeDefaultWorkflows
+// (workflow_defaults.go) additionally writes them to ~/.octo/workflows-default
+// so they're discoverable, listable and editable on disk exactly like a user-
+// or project-level workflow (mirrors internal/skills/defaults.go); when
+// present, that materialized copy overlays the embedded one of the same name,
+// so a local edit takes effect immediately rather than waiting for a version
+// bump to re-materialize.
 //
 //go:embed workflow_defaults
 var defaultWorkflowsFS embed.FS
 
 // savedWorkflow is one named workflow script loaded from a registry directory.
-// The script is the full file content (the @description comment is valid Ruby
-// and harmless to re-run).
+// The script is the full file content (the @description/@param comments are
+// valid Ruby and harmless to re-run).
 type savedWorkflow struct {
 	name        string
 	description string
+	params      []workflowParam
 	script      string
 	source      string // "default" | "user" | "project"
 	path        string // on-disk file path; "" for embedded defaults
+}
+
+// workflowParam is one declared input a saved workflow expects, parsed from a
+// leading `# @param <name> [required] [description]` comment line. Required
+// params are checked before the workflow tool runs the script (see
+// ensureRequiredWorkflowParams in workflow.go) — without this, a missing arg
+// would only surface as a Ruby NoMethodError deep inside the mruby sandbox.
+type workflowParam struct {
+	name        string
+	required    bool
+	description string
 }
 
 // userWorkflowsRoot returns ~/.octo/workflows, or "" when the home dir can't be
@@ -80,15 +96,17 @@ var projectWorkflowsRoot = func(cwd string) string {
 	return filepath.Join(root, ".octo", "workflows")
 }
 
-// discoverWorkflows seeds the embedded default workflows, then scans the user-
-// and project-level registries, and returns a fresh map. Precedence is
-// embedded < user < project: a same-named file at a higher level overrides the
-// one below. cwd is the working directory used to resolve the project-level
-// registry; when empty it falls back to the process CWD. Safe to call
-// concurrently; each call returns an independent snapshot.
+// discoverWorkflows seeds the embedded default workflows, overlays the
+// materialized default root (if present), then scans the user- and
+// project-level registries, and returns a fresh map. Precedence is embedded <
+// materialized-default < user < project: a same-named file at a higher level
+// overrides the one below. cwd is the working directory used to resolve the
+// project-level registry; when empty it falls back to the process CWD. Safe
+// to call concurrently; each call returns an independent snapshot.
 func discoverWorkflows(cwd string) map[string]savedWorkflow {
 	fresh := make(map[string]savedWorkflow)
 	scanEmbeddedWorkflows(fresh)
+	scanWorkflowsRoot(defaultWorkflowsRoot(), "default", fresh)
 	userRoot := userWorkflowsRoot()
 	scanWorkflowsRoot(userRoot, "user", fresh)
 	// projectWorkflowsRoot falls back to cwd itself when cwd isn't inside a
@@ -103,7 +121,8 @@ func discoverWorkflows(cwd string) map[string]savedWorkflow {
 
 // scanEmbeddedWorkflows loads the binary's built-in *.rb workflows into dst.
 // Their file name (without .rb) is the authoritative name, matching on-disk
-// discovery so a user/project file of the same name overrides the default.
+// discovery so a materialized-default/user/project file of the same name
+// overrides it.
 func scanEmbeddedWorkflows(dst map[string]savedWorkflow) {
 	entries, err := defaultWorkflowsFS.ReadDir("workflow_defaults")
 	if err != nil {
@@ -122,6 +141,7 @@ func scanEmbeddedWorkflows(dst map[string]savedWorkflow) {
 		dst[name] = savedWorkflow{
 			name:        name,
 			description: workflowDescription(content),
+			params:      workflowParams(content),
 			script:      content,
 			source:      "default",
 		}
@@ -162,8 +182,8 @@ func scanWorkflowsRoot(root, source string, dst map[string]savedWorkflow) {
 
 // parseWorkflowFile reads one .rb workflow script. The whole file is the script;
 // the description comes from a leading `# @description ...` line, falling back to
-// the first non-empty `#` comment line. ok is false only when the file can't be
-// read.
+// the first non-empty `#` comment line, and declared params come from leading
+// `# @param ...` lines. ok is false only when the file can't be read.
 func parseWorkflowFile(path string) (savedWorkflow, bool) {
 	b, err := os.ReadFile(path)
 	if err != nil {
@@ -172,15 +192,16 @@ func parseWorkflowFile(path string) (savedWorkflow, bool) {
 	content := string(b)
 	return savedWorkflow{
 		description: workflowDescription(content),
+		params:      workflowParams(content),
 		script:      content,
 	}, true
 }
 
-// workflowDescription extracts a one-line description from a script's leading
-// comments: the `# @description ...` line if present, else the first non-empty
-// `#` comment line. Empty when neither exists.
-func workflowDescription(script string) string {
-	first := ""
+// leadingComments returns the body text of each leading `#` comment line in
+// script (its header block), stopping at the first blank-trimmed line that
+// isn't a comment.
+func leadingComments(script string) []string {
+	var out []string
 	for _, ln := range strings.Split(script, "\n") {
 		t := strings.TrimSpace(ln)
 		if t == "" {
@@ -189,7 +210,17 @@ func workflowDescription(script string) string {
 		if !strings.HasPrefix(t, "#") {
 			break // first line of real code: no more leading comments
 		}
-		body := strings.TrimSpace(strings.TrimPrefix(t, "#"))
+		out = append(out, strings.TrimSpace(strings.TrimPrefix(t, "#")))
+	}
+	return out
+}
+
+// workflowDescription extracts a one-line description from a script's leading
+// comments: the `# @description ...` line if present, else the first non-empty
+// `#` comment line. Empty when neither exists.
+func workflowDescription(script string) string {
+	first := ""
+	for _, body := range leadingComments(script) {
 		if d := strings.TrimSpace(strings.TrimPrefix(body, "@description")); d != body {
 			return d
 		}
@@ -198,6 +229,34 @@ func workflowDescription(script string) string {
 		}
 	}
 	return first
+}
+
+// workflowParams extracts `# @param <name> [required] [description]`
+// declarations from a script's leading comment block. The name is the first
+// whitespace-delimited token; an optional literal "required" keyword marks it
+// mandatory; anything after that is the description shown when the workflow
+// tool prompts the user for a missing value.
+func workflowParams(script string) []workflowParam {
+	var out []workflowParam
+	for _, body := range leadingComments(script) {
+		rest := strings.TrimSpace(strings.TrimPrefix(body, "@param"))
+		if rest == body {
+			continue // not an @param line
+		}
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			continue
+		}
+		name := fields[0]
+		rest = strings.TrimSpace(strings.TrimPrefix(rest, name))
+		required := false
+		if rest == "required" || strings.HasPrefix(rest, "required ") {
+			required = true
+			rest = strings.TrimSpace(strings.TrimPrefix(rest, "required"))
+		}
+		out = append(out, workflowParam{name: name, required: required, description: rest})
+	}
+	return out
 }
 
 // lookupWorkflow returns the named workflow, scanning the registries fresh so a

--- a/internal/tools/workflow_registry.go
+++ b/internal/tools/workflow_registry.go
@@ -231,30 +231,40 @@ func workflowDescription(script string) string {
 	return first
 }
 
-// workflowParams extracts `# @param <name> [required] [description]`
-// declarations from a script's leading comment block. The name is the first
-// whitespace-delimited token; an optional literal "required" keyword marks it
-// mandatory; anything after that is the description shown when the workflow
-// tool prompts the user for a missing value.
+// workflowParams extracts `# @param <name> [required][: <description>]`
+// declarations from a script's leading comment block, written by
+// formatWorkflowParamComment (workflow_save.go). The colon is load-bearing:
+// everything before it is pure grammar (name, then an optional literal
+// "required" token), everything after is free-text description, so a
+// description that itself starts with the word "required" (e.g. "required
+// command to double check") can never be misparsed as the required flag —
+// unlike a naive token-stream split, which would (and would also eat that
+// word out of the description).
 func workflowParams(script string) []workflowParam {
 	var out []workflowParam
 	for _, body := range leadingComments(script) {
-		rest := strings.TrimSpace(strings.TrimPrefix(body, "@param"))
-		if rest == body {
-			continue // not an @param line
+		// Word-boundary check: "@param" must be the whole line or followed by
+		// whitespace, so a line like "@parameterized ..." (which merely starts
+		// with the same runes) isn't misread as a parameter declaration.
+		if body != "@param" && !strings.HasPrefix(body, "@param ") {
+			continue
 		}
-		fields := strings.Fields(rest)
+		rest := strings.TrimSpace(strings.TrimPrefix(body, "@param"))
+		if rest == "" {
+			continue
+		}
+		head, description := rest, ""
+		if idx := strings.Index(rest, ":"); idx >= 0 {
+			head = strings.TrimSpace(rest[:idx])
+			description = strings.TrimSpace(rest[idx+1:])
+		}
+		fields := strings.Fields(head)
 		if len(fields) == 0 {
 			continue
 		}
 		name := fields[0]
-		rest = strings.TrimSpace(strings.TrimPrefix(rest, name))
-		required := false
-		if rest == "required" || strings.HasPrefix(rest, "required ") {
-			required = true
-			rest = strings.TrimSpace(strings.TrimPrefix(rest, "required"))
-		}
-		out = append(out, workflowParam{name: name, required: required, description: rest})
+		required := len(fields) > 1 && fields[1] == "required"
+		out = append(out, workflowParam{name: name, required: required, description: description})
 	}
 	return out
 }

--- a/internal/tools/workflow_registry_test.go
+++ b/internal/tools/workflow_registry_test.go
@@ -12,13 +12,22 @@ import (
 	"github.com/open-octo/octo-agent/internal/trash"
 )
 
-// useWorkflowRoots points the user/project registries at temp dirs for the test.
+// useWorkflowRoots points the default/user/project registries at temp dirs
+// for the test. The default root is materialized from the real embedded
+// workflow scripts (not left empty), so tests exercise the same disk-backed
+// "default" tier production uses — deterministically, rather than depending
+// on whatever might already be materialized on the machine running the test.
 func useWorkflowRoots(t *testing.T, userDir, projectDir string) {
 	t.Helper()
-	ou, op := userWorkflowsRoot, projectWorkflowsRoot
+	ou, op, od := userWorkflowsRoot, projectWorkflowsRoot, defaultWorkflowsRoot
+	dflt := t.TempDir()
+	if err := materializeDefaultWorkflows(dflt, "test", true); err != nil {
+		t.Fatalf("materialize default workflows: %v", err)
+	}
 	userWorkflowsRoot = func() string { return userDir }
 	projectWorkflowsRoot = func(_ string) string { return projectDir }
-	t.Cleanup(func() { userWorkflowsRoot, projectWorkflowsRoot = ou, op })
+	defaultWorkflowsRoot = func() string { return dflt }
+	t.Cleanup(func() { userWorkflowsRoot, projectWorkflowsRoot, defaultWorkflowsRoot = ou, op, od })
 }
 
 func writeWorkflowFile(t *testing.T, root, name, content string) {
@@ -54,6 +63,29 @@ func TestWorkflowDescription_FallsBackToFirstComment(t *testing.T) {
 	}
 	if got := workflowDescription("agent(\"x\")"); got != "" {
 		t.Errorf("description = %q, want empty when no leading comment", got)
+	}
+}
+
+func TestWorkflowParams_ParsesRequiredAndOptional(t *testing.T) {
+	script := "# @description does a thing\n" +
+		"# @param target required the file to migrate\n" +
+		"# @param dry_run skip to preview, off by default\n" +
+		"agent(args[\"target\"])\n"
+	got := workflowParams(script)
+	if len(got) != 2 {
+		t.Fatalf("workflowParams = %+v, want 2 entries", got)
+	}
+	if got[0].name != "target" || !got[0].required || got[0].description != "the file to migrate" {
+		t.Errorf("params[0] = %+v", got[0])
+	}
+	if got[1].name != "dry_run" || got[1].required || got[1].description != "skip to preview, off by default" {
+		t.Errorf("params[1] = %+v, want not required", got[1])
+	}
+}
+
+func TestWorkflowParams_NoneWhenNoParamComments(t *testing.T) {
+	if got := workflowParams("# @description just a note\nagent(\"x\")"); len(got) != 0 {
+		t.Errorf("workflowParams = %+v, want none", got)
 	}
 }
 
@@ -115,6 +147,21 @@ func TestLookupWorkflow_SameUserAndProjectRootStaysUser_ThroughSymlink(t *testin
 	}
 }
 
+func TestLookupWorkflow_ParsesParams(t *testing.T) {
+	user := t.TempDir()
+	useWorkflowRoots(t, user, "")
+	writeWorkflowFile(t, user, "migrate.rb",
+		"# @description Migrate\n# @param target required Path to migrate\nagent(args[\"target\"])\n")
+
+	w, ok := lookupWorkflow(context.Background(), "migrate")
+	if !ok {
+		t.Fatal("lookupWorkflow: not found")
+	}
+	if len(w.params) != 1 || w.params[0].name != "target" || !w.params[0].required {
+		t.Errorf("params = %+v", w.params)
+	}
+}
+
 func TestLookupWorkflow_UnknownName(t *testing.T) {
 	useWorkflowRoots(t, t.TempDir(), t.TempDir())
 	if _, ok := lookupWorkflow(context.Background(), "nope"); ok {
@@ -152,6 +199,21 @@ func containsName(names []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// TestLookupWorkflow_BatchMigrateDeclaresRequiredChange pins that the
+// embedded batch-migrate preset declares its required "change" arg via
+// `# @param`, so the workflow tool prompts for it up front instead of
+// batch-migrate's own defensive empty-string check firing after a wasted run.
+func TestLookupWorkflow_BatchMigrateDeclaresRequiredChange(t *testing.T) {
+	useWorkflowRoots(t, "", "")
+	w, ok := lookupWorkflow(context.Background(), "batch-migrate")
+	if !ok {
+		t.Fatal("batch-migrate not found")
+	}
+	if req := requiredParamNames(w.params); len(req) != 1 || req[0] != "change" {
+		t.Errorf("batch-migrate required params = %v, want [change]", req)
+	}
 }
 
 func TestLookupWorkflow_EmbeddedDefaultAlwaysAvailable(t *testing.T) {

--- a/internal/tools/workflow_registry_test.go
+++ b/internal/tools/workflow_registry_test.go
@@ -68,8 +68,8 @@ func TestWorkflowDescription_FallsBackToFirstComment(t *testing.T) {
 
 func TestWorkflowParams_ParsesRequiredAndOptional(t *testing.T) {
 	script := "# @description does a thing\n" +
-		"# @param target required the file to migrate\n" +
-		"# @param dry_run skip to preview, off by default\n" +
+		"# @param target required: the file to migrate\n" +
+		"# @param dry_run: skip to preview, off by default\n" +
 		"agent(args[\"target\"])\n"
 	got := workflowParams(script)
 	if len(got) != 2 {
@@ -80,6 +80,34 @@ func TestWorkflowParams_ParsesRequiredAndOptional(t *testing.T) {
 	}
 	if got[1].name != "dry_run" || got[1].required || got[1].description != "skip to preview, off by default" {
 		t.Errorf("params[1] = %+v, want not required", got[1])
+	}
+}
+
+// TestWorkflowParams_DescriptionStartingWithRequiredWordIsNotMisparsed guards
+// the exact collision a review caught: the colon is what lets a description
+// that happens to start with the literal word "required" stay a plain
+// optional param, instead of the bare "required" keyword-prefix check
+// mistaking it for the required flag and eating the word out of the text.
+func TestWorkflowParams_DescriptionStartingWithRequiredWordIsNotMisparsed(t *testing.T) {
+	script := "# @param verify: required command to double check\n" + "agent(1)\n"
+	got := workflowParams(script)
+	if len(got) != 1 {
+		t.Fatalf("workflowParams = %+v, want 1 entry", got)
+	}
+	if got[0].required {
+		t.Errorf("params[0].required = true, want false — the word came from the description, not the flag")
+	}
+	if got[0].description != "required command to double check" {
+		t.Errorf("params[0].description = %q, want the full text preserved", got[0].description)
+	}
+}
+
+// TestWorkflowParams_AtParamPrefixRequiresWordBoundary guards against a
+// leading comment like "@parameterized ..." being misread as an @param
+// declaration merely because it shares the same leading runes.
+func TestWorkflowParams_AtParamPrefixRequiresWordBoundary(t *testing.T) {
+	if got := workflowParams("# @parameterized foo bar\nagent(1)\n"); len(got) != 0 {
+		t.Errorf("workflowParams = %+v, want none (not a real @param line)", got)
 	}
 }
 
@@ -151,7 +179,7 @@ func TestLookupWorkflow_ParsesParams(t *testing.T) {
 	user := t.TempDir()
 	useWorkflowRoots(t, user, "")
 	writeWorkflowFile(t, user, "migrate.rb",
-		"# @description Migrate\n# @param target required Path to migrate\nagent(args[\"target\"])\n")
+		"# @description Migrate\n# @param target required: Path to migrate\nagent(args[\"target\"])\n")
 
 	w, ok := lookupWorkflow(context.Background(), "migrate")
 	if !ok {

--- a/internal/tools/workflow_save.go
+++ b/internal/tools/workflow_save.go
@@ -16,6 +16,12 @@ import (
 // traversal or shell-hostile characters.
 var workflowNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 
+// paramNamePattern constrains a declared param name to a valid Ruby hash key
+// as it will appear, unquoted, in a `# @param <name> ...` comment line —
+// letters, digits and underscore, so a name can never be confused with the
+// "required" keyword or split across the whitespace-delimited parse.
+var paramNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
 // WorkflowSaveTool persists a Ruby workflow script to the registry so it can be
 // re-run by name with the workflow tool. Like the workflow tool, it is
 // advertised only when a Spawner is configured.
@@ -48,6 +54,31 @@ func (WorkflowSaveTool) Definition() agent.ToolDefinition {
 					"enum":        []string{"project", "user"},
 					"description": "Where to save: \"project\" (default) = the repo's .octo/workflows; \"user\" = ~/.octo/workflows (available across projects).",
 				},
+				"params": map[string]any{
+					"type": "array",
+					"description": "Optional declared inputs for this workflow, stored as `# @param` comments. " +
+						"Mark one required to make the workflow tool check for it before running and prompt " +
+						"the user for a value when it's missing from `args`, instead of the script failing on " +
+						"a nil args[...] lookup at runtime.",
+					"items": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"name": map[string]any{
+								"type":        "string",
+								"description": "Key read via args[\"name\"] in the script. Letters, digits and underscore only — no spaces.",
+							},
+							"required": map[string]any{
+								"type":        "boolean",
+								"description": "Whether the workflow tool must have this value before running.",
+							},
+							"description": map[string]any{
+								"type":        "string",
+								"description": "Shown to the user when prompting for a missing value.",
+							},
+						},
+						"required": []string{"name"},
+					},
+				},
 			},
 			"required": []string{"name", "script"},
 		},
@@ -64,6 +95,10 @@ func (WorkflowSaveTool) Execute(ctx context.Context, _ string, input map[string]
 		return agent.ToolResult{}, fmt.Errorf("workflow_save: script is required")
 	}
 	description := strings.TrimSpace(stringArg(input, "description"))
+	params, err := parseWorkflowSaveParams(input["params"])
+	if err != nil {
+		return agent.ToolResult{}, fmt.Errorf("workflow_save: %w", err)
+	}
 
 	scope := strings.TrimSpace(stringArg(input, "scope"))
 	if scope == "" {
@@ -94,7 +129,13 @@ func (WorkflowSaveTool) Execute(ctx context.Context, _ string, input map[string]
 
 	var b strings.Builder
 	if description != "" {
-		fmt.Fprintf(&b, "# @description %s\n\n", description)
+		fmt.Fprintf(&b, "# @description %s\n", description)
+	}
+	for _, p := range params {
+		fmt.Fprintf(&b, "# @param %s\n", formatWorkflowParamComment(p))
+	}
+	if description != "" || len(params) > 0 {
+		b.WriteString("\n")
 	}
 	b.WriteString(script)
 	if !strings.HasSuffix(script, "\n") {
@@ -111,4 +152,49 @@ func (WorkflowSaveTool) Execute(ctx context.Context, _ string, input map[string]
 	return agent.ToolResult{Text: fmt.Sprintf(
 		"%s workflow %q to %s. Run it with workflow(name: %q, args: {...}).",
 		verb, name, path, name)}, nil
+}
+
+// parseWorkflowSaveParams validates and converts the tool's `params` input
+// (an array of {name, required, description} objects) into workflowParams,
+// ready to render as `# @param` comment lines. nil input is not an error —
+// most workflows have no declared params.
+func parseWorkflowSaveParams(raw any) ([]workflowParam, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("params must be an array")
+	}
+	out := make([]workflowParam, 0, len(items))
+	for _, it := range items {
+		m, ok := it.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("each params entry must be an object")
+		}
+		name := strings.TrimSpace(stringArg(m, "name"))
+		if !paramNamePattern.MatchString(name) {
+			return nil, fmt.Errorf("invalid param name %q — use letters, digits and underscore only", name)
+		}
+		out = append(out, workflowParam{
+			name:        name,
+			required:    askBool(m, "required"),
+			description: strings.TrimSpace(stringArg(m, "description")),
+		})
+	}
+	return out, nil
+}
+
+// formatWorkflowParamComment renders a workflowParam as the text following
+// `# @param ` in a saved workflow file — the exact shape workflowParams (in
+// workflow_registry.go) parses back.
+func formatWorkflowParamComment(p workflowParam) string {
+	s := p.name
+	if p.required {
+		s += " required"
+	}
+	if p.description != "" {
+		s += " " + p.description
+	}
+	return s
 }

--- a/internal/tools/workflow_save.go
+++ b/internal/tools/workflow_save.go
@@ -94,7 +94,7 @@ func (WorkflowSaveTool) Execute(ctx context.Context, _ string, input map[string]
 	if script == "" {
 		return agent.ToolResult{}, fmt.Errorf("workflow_save: script is required")
 	}
-	description := strings.TrimSpace(stringArg(input, "description"))
+	description := sanitizeCommentText(stringArg(input, "description"))
 	params, err := parseWorkflowSaveParams(input["params"])
 	if err != nil {
 		return agent.ToolResult{}, fmt.Errorf("workflow_save: %w", err)
@@ -179,22 +179,38 @@ func parseWorkflowSaveParams(raw any) ([]workflowParam, error) {
 		out = append(out, workflowParam{
 			name:        name,
 			required:    askBool(m, "required"),
-			description: strings.TrimSpace(stringArg(m, "description")),
+			description: sanitizeCommentText(stringArg(m, "description")),
 		})
 	}
 	return out, nil
 }
 
+// sanitizeCommentText collapses embedded newlines into spaces so a
+// multi-line description can never break out of its single-line `#` comment
+// when written to a saved workflow file. An unsanitized embedded newline
+// would land as a bare, non-`#`-prefixed line in the file's leading-comment
+// block, corrupting leadingComments' parse (workflowDescription/workflowParams
+// would stop scanning right there) and, worse, could inject a line that mruby
+// executes as real script code.
+func sanitizeCommentText(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return strings.TrimSpace(s)
+}
+
 // formatWorkflowParamComment renders a workflowParam as the text following
 // `# @param ` in a saved workflow file — the exact shape workflowParams (in
-// workflow_registry.go) parses back.
+// workflow_registry.go) parses back. The colon before the description is
+// load-bearing: it's what lets workflowParams tell "required" the keyword
+// apart from a description that merely starts with that word.
 func formatWorkflowParamComment(p workflowParam) string {
 	s := p.name
 	if p.required {
 		s += " required"
 	}
 	if p.description != "" {
-		s += " " + p.description
+		s += ": " + p.description
 	}
 	return s
 }

--- a/internal/tools/workflow_save_test.go
+++ b/internal/tools/workflow_save_test.go
@@ -57,6 +57,56 @@ func TestWorkflowSave_ProjectScopeUsesContextWorkingDir(t *testing.T) {
 	})
 }
 
+func TestWorkflowSave_WritesParamComments(t *testing.T) {
+	user, project := t.TempDir(), t.TempDir()
+	useWorkflowRoots(t, user, project)
+
+	_, err := WorkflowSaveTool{}.Execute(context.Background(), "c", map[string]any{
+		"name":        "migrate",
+		"script":      `agent(args["target"])`,
+		"description": "Migrate files",
+		"params": []any{
+			map[string]any{"name": "target", "required": true, "description": "Path to migrate"},
+			map[string]any{"name": "dry_run"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(project, "migrate.rb"))
+	if err != nil {
+		t.Fatalf("read saved file: %v", err)
+	}
+	content := string(b)
+	if !strings.Contains(content, "# @param target required Path to migrate\n") {
+		t.Errorf("file = %q, want a required @param line", content)
+	}
+	if !strings.Contains(content, "# @param dry_run\n") {
+		t.Errorf("file = %q, want an optional @param line", content)
+	}
+
+	w, ok := lookupWorkflow(context.Background(), "migrate")
+	if !ok {
+		t.Fatal("lookupWorkflow: not found")
+	}
+	if len(w.params) != 2 || w.params[0].name != "target" || !w.params[0].required || w.params[1].required {
+		t.Errorf("params = %+v", w.params)
+	}
+}
+
+func TestWorkflowSave_RejectsBadParamName(t *testing.T) {
+	useWorkflowRoots(t, t.TempDir(), t.TempDir())
+	_, err := WorkflowSaveTool{}.Execute(context.Background(), "c", map[string]any{
+		"name":   "bad-param",
+		"script": `"x"`,
+		"params": []any{map[string]any{"name": "has space"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid param name") {
+		t.Errorf("err = %v, want invalid-param-name error", err)
+	}
+}
+
 func TestWorkflowSave_UserScope(t *testing.T) {
 	user, project := t.TempDir(), t.TempDir()
 	useWorkflowRoots(t, user, project)

--- a/internal/tools/workflow_save_test.go
+++ b/internal/tools/workflow_save_test.go
@@ -79,7 +79,7 @@ func TestWorkflowSave_WritesParamComments(t *testing.T) {
 		t.Fatalf("read saved file: %v", err)
 	}
 	content := string(b)
-	if !strings.Contains(content, "# @param target required Path to migrate\n") {
+	if !strings.Contains(content, "# @param target required: Path to migrate\n") {
 		t.Errorf("file = %q, want a required @param line", content)
 	}
 	if !strings.Contains(content, "# @param dry_run\n") {
@@ -92,6 +92,91 @@ func TestWorkflowSave_WritesParamComments(t *testing.T) {
 	}
 	if len(w.params) != 2 || w.params[0].name != "target" || !w.params[0].required || w.params[1].required {
 		t.Errorf("params = %+v", w.params)
+	}
+	if w.params[0].description != "Path to migrate" {
+		t.Errorf("params[0].description = %q, want %q", w.params[0].description, "Path to migrate")
+	}
+}
+
+// TestWorkflowSave_ParamDescriptionStartingWithRequiredWordRoundTrips is the
+// end-to-end regression for the review-caught collision: a param explicitly
+// marked NOT required, whose description happens to start with the word
+// "required", must round-trip through workflow_save → disk → workflowParams
+// as an optional param with the description intact — not silently flip to
+// required with the leading word eaten.
+func TestWorkflowSave_ParamDescriptionStartingWithRequiredWordRoundTrips(t *testing.T) {
+	user, project := t.TempDir(), t.TempDir()
+	useWorkflowRoots(t, user, project)
+
+	_, err := WorkflowSaveTool{}.Execute(context.Background(), "c", map[string]any{
+		"name":   "verify-step",
+		"script": `agent(args["verify"])`,
+		"params": []any{
+			map[string]any{"name": "verify", "required": false, "description": "required command to double check"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	w, ok := lookupWorkflow(context.Background(), "verify-step")
+	if !ok {
+		t.Fatal("lookupWorkflow: not found")
+	}
+	if len(w.params) != 1 {
+		t.Fatalf("params = %+v, want 1 entry", w.params)
+	}
+	if w.params[0].required {
+		t.Errorf("params[0].required = true, want false (declared non-required)")
+	}
+	if w.params[0].description != "required command to double check" {
+		t.Errorf("params[0].description = %q, want the full text preserved", w.params[0].description)
+	}
+}
+
+// TestWorkflowSave_SanitizesEmbeddedNewlines guards against a
+// description (top-level or per-param) containing a raw newline breaking out
+// of its single-line `#` comment when written to disk — an unsanitized
+// newline would land as a bare non-`#` line in the leading-comment block,
+// corrupting leadingComments' parse (and, worse, could be read as literal
+// script by the mruby interpreter that follows the header).
+func TestWorkflowSave_SanitizesEmbeddedNewlines(t *testing.T) {
+	user, project := t.TempDir(), t.TempDir()
+	useWorkflowRoots(t, user, project)
+
+	_, err := WorkflowSaveTool{}.Execute(context.Background(), "c", map[string]any{
+		"name":        "injected",
+		"script":      `"ok"`,
+		"description": "line one\nFile.write(\"pwned\", \"x\")",
+		"params": []any{
+			map[string]any{"name": "p", "description": "also\nmultiline"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(project, "injected.rb"))
+	if err != nil {
+		t.Fatalf("read saved file: %v", err)
+	}
+	for _, ln := range strings.Split(strings.TrimRight(string(b), "\n"), "\n") {
+		if ln == `"ok"` {
+			break // reached the real script body — header block is done
+		}
+		// A blank line (the deliberate separator before the script body) is
+		// fine; anything else must still be a `#` comment.
+		if ln != "" && !strings.HasPrefix(ln, "#") {
+			t.Fatalf("header line %q is not a comment — an embedded newline broke out of the comment block:\n%s", ln, string(b))
+		}
+	}
+
+	w, ok := lookupWorkflow(context.Background(), "injected")
+	if !ok {
+		t.Fatal("lookupWorkflow: not found")
+	}
+	if strings.Contains(w.description, "\n") || strings.Contains(w.params[0].description, "\n") {
+		t.Errorf("descriptions still contain a newline: %+v", w)
 	}
 }
 

--- a/internal/tools/workflow_test.go
+++ b/internal/tools/workflow_test.go
@@ -520,6 +520,106 @@ func TestWorkflowTool_RunsSavedByName(t *testing.T) {
 	}
 }
 
+// TestWorkflowTool_RunsSavedByName_PromptsForMissingRequiredArg verifies a
+// saved workflow that declares a required param has the tool ask the user for
+// it (via the same Asker ask_user_question uses) rather than letting the
+// script hit a nil args[...] lookup at runtime.
+func TestWorkflowTool_RunsSavedByName_PromptsForMissingRequiredArg(t *testing.T) {
+	SetSpawner(replySpawner{})
+	t.Cleanup(func() { SetSpawner(nil) })
+	user := t.TempDir()
+	useWorkflowRoots(t, user, "")
+	writeWorkflowFile(t, user, "echo.rb",
+		"# @description echo the arg\n# @param q required the text to echo\nagent(args[\"q\"])\n")
+
+	stub := &stubAsker{resp: AskResponse{Custom: "hi there"}}
+	useAsker(t, stub)
+
+	got := startWorkflowAndWait(t, map[string]any{"name": "echo"})
+	if !stub.called {
+		t.Fatal("expected the tool to prompt for the missing required arg")
+	}
+	if !strings.Contains(stub.lastReq.Question, "q") {
+		t.Errorf("question = %q, want it to mention the missing param name", stub.lastReq.Question)
+	}
+	if !strings.Contains(got, "R[hi there]") {
+		t.Errorf("output = %q, want the prompted value to reach the script", got)
+	}
+}
+
+// TestWorkflowTool_RunsSavedByName_ArgsAlreadySatisfyRequired verifies no
+// prompt fires when the caller already supplied the required arg.
+func TestWorkflowTool_RunsSavedByName_ArgsAlreadySatisfyRequired(t *testing.T) {
+	SetSpawner(replySpawner{})
+	t.Cleanup(func() { SetSpawner(nil) })
+	user := t.TempDir()
+	useWorkflowRoots(t, user, "")
+	writeWorkflowFile(t, user, "echo.rb",
+		"# @description echo the arg\n# @param q required the text to echo\nagent(args[\"q\"])\n")
+
+	stub := &stubAsker{}
+	useAsker(t, stub)
+
+	got := startWorkflowAndWait(t, map[string]any{"name": "echo", "args": map[string]any{"q": "hello"}})
+	if stub.called {
+		t.Error("should not prompt when the required arg is already provided")
+	}
+	if !strings.Contains(got, "R[hello]") {
+		t.Errorf("output = %q, want the provided arg to reach the script", got)
+	}
+}
+
+// TestWorkflowTool_RunsSavedByName_MissingRequiredArgNoAsker verifies a clear
+// error (not a hang, not a Ruby crash deep in mruby) when there's no user to
+// ask — the non-interactive/headless case.
+func TestWorkflowTool_RunsSavedByName_MissingRequiredArgNoAsker(t *testing.T) {
+	SetSpawner(replySpawner{})
+	t.Cleanup(func() { SetSpawner(nil) })
+	SetAsker(nil)
+	user := t.TempDir()
+	useWorkflowRoots(t, user, "")
+	writeWorkflowFile(t, user, "echo.rb",
+		"# @description echo the arg\n# @param q required the text to echo\nagent(args[\"q\"])\n")
+
+	_, err := WorkflowTool{}.Execute(context.Background(), "c", map[string]any{"name": "echo"})
+	if err == nil || !strings.Contains(err.Error(), "missing required arg") {
+		t.Errorf("err = %v, want a missing-required-arg error", err)
+	}
+}
+
+// TestWorkflowTool_RunsSavedByName_CancelledPromptErrors verifies a cancelled
+// prompt aborts the run with an error instead of running with a blank value.
+func TestWorkflowTool_RunsSavedByName_CancelledPromptErrors(t *testing.T) {
+	SetSpawner(replySpawner{})
+	t.Cleanup(func() { SetSpawner(nil) })
+	user := t.TempDir()
+	useWorkflowRoots(t, user, "")
+	writeWorkflowFile(t, user, "echo.rb",
+		"# @description echo the arg\n# @param q required the text to echo\nagent(args[\"q\"])\n")
+	useAsker(t, &stubAsker{resp: AskResponse{Cancelled: true}})
+
+	_, err := WorkflowTool{}.Execute(context.Background(), "c", map[string]any{"name": "echo"})
+	if err == nil || !strings.Contains(err.Error(), "cancelled") {
+		t.Errorf("err = %v, want a cancellation error", err)
+	}
+}
+
+// TestSavedWorkflowsParamDesc_ListsRequiredParams verifies the `name`
+// parameter's "Available: ..." listing surfaces required params up front, so
+// the model can supply them directly instead of round-tripping through a
+// prompt.
+func TestSavedWorkflowsParamDesc_ListsRequiredParams(t *testing.T) {
+	user := t.TempDir()
+	useWorkflowRoots(t, user, "")
+	writeWorkflowFile(t, user, "migrate.rb",
+		"# @description Migrate files\n# @param target required Path to migrate\nagent(args[\"target\"])\n")
+
+	d := savedWorkflowsParamDesc()
+	if !strings.Contains(d, "requires: target") {
+		t.Errorf("description = %q, want it to list required params", d)
+	}
+}
+
 func TestWorkflowTool_UnknownName(t *testing.T) {
 	SetSpawner(replySpawner{})
 	t.Cleanup(func() { SetSpawner(nil) })

--- a/internal/tools/workflow_test.go
+++ b/internal/tools/workflow_test.go
@@ -530,7 +530,7 @@ func TestWorkflowTool_RunsSavedByName_PromptsForMissingRequiredArg(t *testing.T)
 	user := t.TempDir()
 	useWorkflowRoots(t, user, "")
 	writeWorkflowFile(t, user, "echo.rb",
-		"# @description echo the arg\n# @param q required the text to echo\nagent(args[\"q\"])\n")
+		"# @description echo the arg\n# @param q required: the text to echo\nagent(args[\"q\"])\n")
 
 	stub := &stubAsker{resp: AskResponse{Custom: "hi there"}}
 	useAsker(t, stub)
@@ -555,7 +555,7 @@ func TestWorkflowTool_RunsSavedByName_ArgsAlreadySatisfyRequired(t *testing.T) {
 	user := t.TempDir()
 	useWorkflowRoots(t, user, "")
 	writeWorkflowFile(t, user, "echo.rb",
-		"# @description echo the arg\n# @param q required the text to echo\nagent(args[\"q\"])\n")
+		"# @description echo the arg\n# @param q required: the text to echo\nagent(args[\"q\"])\n")
 
 	stub := &stubAsker{}
 	useAsker(t, stub)
@@ -579,7 +579,7 @@ func TestWorkflowTool_RunsSavedByName_MissingRequiredArgNoAsker(t *testing.T) {
 	user := t.TempDir()
 	useWorkflowRoots(t, user, "")
 	writeWorkflowFile(t, user, "echo.rb",
-		"# @description echo the arg\n# @param q required the text to echo\nagent(args[\"q\"])\n")
+		"# @description echo the arg\n# @param q required: the text to echo\nagent(args[\"q\"])\n")
 
 	_, err := WorkflowTool{}.Execute(context.Background(), "c", map[string]any{"name": "echo"})
 	if err == nil || !strings.Contains(err.Error(), "missing required arg") {
@@ -595,7 +595,7 @@ func TestWorkflowTool_RunsSavedByName_CancelledPromptErrors(t *testing.T) {
 	user := t.TempDir()
 	useWorkflowRoots(t, user, "")
 	writeWorkflowFile(t, user, "echo.rb",
-		"# @description echo the arg\n# @param q required the text to echo\nagent(args[\"q\"])\n")
+		"# @description echo the arg\n# @param q required: the text to echo\nagent(args[\"q\"])\n")
 	useAsker(t, &stubAsker{resp: AskResponse{Cancelled: true}})
 
 	_, err := WorkflowTool{}.Execute(context.Background(), "c", map[string]any{"name": "echo"})
@@ -612,7 +612,7 @@ func TestSavedWorkflowsParamDesc_ListsRequiredParams(t *testing.T) {
 	user := t.TempDir()
 	useWorkflowRoots(t, user, "")
 	writeWorkflowFile(t, user, "migrate.rb",
-		"# @description Migrate files\n# @param target required Path to migrate\nagent(args[\"target\"])\n")
+		"# @description Migrate files\n# @param target required: Path to migrate\nagent(args[\"target\"])\n")
 
 	d := savedWorkflowsParamDesc()
 	if !strings.Contains(d, "requires: target") {

--- a/internal/workflow/journal.go
+++ b/internal/workflow/journal.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -57,6 +58,49 @@ func journalsDir() (string, error) {
 		return "", fmt.Errorf("workflow: mkdir %s: %w", dir, err)
 	}
 	return dir, nil
+}
+
+// journalMaxAge is how long a journal file is kept before PruneJournals
+// removes it. A journal exists to resume a run that was interrupted
+// mid-flight; in practice a resume happens within minutes of the interruption,
+// not days later, so a generous week-long window comfortably covers real
+// usage while keeping the directory from growing unbounded — nothing else
+// ever deletes these files.
+const journalMaxAge = 7 * 24 * time.Hour
+
+// PruneJournals removes ~/.octo/workflow-journals files last modified more
+// than journalMaxAge ago. Best-effort: the caller should ignore the error so
+// a read-only or missing HOME never blocks a session.
+func PruneJournals() error {
+	dir, err := journalsDir()
+	if err != nil {
+		return err
+	}
+	return pruneJournalsDir(dir, time.Now())
+}
+
+// pruneJournalsDir removes *.jsonl files in dir last modified before
+// now.Add(-journalMaxAge). now is a parameter so tests can pin it instead of
+// depending on file mtimes lining up with wall-clock sleeps. A per-file
+// stat/remove error is skipped rather than aborting the whole pass, since one
+// bad file shouldn't block cleanup of the rest.
+func pruneJournalsDir(dir string, now time.Time) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	cutoff := now.Add(-journalMaxAge)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir, e.Name()))
+	}
+	return nil
 }
 
 // JournalEntry records one completed agent() call.

--- a/internal/workflow/journal_test.go
+++ b/internal/workflow/journal_test.go
@@ -97,9 +97,13 @@ func TestPruneJournalsDir_RemovesOnlyStaleFiles(t *testing.T) {
 	}
 }
 
-func TestPruneJournalsDir_MissingDirIsNotAnError(t *testing.T) {
+// TestPruneJournalsDir_MissingDirReturnsError pins that pruneJournalsDir
+// itself propagates os.ReadDir's error rather than swallowing it — it's
+// PruneJournals' caller (and, ultimately, cmd/octo/main.go's `_ =`) that
+// treats a missing/unreadable journal dir as best-effort, not this function.
+func TestPruneJournalsDir_MissingDirReturnsError(t *testing.T) {
 	if err := pruneJournalsDir(filepath.Join(t.TempDir(), "nonexistent"), time.Now()); err == nil {
-		t.Error("want an error for a missing dir (caller treats it as best-effort)")
+		t.Error("want an error for a missing dir (the caller is what treats this as best-effort)")
 	}
 }
 

--- a/internal/workflow/journal_test.go
+++ b/internal/workflow/journal_test.go
@@ -2,9 +2,12 @@ package workflow
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // newTestCtx returns a background context (a no-op helper that keeps test
@@ -68,6 +71,48 @@ func TestLoadJournal_NotFound(t *testing.T) {
 	_, _, err := LoadJournal(t.TempDir(), "wf-nonexistent")
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Errorf("err = %v, want not-found", err)
+	}
+}
+
+func TestPruneJournalsDir_RemovesOnlyStaleFiles(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	writeJournalFile(t, dir, "wf-old.jsonl", now.Add(-8*24*time.Hour))
+	writeJournalFile(t, dir, "wf-fresh.jsonl", now.Add(-1*time.Hour))
+	// A non-journal file in the same dir must never be touched.
+	writeJournalFile(t, dir, "not-a-journal.txt", now.Add(-8*24*time.Hour))
+
+	if err := pruneJournalsDir(dir, now); err != nil {
+		t.Fatalf("pruneJournalsDir: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "wf-old.jsonl")); !os.IsNotExist(err) {
+		t.Errorf("stale journal should have been removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "wf-fresh.jsonl")); err != nil {
+		t.Errorf("fresh journal should survive: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "not-a-journal.txt")); err != nil {
+		t.Errorf("non-.jsonl file should be left alone: %v", err)
+	}
+}
+
+func TestPruneJournalsDir_MissingDirIsNotAnError(t *testing.T) {
+	if err := pruneJournalsDir(filepath.Join(t.TempDir(), "nonexistent"), time.Now()); err == nil {
+		t.Error("want an error for a missing dir (caller treats it as best-effort)")
+	}
+}
+
+// writeJournalFile creates a file at dir/name and backdates its mtime to at,
+// so age-based pruning can be tested without sleeping.
+func writeJournalFile(t *testing.T, dir, name string, at time.Time) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, at, at); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/workflow/main_test.go
+++ b/internal/workflow/main_test.go
@@ -1,0 +1,45 @@
+package workflow
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain redirects $HOME (and %USERPROFILE% on Windows) to a throwaway temp
+// dir for the whole package's test run, so journalsDir()'s os.UserHomeDir()
+// call resolves under it instead of a developer's real home directory. Most
+// tests here pass an explicit Options.JournalDir, but a few exercise Run's
+// default-journal-dir fallback deliberately; without this redirect, those
+// (and any future test that forgets to set JournalDir) would leave .jsonl
+// files in the real ~/.octo/workflow-journals forever, since nothing prunes
+// it mid-session.
+func TestMain(m *testing.M) {
+	// os.Exit below skips deferred functions, so restoration runs inline
+	// after m.Run() returns rather than via defer.
+	tmp, err := os.MkdirTemp("", "octo-workflow-home-test")
+	var origHome, origProfile string
+	var hadHome, hadProfile bool
+	if err == nil {
+		origHome, hadHome = os.LookupEnv("HOME")
+		origProfile, hadProfile = os.LookupEnv("USERPROFILE")
+		_ = os.Setenv("HOME", tmp)
+		_ = os.Setenv("USERPROFILE", tmp)
+	}
+
+	code := m.Run()
+
+	if err == nil {
+		if hadHome {
+			_ = os.Setenv("HOME", origHome)
+		} else {
+			_ = os.Unsetenv("HOME")
+		}
+		if hadProfile {
+			_ = os.Setenv("USERPROFILE", origProfile)
+		} else {
+			_ = os.Unsetenv("USERPROFILE")
+		}
+		_ = os.RemoveAll(tmp)
+	}
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary
- The `workflow` tool now parses `# @param <name> [required][: <description>]` comments on saved workflows. Running one by name with a required arg missing from `args` prompts the user for it (via the same Asker `ask_user_question` uses), instead of the script hitting a nil `args[...]` lookup at runtime. Non-interactive modes get a clear error instead of hanging. `workflow_save` accepts a `params` array to declare these when authoring a workflow.
- The 3 embedded default workflows are annotated with their params; `batch-migrate`'s required `change` arg is now enforced up front.
- Default workflows are materialized to `~/.octo/workflows-default` (mirroring `internal/skills`) so they're inspectable/editable on disk instead of living only inside the binary. `discoverWorkflows` still seeds from the embedded copy first so the built-in set works even without materialization (library consumers of `internal/tools`, tests). `octo workflows path|update` reflect the new root.
- Fixed an unbounded-growth bug in `~/.octo/workflow-journals` (10k+ files accumulated on one dev machine, no cleanup ever existed): added a 7-day retention prune at CLI startup, and fixed `internal/tools`/`internal/workflow` tests that were writing real journal files into a developer's home directory on every `go test` run.
- **Review fixup**: the `@param` serialize/parse pair was asymmetric — a non-required param whose description happened to start with the word "required" would silently flip to required and lose that word on the next parse. Fixed by requiring a colon before the description (`@param name required: desc`), which can't collide with free text; also added a word-boundary check on the `@param` prefix, newline-sanitization for descriptions written into `#` comments, and removed a dead-code branch. See commit `fix(workflow): remove @param format/parse asymmetry, drop dead code` for detail.
- **Follow-up**: recorded browser skills already auto-parameterize inputs at record time (`{{name}}` placeholders), but replaying one with a required param missing just errored out. Wired the same Asker-based prompting into `run_skill` (`internal/browser.MissingRequiredParams` + `internal/tools.resolveMissingSkillParams`), closing the equivalent gap on the browser-automation side.

## Test plan
- [x] `make fmt-check` / `make vet` clean
- [x] `make test` (race) green
- [x] Unit tests: required-param parsing/prompting, the `required`-word-collision regression, newline-sanitization, `workflow_save` params, default-workflow materialization, journal pruning, `run_skill` missing-param prompting
- [x] Verified end-to-end with a real build: `octo version` materializes `~/.octo/workflows-default` with the 3 annotated scripts and prunes stale journals