### PR TITLE
chore: bump version to 1.12.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.1"
+var Version = "1.12.2"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Release v1.12.2.

Headline change since v1.12.1: **notify-and-open update flow for the desktop shell** (#1368) — the Wails desktop hub can now surface "a newer version is available" and open the download page, restoring an update affordance the web badge lost when the shared server ran with `UpdateCheck: false`. Also picks up the Linux AppImage CLI bundling (#1367) merged in the same window.

Tag `v1.12.2` will be pushed once this merges, triggering the goreleaser release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)