### PR TITLE
feat(ws): broadcast confirmation completion to all clients

### DIFF
--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -870,13 +870,29 @@ func (s *Server) handleWSRunTask(conn *wsConn, sessionID string) {
 	})
 }
 
-// handleWSConfirmation delivers a confirmation answer from the browser.
+// handleWSConfirmation delivers a confirmation answer from one client and
+// broadcasts a completion event so every other subscribed client can close
+// its modal for the same confirmation.
 func (s *Server) handleWSConfirmation(confID, result string) {
 	s.confirmMu.Lock()
 	if ch, ok := s.confirmations[confID]; ok {
 		ch <- result
 	}
 	s.confirmMu.Unlock()
+
+	s.pendingPromptMu.Lock()
+	defer s.pendingPromptMu.Unlock()
+	for sessionID, pending := range s.pendingConfirms {
+		if pending.ConfID == confID {
+			s.wsHub.broadcast(sessionID, wsEventConfirmationComplete{
+				Type:      "confirmation_complete",
+				SessionID: sessionID,
+				ConfID:    confID,
+				Result:    result,
+			})
+			return
+		}
+	}
 }
 
 // extractTextContent extracts plain text from content which may be a string

--- a/internal/server/ws_types.go
+++ b/internal/server/ws_types.go
@@ -216,6 +216,16 @@ type wsEventRequestConfirmation struct {
 	Input    string `json:"input,omitempty"`   // other tools: sorted "key: value" lines
 }
 
+// wsEventConfirmationComplete tells all connected clients that a permission
+// confirmation has been answered (by any client). It lets secondary tabs close
+// the modal so the user isn't asked again for the same action.
+type wsEventConfirmationComplete struct {
+	Type      string `json:"type"`
+	SessionID string `json:"session_id"`
+	ConfID    string `json:"id"`
+	Result    string `json:"result"`
+}
+
 type wsEventRequestUserQuestion struct {
 	Type string `json:"type"`
 	// SessionID is required by the dispatcher's session filter — without

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -295,6 +295,13 @@ export interface WsEventRequestConfirmation {
   input?: string // other tools
 }
 
+export interface WsEventConfirmationComplete {
+  type: 'confirmation_complete'
+  session_id: string
+  id: string
+  result: string
+}
+
 export interface WsEventRequestUserQuestion {
   type: 'request_user_question'
   session_id: string
@@ -364,6 +371,7 @@ export type WsEvent =
   | WsEventSessionDeleted
   | WsEventRequestFeedback
   | WsEventRequestConfirmation
+  | WsEventConfirmationComplete
   | WsEventRequestUserQuestion
   | WsEventBackgroundTaskUpdate
   | WsEventDiff

--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -754,6 +754,19 @@
       })
     }))
 
+    cleanups.push(ws.on('confirmation_complete', (ev) => {
+      if ((ev as any).session_id && (ev as any).session_id !== sid) return
+      confirmModal.update(current => {
+        if (!current) return current
+        // Only close if this completion is for the confirmation currently
+        // shown in this tab; otherwise leave any unrelated modal untouched.
+        if ((ev as any).id === current.id) {
+          return null
+        }
+        return current
+      })
+    }))
+
     cleanups.push(ws.on('request_user_question', (ev) => {
       if ((ev as any).session_id && (ev as any).session_id !== sid) return
       // Falls back to sid like the dismiss_user_question handler below —


### PR DESCRIPTION
When a permission confirmation is answered on one WebSocket client, other subscribed clients still showed a stale confirmation modal because the server only forwarded the answer to the waiting turn and never told anyone else the prompt was resolved.

Changes:
- Add a server-sent `confirmation_complete` event carrying `session_id`, `id` and `result`.
- Broadcast the event from `handleWSConfirmation` after delivering the answer to the waiting channel.
- Close the web UI confirm modal when `confirmation_complete` arrives for the currently shown confirmation.

This keeps multiple clients in sync so answering on any one of them dismisses the modal everywhere else.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>