### PR TITLE
feat(tui): /model <name> --default to set default model in config

### DIFF
--- a/cmd/octo/model_picker_test.go
+++ b/cmd/octo/model_picker_test.go
@@ -317,3 +317,29 @@ func TestDispatchModel_NoDefaultFlag(t *testing.T) {
 		t.Errorf("default_model = %q, want gpt-4o (unchanged)", saved.DefaultModel)
 	}
 }
+
+// TestDispatchModel_DefaultFlagOnly verifies `/model --default` (flag without
+// a model name) errors cleanly and does not touch the config.
+func TestDispatchModel_DefaultFlagOnly(t *testing.T) {
+	writeModelsConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "gpt-4o", Provider: "openai"},
+		},
+		DefaultModel: "gpt-4o",
+	})
+
+	m := newPickerTestModel("gpt-4o")
+	m.dispatchModel("--default")
+
+	// Switch should fail (no model), default should remain unchanged.
+	if m.a.Model != "gpt-4o" {
+		t.Errorf("active model = %q, want gpt-4o (unchanged)", m.a.Model)
+	}
+	saved, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if saved.DefaultModel != "gpt-4o" {
+		t.Errorf("default_model = %q, want gpt-4o (unchanged)", saved.DefaultModel)
+	}
+}

--- a/cmd/octo/model_picker_test.go
+++ b/cmd/octo/model_picker_test.go
@@ -236,3 +236,84 @@ func TestModelPickerView_EmptyWhenInactive(t *testing.T) {
 		t.Errorf("expected empty picker view when inactive, got:\n%s", out)
 	}
 }
+
+// TestDispatchModel_DefaultFlag verifies that `/model <name> --default` sets
+// the model as default in the persisted config.
+func TestDispatchModel_DefaultFlag(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
+	writeModelsConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "gpt-4o", Provider: "openai"},
+			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+		},
+		DefaultModel: "gpt-4o",
+	})
+
+	m := newPickerTestModel("gpt-4o")
+	m.dispatchModel("deepseek-v4-flash --default")
+
+	if m.a.Model != "deepseek-v4-flash" {
+		t.Errorf("active model = %q, want deepseek-v4-flash", m.a.Model)
+	}
+
+	saved, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if saved.DefaultModel != "deepseek-v4-flash" {
+		t.Errorf("default_model = %q, want deepseek-v4-flash", saved.DefaultModel)
+	}
+}
+
+// TestDispatchModel_DefaultFlagUnconfigured verifies `/model <unknown> --default`
+// errors on the switch step and does NOT touch the config.
+func TestDispatchModel_DefaultFlagUnconfigured(t *testing.T) {
+	writeModelsConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "gpt-4o", Provider: "openai"},
+		},
+		DefaultModel: "gpt-4o",
+	})
+
+	m := newPickerTestModel("gpt-4o")
+	m.dispatchModel("nonexistent --default")
+
+	// Model should NOT have switched.
+	if m.a.Model != "gpt-4o" {
+		t.Errorf("active model = %q, want gpt-4o (unchanged)", m.a.Model)
+	}
+	saved, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if saved.DefaultModel != "gpt-4o" {
+		t.Errorf("default_model = %q, want gpt-4o (unchanged)", saved.DefaultModel)
+	}
+}
+
+// TestDispatchModel_NoDefaultFlag verifies `/model <name>` (no --default) does
+// NOT change the persisted default.
+func TestDispatchModel_NoDefaultFlag(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
+	writeModelsConfig(t, config.Config{
+		Models: []config.ModelEntry{
+			{Model: "deepseek-v4-flash", Provider: "deepseek", BaseURL: "https://api.deepseek.com"},
+			{Model: "gpt-4o", Provider: "openai"},
+		},
+		DefaultModel: "gpt-4o",
+	})
+
+	m := newPickerTestModel("gpt-4o")
+	m.dispatchModel("deepseek-v4-flash")
+
+	if m.a.Model != "deepseek-v4-flash" {
+		t.Errorf("active model = %q, want deepseek-v4-flash", m.a.Model)
+	}
+	saved, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if saved.DefaultModel != "gpt-4o" {
+		t.Errorf("default_model = %q, want gpt-4o (unchanged)", saved.DefaultModel)
+	}
+}

