### PR TITLE
docs(memory-backends): warn about agentmemory's CWD-relative state store

### DIFF
--- a/docs/src/content/docs/guides/memory-backends.md
+++ b/docs/src/content/docs/guides/memory-backends.md
@@ -165,6 +165,18 @@ agentmemory
 (Or run it without installing: `npx @agentmemory/agentmemory`.) The REST API binds to
 `127.0.0.1:3111` by default; a live viewer runs on `3113`.
 
+:::caution[Start it from a fixed, writable directory]
+agentmemory's storage engine writes its state store to `./data/` **relative to the current
+working directory**. Launch it from a different directory each time — or as a service whose
+working directory defaults to `/` (launchd, systemd) — and it can't write there: `state::set`
+calls hang until a 180-second timeout, and **nothing persists across restarts** (every start
+comes up with an empty index, silently losing everything stored since the last run). Always
+run it from a stable, writable directory (e.g. `~/.agentmemory`), and set that directory
+explicitly under a process manager (`WorkingDirectory` in a launchd plist, `WorkingDirectory=`
+in a systemd unit). Confirm it took: after storing something and restarting the server, the
+same query should still return it, and `~/.agentmemory/data/state_store.db` should exist.
+:::
+
 Verify it's up:
 
 ```bash
@@ -262,6 +274,16 @@ free of the extra round trip and rely on the tool alone.
 - **agentmemory: recall returns nothing right after storing** — confirm the server is actually up
   (`curl http://localhost:3111/agentmemory/health`) and that octo's `namespace` matches across
   restarts; it maps to agentmemory's `project`, which scopes what search returns.
+- **agentmemory: everything is gone after a restart, or logs show `Invocation timeout after
+  180000ms: state::set` / `index persistence: failed`** — the server was started from a working
+  directory it can't persist into (its state store is `./data/` relative to the CWD; a service
+  defaulting to `/` can't write there). Restart it from a fixed, writable directory and set
+  `WorkingDirectory` under your process manager — see the caution in the agentmemory setup section.
+  `~/.agentmemory/data/state_store.db` appearing (and surviving a restart) is the signal it's fixed.
+- **agentmemory: startup hangs or the local embedding model won't download on a restricted network**
+  — it fetches `all-MiniLM-L6-v2` from HuggingFace on first run. If `huggingface.co` is blocked or
+  throttled where you're hosting, point it at a mirror via the `HF_ENDPOINT` environment variable
+  (e.g. `HF_ENDPOINT=https://hf-mirror.com`) before starting the server.
 - **hindsight: connection refused right after `docker run`** — give it a minute or two; it's still
   downloading/loading the embedding and reranker models. `docker logs hindsight` shows progress.
   Once it prints its startup banner, subsequent restarts are much faster (models are cached in the

--- a/docs/src/content/docs/zh/guides/memory-backends.md
+++ b/docs/src/content/docs/zh/guides/memory-backends.md
@@ -158,6 +158,15 @@ agentmemory
 （或者不装直接跑：`npx @agentmemory/agentmemory`。）REST API 默认监听 `127.0.0.1:3111`，另有一个
 实时查看器跑在 `3113`。
 
+:::caution[必须从一个固定、可写的目录启动]
+agentmemory 的存储引擎把 state 存到 **相对当前工作目录（CWD）的 `./data/`**。如果每次从不同目录
+启动它——或者作为服务运行、工作目录默认成了 `/`（launchd、systemd）——它就写不进去：`state::set`
+会一直卡到 180 秒超时，**数据在重启后全部丢失**（每次启动都是空索引，上次运行以来存的东西悄无声息地
+没了）。务必从一个稳定、可写的目录启动它（比如 `~/.agentmemory`），在进程管理器里显式指定这个目录
+（launchd plist 的 `WorkingDirectory`、systemd unit 的 `WorkingDirectory=`）。验证是否生效：存一条
+东西后重启 server，同样的 query 应该还能查到，且 `~/.agentmemory/data/state_store.db` 应当存在。
+:::
+
 确认它起来了：
 
 ```bash
@@ -250,6 +259,14 @@ memory_backend:
 - **agentmemory：刚存完召回却是空的**——确认 server 确实起着
   （`curl http://localhost:3111/agentmemory/health`），并且 octo 的 `namespace` 在重启前后
   保持一致；它对应 agentmemory 的 `project`，search 的返回范围就是靠它限定的。
+- **agentmemory：重启后数据全没了，或日志刷 `Invocation timeout after 180000ms: state::set` /
+  `index persistence: failed`**——server 是从一个它写不进去的工作目录启动的（state 存储是相对 CWD
+  的 `./data/`，默认 CWD 为 `/` 的服务写不进根目录）。从一个固定、可写的目录重启它，并在进程管理器里
+  设 `WorkingDirectory`——见上面 agentmemory 安装小节的警示框。`~/.agentmemory/data/state_store.db`
+  出现（且能扛过一次重启）就说明修好了。
+- **agentmemory：受限网络下启动卡住 / 本地 embedding 模型下不下来**——它首次运行会从 HuggingFace 拉
+  `all-MiniLM-L6-v2`。如果你部署的环境里 `huggingface.co` 被墙或被限速，启动前用 `HF_ENDPOINT`
+  环境变量指向镜像（如 `HF_ENDPOINT=https://hf-mirror.com`）。
 - **hindsight：`docker run` 之后马上连不上**——再等一两分钟，它还在下载/加载 embedding 和
   reranker 模型。`docker logs hindsight` 能看到进度。等它打印出启动横幅之后，后续重启就会
   快很多（模型缓存在 `hindsight-hf-cache` 这个 volume 里）。


### PR DESCRIPTION
## What

Documents a real, silent-data-loss pitfall in the **agentmemory** backend setup: its iii storage engine persists state to `./data/` **relative to the process working directory** (`file_path: ./data/state_store.db` in the shipped `iii-config.yaml`).

Started from an unstable CWD — or as a service whose working directory defaults to `/` (launchd, systemd) — the engine can't write there. `state::set` calls hang until a **180-second timeout**, `index persistence: failed` warnings pile up, and **nothing survives a restart**: every start comes up with an empty index, silently discarding everything stored since the last run. The current "just run `agentmemory`" instructions can lead straight into this.

Reproduced and fixed on a real deployment: launching from a fixed, writable directory (and setting `WorkingDirectory` in the launchd plist) makes `~/.agentmemory/data/state_store.db` materialize and persist across restarts.

## Changes (en + zh guides)

- **agentmemory setup section** — a caution admonition: start it from a stable, writable directory; set `WorkingDirectory` under a process manager; how to confirm persistence took.
- **Troubleshooting** — two new entries:
  - data gone after restart / `state::set` 180s timeout → working-directory fix.
  - startup hangs / local embedding model won't download on a restricted network → point `HF_ENDPOINT` at a mirror (e.g. `hf-mirror.com`) since it fetches `all-MiniLM-L6-v2` from HuggingFace on first run.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)