### PR TITLE
chore: bump version to 1.12.17

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.16"
+var Version = "1.12.17"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump version for v1.12.17 release.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>