### PR TITLE
fix(tui): say "Goal starts" on the first turn, not "Goal continues"

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -2039,7 +2039,7 @@ func (m *tuiModel) handleTurnFinished(err error) (tea.Model, tea.Cmd) {
 	// the policy (status, zero-progress suppression); user input always won
 	// above by reaching the queue/inbox branches first.
 	if err == nil {
-		if prompt, ok := m.goalContinuationKick(); ok {
+		if prompt, ok := m.goalContinuationKick(false); ok {
 			return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(prompt, ""))
 		}
 	}

--- a/cmd/octo/tuirepl_goal.go
+++ b/cmd/octo/tuirepl_goal.go
@@ -44,7 +44,7 @@ func (m *tuiModel) dispatchGoal(args string) (tea.Model, tea.Cmd) {
 		m.applyGoalStatus(agent.GoalActive)
 		// Resuming re-enters the continuation loop right away when idle —
 		// the user just asked for the goal to keep going.
-		return m.startGoalNow()
+		return m.startGoalNow(false)
 
 	case sub == "clear":
 		if sess.ClearGoal() {
@@ -85,7 +85,7 @@ func (m *tuiModel) dispatchGoal(args string) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.println(noticeStyle.Render("Goal replaced — " + goalOneLine(g)))
-		return m.startGoalNow()
+		return m.startGoalNow(true)
 
 	default:
 		// "/goal <objective>": start a goal. A finished (complete) goal is
@@ -103,7 +103,7 @@ func (m *tuiModel) dispatchGoal(args string) (tea.Model, tea.Cmd) {
 			} else {
 				m.println(noticeStyle.Render("Goal set — " + goalOneLine(ng)))
 			}
-			return m.startGoalNow()
+			return m.startGoalNow(true)
 		}
 		g, err := sess.CreateGoal(args, 0)
 		if err != nil {
@@ -111,7 +111,7 @@ func (m *tuiModel) dispatchGoal(args string) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.println(noticeStyle.Render("Goal set — " + goalOneLine(g)))
-		return m.startGoalNow()
+		return m.startGoalNow(true)
 	}
 }
 
@@ -152,9 +152,14 @@ func (m *tuiModel) submitGoalEdit(text string) (tea.Model, tea.Cmd) {
 // left alone — dispatchGoal is only ever reached while idle in practice
 // (submit() queues slash commands mid-turn instead), so this is a defensive
 // no-op rather than a real production path.
-func (m *tuiModel) startGoalNow() (tea.Model, tea.Cmd) {
+//
+// fresh is true for create/replace (a brand-new goal that has never run a
+// turn — the notice should say "starts") and false for resume (the same
+// goal picking back up after a pause — "continues" still applies, matching
+// the "Goal active — ..." line applyGoalStatus already printed for it).
+func (m *tuiModel) startGoalNow(fresh bool) (tea.Model, tea.Cmd) {
 	if !m.turnRunning {
-		if prompt, kick := m.goalContinuationKick(true); kick {
+		if prompt, kick := m.goalContinuationKick(fresh); kick {
 			return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(prompt, ""))
 		}
 	}
@@ -163,9 +168,11 @@ func (m *tuiModel) startGoalNow() (tea.Model, tea.Cmd) {
 
 // goalContinuationKick asks the session whether an idle continuation turn
 // should start. Split from the call sites (turn end, /goal resume) so both
-// share the notice. initial distinguishes the very first turn of a
-// create/replace/resume (from startGoalNow — "starts") from a follow-up turn
-// after one already ran (from handleTurnFinished — "continues").
+// share the notice. initial distinguishes a brand-new goal's very first turn
+// (from startGoalNow's create/replace callers — "starts") from a turn on a
+// goal that has already run before, whether picking back up after a pause or
+// auto-continuing after a prior turn (from startGoalNow's resume caller and
+// from handleTurnFinished — "continues").
 func (m *tuiModel) goalContinuationKick(initial bool) (string, bool) {
 	if !m.goalsWired() {
 		return "", false

--- a/cmd/octo/tuirepl_goal.go
+++ b/cmd/octo/tuirepl_goal.go
@@ -154,7 +154,7 @@ func (m *tuiModel) submitGoalEdit(text string) (tea.Model, tea.Cmd) {
 // no-op rather than a real production path.
 func (m *tuiModel) startGoalNow() (tea.Model, tea.Cmd) {
 	if !m.turnRunning {
-		if prompt, kick := m.goalContinuationKick(); kick {
+		if prompt, kick := m.goalContinuationKick(true); kick {
 			return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(prompt, ""))
 		}
 	}
@@ -163,8 +163,10 @@ func (m *tuiModel) startGoalNow() (tea.Model, tea.Cmd) {
 
 // goalContinuationKick asks the session whether an idle continuation turn
 // should start. Split from the call sites (turn end, /goal resume) so both
-// share the notice.
-func (m *tuiModel) goalContinuationKick() (string, bool) {
+// share the notice. initial distinguishes the very first turn of a
+// create/replace/resume (from startGoalNow — "starts") from a follow-up turn
+// after one already ran (from handleTurnFinished — "continues").
+func (m *tuiModel) goalContinuationKick(initial bool) (string, bool) {
 	if !m.goalsWired() {
 		return "", false
 	}
@@ -172,7 +174,11 @@ func (m *tuiModel) goalContinuationKick() (string, bool) {
 	if !ok {
 		return "", false
 	}
-	m.printlnBlock(noticeStyle.Render("● Goal continues — /goal pause to stop"))
+	verb := "continues"
+	if initial {
+		verb = "starts"
+	}
+	m.printlnBlock(noticeStyle.Render("● Goal " + verb + " — /goal pause to stop"))
 	return prompt, true
 }
 

--- a/cmd/octo/tuirepl_goal_test.go
+++ b/cmd/octo/tuirepl_goal_test.go
@@ -66,6 +66,47 @@ func TestDispatchGoal_CreateSummaryAndGuardedReplace(t *testing.T) {
 	}
 }
 
+func TestGoalContinuationKick_InitialAnnouncesStart(t *testing.T) {
+	// Regression: the very first turn of a freshly created/replaced/resumed
+	// goal (startGoalNow's caller) must read "Goal starts", not "Goal
+	// continues" — "continues" implies a prior turn already ran.
+	m, sess := newGoalTestModel()
+	if _, err := sess.CreateGoal("keep going", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := m.goalContinuationKick(true); !ok {
+		t.Fatal("expected a continuation to be available")
+	}
+	out := printed(m)
+	if !strings.Contains(out, "Goal starts") {
+		t.Errorf("expected the initial kick to say \"Goal starts\":\n%s", out)
+	}
+	if strings.Contains(out, "Goal continues") {
+		t.Errorf("initial kick must not say \"Goal continues\":\n%s", out)
+	}
+}
+
+func TestGoalContinuationKick_FollowupAnnouncesContinues(t *testing.T) {
+	// The handleTurnFinished caller fires after a turn already ran, so it
+	// should keep saying "Goal continues".
+	m, sess := newGoalTestModel()
+	if _, err := sess.CreateGoal("keep going", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := m.goalContinuationKick(false); !ok {
+		t.Fatal("expected a continuation to be available")
+	}
+	out := printed(m)
+	if !strings.Contains(out, "Goal continues") {
+		t.Errorf("expected the follow-up kick to say \"Goal continues\":\n%s", out)
+	}
+	if strings.Contains(out, "Goal starts") {
+		t.Errorf("follow-up kick must not say \"Goal starts\":\n%s", out)
+	}
+}
+
 func TestDispatchGoal_PauseResumeClear(t *testing.T) {
 	m, sess := newGoalTestModel()
 	// Seeded directly on the session so the fixture itself doesn't consume


### PR DESCRIPTION
## Summary
- `goalContinuationKick()` shared one notice ("● Goal continues — /goal pause to stop") between the very first kickoff turn (`startGoalNow`, fired right after `/goal create/replace/resume`) and every subsequent auto-continuation turn (`handleTurnFinished`). The first turn hasn't continued anything yet, so it read wrong.
- `goalContinuationKick` now takes an `initial bool`: `true` (from `startGoalNow`) prints "Goal starts", `false` (from `handleTurnFinished`) keeps "Goal continues".

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/octo/...` (added `TestGoalContinuationKick_InitialAnnouncesStart` / `...FollowupAnnouncesContinues`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)