### PR TITLE
fix(title): one shared 5s title mechanism with snippet fallback

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1425,13 +1426,16 @@ func (m *tuiModel) suggestCmd() tea.Cmd {
 
 // titleCmd returns a tea.Cmd that asynchronously generates a session title,
 // once per session. Fired on receipt of the user's message (turn start), not
-// at turn end, so the terminal tab isn't stuck on "(untitled)" for the whole
-// first turn. pending is the message starting the turn — the turn goroutine
-// appends it to History later, so the snapshot is taken here, synchronously,
-// and pending is added on top. It returns nil (no-op) when the session is
-// already titled (non-empty and not the "*Octo Agent" placeholder), a
-// generation is already in flight, saving is off, or there's nothing to
-// summarize. The result is persisted by the titleMsg handler.
+// at turn end, so the terminal tab isn't stuck on the placeholder for the
+// whole first turn. pending is the message starting the turn — the turn
+// goroutine appends it to History later, so the snapshot is taken here,
+// synchronously, and pending is added on top. It returns nil (no-op) when the
+// session is already titled (non-empty and not the "*Octo Agent"
+// placeholder), a generation is already in flight, saving is off, or there's
+// nothing to summarize. The shared mechanism (agent.GenerateTitleOrSnippet)
+// guarantees a title within TitleGenerationTimeout: the model's when the
+// throwaway call works, a snippet of pending otherwise. The result is
+// persisted by the titleMsg handler.
 func (m *tuiModel) titleCmd(pending string) tea.Cmd {
 	if m.cfg.noSave || m.titlePending {
 		return nil
@@ -1450,11 +1454,11 @@ func (m *tuiModel) titleCmd(pending string) tea.Cmd {
 	a := m.a
 	tools := m.cfg.tools // same toolbelt as the loop, so the request hits the prompt cache
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), agent.TitleGenerationTimeout)
 		defer cancel()
-		t, err := a.GenerateTitleFrom(ctx, msgs, tools)
+		t, err := a.GenerateTitleOrSnippet(ctx, msgs, tools)
 		if err != nil {
-			return titleMsg{text: ""}
+			slog.Debug("session title generation failed, using snippet", "err", err)
 		}
 		return titleMsg{text: t}
 	}

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -264,6 +264,31 @@ func TestTUI_TitleCmdFiresOnFirstMessage(t *testing.T) {
 	}
 }
 
