### PR TITLE
blog: match the brand indigo and add a dark theme

### DIFF
--- a/blog/public/architecture-map.html
+++ b/blog/public/architecture-map.html
@@ -11,8 +11,8 @@
   --ink: #1c1917;
   --ink-muted: #78716c;
   --line: #d6d3d1;
-  --accent: #2563eb;
-  --accent-soft: #dbeafe;
+  --accent: #4f46e5;
+  --accent-soft: #e0e7ff;
   --serve: #059669;
   --serve-soft: #d1fae5;
   --agent: #7c3aed;
@@ -35,8 +35,8 @@
     --ink: #f5f5f4;
     --ink-muted: #a8a29e;
     --line: #292524;
-    --accent: #60a5fa;
-    --accent-soft: #1e3a5f;
+    --accent: #818cf8;
+    --accent-soft: #312e81;
     --serve: #34d399;
     --serve-soft: #064e3b;
     --agent: #a78bfa;

--- a/blog/src/styles/blog.css
+++ b/blog/src/styles/blog.css
@@ -1,14 +1,31 @@
 :root {
+	color-scheme: light dark;
 	--color-bg: #ffffff;
 	--color-text: #1f2937;
 	--color-text-muted: #6b7280;
-	--color-accent: #2563eb;
-	--color-accent-dark: #1d4ed8;
+	/* Brand indigo — matches the landing page and docs (--accent #4f46e5). */
+	--color-accent: #4f46e5;
+	--color-accent-dark: #4338ca;
 	--color-border: #e5e7eb;
 	--color-code-bg: #f3f4f6;
 	--font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 	--font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
 	--max-width: 760px;
+}
+
+/* Dark theme, following the viewer's OS preference — the same palette the
+   landing page uses, so the blog matches the rest of the brand in both modes.
+   In dark mode the hover accent goes lighter (a5b4fc), mirroring the landing. */
+@media (prefers-color-scheme: dark) {
+	:root {
+		--color-bg: #0b0f19;
+		--color-text: #f3f4f6;
+		--color-text-muted: #9ca3af;
+		--color-accent: #818cf8;
+		--color-accent-dark: #a5b4fc;
+		--color-border: #1f2937;
+		--color-code-bg: #111827;
+	}
 }
 
 * {


### PR DESCRIPTION
## Why

The blog (`octo-agent.dev`'s blog) looked off-brand: its accent was blue (`#2563eb` / hover `#1d4ed8`) while the **landing page and docs are both indigo** (`#4f46e5` light / `#818cf8` dark). It was also **light-only**, whereas the landing and docs follow the viewer's OS dark preference.

## Changes

- **Brand color.** Retoken the blog accent to the brand indigo — `--color-accent: #4f46e5`, hover `#4338ca` — in `blog.css`. Align the standalone `architecture-map.html` diagram's `--accent` the same way (light `#4f46e5` / dark `#818cf8`); its semantic zone colors (serve/agent/provider/tool/…) are left as-is.
- **Dark theme.** Add a `@media (prefers-color-scheme: dark)` block to `blog.css` using the same dark palette as the landing page (`--color-bg: #0b0f19`, `--color-text: #f3f4f6`, `--color-accent: #818cf8`, hover `#a5b4fc`, border `#1f2937`, code-bg `#111827`), and set `color-scheme: light dark` so native controls adapt. The blog.css is fully token-driven, so every surface flips cleanly.

CSS only; no content or layout changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)