### PR TITLE
chore(skills): drop codegraph mention from grill-me exploration step

### DIFF
--- a/internal/skills/defaults/grill-me/SKILL.md
+++ b/internal/skills/defaults/grill-me/SKILL.md
@@ -50,8 +50,7 @@ Before asking any questions, do your homework:
    can: problem statement, core user flow, scope boundaries. The less the user
    gives, the more Phase 1 needs to cover.
 2. **Explore the codebase** — identify the existing services, data models, APIs,
-   message-queue topics, cache keys, and prior art relevant to the plan. Use
-   codegraph if the project has it indexed, otherwise search directly. Report key
+   message-queue topics, cache keys, and prior art relevant to the plan. Report key
    findings to the user concisely before starting questions.
 
 This phase is silent work — don't ask the user things you can learn from the code.


### PR DESCRIPTION
## What

Remove the codegraph-specific instruction from grill-me's Phase 1 "Explore the codebase" step.

Before:
> Report key findings ... Use codegraph if the project has it indexed, otherwise search directly.

After:
> "Explore the codebase" (no tool named)

## Why

`grill-me` is a generic default skill. "Explore the codebase" is instruction enough — the agent decides on its own whether to use codegraph or plain search based on what the project has. Naming a specific indexer here couples the generic skill to one particular tool.

No behavioral change to the interview logic; single-line edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)