### PR TITLE
fix(server): don't stack duplicate loop-tick steers while a turn runs

### DIFF
--- a/internal/server/loop.go
+++ b/internal/server/loop.go
@@ -38,9 +38,41 @@ func (w serverWaker) CancelWakeup() error {
 // the same path background/sub-agent completion notes use.
 func (s *Server) armWakeup(sessionID string, delay time.Duration, prompt string, repeat bool) {
 	s.armWakeupFn(sessionID, delay, repeat, func() {
-		s.enqueueSteer(sessionID, agent.InboxItem{Text: prompt})
-		s.kickIdleSteerTurn(sessionID)
+		s.deliverLoopTick(sessionID, prompt, repeat)
 	})
+}
+
+// deliverLoopTick injects one loop tick as a user steer and kicks an idle turn.
+// In interval mode it no-ops while a turn is already running: kickIdleSteerTurn
+// bails when busy, so the steer would sit undrained and every later tick would
+// stack another identical copy for the running turn to replay. The interval
+// timer has already re-armed, so the next tick delivers once the session is
+// idle — mirroring the TUI, which only re-arms (never queues) while a turn runs.
+func (s *Server) deliverLoopTick(sessionID, prompt string, repeat bool) {
+	if s.shouldSkipTick(sessionID, repeat) {
+		return
+	}
+	s.enqueueSteer(sessionID, agent.InboxItem{Text: prompt})
+	s.kickIdleSteerTurn(sessionID)
+}
+
+// shouldSkipTick reports whether this tick's delivery should be dropped because
+// a turn is already running. Only interval mode (repeat) skips: its timer
+// re-arms independently, so a dropped tick is retried next cadence. A dynamic
+// tick (repeat=false) fires exactly once and does NOT re-arm — dropping it would
+// silently kill the loop, so it always delivers; the running turn drains the
+// steer at its next chain boundary and the model re-arms from there.
+func (s *Server) shouldSkipTick(sessionID string, repeat bool) bool {
+	return repeat && s.turnActive(sessionID)
+}
+
+// turnActive reports whether a turn is currently running for the session,
+// reading turnRunning under the session's turn lock (its guarding mutex).
+func (s *Server) turnActive(sessionID string) bool {
+	mu := s.sessionTurnLock(sessionID)
+	mu.Lock()
+	defer mu.Unlock()
+	return s.turnRunning[sessionID]
 }
 
 // armWakeupFn (re)starts the loop wakeup timer for key, replacing any pending

--- a/internal/server/loop_test.go
+++ b/internal/server/loop_test.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/channel"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
@@ -90,10 +92,63 @@ func TestServerWaker_MaxLifetimeStops(t *testing.T) {
 	}
 }
 
+// An interval tick must not enqueue a steer while a turn is already running: the
+// steer would sit undrained (kickIdleSteerTurn bails when busy) and every later
+// tick would stack another identical copy. The re-armed timer delivers on the
+// next idle tick instead.
+func TestDeliverLoopTick_IntervalSkipsWhileTurnRunning(t *testing.T) {
+	s := newLoopTestServer()
+	s.turnRunning["sid"] = true
+	s.deliverLoopTick("sid", "check whether the PR is merged", true)
+	if q := s.steerQueues["sid"]; len(q) != 0 {
+		t.Fatalf("expected no steer enqueued while a turn runs, got %d", len(q))
+	}
+}
+
+// shouldSkipTick gates only interval ticks on a running turn. A dynamic tick
+// (repeat=false) fires once and never re-arms, so it must deliver even while a
+// turn runs — skipping it would silently kill the loop.
+func TestShouldSkipTick(t *testing.T) {
+	cases := []struct {
+		name    string
+		repeat  bool
+		running bool
+		skip    bool
+	}{
+		{"interval, turn running", true, true, true},
+		{"interval, idle", true, false, false},
+		{"dynamic, turn running", false, true, false}, // must NOT skip: no re-arm
+		{"dynamic, idle", false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newLoopTestServer()
+			s.turnRunning["sid"] = tc.running
+			if got := s.shouldSkipTick("sid", tc.repeat); got != tc.skip {
+				t.Fatalf("shouldSkipTick(repeat=%v, running=%v) = %v, want %v", tc.repeat, tc.running, got, tc.skip)
+			}
+		})
+	}
+}
+
+func TestServer_TurnActive(t *testing.T) {
+	s := newLoopTestServer()
+	if s.turnActive("sid") {
+		t.Fatal("a session with no running turn must report inactive")
+	}
+	s.turnRunning["sid"] = true
+	if !s.turnActive("sid") {
+		t.Fatal("a session with a running turn must report active")
+	}
+}
+
 func newLoopTestServer() *Server {
 	return &Server{
 		wakeupTimers: map[string]*time.Timer{},
 		wakeupStart:  map[string]time.Time{},
+		turnRunning:  map[string]bool{},
+		turnLocks:    map[string]*sync.Mutex{},
+		steerQueues:  map[string][]agent.InboxItem{},
 	}
 }
 


### PR DESCRIPTION
## Problem

In the web `serverWaker`, the interval-mode (`repeat=true`) fire callback ran `enqueueSteer(prompt)` + `kickIdleSteerTurn` unconditionally. When a woken turn runs **longer than the interval**, `kickIdleSteerTurn` bails (turn busy) — but the steer has already been queued. A *running* `runAgentTurnLoop` drains `steerQueues` at every chain boundary (`ws_handlers.go:1041`), so each tick's copy gets replayed, and copies that pile up between boundaries are folded into one turn joined with `\n\n`. The loop prompt ends up running several times back-to-back.

This is an asymmetry with the TUI, which only **re-arms** the timer while a turn runs (never queues): `tuirepl.go` `wakeupMsg` handler, `if m.turnRunning || len(m.queue) > 0 { armWakeup; return }`.

Low impact in practice — `delay_seconds` has a 60s floor and typical polling turns are short — but it bites when the loop prompt itself kicks off a long-running task.

## Fix

Gate delivery on `shouldSkipTick(sessionID, repeat)`:

- **Interval (`repeat=true`)**: skip the enqueue while a turn runs. The timer has already re-armed, so the next tick delivers once idle — mirroring the TUI.
- **Dynamic (`repeat=false`, the default)**: **always deliver**, even during a running turn. A dynamic tick fires exactly once and does **not** re-arm; skipping it would silently kill the loop. The running turn drains the steer at its next chain boundary and the model re-arms from there. (This preserves the pre-existing behavior — dynamic mode fires once, so it never had a stacking problem to begin with.)

## Scope

- **Web only.** `imWaker` is unaffected: it enqueues into the agent's live `Inbox` (drained by the running turn as a mid-turn steer) rather than accumulating in `steerQueues` — a different mechanism, not the same pile-up.
- Docs-only PR #1404 (loop skill wording) is separate and unrelated.

## Tests

- `TestShouldSkipTick` — the full matrix: only `(interval, turn running)` skips; `(dynamic, turn running)` must **not** skip (the regression guard).
- `TestDeliverLoopTick_IntervalSkipsWhileTurnRunning` — no steer enqueued for an interval tick while a turn runs.
- `TestServer_TurnActive` — the helper reports running/idle correctly.

Follows `loop_test.go`'s precedent of testing the arm/deliver bookkeeping without driving the live-session turn machinery (binding + disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)