### PR TITLE
feat: replace reclaim ReplaceAll with read-time Collapser projection

### DIFF
--- a/internal/agent/collapser.go
+++ b/internal/agent/collapser.go
@@ -1,0 +1,79 @@
+package agent
+
+import "strconv"
+
+// Collapser records which tool_result blocks have been collapsed by
+// reclaimStaleToolResults so Snapshot() can project the placeholder at read
+// time without mutating the underlying messages array. This keeps the
+// provider's prompt cache prefix valid because the stored message slice is
+// never rewritten — only the returned copy carries the projection.
+//
+// Key format: "msgIdx:blockIdx" — two ints joined by a colon.  This is
+// deliberately a string key rather than a struct to keep the zero-value useful
+// (a nil map is empty and needs no initialisation).
+//
+// Collapser is NOT persisted across session save/load. After a restart
+// reclaim will re-evaluate and re-populate entries, so the only cost is one
+// turn of full tool-result visibility after restore — accepted tradeoff.
+type Collapser struct {
+	entry map[string]string // msgIdx:blockIdx → placeholder text
+}
+
+// set records a collapsed placeholder for message at mi, block at bi.
+func (c *Collapser) set(mi, bi int, placeholder string) {
+	if c.entry == nil {
+		c.entry = make(map[string]string)
+	}
+	c.entry[c.key(mi, bi)] = placeholder
+}
+
+// get returns the placeholder and true if a collapse entry exists.
+func (c *Collapser) get(mi, bi int) (string, bool) {
+	if c.entry == nil {
+		return "", false
+	}
+	s, ok := c.entry[c.key(mi, bi)]
+	return s, ok
+}
+
+// remove clears collapse entries for message mi (used when that message is
+// overwritten by replaceLast).
+func (c *Collapser) remove(mi int) {
+	if c.entry == nil {
+		return
+	}
+	prefix := strconv.Itoa(mi) + ":"
+	for k := range c.entry {
+		// Fast path: prefix matches
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			delete(c.entry, k)
+		}
+	}
+}
+
+// clear drops all entries.
+func (c *Collapser) clear() {
+	c.entry = nil
+}
+
+// len reports the number of entries (0 when never used).
+func (c *Collapser) len() int {
+	return len(c.entry)
+}
+
+// project replaces collapsed tool_result blocks in-place on a copy of the
+// message slice (caller must own the copy — Snapshot handles this).
+func (c *Collapser) project(msgs []Message) {
+	for mi := range msgs {
+		for bi := range msgs[mi].Blocks {
+			if placeholder, ok := c.get(mi, bi); ok {
+				msgs[mi].Blocks[bi].Result = placeholder
+				msgs[mi].Blocks[bi].UI = nil
+			}
+		}
+	}
+}
+
+func (c *Collapser) key(mi, bi int) string {
+	return strconv.Itoa(mi) + ":" + strconv.Itoa(bi)
+}

