### PR TITLE
fix(server): refresh memory_backend before hook registration, not after

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -25,6 +25,34 @@ type ToolEnv struct {
 	ToolsFor    func(ctx context.Context) []agent.ToolDefinition
 }
 
+// RefreshMemoryBackend re-reads memory_backend from config and re-installs it
+// via tools.SetMemoryBackend/SetMemoryBackendAutoRecall. WireTools calls this
+// once for the CLI's whole process lifetime; internal/server calls it fresh
+// on every turn (serve never calls WireTools) since it has no equivalent
+// one-time startup hook — see its callers for why it must run before
+// tools.MemoryBackendGuidance()/tools.RegisterMemoryBackendHooks. A bad
+// Type/BaseURL just leaves the backend unconfigured rather than erroring;
+// cheap to call repeatedly (a lightweight REST client, not a persistent
+// connection).
+func RefreshMemoryBackend() {
+	cfg, cfgErr := config.Load()
+	if cfgErr != nil || !cfg.MemoryBackendEnabled() {
+		return
+	}
+	b, err := memorybackend.New(memorybackend.Config{
+		Type:      cfg.MemoryBackend.Type,
+		BaseURL:   cfg.MemoryBackend.BaseURL,
+		APIKey:    cfg.MemoryBackend.APIKey,
+		Namespace: cfg.MemoryBackend.Namespace,
+		Mode:      cfg.MemoryBackend.Mode,
+	})
+	if err != nil {
+		return
+	}
+	tools.SetMemoryBackend(b)
+	tools.SetMemoryBackendAutoRecall(cfg.MemoryBackend.AutoRecall)
+}
+
 // WireTools sets up the tool environment every full-loop entry point shares —
 // the CLI today, the HTTP server and IM bridge as they migrate. It builds a
 // read-before-write executor, registers the sub-agent spawner globally (so
@@ -56,21 +84,9 @@ func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
 		tools.SetBrowserVision(cfg.ModelVision(a.Model))
 	}
 
-	// Optional external semantic memory backend (hindsight/mem0/memos). A
-	// bad Type/BaseURL just leaves it unconfigured rather than failing
-	// session start — the user finds out on the first memory_recall call.
-	if cfgErr == nil && cfg.MemoryBackendEnabled() {
-		if b, err := memorybackend.New(memorybackend.Config{
-			Type:      cfg.MemoryBackend.Type,
-			BaseURL:   cfg.MemoryBackend.BaseURL,
-			APIKey:    cfg.MemoryBackend.APIKey,
-			Namespace: cfg.MemoryBackend.Namespace,
-			Mode:      cfg.MemoryBackend.Mode,
-		}); err == nil {
-			tools.SetMemoryBackend(b)
-			tools.SetMemoryBackendAutoRecall(cfg.MemoryBackend.AutoRecall)
-		}
-	}
+	// Optional external semantic memory backend (hindsight/mem0/memos) — the
+	// user finds out about a bad Type/BaseURL on the first memory_recall call.
+	RefreshMemoryBackend()
 
 	cleanup := func() {
 		tools.SetDefaultSubAgentManager(nil)

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/channel"
+	"github.com/open-octo/octo-agent/internal/config"
 	"github.com/open-octo/octo-agent/internal/hooks"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
@@ -384,6 +385,50 @@ func TestHandleChannelMessage_WiresMemoryHooks(t *testing.T) {
 	}
 	if !sess.Agent.Hooks.Configured(hooks.EventPostToolUse) {
 		t.Error("IM agent missing PostToolUse hook (save-nudge)")
+	}
+}
+
+// TestHandleChannelMessage_RefreshesAutoRecallBeforeRegisteringHooks: IM turns
+// never go through prepareToolTurn (only WS/REST/cron do), so runChannelTurns
+// must refresh the memory-backend globals itself before registering hooks —
+// mirrors TestBuildAgent_RefreshesAutoRecallBeforeRegisteringHooks for the web
+// path. Deliberately leaves the global auto-recall flag stale before the
+// turn, with no prepareToolTurn call anywhere in this path, to prove
+// runChannelTurns's own refresh (not some other turn type having run first)
+// is what makes this work.
+func TestHandleChannelMessage_RefreshesAutoRecallBeforeRegisteringHooks(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "gpt-4o",
+		MemoryBackend: config.MemoryBackendConfig{
+			Type:       "hindsight",
+			BaseURL:    "http://localhost:8888",
+			AutoRecall: true,
+		},
+	})
+	srv := chanServer(t)
+	ad := &fullFakeAdapter{}
+
+	tools.SetMemoryBackend(nil)
+	tools.SetMemoryBackendAutoRecall(false) // simulate a prior turn's stale state
+	t.Cleanup(func() {
+		tools.SetMemoryBackend(nil)
+		tools.SetMemoryBackendAutoRecall(false)
+	})
+
+	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
+
+	// Don't inspect sess.Agent.Hooks directly — the MEMORY.md injector (when
+	// memDir is set) registers its own UserPromptSubmit hook, which would
+	// pass this check even if the auto-recall refresh never ran. Build a
+	// fresh, unrelated engine instead: RegisterMemoryBackendHooks reads the
+	// package-global auto-recall flag at registration time, so this proves
+	// runChannelTurns left that global set to true this turn.
+	e := hooks.NewEngine(nil)
+	tools.RegisterMemoryBackendHooks(e)
+	if !e.Configured(hooks.EventUserPromptSubmit) {
+		t.Error("runChannelTurns should have refreshed the auto-recall global from this turn's config, not left the stale previous value")
 	}
 }
 

