### PR TITLE
fix(test): stop TestStartTypingKeepalive_RepeatsUntilStopped flaking on slow CI

### DIFF
--- a/internal/server/channel_typing_test.go
+++ b/internal/server/channel_typing_test.go
@@ -64,13 +64,13 @@ func TestStartTypingKeepalive_RepeatsUntilStopped(t *testing.T) {
 		t.Fatalf("SendTyping should fire immediately, count = %d", send)
 	}
 
-	// Wait long enough for at least two more ticks.
-	time.Sleep(70 * time.Millisecond)
-	sendBefore, stopBefore := ad.counts()
-	if sendBefore < 3 {
-		t.Fatalf("expected SendTyping to repeat on the ticker, count = %d", sendBefore)
-	}
-	if stopBefore != 0 {
+	// Wait for at least two more ticks. Polled rather than a fixed sleep so a
+	// slow CI scheduler (esp. Windows) can't turn this into a flaky failure.
+	waitFor(t, func() bool {
+		send, _ := ad.counts()
+		return send >= 3
+	})
+	if _, stopBefore := ad.counts(); stopBefore != 0 {
 		t.Fatalf("StopTyping should not fire before stop() is called, count = %d", stopBefore)
 	}
 


### PR DESCRIPTION
## Summary
- PR #1266's Windows CI run failed on `TestStartTypingKeepalive_RepeatsUntilStopped` — unrelated to that PR's actual change (a landing-page copy fix).
- The test asserted `>=3` SendTyping calls after a fixed `70ms` sleep against a `20ms` ticker. Under scheduler contention (seen on `windows-latest`), the goroutine only got 2 ticks in, failing an otherwise-correct run.
- Replaced the fixed sleep + single assertion with the package's existing `waitFor` polling helper (already used in `channel_ask_test.go`), which waits up to 2s for the count to catch up instead of sampling once at a fixed point.

## Test plan
- [x] `go test ./internal/server/... -race` passes locally
- [x] `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)