### PR TITLE
fix(server): replay workflow/sub-agent state on WS subscribe; include tool_input

### DIFF
--- a/internal/server/bg_tasks_test.go
+++ b/internal/server/bg_tasks_test.go
@@ -474,3 +474,79 @@ func toolNames(defs []agent.ToolDefinition) []string {
 	}
 	return names
 }
+
+// toolInputSpawner emits a "tool" SubAgentEvent carrying ToolInput, the way
+// internal/app/spawner.go's real spawner does when a sub-agent dispatches a
+// tool call.
+type toolInputSpawner struct{}
+
+func (toolInputSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
+	if sink := tools.SubAgentEventSink(ctx); sink != nil {
+		sink(tools.SubAgentEvent{Kind: "tool", ToolName: "read_file", ToolInput: map[string]any{"path": "go.mod"}})
+	}
+	return tools.SpawnResult{Reply: "ok"}, nil
+}
+
+func (toolInputSpawner) Continue(_ context.Context, _, _ string) (tools.SpawnResult, error) {
+	return tools.SpawnResult{}, nil
+}
+
+// TestPrepareToolTurn_SubAgentToolEventCarriesToolInput guards the web
+// sub-agent panel's tool-arguments display: the frontend (ChatView.svelte's
+// sub_agent_event handler, stores.ts's applySubAgentEvent, SubAgentsCard's
+// tool-input rendering) has supported showing a tool's input all along, and
+// tools.SubAgentEvent has carried ToolInput since it was added — but the
+// server's WS broadcast in prepareToolTurn's SubAgentOnEvent hook dropped
+// the field, so the argument list never had anything to render.
+func TestPrepareToolTurn_SubAgentToolEventCarriesToolInput(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: true})
+	srv.initWS()
+
+	const sid = "subagent-tool-input-test"
+	// Pre-seed the session's manager with a fake spawner; prepareToolTurn's
+	// SessionSubAgentManager call reuses this cached instance and only wires
+	// the real broadcast callback onto it (mkSpawner runs once per session).
+	tools.SessionSubAgentManager(sid, func() tools.Spawner { return toolInputSpawner{} })
+	t.Cleanup(func() { tools.CloseSessionSubAgentManager(sid) })
+
+	a := agent.New(&stubSender{}, "stub-model")
+	ctx := context.WithValue(context.Background(), ctxKeySessionID{}, sid)
+	_, _, mgr, cleanup, err := srv.prepareToolTurn(ctx, a, nil)
+	if err != nil {
+		t.Fatalf("prepareToolTurn: %v", err)
+	}
+	defer cleanup()
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.wsHub.register <- conn
+	srv.wsHub.subscribe(conn, sid)
+
+	if _, err := mgr.Start(tools.SpawnRequest{Description: "d", Prompt: "p"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case b := <-conn.send:
+			var ev map[string]any
+			if err := json.Unmarshal(b, &ev); err != nil {
+				continue
+			}
+			if ev["type"] != "sub_agent_event" || ev["kind"] != "tool" {
+				continue
+			}
+			input, ok := ev["tool_input"].(map[string]any)
+			if !ok || input["path"] != "go.mod" {
+				t.Fatalf("tool_input = %v, want {path: go.mod}", ev["tool_input"])
+			}
+			return
+		case <-deadline:
+			t.Fatal("timed out waiting for the tool sub_agent_event")
+		}
+	}
+}

--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -115,6 +115,7 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 					"agent_type":  ev.AgentType,
 					"kind":        ev.Kind,
 					"tool_name":   ev.ToolName,
+					"tool_input":  ev.ToolInput,
 				})
 			},
 			SubAgentOnExit: func(ev tools.SubAgentNotification) {

--- a/internal/server/live_replay_test.go
+++ b/internal/server/live_replay_test.go
@@ -1,12 +1,15 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/tools"
+	"github.com/open-octo/octo-agent/internal/workflow"
 )
 
 // drainConn unmarshals everything buffered on the connection's send channel.
