### PR TITLE
fix(server): persist per-session context usage so the bar is timely and correct

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -55,8 +55,16 @@ type Session struct {
 	// turn time" — also the value for every session predating per-session
 	// modes. Set via the Web UI's PATCH …/permission_mode and persisted so a
 	// resumed session keeps the mode it was left in.
-	PermissionMode string    `json:"permission_mode,omitempty"`
-	Messages       []Message `json:"messages"`
+	PermissionMode string `json:"permission_mode,omitempty"`
+	// LastContextTokens is the real input-token count of the most recent model
+	// request in this session — how full the context window was as of the last
+	// turn. Persisted so an idle or resumed session (no live Agent in memory)
+	// reports its true context usage instead of a transcript estimate that omits
+	// the system-prompt/tools overhead. 0 for sessions predating this field or
+	// that never completed a turn with a real token count. Updated once per turn
+	// via SetLastContextTokens.
+	LastContextTokens int       `json:"last_context_tokens,omitempty"`
+	Messages          []Message `json:"messages"`
 
 	// Dir overrides the default ~/.octo/sessions location. Empty means use the
 	// default. Not serialized — it's a runtime override.
@@ -448,23 +456,24 @@ func (s *Session) ChunkDir() (string, error) {
 // type as authoritative; rewriteAll folds them back into the meta header when
 // compacting.
 type sessionRecord struct {
-	Type           string    `json:"type"` // "meta" | "message" | "title" | "model_config" | "working_dir" | "permission_mode" | "lease" | "goal"
-	ID             string    `json:"id,omitempty"`
-	CreatedAt      time.Time `json:"created_at,omitempty"`
-	Model          string    `json:"model,omitempty"`
-	System         string    `json:"system,omitempty"`
-	Title          string    `json:"title,omitempty"`
-	Source         string    `json:"source,omitempty"`
-	ModelConfig    string    `json:"model_config,omitempty"`
-	WorkingDir     string    `json:"working_dir,omitempty"`
-	PermissionMode string    `json:"permission_mode,omitempty"`
-	BoundEntry     string    `json:"bound_entry,omitempty"`
-	BoundAt        time.Time `json:"bound_at,omitempty"`
-	LeaseEntry     string    `json:"lease_entry,omitempty"`
-	LeaseExpires   time.Time `json:"lease_expires,omitempty"`
-	HookStarted    bool      `json:"hook_started,omitempty"`
-	Message        *Message  `json:"message,omitempty"`
-	Goal           *Goal     `json:"goal,omitempty"`
+	Type              string    `json:"type"` // "meta" | "message" | "title" | "model_config" | "working_dir" | "permission_mode" | "context_tokens" | "lease" | "goal"
+	ID                string    `json:"id,omitempty"`
+	CreatedAt         time.Time `json:"created_at,omitempty"`
+	Model             string    `json:"model,omitempty"`
+	System            string    `json:"system,omitempty"`
+	Title             string    `json:"title,omitempty"`
+	Source            string    `json:"source,omitempty"`
+	ModelConfig       string    `json:"model_config,omitempty"`
+	WorkingDir        string    `json:"working_dir,omitempty"`
+	PermissionMode    string    `json:"permission_mode,omitempty"`
+	BoundEntry        string    `json:"bound_entry,omitempty"`
+	BoundAt           time.Time `json:"bound_at,omitempty"`
+	LeaseEntry        string    `json:"lease_entry,omitempty"`
+	LeaseExpires      time.Time `json:"lease_expires,omitempty"`
+	HookStarted       bool      `json:"hook_started,omitempty"`
+	LastContextTokens int       `json:"last_context_tokens,omitempty"`
+	Message           *Message  `json:"message,omitempty"`
+	Goal              *Goal     `json:"goal,omitempty"`
 }
 
 func (s *Session) metaRecord() sessionRecord {
@@ -479,7 +488,7 @@ func (s *Session) metaRecord() sessionRecord {
 		goal = &g
 	}
 	s.mu.Unlock()
-	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, WorkingDir: s.WorkingDir, PermissionMode: s.PermissionMode, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, Goal: goal}
+	return sessionRecord{Type: "meta", ID: s.ID, CreatedAt: s.CreatedAt, Model: s.Model, System: s.System, Title: s.Title, Source: s.Source, ModelConfig: s.ModelConfig, WorkingDir: s.WorkingDir, PermissionMode: s.PermissionMode, LastContextTokens: s.LastContextTokens, BoundEntry: s.BoundEntry, BoundAt: s.BoundAt, HookStarted: s.HookStarted, Goal: goal}
 }
 
 // MarkHookStarted records that SessionStart has fired for this session, so a
@@ -763,6 +772,45 @@ func (s *Session) SetPermissionMode(mode string) error {
 	return nil
 }
 
+// SetLastContextTokens records the context-window fill (real input-token count)
+// as of the just-finished turn, so an idle/resumed session reports its true
+// usage without a live Agent. Same append-or-rewrite persistence mechanics as
+// SetPermissionMode; called once per turn, so an unchanged count is a no-op
+// (avoids a redundant append when the context didn't grow).
+func (s *Session) SetLastContextTokens(n int) error {
+	if n <= 0 || n == s.LastContextTokens {
+		return nil
+	}
+	s.LastContextTokens = n
+	if s.persisted == 0 {
+		// See SetPermissionMode: a meta-only transcript must be rewritten now; a
+		// session with no file yet just carries the value until its first Save.
+		if path, perr := s.SavePath(); perr == nil {
+			if _, statErr := os.Stat(path); statErr == nil {
+				return s.rewriteAll()
+			}
+		}
+		return nil
+	}
+	if s.forceRewrite {
+		return s.rewriteAll()
+	}
+	path, err := s.SavePath()
+	if err != nil {
+		return err
+	}
+	// No O_CREATE — see SetTitle: never materialise an orphan transcript.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("session: open %s: %w", path, err)
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(sessionRecord{Type: "context_tokens", LastContextTokens: n}); err != nil {
+		return fmt.Errorf("session: append context_tokens: %w", err)
+	}
+	return nil
+}
+
 // DisplayTitle returns the label shown for the session in list views: the
 // generated Title when present, otherwise a snippet of the first user message
 // (so pre-title sessions and not-yet-titled ones are still recognisable), and
@@ -949,6 +997,7 @@ func LoadSession(id string) (*Session, error) {
 			s.ModelConfig = rec.ModelConfig
 			s.WorkingDir = rec.WorkingDir
 			s.PermissionMode = rec.PermissionMode
+			s.LastContextTokens = rec.LastContextTokens // a rewritten file carries it in its meta header
 			s.BoundEntry = rec.BoundEntry
 			s.BoundAt = rec.BoundAt
 			s.HookStarted = rec.HookStarted
@@ -965,6 +1014,8 @@ func LoadSession(id string) (*Session, error) {
 			s.WorkingDir = rec.WorkingDir // last one wins, like title
 		case "permission_mode":
 			s.PermissionMode = rec.PermissionMode // last one wins, like title
+		case "context_tokens":
+			s.LastContextTokens = rec.LastContextTokens // last one wins, like title
 		case "message":
 			if rec.Message != nil {
 				s.Messages = append(s.Messages, *rec.Message)

--- a/internal/agent/session_persist_test.go
+++ b/internal/agent/session_persist_test.go
@@ -219,3 +219,58 @@ func TestSetTitle_RewritesAfterPartialTail(t *testing.T) {
 		t.Fatalf("reloaded title=%q messages=%d, want \"My Title\"/1", re.Title, len(re.Messages))
 	}
 }
+
+// TestSetLastContextTokens_AppendsAndRoundTrips covers the path a real turn
+// takes: an already-persisted session gets its context-token count via an
+// APPENDED "context_tokens" record (O(1), not a full rewrite), the no-op guards
+// hold, and the value round-trips through a reload.
+func TestSetLastContextTokens_AppendsAndRoundTrips(t *testing.T) {
+	setTempHome(t)
+	s := NewSession("m", "")
+	s.Messages = []Message{NewUserMessage("hi"), NewAssistantMessage("hello")}
+	if err := s.Save(); err != nil { // persisted > 0, transcript on disk
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := s.SetLastContextTokens(4321); err != nil {
+		t.Fatalf("SetLastContextTokens: %v", err)
+	}
+
+	path, err := s.SavePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Must APPEND a context_tokens record, not rewrite the whole file.
+	if !strings.Contains(string(data), `"type":"context_tokens"`) {
+		t.Fatalf("expected an appended context_tokens record; file was:\n%s", data)
+	}
+
+	// No-op guards: an unchanged value and a non-positive value append nothing.
+	before := len(data)
+	if err := s.SetLastContextTokens(4321); err != nil { // unchanged
+		t.Fatal(err)
+	}
+	if err := s.SetLastContextTokens(0); err != nil { // non-positive
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != before {
+		t.Errorf("no-op SetLastContextTokens must not append: file grew %d -> %d bytes", before, len(after))
+	}
+
+	// Round-trips through a reload.
+	got, err := LoadSession(s.ID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got.LastContextTokens != 4321 {
+		t.Errorf("reloaded LastContextTokens = %d, want 4321", got.LastContextTokens)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -159,7 +159,18 @@ func (srv *Server) sessionStatusFields(sess *agent.Session) (workingDir, permiss
 		eff := cfg.EffectiveShowReasoning(entry.ShowReasoning)
 		showReasoning = &eff
 	}
-	return workingDir, permissionMode, reasoningEffort, showReasoning, 0
+	// Report the session's persisted context usage (its real last-turn token
+	// count) so the list — and thus a page refresh — carries a correct value
+	// instead of 0. The live WS path still refines the active session per turn.
+	if sess != nil && sess.LastContextTokens > 0 {
+		if window := agent.ContextWindow(sess.Model); window > 0 {
+			contextUsage = sess.LastContextTokens * 100 / window
+			if contextUsage > 100 {
+				contextUsage = 100
+			}
+		}
+	}
+	return workingDir, permissionMode, reasoningEffort, showReasoning, contextUsage
 }
 
 type toolInfo struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -194,6 +194,18 @@ type Server struct {
 	liveSessions    map[string]*agent.Session
 	sessionAgentsMu sync.Mutex
 
+	// warmAgent keeps the single most-recently-finished session's Agent alive
+	// after its turn ends, so its exact context-window token count survives for
+	// the composer's "Context" bar. It is READ-ONLY and used only for context
+	// usage — never for steer/Inbox delivery, which strictly require a running
+	// loop (a dead Inbox would swallow the message). Without it, an idle session
+	// has no live token count and sendContextUsage falls back to a transcript
+	// estimate that omits the system-prompt/tools overhead (so it disagrees with
+	// the live value) and rounds tiny conversations to 0. Bounded to one entry
+	// (a new finished turn evicts the previous), guarded by sessionAgentsMu.
+	warmAgentID string
+	warmAgent   *agent.Agent
+
 	// senderCache holds one sender per config entry name, built lazily for
 	// sessions bound to a non-default model entry. Invalidated wholesale on
 	// any /api/config/models mutation; the next turn rebuilds.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -194,18 +194,6 @@ type Server struct {
 	liveSessions    map[string]*agent.Session
 	sessionAgentsMu sync.Mutex
 
-	// warmAgent keeps the single most-recently-finished session's Agent alive
-	// after its turn ends, so its exact context-window token count survives for
-	// the composer's "Context" bar. It is READ-ONLY and used only for context
-	// usage — never for steer/Inbox delivery, which strictly require a running
-	// loop (a dead Inbox would swallow the message). Without it, an idle session
-	// has no live token count and sendContextUsage falls back to a transcript
-	// estimate that omits the system-prompt/tools overhead (so it disagrees with
-	// the live value) and rounds tiny conversations to 0. Bounded to one entry
-	// (a new finished turn evicts the previous), guarded by sessionAgentsMu.
-	warmAgentID string
-	warmAgent   *agent.Agent
-
 	// senderCache holds one sender per config entry name, built lazily for
 	// sessions bound to a non-default model entry. Invalidated wholesale on
 	// any /api/config/models mutation; the next turn rebuilds.

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -154,6 +154,11 @@ func (s *Server) sendContextUsage(sessionID string, conn *wsConn) {
 	usedTokens := 0
 	s.sessionAgentsMu.Lock()
 	a := s.sessionAgents[sessionID]
+	if a == nil && s.warmAgentID == sessionID {
+		// Idle session, but its just-finished agent is still warm: use its exact
+		// token count instead of the transcript estimate below.
+		a = s.warmAgent
+	}
 	s.sessionAgentsMu.Unlock()
 	sess, _ := agent.LoadSession(sessionID)
 	if a != nil {
@@ -1192,6 +1197,11 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		}
 		delete(s.sessionAgents, sess.ID)
 		delete(s.liveSessions, sess.ID)
+		// Retain this agent as the warm read-only instance so its exact context
+		// token count outlives the turn (see warmAgent). Bounded to one: a later
+		// finished turn — this session or another — replaces it.
+		s.warmAgentID = sess.ID
+		s.warmAgent = a
 		s.sessionAgentsMu.Unlock()
 	}()
 

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -162,19 +162,23 @@ func (s *Server) sendContextUsage(sessionID string, conn *wsConn) {
 			pct = used * 100 / window
 			usedTokens = used
 		}
-	} else if sess != nil && sess.LastContextTokens > 0 {
-		// Idle/resumed session: the real count from its last turn was persisted,
-		// so report that exact value (matches what the turn-end broadcast sent).
+	}
+	if pct == 0 && sess != nil && sess.LastContextTokens > 0 {
+		// Idle/resumed session — or a turn whose first provider call hasn't
+		// reported usage yet (live agent returns 0). Report the real count
+		// persisted from its last turn (matches what the turn-end broadcast sent).
 		if window := agent.ContextWindow(sess.Model); window > 0 {
 			pct = sess.LastContextTokens * 100 / window
 			usedTokens = sess.LastContextTokens
 		}
 	}
 	if pct == 0 && sess != nil {
-		// No token count anywhere (a session predating the field, or one that
-		// never completed a turn with a real count): fall back to a transcript
-		// estimate. Leave usedTokens 0 so the UI shows a bare arrow.
+		// No real count anywhere (a session predating the field, one that never
+		// completed a turn with a real count, or a count too small to reach 1% of
+		// the window): fall back to a transcript estimate. It carries no exact
+		// token count, so clear usedTokens — the UI shows a bare arrow.
 		pct = estimateContextPct(sess)
+		usedTokens = 0
 	}
 	if pct <= 0 {
 		return

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -154,23 +154,27 @@ func (s *Server) sendContextUsage(sessionID string, conn *wsConn) {
 	usedTokens := 0
 	s.sessionAgentsMu.Lock()
 	a := s.sessionAgents[sessionID]
-	if a == nil && s.warmAgentID == sessionID {
-		// Idle session, but its just-finished agent is still warm: use its exact
-		// token count instead of the transcript estimate below.
-		a = s.warmAgent
-	}
 	s.sessionAgentsMu.Unlock()
 	sess, _ := agent.LoadSession(sessionID)
 	if a != nil {
+		// Turn in flight: the live Agent has the exact current count.
 		if used, window := a.ContextUsage(); window > 0 && used > 0 {
 			pct = used * 100 / window
 			usedTokens = used
 		}
+	} else if sess != nil && sess.LastContextTokens > 0 {
+		// Idle/resumed session: the real count from its last turn was persisted,
+		// so report that exact value (matches what the turn-end broadcast sent).
+		if window := agent.ContextWindow(sess.Model); window > 0 {
+			pct = sess.LastContextTokens * 100 / window
+			usedTokens = sess.LastContextTokens
+		}
 	}
 	if pct == 0 && sess != nil {
+		// No token count anywhere (a session predating the field, or one that
+		// never completed a turn with a real count): fall back to a transcript
+		// estimate. Leave usedTokens 0 so the UI shows a bare arrow.
 		pct = estimateContextPct(sess)
-		// Cold/resumed session: only a % estimate is available, no exact
-		// token count — leave usedTokens 0 so the UI shows a bare arrow.
 	}
 	if pct <= 0 {
 		return
@@ -1197,11 +1201,6 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		}
 		delete(s.sessionAgents, sess.ID)
 		delete(s.liveSessions, sess.ID)
-		// Retain this agent as the warm read-only instance so its exact context
-		// token count outlives the turn (see warmAgent). Bounded to one: a later
-		// finished turn — this session or another — replaces it.
-		s.warmAgentID = sess.ID
-		s.warmAgent = a
 		s.sessionAgentsMu.Unlock()
 	}()
 
@@ -1346,6 +1345,14 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		ctxPct = used * 100 / window
 		if ctxPct > 100 {
 			ctxPct = 100
+		}
+	}
+	// Persist the real token count on the session so an idle or resumed session
+	// (no live Agent) reports its true context usage — see SetLastContextTokens.
+	// Best-effort: a save failure just leaves the estimate fallback in place.
+	if used > 0 {
+		if err := sess.SetLastContextTokens(used); err != nil {
+			slog.Warn("session: persist context tokens", "session_id", sess.ID, "err", err)
 		}
 	}
 	_, pm, re, _, _ := s.sessionStatusFields(sess)

--- a/internal/server/ws_handlers_test.go
+++ b/internal/server/ws_handlers_test.go
@@ -1,10 +1,65 @@
 package server
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
 )
+
+// After a turn ends the agent is dropped from sessionAgents, but its exact
+// context-token count must survive as the warmAgent so a fresh subscribe (a
+// page refresh / reconnect) reports the real value instead of nothing. Without
+// the warm agent, sendContextUsage falls back to a transcript estimate that can
+// round to 0 and then sends no frame at all — the composer's Context bar stays
+// stale until the next turn.
+func TestSendContextUsage_UsesWarmAgent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	// An idle agent (not in sessionAgents) with enough history that its context
+	// estimate clears 1% of the default 128k window.
+	a := agent.New(stubSender{}, "stub-model")
+	a.History.Append(agent.NewUserMessage(strings.Repeat("word ", 4000)))
+	const sid = "warm-session"
+	srv.sessionAgentsMu.Lock()
+	srv.warmAgentID = sid
+	srv.warmAgent = a
+	srv.sessionAgentsMu.Unlock()
+
+	conn := &wsConn{send: make(chan []byte, 4), subscribed: map[string]struct{}{}}
+	srv.sendContextUsage(sid, conn)
+
+	select {
+	case b := <-conn.send:
+		var m map[string]any
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if m["type"] != "session_update" {
+			t.Fatalf("type = %v, want session_update", m["type"])
+		}
+		if cu, _ := m["context_usage"].(float64); cu <= 0 {
+			t.Fatalf("context_usage = %v, want > 0 (warm agent's real count)", cu)
+		}
+	default:
+		t.Fatal("sendContextUsage sent no frame despite a warm agent")
+	}
+
+	// A session with neither a running nor a warm agent, and nothing on disk,
+	// still sends nothing (no misleading 0% frame).
+	conn2 := &wsConn{send: make(chan []byte, 4), subscribed: map[string]struct{}{}}
+	srv.sendContextUsage("cold-unknown-session", conn2)
+	select {
+	case <-conn2.send:
+		t.Fatal("expected no frame for a cold unknown session")
+	default:
+	}
+}
 
 // lastVisibleUserIdx must land on the typed prompt, not the tool_result
 // carrier an agentic turn leaves as its most recent user-role message.

--- a/internal/server/ws_handlers_test.go
+++ b/internal/server/ws_handlers_test.go
@@ -2,37 +2,34 @@ package server
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
 )
 
-// After a turn ends the agent is dropped from sessionAgents, but its exact
-// context-token count must survive as the warmAgent so a fresh subscribe (a
-// page refresh / reconnect) reports the real value instead of nothing. Without
-// the warm agent, sendContextUsage falls back to a transcript estimate that can
-// round to 0 and then sends no frame at all — the composer's Context bar stays
-// stale until the next turn.
-func TestSendContextUsage_UsesWarmAgent(t *testing.T) {
+// An idle session (no live Agent) must report the real context-token count its
+// last turn persisted, so a fresh subscribe (page refresh / reconnect) shows
+// the same value the turn-end broadcast did — not a transcript estimate that
+// omits the system-prompt/tools overhead and can round to 0 (sending no frame
+// at all, leaving the composer's Context bar stale). This is what makes the bar
+// correct across switching between multiple idle sessions.
+func TestSendContextUsage_UsesPersistedTokens(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
 
-	// An idle agent (not in sessionAgents) with enough history that its context
-	// estimate clears 1% of the default 128k window.
-	a := agent.New(stubSender{}, "stub-model")
-	a.History.Append(agent.NewUserMessage(strings.Repeat("word ", 4000)))
-	const sid = "warm-session"
-	srv.sessionAgentsMu.Lock()
-	srv.warmAgentID = sid
-	srv.warmAgent = a
-	srv.sessionAgentsMu.Unlock()
+	// A persisted, idle session (no entry in sessionAgents) carrying a real
+	// last-turn token count. 6400 tokens is ~5% of the 128k default window.
+	sess := agent.NewSession("stub-model", "")
+	sess.LastContextTokens = 6400
+	if err := sess.Save(); err != nil {
+		t.Fatal(err)
+	}
 
 	conn := &wsConn{send: make(chan []byte, 4), subscribed: map[string]struct{}{}}
-	srv.sendContextUsage(sid, conn)
+	srv.sendContextUsage(sess.ID, conn)
 
 	select {
 	case b := <-conn.send:
@@ -43,21 +40,23 @@ func TestSendContextUsage_UsesWarmAgent(t *testing.T) {
 		if m["type"] != "session_update" {
 			t.Fatalf("type = %v, want session_update", m["type"])
 		}
-		if cu, _ := m["context_usage"].(float64); cu <= 0 {
-			t.Fatalf("context_usage = %v, want > 0 (warm agent's real count)", cu)
+		if cu, _ := m["context_usage"].(float64); cu != 5 {
+			t.Fatalf("context_usage = %v, want 5 (6400/128000)", cu)
+		}
+		if ct, _ := m["context_tokens"].(float64); ct != 6400 {
+			t.Fatalf("context_tokens = %v, want 6400", ct)
 		}
 	default:
-		t.Fatal("sendContextUsage sent no frame despite a warm agent")
+		t.Fatal("sendContextUsage sent no frame despite a persisted token count")
 	}
 
-	// A session with neither a running nor a warm agent, and nothing on disk,
-	// still sends nothing (no misleading 0% frame).
-	conn2 := &wsConn{send: make(chan []byte, 4), subscribed: map[string]struct{}{}}
-	srv.sendContextUsage("cold-unknown-session", conn2)
-	select {
-	case <-conn2.send:
-		t.Fatal("expected no frame for a cold unknown session")
-	default:
+	// The count must survive a reload from disk (it rides the transcript).
+	reloaded, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.LastContextTokens != 6400 {
+		t.Fatalf("reloaded LastContextTokens = %d, want 6400", reloaded.LastContextTokens)
 	}
 }
 


### PR DESCRIPTION
## Problem

The composer's **Context** usage bar updated "not timely — sometimes you have to refresh the page for it to update." And even a refresh wasn't reliable.

## Root cause (three things compound)

The only reliable real context value was the `session_update` broadcast at **turn end**. Once missed, nothing recovered the bar:

1. **`GET /api/sessions` always reported 0** — `sessionStatusFields` hard-returned `contextUsage=0`, and `omitempty` dropped the field. A refresh's session list carried no value.
2. **Idle sessions had no cached agent** — a session's `Agent` lives in `sessionAgents` only *while a turn runs*, so when idle `sendContextUsage` (fired on subscribe/refresh) couldn't read the real `lastInputTokens`.
3. **The estimate fallback was inconsistent and could vanish** — `estimateContextPct(transcript)` omits the system-prompt/tools overhead (so it disagrees with the live value) and rounds small conversations to 0, and `sendContextUsage` then returned *without sending anything*.

## Fix — persist the real token count per session

At turn end the server records the real input-token count on the session: `Session.LastContextTokens`, persisted as a `context_tokens` append record (O(1) per turn) that folds into the meta header on any rewrite. An idle or resumed session then reports its **exact** context usage straight from disk:

- `sendContextUsage` (subscribe/refresh) uses the live agent when a turn is running, else the persisted count, else the transcript estimate (only for sessions predating the field).
- `GET /api/sessions` reports the persisted value too, so the list — and a refresh — carry a correct number.

So the list, a fresh subscribe, and the live turn-end broadcast all agree, for **every** session.

> Note: an earlier revision of this PR kept a single "warm agent" in memory instead. That only covered the one most-recently-finished session — switching between multiple idle Web sessions still showed a stale/0 bar for the rest. Persisting per session fixes that, scales to any number of sessions, survives process restart, and costs no memory.

## Verification

- Live model, raw-WS repro: **before** — turn-end `context_usage=2`, fresh subscribe → nothing, GET → no field; **after** — fresh subscribe → `2`, matching live, and it reloads from disk correctly.
- New test `TestSendContextUsage_UsesPersistedTokens`: a persisted idle session reports `context_usage=5` / `context_tokens=6400` and survives a reload.
- Forward-compatible: unknown `context_tokens` records are ignored by older binaries.
- `go test -race ./internal/agent/ ./internal/server/` passes; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)