### PR TITLE
release: 1.12.8

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.7"
+var Version = "1.12.8"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
## Changelog

- Remove the desktop "run channels on this machine" toggle — channels now start from \`channels.yml\` like \`octo serve\` (#1429)
- Drop \`deep-research\` skill (replaced by combining \`grill + web-access + sub_agent\`); skill count 21 → 20 (#1430)
- Fix flaky \`TestMCPOAuth_LateCallbackAfterTimeout_Rejected\` (relax timeout 50ms → 200ms)
- Add \`cmd/octo/octo\` to \`\`\`.gitignore\`\`\`
- Relax authCodeTimeout to 200ms to fix flaky late-callback test
- Version bump only (` + "`" + `internal/version/version.go` + "`" + `)

Co-authored-by: octo-agent <noreply@octo-agent.dev>