### PR TITLE
fix(desktop): inject Version/Commit ldflags so the in-app update check works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,14 @@ jobs:
       - name: Build desktop app
         shell: pwsh
         working-directory: cmd/octo-desktop
-        run: go build -tags embedrg -ldflags "-H windowsgui" -o ..\..\staging\octo-desktop.exe .
+        # Inject Version/Commit alongside -H windowsgui so the in-app update
+        # check recognizes a real release build — without them
+        # internal/upgrade.Eligible sees an empty Commit and the app reports
+        # "up to date" forever. $env:version is set by the staging step above.
+        run: |
+          $commit = git rev-parse --short HEAD
+          $pkg = "github.com/open-octo/octo-agent/internal/version"
+          go build -tags embedrg -ldflags "-H windowsgui -X $pkg.Version=$env:version -X $pkg.Commit=$commit" -o ..\..\staging\octo-desktop.exe .
 
       # Fetches uv.exe from its upstream GitHub release so the installer can
       # bundle it — see octo.iss's [Files] section. Native PowerShell rather
@@ -238,7 +245,9 @@ jobs:
           echo "UV_BINARY=$PWD/dl/uv-x86_64-unknown-linux-gnu/uv" >> "$GITHUB_ENV"
 
       - name: Build AppImage
-        run: bash scripts/package-desktop-linux.sh
+        # Pass the release version so the packaged binary carries clean release
+        # metadata (see the script) and the in-app update check works.
+        run: bash scripts/package-desktop-linux.sh "${GITHUB_REF_NAME#v}"
 
       - name: Attach AppImage to the release
         env:

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,14 @@ LDFLAGS := -X github.com/open-octo/octo-agent/internal/version.Version=$(VERSION
            -X github.com/open-octo/octo-agent/internal/version.Commit=$(COMMIT) \
            -X github.com/open-octo/octo-agent/internal/tools/rgembed.version=$(RG_VERSION)
 
+# Desktop builds must inject the same Version/Commit as the CLI: the in-app
+# update check (internal/upgrade.Eligible) treats an empty Commit as "no release
+# metadata" and reports "up to date" forever, so a desktop binary built without
+# these never sees a new release. rgembed.version is omitted — the bare
+# `desktop` target builds without -tags embedrg.
+DESKTOP_LDFLAGS := -X github.com/open-octo/octo-agent/internal/version.Version=$(VERSION) \
+                   -X github.com/open-octo/octo-agent/internal/version.Commit=$(COMMIT)
+
 GOFILES := $(shell find . -name '*.go' -not -path './vendor/*' -not -path '*/_vendor/*')
 
 RG_EMBED_DIR := internal/tools/rgembed/binaries
@@ -87,7 +95,7 @@ build-full: build
 # Produces a bare binary; use `wails3 build` inside cmd/octo-desktop for a
 # packaged .app / installer.
 desktop: web-build
-	cd cmd/octo-desktop && CGO_ENABLED=1 go build -o ../../octo-desktop .
+	cd cmd/octo-desktop && CGO_ENABLED=1 go build -ldflags='$(DESKTOP_LDFLAGS)' -o ../../octo-desktop .
 
 # Package the desktop shell into a double-clickable macOS Octo.app bundle
 # (embeds the web UI, ad-hoc signed for local use). Real Developer ID

--- a/scripts/package-desktop-linux.sh
+++ b/scripts/package-desktop-linux.sh
@@ -6,7 +6,7 @@
 # AppRun preflight (build/linux/AppRun) guides the user if they're absent.
 #
 # Requires the GTK4/WebKitGTK dev packages (to compile) and downloads
-# appimagetool. Usage: scripts/package-desktop-linux.sh
+# appimagetool. Usage: scripts/package-desktop-linux.sh [version]
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -14,6 +14,9 @@ MOD_DIR="$ROOT/cmd/octo-desktop"
 LINUX="$MOD_DIR/build/linux"
 APPDIR="$ROOT/Octo.AppDir"
 OUT="$ROOT/Octo-x86_64.AppImage"
+VERSION="${1:-$(git -C "$ROOT" describe --tags --always 2>/dev/null || echo 0.1.0)}"
+VERSION="${VERSION#v}"
+COMMIT="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 
 # Bundle ripgrep so the desktop app's grep tool has an `rg` to shell out to
 # (the app can't rely on one being on the user's PATH). Mirrors `make build`:
@@ -23,7 +26,11 @@ echo "==> embedding ripgrep"
 make -C "$ROOT" rg-embed
 
 echo "==> building octo-desktop binary"
-( cd "$MOD_DIR" && CGO_ENABLED=1 go build -tags embedrg -o "$ROOT/octo-desktop" . )
+# Inject Version/Commit so the in-app update check recognizes a real release
+# build — without them internal/upgrade.Eligible sees an empty Commit and the
+# app reports "up to date" forever.
+LDFLAGS="-X github.com/open-octo/octo-agent/internal/version.Version=$VERSION -X github.com/open-octo/octo-agent/internal/version.Commit=$COMMIT"
+( cd "$MOD_DIR" && CGO_ENABLED=1 go build -tags embedrg -ldflags "$LDFLAGS" -o "$ROOT/octo-desktop" . )
 
 echo "==> assembling AppDir"
 rm -rf "$APPDIR"

--- a/scripts/package-desktop-macos.sh
+++ b/scripts/package-desktop-macos.sh
@@ -13,6 +13,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MOD_DIR="$ROOT/cmd/octo-desktop"
 VERSION="${1:-$(git -C "$ROOT" describe --tags --always 2>/dev/null || echo 0.1.0)}"
 VERSION="${VERSION#v}"
+COMMIT="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 APP="$ROOT/Octo.app"
 CONTENTS="$APP/Contents"
 
@@ -24,7 +25,11 @@ echo "==> embedding ripgrep"
 make -C "$ROOT" rg-embed
 
 echo "==> building octo-desktop binary"
-( cd "$MOD_DIR" && CGO_ENABLED=1 go build -tags embedrg -o "$ROOT/octo-desktop" . )
+# Inject Version/Commit so the in-app update check recognizes a real release
+# build — without them internal/upgrade.Eligible sees an empty Commit and the
+# app reports "up to date" forever.
+LDFLAGS="-X github.com/open-octo/octo-agent/internal/version.Version=$VERSION -X github.com/open-octo/octo-agent/internal/version.Commit=$COMMIT"
+( cd "$MOD_DIR" && CGO_ENABLED=1 go build -tags embedrg -ldflags "$LDFLAGS" -o "$ROOT/octo-desktop" . )
 
 echo "==> assembling $APP (version $VERSION)"
 rm -rf "$APP"


### PR DESCRIPTION
## Problem

A locally-installed 1.12.2 desktop app keeps reporting "already up to date" even after 1.12.3 is published. The release itself is fine (v1.12.3 is `latest`, non-draft, all assets uploaded) — the bug is in how the **desktop binary is built**.

The desktop `go build` invocations omit the `-X internal/version.Version` / `-X internal/version.Commit` ldflags that the CLI build injects. So in every shipped desktop binary `version.Commit == ""`. The update check treats an empty Commit as "not a real release build":

- `internal/upgrade.Eligible()` returns an error when `version.Commit == ""`.
- The tray **Check for Updates…** (`cmd/octo-desktop/main.go:311`) does `if upgrade.Eligible() != nil || CompareVersions(current, latest) >= 0 { showInfo("already latest") }` — so an ineligible build **always** shows "已是最新版", no matter the real latest release.
- The web badge (`needsUpdate`, `internal/server/version_upgrade_handlers.go`) calls `Eligible()` first and returns `false`, so the badge never appears either.

Net effect: desktop update detection has been dead since the build omitted these flags. `version.Version` only *looked* right because it's a hardcoded constant bumped per release; `Commit` was silently empty.

## Fix

Inject `Version` + `Commit` into every desktop build, mirroring the CLI:

- `Makefile` `desktop` target — via a new `DESKTOP_LDFLAGS` (rgembed.version omitted; the bare target builds without `-tags embedrg`). Dev builds keep the `-dev` version so they stay ineligible, as intended.
- `scripts/package-desktop-macos.sh` — adds `COMMIT`, builds with ldflags.
- `scripts/package-desktop-linux.sh` — adds `VERSION` (new optional `[version]` arg, defaulting to `git describe` like the mac script) + `COMMIT`, builds with ldflags.
- `.github/workflows/release.yml` — Windows desktop build injects `$env:version` + short SHA; the Linux AppImage step passes the release version to the script.

At release time Version comes from the tag and Commit from the build SHA → `Eligible()` passes → the app compares against the real latest release. Local/CI builds get a `-dev`/git-describe version and stay ineligible, matching CLI dev-build behavior.

## Verification

- Built `cmd/octo-desktop` with injected ldflags; `strings` confirms the `Version`/`Commit` values land in the binary (the `-X` symbol path resolves from the nested module).
- `make -n desktop` expands to the correct `-ldflags='-X …Version=1.12.3-dev -X …Commit=<sha>'`.
- `bash -n` passes on both packaging scripts; `release.yml` YAML validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)