### PR TITLE
docs(product-help): catch up bundled docs with recent features + fix stale content

### DIFF
--- a/internal/skills/defaults/product_help/CLI.md
+++ b/internal/skills/defaults/product_help/CLI.md
@@ -3,46 +3,91 @@
 ## Commands
 
 ### `octo [prompt]`
-Start an interactive REPL session or run a single prompt and exit.
+Start an interactive REPL/TUI session, or run a single headless agentic turn and exit (with a prompt argument or piped stdin).
 
-Flags:
-- `--provider` — Override the default provider (`anthropic` or `openai`)
-- `--model` — Override the default model
-- `--system` — Path to a custom system-prompt file
-- `--reasoning-effort low|medium|high|xhigh|max` — Enable extended reasoning
-- `--no-reasoning` — Disable reasoning trace display
+Common flags:
+- `-c, --continue [id]` — Resume a session ('last', short ID, or substring; no ID = pick from a list)
+- `--take-over` — When resuming, take over a session bound to another entry
+- `--no-tools` — Disable built-in tools (terminal, edit_file, …) + MCP/skills
+- `--provider <name>` — `anthropic` (default) | `openai` | `custom`
+- `--model <name>` — Override the default model for the provider
+- `--system <path>` — Path to a custom system-prompt file
+- `--no-save` — Don't auto-save the session to `~/.octo/sessions`
+- `--no-memory` — Disable cross-session memory injection
+- `--sandbox` — OS-enforced confinement for terminal commands (macOS/Linux)
+- `--permission-mode <mode>` — `interactive` (default; prompts on ask) | `strict` | `auto`
+- `--reasoning-effort low|medium|high|xhigh|max` — Enable extended reasoning (empty/default = off)
+- `--show-reasoning` — Surface the reasoning trace for the web UI to display (default off). The terminal itself never renders it regardless of this flag.
+- `--quiet` / `--verbose` — Less / more status chrome
 
 ### `octo config [subcommand]`
-Manage persisted configuration (`~/.octo/config.yaml`).
+Manage persisted configuration (`~/.octo/config.yml`).
 
 Subcommands:
-- `setup` / `init` (default) — Interactive wizard to set provider, model, and options
+- `setup` / `init` (default, bare `octo config`) — Interactive wizard to set provider, model, and options
 - `show` / `get` — Display current effective configuration and where each value comes from
 - `path` — Print the config file path
 
+### `octo init`
+Analyze the repo and generate/update `.octorules`. Flags: `-provider`, `-model`, `-permission-mode` (default `strict`), `-sandbox` (+ `-sandbox-allow-net`, `-sandbox-read`, `-sandbox-write`), `-plain` (one-line tool status instead of rich cards).
+
 ### `octo sessions`
-List recent saved sessions. Resume one with `octo -c <id>` / `octo -c last`,
-or run bare `octo -c` to pick from an interactive list.
+List recent saved sessions. Resume one with `octo -c <id>` / `octo -c last`, or run bare `octo -c` to pick from an interactive list.
+
+### `octo memory [list|path]`
+Manage cross-session memory. `list` shows the current project's memory files; `path` prints the memory directory. See `MEMORY.md`.
 
 ### `octo skills [subcommand]`
 Manage skills.
 
 Subcommands:
 - `list` — List available skills (default, user, project)
-- `path` — Show skill search paths
+- `add <owner/repo[/sub/path] | github.com tree URL> [--force]` — Install a skill from a GitHub repo path (e.g. `octo skills add anthropics/skills/skills/docx`)
 - `update` — Refresh default skills from the binary
+- `path` — Show skill search paths
+
+See `SKILLS.md` for the embedding/precedence mechanism.
+
+### `octo workflows [subcommand]`
+List and manage named workflows (multi-step scripts the model runs by name via the `workflow` tool).
+
+Subcommands:
+- `list` — List discovered workflows (default/embedded, user, project) with their args
+- `path` — Show workflow search paths
+- `update` — Refresh embedded default workflows from the binary
+
+`/workflows` in the TUI shows the same listing.
+
+### `octo browser setup`
+Guide through enabling Chrome/Edge remote debugging, verify the connection, and save `browser.connect_port` to config so the `browser` tool can drive your logged-in browser (record/replay, self-heal, vision screenshots).
+
+### `octo hooks list`
+Show currently configured hooks (built-ins plus anything from `hooks.yml`). See `HOOKS.md` for the event/config format — note `octo hooks` isn't in the top-level `--help` listing, but it is a real, working feature.
 
 ### `octo serve`
-Start the web UI server.
+Start the HTTP server (REST + WebSocket + embedded web dashboard), and the IM bridge (unless `-no-channel`).
+
+Notable flags: `-addr` (default `127.0.0.1:8088`), `-access-key` (required for non-localhost clients), `-cors`, `-model`, `-max-tokens`, `-no-channel` (disable IM), `-no-memory`, `-d`/`-daemon` (background, pid at `~/.octo/serve.pid`), `-no-supervisor`.
+
+### `octo upgrade`
+Download and install the latest release in place. `--check` only compares versions without installing; `--force` proceeds despite a dev build or an already-latest version.
+
+### `octo completion <shell>`
+Print a shell-completion snippet. Shells: `bash`, `zsh`, `fish`, `powershell`.
 
 ### `octo version`
 Print version information.
+
+### `octo help [command]`
+Print the top-level help, or a command's detailed help/examples (e.g. `octo help mcp`). `octo <command> --help` prints just that command's flags.
 
 ## Environment Variables
 
 | Variable | Purpose |
 |----------|---------|
