### PR TITLE
fix(desktop): keep window size when returning to a maximised window

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -179,7 +179,14 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		b.window.SetURL(target)
 	}
 	b.window.Show()
-	b.window.Restore()
+	// Only un-minimise here. Wails' Restore() also un-maximises (and exits
+	// fullscreen), so calling it unconditionally on every show/reopen — e.g.
+	// clicking the dock icon to return to a maximised window — would shrink the
+	// window back to its launch size. Guard on IsMinimised so a visible
+	// maximised/fullscreen window keeps its size.
+	if b.window.IsMinimised() {
+		b.window.Restore()
+	}
 	b.window.Focus()
 }
 


### PR DESCRIPTION
## Problem

After maximising the desktop window (double-click titlebar), switching away and clicking the Octo dock icon to return shrinks the window back to its launch size (1280×860).

Root cause: `showWindowAt()` in `cmd/octo-desktop/bridge.go` calls `window.Restore()` unconditionally after `Show()`. Wails' `Restore()` (webview_window.go:1288) does more than un-minimise — its logic is: if minimised → un-minimise; else if fullscreen → exit fullscreen; **else if maximised → un-maximise**. So on any re-show path it un-maximises a maximised window back to its pre-maximise (launch) size.

The re-show paths that hit this:
- `ApplicationShouldHandleReopen` — clicking the dock icon to return (the reported repro)
- notification click
- second-instance launch

## Fix

Guard the `Restore()` on `IsMinimised()`, so only a genuinely minimised window is un-minimised. A visible maximised/fullscreen window keeps its size. One-line-scope change in `bridge.go`.

## Scope note

This fixes the "switch away and back shrinks the window" case. It does **not** persist window size across a full app restart — the window size was never saved to disk (`desktop.json` carries no geometry). Remembering size across launches is a separate change and can be a follow-up PR.

## Verification

Desktop module builds clean (`go build ./...`, exit 0), `go vet` and `gofmt` clean. Behaviour verification on real hardware (maximise → dock-away → dock-back stays maximised) is owed on macOS; the change is a straightforward guard on the documented Wails API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)