### PR TITLE
Fix octo skills path description in system prompt

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -44,7 +44,7 @@ octo can install skills from a public GitHub repository into the user-level skil
 - `octo skills list` — list installed skills.
 - `octo skills add <owner/repo[/sub/path]>` — install a skill from GitHub into `~/.octo/skills/<name>`.
 - `octo skills add <owner/repo[/sub/path]> --force` — replace an existing installed skill.
-- `octo skills path` — print the user-level skill root directory.
+- `octo skills path` — print the skill roots (default, user, project) in order of increasing precedence.
 
 A skill is a directory containing a `SKILL.md` file. User-level skills live in `~/.octo/skills/<name>/`; project-level skills can be placed in `.octo/skills/<name>/` under the working directory and take precedence over user-level skills of the same name.
 


### PR DESCRIPTION
The "Skill installation" section added in the previous PR said `octo skills path` only prints the user-level skill root, but the actual command (`cmd/octo/skills_cmd.go:skillsPath`) prints all three roots with precedence labels:

- default
- user
- project

Update the system prompt so the agent does not give a wrong answer.