### PR TITLE
feat(desktop): auto update check in tray with persistent download item

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -50,6 +50,18 @@ type nativeBridge struct {
 	// its own.
 	notifySeq atomic.Uint64
 
+	// updateAvailable holds the version string of a newer release once an update
+	// check (manual or the periodic auto-check) finds one, or nil when up to
+	// date. The tray menu reads it to show a persistent, clickable "download"
+	// item instead of relying on the transient system notification, which macOS
+	// suppresses while the app is foreground — exactly when a manual check runs.
+	// Atomic: the auto-check goroutine writes it while the tray loop / UI thread
+	// read it.
+	updateAvailable atomic.Pointer[string]
+	// tray is the system-tray handle, stored so an update check can refresh the
+	// menu immediately rather than waiting for refreshTrayLoop's next tick.
+	tray atomic.Pointer[application.SystemTray]
+
 	settingsMu sync.Mutex
 	settings   desktopSettings
 	// geomTimer debounces persistence of the window geometry to disk: a drag
@@ -271,6 +283,16 @@ func (b *nativeBridge) NotifyUpdateAvailable(title, body string) {
 		Body:       body,
 		CategoryID: updateNotifyCategoryID,
 	})
+}
+
+// refreshTray rebuilds and re-publishes the tray menu right now, so an update
+// check's result shows without waiting for refreshTrayLoop's next tick. No-op
+// until the tray handle has been stored. SetMenu marshals to the UI thread, so
+// it's safe to call from the check goroutine.
+func (b *nativeBridge) refreshTray() {
+	if t := b.tray.Load(); t != nil {
+		t.SetMenu(buildTrayMenu(b.app, b))
+	}
 }
 
 // AutostartEnabled reports whether the app is registered to launch at login.

