### PR TITLE
fix(windows): force UTF-8 decoding for PowerShell child output

### DIFF
--- a/cmd/octo/clipimg_windows.go
+++ b/cmd/octo/clipimg_windows.go
@@ -45,7 +45,7 @@ else { $img.Save('%s', [System.Drawing.Imaging.ImageFormat]::Png); Write-Output 
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, shell, "-NoProfile", "-NonInteractive", "-Command", script)
+	cmd := exec.CommandContext(ctx, shell, "-NoProfile", "-NonInteractive", "-Command", executil.PowerShellUTF8EncodingPrefix+script)
 	executil.SetNoWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/executil/powershell.go
+++ b/internal/executil/powershell.go
@@ -1,0 +1,8 @@
+package executil
+
+// PowerShellUTF8EncodingPrefix is prepended to every Windows PowerShell command
+// so that child-process output is interpreted and forwarded as UTF-8.  Without
+// this, a Chinese Windows host (default codepage 936 / GBK) decodes UTF-8 bytes
+// from Python or other tools as GBK, producing the diamond-question-mark
+// garbling users see in terminal output.
+const PowerShellUTF8EncodingPrefix = `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8; $env:PYTHONIOENCODING='utf-8'; `

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -250,7 +250,7 @@ func shellCmd(ctx context.Context, cmd string) *exec.Cmd {
 		if _, err := exec.LookPath("pwsh"); err == nil {
 			shell = "pwsh"
 		}
-		c := exec.CommandContext(ctx, shell, "-NoProfile", "-NonInteractive", "-Command", cmd)
+		c := exec.CommandContext(ctx, shell, "-NoProfile", "-NonInteractive", "-Command", executil.PowerShellUTF8EncodingPrefix+cmd)
 		executil.SetNoWindow(c)
 		return c
 	}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/open-octo/octo-agent/internal/executil"
 )
 
 // makeScript writes a shell script with the given body to a tempdir and
@@ -246,5 +248,23 @@ func TestInjectContext_PreservesUserAndAppendsContext(t *testing.T) {
 	}
 	if !strings.Contains(got, "---") {
 		t.Errorf("divider should be present: %q", got)
+	}
+}
+
+// TestShellCmd_WindowsUTF8EncodingPrefix ensures that, on Windows, the
+// PowerShell -Command payload used by hooks is prefixed with the UTF-8
+// encoding setup so child-process output is decoded correctly on GBK hosts.
+func TestShellCmd_WindowsUTF8EncodingPrefix(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only PowerShell encoding assertion")
+	}
+	cmd := shellCmd(context.Background(), "echo hi")
+	args := cmd.Args
+	if len(args) < 2 || args[len(args)-2] != "-Command" {
+		t.Fatalf("expected -Command payload, got args %v", args)
+	}
+	payload := args[len(args)-1]
+	if !strings.HasPrefix(payload, executil.PowerShellUTF8EncodingPrefix) {
+		t.Errorf("PowerShell command should start with UTF-8 encoding prefix; got:\n%s", payload)
 	}
 }

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -135,11 +135,11 @@ func shellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
 		// wrapper), but only when we can locate the octo binary and a project
 		// dir; otherwise run the command bare (no protection, but never broken).
 		if exe, err := os.Executable(); err == nil && projectDir != "" {
-			wrapped := fmt.Sprintf(windowsSafeRmWrapper, strings.ReplaceAll(exe, "'", "''"), command)
+			wrapped := executil.PowerShellUTF8EncodingPrefix + fmt.Sprintf(windowsSafeRmWrapper, strings.ReplaceAll(exe, "'", "''"), command)
 			cmd = exec.CommandContext(ctx, ps, "-NoProfile", "-NonInteractive", "-Command", wrapped)
 			cmd.Env = withBundledBinPath(append(os.Environ(), "OCTO_TRASH_PROJECT="+projectDir))
 		} else {
-			cmd = exec.CommandContext(ctx, ps, "-NoProfile", "-NonInteractive", "-Command", command)
+			cmd = exec.CommandContext(ctx, ps, "-NoProfile", "-NonInteractive", "-Command", executil.PowerShellUTF8EncodingPrefix+command)
 			cmd.Env = withBundledBinPath(os.Environ())
 		}
 		executil.SetNoWindow(cmd)

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/open-octo/octo-agent/internal/executil"
 )
 
 // TestShellCommand_PlatformShell verifies shellCommand picks the right shell
@@ -79,7 +81,27 @@ func TestWithBundledBinPath_NoOpWhenBundledDirMissing(t *testing.T) {
 	}
 }
 
-// TestShellCommand_ResolvesBundledTool is an integration test: it spawns a
+// TestShellCommand_WindowsUTF8EncodingPrefix ensures that, on Windows, the
+// PowerShell -Command payload is prefixed with the UTF-8 encoding setup so
+// child-process output is decoded correctly on GBK hosts.
+func TestShellCommand_WindowsUTF8EncodingPrefix(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only PowerShell encoding assertion")
+	}
+	cmd, err := shellCommand(context.Background(), "echo hi")
+	if err != nil {
+		t.Fatalf("shellCommand: %v", err)
+	}
+	args := cmd.Args
+	if len(args) < 2 || args[len(args)-2] != "-Command" {
+		t.Fatalf("expected -Command payload, got args %v", args)
+	}
+	payload := args[len(args)-1]
+	if !strings.HasPrefix(payload, executil.PowerShellUTF8EncodingPrefix) {
+		t.Errorf("PowerShell command should start with UTF-8 encoding prefix; got:\n%s", payload)
+	}
+}
+
 // real child process via shellCommand and confirms the child can execute a
 // fake tool that exists ONLY under a fake ~/.octo/bin — never on the real
 // system PATH — proving the PATH-append actually makes the bundled directory


### PR DESCRIPTION
中文 Windows 默认控制台代码页为 936（GBK）。当 agent 通过 PowerShell 执行 Python 等子进程时，Python 已输出 UTF-8，但 PowerShell 按 GBK 解码，导致用户看到菱形问号乱码。

修复：在 Windows 的 PowerShell "-Command" 负载前统一添加 UTF-8 编码前缀：



覆盖 terminal/skill 脚本执行（）和每轮 hook 执行（）两条路径。新增 Windows-only 测试断言该前缀存在。

测试：ok  	github.com/open-octo/octo-agent/internal/tools	48.256s
ok  	github.com/open-octo/octo-agent/internal/tools/rgembed	1.559s
ok  	github.com/open-octo/octo-agent/internal/hooks	13.514s 通过； 通过。