### PR TITLE
feat(trash): back up files before write_file/edit_file overwrites

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,6 +138,25 @@ type Config struct {
 	// Language persists the user's UI language preference ("en" | "zh").
 	// Empty means the default (English).
 	Language string `yaml:"language,omitempty"`
+	// Trash configures the file recycle bin (agent-issued deletes and
+	// overwrites are staged there for recovery).
+	Trash TrashConfig `yaml:"trash,omitempty"`
+}
+
+// TrashConfig configures the file recycle bin.
+type TrashConfig struct {
+	// OverwriteBackup stages a copy of a file into the trash before write_file
+	// or edit_file overwrites it, so an overwrite that destroys uncommitted
+	// work is recoverable. Files that are tracked by git and clean are skipped
+	// regardless — git already holds a recoverable copy. nil means the default
+	// (enabled).
+	OverwriteBackup *bool `yaml:"overwrite_backup,omitempty"`
+}
+
+// OverwriteBackupEnabled reports whether write/edit overwrites are staged into
+// the trash first (default true).
+func (c *Config) OverwriteBackupEnabled() bool {
+	return c.Trash.OverwriteBackup == nil || *c.Trash.OverwriteBackup
 }
 
 // GoalConfig configures session goals (persistent objectives the agent keeps

--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -560,6 +560,9 @@ func (EditFileTool) Execute(ctx context.Context, _ string, input map[string]any)
 	out.WriteString(body[prevOrigEnd:])
 	updated := out.String()
 
+	// Stage the pre-edit version into the trash so an edit that destroys
+	// uncommitted work is recoverable (skipped for git-tracked-clean files).
+	backupBeforeOverwrite(ctx, abs)
 	if err := os.WriteFile(abs, []byte(updated), 0o644); err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: write %q: %w", path, err)
 	}

