### PR TITLE
feat(skills): add artifact-design and dataviz default skills

### DIFF
--- a/internal/skills/defaults/artifact-design/SKILL.md
+++ b/internal/skills/defaults/artifact-design/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: artifact-design
+description: Design guidance for any self-contained HTML/Markdown file shown in octo's Artifacts panel — reports, dashboards, architecture/system diagrams, generated UIs, slide-style pages. Read this BEFORE writing the file, not after — it calibrates how much design effort the request warrants and covers the panel's real constraints (sandboxed iframe, no external resources, narrow default width, no live theme push). Use when the user asks to "画架构图" / "generate a diagram" / "make a dashboard" / "produce a report page" / "visualize this as a page" / build any artifact meant to be looked at rather than edited. For chart/graph/plot-specific color and mark rules, also read the dataviz skill.
+---
+
+# Artifact design
+
+An artifact is any `.html`/`.htm`/`.md`/`.markdown`/`.png`/`.jpg`/`.jpeg`/`.gif`/`.svg`/`.webp`
+file the agent produces. Writing one through `write_file`/`edit_file` surfaces it
+automatically in the web UI's Artifacts panel; a file built some other way (a
+script, a build step, a download) needs one `show_artifact` call with its
+absolute path. This skill is about what to put *inside* the HTML — read it
+before writing the first line.
+
+## How the panel actually works — design within these constraints
+
+- **Sandboxed, not sandboxed-privileged.** HTML renders in
+  `<iframe sandbox="allow-scripts" srcdoc=…>` — scripts run, but there is no
+  `allow-same-origin`: no cookies, no `localStorage`, no reach into the host
+  app. This is a hard boundary, not a suggestion — design as if the page runs
+  on an isolated blank origin, because it does.
+- **Self-contained is enforced, not just recommended.** The panel detects
+  `<script src=…>` / `<link href=…>` pointing anywhere but `data:`, `blob:`,
+  or `#`, and if it finds one it refuses to render the page at all — showing a
+  warning plus the raw source instead of your design. Inline every `<style>`
+  and `<script>`; embed images as `data:` URIs; never reference a CDN, a
+  Google Font, or any other network resource.
+- **The default viewport is narrow.** The panel is a **420px-wide docked
+  sidebar** by default; the user can maximize it to `min(900px, 75vw)`, but
+  don't design for that as the common case. Build the layout to read cleanly
+  at ~380–420px first, then let it use extra space gracefully above that —
+  not the other way around. This is the opposite of most artifact platforms,
+  where the canvas starts wide. Multi-column layouts, wide tables, and
+  side-by-side diagram lanes need an explicit `@media (max-width: 720px)` (or
+  tighter) fallback to a single column, or they'll clip or force horizontal
+  scroll in the default view.
+- **Theme support is one-directional.** Only `@media (prefers-color-scheme:
+  dark)` is a live signal in octo today — the panel does not push its own
+  light/dark toggle state into the iframe (unlike some other artifact
+  hosts). Still write `:root[data-theme="dark"]` / `:root[data-theme="light"]`
+  overrides alongside the media query — they're free, harmless if unused, and
+  correct if that wiring ever lands — but don't rely on them being live; the
+  media query is what actually renders today for most users.
+- **Update in place, not by versioning.** Re-running `write_file`/`edit_file`
+  against the *same absolute path* updates that same panel entry rather than
+  creating a new one. If you're iterating on a diagram, keep writing the same
+  file.
+- **No title/gallery metadata to set.** The panel derives the display name
+  from the file's basename and its type label from the extension — there is
+  no favicon or description field to populate. A `<title>` tag is harmless
+  but cosmetically inert here.
+- **Markdown gets code-block styling for free** (the panel inlines a
+  highlight.js theme for `.md` previews) — don't hand-roll code-fence CSS in
+  a Markdown artifact; that's only a concern for HTML artifacts.
+
+## Calibrate effort to the ask
+
+Don't build a dashboard when a status note was asked for, and don't ship a
+bare unstyled div when the user asked for something they'll actually look at
+and share. Match investment to what's being requested:
+
+- A one-off answer, a small table, a short report → a clean, readable page.
+  Spend your effort on typography and spacing, not on custom components.
+- A named artifact meant to be referred back to (an architecture diagram, a
+  dashboard, a generated tool UI) → invest in layout structure, a real color
+  system, and responsive behavior — this is the case the rest of this skill
+  is written for.
+
+## Self-contained checklist
+
+Before calling `write_file`/`show_artifact`, confirm:
+
+- [ ] No `<link rel="stylesheet" href="https://…">`, no CDN `<script src>` —
+      everything needed is inlined in one `<style>`/`<script>` block
+- [ ] No web fonts — use the system stack:
+      `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`
+- [ ] Any image is a `data:` URI or omitted, never a network URL
+- [ ] `@media (prefers-color-scheme: dark)` covers every color used, and every
+      color has a light-mode default that isn't just "assume light"
+- [ ] The narrowest layout (~380px) has no fixed-pixel widths wider than the
+      viewport and no unintended horizontal scroll on the page body — wrap
+      any table/code block that must be wide in its own
+      `overflow-x: auto` container instead
+
+## The box-and-arrow diagram pattern
+
+For architecture/system/flow diagrams, hand-written CSS beats reaching for a
+charting or graph-layout library — you get exact visual control, real theme
+support, and no library to inline. This is the same technique behind
+well-made "layered boxes with a few connectors" diagrams:
+
+- **Zones** — a `<div>` per architectural layer/boundary, colored via a CSS
+  variable per zone (`--accent`, `--serve`, `--agent`, …), laid out with
+  `display:flex`/`grid`, not absolute positioning
+- **Cards** inside a zone — one per component, a title + one or two lines of
+  description, not a paragraph
+- **Connectors** — Unicode arrow glyphs (`↕ ↓ ↑ → ←`) centered in their own
+  small `<div>`, not actual line-drawing; this keeps everything reflow-safe
+  when the panel width changes, which real SVG connectors are not
+- **Legend** — a row of colored dots (`<span class="dot">` with
+  `background: var(--accent)`) mapped 1:1 to the zone colors, so readers
+  decode color without following a line
+- **Numbered steps** — `<ol>` with CSS counters
+  (`counter-increment`/`content: counter(s)`) rendered as a small filled
+  circle, cheaper and crisper than an actual numbered-badge image
+
+Skeleton:
+
+```html
+<style>
+  :root { --bg:#fafaf9; --ink:#1c1917; --line:#d6d3d1; --accent:#2563eb; --accent-soft:#eff6ff; }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg:#0c0a09; --ink:#f5f5f4; --line:#292524; --accent:#60a5fa; --accent-soft:#172033; }
+  }
+  :root[data-theme="dark"] { --bg:#0c0a09; --ink:#f5f5f4; --line:#292524; --accent:#60a5fa; --accent-soft:#172033; }
+  :root[data-theme="light"] { --bg:#fafaf9; --ink:#1c1917; --line:#d6d3d1; --accent:#2563eb; --accent-soft:#eff6ff; }
+  * { box-sizing: border-box; }
+  body { margin:0; background:var(--bg); color:var(--ink); font:14px/1.5 -apple-system,BlinkMacSystemFont,sans-serif; }
+  .wrap { padding: 20px 16px; }
+  .zone { background:var(--accent-soft); border:1px solid var(--line); border-radius:12px; padding:14px; }
+  .cards { display:grid; gap:10px; }
+  .card { background:var(--bg); border:1px solid var(--line); border-radius:8px; padding:10px 12px; }
+  .connector { text-align:center; color:var(--line); font-size:20px; margin:6px 0; }
+  @media (min-width: 640px) { .cards.two { grid-template-columns: 1fr 1fr; } }
+</style>
+<div class="wrap">
+  <div class="zone">
+    <div class="cards">
+      <div class="card"><b>Component</b><br><span style="color:var(--line)">one line of description</span></div>
+    </div>
+  </div>
+  <div class="connector">↓</div>
+</div>
+```
+
+Reach for real SVG or an inlined graph library only when the diagram has
+many interconnected nodes needing automatic layout, or edges that genuinely
+cross at arbitrary points — most system/architecture diagrams are layered
+boxes and don't need that.

