### PR TITLE
fix(test): stop TestGoalEdit_AsyncTurnStartCancelsPendingEdit racing itself

### DIFF
--- a/cmd/octo/tuirepl_goal_test.go
+++ b/cmd/octo/tuirepl_goal_test.go
@@ -241,7 +241,13 @@ func TestGoalEdit_AsyncTurnStartCancelsPendingEdit(t *testing.T) {
 	// starting while /goal edit is armed must cancel the edit — otherwise the
 	// user's next unrelated message is silently consumed as the objective.
 	m, sess := newGoalTestModel()
-	m.dispatchGoal("keep me")
+	// Seeded directly on the session so dispatchGoal's immediate continuation
+	// kick doesn't spawn its own turn goroutine racing the one started below
+	// by startTurnEcho — see TestHandleTurnFinished_QueuedInputBeatsContinuation
+	// for the same hazard. This test only cares about /goal edit + turn-start.
+	if _, err := sess.CreateGoal("keep me", 0); err != nil {
+		t.Fatal(err)
+	}
 	m.dispatchGoal("edit")
 
 	m.startTurnEcho("background note turn", "")


### PR DESCRIPTION
## Summary

PR #1261 (docs-only) hit a `-race` failure in `cmd/octo` on CI's ubuntu-latest job, which made no sense for a docs-only diff. Reproduced locally on plain `origin/main` (no PR changes at all): **5/5 runs failed** with `go test ./cmd/octo/... -race -run TestGoalEdit_AsyncTurnStartCancelsPendingEdit` — a real, 100%-reproducible pre-existing race, not CI flakiness.

## Root cause

`TestGoalEdit_AsyncTurnStartCancelsPendingEdit` calls `m.dispatchGoal("keep me")`, which (via `startGoalNow()`) immediately kicks off a background continuation turn goroutine on the shared `*Agent`. The test then also calls `m.startTurnEcho(...)` directly to simulate a *second* async turn. Both goroutines call into `internal/agent.appendUserInput` on the same `Agent` concurrently — production code never does this (a `turnRunning` guard ensures only one turn runs at a time on a given `Agent`), but nothing stops two turns from genuinely overlapping when a test manually triggers both paths.

Other tests in the same file already avoid this exact hazard by seeding the goal directly on the session instead of going through `dispatchGoal`'s immediate kick (see `TestHandleTurnFinished_QueuedInputBeatsContinuation`'s comment) — this test just wasn't written that way.

## Fix

Switch to the same "seed directly on the session" pattern. What the test actually checks (goal-edit armed, then a turn starts, pending edit must cancel) only needs the goal to *exist* — not to have been created through `dispatchGoal` specifically — so behavior under test is unchanged.

## Test plan
- [x] Reproduced 5/5 on unmodified `origin/main`
- [x] 8/8 clean runs of the specific test under `-race` after the fix
- [x] 4/4 full `go test ./cmd/octo/... -race` runs clean after the fix
- [x] `go vet`, `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)