### PR TITLE
feat(provider): add LongCat vendor, refresh Claude/GPT model lists, fix --provider completion

### DIFF
--- a/cmd/octo/completion.go
+++ b/cmd/octo/completion.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/app"
 )
 
 // `octo completion <shell>` and the hidden `octo __complete <words…>` work
@@ -121,7 +122,7 @@ func chatCandidates(words []string, prev string) []string {
 	case "-c", "--continue":
 		return sessionIDCandidates()
 	case "--provider":
-		return []string{"anthropic", "openai"}
+		return providerCandidates()
 	case "--permission-mode":
 		return []string{"interactive", "strict", "auto"}
 	case "--reasoning-effort":
@@ -137,6 +138,17 @@ func chatCandidates(words []string, prev string) []string {
 	return chatFlags
 }
 
+// providerCandidates lists every registered vendor ID for --provider
+// completion, derived from the single registry (app.Registry) so a newly
+// added vendor is picked up automatically instead of needing a second edit.
+func providerCandidates() []string {
+	ids := make([]string, len(app.Registry))
+	for i, v := range app.Registry {
+		ids[i] = v.ID
+	}
+	return ids
+}
+
 func memoryCandidates(words []string) []string {
 	if len(words) == 3 {
 		return []string{"list"}
@@ -150,7 +162,7 @@ func memoryCandidates(words []string) []string {
 func initCandidates(prev string) []string {
 	switch prev {
 	case "--provider":
-		return []string{"anthropic", "openai"}
+		return providerCandidates()
 	case "--permission-mode":
 		return []string{"interactive", "strict", "auto"}
 	}
@@ -191,8 +203,8 @@ What it completes:
   - Top-level subcommands (config, memory, init, …) and session flags.
   - Subcommands of memory / help / completion.
   - Session IDs after "octo -c " — full + short + "last".
-  - Fixed values for --provider (anthropic|openai) and --permission-mode
-    (interactive|strict|auto).
+  - Fixed values for --provider (every registered vendor) and
+    --permission-mode (interactive|strict|auto).
 
 The shell snippet just delegates to the hidden "octo __complete" subcommand;
 the routing logic lives in the binary, so the same snippet keeps working as

--- a/cmd/octo/completion_test.go
+++ b/cmd/octo/completion_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/app"
 )
 
 // containsAll is a tiny assertion helper for "every want is present in got".
@@ -92,8 +93,12 @@ func TestCompletionCandidates_DefaultChatMode_SessionIDs(t *testing.T) {
 
 func TestCompletionCandidates_ProviderValueAfterFlag(t *testing.T) {
 	got := completionCandidates([]string{"octo", "--provider", ""})
-	if !sliceEq(got, []string{"anthropic", "openai"}) {
-		t.Errorf("--provider value completion = %v, want [anthropic openai]", got)
+	want := make([]string, len(app.Registry))
+	for i, v := range app.Registry {
+		want[i] = v.ID
+	}
+	if !sliceEq(got, want) {
+		t.Errorf("--provider value completion = %v, want %v", got, want)
 	}
 }
 
@@ -227,8 +232,12 @@ func TestRunComplete_PrintsCandidatesOnePerLine(t *testing.T) {
 		t.Errorf("exit = %d, want 0", code)
 	}
 	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
-	if !sliceEq(lines, []string{"anthropic", "openai"}) {
-		t.Errorf("output = %v", lines)
+	want := make([]string, len(app.Registry))
+	for i, v := range app.Registry {
+		want[i] = v.ID
+	}
+	if !sliceEq(lines, want) {
+		t.Errorf("output = %v, want %v", lines, want)
 	}
 }
 

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -49,7 +49,11 @@ func contextWindow(model string) int {
 	m := strings.ToLower(model)
 	switch {
 	// ── Anthropic Claude ──
+	case strings.Contains(m, "claude-fable-5") || strings.Contains(m, "claude-mythos-5"):
+		return 1_000_000
 	case strings.Contains(m, "claude-opus-4.8") || strings.Contains(m, "claude-opus-4"):
+		return 1_000_000
+	case strings.Contains(m, "claude-sonnet-5"):
 		return 1_000_000
 	case strings.Contains(m, "claude-sonnet-4-5") || strings.Contains(m, "claude-sonnet-4"):
 		return 256_000
@@ -65,6 +69,8 @@ func contextWindow(model string) int {
 		return 256_000
 
 	// ── OpenAI GPT / O-series ──
+	case strings.Contains(m, "gpt-5.6") || strings.Contains(m, "gpt5.6"):
+		return 1_000_000
 	case strings.Contains(m, "gpt-5.5") || strings.Contains(m, "gpt5.5"):
 		return 1_000_000
 	case strings.Contains(m, "gpt-5") || strings.Contains(m, "gpt5"):
@@ -188,6 +194,10 @@ func contextWindow(model string) int {
 		return 256_000
 	case strings.Contains(m, "mimo"):
 		return 128_000
+
+	// ── LongCat (Meituan) ──
+	case strings.Contains(m, "longcat"):
+		return 1_000_000
 
 	// ── Cohere ──
 	case strings.Contains(m, "command-r-plus") || strings.Contains(m, "command-r"):

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -99,6 +99,18 @@ func TestContextWindow(t *testing.T) {
 	if got := contextWindow("gemini-3.5-flash"); got != 1_000_000 {
 		t.Errorf("gemini-3.5-flash window = %d, want 1000000", got)
 	}
+	if got := contextWindow("LongCat-2.0"); got != 1_000_000 {
+		t.Errorf("LongCat-2.0 window = %d, want 1000000", got)
+	}
+	if got := contextWindow("claude-sonnet-5"); got != 1_000_000 {
+		t.Errorf("claude-sonnet-5 window = %d, want 1000000", got)
+	}
+	if got := contextWindow("claude-fable-5"); got != 1_000_000 {
+		t.Errorf("claude-fable-5 window = %d, want 1000000", got)
+	}
+	if got := contextWindow("gpt-5.6-sol"); got != 1_000_000 {
+		t.Errorf("gpt-5.6-sol window = %d, want 1000000", got)
+	}
 	if got := contextWindow("unknown-model-xyz"); got != defaultContextWindow {
 		t.Errorf("unknown model window = %d, want %d (conservative default)", got, defaultContextWindow)
 	}

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -58,6 +58,9 @@ var Registry = []Vendor{
 		DefaultBaseURL: "https://api.openai.com",
 		DefaultModel:   "gpt-5.4",
 		Models: []VendorModel{
+			{ID: "gpt-5.6-sol", Vision: true},
+			{ID: "gpt-5.6-terra", Vision: true},
+			{ID: "gpt-5.6-luna", Vision: true},
 			{ID: "gpt-5.5", Vision: true},
 			{ID: "gpt-5.4", Vision: true},
 			{ID: "gpt-5.4-mini", Vision: true},
@@ -81,9 +84,11 @@ var Registry = []Vendor{
 		DefaultBaseURL: "https://api.anthropic.com",
 		DefaultModel:   "claude-sonnet-4-6",
 		Models: []VendorModel{
+			{ID: "claude-fable-5", Vision: true},
 			{ID: "claude-opus-4-8", Vision: true},
 			{ID: "claude-opus-4-7", Vision: true},
 			{ID: "claude-opus-4-6", Vision: true},
+			{ID: "claude-sonnet-5", Vision: true},
 			{ID: "claude-sonnet-4-6", Vision: true},
 			{ID: "claude-sonnet-4-5", Vision: true},
 			{ID: "claude-haiku-4-5", Vision: true},
@@ -245,6 +250,20 @@ var Registry = []Vendor{
 		},
 		APIKeyEnvVar: "MIMO_API_KEY",
 		WebsiteURL:   "https://platform.xiaomimimo.com/#/console/api-keys",
+	},
+	{
+		ID:             "longcat",
+		DisplayName:    "LongCat (Meituan)",
+		Protocol:       "openai",
+		API:            "openai-completions",
+		DefaultBaseURL: "https://api.longcat.chat/openai",
+		DefaultModel:   "LongCat-2.0",
+		// LongCat-2.0 accepts text input only (no image/vision support on the API).
+		Models: []VendorModel{
+			{ID: "LongCat-2.0", Vision: false},
+		},
+		APIKeyEnvVar: "LONGCAT_API_KEY",
+		WebsiteURL:   "https://longcat.chat/platform/api_keys",
 	},
 	{
 		ID:          ProviderCustom,

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -64,7 +64,7 @@ func TestVendor_KimiCodingPlan_BuildClient_CustomBaseURL(t *testing.T) {
 func TestIsKnownVendor(t *testing.T) {
 	for _, id := range []string{
 		"openrouter", "deepseek", "minimax", "kimi", "kimi-coding-plan",
-		"glm", "openai", "anthropic", "bailian", "mimo",
+		"glm", "openai", "anthropic", "bailian", "mimo", "longcat",
 		ProviderCustom,
 	} {
 		if !IsKnownVendor(id) {
@@ -179,6 +179,7 @@ func TestVendorEnvVars(t *testing.T) {
 		{"anthropic", "ANTHROPIC_API_KEY"},
 		{"bailian", "DASHSCOPE_API_KEY"},
 		{"mimo", "MIMO_API_KEY"},
+		{"longcat", "LONGCAT_API_KEY"},
 	}
 	for _, tc := range tests {
 		got := VendorAPIKeyEnvVar(tc.id)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -270,7 +270,7 @@ func ModelSupportsVision(model string) bool {
 			return true
 		}
 	}
-	for _, textOnly := range []string{"qwen", "deepseek", "kimi", "moonshot", "baichuan", "ernie", "glm-", "spark", "abab", "yi-"} {
+	for _, textOnly := range []string{"qwen", "deepseek", "kimi", "moonshot", "baichuan", "ernie", "glm-", "spark", "abab", "yi-", "longcat"} {
 		if strings.Contains(m, textOnly) {
 			return false
 		}


### PR DESCRIPTION
## Summary
- Registers **LongCat** (Meituan, https://longcat.chat/platform/docs/zh/) as a new OpenAI-protocol vendor: `api.longcat.chat/openai` (openai Chat Completions compatible), model `LongCat-2.0` (text-only, 1M context / 128K max output). Verified live against the real endpoint (401 with a dummy key, confirming the URL path resolves correctly).
- Refreshes the `anthropic` and `openai` vendor model catalogues with newly released models, confirmed against official docs: `claude-sonnet-5`, `claude-fable-5` (Anthropic), `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` (OpenAI). Added matching entries to `internal/agent/compaction.go`'s `contextWindow()` table (1M tokens each) so they don't fall back to the conservative 128K default and trigger auto-compaction too early. Existing `DefaultModel`/`LiteModel` per vendor are left untouched — this only expands the selectable catalogue.
- Fixes `octo __complete` for `--provider`: it hardcoded `[]string{"anthropic", "openai"}` in two places and silently missed every other registered vendor (deepseek, minimax, kimi, glm, bailian, mimo, longcat, custom). Now derives the candidate list from `app.Registry` via a new `providerCandidates()` helper, so future vendors complete automatically without a second edit.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `go test ./internal/app/... ./internal/agent/... ./internal/config/... ./cmd/octo/...`
- [x] Manual smoke test: `octo --provider longcat --model LongCat-2.0 "ping"` reached the real `https://api.longcat.chat/openai/v1/chat/completions` endpoint (401 auth error with a dummy key, confirming the path is correct)
- [x] Independent isolated-subagent code review of the LongCat registration (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)