### PR TITLE
chore: bump version to 1.10.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.10.0"
+var Version = "1.10.1"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Summary
- Bump `internal/version/version.go` to 1.10.1 for release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)