### PR TITLE
fix(tools): workflow and run_skill return error on missing required args

### DIFF
--- a/internal/browser/skill.go
+++ b/internal/browser/skill.go
@@ -737,8 +737,9 @@ func unresolvedPlaceholders(skill *Skill, full map[string]string) []string {
 // MissingRequiredParams reports which {{name}} placeholders in skill's steps
 // remain unresolved after overlaying params on the skill's declared defaults
 // — the same check ReplaySkill performs internally before running any step,
-// exposed so a caller can prompt for the missing values (e.g. via a UI or an
-// interactive asker) instead of letting ReplaySkill fail outright.
+// exposed so a caller can surface a clear error to the model (which then
+// decides whether to re-invoke with values or ask the user) instead of
+// letting ReplaySkill fail outright.
 func MissingRequiredParams(skill *Skill, params map[string]string) []string {
 	return unresolvedPlaceholders(skill, mergedParams(skill, params))
 }

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -650,7 +650,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 				params[k] = fmt.Sprintf("%v", v)
 			}
 		}
-		if err := resolveMissingSkillParams(ctx, &skill, name, params); err != nil {
+		if err := resolveMissingSkillParams(&skill, name, params); err != nil {
 			return agent.ToolResult{}, err
 		}
 		recorderMu.Lock()
@@ -697,37 +697,20 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 // required param(s)" error the model has no way to act on. params is mutated
 // in place. When no asker is available (headless/unattended modes),
 // ReplaySkill's own error still fires, so behavior there is unchanged.
-func resolveMissingSkillParams(ctx context.Context, skill *browser.Skill, skillName string, params map[string]string) error {
+// resolveMissingSkillParams checks a browser skill's declared params against
+// the caller-supplied params. Any that are missing and have no default
+// produce an error listing them — the model then decides whether it already
+// knows the values (re-invoke with `params` filled in) or needs to surface an
+// `ask_user_question` to the caller. The old behaviour auto-promoted via the
+// ctx Asker, which stole that decision from the model and caused repeat prompts
+// when the model had already asked the user.
+func resolveMissingSkillParams(skill *browser.Skill, skillName string, params map[string]string) error {
 	missing := browser.MissingRequiredParams(skill, params)
 	if len(missing) == 0 {
 		return nil
 	}
-	asker := askerFrom(ctx)
-	if asker == nil {
-		return nil
-	}
-	descByName := make(map[string]string, len(skill.Params))
-	for _, p := range skill.Params {
-		descByName[p.Name] = p.Description
-	}
-	for _, pname := range missing {
-		question := fmt.Sprintf("Skill %q needs a value for %q", skillName, pname)
-		if d := descByName[pname]; d != "" {
-			question += ": " + d
-		}
-		res, err := asker.Ask(ctx, AskRequest{Question: question, Header: pname})
-		if err != nil {
-			return fmt.Errorf("browser: %w", err)
-		}
-		if res.Cancelled {
-			return fmt.Errorf("browser: run_skill %q: user cancelled while providing param %q", skillName, pname)
-		}
-		// AskRequest carries no Options, so this is always a free-text prompt —
-		// res.Choices is documented to stay empty in that case (AskResponse),
-		// leaving res.Custom as the only place the answer can land.
-		params[pname] = res.Custom
-	}
-	return nil
+	return fmt.Errorf("browser: run_skill %q is missing required param(s): %s — pass them in `params`",
+		skillName, strings.Join(missing, ", "))
 }
 
 func getStr(input map[string]any, key string) string {

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -174,11 +174,12 @@ func TestBrowserTool_RecordRunRoundTrip(t *testing.T) {
 	}
 }
 
-// TestResolveMissingSkillParams_PromptsForMissingRequired verifies a param
-// with no default and no caller-supplied value triggers a user prompt (via
-// the same Asker ask_user_question uses) instead of silently proceeding or
-// only failing once ReplaySkill runs.
-func TestResolveMissingSkillParams_PromptsForMissingRequired(t *testing.T) {
+// TestResolveMissingSkillParams_ErrorsOnMissingRequired verifies a param
+// with no default and no caller-supplied value returns a clear error naming
+// the missing param(s), rather than auto-prompting the user. The model then
+// decides whether it already knows the value (re-invoke with `params`) or
+// needs to ask the caller via ask_user_question.
+func TestResolveMissingSkillParams_ErrorsOnMissingRequired(t *testing.T) {
 	skill := browser.Skill{
 		Name:   "demo",
 		Params: []browser.Param{{Name: "username", Description: "login name"}},
@@ -188,17 +189,18 @@ func TestResolveMissingSkillParams_PromptsForMissingRequired(t *testing.T) {
 	useAsker(t, stub)
 
 	params := map[string]string{}
-	if err := resolveMissingSkillParams(context.Background(), &skill, "demo", params); err != nil {
-		t.Fatalf("resolveMissingSkillParams: %v", err)
+	err := resolveMissingSkillParams(&skill, "demo", params)
+	if err == nil || !strings.Contains(err.Error(), "missing required param") {
+		t.Fatalf("err = %v, want a missing-required-param error", err)
 	}
-	if !stub.called {
-		t.Fatal("expected a prompt for the missing param")
+	if !strings.Contains(err.Error(), "username") {
+		t.Errorf("err = %v, want it to name the missing param", err)
 	}
-	if !strings.Contains(stub.lastReq.Question, "username") || !strings.Contains(stub.lastReq.Question, "login name") {
-		t.Errorf("question = %q, want it to mention the param name and description", stub.lastReq.Question)
+	if stub.called {
+		t.Error("should not auto-prompt the user — the model owns that decision")
 	}
-	if params["username"] != "alice" {
-		t.Errorf("params[username] = %q, want alice", params["username"])
+	if _, ok := params["username"]; ok {
+		t.Error("params should remain untouched on error")
 	}
 }
 
@@ -214,7 +216,7 @@ func TestResolveMissingSkillParams_NoPromptWhenProvided(t *testing.T) {
 	useAsker(t, stub)
 
 	params := map[string]string{"username": "bob"}
-	if err := resolveMissingSkillParams(context.Background(), &skill, "demo", params); err != nil {
+	if err := resolveMissingSkillParams(&skill, "demo", params); err != nil {
 		t.Fatalf("resolveMissingSkillParams: %v", err)
 	}
 	if stub.called {
@@ -222,11 +224,10 @@ func TestResolveMissingSkillParams_NoPromptWhenProvided(t *testing.T) {
 	}
 }
 
-// TestResolveMissingSkillParams_NoAskerLeavesGapForReplaySkillToReject
-// verifies headless/unattended modes are left unchanged: with no asker
-// registered, resolveMissingSkillParams is a no-op so ReplaySkill's own
-// "missing required param(s)" error still fires downstream.
-func TestResolveMissingSkillParams_NoAskerLeavesGapForReplaySkillToReject(t *testing.T) {
+// TestResolveMissingSkillParams_MissingReturnsError verifies that even when
+// there's no interactive asker, missing required params produce a clear error
+// (rather than the old silent no-op that left ReplaySkill to fail mid-replay).
+func TestResolveMissingSkillParams_MissingReturnsError(t *testing.T) {
 	SetAsker(nil)
 	skill := browser.Skill{
 		Name:   "demo",
@@ -234,27 +235,12 @@ func TestResolveMissingSkillParams_NoAskerLeavesGapForReplaySkillToReject(t *tes
 		Steps:  []browser.Step{{Action: "type", Selector: "#u", Value: "{{username}}"}},
 	}
 	params := map[string]string{}
-	if err := resolveMissingSkillParams(context.Background(), &skill, "demo", params); err != nil {
-		t.Fatalf("resolveMissingSkillParams: %v", err)
+	err := resolveMissingSkillParams(&skill, "demo", params)
+	if err == nil || !strings.Contains(err.Error(), "missing required param") {
+		t.Fatalf("err = %v, want a missing-required-param error", err)
 	}
 	if _, ok := params["username"]; ok {
-		t.Error("params should be untouched when no asker is available")
-	}
-}
-
-// TestResolveMissingSkillParams_CancelledPromptErrors verifies a cancelled
-// prompt aborts with an error instead of proceeding with a blank value.
-func TestResolveMissingSkillParams_CancelledPromptErrors(t *testing.T) {
-	skill := browser.Skill{
-		Name:   "demo",
-		Params: []browser.Param{{Name: "username"}},
-		Steps:  []browser.Step{{Action: "type", Selector: "#u", Value: "{{username}}"}},
-	}
-	useAsker(t, &stubAsker{resp: AskResponse{Cancelled: true}})
-	params := map[string]string{}
-	err := resolveMissingSkillParams(context.Background(), &skill, "demo", params)
-	if err == nil || !strings.Contains(err.Error(), "cancelled") {
-		t.Errorf("err = %v, want a cancellation error", err)
+		t.Error("params should be untouched on error")
 	}
 }
 

--- a/internal/tools/workflow.go
+++ b/internal/tools/workflow.go
@@ -226,14 +226,13 @@ func requiredParamNames(params []workflowParam) []string {
 
 // ensureRequiredWorkflowParams checks a saved workflow's declared `# @param
 // name required ...` inputs against the tool's `args` input. Any that are
-// missing are filled by prompting the user (via the same Asker the
-// ask_user_question tool uses) rather than letting the script hit a nil
-// args[...] lookup at runtime. Returns the args map to use when at least one
-// value was filled in (nil, nil when nothing was missing), or an error if a
-// required value couldn't be obtained (no asker available, or the user
-// cancelled).
-func ensureRequiredWorkflowParams(ctx context.Context, workflowName string, params []workflowParam, args map[string]any) (map[string]any, error) {
-	var missing []workflowParam
+// missing produce an error listing them — the model then decides whether to
+// re-invoke with `args` filled in (it already knows the values) or surface an
+// `ask_user_question` to the caller (it genuinely doesn't know). The old
+// behaviour auto-prompted via the ctx Asker, which stole that decision from the
+// model and caused repeat prompts when the model had already asked the user.
+func ensureRequiredWorkflowParams(workflowName string, params []workflowParam, args map[string]any) error {
+	var missing []string
 	for _, p := range params {
 		if !p.required {
 			continue
@@ -241,44 +240,13 @@ func ensureRequiredWorkflowParams(ctx context.Context, workflowName string, para
 		if v, ok := args[p.name]; ok && v != nil && v != "" {
 			continue
 		}
-		missing = append(missing, p)
+		missing = append(missing, p.name)
 	}
 	if len(missing) == 0 {
-		return nil, nil
+		return nil
 	}
-
-	asker := askerFrom(ctx)
-	if asker == nil {
-		names := make([]string, len(missing))
-		for i, p := range missing {
-			names[i] = p.name
-		}
-		return nil, fmt.Errorf("workflow %q is missing required arg(s) %s and no user is available to "+
-			"ask for them in this mode — pass them in `args` instead", workflowName, strings.Join(names, ", "))
-	}
-
-	filled := make(map[string]any, len(args)+len(missing))
-	for k, v := range args {
-		filled[k] = v
-	}
-	for _, p := range missing {
-		question := fmt.Sprintf("Workflow %q needs a value for %q", workflowName, p.name)
-		if p.description != "" {
-			question += ": " + p.description
-		}
-		res, err := asker.Ask(ctx, AskRequest{Question: question, Header: p.name})
-		if err != nil {
-			return nil, fmt.Errorf("workflow: %w", err)
-		}
-		if res.Cancelled {
-			return nil, fmt.Errorf("workflow %q: user cancelled while providing required arg %q", workflowName, p.name)
-		}
-		// AskRequest carries no Options, so this is always a free-text prompt —
-		// res.Choices is documented to stay empty in that case (AskResponse),
-		// leaving res.Custom as the only place the answer can land.
-		filled[p.name] = res.Custom
-	}
-	return filled, nil
+	return fmt.Errorf("workflow %q is missing required arg(s): %s — pass them in `args`",
+		workflowName, strings.Join(missing, ", "))
 }
 
 // Execute runs the workflow: detached with a run handle in background mode,
@@ -307,12 +275,8 @@ func (WorkflowTool) Execute(ctx context.Context, _ string, input map[string]any)
 		}
 		if len(w.params) > 0 {
 			argsMap, _ := input["args"].(map[string]any)
-			filled, err := ensureRequiredWorkflowParams(ctx, name, w.params, argsMap)
-			if err != nil {
+			if err := ensureRequiredWorkflowParams(name, w.params, argsMap); err != nil {
 				return agent.ToolResult{}, err
-			}
-			if filled != nil {
-				input["args"] = filled
 			}
 		}
 	}

--- a/internal/tools/workflow_test.go
+++ b/internal/tools/workflow_test.go
@@ -520,11 +520,12 @@ func TestWorkflowTool_RunsSavedByName(t *testing.T) {
 	}
 }
 
-// TestWorkflowTool_RunsSavedByName_PromptsForMissingRequiredArg verifies a
-// saved workflow that declares a required param has the tool ask the user for
-// it (via the same Asker ask_user_question uses) rather than letting the
-// script hit a nil args[...] lookup at runtime.
-func TestWorkflowTool_RunsSavedByName_PromptsForMissingRequiredArg(t *testing.T) {
+// TestWorkflowTool_RunsSavedByName_ErrorsOnMissingRequiredArg verifies a saved
+// workflow that declares a required param returns a clear error naming the
+// missing arg(s) rather than auto-prompting the user. The model then decides
+// whether it already knows the value (re-invoke with `args`) or needs to ask
+// the caller via ask_user_question.
+func TestWorkflowTool_RunsSavedByName_ErrorsOnMissingRequiredArg(t *testing.T) {
 	SetSpawner(replySpawner{})
 	t.Cleanup(func() { SetSpawner(nil) })
 	user := t.TempDir()
@@ -535,15 +536,15 @@ func TestWorkflowTool_RunsSavedByName_PromptsForMissingRequiredArg(t *testing.T)
 	stub := &stubAsker{resp: AskResponse{Custom: "hi there"}}
 	useAsker(t, stub)
 
-	got := startWorkflowAndWait(t, map[string]any{"name": "echo"})
-	if !stub.called {
-		t.Fatal("expected the tool to prompt for the missing required arg")
+	_, err := WorkflowTool{}.Execute(context.Background(), "c", map[string]any{"name": "echo"})
+	if err == nil || !strings.Contains(err.Error(), "missing required arg") {
+		t.Errorf("err = %v, want a missing-required-arg error listing q", err)
 	}
-	if !strings.Contains(stub.lastReq.Question, "q") {
-		t.Errorf("question = %q, want it to mention the missing param name", stub.lastReq.Question)
+	if !strings.Contains(err.Error(), "q") {
+		t.Errorf("err = %v, want it to name the missing param", err)
 	}
-	if !strings.Contains(got, "R[hi there]") {
-		t.Errorf("output = %q, want the prompted value to reach the script", got)
+	if stub.called {
+		t.Error("should not auto-prompt the user — the model owns that decision")
 	}
 }
 
@@ -587,9 +588,10 @@ func TestWorkflowTool_RunsSavedByName_MissingRequiredArgNoAsker(t *testing.T) {
 	}
 }
 
-// TestWorkflowTool_RunsSavedByName_CancelledPromptErrors verifies a cancelled
-// prompt aborts the run with an error instead of running with a blank value.
-func TestWorkflowTool_RunsSavedByName_CancelledPromptErrors(t *testing.T) {
+// TestWorkflowTool_RunsSavedByName_MissingRequiredArgWithAsker verifies that even
+// when an interactive asker IS available, the tool still returns a missing-arg
+// error rather than auto-prompting — decision ownership stays with the model.
+func TestWorkflowTool_RunsSavedByName_MissingRequiredArgWithAsker(t *testing.T) {
 	SetSpawner(replySpawner{})
 	t.Cleanup(func() { SetSpawner(nil) })
 	user := t.TempDir()
@@ -599,8 +601,8 @@ func TestWorkflowTool_RunsSavedByName_CancelledPromptErrors(t *testing.T) {
 	useAsker(t, &stubAsker{resp: AskResponse{Cancelled: true}})
 
 	_, err := WorkflowTool{}.Execute(context.Background(), "c", map[string]any{"name": "echo"})
-	if err == nil || !strings.Contains(err.Error(), "cancelled") {
-		t.Errorf("err = %v, want a cancellation error", err)
+	if err == nil || !strings.Contains(err.Error(), "missing required arg") {
+		t.Errorf("err = %v, want a missing-required-arg error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Removes the auto-prompt path that fired `asker.Ask()` whenever a saved workflow or browser skill had a missing required parameter. That behaviour stole the "ask the user or re-invoke with `args`" decision from the model and **caused repeat prompts** when the model had already asked the user via `ask_user_question`.

**New behaviour:** both tools return a clear error naming the missing arg(s). The model then decides whether it already knows the value (re-invoke with `args`) or needs to surface `ask_user_question` to the caller.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| `workflow` missing required arg + asker available | Auto-prompt via `asker.Ask()` | Returns error listing missing args |
| `workflow` missing required arg + no asker | Error | Error (unchanged) |
| `run_skill` missing required param + asker available | Auto-prompt via `asker.Ask()` | Returns error listing missing params |
| `run_skill` missing required param + no asker | **Silent no-op** → ReplaySkill fails mid-replay | Returns error listing missing params |

The last row is an additional bug fix: `browser.run_skill` previously returned `nil` (leaving params unfilled) when no asker was registered, which guaranteed a confusing downstream failure mid-replay. Now it returns the same clear error.

## Files

- `internal/tools/workflow.go` — `ensureRequiredWorkflowParams` no longer prompts, always errors
- `internal/tools/browser.go` — `resolveMissingSkillParams` no longer prompts, always errors (also fixes silent no-op)
- `internal/tools/workflow_test.go` / `browser_test.go` — tests now lock in error behaviour

## Verification

```
go test -race ./... -count=1    # ✓ all packages pass
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)