### PR TITLE
fix(tui): set default session title to *Octo Agent for better notifications

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -716,7 +716,8 @@ func (m *tuiModel) Init() tea.Cmd {
 	// Set the terminal tab/window title to the session name (OSC 2) so the
 	// user can identify this session across tabs. Ghostty, iTerm2, Kitty and
 	// most modern terminals honour it; others ignore the sequence. No-op when
-	// the user disabled it via config.
+	// the user disabled it via config. For new sessions DisplayTitle returns
+	// "*Octo Agent" until the async LLM title gen completes.
 	if m.cfg.terminalTitle {
 		bootCmds = append(bootCmds, tea.Println(setTitleSeq(m.cfg.session.DisplayTitle())))
 	}
@@ -1411,12 +1412,17 @@ func (m *tuiModel) suggestCmd() tea.Cmd {
 }
 
 // titleCmd generates a session title off the event loop, once per session. It
-// returns nil (no-op) when the session is already titled, a generation is
+// titleCmd returns a tea.Cmd that asynchronously generates a session title
+// from the agent's history. It returns nil (no-op) when the session is already
+// titled (non-empty and not the "*Octo Agent" placeholder), a generation is
 // already in flight, saving is off, or there's no turn to summarize yet — so it
 // fires exactly once, after the first completed turn. The result is persisted
 // by the titleMsg handler.
 func (m *tuiModel) titleCmd() tea.Cmd {
-	if m.cfg.noSave || m.titlePending || m.cfg.session.Title != "" {
+	if m.cfg.noSave || m.titlePending {
+		return nil
+	}
+	if t := m.cfg.session.Title; t != "" && t != "*Octo Agent" {
 		return nil
 	}
 	if m.a.History.Len() == 0 {
@@ -2155,16 +2161,17 @@ func (m *tuiModel) handleTurnFinished(err error) (tea.Model, tea.Cmd) {
 			return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(prompt, ""))
 		}
 	}
+
+	// Truly idle (no queued turn, no goal continuation) after a clean turn:
+	// refresh the tab title from the (now-synced) session — by this point
+	// DisplayTitle returns the first-message snippet if the async LLM title
 	// Truly idle (no queued turn, no goal continuation) after a clean turn:
 	// fire a desktop notification so a user who tabbed away is pulled back.
+	// Ghostty renders the tab title (OSC 2) as the notification's secondary
+	// label automatically, so the OSC 777 title is left empty.
 	// Skipped on error / interrupt (err != nil) and when the user disabled it.
 	if err == nil && m.cfg.notify {
-		// OSC 777 with empty title: Ghostty renders both the OSC 2 tab
-		// title and the OSC 777 notification title as visible text, so
-		// passing the session title here duplicates it. Empty title shows
-		// only the body. Other terminals (iTerm2, Kitty, WezTerm) ignore
-		// the title slot entirely.
-		return m, tea.Sequence(m.flushPrints(), tea.Println(notifySeq("", "Turn complete — input needed")))
+		return m, tea.Sequence(m.flushPrints(), tea.Println(notifySeq("Octo Agent", "Octo is waiting for your input")))
 	}
 	return m, nil
 }

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1148,6 +1148,10 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Persist the generated title (silent — it surfaces in the session list).
 		m.titlePending = false
 		if msg.text != "" && !m.cfg.noSave {
+		} else if !m.cfg.noSave && m.cfg.session.Title == "*Octo Agent" {
+			if snippet := m.cfg.session.DisplayTitle(); snippet != "*Octo Agent" {
+				_ = m.cfg.session.SetTitle(snippet)
+			}
 			_ = m.cfg.session.SetTitle(msg.text)
 		}
 		// Refresh the terminal tab/window title to match the now-current session

--- a/internal/agent/goal.go
+++ b/internal/agent/goal.go
@@ -188,7 +188,7 @@ func (s *Session) startGoalLocked(objective string, tokenBudget int64) Goal {
 	// not billed to the fresh goal. Cleared unconsumed at the next turn start.
 	s.goalSkipNextTokenDelta = true
 	records := []sessionRecord{{Type: "goal", Goal: s.Goal}}
-	if s.Title == "" {
+	if s.Title == "" || s.Title == "*Octo Agent" {
 		// Seed the title from the objective (the Codex thread-preview
 		// behavior). It needs its own record — a "goal" record doesn't carry
 		// the title, so without one the seed would vanish on reload.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -364,6 +364,7 @@ func NewSession(model, system string) *Session {
 		CreatedAt: now,
 		Model:     model,
 		System:    system,
+		Title:     "*Octo Agent",
 	}
 }
 
@@ -857,15 +858,15 @@ func (s *Session) SetLastContextTokens(n int) error {
 // DisplayTitle returns the label shown for the session in list views: the
 // generated Title when present, otherwise a snippet of the first user message
 // (so pre-title sessions and not-yet-titled ones are still recognisable), and
-// finally "(untitled)" when there's nothing to show.
+// finally "*Octo Agent" when there's nothing to show.
 func (s *Session) DisplayTitle() string {
-	if t := strings.TrimSpace(s.Title); t != "" {
+	if t := strings.TrimSpace(s.Title); t != "" && t != "*Octo Agent" {
 		return t
 	}
 	if snippet := firstUserSnippet(s.Messages); snippet != "" {
 		return snippet
 	}
-	return "(untitled)"
+	return "*Octo Agent"
 }
 
 // firstUserSnippet extracts a one-line preview from the first user message,

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -387,7 +387,7 @@ func TestDisplayTitle(t *testing.T) {
 		{
 			name: "untitled when empty",
 			s:    &Session{},
-			want: "(untitled)",
+			want: "*Octo Agent",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -43,6 +43,7 @@ func TestIsAutoNamePlaceholder(t *testing.T) {
 		{"  ", true},
 		{"Session 1", true},
 		{"Session 42", true},
+			{"*Octo Agent", true},
 		{"Session", false},
 		{"修复登录问题", false},
 		{"My Session 2", false},

--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -43,7 +43,7 @@ func TestIsAutoNamePlaceholder(t *testing.T) {
 		{"  ", true},
 		{"Session 1", true},
 		{"Session 42", true},
-			{"*Octo Agent", true},
+		{"*Octo Agent", true},
 		{"Session", false},
 		{"修复登录问题", false},
 		{"My Session 2", false},

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1577,7 +1577,7 @@ var sessionPlaceholderRe = regexp.MustCompile(`^Session \d+$`)
 // after the first completed turn. A name the user typed themselves is kept.
 func isAutoNamePlaceholder(title string) bool {
 	t := strings.TrimSpace(title)
-	return t == "" || sessionPlaceholderRe.MatchString(t)
+	return t == "" || t == "*Octo Agent" || sessionPlaceholderRe.MatchString(t)
 }
 
 // claimTitleGeneration marks a title generation in flight for the session;


### PR DESCRIPTION
## 改动

| 文件 | 改动 |
|------|------|
| `internal/agent/session.go` | `NewSession` 默认 `Title: "*Octo Agent"`；`DisplayTitle` fallback 从 `"(untitled)"` 改为 `"*Octo Agent"` |
| `internal/agent/goal.go` | `startGoalLocked` 种子标题判断加上 `Title == "*Octo Agent"` |
| `cmd/octo/tuirepl.go` | `titleCmd()` 触发条件支持 `"*Octo Agent"`；通知 title 硬编码 `"Octo Agent"`，body `"Octo is waiting for your input"` |
| `internal/agent/session_test.go` | 测试从 `"(untitled)"` 更新为 `"*Octo Agent"` |

## 效果

| | 第一次通知 | 后续通知 |
|---|---|---|
| **OSC 777 标题** | `Octo Agent` | `Octo Agent` |
| **Tab 标题 (OSC 2)** | `*Octo Agent` | 生成后的标题 |
| **Body** | Octo is waiting for your input | Octo is waiting for your input |

## 关键决策

- 新建 session `Title` 直接设为 `"*Octo Agent"`，不再等 async 生成后再显示占位符
- `titleCmd` 在 `Title == ""` 或 `"*Octo Agent"` 时都会触发异步生成
- 通知 title 硬编码为 `"Octo Agent"`（之前用户确认过这个值）
- 通知 body 改为 `"Octo is waiting for your input"`（用户确认）