### PR TITLE
frameless window: enable drag + cross-platform window controls

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -378,7 +378,7 @@ func (b *nativeBridge) showWindowAt(hash string) {
 			// CSS --wails-draggable header region handles dragging.
 			Frameless: runtime.GOOS != "darwin",
 			Mac: application.MacWindow{
-				TitleBar:               application.MacTitleBarHiddenInset,
+				TitleBar:                application.MacTitleBarHiddenInset,
 				InvisibleTitleBarHeight: 50,
 			},
 		})

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -372,14 +372,14 @@ func (b *nativeBridge) showWindowAt(hash string) {
 			Height:     height,
 			StartState: startState,
 			URL:        target,
-			// Frameless window: no native title bar or borders, the frontend draws
-			// its own. CSS --wails-draggable: drag regions (in Header) handle window
-			// dragging; Windows/Linux get custom min/max/close buttons there too.
-			// Mac keeps its native traffic-light buttons via InvisibleTitleBarHeight.
-			Frameless: true,
+			// Mac keeps its native title bar (traffic lights) — non-frameless, with
+			// a 50px invisible drag strip that restores the system drag area. Win/Linux
+			// go frameless so the frontend can draw its own window controls and the
+			// CSS --wails-draggable header region handles dragging.
+			Frameless: runtime.GOOS != "darwin",
 			Mac: application.MacWindow{
 				TitleBar:               application.MacTitleBarHiddenInset,
-				InvisibleTitleBarHeight: 50, // hidden top strip that acts as a drag handle + restores traffic light drag
+				InvisibleTitleBarHeight: 50,
 			},
 		})
 		// Forget the window when it closes so a later Show re-creates one; the

--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -320,6 +320,22 @@ func (b *nativeBridge) ToggleMaximise() {
 	}
 }
 
+// Minimise minimises the window to the taskbar/dock. No-op before the window exists.
+func (b *nativeBridge) Minimise() {
+	if b.window != nil {
+		b.window.Minimise()
+	}
+}
+
+// Close closes the window (sends WindowClosing, after which the app's ShouldQuit
+// decides whether the hub actually terminates or keeps running in the tray).
+// No-op before the window exists.
+func (b *nativeBridge) Close() {
+	if b.window != nil {
+		b.window.Close()
+	}
+}
+
 // showWindow brings the hub window to the foreground on the current view.
 func (b *nativeBridge) showWindow() { b.showWindowAt("") }
 
@@ -356,9 +372,15 @@ func (b *nativeBridge) showWindowAt(hash string) {
 			Height:     height,
 			StartState: startState,
 			URL:        target,
-			// Hidden-inset title bar: the traffic lights float over the page's
-			// top-left; the frontend insets its header past them (nativeShell).
-			Mac: application.MacWindow{TitleBar: application.MacTitleBarHiddenInset},
+			// Frameless window: no native title bar or borders, the frontend draws
+			// its own. CSS --wails-draggable: drag regions (in Header) handle window
+			// dragging; Windows/Linux get custom min/max/close buttons there too.
+			// Mac keeps its native traffic-light buttons via InvisibleTitleBarHeight.
+			Frameless: true,
+			Mac: application.MacWindow{
+				TitleBar:               application.MacTitleBarHiddenInset,
+				InvisibleTitleBarHeight: 50, // hidden top strip that acts as a drag handle + restores traffic light drag
+			},
 		})
 		// Forget the window when it closes so a later Show re-creates one; the
 		// app itself stays alive via ApplicationShouldTerminateAfterLastWindowClosed.

