### PR TITLE
blog: rewrite architecture deep-dive as a narrative internals post

### DIFF
--- a/blog/src/content/posts/en/architecture-deep-dive.md
+++ b/blog/src/content/posts/en/architecture-deep-dive.md
@@ -1,137 +1,305 @@
 ---
-title: "octo-agent Architecture Deep Dive: Five-Layer Core Stack & Full-System Dependency Map"
-description: "An interactive panorama architecture diagram parsing octo-agent's five-layer unidirectional dependency from CLI/IM entry to LLM backends, the agent leaf package design, protocol-agnostic abstraction, and cross-cutting concerns like permission, workflow, and memory."
+title: "octo-agent Deep Dive: The Genuinely Hard Parts of an Agent System"
+description: "Starting from the five-layer unidirectional dependency stack, this post dissects seven core mechanisms of octo-agent and the trade-offs behind them: context compaction, prompt caching, loop, workflow orchestration, browser record & replay, permission enforcement, and the trash can."
 pubDate: 2026-07-08
-updatedDate: 2026-07-10
+updatedDate: 2026-07-17
 author: "octo-agent team"
 tags: ["architecture", "deep-dive", "engineering", "ai-agent"]
 locale: en
 originalSlug: architecture-deep-dive
 ---
 
-# octo-agent Architecture Deep Dive: Five-Layer Core Stack & Full-System Dependency Map
+# octo-agent Deep Dive: The Genuinely Hard Parts of an Agent System
 
-> octo-agent's codebase has grown to 480+ Go files, six IM bridges, and an embedded Svelte 5 workbench. This post uses an interactive panorama diagram to show how the whole system hangs together.
+Calling an LLM once is easy — it's one HTTP request. Letting the LLM call tools isn't hard either; every vendor ships a ready-made tool-use protocol. What's genuinely hard is the ring of engineering problems around that loop:
 
----
+- The context window is finite, but conversations only ever grow.
+- Input tokens cost money, and an agent re-sends the entire history on every single round.
+- Processes exit, but users want tasks that "check back in five minutes."
+- Models make mistakes — while holding `rm -rf` and your browser in their hands.
 
-## Design Philosophy: Strictly Unidirectional Dependencies
+octo-agent is an agent CLI written in Go: a single binary, an embedded Web UI, bridges to six IM platforms, 480+ Go files in the repository. This post doesn't tour the features. Instead it picks the problems above and looks at the answer the codebase gives to each one — and why it's usually not the answer you'd reach for first.
 
-The single most important architectural discipline in octo-agent is **strictly unidirectional dependency**. The five-layer stack:
+## The Foundation: The Agent Loop Must Stay Ignorant
 
+Start with the big picture. The core of octo-agent is literally a while loop: send the history to the model; the model either answers (loop ends) or asks for a tool; execute the tool, append the result to history, go back to the top.
+
+```mermaid
+flowchart TB
+    subgraph Entries["Entry layer — five faces, one loop"]
+        TUI["TUI<br/>(Bubble Tea)"]
+        Web["Web<br/>(Svelte 5 SPA)"]
+        Headless["Headless<br/>(octo -p ...)"]
+        IM["IM bridges<br/>(Feishu / Telegram / Discord ...)"]
+    end
+
+    subgraph Assembly["Assembly layer — internal/app"]
+        App["The only package that knows everyone:<br/>provider + permission + subagent<br/>+ mcp + memory get wired here"]
+    end
+
+    subgraph Core["Agent core — internal/agent (leaf of the dependency tree)"]
+        Agent["RunStream: send → tool → append → send<br/>reads no HTTP, builds no JSON,<br/>knows no wire protocol"]
+    end
+
+    subgraph Downstream["Downstream, behind abstract interfaces"]
+        Provider["internal/provider/<br/>anthropic / openai adapters"]
+        Tools["internal/tools/<br/>terminal / browser / workflow ..."]
+    end
+
+    TUI --> App
+    Web --> App
+    Headless --> App
+    IM --> App
+    App --> Agent
+    Agent -.->|Sender interface| Provider
+    Agent -.->|ToolExecutor interface| Tools
+
+    style Agent fill:#2d3748,color:#fff,stroke:#4a5568
+    style Core fill:#1a202c,color:#fff
 ```
