### PR TITLE
chore(web): raise vite chunkSizeWarningLimit to 600

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
   build: {
     outDir: '../internal/server/webdist',
     emptyOutDir: true,
+    // The UI ships as one embedded bundle served from localhost; code-splitting buys nothing here.
+    chunkSizeWarningLimit: 600,
   },
   server: {
     port: 5173,


### PR DESCRIPTION
## Why

`make web-build` prints a chunk-size warning because the main JS chunk (~507 kB minified, ~156 kB gzip) crosses Vite's default 500 kB threshold.

The web UI ships as a single go:embed'd bundle served from localhost (or LAN), so code-splitting buys nothing here — no CDN caching layers, no slow-network first-paint concern. Raise the warning limit to 600 kB instead of adding `manualChunks` complexity.

## Changes

- `web/vite.config.ts`: add `chunkSizeWarningLimit: 600` with a comment explaining the rationale.

No build output changes — rebuilt and asset hashes are identical to what's committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)