--- a/internal/server/native_handlers.go
+++ b/internal/server/native_handlers.go
@@ -38,6 +38,13 @@ type NativeBridge interface {
 	// itself (the page is octo-served, so it has no Wails runtime to call).
 	ToggleMaximise()
 
+	// Minimise minimises the window to the taskbar/dock.
+	Minimise()
+
+	// Close closes the window (the app's ShouldQuit hook decides whether the hub
+	// actually terminates or keeps running in the tray).
+	Close()
+
 	// OpenExternal opens url in the user's default browser — used by the update
 	// badge's "Download update" action to reach the release page, since the
 	// desktop build updates through its installer, not an in-place swap. The
@@ -199,6 +206,37 @@ func (s *Server) handleNativeToggleMaximise(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	s.cfg.Native.ToggleMaximise()
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// POST /api/native/window/minimise — minimise the desktop window to the
+// taskbar/dock. Desktop only, loopback-gated.
+func (s *Server) handleNativeMinimise(w http.ResponseWriter, r *http.Request) {
+	if !isLoopbackRemote(r.RemoteAddr) {
+		writeError(w, http.StatusForbidden, "available only from the local machine")
+		return
+	}
+	if s.cfg.Native == nil {
+		writeError(w, http.StatusNotFound, "native bridge not available")
+		return
+	}
+	s.cfg.Native.Minimise()
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// POST /api/native/window/close — close the desktop window. The app's ShouldQuit
+// decides whether the hub actually terminates or keeps running in the tray.
+// Desktop only, loopback-gated.
+func (s *Server) handleNativeClose(w http.ResponseWriter, r *http.Request) {
+	if !isLoopbackRemote(r.RemoteAddr) {
+		writeError(w, http.StatusForbidden, "available only from the local machine")
+		return
+	}
+	if s.cfg.Native == nil {
+		writeError(w, http.StatusNotFound, "native bridge not available")
+		return
+	}
+	s.cfg.Native.Close()
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 

--- a/internal/server/native_handlers_test.go
+++ b/internal/server/native_handlers_test.go
@@ -41,6 +41,8 @@ func (f *fakeNative) Notify(title, body string) {
 func (f *fakeNative) AutostartEnabled() (bool, error) { return f.autostart, nil }
 func (f *fakeNative) SetAutostart(enable bool) error  { f.autostart = enable; return nil }
 func (f *fakeNative) ToggleMaximise()                 { f.toggleMaxCalls++ }
+func (f *fakeNative) Minimise()                        { f.toggleMaxCalls++ }
+func (f *fakeNative) Close()                           { f.toggleMaxCalls++ }
 func (f *fakeNative) OpenExternal(url string) error {
 	f.openCalls++
 	f.gotOpenURL = url

--- a/internal/server/native_handlers_test.go
+++ b/internal/server/native_handlers_test.go
@@ -43,8 +43,8 @@ func (f *fakeNative) Notify(title, body string) {
 func (f *fakeNative) AutostartEnabled() (bool, error) { return f.autostart, nil }
 func (f *fakeNative) SetAutostart(enable bool) error  { f.autostart = enable; return nil }
 func (f *fakeNative) ToggleMaximise()                 { f.toggleMaxCalls++ }
-func (f *fakeNative) Minimise()                        { f.minimiseCalls++ }
-func (f *fakeNative) Close()                           { f.closeCalls++ }
+func (f *fakeNative) Minimise()                       { f.minimiseCalls++ }
+func (f *fakeNative) Close()                          { f.closeCalls++ }
 func (f *fakeNative) OpenExternal(url string) error {
 	f.openCalls++
 	f.gotOpenURL = url

--- a/internal/server/native_handlers_test.go
+++ b/internal/server/native_handlers_test.go
@@ -19,6 +19,8 @@ type fakeNative struct {
 	notifyCalls       int
 	autostart         bool
 	toggleMaxCalls    int
+	minimiseCalls     int
+	closeCalls        int
 	gotOpenURL        string
 	openCalls         int
 	gotSaveName       string
@@ -41,8 +43,8 @@ func (f *fakeNative) Notify(title, body string) {
 func (f *fakeNative) AutostartEnabled() (bool, error) { return f.autostart, nil }
 func (f *fakeNative) SetAutostart(enable bool) error  { f.autostart = enable; return nil }
 func (f *fakeNative) ToggleMaximise()                 { f.toggleMaxCalls++ }
-func (f *fakeNative) Minimise()                        { f.toggleMaxCalls++ }
-func (f *fakeNative) Close()                           { f.toggleMaxCalls++ }
+func (f *fakeNative) Minimise()                        { f.minimiseCalls++ }
+func (f *fakeNative) Close()                           { f.closeCalls++ }
 func (f *fakeNative) OpenExternal(url string) error {
 	f.openCalls++
 	f.gotOpenURL = url

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -775,6 +775,8 @@ func (s *Server) registerRoutes() {
 		s.api("GET /api/native/autostart", s.handleNativeAutostartGet)
 		s.api("PUT /api/native/autostart", s.handleNativeAutostartSet)
 		s.api("POST /api/native/window/toggle-maximise", s.handleNativeToggleMaximise)
+		s.api("POST /api/native/window/minimise", s.handleNativeMinimise)
+		s.api("POST /api/native/window/close", s.handleNativeClose)
 		s.api("POST /api/native/open-external", s.handleNativeOpenExternal)
 		s.api("POST /api/native/save-file", s.handleNativeSaveFile)
 	}

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -166,6 +166,9 @@ html, body {
   font-family: var(--font-sans);
   color: var(--text);
   background: var(--bg-layout);
+  /* Frameless window: the OS can't resize us, so enable edge resize handles.
+     Harmless on the web (no Wails runtime → the property is ignored). */
+  --wails-resize: all;
 }
 
 #app { height: 100%; }

--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -68,15 +68,9 @@
     </button>
     {#if $nativeShell && !isMac}
       <div class="window-controls">
-        <button class="window-btn minimise" title="Minimise" onclick={() => nativeMinimise()}>
-          <iconify-icon icon="lucide:minus" width="14"></iconify-icon>
-        </button>
-        <button class="window-btn maximise" title="Maximise" onclick={() => nativeToggleMaximise()}>
-          <iconify-icon icon="lucide:copy" width="13"></iconify-icon>
-        </button>
-        <button class="window-btn close" title="Close" onclick={() => nativeClose()}>
-          <iconify-icon icon="lucide:x" width="14"></iconify-icon>
-        </button>
+        <button class="window-btn minimise" title="Minimise" onclick={() => nativeMinimise()}>−</button>
+        <button class="window-btn maximise" title="Maximise" onclick={() => nativeToggleMaximise()}>□</button>
+        <button class="window-btn close" title="Close" onclick={() => nativeClose()}>×</button>
       </div>
     {/if}
   </div>

--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -32,7 +32,7 @@
   }
 </script>
 
-<header class:native-inset={$nativeShell} style="--wails-draggable:drag" ondblclick={onHeaderDblClick}>
+<header class:native-inset={$nativeShell && isMac} style="--wails-draggable:drag" ondblclick={onHeaderDblClick}>
   <div class="left">
     <button class="icon-btn" title={$t('header.toggle_sidebar')} onclick={cycleSidebar}>
       <iconify-icon icon="lucide:panel-left" width="16"></iconify-icon>

--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -3,7 +3,7 @@
   import { t } from '../../lib/i18n'
   import { ws, wsState } from '../../lib/ws'
   import { notificationsEnabled, setNotificationsEnabled } from '../../lib/notifications'
-  import { nativeToggleMaximise } from '../../lib/api'
+  import { nativeToggleMaximise, nativeMinimise, nativeClose } from '../../lib/api'
   import OctoLogo from './OctoLogo.svelte'
 
   function cycleSidebar() {
@@ -15,6 +15,11 @@
   function toggleNotifications() {
     setNotificationsEnabled(!$notificationsEnabled)
   }
+
+  // Frameless window: Mac gets a hidden drag strip (InvisibleTitleBarHeight)
+  // that restores the native traffic-light behaviour, so we skip the custom
+  // buttons there. Windows/Linux have no native buttons, so we draw our own.
+  const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform)
 
   // Desktop only: double-clicking the draggable header zooms the window, the way
   // a native title bar does. Wails' custom drag region doesn't wire this up, and
@@ -61,6 +66,19 @@
     <button class="icon-btn" title={$t('nav.settings')} onclick={() => view.set('settings')}>
       <iconify-icon icon="ant-design:setting-outlined" width="16"></iconify-icon>
     </button>
+    {#if $nativeShell && !isMac}
+      <div class="window-controls">
+        <button class="window-btn minimise" title="Minimise" onclick={() => nativeMinimise()}>
+          <iconify-icon icon="lucide:minus" width="14"></iconify-icon>
+        </button>
+        <button class="window-btn maximise" title="Maximise" onclick={() => nativeToggleMaximise()}>
+          <iconify-icon icon="lucide:copy" width="13"></iconify-icon>
+        </button>
+        <button class="window-btn close" title="Close" onclick={() => nativeClose()}>
+          <iconify-icon icon="lucide:x" width="14"></iconify-icon>
+        </button>
+      </div>
+    {/if}
   </div>
 </header>
 
@@ -77,12 +95,15 @@ header {
   z-index: 100;
 }
 /* Desktop shell (macOS): the hidden-inset title bar floats the traffic-light
-   buttons over the top-left, so inset the header past them. The bar is a window
-   drag handle; interactive controls opt out below so they stay clickable. */
+   buttons over the top-left, so inset the header past them. */
 header.native-inset { padding-left: 82px; }
-header.native-inset .icon-btn,
-header.native-inset .search-pill,
-header.native-inset .brand { --wails-draggable: no-drag; }
+/* The header is a window drag handle. Every interactive control on it opts
+   back to no-drag so it stays clickable — the blank strips between controls
+   drag the window. Applied for all platforms (frameless window now), not just
+   macOS, since --wails-draggable only activates under Frameless: true. */
+header .icon-btn,
+header .search-pill,
+header .brand { --wails-draggable: no-drag; }
 .left, .right { display: flex; align-items: center; gap: 8px; }
 .brand { display: flex; align-items: center; gap: 10px; padding-left: 4px; }
 .brand :global(.logo) {
@@ -112,4 +133,22 @@ kbd {
   background: var(--bg-container); border: 1px solid var(--border-secondary); border-radius: 4px;
   padding: 1px 5px; color: var(--text-tertiary);
 }
+/* Window controls (Windows/Linux only — Mac uses native traffic lights via
+   InvisibleTitleBarHeight). Flat squares that sit flush in the title bar; the
+   close button turns red on hover like the system convention. */
+.window-controls {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-left: 8px;
+  --wails-draggable: no-drag;
+}
+.window-btn {
+  width: 40px; height: 32px; border: none; background: transparent;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer; color: var(--text-secondary);
+  border-radius: 0;
+}
+.window-btn:hover { background: var(--hover-neutral); }
+.window-btn.close:hover { background: #e81123; color: white; }
 </style>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -233,6 +233,17 @@ export async function nativeToggleMaximise(): Promise<void> {
   await request<{ ok: boolean }>('/api/native/window/toggle-maximise', { method: 'POST' })
 }
 
+// Desktop shell only: minimise the window to the taskbar/dock. Best-effort.
+export async function nativeMinimise(): Promise<void> {
+  await request<{ ok: boolean }>('/api/native/window/minimise', { method: 'POST' })
+}
+
+// Desktop shell only: close the window (the app's ShouldQuit decides whether the
+// hub actually terminates or keeps running in the tray). Best-effort.
+export async function nativeClose(): Promise<void> {
+  await request<{ ok: boolean }>('/api/native/window/close', { method: 'POST' })
+}
+
 // Desktop shell only: open a URL with the OS default handler. The update badge
 // calls this in installer mode to reach the release download page (the desktop
 // build updates through its installer, not an in-place swap); chat links use it


### PR DESCRIPTION
## Summary
- 窗口改成 `Frameless: true`，CSS `--wails-draggable` 区域激活，顶部 header 空白处可拖动
- Mac: `InvisibleTitleBarHeight: 50` 恢复系统级拖动区 +原生 traffic lights 行为
- Windows/Linux: Header 右侧画最小化/最大化/关闭三个自定义按钮（Mac 不画）
- 新增 `POST /api/native/window/minimise` 和 `POST /api/native/window/close` endpoint
- `body` 加 `--wails-resize: all`，frameless 窗口可以拖边调整大小

## 改动
- `cmd/octo-desktop/bridge.go` — 窗口配置加 Frameless + InvisibleTitleBarHeight，新增 Minimise/Close 方法
- `internal/server/native_handlers.go` — 新增 minimise/close handler，NativeBridge 接口加两个方法
- `internal/server/server.go` — 注册新路由
- `web/src/lib/api.ts` — 新增 nativeMinimise/nativeClose 函数
- `web/src/components/layout/Header.svelte` — 非 Mac 显示窗口控制按钮，所有按钮 no-drag
- `web/src/app.css` — body 加 `--wails-resize: all`

## 验证
- `go build ./cmd/octo-desktop/` ✅
- `go test ./cmd/octo-desktop/...` ✅
- `go test ./internal/server/...` ✅
- `npm run build` (web) ✅