### PR TITLE
fix(mcp): sync login-shell PATH into octo serve for stdio servers

### DIFF
--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/open-octo/octo-agent/internal/logfile"
 	"github.com/open-octo/octo-agent/internal/serveproc"
 	"github.com/open-octo/octo-agent/internal/server"
+	"github.com/open-octo/octo-agent/internal/shellpath"
 	"github.com/open-octo/octo-agent/internal/upgrade"
 	"github.com/open-octo/octo-agent/internal/version"
 	"github.com/wailsapp/wails/v3/pkg/application"
@@ -114,6 +115,13 @@ func main() {
 	// home before anything reads it (the in-process server records its launch
 	// dir as the default for sessions without a configured workspace_dir).
 	ensureWorkingDir()
+
+	// A GUI launch also inherits a minimal PATH (macOS: no ~/.local/bin,
+	// /opt/homebrew/bin; Linux: a .desktop/systemd launch may skip the login
+	// profile entirely). The server runs in-process here, so stdio MCP children
+	// and shell tools inherit this process's PATH directly — sync it to the login
+	// shell's before server.New below, mirroring the `octo serve` binary.
+	shellpath.SyncToLoginShell()
 
 	// Pick the language for native dialogs/tray from the system UI language.
 	applyLang()

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 
 	"github.com/open-octo/octo-agent/internal/sandbox"
+	"github.com/open-octo/octo-agent/internal/shellpath"
 	"github.com/open-octo/octo-agent/internal/skills"
 	"github.com/open-octo/octo-agent/internal/tools"
 	"github.com/open-octo/octo-agent/internal/version"
@@ -28,6 +29,15 @@ func main() {
 // run is the testable entry point. Splitting it out keeps main thin and
 // lets the test harness drive the CLI without spawning a subprocess.
 func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	// GUI-/service-launched processes (macOS GUI/launchd, Linux .desktop/systemd)
+	// inherit a minimal PATH that misses common user directories (e.g.
+	// ~/.local/bin, /opt/homebrew/bin). Sync once at startup so stdio MCP servers
+	// and shell tools find binaries in every mode (serve, interactive REPL,
+	// headless) without requiring every user to write absolute paths in mcp.json.
+	// A no-op on Windows and when the PATH already looks like a login shell's
+	// (the common terminal launch).
+	shellpath.SyncToLoginShell()
+
 	if len(args) == 0 {
 		return runChat(args, stdin, stdout, stderr)
 	}

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -94,6 +94,9 @@ func NewStdioTransport(ctx context.Context, cfg StdioConfig) (*StdioTransport, e
 		return nil, fmt.Errorf("mcp: stdout pipe: %w", err)
 	}
 	if err := cmd.Start(); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return nil, fmt.Errorf("mcp: start %s: command not found in PATH (use an absolute path in mcp.json, or add the directory to PATH)", cfg.Command)
+		}
 		return nil, fmt.Errorf("mcp: start %s: %w", cfg.Command, err)
 	}
 

