### PR TITLE
fix(windows): hide console windows for taskkill/tasklist

### DIFF
--- a/cmd/octo/clipimg_windows.go
+++ b/cmd/octo/clipimg_windows.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/open-octo/octo-agent/internal/executil"
 )
 
 // captureClipboardImage reads an image from the Windows clipboard via
@@ -43,7 +45,9 @@ else { $img.Save('%s', [System.Drawing.Imaging.ImageFormat]::Png); Write-Output 
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, shell, "-NoProfile", "-NonInteractive", "-Command", script).Output()
+	cmd := exec.CommandContext(ctx, shell, "-NoProfile", "-NonInteractive", "-Command", script)
+	executil.SetNoWindow(cmd)
+	out, err := cmd.Output()
 	if err != nil {
 		return nil, "", fmt.Errorf("clipboard: powershell: %w", err)
 	}

--- a/cmd/octo/mcp_prompt.go
+++ b/cmd/octo/mcp_prompt.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/open-octo/octo-agent/internal/executil"
 	"github.com/open-octo/octo-agent/internal/mcp"
 )
 
@@ -55,6 +56,7 @@ func openBrowser(url string) error {
 		// empty quoted arg is start's window-title placeholder, required
 		// whenever the target itself might be quoted.
 		cmd = exec.Command("cmd", "/c", "start", "", url)
+		executil.SetNoWindow(cmd)
 	default:
 		cmd = exec.Command("xdg-open", url)
 	}

--- a/internal/executil/no_window_other.go
+++ b/internal/executil/no_window_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package executil
+
+import "os/exec"
+
+func SetNoWindow(cmd *exec.Cmd) {}

--- a/internal/executil/no_window_windows.go
+++ b/internal/executil/no_window_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package executil
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// CREATE_NO_WINDOW prevents a console subsystem child from creating a visible
+// console window when spawned from a GUI process.
+const createNoWindow = 0x08000000
+
+func SetNoWindow(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNoWindow}
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -39,6 +39,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/open-octo/octo-agent/internal/executil"
 )
 
 // DefaultTimeout caps how long the REPL is willing to wait for a hook.
@@ -248,7 +250,9 @@ func shellCmd(ctx context.Context, cmd string) *exec.Cmd {
 		if _, err := exec.LookPath("pwsh"); err == nil {
 			shell = "pwsh"
 		}
-		return exec.CommandContext(ctx, shell, "-NoProfile", "-NonInteractive", "-Command", cmd)
+		c := exec.CommandContext(ctx, shell, "-NoProfile", "-NonInteractive", "-Command", cmd)
+		executil.SetNoWindow(c)
+		return c
 	}
 	return exec.CommandContext(ctx, "sh", "-c", cmd)
 }

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/open-octo/octo-agent/internal/executil"
 )
 
 // StdioTransport speaks JSON-RPC 2.0 over a subprocess's stdin/stdout. One
@@ -67,6 +69,7 @@ func NewStdioTransport(ctx context.Context, cfg StdioConfig) (*StdioTransport, e
 	// tool call with "broken pipe". The transport's Close method handles
 	// graceful shutdown via stdin EOF.
 	cmd := exec.Command(cfg.Command, cfg.Args...)
+	executil.SetNoWindow(cmd)
 	// Inherit env + add/override the configured entries. Building a fresh
 	// slice keeps os.Environ() intact for the parent.
 	if len(cfg.Env) > 0 {

--- a/internal/serveproc/proc_windows.go
+++ b/internal/serveproc/proc_windows.go
@@ -40,7 +40,9 @@ func Terminate(proc *os.Process) error {
 	if proc == nil {
 		return nil
 	}
-	if err := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(proc.Pid)).Run(); err != nil {
+	cmd := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(proc.Pid))
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x08000000} // CREATE_NO_WINDOW
+	if err := cmd.Run(); err != nil {
 		return proc.Kill()
 	}
 	return nil

--- a/internal/serveproc/proc_windows.go
+++ b/internal/serveproc/proc_windows.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"strconv"
 	"syscall"
+
+	"github.com/open-octo/octo-agent/internal/executil"
 )
 
 // IsAlive opens the process with PROCESS_QUERY_LIMITED_INFORMATION and calls
@@ -41,7 +43,7 @@ func Terminate(proc *os.Process) error {
 		return nil
 	}
 	cmd := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(proc.Pid))
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x08000000} // CREATE_NO_WINDOW
+	executil.SetNoWindow(cmd)
 	if err := cmd.Run(); err != nil {
 		return proc.Kill()
 	}

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/executil"
 	"github.com/open-octo/octo-agent/internal/tools/rgembed"
 )
 
@@ -309,6 +310,7 @@ func listProjectFiles(ctx context.Context, root string) ([]string, string, error
 
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, rgPath, "--files", "--hidden", "--null", root)
+	executil.SetNoWindow(cmd)
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/open-octo/octo-agent/internal/executil"
 	"github.com/open-octo/octo-agent/internal/sandbox"
 	"github.com/open-octo/octo-agent/internal/trash"
 )
@@ -141,6 +142,7 @@ func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 			cmd = exec.CommandContext(ctx, ps, "-NoProfile", "-NonInteractive", "-Command", command)
 			cmd.Env = withBundledBinPath(os.Environ())
 		}
