### PR TITLE
fix(tools): write-guard blocks only newly-introduced secrets

### DIFF
--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -474,16 +474,6 @@ func (EditFileTool) Execute(ctx context.Context, _ string, input map[string]any)
 		newStrClean = stripTrailingWhitespace(newStr)
 	}
 
-	// Refuse to inject a live-credential shape — same guard write_file applies,
-	// so a secret can't slip in through the edit path instead. Only the new text
-	// is scanned (not the whole file): a pre-existing match the model didn't
-	// introduce shouldn't block an unrelated edit elsewhere in the file.
-	if secret := scanForSecrets(newStrClean); secret != "" {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: refusing to write new_string that contains a %s. "+
-			"If this is genuinely intended (e.g. a test fixture), remove the live-credential "+
-			"shape or create the file outside the agent.", secret)
-	}
-
 	// Use findActualString for quote-, indent-, and trailing-whitespace
 	// normalized matching, plus a line-number-prefix-stripped retry.
 	actualOldStr, indentWidth := findActualString(normBody, oldStr)
@@ -559,6 +549,17 @@ func (EditFileTool) Execute(ctx context.Context, _ string, input map[string]any)
 	}
 	out.WriteString(body[prevOrigEnd:])
 	updated := out.String()
+
+	// Refuse to inject a live-credential shape — same guard write_file applies,
+	// so a secret can't slip in through the edit path instead. Comparing the
+	// whole file before and after means only a credential the edit newly
+	// introduces is blocked: a pre-existing match the edit merely preserves
+	// (or leaves untouched elsewhere in the file) does not.
+	if secret := newSecretsIntroduced(body, updated); secret != "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("edit_file: refusing to write new_string that contains a %s. "+
+			"If this is genuinely intended (e.g. a test fixture), remove the live-credential "+
+			"shape or create the file outside the agent.", secret)
+	}
 
 	// Stage the pre-edit version into the trash so an edit that destroys
 	// uncommitted work is recoverable (skipped for git-tracked-clean files).

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -49,14 +49,19 @@ func (WriteFileTool) Execute(ctx context.Context, _ string, input map[string]any
 		// Distinguish "not provided" from "empty string". JSON null → not a string.
 		return agent.ToolResult{Text: ""}, fmt.Errorf("write_file: content is required (string)")
 	}
