### PR TITLE
feat(tui): /model with no arg opens an arrow-key model picker

### DIFF
--- a/cmd/octo/ensure_sender_test.go
+++ b/cmd/octo/ensure_sender_test.go
@@ -213,3 +213,43 @@ func TestEnsureSender_ErrorLeavesConfigUnchanged(t *testing.T) {
 		t.Error("sender should be unchanged after failed rebuild")
 	}
 }
+
+// TestEnsureSender_UnconfiguredModel verifies that switching to a model not
+// present in the config returns a clear error (listing what is configured)
+// and leaves cfg untouched — the case that used to fall through to the current
+// provider and hit the wrong endpoint (e.g. longcat base URL + deepseek model
+// name → HTTP 500).
+func TestEnsureSender_UnconfiguredModel(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-openai-key")
+
+	writeTestConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "gpt-4o", Provider: "openai"},
+			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+		},
+		DefaultModel: "gpt-4o",
+	})
+
+	stub := &stubSender{reply: "ok"}
+	a := agent.New(stub, "gpt-4o")
+	origEntry := config.ModelEntry{Model: "gpt-4o", Provider: "openai"}
+	cfg := &replConfig{
+		a:            a,
+		providerName: "openai",
+		configEntry:  origEntry,
+		stderr:       io.Discard,
+	}
+
+	if err := cfg.ensureSender("deepseek-v4-pro", senderTuning{}); err == nil {
+		t.Fatal("expected error for unconfigured model, got nil")
+	}
+	if cfg.providerName != "openai" {
+		t.Errorf("providerName = %q, want openai (unchanged)", cfg.providerName)
+	}
+	if cfg.configEntry != origEntry {
+		t.Errorf("configEntry = %+v, want unchanged %+v", cfg.configEntry, origEntry)
+	}
+	if cfg.a.Sender != stub {
+		t.Error("sender should be unchanged after rejected switch")
+	}
+}

