### PR TITLE
fix(workflow): name the failing item when a parallel/pipeline branch raises

### DIFF
--- a/internal/workflow/prelude.rb
+++ b/internal/workflow/prelude.rb
@@ -154,7 +154,12 @@ end
 def __resume_branch(fibers, i, items, *args)
   fibers[i].resume(*args)
 rescue => e
-  raise if e.message.index("workflow: ") == 0
+  # Re-raise `e` explicitly (not a bare `raise`): in this mruby build a bare
+  # re-raise inside a method-level rescue loses the exception message, leaving
+  # only the class name — which would swallow "workflow: token budget
+  # exhausted", "workflow: skill … failed", and an inner level's already-
+  # localized "workflow: item #…" message.
+  raise e if e.message.index("workflow: ") == 0
   preview = (items[i].to_s rescue "?")
   preview = preview[0, 200] + "..." if preview.length > 200
   raise "workflow: item ##{i} (#{preview}) failed: #{e.message}"

--- a/internal/workflow/prelude.rb
+++ b/internal/workflow/prelude.rb
@@ -143,6 +143,23 @@ def phase(title)
   nil
 end
 
+# __resume_branch resumes one branch's fiber and, if the block raises, re-raises
+# with the failing item's index and a short preview — so a parallel/pipeline
+# failure names WHICH item blew up ("item #3 ([\"strict\", \"gpt-4o\"]) failed:
+# ...") instead of surfacing a bare, contextless "script error: <msg>" that
+# forces the author to guess which of N branches produced it. Signals the
+# scheduler itself raises — cancellation, budget exhaustion, or an inner level's
+# already-localized item error — begin with "workflow: " and pass through
+# unwrapped, so cancellation stays clean and nesting doesn't double-prefix.
+def __resume_branch(fibers, i, items, *args)
+  fibers[i].resume(*args)
+rescue => e
+  raise if e.message.index("workflow: ") == 0
+  preview = (items[i].to_s rescue "?")
+  preview = preview[0, 200] + "..." if preview.length > 200
+  raise "workflow: item ##{i} (#{preview}) failed: #{e.message}"
+end
+
 # __run_fibers is the cooperative event loop: every item runs in its own fiber;
 # all branches are advanced to their first agent() call (so every job is in
 # flight) before any result is awaited; then completions are drained in finish
@@ -156,14 +173,14 @@ def __run_fibers(items)
     results = Array.new(fibers.size)
     pending = {}                                 # host token => fiber index
     fibers.each_with_index do |f, i|
-      r = f.resume
+      r = __resume_branch(fibers, i, items)
       f.alive? ? (pending[r] = i) : (results[i] = r)
     end
     until pending.empty?
       token, result = __take_for(pending)         # next completion this level owns
       i      = pending.delete(token)
       f      = fibers[i]
-      r      = f.resume(result)                    # agent() returns; fiber continues
+      r      = __resume_branch(fibers, i, items, result) # agent() returns; fiber continues
       f.alive? ? (pending[r] = i) : (results[i] = r)
     end
     results

--- a/internal/workflow/runtime_test.go
+++ b/internal/workflow/runtime_test.go
@@ -249,6 +249,46 @@ func TestRun_ParallelBranchErrorAfterAgentNamesItem(t *testing.T) {
 	}
 }
 
+// TestRun_NestedParallelBranchErrorKeepsInnerLocus exercises the passthrough
+// branch of __resume_branch: an inner level localizes the failure ("item
+// #0 …"), and the OUTER level must re-raise that already-localized message
+// unchanged rather than swallowing it or double-prefixing. Guards the
+// `raise e` (not bare `raise`) fix — a bare re-raise drops the message in this
+// mruby build, collapsing the error to a bare class name.
+func TestRun_NestedParallelBranchErrorKeepsInnerLocus(t *testing.T) {
+	_, err := Run(context.Background(),
+		`parallel([1]) { |x| parallel([1]) { |y| raise "deep"; agent("z") } }`,
+		Options{Agent: echoAgent})
+	if err == nil {
+		t.Fatal("expected a script error from the nested raising branch")
+	}
+	// The inner locus + original message must survive the outer re-raise.
+	for _, want := range []string{"item #0", "deep"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("nested error should preserve inner locus/message (%q); got: %v", want, err)
+		}
+	}
+}
+
+// TestRun_BudgetExhaustedInParallelKeepsMessage guards that a scheduler signal
+// raised inside a branch ("workflow: token budget exhausted") passes through
+// __resume_branch with its message intact rather than being localized or
+// reduced to a bare class name.
+func TestRun_BudgetExhaustedInParallelKeepsMessage(t *testing.T) {
+	costly := func(_ context.Context, _ string, _ AgentOptions) AgentResult {
+		return AgentResult{Reply: "ok", OutputTokens: 100}
+	}
+	_, err := Run(context.Background(),
+		`parallel([1, 2, 3]) { |i| agent("x") }`,
+		Options{Agent: costly, Budget: 50})
+	if err == nil {
+		t.Fatal("expected a budget-exhausted error")
+	}
+	if !strings.Contains(err.Error(), "budget") {
+		t.Errorf("budget message should survive the branch re-raise; got: %v", err)
+	}
+}
+
 // TestRun_CancellationComputeOnly guards the close-on-context-done path: a
 // runaway script that never re-enters a host call (no agent() in flight) must
 // still observe ctx cancellation, or workflow_kill — and the foreground

