### PR TITLE
tui: colour bg-task and workflow notices by outcome (red on failure)

### DIFF
--- a/cmd/octo/bgnotify_wiring_test.go
+++ b/cmd/octo/bgnotify_wiring_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
@@ -110,5 +112,35 @@ func TestTUI_SubAgentNoteMsgStopReason(t *testing.T) {
 	}})
 	if cmd == nil {
 		t.Fatal("subAgentNoteMsg should return a non-nil cmd even when stopped")
+	}
+}
+
+// TestTUI_NoticeStylesByOutcome verifies the colour-selection helpers pick the
+// right style per outcome (green for success, red for failure). Forces the
+// lipgloss renderer to ANSI so output is deterministic in a test pipeline.
+func TestTUI_NoticeStylesByOutcome(t *testing.T) {
+	orig := lipgloss.DefaultRenderer().ColorProfile()
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.ANSI)
+	defer lipgloss.DefaultRenderer().SetColorProfile(orig)
+
+	// Background task: clean exit → green, failed/killed → red.
+	green := bgExitNoticeStyle(tools.BgExit{Status: "exited: 0", Killed: false}).Render("x")
+	red := bgExitNoticeStyle(tools.BgExit{Status: "exited: 1", Killed: false}).Render("x")
+	redKilled := bgExitNoticeStyle(tools.BgExit{Status: "exited: 0", Killed: true}).Render("x")
+	if !strings.Contains(green, "\x1b[") {
+		t.Errorf("clean exit expected ANSI colour, got: %q", green)
+	}
+	if red == green {
+		t.Errorf("failed exit expected different (red) colour, got same %q", red)
+	}
+	if redKilled == green {
+		t.Errorf("killed exit expected different (red) colour, got same %q", redKilled)
+	}
+
+	// Workflow: done → green, error → red.
+	wfGreen := workflowNoticeStyle("done").Render("x")
+	wfRed := workflowNoticeStyle("error").Render("x")
+	if wfGreen == wfRed {
+		t.Errorf("workflow done vs error should differ, both: %q", wfGreen)
 	}
 }

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -184,6 +184,25 @@ func subAgentNoteStatus(stopReason string) string {
 	}
 }
 
+// bgExitNoticeStyle picks the scrollback notice colour for a background-task
+// completion: green on clean exit, red on non-zero / killed.
+func bgExitNoticeStyle(e tools.BgExit) lipgloss.Style {
+	if e.ExitedOK() {
+		return bgDoneStyle
+	}
+	return errorStyle
+}
+
+// workflowNoticeStyle picks the scrollback notice colour for a workflow
+// completion: green on "done", red on "error". Anything unexpected falls
+// through to green (matches the existing done-only convention in WorkflowNotification).
+func workflowNoticeStyle(status string) lipgloss.Style {
+	if status == "error" {
+		return errorStyle
+	}
+	return bgDoneStyle
+}
+
 type workflowNoteMsg struct{ ev tools.WorkflowNotification } // a background workflow finished (async)
 type mcpReadyMsg struct{ reg *mcp.Registry }                 // background MCP connect finished (async)
 type subAgentEventMsg struct{ ev tools.SubAgentEvent }       // a sub-agent's runtime activity (async)
@@ -1012,8 +1031,9 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case bgExitMsg:
 		// Print a concise, Claude-Code-style scrollback notice so the user
 		// sees the completion even when the model-facing <system-reminder>
-		// is folded into a later turn.
-		m.printlnBlock(bgDoneStyle.Render(fmt.Sprintf("● Background `%s` %s", msg.e.Command, msg.e.Status)))
+		// is folded into a later turn. Colour by outcome so a non-zero exit
+		// / kill jumps out red against the normal green.
+		m.printlnBlock(bgExitNoticeStyle(msg.e).Render(fmt.Sprintf("● Background `%s` %s", msg.e.Command, msg.e.Status)))
 		// Idle auto-turn: if no turn is running and nothing is queued, drain the
 		// inbox (which holds the full <system-reminder> notice) and start a
 		// turn so the model sees the completion immediately instead of waiting
@@ -1029,12 +1049,13 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case workflowNoteMsg:
 		// Scrollback notice for the user; the full <system-reminder> rode the
 		// inbox for the model. Idle auto-turn mirrors bgExitMsg so the model
-		// reacts to a finished background workflow immediately.
+		// reacts to a finished background workflow immediately. Red on error,
+		// green on success — same visual language as the bg-task notice above.
 		status := msg.ev.Status
 		if status == "" {
 			status = "done"
 		}
-		m.printlnBlock(bgDoneStyle.Render(fmt.Sprintf("● Workflow %s (%s) %s", msg.ev.RunID, msg.ev.Description, status)))
+		m.printlnBlock(workflowNoticeStyle(status).Render(fmt.Sprintf("● Workflow %s (%s) %s", msg.ev.RunID, msg.ev.Description, status)))
 		if !m.turnRunning && len(m.queue) == 0 {
 			if items := m.a.Inbox.Drain(); len(items) > 0 {
 				s := strings.Join(agent.Texts(items), "\n\n")

--- a/internal/tools/background.go
+++ b/internal/tools/background.go
@@ -225,6 +225,12 @@ type BgExit struct {
 	Killed    bool          // the process was deliberately killed, not self-exited
 }
 
+// ExitedOK reports whether the process exited cleanly: exit code 0 and not
+// deliberately killed by a user / session teardown.
+func (e BgExit) ExitedOK() bool {
+	return !e.Killed && e.Status == "exited: 0"
+}
+
 // SyncSession is the promote handle for one in-flight synchronous terminal
 // command. Closing the channel (via Signal) unblocks the polling loop so the
 // process is promoted to a visible background task before the timer fires.

--- a/internal/tools/background_test.go
+++ b/internal/tools/background_test.go
@@ -423,3 +423,24 @@ func TestTerminalTool_InvalidBackgroundMode(t *testing.T) {
 		})
 	}
 }
+
+func TestBgExit_ExitedOK(t *testing.T) {
+	cases := []struct {
+		name   string
+		e      BgExit
+		wantOK bool
+	}{
+		{"clean exit", BgExit{Status: "exited: 0", Killed: false}, true},
+		{"clean exit but killed (race)", BgExit{Status: "exited: 0", Killed: true}, false},
+		{"non-zero exit", BgExit{Status: "exited: exit status 1", Killed: false}, false},
+		{"signal killed", BgExit{Status: "exited: signal: terminated", Killed: true}, false},
+		{"still running (should not happen)", BgExit{Status: "running", Killed: false}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.e.ExitedOK(); got != tc.wantOK {
+				t.Errorf("ExitedOK() = %v, want %v", got, tc.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Background task (`● Background \`cmd\``) scrollback notice: green when exit 0, red on non-zero / killed
- Workflow (`● Workflow …`) scrollback notice: green when `done`, red when `error`
- Add `tools.BgExit.ExitedOK()` helper to centralise the clean-exit test
- Extract `bgExitNoticeStyle` / `workflowNoticeStyle` helpers so colour selection is unit-tested
- `TestBgExit_ExitedOK` covers clean-exit / non-zero / killed / running edge cases
- `TestTUI_NoticeStylesByOutcome` verifies the rendered colour differs per outcome

Previously both task types always printed in bright green — a failed `exit 127` and a successful `exit 0` looked identical. Now mirror the already-merged sub-agent colour convention.

4 files, +80 / -4 lines.
