### PR TITLE
fix(windows): make SetNoWindow composable and cover remaining rg call

### DIFF
--- a/cmd/octo/serve_daemon_windows.go
+++ b/cmd/octo/serve_daemon_windows.go
@@ -4,23 +4,22 @@ package main
 
 import (
 	"os/exec"
-	"syscall"
-)
 
-// createNoWindow gives the child its own console but with no visible window.
-// We deliberately avoid DETACHED_PROCESS (0x8) here: a detached child has *no*
-// console at all, so when it spawns its own console-app children (the daemon
-// child is the supervisor, which spawns the serve worker) Windows allocates a
-// fresh *visible* console for each grandchild. With a windowless console the
-// grandchildren inherit it and stay invisible. Combined with stdout/stderr
-// redirected to a log file, the whole tree runs silently in the background.
-const createNoWindow = 0x08000000
+	"github.com/open-octo/octo-agent/internal/executil"
+)
 
 // setSysProcAttrDetach creates the child with a windowless console so neither it
 // nor any console-app grandchild it spawns pops a terminal window, and it does
 // not receive Ctrl-C signals sent to the parent's terminal.
+//
+// We deliberately avoid DETACHED_PROCESS (0x8) here: a detached child has *no*
+// console at all, so when it spawns its own console-app children (the daemon
+// child is the supervisor, which spawns the serve worker) Windows allocates a
+// fresh *visible* console for each grandchild. executil.SetNoWindow (which
+// uses CREATE_NO_WINDOW) gives the child its own console but with no visible
+// window, so grandchildren inherit it and stay invisible. Combined with
+// stdout/stderr redirected to a log file, the whole tree runs silently in the
+// background.
 func setSysProcAttrDetach(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: createNoWindow,
-	}
+	executil.SetNoWindow(cmd)
 }

--- a/internal/executil/no_window_windows.go
+++ b/internal/executil/no_window_windows.go
@@ -12,5 +12,8 @@ import (
 const createNoWindow = 0x08000000
 
 func SetNoWindow(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNoWindow}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= createNoWindow
 }

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/executil"
 	"github.com/open-octo/octo-agent/internal/tools/rgembed"
 )
 
@@ -153,6 +154,7 @@ func (GrepTool) Execute(ctx context.Context, _ string, input map[string]any) (ag
 
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, rgPath, args...)
+	executil.SetNoWindow(cmd)
 	// Root rg in the session's working directory. Without this, a grep with no
 	// explicit `path` runs in the octo process CWD — which for a long-lived
 	// `octo serve`/desktop hub is wherever the daemon launched (often $HOME),


### PR DESCRIPTION
Follow-up to #1439.

### What was wrong
1. `executil.SetNoWindow` replaced `cmd.SysProcAttr` entirely, silently discarding any fields a caller had already set.
2. The `grep` tool's ripgrep invocation was missed in the first pass, so it could still pop a console window on Windows.
3. `cmd/octo/serve_daemon_windows.go` duplicated the `CREATE_NO_WINDOW` constant instead of reusing the helper.

### Changes
- `internal/executil/no_window_windows.go`: OR `CREATE_NO_WINDOW` into existing `SysProcAttr.CreationFlags` instead of replacing the struct.
- `internal/tools/grep.go`: apply `executil.SetNoWindow` to the ripgrep command.
- `cmd/octo/serve_daemon_windows.go`: delegate to `executil.SetNoWindow` and keep the explanatory comment.

### Verification
- `go build ./...`
- `GOOS=windows go build ./...`
- `go vet ./...`
- `go test -short ./internal/executil/... ./internal/tools/... ./internal/hooks/... ./internal/mcp/... ./cmd/octo/... -race -count=1`