+		executil.SetNoWindow(cmd)
 	} else {
 		projectDir := WorkingDirOrCWD(ctx)
 		if projectDir != "" {

--- a/internal/tools/terminal_kill_windows.go
+++ b/internal/tools/terminal_kill_windows.go
@@ -22,6 +22,7 @@ func setProcessGroupOpts() *syscall.SysProcAttr { return nil }
 const (
 	detachedProcess       = 0x00000008
 	createNewProcessGroup = 0x00000200
+	createNoWindow        = 0x08000000
 )
 
 // setDetachedProcessOpts starts the child detached from the harness console in
@@ -33,7 +34,9 @@ func setDetachedProcessOpts() *syscall.SysProcAttr {
 
 // processExists checks whether a process with the given PID is still running.
 func processExists(pid int) bool {
-	out, err := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/NH").Output()
+	cmd := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/NH")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNoWindow}
+	out, err := cmd.Output()
 	if err != nil {
 		return false
 	}
@@ -53,7 +56,9 @@ func killProcessGroup(p *os.Process, sigName string) error {
 	force := sigName == "SIGKILL"
 	if !force {
 		// Graceful attempt: send WM_CLOSE to the process tree.
-		_ = exec.Command("taskkill", "/T", "/PID", strconv.Itoa(p.Pid)).Run()
+		cmd := exec.Command("taskkill", "/T", "/PID", strconv.Itoa(p.Pid))
+		cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNoWindow}
+		_ = cmd.Run()
 		// Wait up to 5s for the process to exit.
 		for i := 0; i < 50; i++ {
 			if !processExists(p.Pid) {
@@ -65,6 +70,7 @@ func killProcessGroup(p *os.Process, sigName string) error {
 	}
 
 	cmd := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(p.Pid))
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNoWindow}
 	if err := cmd.Run(); err != nil {
 		return p.Kill()
 	}

--- a/internal/tools/terminal_kill_windows.go
+++ b/internal/tools/terminal_kill_windows.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/open-octo/octo-agent/internal/executil"
 )
 
 // setProcessGroupOpts is a no-op on Windows, which has no POSIX process groups.
@@ -22,7 +24,6 @@ func setProcessGroupOpts() *syscall.SysProcAttr { return nil }
 const (
 	detachedProcess       = 0x00000008
 	createNewProcessGroup = 0x00000200
-	createNoWindow        = 0x08000000
 )
 
 // setDetachedProcessOpts starts the child detached from the harness console in
@@ -35,7 +36,7 @@ func setDetachedProcessOpts() *syscall.SysProcAttr {
 // processExists checks whether a process with the given PID is still running.
 func processExists(pid int) bool {
 	cmd := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/NH")
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNoWindow}
+	executil.SetNoWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return false
@@ -57,7 +58,7 @@ func killProcessGroup(p *os.Process, sigName string) error {
 	if !force {
 		// Graceful attempt: send WM_CLOSE to the process tree.
 		cmd := exec.Command("taskkill", "/T", "/PID", strconv.Itoa(p.Pid))
-		cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNoWindow}
+		executil.SetNoWindow(cmd)
 		_ = cmd.Run()
 		// Wait up to 5s for the process to exit.
 		for i := 0; i < 50; i++ {
@@ -70,7 +71,7 @@ func killProcessGroup(p *os.Process, sigName string) error {
 	}
 
 	cmd := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(p.Pid))
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNoWindow}
+	executil.SetNoWindow(cmd)
 	if err := cmd.Run(); err != nil {
 		return p.Kill()
 	}


### PR DESCRIPTION
Closes the black console-window flashes reported by Windows desktop users.

### Problem
On Windows, `octo-desktop` is a GUI process. Any `exec.Command` that starts a console subsystem program (`taskkill.exe`, `tasklist.exe`, PowerShell, `rg.exe`, `cmd.exe`, or an MCP stdio server) defaults to creating a visible console window, which briefly pops up as a black flash. This happened during desktop takeover, skill script execution, terminal commands, hook runs, glob searches, MCP stdio startup, clipboard image capture, and OAuth browser prompts.

### Fix
Add a tiny cross-platform helper `internal/executil.SetNoWindow` that sets `CREATE_NO_WINDOW` (`0x08000000`) on Windows and is a no-op elsewhere. Apply it consistently to every Windows subprocess creation point that may spawn a console program.

### Files changed
- `internal/executil/no_window_windows.go` (new)
- `internal/executil/no_window_other.go` (new)
- `internal/serveproc/proc_windows.go`
- `internal/tools/terminal_kill_windows.go`
- `internal/tools/sandbox.go`
- `internal/hooks/hooks.go`
- `internal/tools/glob.go`
- `internal/mcp/stdio.go`
- `cmd/octo/clipimg_windows.go`
- `cmd/octo/mcp_prompt.go`

### Verification
- `go build ./...`
- `GOOS=windows go build ./...`
- `go vet ./...`
- `go test -short ./internal/executil/... ./internal/serveproc/... ./internal/tools/... ./internal/hooks/... ./internal/mcp/... ./cmd/octo/... -race -count=1`
- `gofmt` clean