### PR TITLE
fix(server): wire ArchiveDir into IM turns, matching web via buildAgent

### DIFF
--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -387,6 +387,31 @@ func TestHandleChannelMessage_WiresMemoryHooks(t *testing.T) {
 	}
 }
 
+// TestHandleChannelMessage_WiresArchiveDir: IM turns get compaction chunk
+// archiving like web turns do via buildAgent — without this, folded history
+// is discarded instead of being recallable with the read tool.
+func TestHandleChannelMessage_WiresArchiveDir(t *testing.T) {
+	tmp := t.TempDir() // isolated HOME: deterministic store IDs cross-pollinate otherwise
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+
+	sess := srv.channelMgr.GetSession(evFor("x"))
+	if sess.Agent.ArchiveDir == "" {
+		t.Fatal("IM agent missing ArchiveDir — compaction would fold history without archiving it")
+	}
+	want, err := sess.Store.ChunkDir()
+	if err != nil {
+		t.Fatalf("sess.Store.ChunkDir(): %v", err)
+	}
+	if sess.Agent.ArchiveDir != want {
+		t.Errorf("ArchiveDir = %q, want %q (session's own chunk dir)", sess.Agent.ArchiveDir, want)
+	}
+}
+
 // TestHandleChannelMessage_RejectsTurnWhenBoundToOtherEntry: when the session
 // is owned by another entry, the channel turn is rejected and the reply hints
 // at /new and /bind --force.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2584,6 +2584,12 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		}
 		sess.Agent.SessionStarted = st.HookStarted || len(st.Messages) > 0
 		sess.Agent.OnSessionStart = func() { st.MarkHookStarted() }
+		// Same as buildAgent gives web turns: without this, compaction still
+		// folds history but never archives the originals, so IM loses the
+		// "read the chunk back" recall web/CLI sessions get for free.
+		if dir, err := st.ChunkDir(); err == nil {
+			sess.Agent.ArchiveDir = dir
+		}
 	}
 
 	// Per-turn permission gate, the same shape prepareToolTurn gives web


### PR DESCRIPTION
## Summary

Found while auditing the `product-help` skill docs against `docs/guides/*` — the compaction guide correctly documents that chunk archiving only happens for CLI/web, not IM, but that turned out to be an unintentional code gap rather than a deliberate design choice.

- `buildAgent` (web/REST/WS path, `internal/server/server.go`) sets `a.ArchiveDir = dir` from `sess.ChunkDir()`.
- `runChannelTurns` (IM path) rebuilds a long-lived per-channel-session `Agent`'s per-turn fields every turn (`CWD`, `System`, `Hooks`, `HookMeta`, `Gate`, `Goal`) to mirror `buildAgent`, but never set `ArchiveDir`. Since `archiveChunk()` no-ops on an empty `ArchiveDir`, IM compaction folded old turns into a summary without ever archiving the originals — losing the "read the chunk back later" recall that web/CLI sessions get for free.
- The backing session is the same `*agent.Session` with the same `ChunkDir()` method both paths could already call — IM just never wired it in.

## Change

Sets `sess.Agent.ArchiveDir` from `sess.Store.ChunkDir()` inside the existing nil-checked `Store` block in `runChannelTurns`, alongside the other per-turn `Store`-derived fields it already sets.

## Test plan
- [x] Added `TestHandleChannelMessage_WiresArchiveDir` — confirmed it fails without the fix (`git stash` on `server.go` only) and passes with it
- [x] `go test ./internal/server/...` — full package green
- [x] `go vet ./internal/server/...`, `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)