--- a/cmd/octo/ensure_sender_test.go
+++ b/cmd/octo/ensure_sender_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
@@ -242,6 +243,8 @@ func TestEnsureSender_UnconfiguredModel(t *testing.T) {
 
 	if err := cfg.ensureSender("deepseek-v4-pro", senderTuning{}); err == nil {
 		t.Fatal("expected error for unconfigured model, got nil")
+	} else if !strings.Contains(err.Error(), "gpt-4o") || !strings.Contains(err.Error(), "deepseek-v4-flash") {
+		t.Errorf("error should list available models, got: %v", err)
 	}
 	if cfg.providerName != "openai" {
 		t.Errorf("providerName = %q, want openai (unchanged)", cfg.providerName)

--- a/cmd/octo/model_picker_test.go
+++ b/cmd/octo/model_picker_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/config"
+)
+
+// writeModelsConfig writes a config with the given models to a temp HOME dir
+// so config.Load() finds them.
+func writeModelsConfig(t *testing.T, cfg config.Config) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	dir := filepath.Join(tmp, ".octo")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir .octo: %v", err)
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+}
+
+// newPickerTestModel builds a bare tuiModel with an agent on modelName.
+// Its subAgentFocus is -1 (no sub-agent nav) and stderr is io.Discard so a
+// sender rebuild in the Enter test path doesn't panic on a nil writer.
+func newPickerTestModel(modelName string) *tuiModel {
+	a := agent.New(&stubSender{reply: "ok"}, modelName)
+	return &tuiModel{cfg: replConfig{a: a, stderr: io.Discard}, a: a, subAgentFocus: -1}
+}
+
+// pickUpdate runs m.Update and returns the resulting *tuiModel (cmd discarded).
+func pickUpdate(m *tuiModel, msg tea.Msg) *tuiModel {
+	updated, _ := m.Update(msg)
+	return updated.(*tuiModel)
+}
+
+// TestDispatchModel_NoArgOpensPicker verifies that "/model" without an argument
+// opens the picker overlay (instead of printing a usage error).
+func TestDispatchModel_NoArgOpensPicker(t *testing.T) {
+	writeModelsConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "gpt-4o", Provider: "openai"},
+			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+		},
+		DefaultModel: "gpt-4o",
+	})
+
+	m := newPickerTestModel("gpt-4o")
+	model, _ := m.dispatchModel("")
+
+	if model.(*tuiModel).modelPicker == nil {
+		t.Fatal("expected picker to be open after dispatchModel(\"\")")
+	}
+	if len(model.(*tuiModel).modelPicker.items) != 2 {
+		t.Errorf("picker items = %d, want 2", len(model.(*tuiModel).modelPicker.items))
+	}
+	// Cursor should start on the active model (gpt-4o = index 0).
+	if model.(*tuiModel).modelPicker.idx != 0 {
+		t.Errorf("picker cursor = %d, want 0 (active model)", model.(*tuiModel).modelPicker.idx)
+	}
+}
+
+// TestDispatchModel_NoArgCursorOnActive verifies the picker opens with the
+// cursor on the active model — not always the first one.
+func TestDispatchModel_NoArgCursorOnActive(t *testing.T) {
+	writeModelsConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "gpt-4o", Provider: "openai"},
+			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+		},
+		DefaultModel: "claude-sonnet-4-6",
+	})
+
+	m := newPickerTestModel("claude-sonnet-4-6")
+	m.dispatchModel("")
+
+	if m.modelPicker.idx != 1 {
+		t.Errorf("picker cursor = %d, want 1 (claude-sonnet-4-6)", m.modelPicker.idx)
+	}
+}
+
+// TestDispatchModel_PickerKeyDown verifies DOWN advances the cursor (with
+// wrap) and UP moves it back, while the picker stays open.
+func TestDispatchModel_PickerKeyDown(t *testing.T) {
+	writeModelsConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "gpt-4o", Provider: "openai"},
+			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+		},
+		DefaultModel: "gpt-4o",
+	})
+
+	m := newPickerTestModel("gpt-4o")
+	m.dispatchModel("")
+
+	// Down → index 1
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyDown})
+	if m.modelPicker.idx != 1 {
+		t.Errorf("after DOWN: idx = %d, want 1", m.modelPicker.idx)
+	}
+	// Down again → wraps to 0
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyDown})
+	if m.modelPicker.idx != 0 {
+		t.Errorf("after DOWN (wrap): idx = %d, want 0", m.modelPicker.idx)
+	}
+	// Up → wraps to 1
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyUp})
+	if m.modelPicker.idx != 1 {
+		t.Errorf("after UP (wrap): idx = %d, want 1", m.modelPicker.idx)
+	}
+}
+
+// TestDispatchModel_PickerKeyEsc verifies Esc closes the picker.
+func TestDispatchModel_PickerKeyEsc(t *testing.T) {
+	writeModelsConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "gpt-4o", Provider: "openai"},
+		},
+		DefaultModel: "gpt-4o",
+	})
+
+	m := newPickerTestModel("gpt-4o")
+	m.dispatchModel("")
+
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.modelPicker != nil {
+		t.Error("expected picker to be cleared after Esc")
+	}
+}
+
+// TestDispatchModel_PickerKeyEnter verifies Enter switches to the highlighted
+// model and clears the picker. Two models share a provider + base URL so
+// ensureSender returns early (no live rebuild needed).
+func TestDispatchModel_PickerKeyEnter(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
+	writeModelsConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+			{Model: "deepseek-v4-pro", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+		},
+		DefaultModel: "deepseek-v4-flash",
+	})
+
+	m := newPickerTestModel("deepseek-v4-flash")
+	m.dispatchModel("")
+
+	// Move to index 1 (deepseek-v4-pro)
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyDown})
+	// Enter accepts
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.modelPicker != nil {
+		t.Error("picker should be cleared after Enter")
+	}
+	if m.a.Model != "deepseek-v4-pro" {
+		t.Errorf("active model = %q, want deepseek-v4-pro", m.a.Model)
+	}
+}
+
+// TestModelPickerView_Renders verifies the overlay lists all models with
+// provider/endpoint info.
+func TestModelPickerView_Renders(t *testing.T) {
+	writeModelsConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "gpt-4o", Provider: "openai"},
+			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+		},
+		DefaultModel: "gpt-4o",
+	})
+
+	m := newPickerTestModel("gpt-4o")
+	m.dispatchModel("")
+
+	out := m.modelPickerView()
+	if !strings.Contains(out, "gpt-4o") {
+		t.Errorf("picker view missing gpt-4o:\n%s", out)
+	}
+	if !strings.Contains(out, "deepseek-v4-flash") {
+		t.Errorf("picker view missing deepseek-v4-flash:\n%s", out)
+	}
+	if !strings.Contains(out, "https://api.deepseek.com") {
+		t.Errorf("picker view missing base URL:\n%s", out)
+	}
+	if !strings.Contains(out, "Switch model") {
+		t.Errorf("picker view missing prompt:\n%s", out)
+	}
+}
+
+// TestModelPickerView_EmptyWhenInactive verifies the picker renders nothing
+// when not active.
+func TestModelPickerView_EmptyWhenInactive(t *testing.T) {
+	m := newPickerTestModel("gpt-4o")
+	if out := m.modelPickerView(); out != "" {
+		t.Errorf("expected empty picker view when inactive, got:\n%s", out)
+	}
+}

