### PR TITLE
chore(version): bump version to 1.12.9

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.8"
+var Version = "1.12.9"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump `Version` in `internal/version/version.go` from `1.12.8` to `1.12.9`.