### PR TITLE
docs(blog): add onboarding series 9-10 — Browser setup and Record & Replay

### DIFF
--- a/blog/src/content/posts/en/onboarding-browser-record-and-replay.md
+++ b/blog/src/content/posts/en/onboarding-browser-record-and-replay.md
@@ -1,0 +1,104 @@
+---
+title: "Octo Onboarding Series (10): Record & Replay in Practice — Record Your Actions Once, Let octo Replay Them"
+description: "Record a browser workflow you'd otherwise do by hand, distill it into a replayable, self-healing script — the next time it comes up, octo just clicks through it."
+pubDate: 2026-07-18
+author: "octo-agent team"
+tags: ["onboarding", "octo-agent", "browser"]
+locale: en
+originalSlug: onboarding-browser-record-and-replay
+---
+
+# Octo Onboarding Series (10): Record & Replay in Practice — Record Your Actions Once, Let octo Replay Them
+
+> The last post wired up the browser — fine for a one-off task where octo can just watch and click live. But if you do the same sequence every week, having the model re-observe-and-decide every single time is wasted work. This post covers recording it once so it can replay on its own — and fix its own selectors when they drift.
+
+---
+
+## It records what you do, not what the model does
+
+This is the single most important thing to understand about the mechanism: once you call `record_start`, octo **hands the browser back to you**. You perform the steps yourself, say "done," and only then does it call `record_stop <name>` to save what happened. octo doesn't drive the page itself during recording — it watches and takes notes, it doesn't act.
+
+Each step captures: the action type (`click`/`type`/`select`/`upload`/`navigate`, and so on), a selector anchored to the nearest ancestor element with a stable `id` (rather than a positional selector chain that breaks the moment the page layout shifts), that element's visible text at the time, and the URL it happened on.
+
+## One click in the web UI
+
+You don't need to remember the `record_start`/`record_stop` action names — the "Browser" panel in the web UI has a "● Record" button. Clicking it opens a fresh chat whose first message spells the whole flow out for octo: confirm the browser is connected, ask what to record and what to name it, call `record_start`, hand control to you, and `record_stop` once you say you're done.
+
+Next to every saved recording in that same panel:
+
+- **"▶ Replay"** — calls `run_skill` by name, through the full agent path (the self-heal mechanism covered below only kicks in on this path — it's not a server-side replay that bypasses the model).
+- **"✎ Edit"** — also conversational: it reads the recording's YAML, lists the steps for you, and you say what to change (fix a selector, add/remove/reorder a step, set a param's default), and it writes the file back without replaying it on your behalf.
+
+## What a saved recording looks like
+
+The raw recording goes through one model pass — dropping detours that led nowhere, swapping the concrete values you typed for `{{param}}` placeholders, and writing a description — but this pass can only **reorder or rename steps that were actually recorded**, never invent a new one: any step whose selector isn't in the original recording gets rejected outright, falling back to the raw step instead.
+
+The distilled result is saved as plain YAML at `~/.octo/browser-skills/<name>.yaml` — readable, hand-editable, diffable in git. Roughly:
+
+```yaml
+name: submit-expense-report
+description: Log into the expense system and submit a standard reimbursement form
+params:
+  - name: amount
+    description: Reimbursement amount
+    default: "128.00"
+  - name: memo
+    description: Reason for the expense
+outputs:
+  - name: receipt_url
+    type: string
+steps:
+  - action: navigate
+    url: https://expense.example.com/new
+  - action: click
+    selector: "#category-travel"
+    label: Pick the "Travel" category
+  - action: type
+    selector: "#amount"
+    hint: Reimbursement amount
+    value: "{{amount}}"
+  - action: type
+    selector: "#memo"
+    hint: Reason field
+    value: "{{memo}}"
+  - action: click
+    selector: "#submit-btn"
+    verify:
+      text: Submitted successfully
+  - action: extract
+    js: document.querySelector('.receipt-link').href
+    bind: receipt_url
+```
+
+`params` are replay-time inputs you can override; `{{amount}}`/`{{memo}}` in the steps get substituted with whatever's passed in, falling back to `default` when nothing is. `hint` is that form field's accessible name (placeholder/name/aria-label/id, or its associated `<label>` text) — when the positionally-recorded `selector` drifts, replay tries relocating the field by `hint` before handing off to self-heal (covered below). `outputs` declares the values this recording exposes to whoever calls it; a step like `extract`/`download` can bind its result to a named output via `bind` for a downstream step to consume.
+
+## What makes replay trustworthy
+
+```
+browser(action: "run_skill", name: "<recording-name>", params: { ... })
+```
+
+In the common case replay is deterministic and involves no model call at all: each step waits for its target to appear before acting, and runs a `verify` check if one was declared. A few robustness details worth knowing:
+
+- A click first looks for the exact selector from the original recording; if the page structure has drifted a bit but an element carrying that same recorded visible text still exists, it clicks that instead of failing outright.
+- If a step opens a new tab, subsequent steps automatically follow onto it.
+- If a field comes back empty right after typing into it, replay clears and retries once before actually calling the step a failure.
+
+Replay is all-or-nothing by design — octo is explicitly instructed to only use a recording when the request matches it **start to finish**; it won't execute a partial subset, or improvise beyond the declared params. Recordings are also replay-only: there's no keyword trigger for this path (an earlier version tried one and it was pulled — not reliable enough).
+
+## When the selector is truly gone — self-heal
+
+If a step's selector and its `hint` both come up empty — and only when a model is configured specifically for this purpose — octo takes a plain-text summary of the page's currently interactive elements (selectors + visible text, no screenshot), sends it along with the intended action, the expected label, and the selector that just failed, and asks the model to reply with nothing but a corrected CSS selector. The fix gets one retry, and on success it's **written straight back into the recording's YAML file** — so a self-heal is a permanent fix, not a one-time patch; every future replay skips re-healing the same thing.
+
+## Wiring it into a workflow
+
+A recording's `outputs` can be plugged straight into [the workflow scripts from the previous post in this series](/blog/posts/en/onboarding-workflow-parallel-review/) via `skill("browser:<name>", params)` — record "log in and export the invoice," bind the exported file's path as an output, and hand it to another agent to parse and summarize in the next step, with no manual hand-off in between.
+
+---
+
+## End of the series
+
+Ten posts in: install, Skills, MCP, Loop, Cron, the weekly-report capstone, Workflow, Goal, Browser, and Record & Replay — covering both the "ask once, keep pushing on its own" spectrum and a second, completely different capability: going from "calling a tool" to "actually operating a web page for you." Which one fits depends on the task in front of you: a one-off question just gets asked directly; something that needs repeated checking gets `/loop`; something on a schedule gets cron; something that splits into independent chunks gets workflow; something you can't fully scope up front gets a goal; and anything with no API, only a UI, gets a browser connection you can drive live or record once and replay forever.
+
+**Previous in the series**: [Octo Onboarding Series (9): Browser in Practice — Hand octo Your Own Browser](/blog/posts/en/onboarding-browser-setup/)
+**Back to the start**: [Octo Onboarding Series (1): Install It, Say Your First Word to It](/blog/posts/en/onboarding-install-and-first-run/)