--- a/internal/tools/main_test.go
+++ b/internal/tools/main_test.go
@@ -27,12 +27,28 @@ func TestMain(m *testing.M) {
 	if len(os.Args) > 1 && os.Args[1] == "__sandboxed-exec" {
 		os.Exit(sandbox.ShimMain())
 	}
+	// Point HOME at a throwaway dir for the whole package so nothing touches
+	// the developer's real ~/.octo — in particular the overwrite-protection
+	// path (backupBeforeOverwrite) would otherwise stage every edit_file /
+	// write_file overwrite into the real ~/.octo/trash. A per-test
+	// t.Setenv("HOME", …) still overrides this default for its own duration.
+	//
+	// The throwaway HOME is created UNDER the real home dir, not under TMPDIR:
+	// the sandbox integration tests write a probe to $HOME and rely on it being
+	// a location the OS sandbox denies, and macOS's default policy allows
+	// TMPDIR — so a temp HOME there would let the probe through and break them.
+	realHome, _ := os.UserHomeDir()
+	homeTmp, _ := os.MkdirTemp(realHome, ".octo-tools-test-home")
+	if homeTmp != "" {
+		os.Setenv("HOME", homeTmp)
+		os.Setenv("USERPROFILE", homeTmp)
+	}
 	defaultsTmp, _ := os.MkdirTemp("", "octo-workflows-default-empty")
 	defaultWorkflowsRoot = func() string { return defaultsTmp }
 	journalsTmp, _ := os.MkdirTemp("", "octo-workflow-journals-test")
 	SetWorkflowJournalDir(journalsTmp)
 	code := m.Run()
-	for _, tmp := range []string{defaultsTmp, journalsTmp} {
+	for _, tmp := range []string{homeTmp, defaultsTmp, journalsTmp} {
 		if tmp != "" {
 			_ = os.RemoveAll(tmp)
 		}

--- a/internal/tools/overwrite_backup.go
+++ b/internal/tools/overwrite_backup.go
@@ -1,0 +1,76 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/open-octo/octo-agent/internal/config"
+	"github.com/open-octo/octo-agent/internal/trash"
+)
+
+// backupBeforeOverwrite stages the current contents of abs into the trash
+// before a tool overwrites it, so an overwrite that destroys uncommitted work
+// is recoverable — the most common destructive action an agent takes, and the
+// one the recycle bin most needs to guard.
+//
+// Best-effort: any failure is swallowed so it never blocks the write the model
+// asked for (mirroring the safe-rm shell wrapper). It is skipped when:
+//   - abs doesn't exist yet — a create, nothing to protect;
+//   - the trash.overwrite_backup config toggle is off;
+//   - abs is tracked by git and clean — `git checkout` already recovers the
+//     exact bytes, so staging would only bloat the trash.
+//
+// The git check runs only for an *existing* file, so creating a brand-new file
+// pays nothing.
+func backupBeforeOverwrite(ctx context.Context, abs string) {
+	fi, err := os.Stat(abs)
+	if err != nil || fi.IsDir() {
+		return
+	}
+	if !overwriteBackupEnabled() {
+		return
+	}
+	if gitTrackedClean(abs) {
+		return
+	}
+	_ = trash.Backup(abs, WorkingDirOrCWD(ctx))
+}
+
+func overwriteBackupEnabled() bool {
+	cfg, err := config.Load()
+	if err != nil {
+		return true // default on
+	}
+	return cfg.OverwriteBackupEnabled()
+}
+
+// gitTrackedClean reports whether abs is a git-tracked file with neither
+// unstaged nor staged changes — i.e. `git checkout` could recover its current
+// bytes, making a trash backup redundant. Anything else (untracked, dirty, not
+// a repo, git missing) returns false so the caller backs up.
+func gitTrackedClean(abs string) bool {
+	dir := filepath.Dir(abs)
+	// Tracked at all?
+	if err := runGitQuiet(dir, "ls-files", "--error-unmatch", "--", abs); err != nil {
+		return false
+	}
+	// Unstaged changes? (git diff exits non-zero when the file differs.)
+	if err := runGitQuiet(dir, "diff", "--quiet", "--", abs); err != nil {
+		return false
+	}
+	// Staged changes?
+	if err := runGitQuiet(dir, "diff", "--cached", "--quiet", "--", abs); err != nil {
+		return false
+	}
+	return true
+}
+
+// runGitQuiet runs git in dir with output discarded, returning the run error
+// (which carries the non-zero exit status git uses to signal its answer).
+func runGitQuiet(dir string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	return cmd.Run()
+}

--- a/internal/tools/overwrite_backup_test.go
+++ b/internal/tools/overwrite_backup_test.go
@@ -1,0 +1,151 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/trash"
+)
+
+func setHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+}
+
+func countBackups(t *testing.T, orig string) int {
+	t.Helper()
+	entries, err := trash.List()
+	if err != nil {
+		t.Fatalf("trash.List: %v", err)
+	}
+	n := 0
+	for _, e := range entries {
+		if e.Original == orig {
+			n++
+		}
+	}
+	return n
+}
+
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "t@example.com"},
+		{"config", "user.name", "t"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+func gitCommitAll(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-q", "-m", "x"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+// TestOverwriteBackup_Untracked: a file with no git recovery path is staged
+// before it's overwritten.
+func TestOverwriteBackup_Untracked(t *testing.T) {
+	setHome(t)
+	dir := t.TempDir() // plain dir, not a git repo
+	f := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(f, []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	backupBeforeOverwrite(context.Background(), f)
+	if got := countBackups(t, f); got != 1 {
+		t.Errorf("untracked overwrite should stage 1 backup, got %d", got)
+	}
+}
+
+// TestOverwriteBackup_TrackedClean: a committed, unmodified file is skipped —
+// git already recovers it.
+func TestOverwriteBackup_TrackedClean(t *testing.T) {
+	setHome(t)
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	f := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(f, []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCommitAll(t, dir)
+
+	backupBeforeOverwrite(context.Background(), f)
+	if got := countBackups(t, f); got != 0 {
+		t.Errorf("clean tracked file should NOT be staged (git recovers it), got %d", got)
+	}
+}
+
+// TestOverwriteBackup_TrackedDirty: a tracked file with uncommitted changes is
+// staged — the working-tree bytes differ from anything git holds.
+func TestOverwriteBackup_TrackedDirty(t *testing.T) {
+	setHome(t)
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	f := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(f, []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCommitAll(t, dir)
+	if err := os.WriteFile(f, []byte("package main // edited"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	backupBeforeOverwrite(context.Background(), f)
+	if got := countBackups(t, f); got != 1 {
+		t.Errorf("dirty tracked file should be staged, got %d", got)
+	}
+}
+
+// TestOverwriteBackup_CreateIsNoOp: no file at the path yet → nothing to stage.
+func TestOverwriteBackup_CreateIsNoOp(t *testing.T) {
+	setHome(t)
+	dir := t.TempDir()
+	f := filepath.Join(dir, "new.txt")
+	backupBeforeOverwrite(context.Background(), f)
+	if got := countBackups(t, f); got != 0 {
+		t.Errorf("creating a new file should stage nothing, got %d", got)
+	}
+}
+
+// TestOverwriteBackup_ToggleOff: trash.overwrite_backup:false disables staging
+// even for an untracked file.
+func TestOverwriteBackup_ToggleOff(t *testing.T) {
+	setHome(t)
+	home, _ := os.UserHomeDir()
+	if err := os.MkdirAll(filepath.Join(home, ".octo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".octo", "config.yml"),
+		[]byte("trash:\n  overwrite_backup: false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	f := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(f, []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	backupBeforeOverwrite(context.Background(), f)
+	if got := countBackups(t, f); got != 0 {
+		t.Errorf("toggle off should stage nothing, got %d", got)
+	}
+}

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -62,6 +62,9 @@ func (WriteFileTool) Execute(ctx context.Context, _ string, input map[string]any
 	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("write_file: mkdir parent: %w", err)
 	}
+	// Stage the version being overwritten into the trash so a clobber that
+	// destroys uncommitted work is recoverable (no-op for a new file).
+	backupBeforeOverwrite(ctx, abs)
 	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
 		return agent.ToolResult{Text: ""}, fmt.Errorf("write_file: write %q: %w", path, err)
 	}


### PR DESCRIPTION
**PR 2 of 4** in the recycle-bin (回收站) upgrade. Closes the biggest safety hole: overwriting an existing file — the agent's most common destructive action — bypassed the trash entirely (the package doc claimed overwrites were covered; only `rm` and programmatic deletes were). Depends conceptually on #1383 but touches disjoint files. Design: `dev-docs/trash-recall-design.md` (lands with #1383).

## What this adds

`write_file` and `edit_file` now stage the current bytes into the trash **before** clobbering, via a new best-effort `backupBeforeOverwrite`. A git-aware gate keeps the trash useful rather than noisy:

| File state | Action |
|---|---|
| Untracked | **back up** — nothing else can recover it |
| Tracked but dirty | **back up** — working tree differs from anything git holds |
| Tracked and clean | **skip** — `git checkout` recovers the exact bytes |
| Not a git repo / git missing | **back up** |

- Best-effort, mirroring the safe-rm wrapper: a backup failure never blocks the write.
- The git check runs **only when overwriting an existing file**, so creating a new file pays nothing.
- Default on; opt out with `trash.overwrite_backup: false` (new `TrashConfig`).

## Test isolation

Extends the tools package `TestMain` (which already redirects the workflow dirs away from real `~/.octo`) to also point `HOME` at a throwaway dir — otherwise the new overwrite path would stage test files into the developer's real `~/.octo/trash` during `make test`. The temp HOME is created **under the real home dir, not TMPDIR**, because the sandbox integration tests write a probe to `$HOME` expecting the OS sandbox to deny it, and macOS's default policy allows TMPDIR (a temp HOME there would let the probe through and break them).

## Verification

- `go build/vet ./...` clean, `gofmt -l` clean.
- `go test -race ./internal/{config,tools}` green (one unrelated pre-existing flake: `TestBrowserTool_CookiesIncludesHttpOnly`, a live-Chrome CDP test — passes on its own).
- New tests cover: untracked → staged, dirty-tracked → staged, clean-tracked → skipped, create → no-op, toggle-off → no-op.
- Confirmed the change no longer pollutes the real `~/.octo/trash` (before/after project-dir count unchanged across a full package run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)