### PR TITLE
docs(product-help): document the new external memory-backend feature

### DIFF
--- a/internal/skills/defaults/product_help/CLI.md
+++ b/internal/skills/defaults/product_help/CLI.md
@@ -1,93 +1,44 @@
 # octo CLI Reference
 
-## Commands
+Precedence is **CLI flag > env var > `~/.octo/config.yml` > built-in default**. Run `octo <command> --help` for any subcommand's full flag list.
 
-### `octo [prompt]`
-Start an interactive REPL/TUI session, or run a single headless agentic turn and exit (with a prompt argument or piped stdin).
+## `octo [message]`
 
-Common flags:
-- `-c, --continue [id]` — Resume a session ('last', short ID, or substring; no ID = pick from a list)
-- `--take-over` — When resuming, take over a session bound to another entry
-- `--no-tools` — Disable built-in tools (terminal, edit_file, …) + MCP/skills
-- `--provider <name>` — `anthropic` (default) | `openai` | `custom`
-- `--model <name>` — Override the default model for the provider
-- `--system <path>` — Path to a custom system-prompt file
-- `--no-save` — Don't auto-save the session to `~/.octo/sessions`
-- `--no-memory` — Disable cross-session memory injection
-- `--sandbox` — OS-enforced confinement for terminal commands (macOS/Linux)
-- `--permission-mode <mode>` — `interactive` (default; prompts on ask) | `strict` | `auto`
-- `--reasoning-effort low|medium|high|xhigh|max` — Enable extended reasoning (empty/default = off)
-- `--show-reasoning` — Surface the reasoning trace for the web UI to display (default off). The terminal itself never renders it regardless of this flag.
-- `--quiet` / `--verbose` — Less / more status chrome
+No positional message in a terminal → interactive TUI. A message (or piped stdin) → headless one-shot: full agentic tool loop, then exit.
 
-### `octo config [subcommand]`
-Manage persisted configuration (`~/.octo/config.yml`).
+Frequently-used flags: `-c`/`--continue [id]` (resume), `--provider anthropic|openai|custom`, `--model <name>`, `--no-tools`, `--no-save`, `--no-memory`, `--sandbox`, `--permission-mode interactive|strict|auto`, `--reasoning-effort low|medium|high|xhigh|max`, `--show-reasoning` (web UI trace display, default off — the terminal never renders it regardless), `--quiet`/`--verbose`.
 
-Subcommands:
-- `setup` / `init` (default, bare `octo config`) — Interactive wizard to set provider, model, and options
-- `show` / `get` — Display current effective configuration and where each value comes from
-- `path` — Print the config file path
+## Subcommands
 
-### `octo init`
-Analyze the repo and generate/update `.octorules`. Flags: `-provider`, `-model`, `-permission-mode` (default `strict`), `-sandbox` (+ `-sandbox-allow-net`, `-sandbox-read`, `-sandbox-write`), `-plain` (one-line tool status instead of rich cards).
+| Command | Purpose |
+|---|---|
+| `octo config` [`show`\|`path`] | Interactive setup wizard; print effective settings; print the config file path |
+| `octo init` | One-shot run that writes/improves `.octorules` for the current repo |
+| `octo memory list`\|`path` | List or locate the project's and inherited memory files |
+| `octo skills list`\|`add`\|`update`\|`path` | Manage discovered skills — see `SKILLS.md` |
+| `octo hooks list` | List configured lifecycle hooks (not shown in top-level `--help`, but real) — see `HOOKS.md` |
+| `octo sessions` | List saved sessions |
+| `octo serve` | Start the HTTP server (REST + WebSocket + Web UI + IM bridge) |
+| `octo workflows list`\|`path`\|`update` | Manage named multi-step workflows the model runs by name |
+| `octo browser setup` | Configure Chrome DevTools Protocol automation |
+| `octo upgrade` [`--check`] [`--force`] | Install the latest release in place, or just check |
+| `octo completion bash`\|`zsh`\|`fish`\|`powershell` | Print a shell completion script |
+| `octo version` | Print version information |
+| `octo help [command]` | Top-level help, or a command's detailed help/examples |
 
-### `octo sessions`
-List recent saved sessions. Resume one with `octo -c <id>` / `octo -c last`, or run bare `octo -c` to pick from an interactive list.
+### `octo serve` flags
 
-### `octo memory [list|path]`
-Manage cross-session memory. `list` shows the current project's memory files; `path` prints the memory directory. See `MEMORY.md`.
+`-addr` (default `127.0.0.1:8088`), `--access-key` (required for non-loopback clients), `--no-channel` (skip IM bridges), `-d`/`--daemon` (background), `--stop` (stop a background instance), `--cors`.
 
-### `octo skills [subcommand]`
-Manage skills.
-
-Subcommands:
-- `list` — List available skills (default, user, project)
-- `add <owner/repo[/sub/path] | github.com tree URL> [--force]` — Install a skill from a GitHub repo path (e.g. `octo skills add anthropics/skills/skills/docx`)
-- `update` — Refresh default skills from the binary
-- `path` — Show skill search paths
-
-See `SKILLS.md` for the embedding/precedence mechanism.
-
-### `octo workflows [subcommand]`
-List and manage named workflows (multi-step scripts the model runs by name via the `workflow` tool).
-
-Subcommands:
-- `list` — List discovered workflows (default/embedded, user, project) with their args
-- `path` — Show workflow search paths
-- `update` — Refresh embedded default workflows from the binary
-
-`/workflows` in the TUI shows the same listing.
-
-### `octo browser setup`
-Guide through enabling Chrome/Edge remote debugging, verify the connection, and save `browser.connect_port` to config so the `browser` tool can drive your logged-in browser (record/replay, self-heal, vision screenshots).
-
-### `octo hooks list`
-Show currently configured hooks (built-ins plus anything from `hooks.yml`). See `HOOKS.md` for the event/config format — note `octo hooks` isn't in the top-level `--help` listing, but it is a real, working feature.
-
-### `octo serve`
-Start the HTTP server (REST + WebSocket + embedded web dashboard), and the IM bridge (unless `-no-channel`).
-
-Notable flags: `-addr` (default `127.0.0.1:8088`), `-access-key` (required for non-localhost clients), `-cors`, `-model`, `-max-tokens`, `-no-channel` (disable IM), `-no-memory`, `-d`/`-daemon` (background, pid at `~/.octo/serve.pid`), `-no-supervisor`.
-
-### `octo upgrade`
-Download and install the latest release in place. `--check` only compares versions without installing; `--force` proceeds despite a dev build or an already-latest version.
-
-### `octo completion <shell>`
-Print a shell-completion snippet. Shells: `bash`, `zsh`, `fish`, `powershell`.
-
-### `octo version`
-Print version information.
-
-### `octo help [command]`
-Print the top-level help, or a command's detailed help/examples (e.g. `octo help mcp`). `octo <command> --help` prints just that command's flags.
-
-## Environment Variables
+## Environment variables
 
 | Variable | Purpose |
 |----------|---------|
-| `OCTO_PROVIDER` | Default provider (`anthropic` \| `openai` \| `custom`) |
+| `OCTO_PROVIDER` | Default provider (`anthropic`\|`openai`\|`custom`) |
 | `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` | Required for the chosen provider |
-| `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` | Override the endpoint (proxies, compatible servers) |
+| `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` | Override the endpoint |
 | `ANTHROPIC_MODEL` / `OPENAI_MODEL` | Default model override |
-| `CUSTOM_API_KEY` + `CUSTOM_BASE_URL` | Self-hosted/third-party endpoint (`--provider custom`; wire protocol picked in `octo config`) |
-| `OCTO_ACCESS_KEY` | `octo serve` access key for non-localhost clients |
+| `CUSTOM_API_KEY` + `CUSTOM_BASE_URL` | Self-hosted/third-party endpoint (`--provider custom`) |
+| `OCTO_ACCESS_KEY` | `octo serve` access key for non-loopback clients |
+
+Full flag-by-flag reference (every `octo [message]` flag, compaction thresholds, `octo serve` self-restart contract): **https://octo-agent.dev/docs/reference/cli/** (`web_fetch`). Self-hosting `octo serve` as a service: **https://octo-agent.dev/docs/guides/self-host/**. Named workflows in depth: **https://octo-agent.dev/docs/guides/workflows/**. Browser automation in depth: **https://octo-agent.dev/docs/guides/browser-automation/**.

