### PR TITLE
feat(cli): octo doctor + octo config --fix for broken configs

### DIFF
--- a/cmd/octo/completion.go
+++ b/cmd/octo/completion.go
@@ -98,7 +98,7 @@ func completionCandidates(words []string) []string {
 		return initCandidates(prev)
 	case "config":
 		if len(words) == 3 {
-			return []string{"show", "path"}
+			return []string{"show", "path", "fix"}
 		}
 	case "help":
 		// `octo help <TAB>` → list of help targets.
@@ -215,7 +215,7 @@ new flags / subcommands are added.`))
 // ── Static lists ─────────────────────────────────────────────────────────
 
 var topLevelCommands = []string{
-	"config", "init", "memory", "serve", "sessions", "skills", "upgrade",
+	"config", "doctor", "init", "memory", "serve", "sessions", "skills", "upgrade",
 	"version", "help", "completion",
 }
 

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -146,9 +146,9 @@ func runConfigFix(stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, "Run `octo config` to rebuild it from scratch.")
 			return 1
 		}
-		fmt.Fprintln(stdout, "Restored config.yml from its backup (config.yml.bak).")
+		fmt.Fprintln(stdout, "Restored config.yml from the last version octo saved (config.yml.bak).")
 		if broken != "" {
-			fmt.Fprintf(stdout, "Your unparseable file was kept as %s.\n", broken)
+			fmt.Fprintf(stdout, "Your edited (unparseable) file was kept as %s — copy any recent changes back from it.\n", broken)
 		}
 		return 0
 	}

--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -124,10 +124,58 @@ func runConfig(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 		fmt.Fprintln(stdout, path)
 		return 0
+	case "fix", "--fix":
+		return runConfigFix(stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "octo config: unknown subcommand %q (use: setup | show | path)\n", sub)
+		fmt.Fprintf(stderr, "octo config: unknown subcommand %q (use: setup | show | path | fix)\n", sub)
 		return 2
 	}
+}
+
+// runConfigFix repairs ~/.octo/config.yml. If it no longer parses (the case that
+// stops octo from starting), it restores the last good backup. If it parses but
+// has semantic problems, it auto-fixes the safe ones (dangling default_model /
+// lite_model) and reports the rest for manual attention.
+func runConfigFix(stdout, stderr io.Writer) int {
+	cfg, err := config.Load()
+	if err != nil {
+		broken, rerr := config.RestoreFromBackup()
+		if rerr != nil {
+			fmt.Fprintf(stderr, "octo config --fix: config.yml doesn't parse: %v\n", err)
+			fmt.Fprintf(stderr, "Could not auto-restore: %v\n", rerr)
+			fmt.Fprintln(stderr, "Run `octo config` to rebuild it from scratch.")
+			return 1
+		}
+		fmt.Fprintln(stdout, "Restored config.yml from its backup (config.yml.bak).")
+		if broken != "" {
+			fmt.Fprintf(stdout, "Your unparseable file was kept as %s.\n", broken)
+		}
+		return 0
+	}
+
+	repaired, fixed, unfixable := cfg.Repair()
+	if len(fixed) == 0 && len(unfixable) == 0 {
+		fmt.Fprintln(stdout, "config.yml is healthy — nothing to fix.")
+		return 0
+	}
+	if len(fixed) > 0 {
+		if serr := repaired.Save(); serr != nil {
+			fmt.Fprintf(stderr, "octo config --fix: save: %v\n", serr)
+			return 1
+		}
+		fmt.Fprintln(stdout, "Fixed:")
+		for _, f := range fixed {
+			fmt.Fprintf(stdout, "  • %s\n", f)
+		}
+	}
+	if len(unfixable) > 0 {
+		fmt.Fprintln(stdout, "Needs manual attention (edit ~/.octo/config.yml):")
+		for _, u := range unfixable {
+			fmt.Fprintf(stdout, "  • %s\n", u)
+		}
+		return 1
+	}
+	return 0
 }
 
 // runConfigShow prints the effective provider/model/base-URL and where each
@@ -214,6 +262,19 @@ func otherEntryModels(cfg config.Config, skip string) string {
 
 // apiKeyStatus reports where a key for the given provider would come from,
 // without revealing it. Env always wins over a config-stored key.
+// apiKeyReachable reports whether a usable API key exists for the entry —
+// either via the provider's env var or stored in the entry itself.
+func apiKeyReachable(provider string, entry config.ModelEntry) bool {
+	envVar := app.VendorAPIKeyEnvVar(provider)
+	if envVar == "" {
+		envVar = strings.ToUpper(provider) + "_API_KEY"
+	}
+	if os.Getenv(envVar) != "" {
+		return true
+	}
+	return entry.APIKey != "" && entry.Provider == provider
+}
+
 func apiKeyStatus(provider string, entry config.ModelEntry) string {
 	envVar := app.VendorAPIKeyEnvVar(provider)
 	if envVar == "" {

--- a/cmd/octo/doctor.go
+++ b/cmd/octo/doctor.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/open-octo/octo-agent/internal/config"
+)
+
+// runDoctor is `octo doctor`: a read-only health check that works even when
+// config.yml won't parse — the exact case that stops `octo` from starting. It
+// checks the config file (parse + semantic Validate) and a couple of
+// environment essentials, prints ✓/✗ lines, and exits non-zero when anything is
+// wrong so it can be scripted. It never mutates anything (`octo config --fix`
+// does the repairs it points to).
+func runDoctor(_ []string, _ io.Reader, stdout, stderr io.Writer) int {
+	problems := 0
+	note := func(ok bool, msg string) {
+		mark := "✓"
+		if !ok {
+			mark = "✗"
+			problems++
+		}
+		fmt.Fprintf(stdout, "  %s %s\n", mark, msg)
+	}
+
+	fmt.Fprintln(stdout, "octo doctor — checking your setup")
+	fmt.Fprintln(stdout)
+
+	path, perr := config.Path()
+	if perr != nil {
+		fmt.Fprintf(stderr, "  ✗ cannot resolve config path: %v\n", perr)
+		return 1
+	}
+	fmt.Fprintf(stdout, "config: %s\n", path)
+
+	cfg, err := config.Load()
+	if err != nil {
+		note(false, fmt.Sprintf("config.yml does not parse: %v", err))
+		fmt.Fprintln(stdout)
+		fmt.Fprintln(stdout, "  → run `octo config --fix` to restore the last good backup, or edit the file by hand.")
+		fmt.Fprintf(stdout, "\n%d problem(s) found.\n", problems)
+		return 1
+	}
+	note(true, "config.yml parses")
+	for _, p := range cfg.Validate() {
+		note(false, p)
+	}
+
+	// Environment essentials — only meaningful once a model is configured.
+	if len(cfg.Models) == 0 {
+		fmt.Fprintln(stdout, "  ! no models configured yet — run `octo config` to set one up")
+	} else {
+		def := cfg.DefaultEntry()
+		prov := def.Provider
+		if prov == "" {
+			prov = providerAnthropic
+		}
+		if apiKeyReachable(prov, def) {
+			note(true, fmt.Sprintf("default model %q (%s): API key found", def.Model, prov))
+		} else {
+			note(false, fmt.Sprintf("default model %q (%s): %s", def.Model, prov, apiKeyStatus(prov, def)))
+		}
+	}
+
+	fmt.Fprintln(stdout)
+	if problems == 0 {
+		fmt.Fprintln(stdout, "All checks passed.")
+		return 0
+	}
+	fmt.Fprintf(stdout, "%d problem(s) found — `octo config --fix` can repair config issues.\n", problems)
+	return 1
+}

--- a/cmd/octo/doctor.go
+++ b/cmd/octo/doctor.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/open-octo/octo-agent/internal/config"
 )
@@ -42,7 +43,11 @@ func runDoctor(_ []string, _ io.Reader, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "\n%d problem(s) found.\n", problems)
 		return 1
 	}
-	note(true, "config.yml parses")
+	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+		fmt.Fprintln(stdout, "  ! config.yml not created yet — octo uses env vars + built-in defaults")
+	} else {
+		note(true, "config.yml parses")
+	}
 	for _, p := range cfg.Validate() {
 		note(false, p)
 	}

--- a/cmd/octo/doctor_test.go
+++ b/cmd/octo/doctor_test.go
@@ -181,6 +181,38 @@ func TestRunConfigFix_HealthyIsNoOp(t *testing.T) {
 	}
 }
 
+func TestRunConfigFix_FixesAndReportsUnfixable(t *testing.T) {
+	home := doctorHome(t)
+	dir := filepath.Join(home, ".octo")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Dangling default_model (fixable) AND a duplicate model (unfixable) in one
+	// file: --fix should Save the fix, report both, and still exit non-zero.
+	yml := "models:\n  - {provider: openai, model: gpt-4o}\n  - {provider: openai, model: gpt-4o}\ndefault_model: gone\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte(yml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runConfig([]string{"fix"}, strings.NewReader(""), &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("exit = 0, want non-zero while an unfixable problem remains")
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Fixed:") || !strings.Contains(out, "manual attention") {
+		t.Errorf("output should show both the fix and the remaining problem:\n%s", out)
+	}
+	// The fixable part was persisted.
+	got, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load after fix: %v", err)
+	}
+	if got.DefaultModel != "gpt-4o" {
+		t.Errorf("default_model = %q, want reset to gpt-4o", got.DefaultModel)
+	}
+}
+
 func TestRunConfigFix_ReportsUnfixable(t *testing.T) {
 	home := doctorHome(t)
 	dir := filepath.Join(home, ".octo")

--- a/cmd/octo/doctor_test.go
+++ b/cmd/octo/doctor_test.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/config"
+)
+
+// doctorHome isolates HOME (via the shared isolateHome helper) and additionally
+// clears provider API keys so the environment checks are deterministic.
+func doctorHome(t *testing.T) string {
+	t.Helper()
+	home := isolateHome(t)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	return home
+}
+
+func TestRunDoctor_HealthyWithKey(t *testing.T) {
+	doctorHome(t)
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	cfg := config.Config{
+		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "gpt-4o",
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDoctor(nil, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "config.yml parses") || !strings.Contains(out, "All checks passed") {
+		t.Errorf("healthy output missing expected lines:\n%s", out)
+	}
+}
+
+func TestRunDoctor_MissingKeyIsProblem(t *testing.T) {
+	doctorHome(t)
+	cfg := config.Config{
+		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "gpt-4o",
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDoctor(nil, strings.NewReader(""), &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("exit = 0, want non-zero when the API key is missing; out=%q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "OPENAI_API_KEY") {
+		t.Errorf("output should name the missing env var:\n%s", stdout.String())
+	}
+}
+
+func TestRunDoctor_UnparseableConfig(t *testing.T) {
+	home := doctorHome(t)
+	dir := filepath.Join(home, ".octo")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte("models: [oops\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDoctor(nil, strings.NewReader(""), &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("exit = 0, want non-zero on an unparseable config")
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "does not parse") || !strings.Contains(out, "octo config --fix") {
+		t.Errorf("unparseable output should point at --fix:\n%s", out)
+	}
+}
+
+func TestRunDoctor_SemanticProblem(t *testing.T) {
+	doctorHome(t)
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	// Dangling default_model — parses fine, fails Validate.
+	cfg := config.Config{
+		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "does-not-exist",
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDoctor(nil, strings.NewReader(""), &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("exit = 0, want non-zero on a semantic problem")
+	}
+	if !strings.Contains(stdout.String(), "default_model") {
+		t.Errorf("output should surface the dangling default_model:\n%s", stdout.String())
+	}
+}
+
+func TestRunConfigFix_RestoresBrokenConfig(t *testing.T) {
+	home := doctorHome(t)
+	good := config.Config{
+		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "gpt-4o",
+	}
+	if err := good.Save(); err != nil { // writes config.yml + .bak
+		t.Fatal(err)
+	}
+	// Corrupt it.
+	path := filepath.Join(home, ".octo", "config.yml")
+	if err := os.WriteFile(path, []byte("models: [oops\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runConfig([]string{"--fix"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; err=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Restored config.yml") {
+		t.Errorf("output should confirm the restore:\n%s", stdout.String())
+	}
+	got, err := config.Load()
+	if err != nil {
+		t.Fatalf("config still broken after --fix: %v", err)
+	}
+	if got.DefaultModel != "gpt-4o" {
+		t.Errorf("restored default_model = %q, want gpt-4o", got.DefaultModel)
+	}
+}
+
+func TestRunConfigFix_RepairsSemanticProblem(t *testing.T) {
+	doctorHome(t)
+	cfg := config.Config{
+		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "gone",
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runConfig([]string{"fix"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; err=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Fixed:") {
+		t.Errorf("output should report the fix:\n%s", stdout.String())
+	}
+	got, _ := config.Load()
+	if got.DefaultModel != "gpt-4o" {
+		t.Errorf("default_model = %q, want reset to gpt-4o", got.DefaultModel)
+	}
+}
+
+func TestRunConfigFix_HealthyIsNoOp(t *testing.T) {
+	doctorHome(t)
+	cfg := config.Config{
+		Models:       []config.ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "gpt-4o",
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runConfig([]string{"fix"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "healthy") {
+		t.Errorf("healthy config should report nothing to fix:\n%s", stdout.String())
+	}
+}
+
+func TestRunConfigFix_ReportsUnfixable(t *testing.T) {
+	home := doctorHome(t)
+	dir := filepath.Join(home, ".octo")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Duplicate model — parses, but Repair can't guess intent.
+	yml := "models:\n  - {provider: openai, model: gpt-4o}\n  - {provider: openai, model: gpt-4o}\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte(yml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runConfig([]string{"fix"}, strings.NewReader(""), &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("exit = 0, want non-zero when unfixable problems remain")
+	}
+	if !strings.Contains(stdout.String(), "manual attention") {
+		t.Errorf("output should flag the unfixable duplicate:\n%s", stdout.String())
+	}
+}

--- a/cmd/octo/help.go
+++ b/cmd/octo/help.go
@@ -177,6 +177,9 @@ Usage:
   octo config show                 Print the effective provider/model and where each
                                    comes from (never prints the key itself)
   octo config path                 Print the config file path
+  octo config --fix                Repair the file: restore the last good backup
+                                   if it no longer parses, else fix dangling
+                                   default_model / lite_model references
 File (~/.octo/config.yml):
   provider: openai
   model: gpt-4o-mini

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -74,6 +74,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return runInit(args[1:], stdin, stdout, stderr)
 	case "config":
 		return runConfig(args[1:], stdin, stdout, stderr)
+	case "doctor":
+		return runDoctor(args[1:], stdin, stdout, stderr)
 	case "memory":
 		return runMemory(args[1:], stdout, stderr)
 	case "sessions":
@@ -133,7 +135,8 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  --quiet / --verbose      Less / more status chrome")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Commands:")
-	fmt.Fprintln(w, "  config     Set your default provider/model (~/.octo/config.yml)")
+	fmt.Fprintln(w, "  config     Set your default provider/model (`octo config --fix` repairs it)")
+	fmt.Fprintln(w, "  doctor     Check config + environment health (safe to run with a broken config)")
 	fmt.Fprintln(w, "  serve      Start the HTTP server (REST + WebSocket + Web UI)")
 	fmt.Fprintln(w, "  init       Analyze the repo and generate/update .octorules")
 	fmt.Fprintln(w, "  memory     Manage cross-session memory (e.g. `octo memory list`)")

--- a/dev-docs/desktop-update-notice.md
+++ b/dev-docs/desktop-update-notice.md
@@ -1,0 +1,218 @@
+# Desktop update notification
+
+The Wails desktop shell (`cmd/octo-desktop`) is distributed as a whole-app
+installer (macOS pkg, Windows `octo-setup.exe`, Linux AppImage), not as the
+`octo` CLI tarball. It cannot use the in-place binary swap that
+`octo serve` offers, because the running executable is the app bundle's
+`octo-desktop`, and `upgrade.Install` would rename the CLI `octo` binary over
+it — breaking the app (and, on macOS, its bundle code signature). That is why
+the desktop shell constructs the server with `UpdateCheck: false` today, which
+suppresses the whole version badge.
+
+This design gives the desktop shell a **notify-and-open** update flow instead:
+detect a newer release, tell the user, and open the release download page in
+the system browser. The user installs the new package themselves. No in-app
+download, no in-place swap.
+
+## Goals
+
+- The desktop shell surfaces "a newer version is available" and links to the
+  download page, from three entry points: the web version badge, a tray menu
+  item, and the Settings page.
+- The CLI (`octo serve`) self-upgrade flow is untouched.
+- A remote browser connected to the desktop-hosted server is handled correctly
+  (it also cannot swap the desktop binary, and its OS may differ).
+
+## Non-goals
+
+- In-app download of the installer, launching the installer, or silent
+  auto-update. Explicitly out of scope for this iteration.
+
+## Two upgrade modes
+
+The server already reports `native` (a `NativeBridge` is wired) on
+`GET /api/version`. The single fact the frontend is missing is *which* upgrade
+mechanism this server offers. We add an explicit field:
+
+- `upgrade_mode: "cli"` — `octo serve`: the existing in-place swap
+  (`POST /api/version/upgrade`) is valid. Badge shows the current "Upgrade"
+  flow.
+- `upgrade_mode: "installer"` — desktop shell (`Native != nil`): binary swap is
+  refused; the UI offers "Download update" instead.
+
+Because the desktop shell is the single shared server, a *remote* browser
+connected to it also receives `upgrade_mode: "installer"` — correct, since that
+peer likewise must not swap the desktop binary.
+
+`upgrade_mode` is derived, not configured:
+
+```
+if s.cfg.Native != nil        -> "installer"
+else if s.cfg.UpdateCheck     -> "cli"
+else                          -> "cli"   // value irrelevant; needs_update is always false
+```
+
+## Backend
+
+### `GET /api/version` (handleVersion)
+
+Add two fields to the existing response:
+
+- `upgrade_mode` — as above.
+- `release_url` — `upgrade.BaseURL + "/releases/latest"`, so the frontend does
+  not hardcode the repo. Constant; the endpoint stays unauthenticated and leaks
+  no local path.
+
+The desktop shell flips `UpdateCheck: false` → `true` so `latestVersion()`
+actually resolves `latest`/`needs_update`. `UpdateCheck` now means only "perform
+the outbound latest-release check"; whether an in-place swap is allowed is
+governed by `upgrade_mode`, not by `UpdateCheck`.
+
+### `POST /api/version/upgrade` (handleVersionUpgrade)
+
+Add a guard at the top: when `s.cfg.Native != nil`, refuse the in-place swap.
+
+```go
+if s.cfg.Native != nil {
+    writeError(w, http.StatusConflict, "this build updates through its installer; use the download link")
+    return
+}
+```
+
+This is defense in depth: the installer-mode frontend never calls this endpoint,
+but the route is registered unconditionally, so a remote peer must not be able
+to drive a desktop binary swap.
+
+### New: `POST /api/native/open-external`
+
+Opens a URL in the system browser via the bridge. Same shape and loopback guard
+as the other `/api/native/*` handlers (`native_handlers.go`): registered only
+when `Native != nil`, `403` for non-loopback peers, validates the URL is
+`http(s)`.
+
+```go
+type nativeOpenExternalRequest struct {
+    URL string `json:"url"`
+}
+```
+
+Rejects any scheme other than `http`/`https` so the endpoint can't be coerced
+into launching arbitrary local handlers.
+
+### `NativeBridge` interface
+
+Add one method:
+
+```go
+// OpenExternal opens url in the user's default browser (the release download
+// page). http/https only; the server validates the scheme before calling.
+OpenExternal(url string) error
+```
+
+## Desktop shell (`cmd/octo-desktop`)
+
+### Config
+
+`main.go`: `UpdateCheck: false` → `true`.
+
+### `OpenExternal` (bridge.go)
+
+Implemented on the Wails app. Prefer the Wails runtime browser API if present;
+otherwise shell out per-platform (no new third-party dependency):
+
+- macOS: `open <url>`
+- Windows: `rundll32 url.dll,FileProtocolHandler <url>`
+- Linux: `xdg-open <url>`
+
+(Confirm the Wails v3 browser-open API before adding the exec fallback.)
+
+### Tray menu item "Check for updates…"
+
+`buildTrayMenu` gains one item between "Settings" and the separator. On click,
+a background goroutine (never block the UI thread):
+
+1. `upgrade.Check(ctx)` for the latest tag.
+2. Compare with `version.Version`:
+   - Newer → native question dialog "vX is available. Open the download page?"
+     → on confirm, `OpenExternal(BaseURL + "/releases/latest")`.
+   - Already latest → native info dialog "You're on the latest version."
+   - Check failed → native error dialog.
+
+Pure native path; does not depend on a window being open. Reuses the existing
+`confirm` / `showError` dialog helpers. New strings go in `lang.go` +
+`lang_*.go` (zh/en), matching the tray/dialog i18n already there.
+
+## Frontend
+
+### `VersionBadge.svelte`
+
+`checkVersion()` reads `upgrade_mode` and `release_url` into state.
+
+- `upgrade_mode === 'cli'`: unchanged — the existing upgrade→restart state
+  machine.
+- `upgrade_mode === 'installer'`: when `needsUpdate`, the popover shows the new
+  release version and a **"Download update"** button instead of "Upgrade".
+  The button opens the download page:
+  - `localAccess` true (loopback — the desktop window itself, or a localhost
+    browser) → `POST /api/native/open-external { url: release_url }`.
+  - otherwise (remote browser) → `window.open(release_url, '_blank')`.
+
+The `upgrading` / `needs_restart` / `reconnecting` phases are never entered in
+installer mode.
+
+### `SettingsView.svelte`
+
+Inside the existing `{#if $nativeShell}` block, add an "About / Updates" card:
+current version, a "Check for updates" button, and — when an update is
+available — the same "Download update" action as the badge. Reuses
+`api.getVersion()`.
+
+### `lib/api.ts`
+
+Add `openExternal(url)` → `POST /api/native/open-external`. i18n keys for the
+new badge/settings strings.
+
+## Edge cases
+
+- **Remote browser on the desktop server**: `native=true` but the peer is not on
+  the local machine, so `/api/native/open-external` refuses it (loopback guard).
+  The frontend already branches on `localAccess` and falls back to
+  `window.open`, so the remote user still reaches the download page.
+- **Dev / unbundled desktop build**: `needsUpdate()` returns false whenever
+  `upgrade.Eligible() != nil` (dev version string), so a dev build never grows
+  the badge — matching CLI behavior. The tray "Check for updates…" still works
+  and reports status via dialog.
+- **Notifications service absent** (unbundled): the tray flow uses modal
+  dialogs, not `Notify`, so it is unaffected.
+
+## Test points
+
+- `handleVersion` returns `upgrade_mode: "cli"` for a plain server,
+  `"installer"` when a stub `Native` is set; `release_url` present.
+- `handleVersionUpgrade` returns 409 when `Native != nil`.
+- `handleNativeOpenExternal`: 403 for non-loopback; 400 for a non-http(s)
+  scheme; calls the bridge for a valid loopback request (stub bridge records the
+  URL).
+- Frontend: installer-mode badge renders "Download update" and routes to the
+  native endpoint vs `window.open` by `localAccess`.
+
+## Change list
+
+Backend:
+- `internal/server/version_upgrade_handlers.go` — `upgrade_mode` + `release_url`
+  in `handleVersion`; native guard in `handleVersionUpgrade`.
+- `internal/server/native_handlers.go` — `OpenExternal` on `NativeBridge`;
+  `handleNativeOpenExternal`.
+- `internal/server/server.go` — register `POST /api/native/open-external`.
+
+Desktop:
+- `cmd/octo-desktop/main.go` — `UpdateCheck: true`; tray "Check for updates…"
+  item + handler.
+- `cmd/octo-desktop/bridge.go` — implement `OpenExternal`.
+- `cmd/octo-desktop/lang.go`, `lang_darwin.go`, `lang_windows.go`,
+  `lang_other.go` — new tray/dialog strings.
+
+Frontend (remember `make web-build` + commit `internal/server/webdist`):
+- `web/src/components/layout/VersionBadge.svelte`
+- `web/src/views/SettingsView.svelte`
+- `web/src/lib/api.ts` + i18n message files.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -593,10 +593,93 @@ func (c Config) Save() error {
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return err
 	}
+	// Rolling backup of the last config we wrote (always valid, since it's a
+	// marshaled Config): `octo config --fix` restores from it when a later hand
+	// edit leaves config.yml unparseable. Best-effort — a backup failure must
+	// never fail the save itself.
+	_ = os.WriteFile(path+".bak", data, 0o600)
 	if legacy, lerr := legacyPath(); lerr == nil {
 		if _, statErr := os.Stat(legacy); statErr == nil {
 			_ = os.Rename(legacy, legacy+".bak")
 		}
 	}
 	return nil
+}
+
+// BackupPath returns the rolling-backup path (config.yml.bak) that Save writes
+// and `octo config --fix` restores from.
+func BackupPath() (string, error) {
+	p, err := Path()
+	if err != nil {
+		return "", err
+	}
+	return p + ".bak", nil
+}
+
+// RestoreFromBackup replaces config.yml with config.yml.bak, used by
+// `octo config --fix` when the current file no longer parses. It only proceeds
+// when the backup itself parses cleanly, and first preserves the current
+// (broken) file as config.yml.broken so the mangled edit isn't lost. It returns
+// the path the broken file was saved to (empty if there was nothing to save),
+// or an error when there is no usable backup.
+func RestoreFromBackup() (brokenSaved string, err error) {
+	path, err := Path()
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path + ".bak")
+	if err != nil {
+		return "", fmt.Errorf("no backup at %s: %w", path+".bak", err)
+	}
+	var f fileConfig
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return "", fmt.Errorf("the backup %s is also invalid: %w", path+".bak", err)
+	}
+	if cur, rerr := os.ReadFile(path); rerr == nil {
+		broken := path + ".broken"
+		if werr := os.WriteFile(broken, cur, 0o600); werr == nil {
+			brokenSaved = broken
+		}
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return "", err
+	}
+	return brokenSaved, nil
+}
+
+// Repair auto-fixes the semantic problems Validate reports that have a safe,
+// unambiguous resolution, returning the repaired config plus a list of what it
+// changed and what still needs a human. Safe fixes: a dangling default_model is
+// reset to the first entry; a dangling lite_model is cleared. A duplicate model
+// or a half-filled entry is reported as unfixable — the intended value can't be
+// guessed, so it's left for the user.
+func (c Config) Repair() (repaired Config, fixed, unfixable []string) {
+	repaired = c
+	if len(repaired.Models) == 0 {
+		return repaired, nil, nil
+	}
+	seen := make(map[string]bool, len(repaired.Models))
+	for i, m := range repaired.Models {
+		if strings.TrimSpace(m.Model) == "" {
+			unfixable = append(unfixable, fmt.Sprintf("models[%d] has no model name — add one or remove the entry", i))
+			continue
+		}
+		if strings.TrimSpace(m.Provider) == "" {
+			unfixable = append(unfixable, fmt.Sprintf("model %q has no provider — add one", m.Model))
+		}
+		if seen[m.Model] {
+			unfixable = append(unfixable, fmt.Sprintf("duplicate model %q — remove the extra entry", m.Model))
+		}
+		seen[m.Model] = true
+	}
+	if repaired.DefaultModel != "" && !seen[repaired.DefaultModel] {
+		first := repaired.Models[0].Model
+		fixed = append(fixed, fmt.Sprintf("reset default_model %q → %q (first entry)", repaired.DefaultModel, first))
+		repaired.DefaultModel = first
+	}
+	if repaired.LiteModel != "" && !seen[repaired.LiteModel] {
+		fixed = append(fixed, fmt.Sprintf("cleared lite_model %q (matched no entry)", repaired.LiteModel))
+		repaired.LiteModel = ""
+	}
+	return repaired, fixed, unfixable
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -635,11 +635,16 @@ func RestoreFromBackup() (brokenSaved string, err error) {
 	if err := yaml.Unmarshal(data, &f); err != nil {
 		return "", fmt.Errorf("the backup %s is also invalid: %w", path+".bak", err)
 	}
+	// Preserve the current (broken) file as config.yml.broken BEFORE overwriting
+	// it — it holds the user's edits and is otherwise the only copy. If that
+	// preservation fails, abort rather than silently destroy it: a failed
+	// restore the user can retry beats one that loses their file.
 	if cur, rerr := os.ReadFile(path); rerr == nil {
 		broken := path + ".broken"
-		if werr := os.WriteFile(broken, cur, 0o600); werr == nil {
-			brokenSaved = broken
+		if werr := os.WriteFile(broken, cur, 0o600); werr != nil {
+			return "", fmt.Errorf("refusing to overwrite %s: could not preserve it as %s first: %w", path, broken, werr)
 		}
+		brokenSaved = broken
 	}
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return "", err
@@ -659,10 +664,14 @@ func (c Config) Repair() (repaired Config, fixed, unfixable []string) {
 		return repaired, nil, nil
 	}
 	seen := make(map[string]bool, len(repaired.Models))
+	var firstNamed string // first entry with a usable model name — the reset target
 	for i, m := range repaired.Models {
 		if strings.TrimSpace(m.Model) == "" {
 			unfixable = append(unfixable, fmt.Sprintf("models[%d] has no model name — add one or remove the entry", i))
 			continue
+		}
+		if firstNamed == "" {
+			firstNamed = m.Model
 		}
 		if strings.TrimSpace(m.Provider) == "" {
 			unfixable = append(unfixable, fmt.Sprintf("model %q has no provider — add one", m.Model))
@@ -672,10 +681,12 @@ func (c Config) Repair() (repaired Config, fixed, unfixable []string) {
 		}
 		seen[m.Model] = true
 	}
-	if repaired.DefaultModel != "" && !seen[repaired.DefaultModel] {
-		first := repaired.Models[0].Model
-		fixed = append(fixed, fmt.Sprintf("reset default_model %q → %q (first entry)", repaired.DefaultModel, first))
-		repaired.DefaultModel = first
+	// Reset a dangling default_model to the first usable entry. If no entry has a
+	// name there's nothing safe to point it at, so leave it for the user (the
+	// nameless entries are already reported as unfixable above).
+	if repaired.DefaultModel != "" && !seen[repaired.DefaultModel] && firstNamed != "" {
+		fixed = append(fixed, fmt.Sprintf("reset default_model %q → %q (first configured model)", repaired.DefaultModel, firstNamed))
+		repaired.DefaultModel = firstNamed
 	}
 	if repaired.LiteModel != "" && !seen[repaired.LiteModel] {
 		fixed = append(fixed, fmt.Sprintf("cleared lite_model %q (matched no entry)", repaired.LiteModel))

--- a/internal/config/repair_test.go
+++ b/internal/config/repair_test.go
@@ -149,6 +149,45 @@ func TestRepair_ReportsUnfixable(t *testing.T) {
 	}
 }
 
+func TestRepair_DanglingDefaultWithNoNamedEntry(t *testing.T) {
+	// First (and only) entry has no model name, and default_model is dangling.
+	// There's no usable model to reset the default to, so Repair must NOT claim
+	// a fix or set default_model to "".
+	c := Config{
+		Models:       []ModelEntry{{Provider: "openai", Model: ""}},
+		DefaultModel: "gone",
+	}
+	repaired, fixed, unfixable := c.Repair()
+	if len(fixed) != 0 {
+		t.Errorf("fixed = %v, want none — no named entry to reset the default to", fixed)
+	}
+	if repaired.DefaultModel != "gone" {
+		t.Errorf("default_model = %q, want left unchanged (not blanked)", repaired.DefaultModel)
+	}
+	if len(unfixable) == 0 {
+		t.Error("the nameless entry should be reported as unfixable")
+	}
+}
+
+func TestRepair_PicksFirstNamedEntry(t *testing.T) {
+	// A nameless entry precedes a valid one; a dangling default must reset to the
+	// first *named* model, not to the empty first entry.
+	c := Config{
+		Models: []ModelEntry{
+			{Provider: "openai", Model: ""},
+			{Provider: "openai", Model: "gpt-4o"},
+		},
+		DefaultModel: "gone",
+	}
+	repaired, fixed, _ := c.Repair()
+	if repaired.DefaultModel != "gpt-4o" {
+		t.Errorf("default_model = %q, want gpt-4o (first named)", repaired.DefaultModel)
+	}
+	if len(fixed) != 1 {
+		t.Errorf("fixed = %v, want the default reset", fixed)
+	}
+}
+
 func TestRepair_HealthyIsNoOp(t *testing.T) {
 	c := Config{
 		Models:       []ModelEntry{{Provider: "openai", Model: "gpt-4o"}},

--- a/internal/config/repair_test.go
+++ b/internal/config/repair_test.go
@@ -1,0 +1,175 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestSave_WritesRollingBackup(t *testing.T) {
+	setHome(t)
+
+	cfg := Config{
+		Models:       []ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "gpt-4o",
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	bak, err := BackupPath()
+	if err != nil {
+		t.Fatalf("BackupPath: %v", err)
+	}
+	got, err := os.ReadFile(bak)
+	if err != nil {
+		t.Fatalf("reading %s: %v", bak, err)
+	}
+	// The .bak is a marshaled Config, so it must itself parse back cleanly.
+	var f fileConfig
+	if uerr := yaml.Unmarshal(got, &f); uerr != nil {
+		t.Fatalf("backup does not parse: %v", uerr)
+	}
+	if len(f.Models) != 1 || f.Models[0].Model != "gpt-4o" {
+		t.Errorf("backup content = %+v, want the saved config", f)
+	}
+}
+
+func TestRestoreFromBackup(t *testing.T) {
+	home := setHome(t)
+
+	good := Config{
+		Models:       []ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "gpt-4o",
+	}
+	if err := good.Save(); err != nil { // writes config.yml + config.yml.bak
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Now corrupt config.yml the way a hand edit would.
+	path, _ := Path()
+	if err := os.WriteFile(path, []byte("models: [oops\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() should fail on the corrupted file")
+	}
+
+	broken, err := RestoreFromBackup()
+	if err != nil {
+		t.Fatalf("RestoreFromBackup: %v", err)
+	}
+	if broken == "" || !strings.HasSuffix(broken, ".broken") {
+		t.Errorf("broken-file path = %q, want a *.broken path", broken)
+	}
+	if _, statErr := os.Stat(broken); statErr != nil {
+		t.Errorf("broken file not kept at %s: %v", broken, statErr)
+	}
+
+	// config.yml now parses again and matches the backup.
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("Load after restore: %v", err)
+	}
+	if got.DefaultModel != "gpt-4o" || len(got.Models) != 1 {
+		t.Errorf("restored config = %+v, want the good one", got)
+	}
+	_ = home
+}
+
+func TestRestoreFromBackup_NoBackup(t *testing.T) {
+	setHome(t)
+	writeOcto(t, os.Getenv("HOME"), "config.yml", "models: [oops\n")
+	if _, err := RestoreFromBackup(); err == nil {
+		t.Fatal("RestoreFromBackup with no .bak should error")
+	}
+}
+
+func TestRestoreFromBackup_InvalidBackup(t *testing.T) {
+	home := setHome(t)
+	writeOcto(t, home, "config.yml", "models: [oops\n")
+	writeOcto(t, home, "config.yml.bak", "also: [broken\n")
+	if _, err := RestoreFromBackup(); err == nil {
+		t.Fatal("RestoreFromBackup with an invalid .bak should error")
+	}
+}
+
+func TestRepair_ResetsDanglingDefaultModel(t *testing.T) {
+	c := Config{
+		Models:       []ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "gone",
+	}
+	repaired, fixed, unfixable := c.Repair()
+	if len(unfixable) != 0 {
+		t.Errorf("unfixable = %v, want none", unfixable)
+	}
+	if len(fixed) != 1 {
+		t.Fatalf("fixed = %v, want 1 entry", fixed)
+	}
+	if repaired.DefaultModel != "gpt-4o" {
+		t.Errorf("default_model = %q, want reset to gpt-4o", repaired.DefaultModel)
+	}
+	// Repaired config is clean.
+	if p := repaired.Validate(); len(p) != 0 {
+		t.Errorf("repaired config still has problems: %v", p)
+	}
+}
+
+func TestRepair_ClearsDanglingLiteModel(t *testing.T) {
+	c := Config{
+		Models:    []ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		LiteModel: "gone",
+	}
+	repaired, fixed, unfixable := c.Repair()
+	if len(unfixable) != 0 || len(fixed) != 1 {
+		t.Fatalf("fixed=%v unfixable=%v, want 1 fixed 0 unfixable", fixed, unfixable)
+	}
+	if repaired.LiteModel != "" {
+		t.Errorf("lite_model = %q, want cleared", repaired.LiteModel)
+	}
+}
+
+func TestRepair_ReportsUnfixable(t *testing.T) {
+	c := Config{
+		Models: []ModelEntry{
+			{Provider: "openai", Model: "gpt-4o"},
+			{Provider: "openai", Model: "gpt-4o"}, // duplicate
+			{Provider: "", Model: "no-provider"},  // missing provider
+			{Provider: "openai", Model: ""},       // missing model name
+		},
+	}
+	_, fixed, unfixable := c.Repair()
+	if len(fixed) != 0 {
+		t.Errorf("fixed = %v, want none (all problems are unfixable)", fixed)
+	}
+	if len(unfixable) != 3 {
+		t.Errorf("unfixable = %v, want 3 (duplicate, missing provider, missing model)", unfixable)
+	}
+}
+
+func TestRepair_HealthyIsNoOp(t *testing.T) {
+	c := Config{
+		Models:       []ModelEntry{{Provider: "openai", Model: "gpt-4o"}},
+		DefaultModel: "gpt-4o",
+	}
+	repaired, fixed, unfixable := c.Repair()
+	if len(fixed) != 0 || len(unfixable) != 0 {
+		t.Errorf("healthy config: fixed=%v unfixable=%v, want none", fixed, unfixable)
+	}
+	if repaired.DefaultModel != "gpt-4o" {
+		t.Errorf("healthy config mutated: %+v", repaired)
+	}
+}
+
+func TestRepair_EmptyConfigIsNoOp(t *testing.T) {
+	var c Config
+	repaired, fixed, unfixable := c.Repair()
+	if len(fixed) != 0 || len(unfixable) != 0 {
+		t.Errorf("empty config: fixed=%v unfixable=%v, want none", fixed, unfixable)
+	}
+	if len(repaired.Models) != 0 {
+		t.Errorf("empty config gained models: %+v", repaired)
+	}
+}


### PR DESCRIPTION
## What

Two new CLI commands to diagnose and repair `~/.octo/config.yml`, closing the gap where a hand-edited config that no longer parses stops `octo` from starting with no built-in recovery path.

### `octo doctor`
Read-only health check that works **even when the config won't parse** (the exact case that blocks startup):
- config parse status
- semantic problems via `config.Validate` (dangling `default_model`/`lite_model`, duplicates, half-filled entries)
- whether the default model's API key is reachable (env var or stored key)

Exits non-zero when anything is wrong, so it's scriptable. Mutates nothing.

### `octo config --fix`
Repairs the file:
- **Won't parse** → restores the last good backup (`config.yml.bak`), preserving the broken file as `config.yml.broken`.
- **Parses but has safe-fixable problems** → auto-fixes dangling `default_model` (reset to first entry) / `lite_model` (cleared).
- **Unfixable** (duplicates, missing model/provider) → reported for manual attention, exit non-zero.

## How

- `config.Save` now writes a rolling `config.yml.bak` on every save. It's a marshaled `Config`, so it's always valid YAML — that's what `--fix` restores from.
- New helpers: `config.BackupPath`, `config.RestoreFromBackup`, `config.Repair`.
- Wired into `octo help config`, top-level usage, and shell completion (`config` subcommands + `doctor` top-level).

## Testing
- `internal/config/repair_test.go` — Save-writes-.bak, RestoreFromBackup (happy path + no-backup + invalid-backup), Repair (dangling default/lite, unfixable, healthy no-op, empty no-op).
- `cmd/octo/doctor_test.go` — doctor healthy/missing-key/unparseable/semantic; config --fix restore/repair/healthy/unfixable.
- `go test -race ./...` green, `gofmt` clean, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)