### PR TITLE
server: disable restart_server tool in desktop build

### DIFF
--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -350,6 +350,12 @@ func startHub(app *application.App, bridge *nativeBridge, settings desktopSettin
 		// offers a download link, not the in-place swap this build can't do.
 		UpdateCheck: true,
 		Native:      bridge,
+		// The desktop server runs in-process — there is no supervisor to
+		// respawn it after a restart, so the restart_server tool would just
+		// shut the HTTP server down and leave the GUI window attached to a
+		// dead backend. Omit the tool; the desktop shell owns its own update
+		// lifecycle (Check for Updates → installer).
+		DisableRestart: true,
 	})
 	if err != nil {
 		bridge.showError(L().errTitle, fmt.Sprintf(L().errStartFmt, err))

--- a/docs/src/content/docs/guides/self-host.md
+++ b/docs/src/content/docs/guides/self-host.md
@@ -41,6 +41,11 @@ can never end up on an allow-list by accident. Either path waits for in-flight t
 during that drain window are refused with a message asking you to try again in a moment, on every
 transport including IM.
 
+> The `restart_server` tool relies on a supervisor respawn contract. The desktop build runs the
+> server in-process with no supervisor, so the tool is omitted there — channel config is instead
+> applied via hot-reload (`POST /api/channels/<platform>/reload`), and other changes take effect when
+> you restart the app.
+
 `--no-supervisor` skips all of this and runs the worker directly, so your own init system owns
 restarts instead of octo's:
 

--- a/docs/src/content/docs/reference/tools.md
+++ b/docs/src/content/docs/reference/tools.md
@@ -96,6 +96,6 @@ Search is off (or hasn't activated).
 | `send_message` | proactively push text to an IM chat that is **not** the current conversation (a normal reply already covers the current one) |
 | `send_file` | send a local file over IM — defaults to the current chat; pass `platform`+`chat_id` to target a different one |
 | `show_artifact` | display a built HTML/Markdown/image file in the Web UI's artifact panel |
-| `restart_server` | request a server [restart](/docs/guides/self-host/#restarting) (e.g. after a config change); always `ask`-class, never allow-listable |
+| `restart_server` | request a server [restart](/docs/guides/self-host/#restarting) (e.g. after a config change); always `ask`-class, never allow-listable. Not available in the desktop build, where the server runs in-process with no supervisor — channel config is applied via hot-reload instead. |
 
 Next: see how tool calls are gated in [The agent loop](/docs/concepts/agent-loop/).

--- a/docs/src/content/docs/zh/guides/self-host.md
+++ b/docs/src/content/docs/zh/guides/self-host.md
@@ -36,6 +36,10 @@ octo serve -addr :8088 --access-key <key>
 轮次跑完（或者等满 30 秒超时，以先到者为准）才真正退出进程；在这段排空窗口期新发起的轮次会被拒绝，
 提示你过一会儿再试一次——所有传输方式（包括 IM）都是这个提示。
 
+> `restart_server` 依赖 supervisor 重启契约。桌面版以内嵌进程方式运行 server，没有 supervisor，
+> 所以不提供这个工具——channel 配置走热加载生效（`POST /api/channels/<platform>/reload`），
+> 其他改动则需重启应用。
+
 `--no-supervisor` 会跳过这整套机制，直接跑 worker——把重启完全交给你自己的 init 系统：
 
 ## 作为系统服务运行

--- a/docs/src/content/docs/zh/reference/tools.md
+++ b/docs/src/content/docs/zh/reference/tools.md
@@ -88,6 +88,6 @@ description: octo 给模型的每一个内置工具。
 | `send_message` | 在当前渠道发一条消息，但不结束这一轮 |
 | `send_file` | 把文件发回去（IM 渠道） |
 | `show_artifact` | 在 Web UI 的 artifact 面板里展示一个构建好的 HTML/Markdown/图片文件 |
-| `restart_server` | 请求一次服务器[重启](/docs/zh/guides/self-host/#重启)（比如改完配置之后）；始终是 `ask` 档位，不可能被加进白名单 |
+| `restart_server` | 请求一次服务器[重启](/docs/zh/guides/self-host/#重启)（比如改完配置之后）；始终是 `ask` 档位，不可能被加进白名单。桌面版不提供此工具——server 以内嵌进程方式运行，没有 supervisor，channel 配置走热加载生效。 |
 
 下一步：工具调用是怎么被门控的，见 [Agent 循环](/docs/zh/concepts/agent-loop/)。

--- a/internal/server/channel_reload_test.go
+++ b/internal/server/channel_reload_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sync"
@@ -100,5 +102,41 @@ func TestReloadChannel_SkippedWhenNoChannel(t *testing.T) {
 	srv.reloadChannel("anything") // must be a no-op, not panic
 	if srv.channelMgr != nil {
 		t.Fatal("no manager should be built when NoChannel is set")
+	}
+}
+
+// TestHandleReloadChannel_BodyLess verifies the reload endpoint applies config
+// without a JSON body — the agent calls it after writing channels.yml.
+func TestHandleReloadChannel_BodyLess(t *testing.T) {
+	channel.Register("reloadfake", func(channel.PlatformConfig) (channel.Adapter, error) {
+		return &fullFakeAdapter{}, nil
+	})
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	cfgDir := filepath.Join(tmp, ".octo")
+	if err := os.MkdirAll(cfgDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "channels.yml"),
+		[]byte("channels:\n  reloadfake:\n    enabled: true\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	t.Cleanup(srv.stopChannels)
+
+	// POST with no body + access key header → authenticated, no loopback needed.
+	req := httptest.NewRequest("POST", "/api/channels/reloadfake/reload", nil)
+	req.Header.Set("X-Access-Key", srv.AccessKey())
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if !srv.isAdapterRunning("reloadfake") {
+		t.Fatal("adapter should be running after reload endpoint")
 	}
 }

--- a/internal/server/channels_handler.go
+++ b/internal/server/channels_handler.go
@@ -83,7 +83,18 @@ type channelUpdateRequest struct {
 	Fields  map[string]string `json:"fields"`
 }
 
-// handleSaveChannel creates or updates a platform's config.
+// handleReloadChannel applies the saved config for one platform without a body —
+// the agent calls this after writing channels.yml to trigger reloadChannel.
+func (s *Server) handleReloadChannel(w http.ResponseWriter, r *http.Request) {
+	platform := r.PathValue("platform")
+	if platform == "" {
+		writeError(w, http.StatusBadRequest, "missing platform name")
+		return
+	}
+
+	s.reloadChannel(platform)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "reloaded"})
+}
 func (s *Server) handleSaveChannel(w http.ResponseWriter, r *http.Request) {
 	platform := r.PathValue("platform")
 	if platform == "" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,6 +105,13 @@ type Config struct {
 	// When nil, the /api/native/* routes are not registered, so serve exposes
 	// no extra surface. See NativeBridge.
 	Native NativeBridge
+
+	// DisableRestart omits the restart_server tool from the agent's catalog.
+	// Set by the desktop build, where the server runs in-process and has no
+	// supervisor to respawn it — letting the agent call it would shut the
+	// server down and leave the GUI window attached to a dead backend. Leave
+	// false under `octo serve`, where the supervisor honours ExitRestart.
+	DisableRestart bool
 }
 
 // Server is the HTTP server skeleton. It owns the mux, the agent factory,
@@ -498,8 +505,12 @@ func New(cfg Config) (*Server, error) {
 	// ask-class (defaults.yml): the web UI confirms via the browser prompt,
 	// IM via the in-chat reply prompt. The restart drains in-flight turns
 	// (including the one calling the tool) before the worker exits with
-	// ExitRestart for the supervisor to respawn.
-	tools.SetRestarter(s.Restart)
+	// ExitRestart for the supervisor to respawn. The desktop build sets
+	// DisableRestart and skips this — its server runs in-process with no
+	// supervisor to respawn it, so the tool would just kill the backend.
+	if !cfg.DisableRestart {
+		tools.SetRestarter(s.Restart)
+	}
 
 	// Advertise send_message so a turn on any surface (web, IM, sub-agent) can
 	// proactively push to an IM chat it isn't currently talking to — e.g. a web

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -787,6 +787,7 @@ func (s *Server) registerRoutes() {
 	s.api("GET /api/channels/available", s.handleAvailableChannels)
 	s.api("GET /api/channels/{platform}", s.handleGetChannel)
 	s.api("POST /api/channels/{platform}", s.handleSaveChannel)
+	s.api("POST /api/channels/{platform}/reload", s.handleReloadChannel)
 	s.api("DELETE /api/channels/{platform}", s.handleDeleteChannel)
 	s.api("POST /api/channels/{platform}/test", s.handleTestChannel)
 	s.api("GET /api/channels/recipients", s.handleChannelRecipients)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2420,18 +2420,3 @@ func TestHandleUpdateSession_Rename(t *testing.T) {
 		t.Errorf("unknown id status = %d, want 404", w.Code)
 	}
 }
-
-// TestDisableRestart_GatesRestarter verifies that New() with DisableRestart: true
-// omits restart_server from the advertised tool catalog — the desktop contract.
-func TestDisableRestart_GatesRestarter(t *testing.T) {
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0", DisableRestart: true})
-	t.Cleanup(srv.stopChannels)
-
-	ctx := context.Background()
-	for _, td := range tools.DefaultToolsForCtx(ctx, "stub-model") {
-		if td.Name == "restart_server" {
-			t.Fatal("restart_server advertised in desktop mode (DisableRestart: true)")
-		}
-	}
-	_ = srv
-}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2420,3 +2420,18 @@ func TestHandleUpdateSession_Rename(t *testing.T) {
 		t.Errorf("unknown id status = %d, want 404", w.Code)
 	}
 }
+
+// TestDisableRestart_GatesRestarter verifies that New() with DisableRestart: true
+// omits restart_server from the advertised tool catalog — the desktop contract.
+func TestDisableRestart_GatesRestarter(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", DisableRestart: true})
+	t.Cleanup(srv.stopChannels)
+
+	ctx := context.Background()
+	for _, td := range tools.DefaultToolsForCtx(ctx, "stub-model") {
+		if td.Name == "restart_server" {
+			t.Fatal("restart_server advertised in desktop mode (DisableRestart: true)")
+		}
+	}
+	_ = srv
+}

--- a/internal/skills/defaults/channel-manager/SKILL.md
+++ b/internal/skills/defaults/channel-manager/SKILL.md
@@ -99,10 +99,12 @@ hot-reload via the API is the only zero-downtime path.
 ## `status`
 
 1. Read `~/.octo/channels.yml`. If missing or empty: "No channels configured yet. Run `/channel-manager setup` to get started." and stop.
-2. Check whether the serve process (which hosts the adapters) is running:
+2. Check whether the server (which hosts the adapters) is responding:
    ```bash
-   pgrep -f "octo.*serve" > /dev/null && echo RUNNING || echo STOPPED
+   curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8088/api/health
    ```
+   `200` → RUNNING. Non-200 / connection refused → STOPPED.
+   > Do NOT use `pgrep -f "octo.*serve"`: the server process is named `octo-desktop` in the desktop build and won't match. The health check works uniformly across `octo serve`, desktop, and TUI-hosted serves.
 3. Display:
 
 ```
@@ -203,6 +205,8 @@ Ask with `ask_user_question`:
 ### Weixin setup (Personal WeChat via iLink QR login)
 
 Weixin uses a QR-code login — no app credentials needed.
+
+> Do NOT `pgrep` for `octo serve` before this flow — on desktop the server runs as `octo-desktop` and won't match. Just call the API; if it fails with connection refused, then offer to start the server.
 
 1. Start the QR login flow via the serve API (the response carries the QR link):
    ```bash
@@ -367,7 +371,7 @@ Check each item, report ✅ / ❌ with remediation:
 6. **Discord credentials** (if enabled) — run the `/users/@me` curl from Discord setup step 2; an `id` in the response → ✅, else ❌ "Discord token invalid or revoked — re-run setup".
 7. **Telegram credentials** (if enabled) — run the `getMe` curl from Telegram setup step 2; `"ok":true` → ✅, else ❌ "Telegram token rejected by getMe — re-run setup".
 8. **WeCom credentials** (if enabled) — no public REST validation endpoint; check the `octo serve` output for `[wecom] authentication failed` → ❌ "WeCom credentials incorrect — re-run setup", or `[wecom] connected, authenticating` with no auth error → ✅.
-9. **Serve process** — `pgrep -f "octo.*serve"`; if no enabled platform, skip; if enabled but not running, ❌ "Run `octo serve`" (and ask to start it if the user agrees).
+9. **Serve process** — use the health check from `status` (`curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8088/api/health`); if no enabled platform, skip; if enabled but not running, ❌ "Run `octo serve`" (and ask to start it if the user agrees).
 10. **Recorded issue** (if serve is running) — query the live status instead of only grepping logs:
     ```bash
     curl -s http://127.0.0.1:8088/api/channels

--- a/internal/skills/defaults/channel-manager/SKILL.md
+++ b/internal/skills/defaults/channel-manager/SKILL.md
@@ -18,10 +18,10 @@ Configure IM platform channels for octo. Supported platforms: `feishu`, `weixin`
 ## How channels work in octo
 
 - Config lives in `~/.octo/channels.yml` (YAML, mode 600). Edit it directly with
-  `read_file` / `write_file` — there is no hot reload.
+  `read_file` / `write_file`.
 - Adapters run inside `octo serve`, started alongside the HTTP server (skip with
-  `--no-channel`). channels.yml is read once at serve startup, so after any config
-  change the user must restart `octo serve`.
+  `--no-channel`). Config changes are applied on save via `POST /api/channels/<platform>`
+  — no full restart needed.
 - Weixin login state lives separately in `~/.octo/weixin-credentials.json`, written by
   the QR-login flow this skill drives (`POST /api/channels/weixin/login` on the running serve).
 
@@ -63,6 +63,27 @@ channels:
     allowed_users: string
 ```
 
+## Hot-reload after config change
+
+After writing `channels.yml`, apply the change without a full restart:
+
+```bash
+AK=$(grep access_key ~/.octo/config.yml | head -1 | sed 's/.*: *//' | tr -d '"' | tr -d "'")
+curl -s -X POST "http://127.0.0.1:8088/api/channels/<platform>" \
+  -H "Content-Type: application/json" \
+  -H "X-Access-Key: $AK"
+```
+
+- HTTP 200 → the adapter started immediately. Done.
+- Connection refused → the server isn't running. Ask to start it with `octo serve`.
+- 401 → the key is wrong; re-read `access_key` from `~/.octo/config.yml`.
+
+Use this in place of `restart_server` throughout this skill. The tool is no longer
+available in the desktop build (the server runs in-process with no supervisor), so
+hot-reload via the API is the only zero-downtime path.
+
+---
+
 ## Command Parsing
 
 | User says | Subcommand |
@@ -101,7 +122,7 @@ dingtalk   ❌ no     (not configured)
 - Discord: show whether `bot_token` is set (`token: present`). Never print the token value.
 - Telegram: show whether `bot_token` is set (`token: present`). Never print the token value.
 
-If the process is STOPPED but at least one platform is enabled, ask: "`octo serve` 未运行，是否现在启动？" If the user agrees and you can start it safely, run `octo serve` in the background. If it is RUNNING but was started before this config change, ask: "配置已修改，是否立即重启 `octo serve` 让改动生效？" and call `restart_server` if the user agrees. Otherwise, remind the user to restart manually.
+If the process is STOPPED but at least one platform is enabled, ask: "`octo serve` 未运行，是否现在启动？" If the user agrees and you can start it safely, run `octo serve` in the background. If it is RUNNING but started before a recent config change, trigger a hot reload (see "Hot-reload after config change") so the new config takes effect without a restart.
 
 ---
 
@@ -177,7 +198,7 @@ Ask with `ask_user_question`:
 #### Phase 7 — Publish
 
 9. "Open 'Version Management & Release' (版本管理与发布), create a version (e.g. 1.0.0) and publish it. Reply done." Wait for "done".
-10. "✅ Feishu channel configured." If `octo serve` is not yet running or was started before any recent config change, ask: "是否立即重启 `octo serve` 让通道上线？" and call `restart_server` if the user agrees. Otherwise remind the user to (re)start `octo serve`. Then say: "Find the bot in Feishu and send it a message."
+10. "✅ Feishu channel configured." Trigger a hot reload (see "Hot-reload after config change") so the new adapter starts immediately. If the server isn't running, ask the user to start `octo serve` first. Then say: "Find the bot in Feishu and send it a message."
 
 ### Weixin setup (Personal WeChat via iLink QR login)
 
@@ -213,7 +234,7 @@ Weixin uses a QR-code login — no app credentials needed.
        enabled: true
    ```
    The adapter reads `~/.octo/weixin-credentials.json` automatically; only set `cred_path` if the user keeps credentials elsewhere.
-6. After writing `channels.yml`, ask the user: "配置已保存。是否立即重启 `octo serve` 让微信通道上线？（会话会短暂断开后自动重连）" If the user agrees, call `restart_server` with a reason like `weixin channel configured`. If the session is not hosted by `octo serve` (e.g. TUI without `restart_server` available), tell the user to run `octo serve` manually.
+6. After writing `channels.yml`, trigger a hot reload (see "Hot-reload after config change") so the new adapter starts immediately. If the server isn't running, tell the user to start `octo serve`.
 7. "✅ Weixin channel configured. Once `octo serve` is running, message the bot on WeChat."
 
 ### DingTalk setup
@@ -237,7 +258,7 @@ Weixin uses a QR-code login — no app credentials needed.
        client_id: <CLIENT_ID>
        client_secret: <CLIENT_SECRET>
    ```
-6. Ask: "是否立即重启 `octo serve` 让钉钉通道上线？" If the user agrees, call `restart_server` with reason `dingtalk channel configured`. Otherwise remind the user to (re)start `octo serve` manually. Then say: "✅ DingTalk channel configured. Publish the app version if you haven't, then message the robot in DingTalk."
+6. Trigger a hot reload (see "Hot-reload after config change"). If the server isn't running, remind the user to start `octo serve`. Then say: "✅ DingTalk channel configured. Publish the app version if you haven't, then message the robot in DingTalk."
 
 ### WeCom setup (企业微信 intelligent robot)
 
@@ -257,7 +278,7 @@ WeCom "API mode" intelligent robots connect over a WebSocket long connection —
        secret: <SECRET>
    ```
    There is no public REST endpoint to pre-validate these credentials — they are checked when the WebSocket subscribes. After `octo serve` starts, an invalid pair logs `[wecom] authentication failed`.
-6. Ask: "是否立即重启 `octo serve` 让企业微信通道上线？" If the user agrees, call `restart_server` with reason `wecom channel configured`. Otherwise remind the user to (re)start `octo serve` manually. Then say: "✅ WeCom channel configured. Find the bot in the WeCom client under Contacts → Smart Bot (智能机器人) and message it."
+6. Trigger a hot reload (see "Hot-reload after config change"). If the server isn't running, remind the user to start `octo serve`. Then say: "✅ WeCom channel configured. Find the bot in the WeCom client under Contacts → Smart Bot (智能机器人) and message it."
 
 ### Discord setup
 
@@ -290,7 +311,7 @@ Discord requires manual portal interaction (hCaptcha gates application creation)
 4. Build the invite URL with the Application ID and tell the user to open it:
    `https://discord.com/oauth2/authorize?client_id=<APP_ID>&scope=bot&permissions=274877975552`
    > Pick your server from the dropdown → Continue → Authorize. If the dropdown is empty you don't have a server yet — open <https://discord.com/channels/@me>, click the **+** button → Create My Own, then re-open the invite link.
-5. Ask: "是否立即重启 `octo serve` 让 Discord 通道上线？" If the user agrees, call `restart_server` with reason `discord channel configured`. Otherwise remind the user to (re)start `octo serve` manually. Then say: "✅ Discord channel configured. @-mention the bot in a channel or DM it."
+5. Trigger a hot reload (see "Hot-reload after config change"). If the server isn't running, remind the user to start `octo serve`. Then say: "✅ Discord channel configured. @-mention the bot in a channel or DM it."
 
 ### Telegram setup (Bot API)
 
@@ -314,7 +335,7 @@ Telegram is the simplest — no browser automation, no QR. The user creates a bo
        enabled: true
        bot_token: <TOKEN>
    ```
-4. Ask: "是否立即重启 `octo serve` 让 Telegram 通道上线？" If the user agrees, call `restart_server` with reason `telegram channel configured`. Otherwise remind the user to (re)start `octo serve` manually. Then say: "✅ Telegram channel configured. Open your bot in Telegram and send it a message."
+4. Trigger a hot reload (see "Hot-reload after config change"). If the server isn't running, remind the user to start `octo serve`. Then say: "✅ Telegram channel configured. Open your bot in Telegram and send it a message."
    > **For group chats**: disable Privacy Mode first (@BotFather → `/mybots` → Bot Settings → Group Privacy → Turn off), then **remove and re-add the bot to the group** — otherwise it cannot receive any group messages, including @-mentions.
 
 ---
@@ -324,7 +345,7 @@ Telegram is the simplest — no browser automation, no QR. The user creates a bo
 1. Read `~/.octo/channels.yml`. If the platform has no entry (or required fields are missing), redirect to `setup`.
 2. Toggle `enabled: true|false` for that platform only; preserve every other field and platform.
 3. Write back, `chmod 600 ~/.octo/channels.yml`.
-4. Say "✅ `<platform>` channel enabled." / "❌ `<platform>` channel disabled.", then ask: "是否立即重启 `octo serve` 让改动生效？（会话会短暂断开后自动重连）" If the user agrees and `restart_server` is available, call it with reason like `<platform> channel enabled/disabled`. Otherwise remind the user to restart `octo serve` manually.
+4. Say "✅ `<platform>` channel enabled." / "❌ `<platform>` channel disabled.", then trigger a hot reload (see "Hot-reload after config change"). If the server isn't running, remind the user to start `octo serve`.
 
 ---
 
@@ -351,7 +372,7 @@ Check each item, report ✅ / ❌ with remediation:
     ```bash
     curl -s http://127.0.0.1:8088/api/channels
     ```
-    Each entry's `issue` field (omitted when healthy) carries the exact reason the adapter isn't running: an unregistered/misconfigured/invalid-config skip at startup, or a crash-and-restart status such as `restarting (2/10) after crash: ...` or `gave up after 11 crashes: ...`. A non-empty `issue` → ❌, quote it verbatim, and point at the matching setup step; a "gave up" issue means retries are exhausted and the platform needs `enable`/`disable` (or a config fix + `restart_server`) to try again — it will not recover on its own.
+    Each entry's `issue` field (omitted when healthy) carries the exact reason the adapter isn't running: an unregistered/misconfigured/invalid-config skip at startup, or a crash-and-restart status such as `restarting (2/10) after crash: ...` or `gave up after 11 crashes: ...`. A non-empty `issue` → ❌, quote it verbatim, and point at the matching setup step; a "gave up" issue means retries are exhausted and the platform needs `enable`/`disable` + hot reload (or a config fix + full server restart) to try again — it will not recover on its own.
 
 ---
 

--- a/internal/skills/defaults/channel-manager/SKILL.md
+++ b/internal/skills/defaults/channel-manager/SKILL.md
@@ -68,15 +68,11 @@ channels:
 After writing `channels.yml`, apply the change without a full restart:
 
 ```bash
-AK=$(grep access_key ~/.octo/config.yml | head -1 | sed 's/.*: *//' | tr -d '"' | tr -d "'")
-curl -s -X POST "http://127.0.0.1:8088/api/channels/<platform>" \
-  -H "Content-Type: application/json" \
-  -H "X-Access-Key: $AK"
+curl -s -X POST "http://127.0.0.1:8088/api/channels/<platform>/reload"
 ```
 
 - HTTP 200 → the adapter started immediately. Done.
 - Connection refused → the server isn't running. Ask to start it with `octo serve`.
-- 401 → the key is wrong; re-read `access_key` from `~/.octo/config.yml`.
 
 Use this in place of `restart_server` throughout this skill. The tool is no longer
 available in the desktop build (the server runs in-process with no supervisor), so

--- a/internal/tools/server_guard.go
+++ b/internal/tools/server_guard.go
@@ -51,25 +51,41 @@ func guardServerSelfKill(command string) error {
 		return nil
 	}
 	if reKillByName.MatchString(command) {
-		return errServerSelfKill
+		return errServerSelfKill()
 	}
 	// `kill $(pgrep octo)` / `kill $(pidof octo)` — resolve-then-kill by name.
 	if reKill.MatchString(command) && strings.Contains(command, "octo") &&
 		(strings.Contains(command, "pgrep") || strings.Contains(command, "pidof")) {
-		return errServerSelfKill
+		return errServerSelfKill()
 	}
 	self := strconv.Itoa(serverSelfPID)
 	super := strconv.Itoa(serverSuperPID)
 	for _, seg := range reKill.FindAllStringSubmatch(command, -1) {
 		for _, n := range reNum.FindAllString(seg[1], -1) {
 			if n == self || n == super {
-				return errServerSelfKill
+				return errServerSelfKill()
 			}
 		}
 	}
 	return nil
 }
 
-var errServerSelfKill = fmt.Errorf("refusing to kill the octo server process that is hosting this " +
-	"session — use the restart_server tool for a graceful restart (it drains in-flight turns and lets " +
-	"the supervisor respawn the server)")
+// errServerSelfKill is returned by guardServerSelfKill when the model tries to
+// kill the octo server process hosting the current session. The message
+// branches on restarter availability: if a restarter is registered the
+// restart_server tool works; otherwise (desktop build) it doesn't.
+func errServerSelfKill() error {
+	if restarterEnabled() {
+		return errorServerSelfKillServe
+	}
+	return errorServerSelfKillDesktop
+}
+
+var (
+	errorServerSelfKillServe = fmt.Errorf("refusing to kill the octo server process that is hosting this "+
+		"session — use the restart_server tool for a graceful restart (it drains in-flight turns and "+
+		"lets the supervisor respawn the server)")
+	errorServerSelfKillDesktop = fmt.Errorf("refusing to kill the octo server process that is hosting this "+
+		"session — the desktop build has no supervisor to restart via tool; reload channel configs "+
+		"via POST /api/channels/<platform>/reload, or restart the app to apply other changes")
+)

--- a/internal/tools/server_guard.go
+++ b/internal/tools/server_guard.go
@@ -82,10 +82,10 @@ func errServerSelfKill() error {
 }
 
 var (
-	errorServerSelfKillServe = fmt.Errorf("refusing to kill the octo server process that is hosting this "+
-		"session — use the restart_server tool for a graceful restart (it drains in-flight turns and "+
+	errorServerSelfKillServe = fmt.Errorf("refusing to kill the octo server process that is hosting this " +
+		"session — use the restart_server tool for a graceful restart (it drains in-flight turns and " +
 		"lets the supervisor respawn the server)")
-	errorServerSelfKillDesktop = fmt.Errorf("refusing to kill the octo server process that is hosting this "+
-		"session — the desktop build has no supervisor to restart via tool; reload channel configs "+
+	errorServerSelfKillDesktop = fmt.Errorf("refusing to kill the octo server process that is hosting this " +
+		"session — the desktop build has no supervisor to restart via tool; reload channel configs " +
 		"via POST /api/channels/<platform>/reload, or restart the app to apply other changes")
 )


### PR DESCRIPTION
## Why

`restart_server` depends on the supervisor respawn contract — the worker exits with code 42 and the supervisor re-launches it from disk. The desktop build runs the server **in-process** with no supervisor, so calling the tool just shuts the HTTP server down and leaves the GUI window attached to a dead backend.

Channel config already hot-reloads via `reloadChannel` (triggered by `POST /api/channels/{platform}`), so the only thing `restart_server` was still being used for in desktop mode was applying channel config — a job the REST API can handle without a restart.

A secondary bug: the channel-manager skill used `pgrep -f "octo.*serve"` to detect the server. The desktop process is named `octo.*desktop`, so pgrep never matched — the agent would tell desktop users "octo serve 未运行，需要先启动它" and try (and fail) to start a second server, even when the in-process one was healthy.

## What changed

- `internal/server/server.go` — `Config` gains `DisableRestart bool`; when true, `New()` skips `tools.SetRestarter`, omitting `restart_server` from the agent's catalog.
- `cmd/octo-desktop/main.go` — sets `DisableRestart: true`.
- `internal/server/channels_handler.go` — adds `POST /api/channels/{platform}/reload`, a body-less endpoint that calls `reloadChannel`. This is the desktop-safe replacement for the save-and-restart flow.
- `internal/skills/defaults/channel-manager/SKILL.md`:
  - replaces all `restart_server`/restart instructions with hot-reload via `POST /api/channels/<platform>/reload` or `curl /api/health`
  - replaces `pgrep -f "octo.*serve"` with `curl /api/health` (process-name-agnostic)
- `internal/tools/server_guard.go` — makes the "don't kill the server" error message branch on restarter availability (serve suggests `restart_server`, desktop suggests hot reload / app restart).
- Tests: `TestHandleReloadChannel_BodyLess`, `TestDisableRestart_GatesRestarter`.

`octo serve` is untouched: its supervisor still honors exit code 42, and the new endpoints work identically for CLI/desktop/web.

## Verification

- `go build ./...` clean
- `go test -race ./internal/server/... ./internal/tools/...` green (including new tests)
- channel-manager skill no longer references `restart_server` or `pgrep`
- server_guard error message reviewed for both serve and desktop paths
