### PR TITLE
fix(macos-installer): quit running desktop app before replacing bundle

### DIFF
--- a/packaging/macos/scripts/preinstall
+++ b/packaging/macos/scripts/preinstall
@@ -1,11 +1,31 @@
 #!/bin/sh
 # Upgrade + migration prep, run unprivileged (currentUserHome domain, $HOME is
-# the real account). Stop any running `octo serve -d` daemon and remove the
-# legacy login LaunchAgent that the pre-desktop installer registered (it
-# auto-started serve on login and opened the browser dashboard). The desktop
-# app is that UI now, so a leftover autostarting daemon would just be a zombie.
+# the real account). Quit a running Octo desktop app so the .pkg can replace its
+# bundle in place, stop any running `octo serve -d` daemon, and remove the legacy
+# login LaunchAgent that the pre-desktop installer registered (it auto-started
+# serve on login and opened the browser dashboard). The desktop app is that UI
+# now, so a leftover autostarting daemon would just be a zombie.
 # No-op on a clean first install.
 set -eu
+
+# Quit a running Octo desktop app before its bundle is replaced. Without this the
+# .pkg overwrites Octo.app underneath the live process, and postinstall's `open`
+# on an already-running app only reactivates the OLD process — so the user
+# silently keeps running the previous version after "upgrading". Mirrors the
+# taskkill in packaging/windows/octo.iss. The desktop app runs serve in-process
+# (not as an `octo serve -d` daemon), so the `octo serve --stop` below can't
+# reach it — quitting the app is what frees the port and releases the old binary.
+# Graceful first (the app's ShouldQuit always allows termination on macOS, so it
+# tears down cleanly and releases its serveproc pid entry), then hard-kill any
+# stragglers an unresponsive UI leaves behind. No-op on a clean first install.
+osascript -e 'tell application id "dev.octo-agent.desktop" to quit' >/dev/null 2>&1 || true
+n=0
+while [ "$n" -lt 20 ]; do
+  pgrep -f 'Octo.app/Contents/MacOS/octo-desktop' >/dev/null 2>&1 || break
+  sleep 0.25
+  n=$((n + 1))
+done
+pkill -f 'Octo.app/Contents/MacOS/octo-desktop' >/dev/null 2>&1 || true
 
 # Stop a running serve daemon — from an old CLI install or one started by hand.
 old_bin="$HOME/Library/Application Support/octo/bin/octo"

--- a/packaging/macos/scripts/preinstall
+++ b/packaging/macos/scripts/preinstall
@@ -16,8 +16,10 @@ set -eu
 # (not as an `octo serve -d` daemon), so the `octo serve --stop` below can't
 # reach it — quitting the app is what frees the port and releases the old binary.
 # Graceful first (the app's ShouldQuit always allows termination on macOS, so it
-# tears down cleanly and releases its serveproc pid entry), then hard-kill any
-# stragglers an unresponsive UI leaves behind. No-op on a clean first install.
+# tears down cleanly and releases its serveproc pid entry), then SIGTERM any
+# straggler an unresponsive UI leaves behind — a process already mid-shutdown is
+# a no-op. Deliberately not SIGKILL: that would skip the app's pid-file cleanup
+# and leave a stale serveproc entry. No-op on a clean first install.
 osascript -e 'tell application id "dev.octo-agent.desktop" to quit' >/dev/null 2>&1 || true
 n=0
 while [ "$n" -lt 20 ]; do


### PR DESCRIPTION
## Problem

On macOS, installing the Octo desktop `.pkg` while an old version is still running silently leaves the user on the old version — no auto-quit, no prompt.

Root cause:
- The desktop app runs `serve` **in-process**, not as an `octo serve -d` daemon, so preinstall's existing `octo serve --stop` can't reach it.
- The `.pkg` overwrites `~/Applications/Octo.app` underneath the live process.
- postinstall's `open "$app_bundle"` on an **already-running** app just reactivates the old process — it does not relaunch the new binary.

Windows (`packaging/windows/octo.iss`) already handles this with `taskkill /IM octo-desktop.exe /F` at the install step. macOS `preinstall` had no equivalent. Linux ships an AppImage (user replaces the file directly; no in-place bundle overwrite), so it's out of scope.

## Fix

Add an app-quit step to `packaging/macos/scripts/preinstall`, mirroring the Windows taskkill:
1. Graceful quit via `osascript … to quit` (the app's `ShouldQuit` always allows termination on macOS, so it tears down cleanly and releases the serve port + its serveproc pid entry).
2. Poll up to ~5s for the process to exit.
3. `pkill` fallback for an unresponsive UI.

postinstall's `open` then launches the freshly-installed binary. No-op on a clean first install.

## Test

- `sh -n` syntax check passes.
- Not exercised against a live install in CI (the .pkg install flow isn't run in CI); the quit primitives are standard and match the Windows behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)