### PR TITLE
fix(branch): exclude user message from branched session to prevent duplicate

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -727,11 +727,10 @@ type branchSessionRequest struct {
 }
 
 // handleBranchSession creates a new session branched from the source session's
-// history up to message_index (inclusive). The source session is untouched.
-// If prompt_override is non-empty, the branched session's last message (the
-// user message at message_index) is replaced with it before save — this lets
-// the user vary the prompt and compare results. Returns the new session so the
-// client can navigate to it.
+// history up to (but not including) message_index. The source session is
+// untouched. The user message at message_index is NOT copied — the client
+// sends it fresh via ws.sendMessage so there is no duplicate. Returns the
+// new session so the client can navigate to it.
 func (s *Server) handleBranchSession(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
@@ -752,10 +751,8 @@ func (s *Server) handleBranchSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("message_index out of range: %d (have %d messages)", req.MessageIndex, len(src.Messages)))
 		return
 	}
-	branch := agent.BranchFrom(src, req.MessageIndex+1) // +1: BranchFrom takes an exclusive count
-	if req.PromptOverride != "" {
-		branch.Messages[len(branch.Messages)-1].Content = req.PromptOverride
-	}
+	branch := agent.BranchFrom(src, req.MessageIndex) // BranchFrom takes an exclusive count; exclude the user message so the client can send it fresh
+
 	if err := branch.Save(); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -209,11 +209,8 @@ func TestHandleBranchSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load branch: %v", err)
 	}
-	if len(branch.Messages) != 3 {
-		t.Fatalf("branch Messages len = %d, want 3", len(branch.Messages))
-	}
-	if branch.Messages[2].Content != "BRANCHED VARIANT" {
-		t.Fatalf("last message = %q, want BRANCHED VARIANT", branch.Messages[2].Content)
+	if len(branch.Messages) != 2 {
+		t.Fatalf("branch Messages len = %d, want 2 (user message at message_index is excluded)", len(branch.Messages))
 	}
 	if branch.BranchedFrom != sess.ID {
 		t.Fatalf("BranchedFrom = %q, want %q", branch.BranchedFrom, sess.ID)

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1570,7 +1570,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 // safety margin for normal network/provider variance, not a substitute for
 // the effort cap, so it stays modest rather than papering over a slow call
 // with a long wait.
-const throwawayGenerationTimeout = 30 * time.Second
+const throwawayGenerationTimeout = 5 * time.Second
 
 // sessionPlaceholderRe matches the frontend's auto-assigned "Session N"
 // default name on freshly created web sessions.


### PR DESCRIPTION
## Summary

Branch 功能发了两条重复的用户消息。同时将 throwaway title/suggestion 生成的超时从 30s 降到 5s。

## Changes

### 1. Branch duplicate fix

**Root cause**: `handleBranchSession` 通过 `BranchFrom(src, message_index+1)` 把用户消息复制到了新 session 里。随后客户端又通过 `ws.sendMessage` 发送了同一条消息。`doAgentTurn` 在服务端又追加了一条，于是 session 里出现了两条一模一样的用户消息。

**Fix**: `handleBranchSession` 改为 `BranchFrom(src, message_index)`（不包含用户消息本身）。用户在界面编辑或确认后的内容，由客户端通过 `ws.sendMessage` 统一发送一遍，不会重复。同时移除了不再需要的 `prompt_override` 逻辑。

### 2. Timeout reduction

`throwawayGenerationTimeout` 从 30s 降到 5s。标题和 suggestion 生成已经用了 `LowEffortSender`，30s 安全余量太大，5s 足够应对正常网络波动。