### PR TITLE
feat(tui): colour sub-agent notice by outcome (success/warning/failed)

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1111,9 +1111,19 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Print a concise scrollback notice so the user sees the completion even
 		// when the model-facing <system-reminder> is folded into a later turn.
 		status := subAgentNoteStatus(msg.ev.StopReason)
-		// A completion notice is just a low-key hint, not a headline event — render
-		// it in the muted notice style rather than the attention-grabbing accent.
-		m.printlnBlock(noticeStyle.Render(fmt.Sprintf("● Sub-agent %s (%s) %s", msg.ev.AgentID, msg.ev.Description, status)))
+		// Colour the notice by outcome so the user can tell at a glance whether
+		// the sub-agent succeeded (green), hit a budget and returned partial work
+		// (amber), or errored out (red) — mirrors the Web UI notice levels.
+		var style lipgloss.Style
+		switch {
+		case status == "completed":
+			style = bgDoneStyle
+		case status == "failed":
+			style = errorStyle
+		default: // incomplete (max_turns / max_tokens)
+			style = bgWarnStyle
+		}
+		m.printlnBlock(style.Render(fmt.Sprintf("● Sub-agent %s (%s) %s", msg.ev.AgentID, msg.ev.Description, status)))
 		// Idle auto-turn: same logic as bgExitMsg — drain inbox and trigger a
 		// turn so the model sees the notification immediately.
 		if !m.turnRunning && len(m.queue) == 0 {

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -48,6 +48,7 @@ var (
 	complSelStyle        = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
 	complNameStyle       = lipgloss.NewStyle().Foreground(tui.ColAccent)
 	bgDoneStyle          = lipgloss.NewStyle().Foreground(tui.ColAccent)
+	bgWarnStyle          = lipgloss.NewStyle().Foreground(tui.ColWarning)
 )
 
 func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -10,12 +10,13 @@ import (
 // terminals. Values follow GitHub's light/dark themes; lipgloss resolves the
 // right side at render time from the terminal-background probe.
 var (
-	ColAccent = lipgloss.AdaptiveColor{Light: "#1A7F37", Dark: "#3FB950"} // success / additions
-	ColDanger = lipgloss.AdaptiveColor{Light: "#CF222E", Dark: "#F85149"} // errors / removals
-	ColMuted  = lipgloss.AdaptiveColor{Light: "#57606A", Dark: "#8B949E"} // secondary text
-	ColDim    = lipgloss.AdaptiveColor{Light: "#6E7781", Dark: "#6E7681"} // gutters, line numbers
-	ColDimmer = lipgloss.AdaptiveColor{Light: "#AFB8C1", Dark: "#484F58"} // dimmest (unchanged line nos)
-	ColBorder = lipgloss.AdaptiveColor{Light: "#D0D7DE", Dark: "#30363D"} // panel / input-box border
+	ColAccent  = lipgloss.AdaptiveColor{Light: "#1A7F37", Dark: "#3FB950"} // success / additions
+	ColDanger  = lipgloss.AdaptiveColor{Light: "#CF222E", Dark: "#F85149"} // errors / removals
+	ColWarning = lipgloss.AdaptiveColor{Light: "#D89614", Dark: "#FAAD14"} // partial / warnings
+	ColMuted   = lipgloss.AdaptiveColor{Light: "#57606A", Dark: "#8B949E"} // secondary text
+	ColDim     = lipgloss.AdaptiveColor{Light: "#6E7781", Dark: "#6E7681"} // gutters, line numbers
+	ColDimmer  = lipgloss.AdaptiveColor{Light: "#AFB8C1", Dark: "#484F58"} // dimmest (unchanged line nos)
+	ColBorder  = lipgloss.AdaptiveColor{Light: "#D0D7DE", Dark: "#30363D"} // panel / input-box border
 
 	ColBrand    = lipgloss.AdaptiveColor{Light: "#6F42C1", Dark: "#A371F7"} // purple — octo brand
 	ColBrandDim = lipgloss.AdaptiveColor{Light: "#B4A7D6", Dark: "#6E5494"} // muted purple


### PR DESCRIPTION
## What

Sub-agent completion notice in the TUI now uses three colors based on outcome:
- 🟢 **completed** → green (ColAccent)
- 🟡 **incomplete** (max_turns / max_tokens) → amber (ColWarning)
- 🔴 **failed** → red (ColDanger)

Previously all sub-agent notices rendered in muted gray regardless of result.

## Why

PR #1407 unified the sub-agent completion notice to muted gray, but that lost the ability to distinguish a successful completion from a failure at a glance. Mirror the Web UI's three-level notice semantics so users can tell the outcome without reading the status word.

## Changes

- internal/tui/theme.go — add ColWarning (adaptive amber, matches Web #FAAD14)
- cmd/octo/tuirepl_view.go — add bgWarnStyle alongside bgDoneStyle/errorStyle
- cmd/octo/tuirepl.go — pick style in subAgentNoteMsg handler based on subAgentNoteStatus