-| `OCTO_PROVIDER` | Default provider (`anthropic` or `openai`) |
-| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` | API key for the respective provider |
-| `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` | Custom endpoint URL |
+| `OCTO_PROVIDER` | Default provider (`anthropic` \| `openai` \| `custom`) |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` | Required for the chosen provider |
+| `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` | Override the endpoint (proxies, compatible servers) |
 | `ANTHROPIC_MODEL` / `OPENAI_MODEL` | Default model override |
+| `CUSTOM_API_KEY` + `CUSTOM_BASE_URL` | Self-hosted/third-party endpoint (`--provider custom`; wire protocol picked in `octo config`) |
+| `OCTO_ACCESS_KEY` | `octo serve` access key for non-localhost clients |

--- a/internal/skills/defaults/product_help/CONFIG.md
+++ b/internal/skills/defaults/product_help/CONFIG.md
@@ -2,22 +2,28 @@
 
 ## Config file
 
-Path: `~/.octo/config.yaml`
+Path: `~/.octo/config.yml`
 
-Created interactively via `octo config` or edited directly.
+Created interactively via `octo config` or edited directly. (A pre-rename `~/.octo/config.yaml` is read as a fallback if `config.yml` is absent, and gets migrated to `config.yml` — with the old file parked as `config.yaml.bak` — on the first save.)
 
 ## Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `provider` | string | `"anthropic"` or `"openai"` |
+| `provider` | string | `"anthropic"`, `"openai"`, or `"custom"` (any Anthropic/OpenAI-compatible endpoint via `CUSTOM_API_KEY`/`CUSTOM_BASE_URL`) |
 | `model` | string | Model name (e.g. `claude-sonnet-4-20250514`, `gpt-4.1`) |
 | `base_url` | string | Optional custom API endpoint |
-| `permission_mode` | string | `"strict"`, `"confirm"`, or `"auto"` |
+| `permission_mode` | string | `"interactive"` (default), `"strict"`, or `"auto"` |
 | `coauthor` | bool | Append `Co-authored-by` to git commits |
-| `show_reasoning` | bool | Stream reasoning/thinking traces to terminal |
+| `show_reasoning` | bool | Surface the reasoning/thinking trace for the web UI to display (default off; the terminal never renders it) |
 | `reasoning_effort` | string | `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`, or `""` (off) |
 | `api_key` | string | Plaintext fallback (discouraged — use env var instead) |
+| `workspace_dir` | string | Default working directory for new **web** sessions only. Empty (default) = the server's own launch directory; `"auto"` = `~/Desktop/octo`; anything else = a literal path. Doesn't affect CLI/TUI sessions |
+| `goal.enabled` | bool | Gates the `/goal` surface and goal tools (default true — inert until a goal is actually created) |
+| `browser.connect_port` | int | Chrome remote-debugging port to attach to (set by `octo browser setup`) |
+| `browser.attach_running` | bool | Attach to your already-running Chrome via its default profile, reusing the logged-in session |
+| `language` | string | UI language preference: `"en"` (default) or `"zh"` |
+| `tools.tool_search` | object | MCP Tool Search settings — `enabled: auto\|on\|off`, `threshold_pct: <int>`. See `MCP.md` |
 
 ## Precedence
 
