### PR TITLE
fix(desktop): embed ripgrep in desktop app builds

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -90,11 +90,19 @@ jobs:
           name: Octo-linux-appimage
           path: Octo-x86_64.AppImage
 
+      # Bundle ripgrep so the desktop app's grep tool has an `rg` to shell out
+      # to (mirrors `make build`; the app can't rely on the user's PATH).
+      - name: Embed ripgrep
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: pwsh scripts/embed-rg-windows.ps1
+
       # -H windowsgui: a GUI app, so no console window flashes behind it.
+      # -tags embedrg go:embeds the rg fetched above.
       - name: Build Windows binary
         if: runner.os == 'Windows'
         working-directory: cmd/octo-desktop
-        run: go build -v -ldflags "-H windowsgui" -o octo-desktop.exe .
+        run: go build -v -tags embedrg -ldflags "-H windowsgui" -o octo-desktop.exe .
 
       # Raw .exe for now; wrapping it in an installer rides the existing Inno
       # Setup track (see windows-installer-check.yml), a separate change.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,19 @@ jobs:
           Copy-Item LICENSE.txt staging\LICENSE.txt
           "version=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
 
+      # Bundle ripgrep so the desktop app's grep tool has an `rg` to shell out
+      # to (mirrors `make build`; the app can't rely on the user's PATH).
+      - name: Embed ripgrep
+        shell: pwsh
+        run: pwsh scripts/embed-rg-windows.ps1
+
       # Build the desktop GUI (nested module; embeds the committed web UI).
       # -H windowsgui so no console window flashes behind the app.
+      # -tags embedrg go:embeds the rg fetched above.
       - name: Build desktop app
         shell: pwsh
         working-directory: cmd/octo-desktop
-        run: go build -ldflags "-H windowsgui" -o ..\..\staging\octo-desktop.exe .
+        run: go build -tags embedrg -ldflags "-H windowsgui" -o ..\..\staging\octo-desktop.exe .
 
       # Fetches uv.exe from its upstream GitHub release so the installer can
       # bundle it — see octo.iss's [Files] section. Native PowerShell rather

--- a/scripts/embed-rg-windows.ps1
+++ b/scripts/embed-rg-windows.ps1
@@ -1,0 +1,22 @@
+#!/usr/bin/env pwsh
+# Download ripgrep for windows/amd64 and place it at the go:embed path so a
+# desktop build with -tags=embedrg bundles a working `rg` (the grep tool shells
+# out to it). This mirrors the Makefile's rg-embed target for the one platform
+# that can't use it: windows-latest runners aren't guaranteed to have GNU Make,
+# and the release pipeline avoids adding a `choco install make` dependency just
+# for a curl+unzip (same reason the uv fetch is inlined in pwsh). Keep
+# $rgVersion in sync with RG_VERSION in the Makefile.
+$ErrorActionPreference = 'Stop'
+$rgVersion = '15.1.0'
+$embedDir = 'internal/tools/rgembed/binaries'
+$asset = "ripgrep-$rgVersion-x86_64-pc-windows-msvc.zip"
+$url = "https://github.com/BurntSushi/ripgrep/releases/download/$rgVersion/$asset"
+
+New-Item -ItemType Directory -Force -Path $embedDir, dl\rg | Out-Null
+Invoke-WebRequest -Uri $url -OutFile dl\rg.zip
+Expand-Archive -Path dl\rg.zip -DestinationPath dl\rg -Force
+$rg = Get-ChildItem -Path dl\rg -Recurse -Filter rg.exe | Select-Object -First 1
+# go:embed reads a file named "rg" (no extension) on every platform; the runtime
+# renames the extracted copy to rg.exe on Windows.
+Copy-Item $rg.FullName "$embedDir/rg" -Force
+Write-Host "Embedded rg $rgVersion for windows/amd64"

--- a/scripts/package-desktop-linux.sh
+++ b/scripts/package-desktop-linux.sh
@@ -15,8 +15,15 @@ LINUX="$MOD_DIR/build/linux"
 APPDIR="$ROOT/Octo.AppDir"
 OUT="$ROOT/Octo-x86_64.AppImage"
 
+# Bundle ripgrep so the desktop app's grep tool has an `rg` to shell out to
+# (the app can't rely on one being on the user's PATH). Mirrors `make build`:
+# download rg for the host platform, then build with -tags=embedrg to go:embed
+# it. Without this the grep tool fails at runtime with "no binary was embedded".
+echo "==> embedding ripgrep"
+make -C "$ROOT" rg-embed
+
 echo "==> building octo-desktop binary"
-( cd "$MOD_DIR" && CGO_ENABLED=1 go build -o "$ROOT/octo-desktop" . )
+( cd "$MOD_DIR" && CGO_ENABLED=1 go build -tags embedrg -o "$ROOT/octo-desktop" . )
 
 echo "==> assembling AppDir"
 rm -rf "$APPDIR"

--- a/scripts/package-desktop-macos.sh
+++ b/scripts/package-desktop-macos.sh
@@ -16,8 +16,15 @@ VERSION="${VERSION#v}"
 APP="$ROOT/Octo.app"
 CONTENTS="$APP/Contents"
 
+# Bundle ripgrep so the desktop app's grep tool has an `rg` to shell out to
+# (the app can't rely on one being on the user's PATH). Mirrors `make build`:
+# download rg for the host platform, then build with -tags=embedrg to go:embed
+# it. Without this the grep tool fails at runtime with "no binary was embedded".
+echo "==> embedding ripgrep"
+make -C "$ROOT" rg-embed
+
 echo "==> building octo-desktop binary"
-( cd "$MOD_DIR" && CGO_ENABLED=1 go build -o "$ROOT/octo-desktop" . )
+( cd "$MOD_DIR" && CGO_ENABLED=1 go build -tags embedrg -o "$ROOT/octo-desktop" . )
 
 echo "==> assembling $APP (version $VERSION)"
 rm -rf "$APP"


### PR DESCRIPTION
## Problem

The desktop app's grep tool failed at runtime:

```
grep: rgembed: ripgrep (`rg`) is not on PATH and no binary was embedded at build time
```

`cmd/octo-desktop` was built with a plain `go build` — no `-tags=embedrg`, no fetched `rg`. The CLI's `make build` does both (downloads rg 15.1.0 → `internal/tools/rgembed/binaries/rg`, then `go build -tags='… embedrg'`), but every desktop packaging path skipped it, so the shipped app can't grep unless the user happens to have `rg` on PATH.

## Fix

Embed rg in every **shipped** desktop build, mirroring the CLI:

- **macOS / Linux** — `scripts/package-desktop-{macos,linux}.sh` now run `make rg-embed` (host platform) and build with `-tags embedrg`. Covers the release `macos-installer` / `linux-appimage` jobs and the `desktop.yml` CI build.
- **Windows** — a new `scripts/embed-rg-windows.ps1` fetches the windows-msvc rg and places it at the go:embed path; the release `windows-installer` job and `desktop.yml` Windows build call it, then build with `-tags embedrg`. Windows gets its own pwsh helper because `windows-latest` runners aren't guaranteed to have GNU Make (same reason the uv fetch is already inlined in pwsh).

## Verification

- `go test -tags embedrg ./internal/tools/rgembed/` passes (the test runs instead of skipping only when a binary is embedded).
- Ran `scripts/package-desktop-macos.sh` end-to-end: the bundled `octo-desktop` is ~33 MB (vs ~29 MB plain), confirming the ~4 MB rg is embedded.
- Windows/Linux: build-path change only, verified by reading; not run on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)