### PR TITLE
feat(title): generate session title on message receipt, not turn end

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -892,6 +892,10 @@ func (m *tuiModel) startTurnEchoRestore(line, echo, restore string) tea.Cmd {
 	m.sprintBuf.Reset()
 	m.toolStreamName, m.toolStreamID, m.toolStreamBytes = "", "", 0
 	m.clearSuggestion() // a new turn supersedes any pending follow-up
+	// Title on receipt: kick the throwaway title call now, before the turn
+	// goroutine starts, so its History snapshot is taken pre-append (no
+	// duplicate of line) and the tab title lands while the turn still runs.
+	titleCmd := m.titleCmd(line)
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx = tools.WithWaker(ctx, tuiWaker{prog: m.sink.prog})
 	m.cancelTurn = cancel
@@ -915,6 +919,9 @@ func (m *tuiModel) startTurnEchoRestore(line, echo, restore string) tea.Cmd {
 	if echo != "" && !strings.HasPrefix(echo, "<system-reminder>") {
 		m.echoPending = userEchoStyle.Render("> ") + echo
 		m.echoRestore = restore
+	}
+	if titleCmd != nil {
+		return tea.Batch(m.startTicker(), titleCmd)
 	}
 	return m.startTicker()
 }
@@ -1252,9 +1259,6 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.cfg.suggest && !goalActive {
 				cmds = append(cmds, m.suggestCmd())
 			}
-			if c := m.titleCmd(); c != nil {
-				cmds = append(cmds, c)
-			}
 			return m, tea.Batch(cmds...)
 		}
 		return m, m.flushPrints()
@@ -1419,21 +1423,27 @@ func (m *tuiModel) suggestCmd() tea.Cmd {
 	}
 }
 
