### PR TITLE
fix(skills): repair grill-me YAML frontmatter that broke skill discovery

### DIFF
--- a/internal/skills/defaults/grill-me/SKILL.md
+++ b/internal/skills/defaults/grill-me/SKILL.md
@@ -6,7 +6,7 @@ description:
   understanding, resolving each branch of the decision tree one at a time. Use
   when the user wants to stress-test a plan, pressure-test a design before
   building, or says "grill me", "拷问我", "帮我把方案想清楚", "挑战一下这个设计",
-  "review my plan before I build". Pairs with the tech-design skill: grill first,
+  "review my plan before I build". Pairs with the tech-design skill — grill first,
   then hand the resolved decisions to tech-design to write them up.
 metadata:
   origin: adapted for octo — generic stack, octo-native codebase exploration


### PR DESCRIPTION
## Problem

The `grill-me` skill has never been loadable since its addition in PR #1034 — typing `/grill-me` returns "unknown skill" and the skill tool can't find it.

## Root Cause

Its SKILL.md frontmatter contains a colon that breaks YAML parsing:

```yaml
description:
  ...
  "review my plan before I build". Pairs with the tech-design skill: grill first,
```

The `skill: grill first` is interpreted by the YAML parser as a mapping key inside a scalar value, yielding:

```
yaml: line 8: mapping values are not allowed in this context
```

`scanRoot` silently skips skills whose frontmatter fails to parse, so `grill-me` was never registered — no error, no warning, just missing from the list.

## Fix

Replace the colon with an em dash (—):

```yaml
"review my plan before I build". Pairs with the tech-design skill — grill first,
```

Verified: `parse()` now returns `ok=true` with a non-empty description.

## Scope

- Only `internal/skills/defaults/grill-me/SKILL.md` changed (1 line)
- All other 19 default skills parse correctly — this file was the only one with a colon inside a description line
- The on-disk materialized copy at `~/.octo/skills-default/grill-me/SKILL.md` was also patched for the current install; future installs get the fix via the embedded defaults