### PR TITLE
refactor(channel): remove the Manager's dead standalone run loop

### DIFF
--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -3,7 +3,6 @@ package channel
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strconv"
 	"strings"
 	"sync"
@@ -156,9 +155,6 @@ type Manager struct {
 	factory AgentFactory
 	mode    BindingMode
 
-	// adapters holds running platform adapters keyed by platform name.
-	adapters sync.Map // string -> Adapter
-
 	// sessions holds active sessions keyed by SessionKey.
 	sessions sync.Map // SessionKey -> *Session
 
@@ -166,11 +162,6 @@ type Manager struct {
 	// key is present, the chat routes to the recorded store instead of its
 	// deterministic default (see resolveStoreID).
 	bindings *bindingStore
-
-	// mu guards the running flag.
-	mu      sync.RWMutex
-	running bool
-	cancel  context.CancelFunc
 
 	// goalsEnabled mirrors the main config's goal.enabled (default true,
 	// matching config.Config.GoalEnabled's default). The server sets it via
@@ -212,111 +203,6 @@ func (m *Manager) resolveStoreID(key SessionKey) string {
 		return id
 	}
 	return sessionStoreID(key)
-}
-
-// Start launches all enabled adapters and begins listening for messages.
-// It blocks until Stop is called or the context is cancelled.
-func (m *Manager) Start(ctx context.Context) error {
-	m.mu.Lock()
-	if m.running {
-		m.mu.Unlock()
-		return fmt.Errorf("manager already running")
-	}
-	m.running = true
-	ctx, m.cancel = context.WithCancel(ctx)
-	m.mu.Unlock()
-
-	for _, name := range m.cfg.EnabledPlatforms() {
-		pc := m.cfg.Platform(name)
-		if pc == nil {
-			// Shouldn't happen — EnabledPlatforms is derived from Config.Channels,
-			// so every name it yields should resolve back to a config here — but
-			// log it like every other skip in this loop rather than silently
-			// continuing, in case that invariant is ever violated.
-			slog.Error("channel start failed: enabled platform has no config", "channel", name)
-			continue
-		}
-		ctor, err := Find(name)
-		if err != nil {
-			slog.Error("channel start failed: adapter not registered", "channel", name, "err", err)
-			continue
-		}
-		ad, err := ctor(pc)
-		if err != nil {
-			slog.Error("channel start failed: construction failed", "channel", name, "err", err)
-			continue
-		}
-		if errs := ad.ValidateConfig(pc); len(errs) > 0 {
-			for _, e := range errs {
-				slog.Warn("channel config issue", "channel", name, "detail", e)
-			}
-			continue
-		}
-		m.adapters.Store(name, ad)
-
-		// #1121: the run error used to be discarded (`_ = a.Start(...)`), so
-		// an adapter crash mid-session (auth revoked, websocket dies
-		// unrecoverably) went dead with zero diagnostics — the only symptom
-		// was "the bot never replies". Logging it here at least gets the
-		// reason into octo serve's own log; internal/server's parallel
-		// startOneChannelLocked/runChannelWithRestart (the path octo serve
-		// actually runs) goes further and also retries with backoff and
-		// records the reason somewhere queryable (GET /api/channels).
-		go func(a Adapter, platform string) {
-			if err := a.Start(ctx, func(ev InboundEvent) {
-				ev.Platform = platform
-				m.handleInbound(ctx, ev)
-			}); err != nil && ctx.Err() == nil {
-				slog.Error("channel adapter exited unexpectedly", "channel", platform, "err", err)
-			}
-		}(ad, name)
-	}
-
-	<-ctx.Done()
-	return ctx.Err()
-}
-
-// Stop signals all adapters to shut down.
-func (m *Manager) Stop() error {
-	m.mu.Lock()
-	if !m.running {
-		m.mu.Unlock()
-		return nil
-	}
-	m.running = false
-	if m.cancel != nil {
-		m.cancel()
-	}
-	m.mu.Unlock()
-
-	m.adapters.Range(func(_, value any) bool {
-		if ad, ok := value.(Adapter); ok {
-			_ = ad.Stop()
-		}
-		return true
-	})
-	return nil
-}
-
-// IsRunning reports whether the manager is currently active.
-func (m *Manager) IsRunning() bool {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.running
-}
-
-// handleInbound routes an inbound event: commands go to commandRouter,
-// everything else goes to the session handler.
-func (m *Manager) handleInbound(ctx context.Context, ev InboundEvent) {
-	text := strings.TrimSpace(ev.Text)
-	if strings.HasPrefix(text, "/") {
-		reply := m.CommandRouter(ev)
-		if reply != "" {
-			m.sendReply(ev, reply)
-		}
-		return
-	}
-	m.handleSessionMessage(ctx, ev)
 }
 
 // CommandRouter processes slash commands and returns a reply text.
@@ -640,57 +526,6 @@ func (m *Manager) cmdList() string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// handleSessionMessage routes a non-command message to the appropriate session,
-// creating one automatically if needed.
-func (m *Manager) handleSessionMessage(ctx context.Context, ev InboundEvent) {
-	key := sessionKeyFor(m.mode, ev)
-
-	val, loaded := m.sessions.Load(key)
-	if !loaded {
-		// Auto-create session on first message.
-		sess := m.newSession(key, ev)
-		val, _ = m.sessions.LoadOrStore(key, sess)
-	}
-	sess := val.(*Session)
-
-	// Notify the adapter that we're processing (typing indicator).
-	m.sendTyping(ev)
-
-	// The actual agent run is delegated to the UI controller callback.
-	// The manager itself does not run the agent — it only manages sessions.
-	// The caller (CLI wiring) provides the event handler that bridges
-	// agent events back to the adapter.
-	_ = ctx
-	_ = sess
-}
-
-// sendReply sends a text reply back to the chat where the event originated.
-func (m *Manager) sendReply(ev InboundEvent, text string) {
-	val, ok := m.adapters.Load(ev.Platform)
-	if !ok {
-		return
-	}
-	ad := val.(Adapter)
-	// #1118: the SendResult was previously discarded — a failed /list or
-	// /bind confirmation just evaporated with nothing in the logs to explain
-	// why the user never saw it. There's no in-band way to notify the user
-	// here (this send *is* the notification), so log loudly instead.
-	if res := ad.SendText(ev.ChatID, text, ev.MessageID); !res.OK {
-		slog.Error("channel reply send failed", "platform", ev.Platform, "chat_id", ev.ChatID, "err", res.Error)
-	}
-}
-
-// sendTyping sends a typing indicator to the chat.
-func (m *Manager) sendTyping(ev InboundEvent) {
-	val, ok := m.adapters.Load(ev.Platform)
-	if !ok {
-		return
-	}
-	ad := val.(Adapter)
-	// Best-effort; ignore errors.
-	_ = ad.SendTyping(ev.ChatID, ev.ContextToken)
-}
-
 // KeyFor exposes the session key an inbound event maps to under this
 // manager's binding mode, for callers that keep per-session state outside
 // the manager (e.g. the server's remembered-permission stores).
@@ -717,15 +552,6 @@ func (m *Manager) GetOrCreateSession(ev InboundEvent) *Session {
 		val, _ = m.sessions.LoadOrStore(key, sess)
 	}
 	return val.(*Session)
-}
-
-// AdapterFor returns the adapter for a platform name.
-func (m *Manager) AdapterFor(platform string) Adapter {
-	val, ok := m.adapters.Load(platform)
-	if !ok {
-		return nil
-	}
-	return val.(Adapter)
 }
 
 // SessionCount returns the number of active sessions.

