### PR TITLE
serve: load ~/.octo/serve.env on startup so GUI apps can see env vars

### DIFF
--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/open-octo/octo-agent/internal/logfile"
+	"github.com/open-octo/octo-agent/internal/serveenv"
 	"github.com/open-octo/octo-agent/internal/serveproc"
 	"github.com/open-octo/octo-agent/internal/server"
 	"github.com/open-octo/octo-agent/internal/shellpath"
@@ -122,6 +123,14 @@ func main() {
 	// and shell tools inherit this process's PATH directly — sync it to the login
 	// shell's before server.New below, mirroring the `octo serve` binary.
 	shellpath.SyncToLoginShell()
+
+	// Load ~/.octo/serve.env for variables a GUI launch can't inherit from a
+	// login shell (e.g. TAVILY_API_KEY, provider keys). Best-effort — missing
+	// file is a no-op, explicit env always wins. Mirrors the `octo serve` CLI
+	// path so both backends resolve the same set of environment variables.
+	serveenv.Load()
+
+	// Pick the language for native dialogs/tray from the system UI language.
 
 	// Pick the language for native dialogs/tray from the system UI language.
 	applyLang()

--- a/cmd/octo/main.go
+++ b/cmd/octo/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 
 	"github.com/open-octo/octo-agent/internal/sandbox"
+	"github.com/open-octo/octo-agent/internal/serveenv"
 	"github.com/open-octo/octo-agent/internal/shellpath"
 	"github.com/open-octo/octo-agent/internal/skills"
 	"github.com/open-octo/octo-agent/internal/tools"
@@ -37,6 +38,16 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	// A no-op on Windows and when the PATH already looks like a login shell's
 	// (the common terminal launch).
 	shellpath.SyncToLoginShell()
+
+	// Load ~/.octo/serve.env for variables the launcher can't inherit (GUI /
+	// launchd / .desktop start with a minimal environment, missing the user's
+	// shell profile). Best-effort — a missing file is a no-op, and explicit
+	// env (CLI / systemd Environment=) always wins over the file. Done early
+	// so provider keys, TAVILY_API_KEY, OCTO_LOG_LEVEL etc. are present before
+	// any tool or subcommand reads the environment.
+	serveenv.Load()
+
+	// Materialize the binary's default skills/workflows to ~/.octo/skills-default
 
 	// Materialize the binary's default skills/workflows to ~/.octo/skills-default
 	// and ~/.octo/workflows-default so they're discoverable like any user

--- a/docs/src/content/docs/guides/self-host.md
+++ b/docs/src/content/docs/guides/self-host.md
@@ -10,6 +10,39 @@ octo serve --stop               # stop a background instance
 octo serve -addr :8088          # expose on the LAN
 ```
 
+## Environment variables
+
+Some environment variables (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OCTO_ACCESS_KEY`,
+`OCTO_LOG_LEVEL`, search keys like `TAVILY_API_KEY`, …) control how octo behaves at runtime.
+Normally your shell profile exports them — but **GUI-launched processes don't inherit those**:
+the desktop app, a launchd agent, and a `.desktop` session all start with a minimal
+environment that skips `~/.bashrc` / `~/.zprofile`.
+
+Drop a `~/.octo/serve.env` file to cover every launch mode uniformly:
+
+```bash
+cat > ~/.octo/serve.env << 'EOF'
+TAVILY_API_KEY=tvly-xxxxx
+ANTHROPIC_API_KEY=sk-ant-xxxxx
+OCTO_LOG_LEVEL=debug
+EOF
+chmod 600 ~/.octo/serve.env
+```
+
+octo loads it at startup (before any tool or channel reads the environment):
+
+- **Simple `KEY=VALUE` lines**, one per line.
+- `#` comments and blank lines are skipped.
+- An optional `export ` prefix is tolerated (so you can copy-paste from a shell rc file).
+- Keys are **whitespace-trimmed**; a value with `=` inside it is preserved (`KEY=val=ue` works).
+- **Variables already set in the process environment are NOT overridden** — explicit
+  `FOO=bar octo serve`, systemd `Environment=`, and launchd `SetEnvironmentVariable`
+  all win over the file. This keeps the file as a safe fallback, not a surprise override.
+
+This is the same file the systemd/launchd packaging templates already point at via
+`EnvironmentFile=%h/.octo/serve.env` (`packaging/systemd/octo.service`). Now `octo serve`,
+the desktop app, and the TUI all resolve the same file — pick once, work everywhere.
+
 ## Access control
 
 `127.0.0.1` is loopback and trusted implicitly — no key needed, and that's the default bind. The

