### PR TITLE
fix: persist context-token count on every transport (IM/CLI/scheduled parity)

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -2007,6 +2007,9 @@ func (m *tuiModel) handleTurnFinished(err error) (tea.Model, tea.Cmd) {
 	if !m.cfg.noSave {
 		m.cfg.session.SyncFrom(m.a.History)
 		_ = m.cfg.session.Save()
+		// Record the real context-token count so this session shows accurate
+		// usage when later opened in the Web UI (parity with web/desktop turns).
+		_ = m.a.PersistContextUsage(m.cfg.session)
 	}
 
 	// An aborted or errored turn parks the goal-continuation loop: an

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1826,6 +1826,24 @@ func (a *Agent) ContextUsage() (used, window int) {
 	return estimateMessages(a.History.Snapshot()), contextWindow(a.Model)
 }
 
+// PersistContextUsage records this agent's current context-window token count on
+// the session (Session.LastContextTokens) so an idle or resumed session — one
+// with no live Agent in memory — reports its true context usage instead of a
+// transcript estimate that omits the system-prompt/tools overhead. Every
+// transport (web, IM, CLI, scheduled) calls it at turn end, so a session opened
+// in the Web UI shows the right number regardless of where it last ran. No-op
+// when no count is available yet; best-effort — callers log any save error.
+func (a *Agent) PersistContextUsage(sess *Session) error {
+	if sess == nil {
+		return nil
+	}
+	used, _ := a.ContextUsage()
+	if used <= 0 {
+		return nil
+	}
+	return sess.SetLastContextTokens(used)
+}
+
 // SessionCacheTokens returns the cumulative cache read/write token counts.
 // Read is input served from cache (cheap); write is input written into the
 // cache (Anthropic only). Both zero when the backend reports no cache info.

--- a/internal/agent/session_persist_test.go
+++ b/internal/agent/session_persist_test.go
@@ -274,3 +274,49 @@ func TestSetLastContextTokens_AppendsAndRoundTrips(t *testing.T) {
 		t.Errorf("reloaded LastContextTokens = %d, want 4321", got.LastContextTokens)
 	}
 }
