### PR TITLE
docs: surface the recycle bin as a first-class safety feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,12 +347,22 @@ octo --sandbox --sandbox-write ./build      # extra writable dir (repeatable)
 octo --sandbox --sandbox-read /opt/data     # extra readable dir (repeatable)
 ```
 
+## Recycle bin
+
+An agent that goes off the rails and deletes or overwrites the wrong file shouldn't cost you your work. octo keeps a file-level recycle bin at `~/.octo/trash/`, scoped per project:
+
+- **Deletes are intercepted.** Agent-issued `rm` / `del` / `Remove-Item` are wrapped so the targets are copied to the trash *before* removal, recoverable from the Web UI's **File Recall** panel. The same guard covers deletions the agent makes through sessions, skills, workflows, the scheduler, and memory.
+- **Overwrites are backed up.** Before `write_file` / `edit_file` overwrites an existing file, its previous contents are staged into the trash and the tool result offers a one-click **Undo**. Files that are git-tracked and clean are skipped — `git checkout` already recovers those, so the bin stays lean.
+- **Restore never clobbers.** Restoring a file that has since been recreated at the same path won't silently overwrite it: octo aborts, restores alongside, or moves the current file to the trash first — your choice.
+- **Provenance is recorded.** Each entry knows what removed it (`rm`, `write_file`, a session and its title, a skill, a workflow…) and when, so an accidental delete is easy to tell from an intended one.
+- **Bounded automatically.** Entries age out after 14 days and the bin is capped at 10 GiB (both configurable via `trash.retention_days` / `trash.max_size_mb`), evicting oldest-first so it never grows without limit.
+
 ## Platform notes
 
 octo runs on Linux, macOS, and Windows. A few behaviors differ on Windows:
 
 - **Shell is PowerShell.** The `terminal` tool runs commands through PowerShell (`pwsh`, else Windows PowerShell 5.1), not POSIX `sh` — use PowerShell syntax (`Get-ChildItem`, `Select-String`, `Remove-Item`, `$env:VAR`) and chain with `;` (5.1 has no `&&`). The agent is told this, and the built-in `read_file` / `glob` / `grep` / `write_file` / `edit_file` tools are cross-platform and don't shell out, so prefer them.
-- **Deletes go to the trash, like POSIX.** Agent-issued `Remove-Item` / `rm` / `del` are intercepted and the targets copied to `~/.octo/trash/` before deletion, so they're recoverable from the Web UI trash panel — the same protection as the POSIX `rm` wrapper. Best-effort: literal and globbed filesystem paths are backed up; provider paths (`Env:`, registry), pipeline input, and anything that fails to copy fall through to a normal delete.
+- **Deletes go to the recycle bin, like POSIX.** Agent-issued `Remove-Item` / `rm` / `del` are intercepted and backed up before deletion, the same protection as the POSIX `rm` wrapper (see [Recycle bin](#recycle-bin)). Best-effort: literal and globbed filesystem paths are backed up; provider paths (`Env:`, registry), pipeline input, and anything that fails to copy fall through to a normal delete.
 - **`--sandbox` is unavailable on Windows.** OS confinement is macOS Seatbelt / Linux Landlock only; on Windows `--sandbox` fails closed (refuses to run). The permission engine (interactive prompts) is the safety layer there.
 - **`terminal_input`** (writing to a background process's stdin) is reliable only on POSIX shells; PowerShell's `-Command` mode doesn't deterministically forward stdin to a spawned process.
 
@@ -368,6 +378,7 @@ octo runs on Linux, macOS, and Windows. A few behaviors differ on Windows:
 | Memory & config | done | `~/.octo/octorules.md`, `.octorules`, `octo init`, `@include` |
 | Skills | done | Claude Code-compatible SKILL.md loader (`octo skills`, `/skills`, `/<name>`) |
 | Sandbox | done | OS-enforced `--sandbox` (macOS / Linux) |
+| Recycle bin | done | File-level trash at `~/.octo/trash/` — agent deletes (`rm`/`del`/`Remove-Item`) and `write_file`/`edit_file` overwrites are backed up first; restore or one-click undo from the Web UI, provenance-tagged, retention + size-capped |
 | MCP client | done | `mcp.json` stdio + Streamable HTTP servers, tools/resources/prompts, OAuth (Authorization Code + PKCE); Tool Search defers large MCP schemas until needed |
 | Memory | done | Persistent cross-session memory under `~/.octo/memories/`, auto extract/consolidate |
 | Sub-agents | done | `sub_agent` fan-out, async + resumable (`sub_agent_send`, `sub_agent_status`, `sub_agent_kill`) |

--- a/README_CN.md
+++ b/README_CN.md
@@ -319,6 +319,16 @@ octo --sandbox --sandbox-write ./build      # 额外可写目录（可重复）
 octo --sandbox --sandbox-read /opt/data     # 额外可读目录（可重复）
 ```
 
