### PR TITLE
fix(browser): attach-only, never launch a headless Chrome

### DIFF
--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -165,10 +165,12 @@ func ResetBrowserSession() {
 	closeSession(b, p)
 }
 
-// closeSession tears down a browser session. When we attached to the user's own
+// closeSession tears down a browser session. When attached to the user's own
 // Chrome, Close() only drops the WS and leaves our tab behind, so close the tab
-// we opened too (don't litter the user's browser); if we launched Chrome
-// ourselves, Close() kills it whole. Safe to call with nils.
+// we opened too (don't litter the user's browser). The production path never
+// launches its own Chrome (attach-only), so OwnsProcess is always false there;
+// integration tests inject a launched browser via SetBrowserSession, where
+// OwnsProcess can be true and Close() kills it whole. Safe to call with nils.
 func closeSession(b *browser.Browser, p *browser.Page) {
 	if b == nil {
 		return
@@ -282,7 +284,11 @@ func browserPage(ctx context.Context) (*browser.Page, *browser.Browser, error) {
 		// would carry no login session and trip the macOS "Chrome Safe Storage"
 		// keychain prompt).
 		if b, err = browser.DiscoverRunningChrome(ctx); err != nil {
-			return nil, nil, wrapBrowserConnectError(err)
+			// Return the discovery error as-is — it already carries an
+			// actionable connect guide ("launch Chrome with
+			// --remote-debugging-port or set browser.connect_port"), so
+			// wrapping it would repeat the setup instruction.
+			return nil, nil, err
 		}
 	}
 

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -272,21 +272,17 @@ func browserPage(ctx context.Context) (*browser.Page, *browser.Browser, error) {
 			return nil, nil, wrapBrowserConnectError(err)
 		}
 	default:
-		// No explicit attach config: prefer the user's logged-in Chrome if one
-		// is running with remote debugging. Discovery only succeeds when the
-		// user deliberately enabled it (the chrome://inspect toggle or
-		// --remote-debugging-port), so this never hijacks an ordinary browser —
-		// it just means `octo browser setup` users, and anyone who flipped the
-		// toggle, get their logged-in session without extra config. Falls back
-		// to a fresh throwaway Chrome.
+		// No explicit attach config: reuse the user's logged-in Chrome if one is
+		// running with remote debugging. Discovery only succeeds when the user
+		// deliberately enabled it (the chrome://inspect toggle or
+		// --remote-debugging-port), so this never hijacks an ordinary browser.
+		// When nothing is reachable we return an actionable error rather than
+		// launching a throwaway Chrome: the browser tool only ever drives a real,
+		// user-owned Chrome, never a headless instance it spins up itself (which
+		// would carry no login session and trip the macOS "Chrome Safe Storage"
+		// keychain prompt).
 		if b, err = browser.DiscoverRunningChrome(ctx); err != nil {
-			if b, err = browser.Launch(ctx, browser.LaunchOptions{
-				ExecPath:    bc.ExecPath,
-				UserDataDir: bc.UserDataDir,
-				Headless:    bc.Headless,
-			}); err != nil {
-				return nil, nil, fmt.Errorf("launch Chrome: %w", wrapBrowserConnectError(err))
-			}
+			return nil, nil, wrapBrowserConnectError(err)
 		}
 	}
 

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -421,3 +421,37 @@ func TestWrapBrowserConnectError(t *testing.T) {
 		})
 	}
 }
+
+// TestBrowserPage_NoLaunchFallback locks the invariant that the browser tool
+// only ever attaches to a real, user-owned Chrome and never spins up a headless
+// instance of its own. With no attach config and no discoverable Chrome, it must
+// return the actionable connect guide — not launch a throwaway Chrome, whose
+// empty profile carries no login session and trips the macOS "Chrome Safe
+// Storage" keychain prompt.
+func TestBrowserPage_NoLaunchFallback(t *testing.T) {
+	// An empty HOME means no ~/.octo/config.yml — so ConnectPort=0 and
+	// AttachRunning=false, i.e. the default branch — and Chrome's default profile
+	// dirs resolve under this empty home, so discovery finds no running Chrome.
+	// Deterministic across runners, and it never touches the user's real profile.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // windows
+
+	ResetBrowserSession()
+	defer ResetBrowserSession()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	page, b, err := browserPage(ctx)
+	if err == nil {
+		ResetBrowserSession()
+		t.Fatal("browserPage returned a live browser with no attach config; it must attach only, never launch its own Chrome")
+	}
+	if page != nil || b != nil {
+		t.Fatalf("expected nil page/browser on failure, got page=%v browser=%v", page, b)
+	}
+	if !strings.Contains(err.Error(), "--remote-debugging-port") {
+		t.Fatalf("error should be the actionable connect guide, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

On macOS a recurring **「找不到用于储存 "Chrome" 的钥匙串」 / "Cannot find the keychain to store Chrome"** dialog kept popping up. Root cause traced to the browser tool: its default connection branch (no `connect_port` / `attach_running` configured) tried `DiscoverRunningChrome` and, on failure, **fell back to launching a throwaway headless Chrome** (`browser.Launch`, the only production call site).

That fallback instance:
- uses a fresh empty temp profile (`octo-chrome-*`) with **no login session** — so it's useless for the tool's actual purpose (reusing the user's logged-in Chrome), and
- on startup runs Chromium's OSCrypt init, which reaches for the app-global **"Chrome Safe Storage"** keychain key. In a headless/one-shot context that **store** step fails and surfaces the keychain dialog — once per launch, hence "every so often."

## Fix

Remove the launch fallback from `browserPage`'s default branch. When no Chrome is reachable, it now returns the **same actionable connect guide** the explicit-attach branches already return (`--remote-debugging-port` / `chrome://inspect`), instead of spinning up its own instance. The browser tool is now strictly **attach-only** — it only ever drives a real, user-owned Chrome, matching the intended design.

Because there is no longer *any* production code path that launches Chrome, this holds regardless of which config a process reads — the headless instance can no longer appear.

`browser.Launch` / `LaunchOptions` are retained: the integration tests spin up a fixture Chrome through them directly (bypassing `browserPage`).

## Dead-field cleanup (2nd commit)

With the launch path gone, `BrowserConfig.Headless` was unread by all production code, so it's removed (field + `headless` yaml tag). `ExecPath` and `DownloadDir` **stay** — `ExecPath` still feeds `browser.ChromeAvailable` (the availability probe, in both the tool gate and the server's `/browser` status), and `DownloadDir` still directs captured downloads. `UserDataDir` stays too (attach-to-profile path); its now-stale "used when launching" comment is refreshed.

## Test

`TestBrowserPage_NoLaunchFallback` — with an empty `$HOME` (⇒ zero config ⇒ default branch, and Chrome's default profile dirs resolve under the empty home ⇒ discovery finds nothing), `browserPage` must return the connect-guide error and a nil browser, never a live one. Deterministic across runners; never touches the user's real profile. Passes; `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)