--- a/docs/src/content/docs/zh/guides/self-host.md
+++ b/docs/src/content/docs/zh/guides/self-host.md
@@ -10,6 +10,31 @@ octo serve --stop               # 停止后台实例
 octo serve -addr :8088          # 暴露到局域网
 ```
 
+## 环境变量
+
+部分环境变量（`ANTHROPIC_API_KEY`、`OPENAI_API_KEY`、`OCTO_ACCESS_KEY`、`OCTO_LOG_LEVEL`，以及 `TAVILY_API_KEY` 等搜索 key）在运行时控制 octo 的行为。通常由 shell profile export —— 但 **GUI 启动的进程不会继承这些变量**：桌面应用、launchd agent、`.desktop` session 启动时只拿到最小环境，不读 `~/.bashrc` / `~/.zprofile`。
+
+放一份 `~/.octo/serve.env` 即可统一覆盖所有启动方式：
+
+```bash
+cat > ~/.octo/serve.env << 'EOF'
+TAVILY_API_KEY=tvly-xxxxx
+ANTHROPIC_API_KEY=sk-ant-xxxxx
+OCTO_LOG_LEVEL=debug
+EOF
+chmod 600 ~/.octo/serve.env
+```
+
+octo 在启动时（早于任何工具或 channel 读取环境）加载它：
+
+- **简单的 `KEY=VALUE` 行**，一行一个。
+- `#` 注释和空行会被跳过。
+- 允许 `export ` 前缀（方便直接从 shell rc 文件复制粘贴）。
+- Key 会**去空白**；value 内部可以含 `=`（`KEY=val=ue` 能用）。
+- **已在进程环境中设置的变量不会被覆盖** ——显式的 `FOO=bar octo serve`、systemd `Environment=`、launchd `SetEnvironmentVariable` 都优先于本文件。这让文件保持为安全的 fallback，不会意外覆盖你显式设的值。
+
+这也是 systemd/launchd 打包模板里已经通过 `EnvironmentFile=%h/.octo/serve.env`（`packaging/systemd/octo.service`）指向的同一个文件。现在 `octo serve`、桌面版、TUI 都能解析同一份文件 ——配一次，到处生效。
+
 ## 访问控制
 
 `127.0.0.1` 是回环地址，默认就被信任——不需要 key，这也是默认的绑定方式。一旦绑定得更宽

--- a/internal/serveenv/serveenv.go
+++ b/internal/serveenv/serveenv.go
@@ -1,0 +1,76 @@
+// Package serveenv loads ~/.octo/serve.env (if it exists) into the process
+// environment at startup. It lets a GUI-launched process (desktop app, launchd
+// agent, .desktop session) pick up API keys and other variables that it can't
+// inherit from a login shell — the same file the systemd/launchd packaging
+// templates ship as EnvironmentFile. Without it, `octo-desktop` can't see
+// TAVILY_API_KEY / OPENAI_API_KEY etc. because GUI processes inherit a minimal
+// environment without the user's shell profile.
+//
+// Format: simple KEY=VALUE, one per line; "#" comments and blank lines are
+// skipped; an optional "export " prefix is tolerated. Key and value are
+// whitespace-trimmed at both ends, so `KEY = value` and `KEY=value` are
+// equivalent — deliberate internal spaces must be intentional (most parsers
+// treat `.env` as single-line key/value and don't carry leading/trailing
+// padding into the value).
+//
+// Variables already present in the process environment are NOT overridden:
+// explicit `FOO=bar octo serve` or systemd `Environment=` win over the file.
+// Load is best-effort: a missing file is a silent no-op, and a malformed line
+// is skipped without aborting the rest.
+package serveenv
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// envPath returns the absolute path to the serve.env file. Kept as a var so
+// tests can redirect it.
+var envPath = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".octo", "serve.env")
+}
+
+// Load reads ~/.octo/serve.env and sets any KEY=VALUE pair whose key is not
+// already present in the process environment. Safe to call repeatedly and from
+// concurrent goroutines (os.Setenv is process-global but the file is only read
+// once at startup, so races only matter in tests).
+func Load() {
+	path := envPath()
+	if path == "" {
+		// No home dir — nothing to load.
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Missing file is the common case on a fresh install; not an error.
+		return
+	}
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Tolerate "export KEY=VALUE" (some users copy-paste from shell rc).
+		line = strings.TrimPrefix(line, "export ")
+		line = strings.TrimSpace(line)
+		eq := strings.IndexByte(line, '=')
+		if eq <= 0 {
+			continue // no "=" or empty key — skip
+		}
+		key := strings.TrimSpace(line[:eq])
+		val := strings.TrimSpace(line[eq+1:])
+		if key == "" {
+			continue
+		}
+		// Explicit env wins: don't clobber what systemd/launchd/CLI already set.
+		if _, exists := os.LookupEnv(key); exists {
+			continue
+		}
+		_ = os.Setenv(key, val)
+	}
+}

--- a/internal/serveenv/serveenv.go
+++ b/internal/serveenv/serveenv.go
@@ -36,9 +36,9 @@ var envPath = func() string {
 }
 
 // Load reads ~/.octo/serve.env and sets any KEY=VALUE pair whose key is not
