### PR TITLE
fix(agent): give session-title generation room for reasoning tokens

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1253,8 +1253,14 @@ func (a *Agent) Suggest(ctx context.Context, tools []ToolDefinition) (string, er
 	return cleanSuggestion(reply.Content), nil
 }
 
-// titleMaxTokens caps the title response — it's a handful of words.
-const titleMaxTokens = 32
+// titleMaxTokens caps the title response. The title itself is a handful of
+// words, but the cap has to cover the model's reasoning tokens too: on a
+// reasoning model (LowEffort only lowers effort, it doesn't disable thinking)
+// the hidden reasoning is billed against this same budget, so a tight cap gets
+// entirely consumed by reasoning and the model emits empty text — leaving the
+// session with no generated title and no live sidebar update. Give it room for
+// low-effort reasoning plus the title line.
+const titleMaxTokens = 1024
 
 const titleInstruction = "Summarize this conversation as a short title of at most 6 words. " +
 	"Reply with the title text only — no preamble, no quotes, no trailing punctuation, no markdown."


### PR DESCRIPTION
## Problem

On a **reasoning model** (the report was against the default `LongCat-2.0`), a new session's title never updated live in the sidebar — the name only appeared after a manual page refresh.

## Root cause

`titleMaxTokens` was `32`. `GenerateTitle` lowers effort through `LowEffort()`, but that only caps reasoning to `"low"` — it does **not** disable thinking. On a reasoning model the hidden reasoning tokens are billed against the *same* `max_tokens` budget, so a 32-token cap is consumed entirely by reasoning and the model returns **empty text content**. Then:

- `cleanTitle("")` → `""`
- the server logs `session title generation returned an empty title` and **returns without broadcasting `session_renamed`**
- the sidebar is never told the new name; a reload only *appears* to fix it because the REST list falls back to a first-message-derived `DisplayTitle`.

It's intermittent — when reasoning happened to be short enough to leave room, a title came through — which matches "sometimes it updates, usually I have to refresh".

## Fix

Raise `titleMaxTokens` to `1024` so low-effort reasoning **plus** the short title line both fit within the budget. One-line change; the throwaway call still stops as soon as the model finishes the title.

## Verification (live `LongCat-2.0`)

Reproduced against a real server driving the actual web UI in a headless browser:

- **Before (32):** title came back empty, `WARN "returned an empty title"`, no `session_renamed` frame reached the browser, sidebar stayed `(untitled)` until reload.
- **After (1024):** every run produced a real title; the browser received `session_renamed` and the sidebar row flipped from `(untitled)` to the generated title **live, with no refresh**. Raw-WS repro: 3/3 non-empty, zero empty-title warnings.

`go test ./internal/agent/ ./internal/server/` pass (the title test asserts against the `titleMaxTokens` constant, not a literal); `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)