### PR TITLE
fix(blog): move architecture deep-dive before onboarding series

### DIFF
--- a/blog/src/content/posts/en/architecture-deep-dive.md
+++ b/blog/src/content/posts/en/architecture-deep-dive.md
@@ -1,7 +1,7 @@
 ---
 title: "octo-agent Architecture Deep Dive: Five-Layer Core Stack & Full-System Dependency Map"
 description: "An interactive panorama architecture diagram parsing octo-agent's five-layer unidirectional dependency from CLI/IM entry to LLM backends, the agent leaf package design, protocol-agnostic abstraction, and cross-cutting concerns like permission, workflow, and memory."
-pubDate: 2026-07-10
+pubDate: 2026-07-08
 updatedDate: 2026-07-10
 author: "octo-agent team"
 tags: ["architecture", "deep-dive", "engineering", "ai-agent"]

--- a/blog/src/content/posts/zh/architecture-deep-dive.md
+++ b/blog/src/content/posts/zh/architecture-deep-dive.md
@@ -1,7 +1,7 @@
 ---
 title: "octo-agent 架构深度解析：五层核心栈与全系统依赖图"
 description: "一幅可交互的全景架构图，解析 octo-agent 从 CLI/IM 入口到 LLM 后端的五层单向依赖、agent 叶子包设计、协议无关抽象，以及 permission/workflow/memory 等跨切关注点。"
-pubDate: 2026-07-10
+pubDate: 2026-07-08
 updatedDate: 2026-07-10
 author: "octo-agent team"
 tags: ["architecture", "deep-dive", "engineering", "ai-agent"]


### PR DESCRIPTION
## Problem

The <octo-agent Architecture Deep Dive> post had the same  (2026-07-10) as **Octo Onboarding Series (2)**. Because the blog list is sorted by  descending, this placed the architecture post between Onboarding Series (3) (2026-07-11) and Onboarding Series (2) (2026-07-10).

## Fix

Move the architecture deep-dive publication date to **2026-07-08** in both EN and ZH frontmatter, so it appears before the onboarding series. The  is left as 2026-07-10 to preserve the original publish record.

## Verification

-  in  completes successfully.
- Generated  and  now list Architecture Deep Dive after the full onboarding series.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>