### PR TITLE
feat(serve): allow vscode-webview origins by default

### DIFF
--- a/cmd/octo/serve.go
+++ b/cmd/octo/serve.go
@@ -42,7 +42,7 @@ func runServe(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	system := fs.String("system", "", "System prompt")
 	maxTokens := fs.Int("max-tokens", 0, "max_tokens for responses")
 	tools := fs.Bool("tools", true, "Enable agentic tool loop")
-	cors := fs.String("cors", "", "Additional CORS allowed origins (comma-separated, * for any). app://obsidian.md is always allowed by default.")
+	cors := fs.String("cors", "", "Additional CORS allowed origins (comma-separated, * for any). app://obsidian.md and vscode-webview:// origins are always allowed by default.")
 	noChannel := fs.Bool("no-channel", false, "Disable IM channel (DingTalk, Feishu)")
 	noMemory := fs.Bool("no-memory", false, "Disable cross-session memory injection")
 	noSupervisor := fs.Bool("no-supervisor", false, "Run the server directly, without the self-restart supervisor (exit code 42 still signals a restart request to an external supervisor)")

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -131,6 +131,19 @@ func isLocalName(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+// isVSCodeWebviewOrigin reports whether origin was sent by a VS Code webview
+// panel. Each webview gets a fresh vscode-webview://<uuid> origin per window
+// and reload, so — unlike a fixed app scheme origin — it can never be pinned
+// as a literal --cors allowlist entry; the scheme itself is the only stable
+// signal. A hostile web page cannot forge this: browsers control the Origin
+// header, and only an actual local VS Code webview process can send this
+// scheme, so treating it as always-allowed is no wider than the existing
+// loopback exemption.
+func isVSCodeWebviewOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	return err == nil && u.Scheme == "vscode-webview"
+}
+
 // hostAllowed is the DNS-rebinding gate for the loopback exemption: the
 // Host header must name the local machine or a --cors allowlisted host. A
 // rebound page's request reaches 127.0.0.1 but carries Host: attacker.com.
@@ -164,7 +177,7 @@ func (s *Server) originAllowed(origin string) bool {
 	if err != nil || u.Host == "" {
 		return false
 	}
-	if isLocalName(canonicalHost(u.Host)) {
+	if u.Scheme == "vscode-webview" || isLocalName(canonicalHost(u.Host)) {
 		return true
 	}
 	for _, o := range s.cfg.CORSOrigins {

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -137,8 +137,19 @@ func isLocalName(host string) bool {
 // as a literal --cors allowlist entry; the scheme itself is the only stable
 // signal. A hostile web page cannot forge this: browsers control the Origin
 // header, and only an actual local VS Code webview process can send this
-// scheme, so treating it as always-allowed is no wider than the existing
-// loopback exemption.
+// scheme.
+//
+// The two call sites carry different guarantees, though. Here in
+// originAllowed(), this only ever gets consulted from behind requireAuth's
+// prior isLoopbackRemote check (and from wsCheckOrigin, reached only after
+// the same requireAuth gate on the /ws route) — so granting it is no wider
+// than the existing loopback exemption. corsMiddleware's use of this
+// predicate carries no such loopback guarantee: like every other configured
+// --cors entry (including the default app://obsidian.md), it reflects
+// Access-Control-Allow-Origin regardless of RemoteAddr. That's fine because
+// CORS headers only affect whether a browser lets JS read a response, never
+// whether requireAuth executes the request — but don't assume this predicate
+// implies loopback-only just because this call site does.
 func isVSCodeWebviewOrigin(origin string) bool {
 	u, err := url.Parse(origin)
 	return err == nil && u.Scheme == "vscode-webview"

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -53,6 +53,9 @@ func TestRequireAuth_LoopbackExemption(t *testing.T) {
 		// Non-loopback peers need the key, and spoofable headers don't help.
 		{"non-loopback no key", "http://192.168.1.5:8080/api/sessions", "192.168.1.9:50000", nil, http.StatusUnauthorized},
 		{"non-loopback XFF spoof", "http://192.168.1.5:8080/api/sessions", "192.168.1.9:50000", map[string]string{"X-Forwarded-For": "127.0.0.1"}, http.StatusUnauthorized},
+		// A vscode-webview Origin only grants the loopback exemption; it must
+		// not let a non-loopback caller skip the key, even genuinely presented.
+		{"non-loopback vscode-webview origin", "http://192.168.1.5:8080/api/sessions", "192.168.1.9:50000", map[string]string{"Origin": "vscode-webview://1a2b3c4d5e6f7890abcdef1234567890"}, http.StatusUnauthorized},
 	}
 
 	for _, tc := range cases {

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -163,6 +163,29 @@ func TestRequireAuth_CORSAllowlist(t *testing.T) {
 	}
 }
 
+// TestRequireAuth_VSCodeWebviewOrigin covers the octo VS Code extension's
+// default local path: a loopback request carrying a vscode-webview:// Origin
+// passes the exemption with no access key and no --cors flag, while a
+// lookalike Origin using the string "vscode-webview" as a Host (not a
+// Scheme) is rejected like any other foreign origin.
+func TestRequireAuth_VSCodeWebviewOrigin(t *testing.T) {
+	srv := mustServer(t, Config{AccessKey: testAccessKey})
+
+	w := authRequest(t, srv, http.MethodGet,
+		"http://127.0.0.1:8080/api/sessions", "127.0.0.1:50000",
+		map[string]string{"Origin": "vscode-webview://1a2b3c4d5e6f7890abcdef1234567890"})
+	if w.Code != http.StatusOK {
+		t.Errorf("vscode-webview origin: got %d, want 200", w.Code)
+	}
+
+	w = authRequest(t, srv, http.MethodGet,
+		"http://127.0.0.1:8080/api/sessions", "127.0.0.1:50000",
+		map[string]string{"Origin": "http://vscode-webview.evil.com"})
+	if w.Code != http.StatusForbidden {
+		t.Errorf("vscode-webview lookalike host: got %d, want 403", w.Code)
+	}
+}
+
 func TestRequireAuth_CORSWildcardNeverWidensGates(t *testing.T) {
 	srv := mustServer(t, Config{AccessKey: testAccessKey, CORSOrigins: []string{"*"}})
 
@@ -357,6 +380,10 @@ func TestWSCheckOrigin(t *testing.T) {
 		{"same origin non-local keyless", mkReq("192.168.1.5:8080", "http://192.168.1.5:8080", ""), false},
 		{"foreign origin", mkReq("127.0.0.1:8080", "https://evil.example", ""), false},
 		{"foreign origin with key", mkReq("127.0.0.1:8080", "https://evil.example", testAccessKey), true},
+		{"vscode webview origin", mkReq("127.0.0.1:8080", "vscode-webview://1a2b3c4d5e6f7890abcdef1234567890", ""), true},
+		// A spoofed Host under the vscode-webview name (not the scheme) must
+		// not pass — only url.Parse's Scheme grants the exemption.
+		{"vscode webview lookalike host", mkReq("127.0.0.1:8080", "http://vscode-webview.evil.com", ""), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -819,14 +819,18 @@ func (s *Server) registerRoutes() {
 	s.mux.Handle("/", s.staticHandler())
 }
 
-// corsMiddleware wraps the mux with CORS headers when configured.
+// corsMiddleware wraps the mux with CORS headers when configured, plus a
+// built-in allowance for VS Code webview origins (isVSCodeWebviewOrigin) so
+// the octo VS Code extension's REST calls work without a --cors flag. That
+// case can't reuse the CORSOrigins-driven fast path below, so the middleware
+// now always runs rather than short-circuiting to next when CORSOrigins is
+// empty; a bare OPTIONS request with no Origin header and no --cors
+// configured now gets 204 instead of falling through to the mux, which is
+// harmless (no client relies on that path 404ing/405ing).
 func (s *Server) corsMiddleware(next http.Handler) http.Handler {
-	if len(s.cfg.CORSOrigins) == 0 {
-		return next
-	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
-		allowed := false
+		allowed := isVSCodeWebviewOrigin(origin)
 		wildcard := false
 		for _, o := range s.cfg.CORSOrigins {
 			if o == "*" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -66,7 +66,8 @@ type Config struct {
 	// Tools enables the agentic tool loop.
 	Tools bool
 
-	// CORSOrigins lists allowed origins for CORS. Empty disables CORS.
+	// CORSOrigins lists additional allowed origins for CORS. vscode-webview://
+	// origins are always allowed regardless — see isVSCodeWebviewOrigin.
 	CORSOrigins []string
 
 	// NoChannel disables IM channel (DingTalk, Feishu, etc.) startup.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -392,6 +392,48 @@ func TestCORS_DisallowedOrigin(t *testing.T) {
 	}
 }
 
+// TestCORS_VSCodeWebview covers the octo VS Code extension's default local
+// path: its REST fetch()es carry a vscode-webview:// Origin and must get a
+// reflected Access-Control-Allow-Origin without any --cors flag configured.
+func TestCORS_VSCodeWebview(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/health", nil)
+	req.Header.Set("Origin", "vscode-webview://1a2b3c4d5e6f7890abcdef1234567890")
+	w := httptest.NewRecorder()
+	serveLoopback(srv.http.Handler, w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "vscode-webview://1a2b3c4d5e6f7890abcdef1234567890" {
+		t.Fatalf("CORS origin = %q, want the vscode-webview origin reflected", got)
+	}
+}
+
+// TestCORS_VSCodeWebviewLookalikeRejected asserts the allowance is scoped to
+// the vscode-webview: URL scheme, not any origin containing that string.
+func TestCORS_VSCodeWebviewLookalikeRejected(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	req.Header.Set("Origin", "http://vscode-webview.evil.com")
+	w := httptest.NewRecorder()
+	serveLoopback(srv.http.Handler, w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("expected no CORS header for lookalike origin, got %q", got)
+	}
+}
+
 func TestCORS_WildcardDoesNotReflectOrigin(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)


### PR DESCRIPTION
## Summary
- First slice of `dev-docs/vscode-extension-design.md` (#1316): admit `vscode-webview://<uuid>` origins so the upcoming octo VS Code extension's webview can talk to `octo serve` without `--cors` or an access key on the local loopback path.
- Unlike the existing `app://obsidian.md` default (a fixed string in `--cors`), each VS Code webview gets a fresh UUID per window/reload, so it's recognized by URL **scheme**, not by pinning a literal origin string.
- Two call sites needed the change, since they gate different things:
  - `originAllowed()` (`internal/server/auth.go`) — the `requireAuth` loopback exemption + WS upgrade `CheckOrigin`. Grants the connection itself.
  - `corsMiddleware()` (`internal/server/server.go`) — reflects the origin so the browser actually lets webview JS read cross-origin `fetch()` responses. Previously this fully no-opped whenever `--cors` was unset (the shipped Web UI is same-origin and never needed it), so a request could pass auth and still be unreadable client-side without this.
- Scoped strictly to the `vscode-webview:` scheme (never `"*"`); a lookalike origin like `http://vscode-webview.evil.com` is rejected in both places since only `url.Parse(origin).Scheme` is checked, not a substring/Host match.

## Test plan
- [x] `go test -race ./internal/server/...` — added `TestRequireAuth_VSCodeWebviewOrigin`, two new cases in `TestWSCheckOrigin`, `TestCORS_VSCodeWebview`, `TestCORS_VSCodeWebviewLookalikeRejected`; all existing origin/CORS tests still pass.
- [x] `go build ./...` && `go test -race ./...` — full repo green.
- [x] `gofmt -l` clean on changed files.