### PR TITLE
a11y(landing): raise Lighthouse accessibility score to 100

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -381,7 +381,7 @@
       transform: translateY(-2px);
       box-shadow: var(--shadow-lg);
     }
-    .iface.soon { opacity: 0.72; }
+    .iface.soon { background: #fafafa; border: 1px dashed var(--border); }
     .soon-badge {
       display: inline-block;
       font-size: 0.68rem;
@@ -612,6 +612,7 @@
     </div>
   </header>
 
+  <main>
   <!-- Features -->
   <section>
     <div class="container">
@@ -867,6 +868,7 @@ echo <span class="arg">"Summarise the last commit"</span> | <span class="cmd">oc
     </div>
   </section>
 
+  </main>
   <footer>
     <div class="footer-links">
       <a href="https://github.com/open-octo/octo-agent">GitHub</a>


### PR DESCRIPTION
## Summary
- Add `<main>` landmark wrapping all content sections — helps screen-reader users jump to main content directly
- Replace `.iface.soon { opacity: 0.72 }` with dashed-border + tinted-bg — fixes WCAG AA contrast failure on the inner `<p>` and `.soon-badge` text

## Verification
Lighthouse (accessibility): **93 → 100**
Other categories unchanged at 100.

One file, three lines.