### PR TITLE
fix(tools): don't tell the model a killed background process "didn't need run_in_background"

### DIFF
--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -54,6 +54,7 @@ type bgProcess struct {
 	done     bool
 	end      time.Time // set when the process exits; used for accurate elapsed time in listings
 	exitErr  error
+	killed   bool // set by terminate(): the process was deliberately killed, not self-exited
 
 	// Anti-polling: time-window based. Within a 30-second window, 3 or more
 	// empty reads on a running process trigger a block. This allows occasional
@@ -221,6 +222,7 @@ type BgExit struct {
 	NewOutput string
 	Mode      BackgroundMode
 	Duration  time.Duration // wall-clock time from launch to exit
+	Killed    bool          // the process was deliberately killed, not self-exited
 }
 
 // SyncSession is the promote handle for one in-flight synchronous terminal
@@ -438,9 +440,12 @@ func (m *BackgroundManager) Start(command string, mode BackgroundMode, opts ...S
 			// its result was already returned synchronously — no notification.
 			if visible {
 				out, status, _ := p.readNew()
+				p.mu.Lock()
+				killed := p.killed
+				p.mu.Unlock()
 				hook(BgExit{
 					ID: p.id, Command: p.command, Status: status, NewOutput: out,
-					Mode: p.mode, Duration: p.end.Sub(p.start),
+					Mode: p.mode, Duration: p.end.Sub(p.start), Killed: killed,
 				})
 			}
 		}
@@ -596,6 +601,15 @@ func terminate(p *bgProcess, sigName string) {
 	if p == nil {
 		return
 	}
+	// Record that this exit is a deliberate kill, not a self-completion, so the
+	// completion notice doesn't tell the model the process "finished fast". This
+	// is the single choke point for every kill path (Kill / KillWithSignal /
+	// KillAll / the sync ctx-cancel), and it works cross-platform — including
+	// Windows, where a taskkill'd process reports a plain non-zero exit with no
+	// signal in its status string.
+	p.mu.Lock()
+	p.killed = true
+	p.mu.Unlock()
 	if sigName == "SIGKILL" {
 		p.cancel()
 	}

--- a/internal/tools/bgnotify.go
+++ b/internal/tools/bgnotify.go
@@ -44,8 +44,10 @@ func FormatBgNote(e BgExit) string {
 	// process that was killed (session/turn-end reap, user Ctrl-C, an explicit
 	// kill_shell) didn't "finish fast": e.Duration is time-until-kill, so the
 	// nudge would mislead ("finished in 4s, didn't need background") about a
-	// `sleep 118` that was terminated at 4s. Killed exits carry a "signal:" status.
-	completedOnItsOwn := !strings.Contains(e.Status, "signal:")
+	// `sleep 118` terminated at 4s. e.Killed flags a deliberate kill on every
+	// platform; the "signal:" check additionally covers a POSIX signal death not
+	// routed through our killer (e.g. an OOM kill).
+	completedOnItsOwn := !e.Killed && !strings.Contains(e.Status, "signal:")
 	if e.Mode == BgModeAsync && completedOnItsOwn && e.Duration > 0 && e.Duration < shortAsyncDuration {
 		fmt.Fprintf(&b,
 			"\n\n[Note: this finished in %s — that's fast enough it didn't need run_in_background at all. "+

--- a/internal/tools/bgnotify.go
+++ b/internal/tools/bgnotify.go
@@ -39,7 +39,14 @@ func FormatBgNote(e BgExit) string {
 	} else {
 		b.WriteString("\n(no new output)")
 	}
-	if e.Mode == BgModeAsync && e.Duration > 0 && e.Duration < shortAsyncDuration {
+	// Only nudge for a process that exited ON ITS OWN quickly — that's the case
+	// where a synchronous call would have returned the same output in-band. A
+	// process that was killed (session/turn-end reap, user Ctrl-C, an explicit
+	// kill_shell) didn't "finish fast": e.Duration is time-until-kill, so the
+	// nudge would mislead ("finished in 4s, didn't need background") about a
+	// `sleep 118` that was terminated at 4s. Killed exits carry a "signal:" status.
+	completedOnItsOwn := !strings.Contains(e.Status, "signal:")
+	if e.Mode == BgModeAsync && completedOnItsOwn && e.Duration > 0 && e.Duration < shortAsyncDuration {
 		fmt.Fprintf(&b,
 			"\n\n[Note: this finished in %s — that's fast enough it didn't need run_in_background at all. "+
 				"A synchronous terminal call (no run_in_background) would have returned this same output "+

--- a/internal/tools/bgnotify_test.go
+++ b/internal/tools/bgnotify_test.go
@@ -93,14 +93,26 @@ func TestFormatBgNote_NoNudgeWithZeroDuration(t *testing.T) {
 // TestFormatBgNote_NoNudgeForKilled verifies a process that was KILLED quickly
 // does not get the short-async nudge. Its Duration is time-until-kill, so a
 // `sleep 118` reaped at 4s would otherwise be mislabeled "finished in 4s —
-// didn't need run_in_background" when it never finished at all.
+// didn't need run_in_background" when it never finished at all. Two flavors:
+// the POSIX signal status, and (Killed set, no signal in status) the Windows
+// taskkill shape — the Killed flag must suppress the nudge either way.
 func TestFormatBgNote_NoNudgeForKilled(t *testing.T) {
-	got := FormatBgNote(BgExit{
-		ID: "bg_1", Command: "sleep 118", Status: "exited: signal: killed",
-		Mode: BgModeAsync, Duration: 4 * time.Second,
-	})
-	if strings.Contains(got, "didn't need run_in_background") {
-		t.Errorf("a killed process must not get the short-async nudge; got:\n%s", got)
+	cases := []struct {
+		name   string
+		status string
+		killed bool
+	}{
+		{"posix signal", "exited: signal: killed", true},
+		{"windows taskkill", "exited: exit status 1", true}, // no "signal:" — relies on Killed
+	}
+	for _, tc := range cases {
+		got := FormatBgNote(BgExit{
+			ID: "bg_1", Command: "sleep 118", Status: tc.status,
+			Mode: BgModeAsync, Duration: 4 * time.Second, Killed: tc.killed,
+		})
+		if strings.Contains(got, "didn't need run_in_background") {
+			t.Errorf("%s: a killed process must not get the short-async nudge; got:\n%s", tc.name, got)
+		}
 	}
 }
 

--- a/internal/tools/bgnotify_test.go
+++ b/internal/tools/bgnotify_test.go
@@ -90,6 +90,20 @@ func TestFormatBgNote_NoNudgeWithZeroDuration(t *testing.T) {
 	}
 }
 
+// TestFormatBgNote_NoNudgeForKilled verifies a process that was KILLED quickly
+// does not get the short-async nudge. Its Duration is time-until-kill, so a
+// `sleep 118` reaped at 4s would otherwise be mislabeled "finished in 4s —
+// didn't need run_in_background" when it never finished at all.
+func TestFormatBgNote_NoNudgeForKilled(t *testing.T) {
+	got := FormatBgNote(BgExit{
+		ID: "bg_1", Command: "sleep 118", Status: "exited: signal: killed",
+		Mode: BgModeAsync, Duration: 4 * time.Second,
+	})
+	if strings.Contains(got, "didn't need run_in_background") {
+		t.Errorf("a killed process must not get the short-async nudge; got:\n%s", got)
+	}
+}
+
 func TestFormatBgNoteWithSummary_SkipsFinishedAndSelf(t *testing.T) {
 	mgr := NewBackgroundManager()
 	// Launch three processes; we will simulate bg_1 finishing.


### PR DESCRIPTION
## Problem

The short-async advisory in `FormatBgNote` —

> [Note: this finished in Ns — that's fast enough it didn't need run_in_background at all. …]

fired for **any** async process whose `Duration` was under the 10s threshold, without checking *how* it ended. `Duration` is launch-to-exit wall clock, so for a process killed early — the session/turn-end reap, a user Ctrl-C, an explicit `kill_shell` — it's the time until termination, not a completion time.

Observed in a real session: a workflow's sub-agents each launched a `sleep 118` / `sleep 120` in the background; when they were reaped at ~4s, the model received `Background process bg_9 (sleep 118 && echo "done") exited: signal: killed … [Note: this finished in 4s — that's fast enough it didn't need run_in_background at all]`. The `sleep 118` never finished — it was killed — so the advice is both wrong and misleading.

## Fix

Gate the advisory on the process having exited on its own. A killed/signaled exit carries a `"signal:"` status (`exited: signal: killed`), a self-exit is `exited: 0` / `exited: exit status N`, so the nudge is skipped when the status contains `"signal:"`. No behavior change for genuinely-quick self-completed async launches, which is the case the nudge exists for.

## Tests

- `TestFormatBgNote_NoNudgeForKilled` — a killed `sleep 118` with Duration 4s gets no nudge.
- Existing advisory tests (quick self-exit nudges, long async / interactive / zero-duration don't) still pass.

`gofmt` clean, `go vet` + `go test ./internal/tools/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