--- a/cmd/octo/model_picker_test.go
+++ b/cmd/octo/model_picker_test.go
@@ -195,6 +195,39 @@ func TestModelPickerView_Renders(t *testing.T) {
 	}
 }
 
+// TestDispatchModel_PickerSingleModel verifies the picker opens and behaves
+// correctly when only one model is configured (wrap arithmetic is a no-op).
+func TestDispatchModel_PickerSingleModel(t *testing.T) {
+	writeModelsConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "gpt-4o", Provider: "openai"},
+		},
+		DefaultModel: "gpt-4o",
+	})
+
+	m := newPickerTestModel("gpt-4o")
+	m.dispatchModel("")
+
+	if m.modelPicker == nil {
+		t.Fatal("picker should open even with a single model")
+	}
+	if len(m.modelPicker.items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(m.modelPicker.items))
+	}
+	if m.modelPicker.idx != 0 {
+		t.Errorf("picker cursor = %d, want 0", m.modelPicker.idx)
+	}
+	// DOWN/UP should both stay at index 0 (wrap with len==1).
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyDown})
+	if m.modelPicker.idx != 0 {
+		t.Errorf("after DOWN: idx = %d, want 0", m.modelPicker.idx)
+	}
+	m = pickUpdate(m, tea.KeyMsg{Type: tea.KeyUp})
+	if m.modelPicker.idx != 0 {
+		t.Errorf("after UP: idx = %d, want 0", m.modelPicker.idx)
+	}
+}
+
 // TestModelPickerView_EmptyWhenInactive verifies the picker renders nothing
 // when not active.
 func TestModelPickerView_EmptyWhenInactive(t *testing.T) {

--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -96,6 +96,18 @@ func (cfg *replConfig) ensureSender(targetModel string, tuning senderTuning) err
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
+	// Reject models not present in the config — resolveProviderModel would
+	// silently fall back to the current provider (matching on flagProvider),
+	// sending the request to the wrong endpoint (e.g. longcat base URL with a
+	// deepseek model name → HTTP 500).
+	if _, found := models.EntryByModel(targetModel); !found {
+		available := make([]string, 0, len(models.Models))
+		for _, e := range models.Models {
+			available = append(available, e.Model)
+		}
+		sort.Strings(available)
+		return fmt.Errorf("model %q is not configured (available: %s)", targetModel, strings.Join(available, ", "))
+	}
 	provName, _, entry, ok := resolveProviderModel(cfg.providerName, targetModel, models)
 	if !ok {
 		return fmt.Errorf("cannot resolve provider for model %q", targetModel)

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -351,6 +351,12 @@ type tuiModel struct {
 	complItems []complItem
 	complIdx   int
 
+	// modelPicker is the arrow-key model-switch overlay. When non-nil, ↑/↓/Enter/Esc
+	// are routed to it and it renders over the conversation. Built on demand by
+	// dispatchModel when "/model" is issued with no argument, and cleared once the
+	// user picks or cancels.
+	modelPicker *modelPicker
+
 	// turnRunning is true between starting a turn and turnFinishedMsg.
 	turnRunning bool
 	cancelTurn  context.CancelFunc
@@ -558,6 +564,12 @@ type tuiModel struct {
 	// id (wf_N). An entry appears on the "started" event and is removed when the
 	// "done" event arrives, so only running workflows are shown in the panel.
 	workflows map[string]*workflowUI
+}
+
+// modelPicker is the state of the arrow-key model-switch overlay.
+type modelPicker struct {
+	items []complItem // one per configured model (name = model id, desc = provider + base URL)
+	idx   int         // highlighted row
 }
 
 // subAgentUI is the live panel state for one running sub-agent.

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -89,6 +89,10 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case tea.KeyEsc:
 			m.modelPicker = nil
 			return m, nil
+		default:
+			// Any other key (printable chars, etc.) dismisses the picker and
+			// falls through to normal handling so the key reaches the textarea.
+			m.modelPicker = nil
 		}
 	}
 	if len(m.complItems) > 0 {

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -19,6 +19,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	rw "github.com/mattn/go-runewidth"
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/config"
 	"github.com/open-octo/octo-agent/internal/permission"
 	"github.com/open-octo/octo-agent/internal/tools"
 	"github.com/open-octo/octo-agent/internal/tui"
@@ -73,6 +74,23 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// submit. Plain typing falls through and re-filters the menu below.
 	// Key semantics mirror Claude Code: Enter runs the highlighted command
 	// immediately; Tab fills it into the input to add arguments first.
+	if m.modelPicker != nil {
+		switch msg.Type {
+		case tea.KeyDown:
+			m.modelPicker.idx = (m.modelPicker.idx + 1) % len(m.modelPicker.items)
+			return m, nil
+		case tea.KeyUp:
+			m.modelPicker.idx = (m.modelPicker.idx - 1 + len(m.modelPicker.items)) % len(m.modelPicker.items)
+			return m, nil
+		case tea.KeyEnter:
+			if !msg.Alt {
+				return m.acceptModelPicker()
+			}
+		case tea.KeyEsc:
+			m.modelPicker = nil
+			return m, nil
+		}
+	}
 	if len(m.complItems) > 0 {
 		switch msg.Type {
 		case tea.KeyDown:
@@ -985,13 +1003,78 @@ func (m *tuiModel) dispatchTranscript(arg string) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// openModelPicker arms m.modelPicker with the configured models (name +
+// provider + base URL), cursor starting on the active model. The picker renders
+// as an overlay and owns ↑/↓/Enter/Esc until the user picks or cancels. Returns
+// false if no models are configured (rare — there's always at least the default).
+func (m *tuiModel) openModelPicker() bool {
+	cfg, err := config.Load()
+	if err != nil || len(cfg.Models) == 0 {
+		return false
+	}
+	items := make([]complItem, 0, len(cfg.Models))
+	for _, e := range cfg.Models {
+		desc := e.Provider
+		if e.BaseURL != "" {
+			desc += " · " + e.BaseURL
+		}
+		items = append(items, complItem{name: e.Model, desc: desc})
+	}
+	idx := 0
+	for i, it := range items {
+		if it.name == m.a.Model {
+			idx = i
+			break
+		}
+	}
+	m.modelPicker = &modelPicker{items: items, idx: idx}
+	return true
+}
+
+// acceptModelPicker switches to the highlighted model and clears the picker.
+func (m *tuiModel) acceptModelPicker() (tea.Model, tea.Cmd) {
+	p := m.modelPicker
+	m.modelPicker = nil
+	if p == nil || p.idx < 0 || p.idx >= len(p.items) {
+		return m, nil
+	}
+	return m.dispatchModel(p.items[p.idx].name)
+}
+
+// modelPickerView renders the model-switch overlay, reusing the completion menu
+// styles so it reads as the same family of UI.
+func (m *tuiModel) modelPickerView() string {
+	p := m.modelPicker
+	if p == nil || len(p.items) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(selectPromptStyle.Render("Switch model:") + "\n")
+	for i, it := range p.items {
+		label := fmt.Sprintf("%-24s", it.name)
+		if i == p.idx {
+			b.WriteString("  " + complSelStyle.Render("▸ "+label) + " " + hintStyle.Render(it.desc))
+		} else {
+			b.WriteString("  " + complNameStyle.Render(label) + " " + hintStyle.Render(it.desc))
+		}
+		b.WriteByte('\n')
+	}
+	b.WriteString(hintStyle.Render("  ↑/↓ select · Enter switch · Esc dismiss"))
+	b.WriteByte('\n')
+	return b.String()
+}
+
 // dispatchModel handles "/model <name>" — switch the active model for the
 // current session. If the new model resolves to a different provider or base
 // URL, the sender is rebuilt so requests go to the right endpoint. A rebuild
 // failure (e.g. missing API key for the target provider) aborts the switch and
-// reports the error — the session stays on the old model.
+// reports the error — the session stays on the old model. With no argument, an
+// arrow-key picker overlays the configured models so one can be chosen.
 func (m *tuiModel) dispatchModel(name string) (tea.Model, tea.Cmd) {
 	if name == "" {
+		if m.openModelPicker() {
+			return m, nil
+		}
 		m.println(errorStyle.Render("Usage: /model <model-name>"))
 		return m, nil
 	}
@@ -1432,6 +1515,12 @@ func (m *tuiModel) View() string {
 
 	// Slash-command completion menu, right above the input box (Claude Code style).
 	b.WriteString(m.completionView())
+
+	// Model-switch picker overlay, shown when "/model" was issued without an
+	// argument. Renders the configured models; ↑/↓/Enter switch, Esc dismisses.
+	if pv := m.modelPickerView(); pv != "" {
+		b.WriteString(pv)
+	}
 
 	// Input box + status bar
 	b.WriteString(m.renderInputBox())


### PR DESCRIPTION
## Problem

`/model` (no argument) printed only `Usage: /model <model-name>`. Users had to remember exact model ids and retype the command to retry — no discoverability for what is configured.

## Fix

`/model` with no argument now opens an arrow-key picker overlay listing every configured model, each annotated with its provider and base URL. The cursor starts on the active model; ↑/↓ navigate (with wrap), Enter switches to the highlight, Esc dismisses without changing anything. The picker reuses the completion menu styles so it reads as the same family of UI.

This PR also includes the unconfigured-model guard from #1414 (reject `/model <unknown-model>` with a clear error listing configured models instead of silently falling back to the wrong provider endpoint).

## Behavior

- `/model` → picker overlay
- `/model <name>` → directly switch (existing behavior, unchanged)
- `/model <unknown>` → error: `model "x" is not configured (available: a, b, c)`

## Test

7 new tests in `model_picker_test.go`: opens picker, cursor-on-active, DOWN/UP wrap, Esc dismiss, Enter switches + clears, view rendering, empty-when-inactive. All `cmd/octo` + full `go test -race ./...` green.

## Files

- `cmd/octo/repl.go` — new `modelPicker` struct + field
- `cmd/octo/tuirepl_view.go` — `openModelPicker`, `acceptModelPicker`, `modelPickerView`, `dispatchModel` no-arg path, Update routing, View rendering
- `cmd/octo/model_picker_test.go` — new tests
- `cmd/octo/ensure_sender_test.go` + `cmd/octo/repl.go` — unconfigured-model guard (#1414)