### PR TITLE
refactor: extract FallbackTitleIfPlaceholder, unify TUI+server title fallback

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1148,11 +1148,9 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Persist the generated title (silent — it surfaces in the session list).
 		m.titlePending = false
 		if msg.text != "" && !m.cfg.noSave {
-		} else if !m.cfg.noSave && m.cfg.session.Title == "*Octo Agent" {
-			if snippet := m.cfg.session.DisplayTitle(); snippet != "*Octo Agent" {
-				_ = m.cfg.session.SetTitle(snippet)
-			}
 			_ = m.cfg.session.SetTitle(msg.text)
+		} else if !m.cfg.noSave {
+			m.cfg.session.FallbackTitleIfPlaceholder()
 		}
 		// Refresh the terminal tab/window title to match the now-current session
 		// name. On a brand-new session Init() set it to "(untitled)"; that was the

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -869,6 +869,21 @@ func (s *Session) DisplayTitle() string {
 	return "*Octo Agent"
 }
 
+// FallbackTitleIfPlaceholder replaces the "*Octo Agent" placeholder with the
+// first-message snippet when available. Returns the new title, or "" when
+// the title isn't the placeholder or there's no message content to use.
+// Both the TUI and the web server call this when async title generation fails.
+func (s *Session) FallbackTitleIfPlaceholder() string {
+	if s.Title != "*Octo Agent" {
+		return ""
+	}
+	if snippet := firstUserSnippet(s.Messages); snippet != "" {
+		_ = s.SetTitle(snippet)
+		return snippet
+	}
+	return ""
+}
+
 // firstUserSnippet extracts a one-line preview from the first user message,
 // skipping injected <system-reminder> blocks and tool-result turns, and
 // truncating to a list-friendly width.

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1491,19 +1491,23 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			ctx, cancel := context.WithTimeout(context.Background(), throwawayGenerationTimeout)
 			defer cancel()
 			t, terr := a.GenerateTitle(ctx, toolDefs)
-			if terr != nil {
-				// Silent by design (retried after the next completed turn,
-				// per the comment above) — but silent must not mean
-				// invisible: without this, a persistently misconfigured
-				// model/provider on a given install never generates a
-				// title, and nothing anywhere records why, making the
-				// exact symptom "sidebar title never updates" unexplainable
-				// from the server side.
-				slog.Warn("session title generation failed", "session_id", sid, "err", terr)
-				return
-			}
-			if strings.TrimSpace(t) == "" {
-				slog.Warn("session title generation returned an empty title", "session_id", sid)
+			if terr != nil || strings.TrimSpace(t) == "" {
+				if terr != nil {
+					slog.Warn("session title generation failed", "session_id", sid, "err", terr)
+				} else {
+					slog.Warn("session title generation returned an empty title", "session_id", sid)
+				}
+				// Fall back to the first-message snippet instead of leaving
+				// the "*Octo Agent" placeholder (same logic as the TUI).
+				if fresh, lerr := agent.LoadSession(sid); lerr == nil {
+					if title := fresh.FallbackTitleIfPlaceholder(); title != "" {
+						s.wsHub.broadcast("", map[string]any{
+							"type":       "session_renamed",
+							"session_id": sid,
+							"name":       title,
+						})
+					}
+				}
 				return
 			}
 			// Apply the title to a freshly loaded Session, not the live one —


### PR DESCRIPTION
## 改动

`FallbackTitleIfPlaceholder()` 公共方法 + TUI 和 server 两端统一调用。

| 文件 | 改动 |
|------|------|
| `internal/agent/session.go` | 新增 `Session.FallbackTitleIfPlaceholder()` 方法 |
| `cmd/octo/tuirepl.go` | `titleMsg` handler 改为调用 `FallbackTitleIfPlaceholder()` |
| `internal/server/ws_handlers.go` | GenerateTitle 失败后也调用 `FallbackTitleIfPlaceholder()`，成功则 `broadcast session_renamed` |

## 效果

生成失败后两端表现一致：用第一句话截断写入 `s.Title`，不再重试，也不再永久停在 `"*Octo Agent"`。