### PR TITLE
fix(tools): forbid background/detached processes inside sub-agents

### DIFF
--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -99,7 +99,7 @@ func (TerminalTool) Definition() agent.ToolDefinition {
 				"run_in_background": map[string]any{
 					"type":        "string",
 					"enum":        []string{"async", "interactive"},
-					"description": "Run detached in the background (no 120s timeout, non-blocking). Only use this if the next step does NOT need the command's output AND you already expect the command to run well past a few tens of seconds — omitting this runs synchronously and auto-promotes to background on its own if it turns out to be slow, so most builds/tests/installs (which finish in a few seconds) should just run synchronously instead of guessing async up front. \"async\" for one-shot tasks whose result can wait and that you expect to be genuinely long-running — the system auto-notifies on completion and terminal_output is not allowed. \"interactive\" for long-running services or REPLs — terminal_output and terminal_input are allowed. Either way the process is tracked by octo and KILLED when the session ends — including a tunnel/proxy meant to keep exposing a port (e.g. ngrok, cloudflared) or any daemon meant to outlive octo: use detached:true for those instead.",
+					"description": "Run detached in the background (no 120s timeout, non-blocking). Only use this if the next step does NOT need the command's output AND you already expect the command to run well past a few tens of seconds — omitting this runs synchronously and auto-promotes to background on its own if it turns out to be slow, so most builds/tests/installs (which finish in a few seconds) should just run synchronously instead of guessing async up front. \"async\" for one-shot tasks whose result can wait and that you expect to be genuinely long-running — the system auto-notifies on completion and terminal_output is not allowed. \"interactive\" for long-running services or REPLs — terminal_output and terminal_input are allowed. Either way the process is tracked by octo and KILLED when the session ends — including a tunnel/proxy meant to keep exposing a port (e.g. ngrok, cloudflared) or any daemon meant to outlive octo: use detached:true for those instead.\n\nNOT available inside a sub-agent: a sub-agent must return its result within the single turn that spawned it, so it has no later turn in which to collect a backgrounded process's output. When you are a sub-agent, do NOT pass run_in_background — async and interactive are both ignored and the command runs synchronously (and is killed if it exceeds the 120s timeout). detached is unavailable to a sub-agent for the same reason. A command that genuinely needs to run longer than 120s must be handed back to the parent to run.",
 				},
 				"detached": map[string]any{
 					"type":        "boolean",
@@ -156,10 +156,21 @@ func (t TerminalTool) ExecuteStream(
 	}
 	stdinText, _ := input["stdin"].(string)
 
+	// A sub-agent has no life beyond the turn that spawned it: it returns its
+	// result to the parent and stops, so there is no later turn in which it could
+	// collect a detached/backgrounded process's output. Letting it background a
+	// command therefore (a) leaks the process's completion notice into the PARENT
+	// conversation, unattributed, and (b) makes the sub-agent return a useless
+	// "started in background" mid-state instead of the result it was asked for.
+	// So every terminal call from inside a sub-agent runs synchronously: the
+	// detached and run_in_background branches below are skipped, and the sync
+	// timeout kills the command with an error rather than promoting it.
+	subAgent := IsSubAgent(ctx)
+
 	// Detached launch: a daemon that deliberately outlives octo. Not tracked, not
 	// killed on exit — fire-and-forget. Checked before run_in_background so
 	// detached wins if both are set.
-	if det, _ := input["detached"].(bool); det {
+	if det, _ := input["detached"].(bool); det && !subAgent {
 		logFile, _ := input["log_file"].(string)
 		pid, logPath, err := startDetached(ctx, command, logFile)
 		if err != nil {
@@ -180,7 +191,9 @@ func (t TerminalTool) ExecuteStream(
 
 	// Background launch: detach, no timeout, return the id immediately. The
 	// guard above still applies, so dangerous commands are blocked either way.
-	if useBg {
+	// Skipped for sub-agents (see subAgent above) — the requested async/
+	// interactive mode is ignored and the command runs synchronously instead.
+	if useBg && !subAgent {
 		id, err := t.managerFor(ctx).Start(command, bgMode)
 		if err != nil {
 			return agent.ToolResult{Text: ""}, err
@@ -199,6 +212,18 @@ func (t TerminalTool) ExecuteStream(
 			Text: fmt.Sprintf("Started %s background process %s.%s\n\n%s", bgMode, id, stdinWarn, notice),
 			UI:   terminalUI(command, "running", fmt.Sprintf("%s background process %s", bgMode, id)),
 		}, nil
+	}
+
+	// If a sub-agent asked to background/detach, we ignored that above and fall
+	// through to the synchronous path. Surface a note so the sub-agent learns the
+	// mode was dropped rather than silently getting different behavior than it
+	// requested. Wrapped in <system-reminder> so UIs keep it out of the card.
+	var bgIgnoredNote string
+	if subAgent {
+		detached, _ := input["detached"].(bool)
+		if useBg || detached {
+			bgIgnoredNote = "<system-reminder>run_in_background / detached is not available to a sub-agent — a sub-agent must finish within its turn, so the command was run synchronously instead. Do not request async, interactive, or detached from a sub-agent; hand any genuinely long-running command back to the parent.</system-reminder>\n\n"
+		}
 	}
 
 	// Synchronous path: start as a background process so that if we hit the
@@ -287,6 +312,18 @@ func (t TerminalTool) ExecuteStream(
 				UI:   terminalUI(command, "running", body),
 			}, nil
 		case <-timer.C:
+			if subAgent {
+				// A sub-agent cannot background a process (see subAgent above), so
+				// there is no one to collect this command's output later. Kill and
+				// reap it here and return the partial output plus an error, rather
+				// than promoting it to a background process that would outlive the
+				// sub-agent and fire its completion notice into the parent session.
+				mgr.Kill(id)
+				body := snapshot()
+				mgr.Remove(id)
+				text := fmt.Sprintf("%s\n[timeout: command exceeded %s and was killed. A sub-agent runs every command synchronously and cannot background or detach a process, so a command that needs to run longer than %s can't complete here — return what you have, or hand the long-running work back to the parent.]", body, TerminalTimeout, TerminalTimeout)
+				return agent.ToolResult{Text: text, UI: terminalUI(command, "failed", text)}, nil
+			}
 			// Timer backstop: covers IM channels and forgotten browser tabs.
 			// Identical outcome to the manual promote path.
 			mgr.Promote(id)
@@ -316,10 +353,10 @@ func (t TerminalTool) ExecuteStream(
 			mgr.Remove(id)
 			hint := backtickSubstitutionHint(command, body)
 			if status != "exited: 0" {
-				text := hint + body + "\n[exit: " + strings.TrimPrefix(status, "exited: ") + "]"
+				text := bgIgnoredNote + hint + body + "\n[exit: " + strings.TrimPrefix(status, "exited: ") + "]"
 				return agent.ToolResult{Text: text, UI: terminalUI(command, "failed", text)}, nil
 			}
-			return agent.ToolResult{Text: hint + body, UI: terminalUI(command, "success", body)}, nil
+			return agent.ToolResult{Text: bgIgnoredNote + hint + body, UI: terminalUI(command, "success", body)}, nil
 		}
 		time.Sleep(50 * time.Millisecond)
 	}

--- a/internal/tools/terminal.go
+++ b/internal/tools/terminal.go
@@ -103,7 +103,7 @@ func (TerminalTool) Definition() agent.ToolDefinition {
 				},
 				"detached": map[string]any{
 					"type":        "boolean",
-					"description": "Launch the command as a daemon that DELIBERATELY outlives octo: it runs in its own session, is NOT tracked, and is NOT killed when the session ends. Returns only the OS pid — terminal_output and kill_shell cannot see it, so the user manages it themselves (e.g. `kill <pid>`). Use ONLY when the user explicitly wants a process to survive the agent (e.g. exposing a port with ngrok, starting a standalone server). For tasks that should be cleaned up with the session, use run_in_background instead. No `nohup`/`&` needed — detachment is handled for you. stdout+stderr go to log_file.",
+					"description": "Launch the command as a daemon that DELIBERATELY outlives octo: it runs in its own session, is NOT tracked, and is NOT killed when the session ends. Returns only the OS pid — terminal_output and kill_shell cannot see it, so the user manages it themselves (e.g. `kill <pid>`). Use ONLY when the user explicitly wants a process to survive the agent (e.g. exposing a port with ngrok, starting a standalone server). For tasks that should be cleaned up with the session, use run_in_background instead. No `nohup`/`&` needed — detachment is handled for you. stdout+stderr go to log_file. NOT available inside a sub-agent — a sub-agent must finish within its turn and cannot leave a daemon behind, so detached is ignored and the command runs synchronously.",
 				},
 				"log_file": map[string]any{
 					"type":        "string",
@@ -266,10 +266,18 @@ func (t TerminalTool) ExecuteStream(
 		}
 	}
 
-	// Register a SyncSession so TUI (Ctrl+B) and Web ("Background" button)
-	// can promote this process before the timer fires.
-	sess := mgr.BeginSync()
-	defer mgr.EndSync()
+	// Register a SyncSession so TUI (Ctrl+B) and Web ("Background" button) can
+	// promote this process before the timer fires. A sub-agent's command is never
+	// promotable: promotion leaves the process running past the sub-agent's turn
+	// (see subAgent above), so we skip registration entirely — the process stays
+	// invisible to HasActiveSync, so Ctrl+B/the button can't target it — and leave
+	// promoteCh nil, so that select arm (a receive on a nil channel) never fires.
+	var promoteCh <-chan struct{}
+	if !subAgent {
+		sess := mgr.BeginSync()
+		defer mgr.EndSync()
+		promoteCh = sess.C()
+	}
 
 	// snapshot returns the collected output so far, tab-expanded and with the
 	// truncation marker prepended when the cap dropped earlier bytes. The
@@ -302,9 +310,10 @@ func (t TerminalTool) ExecuteStream(
 
 	for {
 		select {
-		case <-sess.C():
+		case <-promoteCh:
 			// User promoted (Ctrl+B in TUI / button in Web): make the process
-			// visible in the background panel and return. NOT reaped.
+			// visible in the background panel and return. NOT reaped. Never fires
+			// for a sub-agent (promoteCh is nil there).
 			mgr.Promote(id)
 			body := MaybeSpillOutput(id, snapshot())
 			return agent.ToolResult{

--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -375,6 +375,58 @@ func TestTerminalTool_SubAgent_SyncTimeoutKills(t *testing.T) {
 	}
 }
 
+// TestTerminalTool_SubAgent_NotPromotable verifies a sub-agent's synchronous
+// command registers NO promotable SyncSession, so the TUI Ctrl+B / web
+// "Background" button can't promote it into a process that outlives the
+// sub-agent. Without the guard, a manual promote signal would background the
+// command and fire its completion notice into the parent session.
+func TestTerminalTool_SubAgent_NotPromotable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell only")
+	}
+	mgr := NewBackgroundManager()
+	tool := TerminalTool{mgr: mgr}
+
+	// Sub-agent command: run ~1s in the background so we can observe the manager
+	// while it polls. It must never expose a promotable sync session.
+	subDone := make(chan struct{})
+	go func() {
+		_, _ = tool.Execute(WithSubAgentMarker(context.Background()), "terminal", map[string]any{"command": "sleep 1"})
+		close(subDone)
+	}()
+	deadline := time.Now().Add(600 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if mgr.HasSync() {
+			t.Fatal("a sub-agent's sync command must not register a promotable SyncSession")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	mgr.PromoteSync() // no-op: nothing registered
+	<-subDone
+
+	// Control: a non-sub-agent command DOES register one (proves the guard, not a
+	// missing BeginSync, is what suppresses it).
+	ctlDone := make(chan struct{})
+	go func() {
+		_, _ = tool.Execute(context.Background(), "terminal", map[string]any{"command": "sleep 1"})
+		close(ctlDone)
+	}()
+	sawSync := false
+	deadline = time.Now().Add(700 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if mgr.HasSync() {
+			sawSync = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !sawSync {
+		t.Error("a non-sub-agent sync command should register a promotable SyncSession")
+	}
+	mgr.PromoteSync() // let the control return promptly instead of waiting out the sleep
+	<-ctlDone
+}
+
 func TestTerminalInputTool_Definition(t *testing.T) {
 	def := TerminalInputTool{}.Definition()
 	if def.Name != "terminal_input" {

--- a/internal/tools/terminal_test.go
+++ b/internal/tools/terminal_test.go
@@ -45,6 +45,10 @@ func TestTerminalTool_Definition(t *testing.T) {
 	if got, ok := rib["enum"].([]string); !ok || len(got) != len(wantEnum) {
 		t.Errorf("run_in_background.enum = %v, want %v", rib["enum"], wantEnum)
 	}
+	// The description must tell a sub-agent that backgrounding is unavailable.
+	if desc, _ := rib["description"].(string); !strings.Contains(desc, "sub-agent") {
+		t.Errorf("run_in_background.description should explain the sub-agent restriction; got: %q", desc)
+	}
 	req, ok := def.Parameters["required"].([]string)
 	if !ok {
 		t.Fatal("Parameters.required is not []string")
@@ -266,6 +270,108 @@ func TestTerminalTool_RespectsContextDeadline(t *testing.T) {
 	}
 	if elapsed > 2*time.Second {
 		t.Errorf("elapsed %s — context deadline was not respected", elapsed)
+	}
+}
+
+// TestTerminalTool_SubAgent_BackgroundRunsSync verifies that a run_in_background
+// request from inside a sub-agent is ignored and the command runs synchronously,
+// returning its real output in-band rather than a "started in background" id.
+// Backgrounding from a sub-agent would leak the completion notice into the parent
+// session and return a useless mid-state to the sub-agent.
+func TestTerminalTool_SubAgent_BackgroundRunsSync(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell only")
+	}
+	ctx := WithSubAgentMarker(context.Background())
+	for _, mode := range []string{"async", "interactive"} {
+		result, err := TerminalTool{}.Execute(ctx, "terminal", map[string]any{
+			"command":           "echo sub-agent-hi",
+			"run_in_background": mode,
+		})
+		if err != nil {
+			t.Fatalf("mode %q: Execute: %v", mode, err)
+		}
+		if !strings.Contains(result.Text, "sub-agent-hi") {
+			t.Errorf("mode %q: want real output in-band, got: %q", mode, result.Text)
+		}
+		if strings.Contains(result.Text, "background process") {
+			t.Errorf("mode %q: sub-agent must not background; got: %q", mode, result.Text)
+		}
+		// The sub-agent must be told the mode was dropped, not silently downgraded.
+		if !strings.Contains(result.Text, "not available to a sub-agent") {
+			t.Errorf("mode %q: want an explanatory note, got: %q", mode, result.Text)
+		}
+	}
+}
+
+// TestTerminalTool_SubAgent_DetachedRunsSync verifies that detached:true from a
+// sub-agent is ignored and the command runs synchronously — a sub-agent must not
+// spawn a daemon that outlives it.
+func TestTerminalTool_SubAgent_DetachedRunsSync(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell only")
+	}
+	ctx := WithSubAgentMarker(context.Background())
+	result, err := TerminalTool{}.Execute(ctx, "terminal", map[string]any{
+		"command":  "echo sub-agent-detached",
+		"detached": true,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(result.Text, "sub-agent-detached") {
+		t.Errorf("want real output in-band, got: %q", result.Text)
+	}
+	if strings.Contains(result.Text, "detached process") {
+		t.Errorf("sub-agent must not detach; got: %q", result.Text)
+	}
+	if !strings.Contains(result.Text, "not available to a sub-agent") {
+		t.Errorf("want an explanatory note, got: %q", result.Text)
+	}
+}
+
+// TestTerminalTool_SubAgent_SyncTimeoutKills verifies that when a sub-agent's
+// synchronous command exceeds TerminalTimeout it is killed with an error, rather
+// than auto-promoted to a background process (which would outlive the sub-agent
+// and notify the parent). A non-sub-agent context still promotes.
+func TestTerminalTool_SubAgent_SyncTimeoutKills(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell only")
+	}
+	orig := TerminalTimeout
+	TerminalTimeout = 200 * time.Millisecond
+	defer func() { TerminalTimeout = orig }()
+	// The control case below promotes a sleep to the default manager; reap it (and
+	// any straggler) so it doesn't outlive the test.
+	defer DefaultBackgroundManager().KillAll()
+
+	// Sub-agent: timeout kills the command, no background promotion.
+	start := time.Now()
+	result, err := TerminalTool{}.Execute(WithSubAgentMarker(context.Background()), "terminal", map[string]any{
+		"command": "sleep 30",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("elapsed %s — sub-agent timeout did not kill promptly", elapsed)
+	}
+	if !strings.Contains(result.Text, "was killed") {
+		t.Errorf("want a kill/timeout error, got: %q", result.Text)
+	}
+	if strings.Contains(result.Text, "background process") {
+		t.Errorf("sub-agent timeout must not promote to background; got: %q", result.Text)
+	}
+
+	// Control: a normal (non-sub-agent) context still promotes to background.
+	result, err = TerminalTool{}.Execute(context.Background(), "terminal", map[string]any{
+		"command": "sleep 30",
+	})
+	if err != nil {
+		t.Fatalf("Execute (control): %v", err)
+	}
+	if !strings.Contains(result.Text, "background process") {
+		t.Errorf("non-sub-agent should promote to background; got: %q", result.Text)
 	}
 }
 


### PR DESCRIPTION
## Problem

A sub-agent returns its result within the single turn that spawned it and then stops, so it has no later turn in which to collect a backgrounded or detached process's output. Yet a sub-agent's `terminal` calls shared the parent session's background manager and could still detach/background a command. Two bad consequences, both observed when a workflow fanned out sub-agents that each ran a long `sleep`:

- The process's `[BACKGROUND COMPLETED]` completion notice fired into the **parent** session's conversation, **unattributed** — the orchestrating agent couldn't tell the notices were its own workflow's sub-agents and repeatedly reported them to the user as "unrelated background processes".
- The sub-agent returned a useless "started in background" mid-state instead of the result it was asked for, so the aggregating workflow saw garbage where it expected structured JSON (this was the direct cause of a fan-out eval run scoring 6/12 combinations as parse failures).

## Change

Every `terminal` call from inside a sub-agent (`IsSubAgent(ctx)`) now runs **synchronously**:

| Branch | Sub-agent | Non-sub-agent (unchanged) |
|--------|-----------|---------------------------|
| `detached: true` | ignored → runs sync | starts an unmanaged daemon |
| `run_in_background: async` / `interactive` | ignored → runs sync | starts a tracked background process |
| sync command exceeds 120s timeout | **killed + error returned** | auto-promoted to background |

The restriction is explained in two places so the model isn't surprised:

1. **Up front** — the `run_in_background` parameter description states it's unavailable to a sub-agent.
2. **At runtime** — when a sub-agent's async/interactive/detached request is dropped, the synchronous result carries a `<system-reminder>` note saying the mode was ignored and the command ran synchronously. (Wrapped in `<system-reminder>` so UIs strip it from the card; the parent agent never hits this path.)

The change is confined to `internal/tools/terminal.go` plus its tests — no new background-manager scoping or lifecycle state.

## Tests

- `TestTerminalTool_SubAgent_BackgroundRunsSync` — async/interactive ignored; real output returned in-band; explanatory note present.
- `TestTerminalTool_SubAgent_DetachedRunsSync` — detached ignored; runs sync; note present.
- `TestTerminalTool_SubAgent_SyncTimeoutKills` — sub-agent timeout kills + errors; **control** asserts a non-sub-agent context still promotes to background (proves the gate is marker-scoped, not a blanket sync).
- `TestTerminalTool_Definition` — asserts the description mentions the sub-agent restriction.

`gofmt -l .` clean, `go vet ./internal/tools/`, and `go test -race ./internal/tools/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
