### PR TITLE
Improve sub_agent guidance for background and parallel use

### DIFF
--- a/internal/skills/defaults/code-review/SKILL.md
+++ b/internal/skills/defaults/code-review/SKILL.md
@@ -28,7 +28,7 @@ Also identify:
 
 Call the `sub_agent` tool with `subagent_type: "code-review"` — a read-only reviewer that starts with zero context. Pass it the diff range, file list, and tech design reference in the prompt — but NOT your implementation reasoning or conversation history.
 
-If you need to review multiple independent changes (e.g., several PRs), dispatch each sub-agent with `run_in_background: true` so they run in parallel. Wait for the completion notifications and collect results with `sub_agent_status` (or from the notifications themselves). For a single review, a synchronous `sub_agent` call is fine.
+If you need to review multiple independent changes (e.g., several PRs), dispatch each sub-agent with `run_in_background: true` so they run in parallel. Wait for the completion notifications and use the results from those notifications. Do not poll `sub_agent_status` while waiting; use `sub_agent_status` only if you suspect an agent is stuck or need to list running agents. For a single short review, a synchronous `sub_agent` call is fine.
 
 The sub-agent prompt should follow the template in [code-reviewer.md](code-reviewer.md).
 

--- a/internal/skills/defaults/code-review/SKILL.md
+++ b/internal/skills/defaults/code-review/SKILL.md
@@ -28,6 +28,8 @@ Also identify:
 
 Call the `sub_agent` tool with `subagent_type: "code-review"` — a read-only reviewer that starts with zero context. Pass it the diff range, file list, and tech design reference in the prompt — but NOT your implementation reasoning or conversation history.
 
+If you need to review multiple independent changes (e.g., several PRs), dispatch each sub-agent with `run_in_background: true` so they run in parallel. Wait for the completion notifications and collect results with `sub_agent_status` (or from the notifications themselves). For a single review, a synchronous `sub_agent` call is fine.
+
 The sub-agent prompt should follow the template in [code-reviewer.md](code-reviewer.md).
 
 Fill in:

--- a/internal/tools/agent.go
+++ b/internal/tools/agent.go
@@ -42,11 +42,13 @@ func (AgentTool) Definition() agent.ToolDefinition {
 			"- **Fresh agent** (set subagent_type): the child starts with zero context and a " +
 			"specialized persona. Provide a complete task description. Use when you want an " +
 			"independent read (e.g. code review).\n\n" +
-			"Set run_in_background=true to run asynchronously — you will be notified when " +
-			"it completes. Leave it false (default) to block and receive the result directly. " +
+			"Set run_in_background=true when you are dispatching multiple independent sub-agents that can run in parallel, " +
+			"or when a sub-agent is expected to take a while. You will be notified when it completes. " +
+			"Leave it false (default) to block and receive the result directly when the task is short. " +
 			"(Some transports run every sub-agent synchronously; the result says so when it does.)\n\n" +
-			"Follow up with sub_agent_send (message a child with its context intact), " +
-			"sub_agent_status (check progress / latest result), and sub_agent_kill.",
+			"Follow up with sub_agent_send. Do not poll sub_agent_status while waiting for a background sub-agent; " +
+			"wait for the completion notification instead. Use sub_agent_status only to list running agents or when you " +
+			"suspect a sub-agent is stuck. Use sub_agent_kill to terminate a stuck or no-longer-needed agent.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/agent_followup.go
+++ b/internal/tools/agent_followup.go
@@ -96,10 +96,12 @@ type AgentStatusTool struct{}
 func (AgentStatusTool) Definition() agent.ToolDefinition {
 	return agent.ToolDefinition{
 		Name: "sub_agent_status",
-		Description: "Check on async sub-agents: with agent_id, report that sub-agent's state " +
-			"(running/done/exited) and its latest result; without agent_id, list all currently " +
-			"running sub-agents. Synchronous sub-agents return their result inline at spawn " +
-			"and are not tracked here unless the user promotes them to background while running.",
+		Description: "Check on async sub-agents, but do not use this as a polling loop while waiting for a " +
+			"background sub-agent to finish — wait for the completion notification instead. With agent_id, report " +
+			"that sub-agent's state (running/done/exited) and its latest result; without agent_id, list all currently " +
+			"running sub-agents. Use this tool only when you suspect a sub-agent is stuck or when you need to know " +
+			"which agents are still running. Synchronous sub-agents return their result inline at spawn and are not " +
+			"tracked here unless the user promotes them to background while running.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{


### PR DESCRIPTION
Make it clear when and how to run sub-agents in the background, and how to collect their results.

Changes:
- `internal/tools/agent.go`: the `sub_agent` description now says to set `run_in_background=true` for multiple independent agents that can run in parallel, or for long-running sub-agents. It also tells the model to wait for completion notifications instead of polling `sub_agent_status`.
- `internal/tools/agent_followup.go`: the `sub_agent_status` description now explicitly warns against polling while waiting and limits its use to listing running agents or checking on a suspected stuck agent.
- `internal/skills/defaults/code-review/SKILL.md`: the code-review skill now instructs the caller to dispatch independent reviews with `run_in_background: true`, wait for notifications, and only use `sub_agent_status` if an agent seems stuck.

Also runs `go test ./internal/tools/... ./internal/prompt/... ./internal/skills/...` and `go vet ./...` — all green.