### PR TITLE
fix(tui): make permission prompt hint text more readable

### DIFF
--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -41,6 +41,7 @@ var (
 	toolErrStyle         = lipgloss.NewStyle().Foreground(tui.ColDanger)
 	queueStyle           = lipgloss.NewStyle().Foreground(tui.ColAccent)
 	modalStyle           = lipgloss.NewStyle().Foreground(tui.ColBrand).Bold(true)
+	permHintStyle        = lipgloss.NewStyle().Foreground(tui.ColMuted)
 	hintStyle            = lipgloss.NewStyle().Foreground(tui.ColDimmer).Italic(true)
 	activityStyle        = lipgloss.NewStyle().Foreground(tui.ColBrand)
 	userEchoStyle        = lipgloss.NewStyle().Foreground(tui.ColUserMsg).Bold(true)
@@ -1754,7 +1755,7 @@ func (m *tuiModel) modalView() string {
 		b.WriteByte('\n')
 		b.WriteString(st.detail)
 		b.WriteByte('\n')
-		b.WriteString(hintStyle.Render("[y]es · [a]lways this session · [n]o/Esc"))
+		b.WriteString(permHintStyle.Render("[y]es · [a]lways this session · [n]o/Esc"))
 		return b.String()
 	}
 


### PR DESCRIPTION
## Summary

TUI 权限提示底部的操作说明文字（`[y]es · [a]lways this session · [n]o/Esc`）颜色太淡，深色终端上几乎看不清。

## Change

**之前**：使用 `ColDimmer`（暗色 `#484F58`），基本就是深灰，和黑色背景混在一起。

**之后**：新增 `permHintStyle`，使用 `ColMuted`（暗色 `#8B949E`），是清晰可读的中等灰色。

`hintStyle`（`ColDimmer` + `Italic`）在其他地方（内联提示、状态栏）有意用作极淡装饰色，不改它。只改权限弹窗这一处。不影响原有 `ask_user_question` 等其他弹窗的样式。