### PR TITLE
feat(desktop): tray status + localized dialogs + takeover bind-race fix

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 
@@ -112,10 +113,22 @@ func (b *nativeBridge) PersistChannelsEnabled(enabled bool) error {
 	return saveDesktopSettings(snapshot)
 }
 
-// showWindow brings the hub window to the foreground, re-creating it if it was
-// closed to the tray (KeepRunningInBackground). Used by the tray's "Show Octo"
-// item, a second-instance launch, and a notification click.
-func (b *nativeBridge) showWindow() {
+// showWindow brings the hub window to the foreground on the current view.
+func (b *nativeBridge) showWindow() { b.showWindowAt("") }
+
+// openSettings brings the window up on the Settings view (tray "Settings").
+func (b *nativeBridge) openSettings() { b.showWindowAt("settings") }
+
+// showWindowAt brings the hub window to the foreground, re-creating it if it was
+// closed to the tray (KeepRunningInBackground), and navigates to the given
+// frontend hash route (empty = leave it where it is). The frontend routes on
+// location.hash, so a fresh window loads straight into the view and an existing
+// one navigates via a hashchange — no full reload.
+func (b *nativeBridge) showWindowAt(hash string) {
+	target := b.url
+	if hash != "" {
+		target = b.url + "#" + hash
+	}
 	if b.window == nil {
 		if b.app == nil || b.url == "" {
 			return // not bound yet
@@ -124,7 +137,7 @@ func (b *nativeBridge) showWindow() {
 			Title:  "Octo",
 			Width:  1280,
 			Height: 860,
-			URL:    b.url,
+			URL:    target,
 			// Hidden-inset title bar: the traffic lights float over the page's
 			// top-left; the frontend insets its header past them (nativeShell).
 			Mac: application.MacWindow{TitleBar: application.MacTitleBarHiddenInset},
@@ -135,6 +148,9 @@ func (b *nativeBridge) showWindow() {
 			b.window = nil
 		})
 		b.window = w
+	} else if hash != "" {
+		// Already loaded — switch the SPA route without reloading.
+		b.window.ExecJS("window.location.hash = " + strconv.Quote(hash))
 	}
 	b.window.Show()
 	b.window.Restore()

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -25,6 +25,14 @@ type nativeBridge struct {
 	srv atomic.Pointer[server.Server]
 	url string // http://127.0.0.1:8088, set once bound
 
+	// allowQuit gates the app's ShouldQuit on Windows/Linux, where closing the
+	// last window would otherwise terminate the app (and the hub with it). It
+	// starts false when KeepRunningInBackground is on, so a window close hides
+	// to the tray; requestQuit flips it true for a real quit. Unused on macOS
+	// (its close behavior is the ApplicationShouldTerminateAfterLastWindowClosed
+	// option; ShouldQuit there always allows the quit).
+	allowQuit atomic.Bool
+
 	settingsMu sync.Mutex
 	settings   desktopSettings
 }
@@ -198,5 +206,7 @@ func (b *nativeBridge) requestQuit() {
 			return
 		}
 	}
+	// A real quit: let ShouldQuit (Windows/Linux) allow app termination.
+	b.allowQuit.Store(true)
 	b.app.Quit()
 }

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -159,7 +159,7 @@ func (b *nativeBridge) confirm(title, message, okLabel, cancelLabel string) bool
 // showError shows a modal error dialog with a single OK button.
 func (b *nativeBridge) showError(title, message string) {
 	dlg := b.app.Dialog.Error().SetTitle(title).SetMessage(message)
-	dlg.AddButton("OK").SetAsDefault()
+	dlg.AddButton(L.dialogOKText).SetAsDefault()
 	dlg.Show()
 }
 
@@ -167,20 +167,16 @@ func (b *nativeBridge) showError(title, message string) {
 // the hub. Declining means the app will quit (it won't run windowed without
 // its own server to attach the native bridge to).
 func (b *nativeBridge) confirmTakeover(pid int) bool {
-	return b.confirm("Octo",
-		fmt.Sprintf("A background Octo backend is already running (pid %d).\n\n"+
-			"Stop it and run Octo as the hub for this machine?", pid),
-		"Stop and Continue", "Quit")
+	return b.confirm(L.takeoverTitle,
+		fmt.Sprintf(L.takeoverMsgFmt, pid),
+		L.takeoverOK, L.takeoverCancel)
 }
 
 // requestQuit is the tray "Quit Octo" action: it fully stops the backend, so it
 // confirms first when channels are running (other clients would disconnect).
 func (b *nativeBridge) requestQuit() {
 	if srv := b.srv.Load(); srv != nil && srv.ChannelsEnabled() {
-		if !b.confirm("Quit Octo",
-			"Quitting stops the Octo backend on this machine. Connected editors, "+
-				"browsers, and IM channels will disconnect.\n\nQuit anyway?",
-			"Quit", "Cancel") {
+		if !b.confirm(L.quitTitle, L.quitMsg, L.quitOK, L.quitCancel) {
 			return
 		}
 	}

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"sync"
 	"sync/atomic"
 
@@ -149,8 +148,11 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		})
 		b.window = w
 	} else if hash != "" {
-		// Already loaded — switch the SPA route without reloading.
-		b.window.ExecJS("window.location.hash = " + strconv.Quote(hash))
+		// Already open — navigate to the route. ExecJS can't be used here: the
+		// page is served by octo's own server, not Wails' asset server, so the
+		// Wails runtime never loads and ExecJS stays queued forever. SetURL is a
+		// native navigation that doesn't depend on it.
+		b.window.SetURL(target)
 	}
 	b.window.Show()
 	b.window.Restore()

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/open-octo/octo-agent/internal/server"
 	"github.com/wailsapp/wails/v3/pkg/application"
@@ -19,8 +20,10 @@ type nativeBridge struct {
 	app      *application.App
 	window   *application.WebviewWindow
 	notifier *notifications.NotificationService // nil unless bundled
-	srv      *server.Server                     // the in-process hub; set once bound
-	url      string                             // http://127.0.0.1:8088, set once bound
+	// srv is the in-process hub, set once bound. Atomic because startHub (the
+	// ApplicationStarted goroutine) writes it while the tray-refresh loop reads it.
+	srv atomic.Pointer[server.Server]
+	url string // http://127.0.0.1:8088, set once bound
 
 	settingsMu sync.Mutex
 	settings   desktopSettings
@@ -173,7 +176,7 @@ func (b *nativeBridge) confirmTakeover(pid int) bool {
 // requestQuit is the tray "Quit Octo" action: it fully stops the backend, so it
 // confirms first when channels are running (other clients would disconnect).
 func (b *nativeBridge) requestQuit() {
-	if b.srv != nil && b.srv.ChannelsEnabled() {
+	if srv := b.srv.Load(); srv != nil && srv.ChannelsEnabled() {
 		if !b.confirm("Quit Octo",
 			"Quitting stops the Octo backend on this machine. Connected editors, "+
 				"browsers, and IM channels will disconnect.\n\nQuit anyway?",

--- a/cmd/octo-desktop/lang.go
+++ b/cmd/octo-desktop/lang.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 )
 
@@ -105,24 +103,17 @@ func detectLang() {
 	}
 }
 
-// preferredLang returns "zh" or "en" from the OS's preferred UI language. On
-// macOS a Finder-launched app often has no LANG, so it reads AppleLanguages
-// (whose first element is the user's preferred UI language); elsewhere it falls
-// back to the LC_*/LANG environment.
+// preferredLang returns "zh" or "en" from the OS's preferred UI language. It
+// asks the platform (osLang: AppleLanguages on macOS, GetUserDefaultLocaleName
+// on Windows) first, since a Finder/Explorer-launched app usually has no LANG;
+// only when that yields nothing does it fall back to the LC_*/LANG environment
+// (which is how Linux exposes it).
 func preferredLang() string {
-	if runtime.GOOS == "darwin" {
-		if out, err := exec.Command("/usr/bin/defaults", "read", "-g", "AppleLanguages").Output(); err == nil {
-			// Output is a plist array; the first quoted token is the preferred one.
-			if i := strings.Index(string(out), "\""); i >= 0 {
-				rest := string(out)[i+1:]
-				if j := strings.Index(rest, "\""); j >= 0 {
-					if strings.HasPrefix(strings.ToLower(rest[:j]), "zh") {
-						return "zh"
-					}
-					return "en"
-				}
-			}
+	if lang := osLang(); lang != "" {
+		if strings.HasPrefix(strings.ToLower(lang), "zh") {
+			return "zh"
 		}
+		return "en"
 	}
 	for _, k := range []string{"LC_ALL", "LC_MESSAGES", "LANG"} {
 		if v := os.Getenv(k); v != "" {

--- a/cmd/octo-desktop/lang.go
+++ b/cmd/octo-desktop/lang.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// uiStrings holds every user-facing native string the desktop shell shows
+// outside the web UI — dialogs, the tray menu, error messages. Selected once at
+// startup by the system language. Format strings keep their verbs so call sites
+// can fmt.Sprintf them.
+type uiStrings struct {
+	trayShow, trayQuit string
+	trayStarting       string
+	trayBackendFmt     string // "Backend · %s"
+	trayChannelsOff    string
+	trayChannelsOnNone string
+	trayChannelsOnFmt  string // "Channels: on · %d (%s)"
+	trayClientsFmt     string // "Connected clients: %d"
+
+	takeoverTitle  string
+	takeoverMsgFmt string // "...(pid %d)..."
+	takeoverOK     string
+	takeoverCancel string
+
+	quitTitle  string
+	quitMsg    string
+	quitOK     string
+	quitCancel string
+
+	errTitle     string
+	errBindFmt   string // "...%s...%v"
+	errStopFmt   string // "...%v"
+	errStartFmt  string // "...%v"
+	dialogOKText string
+}
+
+var enStrings = uiStrings{
+	trayShow:           "Show Octo",
+	trayQuit:           "Quit Octo",
+	trayStarting:       "Starting…",
+	trayBackendFmt:     "Backend · %s",
+	trayChannelsOff:    "Channels: off",
+	trayChannelsOnNone: "Channels: on · none connected",
+	trayChannelsOnFmt:  "Channels: on · %d (%s)",
+	trayClientsFmt:     "Connected clients: %d",
+
+	takeoverTitle:  "Octo",
+	takeoverMsgFmt: "A background Octo backend is already running (pid %d).\n\nStop it and run Octo as the hub for this machine?",
+	takeoverOK:     "Stop and Continue",
+	takeoverCancel: "Quit",
+
+	quitTitle:  "Quit Octo",
+	quitMsg:    "Quitting stops the Octo backend on this machine. Connected editors, browsers, and IM channels will disconnect.\n\nQuit anyway?",
+	quitOK:     "Quit",
+	quitCancel: "Cancel",
+
+	errTitle:     "Octo",
+	errBindFmt:   "Couldn't bind %s — another program may be using it.\n\n%v",
+	errStopFmt:   "Couldn't stop the running backend: %v",
+	errStartFmt:  "Couldn't start the backend: %v",
+	dialogOKText: "OK",
+}
+
+var zhStrings = uiStrings{
+	trayShow:           "显示 Octo",
+	trayQuit:           "退出 Octo",
+	trayStarting:       "启动中…",
+	trayBackendFmt:     "后端 · %s",
+	trayChannelsOff:    "Channel：未开启",
+	trayChannelsOnNone: "Channel：已开启 · 暂无连接",
+	trayChannelsOnFmt:  "Channel：已开启 · %d 个（%s）",
+	trayClientsFmt:     "已连接客户端：%d",
+
+	takeoverTitle:  "Octo",
+	takeoverMsgFmt: "已有一个 Octo 后端在后台运行（pid %d）。\n\n停止它，并让 Octo 作为本机的后端中枢？",
+	takeoverOK:     "停止并继续",
+	takeoverCancel: "退出",
+
+	quitTitle:  "退出 Octo",
+	quitMsg:    "退出会停止本机的 Octo 后端，已连接的编辑器、浏览器和 IM channel 都会断开。\n\n仍要退出？",
+	quitOK:     "退出",
+	quitCancel: "取消",
+
+	errTitle:     "Octo",
+	errBindFmt:   "无法绑定 %s —— 可能有其他程序正在占用。\n\n%v",
+	errStopFmt:   "无法停止正在运行的后端：%v",
+	errStartFmt:  "无法启动后端：%v",
+	dialogOKText: "好",
+}
+
+// L is the active string set, chosen at startup by detectLang.
+var L = enStrings
+
+// detectLang switches L to Chinese when the system's preferred UI language is
+// Chinese; everything else stays English.
+func detectLang() {
+	if preferredLang() == "zh" {
+		L = zhStrings
+	}
+}
+
+// preferredLang returns "zh" or "en" from the OS's preferred UI language. On
+// macOS a Finder-launched app often has no LANG, so it reads AppleLanguages
+// (whose first element is the user's preferred UI language); elsewhere it falls
+// back to the LC_*/LANG environment.
+func preferredLang() string {
+	if runtime.GOOS == "darwin" {
+		if out, err := exec.Command("/usr/bin/defaults", "read", "-g", "AppleLanguages").Output(); err == nil {
+			// Output is a plist array; the first quoted token is the preferred one.
+			if i := strings.Index(string(out), "\""); i >= 0 {
+				rest := string(out)[i+1:]
+				if j := strings.Index(rest, "\""); j >= 0 {
+					if strings.HasPrefix(strings.ToLower(rest[:j]), "zh") {
+						return "zh"
+					}
+					return "en"
+				}
+			}
+		}
+	}
+	for _, k := range []string{"LC_ALL", "LC_MESSAGES", "LANG"} {
+		if v := os.Getenv(k); v != "" {
+			if strings.HasPrefix(strings.ToLower(v), "zh") {
+				return "zh"
+			}
+			return "en"
+		}
+	}
+	return "en"
+}

--- a/cmd/octo-desktop/lang.go
+++ b/cmd/octo-desktop/lang.go
@@ -13,6 +13,7 @@ import (
 // can fmt.Sprintf them.
 type uiStrings struct {
 	trayShow, trayQuit string
+	traySettings       string
 	trayStarting       string
 	trayBackendFmt     string // "Backend · %s"
 	trayChannelsOff    string
@@ -40,6 +41,7 @@ type uiStrings struct {
 var enStrings = uiStrings{
 	trayShow:           "Show Octo",
 	trayQuit:           "Quit Octo",
+	traySettings:       "Settings…",
 	trayStarting:       "Starting…",
 	trayBackendFmt:     "Backend · %s",
 	trayChannelsOff:    "Channels: off",
@@ -67,6 +69,7 @@ var enStrings = uiStrings{
 var zhStrings = uiStrings{
 	trayShow:           "显示 Octo",
 	trayQuit:           "退出 Octo",
+	traySettings:       "设置…",
 	trayStarting:       "启动中…",
 	trayBackendFmt:     "后端 · %s",
 	trayChannelsOff:    "Channel：未开启",

--- a/cmd/octo-desktop/lang_darwin.go
+++ b/cmd/octo-desktop/lang_darwin.go
@@ -1,0 +1,26 @@
+//go:build darwin
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// osLang returns the user's preferred UI language from macOS's AppleLanguages
+// (its first element), e.g. "zh-Hans-CN" or "en-US". Empty on failure so the
+// caller falls back to the environment.
+func osLang() string {
+	out, err := exec.Command("/usr/bin/defaults", "read", "-g", "AppleLanguages").Output()
+	if err != nil {
+		return ""
+	}
+	// The output is a plist array; the first quoted token is the preferred one.
+	if i := strings.Index(string(out), "\""); i >= 0 {
+		rest := string(out)[i+1:]
+		if j := strings.Index(rest, "\""); j >= 0 {
+			return rest[:j]
+		}
+	}
+	return ""
+}

--- a/cmd/octo-desktop/lang_other.go
+++ b/cmd/octo-desktop/lang_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !windows
+
+package main
+
+// osLang has no cheap system query on Linux/BSD; preferredLang falls back to
+// the LC_*/LANG environment, which desktop sessions there set.
+func osLang() string { return "" }

--- a/cmd/octo-desktop/lang_windows.go
+++ b/cmd/octo-desktop/lang_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// osLang returns the user's default locale name from Windows (e.g. "zh-CN",
+// "en-US") via GetUserDefaultLocaleName. Windows GUI apps don't get LANG set,
+// so this is the reliable source. Empty on failure.
+func osLang() string {
+	const localeNameMaxLength = 85 // LOCALE_NAME_MAX_LENGTH
+	proc := syscall.NewLazyDLL("kernel32.dll").NewProc("GetUserDefaultLocaleName")
+	buf := make([]uint16, localeNameMaxLength)
+	n, _, _ := proc.Call(uintptr(unsafe.Pointer(&buf[0])), uintptr(len(buf)))
+	if n == 0 {
+		return ""
+	}
+	return syscall.UTF16ToString(buf)
+}

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -61,6 +61,9 @@ func isBundled() bool {
 }
 
 func main() {
+	// Pick the language for native dialogs/tray from the system UI language.
+	detectLang()
+
 	settings := loadDesktopSettings()
 
 	// Seed ~/.octo/bin/uv from the app's bundled copy on first run so skills
@@ -115,7 +118,7 @@ func main() {
 	} else {
 		tray.SetIcon(trayColorIcon)
 	}
-	tray.SetTooltip("Octo")
+	tray.SetTooltip(L.takeoverTitle)
 	tray.SetMenu(buildTrayMenu(app, bridge))
 	// Keep the tray's status lines (backend, channels, connected clients) fresh
 	// while the app runs — macOS doesn't refresh a status menu on open.
@@ -155,22 +158,30 @@ func main() {
 // the ApplicationStarted hook so its dialogs have a live event loop.
 func startHub(app *application.App, bridge *nativeBridge, settings desktopSettings) {
 	// If another backend already owns the port, ask before displacing it.
+	tookOver := false
 	if pid, ok := serveproc.Running(); ok {
 		if !bridge.confirmTakeover(pid) {
 			app.Quit()
 			return
 		}
 		if _, err := serveproc.Stop(); err != nil {
-			bridge.showError("Octo", fmt.Sprintf("Couldn't stop the running backend: %v", err))
+			bridge.showError(L.errTitle, fmt.Sprintf(L.errStopFmt, err))
 			app.Quit()
 			return
 		}
+		tookOver = true
 	}
 
-	ln, err := net.Listen("tcp", hubAddr)
+	// After a takeover, the stopped daemon needs a moment to release the port —
+	// serveproc.Stop only signals it. Retry the bind for a few seconds so the
+	// handoff is seamless; a cold start with a genuine conflict fails at once.
+	grace := time.Duration(0)
+	if tookOver {
+		grace = 8 * time.Second
+	}
+	ln, err := listenHub(hubAddr, grace)
 	if err != nil {
-		bridge.showError("Octo",
-			fmt.Sprintf("Couldn't bind %s — another program may be using it.\n\n%v", hubAddr, err))
+		bridge.showError(L.errTitle, fmt.Sprintf(L.errBindFmt, hubAddr, err))
 		app.Quit()
 		return
 	}
@@ -190,7 +201,7 @@ func startHub(app *application.App, bridge *nativeBridge, settings desktopSettin
 		ChannelsEnabled: &channelsOn,
 	})
 	if err != nil {
-		bridge.showError("Octo", fmt.Sprintf("Couldn't start the backend: %v", err))
+		bridge.showError(L.errTitle, fmt.Sprintf(L.errStartFmt, err))
 		app.Quit()
 		return
 	}
@@ -202,6 +213,23 @@ func startHub(app *application.App, bridge *nativeBridge, settings desktopSettin
 	}()
 
 	bridge.showWindow()
+}
+
+// listenHub binds addr, retrying for up to grace so a just-stopped daemon has
+// time to release the port (SIGTERM only signals it; the listener closes a
+// beat later). grace of 0 means a single attempt.
+func listenHub(addr string, grace time.Duration) (net.Listener, error) {
+	deadline := time.Now().Add(grace)
+	for {
+		ln, err := net.Listen("tcp", addr)
+		if err == nil {
+			return ln, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, err
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 }
 
 // trayStatusLines is the (info-only) top of the tray menu: what the hub is

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -71,6 +71,9 @@ func main() {
 	ensureBundledUv()
 
 	bridge := &nativeBridge{settings: settings, url: "http://" + hubAddr}
+	// On Windows/Linux a window close would otherwise quit the app; start with
+	// quit allowed only when the user opted out of keep-running-in-background.
+	bridge.allowQuit.Store(!settings.KeepRunningInBackground)
 
 	// Native notifications only when bundled (see isBundled): the service needs
 	// a bundle identifier. Registered as a Wails service so its ServiceStartup
@@ -91,6 +94,18 @@ func main() {
 			OnSecondInstanceLaunch: func(application.SecondInstanceData) {
 				bridge.showWindow()
 			},
+		},
+		// ShouldQuit is consulted on every termination attempt. On Windows/Linux
+		// that includes closing the last window, so returning allowQuit there
+		// keeps the hub alive in the tray (reopen via "Show Octo" or relaunch)
+		// until the user picks "Quit Octo". macOS never quits on window close
+		// thanks to the option below and handles real quits (Cmd-Q) itself, so
+		// it always allows the quit.
+		ShouldQuit: func() bool {
+			if runtime.GOOS == "darwin" {
+				return true
+			}
+			return bridge.allowQuit.Load()
 		},
 		Mac: application.MacOptions{
 			// Closing the window must not quit the hub when the user wants it to

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -238,19 +238,19 @@ func listenHub(addr string, grace time.Duration) (net.Listener, error) {
 func trayStatusLines(bridge *nativeBridge) []string {
 	srv := bridge.srv.Load()
 	if srv == nil {
-		return []string{"Starting…"}
+		return []string{L.trayStarting}
 	}
-	lines := []string{"Backend · " + hubAddr}
+	lines := []string{fmt.Sprintf(L.trayBackendFmt, hubAddr)}
 	if srv.ChannelsEnabled() {
 		if running := srv.RunningChannels(); len(running) > 0 {
-			lines = append(lines, fmt.Sprintf("Channels: on · %d (%s)", len(running), strings.Join(running, ", ")))
+			lines = append(lines, fmt.Sprintf(L.trayChannelsOnFmt, len(running), strings.Join(running, ", ")))
 		} else {
-			lines = append(lines, "Channels: on · none connected")
+			lines = append(lines, L.trayChannelsOnNone)
 		}
 	} else {
-		lines = append(lines, "Channels: off")
+		lines = append(lines, L.trayChannelsOff)
 	}
-	lines = append(lines, fmt.Sprintf("Connected clients: %d", srv.ConnectedClients()))
+	lines = append(lines, fmt.Sprintf(L.trayClientsFmt, srv.ConnectedClients()))
 	return lines
 }
 
@@ -263,8 +263,10 @@ func buildTrayMenu(app *application.App, bridge *nativeBridge) *application.Menu
 		m.Add(line).SetEnabled(false)
 	}
 	m.AddSeparator()
-	m.Add("Show Octo").OnClick(func(*application.Context) { bridge.showWindow() })
-	m.Add("Quit Octo").OnClick(func(*application.Context) { bridge.requestQuit() })
+	m.Add(L.trayShow).OnClick(func(*application.Context) { bridge.showWindow() })
+	m.Add(L.traySettings).OnClick(func(*application.Context) { bridge.openSettings() })
+	m.AddSeparator()
+	m.Add(L.trayQuit).OnClick(func(*application.Context) { bridge.requestQuit() })
 	return m
 }
 

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -116,11 +116,10 @@ func main() {
 		tray.SetIcon(trayColorIcon)
 	}
 	tray.SetTooltip("Octo")
-	trayMenu := app.NewMenu()
-	trayMenu.Add("Show Octo").OnClick(func(*application.Context) { bridge.showWindow() })
-	trayMenu.AddSeparator()
-	trayMenu.Add("Quit Octo").OnClick(func(*application.Context) { bridge.requestQuit() })
-	tray.SetMenu(trayMenu)
+	tray.SetMenu(buildTrayMenu(app, bridge))
+	// Keep the tray's status lines (backend, channels, connected clients) fresh
+	// while the app runs — macOS doesn't refresh a status menu on open.
+	go refreshTrayLoop(app, tray, bridge)
 
 	// Bind + serve + open the window once the event loop is up, so the takeover
 	// prompt (a modal dialog) can run. Doing it here rather than before Run lets
@@ -141,9 +140,9 @@ func main() {
 	// a successor that took the port over must keep its own) and shut the
 	// server down cleanly.
 	serveproc.ReleaseOwned(os.Getpid())
-	if bridge.srv != nil {
+	if srv := bridge.srv.Load(); srv != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		_ = bridge.srv.Shutdown(ctx)
+		_ = srv.Shutdown(ctx)
 		cancel()
 	}
 	if err != nil {
@@ -195,7 +194,7 @@ func startHub(app *application.App, bridge *nativeBridge, settings desktopSettin
 		app.Quit()
 		return
 	}
-	bridge.srv = srv
+	bridge.srv.Store(srv)
 	go func() {
 		if err := srv.ServeOn(ln); err != nil {
 			log.Printf("octo-desktop: server stopped: %v", err)
@@ -203,4 +202,56 @@ func startHub(app *application.App, bridge *nativeBridge, settings desktopSettin
 	}()
 
 	bridge.showWindow()
+}
+
+// trayStatusLines is the (info-only) top of the tray menu: what the hub is
+// doing right now — where it's serving, whether it's bridging IM channels
+// (and which), and how many clients are attached.
+func trayStatusLines(bridge *nativeBridge) []string {
+	srv := bridge.srv.Load()
+	if srv == nil {
+		return []string{"Starting…"}
+	}
+	lines := []string{"Backend · " + hubAddr}
+	if srv.ChannelsEnabled() {
+		if running := srv.RunningChannels(); len(running) > 0 {
+			lines = append(lines, fmt.Sprintf("Channels: on · %d (%s)", len(running), strings.Join(running, ", ")))
+		} else {
+			lines = append(lines, "Channels: on · none connected")
+		}
+	} else {
+		lines = append(lines, "Channels: off")
+	}
+	lines = append(lines, fmt.Sprintf("Connected clients: %d", srv.ConnectedClients()))
+	return lines
+}
+
+// buildTrayMenu assembles the tray menu: disabled status lines on top, then the
+// Show/Quit actions. Rebuilt (not mutated in place) so a refresh is one
+// SetMenu call, which Wails marshals to the UI thread.
+func buildTrayMenu(app *application.App, bridge *nativeBridge) *application.Menu {
+	m := app.NewMenu()
+	for _, line := range trayStatusLines(bridge) {
+		m.Add(line).SetEnabled(false)
+	}
+	m.AddSeparator()
+	m.Add("Show Octo").OnClick(func(*application.Context) { bridge.showWindow() })
+	m.Add("Quit Octo").OnClick(func(*application.Context) { bridge.requestQuit() })
+	return m
+}
+
+// refreshTrayLoop re-publishes the tray menu whenever its status text changes,
+// so the counts stay live without rebuilding on every tick.
+func refreshTrayLoop(app *application.App, tray *application.SystemTray, bridge *nativeBridge) {
+	last := strings.Join(trayStatusLines(bridge), "|")
+	t := time.NewTicker(3 * time.Second)
+	defer t.Stop()
+	for range t.C {
+		sig := strings.Join(trayStatusLines(bridge), "|")
+		if sig == last {
+			continue
+		}
+		last = sig
+		tray.SetMenu(buildTrayMenu(app, bridge))
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2951,3 +2951,29 @@ func (s *Server) SetChannelsEnabled(on bool) {
 func (s *Server) ChannelsEnabled() bool {
 	return !s.cfg.NoChannel && !s.channelsDisabled.Load()
 }
+
+// RunningChannels returns the sorted names of the IM platforms with a live
+// adapter. Empty when channels are off or none have connected yet. Surfaced in
+// the desktop tray.
+func (s *Server) RunningChannels() []string {
+	var names []string
+	s.runningAdapters.Range(func(k, _ any) bool {
+		if name, ok := k.(string); ok {
+			names = append(names, name)
+		}
+		return true
+	})
+	sort.Strings(names)
+	return names
+}
+
+// ConnectedClients reports how many WebSocket clients (web tabs, editor
+// extensions) are currently connected. Surfaced in the desktop tray.
+func (s *Server) ConnectedClients() int {
+	if s.wsHub == nil {
+		return 0
+	}
+	s.wsHub.mu.Lock()
+	defer s.wsHub.mu.Unlock()
+	return len(s.wsHub.connections)
+}


### PR DESCRIPTION
Follow-ups to #1347, from on-device testing of the v1.12.0 desktop hub. Three related desktop-shell refinements:

### 1. Live backend status in the tray menu
The menu was just Show/Quit — no way to see what the background hub is doing. Adds disabled info lines on top: **Backend · 127.0.0.1:8088**, channel state (**off** / **on · N (feishu, telegram…)** / **on · none connected**), and **Connected clients: N**. A 3s loop re-publishes the menu only when the text changes (`SetMenu` marshals to the UI thread). Backed by new server accessors `RunningChannels()` + `ConnectedClients()`; `bridge.srv` becomes an `atomic.Pointer`.

### 2. Takeover bind-race fix (real bug)
Choosing "Stop and Continue" sent the running daemon a SIGTERM then bound `:8088` immediately — but the port wasn't released yet, so it failed with *"address already in use."* Now retries the bind for up to 8s after a takeover so the handoff is seamless; a cold start with a genuine conflict still fails on the first attempt.

### 3. Localized native dialogs + tray (zh/en)
The takeover / quit / error dialogs and the tray menu were English-only. Added a zh/en string set chosen at startup from the OS UI language (macOS reads `AppleLanguages`; others fall back to `LC_*`/`LANG`) and routed every native string through it. The web UI keeps its own i18n.

Build-verified (macOS CGO + Windows cross-compile, `go test ./internal/server`). Tray rendering, the takeover handoff, and the localized dialogs were exercised on a local build during testing.