### PR TITLE
fix(tui): don't recall last message into the input box after output

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -37,7 +37,7 @@ import (
 //   - Alt+Enter          → newline (traditional escape sequence)
 //   - Ctrl+J             → newline (LF — works on all terminals)
 //   - Ctrl+Q             → queue  (run as a fresh turn after this one finishes)
-//   - Esc                → take the turn back if no output yet (text returns to the input), else interrupt; queue survives
+//   - Esc                → take the turn back if no output yet (text returns to the input), else just interrupt; queue survives
 //   - Ctrl+C             → interrupt if a turn runs, else save & quit (twice)
 //   - Ctrl+D (twice)     → save & quit (first press arms, second confirms)
 func runTUI(cfg replConfig) int {

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -209,7 +209,8 @@ func TestTUI_EscTakesBackBeforeOutput(t *testing.T) {
 }
 
 // Once output has streamed the echo is already committed (echoPending == ""), so
-// Esc interrupts and recalls the last submitted message from history.
+// Esc only interrupts — the last submitted message is NOT recalled into the box,
+// even when it sits in history.
 func TestTUI_EscAfterOutputJustInterrupts(t *testing.T) {
 	m := newTestModel()
 	m.turnRunning = true
@@ -223,8 +224,8 @@ func TestTUI_EscAfterOutputJustInterrupts(t *testing.T) {
 	if !cancelled {
 		t.Error("Esc should still interrupt once output has started")
 	}
-	if m.ta.Value() != "fix the bug" {
-		t.Errorf("input box should recall last message, got %q", m.ta.Value())
+	if m.ta.Value() != "" {
+		t.Errorf("input box should stay empty after output, got %q", m.ta.Value())
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -181,8 +181,9 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// and restore the typed text to the input box for editing — the agent's
 			// interrupt rolls the unanswered user message back out of history, so
 			// it leaves no trace in the scrollback. Once output has streamed the
-			// echo is already committed (echoPending == "") and Esc interrupts +
-			// recalls the last submitted message from history.
+			// echo is already committed (echoPending == "") and Esc only interrupts:
+			// the message stays in the transcript and is NOT recalled into the box
+			// (the user can still press ↑ to edit and resubmit).
 			if m.echoPending != "" {
 				restore := m.echoRestore
 				m.echoPending = ""
@@ -196,25 +197,7 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 				return m, nil
 			}
-			// After output has streamed the echo is committed; Esc interrupts
-			// and recalls the last submitted message into the input box so the
-			// user can edit and resubmit without pressing ↑ manually.
-			//
-			// Pending steers are exempt: they stay in the inbox and run as the
-			// next turn on their own (handleTurnFinished drains it), so recalling
-			// them here would both run the steer AND strand its text in the box.
-			// Note interrupt() clears pendingSteer, so capture it first.
-			hadSteer := len(m.pendingSteer) > 0
 			m.interrupt()
-			if hadSteer {
-				return m, nil
-			}
-			if n := len(m.inputHistory); n > 0 && m.ta.Value() == "" {
-				m.ta.SetValue(m.inputHistory[n-1])
-				m.ta.CursorEnd()
-				m.inputHistoryIdx = -1
-				return m, m.updateTextAreaHeight()
-			}
 			return m, nil
 		}
 		// Idle: clear the input line and discard any pending attachments.


### PR DESCRIPTION
## What

When you press Esc to interrupt a running turn in the TUI, it used to put the previous submitted message back into the input box. This only makes sense before any output has streamed (the true take-back case). Once the agent has already produced output, the interrupted message stays in the transcript, so re-populating the box is surprising and forces you to clear it before typing something new.

Now Esc behaves like this:

- **No output yet** (`echoPending != ""`): unchanged — drop the not-yet-committed echo and restore the freshly typed text to the box.
- **After output** (`echoPending == ""`): only interrupt; the input box is left untouched. `↑` still recalls history on demand.

The now-unnecessary pending-steer recall exemption was removed with the recall itself.

## Changes

- `cmd/octo/tuirepl_view.go` — remove the after-output history recall from the Esc handler.
- `cmd/octo/tuirepl.go` — update the key-binding doc comment.
- `cmd/octo/tuirepl_test.go` — `TestTUI_EscAfterOutputJustInterrupts` now asserts the box stays empty even when history is present.

## Test

`go test ./cmd/octo/` passes; `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)