### PR TITLE
feat(desktop): report tray update check via toast, not a modal dialog

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -149,6 +149,48 @@ func (b *nativeBridge) Notify(title, body string) {
 	})
 }
 
+// Update-check notifications: the tray "Check for Updates…" flow reports via a
+// toast rather than a modal dialog. The "update available" toast carries an
+// action button; both it and a tap on the body open the download page, routed
+// in main.go's OnNotificationResponse handler by matching updateNotifyCategoryID.
+const (
+	updateNotifyID           = "octo-update-available"
+	updateNotifyCategoryID   = "octo.update-available"
+	updateNotifyOpenActionID = "octo.update-open"
+)
+
+// registerUpdateNotifyCategory registers the category that gives the "update
+// available" toast its "Open Download Page" action button. No-op when the
+// notifier is unavailable (an unbundled dev binary). Register once at startup,
+// after the notification service has started.
+func (b *nativeBridge) registerUpdateNotifyCategory() {
+	if b.notifier == nil {
+		return
+	}
+	_ = b.notifier.RegisterNotificationCategory(notifications.NotificationCategory{
+		ID: updateNotifyCategoryID,
+		Actions: []notifications.NotificationAction{
+			{ID: updateNotifyOpenActionID, Title: L().updOpen},
+		},
+	})
+}
+
+// NotifyUpdateAvailable raises the actionable "update available" toast. Its
+// action button (and a tap on the body) open the download page via the
+// OnNotificationResponse handler. Same best-effort contract as Notify: no-op
+// when the notifier is unavailable.
+func (b *nativeBridge) NotifyUpdateAvailable(title, body string) {
+	if b.notifier == nil {
+		return
+	}
+	_ = b.notifier.SendNotificationWithActions(notifications.NotificationOptions{
+		ID:         updateNotifyID,
+		Title:      title,
+		Body:       body,
+		CategoryID: updateNotifyCategoryID,
+	})
+}
+
 // AutostartEnabled reports whether the app is registered to launch at login.
 func (b *nativeBridge) AutostartEnabled() (bool, error) {
 	st, err := b.app.Autostart.Status()
@@ -283,14 +325,6 @@ func (b *nativeBridge) confirm(title, message, okLabel, cancelLabel string) bool
 // showError shows a modal error dialog with a single OK button.
 func (b *nativeBridge) showError(title, message string) {
 	dlg := b.app.Dialog.Error().SetTitle(title).SetMessage(message)
-	dlg.AddButton(L().dialogOKText).SetAsDefault()
-	dlg.Show()
-}
-
-// showInfo shows a modal informational dialog with a single OK button (the
-// "you're on the latest version" outcome of the tray update check).
-func (b *nativeBridge) showInfo(title, message string) {
-	dlg := b.app.Dialog.Info().SetTitle(title).SetMessage(message)
 	dlg.AddButton(L().dialogOKText).SetAsDefault()
 	dlg.Show()
 }

--- a/cmd/octo-desktop/lang.go
+++ b/cmd/octo-desktop/lang.go
@@ -44,7 +44,6 @@ type uiStrings struct {
 	updLatestFmt    string // "...(v%s)."
 	updAvailableFmt string // "...%s..."
 	updOpen         string
-	updLater        string
 }
 
 var enStrings = uiStrings{
@@ -78,9 +77,8 @@ var enStrings = uiStrings{
 	updTitle:        "Octo",
 	updFailed:       "Couldn't check for updates. Please try again later.",
 	updLatestFmt:    "You're on the latest version (v%s).",
-	updAvailableFmt: "Octo %s is available. Open the download page?",
+	updAvailableFmt: "Octo %s is available.",
 	updOpen:         "Open Download Page",
-	updLater:        "Later",
 }
 
 var zhStrings = uiStrings{
@@ -114,9 +112,8 @@ var zhStrings = uiStrings{
 	updTitle:        "Octo",
 	updFailed:       "检查更新失败,请稍后重试。",
 	updLatestFmt:    "已是最新版本(v%s)。",
-	updAvailableFmt: "Octo %s 已发布,是否打开下载页?",
+	updAvailableFmt: "Octo %s 已发布。",
 	updOpen:         "打开下载页",
-	updLater:        "稍后",
 }
 
 // active holds the current string set. It's an atomic pointer because the tray

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -64,6 +64,18 @@ func isBundled() bool {
 	return strings.Contains(exe, ".app/Contents/MacOS/")
 }
 
+// notificationsAvailable reports whether the OS-native notification service can
+// be created on this platform. macOS's UNUserNotificationCenter needs a bundle
+// identifier, so it only works from a .app bundle; Windows (a registered COM
+// toast activator) and Linux (D-Bus) work for any running executable, so the
+// tray update toast reaches all three platforms uniformly.
+func notificationsAvailable() bool {
+	if runtime.GOOS == "darwin" {
+		return isBundled()
+	}
+	return true
+}
+
 func main() {
 	// Pick the language for native dialogs/tray from the system UI language.
 	applyLang()
@@ -84,11 +96,12 @@ func main() {
 	// quit allowed only when the user opted out of keep-running-in-background.
 	bridge.allowQuit.Store(!settings.KeepRunningInBackground)
 
-	// Native notifications only when bundled (see isBundled): the service needs
-	// a bundle identifier. Registered as a Wails service so its ServiceStartup
-	// runs; the bridge holds it to send notifications the frontend requests.
+	// Native notifications where the platform supports them (see
+	// notificationsAvailable — macOS requires a bundle, Windows/Linux don't).
+	// Registered as a Wails service so its ServiceStartup runs; the bridge holds
+	// it to send notifications the frontend and the tray update check request.
 	var services []application.Service
-	if isBundled() {
+	if notificationsAvailable() {
 		notifier := notifications.New()
 		bridge.notifier = notifier
 		services = append(services, application.NewService(notifier))
@@ -125,9 +138,20 @@ func main() {
 	})
 	bridge.app = app
 
-	// Clicking a notification raises the window — that's its whole point.
+	// Interacting with the "update available" toast opens the download page;
+	// every other notification raises the window. Match the category (which all
+	// three platform notifiers echo back) and then only the "Open" action or a
+	// tap on the body — so dismissing the toast, whatever identifier a platform
+	// reports for that, never opens a browser.
 	if bridge.notifier != nil {
-		bridge.notifier.OnNotificationResponse(func(notifications.NotificationResult) {
+		bridge.notifier.OnNotificationResponse(func(res notifications.NotificationResult) {
+			if res.Response.CategoryID == updateNotifyCategoryID {
+				switch res.Response.ActionIdentifier {
+				case updateNotifyOpenActionID, notifications.DefaultActionIdentifier:
+					_ = bridge.OpenExternal(upgrade.DownloadPageURL)
+				}
+				return
+			}
 			bridge.showWindow()
 		})
 	}
@@ -152,6 +176,10 @@ func main() {
 	// prompt (a modal dialog) can run. Doing it here rather than before Run lets
 	// us ask the user before stopping someone else's backend.
 	app.Event.OnApplicationEvent(events.Common.ApplicationStarted, func(*application.ApplicationEvent) {
+		// Register the update-toast action category once the notification
+		// service has started (Windows/Linux drop the action buttons if a
+		// notification is sent before its category is registered).
+		bridge.registerUpdateNotifyCategory()
 		startHub(app, bridge, settings)
 	})
 
@@ -292,31 +320,28 @@ func startHub(app *application.App, bridge *nativeBridge, settings desktopSettin
 
 // checkForUpdates is the tray "Check for updates…" action. It runs on a
 // background goroutine (never the UI thread) so the network round-trip can't
-// freeze the menu, then reports via a native dialog: a newer release offers to
-// open the download page; already-current shows an info dialog; a failed lookup
-// shows an error. Pure native path — it works with the window closed to the
-// tray, and uses modal dialogs (not Notify) so an unbundled build without the
-// notifications service still surfaces the result.
+// freeze the menu, then reports via a non-intrusive OS toast rather than a
+// modal dialog: a failed lookup and the already-current case are plain toasts;
+// a newer release raises the actionable "update available" toast whose button
+// (and body tap) opens the download page. Toasts are best-effort — on a
+// platform/build without the notification service (an unbundled macOS binary)
+// they no-op, matching the version badge's own silence there.
 func checkForUpdates(bridge *nativeBridge) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	latest, err := upgrade.Check(ctx)
 	if err != nil {
-		bridge.showError(L().updTitle, L().updFailed)
+		bridge.Notify(L().updTitle, L().updFailed)
 		return
 	}
 	current := strings.TrimPrefix(version.Version, "v")
 	// Eligible() != nil means a dev/unbundled build that never claims to be
 	// behind (matching the badge); report status without offering a download.
 	if upgrade.Eligible() != nil || upgrade.CompareVersions(current, latest) >= 0 {
-		bridge.showInfo(L().updTitle, fmt.Sprintf(L().updLatestFmt, current))
+		bridge.Notify(L().updTitle, fmt.Sprintf(L().updLatestFmt, current))
 		return
 	}
-	if bridge.confirm(L().updTitle, fmt.Sprintf(L().updAvailableFmt, latest), L().updOpen, L().updLater) {
-		if err := bridge.OpenExternal(upgrade.DownloadPageURL); err != nil {
-			bridge.showError(L().updTitle, err.Error())
-		}
-	}
+	bridge.NotifyUpdateAvailable(L().updTitle, fmt.Sprintf(L().updAvailableFmt, latest))
 }
 
 // listenHub binds addr, retrying for up to grace so a just-stopped daemon has


### PR DESCRIPTION
## Problem

The system-tray **Check for Updates…** action reported every outcome through a modal dialog (`showInfo` / `showError` / `confirm`). For a background tray app that's intrusive — a routine "you're on the latest version" check pops a window you have to dismiss.

## Change

Report via a non-intrusive OS toast instead:

- **Check failed** / **already current** → plain toast (`Notify`).
- **Update available** → an actionable toast whose **Open Download Page** button — and a tap on the body — opens the download page, routed through the existing `OnNotificationResponse` handler by category id.

## Cross-platform unification (macOS / Windows / Linux)

The notifier was created only under `isBundled()`, which matches a macOS `.app` bundle path — so on **Windows and Linux the notifier was never created** and the toast would show nothing. Gate on `notificationsAvailable()` instead:

- **macOS**: still requires a bundle (`UNUserNotificationCenter` needs a bundle id).
- **Windows** (registered COM toast activator) and **Linux** (D-Bus): always create the notifier.

All three platform notifiers echo the sent category id back in the response and normalize a body/default tap to `DefaultActionIdentifier`, so the routing is identical everywhere. The handler matches the category **and** then only the open action or a body tap, so dismissing the toast never opens a browser regardless of how a platform reports dismissal. The action category is registered at `ApplicationStarted` (after the notifier's `ServiceStartup`) because Windows/Linux drop the action buttons if a notification is sent before its category is registered.

### Known, accepted tradeoff

Unbundled **macOS dev builds** have no notifier, so the update check is silent there — matching the version badge's own silence in that build. Not worth reintroducing a macOS-only dialog fallback.

## Cleanup

Removed the now-unused `showInfo` dialog and the `updLater` ("Later") string; reworded `updAvailableFmt` from a dialog question to a toast statement (the CTA is the action button). `showError` (other error paths) and `confirm` (takeover/quit) are retained.

## Testing

Host `go build` / `go vet` / `go test -count=1 ./cmd/octo-desktop` pass; gofmt clean. Windows/Linux builds require their Wails/cgo toolchains (CI) — the changed files carry no build tags and use only the platform-agnostic notifications API, and each OS impl was checked to support action categories and echo the category id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)