### PR TITLE
fix(agent): TUI ctx% missing after resuming a session

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1808,14 +1808,14 @@ func (a *Agent) resetContextTrigger() {
 }
 
 // ContextUsage reports how full the model's context window is: used is the
-// most recently sent context size in tokens (reported by the provider), and
-// window is the model's approximate context-window size. Lets the TUI status
-// bar render a "ctx N%" gauge. window is always > 0.
+// most recently sent context size in tokens (reported by the provider), or,
+// before any turn has run in this process (e.g. right after resuming a
+// session), a heuristic estimate over the restored history — see
+// historyTokens. window is the model's approximate context-window size. Lets
+// the TUI status bar and the web UI render a "ctx N%" gauge. window is always
+// > 0.
 func (a *Agent) ContextUsage() (used, window int) {
-	a.usageMu.Lock()
-	used = a.lastInputTokens
-	a.usageMu.Unlock()
-	return used, contextWindow(a.Model)
+	return a.historyTokens(a.History.Snapshot()), contextWindow(a.Model)
 }
 
 // SessionCacheTokens returns the cumulative cache read/write token counts.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1815,7 +1815,16 @@ func (a *Agent) resetContextTrigger() {
 // the TUI status bar and the web UI render a "ctx N%" gauge. window is always
 // > 0.
 func (a *Agent) ContextUsage() (used, window int) {
-	return a.historyTokens(a.History.Snapshot()), contextWindow(a.Model)
+	a.usageMu.Lock()
+	real := a.lastInputTokens
+	a.usageMu.Unlock()
+	if real > 0 {
+		return real, contextWindow(a.Model)
+	}
+	// Only pay for the History snapshot + heuristic estimate when there's no
+	// real count yet (cold start) — this is called at TUI render-tick rate,
+	// where a real count is the common case.
+	return estimateMessages(a.History.Snapshot()), contextWindow(a.Model)
 }
 
 // SessionCacheTokens returns the cumulative cache read/write token counts.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1407,11 +1407,42 @@ func TestContextUsage_EstimatesFromHistoryBeforeFirstTurn(t *testing.T) {
 	}
 
 	used, window := a.ContextUsage()
