### PR TITLE
fix(skill): materialize defaults before REPL early-return

### DIFF
--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -38,18 +38,20 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// (the common terminal launch).
 	shellpath.SyncToLoginShell()
 
-	if len(args) == 0 {
-		return runChat(args, stdin, stdout, stderr)
-	}
-
 	// Materialize the binary's default skills/workflows to ~/.octo/skills-default
 	// and ~/.octo/workflows-default so they're discoverable like any user
 	// skill/workflow, and prune stale workflow run journals. Best-effort and a
 	// fast no-op/pass once current; skipped for the internal fast-path commands.
-	if args[0] != "__sandboxed-exec" && args[0] != "__complete" {
+	// Done before the len(args)==0 REPL early-return so a bare `octo` (the common
+	// launch on Linux) still populates the defaults before Discover() runs.
+	if len(args) == 0 || (args[0] != "__sandboxed-exec" && args[0] != "__complete") {
 		_ = skills.MaterializeDefaults(version.Version)
 		_ = tools.MaterializeDefaultWorkflows(version.Version)
 		_ = workflow.PruneJournals()
+	}
+
+	if len(args) == 0 {
+		return runChat(args, stdin, stdout, stderr)
 	}
 
 	switch args[0] {


### PR DESCRIPTION
## Problem

A bare `octo` (no subcommand, the common REPL entry on Linux) short-circuits to `runChat()` before `MaterializeDefaults` runs. On a fresh Linux install, `~/.octo/skills-default/` is never populated, so `Discover()` finds zero system skills.

## Fix

Move the materialize block above the `len(args)==0` early-return, with `len(args) == 0 ||` added to the guard so the empty-args path also runs initialization.

## Review

Isolated sub-agent code review: no critical/important issues. Short-circuit `||` prevents `args[0]` evaluation when `args` is empty. Behavior for all other paths unchanged.