### PR TITLE
fix: disable reasoning and cap tokens for session title generation

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -63,22 +63,28 @@ type ToolSender interface {
 
 // LowEffortSender is implemented by a Sender that can produce a cheaper
 // variant of itself with reasoning effort capped to a small, fast budget.
-// GenerateTitle and Suggest use this: both deliberately reuse the turn's own
-// Sender (so the request shares the main conversation's prompt-cache
-// prefix — see their doc comments), but that Sender carries whatever
-// reasoning_effort the session happens to be configured with. A session
-// running "high"/"max" would otherwise pay the model's full reasoning
-// budget just to produce a 6-word title or a one-line suggestion, for no
-// benefit — and on a slower provider this reliably exceeds the throwaway
-// call's timeout every single time (a session stays on that effort level
-// across turns, so title generation would retry into the same failure on
-// every turn, never succeeding). LowEffort caps effort down rather than
-// disabling it outright — thinking stays nominally enabled, just with a
-// small budget, keeping the request shape consistent with earlier turns in
-// the same conversation that may already carry thinking blocks in history.
+// Suggest uses this: it deliberately reuses the turn's own Sender (so the
+// request shares the main conversation's prompt-cache prefix — see its doc
+// comment), but that Sender carries whatever reasoning_effort the session
+// happens to be configured with. A session running "high"/"max" would otherwise
+// pay the model's full reasoning budget just to produce a one-line suggestion,
+// for no benefit — and on a slower provider this reliably exceeds the throwaway
+// call's timeout. LowEffort caps effort to "low" rather than disabling it
+// outright, so the request shape stays consistent with earlier turns that may
+// already carry thinking blocks in history.
 type LowEffortSender interface {
 	Sender
 	LowEffort() Sender
+}
+
+// NoReasoningSender is implemented by a Sender that can produce a variant of
+// itself with reasoning disabled entirely. GenerateTitle uses this because a
+// 6-word title needs no reasoning at all, and even "low" reasoning can consume
+// the tight title token budget or time out. If a sender does not implement this
+// interface, GenerateTitle falls back to LowEffortSender instead.
+type NoReasoningSender interface {
+	Sender
+	NoReasoning() Sender
 }
 
 // ToolInputDeltaFunc receives raw JSON fragments of a tool_use block's
@@ -1271,13 +1277,10 @@ func (a *Agent) Suggest(ctx context.Context, tools []ToolDefinition) (string, er
 }
 
 // titleMaxTokens caps the title response. The title itself is a handful of
-// words, but the cap has to cover the model's reasoning tokens too: on a
-// reasoning model (LowEffort only lowers effort, it doesn't disable thinking)
-// the hidden reasoning is billed against this same budget, so a tight cap gets
-// entirely consumed by reasoning and the model emits empty text — leaving the
-// session with no generated title and no live sidebar update. Give it room for
-// low-effort reasoning plus the title line.
-const titleMaxTokens = 1024
+// words; a tiny cap is enough because LowEffortSender now disables reasoning
+// outright for this throwaway call, so the budget only has to cover the title
+// line itself.
+const titleMaxTokens = 250
 
 const titleInstruction = "Summarize this conversation as a short title of at most 6 words. " +
 	"Reply with the title text only — no preamble, no quotes, no trailing punctuation, no markdown."
@@ -1305,7 +1308,9 @@ func (a *Agent) GenerateTitle(ctx context.Context, tools []ToolDefinition) (stri
 	msgs = append(msgs, snap...)
 	msgs = append(msgs, NewUserMessage(titleInstruction))
 
-	if le, ok := sender.(LowEffortSender); ok {
+	if nr, ok := sender.(NoReasoningSender); ok {
+		sender = nr.NoReasoning()
+	} else if le, ok := sender.(LowEffortSender); ok {
 		sender = le.LowEffort()
 	}
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -32,14 +32,23 @@ func (f *fakeSender) SendMessages(_ context.Context, model, system string, messa
 }
 
 // fakeLowEffortSender additionally implements LowEffortSender: LowEffort()
-// hands back a distinct sender (low) so a test can assert GenerateTitle/
-// Suggest actually swap to it instead of using the main sender directly.
+// hands back a distinct sender (low) so a test can assert Suggest actually
+// swaps to it instead of using the main sender directly.
 type fakeLowEffortSender struct {
 	fakeSender
 	low *fakeSender
 }
 
 func (f *fakeLowEffortSender) LowEffort() Sender { return f.low }
+
+// fakeNoReasoningSender implements both LowEffortSender and NoReasoningSender.
+// GenerateTitle should prefer NoReasoning() over LowEffort().
+type fakeNoReasoningSender struct {
+	fakeLowEffortSender
+	noReasoning *fakeSender
+}
+
+func (f *fakeNoReasoningSender) NoReasoning() Sender { return f.noReasoning }
 
 func TestAgent_Turn_HappyPath(t *testing.T) {
 	send := &fakeSender{reply: Reply{Content: "hi from agent", Model: "m", StopReason: "end_turn"}}
@@ -1892,13 +1901,45 @@ func TestAgent_GenerateTitle_NotConfigured(t *testing.T) {
 	}
 }
 
-// TestAgent_GenerateTitle_UsesLowEffortSenderWhenAvailable guards the actual
-// fix for a confirmed production failure: a session running reasoning_effort
-// "max" paid the model's full reasoning budget just to produce a 6-word
-// title, reliably exceeding the throwaway call's timeout. When the Sender
-// implements LowEffortSender, GenerateTitle must route through the
-// low-effort variant instead of the session's main sender.
-func TestAgent_GenerateTitle_UsesLowEffortSenderWhenAvailable(t *testing.T) {
+// TestAgent_GenerateTitle_UsesNoReasoningSenderWhenAvailable guards that title
+// generation disables reasoning outright when the sender supports it. A session
+// running reasoning_effort "max" would otherwise pay the model's full reasoning
+// budget just to produce a 6-word title, reliably exceeding the throwaway call's
+// timeout. GenerateTitle must prefer NoReasoning() over LowEffort().
+func TestAgent_GenerateTitle_UsesNoReasoningSenderWhenAvailable(t *testing.T) {
+	no := &fakeSender{reply: Reply{Content: "No reasoning title"}}
+	low := &fakeSender{reply: Reply{Content: "Low effort title"}}
+	main := &fakeNoReasoningSender{
+		fakeLowEffortSender: fakeLowEffortSender{fakeSender: fakeSender{reply: Reply{Content: "should not be used"}}, low: low},
+		noReasoning:         no,
+	}
+	a := New(main, "m")
+	a.History.Append(NewUserMessage("do X"))
+	a.History.Append(NewAssistantMessage("did X"))
+
+	title, err := a.GenerateTitle(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GenerateTitle: %v", err)
+	}
+	if title != "No reasoning title" {
+		t.Errorf("title = %q, want the no-reasoning sender's reply", title)
+	}
+	if len(main.gotMessages) != 0 {
+		t.Errorf("main sender should not have been called; got %d messages", len(main.gotMessages))
+	}
+	if len(no.gotMessages) == 0 {
+		t.Error("no-reasoning sender was never called")
+	}
+	if len(low.gotMessages) != 0 {
+		t.Errorf("low-effort sender should not have been called when NoReasoning is available; got %d messages", len(low.gotMessages))
+	}
+}
+
+// TestAgent_GenerateTitle_FallsBackToLowEffortSenderWhenNoReasoningUnavailable
+// guards the fallback path: if a sender implements LowEffortSender but not
+// NoReasoningSender, GenerateTitle still uses LowEffort() to avoid paying the
+// session's full reasoning budget.
+func TestAgent_GenerateTitle_FallsBackToLowEffortSenderWhenNoReasoningUnavailable(t *testing.T) {
 	low := &fakeSender{reply: Reply{Content: "Low effort title"}}
 	main := &fakeLowEffortSender{
 		fakeSender: fakeSender{reply: Reply{Content: "should not be used"}},

--- a/internal/app/sender.go
+++ b/internal/app/sender.go
@@ -195,6 +195,16 @@ func (s sender) LowEffort() agent.Sender {
 	return s
 }
 
+// NoReasoning implements agent.NoReasoningSender: it returns a copy of s with
+// reasoning disabled entirely (empty effort / zero thinking budget). Used by
+// GenerateTitle because a 6-word title needs no reasoning and even "low"
+// reasoning can consume the tight title token budget or time out.
+func (s sender) NoReasoning() agent.Sender {
+	s.reasoningEffort = ""
+	s.thinkingBudget = 0
+	return s
+}
+
 // reasoningSink returns the OnThinking callback to hand the provider: the
 // agent's onThinking when reasoning display is enabled, else nil so the
 // provider skips surfacing reasoning entirely.

--- a/internal/app/sender_test.go
+++ b/internal/app/sender_test.go
@@ -72,12 +72,12 @@ func TestNewSender_DerivesThinkingBudgetFromEffort(t *testing.T) {
 
 // TestSender_LowEffort_CapsReasoningRegardlessOfOriginal guards the fix for a
 // confirmed production failure: a session running reasoning_effort "max" paid
-// the model's full reasoning budget for GenerateTitle/Suggest's throwaway
-// calls, reliably exceeding their timeout. sender.LowEffort() must always cap
-// to "low" — never inherit whatever the session was actually configured
-// with — and must leave the original sender (and its caller-visible
-// reasoningEffort/thinkingBudget) untouched, since it's a value receiver
-// returning a modified copy, not a mutation.
+// the model's full reasoning budget for Suggest's throwaway call, reliably
+// exceeding its timeout. sender.LowEffort() must always cap to "low" — never
+// inherit whatever the session was actually configured with — and must leave
+// the original sender (and its caller-visible reasoningEffort/thinkingBudget)
+// untouched, since it's a value receiver returning a modified copy, not a
+// mutation.
 func TestSender_LowEffort_CapsReasoningRegardlessOfOriginal(t *testing.T) {
 	for _, original := range []string{"", "low", "medium", "high", "xhigh", "max"} {
 		t.Run("from "+original, func(t *testing.T) {
@@ -93,6 +93,35 @@ func TestSender_LowEffort_CapsReasoningRegardlessOfOriginal(t *testing.T) {
 			}
 			if want := AnthropicThinkingBudget("low"); fake.gotReq.ThinkingBudget != want {
 				t.Errorf("ThinkingBudget sent = %d, want %d", fake.gotReq.ThinkingBudget, want)
+			}
+
+			// The original sender must be unaffected (value receiver).
+			if s.reasoningEffort != original {
+				t.Errorf("original sender's reasoningEffort mutated: got %q, want %q", s.reasoningEffort, original)
+			}
+		})
+	}
+}
+
+// TestSender_NoReasoning_DisablesReasoningRegardlessOfOriginal guards
+// GenerateTitle's separate requirement: title generation needs no reasoning at
+// all, so NoReasoning() must always disable it outright regardless of the
+// session's configured effort, without mutating the original sender.
+func TestSender_NoReasoning_DisablesReasoningRegardlessOfOriginal(t *testing.T) {
+	for _, original := range []string{"", "low", "medium", "high", "xhigh", "max"} {
+		t.Run("from "+original, func(t *testing.T) {
+			fake := &mockProvider{reply: provider.Response{Content: "ok"}}
+			s := sender{p: fake, reasoningEffort: original, thinkingBudget: AnthropicThinkingBudget(original)}
+
+			no := s.NoReasoning()
+			if _, err := no.SendMessages(context.Background(), "m", "", []agent.Message{agent.NewUserMessage("hi")}, 0); err != nil {
+				t.Fatalf("SendMessages: %v", err)
+			}
+			if fake.gotReq.ReasoningEffort != "" {
+				t.Errorf("ReasoningEffort sent = %q, want %q (off)", fake.gotReq.ReasoningEffort, "")
+			}
+			if fake.gotReq.ThinkingBudget != 0 {
+				t.Errorf("ThinkingBudget sent = %d, want %d", fake.gotReq.ThinkingBudget, 0)
 			}
 
 			// The original sender must be unaffected (value receiver).


### PR DESCRIPTION
Sets titleMaxTokens to 250 (down from 1024) and makes LowEffortSender disable reasoning outright instead of capping it to "low". This keeps throwaway GenerateTitle/Suggest calls fast and avoids timeouts when the session model is configured with high reasoning effort.