--- a/cmd/octo/tuirepl_completion.go
+++ b/cmd/octo/tuirepl_completion.go
@@ -19,7 +19,7 @@ const maxComplVisible = 10
 // order. Skills are appended after these by slashCandidates.
 var builtinSlashCommands = []complItem{
 	{"/help", "List commands and tools"},
-	{"/model", "Switch to another model"},
+	{"/model", "Switch to another model (--default to make it the default)"},
 	{"/thinking", "Set reasoning effort (off/low/medium/high/xhigh/max)"},
 	{"/compact", "Summarize older history to free up context"},
 	{"/transcript", "Re-print the last (or last N) tool call(s) with full output"},

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1084,15 +1084,16 @@ func (m *tuiModel) dispatchModel(name string) (tea.Model, tea.Cmd) {
 		if m.openModelPicker() {
 			return m, nil
 		}
-		m.println(errorStyle.Render("Usage: /model <model-name> [--default]"))
+		m.println(errorStyle.Render("Usage: /model <model-name> --default"))
 		return m, nil
 	}
 
-	// Parse optional flags.
+	// Parse optional --default flag (must be a trailing token).
 	setDefault := false
-	if idx := strings.Index(name, " --default"); idx >= 0 {
+	if trimmed := strings.TrimSpace(name); strings.HasSuffix(trimmed, "--default") {
 		setDefault = true
-		name = strings.TrimSpace(name[:idx])
+		rest, _ := strings.CutSuffix(trimmed, "--default")
+		name = strings.TrimSpace(rest)
 	}
 
 	tuning := senderTuning{showReasoning: m.cfg.showReasoning}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1092,8 +1092,11 @@ func (m *tuiModel) dispatchModel(name string) (tea.Model, tea.Cmd) {
 	setDefault := false
 	if trimmed := strings.TrimSpace(name); strings.HasSuffix(trimmed, "--default") {
 		setDefault = true
-		rest, _ := strings.CutSuffix(trimmed, "--default")
-		name = strings.TrimSpace(rest)
+		name = strings.TrimSpace(strings.TrimSuffix(trimmed, "--default"))
+	}
+	if setDefault && name == "" {
+		m.println(errorStyle.Render("Usage: /model <model-name> --default"))
+		return m, nil
 	}
 
 	tuning := senderTuning{showReasoning: m.cfg.showReasoning}

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1075,14 +1075,26 @@ func (m *tuiModel) modelPickerView() string {
 // failure (e.g. missing API key for the target provider) aborts the switch and
 // reports the error — the session stays on the old model. With no argument, an
 // arrow-key picker overlays the configured models so one can be chosen.
+//
+// Flags:
+//
+//	--default  also persist the model as default_model in ~/.octo/config.yml.
 func (m *tuiModel) dispatchModel(name string) (tea.Model, tea.Cmd) {
 	if name == "" {
 		if m.openModelPicker() {
 			return m, nil
 		}
-		m.println(errorStyle.Render("Usage: /model <model-name>"))
+		m.println(errorStyle.Render("Usage: /model <model-name> [--default]"))
 		return m, nil
 	}
+
+	// Parse optional flags.
+	setDefault := false
+	if idx := strings.Index(name, " --default"); idx >= 0 {
+		setDefault = true
+		name = strings.TrimSpace(name[:idx])
+	}
+
 	tuning := senderTuning{showReasoning: m.cfg.showReasoning}
 	if err := m.cfg.ensureSender(name, tuning); err != nil {
 		m.println(errorStyle.Render(fmt.Sprintf("error switching model: %v", err)))
@@ -1094,7 +1106,29 @@ func (m *tuiModel) dispatchModel(name string) (tea.Model, tea.Cmd) {
 	if m.cfg.tools != nil {
 		m.cfg.tools = tools.DefaultToolsFor(name)
 	}
+
+	if setDefault {
+		if err := setModelAsDefault(name); err != nil {
+			m.println(errorStyle.Render(fmt.Sprintf("switched to %q but failed to set default: %v", name, err)))
+		} else {
+			m.println(noticeStyle.Render(fmt.Sprintf("Default model set to %q", name)))
+		}
+	}
 	return m, nil
+}
+
+// setModelAsDefault persists name as default_model in ~/.octo/config.yml,
+// keeping all existing entries intact.
+func setModelAsDefault(name string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+	if _, ok := cfg.EntryByModel(name); !ok {
+		return fmt.Errorf("model %q is not configured", name)
+	}
+	cfg.DefaultModel = name
+	return cfg.Save()
 }
 
 // dispatchThinking handles "/thinking <off|low|medium|high|xhigh|max>" — change the


### PR DESCRIPTION
## Problem

`/model` only switches the model for the current session. There is no way to set the default model from within the TUI — users must quit and run `octo config` to change `default_model`.

## Fix

`/model <name> --default` now also persists `default_model` in `~/.octo/config.yml`, so future sessions start on the selected model.

```
/model deepseek-v4-pro --default
# → switched to deepseek-v4-pro
# → Default model set to "deepseek-v4-pro"
```

Without `--default`, behavior is unchanged (session-only switch).

## Implementation

- `dispatchModel` parses a trailing `--default` flag, strips it, then after a successful switch calls `setModelAsDefault(name)`.
- `setModelAsDefault` loads config, validates the model exists in `models`, sets `DefaultModel`, and saves.
- On save failure the user sees `switched to "x" but failed to set default: ...`; on success `Default model set to "x"`.
- Description updated in the slash completion menu.

## Test

3 new tests in `model_picker_test.go`: flag sets default, flag with unknown model errors without touching config, no flag does not change default. All `cmd/octo` tests pass with `-race`.