### PR TITLE
fix(server): always allow the Obsidian desktop origin

### DIFF
--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -155,6 +155,25 @@ func isVSCodeWebviewOrigin(origin string) bool {
 	return err == nil && u.Scheme == "vscode-webview"
 }
 
+// obsidianDesktopOrigin is the fixed Origin the Obsidian desktop app's
+// renderer sends (app://obsidian.md). Unlike vscode-webview — a per-window
+// scheme with a rotating uuid host — it is a single stable literal, so it is
+// matched exactly rather than by scheme.
+const obsidianDesktopOrigin = "app://obsidian.md"
+
+// isObsidianDesktopOrigin reports whether origin was sent by the Obsidian
+// desktop app. Baking this allowance into the server predicate — rather than
+// relying on a --cors default that only cmd/octo applies — keeps every server
+// entry point accepting the Obsidian plugin. cmd/octo-desktop builds a Config
+// without CORSOrigins, so without this the desktop hub rejected app://
+// obsidian.md with "forbidden origin" while octo serve accepted it. Same
+// hardening as isVSCodeWebviewOrigin: browsers control the Origin header, so a
+// hostile web page cannot forge this scheme, and both auth call sites sit
+// behind requireAuth's loopback gate.
+func isObsidianDesktopOrigin(origin string) bool {
+	return origin == obsidianDesktopOrigin
+}
+
 // hostAllowed is the DNS-rebinding gate for the loopback exemption: the
 // Host header must name the local machine or a --cors allowlisted host. A
 // rebound page's request reaches 127.0.0.1 but carries Host: attacker.com.
