### PR TITLE
Worktree browser no headless fallback

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -251,14 +251,12 @@ type BrowserConfig struct {
 	// --remote-debugging-port=<port> via the /json HTTP endpoint. Use when the
 	// port is known and that endpoint is served.
 	ConnectPort int `yaml:"connect_port,omitempty"`
-	// UserDataDir is the Chrome profile dir used when launching (the fallback
-	// when no running Chrome is attached). Empty uses a throwaway profile.
+	// UserDataDir is the Chrome profile dir to attach to when AttachRunning is
+	// set — its DevToolsActivePort is read to reach the logged-in session.
 	UserDataDir string `yaml:"user_data_dir,omitempty"`
-	// ExecPath overrides Chrome executable auto-detection.
+	// ExecPath overrides Chrome executable auto-detection (used to locate Chrome
+	// for the availability probe).
 	ExecPath string `yaml:"exec_path,omitempty"`
-	// Headless launches Chrome headless. Interactive workflows want this off so
-	// the user can watch and intervene.
-	Headless bool `yaml:"headless,omitempty"`
 	// DownloadDir is where captured downloads are written. Empty uses a temp dir.
 	DownloadDir string `yaml:"download_dir,omitempty"`
 }

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -165,10 +165,12 @@ func ResetBrowserSession() {
 	closeSession(b, p)
 }
 
-// closeSession tears down a browser session. When we attached to the user's own
+// closeSession tears down a browser session. When attached to the user's own
 // Chrome, Close() only drops the WS and leaves our tab behind, so close the tab
-// we opened too (don't litter the user's browser); if we launched Chrome
-// ourselves, Close() kills it whole. Safe to call with nils.
+// we opened too (don't litter the user's browser). The production path never
+// launches its own Chrome (attach-only), so OwnsProcess is always false there;
+// integration tests inject a launched browser via SetBrowserSession, where
+// OwnsProcess can be true and Close() kills it whole. Safe to call with nils.
 func closeSession(b *browser.Browser, p *browser.Page) {
 	if b == nil {
 		return
@@ -282,7 +284,11 @@ func browserPage(ctx context.Context) (*browser.Page, *browser.Browser, error) {
 		// would carry no login session and trip the macOS "Chrome Safe Storage"
 		// keychain prompt).
 		if b, err = browser.DiscoverRunningChrome(ctx); err != nil {
-			return nil, nil, wrapBrowserConnectError(err)
+			// Return the discovery error as-is — it already carries an
+			// actionable connect guide ("launch Chrome with
+			// --remote-debugging-port or set browser.connect_port"), so
+			// wrapping it would repeat the setup instruction.
+			return nil, nil, err
 		}
 	}
 

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -272,21 +272,17 @@ func browserPage(ctx context.Context) (*browser.Page, *browser.Browser, error) {
 			return nil, nil, wrapBrowserConnectError(err)
 		}
 	default:
-		// No explicit attach config: prefer the user's logged-in Chrome if one
-		// is running with remote debugging. Discovery only succeeds when the
-		// user deliberately enabled it (the chrome://inspect toggle or
-		// --remote-debugging-port), so this never hijacks an ordinary browser —
-		// it just means `octo browser setup` users, and anyone who flipped the
-		// toggle, get their logged-in session without extra config. Falls back
-		// to a fresh throwaway Chrome.
+		// No explicit attach config: reuse the user's logged-in Chrome if one is
+		// running with remote debugging. Discovery only succeeds when the user
+		// deliberately enabled it (the chrome://inspect toggle or
+		// --remote-debugging-port), so this never hijacks an ordinary browser.
+		// When nothing is reachable we return an actionable error rather than
+		// launching a throwaway Chrome: the browser tool only ever drives a real,
+		// user-owned Chrome, never a headless instance it spins up itself (which
+		// would carry no login session and trip the macOS "Chrome Safe Storage"
+		// keychain prompt).
 		if b, err = browser.DiscoverRunningChrome(ctx); err != nil {
-			if b, err = browser.Launch(ctx, browser.LaunchOptions{
-				ExecPath:    bc.ExecPath,
-				UserDataDir: bc.UserDataDir,
-				Headless:    bc.Headless,
-			}); err != nil {
-				return nil, nil, fmt.Errorf("launch Chrome: %w", wrapBrowserConnectError(err))
-			}
+			return nil, nil, wrapBrowserConnectError(err)
 		}
 	}
 

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -421,3 +421,37 @@ func TestWrapBrowserConnectError(t *testing.T) {
 		})
 	}
 }
+
+// TestBrowserPage_NoLaunchFallback locks the invariant that the browser tool
+// only ever attaches to a real, user-owned Chrome and never spins up a headless
+// instance of its own. With no attach config and no discoverable Chrome, it must
+// return the actionable connect guide — not launch a throwaway Chrome, whose
+// empty profile carries no login session and trips the macOS "Chrome Safe
+// Storage" keychain prompt.
+func TestBrowserPage_NoLaunchFallback(t *testing.T) {
+	// An empty HOME means no ~/.octo/config.yml — so ConnectPort=0 and
+	// AttachRunning=false, i.e. the default branch — and Chrome's default profile
+	// dirs resolve under this empty home, so discovery finds no running Chrome.
+	// Deterministic across runners, and it never touches the user's real profile.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // windows
+
+	ResetBrowserSession()
+	defer ResetBrowserSession()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	page, b, err := browserPage(ctx)
+	if err == nil {
+		ResetBrowserSession()
+		t.Fatal("browserPage returned a live browser with no attach config; it must attach only, never launch its own Chrome")
+	}
+	if page != nil || b != nil {
+		t.Fatalf("expected nil page/browser on failure, got page=%v browser=%v", page, b)
+	}
+	if !strings.Contains(err.Error(), "--remote-debugging-port") {
+		t.Fatalf("error should be the actionable connect guide, got: %v", err)
+	}
+}


### PR DESCRIPTION
<!-- Write this PR description in English. -->

## What

<!-- One or two sentences: what does this PR change? -->

## Why

<!-- The need this addresses, and who benefits. -->

## User-visible impact

<!-- Default behavior changes? New config? Breaking changes? "None" is a valid answer. -->

---

## Self-review

Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### 1. Architecture

- [ ] Smallest possible diff for the need
- [ ] No new configuration knobs (or justified below)
- [ ] No new dependencies (or justified below)
- [ ] Fits the existing design / naming / layering

### 2. Need

- [ ] Common need that benefits most users, **or** scope and side effects are explained below
- [ ] No unintended impact on other users' workflows or defaults

### 3. Code

- [ ] All tests pass
- [ ] Coverage does not drop; new code has new tests
- [ ] Commit messages and this PR are written in English
- [ ] This branch was created from the latest `main` and is currently up to date with it

### Bonus

- [ ] This PR was authored using Octo itself

---

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs you considered, or follow-ups planned. -->