+## 回收站
+
+Agent 发疯删错、覆盖错文件，不该让你丢掉工作成果。octo 在 `~/.octo/trash/` 维护一个按项目隔离的文件级回收站：
+
+- **删除被拦截。** Agent 发起的 `rm` / `del` / `Remove-Item` 会被包一层，目标在删除*之前*先复制进回收站，之后可从 Web UI 的 **文件回收站** 面板还原。Agent 通过 session、skill、workflow、调度器、记忆等途径的删除也同样受保护。
+- **覆盖会备份。** `write_file` / `edit_file` 覆盖已有文件前，旧内容先暂存进回收站，工具结果里给出一键 **撤销**。已被 git 跟踪且干净的文件会跳过 —— `git checkout` 本就能还原，回收站因此保持精简。
+- **还原绝不覆盖。** 如果原路径处已重新存在文件，还原不会静默覆盖它：octo 会中止、还原到旁边、或先把当前文件移入回收站 —— 由你选择。
+- **记录来源。** 每条记录都知道是谁删的（`rm`、`write_file`、某个 session 及其标题、某个 skill、某个 workflow……）以及何时删的，误删和有意删除一眼可辨。
+- **自动有界。** 条目 14 天后自动过期，回收站上限 10 GiB（均可经 `trash.retention_days` / `trash.max_size_mb` 配置），超限时按最旧优先淘汰，绝不无限增长。
+
 ## 已实现
 
 | 领域 | 状态 | 内容 |
@@ -331,6 +341,7 @@ octo --sandbox --sandbox-read /opt/data     # 额外可读目录（可重复）
 | 记忆与配置 | 完成 | `~/.octo/octorules.md`、`.octorules`、`octo init`、`@include` |
 | Skills | 完成 | 兼容 Claude Code 的 SKILL.md 加载器（`octo skills`、`/skills`、`/<name>`） |
 | 沙箱 | 完成 | 操作系统强制的 `--sandbox`（macOS / Linux） |
+| 回收站 | 完成 | `~/.octo/trash/` 文件级回收站 —— agent 的删除（`rm`/`del`/`Remove-Item`）和 `write_file`/`edit_file` 覆盖都先备份；可从 Web UI 还原或一键撤销，带来源标记，按保留期 + 体积上限清理 |
 | MCP 客户端 | 完成 | `mcp.json` 的 stdio + Streamable HTTP 服务，tools/resources/prompts，OAuth（Authorization Code + PKCE）；Tool Search 按需延迟加载大量 MCP 工具 schema |
 | 记忆 | 完成 | `~/.octo/memories/` 下的跨会话持久化记忆，自动抽取/整合 |
 | 子代理 | 完成 | `sub_agent` 并行扇出，异步 + 可恢复（`sub_agent_send`、`sub_agent_status`、`sub_agent_kill`） |

--- a/docs/src/content/docs/guides/sandbox-the-agent.md
+++ b/docs/src/content/docs/guides/sandbox-the-agent.md
@@ -21,5 +21,35 @@ Seatbelt/Landlock only, so on Windows `--sandbox` refuses to run rather than pre
 anything. The permission engine (interactive prompts before each tool call) is the safety layer
 there instead.
 
+## Recycle bin
+
+Confinement stops the agent from reaching *outside* the project. The recycle bin is the safety net
+*inside* it: an agent that goes off the rails and deletes or overwrites the wrong file shouldn't cost
+you your work. octo keeps a file-level trash at `~/.octo/trash/`, scoped per project.
+
+- **Deletes are intercepted.** Agent-issued `rm` / `del` / `Remove-Item` are wrapped so the targets
+  are copied to the trash *before* removal. The same guard covers deletions the agent makes through
+  sessions, skills, workflows, the scheduler, and memory.
+- **Overwrites are backed up.** Before `write_file` / `edit_file` overwrites an existing file, its
+  previous contents are staged into the trash and the tool result offers a one-click **Undo**. Files
+  that are git-tracked and clean are skipped — `git checkout` already recovers those, so the bin
+  stays lean.
+- **Restore never clobbers.** Restoring a file that has since been recreated at the same path won't
+  silently overwrite it: octo aborts, restores alongside, or moves the current file to the trash
+  first — your choice.
+- **Provenance is recorded.** Each entry knows what removed it (`rm`, `write_file`, a session and its
+  title, a skill, a workflow…) and when.
+- **Bounded automatically.** Entries age out after 14 days and the bin is capped at 10 GiB, evicting
+  oldest-first. Configure both in `config.yml`:
+
+```yaml
+trash:
+  retention_days: 14   # 0 = default (14); negative disables age-out
+  max_size_mb: 10240   # 0 = default (10 GiB); negative disables the cap
+  overwrite_backup: true  # back up files before write_file/edit_file overwrites
+```
+
+Restore, undo, and empty the bin from the Web UI's **File Recall** panel (`octo serve`).
+
 Next: pair sandboxing with [hooks](/docs/guides/hooks/) for a fully automated, still-confined loop,
 or read the full boundary in the [security model](/docs/reference/security/).

