### PR TITLE
web(sidebar): move workflows after mcp in sidebar order

### DIFF
--- a/web/src/components/layout/Sidebar.svelte
+++ b/web/src/components/layout/Sidebar.svelte
@@ -29,8 +29,8 @@
     { icon: 'ant-design:message-outlined', title: 'sidebar.chat', v: 'chat' },
     { icon: 'ant-design:clock-circle-outlined', title: 'nav.tasks', v: 'tasks' },
     { icon: 'ant-design:thunderbolt-outlined', title: 'nav.skills', v: 'skills' },
-    { icon: 'ant-design:partition-outlined', title: 'nav.workflows', v: 'workflows' },
     { icon: 'ant-design:api-outlined', title: 'nav.mcp', v: 'mcp' },
+    { icon: 'ant-design:partition-outlined', title: 'nav.workflows', v: 'workflows' },
     { icon: 'ant-design:global-outlined', title: 'nav.browser', v: 'browser' },
     { icon: 'ant-design:mobile-outlined', title: 'nav.channels', v: 'channels' },
     { icon: 'ant-design:user-outlined', title: 'nav.memory', v: 'profile' },
@@ -209,8 +209,8 @@
         {#each [
           { icon: 'ant-design:clock-circle-outlined', label: 'nav.tasks', v: 'tasks' },
           { icon: 'ant-design:thunderbolt-outlined', label: 'nav.skills', v: 'skills' },
-          { icon: 'ant-design:partition-outlined', label: 'nav.workflows', v: 'workflows' },
           { icon: 'ant-design:api-outlined', label: 'nav.mcp', v: 'mcp' },
+          { icon: 'ant-design:partition-outlined', label: 'nav.workflows', v: 'workflows' },
           { icon: 'ant-design:global-outlined', label: 'nav.browser', v: 'browser' },
           { icon: 'ant-design:mobile-outlined', label: 'nav.channels', v: 'channels' },
         ] as item}


### PR DESCRIPTION
## Summary
- 调整侧边栏顺序：将 workflows 移到 mcp 后面
- 完整侧边栏和 rail 侧边栏同步调整，保持一致

## Before
tasks → skills → workflows → mcp → browser → channels

## After
tasks → skills → mcp → workflows → browser → channels

Co-authored-by: octo-agent <no-reply@octo-agent.dev>