+
+// PersistContextUsage records the agent's current context-token count on the
+// session and round-trips it, and is a safe no-op with a nil session or no
+// count. Every transport (web, IM, CLI, scheduled) calls it at turn end so a
+// session opened in the Web UI shows accurate usage regardless of where it ran.
+func TestPersistContextUsage(t *testing.T) {
+	setTempHome(t)
+
+	a := New(&summarizeFake{}, "m")
+	// No real provider count yet, so ContextUsage estimates from history; make
+	// it big enough to be > 0.
+	a.History.Append(NewUserMessage(strings.Repeat("word ", 2000)))
+
+	sess := NewSession("m", "")
+	sess.Messages = []Message{NewUserMessage("hi")}
+	if err := sess.Save(); err != nil { // persisted, on disk
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := a.PersistContextUsage(sess); err != nil {
+		t.Fatalf("PersistContextUsage: %v", err)
+	}
+	if sess.LastContextTokens <= 0 {
+		t.Fatalf("expected a persisted context-token count, got %d", sess.LastContextTokens)
+	}
+	reloaded, err := LoadSession(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.LastContextTokens != sess.LastContextTokens {
+		t.Errorf("reloaded LastContextTokens = %d, want %d", reloaded.LastContextTokens, sess.LastContextTokens)
+	}
+
+	// A nil session and an agent with no countable context are safe no-ops.
+	if err := a.PersistContextUsage(nil); err != nil {
+		t.Errorf("nil session should be a no-op, got %v", err)
+	}
+	empty := New(&summarizeFake{}, "m")
+	s2 := NewSession("m", "")
+	if err := empty.PersistContextUsage(s2); err != nil {
+		t.Errorf("no-count should be a no-op, got %v", err)
+	}
+	if s2.LastContextTokens != 0 {
+		t.Errorf("no-count must not set a token count, got %d", s2.LastContextTokens)
+	}
+}

--- a/internal/agent/session_persist_test.go
+++ b/internal/agent/session_persist_test.go
@@ -283,9 +283,11 @@ func TestPersistContextUsage(t *testing.T) {
 	setTempHome(t)
 
 	a := New(&summarizeFake{}, "m")
-	// No real provider count yet, so ContextUsage estimates from history; make
-	// it big enough to be > 0.
-	a.History.Append(NewUserMessage(strings.Repeat("word ", 2000)))
+	// The helper's purpose is persisting the real provider-reported count; set it
+	// directly (in-package) so the assertion pins the exact value, not an estimate.
+	a.usageMu.Lock()
+	a.lastInputTokens = 12345
+	a.usageMu.Unlock()
 
 	sess := NewSession("m", "")
 	sess.Messages = []Message{NewUserMessage("hi")}
@@ -296,15 +298,15 @@ func TestPersistContextUsage(t *testing.T) {
 	if err := a.PersistContextUsage(sess); err != nil {
 		t.Fatalf("PersistContextUsage: %v", err)
 	}
-	if sess.LastContextTokens <= 0 {
-		t.Fatalf("expected a persisted context-token count, got %d", sess.LastContextTokens)
+	if sess.LastContextTokens != 12345 {
+		t.Fatalf("LastContextTokens = %d, want 12345 (the real provider count)", sess.LastContextTokens)
 	}
 	reloaded, err := LoadSession(sess.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if reloaded.LastContextTokens != sess.LastContextTokens {
-		t.Errorf("reloaded LastContextTokens = %d, want %d", reloaded.LastContextTokens, sess.LastContextTokens)
+	if reloaded.LastContextTokens != 12345 {
+		t.Errorf("reloaded LastContextTokens = %d, want 12345", reloaded.LastContextTokens)
 	}
 
 	// A nil session and an agent with no countable context are safe no-ops.

--- a/internal/channel/persist.go
+++ b/internal/channel/persist.go
@@ -131,7 +131,15 @@ func (s *Session) Persist() error {
 		return nil
 	}
 	s.Store.SyncFrom(s.Agent.History)
-	return s.Store.Save()
+	if err := s.Store.Save(); err != nil {
+		return err
+	}
+	// Record the real context-token count under the same storeMu as the save
+	// (Store is only ever touched while holding it), so an idle/resumed session
+	// shows accurate usage in the Web UI — parity with web/desktop turns.
+	// Best-effort and idempotent (a no-op when the count is unchanged).
+	_ = s.Agent.PersistContextUsage(s.Store)
+	return nil
 }
 
 // UnbindStore releases the store's entry binding and persists the change.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2824,13 +2824,10 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	persist := func() {
 		// Persist the conversation so it survives server restarts. Failure
 		// must not eat the reply the user already got — log and move on.
+		// Persist() also records the context-token count (under storeMu) so this
+		// session shows accurate usage in the Web UI — parity with web/desktop.
 		if err := sess.Persist(); err != nil {
 			slog.Error("channel persist session", "channel", ev.Platform, "err", err)
-		}
-		// Record the real context-token count so this session shows accurate
-		// usage when opened in the Web UI (parity with web/desktop turns).
-		if err := sess.Agent.PersistContextUsage(sess.Store); err != nil {
-			slog.Warn("channel persist context tokens", "channel", ev.Platform, "err", err)
 		}
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2827,6 +2827,11 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		if err := sess.Persist(); err != nil {
 			slog.Error("channel persist session", "channel", ev.Platform, "err", err)
 		}
+		// Record the real context-token count so this session shows accurate
+		// usage when opened in the Web UI (parity with web/desktop turns).
+		if err := sess.Agent.PersistContextUsage(sess.Store); err != nil {
+			slog.Warn("channel persist context tokens", "channel", ev.Platform, "err", err)
+		}
 	}
 
 	// Goal status before the turn, for the terminal-transition notice below —

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -292,6 +292,11 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (sessionID st
 
 	sess.SyncFrom(a.History)
 	_ = sess.Save()
+	// Record the real context-token count so this cron session shows accurate
+	// usage when opened in the Web UI (parity with web/desktop turns).
+	if perr := a.PersistContextUsage(sess); perr != nil {
+		slog.Warn("scheduled task: persist context tokens", "task", task.Name, "err", perr)
+	}
 
 	s.liveStateMu.Lock()
 	delete(s.liveStates, sessionID)

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1439,12 +1439,10 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		}
 	}
 	// Persist the real token count on the session so an idle or resumed session
-	// (no live Agent) reports its true context usage — see SetLastContextTokens.
+	// (no live Agent) reports its true context usage — see PersistContextUsage.
 	// Best-effort: a save failure just leaves the estimate fallback in place.
-	if used > 0 {
-		if err := sess.SetLastContextTokens(used); err != nil {
-			slog.Warn("session: persist context tokens", "session_id", sess.ID, "err", err)
-		}
+	if err := a.PersistContextUsage(sess); err != nil {
+		slog.Warn("session: persist context tokens", "session_id", sess.ID, "err", err)
 	}
 	_, pm, re, _, _ := s.sessionStatusFields(sess)
 	s.wsHub.broadcast(sess.ID, map[string]any{


### PR DESCRIPTION
## Problem

The per-session context-token count (`Session.LastContextTokens`, from #1357) was recorded **only on the web/desktop turn path**. A session that last ran over IM, the CLI/TUI, or a scheduled task never persisted it — so opening such a session in the Web UI fell back to the transcript estimate (which omits the system-prompt/tools overhead and can round to 0). This is the parity gap called out in #1357's review.

## Fix

Extract the web path's logic into one helper — `Agent.PersistContextUsage(sess)` — and call it at turn end on **every** transport:

| Transport | Call site |
|---|---|
| web/desktop | `doAgentTurn` (refactored to the helper) |
| IM | the `runChannelTurns` `persist()` closure (covers every chained turn) |
| scheduled | `RunTask`, after the turn's save |
| CLI/TUI | the per-turn auto-save in `tuirepl` |

`PersistContextUsage` is a no-op when no count is available and best-effort on save (callers log). Headless one-shots still don't persist a session, so they're unaffected.

Result: a session shows accurate context usage in the Web UI regardless of where it last ran.

## Verification

- `TestPersistContextUsage`: records + round-trips the count through a reload; nil session and no-count are safe no-ops.
- Existing `TestSendContextUsage_UsesPersistedTokens` still covers the read side.
- `go test -race ./internal/agent/ ./internal/server/`, `go test ./cmd/octo/` pass; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)