### PR TITLE
fix(config): LongCat-2.0 支持 vision 输入

### DIFF
--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -258,9 +258,9 @@ var Registry = []Vendor{
 		API:            "openai-completions",
 		DefaultBaseURL: "https://api.longcat.chat/openai",
 		DefaultModel:   "LongCat-2.0",
-		// LongCat-2.0 accepts text input only (no image/vision support on the API).
+		// LongCat-2.0 supports image/vision input on the API.
 		Models: []VendorModel{
-			{ID: "LongCat-2.0", Vision: false},
+			{ID: "LongCat-2.0", Vision: true},
 		},
 		APIKeyEnvVar: "LONGCAT_API_KEY",
 		WebsiteURL:   "https://longcat.chat/platform/api_keys",

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -254,6 +254,7 @@ func TestVendorModelVision(t *testing.T) {
 		{"kimi", "kimi-k2.6", true, true},       // MoonViT multimodal
 		{"openai", "o3-mini", false, true},      // no image input
 		{"openai", "o4-mini", true, true},
+		{"longcat", "LongCat-2.0", true, true},   // vision supported
 		{"bailian", "not-a-model", false, false}, // unknown model
 		{"bogus", "whatever", false, false},      // unknown vendor
 		{ProviderCustom, "anything", false, false},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -339,7 +339,7 @@ func ModelSupportsVision(model string) bool {
 			return true
 		}
 	}
-	for _, textOnly := range []string{"qwen", "deepseek", "kimi", "moonshot", "baichuan", "ernie", "glm-", "spark", "abab", "yi-", "longcat"} {
+	for _, textOnly := range []string{"qwen", "deepseek", "kimi", "moonshot", "baichuan", "ernie", "glm-", "spark", "abab", "yi-"} {
 		if strings.Contains(m, textOnly) {
 			return false
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -290,6 +290,7 @@ func TestModelSupportsVision(t *testing.T) {
 		"gpt-4.1-mini":      true,
 		"claude-sonnet-4-6": true,
 		"gemini-2.0-flash":  true,
+		"LongCat-2.0":       true, // longcat family → now vision-capable
 		"o3":                true, // unknown family → default true
 		"some-new-llm":      true,
 	}


### PR DESCRIPTION
## 问题

LongCat-2.0 API 已支持多模态图片输入，但代码里两处误配为 text-only：

1. `internal/app/provider.go` — LongCat-2.0 的 `VendorModel.Vision` 写成了 `false`，注释也说"text input only"
2. `internal/config/config.go` — `ModelSupportsVision` 的 `textOnly` 列表含 `"longcat"`，导致启发式判断也返回 `false`

后果：选择 LongCat-2.0 模型时，图片被降级为 `[Attached file: ...]` 路径 note，模型看不到图。

## 修复

| 文件 | 改动 |
|------|------|
| `internal/app/provider.go:261-263` | `Vision: false` → `true`，注释更新 |
| `internal/config/config.go:342` | `textOnly` 列表移除 `"longcat"` |
| `internal/app/provider_test.go:250` | 新增 `{"longcat", "LongCat-2.0", true, true}` |
| `internal/config/config_test.go:293` | 新增 `"LongCat-2.0": true` |

## 验证

- `go test ./internal/app/ ./internal/config/ -run 'TestVendorModelVision|TestModelSupportsVision' -count=1` ✅