### PR TITLE
chore(sub-agent): raise concurrent async sub-agent cap from 8 to 16

### DIFF
--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -178,7 +178,7 @@ func subAgentManagerEnabled() bool {
 // New spawns past the cap are rejected with a clear error so the model waits
 // for some to finish; it does not bound resumed (Send/Continue) rounds, which
 // are limited by the live-child cap.
-const maxConcurrentSubAgents = 8
+const maxConcurrentSubAgents = 16
 
 // SubAgentManager owns the set of async sub-agents for a session.
 // Methods are safe for concurrent use.


### PR DESCRIPTION
## Summary

`maxConcurrentSubAgents` gates how many `run_in_background` sub-agents run at once. 8 was conservative; double it to 16 to give larger fan-outs more headroom while still bounding concurrent API-driven agent loops.

The rejection error already interpolates the constant, so its message updates automatically.

## Test plan

- `make test`
- `make vet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)