### PR TITLE
chore: bump version to 1.12.4

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.3"
+var Version = "1.12.4"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Release 1.12.4.

Headline since 1.12.3: the **file recycle bin (回收站) upgrade** (#1392) — safe restore with conflict policy (no silent overwrite), overwrite protection before write/edit (git-clean files skipped), `octo trash` CLI + `/trash` TUI, retention + size-cap eviction, provenance metadata + one-click undo in the web transcript, session-title labels, and the POSIX absolute-path `rm` fix. Plus desktop webview fixes (#1387/#1388), sub-agent panel fix (#1394), and image-gen endpoint default (#1393).

Tag `v1.12.4` on the merge of this PR triggers goreleaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)