--- a/internal/agent/collapser_test.go
+++ b/internal/agent/collapser_test.go
@@ -1,0 +1,133 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCollapser_ProjectReturnsPlaceholder(t *testing.T) {
+	var c Collapser
+	c.set(0, 1, "[elided]")
+	msgs := []Message{{
+		Role: RoleUser,
+		Blocks: []ContentBlock{
+			{Type: "tool_use", ID: "id1", Name: "grep"},
+			{Type: "tool_result", ToolUseID: "id1", Result: strings.Repeat("a", 5000)},
+		},
+	}}
+	c.project(msgs)
+	if msgs[0].Blocks[1].Result != "[elided]" {
+		t.Errorf("expected placeholder, got %q", msgs[0].Blocks[1].Result)
+	}
+}
+
+func TestCollapser_ProjectLeavesUncollapsedAlone(t *testing.T) {
+	var c Collapser
+	msgs := []Message{{
+		Role:   RoleUser,
+		Blocks: []ContentBlock{{Type: "tool_result", Result: "keep me"}},
+	}}
+	c.project(msgs)
+	if msgs[0].Blocks[0].Result != "keep me" {
+		t.Error("uncollapsed block was modified")
+	}
+}
+
+func TestCollapser_ClearRemovesAll(t *testing.T) {
+	var c Collapser
+	c.set(0, 0, "x")
+	c.set(1, 2, "y")
+	c.clear()
+	if c.len() != 0 {
+		t.Errorf("expected 0 after clear, got %d", c.len())
+	}
+}
+
+func TestCollapser_RemoveRemovesMessageEntries(t *testing.T) {
+	var c Collapser
+	c.set(0, 0, "a")
+	c.set(0, 1, "b")
+	c.set(1, 0, "c")
+	c.remove(0)
+	if c.len() != 1 {
+		t.Errorf("expected 1 after remove(0), got %d", c.len())
+	}
+	if _, ok := c.get(1, 0); !ok {
+		t.Error("entry for msg 1 was incorrectly removed")
+	}
+}
+
+func TestReclaim_WritesToCollapser(t *testing.T) {
+	a := New(&summarizeFake{}, "test-model")
+	for i := 0; i < 10; i++ {
+		a.History.Append(Message{Role: RoleUser, Blocks: []ContentBlock{{
+			Type: "tool_result", ToolUseID: "id", Result: strings.Repeat("x", 5000),
+		}}})
+		a.History.Append(NewAssistantMessage("ok"))
+	}
+	reclaimed := a.reclaimStaleToolResults()
+	if reclaimed <= 0 {
+		t.Fatal("expected reclaim to return tokens")
+	}
+	if a.History.collapser.len() == 0 {
+		t.Fatal("collapser should have entries after reclaim")
+	}
+	snap := a.History.Snapshot()
+	for _, m := range snap {
+		for _, b := range m.Blocks {
+			if b.Type == "tool_result" && strings.Contains(b.Result, "bytes elided") {
+				return
+			}
+		}
+	}
+	t.Error("Snapshot did not contain projected placeholders")
+}
+
+func TestReclaim_ReplaceAllClearsCollapser(t *testing.T) {
+	a := New(&summarizeFake{}, "test-model")
+	a.History.collapser.set(0, 0, "placeholder")
+	a.History.ReplaceAll([]Message{NewUserMessage("fresh")})
+	if a.History.collapser.len() != 0 {
+		t.Errorf("ReplaceAll should clear collapser, got %d entries", a.History.collapser.len())
+	}
+}
+
+func TestReclaim_DoesNotMutateLiveHistory(t *testing.T) {
+	a := New(&summarizeFake{}, "test-model")
+	a.History.Append(Message{Role: RoleUser, Blocks: []ContentBlock{{
+		Type: "tool_result", ToolUseID: "id", Result: strings.Repeat("x", 10000),
+	}}})
+	a.History.Append(NewAssistantMessage("ok"))
+	for i := 0; i < 6; i++ {
+		a.History.Append(Message{Role: RoleUser, Blocks: []ContentBlock{{
+			Type: "tool_result", ToolUseID: "id", Result: strings.Repeat("y", 5000),
+		}}})
+		a.History.Append(NewAssistantMessage("ok"))
+	}
+	before := a.History.Snapshot()
+	originalLen := len(before[0].Blocks[0].Result)
+
+	a.reclaimStaleToolResults()
+
+	// Swap out the collapser temporarily so Snapshot returns raw data.
+	saved := a.History.collapser
+	a.History.collapser = Collapser{}
+	raw := a.History.Snapshot()
+	a.History.collapser = saved
+
+	if len(raw[0].Blocks[0].Result) != originalLen {
+		t.Errorf("live history was mutated: expected %d bytes, got %d", originalLen, len(raw[0].Blocks[0].Result))
+	}
+}
+
+func TestCollapser_SnapshotReturnsProjected(t *testing.T) {
+	h := NewHistory()
+	h.collapser.set(0, 0, "[collapsed]")
+	h.Append(Message{Role: RoleUser, Blocks: []ContentBlock{{
+		Type: "tool_result", ToolUseID: "id", Result: strings.Repeat("x", 5000),
+	}}})
+	snap := h.Snapshot()
+	if snap[0].Blocks[0].Result != "[collapsed]" {
+		t.Errorf("Snapshot should project collapsed content, got %q", snap[0].Blocks[0].Result)
+	}
+}

--- a/internal/agent/history.go
+++ b/internal/agent/history.go
@@ -21,6 +21,12 @@ type History struct {
 	// pure length comparison can't detect this: a rewrite can leave history at
 	// or above the persisted length while changing earlier messages.
 	rewritten bool
+
+	// collapser records which tool_result blocks have been collapsed via
+	// reclaimStaleToolResults so Snapshot() can project the placeholder
+	// at read time without mutating the underlying messages array (and thus
+	// without invalidating the provider's prompt cache prefix).
+	collapser Collapser
 }
 
 // NewHistory returns an empty History.
