### PR TITLE
feat(desktop): bundle the octo CLI in the Linux AppImage and seed it on launch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,19 @@ jobs:
       - name: Install webview deps
         run: sudo apt-get update && sudo apt-get install -y libgtk-4-dev libwebkitgtk-6.0-dev libsoup-3.0-dev
 
+      # Stage the released linux amd64 CLI so package-desktop-linux.sh bundles it
+      # into the AppImage — the app seeds it to ~/.local/bin on first launch, so
+      # a terminal has `octo` like the mac/win installers provide.
+      - name: Stage the released CLI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          mkdir -p dl
+          gh release download "$GITHUB_REF_NAME" --pattern "octo_${version}_linux_amd64.tar.gz" --dir dl
+          tar -xzf "dl/octo_${version}_linux_amd64.tar.gz" -C dl octo
+          echo "OCTO_CLI=$PWD/dl/octo" >> "$GITHUB_ENV"
+
       - name: Fetch bundled uv
         run: |
           uvVersion=0.11.26

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -70,6 +70,11 @@ func main() {
 	// that need Python work even for a standalone download (no installer).
 	ensureBundledUv()
 
+	// Seed the octo CLI to ~/.local/bin on Linux so a terminal has `octo` like
+	// the mac/win installers provide. May update settings.SeededOctoVersion, so
+	// it runs before the bridge takes its copy of settings below.
+	ensureBundledOcto(&settings)
+
 	bridge := &nativeBridge{settings: settings, url: "http://" + hubAddr}
 	// On Windows/Linux a window close would otherwise quit the app; start with
 	// quit allowed only when the user opted out of keep-running-in-background.

--- a/cmd/octo-desktop/octo_cli.go
+++ b/cmd/octo-desktop/octo_cli.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/open-octo/octo-agent/internal/version"
+)
+
+// ensureBundledOcto seeds the octo CLI bundled with the app to ~/.local/bin/octo
+// on Linux, so a terminal has `octo` after installing the desktop app — matching
+// the macOS and Windows installers, which put the CLI on PATH themselves. The
+// AppImage has no installer step to do that, so the app does it on launch.
+//
+// ~/.local/bin is the XDG user bin dir, already on PATH on current desktops, so
+// no shell rc is touched. mac/win are skipped: their installers own the CLI and
+// its PATH entry, and on macOS the bundled octo lives inside the signed .app.
+//
+// Refresh-on-upgrade without clobbering the user: settings.SeededOctoVersion
+// records what we last wrote. An octo already at the target with no matching
+// record is the user's own (or hand-placed) and is left untouched; one we
+// seeded is replaced when the app version moved on. Best-effort throughout.
+func ensureBundledOcto(settings *desktopSettings) {
+	if runtime.GOOS != "linux" {
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	src := bundledBinaryPath("octo")
+	if src == "" {
+		return // this build didn't bundle the CLI (dev run / plain make)
+	}
+	target := filepath.Join(home, ".local", "bin", "octo")
+	cur := version.Version
+
+	_, statErr := os.Stat(target)
+	if !shouldSeedOcto(statErr == nil, settings.SeededOctoVersion, cur) {
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return
+	}
+	if err := copyExecutable(src, target); err != nil {
+		return // leave SeededOctoVersion unchanged so the next launch retries
+	}
+	settings.SeededOctoVersion = cur
+	_ = saveDesktopSettings(*settings)
+}
+
+// shouldSeedOcto decides whether to (re)write ~/.local/bin/octo. Fresh target:
+// yes. Target present but no seeded-version record: it's the user's own octo —
+// leave it. Present and recorded: rewrite only when the recorded version no
+// longer matches the running app (an upgrade).
+func shouldSeedOcto(targetExists bool, seededVer, curVer string) bool {
+	if !targetExists {
+		return true
+	}
+	if seededVer == "" {
+		return false
+	}
+	return seededVer != curVer
+}

--- a/cmd/octo-desktop/octo_cli_test.go
+++ b/cmd/octo-desktop/octo_cli_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+func TestShouldSeedOcto(t *testing.T) {
+	tests := []struct {
+		name         string
+		targetExists bool
+		seededVer    string
+		curVer       string
+		want         bool
+	}{
+		{"fresh install seeds", false, "", "1.13.0", true},
+		{"fresh install ignores stale record", false, "1.12.0", "1.13.0", true},
+		{"user's own octo left untouched", true, "", "1.13.0", false},
+		{"ours and current is a no-op", true, "1.13.0", "1.13.0", false},
+		{"ours but stale refreshes on upgrade", true, "1.12.0", "1.13.0", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldSeedOcto(tt.targetExists, tt.seededVer, tt.curVer); got != tt.want {
+				t.Errorf("shouldSeedOcto(%v, %q, %q) = %v, want %v",
+					tt.targetExists, tt.seededVer, tt.curVer, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/octo-desktop/settings.go
+++ b/cmd/octo-desktop/settings.go
@@ -18,6 +18,11 @@ type desktopSettings struct {
 	// window is closed, hiding to the tray instead of quitting. Default true —
 	// closing the window shouldn't drop a VS Code / phone client's backend.
 	KeepRunningInBackground bool `json:"keep_running_in_background"`
+	// SeededOctoVersion records the version of the octo CLI this app last seeded
+	// to ~/.local/bin (Linux only — mac/win ship the CLI through their
+	// installers). It scopes the refresh-on-upgrade: an octo on ~/.local/bin
+	// with no matching record here is the user's own and is never overwritten.
+	SeededOctoVersion string `json:"seeded_octo_version,omitempty"`
 }
 
 // defaultDesktopSettings is what a first launch (no file yet) uses.

--- a/cmd/octo-desktop/uv.go
+++ b/cmd/octo-desktop/uv.go
@@ -26,20 +26,20 @@ func ensureBundledUv() {
 	if _, err := os.Stat(target); err == nil {
 		return // already seeded (by us or the installer)
 	}
-	src := bundledUvPath(name)
+	src := bundledBinaryPath(name)
 	if src == "" {
 		return // this build doesn't ship uv
 	}
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		return
 	}
-	copyExecutable(src, target)
+	_ = copyExecutable(src, target)
 }
 
-// bundledUvPath locates the uv shipped alongside the app, whichever way it was
-// packaged: beside the binary (Windows dir, Linux), in the macOS .app's
-// Resources, or under an AppImage's mount ($APPDIR).
-func bundledUvPath(name string) string {
+// bundledBinaryPath locates a binary shipped alongside the app (uv, or the octo
+// CLI), whichever way it was packaged: beside the binary (Windows dir, Linux),
+// in the macOS .app's Resources, or under an AppImage's mount ($APPDIR).
+func bundledBinaryPath(name string) string {
 	exe, err := os.Executable()
 	if err != nil {
 		return ""
@@ -61,26 +61,27 @@ func bundledUvPath(name string) string {
 }
 
 // copyExecutable copies src to dst (0755) via a temp file + rename so a crash
-// mid-copy can't leave a truncated, executable uv behind. Best-effort.
-func copyExecutable(src, dst string) {
+// mid-copy can't leave a truncated, executable binary behind. Returns an error
+// so callers that persist "seeded version" state only record success.
+func copyExecutable(src, dst string) error {
 	in, err := os.Open(src)
 	if err != nil {
-		return
+		return err
 	}
 	defer in.Close()
 	tmp := dst + ".tmp"
 	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
 	if err != nil {
-		return
+		return err
 	}
 	if _, err := io.Copy(out, in); err != nil {
 		out.Close()
 		os.Remove(tmp)
-		return
+		return err
 	}
 	if err := out.Close(); err != nil {
 		os.Remove(tmp)
-		return
+		return err
 	}
-	_ = os.Rename(tmp, dst)
+	return os.Rename(tmp, dst)
 }

--- a/cmd/octo-desktop/uv.go
+++ b/cmd/octo-desktop/uv.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -69,7 +70,9 @@ func copyExecutable(src, dst string) error {
 		return err
 	}
 	defer in.Close()
-	tmp := dst + ".tmp"
+	// PID in the temp name so two instances launched before the single-instance
+	// lock is taken don't write the same .tmp and rename a half-written binary.
+	tmp := fmt.Sprintf("%s.tmp.%d", dst, os.Getpid())
 	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
 	if err != nil {
 		return err

--- a/scripts/package-desktop-linux.sh
+++ b/scripts/package-desktop-linux.sh
@@ -35,8 +35,17 @@ cp "$LINUX/octo-desktop.desktop" "$APPDIR/usr/share/applications/octo-desktop.de
 cp "$LINUX/icon.png" "$APPDIR/octo-desktop.png"
 cp "$LINUX/icon.png" "$APPDIR/usr/share/icons/hicolor/256x256/apps/octo-desktop.png"
 
+# Bundle the octo CLI so the app seeds it to ~/.local/bin on first launch (via
+# $APPDIR/usr/bin by bundledBinaryPath), matching the mac/win installers that
+# put the CLI on PATH. Optional — a plain `make` without OCTO_CLI still produces
+# a runnable GUI; the release sets OCTO_CLI to the linux amd64 CLI binary.
+if [ -n "${OCTO_CLI:-}" ] && [ -f "$OCTO_CLI" ]; then
+	install -m 0755 "$OCTO_CLI" "$APPDIR/usr/bin/octo"
+	echo "    embedded octo CLI"
+fi
+
 # Bundle uv so it's seeded into ~/.octo/bin on first launch (via $APPDIR/usr/bin
-# by bundledUvPath). Optional. Release sets UV_BINARY.
+# by bundledBinaryPath). Optional. Release sets UV_BINARY.
 if [ -n "${UV_BINARY:-}" ] && [ -f "$UV_BINARY" ]; then
 	install -m 0755 "$UV_BINARY" "$APPDIR/usr/bin/uv"
 	echo "    embedded uv"


### PR DESCRIPTION
## What

Bring the Linux desktop AppImage in line with the macOS/Windows installers: bundle the `octo` CLI and put it on PATH so a terminal has `octo` after installing the desktop app.

Before this, only mac (`Octo.app/Contents/Resources/octo` → PATH via pkg postinstall) and Windows (`octo.exe` in the install dir → HKCU PATH) shipped the CLI. The Linux AppImage packaged only `octo-desktop`.

## How

- **Packaging** (`scripts/package-desktop-linux.sh`): embed `$OCTO_CLI` into the AppImage at `$APPDIR/usr/bin/octo`, mirroring the existing optional `UV_BINARY` bundling.
- **Release** (`.github/workflows/release.yml`): the `linux-appimage` job downloads the released `octo_<ver>_linux_amd64.tar.gz`, extracts `octo`, and sets `OCTO_CLI` — mirroring the mac installer job's "Stage the released binary" step.
- **Runtime** (`cmd/octo-desktop`): on Linux launch, `ensureBundledOcto` seeds the bundled CLI to `~/.local/bin/octo` (the XDG user bin dir — already on PATH on current desktops, so no shell rc is touched). mac/win are skipped; their installers own the CLI.

## Why `~/.local/bin` and not a shell-rc edit

The mac/win installers edit PATH because they install into a non-standard dir. Linux has a standard user bin dir already on PATH, so seeding there aligns the *outcome* (terminal has `octo`) without the *side effect* (rewriting `~/.profile`/`.bashrc`/`.zshrc`).

## Not clobbering the user's own octo

`~/.local/bin` is a shared dir, so refresh-on-upgrade is scoped by `desktop.json`'s new `seeded_octo_version`:

- target absent → seed
- target present, no record → **the user's own octo, left untouched**
- target present, our record == app version → no-op
- target present, our record != app version → refresh (app was upgraded)

So a slot we seeded is refreshed on the next app upgrade — don't run `octo upgrade` against the seeded CLI (reinstall/upgrade the app instead). A slot with no record is the user's own and is never touched. Decision logic is a pure function (`shouldSeedOcto`) with a table test.

## Test

- `go test ./cmd/octo-desktop/ -run TestShouldSeedOcto` — covers the 5 seed cases.
- `go vet ./cmd/octo-desktop/` clean; `gofmt` clean; `bash -n` on the packaging script.
- Not yet exercised on real Linux hardware (an AppImage build + install); the seed logic and packaging are unit/syntax-verified only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