--- a/internal/workflow/runtime_test.go
+++ b/internal/workflow/runtime_test.go
@@ -215,6 +215,40 @@ func TestRun_Cancellation(t *testing.T) {
 	}
 }
 
+// TestRun_ParallelBranchErrorNamesItem verifies a branch that raises before its
+// first agent() call surfaces the failing item's index and value, not a bare
+// contextless script error — so the author knows which of N branches blew up.
+func TestRun_ParallelBranchErrorNamesItem(t *testing.T) {
+	_, err := Run(context.Background(),
+		`parallel([10, 20, 30]) { |x| raise "boom" if x == 20; agent("x") }`,
+		Options{Agent: echoAgent})
+	if err == nil {
+		t.Fatal("expected a script error from the raising branch")
+	}
+	for _, want := range []string{"item #1", "20", "boom"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should name the failing item (%q); got: %v", want, err)
+		}
+	}
+}
+
+// TestRun_ParallelBranchErrorAfterAgentNamesItem covers the second resume path:
+// a branch that raises AFTER its agent() returns (the fiber is resumed with the
+// result, then throws) must still be localized to its item.
+func TestRun_ParallelBranchErrorAfterAgentNamesItem(t *testing.T) {
+	_, err := Run(context.Background(),
+		`parallel([1, 2]) { |x| r = agent("x"); raise "bad" if x == 2; r }`,
+		Options{Agent: echoAgent})
+	if err == nil {
+		t.Fatal("expected a script error from the raising branch")
+	}
+	for _, want := range []string{"item #1", "bad"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should name the failing item (%q); got: %v", want, err)
+		}
+	}
+}
+
 // TestRun_CancellationComputeOnly guards the close-on-context-done path: a
 // runaway script that never re-enters a host call (no agent() in flight) must
 // still observe ctx cancellation, or workflow_kill — and the foreground


### PR DESCRIPTION
## Problem

When a block inside `parallel()` / `pipeline()` raised — the classic case being `JSON.parse` choking on a sub-agent reply that wasn't valid JSON — the exception propagated out of the cooperative fiber scheduler as a bare `workflow: script error: invalid json (JSON::ParserError)`. With a dozen branches fanned out over the same code, that message names no item, so the author has no idea which of the N sub-agents returned the bad payload.

## Fix

`__run_fibers` now resumes each branch through `__resume_branch`, which, if the block raises, re-raises with the item's index and a short preview:

```
workflow: item #3 (["strict", "gpt-4o"]) failed: invalid json (JSON::ParserError)
```

Signals the scheduler itself raises — cancellation (`workflow: canceled`), budget exhaustion (`workflow: token budget exhausted`), and an inner nesting level's already-localized `workflow: item #…` error — all begin with `workflow: ` and pass through unwrapped, so cancellation stays clean and nested `parallel`s don't double-prefix.

### Scope (what this does NOT change)

It does not change *when* the error surfaces. A script that collects `parallel()` results and only `JSON.parse`s them **after** the join (as in the motivating session) still parses after the join — that ordering is the script's own structure, not a scheduler defect, so there's no "fail-fast" change here. This PR only adds **locus** to a branch-level failure — which also lands for the recommended pattern where each branch parses its own result (`parallel(items) { |it| JSON.parse(agent(...)) }`).

## Tests

- `TestRun_ParallelBranchErrorNamesItem` — a branch raising before its first `agent()` names the item (index + value) and preserves the original message.
- `TestRun_ParallelBranchErrorAfterAgentNamesItem` — same for a branch that raises after `agent()` returns (the second resume path).
- `TestRun_Cancellation` and the nested-parallel tests still pass, confirming `workflow:`-prefixed signals pass through unwrapped.

`gofmt` clean, `go vet` + `go test ./internal/workflow/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