+// The 5-second guarantee's other half: when the throwaway provider call
+// fails (bad model alias, rate limit, timeout), titleCmd still yields a
+// non-empty titleMsg built from the pending message — the tab title always
+// lands, never waits for a retry that may fail the same way. This is the
+// same GenerateTitleOrSnippet mechanism the server uses.
+func TestTUI_TitleCmdFallsBackToSnippet(t *testing.T) {
+	isolateTestInputHistory()
+	a := agent.New(&stubSender{err: fmt.Errorf("stub: provider down")}, "m")
+	m := newTUIModel(replConfig{a: a})
+	m.sink = &tuiSink{prog: &fakeProg{}}
+	m.cfg.session = agent.NewSession("m", "")
+
+	c := m.titleCmd("fix the flaky title test")
+	if c == nil {
+		t.Fatal("titleCmd = nil on first message, want a command")
+	}
+	msg, ok := c().(titleMsg)
+	if !ok {
+		t.Fatalf("cmd returned %T, want titleMsg", c())
+	}
+	if msg.text != "fix the flaky title test" {
+		t.Errorf("title = %q, want the pending-message snippet %q", msg.text, "fix the flaky title test")
+	}
+}
+
 // An Esc take-back must leave no trace in the agent's history either: the
 // interrupt keeps the input capped with a note (finishInterrupted), so
 // handleTurnFinished has to strip that pair — otherwise the recalled text

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1334,6 +1334,12 @@ func (a *Agent) Suggest(ctx context.Context, tools []ToolDefinition) (string, er
 // line itself.
 const titleMaxTokens = 250
 
+// TitleGenerationTimeout bounds a throwaway session-title call. The TUI and
+// the server share one title mechanism: within this budget the model produces
+// a title, otherwise GenerateTitleOrSnippet falls back to a message snippet,
+// so a title always lands ~5s after the first user message.
+const TitleGenerationTimeout = 5 * time.Second
+
 const titleInstruction = "Summarize this conversation as a short title of at most 6 words. " +
 	"Reply with the title text only — no preamble, no quotes, no trailing punctuation, no markdown."
 
@@ -1384,6 +1390,23 @@ func (a *Agent) GenerateTitleFrom(ctx context.Context, snap []Message, tools []T
 		return "", err
 	}
 	return cleanTitle(reply.Content), nil
+}
+
+// GenerateTitleOrSnippet is GenerateTitleFrom with a guaranteed result: on
+// error, timeout, or an empty model reply it falls back to a truncated snippet
+// of the first user message in snap. This is THE session-title mechanism —
+// the TUI and the server both call it (wrapped in TitleGenerationTimeout) so
+// every frontend gets the same behaviour: an LLM title when the call works, a
+// snippet otherwise, always within ~5s of the first user message. Returns ""
+// only when snap carries no user text at all.
+func (a *Agent) GenerateTitleOrSnippet(ctx context.Context, snap []Message, tools []ToolDefinition) (string, error) {
+	t, err := a.GenerateTitleFrom(ctx, snap, tools)
+	if err == nil {
+		if t = strings.TrimSpace(t); t != "" {
+			return t, nil
+		}
+	}
+	return FirstUserSnippet(snap), err
 }
 
 // cleanTitle reduces the model's reply to a single tidy line: first non-empty

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1901,6 +1901,56 @@ func TestAgent_GenerateTitle_NotConfigured(t *testing.T) {
 	}
 }
 
+// TestAgent_GenerateTitleOrSnippet pins the shared title mechanism used by
+// both the TUI and the server: the model's title when the throwaway call
+// works, a snippet of the first user message when it errors, times out, or
+// answers empty — so every frontend gets a title within
+// TitleGenerationTimeout.
+func TestAgent_GenerateTitleOrSnippet(t *testing.T) {
+	snap := []Message{NewUserMessage("please fix the login bug")}
+
+	t.Run("model title wins", func(t *testing.T) {
+		a := New(&fakeSender{reply: Reply{Content: "Fix the login bug"}}, "m")
+		got, err := a.GenerateTitleOrSnippet(context.Background(), snap, nil)
+		if err != nil {
+			t.Fatalf("GenerateTitleOrSnippet: %v", err)
+		}
+		if got != "Fix the login bug" {
+			t.Errorf("title = %q, want the model's title", got)
+		}
+	})
+
+	t.Run("provider error falls back to snippet", func(t *testing.T) {
+		a := New(&fakeSender{err: errors.New("boom")}, "m")
+		got, err := a.GenerateTitleOrSnippet(context.Background(), snap, nil)
+		if err == nil {
+			t.Error("expected the provider error to surface for logging")
+		}
+		if got != "please fix the login bug" {
+			t.Errorf("title = %q, want the user-message snippet", got)
+		}
+	})
+
+	t.Run("empty reply falls back to snippet", func(t *testing.T) {
+		a := New(&fakeSender{reply: Reply{Content: ""}}, "m")
+		got, err := a.GenerateTitleOrSnippet(context.Background(), snap, nil)
+		if err != nil {
+			t.Fatalf("GenerateTitleOrSnippet: %v", err)
+		}
+		if got != "please fix the login bug" {
+			t.Errorf("title = %q, want the user-message snippet", got)
+		}
+	})
+
+	t.Run("no user text returns empty", func(t *testing.T) {
+		a := New(&fakeSender{reply: Reply{Content: ""}}, "m")
+		got, _ := a.GenerateTitleOrSnippet(context.Background(), []Message{NewAssistantMessage("hi")}, nil)
+		if got != "" {
+			t.Errorf("title = %q, want empty when there's nothing to title from", got)
+		}
+	})
+}
+
 // TestAgent_GenerateTitle_UsesNoReasoningSenderWhenAvailable guards that title
 // generation disables reasoning outright when the sender supports it. A session
 // running reasoning_effort "max" would otherwise pay the model's full reasoning

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -96,11 +96,20 @@ func (srv *Server) toSessionItem(s *agent.Session, source, agentProfile string) 
 	if name == "" {
 		name = s.DisplayTitle()
 	}
