### PR TITLE
fix(browser): discard stale WebSocket and rebuild on probe failure

### DIFF
--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -252,7 +252,23 @@ func browserPage(ctx context.Context) (*browser.Page, *browser.Browser, error) {
 			browserSession.page = page
 			return page, browserSession.b, nil
 		}
-		go closeSession(browserSession.b, nil)
+		// Probe failed — the browser-level WebSocket is dead (Chrome was restarted
+		// or crashed). Close it and fall through to a fresh ConnectByPort below:
+		// the new dial must happen on a clean socket, otherwise it can land on the
+		// stale Chrome still bound to the port (bad handshake, no authorization
+		// prompt — the exact "no prompt after restart" bug this guards against).
+		// Passing page=nil skips the (dead) tab close and just drops the WS.
+		// concurrent close so a Chrome that never answers the close frame can't
+		// stall the reconnect — wait up to 3s for it to finish, then move on.
+		closeDone := make(chan struct{})
+		go func() {
+			closeSession(browserSession.b, nil)
+			close(closeDone)
+		}()
+		select {
+		case <-closeDone:
+		case <-time.After(3 * time.Second):
+		}
 		browserSession.b = nil
 	}
 	cfg, _ := config.Load()


### PR DESCRIPTION
## Problem

When Chrome is restarted, the cached `browserSession.b` holds a dead WebSocket. The probe (`NewPage` with 3s timeout) detects this, but the old `closeSession` ran async (`go closeSession`), racing the new dial against the old socket's teardown. This lands on a stale Chrome still bound to the port, producing "bad handshake" with no authorization prompt — the user-visible symptom is "Chrome重启后 agent 连不上、不弹授权".

## Fix

In `browserPage`'s probe-failure path (`internal/tools/browser.go:255`), close the dead session concurrently but wait up to 3s for it to finish before falling through to `ConnectByPort`. This:

1. Guarantees the old socket is torn down before the new dial (no race)
2. Bounds the wait so a Chrome that never answers the close frame can't stall the reconnect indefinitely

## Verification

- `go build ./internal/tools/ ./internal/browser/` ✅
- `go test ./internal/browser/ -count=1` ✅ all pass
- `go test ./internal/tools/ -run Browser -count=1` ✅ pass (timing variability is pre-existing headless Chrome flake, unrelated)
