### PR TITLE
docs: add missing guides for /loop and cron tasks, fix /api/tasks docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -64,6 +64,8 @@ export default defineConfig({
 						{ label: 'Bridge to chat apps', slug: 'guides/channels', translations: { 'zh-CN': '接入聊天应用' } },
 						{ label: 'Automate with browser control', slug: 'guides/browser-automation', translations: { 'zh-CN': '浏览器自动化' } },
 						{ label: 'Run long-horizon goals', slug: 'guides/goals', translations: { 'zh-CN': '运行长周期目标' } },
+						{ label: 'Repeat a task with /loop', slug: 'guides/loop', translations: { 'zh-CN': '用 /loop 重复任务' } },
+						{ label: 'Schedule cron tasks', slug: 'guides/cron-tasks', translations: { 'zh-CN': '定时任务' } },
 						{ label: 'Self-host octo serve', slug: 'guides/self-host', translations: { 'zh-CN': '自托管 octo serve' } },
 					],
 				},

--- a/docs/src/content/docs/guides/cron-tasks.md
+++ b/docs/src/content/docs/guides/cron-tasks.md
@@ -1,0 +1,129 @@
+---
+title: Schedule cron tasks
+description: Recurring agent prompts that fire on a schedule, run by octo serve.
+---
+
+A cron task is a recurring agent prompt — "check the queue every 5 minutes", "write a daily
+report at 9am" — that fires on its own while `octo serve` is running, with nobody watching.
+
+```bash
+octo serve
+```
+
+## How it works
+
+Each task is a JSON file in `~/.octo/tasks/`, loaded by a scheduler that runs inside `octo serve`.
+When a task fires, the scheduler runs one agent turn with the task's prompt and **reuses the same
+session across runs**, so the task accumulates history from one run to the next. Each run is
+bounded by a **30-minute wall-clock timeout** — the only hard cap.
+
+**Tasks only fire while `octo serve` is running.** No serve, no runs — and a schedule missed while
+the server was down is not replayed on restart.
+
+## Task fields
+
+| Field | Required | Meaning |
+|---|---|---|
+| `name` | yes | Human-readable task name |
+| `cron` | yes | Schedule expression — see below |
+| `prompt` | yes | The prompt sent to the agent on each run |
+| `model` | no | Model override; defaults to the server's model |
+| `agent` | no | `"general"` or `"coding"` |
+| `directory` | no | Working directory the run executes in |
+| `notify` | no | IM chats to push each run's final reply (or failure) to |
+| `enabled` | yes | Whether the schedule is currently active |
+
+The prompt runs in its own session with no access to whatever conversation created the task, so it
+needs to be self-contained: what to do, where, and what the output should look like. Give it an
+explicit stop condition too — an open-ended prompt keeps the model re-verifying until the 30-minute
+timeout instead of finishing once the answer is "nothing to report."
+
+## Cron expression — 6 fields, seconds first
+
+The scheduler is [robfig/cron](https://github.com/robfig/cron) **with a seconds field** — a
+standard 5-field crontab line is invalid here; always prepend a seconds field:
+
+```
+seconds minutes hours day-of-month month day-of-week
+```
+
+| Want | Expression |
+|---|---|
+| Every day at 09:00 | `0 0 9 * * *` |
+| Every 30 minutes | `0 */30 * * * *` |
+| Weekdays at 18:30 | `0 30 18 * * 1-5` |
+| 1st of each month at 08:00 | `0 0 8 1 * *` |
+
+Descriptors also work: `@hourly`, `@daily`, `@weekly`, `@every 90m`. Times are in the server's
+local timezone.
+
+## Managing tasks via the API
+
+Every change through the API reschedules the running process immediately — the recommended path
+whenever `octo serve` is up.
+
+```bash
+# Create — returns {"id":"task_..."}. Any optional field (directory, model,
+# agent, notify) goes right in the create body.
+curl -s -X POST http://127.0.0.1:8088/api/tasks \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"daily-report","cron":"0 0 9 * * *","prompt":"Summarize ...","directory":"/srv/repo"}'
+
+curl -s http://127.0.0.1:8088/api/tasks                # list
+curl -s -X DELETE http://127.0.0.1:8088/api/tasks/{id} # delete
+
+# Run now, out of schedule
+curl -s -X POST http://127.0.0.1:8088/api/tasks/{id}/run
+
+# Edit any subset of fields — this is also how you enable/disable
+curl -s -X PATCH http://127.0.0.1:8088/api/tasks/{id} \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt":"new prompt ...","enabled":false}'
+```
+
+`PATCH /api/tasks/{id}` accepts `enabled`, `cron`, `prompt`, `model`, `agent`, `directory`, `notify`
+— send only what you're changing. The Web UI's scheduler panel is a client of this same API, so a
+task created by `curl` shows up there and vice versa; the panel is also the recommended place to
+**smoke-test a new task's `Run` button** rather than triggering `/api/tasks/{id}/run` from a chat
+session — a run is a full agent turn (up to 30 minutes) in the task's *own* session, so firing it
+from a conversation just blocks that conversation while the actual output lands somewhere nobody is
+watching it.
+
+### Without a running server
+
+Write `~/.octo/tasks/<id>.json` directly (`id` format `task_<unix-millis>`; filename must equal
+`<id>.json`):
+
+```json
+{
+  "id": "task_1717999999999",
+  "name": "daily-report",
+  "cron": "0 0 9 * * *",
+  "prompt": "Summarize ...",
+  "directory": "/srv/repo",
+  "enabled": true,
+  "created_at": "2026-06-10T09:00:00Z"
+}
+```
+
+The file is picked up the next time `octo serve` starts. A hand-written file with a bad cron
+expression fails silently at load (logged to stderr only). **File edits made while the server is
+already running are ignored until restart** — once it's up, go through the API instead.
+
+## Notifications
+
+`notify` is a list of IM targets (a single bare object is also accepted); every entry gets pushed
+the run's final reply on success, or a short failure note on error. A failed push is logged on the
+server and never affects the run itself.
+
+| Platform | `chat_id` | Notes |
+|---|---|---|
+| `feishu` | `oc_…` chat id | Needs app creds in `channels.yml`; get the id from chat settings or the server log after messaging the bot |
+| `dingtalk` | staff id (1:1) or `cid…` conversation id (group) | A DM's conversation id does not work — use the staff id |
+| `weixin` (iLink) | user id | User must have messaged the bot at least once |
+| `telegram` | chat id (user/group/channel) | Bot must already be able to message it |
+| `discord` | channel id | Bot needs Send Messages permission there |
+| `wecom` | ignored | Pushes go through a group-robot webhook bound to one group instead |
+
+Next: for a shorter-lived, in-conversation repeat that doesn't need to survive a restart, see
+[`/loop`](/docs/guides/loop/) instead.

--- a/docs/src/content/docs/guides/goals.mdx
+++ b/docs/src/content/docs/guides/goals.mdx
@@ -20,9 +20,10 @@ stopping once the current message is answered.
 ```
 
 When a session goes idle with an active goal, octo continues working toward it on its own —
-the same machinery behind `/loop`, applied to a single durable objective instead of a recurring
-prompt. The underlying tools (`get_goal`, `create_goal`, `update_goal`) are also available to the
-model directly, so a goal can be created or refined mid-conversation, not just via the slash command.
+the same machinery behind [`/loop`](/docs/guides/loop/), applied to a single durable objective
+instead of a recurring prompt. The underlying tools (`get_goal`, `create_goal`, `update_goal`) are
+also available to the model directly, so a goal can be created or refined mid-conversation, not
+just via the slash command.
 
 :::note[`/goal edit` differs by transport]
 In the TUI, `/goal edit` with no text prefills the input box with the current objective for you to

--- a/docs/src/content/docs/guides/loop.md
+++ b/docs/src/content/docs/guides/loop.md
@@ -1,0 +1,48 @@
+---
+title: Repeat a task with /loop
+description: Keep re-running a prompt in the current session without re-typing it every time.
+---
+
+`/loop` keeps re-running a task in the **current session** without you re-prompting each time, by
+having the model schedule its own next turn.
+
+```text
+/loop 5m check the deploy
+/loop keep refining the draft until it reads cleanly
+```
+
+The text after `/loop` is `[interval] <task>`:
+
+- **An interval given** (`/loop 5m …`, `/loop 30s …`, `/loop 2h …`) — **interval mode**: the task
+  runs on that fixed cadence until stopped.
+- **No interval** (`/loop keep polling until the build is green`) — **dynamic mode**: the model
+  picks the cadence itself each turn, and decides on its own when the loop is done.
+
+Under the hood both modes use the same `schedule_wakeup` tool: after a turn ends and the session
+goes idle, the system re-runs the task as a fresh user turn once the delay elapses. Delays are
+clamped to **60 seconds – 1 hour** per tick.
+
+## It coexists with the conversation
+
+A loop doesn't block you out of the session — you can talk to the model mid-loop (ask a question,
+give a side instruction) and the loop keeps ticking; a plain message does not stop it.
+
+## Stopping a loop
+
+- **Dynamic mode** stops itself: once the model decides the task is done (or stuck), it simply
+  doesn't schedule another wakeup and tells you why.
+- **Interval mode** re-arms on every tick, so ask explicitly ("stop the loop") to end it.
+- **Ctrl+C** in the TUI, or `/stop` in an IM channel, hard-stops any loop immediately.
+- Every loop auto-stops after a safety cap of roughly **12 hours** of total runtime regardless — a
+  backstop for a forgotten loop, not something to rely on instead of stopping it yourself.
+
+## `/loop` vs. a cron task
+
+`/loop` lives inside one conversation: it's cheap to start, ends when you say so or when you close
+the session, and has no persistence of its own. For a schedule that needs to **survive a restart**
+or **fire while nobody is watching** — a daily report, a recurring health check — use a
+[scheduled cron task](/docs/guides/cron-tasks/) instead; it's a separate, durable mechanism run by
+`octo serve`, not a `/loop` running unattended.
+
+Next: [session goals](/docs/guides/goals/) build on the same underlying wakeup machinery, applied to
+a single durable objective instead of a recurring prompt.

--- a/docs/src/content/docs/guides/use-skills.md
+++ b/docs/src/content/docs/guides/use-skills.md
@@ -84,8 +84,8 @@ matches its description — you rarely need to invoke them by name.
 
 | Skill | What it does |
 |---|---|
-| `loop` | Repeats a prompt in the current session — fixed interval or self-paced — without re-prompting each time |
-| `cron-task-creator` | Creates/inspects/edits/deletes recurring prompts that survive a restart, run by `octo serve`'s scheduler |
+| `loop` | Repeats a prompt in the current session — fixed interval or self-paced — without re-prompting each time. See [`/loop`](/docs/guides/loop/) |
+| `cron-task-creator` | Creates/inspects/edits/deletes recurring prompts that survive a restart, run by `octo serve`'s scheduler. See [Schedule cron tasks](/docs/guides/cron-tasks/) |
 
 **Connect things**
 

--- a/docs/src/content/docs/guides/workflows.mdx
+++ b/docs/src/content/docs/guides/workflows.mdx
@@ -89,7 +89,7 @@ workflow(name: "my-check", args: { target: "src/" })
 - The registry merges **built-in presets < user workflows < project workflows** by name, rescanned
   fresh on every call — no caching, no restart needed after editing a saved script by hand.
   Project workflows are resolved from the **current working directory** of the turn (the directory
-  you ran `octo` from, the `directory` of a scheduled cron task, or a web/IM session's working
+  you ran `octo` from, the `directory` of a [scheduled cron task](/docs/guides/cron-tasks/), or a web/IM session's working
   directory when it's been changed from the server default), not necessarily the server's process
   CWD. A running workflow script's own `agent()`/`skill()` calls keep resolving against that same
   directory too, even in background mode.

--- a/docs/src/content/docs/reference/http-api.md
+++ b/docs/src/content/docs/reference/http-api.md
@@ -47,11 +47,13 @@ called out in the release notes — there's no versioned `/api/v1` yet.
 | `POST /api/channels/{platform}/send`, `/send-file` | send from the API |
 | `POST/GET/DELETE /api/channels/weixin/login` | WeChat QR login flow |
 
-## Tasks, profile, memory, trash
+## Cron tasks, profile, memory, trash
 
 | Route | Purpose |
 |---|---|
-| `GET/POST/PATCH/DELETE /api/tasks` | the task graph (`task_create`/`task_update`/`task_list` mirrored over HTTP) |
+| `GET/POST /api/tasks` | list / create a [scheduled cron task](/docs/guides/cron-tasks/) |
+| `DELETE`, `PATCH /api/tasks/{id}` | delete, or edit any subset of fields (this is also how you enable/disable) |
+| `POST /api/tasks/{id}/run` | trigger an out-of-schedule run now |
 | `GET /api/profile/soul`, `/api/profile/user` | read `soul.md` / `user.md` |
 | `GET /api/memories` | read the memory index |
 | `GET /api/trash`, `POST .../empty`, `POST .../{id}/restore`, `DELETE /api/trash/{id}` | the recoverable-delete trash panel |

--- a/docs/src/content/docs/reference/tools.md
+++ b/docs/src/content/docs/reference/tools.md
@@ -59,7 +59,7 @@ first; there's no cap on how many background processes can run at once, and all 
 | `workflow_status` / `workflow_kill` | check on or stop a background workflow run (completion is pushed automatically — no polling) |
 | `workflow_save` | persist a script as a named, reusable workflow |
 | `task_create` / `task_update` / `task_list` | track discrete steps of a larger piece of work |
-| `schedule_wakeup` | ask to be resumed after a delay (used by `/loop`-style recurring work) |
+| `schedule_wakeup` | ask to be resumed after a delay (used by [`/loop`](/docs/guides/loop/)-style recurring work) |
 
 ## Goals
 
@@ -82,8 +82,8 @@ Search is off (or hasn't activated).
 | Tool | Purpose |
 |---|---|
 | `ask_user_question` | ask the user a clarifying question mid-turn |
-| `send_message` | send a message on the current channel without ending the turn |
-| `send_file` | send a file back (IM channels) |
+| `send_message` | proactively push text to an IM chat that is **not** the current conversation (a normal reply already covers the current one) |
+| `send_file` | send a local file over IM — defaults to the current chat; pass `platform`+`chat_id` to target a different one |
 | `show_artifact` | display a built HTML/Markdown/image file in the Web UI's artifact panel |
 | `restart_server` | request a server [restart](/docs/guides/self-host/#restarting) (e.g. after a config change); always `ask`-class, never allow-listable |
 


### PR DESCRIPTION
## Summary

Two real, substantial features had no dedicated guide on the docs site, only a one-line mention in `use-skills.md`'s skill table:
- **`/loop`** — in-session repeating prompt (fixed interval or self-paced), backed by `schedule_wakeup`
- **Cron tasks** — recurring prompts that survive a restart, run by `octo serve`'s scheduler (`robfig/cron` with a seconds field, full CRUD under `/api/tasks`, IM notifications)

Also found and fixed two factual errors while researching this (verified against source, not carried over from prior doc text):
- `reference/http-api.md` described `/api/tasks` as *"the task graph (`task_create`/`task_update`/`task_list` mirrored over HTTP)"*. Checked `internal/server/tasks_handlers.go` and `internal/scheduler`: `/api/tasks` is unambiguously the **cron scheduler** API — there is no HTTP mirror of the `task_create`/`task_update`/`task_list` tools anywhere in the codebase.
- `reference/tools.md` described `send_message` as sending "on the current channel". The tool's own description (`internal/tools/send_message.go`) says the opposite — it's for reaching a chat that is **not** the current conversation, since a normal reply already covers the current one. Tightened `send_file`'s description too (defaults to the current chat unless `platform`+`chat_id` is passed).

## Changes
- New `guides/loop.md` and `guides/cron-tasks.md`, registered in `astro.config.mjs`'s sidebar
- Cross-linked from `goals.mdx`, `workflows.mdx`, `use-skills.md`, and `reference/tools.md`'s `schedule_wakeup` row
- Fixed the two factual errors above

## Test plan
- [x] `npm run build` — 73 pages, no errors or warnings (run in an isolated worktree — see note below)
- [x] Verified `/api/tasks` semantics against `internal/server/tasks_handlers.go` route registrations and handler bodies
- [x] Verified `send_message`/`send_file` semantics against their tool descriptions in `internal/tools/`

Note: built this in an isolated worktree after noticing the shared working directory had concurrent changes from another branch/session in flight — this PR touches only the 8 docs files listed in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)