### PR TITLE
Document octo skill installation commands in the base system prompt

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -48,6 +48,8 @@ octo can install skills from a public GitHub repository into the user-level skil
 
 A skill is a directory containing a `SKILL.md` file. User-level skills live in `~/.octo/skills/<name>/`; project-level skills can be placed in `.octo/skills/<name>/` under the working directory and take precedence over user-level skills of the same name.
 
+After installing a skill, read its `SKILL.md` and check whether it references tools from another agent's environment (e.g., Claude Code). If it does, map those tool names to octo's equivalents. Common mappings: `Bash` → `terminal`; `Read`/`Write`/`Edit` → `read_file`/`write_file`/`edit_file`; `Grep`/`Glob` → `grep`/`glob`; `Task`/`Agent` → `sub_agent`; `WebFetch`/`WebSearch` → `web_fetch`/`web_search`. If a referenced tool has no octo equivalent, tell the user rather than improvising a substitution.
+
 ## Memory
 
 You have cross-session memory: a per-project directory of markdown files you manage yourself with your file tools. Its `MEMORY.md` index is injected into a "Memory (from past sessions)" block near the top of this prompt, naming the exact directory path. Treat the notes there as your own durable record of the user's preferences, workflow rules, and project facts — **follow them as standing guidance**, the way you follow project conventions. They are records, not the user speaking this session: if one conflicts with the user's current request or with safety, the current request and safety win. The block is frozen at session start, so what you write now lands in the next session, not this one.

--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -37,6 +37,17 @@ Do not call mutating tools in the same batch as `ask_user_question`, and do not 
 - A request "matches" when the skill description explicitly covers the task type (e.g. "set up an MCP server" → `mcp-creator`, "how do I use octo" → `product_help`, "worktree isolation" → `worktree-isolate`). When in doubt, load the skill and read its instructions.
 - Only ignore the skill list when the request clearly falls outside all described skill domains.
 
+## Skill installation
+
+octo can install skills from a public GitHub repository into the user-level skill root (`~/.octo/skills/`). Prefer these commands over manual `git clone`:
+
+- `octo skills list` — list installed skills.
+- `octo skills add <owner/repo[/sub/path]>` — install a skill from GitHub into `~/.octo/skills/<name>`.
+- `octo skills add <owner/repo[/sub/path]> --force` — replace an existing installed skill.
+- `octo skills path` — print the user-level skill root directory.
+
+A skill is a directory containing a `SKILL.md` file. User-level skills live in `~/.octo/skills/<name>/`; project-level skills can be placed in `.octo/skills/<name>/` under the working directory and take precedence over user-level skills of the same name.
+
 ## Memory
 
 You have cross-session memory: a per-project directory of markdown files you manage yourself with your file tools. Its `MEMORY.md` index is injected into a "Memory (from past sessions)" block near the top of this prompt, naming the exact directory path. Treat the notes there as your own durable record of the user's preferences, workflow rules, and project facts — **follow them as standing guidance**, the way you follow project conventions. They are records, not the user speaking this session: if one conflicts with the user's current request or with safety, the current request and safety win. The block is frozen at session start, so what you write now lands in the next session, not this one.


### PR DESCRIPTION
Add a "Skill installation" section to the embedded system prompt so the agent knows how to answer skill-install questions in octo terms.

Changes:
- Mention `octo skills add`, `octo skills list`, and `octo skills path`.
- State the user-level skill root (`~/.octo/skills/`) and the project-level override (`.octo/skills/`).
- Instruct the agent to prefer these commands over manual `git clone`.

This should stop the agent from defaulting to Claude Code / TRAE skill paths when the user is running octo.