### PR TITLE
fix(server): replay sub-agent tool history on WebSocket subscribe

### DIFF
--- a/internal/server/live_replay_test.go
+++ b/internal/server/live_replay_test.go
@@ -456,6 +456,25 @@ func (s *blockingSpawner) Continue(ctx context.Context, _, _ string) (tools.Spaw
 	return tools.SpawnResult{}, nil
 }
 
+// toolEmittingBlockingSpawner blocks like blockingSpawner, but emits a single
+// tool-level sub-agent event before blocking so the replay can be tested.
+type toolEmittingBlockingSpawner struct{ block <-chan struct{} }
+
+func (s *toolEmittingBlockingSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
+	if sink := tools.SubAgentEventSink(ctx); sink != nil {
+		sink(tools.SubAgentEvent{Kind: "tool", ToolName: "read_file", ToolInput: map[string]any{"path": "go.mod"}})
+	}
+	select {
+	case <-s.block:
+	case <-ctx.Done():
+	}
+	return tools.SpawnResult{Reply: "done"}, nil
+}
+
+func (s *toolEmittingBlockingSpawner) Continue(ctx context.Context, _, _ string) (tools.SpawnResult, error) {
+	return tools.SpawnResult{}, nil
+}
+
 // TestReplayLiveState_ReplaysRunningSubAgent is the regression guard for the
 // same gap in the sub-agent panel: SubAgentOnEvent also broadcasts directly
 // with no buffering, so a tab that (re)subscribes after a sub-agent already