--- a/internal/skills/defaults/dataviz/SKILL.md
+++ b/internal/skills/defaults/dataviz/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: dataviz
+description: Use whenever you are about to create a chart, graph, plot, heatmap, sparkline, stat tile, or dashboard — whether as an HTML artifact, inline SVG, or plotting code in any library (matplotlib, plotly, Chart.js, D3, …). Covers chart-type selection, the color system for categorical/sequential/diverging data, legend/axis/tooltip conventions, and legibility at the Artifacts panel's narrow default width. Triggers on "chart", "graph", "plot", "visualize this data", "dashboard", "heatmap", "颜色", "配色", "画个图表". Read artifact-design first if the chart is going inside a full HTML artifact page — this skill is only about the chart itself, not the page it lives in.
+---
+
+# Data visualization
+
+This skill is scoped to the chart/graph, not the page around it. If you're
+building a full HTML artifact (a dashboard, a report page) that happens to
+contain a chart, read `artifact-design` for the page mechanics (self-contained
+HTML, theme handling, the panel's narrow default width) and come back here for
+the chart itself.
+
+## Pick the chart type from the data shape, not habit
+
+| Data shape | Chart |
+|---|---|
+| One value per category, few categories (≤8) | Horizontal or vertical bar |
+| A value over time | Line (single series) or small-multiple lines (few series) |
+| Part-of-whole, ≤5 slices | Stacked bar, not pie — bars compare more accurately than angles |
+| Distribution of one variable | Histogram |
+| Two continuous variables, looking for correlation | Scatter |
+| A matrix / two categorical axes | Heatmap |
+| One number that matters right now | A stat tile with a sparkline, not a full chart |
+
+Don't default to a bar chart for everything, and don't reach for a pie chart
+for more than a handful of categories — angle comparison degrades fast past
+3–4 slices.
+
+## Color: three systems, pick the one that matches the data
+
+- **Categorical** (distinct groups, no order) — one hue per series, evenly
+  spaced in perceptual lightness, capped around 6–8 before colors become
+  indistinguishable. Never let two adjacent categories share a hue family
+  (two blues next to each other reads as one blurred category).
+- **Sequential** (low→high, one direction) — a single hue ramped in
+  lightness only. Don't rainbow a sequential scale — a viewer should be able
+  to order values by lightness alone, and a rainbow ramp breaks that
+  ordering intuition (is red higher or lower than green?).
+- **Diverging** (a meaningful midpoint — zero, a target, "no change") — two
+  hues radiating from a neutral midpoint, symmetric in intensity on both
+  sides. Pick hues that read as opposites in the domain (red/green for
+  bad/good, cool/warm for below/above target) — not arbitrary complements.
+
+Use one accent color to mean "the thing being highlighted" and everything
+else in a muted neutral — don't give every bar its own loud color when only
+one of them is the point. `references/palette.md` has a validated default
+palette (light/dark aware, colorblind-checked) for all three systems — use it
+unless the artifact needs to match an existing brand palette, in which case
+swap the hex values but keep the lightness/spacing relationships.
+
+## Legends, axes, tooltips
+
+- If there are only 2–3 series, label them directly on the chart (a line's
+  end, a bar's top) instead of a separate legend — one less lookup for the
+  reader.
+- Axis labels need units in the label itself (`"latency (ms)"`), not just in
+  a caption below the chart — a screenshot or a scrolled view loses the
+  caption.
+- Truncate a y-axis that doesn't start at zero only when the domain
+  genuinely doesn't include zero (temperature, index values) — otherwise a
+  truncated bar-chart axis exaggerates differences and misleads.
+- A tooltip (if the chart is interactive) should repeat the exact value and
+  its unit, not just re-show what the axis already says visually.
+
+## Legibility at the panel's default width
+
+octo's Artifacts panel docks at **420px wide by default** — see
+`artifact-design` for the full constraint. For a chart specifically:
+
+- Avoid grouped/clustered bar charts with more than ~4 categories × 3 series
+  at that width — bars become too thin to read; switch to a small-multiple
+  layout (one mini-chart per series, stacked vertically) instead.
+- Rotate long category labels 0° if at all possible — a 420px column has no
+  room for a 45°-rotated label run without eating half the chart height.
+  Prefer horizontal bars (category on the y-axis) over vertical bars when
+  category names are long.
+- Don't rely on hover-only tooltips as the sole way to read a value if the
+  chart is likely viewed at the docked width — a static value label on the
+  mark itself survives both widths.
+
+## Accessibility
+
+- Every categorical palette in `references/palette.md` is checked against
+  common color-vision deficiencies — don't hand-pick replacement hues
+  without re-checking, since two colors that look distinct to you may not
+  be distinguishable to a colorblind reader.
+- Never encode meaning in color alone when the chart might be printed,
+  screenshotted in grayscale, or read by someone colorblind — pair color
+  with a position, a label, or a pattern (dashed vs solid line, filled vs
+  outlined marker).

--- a/internal/skills/defaults/dataviz/references/palette.md
+++ b/internal/skills/defaults/dataviz/references/palette.md
@@ -1,0 +1,73 @@
+# Default palette
+
+A validated starting palette for the three color systems described in
+`dataviz`'s SKILL.md. Swap these hex values for a brand palette when one
+exists; keep the lightness/spacing relationships between stops when you do —
+that's what keeps the ramp readable, not the specific hues.
+
+## Categorical (distinct groups, no order)
+
+Base set is Okabe–Ito — the standard colorblind-safe categorical palette
+(distinguishable under deuteranopia/protanopia/tritanopia). Light-mode value
+first, dark-mode tint second (a lighter, higher-saturation shade of the same
+hue for legibility on a dark background):
+
+| Role | Light | Dark |
+|---|---|---|
+| Series 1 (orange) | `#E69F00` | `#fbbf24` |
+| Series 2 (sky blue) | `#56B4E9` | `#38bdf8` |
+| Series 3 (bluish green) | `#009E73` | `#34d399` |
+| Series 4 (blue) | `#0072B2` | `#60a5fa` |
+| Series 5 (vermillion) | `#D55E00` | `#f87171` |
+| Series 6 (reddish purple) | `#CC79A7` | `#f472b6` |
+| Series 7 (yellow — use sparingly, low contrast on light bg) | `#F0E442` | `#fde047` |
+| Neutral / "everything else" | `#a8a29e` | `#78716c` |
+
+Assign in this order — it's ordered for maximum adjacent-pair distinguishability,
+so cap the series count at what you actually need and take from the top rather
+than reordering.
+
+## Sequential (low → high, one direction)
+
+Single hue, lightness-only ramp — don't rainbow this:
+
+| Stop | Light | Dark |
+|---|---|---|
+| Lowest | `#eff6ff` | `#172033` |
+| | `#bfdbfe` | `#1e3a5f` |
+| Mid | `#60a5fa` | `#3b82f6` |
+| | `#2563eb` | `#60a5fa` |
+| Highest | `#1e3a8a` | `#bfdbfe` |
+
+Dark mode inverts the lightness direction (dark→light reads as low→high on a
+dark background) — don't reuse the light-mode ramp verbatim under a dark
+media query, it'll invert the meaning.
+
+## Diverging (a meaningful midpoint — zero, a target, "no change")
+
+Two hues radiating from a neutral center, symmetric intensity both sides:
+
+| Stop | Light | Dark |
+|---|---|---|
+| Most negative | `#b91c1c` | `#f87171` |
+| | `#fca5a5` | `#7f1d1d` |
+| Midpoint (neutral) | `#f5f5f4` | `#292524` |
+| | `#93c5fd` | `#1e3a5f` |
+| Most positive | `#1d4ed8` | `#60a5fa` |
+
+Red/blue is the default here because "negative/positive" and "below/above
+target" are the most common diverging cases; swap to a domain-appropriate
+pair (e.g. a single hue's light/dark tint on each side) when red/green-coded
+good/bad would clash with a status color already used elsewhere on the page.
+
+## Accent + neutral (the common case: one series matters, the rest are context)
+
+Don't pull from the categorical table when only one series is the point of
+the chart — use a single accent against a neutral background instead:
+
+| Role | Light | Dark |
+|---|---|---|
+| Accent (the highlighted series) | `#2563eb` | `#60a5fa` |
+| Neutral (context series) | `#d6d3d1` | `#44403c` |
+| Ink (text, axis lines) | `#1c1917` | `#f5f5f4` |
+| Muted text (labels, captions) | `#78716c` | `#a8a29e` |

--- a/internal/tools/artifact.go
+++ b/internal/tools/artifact.go
@@ -63,7 +63,9 @@ func (ShowArtifactTool) Definition() agent.ToolDefinition {
 			"create with write_file/edit_file are surfaced automatically and do NOT need this. In the " +
 			"web UI the file opens in the Artifacts panel (HTML renders in a sandboxed preview); in " +
 			"the TUI the path renders as a click-to-open link; elsewhere the path is simply " +
-			"reported. The file must already exist.",
+			"reported. The file must already exist. Before authoring an HTML artifact's content, " +
+			"check the artifact-design skill (and dataviz for any chart/graph) for the panel's " +
+			"constraints — self-contained only, sandboxed iframe, narrow default width.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{


### PR DESCRIPTION
## Summary
- Adds two bundled default skills mirroring Claude Code's `artifact-design` and `dataviz`, scoped to octo's actual Artifacts panel mechanics (sandboxed iframe, enforced self-contained HTML, no live theme push, 420px default width, chip-switchable per-session panel — no gallery/favicon concepts).
- `artifact-design`: effort calibration, self-contained checklist, theme handling given octo only has a live `prefers-color-scheme` signal today, and a reusable box-and-arrow diagram pattern (the "架构图" case).
- `dataviz`: chart-type selection, categorical/sequential/diverging color systems with a bundled colorblind-safe palette (`references/palette.md`, Okabe–Ito based), legibility guidance at the panel's narrow default width. Defers HTML/page mechanics to `artifact-design`.
- `show_artifact`'s tool description now points at both skills before HTML authoring — the same coupling Claude Code's Artifact tool has with its own `artifact-design` skill.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `go test ./internal/tools/... ./internal/skills/...` passes
- [x] Manually verified both new SKILL.md files parse through the real `MaterializeDefaults` → `Discover` → `Get` pipeline (frontmatter with embedded quotes/CJK text parses correctly, description + body both load)
- [ ] Manual: ask an octo session to "画一个架构图" and confirm it reads `artifact-design` and produces a self-contained, theme-aware artifact that renders in the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)