-	if secret := scanForSecrets(content); secret != "" {
-		return agent.ToolResult{Text: ""}, fmt.Errorf("write_file: refusing to write content that contains a %s. "+
-			"If this is genuinely intended (e.g. a test fixture), remove the live-credential "+
-			"shape or create the file outside the agent.", secret)
-	}
 	abs, err := resolvePathIn(WorkingDir(ctx), path)
 	if err != nil {
 		return agent.ToolResult{Text: ""}, err
+	}
+
+	// Refuse only credentials the write would newly introduce. Overwriting a
+	// file that already holds the same secret (e.g. rewriting config.yml to add
+	// a field while preserving its api_key) carries nothing new and is allowed.
+	prior, _ := os.ReadFile(abs)
+	if secret := newSecretsIntroduced(string(prior), content); secret != "" {
+		return agent.ToolResult{Text: ""}, fmt.Errorf("write_file: refusing to write content that contains a %s. "+
+			"If this is genuinely intended (e.g. a test fixture), remove the live-credential "+
+			"shape or create the file outside the agent.", secret)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {

--- a/internal/tools/write_guard.go
+++ b/internal/tools/write_guard.go
@@ -23,17 +23,37 @@ var secretPatterns = []struct {
 	{"Google API key", regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{30,}\b`)},
 	{"JWT", regexp.MustCompile(`\beyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*\b`)},
 	{"generic API key", regexp.MustCompile(`(?i)\b(?:api[_-]?key|apikey|secret[_-]?key)\s*[=:]\s*['"]?[a-zA-Z0-9_\-]{16,}\b`)},
-	{"JWT", regexp.MustCompile(`\beyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*\b`)},
-	{"generic API key", regexp.MustCompile(`(?i)\b(?:api[_-]?key|apikey|secret[_-]?key)\s*[=:]\s*['"]?[a-zA-Z0-9_\-]{16,}\b`)},
 }
 
 // scanForSecrets returns the name of the first secret shape detected in
-// content, or "" if none match. write_file uses this to refuse writing a
-// file that looks like it embeds live credentials.
+// content, or "" if none match. It is the "written from scratch" case of
+// newSecretsIntroduced — there is no prior content to compare against.
 func scanForSecrets(content string) string {
+	return newSecretsIntroduced("", content)
+}
+
+// newSecretsIntroduced returns the name of the first secret shape that appears
+// in newContent but was not already present in oldContent, or "" if every
+// secret in newContent already existed verbatim in oldContent. The guard's job
+// is to stop the agent from introducing a live credential, not to stop it from
+// preserving one it didn't author: a read-modify-write of a credential-bearing
+// file (e.g. rewriting ~/.octo/config.yml to add a preference while keeping the
+// existing api_key) carries the same secret through both sides and is allowed,
+// while a brand-new or changed credential is still refused.
+func newSecretsIntroduced(oldContent, newContent string) string {
 	for _, p := range secretPatterns {
-		if p.re.MatchString(content) {
-			return p.name
+		newHits := p.re.FindAllString(newContent, -1)
+		if len(newHits) == 0 {
+			continue
+		}
+		oldHits := make(map[string]bool, len(newHits))
+		for _, h := range p.re.FindAllString(oldContent, -1) {
+			oldHits[h] = true
+		}
+		for _, h := range newHits {
+			if !oldHits[h] {
+				return p.name
+			}
 		}
 	}
 	return ""

--- a/internal/tools/write_guard_test.go
+++ b/internal/tools/write_guard_test.go
@@ -80,3 +80,83 @@ func TestWriteFile_AllowsNormalContent(t *testing.T) {
 		t.Errorf("normal write should succeed: %v", err)
 	}
 }
+
+func TestNewSecretsIntroduced(t *testing.T) {
+	const key = "sk-ant-aaaabbbbccccddddeeeeffffgggghhhh"
+	oldCfg := "provider: anthropic\napi_key: " + key + "\n"
+
+	// Preserving an existing key while adding an unrelated field is allowed.
+	if got := newSecretsIntroduced(oldCfg, oldCfg+"permission_mode: auto\n"); got != "" {
+		t.Errorf("preserving an existing key should be allowed, got %q", got)
+	}
+	// A key in a brand-new file (no prior content) is refused.
+	if got := newSecretsIntroduced("", oldCfg); got == "" {
+		t.Errorf("a key in new content with no prior should be refused")
+	}
+	// Changing the key's value counts as introducing a new secret.
+	changed := "provider: anthropic\napi_key: sk-ant-zzzzyyyyxxxxwwwwvvvvuuuuttttssss\n"
+	if got := newSecretsIntroduced(oldCfg, changed); got == "" {
+		t.Errorf("changing the key value should be refused")
+	}
+	// Keeping the existing key A while ALSO adding a second key B (same pattern,
+	// different value) must still refuse — B is newly introduced.
+	addB := oldCfg + "backup_key: sk-ant-zzzzyyyyxxxxwwwwvvvvuuuuttttssss\n"
+	if got := newSecretsIntroduced(oldCfg, addB); got == "" {
+		t.Errorf("adding a second, different key alongside the preserved one should be refused")
+	}
+}
+
+// A config.yml rewrite that keeps the existing api_key must not trip the guard
+// — this is the onboard flow that previously always failed.
+func TestWriteFile_PreservesExistingSecret(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yml")
+	orig := "provider: anthropic\nmodel: claude-sonnet-4-5\napi_key: sk-ant-aaaabbbbccccddddeeeeffffgggghhhh\n"
+	if err := os.WriteFile(p, []byte(orig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := WriteFileTool{}.Execute(context.Background(), "write_file", map[string]any{
+		"path":    p,
+		"content": orig + "permission_mode: auto\nshow_reasoning: true\n",
+	})
+	if err != nil {
+		t.Errorf("rewrite preserving the existing api_key should succeed, got %v", err)
+	}
+}
+
+// The same preservation must hold via edit_file: appending a field next to an
+// untouched api_key line does not introduce a new secret.
+func TestEditFile_PreservesExistingSecret(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yml")
+	orig := "provider: anthropic\nmodel: claude-sonnet-4-5\napi_key: sk-ant-aaaabbbbccccddddeeeeffffgggghhhh\n"
+	if err := os.WriteFile(p, []byte(orig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       p,
+		"old_string": "model: claude-sonnet-4-5",
+		"new_string": "model: claude-sonnet-4-5\npermission_mode: auto",
+	})
+	if err != nil {
+		t.Errorf("edit preserving the existing api_key should succeed, got %v", err)
+	}
+}
+
+// edit_file must still refuse an edit that injects a brand-new credential.
+func TestEditFile_RefusesNewSecret(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yml")
+	orig := "provider: anthropic\nmodel: claude-sonnet-4-5\n"
+	if err := os.WriteFile(p, []byte(orig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := EditFileTool{}.Execute(context.Background(), "edit_file", map[string]any{
+		"path":       p,
+		"old_string": "model: claude-sonnet-4-5",
+		"new_string": "model: claude-sonnet-4-5\napi_key: sk-ant-zzzzyyyyxxxxwwwwvvvvuuuuttttssss",
+	})
+	if err == nil || !strings.Contains(err.Error(), "API key") {
+		t.Errorf("edit injecting a new key should be refused, got %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

The `write_file` / `edit_file` secret guard refused any content matching a live-credential shape (private keys, API keys, tokens, JWTs). The first-run **onboard** flow rewrites `~/.octo/config.yml` — which legitimately holds `api_key: sk-...` — via `write_file` (SKILL.md step A.10), so the guard fired on **every** onboard. The agent silently fell back to `edit_file`, which only worked by accident: `edit_file` scanned just the replacement fragment, and the appended prefs happened not to contain the key.

## Fix

Reframe the guard from *"content contains a secret"* to *"the write introduces a secret not already present in the file being overwritten"*.

- `newSecretsIntroduced(old, new)` compares matches per pattern; a match in `new` that isn't verbatim in `old` is refused. `scanForSecrets` is now its from-scratch case (`old == ""`).
- `write_file` reads the on-disk content first and diffs against it.
- `edit_file` moves its guard to after the splice, comparing the whole file **before vs after** instead of only the replacement fragment.
- Dropped the duplicated JWT / generic-API-key patterns (harmless before, double-scanned now that matching uses `FindAllString`).

A read-modify-write that preserves an existing key (add a field, keep `api_key`) is allowed. A brand-new file, a changed key value, or a **second** key added alongside the preserved one are still refused — so onboard stops failing without weakening the guard against genuinely new leaks. No skill change needed.

## Tests

`internal/tools/write_guard_test.go` adds: unit cases (preserve allowed / new-file refused / changed-value refused / preserved-plus-new-key refused) and integration cases for both `write_file` and `edit_file` preserving an existing key, plus `edit_file` still refusing an injected new key.

`go test -race ./internal/tools/`, `go vet`, `gofmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)