### PR TITLE
test(cli): stop status-bar test depending on the cwd path length

### DIFF
--- a/cmd/octo/tuirepl_p2_test.go
+++ b/cmd/octo/tuirepl_p2_test.go
@@ -11,6 +11,13 @@ import (
 // live in the startup banner) and no running-turn duration.
 func TestRenderStatusBar_NoHintNoDuration(t *testing.T) {
 	m := newTestModel()
+	// Pin a short cwd and a wide terminal so the segment isn't width-elided:
+	// newTestModel inherits the real os.Getwd(), which under a deeply-nested
+	// git worktree (.claude/worktrees/<name>/…) is long enough that StatusBar
+	// truncates it with "…", breaking the substring check for reasons unrelated
+	// to what this test asserts.
+	m.cwd = "/tmp/proj"
+	m.width = 200
 	if !strings.Contains(m.renderStatusBar(), m.cwd) {
 		t.Errorf("status bar should include the cwd; got:\n%s", m.renderStatusBar())
 	}


### PR DESCRIPTION
## Problem

`TestRenderStatusBar_NoHintNoDuration` asserts the full `m.cwd` substring appears in the rendered status bar:

```go
if !strings.Contains(m.renderStatusBar(), m.cwd) { ... }
```

But `tui.StatusBar` width-elides a long cwd with `…`. `newTestModel` inherits the real `os.Getwd()`, so running the suite from a deeply-nested git worktree (`.claude/worktrees/<name>/…`) truncates the path (`wo…rees`) and the substring check fails — for reasons unrelated to what the test verifies. It passes from a short cwd (e.g. the repo root) and fails from any deep checkout.

## Fix

Pin a short cwd and a wide width in the test so the cwd segment renders in full and the check is deterministic wherever the suite runs. The rest of the test (no key hints, no turn duration) is unchanged.

## Test plan

- `go test ./cmd/octo/` passes (previously failed when run from a deep worktree path).
- `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)