--- a/internal/skills/defaults/product_help/CONFIG.md
+++ b/internal/skills/defaults/product_help/CONFIG.md
@@ -24,6 +24,7 @@ Created interactively via `octo config` or edited directly. (A pre-rename `~/.oc
 | `browser.attach_running` | bool | Attach to your already-running Chrome via its default profile, reusing the logged-in session |
 | `language` | string | UI language preference: `"en"` (default) or `"zh"` |
 | `tools.tool_search` | object | MCP Tool Search settings — `enabled: auto\|on\|off`, `threshold_pct: <int>`. See `MCP.md` |
+| `memory_backend` | object | Optional external semantic memory (hindsight/mem0/memos) — `type`, `base_url`, `api_key`, `namespace`. Unset disables it entirely. See `MEMORY.md` |
 
 ## Precedence
 

--- a/internal/skills/defaults/product_help/CONFIG.md
+++ b/internal/skills/defaults/product_help/CONFIG.md
@@ -1,50 +1,32 @@
 # octo Configuration Reference
 
-## Config file
+Path: `~/.octo/config.yml`. Every field is optional — a missing file or field falls back to the built-in default. Manage with `octo config` rather than hand-editing where possible. (A pre-rename `~/.octo/config.yaml` is read as a fallback if `config.yml` is absent, and migrates automatically on first save — old file parked as `config.yaml.bak`.)
 
-Path: `~/.octo/config.yml`
+## Top-level keys
 
-Created interactively via `octo config` or edited directly. (A pre-rename `~/.octo/config.yaml` is read as a fallback if `config.yml` is absent, and gets migrated to `config.yml` — with the old file parked as `config.yaml.bak` — on the first save.)
-
-## Fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `provider` | string | `"anthropic"`, `"openai"`, or `"custom"` (any Anthropic/OpenAI-compatible endpoint via `CUSTOM_API_KEY`/`CUSTOM_BASE_URL`) |
-| `model` | string | Model name (e.g. `claude-sonnet-4-20250514`, `gpt-4.1`) |
-| `base_url` | string | Optional custom API endpoint |
-| `permission_mode` | string | `"interactive"` (default), `"strict"`, or `"auto"` |
-| `coauthor` | bool | Append `Co-authored-by` to git commits |
-| `show_reasoning` | bool | Surface the reasoning/thinking trace for the web UI to display (default off; the terminal never renders it) |
-| `reasoning_effort` | string | `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`, or `""` (off) |
-| `api_key` | string | Plaintext fallback (discouraged — use env var instead) |
-| `workspace_dir` | string | Default working directory for new **web** sessions only. Empty (default) = the server's own launch directory; `"auto"` = `~/Desktop/octo`; anything else = a literal path. Doesn't affect CLI/TUI sessions |
-| `goal.enabled` | bool | Gates the `/goal` surface and goal tools (default true — inert until a goal is actually created) |
-| `browser.connect_port` | int | Chrome remote-debugging port to attach to (set by `octo browser setup`) |
-| `browser.attach_running` | bool | Attach to your already-running Chrome via its default profile, reusing the logged-in session |
-| `language` | string | UI language preference: `"en"` (default) or `"zh"` |
-| `tools.tool_search` | object | MCP Tool Search settings — `enabled: auto\|on\|off`, `threshold_pct: <int>`. See `MCP.md` |
-| `memory_backend` | object | Optional external semantic memory (hindsight/mem0/memos) — `type`, `base_url`, `api_key`, `namespace`. Unset disables it entirely. See `MEMORY.md` |
-
-## Precedence
-
-CLI flags (`--provider`, `--model`, etc.) > env vars (`OCTO_PROVIDER`, `ANTHROPIC_API_KEY`, etc.) > config file > built-in defaults.
-
-## Permission modes
-
-- **interactive** (default) — Prompt for approval when a rule says `ask`.
-- **strict** — Auto-deny when a rule says `ask`. Used for non-interactive callers (HTTP server, IM bridge) by default.
-- **auto** — Auto-allow when a rule says `ask`. Useful for trusted, repetitive workflows — use with caution.
-
-Cycle modes in the TUI with **Shift+Tab**; a web session can also override its own mode via the composer status bar (per-session, doesn't touch this global default). See `PERMISSIONS.md` for the full rule engine.
+| Key | Type | Description |
+|---|---|---|
+| `models` | list | Named model configurations — `provider` (`anthropic`\|`openai`\|`custom`), `model`, `protocol` (custom vendor only), `base_url`, `api_key`, `reasoning_effort`, `show_reasoning`, `vision` |
+| `default_model` | string | Entry used when nothing else selects one |
+| `permission_mode` | string | `interactive` (default) \| `strict` \| `auto` |
+| `coauthor` | bool | Append `Co-authored-by` to git commits (default true) |
+| `show_reasoning` | bool | Global default for surfacing the reasoning trace to the web UI (default off; terminal never renders it) |
+| `workspace_dir` | string | Default working dir for new **web** sessions only; `"auto"` → `~/Desktop/octo` |
+| `goal.enabled` | bool | Gates `/goal` and the goal tools (default true) |
+| `browser.connect_port` / `browser.attach_running` | int / bool | Chrome connection settings — see `octo browser setup` |
+| `memory_backend` | object | Optional external semantic memory (hindsight/mem0/memos) — see `MEMORY.md` |
+| `tools.tool_search` | object | MCP Tool Search settings — see `MCP.md` |
 
 ## Example
 
 ```yaml
-provider: anthropic
-model: claude-sonnet-4-20250514
+models:
+  - provider: anthropic
+    model: claude-sonnet-5
+default_model: claude-sonnet-5
+permission_mode: interactive
 coauthor: true
-show_reasoning: true
-reasoning_effort: medium
 workspace_dir: auto
 ```
+
+Full field reference (every model-entry field, `tools.disabled_skills`, compaction thresholds): **https://octo-agent.dev/docs/reference/config-file/** (`web_fetch`).

--- a/internal/skills/defaults/product_help/HOOKS.md
+++ b/internal/skills/defaults/product_help/HOOKS.md
@@ -1,80 +1,19 @@
 # Hooks — run your own commands at points in the agent loop
 
-octo can shell out to your own scripts at fixed points in the agent loop — inject retrieved context, log every tool call, block a dangerous command before it runs, or clean up after a turn. The model, the CLI, `octo serve` (web + IM), and sub-agents all share the same hook engine and the same `hooks.yml`.
+octo can shell out to your own scripts at 7 lifecycle points (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `SubagentStop`, `PreCompact`) — inject retrieved context, log every tool call, or block a dangerous command before it runs. One engine, shared by the CLI, `octo serve` (web + IM), and sub-agents.
 
-`octo hooks` isn't listed in the top-level `octo --help`, but it's a real, working feature — `octo hooks list` shows what's currently configured (built-ins plus anything from `hooks.yml`).
-
-## Config files
-
-| File | Scope |
-|------|-------|
-| `~/.octo/hooks.yml` | User-global — loaded for every session |
-| `<project>/.octo/hooks.yml` | Project-local — layered on top (runs after user hooks) |
-
-A project-level `hooks.yml` can run shell commands on your machine, so it's **trust-on-first-use**: the first time an interactive session (TUI, or a one-shot at a terminal) sees a project file it hasn't approved, it prompts `Trust and run this repo's hooks? [y/N]`. Approving records the file's content fingerprint, so it won't ask again until the file changes. A non-interactive session (piped stdin) declines silently rather than running an untrusted repo's hooks unattended. `octo serve` auto-trusts its own operator-chosen working directory.
-
-## Schema
+Configured in `~/.octo/hooks.yml` (user-level, always loaded) and `<project>/.octo/hooks.yml` (project-level — trust-on-first-use prompt, since it can run shell commands):
 
 ```yaml
 hooks:
-  UserPromptSubmit:
-    - command: "hindsight-retrieve"
-      timeout: 5s
+  PreToolUse:
+    - matcher: "terminal"        # regexp on tool name; PreToolUse/PostToolUse only
+      command: "./scripts/guard.sh"
   PostToolUse:
-    - matcher: "terminal|write_file"   # regexp over the tool name
+    - matcher: "terminal"
       command: "audit-logger"
-  Stop:
-    - command: "log-session-end"
-      async: true
 ```
 
-Each event maps to a list of hooks (an event can fan out to several commands). Fields per hook:
+`PreToolUse` can block a call: exit code `2` (or `{"decision":"block","reason":"..."}` on stdout) blocks it; `{"decision":"approve",...}` skips the normal permission prompt entirely. `octo hooks list` shows what's currently configured, built-ins included. `octo hooks` isn't in the top-level `octo --help`, but it's real and working.
 
-| Field | Required | Description |
-|-------|----------|--------------|
-| `command` | yes | Shell command to run |
-| `matcher` | no | Regexp over the tool name — only honored for `PreToolUse`/`PostToolUse` |
-| `timeout` | no | Go duration string (e.g. `5s`); empty uses the package default |
-| `async` | no | Run off the turn's critical path via a durable queue — only honored for the side-effect events (`Stop`/`SubagentStop`/`PreCompact`); rejected as a config error on the events whose output is folded into the model stream |
-
-An unknown event name or an invalid `matcher` regexp is a hard config error naming the offending entry (so a typo surfaces instead of silently doing nothing); a hook that fails at runtime is reported via a notice and just contributes no text — it never crashes the turn.
-
-## Events
-
-Mirrors Claude Code's hook model (a CC hook script ports with just field-name changes) — 7 lifecycle points:
-
-| Event | When | Hook's stdout |
-|-------|------|----------------|
-| `SessionStart` | Once per logical session opening | Injected into the first user message (persisted) |
-| `UserPromptSubmit` | Before each user turn | Folded into that turn's user message |
-| `PreToolUse` | Before each tool dispatch | Can **block** the tool (see below) |
-| `PostToolUse` | After each successful tool result | Appended to that tool result's text |
-| `Stop` | An assistant turn ends (success or failure/interrupt) | Discarded — side-effect only |
-| `SubagentStop` | A spawned sub-agent finishes | Discarded — side-effect only |
-| `PreCompact` | Before history compaction | Discarded — side-effect only |
-
-Every hook receives a JSON payload on stdin with `event`, `session_id`, `cwd`, `transcript_path`, `model`, `transport`, plus event-specific fields.
-
-## Blocking (`PreToolUse` / `UserPromptSubmit`)
-
-A hook on one of these events can veto the action:
-
-- **exit code 2** → block (reason = a structured `{"decision":"block","reason":"..."}` on stdout if present, else stderr)
-- **exit 0 with `{"decision":"block"|"approve","reason":"..."}` on stdout** → that decision
-- **timeout or any other exit** → non-blocking error (reported via a notice; the tool/turn proceeds)
-
-The first hook that blocks short-circuits the rest; a later `approve` never overrides an earlier `block`. An `approve` tells octo to bypass the interactive permission prompt for that call — it doesn't otherwise change permission-engine behavior (see `PERMISSIONS.md`).
-
-## Legacy env-var shim
-
-The pre-`hooks.yml` mechanism still works and is layered in first (`hooks.yml` entries run after it):
-
-```
-OCTO_HOOK_PRE_TURN=/path/to/pre-script    # optional
-OCTO_HOOK_POST_TURN=/path/to/post-script  # optional
-OCTO_HOOK_TIMEOUT=5s                      # optional
-```
-
-## Built-ins
-
-Two hooks are always registered even with no `hooks.yml` present: a memory reminder (`UserPromptSubmit`) and a save-nudge (`PostToolUse`). `octo hooks list` shows these plus anything you've configured.
+Full schema (`matcher`/`timeout`/`async` per field, the exact stdin payload shape, the legacy `OCTO_HOOK_PRE_TURN`/`OCTO_HOOK_POST_TURN` env shim, and a worked blocking example): **https://octo-agent.dev/docs/guides/hooks/** (`web_fetch` — not one of the files bundled in this skill directory).

--- a/internal/skills/defaults/product_help/IM.md
+++ b/internal/skills/defaults/product_help/IM.md
@@ -1,31 +1,13 @@
 # IM bridge — chat with octo from WeChat, Feishu, Telegram, etc.
 
-octo can run as a chat bot on WeChat (iLink), Feishu, DingTalk, WeCom, Discord, and Telegram. The bridge runs **inside `octo serve`** (not a separate process) — each platform has its own adapter under `internal/channel/adapters/`, and every adapter shares the same agent loop, tools, skills, memory, and permission engine as the CLI/web surfaces.
+octo can run as a chat bot on WeChat (iLink), Feishu, DingTalk, WeCom, Discord, and Telegram. The bridge runs **inside `octo serve`** — no separate process. Each platform is connected, tested, and can send a one-off test message from the web UI's **Channels** panel (WeChat is scan-to-login; the rest use app/bot credentials). Credentials persist to `~/.octo/channels.yml` and hot-reload — no restart needed after editing a platform in the panel.
 
-## Setup
-
-The primary path is the **Channels panel in the web UI** (`octo serve`, then open the dashboard): it walks through connecting each platform — for WeChat iLink this is scan-to-login (a QR code), other platforms are configured with their own credentials (bot token, app ID/secret, etc., depending on the platform).
-
-Credentials persist to `~/.octo/channels.yml` (mode 0600):
-
-```yaml
-channels:
-  telegram:
-    bot_token: "..."
-  discord:
-    bot_token: "..."
-```
-
-Each platform's config keys are its own (`PlatformConfig` is an open map), set via the web wizard rather than documented as a fixed schema here — use the Channels panel rather than hand-authoring this file. Channel config hot-reloads — enabling/editing a platform in the web UI takes effect without restarting `octo serve`.
-
-## What a chat gets
-
-Each IM chat is a session like any other — per-user sessions, slash commands, tool use, skills, and (if enabled) a session goal all work the same as the TUI. A sustained "typing…" indicator is kept alive on the platforms that support it while an agentic turn is in progress. After each turn, the chat gets a short summary line: `⏱ <elapsed>, <tokens> tokens`.
+Each chat is a session like any other — per-user history and permission context, slash commands (a different set than the TUI/web; see the reference below), attachments bridge both ways, and a session goal works the same as elsewhere.
 
 ## Proactive messaging (`send_message` / `send_file`)
 
-A normal reply only reaches the chat the current turn is already talking to. To reach a **different** chat — e.g. the user is on the web UI and asks octo to message their WeChat — the model uses the `send_message` (text) or `send_file` (file) tools, addressed by `platform` + `chat_id`. If the model doesn't know the `chat_id`, calling the tool with just a platform (or no arguments) returns the list of chats it can currently reach; a chat only appears once it has messaged the bot at least once (that's how the bot learns its `chat_id`). These tools are only registered when a messenger is active (i.e. `octo serve` is running with channels enabled) — they don't appear in a plain CLI/TUI session.
-
-## Disabling the bridge
+A normal reply only reaches the chat the current turn is already talking to. To reach a **different** chat — e.g. the user is on the web UI and asks octo to message their WeChat — the model uses `send_message`/`send_file`, addressed by `platform` + `chat_id`. Calling with just a platform (or no arguments) returns the list of chats it can currently reach; a chat only appears once it has messaged the bot at least once. These tools only appear when a messenger is active (`octo serve` running with channels enabled).
 
 `octo serve -no-channel` starts the web server without the IM bridge.
