### PR TITLE
Bump version to 1.12.5

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.4"
+var Version = "1.12.5"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Prepare for the 1.12.5 release by updating `internal/version/version.go`.