-cmd/ → app/ → agent/ ← (provider/, tools/)
+
+The loop itself is a few hundred lines. Everything complicated is kept out of it by a single discipline: **`internal/agent` is the leaf package of the entire dependency tree.** It imports neither `provider` nor `tools` nor any UI. It knows exactly two interfaces — `Sender` (send messages, get an abstract reply back) and `ToolExecutor` (run a tool by name, get text back).
+
+The value of that discipline only shows in the details. When the model wants a tool, Anthropic's API says `stop_reason: "tool_use"` while OpenAI says `finish_reason: "tool_calls"`. In OpenAI streaming, tool arguments arrive as JSON fragments scattered across chunks that must be reassembled by index before parsing. Some third-party OpenAI-compatible servers don't even send the `[DONE]` sentinel. Each of these quirks is one temptation to bury an `if provider == "openai"` inside the core loop — and once that starts, the loop is unreadable by the time the third provider lands. octo-agent instead locks all of it inside two adapter packages, `internal/provider/anthropic` and `internal/provider/openai`; the agent loop only ever sees normalized, unified semantics.
+
+The payoff: five kinds of entry points (TUI, Web, Headless, IM, plus sub-agents) all run the same `RunStream`. Plugging in a new LLM backend changes zero lines of agent code; adding a tool means implementing an interface and registering one line. A full turn looks like this:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User (any entry point)
+    participant Ag as Agent.RunStream
+    participant Perm as Permission gate
+    participant Prov as Provider adapter
+    participant Tool as Tool
+
+    U->>Ag: one message (app layer has injected permission / browser / memory env)
+    loop until the model gives a final answer
+        Ag->>Prov: SendMessagesToTools(entire history)
+        Prov-->>Ag: normalized text / tool_use
+        Ag->>Perm: is this call allowed? (deny/ask/allow)
+        Perm-->>Ag: allow / ask the user / deny
+        Ag->>Tool: execute, append result as tool_result
+    end
+    Ag-->>U: event stream (text_delta / tool_started / turn_done)
+    Note over Ag: history persisted to ~/.octo/sessions/*.jsonl
 ```
 
-`internal/agent/` is a **leaf package** in the dependency tree — it imports nothing from upper layers (no `provider`, `tools`, `server`, `channel`, or `web`). All protocol details, tool implementations, and UI rendering are "pushed upward."
+That's the foundation. Now for the main course: the problems that only start once this loop is actually running.
 
-This means you can:
-- Swap LLM backends (anthropic → openai → deepseek) without touching a single line of agent code.
-- Add a new tool (terminal, browser, skill, workflow, MCP…) without modifying the agent loop.
-- Change the rendering surface (T1 UI, Web, IM, Headless) without affecting core logic.
+## Context Compaction: You Can't Delete Messages, Only Fold Time
 
-This one rule is the main reason octo-agent has been able to scale.
+The first wall you hit is physical: the context window has a fixed size, and agent conversations balloon fast — a single compiler-error tool_result can be thousands of tokens, and an afternoon session piles up to six figures without trying.
+
+The intuitive fix is "when the window fills up, drop the oldest messages." In an agent setting this breaks the API outright: `tool_use` and `tool_result` blocks in history are strictly paired, and deleting messages that sever a pair gets you a 400 from both Anthropic and OpenAI. Worse, the oldest messages usually contain the original task statement — drop them and the agent forgets what it's doing halfway through.
+
+octo-agent's answer is **summary folding**: compress the early history into one summary, keep the recent history verbatim. Three details carry the design.
+
+```mermaid
+flowchart LR
+    A["usage ≥ 75% of window"] --> B["Free win first: reclaim stale<br/>bulky tool_results (zero cost)"]
+    B --> C{"still over?"}
+    C -->|no| Z["done"]
+    C -->|yes| D["Find a split point: only at a<br/>'pure user message' boundary"]
+    D --> E["before the split → LLM summary<br/>after (≤30% of window) → kept verbatim"]
+    E --> F["History rebuilt as:<br/>one summary message + recent originals"]
+```
+
+**First, the split point is always safe.** `safeSplitIndexByBudget` (`internal/agent/compaction.go`) only ever cuts at a "pure user message containing no tool_result," which structurally guarantees no tool_use/tool_result pair is ever severed. That same guarantee is what allows compaction to happen *mid-turn*: a long turn checks usage after every batch of tool calls, and if it's over the line, earlier completed rounds get folded immediately while the in-flight calls stay untouched. For agent tasks that routinely make dozens of tool calls in one turn, mid-turn compaction isn't a nicety — it's table stakes.
+
+**Second, the usage math is counter-intuitive.** Context usage is not whatever `input_tokens` reports — when the prompt cache hits, Anthropic's `input_tokens` is only the uncached remainder, and the real footprint requires adding `cache_read + cache_write` back in (`accrueUsage` in `agent.go`). Get this wrong and the better your cache hit rate, the less compaction triggers — until one cache miss blows straight through the window.
+
+**Third, compaction has damping.** The trigger threshold defaults to 75% (configurable via `compact_auto_pct`), the keep budget is 30% of the window, and there's an anti-thrashing rule: if a fold would reclaim less than 15%, skip it entirely — otherwise a session hovering at the threshold pays for an expensive summarization call every single round.
+
+One pitfall worth knowing: **the persisted `session.jsonl` stores the post-compaction history.** Compaction rebuilds the history wholesale, which triggers a full rewrite of the session file; the verbatim originals survive only if `ArchiveDir` is configured, in which case they're archived as `chunk-*.md` (the summary ends with the file path, so the model can read them back on demand) — otherwise they're gone for good. And since the history just got shorter, every `message_index` held by the Web frontend (edit and branch features depend on it) is silently invalidated; the server watches a length watermark and forces the frontend to re-fetch the whole transcript when the history shrinks below it. These compaction ripple effects have caused more rework than any other part of the mechanism.
+
+## Prompt Caching: An Agent's Bill Is Quadratic
+
+The second problem is money. Every round of the loop re-sends the entire history, which means in an N-round session, message #1 gets billed N times — without caching, cost grows quadratically with conversation length.
+
+Prompt caching fits in one sentence: if this request shares a prefix with the previous one, the matched part is billed at roughly a tenth of the price. The trouble is twofold: different protocols report "how much was cached" in completely different ways, and the Anthropic protocol requires you to **explicitly declare** where the cache boundary sits.
+
+The first point is where self-hosted gateway integrations crash most often:
+
+| Protocol | Cache-hit field | Meaning of `input`/`prompt` tokens |
+|---|---|---|
+| Anthropic | `cache_read_input_tokens` | **only the uncached remainder**; hits counted separately |
+| OpenAI | `prompt_tokens_details.cached_tokens` | **the entire input**; hits are a subset of it |
+| DeepSeek | `prompt_cache_hit/miss_tokens` | explicitly split into two buckets |
+
+Same semantics, three encodings. octo-agent performs one subtraction in the openai adapter (`nonCachedInput()`, `internal/provider/openai/types.go`) so the OpenAI-style numbers also become "two non-overlapping buckets" — from that point on, `InputTokens` and `CacheReadTokens` mean the same thing at the agent layer regardless of protocol. The usage arithmetic that compaction depends on (previous section) is built exactly on this unification. Protocol normalization isn't tidiness; it's the precondition for the layers above to be *correct*.
+
+The second point is more interesting: where to place the breakpoints. octo-agent plants exactly three `cache_control` breakpoints in every Anthropic request:
+
+```mermaid
+flowchart TB
+    subgraph Req["Request body (fixed order: tools → system → messages)"]
+        T["tool definitions"]
+        S["system prompt"]
+        M1["... earlier history ..."]
+        M2["second-to-last message"]
+        M3["last message"]
+    end
+    S ---|"breakpoint ① static prefix<br/>1h TTL on official endpoint, 5min on gateways"| S
+    M2 ---|"breakpoint ② 5min"| M2
+    M3 ---|"breakpoint ③ 5min"| M3
+```
+
+The static prefix (tool definitions + system prompt) needs only one breakpoint — since tools precede system in the request body, a breakpoint on the system block caches the tool definitions along with it. History gets a breakpoint on each of the **last two** messages. Why two? Because the next request appends new messages, so last round's "last message" becomes "N-th from the end"; with a single breakpoint, a retry that drops the trailing message would leave *no* breakpoint anywhere in the common prefix. Two breakpoints guarantee that however the sliding window moves, at least one lands inside the prefix shared with the previous request. Three total, against Anthropic's limit of four — margin left on purpose.
+
+An honest disclosure: the money this machinery saves is currently **almost invisible to the user**. The only place in the whole repo that surfaces it is headless mode printing one `[usage] ... cache %d read` line to stderr; TUI and Web show only input/output deltas — `SessionCacheTokens()` is defined but has no callers. The mechanism is finely built; the observability hasn't caught up.
+
+## /loop: A Command That Doesn't Exist
+
+Users keep asking for things like "check every five minutes whether CI passed." octo-agent's answer is `/loop 5m check CI` — but grep the codebase for the implementation of `/loop` and you'll find the server's command router handles it with `return false`: don't intercept, pass it to the model as an ordinary message.
+
+**`/loop` isn't a command. It's a behavior taught by a tool description.** The thing that actually exists is a tool called `schedule_wakeup`, whose description spells out the convention: if the user's message starts with `/loop` plus a duration, parse the duration and call me with `repeat=true`; if it's `/loop` with no duration, enter dynamic mode and decide the next interval yourself each time you wake. Everything else is left to the model's reading comprehension.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant M as Model
+    participant W as schedule_wakeup
+    participant T as time.AfterFunc (in-process timer)
+    participant S as same session
+
+    M->>W: repeat=true, delay=300s (clamped to [60, 3600])
+    W->>T: arm the timer (12-hour hard cap)
+    T-->>S: fires: drop a [LOOP TICK] system reminder into the inbox
+    S->>M: kick one idle turn, the model carries on
+    T->>T: repeat=true → re-arm inside the callback
+```
+
+What makes this design good is how cleanly it splits three responsibilities: **parsing belongs to the model** (no parser needed for "5m" or "every half hour"), **triggering belongs to Go** (`time.AfterFunc`; on wake, the prompt is wrapped as a system reminder and dropped into the session inbox, reusing the existing pathway for background-task notifications), and **cadence belongs to convention** (in dynamic mode, if the model doesn't re-arm, the loop simply ends — the termination condition is the model's *inaction*, not a state machine).
+
+The cost is that loops live entirely in process memory: the timers are a map on the `Server` struct, gone on restart, with no state file. That's a deliberate division of labor — periodic tasks that must survive restarts belong to a different subsystem, `internal/scheduler` (real cron, JSON-persisted under `~/.octo/tasks/`); `/loop` serves the session-scoped "keep an eye on this for the next few hours" need, which is why it carries a 12-hour hard cap after which it stops re-arming. As for "won't a long-running loop blow up the history" — every tick is just a normal turn, and the compaction machinery above applies unchanged. Loop needs, and gets, no special treatment.
+
+## Workflow: Make Orchestration Turing-Complete, but Keep It Away from the System
+
+Concurrent sub-agents are another recurring need: "review this diff from correctness, security, and performance angles simultaneously, then synthesize." Having the main model call sub-agents one by one is slow and expensive; making users write Go is too heavy. octo-agent's answer is a Ruby DSL:
+
+```ruby
+findings = parallel(["correctness", "security", "performance"].map { |view|
+  -> { agent("Review this diff from the #{view} angle") }
+})
+agent("Synthesize these findings: #{findings.join("\n")}")
+```
+
+Where does this script run? The answer takes a detour: **an mruby interpreter, compiled to wasm32-wasi, executed by wazero (a pure-Go wasm runtime).** Every layer of the detour has a reason. Turing-complete orchestration (loops, conditionals, retries) demands a real language. Embedding an interpreter without cgo is non-negotiable — cgo destroys Go's "one command, binaries for every platform" cross-compilation, fatal for a project whose selling point is single-file distribution. And the wasm sandbox solves a third problem for free: user scripts physically cannot touch the filesystem or network; their entire capability surface is the handful of functions the host explicitly exports. Even the regex support is a child of this constraint — mruby's official C regex engine won't compile for the wasi target, so `Regexp` is bridged to Go's RE2, with an accidental bonus: RE2 guarantees linear time, so script authors can't write a ReDoS.
+
+The most delicate part is the concurrency model. mruby inside wasm is single-threaded — how does `parallel` actually parallelize? By **two kinds of coroutines shaking hands at the function boundary**: Fibers (cooperative) on the mruby side, goroutines (truly concurrent) on the Go side.
+
+```mermaid
+flowchart TB
+    subgraph mruby["mruby VM (inside wasm, single-threaded)"]
+        F1["Fiber ①: agent('correctness…')"]
+        F2["Fiber ②: agent('security…')"]
+        L["scheduler loop __run_fibers"]
+    end
+    subgraph go["Go host (real concurrency)"]
+        S["agent_start: register token,<br/>immediately go func() the sub-agent"]
+        G1["goroutine ①: LLM call"]
+        G2["goroutine ②: LLM call"]
+        W["agent_wait_any:<br/>select on first completion"]
+    end
+    F1 -->|"non-blocking start"| S
+    F2 -->|"non-blocking start"| S
+    S --> G1
+    S --> G2
+    F1 -.->|"Fiber.yield suspends"| L
+    F2 -.->|"Fiber.yield suspends"| L
+    L -->|wait| W
+    G1 --> W
+    G2 --> W
+    W -->|"first finished token"| L
+    L -->|"resume that Fiber"| F1
+```
+
+An `agent()` call into the host's `agent_start` is non-blocking: the Go side immediately spawns a goroutine for the real LLM call and hands back a token, while the mruby side suspends itself with `Fiber.yield`. The scheduler loop first advances every branch to its first `agent()` call — launching all the goroutines — then repeatedly calls `agent_wait_any` (a Go `select` parked on a completion channel) and resumes whichever Fiber's work finished first. Concurrency is capped at a hardcoded 8; calls beyond the cap queue on a semaphore, so a `parallel` over a large list can't fan out an unbounded number of concurrent LLM turns.
+
+There's a journal to go with it: every `agent()` result is appended to `~/.octo/workflow-journals/`, and on re-run — after verifying the script+args hash matches — completed calls replay their cached results instead of hitting the LLM again. For a long workflow that died at step 8, fixing one line and re-running doesn't re-pay for the first 7 steps.
+
+## Browser: Never Launch, Only Attach
+
+The industry-standard move in browser automation is to launch a headless Chrome. octo-agent goes the opposite way: **it never launches a browser; it only attaches to the Chrome the user already has open.** The launch capability exists in the code but the production path never calls it, and the comment is blunt about why: a self-launched headless instance carries no login sessions, and on macOS it trips the "Chrome Safe Storage" keychain prompt — for a daily-driver tool, the moment that dialog appears, the user's trust is gone. When no attachable Chrome is found, the tool returns instructions for enabling the remote-debugging port rather than silently falling back to headless.
+
+Underneath is a hand-rolled CDP (Chrome DevTools Protocol) client over `gorilla/websocket` — no chromedp. The needed domains (Target/Page/DOM/Runtime/Input/Network and a few more) are a short list; writing them directly turns out thinner than the dependency.
+
+The part worth unpacking is **record & replay**. What gets recorded is neither a screen capture nor a coordinate sequence — coordinates die with the next window resize — but a **semantic event stream**:
+
+```mermaid
+flowchart LR
+    A["Inject listener script<br/>(Runtime.addBinding)"] --> B["Capture click / change / navigation"]
+    B --> C["Generate a selector per target<br/>#id → data-testid / aria-label<br/>→ fallback nth-of-type path"]
+    C --> D["Password fields flagged secret,<br/>value never stored"]
+    D --> E["Compile: dedupe + parameterize<br/>into {{param}} placeholders"]
+    E --> F["Artifact: structured YAML<br/>~/.octo/browser-skills/*.yaml"]
+```
+
+Each recorded step compiles into structured fields — `action / selector / value / verify` — with the repeatable inputs (search terms, dates) lifted into parameters: record once, replay many times with arguments.
+
+But selectors rot: the frontend ships a redesign, `.btn-submit` becomes `.button-primary`, and the script breaks. The replay engine responds in two tiers. Tier one costs nothing: the most common failure is actually a cookie banner covering the target, so first dismiss the overlay and retry. Tier two is **self-healing**: hand the LLM the step's intent description, the dead selector, and a digest of every interactive element on the current page, and ask for exactly one new selector; swap it in and retry, up to three rounds. If the fix works and the whole skill runs green, the new selector is **written back to the YAML on disk** — the healing is durable, so one redesign doesn't cost you an LLM repair fee on every subsequent replay.
+
+One axed feature deserves a footnote: early versions tried auto-triggering recorded skills when the user mentioned certain keywords. Too many false triggers in practice; it was removed. Recorded skills now fire in exactly two ways — an explicit Replay button in the Web UI, or the model explicitly invoking `run_skill` in conversation. The design doc keeps the record of that failure — knowing what was tried and abandoned is sometimes worth more than knowing what exists.
+
+## Permissions: Admitting It's Just String Matching
+
+An agent that can run arbitrary shell commands needs its security model thought all the way through. octo-agent's permission system has three designs worth telling, and one piece of honesty worth respecting.
+
+**First, precedence is independent of declaration order.** The verdict is not "first matching rule from the top wins" — that would make the line order of a config file part of the security semantics, where reshuffling lines can open a hole. The actual implementation buckets: walk every rule, drop the hits into deny/ask/allow buckets, then read out in fixed precedence — a non-empty deny bucket means denied, regardless of whether an allow was written above or below it. The hardcoded backstop rules (catastrophes like `^rm -rf /usr`, `^dd if=`) ride the same mechanism, so no user-written allow can override them.
+
+**Second, the `^` anchor exists because of real incidents.** Matching is substring-based at its core, and bare substrings over-block: `deny: "format"` was meant to stop disk formatting but also blocked `docker ps --format json`; `deny: "shutdown"` blocked `git commit -m "fix shutdown handling"` — the sensitive word merely appeared inside a commit message. The `^` prefix anchors the match to **command position**: start of line, after `&&`/`;`/`|`, after `sudo` or environment-variable prefixes. `^format` matches format being *executed as a command*, never as an argument or string content. This feature wasn't designed in the abstract; it was forced into existence by those two false positives.
+
+**Third, hot reload plus graceful degradation.** The permission engine is rebuilt every turn, so an edit to `permissions.yml` takes effect on the very next command, no restart. What if the YAML is mid-edit and syntactically broken? Fall back to the last successfully parsed rules (`lastGoodRules`) and log a warning — a briefly broken config file must neither crash the session nor leave it *temporarily unguarded* during that window.
+
+Then the honesty. **By default, octo-agent has no OS-level isolation whatsoever**: without `--sandbox`, the shell tool is a bare `exec.Command("sh", "-c", ...)`, and the only line of defense is the string rules above. Real OS-level isolation is opt-in depth: Seatbelt on macOS, Landlock + seccomp on Linux (inet sockets banned outright), unsupported elsewhere — and if `--sandbox` is requested on an unsupported platform, it refuses to run (fail closed) rather than silently degrading. The package comment in `internal/sandbox` characterizes the relationship precisely: the sandbox is "defense-in-depth *beneath* the permission engine, which only gates command strings." String matching can of course be bypassed — stating the boundary plainly is worth far more than advertising a security model that doesn't exist.
+
+The companion audit log records every deny and every user verdict (one JSON per line, 10 MiB rotation). One detail inside: every field is truncated at 1 KiB. Not to save disk — to prevent a single rejected `write_file` from copying an entire file's contents, or a command containing a secret, verbatim into the audit log. The audit log must not become a new leak surface.
+
+## Trash Can: Designed for the Premise "the Model Will Delete the Wrong File"
+
+The last mechanism is the humblest, and the clearest window into the project's worldview. The premise is simple: the model **will** delete the wrong file. Not might — eventually will. So the right question isn't "how do we prevent wrong deletions" but "what happens after one."
+
+octo-agent's answer is to turn every destructive operation from irreversible into reversible — with broader coverage than you'd guess:
+
+```mermaid
+flowchart TD
+    A["rm in the shell<br/>(injected __octo_safe_rm backs up first)"] --> T
+    B["Remove-Item on Windows<br/>(cmdlet shadowed by a wrapper)"] --> T
+    C["write_file / edit_file overwriting an existing file<br/>(old version backed up first)"] --> T
+    D["programmatic deletion<br/>session / skill / workflow / memory"] --> T
+    T["~/.octo/trash/&lt;project hash&gt;/<br/>&lt;timestamp&gt;_&lt;random&gt;_&lt;filename&gt; + .meta.json"]
+    T --> R["octo trash restore<br/>(by ID or fuzzy path match)"]
+    T --> E["background cleanup: 14-day expiry<br/>+ size cap, oldest evicted first"]
+```
+
+The `rm` interception works by injecting a same-named function into the shell environment; before the real delete, the target is moved into the trash via `cp -al` (hard links, nearly zero cost). On Windows the `Remove-Item` cmdlet is shadowed to run the same flow. Even the model *editing* files is covered — `write_file` overwriting an existing file sends the old version to the trash first.
+
+One judgment call in the overwrite backup shows real craft: **if the target file is git-tracked and the working tree is clean, skip the backup.** Git already has that content; a second copy in the trash is pure waste. One `git ls-files` plus two `git diff --quiet` calls cut the trash noise dramatically — a good safety net must not only catch, it must stay quiet, or users will switch the whole thing off.
+
+Recovery goes through `octo trash restore`, matching by ID or fuzzy path. If the destination is now occupied, three policies apply: abort with an error (default), move the occupant into the trash too and then restore, or restore under a timestamped new name. Each project's trash is isolated by a hash of the project path; it's purely local, with 14-day expiry and a size cap enforced by background cleanup, so it never grows without bound.
+
+## Coda: One Worldview Throughout
+
+Each of the seven mechanisms minds its own patch; together they express a single judgment: **in an agent system, whatever a mechanism can guarantee, never leave to the model's good behavior.**
+
+Compaction relies on token thresholds and safe split points, not on praying the summary loses nothing. Cache breakpoints are placed explicitly, not left to luck. Loop has a 12-hour hard cap to catch a model that forgets to stop. Workflow's concurrency cap is a constant, not a hope that script authors show restraint. Every rule in the permission system — deny precedence, command anchoring — maps to an incident that actually happened. And the trash can simply assumes wrong deletions are inevitable and spends its effort on the *after*.
+
+The model supplies the intelligence; the mechanisms supply the floor. If one sentence is worth taking away from this codebase, it's that.
 
 ---
 
-## The Architecture Panorama
+### Appendix: Where to Start Reading the Code
 
-<iframe
-  src="/blog/architecture-map.html"
-  width="100%"
-  height="1400"
-  style="border: none; border-radius: 8px;"
-  loading="lazy"
-</iframe>
-
-> 👆 Click any card's title to expand and see key file paths and design details.
-
----
-
-## Seven Facets at a Glance
-
-### 1. Entry Layer: One Agentic Loop, Many Faces
-
-TUI (Bubble Tea), Web (Svelte 5 SPA), Headless (`octo -p "..."`), IM (Feishu / Telegram / Discord / WeChat / WeCom / DingTalk) — five entry points, all running the same `agent.RunStream`. The entry layer's only job is to translate "user input" into a unified turn request and then translate agent events into their respective rendering formats (TUI cards, WebSocket messages, IM text chunks).
-
-### 2. Assembly Layer: The Only Package Allowed to Know Everything
-
-`internal/app/` is the only place that imports `agent`, `provider`, `permission`, `subagent_manager`, `mcp`, and `memorybackend` at the same time. Its job: adapt a Provider to `agent.Sender`, and build a `NewSessionToolEnv` (permission gate, browser, task store, goal store).
-
-Clean separation: upper layers only talk to `app`; `app` assembles everything into what agent needs.
-
-### 3. Agent Core: Doesn't Read HTTP, Doesn't Splice JSON
-
-`Agent.RunStream` is a send → tool-dispatch → reply loop. It only knows that `Sender.SendMessagesToTools()` returns an abstract response. It has no idea about SSE, streaming tool_call fragment splicing, or the spelling differences between `finish_reason` and `stop_reason`.
-
-All wire-format quirks are encapsulated in provider adapters: `internal/provider/anthropic` handles Messages API, `internal/provider/openai` handles Chat Completions. Even the `retry` package is isolated — provider-level request recovery and stream idle timeouts never pollute agent code.
-
-### 4. Provider Normalization: The Same "tool_use"
-
-Anthropic returns `stop_reason: "tool_use"`, OpenAI returns `finish_reason: "tool_calls"`. One job of the provider adapter is to normalize both into the unified "tool calls needed" signal. Similarly, cache-token bucketing differs by protocol: Anthropic uses `(input_tokens, cache_read_input_tokens)`, OpenAI uses `(prompt_tokens, cached_tokens)` — the agent always sees non-overlapping `InputTokens` and `CacheReadTokens` counters.
-
-### 5. Tool System: One Line to Register, Zero Core Edits
-
-Each tool implements the `ToolExecutor` interface + a `Definition()` method (returning the JSON Schema). Adding a tool means appending one line to `tools/allTools`. `DefaultRegistry.Execute` dispatches by name — MCP tools are injected with the `mcp__` prefix, built-ins run their own Go implementations. A permission gate (deny/ask/allow + interactive/auto/strict modes) intercepts before execution.
-
-### 6. The Cross-Cutting "Invisible Champions"
-
-Several packages that don't get their own layer but are everywhere:
-
-- **`internal/permission/`** — deny > ask > allow, deny wins regardless of declaration order. Engine rebuilt per-turn; editing `permissions.yml` takes effect immediately. Parse failures silently fall back to `lastGoodRules` without crashing sessions.
-- **`internal/skills/`** — L1 is just name + description + frontmatter — the smallest system-prompt budget. L2 body is loaded on demand via the `skill` tool, preventing skills from blowing up the context window.
-- **`internal/memorybackend/`** — hindsight / mem0 / agentmemory semantic memory backends, swappable. The `eventSink` hook auto-writes conversations to memory on `EventStop`.
-- **`internal/workflow/`** — mruby (wazero-wasm Fiber) × Go goroutine collaboration; write `agent/parallel/pipeline` composable workflows in Ruby DSL.
-
-### 7. Server + Channel: Dual Event Exits
-
-`internal/server` handles 80+ HTTP routes + WebSocket broadcast. Agent-produced `EventKind` events (text_delta, tool_started, tool_done, turn_done…) fan out in two directions:
-
-- **Server path** → `ws_hub` broadcasts to all WebSocket subscribers
-- **Channel path** → `UIController.Handler` adapts into IM messages (Telegram edit_message / Feishu card.action.trigger / WeChat text chunking)
-
-IM ask buttons (Telegram inline_keyboard / Discord components / Feishu interactive card) map button presses back to `allow/always/deny` text, reusing the existing `isAffirmative` / `isAlways` logic — no new backend code required.
-
----
-
-## One Turn's Lifetime
-
-From the user hitting Enter in the TUI, to the output appearing on screen, there are five steps:
-
-1. **Entry**: `turncore.go` receives the request → calls `RunStream()`
-2. **Assemble turn environment**: `app.NewSessionToolEnv()` injects the permission gate + SubAgentManager + GoalStore + browser + memory
-3. **Core loop**: `RunStream()` calls `SendMessagesToTools()` → LLM returns `tool_use` → permission deny/ask/allow → `DefaultRegistry.Execute` → results fed back to LLM → loop until `end_turn`
-4. **Event broadcast**: each text_delta / tool_start / turn_done through `EventHandler` → TUI card rendering (ViewSink) + WS broadcast (server) + IM message (channel UIController)
-5. **Session sync to disk**: `Session.SyncFrom(history)` appends to `~/.octo/sessions/<id>.jsonl`
-
----
-
-## Quick Map: Where to Find Code
-
-| To understand...            | Go to                                                          |
-| ---------------------------- | -------------------------------------------------------------- |
-| Permission decision logic    | `internal/permission/permission.go`                            |
-| What happens on context overflow | `internal/agent/overflow.go` → `compaction.go`             |
-| Where sessions live, what they look like | `internal/agent/session.go` + `~/.octo/sessions/`    |
-| How sub-agents are spawned   | `internal/tools/subagent_manager/` + `internal/app/spawner.go` |
-| WS protocol details          | `internal/server/ws_types.go`                                  |
-| Adding a new provider        | Copy `internal/provider/anthropic/`, update routing in `app/sender.go` |
-| Adding a new IM              | Implement `channel.Adapter` interface, self-register             |
-
----
-
-## Next Steps
-
-After your first `octo serve`, look right in the Web UI — you'll see this architecture run live: the event stream in the WebSocket panel, session writes, tool-call folding cards — each frame maps directly to the data flow drawn above.
-
-Recommended reading path for backend engineers:
-
-1. `cmd/octo/turncore.go` — what a single turn looks like
-2. `internal/agent/agent.go` — `runLoop` + tool dispatch + senderMu
-3. `internal/server/ws_handlers.go` → WS event conversion
-4. `internal/provider/anthropic/stream.go` → SSE aggregation + stop_reason normalization
-5. `internal/tools/terminal.go` — the canonical `ToolExecutor` reference
-6. `internal/permission/permission.go` — how instant生效 works
-7. `internal/workflow/runtime.go` — mruby Fiber × Go goroutine
-
-Treat each layer as a black box — the full picture forms in ~90 minutes.
+| Mechanism | Entry file |
+|---|---|
+| Agent loop | `internal/agent/agent.go` |
+| Context compaction | `internal/agent/compaction.go` |
+| Prompt cache breakpoints | `internal/provider/anthropic/client.go` (`markMessagesCacheable`) |
+| Protocol token normalization | `internal/provider/openai/types.go` (`nonCachedInput`) |
+| /loop | `internal/tools/schedule_wakeup.go`, `internal/server/loop.go` |
+| Workflow runtime | `internal/workflow/runtime.go`, `internal/workflow/prelude.rb` |
+| Browser record / self-heal | `internal/browser/recorder.go`, `internal/app/browser_heal.go` |
+| Permission verdicts | `internal/permission/permission.go` (`classify` / `Check`) |
+| OS-level sandbox | `internal/sandbox/` |
+| Trash can | `internal/trash/trash.go` |

--- a/blog/src/content/posts/zh/architecture-deep-dive.md
+++ b/blog/src/content/posts/zh/architecture-deep-dive.md
@@ -1,137 +1,305 @@
 ---
-title: "octo-agent 架构深度解析：五层核心栈与全系统依赖图"
-description: "一幅可交互的全景架构图，解析 octo-agent 从 CLI/IM 入口到 LLM 后端的五层单向依赖、agent 叶子包设计、协议无关抽象，以及 permission/workflow/memory 等跨切关注点。"
+title: "octo-agent 深度解析：一个 Agent 系统里真正难的部分"
+description: "从五层单向依赖讲起，拆解 octo-agent 七个核心机制的设计与取舍：上下文压缩、prompt 缓存、loop、workflow 编排、浏览器录制回放、权限管控、回收站。"
 pubDate: 2026-07-08
-updatedDate: 2026-07-10
+updatedDate: 2026-07-17
 author: "octo-agent team"
 tags: ["architecture", "deep-dive", "engineering", "ai-agent"]
 locale: zh
 originalSlug: architecture-deep-dive
 ---
 
-# octo-agent 架构深度解析：五层核心栈与全系统依赖图
+# octo-agent 深度解析：一个 Agent 系统里真正难的部分
 
-> octo-agent 的代码仓库已经膨胀到 480+ Go 文件、六个 IM 桥接、一个内嵌 Svelte 5 工作台。本文用一幅可交互的全景架构图，看懂整个系统是怎么组织起来的。
+调用一次 LLM 很简单，一个 HTTP 请求的事。让 LLM 调用工具也不难，各家 API 都有现成的 tool use 协议。真正难的是围绕这个循环的一圈工程问题：
 
----
+- 上下文窗口是有限的，而对话只会越来越长；
+- 输入 token 是要钱的，而 agent 每一轮都要把全部历史重发一遍；
+- 进程是会退出的，而用户希望任务能"过五分钟再看一眼"；
+- 模型是会犯错的，而它手里握着 `rm -rf` 和你的浏览器。
 
-## 设计哲学：严格单向依赖
+octo-agent 是一个 Go 写的 agent CLI：单二进制、内嵌 Web UI、桥接六种 IM，仓库 480 多个 Go 文件。这篇文章不介绍功能，而是挑上面这几个问题，看它在代码层面各给出了什么答案——以及为什么不是你第一反应想到的那个答案。
 
-octo-agent 最核心的架构准则是**依赖方向严格单向**。整个系统五层栈：
+## 一切的地基：agent 循环必须保持无知
 
+先看整体。octo-agent 的核心其实就是一个 while 循环：把历史发给模型，模型要么给出回答（循环结束），要么要求调用工具；执行工具，把结果追加进历史，回到开头。
+
+```mermaid
+flowchart TB
+    subgraph 入口层["入口层 — 五张脸，一个循环"]
+        TUI["TUI<br/>(Bubble Tea)"]
+        Web["Web<br/>(Svelte 5 SPA)"]
+        Headless["Headless<br/>(octo -p ...)"]
+        IM["IM 桥接<br/>(飞书 / Telegram / Discord ...)"]
+    end
+
+    subgraph 装配层["装配层 — internal/app"]
+        App["唯一同时认识所有组件的包：<br/>provider + permission + subagent<br/>+ mcp + memory 在这里拼装"]
+    end
+
+    subgraph 核心["Agent 核心 — internal/agent（依赖树的叶子）"]
+        Agent["RunStream：send → tool → append → send<br/>不读 HTTP，不拼 JSON，不认识任何协议"]
+    end
+
+    subgraph 下游["被抽象接口隔开的下游"]
+        Provider["internal/provider/<br/>anthropic / openai 适配器"]
+        Tools["internal/tools/<br/>terminal / browser / workflow ..."]
+    end
+
+    TUI --> App
+    Web --> App
+    Headless --> App
+    IM --> App
+    App --> Agent
+    Agent -.->|Sender 接口| Provider
+    Agent -.->|ToolExecutor 接口| Tools
+
+    style Agent fill:#2d3748,color:#fff,stroke:#4a5568
+    style 核心 fill:#1a202c,color:#fff
 ```
-cmd/ → app/ → agent/ ← (provider/, tools/)
+
+这个循环本身只有几百行，围绕它的一切复杂性都被一条纪律挡在外面：**`internal/agent` 是整棵依赖树的叶子包**，它不 import `provider`、不 import `tools`、不 import 任何 UI。它对外只认识两个接口——`Sender`（把消息发出去，拿回一个抽象回复）和 `ToolExecutor`（按名字执行一个工具，拿回一段文本）。
+
+这条纪律的价值在细节里才看得出来。Anthropic 的 API 说"模型想调工具"时用的字段是 `stop_reason: "tool_use"`，OpenAI 用的是 `finish_reason: "tool_calls"`；OpenAI 流式响应里工具参数是拆成 JSON 碎片跨多个 chunk 传的，得按 index 拼好才能解析；有些第三方 OpenAI 兼容服务连 `[DONE]` 哨兵都不发。这些怪癖每一个都足以在核心循环里埋一个 `if provider == "openai"`——而一旦开了这个头，第三个 provider 接入时循环就没法看了。octo-agent 的做法是把它们全部锁死在 `internal/provider/anthropic` 和 `internal/provider/openai` 两个适配器包里，agent 循环永远只见到归一化之后的统一语义。
+
+于是五种入口（TUI、Web、Headless、IM，外加子 agent）跑的是同一条 `RunStream`，接入一个新的 LLM 后端不用改一行 agent 代码，加一个新工具只需要实现接口再注册一行。一次 turn 的完整生命周期是这样的：
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as 用户（任意入口）
+    participant Ag as Agent.RunStream
+    participant Perm as 权限闸门
+    participant Prov as Provider 适配器
+    participant Tool as 工具
+
+    U->>Ag: 一条消息（app 层已注入好权限/浏览器/记忆等环境）
+    loop 直到模型给出最终回答
+        Ag->>Prov: SendMessagesToTools(全部历史)
+        Prov-->>Ag: 归一化后的 text / tool_use
+        Ag->>Perm: 这个调用允许吗？(deny/ask/allow)
+        Perm-->>Ag: 放行 / 询问用户 / 拒绝
+        Ag->>Tool: 执行，结果作为 tool_result 追加进历史
+    end
+    Ag-->>U: 事件流（text_delta / tool_started / turn_done）
+    Note over Ag: 历史落盘到 ~/.octo/sessions/*.jsonl
 ```
 
-`internal/agent/` 是整个依赖树的**叶子包**——它不导入任何上层代码（不导入 `provider`、`tools`、`server`、`channel`、`web`）。所有协议细节、工具实现、UI 渲染都被"向上推"到更高层。
+地基讲完了。接下来是重头戏：这个循环运转起来之后，那些真正难的问题。
 
-这意味着你可以：
-- 替换 LLM 后端（anthropic → openai → deepseek）而不改一行 agent 代码
-- 新增工具（terminal、browser、skill、workflow、MCP……）而不碰 agent 循环
-- 更换渲染终端（TUI、Web IM、Headless）而不影响核心逻辑
+## 上下文压缩：不能删消息，只能折叠时间
 
-这一条纪律，是 octo-agent 能持续膨胀的主要原因。
+第一个撞上的问题是物理限制：上下文窗口就那么大，而 agent 对话膨胀得飞快——一次编译报错的 tool_result 就可能有几千 token，一个下午的会话轻松堆到十几万。
+
+直觉方案是"窗口快满了就删掉最早的消息"。这在 agent 场景下会直接把 API 请求搞挂：历史里的 `tool_use` 和 `tool_result` 是严格配对的，删消息一旦切断某一对，Anthropic 和 OpenAI 都会返回 400。而且"最早的消息"里往往有整个任务的原始需求，删了它，agent 后半程就不知道自己在干什么了。
+
+octo-agent 的方案是**摘要折叠**：把早期历史压成一段摘要，近期历史原文保留。关键在三个细节。
+
+```mermaid
+flowchart LR
+    A["占用 ≥ 窗口 75%"] --> B["先白嫖：回收过期的<br/>大块 tool_result（零成本）"]
+    B --> C{"还超？"}
+    C -->|否| Z["结束"]
+    C -->|是| D["找切分点：只在<br/>『纯 user 消息』边界切"]
+    D --> E["切分点之前 → LLM 摘要<br/>之后（≤窗口30%）→ 原文保留"]
+    E --> F["历史重建为：<br/>一条摘要消息 + 近期原文"]
+```
+
+**第一，切分点永远安全。** `safeSplitIndexByBudget`（`internal/agent/compaction.go`）只会在"不含任何 tool_result 的纯 user 消息"处下刀，从结构上保证 tool_use/tool_result 配对永远不会被劈开。这也让压缩可以发生在 turn 进行中——一个长 turn 每跑完一批工具调用就检查一次占用，超了立刻折叠更早的完整轮次，正在进行的调用毫发无伤。对于动辄几十次工具调用的 agent 长任务，"turn 中途能压缩"不是锦上添花，是必需品。
+
+**第二，占用的算法反直觉。** 上下文占用不是 `input_tokens` 报多少算多少——命中 prompt 缓存时 Anthropic 的 `input_tokens` 只是未命中的差量，真实占用得把 `cache_read + cache_write` 加回来（`agent.go` 的 `accrueUsage`）。不这么算的话，缓存命中率越高，压缩越不触发，最后一次缓存 miss 直接把窗口打爆。
+
+**第三，压缩有阻尼。** 触发阈值默认 75%（可配 `compact_auto_pct`），保留预算是窗口的 30%，另有一条反抖动规则：这次折叠能省下的比例不足 15% 就干脆不折——否则临界状态下每一轮都要付一次昂贵的摘要调用。
+
+一个值得知道的坑：**落盘的 `session.jsonl` 存的是压缩后的历史**。compaction 走的是整体重建历史，会触发 session 文件全量重写，原文只有在配置了 `ArchiveDir` 时才会归档成 `chunk-*.md`（摘要末尾会附上文件路径，模型需要时可以自己用 read 工具翻回去），否则永久丢失。另外历史变短会导致 Web 前端持有的 `message_index`（编辑/分支功能依赖它）集体失效，服务端用水位线检测到长度回缩后会强制前端重拉整个 transcript——这类"压缩的涟漪效应"是这套机制里返工最多的部分。
+
+## Prompt 缓存：agent 的账单是二次方的
+
+第二个问题是钱。Agent 循环的每一轮都要重发全部历史，也就是说一个 N 轮的会话，第 1 条消息要被计费 N 次——不做缓存，成本随对话长度平方增长。
+
+Prompt 缓存的原理一句话就能说完：如果这次请求和上次请求有相同的前缀，命中部分按一折左右计费。麻烦在于两点：不同协议对"命中了多少"的报法完全不同；以及 Anthropic 协议需要你**主动声明**缓存到哪里。
+
+先看第一点。这是自建网关接入时最容易翻车的地方：
+
+| 协议 | 缓存命中字段 | `input`/`prompt` tokens 的语义 |
+|---|---|---|
+| Anthropic | `cache_read_input_tokens` | **只是未命中的差量**，命中部分单独计 |
+| OpenAI | `prompt_tokens_details.cached_tokens` | **全部输入**，命中部分是其子集 |
+| DeepSeek | `prompt_cache_hit/miss_tokens` | 显式拆开两个桶 |
+
+同一个语义，三种报法。octo-agent 在 openai 适配器里做一次减法（`nonCachedInput()`，`internal/provider/openai/types.go`），把 OpenAI 系的报数也转成"互不重叠的两个桶"，从此 agent 层的 `InputTokens` 和 `CacheReadTokens` 在所有协议下含义一致——上一节压缩机制依赖的占用计算，正是建立在这个统一之上。协议归一化不是洁癖，是让上层逻辑能写对的前提。
+
+第二点更有意思：断点打在哪。octo-agent 在每个 Anthropic 请求里固定打三个 `cache_control` 断点：
+
+```mermaid
+flowchart TB
+    subgraph Req["请求体（顺序固定：tools → system → messages）"]
+        T["工具定义"]
+        S["system prompt"]
+        M1["……更早的历史……"]
+        M2["倒数第二条消息"]
+        M3["最后一条消息"]
+    end
+    S ---|"断点① 静态前缀<br/>官方端点 1h TTL，第三方网关 5min"| S
+    M2 ---|"断点② 5min"| M2
+    M3 ---|"断点③ 5min"| M3
+```
+
+静态前缀（工具定义 + system prompt）只需要一个断点——因为请求体顺序是 tools 在 system 之前，打在 system 上的断点会连带把工具定义一起缓存住。历史消息则在**最后两条**上各打一个。为什么是两个？因为下一轮请求会追加新消息，上一轮的"最后一条"就变成了"倒数第 N 条"；如果只打一个断点，遇到重试丢弃末条消息的情况，公共前缀上就没有任何断点可命中了。双断点保证滑动窗口无论怎么移动，总有一个断点落在两次请求的公共前缀内。三个断点，Anthropic 的限额是四个，留了余量。
+
+一个诚实的暴露：这套机制目前省下的钱**用户基本看不见**。全仓库只有 headless 模式往 stderr 打一行 `[usage] ... cache %d read`，TUI 和 Web 都只展示 input/output 增量——`SessionCacheTokens()` 这个方法定义了，但没有任何调用方。机制做得很细，可观测性还没跟上。
+
+## /loop：一个不存在的命令
+
+用户经常提这样的需求："每五分钟看一眼 CI 过没过。" octo-agent 的答案是 `/loop 5m 看一眼CI`——但如果你去代码里 grep `/loop` 的实现，会发现服务端命令路由对它的处理是 `return false`：不拦截，当成普通消息发给模型。
+
+**`/loop` 不是命令，是一个工具描述"教"出来的行为。** 真正存在的是一个叫 `schedule_wakeup` 的工具，它的 description 里写明了约定：用户消息以 `/loop + 时长` 开头，就解析时长、带 `repeat=true` 调用我；只有 `/loop` 没有时长，就进入动态模式，每次醒来自己决定下一次隔多久。剩下的交给模型的理解能力。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant M as 模型
+    participant W as schedule_wakeup
+    participant T as time.AfterFunc（进程内定时器）
+    participant S as 同一个 session
+
+    M->>W: repeat=true, delay=300s（clamp 到 [60, 3600]）
+    W->>T: 武装定时器（12 小时硬顶）
+    T-->>S: 到点：投一条 [LOOP TICK] 系统提醒进收件箱
+    S->>M: 踢一次 idle turn，模型继续干活
+    T->>T: repeat=true → 回调里自动重新武装
+```
+
+这个设计好在把三层职责切干净了：**解析归模型**（"5m"还是"每半小时"都不用写 parser），**触发归 Go**（`time.AfterFunc`，唤醒时把 prompt 包成一条系统提醒投进 session 收件箱，复用后台任务通知的现成通路），**节奏归约定**（动态模式下模型不续期，循环自然结束——终止条件是模型的一个"不作为"，而非一段状态机代码）。
+
+代价是 loop 完全活在进程内存里：定时器就是 `Server` 结构体里的一个 map，进程重启即消失，也没有状态文件。这是刻意的分工——需要跨重启存活的定期任务归另一个子系统 `internal/scheduler`（真 cron，JSON 持久化在 `~/.octo/tasks/`）；`/loop` 只服务"接下来几个小时盯着点"这种会话级需求，所以它有 12 小时硬顶，到点就不再续。至于"长跑会不会把历史撑爆"——每个 tick 就是一次普通 turn，上文的压缩机制照常生效，loop 不需要也没有任何特殊处理。
+
+## Workflow：让编排图灵完备，但别让它碰系统
+
+子 agent 并发是另一类需求："对这个 diff 同时跑正确性、安全、性能三个视角的审查，最后汇总。"让主模型挨个调用子 agent 太慢也太贵，让用户写 Go 又太重。octo-agent 给的答案是一个 Ruby DSL：
+
+```ruby
+findings = parallel(["正确性", "安全", "性能"].map { |view|
+  -> { agent("从#{view}视角审查这个 diff") }
+})
+agent("汇总以下发现：#{findings.join("\n")}")
+```
+
+这个脚本跑在哪？答案有点绕：**mruby 解释器，编译成 wasm32-wasi，跑在 wazero（纯 Go 的 wasm runtime）里**。绕出来的每一层都有理由。要图灵完备的编排（循环、条件、重试）就需要真语言；要嵌入解释器又不想引入 cgo——cgo 会毁掉 Go 交叉编译"一条命令出全平台二进制"的能力，对一个以单文件分发为卖点的项目是致命的；而 wasm 沙箱顺手解决了第三个问题：用户脚本天然碰不到文件系统和网络，能力只有宿主显式导出的那几个函数。连正则都是这个约束的产物——mruby 官方 C 正则引擎编译不了 wasi target，于是 Regexp 被桥接到 Go 侧的 RE2 实现，意外的红利是 RE2 保证线性时间，脚本作者写不出 ReDoS。
+
+最精巧的是并发模型。wasm 里的 mruby 是单线程的，`parallel` 怎么真正并行？答案是**两种协程在函数边界上握手**：mruby 侧用 Fiber（协作式），Go 侧用 goroutine（真并发）。
+
+```mermaid
+flowchart TB
+    subgraph mruby["mruby VM（wasm 内，单线程）"]
+        F1["Fiber①: agent('正确性…')"]
+        F2["Fiber②: agent('安全…')"]
+        L["调度循环 __run_fibers"]
+    end
+    subgraph go["Go 宿主（真并发）"]
+        S["agent_start：登记 token<br/>立刻 go func() 发起子 agent"]
+        G1["goroutine①: LLM 调用"]
+        G2["goroutine②: LLM 调用"]
+        W["agent_wait_any：<br/>select 等最先完成的"]
+    end
+    F1 -->|"非阻塞启动"| S
+    F2 -->|"非阻塞启动"| S
+    S --> G1
+    S --> G2
+    F1 -.->|"Fiber.yield 挂起"| L
+    F2 -.->|"Fiber.yield 挂起"| L
+    L -->|等待| W
+    G1 --> W
+    G2 --> W
+    W -->|"最先完成的 token"| L
+    L -->|"resume 对应 Fiber"| F1
+```
+
+`agent()` 调用宿主的 `agent_start` 是非阻塞的：Go 侧立刻起 goroutine 去跑真正的 LLM 调用并返回一个 token，mruby 侧则 `Fiber.yield` 把自己挂起。调度循环先把所有分支都推进到各自第一次 `agent()` 调用——即先把所有 goroutine 都发射出去——然后循环调 `agent_wait_any`（Go 侧一个 `select` 挡在完成 channel 上），谁先完成就 resume 谁的 Fiber。并发上限硬编码为 8，超出的调用在信号量上排队，防止一个 `parallel` 遍历大列表时扇出无界数量的并发 LLM 调用。
+
+配套还有一套 journal 机制：每个 `agent()` 调用的结果都追加记录到 `~/.octo/workflow-journals/`，重跑时校验"脚本+参数"哈希一致后，已完成的调用直接回放缓存结果。对于"跑到第 8 步挂了"的长工作流，改一行重跑不用重付前 7 步的 LLM 账单。
+
+## 浏览器：不启动，只连接
+
+浏览器自动化领域的标准做法是启动一个 headless Chrome。octo-agent 反其道而行：**它永远不启动浏览器，只连接（attach）用户已经开着的那个 Chrome**。代码里留了 launch 能力，但生产路径一次都没调用过，注释写得很直白：自己启动的 headless 实例没有任何登录态，在 macOS 上还会触发"Chrome Safe Storage"的钥匙串弹窗——对一个日常工具来说，这个弹窗一出现，用户的信任就没了。找不到可连的 Chrome 时，工具返回的是一份开启远程调试端口的操作指引，而不是悄悄退回 headless。
+
+底层是基于 `gorilla/websocket` 自研的 CDP（Chrome DevTools Protocol）客户端，没有引 chromedp——需要的 domain（Target/Page/DOM/Runtime/Input/Network 等）就那么几个，自己写反而薄。
+
+真正值得展开的是**录制回放**。录下来的既不是录屏也不是坐标序列——坐标换个窗口尺寸就废——而是**语义化的事件流**：
+
+```mermaid
+flowchart LR
+    A["页面注入监听脚本<br/>（Runtime.addBinding）"] --> B["捕获 click / change / 导航"]
+    B --> C["为目标元素生成选择器<br/>#id → data-testid / aria-label<br/>→ 兜底 nth-of-type 路径"]
+    C --> D["密码字段标记 secret<br/>不落原值"]
+    D --> E["编译：去重 + 参数化为<br/>{{param}} 占位符"]
+    E --> F["产物：结构化 YAML<br/>~/.octo/browser-skills/*.yaml"]
+```
+
+每一步录制都被编译成 `action / selector / value / verify` 这样的结构化字段，可重复输入的部分（搜索词、日期）被抽成参数——一次录制，多次带参重放。
+
+但选择器会腐烂：前端一改版，`.btn-submit` 变成 `.button-primary`，脚本就断了。回放引擎的应对分两层。第一层不花钱：最常见的失败原因其实是 cookie 弹窗挡住了目标元素，先自动关掉遮罩重试。第二层才是**自愈**：把这一步的意图描述、失效的旧选择器、当前页面全部可交互元素的摘要一起交给 LLM，让它只回答一个新选择器，换上重试，最多三轮。修复成功且整个技能跑通后，新选择器**写回磁盘上的 YAML**——自愈的成果是持久的，同一个改版不会让你每次重放都付一次 LLM 修复费。
+
+一个被砍掉的特性也值得记一笔：早期版本尝试过"用户说到某个关键词就自动触发录制好的技能"，实践中误触发太多，已经移除。现在录制好的技能只有两种触发方式：Web UI 里显式点重放，或模型在对话中显式调用 `run_skill`。设计文档里保留了这次失败的记录——知道什么被试过并放弃，有时比知道什么存在更有价值。
+
+## 权限系统：承认自己只是字符串匹配
+
+一个能执行任意 shell 命令的 agent，安全模型必须想清楚。octo-agent 的权限系统有三个值得讲的设计，和一条值得尊敬的诚实。
+
+**第一，优先级与声明顺序无关。** 判定不是"从上往下第一条命中的规则说了算"——那会让规则文件的行序变成安全语义的一部分，改个顺序就可能打开一个洞。实际实现是分桶：遍历所有规则，命中的按 deny/ask/allow 分别入桶，然后按固定优先级取结果——deny 桶非空即拒绝，无视 allow 写在它前面还是后面。硬编码的兜底规则（`^rm -rf /usr`、`^dd if=` 这类灾难命令）也走同一套机制，用户在配置里写 allow 也压不过。
+
+**第二，`^` 锚定解决的是真实事故。** 匹配的基础是子串匹配，但纯子串会误伤：`deny: "format"` 本意是拦磁盘格式化，结果 `docker ps --format json` 也被拦了；`deny: "shutdown"` 会拦下 `git commit -m "fix shutdown handling"`——敏感词出现在 commit message 里而已。`^` 前缀把匹配锚定到**命令位置**：行首、`&&`/`;`/`|` 之后、`sudo`/环境变量前缀之后。`^format` 只匹配作为命令执行的 format，不碰参数和字符串内容。这个特性不是设计出来的，是被上面两个真实误伤逼出来的。
+
+**第三，配置热加载 + 优雅降级。** 权限引擎每个 turn 重建一次，改完 `permissions.yml` 下一条命令就生效，不用重启。改到一半 YAML 语法错误怎么办？回退到上一次成功解析的规则（`lastGoodRules`）并打警告——既不能因为配置文件短暂坏掉就让 session 崩溃，更不能在这个窗口期"暂时不设防"。
+
+然后是那条诚实。**默认情况下，octo-agent 没有任何 OS 级隔离**：不开 `--sandbox` 时，shell 工具就是裸的 `exec.Command("sh", "-c", ...)`，唯一防线是上面的字符串规则。真正的 OS 级隔离是可选纵深：macOS 用 Seatbelt，Linux 用 Landlock + seccomp（直接禁掉 inet socket），其他平台不支持——且请求了 `--sandbox` 但平台不支持时会拒绝启动（fail closed），而不是静默退化。`internal/sandbox` 的包注释把两层的关系定性得很清楚：sandbox 是"permission 引擎之下的纵深防御，而 permission 引擎只 gate 命令字符串"。字符串匹配当然绕得过——把边界说清楚，比宣传一个不存在的安全模型有价值得多。
+
+配套的审计日志记录每一次 deny 和每一次用户裁决（一行一条 JSON，10MiB 轮转）。里面有个细节：每个字段截断到 1KiB。不是省磁盘——是防止一次被拒绝的 `write_file` 把整份文件内容、或一条含密钥的命令，原样抄进审计日志。审计日志本身不该成为新的泄露面。
+
+## 回收站：为"模型会删错文件"这个前提设计
+
+最后一个机制最朴素，也最能体现这个项目的世界观。前提很简单：模型**会**删错文件。不是可能，是迟早。那么正确的问题就不是"怎么防止删错"，而是"删错之后怎么办"。
+
+octo-agent 的答案是把所有破坏性操作从"不可逆"改成"可逆"——而且覆盖面比你以为的宽：
+
+```mermaid
+flowchart TD
+    A["shell 里的 rm<br/>（注入的 __octo_safe_rm 先备份再删）"] --> T
+    B["Windows 的 Remove-Item<br/>（cmdlet 被包装函数遮蔽）"] --> T
+    C["write_file / edit_file 覆盖已有文件<br/>（旧版本先备份）"] --> T
+    D["程序化删除<br/>session / skill / workflow / memory"] --> T
+    T["~/.octo/trash/<项目哈希>/<br/><时间戳>_<随机>_<文件名> + .meta.json"]
+    T --> R["octo trash restore<br/>（按 ID 或路径模糊匹配）"]
+    T --> E["后台清理：14 天过期<br/>+ 容量上限，最旧先走"]
+```
+
+`rm` 的拦截方式是往 shell 环境里注入一个同名函数，真删之前先 `cp -al`（硬链接，几乎零成本）把目标搬进回收站；Windows 上则遮蔽 `Remove-Item` cmdlet 走同样的流程。连模型改文件这种操作也在保护范围内——`write_file` 覆盖已有文件前旧版本先进回收站。
+
+覆盖备份里有一个判断特别见功力：**如果目标文件被 git 跟踪且工作区是干净的，跳过备份**。因为这份内容 git 里已经有了，回收站再存一份是纯浪费。一个 `git ls-files` 加两次 `git diff --quiet`，把回收站噪音降了一大截——好的安全网不光要接得住，还要足够安静，不然很快会被用户整个关掉。
+
+恢复走 `octo trash restore`，支持 ID 或路径模糊匹配；目标路径已被占用时可选三种策略：报错中止（默认）、把占用者也挪进回收站再恢复、或恢复为带时间戳的新名字。每个项目的回收站按项目路径哈希隔离，纯本地，14 天过期加容量上限的后台清理，不会无限膨胀。
+
+## 尾声：一以贯之的世界观
+
+七个机制分开看各管一摊，合起来是同一个判断：**在 agent 系统里，凡是能用机制保证的，就不要指望模型的自觉。**
+
+压缩靠 token 阈值和安全切分点，而不是祈祷摘要别丢东西；缓存断点是显式插的，不是等运气命中；loop 有 12 小时硬顶兜住模型忘记停止；workflow 的并发上限是常量，不指望脚本作者自律；权限系统的 deny 优先和命令锚定，每一条都对应一个真出过的事故；回收站则干脆假设删错必然发生，把功夫花在"删错之后"。
+
+模型负责聪明，机制负责兜底。这大概就是读完这份代码库之后，最值得带走的一句话。
 
 ---
 
-## 全景架构图
+### 附：想读代码，从这里进
 
-<iframe
-  src="/blog/architecture-map.html"
-  width="100%"
-  height="1400"
-  style="border: none; border-radius: 8px;"
-  loading="lazy"
-></iframe>
-
-> 👆 点击每个卡片的标题区域，可展开查看关键文件路径和设计细节。
-
----
-
-## 七个切面速览
-
-### 1. 入口层：同一条 agentic 循环，多种面孔
-
-TUI（Bubble Tea）、Web（Svelte 5 SPA）、Headless（`octo -p "..."`）、IM（飞书/Telegram/Discord/微信/企微/钉钉）——五种入口，底层跑的都是同一个 `agent.RunStream`。入口层唯一做的事是把"用户输入"翻译成统一的 turn 请求，然后把 agent 产出的事件翻译成各自的渲染格式（TUI 卡片、WebSocket 消息、IM 分片文本）。
-
-### 2. 装配层：唯一有权限知道所有东西的包
-
-`internal/app/` 是整个系统唯一同时导入 `agent`、`provider`、`permission`、`subagent_manager`、`mcp`、`memorybackend` 的地方。它负责把 Provider 适配成 `agent.Sender`，搭建 `NewSessionToolEnv`（包含权限闸门、浏览器、任务 store、goal store）。
-
-职责分明：上层只和 `app` 交互；`app` 负责把一切组装成 agent 需要的样子。
-
-### 3. Agent 核心：不读 HTTP、不拼 JSON
-
-`Agent.RunStream` 是 send → tool-dispatch → reply 的循环。它只知道 `Sender.SendMessagesToTools()` 返回一个抽象响应；不知道 SSE、不知道 tool_call 流式拼接、不知道 `finish_reason` 和 `stop_reason` 的拼写差异。
-
-所有 Wire 格式的怪癖都被封在 Provider 适配层：`internal/provider/anthropic` 处理 Messages API、`internal/provider/openai` 处理 Chat Completions。甚至 `retry` 包也是独立的——provider 级别的请求恢复和流式 idle 超时，完全不污染 agent。
-
-### 4. Provider 归一化：同一个"tool_use"
-
-Anthropic 返回 `stop_reason: "tool_use"`，OpenAI 返回 `finish_reason: "tool_calls"`。Provider 适配层的职责之一就是把它们归一化成统一的"需要调用工具"信号。同理，cache token 分桶在 Anthropic 协议是 `(input_tokens, cache_read_input_tokens)`，在 OpenAI 协议是 `(prompt_tokens, cached_tokens)`，agent 看到的始终是统一的 `InputTokens` 和 `CacheReadTokens` 不重叠计数。
-
-### 5. 工具系统：一行注册，不改核心
-
-每个工具实现 `ToolExecutor` 接口 + `Definition()` 方法（返回 JSON Schema）。新增工具只需往 `tools/allTools` 加一行。`DefaultRegistry.Execute` 按名分发——MCP 工具以 `mcp__` 前缀注入、内置工具走自己的 Go 实现。权限闸门（deny/ask/allow + interactive/auto/strict 三 mode）在工具执行前拦截。
-
-### 6. 跨切关注点的"隐形冠军"
-
-几个不单独成片但无处不在的包：
-
-- **`internal/permission/`** — deny > ask > allow，deny 优先级最高，无视声明顺序。每 turn 重建引擎，改 `permissions.yml` 立即生效。解析失败时安静回退到 `lastGoodRules`，不会绷掉 session。
-- **`internal/skills/`** — L1 只有 name + description + frontmatter，注入 system prompt 的 budget 最小；L2 的 body 通过 `skill` 工具按需加载，避免 skill 冲爆上下文窗口。
-- **`internal/memorybackend/`** — hindsight / mem0 / agentmemory 三种语义记忆后端可选。`eventSink` hook 在 `EventStop` 时自动将对话写入记忆。
-- **`internal/workflow/`** — mruby（wazero-wasm Fiber）+ Go goroutine 协作，用 Ruby DSL 写 `agent/parallel/pipeline` 组合式工作流。
-
-### 7. Server + Channel：事件双重出口
-
-`internal/server` 处理 HTTP 路由（80+）+ WebSocket broadcast。Agent 产出的 `EventKind` 事件（text_delta、tool_started、tool_done、turn_done……）被分发两个方向：
-
-- **Server 路径** → `ws_hub` 广播给所有 WebSocket 订阅者
-- **Channel 路径** → `UIController.Handler` 适配成 IM 消息（Telegram edit_message / Feishu card.action.trigger / WeChat 纯文本分包）
-
-IM 的 ask 按钮（Telegram inline_keyboard / Discord components / Feishu interactive card）按下后映射为 `allow/always/deny` 文本，复用已有的 `isAffirmative` / `isAlways` 判断逻辑，完全不需要新的后端路径。
-
----
-
-## 一个 turn 的生命周期
-
-从用户在 TUI 敲下回车，到结果出现在屏幕上，一共五步：
-
-1. **入口**：`turncore.go` 接收请求 → 调 `RunStream()`
-2. **装配 turn 环境**：`app.NewSessionToolEnv()` 注入权限闸门 + SubAgentManager + GoalStore + browser + memory
-3. **核心循环**：`RunStream()` 调 `SendMessagesToTools()` → LLM 返回 `tool_use` → permission deny/ask/allow → `DefaultRegistry.Execute` → 结果回喂 LLM → 循环直到 `end_turn`
-4. **事件广播**：每次 text_delta / tool_start / turn_done 经 `EventHandler` → TUI card 渲染（ViewSink）+ WS broadcast（server）+ IM 消息（channel UIController）
-5. **Session 落盘**：`Session.SyncFrom(history)` 追加到 `~/.octo/sessions/<id>.jsonl`
-
----
-
-## 速查：找代码去哪
-
-| 想了解...                   | 去哪看                                                          |
-| -------------------------- | --------------------------------------------------------------- |
-| 权限判定逻辑               | `internal/permission/permission.go`                             |
-| 上下文溢出怎么办           | `internal/agent/overflow.go` → `compaction.go`                  |
-| session 存在哪、长什么样   | `internal/agent/session.go` + `~/.octo/sessions/`               |
-| 子 agent 怎么 spawn        | `internal/tools/subagent_manager/` + `internal/app/spawner.go`  |
-| WS 协议细节                | `internal/server/ws_types.go`                                   |
-| 加新 provider              | 复制 `internal/provider/anthropic/`、改 `app/sender.go` 路由    |
-| 加新 IM                   | 实现 `channel.Adapter` 接口自注册                               |
-
----
-
-## 下一步
-
-你第一次启动 `octo serve` 后，Web UI 右侧就能看到这套架构在实时运行：WebSocket 面板里的 event 流、session 写入、工具调用折叠卡片——每一帧都对应上图里画的那条数据流。
-
-后端工程师推荐阅读顺序：
-
-1. `cmd/octo/turncore.go` — 单 turn 长什么样
-2. `internal/agent/agent.go` — `runLoop` + tool dispatch + senderMu
-3. `internal/server/ws_handlers.go` → WS 事件转换
-4. `internal/provider/anthropic/stream.go` → SSE 聚合 + stop_reason 归一化
-5. `internal/tools/terminal.go` — 公认的 ToolExecutor 典范
-6. `internal/permission/permission.go` — 即时生效的奥秘
-7. `internal/workflow/runtime.go` — mruby Fiber × Go goroutine
-
-每层当黑盒用，整体认识 ~90 分钟形成。
+| 机制 | 入口文件 |
+|---|---|
+| Agent 循环 | `internal/agent/agent.go` |
+| 上下文压缩 | `internal/agent/compaction.go` |
+| Prompt 缓存断点 | `internal/provider/anthropic/client.go`（`markMessagesCacheable`） |
+| 协议 token 归一化 | `internal/provider/openai/types.go`（`nonCachedInput`） |
+| /loop | `internal/tools/schedule_wakeup.go`、`internal/server/loop.go` |
+| Workflow 运行时 | `internal/workflow/runtime.go`、`internal/workflow/prelude.rb` |
+| 浏览器录制/自愈 | `internal/browser/recorder.go`、`internal/app/browser_heal.go` |
+| 权限判定 | `internal/permission/permission.go`（`classify` / `Check`） |
+| OS 级沙箱 | `internal/sandbox/` |
+| 回收站 | `internal/trash/trash.go` |


### PR DESCRIPTION
## Summary

Rewrites `architecture-deep-dive` (zh + en) from scratch. The old article was a diagram index with bullet-point section summaries; the new one is a problem-driven narrative deep dive aimed at professional developers.

- Opens with the four engineering problems that make agent systems hard (finite context, quadratic cost, process lifetime, model fallibility), then covers the five-layer unidirectional architecture and seven internal mechanisms as answers to those problems: context compaction, prompt caching, `/loop`, workflow orchestration, browser record & replay, permission enforcement, and the trash can.
- Every technical claim was verified against the current source (compaction thresholds/split-point safety, cache breakpoint placement and TTLs, `schedule_wakeup` internals, mruby/wazero Fiber-goroutine bridge, attach-only browser + selector self-heal, permission bucket precedence + `^` anchoring + audit truncation, trash trigger points + git-clean skip).
- Replaces the `/blog/architecture-map.html` iframe with self-contained Mermaid diagrams; the en version uses English diagram labels throughout.
- `astro build` passes (28 pages).

## Notes for review

- The en post is a fresh English rewrite, not a literal translation.
- `pubDate` kept at 2026-07-08; `updatedDate` bumped to 2026-07-17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)