--- a/docs/src/content/docs/zh/guides/sandbox-the-agent.md
+++ b/docs/src/content/docs/zh/guides/sandbox-the-agent.md
@@ -20,5 +20,30 @@ Linux 和 macOS 是一等公民。**`--sandbox` 在 Windows 上不可用**——
 Seatbelt/Landlock，所以在 Windows 上 `--sandbox` 会直接拒绝运行，而不是假装限制了什么。
 权限引擎（每次工具调用前的交互式确认）是那边唯一的安全层。
 
+## 回收站
+
+沙箱管住的是 agent 伸到项目*外面*的手，回收站则是项目*里面*的安全网：agent 发疯删错、覆盖错
+文件，不该让你丢掉工作成果。octo 在 `~/.octo/trash/` 维护一个按项目隔离的文件级回收站。
+
+- **删除被拦截。** Agent 发起的 `rm` / `del` / `Remove-Item` 会被包一层，目标在删除*之前*先复制进
+  回收站。Agent 通过 session、skill、workflow、调度器、记忆等途径的删除也同样受保护。
+- **覆盖会备份。** `write_file` / `edit_file` 覆盖已有文件前，旧内容先暂存进回收站，工具结果里给出
+  一键 **撤销**。已被 git 跟踪且干净的文件会跳过——`git checkout` 本就能还原，回收站因此保持精简。
+- **还原绝不覆盖。** 如果原路径处已重新存在文件，还原不会静默覆盖它：octo 会中止、还原到旁边、或先
+  把当前文件移入回收站——由你选择。
+- **记录来源。** 每条记录都知道是谁删的（`rm`、`write_file`、某个 session 及其标题、某个 skill、某个
+  workflow……）以及何时删的。
+- **自动有界。** 条目 14 天后自动过期，回收站上限 10 GiB，超限时按最旧优先淘汰。二者都可在
+  `config.yml` 里配置：
+
+```yaml
+trash:
+  retention_days: 14   # 0 = 默认（14）；负数则禁用过期
+  max_size_mb: 10240   # 0 = 默认（10 GiB）；负数则禁用上限
+  overwrite_backup: true  # write_file/edit_file 覆盖前是否备份
+```
+
+从 Web UI 的 **文件回收站** 面板（`octo serve`）还原、撤销、清空回收站。
+
 下一步：把沙箱和[hooks](/docs/zh/guides/hooks/)搭配使用可以实现全自动、依然受限的循环；
 完整的安全边界见[安全模型](/docs/zh/reference/security/)。

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.3"
+var Version = "1.12.4"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.

--- a/landing/index.html
+++ b/landing/index.html
@@ -627,6 +627,12 @@
              data-zh="配置与权限变更先校验、后生效 —— config.yml 或 permissions.yml 改错了也不会把正在跑的 agent 搞挂，新配置没校验通过就继续用上一份好的。"></p>
         </div>
         <div class="feature reveal">
+          <span class="feature-icon">♻️</span>
+          <h3 data-en="A recycle bin for your files" data-zh="给文件留一个回收站"></h3>
+          <p data-en="An agent that goes rogue and deletes or overwrites the wrong file shouldn't cost you your work. Agent deletes are intercepted and overwrites are backed up before they happen — restore from the Web UI, or hit one-click Undo. Every entry is tagged with what removed it, and the bin bounds itself by age and size."
+             data-zh="Agent 发疯删错、覆盖错文件，不该让你丢掉成果。删除会被拦截、覆盖会被提前备份 —— 从 Web UI 还原，或一键撤销。每条记录都标注是谁删的，回收站还会按时间和体积自动清理。"></p>
+        </div>
+        <div class="feature reveal">
           <span class="feature-icon">⚡</span>
           <h3 data-en="Built for prompt caching" data-zh="为 prompt 缓存而设计"></h3>
           <p data-en="Stable system prompts and message structure keep provider-side prompt caching effective across turns, and cache-read/cache-write tokens are tracked and reported per protocol — so the savings are real and visible, not just a marketing number."


### PR DESCRIPTION
## What

The recycle bin was recently enhanced (overwrite backup + one-click undo, provenance metadata, retention + size cap), but it was still only mentioned in passing as a Windows platform note. This promotes it everywhere users evaluate the safety story.

The hook: **an agent going rogue and deleting or overwriting the wrong file is recoverable.**

## Changes

- **README.md / README_CN.md** — dedicated `Recycle bin` section, a `What's implemented` table row, and trimmed the duplicated Windows platform bullet down to a cross-reference.
- **landing/index.html** — a new feature card (♻️) in "Built for people who ship", grouped with the other safety-net cards.
- **docs (EN + ZH)** `guides/sandbox-the-agent` — a `Recycle bin` section framed as the safety net *inside* the project (vs. the sandbox's *outside* boundary), including the `config.yml` knobs (`retention_days`, `max_size_mb`, `overwrite_backup`).

All copy verified against the merged implementation (`internal/trash/trash.go`, `internal/tools/overwrite_backup.go`, `internal/config/config.go`, Web UI File Recall panel) — defaults 14-day retention / 10 GiB cap, git-clean overwrites skipped, restore never silently clobbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)