### PR TITLE
fix(server): bound sub-agent event history and make replay non-blocking

### DIFF
--- a/dev-docs/sub-agent-design.md
+++ b/dev-docs/sub-agent-design.md
@@ -211,7 +211,8 @@ TUI 底部一个 sub-agent 面板,实时呈现每个**活跃**子 agent 的 tool
   子 agent 的 token 流会淹没事件循环。
 - **异步层**:`SubAgentManager.onEvent`(与 `onExit` 并列)。`Start` / `runContinue` 调
   `Spawn` / `Continue` 前用 `WithSubAgentEventSink(ctx, sink)` 注入带 `agent_N` 标记的 sink,并先发
-  `started`。没有 `onEvent` 时不注入 sink、执行层不流式——headless 零开销、零行为变化。
+  `started`。即使未设置 `onEvent`,这个 sink 仍然存在并记录事件,供 Web UI 等 late-joining 订阅者重放。
+  没有 `onEvent` 时只是不向 live hook 转发,headless 行为不变。
 - **传递**:sink 走 context,`Spawner` 接口签名不变,`internal/tools` 与 `cmd/octo` 解耦。
 - **TUI**:`subAgentUI` 状态按 `agent_N` 聚合,渲染成 `tui.Panel`;子 agent 完成时移除,续话再
   `started` 重新加入。Web UI 有镜像同一事件流的 sub-agent 面板。

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -256,7 +256,9 @@ func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
 	// session's sub-agent manager just to discover it's empty — nil back
 	// means no sub-agent has run in this session yet. Replay the retained
 	// tool-level events (excluding the terminal "done") so the panel shows
-	// the current tool trail, not just a coarse "started" stub.
+	// the current tool trail, not just a coarse "started" stub. Use non-
+	// blocking sends to avoid stalling the subscribe handler if the client is
+	// a slow consumer.
 	if sam := tools.SessionSubAgentManager(sessionID, nil); sam != nil {
 		for _, sa := range sam.ListRunning() {
 			for _, ev := range sa.Events {
@@ -273,7 +275,10 @@ func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
 					"tool_name":   ev.ToolName,
 					"tool_input":  ev.ToolInput,
 				}); err == nil {
-					conn.send <- b
+					select {
+					case conn.send <- b:
+					default:
+					}
 				}
 			}
 		}

--- a/internal/tools/subagent_event.go
+++ b/internal/tools/subagent_event.go
@@ -32,6 +32,10 @@ type subAgentSinkKey struct{}
 // SubAgentManager stamps this in before calling Spawn/Continue, so the Spawner
 // interface itself stays unchanged and the non-TUI path (no sink) emits
 // nothing.