@@ -486,5 +505,78 @@ func TestReplayLiveState_ReplaysRunningSubAgent(t *testing.T) {
 	}
 	if !sawStarted {
 		t.Error("replay did not include the sub-agent's started event")
+	}
+}
+
+// TestReplayLiveState_ReplaysSubAgentToolHistory checks that switching back
+// to a session with a running sub-agent restores the tool trail, not just a
+// coarse "started" stub.
+func TestReplayLiveState_ReplaysSubAgentToolHistory(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "replay-subagent-tool-history-session"
+	defer tools.CloseSessionSubAgentManager(sid)
+
+	block := make(chan struct{})
+	defer close(block)
+	mgr := tools.SessionSubAgentManager(sid, func() tools.Spawner { return &toolEmittingBlockingSpawner{block: block} })
+
+	id, err := mgr.Start(tools.SpawnRequest{
+		Description: "test sub-agent",
+		Prompt:      "do it",
+		AgentType:   "explore",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for the goroutine to emit the tool event and enter the block.
+	waitFor(t, func() bool {
+		infos := mgr.ListRunning()
+		for _, in := range infos {
+			if in.ID == id {
+				for _, ev := range in.Events {
+					if ev.Kind == "tool" {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	})
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.replayLiveState(sid, conn)
+
+	var sawStarted, sawTool bool
+	for _, ev := range drainConn(t, conn) {
+		if ev["type"] != "sub_agent_event" || ev["agent_id"] != id {
+			continue
+		}
+		switch ev["kind"] {
+		case "started":
+			if ev["agent_type"] != "explore" {
+				t.Errorf("replayed started agent_type = %v, want explore", ev["agent_type"])
+			}
+			sawStarted = true
+		case "tool":
+			if ev["tool_name"] != "read_file" {
+				t.Errorf("replayed tool tool_name = %v, want read_file", ev["tool_name"])
+			}
+			input, ok := ev["tool_input"].(map[string]any)
+			if !ok || input["path"] != "go.mod" {
+				t.Errorf("replayed tool tool_input = %v, want {path: go.mod}", ev["tool_input"])
+			}
+			sawTool = true
+		case "done":
+			t.Error("replay should not include done events for running agents")
+		}
+	}
+	if !sawStarted {
+		t.Error("replay did not include the sub-agent's started event")
+	}
+	if !sawTool {
+		t.Error("replay did not include the sub-agent's tool event")
 	}
 }

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -254,22 +254,27 @@ func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
 	// no buffering, so a late-subscribing tab misses a still-running
 	// sub-agent entirely. mkSpawner is nil: this must never create a
 	// session's sub-agent manager just to discover it's empty — nil back
-	// means no sub-agent has run in this session yet. SubAgentInfo doesn't
-	// retain agent_type or per-tool history, so the replay is coarser than
-	// the live stream (the panel will show the agent as running without its
-	// tool trail), but that beats not showing it at all.
+	// means no sub-agent has run in this session yet. Replay the retained
+	// tool-level events (excluding the terminal "done") so the panel shows
+	// the current tool trail, not just a coarse "started" stub.
 	if sam := tools.SessionSubAgentManager(sessionID, nil); sam != nil {
 		for _, sa := range sam.ListRunning() {
-			if b, err := json.Marshal(map[string]any{
-				"type":        "sub_agent_event",
-				"session_id":  sessionID,
-				"agent_id":    sa.ID,
-				"description": sa.Description,
-				"agent_type":  "",
-				"kind":        "started",
-				"tool_name":   "",
-			}); err == nil {
-				conn.send <- b
+			for _, ev := range sa.Events {
+				if ev.Kind == "done" {
+					continue
+				}
+				if b, err := json.Marshal(map[string]any{
+					"type":        "sub_agent_event",
+					"session_id":  sessionID,
+					"agent_id":    sa.ID,
+					"description": ev.Description,
+					"agent_type":  ev.AgentType,
+					"kind":        ev.Kind,
+					"tool_name":   ev.ToolName,
+					"tool_input":  ev.ToolInput,
+				}); err == nil {
+					conn.send <- b
+				}
 			}
 		}
 	}

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -29,8 +29,10 @@ type SubAgentNotification struct {
 type SubAgentInfo struct {
 	ID          string
 	Description string
+	AgentType   string
 	Start       time.Time
 	Busy        bool
+	Events      []SubAgentEvent
 }
 
 // asyncSubAgent tracks one detached sub-agent launched via SubAgentManager.
@@ -51,6 +53,21 @@ type asyncSubAgent struct {
 	stopReason   string // "max_turns" when the loop budget was exhausted
 	inputTokens  int
 	outputTokens int
+	events       []SubAgentEvent // retained tool-level events for late-joining clients
+}
+
+func (a *asyncSubAgent) recordEvent(ev SubAgentEvent) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.events = append(a.events, ev)
+}
+
+func (a *asyncSubAgent) listEvents() []SubAgentEvent {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]SubAgentEvent, len(a.events))
+	copy(out, a.events)
+	return out
 }
 
 func (a *asyncSubAgent) setResult(result string, inputTokens, outputTokens int) {
@@ -475,13 +492,16 @@ func (m *SubAgentManager) SetOnEvent(fn func(SubAgentEvent)) {
 	m.mu.Unlock()
 }
 
-// eventSink builds the per-agent sink stamped into the spawn context. Returns
-// nil when no onEvent hook is set, so the spawner skips streaming entirely.
+// eventSink builds the per-agent sink stamped into the spawn context. The sink
+// always records events on the agent so late-joining subscribers can replay
+// the tool trail; it forwards them to the live onEvent hook when one is set.
+// Returns nil only when the agent no longer exists.
 func (m *SubAgentManager) eventSink(id, description, agentType string) func(SubAgentEvent) {
 	m.mu.Lock()
+	agent := m.agents[id]
 	onEvent := m.onEvent
 	m.mu.Unlock()
-	if onEvent == nil {
+	if agent == nil {
 		return nil
 	}
 	return func(ev SubAgentEvent) {
@@ -492,7 +512,10 @@ func (m *SubAgentManager) eventSink(id, description, agentType string) func(SubA
 		if ev.AgentType == "" {
 			ev.AgentType = agentType
 		}
-		onEvent(ev)
+		agent.recordEvent(ev)
+		if onEvent != nil {
+			onEvent(ev)
+		}
 	}
 }
 
@@ -752,8 +775,10 @@ func (m *SubAgentManager) ListRunning() []SubAgentInfo {
 			out = append(out, SubAgentInfo{
 				ID:          a.id,
 				Description: a.description,
+				AgentType:   a.agentType,
 				Start:       a.start,
 				Busy:        busy,
+				Events:      a.listEvents(),
 			})
 		}
 	}


### PR DESCRIPTION
## Problem

Switching between sessions in the web UI caused the sub-agent panel to lose the running sub-agent's tool-call history. The panel showed the agent as running, but with "0 tools".

## Root cause

- `SubAgentManager` only retained basic metadata (`ID`, `Description`, `Busy`, ...); it did not store the `started` / `tool` / `tool_error` events.
- When a browser tab (re)subscribed to a session, `replayLiveState` could only send a coarse `started` event, so the panel had no tool trail.

## Changes

- `internal/tools/subagent_manager.go`
  - `asyncSubAgent` now stores every `SubAgentEvent` it receives.
  - `eventSink` records each event on the agent before forwarding it to the live `onEvent` hook.
  - `SubAgentInfo` exposes `AgentType` and `Events`.
- `internal/server/ws_handlers.go`
  - Replay all non-`done` events for each running sub-agent on subscribe, restoring the full tool chain.
- `internal/server/live_replay_test.go`
  - Added `TestReplayLiveState_ReplaysSubAgentToolHistory` as a regression guard.

## Verification

- `make test` passes.
- New regression test verifies that `started` and `tool` events are both replayed, including `tool_input`.

---

Co-authored-by: octo-agent <no-octo-agent.dev>