@@ -25,9 +31,11 @@ CLI flags (`--provider`, `--model`, etc.) > env vars (`OCTO_PROVIDER`, `ANTHROPI
 
 ## Permission modes
 
-- **strict** — Block risky operations (file overwrites outside worktrees, shell commands that modify system state, etc.). The agent must ask for explicit approval.
-- **confirm** — Ask before executing any tool that has side effects (default behavior).
-- **auto** — Run without asking. Useful for trusted, repetitive workflows. Use with caution.
+- **interactive** (default) — Prompt for approval when a rule says `ask`.
+- **strict** — Auto-deny when a rule says `ask`. Used for non-interactive callers (HTTP server, IM bridge) by default.
+- **auto** — Auto-allow when a rule says `ask`. Useful for trusted, repetitive workflows — use with caution.
+
+Cycle modes in the TUI with **Shift+Tab**; a web session can also override its own mode via the composer status bar (per-session, doesn't touch this global default). See `PERMISSIONS.md` for the full rule engine.
 
 ## Example
 
@@ -37,4 +45,5 @@ model: claude-sonnet-4-20250514
 coauthor: true
 show_reasoning: true
 reasoning_effort: medium
+workspace_dir: auto
 ```

--- a/internal/skills/defaults/product_help/HOOKS.md
+++ b/internal/skills/defaults/product_help/HOOKS.md
@@ -1,0 +1,80 @@
+# Hooks — run your own commands at points in the agent loop
+
+octo can shell out to your own scripts at fixed points in the agent loop — inject retrieved context, log every tool call, block a dangerous command before it runs, or clean up after a turn. The model, the CLI, `octo serve` (web + IM), and sub-agents all share the same hook engine and the same `hooks.yml`.
+
+`octo hooks` isn't listed in the top-level `octo --help`, but it's a real, working feature — `octo hooks list` shows what's currently configured (built-ins plus anything from `hooks.yml`).
+
+## Config files
+
+| File | Scope |
+|------|-------|
+| `~/.octo/hooks.yml` | User-global — loaded for every session |
+| `<project>/.octo/hooks.yml` | Project-local — layered on top (runs after user hooks) |
+
+A project-level `hooks.yml` can run shell commands on your machine, so it's **trust-on-first-use**: the first time an interactive session (TUI, or a one-shot at a terminal) sees a project file it hasn't approved, it prompts `Trust and run this repo's hooks? [y/N]`. Approving records the file's content fingerprint, so it won't ask again until the file changes. A non-interactive session (piped stdin) declines silently rather than running an untrusted repo's hooks unattended. `octo serve` auto-trusts its own operator-chosen working directory.
+
+## Schema
+
+```yaml
+hooks:
+  UserPromptSubmit:
+    - command: "hindsight-retrieve"
+      timeout: 5s
+  PostToolUse:
+    - matcher: "terminal|write_file"   # regexp over the tool name
+      command: "audit-logger"
+  Stop:
+    - command: "log-session-end"
+      async: true
+```
+
+Each event maps to a list of hooks (an event can fan out to several commands). Fields per hook:
+
+| Field | Required | Description |
+|-------|----------|--------------|
+| `command` | yes | Shell command to run |
+| `matcher` | no | Regexp over the tool name — only honored for `PreToolUse`/`PostToolUse` |
+| `timeout` | no | Go duration string (e.g. `5s`); empty uses the package default |
+| `async` | no | Run off the turn's critical path via a durable queue — only honored for the side-effect events (`Stop`/`SubagentStop`/`PreCompact`); rejected as a config error on the events whose output is folded into the model stream |
+
+An unknown event name or an invalid `matcher` regexp is a hard config error naming the offending entry (so a typo surfaces instead of silently doing nothing); a hook that fails at runtime is reported via a notice and just contributes no text — it never crashes the turn.
+
+## Events
+
+Mirrors Claude Code's hook model (a CC hook script ports with just field-name changes) — 7 lifecycle points:
+
+| Event | When | Hook's stdout |
+|-------|------|----------------|
+| `SessionStart` | Once per logical session opening | Injected into the first user message (persisted) |
+| `UserPromptSubmit` | Before each user turn | Folded into that turn's user message |
+| `PreToolUse` | Before each tool dispatch | Can **block** the tool (see below) |
+| `PostToolUse` | After each successful tool result | Appended to that tool result's text |
+| `Stop` | An assistant turn ends (success or failure/interrupt) | Discarded — side-effect only |
+| `SubagentStop` | A spawned sub-agent finishes | Discarded — side-effect only |
+| `PreCompact` | Before history compaction | Discarded — side-effect only |
+
+Every hook receives a JSON payload on stdin with `event`, `session_id`, `cwd`, `transcript_path`, `model`, `transport`, plus event-specific fields.
+
+## Blocking (`PreToolUse` / `UserPromptSubmit`)
+
+A hook on one of these events can veto the action:
+
+- **exit code 2** → block (reason = a structured `{"decision":"block","reason":"..."}` on stdout if present, else stderr)
+- **exit 0 with `{"decision":"block"|"approve","reason":"..."}` on stdout** → that decision
+- **timeout or any other exit** → non-blocking error (reported via a notice; the tool/turn proceeds)
+
+The first hook that blocks short-circuits the rest; a later `approve` never overrides an earlier `block`. An `approve` tells octo to bypass the interactive permission prompt for that call — it doesn't otherwise change permission-engine behavior (see `PERMISSIONS.md`).
+
+## Legacy env-var shim
+
+The pre-`hooks.yml` mechanism still works and is layered in first (`hooks.yml` entries run after it):
+
+```
+OCTO_HOOK_PRE_TURN=/path/to/pre-script    # optional
+OCTO_HOOK_POST_TURN=/path/to/post-script  # optional
+OCTO_HOOK_TIMEOUT=5s                      # optional
+```
+
+## Built-ins
+
+Two hooks are always registered even with no `hooks.yml` present: a memory reminder (`UserPromptSubmit`) and a save-nudge (`PostToolUse`). `octo hooks list` shows these plus anything you've configured.

--- a/internal/skills/defaults/product_help/IM.md
+++ b/internal/skills/defaults/product_help/IM.md
@@ -1,0 +1,31 @@
+# IM bridge — chat with octo from WeChat, Feishu, Telegram, etc.
+
+octo can run as a chat bot on WeChat (iLink), Feishu, DingTalk, WeCom, Discord, and Telegram. The bridge runs **inside `octo serve`** (not a separate process) — each platform has its own adapter under `internal/channel/adapters/`, and every adapter shares the same agent loop, tools, skills, memory, and permission engine as the CLI/web surfaces.
+
+## Setup
+
+The primary path is the **Channels panel in the web UI** (`octo serve`, then open the dashboard): it walks through connecting each platform — for WeChat iLink this is scan-to-login (a QR code), other platforms are configured with their own credentials (bot token, app ID/secret, etc., depending on the platform).
+
+Credentials persist to `~/.octo/channels.yml` (mode 0600):
+
+```yaml
+channels:
+  telegram:
+    bot_token: "..."
+  discord:
+    bot_token: "..."
+```
+
+Each platform's config keys are its own (`PlatformConfig` is an open map), set via the web wizard rather than documented as a fixed schema here — use the Channels panel rather than hand-authoring this file. Channel config hot-reloads — enabling/editing a platform in the web UI takes effect without restarting `octo serve`.
+
+## What a chat gets
+
+Each IM chat is a session like any other — per-user sessions, slash commands, tool use, skills, and (if enabled) a session goal all work the same as the TUI. A sustained "typing…" indicator is kept alive on the platforms that support it while an agentic turn is in progress. After each turn, the chat gets a short summary line: `⏱ <elapsed>, <tokens> tokens`.
+
+## Proactive messaging (`send_message` / `send_file`)
+
+A normal reply only reaches the chat the current turn is already talking to. To reach a **different** chat — e.g. the user is on the web UI and asks octo to message their WeChat — the model uses the `send_message` (text) or `send_file` (file) tools, addressed by `platform` + `chat_id`. If the model doesn't know the `chat_id`, calling the tool with just a platform (or no arguments) returns the list of chats it can currently reach; a chat only appears once it has messaged the bot at least once (that's how the bot learns its `chat_id`). These tools are only registered when a messenger is active (i.e. `octo serve` is running with channels enabled) — they don't appear in a plain CLI/TUI session.
+
+## Disabling the bridge
+
+`octo serve -no-channel` starts the web server without the IM bridge.

