### PR TITLE
fix(channel): route IM message-reception logs through slog at debug level

### DIFF
--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -637,6 +638,9 @@ func (a *Adapter) handleInbound(raw json.RawMessage, onMessage func(channel.Inbo
 		ct = "group"
 	}
 
+	// Content-free reception line: message text is never logged (only metadata),
+	// so this stays a safe per-message signal in serve.log at the default level.
+	slog.Info("channel message received", "platform", platformName, "chat", chatID, "user", senderID, "chat_type", ct, "bytes", len(text))
 	onMessage(channel.InboundEvent{
 		Type:      "message",
 		Platform:  platformName,

--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -953,9 +953,9 @@ func (a *Adapter) handleMessage(msg *dcMessage, onMessage func(channel.InboundEv
 		return
 	}
 
-	// Debug-level and content-free: message text is not logged, and the line
-	// stays silent at the default level so IM traffic never lands in serve.log.
-	slog.Debug("channel message received", "platform", platformName, "chat", msg.ChannelID, "user", msg.Author.ID, "chat_type", chatType, "chars", len(text))
+	// Content-free reception line: message text is never logged (only metadata),
+	// so this stays a safe per-message signal in serve.log at the default level.
+	slog.Info("channel message received", "platform", platformName, "chat", msg.ChannelID, "user", msg.Author.ID, "chat_type", chatType, "bytes", len(text))
 	onMessage(channel.InboundEvent{
 		Type:      "message",
 		Platform:  platformName,

--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"math/rand"
 	"mime/multipart"
 	"net/http"
@@ -952,7 +953,9 @@ func (a *Adapter) handleMessage(msg *dcMessage, onMessage func(channel.InboundEv
 		return
 	}
 
-	log.Printf("[discord] msg from %s in %s (%s): %.80s", msg.Author.ID, msg.ChannelID, chatType, text)
+	// Debug-level and content-free: message text is not logged, and the line
+	// stays silent at the default level so IM traffic never lands in serve.log.
+	slog.Debug("channel message received", "platform", platformName, "chat", msg.ChannelID, "user", msg.Author.ID, "chat_type", chatType, "chars", len(text))
 	onMessage(channel.InboundEvent{
 		Type:      "message",
 		Platform:  platformName,

--- a/internal/channel/adapters/feishu/feishu.go
+++ b/internal/channel/adapters/feishu/feishu.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -642,6 +643,9 @@ func (a *Adapter) handleMessageEvent(raw json.RawMessage, onMessage func(channel
 		text = a.enrichDocContent(text)
 	}
 
+	// Content-free reception line: message text is never logged (only metadata),
+	// so this stays a safe per-message signal in serve.log at the default level.
+	slog.Info("channel message received", "platform", platformName, "chat", msg.ChatID, "user", senderID, "chat_type", chatType, "bytes", len(text))
 	onMessage(channel.InboundEvent{
 		Type:      "message",
 		Platform:  platformName,

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -837,9 +837,9 @@ func (a *Adapter) processUpdate(upd tgUpdate, onMessage func(channel.InboundEven
 		chatType = "group"
 	}
 
-	// Debug-level and content-free: message text is not logged, and the line
-	// stays silent at the default level so IM traffic never lands in serve.log.
-	slog.Debug("channel message received", "platform", platformName, "chat", msg.Chat.ID, "user", userID, "chat_type", chatType, "chars", len(text))
+	// Content-free reception line: message text is never logged (only metadata),
+	// so this stays a safe per-message signal in serve.log at the default level.
+	slog.Info("channel message received", "platform", platformName, "chat", msg.Chat.ID, "user", userID, "chat_type", chatType, "bytes", len(text))
 	onMessage(channel.InboundEvent{
 		Type:      "message",
 		Platform:  platformName,

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -836,7 +837,9 @@ func (a *Adapter) processUpdate(upd tgUpdate, onMessage func(channel.InboundEven
 		chatType = "group"
 	}
 
-	log.Printf("[telegram] msg from %s in %d (%s): %.80s", userID, msg.Chat.ID, msg.Chat.Type, text)
+	// Debug-level and content-free: message text is not logged, and the line
+	// stays silent at the default level so IM traffic never lands in serve.log.
+	slog.Debug("channel message received", "platform", platformName, "chat", msg.Chat.ID, "user", userID, "chat_type", chatType, "chars", len(text))
 	onMessage(channel.InboundEvent{
 		Type:      "message",
 		Platform:  platformName,

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -972,9 +972,9 @@ func (a *Adapter) handleInbound(body json.RawMessage, onMessage func(channel.Inb
 		chatType = "group"
 	}
 
-	// Debug-level: reception is routine traffic, silent at the default level so
-	// it never fills serve.log. Message text was never logged here.
-	slog.Debug("channel message received", "platform", platformName, "chat", chatID, "user", msg.From.UserID, "chat_type", chatType, "msgtype", msg.MsgType)
+	// Content-free reception line: message text is never logged (only metadata),
+	// so this stays a safe per-message signal in serve.log at the default level.
+	slog.Info("channel message received", "platform", platformName, "chat", chatID, "user", msg.From.UserID, "chat_type", chatType, "msgtype", msg.MsgType)
 	onMessage(channel.InboundEvent{
 		Type:      "message",
 		Platform:  platformName,

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -971,7 +972,9 @@ func (a *Adapter) handleInbound(body json.RawMessage, onMessage func(channel.Inb
 		chatType = "group"
 	}
 
-	log.Printf("[wecom] msg from %s in %s (%s) type=%s", msg.From.UserID, chatID, chatType, msg.MsgType)
+	// Debug-level: reception is routine traffic, silent at the default level so
+	// it never fills serve.log. Message text was never logged here.
+	slog.Debug("channel message received", "platform", platformName, "chat", chatID, "user", msg.From.UserID, "chat_type", chatType, "msgtype", msg.MsgType)
 	onMessage(channel.InboundEvent{
 		Type:      "message",
 		Platform:  platformName,

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -750,9 +750,9 @@ func (a *Adapter) handleInbound(wire *ilink.WireMessage, onMessage func(channel.
 		return
 	}
 
-	// Debug-level and content-free: message text is not logged, and the line
-	// stays silent at the default level so IM traffic never lands in serve.log.
-	slog.Debug("channel message received", "platform", platformName, "chat", userID, "user", userID, "chars", len(strings.TrimSpace(text)))
+	// Content-free reception line: message text is never logged (only metadata),
+	// so this stays a safe per-message signal in serve.log at the default level.
+	slog.Info("channel message received", "platform", platformName, "chat", userID, "user", userID, "bytes", len(strings.TrimSpace(text)))
 
 	ev := channel.InboundEvent{
 		Type:         "message",

--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -749,7 +750,9 @@ func (a *Adapter) handleInbound(wire *ilink.WireMessage, onMessage func(channel.
 		return
 	}
 
-	log.Printf("[weixin] message from %s: %s", userID, truncate(text, 80))
+	// Debug-level and content-free: message text is not logged, and the line
+	// stays silent at the default level so IM traffic never lands in serve.log.
+	slog.Debug("channel message received", "platform", platformName, "chat", userID, "user", userID, "chars", len(strings.TrimSpace(text)))
 
 	ev := channel.InboundEvent{
 		Type:         "message",
@@ -970,11 +973,3 @@ func markdownToPlain(text string) string {
 // from strings.LastIndex directly into a rune-slice index, which could
 // panic ("slice bounds out of range") on CJK text with a separator late in
 // the chunk window; SplitForSend cuts on byte offsets throughout instead.
-
-func truncate(s string, max int) string {
-	runes := []rune(s)
-	if len(runes) <= max {
-		return s
-	}
-	return string(runes[:max]) + "…"
-}


### PR DESCRIPTION
## Problem

`server.log` (`~/.octo/serve.log`) is the single log file for the serve daemon — the worker's stderr is redirected there, and `slog`'s default handler writes to stderr. The IM adapters, however, logged inbound-message **reception** through the stdlib `log` package rather than `slog`, which caused three issues:

1. **Message content leaked to disk by default.** telegram/discord/weixin logged the first 80 chars of every incoming message. That content landed in `serve.log` (mode `0644`) unconditionally — a privacy/compliance concern.
2. **Not level-gated.** `OCTO_LOG_LEVEL` only controls `slog`. These `log.Printf` lines were emitted regardless of level, with no way to turn them down short of a code change.
3. **Inconsistent / incomplete.** stdlib `log` output mixes with the `slog` text handler format in the same file; and the reception line existed for only some adapters (feishu/dingtalk had none at all).

## Change

Give all six IM adapters a single, uniform, content-free reception log via `slog.Info`:

- Fields: `platform, chat, user, chat_type, bytes` (`wecom` carries `msgtype` in place of `bytes` since it never decoded text there). Message text is **never** logged; `bytes` is the UTF-8 byte length, preserving activity/size visibility.
- **telegram / discord / weixin**: converted from `log.Printf` (which logged the first 80 chars of message text) — this is the actual content leak being fixed.
- **wecom**: converted from `log.Printf` (metadata only, never leaked) for format consistency and level-gating.
- **feishu / dingtalk**: had no reception log at all — added, so the per-message signal is uniform across all six.
- Kept at **Info**, not Debug: the server's channel/turn path has no other per-message info logging, so Debug would leave `serve.log` with no trace that IM messages were received or processed at the default level. Dropping the message text already fixes the privacy issue; the content-free reception line stays as a useful per-message operational signal (like an access log).
- Drops weixin's now-unused `truncate` helper.

Error/retry logs and the feishu card-action (button-press) log are left on stdlib `log` — they stay visible and carry no message content.

## Test

`go test ./internal/channel/...` passes; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)