### PR TITLE
fix(server): gate image attachments on model vision capability

### DIFF
--- a/internal/server/attachments.go
+++ b/internal/server/attachments.go
@@ -62,8 +62,10 @@ func ensureUploadsDir() (string, error) {
 
 // parseUserFiles converts a WS files payload into model blocks, display refs,
 // and document path notes. Per-file failures are logged and skipped so one bad
-// attachment doesn't drop the rest of the message.
-func parseUserFiles(files []wsUserFile, allowLocalPath bool) userAttachments {
+// attachment doesn't drop the rest of the message. When vision is false, image
+// data URLs are persisted to disk and referenced by path (so the model can read
+// them with read_file) instead of being sent as image blocks.
+func parseUserFiles(files []wsUserFile, allowLocalPath, vision bool) userAttachments {
 	var att userAttachments
 	for _, f := range files {
 		switch {
@@ -87,8 +89,14 @@ func parseUserFiles(files []wsUserFile, allowLocalPath bool) userAttachments {
 				log.Printf("[ws] image attachment %q: %v", f.Name, err)
 				continue
 			}
-			att.blocks = append(att.blocks, block)
 			att.images = append(att.images, url)
+			if vision {
+				att.blocks = append(att.blocks, block)
+			} else {
+				// Text-only model: hand the model a path note instead of an image
+				// block so it can read_file the image and keep working.
+				att.notes = append(att.notes, agent.AttachmentNote(block.ImagePath))
+			}
 		case f.Path != "":
 			dir, err := ensureUploadsDir()
 			if err != nil {

--- a/internal/server/attachments_test.go
+++ b/internal/server/attachments_test.go
@@ -26,7 +26,7 @@ func TestParseUserFiles_ImageDataURL(t *testing.T) {
 	payload := []byte{0xFF, 0xD8, 0xFF, 1, 2, 3}
 	att := parseUserFiles([]wsUserFile{
 		{Name: "shot.png", MimeType: "image/jpeg", DataURL: jpegDataURL(payload)},
-	}, false)
+	}, false, true)
 
 	if len(att.blocks) != 1 || len(att.images) != 1 || len(att.notes) != 0 {
 		t.Fatalf("blocks/images/notes = %d/%d/%d, want 1/1/0",
@@ -60,6 +60,38 @@ func TestParseUserFiles_ImageDataURL(t *testing.T) {
 	}
 }
 
+// TestParseUserFiles_ImageDataURL_NonVision verifies that when the active model
+// does not accept images, an image data URL is persisted to disk and surfaced
+// to the model as a path note (so it can read_file the image) rather than an
+// image block that would be rejected by the provider.
+func TestParseUserFiles_ImageDataURL_NonVision(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	payload := []byte{0xFF, 0xD8, 0xFF, 1, 2, 3}
+	att := parseUserFiles([]wsUserFile{
+		{Name: "shot.png", MimeType: "image/jpeg", DataURL: jpegDataURL(payload)},
+	}, false, false)
+
+	if len(att.blocks) != 0 || len(att.images) != 1 || len(att.notes) != 1 {
+		t.Fatalf("blocks/images/notes = %d/%d/%d, want 0/1/1",
+			len(att.blocks), len(att.images), len(att.notes))
+	}
+	path := strings.TrimPrefix(strings.TrimSuffix(att.notes[0], "]"), "[Attached file: ")
+	wantURL := "/api/uploads/" + filepath.Base(path)
+	if att.images[0] != wantURL {
+		t.Errorf("display URL = %q, want %q", att.images[0], wantURL)
+	}
+	if !strings.Contains(path, ".octo") || !strings.Contains(path, "uploads") {
+		t.Errorf("note should reference the persisted upload path, got %q", att.notes[0])
+	}
+	onDisk, err := os.ReadFile(path)
+	if err != nil || string(onDisk) != string(payload) {
+		t.Errorf("persisted copy mismatch: err=%v, match=%v", err, string(onDisk) == string(payload))
+	}
+}
+
 func TestParseUserFiles_DocPath(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -75,7 +107,7 @@ func TestParseUserFiles_DocPath(t *testing.T) {
 
 	att := parseUserFiles([]wsUserFile{
 		{Name: "report.pdf", MimeType: "application/pdf", Path: "/api/uploads/123_report.pdf"},
-	}, false)
+	}, false, true)
 
 	// A document produces no block and no image ref — only a note. Its display
 	// chip is derived from that note (see docChipRefs / the replay test).
@@ -111,7 +143,7 @@ func TestParseUserFiles_SkipsBadEntries(t *testing.T) {
 		{Name: "bad.jpg", DataURL: "not-a-data-url"},
 		{Name: "evil.pdf", Path: "/api/uploads/does-not-exist.pdf"},
 		{Name: "text.txt", DataURL: "data:text/plain;base64,aGk="}, // non-image data URL
-	}, false)
+	}, false, true)
 	if len(att.blocks) != 0 || len(att.images) != 0 || len(att.notes) != 0 {
 		t.Errorf("bad entries not skipped: %+v", att)
 	}
@@ -369,6 +401,113 @@ drain:
 	}
 }
 
+// TestHandleWSUserMessage_ImageOnly_NonVision verifies that when the active
+// model is text-only, an image-only WS message is not dropped and is surfaced
+// to the model as a path note rather than an image block that the provider
+// would reject.
+func TestHandleWSUserMessage_ImageOnly_NonVision(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]agent.InboxItem)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("deepseek-v4-pro", "")
+	sess.Title = "fixed title"
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+	srv.wsHub.subscribe(conn, sess.ID)
+
+	payload := []byte{0xFF, 0xD8, 0xFF, 9, 9}
+	srv.handleWSUserMessage(conn, &wsMsgUserMessage{
+		SessionID: sess.ID,
+		Content:   json.RawMessage(`""`),
+		Files: []wsUserFile{
+			{Name: "shot.jpg", MimeType: "image/jpeg", DataURL: jpegDataURL(payload)},
+		},
+	})
+
+	var gotDocChip bool
+	deadline := time.After(5 * time.Second)
+drain:
+	for {
+		select {
+		case b := <-conn.send:
+			var ev map[string]any
+			if err := json.Unmarshal(b, &ev); err != nil {
+				continue
+			}
+			switch ev["type"] {
+			case "history_user_message":
+				if imgs, ok := ev["images"].([]any); ok {
+					for _, img := range imgs {
+						ref, _ := img.(string)
+						if strings.HasPrefix(ref, "pdf:shot") {
+							gotDocChip = true
+						}
+					}
+				}
+			case "complete":
+				break drain
+			}
+		case <-deadline:
+			t.Fatal("turn did not complete — non-vision image-only message still dropped?")
+		}
+	}
+	if !gotDocChip {
+		t.Error("history_user_message carried no document chip for the persisted image")
+	}
+
+	// The persisted message should carry a path note, not an image block.
+	loaded, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	var hasNote, hasBlock bool
+	for _, m := range loaded.Messages {
+		if m.Role != agent.RoleUser {
+			continue
+		}
+		if strings.Contains(m.Content, "[Attached file:") && strings.Contains(filepath.ToSlash(m.Content), ".octo/uploads") {
+			hasNote = true
+		}
+		for _, blk := range m.Blocks {
+			if blk.Type == "image" {
+				hasBlock = true
+			}
+		}
+	}
+	if !hasNote {
+		t.Error("persisted user message missing the image path note")
+	}
+	if hasBlock {
+		t.Error("non-vision model persisted an image block")
+	}
+
+	turnMu := srv.sessionTurnLock(sess.ID)
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
+		turnMu.Lock()
+		running := srv.turnRunning[sess.ID]
+		turnMu.Unlock()
+		if !running {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 // TestParseUserFilesLocalPath: a real local path is referenced in place only
 // for a loopback (same-machine) client; for a remote client it's ignored so it
 // can't make the agent read arbitrary server files.
@@ -379,12 +518,12 @@ func TestParseUserFilesLocalPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	att := parseUserFiles([]wsUserFile{{Name: "notes.md", LocalPath: f}}, true)
+	att := parseUserFiles([]wsUserFile{{Name: "notes.md", LocalPath: f}}, true, true)
 	if len(att.notes) != 1 || !strings.Contains(att.notes[0], f) {
 		t.Errorf("local path should be referenced in place for loopback, got notes=%+v", att.notes)
 	}
 
-	att2 := parseUserFiles([]wsUserFile{{Name: "notes.md", LocalPath: f}}, false)
+	att2 := parseUserFiles([]wsUserFile{{Name: "notes.md", LocalPath: f}}, false, true)
 	if len(att2.notes) != 0 {
 		t.Errorf("local path must be ignored for a non-loopback client, got notes=%+v", att2.notes)
 	}

--- a/internal/server/channel_attach_test.go
+++ b/internal/server/channel_attach_test.go
@@ -77,3 +77,37 @@ func TestAttachInboundFiles_Image(t *testing.T) {
 		t.Error("expected the inbound image to be persisted under uploads")
 	}
 }
