### PR TITLE
chore: bump version to 1.10.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.10.1"
+var Version = "1.10.2"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Version bump for the next release, covering the day's merged work:
- #1254 fix(tui): "Goal starts" vs "Goal continues" wording
- #1256/#1257 product-help skill docs catch-up + trim to summaries with links
- #1258 fix(server): wire ArchiveDir into IM turns
- #1261 docs: add /loop and cron-tasks guides, fix /api/tasks + send_message docs
- #1262 fix(test): stop a real, 100%-reproducible race in TestGoalEdit_AsyncTurnStartCancelsPendingEdit

🤖 Generated with [Claude Code](https://claude.com/claude-code)