### PR TITLE
feat(logfile): bounded, self-rotating serve.log for the desktop hub and daemon

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -25,6 +25,12 @@ type nativeBridge struct {
 	srv atomic.Pointer[server.Server]
 	url string // http://127.0.0.1:8088, set once bound
 
+	// closeLog releases the rotating serve.log writer that startHub installs once
+	// this process owns the port. Written by startHub (the ApplicationStarted
+	// goroutine) and read by main's post-Run cleanup on another goroutine, so it's
+	// atomic like srv.
+	closeLog atomic.Pointer[func()]
+
 	// allowQuit gates the app's ShouldQuit on Windows/Linux, where closing the
 	// last window would otherwise terminate the app (and the hub with it). It
 	// starts false when KeepRunningInBackground is on, so a window close hides

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -66,17 +66,6 @@ func main() {
 	// Pick the language for native dialogs/tray from the system UI language.
 	applyLang()
 
-	// Persist the hub's logs to ~/.octo/serve.log — the same file `octo serve -d`
-	// writes. The serve.pid protocol guarantees only one backend owns the port at
-	// a time, so the two never write it concurrently. Without this a Finder-/dock-
-	// launched .app drops its stderr into the OS console with nothing greppable on
-	// disk; the desktop hub reused serve.pid but never the log half of the daemon
-	// contract. The file self-rotates so an always-on hub can't grow it unbounded.
-	// On any failure we leave the process's default stderr in place.
-	if closeLog := setupHubLog(); closeLog != nil {
-		defer closeLog()
-	}
-
 	settings := loadDesktopSettings()
 
 	// Seed ~/.octo/bin/uv from the app's bundled copy on first run so skills
@@ -176,6 +165,9 @@ func main() {
 		_ = srv.Shutdown(ctx)
 		cancel()
 	}
+	if closeLog := bridge.closeLog.Load(); closeLog != nil {
+		(*closeLog)()
+	}
 	if err != nil {
 		log.Fatalf("octo-desktop: %v", err)
 	}
@@ -248,6 +240,18 @@ func startHub(app *application.App, bridge *nativeBridge, settings desktopSettin
 	}
 	if path, perr := serveproc.PidPath(); perr == nil {
 		_ = serveproc.WritePid(path, os.Getpid())
+	}
+
+	// Only now, having taken over any prior daemon and bound the port, are we the
+	// sole backend — so it's safe to open the shared ~/.octo/serve.log. A prior
+	// `octo serve -d` that was stopped above has since exited (listenHub only
+	// succeeds once the port is free), releasing the fd it held on the file;
+	// opening/rotating earlier (e.g. in main, before the takeover) could rotate a
+	// file a live daemon still holds open — on Windows the rename would fail
+	// outright and drop us to a console for the whole session. Set up before
+	// server.New so the hub's own startup logs are captured too.
+	if closeLog := setupHubLog(); closeLog != nil {
+		bridge.closeLog.Store(&closeLog)
 	}
 
 	// Channels start only when the per-machine toggle is on (default off): the

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -19,12 +19,14 @@ import (
 	_ "embed"
 	"fmt"
 	"log"
+	"log/slog"
 	"net"
 	"os"
 	"runtime"
 	"strings"
 	"time"
 
+	"github.com/open-octo/octo-agent/internal/logfile"
 	"github.com/open-octo/octo-agent/internal/serveproc"
 	"github.com/open-octo/octo-agent/internal/server"
 	"github.com/wailsapp/wails/v3/pkg/application"
@@ -63,6 +65,17 @@ func isBundled() bool {
 func main() {
 	// Pick the language for native dialogs/tray from the system UI language.
 	applyLang()
+
+	// Persist the hub's logs to ~/.octo/serve.log — the same file `octo serve -d`
+	// writes. The serve.pid protocol guarantees only one backend owns the port at
+	// a time, so the two never write it concurrently. Without this a Finder-/dock-
+	// launched .app drops its stderr into the OS console with nothing greppable on
+	// disk; the desktop hub reused serve.pid but never the log half of the daemon
+	// contract. The file self-rotates so an always-on hub can't grow it unbounded.
+	// On any failure we leave the process's default stderr in place.
+	if closeLog := setupHubLog(); closeLog != nil {
+		defer closeLog()
+	}
 
 	settings := loadDesktopSettings()
 
@@ -165,6 +178,39 @@ func main() {
 	}
 	if err != nil {
 		log.Fatalf("octo-desktop: %v", err)
+	}
+}
+
+// setupHubLog routes slog and the stdlib logger to a self-rotating
+// ~/.octo/serve.log and returns a close func (nil if setup failed, leaving the
+// default stderr in place). The stdlib logger is redirected too so the channel
+// adapters' error/retry lines — still on `log` — land in the same file.
+func setupHubLog() func() {
+	logPath, err := serveproc.LogPath()
+	if err != nil {
+		return nil
+	}
+	lw, err := logfile.Open(logPath, logfile.DefaultMaxBytes, logfile.DefaultBackups)
+	if err != nil {
+		return nil
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(lw, &slog.HandlerOptions{Level: hubLogLevel()})))
+	log.SetOutput(lw)
+	return func() { _ = lw.Close() }
+}
+
+// hubLogLevel reads OCTO_LOG_LEVEL (debug|info|warn|error), defaulting to info —
+// matching `octo serve`'s level handling so the two backends behave alike.
+func hubLogLevel() slog.Level {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("OCTO_LOG_LEVEL"))) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
 	}
 }
 

