### PR TITLE
fix(workflows): make daily-triage repo required

### DIFF
--- a/internal/tools/workflow_defaults/daily-triage.rb
+++ b/internal/tools/workflow_defaults/daily-triage.rb
@@ -1,10 +1,10 @@
-# @description Run a daily triage loop: discover open issues and recent CI failures, categorize them, draft safe fixes in isolated git worktrees, verify them with a second agent, and write a state report. args: repo (optional path to git repo, defaults to current directory), since (optional "Nh" or "Nd" lookback, e.g. "24h" or "1d", default "1d").
-# @param repo: Path to the git repo (optional — defaults to the current directory).
+# @description Run a daily triage loop: discover open issues and recent CI failures, categorize them, draft safe fixes in isolated git worktrees, verify them with a second agent, and write a state report. args: repo (required, path to git repo), since (optional "Nh" or "Nd" lookback, e.g. "24h" or "1d", default "1d").
+# @param repo required: Path to the git repo to triage.
 # @param since: Lookback window, e.g. "24h" or "1d" (optional — defaults to "1d").
 
 # ---- inputs -----------------------------------------------------------------
 a          = args || {}
-repo       = a["repo"].to_s.empty? ? "./" : a["repo"]
+repo       = a["repo"]
 since      = a["since"].to_s.empty? ? "1d" : a["since"]
 STATE_REL  = ".octo/daily-triage-state.md"
 

--- a/internal/tools/workflow_execution_test.go
+++ b/internal/tools/workflow_execution_test.go
@@ -84,7 +84,7 @@ func TestEmbeddedDefaultWorkflows_Execute(t *testing.T) {
 	runs := []run{
 		{"parallel-understand", `{"target": "test"}`},
 		{"batch-migrate", `{"change": "test"}`},
-		{"daily-triage", ""},
+		{"daily-triage", `{"repo": "test"}`},
 	}
 
 	for _, r := range runs {

--- a/internal/tools/workflow_registry_test.go
+++ b/internal/tools/workflow_registry_test.go
@@ -244,6 +244,21 @@ func TestLookupWorkflow_ParallelUnderstandDeclaresRequiredTarget(t *testing.T) {
 	}
 }
 
+// TestLookupWorkflow_DailyTriageDeclaresRequiredRepo pins that the
+// embedded daily-triage preset declares its required "repo" arg via
+// `# @param`, so the workflow tool prompts for it up front instead of
+// silently triaging the current directory.
+func TestLookupWorkflow_DailyTriageDeclaresRequiredRepo(t *testing.T) {
+	useWorkflowRoots(t, "", "")
+	w, ok := lookupWorkflow(context.Background(), "daily-triage")
+	if !ok {
+		t.Fatal("daily-triage not found")
+	}
+	if req := requiredParamNames(w.params); len(req) != 1 || req[0] != "repo" {
+		t.Errorf("daily-triage required params = %v, want [repo]", req)
+	}
+}
+
 // TestLookupWorkflow_BatchMigrateDeclaresRequiredChange pins that the
 // embedded batch-migrate preset declares its required "change" arg via
 // `# @param`, so the workflow tool prompts for it up front instead of


### PR DESCRIPTION
The `daily-triage` workflow previously defaulted its `repo` to the current directory (`"./"`), which is meaningless when the current directory is not a git repo. Mark `repo` as a required arg so the workflow tool prompts for it up front instead of silently running against a non-repo.

Changes:
- `internal/tools/workflow_defaults/daily-triage.rb`: declare `# @param repo required` and drop the fallback to `"./"`.
- `internal/tools/workflow_execution_test.go`: pass `{"repo": "test"}` for the daily-triage execution test.
- `internal/tools/workflow_registry_test.go`: add `TestLookupWorkflow_DailyTriageDeclaresRequiredRepo` to pin the declaration.

Tests:
```
go test ./internal/tools/ -run TestLookupWorkflow_DailyTriageDeclaresRequiredRepo -v
# PASS
go test ./internal/tools/
# PASS
```

Co-authored-by: octo-agent <no-reply@octo-agent.dev>