### PR TITLE
fix(tui): don't let thinking deltas consume the Esc take-back

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1435,9 +1435,16 @@ func (m *tuiModel) acceptSuggestion() {
 }
 
 func (m *tuiModel) handleEvent(ev agent.AgentEvent) {
-	// Promote the deferred user echo above this turn's first output so the
-	// transcript order (your message → reply) is preserved.
-	m.commitEcho()
+	// Promote the deferred user echo above this turn's first *visible* output so
+	// the transcript order (your message → reply) is preserved. Thinking deltas
+	// are invisible in the terminal (they only nudge the token counter), so they
+	// must NOT commit the echo — otherwise an Esc during a reasoning model's
+	// thinking phase, when nothing is on screen yet, would fail the take-back and
+	// strand the typed text. Keeping echoPending set through thinking makes it a
+	// truthful "no visible output yet" signal for the Esc handler.
+	if ev.Kind != agent.EventThinkingDelta {
+		m.commitEcho()
+	}
 	// Any event other than a continued answer delta ends a hand-off sprint and
 	// releases the held text first, so a following tool call / turn-end commits
 	// in the right order.

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -208,6 +208,36 @@ func TestTUI_EscTakesBackBeforeOutput(t *testing.T) {
 	}
 }
 
+// A reasoning model's thinking is invisible in the terminal, so thinking deltas
+// must not commit the echo. Esc during the thinking phase (still no visible
+// output) must therefore still take the turn back and restore the typed text.
+func TestTUI_EscTakesBackDuringThinking(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	cancelled := false
+	m.cancelTurn = func() { cancelled = true }
+	m.echoPending = userEchoStyle.Render("> ") + "fix the bug"
+	m.echoRestore = "fix the bug"
+
+	// The model thinks (invisible) before producing any answer text.
+	m.handleEvent(agent.AgentEvent{Kind: agent.EventThinkingDelta, Text: "hmm, let me reason about this"})
+	if m.echoPending == "" {
+		t.Fatal("thinking must not commit the echo — take-back would be lost")
+	}
+
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if !cancelled {
+		t.Error("Esc should cancel the running turn")
+	}
+	if m.ta.Value() != "fix the bug" {
+		t.Errorf("typed text should return to the input box, got %q", m.ta.Value())
+	}
+	if len(m.printlnBuf) != 0 {
+		t.Errorf("nothing should be flushed to the scrollback, got %v", m.printlnBuf)
+	}
+}
+
 // Once output has streamed the echo is already committed (echoPending == ""), so
 // Esc only interrupts — the last submitted message is NOT recalled into the box,
 // even when it sits in history.


### PR DESCRIPTION
## What

Follow-up to #1442. That PR made Esc-after-output only interrupt (no history recall), and kept the pre-output take-back (typed text returns to the input box). But the take-back stopped firing in a common case: **reasoning models**.

### Root cause

The take-back path keys off `echoPending`, but `commitEcho()` ran unconditionally on the first event of *any* kind at the top of `handleEvent`. `EventThinkingDelta` is invisible in the terminal — it only nudges the token counter — yet it still committed (cleared) the echo. On a reasoning model the very first event is a thinking delta, so `echoPending` was cleared before any visible output existed. Pressing Esc during the thinking phase then fell through to the just-interrupt branch and stranded the text the user had typed.

### Fix

Skip `commitEcho()` for thinking deltas, so `echoPending` stays a truthful "no visible output yet" signal. The echo is still promoted to the scrollback on the first *visible* event (text / tool), preserving transcript order. Esc during thinking now takes the turn back and restores the typed text, exactly as it does before the first event arrives.

## Changes

- `cmd/octo/tuirepl.go` — gate `commitEcho()` on `ev.Kind != EventThinkingDelta`.
- `cmd/octo/tuirepl_test.go` — new `TestTUI_EscTakesBackDuringThinking` regression test.

## Test

`go test ./cmd/octo/` passes; `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)