@@ -363,5 +366,125 @@ func TestReplayLiveState_StdoutClearsAfterToolDone(t *testing.T) {
 		if ev["type"] == "tool_stdout" {
 			t.Errorf("stale tool_stdout replayed after the tool finished: %v", ev)
 		}
+	}
+}
+
+// TestReplayLiveState_ReplaysRunningWorkflow is the regression guard for the
+// web workflow panel never appearing (or never clearing) when a tab
+// (re)subscribes after a background workflow already started: the panel is
+// built entirely from workflow_event pushes with no initial fetch, and
+// broadcast() is fire-and-forget, so a tab that wasn't connected when
+// "started"/"progress" fired used to never learn the run exists.
+func TestReplayLiveState_ReplaysRunningWorkflow(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "replay-workflow-session"
+	defer tools.CloseSessionWorkflowManager(sid)
+
+	block := make(chan struct{})
+	blockingAgent := func(ctx context.Context, _ string, _ workflow.AgentOptions) workflow.AgentResult {
+		<-block
+		return workflow.AgentResult{Reply: "done"}
+	}
+	mgr := tools.SessionWorkflowManager(sid)
+	id, err := mgr.Start(tools.WorkflowRunRequest{
+		Description: "test workflow",
+		Script:      `log("step one"); agent("x")`,
+		Agent:       blockingAgent,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer close(block)
+
+	// Wait for the script to emit its progress line and reach the blocking
+	// agent call, so the run is still "running" when we replay. Generous
+	// deadline: under `go test -race` the mruby interpreter runs several
+	// times slower (see waitForDone in workflow_manager_test.go).
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if snap, ok := mgr.Read(id); ok && len(snap.Logs) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.replayLiveState(sid, conn)
+
+	var sawStarted bool
+	var progressLines []any
+	for _, ev := range drainConn(t, conn) {
+		if ev["type"] != "workflow_event" || ev["run_id"] != id {
+			continue
+		}
+		switch ev["kind"] {
+		case "started":
+			sawStarted = true
+		case "progress":
+			progressLines = append(progressLines, ev["line"])
+		}
+	}
+	if !sawStarted {
+		t.Error("replay did not include the workflow's started event")
+	}
+	found := false
+	for _, l := range progressLines {
+		if l == "step one" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("replay progress lines = %v, want one of them to be %q", progressLines, "step one")
+	}
+}
+
+// blockingSpawner's Spawn hangs until unblocked, so a Start()ed sub-agent
+// stays "running" long enough for a test to replay it.
+type blockingSpawner struct{ block <-chan struct{} }
+
+func (s *blockingSpawner) Spawn(ctx context.Context, _ tools.SpawnRequest) (tools.SpawnResult, error) {
+	select {
+	case <-s.block:
+	case <-ctx.Done():
+	}
+	return tools.SpawnResult{Reply: "done"}, nil
+}
+
+func (s *blockingSpawner) Continue(ctx context.Context, _, _ string) (tools.SpawnResult, error) {
+	return tools.SpawnResult{}, nil
+}
+
+// TestReplayLiveState_ReplaysRunningSubAgent is the regression guard for the
+// same gap in the sub-agent panel: SubAgentOnEvent also broadcasts directly
+// with no buffering, so a tab that (re)subscribes after a sub-agent already
+// started never learned it existed.
+func TestReplayLiveState_ReplaysRunningSubAgent(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "replay-subagent-session"
+	defer tools.CloseSessionSubAgentManager(sid)
+
+	block := make(chan struct{})
+	defer close(block)
+	mgr := tools.SessionSubAgentManager(sid, func() tools.Spawner { return &blockingSpawner{block: block} })
+	id, err := mgr.Start(tools.SpawnRequest{Description: "test sub-agent", Prompt: "do it"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.replayLiveState(sid, conn)
+
+	var sawStarted bool
+	for _, ev := range drainConn(t, conn) {
+		if ev["type"] == "sub_agent_event" && ev["agent_id"] == id && ev["kind"] == "started" {
+			sawStarted = true
+		}
+	}
+	if !sawStarted {
+		t.Error("replay did not include the sub-agent's started event")
 	}
 }

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -213,6 +213,69 @@ func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
 		conn.send <- b
 	}
 
+	// Replay still-running workflow runs the same way: the live panel is
+	// built entirely from workflow_event pushes with no initial fetch, so a
+	// tab that (re)subscribes after a run already started never sees it
+	// otherwise — the started/progress events already went to whichever
+	// connection was live at the time, and broadcast() is fire-and-forget
+	// with no queueing. Finished runs need no replay: the panel already
+	// removes them on "done", so if that event was missed there is nothing
+	// left to reconstruct.
+	for _, run := range tools.SessionWorkflowManager(sessionID).List() {
+		if run.Status != "running" {
+			continue
+		}
+		if b, err := json.Marshal(map[string]any{
+			"type":        "workflow_event",
+			"session_id":  sessionID,
+			"run_id":      run.ID,
+			"description": run.Description,
+			"kind":        "started",
+			"line":        "",
+			"status":      run.Status,
+		}); err == nil {
+			conn.send <- b
+		}
+		for _, line := range run.Logs {
+			if b, err := json.Marshal(map[string]any{
+				"type":        "workflow_event",
+				"session_id":  sessionID,
+				"run_id":      run.ID,
+				"description": run.Description,
+				"kind":        "progress",
+				"line":        line,
+				"status":      run.Status,
+			}); err == nil {
+				conn.send <- b
+			}
+		}
+	}
+
+	// Sub-agents have the identical gap: SubAgentOnEvent (see
+	// handlers_prepare_toolturn.go) also broadcasts directly to the hub with
+	// no buffering, so a late-subscribing tab misses a still-running
+	// sub-agent entirely. mkSpawner is nil: this must never create a
+	// session's sub-agent manager just to discover it's empty — nil back
+	// means no sub-agent has run in this session yet. SubAgentInfo doesn't
+	// retain agent_type or per-tool history, so the replay is coarser than
+	// the live stream (the panel will show the agent as running without its
+	// tool trail), but that beats not showing it at all.
+	if sam := tools.SessionSubAgentManager(sessionID, nil); sam != nil {
+		for _, sa := range sam.ListRunning() {
+			if b, err := json.Marshal(map[string]any{
+				"type":        "sub_agent_event",
+				"session_id":  sessionID,
+				"agent_id":    sa.ID,
+				"description": sa.Description,
+				"agent_type":  "",
+				"kind":        "started",
+				"tool_name":   "",
+			}); err == nil {
+				conn.send <- b
+			}
+		}
+	}
+
 	// Snapshot the in-progress turn under the read lock: the event buffer,
 	// any unflushed streaming deltas, the current progress, and buffered
 	// stdout. Marshaling happens inside the lock because the builders and the


### PR DESCRIPTION
## Summary
- The web workflow panel (`WorkflowsCard`) and sub-agent panel (`SubAgentsCard`) are built entirely from `workflow_event` / `sub_agent_event` WebSocket pushes with no initial fetch. `replayLiveState()` already backfilled background-task and in-flight turn state for a late-subscribing tab, but never workflow or sub-agent state — so a tab that (re)subscribes after a run already started never learned it existed. Symptoms: the panel appears only after a long delay (whenever a later event happens to land on a now-connected tab), or a missed `done` push leaves it stuck until a full page reload.
- Fix: `replayLiveState` now also snapshots still-`running` workflow runs (`tools.SessionWorkflowManager(...).List()`) and sub-agents (`tools.SessionSubAgentManager(sessionID, nil).ListRunning()`) and synthesizes `started`/`progress` events to backfill the newly-subscribing connection.
- Also fixes `sub_agent_event` dropping `ToolInput`: the field has existed on `tools.SubAgentEvent` since it was added, and the frontend already renders it (`SubAgentsCard.svelte`'s `tool-input` span), but the server's WS broadcast never included it, so the panel only ever showed the tool name with no arguments.

## Test plan
- [x] `go test ./internal/server/...` (including new tests `TestReplayLiveState_ReplaysRunningWorkflow`, `TestReplayLiveState_ReplaysRunningSubAgent`, `TestPrepareToolTurn_SubAgentToolEventCarriesToolInput`)
- [x] `go test -race ./internal/server/... ./internal/tools/... ./internal/app/... ./internal/workflow/...`
- [x] `gofmt -l` clean, `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)