### PR TITLE
chore: bump version to 1.10.7 + fix flaky channel-issue test

### DIFF
--- a/internal/server/channel_restart_test.go
+++ b/internal/server/channel_restart_test.go
@@ -345,8 +345,18 @@ func TestChannelIssue_SurfacedViaListChannels(t *testing.T) {
 	})
 	srv.reloadChannel("crashfake-api")
 
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) && srv.channelIssue("crashfake-api") == "" {
+	// Wait for the terminal give-up state, not merely any recorded issue.
+	// While the restart loop is still cycling, the issue toggles: it's set on
+	// each crash (recordChannelIssue) and cleared again after a successful
+	// rebuild (clearChannelIssue). A poll that breaks on the first set issue
+	// can then land its follow-up read in that brief cleared window and see
+	// "". Once the adapter gives up it's removed from runningAdapters and the
+	// issue is recorded permanently — a stable state to assert against.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if srv.channelIssue("crashfake-api") != "" && !srv.isAdapterRunning("crashfake-api") {
+			break
+		}
 		time.Sleep(10 * time.Millisecond)
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.10.5"
+var Version = "1.10.6"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.10.6"
+var Version = "1.10.7"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bumps the version to **1.10.7** and fixes the flaky `TestChannelIssue_SurfacedViaListChannels` that was failing the ubuntu race job on this PR.

## Flaky test fix

The test polled for *any* recorded channel issue, then did a **separate** follow-up read to assert on. While the restart loop is still cycling, the issue toggles — set on each crash (`recordChannelIssue`), cleared after a successful rebuild (`clearChannelIssue`) — so the follow-up read could land in the brief cleared window and see `""`, failing the assertion. Under `-race` on a loaded CI runner that window widens enough to hit occasionally.

Fix: wait for the **terminal give-up state** (issue recorded *and* adapter no longer running), where the issue is recorded permanently — matching the sibling `TestChannelIssue_ExceededRestartLimit`. Deadline widened to 5s for race-build headroom.

Verified with `go test -race -run TestChannelIssue -count=30 ./internal/server/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)