### PR TITLE
fix(onboard): skip show_reasoning when reasoning is off, add missing xhigh/max options

### DIFF
--- a/cmd/octo/config.go
+++ b/cmd/octo/config.go
@@ -555,13 +555,16 @@ func runConfigWizard(stdin io.Reader, stdout, stderr io.Writer, firstRun bool) i
 
 		// Surface the reasoning/thinking trace for the Web UI to display (the
 		// terminal never renders it): default off.
-		showDefault := existing.ShowReasoning != nil && *existing.ShowReasoning
-		showVal, ok := pickYesNo(tty, reader, stdin, stdout,
-			"Show the reasoning/thinking trace on the Web UI?", showDefault)
-		if !ok {
-			return cancelWizard(stderr)
+		// Skip when reasoning is off — no reasoning output to show.
+		if outEntry.ReasoningEffort != "" {
+			showDefault := existing.ShowReasoning != nil && *existing.ShowReasoning
+			showVal, ok := pickYesNo(tty, reader, stdin, stdout,
+				"Show the reasoning/thinking trace on the Web UI?", showDefault)
+			if !ok {
+				return cancelWizard(stderr)
+			}
+			outEntry.ShowReasoning = &showVal
 		}
-		outEntry.ShowReasoning = &showVal
 	}
 
 	// Vision capability is always recorded on the entry. A predefined model

--- a/internal/skills/defaults/onboard/SKILL.md
+++ b/internal/skills/defaults/onboard/SKILL.md
@@ -144,6 +144,11 @@ All have fixed choices with a sensible default, so present each as an
 skip: an empty message can't be sent (both the terminal UI and the web composer
 ignore a blank Enter), so an un-clickable list would strand them.
 
+**Before asking any behaviour question, read `~/.octo/config.yml`** and check
+for existing values. If a field is already present in the config (e.g. the user
+set it via `octo config`), **skip** that question and reuse its value. Only ask
+when the field is absent from the file.
+
 **Permission mode** — how the assistant handles sensitive tool calls (file writes, shell commands, etc.).
 
 zh:
@@ -162,19 +167,24 @@ Store as `prefs.permission_mode` (default `"interactive"`).
 
 zh:
 > **推理强度** — 支持扩展思考的模型（Claude 3.7 / o3 等）的思考深度：
-> - 空（默认关闭）— 标准模式
+> - **off**（默认）— 关闭推理功能
 > - **low** — 轻量思考，响应快
 > - **medium** — 平衡
 > - **high** — 深度思考，响应慢但质量更高
+> - **xhigh** — 更强思考
+> - **max** — 最大思考
 
 en:
 > **Reasoning effort** — how deeply supported models think (Claude 3.7, o3, etc.):
-> - empty (default off) — standard mode
+> - **off** (default) — disable, no reasoning
 > - **low** — light thinking, faster responses
 > - **medium** — balanced
 > - **high** — deep thinking, slower but higher quality
+> - **xhigh** — even deeper thinking
+> - **max** — maximum reasoning
 
-Store as `prefs.reasoning_effort` (default `""`). If the user gives an invalid value, silently fall back to `""`.
+Store as `prefs.reasoning_effort` (default `""`). If the user picks `"off"`, store as `""`. If the user gives an invalid value, silently fall back to `""`.
+If `prefs.reasoning_effort` is `""` (off), **skip** the **Show reasoning trace** question below — there is no reasoning output to show.
 
 **Show reasoning trace** — whether to stream the model's thinking chain to the terminal.
 

--- a/web/src/components/settings/ModelConfigForm.svelte
+++ b/web/src/components/settings/ModelConfigForm.svelte
@@ -183,6 +183,15 @@
     if (!valid()) { result = { ok: false, msg: $t('models.error.required') }; return }
     saving = true
     try {
+      // Test the connection first — the button label says "Test connection and continue"
+      // during first-run onboard, and "Save" in Settings; either way, don't save an
+      // invalid or unreachable config.
+      const testRes = await api.testConfig(buildReq())
+      if (!testRes.ok) {
+        result = { ok: false, msg: testRes.message || $t('models.test.fail') }
+        saving = false
+        return
+      }
       await onSubmit(buildReq())
     } catch (e: any) {
       result = { ok: false, msg: e?.message ?? $t('models.save.fail') }


### PR DESCRIPTION
## Summary

修复 onboard 流程中的三个 bug。

## Changes

### 1. SKILL.md (onboard skill instructions)

- **推理强度选项补充** — 新增 **off**（明确替代原来的"空/默认关闭"）、**xhigh**、**max** 三档，现在共 6 档：off / low / medium / high / xhigh / max
- **选 off 时跳过 show_reasoning** — 如果推理强度为 off，不再询问"显示推理过程"，因为没有 reasoning_content 可以展示
- **配置已存在时跳过询问** — A.6 要求先读取 `~/.octo/config.yml`，如果某项行为偏好已被 `octo config` 配置过，直接复用，不再重复提问

### 2. config.go (CLI wizard)

- **选 Off 时跳过 show_reasoning** — CLI 交互中如果 reasoning effort 选了 Off，不再问"Show the reasoning/thinking trace on the Web UI?"

### 3. ModelConfigForm.svelte (web onboard)

- **Test connection before submit** — `handleSubmit` 现在先调用 `api.testConfig()`，测试通过后才保存并继续。首次启动流程中"Test connection and continue"按钮现在真的会测试连接，输入无效 key 不会放行。

## 对齐的代码值

| 选项 | 存储值 | 来源 |
|------|--------|------|
| off | `""` | `validReasoningEffort` + `normalizeOffEffort` |
| low | `"low"` | |
| medium | `"medium"` | |
| high | `"high"` | |
| xhigh | `"xhigh"` | |
| max | `"max"` | |