@@ -37,11 +43,16 @@ func (h *History) Append(m Message) {
 
 // Snapshot returns a copy of the message slice safe to iterate without holding
 // the lock. The returned slice's backing array is fresh; callers can mutate it.
+// Tool_result blocks that have been collapsed via reclaim are replaced with
+// their placeholder text before returning, without mutating the stored history.
 func (h *History) Snapshot() []Message {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	out := make([]Message, len(h.messages))
 	copy(out, h.messages)
+	if h.collapser.len() > 0 {
+		h.collapser.project(out)
+	}
 	return out
 }
 
@@ -58,6 +69,7 @@ func (h *History) Reset() {
 	defer h.mu.Unlock()
 	h.messages = nil
 	h.rewritten = true
+	h.collapser.clear()
 }
 
 // TruncateTo keeps only the first n messages.
@@ -68,6 +80,7 @@ func (h *History) TruncateTo(n int) {
 	if n < len(h.messages) {
 		h.messages = h.messages[:n]
 		h.rewritten = true
+		h.collapser.clear()
 	}
 }
 
@@ -79,6 +92,7 @@ func (h *History) ReplaceAll(msgs []Message) {
 	h.messages = make([]Message, len(msgs))
 	copy(h.messages, msgs)
 	h.rewritten = true
+	h.collapser.clear()
 }
 
 // Tail returns the last n messages (or all if fewer).
@@ -107,6 +121,7 @@ func (h *History) replaceLast(m Message) {
 	}
 	h.messages[len(h.messages)-1] = m
 	h.rewritten = true
+	h.collapser.remove(len(h.messages) - 1)
 }
 
 // RewriteDirty reports whether history has been rewritten (any non-append

--- a/internal/agent/reclaim.go
+++ b/internal/agent/reclaim.go
@@ -11,26 +11,26 @@ const hotToolResults = 6
 // alone: small results aren't worth the cache cost of a rewrite.
 const staleToolResultMinBytes = 4_000
 
-// reclaimStaleToolResults rewrites old, large tool_result blocks to a compact
-// placeholder, freeing context without an LLM call. This is the cheap tier that
-// shrinks a single huge agentic turn — the case the summarize path deliberately
-// skips (one user turn holding ~150k of tool output can't be folded on a
-// user-turn boundary, but its stale tool results can be elided in place).
+// reclaimStaleToolResults records collapsed placeholders for old, large tool_result
+// blocks in the History's Collapser, freeing context without an LLM call. This is
+// the cheap tier that shrinks a single huge agentic turn — the case the summarize
+// path deliberately skips (one user turn holding ~150k of tool output can't be
+// folded on a user-turn boundary, but its stale tool results can be elided in
+// place).
 //
-// The most recent hotToolResults tool results are kept inline verbatim; older
-// ones whose Result exceeds staleToolResultMinBytes are elided, preserving the
-// tool_use pairing (ToolUseID/IsError) so the wire structure stays valid. The
-// elided originals are regenerable by re-running the tool — the placeholder
-// says so, mirroring the write-time microCompact backstop.
+// The most recent hotToolResults tool results are kept inline verbatim; older ones
+// whose Result exceeds staleToolResultMinBytes are recorded as collapsed entries
+// in the Collapser, preserving the tool_use pairing (ToolUseID/IsError) so the wire
+// structure stays valid. The elided originals are regenerable by re-running the
+// tool — the placeholder says so, mirroring the write-time microCompact backstop.
 //