+
+Full platform setup notes, IM-specific slash commands (`/bind`, `/unbind`, `/new`, `/stop`, `/status`, `/list`), and attachment handling: **https://octo-agent.dev/docs/guides/channels/** (`web_fetch`).

--- a/internal/skills/defaults/product_help/MCP.md
+++ b/internal/skills/defaults/product_help/MCP.md
@@ -1,132 +1,29 @@
-# MCP (Model Context Protocol) Configuration
+# MCP (Model Context Protocol)
 
-octo supports MCP servers that expose external tools, resources, and prompts to the agent. MCP servers are configured via JSON and loaded on session start.
+octo connects to MCP servers for extra tools — databases, ticket trackers, internal APIs. Tools are on by default; each configured server connects at session start and its tools ride alongside octo's built-ins as `mcp__<server>__<tool>`.
 
-## Config files
-
-Two files are read and merged:
-
-| File | Scope |
-|------|-------|
-| `~/.octo/mcp.json` | User-global — shared across all projects |
-| `<project>/.octo/mcp.json` | Project-local — overrides user-global by server name |
-
-Missing files are silently ignored. Project-local entries with the same name as a user-global entry win.
-
-## Config format
+Declared in `~/.octo/mcp.json` (user-global) and `./.octo/mcp.json` (project-local, overrides by server name):
 
 ```json
 {
   "mcpServers": {
-    "server-name": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
-      "env": {"FOO": "bar"}
-    },
-    "remote-api": {
-      "url": "https://example.com/mcp",
-      "headers": {"Authorization": "Bearer ..."},
-      "auth": "oauth"
-    }
+    "github": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"] },
+    "linear": { "url": "https://mcp.linear.app/sse", "auth": "oauth" }
   }
 }
 ```
 