--- a/blog/src/content/posts/en/onboarding-browser-setup.md
+++ b/blog/src/content/posts/en/onboarding-browser-setup.md
@@ -1,0 +1,82 @@
+---
+title: "Octo Onboarding Series (9): Browser in Practice — Hand octo Your Own Browser"
+description: "The browser tool isn't another headless framework — it attaches to your real, already-logged-in Chrome, and a click or form submit is treated as a real action that needs approval."
+pubDate: 2026-07-17
+author: "octo-agent team"
+tags: ["onboarding", "octo-agent", "browser"]
+locale: en
+originalSlug: onboarding-browser-setup
+---
+
+# Octo Onboarding Series (9): Browser in Practice — Hand octo Your Own Browser
+
+> The first eight posts all covered tasks with something to call — files, shell, MCP, workflows, goals. But a lot of everyday work has no API at all: clicking through an internal admin panel, filling in a form on a site that only has a UI. octo can only help there once it has a real browser to drive. This post sets that up.
+
+---
+
+## Not another headless-browser framework
+
+octo's `browser` tool drives a real Chrome tab directly over the Chrome DevTools Protocol (CDP) — no Puppeteer, no Playwright, no extra runtime to install. That's not an implementation detail, it's a capability difference: it operates on **the Chrome you're already signed into**, not a blank, cookie-less automation profile. Whatever you're logged into on some internal system, octo can just use it.
+
+## One command to wire it up
+
+```bash
+octo browser setup
+```
+
+This walks you to `chrome://inspect/#remote-debugging` and has you tick "Allow remote debugging for this browser instance" (Chrome 144+ disabled the old `--remote-debugging-port` flag on the default profile, so the inspect-page checkbox is the supported path today), restarting the browser if needed. Once ticked, `octo browser setup` probes port 9222 in a loop — and it checks more than "did it connect": it makes an actual page-level CDP call, because on recent Chrome a browser-level connection can succeed while page control still fails. Once that succeeds, the port is saved to your config, so every future `octo` run reuses it without repeating this step.
+
+If you don't finish right away, that's fine — the command waits for you to confirm the toggle is on, retries on Enter, or quits any time on `q`. Run `octo browser setup` again whenever you're ready.
+
+## Connect order: three paths, none silently downgrade into the next
+
+The `browser` tool tries, in a fixed order, to get hold of a page it can drive:
+
+1. **A known debug port** (`browser.connect_port` in config) — connects directly; a failure here does not fall through to the next option. This is the path `octo browser setup` wires up for you.
+2. **Attach to an already-running, remote-debugging-enabled Chrome** (`browser.attach_running: true`) — reuses your logged-in session, but only ever attaches to a browser that already opted into debugging; it will never hijack an ordinary Chrome window that didn't.
+3. **Launch a brand-new temporary profile** — the fallback when neither of the above is configured or reachable, with none of your logins.
+
+The matching config lives in `~/.octo/config.yml`:
+
+```yaml
+browser:
+  attach_running: true   # reuse your logged-in Chrome instead of a temp profile
+  connect_port: 9222      # or attach via --remote-debugging-port
+  headless: false          # off by default — interactive workflows need to be watchable/interruptible
+  user_data_dir: ""
+  exec_path: ""
+  download_dir: ""
+```
+
+Every field has a matching CLI flag for a one-off override without touching the config file.
+
+Whichever path connects, octo always opens a **brand-new tab** rather than reusing one you already have open (including its own web UI's tab) — to drive an existing tab, call `pages`/`select_page` explicitly. The connection is reused for the whole session, and the debugger authorization prompt only appears once, not on every navigation.
+
+## Just say what you need — it figures out where to click
+
+You don't need to know a single CSS selector; just describe the task:
+
+```text
+Open the internal ticketing system and mark ticket #4821 as done.
+```
+
+Under the hood, octo roughly: `navigate`s to the target page → `observe`s (or, at a lower level, `ax` — the accessibility tree) to see which elements are actually interactive and what their real selectors are → `click`/`type`/`select`s to carry out the action → `wait`s for async content, either a fixed timeout or `network_idle`, which settles once the page's fetch/XHR traffic actually stops — much more robust than waiting a fixed delay and hoping.
+
+A few actions worth calling out specifically:
+
+- **Uploading a file** goes through `upload`, passing an absolute path straight to the file `<input>`, rather than clicking an upload button — a click opens a native OS file dialog that can't be automated.
+- **Reading something inside shadow DOM, or anything `click`/`type` can't reach**, `eval` runs a raw JS expression and gets you past what CSS selectors can't pierce.
+- If a step opens a new tab (say, a link that opens in a new window), subsequent actions automatically follow onto that new tab — no manual `select_page` needed.
+
+## Permissions and vision
+
+Browser actions go through the exact same permission engine as every other tool — clicking or submitting a form on a logged-in account is treated as a real, high-impact action that needs approval, not waved through as read-only. Screenshots only actually hand an image to the model when the active model supports vision; a text-only model gets a plain text note instead of an image block it would just reject.
+
+---
+
+## Next: record it once, replay it forever
+
+Once the browser is wired up, a one-off task is fine to let octo watch-and-click through live. But if you do the same thing every week — filling out a weekly report, exporting an invoice — having the model re-observe-and-decide every single time is wasted work. The next post covers **recording** that sequence once, distilling it into a script that replays deterministically and can even fix its own selectors.
+
+**Previous in the series**: [Octo Onboarding Series (8): Goal in Practice — Set a Standing Objective and Let It Find Idle Time to Push On](/blog/posts/en/onboarding-goal-long-running-migration/)
+**Next in the series**: [Octo Onboarding Series (10): Record & Replay in Practice — Record Your Actions Once, Let octo Replay Them](/blog/posts/en/onboarding-browser-record-and-replay/)

--- a/blog/src/content/posts/en/onboarding-goal-long-running-migration.md
+++ b/blog/src/content/posts/en/onboarding-goal-long-running-migration.md
@@ -83,9 +83,9 @@ With it disabled, `/goal` explicitly reports itself as unavailable rather than s
 
 ---
 
-## End of the series
+## Next: a whole different class of task
 
-Eight posts in, and install, Skills, MCP, Loop, Cron, the weekly-report capstone, Workflow, and Goal cover the main shapes work can take — from "ask once, get an answer" to "keep pushing on its own." Which one fits depends on the task in front of you: a one-off question just gets asked directly; something that needs repeated checking gets `/loop`; something that fires on its own schedule gets cron; something that splits into independent chunks gets workflow; and something you can't fully scope up front, that needs several passes spread across idle time, gets a goal.
+Eight posts in, and install, Skills, MCP, Loop, Cron, the weekly-report capstone, Workflow, and Goal cover the main shapes work can take on the "ask once, get an answer" to "keep pushing on its own" spectrum — but all of it is still text, code, and tool calls under the hood. There's a whole other class of work with no API at all: clicking through an internal admin panel, filling in a form on a site that's only a UI. That's not something a tool call covers — it takes an actual pair of hands driving a browser. The next two posts turn there.
 
 **Previous in the series**: [Octo Onboarding Series (7): Workflow in Practice — Get Several Agents Working in Parallel](/blog/posts/en/onboarding-workflow-parallel-review/)
-**Back to the start**: [Octo Onboarding Series (1): Install It, Say Your First Word to It](/blog/posts/en/onboarding-install-and-first-run/)
+**Next in the series**: [Octo Onboarding Series (9): Browser in Practice — Hand octo Your Own Browser](/blog/posts/en/onboarding-browser-setup/)

--- a/blog/src/content/posts/zh/onboarding-browser-record-and-replay.md
+++ b/blog/src/content/posts/zh/onboarding-browser-record-and-replay.md
@@ -1,0 +1,104 @@
+---
+title: "Octo 上手系列（十）：Record & Replay 实战——录一遍你的操作，以后让 octo 自己回放"
+description: "把你亲手做一遍的浏览器操作录下来，蒸馏成一段可回放、能自愈的脚本——下次同样的事，octo 自己点完。"
+pubDate: 2026-07-18
+author: "octo-agent team"
+tags: ["onboarding", "octo-agent", "browser"]
+locale: zh
+originalSlug: onboarding-browser-record-and-replay
+---
+
+# Octo 上手系列（十）：Record & Replay 实战——录一遍你的操作，以后让 octo 自己回放
+
+> 上一篇把浏览器接上了，遇到一次性的任务，直接让 octo 边看边点就够了。但同一套操作如果你自己每周都要点一遍，每次都让模型重新"观察-决定-点击"就是在浪费——这一篇讲怎么录一遍，让它以后自己回放，选择器失效了还能自己修。
+
+---
+
+## 录的是你做的操作，不是模型做的操作
+
+这是理解这套机制最关键的一点：调用 `record_start` 之后，octo 会把浏览器**交还给你**，由你亲手完成这几步操作，说一声"做完了"之后，它才调用 `record_stop <名字>` 把过程保存下来。录制期间 octo 不会自己驱动页面——它在旁边看着记，不代劳。
+
+每一步会记录：动作类型（`click`/`type`/`select`/`upload`/`navigate` 这些）、一个锚定在最近的、带稳定 `id` 的祖先元素上的选择器（而不是那种一变页面结构就失效的、按位置算出来的选择器链）、这个元素当时的可见文本，以及所在的 URL。
+
+## 网页界面一键开录
+
+不用记住 `record_start`/`record_stop` 这两个动作名——网页界面的"浏览器"面板里有一个"● 录制"按钮，点一下会开一个新的对话，第一句话就是把这套流程说给 octo 听：先确认浏览器已连接，问你想录什么、起什么名字，调 `record_start` 之后把控制权交给你，等你说完成了再 `record_stop` 保存。
+
+同一个面板上，每条已保存的录制旁边还有：
+
+- **"▶ 回放"**——按名字调 `run_skill`，走的是完整的 agent 路径（后面会讲到的自愈机制也在这条路径里生效），不是绕开模型的服务端直接重放。
+- **"✎ 编辑"**——同样是对话式的：读取录制对应的 YAML，把步骤列给你看，你说要改哪一步、加/删/重排哪一步、给哪个参数设默认值，改完写回文件，不会顺手帮你回放一遍。
+
+## 一段录制存下来长什么样
+
+原始录制会经过一次模型处理——把绕路的死胡同去掉、把你当时输入的具体值换成 `{{参数名}}` 占位符、补一段描述——但这一步只能**重新排列或重命名真实录到的步骤**，不能凭空造一个新目标：任何一步如果它的选择器不在原始录制里，就会被直接拒绝，退回用原始步骤。
+
+蒸馏完存成纯 YAML，放在 `~/.octo/browser-skills/<名字>.yaml`——可读、可手改、能用 git 追踪差异。大致长这样：
+
+```yaml
+name: submit-expense-report
+description: 登录报销系统，填一张标准报销单并提交
+params:
+  - name: amount
+    description: 报销金额
+    default: "128.00"
+  - name: memo
+    description: 报销事由
+outputs:
+  - name: receipt_url
+    type: string
+steps:
+  - action: navigate
+    url: https://expense.example.com/new
+  - action: click
+    selector: "#category-travel"
+    label: 选择"差旅"分类
+  - action: type
+    selector: "#amount"
+    hint: 报销金额
+    value: "{{amount}}"
+  - action: type
+    selector: "#memo"
+    hint: 事由说明
+    value: "{{memo}}"
+  - action: click
+    selector: "#submit-btn"
+    verify:
+      text: 提交成功
+  - action: extract
+    js: document.querySelector('.receipt-link').href
+    bind: receipt_url
+```
+
+`params` 是回放时可以覆盖的输入，步骤里的 `{{amount}}`/`{{memo}}` 会被替换成调用时传的值，没传就退回 `default`；`hint` 是这个表单字段的无障碍名字（placeholder/name/aria-label/id 或者关联的 `<label>` 文字）——当按位置记下的 `selector` 失效时，回放会先按这个再定位一次，实在不行才交给下面说的自愈；`outputs` 声明了这段录制对外暴露的值，`extract`/`download` 这类步骤可以把结果通过 `bind` 绑定给一个具名的 output，供下游取用。
+
+## 回放怎么保证靠谱
+
+```
+browser(action: "run_skill", name: "<录制名>", params: { ... })
+```
+
+常见情况下回放是确定性的，不涉及模型调用：每一步先等目标出现再执行，声明了 `verify` 的话还会做一次校验。几个值得知道的健壮细节：
+
+- 点击先按原始录制里的选择器找；如果页面结构有点变化，但一个带着录制时那段可见文字的元素还在，就点那个元素，而不是直接判失败。
+- 某一步打开了新标签页，后续步骤会自动跟到新标签页上。
+- 输入之后如果字段意外变成空的，会先清空重打一次，再失败才真正判定这一步失败。
+
+回放是"要么整段做完，要么不做"——octo 被明确指示只有当请求和一段录制**从头到尾**完全匹配时才用它，不会只执行一部分、也不会在声明的参数之外自己发挥。录制也只能显式回放，没有关键词触发这条路（早期版本试过又撤了，不够可靠）。
+
+## 选择器彻底失效了呢——自愈
+
+如果某一步的选择器和 `hint` 都找不到东西了——并且只有在配置了专门用于这个用途的模型时——octo 会对页面当前可交互的元素取一份纯文本摘要（选择器 + 可见文本，不截图），连同预期动作、预期的文字标签、失效的旧选择器一起发给模型，让它只回一个修正后的 CSS 选择器。修正会被重试一次，成功的话会**直接写回这段录制的 YAML 文件**——所以一次自愈是持久生效的，不是临时补丁，以后每次回放都不用再修一遍。
+
+## 接进 workflow
+
+一段录制的 `outputs` 可以通过 `skill("browser:<名字>", params)` 直接接进[上一篇系列讲过的 workflow 脚本](/blog/posts/onboarding-workflow-parallel-review/)——比如录一段"登录后台导出账单"，把导出的文件路径当 output 绑出来，下一步再交给另一个 agent 去解析、汇总，整条链路就不用你手动衔接。
+
+---
+
+## 系列到这里
+
+十篇下来，装机、Skills、MCP、Loop、Cron、实战合体、Workflow、Goal、Browser、Record & Replay——覆盖了从"问一次答一次"到"持续自主推进"，也覆盖了从"调用工具"到"真的替你操作一个网页"这两条完全不同的能力线。挑哪一种，取决于你手上的任务长什么样：一次性的问题直接问；要反复盯着用 `/loop`；按时间表触发用 cron；能拆开并行跑用 workflow；说不清楚要几轮的长任务交给 goal；没有 API 只有网页的操作，接上浏览器直接让它点，重复做的事录一遍让它自己回放。
+
+**系列上一篇**：[Octo 上手系列（九）：Browser 实战——把你自己的浏览器接给 octo](/blog/posts/onboarding-browser-setup/)
+**系列开头**：[Octo 上手系列（一）：装好它，跟它说上第一句话](/blog/posts/onboarding-install-and-first-run/)

--- a/blog/src/content/posts/zh/onboarding-browser-setup.md
+++ b/blog/src/content/posts/zh/onboarding-browser-setup.md
@@ -1,0 +1,82 @@
+---
+title: "Octo 上手系列（九）：Browser 实战——把你自己的浏览器接给 octo"
+description: "浏览器工具不是又一个 headless 框架——它直接接上你已登录的真实 Chrome，点击、填表、传文件都算一次正儿八经要审批的操作。"
+pubDate: 2026-07-17
+author: "octo-agent team"
+tags: ["onboarding", "octo-agent", "browser"]
+locale: zh
+originalSlug: onboarding-browser-setup
+---
+
+# Octo 上手系列（九）：Browser 实战——把你自己的浏览器接给 octo
+
+> 前八篇覆盖的都是文件、终端、MCP、workflow、goal 这类"有接口可调"的任务。但日常里还有一大类事完全没有接口——登录一个内部后台点几下、在一个只有网页表单的系统里填信息——octo 能做的前提是先给它接上一个真正的浏览器。这一篇就来把这件事办了。
+
+---
+
+## 不是又一个 headless 浏览器框架
+
+octo 的 `browser` 工具通过 Chrome DevTools Protocol（CDP）直接操作一个真实的 Chrome 标签页——不依赖 Puppeteer、Playwright 这类 headless 框架，也不需要额外装任何运行时。这个区别不是实现细节，是能力上的区别：它操作的是**你自己在用的、已经登录好的那个 Chrome**，而不是一个从零开始、什么 cookie 都没有的匿名自动化环境。你在某个内部系统里的登录态，octo 直接就能用。
+
+## 一条命令把它接上
+
+```bash
+octo browser setup
+```
+
+这个命令会带你打开 `chrome://inspect/#remote-debugging`，勾选"Allow remote debugging for this browser instance"（Chrome 144 之后，默认 profile 上原来那个 `--remote-debugging-port` 命令行参数被禁用了，走 inspect 页面的这个勾选框是目前能用的路径），必要时重启一下浏览器。勾完之后，`octo browser setup` 会在本地 9222 端口反复探测——注意，它验证的不只是"连上了"，还会真正发一次页面级的 CDP 调用确认可用，因为在新版 Chrome 上，浏览器级的连接可能成功，但页面控制那一层还是会失败。探测成功后，端口号会存进你的配置，以后每次开 octo 都直接复用，不用再走一遍这个流程。
+
+如果一时半会没弄好也没关系：命令会停下来等你确认已经打开开关，回车重试，或者随时按 `q` 退出，下次想起来了再跑一遍 `octo browser setup` 就行。
+
+## 连接顺序：三条路径，不会帮你偷偷降级
+
+`browser` 工具按固定顺序尝试拿到一个可操作的页面：
+
+1. **已知的调试端口**（配置里的 `browser.connect_port`）——直接连，这条失败了不会自动退到下一条。这就是 `octo browser setup` 帮你接好的那条路。
+2. **接入一个已经在跑、开了远程调试的 Chrome**（`browser.attach_running: true`）——复用你的登录态；但只会接一个原本就开了调试的浏览器，绝不会去劫持一个没开调试的普通 Chrome 窗口。
+3. **启动一个全新的临时 profile**——前两条都没配或者都连不上时的兜底选项，没有你的任何登录态。
+
+对应的配置写在 `~/.octo/config.yml` 里：
+
+```yaml
+browser:
+  attach_running: true   # 复用你已登录的 Chrome，而不是用一个临时 profile
+  connect_port: 9222      # 或者通过 --remote-debugging-port 接入
+  headless: false          # 默认关闭——交互式工作流需要能看到、能介入
+  user_data_dir: ""
+  exec_path: ""
+  download_dir: ""
+```
+
+每一项都有对应的 CLI flag，可以在单次运行时临时覆盖，不用改配置文件。
+
+不管走的是哪条路径，octo 都会打开一个**全新标签页**，而不是复用你已经开着的某个标签页（包括它自己网页界面的那个）——要操作一个已经开着的标签页，得显式调用 `pages`/`select_page` 这两个动作去选。连接会在整个会话里复用，调试器的授权提示只会跳一次，不会每次导航都弹一遍。
+
+## 直接说需求，它自己决定点哪里
+
+你不需要知道 CSS 选择器长什么样，直接描述任务就行：
+
+```text
+帮我打开内部工单系统，把 #4821 这张工单的状态改成"已完成"。
+```
+
+octo 拿到这句话后，大致是这样一步步来的：`navigate` 打开目标页面 → `observe`（或者更底层的 `ax`，读无障碍树）看清页面上真正存在哪些可交互元素、它们的选择器长什么样 → `click`/`type`/`select` 完成实际操作 → 需要等异步内容加载完时用 `wait`（可以是固定超时，也可以让它按 `network_idle` 等到页面的 fetch/XHR 活动真正停下来，这比死等一个固定时间靠谱）。
+
+几个容易被问到的动作单独说一下：
+
+- **上传文件**用 `upload` 直接传一个绝对路径给文件 `<input>`，而不是让它去点上传按钮——点按钮弹出的是系统原生文件选择框，是没法被自动化驱动的。
+- **要读一段 shadow DOM 里的内容，或者 `click`/`type` 够不到的地方**，`eval` 可以直接跑一段 JS，拿到 CSS 选择器穿不透的东西。
+- 页面上开了新标签页（比如点了一个"在新窗口打开"的链接），后续动作会自动跟到新标签页上，不用你手动 `select_page`。
+
+## 权限与视觉能力
+
+浏览器动作走的是和其他工具完全一样的权限引擎——在一个已登录账号上点击或者提交表单，会被当成一次真实的、影响很大的操作去审批，而不是被当作只读的一步蒙混过去。截图这个动作只有在当前模型支持视觉能力时才会真的把图片传给模型；纯文本模型拿到的是一句文字提示，而不会收到一个它处理不了、会被直接拒绝的图片内容块。
+
+---
+
+## 下一篇：录一遍，让它自己回放
+
+浏览器接上之后，遇到一次性的任务，直接让 octo 边看边点就够了。但如果同一套操作你自己每周都要点一遍——填一份周报、导一次账单——每次都让模型重新"观察-决定-点击"就有点浪费了。下一篇讲怎么把这套操作**录一遍**，蒸馏成一段可以直接回放、还能自己修选择器的脚本。
+
+**系列上一篇**：[Octo 上手系列（八）：Goal 实战——定一个长期目标，让它自己找空闲时间推进](/blog/posts/onboarding-goal-long-running-migration/)
+**系列下一篇**：[Octo 上手系列（十）：Record & Replay 实战——录一遍你的操作，以后让 octo 自己回放](/blog/posts/onboarding-browser-record-and-replay/)

--- a/blog/src/content/posts/zh/onboarding-goal-long-running-migration.md
+++ b/blog/src/content/posts/zh/onboarding-goal-long-running-migration.md
@@ -83,9 +83,9 @@ goal:
 
 ---
 
-## 系列到这里
+## 下一篇：一整类完全不同的任务
 
-八篇下来，装机、Skills、MCP、Loop、Cron、实战合体、Workflow、Goal——覆盖了从"问一次答一次"到"持续自主推进"的几种主要形状。挑哪一种，取决于你手上的任务长什么样：一次性的用一句话直接问；要反复盯着用 `/loop`；要按时间表触发用 cron；能拆开并行跑用 workflow；说不清楚要几轮、需要跨会话持续推进的，交给 goal。
+八篇下来，装机、Skills、MCP、Loop、Cron、实战合体、Workflow、Goal，覆盖的都是"问一次答一次"到"持续自主推进"这条线上的几种主要形状——本质上还是文本、代码、工具调用能解决的任务。但还有一大类事完全没有接口：登录一个内部后台点几下、在只有网页表单的系统里填信息，不是"调用工具"能覆盖的，得真的有一双手去操作浏览器。接下来两篇转向这个方向。
 
 **系列上一篇**：[Octo 上手系列（七）：Workflow 实战——写一个脚本，让几个 agent 一起并行干活](/blog/posts/onboarding-workflow-parallel-review/)
-**系列开头**：[Octo 上手系列（一）：装好它，跟它说上第一句话](/blog/posts/onboarding-install-and-first-run/)
+**系列下一篇**：[Octo 上手系列（九）：Browser 实战——把你自己的浏览器接给 octo](/blog/posts/onboarding-browser-setup/)


### PR DESCRIPTION
## Summary
- Adds two new posts (zh + en) to the Octo Onboarding series:
  - **(9) Browser in Practice** — connecting a real, logged-in Chrome via CDP (`octo browser setup`, the three-tier connect order, the `browser:` config block), and the core action set (navigate/click/type/upload/eval/...) with a concrete example.
  - **(10) Record & Replay in Practice** — `record_start`/`record_stop` semantics, the web UI's Record/Replay/Edit buttons, the recorded-skill YAML shape (verified against `internal/browser/skill.go`'s actual field names), replay's determinism/robustness, self-heal, and bridging a recording's outputs into a workflow script.
- Technical claims are grounded in `internal/tools/browser.go` (action enum), `cmd/octo/browser.go` (setup flow), `internal/browser/skill.go` (YAML schema), `docs/.../guides/browser-automation.mdx`, and the web UI's `BrowserView.svelte`/i18n strings — not invented.
- Updates post 8 (Goal)'s closing section, which previously declared itself the end of the series ("系列到这里" / "End of the series") — now transitions into the two new posts instead, with its footer pointing forward to post 9. The wrap-up summary moves to the new post 10.
- Rebased the working changes onto latest `main` (which had since merged #1289's goal-chip screenshot removal) so post 8 doesn't resurrect the now-deleted image reference.

## Test plan
- [x] `npm run build` in `blog/` — 26 pages generated cleanly (no broken content-schema fields, no dangling image refs)
- [x] Manually verified every technical claim (action names, config keys, YAML field names, CLI flow, UI button behavior) against the actual source instead of writing from memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)