### PR TITLE
fix(upgrade): per-attempt timeout for Check so slow mirrors aren't starved

### DIFF
--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -85,6 +86,11 @@ func (o Options) log(format string, args ...any) {
 	}
 }
 
+// checkAttemptTimeout caps how long each individual base URL attempt
+// (GitHub or a mirror) may take. A slow primary URL must not starve the
+// mirrors of their timeout budget — each one gets a full window.
+const checkAttemptTimeout = 5 * time.Second
+
 // checkBodyCap limits how much of a 200 (non-redirect) response body gets
 // read when hunting for the release tag in HTML — a real release page is
 // ~200 KB.
@@ -107,7 +113,12 @@ var ogURLPattern = regexp.MustCompile(`<meta\s+property="og:url"\s+content="([^"
 func Check(ctx context.Context) (string, error) {
 	var lastErr error
 	for _, base := range append([]string{BaseURL}, MirrorBaseURLs...) {
-		tag, err := checkAt(ctx, base)
+		// Each attempt gets its own sub-context so a slow primary URL can't
+		// starve the mirrors of their timeout budget. Bounded by the parent
+		// context — if it's near expiry the child inherits its deadline.
+		attemptCtx, cancel := context.WithTimeout(ctx, checkAttemptTimeout)
+		tag, err := checkAt(attemptCtx, base)
+		cancel()
 		if err == nil {
 			return tag, nil
 		}
@@ -360,9 +371,18 @@ func releaseURLs(ver, asset string) []string {
 }
 
 // proxiedClient returns an *http.Client that honors HTTP_PROXY,
-// HTTPS_PROXY, and NO_PROXY via http.ProxyFromEnvironment.
+// HTTPS_PROXY, and NO_PROXY via http.ProxyFromEnvironment. The transport
+// has conservative per-connection timeouts so each mirror attempt fails
+// quickly; the caller's context is the overall budget.
 func proxiedClient() *http.Client {
-	return &http.Client{Transport: &http.Transport{Proxy: http.ProxyFromEnvironment}}
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   5 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+		},
+	}
 }
 
 // downloadWithMirrors tries each URL in turn until one succeeds, respecting


### PR DESCRIPTION
## 问题

`upgrade.Check()` 把所有镜像尝试串进同一个 `ctx`。如果 GitHub 直连在国内环境下 TCP 重试吞掉全部超时预算（托盘 10s / 徽章 3s），后面三个国内镜像来不及试就失败了。这就是为什么 macOS（有 VPN）能检测到更新，而 Linux（直连）始终不能。

## 改动

两处修复，都在 `internal/upgrade/upgrade.go`：

1. **每个 URL 独立超时** — `Check()` 给每个 base URL 创建 5 秒的子 context，一个慢了不影响下一个。之前是 4 个 URL 抢同一份预算。
2. **传输层连接超时** — `proxiedClient()` 的 Transport 加上 `DialContext`（5s）、`TLSHandshakeTimeout`（5s）、`ResponseHeaderTimeout`（5s），TCP/TLS 失败快速放弃而不是反复重试直到 context 过期。

## 测试

```
go test -race -count=1 ./internal/upgrade/   → PASS
go test -race -count=1 ./internal/server/ -run Version → PASS
```

## 效果

| 场景 | 改前 | 改后 |
|------|------|------|
| 直连 GitHub 慢（~8s 超时） | 8s 吃光，剩 2s 不够试镜像 → 失败 | GitHub ≤5s 超时，剩 ≥5s 试镜像 → 很可能成功 |
| 快速成功 | 不变 | 不变 |