@@ -188,7 +207,7 @@ func (s *Server) originAllowed(origin string) bool {
 	if err != nil || u.Host == "" {
 		return false
 	}
-	if u.Scheme == "vscode-webview" || isLocalName(canonicalHost(u.Host)) {
+	if u.Scheme == "vscode-webview" || isObsidianDesktopOrigin(origin) || isLocalName(canonicalHost(u.Host)) {
 		return true
 	}
 	for _, o := range s.cfg.CORSOrigins {

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -189,6 +189,30 @@ func TestRequireAuth_VSCodeWebviewOrigin(t *testing.T) {
 	}
 }
 
+// TestRequireAuth_ObsidianDesktopOrigin covers the Obsidian desktop plugin's
+// default local path: a loopback request carrying the fixed app://obsidian.md
+// Origin passes the exemption with no access key and no --cors flag, so the
+// desktop hub — which builds a Config without CORSOrigins — accepts it just
+// like the CLI's octo serve does. A lookalike foreign origin that merely
+// prefixes the string is still rejected.
+func TestRequireAuth_ObsidianDesktopOrigin(t *testing.T) {
+	srv := mustServer(t, Config{AccessKey: testAccessKey})
+
+	w := authRequest(t, srv, http.MethodGet,
+		"http://127.0.0.1:8080/api/sessions", "127.0.0.1:50000",
+		map[string]string{"Origin": "app://obsidian.md"})
+	if w.Code != http.StatusOK {
+		t.Errorf("obsidian desktop origin: got %d, want 200", w.Code)
+	}
+
+	w = authRequest(t, srv, http.MethodGet,
+		"http://127.0.0.1:8080/api/sessions", "127.0.0.1:50000",
+		map[string]string{"Origin": "app://obsidian.md.evil.com"})
+	if w.Code != http.StatusForbidden {
+		t.Errorf("obsidian lookalike origin: got %d, want 403", w.Code)
+	}
+}
+
 func TestRequireAuth_CORSWildcardNeverWidensGates(t *testing.T) {
 	srv := mustServer(t, Config{AccessKey: testAccessKey, CORSOrigins: []string{"*"}})
 
@@ -387,6 +411,10 @@ func TestWSCheckOrigin(t *testing.T) {
 		// A spoofed Host under the vscode-webview name (not the scheme) must
 		// not pass — only url.Parse's Scheme grants the exemption.
 		{"vscode webview lookalike host", mkReq("127.0.0.1:8080", "http://vscode-webview.evil.com", ""), false},
+		{"obsidian desktop origin", mkReq("127.0.0.1:8080", "app://obsidian.md", ""), true},
+		// A lookalike that only prefixes the fixed literal must not pass — the
+		// match is exact, not a substring/host check.
+		{"obsidian lookalike origin", mkReq("127.0.0.1:8080", "app://obsidian.md.evil.com", ""), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -884,9 +884,10 @@ func (s *Server) registerRoutes() {
 }
 
 // corsMiddleware wraps the mux with CORS headers when configured, plus a
-// built-in allowance for VS Code webview origins (isVSCodeWebviewOrigin) so
-// the octo VS Code extension's REST calls work without a --cors flag. That
-// case can't reuse the CORSOrigins-driven fast path below, so the middleware
+// built-in allowance for VS Code webview origins (isVSCodeWebviewOrigin) and
+// the Obsidian desktop origin (isObsidianDesktopOrigin) so the octo VS Code
+// extension's and Obsidian plugin's REST calls work without a --cors flag.
+// That case can't reuse the CORSOrigins-driven fast path below, so the middleware
 // now always runs rather than short-circuiting to next when CORSOrigins is
 // empty; a bare OPTIONS request with no Origin header and no --cors
 // configured now gets 204 instead of falling through to the mux, which is
@@ -894,7 +895,7 @@ func (s *Server) registerRoutes() {
 func (s *Server) corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
-		allowed := isVSCodeWebviewOrigin(origin)
+		allowed := isVSCodeWebviewOrigin(origin) || isObsidianDesktopOrigin(origin)
 		wildcard := false
 		for _, o := range s.cfg.CORSOrigins {
 			if o == "*" {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -415,6 +415,48 @@ func TestCORS_VSCodeWebview(t *testing.T) {
 	}
 }
 
+// TestCORS_ObsidianDesktop covers the Obsidian desktop plugin's default local
+// path: its REST calls carry Origin app://obsidian.md and must get a reflected
+// Access-Control-Allow-Origin without any --cors flag configured.
+func TestCORS_ObsidianDesktop(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/health", nil)
+	req.Header.Set("Origin", "app://obsidian.md")
+	w := httptest.NewRecorder()
+	serveLoopback(srv.http.Handler, w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "app://obsidian.md" {
+		t.Fatalf("CORS origin = %q, want the obsidian desktop origin reflected", got)
+	}
+}
+
+// TestCORS_ObsidianLookalikeRejected asserts the allowance is scoped to the
+// exact app://obsidian.md literal, not any origin that merely prefixes it.
+func TestCORS_ObsidianLookalikeRejected(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	req.Header.Set("Origin", "app://obsidian.md.evil.com")
+	w := httptest.NewRecorder()
+	serveLoopback(srv.http.Handler, w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("expected no CORS header for lookalike origin, got %q", got)
+	}
+}
+
 // TestCORS_VSCodeWebviewLookalikeRejected asserts the allowance is scoped to
 // the vscode-webview: URL scheme, not any origin containing that string.
 func TestCORS_VSCodeWebviewLookalikeRejected(t *testing.T) {


### PR DESCRIPTION
## Problem

The Obsidian **desktop** plugin (Claudian / Octo Agent) can't connect to the local Octo server — every WS/REST call is rejected with `403 {"error":"forbidden origin"}`, surfacing in the plugin as *"Octo Agent is not ready or not connected."*

Obsidian desktop's renderer sends `Origin: app://obsidian.md`. In `originAllowed()`, that origin's host (`obsidian.md`) is not loopback, so it only passes when it's an exact `CORSOrigins` allowlist entry.

- `cmd/octo` (`octo serve`) injects `app://obsidian.md` into `CORSOrigins` by default → **works**.
- `cmd/octo-desktop` constructs `server.New(server.Config{...})` **without** `CORSOrigins` → allowlist empty → **403 for every plugin request**.

So the allowance lived only in the CLI entry point and the desktop hub drifted away from it.

## Fix

Bake the fixed `app://obsidian.md` origin into the server predicate itself, mirroring the existing `isVSCodeWebviewOrigin` allowance, so **every** entry point (CLI, desktop, future) accepts it and the two paths can't drift again:

- `internal/server/auth.go`: add `isObsidianDesktopOrigin` (exact literal match) and wire it into `originAllowed` — the auth gate the plugin's REST + WS (`wsCheckOrigin`) calls go through.
- `internal/server/server.go`: add the same allowance to `corsMiddleware` for CORS-header parity with vscode-webview.

The match is an exact literal, so a lookalike such as `app://obsidian.md.evil.com` is still rejected. As with vscode-webview, browsers control the `Origin` header and both call sites sit behind `requireAuth`'s loopback gate, so this doesn't widen the exemption beyond the existing loopback allowance.

## Tests

- `TestRequireAuth_ObsidianDesktopOrigin`: loopback + `Origin: app://obsidian.md` with **no** `CORSOrigins` (the desktop hub's exact config shape) → 200; lookalike → 403.
- `TestWSCheckOrigin`: added `app://obsidian.md` → allowed, `app://obsidian.md.evil.com` → rejected.
- `go build ./...`, `go test ./internal/server/ ./cmd/octo/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)