### PR TITLE
docs(memory): document Hindsight Cloud as a config-only alternative to self-hosting

### DIFF
--- a/docs/src/content/docs/guides/memory-backends.md
+++ b/docs/src/content/docs/guides/memory-backends.md
@@ -12,7 +12,9 @@ extraction and indexing, and octo doesn't touch or duplicate the `MEMORY.md` lay
 
 Three backends are supported; pick at most one:
 
-- [hindsight](https://github.com/vectorize-io/hindsight) — self-hosted, no auth by default.
+- [hindsight](https://github.com/vectorize-io/hindsight) — self-hosted, no auth by default; a managed
+  [Hindsight Cloud](https://docs.hindsight.vectorize.io/) option also exists if you'd rather not run
+  the container yourself (see below).
 - [mem0](https://github.com/mem0ai/mem0) — self-hosted (`server/` in the mem0ai/mem0 repo), auth on
   by default.
 - [MemTensor/MemOS](https://github.com/MemTensor/MemOS) — self-hosted, no auth by default. (Not
@@ -59,6 +61,25 @@ curl http://localhost:8888/v1/default/banks
 ```
 
 No auth is required unless you explicitly set `HINDSIGHT_API_TENANT_API_KEY` on the container.
+
+#### Hindsight Cloud (no Docker required)
+
+Vectorize also runs a managed version — [Hindsight Cloud](https://docs.hindsight.vectorize.io/) — for
+anyone who'd rather not run the container themselves. It speaks the same REST API at
+`https://api.hindsight.vectorize.io` with the same `/v1/default/banks/...` paths as the self-hosted
+container, so pointing octo at it is a config change, not a code change:
+
+```yaml
+memory_backend:
+  type: hindsight
+  base_url: https://api.hindsight.vectorize.io
+  api_key: "<your Hindsight Cloud API key>"
+  namespace: octo-agent
+```
+
+Unlike the self-hosted default, Hindsight Cloud requires the API key — generate one from its
+dashboard and set it here. octo sends it as `Authorization: Bearer <api_key>`, matching what the
+cloud API expects.
 
 ### mem0
 
@@ -183,8 +204,9 @@ memory_backend:
 - **`base_url`** is the backend's REST endpoint — wherever you're running its server (`http://localhost:8888`
   for hindsight/mem0 as set up above, `http://localhost:8000` for MemOS).
 - **`api_key`** is optional and backend-dependent:
-  - hindsight has no auth by default; set an API key only if you've enabled
-    `HINDSIGHT_API_TENANT_API_KEY` on the server.
+  - self-hosted hindsight has no auth by default; set an API key only if you've enabled
+    `HINDSIGHT_API_TENANT_API_KEY` on the server. Hindsight Cloud is the exception — it always
+    requires the API key from its dashboard.
   - mem0 requires auth by default — set the server's `X-API-Key`-compatible key here, or run the
     server with `AUTH_DISABLED=true` for local development and leave this blank.
   - memos (MemTensor/MemOS) has no auth by default; leaving this blank sends your `namespace` as an

--- a/docs/src/content/docs/zh/guides/memory-backends.md
+++ b/docs/src/content/docs/zh/guides/memory-backends.md
@@ -11,7 +11,8 @@ octo 可以选择性地接入一个自托管的外部记忆服务，让它给你
 
 支持三种后端，最多选一个：
 
-- [hindsight](https://github.com/vectorize-io/hindsight)——自托管，默认不需要鉴权。
+- [hindsight](https://github.com/vectorize-io/hindsight)——自托管，默认不需要鉴权；如果不想自己
+  跑容器，也有一个托管的 [Hindsight Cloud](https://docs.hindsight.vectorize.io/) 选项（见下文）。
 - [mem0](https://github.com/mem0ai/mem0)——自托管（用的是 mem0ai/mem0 仓库里的 `server/`），
   默认开启鉴权。
 - [MemTensor/MemOS](https://github.com/MemTensor/MemOS)——自托管，默认不需要鉴权。（注意不是
@@ -57,6 +58,23 @@ curl http://localhost:8888/v1/default/banks
 ```
 
 除非你在容器上显式设置了 `HINDSIGHT_API_TENANT_API_KEY`，否则不需要任何鉴权。
+
+#### Hindsight Cloud（不用跑 Docker）
+
+Vectorize 还提供一个托管版本——[Hindsight Cloud](https://docs.hindsight.vectorize.io/)——给不想
+自己跑容器的人用。它用的是同一套 REST API，端点是 `https://api.hindsight.vectorize.io`，路径
+结构（`/v1/default/banks/...`）也跟自托管容器一模一样，所以把 octo 指过去只是改配置，不用改代码：
+
+```yaml
+memory_backend:
+  type: hindsight
+  base_url: https://api.hindsight.vectorize.io
+  api_key: "<你的 Hindsight Cloud API key>"
+  namespace: octo-agent
+```
+
+跟自托管默认情况不同，Hindsight Cloud 是强制要求 API key 的——去它的控制台生成一个填在这里。
+octo 会把它当作 `Authorization: Bearer <api_key>` 发出去，正好是云端 API 要求的格式。
 
 ### mem0
 
@@ -181,8 +199,8 @@ memory_backend:
 - **`base_url`** 是后端的 REST 端点——也就是你把它的 server 跑在哪（照上面的方式搭的话，
   hindsight/mem0 是 `http://localhost:8888`，MemOS 是 `http://localhost:8000`）。
 - **`api_key`** 是可选的，具体看后端：
-  - hindsight 默认不需要鉴权；只有在 server 上开了 `HINDSIGHT_API_TENANT_API_KEY` 时才需要
-    填一个 API key。
+  - 自托管 hindsight 默认不需要鉴权；只有在 server 上开了 `HINDSIGHT_API_TENANT_API_KEY` 时才
+    需要填一个 API key。Hindsight Cloud 是例外——它始终要求填控制台生成的 API key。
   - mem0 默认要求鉴权——把 server 那个兼容 `X-API-Key` 的 key 填在这里，或者本地开发时
     直接用 `AUTH_DISABLED=true` 跑 server，把这里留空。
   - memos（MemTensor/MemOS）默认不需要鉴权；留空的话会把你的 `namespace` 当作


### PR DESCRIPTION
## Summary
- Adds a "Hindsight Cloud" subsection to `guides/memory-backends.md` (+ zh translation) documenting `https://api.hindsight.vectorize.io` as a managed alternative to running the container yourself.
- Verified this is a genuine drop-in config swap: Hindsight Cloud's REST API uses the identical `/v1/default/banks/...` path structure and `Authorization: Bearer <key>` auth as the self-hosted container octo's `internal/memorybackend/hindsight.go` already talks to — no code changes needed, just `base_url` + `api_key`.
- Deliberately does **not** document mem0 Cloud or MemOS Cloud the same way: checked their actual REST APIs (mem0: `api.mem0.ai/v3/memories/...` with `Authorization: Token`; MemOS: `memos.memtensor.cn/api/openmem/v1/...` with `Authorization: Token`) and both differ from the self-hosted paths/auth octo's `mem0.go`/`memos.go` implement, so pointing octo at either cloud today would silently fail, not just need a config change.

## Test plan
- [x] `npx astro build` succeeds, both `guides/memory-backends` and `zh/guides/memory-backends` render the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)