### PR TITLE
feat(desktop): remember window size and maximised state across relaunches

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/open-octo/octo-agent/internal/server"
 	"github.com/wailsapp/wails/v3/pkg/application"
@@ -43,6 +44,54 @@ type nativeBridge struct {
 
 	settingsMu sync.Mutex
 	settings   desktopSettings
+	// geomTimer debounces window-geometry persistence: WindowDidResize fires
+	// once per pixel during a drag, so we coalesce to a single write after the
+	// gesture settles. Guarded by settingsMu.
+	geomTimer *time.Timer
+}
+
+// Built-in window size for a first launch (no saved geometry yet).
+const (
+	defaultWindowWidth  = 1280
+	defaultWindowHeight = 860
+)
+
+// scheduleWindowGeometrySave coalesces the flood of WindowDidResize events from
+// a single drag/zoom into one persisted write ~400ms after it settles.
+func (b *nativeBridge) scheduleWindowGeometrySave() {
+	b.settingsMu.Lock()
+	defer b.settingsMu.Unlock()
+	if b.geomTimer != nil {
+		b.geomTimer.Stop()
+	}
+	b.geomTimer = time.AfterFunc(400*time.Millisecond, b.saveWindowGeometry)
+}
+
+// saveWindowGeometry records the window's current maximised state and, while it
+// is NOT maximised, its size. Skipping the size write while maximised keeps the
+// persisted W×H as the restore size, so a relaunch that reopens maximised still
+// un-maximises back to the size the user last chose. Wails window methods are
+// read outside the lock — they marshal to the UI thread internally, and holding
+// settingsMu across that could deadlock the main thread.
+func (b *nativeBridge) saveWindowGeometry() {
+	b.settingsMu.Lock()
+	w := b.window
+	b.settingsMu.Unlock()
+	if w == nil {
+		return
+	}
+	maximised := w.IsMaximised()
+	width, height := w.Size()
+
+	b.settingsMu.Lock()
+	b.settings.WindowMaximised = maximised
+	if !maximised && width > 0 && height > 0 {
+		b.settings.WindowWidth = width
+		b.settings.WindowHeight = height
+	}
+	snapshot := b.settings
+	b.settingsMu.Unlock()
+	_ = saveDesktopSettings(snapshot)
 }
 
 // PickFolder opens the OS directory-choose dialog and returns the chosen path.
@@ -156,19 +205,38 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		if b.app == nil || b.url == "" {
 			return // not bound yet
 		}
+		// Restore the size and maximised state saved from the last session.
+		b.settingsMu.Lock()
+		width, height, maximised := b.settings.WindowWidth, b.settings.WindowHeight, b.settings.WindowMaximised
+		b.settingsMu.Unlock()
+		if width <= 0 || height <= 0 {
+			width, height = defaultWindowWidth, defaultWindowHeight
+		}
+		startState := application.WindowStateNormal
+		if maximised {
+			startState = application.WindowStateMaximised
+		}
 		w := b.app.Window.NewWithOptions(application.WebviewWindowOptions{
-			Title:  "Octo",
-			Width:  1280,
-			Height: 860,
-			URL:    target,
+			Title:      "Octo",
+			Width:      width,
+			Height:     height,
+			StartState: startState,
+			URL:        target,
 			// Hidden-inset title bar: the traffic lights float over the page's
 			// top-left; the frontend insets its header past them (nativeShell).
 			Mac: application.MacWindow{TitleBar: application.MacTitleBarHiddenInset},
 		})
 		// Forget the window when it closes so a later Show re-creates one; the
 		// app itself stays alive via ApplicationShouldTerminateAfterLastWindowClosed.