-// already present in the process environment. Safe to call repeatedly and from
-// concurrent goroutines (os.Setenv is process-global but the file is only read
-// once at startup, so races only matter in tests).
+// already present in the process environment. Call once at startup — safe to
+// call repeatedly if no concurrent goroutines are reading these keys yet
+// (os.Setenv mutates process-global state, so concurrent Load + Getenv races).
 func Load() {
 	path := envPath()
 	if path == "" {
@@ -64,9 +64,6 @@ func Load() {
 		}
 		key := strings.TrimSpace(line[:eq])
 		val := strings.TrimSpace(line[eq+1:])
-		if key == "" {
-			continue
-		}
 		// Explicit env wins: don't clobber what systemd/launchd/CLI already set.
 		if _, exists := os.LookupEnv(key); exists {
 			continue

--- a/internal/serveenv/serveenv_test.go
+++ b/internal/serveenv/serveenv_test.go
@@ -1,0 +1,86 @@
+package serveenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_NoFileIsSilent(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := envPath
+	envPath = func() string { return filepath.Join(dir, "serve.env") }
+	defer func() { envPath = oldPath }()
+
+	// File does NOT exist — Load must be a silent no-op, not error.
+	Load()
+}
+
+func TestLoad_SetsMissingVars(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "serve.env")
+	content := "# a comment\nTAVILY_API_KEY=tvly-abc123\n\nexport BRAVE_SEARCH_API_KEY=brave-xyz\nSERPER_API_KEY = serp-789\nNO_EQUAL_SIGN\n=emptykey\n  # indented comment\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldPath := envPath
+	envPath = func() string { return path }
+	defer func() { envPath = oldPath }()
+
+	// Clear any pre-existing values so we can observe the set.
+	_ = os.Unsetenv("TAVILY_API_KEY")
+	_ = os.Unsetenv("BRAVE_SEARCH_API_KEY")
+	defer func() {
+		_ = os.Unsetenv("TAVILY_API_KEY")
+		_ = os.Unsetenv("BRAVE_SEARCH_API_KEY")
+		_ = os.Unsetenv("SERPER_API_KEY")
+	}()
+
+	Load()
+
+	if got := os.Getenv("TAVILY_API_KEY"); got != "tvly-abc123" {
+		t.Errorf("TAVILY_API_KEY = %q, want tvly-abc123", got)
+	}
+	if got := os.Getenv("BRAVE_SEARCH_API_KEY"); got != "brave-xyz" {
+		t.Errorf("BRAVE_SEARCH_API_KEY = %q, want brave-xyz", got)
+	}
+	// Whitespace-trimmed key, verbatim value.
+	if got := os.Getenv("SERPER_API_KEY"); got != "serp-789" {
+		t.Errorf("SERPER_API_KEY = %q, want serp-789", got)
+	}
+	// Line with no "=" is skipped → not set.
+	if _, ok := os.LookupEnv("NO_EQUAL_SIGN"); ok {
+		t.Error("NO_EQUAL_SIGN should not be set (no '=' in line)")
+	}
+}
+
+func TestLoad_DoesNotOverrideExplicit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "serve.env")
+	if err := os.WriteFile(path, []byte("TAVILY_API_KEY=from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldPath := envPath
+	envPath = func() string { return path }
+	defer func() { envPath = oldPath }()
+
+	// Explicit env must win over the file.
+	t.Setenv("TAVILY_API_KEY", "from-cli")
+
+	Load()
+
+	if got := os.Getenv("TAVILY_API_KEY"); got != "from-cli" {
+		t.Errorf("explicit env was overridden: got %q, want from-cli", got)
+	}
+}
+
+func TestLoad_NoHomeDir(t *testing.T) {
+	oldPath := envPath
+	envPath = func() string { return "" }
+	defer func() { envPath = oldPath }()
+
+	// Must not panic or error when home dir is unavailable.
+	Load()
+}


### PR DESCRIPTION
## Problem

GUI-launched processes (`octo-desktop`, launchd agent, .desktop session) inherit a minimal environment that skips the user's shell profile. API keys set in `~/.bashrc`/`~/.zprofile` (e.g. `TAVILY_API_KEY`, `OPENAI_API_KEY`) are invisible to them, even though the systemd/launchd packaging templates already point at `~/.octo/serve.env` via `EnvironmentFile`.

## Fix

Add `internal/serveenv.Load()` — a small best-effort parser that reads `~/.octo/serve.env` (`KEY=VALUE`, `#` comments, `export ` prefix tolerated) and `os.Setenv()`s any key not already present in the process environment. Wired into both `cmd/octo` (`octo serve`) and `cmd/octo-desktop` (in-process server), so every entry point resolves the same set of variables.

## Priority (high → low)

Explicit env (`FOO=bar octo serve` / systemd `Environment=` / launchd setenv) > `~/.octo/serve.env` > defaults.

## Usage

```bash
cat > ~/.octo/serve.env << 'EOF'
TAVILY_API_KEY=tvly-xxxxx
EOF
chmod 600 ~/.octo/serve.env
```

## Files

| File | Change |
|------|--------|
| `internal/serveenv/serveenv.go` | New package: load serve.env, skip already-set vars |
| `internal/serveenv/serveenv_test.go` | Tests: missing file, set values, no override, no home |
| `cmd/octo/main.go` | Call `serveenv.Load()` at start of `run()` |
| `cmd/octo-desktop/main.go` | Call `serveenv.Load()` at start of `main()` |