-## Server types
-
-### stdio (local subprocess)
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `command` | yes | Executable to spawn |
-| `args` | no | Arguments passed to the command |
-| `env` | no | Extra environment variables |
-
-Example: filesystem server via npx
-```json
-{
-  "mcpServers": {
-    "fs": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/me/projects"]
-    }
-  }
-}
-```
-
-### HTTP (remote endpoint)
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `url` | yes | MCP endpoint URL |
-| `headers` | no | Extra HTTP headers |
-| `auth` | no | `"oauth"` for OAuth (Authorization Code + PKCE), or omit |
-
-Example: remote API with OAuth
-```json
-{
-  "mcpServers": {
-    "my-api": {
-      "url": "https://api.example.com/mcp",
-      "auth": "oauth"
-    }
-  }
-}
-```
-
-## Auth strategies
-
-- `""` (default) — No automatic auth. Pass tokens manually via `headers`.
-- `"oauth"` — Runs RFC-compliant OAuth (Authorization Code + PKCE) on first connect and on every 401. Tokens are cached at `~/.octo/mcp-tokens/<server>.json`.
-
-## Disabling a server
-
-Add `"disabled": true` to keep the config but skip loading it:
-
-```json
-{
-  "mcpServers": {
-    "broken": {
-      "command": "npx",
-      "args": ["-y", "@some/broken-server"],
-      "disabled": true
-    }
-  }
-}
-```
-
-## Verification
-
-After editing `mcp.json`, start `octo` and look for the startup line:
-
-```
-Connected 2 MCP servers: fs, my-api
-```
-
-If a server fails to connect, the error is printed to stderr and that server is skipped — the session continues with the others.
+`"auth": "oauth"` on a Streamable HTTP entry runs Authorization Code + PKCE automatically on first `401` — a browser tab opens for consent, the token caches at `~/.octo/mcp-tokens/<server>.json` and auto-refreshes. Check what's connected with `/mcp` in the TUI. A server that fails to start or times out (10s) is logged and skipped; the session continues with the others.
 
 ## Tool Search
 
-MCP servers with many tools can push a lot of schema tokens into every request. Tool Search defers those *schemas*: built-in tools stay visible, and every connected MCP tool's name + one-line description stays listed in the system prompt the whole time — only the full parameter schema is loaded on demand, via `mcp_describe` → `mcp_call`.
-
-Control it under `tools.tool_search` in `~/.octo/config.yml`:
+When MCP servers expose many tools, uploading every schema every turn wastes context. Tool Search keeps every connected tool's name + one-line description listed in the system prompt, and defers the full schema behind `mcp_describe` → `mcp_call`, loaded only on demand. Control it under `tools.tool_search` in `~/.octo/config.yml`:
 
 ```yaml
 tools:
   tool_search:
-    enabled: auto          # auto | on | off
-    threshold_pct: 10      # auto: activate when deferred schemas >= N% of context window
+    enabled: auto          # auto (default, activates past threshold_pct) | on | off
+    threshold_pct: 10
 ```
 
-- `auto` (default) — enable only when deferred MCP schemas would occupy at least `threshold_pct` of the model's context window.
-- `on` — always defer MCP schemas when any MCP tool is connected.
-- `off` — upload every MCP schema upfront (legacy behavior).
-
-## Troubleshooting
-
-| Symptom | Fix |
-|---------|-----|
-| `command not found` | Ensure the binary is on `$PATH` or use an absolute path |
-| `connection refused` | Check the URL and network; verify the server is running |
-| OAuth loop | Delete `~/.octo/mcp-tokens/<server>.json` to force re-auth |
-| Server not appearing | Check JSON syntax; validate with `python3 -m json.tool mcp.json` |
+Full reference (troubleshooting a broken server, the exact OAuth discovery flow): **https://octo-agent.dev/docs/guides/connect-mcp-servers/** (`web_fetch`).

--- a/internal/skills/defaults/product_help/MEMORY.md
+++ b/internal/skills/defaults/product_help/MEMORY.md
@@ -1,142 +1,30 @@
 # Cross-session memory
 
-octo's memory is a per-repo directory of plain markdown that the agent manages
-with its own file tools — the Claude Code model. There is no dedicated
-remember/forget tool, no typed-entry store, and no code-driven consolidation:
-the agent reads, writes, edits, and deletes memory files directly, so editing
-and deletion are first-class and instant.
+octo remembers preferences, project conventions, and past corrections across sessions — stored locally as plain markdown in `~/.octo/memories/<repo-slug>/`, never in the cloud. There's no dedicated remember/forget tool and no background consolidation: the agent manages memory with its own file tools (`read_file`/`write_file`/`edit_file`), keeping to one convention:
 
-This is the agent's *automatic* layer. The *hand-written* layers — `~/.octo/soul.md`,
-`~/.octo/user.md`, `~/.octo/octorules.md`, and per-repo `.octorules` — are
-separate and described in `identity-files-design.md`.
+- `MEMORY.md` — the index, loaded into the system prompt every session (capped at 200 lines / 25KB).
+- `<topic>.md` — detail files the agent creates and reads on demand, linked from the index.
 
