### PR TITLE
fix(tools): resolve workflow_status / workflow_kill by JournalRunID too

### DIFF
--- a/internal/tools/workflow_manager.go
+++ b/internal/tools/workflow_manager.go
@@ -398,6 +398,13 @@ func (m *WorkflowManager) Wait(ctx context.Context, id string) (WorkflowRunSnaps
 // so a lookup tool must accept either — the model naturally retries with whatever
 // id the last message showed it. Caller holds m.mu.
 func (m *WorkflowManager) resolveLocked(id string) *workflowRun {
+	// A running run's journalID is "" until it finishes, so an empty id would
+	// otherwise match the first still-running run in the scan below — a lookup
+	// (or a Kill) of "" must find nothing. Callers already reject empty ids, but
+	// keep the invariant inside the resolver so a future caller can't trip it.
+	if id == "" {
+		return nil
+	}
 	if run := m.runs[id]; run != nil {
 		return run
 	}

--- a/internal/tools/workflow_manager.go
+++ b/internal/tools/workflow_manager.go
@@ -153,6 +153,13 @@ func (r *workflowRun) finish(output, journalRunID, errMsg string, end time.Time)
 	close(r.finished)
 }
 
+// journalID returns the run's resume_from handle (empty until finish records it).
+func (r *workflowRun) journalID() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.journalRunID
+}
+
 func (r *workflowRun) snapshot() WorkflowRunSnapshot {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -385,10 +392,27 @@ func (m *WorkflowManager) Wait(ctx context.Context, id string) (WorkflowRunSnaps
 	}
 }
 