--- a/internal/skills/defaults/product_help/MCP.md
+++ b/internal/skills/defaults/product_help/MCP.md
@@ -109,7 +109,7 @@ If a server fails to connect, the error is printed to stderr and that server is 
 
 MCP servers with many tools can push a lot of schema tokens into every request. Tool Search defers those *schemas*: built-in tools stay visible, and every connected MCP tool's name + one-line description stays listed in the system prompt the whole time — only the full parameter schema is loaded on demand, via `mcp_describe` → `mcp_call`.
 
-Control it under `tools.tool_search` in `~/.octo/config.yaml`:
+Control it under `tools.tool_search` in `~/.octo/config.yml`:
 
 ```yaml
 tools:

--- a/internal/skills/defaults/product_help/PERMISSIONS.md
+++ b/internal/skills/defaults/product_help/PERMISSIONS.md
@@ -14,6 +14,10 @@ The engine runs in one of three modes, selectable at startup or cycled at runtim
 
 Cycle modes in the TUI with **Shift+Tab**.
 
+### Per-session override (web)
+
+A web session's permission mode can also be changed from its own composer status bar, or via `PATCH /api/sessions/{id}/permission_mode`. This only affects that one session — it never touches the global default in `~/.octo/config.yml` (edited instead via `octo config` or Settings → default model), so other sessions and any brand-new session are unaffected. The change is saved to the session and takes effect on its next turn.
+
 ## Rule format
 
 Rules are defined in `~/.octo/permissions.yml` (user overrides) and an embedded `defaults.yml` (base layer). The YAML schema:

--- a/internal/skills/defaults/product_help/README.md
+++ b/internal/skills/defaults/product_help/README.md
@@ -29,7 +29,11 @@ octo version
 ```
 
 Archives ship for linux / darwin / windows on amd64 + arm64; `checksums.txt`
-in each release verifies the download.
+in each release verifies the download. macOS also has a double-click
+`octo-setup.pkg` installer; Windows installs PowerShell 7 automatically if
+missing. `uv` (for the `office-xlsx` skill) is bundled with both. Already
+installed? `octo upgrade` fetches and installs the latest release in place
+(`octo upgrade --check` only compares versions).
 
 **From Go:**
 
@@ -102,7 +106,17 @@ octo serve --addr 127.0.0.1:8088
 # IM bridge (WeChat iLink): scan-to-login; channels run inside `octo serve`
 octo serve   # WeChat login: Channels panel in the web UI (scan QR)
 
-# Autonomous long-horizon goal: plan into a subtask DAG and run it to completion
+# Session goal: set an objective and let octo auto-continue turns until it's
+# done (or paused/budget-limited). /goal in the TUI, a chip in the web UI.
+octo
+> /goal migrate all callers of the old logger to the new one
+
+# Workflows: named, multi-step scripts (embedded presets or your own, saved
+# via the workflow tool) the model runs by name. /workflows lists what's available.
+octo workflows list
+
+# Browser automation: drive your own logged-in Chrome (record/replay, self-heal)
+octo browser setup
 ```
 
 ## Configuration
@@ -122,13 +136,13 @@ The identity and rule files support `@include path/to/fragment.md` to pull in sh
 Reasoning models can deliberate before answering. Two knobs control it, both available as CLI flags and as `octo config` defaults:
 
 - `--reasoning-effort low|medium|high` — the intensity. OpenAI-protocol backends receive it as `reasoning_effort`; Anthropic-protocol backends map it to an extended-thinking token budget. Empty (the default) means off.
-- `--show-reasoning` (default on) — stream the thinking trace to the terminal, dimmed. `--show-reasoning=false` keeps reasoning enabled but hides the trace.
+- `--show-reasoning` (default off) — surface the reasoning/thinking trace for the web UI to display. The terminal itself never renders it regardless of this flag.
 
 This unifies Anthropic `thinking` blocks and OpenAI `reasoning_content` behind one pair of controls.
 
 ### Defaults (`octo config`)
 
-`octo config` saves your default provider, model, (optionally) base URL, and reasoning settings to `~/.octo/config.yaml`, so a bare `octo` works without re-typing `--provider`/`--model` every time:
+`octo config` saves your default provider, model, (optionally) base URL, and reasoning settings to `~/.octo/config.yml`, so a bare `octo` works without re-typing `--provider`/`--model` every time:
 
 ```bash
 octo config        # interactive wizard
