### PR TITLE
feat(tui): require two presses to quit via Ctrl+D / idle Ctrl+C

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -38,8 +38,8 @@ import (
 //   - Ctrl+J             → newline (LF — works on all terminals)
 //   - Ctrl+Q             → queue  (run as a fresh turn after this one finishes)
 //   - Esc                → take the turn back if no output yet (text returns to the input), else interrupt; queue survives
-//   - Ctrl+C             → interrupt if a turn runs, else save & quit
-//   - Ctrl+D             → save & quit
+//   - Ctrl+C             → interrupt if a turn runs, else save & quit (twice)
+//   - Ctrl+D (twice)     → save & quit (first press arms, second confirms)
 func runTUI(cfg replConfig) int {
 	defer tools.KillAllBackground()
 	defer tools.CleanSpillFiles()
@@ -438,6 +438,12 @@ type tuiModel struct {
 
 	width int
 	quit  bool
+
+	// quitArmed is set by a first Ctrl+D or idle Ctrl+C press and cleared by any
+	// other key, so a quit only lands when the shortcut is pressed twice in a row
+	// — a guard against an accidental single press dropping the session (Claude
+	// Code style). A running-turn Ctrl+C interrupts instead and clears this.
+	quitArmed bool
 
 	// cwd is the home-abbreviated working directory shown in the status bar
 	// (computed once — it doesn't change during a session).

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -775,9 +775,123 @@ func TestTUI_ReplayHistoryLines_ToolError(t *testing.T) {
 
 func TestTUI_CtrlDQuits(t *testing.T) {
 	m := newTestModel()
+
+	// First press arms but must not quit.
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	if m.quit || cmd != nil {
+		t.Fatal("first Ctrl+D should arm, not quit")
+	}
+	if !m.quitArmed {
+		t.Fatal("first Ctrl+D should arm the quit confirmation")
+	}
+
+	// Second consecutive press quits.
+	_, cmd = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	if !m.quit || cmd == nil {
+		t.Error("second Ctrl+D should set quit and return a quit cmd")
+	}
+}
+
+func TestTUI_CtrlCQuitsWhenIdle(t *testing.T) {
+	m := newTestModel()
+
+	// First idle Ctrl+C arms but must not quit.
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if m.quit || cmd != nil {
+		t.Fatal("first idle Ctrl+C should arm, not quit")
+	}
+	if !m.quitArmed {
+		t.Fatal("first idle Ctrl+C should arm the quit confirmation")
+	}
+
+	// Second consecutive press quits.
+	_, cmd = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if !m.quit || cmd == nil {
+		t.Error("second idle Ctrl+C should set quit and return a quit cmd")
+	}
+}
+
+func TestTUI_CtrlCInterruptsWithoutArmingQuit(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+
+	// While a turn runs, Ctrl+C interrupts and must never arm a quit.
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if m.quit || cmd != nil {
+		t.Fatal("running-turn Ctrl+C should interrupt, not quit")
+	}
+	if m.quitArmed {
+		t.Error("running-turn Ctrl+C must not arm the quit confirmation")
+	}
+}
+
+func TestTUI_CtrlDAndCShareQuitConfirmation(t *testing.T) {
+	m := newTestModel()
+
+	// Ctrl+D arms; a following idle Ctrl+C confirms the shared quit.
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if !m.quit || cmd == nil {
+		t.Error("Ctrl+C after Ctrl+D should confirm the shared quit")
+	}
+}
+
+func TestTUI_CtrlCArmsThenCtrlDConfirms(t *testing.T) {
+	m := newTestModel()
+
+	// Reverse of the shared-confirmation test: idle Ctrl+C arms, Ctrl+D confirms.
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
 	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlD})
 	if !m.quit || cmd == nil {
-		t.Error("Ctrl+D should set quit and return a quit cmd")
+		t.Error("Ctrl+D after idle Ctrl+C should confirm the shared quit")
+	}
+}
+
+func TestTUI_QuitDisarmedByOtherKey(t *testing.T) {
+	m := newTestModel()
+
+	// Arm with one Ctrl+D, then press another key — the confirmation resets.
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	if m.quitArmed {
+		t.Fatal("a non-quit key should disarm the quit confirmation")
+	}
+
+	// A lone Ctrl+D after the reset must arm again, not quit.
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	if m.quit || cmd != nil {
+		t.Error("Ctrl+D after a disarm should re-arm, not quit")
+	}
+}
+
+func TestTUI_QuitDisarmedByEarlyReturnKey(t *testing.T) {
+	m := newTestModel()
+
+	// Arm, then press a key that the completion menu consumes with an early
+	// return (before the main key switch). The top-of-handleKey guard must still
+	// disarm, otherwise the confirmation would leak past menu navigation.
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	m.complItems = []complItem{{"/help", ""}, {"/model", ""}}
+	m.complIdx = 0
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.quitArmed {
+		t.Error("an early-return completion key should still disarm the quit confirmation")
+	}
+}
+
+func TestTUI_CtrlDArmedThenRunningCtrlCInterrupts(t *testing.T) {
+	m := newTestModel()
+
+	// Ctrl+D arms while idle; then a turn starts and Ctrl+C arrives. It must
+	// interrupt and disarm, never confirming the pending quit.
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	m.turnRunning = true
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if m.quit || cmd != nil {
+		t.Fatal("running-turn Ctrl+C must interrupt, not confirm an armed quit")
+	}
+	if m.quitArmed {
+		t.Error("running-turn Ctrl+C must disarm the pending quit confirmation")
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -51,6 +51,14 @@ var (
 )
 
 func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Ctrl+D and idle Ctrl+C quit only on a second consecutive press; any other
+	// key disarms the confirmation. Ctrl+C keeps the arm here so a second one can
+	// confirm — but when a turn is running its handler interrupts and clears it.
+	quitArmed := m.quitArmed
+	if msg.Type != tea.KeyCtrlD && msg.Type != tea.KeyCtrlC {
+		m.quitArmed = false
+	}
+
 	if m.modal != nil {
 		return m.handleModalKey(msg)
 	}
@@ -107,8 +115,13 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.Type {
 	case tea.KeyCtrlD:
-		m.quit = true
-		return m, tea.Quit
+		// First press arms and shows a hint; a second consecutive press quits.
+		if quitArmed {
+			m.quit = true
+			return m, tea.Quit
+		}
+		m.quitArmed = true
+		return m, nil
 
 	case tea.KeyCtrlB:
 		// Background the current sync terminal or sub-agent, if one is running.
@@ -124,11 +137,19 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyCtrlC:
 		if m.turnRunning {
+			// Interrupt is a distinct action, not a quit — reset any pending
+			// quit confirmation so a later Ctrl+C starts the count fresh.
+			m.quitArmed = false
 			m.interrupt()
 			return m, nil
 		}
-		m.quit = true
-		return m, tea.Quit
+		// Idle: first press arms and shows a hint; a second consecutive press quits.
+		if quitArmed {
+			m.quit = true
+			return m, tea.Quit
+		}
+		m.quitArmed = true
+		return m, nil
 
 	case tea.KeyEsc:
 		if m.turnRunning {
@@ -1380,6 +1401,13 @@ func (m *tuiModel) View() string {
 	if m.modal != nil {
 		b.WriteString(m.modalView())
 		return b.String()
+	}
+
+	// Quit confirmation: a first Ctrl+D or idle Ctrl+C arms the quit and shows
+	// this hint, which clears as soon as any other key is pressed.
+	if m.quitArmed {
+		b.WriteString(hintStyle.Render("  Press Ctrl+C or Ctrl+D again to exit"))
+		b.WriteByte('\n')
 	}
 
 	// Slash-command completion menu, right above the input box (Claude Code style).


### PR DESCRIPTION
## What

A single **Ctrl+D** — or a single **Ctrl+C while idle** — used to drop the whole TUI session immediately, which was easy to trigger by accident.

Both now arm a **shared quit confirmation** on the first press and only exit on a second consecutive press:

- First press → arms and shows a hint `Press Ctrl+C or Ctrl+D again to exit`.
- Second consecutive Ctrl+C or Ctrl+D → saves & quits. The confirmation is shared, so Ctrl+D→Ctrl+C and Ctrl+C→Ctrl+D both work.
- Any other key → disarms.
- **Ctrl+C during a running turn is unchanged** — it interrupts on a single press and clears any pending confirmation, so an interrupt can never confirm a quit.

## Implementation

- New `quitArmed` field on `tuiModel`.
- `handleKey` clears `quitArmed` at the top for any key except Ctrl+C/Ctrl+D — so the disarm applies even on the early-return paths (modal / sub-agent panel / completion menu / paste), before the main key switch.
- `KeyCtrlD` and the idle branch of `KeyCtrlC` arm on first press, quit on second.
- Running-turn `KeyCtrlC` explicitly resets `quitArmed` before interrupting.
- Hint rendered in `View` above the input box (suppressed while a modal is up).

## Tests

Added coverage in `tuirepl_test.go`:
- `TestTUI_CtrlDQuits` — arm then confirm.
- `TestTUI_CtrlCQuitsWhenIdle` — arm then confirm.
- `TestTUI_CtrlCInterruptsWithoutArmingQuit` — running-turn Ctrl+C never arms.
- `TestTUI_CtrlDAndCShareQuitConfirmation` / `TestTUI_CtrlCArmsThenCtrlDConfirms` — shared confirmation, both directions.
- `TestTUI_QuitDisarmedByOtherKey` / `TestTUI_QuitDisarmedByEarlyReturnKey` — disarm on a normal key and on an early-return completion-menu key (regression guard for the disarm placement).
- `TestTUI_CtrlDArmedThenRunningCtrlCInterrupts` — armed quit, then turn starts, Ctrl+C interrupts + disarms without quitting.

`go vet`, `gofmt -l`, and `go test ./cmd/octo/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)