--- a/cmd/octo-desktop/lang.go
+++ b/cmd/octo-desktop/lang.go
@@ -16,6 +16,7 @@ type uiStrings struct {
 	trayShow, trayQuit string
 	traySettings       string
 	trayCheckUpdates   string
+	trayUpdateAvailFmt string // "↑ Update to v%s"
 	trayStarting       string
 	trayBackendFmt     string // "Backend · %s"
 	trayClientsFmt     string // "Connected clients: %d"
@@ -45,14 +46,15 @@ type uiStrings struct {
 }
 
 var enStrings = uiStrings{
-	trayShow:         "Show Octo",
-	trayQuit:         "Quit Octo",
-	traySettings:     "Settings…",
-	trayCheckUpdates: "Check for Updates…",
-	trayStarting:     "Starting…",
-	trayBackendFmt:   "Backend · %s",
-	trayClientsFmt:   "Connected clients: %d",
-	trayChannelsFmt:  "Configured channels: %d",
+	trayShow:           "Show Octo",
+	trayQuit:           "Quit Octo",
+	traySettings:       "Settings…",
+	trayCheckUpdates:   "Check for Updates…",
+	trayUpdateAvailFmt: "↑ Update to v%s",
+	trayStarting:       "Starting…",
+	trayBackendFmt:     "Backend · %s",
+	trayClientsFmt:     "Connected clients: %d",
+	trayChannelsFmt:    "Configured channels: %d",
 
 	takeoverTitle:  "Octo",
 	takeoverMsgFmt: "A background Octo backend is already running (pid %d).\n\nStop it and run Octo as the hub for this machine?",
@@ -78,14 +80,15 @@ var enStrings = uiStrings{
 }
 
 var zhStrings = uiStrings{
-	trayShow:         "显示 Octo",
-	trayQuit:         "退出 Octo",
-	traySettings:     "设置…",
-	trayCheckUpdates: "检查更新…",
-	trayStarting:     "启动中…",
-	trayBackendFmt:   "后端 · %s",
-	trayClientsFmt:   "已连接客户端：%d",
-	trayChannelsFmt:  "已配置 channel：%d",
+	trayShow:           "显示 Octo",
+	trayQuit:           "退出 Octo",
+	traySettings:       "设置…",
+	trayCheckUpdates:   "检查更新…",
+	trayUpdateAvailFmt: "↑ 更新到 v%s",
+	trayStarting:       "启动中…",
+	trayBackendFmt:     "后端 · %s",
+	trayClientsFmt:     "已连接客户端：%d",
+	trayChannelsFmt:    "已配置 channel：%d",
 
 	takeoverTitle:  "Octo",
 	takeoverMsgFmt: "已有一个 Octo 后端在后台运行（pid %d）。\n\n停止它，并让 Octo 作为本机的后端中枢？",

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -207,6 +207,7 @@ func main() {
 	// would disconnect other clients. An icon is required — a status item with
 	// neither icon nor label doesn't render on macOS.
 	tray := app.SystemTray.New()
+	bridge.tray.Store(tray) // let update checks refresh the menu on their own goroutine
 	if runtime.GOOS == "darwin" {
 		tray.SetTemplateIcon(trayTemplateIcon)
 	} else {
@@ -230,6 +231,10 @@ func main() {
 		// off the UI thread) — without it every toast silently no-ops.
 		go bridge.requestNotificationAuthorization()
 		startHub(app, bridge, settings)
+		// Surface a newer release in the tray without the user asking: a delayed
+		// first check, then daily. Foreground-suppressed toasts don't matter here
+		// — the tray item is the durable signal.
+		go autoUpdateLoop(bridge)
 	})
 
 	// macOS: clicking the dock icon after the window was closed (hidden to the
@@ -361,30 +366,64 @@ func startHub(app *application.App, bridge *nativeBridge, settings desktopSettin
 	bridge.showWindow()
 }
 
-// checkForUpdates is the tray "Check for updates…" action. It runs on a
-// background goroutine (never the UI thread) so the network round-trip can't
-// freeze the menu, then reports via a non-intrusive OS toast rather than a
-// modal dialog: a failed lookup and the already-current case are plain toasts;
-// a newer release raises the actionable "update available" toast whose button
-// (and body tap) opens the download page. Toasts are best-effort — on a
-// platform/build without the notification service (an unbundled macOS binary)
-// they no-op, matching the version badge's own silence there.
-func checkForUpdates(bridge *nativeBridge) {
+// checkForUpdates is the tray "Check for updates…" action — a manual check that
+// always reports its result.
+func checkForUpdates(bridge *nativeBridge) { runUpdateCheck(bridge, true) }
+
+// autoUpdateLoop checks for a newer release on its own, so the tray can show one
+// without the user asking. A delayed first check keeps startup uncontended, then
+// a daily cadence. Auto checks are silent unless they turn up a new version, and
+// even then only when it differs from the one already surfaced — the tray item,
+// not a daily toast, is the standing reminder.
+func autoUpdateLoop(bridge *nativeBridge) {
+	time.Sleep(30 * time.Second)
+	runUpdateCheck(bridge, false)
+	t := time.NewTicker(24 * time.Hour)
+	defer t.Stop()
+	for range t.C {
+		runUpdateCheck(bridge, false)
+	}
+}
+
+// runUpdateCheck performs one update lookup and records the outcome on the
+// bridge so the tray can show a persistent, clickable "download" item — the
+// durable signal, since macOS suppresses the toast while the app is foreground
+// (exactly when a manual check runs). It runs on a background goroutine (never
+// the UI thread) so the network round-trip can't freeze the menu.
+//
+// manual checks always report via an OS toast (failure, already-current, or the
+// actionable "update available" toast whose button and body tap open the
+// download page). auto checks stay silent except when they surface a version
+// not already shown, so the daily cadence doesn't nag. Toasts are best-effort —
+// on a build without the notification service (an unbundled macOS binary) they
+// no-op, matching the version badge's own silence there.
+func runUpdateCheck(bridge *nativeBridge, manual bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	latest, err := upgrade.Check(ctx)
 	if err != nil {
-		bridge.Notify(L().updTitle, L().updFailed)
+		if manual {
+			bridge.Notify(L().updTitle, L().updFailed)
+		}
 		return
 	}
 	current := strings.TrimPrefix(version.Version, "v")
 	// Eligible() != nil means a dev/unbundled build that never claims to be
 	// behind (matching the badge); report status without offering a download.
 	if upgrade.Eligible() != nil || upgrade.CompareVersions(current, latest) >= 0 {
-		bridge.Notify(L().updTitle, fmt.Sprintf(L().updLatestFmt, current))
+		bridge.updateAvailable.Store(nil)
+		bridge.refreshTray()
+		if manual {
+			bridge.Notify(L().updTitle, fmt.Sprintf(L().updLatestFmt, current))
+		}
 		return
 	}
-	bridge.NotifyUpdateAvailable(L().updTitle, fmt.Sprintf(L().updAvailableFmt, latest))
+	prev := bridge.updateAvailable.Load()
+	bridge.updateAvailable.Store(&latest)
+	bridge.refreshTray()
+	if manual || prev == nil || *prev != latest {
+		bridge.NotifyUpdateAvailable(L().updTitle, fmt.Sprintf(L().updAvailableFmt, latest))
+	}
 }
 
 // listenHub binds addr, retrying for up to grace so a just-stopped daemon has
@@ -431,7 +470,15 @@ func buildTrayMenu(app *application.App, bridge *nativeBridge) *application.Menu
 	m.AddSeparator()
 	m.Add(L().trayShow).OnClick(func(*application.Context) { bridge.showWindow() })
 	m.Add(L().traySettings).OnClick(func(*application.Context) { bridge.openSettings() })
-	m.Add(L().trayCheckUpdates).OnClick(func(*application.Context) { go checkForUpdates(bridge) })
+	// A known-newer release replaces the "check" item with a one-click download —
+	// the durable prompt when the toast was suppressed. Otherwise the manual check.
+	if v := bridge.updateAvailable.Load(); v != nil {
+		m.Add(fmt.Sprintf(L().trayUpdateAvailFmt, *v)).OnClick(func(*application.Context) {
+			_ = bridge.OpenExternal(upgrade.DownloadPageURL)
+		})
+	} else {
+		m.Add(L().trayCheckUpdates).OnClick(func(*application.Context) { go checkForUpdates(bridge) })
+	}
 	m.AddSeparator()
 	m.Add(L().trayQuit).OnClick(func(*application.Context) { bridge.requestQuit() })
 	return m
@@ -444,7 +491,13 @@ func refreshTrayLoop(app *application.App, tray *application.SystemTray, bridge 
 		applyLang() // follow a language switch made in onboarding / Settings
 		// The status lines are language-dependent, so a language switch changes
 		// this signature and triggers a rebuild (which re-reads L() for labels).
-		return strings.Join(trayStatusLines(bridge), "|")
+		// The update state is folded in too, so a flip rebuilds even if the
+		// immediate refreshTray call raced with a concurrent rebuild.
+		upd := ""
+		if v := bridge.updateAvailable.Load(); v != nil {
+			upd = *v
+		}
+		return strings.Join(trayStatusLines(bridge), "|") + "\x00" + upd
 	}
 	last := sigOf()
 	t := time.NewTicker(3 * time.Second)


### PR DESCRIPTION
## What

The tray menu automatically surfaces a newer release — no need to remember to click "Check for Updates…".

## Changes

- **** —  stores the latest version;  lets the update goroutine refresh the menu immediately;  method calls  (marshals to UI thread, safe from any goroutine)
- **** —  string for both en/zh
- **** —  is the unified check function;  starts 30s after launch, then every 24h;  shows "↑ Update to v%s" (click → download page) when an update is known, falling back to the regular check item; 's sig includes the version so a concurrent  triggers a rebuild without waiting for the next tick

## Why the tray, not just the toast

macOS suppresses notification banners while the app is foreground — exactly when a manual "Check for Updates…" runs. The tray item acts as the **durable** signal that survives that suppression. The toast still fires too (for the rare case the user is in another app when a daily check finds one).

## Key decisions

| Decision | Choice |
|----------|--------|
| Cadence | 30s delay → 24h ticker (daily is enough for a version check; startup-delay avoids racing the network/NYI toast-permission prompt) |
| Auto vs manual notification |  always toasts; auto only toasts when surfacing a version not already known — no daily nag |
| Double  | Both  and  may race on . Wails internally marshals to the UI thread, so no data race — just a harmless double-build that happens at most once per version