### PR TITLE
fix(agent): keep unanswered user message on interrupt instead of dropping it

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -400,6 +400,12 @@ type tuiModel struct {
 	// user takes the turn back with Esc before any output. Empty when the turn
 	// isn't a typed user message (e.g. a skill, /init, or a dequeued item).
 	echoRestore string
+	// takeBackPending marks an Esc take-back whose interrupt is still winding
+	// down. finishInterrupted keeps the interrupted input in history (capped
+	// with a note); a take-back's contract is "no trace", so handleTurnFinished
+	// consumes this flag and strips that pair before the auto-save — otherwise
+	// the recalled text would silently survive in context as a ghost message.
+	takeBackPending bool
 
 	// partial holds the in-progress assistant text not yet committed to the
 	// scrollback.  In the TUI the raw partial is rendered live in the View()
@@ -2092,6 +2098,16 @@ func (m *tuiModel) handleTurnFinished(err error) (tea.Model, tea.Cmd) {
 	// it would strand that sub-agent's Ask goroutine forever (its resp channel
 	// would never receive, and its context isn't cancelled at turn end). A
 	// foreground ask, by contrast, already unblocks via turn-context cancellation.
+
+	// An Esc take-back recalled the typed text into the input box; remove the
+	// interrupted input (and its interrupt note) from history before the
+	// auto-save below, so the take-back leaves no trace in context. The shape
+	// check inside TakeBackInterrupted makes this a no-op if the turn actually
+	// made progress before the cancel landed (a race Esc can't see).
+	if m.takeBackPending {
+		m.takeBackPending = false
+		m.a.TakeBackInterrupted()
+	}
 
 	// Any steer messages that weren't drained via EventSteerInjected during
 	// the turn (e.g. typed after the last loop iteration) are printed now so

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -235,6 +236,52 @@ func TestTUI_EscTakesBackDuringThinking(t *testing.T) {
 	}
 	if len(m.printlnBuf) != 0 {
 		t.Errorf("nothing should be flushed to the scrollback, got %v", m.printlnBuf)
+	}
+}
+
+// An Esc take-back must leave no trace in the agent's history either: the
+// interrupt keeps the input capped with a note (finishInterrupted), so
+// handleTurnFinished has to strip that pair — otherwise the recalled text
+// would silently survive in context as a ghost message and reappear when the
+// session is resumed or opened in the Web UI.
+func TestTUI_EscTakeBackStripsHistoryGhost(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.cancelTurn = func() {}
+	m.echoPending = userEchoStyle.Render("> ") + "fix the bug"
+	m.echoRestore = "fix the bug"
+
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+
+	// The turn goroutine winds down: finishInterrupted kept the input and
+	// capped it with the interrupt note before turnFinishedMsg arrived.
+	m.a.History.Append(agent.NewUserMessage("fix the bug"))
+	m.a.History.Append(agent.NewAssistantMessage("[Interrupted by user.]"))
+	_, _ = m.handleTurnFinished(context.Canceled)
+
+	if n := m.a.History.Len(); n != 0 {
+		t.Errorf("history len = %d, want 0 (take-back must leave no trace)", n)
+	}
+	if m.takeBackPending {
+		t.Error("takeBackPending should be consumed by handleTurnFinished")
+	}
+}
+
+// A plain interrupt (no take-back) keeps the interrupted input in history —
+// handleTurnFinished must NOT strip it when the user didn't ask for a recall.
+func TestTUI_PlainInterruptKeepsHistory(t *testing.T) {
+	m := newTestModel()
+	m.turnRunning = true
+	m.cancelTurn = func() {}
+	// Echo already committed (output streamed) — Esc is a plain interrupt.
+	_, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+
+	m.a.History.Append(agent.NewUserMessage("fix the bug"))
+	m.a.History.Append(agent.NewAssistantMessage("[Interrupted by user.]"))
+	_, _ = m.handleTurnFinished(context.Canceled)
+
+	if n := m.a.History.Len(); n != 2 {
+		t.Errorf("history len = %d, want 2 (plain interrupt keeps the input)", n)
 	}
 }
 

--- a/cmd/octo/tuirepl_view.go
+++ b/cmd/octo/tuirepl_view.go
@@ -179,16 +179,19 @@ func (m *tuiModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.turnRunning {
 			// Take-back: Esc before the model has produced any output (the echo
 			// is still pending in the live area). Drop the not-yet-committed echo
-			// and restore the typed text to the input box for editing — the agent's
-			// interrupt rolls the unanswered user message back out of history, so
-			// it leaves no trace in the scrollback. Once output has streamed the
-			// echo is already committed (echoPending == "") and Esc only interrupts:
-			// the message stays in the transcript and is NOT recalled into the box
-			// (the user can still press ↑ to edit and resubmit).
+			// and restore the typed text to the input box for editing — the
+			// interrupt keeps the input in history (finishInterrupted caps it
+			// with a note), so handleTurnFinished strips that pair via
+			// takeBackPending to honor the take-back's "no trace" contract.
+			// Once output has streamed the echo is already committed
+			// (echoPending == "") and Esc only interrupts: the message stays in
+			// the transcript and is NOT recalled into the box (the user can
+			// still press ↑ to edit and resubmit).
 			if m.echoPending != "" {
 				restore := m.echoRestore
 				m.echoPending = ""
 				m.echoRestore = ""
+				m.takeBackPending = true
 				m.interrupt()
 				if restore != "" {
 					m.ta.SetValue(restore)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -588,18 +588,25 @@ func (a *Agent) TurnStream(
 	onChunk func(textDelta string),
 	onThinking func(thinkingDelta string),
 ) (Reply, error) {
-	return a.turnStream(ctx, userInput, onChunk, onThinking, nil)
+	return a.turnStream(ctx, userInput, onChunk, onThinking, nil, false)
 }
 
 // turnStream is TurnStream plus an optional event handler, so the RunStream
 // no-tools fallback keeps emitting EventGoalUpdated for goal accounting.
 // Direct TurnStream callers have no event channel and pass nil.
+//
+// finishInterrupt selects the cancellation contract: RunStream-driven calls
+// pass true so an interrupt finalizes via finishInterrupted (user input kept,
+// capped with a note, EventTurnDone emitted) exactly like the tool loop;
+// direct TurnStream/Turn callers pass false and keep the pop-on-error retry
+// contract.
 func (a *Agent) turnStream(
 	ctx context.Context,
 	userInput string,
 	onChunk func(textDelta string),
 	onThinking func(thinkingDelta string),
 	handler EventHandler,
+	finishInterrupt bool,
 ) (Reply, error) {
 	sender := a.GetSender()
 	if sender == nil {
@@ -631,6 +638,9 @@ func (a *Agent) turnStream(
 		}
 	}
 	if err != nil {
+		if finishInterrupt && ctx.Err() != nil {
+			return a.finishInterrupted(handler)
+		}
 		a.History.popLast()
 		return Reply{}, fmt.Errorf("agent: stream: %w", err)
 	}
@@ -754,7 +764,7 @@ func (a *Agent) RunStream(
 	// terminal EventTurnDone is fired here so the caller's contract is
 	// identical regardless of whether tools were used.
 	if len(tools) == 0 || executor == nil {
-		reply, err := a.turnStream(ctx, userInput, onChunk, onThinking, handler)
+		reply, err := a.turnStream(ctx, userInput, onChunk, onThinking, handler, true)
 		if err == nil && handler != nil {
 			r := reply
 			handler(AgentEvent{Kind: EventTurnDone, Reply: &r})
@@ -795,7 +805,7 @@ func (a *Agent) RunStream(
 
 	// Neither tool-aware interface available → plain TurnStream with the
 	// event-adapting onChunk. EventTurnDone fires on success.
-	reply, err = a.turnStream(ctx, userInput, onChunk, onThinking, handler)
+	reply, err = a.turnStream(ctx, userInput, onChunk, onThinking, handler, true)
 	if err == nil && handler != nil {
 		r := reply
 		handler(AgentEvent{Kind: EventTurnDone, Reply: &r})
@@ -1124,9 +1134,12 @@ func (a *Agent) runLoop(
 // context.Canceled so the caller can recognise the interrupt. It restores the
 // user/assistant alternation invariant:
 //
-//   - last message is the unanswered user input → drop it (turn never happened)
-//   - last message is a tool_result (user role) → cap with an assistant note,
-//     so the next user turn doesn't produce two user messages in a row
+//   - last message is user-role (unanswered input or a tool_result) → cap with
+//     an assistant note, so the next user turn doesn't produce two user
+//     messages in a row. The unanswered input is deliberately kept: dropping
+//     it shrank persisted history below the turn-start watermark, and every
+//     UI that re-renders from disk after the turn (web history_reload) lost
+//     the message the user just sent — a fresh session went fully blank.
 //   - last message is an assistant(tool_use) without tool_result → synthesize
 //     error tool_results and cap with an assistant note
 //   - last message is already a plain assistant turn → nothing to do
@@ -1148,10 +1161,8 @@ func (a *Agent) finishInterrupted(handler EventHandler) (Reply, error) {
 				a.History.Append(NewToolResultMessage(results))
 			}
 			a.History.Append(NewAssistantMessage(interruptNote))
-		case last.Role == RoleUser && hasToolResult(last):
-			a.History.Append(NewAssistantMessage(interruptNote))
 		case last.Role == RoleUser:
-			a.History.popLast()
+			a.History.Append(NewAssistantMessage(interruptNote))
 		}
 	}
 	reply := Reply{Content: interruptNote, StopReason: StopReasonInterrupted}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -541,6 +541,14 @@ func (a *Agent) SetSender(s Sender) {
 // appends the reply to history, and returns it. Errors leave History
 // unchanged from before the call.
 func (a *Agent) Turn(ctx context.Context, userInput string) (Reply, error) {
+	return a.turn(ctx, userInput, false)
+}
+
+// turn is Turn plus the finishInterrupt contract selector — see turnStream
+// for the two cancellation contracts. Run's no-tools fallbacks pass true so
+// an interrupted Run keeps the input regardless of tool availability; direct
+// Turn callers pass false and keep the pop-on-error retry contract.
+func (a *Agent) turn(ctx context.Context, userInput string, finishInterrupt bool) (Reply, error) {
 	sender := a.GetSender()
 	if sender == nil {
 		return Reply{}, fmt.Errorf("agent: no Sender configured")
@@ -558,6 +566,9 @@ func (a *Agent) Turn(ctx context.Context, userInput string) (Reply, error) {
 	a.ResetGoalBaseline()
 	reply, err := sender.SendMessages(ctx, a.Model, a.System, a.History.Snapshot(), a.MaxTokens)
 	if err != nil {
+		if finishInterrupt && ctx.Err() != nil {
+			return a.finishInterrupted(nil)
+		}
 		// Pop the user message we just appended so retrying with the same
 		// History doesn't duplicate it. Cheaper than transactional locking
 		// since History is only mutated from this goroutine in M1.2.
@@ -696,13 +707,15 @@ func (a *Agent) Run(ctx context.Context, userInput string, tools []ToolDefinitio
 	// closure reads the final named returns.
 	defer func() { a.fireStop(userInput, reply, err) }()
 
-	// No tools (or a Sender that can't do tools) → plain Turn.
+	// No tools (or a Sender that can't do tools) → plain single-shot turn,
+	// with the loop's interrupt contract (input kept, capped with a note) so
+	// an interrupted Run ends the same whether tools were available or not.
 	if len(tools) == 0 || executor == nil {
-		return a.Turn(ctx, userInput)
+		return a.turn(ctx, userInput, true)
 	}
 	ts, ok := sender.(ToolSender)
 	if !ok {
-		return a.Turn(ctx, userInput)
+		return a.turn(ctx, userInput, true)
 	}
 
 	// Buffered send + nil handler: runLoop runs the same dispatch/history
@@ -1174,6 +1187,31 @@ func (a *Agent) finishInterrupted(handler EventHandler) (Reply, error) {
 	// before finishInterrupted is reached) so the UI shows how many iterations
 	// completed before the interrupt.
 	return reply, context.Canceled
+}
+
+// TakeBackInterrupted undoes an interrupt that produced no output: when
+// history ends with the assistant interrupt note sitting directly on a plain
+// user message (no tool_results — nothing ran), both are removed and true is
+// returned. UIs that recall the interrupted input into their compose box for
+// editing (the TUI's Esc take-back) call this after the turn winds down, so
+// the recalled text doesn't also linger in context as a ghost message. Any
+// other tail shape means the turn made observable progress; it is left
+// untouched and false is returned.
+func (a *Agent) TakeBackInterrupted() bool {
+	msgs := a.History.Snapshot()
+	n := len(msgs)
+	if n < 2 {
+		return false
+	}
+	last, prev := msgs[n-1], msgs[n-2]
+	if last.Role != RoleAssistant || last.Content != interruptNote {
+		return false
+	}
+	if prev.Role != RoleUser || hasToolResult(prev) {
+		return false
+	}
+	a.History.TruncateTo(n - 2)
+	return true
 }
 
 // TurnIterations returns the number of provider round-trips executed during

--- a/internal/agent/interrupt_test.go
+++ b/internal/agent/interrupt_test.go
@@ -9,15 +9,22 @@ import (
 // TestFinishInterrupted_HistoryShapes covers the three history end-states the
 // helper must normalize so the next turn keeps user/assistant alternation.
 func TestFinishInterrupted_HistoryShapes(t *testing.T) {
-	t.Run("unanswered user input is dropped", func(t *testing.T) {
+	t.Run("unanswered user input is kept and capped with a note", func(t *testing.T) {
 		a := New(&summarizeFake{}, "m")
 		a.History.Append(NewUserMessage("hi"))
 		_, err := a.finishInterrupted(nil)
 		if !errors.Is(err, context.Canceled) {
 			t.Errorf("err = %v, want context.Canceled", err)
 		}
-		if a.History.Len() != 0 {
-			t.Errorf("history len = %d, want 0 (unanswered input dropped)", a.History.Len())
+		msgs := a.History.Snapshot()
+		if len(msgs) != 2 {
+			t.Fatalf("history len = %d, want 2 (input kept + interrupt note)", len(msgs))
+		}
+		if msgs[0].Role != RoleUser || msgs[0].Content != "hi" {
+			t.Errorf("msg[0] = %+v, want the original user input", msgs[0])
+		}
+		if last := msgs[1]; last.Role != RoleAssistant || last.Content != interruptNote {
+			t.Errorf("msg[1] = %+v, want assistant interrupt note", last)
 		}
 	})
 
@@ -62,8 +69,10 @@ func (s *cancelOnSendSender) SendMessages(ctx context.Context, _, _ string, _ []
 }
 
 // TestRun_InterruptDuringFirstCall verifies an interrupt on the very first
-// model call returns context.Canceled and leaves history empty (the unanswered
-// user turn is dropped).
+// model call returns context.Canceled. Turn's error-path contract (pop the
+// user message so a retry doesn't duplicate it) applies to every error,
+// including cancellation, so history ends up empty here — unlike the
+// Run/RunStream loop, where finishInterrupted keeps the input.
 func TestRun_InterruptDuringFirstCall(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	a := New(&cancelOnSendSender{cancel: cancel}, "m")

--- a/internal/agent/interrupt_test.go
+++ b/internal/agent/interrupt_test.go
@@ -86,6 +86,104 @@ func TestRun_InterruptDuringFirstCall(t *testing.T) {
 	}
 }
 
+// TestRunStream_InterruptNoTools drives the RunStream no-tools fallback
+// (turnStream with finishInterrupt=true): an interrupt during the provider
+// call must keep the user input capped with the interrupt note — not pop it —
+// and emit exactly one EventTurnDone.
+func TestRunStream_InterruptNoTools(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	a := New(&cancelOnSendSender{cancel: cancel}, "m")
+
+	var turnDones int
+	_, err := a.RunStream(ctx, "hi", nil, nil, func(ev AgentEvent) {
+		if ev.Kind == EventTurnDone {
+			turnDones++
+		}
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	msgs := a.History.Snapshot()
+	if len(msgs) != 2 {
+		t.Fatalf("history len = %d, want 2 (input kept + interrupt note): %+v", len(msgs), msgs)
+	}
+	if msgs[0].Role != RoleUser || msgs[0].Content != "hi" {
+		t.Errorf("msg[0] = %+v, want the original user input", msgs[0])
+	}
+	if msgs[1].Role != RoleAssistant || msgs[1].Content != interruptNote {
+		t.Errorf("msg[1] = %+v, want assistant interrupt note", msgs[1])
+	}
+	if turnDones != 1 {
+		t.Errorf("EventTurnDone fired %d times, want exactly 1", turnDones)
+	}
+}
+
+// TestRun_InterruptNoTools: Run's no-tools fallback must follow the same
+// interrupt contract as its tool loop — input kept, capped with the note —
+// so an interrupted Run ends identically with or without tools.
+func TestRun_InterruptNoTools(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	a := New(&cancelOnSendSender{cancel: cancel}, "m")
+
+	_, err := a.Run(ctx, "hi", nil, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	msgs := a.History.Snapshot()
+	if len(msgs) != 2 {
+		t.Fatalf("history len = %d, want 2 (input kept + interrupt note): %+v", len(msgs), msgs)
+	}
+	if msgs[1].Role != RoleAssistant || msgs[1].Content != interruptNote {
+		t.Errorf("msg[1] = %+v, want assistant interrupt note", msgs[1])
+	}
+}
+
+// TestTakeBackInterrupted covers the take-back contract: the [user, note]
+// pair left by a no-output interrupt is removed; any tail showing progress
+// (tool_results under the note, or no note at all) is left untouched.
+func TestTakeBackInterrupted(t *testing.T) {
+	t.Run("strips the interrupted input and note", func(t *testing.T) {
+		a := New(&summarizeFake{}, "m")
+		a.History.Append(NewUserMessage("old q"))
+		a.History.Append(NewAssistantMessage("old a"))
+		a.History.Append(NewUserMessage("taken back"))
+		a.History.Append(NewAssistantMessage(interruptNote))
+		if !a.TakeBackInterrupted() {
+			t.Fatal("TakeBackInterrupted() = false, want true")
+		}
+		msgs := a.History.Snapshot()
+		if len(msgs) != 2 || msgs[1].Content != "old a" {
+			t.Errorf("history = %+v, want the pre-turn [old q, old a]", msgs)
+		}
+	})
+
+	t.Run("leaves a tool-round interrupt untouched", func(t *testing.T) {
+		a := New(&summarizeFake{}, "m")
+		a.History.Append(NewUserMessage("q"))
+		a.History.Append(NewToolUseMessage([]ContentBlock{NewToolUseBlock("c1", "do", nil)}))
+		a.History.Append(NewToolResultMessage([]ContentBlock{NewToolResultBlock("c1", "canceled", true)}))
+		a.History.Append(NewAssistantMessage(interruptNote))
+		if a.TakeBackInterrupted() {
+			t.Fatal("TakeBackInterrupted() = true, want false (turn made progress)")
+		}
+		if a.History.Len() != 4 {
+			t.Errorf("history len = %d, want 4 (untouched)", a.History.Len())
+		}
+	})
+
+	t.Run("leaves a normal completion untouched", func(t *testing.T) {
+		a := New(&summarizeFake{}, "m")
+		a.History.Append(NewUserMessage("q"))
+		a.History.Append(NewAssistantMessage("real answer"))
+		if a.TakeBackInterrupted() {
+			t.Fatal("TakeBackInterrupted() = true, want false (no interrupt note)")
+		}
+		if a.History.Len() != 2 {
+			t.Errorf("history len = %d, want 2 (untouched)", a.History.Len())
+		}
+	})
+}
+
 // toolThenCancelSender returns a tool_use on the first call; the executor
 // cancels the context during dispatch, so the loop must still produce a
 // well-formed history (assistant tool_use + tool_result + interrupt note).

--- a/internal/server/edit_branch_index_test.go
+++ b/internal/server/edit_branch_index_test.go
@@ -105,12 +105,13 @@ func (s *interruptingSender) StreamMessages(ctx context.Context, _, _ string, _ 
 	return agent.Reply{}, ctx.Err()
 }
 
-// TestDoAgentTurn_InterruptRollback_BroadcastsHistoryReload: interrupting a
-// turn before its first round completes rolls the unanswered user message back
-// just like a provider error does — the reload must fire on the canceled path
-// too, not only the error-toast path ("send → immediately Stop → Edit" is the
-// most natural way to hit the out-of-range 400).
-func TestDoAgentTurn_InterruptRollback_BroadcastsHistoryReload(t *testing.T) {
+// TestDoAgentTurn_Interrupt_KeepsUserMessage_NoReload: interrupting a turn
+// before its first round completes must KEEP the unanswered user message
+// (capped with the interrupt note) and must NOT broadcast history_reload —
+// the old rollback+reload combination cleared the rendered transcript and
+// re-fetched a history that no longer contained the message the user just
+// sent, blanking the chat (fully blank on a fresh session).
+func TestDoAgentTurn_Interrupt_KeepsUserMessage_NoReload(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)
@@ -142,20 +143,25 @@ func TestDoAgentTurn_InterruptRollback_BroadcastsHistoryReload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	if len(reloaded.Messages) != wantLen {
-		t.Fatalf("persisted message count = %d, want %d (interrupted user message should have rolled back)", len(reloaded.Messages), wantLen)
+	// Prior history + the interrupted user message + the assistant interrupt
+	// note: the input survives the interrupt instead of rolling back.
+	if len(reloaded.Messages) != wantLen+2 {
+		t.Fatalf("persisted message count = %d, want %d (user message + interrupt note kept)", len(reloaded.Messages), wantLen+2)
+	}
+	if m := reloaded.Messages[wantLen]; m.Role != agent.RoleUser || m.Content != "second question" {
+		t.Errorf("messages[%d] = %+v, want the interrupted user message", wantLen, m)
+	}
+	if m := reloaded.Messages[wantLen+1]; m.Role != agent.RoleAssistant {
+		t.Errorf("messages[%d].Role = %q, want assistant interrupt note", wantLen+1, m.Role)
 	}
 
-	var seen []map[string]any
-	waitFor(t, func() bool {
-		seen = append(seen, drainConn(t, conn)...)
-		for _, ev := range seen {
-			if ev["type"] == "history_reload" {
-				return true
-			}
+	// doAgentTurn has returned, so every broadcast is already queued: a single
+	// drain sees them all. History did not shrink, so no reload may fire.
+	for _, ev := range drainConn(t, conn) {
+		if ev["type"] == "history_reload" {
+			t.Fatal("history_reload broadcast on interrupt — this is the blank-transcript bug")
 		}
-		return false
-	})
+	}
 }
 
 // failSecondRoundSender drives one successful tool round then errors, so the

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -824,9 +824,9 @@ func (s *Server) handleEditMessage(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("message_index out of range: %d (have %d messages)", req.MessageIndex, len(sess.Messages)))
 		return
 	}
-	// message_index == len(Messages) is legal: a first-round interrupt rolls
-	// the still-unanswered prompt back out of history, so there is nothing
-	// left to strip — the rerun below simply recreates it.
+	// message_index == len(Messages) is legal: a first-round send failure
+	// rolls the still-unanswered prompt back out of history, so there is
+	// nothing left to strip — the rerun below simply recreates it.
 	var blocks []agent.ContentBlock
 	if req.MessageIndex < len(sess.Messages) {
 		target := sess.Messages[req.MessageIndex]

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -938,11 +938,17 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 	a := s.buildAgent(sess)
 
 	if !s.cfg.Tools {
-		reply, err := a.Turn(ctx, userInput)
+		// Run (not Turn) so this path shares the loop's interrupt contract
+		// (input kept, capped with a note) and Stop-hook firing with the WS
+		// transport's no-tools turns.
+		reply, err := a.Run(ctx, userInput, nil, nil)
+		sess.SyncFrom(a.History)
 		if err != nil {
+			// Callers only Save on success; persist what the turn left behind
+			// (an interrupt keeps the input + note) like the WS path does.
+			_ = sess.Save()
 			return "", err
 		}
-		sess.SyncFrom(a.History)
 		return reply.Content, nil
 	}
 
@@ -955,11 +961,15 @@ func (s *Server) runTurn(ctx context.Context, sess *agent.Session, userInput str
 	defer cleanup()
 
 	reply, err := a.Run(ctx, userInput, tools.DefaultToolsForCtx(ctx, a.Model), executor)
+	// Sync even on failure: an interrupt keeps the input + note, and rounds
+	// completed before a mid-turn error are billed work — the WS path
+	// persists both, so this transport must too (callers only Save on
+	// success, hence the explicit Save on the error path).
+	sess.SyncFrom(a.History)
 	if err != nil {
+		_ = sess.Save()
 		return "", err
 	}
-
-	sess.SyncFrom(a.History)
 	return reply.Content, nil
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -2242,6 +2243,54 @@ func TestRunTurnForwardsTools(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("web_search not among forwarded tools: %v", rec.lastTools)
+	}
+}
+
+// ctxCancelSender cancels the turn context on its first provider call —
+// a Ctrl-C/client-disconnect arriving while the call is in flight.
+type ctxCancelSender struct{ cancel context.CancelFunc }
+
+func (s *ctxCancelSender) SendMessages(ctx context.Context, _, _ string, _ []agent.Message, _ int) (agent.Reply, error) {
+	s.cancel()
+	return agent.Reply{}, ctx.Err()
+}
+
+// TestRunTurn_InterruptPersistsKeptInput: the REST transport must persist
+// what an interrupted turn leaves in history (the input capped with the
+// interrupt note) even though runTurn returns an error — its callers only
+// Save on success. The WS path saves on every outcome; without the
+// error-path Save here the kept message silently vanished on this transport.
+func TestRunTurn_InterruptPersistsKeptInput(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	srv := &Server{
+		cfg:       Config{Tools: false},
+		model:     "stub-model",
+		turnLocks: map[string]*sync.Mutex{},
+		sender:    &ctxCancelSender{cancel: cancel},
+	}
+
+	sess := agent.NewSession("stub-model", "")
+	_, err := srv.runTurn(ctx, sess, "fix the bug")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+
+	reloaded, lerr := agent.LoadSession(sess.ID)
+	if lerr != nil {
+		t.Fatalf("session was not persisted on the interrupt path: %v", lerr)
+	}
+	if len(reloaded.Messages) != 2 {
+		t.Fatalf("persisted messages = %d, want 2 (input + interrupt note): %+v", len(reloaded.Messages), reloaded.Messages)
+	}
+	if m := reloaded.Messages[0]; m.Role != agent.RoleUser || m.Content != "fix the bug" {
+		t.Errorf("messages[0] = %+v, want the interrupted user input", m)
+	}
+	if m := reloaded.Messages[1]; m.Role != agent.RoleAssistant {
+		t.Errorf("messages[1].Role = %q, want assistant interrupt note", m.Role)
 	}
 }
 

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -333,8 +333,9 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (sessionID st
 		if !errors.Is(err, context.Canceled) {
 			sw.error(err.Error())
 		}
-		// A first-round failure or interrupt rolls the task prompt back out of
-		// history and the SyncFrom+Save above erased the persisted copy — tell
+		// A first-round failure rolls the task prompt back out of history
+		// (an interrupt no longer does — finishInterrupted keeps the prompt)
+		// and the SyncFrom+Save above erased the persisted copy — tell
 		// watching tabs to re-fetch so their message indices realign with disk
 		// (same contract as doAgentTurn).
 		if len(sess.Messages) < historyWatermark {

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1405,15 +1405,17 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		// A first-round failure makes runLoop roll history back past the user
 		// message (appendUserInput's error-path contract), and the SyncFrom+
 		// Save above erased the crash-safety copy persisted before the turn.
-		// An interrupt can do the same: finishInterrupted pops an unanswered
-		// user message, so this must run for BOTH branches above. The browser
-		// still shows that user bubble with a now out-of-range message_index,
-		// so a later edit/branch would 400. Tell it to re-fetch the (shorter)
-		// transcript so its indices realign with disk. Gated on an actual
-		// shrink below the turn-start watermark (deliberately not the live
-		// state's compaction-adjusted copy) so a mid-turn failure that kept
-		// the message doesn't trigger a needless reload; a turn compacted
-		// below the watermark reloads too, which also realigns its indices.
+		// The browser still shows that user bubble with a now out-of-range
+		// message_index, so a later edit/branch would 400. Tell it to re-fetch
+		// the (shorter) transcript so its indices realign with disk. An
+		// interrupt no longer shrinks history (finishInterrupted keeps the
+		// unanswered user message and caps it with a note — popping it made
+		// this very reload blank the transcript), but the gate must still run
+		// for both branches: a turn compacted below the watermark reloads too,
+		// which also realigns its indices. Gated on an actual shrink below the
+		// turn-start watermark (deliberately not the live state's
+		// compaction-adjusted copy) so a mid-turn failure that kept the
+		// message doesn't trigger a needless reload.
 		if len(sess.Messages) < historyWatermark {
 			s.broadcastHistoryReload(sess.ID)
 		}


### PR DESCRIPTION
## Problem

Interrupting a turn **before its first round completes** (the most common Stop timing — while the model is still thinking/streaming) blanked the web transcript. On a fresh session the entire chat went blank; on an existing session the just-sent message and all partial output vanished.

Chain: `finishInterrupted` popped the unanswered user message ("turn never happened") → persisted history shrank below the turn-start watermark → the shrink gate from #1502 broadcast `history_reload` → the frontend cleared the rendered transcript and re-fetched a history that no longer contained the message the user just sent.

The frontend was faithfully rendering the truth — the data was really gone. The fix is at the source: stop dropping the user's message on interrupt.

## Change

- `finishInterrupted`: a trailing user-role message (unanswered input or tool_result) is now uniformly capped with the assistant interrupt note instead of the input being popped. History never shrinks on interrupt → no `history_reload` → transcript stays put. The next turn sees the interrupted instruction plus `[Interrupted by user.]`, matching how tool-round interrupts have always read.
- `RunStream`'s two no-tools fallbacks route through `turnStream`, whose error path pops unconditionally. Threaded a `finishInterrupt` flag so RunStream-driven turns finalize interrupts via `finishInterrupted` too, while direct `Turn`/`TurnStream` callers keep their documented pop-on-error retry contract.
- The reload-on-shrink gate in `doAgentTurn`/`runScheduledTask` stays — first-round provider errors and mid-turn compaction below the watermark still need it. Comments updated to the new contract.

## Tests

- `TestFinishInterrupted_HistoryShapes`: unanswered-input case now asserts keep+note.
- `TestDoAgentTurn_Interrupt_KeepsUserMessage_NoReload` (rewritten from `…_BroadcastsHistoryReload`): asserts the persisted user message + note survive an interrupt and that **no** `history_reload` is broadcast — the regression guard for the blank transcript.
- `go test -race ./...`, `go vet`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)