### PR TITLE
fix(tui): reject /model switch to unconfigured model with a clear error

### DIFF
--- a/cmd/octo/ensure_sender_test.go
+++ b/cmd/octo/ensure_sender_test.go
@@ -213,3 +213,43 @@ func TestEnsureSender_ErrorLeavesConfigUnchanged(t *testing.T) {
 		t.Error("sender should be unchanged after failed rebuild")
 	}
 }
+
+// TestEnsureSender_UnconfiguredModel verifies that switching to a model not
+// present in the config returns a clear error (listing what is configured)
+// and leaves cfg untouched — the case that used to fall through to the current
+// provider and hit the wrong endpoint (e.g. longcat base URL + deepseek model
+// name → HTTP 500).
+func TestEnsureSender_UnconfiguredModel(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-openai-key")
+
+	writeTestConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "gpt-4o", Provider: "openai"},
+			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+		},
+		DefaultModel: "gpt-4o",
+	})
+
+	stub := &stubSender{reply: "ok"}
+	a := agent.New(stub, "gpt-4o")
+	origEntry := config.ModelEntry{Model: "gpt-4o", Provider: "openai"}
+	cfg := &replConfig{
+		a:            a,
+		providerName: "openai",
+		configEntry:  origEntry,
+		stderr:       io.Discard,
+	}
+
+	if err := cfg.ensureSender("deepseek-v4-pro", senderTuning{}); err == nil {
+		t.Fatal("expected error for unconfigured model, got nil")
+	}
+	if cfg.providerName != "openai" {
+		t.Errorf("providerName = %q, want openai (unchanged)", cfg.providerName)
+	}
+	if cfg.configEntry != origEntry {
+		t.Errorf("configEntry = %+v, want unchanged %+v", cfg.configEntry, origEntry)
+	}
+	if cfg.a.Sender != stub {
+		t.Error("sender should be unchanged after rejected switch")
+	}
+}

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -96,6 +96,18 @@ func (cfg *replConfig) ensureSender(targetModel string, tuning senderTuning) err
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
+	// Reject models not present in the config — resolveProviderModel would
+	// silently fall back to the current provider (matching on flagProvider),
+	// sending the request to the wrong endpoint (e.g. longcat base URL with a
+	// deepseek model name → HTTP 500).
+	if _, found := models.EntryByModel(targetModel); !found {
+		available := make([]string, 0, len(models.Models))
+		for _, e := range models.Models {
+			available = append(available, e.Model)
+		}
+		sort.Strings(available)
+		return fmt.Errorf("model %q is not configured (available: %s)", targetModel, strings.Join(available, ", "))
+	}
 	provName, _, entry, ok := resolveProviderModel(cfg.providerName, targetModel, models)
 	if !ok {
 		return fmt.Errorf("cannot resolve provider for model %q", targetModel)


### PR DESCRIPTION
## Problem

Previously, `/model <name>` against a model not present in the config silently fell back to the current provider. When switching from e.g. LongCat-2.0 to `deepseek-v4-pro` (not configured), `resolveProviderModel` returned `flagProvider` (the active one) because `EntryByModel` missed. `ensureSender` then saw no provider change and kept the old sender bound to the wrong endpoint — requests to `api.longcat.chat/openai` with a deepseek model name → **HTTP 500**.

## Fix

`ensureSender` now pre-checks `EntryByModel` before falling through to provider resolution. If the target model is not in the config, it returns an error listing the configured models and leaves cfg untouched (session stays on the old model).

## Test

Added `TestEnsureSender_UnconfiguredModel` — verifies the error path leaves providerName, configEntry, and sender unchanged. All 6 ensureSender tests + full `cmd/octo` package pass with `-race`.