### PR TITLE
feat(tui): stop inline-expanding /<skill>, unify with web/IM

### DIFF
--- a/cmd/octo/repl.go
+++ b/cmd/octo/repl.go
@@ -386,14 +386,6 @@ func skillTrigger(reg *skills.Registry, line string) (skills.Skill, string, bool
 	return s, args, true
 }
 
-// inlineSkill builds the turn input for an explicit /<name> trigger: the skill
-// rendered with its directory header (so referenced files resolve) plus any
-// trailing user arguments. Same text the `skill` tool returns for a
-// model-initiated load — see skills.RenderSkill.
-func inlineSkill(s skills.Skill, args string) string {
-	return skills.RenderSkill(s, args)
-}
-
 // printSkills lists the discovered skills, or a hint when there are none.
 func printSkills(w io.Writer, reg *skills.Registry) {
 	if reg == nil || reg.Len() == 0 {

--- a/cmd/octo/skill_repl_test.go
+++ b/cmd/octo/skill_repl_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/skills"
 )
 
@@ -59,28 +61,68 @@ func TestSkillTrigger(t *testing.T) {
 	}
 }
 
-func TestInlineSkill(t *testing.T) {
-	// No Dir → no location header, so the bare body (matching the old behaviour).
-	plain := skills.Skill{Body: "BODY"}
-	if got := inlineSkill(plain, ""); got != "BODY" {
-		t.Errorf("no args → %q", got)
+// noopExec is a do-nothing ToolExecutor: enough to make a replConfig look
+// tool-enabled so dispatchSlash takes its with-tools path.
+type noopExec struct{}
+
+func (noopExec) Execute(context.Context, string, map[string]any) (agent.ToolResult, error) {
+	return agent.ToolResult{}, nil
+}
+
+// skillDispatchModel builds a TUI model backed by a stub sender and fake
+// program, with the given skill registry and (optionally) tools, so
+// dispatchSlash can be driven without a real provider or terminal.
+func skillDispatchModel(reg *skills.Registry, withTools bool) *tuiModel {
+	cfg := replConfig{a: agent.New(&stubSender{reply: "ok"}, "m"), skillReg: reg, noSave: true}
+	if withTools {
+		cfg.tools = []agent.ToolDefinition{{Name: "noop"}}
+		cfg.executor = noopExec{}
 	}
-	if got := inlineSkill(plain, "x"); got != "BODY\n\nUser input: x" {
-		t.Errorf("with args → %q", got)
+	m := newTUIModel(cfg)
+	m.sink = &tuiSink{prog: &fakeProg{}}
+	return m
+}
+
+// A /<skill> trigger with tools present is NOT expanded inline — it falls
+// through to the default branch and starts an ordinary turn with the literal
+// "/name" text, so the model loads the skill via the `skill` tool (parity with
+// the web and IM transports).
+func TestDispatchSlash_SkillWithTools_FallsThrough(t *testing.T) {
+	reg := skillRegFor(t, map[string]string{"greet": "---\ndescription: d\n---\nbody"})
+	m := skillDispatchModel(reg, true)
+
+	_, cmd := m.dispatchSlash("/greet")
+
+	if got := strings.Join(m.printlnBuf, "\n"); strings.Contains(got, "needs tools") {
+		t.Errorf("with tools, a skill trigger must not be refused; got:\n%s", got)
 	}
-	// With Dir → the directory header is prefixed so referenced files resolve.
-	withDir := skills.Skill{Name: "review", Body: "BODY", Dir: "/abs/skills/review"}
-	got := inlineSkill(withDir, "")
-	if !strings.Contains(got, "/abs/skills/review") || !strings.Contains(got, "BODY") {
-		t.Errorf("expected dir header + body; got:\n%s", got)
+	if !m.turnRunning || cmd == nil {
+		t.Error("with tools, /greet should fall through and start an ordinary turn")
 	}
 }
 
-// The /skills listing, /<skill> trigger, and unknown-command behaviour are
-// exercised through the TUI's dispatchSlash in tuirepl_slash_test.go now that
-// slash commands live there. skillTrigger / inlineSkill remain unit-tested
-// above since dispatchSlash relies on them; printSkills (the /skills renderer)
-// is tested directly here.
+// Without tools the `skill` tool doesn't exist, so a /<skill> trigger can't
+// work — it is refused (mirroring /init) rather than starting a dead turn.
+func TestDispatchSlash_SkillWithoutTools_Refused(t *testing.T) {
+	reg := skillRegFor(t, map[string]string{"greet": "---\ndescription: d\n---\nbody"})
+	m := skillDispatchModel(reg, false)
+
+	_, cmd := m.dispatchSlash("/greet")
+
+	if cmd != nil {
+		t.Errorf("refusal must not start a turn, got cmd=%v", cmd)
+	}
+	if m.turnRunning {
+		t.Error("no turn should start when a skill trigger is refused")
+	}
+	if got := strings.Join(m.printlnBuf, "\n"); !strings.Contains(got, "/greet needs tools") {
+		t.Errorf("expected a 'needs tools' refusal for /greet; got:\n%s", got)
+	}
+}
+
+// skillTrigger remains unit-tested above since dispatchSlash relies on it to
+// detect a skill name (to refuse without tools); printSkills (the /skills
+// renderer) is tested directly here.
 
 func TestPrintSkills_ListsSkills(t *testing.T) {
 	reg := skillRegFor(t, map[string]string{"greet": "---\ndescription: say hi\n---\nbody"})

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -881,13 +881,17 @@ func (m *tuiModel) dispatchSlash(text string) (tea.Model, tea.Cmd) {
 		return m, m.startTurnEcho(initInstruction, "/init")
 	}
 
-	// /<skill> [args]: inline the skill body and run it as a turn.
-	if s, args, ok := skillTrigger(cfg.skillReg, text); ok {
-		echo := "/" + s.Name
-		if args != "" {
-			echo += " " + args
-		}
-		return m, m.startTurnEcho(inlineSkill(s, args), echo)
+	// /<skill> [args]: a discovered skill invoked by name. It is NOT expanded
+	// inline here — with tools it falls through to the default branch and is
+	// sent as ordinary "/name" text, so the model loads it via the `skill` tool
+	// (matching the web and IM transports: one path, and the body lands in a
+	// foldable tool card instead of flooding the scrollback — and the resumed
+	// transcript shows "> /name" rather than the whole SKILL.md). Without tools
+	// the `skill` tool doesn't exist, so the trigger can't work — refuse with the
+	// same guidance as /init.
+	if s, _, ok := skillTrigger(cfg.skillReg, text); ok && (len(cfg.tools) == 0 || cfg.executor == nil) {
+		m.println(noticeStyle.Render("/" + s.Name + " needs tools — restart with: octo --tools"))
+		return m, nil
 	}
 
 	first := strings.Fields(text)[0]

--- a/dev-docs/m7-skills-design.md
+++ b/dev-docs/m7-skills-design.md
@@ -133,9 +133,12 @@ turn
 
 ## 5. 显式触发与 CLI
 
-- **`/<name> [args]`**(REPL):命中 skill registry 则 `line = skill.Body`(args 非空追加为
-  用户附加输入)、fall through 到 turn——直接把正文喂模型,省一次 skill 工具往返。与模型
-  自主调 skill 工具并存,语义一致。未命中保持 `Unknown command`。
+- **`/<name> [args]`**(TUI):命中 skill registry 时**不再内联展开正文**——作为普通 `/<name>`
+  文本 fall through 到 turn,由模型看到 system 的 "Available skills" 清单后自主调 `skill` 工具
+  加载正文。与 web / IM 完全一致:一条路径,正文落在可折叠的 tool_result 卡里,而非灌进
+  scrollback,resume 时也只显示 `> /<name>`。无工具模式下 `skill` 工具不存在、触发无从谈起,
+  直接拒绝(`/<name> needs tools — restart with: octo --tools`,与 `/init` 一致)。未命中的
+  `/` 前缀文本当普通用户输入照发(路径、正则等)。
 - **`octo skills list|update|path`**:`list` 按来源(default → user → project)列出;
   `update` 强制重新落地默认集;`path` 打印三个 root。
 - **`octo chat --list-skills`**:发现并打印后退出,不需 provider/key。
@@ -152,5 +155,6 @@ description 时,先调 `skill` 工具加载完整指令再行动,不要凭一句
   skill 覆盖。
 - `internal/tools`:`SkillTool.Execute` 命中返回正文 / 未命中报错;`DefaultTools` 按 registry
   空非空决定 skill 工具有无。
-- `cmd/octo`:`/<name>` 命中 inline / 未命中 Unknown command / `/skills` 输出;`--list-skills`
+- `cmd/octo`:`skillTrigger` 命中/未命中/保留命令不被同名 skill 劫持;无工具时 `/<name>` 被拒绝 /
+  `/skills` 输出;`--list-skills`
   与退出码;`Compose` 的 skills 层位置;`octo skills` 子命令。

--- a/docs/src/content/docs/reference/slash-commands.md
+++ b/docs/src/content/docs/reference/slash-commands.md
@@ -25,7 +25,7 @@ is the process; an IM chat can be re-bound to a different session entirely).
 | `/save` | `/save` | Saves the session now, prints the file path |
 | `/sessions` | `/sessions` | Lists the 10 most recent sessions |
 | `/exit`, `/quit` | | Quits (same as Ctrl-C / Ctrl-D) |
-| `/<skill-name>` | `/<name> [args]` | Any discovered skill not shadowed by a reserved command above inlines that skill as the next turn |
+| `/<skill-name>` | `/<name> [args]` | Any discovered skill not shadowed by a reserved command above is sent as ordinary `/<name>` text so the model loads it via the `skill` tool (needs tools — refused without them) |
 
 Anything starting with `/` that isn't recognized is sent to the model as plain text — handy for
 paths or regexes that happen to start with a slash.

--- a/docs/src/content/docs/zh/reference/slash-commands.md
+++ b/docs/src/content/docs/zh/reference/slash-commands.md
@@ -24,7 +24,7 @@ description: 每一个 / 命令，以及它们在 TUI、Web UI、IM 渠道之间
 | `/save` | `/save` | 立即保存会话，打印文件路径 |
 | `/sessions` | `/sessions` | 列出最近的 10 个会话 |
 | `/exit`、`/quit` | | 退出（等同 Ctrl-C / Ctrl-D） |
-| `/<skill-name>` | `/<name> [args]` | 任何没有被上面这些保留命令占用名字的已发现 skill，会把它内联成下一轮对话 |
+| `/<skill-name>` | `/<name> [args]` | 任何没有被上面这些保留命令占用名字的已发现 skill，会作为普通 `/<name>` 文本发出，由模型通过 `skill` 工具加载（需要工具——无工具时会被拒绝） |
 
 不认识的 `/xxx` 会原样当作纯文本发给模型——对那些碰巧以斜杠开头的路径或正则表达式很友好。
 


### PR DESCRIPTION
## Problem

Typing `/<skill>` (e.g. `/grill-me`) in the TUI rendered the full `SKILL.md` body and sent it as the turn text. That body then became the **persisted user message**, so every history re-render — `--resume`, the web transcript panel — dumped the whole `SKILL.md` as a wall of text. The compact `/name` echo only ever lived in the live scrollback, never in storage; nothing masked it on replay.

Two user reports ("skill slash command floods the message list", "resuming a session looks ugly") turned out to be the same root cause.

## Change

Drop the TUI inline expansion so it behaves like the web and IM transports:

- **With tools**: `/<skill>` falls through as ordinary `/name` text; the model loads the skill via the `skill` tool. One path across all transports, and the body lands in a foldable `tool_result` card instead of flooding the scrollback. A resumed transcript shows just `> /name`.
- **Without tools**: the `skill` tool isn't registered, so the trigger can't work — refuse with the same guidance as `/init` (`/<skill> needs tools — restart with: octo --tools`).

The unused `inlineSkill` helper and its test are removed; `skillTrigger` stays (used to detect a skill name for the no-tools refusal).

## Why not mask the stored body instead

Considered adding a persisted-but-model-invisible `CommandEcho` field (mirroring `ContentBlock.UI`) so renderers could collapse the stored body. Rejected in favour of unification: web/IM already prove the tool-load path works, it removes a TUI-only special case rather than papering over it, and it needs no schema change.

## Tests

- `TestDispatchSlash_SkillWithTools_FallsThrough` — with tools, `/greet` is not refused and starts an ordinary turn.
- `TestDispatchSlash_SkillWithoutTools_Refused` — without tools, `/greet` prints the `needs tools` refusal and starts no turn.
- Removed `TestInlineSkill` (helper deleted).

`go build ./...` and `go test ./cmd/octo/` pass.

## Docs

`dev-docs/m7-skills-design.md` §5 + test list, and the EN/ZH `reference/slash-commands.md` tables, updated from the old "inlines the skill as the next turn" wording to the new behaviour.

## Known non-goal

Sessions that already persisted a full-body `/<skill>` turn still show the full text on resume — the data is already on disk; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)