-	if used <= 0 {
-		t.Errorf("ContextUsage used = %d, want > 0 (heuristic estimate over restored history)", used)
+	want := estimateMessages(a.History.Snapshot())
+	if used != want {
+		t.Errorf("ContextUsage used = %d, want %d (estimateMessages over restored history)", used, want)
 	}
 	if window <= 0 {
 		t.Errorf("ContextUsage window = %d, want > 0", window)
+	}
+}
+
+// A brand new session with no history yet must report used == 0, not a
+// nonzero estimate, or the TUI status bar's used > 0 guard would show a
+// misleading "ctx N%" for a conversation that hasn't started.
+func TestContextUsage_ZeroForEmptyHistory(t *testing.T) {
+	a := New(nil, "m")
+
+	if used, _ := a.ContextUsage(); used != 0 {
+		t.Errorf("ContextUsage used = %d, want 0 for empty history", used)
+	}
+}
+
+// ClearHistory must reset ContextUsage back to 0, not leave a stale estimate
+// or real count from before the /clear.
+func TestContextUsage_ZeroAfterClearHistory(t *testing.T) {
+	send := &fakeSender{reply: Reply{Content: "ok", InputTokens: 500}}
+	a := New(send, "m")
+	if _, err := a.Turn(context.Background(), "hi"); err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+	if used, _ := a.ContextUsage(); used == 0 {
+		t.Fatalf("ContextUsage used = 0 after a real turn, want > 0 (test setup broken)")
+	}
+
+	a.ClearHistory()
+
+	if used, _ := a.ContextUsage(); used != 0 {
+		t.Errorf("ContextUsage used = %d after ClearHistory, want 0", used)
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1394,6 +1394,27 @@ func TestContextUsage_IncludesCacheTokens(t *testing.T) {
 	}
 }
 
+// A resumed session (e.g. after -r on the CLI/TUI, or a fresh server process)
+// starts with lastInputTokens == 0 since no turn has run in this process yet.
+// ContextUsage must fall back to a heuristic estimate over the restored
+// history instead of reporting 0, or the TUI status bar's "ctx N%" segment
+// disappears entirely until the next turn completes — the bug this guards
+// against (it matches the web UI's own cold-start estimate in ws_handlers.go).
+func TestContextUsage_EstimatesFromHistoryBeforeFirstTurn(t *testing.T) {
+	a := New(nil, "m")
+	for i := 0; i < 50; i++ {
+		a.History.Append(Message{Role: "user", Content: strings.Repeat("word ", 200)})
+	}
+
+	used, window := a.ContextUsage()
+	if used <= 0 {
+		t.Errorf("ContextUsage used = %d, want > 0 (heuristic estimate over restored history)", used)
+	}
+	if window <= 0 {
+		t.Errorf("ContextUsage window = %d, want > 0", window)
+	}
+}
+
 // ─── Output-truncation recovery (layer 1) ──────────────────────────────────
 
 // truncToolDefs/exec: a minimal tool set so Run takes the runLoop path. The

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -35,6 +35,12 @@ const defaultContextWindow = 128_000
 // Tool Search threshold) without duplicating the model→window table.
 func ContextWindow(model string) int { return contextWindow(model) }
 
+// EstimateTokens exposes estimateMessages to other packages (e.g. the web
+// server's cold-start context-percent estimate for a resumed session with no
+// live Agent yet) so they share the exact same heuristic as compaction and
+// ContextUsage instead of maintaining a second implementation.
+func EstimateTokens(msgs []Message) int { return estimateMessages(msgs) }
+
 // contextWindow returns the approximate context-window size (in tokens) for a
 // model. Values are deliberately conservative; matched case-insensitively by
 // substring so dated/aliased names ("claude-haiku-4-5-2025…") still resolve.

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -189,29 +189,15 @@ func (s *Server) sendContextUsage(sessionID string, conn *wsConn) {
 }
 
 // estimateContextPct approximates how full the model's context window a
-// persisted transcript occupies, using a coarse chars/4 token heuristic. Used
-// only when no live token count is available.
+// persisted transcript occupies, using the same heuristic Agent.ContextUsage
+// falls back to (agent.EstimateTokens). Used only when no live token count is
+// available (no Agent has run in this process for the session yet).
 func estimateContextPct(sess *agent.Session) int {
 	window := agent.ContextWindow(sess.Model)
 	if window <= 0 {
 		return 0
 	}
-	chars := 0
-	for _, m := range sess.Messages {
-		chars += len(m.Content)
-		for _, b := range m.Blocks {
-			chars += len(b.Text) + len(b.Result) + len(b.Thinking) + len(b.Reasoning) + len(b.Name)
-			for k, v := range b.Input {
-				chars += len(k)
-				if str, ok := v.(string); ok {
-					chars += len(str)
-				} else {
-					chars += 16
-				}
-			}
-		}
-	}
-	return (chars / 4) * 100 / window
+	return agent.EstimateTokens(sess.Messages) * 100 / window
 }
 
 // replayLiveState replays in-progress agent state (progress + stdout) to a


### PR DESCRIPTION
## Summary
- TUI's status bar `ctx N%` segment disappeared entirely after resuming a session (`-r`) until a turn ran, because `Agent.ContextUsage()` had no fallback and returned `used == 0` — unlike the web UI, which already estimates from persisted messages in this cold-start case.
- `ContextUsage()` now reuses the existing `historyTokens()` heuristic fallback (real provider count when available, chars/4 estimate over the restored history otherwise), so TUI and web now agree.
- Collapsed the web server's duplicate chars/4 estimator (`estimateContextPct` in `internal/server/ws_handlers.go`) into a newly exported `agent.EstimateTokens`, so both surfaces share one heuristic instead of two copies that could drift.

## Test plan
- [x] `go test -race ./...` passes
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] New test `TestContextUsage_EstimatesFromHistoryBeforeFirstTurn` covers the cold-start fallback
- [x] Existing `TestContextUsage_IncludesCacheTokens` still passes (hot path unchanged)