### PR TITLE
fix: correct Discord bot permissions in channel-manager skill

### DIFF
--- a/internal/skills/defaults/channel-manager/SKILL.md
+++ b/internal/skills/defaults/channel-manager/SKILL.md
@@ -309,7 +309,7 @@ Discord requires manual portal interaction (hCaptcha gates application creation)
        bot_token: <BOT_TOKEN>
    ```
 4. Build the invite URL with the Application ID and tell the user to open it:
-   `https://discord.com/oauth2/authorize?client_id=<APP_ID>&scope=bot&permissions=274877975552`
+   `https://discord.com/oauth2/authorize?client_id=<APP_ID>&scope=bot&permissions=274878220912`
    > Pick your server from the dropdown → Continue → Authorize. If the dropdown is empty you don't have a server yet — open <https://discord.com/channels/@me>, click the **+** button → Create My Own, then re-open the invite link.
 5. Trigger a hot reload (see "Hot-reload after config change"). If the server isn't running, remind the user to start `octo serve`. Then say: "✅ Discord channel configured. @-mention the bot in a channel or DM it."
 


### PR DESCRIPTION
The `permissions` value in the Discord invite URL was `274877975552`, which only included View Channels, Send Messages, Read Message History, and Send Messages in Threads.

Updated to `274878220912`, which also includes:
- Attach Files
- Embed Links
- Add Reactions

These are needed for octo's bot to send files, show link previews, and handle message interactions.