@@ -136,7 +150,7 @@ octo config show   # print the effective settings + where each comes from
 octo config path   # print the file location
 ```
 
-Precedence is **CLI flag > env var > `~/.octo/config.yaml` > built-in default**. API keys are read from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` first; the wizard can store one in the file (mode `0600`), but the env var is recommended.
+Precedence is **CLI flag > env var > `~/.octo/config.yml` > built-in default**. API keys are read from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` first; the wizard can store one in the file (mode `0600`), but the env var is recommended.
 
 ## Skills
 
@@ -173,7 +187,7 @@ octo --sandbox --sandbox-read /opt/data     # extra readable dir (repeatable)
 | Area | Status | Description |
 |------|--------|-------------|
 | Core CLI | done | Headless agentic one-shot (`claude -p` style) + interactive TUI, streaming, session persistence (`~/.octo/sessions/`), `/cost` `/save` `/sessions` |
-| Providers | done | Anthropic Messages + OpenAI Chat Completions, plus any compatible third party |
+| Providers | done | Anthropic Messages + OpenAI Chat Completions, plus `custom` for any compatible third party (`CUSTOM_API_KEY`/`CUSTOM_BASE_URL`, protocol picked in `octo config`) |
 | Reasoning | done | Unified extended thinking (Anthropic) / `reasoning_content` (OpenAI), `--reasoning-effort`, `--show-reasoning` |
 | Tools | done | `terminal` (+ background), file read/write/edit, glob, grep, web fetch/search |
 | Agentic loop | done | Multi-step tool calling, permission gating, history compaction, graceful Ctrl-C |
@@ -181,10 +195,14 @@ octo --sandbox --sandbox-read /opt/data     # extra readable dir (repeatable)
 | Skills | done | Claude Code-compatible SKILL.md loader (`octo skills`, `/skills`, `/<name>`) |
 | Sandbox | done | OS-enforced `--sandbox` (macOS / Linux) |
 | MCP client | done | `mcp.json` stdio + Streamable HTTP servers, tools/resources/prompts, OAuth (Authorization Code + PKCE) |
-| Memory | done | Persistent cross-session memory under `~/.octo/memories/`, auto extract/consolidate |
-| Sub-agents | done | `launch_agent` fan-out, async + resumable (`send_message`, `agent_status`, `kill_agent`) |
+| Memory | done | Persistent cross-session memory under `~/.octo/memories/<repo-slug>/` — plain markdown files the agent manages directly with its own file tools (no typed store, no background consolidation) |
+| Sub-agents | done | `sub_agent` fan-out, async + resumable (`sub_agent_send` follow-up, `sub_agent_status`, `sub_agent_kill`) |
+| Session goals | done | `/goal` (create/edit/pause/resume/clear/replace) — status machine, token/turn budget, auto-continuation across turns; surfaced in the TUI status bar, a web chip, and IM |
+| Workflows | done | Named, multi-step scripts the model runs by name via the `workflow` tool — embedded presets (`batch-migrate`, `daily-triage`, `parallel-understand`) plus your own, saved with `workflow_save`; `octo workflows list/path/update`, `/workflows` in the TUI, a web management panel |
+| Hooks | done | `hooks.yml` (user- and project-level) — 7 lifecycle events incl. `PreToolUse`/`PreCompact`, blocking hooks, `async` side-effect hooks, trust-on-first-use; `octo hooks list` |
+| Browser automation | done | Owned Go-native CDP backend — attaches to your logged-in Chrome (`octo browser setup`), record/replay/self-heal, vision screenshots; a web Browser view for managing recordings |
 | Web server | done | `octo serve` — REST + WebSocket, embedded dashboard UI (bind localhost) |
-| IM bridge | done | runs inside `octo serve` — WeChat iLink / Feishu / DingTalk / WeCom / Discord / Telegram adapters (web QR login, per-user sessions, slash commands) |
+| IM bridge | done | runs inside `octo serve` — WeChat iLink / Feishu / DingTalk / WeCom / Discord / Telegram adapters (web QR login, per-user sessions, slash commands, proactive `send_message`/`send_file` to any known chat) |
 
 ## Architecture
 

--- a/internal/skills/defaults/product_help/SKILL.md
+++ b/internal/skills/defaults/product_help/SKILL.md
@@ -10,11 +10,18 @@ You have access to octo's product documentation. Use it to answer user questions
 ## Documentation sources
 
 1. **Bundled docs** — check the skill directory for reference files:
-   - `README.md` — quick start, installation, basic usage
-   - `CLI.md` — command reference (`octo`, `octo config`, `octo skills`, etc.)
+   - `README.md` — quick start, installation, basic usage, feature overview
+   - `CLI.md` — command reference (`octo`, `octo config`, `octo skills`, `octo workflows`, `octo browser`, etc.)
    - `CONFIG.md` — configuration file format and all supported fields
-   - `SKILLS.md` — how to write custom skills
-   - `WORKFLOW.md` — development workflow, git conventions, PR process
+   - `SKILLS.md` — the default-skill mechanism (embedding, precedence, `octo skills`) and how to write your own
+   - `WORKFLOW.md` — contributor development workflow, git conventions, PR process (NOT the `octo workflows` product feature — see CLI.md/TUI.md for that)
+   - `MCP.md` — MCP server configuration (`mcp.json`, OAuth, Tool Search)
+   - `MEMORY.md` — cross-session memory (file layout, injection, attention-rule tiers)
+   - `PERMISSIONS.md` — the permission engine (modes, rule format, per-session overrides)
+   - `HOOKS.md` — the hooks engine (`hooks.yml`, event types, blocking, trust-on-first-use)
+   - `IM.md` — the IM/chat bridge (`channels.yml`, supported platforms, `send_message`/`send_file`)
+   - `TUI.md` — terminal UI reference (slash commands, keyboard shortcuts, status bar)
+   - `TROUBLESHOOTING.md` — common issues and fixes
 
    Read the relevant file(s) with `read_file` before answering.
 
@@ -43,4 +50,4 @@ User: "what does permission_mode do?"
 
 User: "how do I switch to OpenAI?"
 → Read `CONFIG.md` and `CLI.md`
-→ Explain `octo config` wizard vs. editing `~/.octo/config.yaml` directly
+→ Explain `octo config` wizard vs. editing `~/.octo/config.yml` directly

--- a/internal/skills/defaults/product_help/SKILLS.md
+++ b/internal/skills/defaults/product_help/SKILLS.md
@@ -1,71 +1,56 @@
-# Default Skills (embed + materialize)
+# Skills — defaults, installing, and writing your own
 
-> A curated set of skills ships with the binary and lands on disk on first run,
-> so a fresh `octo` install has useful skills without the user authoring any.
+Skills are reusable instruction sets in Claude Code's SKILL.md format: YAML frontmatter (`name` + `description`) plus a markdown body. At session start octo lists each discovered skill's name and description in the system prompt; the model loads a skill's full instructions on demand (via the `skill` tool) when a task matches, or a user triggers one explicitly with `/<name>` in the TUI.
 
-## 1. Goal
-
-After install, a curated skill set (today: `worktree-isolate`) is discoverable,
-listable, and overridable — **offline, version-locked to the binary, and never
-clobbering a user's own skills.**
-
-## 2. Decision: embed, don't download
-
-The default set is embedded in the binary via `//go:embed` and materialized to
-disk on startup — **not** fetched from a remote. Embedding keeps a fresh install
-offline-capable (works for `go install`, air-gapped, CI) and immune to
-supply-chain / network-failure modes. A real download path is reserved for a
-future *optional* community catalog (`octo skills add <name>`), which is a
-separate concern from the built-in defaults.
-
-## 3. Mechanism
-
-- **Source of truth:** `internal/skills/defaults/<name>/SKILL.md`, embedded as
-  `defaultsFS` (`internal/skills/defaults.go`).
-- **Materialize:** `MaterializeDefaults(version)` writes the embedded tree to
-  `~/.octo/skills-default/`, stamped with the binary version in `.octo-version`.
-  It's a fast no-op once the stamp matches; a version bump wipes-and-rewrites the
-  whole dir (stale/renamed skills handled). Called best-effort at startup in
-  `cmd/octo` `run()` (skipped for the `__complete` / `__sandboxed-exec` fast
-  paths); a read-only HOME degrades to "no defaults", never an error.
-- **Dedicated dir:** `~/.octo/skills-default/` is exclusively octo-managed and
-  kept **separate** from `~/.octo/skills/`, so refreshing defaults never touches
-  a user's own skills and needs no per-file provenance tracking.
-
-## 4. Precedence
-
-`Discover` scans lowest-first; `scanRoot` overwrites by name:
+## 1. Where skills come from
 
 ```
-default  ~/.octo/skills-default/   (shipped, materialized)
+default  ~/.octo/skills-default/   (shipped, materialized from the binary)
    ↓ overridden by
-user     ~/.octo/skills/
+user     ~/.octo/skills/           (yours, or `octo skills add`)
    ↓ overridden by
-project  ./.octo/skills/
+project  ./.octo/skills/           (committed with the repo)
 ```
 
