### PR TITLE
fix(tui): remove duplicate title from desktop notification

### DIFF
--- a/cmd/octo/termnotify_test.go
+++ b/cmd/octo/termnotify_test.go
@@ -63,3 +63,19 @@ func TestNotifySeq(t *testing.T) {
 		}
 	}
 }
+
+// TestNotifySeqEmptyTitle verifies that passing an empty title doesn't
+// produce malformed OSC sequences, and that Ghostty skips the title slot
+// so the tab title (OSC 2) and notification title don't duplicate.
+func TestNotifySeqEmptyTitle(t *testing.T) {
+	term := os.Getenv("TERM_PROGRAM")
+	defer os.Setenv("TERM_PROGRAM", term)
+
+	// Ghostty: empty title after "notify;" separator is safe to ignore.
+	os.Setenv("TERM_PROGRAM", "ghostty")
+	got := notifySeq("", "Turn complete")
+	want := "\033]777;notify;;Turn complete\007"
+	if got != want {
+		t.Errorf("ghostty empty title: got %q, want %q", got, want)
+	}
+}

--- a/cmd/octo/termnotify_test.go
+++ b/cmd/octo/termnotify_test.go
@@ -63,19 +63,3 @@ func TestNotifySeq(t *testing.T) {
 		}
 	}
 }
-
-// TestNotifySeqEmptyTitle verifies that passing an empty title doesn't
-// produce malformed OSC sequences, and that Ghostty skips the title slot
-// so the tab title (OSC 2) and notification title don't duplicate.
-func TestNotifySeqEmptyTitle(t *testing.T) {
-	term := os.Getenv("TERM_PROGRAM")
-	defer os.Setenv("TERM_PROGRAM", term)
-
-	// Ghostty: empty title after "notify;" separator is safe to ignore.
-	os.Setenv("TERM_PROGRAM", "ghostty")
-	got := notifySeq("", "Turn complete")
-	want := "\033]777;notify;;Turn complete\007"
-	if got != want {
-		t.Errorf("ghostty empty title: got %q, want %q", got, want)
-	}
-}

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -2162,11 +2162,10 @@ func (m *tuiModel) handleTurnFinished(err error) (tea.Model, tea.Cmd) {
 	// fire a desktop notification so a user who tabbed away is pulled back.
 	// Skipped on error / interrupt (err != nil) and when the user disabled it.
 	if err == nil && m.cfg.notify {
-		// Empty title: Ghostty renders both the OSC 2 tab title and the
-		// OSC 777 notification title as visible text, so passing the
-		// session title here duplicates it. Other terminals (iTerm2,
-		// Kitty, WezTerm) ignore the title slot entirely.
-		return m, tea.Sequence(m.flushPrints(), tea.Println(notifySeq("", "Turn complete — input needed")))
+		// Terminal bell (BEL): Ghostty shows a notification tied to the
+		// sending tab and clicking it focuses that specific tab. This is
+		// simpler than OSC 777 and gives us click-to-focus-tab for free.
+		return m, tea.Sequence(m.flushPrints(), tea.Println("\007"))
 	}
 	return m, nil
 }

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -2162,7 +2162,7 @@ func (m *tuiModel) handleTurnFinished(err error) (tea.Model, tea.Cmd) {
 	// fire a desktop notification so a user who tabbed away is pulled back.
 	// Skipped on error / interrupt (err != nil) and when the user disabled it.
 	if err == nil && m.cfg.notify {
-		return m, tea.Sequence(m.flushPrints(), tea.Println(notifySeq(m.cfg.session.DisplayTitle(), "Turn complete — input needed")))
+		return m, tea.Sequence(m.flushPrints(), tea.Println(notifySeq("", "Turn complete — input needed")))
 	}
 	return m, nil
 }

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -2162,6 +2162,10 @@ func (m *tuiModel) handleTurnFinished(err error) (tea.Model, tea.Cmd) {
 	// fire a desktop notification so a user who tabbed away is pulled back.
 	// Skipped on error / interrupt (err != nil) and when the user disabled it.
 	if err == nil && m.cfg.notify {
+		// Empty title: Ghostty renders both the OSC 2 tab title and the
+		// OSC 777 notification title as visible text, so passing the
+		// session title here duplicates it. Other terminals (iTerm2,
+		// Kitty, WezTerm) ignore the title slot entirely.
 		return m, tea.Sequence(m.flushPrints(), tea.Println(notifySeq("", "Turn complete — input needed")))
 	}
 	return m, nil

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -2162,10 +2162,12 @@ func (m *tuiModel) handleTurnFinished(err error) (tea.Model, tea.Cmd) {
 	// fire a desktop notification so a user who tabbed away is pulled back.
 	// Skipped on error / interrupt (err != nil) and when the user disabled it.
 	if err == nil && m.cfg.notify {
-		// Terminal bell (BEL): Ghostty shows a notification tied to the
-		// sending tab and clicking it focuses that specific tab. This is
-		// simpler than OSC 777 and gives us click-to-focus-tab for free.
-		return m, tea.Sequence(m.flushPrints(), tea.Println("\007"))
+		// OSC 777 with empty title: Ghostty renders both the OSC 2 tab
+		// title and the OSC 777 notification title as visible text, so
+		// passing the session title here duplicates it. Empty title shows
+		// only the body. Other terminals (iTerm2, Kitty, WezTerm) ignore
+		// the title slot entirely.
+		return m, tea.Sequence(m.flushPrints(), tea.Println(notifySeq("", "Turn complete — input needed")))
 	}
 	return m, nil
 }


### PR DESCRIPTION
## Problem

Ghostty renders the OSC 777 desktop notification with both the terminal tab title (OSC 2) and the notification title (OSC 777) as separate lines, causing the session title to appear twice in the notification popup.

## Fix

Pass an empty title to notifySeq so the notification only shows the body text.

Now the notification shows a single line: Turn complete — input needed