### PR TITLE
docs(memory): add tested self-host quick starts for hindsight/mem0/memos

### DIFF
--- a/docs/src/content/docs/guides/memory-backends.md
+++ b/docs/src/content/docs/guides/memory-backends.md
@@ -18,8 +18,142 @@ Three backends are supported; pick at most one:
 - [MemTensor/MemOS](https://github.com/MemTensor/MemOS) — self-hosted, no auth by default. (Not
   `usememos/memos`, which is an unrelated note-taking app, and not `agiresearch/MemOS`.)
 
-Follow each project's own docs to get its server running locally (typically a `docker compose up` or
-equivalent) — octo only talks to the REST API once it's up.
+All three need an LLM (for fact extraction) and an embedding model (for search) — either your own
+OpenAI-compatible endpoint (DashScope/Bailian, DeepSeek, etc.) or, for hindsight, a fully local
+setup. The steps below are a tested, copy-pasteable quick start for each — a supplement to their own
+docs, not a replacement.
+
+## Running a backend locally
+
+Pick one. Each assumes Docker is installed and running.
+
+### hindsight
+
+Simplest to start: no database to configure, no auth by default.
+
+```bash
+docker run -d --name hindsight \
+  -p 8888:8888 -p 9999:9999 \
+  -v hindsight-data:/home/hindsight/.pg0 \
+  -v hindsight-hf-cache:/home/hindsight/.cache \
+  -e HINDSIGHT_API_LLM_PROVIDER=openai \
+  -e HINDSIGHT_API_LLM_MODEL=<your-model> \
+  -e HINDSIGHT_API_LLM_BASE_URL=<your-openai-compatible-base-url> \
+  -e HINDSIGHT_API_LLM_API_KEY=<your-api-key> \
+  -e HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=BAAI/bge-small-en-v1.5 \
+  ghcr.io/vectorize-io/hindsight:latest
+```
+
+`HINDSIGHT_API_LLM_*` can point at any OpenAI-compatible endpoint (DashScope's
+`https://dashscope.aliyuncs.com/compatible-mode/v1`, DeepSeek, real OpenAI, etc.) — hindsight uses it
+only for consolidating what it retains, not for embeddings (those run locally via the
+`HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL`, no key needed). First start takes **~1-2 minutes** while it
+downloads the embedding/reranker models and boots an embedded Postgres — don't be alarmed if the API
+doesn't answer immediately.
+
+Verify it's up:
+
+```bash
+curl http://localhost:8888/v1/default/banks
+# {"banks":[]}  — empty is fine, a bank is created automatically on first write
+```
+
+No auth is required unless you explicitly set `HINDSIGHT_API_TENANT_API_KEY` on the container.
+
+### mem0
+
+Needs Postgres (with pgvector) — the official `server/` stack bundles it via Docker Compose.
+
+```bash
+git clone https://github.com/mem0ai/mem0
+cd mem0/server
+cp .env.example .env
+```
+
+Edit `.env`:
+
+```bash
+OPENAI_API_KEY=<your-api-key>
+POSTGRES_PASSWORD=<pick-anything>
+AUTH_DISABLED=true   # local development only — see "Auth" below for the real thing
+MEM0_DEFAULT_LLM_MODEL=<your-model>
+MEM0_DEFAULT_EMBEDDER_MODEL=<your-embedding-model>
+```
+
+Then:
+
+```bash
+make bootstrap
+```
+
+**If you're using a non-OpenAI, OpenAI-compatible provider** (DashScope, DeepSeek, ...), the `.env`
+model names alone aren't enough — mem0's OpenAI client defaults to `api.openai.com`. Point it at your
+provider's base URL via the `/configure` endpoint, **before you store anything**:
+
+```bash
+curl -X POST http://localhost:8888/configure \
+  -H "Content-Type: application/json" \
+  -d '{
+    "llm": {"provider": "openai", "config": {"model": "<your-model>", "openai_base_url": "<your-base-url>"}},
+    "embedder": {"provider": "openai", "config": {"model": "<your-embedding-model>", "embedding_dims": <dims>, "openai_base_url": "<your-base-url>"}}
+  }'
+```
+
+(No auth header needed with `AUTH_DISABLED=true`.) `embedding_dims` matters — see
+[Troubleshooting](#troubleshooting) if you skip this and hit a dimension error.
+
+#### Auth
+
+`AUTH_DISABLED=true` is fine for a local trial but skips real access control. For anything longer-lived,
+drop it, run `make bootstrap` as-is, and it prints an admin email/password/API key on first start —
+use that generated API key as `api_key` in octo's config instead of leaving it blank.
+
+### MemOS (MemTensor)
+
+The heaviest of the three — bundles Neo4j (graph store) and Qdrant (vector store) alongside the API.
+Their docs give a ready-made [Bailian/DashScope example](https://github.com/MemTensor/MemOS/blob/main/docs/en/open_source/getting_started/rest_api_server.md)
+that already has the embedding dimension set correctly, so it's the least fiddly of the three if
+you have a DashScope key:
+
+```bash
+git clone https://github.com/MemTensor/MemOS
+cd MemOS
+cat > .env <<'EOF'
+OPENAI_API_KEY=<your-bailian-api-key>
+OPENAI_API_BASE=https://dashscope.aliyuncs.com/compatible-mode/v1
+MOS_CHAT_MODEL=qwen3-max
+
+MEMRADER_MODEL=qwen3-max
+MEMRADER_API_KEY=<your-bailian-api-key>
+MEMRADER_API_BASE=https://dashscope.aliyuncs.com/compatible-mode/v1
+
+MOS_EMBEDDER_MODEL=text-embedding-v4
+MOS_EMBEDDER_BACKEND=universal_api
+MOS_EMBEDDER_API_BASE=https://dashscope.aliyuncs.com/compatible-mode/v1
+MOS_EMBEDDER_API_KEY=<your-bailian-api-key>
+EMBEDDING_DIMENSION=1024
+MOS_RERANKER_BACKEND=cosine_local
+
+NEO4J_BACKEND=neo4j-community
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=12345678
+NEO4J_DB_NAME=neo4j
+MOS_NEO4J_SHARED_DB=false
+
+DEFAULT_USE_REDIS_QUEUE=false
+ENABLE_CHAT_API=true
+CHAT_MODEL_LIST=[{"backend": "qwen", "api_base": "https://dashscope.aliyuncs.com/compatible-mode/v1", "api_key": "<your-bailian-api-key>", "model_name_or_path": "qwen3-max", "support_models": ["qwen3-max"]}]
+EOF
+cd docker
+docker compose up --build
+```
+
+(Using a different OpenAI-compatible provider: swap `OPENAI_API_BASE`/`MOS_EMBEDDER_API_BASE` and set
+`EMBEDDING_DIMENSION` to match your embedding model's actual output size — same rule as mem0 above.)
+
+Verify it's up: `http://localhost:8000/docs` should load. No auth is required by default — identity
+comes from an `X-User-Name` header instead, which octo sends automatically when `api_key` is blank.
 
 ## How it works
 
@@ -46,7 +180,8 @@ memory_backend:
 
 - **`type`** selects the backend. Leaving it unset (or omitting the whole block) disables the
   feature entirely — no tool is advertised, nothing is sent anywhere.
-- **`base_url`** is the backend's REST endpoint — wherever you're running its server.
+- **`base_url`** is the backend's REST endpoint — wherever you're running its server (`http://localhost:8888`
+  for hindsight/mem0 as set up above, `http://localhost:8000` for MemOS).
 - **`api_key`** is optional and backend-dependent:
   - hindsight has no auth by default; set an API key only if you've enabled
     `HINDSIGHT_API_TENANT_API_KEY` on the server.
@@ -59,3 +194,32 @@ memory_backend:
 
 Restart `octo` (or `octo serve`) after changing this — it's read once at session start, the same as
 every other config-file setting.
+
+Sanity-check the wiring: start `octo`, have a short exchange, then ask something that requires
+recalling it (in a fresh session, or after `octo` restarts) — you should see it call `memory_recall`
+and get the earlier fact back.
+
+## Troubleshooting
+
+- **mem0: `psycopg.errors.DataException: expected 1536 dimensions, not N`** — mem0's Postgres vector
+  column size is fixed the first time anything is stored (1536, matching OpenAI's default embedding
+  model). If your embedder returns a different size, you must set `embedding_dims` via `/configure`
+  **before** the first `/memories` call. If you already stored something with the wrong size, there's
+  no in-place fix — wipe and start over: `docker compose down -v && docker compose up -d`, then
+  `/configure` again immediately, before storing anything.
+- **mem0/MemOS: `provider_auth_failed` / 401 from `api.openai.com`** — your LLM/embedder config is
+  still pointing at real OpenAI. For mem0, set the base URL via `/configure` (not just `.env`); for
+  MemOS, double check `OPENAI_API_BASE`/`MOS_EMBEDDER_API_BASE` in `.env` and rebuild
+  (`docker compose up -d --force-recreate`).
+- **hindsight: connection refused right after `docker run`** — give it a minute or two; it's still
+  downloading/loading the embedding and reranker models. `docker logs hindsight` shows progress.
+  Once it prints its startup banner, subsequent restarts are much faster (models are cached in the
+  `hindsight-hf-cache` volume).
+- **Using Colima instead of Docker Desktop and a bind-mount volume shows up empty in the
+  container** — Colima only shares specific host paths into its VM (by default your home directory
+  and `/tmp/colima`). Clone the repo somewhere under your home directory, not under a path outside
+  Colima's configured mounts (e.g. not a random `/tmp/...` or `/private/tmp/...` location), or the
+  `.:/app`-style bind mounts these projects use will silently mount as empty.
+- **octo never calls `memory_recall`, or the backend never receives anything** — confirm
+  `memory_backend.type` is actually set (an empty/missing block disables the feature with no error),
+  and that `base_url` matches the port you actually exposed.


### PR DESCRIPTION
## Summary
- Adds copy-pasteable local setup steps for all three memory backends (hindsight/mem0/MemTensor MemOS), tested end-to-end against real services in this session.
- Adds a Troubleshooting section covering real pitfalls hit during that verification:
  - mem0's pgvector column dimension is fixed on first write — must `POST /configure` with the right `embedding_dims` **before** the first `/memories` call when using a non-1536-dim embedder, or wipe (`docker compose down -v`) and redo.
  - Pointing mem0/MemOS at a non-OpenAI OpenAI-compatible provider (DashScope, DeepSeek, ...) requires the base_url override to actually take effect (mem0: via `/configure`, not `.env`).
  - Colima only bind-mounts specific host paths into its VM — cloning these repos outside `$HOME` silently mounts as empty and produces confusing errors (e.g. alembic "script_location" failures).
- No code changes — docs only.

## Test plan
- [x] Reviewed rendered markdown for broken code fences / frontmatter
- [ ] CI docs build (Svelte Check / Astro build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)