### PR TITLE
fix(browser): use in-memory password store to avoid macOS keychain prompt

### DIFF
--- a/internal/browser/chrome.go
+++ b/internal/browser/chrome.go
@@ -167,6 +167,12 @@ func launchChrome(ctx context.Context, opts LaunchOptions) (*exec.Cmd, string, e
 		"--no-first-run",
 		"--no-default-browser-check",
 		"--disable-gpu",
+		// Use an in-memory password store instead of the OS keychain. The
+		// browser runs on a throwaway profile and never needs real secrets;
+		// touching the OS keychain otherwise pops a blocking "cannot find
+		// keychain" dialog on macOS on every launch.
+		"--password-store=basic",
+		"--use-mock-keychain",
 		"about:blank",
 	}
 	if opts.Headless {


### PR DESCRIPTION
## Problem

The browser tool launches Chrome on a throwaway temp profile (`octo-chrome-*`) that never needs real secrets. But Chrome still reaches for the OS keychain on every launch to unlock its **Chrome Safe Storage** key. On macOS this pops a blocking **"cannot find the keychain used to store Chrome"** dialog on *every* launch.

This is especially noisy during test runs — e.g. `TestBrowserTool_SearchDownloadFlow` spawns headless Chrome repeatedly, firing the dialog each time. It also leaves orphaned headless Chrome processes that share the Google Chrome app bundle, which confuses macOS LaunchServices into thinking Chrome is "already running" so the user's normal Chrome won't open a window.

## Fix

Add two launch flags in `internal/browser/chrome.go`:

- `--password-store=basic` — use the in-memory password store instead of the OS keychain (macOS Keychain / Linux kwallet / gnome-keyring).
- `--use-mock-keychain` — macOS-specific; force a mock keychain so the real keychain is never touched even for reads.

Both are standard flags for automation/headless Chrome running on disposable profiles.

## Verification

- `gofmt -l`, `go vet ./internal/browser/`, `go build ./internal/browser/` clean.
- `go test ./internal/browser/ -run 'TestPrimitives|TestSearchThenDownload'` passes — Chrome still launches and connects to CDP with the new flags, and no keychain dialog appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)