### PR TITLE
docs(landing): fix stale MCP Tool Search copy

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -482,8 +482,8 @@
         <div class="feature reveal">
           <span class="feature-icon">🔎</span>
           <h3 data-en="MCP Tool Search" data-zh="MCP Tool Search"></h3>
-          <p data-en="Connect dozens of MCP tools without blowing the context window. Octo advertises a small search/describe/call bridge and loads each schema only when the model needs it."
-             data-zh="连接几十个 MCP 工具也不撑爆上下文。Octo 暴露小型 search/describe/call 桥，只在模型需要时才加载每个 schema。"></p>
+          <p data-en="Connect dozens of MCP tools without blowing the context window. Octo keeps every tool's name and one-line description listed, and defers the full schema behind a small describe/call bridge loaded only when the model needs it."
+             data-zh="连接几十个 MCP 工具也不撑爆上下文。Octo 会一直列出每个工具的名字和一行说明，完整 schema 则通过小型 describe/call 桥延迟加载，只在模型需要时才加载。"></p>
         </div>
         <div class="feature reveal">
           <span class="feature-icon">🧠</span>


### PR DESCRIPTION
## Summary
- The landing page's "MCP Tool Search" card described the bridge as "search/describe/call", but that tool set no longer exists — the actual mechanism only has `mcp_describe`/`mcp_call`; every connected tool's name and one-line description stay listed in the system prompt at all times, so there's no separate search step.
- Fixed both English and Chinese copy to match `docs/src/content/docs/guides/connect-mcp-servers.mdx`, which already documents the correct two-tool bridge.

## Test plan
- [x] Diffed against `docs/guides/connect-mcp-servers.mdx` to confirm the corrected wording matches the current tool set

🤖 Generated with [Claude Code](https://claude.com/claude-code)