### PR TITLE
feat: build arm64 desktop artifacts and a universal macOS app

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -2,12 +2,15 @@ name: Desktop
 
 # Builds the Wails desktop shell (cmd/octo-desktop, a nested module). macOS and
 # Windows are the launch platforms; Linux builds an AppImage too (installing
-# GTK4 + WebKitGTK 6.0 + libsoup 3.0). All three artifacts are build-verified
-# in CI. The Linux AppImage relies on the host GTK4/WebKitGTK 6.0 (its AppRun
-# preflights and guides the user if absent) and is not yet run-tested on a
-# real desktop. The main `Go` workflow's
-# matrix does not build this module (nested go.mod, excluded from ./...), so the
-# CLI's CGO-free, cross-platform matrix stays green independent of Wails.
+# GTK4 + WebKitGTK 6.0 + libsoup 3.0). Each is build-verified in CI across
+# amd64 and arm64: macOS is one universal app; Linux builds each arch natively
+# (CGO/GTK, so arm64 uses the ubuntu-24.04-arm runner); Windows is pure-Go
+# (WebView2, no CGO), so arm64 cross-compiles on the amd64 runner. The Linux
+# AppImage relies on the host GTK4/WebKitGTK 6.0 (its AppRun preflights and
+# guides the user if absent) and is not yet run-tested on a real desktop. The
+# main `Go` workflow's matrix does not build this module (nested go.mod,
+# excluded from ./...), so the CLI's CGO-free, cross-platform matrix stays
+# green independent of Wails.
 on:
   push:
     branches: [main]
@@ -15,12 +18,16 @@ on:
       - 'cmd/octo-desktop/**'
       - 'internal/server/**'
       - 'scripts/package-desktop-macos.sh'
+      - 'scripts/package-desktop-linux.sh'
+      - 'scripts/embed-rg-windows.ps1'
       - '.github/workflows/desktop.yml'
   pull_request:
     paths:
       - 'cmd/octo-desktop/**'
       - 'internal/server/**'
       - 'scripts/package-desktop-macos.sh'
+      - 'scripts/package-desktop-linux.sh'
+      - 'scripts/embed-rg-windows.ps1'
       - '.github/workflows/desktop.yml'
   workflow_dispatch:
 
@@ -33,12 +40,22 @@ concurrency:
 
 jobs:
   build:
-    name: Desktop (${{ matrix.os }})
+    name: Desktop (${{ matrix.label }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # macOS ships a single universal (amd64+arm64) app. Linux links
+      # GTK4/WebKitGTK via CGO, so each arch builds natively on its own runner
+      # (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm). Windows is pure-Go
+      # (WebView2, no CGO), so arm64 cross-compiles on the amd64 runner —
+      # `goarch` drives the target for `go build` and the embedded ripgrep.
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        include:
+          - { os: macos-latest,     label: macos }
+          - { os: ubuntu-latest,    label: linux-amd64,   goarch: amd64 }
+          - { os: ubuntu-24.04-arm, label: linux-arm64,   goarch: arm64 }
+          - { os: windows-latest,   label: windows-amd64, goarch: amd64 }
+          - { os: windows-latest,   label: windows-arm64, goarch: arm64 }
     steps:
       - uses: actions/checkout@v5
         with:
@@ -83,25 +100,34 @@ jobs:
         if: runner.os == 'Linux'
         run: bash scripts/package-desktop-linux.sh
 
+      # package-desktop-linux.sh names its output by host arch
+      # (Octo-x86_64 / Octo-aarch64), so glob rather than hardcode; the
+      # per-arch artifact name keeps the amd64 and arm64 uploads distinct.
       - name: Upload Linux AppImage
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4
         with:
-          name: Octo-linux-appimage
-          path: Octo-x86_64.AppImage
+          name: Octo-linux-${{ matrix.goarch }}-appimage
+          path: Octo-*.AppImage
 
       # Bundle ripgrep so the desktop app's grep tool has an `rg` to shell out
       # to (mirrors `make build`; the app can't rely on the user's PATH).
+      # -Arch is the target GOARCH so the arm64 cross-build embeds arm64 rg.
       - name: Embed ripgrep
         if: runner.os == 'Windows'
         shell: pwsh
-        run: pwsh scripts/embed-rg-windows.ps1
+        run: pwsh scripts/embed-rg-windows.ps1 -Arch ${{ matrix.goarch }}
 
       # -H windowsgui: a GUI app, so no console window flashes behind it.
-      # -tags embedrg go:embeds the rg fetched above.
+      # -tags embedrg go:embeds the rg fetched above. Windows is pure-Go
+      # (WebView2, no CGO), so arm64 cross-compiles cleanly from the amd64
+      # runner: set GOARCH and keep CGO off.
       - name: Build Windows binary
         if: runner.os == 'Windows'
         working-directory: cmd/octo-desktop
+        env:
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '0'
         run: go build -v -tags embedrg -ldflags "-H windowsgui" -o octo-desktop.exe .
 
       # Raw .exe for now; wrapping it in an installer rides the existing Inno
@@ -110,5 +136,5 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
-          name: octo-desktop-windows
+          name: octo-desktop-windows-${{ matrix.goarch }}
           path: cmd/octo-desktop/octo-desktop.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Build the double-click Windows installer (octo-setup.exe) from the binary
-  # goreleaser just published, and attach it to the same release. Kept separate
-  # from goreleaser because Inno Setup is a Windows-only toolchain. The MVP
-  # installer is unsigned — see dev-docs/windows-onboarding-design.md.
+  # Build the double-click Windows installers (octo-setup.exe for x64,
+  # octo-setup-arm64.exe for Windows-on-ARM) from the binaries goreleaser just
+  # published, and attach them to the same release. Kept separate from
+  # goreleaser because Inno Setup is a Windows-only toolchain. The desktop shell
+  # is pure-Go (WebView2, no CGO), so the arm64 leg cross-compiles on the x64
+  # runner — GOARCH drives the target for the desktop build and the embedded
+  # ripgrep. The MVP installer is unsigned — see dev-docs/windows-onboarding-design.md.
   windows-installer:
-    name: windows installer
+    name: windows installer (${{ matrix.arch }})
     needs: goreleaser
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: amd64, uvarch: x86_64,  archallowed: x64compatible, out: octo-setup }
+          - { arch: arm64, uvarch: aarch64, archallowed: arm64,         out: octo-setup-arm64 }
     steps:
       - uses: actions/checkout@v5 # for packaging/windows/octo.iss + LICENSE.txt
 
@@ -57,8 +66,8 @@ jobs:
         run: |
           $version = "${{ github.ref_name }}".TrimStart('v')
           New-Item -ItemType Directory -Force -Path staging | Out-Null
-          gh release download "${{ github.ref_name }}" --pattern "octo_${version}_windows_amd64.zip" --dir dl
-          Expand-Archive -Path "dl\octo_${version}_windows_amd64.zip" -DestinationPath dl\extract -Force
+          gh release download "${{ github.ref_name }}" --pattern "octo_${version}_windows_${{ matrix.arch }}.zip" --dir dl
+          Expand-Archive -Path "dl\octo_${version}_windows_${{ matrix.arch }}.zip" -DestinationPath dl\extract -Force
           $exe = Get-ChildItem -Path dl\extract -Recurse -Filter octo.exe | Select-Object -First 1
           Copy-Item $exe.FullName staging\octo.exe
           Copy-Item LICENSE.txt staging\LICENSE.txt
@@ -66,16 +75,21 @@ jobs:
 
       # Bundle ripgrep so the desktop app's grep tool has an `rg` to shell out
       # to (mirrors `make build`; the app can't rely on the user's PATH).
+      # -Arch is the target GOARCH so the arm64 build embeds arm64 rg.
       - name: Embed ripgrep
         shell: pwsh
-        run: pwsh scripts/embed-rg-windows.ps1
+        run: pwsh scripts/embed-rg-windows.ps1 -Arch ${{ matrix.arch }}
 
       # Build the desktop GUI (nested module; embeds the committed web UI).
       # -H windowsgui so no console window flashes behind the app.
-      # -tags embedrg go:embeds the rg fetched above.
+      # -tags embedrg go:embeds the rg fetched above. Pure-Go (WebView2, no
+      # CGO), so arm64 cross-compiles cleanly from the x64 runner via GOARCH.
       - name: Build desktop app
         shell: pwsh
         working-directory: cmd/octo-desktop
+        env:
+          GOARCH: ${{ matrix.arch }}
+          CGO_ENABLED: '0'
         # Inject Version/Commit alongside -H windowsgui so the in-app update
         # check recognizes a real release build — without them
         # internal/upgrade.Eligible sees an empty Commit and the app reports
@@ -99,7 +113,7 @@ jobs:
           $uvVersion = "0.11.26"
           New-Item -ItemType Directory -Force -Path dl\uv | Out-Null
 
-          Invoke-WebRequest -Uri "https://github.com/astral-sh/uv/releases/download/$uvVersion/uv-x86_64-pc-windows-msvc.zip" -OutFile dl\uv.zip
+          Invoke-WebRequest -Uri "https://github.com/astral-sh/uv/releases/download/$uvVersion/uv-${{ matrix.uvarch }}-pc-windows-msvc.zip" -OutFile dl\uv.zip
           Expand-Archive -Path dl\uv.zip -DestinationPath dl\uv -Force
           Copy-Item dl\uv\uv.exe staging\uv.exe
 
@@ -109,13 +123,16 @@ jobs:
 
       - name: Compile installer
         shell: pwsh
+        # ArchAllowed/OutputName pin the installer to the target CPU and give
+        # each arch a distinct output name (see octo.iss).
         run: |
           # Source paths in the .iss resolve relative to the script's own dir,
           # so SourceDir / OutputDir must be absolute.
           $staging = Join-Path $PWD 'staging'
           & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" `
-            "/DAppVersion=$env:version" "/DSourceDir=$staging" "/O$staging" `
-            packaging\windows\octo.iss
+            "/DAppVersion=$env:version" "/DSourceDir=$staging" `
+            "/DArchAllowed=${{ matrix.archallowed }}" "/DOutputName=${{ matrix.out }}" `
+            "/O$staging" packaging\windows\octo.iss
 
       # Authenticode signing via SignPath Foundation (free for open source).
       # Dormant until SignPath is configured: set repo variables
@@ -128,8 +145,8 @@ jobs:
         id: unsigned-installer
         uses: actions/upload-artifact@v6
         with:
-          name: octo-setup-unsigned
-          path: staging\octo-setup.exe
+          name: octo-setup-unsigned-${{ matrix.arch }}
+          path: staging\${{ matrix.out }}.exe
 
       - name: Sign installer (SignPath)
         if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' }}
@@ -146,13 +163,13 @@ jobs:
       - name: Swap in the signed installer
         if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' }}
         shell: pwsh
-        run: Copy-Item signed\octo-setup.exe staging\octo-setup.exe -Force
+        run: Copy-Item signed\${{ matrix.out }}.exe staging\${{ matrix.out }}.exe -Force
 
       - name: Attach installer to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: pwsh
-        run: gh release upload "${{ github.ref_name }}" staging\octo-setup.exe --clobber
+        run: gh release upload "${{ github.ref_name }}" staging\${{ matrix.out }}.exe --clobber
 
   # Build the double-click macOS installer (octo-setup.pkg) from the universal
   # (amd64+arm64) binary goreleaser just published, and attach it to the same
@@ -205,13 +222,22 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "$GITHUB_REF_NAME" staging/octo-setup.pkg --clobber
 
-  # Build the Linux desktop AppImage (Octo-x86_64.AppImage) and attach it. The
-  # AppImage is the GUI + bundled uv; GTK4/WebKitGTK 6.0 come from the host (the
-  # AppRun launcher preflights them). Linux CLI users keep using the tarball.
+  # Build the Linux desktop AppImages (Octo-x86_64.AppImage,
+  # Octo-aarch64.AppImage) and attach them. The AppImage is the GUI + bundled
+  # uv; GTK4/WebKitGTK 6.0 come from the host (the AppRun launcher preflights
+  # them). Linux CLI users keep using the tarball. Each arch builds natively on
+  # its own runner — the shell links GTK4/WebKitGTK via CGO, so amd64 uses
+  # ubuntu-latest and arm64 uses ubuntu-24.04-arm.
   linux-appimage:
-    name: linux appimage
+    name: linux appimage (${{ matrix.arch }})
     needs: goreleaser
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-latest,    arch: amd64, apparch: x86_64,  uvarch: x86_64 }
+          - { runner: ubuntu-24.04-arm, arch: arm64, apparch: aarch64, uvarch: aarch64 }
     steps:
       - uses: actions/checkout@v5
 
@@ -223,33 +249,34 @@ jobs:
       - name: Install webview deps
         run: sudo apt-get update && sudo apt-get install -y libgtk-4-dev libwebkitgtk-6.0-dev libsoup-3.0-dev
 
-      # Stage the released linux amd64 CLI so package-desktop-linux.sh bundles it
-      # into the AppImage — the app seeds it to ~/.local/bin on first launch, so
-      # a terminal has `octo` like the mac/win installers provide.
+      # Stage the released linux CLI for this arch so package-desktop-linux.sh
+      # bundles it into the AppImage — the app seeds it to ~/.local/bin on first
+      # launch, so a terminal has `octo` like the mac/win installers provide.
       - name: Stage the released CLI
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           version="${GITHUB_REF_NAME#v}"
           mkdir -p dl
-          gh release download "$GITHUB_REF_NAME" --pattern "octo_${version}_linux_amd64.tar.gz" --dir dl
-          tar -xzf "dl/octo_${version}_linux_amd64.tar.gz" -C dl octo
+          gh release download "$GITHUB_REF_NAME" --pattern "octo_${version}_linux_${{ matrix.arch }}.tar.gz" --dir dl
+          tar -xzf "dl/octo_${version}_linux_${{ matrix.arch }}.tar.gz" -C dl octo
           echo "OCTO_CLI=$PWD/dl/octo" >> "$GITHUB_ENV"
 
       - name: Fetch bundled uv
         run: |
           uvVersion=0.11.26
           mkdir -p dl
-          curl -fsSL -o dl/uv.tar.gz "https://github.com/astral-sh/uv/releases/download/$uvVersion/uv-x86_64-unknown-linux-gnu.tar.gz"
+          curl -fsSL -o dl/uv.tar.gz "https://github.com/astral-sh/uv/releases/download/$uvVersion/uv-${{ matrix.uvarch }}-unknown-linux-gnu.tar.gz"
           tar -xzf dl/uv.tar.gz -C dl
-          echo "UV_BINARY=$PWD/dl/uv-x86_64-unknown-linux-gnu/uv" >> "$GITHUB_ENV"
+          echo "UV_BINARY=$PWD/dl/uv-${{ matrix.uvarch }}-unknown-linux-gnu/uv" >> "$GITHUB_ENV"
 
       - name: Build AppImage
         # Pass the release version so the packaged binary carries clean release
-        # metadata (see the script) and the in-app update check works.
+        # metadata (see the script) and the in-app update check works. The
+        # script names its output by host arch (Octo-x86_64 / Octo-aarch64).
         run: bash scripts/package-desktop-linux.sh "${GITHUB_REF_NAME#v}"
 
       - name: Attach AppImage to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$GITHUB_REF_NAME" Octo-x86_64.AppImage --clobber
+        run: gh release upload "$GITHUB_REF_NAME" Octo-${{ matrix.apparch }}.AppImage --clobber

--- a/cmd/octo-desktop/build/linux/AppRun
+++ b/cmd/octo-desktop/build/linux/AppRun
@@ -7,11 +7,15 @@
 # show install guidance instead.
 HERE="$(dirname "$(readlink -f "$0")")"
 
+# Debian/Ubuntu multiarch triplet for the running CPU, so the lib probe below
+# checks the right per-arch dir on both x86_64 and arm64 hosts.
+TRIPLET="$(uname -m)-linux-gnu"
+
 missing=""
 probe() {
   # Loadable if the linker cache knows it OR it's under a standard lib dir.
   ldconfig -p 2>/dev/null | grep -q "$1" && return 0
-  for d in /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu; do
+  for d in /usr/lib /usr/lib64 "/usr/lib/$TRIPLET" "/lib/$TRIPLET"; do
     [ -e "$d/$1".* ] 2>/dev/null && return 0
   done
   return 1

--- a/packaging/windows/octo.iss
+++ b/packaging/windows/octo.iss
@@ -23,6 +23,15 @@
 #ifndef SourceDir
   #define SourceDir "."
 #endif
+; Target CPU architecture. Defaults keep the amd64 (x64) installer byte-for-byte
+; as before; the release passes /DArchAllowed=arm64 /DOutputName=octo-setup-arm64
+; for the native Windows-on-ARM build.
+#ifndef ArchAllowed
+  #define ArchAllowed "x64compatible"
+#endif
+#ifndef OutputName
+  #define OutputName "octo-setup"
+#endif
 
 [Setup]
 ; A stable AppId so re-running a newer installer updates in place rather than
@@ -36,9 +45,9 @@ DefaultDirName={userpf}\octo
 DisableProgramGroupPage=yes
 DisableDirPage=yes
 PrivilegesRequired=lowest
-ArchitecturesAllowed=x64compatible
-ArchitecturesInstallIn64BitMode=x64compatible
-OutputBaseFilename=octo-setup
+ArchitecturesAllowed={#ArchAllowed}
+ArchitecturesInstallIn64BitMode={#ArchAllowed}
+OutputBaseFilename={#OutputName}
 Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern

--- a/scripts/embed-rg-windows.ps1
+++ b/scripts/embed-rg-windows.ps1
@@ -1,15 +1,24 @@
 #!/usr/bin/env pwsh
-# Download ripgrep for windows/amd64 and place it at the go:embed path so a
-# desktop build with -tags=embedrg bundles a working `rg` (the grep tool shells
-# out to it). This mirrors the Makefile's rg-embed target for the one platform
-# that can't use it: windows-latest runners aren't guaranteed to have GNU Make,
-# and the release pipeline avoids adding a `choco install make` dependency just
-# for a curl+unzip (same reason the uv fetch is inlined in pwsh). Keep
-# $rgVersion in sync with RG_VERSION in the Makefile.
+# Download ripgrep for the target Windows arch and place it at the go:embed path
+# so a desktop build with -tags=embedrg bundles a working `rg` (the grep tool
+# shells out to it). This mirrors the Makefile's rg-embed target for the one
+# platform that can't use it: windows-latest runners aren't guaranteed to have
+# GNU Make, and the release pipeline avoids adding a `choco install make`
+# dependency just for a curl+unzip (same reason the uv fetch is inlined in
+# pwsh). Keep $rgVersion in sync with RG_VERSION in the Makefile.
+#
+# -Arch is the GO arch of the desktop binary being built (amd64 | arm64), NOT
+# the runner's arch: the windows/arm64 desktop build cross-compiles on an
+# amd64 runner, so the embedded rg must match the target, not the host.
+param(
+	[ValidateSet('amd64', 'arm64')]
+	[string]$Arch = 'amd64'
+)
 $ErrorActionPreference = 'Stop'
 $rgVersion = '15.1.0'
 $embedDir = 'internal/tools/rgembed/binaries'
-$asset = "ripgrep-$rgVersion-x86_64-pc-windows-msvc.zip"
+$rgArch = if ($Arch -eq 'arm64') { 'aarch64' } else { 'x86_64' }
+$asset = "ripgrep-$rgVersion-$rgArch-pc-windows-msvc.zip"
 $url = "https://github.com/BurntSushi/ripgrep/releases/download/$rgVersion/$asset"
 
 New-Item -ItemType Directory -Force -Path $embedDir, dl\rg | Out-Null
@@ -19,4 +28,4 @@ $rg = Get-ChildItem -Path dl\rg -Recurse -Filter rg.exe | Select-Object -First 1
 # go:embed reads a file named "rg" (no extension) on every platform; the runtime
 # renames the extracted copy to rg.exe on Windows.
 Copy-Item $rg.FullName "$embedDir/rg" -Force
-Write-Host "Embedded rg $rgVersion for windows/amd64"
+Write-Host "Embedded rg $rgVersion for windows/$Arch"

--- a/scripts/package-desktop-linux.sh
+++ b/scripts/package-desktop-linux.sh
@@ -13,7 +13,18 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MOD_DIR="$ROOT/cmd/octo-desktop"
 LINUX="$MOD_DIR/build/linux"
 APPDIR="$ROOT/Octo.AppDir"
-OUT="$ROOT/Octo-x86_64.AppImage"
+
+# Native build only: the Wails shell links GTK4/WebKitGTK 6.0 via CGO, so the
+# AppImage architecture is whatever host this runs on. Derive the AppImage arch
+# (and appimagetool variant) from uname -m instead of hardcoding x86_64, so the
+# same script produces Octo-x86_64.AppImage on amd64 and Octo-aarch64.AppImage
+# on arm64.
+case "$(uname -m)" in
+	x86_64)  APPARCH=x86_64 ;;
+	aarch64) APPARCH=aarch64 ;;
+	*) echo "unsupported host arch: $(uname -m) (expected x86_64 or aarch64)" >&2; exit 1 ;;
+esac
+OUT="$ROOT/Octo-$APPARCH.AppImage"
 VERSION="${1:-$(git -C "$ROOT" describe --tags --always 2>/dev/null || echo 0.1.0)}"
 VERSION="${VERSION#v}"
 COMMIT="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
@@ -59,14 +70,16 @@ if [ -n "${UV_BINARY:-}" ] && [ -f "$UV_BINARY" ]; then
 fi
 
 echo "==> fetching appimagetool"
+# appimagetool must match the host arch to run natively (it's an AppImage
+# itself); the packaged AppImage's arch is set via the ARCH env var below.
 TOOL="$ROOT/appimagetool.AppImage"
 if [ ! -x "$TOOL" ]; then
 	curl -fsSL -o "$TOOL" \
-		"https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+		"https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$APPARCH.AppImage"
 	chmod +x "$TOOL"
 fi
 
 echo "==> building AppImage"
 # --appimage-extract-and-run: no FUSE in CI containers.
-ARCH=x86_64 "$TOOL" --appimage-extract-and-run "$APPDIR" "$OUT"
+ARCH=$APPARCH "$TOOL" --appimage-extract-and-run "$APPDIR" "$OUT"
 echo "==> done: $OUT"

--- a/scripts/package-desktop-macos.sh
+++ b/scripts/package-desktop-macos.sh
@@ -17,19 +17,42 @@ COMMIT="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 APP="$ROOT/Octo.app"
 CONTENTS="$APP/Contents"
 
-# Bundle ripgrep so the desktop app's grep tool has an `rg` to shell out to
-# (the app can't rely on one being on the user's PATH). Mirrors `make build`:
-# download rg for the host platform, then build with -tags=embedrg to go:embed
-# it. Without this the grep tool fails at runtime with "no binary was embedded".
-echo "==> embedding ripgrep"
-make -C "$ROOT" rg-embed
-
-echo "==> building octo-desktop binary"
+# Build a universal (x86_64 + arm64) octo-desktop so Octo.app runs natively on
+# both Intel and Apple Silicon. Each arch is compiled separately and lipo'd
+# together — Wails links WKWebView via CGO, and the macOS SDK ships both arch
+# slices, so CC="clang -arch <arch>" cross-compiles the C/ObjC side while GOARCH
+# handles the Go side.
+#
+# ripgrep is go:embed'd per arch (the grep tool shells out to it): each slice
+# must embed its OWN arch's rg, or grep breaks on the other arch. rg-embed is a
+# file target keyed on GOARCH, so wipe the embedded binary between arches to
+# force a re-download for the arch being built.
+RG_EMBED="$ROOT/internal/tools/rgembed/binaries/rg"
 # Inject Version/Commit so the in-app update check recognizes a real release
 # build — without them internal/upgrade.Eligible sees an empty Commit and the
 # app reports "up to date" forever.
 LDFLAGS="-X github.com/open-octo/octo-agent/internal/version.Version=$VERSION -X github.com/open-octo/octo-agent/internal/version.Commit=$COMMIT"
-( cd "$MOD_DIR" && CGO_ENABLED=1 go build -tags embedrg -ldflags "$LDFLAGS" -o "$ROOT/octo-desktop" . )
+slices=()
+for arch in amd64 arm64; do
+	case "$arch" in
+		amd64) cc_arch=x86_64 ;;
+		arm64) cc_arch=arm64 ;;
+	esac
+	echo "==> embedding ripgrep (darwin/$arch)"
+	rm -f "$RG_EMBED"
+	make -C "$ROOT" rg-embed GOOS=darwin GOARCH="$arch"
+
+	echo "==> building octo-desktop (darwin/$arch)"
+	out="$ROOT/octo-desktop-$arch"
+	( cd "$MOD_DIR" && \
+		GOOS=darwin GOARCH="$arch" CGO_ENABLED=1 CC="clang -arch $cc_arch" \
+		go build -tags embedrg -ldflags "$LDFLAGS" -o "$out" . )
+	slices+=("$out")
+done
+
+echo "==> lipo -> universal octo-desktop"
+lipo -create -output "$ROOT/octo-desktop" "${slices[@]}"
+rm -f "${slices[@]}"
 
 echo "==> assembling $APP (version $VERSION)"
 rm -rf "$APP"


### PR DESCRIPTION
## What

Adds arm64 desktop builds across macOS, Linux, and Windows, and makes the macOS GUI a universal binary. Previously the desktop shell shipped x86_64/amd64 only.

## Changes

**macOS — universal GUI**
- `scripts/package-desktop-macos.sh` builds `amd64` + `arm64` separately (each embedding its own-arch ripgrep) and `lipo`s them into one universal `octo-desktop`. The GUI was previously single-arch/host-only — on the Apple-Silicon `macos-latest` runner that meant an arm64-only binary that **cannot** run on Intel (Rosetta only translates x86→arm). Now `Octo.app` runs natively on both.

**Linux — arch-aware AppImage**
- `scripts/package-desktop-linux.sh` derives the arch from `uname -m` (`x86_64` | `aarch64`) instead of hardcoding `x86_64` (output name, appimagetool variant, `ARCH=`).
- `cmd/octo-desktop/build/linux/AppRun` probes the per-arch multiarch lib dir (`$(uname -m)-linux-gnu`) so arm64 hosts don't false-positive on missing GTK4/WebKitGTK.
- arm64 builds **natively** on `ubuntu-24.04-arm` (Wails links GTK4/WebKitGTK via CGO).

**Windows — cross-compiled arm64 installer**
- Desktop shell is pure-Go (WebView2, no CGO), so arm64 **cross-compiles** on the amd64 runner via `GOARCH`.
- `scripts/embed-rg-windows.ps1` takes `-Arch` to embed the target-arch rg (not the runner's).
- `packaging/windows/octo.iss` takes `ArchAllowed`/`OutputName` defines (amd64 defaults unchanged) to emit a native `octo-setup-arm64.exe`.

**CI**
- `desktop.yml` matrix covers all five build variants (macos / linux-amd64 / linux-arm64 / windows-amd64 / windows-arm64).
- `release.yml` `windows-installer` and `linux-appimage` fan out over arch and attach the arm64 installer/AppImage alongside the existing x64 artifacts.

## Verification

- ✅ Both workflows parse; the three bash scripts pass `bash -n`; arm64 uv + ripgrep (Windows/Linux) release assets confirmed present; goreleaser already produces linux/windows arm64 CLIs.
- ⚠️ Not yet run through real CI — the `ubuntu-24.04-arm` native build, Windows arm64 cross-compile, and macOS `lipo` universal binary need a workflow run to confirm. The `.ps1 -Arch` path was logic-checked, not executed on Windows.
- ⚠️ Windows arm64 cross-compile relies on the shell staying pure-Go (no CGO). If a CGO dep is ever introduced on Windows, that leg must move to a `windows-11-arm` native runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)