### PR TITLE
docs(landing): hero tagline covers the editor interfaces

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -500,8 +500,8 @@
       </svg>
       <h1><span data-en="Meet " data-zh="认识 "></span><span class="accent">Octo</span></h1>
       <p class="hero-tagline"
-         data-en="A functionality-first AI agent in a single Go binary. Bring it to your terminal, browser, or chat app — it speaks Anthropic and OpenAI natively, and actually gets things done."
-         data-zh="以功能为先的 AI Agent，单一 Go 二进制。带它进终端、浏览器或聊天工具 —— 原生支持 Anthropic 与 OpenAI，真正把事情干完。"></p>
+         data-en="A functionality-first AI agent in a single Go binary. Reach it from your terminal, browser, editor, or chat — it speaks Anthropic and OpenAI natively, and actually gets things done."
+         data-zh="以功能为先的 AI Agent，单一 Go 二进制。终端、浏览器、编辑器、聊天工具都能用它 —— 原生支持 Anthropic 与 OpenAI，真正把事情干完。"></p>
       <div class="download-row">
         <a class="dl-btn" href="https://github.com/open-octo/octo-agent/releases/latest/download/octo-setup.pkg">
           <svg class="dl-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>


### PR DESCRIPTION
The hero tagline said "terminal, browser, or chat app" — 3 surfaces, from before the VS Code / Obsidian editor integrations and the desktop app. Broadened to **"terminal, browser, editor, or chat"** (zh: 终端、浏览器、编辑器、聊天工具都能用它) — four buckets covering all six interfaces without enumerating each. Copy-only.