--- a/cmd/octo/serve_daemon.go
+++ b/cmd/octo/serve_daemon.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/open-octo/octo-agent/internal/logfile"
 	"github.com/open-octo/octo-agent/internal/serveproc"
 )
 
@@ -52,6 +53,13 @@ func startDaemon(serveArgs []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "octo serve: daemon: %v\n", err)
 		return 1
 	}
+	// Cap the log across daemon restarts: rotate the existing file if it has
+	// already grown past the size bound before we append to it again. `-d`
+	// hands this file's fd to the worker child as its stderr, so it can't be
+	// wrapped in a rotating writer the way the in-process desktop hub is;
+	// open-time rotation is the fd-compatible equivalent and bounds growth per
+	// daemon generation. Best-effort — a rotation failure must not stop serve.
+	_ = logfile.RotateIfLarger(logPath, logfile.DefaultMaxBytes, logfile.DefaultBackups)
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		fmt.Fprintf(stderr, "octo serve: daemon: open log: %v\n", err)

--- a/internal/logfile/rotating.go
+++ b/internal/logfile/rotating.go
@@ -1,0 +1,166 @@
+// Package logfile provides a size-bounded, self-rotating log file for the
+// backends that write ~/.octo/serve.log directly with no service manager in
+// front of them: the desktop hub (in-process) and `octo serve -d`. systemd
+// users are unaffected — they capture stderr into the journal, which rotates
+// itself; this exists for the paths that don't have that.
+//
+// Two entry points cover the two ways that file is consumed:
+//
+//   - Rotating wraps the file as an io.WriteCloser and rotates inline, so a
+//     long-running in-process writer (the desktop hub) stays bounded without
+//     ever restarting. Used as the slog handler's output.
+//   - RotateIfLarger rotates once at open time for callers that hand the
+//     file's fd to a child process and so can't intercept its writes
+//     (`octo serve -d` pipes the fd in as the worker's stderr). It bounds
+//     growth per daemon generation rather than continuously.
+//
+// Both share one rename-chain (rotate), which is Windows-safe: os.Rename onto
+// an existing file fails on Windows, so every destination is removed first.
+package logfile
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+// Default size bound and backup count. Worst-case on-disk footprint is
+// DefaultMaxBytes * (DefaultBackups + 1) — the live file plus its history.
+const (
+	DefaultMaxBytes = 10 << 20 // 10 MiB
+	DefaultBackups  = 3
+)
+
+// Rotating is an io.WriteCloser that caps a log file at maxBytes, keeping up to
+// `backups` rotated generations (name, name.1, … name.<backups>). It rotates
+// just before a write that would cross the cap, so the live file exceeds
+// maxBytes by at most one record. Writes are serialized, which also makes it
+// safe for the concurrent use an slog handler may make of it.
+type Rotating struct {
+	mu       sync.Mutex
+	path     string
+	maxBytes int64
+	backups  int
+	f        *os.File
+	size     int64
+}
+
+// Open opens path for appending (creating it if absent). If the existing file
+// is already at or over maxBytes — e.g. a log grown unbounded before rotation
+// existed — it is rotated at open so appending starts on a fresh file. The
+// parent directory must already exist.
+func Open(path string, maxBytes int64, backups int) (*Rotating, error) {
+	if fi, err := os.Stat(path); err == nil && maxBytes > 0 && fi.Size() >= maxBytes {
+		if err := rotate(path, backups); err != nil {
+			return nil, err
+		}
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return &Rotating{path: path, maxBytes: maxBytes, backups: backups, f: f, size: fi.Size()}, nil
+}
+
+// Write implements io.Writer. It rotates before writing when the record would
+// push the file past maxBytes, except when the file is empty — a single record
+// larger than maxBytes is written as-is rather than triggering an endless
+// rotate-with-nothing-to-move.
+func (r *Rotating) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.maxBytes > 0 && r.size > 0 && r.size+int64(len(p)) > r.maxBytes {
+		if err := r.rotateLocked(); err != nil {
+			return 0, err
+		}
+	}
+	n, err := r.f.Write(p)
+	r.size += int64(n)
+	return n, err
+}
+
+// Close closes the underlying file. Further writes will fail.
+func (r *Rotating) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.f == nil {
+		return nil
+	}
+	err := r.f.Close()
+	r.f = nil
+	return err
+}
+
+// rotateLocked closes the current file, shifts the rename chain, and reopens a
+// fresh file. It reopens even if the shift failed so logging keeps working; on
+// that path r.size is reset from the reopened file so accounting stays correct
+// whether or not the current file was actually renamed away.
+func (r *Rotating) rotateLocked() error {
+	_ = r.f.Close()
+	rotErr := rotate(r.path, r.backups)
+	f, err := os.OpenFile(r.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		r.f = nil
+		return err
+	}
+	r.f = f
+	r.size = 0
+	if fi, err := f.Stat(); err == nil {
+		r.size = fi.Size()
+	}
+	return rotErr
+}
+
+// RotateIfLarger rotates path (keeping `backups` generations) if it exists and
+// is at least maxBytes, then returns without installing any further rotation.
+// It is the fd-compatible, open-time cap for `octo serve -d`, which pipes the
+// file's fd into its worker child and so can't wrap it in a Rotating writer. A
+// missing file or maxBytes<=0 is a no-op.
+func RotateIfLarger(path string, maxBytes int64, backups int) error {
+	if maxBytes <= 0 {
+		return nil
+	}
+	fi, err := os.Stat(path)
+	if err != nil || fi.Size() < maxBytes {
+		return nil
+	}
+	return rotate(path, backups)
+}
+
+// rotate shifts path -> path.1 -> … -> path.<backups>, dropping the oldest
+// generation. It renames oldest-first and removes each destination before the
+// rename so it works on Windows (where renaming onto an existing file fails).
+// A generation that doesn't exist yet is skipped. With backups <= 0 the file
+// is simply removed (no history kept). A missing source is not an error.
+func rotate(path string, backups int) error {
+	if backups <= 0 {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	// Drop the oldest generation, then shift the rest up by one.
+	_ = os.Remove(fmt.Sprintf("%s.%d", path, backups))
+	for i := backups - 1; i >= 1; i-- {
+		src := fmt.Sprintf("%s.%d", path, i)
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		dst := fmt.Sprintf("%s.%d", path, i+1)
+		_ = os.Remove(dst)
+		if err := os.Rename(src, dst); err != nil {
+			return err
+		}
+	}
+	if _, err := os.Stat(path); err != nil {
+		return nil // nothing to rotate
+	}
+	dst := path + ".1"
+	_ = os.Remove(dst)
+	return os.Rename(path, dst)
+}

--- a/internal/logfile/rotating_test.go
+++ b/internal/logfile/rotating_test.go
@@ -1,0 +1,211 @@
+package logfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// write is a helper that fails the test on a short write or error.
+func write(t *testing.T, w *Rotating, s string) {
+	t.Helper()
+	n, err := w.Write([]byte(s))
+	if err != nil {
+		t.Fatalf("write %q: %v", s, err)
+	}
+	if n != len(s) {
+		t.Fatalf("write %q: short write %d/%d", s, n, len(s))
+	}
+}
+
+func read(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func TestRotatesBeforeCrossingCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "serve.log")
+	w, err := Open(path, 10, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	write(t, w, "aaaaa\n") // 6 bytes, file was empty → no rotate, size 6
+	write(t, w, "bbbbb\n") // 6 bytes, 6+6 > 10 → rotate first, then write into fresh file
+
+	if got := read(t, path); got != "bbbbb\n" {
+		t.Errorf("live file = %q, want %q", got, "bbbbb\n")
+	}
+	if got := read(t, path+".1"); got != "aaaaa\n" {
+		t.Errorf("rotated .1 = %q, want %q", got, "aaaaa\n")
+	}
+	if _, err := os.Stat(path + ".2"); !os.IsNotExist(err) {
+		t.Errorf(".2 should not exist yet")
+	}
+}
+
+func TestNeverExceedsCapByMoreThanOneRecord(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "serve.log")
+	w, err := Open(path, 100, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	for i := 0; i < 200; i++ {
+		write(t, w, fmt.Sprintf("line-%03d\n", i)) // 9 bytes each
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Live file holds at most one record beyond the cap.
+	if fi.Size() > 100+9 {
+		t.Errorf("live file size %d exceeds cap+record", fi.Size())
+	}
+}
+
+func TestBackupsChainDropsOldest(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "serve.log")
+	w, err := Open(path, 10, 2) // keep serve.log, .1, .2 → 3 generations total
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	// Each 6-byte record after the first forces a rotation.
+	for _, r := range []string{"AAAAA\n", "BBBBB\n", "CCCCC\n", "DDDDD\n"} {
+		write(t, w, r)
+	}
+	// Newest in live file, older ones shifted; the very oldest (AAAAA) dropped.
+	if got := read(t, path); got != "DDDDD\n" {
+		t.Errorf("live = %q, want DDDDD", got)
+	}
+	if got := read(t, path+".1"); got != "CCCCC\n" {
+		t.Errorf(".1 = %q, want CCCCC", got)
+	}
+	if got := read(t, path+".2"); got != "BBBBB\n" {
+		t.Errorf(".2 = %q, want BBBBB", got)
+	}
+	if _, err := os.Stat(path + ".3"); !os.IsNotExist(err) {
+		t.Errorf(".3 should not exist (backups=2)")
+	}
+}
+
+// TestRotateOverwritesExistingBackup exercises the Windows-safe path: a second
+// rotation must replace an already-present .1, which requires removing the
+// destination before the rename (os.Rename onto an existing file fails on
+// Windows).
+func TestRotateOverwritesExistingBackup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "serve.log")
+	w, err := Open(path, 10, 1) // only one backup slot, so .1 gets overwritten
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	write(t, w, "first\n")
+	write(t, w, "secnd\n") // rotate: first → .1
+	write(t, w, "third\n") // rotate again: .1 (first) dropped, secnd → .1
+
+	if got := read(t, path); got != "third\n" {
+		t.Errorf("live = %q, want third", got)
+	}
+	if got := read(t, path+".1"); got != "secnd\n" {
+		t.Errorf(".1 = %q, want secnd", got)
+	}
+}
+
+func TestOversizedSingleRecordWrittenWhole(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "serve.log")
+	w, err := Open(path, 8, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	big := strings.Repeat("x", 50) + "\n" // far larger than the 8-byte cap
+	write(t, w, big)
+	if got := read(t, path); got != big {
+		t.Errorf("oversized record truncated/rotated: got %d bytes, want %d", len(got), len(big))
+	}
+	if _, err := os.Stat(path + ".1"); !os.IsNotExist(err) {
+		t.Errorf("nothing should have rotated on the first oversized write")
+	}
+}
+
+func TestOpenRotatesPreexistingOversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "serve.log")
+	// Simulate a log grown unbounded before rotation was introduced.
+	if err := os.WriteFile(path, []byte(strings.Repeat("old", 100)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w, err := Open(path, 100, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	// The oversized content moved to .1; the live file starts fresh.
+	if fi, err := os.Stat(path); err != nil || fi.Size() != 0 {
+		t.Errorf("live file not fresh after open-time rotation: size=%v err=%v", fiSize(fi), err)
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Errorf("expected pre-existing content rotated to .1: %v", err)
+	}
+}
+
+func TestRotateIfLarger(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "serve.log")
+
+	// Missing file: no-op, no error.
+	if err := RotateIfLarger(path, 100, 2); err != nil {
+		t.Fatalf("missing file should be a no-op: %v", err)
+	}
+
+	// Below the bound: left in place.
+	if err := os.WriteFile(path, []byte("small"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RotateIfLarger(path, 100, 2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path + ".1"); !os.IsNotExist(err) {
+		t.Errorf("small file should not rotate")
+	}
+
+	// At/over the bound: rotated to .1, original path gone.
+	if err := os.WriteFile(path, []byte(strings.Repeat("y", 150)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RotateIfLarger(path, 100, 2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("oversized file should have been renamed away")
+	}
+	if got := read(t, path+".1"); len(got) != 150 {
+		t.Errorf(".1 = %d bytes, want 150", len(got))
+	}
+}
+
+func fiSize(fi os.FileInfo) int64 {
+	if fi == nil {
+		return -1
+	}
+	return fi.Size()
+}


### PR DESCRIPTION
## Problem

Two related gaps in how `~/.octo/serve.log` is handled for backends with **no service manager** in front of them (systemd users are unaffected — journald captures and rotates stderr itself):

1. **The desktop hub had no persistent log at all.** It runs the server in-process (`srv.ServeOn`) and never redirected `slog`/stderr to a file, so a Finder-/dock-launched `.app` dropped its logs into the OS console (macOS) or nowhere (Windows GUI) — nothing greppable on disk. The desktop-hub work reused the `serve.pid` protocol but never the *log* half of the `octo serve -d` contract (the daemon opens the file in the launcher and pipes the fd into its forked worker — a step that simply doesn't exist for the in-process hub).
2. **The file `octo serve -d` does write grew unbounded** — opened `O_APPEND` with no size cap and no rotation, accumulating across restarts.

## Change

New `internal/logfile` package (no third-party deps):

- **`Rotating`** — an `io.WriteCloser` that caps the file at `maxBytes`, keeping `backups` rotated generations (`serve.log`, `serve.log.1`, …). Rotates inline just before a write that would cross the cap, so a long-running **in-process** writer (the desktop hub) stays bounded without ever restarting.
- **`RotateIfLarger`** — an open-time cap for `octo serve -d`, which hands the file's fd to its worker child as stderr and so *can't* wrap it in a writer. Rotates once before re-appending, bounding growth per daemon generation.
- Shared rename-chain is **Windows-safe** (removes each destination before renaming, since `os.Rename` onto an existing file fails on Windows) and **rotates a pre-existing oversized file at open**, retroactively capping logs from before rotation existed.

Wiring:
- **`cmd/octo-desktop`** — routes both `slog` and the stdlib `log` (the adapters' error/retry lines still use it) to a rotating `serve.log`, `OCTO_LOG_LEVEL`-gated to match `octo serve`. On any setup failure it leaves the default stderr in place.
- **`cmd/octo` serve_daemon** — `RotateIfLarger` before the append open.

The `serve.pid` protocol guarantees only one backend owns the port at a time, so the desktop hub and `-d` never write the shared file concurrently.

Defaults: **10 MiB × 3 backups** (~40 MiB worst case).

## Test

`internal/logfile` table tests (via `t.TempDir()`), passing under `-race`, cover: rotate-before-crossing-cap, cap never exceeded by more than one record, backup-chain drops oldest, **overwrite an existing backup (Windows remove-then-rename path)**, oversized single record written whole, open-time rotation of a pre-existing oversized file, and `RotateIfLarger` (missing / small / oversized). Main module `go build`/`vet`/tests clean; desktop nested module builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)