-## Layout
+Memory is scoped per repo (shared across that repo's worktrees) plus a home-level index inherited into every project for cross-project preferences. `MEMORY.md` can also carry two optional rule tiers beyond a plain index — always-apply rules (restated every turn) and triggered rules (recalled once per session on a keyword hit).
 
 ```
-~/.octo/memories/<repo-slug>/
-  MEMORY.md      index, injected into the system prompt every session
-  <topic>.md     detail files the agent creates and reads on demand
+octo memory list     # list the project's and inherited memory files
+octo memory path     # print the memory directories
+octo --no-memory     # disable memory injection for a single session
 ```
 
-- **Per repo.** The directory is keyed by the git top-level of the working
-  directory (`memory.ProjectRoot`), so each project has its own memory and
-  facts don't bleed across repos. Outside a git repo the working directory is
-  used. The slug is the repo basename plus a short hash of the full path, so two
-  checkouts that share a basename don't collide.
-- **Inheritance.** The home directory (`~`) also has its own memory slot.
-  When running inside any project, the home MEMORY.md is injected *before* the
-  project MEMORY.md, so cross-project preferences and personal facts are
-  available everywhere. The agent is instructed to sort new memories by scope:
-  project-specific facts go to the project memory; cross-project or personal
-  preferences go to the home (inherited) memory.
-- **MEMORY.md is the index.** It is loaded into the system prompt at session
-  start, truncated to the first 200 lines / 25 KB (whichever comes first),
-  mirroring Claude Code's cap. Topic files are not loaded up front — the agent
-  reads them on demand with its file tools when MEMORY.md points at one.
+`/memory` in the TUI shows the same listing.
 
-## Injection
-
-At session start `cmd/octo` resolves the directory, creates it, and injects
-`memory.RenderInjection(dir, inheritedDirs...)` into the composed system prompt
-(the `memory` layer of `prompt.Compose`). The injection is a short instruction
-block — *where* memory lives and *how* to manage it — followed by inherited
-MEMORY.md files (home directory first) and then the project MEMORY.md (or an
-"empty" marker so a fresh project knows where to start). The notes are framed
-as the agent's own durable record of the user's preferences, workflow rules,
-and project facts, to be followed as standing guidance; the current user request
-and safety override a conflicting note. The block is frozen for the session:
-what the agent writes now surfaces in the *next* session, not the current one.
-
-The session-prompt guidance (`internal/prompt/base.md`, "Memory" section)
-covers when to save (lasting preferences, corrections + the why, validated
-judgment, external resources), what not to save (one-off task state, anything
-derivable from the repo, secrets), grounding answers in memory with a brief
-inline attribution, and verifying a remembered file/flag still exists before
-acting on it.
-
-## Attention layer — structured rules, re-surfaced at the point of action
-
-A note buried in the frozen system-prompt block is easy for the model to skim
-past by the time it matters, many turns later. MEMORY.md may therefore carry two
-optional sections whose rules are written **in full** (not as pointer links) and
-re-surfaced on the message stream when they're relevant:
-
-```
-## 必须遵守        always-apply rules — restated every turn
-## 触发提醒        each bullet "(触发: kw1, kw2) rule text" — recalled on a keyword hit
-```
-
-`memory.ParseRules` extracts these tiers (section headings are matched by
-keyword — `必须遵守`/`always`, `触发`/`trigger` — tolerant of emoji and heading
-level). `memory.Injector.Reminder` renders the per-turn `<system-reminder>`:
-always-apply rules on every turn, plus any triggered rules whose keywords occur
-in the user input, each surfaced at most once per session. Trigger matching is
-deliberately conservative and one-directional — *input contains trigger* —
-with ASCII keywords matched on word boundaries (`deploy` does not fire on
-`deployment`) and CJK keywords matched as substrings (`部署` fires inside
-`帮我部署一下`).
-
-`cmd/octo` builds the injector once per session and wires it as
-`agent.UserInputHook`, which folds the reminder into the user message at the
-single `History.Append` choke point in `Turn`/`TurnStream`/`runLoop` (one
-appended message, so the error-path `popLast` rollback still removes exactly one
-turn). The reminder rides the message stream rather than the system prompt, so
-the cached prompt prefix stays byte-stable across the session.
-
-A MEMORY.md without these sections — the plain pointer-index format — parses to
-zero rules, sets no hook, and behaves exactly as before.
-
-## Writing — file tools, whitelisted directory
-
-The agent saves with `write_file` (append to MEMORY.md or a topic file), edits
-with `edit_file`, and removes with `terminal` (`rm`/`mv`). The memory directory
-lives outside the working directory, where the permission engine's default
-`write_file`/`edit_file` rules only auto-allow `$CWD/**`. So `cmd/octo` passes
-both the project memory directory and the inherited home memory directory to
-`permission.New(..., allowWriteRoots...)`, which prepends an
-`allow { path: [<memDir>, <memDir>/**] }` rule to those tools — the agent
-manages its memory without a prompt on every save, while CWD and
-secret-path rules still apply everywhere else.
-
-## Inspecting
-
-- `octo memory list` — list the project's memory files; `octo memory path` —
-  print the directory.
-- `/memory` in the TUI — the same listing.
-
-These are viewers/locators only; the files are the source of truth and the
-agent owns them.
+Full mechanics (rule-tier syntax, the save-nudge hook, why the CLI composes once per session while web/IM recompose every turn): **https://octo-agent.dev/docs/guides/memory/** (`web_fetch`).
 
 ## Optional: an external memory backend (separate feature)
 
-Everything above is `MEMORY.md` — the agent's own curated standing guidance, frozen into the system prompt every session. octo can *additionally* connect to a self-hosted external semantic-memory service that indexes raw conversation text and lets the agent search it later. This is a completely separate, optional layer: octo doesn't touch or duplicate `MEMORY.md` to support it, and it's off by default.
+Everything above is `MEMORY.md` — curated standing guidance, frozen into the system prompt. octo can *additionally* connect to a self-hosted external semantic-memory service that indexes raw conversation text for later search. Separate, optional layer — off by default, doesn't touch `MEMORY.md`.
 
-Three backends are supported, pick at most one — [hindsight](https://github.com/vectorize-io/hindsight), [mem0](https://github.com/mem0ai/mem0), or [MemTensor/MemOS](https://github.com/MemTensor/MemOS) (not the unrelated `usememos/memos` note-taking app). Each is self-hosted; octo only talks to its REST API once you've got the server running.
+Three backends, pick at most one: [hindsight](https://github.com/vectorize-io/hindsight), [mem0](https://github.com/mem0ai/mem0), or [MemTensor/MemOS](https://github.com/MemTensor/MemOS) (not the unrelated `usememos/memos` app) — each self-hosted, octo just talks to its REST API.
 
-- **Storing is automatic and silent.** After every turn, octo sends that turn's content to the backend in the background — there's no `memory_store` tool, nothing for the agent to decide, and a failed store doesn't surface anywhere or slow down the turn.
-- **Recall is a tool.** The agent calls `memory_recall` when it suspects something relevant was discussed before. Unlike storing, this blocks on the network round trip and its errors do surface, since it's an explicit, visible action.
-- **Configure** via a `memory_backend` block in `~/.octo/config.yml`:
+- **Storing is automatic and silent** — after every turn, in the background, no tool involved.
+- **Recall is a tool** — the agent calls `memory_recall` when it suspects something relevant was discussed before; this one blocks and its errors surface.
+- **Configure** via `memory_backend` in `~/.octo/config.yml`: `type` (`hindsight`\|`mem0`\|`memos`; unset disables the feature entirely), `base_url`, `api_key` (backend-dependent — hindsight/memos default to no auth, mem0 requires it by default), `namespace` (scopes stored/recalled memories).
 
-  ```yaml
-  memory_backend:
-    type: hindsight        # hindsight | mem0 | memos
-    base_url: http://localhost:8888
-    api_key: ""            # optional, backend-dependent — see below
-    namespace: my-project  # scopes stored/recalled memories; defaults to "default"
-  ```
-
-  Leaving `type` unset (or omitting the block) disables the feature entirely — no tool advertised, nothing sent anywhere. `api_key`: hindsight has no auth by default (only needed if you've enabled `HINDSIGHT_API_TENANT_API_KEY` server-side); mem0 requires auth by default (set it, or run the server with `AUTH_DISABLED=true` for local dev); memos has no auth by default and sends `namespace` as an `X-User-Name` header when the key is blank. `namespace` maps to hindsight's `bank_id`, mem0's `user_id`, or memos's `user_id`. Config is read once at session start — restart after changing it.
-
-See the full guide at `docs/src/content/docs/guides/memory-backends.md` for backend-specific setup notes.
-
-## Why this shape
-
-The earlier design was a typed one-file-per-fact store written through a
-`remember` tool and folded into consolidated summaries by a background
-sub-agent. It had no way to remove a fact once consolidated — a wrong or
-obsolete entry lived in the summary prose with no addressable handle, re-injected
-every session. The file model removes that gap by construction: memory is just
-files, so correcting or forgetting is an ordinary edit or delete. It also drops
-a large amount of machinery (typed entries, summaries, state, archive, git
-auto-commit, the remember/forget tools, the per-turn nudge) in favour of the
-tools the agent already has.
+Full backend-specific auth/setup notes: **https://octo-agent.dev/docs/guides/memory-backends/** (`web_fetch`).

--- a/internal/skills/defaults/product_help/MEMORY.md
+++ b/internal/skills/defaults/product_help/MEMORY.md
@@ -107,6 +107,28 @@ secret-path rules still apply everywhere else.
 These are viewers/locators only; the files are the source of truth and the
 agent owns them.
 
+## Optional: an external memory backend (separate feature)
+
+Everything above is `MEMORY.md` — the agent's own curated standing guidance, frozen into the system prompt every session. octo can *additionally* connect to a self-hosted external semantic-memory service that indexes raw conversation text and lets the agent search it later. This is a completely separate, optional layer: octo doesn't touch or duplicate `MEMORY.md` to support it, and it's off by default.
+
+Three backends are supported, pick at most one — [hindsight](https://github.com/vectorize-io/hindsight), [mem0](https://github.com/mem0ai/mem0), or [MemTensor/MemOS](https://github.com/MemTensor/MemOS) (not the unrelated `usememos/memos` note-taking app). Each is self-hosted; octo only talks to its REST API once you've got the server running.
+
+- **Storing is automatic and silent.** After every turn, octo sends that turn's content to the backend in the background — there's no `memory_store` tool, nothing for the agent to decide, and a failed store doesn't surface anywhere or slow down the turn.
+- **Recall is a tool.** The agent calls `memory_recall` when it suspects something relevant was discussed before. Unlike storing, this blocks on the network round trip and its errors do surface, since it's an explicit, visible action.
+- **Configure** via a `memory_backend` block in `~/.octo/config.yml`:
+
+  ```yaml
+  memory_backend:
+    type: hindsight        # hindsight | mem0 | memos
+    base_url: http://localhost:8888
+    api_key: ""            # optional, backend-dependent — see below
+    namespace: my-project  # scopes stored/recalled memories; defaults to "default"
+  ```
+
+  Leaving `type` unset (or omitting the block) disables the feature entirely — no tool advertised, nothing sent anywhere. `api_key`: hindsight has no auth by default (only needed if you've enabled `HINDSIGHT_API_TENANT_API_KEY` server-side); mem0 requires auth by default (set it, or run the server with `AUTH_DISABLED=true` for local dev); memos has no auth by default and sends `namespace` as an `X-User-Name` header when the key is blank. `namespace` maps to hindsight's `bank_id`, mem0's `user_id`, or memos's `user_id`. Config is read once at session start — restart after changing it.
+
+See the full guide at `docs/src/content/docs/guides/memory-backends.md` for backend-specific setup notes.
+
 ## Why this shape
 
 The earlier design was a typed one-file-per-fact store written through a

--- a/internal/skills/defaults/product_help/PERMISSIONS.md
+++ b/internal/skills/defaults/product_help/PERMISSIONS.md
@@ -1,96 +1,34 @@
 # Permission System
 
-octo's permission engine gates every tool call through a rule-driven decision engine. Each invocation is evaluated against an ordered list of rules; the first matching rule wins. If no rule matches, the implicit default is `ask`.
-
-## Modes
-
-The engine runs in one of three modes, selectable at startup or cycled at runtime:
-
-| Mode | Behavior | Best for |
-|------|----------|----------|
-| **interactive** | `ask` → prompt the user for approval | CLI default — safe and usable |
-| **strict** | `ask` → deny automatically | Non-interactive callers (HTTP server, IM bridge) |
-| **auto** | `ask` → allow automatically | Trusted, repetitive workflows — use with caution |
-
-Cycle modes in the TUI with **Shift+Tab**.
-
-### Per-session override (web)
-
-A web session's permission mode can also be changed from its own composer status bar, or via `PATCH /api/sessions/{id}/permission_mode`. This only affects that one session — it never touches the global default in `~/.octo/config.yml` (edited instead via `octo config` or Settings → default model), so other sessions and any brand-new session are unaffected. The change is saved to the session and takes effect on its next turn.
-
-## Rule format
-
-Rules are defined in `~/.octo/permissions.yml` (user overrides) and an embedded `defaults.yml` (base layer). The YAML schema:
-
-```yaml
-tool_name:
-  - allow: { pattern: "substring" }
-  - deny:  { pattern: "substring" }
-  - ask:   { pattern: "substring" }
-```
-
-Rules are scanned in order; the first match wins. A tool with no matching rules falls through to the implicit `ask`.
-
-### Rule axes
-
-| Axis | Applies to | Syntax |
-|------|-----------|--------|
-| `pattern` | `terminal` — substring match against the command string | Plain string, case-sensitive |
-| `path` | `write_file`, `edit_file`, `read_file` — glob match against file path | Glob with `**` for recursive dirs; `$CWD` expands to working directory |
-| `hostname` | `web_fetch` — glob match against URL host | `*` matches a single DNS label |
-
-### Pattern refinements
-
-- A pattern ending in `/` or `~` (filesystem root marker) only matches when that marker ends an argument. So `deny: rm -rf /` blocks `rm -rf /` and `rm -rf /*` but **not** `rm -rf /path/under`.
-- Empty pattern (`""`) matches unconditionally — used for default allow/deny on pattern-free tools.
-
-## Default rules (excerpt)
+Every tool call — CLI, web, or IM — passes through the same rule-driven engine before it runs. Rules live in `~/.octo/permissions.yml` (fully replaces the embedded default list per tool it mentions — it doesn't merge) plus the embedded defaults for everything else. First matching rule wins; no match falls through to `ask`.
 
 ```yaml
 terminal:
   - deny:  { pattern: "rm -rf /" }
-  - deny:  { pattern: "rm -rf ~" }
-  - ask:   { pattern: "rm -rf" }
   - ask:   { pattern: "sudo " }
-  - ask:   { pattern: "curl " }
-  - allow: { pattern: "ls" }
   - allow: { pattern: "git status" }
-  - allow: { pattern: "go test" }
 
 write_file:
-  - deny:  { path: ["**/.ssh/**", "**/.env", "**/id_rsa*"] }
+  - deny:  { path: ["**/.ssh/**", "**/.env"] }
   - allow: { path: ["$CWD/**"] }
 
 web_fetch:
   - deny:  { hostname: ["10.*", "192.168.*", "127.*", "localhost"] }
-  - allow: { hostname: ["github.com", "*.github.com", "go.dev"] }
+  - allow: { hostname: ["github.com", "*.github.com"] }
 ```
 
-## Session memory
+`pattern` (substring, `terminal`), `path` (glob with `$CWD` expansion, file tools), `hostname` (glob, `web_fetch`) — pick the one that matches the tool.
 
-When the user answers a permission prompt, they can choose:
-- **y** — allow this once
-- **a** — allow for the rest of this session (remembered until exit)
-- **n / Esc** — deny this once
+## Modes
 
-Session-remembered decisions are keyed by a hash of (tool, input), so identical calls short-circuit without re-prompting.
+| Mode | What an `ask` verdict resolves to |
+|------|------|
+| **interactive** (default) | Prompt the user |
+| **strict** | Auto-deny — default for non-interactive callers (HTTP server, IM bridge) |
+| **auto** | Auto-allow — trusted, repetitive workflows only |
 
-## Custom rules
+Cycle in the TUI with **Shift+Tab**; a web session can also override just its own mode via the composer status bar or `PATCH /api/sessions/{id}/permission_mode` — per-session only, never touches the global default in `~/.octo/config.yml`.
 
-Create `~/.octo/permissions.yml` to override defaults per-tool:
+Answering an interactive prompt with "always" remembers that exact `(tool, input)` pair for the rest of the session only — never written to `permissions.yml`.
 
-```yaml
-terminal:
-  - allow: { pattern: "docker " }   # auto-allow docker commands
-  - deny:  { pattern: "docker system prune" }  # except this one
-```
-
-User rules **fully replace** the default rule list for that tool (not append). To keep defaults and add extras, copy the defaults and edit.
-
-## Denial messages
-
-When a tool call is denied, the engine returns a structured reason that the LLM sees, so it can explain to the user instead of failing silently:
-
-- `permission_denied: terminal matched deny rule (pattern: "rm -rf /")`
-- `permission_denied: write_file matched deny rule (path: [**/.ssh/**])`
-- `permission_denied: web_fetch — no matching rule in strict mode (implicit ask → deny)`
+Full matching semantics (pattern boundary-anchoring, allow-rule strictness against shell-chaining) and how a `PreToolUse` hook composes with this: **https://octo-agent.dev/docs/reference/permissions/** (`web_fetch`).

--- a/internal/skills/defaults/product_help/README.md
+++ b/internal/skills/defaults/product_help/README.md
@@ -229,6 +229,10 @@ internal/channel/  IM bridge — adapter interface + WeChat iLink adapter
 
 Each provider implements both **buffered** (`Send`) and **streaming** (`SendStream`) variants. The agent layer mirrors with `Sender` / `StreamingSender` / `ToolSender` / `ToolStreamingSender` — interfaces are added incrementally so non-streaming providers still work.
 
+## Full documentation
+
+This file and the other bundled docs in this skill directory are concise summaries. The full docs site — narrative guides and exhaustive references for every feature above — is at **https://octo-agent.dev/docs/** (fetch with `web_fetch`).
+
 ## Development
 
 ```bash
@@ -238,7 +242,7 @@ make vet           # go vet ./...
 make fmt-check     # gofmt -l . must be empty
 ```
 
-Project conventions live in [`.octorules`](.octorules) (the human-facing rules); [`CLAUDE.md`](CLAUDE.md) expands them with the operational detail AI coding agents need in this repo. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the human PR workflow.
+Project conventions live in `.octorules` (the human-facing rules); `CLAUDE.md` expands them with the operational detail AI coding agents need in this repo. See **https://octo-agent.dev/docs/community/contributing/** for the PR workflow (also summarized in `WORKFLOW.md`).
 
 ## License
 

--- a/internal/skills/defaults/product_help/README.md
+++ b/internal/skills/defaults/product_help/README.md
@@ -196,6 +196,7 @@ octo --sandbox --sandbox-read /opt/data     # extra readable dir (repeatable)
 | Sandbox | done | OS-enforced `--sandbox` (macOS / Linux) |
 | MCP client | done | `mcp.json` stdio + Streamable HTTP servers, tools/resources/prompts, OAuth (Authorization Code + PKCE) |
 | Memory | done | Persistent cross-session memory under `~/.octo/memories/<repo-slug>/` — plain markdown files the agent manages directly with its own file tools (no typed store, no background consolidation) |
+| Memory backends | done | Optional self-hosted external semantic recall (hindsight / mem0 / MemTensor-MemOS) — automatic background storage, `memory_recall` tool. Separate from and off by default; doesn't touch `MEMORY.md` |
 | Sub-agents | done | `sub_agent` fan-out, async + resumable (`sub_agent_send` follow-up, `sub_agent_status`, `sub_agent_kill`) |
 | Session goals | done | `/goal` (create/edit/pause/resume/clear/replace) — status machine, token/turn budget, auto-continuation across turns; surfaced in the TUI status bar, a web chip, and IM |
 | Workflows | done | Named, multi-step scripts the model runs by name via the `workflow` tool — embedded presets (`batch-migrate`, `daily-triage`, `parallel-understand`) plus your own, saved with `workflow_save`; `octo workflows list/path/update`, `/workflows` in the TUI, a web management panel |

--- a/internal/skills/defaults/product_help/SKILL.md
+++ b/internal/skills/defaults/product_help/SKILL.md
@@ -9,26 +9,27 @@ You have access to octo's product documentation. Use it to answer user questions
 
 ## Documentation sources
 
-1. **Bundled docs** — check the skill directory for reference files:
+1. **Bundled docs** — check the skill directory for reference files. Each is a concise, offline-readable summary; most end with a link to the fuller online guide for depth (exact schemas, edge cases, worked examples) — follow that link with `web_fetch` when the summary doesn't fully answer the question, rather than guessing at the missing detail.
    - `README.md` — quick start, installation, basic usage, feature overview
    - `CLI.md` — command reference (`octo`, `octo config`, `octo skills`, `octo workflows`, `octo browser`, etc.)
-   - `CONFIG.md` — configuration file format and all supported fields
+   - `CONFIG.md` — configuration file format and top-level fields
    - `SKILLS.md` — the default-skill mechanism (embedding, precedence, `octo skills`) and how to write your own
-   - `WORKFLOW.md` — contributor development workflow, git conventions, PR process (NOT the `octo workflows` product feature — see CLI.md/TUI.md for that)
+   - `WORKFLOW.md` — contributor development workflow for octo-agent's own codebase, git conventions, PR process (NOT the `octo workflows` product feature — see CLI.md for that)
    - `MCP.md` — MCP server configuration (`mcp.json`, OAuth, Tool Search)
-   - `MEMORY.md` — cross-session memory (file layout, injection, attention-rule tiers)
+   - `MEMORY.md` — cross-session memory (file layout, injection) and the optional external memory-backend feature
    - `PERMISSIONS.md` — the permission engine (modes, rule format, per-session overrides)
-   - `HOOKS.md` — the hooks engine (`hooks.yml`, event types, blocking, trust-on-first-use)
+   - `HOOKS.md` — the hooks engine (`hooks.yml`, event types, blocking)
    - `IM.md` — the IM/chat bridge (`channels.yml`, supported platforms, `send_message`/`send_file`)
    - `TUI.md` — terminal UI reference (slash commands, keyboard shortcuts, status bar)
    - `TROUBLESHOOTING.md` — common issues and fixes
 
    Read the relevant file(s) with `read_file` before answering.
 
-2. **Online docs** (fallback) — if the bundled docs don't cover the question, fetch from the official documentation:
-   - Base URL: `https://github.com/open-octo/octo-agent/blob/main/`
-   - Append the relevant doc filename (e.g. `README.md`, `dev-docs/go-rewrite-roadmap.md`)
-   - Use `web_fetch` to retrieve the raw markdown content
+2. **Online docs** (fallback, and the source of truth for anything the bundled summaries don't cover) — the public docs site at `https://octo-agent.dev/docs/`, fetched with `web_fetch`:
+   - `guides/<topic>/` for narrative how-tos — e.g. `guides/goals/`, `guides/workflows/`, `guides/browser-automation/`, `guides/sub-agents/`, `guides/sandbox-the-agent/`, `guides/self-host/`, `guides/channels/`, `guides/hooks/`, `guides/use-skills/`, `guides/connect-mcp-servers/`, `guides/memory/`, `guides/memory-backends/`
+   - `reference/<topic>/` for exhaustive lookups — `reference/cli/`, `reference/config-file/`, `reference/permissions/`, `reference/slash-commands/`, `reference/tools/`, `reference/http-api/`, `reference/security/`, `reference/compatibility/`
+   - Some topics (`sub-agents`, `sandbox-the-agent`, `self-host`) have a full guide online but no bundled summary file at all — go straight to `web_fetch` for those.
+   - For anything neither the bundled docs nor the docs site cover (e.g. an internal design doc under `dev-docs/`), fall back to `https://github.com/open-octo/octo-agent/blob/main/<path>` via `web_fetch`.
 
 ## How to answer
 

--- a/internal/skills/defaults/product_help/SKILLS.md
+++ b/internal/skills/defaults/product_help/SKILLS.md
@@ -1,45 +1,29 @@
 # Skills — defaults, installing, and writing your own
 
-Skills are reusable instruction sets in Claude Code's SKILL.md format: YAML frontmatter (`name` + `description`) plus a markdown body. At session start octo lists each discovered skill's name and description in the system prompt; the model loads a skill's full instructions on demand (via the `skill` tool) when a task matches, or a user triggers one explicitly with `/<name>` in the TUI.
+Skills are reusable instruction sets in Claude Code's SKILL.md format (YAML frontmatter `name` + `description`, plus a markdown body) that the model loads only when a task matches — they don't cost context on turns that don't need them.
 
-## 1. Where skills come from
+## Where skills live
 
 ```
-default  ~/.octo/skills-default/   (shipped, materialized from the binary)
+~/.octo/skills-default/   built-in set, materialized from the binary (octo skills update re-syncs)
    ↓ overridden by
-user     ~/.octo/skills/           (yours, or `octo skills add`)
+~/.octo/skills/<name>/SKILL.md      user-level, all projects
    ↓ overridden by
-project  ./.octo/skills/           (committed with the repo)
+.octo/skills/<name>/SKILL.md        project-level, committed with the repo
 ```
 
-`Discover` scans lowest-first and `scanRoot` overwrites by name, so a user- or project-level skill with the same name as a default silently wins. `octo skills list` tags each with its source (default/user/project).
-
-## 2. Default skills (embedded, not downloaded)
-
-A curated set ships **embedded in the binary** via `//go:embed` and is materialized to `~/.octo/skills-default/` on first run of each version — offline-capable (works for `go install`, air-gapped, CI), immune to supply-chain/network failure, and never touches `~/.octo/skills/` (your own skills). A version bump wipes-and-rewrites the default dir; a read-only `$HOME` degrades to "no defaults" rather than erroring.
-
-Today's default set (`internal/skills/defaults/`, 20 skills): `channel-manager`, `code-review`, `cron-task-creator`, `deep-research`, `find-skills`, `grill-me`, `implement`, `loop`, `loop-engineering`, `mcp-creator`, `office-xlsx`, `onboard`, `product_help` (this skill), `skill-creator`, `tdd`, `tech-design`, `web-access`, `workflow-creator`, `worktree-isolate`, `zoom-out`. Keep the set small and high-value — every default costs system-prompt manifest space for every user.
+Same format as Claude Code's — `~/.claude/skills` can be symlinked to `~/.octo/skills` to reuse skills you already have.
 
 ```
 octo skills list      # all skills, grouped default → user → project
-octo skills update    # force re-materialize the defaults (ignores the version stamp)
+octo skills add       # install a skill from a source (guided)
+octo skills update    # re-sync the built-in defaults after an upgrade
 octo skills path      # print the three roots
 ```
 
-## 3. Installing a skill from GitHub
+In the TUI, `/skills` lists them and `/<name>` runs one directly. **IM channels don't support `/<skill-name>` triggering** — ask in plain language there instead.
 
-`octo skills add <owner/repo[/sub/path] | github.com tree URL> [--force]` fetches a skill's directory straight into `~/.octo/skills/<name>/`:
-
-```
-octo skills add anthropics/skills/skills/docx
-octo skills add https://github.com/anthropics/skills/tree/main/skills/pdf
-```
-
-Fails if a skill with that name already exists there — pass `--force` to replace it. The skill is copied for local use; check the source repository's license before redistributing it.
-
-## 4. Writing your own skill
-
-Drop a directory under `~/.octo/skills/<name>/` (user-level, all projects) or `./.octo/skills/<name>/` (project-level, committed with the repo) containing a `SKILL.md`:
+## Writing your own skill
 
 ```markdown
 ---
@@ -49,8 +33,6 @@ description: Review the current diff for correctness and style
 Walk the diff hunk by hunk and flag correctness bugs first, then style.
 ```
 
-`name` and `description` are the only required frontmatter fields — the description is what the model sees in the manifest to decide when the skill applies, so make it specific about triggers ("use when...") rather than just naming the topic. The body is whatever instructions/context the skill needs; it can reference sibling files in the same directory (e.g. templates, reference docs) that the model reads on demand. The format is identical to Claude Code's, so `~/.claude/skills` can be symlinked to `~/.octo/skills` to reuse skills you already have. The `skill-creator` default skill can also build one interactively.
+`name` and `description` are the only required frontmatter fields — the description is what the model sees to decide when the skill applies, so make it specific about triggers. Drop it under `~/.octo/skills/<name>/` or `.octo/skills/<name>/`. The `skill-creator` default skill can also build one interactively.
 
-## 5. Adding a *default* skill (contributing to octo itself)
-
-Drop `internal/skills/defaults/<name>/SKILL.md` in the octo-agent repo (standard SKILL.md frontmatter). It ships on the next release and materializes on the user's next run after upgrading.
+Full built-in skill catalog (18 skills, grouped by purpose) and the `octo skills add` source format: **https://octo-agent.dev/docs/guides/use-skills/** (`web_fetch`).

--- a/internal/skills/defaults/product_help/TUI.md
+++ b/internal/skills/defaults/product_help/TUI.md
@@ -4,25 +4,11 @@ octo's TUI is a bubbletea-based interactive interface launched by `octo` with no
 
 ## Slash commands
 
-Type `/` to open the completion menu (↑/↓ to navigate, Enter to run, Tab to fill in for arguments). Available commands:
+Type `/` to open the completion menu (↑/↓ to navigate, Enter to run, Tab to fill in for arguments). Commands: `/help`, `/model`, `/thinking`, `/compact`, `/transcript`, `/goal` (create/edit/pause/resume/clear/replace a standing session objective — see below), `/clear`, `/skills` (trigger one directly with `/<name>`), `/mcp`, `/workflows`, `/memory`, `/init`, `/save`, `/sessions`, `/exit`/`/quit`.
 
-| Command | Description |
-|---------|-------------|
-| `/help` | List commands and tools |
-| `/model` | Switch to another model |
-| `/thinking` | Set reasoning effort (off/low/medium/high/xhigh/max) |
-| `/compact` | Summarize older history to free up context |
-| `/transcript` | Re-print the last (or last N) tool call(s) with full, uncapped output |
-| `/goal` | Bare `/goal` shows the current goal (if any); `/goal <objective>` sets one. Manage it with `/goal pause`, `/goal resume`, `/goal clear`, `/goal edit` (prefills the input to change the objective), or `/goal replace <objective>` (replace an unfinished goal). Once set, octo auto-continues turns on its own until the goal completes, is paused, or hits its token/turn budget |
-| `/clear` | Wipe the conversation and start fresh |
-| `/skills` | List discovered skills (trigger one directly with `/<name>`) |
-| `/mcp` | Show connected MCP servers and their surfaces |
-| `/workflows` | List available named workflows (run by the model via the `workflow` tool) |
-| `/memory` | List what's remembered across sessions |
-| `/init` | Analyze repo and generate/update `.octorules` |
-| `/save` | Save the session now (also auto-saves after each turn) |
-| `/sessions` | List recent sessions |
-| `/exit` or `/quit` | Save and exit |
+`/goal <objective>` sets a goal; once set, octo auto-continues turns on its own until it completes, is paused, or hits its token/turn budget. `/goal edit` here is **prefill-only** (fills the input box with the current objective to revise) — unlike the web UI/IM where `/goal edit <text>` edits inline in one step.
+
+The Web UI and IM channels each recognize a **different** command set than the TUI (e.g. IM has `/bind`/`/unbind`/`/new` for re-binding a chat to a session; the TUI's `/skills`/`/mcp`/`/init`/etc. don't exist there). Full per-surface command tables and an availability matrix: **https://octo-agent.dev/docs/reference/slash-commands/** (`web_fetch`). The `/goal` feature in depth: **https://octo-agent.dev/docs/guides/goals/**.
 
 ## Keyboard shortcuts
 

--- a/internal/skills/defaults/product_help/WORKFLOW.md
+++ b/internal/skills/defaults/product_help/WORKFLOW.md
@@ -1,6 +1,6 @@
 # octo-agent Project Rules
 
-The canonical project guidance for contributors and AI coding agents. Keep this short — substantive design context belongs in `dev-docs/`.
+Canonical guidance for contributing to the octo-agent codebase itself (this is about developing octo, not using it — for that see the other bundled docs). Every PR is human-reviewed.
 
 ## Project
 
@@ -9,50 +9,33 @@ The canonical project guidance for contributors and AI coding agents. Keep this 
 ## Layering
 
 ```
-cmd/octo/           CLI entry, flag parsing, REPL/TUI, sessions
-internal/agent/     Agent loop, history, content blocks, Sender interfaces
-internal/provider/  Provider interface + per-vendor implementations
-internal/tools/     Concrete ToolExecutor implementations
-internal/skills/    SKILL.md discovery + system-prompt manifest
+cmd/octo/            CLI entry, flag parsing, REPL/TUI, sessions
+internal/agent/      Agent loop, history, content blocks, Sender interfaces
+internal/provider/   Provider interface + per-vendor implementations
+internal/tools/      Concrete ToolExecutor implementations
+internal/skills/     SKILL.md discovery + system-prompt manifest
 internal/permission/ allow/deny/ask rule engine gating every tool call
-internal/hooks/     Lifecycle-event hook engine (hooks.yml)
-internal/mcp/       MCP client (stdio + HTTP, OAuth)
-internal/server/    octo serve — HTTP REST + WebSocket + embedded dashboard
-internal/channel/   IM bridge — adapter interface + platform adapters
-internal/workflow/  Named multi-step workflow execution
-internal/browser/   Browser automation (CDP) backend
-internal/memory/    Cross-session memory
-internal/version/   Version constants overridable via -ldflags
-pkg/octoagent/      Public Go SDK re-exporting core agent types for embedding octo in other programs
+internal/hooks/      Lifecycle-event hook engine (hooks.yml)
+internal/mcp/        MCP client (stdio + HTTP, OAuth)
+internal/server/     octo serve — HTTP REST + WebSocket + embedded dashboard
+internal/channel/    IM bridge — adapter interface + platform adapters
+internal/workflow/   Named multi-step workflow execution
+internal/browser/    Browser automation (CDP) backend
+internal/memory/     Cross-session memory
+internal/version/    Version constants overridable via -ldflags
+pkg/octoagent/       Public Go SDK re-exporting core agent types for embedding octo in other programs
 ```
 
 Dependency direction is one-way: `provider → agent`, `tools → agent`, never the other way. `cmd/octo` is the only package allowed to import `provider` directly; everything else talks through `agent.Sender` / `StreamingSender` / `ToolSender` / `ToolStreamingSender`.
 
 ## Adding capability
 
-- **New provider** — implement `provider.Provider` (required) and optionally `provider.StreamingProvider`, `provider.ToolProvider`, `provider.ToolStreamingProvider`. Put it under `internal/provider/<name>/`. Each protocol's wire-format quirks are isolated inside the package; the agent layer must not learn about them.
-- **New tool** — implement `agent.ToolExecutor` and `Definition() agent.ToolDefinition` returning the JSON Schema the LLM sees. Place it under `internal/tools/<name>.go`. Register it in `tools.DefaultRegistry` and add it to `tools.DefaultTools()` if it belongs in the default set.
-- **New skill** — `~/.octo/skills/<name>/SKILL.md` with the same frontmatter format Claude Code uses, or `internal/skills/defaults/<name>/SKILL.md` to ship it as a default. The skill loader composes existing tools — adding a skill should not require new tool code.
+- **New provider** — implement `provider.Provider` (required) and optionally the streaming/tool variants, under `internal/provider/<name>/`.
+- **New tool** — implement `agent.ToolExecutor` under `internal/tools/<name>.go`, register in `tools.DefaultRegistry`.
+- **New skill** — `~/.octo/skills/<name>/SKILL.md`, or `internal/skills/defaults/<name>/SKILL.md` to ship it as a default.
 
-## Code style
+## Before opening a PR
 
-- Go 1.22 syntax. `gofmt -w` is the formatter; `go vet ./...` must pass.
-- Tests live next to code (`foo.go` + `foo_test.go`). Use `httptest.NewServer` for HTTP-mocked tests; do not hit live APIs in `go test ./...`.
-- Comments in English. Prefer self-documenting names over comments. Only comment the **why**, never the **what**.
-- No new third-party dependencies without justification in the PR description.
+Read `.octorules` and `CLAUDE.md` at the repo root — layering, conventions, and common pitfalls, most "will this land" questions answered there. Branch off latest `main` (never commit on `main` directly); one concept per PR; `make test && make vet && make fmt-check` before pushing; squash-and-merge is the default.
 
-## Workflow
-
-- **Branch off latest `main`** before editing. Never commit on `main` directly.
-- Push lands via PR only. Squash-and-merge is the project default; force-push only after explicit approval.
-- Commit messages and PR descriptions in English.
-- One concept per PR. Mass mechanical changes (rename, move) can ride together but should be a single self-contained change set.
-
-## Testing
-
-- `make test` runs `go test -race ./...` — must be green before pushing.
-- Integration tests against real provider APIs are run by hand with a real key, not in CI.
-
-## What lives in `dev-docs/`
-
-Architecture decisions, milestone plans, and verified-fact dumps (e.g. the iLink protocol notes in the roadmap). One Markdown file per topic. Don't commit speculative or unverified claims — verify before writing.
+Full contributor guide (what reviewers look for, dependency policy, comment style): **https://octo-agent.dev/docs/community/contributing/** (`web_fetch`).


### PR DESCRIPTION
## Summary
- #1255 (external semantic memory backends — hindsight/mem0/memos) merged to `main` while the product-help doc catch-up (#1256) was in flight, so it wasn't covered.
- `MEMORY.md`: new section explaining the `memory_backend` config block, the automatic-background-store vs. explicit-`memory_recall`-tool split, and per-backend auth defaults (hindsight/memos no-auth, mem0 auth-on-by-default) — clearly scoped as separate from and not touching the existing `MEMORY.md`-file mechanism documented above it.
- `CONFIG.md`: add the `memory_backend` field row.
- `README.md`: add a "Memory backends" row to the implementation table.

## Test plan
- [x] Verified field names against `internal/config.MemoryBackendConfig` (`type`/`base_url`/`api_key`/`namespace`)
- [x] Verified tool name (`memory_recall`) against `internal/tools/memory_backend.go`
- [x] Docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)