### PR TITLE
fix(subagent): dispatch a sub_agent fan-out concurrently, not serially

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -452,6 +452,13 @@ type tuiModel struct {
 
 	// modal, when non-nil, is an active Ask prompt (design §6).
 	modal *modalState
+	// modalQueue holds Ask prompts that arrived while a modal was already open.
+	// Concurrent sub-agents (parallel fan-out) can each raise a permission ask
+	// at once; only one modal renders at a time, so the rest wait here FIFO and
+	// answerModal opens the next. Without this a second ask would overwrite the
+	// first, whose Ask goroutine would then block until its context is
+	// cancelled.
+	modalQueue []askMsg
 
 	// showTasks pins the task checklist in the live area regardless of turn
 	// state (Ctrl+T toggle, Claude Code style). The pinned view also shows a
@@ -2031,6 +2038,12 @@ func (m *tuiModel) handleTurnFinished(err error) (tea.Model, tea.Cmd) {
 	m.turnRunning = false
 	m.cancelTurn = nil
 	m.running = nil // clear any live tool indicator (e.g. on interrupt)
+	// NB: intentionally do NOT clear m.modal / m.modalQueue here. A background
+	// sub-agent (run_in_background) runs on a context detached from the turn, so
+	// its permission prompt outlives the turn and must stay answerable — nil-ing
+	// it would strand that sub-agent's Ask goroutine forever (its resp channel
+	// would never receive, and its context isn't cancelled at turn end). A
+	// foreground ask, by contrast, already unblocks via turn-context cancellation.
 
 	// Any steer messages that weren't drained via EventSteerInjected during
 	// the turn (e.g. typed after the last loop iteration) are printed now so

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -965,6 +965,65 @@ func TestTUI_PermissionModal(t *testing.T) {
 	}
 }
 
+// A second Ask arriving while a modal is open (concurrent sub-agents can each
+// prompt at once) is queued, not dropped: the first prompt stays on screen, the
+// second opens once the first is answered, and neither Ask goroutine is
+// stranded.
+func TestTUI_ConcurrentAsksQueue(t *testing.T) {
+	m := newTestModel()
+	resp1 := make(chan UserResponse, 1)
+	resp2 := make(chan UserResponse, 1)
+	m.openModal(askMsg{prompt: UserPrompt{Kind: KindPermission, ToolName: "terminal"}, resp: resp1})
+	m.openModal(askMsg{prompt: UserPrompt{Kind: KindPermission, ToolName: "write_file"}, resp: resp2})
+
+	if m.modal == nil || m.modal.prompt.ToolName != "terminal" {
+		t.Fatalf("first prompt should be showing, got %+v", m.modal)
+	}
+	if len(m.modalQueue) != 1 {
+		t.Fatalf("second prompt should be queued, queue len = %d", len(m.modalQueue))
+	}
+
+	// Answer the first: its resp fires and the queued second opens.
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if got := <-resp1; !got.Allow {
+		t.Errorf("first prompt should have been allowed, got %+v", got)
+	}
+	if m.modal == nil || m.modal.prompt.ToolName != "write_file" {
+		t.Fatalf("queued prompt should now be showing, got %+v", m.modal)
+	}
+	if len(m.modalQueue) != 0 {
+		t.Errorf("queue should be empty after popping, len = %d", len(m.modalQueue))
+	}
+
+	// Answer the second.
+	_, _ = m.handleModalKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if got := <-resp2; got.Allow {
+		t.Errorf("second prompt should have been denied, got %+v", got)
+	}
+	if m.modal != nil {
+		t.Error("no modal should remain after both answered")
+	}
+}
+
+// A background sub-agent's permission prompt outlives the turn that spawned it
+// (its context is detached from the turn), so a finishing turn must NOT clear an
+// open/queued modal — doing so would strand that sub-agent's Ask goroutine.
+func TestTUI_TurnFinishedKeepsBackgroundModal(t *testing.T) {
+	m := newTestModel()
+	m.openModal(askMsg{prompt: UserPrompt{Kind: KindPermission, ToolName: "terminal"}, resp: make(chan UserResponse, 1)})
+	m.openModal(askMsg{prompt: UserPrompt{Kind: KindPermission, ToolName: "write_file"}, resp: make(chan UserResponse, 1)})
+	m.turnRunning = true
+
+	m.handleTurnFinished(nil)
+
+	if m.modal == nil {
+		t.Error("modal must survive turn finish (may belong to a background sub-agent)")
+	}
+	if len(m.modalQueue) != 1 {
+		t.Errorf("queued modal must survive turn finish, len = %d", len(m.modalQueue))
+	}
+}
+
 func TestTUI_PermissionModalEscDenies(t *testing.T) {
 	m := newTestModel()
 	resp := make(chan UserResponse, 1)

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -1185,6 +1185,19 @@ func (m *tuiModel) interrupt() {
 // ── modal (Ask) ──
 
 func (m *tuiModel) openModal(msg askMsg) {
+	// A modal is already showing — queue this one; answerModal opens it once the
+	// current prompt is resolved. Concurrent sub-agents can each ask at once, and
+	// overwriting m.modal would strand the earlier prompt's Ask goroutine (its
+	// resp channel would never receive) until its context is cancelled.
+	if m.modal != nil {
+		m.modalQueue = append(m.modalQueue, msg)
+		return
+	}
+	m.modal = m.newModalState(msg)
+}
+
+// newModalState builds the modalState for an Ask prompt.
+func (m *tuiModel) newModalState(msg askMsg) *modalState {
 	st := &modalState{prompt: msg.prompt, resp: msg.resp, selected: map[int]bool{}}
 	if msg.prompt.Kind == KindQuestion {
 		st.options = append(st.options, msg.prompt.Options...)
@@ -1194,10 +1207,11 @@ func (m *tuiModel) openModal(msg askMsg) {
 	st.otherActive = false
 	st.otherInput = textinput.New()
 	st.otherInput.Prompt = ""
-	m.modal = st
+	return st
 }
 
-// answerModal sends a response and clears the modal.
+// answerModal sends a response, clears the modal, and opens the next queued
+// prompt (if any) so concurrent asks are handled one at a time.
 func (m *tuiModel) answerModal(r UserResponse) {
 	if m.modal == nil {
 		return
@@ -1207,6 +1221,11 @@ func (m *tuiModel) answerModal(r UserResponse) {
 	default:
 	}
 	m.modal = nil
+	if len(m.modalQueue) > 0 {
+		next := m.modalQueue[0]
+		m.modalQueue = m.modalQueue[1:]
+		m.modal = m.newModalState(next)
+	}
 }
 
 func (m *tuiModel) handleModalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1470,9 +1470,13 @@ type toolCall struct {
 // "ask" prompt must never race another on stdin. Execution then happens in one
 // of two modes:
 //   - Parallel, when the batch has >1 executable call and every executable
-//     call is a read-only tool (readOnlyTools). The model frequently fires
-//     several read_file/grep calls at once; running them concurrently cuts
-//     latency. Read-only tools don't stream, so no progress events are lost.
+//     call is concurrency-safe (concurrencySafe): the read-only built-ins the
+//     model frequently fires several of at once (read_file/grep/…), plus
+//     sub_agent, whose whole point is a parallel fan-out. Running them
+//     concurrently cuts latency — and for sub_agent avoids the "7 sub-agents
+//     block one another" serialization that a synchronous fan-out would
+//     otherwise hit. None of these stream tool-level progress, so no
+//     EventToolProgress is lost.
 //   - Serial otherwise (a single call, or any mutating/streaming tool present),
 //     preserving EventToolProgress for StreamingToolExecutor tools.
 //
@@ -1551,15 +1555,28 @@ func dispatchTools(ctx context.Context, executor ToolExecutor, blocks []ContentB
 	return flattenResults(resultSlices), nil
 }
 
+// concurrencySafe reports whether a tool may be dispatched concurrently with
+// its siblings in the same turn. It's the read-only built-ins (no side effects)
+// plus sub_agent: each sub-agent runs in its own isolated child (fresh history,
+// its own agent loop) and the SubAgentManager and token accounting are
+// mutex-guarded, so a fan-out of sub_agent calls is safe to run at once —
+// running them serially is exactly the "7 sub-agents block one another" latency
+// the concurrent path avoids. sub_agent surfaces its activity through its own
+// event sink (not EventToolProgress), so the parallel path loses no progress
+// events for it either.
+func concurrencySafe(name string) bool {
+	return readOnlyTools[name] || name == "sub_agent"
+}
+
 // canParallelize reports whether a batch can run concurrently: more than one
-// executable (non-denied) call, every one a known read-only tool.
+// executable (non-denied) call, every one a concurrency-safe tool.
 func canParallelize(calls []toolCall) bool {
 	executable := 0
 	for _, c := range calls {
 		if c.denyReason != "" {
 			continue
 		}
-		if !readOnlyTools[c.block.Name] {
+		if !concurrencySafe(c.block.Name) {
 			return false
 		}
 		executable++

--- a/internal/agent/dispatch_test.go
+++ b/internal/agent/dispatch_test.go
@@ -33,17 +33,23 @@ func TestCanParallelize(t *testing.T) {
 			true,
 		},
 		{
-			// sub_agent is NOT in the parallel-safe set because sub-agents can have
-			// side effects and run for a long time. Serial dispatch preserves
-			// EventToolProgress for streaming tools and keeps the event order
-			// predictable.
-			"two sub_agent calls → serial",
+			// sub_agent is concurrency-safe: each runs in an isolated child, and
+			// the manager/token accounting are mutex-guarded. A fan-out must run
+			// concurrently, else 7 sub-agents block one another.
+			"two sub_agent calls → parallel",
 			[]toolCall{ro("sub_agent"), ro("sub_agent")},
-			false,
+			true,
 		},
 		{
-			"sub_agent + read_file → serial",
+			"sub_agent + read_file → parallel",
 			[]toolCall{ro("sub_agent"), ro("read_file")},
+			true,
+		},
+		{
+			// A mutating tool in the batch still forces serial, even alongside
+			// sub_agent — write_file is not concurrency-safe.
+			"sub_agent + write_file → serial",
+			[]toolCall{ro("sub_agent"), ro("write_file")},
 			false,
 		},
 	}
@@ -101,6 +107,40 @@ func TestDispatchTools_ParallelReadOnly(t *testing.T) {
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("read-only batch did not run concurrently — the arrival barrier never released (serial dispatch)")
+	}
+}
+
+func TestDispatchTools_ParallelSubAgents(t *testing.T) {
+	// A fan-out of sub_agent calls must run concurrently, not serially — the
+	// whole point of dispatching several at once. The arrival barrier only
+	// releases if all three start together.
+	exec := &barrierExec{}
+	exec.wg.Add(3)
+	blocks := []ContentBlock{
+		NewToolUseBlock("s1", "sub_agent", map[string]any{"prompt": "a"}),
+		NewToolUseBlock("s2", "sub_agent", map[string]any{"prompt": "b"}),
+		NewToolUseBlock("s3", "sub_agent", map[string]any{"prompt": "c"}),
+	}
+
+	done := make(chan []ContentBlock, 1)
+	go func() {
+		r, _ := dispatchTools(context.Background(), exec, blocks, nil, nil)
+		done <- r
+	}()
+
+	select {
+	case results := <-done:
+		want := []string{"s1", "s2", "s3"}
+		if len(results) != 3 {
+			t.Fatalf("got %d results, want 3", len(results))
+		}
+		for i, w := range want {
+			if results[i].ToolUseID != w {
+				t.Errorf("results[%d].ToolUseID = %q, want %q", i, results[i].ToolUseID, w)
+			}
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("sub_agent batch did not run concurrently — the arrival barrier never released (serial dispatch)")
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2749,9 +2749,11 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		// soon as the message finished, same bug prepareToolTurn had for web.
 		executor = tools.NewDefaultRegistryWithTracker(tools.SessionReadTracker("im:" + string(sess.Key)))
 
-		// Per-message sub-agent manager bound to THIS chat's agent —
-		// synchronous, since a chat message is request/response with no
-		// follow-up channel for an async result. Stamped into ctx BEFORE
+		// Per-message sub-agent manager bound to THIS chat's agent. Async, like
+		// the web path: a background sub-agent Starts and reports completion via
+		// SetOnExit below, and a default (foreground) fan-out of several
+		// sub_agents runs concurrently rather than blocking one another
+		// (dispatchTools parallelizes a sub_agent batch). Stamped into ctx BEFORE
 		// toolDefs is computed below (#1133 follow-up) — the process-global
 		// spawner slot is never set in server mode (only
 		// SetDefaultSubAgentManager is, in enableSubAgentTools), so without
@@ -2765,7 +2767,17 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 			return tools.WithoutGoalTools(tools.DefaultToolsForCtx(ctx, sess.Agent.Model))
 		})
 		subMgr := tools.NewSubAgentManager(spawner)
-		subMgr.SetSynchronous(true)
+		// A background sub-agent finishes after this turn's chain ends; its
+		// result reaches the model via the agent Inbox + an idle follow-up turn,
+		// the same channel every background process and workflow completion uses
+		// (see wireChannelCompletionHooks). Without this an async sub-agent's
+		// reply would be dropped, which is why this path used to force synchronous
+		// dispatch. `ev` is the outer InboundEvent (the message that opened this
+		// turn); `n` is the completion notification.
+		subMgr.SetOnExit(func(n tools.SubAgentNotification) {
+			sess.Agent.Inbox.Enqueue(tools.FormatSubAgentNote(n))
+			go s.runChannelIdleTurn(context.Background(), sess, ad, ev)
+		})
 		ctx = tools.WithSubAgentManager(ctx, subMgr)
 
 		toolDefs = tools.DefaultToolsForCtx(ctx, sess.Agent.Model)

--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -194,6 +194,16 @@ type SubAgentManager struct {
 	synchronous bool
 	activeAsync int // running async spawns, for the concurrency cap
 
+	// syncSem bounds how many synchronous (RunSync) sub-agents run at once. A
+	// single assistant turn can dispatch a whole batch of foreground sub_agent
+	// calls, and dispatchTools now runs them concurrently — without this a large
+	// fan-out would open an unbounded number of child agent loops (and provider
+	// connections) at once. Excess RunSync calls block here until a slot frees,
+	// mirroring the maxConcurrentSubAgents guard the async Start path enforces by
+	// rejection. Buffered to maxConcurrentSubAgents; nil-safe is not required
+	// since NewSubAgentManager always sets it.
+	syncSem chan struct{}
+
 	// syncMu guards the sync session slot used to promote a synchronous
 	// sub-agent to background while it is running.
 	syncMu   sync.Mutex
@@ -205,6 +215,7 @@ func NewSubAgentManager(spawner Spawner) *SubAgentManager {
 	return &SubAgentManager{
 		agents:  map[string]*asyncSubAgent{},
 		spawner: spawner,
+		syncSem: make(chan struct{}, maxConcurrentSubAgents),
 	}
 }
 
@@ -314,6 +325,18 @@ func PromoteCurrentSubAgentSync() {
 func (m *SubAgentManager) RunSync(ctx context.Context, req SpawnRequest) (SpawnResult, error) {
 	if m.spawner == nil {
 		return SpawnResult{}, fmt.Errorf("subagent: no spawner configured")
+	}
+
+	// Bound concurrent foreground sub-agents (see syncSem): a batch dispatched
+	// in one turn runs concurrently, so cap how many child agent loops run at
+	// once. Blocks until a slot frees; a cancelled turn stops waiting. Released
+	// on return — including the promote path, where the run is re-counted against
+	// the async budget (activeAsync) instead.
+	select {
+	case m.syncSem <- struct{}{}:
+		defer func() { <-m.syncSem }()
+	case <-ctx.Done():
+		return SpawnResult{}, ctx.Err()
 	}
 
 	// Run the spawn on a background context so a user promotion can detach it


### PR DESCRIPTION
## Problem

When the model emits several `sub_agent` tool calls in one assistant turn, they ran strictly **serially** — each child fully completes before the next starts. `dispatchTools` only ran a multi-tool batch concurrently when *every* call was a read-only built-in, and a default (foreground) `sub_agent` goes through `RunSync`, which blocks. So a "parallel" fan-out of 7 sub-agents was really a 7-deep queue; the only escape was manually promoting each to the background (Ctrl+B / Web "Background" button).

## Changes

- **agent** (`internal/agent/agent.go`): `canParallelize` now treats `sub_agent` as concurrency-safe via a new `concurrencySafe` helper (read-only built-ins ∪ `sub_agent`). Each child runs in isolation and the manager / token accounting are mutex-guarded, so a `sub_agent` batch is safe to dispatch at once. A mutating tool in the batch still forces serial.
- **tools** (`internal/tools/subagent_manager.go`): bound concurrent foreground `RunSync` with a blocking semaphore (size `maxConcurrentSubAgents`) so a large fan-out can't open an unbounded number of child agent loops / provider connections — parity with the async `Start` path's existing cap. Released on return, including the promote path (re-counted against the async budget).
- **tui** (`cmd/octo/tuirepl_view.go`, `tuirepl.go`): a permission ask arriving while a modal is open is now **queued** (`modalQueue`) instead of overwriting it. Concurrent sub-agents can each raise a prompt at once; overwriting stranded the earlier prompt's `Ask` goroutine (its resp channel would never receive). `answerModal` opens the next queued prompt. `handleTurnFinished` intentionally does **not** clear an open modal — a background sub-agent's prompt outlives the turn and must stay answerable.
- **server** (`internal/server/server.go`): IM (channel) sub-agents now dispatch **asynchronously** — drop `SetSynchronous(true)` and wire `SetOnExit` to enqueue the completion note into the agent Inbox + fire an idle follow-up turn, reusing the same completion channel background tasks and workflows already use (`wireChannelCompletionHooks` / `runChannelIdleTurn`). The one-shot (no-session) path and the process-global default stay synchronous (no follow-up-turn channel).

Web WS chat was already async; this makes its default fan-out concurrent too.

## Coverage across transports

| Transport | Before | After |
|---|---|---|
| Web WS | already async, but default fan-out serial (RunSync + serial dispatch) | concurrent |
| IM / channel | forced synchronous, always serial | async; default fan-out concurrent, `run_in_background` works |
| CLI / TUI | default fan-out serial | concurrent (with modal-queue fix for concurrent permission prompts) |

## Known trade-off

Under a concurrent foreground fan-out, `RunSync`'s single `syncSess` slot means a manual Ctrl+B / "Background" promote targets only one of the in-flight sub-agents. This is benign (no hang) and largely moot once the fan-out already runs concurrently.

## Testing

- `internal/agent/dispatch_test.go`: updated `TestCanParallelize` (sub_agent now parallel; `sub_agent + write_file` still serial) + new `TestDispatchTools_ParallelSubAgents` barrier test proving concurrency.
- `cmd/octo/tuirepl_test.go`: `TestTUI_ConcurrentAsksQueue` (FIFO queue) + `TestTUI_TurnFinishedKeepsBackgroundModal`.
- `make fmt-check`, `make vet` clean. `go test -race ./internal/agent ./internal/tools ./internal/server` and the cmd/octo modal suite pass.

This change was reviewed by an isolated reviewer subagent; both flagged Important issues (foreground concurrency cap bypass; a background sub-agent's permission prompt being stranded on turn end) are fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
