### PR TITLE
docs(loop): clarify interval mode for fixed-cadence polling

### DIFF
--- a/internal/skills/defaults/loop/SKILL.md
+++ b/internal/skills/defaults/loop/SKILL.md
@@ -44,7 +44,7 @@ wakeup re-arms itself automatically:
 ```
 schedule_wakeup(delay_seconds=120, repeat=true,
                 reason="checking if PR is merged every 2 minutes",
-                prompt="Check whether the PR has been merged. If it has, say so and stop the loop. If not, just report the current status.")
+                prompt="Check whether the PR has been merged. If it has, say so and stop the loop by cancelling the wakeup. If not, just report the current status.")
 ```
 
 You only call it **once** — the cadence holds on its own. Each tick re-runs
@@ -52,15 +52,6 @@ You only call it **once** — the cadence holds on its own. Each tick re-runs
 the same work. **Do NOT call `schedule_wakeup` again inside the tick; the timer
 re-arms automatically.** The loop keeps ticking until it's stopped (see
 **Stopping**).
-
-### Why interval mode for fixed-interval polling?
-
-A polling task like "check every 2 minutes if PR #123 is merged" is a perfect
-fit for interval mode: the user named the interval (`2m`), and the work repeats
-until a condition is met. Use `repeat=true` and let the system wake you up on
-cadence. On each tick, inspect the state; if the goal is achieved, call
-`schedule_wakeup(cancel=true)` to stop. If not, simply report the status and end
-your turn — the next tick will fire automatically.
 
 ## Dynamic mode — you set the pace
 

--- a/internal/skills/defaults/loop/SKILL.md
+++ b/internal/skills/defaults/loop/SKILL.md
@@ -22,6 +22,11 @@ The text after `/loop` is `[interval] <task>`:
 - **Interval given** (`/loop 5m check the build`, `/loop 30s …`, `/loop 2h …`) →
   **interval mode**. Parse the leading duration to seconds and run the task on
   that fixed cadence.
+  - **Rule of thumb:** if the user names a concrete interval, use interval mode
+    with `repeat=true`. The system will re-run the task on that cadence; you do
+    **not** need to call `schedule_wakeup` again on each tick. Once the goal is
+    met (e.g. the PR is merged, CI is green), call `schedule_wakeup(cancel=true)`
+    to stop the loop.
 - **No interval** (`/loop keep refining the draft until it reads cleanly`) →
   **dynamic mode**. You choose the cadence each turn and you decide when to stop.
 
@@ -30,23 +35,39 @@ loop that runs the wrong task wastes every iteration.
 
 ## Interval mode — fixed cadence
 
+Use this when the user wants the same task checked or run on a **steady
+cadence** (e.g. polling a CI job, a deploy, a PR merge status, or a queue).
+
 Do the task once, then call `schedule_wakeup` **with `repeat: true`** so the
 wakeup re-arms itself automatically:
 
 ```
-schedule_wakeup(delay_seconds=300, repeat=true,
-                reason="polling the deploy every 5m until it's live",
-                prompt="<the task to run each tick>")
+schedule_wakeup(delay_seconds=120, repeat=true,
+                reason="checking if PR is merged every 2 minutes",
+                prompt="Check whether the PR has been merged. If it has, say so and stop the loop. If not, just report the current status.")
 ```
 
 You only call it **once** — the cadence holds on its own. Each tick re-runs
 `prompt` as a fresh turn. Pass the task verbatim as `prompt` so every tick does
-the same work. The loop keeps ticking until it's stopped (see **Stopping**).
+the same work. **Do NOT call `schedule_wakeup` again inside the tick; the timer
+re-arms automatically.** The loop keeps ticking until it's stopped (see
+**Stopping**).
+
+### Why interval mode for fixed-interval polling?
+
+A polling task like "check every 2 minutes if PR #123 is merged" is a perfect
+fit for interval mode: the user named the interval (`2m`), and the work repeats
+until a condition is met. Use `repeat=true` and let the system wake you up on
+cadence. On each tick, inspect the state; if the goal is achieved, call
+`schedule_wakeup(cancel=true)` to stop. If not, simply report the status and end
+your turn — the next tick will fire automatically.
 
 ## Dynamic mode — you set the pace
 
-Do the task, then call `schedule_wakeup` **with `repeat: false`** (the default)
-to come back later:
+Use this when the user did **not** specify an interval, or when the next step
+depends on what you learn in this turn and you want to decide the cadence
+yourself (e.g. "keep refining this draft until it reads cleanly"). Do **not**
+use dynamic mode for fixed-interval polling; that is what interval mode is for.
 
 ```
 schedule_wakeup(delay_seconds=900, reason="<what you're waiting for>",

--- a/internal/tools/schedule_wakeup.go
+++ b/internal/tools/schedule_wakeup.go
@@ -136,7 +136,7 @@ func (ScheduleWakeupTool) Definition() agent.ToolDefinition {
 				},
 				"repeat": map[string]any{
 					"type":        "boolean",
-					"description": "false (default) for dynamic mode (fires once; re-arm yourself to continue). true for interval mode (re-arms automatically on the same cadence).",
+					"description": "false (default) for dynamic mode (fires once; you must call schedule_wakeup again on the next turn to continue). true for interval mode (the wakeup re-arms automatically on the same cadence; do NOT call schedule_wakeup again inside each tick).",
 				},
 				"cancel": map[string]any{
 					"type":        "boolean",


### PR DESCRIPTION
Improve the loop skill and schedule_wakeup tool descriptions so the model chooses interval mode (repeat=true) when the user names a concrete interval, instead of re-scheduling every tick in dynamic mode.

Changes:
- Add a hard rule of thumb: concrete interval -> interval mode with repeat=true.
- Add a PR-merge polling example (`/loop 2m check if PR is merged`).
- Emphasize that interval mode re-arms automatically and must not be called again inside each tick.
- Clarify when to use dynamic mode vs interval mode.
- Tighten the `schedule_wakeup` repeat parameter description.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>