### PR TITLE
chore: bump version to 1.10.3

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.10.2"
+var Version = "1.10.3"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Version bump for the 1.10.3 release, covering everything merged since 1.10.2: zh docs for
/loop and cron-tasks (#1265), landing page MCP Tool Search copy fix (#1266), a flaky-test fix
(#1267), Hindsight Cloud docs (#1268), stronger memory_recall guidance (#1270), opt-in
memory_backend.auto_recall (#1271), and mem0 Cloud support (#1272).