### PR TITLE
fix(grep): root ripgrep in the session working directory

### DIFF
--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -153,6 +153,11 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, rgPath, args...)
+	// Root rg in the session's working directory. Without this, a grep with no
+	// explicit `path` runs in the octo process CWD — which for a long-lived
+	// `octo serve`/desktop hub is wherever the daemon launched (often $HOME),
+	// not this session's working_dir — so it scans a huge tree and hangs.
+	applyWorkingDir(ctx, cmd)
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -249,3 +249,31 @@ func TestGrep_IncludesStderrOnError(t *testing.T) {
 		t.Errorf("error should include rg's stderr message, got: %v", err)
 	}
 }
+
+// TestGrep_NoPathUsesWorkingDir guards the regression where a grep with no
+// explicit `path` ran in the octo process CWD instead of the session's
+// stamped working directory — so on a long-lived serve/desktop hub it scanned
+// the daemon's launch dir (often $HOME) and hung. The sentinel pattern can
+// only match the file we planted under the stamped dir, never the process CWD
+// (the package source tree), so a match proves rg was rooted correctly.
+func TestGrep_NoPathUsesWorkingDir(t *testing.T) {
+	requireRg(t)
+	dir := t.TempDir()
+	// Assemble the sentinel from fragments so the full string never appears
+	// verbatim in any source file. `go test` runs with the package dir as its
+	// process CWD, so a literal sentinel would also live in this test file and
+	// rg would match it there even with the bug present — masking the regression.
+	sentinel := "grepWorkingDir" + "Sentinel" + "42"
+	writeTestFile(t, filepath.Join(dir, "a.go"), "package main\n\n// "+sentinel+"\n")
+
+	ctx := WithWorkingDir(context.Background(), dir)
+	out, err := GrepTool{}.Execute(ctx, "grep", map[string]any{
+		"pattern": sentinel,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.Text, sentinel) {
+		t.Errorf("grep without path should search the stamped working dir; got:\n%s", out.Text)
+	}
+}


### PR DESCRIPTION
## Problem

The `grep` tool often appears to hang when the agent runs it without an explicit `path`. Root cause: `GrepTool.Execute` builds the `rg` command but never sets `cmd.Dir`.

- When `path` **is** provided, the arg is resolved against `WorkingDir(ctx)` via `resolvePathIn` — correct.
- When `path` is **omitted** (the default, and the common case), `rg` gets no path argument and searches its own process CWD. `cmd.Dir` is unset, so it inherits the **octo process** CWD.

For a long-lived `octo serve` / desktop hub, that process CWD is wherever the daemon was launched — often `$HOME` or `/` — not the session's `working_dir`. So a no-path grep scans a giant tree and looks like it's stuck.

`terminal` (via `applyWorkingDir`) and `glob` (always resolves `.` to an absolute path) already anchor to the session dir. `grep` was the lone omission.

## Fix

Call the existing `applyWorkingDir(ctx, cmd)` helper — the same one `terminal` uses — right after constructing the command.

- **server / desktop**: `WorkingDir(ctx)` is stamped → `cmd.Dir` is set → rg runs in the session's `working_dir`. Matches what the `path`-provided branch already does with `resolvePathIn(WorkingDir(ctx), …)`.
- **CLI single-process**: no working dir is stamped → `cmd.Dir` stays unset → rg runs in the process CWD (which *is* the session dir there). Behaviour unchanged.

## Test

Adds `TestGrep_NoPathUsesWorkingDir`: stamps `WithWorkingDir` and greps **without** a path, asserting the match comes from the stamped dir. The sentinel is assembled from fragments so the full string never appears verbatim in the test source — `go test` runs with the package dir as its process CWD, so a literal sentinel would match the test file itself even with the bug present, masking the regression. Verified red→green: the test FAILs with the `applyWorkingDir` line removed and PASSes with it.

`gofmt`, `go vet`, and the full `internal/tools` package tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)