+	title := s.Title
+	// A title generated mid-turn is broadcast immediately but adopted (and
+	// persisted) only at turn end; surface it in list responses meanwhile so
+	// a client refetch in between doesn't regress the sidebar to the
+	// placeholder. One storage: this overlays the same pendingTitles record
+	// the turn adopts from — it never writes anything itself.
+	if pt := srv.peekPendingTitle(s.ID); pt != "" && isAutoNamePlaceholder(s.Title) {
+		name, title = pt, pt
+	}
 	_, pm, re, sr, ctxUsage := srv.sessionStatusFields(s)
 	return sessionItem{
 		ID:              s.ID,
 		Name:            name,
-		Title:           s.Title,
+		Title:           title,
 		CreatedAt:       s.CreatedAt,
 		UpdatedAt:       updated,
 		Model:           s.Model,

--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -124,6 +124,13 @@ func TestDoAgentTurn_GeneratesSessionTitle(t *testing.T) {
 	close(sender.release)
 	<-turnDone
 
+	// The turn adopts the pending title as its last write and re-broadcasts
+	// the rename: any client whose list refetch raced the not-yet-persisted
+	// title (and saw the placeholder) converges on this second broadcast.
+	if name := waitForRename(t, conn, sess.ID); name != "early title" {
+		t.Errorf("adoption rename name = %q, want %q", name, "early title")
+	}
+
 	// The title must survive the turn's end-of-turn saves.
 	loaded, err := agent.LoadSession(sess.ID)
 	if err != nil {
@@ -163,6 +170,22 @@ func TestListSessionsBrief_ReflectsGeneratedTitle(t *testing.T) {
 	go func() { defer close(turnDone); srv.doAgentTurn(sess, "hello there", nil, nil) }()
 	<-sender.entered
 	waitForRename(t, conn, sess.ID)
+
+	// Overlay: the title is broadcast but NOT yet adopted/persisted (the turn
+	// is still running). List responses must already surface it — the web
+	// sidebar refetches on session_renamed, and without the overlay that
+	// refetch would regress the just-renamed session to the placeholder.
+	if brief := srv.listSessionsBrief(); len(brief) != 1 || brief[0].Name != "early title" {
+		n := ""
+		if len(brief) == 1 {
+			n = brief[0].Name
+		}
+		t.Errorf("mid-turn listSessionsBrief Name = %q (n=%d), want %q — pending-title overlay missing", n, len(brief), "early title")
+	}
+	if item := srv.toSessionItem(sess, "web", ""); item.Name != "early title" || item.Title != "early title" {
+		t.Errorf("mid-turn toSessionItem = (%q, %q), want (%q, %q)", item.Name, item.Title, "early title", "early title")
+	}
+
 	close(sender.release)
 	<-turnDone
 
@@ -175,42 +198,6 @@ func TestListSessionsBrief_ReflectsGeneratedTitle(t *testing.T) {
 	if brief[0].Name != "early title" {
 		t.Errorf("Name = %q, want %q", brief[0].Name, "early title")
 	}
-}
-
-// titleFailSender behaves exactly like stubSender for a normal turn, but
-// returns an error specifically for GenerateTitle's throwaway prompt (its
-// message list always ends with the "Summarize this conversation..."
-// instruction) — simulating a provider/model that's misconfigured only for
-// this fire-and-forget call, e.g. a bad model alias or a rate limit hit on a
-// second request right after the main turn's.
-type titleFailSender struct{}
-
-func (titleFailSender) SendMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int) (agent.Reply, error) {
-	if isTitlePrompt(msgs) {
-		return agent.Reply{}, fmt.Errorf("stub: title provider error")
-	}
-	return agent.Reply{Content: "stub reply"}, nil
-}
-
-func (titleFailSender) StreamMessages(_ context.Context, _, _ string, _ []agent.Message, _ int, onChunk func(string), _ func(string)) (agent.Reply, error) {
-	if onChunk != nil {
-		onChunk("stub reply")
-	}
-	return agent.Reply{Content: "stub reply"}, nil
-}
-
-func (titleFailSender) SendMessagesWithTools(_ context.Context, _, _ string, msgs []agent.Message, _ int, _ []agent.ToolDefinition) (agent.Reply, error) {
-	if isTitlePrompt(msgs) {
-		return agent.Reply{}, fmt.Errorf("stub: title provider error")
-	}
-	return agent.Reply{Content: "stub reply"}, nil
-}
-
-func (titleFailSender) StreamMessagesWithTools(_ context.Context, _, _ string, _ []agent.Message, _ int, _ []agent.ToolDefinition, onChunk func(string), _ agent.ToolInputDeltaFunc, _ agent.ThinkingDeltaFunc) (agent.Reply, error) {
-	if onChunk != nil {
-		onChunk("stub reply")
-	}
-	return agent.Reply{Content: "stub reply"}, nil
 }
 
 // isTitlePrompt reports whether msgs is GenerateTitle's throwaway call
@@ -244,12 +231,34 @@ func (s *blockingTurnSender) StreamMessages(_ context.Context, _, _ string, _ []
 	return agent.Reply{Content: "stub reply"}, nil
 }
 
-// TestDoAgentTurn_TitleGenerationFailureIsLogged is the regression guard for
-// a real production symptom: on an install where the title-generation call
-// fails every time (bad model config, rate limit, etc.), the sidebar title
-// never appears and — before this test — nothing anywhere recorded why. The
-// failure is still silent to the user by design (retried on the next turn),
-// but it must not be silent to the server operator.
+// blockingTitleFailSender fails the title-generation call (plain SendMessages
+// on the title prompt) while the main turn's streaming call blocks until
+// released — so the snippet fallback is guaranteed to land mid-turn and the
+// turn-end adoption is deterministic.
+type blockingTitleFailSender struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingTitleFailSender) SendMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int) (agent.Reply, error) {
+	if isTitlePrompt(msgs) {
+		return agent.Reply{}, fmt.Errorf("stub: title provider error")
+	}
+	return agent.Reply{Content: "stub reply"}, nil
+}
+
+func (s *blockingTitleFailSender) StreamMessages(_ context.Context, _, _ string, _ []agent.Message, _ int, _ func(string), _ func(string)) (agent.Reply, error) {
+	close(s.entered)
+	<-s.release
+	return agent.Reply{Content: "stub reply"}, nil
+}
+
+// TestDoAgentTurn_TitleGenerationFailureIsLogged covers the production
+// symptom where the title-generation call fails every time (bad model config,
+// rate limit, timeout). Two guarantees: the failure is logged for the server
+// operator, AND the session still gets titled within ~5s — the shared
+// GenerateTitleOrSnippet mechanism falls back to the first-message snippet,
+// for the numbered "Session N" placeholder just as for "*Octo Agent".
 func TestDoAgentTurn_TitleGenerationFailureIsLogged(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -261,7 +270,8 @@ func TestDoAgentTurn_TitleGenerationFailureIsLogged(t *testing.T) {
 	t.Cleanup(func() { slog.SetDefault(prevLogger) })
 
 	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
-	srv.sender = &titleFailSender{}
+	sender := &blockingTitleFailSender{entered: make(chan struct{}), release: make(chan struct{})}
+	srv.sender = sender
 	srv.initWS()
 	srv.turnRunning = make(map[string]bool)
 	srv.steerQueues = make(map[string][]agent.InboxItem)
@@ -280,15 +290,13 @@ func TestDoAgentTurn_TitleGenerationFailureIsLogged(t *testing.T) {
 	}
 	srv.wsHub.register <- conn
 
-	srv.doAgentTurn(sess, "hello there", nil, nil)
+	turnDone := make(chan struct{})
+	go func() { defer close(turnDone); srv.doAgentTurn(sess, "hello there", nil, nil) }()
+	<-sender.entered // main turn call is blocked; title generation runs concurrently
 
-	// The title goroutine is fire-and-forget, so there's no broadcast to wait
-	// on for the failure path — poll the captured log instead.
+	// The failure must be logged...
 	deadline := time.After(5 * time.Second)
-	for {
-		if strings.Contains(logBuf.String(), "session title generation failed") {
-			break
-		}
+	for !strings.Contains(logBuf.String(), "session title generation failed") {
 		select {
 		case <-deadline:
 			t.Fatalf("expected a logged warning for the failed title generation; log so far:\n%s", logBuf.String())
@@ -302,13 +310,20 @@ func TestDoAgentTurn_TitleGenerationFailureIsLogged(t *testing.T) {
 		t.Errorf("expected the underlying error in the log line; got:\n%s", logBuf.String())
 	}
 
-	// And the title must genuinely still be unset — the failure path must not
-	// have persisted a garbage title.
+	// ...and the snippet fallback must still title the session mid-turn.
+	if name := waitForRename(t, conn, sess.ID); name != "hello there" {
+		t.Errorf("rename name = %q, want the first-message snippet %q", name, "hello there")
+	}
+
+	close(sender.release)
+	<-turnDone
+
+	// Adoption persists the snippet title even for a "Session N" placeholder.
 	loaded, err := agent.LoadSession(sess.ID)
 	if err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	if !isAutoNamePlaceholder(loaded.Title) {
-		t.Errorf("Title = %q, want it to remain a placeholder after a failed generation", loaded.Title)
+	if loaded.Title != "hello there" {
+		t.Errorf("persisted Title = %q, want the snippet fallback %q", loaded.Title, "hello there")
 	}
 }

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -108,10 +108,16 @@ func (s *Server) listSessionsBrief() []wsSessionInfo {
 		if source == "" {
 			source = "manual"
 		}
+		name := sess.DisplayTitle()
+		// Same pending-title overlay as toSessionItem: a title broadcast
+		// mid-turn isn't on disk yet, and this list feeds the sidebar.
+		if pt := s.peekPendingTitle(sess.ID); pt != "" && isAutoNamePlaceholder(sess.Title) {
+			name = pt
+		}
 		_, pm, re, sr, ctxUsage := s.sessionStatusFields(sess)
 		out = append(out, wsSessionInfo{
 			ID:              sess.ID,
-			Name:            sess.DisplayTitle(),
+			Name:            name,
 			Status:          s.sessionStatus(sess.ID),
 			CreatedAt:       sess.CreatedAt.UnixMilli(),
 			Source:          source,
@@ -1341,36 +1347,30 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// turn's transcript. Instead it broadcasts the rename (live UX) and hands
 	// the title to the turn goroutine via storePendingTitle; the turn adopts
 	// it after its final write, on the single serialized write path. If the
-	// title lands after that point it rides the next turn's adoption. Failure
-	// falls back to the first-message snippet; the claim releases either way
-	// and the next user message retries.
+	// title lands after that point it rides the next turn's adoption.
+	//
+	// One mechanism, one storage: GenerateTitleOrSnippet is the same call the
+	// TUI makes — an LLM title within TitleGenerationTimeout, else a snippet
+	// of the first user message — and the turn-end SetTitle adoption is the
+	// only persistence path. A provider failure is logged and the snippet
+	// still applies; the claim releases either way and the next user message
+	// retries.
 	if isAutoNamePlaceholder(sess.Title) && s.claimTitleGeneration(sess.ID) {
 		sid := sess.ID
-		placeholder := sess.Title
 		titleMsgs := append(append([]agent.Message{}, sess.Messages...), userMsg)
 		go func() {
 			defer s.recoverBg("title generation")
 			defer s.releaseTitleGeneration(sid)
-			ctx, cancel := context.WithTimeout(context.Background(), throwawayGenerationTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), agent.TitleGenerationTimeout)
 			defer cancel()
-			t, terr := a.GenerateTitleFrom(ctx, titleMsgs, toolDefs)
-			if terr != nil || strings.TrimSpace(t) == "" {
-				if terr != nil {
-					slog.Warn("session title generation failed", "session_id", sid, "err", terr)
-				} else {
-					slog.Warn("session title generation returned an empty title", "session_id", sid)
-				}
-				// Fall back to the first-message snippet only for the bare
-				// "*Octo Agent" placeholder (matching FallbackTitleIfPlaceholder);
-				// the web's numbered "Session N" is left as-is and retried on the
-				// next turn. Pure snippet, no file IO — the turn owns the file.
-				if placeholder != "*Octo Agent" {
-					return
-				}
-				t = agent.FirstUserSnippet(titleMsgs)
-				if t == "" {
-					return
-				}
+			t, terr := a.GenerateTitleOrSnippet(ctx, titleMsgs, toolDefs)
+			if terr != nil {
+				slog.Warn("session title generation failed, falling back to message snippet", "session_id", sid, "err", terr)
+			}
+			if strings.TrimSpace(t) == "" {
+				// No user text to title from at all (e.g. an attachments-only
+				// first message); nothing to fall back to — next turn retries.
+				return
 			}
 			// Hand the title to the turn goroutine (it persists it) and
 			// broadcast the rename so every tab's sidebar updates live.
@@ -1541,6 +1541,15 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	if t := s.takePendingTitle(sess.ID); t != "" && isAutoNamePlaceholder(sess.Title) {
 		if terr := sess.SetTitle(t); terr != nil {
 			slog.Warn("session title adoption: save failed", "session_id", sess.ID, "err", terr)
+		} else {
+			// The mid-turn rename broadcast raced the not-yet-persisted title:
+			// any client whose list refetch saw the placeholder since then
+			// converges on this re-broadcast, now that disk is authoritative.
+			s.wsHub.broadcast("", map[string]any{
+				"type":       "session_renamed",
+				"session_id": sess.ID,
+				"name":       t,
+			})
 		}
 	}
 	_, pm, re, _, _ := s.sessionStatusFields(sess)
@@ -1575,17 +1584,17 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	}
 }
 
-// throwawayGenerationTimeout bounds the title- and suggestion-generation
-// calls above. A confirmed field failure hit "anthropic: send: ... context
-// deadline exceeded" on every attempt at the previous 20s timeout: both
-// calls reuse the turn's own Agent/Sender and inherited that session's
-// reasoning_effort ("max"), paying the model's full reasoning budget even
-// for a 6-word title. The real fix is agent.LowEffortSender (both calls now
-// cap effort to "low" instead of inheriting the session's), which removes
-// most of that latency at the source — this timeout is only the remaining
-// safety margin for normal network/provider variance, not a substitute for
-// the effort cap, so it stays modest rather than papering over a slow call
-// with a long wait.
+// throwawayGenerationTimeout bounds the suggestion-generation call above. A
+// confirmed field failure hit "anthropic: send: ... context deadline exceeded"
+// on every attempt at the previous 20s timeout: both throwaway calls reuse
+// the turn's own Agent/Sender and inherited that session's reasoning_effort
+// ("max"), paying the model's full reasoning budget even for a 6-word title.
+// The real fix is agent.LowEffortSender (both calls now cap effort to "low"
+// instead of inheriting the session's), which removes most of that latency at
+// the source — this timeout is only the remaining safety margin for normal
+// network/provider variance, not a substitute for the effort cap, so it stays
+// modest rather than papering over a slow call with a long wait. (Session
+// titles use agent.TitleGenerationTimeout, the shared title mechanism.)
 const throwawayGenerationTimeout = 5 * time.Second
 
 // sessionPlaceholderRe matches the frontend's auto-assigned "Session N"
@@ -1645,6 +1654,16 @@ func (s *Server) takePendingTitle(sessionID string) string {
 	t := s.pendingTitles[sessionID]
 	delete(s.pendingTitles, sessionID)
 	return t
+}
+
+// peekPendingTitle returns the stored title without clearing it. List
+// responses overlay it over the not-yet-adopted disk placeholder so a client
+// refetch between the mid-turn rename broadcast and the turn-end adoption
+// doesn't regress the sidebar to the placeholder.
+func (s *Server) peekPendingTitle(sessionID string) string {
+	s.titleMu.Lock()
+	defer s.titleMu.Unlock()
+	return s.pendingTitles[sessionID]
 }
 
 // ─── wsStreamWriter ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

PR #1523 moved session-title generation to message receipt, but real-world testing showed titles broke on both the TUI and web:

1. **Web sidebar reverts to the placeholder.** The `session_renamed` broadcast lands *before* the title is persisted (mid-turn), and the frontend's own reconciliation `listSessions()` refetch immediately replaces the just-applied rename with the stale disk state (`Session N`). The turn-end adoption persists the title but never re-broadcasts, so the sidebar stays wrong until a full reload.
2. **TUI produces no title on LLM failure.** `titleMsg{text:""}` fell back to `FallbackTitleIfPlaceholder()`, which reads `s.Messages` — empty mid-turn in the TUI (it only `SyncFrom`s at turn end) — so a failed/timeout LLM call meant no tab title at all. Its 20s timeout also broke the 5s expectation.
3. **Server fallback was placeholder-specific.** On LLM failure only `"*Octo Agent"` got a snippet fallback; `"Session N"` got nothing.

## Fix — one mechanism, one storage

**One mechanism:** new `agent.GenerateTitleOrSnippet` (+ `agent.TitleGenerationTimeout` = 5s), used by *both* the TUI (`titleCmd`) and the server (on-receipt goroutine). Within 5s the model produces a title; on error/timeout/empty reply it falls back to a snippet of the first user message. A title always lands ~5s after the first user message.

**One storage:** `Session.SetTitle` remains the only write path — via the TUI's `titleMsg` handler, or the server turn's end-of-turn adoption (the single serialized writer; the generation goroutine still never touches the file).

**Make the web rename stick:**
- `toSessionItem` / `listSessionsBrief` overlay the pending (not-yet-adopted) title, so a client refetch between the mid-turn broadcast and the turn-end adoption can no longer regress to the placeholder.
- The turn-end adoption re-broadcasts `session_renamed` once disk is authoritative, so any client that did regress converges.

## Tests

- `TestAgent_GenerateTitleOrSnippet` — model title wins; provider error / empty reply fall back to snippet; no user text → empty.
- `TestTUI_TitleCmdFallsBackToSnippet` — failing provider still yields a non-empty titleMsg from the pending message.
- `TestDoAgentTurn_GeneratesSessionTitle` — now also pins the post-adoption re-broadcast.
- `TestListSessionsBrief_ReflectsGeneratedTitle` — now also pins the mid-turn overlay (both WS brief and REST item) before adoption.
- `TestDoAgentTurn_TitleGenerationFailureIsLogged` — rewritten for the new semantics: failure is logged **and** the snippet fallback titles a `"Session N"` session (broadcast + persisted).

`go build ./...`, `gofmt -l`, `go vet ./...`, and `go test -race ./...` all clean.
