### PR TITLE
landing: add the "one brain, many arms" octopus diagram

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -300,24 +300,22 @@
     }
 
     /* One brain, many arms — the octopus diagram */
-    .octo-map { max-width: 720px; margin: -1rem auto 2.5rem; }
-    .octo-map svg { width: 100%; height: auto; display: block; }
-    .om-boundary { fill: none; stroke: var(--muted); stroke-width: 1.4; stroke-dasharray: 4 6; opacity: 0.5; }
-    .om-boundary-label { fill: var(--muted); font-size: 12px; letter-spacing: 0.04em; text-transform: uppercase; }
-    .om-arm { fill: none; stroke: var(--accent); stroke-width: 2.2; stroke-linecap: round; opacity: 0.85; stroke-dasharray: 4 10; animation: om-flow 3.4s linear infinite; }
-    .om-exit { fill: none; stroke: var(--accent); stroke-width: 2.2; stroke-linecap: round; }
+    .octo-map { max-width: 640px; margin: -0.5rem auto 2.5rem; }
+    .octo-map svg { width: 100%; height: auto; display: block; overflow: visible; }
+    .om-tentacle { fill: var(--accent); }
+    .om-halo { fill: var(--accent-soft); opacity: 0.55; }
+    .om-head { fill: var(--accent); }
+    .om-eye { fill: #fff; }
+    .om-pupil { fill: var(--accent); }
     .om-chip { fill: var(--card-bg); stroke: var(--border); stroke-width: 1.4; }
     .om-ico { fill: none; stroke: var(--accent); stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
     .om-name { fill: var(--fg-secondary); font-size: 14px; font-weight: 600; }
-    .om-brain-ring { fill: var(--accent-soft); stroke: var(--accent); stroke-width: 1.5; }
-    .om-brain-body { fill: var(--accent); }
-    .om-brain-eye { fill: var(--bg); }
-    .om-model { fill: var(--accent); }
-    .om-model-txt { fill: #fff; font-size: 13px; font-weight: 600; }
+    .om-leak { fill: none; stroke: var(--muted); stroke-width: 1.5; stroke-dasharray: 2 5; stroke-linecap: round; opacity: 0.8; }
+    .om-leak-head { fill: none; stroke: var(--muted); stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; opacity: 0.8; }
+    .om-model { fill: none; stroke: var(--border); stroke-width: 1.4; }
+    .om-model-txt { fill: var(--muted); font-size: 12px; font-weight: 600; }
     .octo-map text { font-family: inherit; }
-    .octo-map figcaption { text-align: center; color: var(--muted); font-size: 0.92rem; max-width: 540px; margin: 0.75rem auto 0; }
-    @keyframes om-flow { to { stroke-dashoffset: -140; } }
-    @media (prefers-reduced-motion: reduce) { .om-arm { animation: none; } }
+    .octo-map figcaption { text-align: center; color: var(--muted); font-size: 0.92rem; max-width: 520px; margin: 1rem auto 0; }
     @media (max-width: 640px) { .octo-map { margin-top: 0; } }
 
     /* Feature grid */
@@ -672,62 +670,52 @@
       </div>
 
       <figure class="octo-map reveal">
-        <svg viewBox="0 0 720 430" role="img" aria-label="One brain, many arms — one local agent reaching six interfaces, with only requests leaving your machine">
-          <!-- your-machine boundary -->
-          <rect class="om-boundary" x="28" y="70" width="550" height="330" rx="24"/>
-          <text class="om-boundary-label" x="40" y="60">your machine</text>
+        <svg viewBox="0 0 720 430" role="img" aria-label="One brain, many arms — one local octopus agent whose tentacles reach six interfaces; only requests leave, to the model you chose">
+          <!-- the one thing that leaves: a request to the model -->
+          <path class="om-leak" d="M300 150 L300 44"/>
+          <path class="om-leak-head" d="M294 54 L300 43 L306 54"/>
+          <rect class="om-model" x="252" y="10" width="96" height="30" rx="15"/>
+          <text class="om-model-txt" x="300" y="30" text-anchor="middle">your model</text>
 
-          <!-- six arms (brain → interfaces) -->
-          <path class="om-arm" d="M262 216 C216 200 176 165 146 151"/>
-          <path class="om-arm" d="M250 240 C210 232 165 248 134 240"/>
-          <path class="om-arm" d="M262 264 C216 280 176 315 146 329"/>
-          <path class="om-arm" d="M338 216 C384 200 424 165 454 151"/>
-          <path class="om-arm" d="M350 240 C390 232 435 248 466 240"/>
-          <path class="om-arm" d="M338 264 C384 280 424 315 454 329"/>
-
-          <!-- the one thing that leaves: request → model -->
-          <path class="om-exit" d="M300 190 C300 150 300 95 300 46"/>
-          <path class="om-exit" d="M293 55 L300 44 L307 55"/>
-          <rect class="om-model" x="246" y="8" width="108" height="32" rx="16"/>
-          <text class="om-model-txt" x="300" y="29" text-anchor="middle">your model</text>
-
-          <!-- brain -->
-          <circle class="om-brain-ring" cx="300" cy="240" r="50"/>
-          <g transform="translate(259,199) scale(0.82)">
-            <path class="om-brain-body" d="M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z"/>
-            <circle class="om-brain-eye" cx="40" cy="42" r="5"/>
-            <circle class="om-brain-eye" cx="60" cy="42" r="5"/>
+          <!-- six tentacles = the six connectors -->
+          <g class="om-body">
+          <path class="om-tentacle" d="M 265.97 209.98 L 261.58 209.81 L 257.26 209.35 L 252.99 208.61 L 248.77 207.59 L 244.59 206.32 L 240.46 204.81 L 236.36 203.07 L 232.30 201.11 L 228.28 198.97 L 224.29 196.66 L 220.34 194.20 L 216.43 191.61 L 212.55 188.92 L 208.71 186.14 L 204.89 183.30 L 201.10 180.43 L 197.33 177.54 L 193.58 174.66 L 189.84 171.82 L 186.11 169.02 L 182.39 166.31 L 178.67 163.69 L 174.94 161.20 L 171.20 158.85 L 167.44 156.66 L 163.66 154.67 L 159.86 152.88 L 156.03 151.32 L 152.17 150.00 L 148.27 148.93 L 147.73 151.07 L 151.43 152.22 L 155.07 153.68 L 158.65 155.42 L 162.17 157.39 L 165.66 159.59 L 169.11 161.99 L 172.54 164.57 L 175.95 167.30 L 179.35 170.17 L 182.75 173.16 L 186.16 176.24 L 189.58 179.41 L 193.02 182.62 L 196.50 185.88 L 200.01 189.15 L 203.58 192.42 L 207.20 195.66 L 210.90 198.87 L 214.67 202.01 L 218.54 205.06 L 222.50 208.01 L 226.59 210.84 L 230.80 213.52 L 235.15 216.03 L 239.65 218.33 L 244.32 220.42 L 249.16 222.25 L 254.18 223.80 L 259.39 225.04 L 264.80 225.94 Z"/>
+          <path class="om-tentacle" d="M 256.51 230.80 L 252.95 232.71 L 249.30 234.36 L 245.56 235.76 L 241.73 236.93 L 237.81 237.86 L 233.80 238.59 L 229.72 239.12 L 225.56 239.46 L 221.35 239.63 L 217.08 239.64 L 212.77 239.52 L 208.42 239.28 L 204.06 238.94 L 199.67 238.51 L 195.29 238.03 L 190.90 237.50 L 186.52 236.95 L 182.16 236.40 L 177.83 235.86 L 173.53 235.37 L 169.26 234.93 L 165.05 234.58 L 160.88 234.32 L 156.77 234.18 L 152.73 234.19 L 148.76 234.35 L 144.87 234.69 L 141.06 235.23 L 137.34 235.98 L 133.70 236.94 L 134.30 239.06 L 137.81 238.27 L 141.41 237.76 L 145.09 237.50 L 148.84 237.46 L 152.66 237.61 L 156.55 237.95 L 160.50 238.44 L 164.50 239.06 L 168.57 239.80 L 172.69 240.63 L 176.86 241.54 L 181.07 242.51 L 185.34 243.51 L 189.64 244.52 L 193.99 245.53 L 198.38 246.52 L 202.80 247.46 L 207.27 248.33 L 211.77 249.12 L 216.31 249.80 L 220.88 250.34 L 225.50 250.74 L 230.14 250.95 L 234.83 250.96 L 239.55 250.74 L 244.30 250.26 L 249.08 249.49 L 253.88 248.41 L 258.69 246.99 L 263.49 245.20 Z"/>
+          <path class="om-tentacle" d="M 259.07 254.36 L 256.77 258.19 L 254.24 261.81 L 251.49 265.25 L 248.52 268.51 L 245.34 271.61 L 241.96 274.55 L 238.41 277.35 L 234.68 280.01 L 230.81 282.54 L 226.80 284.95 L 222.68 287.26 L 218.46 289.48 L 214.17 291.61 L 209.82 293.67 L 205.43 295.68 L 201.02 297.65 L 196.61 299.59 L 192.22 301.52 L 187.86 303.45 L 183.55 305.40 L 179.32 307.39 L 175.17 309.42 L 171.13 311.52 L 167.21 313.70 L 163.43 315.97 L 159.81 318.36 L 156.36 320.86 L 153.11 323.51 L 150.05 326.30 L 147.19 329.25 L 148.81 330.75 L 151.64 328.02 L 154.72 325.49 L 158.00 323.15 L 161.49 320.98 L 165.14 318.94 L 168.96 317.04 L 172.93 315.24 L 177.03 313.54 L 181.24 311.91 L 185.56 310.34 L 189.97 308.82 L 194.45 307.31 L 198.99 305.81 L 203.58 304.31 L 208.21 302.77 L 212.86 301.19 L 217.51 299.54 L 222.16 297.82 L 226.80 295.99 L 231.40 294.04 L 235.96 291.95 L 240.46 289.69 L 244.90 287.25 L 249.25 284.60 L 253.49 281.72 L 257.62 278.58 L 261.60 275.17 L 265.43 271.46 L 269.07 267.43 L 272.49 263.06 Z"/>
+          <path class="om-tentacle" d="M 335.20 225.94 L 340.61 225.04 L 345.82 223.80 L 350.84 222.25 L 355.68 220.42 L 360.35 218.33 L 364.85 216.03 L 369.20 213.52 L 373.41 210.84 L 377.50 208.01 L 381.46 205.06 L 385.33 202.01 L 389.10 198.87 L 392.80 195.66 L 396.42 192.42 L 399.99 189.15 L 403.50 185.88 L 406.98 182.62 L 410.42 179.41 L 413.84 176.24 L 417.25 173.16 L 420.65 170.17 L 424.05 167.30 L 427.46 164.57 L 430.89 161.99 L 434.34 159.59 L 437.83 157.39 L 441.35 155.42 L 444.93 153.68 L 448.57 152.22 L 452.27 151.07 L 451.73 148.93 L 447.83 150.00 L 443.97 151.32 L 440.14 152.88 L 436.34 154.67 L 432.56 156.66 L 428.80 158.85 L 425.06 161.20 L 421.33 163.69 L 417.61 166.31 L 413.89 169.02 L 410.16 171.82 L 406.42 174.66 L 402.67 177.54 L 398.90 180.43 L 395.11 183.30 L 391.29 186.14 L 387.45 188.92 L 383.57 191.61 L 379.66 194.20 L 375.71 196.66 L 371.72 198.97 L 367.70 201.11 L 363.64 203.07 L 359.54 204.81 L 355.41 206.32 L 351.23 207.59 L 347.01 208.61 L 342.74 209.35 L 338.42 209.81 L 334.03 209.98 Z"/>
+          <path class="om-tentacle" d="M 336.51 245.20 L 341.31 246.99 L 346.12 248.41 L 350.92 249.49 L 355.70 250.26 L 360.45 250.74 L 365.17 250.96 L 369.86 250.95 L 374.50 250.74 L 379.12 250.34 L 383.69 249.80 L 388.23 249.12 L 392.73 248.33 L 397.20 247.46 L 401.62 246.52 L 406.01 245.53 L 410.36 244.52 L 414.66 243.51 L 418.93 242.51 L 423.14 241.54 L 427.31 240.63 L 431.43 239.80 L 435.50 239.06 L 439.50 238.44 L 443.45 237.95 L 447.34 237.61 L 451.16 237.46 L 454.91 237.50 L 458.59 237.76 L 462.19 238.27 L 465.70 239.06 L 466.30 236.94 L 462.66 235.98 L 458.94 235.23 L 455.13 234.69 L 451.24 234.35 L 447.27 234.19 L 443.23 234.18 L 439.12 234.32 L 434.95 234.58 L 430.74 234.93 L 426.47 235.37 L 422.17 235.86 L 417.84 236.40 L 413.48 236.95 L 409.10 237.50 L 404.71 238.03 L 400.33 238.51 L 395.94 238.94 L 391.58 239.28 L 387.23 239.52 L 382.92 239.64 L 378.65 239.63 L 374.44 239.46 L 370.28 239.12 L 366.20 238.59 L 362.19 237.86 L 358.27 236.93 L 354.44 235.76 L 350.70 234.36 L 347.05 232.71 L 343.49 230.80 Z"/>
+          <path class="om-tentacle" d="M 327.51 263.06 L 330.93 267.43 L 334.57 271.46 L 338.40 275.17 L 342.38 278.58 L 346.51 281.72 L 350.75 284.60 L 355.10 287.25 L 359.54 289.69 L 364.04 291.95 L 368.60 294.04 L 373.20 295.99 L 377.84 297.82 L 382.49 299.54 L 387.14 301.19 L 391.79 302.77 L 396.42 304.31 L 401.01 305.81 L 405.55 307.31 L 410.03 308.82 L 414.44 310.34 L 418.76 311.91 L 422.97 313.54 L 427.07 315.24 L 431.04 317.04 L 434.86 318.94 L 438.51 320.98 L 442.00 323.15 L 445.28 325.49 L 448.36 328.02 L 451.19 330.75 L 452.81 329.25 L 449.95 326.30 L 446.89 323.51 L 443.64 320.86 L 440.19 318.36 L 436.57 315.97 L 432.79 313.70 L 428.87 311.52 L 424.83 309.42 L 420.68 307.39 L 416.45 305.40 L 412.14 303.45 L 407.78 301.52 L 403.39 299.59 L 398.98 297.65 L 394.57 295.68 L 390.18 293.67 L 385.83 291.61 L 381.54 289.48 L 377.32 287.26 L 373.20 284.95 L 369.19 282.54 L 365.32 280.01 L 361.59 277.35 L 358.04 274.55 L 354.66 271.61 L 351.48 268.51 L 348.51 265.25 L 345.76 261.81 L 343.23 258.19 L 340.93 254.36 Z"/>
+            <!-- head -->
+            <ellipse class="om-halo" cx="300" cy="234" rx="58" ry="54"/>
+            <path class="om-head" d="M256 244 C256 205 273 186 300 186 C327 186 344 205 344 244 C344 262 330 272 300 272 C270 272 256 262 256 244 Z"/>
+            <ellipse class="om-eye" cx="287" cy="230" rx="6.5" ry="8"/>
+            <ellipse class="om-eye" cx="313" cy="230" rx="6.5" ry="8"/>
+            <circle class="om-pupil" cx="288.5" cy="231.5" r="2.6"/>
+            <circle class="om-pupil" cx="314.5" cy="231.5" r="2.6"/>
           </g>
 
-          <!-- endpoints: chip + hand-drawn line icon + label -->
-          <!-- Terminal -->
-          <rect class="om-chip" x="108" y="130" width="40" height="40" rx="10"/>
+          <rect class="om-chip" x="108" y="130" width="40" height="40" rx="11"/>
           <g class="om-ico" transform="translate(116,138)"><polyline points="5 7 10 12 5 17"/><line x1="12" y1="17" x2="19" y2="17"/></g>
           <text class="om-name" x="96" y="155" text-anchor="end">Terminal</text>
-          <!-- VS Code -->
-          <rect class="om-chip" x="92" y="220" width="40" height="40" rx="10"/>
-          <g class="om-ico" transform="translate(100,228)"><polyline points="9 8 5 12 9 16"/><polyline points="15 8 19 12 15 16"/></g>
-          <text class="om-name" x="80" y="245" text-anchor="end">VS Code</text>
-          <!-- Obsidian -->
-          <rect class="om-chip" x="108" y="310" width="40" height="40" rx="10"/>
+          <rect class="om-chip" x="94" y="218" width="40" height="40" rx="11"/>
+          <g class="om-ico" transform="translate(102,226)"><polyline points="9 8 5 12 9 16"/><polyline points="15 8 19 12 15 16"/></g>
+          <text class="om-name" x="82" y="243" text-anchor="end">VS Code</text>
+          <rect class="om-chip" x="108" y="310" width="40" height="40" rx="11"/>
           <g class="om-ico" transform="translate(116,318)"><path d="M12 2 4 9l8 13 8-13-8-7z"/><path d="M4 9h16"/></g>
           <text class="om-name" x="96" y="335" text-anchor="end">Obsidian</text>
-          <!-- Web -->
-          <rect class="om-chip" x="452" y="130" width="40" height="40" rx="10"/>
+          <rect class="om-chip" x="452" y="130" width="40" height="40" rx="11"/>
           <g class="om-ico" transform="translate(460,138)"><circle cx="12" cy="12" r="9"/><line x1="3" y1="12" x2="21" y2="12"/><path d="M12 3c3.5 3 3.5 15 0 18M12 3c-3.5 3-3.5 15 0 18"/></g>
           <text class="om-name" x="496" y="155" text-anchor="start">Web</text>
-          <!-- Desktop -->
-          <rect class="om-chip" x="468" y="220" width="40" height="40" rx="10"/>
-          <g class="om-ico" transform="translate(476,228)"><rect x="3" y="4" width="18" height="12" rx="1.5"/><line x1="9" y1="20" x2="15" y2="20"/><line x1="12" y1="16" x2="12" y2="20"/></g>
-          <text class="om-name" x="512" y="245" text-anchor="start">Desktop</text>
-          <!-- IM -->
-          <rect class="om-chip" x="452" y="310" width="40" height="40" rx="10"/>
+          <rect class="om-chip" x="468" y="218" width="40" height="40" rx="11"/>
+          <g class="om-ico" transform="translate(476,226)"><rect x="3" y="4" width="18" height="12" rx="1.5"/><line x1="9" y1="20" x2="15" y2="20"/><line x1="12" y1="16" x2="12" y2="20"/></g>
+          <text class="om-name" x="512" y="243" text-anchor="start">Desktop</text>
+          <rect class="om-chip" x="452" y="310" width="40" height="40" rx="11"/>
           <g class="om-ico" transform="translate(460,318)"><path d="M20 15a2 2 0 0 1-2 2H8l-4 4V6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2z"/></g>
           <text class="om-name" x="496" y="335" text-anchor="start">IM</text>
         </svg>
         <figcaption
-          data-en="Everything lives in one body on your machine — only the requests you send cross the line, to the model you chose."
-          data-zh="一切都在你机器上的同一具身体里 —— 只有你发出的请求会越过这条线，去到你选定的模型。"></figcaption>
+          data-en="One local octopus, many arms — its tentacles reach every interface, while the brain and your data stay in one body. Only the requests you send ever leave, to the model you chose."
+          data-zh="一只本地章鱼，多条腕 —— 触手够到每个界面，而大脑和你的数据留在同一具身体里。只有你发出的请求会离开，去到你选定的模型。"></figcaption>
       </figure>
 
       <div class="interfaces">

--- a/landing/index.html
+++ b/landing/index.html
@@ -299,6 +299,27 @@
       margin: 0 auto;
     }
 
+    /* One brain, many arms — the octopus diagram */
+    .octo-map { max-width: 720px; margin: -1rem auto 2.5rem; }
+    .octo-map svg { width: 100%; height: auto; display: block; }
+    .om-boundary { fill: none; stroke: var(--muted); stroke-width: 1.4; stroke-dasharray: 4 6; opacity: 0.5; }
+    .om-boundary-label { fill: var(--muted); font-size: 12px; letter-spacing: 0.04em; text-transform: uppercase; }
+    .om-arm { fill: none; stroke: var(--accent); stroke-width: 2.2; stroke-linecap: round; opacity: 0.85; stroke-dasharray: 4 10; animation: om-flow 3.4s linear infinite; }
+    .om-exit { fill: none; stroke: var(--accent); stroke-width: 2.2; stroke-linecap: round; }
+    .om-chip { fill: var(--card-bg); stroke: var(--border); stroke-width: 1.4; }
+    .om-ico { fill: none; stroke: var(--accent); stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; }
+    .om-name { fill: var(--fg-secondary); font-size: 14px; font-weight: 600; }
+    .om-brain-ring { fill: var(--accent-soft); stroke: var(--accent); stroke-width: 1.5; }
+    .om-brain-body { fill: var(--accent); }
+    .om-brain-eye { fill: var(--bg); }
+    .om-model { fill: var(--accent); }
+    .om-model-txt { fill: #fff; font-size: 13px; font-weight: 600; }
+    .octo-map text { font-family: inherit; }
+    .octo-map figcaption { text-align: center; color: var(--muted); font-size: 0.92rem; max-width: 540px; margin: 0.75rem auto 0; }
+    @keyframes om-flow { to { stroke-dashoffset: -140; } }
+    @media (prefers-reduced-motion: reduce) { .om-arm { animation: none; } }
+    @media (max-width: 640px) { .octo-map { margin-top: 0; } }
+
     /* Feature grid */
     .features {
       display: grid;
@@ -649,6 +670,66 @@
         <p data-en="Each interface is a first-class arm — same brain, same memory, same ~/.octo. Reach the agent from wherever you work."
            data-zh="每个界面都是一条一等公民的腕 —— 同一个大脑、同一份记忆、同一个 ~/.octo。你在哪干活，就从哪够到它。"></p>
       </div>
+
+      <figure class="octo-map reveal">
+        <svg viewBox="0 0 720 430" role="img" aria-label="One brain, many arms — one local agent reaching six interfaces, with only requests leaving your machine">
+          <!-- your-machine boundary -->
+          <rect class="om-boundary" x="28" y="70" width="550" height="330" rx="24"/>
+          <text class="om-boundary-label" x="40" y="60">your machine</text>
+
+          <!-- six arms (brain → interfaces) -->
+          <path class="om-arm" d="M262 216 C216 200 176 165 146 151"/>
+          <path class="om-arm" d="M250 240 C210 232 165 248 134 240"/>
+          <path class="om-arm" d="M262 264 C216 280 176 315 146 329"/>
+          <path class="om-arm" d="M338 216 C384 200 424 165 454 151"/>
+          <path class="om-arm" d="M350 240 C390 232 435 248 466 240"/>
+          <path class="om-arm" d="M338 264 C384 280 424 315 454 329"/>
+
+          <!-- the one thing that leaves: request → model -->
+          <path class="om-exit" d="M300 190 C300 150 300 95 300 46"/>
+          <path class="om-exit" d="M293 55 L300 44 L307 55"/>
+          <rect class="om-model" x="246" y="8" width="108" height="32" rx="16"/>
+          <text class="om-model-txt" x="300" y="29" text-anchor="middle">your model</text>
+
+          <!-- brain -->
+          <circle class="om-brain-ring" cx="300" cy="240" r="50"/>
+          <g transform="translate(259,199) scale(0.82)">
+            <path class="om-brain-body" d="M50 18 C34 18 26 30 26 44 C26 54 32 60 36 62 C34 70 28 78 20 82 C18 83 18 86 20 88 C22 89 25 89 27 87 C33 83 39 76 42 68 C44 69 47 70 50 70 L50 82 C50 85 53 87 56 86 C58 85 59 83 58 81 L56 70 C59 70 62 69 64 68 C67 76 73 83 79 87 C81 89 84 89 86 88 C88 86 88 83 86 82 C78 78 72 70 70 62 C74 60 80 54 80 44 C80 30 72 18 56 18 Z"/>
+            <circle class="om-brain-eye" cx="40" cy="42" r="5"/>
+            <circle class="om-brain-eye" cx="60" cy="42" r="5"/>
+          </g>
+
+          <!-- endpoints: chip + hand-drawn line icon + label -->
+          <!-- Terminal -->
+          <rect class="om-chip" x="108" y="130" width="40" height="40" rx="10"/>
+          <g class="om-ico" transform="translate(116,138)"><polyline points="5 7 10 12 5 17"/><line x1="12" y1="17" x2="19" y2="17"/></g>
+          <text class="om-name" x="96" y="155" text-anchor="end">Terminal</text>
+          <!-- VS Code -->
+          <rect class="om-chip" x="92" y="220" width="40" height="40" rx="10"/>
+          <g class="om-ico" transform="translate(100,228)"><polyline points="9 8 5 12 9 16"/><polyline points="15 8 19 12 15 16"/></g>
+          <text class="om-name" x="80" y="245" text-anchor="end">VS Code</text>
+          <!-- Obsidian -->
+          <rect class="om-chip" x="108" y="310" width="40" height="40" rx="10"/>
+          <g class="om-ico" transform="translate(116,318)"><path d="M12 2 4 9l8 13 8-13-8-7z"/><path d="M4 9h16"/></g>
+          <text class="om-name" x="96" y="335" text-anchor="end">Obsidian</text>
+          <!-- Web -->
+          <rect class="om-chip" x="452" y="130" width="40" height="40" rx="10"/>
+          <g class="om-ico" transform="translate(460,138)"><circle cx="12" cy="12" r="9"/><line x1="3" y1="12" x2="21" y2="12"/><path d="M12 3c3.5 3 3.5 15 0 18M12 3c-3.5 3-3.5 15 0 18"/></g>
+          <text class="om-name" x="496" y="155" text-anchor="start">Web</text>
+          <!-- Desktop -->
+          <rect class="om-chip" x="468" y="220" width="40" height="40" rx="10"/>
+          <g class="om-ico" transform="translate(476,228)"><rect x="3" y="4" width="18" height="12" rx="1.5"/><line x1="9" y1="20" x2="15" y2="20"/><line x1="12" y1="16" x2="12" y2="20"/></g>
+          <text class="om-name" x="512" y="245" text-anchor="start">Desktop</text>
+          <!-- IM -->
+          <rect class="om-chip" x="452" y="310" width="40" height="40" rx="10"/>
+          <g class="om-ico" transform="translate(460,318)"><path d="M20 15a2 2 0 0 1-2 2H8l-4 4V6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2z"/></g>
+          <text class="om-name" x="496" y="335" text-anchor="start">IM</text>
+        </svg>
+        <figcaption
+          data-en="Everything lives in one body on your machine — only the requests you send cross the line, to the model you chose."
+          data-zh="一切都在你机器上的同一具身体里 —— 只有你发出的请求会越过这条线，去到你选定的模型。"></figcaption>
+      </figure>
+
       <div class="interfaces">
         <div class="iface reveal">
           <div class="iface-icon">💻</div>


### PR DESCRIPTION
Gives the **"One brain, many arms"** section its signature visual — turning the copy we just shipped into an image.

## What it shows

A central **octopus brain** (the brand mark) with **six arms** reaching out to the six interfaces — Terminal, Web, Desktop, IM, VS Code, Obsidian — each a **hand-drawn line icon** in a chip. A dashed **"your machine"** boundary encloses the whole body; the one **solid arrow** that crosses it goes up to **"your model"** — the only thing that ever leaves. One image carries both the multi-interface story and the privacy story.

## How it's built

- **Inline SVG, no JS, no deps** — in keeping with the page's "fast, no bloat" pitch.
- Arms have a slow **dash-flow** animation (disabled under `prefers-reduced-motion`).
- Fully **token-driven**, so it themes with the rest of the site — brand indigo `#4f46e5` (light) / `#818cf8` (dark). Rendered and checked in **both light and dark**.
- SVG is `aria-hidden` with a real `<figcaption>`; the six cards below remain the substantive, accessible content.

Placed between the section header and the six interface cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)