### PR TITLE
chore: bump version to 1.12.3

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.2"
+var Version = "1.12.3"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump `internal/version/version.go` to 1.12.3 ahead of cutting the `v1.12.3` release tag.

Includes since 1.12.2: Obsidian desktop CORS origin (#1374), tray update-check toast (#1375), macOS installer CI stub-open fix (#1377), native-shell client detection (#1376), and the hub launch-directory fix (#1378).

🤖 Generated with [Claude Code](https://claude.com/claude-code)