### PR TITLE
docs(blog): add origin-story post 'Why I Built Another Open-Source Agent'

### DIFF
--- a/blog/src/content/posts/en/why-octo.md
+++ b/blog/src/content/posts/en/why-octo.md
@@ -1,0 +1,54 @@
+---
+title: "Why I Built Another Open-Source Agent"
+description: "The origin story of Octo, a self-hosted AI agent in a single Go binary — why I built it, the design decisions behind it, and what it deliberately won't do."
+pubDate: 2026-07-17
+author: "Roy Lei"
+tags: ["announcement", "octo-agent", "story"]
+locale: en
+originalSlug: why-octo
+---
+
+# Why I Built Another Open-Source Agent
+
+Octo is a personal AI agent that ships as one Go binary: 34 built-in tools, 20 default skills, and 7 of 8 planned interfaces live (CLI, web, desktop, IM bridges, VS Code, Obsidian, Go SDK — mobile is in the works). Install is a one-liner with no Node, Python, or Ruby:
+
+```bash
+curl -fsSL https://octo-agent.dev/install.sh | sh
+octo config
+```
+
+## Why I built it
+
+Two reasons.
+
+First, I was genuinely frustrated with the split workflow — Claude Code for coding, OpenClaw for everyday tasks. Two tools, two configs, two experiences, when they're fundamentally the same thing: a conversation with an agent that has tools. That frustration shaped every design decision in Octo.
+
+Second, the first time I used Claude Code in anger, I was struck by how much was going on under the hood — an AI navigating a terminal, reading files, running commands, correcting itself. I wanted to understand how that actually works, and the best way to understand a system is to build one from scratch. With AI helping write the code, that turned out to be feasible for one person.
+
+## One session, no modes
+
+Most agents split Chat, Coding, and Work into separate modes or apps. Octo doesn't. All three are the same thing — a conversation with an agent that has tools — so Octo has exactly one kind of session that does all of it. You never have to stop and decide which mode you're supposed to be in.
+
+The same reasoning removes the "coding agent" vs "general agent" divide. A general-purpose personal assistant should be able to write code and build a slide deck. There is no reason those are two products.
+
+## A few design decisions worth talking about
+
+**MCP without context bloat.** Octo supports stdio, Streamable HTTP, and OAuth MCP servers, but tool schemas load on demand through a built-in Tool Search bridge — the model looks tools up by name instead of carrying every schema on every turn. You can pile on MCP servers without blowing up the context window.
+
+**The agent can't break its own host.** Octo is a compiled binary, so the agent can't modify its own source the way Node/Python agents installed from source can. Config edits are validated on write and a broken config never takes effect — the last good one keeps working. The agent also can't kill the Octo server process, even if you ask it to: the server's own PID is guarded at the tool layer.
+
+**Deletes are reversible by default.** Models occasionally do something destructive. In Octo, `rm`, file overwrites, and programmatic deletes all stage into a local recycle bin first (14-day retention, size-capped), restorable from the CLI or the web UI. If a file is git-tracked and clean, the backup is skipped — git already has it.
+
+**Browser automation attaches, never launches.** The browser tool drives your real, logged-in Chrome over CDP instead of spinning up a headless instance with no cookies. Recordings compile to semantic selector-based YAML skills that self-heal when the frontend changes.
+
+## Privacy
+
+Octo has zero telemetry. Nothing leaves your machine except the model requests you explicitly send, and you can point it at local models — both wire protocols (Anthropic and OpenAI style) and any compatible endpoint work.
+
+## What it doesn't do (yet)
+
+By default there is **no OS-level isolation** — the permission engine gates commands by rules, and the real sandbox (`--sandbox`, Seatbelt on macOS, Landlock + seccomp on Linux) is opt-in and not available on Windows. Mobile clients aren't shipped yet. And a solo-built agent won't beat frontier-lab agents on raw capability — Octo competes on being self-hosted, private, and having everything in one place.
+
+## Standing on the shoulders of giants
+
+Octo wouldn't exist without these projects: Claude Code (Loop and Skill design), Codex (the Goal mechanism), OpenClaw (the personal-assistant form factor), Hermes (agent interaction design), and OpenClacky (whose web UI inspired Octo's).

