### PR TITLE
fix(agent): add RWMutex to protect Sender from data race

### DIFF
--- a/cmd/octo/ensure_sender_test.go
+++ b/cmd/octo/ensure_sender_test.go
@@ -62,7 +62,7 @@ func TestEnsureSender_ConfigLoadFailure(t *testing.T) {
 	if cfg.configEntry != origEntry {
 		t.Errorf("configEntry = %+v, want unchanged %+v", cfg.configEntry, origEntry)
 	}
-	if cfg.a.Sender != stub {
+	if cfg.a.GetSender() != stub {
 		t.Error("sender should be unchanged after config.Load() failure")
 	}
 }
@@ -101,10 +101,10 @@ func TestEnsureSender_RebuildsOnProviderChange(t *testing.T) {
 	if cfg.configEntry.BaseURL != "https://api.moonshot.cn/anthropic" {
 		t.Errorf("configEntry.BaseURL = %q, want https://api.moonshot.cn/anthropic", cfg.configEntry.BaseURL)
 	}
-	if cfg.a.Sender == nil {
+	if cfg.a.GetSender() == nil {
 		t.Fatal("sender should be rebuilt, got nil")
 	}
-	if _, ok := cfg.a.Sender.(*stubSender); ok {
+	if _, ok := cfg.a.GetSender().(*stubSender); ok {
 		t.Error("sender should be a real provider sender, not the original stub")
 	}
 }
@@ -136,7 +136,7 @@ func TestEnsureSender_NoRebuildWhenUnchanged(t *testing.T) {
 		t.Fatalf("ensureSender: %v", err)
 	}
 	// Sender must be the same stub — no rebuild happened.
-	if cfg.a.Sender != stub {
+	if cfg.a.GetSender() != stub {
 		t.Error("sender should NOT be rebuilt when provider and base URL match")
 	}
 }
@@ -169,7 +169,7 @@ func TestEnsureSender_RebuildsOnBaseURLChange(t *testing.T) {
 	if cfg.configEntry.BaseURL != "https://api.moonshot.cn/anthropic" {
 		t.Errorf("configEntry.BaseURL = %q, want https://api.moonshot.cn/anthropic", cfg.configEntry.BaseURL)
 	}
-	if cfg.a.Sender == stub {
+	if cfg.a.GetSender() == stub {
 		t.Error("sender should be rebuilt when base URL changes")
 	}
 }
@@ -209,7 +209,7 @@ func TestEnsureSender_ErrorLeavesConfigUnchanged(t *testing.T) {
 	if cfg.configEntry != origEntry {
 		t.Errorf("configEntry = %+v, want unchanged %+v", cfg.configEntry, origEntry)
 	}
-	if cfg.a.Sender != stub {
+	if cfg.a.GetSender() != stub {
 		t.Error("sender should be unchanged after failed rebuild")
 	}
 }

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -107,7 +107,7 @@ func (cfg *replConfig) ensureSender(targetModel string, tuning senderTuning) err
 	if err != nil {
 		return err
 	}
-	cfg.a.Sender = newSender
+	cfg.a.SetSender(newSender)
 	cfg.providerName = provName
 	cfg.configEntry = entry
 	return nil

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1039,7 +1039,7 @@ func (m *tuiModel) dispatchThinking(level string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	m.a.Sender = newSender
+	m.a.SetSender(newSender)
 	m.cfg.reasoningEffort = level
 	return m, nil
 }

--- a/dev-docs/octoagent-pkg-design.md
+++ b/dev-docs/octoagent-pkg-design.md
@@ -112,8 +112,8 @@ type PermissionGate interface {
 
 ```go
 tools.SetBrowserVision(cfg.ModelVision(a.Model))
-tools.SetBrowserSkillGenerator(app.MakeSkillGenerator(a.Sender, a.Model))
-tools.SetBrowserHealer(app.MakeBrowserHealer(a.Sender, a.Model))
+tools.SetBrowserSkillGenerator(app.MakeSkillGenerator(a.GetSender(), a.Model))
+tools.SetBrowserHealer(app.MakeBrowserHealer(a.GetSender(), a.Model))
 ```
 
 如果 Director 并发跑的两个 agent 都启用 browser 工具且用不同 model,这三行会互相覆盖——**这是一个

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -136,10 +136,10 @@ type Reply struct {
 // Agent owns one conversation: the system prompt, the history of turns, the
 // model name, and the LLM transport (Sender).
 type Agent struct {
-	mu      sync.RWMutex // protects Sender (written by TUI event loop, read by turn goroutine)
-	Sender  Sender
-	System  string
-	Model   string
+	mu        sync.RWMutex // protects Sender (written by TUI event loop, read by turn goroutine)
+	Sender    Sender
+	System    string
+	Model     string
 	MaxTokens int
 	History   *History
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -136,11 +136,12 @@ type Reply struct {
 // Agent owns one conversation: the system prompt, the history of turns, the
 // model name, and the LLM transport (Sender).
 type Agent struct {
-	System    string
-	Model     string
+	mu      sync.RWMutex // protects Sender (written by TUI event loop, read by turn goroutine)
+	Sender  Sender
+	System  string
+	Model   string
 	MaxTokens int
 	History   *History
-	Sender    Sender
 
 	// LeanSystem, when set, is a lighter variant of System (skills manifest and
 	// memory dropped) used to seed cheap read-only sub-agents. Empty falls back
@@ -511,11 +512,31 @@ func New(sender Sender, model string) *Agent {
 	}
 }
 
+// GetSender returns the agent's current sender under a read lock. Callers that
+// need a consistent sender across multiple calls (e.g. type-asserting to
+// StreamingSender AND calling SendMessages) should capture the returned value
+// once and use that snapshot.
+func (a *Agent) GetSender() Sender {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.Sender
+}
+
+// SetSender swaps the agent's sender under a write lock. Used by the TUI's
+// /model and /thinking commands to rebuild the sender when the provider or
+// base URL changes.
+func (a *Agent) SetSender(s Sender) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.Sender = s
+}
+
 // Turn appends the user's input to history, asks the Sender for a reply,
 // appends the reply to history, and returns it. Errors leave History
 // unchanged from before the call.
 func (a *Agent) Turn(ctx context.Context, userInput string) (Reply, error) {
-	if a.Sender == nil {
+	sender := a.GetSender()
+	if sender == nil {
 		return Reply{}, fmt.Errorf("agent: no Sender configured")
 	}
 	if a.Model == "" {
@@ -529,7 +550,7 @@ func (a *Agent) Turn(ctx context.Context, userInput string) (Reply, error) {
 	a.appendUserInput(ctx, userInput)
 
 	a.ResetGoalBaseline()
-	reply, err := a.Sender.SendMessages(ctx, a.Model, a.System, a.History.Snapshot(), a.MaxTokens)
+	reply, err := sender.SendMessages(ctx, a.Model, a.System, a.History.Snapshot(), a.MaxTokens)
 	if err != nil {
 		// Pop the user message we just appended so retrying with the same
 		// History doesn't duplicate it. Cheaper than transactional locking
@@ -574,7 +595,8 @@ func (a *Agent) turnStream(
 	onThinking func(thinkingDelta string),
 	handler EventHandler,
 ) (Reply, error) {
-	if a.Sender == nil {
+	sender := a.GetSender()
+	if sender == nil {
 		return Reply{}, fmt.Errorf("agent: no Sender configured")
 	}
 	if a.Model == "" {
@@ -591,13 +613,13 @@ func (a *Agent) turnStream(
 		reply Reply
 		err   error
 	)
-	if ss, ok := a.Sender.(StreamingSender); ok {
+	if ss, ok := sender.(StreamingSender); ok {
 		reply, err = ss.StreamMessages(ctx, a.Model, a.System, a.History.Snapshot(), a.MaxTokens, onChunk, onThinking)
 	} else {
 		// Fallback: buffer the call and surface a single "chunk" with the
 		// full content. Keeps callers from having to branch on capability
 		// at the cost of losing real-time visibility on this backend.
-		reply, err = a.Sender.SendMessages(ctx, a.Model, a.System, a.History.Snapshot(), a.MaxTokens)
+		reply, err = sender.SendMessages(ctx, a.Model, a.System, a.History.Snapshot(), a.MaxTokens)
 		if err == nil && onChunk != nil && reply.Content != "" {
 			onChunk(reply.Content)
 		}
@@ -642,7 +664,8 @@ const truncationResumePrompt = "You were cut off mid-thought. Continue exactly w
 // If tools is nil or executor is nil, Run is equivalent to Turn (single-turn,
 // no tool dispatch).
 func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinition, executor ToolExecutor) (reply Reply, err error) {
-	if a.Sender == nil {
+	sender := a.GetSender()
+	if sender == nil {
 		return Reply{}, fmt.Errorf("agent: no Sender configured")
 	}
 	if a.Model == "" {
@@ -661,7 +684,7 @@ func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinitio
 	if len(tools) == 0 || executor == nil {
 		return a.Turn(ctx, userInput)
 	}
-	ts, ok := a.Sender.(ToolSender)
+	ts, ok := sender.(ToolSender)
 	if !ok {
 		return a.Turn(ctx, userInput)
 	}
@@ -688,7 +711,8 @@ func (a *Agent) RunStream(
 	executor ToolExecutor,
 	handler EventHandler,
 ) (reply Reply, err error) {
-	if a.Sender == nil {
+	sender := a.GetSender()
+	if sender == nil {
 		return Reply{}, fmt.Errorf("agent: no Sender configured")
 	}
 	if a.Model == "" {
@@ -746,13 +770,13 @@ func (a *Agent) RunStream(
 	}
 
 	// Try ToolStreamingSender first, then fall back to ToolSender (buffered).
-	if tss, ok := a.Sender.(ToolStreamingSender); ok {
+	if tss, ok := sender.(ToolStreamingSender); ok {
 		return a.runLoop(ctx, userInput, tools, executor, handler,
 			func(ctx context.Context, msgs []Message, maxTokens int) (Reply, error) {
 				return tss.StreamMessagesWithTools(ctx, a.Model, a.System, msgs, maxTokens, tools, onChunk, onToolDelta, onThinking)
 			})
 	}
-	if ts, ok := a.Sender.(ToolSender); ok {
+	if ts, ok := sender.(ToolSender); ok {
 		return a.runLoop(ctx, userInput, tools, executor, handler,
 			func(ctx context.Context, msgs []Message, maxTokens int) (Reply, error) {
 				reply, err := ts.SendMessagesWithTools(ctx, a.Model, a.System, msgs, maxTokens, tools)
@@ -1217,7 +1241,8 @@ const suggestInstruction = "Suggest ONE concise, specific next message I (the us
 // is told not to call tools; if it returns a tool_use anyway, Content is empty
 // and we simply produce no suggestion that turn.
 func (a *Agent) Suggest(ctx context.Context, tools []ToolDefinition) (string, error) {
-	if a.Sender == nil || a.Model == "" {
+	sender := a.GetSender()
+	if sender == nil || a.Model == "" {
 		return "", fmt.Errorf("agent: suggest: not configured")
 	}
 	snap := a.History.Snapshot()
@@ -1228,7 +1253,6 @@ func (a *Agent) Suggest(ctx context.Context, tools []ToolDefinition) (string, er
 	msgs = append(msgs, snap...)
 	msgs = append(msgs, NewUserMessage(suggestInstruction))
 
-	sender := a.Sender
 	if le, ok := sender.(LowEffortSender); ok {
 		sender = le.LowEffort()
 	}
@@ -1269,7 +1293,8 @@ const titleInstruction = "Summarize this conversation as a short title of at mos
 // rationale). The model is told not to call tools; a stray tool_use yields empty
 // Content and we simply produce no title.
 func (a *Agent) GenerateTitle(ctx context.Context, tools []ToolDefinition) (string, error) {
-	if a.Sender == nil || a.Model == "" {
+	sender := a.GetSender()
+	if sender == nil || a.Model == "" {
 		return "", fmt.Errorf("agent: title: not configured")
 	}
 	snap := a.History.Snapshot()
@@ -1280,7 +1305,6 @@ func (a *Agent) GenerateTitle(ctx context.Context, tools []ToolDefinition) (stri
 	msgs = append(msgs, snap...)
 	msgs = append(msgs, NewUserMessage(titleInstruction))
 
-	sender := a.Sender
 	if le, ok := sender.(LowEffortSender); ok {
 		sender = le.LowEffort()
 	}

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -499,7 +499,7 @@ func (a *Agent) summarize(ctx context.Context, msgs []Message, handler EventHand
 			return summary, nil
 		}
 	}
-	return a.summarizeOn(ctx, a.Sender, a.Model, msgs, handler)
+	return a.summarizeOn(ctx, a.GetSender(), a.Model, msgs, handler)
 }
 
 // summarizeOn runs one summarisation call on the given sender/model pair.

--- a/internal/agent/consolidate.go
+++ b/internal/agent/consolidate.go
@@ -26,7 +26,8 @@ project context, useful references). Output only the updated summary text.`
 // may be empty — empty priorSummary means "first pass"; empty newNotes means
 // "no new material" and the call short-circuits.
 func (a *Agent) ConsolidateMemory(ctx context.Context, priorSummary, newNotes string) (string, error) {
-	if a.Sender == nil {
+	sender := a.GetSender()
+	if sender == nil {
 		return "", fmt.Errorf("agent: no Sender configured")
 	}
 	priorSummary = strings.TrimSpace(priorSummary)
@@ -49,7 +50,7 @@ func (a *Agent) ConsolidateMemory(ctx context.Context, priorSummary, newNotes st
 	prompt.WriteString("Produce the updated consolidated summary per your instructions.")
 
 	req := []Message{NewUserMessage(prompt.String())}
-	reply, err := a.Sender.SendMessages(ctx, a.Model, consolidateSystem, req, consolidateMaxTokens)
+	reply, err := sender.SendMessages(ctx, a.Model, consolidateSystem, req, consolidateMaxTokens)
 	if err != nil {
 		return "", err
 	}

--- a/internal/agent/sessionstart_test.go
+++ b/internal/agent/sessionstart_test.go
@@ -42,7 +42,7 @@ func TestSessionStart_StartupFiresPersistsAndFolds(t *testing.T) {
 	if !a.SessionStarted {
 		t.Error("SessionStarted must be set after startup")
 	}
-	send := a.Sender.(*fakeSender)
+	send := a.GetSender().(*fakeSender)
 	got := userText(send.gotMessages[0])
 	if !strings.Contains(got, "[warmup]") || !strings.HasSuffix(got, "hello") {
 		t.Errorf("SessionStart output not folded into the first user message: %q", got)

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -76,8 +76,8 @@ func WireTools(a *agent.Agent, enableTasks bool) (ToolEnv, func()) {
 	tools.SetDefaultSubAgentManager(mgr)
 
 	// LLM-backed distill (record_stop) + self-heal (run_skill) for browser skills.
-	tools.SetBrowserSkillGenerator(MakeSkillGenerator(a.Sender, a.Model))
-	tools.SetBrowserHealer(MakeBrowserHealer(a.Sender, a.Model))
+	tools.SetBrowserSkillGenerator(MakeSkillGenerator(a.GetSender(), a.Model))
+	tools.SetBrowserHealer(MakeBrowserHealer(a.GetSender(), a.Model))
 
 	// Gate image content (browser screenshots) on the active model's vision
 	// capability so a text-only model isn't handed images its endpoint rejects.

--- a/internal/app/spawner.go
+++ b/internal/app/spawner.go
@@ -69,7 +69,7 @@ func (s *Spawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.Spaw
 	// parent's lite model when one is configured — its own cheaper sender, not
 	// the main one, since a named lite model may live on a different provider.
 	// An explicit req.Model always wins; otherwise lean → lite, else parent's.
-	sender, model := s.parent.Sender, req.Model
+	sender, model := s.parent.GetSender(), req.Model
 	if model == "" {
 		if req.LeanContext && s.parent.LiteModel != "" && s.parent.LiteSender != nil {
 			sender, model = s.parent.LiteSender, s.parent.LiteModel

--- a/internal/app/spawner_test.go
+++ b/internal/app/spawner_test.go
@@ -484,7 +484,7 @@ func TestAgentSpawner_LeanUsesLiteModelAndSystem(t *testing.T) {
 	if lc.agent.Model != "lite-model" {
 		t.Errorf("lean child model = %q, want lite-model", lc.agent.Model)
 	}
-	if lc.agent.Sender != lite {
+	if lc.agent.GetSender() != lite {
 		t.Error("lean child should run on the lite sender, not the main one")
 	}
 	if lc.agent.System != "LEAN BASE\n\nPERSONA" {
@@ -502,7 +502,7 @@ func TestAgentSpawner_LeanFallsBackWithoutLiteModel(t *testing.T) {
 		t.Fatal(err)
 	}
 	lc := sp.reg.m[onlyChildID(t, sp)]
-	if lc.agent.Model != "main-model" || lc.agent.Sender != main {
+	if lc.agent.Model != "main-model" || lc.agent.GetSender() != main {
 		t.Errorf("lean with no lite model should fall back to main sender/model; got model=%q", lc.agent.Model)
 	}
 	if lc.agent.System != "FULL BASE" {
@@ -521,7 +521,7 @@ func TestAgentSpawner_ExplicitModelWinsOverLean(t *testing.T) {
 		t.Fatal(err)
 	}
 	lc := sp.reg.m[onlyChildID(t, sp)]
-	if lc.agent.Model != "explicit" || lc.agent.Sender != main {
+	if lc.agent.Model != "explicit" || lc.agent.GetSender() != main {
 		t.Errorf("explicit model should win and use main sender; got model=%q", lc.agent.Model)
 	}
 }

--- a/internal/server/handlers_prepare_toolturn.go
+++ b/internal/server/handlers_prepare_toolturn.go
@@ -68,8 +68,8 @@ func (s *Server) prepareToolTurn(ctx context.Context, a *agent.Agent, sess *agen
 	// distillation and run_skill's selector self-heal need a model. WireTools
 	// installs these for the CLI; serve must too, or the web UI silently falls
 	// back to deterministic compilation and no self-heal.
-	tools.SetBrowserSkillGenerator(app.MakeSkillGenerator(a.Sender, a.Model))
-	tools.SetBrowserHealer(app.MakeBrowserHealer(a.Sender, a.Model))
+	tools.SetBrowserSkillGenerator(app.MakeSkillGenerator(a.GetSender(), a.Model))
+	tools.SetBrowserHealer(app.MakeBrowserHealer(a.GetSender(), a.Model))
 
 	// Same omission for the external memory backend: WireTools installs it for
 	// the CLI, but serve never calls WireTools. app.RefreshMemoryBackend is

--- a/internal/server/onboard_config_handlers_test.go
+++ b/internal/server/onboard_config_handlers_test.go
@@ -726,7 +726,7 @@ func TestBuildAgent_ImplicitLiteForBoundSession(t *testing.T) {
 	if a.LiteModel != "deepseek-v4-flash" {
 		t.Errorf("LiteModel = %q, want deepseek-v4-flash from the bound entry's vendor", a.LiteModel)
 	}
-	if a.LiteSender == nil || a.LiteSender != a.Sender {
+	if a.LiteSender == nil || a.LiteSender != a.GetSender() {
 		t.Error("bound session's implicit lite must reuse that session's sender")
 	}
 }


### PR DESCRIPTION
## Problem

TUI /model and /thinking commands wrote a.Sender from the Bubble Tea event-loop goroutine while the turn goroutine read the same field for SendMessages — a data race flagged by -race. Introduced by the /model sender-rebuild fix (PR #1412) and pre-existing in /thinking.

## Fix

Add sync.RWMutex to Agent and expose GetSender / SetSender. All internal reads in Turn, TurnStream, Run, RunStream, Suggest, GenerateTitle capture the sender once at method start so the turn loop uses a consistent sender even if the TUI swaps it mid-turn.

## Files

- internal/agent/agent.go — mutex + getter/setter, all reads updated
- cmd/octo/repl.go, cmd/octo/tuirepl_view.go — use SetSender()
- internal/app/bootstrap.go, internal/app/spawner.go, internal/server/handlers_prepare_toolturn.go — use GetSender()
- internal/agent/compaction.go, internal/agent/consolidate.go — use GetSender()
- dev-docs/octoagent-pkg-design.md — example code updated to a.GetSender()
- Test files updated to use GetSender() for assertions

## Design notes

- Sender field stays exported for backward compatibility. Internal access is fully migrated to GetSender()/SetSender(); external consumers of pkg/octoagent should be aware that direct field writes bypass the mutex.
- RWMutex chosen over Mutex because reads dominate (every turn) while writes are rare (only on /model or /thinking).

## Verification

go test -race ./... -count=1 — all packages green.
gofmt -l clean, go vet ./... clean.