### PR TITLE
fix(landing): center the 5 interface cards as 3+2 rows

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -235,14 +235,16 @@
 
     /* Interfaces */
     .interfaces {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
       gap: 1.25rem;
     }
     @media (max-width: 640px) {
-      .interfaces { grid-template-columns: 1fr; }
+      .iface { flex: 1 1 100%; }
     }
     .iface {
+      flex: 0 1 260px;
       background: var(--card-bg);
       border: 1px solid var(--border);
       border-radius: var(--radius);


### PR DESCRIPTION
## Summary
Follow-up to #1327 (already merged). The 5-card interfaces grid left a 4th card stranded at the left edge instead of wrapping cleanly. Switches `.interfaces` from grid to a centered `flex-wrap` layout so 3 cards fill each row and the trailing row of 2 centers itself.

## Test plan
- [x] Reviewed CSS diff — flex-basis 260px keeps 3 per row within the 960px container, wraps to a centered row of 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)