--- a/blog/src/content/posts/zh/why-octo.md
+++ b/blog/src/content/posts/zh/why-octo.md
@@ -1,0 +1,54 @@
+---
+title: "为什么到今天我又做了一个开源 Agent"
+description: "Octo 是一个单 Go 二进制、自托管的个人 AI Agent。这是它的起源故事：为什么做、关键设计取舍，以及它刻意不做什么。"
+pubDate: 2026-07-17
+author: "Roy Lei"
+tags: ["announcement", "octo-agent", "story"]
+locale: zh
+originalSlug: why-octo
+---
+
+# 为什么到今天我又做了一个开源 Agent
+
+Octo 是一个个人 AI Agent，打成一个 Go 二进制发布：34 个内置工具、20 个默认技能，8 个规划界面已上线 7 个（CLI、Web、桌面、IM 桥接、VS Code、Obsidian、Go SDK——移动端在做）。安装就是一行命令，不依赖 Node、Python、Ruby：
+
+```bash
+curl -fsSL https://octo-agent.dev/install.sh | sh
+octo config
+```
+
+## 为什么还要做
+
+两个原因。
+
+第一，我真心受够了分裂的工作流——写代码用 Claude Code，日常任务用 OpenClaw。两个工具，两套配置，两种体验，而它们本质上是同一件事：和一个有工具的 Agent 对话。这种不满贯穿了 Octo 的每一个设计决策。
+
+第二，第一次深度使用 Claude Code 时，我被它背后发生的事情震撼了——一个 AI 在终端里读写文件、执行命令、自我纠错。我想搞懂这一切到底是怎么运作的，而理解一个系统最好的方式就是从零造一个。有 AI 帮忙写代码，一个人做这件事变成了可能。
+
+## 一种会话，没有模式
+
+市面上的 Agent 总把 Chat、Coding、Work 拆成不同的模式或应用。Octo 不拆。这三者本质上是同一件事——和一个有工具的 Agent 对话——所以 Octo 只有一种会话，做所有事。你永远不用停下来想"我现在该用哪个模式"。
+
+同样的逻辑也消除了"Coding Agent"和"General Agent"的划分。一个通用的个人助手，当然应该会写代码、会做 PPT，没理由拆成两个产品。
+
+## 几个值得说的设计决策
+
+**MCP 不撑爆上下文。** Octo 支持 stdio、Streamable HTTP、OAuth 三种 MCP Server，但工具 schema 按需加载——内置的 Tool Search 桥让模型按名查找工具，而不是每轮对话都背着全部 schema。MCP Server 随便加，上下文窗口不会爆。
+
+**Agent 拆不了自己的家。** Octo 是编译型二进制，Agent 没法像 Node/Python 源码安装类 Agent 那样修改自己的源码。配置修改写入时会校验，坏配置永远不生效——最后一份好配置继续工作。Agent 也杀不掉 Octo server 进程，即使你让它这么做：server 自己的 PID 在工具层就被保护住了。
+
+**删除默认可恢复。** 模型偶尔会干出破坏性操作。Octo 里 `rm`、覆盖写入、程序化删除全部先进本地回收站（保留 14 天，有容量上限），CLI 或 Web UI 随时找回。如果文件被 git 追踪且干净，备份直接跳过——git 已经有了。
+
+**浏览器自动化只接管，不新起。** 浏览器工具通过 CDP 驱动你已登录的真实 Chrome，而不是新起一个没 cookie 的 headless 实例。录制的操作会编译成基于语义选择器的 YAML 技能，前端改版时能自愈。
+
+## 隐私
+
+Octo 零遥测。除了你显式发出的模型请求，没有任何东西离开你的机器。你也可以指向本地模型——两种协议（Anthropic 和 OpenAI 风格）以及任何兼容端点都支持。
+
+## 它（还）不做什么
+
+默认**没有 OS 级隔离**——权限引擎按规则拦截命令，真正的沙箱（`--sandbox`，macOS 用 Seatbelt，Linux 用 Landlock + seccomp）是可选开启的，Windows 上不可用。移动客户端还没发布。一个人做的 Agent 在绝对能力上也赢不了顶级厂商的 Agent——Octo 的竞争力在于自托管、隐私，以及所有东西都在一个地方。
+
+## 站在巨人的肩膀上
+
+Octo 离不开这些优秀的开源项目：Claude Code（Loop 和 Skill 体系的设计灵感）、Codex（Goal 机制的参考来源）、OpenClaw（个人助手形态的先行者）、Hermes（Agent 交互的另一种优秀探索）、OpenClacky（Octo 的 Web 端交互受它启发）。


### PR DESCRIPTION
## What

Adds the blog's first **origin-story / announcement** post, as a bilingual zh/en pair:

- `blog/src/content/posts/zh/why-octo.md` → `/blog/posts/why-octo/`
- `blog/src/content/posts/en/why-octo.md` → `/blog/posts/en/why-octo/`

All 13 existing posts are tutorials (onboarding series) or engineering deep dives — this is the first first-person "why this project exists" piece.

## How it was adapted from the source drafts

Source: the Show HN drafts (EN + ZH) from the author's desktop. Changes per review:

1. **Show HN framing removed** — submission title line and footer Website/GitHub/Docs link block dropped (the blog has its own nav); replaced with standard frontmatter.
2. **Both languages aligned to one structure** — the drafts were not translations of each other. Final skeleton (from the EN draft): intro → why → **one session, no modes** → design decisions → privacy → what it doesn't do → acknowledgements. The "one session, no modes" section merges in the ZH draft's unique Chat/Coding/Work unification argument.
3. **Competitor telemetry accusation dropped** — the ZH draft's claim about another agent identifying users via invisible Unicode markers was removed entirely (no naming), per review.
4. **Sandbox wording uses the honest phrasing** — the ZH draft's "built-in OS-level sandbox" was softened to the EN draft's accurate version: opt-in `--sandbox`, not available on Windows.
5. **Roadmap tease dropped** — the ZH draft's "Agent Team coming soon" promise was left out; the feature hasn't landed yet.

## Verified facts in the post

- **34 built-in tools** = exact count of `allTools` in `internal/tools/registry.go`
- **20 default skills** = exact count of `internal/skills/defaults/`
- **7 of 8 interfaces live** = matches the settled "one brain, eight arms" narrative (mobile pending)

## Checks

- `cd blog && npm install && npm run build` — ✅ 30 pages built, both new pages generated (`/posts/why-octo/`, `/posts/en/why-octo/`)

## Notes for review

- `author` is set to **"Roy Lei"** (first-person story; existing posts use "octo-agent team") — change if you'd rather keep the team byline.
- `pubDate: 2026-07-17`.

Docs-only change; no code touched.
