### PR TITLE
chore: bump version to 1.12.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.0"
+var Version = "1.12.1"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release — desktop-shell polish on top of 1.12.0's hub: visible tray icon + reopen, live tray status + Settings item, localized native dialogs/tray (incl. Windows), takeover bind-race fix, Windows/Linux keep-running, and landing per-platform download buttons + top nav. Tagging `v1.12.1` after merge triggers the release build.