-// titleCmd generates a session title off the event loop, once per session. It
-// titleCmd returns a tea.Cmd that asynchronously generates a session title
-// from the agent's history. It returns nil (no-op) when the session is already
-// titled (non-empty and not the "*Octo Agent" placeholder), a generation is
-// already in flight, saving is off, or there's no turn to summarize yet — so it
-// fires exactly once, after the first completed turn. The result is persisted
-// by the titleMsg handler.
-func (m *tuiModel) titleCmd() tea.Cmd {
+// titleCmd returns a tea.Cmd that asynchronously generates a session title,
+// once per session. Fired on receipt of the user's message (turn start), not
+// at turn end, so the terminal tab isn't stuck on "(untitled)" for the whole
+// first turn. pending is the message starting the turn — the turn goroutine
+// appends it to History later, so the snapshot is taken here, synchronously,
+// and pending is added on top. It returns nil (no-op) when the session is
+// already titled (non-empty and not the "*Octo Agent" placeholder), a
+// generation is already in flight, saving is off, or there's nothing to
+// summarize. The result is persisted by the titleMsg handler.
+func (m *tuiModel) titleCmd(pending string) tea.Cmd {
 	if m.cfg.noSave || m.titlePending {
 		return nil
 	}
 	if t := m.cfg.session.Title; t != "" && t != "*Octo Agent" {
 		return nil
 	}
-	if m.a.History.Len() == 0 {
+	msgs := m.a.History.Snapshot()
+	if strings.TrimSpace(pending) != "" {
+		msgs = append(msgs, agent.NewUserMessage(pending))
+	}
+	if len(msgs) == 0 {
 		return nil
 	}
 	m.titlePending = true
@@ -1442,7 +1452,7 @@ func (m *tuiModel) titleCmd() tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
-		t, err := a.GenerateTitle(ctx, tools)
+		t, err := a.GenerateTitleFrom(ctx, msgs, tools)
 		if err != nil {
 			return titleMsg{text: ""}
 		}

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -239,6 +239,31 @@ func TestTUI_EscTakesBackDuringThinking(t *testing.T) {
 	}
 }
 
+// Title generation fires on receipt of the first message: with History still
+// empty (the turn goroutine hasn't appended the input yet), titleCmd must
+// build the throwaway prompt from the pending text alone — the old turn-end
+// version returned nil until a turn had completed.
+func TestTUI_TitleCmdFiresOnFirstMessage(t *testing.T) {
+	m := newTestModel()
+	m.cfg.noSave = false // newTestModel defaults to noSave, which gates titling
+	m.cfg.session = agent.NewSession("m", "")
+
+	c := m.titleCmd("fix the bug")
+	if c == nil {
+		t.Fatal("titleCmd = nil on first message, want a command (title on receipt)")
+	}
+	if !m.titlePending {
+		t.Error("titlePending should be set while generation is in flight")
+	}
+	msg, ok := c().(titleMsg)
+	if !ok {
+		t.Fatalf("cmd returned %T, want titleMsg", c())
+	}
+	if msg.text != "ok" { // stubSender's canned reply
+		t.Errorf("title = %q, want %q", msg.text, "ok")
+	}
+}
+
 // An Esc take-back must leave no trace in the agent's history either: the
 // interrupt keeps the input capped with a note (finishInterrupted), so
 // handleTurnFinished has to strip that pair — otherwise the recalled text

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1348,11 +1348,18 @@ const titleInstruction = "Summarize this conversation as a short title of at mos
 // rationale). The model is told not to call tools; a stray tool_use yields empty
 // Content and we simply produce no title.
 func (a *Agent) GenerateTitle(ctx context.Context, tools []ToolDefinition) (string, error) {
+	return a.GenerateTitleFrom(ctx, a.History.Snapshot(), tools)
+}
+
+// GenerateTitleFrom is GenerateTitle over an explicit message snapshot. It
+// exists for title-on-receipt callers: when a turn starts, the loop goroutine
+// owns History and hasn't appended the incoming user message yet, so the
+// caller passes its own pre-turn snapshot plus that message instead.
+func (a *Agent) GenerateTitleFrom(ctx context.Context, snap []Message, tools []ToolDefinition) (string, error) {
 	sender := a.GetSender()
 	if sender == nil || a.Model == "" {
 		return "", fmt.Errorf("agent: title: not configured")
 	}
-	snap := a.History.Snapshot()
 	if len(snap) == 0 {
 		return "", nil
 	}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -863,7 +863,7 @@ func (s *Session) DisplayTitle() string {
 	if t := strings.TrimSpace(s.Title); t != "" && t != "*Octo Agent" {
 		return t
 	}
-	if snippet := firstUserSnippet(s.Messages); snippet != "" {
+	if snippet := FirstUserSnippet(s.Messages); snippet != "" {
 		return snippet
 	}
 	return "*Octo Agent"
@@ -877,17 +877,17 @@ func (s *Session) FallbackTitleIfPlaceholder() string {
 	if s.Title != "*Octo Agent" {
 		return ""
 	}
-	if snippet := firstUserSnippet(s.Messages); snippet != "" {
+	if snippet := FirstUserSnippet(s.Messages); snippet != "" {
 		_ = s.SetTitle(snippet)
 		return snippet
 	}
 	return ""
 }
 
-// firstUserSnippet extracts a one-line preview from the first user message,
+// FirstUserSnippet extracts a one-line preview from the first user message,
 // skipping injected <system-reminder> blocks and tool-result turns, and
 // truncating to a list-friendly width.
-func firstUserSnippet(msgs []Message) string {
+func FirstUserSnippet(msgs []Message) string {
 	const maxLen = 60
 	for _, m := range msgs {
 		if m.Role != RoleUser {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,7 +203,10 @@ type Server struct {
 	// titlePending guards one in-flight title generation per session
 	// (lazily initialised by claimTitleGeneration).
 	titlePending map[string]bool
-	titleMu      sync.Mutex
+	// pendingTitles carries a mid-turn generated title to the turn goroutine,
+	// which adopts it after its final end-of-turn write (see storePendingTitle).
+	pendingTitles map[string]string
+	titleMu       sync.Mutex
 
 	// WebSocket hub for real-time browser communication.
 	wsHub *wsHub

--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -225,6 +225,94 @@ func isTitlePrompt(msgs []agent.Message) bool {
 	return strings.Contains(msgs[len(msgs)-1].Content, "Summarize this conversation")
 }
 
+// blockingTurnSender lets the title-generation call (plain SendMessages, no
+// tools in these tests) complete instantly while the main turn's streaming
+// call blocks until released — a long agentic first turn in miniature.
+type blockingTurnSender struct {
+	entered chan struct{} // closed when the main call is in flight
+	release chan struct{} // the main call returns once this is closed
+}
+
+func (s *blockingTurnSender) SendMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int) (agent.Reply, error) {
+	if isTitlePrompt(msgs) {
+		return agent.Reply{Content: "early title"}, nil
+	}
+	return agent.Reply{Content: "stub reply"}, nil
+}
+
+func (s *blockingTurnSender) StreamMessages(_ context.Context, _, _ string, _ []agent.Message, _ int, _ func(string), _ func(string)) (agent.Reply, error) {
+	close(s.entered)
+	<-s.release
+	return agent.Reply{Content: "stub reply"}, nil
+}
+
+// TestDoAgentTurn_TitleGeneratedOnReceipt pins the title timing contract:
+// the sidebar title is generated from the incoming user message and lands
+// WHILE the turn is still running — not after it — and still survives the
+// turn's end-of-turn saves (PersistContextUsage rewrites the file from the
+// live Session, whose stale placeholder Title would clobber a title record
+// without the adoption step).
+func TestDoAgentTurn_TitleGeneratedOnReceipt(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	sender := &blockingTurnSender{entered: make(chan struct{}), release: make(chan struct{})}
+	srv.sender = sender
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]agent.InboxItem)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	sess.Title = "Session 4"
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.wsHub.register <- conn
+
+	turnDone := make(chan struct{})
+	go func() {
+		defer close(turnDone)
+		srv.doAgentTurn(sess, "hello there", nil, nil)
+	}()
+	<-sender.entered // the model call is in flight and blocked
+
+	// The rename must arrive while the turn is still blocked.
+	deadline := time.After(5 * time.Second)
+	for renamed := false; !renamed; {
+		select {
+		case b := <-conn.send:
+			var ev map[string]any
+			if json.Unmarshal(b, &ev) == nil && ev["type"] == "session_renamed" && ev["session_id"] == sess.ID {
+				if ev["name"] != "early title" {
+					t.Errorf("name = %v, want %q", ev["name"], "early title")
+				}
+				renamed = true
+			}
+		case <-turnDone:
+			t.Fatal("turn finished before session_renamed — title was not generated on receipt")
+		case <-deadline:
+			t.Fatal("no session_renamed broadcast while the turn was running")
+		}
+	}
+
+	close(sender.release)
+	<-turnDone
+
+	// The turn's final saves must not have clobbered the title.
+	loaded, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if loaded.Title != "early title" {
+		t.Errorf("persisted Title = %q, want %q (turn-end rewrite clobbered it)", loaded.Title, "early title")
+	}
+}
+
 // TestDoAgentTurn_TitleGenerationFailureIsLogged is the regression guard for
 // a real production symptom: on an install where the title-generation call
 // fails every time (bad model config, rate limit, etc.), the sidebar title

--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -55,16 +55,46 @@ func TestIsAutoNamePlaceholder(t *testing.T) {
 	}
 }
 
+// waitForRename blocks until a global session_renamed for sid is observed on
+// conn (or fails on timeout), returning the broadcast name. Shared by the
+// title tests, which all drive a turn whose main call blocks so the rename is
+// guaranteed to land while the turn is still running.
+func waitForRename(t *testing.T, conn *wsConn, sid string) string {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case b := <-conn.send:
+			var ev map[string]any
+			if json.Unmarshal(b, &ev) != nil {
+				continue
+			}
+			if ev["type"] == "session_renamed" && ev["session_id"] == sid {
+				name, _ := ev["name"].(string)
+				return name
+			}
+		case <-deadline:
+			t.Fatal("no session_renamed broadcast — title was never generated")
+			return ""
+		}
+	}
+}
+
 // TestDoAgentTurn_GeneratesSessionTitle is the regression guard for web
-// sessions never getting an auto-generated title. Two historical gaps: only
-// the TUI called GenerateTitle, and web sessions are created with a
-// "Session N" placeholder title that blocked the untitled-only gate.
+// sessions never getting an auto-generated title. Historical gaps: only the
+// TUI called GenerateTitle, and web sessions are created with a "Session N"
+// placeholder that blocked the untitled-only gate. It now also pins the
+// on-receipt timing: the rename is broadcast while the turn is still running,
+// and the title survives the turn's end-of-turn saves (adopted on the single
+// serialized write path — the title goroutine never writes the file itself).
 func TestDoAgentTurn_GeneratesSessionTitle(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	sender := &blockingTurnSender{entered: make(chan struct{}), release: make(chan struct{})}
+	srv.sender = sender
 	srv.initWS()
 	srv.turnRunning = make(map[string]bool)
 	srv.steerQueues = make(map[string][]agent.InboxItem)
@@ -80,44 +110,27 @@ func TestDoAgentTurn_GeneratesSessionTitle(t *testing.T) {
 
 	// Registered but NOT subscribed to the session: session_renamed must be a
 	// global broadcast (the sidebar lists every session in every tab).
-	conn := &wsConn{
-		hub:        srv.wsHub,
-		send:       make(chan []byte, 256),
-		subscribed: map[string]struct{}{},
-	}
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
 	srv.wsHub.register <- conn
 
-	srv.doAgentTurn(sess, "hello there", nil, nil)
+	turnDone := make(chan struct{})
+	go func() { defer close(turnDone); srv.doAgentTurn(sess, "hello there", nil, nil) }()
+	<-sender.entered // main turn call is blocked; title generation runs concurrently
 
-	deadline := time.After(5 * time.Second)
-	for {
-		select {
-		case b := <-conn.send:
-			var ev map[string]any
-			if err := json.Unmarshal(b, &ev); err != nil {
-				continue
-			}
-			if ev["type"] != "session_renamed" {
-				continue
-			}
-			if ev["session_id"] != sess.ID {
-				t.Errorf("session_id = %v, want %s", ev["session_id"], sess.ID)
-			}
-			if ev["name"] != "stub reply" {
-				t.Errorf("name = %v, want %q", ev["name"], "stub reply")
-			}
-			// The title must also be persisted.
-			loaded, err := agent.LoadSession(sess.ID)
-			if err != nil {
-				t.Fatalf("reload: %v", err)
-			}
-			if loaded.Title != "stub reply" {
-				t.Errorf("persisted Title = %q, want %q", loaded.Title, "stub reply")
-			}
-			return
-		case <-deadline:
-			t.Fatal("no session_renamed broadcast — title was never generated")
-		}
+	if name := waitForRename(t, conn, sess.ID); name != "early title" {
+		t.Errorf("rename name = %q, want %q", name, "early title")
+	}
+
+	close(sender.release)
+	<-turnDone
+
+	// The title must survive the turn's end-of-turn saves.
+	loaded, err := agent.LoadSession(sess.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if loaded.Title != "early title" {
+		t.Errorf("persisted Title = %q, want %q", loaded.Title, "early title")
 	}
 }
 
@@ -130,6 +143,8 @@ func TestListSessionsBrief_ReflectsGeneratedTitle(t *testing.T) {
 	t.Setenv("USERPROFILE", tmp)
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	sender := &blockingTurnSender{entered: make(chan struct{}), release: make(chan struct{})}
+	srv.sender = sender
 	srv.initWS()
 	srv.turnRunning = make(map[string]bool)
 	srv.steerQueues = make(map[string][]agent.InboxItem)
@@ -141,32 +156,15 @@ func TestListSessionsBrief_ReflectsGeneratedTitle(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	// Drain the rename broadcast so we know title generation finished.
-	conn := &wsConn{
-		hub:        srv.wsHub,
-		send:       make(chan []byte, 256),
-		subscribed: map[string]struct{}{},
-	}
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
 	srv.wsHub.register <- conn
 
-	srv.doAgentTurn(sess, "hello there", nil, nil)
-
-	deadline := time.After(5 * time.Second)
-wait:
-	for {
-		select {
-		case b := <-conn.send:
-			var ev map[string]any
-			if err := json.Unmarshal(b, &ev); err != nil {
-				continue
-			}
-			if ev["type"] == "session_renamed" && ev["session_id"] == sess.ID {
-				break wait
-			}
-		case <-deadline:
-			t.Fatal("no session_renamed broadcast — title was never generated")
-		}
-	}
+	turnDone := make(chan struct{})
+	go func() { defer close(turnDone); srv.doAgentTurn(sess, "hello there", nil, nil) }()
+	<-sender.entered
+	waitForRename(t, conn, sess.ID)
+	close(sender.release)
+	<-turnDone
 
 	// listSessionsBrief is what the frontend REST fallback calls. It must
 	// report the generated title, not the placeholder.
@@ -174,8 +172,8 @@ wait:
 	if len(brief) != 1 {
 		t.Fatalf("listSessionsBrief returned %d sessions, want 1", len(brief))
 	}
-	if brief[0].Name != "stub reply" {
-		t.Errorf("Name = %q, want %q", brief[0].Name, "stub reply")
+	if brief[0].Name != "early title" {
+		t.Errorf("Name = %q, want %q", brief[0].Name, "early title")
 	}
 }
 
@@ -244,73 +242,6 @@ func (s *blockingTurnSender) StreamMessages(_ context.Context, _, _ string, _ []
 	close(s.entered)
 	<-s.release
 	return agent.Reply{Content: "stub reply"}, nil
-}
-
-// TestDoAgentTurn_TitleGeneratedOnReceipt pins the title timing contract:
-// the sidebar title is generated from the incoming user message and lands
-// WHILE the turn is still running — not after it — and still survives the
-// turn's end-of-turn saves (PersistContextUsage rewrites the file from the
-// live Session, whose stale placeholder Title would clobber a title record
-// without the adoption step).
-func TestDoAgentTurn_TitleGeneratedOnReceipt(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
-	t.Setenv("USERPROFILE", tmp)
-
-	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
-	sender := &blockingTurnSender{entered: make(chan struct{}), release: make(chan struct{})}
-	srv.sender = sender
-	srv.initWS()
-	srv.turnRunning = make(map[string]bool)
-	srv.steerQueues = make(map[string][]agent.InboxItem)
-	srv.sessionAgents = make(map[string]*agent.Agent)
-
-	sess := agent.NewSession("stub-model", "")
-	sess.Title = "Session 4"
-	if err := sess.Save(); err != nil {
-		t.Fatalf("save: %v", err)
-	}
-
-	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
-	srv.wsHub.register <- conn
-
-	turnDone := make(chan struct{})
-	go func() {
-		defer close(turnDone)
-		srv.doAgentTurn(sess, "hello there", nil, nil)
-	}()
-	<-sender.entered // the model call is in flight and blocked
-
-	// The rename must arrive while the turn is still blocked.
-	deadline := time.After(5 * time.Second)
-	for renamed := false; !renamed; {
-		select {
-		case b := <-conn.send:
-			var ev map[string]any
-			if json.Unmarshal(b, &ev) == nil && ev["type"] == "session_renamed" && ev["session_id"] == sess.ID {
-				if ev["name"] != "early title" {
-					t.Errorf("name = %v, want %q", ev["name"], "early title")
-				}
-				renamed = true
-			}
-		case <-turnDone:
-			t.Fatal("turn finished before session_renamed — title was not generated on receipt")
-		case <-deadline:
-			t.Fatal("no session_renamed broadcast while the turn was running")
-		}
-	}
-
-	close(sender.release)
-	<-turnDone
-
-	// The turn's final saves must not have clobbered the title.
-	loaded, err := agent.LoadSession(sess.ID)
-	if err != nil {
-		t.Fatalf("reload: %v", err)
-	}
-	if loaded.Title != "early title" {
-		t.Errorf("persisted Title = %q, want %q (turn-end rewrite clobbered it)", loaded.Title, "early title")
-	}
 }
 
 // TestDoAgentTurn_TitleGenerationFailureIsLogged is the regression guard for

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1326,6 +1326,77 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		s.wireBackgroundTaskNotices(sess.ID)
 	}
 
+	// Once per session, as soon as its first user message arrives: generate a
+	// sidebar title. Fired on receipt rather than at turn end so the user isn't
+	// staring at the placeholder for the whole first turn (an agentic turn can
+	// run minutes). The throwaway call runs concurrently with the turn's own
+	// provider call, off a pre-turn copy of sess.Messages plus this turn's user
+	// message — the live History belongs to the loop goroutine (and is still
+	// empty here). Failure is silent: the fallback snippet lands instead, the
+	// claim is released, and the next user message retries.
+	if isAutoNamePlaceholder(sess.Title) && s.claimTitleGeneration(sess.ID) {
+		sid := sess.ID
+		titleMsgs := append(append([]agent.Message{}, sess.Messages...), userMsg)
+		go func() {
+			defer s.recoverBg("title generation")
+			defer s.releaseTitleGeneration(sid)
+			ctx, cancel := context.WithTimeout(context.Background(), throwawayGenerationTimeout)
+			defer cancel()
+			t, terr := a.GenerateTitleFrom(ctx, titleMsgs, toolDefs)
+			if terr != nil || strings.TrimSpace(t) == "" {
+				if terr != nil {
+					slog.Warn("session title generation failed", "session_id", sid, "err", terr)
+				} else {
+					slog.Warn("session title generation returned an empty title", "session_id", sid)
+				}
+				// Fall back to the first-message snippet instead of leaving
+				// the "*Octo Agent" placeholder (same logic as the TUI).
+				if fresh, lerr := agent.LoadSession(sid); lerr == nil {
+					if title := fresh.FallbackTitleIfPlaceholder(); title != "" {
+						s.wsHub.broadcast("", map[string]any{
+							"type":       "session_renamed",
+							"session_id": sid,
+							"name":       title,
+						})
+					}
+				}
+				return
+			}
+			// Hand the title to the turn goroutine FIRST: its end-of-turn
+			// saves can rewrite the file from the live Session (stale
+			// placeholder Title) and clobber the record persisted below; the
+			// adoption step after the turn's last write re-applies it. Storing
+			// before persisting closes that race in both orders.
+			s.storePendingTitle(sid, t)
+			// Apply the title to a freshly loaded Session, not the live one —
+			// the turn keeps appending to sess on the loop goroutine, and
+			// Session isn't goroutine-safe. A load that races a concurrent
+			// append just errors out and a later turn retries.
+			fresh, lerr := agent.LoadSession(sid)
+			if lerr != nil {
+				slog.Warn("session title generation: reload session failed", "session_id", sid, "err", lerr)
+				return
+			}
+			if !isAutoNamePlaceholder(fresh.Title) {
+				// Not an error: something else (the user, or an earlier
+				// retry) already gave the session a real title.
+				return
+			}
+			if err := fresh.SetTitle(t); err != nil {
+				slog.Warn("session title generation: save failed", "session_id", sid, "err", err)
+				return
+			}
+			// Global broadcast: the sidebar lists every session, so every
+			// connected tab needs the rename, not just this session's
+			// subscribers.
+			s.wsHub.broadcast("", map[string]any{
+				"type":       "session_renamed",
+				"session_id": sid,
+				"name":       t,
+			})
+		}()
+	}
+
 	// Persist the turn's progress incrementally: after any event that grew or
 	// rewrote history, flush it to disk so a server crash mid-turn loses at
 	// most the round in flight, not the whole turn. The length/dirty gate
@@ -1470,6 +1541,19 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	if err := a.PersistContextUsage(sess); err != nil {
 		slog.Warn("session: persist context tokens", "session_id", sess.ID, "err", err)
 	}
+
+	// Adopt a title generated while the turn ran. The generation goroutine
+	// persisted it to a fresh copy, but any turn-end rewrite above (context
+	// tokens, history rewrite) re-stamped the file from this live sess — whose
+	// Title was still the placeholder — clobbering that record. This is the
+	// turn's LAST write, so re-applying here survives; a generation that
+	// finishes later than this point persists itself with nothing left to
+	// clobber it. Broadcast already happened on the generation side.
+	if t := s.takePendingTitle(sess.ID); t != "" && isAutoNamePlaceholder(sess.Title) {
+		if terr := sess.SetTitle(t); terr != nil {
+			slog.Warn("session title adoption: save failed", "session_id", sess.ID, "err", terr)
+		}
+	}
 	_, pm, re, _, _ := s.sessionStatusFields(sess)
 	s.wsHub.broadcast(sess.ID, map[string]any{
 		"type":             "session_update",
@@ -1481,65 +1565,6 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		"permission_mode":  pm,
 		"reasoning_effort": re,
 	})
-
-	// Once per session, after its first successful turn: generate a sidebar
-	// title (matches TUI titleCmd behaviour). Fire-and-forget; a failure is
-	// silent and simply retried after a later turn.
-	if err == nil && isAutoNamePlaceholder(sess.Title) && s.claimTitleGeneration(sess.ID) {
-		sid := sess.ID
-		go func() {
-			defer s.recoverBg("title generation")
-			defer s.releaseTitleGeneration(sid)
-			ctx, cancel := context.WithTimeout(context.Background(), throwawayGenerationTimeout)
-			defer cancel()
-			t, terr := a.GenerateTitle(ctx, toolDefs)
-			if terr != nil || strings.TrimSpace(t) == "" {
-				if terr != nil {
-					slog.Warn("session title generation failed", "session_id", sid, "err", terr)
-				} else {
-					slog.Warn("session title generation returned an empty title", "session_id", sid)
-				}
-				// Fall back to the first-message snippet instead of leaving
-				// the "*Octo Agent" placeholder (same logic as the TUI).
-				if fresh, lerr := agent.LoadSession(sid); lerr == nil {
-					if title := fresh.FallbackTitleIfPlaceholder(); title != "" {
-						s.wsHub.broadcast("", map[string]any{
-							"type":       "session_renamed",
-							"session_id": sid,
-							"name":       title,
-						})
-					}
-				}
-				return
-			}
-			// Apply the title to a freshly loaded Session, not the live one —
-			// chained steer turns keep appending to sess on the loop
-			// goroutine, and Session isn't goroutine-safe. A load that races
-			// a concurrent append just errors out and a later turn retries.
-			fresh, lerr := agent.LoadSession(sid)
-			if lerr != nil {
-				slog.Warn("session title generation: reload session failed", "session_id", sid, "err", lerr)
-				return
-			}
-			if !isAutoNamePlaceholder(fresh.Title) {
-				// Not an error: something else (the user, or an earlier
-				// retry) already gave the session a real title.
-				return
-			}
-			if err := fresh.SetTitle(t); err != nil {
-				slog.Warn("session title generation: save failed", "session_id", sid, "err", err)
-				return
-			}
-			// Global broadcast: the sidebar lists every session, so every
-			// connected tab needs the rename, not just this session's
-			// subscribers.
-			s.wsHub.broadcast("", map[string]any{
-				"type":       "session_renamed",
-				"session_id": sid,
-				"name":       t,
-			})
-		}()
-	}
 
 	// After-turn follow-up suggestion (matches TUI suggestCmd behaviour).
 	// Fire-and-forget: the frontend shows it as ghost text; failures are silent.
@@ -1607,6 +1632,31 @@ func (s *Server) releaseTitleGeneration(sessionID string) {
 	s.titleMu.Lock()
 	delete(s.titlePending, sessionID)
 	s.titleMu.Unlock()
+}
+
+// storePendingTitle hands a title generated mid-turn to the turn goroutine.
+// The generation goroutine persists the title itself, but the turn's own
+// end-of-turn saves can rewrite the session file from the live Session —
+// whose Title field is still the placeholder — clobbering that record. The
+// turn goroutine adopts the pending title after its last write (see
+// doAgentTurn); storing BEFORE the goroutine's own persist is what makes the
+// pair race-free in both orders.
+func (s *Server) storePendingTitle(sessionID, title string) {
+	s.titleMu.Lock()
+	if s.pendingTitles == nil {
+		s.pendingTitles = make(map[string]string)
+	}
+	s.pendingTitles[sessionID] = title
+	s.titleMu.Unlock()
+}
+
+// takePendingTitle returns and clears the title stored by storePendingTitle.
+func (s *Server) takePendingTitle(sessionID string) string {
+	s.titleMu.Lock()
+	defer s.titleMu.Unlock()
+	t := s.pendingTitles[sessionID]
+	delete(s.pendingTitles, sessionID)
+	return t
 }
 
 // ─── wsStreamWriter ────────────────────────────────────────────────────────

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1533,7 +1533,11 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// the turn); this is the turn's LAST write, on the single serialized write
 	// path, so persisting here is safe and survives. A generation that hasn't
 	// finished by now leaves nothing to take — its title rides the next turn's
-	// adoption (already broadcast, so the live UI is correct meanwhile).
+	// adoption (already broadcast, so the live UI is correct meanwhile). If
+	// that session never gets a next turn, the title stays broadcast-only:
+	// disk keeps the placeholder and a reload falls back to the message
+	// snippet. Acceptable for a best-effort throwaway title; the common
+	// long-turn case always finishes generation well before this point.
 	if t := s.takePendingTitle(sess.ID); t != "" && isAutoNamePlaceholder(sess.Title) {
 		if terr := sess.SetTitle(t); terr != nil {
 			slog.Warn("session title adoption: save failed", "session_id", sess.ID, "err", terr)
@@ -1619,13 +1623,12 @@ func (s *Server) releaseTitleGeneration(sessionID string) {
 	s.titleMu.Unlock()
 }
 
-// storePendingTitle hands a title generated mid-turn to the turn goroutine.
-// The generation goroutine persists the title itself, but the turn's own
-// end-of-turn saves can rewrite the session file from the live Session —
-// whose Title field is still the placeholder — clobbering that record. The
-// turn goroutine adopts the pending title after its last write (see
-// doAgentTurn); storing BEFORE the goroutine's own persist is what makes the
-// pair race-free in both orders.
+// storePendingTitle hands a title generated mid-turn to the turn goroutine,
+// which is the ONLY writer of the session file (the generation goroutine must
+// not write it concurrently — rewriteAll truncates in place and would corrupt
+// the transcript). The turn goroutine persists the stored title at its
+// end-of-turn adoption step (see doAgentTurn), on its single serialized write
+// path.
 func (s *Server) storePendingTitle(sessionID, title string) {
 	s.titleMu.Lock()
 	if s.pendingTitles == nil {

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1332,10 +1332,21 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// run minutes). The throwaway call runs concurrently with the turn's own
 	// provider call, off a pre-turn copy of sess.Messages plus this turn's user
 	// message — the live History belongs to the loop goroutine (and is still
-	// empty here). Failure is silent: the fallback snippet lands instead, the
-	// claim is released, and the next user message retries.
+	// empty here).
+	//
+	// The goroutine does NOT write the session file: the turn is concurrently
+	// rewriting it (persistTurnProgress on every event, plus a compaction
+	// rewrite), and a second writer here — via its own LoadSession'd Session —
+	// could truncate the file to a stale, shorter message list and lose the
+	// turn's transcript. Instead it broadcasts the rename (live UX) and hands
+	// the title to the turn goroutine via storePendingTitle; the turn adopts
+	// it after its final write, on the single serialized write path. If the
+	// title lands after that point it rides the next turn's adoption. Failure
+	// falls back to the first-message snippet; the claim releases either way
+	// and the next user message retries.
 	if isAutoNamePlaceholder(sess.Title) && s.claimTitleGeneration(sess.ID) {
 		sid := sess.ID
+		placeholder := sess.Title
 		titleMsgs := append(append([]agent.Message{}, sess.Messages...), userMsg)
 		go func() {
 			defer s.recoverBg("title generation")
@@ -1349,46 +1360,21 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 				} else {
 					slog.Warn("session title generation returned an empty title", "session_id", sid)
 				}
-				// Fall back to the first-message snippet instead of leaving
-				// the "*Octo Agent" placeholder (same logic as the TUI).
-				if fresh, lerr := agent.LoadSession(sid); lerr == nil {
-					if title := fresh.FallbackTitleIfPlaceholder(); title != "" {
-						s.wsHub.broadcast("", map[string]any{
-							"type":       "session_renamed",
-							"session_id": sid,
-							"name":       title,
-						})
-					}
+				// Fall back to the first-message snippet only for the bare
+				// "*Octo Agent" placeholder (matching FallbackTitleIfPlaceholder);
+				// the web's numbered "Session N" is left as-is and retried on the
+				// next turn. Pure snippet, no file IO — the turn owns the file.
+				if placeholder != "*Octo Agent" {
+					return
 				}
-				return
+				t = agent.FirstUserSnippet(titleMsgs)
+				if t == "" {
+					return
+				}
 			}
-			// Hand the title to the turn goroutine FIRST: its end-of-turn
-			// saves can rewrite the file from the live Session (stale
-			// placeholder Title) and clobber the record persisted below; the
-			// adoption step after the turn's last write re-applies it. Storing
-			// before persisting closes that race in both orders.
+			// Hand the title to the turn goroutine (it persists it) and
+			// broadcast the rename so every tab's sidebar updates live.
 			s.storePendingTitle(sid, t)
-			// Apply the title to a freshly loaded Session, not the live one —
-			// the turn keeps appending to sess on the loop goroutine, and
-			// Session isn't goroutine-safe. A load that races a concurrent
-			// append just errors out and a later turn retries.
-			fresh, lerr := agent.LoadSession(sid)
-			if lerr != nil {
-				slog.Warn("session title generation: reload session failed", "session_id", sid, "err", lerr)
-				return
-			}
-			if !isAutoNamePlaceholder(fresh.Title) {
-				// Not an error: something else (the user, or an earlier
-				// retry) already gave the session a real title.
-				return
-			}
-			if err := fresh.SetTitle(t); err != nil {
-				slog.Warn("session title generation: save failed", "session_id", sid, "err", err)
-				return
-			}
-			// Global broadcast: the sidebar lists every session, so every
-			// connected tab needs the rename, not just this session's
-			// subscribers.
 			s.wsHub.broadcast("", map[string]any{
 				"type":       "session_renamed",
 				"session_id": sid,
@@ -1543,12 +1529,11 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	}
 
 	// Adopt a title generated while the turn ran. The generation goroutine
-	// persisted it to a fresh copy, but any turn-end rewrite above (context
-	// tokens, history rewrite) re-stamped the file from this live sess — whose
-	// Title was still the placeholder — clobbering that record. This is the
-	// turn's LAST write, so re-applying here survives; a generation that
-	// finishes later than this point persists itself with nothing left to
-	// clobber it. Broadcast already happened on the generation side.
+	// only broadcast + stored it (it must not write the file concurrently with
+	// the turn); this is the turn's LAST write, on the single serialized write
+	// path, so persisting here is safe and survives. A generation that hasn't
+	// finished by now leaves nothing to take — its title rides the next turn's
+	// adoption (already broadcast, so the live UI is correct meanwhile).
 	if t := s.takePendingTitle(sess.ID); t != "" && isAutoNamePlaceholder(sess.Title) {
 		if terr := sess.SetTitle(t); terr != nil {
 			slog.Warn("session title adoption: save failed", "session_id", sess.ID, "err", terr)


### PR DESCRIPTION
## What

Session title generation moves from **after the first turn completes** to **as soon as the user's first message arrives**. Previously a long agentic first turn (minutes) left the sidebar / terminal tab stuck on the `Session N` / `*Octo Agent` / `(untitled)` placeholder the whole time.

Now the throwaway title call runs concurrently with the turn's own provider call, off a pre-turn message snapshot, and the rename broadcasts live while the turn is still running.

## How

- `internal/agent/agent.go`: `GenerateTitle` split — new `GenerateTitleFrom(ctx, snap, tools)` takes an explicit snapshot (at turn start the loop goroutine owns `History` and hasn't appended the incoming message yet). `firstUserSnippet` exported as `FirstUserSnippet` for the pure failure-fallback.
- `internal/server/ws_handlers.go` (`doAgentTurn`): the once-per-session title block moved to just before `RunStream`, built from a pre-turn `sess.Messages` copy + the incoming user message.
- `cmd/octo/tuirepl.go`: `titleCmd(pending)` fires from `startTurnEchoRestore` (turn start) instead of the turn-done handler, snapshotting `History` synchronously + the pending input.

### Concurrency (the load-bearing part)

`rewriteAll` is an in-place `O_TRUNC` rewrite, not an atomic rename — two goroutines writing the same session file can truncate/corrupt the transcript. So the **title goroutine never writes the file**: it only broadcasts `session_renamed` and hands the title to the turn goroutine via `storePendingTitle`. The turn goroutine adopts it at its end-of-turn step, on its single serialized write path.

A title finishing after that adoption point rides the next turn's adoption (already broadcast, so the live UI is correct meanwhile); a session with no follow-up turn keeps the title broadcast-only and falls back to the message snippet on reload — acceptable for a best-effort throwaway title.

The TUI path is inherently safe: all its session-file writes happen on the Bubbletea event loop (serialized) against the same `Session` object.

## Tests

- `session_title_test.go`: title tests now block the main turn call so adoption is deterministic (no reliance on the generation-vs-adoption race); assert the rename lands **while the turn runs** and survives end-of-turn saves. Failure-fallback test unchanged (web `Session N` stays placeholder on failure).
- `tuirepl_test.go`: `TestTUI_TitleCmdFiresOnFirstMessage` — title fires with empty `History` from the pending text.
- `go test -race ./...`, `go vet`, `gofmt` all clean. Reviewed by an isolated subagent across two rounds; the concurrent-file-write finding was fixed and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)