### PR TITLE
fix(desktop): window minimise geometry, textarea height, double-click maximise

### DIFF
--- a/cmd/octo-desktop/bridge.go
+++ b/cmd/octo-desktop/bridge.go
@@ -110,18 +110,20 @@ func shellURL(base, hash string) string {
 // false/0×0 and would clobber the freshly-saved state. The window methods are
 // read before taking the lock (they marshal to the UI thread; holding
 // settingsMu across that could deadlock the main thread). Size is recorded only
-// while neither maximised nor fullscreen — both report a size that isn't the
-// windowed size, so persisting it would corrupt the restore size a relaunch
-// un-maximises back to.
+// while neither maximised, fullscreen, nor minimised — maximised/fullscreen
+// report a size that isn't the windowed size, and on Windows a minimised window
+// reports its taskbar-button size (≈160×28); persisting any of these would
+// corrupt the restore size a relaunch un-maximises back to.
 func (b *nativeBridge) rememberWindowGeometry(w *application.WebviewWindow) {
 	maximised := w.IsMaximised()
 	fullscreen := w.IsFullscreen()
+	minimised := w.IsMinimised()
 	width, height := w.Size()
 
 	b.settingsMu.Lock()
 	defer b.settingsMu.Unlock()
 	b.settings.WindowMaximised = maximised
-	if !maximised && !fullscreen && width > 0 && height > 0 {
+	if !maximised && !fullscreen && !minimised && width > 0 && height > 0 {
 		b.settings.WindowWidth = width
 		b.settings.WindowHeight = height
 	}

--- a/web/src/components/chat/Composer.svelte
+++ b/web/src/components/chat/Composer.svelte
@@ -67,12 +67,21 @@
   // Auto-grow the textarea with its content up to a max height, then scroll
   // inside (matches the max-height in CSS). The $effect re-runs on every text
   // change — typing, paste, send-clear, or programmatic setText.
+  //
+  // On Windows, setting height:'auto' then reading scrollHeight can return an
+  // inflated value (the drag strip + font metrics differ), blowing the textarea
+  // up to 5-6 lines on mount. Lock overflow to hidden while measuring so the
+  // scrollbar never contributes to scrollHeight, and floor the result to a
+  // single line so an empty box never opens tall.
   const MAX_TEXTAREA_PX = 200
+  const MIN_TEXTAREA_PX = 24 // ≈ one line: 14px * 1.6 line-height + padding
   function autoResize() {
     const el = textareaEl
     if (!el) return
+    el.style.overflow = 'hidden'
     el.style.height = 'auto'
-    el.style.height = Math.min(el.scrollHeight, MAX_TEXTAREA_PX) + 'px'
+    el.style.height = Math.min(Math.max(el.scrollHeight, MIN_TEXTAREA_PX), MAX_TEXTAREA_PX) + 'px'
+    el.style.overflow = ''
   }
   $effect(() => {
     text // track the bound value so the effect re-runs when it changes
@@ -1067,7 +1076,7 @@
 textarea {
   border: none; outline: none; resize: none; font-size: 14px; line-height: 1.6;
   font-family: inherit; color: var(--text); background: transparent; width: 100%;
-  max-height: 200px; overflow-y: auto;
+  max-height: 200px; overflow-y: auto; min-height: 24px; /* ≈ MIN_TEXTAREA_PX in autoResize */
 }
 .attachments { display: flex; flex-wrap: wrap; gap: 6px; }
 .attach-chip {

--- a/web/src/components/layout/Header.svelte
+++ b/web/src/components/layout/Header.svelte
@@ -23,11 +23,13 @@
   const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform)
 
   // Desktop only: double-clicking the draggable header zooms the window, the way
-  // a native title bar does. Wails' custom drag region doesn't wire this up, and
-  // the octo-served page can't call Wails directly, so it goes through the native
-  // bridge over HTTP. Ignore double-clicks that land on a control.
+  // a native title bar does. Wails' custom drag region (and the Mac hidden-inset
+  // drag strip) doesn't wire this up, and the octo-served page can't call Wails
+  // directly, so it goes through the native bridge over HTTP. Ignore double-clicks
+  // that land on a control. Applies to all platforms — Mac's InvisibleTitleBarHeight
+  // strip doesn't forward double-click events to the OS either, so we handle it.
   function onHeaderDblClick(e: MouseEvent) {
-    if (!$nativeShell || isMac) return
+    if (!$nativeShell) return
     if ((e.target as HTMLElement).closest('button, a, input, select, textarea')) return
     flipMaximise()
   }
@@ -171,8 +173,8 @@ kbd {
   display: flex;
   align-items: center;
   gap: 0;
-  margin-left: 16px;
-  padding-left: 16px;
+  margin-left: 8px;
+  padding-left: 8px;
   border-left: 1px solid var(--border-secondary);
   --wails-draggable: no-drag;
 }


### PR DESCRIPTION
## 改动

三个文件，四件事：

### 1. 窗口最小化不保存尺寸（bridge.go）

`rememberWindowGeometry` 只在非 maximised / 非 fullscreen 时保存窗口尺寸，但**没排除 minimised**。Windows 上最小化会触发 `WindowDidResize`，`Size()` 返回任务栏按钮大小（≈160×28），被当成了 restore size 持久化，下次打开窗口极小。

修复：加 `!minimised` 门卫。

### 2. Windows 输入框 5-6 行高（Composer.svelte）

`autoResize` 先设 `height: auto` 再读 `scrollHeight`。在 Windows 上这个组合返回异常大的值（`height: auto` 让浏览器忽略 `rows=1`，加上字体度量差异），空框一打开就是 5-6 行。

修复：测量时锁 `overflow: hidden`；结果下限兜底 `MIN_TEXTAREA_PX=24`；CSS 加 `min-height: 24px`。

### 3. Mac 双击顶部不最大化（Header.svelte）

`onHeaderDblClick` 对 Mac return 了，理由是 `InvisibleTitleBarHeight` 隐形条"应该自己处理双击"。但 Wails 的隐形条只提供拖动，不转发双击事件。

修复：去掉 `|| isMac`，让 Mac 也走 `flipMaximise()`。

### 4. 窗口控制按钮间距太宽（Header.svelte）

`.window-controls` 的 `margin-left` 和 `padding-left` 各 16px，加上 1px 分隔线，总共 33px。视觉上设置按钮和最小化按钮之间空得太夸张。

修复：缩到各 8px（共 17px），保持独立分组感但更紧凑。

## Review

已用 code-review skill 自审，结果：**Ready to merge**，无 Critical/Important 问题。

| 级别 | 内容 |
|------|------|
| Critical | 无 |
| Important | 无 |
| Minor | CSS `min-height:24px` 与 JS `MIN_TEXTAREA_PX=24` 值重复，已加注释关联 |
