### PR TITLE
chore: bump version to 1.12.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.11.0"
+var Version = "1.12.0"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Minor release since v1.11.0.

**Highlights**
- **Desktop app is now the shared `octo serve` hub** for the machine (#1342) — one backend on 127.0.0.1:8088 that the Web UI, VS Code, Obsidian, and CLI all share; opt-in per-machine channels; pid-protocol takeover — on top of shipping as octo's 6th interface with macOS/Windows/Linux packaging (#1335).
- **Web folder picker** to set a session's working dir from a real path (#1331).
- **Sidebar session groups** (#1341).
- **image-gen** improvements + **ppt-master** default skill (#1332/#1336/#1337/#1338).
- **agentmemory** memory backend, replacing memos (#1343).

No breaking changes. Tagging `v1.12.0` after this merges triggers the release build (binaries + macOS `.pkg` / Windows `.exe` / Linux AppImage).