### PR TITLE
feat(image-gen): show generated images to the user via show_artifact

### DIFF
--- a/internal/skills/defaults/image-gen/SKILL.md
+++ b/internal/skills/defaults/image-gen/SKILL.md
@@ -93,7 +93,8 @@ uv run <skill-dir>/scripts/image_search.py "diverse engineering team in a modern
 ```
 
 The positional-prompt form skips the manifest and leaves no audit trail — reserve
-it for quick fixups and standalone requests.
+it for quick fixups and standalone requests. **After it finishes, present the file
+to the user** — see [Show the result](#show-the-result-to-the-user).
 
 ### Batch — an `image_prompts.json` manifest (audit trail)
 
@@ -138,6 +139,27 @@ uv run <skill-dir>/scripts/slice_images.py /abs/images/spot_sheet.png \
 
 `--trim` tight-crops each cell to its content; `--alpha` knocks out the flat
 background to transparency. Geometry rules: `references/image-generator.md` §4.3.
+
+## Show the result to the user
+
+These files are produced by a **script**, so — unlike `write_file` output — they
+are **not surfaced automatically**. After producing an image the user wants to
+see, call the **`show_artifact`** tool with the file's **absolute path** (one call
+per file). It adapts to the interface: in the **web UI** the image previews inline
+in the Artifacts panel; in the **TUI** the path becomes a click-to-open link;
+headless / IM just reports the path. (`show_artifact` only accepts a path that
+already exists and a previewable type — `.png/.jpg/.jpeg/.gif/.webp/.svg` all
+qualify.)
+
+**When to show:**
+
+- **One-off / standalone requests** — "generate an image of …", "find a photo of
+  …", a single fixup: **show every file you produce.** Seeing it is the point.
+- **Batch manifest, or when invoked by another skill** (e.g. `ppt-master` building
+  a deck): **do not `show_artifact` each item.** Those images are consumed into
+  the deck and the calling skill presents the finished artifact; per-image
+  previews would just spam the panel. Show one only on an explicit request to
+  review a specific generated image.
 
 ## Prompt quality — consult the craft library before writing an AI prompt
 


### PR DESCRIPTION
## Problem

You asked how a generated image reaches the user. Today: `image_gen.py` / `image_search.py` write the file and print `File saved to: <path>`, and that's it. Because the file comes from a **script** (not `write_file`), nothing surfaces it — the user only sees a **path**, no inline preview.

## Fix (instruction-only — the plumbing already exists)

octo already has the full pipeline to preview an agent-produced image:
- the **`show_artifact`** tool (default tool, `registry.go`) whitelists a script-produced file,
- `GET /api/sessions/{id}/artifacts?path=…` serves it (transcript-whitelisted, 10 MB cap, sandboxed CSP),
- `web/src/lib/artifacts.ts` has a `kind === 'image'` branch that renders `<img>` in the Artifacts panel,
- `ArtifactContentType` already accepts `.png/.jpg/.jpeg/.gif/.webp/.svg`.

The only gap was that the image-gen skill never told the model to call `show_artifact`. This adds a **"Show the result to the user"** section to `SKILL.md`:

- After a **one-off / standalone** generate or search → call `show_artifact <abs-path>` per file. Web previews inline; TUI gives a click-to-open link; headless/IM reports the path.
- In the **batch/manifest or ppt-master-invoked** path → do **not** show per item (images are consumed into the deck; the caller presents the finished artifact) — only on an explicit request to review one.

No Go or frontend change.

## Verification

`go test ./internal/skills/` passes; `make build` embeds cleanly; `fmt-check` clean. Mechanism confirmed by reading `artifact_handler.go`, `tools/artifact.go` (show_artifact + ArtifactContentType), `registry.go`, and `artifacts.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)