### PR TITLE
fix(memory): strip <system-reminder> before storing to long-term memory

### DIFF
--- a/internal/tools/memory_backend.go
+++ b/internal/tools/memory_backend.go
@@ -140,6 +140,10 @@ func RegisterMemoryBackendHooks(e *hooks.Engine) {
 			return ""
 		}
 		content := strings.TrimSpace("User: " + p.UserInput + "\nAssistant: " + p.AssistantReply)
+		// Strip <system-reminder> spans before storing so injected context
+		// (recalled memories, background-task notes, goal context, …) never
+		// lands in long-term memory and can't resurface via memory_recall.
+		content = agent.StripSystemReminders(content)
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
@@ -165,7 +169,10 @@ func RegisterMemoryBackendHooks(e *hooks.Engine) {
 				"`memory_recall` again for this same question; only call it if you need to dig further " +
 				"(a different angle, more results, or something this list doesn't cover):\n")
 			for _, r := range results {
-				sb.WriteString("- " + r.Content + "\n")
+				// Recall may return content stored before the strip was added, or
+				// externally indexed text carrying <system-reminder> spans — strip
+				// them so they don't ride the automatic-injection path back in.
+				sb.WriteString("- " + agent.StripSystemReminders(r.Content) + "\n")
 			}
 			sb.WriteString("</system-reminder>")
 			return sb.String()

--- a/internal/tools/memory_backend_test.go
+++ b/internal/tools/memory_backend_test.go
@@ -226,3 +226,71 @@ func TestRegisterMemoryBackendHooks_AutoRecallSkipsEmptyInput(t *testing.T) {
 		t.Errorf("expected empty injection for empty UserInput, got %q", got)
 	}
 }
+
+// TestRegisterMemoryBackendHooks_StripsSystemRemindersBeforeStore guards against
+// <system-reminder> spans (recalled memories, goal context, background-task
+// notes) landing in long-term memory — they'd resurface via memory_recall and
+// ride the tool_result path to the web UI.
+func TestRegisterMemoryBackendHooks_StripsSystemRemindersBeforeStore(t *testing.T) {
+	fake := &fakeMemoryBackend{name: "hindsight", stored: make(chan string, 1)}
+	setMemoryBackendFor(t, fake)
+
+	e := hooks.NewEngine(nil)
+	RegisterMemoryBackendHooks(e)
+	e.Dispatch(context.Background(), hooks.Payload{
+		Event:          hooks.EventStop,
+		UserInput:      "<system-reminder>\n[OLD MEMORY] legacy content\n</system-reminder>Hello",
+		AssistantReply: "Hi",
+	})
+
+	select {
+	case got := <-fake.stored:
+		if strings.Contains(got, "<system-reminder>") || strings.Contains(got, "</system-reminder>") {
+			t.Errorf("stored content should have system-reminder spans stripped, got %q", got)
+		}
+		if strings.Contains(got, "legacy content") {
+			t.Errorf("stored content should not contain reminder body text, got %q", got)
+		}
+		if !strings.Contains(got, "Hello") || !strings.Contains(got, "Hi") {
+			t.Errorf("stored content should keep real turn text, got %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Store was not called within timeout")
+	}
+}
+
+// TestRegisterMemoryBackendHooks_AutoRecallStripsSystemReminders guards Recall
+// results that carry pre-existing <system-reminder> spans (e.g. from before
+// this fix, or external index data) — they must be stripped before the
+// automatic user-prompt injection, not re-injected verbatim.
+func TestRegisterMemoryBackendHooks_AutoRecallStripsSystemReminders(t *testing.T) {
+	fake := &fakeMemoryBackend{
+		name: "hindsight",
+		recallOut: []memorybackend.Result{
+			{ID: "m1", Content: "<system-reminder>\nStale recall body\n</system-reminder>real fact"},
+		},
+	}
+	setMemoryBackendFor(t, fake)
+	SetMemoryBackendAutoRecall(true)
+	t.Cleanup(func() { SetMemoryBackendAutoRecall(false) })
+
+	e := hooks.NewEngine(nil)
+	RegisterMemoryBackendHooks(e)
+	got := e.Inject(context.Background(), hooks.Payload{
+		Event:     hooks.EventUserPromptSubmit,
+		UserInput: "question",
+	})
+
+	// The hook intentionally wraps recalled memory in <system-reminder>, so we
+	// expect exactly one open tag — two would mean the nested span leaked
+	// through. The nested reminder body must be gone.
+	if gotCount := strings.Count(got, "<system-reminder>"); gotCount != 1 {
+		t.Errorf("injected text should have exactly one <system-reminder> wrapper, found %d in %q", gotCount, got)
+	}
+	if strings.Contains(got, "Stale recall body") {
+		t.Errorf("injected text should not contain reminder body from recall result, got %q", got)
+	}
+	if !strings.Contains(got, "real fact") {
+		t.Errorf("injected text should keep the real part of the recall, got %q", got)
+	}
+}


### PR DESCRIPTION
## Problem

`memory_recall` results were leaking prior session context into the web UI. The `EventUserPromptSubmit` hook wraps recalled memories in `<system-reminder>` and injects them into the user message; the `EventStop` hook then stores the full message — including those spans — into the external memory backend. On the next `memory_recall`, the stale `<system-reminder>` spans (with their full prior-session payloads) ride the `tool_result` path to the frontend.

## Fix

Strip `<system-reminder>` spans in two places so injected context never persists:

1. **EventStop hook** — strip before `b.Store`, so only clean text is indexed.
2. **EventUserPromptSubmit hook** — strip each recalled result before wrapping in a fresh `<system-reminder>`. This covers content stored before this fix and any externally indexed text that still carries raw spans.

## Verification

- `go build ./...` passes
- `go test -race ./internal/tools/ ./internal/agent/ -count=1` passes

Fixes the leak reported in session.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>