+//
+// Note: the SubAgentManager always stamps a sink for a tracked agent, even if
+// no live onEvent hook is set, so events can be retained for late-joining
+// subscribers.
 func WithSubAgentEventSink(ctx context.Context, sink func(SubAgentEvent)) context.Context {
 	if sink == nil {
 		return ctx
@@ -40,7 +44,7 @@ func WithSubAgentEventSink(ctx context.Context, sink func(SubAgentEvent)) contex
 }
 
 // SubAgentEventSink returns the sink stamped by WithSubAgentEventSink, or nil
-// when none is set (headless, tests, or a manager with no onEvent hook).
+// when none is set (headless or tests where no manager is involved).
 func SubAgentEventSink(ctx context.Context) func(SubAgentEvent) {
 	sink, _ := ctx.Value(subAgentSinkKey{}).(func(SubAgentEvent))
 	return sink

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -11,6 +11,11 @@ import (
 // maxSubAgentResultBytes caps how much result text is retained per async sub-agent.
 const maxSubAgentResultBytes = 1 << 20 // 1 MiB
 
+// maxSubAgentEvents caps how many tool-level events are retained per sub-agent.
+// Old events are dropped in FIFO order so late-joining panels see the most
+// recent tool trail without unbounded memory growth.
+const maxSubAgentEvents = 200
+
 // SubAgentNotification is delivered to the onExit hook when a sub-agent
 // finishes a task (spawn) or replies to a message (continue).
 type SubAgentNotification struct {
@@ -59,6 +64,11 @@ type asyncSubAgent struct {
 func (a *asyncSubAgent) recordEvent(ev SubAgentEvent) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if len(a.events) >= maxSubAgentEvents {
+		// Drop oldest event to bound memory; panels care most about recent tools.
+		copy(a.events, a.events[1:])
+		a.events = a.events[:len(a.events)-1]
+	}
 	a.events = append(a.events, ev)
 }
 
@@ -549,8 +559,9 @@ func (m *SubAgentManager) Start(req SpawnRequest) (string, error) {
 	m.agents[id] = agent
 	m.mu.Unlock()
 
-	// Stream runtime events (started + per-tool) for live display. nil sink =>
-	// no onEvent hook => the spawner runs without streaming.
+	// Stream runtime events (started + per-tool) for live display and replay.
+	// The sink is always non-nil while the agent is tracked, so events are
+	// retained even when no live onEvent hook is set.
 	sink := m.eventSink(id, req.Description, req.AgentType)
 	if sink != nil {
 		ctx = WithSubAgentEventSink(ctx, sink)

--- a/internal/tools/subagent_manager_test.go
+++ b/internal/tools/subagent_manager_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -329,4 +330,52 @@ func TestSend_CancelsSpawnContext(t *testing.T) {
 	waitForStatus(t, m, id, "idle")
 
 	waitForCancel(t, ctx2, "Continue")
+}
+
+// TestRecordEventCaps verifies that retained sub-agent events are bounded in
+// FIFO order so a long-running agent can't grow memory without bound.
+func TestRecordEventCaps(t *testing.T) {
+	a := &asyncSubAgent{id: "agent_1"}
+	for i := 0; i < maxSubAgentEvents+10; i++ {
+		a.recordEvent(SubAgentEvent{Kind: "tool", ToolName: fmt.Sprintf("tool_%d", i)})
+	}
+
+	events := a.listEvents()
+	if len(events) != maxSubAgentEvents {
+		t.Fatalf("len(events) = %d, want %d", len(events), maxSubAgentEvents)
+	}
+
+	// The oldest 10 events should have been dropped.
+	if events[0].ToolName != "tool_10" {
+		t.Errorf("first retained event = %q, want tool_10", events[0].ToolName)
+	}
+	if events[len(events)-1].ToolName != fmt.Sprintf("tool_%d", maxSubAgentEvents+10-1) {
+		t.Errorf("last retained event = %q, want tool_%d", events[len(events)-1].ToolName, maxSubAgentEvents+10-1)
+	}
+}
+
+// TestEventSinkRecordsWithoutOnEvent verifies that the sink stamped into a
+// sub-agent context records events even when no live onEvent hook is set,
+// enabling late-joining subscribers to replay the tool trail.
+func TestEventSinkRecordsWithoutOnEvent(t *testing.T) {
+	m := NewSubAgentManager(&fakeSpawner{})
+
+	a := &asyncSubAgent{id: "agent_1"}
+	m.agents[a.id] = a
+
+	sink := m.eventSink(a.id, "test", "explore")
+	if sink == nil {
+		t.Fatal("eventSink returned nil for a tracked agent")
+	}
+
+	sink(SubAgentEvent{Kind: "started"})
+	sink(SubAgentEvent{Kind: "tool", ToolName: "read_file"})
+
+	events := a.listEvents()
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	if events[0].Kind != "started" || events[1].Kind != "tool" {
+		t.Errorf("events = %v, want [started tool]", events)
+	}
 }


### PR DESCRIPTION
Follow-up to #1295.

The review of #1295 identified two Important issues:

1. `asyncSubAgent.events` could grow without bound for a long-running sub-agent.
2. The sub-agent replay sent directly into the 256-slot `conn.send` channel, risking the subscribe handler stalling if the client was a slow consumer.

## Changes

- `internal/tools/subagent_manager.go`
  - Add `maxSubAgentEvents = 200`; `recordEvent` drops oldest events in FIFO order.
  - Update `Start` comment to clarify that the sink is always stamped for tracked agents.
- `internal/server/ws_handlers.go`
  - Use `select`/`default` for sub-agent replay sends, matching the existing transcript replay behavior.
- `internal/tools/subagent_event.go`
  - Update comments to reflect that a sink is always stamped by `SubAgentManager` even when no live `onEvent` hook is set.
- `dev-docs/sub-agent-design.md`
  - Sync the TUI/runtime section with the new behavior.
- `internal/tools/subagent_manager_test.go`
  - Add `TestRecordEventCaps` and `TestEventSinkRecordsWithoutOnEvent`.

## Verification

- `make test` passes with race detector.

---

Co-authored-by: octo-agent <no-octo-agent.dev>