--- a/internal/server/channel_route_test.go
+++ b/internal/server/channel_route_test.go
@@ -398,12 +398,13 @@ func TestHandleChannelMessage_WiresMemoryHooks(t *testing.T) {
 // is what makes this work.
 func TestHandleChannelMessage_RefreshesAutoRecallBeforeRegisteringHooks(t *testing.T) {
 	setTestHome(t)
+	marker := "octo-agent lucky number is 47"
 	seedModels(t, config.Config{
 		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
 		DefaultModel: "gpt-4o",
 		MemoryBackend: config.MemoryBackendConfig{
 			Type:       "hindsight",
-			BaseURL:    "http://localhost:8888",
+			BaseURL:    hindsightRecallStub(t, marker),
 			AutoRecall: true,
 		},
 	})
@@ -419,16 +420,26 @@ func TestHandleChannelMessage_RefreshesAutoRecallBeforeRegisteringHooks(t *testi
 
 	srv.handleChannelMessage(context.Background(), ad, evFor("hello"))
 
-	// Don't inspect sess.Agent.Hooks directly — the MEMORY.md injector (when
-	// memDir is set) registers its own UserPromptSubmit hook, which would
-	// pass this check even if the auto-recall refresh never ran. Build a
-	// fresh, unrelated engine instead: RegisterMemoryBackendHooks reads the
-	// package-global auto-recall flag at registration time, so this proves
-	// runChannelTurns left that global set to true this turn.
-	e := hooks.NewEngine(nil)
-	tools.RegisterMemoryBackendHooks(e)
-	if !e.Configured(hooks.EventUserPromptSubmit) {
-		t.Error("runChannelTurns should have refreshed the auto-recall global from this turn's config, not left the stale previous value")
+	// Drive a REAL Inject() call against this session's own engine and check
+	// for actual recalled content — not e.Configured(EventUserPromptSubmit)
+	// on sess.Agent.Hooks (the WorkflowNudger, wired unconditionally for
+	// every session, registers its own no-op-output hook on that same event,
+	// so "configured" is true regardless of whether the auto-recall hook is
+	// there) and not a fresh throwaway engine re-queried after the turn
+	// (proves only that the global ends up correct eventually, not that
+	// THIS turn's engine was built with the right value at registration
+	// time — see TestBuildAgent_RefreshesAutoRecallBeforeRegisteringHooks's
+	// doc comment for the experiment that found this).
+	sess := srv.channelMgr.GetSession(evFor("x"))
+	if sess == nil || sess.Agent == nil || sess.Agent.Hooks == nil {
+		t.Fatal("expected a bound IM session with hooks wired after handleChannelMessage")
+	}
+	got := sess.Agent.Hooks.Inject(context.Background(), hooks.Payload{
+		Event:     hooks.EventUserPromptSubmit,
+		UserInput: "what's my lucky number?",
+	})
+	if !strings.Contains(got, marker) {
+		t.Errorf("injected UserPromptSubmit text = %q, want it to contain the recalled marker %q — runChannelTurns must refresh the memory backend before registering hooks, not after", got, marker)
 	}
 }
 

--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -7,43 +7,10 @@ import (
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/app"
 	"github.com/open-octo/octo-agent/internal/config"
-	"github.com/open-octo/octo-agent/internal/memorybackend"
 	"github.com/open-octo/octo-agent/internal/permission"
 	"github.com/open-octo/octo-agent/internal/tasks"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
-
-// refreshMemoryBackend re-reads memory_backend from config and re-installs it
-// via tools.SetMemoryBackend/SetMemoryBackendAutoRecall. WireTools does this
-// once for the CLI; serve never calls WireTools, so every turn-building path
-// must call this itself — and must call it BEFORE reading
-// tools.MemoryBackendGuidance() (baked into the system prompt) or calling
-// tools.RegisterMemoryBackendHooks (which reads the auto-recall flag at
-// registration time, not per-hook-invocation): buildAgent and runChannelTurns
-// both do the former and call the latter before prepareToolTurn ever runs, so
-// calling this only from prepareToolTurn left a one-turn-stale window where a
-// just-changed auto_recall (or a first-time memory_backend config) wouldn't
-// take effect until the turn after next. A bad Type/BaseURL just leaves the
-// backend unconfigured rather than erroring; cheap to call every turn (a
-// lightweight REST client, not a persistent connection).
-func refreshMemoryBackend() {
-	cfg, cfgErr := config.Load()
-	if cfgErr != nil || !cfg.MemoryBackendEnabled() {
-		return
-	}
-	b, err := memorybackend.New(memorybackend.Config{
-		Type:      cfg.MemoryBackend.Type,
-		BaseURL:   cfg.MemoryBackend.BaseURL,
-		APIKey:    cfg.MemoryBackend.APIKey,
-		Namespace: cfg.MemoryBackend.Namespace,
-		Mode:      cfg.MemoryBackend.Mode,
-	})
-	if err != nil {
-		return
-	}
-	tools.SetMemoryBackend(b)
-	tools.SetMemoryBackendAutoRecall(cfg.MemoryBackend.AutoRecall)
-}
 
 // prepareToolTurn wires the per-turn tool environment for agent a: the strict,
 // non-interactive permission gate, plus a sub-agent manager and task store
@@ -103,13 +70,13 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 	tools.SetBrowserHealer(app.MakeBrowserHealer(a.Sender, a.Model))
 
 	// Same omission for the external memory backend: WireTools installs it for
-	// the CLI, but serve never calls WireTools. refreshMemoryBackend is also
-	// called earlier in the same turn by buildAgent/runChannelTurns (before
-	// they read tools.MemoryBackendGuidance()/call tools.RegisterMemoryBackendHooks,
-	// which need the refreshed globals) — calling it again here is redundant
-	// but harmless, and keeps this path correct standalone if ever called
-	// without one of those two upstream.
-	refreshMemoryBackend()
+	// the CLI, but serve never calls WireTools. app.RefreshMemoryBackend is
+	// also called earlier in the same turn by buildAgent/runChannelTurns
+	// (before they read tools.MemoryBackendGuidance()/call
+	// tools.RegisterMemoryBackendHooks, which need the refreshed globals) —
+	// calling it again here is redundant but harmless, and keeps this path
+	// correct standalone if ever called without one of those two upstream.
+	app.RefreshMemoryBackend()
 
 	// Anchor the gate at the agent's per-session cwd (not the server default) so
 	// $CWD path rules and relative-path resolution match where the tools

--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -13,6 +13,38 @@ import (
 	"github.com/open-octo/octo-agent/internal/tools"
 )
 
+// refreshMemoryBackend re-reads memory_backend from config and re-installs it
+// via tools.SetMemoryBackend/SetMemoryBackendAutoRecall. WireTools does this
+// once for the CLI; serve never calls WireTools, so every turn-building path
+// must call this itself — and must call it BEFORE reading
+// tools.MemoryBackendGuidance() (baked into the system prompt) or calling
+// tools.RegisterMemoryBackendHooks (which reads the auto-recall flag at
+// registration time, not per-hook-invocation): buildAgent and runChannelTurns
+// both do the former and call the latter before prepareToolTurn ever runs, so
+// calling this only from prepareToolTurn left a one-turn-stale window where a
+// just-changed auto_recall (or a first-time memory_backend config) wouldn't
+// take effect until the turn after next. A bad Type/BaseURL just leaves the
+// backend unconfigured rather than erroring; cheap to call every turn (a
+// lightweight REST client, not a persistent connection).
+func refreshMemoryBackend() {
+	cfg, cfgErr := config.Load()
+	if cfgErr != nil || !cfg.MemoryBackendEnabled() {
+		return
+	}
+	b, err := memorybackend.New(memorybackend.Config{
+		Type:      cfg.MemoryBackend.Type,
+		BaseURL:   cfg.MemoryBackend.BaseURL,
+		APIKey:    cfg.MemoryBackend.APIKey,
+		Namespace: cfg.MemoryBackend.Namespace,
+		Mode:      cfg.MemoryBackend.Mode,
+	})
+	if err != nil {
+		return
+	}
+	tools.SetMemoryBackend(b)
+	tools.SetMemoryBackendAutoRecall(cfg.MemoryBackend.AutoRecall)
+}
+
 // prepareToolTurn wires the per-turn tool environment for agent a: the strict,
 // non-interactive permission gate, plus a sub-agent manager and task store
 // bound to THIS turn's agent and stamped into ctx so the sub-agent / task tools
@@ -71,22 +103,13 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 	tools.SetBrowserHealer(app.MakeBrowserHealer(a.Sender, a.Model))
 
 	// Same omission for the external memory backend: WireTools installs it for
-	// the CLI, but serve never calls WireTools, so without this the feature
-	// silently doesn't exist under `octo serve` even when configured. Cheap to
-	// re-evaluate per turn (a lightweight REST client, not a persistent
-	// connection); a bad Type/BaseURL just leaves it unconfigured.
-	if cfgErr == nil && cfg.MemoryBackendEnabled() {
-		if b, err := memorybackend.New(memorybackend.Config{
-			Type:      cfg.MemoryBackend.Type,
-			BaseURL:   cfg.MemoryBackend.BaseURL,
-			APIKey:    cfg.MemoryBackend.APIKey,
-			Namespace: cfg.MemoryBackend.Namespace,
-			Mode:      cfg.MemoryBackend.Mode,
-		}); err == nil {
-			tools.SetMemoryBackend(b)
-			tools.SetMemoryBackendAutoRecall(cfg.MemoryBackend.AutoRecall)
-		}
-	}
+	// the CLI, but serve never calls WireTools. refreshMemoryBackend is also
+	// called earlier in the same turn by buildAgent/runChannelTurns (before
+	// they read tools.MemoryBackendGuidance()/call tools.RegisterMemoryBackendHooks,
+	// which need the refreshed globals) — calling it again here is redundant
+	// but harmless, and keeps this path correct standalone if ever called
+	// without one of those two upstream.
+	refreshMemoryBackend()
 
 	// Anchor the gate at the agent's per-session cwd (not the server default) so
 	// $CWD path rules and relative-path resolution match where the tools

--- a/internal/server/memory_backend_wiring_test.go
+++ b/internal/server/memory_backend_wiring_test.go
@@ -69,6 +69,55 @@ func TestPrepareToolTurn_WiresAutoRecall(t *testing.T) {
 	}
 }
 
+// TestBuildAgent_RefreshesAutoRecallBeforeRegisteringHooks guards against a
+// real regression: buildAgent reads tools.MemoryBackendGuidance() and calls
+// tools.RegisterMemoryBackendHooks BEFORE prepareToolTurn ever runs (in every
+// caller — runTurn, the WS handler, the scheduled-task handler — buildAgent
+// executes first in the same function). Relying on prepareToolTurn alone to
+// keep the auto-recall flag fresh left a one-turn-stale window: a session
+// hitting buildAgent right after auto_recall flips to true in config would
+// still get built with the hook missing, because the global the previous
+// turn's prepareToolTurn call last set was false. This deliberately leaves
+// the global at false before calling buildAgent, with no prepareToolTurn call
+// at all, to prove buildAgent's own refresh (not prepareToolTurn's) is what
+// makes this work.
+func TestBuildAgent_RefreshesAutoRecallBeforeRegisteringHooks(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "gpt-4o",
+		MemoryBackend: config.MemoryBackendConfig{
+			Type:       "hindsight",
+			BaseURL:    "http://localhost:8888",
+			AutoRecall: true,
+		},
+	})
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	tools.SetMemoryBackend(nil)
+	tools.SetMemoryBackendAutoRecall(false) // simulate the previous turn's stale state
+	t.Cleanup(func() {
+		tools.SetMemoryBackend(nil)
+		tools.SetMemoryBackendAutoRecall(false)
+	})
+
+	sess := agent.NewSession("gpt-4o", "")
+	srv.buildAgent(sess)
+
+	// Don't inspect a.Hooks directly — the MEMORY.md injector also registers
+	// a hook on EventUserPromptSubmit, so Configured() there would pass even
+	// if buildAgent never refreshed the auto-recall flag at all. Build a
+	// fresh, unrelated engine instead: RegisterMemoryBackendHooks reads the
+	// package-global auto-recall flag at registration time, so this proves
+	// buildAgent left that global set to true — not just that some other
+	// unrelated hook happens to share the event.
+	e := hooks.NewEngine(nil)
+	tools.RegisterMemoryBackendHooks(e)
+	if !e.Configured(hooks.EventUserPromptSubmit) {
+		t.Error("buildAgent should have refreshed the auto-recall global from this turn's config, not left the stale previous value")
+	}
+}
+
 func TestPrepareToolTurn_NoMemoryBackendConfigured(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{

--- a/internal/server/memory_backend_wiring_test.go
+++ b/internal/server/memory_backend_wiring_test.go
@@ -2,6 +2,10 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
@@ -9,6 +13,25 @@ import (
 	"github.com/open-octo/octo-agent/internal/hooks"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
+
+// hindsightRecallStub is a minimal httptest double for the hindsight recall
+// endpoint (see internal/memorybackend/hindsight.go's bankURL/Recall), used
+// so tests can drive a REAL auto-recall hook invocation end to end (real
+// HTTP round trip against localhost, no live network) and inspect its actual
+// output — rather than re-querying the tools package-global state after the
+// fact, which would pass even if the refresh under test ran too late (see
+// this function's/sibling tests' doc comments for why that check is unsound).
+func hindsightRecallStub(t *testing.T, marker string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{{"id": "m1", "text": marker, "scores": map[string]any{"final": 0.9}}},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
 
 // TestPrepareToolTurn_WiresMemoryBackend guards the serve path: unlike the CLI
 // (app.WireTools), the server wires tools in prepareToolTurn, so it must build
@@ -81,14 +104,27 @@ func TestPrepareToolTurn_WiresAutoRecall(t *testing.T) {
 // the global at false before calling buildAgent, with no prepareToolTurn call
 // at all, to prove buildAgent's own refresh (not prepareToolTurn's) is what
 // makes this work.
+//
+// Drives a REAL Inject() call against the returned agent's own a.Hooks and
+// checks for actual recalled content — not e.Configured(EventUserPromptSubmit)
+// on a.Hooks (the WorkflowNudger every session gets, unconditionally,
+// registers its own no-op-output hook on that same event — "configured"
+// would be true whether or not the auto-recall hook is there) and not a
+// freshly-built throwaway engine re-queried after buildAgent returns (that
+// only proves the global ends up correct eventually, not that THIS turn's
+// engine was built with the right value at registration time — verified this
+// is a real gap: temporarily moved buildAgent's refresh call to run after
+// RegisterMemoryBackendHooks and both of those alternate assertions still
+// passed).
 func TestBuildAgent_RefreshesAutoRecallBeforeRegisteringHooks(t *testing.T) {
 	setTestHome(t)
+	marker := "octo-agent lucky number is 47"
 	seedModels(t, config.Config{
 		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
 		DefaultModel: "gpt-4o",
 		MemoryBackend: config.MemoryBackendConfig{
 			Type:       "hindsight",
-			BaseURL:    "http://localhost:8888",
+			BaseURL:    hindsightRecallStub(t, marker),
 			AutoRecall: true,
 		},
 	})
@@ -102,19 +138,17 @@ func TestBuildAgent_RefreshesAutoRecallBeforeRegisteringHooks(t *testing.T) {
 	})
 
 	sess := agent.NewSession("gpt-4o", "")
-	srv.buildAgent(sess)
+	a := srv.buildAgent(sess)
 
-	// Don't inspect a.Hooks directly — the MEMORY.md injector also registers
-	// a hook on EventUserPromptSubmit, so Configured() there would pass even
-	// if buildAgent never refreshed the auto-recall flag at all. Build a
-	// fresh, unrelated engine instead: RegisterMemoryBackendHooks reads the
-	// package-global auto-recall flag at registration time, so this proves
-	// buildAgent left that global set to true — not just that some other
-	// unrelated hook happens to share the event.
-	e := hooks.NewEngine(nil)
-	tools.RegisterMemoryBackendHooks(e)
-	if !e.Configured(hooks.EventUserPromptSubmit) {
-		t.Error("buildAgent should have refreshed the auto-recall global from this turn's config, not left the stale previous value")
+	if a.Hooks == nil {
+		t.Fatal("buildAgent should set a.Hooks")
+	}
+	got := a.Hooks.Inject(context.Background(), hooks.Payload{
+		Event:     hooks.EventUserPromptSubmit,
+		UserInput: "what's my lucky number?",
+	})
+	if !strings.Contains(got, marker) {
+		t.Errorf("injected UserPromptSubmit text = %q, want it to contain the recalled marker %q — buildAgent must refresh the memory backend before registering hooks, not after", got, marker)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1132,6 +1132,13 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 		}
 	}
 
+	// Refresh the external memory backend from config before reading
+	// MemoryBackendGuidance()/registering its hooks below — both need this
+	// turn's config, not whatever the last turn (of any kind) left set. See
+	// refreshMemoryBackend's doc comment for why prepareToolTurn alone (which
+	// runs after this function returns) is one turn too late.
+	refreshMemoryBackend()
+
 	// L1: project memory embedded in the system prompt (stable across turns).
 	var memInjection string
 	if s.memDir != "" {
@@ -2542,6 +2549,13 @@ func (s *Server) runChannelIdleTurn(ctx context.Context, sess *channel.Session, 
 // typing-keepalive ticker the first time this chain's reply text reaches the
 // user (see channel.NewUIController).
 func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad channel.Adapter, ev channel.InboundEvent, content string, stopTyping func()) {
+	// Refresh the external memory backend from config — IM turns never go
+	// through prepareToolTurn (only WS/REST/cron do), so this is the only
+	// place that keeps it live for IM at all, not just on-time. Must run
+	// before MemoryBackendGuidance()/RegisterMemoryBackendHooks below; see
+	// refreshMemoryBackend's doc comment.
+	refreshMemoryBackend()
+
 	// Recompose the system prompt every turn so memory written and skills
 	// imported/toggled since server start are visible — web turns get this
 	// for free from buildAgent; the IM factory's compose-once snapshot went

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1939,26 +1939,19 @@ func (s *Server) initChannels() {
 // builds a fresh per-turn gate (configured mode + chat-interactive ask), the
 // same shape prepareToolTurn gives web turns. A factory-time gate would freeze
 // one policy snapshot for the session's whole life.
+// System/LeanSystem and CWD are deliberately NOT set here (unlike buildAgent):
+// runChannelTurns unconditionally recomposes both on every IM turn before the
+// first LLM call ever happens, so baking them here once at session-creation
+// time only produced a value nothing would ever read. MaxTokens and the
+// LiteSender/LiteModel resolved below have no such per-turn refresh anywhere
+// in the IM path, so they stay — this is genuinely the only place they're set
+// for the session's whole lifetime.
 func (s *Server) buildChannelFactory() func() *agent.Agent {
-	var memInjection string
-	if s.memDir != "" {
-		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
-	}
-	if g := tools.MemoryBackendGuidance(); g != "" {
-		memInjection = strings.TrimSpace(memInjection + "\n\n" + g)
-	}
 	return func() *agent.Agent {
 		defaultSender, model := s.defaultSenderAndModel()
 		a := agent.New(defaultSender, model)
-		cwd, envCtx := s.curCwdEnv()
-		a.CWD = cwd
 		a.MaxTokens = s.cfg.MaxTokens
-		// Loaded once and reused below for LiteSender resolution — see the
-		// matching comment on effectiveCoauthor's doc for why a second
-		// config.Load() here would be wasted work.
-		cfg, cfgErr := config.Load()
-		a.System, a.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), tools.MCPManifestFor(model), memInjection, s.effectiveCoauthor(cfg))
-		if cfgErr == nil {
+		if cfg, err := config.Load(); err == nil {
 			a.LiteSender, a.LiteModel = s.liteSenderFromConfig(cfg)
 			if a.LiteSender == nil {
 				if lm := app.ImplicitLiteModel(s.getProvider(), model, resolveBaseURL(s.getProvider(), cfg)); lm != "" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -527,6 +527,14 @@ func (s *Server) enableSubAgentTools() {
 	}
 	defaultSender, model := s.defaultSenderAndModel()
 	template := agent.New(defaultSender, model)
+	// Refresh before reading MemoryBackendGuidance() below — enableSubAgentTools
+	// runs at server startup (before any turn has ever called this) and once
+	// more after onboarding, so without this the sub-agent template's baked-in
+	// system prompt would never see the memory-backend guidance at all if it
+	// was configured before the first real turn, since spawned sub-agents
+	// reuse this template's System rather than recomposing it per spawn (see
+	// app.NewSpawner below).
+	app.RefreshMemoryBackend()
 	var memInjection string
 	if s.memDir != "" {
 		memInjection = memory.RenderInjection(s.memDir, s.homeMemDir)
@@ -1135,9 +1143,9 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 	// Refresh the external memory backend from config before reading
 	// MemoryBackendGuidance()/registering its hooks below — both need this
 	// turn's config, not whatever the last turn (of any kind) left set. See
-	// refreshMemoryBackend's doc comment for why prepareToolTurn alone (which
-	// runs after this function returns) is one turn too late.
-	refreshMemoryBackend()
+	// app.RefreshMemoryBackend's doc comment for why prepareToolTurn alone
+	// (which runs after this function returns) is one turn too late.
+	app.RefreshMemoryBackend()
 
 	// L1: project memory embedded in the system prompt (stable across turns).
 	var memInjection string
@@ -2553,8 +2561,8 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// through prepareToolTurn (only WS/REST/cron do), so this is the only
 	// place that keeps it live for IM at all, not just on-time. Must run
 	// before MemoryBackendGuidance()/RegisterMemoryBackendHooks below; see
-	// refreshMemoryBackend's doc comment.
-	refreshMemoryBackend()
+	// app.RefreshMemoryBackend's doc comment.
+	app.RefreshMemoryBackend()
 
 	// Recompose the system prompt every turn so memory written and skills
 	// imported/toggled since server start are visible — web turns get this

--- a/internal/server/subagent_test.go
+++ b/internal/server/subagent_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 
@@ -38,6 +39,65 @@ func TestEnableSubAgentToolsAdvertises(t *testing.T) {
 	}
 }
 
+// systemRecordingSender is scriptedSender plus capturing the `system` prompt
+// each call received, indexed by call order. Needed because
+// TestEnableSubAgentTools_RefreshesMemoryBackendBeforeBakingGuidance must
+// verify what actually got baked into the sub-agent template's System — not
+// re-read tools.MemoryBackendGuidance() after the fact, which would pass even
+// if enableSubAgentTools refreshed the backend too late (after baking), since
+// that global would still end up correct by the time the function returns.
+type systemRecordingSender struct {
+	mu      sync.Mutex
+	replies []agent.Reply
+	systems []string
+}
+
+func (s *systemRecordingSender) next(system string) agent.Reply {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.systems = append(s.systems, system)
+	var r agent.Reply
+	if len(s.systems)-1 < len(s.replies) {
+		r = s.replies[len(s.systems)-1]
+	} else {
+		r = agent.Reply{Content: "fallback"}
+	}
+	return r
+}
+
+func (s *systemRecordingSender) systemAt(i int) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if i < 0 || i >= len(s.systems) {
+		return ""
+	}
+	return s.systems[i]
+}
+
+func (s *systemRecordingSender) SendMessages(_ context.Context, _, system string, _ []agent.Message, _ int) (agent.Reply, error) {
+	return s.next(system), nil
+}
+
+func (s *systemRecordingSender) StreamMessages(_ context.Context, _, system string, _ []agent.Message, _ int, onChunk func(string), _ func(string)) (agent.Reply, error) {
+	r := s.next(system)
+	if onChunk != nil && r.Content != "" {
+		onChunk(r.Content)
+	}
+	return r, nil
+}
+
+func (s *systemRecordingSender) SendMessagesWithTools(_ context.Context, _, system string, _ []agent.Message, _ int, _ []agent.ToolDefinition) (agent.Reply, error) {
+	return s.next(system), nil
+}
+
+func (s *systemRecordingSender) StreamMessagesWithTools(_ context.Context, _, system string, _ []agent.Message, _ int, _ []agent.ToolDefinition, onChunk func(string), _ agent.ToolInputDeltaFunc, _ agent.ThinkingDeltaFunc) (agent.Reply, error) {
+	r := s.next(system)
+	if onChunk != nil && r.Content != "" {
+		onChunk(r.Content)
+	}
+	return r, nil
+}
+
 // TestEnableSubAgentTools_RefreshesMemoryBackendBeforeBakingGuidance guards a
 // related staleness bug found while fixing #1274: enableSubAgentTools bakes
 // tools.MemoryBackendGuidance() into the sub-agent template's System prompt
@@ -50,6 +110,19 @@ func TestEnableSubAgentToolsAdvertises(t *testing.T) {
 // first-ever invocation. Simulates that cold-start ordering directly: sets
 // the backend to nil (as it is before any turn or startup hook has touched
 // it) before calling enableSubAgentTools.
+//
+// Drives the spawn via tools.DefaultSubAgentManager().RunSync directly
+// (rather than srv.runTurn) with a plain context.Background(): a runTurn-driven
+// spawn goes through prepareToolTurn's CTX-SCOPED sub-agent manager (built
+// fresh per turn from buildAgent's own, already-correct agent — see #1133 /
+// resolveSubAgentManager), which takes priority over and completely bypasses
+// enableSubAgentTools's process-global manager, so it can't observe this
+// function's bug at all. Also inspects the system prompt the sub-agent's own
+// LLM call actually received, rather than re-querying
+// tools.MemoryBackendGuidance() after enableSubAgentTools returns (which
+// would pass even if the refresh ran too late to affect the baked template —
+// see this function's sibling tests in memory_backend_wiring_test.go and
+// channel_route_test.go for the same fix applied to buildAgent/runChannelTurns).
 func TestEnableSubAgentTools_RefreshesMemoryBackendBeforeBakingGuidance(t *testing.T) {
 	setTestHome(t)
 	seedModels(t, config.Config{
@@ -60,9 +133,15 @@ func TestEnableSubAgentTools_RefreshesMemoryBackendBeforeBakingGuidance(t *testi
 			BaseURL: "http://localhost:8888",
 		},
 	})
+
+	// The sub-agent's own reply (no tools) ends its loop after one call — the
+	// `system` param that call received (captured by systemRecordingSender)
+	// is what this test inspects.
+	sender := &systemRecordingSender{replies: []agent.Reply{{Content: "child result"}}}
+
 	srv := &Server{
 		cfg:       Config{Tools: true},
-		sender:    &stubSender{},
+		sender:    sender,
 		model:     "stub-model",
 		cwd:       t.TempDir(),
 		turnLocks: map[string]*sync.Mutex{},
@@ -77,8 +156,17 @@ func TestEnableSubAgentTools_RefreshesMemoryBackendBeforeBakingGuidance(t *testi
 
 	srv.enableSubAgentTools()
 
-	if g := tools.MemoryBackendGuidance(); g == "" {
-		t.Error("enableSubAgentTools should refresh the memory backend from config before reading MemoryBackendGuidance(), got empty guidance")
+	mgr := tools.DefaultSubAgentManager()
+	if mgr == nil {
+		t.Fatal("enableSubAgentTools should have registered a process-global SubAgentManager")
+	}
+	if _, err := mgr.RunSync(context.Background(), tools.SpawnRequest{Description: "d", Prompt: "do the sub task"}); err != nil {
+		t.Fatalf("RunSync: %v", err)
+	}
+
+	childSystem := sender.systemAt(0)
+	if !strings.Contains(childSystem, "Memory backend") {
+		t.Errorf("sub-agent's actual system prompt = %q, want it to contain the memory-backend guidance baked by enableSubAgentTools", childSystem)
 	}
 }
 

--- a/internal/server/subagent_test.go
+++ b/internal/server/subagent_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/config"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
 
@@ -34,6 +35,50 @@ func TestEnableSubAgentToolsAdvertises(t *testing.T) {
 		if !names[want] {
 			t.Errorf("expected %q to be advertised after enableSubAgentTools", want)
 		}
+	}
+}
+
+// TestEnableSubAgentTools_RefreshesMemoryBackendBeforeBakingGuidance guards a
+// related staleness bug found while fixing #1274: enableSubAgentTools bakes
+// tools.MemoryBackendGuidance() into the sub-agent template's System prompt
+// ONCE — at server startup, and again after onboarding — and spawned
+// sub-agents reuse that baked template rather than recomposing per spawn
+// (unlike buildAgent/runChannelTurns, which do recompose every turn). Without
+// refreshing the memory-backend globals first, a server that starts with
+// memory_backend already configured would still bake an empty guidance
+// block, because nothing had ever called the refresh before this function's
+// first-ever invocation. Simulates that cold-start ordering directly: sets
+// the backend to nil (as it is before any turn or startup hook has touched
+// it) before calling enableSubAgentTools.
+func TestEnableSubAgentTools_RefreshesMemoryBackendBeforeBakingGuidance(t *testing.T) {
+	setTestHome(t)
+	seedModels(t, config.Config{
+		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "gpt-4o",
+		MemoryBackend: config.MemoryBackendConfig{
+			Type:    "hindsight",
+			BaseURL: "http://localhost:8888",
+		},
+	})
+	srv := &Server{
+		cfg:       Config{Tools: true},
+		sender:    &stubSender{},
+		model:     "stub-model",
+		cwd:       t.TempDir(),
+		turnLocks: map[string]*sync.Mutex{},
+	}
+
+	tools.SetMemoryBackend(nil) // simulate cold start: nothing has refreshed this yet
+	t.Cleanup(func() {
+		tools.SetDefaultSubAgentManager(nil)
+		tools.SetTaskStore(nil)
+		tools.SetMemoryBackend(nil)
+	})
+
+	srv.enableSubAgentTools()
+
+	if g := tools.MemoryBackendGuidance(); g == "" {
+		t.Error("enableSubAgentTools should refresh the memory backend from config before reading MemoryBackendGuidance(), got empty guidance")
 	}
 }
 


### PR DESCRIPTION
## Summary

Live bug report: with `memory_backend.auto_recall: true` set, a Web UI turn still had the model
explicitly call `memory_recall` itself (visible tool-use badge) instead of the recall happening
silently via the new auto-recall hook — meaning the hook was never registered for that turn.

Root cause: `buildAgent` (serves Web/WS/REST/cron turns) and `runChannelTurns` (IM turns) both read
`tools.MemoryBackendGuidance()` and call `tools.RegisterMemoryBackendHooks` while building that
turn's system prompt and hook engine — and both run **before** `prepareToolTurn`, which was the
only place re-reading config and calling `tools.SetMemoryBackend`/`SetMemoryBackendAutoRecall`.
`RegisterMemoryBackendHooks` decides whether to register the auto-recall hook by reading the
package-global flag **at registration time**, so it always saw whatever the *previous* turn left
set — a permanent one-turn-stale window on every config change (not just a first-turn-after-boot
glitch), and IM turns never call `prepareToolTurn` at all, so they depended entirely on some other
turn type having run it first in the same process.

## Fix

- Extracted the refresh into `app.RefreshMemoryBackend()` (`internal/app/bootstrap.go`), called
  from `buildAgent`/`runChannelTurns`/`prepareToolTurn`/`enableSubAgentTools`
  (`internal/server/...`) **before** they touch `MemoryBackendGuidance()`/`RegisterMemoryBackendHooks`.
- Also fixes findings from two independent code-review rounds on this branch:
  1. **Duplicated config-wiring logic** — deduplicated against `internal/app/bootstrap.go`'s
     `WireTools`, which had the exact same field-mapping logic. One function now, called by both.
  2. **`enableSubAgentTools`'s template staleness** — it bakes `MemoryBackendGuidance()` into the
     sub-agent template's system prompt once at server startup; spawned sub-agents reuse that
     baked template rather than recomposing per spawn. Fixed with the same refresh call.
  3. **`buildChannelFactory` dead code** — its `System`/`LeanSystem`/`CWD` bake is provably dead
     (confirmed by grep, not assumed): `runChannelTurns` unconditionally overwrites all three every
     IM turn before any LLM call. Removed. `MaxTokens`/`LiteSender`/`LiteModel` stay — nothing else
     touches those for IM sessions.
  4. **All three regression tests were unsound** — a second review round found each one could be
     defeated by moving its subject function's refresh call to the *end* of the function (still
     passes, since the check re-queried global state *after* the function returned, which is
     correct by then regardless of internal ordering). Rewrote all three to inspect the actual
     frozen artifact via a real round trip against an in-process httptest hindsight stub, and
     manually re-ran the "move the call to the end" experiment against the fixed versions —
     confirmed each now goes red without the fix and green with it.

## Test plan
- [x] Every claim above (dead-code removal, no-deadlock in `enableSubAgentTools`, all 3 regression
      tests, the reordering-defeats-them finding) was independently verified by hand — either by
      grepping the whole tree for corroborating/contradicting evidence, or by temporarily patching
      the fix out, confirming red, and restoring — not taken on either review round's word alone.
- [x] `go test -race ./...` passes (full suite), `go vet ./...`, `gofmt -l .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)