+		// Flush the latest geometry first, in case a resize is still pending in
+		// the debounce timer when the window (or the app) goes away.
 		w.OnWindowEvent(events.Common.WindowClosing, func(*application.WindowEvent) {
+			b.saveWindowGeometry()
 			b.window = nil
+		})
+		// Persist size/maximised changes as the user drags or zooms the window.
+		w.OnWindowEvent(events.Common.WindowDidResize, func(*application.WindowEvent) {
+			b.scheduleWindowGeometrySave()
 		})
 		b.window = w
 	} else if hash != "" {

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -44,9 +44,9 @@ type nativeBridge struct {
 
 	settingsMu sync.Mutex
 	settings   desktopSettings
-	// geomTimer debounces window-geometry persistence: WindowDidResize fires
-	// once per pixel during a drag, so we coalesce to a single write after the
-	// gesture settles. Guarded by settingsMu.
+	// geomTimer debounces persistence of the window geometry to disk: a drag
+	// fires WindowDidResize once per pixel, so we coalesce to a single write
+	// ~400ms after the gesture settles. Guarded by settingsMu.
 	geomTimer *time.Timer
 }
 
@@ -56,39 +56,40 @@ const (
 	defaultWindowHeight = 860
 )
 
-// scheduleWindowGeometrySave coalesces the flood of WindowDidResize events from
-// a single drag/zoom into one persisted write ~400ms after it settles.
-func (b *nativeBridge) scheduleWindowGeometrySave() {
-	b.settingsMu.Lock()
-	defer b.settingsMu.Unlock()
-	if b.geomTimer != nil {
-		b.geomTimer.Stop()
-	}
-	b.geomTimer = time.AfterFunc(400*time.Millisecond, b.saveWindowGeometry)
-}
-
-// saveWindowGeometry records the window's current maximised state and, while it
-// is NOT maximised, its size. Skipping the size write while maximised keeps the
-// persisted W×H as the restore size, so a relaunch that reopens maximised still
-// un-maximises back to the size the user last chose. Wails window methods are
-// read outside the lock — they marshal to the UI thread internally, and holding
-// settingsMu across that could deadlock the main thread.
-func (b *nativeBridge) saveWindowGeometry() {
-	b.settingsMu.Lock()
-	w := b.window
-	b.settingsMu.Unlock()
-	if w == nil {
-		return
-	}
+// rememberWindowGeometry captures the window's size and maximised state into
+// settings and debounces the disk write. The window is read HERE, from the
+// WindowDidResize handler where it is guaranteed alive — never from the debounce
+// timer or the close path. Those paths run on their own goroutines and would
+// race the window's destruction: Wails' built-in WindowClosing listener marks
+// the window destroyed, after which IsMaximised()/Size() short-circuit to
+// false/0×0 and would clobber the freshly-saved state. The window methods are
+// read before taking the lock (they marshal to the UI thread; holding
+// settingsMu across that could deadlock the main thread). Size is recorded only
+// while neither maximised nor fullscreen — both report a size that isn't the
+// windowed size, so persisting it would corrupt the restore size a relaunch
+// un-maximises back to.
+func (b *nativeBridge) rememberWindowGeometry(w *application.WebviewWindow) {
 	maximised := w.IsMaximised()
+	fullscreen := w.IsFullscreen()
 	width, height := w.Size()
 
 	b.settingsMu.Lock()
+	defer b.settingsMu.Unlock()
 	b.settings.WindowMaximised = maximised
-	if !maximised && width > 0 && height > 0 {
+	if !maximised && !fullscreen && width > 0 && height > 0 {
 		b.settings.WindowWidth = width
 		b.settings.WindowHeight = height
 	}
+	if b.geomTimer != nil {
+		b.geomTimer.Stop()
+	}
+	b.geomTimer = time.AfterFunc(400*time.Millisecond, b.persistSettings)
+}
+
+// persistSettings writes the current settings to disk. It touches no window
+// state, so it is safe to call from the debounce timer or the closing window.
+func (b *nativeBridge) persistSettings() {
+	b.settingsMu.Lock()
 	snapshot := b.settings
 	b.settingsMu.Unlock()
 	_ = saveDesktopSettings(snapshot)
@@ -228,15 +229,21 @@ func (b *nativeBridge) showWindowAt(hash string) {
 		})
 		// Forget the window when it closes so a later Show re-creates one; the
 		// app itself stays alive via ApplicationShouldTerminateAfterLastWindowClosed.
-		// Flush the latest geometry first, in case a resize is still pending in
-		// the debounce timer when the window (or the app) goes away.
+		// Cancel any pending debounce and flush the last captured geometry — this
+		// only persists already-captured settings, so unlike reading the window
+		// here it can't race the window's destruction.
 		w.OnWindowEvent(events.Common.WindowClosing, func(*application.WindowEvent) {
-			b.saveWindowGeometry()
+			b.settingsMu.Lock()
+			if b.geomTimer != nil {
+				b.geomTimer.Stop()
+			}
+			b.settingsMu.Unlock()
+			b.persistSettings()
 			b.window = nil
 		})
-		// Persist size/maximised changes as the user drags or zooms the window.
+		// Capture size/maximised changes as the user drags or zooms the window.
 		w.OnWindowEvent(events.Common.WindowDidResize, func(*application.WindowEvent) {
-			b.scheduleWindowGeometrySave()
+			b.rememberWindowGeometry(w)
 		})
 		b.window = w
 	} else if hash != "" {

--- a/cmd/octo-desktop/settings.go
+++ b/cmd/octo-desktop/settings.go
@@ -23,6 +23,15 @@ type desktopSettings struct {
 	// installers). It scopes the refresh-on-upgrade: an octo on ~/.local/bin
 	// with no matching record here is the user's own and is never overwritten.
 	SeededOctoVersion string `json:"seeded_octo_version,omitempty"`
+	// WindowWidth/WindowHeight remember the window's non-maximised size across
+	// relaunches. Zero (a fresh install) means "use the built-in default size".
+	// They hold the *restore* size — while maximised the size isn't overwritten,
+	// so un-maximising after a relaunch returns to the size the user last chose.
+	WindowWidth  int `json:"window_width,omitempty"`
+	WindowHeight int `json:"window_height,omitempty"`
+	// WindowMaximised remembers whether the window was maximised at exit, so a
+	// relaunch reopens maximised instead of at the restore size.
+	WindowMaximised bool `json:"window_maximised,omitempty"`
 }
 
 // defaultDesktopSettings is what a first launch (no file yet) uses.

--- a/cmd/octo-desktop/settings_test.go
+++ b/cmd/octo-desktop/settings_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDesktopSettings_WindowGeometryRoundTrip guards the on-disk contract for
+// the remembered window geometry. A typo'd json tag would silently reset the
+// window to its default size on every launch — the exact kind of quiet
+// regression this test exists to catch.
+func TestDesktopSettings_WindowGeometryRoundTrip(t *testing.T) {
+	in := desktopSettings{
+		WindowWidth:     1600,
+		WindowHeight:    1000,
+		WindowMaximised: true,
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out desktopSettings
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.WindowWidth != in.WindowWidth || out.WindowHeight != in.WindowHeight {
+		t.Errorf("size not preserved: got %dx%d, want %dx%d",
+			out.WindowWidth, out.WindowHeight, in.WindowWidth, in.WindowHeight)
+	}
+	if out.WindowMaximised != in.WindowMaximised {
+		t.Errorf("maximised not preserved: got %v, want %v", out.WindowMaximised, in.WindowMaximised)
+	}
+}
+
+// TestDefaultDesktopSettings_NoGeometry documents that a fresh install carries
+// zero geometry, which showWindowAt reads as "use the built-in default size".
+func TestDefaultDesktopSettings_NoGeometry(t *testing.T) {
+	s := defaultDesktopSettings()
+	if s.WindowWidth != 0 || s.WindowHeight != 0 || s.WindowMaximised {
+		t.Errorf("defaults should carry no saved geometry, got %+v", s)
+	}
+}


### PR DESCRIPTION
## What

The desktop window always opened at the hard-coded 1280×860, discarding whatever size the user last set. This persists the window's size and maximised state to `~/.octo/desktop.json` and restores them on launch.

Scope chosen: **size + maximised state** (not on-screen position — a deliberate cut to avoid off-screen/disconnected-monitor edge cases).

## How

- **`settings.go`** — add `WindowWidth`/`WindowHeight` (the *restore* size) and `WindowMaximised`. Zero geometry (a fresh install) means "use the built-in default size", so existing installs are unaffected.
- **`bridge.go`**
  - Window creation reads the saved geometry: `StartState = Maximised` when the flag is set, otherwise the saved W×H (default when none).
  - A `WindowDidResize` handler persists changes, **debounced 400ms** because the event fires per-pixel during a drag.
  - The size is written **only while NOT maximised**, so the persisted W×H stays the restore size — a relaunch that reopens maximised still un-maximises to the size the user last chose.
  - `WindowClosing` flushes any pending debounced write before the window goes away.

### macOS note
`IsMaximised()` maps to `NSWindow.isZoomed`, so the double-click-titlebar zoom is captured too (same gesture as the earlier window bug). This design keys off `IsMaximised()` in the resize handler rather than the `WindowMaximise`/`WindowUnMaximise` events, so it doesn't depend on their firing order (both map to `zoom:` on mac).

### Concurrency
Wails window methods (`IsMaximised`, `Size`) are read **outside** `settingsMu` — they marshal to the UI thread internally, and holding the lock across that could deadlock the main thread. The lock only guards the settings struct mutation + snapshot.

## Relationship to #1371
Complementary and non-overlapping. #1371 stops an *in-session* reopen (dock-click) from un-maximising a visible window (guards `Restore()`); this PR handles *cross-restart* persistence (via `StartState`). Different regions of `bridge.go`, no merge conflict.

## Tests

`settings_test.go`: round-trips the geometry through JSON to lock the on-disk contract (a typo'd json tag would silently reset the window every launch), and asserts fresh-install defaults carry no geometry. The window-event/debounce logic needs a live Wails window and isn't unit-tested (the module mocks no window; consistent with existing tests).

`go build ./...`, `go vet ./...`, `gofmt`, and `go test ./...` all pass on the desktop module. Real-hardware behaviour verification (resize → quit → relaunch restores size; maximise → quit → relaunch reopens maximised) is owed on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)