### PR TITLE
chore(release): bump version to 1.12.16

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.15"
+var Version = "1.12.16"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump `internal/version/version.go` to `1.12.16` for the v1.12.16 release.

:warning: Tag `v1.12.16` is already pushed and points to this commit. Once merged, the tag is live.