### PR TITLE
feat(memory): support mem0 Cloud via memory_backend.mode

### DIFF
--- a/docs/src/content/docs/guides/memory-backends.md
+++ b/docs/src/content/docs/guides/memory-backends.md
@@ -16,7 +16,8 @@ Three backends are supported; pick at most one:
   [Hindsight Cloud](https://docs.hindsight.vectorize.io/) option also exists if you'd rather not run
   the container yourself (see below).
 - [mem0](https://github.com/mem0ai/mem0) — self-hosted (`server/` in the mem0ai/mem0 repo), auth on
-  by default.
+  by default; a managed [mem0 Platform](https://docs.mem0.ai/platform/quickstart) (cloud) option
+  also exists (see below).
 - [MemTensor/MemOS](https://github.com/MemTensor/MemOS) — self-hosted, no auth by default. (Not
   `usememos/memos`, which is an unrelated note-taking app, and not `agiresearch/MemOS`.)
 
@@ -129,6 +130,25 @@ curl -X POST http://localhost:8888/configure \
 drop it, run `make bootstrap` as-is, and it prints an admin email/password/API key on first start —
 use that generated API key as `api_key` in octo's config instead of leaving it blank.
 
+#### mem0 Cloud (no Postgres/Docker required)
+
+mem0 also runs a managed version — the [mem0 Platform](https://docs.mem0.ai/platform/quickstart) —
+for anyone who'd rather not self-host the `server/` stack. Unlike Hindsight Cloud, this **isn't**
+a drop-in swap: the Platform API uses different endpoint paths and a different auth header than the
+self-hosted server, so octo needs `mode: cloud` to talk to it correctly:
+
+```yaml
+memory_backend:
+  type: mem0
+  mode: cloud
+  api_key: "<your mem0 Platform API key>"
+  namespace: octo-agent
+```
+
+`base_url` can be omitted — it defaults to `https://api.mem0.ai` when `mode: cloud` and no
+`base_url` is set. `api_key` is required (the Platform has no unauthenticated mode); octo sends it
+as `Authorization: Token <api_key>`, matching what the Platform API expects.
+
 ### MemOS (MemTensor)
 
 The heaviest of the three — bundles Neo4j (graph store) and Qdrant (vector store) alongside the API.
@@ -197,6 +217,7 @@ Add a `memory_backend` block to `~/.octo/config.yml`:
 ```yaml
 memory_backend:
   type: hindsight        # hindsight | mem0 | memos
+  mode: ""               # only meaningful for mem0: "cloud" or "" (self-hosted, default)
   base_url: http://localhost:8888
   api_key: ""            # optional — see per-backend notes below
   namespace: my-project  # scopes stored/recalled memories; defaults to "default"
@@ -205,14 +226,19 @@ memory_backend:
 
 - **`type`** selects the backend. Leaving it unset (or omitting the whole block) disables the
   feature entirely — no tool is advertised, nothing is sent anywhere.
+- **`mode`** only matters for `type: mem0`: set it to `cloud` to talk to the hosted mem0 Platform
+  instead of a self-hosted server (see "mem0 Cloud" above) — the two use different endpoint paths
+  and auth headers, so this isn't inferred from `base_url`. Ignored by hindsight and memos.
 - **`base_url`** is the backend's REST endpoint — wherever you're running its server (`http://localhost:8888`
-  for hindsight/mem0 as set up above, `http://localhost:8000` for MemOS).
+  for hindsight/mem0 as set up above, `http://localhost:8000` for MemOS). Can be omitted for
+  `mem0` with `mode: cloud`, which defaults it to `https://api.mem0.ai`.
 - **`api_key`** is optional and backend-dependent:
   - self-hosted hindsight has no auth by default; set an API key only if you've enabled
     `HINDSIGHT_API_TENANT_API_KEY` on the server. Hindsight Cloud is the exception — it always
     requires the API key from its dashboard.
-  - mem0 requires auth by default — set the server's `X-API-Key`-compatible key here, or run the
-    server with `AUTH_DISABLED=true` for local development and leave this blank.
+  - self-hosted mem0 requires auth by default — set the server's `X-API-Key`-compatible key here,
+    or run the server with `AUTH_DISABLED=true` for local development and leave this blank. mem0
+    Cloud (`mode: cloud`) always requires the API key from its dashboard.
   - memos (MemTensor/MemOS) has no auth by default; leaving this blank sends your `namespace` as an
     `X-User-Name` header instead.
 - **`namespace`** scopes what gets stored/recalled — hindsight's `bank_id`, mem0's `user_id`, or

--- a/docs/src/content/docs/zh/guides/memory-backends.md
+++ b/docs/src/content/docs/zh/guides/memory-backends.md
@@ -14,7 +14,8 @@ octo 可以选择性地接入一个自托管的外部记忆服务，让它给你
 - [hindsight](https://github.com/vectorize-io/hindsight)——自托管，默认不需要鉴权；如果不想自己
   跑容器，也有一个托管的 [Hindsight Cloud](https://docs.hindsight.vectorize.io/) 选项（见下文）。
 - [mem0](https://github.com/mem0ai/mem0)——自托管（用的是 mem0ai/mem0 仓库里的 `server/`），
-  默认开启鉴权。
+  默认开启鉴权；也有一个托管的 [mem0 Platform](https://docs.mem0.ai/platform/quickstart)（云端）
+  选项（见下文）。
 - [MemTensor/MemOS](https://github.com/MemTensor/MemOS)——自托管，默认不需要鉴权。（注意不是
   `usememos/memos`，那是一个不相关的笔记应用，也不是 `agiresearch/MemOS`。）
 
@@ -124,6 +125,25 @@ curl -X POST http://localhost:8888/configure \
 去掉这个变量，照常跑 `make bootstrap`，它首次启动时会打印一个管理员邮箱/密码/API key——
 把这个生成出来的 API key 填进 octo 配置的 `api_key` 里，别留空。
 
+#### mem0 Cloud（不用 Postgres/Docker）
+
+mem0 也有一个托管版本——[mem0 Platform](https://docs.mem0.ai/platform/quickstart)——给不想
+自己搭 `server/` 那套栈的人用。跟 Hindsight Cloud 不一样，这**不是**配个 URL 就能切换的——
+Platform API 用的端点路径和鉴权 header 都跟自托管 server 不一样，所以 octo 需要显式设置
+`mode: cloud` 才能对上：
+
+```yaml
+memory_backend:
+  type: mem0
+  mode: cloud
+  api_key: "<你的 mem0 Platform API key>"
+  namespace: octo-agent
+```
+
+`base_url` 可以不填——`mode: cloud` 且没设 `base_url` 时会自动用
+`https://api.mem0.ai`。`api_key` 是必填的（Platform 没有免鉴权模式）；octo 会把它当作
+`Authorization: Token <api_key>` 发出去，正好是 Platform API 要求的格式。
+
 ### MemOS（MemTensor）
 
 三者里最重的一个——除了 API 本身，还打包了 Neo4j（图数据库）和 Qdrant（向量数据库）。
@@ -190,6 +210,7 @@ docker compose up --build
 ```yaml
 memory_backend:
   type: hindsight        # hindsight | mem0 | memos
+  mode: ""               # 只对 mem0 有意义："cloud" 或 ""（自托管，默认）
   base_url: http://localhost:8888
   api_key: ""            # 可选——具体看下面每个后端的说明
   namespace: my-project  # 限定存储/召回的记忆范围；不填默认是 "default"
@@ -198,13 +219,18 @@ memory_backend:
 
 - **`type`** 选择用哪个后端。不填（或者整段都不写）就是彻底关掉这个功能——不会向模型
   暴露任何工具，也不会往外发任何东西。
+- **`mode`** 只对 `type: mem0` 有意义：设成 `cloud` 就会走托管的 mem0 Platform，而不是自托管
+  server（见上文「mem0 Cloud」）——两者端点路径和鉴权 header 都不一样，不会根据 `base_url`
+  自动判断。hindsight 和 memos 不看这个字段。
 - **`base_url`** 是后端的 REST 端点——也就是你把它的 server 跑在哪（照上面的方式搭的话，
-  hindsight/mem0 是 `http://localhost:8888`，MemOS 是 `http://localhost:8000`）。
+  hindsight/mem0 是 `http://localhost:8888`，MemOS 是 `http://localhost:8000`）。`mem0` 配合
+  `mode: cloud` 时可以不填，会自动用 `https://api.mem0.ai`。
 - **`api_key`** 是可选的，具体看后端：
   - 自托管 hindsight 默认不需要鉴权；只有在 server 上开了 `HINDSIGHT_API_TENANT_API_KEY` 时才
     需要填一个 API key。Hindsight Cloud 是例外——它始终要求填控制台生成的 API key。
-  - mem0 默认要求鉴权——把 server 那个兼容 `X-API-Key` 的 key 填在这里，或者本地开发时
-    直接用 `AUTH_DISABLED=true` 跑 server，把这里留空。
+  - 自托管 mem0 默认要求鉴权——把 server 那个兼容 `X-API-Key` 的 key 填在这里，或者本地开发时
+    直接用 `AUTH_DISABLED=true` 跑 server，把这里留空。mem0 Cloud（`mode: cloud`）始终要求填
+    控制台生成的 API key。
   - memos（MemTensor/MemOS）默认不需要鉴权；留空的话会把你的 `namespace` 当作
     `X-User-Name` header 发过去。
 - **`namespace`** 限定存储/召回的范围——对应 hindsight 的 `bank_id`、mem0 的 `user_id`，

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -65,6 +65,7 @@ func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
 			BaseURL:   cfg.MemoryBackend.BaseURL,
 			APIKey:    cfg.MemoryBackend.APIKey,
 			Namespace: cfg.MemoryBackend.Namespace,
+			Mode:      cfg.MemoryBackend.Mode,
 		}); err == nil {
 			tools.SetMemoryBackend(b)
 			tools.SetMemoryBackendAutoRecall(cfg.MemoryBackend.AutoRecall)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,6 +169,11 @@ type MemoryBackendConfig struct {
 	// Namespace scopes stored/recalled memories (hindsight bank_id, mem0/memos
 	// user_id). Defaults to "default" when empty.
 	Namespace string `yaml:"namespace,omitempty"`
+	// Mode selects between deployment variants of the same Type. Currently
+	// only meaningful for "mem0": "cloud" talks to the hosted mem0 Platform
+	// API instead of a self-hosted server — see the memory-backends guide.
+	// Ignored by other backend types.
+	Mode string `yaml:"mode,omitempty"`
 	// AutoRecall, when true, automatically calls Recall with the user's
 	// message before every turn and injects the result as context —
 	// independent of the memory_recall tool, which stays available either

--- a/internal/memorybackend/backend.go
+++ b/internal/memorybackend/backend.go
@@ -26,6 +26,11 @@ type Config struct {
 	// Namespace scopes stored/recalled memories (hindsight bank_id, mem0
 	// user_id, memos user_id). Defaults to "default" when empty.
 	Namespace string
+	// Mode selects between deployment variants of the same Type. Currently
+	// only meaningful for "mem0": "cloud" talks to the hosted Platform API
+	// (api.mem0.ai); "" or "self_hosted" (the default) talks to the
+	// self-hosted server/ OSS stack. Ignored by other backend types.
+	Mode string
 }
 
 func (c Config) namespace() string {
@@ -59,6 +64,9 @@ type Backend interface {
 // unreachable or misconfigured backend surface on the first Store/Recall
 // call.
 func New(cfg Config) (Backend, error) {
+	if cfg.Type == "mem0" && cfg.Mode == "cloud" && cfg.BaseURL == "" {
+		cfg.BaseURL = mem0CloudBaseURL
+	}
 	if cfg.BaseURL == "" {
 		return nil, fmt.Errorf("memorybackend: base_url is required")
 	}

--- a/internal/memorybackend/backend_test.go
+++ b/internal/memorybackend/backend_test.go
@@ -34,6 +34,37 @@ func TestNewRequiresBaseURL(t *testing.T) {
 	}
 }
 
+func TestNewRequiresBaseURLForSelfHostedMem0(t *testing.T) {
+	if _, err := New(Config{Type: "mem0"}); err == nil {
+		t.Fatal("New(mem0, no mode, no base_url): want error, got nil")
+	}
+}
+
+func TestNewDefaultsBaseURLForMem0Cloud(t *testing.T) {
+	b, err := New(Config{Type: "mem0", Mode: "cloud"})
+	if err != nil {
+		t.Fatalf("New(mem0 cloud, no base_url): unexpected error: %v", err)
+	}
+	m, ok := b.(*mem0Backend)
+	if !ok {
+		t.Fatalf("New(mem0 cloud) returned %T, want *mem0Backend", b)
+	}
+	if m.cfg.BaseURL != mem0CloudBaseURL {
+		t.Errorf("BaseURL = %q, want the mem0 Cloud default %q", m.cfg.BaseURL, mem0CloudBaseURL)
+	}
+}
+
+func TestNewDoesNotOverrideExplicitBaseURLForMem0Cloud(t *testing.T) {
+	b, err := New(Config{Type: "mem0", Mode: "cloud", BaseURL: "https://staging.mem0.example"})
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+	m := b.(*mem0Backend)
+	if m.cfg.BaseURL != "https://staging.mem0.example" {
+		t.Errorf("BaseURL = %q, want the explicitly configured value preserved", m.cfg.BaseURL)
+	}
+}
+
 func TestConfigNamespaceDefault(t *testing.T) {
 	if got := (Config{}).namespace(); got != "default" {
 		t.Errorf("empty Namespace: got %q, want %q", got, "default")

--- a/internal/memorybackend/mem0.go
+++ b/internal/memorybackend/mem0.go
@@ -9,9 +9,19 @@ import (
 	"strings"
 )
 
-// mem0Backend talks to a self-hosted github.com/mem0ai/mem0 server (the
-// server/ FastAPI stack, no version prefix in its routes — verified against
-// server/main.py and server/auth.py in the mem0ai/mem0 repo).
+// mem0CloudBaseURL is the fixed hosted-Platform endpoint, used when Mode is
+// "cloud" and BaseURL is left blank — there's only one, unlike self-hosted
+// deployments which need an explicit address.
+const mem0CloudBaseURL = "https://api.mem0.ai"
+
+// mem0Backend talks to either a self-hosted github.com/mem0ai/mem0 server
+// (the server/ FastAPI stack, no version prefix in its routes — verified
+// against server/main.py and server/auth.py in the mem0ai/mem0 repo) or,
+// when cfg.Mode == "cloud", the hosted mem0 Platform API (api.mem0.ai) —
+// verified against docs.mem0.ai/platform/quickstart. The two differ in
+// endpoint path, auth header, and part of the search request body; the
+// response shape for search is close enough (both return flat {id, memory,
+// score} objects) that decoding is shared.
 type mem0Backend struct {
 	cfg    Config
 	client *http.Client
@@ -22,6 +32,22 @@ func newMem0(cfg Config) *mem0Backend {
 }
 
 func (b *mem0Backend) Name() string { return "mem0" }
+
+func (b *mem0Backend) cloud() bool { return b.cfg.Mode == "cloud" }
+
+func (b *mem0Backend) addPath() string {
+	if b.cloud() {
+		return "/v3/memories/add/"
+	}
+	return "/memories"
+}
+
+func (b *mem0Backend) searchPath() string {
+	if b.cloud() {
+		return "/v3/memories/search/"
+	}
+	return "/search"
+}
 
 func (b *mem0Backend) url(path string) string {
 	return strings.TrimRight(b.cfg.BaseURL, "/") + path
@@ -38,7 +64,11 @@ func (b *mem0Backend) do(ctx context.Context, url string, body any, out any) err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if b.cfg.APIKey != "" {
-		req.Header.Set("X-API-Key", b.cfg.APIKey)
+		if b.cloud() {
+			req.Header.Set("Authorization", "Token "+b.cfg.APIKey)
+		} else {
+			req.Header.Set("X-API-Key", b.cfg.APIKey)
+		}
 	}
 	resp, err := b.client.Do(req)
 	if err != nil {
@@ -62,7 +92,7 @@ func (b *mem0Backend) Store(ctx context.Context, content string) error {
 		"messages": []map[string]any{{"role": "user", "content": content}},
 		"user_id":  b.cfg.namespace(),
 	}
-	return b.do(ctx, b.url("/memories"), body, nil)
+	return b.do(ctx, b.url(b.addPath()), body, nil)
 }
 
 // mem0SearchResponse is decoded tolerantly. The self-hosted server's /search
@@ -112,13 +142,17 @@ func mem0ResultScore(item map[string]json.RawMessage) float64 {
 }
 
 func (b *mem0Backend) Recall(ctx context.Context, query string) ([]Result, error) {
-	body := map[string]any{
-		"query":   query,
-		"user_id": b.cfg.namespace(),
-		"top_k":   5,
+	body := map[string]any{"query": query}
+	if b.cloud() {
+		// Platform API scopes by a top-level "filters" object rather than a
+		// bare user_id, and doesn't document a top_k equivalent.
+		body["filters"] = map[string]any{"user_id": b.cfg.namespace()}
+	} else {
+		body["user_id"] = b.cfg.namespace()
+		body["top_k"] = 5
 	}
 	var resp mem0SearchResponse
-	if err := b.do(ctx, b.url("/search"), body, &resp); err != nil {
+	if err := b.do(ctx, b.url(b.searchPath()), body, &resp); err != nil {
 		return nil, err
 	}
 	results := make([]Result, 0, len(resp.Results))

--- a/internal/memorybackend/mem0_test.go
+++ b/internal/memorybackend/mem0_test.go
@@ -77,6 +77,69 @@ func TestMem0RecallTolerantFieldNames(t *testing.T) {
 	}
 }
 
+func TestMem0CloudStore(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	b := newMem0(Config{BaseURL: srv.URL, Mode: "cloud", Namespace: "proj", APIKey: "m0sk_secret"})
+	if err := b.Store(context.Background(), "hello world"); err != nil {
+		t.Fatalf("Store: unexpected error: %v", err)
+	}
+
+	if gotPath != "/v3/memories/add/" {
+		t.Errorf("path = %q, want the Platform API's versioned add path", gotPath)
+	}
+	if gotAuth != "Token m0sk_secret" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Token m0sk_secret")
+	}
+	if gotBody["user_id"] != "proj" {
+		t.Errorf("user_id = %v, want %q", gotBody["user_id"], "proj")
+	}
+}
+
+func TestMem0CloudRecall(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				{"id": "14e1b28a", "memory": "Allergic to nuts", "score": 0.30},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	b := newMem0(Config{BaseURL: srv.URL, Mode: "cloud", Namespace: "proj"})
+	results, err := b.Recall(context.Background(), "dietary restrictions")
+	if err != nil {
+		t.Fatalf("Recall: unexpected error: %v", err)
+	}
+
+	if gotPath != "/v3/memories/search/" {
+		t.Errorf("path = %q, want the Platform API's versioned search path", gotPath)
+	}
+	if _, hasTopLevelUserID := gotBody["user_id"]; hasTopLevelUserID {
+		t.Error("cloud search body should scope by filters.user_id, not a top-level user_id")
+	}
+	filters, ok := gotBody["filters"].(map[string]any)
+	if !ok || filters["user_id"] != "proj" {
+		t.Errorf("filters = %v, want {user_id: proj}", gotBody["filters"])
+	}
+	if len(results) != 1 || results[0].Content != "Allergic to nuts" || results[0].Score != 0.30 {
+		t.Errorf("results = %+v, want one result {14e1b28a, Allergic to nuts, 0.30}", results)
+	}
+}
+
 func TestMem0NoAPIKeyOmitsHeader(t *testing.T) {
 	sawKey := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -81,6 +81,7 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 			BaseURL:   cfg.MemoryBackend.BaseURL,
 			APIKey:    cfg.MemoryBackend.APIKey,
 			Namespace: cfg.MemoryBackend.Namespace,
+			Mode:      cfg.MemoryBackend.Mode,
 		}); err == nil {
 			tools.SetMemoryBackend(b)
 			tools.SetMemoryBackendAutoRecall(cfg.MemoryBackend.AutoRecall)


### PR DESCRIPTION
## Summary

Closes #1269 for **mem0 only** — per discussion on the issue, MemOS Cloud's response shape
(`memory_detail_list`/`preference_detail_list`) is different enough from the self-hosted server's
(`data.text_mem[].memories[]`) to warrant a separate implementation rather than a mode branch, so
it's left open in the issue for later.

- Adds `memory_backend.mode: "cloud" | ""` (default `""`, self-hosted — no behavior change for
  existing configs). Only meaningful for `type: mem0`; ignored by hindsight/memos.
- `mem0Backend` now branches on mode for: endpoint path (`/memories`,`/search` vs
  `/v3/memories/add/`,`/v3/memories/search/`), auth header (`X-API-Key` vs `Authorization: Token
  <key>`), and the search request body shape (top-level `user_id`+`top_k` vs `filters.user_id`).
- The search **response** decode is shared unchanged — cloud's `{id, memory, score}` shape is close
  enough to self-hosted's that the existing tolerant `mem0ResultText/ID/Score` helpers handle both.
- `base_url` defaults to `https://api.mem0.ai` when `mode: cloud` and left blank (there's only one
  real cloud endpoint, unlike self-hosted deployments which need an explicit address).
- Docs (`guides/memory-backends.md` + zh) get a new "mem0 Cloud" subsection mirroring the Hindsight
  Cloud one from #1268, explicit that — unlike Hindsight Cloud — this isn't a drop-in `base_url`
  swap.

## Test plan
- [x] `go test -race ./...` passes (full suite)
- [x] `go vet ./...`, `gofmt -l .` clean
- [x] New unit tests in `internal/memorybackend/{backend,mem0}_test.go` covering: cloud-mode
      path/header/body construction, `base_url` defaulting (and not overriding an explicit value),
      and that self-hosted mem0 behavior is unchanged
- [x] `npx astro build` renders both updated doc pages
- [ ] Not verified against a live mem0 Cloud account (none available) — request/response shapes are
      matched against docs.mem0.ai/platform/quickstart via httptest, not a real integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)