### PR TITLE
ci(macos-installer): stub `open` so postinstall test doesn't launch the app

### DIFF
--- a/.github/workflows/macos-installer-check.yml
+++ b/.github/workflows/macos-installer-check.yml
@@ -106,7 +106,16 @@ jobs:
           mkdir -p "$fake/Applications"
           cp -R expanded/octo-component.pkg/Payload/. "$fake/Applications/"
 
-          HOME="$fake" expanded/octo-component.pkg/Scripts/postinstall
+          # postinstall ends by `open`-ing the app. In CI we must not actually
+          # launch the GUI: it would run the app's ensureBundledOcto and write
+          # the very PATH line we assert postinstall itself does NOT write. Stub
+          # `open` to a no-op so postinstall is exercised in isolation.
+          stub="$RUNNER_TEMP/stub-bin"
+          mkdir -p "$stub"
+          printf '#!/bin/sh\nexit 0\n' > "$stub/open"
+          chmod +x "$stub/open"
+
+          HOME="$fake" PATH="$stub:$PATH" expanded/octo-component.pkg/Scripts/postinstall
 
           # The bundled CLI must be present and runnable inside the installed app.
           bin="$fake/Applications/Octo.app/Contents/Resources/octo"


### PR DESCRIPTION
## What

Restores a commit that was lost from #1373: the macOS installer check stubs `open` to a no-op before running `postinstall` against the scratch `$HOME`, so `postinstall`'s final `open "$app_bundle"` doesn't actually launch the GUI during CI.

## Why (it got lost)

#1373 (branch `fix/macos-installer-cli-path`) squash-merged at 07:39 UTC. This commit (`1a4fe17f`) was pushed to that branch ~2.7 min **after** the merge (07:41 UTC), so it was never part of any PR and never reached `main`. Everything else on that branch (install-location fix, CLI-seeding hardening) did land via #1373.

## The bug it fixes

`postinstall` ends with `open "$app_bundle"`. On the macOS CI runner that actually launches `octo-desktop`, whose `main()` runs `ensureBundledOcto` **before** the GUI event loop; on macOS that calls `ensureDirOnPath`, which writes the `# added by the octo installer` PATH line into `$HOME/.zshrc`. The check then asserts *postinstall must NOT write PATH* and fails with:

```
postinstall should not write PATH (.zshrc); the app does that on launch
```

The check's premise — "a headless CI runner never launches the GUI" — is false, because `postinstall` itself opens the app. Stubbing `open` to a no-op exercises `postinstall` in isolation (its own logic genuinely doesn't touch PATH), while the app's PATH seeding stays covered by the Go unit tests.

This is why the `build and install` check has been red on recent PRs that touch `cmd/octo-desktop/**` (it's a non-required check, so it did not block them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)