+// resolveLocked finds a run by its short alias (the map key, e.g. "wf_1") or by
+// its JournalRunID (the "wf-YYYYMMDD-HHMMSS-xxxxxxxx" handle that failure notices
+// print and tell the model to pass to resume_from). Both identify the same run,
+// so a lookup tool must accept either — the model naturally retries with whatever
+// id the last message showed it. Caller holds m.mu.
+func (m *WorkflowManager) resolveLocked(id string) *workflowRun {
+	if run := m.runs[id]; run != nil {
+		return run
+	}
+	for _, run := range m.runs {
+		if run.journalID() == id {
+			return run
+		}
+	}
+	return nil
+}
+
 // Read returns a snapshot of one run.
 func (m *WorkflowManager) Read(id string) (WorkflowRunSnapshot, bool) {
 	m.mu.Lock()
-	run := m.runs[id]
+	run := m.resolveLocked(id)
 	m.mu.Unlock()
 	if run == nil {
 		return WorkflowRunSnapshot{}, false
@@ -419,7 +443,7 @@ func (m *WorkflowManager) List() []WorkflowRunSnapshot {
 // propagates to its in-flight sub-agents and unwinds the script.
 func (m *WorkflowManager) Kill(id string) (found, wasRunning bool) {
 	m.mu.Lock()
-	run := m.runs[id]
+	run := m.resolveLocked(id)
 	m.mu.Unlock()
 	if run == nil {
 		return false, false

--- a/internal/tools/workflow_manager_test.go
+++ b/internal/tools/workflow_manager_test.go
@@ -204,6 +204,41 @@ func TestWorkflowManager_Kill(t *testing.T) {
 	}
 }
 
+// TestWorkflowManager_ResolvesByJournalRunID verifies Read and Kill accept the
+// JournalRunID handle (the "wf-YYYYMMDD-..." id that failure notices print and
+// tell the model to pass to resume_from), not just the short "wf_N" alias. The
+// two identify the same run, so a lookup with either must succeed — otherwise
+// the model gets "no run named ..." for the very id the last message showed it.
+func TestWorkflowManager_ResolvesByJournalRunID(t *testing.T) {
+	m := NewWorkflowManager()
+	id, err := m.Start(WorkflowRunRequest{Script: `agent("x")`, Agent: echoAgentOpts})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	snap := waitForDone(t, m, id)
+	if snap.JournalRunID == "" {
+		t.Fatal("expected a non-empty JournalRunID after completion")
+	}
+	if snap.JournalRunID == id {
+		t.Fatalf("JournalRunID (%q) should differ from the short alias (%q)", snap.JournalRunID, id)
+	}
+
+	byJournal, ok := m.Read(snap.JournalRunID)
+	if !ok {
+		t.Fatalf("Read(%q) by JournalRunID should resolve", snap.JournalRunID)
+	}
+	if byJournal.ID != id {
+		t.Errorf("Read by JournalRunID resolved to %q, want the same run %q", byJournal.ID, id)
+	}
+	if _, ok := m.Read("wf-nonexistent-00000000"); ok {
+		t.Error("Read of an unknown JournalRunID should not resolve")
+	}
+	// Kill accepts the JournalRunID too (already-finished run → found, not running).
+	if found, _ := m.Kill(snap.JournalRunID); !found {
+		t.Error("Kill by JournalRunID should report found=true")
+	}
+}
+
 // TestWorkflowManager_KillUnknownAndFinished covers the non-running cases.
 func TestWorkflowManager_KillUnknownAndFinished(t *testing.T) {
 	m := NewWorkflowManager()

--- a/internal/tools/workflow_manager_test.go
+++ b/internal/tools/workflow_manager_test.go
@@ -239,6 +239,24 @@ func TestWorkflowManager_ResolvesByJournalRunID(t *testing.T) {
 	}
 }
 
+// TestWorkflowManager_EmptyIDMatchesNoRun guards the resolveLocked empty-id
+// short-circuit: a running run has an empty journalID, so without the guard an
+// empty id would match (and Kill) the first still-running run.
+func TestWorkflowManager_EmptyIDMatchesNoRun(t *testing.T) {
+	m := NewWorkflowManager()
+	id, err := m.Start(WorkflowRunRequest{Script: `agent("x")`, Agent: ctxBlockingAgent})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer m.Kill(id) // clean up the blocked run
+	if _, ok := m.Read(""); ok {
+		t.Error(`Read("") must not resolve to a running run`)
+	}
+	if found, _ := m.Kill(""); found {
+		t.Error(`Kill("") must not find (and cancel) a running run`)
+	}
+}
+
 // TestWorkflowManager_KillUnknownAndFinished covers the non-running cases.
 func TestWorkflowManager_KillUnknownAndFinished(t *testing.T) {
 	m := NewWorkflowManager()


### PR DESCRIPTION
## Problem

A workflow run is identified by two ids:
- the short alias `wf_N` (the `runs` map key), and
- the `JournalRunID` `wf-YYYYMMDD-HHMMSS-xxxxxxxx`.

The `JournalRunID` is the one the system actively puts in front of the model: a failed run's notice says `pass resume_from: "wf-2026…"` and prints `[workflow run: wf-2026…]`. But `workflow_status` / `workflow_kill` (`WorkflowManager.Read` / `Kill`) looked runs up by map key only.

Observed in a real session: a run failed, the notice surfaced `wf-20260710-102942-22e1cd0a` and told the model to use it; the model called `workflow_status("wf-20260710-102942-22e1cd0a")` and got `workflow_status: no run named "wf-20260710-102942-22e1cd0a" in this session` — an error for the exact id the previous message handed it.

## Fix

Add `resolveLocked(id)`: exact map-key match first, then fall back to scanning for a run whose `JournalRunID == id`. Route `Read` and `Kill` (the two model-facing lookups that emit "no run named …") through it. Both ids now resolve to the same run. Lock ordering is preserved — `m.mu` is only ever taken before `run.mu`, never the reverse.

## Tests

- `TestWorkflowManager_ResolvesByJournalRunID` — after a run completes, `Read` and `Kill` by its `JournalRunID` resolve to the same run; an unknown journal id still fails.
- Existing `Read` / `Kill` / list tests unaffected.

`gofmt` clean, `go vet` + `go test ./internal/tools/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
