### PR TITLE
fix(server): render non-vision image attachments as thumbnails in history and steer

### DIFF
--- a/internal/agent/attachment_note_test.go
+++ b/internal/agent/attachment_note_test.go
@@ -5,6 +5,38 @@ import (
 	"testing"
 )
 
+func TestAttachmentPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "single note",
+			in:   "[Attached file: /home/u/.octo/uploads/123_report.pdf]",
+			want: []string{"/home/u/.octo/uploads/123_report.pdf"},
+		},
+		{
+			name: "multiple notes",
+			in:   "compare them\n\n[Attached file: /a/q1.xlsx]\n[Attached file: /a/q2.xlsx]",
+			want: []string{"/a/q1.xlsx", "/a/q2.xlsx"},
+		},
+		{
+			name: "no note",
+			in:   "just a normal message",
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AttachmentPaths(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("AttachmentPaths = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAttachmentNoteRoundTrip(t *testing.T) {
 	note := AttachmentNote("/home/u/.octo/uploads/123_report.pdf")
 	cleaned, names := StripAttachmentNotes(note)

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -941,6 +941,18 @@ func StripAttachmentNotes(s string) (cleaned string, names []string) {
 	return cleaned, names
 }
 
+// AttachmentPaths returns the raw on-disk paths from every "[Attached file: <>]"
+// note in s, in order. This is the complement of StripAttachmentNotes: callers
+// that need the full path (e.g. to derive an /api/uploads/ thumbnail URL) use
+// this; callers that only need a display name use StripAttachmentNotes.
+func AttachmentPaths(s string) []string {
+	var paths []string
+	for _, m := range attachmentNoteRe.FindAllStringSubmatch(s, -1) {
+		paths = append(paths, strings.TrimSpace(m[1]))
+	}
+	return paths
+}
+
 // LoadSession reads ~/.octo/sessions/<id>.jsonl. id may be a bare session id,
 // an id with a .jsonl/.json suffix, or an absolute path to a transcript file.
 func LoadSession(id string) (*Session, error) {

--- a/internal/server/attachments.go
+++ b/internal/server/attachments.go
@@ -14,17 +14,34 @@ import (
 )
 
 // docChipRefs strips "[Attached file: …]" notes from display text and returns
-// the cleaned text plus one "pdf:<name>" chip ref per note. The note in the
-// message text is the only persisted trace of a document attachment, so this is
-// the single source of doc chips for both the live broadcast and history
-// replay. ("pdf:" is the frontend's document-chip sentinel; the name is any
-// file type, not only PDFs.)
+// the cleaned text plus one chip ref per note. Image attachments persisted
+// under ~/.octo/uploads are returned as "/api/uploads/<name>" so the frontend
+// renders a thumbnail; documents and non-uploaded local paths are returned as
+// "pdf:<name>" for the document chip. The note in the message text is the only
+// persisted trace of an attachment, so this is the single source of chips for
+// both the live broadcast and history replay.
 func docChipRefs(text string) (cleaned string, refs []string) {
 	cleaned, names := agent.StripAttachmentNotes(text)
-	for _, n := range names {
-		refs = append(refs, "pdf:"+n)
+	paths := agent.AttachmentPaths(text)
+	for i, name := range names {
+		if i < len(paths) && isImageUpload(paths[i]) {
+			refs = append(refs, "/api/uploads/"+filepath.Base(paths[i]))
+		} else {
+			refs = append(refs, "pdf:"+name)
+		}
 	}
 	return cleaned, refs
+}
+
+// isImageUpload reports whether path is an image file persisted in the uploads
+// directory, i.e. one that can be served back under /api/uploads/.
+func isImageUpload(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg":
+		return strings.Contains(filepath.ToSlash(path), "/.octo/"+uploadsDirName+"/")
+	}
+	return false
 }
 
 // User attachments sent over the WebSocket message payload. Images arrive as

--- a/internal/server/attachments_test.go
+++ b/internal/server/attachments_test.go
@@ -122,8 +122,7 @@ func TestParseUserFiles_DocPath(t *testing.T) {
 }
 
 func TestDocChipRefs(t *testing.T) {
-	// The unixnano prefix handleUpload adds is stripped so the chip shows the
-	// original filename; the note is removed from the returned text.
+	// Document attachment → "pdf:<name>" chip.
 	in := "look at this\n\n" + agent.AttachmentNote("/home/u/.octo/uploads/1720000000000000000_report.pdf")
 	cleaned, refs := docChipRefs(in)
 	if cleaned != "look at this" {
@@ -131,6 +130,23 @@ func TestDocChipRefs(t *testing.T) {
 	}
 	if len(refs) != 1 || refs[0] != "pdf:report.pdf" {
 		t.Errorf("refs = %v, want [pdf:report.pdf]", refs)
+	}
+
+	// Image attachment persisted under uploads → "/api/uploads/" thumbnail URL.
+	in = "look at this\n\n" + agent.AttachmentNote("/home/u/.octo/uploads/1720000000000000000_shot.jpg")
+	cleaned, refs = docChipRefs(in)
+	if cleaned != "look at this" {
+		t.Errorf("cleaned = %q, want %q", cleaned, "look at this")
+	}
+	if len(refs) != 1 || refs[0] != "/api/uploads/1720000000000000000_shot.jpg" {
+		t.Errorf("refs = %v, want [/api/uploads/1720000000000000000_shot.jpg]", refs)
+	}
+
+	// Non-upload local image path stays a document chip (not served by /api/uploads/).
+	in = "look at this\n\n" + agent.AttachmentNote("/tmp/local_shot.jpg")
+	cleaned, refs = docChipRefs(in)
+	if len(refs) != 1 || refs[0] != "pdf:local_shot.jpg" {
+		t.Errorf("refs = %v, want [pdf:local_shot.jpg]", refs)
 	}
 }
 
@@ -152,7 +168,8 @@ func TestParseUserFiles_SkipsBadEntries(t *testing.T) {
 // A persisted document attachment (only an "[Attached file: <abspath>]" note in
 // the text, no image block) must replay with the note stripped from the visible
 // content and re-derived into a "pdf:<name>" chip ref — so a reloaded transcript
-// matches what the live turn showed.
+// matches what the live turn showed. Image notes instead become
+// "/api/uploads/<name>" thumbnail refs.
 func TestHandleGetSessionMessages_DocAttachmentReplay(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -439,7 +456,7 @@ func TestHandleWSUserMessage_ImageOnly_NonVision(t *testing.T) {
 		},
 	})
 
-	var gotDocChip bool
+	var gotImage bool
 	deadline := time.After(5 * time.Second)
 drain:
 	for {
@@ -454,8 +471,8 @@ drain:
 				if imgs, ok := ev["images"].([]any); ok {
 					for _, img := range imgs {
 						ref, _ := img.(string)
-						if strings.HasPrefix(ref, "pdf:shot") {
-							gotDocChip = true
+						if strings.HasPrefix(ref, "/api/uploads/") {
+							gotImage = true
 						}
 					}
 				}
@@ -466,8 +483,8 @@ drain:
 			t.Fatal("turn did not complete — non-vision image-only message still dropped?")
 		}
 	}
-	if !gotDocChip {
-		t.Error("history_user_message carried no document chip for the persisted image")
+	if !gotImage {
+		t.Error("history_user_message carried no /api/uploads/ image ref for the persisted image")
 	}
 
 	// The persisted message should carry a path note, not an image block.


### PR DESCRIPTION
Follow-up to #1467.

When a non-vision model receives an image, the attachment is persisted as a path note. Live broadcasts showed the thumbnail via att.images, but history replay and steer queue rebuilds derive display refs from docChipRefs, which always emitted pdf: name chips. Images therefore rendered as document chips.

Now docChipRefs inspects the attachment path: images persisted under ~/.octo/uploads become /api/uploads/ name thumbnail refs, while documents stay as pdf: name chips. The frontend already renders any non-pdf ref as an img element, so no web change is required.

Also adds AttachmentPaths to the agent package so server can derive the original upload basename without re-parsing the note regex.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>