### PR TITLE
chore: bump version to 1.12.7

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.6"
+var Version = "1.12.7"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Patch release bundling the 11 commits merged since v1.12.6 — TUI skill-invocation unification (#1423), skills fixes (#1419, #1417, #1422), `/model` picker (#1416), sub-agent notice colouring (#1415), and several agent/tui/memory fixes.

Merging this, then pushing the `v1.12.7` tag, triggers goreleaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)