### PR TITLE
Teach code-review skill to dispatch sub-agents in parallel

### DIFF
--- a/internal/prompt/base.md
+++ b/internal/prompt/base.md
@@ -44,7 +44,7 @@ octo can install skills from a public GitHub repository into the user-level skil
 - `octo skills list` — list installed skills.
 - `octo skills add <owner/repo[/sub/path]>` — install a skill from GitHub into `~/.octo/skills/<name>`.
 - `octo skills add <owner/repo[/sub/path]> --force` — replace an existing installed skill.
-- `octo skills path` — print the user-level skill root directory.
+- `octo skills path` — print the skill roots (default, user, project) in order of increasing precedence.
 
 A skill is a directory containing a `SKILL.md` file. User-level skills live in `~/.octo/skills/<name>/`; project-level skills can be placed in `.octo/skills/<name>/` under the working directory and take precedence over user-level skills of the same name.
 

--- a/internal/skills/defaults/code-review/SKILL.md
+++ b/internal/skills/defaults/code-review/SKILL.md
@@ -28,6 +28,8 @@ Also identify:
 
 Call the `sub_agent` tool with `subagent_type: "code-review"` — a read-only reviewer that starts with zero context. Pass it the diff range, file list, and tech design reference in the prompt — but NOT your implementation reasoning or conversation history.
 
+If you need to review multiple independent changes (e.g., several PRs), dispatch each sub-agent with `run_in_background: true` so they run in parallel. Wait for the completion notifications and collect results with `sub_agent_status` (or from the notifications themselves). For a single review, a synchronous `sub_agent` call is fine.
+
 The sub-agent prompt should follow the template in [code-reviewer.md](code-reviewer.md).
 
 Fill in:


### PR DESCRIPTION
The code-review skill instructions told the caller to dispatch an isolated sub-agent but did not explain how to run multiple independent reviews concurrently. In practice, a review of several PRs would block on the first sub-agent and only start the second after it returned.

Add a short paragraph to the "Dispatch the sub-agent" step explaining:

- For multiple independent reviews, set `run_in_background: true` on each `sub_agent` call.
- Collect the results from completion notifications or via `sub_agent_status`.
- A single review can still use a synchronous `sub_agent` call.