### PR TITLE
chore(version): bump version to 1.12.12

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.11"
+var Version = "1.12.12"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Version bump from 1.12.11 to 1.12.12.\n\nIncludes:\n- mcp: allow absolute-path and non-whitelisted stdio commands via allow_arbitrary_command opt-in\n- web: import dialog UX with inline errors and i18n\n- test: cross-platform path tests\n\nCo-authored-by: octo-agent <no-reply@octo-agent.dev>