-// Returns the estimated tokens reclaimed (0 if nothing changed). It rebuilds
-// history via ReplaceAll, which invalidates the prompt-cache prefix from the
-// first rewrite — still far cheaper than an LLM summarize.
+// Returns the estimated tokens reclaimed (0 if nothing changed). Unlike the old
+// implementation, this no longer calls History.ReplaceAll — collapsed results stay
+// in the live history and are projected at read time by History.Snapshot(), keeping
+// the provider's prompt cache prefix intact.
 func (a *Agent) reclaimStaleToolResults() int {
 	msgs := a.History.Snapshot()
 
-	// Map tool_use ID → tool name (for friendlier placeholders) and locate
-	// every tool_result block in order.
 	names := map[string]string{}
 	type loc struct{ mi, bi int }
 	var locs []loc
@@ -48,35 +48,25 @@ func (a *Agent) reclaimStaleToolResults() int {
 		return 0
 	}
 
-	// Snapshot copies Message structs but their Blocks slices still alias the
-	// live history, so copy-on-write each message we touch before mutating.
-	cloned := map[int]bool{}
 	reclaimed := 0
 	for _, l := range locs[:len(locs)-hotToolResults] {
-		if len(msgs[l.mi].Blocks[l.bi].Result) < staleToolResultMinBytes {
+		b := msgs[l.mi].Blocks[l.bi]
+		if len(b.Result) < staleToolResultMinBytes {
 			continue
 		}
-		if !cloned[l.mi] {
-			cp := make([]ContentBlock, len(msgs[l.mi].Blocks))
-			copy(cp, msgs[l.mi].Blocks)
-			msgs[l.mi].Blocks = cp
-			cloned[l.mi] = true
-		}
-		b := &msgs[l.mi].Blocks[l.bi]
 		name := names[b.ToolUseID]
 		if name == "" {
 			name = "tool"
 		}
 		freed := estimateText(b.Result)
-		b.Result = fmt.Sprintf(
+		placeholder := fmt.Sprintf(
 			"[%d bytes elided by octo to save context — earlier %s result; re-run the tool to view it again]",
 			len(b.Result), name)
-		b.UI = nil // the structured card no longer matches the elided text
-		reclaimed += freed - estimateText(b.Result)
+		a.History.collapser.set(l.mi, l.bi, placeholder)
+		reclaimed += freed - estimateText(placeholder)
 	}
 	if reclaimed <= 0 {
 		return 0
 	}
-	a.History.ReplaceAll(msgs)
 	return reclaimed
 }


### PR DESCRIPTION
## Summary

`reclaimStaleToolResults` currently calls `History.ReplaceAll`, which replaces the entire messages array — invalidating the provider's prompt cache prefix. This PR replaces that with a **Collapser** that records collapsed block positions in a lightweight map, and `Snapshot()` projects them at read time without mutating the history.

## Changes

- `internal/agent/collapser.go`: +79 lines — Collapser struct with set/get/clear/remove/project
- `internal/agent/collapser_test.go`: +133 lines — 8 tests
- `internal/agent/history.go`: +15 lines — Collapser field, Snapshot projection, collapser clear on Reset/TruncateTo/ReplaceAll
- `internal/agent/reclaim.go`: −30/+22 lines — rewrite to write Collapser entries instead of ReplaceAll

## How it works

Before:
```
reclaim → mutate snapshot copy → History.ReplaceAll(modified copy)
          → messages array pointer changes → prompt cache invalidated
```

After:
```
reclaim → History.collapser.set(msgIdx, blockIdx, placeholder)
          → messages array stays unchanged → prompt cache intact

Snapshot():
  copy messages → project via collapser entries → return projected copy
```

## Side effects

- Collapser is cleared on Reset / TruncateTo / ReplaceAll / replaceLast — no stale entries leak.
- Collapser is NOT persisted across session save/load — the cost is one turn of full visibility after restore (reclaim re-populates on next trigger).

Co-authored-by: octo-agent <no-reply@octo-agent.dev><!-- Write this PR description in English. -->

## What

<!-- One or two sentences: what does this PR change? -->

## Why

<!-- The need this addresses, and who benefits. -->

## User-visible impact

<!-- Default behavior changes? New config? Breaking changes? "None" is a valid answer. -->

---

## Self-review

Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### 1. Architecture

- [ ] Smallest possible diff for the need
- [ ] No new configuration knobs (or justified below)
- [ ] No new dependencies (or justified below)
- [ ] Fits the existing design / naming / layering

### 2. Need

- [ ] Common need that benefits most users, **or** scope and side effects are explained below
- [ ] No unintended impact on other users' workflows or defaults

### 3. Code

- [ ] All tests pass
- [ ] Coverage does not drop; new code has new tests
- [ ] Commit messages and this PR are written in English
- [ ] This branch was created from the latest `main` and is currently up to date with it

### Bonus

- [ ] This PR was authored using Octo itself

---

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs you considered, or follow-ups planned. -->