--- a/internal/channel/manager_test.go
+++ b/internal/channel/manager_test.go
@@ -1,10 +1,8 @@
 package channel
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -129,39 +127,6 @@ type fakeSender struct{}
 
 func (f fakeSender) SendMessages(ctx context.Context, model, system string, messages []agent.Message, maxTokens int) (agent.Reply, error) {
 	return agent.Reply{Content: "ok"}, nil
-}
-
-func TestManager_StartStop(t *testing.T) {
-	tempHome(t)
-	Register("mock", func(pc PlatformConfig) (Adapter, error) {
-		return &mockAdapter{platform: "mock"}, nil
-	})
-
-	cfg := &Config{
-		Channels: map[string]PlatformConfig{
-			"mock": {"enabled": true},
-		},
-	}
-	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-
-	// Start blocks; run it in a goroutine.
-	done := make(chan error, 1)
-	go func() { done <- mgr.Start(ctx) }()
-
-	time.Sleep(50 * time.Millisecond)
-	if !mgr.IsRunning() {
-		t.Fatal("expected manager to be running")
-	}
-
-	mgr.Stop()
-	<-done
-
-	if mgr.IsRunning() {
-		t.Fatal("expected manager to be stopped")
-	}
 }
 
 func TestManager_SessionBindingModes(t *testing.T) {
@@ -321,7 +286,7 @@ func TestManager_AutoSessionCreation(t *testing.T) {
 	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
 
 	ev := InboundEvent{Platform: "mock2", ChatID: "c1", UserID: "u1", Text: "hello"}
-	mgr.handleSessionMessage(context.Background(), ev)
+	mgr.GetOrCreateSession(ev)
 
 	if mgr.SessionCount() != 1 {
 		t.Fatalf("expected 1 auto-created session, got %d", mgr.SessionCount())
@@ -333,70 +298,6 @@ func TestManager_AutoSessionCreation(t *testing.T) {
 	}
 	if sess.ChatID != "c1" || sess.UserID != "u1" {
 		t.Fatalf("unexpected session chat/user: %s/%s", sess.ChatID, sess.UserID)
-	}
-}
-
-func TestManager_SendReply(t *testing.T) {
-	tempHome(t)
-	mock := &mockAdapter{platform: "mock3"}
-	Register("mock3", func(pc PlatformConfig) (Adapter, error) {
-		return mock, nil
-	})
-
-	cfg := &Config{
-		Channels: map[string]PlatformConfig{
-			"mock3": {"enabled": true},
-		},
-	}
-	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
-
-	// Manually store the adapter so sendReply works without Start().
-	mgr.adapters.Store("mock3", mock)
-
-	ev := InboundEvent{Platform: "mock3", ChatID: "c1", MessageID: "m1"}
-	mgr.sendReply(ev, "hello back")
-
-	if mock.sentTextCount() != 1 {
-		t.Fatalf("expected 1 sent text, got %d", mock.sentTextCount())
-	}
-	last := mock.lastSentText()
-	if last.text != "hello back" || last.chatID != "c1" {
-		t.Fatalf("unexpected sent text: %+v", last)
-	}
-}
-
-// #1118: a failed reply send used to just evaporate — the SendResult was
-// discarded with nothing logged, so a broken /list or /bind confirmation
-// left no trace explaining why the user never saw it.
-func TestManager_SendReply_LogsFailure(t *testing.T) {
-	tempHome(t)
-	mock := &mockAdapter{platform: "mock4", failSends: true}
-	Register("mock4", func(pc PlatformConfig) (Adapter, error) {
-		return mock, nil
-	})
-
-	cfg := &Config{
-		Channels: map[string]PlatformConfig{
-			"mock4": {"enabled": true},
-		},
-	}
-	mgr := NewManager(cfg, fakeAgentFactory, BindByChatUser)
-	mgr.adapters.Store("mock4", mock)
-
-	var buf bytes.Buffer
-	orig := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
-	t.Cleanup(func() { slog.SetDefault(orig) })
-
-	ev := InboundEvent{Platform: "mock4", ChatID: "c1", MessageID: "m1"}
-	mgr.sendReply(ev, "hello back")
-
-	if mock.sentTextCount() != 0 {
-		t.Fatalf("expected no delivered text on a failed send, got %d", mock.sentTextCount())
-	}
-	logged := buf.String()
-	if !strings.Contains(logged, "channel reply send failed") || !strings.Contains(logged, "mock4") {
-		t.Fatalf("expected the failed send to be logged, got: %s", logged)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2922,9 +2922,6 @@ func (s *Server) stopChannels() {
 	for name := range s.adapterCancels {
 		delete(s.adapterCancels, name)
 	}
-	if s.channelMgr != nil {
-		_ = s.channelMgr.Stop()
-	}
 	// Clear entries in place rather than reassigning the sync.Map: a concurrent
 	// HTTP handler (handleListChannels/handleGetChannel → isAdapterRunning) may
 	// be calling Load() during shutdown, and a sync.Map must not be copied or


### PR DESCRIPTION
## Why

`channel.Manager` once ran channels itself: `Start` → per-adapter goroutine → `handleInbound` → `CommandRouter`/`handleSessionMessage`. `octo serve` long ago replaced that with **internal/server's own `runChannelWithRestart` loop** (retry/backoff, queryable status via `GET /api/channels`), which drives adapters directly and uses the Manager only for session/binding/command bookkeeping.

The old run loop had **no production caller left**:
- `Manager.Start` was reachable only from its own test.
- `Manager.Stop` was called once in `server.stopChannels`, but purely as a **no-op** — `running` is always false in production (Start never ran), so it returned immediately.

This surfaced during review of the `/loop` work (a reviewer noted the `handleInbound → CommandRouter` path was dead); this PR cleans it up on its own.

## What

Remove the whole vestigial cluster:
- **methods**: `Start`, `Stop`, `IsRunning` (Manager-level — `Session.IsRunning` is a different, live method and stays), `handleInbound`, `handleSessionMessage`, `sendReply`, `sendTyping`, `AdapterFor` (this one had **zero** callers anywhere).
- **fields**: `adapters`, `mu`, `running`, `cancel`.
- the now-dead no-op `s.channelMgr.Stop()` call in `server.stopChannels`.
- **tests**: `TestManager_StartStop` and the two `TestManager_SendReply*` tests; `TestManager_AutoSessionCreation` retargeted onto the live `GetOrCreateSession` (same auto-create assertion, minus the dead method).

`CommandRouter` and the session/binding API are untouched. Net −277 lines.

## Test plan

- `go build ./...`, `gofmt -l`, `go vet ./internal/channel/ ./internal/server/`, and `go test ./internal/channel/ ./internal/server/` all clean.
- No behavior change: everything removed was unreachable in production.

### Note (unrelated pre-existing failure)
`go test ./...` shows one failure — `cmd/octo TestRenderStatusBar_NoHintNoDuration` — which this PR does not touch (`cmd/octo` is not in the diff). It fails because the test asserts the full cwd appears in the width-elided status bar, and this branch's worktree path (`.claude/worktrees/channel-mgr-legacy-cleanup/…`) is long enough to be truncated. It fails identically in any deeply-nested checkout and is independent of these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)