### PR TITLE
fix(server): validate-then-swap cache for config.yml/permissions.yml hot reload

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -33,9 +33,11 @@ type ToolEnv struct {
 // tools.MemoryBackendGuidance()/tools.RegisterMemoryBackendHooks. A bad
 // Type/BaseURL just leaves the backend unconfigured rather than erroring;
 // cheap to call repeatedly (a lightweight REST client, not a persistent
-// connection).
+// connection). Uses LoadCached so a config.yml that's mid-edit and
+// momentarily invalid doesn't tear down a live serve session's memory
+// backend on the next turn — it keeps the last config that parsed.
 func RefreshMemoryBackend() {
-	cfg, cfgErr := config.Load()
+	cfg, cfgErr := config.LoadCached()
 	if cfgErr != nil || !cfg.MemoryBackendEnabled() {
 		return
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
@@ -481,6 +482,50 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 	return f.normalize(), nil
+}
+
+// lastGood caches the most recently successfully loaded Config for
+// LoadCached — see its doc comment.
+var lastGood struct {
+	mu  sync.Mutex
+	cfg Config
+	ok  bool
+}
+
+// LoadCached is Load with a validate-then-replace cache: octo serve re-reads
+// config.yml on every turn (so changes apply without a restart), but with no
+// cache a hand-edit that leaves invalid YAML mid-session would revert every
+// in-flight, config-derived feature (per-session model binding, the
+// compaction lite model, the coauthor flag, browser vision) to its hardcoded
+// default the instant the bad file is saved — a config typo turning into a
+// live behavior change across every session. LoadCached instead keeps
+// serving the last config that parsed cleanly until the file is fixed. Only
+// the very first call, before anything has loaded successfully, surfaces the
+// raw error, matching Load's own contract for that case.
+//
+// Callers that need the file's actual current state (validation UI, `octo
+// config show`) should call Load directly — LoadCached silently swallows a
+// load error into the cached value once one exists.
+func LoadCached() (Config, error) {
+	cfg, err := Load()
+	lastGood.mu.Lock()
+	defer lastGood.mu.Unlock()
+	if err == nil {
+		lastGood.cfg, lastGood.ok = cfg, true
+		return cfg, nil
+	}
+	if lastGood.ok {
+		return lastGood.cfg, nil
+	}
+	return Config{}, err
+}
+
+// resetLastGoodForTest clears LoadCached's cache so tests using different
+// HOME dirs in the same test binary don't leak state between each other.
+func resetLastGoodForTest() {
+	lastGood.mu.Lock()
+	defer lastGood.mu.Unlock()
+	lastGood.cfg, lastGood.ok = Config{}, false
 }
 
 // Save writes the config to ~/.octo/config.yml with mode 0600 (it may hold

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"errors"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -484,12 +485,14 @@ func Load() (Config, error) {
 	return f.normalize(), nil
 }
 
-// lastGood caches the most recently successfully loaded Config for
-// LoadCached — see its doc comment.
+// lastGood caches, per resolved config path, the most recently successfully
+// loaded Config for LoadCached — see its doc comment. Keyed by path (like
+// permission's cachedUserRules) rather than a single global value so tests
+// using different HOME dirs in the same binary can't leak cached state into
+// each other.
 var lastGood struct {
-	mu  sync.Mutex
-	cfg Config
-	ok  bool
+	mu     sync.Mutex
+	byPath map[string]Config
 }
 
 // LoadCached is Load with a validate-then-replace cache: octo serve re-reads
@@ -499,33 +502,44 @@ var lastGood struct {
 // compaction lite model, the coauthor flag, browser vision) to its hardcoded
 // default the instant the bad file is saved — a config typo turning into a
 // live behavior change across every session. LoadCached instead keeps
-// serving the last config that parsed cleanly until the file is fixed. Only
-// the very first call, before anything has loaded successfully, surfaces the
-// raw error, matching Load's own contract for that case.
+// serving the last config that parsed cleanly until the file is fixed,
+// logging a warning so the failure isn't entirely invisible. Only the very
+// first call, before anything has loaded successfully, surfaces the raw
+// error, matching Load's own contract for that case.
 //
 // Callers that need the file's actual current state (validation UI, `octo
 // config show`) should call Load directly — LoadCached silently swallows a
 // load error into the cached value once one exists.
 func LoadCached() (Config, error) {
 	cfg, err := Load()
+	path, pathErr := Path() // cache key; a Path() failure (no home dir) just skips caching
+
 	lastGood.mu.Lock()
 	defer lastGood.mu.Unlock()
+
 	if err == nil {
-		lastGood.cfg, lastGood.ok = cfg, true
+		if pathErr == nil {
+			if lastGood.byPath == nil {
+				lastGood.byPath = make(map[string]Config)
+			}
+			lastGood.byPath[path] = cfg
+		}
 		return cfg, nil
 	}
-	if lastGood.ok {
-		return lastGood.cfg, nil
+	if pathErr == nil {
+		if cached, ok := lastGood.byPath[path]; ok {
+			slog.Warn("config: config.yml failed to load, using last known good config until it's fixed", "path", path, "err", err)
+			return cached, nil
+		}
 	}
 	return Config{}, err
 }
 
-// resetLastGoodForTest clears LoadCached's cache so tests using different
-// HOME dirs in the same test binary don't leak state between each other.
+// resetLastGoodForTest clears LoadCached's cache (tests only).
 func resetLastGoodForTest() {
 	lastGood.mu.Lock()
 	defer lastGood.mu.Unlock()
-	lastGood.cfg, lastGood.ok = Config{}, false
+	lastGood.byPath = nil
 }
 
 // Save writes the config to ~/.octo/config.yml with mode 0600 (it may hold

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -197,6 +197,42 @@ func TestLoad_MalformedIsError(t *testing.T) {
 	}
 }
 
+func TestLoadCached_FallsBackToLastGoodOnParseError(t *testing.T) {
+	t.Cleanup(resetLastGoodForTest)
+	resetLastGoodForTest()
+	home := setHome(t)
+	writeOcto(t, home, "config.yml", "default_model: good-model\n")
+
+	cfg, err := LoadCached()
+	if err != nil {
+		t.Fatalf("LoadCached() first load = %v, want nil", err)
+	}
+	if cfg.DefaultModel != "good-model" {
+		t.Fatalf("LoadCached() first load DefaultModel = %q, want %q", cfg.DefaultModel, "good-model")
+	}
+
+	writeOcto(t, home, "config.yml", "not: valid: yaml: [")
+
+	cfg, err = LoadCached()
+	if err != nil {
+		t.Fatalf("LoadCached() after malformed edit = %v, want nil (fall back to last good)", err)
+	}
+	if cfg.DefaultModel != "good-model" {
+		t.Errorf("LoadCached() after malformed edit DefaultModel = %q, want cached %q", cfg.DefaultModel, "good-model")
+	}
+}
+
+func TestLoadCached_ErrorsWhenNothingCachedYet(t *testing.T) {
+	t.Cleanup(resetLastGoodForTest)
+	resetLastGoodForTest()
+	home := setHome(t)
+	writeOcto(t, home, "config.yml", "not: valid: yaml: [")
+
+	if _, err := LoadCached(); err == nil {
+		t.Error("LoadCached() with no prior good load and a malformed file = nil, want error")
+	}
+}
+
 func TestSetDefaultEntry(t *testing.T) {
 	var c Config
 

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -24,6 +24,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path"
@@ -102,6 +103,36 @@ type Rule struct {
 // RuleSet maps tool name → ordered list of rules.
 type RuleSet map[string][]Rule
 
+// lastGoodRules caches, per configPath, the most recently successfully
+// parsed *user* rule overrides (never the merged-with-defaults RuleSet New
+// builds) — see New's fallback logic.
+var lastGoodRules struct {
+	mu    sync.Mutex
+	rules map[string]RuleSet
+}
+
+func cachedUserRules(configPath string) (RuleSet, bool) {
+	lastGoodRules.mu.Lock()
+	defer lastGoodRules.mu.Unlock()
+	rules, ok := lastGoodRules.rules[configPath]
+	return rules, ok
+}
+
+func setCachedUserRules(configPath string, rules RuleSet) {
+	lastGoodRules.mu.Lock()
+	defer lastGoodRules.mu.Unlock()
+	if lastGoodRules.rules == nil {
+		lastGoodRules.rules = make(map[string]RuleSet)
+	}
+	lastGoodRules.rules[configPath] = rules
+}
+
+func clearCachedUserRules(configPath string) {
+	lastGoodRules.mu.Lock()
+	defer lastGoodRules.mu.Unlock()
+	delete(lastGoodRules.rules, configPath)
+}
+
 // Engine evaluates rules against tool calls and remembers session-level
 // decisions for "always allow this" style answers.
 type Engine struct {
@@ -131,12 +162,28 @@ func New(configPath string, cwd string, mode Mode, allowWriteRoots ...string) (*
 	}
 
 	if configPath != "" {
-		raw, err := os.ReadFile(configPath)
+		raw, readErr := os.ReadFile(configPath)
 		switch {
-		case err == nil:
-			user, err := loadRules(raw)
-			if err != nil {
-				return nil, fmt.Errorf("permission: parse %s: %w", configPath, err)
+		case readErr == nil:
+			user, parseErr := loadRules(raw)
+			if parseErr != nil {
+				// New is called fresh on every turn (octo serve has no
+				// restart hook for a config change to take effect), so with
+				// no fallback a single typo saved mid-edit would deny/ask
+				// every tool call on every live session the instant the
+				// file hits disk — permission.New callers treat an error
+				// here as "abort the turn", never "run ungated" (see
+				// server.go's prepareToolTurn/runChannelTurns). Falling
+				// back to the last rules that DID parse keeps serve
+				// running on the previous good policy instead.
+				if cached, ok := cachedUserRules(configPath); ok {
+					slog.Warn("permission: permissions.yml has a parse error, using last known good rules until it's fixed", "path", configPath, "err", parseErr)
+					user = cached
+				} else {
+					return nil, fmt.Errorf("permission: parse %s: %w", configPath, parseErr)
+				}
+			} else {
+				setCachedUserRules(configPath, user)
 			}
 			// User rules override defaults per-tool. (Full-replace per
 			// tool, not append — keeps "I want to allow rm -rf in this
@@ -144,10 +191,20 @@ func New(configPath string, cwd string, mode Mode, allowWriteRoots ...string) (*
 			for tool, rs := range user {
 				rules[tool] = rs
 			}
-		case os.IsNotExist(err):
-			// Fall through with defaults only.
+		case os.IsNotExist(readErr):
+			// Deleted → no override is the correct state, not "temporarily
+			// broken"; drop any cached rules so a later parse error against
+			// a recreated file doesn't resurrect a deleted config.
+			clearCachedUserRules(configPath)
 		default:
-			return nil, fmt.Errorf("permission: read %s: %w", configPath, err)
+			if cached, ok := cachedUserRules(configPath); ok {
+				slog.Warn("permission: failed to read permissions.yml, using last known good rules until it's fixed", "path", configPath, "err", readErr)
+				for tool, rs := range cached {
+					rules[tool] = rs
+				}
+			} else {
+				return nil, fmt.Errorf("permission: read %s: %w", configPath, readErr)
+			}
 		}
 	}
 

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -155,6 +155,12 @@ var defaultsYAML []byte
 // for tests. allowWriteRoots are extra directories (e.g. the per-repo memory
 // directory, which lives outside CWD) whose contents the agent may write/edit
 // without a prompt; each gets a prepended allow rule on write_file / edit_file.
+//
+// If configPath fails to read or parse but a previous call for the same path
+// already loaded successfully, New falls back to those last known good user
+// rules instead of erroring — see the fallback logic below. Only the very
+// first call for a given path, before anything has loaded successfully,
+// returns the raw error.
 func New(configPath string, cwd string, mode Mode, allowWriteRoots ...string) (*Engine, error) {
 	rules, err := loadRules(defaultsYAML)
 	if err != nil {

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -387,6 +387,40 @@ terminal:
 	}
 }
 
+func TestNew_FallsBackToLastGoodRulesOnReadError(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "permissions.yml")
+	yml := `
+terminal:
+  - allow: { pattern: "" }   # blanket allow
+`
+	if err := os.WriteFile(cfg, []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := New(cfg, "/work", ModeInteractive); err != nil {
+		t.Fatalf("first New() = %v, want nil", err)
+	}
+
+	// Replace the file with a directory of the same name: os.ReadFile now
+	// fails with something other than "not exist", exercising the `default:`
+	// branch (as opposed to the parse-error branch above).
+	if err := os.Remove(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	e, err := New(cfg, "/work", ModeInteractive)
+	if err != nil {
+		t.Fatalf("New() after read error = %v, want nil (fall back to last known good)", err)
+	}
+	if got := e.Check("terminal", map[string]any{"command": "rm -rf /"}); got != Allow {
+		t.Errorf("New() after read error should keep last good rules (blanket allow), got %s", got)
+	}
+}
+
 func TestNew_DeletedConfigDropsCachedRules(t *testing.T) {
 	dir := t.TempDir()
 	cfg := filepath.Join(dir, "permissions.yml")

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -354,6 +354,73 @@ func TestNew_InvalidYAMLErrors(t *testing.T) {
 	}
 }
 
+func TestNew_FallsBackToLastGoodRulesOnParseError(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "permissions.yml")
+	yml := `
+terminal:
+  - allow: { pattern: "" }   # blanket allow
+`
+	if err := os.WriteFile(cfg, []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e, err := New(cfg, "/work", ModeInteractive)
+	if err != nil {
+		t.Fatalf("first New() = %v, want nil", err)
+	}
+	if got := e.Check("terminal", map[string]any{"command": "rm -rf /"}); got != Allow {
+		t.Fatalf("first New() should have the blanket allow, got %s", got)
+	}
+
+	// A hand-edit mid-session leaves the file momentarily invalid.
+	if err := os.WriteFile(cfg, []byte("not: valid: yaml: ["), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e2, err := New(cfg, "/work", ModeInteractive)
+	if err != nil {
+		t.Fatalf("New() after parse error = %v, want nil (fall back to last known good)", err)
+	}
+	if got := e2.Check("terminal", map[string]any{"command": "rm -rf /"}); got != Allow {
+		t.Errorf("New() after parse error should keep last good rules (blanket allow), got %s", got)
+	}
+}
+
+func TestNew_DeletedConfigDropsCachedRules(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "permissions.yml")
+	yml := `
+terminal:
+  - allow: { pattern: "" }   # blanket allow
+`
+	if err := os.WriteFile(cfg, []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(cfg, "/work", ModeInteractive); err != nil {
+		t.Fatalf("first New() = %v, want nil", err)
+	}
+
+	if err := os.Remove(cfg); err != nil {
+		t.Fatal(err)
+	}
+	e, err := New(cfg, "/work", ModeInteractive)
+	if err != nil {
+		t.Fatalf("New() after delete = %v, want nil", err)
+	}
+	if got := e.Check("terminal", map[string]any{"command": "rm -rf /"}); got != Deny {
+		t.Errorf("New() after delete should NOT resurrect the deleted blanket allow, want default rule (Deny), got %s", got)
+	}
+
+	// The cache stays cleared even if the file comes back malformed.
+	if err := os.WriteFile(cfg, []byte("not: valid: yaml: ["), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(cfg, "/work", ModeInteractive); err == nil {
+		t.Error("New() with a malformed file and no live cache should error, not silently use the deleted config's rules")
+	}
+}
+
 func TestLoadRules_RejectsMultipleClausesPerRule(t *testing.T) {
 	yml := []byte(`
 terminal:

--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -57,7 +57,9 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 	// this is the only place serve learns whether the model can take images — a
 	// text-only model would otherwise be handed a screenshot it rejects (HTTP
 	// 400). Re-evaluated per turn so a mid-session model switch takes effect.
-	cfg, cfgErr := config.Load()
+	// LoadCached so a config.yml that's momentarily invalid mid-edit keeps
+	// the last vision setting that parsed instead of silently going stale.
+	cfg, cfgErr := config.LoadCached()
 	if cfgErr == nil {
 		tools.SetBrowserVision(cfg.ModelVision(a.Model))
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1118,11 +1118,13 @@ func (s *Server) buildAgent(sess *agent.Session) *agent.Agent {
 		a.ArchiveDir = dir // recall folded turns via the read tool
 	}
 	// Loaded once and reused below for effectiveCoauthor — a second
-	// config.Load() there would re-read and re-parse the same file. A load
-	// error leaves cfg at its zero value, which EffectiveCoauthor still
-	// resolves correctly (OCTO_COAUTHOR checked before falling back to the
-	// built-in default), so callers don't need a separate error branch for it.
-	cfg, cfgErr := config.Load()
+	// config.Load() there would re-read and re-parse the same file.
+	// LoadCached (not Load): a config.yml that currently fails to parse
+	// falls back to the last one that did, so a hand-edit typo degrades the
+	// lite-model/coauthor resolution below to stale-but-correct settings
+	// instead of the hardcoded defaults every live session would otherwise
+	// revert to for as long as the file stays broken.
+	cfg, cfgErr := config.LoadCached()
 	if cfgErr == nil {
 		a.LiteSender, a.LiteModel = s.liteSenderFromConfig(cfg)
 		if a.LiteSender == nil {
@@ -1371,7 +1373,7 @@ func (s *Server) senderForSession(sess *agent.Session) (agent.Sender, string) {
 		return defaultSender, model
 	}
 
-	cfg, err := config.Load()
+	cfg, err := config.LoadCached()
 	if err != nil {
 		return defaultSender, model
 	}
@@ -1434,7 +1436,7 @@ func senderForEntry(entry config.ModelEntry) (agent.Sender, error) {
 	if apiKey == "" {
 		return nil, fmt.Errorf("no API key for model %q (provider %q)", entry.Model, entry.Provider)
 	}
-	cfg, _ := config.Load()
+	cfg, _ := config.LoadCached()
 	return app.NewSender(app.SenderOptions{
 		Provider:        entry.Provider,
 		APIKey:          apiKey,
@@ -2586,8 +2588,8 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		memInjection = strings.TrimSpace(memInjection + "\n\n" + g)
 	}
 	cwd, envCtx := s.sessionCwdEnv(sess.Store)
-	sess.Agent.CWD = cwd    // keep tool cwd aligned with the per-session dir the prompt/hooks use
-	cfg, _ := config.Load() // zero value on error still resolves correctly via EffectiveCoauthor
+	sess.Agent.CWD = cwd          // keep tool cwd aligned with the per-session dir the prompt/hooks use
+	cfg, _ := config.LoadCached() // zero value on error (no last-good yet) still resolves correctly via EffectiveCoauthor
 	sess.Agent.System, sess.Agent.LeanSystem = prompt.ComposePair(s.system, cwd, envCtx, s.curSkillsManifest(), tools.MCPManifestFor(sess.Agent.Model), memInjection, s.effectiveCoauthor(cfg))
 
 	// L2 memory hooks + shell hooks, same engine buildAgent gives web turns,


### PR DESCRIPTION
## Summary

`octo serve` re-reads `~/.octo/config.yml` and `~/.octo/permissions.yml` on every turn (there's no restart hook for a config change to take effect on a long-running server), but neither had any caching — a hand-edit that momentarily leaves invalid YAML on disk took effect the instant it was saved:

- **`permissions.yml` — a real outage.** `permission.New`'s callers (`prepareToolTurn` for Web, `runChannelTurns` for IM) treat a build error as "abort the turn" by design — running ungated is never an acceptable fallback. So a single typo denied every tool call on every live Web/IM session the moment the file hit disk, with no restart needed to trigger it.
- **`config.yml` — smaller but still real.** Call sites already degrade to hardcoded defaults on a load error (no turn-aborting), but a bad edit still reverted per-session model bindings, the compaction lite model, and the coauthor flag to defaults for as long as the file stayed broken.

## What changed

- `internal/config.LoadCached()` — new function alongside `Load()`. Validates before replacing: on success it updates an in-memory "last known good" `Config` and returns it; on failure it returns the last known good value with a nil error, so callers on the per-turn hot path degrade gracefully instead of erroring. Only the very first-ever call (nothing cached yet) surfaces the raw error, matching `Load()`'s existing contract for that case. `Load()` itself is untouched — every caller that wants the file's real current state (tests, `octo config show`, the onboarding UI) keeps that exact behavior.
- `internal/permission.New()` — same pattern, scoped to the parsed *user* rule overrides (not the merged-with-defaults RuleSet): a parse/read error falls back to the last successfully parsed rules if any exist, logging a warning instead of aborting the turn. Deleting the file clears the cache (so a deleted override doesn't come back from a later parse error) rather than resurrecting stale rules.
- Swapped the genuinely per-turn hot-path call sites to the cached versions: `buildAgent`, `senderForSession`, `senderForEntry`, `runChannelTurns` (server.go), `prepareToolTurn` (handlers_prepare_toolturn.go), and `RefreshMemoryBackend` (app/bootstrap.go, shared by both the CLI's one-time call and serve's per-turn call). Left one-time/startup-only/config-change-only call sites (`NewServer` construction, `enableMCP`, `syncGoalsEnabled`, `resolveProviderAndModel`, `buildChannelFactory`) on the raw, fail-visible `Load()`/`New()` — they don't run per turn, so there's no live-session blast radius to protect against, and startup errors should stay loud.

## Test plan
- [x] New tests: `TestLoadCached_FallsBackToLastGoodOnParseError`, `TestLoadCached_ErrorsWhenNothingCachedYet` (config); `TestNew_FallsBackToLastGoodRulesOnParseError`, `TestNew_DeletedConfigDropsCachedRules` (permission)
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./internal/config/... ./internal/permission/... ./internal/server/... ./internal/app/...`
- [x] `go test -race ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)