### PR TITLE
Fix silent notification failures on macOS desktop

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -210,6 +210,19 @@ func (b *nativeBridge) Notify(title, body string) {
 	})
 }
 
+// requestNotificationAuthorization asks the OS for permission to post
+// notifications, without which every Notify call silently no-ops. macOS
+// requires this at runtime: UNUserNotificationCenter drops delivery (reporting
+// no error) until the user has granted authorization, so the first call raises
+// the system permission prompt and blocks until they answer — run it off the UI
+// thread. Windows/Linux grant immediately. No-op without a notifier.
+func (b *nativeBridge) requestNotificationAuthorization() {
+	if b.notifier == nil {
+		return
+	}
+	_, _ = b.notifier.RequestNotificationAuthorization()
+}
+
 // Update-check notifications: the tray "Check for Updates…" flow reports via a
 // toast rather than a modal dialog. The "update available" toast carries an
 // action button; both it and a tap on the body open the download page, routed

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -43,6 +43,13 @@ type nativeBridge struct {
 	// option; ShouldQuit there always allows the quit).
 	allowQuit atomic.Bool
 
+	// notifySeq makes each Notify call's notification identifier unique. macOS
+	// rejects an addNotificationRequest with an empty identifier (its completion
+	// handler errors and nothing is delivered), and a shared constant id would
+	// make each new toast silently replace the previous one, so every call gets
+	// its own.
+	notifySeq atomic.Uint64
+
 	settingsMu sync.Mutex
 	settings   desktopSettings
 	// geomTimer debounces persistence of the window geometry to disk: a drag
@@ -205,6 +212,7 @@ func (b *nativeBridge) Notify(title, body string) {
 		return
 	}
 	_ = b.notifier.SendNotification(notifications.NotificationOptions{
+		ID:    fmt.Sprintf("octo-notify-%d", b.notifySeq.Add(1)),
 		Title: title,
 		Body:  body,
 	})

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -218,6 +218,9 @@ func main() {
 		// service has started (Windows/Linux drop the action buttons if a
 		// notification is sent before its category is registered).
 		bridge.registerUpdateNotifyCategory()
+		// Prompt for notification permission (macOS blocks until answered, so
+		// off the UI thread) — without it every toast silently no-ops.
+		go bridge.requestNotificationAuthorization()
 		startHub(app, bridge, settings)
 	})
 


### PR DESCRIPTION
## Problem

On the packaged macOS desktop app, clicking the tray **"Check for updates…"** item did nothing — no toast at all. The same silent failure hit the web frontend's turn-complete activity notifications (`/api/native/notify`), which go through the same bridge.

## Root cause

Two independent bugs stacked, both specific to macOS's `UNUserNotificationCenter`:

1. **No authorization was ever requested.** macOS requires runtime authorization; without a granted authorization it drops every notification *and reports no error* to the completion handler. `cmd/octo-desktop` never called `RequestNotificationAuthorization`.

2. **`bridge.Notify` sent an empty notification identifier.** Even once authorized, `addNotificationRequest` with an empty identifier is rejected — the completion handler errors and nothing is delivered, not even to Notification Center. `NotifyUpdateAvailable` already set an id, so only the empty-id path (update-check result toasts + web activity notifications) was affected.

## Fix

1. Request notification authorization once at startup, in the `ApplicationStarted` handler (after the notification service has initialized). macOS raises the system permission prompt and blocks until the user answers, so it runs off the UI thread; Windows/Linux `RequestNotificationAuthorization()` returns `(true, nil)` immediately, so the call is harmless there.

2. Give each `Notify` call a unique identifier from an atomic counter — unique rather than a shared constant so a new toast doesn't silently replace the previous one.

## Verification

Verified end-to-end on a packaged macOS `Octo.app` bundle:
- First launch raises the "Octo would like to send you notifications" system prompt; after granting, System Settings → Notifications → Octo shows the permission enabled.
- Before the id fix, `POST /api/native/notify` delivered nothing (absent even from Notification Center) despite authorization; after it, the notification raises a visible banner.

`go build ./...` and `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)