### PR TITLE
fix(macos-installer): correct install location + converge CLI to ~/.local/bin

### DIFF
--- a/.github/workflows/macos-installer-check.yml
+++ b/.github/workflows/macos-installer-check.yml
@@ -69,10 +69,14 @@ jobs:
           test -x expanded/octo-component.pkg/Scripts/preinstall
           test -x expanded/octo-component.pkg/Scripts/postinstall
           # Payload is the self-contained app bundle: the GUI binary + the
-          # embedded CLI the installer puts on PATH.
-          test -d expanded/octo-component.pkg/Payload/Applications/Octo.app
-          test -x expanded/octo-component.pkg/Payload/Applications/Octo.app/Contents/MacOS/octo-desktop
-          test -x expanded/octo-component.pkg/Payload/Applications/Octo.app/Contents/Resources/octo
+          # embedded CLI the installer puts on PATH. The payload root is the
+          # directory that HOLDS Octo.app (install-location 'Applications'
+          # supplies the parent), so the bundle sits at Payload/Octo.app. If it
+          # were Payload/Applications/Octo.app it would install to
+          # ~/Applications/Applications/Octo.app — the double-nesting this guards.
+          test -d expanded/octo-component.pkg/Payload/Octo.app
+          test -x expanded/octo-component.pkg/Payload/Octo.app/Contents/MacOS/octo-desktop
+          test -x expanded/octo-component.pkg/Payload/Octo.app/Contents/Resources/octo
 
       - name: Verify the package installs under the user's real home directory
         run: |
@@ -93,10 +97,14 @@ jobs:
 
           HOME="$fake" expanded/octo-component.pkg/Scripts/preinstall
 
-          # Simulate Installer.app placing the payload under the home domain's
-          # install-location, then run postinstall exactly as it would.
+          # Simulate Installer.app placing the payload's CONTENTS under the home
+          # domain's install-location ('Applications'), then run postinstall
+          # exactly as it would. Copying the payload contents — not a hand-picked
+          # Octo.app — mirrors the real mapping: a payload that nested
+          # Applications/Octo.app would land at ~/Applications/Applications/Octo.app
+          # and the postinstall's $HOME/Applications/Octo.app lookup would fail here.
           mkdir -p "$fake/Applications"
-          cp -R expanded/octo-component.pkg/Payload/Applications/Octo.app "$fake/Applications/Octo.app"
+          cp -R expanded/octo-component.pkg/Payload/. "$fake/Applications/"
 
           HOME="$fake" expanded/octo-component.pkg/Scripts/postinstall
 

--- a/.github/workflows/macos-installer-check.yml
+++ b/.github/workflows/macos-installer-check.yml
@@ -108,14 +108,21 @@ jobs:
 
           HOME="$fake" expanded/octo-component.pkg/Scripts/postinstall
 
+          # The bundled CLI must be present and runnable inside the installed app.
           bin="$fake/Applications/Octo.app/Contents/Resources/octo"
           test -x "$bin" || { echo "octo CLI missing at $bin"; exit 1; }
           HOME="$fake" "$bin" version
-          grep -qF 'added by the octo installer' "$fake/.zprofile" || { echo "PATH not updated in .zprofile"; exit 1; }
-          # zsh's non-login interactive shells (e.g. VS Code's terminal) read
-          # only .zshrc, so it must get the PATH line too.
-          grep -qF 'added by the octo installer' "$fake/.zshrc" || { echo "PATH not updated in .zshrc"; exit 1; }
           test -x "$fake/.octo/uninstall.sh" || { echo "uninstall.sh missing"; exit 1; }
+          # postinstall no longer touches PATH — the app seeds ~/.local/bin/octo
+          # and edits the shell rc on first launch (ensureBundledOcto), which is
+          # covered by the Go unit tests. A headless CI runner never launches the
+          # GUI, so there is nothing to assert about PATH here. Guard the split:
+          # postinstall must NOT write a PATH line itself.
+          for rc in .zshrc .zprofile .bash_profile .profile; do
+            if [ -f "$fake/$rc" ] && grep -qF 'added by the octo installer' "$fake/$rc"; then
+              echo "postinstall should not write PATH ($rc); the app does that on launch"; exit 1
+            fi
+          done
           # The desktop app replaces the old serve-on-login flow: no LaunchAgent.
           test ! -f "$fake/Library/LaunchAgents/dev.octo-agent.serve.plist" || { echo "unexpected leftover serve LaunchAgent"; exit 1; }
 