-A user overrides a default skill by dropping a same-named skill in
-`~/.octo/skills/`. `octo skills list` tags each with its
-source.
+`Discover` scans lowest-first and `scanRoot` overwrites by name, so a user- or project-level skill with the same name as a default silently wins. `octo skills list` tags each with its source (default/user/project).
 
-## 5. CLI
+## 2. Default skills (embedded, not downloaded)
+
+A curated set ships **embedded in the binary** via `//go:embed` and is materialized to `~/.octo/skills-default/` on first run of each version — offline-capable (works for `go install`, air-gapped, CI), immune to supply-chain/network failure, and never touches `~/.octo/skills/` (your own skills). A version bump wipes-and-rewrites the default dir; a read-only `$HOME` degrades to "no defaults" rather than erroring.
+
+Today's default set (`internal/skills/defaults/`, 20 skills): `channel-manager`, `code-review`, `cron-task-creator`, `deep-research`, `find-skills`, `grill-me`, `implement`, `loop`, `loop-engineering`, `mcp-creator`, `office-xlsx`, `onboard`, `product_help` (this skill), `skill-creator`, `tdd`, `tech-design`, `web-access`, `workflow-creator`, `worktree-isolate`, `zoom-out`. Keep the set small and high-value — every default costs system-prompt manifest space for every user.
 
 ```
 octo skills list      # all skills, grouped default → user → project
-octo skills update    # force re-materialize the defaults (ignores the stamp)
+octo skills update    # force re-materialize the defaults (ignores the version stamp)
 octo skills path      # print the three roots
 ```
 
-## 6. Adding a default skill
+## 3. Installing a skill from GitHub
 
-Drop `internal/skills/defaults/<name>/SKILL.md` (standard SKILL.md frontmatter:
-`name` + `description`). It ships on the next release and materializes on the
-user's next run after upgrade. Keep the set small and high-value — every default
-costs system-prompt manifest space for every user.
+`octo skills add <owner/repo[/sub/path] | github.com tree URL> [--force]` fetches a skill's directory straight into `~/.octo/skills/<name>/`:
 
-## 7. Out of scope
+```
+octo skills add anthropics/skills/skills/docx
+octo skills add https://github.com/anthropics/skills/tree/main/skills/pdf
+```
 
