### PR TITLE
chore(version): bump version to 1.12.11

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.10"
+var Version = "1.12.11"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump `internal/version/version.go` to 1.12.11 ahead of tagging the release.

Ships with:
- #1456 fix(skill): onboard greets and asks in one turn instead of stalling
- #1457 feat(landing): copy button on the CLI install commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)