### PR TITLE
fix(desktop): run the hub from the user's home, not the filesystem root

### DIFF
--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -76,7 +77,44 @@ func notificationsAvailable() bool {
 	return true
 }
 
+// homeIfRootLaunch returns the directory the hub should switch to given its
+// inherited working dir and the user's home, or "" to keep the inherited dir.
+// A GUI launcher drops a double-clicked app at a filesystem root — "/" for
+// Finder/LaunchServices on macOS and several Linux .desktop launchers, a drive
+// root like "C:\" on Windows — detected here as a path that is its own parent;
+// an os.Getwd error surfaces as an empty wd. In those cases home is the sane
+// default. A meaningful cwd (a terminal launch from a project dir) is left
+// untouched. Not covered: a Windows launch that inherits a system directory
+// such as C:\Windows\System32 — that is not a root, so this leaves it in place.
+func homeIfRootLaunch(wd, home string) string {
+	if home == "" {
+		return ""
+	}
+	if wd == "" || filepath.Dir(wd) == wd {
+		return home
+	}
+	return ""
+}
+
+// ensureWorkingDir moves the process out of a root/unknown launch directory
+// into the user's home. New sessions with no configured workspace_dir default
+// to the server's launch directory, so a Finder-launched app left at "/" would
+// run the agent's tools from the filesystem root — the reported bug. Best
+// effort: a chdir failure leaves the inherited dir in place.
+func ensureWorkingDir() {
+	wd, _ := os.Getwd()
+	home, _ := os.UserHomeDir()
+	if dir := homeIfRootLaunch(wd, home); dir != "" {
+		_ = os.Chdir(dir)
+	}
+}
+
 func main() {
+	// A GUI launch inherits "/" as the working directory; move to the user's
+	// home before anything reads it (the in-process server records its launch
+	// dir as the default for sessions without a configured workspace_dir).
+	ensureWorkingDir()
+
 	// Pick the language for native dialogs/tray from the system UI language.
 	applyLang()
 

--- a/cmd/octo-desktop/workdir_test.go
+++ b/cmd/octo-desktop/workdir_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func TestHomeIfRootLaunch(t *testing.T) {
+	const home = "/Users/alice"
+	cases := []struct {
+		name string
+		wd   string
+		home string
+		want string
+	}{
+		{"finder launch at root", "/", home, home},
+		{"getwd failed (empty)", "", home, home},
+		{"terminal launch in a project dir", "/Users/alice/proj", home, ""},
+		{"home itself is fine", home, home, ""},
+		{"no home resolved leaves cwd untouched", "/", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := homeIfRootLaunch(tc.wd, tc.home); got != tc.want {
+				t.Errorf("homeIfRootLaunch(%q, %q) = %q, want %q", tc.wd, tc.home, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Launched from Finder/LaunchServices (macOS) — and several Linux `.desktop` launchers — the desktop app inherits the **filesystem root** (`/`) as its working directory. The in-process server records its launch dir (`os.Getwd`) as the default working directory for sessions that have no configured `workspace_dir`, so those sessions ran the agent's tools from `/`. The reported bug: the desktop app's working directory at startup is the root directory; it should be the user's home.

## Fix

`chdir` to the user's home at the very start of `main()`, before anything reads the working directory (and well before the server records `s.cwd` at `ApplicationStarted`).

Root-launch detection is a path that is its own parent — `filepath.Dir(wd) == wd` — which covers `/` on macOS/Linux and a drive root like `C:\` on Windows alike, plus an empty `wd` from an `os.Getwd` error. A meaningful cwd (a terminal launch from a project dir) is left untouched, and `octo serve` (a separate CLI binary) is unaffected.

The decision is a pure function (`homeIfRootLaunch`) so it's unit-tested without touching process-global cwd; `ensureWorkingDir` wires it to `os.Getwd`/`os.UserHomeDir`/`os.Chdir` (best effort — a chdir failure leaves the inherited dir in place).

### Out of scope

A Windows launch that inherits a *system directory* such as `C:\Windows\System32` is not a filesystem root, so this leaves it in place. Detecting that reliably would need a fuzzy system-dir heuristic that risks misfiring; noted in the code comment.

## Testing

`TestHomeIfRootLaunch` covers root → home, empty (Getwd error) → home, project dir → unchanged, home itself → unchanged, and no-home-resolved → unchanged. `go build` / `go vet` / `go test -count=1 ./cmd/octo-desktop` pass; gofmt clean. (The GUI's real Finder-launch behavior can't be exercised headlessly; the decision logic is covered by the unit test and the chdir wiring is direct.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)