-- **Remote / community skills** (`octo skills add`, a catalog) — a separate
-  optional feature; defaults stay embedded.
-- **Per-file user-edit preservation in the default dir** — unnecessary, because
-  users edit in `~/.octo/skills/`, not the octo-managed default dir.
+Fails if a skill with that name already exists there — pass `--force` to replace it. The skill is copied for local use; check the source repository's license before redistributing it.
+
+## 4. Writing your own skill
+
+Drop a directory under `~/.octo/skills/<name>/` (user-level, all projects) or `./.octo/skills/<name>/` (project-level, committed with the repo) containing a `SKILL.md`:
+
+```markdown
+---
+name: review
+description: Review the current diff for correctness and style
+---
+Walk the diff hunk by hunk and flag correctness bugs first, then style.
+```
+
+`name` and `description` are the only required frontmatter fields — the description is what the model sees in the manifest to decide when the skill applies, so make it specific about triggers ("use when...") rather than just naming the topic. The body is whatever instructions/context the skill needs; it can reference sibling files in the same directory (e.g. templates, reference docs) that the model reads on demand. The format is identical to Claude Code's, so `~/.claude/skills` can be symlinked to `~/.octo/skills` to reuse skills you already have. The `skill-creator` default skill can also build one interactively.
+
+## 5. Adding a *default* skill (contributing to octo itself)
+
+Drop `internal/skills/defaults/<name>/SKILL.md` in the octo-agent repo (standard SKILL.md frontmatter). It ships on the next release and materializes on the user's next run after upgrading.

--- a/internal/skills/defaults/product_help/TROUBLESHOOTING.md
+++ b/internal/skills/defaults/product_help/TROUBLESHOOTING.md
@@ -24,7 +24,7 @@ Common issues and their fixes.
 ### `octo` says "no API key"
 
 - Check that the env var is set: `echo $ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`)
-- Or run `octo config` to store the key in `~/.octo/config.yaml` (mode 0600)
+- Or run `octo config` to store the key in `~/.octo/config.yml` (mode 0600)
 - Check `octo config show` to see where the provider/model resolve from
 
 ### Provider/model not what I expected

