### PR TITLE
feat(blog): add architecture deep-dive article with interactive panorama

### DIFF
--- a/blog/public/architecture-map.html
+++ b/blog/public/architecture-map.html
@@ -1,0 +1,620 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>octo-agent 架构地图</title>
+<style>
+:root {
+  --bg: #fafaf9;
+  --surface: #ffffff;
+  --ink: #1c1917;
+  --ink-muted: #78716c;
+  --line: #d6d3d1;
+  --accent: #2563eb;
+  --accent-soft: #dbeafe;
+  --serve: #059669;
+  --serve-soft: #d1fae5;
+  --agent: #7c3aed;
+  --agent-soft: #ede9fe;
+  --provider: #d97706;
+  --provider-soft: #fef3c7;
+  --tool: #dc2626;
+  --tool-soft: #fee2e2;
+  --server: #0891b2;
+  --server-soft: #cffafe;
+  --channel: #db2777;
+  --channel-soft: #fce7f3;
+  --cross: #64748b;
+  --cross-soft: #f1f5f9;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0c0a09;
+    --surface: #1c1917;
+    --ink: #f5f5f4;
+    --ink-muted: #a8a29e;
+    --line: #292524;
+    --accent: #60a5fa;
+    --accent-soft: #1e3a5f;
+    --serve: #34d399;
+    --serve-soft: #064e3b;
+    --agent: #a78bfa;
+    --agent-soft: #2e1065;
+    --provider: #fbbf24;
+    --provider-soft: #78350f;
+    --tool: #f87171;
+    --tool-soft: #7f1d1d;
+    --server: #22d3ee;
+    --server-soft: #164e63;
+    --channel: #f472b6;
+    --channel-soft: #831843;
+    --cross: #94a3b8;
+    --cross-soft: #1e293b;
+  }
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font: 13px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.wrap { padding: 16px; max-width: 100%; }
+
+h1 {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0 0 4px 0;
+  letter-spacing: -0.01em;
+}
+.subtitle {
+  font-size: 12px;
+  color: var(--ink-muted);
+  margin-bottom: 16px;
+}
+
+/* Legend */
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 14px;
+  padding: 10px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--ink-muted);
+}
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+/* Zones */
+.zone {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 12px;
+  margin-bottom: 4px;
+  background: var(--surface);
+}
+.zone-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.zone-title {
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: -0.01em;
+}
+.zone-badge {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.zone-entry { border-color: var(--accent); }
+.zone-entry .zone-title { color: var(--accent); }
+.zone-entry .zone-badge { background: var(--accent-soft); color: var(--accent); }
+
+.zone-app { border-color: var(--serve); }
+.zone-app .zone-title { color: var(--serve); }
+.zone-app .zone-badge { background: var(--serve-soft); color: var(--serve); }
+
+.zone-agent { border-color: var(--agent); border-width: 2px; }
+.zone-agent .zone-title { color: var(--agent); }
+.zone-agent .zone-badge { background: var(--agent-soft); color: var(--agent); }
+
+.zone-provider { border-color: var(--provider); }
+.zone-provider .zone-title { color: var(--provider); }
+.zone-provider .zone-badge { background: var(--provider-soft); color: var(--provider); }
+
+.zone-tool { border-color: var(--tool); }
+.zone-tool .zone-title { color: var(--tool); }
+.zone-tool .zone-badge { background: var(--tool-soft); color: var(--tool); }
+
+.zone-server { border-color: var(--server); }
+.zone-server .zone-title { color: var(--server); }
+.zone-server .zone-badge { background: var(--server-soft); color: var(--server); }
+
+.zone-cross { border-color: var(--cross); }
+.zone-cross .zone-title { color: var(--cross); }
+.zone-cross .zone-badge { background: var(--cross-soft); color: var(--cross); }
+
+/* Cards */
+.cards { display: grid; gap: 8px; }
+.card {
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--line);
+  border-radius: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  transition: border-color 0.15s, transform 0.1s;
+}
+.card:hover { border-color: var(--accent); transform: translateX(2px); }
+.card-title {
+  font-weight: 600;
+  font-size: 12px;
+  margin-bottom: 2px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.card-desc {
+  font-size: 11px;
+  color: var(--ink-muted);
+  line-height: 1.4;
+}
+.card-detail {
+  display: none;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px dashed var(--line);
+  font-size: 11px;
+  color: var(--ink-muted);
+}
+.card.expanded .card-detail { display: block; }
+.card .arrow { transition: transform 0.2s; }
+.card.expanded .arrow { transform: rotate(90deg); }
+
+.card.entry { border-left-color: var(--accent); }
+.card.app { border-left-color: var(--serve); }
+.card.agent { border-left-color: var(--agent); }
+.card.provider { border-left-color: var(--provider); }
+.card.tool { border-left-color: var(--tool); }
+.card.server { border-left-color: var(--server); }
+.card.channel { border-left-color: var(--channel); }
+.card.cross { border-left-color: var(--cross); }
+
+/* Connectors */
+.connector {
+  text-align: center;
+  color: var(--line);
+  font-size: 18px;
+  padding: 4px 0;
+  position: relative;
+}
+.connector-label {
+  font-size: 10px;
+  color: var(--ink-muted);
+  background: var(--bg);
+  padding: 0 6px;
+  position: relative;
+  top: -2px;
+}
+
+/* Flow section */
+.flow {
+  margin-top: 16px;
+  padding: 12px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+}
+.flow-title {
+  font-weight: 700;
+  font-size: 12px;
+  margin-bottom: 10px;
+  color: var(--accent);
+}
+.flow-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.flow-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 11px;
+}
+.step-num {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 10px;
+}
+.step-text { color: var(--ink-muted); padding-top: 2px; }
+.step-text b { color: var(--ink); }
+
+/* Key insight */
+.insight {
+  margin-top: 12px;
+  padding: 10px;
+  background: var(--accent-soft);
+  border-radius: 8px;
+  font-size: 11px;
+  line-height: 1.5;
+}
+.insight-title {
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 4px;
+  font-size: 12px;
+}
+
+/* Responsive */
+@media (min-width: 640px) {
+  .cards.two { grid-template-columns: 1fr 1fr; }
+  .cards.three { grid-template-columns: 1fr 1fr 1fr; }
+  .flow-steps { flex-direction: row; flex-wrap: wrap; }
+  .flow-step { width: calc(50% - 4px); }
+}
+@media (min-width: 900px) {
+  .flow-step { width: calc(25% - 6px); }
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>🐙 octo-agent 架构地图</h1>
+<p class="subtitle">Go 1.22+ 单二进制 · 五层单向依赖 · 协议无关 Agent 循环</p>
+
+<!-- Legend -->
+<div class="legend">
+  <div class="legend-item"><span class="dot" style="background:var(--accent)"></span>入口层</div>
+  <div class="legend-item"><span class="dot" style="background:var(--serve)"></span>装配层</div>
+  <div class="legend-item"><span class="dot" style="background:var(--agent)"></span>Agent 核心</div>
+  <div class="legend-item"><span class="dot" style="background:var(--provider)"></span>Provider</div>
+  <div class="legend-item"><span class="dot" style="background:var(--tool)"></span>工具集</div>
+  <div class="legend-item"><span class="dot" style="background:var(--server)"></span>服务层</div>
+  <div class="legend-item"><span class="dot" style="background:var(--channel)"></span>IM 桥接</div>
+  <div class="legend-item"><span class="dot" style="background:var(--cross)"></span>跨切关注</div>
+</div>
+
+<!-- Entry Layer -->
+<div class="zone zone-entry">
+  <div class="zone-header">
+    <span class="zone-title">📥 入口层</span>
+    <span class="zone-badge">cmd/octo/</span>
+  </div>
+  <div class="cards two">
+    <div class="card entry" onclick="toggle(this)">
+      <div class="card-title"><span>CLI / TUI / Headless</span><span class="arrow">▶</span></div>
+      <div class="card-desc">Bubble Tea 交互界面 + claude -p 风格单次执行</div>
+      <div class="card-detail">
+        <b>关键文件：</b>main.go → chat.go / tuirepl.go / repl.go / turncore.go<br>
+        <b>职责：</b>解析命令行 → 装配 session → 分派到 runTurn()
+      </div>
+    </div>
+    <div class="card entry" onclick="toggle(this)">
+      <div class="card-title"><span>octo serve</span><span class="arrow">▶</span></div>
+      <div class="card-desc">启动内嵌 Web 服务 + WebSocket 网关</div>
+      <div class="card-detail">
+        <b>关键文件：</b>cmd/octo/serve.go<br>
+        <b>职责：</b>拉起 server 实例，监听 8088 端口，承载 Web + REST + WS
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="connector">↓ <span class="connector-label">装配 NewSessionToolEnv</span> ↓</div>
+
+<!-- App Assembly Layer -->
+<div class="zone zone-app">
+  <div class="zone-header">
+    <span class="zone-title">🔧 装配层</span>
+    <span class="zone-badge">internal/app/</span>
+  </div>
+  <div class="cards two">
+    <div class="card app" onclick="toggle(this)">
+      <div class="card-title"><span>Sender 适配</span><span class="arrow">▶</span></div>
+      <div class="card-desc">Provider → agent.Sender 统一接口</div>
+      <div class="card-detail">
+        <b>关键文件：</b>sender.go — NewSender()<br>
+        <b>解耦点：</b>agent 不知道 HTTP、JSON 字段、SSE 细节
+      </div>
+    </div>
+    <div class="card app" onclick="toggle(this)">
+      <div class="card-title"><span>工具环境装配</span><span class="arrow">▶</span></div>
+      <div class="card-desc">并发安全的工具运行时环境</div>
+      <div class="card-detail">
+        <b>关键文件：</b>toolenv.go — NewSessionToolEnv()<br>
+        <b>装配内容：</b>权限闸门、SubAgentManager、GoalStore、browser、memory
+      </div>
+    </div>
+    <div class="card app" onclick="toggle(this)">
+      <div class="card-title"><span>Permission Gate</span><span class="arrow">▶</span></div>
+      <div class="card-desc">每 turn 重建规则引擎</div>
+      <div class="card-detail">
+        <b>行为：</b>prepareToolTurn 中调用，即时生效 + 失败回退 lastGoodRules
+      </div>
+    </div>
+    <div class="card app" onclick="toggle(this)">
+      <div class="card-title"><span>MCP 连接</span><span class="arrow">▶</span></div>
+      <div class="card-desc">启动时连接所有配置中的 MCP server</div>
+      <div class="card-detail">
+        <b>关键文件：</b>mcp.go — ConnectAll()<br>
+        <b>装配时机：</b>session 启动时一次性建立
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="connector">↓ <span class="connector-label">Sender 协议无关抽象</span> ↓</div>
+
+<!-- Agent Core Layer -->
+<div class="zone zone-agent">
+  <div class="zone-header">
+    <span class="zone-title">🧠 Agent 核心</span>
+    <span class="zone-badge">internal/agent/ — 叶子包，不导入任何上层</span>
+  </div>
+  <div class="cards two">
+    <div class="card agent" onclick="toggle(this)">
+      <div class="card-title"><span>runLoop / RunStream</span><span class="arrow">▶</span></div>
+      <div class="card-desc">send → tool dispatch → reply 的 agentic 循环</div>
+      <div class="card-detail">
+        <b>关键文件：</b>agent.go — Turn() / Run() / RunStream()<br>
+        <b>核心：</b>持 senderMu，单 turn 全局互斥
+      </div>
+    </div>
+    <div class="card agent" onclick="toggle(this)">
+      <div class="card-title"><span>History + Session</span><span class="arrow">▶</span></div>
+      <div class="card-desc">消息历史 + JSONL 持久化</div>
+      <div class="card-detail">
+        <b>关键文件：</b>history.go / session.go<br>
+        <b>存储：</b>~/.octo/sessions/&lt;id&gt;.jsonl
+      </div>
+    </div>
+    <div class="card agent" onclick="toggle(this)">
+      <div class="card-title"><span>Overflow / Compaction</span><span class="arrow">▶</span></div>
+      <div class="card-desc">上下文溢出处理（分层状态机）</div>
+      <div class="card-detail">
+        <b>关键文件：</b>overflow.go / compaction.go / microcompact.go<br>
+        <b>策略：</b>microcompact → compact → overflow 降级
+      </div>
+    </div>
+    <div class="card agent" onclick="toggle(this)">
+      <div class="card-title"><span>EventHandler</span><span class="arrow">▶</span></div>
+      <div class="card-desc">抽象事件流（text_delta / tool_start / turn_done）</div>
+      <div class="card-detail">
+        <b>关键文件：</b>event.go — EventKind / EventHandler<br>
+        <b>下游适配：</b>TUI card ← ViewSink | WS broadcast | IM message
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="connector">
+  ↕ <span class="connector-label">agent 不导入这些包 — 通过接口反转</span> ↕
+</div>
+
+<!-- Provider + Tools (side by side on wide screens) -->
+<div class="zone zone-provider">
+  <div class="zone-header">
+    <span class="zone-title">🔌 LLM 后端适配</span>
+    <span class="zone-badge">internal/provider/</span>
+  </div>
+  <div class="cards two">
+    <div class="card provider" onclick="toggle(this)">
+      <div class="card-title"><span>Anthropic (Messages API)</span><span class="arrow">▶</span></div>
+      <div class="card-desc">claude-3-5-sonnet 等模型</div>
+      <div class="card-detail">
+        <b>关键文件：</b>anthropic/client.go / stream.go<br>
+        <b>Wire 归一化：</b>stop_reason → "tool_use"，cache_read_input_tokens 分桶
+      </div>
+    </div>
+    <div class="card provider" onclick="toggle(this)">
+      <div class="card-title"><span>OpenAI (Chat Completions)</span><span class="arrow">▶</span></div>
+      <div class="card-desc">GPT-4o / DeepSeek 等兼容端点</div>
+      <div class="card-detail">
+        <b>关键文件：</b>openai/client.go / stream.go<br>
+        <b>特殊处理：</b>tool_calls 流式片段拼接、cached_tokens 从 prompt_tokens 扣减
+      </div>
+    </div>
+    <div class="card provider" onclick="toggle(this)">
+      <div class="card-title"><span>DashScope / DeepSeek</span><span class="arrow">▶</span></div>
+      <div class="card-desc">百炼 / DeepSeek 兼容端点</div>
+      <div class="card-detail">
+        <b>注意：</b>Bailian 需要 stream_options.include_usage=true，DeepSeek 自带 usage
+      </div>
+    </div>
+    <div class="card provider" onclick="toggle(this)">
+      <div class="card-title"><span>Retry Layer</span><span class="arrow">▶</span></div>
+      <div class="card-desc">请求级恢复 + 流式 idle 超时</div>
+      <div class="card-detail">
+        <b>关键文件：</b>retry/retry.go<br>
+        <b>退避：</b>exponential backoff + jitter
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="zone zone-tool" style="margin-top:8px;">
+  <div class="zone-header">
+    <span class="zone-title">🛠️ 内置工具集</span>
+    <span class="zone-badge">internal/tools/ — 30+ ToolExecutor</span>
+  </div>
+  <div class="cards three">
+    <div class="card tool" onclick="toggle(this)">
+      <div class="card-title"><span>终端 + 沙盒</span><span class="arrow">▶</span></div>
+      <div class="card-desc">命令执行典范实现</div>
+      <div class="card-detail"><b>文件：</b>terminal.go / sandbox.go</div>
+    </div>
+    <div class="card tool" onclick="toggle(this)">
+      <div class="card-title"><span>文件读写</span><span class="arrow">▶</span></div>
+      <div class="card-desc">读写 + grep + glob</div>
+      <div class="card-detail"><b>文件：</b>read_file.go / write_file.go 等</div>
+    </div>
+    <div class="card tool" onclick="toggle(this)">
+      <div class="card-title"><span>Web + Browser</span><span class="arrow">▶</span></div>
+      <div class="card-desc">抓取 + CDP 浏览器自动化</div>
+      <div class="card-detail"><b>文件：</b>web_fetch.go / browser.go</div>
+    </div>
+    <div class="card tool" onclick="toggle(this)">
+      <div class="card-title"><span>Skill + MCP</span><span class="arrow">▶</span></div>
+      <div class="card-desc">技能按需加载 + MCP server 中转</div>
+      <div class="card-detail"><b>文件：</b>skill.go / mcp*.go</div>
+    </div>
+    <div class="card tool" onclick="toggle(this)">
+      <div class="card-title"><span>Sub-agent</span><span class="arrow">▶</span></div>
+      <div class="card-desc">派生子 agent 处理子任务</div>
+      <div class="card-detail"><b>文件：</b>subagent_manager/</div>
+    </div>
+    <div class="card tool" onclick="toggle(this)">
+      <div class="card-title"><span>Workflow / Memory</span><span class="arrow">▶</span></div>
+      <div class="card-desc">mruby 工作流 + 语义记忆 recall</div>
+      <div class="card-detail"><b>文件：</b>workflow.go / memory.go</div>
+    </div>
+  </div>
+</div>
+
+<div class="connector">↕ <span class="connector-label">HTTP · WebSocket · IM 调用</span> ↕</div>
+
+<!-- Server + Channel Layer -->
+<div class="zone zone-server">
+  <div class="zone-header">
+    <span class="zone-title">🌐 服务层</span>
+    <span class="zone-badge">internal/server/</span>
+  </div>
+  <div class="cards two">
+    <div class="card server" onclick="toggle(this)">
+      <div class="card-title"><span>REST + WebSocket</span><span class="arrow">▶</span></div>
+      <div class="card-desc">80+ 路由 + /ws 双向通信</div>
+      <div class="card-detail">
+        <b>关键文件：</b>server.go / ws_handlers.go / ws_hub.go<br>
+        <b>职责：</b>session binding、turn 锁、wake-up 调度、优雅 shutdown
+      </div>
+    </div>
+    <div class="card server" onclick="toggle(this)">
+      <div class="card-title"><span>prepareToolTurn</span><span class="arrow">▶</span></div>
+      <div class="card-desc">装配 turn 环境（server 路径入口）</div>
+      <div class="card-detail">
+        <b>关键文件：</b>handlers_prepare_toolturn.go<br>
+        <b>流程：</b>app.NewSessionToolEnv → 注入权限/agent/browser/memory
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="zone zone-channel" style="margin-top:8px;">
+  <div class="zone-header">
+    <span class="zone-title">📡 IM 桥接</span>
+    <span class="zone-badge">internal/channel/ — 6 大平台</span>
+  </div>
+  <div class="cards two">
+    <div class="card channel" onclick="toggle(this)">
+      <div class="card-title"><span>Telegram / Discord / Feishu</span><span class="arrow">▶</span></div>
+      <div class="card-desc">按钮支持（callback_query / interactive card）</div>
+      <div class="card-detail">
+        <b>接口：</b>SupportsButtons() + SendButtons()<br>
+        <b>数据映射：</b>按钮 → text，复用 isAffirmative/isAlways
+      </div>
+    </div>
+    <div class="card channel" onclick="toggle(this)">
+      <div class="card-title"><span>微信 / 企微 / 钉钉</span><span class="arrow">▶</span></div>
+      <div class="card-desc">纯文本 reply 契约</div>
+      <div class="card-detail">
+        <b>限制：</b>无按钮 SDK，走纯文本交互<br>
+        <b>chunking：</b>长消息自动分片
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Cross-cutting -->
+<div class="zone zone-cross" style="margin-top:8px;">
+  <div class="zone-header">
+    <span class="zone-title">⚙️ 跨切关注点</span>
+    <span class="zone-badge">internal/*</span>
+  </div>
+  <div class="cards three">
+    <div class="card cross" onclick="toggle(this)">
+      <div class="card-title"><span>Permission</span><span class="arrow">▶</span></div>
+      <div class="card-desc">deny > ask > allow 三级决策</div>
+      <div class="card-detail"><b>文件：</b>permission.go + defaults.yml</div>
+    </div>
+    <div class="card cross" onclick="toggle(this)">
+      <div class="card-title"><span>Skills</span><span class="arrow">▶</span></div>
+      <div class="card-desc">L1 name 注入 / L2 body 按需加载</div>
+      <div class="card-detail"><b>文件：</b>skills.go + defaults.go (go:embed)</div>
+    </div>
+    <div class="card cross" onclick="toggle(this)">
+      <div class="card-title"><span>Workflow</span><span class="arrow">▶</span></div>
+      <div class="card-desc">mruby (wazero) Ruby DSL</div>
+      <div class="card-detail"><b>文件：</b>runtime.go / prelude.rb / journal.go</div>
+    </div>
+    <div class="card cross" onclick="toggle(this)">
+      <div class="card-title"><span>Scheduler</span><span class="arrow">▶</span></div>
+      <div class="card-desc">cron 定时任务调度</div>
+      <div class="card-detail"><b>路径：</b>~/.octo/tasks/*.json</div>
+    </div>
+    <div class="card cross" onclick="toggle(this)">
+      <div class="card-title"><span>Hooks</span><span class="arrow">▶</span></div>
+      <div class="card-desc">pre/post-turn + TOFU 信任</div>
+      <div class="card-detail"><b>文件：</b>internal/hooks/</div>
+    </div>
+    <div class="card cross" onclick="toggle(this)">
+      <div class="card-title"><span>Memory Backend</span><span class="arrow">▶</span></div>
+      <div class="card-desc">hindsight / mem0 / MemTensor</div>
+      <div class="card-detail"><b>文件：</b>memorybackend/backend.go</div>
+    </div>
+  </div>
+</div>
+
+<!-- Key Insight -->
+<div class="insight">
+  <div class="insight-title">🎯 关键解耦设计</div>
+  <ul style="margin:0;padding-left:16px;">
+    <li><b>Sender 抽象</b> — agent 不知道 HTTP/SSE/JSON，一切协议细节止步于 app/sender.go</li>
+    <li><b>ToolExecutor 接口</b> — 新增工具 = 往 allTools 加一行，不动 agent/provider</li>
+    <li><b>UIController / ViewSink</b> — 同一套 Event 流被 TUI、Web、IM 三种后端解析渲染</li>
+    <li><b>agent 是叶子包</b> — 零上层依赖，依赖方向严格单向</li>
+  </ul>
+</div>
+
+<br>
+
+</div>
+
+<script>
+function toggle(card) {
+  card.classList.toggle('expanded');
+}
+</script>
+</body>
+</html>

--- a/blog/src/content/posts/en/architecture-deep-dive.md
+++ b/blog/src/content/posts/en/architecture-deep-dive.md
@@ -1,0 +1,137 @@
+---
+title: "octo-agent Architecture Deep Dive: Five-Layer Core Stack & Full-System Dependency Map"
+description: "An interactive panorama architecture diagram parsing octo-agent's five-layer unidirectional dependency from CLI/IM entry to LLM backends, the agent leaf package design, protocol-agnostic abstraction, and cross-cutting concerns like permission, workflow, and memory."
+pubDate: 2026-07-10
+updatedDate: 2026-07-10
+author: "octo-agent team"
+tags: ["architecture", "deep-dive", "engineering", "ai-agent"]
+locale: en
+originalSlug: architecture-deep-dive
+---
+
+# octo-agent Architecture Deep Dive: Five-Layer Core Stack & Full-System Dependency Map
+
+> octo-agent's codebase has grown to 480+ Go files, six IM bridges, and an embedded Svelte 5 workbench. This post uses an interactive panorama diagram to show how the whole system hangs together.
+
+---
+
+## Design Philosophy: Strictly Unidirectional Dependencies
+
+The single most important architectural discipline in octo-agent is **strictly unidirectional dependency**. The five-layer stack:
+
+```
+cmd/ → app/ → agent/ ← (provider/, tools/)
+```
+
+`internal/agent/` is a **leaf package** in the dependency tree — it imports nothing from upper layers (no `provider`, `tools`, `server`, `channel`, or `web`). All protocol details, tool implementations, and UI rendering are "pushed upward."
+
+This means you can:
+- Swap LLM backends (anthropic → openai → deepseek) without touching a single line of agent code.
+- Add a new tool (terminal, browser, skill, workflow, MCP…) without modifying the agent loop.
+- Change the rendering surface (T1 UI, Web, IM, Headless) without affecting core logic.
+
+This one rule is the main reason octo-agent has been able to scale.
+
+---
+
+## The Architecture Panorama
+
+<iframe
+  src="/blog/architecture-map.html"
+  width="100%"
+  height="1400"
+  style="border: none; border-radius: 8px;"
+  loading="lazy"
+</iframe>
+
+> 👆 Click any card's title to expand and see key file paths and design details.
+
+---
+
+## Seven Facets at a Glance
+
+### 1. Entry Layer: One Agentic Loop, Many Faces
+
+TUI (Bubble Tea), Web (Svelte 5 SPA), Headless (`octo -p "..."`), IM (Feishu / Telegram / Discord / WeChat / WeCom / DingTalk) — five entry points, all running the same `agent.RunStream`. The entry layer's only job is to translate "user input" into a unified turn request and then translate agent events into their respective rendering formats (TUI cards, WebSocket messages, IM text chunks).
+
+### 2. Assembly Layer: The Only Package Allowed to Know Everything
+
+`internal/app/` is the only place that imports `agent`, `provider`, `permission`, `subagent_manager`, `mcp`, and `memorybackend` at the same time. Its job: adapt a Provider to `agent.Sender`, and build a `NewSessionToolEnv` (permission gate, browser, task store, goal store).
+
+Clean separation: upper layers only talk to `app`; `app` assembles everything into what agent needs.
+
+### 3. Agent Core: Doesn't Read HTTP, Doesn't Splice JSON
+
+`Agent.RunStream` is a send → tool-dispatch → reply loop. It only knows that `Sender.SendMessagesToTools()` returns an abstract response. It has no idea about SSE, streaming tool_call fragment splicing, or the spelling differences between `finish_reason` and `stop_reason`.
+
+All wire-format quirks are encapsulated in provider adapters: `internal/provider/anthropic` handles Messages API, `internal/provider/openai` handles Chat Completions. Even the `retry` package is isolated — provider-level request recovery and stream idle timeouts never pollute agent code.
+
+### 4. Provider Normalization: The Same "tool_use"
+
+Anthropic returns `stop_reason: "tool_use"`, OpenAI returns `finish_reason: "tool_calls"`. One job of the provider adapter is to normalize both into the unified "tool calls needed" signal. Similarly, cache-token bucketing differs by protocol: Anthropic uses `(input_tokens, cache_read_input_tokens)`, OpenAI uses `(prompt_tokens, cached_tokens)` — the agent always sees non-overlapping `InputTokens` and `CacheReadTokens` counters.
+
+### 5. Tool System: One Line to Register, Zero Core Edits
+
+Each tool implements the `ToolExecutor` interface + a `Definition()` method (returning the JSON Schema). Adding a tool means appending one line to `tools/allTools`. `DefaultRegistry.Execute` dispatches by name — MCP tools are injected with the `mcp__` prefix, built-ins run their own Go implementations. A permission gate (deny/ask/allow + interactive/auto/strict modes) intercepts before execution.
+
+### 6. The Cross-Cutting "Invisible Champions"
+
+Several packages that don't get their own layer but are everywhere:
+
+- **`internal/permission/`** — deny > ask > allow, deny wins regardless of declaration order. Engine rebuilt per-turn; editing `permissions.yml` takes effect immediately. Parse failures silently fall back to `lastGoodRules` without crashing sessions.
+- **`internal/skills/`** — L1 is just name + description + frontmatter — the smallest system-prompt budget. L2 body is loaded on demand via the `skill` tool, preventing skills from blowing up the context window.
+- **`internal/memorybackend/`** — hindsight / mem0 / MemTensor semantic memory backends, swappable. The `eventSink` hook auto-writes conversations to memory on `EventStop`.
+- **`internal/workflow/`** — mruby (wazero-wasm Fiber) × Go goroutine collaboration; write `agent/parallel/pipeline` composable workflows in Ruby DSL.
+
+### 7. Server + Channel: Dual Event Exits
+
+`internal/server` handles 80+ HTTP routes + WebSocket broadcast. Agent-produced `EventKind` events (text_delta, tool_started, tool_done, turn_done…) fan out in two directions:
+
+- **Server path** → `ws_hub` broadcasts to all WebSocket subscribers
+- **Channel path** → `UIController.Handler` adapts into IM messages (Telegram edit_message / Feishu card.action.trigger / WeChat text chunking)
+
+IM ask buttons (Telegram inline_keyboard / Discord components / Feishu interactive card) map button presses back to `allow/always/deny` text, reusing the existing `isAffirmative` / `isAlways` logic — no new backend code required.
+
+---
+
+## One Turn's Lifetime
+
+From the user hitting Enter in the TUI, to the output appearing on screen, there are five steps:
+
+1. **Entry**: `turncore.go` receives the request → calls `RunStream()`
+2. **Assemble turn environment**: `app.NewSessionToolEnv()` injects the permission gate + SubAgentManager + GoalStore + browser + memory
+3. **Core loop**: `RunStream()` calls `SendMessagesToTools()` → LLM returns `tool_use` → permission deny/ask/allow → `DefaultRegistry.Execute` → results fed back to LLM → loop until `end_turn`
+4. **Event broadcast**: each text_delta / tool_start / turn_done through `EventHandler` → TUI card rendering (ViewSink) + WS broadcast (server) + IM message (channel UIController)
+5. **Session sync to disk**: `Session.SyncFrom(history)` appends to `~/.octo/sessions/<id>.jsonl`
+
+---
+
+## Quick Map: Where to Find Code
+
+| To understand...            | Go to                                                          |
+| ---------------------------- | -------------------------------------------------------------- |
+| Permission decision logic    | `internal/permission/permission.go`                            |
+| What happens on context overflow | `internal/agent/overflow.go` → `compaction.go`             |
+| Where sessions live, what they look like | `internal/agent/session.go` + `~/.octo/sessions/`    |
+| How sub-agents are spawned   | `internal/tools/subagent_manager/` + `internal/app/spawner.go` |
+| WS protocol details          | `internal/server/ws_types.go`                                  |
+| Adding a new provider        | Copy `internal/provider/anthropic/`, update routing in `app/sender.go` |
+| Adding a new IM              | Implement `channel.Adapter` interface, self-register             |
+
+---
+
+## Next Steps
+
+After your first `octo serve`, look right in the Web UI — you'll see this architecture run live: the event stream in the WebSocket panel, session writes, tool-call folding cards — each frame maps directly to the data flow drawn above.
+
+Recommended reading path for backend engineers:
+
+1. `cmd/octo/turncore.go` — what a single turn looks like
+2. `internal/agent/agent.go` — `runLoop` + tool dispatch + senderMu
+3. `internal/server/ws_handlers.go` → WS event conversion
+4. `internal/provider/anthropic/stream.go` → SSE aggregation + stop_reason normalization
+5. `internal/tools/terminal.go` — the canonical `ToolExecutor` reference
+6. `internal/permission/permission.go` — how instant生效 works
+7. `internal/workflow/runtime.go` — mruby Fiber × Go goroutine
+
+Treat each layer as a black box — the full picture forms in ~90 minutes.

--- a/blog/src/content/posts/zh/architecture-deep-dive.md
+++ b/blog/src/content/posts/zh/architecture-deep-dive.md
@@ -1,0 +1,137 @@
+---
+title: "octo-agent 架构深度解析：五层核心栈与全系统依赖图"
+description: "一幅可交互的全景架构图，解析 octo-agent 从 CLI/IM 入口到 LLM 后端的五层单向依赖、agent 叶子包设计、协议无关抽象，以及 permission/workflow/memory 等跨切关注点。"
+pubDate: 2026-07-10
+updatedDate: 2026-07-10
+author: "octo-agent team"
+tags: ["architecture", "deep-dive", "engineering", "ai-agent"]
+locale: zh
+originalSlug: architecture-deep-dive
+---
+
+# octo-agent 架构深度解析：五层核心栈与全系统依赖图
+
+> octo-agent 的代码仓库已经膨胀到 480+ Go 文件、六个 IM 桥接、一个内嵌 Svelte 5 工作台。本文用一幅可交互的全景架构图，看懂整个系统是怎么组织起来的。
+
+---
+
+## 设计哲学：严格单向依赖
+
+octo-agent 最核心的架构准则是**依赖方向严格单向**。整个系统五层栈：
+
+```
+cmd/ → app/ → agent/ ← (provider/, tools/)
+```
+
+`internal/agent/` 是整个依赖树的**叶子包**——它不导入任何上层代码（不导入 `provider`、`tools`、`server`、`channel`、`web`）。所有协议细节、工具实现、UI 渲染都被"向上推"到更高层。
+
+这意味着你可以：
+- 替换 LLM 后端（anthropic → openai → deepseek）而不改一行 agent 代码
+- 新增工具（terminal、browser、skill、workflow、MCP……）而不碰 agent 循环
+- 更换渲染终端（TUI、Web IM、Headless）而不影响核心逻辑
+
+这一条纪律，是 octo-agent 能持续膨胀的主要原因。
+
+---
+
+## 全景架构图
+
+<iframe
+  src="/blog/architecture-map.html"
+  width="100%"
+  height="1400"
+  style="border: none; border-radius: 8px;"
+  loading="lazy"
+></iframe>
+
+> 👆 点击每个卡片的标题区域，可展开查看关键文件路径和设计细节。
+
+---
+
+## 七个切面速览
+
+### 1. 入口层：同一条 agentic 循环，多种面孔
+
+TUI（Bubble Tea）、Web（Svelte 5 SPA）、Headless（`octo -p "..."`）、IM（飞书/Telegram/Discord/微信/企微/钉钉）——五种入口，底层跑的都是同一个 `agent.RunStream`。入口层唯一做的事是把"用户输入"翻译成统一的 turn 请求，然后把 agent 产出的事件翻译成各自的渲染格式（TUI 卡片、WebSocket 消息、IM 分片文本）。
+
+### 2. 装配层：唯一有权限知道所有东西的包
+
+`internal/app/` 是整个系统唯一同时导入 `agent`、`provider`、`permission`、`subagent_manager`、`mcp`、`memorybackend` 的地方。它负责把 Provider 适配成 `agent.Sender`，搭建 `NewSessionToolEnv`（包含权限闸门、浏览器、任务 store、goal store）。
+
+职责分明：上层只和 `app` 交互；`app` 负责把一切组装成 agent 需要的样子。
+
+### 3. Agent 核心：不读 HTTP、不拼 JSON
+
+`Agent.RunStream` 是 send → tool-dispatch → reply 的循环。它只知道 `Sender.SendMessagesToTools()` 返回一个抽象响应；不知道 SSE、不知道 tool_call 流式拼接、不知道 `finish_reason` 和 `stop_reason` 的拼写差异。
+
+所有 Wire 格式的怪癖都被封在 Provider 适配层：`internal/provider/anthropic` 处理 Messages API、`internal/provider/openai` 处理 Chat Completions。甚至 `retry` 包也是独立的——provider 级别的请求恢复和流式 idle 超时，完全不污染 agent。
+
+### 4. Provider 归一化：同一个"tool_use"
+
+Anthropic 返回 `stop_reason: "tool_use"`，OpenAI 返回 `finish_reason: "tool_calls"`。Provider 适配层的职责之一就是把它们归一化成统一的"需要调用工具"信号。同理，cache token 分桶在 Anthropic 协议是 `(input_tokens, cache_read_input_tokens)`，在 OpenAI 协议是 `(prompt_tokens, cached_tokens)`，agent 看到的始终是统一的 `InputTokens` 和 `CacheReadTokens` 不重叠计数。
+
+### 5. 工具系统：一行注册，不改核心
+
+每个工具实现 `ToolExecutor` 接口 + `Definition()` 方法（返回 JSON Schema）。新增工具只需往 `tools/allTools` 加一行。`DefaultRegistry.Execute` 按名分发——MCP 工具以 `mcp__` 前缀注入、内置工具走自己的 Go 实现。权限闸门（deny/ask/allow + interactive/auto/strict 三 mode）在工具执行前拦截。
+
+### 6. 跨切关注点的"隐形冠军"
+
+几个不单独成片但无处不在的包：
+
+- **`internal/permission/`** — deny > ask > allow，deny 优先级最高，无视声明顺序。每 turn 重建引擎，改 `permissions.yml` 立即生效。解析失败时安静回退到 `lastGoodRules`，不会绷掉 session。
+- **`internal/skills/`** — L1 只有 name + description + frontmatter，注入 system prompt 的 budget 最小；L2 的 body 通过 `skill` 工具按需加载，避免 skill 冲爆上下文窗口。
+- **`internal/memorybackend/`** — hindsight / mem0 / MemTensor 三种语义记忆后端可选。`eventSink` hook 在 `EventStop` 时自动将对话写入记忆。
+- **`internal/workflow/`** — mruby（wazero-wasm Fiber）+ Go goroutine 协作，用 Ruby DSL 写 `agent/parallel/pipeline` 组合式工作流。
+
+### 7. Server + Channel：事件双重出口
+
+`internal/server` 处理 HTTP 路由（80+）+ WebSocket broadcast。Agent 产出的 `EventKind` 事件（text_delta、tool_started、tool_done、turn_done……）被分发两个方向：
+
+- **Server 路径** → `ws_hub` 广播给所有 WebSocket 订阅者
+- **Channel 路径** → `UIController.Handler` 适配成 IM 消息（Telegram edit_message / Feishu card.action.trigger / WeChat 纯文本分包）
+
+IM 的 ask 按钮（Telegram inline_keyboard / Discord components / Feishu interactive card）按下后映射为 `allow/always/deny` 文本，复用已有的 `isAffirmative` / `isAlways` 判断逻辑，完全不需要新的后端路径。
+
+---
+
+## 一个 turn 的生命周期
+
+从用户在 TUI 敲下回车，到结果出现在屏幕上，一共五步：
+
+1. **入口**：`turncore.go` 接收请求 → 调 `RunStream()`
+2. **装配 turn 环境**：`app.NewSessionToolEnv()` 注入权限闸门 + SubAgentManager + GoalStore + browser + memory
+3. **核心循环**：`RunStream()` 调 `SendMessagesToTools()` → LLM 返回 `tool_use` → permission deny/ask/allow → `DefaultRegistry.Execute` → 结果回喂 LLM → 循环直到 `end_turn`
+4. **事件广播**：每次 text_delta / tool_start / turn_done 经 `EventHandler` → TUI card 渲染（ViewSink）+ WS broadcast（server）+ IM 消息（channel UIController）
+5. **Session 落盘**：`Session.SyncFrom(history)` 追加到 `~/.octo/sessions/<id>.jsonl`
+
+---
+
+## 速查：找代码去哪
+
+| 想了解...                   | 去哪看                                                          |
+| -------------------------- | --------------------------------------------------------------- |
+| 权限判定逻辑               | `internal/permission/permission.go`                             |
+| 上下文溢出怎么办           | `internal/agent/overflow.go` → `compaction.go`                  |
+| session 存在哪、长什么样   | `internal/agent/session.go` + `~/.octo/sessions/`               |
+| 子 agent 怎么 spawn        | `internal/tools/subagent_manager/` + `internal/app/spawner.go`  |
+| WS 协议细节                | `internal/server/ws_types.go`                                   |
+| 加新 provider              | 复制 `internal/provider/anthropic/`、改 `app/sender.go` 路由    |
+| 加新 IM                   | 实现 `channel.Adapter` 接口自注册                               |
+
+---
+
+## 下一步
+
+你第一次启动 `octo serve` 后，Web UI 右侧就能看到这套架构在实时运行：WebSocket 面板里的 event 流、session 写入、工具调用折叠卡片——每一帧都对应上图里画的那条数据流。
+
+后端工程师推荐阅读顺序：
+
+1. `cmd/octo/turncore.go` — 单 turn 长什么样
+2. `internal/agent/agent.go` — `runLoop` + tool dispatch + senderMu
+3. `internal/server/ws_handlers.go` → WS 事件转换
+4. `internal/provider/anthropic/stream.go` → SSE 聚合 + stop_reason 归一化
+5. `internal/tools/terminal.go` — 公认的 ToolExecutor 典范
+6. `internal/permission/permission.go` — 即时生效的奥秘
+7. `internal/workflow/runtime.go` — mruby Fiber × Go goroutine
+
+每层当黑盒用，整体认识 ~90 分钟形成。


### PR DESCRIPTION
## Summary

- 新增一篇双语（zh/en）架构深度解析文章 \`/blog/posts/architecture-deep-dive/\`
- 文章含可交互 HTML 全景架构图，覆盖七层子系统、六个跨切关注点、turn 生命周期和代码速查表
- 中文默认路径（\`/blog/posts/architecture-deep-dive/\`），英文版通过 \`originalSlug\` 关联（\`/blog/posts/en/architecture-deep-dive/\`）

## Files

| File | Purpose |
|------|---------|
| \`blog/public/architecture-map.html\` | 可交互架构全景图（暗色/亮色自适应，iframe 嵌入） |
| \`blog/src/content/posts/zh/architecture-deep-dive.md\` | 中文版文章（七切面 + turn 生命周期 + 代码速查） |
| \`blog/src/content/posts/en/architecture-deep-dive.md\` | 英文版文章 |

## Local verification

\`\`\`
cd blog && npm run build   # ✓ 28 pages built, no errors
\`\`\`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)