--- a/.github/workflows/macos-installer-check.yml
+++ b/.github/workflows/macos-installer-check.yml
@@ -111,7 +111,10 @@ jobs:
           bin="$fake/Applications/Octo.app/Contents/Resources/octo"
           test -x "$bin" || { echo "octo CLI missing at $bin"; exit 1; }
           HOME="$fake" "$bin" version
-          grep -qF 'added by the octo installer' "$fake/.zprofile" || { echo "PATH not updated"; exit 1; }
+          grep -qF 'added by the octo installer' "$fake/.zprofile" || { echo "PATH not updated in .zprofile"; exit 1; }
+          # zsh's non-login interactive shells (e.g. VS Code's terminal) read
+          # only .zshrc, so it must get the PATH line too.
+          grep -qF 'added by the octo installer' "$fake/.zshrc" || { echo "PATH not updated in .zshrc"; exit 1; }
           test -x "$fake/.octo/uninstall.sh" || { echo "uninstall.sh missing"; exit 1; }
           # The desktop app replaces the old serve-on-login flow: no LaunchAgent.
           test ! -f "$fake/Library/LaunchAgents/dev.octo-agent.serve.plist" || { echo "unexpected leftover serve LaunchAgent"; exit 1; }

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -74,8 +74,8 @@ func main() {
 	// that need Python work even for a standalone download (no installer).
 	ensureBundledUv()
 
-	// Seed the octo CLI to ~/.local/bin on Linux so a terminal has `octo` like
-	// the mac/win installers provide. May update settings.SeededOctoVersion, so
+	// Seed the octo CLI to ~/.local/bin (macOS + Linux) so a terminal has `octo`,
+	// and on macOS put that dir on PATH. May update settings.SeededOctoVersion, so
 	// it runs before the bridge takes its copy of settings below.
 	ensureBundledOcto(&settings)
 

--- a/cmd/octo-desktop/octo_cli.go
+++ b/cmd/octo-desktop/octo_cli.go
@@ -46,23 +46,27 @@ func ensureBundledOcto(settings *desktopSettings) {
 	cur := version.Version
 
 	_, statErr := os.Stat(target)
-	if !shouldSeedOcto(statErr == nil, settings.SeededOctoVersion, cur) {
-		return
+	if shouldSeedOcto(statErr == nil, settings.SeededOctoVersion, cur) {
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err == nil {
+			if err := copyExecutable(src, target); err == nil {
+				settings.SeededOctoVersion = cur
+				_ = saveDesktopSettings(*settings)
+			}
+			// A copy failure leaves SeededOctoVersion unchanged so the next
+			// launch retries.
+		}
 	}
 
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-		return
-	}
-	if err := copyExecutable(src, target); err != nil {
-		return // leave SeededOctoVersion unchanged so the next launch retries
-	}
-	// macOS: put ~/.local/bin on PATH via the shell rc files. Linux's XDG bin
-	// dir is already on PATH, so it needs no rc edit.
+	// Put ~/.local/bin on PATH (macOS only — Linux's XDG bin dir is already
+	// there). This is deliberately NOT gated on the seed above: it's idempotent
+	// and runs whenever the target CLI exists, so an rc write that failed on a
+	// previous launch self-heals on the next one instead of being stranded by a
+	// recorded SeededOctoVersion. No-op when the file already has the right line.
 	if runtime.GOOS == "darwin" {
-		ensureDirOnPath(home, filepath.Dir(target))
+		if _, err := os.Stat(target); err == nil {
+			ensureDirOnPath(home, filepath.Dir(target))
+		}
 	}
-	settings.SeededOctoVersion = cur
-	_ = saveDesktopSettings(*settings)
 }
 
 // shouldSeedOcto decides whether to (re)write ~/.local/bin/octo. Fresh target:
@@ -82,20 +86,27 @@ func shouldSeedOcto(targetExists bool, seededVer, curVer string) bool {
 // ensureDirOnPath makes dir reachable from the shell by adding an `export PATH`
 // line to the user's rc files. zsh (the macOS default) reads .zshrc for every
 // interactive shell — login or not — so it's the reliable target; .zprofile
-// (login shells), .bash_profile, and .profile cover the rest. Each write heals
-// any previous octo-installer line first, so an upgrade whose CLI path changed
-// doesn't leave a stale, dead entry. Best-effort: unreadable/unwritable rc
-// files are skipped.
+// (login shells) and .profile (sh, and bash login when no .bash_profile) cover
+// the rest. .bash_profile is written only when it already exists: creating it
+// would make bash login shells read it INSTEAD of ~/.profile, silently shadowing
+// the user's existing setup there. Each write self-heals a prior octo-installer
+// line, so an upgrade whose CLI path changed doesn't leave a stale, dead entry.
 func ensureDirOnPath(home, dir string) {
 	line := fmt.Sprintf(`export PATH="%s:$PATH"  %s`, dir, octoInstallerMarker)
-	for _, name := range []string{".zshrc", ".zprofile", ".bash_profile", ".profile"} {
-		writeMarkedPathLine(filepath.Join(home, name), line)
+	writeMarkedPathLine(filepath.Join(home, ".zshrc"), line)
+	writeMarkedPathLine(filepath.Join(home, ".zprofile"), line)
+	writeMarkedPathLine(filepath.Join(home, ".profile"), line)
+	if bp := filepath.Join(home, ".bash_profile"); fileExists(bp) {
+		writeMarkedPathLine(bp, line)
 	}
 }
 
 // writeMarkedPathLine rewrites rc with any prior octo-installer line removed and
 // the current one appended, creating the file if absent. Removing first keeps
-// the entry idempotent and self-healing across upgrades.
+// the entry idempotent and self-healing across upgrades. The write goes through
+// a temp file + rename so an interrupted/failed write can't truncate the user's
+// rc file. A no-op when the file already has exactly the desired content, so
+// running this on every launch doesn't churn the file.
 func writeMarkedPathLine(rc, line string) {
 	data, err := os.ReadFile(rc)
 	if err != nil && !os.IsNotExist(err) {
@@ -116,5 +127,31 @@ func writeMarkedPathLine(rc, line string) {
 		body += "\n"
 	}
 	body += line + "\n"
-	_ = os.WriteFile(rc, []byte(body), 0o644)
+	if string(data) == body {
+		return // already correct — don't rewrite on every launch
+	}
+	_ = writeFileAtomic(rc, []byte(body), 0o644)
+}
+
+// writeFileAtomic writes data to path via a temp file + rename, so a crash or
+// error mid-write can't leave a truncated file behind. The PID in the temp name
+// keeps two app instances (launched before the single-instance lock is taken)
+// from colliding on the same temp path.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	tmp := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
+	if err := os.WriteFile(tmp, data, perm); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// fileExists reports whether path exists and is a regular file (not a dir).
+func fileExists(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && !fi.IsDir()
 }

--- a/cmd/octo-desktop/octo_cli.go
+++ b/cmd/octo-desktop/octo_cli.go
@@ -1,29 +1,38 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/open-octo/octo-agent/internal/version"
 )
 
+// octoInstallerMarker tags the PATH line this app adds to shell rc files so a
+// later launch can find and refresh it and the uninstaller can strip it. It
+// MUST stay byte-identical to the marker the macOS pkg's uninstall.sh greps for
+// (packaging/macos/scripts/postinstall) — they coordinate across shell and Go.
+const octoInstallerMarker = "# added by the octo installer"
+
 // ensureBundledOcto seeds the octo CLI bundled with the app to ~/.local/bin/octo
-// on Linux, so a terminal has `octo` after installing the desktop app — matching
-// the macOS and Windows installers, which put the CLI on PATH themselves. The
-// AppImage has no installer step to do that, so the app does it on launch.
+// so a terminal has `octo` after installing the desktop app, on macOS and Linux
+// alike. Keeping the CLI at a stable, writable path (rather than inside the
+// app) means `octo upgrade` can replace it in place without touching the signed
+// .app bundle, and the same path is used on both platforms.
 //
-// ~/.local/bin is the XDG user bin dir, already on PATH on current desktops, so
-// no shell rc is touched. mac/win are skipped: their installers own the CLI and
-// its PATH entry, and on macOS the bundled octo lives inside the signed .app.
+// On macOS the shell needs a PATH entry — ~/.local/bin is not on the default
+// PATH there. On Linux it is the XDG user bin dir, already on PATH, so no rc
+// file is touched. Windows keeps its own installer-managed CLI on PATH.
 //
 // Refresh-on-upgrade without clobbering the user: settings.SeededOctoVersion
 // records what we last wrote. An octo already at the target with no matching
 // record is the user's own (or hand-placed) and is left untouched; one we
 // seeded is replaced when the app version moved on. Best-effort throughout.
 func ensureBundledOcto(settings *desktopSettings) {
-	if runtime.GOOS != "linux" {
-		return
+	if runtime.GOOS == "windows" {
+		return // the Windows installer owns the CLI and its PATH entry
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -47,6 +56,11 @@ func ensureBundledOcto(settings *desktopSettings) {
 	if err := copyExecutable(src, target); err != nil {
 		return // leave SeededOctoVersion unchanged so the next launch retries
 	}
+	// macOS: put ~/.local/bin on PATH via the shell rc files. Linux's XDG bin
+	// dir is already on PATH, so it needs no rc edit.
+	if runtime.GOOS == "darwin" {
+		ensureDirOnPath(home, filepath.Dir(target))
+	}
 	settings.SeededOctoVersion = cur
 	_ = saveDesktopSettings(*settings)
 }
@@ -63,4 +77,44 @@ func shouldSeedOcto(targetExists bool, seededVer, curVer string) bool {
 		return false
 	}
 	return seededVer != curVer
+}
+
+// ensureDirOnPath makes dir reachable from the shell by adding an `export PATH`
+// line to the user's rc files. zsh (the macOS default) reads .zshrc for every
+// interactive shell — login or not — so it's the reliable target; .zprofile
+// (login shells), .bash_profile, and .profile cover the rest. Each write heals
+// any previous octo-installer line first, so an upgrade whose CLI path changed
+// doesn't leave a stale, dead entry. Best-effort: unreadable/unwritable rc
+// files are skipped.
+func ensureDirOnPath(home, dir string) {
+	line := fmt.Sprintf(`export PATH="%s:$PATH"  %s`, dir, octoInstallerMarker)
+	for _, name := range []string{".zshrc", ".zprofile", ".bash_profile", ".profile"} {
+		writeMarkedPathLine(filepath.Join(home, name), line)
+	}
+}
+
+// writeMarkedPathLine rewrites rc with any prior octo-installer line removed and
+// the current one appended, creating the file if absent. Removing first keeps
+// the entry idempotent and self-healing across upgrades.
+func writeMarkedPathLine(rc, line string) {
+	data, err := os.ReadFile(rc)
+	if err != nil && !os.IsNotExist(err) {
+		return
+	}
+	var kept []string
+	for _, l := range strings.Split(string(data), "\n") {
+		if !strings.Contains(l, octoInstallerMarker) {
+			kept = append(kept, l)
+		}
+	}
+	// Drop trailing blank lines so repeated writes don't accumulate them.
+	for len(kept) > 0 && strings.TrimSpace(kept[len(kept)-1]) == "" {
+		kept = kept[:len(kept)-1]
+	}
+	body := strings.Join(kept, "\n")
+	if body != "" {
+		body += "\n"
+	}
+	body += line + "\n"
+	_ = os.WriteFile(rc, []byte(body), 0o644)
 }

--- a/cmd/octo-desktop/octo_cli_test.go
+++ b/cmd/octo-desktop/octo_cli_test.go
@@ -37,11 +37,16 @@ func TestShouldSeedOcto(t *testing.T) {
 // it pointed at) rather than accumulate, and never touch the user's own lines.
 func TestEnsureDirOnPath_SelfHealsAndPreservesUserLines(t *testing.T) {
 	home := t.TempDir()
-	// A pre-existing rc with the user's own PATH line and a STALE octo line
+	// A pre-existing .zshrc with the user's own PATH line and a STALE octo line
 	// pointing at a long-gone location (mirrors the real bug on upgrade).
 	stale := `export PATH="/opt/homebrew/bin:$PATH"
 export PATH="` + home + `/Library/Application Support/octo/bin:$PATH"  ` + octoInstallerMarker + "\n"
 	if err := os.WriteFile(filepath.Join(home, ".zshrc"), []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-create .bash_profile so it's a write target (it's only touched when it
+	// already exists — see the no-create case below).
+	if err := os.WriteFile(filepath.Join(home, ".bash_profile"), nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -50,7 +55,9 @@ export PATH="` + home + `/Library/Application Support/octo/bin:$PATH"  ` + octoI
 	ensureDirOnPath(home, dir) // idempotent: a second launch must not duplicate
 
 	want := `export PATH="` + dir + `:$PATH"  ` + octoInstallerMarker
-	for _, name := range []string{".zshrc", ".zprofile", ".bash_profile", ".profile"} {
+	// .zshrc/.zprofile/.profile are always written; .bash_profile because it
+	// existed here.
+	for _, name := range []string{".zshrc", ".zprofile", ".profile", ".bash_profile"} {
 		data, err := os.ReadFile(filepath.Join(home, name))
 		if err != nil {
 			t.Fatalf("read %s: %v", name, err)
@@ -70,5 +77,22 @@ export PATH="` + home + `/Library/Application Support/octo/bin:$PATH"  ` + octoI
 	zshrc, _ := os.ReadFile(filepath.Join(home, ".zshrc"))
 	if !strings.Contains(string(zshrc), `/opt/homebrew/bin`) {
 		t.Errorf(".zshrc: user's own PATH line was dropped:\n%s", zshrc)
+	}
+}
+
+// TestEnsureDirOnPath_DoesNotCreateBashProfile guards the footgun: creating
+// ~/.bash_profile when it's absent makes bash login shells stop reading
+// ~/.profile, silently shadowing the user's setup. When the user has no
+// .bash_profile, we must not create one — .profile covers bash login instead.
+func TestEnsureDirOnPath_DoesNotCreateBashProfile(t *testing.T) {
+	home := t.TempDir()
+	ensureDirOnPath(home, filepath.Join(home, ".local", "bin"))
+
+	if _, err := os.Stat(filepath.Join(home, ".bash_profile")); !os.IsNotExist(err) {
+		t.Errorf(".bash_profile should not be created when absent (err=%v)", err)
+	}
+	// .profile is still written, so bash login shells reach octo through it.
+	if _, err := os.Stat(filepath.Join(home, ".profile")); err != nil {
+		t.Errorf(".profile should have been written: %v", err)
 	}
 }

--- a/cmd/octo-desktop/octo_cli_test.go
+++ b/cmd/octo-desktop/octo_cli_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestShouldSeedOcto(t *testing.T) {
 	tests := []struct {
@@ -23,5 +28,47 @@ func TestShouldSeedOcto(t *testing.T) {
 					tt.targetExists, tt.seededVer, tt.curVer, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestEnsureDirOnPath_SelfHealsAndPreservesUserLines guards the PATH-writing
+// that moved from the shell postinstall into the app: it must add the dir to
+// each rc file exactly once, replace a stale octo-installer line (whatever dir
+// it pointed at) rather than accumulate, and never touch the user's own lines.
+func TestEnsureDirOnPath_SelfHealsAndPreservesUserLines(t *testing.T) {
+	home := t.TempDir()
+	// A pre-existing rc with the user's own PATH line and a STALE octo line
+	// pointing at a long-gone location (mirrors the real bug on upgrade).
+	stale := `export PATH="/opt/homebrew/bin:$PATH"
+export PATH="` + home + `/Library/Application Support/octo/bin:$PATH"  ` + octoInstallerMarker + "\n"
+	if err := os.WriteFile(filepath.Join(home, ".zshrc"), []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(home, ".local", "bin")
+	ensureDirOnPath(home, dir)
+	ensureDirOnPath(home, dir) // idempotent: a second launch must not duplicate
+
+	want := `export PATH="` + dir + `:$PATH"  ` + octoInstallerMarker
+	for _, name := range []string{".zshrc", ".zprofile", ".bash_profile", ".profile"} {
+		data, err := os.ReadFile(filepath.Join(home, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		body := string(data)
+		if n := strings.Count(body, octoInstallerMarker); n != 1 {
+			t.Errorf("%s: got %d marker lines, want 1:\n%s", name, n, body)
+		}
+		if !strings.Contains(body, want) {
+			t.Errorf("%s: missing current PATH line %q:\n%s", name, want, body)
+		}
+		if strings.Contains(body, "Library/Application Support/octo/bin") {
+			t.Errorf("%s: stale octo line not healed:\n%s", name, body)
+		}
+	}
+	// The user's own line survives in the file that had it.
+	zshrc, _ := os.ReadFile(filepath.Join(home, ".zshrc"))
+	if !strings.Contains(string(zshrc), `/opt/homebrew/bin`) {
+		t.Errorf(".zshrc: user's own PATH line was dropped:\n%s", zshrc)
 	}
 }

--- a/cmd/octo-desktop/settings.go
+++ b/cmd/octo-desktop/settings.go
@@ -19,8 +19,8 @@ type desktopSettings struct {
 	// closing the window shouldn't drop a VS Code / phone client's backend.
 	KeepRunningInBackground bool `json:"keep_running_in_background"`
 	// SeededOctoVersion records the version of the octo CLI this app last seeded
-	// to ~/.local/bin (Linux only — mac/win ship the CLI through their
-	// installers). It scopes the refresh-on-upgrade: an octo on ~/.local/bin
+	// to ~/.local/bin (macOS + Linux; Windows ships the CLI through its
+	// installer). It scopes the refresh-on-upgrade: an octo on ~/.local/bin
 	// with no matching record here is the user's own and is never overwritten.
 	SeededOctoVersion string `json:"seeded_octo_version,omitempty"`
 }

--- a/landing/install.sh
+++ b/landing/install.sh
@@ -112,13 +112,12 @@ case ":$PATH:" in
     shell_name=$(basename "${SHELL:-}" 2>/dev/null || echo "")
     case "$shell_name" in
       zsh)
-        # macOS Terminal opens zsh as a login shell → .zprofile takes effect
-        # Linux interactive zsh → .zshrc
-        if [ "$os" = "darwin" ]; then
-          rc="$HOME/.zprofile"
-        else
-          rc="$HOME/.zshrc"
-        fi
+        # .zshrc is read by every interactive zsh — login or not. macOS Terminal
+        # opens a login shell (which also reads .zshrc), while VS Code's terminal
+        # and other non-login shells read only .zshrc, never .zprofile. So .zshrc
+        # is the reliable target on both platforms; picking .zprofile on macOS
+        # would leave octo off PATH in non-login shells.
+        rc="$HOME/.zshrc"
         ;;
       bash)
         # macOS bash as login → .bash_profile; Linux → .bashrc

--- a/packaging/macos/build.sh
+++ b/packaging/macos/build.sh
@@ -32,13 +32,17 @@ OCTO_CLI="$SourceDir/octo" UV_BINARY="$uv_arg" \
   sh "$repo_root/scripts/package-desktop-macos.sh" "$AppVersion"
 
 # Payload: Octo.app under the user's Applications (currentUserHome domain, so
-# --install-location is relative to the home dir).
+# --install-location is relative to the home dir). --root is the tree whose
+# CONTENTS land at --install-location, so it must be the directory that *holds*
+# Octo.app — not its parent. Rooting one level up ("$work/payload", which
+# contains Applications/Octo.app) plus --install-location 'Applications' would
+# nest it as ~/Applications/Applications/Octo.app.
 payload="$work/payload/Applications"
 mkdir -p "$payload"
 cp -R "$repo_root/Octo.app" "$payload/Octo.app"
 
 pkgbuild \
-  --root "$work/payload" \
+  --root "$payload" \
   --scripts "$script_dir/scripts" \
   --identifier dev.octo-agent.octo \
   --version "$AppVersion" \

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -10,8 +10,13 @@ app_bundle="$HOME/Applications/Octo.app"
 res="$app_bundle/Contents/Resources"
 marker="# added by the octo installer"
 
-# Put the bundled octo CLI on PATH. .zprofile covers the default zsh login
-# shell; the others cover bash / plain sh.
+# Put the bundled octo CLI on PATH. zsh (the macOS default) reads .zshrc for
+# every INTERACTIVE shell whether or not it's a login shell — VS Code's
+# integrated terminal and many others open non-login interactive shells that
+# read only .zshrc, never .zprofile — so .zshrc is the reliable target. We also
+# write .zprofile (login shells) and .bash_profile / .profile (bash, plain sh).
+# A login+interactive shell reads both zsh files and gets a harmless duplicate
+# PATH entry.
 add_to_path() {
   rc="$1"
   [ -f "$rc" ] || touch "$rc"
@@ -23,6 +28,7 @@ add_to_path() {
   grep -qF "$marker" "$rc" 2>/dev/null && sed -i '' "/$marker/d" "$rc"
   printf '\nexport PATH="%s:$PATH"  %s\n' "$res" "$marker" >> "$rc"
 }
+add_to_path "$HOME/.zshrc"
 add_to_path "$HOME/.zprofile"
 add_to_path "$HOME/.bash_profile"
 add_to_path "$HOME/.profile"
@@ -53,7 +59,7 @@ cat > "$config_dir/uninstall.sh" <<UNINSTALL
 #!/bin/sh
 set -eu
 rm -rf "$app_bundle"
-for rc in "\$HOME/.zprofile" "\$HOME/.bash_profile" "\$HOME/.profile"; do
+for rc in "\$HOME/.zshrc" "\$HOME/.zprofile" "\$HOME/.bash_profile" "\$HOME/.profile"; do
   [ -f "\$rc" ] && sed -i '' '/$marker/d' "\$rc"
 done
 echo "Octo uninstalled (your ~/.octo data was left intact)."

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -15,7 +15,12 @@ marker="# added by the octo installer"
 add_to_path() {
   rc="$1"
   [ -f "$rc" ] || touch "$rc"
-  grep -qF "$marker" "$rc" 2>/dev/null && return
+  # Drop any previous octo-installer line before writing the current one. The
+  # CLI location can change between releases; an early "already present" bail
+  # would leave a stale entry pointing at a directory that no longer exists,
+  # silently keeping the CLI off PATH after an upgrade. Deleting first makes the
+  # upgrade self-heal. (sed -i '' matches the uninstall helper below.)
+  grep -qF "$marker" "$rc" 2>/dev/null && sed -i '' "/$marker/d" "$rc"
   printf '\nexport PATH="%s:$PATH"  %s\n' "$res" "$marker" >> "$rc"
 }
 add_to_path "$HOME/.zprofile"

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -1,37 +1,21 @@
 #!/bin/sh
-# Runs as the installing user (currentUserHome domain — no root, no sudo). Puts
-# the octo CLI (bundled inside Octo.app/Contents/Resources) on PATH, seeds
-# ~/.octo/bin/uv + a fresh config, writes an uninstall helper, and opens the
-# app. The desktop app replaces the old "start `octo serve -d` on login + open
-# the browser dashboard" onboarding — that surrogate GUI is now a real app.
+# Runs as the installing user (currentUserHome domain — no root, no sudo). Seeds
+# ~/.octo/bin/uv + a fresh config, writes an uninstall helper, and opens the app.
+#
+# The octo CLI is put on PATH by the app itself on first launch, not here: its
+# ensureBundledOcto (cmd/octo-desktop/octo_cli.go) copies the bundled CLI to
+# ~/.local/bin/octo and adds that dir to PATH via the shell rc files — the same
+# path used on Linux. Keeping the CLI at a stable, writable location (rather than
+# inside the app) lets `octo upgrade` replace it without modifying the signed
+# .app bundle. The desktop app replaces the old "start `octo serve -d` on login +
+# open the browser dashboard" onboarding — that surrogate GUI is now a real app.
 set -eu
 
 app_bundle="$HOME/Applications/Octo.app"
 res="$app_bundle/Contents/Resources"
+# Kept byte-identical to octoInstallerMarker in cmd/octo-desktop/octo_cli.go: the
+# app writes the PATH line, this uninstaller strips it.
 marker="# added by the octo installer"
-
-# Put the bundled octo CLI on PATH. zsh (the macOS default) reads .zshrc for
-# every INTERACTIVE shell whether or not it's a login shell — VS Code's
-# integrated terminal and many others open non-login interactive shells that
-# read only .zshrc, never .zprofile — so .zshrc is the reliable target. We also
-# write .zprofile (login shells) and .bash_profile / .profile (bash, plain sh).
-# A login+interactive shell reads both zsh files and gets a harmless duplicate
-# PATH entry.
-add_to_path() {
-  rc="$1"
-  [ -f "$rc" ] || touch "$rc"
-  # Drop any previous octo-installer line before writing the current one. The
-  # CLI location can change between releases; an early "already present" bail
-  # would leave a stale entry pointing at a directory that no longer exists,
-  # silently keeping the CLI off PATH after an upgrade. Deleting first makes the
-  # upgrade self-heal. (sed -i '' matches the uninstall helper below.)
-  grep -qF "$marker" "$rc" 2>/dev/null && sed -i '' "/$marker/d" "$rc"
-  printf '\nexport PATH="%s:$PATH"  %s\n' "$res" "$marker" >> "$rc"
-}
-add_to_path "$HOME/.zshrc"
-add_to_path "$HOME/.zprofile"
-add_to_path "$HOME/.bash_profile"
-add_to_path "$HOME/.profile"
 
 # Seed ~/.octo/bin/uv from the bundle so the CLI has Python tooling immediately
 # (the app also self-provisions this on first launch). octo-managed binary, so


### PR DESCRIPTION
Makes the octo CLI reliably reachable on PATH after installing on macOS, and unifies where the CLI lives across install methods. (Squash-merges to one commit; intermediate commits show the evolution.)

## What was broken

1. **Double-nested install location.** `build.sh` ran `pkgbuild --root "$work/payload"` (tree: `payload/Applications/Octo.app`) with `--install-location Applications`, so the app installed to `~/Applications/Applications/Octo.app`. `postinstall` assumes `$HOME/Applications/Octo.app`, so everything it derived was wrong — **even a fresh install left the CLI off PATH**.

2. **CLI inside the signed bundle.** The CLI lived at `Octo.app/Contents/Resources/octo` with PATH pointing into it. `octo upgrade` would rewrite that file and **break the .app signature**, and the path differed from Linux (`~/.local/bin`) and the standalone script (`/usr/local/bin`).

3. **zsh PATH gap.** PATH was written to `.zprofile` only; zsh non-login interactive shells (VS Code's terminal, tmux) read only `.zshrc`, missing `octo`.

## What changed

- **build.sh** — root `pkgbuild` at the directory that holds `Octo.app`, so it installs to `~/Applications/Octo.app`.
- **CLI provisioning converged onto the Linux model.** `ensureBundledOcto` (Go, `cmd/octo-desktop/octo_cli.go`) now runs on macOS too: on first launch it copies the bundled CLI to `~/.local/bin/octo` and — macOS only, since `~/.local/bin` isn't on the default PATH there — adds that dir to PATH via `.zshrc`/`.zprofile`/`.bash_profile`/`.profile`, self-healing any prior octo-installer line. `octo upgrade` now swaps a plain file, never the signed bundle. mac and Linux share one path.
- **postinstall** no longer touches PATH (the app owns it). It still seeds uv, writes config + the uninstall helper, and opens the app. The uninstaller strips the (now app-written) PATH line via a marker kept byte-identical between the Go writer and the shell uninstaller.
- **install.sh** (standalone `curl|sh`) — target `.zshrc` for zsh so non-login shells see `octo` (same zsh gap). This installer keeps its `/usr/local/bin` default by design; it is a separate distribution path.
- **CI** (`macos-installer-check.yml`) — fixed the blind spot that let the double-nest ship (the simulation now copies the payload *contents* into the install-location, so a reintroduced nest fails), asserts payload is `Payload/Octo.app`, and asserts postinstall does NOT write PATH. The seed/rc logic is covered by Go unit tests (`shouldSeedOcto`, `ensureDirOnPath`).

## Deliberately out of scope
- **Standalone script stays at `/usr/local/bin`.** Full string-identical unification with the pkg (`~/.local/bin`) would move existing script users' binary — not worth it. The two use distinct markers so neither manages the other's PATH line.
- **A machine with the old nested `~/Applications/Applications/Octo.app`** self-heals its PATH on the next install of a fixed build; the orphan bundle is left in place.
- **Windows** keeps its installer-managed CLI at `{app}` on PATH (no `~/.local/bin` convention there).

## Verification (real hardware, macOS)
- Built `octo-setup.pkg`; expanded → payload at `Payload/Octo.app`, `install-location=Applications`; simulated install → `~/Applications/Octo.app`, no nesting.
- postinstall writes no PATH line yet still seeds uv/config/uninstall; the uninstaller strips an app-written marker line while preserving the user's own.
- Go unit tests: `ensureDirOnPath` adds the dir once per rc file, heals a stale line, preserves user lines; `shouldSeedOcto` matrix.
- `go build`/`vet`/`test`, `gofmt`, `sh -n` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)