### PR TITLE
fix(workflows): make parallel-understand target required

### DIFF
--- a/internal/tools/workflow_defaults/parallel-understand.rb
+++ b/internal/tools/workflow_defaults/parallel-understand.rb
@@ -1,11 +1,11 @@
-# @description Map a codebase in parallel — fan out one reader per subsystem, then synthesize a single architecture map. args (all optional): target (what to map, default = this repo), subsystems (array to skip auto-detection), focus (a question to bias the map toward).
-# @param target: What to map (optional — defaults to this repository).
+# @description Map a codebase in parallel — fan out one reader per subsystem, then synthesize a single architecture map. args: target (required, what to map), subsystems (array to skip auto-detection), focus (a question to bias the map toward).
+# @param target required: Path or name of the repository / directory to map.
 # @param subsystems: Array of subsystem names, to skip auto-detection (optional).
 # @param focus: A question to bias the map toward (optional).
 
 # ---- inputs -----------------------------------------------------------------
 a      = args || {}
-target = a["target"] || "this repository"
+target = a["target"]
 focus  = a["focus"].to_s
 
 SUBSYS_SCHEMA = JSON.generate({

--- a/internal/tools/workflow_execution_test.go
+++ b/internal/tools/workflow_execution_test.go
@@ -82,7 +82,7 @@ func TestEmbeddedDefaultWorkflows_Execute(t *testing.T) {
 		args string // JSON; "" means the script's `args` primitive returns nil
 	}
 	runs := []run{
-		{"parallel-understand", ""},
+		{"parallel-understand", `{"target": "test"}`},
 		{"batch-migrate", `{"change": "test"}`},
 		{"daily-triage", ""},
 	}

--- a/internal/tools/workflow_registry_test.go
+++ b/internal/tools/workflow_registry_test.go
@@ -229,6 +229,21 @@ func containsName(names []string, want string) bool {
 	return false
 }
 
+// TestLookupWorkflow_ParallelUnderstandDeclaresRequiredTarget pins that the
+// embedded parallel-understand preset declares its required "target" arg via
+// `# @param`, so the workflow tool prompts for it up front instead of silently
+// mapping a non-git "this repository" default.
+func TestLookupWorkflow_ParallelUnderstandDeclaresRequiredTarget(t *testing.T) {
+	useWorkflowRoots(t, "", "")
+	w, ok := lookupWorkflow(context.Background(), "parallel-understand")
+	if !ok {
+		t.Fatal("parallel-understand not found")
+	}
+	if req := requiredParamNames(w.params); len(req) != 1 || req[0] != "target" {
+		t.Errorf("parallel-understand required params = %v, want [target]", req)
+	}
+}
+
 // TestLookupWorkflow_BatchMigrateDeclaresRequiredChange pins that the
 // embedded batch-migrate preset declares its required "change" arg via
 // `# @param`, so the workflow tool prompts for it up front instead of


### PR DESCRIPTION
The `parallel-understand` workflow previously defaulted its `target` to `"this repository"`, which is meaningless when the current directory is not a git repo. Mark `target` as a required arg so the workflow tool prompts for it up front instead of silently running against a non-repo.

Changes:
- `internal/tools/workflow_defaults/parallel-understand.rb`: declare `# @param target required` and drop the fallback to `"this repository"`.
- `internal/tools/workflow_registry_test.go`: add `TestLookupWorkflow_ParallelUnderstandDeclaresRequiredTarget` to pin the declaration.

Tests:
```
go test ./internal/tools/ -run TestLookupWorkflow_ParallelUnderstandDeclaresRequiredTarget -v
# PASS
go test ./internal/tools/
# PASS
```

Co-authored-by: octo-agent <no-reply@octo-agent.dev>