### PR TITLE
feat(desktop): show configured channel count in tray menu

### DIFF
--- a/cmd/octo-desktop/lang.go
+++ b/cmd/octo-desktop/lang.go
@@ -19,6 +19,7 @@ type uiStrings struct {
 	trayStarting       string
 	trayBackendFmt     string // "Backend · %s"
 	trayClientsFmt     string // "Connected clients: %d"
+	trayChannelsFmt    string // "Configured channels: %d"
 
 	takeoverTitle  string
 	takeoverMsgFmt string // "...(pid %d)..."
@@ -51,6 +52,7 @@ var enStrings = uiStrings{
 	trayStarting:     "Starting…",
 	trayBackendFmt:   "Backend · %s",
 	trayClientsFmt:   "Connected clients: %d",
+	trayChannelsFmt:  "Configured channels: %d",
 
 	takeoverTitle:  "Octo",
 	takeoverMsgFmt: "A background Octo backend is already running (pid %d).\n\nStop it and run Octo as the hub for this machine?",
@@ -83,6 +85,7 @@ var zhStrings = uiStrings{
 	trayStarting:     "启动中…",
 	trayBackendFmt:   "后端 · %s",
 	trayClientsFmt:   "已连接客户端：%d",
+	trayChannelsFmt:  "已配置 channel：%d",
 
 	takeoverTitle:  "Octo",
 	takeoverMsgFmt: "已有一个 Octo 后端在后台运行（pid %d）。\n\n停止它，并让 Octo 作为本机的后端中枢？",

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -413,6 +413,10 @@ func trayStatusLines(bridge *nativeBridge) []string {
 	}
 	lines := []string{fmt.Sprintf(L().trayBackendFmt, hubAddr)}
 	lines = append(lines, fmt.Sprintf(L().trayClientsFmt, srv.ConnectedClients()))
+	// Only when > 0 — keeps the menu clean before any channel is configured.
+	if n := srv.ConfiguredChannelCount(); n > 0 {
+		lines = append(lines, fmt.Sprintf(L().trayChannelsFmt, n))
+	}
 	return lines
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2987,3 +2987,14 @@ func (s *Server) ConnectedClients() int {
 	defer s.wsHub.mu.Unlock()
 	return len(s.wsHub.connections)
 }
+
+// ConfiguredChannelCount reports how many IM platforms are configured in
+// channels.yml (enabled or not). Surfaced in the desktop tray so the user
+// can tell "configured" from "connected" at a glance.
+func (s *Server) ConfiguredChannelCount() int {
+	cfg, err := channel.LoadConfig()
+	if err != nil {
+		return 0
+	}
+	return len(cfg.Channels)
+}


### PR DESCRIPTION
## Summary
- Adds a "Configured channels: N" line to the desktop tray menu (only when > 0)
--distinguishes "configured" (platforms in channels.yml) from "connected" (web UI tabs)
- New `Server.ConfiguredChannelCount()` method reads `channels.yml` directly

## Screenshot (text)
```
后端 · http://127.0.0.1:3003
已连接客户端：3
已配置 channel：2    ← new
```

## Test plan
- [ ] Build desktop app, verify tray shows the new line when channels.yml has entries
- [ ] Empty channels.yml → line hidden
- [ ] Language switch EN/ZH updates label correctly

🤖 Generated with [octo-agent](https://github.com/open-octo/octo-agent)