--- a/internal/skills/defaults/product_help/TUI.md
+++ b/internal/skills/defaults/product_help/TUI.md
@@ -8,13 +8,20 @@ Type `/` to open the completion menu (↑/↓ to navigate, Enter to run, Tab to 
 
 | Command | Description |
 |---------|-------------|
-| `/help` | Show this help message |
-| `/init` | Analyze repo and generate/update `.octorules` (needs `--tools`) |
-| `/save` | Save the session now (also auto-saves after each turn) |
-| `/sessions` | List the 10 most recent sessions |
-| `/skills` | List available skills (trigger with `/<name>`) |
-| `/memory` | List what's remembered across sessions |
+| `/help` | List commands and tools |
+| `/model` | Switch to another model |
+| `/thinking` | Set reasoning effort (off/low/medium/high/xhigh/max) |
+| `/compact` | Summarize older history to free up context |
+| `/transcript` | Re-print the last (or last N) tool call(s) with full, uncapped output |
+| `/goal` | Bare `/goal` shows the current goal (if any); `/goal <objective>` sets one. Manage it with `/goal pause`, `/goal resume`, `/goal clear`, `/goal edit` (prefills the input to change the objective), or `/goal replace <objective>` (replace an unfinished goal). Once set, octo auto-continues turns on its own until the goal completes, is paused, or hits its token/turn budget |
+| `/clear` | Wipe the conversation and start fresh |
+| `/skills` | List discovered skills (trigger one directly with `/<name>`) |
 | `/mcp` | Show connected MCP servers and their surfaces |
+| `/workflows` | List available named workflows (run by the model via the `workflow` tool) |
+| `/memory` | List what's remembered across sessions |
+| `/init` | Analyze repo and generate/update `.octorules` |
+| `/save` | Save the session now (also auto-saves after each turn) |
+| `/sessions` | List recent sessions |
 | `/exit` or `/quit` | Save and exit |
 
 ## Keyboard shortcuts
@@ -91,5 +98,12 @@ The bottom status bar shows:
 - **ctx** — context window usage percentage
 - **perm** — current permission mode (interactive / strict / auto)
 - **elapsed** — turn duration (while running)
+- **goal** — a segment appears here when a session goal is active (see `/goal` above), refreshing as it accounts tokens/turns
 
 Contextual hints appear below the status bar depending on state (e.g. "Enter steer · Ctrl+Q queue · Esc interrupt").
+
+After each turn finishes, an always-on footer line prints the elapsed time and tokens spent on that turn (suppressed in `--quiet` mode).
+
+## Artifacts
+
+When the model calls `show_artifact` to present a previewable file (HTML, Markdown, or an image), the TUI renders it as a click-to-open `file://` hyperlink instead of dumping raw content inline.

--- a/internal/skills/defaults/product_help/WORKFLOW.md
+++ b/internal/skills/defaults/product_help/WORKFLOW.md
@@ -4,16 +4,26 @@ The canonical project guidance for contributors and AI coding agents. Keep this 
 
 ## Project
 
-`octo-agent` is a Go AI agent CLI (Go 1.22+, single binary). Module path `github.com/open-octo/octo-agent`. CLI today; Web UI and IM bridges land in M8/M9 — see `dev-docs/go-rewrite-roadmap.md`.
+`octo-agent` is a Go AI agent CLI (Go 1.22+, single binary). Module path `github.com/open-octo/octo-agent`. All three surfaces are live — CLI/TUI, `octo serve` (web REST + WebSocket + dashboard), and the IM bridge (runs inside `octo serve`).
 
 ## Layering
 
 ```
-cmd/octo/          CLI entry, flag parsing, REPL, sessions
-internal/agent/    Agent loop, history, content blocks, Sender interfaces
-internal/provider/ Provider interface + per-vendor implementations
-internal/tools/    Concrete ToolExecutor implementations
-internal/version/  Version constants overridable via -ldflags
+cmd/octo/           CLI entry, flag parsing, REPL/TUI, sessions
+internal/agent/     Agent loop, history, content blocks, Sender interfaces
+internal/provider/  Provider interface + per-vendor implementations
+internal/tools/     Concrete ToolExecutor implementations
+internal/skills/    SKILL.md discovery + system-prompt manifest
+internal/permission/ allow/deny/ask rule engine gating every tool call
+internal/hooks/     Lifecycle-event hook engine (hooks.yml)
+internal/mcp/       MCP client (stdio + HTTP, OAuth)
+internal/server/    octo serve — HTTP REST + WebSocket + embedded dashboard
+internal/channel/   IM bridge — adapter interface + platform adapters
+internal/workflow/  Named multi-step workflow execution
+internal/browser/   Browser automation (CDP) backend
+internal/memory/    Cross-session memory
+internal/version/   Version constants overridable via -ldflags
+pkg/octoagent/      Public Go SDK re-exporting core agent types for embedding octo in other programs
 ```
 
 Dependency direction is one-way: `provider → agent`, `tools → agent`, never the other way. `cmd/octo` is the only package allowed to import `provider` directly; everything else talks through `agent.Sender` / `StreamingSender` / `ToolSender` / `ToolStreamingSender`.
@@ -22,7 +32,7 @@ Dependency direction is one-way: `provider → agent`, `tools → agent`, never 
 
 - **New provider** — implement `provider.Provider` (required) and optionally `provider.StreamingProvider`, `provider.ToolProvider`, `provider.ToolStreamingProvider`. Put it under `internal/provider/<name>/`. Each protocol's wire-format quirks are isolated inside the package; the agent layer must not learn about them.
 - **New tool** — implement `agent.ToolExecutor` and `Definition() agent.ToolDefinition` returning the JSON Schema the LLM sees. Place it under `internal/tools/<name>.go`. Register it in `tools.DefaultRegistry` and add it to `tools.DefaultTools()` if it belongs in the default set.
-- **New skill** (M7+) — `~/.octo/skills/<name>/SKILL.md` with the same frontmatter format Claude Code uses. The skill loader composes existing tools — adding a skill should not require new tool code.
+- **New skill** — `~/.octo/skills/<name>/SKILL.md` with the same frontmatter format Claude Code uses, or `internal/skills/defaults/<name>/SKILL.md` to ship it as a default. The skill loader composes existing tools — adding a skill should not require new tool code.
 
 ## Code style
 


### PR DESCRIPTION
## Summary

The `product-help` skill's bundled docs (what octo reads to answer its own "how do I..." questions) hadn't kept pace with several months of feature work, and had accumulated stale/wrong content along the way. Every claim below was verified against current source or `--help` output, not carried over from the prior doc text.

**Previously undocumented anywhere:**
- Session goals (`/goal`), the `octo workflows` feature, `octo browser setup`, the hooks engine (`octo hooks`/`hooks.yml`), IM `send_message`/`send_file`, per-session `permission_mode`/`workspace_dir`, per-turn token usage footer, `show_artifact` link rendering, packaging installers

**Stale or outright wrong:**
- `~/.octo/config.yaml` → `config.yml` (renamed a while back) across 6 files
- `--no-reasoning` flag doesn't exist; it's `--show-reasoning`, default **off** (README and CLI.md contradicted each other on the default)
- `permission_mode` had a fabricated `"confirm"` value — real values are `interactive`/`strict`/`auto`
- Sub-agent tool names were stale (`launch_agent`/`send_message`/`agent_status`/`kill_agent` → actually `sub_agent`/`sub_agent_send`/`sub_agent_status`/`sub_agent_kill`)
- A workflow preset (`adversarial-review`) I initially wrote in based on a commit message turned out to have been removed since — caught by actually running `octo workflows list`
- Memory doc claimed "auto extract/consolidate", which MEMORY.md itself documents as the design that was replaced (now plain files, no consolidation)
- `SKILLS.md` said only 1 default skill existed (actually 20) and that `octo skills add` wasn't built yet (it is)
- `WORKFLOW.md` said "Web UI and IM bridges land in M8/M9" (all three surfaces have been live for a while)
- `SKILL.md`'s doc index only listed 5 of the (now) 12 bundled files

## Changes
- `README.md`, `CLI.md`, `CONFIG.md`, `TROUBLESHOOTING.md`, `MCP.md`, `SKILL.md` — fix stale/wrong content above
- `CLI.md` — add `init`/`memory`/`workflows`/`browser`/`upgrade`/`completion`/`help` commands, `skills add`
- `CONFIG.md` — add `custom` provider, `workspace_dir`, `goal.enabled`, `browser.*`, `language` fields
- `SKILLS.md` — rewritten: current 20 default skills, real `octo skills add`, a "writing your own skill" section
- `WORKFLOW.md` — updated layering to current `internal/` package list
- `TUI.md` — add the 7 missing slash commands, per-turn token footer, `show_artifact` link rendering
- New `HOOKS.md` (hooks.yml schema, 7 events, blocking protocol) and `IM.md` (channels.yml, send_message/send_file)

## Test plan
- [x] Verified every CLI command/flag against the built binary's `--help` output
- [x] Verified every config field name against `internal/config/config.go`
- [x] Verified hooks.yml schema against `internal/hooks/config.go` + `payload.go`
- [x] Verified default skill list against `internal/skills/defaults/`
- [x] Docs-only change — no Go code touched, no build/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)