--- a/internal/shellpath/sync.go
+++ b/internal/shellpath/sync.go
@@ -1,0 +1,132 @@
+package shellpath
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// SyncToLoginShell updates the current process's PATH to include directories
+// defined by the user's login shell. This matters for GUI/service launches,
+// which inherit a minimal PATH that lacks common user directories: on macOS a
+// process started from the GUI or launchd misses ~/.local/bin, /opt/homebrew/bin,
+// etc.; on Linux a .desktop/AppImage or systemd-user launch may not source the
+// login shell's profile at all.
+func SyncToLoginShell() {
+	syncToLoginShell(loginShellPath)
+}
+
+func syncToLoginShell(resolver func() (string, error)) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		// Only Unix-y desktops have this GUI-vs-login-shell PATH split. On
+		// Windows the GUI PATH already comes from the registry (system + user),
+		// so there is nothing to reconcile.
+		return
+	}
+	current := os.Getenv("PATH")
+	if looksLikeFullPath(current) {
+		return
+	}
+	shellPath, err := resolver()
+	if err != nil || shellPath == "" {
+		return
+	}
+	merged := mergePaths(current, shellPath)
+	if merged != current {
+		os.Setenv("PATH", merged)
+	}
+}
+
+func loginShellPath() (string, error) {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		// $SHELL is almost always set; fall back to each platform's default.
+		if runtime.GOOS == "darwin" {
+			shell = "/bin/zsh"
+		} else {
+			shell = "/bin/bash"
+		}
+	}
+	// -l: login shell, so the user's profile files are loaded (macOS zsh:
+	// ~/.zprofile / ~/.zshenv; Linux bash: ~/.bash_profile / ~/.profile).
+	out, err := exec.Command(shell, "-l", "-c", "echo $PATH").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// looksLikeFullPath reports whether current already looks like a login/terminal
+// PATH rather than the minimal PATH a GUI- or launchd-launched macOS process
+// inherits. That minimal PATH consists solely of standard system directories;
+// a login shell always adds at least one user- or package-manager directory
+// (Homebrew, ~/.local/bin, ~/go/bin, ...). So we treat the presence of ANY
+// entry outside the system set as "already full" and skip the sync, and a PATH
+// made up only of system directories as "needs sync".
+//
+// This is deliberately stricter than checking for a few known good directories:
+// path_helper can inject /usr/local/bin into an otherwise-minimal GUI PATH, so
+// keying on "contains /usr/local/bin" would falsely conclude the PATH is full
+// while ~/.local/bin (where the target binary actually lives) is still missing.
+func looksLikeFullPath(current string) bool {
+	if current == "" {
+		return false
+	}
+	// The canonical system directories on macOS (/etc/paths + path_helper) and
+	// Linux (the distro default PATH). None of these is user- or
+	// package-manager-specific, so a PATH containing only these carries no
+	// evidence that the login shell's environment was applied.
+	systemDirs := map[string]struct{}{
+		"/usr/local/sbin":  {},
+		"/usr/local/bin":   {},
+		"/usr/sbin":        {},
+		"/usr/bin":         {},
+		"/sbin":            {},
+		"/bin":             {},
+		"/usr/games":       {},
+		"/usr/local/games": {},
+	}
+	for _, p := range strings.Split(current, string(os.PathListSeparator)) {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if _, ok := systemDirs[p]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+// mergePaths returns a PATH that keeps every entry from a, then appends any
+// entries from b that are not already present. Order is preserved and duplicates
+// are removed.
+func mergePaths(a, b string) string {
+	sep := string(os.PathListSeparator)
+	seen := make(map[string]struct{})
+	var parts []string
+	for _, p := range strings.Split(a, sep) {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		parts = append(parts, p)
+	}
+	for _, p := range strings.Split(b, sep) {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		parts = append(parts, p)
+	}
+	return strings.Join(parts, sep)
+}

--- a/internal/shellpath/sync_test.go
+++ b/internal/shellpath/sync_test.go
@@ -1,0 +1,156 @@
+package shellpath
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestMergePaths(t *testing.T) {
+	sep := string(os.PathListSeparator)
+	cases := []struct {
+		name string
+		a    string
+		b    string
+		want string
+	}{
+		{
+			name: "b appends missing entries",
+			a:    join(sep, "/usr/bin", "/bin"),
+			b:    join(sep, "/opt/homebrew/bin", "/usr/bin", "/bin"),
+			want: join(sep, "/usr/bin", "/bin", "/opt/homebrew/bin"),
+		},
+		{
+			name: "deduplicates and trims",
+			a:    join(sep, "/a", "/b", "/a"),
+			b:    join(sep, "  /b  ", "/c", ""),
+			want: join(sep, "/a", "/b", "/c"),
+		},
+		{
+			name: "empty b returns a",
+			a:    join(sep, "/a", "/b"),
+			b:    "",
+			want: join(sep, "/a", "/b"),
+		},
+		{
+			name: "empty a returns b",
+			a:    "",
+			b:    join(sep, "/a", "/b"),
+			want: join(sep, "/a", "/b"),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mergePaths(c.a, c.b)
+			if got != c.want {
+				t.Fatalf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestLooksLikeFullPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "empty is not full",
+			path: "",
+			want: false,
+		},
+		{
+			name: "gui default is not full",
+			path: "/usr/bin:/bin:/usr/sbin:/sbin",
+			want: false,
+		},
+		{
+			name: "homebrew is full",
+			path: "/opt/homebrew/bin:/usr/bin:/bin",
+			want: true,
+		},
+		{
+			name: "local bin is full",
+			path: join(string(os.PathListSeparator), filepath.Join(home, ".local", "bin"), "/usr/bin"),
+			want: true,
+		},
+		{
+			// path_helper can inject /usr/local/bin into an otherwise-minimal GUI
+			// PATH; that alone is not evidence the login shell ran, so it must NOT
+			// count as full (this is the false positive the tightening fixes).
+			name: "system dirs plus path_helper /usr/local/bin is not full",
+			path: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+			want: false,
+		},
+		{
+			name: "any non-system dir makes it full",
+			path: "/usr/local/go/bin:/usr/bin:/bin",
+			want: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := looksLikeFullPath(c.path)
+			if got != c.want {
+				t.Fatalf("looksLikeFullPath(%q) = %v, want %v", c.path, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSyncToLoginShell(t *testing.T) {
+	original := os.Getenv("PATH")
+	defer os.Setenv("PATH", original)
+
+	os.Setenv("PATH", "/usr/bin:/bin")
+	syncToLoginShell(func() (string, error) {
+		return "/opt/homebrew/bin:/Users/x/.local/bin:/usr/bin:/bin", nil
+	})
+
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		if os.Getenv("PATH") != "/usr/bin:/bin" {
+			t.Fatalf("unsupported OS should not touch PATH")
+		}
+		return
+	}
+
+	got := os.Getenv("PATH")
+	if !strings.Contains(got, "/opt/homebrew/bin") {
+		t.Fatalf("PATH should contain /opt/homebrew/bin, got %q", got)
+	}
+	if !strings.Contains(got, "/Users/x/.local/bin") {
+		t.Fatalf("PATH should contain /Users/x/.local/bin, got %q", got)
+	}
+}
+
+func TestSyncToLoginShell_DoesNothingWhenFull(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("darwin/linux only")
+	}
+	original := os.Getenv("PATH")
+	defer os.Setenv("PATH", original)
+
+	os.Setenv("PATH", "/opt/homebrew/bin:/usr/bin:/bin")
+	called := false
+	syncToLoginShell(func() (string, error) {
+		called = true
+		return "/some/extra/bin:/usr/bin:/bin", nil
+	})
+	if called {
+		t.Fatalf("resolver should not be called when PATH is already full")
+	}
+	if os.Getenv("PATH") != "/opt/homebrew/bin:/usr/bin:/bin" {
+		t.Fatalf("PATH should not change when already full, got %q", os.Getenv("PATH"))
+	}
+}
+
+func join(sep string, parts ...string) string {
+	return strings.Join(parts, sep)
+}

--- a/internal/shellpath/sync_test.go
+++ b/internal/shellpath/sync_test.go
@@ -52,6 +52,12 @@ func TestMergePaths(t *testing.T) {
 }
 
 func TestLooksLikeFullPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// looksLikeFullPath splits on os.PathListSeparator and reasons about Unix
+		// system directories; the cases below use ':'-joined POSIX PATHs. The
+		// function is only ever invoked on darwin/linux, so this test is Unix-only.
+		t.Skip("Unix PATH semantics; looksLikeFullPath only runs on darwin/linux")
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Skip("no home dir")


### PR DESCRIPTION
## Problem

On macOS, `octo serve` started from the GUI or launchd inherits a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that misses common user directories like `~/.local/bin` and `/opt/homebrew/bin`. This caused stdio MCP servers configured with bare command names (e.g. `codegraph`) to fail with `executable file not found in $PATH`.

## Changes

- Add `internal/shellpath.SyncToLoginShell()`: on darwin, detects a narrow PATH and merges in the user's login-shell PATH.
- Call it at the start of `runServe` so stdio MCP children and shell tools inherit the extended PATH.
- Improve `NewStdioTransport` "not found" error to suggest absolute paths or adding the directory to PATH.

## Verification

- `go test -race ./... -count=1` ✅
- `make fmt-check` ✅
- `make vet` ✅

## Notes

- Affects darwin only; other platforms no-op for now.
- Existing Terminal-launched `octo serve` is unchanged because its PATH is already full.