### PR TITLE
feat(provider): add k3, grok-4.5, and glm-5.2 model catalogue entries

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -176,6 +176,8 @@ func contextWindow(model string) int {
 		return 128_000
 
 	// ── GLM (Zhipu) ──
+	case strings.Contains(m, "glm-5.2") || strings.Contains(m, "glm5.2"):
+		return 128_000
 	case strings.Contains(m, "glm-4-air") || strings.Contains(m, "glm-4.5-air"):
 		return 128_000
 	case strings.Contains(m, "glm-4-flash") || strings.Contains(m, "glm-4.5-flash"):

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -169,7 +169,7 @@ func contextWindow(model string) int {
 
 	// ── MiniMax ──
 	case strings.Contains(m, "minimax-m3"):
-		return 256_000
+		return 1_000_000
 	case strings.Contains(m, "minimax-m2"):
 		return 256_000
 	case strings.Contains(m, "minimax"):
@@ -199,13 +199,23 @@ func contextWindow(model string) int {
 
 	// ── MiMo (Xiaomi) ──
 	case strings.Contains(m, "mimo-v2.5") || strings.Contains(m, "mimov2.5"):
-		return 256_000
+		return 1_000_000
 	case strings.Contains(m, "mimo"):
 		return 128_000
 
 	// ── LongCat (Meituan) ──
 	case strings.Contains(m, "longcat"):
 		return 1_000_000
+
+	// ── Tencent ──
+	case strings.Contains(m, "hy3"):
+		return 256_000
+
+	// ── NVIDIA ──
+	case strings.Contains(m, "nemotron-3-ultra") || strings.Contains(m, "nemotron3-ultra"):
+		return 1_000_000
+	case strings.Contains(m, "nemotron"):
+		return 128_000
 
 	// ── Cohere ──
 	case strings.Contains(m, "command-r-plus") || strings.Contains(m, "command-r"):

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -177,7 +177,7 @@ func contextWindow(model string) int {
 
 	// ── GLM (Zhipu) ──
 	case strings.Contains(m, "glm-5.2") || strings.Contains(m, "glm5.2"):
-		return 128_000
+		return 1_000_000
 	case strings.Contains(m, "glm-4-air") || strings.Contains(m, "glm-4.5-air"):
 		return 128_000
 	case strings.Contains(m, "glm-4-flash") || strings.Contains(m, "glm-4.5-flash"):
@@ -190,6 +190,8 @@ func contextWindow(model string) int {
 		return 64_000
 
 	// ── XAI Grok ──
+	case strings.Contains(m, "grok-4.5") || strings.Contains(m, "grok4.5"):
+		return 500_000
 	case strings.Contains(m, "grok-4") || strings.Contains(m, "grok4"):
 		return 256_000
 	case strings.Contains(m, "grok"):

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -117,6 +117,9 @@ func TestContextWindow(t *testing.T) {
 	if got := contextWindow("gpt-5.6-sol"); got != 1_000_000 {
 		t.Errorf("gpt-5.6-sol window = %d, want 1000000", got)
 	}
+	if got := contextWindow("glm-5.2"); got != 128_000 {
+		t.Errorf("glm-5.2 window = %d, want 128000", got)
+	}
 	if got := contextWindow("unknown-model-xyz"); got != defaultContextWindow {
 		t.Errorf("unknown model window = %d, want %d (conservative default)", got, defaultContextWindow)
 	}

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -123,6 +123,18 @@ func TestContextWindow(t *testing.T) {
 	if got := contextWindow("x-ai/grok-4.5"); got != 500_000 {
 		t.Errorf("grok-4.5 window = %d, want 500000", got)
 	}
+	if got := contextWindow("xiaomi/mimo-v2.5"); got != 1_000_000 {
+		t.Errorf("mimo-v2.5 window = %d, want 1000000", got)
+	}
+	if got := contextWindow("minimax/minimax-m3"); got != 1_000_000 {
+		t.Errorf("minimax-m3 window = %d, want 1000000", got)
+	}
+	if got := contextWindow("tencent/hy3"); got != 256_000 {
+		t.Errorf("hy3 window = %d, want 256000", got)
+	}
+	if got := contextWindow("nvidia/nemotron-3-ultra-550b-a55b"); got != 1_000_000 {
+		t.Errorf("nemotron-3-ultra window = %d, want 1000000", got)
+	}
 	if got := contextWindow("unknown-model-xyz"); got != defaultContextWindow {
 		t.Errorf("unknown model window = %d, want %d (conservative default)", got, defaultContextWindow)
 	}

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -117,8 +117,11 @@ func TestContextWindow(t *testing.T) {
 	if got := contextWindow("gpt-5.6-sol"); got != 1_000_000 {
 		t.Errorf("gpt-5.6-sol window = %d, want 1000000", got)
 	}
-	if got := contextWindow("glm-5.2"); got != 128_000 {
-		t.Errorf("glm-5.2 window = %d, want 128000", got)
+	if got := contextWindow("glm-5.2"); got != 1_000_000 {
+		t.Errorf("glm-5.2 window = %d, want 1000000", got)
+	}
+	if got := contextWindow("x-ai/grok-4.5"); got != 500_000 {
+		t.Errorf("grok-4.5 window = %d, want 500000", got)
 	}
 	if got := contextWindow("unknown-model-xyz"); got != defaultContextWindow {
 		t.Errorf("unknown model window = %d, want %d (conservative default)", got, defaultContextWindow)

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -104,7 +104,12 @@ var Registry = []Vendor{
 		API:            "openai-completions",
 		DefaultBaseURL: "https://openrouter.ai/api",
 		DefaultModel:   "anthropic/claude-sonnet-4-6",
+		// The vendor-prefixed entries below (tencent/, xiaomi/, deepseek/, z-ai/,
+		// minimax/, nvidia/) mirror OpenRouter's own top-usage rankings
+		// (openrouter.ai/rankings) — added so the most-routed models are
+		// reachable without a second direct-vendor account.
 		Models: []VendorModel{
+			{ID: "anthropic/claude-sonnet-5", Vision: true},
 			{ID: "anthropic/claude-sonnet-4-6", Vision: true},
 			{ID: "anthropic/claude-opus-4-8", Vision: true},
 			{ID: "anthropic/claude-opus-4-7", Vision: true},
@@ -113,11 +118,19 @@ var Registry = []Vendor{
 			{ID: "openai/gpt-5.5", Vision: true},
 			{ID: "openai/gpt-5.4", Vision: true},
 			{ID: "openai/gpt-5.4-mini", Vision: true},
+			{ID: "google/gemini-3-flash-preview", Vision: true},
 			{ID: "google/gemini-2.5-pro", Vision: true},
 			{ID: "google/gemini-2.5-flash", Vision: true},
 			{ID: "meta-llama/llama-3.3-70b-instruct", Vision: false}, // Llama 3.3 70B is text-only
 			{ID: "x-ai/grok-4.5", Vision: true},
 			{ID: "x-ai/grok-4.3", Vision: true},
+			{ID: "tencent/hy3", Vision: false}, // text-only on OpenRouter as of this writing
+			{ID: "xiaomi/mimo-v2.5", Vision: true},
+			{ID: "deepseek/deepseek-v4-flash", Vision: false}, // vision not exposed on the API
+			{ID: "deepseek/deepseek-v4-pro", Vision: false},   // vision not exposed on the API
+			{ID: "z-ai/glm-5.2", Vision: false},
+			{ID: "minimax/minimax-m3", Vision: true},
+			{ID: "nvidia/nemotron-3-ultra-550b-a55b", Vision: false},
 		},
 		APIKeyEnvVar: "OPENROUTER_API_KEY",
 		WebsiteURL:   "https://openrouter.ai/keys",

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -116,6 +116,7 @@ var Registry = []Vendor{
 			{ID: "google/gemini-2.5-pro", Vision: true},
 			{ID: "google/gemini-2.5-flash", Vision: true},
 			{ID: "meta-llama/llama-3.3-70b-instruct", Vision: false}, // Llama 3.3 70B is text-only
+			{ID: "x-ai/grok-4.5", Vision: true},
 			{ID: "x-ai/grok-4.3", Vision: true},
 		},
 		APIKeyEnvVar: "OPENROUTER_API_KEY",
@@ -166,6 +167,7 @@ var Registry = []Vendor{
 		DefaultModel:   "kimi-k2.6",
 		// Kimi K2 family is natively multimodal (image input via MoonViT).
 		Models: []VendorModel{
+			{ID: "k3", Vision: true},
 			{ID: "kimi-k2.6", Vision: true},
 			{ID: "kimi-k2.7-code", Vision: true},
 		},
@@ -200,8 +202,9 @@ var Registry = []Vendor{
 		API:            "openai-completions",
 		DefaultBaseURL: "https://open.bigmodel.cn/api/paas/v4",
 		DefaultModel:   "glm-4.5",
-		// GLM-4.5 line is text-only; the vision variant (GLM-4.5V) isn't offered here.
+		// GLM-4.5/5.2 line is text-only; the vision variant (GLM-4.5V) isn't offered here.
 		Models: []VendorModel{
+			{ID: "glm-5.2", Vision: false},
 			{ID: "glm-4.5", Vision: false},
 			{ID: "glm-4.5-air", Vision: false},
 			{ID: "glm-4.5-flash", Vision: false},


### PR DESCRIPTION
## Summary
- k3 was already registered for the kimi-coding-plan vendor (#1516) but missing from the base Moonshot (kimi) vendor — added it there too
- Added `x-ai/grok-4.5` to OpenRouter alongside the existing `grok-4.3` entry, with a verified 500K `contextWindow()` case (official docs: https://docs.x.ai/developers/models/grok-4.5)
- Added `glm-5.2` to the GLM (Zhipu) vendor, with a verified 1M-token `contextWindow()` case (text-only, no vision — confirmed via Zhipu/community sources)
- `gpt-5.6-sol` was already present in the OpenAI vendor (#1320) — no change needed there
- Added OpenRouter's other top-usage models per openrouter.ai/rankings: `anthropic/claude-sonnet-5`, `google/gemini-3-flash-preview`, `tencent/hy3`, `xiaomi/mimo-v2.5`, `deepseek/deepseek-v4-flash`, `deepseek/deepseek-v4-pro`, `z-ai/glm-5.2`, `minimax/minimax-m3`, `nvidia/nemotron-3-ultra-550b-a55b` — each model id, vision capability, and context window checked against its OpenRouter model page
- While verifying, found `mimo-v2.5` and `minimax-m3`'s existing `contextWindow()` cases were stale (256K vs. the confirmed 1M) — corrected both since new entries resolve through the same case

Note: the context-window values were initially guessed by analogy to sibling models (glm-5.2 as 128K, grok-4.5 as 256K) and then corrected after verifying against official docs — see the second commit.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/app/... ./internal/agent/...`
- [x] `gofmt -l` clean on touched files