### PR TITLE
fix(server): materialize defaults in New() before Discover()

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,8 @@ import (
 	"github.com/open-octo/octo-agent/internal/skills"
 	"github.com/open-octo/octo-agent/internal/tasks"
 	"github.com/open-octo/octo-agent/internal/tools"
+	"github.com/open-octo/octo-agent/internal/version"
+	"github.com/open-octo/octo-agent/internal/workflow"
 )
 
 // getDefaultToolsFor bridges to tools.DefaultToolsFor for ws_handlers.go.
@@ -393,6 +395,16 @@ func New(cfg Config) (*Server, error) {
 			}
 		}
 	}
+
+	// Materialize the binary's default skills/workflows to ~/.octo/skills-default
+	// and ~/.octo/workflows-default so Discover() below finds them. The CLI's
+	// run() does the same before runChat/runServe, but server.New() is also
+	// called directly by the desktop app (which never goes through run()) — so
+	// the init has to live here too. A no-op/cheap-pass once current (stamp
+	// file), so calling it from both paths is harmless.
+	_ = skills.MaterializeDefaults(version.Version)
+	_ = tools.MaterializeDefaultWorkflows(version.Version)
+	_ = workflow.PruneJournals()
 
 	cwd, _ := os.Getwd()
 	envCtx := buildEnvContext(cwd)


### PR DESCRIPTION
## Problem

server.New() is called directly by the macOS Wails desktop app, which never goes through run(). So MaterializeDefaults was never called, and Discover() found zero system skills — skill panel shows nothing.

The CLI's run() was fixed in #1448, but the desktop app bypasses run() entirely.

## Fix

Add the materialize block (MaterializeDefaults + MaterializeDefaultWorkflows + PruneJournals) at the top of server.New(), before skills.Discover(). Calling it twice is harmless — the stamp-file gate makes the second call a cheap no-op.

## Verification

- Build passes (no import cycle: workflow and version don't import server)
- Server package tests pass

Co-authored-by: octo-agent <no-reply@octo-agent.dev>