### PR TITLE
fix: desktop notification click jumps to the target session

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -230,6 +230,23 @@ func (b *nativeBridge) Notify(title, body string) {
 	})
 }
 
+// NotifySession raises an OS-native notification that, when clicked, brings the
+// user to the given session. The session ID travels in the notification's Data
+// payload and is echoed back as UserInfo in the platform response handler.
+func (b *nativeBridge) NotifySession(title, body, sessionID string) {
+	if b.notifier == nil {
+		return
+	}
+	_ = b.notifier.SendNotification(notifications.NotificationOptions{
+		ID:    fmt.Sprintf("octo-notify-%d", b.notifySeq.Add(1)),
+		Title: title,
+		Body:  body,
+		Data: map[string]any{
+			"session_id": sessionID,
+		},
+	})
+}
+
 // requestNotificationAuthorization asks the OS for permission to post
 // notifications, without which every Notify call silently no-ops. macOS
 // requires this at runtime: UNUserNotificationCenter drops delivery (reporting

--- a/cmd/octo-desktop/main.go
+++ b/cmd/octo-desktop/main.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"log/slog"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -194,10 +195,10 @@ func main() {
 	bridge.app = app
 
 	// Interacting with the "update available" toast opens the download page;
-	// every other notification raises the window. Match the category (which all
-	// three platform notifiers echo back) and then only the "Open" action or a
-	// tap on the body — so dismissing the toast, whatever identifier a platform
-	// reports for that, never opens a browser.
+	// session notifications focus and route to the relevant session; every other
+	// notification just raises the window. Match the category (which all three
+	// platform notifiers echo back) and then only the "Open" action or a tap
+	// on the body — so dismissing the toast never triggers an action.
 	if bridge.notifier != nil {
 		bridge.notifier.OnNotificationResponse(func(res notifications.NotificationResult) {
 			if res.Response.CategoryID == updateNotifyCategoryID {
@@ -205,6 +206,10 @@ func main() {
 				case updateNotifyOpenActionID, notifications.DefaultActionIdentifier:
 					_ = bridge.OpenExternal(upgrade.DownloadPageURL)
 				}
+				return
+			}
+			if sid, ok := res.Response.UserInfo["session_id"].(string); ok && sid != "" {
+				bridge.showWindowAt("chat/" + url.PathEscape(sid))
 				return
 			}
 			bridge.showWindow()

--- a/internal/server/native_handlers.go
+++ b/internal/server/native_handlers.go
@@ -28,6 +28,10 @@ type NativeBridge interface {
 	// own failures; callers don't handle an error.
 	Notify(title, body string)
 
+	// NotifySession raises an OS-native notification that, when clicked, focuses
+	// the app and navigates to the given session. Best-effort like Notify.
+	NotifySession(title, body, sessionID string)
+
 	// AutostartEnabled reports whether the app is registered to launch at login.
 	AutostartEnabled() (bool, error)
 	// SetAutostart registers (enable) or unregisters the app from launch-at-login.
@@ -124,14 +128,17 @@ func (s *Server) handleNativePickFile(w http.ResponseWriter, r *http.Request) {
 }
 
 type nativeNotifyRequest struct {
-	Title string `json:"title"`
-	Body  string `json:"body"`
+	Title     string `json:"title"`
+	Body      string `json:"body"`
+	SessionID string `json:"session_id"`
 }
 
 // POST /api/native/notify — raise an OS-native notification (desktop only).
 // The frontend calls this in desktop mode instead of the browser Notification
-// API, which native webviews don't implement. Best-effort: it always returns
-// ok; the bridge swallows delivery failures. Registered only with a bridge.
+// API, which native webviews don't implement. When session_id is present, the
+// desktop shell routes a click on that notification to the specified session.
+// Best-effort: it always returns ok; the bridge swallows delivery failures.
+// Registered only with a bridge.
 func (s *Server) handleNativeNotify(w http.ResponseWriter, r *http.Request) {
 	if !isLoopbackRemote(r.RemoteAddr) {
 		writeError(w, http.StatusForbidden, "native notifications are available only from the local machine")
@@ -146,7 +153,11 @@ func (s *Server) handleNativeNotify(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	s.cfg.Native.Notify(req.Title, req.Body)
+	if req.SessionID != "" {
+		s.cfg.Native.NotifySession(req.Title, req.Body, req.SessionID)
+	} else {
+		s.cfg.Native.Notify(req.Title, req.Body)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 

--- a/internal/server/native_handlers_test.go
+++ b/internal/server/native_handlers_test.go
@@ -12,20 +12,22 @@ import (
 
 // fakeNative records what it was asked and returns canned results.
 type fakeNative struct {
-	gotStartDir       string
-	retPath           string
-	retCancel         bool
-	gotTitle, gotBody string
-	notifyCalls       int
-	autostart         bool
-	toggleMaxCalls    int
-	minimiseCalls     int
-	closeCalls        int
-	gotOpenURL        string
-	openCalls         int
-	gotSaveName       string
-	gotSaveContent    string
-	saveCalls         int
+	gotStartDir        string
+	retPath            string
+	retCancel          bool
+	gotTitle, gotBody  string
+	notifyCalls        int
+	gotSessionID       string
+	notifySessionCalls int
+	autostart          bool
+	toggleMaxCalls     int
+	minimiseCalls      int
+	closeCalls         int
+	gotOpenURL         string
+	openCalls          int
+	gotSaveName        string
+	gotSaveContent     string
+	saveCalls          int
 }
 
 func (f *fakeNative) PickFolder(_ context.Context, startDir string) (string, bool, error) {
@@ -39,6 +41,11 @@ func (f *fakeNative) PickFile(_ context.Context, startDir string) (string, bool,
 func (f *fakeNative) Notify(title, body string) {
 	f.notifyCalls++
 	f.gotTitle, f.gotBody = title, body
+}
+func (f *fakeNative) NotifySession(title, body, sessionID string) {
+	f.notifySessionCalls++
+	f.gotTitle, f.gotBody = title, body
+	f.gotSessionID = sessionID
 }
 func (f *fakeNative) AutostartEnabled() (bool, error) { return f.autostart, nil }
 func (f *fakeNative) SetAutostart(enable bool) error  { f.autostart = enable; return nil }
@@ -134,6 +141,29 @@ func TestNativeNotifyDelegatesToBridge(t *testing.T) {
 	}
 	if fake.notifyCalls != 1 || fake.gotTitle != "Done" || fake.gotBody != "turn complete" {
 		t.Errorf("bridge.Notify got calls=%d title=%q body=%q, want 1/Done/turn complete", fake.notifyCalls, fake.gotTitle, fake.gotBody)
+	}
+}
+
+func TestNativeNotifyRoutesToNotifySessionWhenSessionIDPresent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	fake := &fakeNative{}
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Native: fake})
+	req := httptest.NewRequest(http.MethodPost, "/api/native/notify", strings.NewReader(`{"title":"Question","body":"needs input","session_id":"sess-123"}`))
+	w := httptest.NewRecorder()
+	serveLoopback(srv.mux, w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 (%s)", w.Code, w.Body.String())
+	}
+	if fake.notifyCalls != 0 {
+		t.Errorf("bridge.Notify calls = %d, want 0 (NotifySession should be used)", fake.notifyCalls)
+	}
+	if fake.notifySessionCalls != 1 || fake.gotTitle != "Question" || fake.gotBody != "needs input" || fake.gotSessionID != "sess-123" {
+		t.Errorf("bridge.NotifySession got calls=%d title=%q body=%q sessionID=%q, want 1/Question/needs input/sess-123",
+			fake.notifySessionCalls, fake.gotTitle, fake.gotBody, fake.gotSessionID)
 	}
 }
 
@@ -282,7 +312,6 @@ func TestNativeOpenExternalRejectsDisallowedScheme(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/api/native/open-external", strings.NewReader(`{"url":"`+link+`"}`))
 		w := httptest.NewRecorder()
 		serveLoopback(srv.mux, w, req)
-
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("%s: got %d, want 400", link, w.Code)
 		}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -269,9 +269,9 @@ import ArtifactModal from './components/ArtifactModal.svelte'
     const title = tr(titleKey)
     const body = tr(bodyKey).replace('{name}', escapedName)
     if (native) {
-      // No click-to-focus yet (would need a native notification callback); the
-      // tray/dock and single-instance focus cover raising the window.
-      api.nativeNotify(title, body).catch(() => {})
+      // The native notification carries this session id so the desktop shell
+      // routes to it on click. Browser path handles the click in-page below.
+      api.nativeNotify(title, body, sid).catch(() => {})
       return
     }
     const n = new Notification(title, { body })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -219,10 +219,12 @@ export async function nativeSaveBinary(name: string, b64: string): Promise<{ pat
 
 // Desktop shell only: raise an OS-native notification. Used in place of the
 // browser Notification API, which native webviews don't implement. Best-effort.
-export async function nativeNotify(title: string, body: string): Promise<void> {
+// When sessionId is provided, clicking the notification focuses the app and
+// jumps to that session.
+export async function nativeNotify(title: string, body: string, sessionId?: string): Promise<void> {
   await request<{ ok: boolean }>('/api/native/notify', {
     method: 'POST',
-    ...json({ title, body }),
+    ...json({ title, body, session_id: sessionId }),
   })
 }
 


### PR DESCRIPTION
Session notifications in the desktop build now carry the session ID. When the user clicks the OS notification, the desktop bridge routes the window to #chat/{sessionID} instead of only raising the current session.