+
+// TestAttachInboundFiles_Image_NonVision verifies that for a text-only model
+// an inbound image is surfaced as a path note rather than a vision block, so the
+// model can read_file the image and the turn doesn't fail with a provider 400.
+func TestAttachInboundFiles_Image_NonVision(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+
+	s := &Server{}
+	sess := &channel.Session{Agent: agent.New(&stubSender{}, "deepseek-v4-pro")}
+	dataURL := "data:image/png;base64," + tinyPNG
+	ev := channel.InboundEvent{
+		Platform: "telegram",
+		Text:     "what is this",
+		Files:    []channel.FileAttachment{{Type: "image", Name: "pic.png", MimeType: "image/png", DataURL: dataURL}},
+	}
+	got := s.attachInboundFiles(sess, ev)
+	if !strings.Contains(got, "what is this") {
+		t.Errorf("content lost the caption: %q", got)
+	}
+	if !strings.Contains(got, "[Attached file:") || !strings.Contains(filepath.ToSlash(got), ".octo/uploads") {
+		t.Errorf("content should carry a persisted upload path note for non-vision model, got %q", got)
+	}
+	// The image should still be persisted so the model can read it.
+	dir := filepath.Join(tmpHome, ".octo", "uploads")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("uploads dir not created: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Error("expected the inbound image to be persisted under uploads")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2557,15 +2557,20 @@ func (s *Server) handleChannelMessage(ctx context.Context, ad channel.Adapter, e
 
 // attachInboundFiles bridges an inbound event's attachments into the agent
 // turn, mirroring the web composer's parseUserFiles. Images (delivered as data
-// URLs by the adapters) are decoded, persisted under ~/.octo/uploads, and
-// queued as vision blocks merged into the next user message; documents
-// (delivered as a local Path) become "[Attached file: <path>]" notes so the
-// model can open them with read_file. Per-file failures are logged and
-// skipped. Returns the content to run with any file notes folded in.
+// URLs by the adapters) are decoded and persisted under ~/.octo/uploads. If the
+// active model accepts vision they are queued as vision blocks; otherwise they
+// are surfaced as path notes so the model can read_file them and the turn keeps
+// running. Documents (delivered as a local Path) become "[Attached file: <path>]"
+// notes. Per-file failures are logged and skipped. Returns the content to run
+// with any file notes folded in.
 func (s *Server) attachInboundFiles(sess *channel.Session, ev channel.InboundEvent) string {
 	content := ev.Text
 	var blocks []agent.ContentBlock
 	var notes []string
+
+	cfg, _ := config.LoadCached()
+	vision := cfg.ModelVision(sess.Agent.Model)
+
 	for _, f := range ev.Files {
 		switch {
 		case f.DataURL != "":
@@ -2574,7 +2579,11 @@ func (s *Server) attachInboundFiles(sess *channel.Session, ev channel.InboundEve
 				slog.Debug("channel image attachment", "platform", ev.Platform, "name", f.Name, "err", err)
 				continue
 			}
-			blocks = append(blocks, block)
+			if vision {
+				blocks = append(blocks, block)
+			} else {
+				notes = append(notes, agent.AttachmentNote(block.ImagePath))
+			}
 		case f.Path != "":
 			notes = append(notes, agent.AttachmentNote(f.Path))
 		}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/config"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
 
@@ -435,7 +436,24 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 	// through this handler): treat those as non-loopback so a real path is only
 	// ever honored for a message that genuinely arrived from a local peer.
 	loopback := conn != nil && conn.loopback
-	att := parseUserFiles(msg.Files, loopback)
+
+	sess, err := agent.LoadSession(sid)
+	if err != nil {
+		s.wsHub.broadcast(sid, map[string]any{
+			"type":       "send_rejected",
+			"session_id": sid,
+			"message":    fmt.Sprintf("session not found: %s", sid),
+		})
+		return
+	}
+
+	// Gate image attachments on the active model's vision capability so a
+	// text-only model isn't sent image blocks it rejects (HTTP 400). LoadCached
+	// keeps the last good vision setting even if config.yml is mid-edit.
+	cfg, _ := config.LoadCached()
+	vision := cfg.ModelVision(sess.Model)
+
+	att := parseUserFiles(msg.Files, loopback, vision)
 	if content == "" && len(att.blocks) == 0 && len(att.notes) == 0 {
 		return
 	}
@@ -466,16 +484,6 @@ func (s *Server) handleWSUserMessage(conn *wsConn, msg *wsMsgUserMessage) {
 	// read_file them and the transcript keeps a visible record.
 	if len(att.notes) > 0 {
 		content = strings.TrimSpace(content + "\n\n" + strings.Join(att.notes, "\n"))
-	}
-
-	sess, err := agent.LoadSession(sid)
-	if err != nil {
-		s.wsHub.broadcast(sid, map[string]any{
-			"type":       "send_rejected",
-			"session_id": sid,
-			"message":    fmt.Sprintf("session not found: %s", sid),
-		})
-		return
 	}
 
 	if ok, bindMsg, berr := s.acquireSessionBinding(sid, agent.EntryWeb, msg.Force); !ok {


### PR DESCRIPTION
When the active model does not accept images (vision=false), sending an image block causes a provider HTTP 400 (e.g. deepseek-v4-pro rejects image_url content). This change makes both web and IM inbound image attachments fall back to a persisted upload path note instead of an image block, so text-only models can read_file the image and keep working.

Vision models keep the existing image-block behavior unchanged.

Fixes the scenario where pasting an image into the web composer with a non-vision model errors out immediately.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>