### PR TITLE
fix(provider): fix reasoning-effort wire shape for openrouter, bailian, and kimi

### DIFF
--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -52,6 +52,29 @@ const DialectOpenAI = "openai"
 // https://openrouter.ai/docs/use-cases/reasoning-tokens.
 const DialectOpenRouter = "openrouter"
 
+// DialectBailian selects DashScope's (Alibaba Bailian) reasoning shape: a
+// plain top-level enable_thinking boolean — there is no reasoning_effort
+// field at all, flat or nested, so the generic fallback's clamped
+// reasoning_effort is silently ignored. Assign it to Client.Dialect for the
+// "bailian" vendor. See
+// https://www.alibabacloud.com/help/en/model-studio/deep-thinking.
+const DialectBailian = "bailian"
+
+// DialectKimi selects Moonshot Kimi's reasoning shape, which is split by
+// model generation rather than uniform across the vendor:
+//   - k2.6 / k2.5: the same nested {type: "enabled"|"disabled"} toggle as
+//     DeepSeek — no reasoning_effort field.
+//   - k2.7-code: thinking is permanently on; sending "disabled" errors, so
+//     the toggle is always {type: "enabled"}.
+//   - k3: a top-level reasoning_effort field, but the only value it currently
+//     accepts is "max" — the generic fallback's clamp-to-"high" would send an
+//     unsupported value.
+//
+// Assign it to Client.Dialect for the "kimi" vendor (kimi-coding-plan speaks
+// the Anthropic protocol and never reaches this client). See
+// https://platform.kimi.ai/docs/api/chat.
+const DialectKimi = "kimi"
+
 // DefaultStreamIdleTimeout bounds how long a streaming response may go silent
 // (no bytes received) before SendStream aborts it as a stall. Chat Completions
 // backends stream chunks continuously while generating, so a healthy stream
@@ -85,8 +108,9 @@ type Client struct {
 	StreamIdleTimeout time.Duration
 
 	// Dialect selects vendor-specific request quirks within the OpenAI protocol.
-	// Empty (the default) is generic OpenAI-compatible; DialectDeepSeek enables
-	// DeepSeek's thinking-mode toggle. Set at construction (see internal/app).
+	// Empty (the default) is generic OpenAI-compatible. See applyReasoning for
+	// what each DialectXxx constant changes. Set at construction (see
+	// internal/app).
 	Dialect string
 }
 
@@ -104,6 +128,13 @@ type Client struct {
 //   - OpenRouter: forwards verbatim into the nested reasoning object — its
 //     effort enum ("none".."max") is a superset of ours, so no clamping is
 //     needed. Omitted (nil) entirely when effort is "".
+//   - Bailian (DashScope): no reasoning_effort field at all — only a plain
+//     enable_thinking boolean, sent explicitly either way (true/false) since
+//     per-model defaults vary.
+//   - Kimi: model-dependent (see DialectKimi) — k2.6/k2.5 get the same
+//     nested toggle as DeepSeek with no reasoning_effort; k2.7-code always
+//     gets the toggle forced to "enabled"; k3 gets a top-level
+//     reasoning_effort clamped to its only supported value, "max".
 //   - Generic OpenAI-compatible: top out at "high" and reject unknown enums, so
 //     both "xhigh" and "max" clamp to "high"; "thinking" is never sent.
 func (c *Client) applyReasoning(body *apiRequest, effort string) {
@@ -119,6 +150,27 @@ func (c *Client) applyReasoning(body *apiRequest, effort string) {
 	case DialectOpenRouter:
 		if effort != "" {
 			body.Reasoning = &apiReasoning{Effort: effort}
+		}
+		return
+	case DialectBailian:
+		enabled := effort != ""
+		body.EnableThinking = &enabled
+		return
+	case DialectKimi:
+		m := strings.ToLower(body.Model)
+		switch {
+		case strings.Contains(m, "k3"):
+			if effort != "" {
+				body.ReasoningEffort = "max"
+			}
+		case strings.Contains(m, "k2.7-code") || strings.Contains(m, "k2-7-code"):
+			body.Thinking = &apiThinking{Type: "enabled"}
+		default: // k2.6, k2.5, and any other kimi model
+			if effort == "" {
+				body.Thinking = &apiThinking{Type: "disabled"}
+			} else {
+				body.Thinking = &apiThinking{Type: "enabled"}
+			}
 		}
 		return
 	default:

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -153,6 +153,11 @@ func (c *Client) applyReasoning(body *apiRequest, effort string) {
 		}
 		return
 	case DialectBailian:
+		// Sent explicitly both ways since per-model defaults vary. Note: a
+		// handful of DashScope models (e.g. qwq-plus, deepseek-r1) are
+		// thinking-only and reject enable_thinking:false outright — none of
+		// the vendor's catalogued models are (see internal/app/provider.go's
+		// "bailian" entry), so this only bites a hand-typed custom model id.
 		enabled := effort != ""
 		body.EnableThinking = &enabled
 		return

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -43,6 +43,15 @@ const DialectDeepSeek = "deepseek"
 // Client.Dialect for the "openai" vendor.
 const DialectOpenAI = "openai"
 
+// DialectOpenRouter selects OpenRouter's reasoning shape: a nested
+// `reasoning: {effort: ...}` object rather than the flat reasoning_effort
+// field every other OpenAI-compatible backend here uses. OpenRouter's schema
+// has no reasoning_effort field, so sending it there — as the generic
+// fallback below does — is silently ignored and the effort setting has no
+// effect. Assign it to Client.Dialect for the "openrouter" vendor. See
+// https://openrouter.ai/docs/use-cases/reasoning-tokens.
+const DialectOpenRouter = "openrouter"
+
 // DefaultStreamIdleTimeout bounds how long a streaming response may go silent
 // (no bytes received) before SendStream aborts it as a stall. Chat Completions
 // backends stream chunks continuously while generating, so a healthy stream
@@ -92,6 +101,9 @@ type Client struct {
 //     sent explicitly or it would still think).
 //   - OpenAI: gpt-5.x reasoning_effort accepts "low".."high" and "xhigh" but
 //     not "max", so "max" maps to "xhigh" (the real top tier).
+//   - OpenRouter: forwards verbatim into the nested reasoning object — its
+//     effort enum ("none".."max") is a superset of ours, so no clamping is
+//     needed. Omitted (nil) entirely when effort is "".
 //   - Generic OpenAI-compatible: top out at "high" and reject unknown enums, so
 //     both "xhigh" and "max" clamp to "high"; "thinking" is never sent.
 func (c *Client) applyReasoning(body *apiRequest, effort string) {
@@ -103,6 +115,11 @@ func (c *Client) applyReasoning(body *apiRequest, effort string) {
 			effort = "xhigh"
 		}
 		body.ReasoningEffort = effort
+		return
+	case DialectOpenRouter:
+		if effort != "" {
+			body.Reasoning = &apiReasoning{Effort: effort}
+		}
 		return
 	default:
 		if effort == "xhigh" || effort == "max" {

--- a/internal/provider/openai/reasoning_dialect_test.go
+++ b/internal/provider/openai/reasoning_dialect_test.go
@@ -16,6 +16,13 @@ import (
 // returns a minimal valid chat.completion so Send succeeds.
 func captureRequest(t *testing.T, dialect, effort string, stream bool) apiRequest {
 	t.Helper()
+	return captureRequestModel(t, dialect, "deepseek-v4-pro", effort, stream)
+}
+
+// captureRequestModel is captureRequest with an explicit model id, for
+// dialects (Kimi) whose reasoning shape is model-dependent.
+func captureRequestModel(t *testing.T, dialect, model, effort string, stream bool) apiRequest {
+	t.Helper()
 	var got apiRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -27,7 +34,7 @@ func captureRequest(t *testing.T, dialect, effort string, stream bool) apiReques
 			_, _ = io.WriteString(w, `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":"stop"}]}`+"\n\n")
 			return
 		}
-		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"deepseek-v4-pro","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","model":"` + model + `","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
 	}))
 	defer srv.Close()
 
@@ -39,7 +46,7 @@ func captureRequest(t *testing.T, dialect, effort string, stream bool) apiReques
 	c.Dialect = dialect
 
 	req := provider.Request{
-		Model:           "deepseek-v4-pro",
+		Model:           model,
 		Messages:        []agent.Message{agent.NewUserMessage("hi")},
 		ReasoningEffort: effort,
 	}
@@ -128,6 +135,74 @@ func TestOpenRouterDialect_UsesNestedReasoningObject(t *testing.T) {
 			t.Errorf("stream=%v: off reasoning = %+v, want omitted", stream, off.Reasoning)
 		}
 	}
+}
+
+// Bailian (DashScope) has no reasoning_effort field at all — only a plain
+// enable_thinking boolean, sent explicitly in both directions since per-model
+// defaults vary.
+func TestBailianDialect_UsesEnableThinkingBoolean(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		got := captureRequest(t, DialectBailian, "high", stream)
+		if got.ReasoningEffort != "" {
+			t.Errorf("stream=%v: reasoning_effort = %q, want empty (must use enable_thinking)", stream, got.ReasoningEffort)
+		}
+		if got.EnableThinking == nil || !*got.EnableThinking {
+			t.Errorf("stream=%v: enable_thinking = %v, want true", stream, got.EnableThinking)
+		}
+		if got.Thinking != nil {
+			t.Errorf("stream=%v: thinking = %+v, want omitted (bailian uses enable_thinking, not thinking)", stream, got.Thinking)
+		}
+
+		off := captureRequest(t, DialectBailian, "", stream)
+		if off.EnableThinking == nil || *off.EnableThinking {
+			t.Errorf("stream=%v: off enable_thinking = %v, want explicit false", stream, off.EnableThinking)
+		}
+	}
+}
+
+// Kimi's reasoning shape is split by model generation: k2.6/k2.5 get
+// DeepSeek's nested toggle (no reasoning_effort), k2.7-code always forces the
+// toggle to "enabled" regardless of effort, and k3 gets a top-level
+// reasoning_effort clamped to its only supported value, "max".
+func TestKimiDialect_ModelDependentShape(t *testing.T) {
+	t.Run("k2.6 toggles like DeepSeek", func(t *testing.T) {
+		on := captureRequestModel(t, DialectKimi, "kimi-k2.6", "high", false)
+		if on.Thinking == nil || on.Thinking.Type != "enabled" {
+			t.Errorf("thinking = %+v, want type=enabled", on.Thinking)
+		}
+		if on.ReasoningEffort != "" {
+			t.Errorf("reasoning_effort = %q, want empty (k2.6 has no such field)", on.ReasoningEffort)
+		}
+
+		off := captureRequestModel(t, DialectKimi, "kimi-k2.6", "", false)
+		if off.Thinking == nil || off.Thinking.Type != "disabled" {
+			t.Errorf("off thinking = %+v, want type=disabled", off.Thinking)
+		}
+	})
+
+	t.Run("k2.7-code always enabled", func(t *testing.T) {
+		for _, effort := range []string{"", "high"} {
+			got := captureRequestModel(t, DialectKimi, "kimi-k2.7-code", effort, false)
+			if got.Thinking == nil || got.Thinking.Type != "enabled" {
+				t.Errorf("effort=%q: thinking = %+v, want type=enabled (k2.7-code can't disable)", effort, got.Thinking)
+			}
+		}
+	})
+
+	t.Run("k3 clamps to reasoning_effort=max", func(t *testing.T) {
+		got := captureRequestModel(t, DialectKimi, "k3", "low", false)
+		if got.ReasoningEffort != "max" {
+			t.Errorf("reasoning_effort = %q, want max (k3's only supported value)", got.ReasoningEffort)
+		}
+		if got.Thinking != nil {
+			t.Errorf("thinking = %+v, want omitted (k3 uses reasoning_effort)", got.Thinking)
+		}
+
+		off := captureRequestModel(t, DialectKimi, "k3", "", false)
+		if off.ReasoningEffort != "" {
+			t.Errorf("off reasoning_effort = %q, want empty", off.ReasoningEffort)
+		}
+	})
 }
 
 // A generic (unknown) backend must never see the thinking toggle, and tops out

--- a/internal/provider/openai/reasoning_dialect_test.go
+++ b/internal/provider/openai/reasoning_dialect_test.go
@@ -105,6 +105,31 @@ func TestOpenAIDialect_MaxMapsToXHigh(t *testing.T) {
 	}
 }
 
+// OpenRouter has no reasoning_effort field at all — only a nested
+// reasoning:{effort:...} object — so the flat field must stay empty and the
+// value must pass through verbatim (its enum is a superset of ours, no
+// clamping needed). Empty effort omits the reasoning object entirely rather
+// than sending an empty one.
+func TestOpenRouterDialect_UsesNestedReasoningObject(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		got := captureRequest(t, DialectOpenRouter, "max", stream)
+		if got.ReasoningEffort != "" {
+			t.Errorf("stream=%v: reasoning_effort = %q, want empty (must use nested reasoning object)", stream, got.ReasoningEffort)
+		}
+		if got.Reasoning == nil || got.Reasoning.Effort != "max" {
+			t.Errorf("stream=%v: reasoning = %+v, want {Effort:max}", stream, got.Reasoning)
+		}
+		if got.Thinking != nil {
+			t.Errorf("stream=%v: thinking = %+v, want omitted", stream, got.Thinking)
+		}
+
+		off := captureRequest(t, DialectOpenRouter, "", stream)
+		if off.Reasoning != nil {
+			t.Errorf("stream=%v: off reasoning = %+v, want omitted", stream, off.Reasoning)
+		}
+	}
+}
+
 // A generic (unknown) backend must never see the thinking toggle, and tops out
 // at "high" — both "xhigh" and "max" clamp down since it rejects unknown enums.
 func TestGenericDialect_OmitsThinkingAndClampsHigh(t *testing.T) {

--- a/internal/provider/openai/reasoning_dialect_test.go
+++ b/internal/provider/openai/reasoning_dialect_test.go
@@ -166,41 +166,60 @@ func TestBailianDialect_UsesEnableThinkingBoolean(t *testing.T) {
 // reasoning_effort clamped to its only supported value, "max".
 func TestKimiDialect_ModelDependentShape(t *testing.T) {
 	t.Run("k2.6 toggles like DeepSeek", func(t *testing.T) {
-		on := captureRequestModel(t, DialectKimi, "kimi-k2.6", "high", false)
+		for _, stream := range []bool{false, true} {
+			on := captureRequestModel(t, DialectKimi, "kimi-k2.6", "high", stream)
+			if on.Thinking == nil || on.Thinking.Type != "enabled" {
+				t.Errorf("stream=%v: thinking = %+v, want type=enabled", stream, on.Thinking)
+			}
+			if on.ReasoningEffort != "" {
+				t.Errorf("stream=%v: reasoning_effort = %q, want empty (k2.6 has no such field)", stream, on.ReasoningEffort)
+			}
+
+			off := captureRequestModel(t, DialectKimi, "kimi-k2.6", "", stream)
+			if off.Thinking == nil || off.Thinking.Type != "disabled" {
+				t.Errorf("stream=%v: off thinking = %+v, want type=disabled", stream, off.Thinking)
+			}
+		}
+	})
+
+	// k2.5 shares k2.6's nested-toggle shape (see DialectKimi's doc comment);
+	// this pins that the default branch actually covers it, not just k2.6.
+	t.Run("k2.5 toggles like k2.6", func(t *testing.T) {
+		on := captureRequestModel(t, DialectKimi, "kimi-k2.5", "high", false)
 		if on.Thinking == nil || on.Thinking.Type != "enabled" {
 			t.Errorf("thinking = %+v, want type=enabled", on.Thinking)
 		}
-		if on.ReasoningEffort != "" {
-			t.Errorf("reasoning_effort = %q, want empty (k2.6 has no such field)", on.ReasoningEffort)
-		}
-
-		off := captureRequestModel(t, DialectKimi, "kimi-k2.6", "", false)
+		off := captureRequestModel(t, DialectKimi, "kimi-k2.5", "", false)
 		if off.Thinking == nil || off.Thinking.Type != "disabled" {
 			t.Errorf("off thinking = %+v, want type=disabled", off.Thinking)
 		}
 	})
 
 	t.Run("k2.7-code always enabled", func(t *testing.T) {
-		for _, effort := range []string{"", "high"} {
-			got := captureRequestModel(t, DialectKimi, "kimi-k2.7-code", effort, false)
-			if got.Thinking == nil || got.Thinking.Type != "enabled" {
-				t.Errorf("effort=%q: thinking = %+v, want type=enabled (k2.7-code can't disable)", effort, got.Thinking)
+		for _, stream := range []bool{false, true} {
+			for _, effort := range []string{"", "high"} {
+				got := captureRequestModel(t, DialectKimi, "kimi-k2.7-code", effort, stream)
+				if got.Thinking == nil || got.Thinking.Type != "enabled" {
+					t.Errorf("stream=%v effort=%q: thinking = %+v, want type=enabled (k2.7-code can't disable)", stream, effort, got.Thinking)
+				}
 			}
 		}
 	})
 
 	t.Run("k3 clamps to reasoning_effort=max", func(t *testing.T) {
-		got := captureRequestModel(t, DialectKimi, "k3", "low", false)
-		if got.ReasoningEffort != "max" {
-			t.Errorf("reasoning_effort = %q, want max (k3's only supported value)", got.ReasoningEffort)
-		}
-		if got.Thinking != nil {
-			t.Errorf("thinking = %+v, want omitted (k3 uses reasoning_effort)", got.Thinking)
-		}
+		for _, stream := range []bool{false, true} {
+			got := captureRequestModel(t, DialectKimi, "k3", "low", stream)
+			if got.ReasoningEffort != "max" {
+				t.Errorf("stream=%v: reasoning_effort = %q, want max (k3's only supported value)", stream, got.ReasoningEffort)
+			}
+			if got.Thinking != nil {
+				t.Errorf("stream=%v: thinking = %+v, want omitted (k3 uses reasoning_effort)", stream, got.Thinking)
+			}
 
-		off := captureRequestModel(t, DialectKimi, "k3", "", false)
-		if off.ReasoningEffort != "" {
-			t.Errorf("off reasoning_effort = %q, want empty", off.ReasoningEffort)
+			off := captureRequestModel(t, DialectKimi, "k3", "", stream)
+			if off.ReasoningEffort != "" {
+				t.Errorf("stream=%v: off reasoning_effort = %q, want empty", stream, off.ReasoningEffort)
+			}
 		}
 	})
 }

--- a/internal/provider/openai/types.go
+++ b/internal/provider/openai/types.go
@@ -46,12 +46,25 @@ type apiRequest struct {
 	// Client.applyReasoning, which normalises the value per dialect (DeepSeek
 	// verbatim, OpenAI "max"→"xhigh", generic clamps "xhigh"/"max"→"high").
 	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	// Reasoning is OpenRouter's own reasoning-tuning shape: a nested object
+	// rather than the flat reasoning_effort field above. OpenRouter's schema
+	// has no reasoning_effort field at all — sending it there is silently
+	// ignored — so the openrouter dialect populates this instead (see
+	// Client.applyReasoning and https://openrouter.ai/docs/use-cases/reasoning-tokens).
+	Reasoning *apiReasoning `json:"reasoning,omitempty"`
 	// Thinking is DeepSeek's on/off toggle for thinking mode, set only for the
 	// DeepSeek dialect (see Client.applyReasoning). DeepSeek separates enabling
 	// thinking from tuning its effort, and leaves thinking on by default — so
 	// reasoning_effort alone may not engage it, and "off" must be sent
 	// explicitly. nil (omitted) for every other OpenAI-compatible backend.
 	Thinking *apiThinking `json:"thinking,omitempty"`
+}
+
+// apiReasoning is OpenRouter's nested reasoning-tuning object. Effort accepts
+// "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" — a
+// superset of our own effort vocabulary, so values pass through unchanged.
+type apiReasoning struct {
+	Effort string `json:"effort,omitempty"`
 }
 
 // apiThinking is DeepSeek's thinking-mode toggle. Type is "enabled" or

--- a/internal/provider/openai/types.go
+++ b/internal/provider/openai/types.go
@@ -52,12 +52,18 @@ type apiRequest struct {
 	// ignored — so the openrouter dialect populates this instead (see
 	// Client.applyReasoning and https://openrouter.ai/docs/use-cases/reasoning-tokens).
 	Reasoning *apiReasoning `json:"reasoning,omitempty"`
-	// Thinking is DeepSeek's on/off toggle for thinking mode, set only for the
-	// DeepSeek dialect (see Client.applyReasoning). DeepSeek separates enabling
-	// thinking from tuning its effort, and leaves thinking on by default — so
-	// reasoning_effort alone may not engage it, and "off" must be sent
-	// explicitly. nil (omitted) for every other OpenAI-compatible backend.
+	// Thinking is the nested on/off toggle for thinking mode used by DeepSeek
+	// and Kimi's k2.6/k2.5 models (see Client.applyReasoning). Both separate
+	// enabling thinking from tuning its effort, and leave thinking on by
+	// default — so reasoning_effort alone may not engage/disengage it, and
+	// "disabled" must be sent explicitly. nil (omitted) for every other
+	// OpenAI-compatible backend.
 	Thinking *apiThinking `json:"thinking,omitempty"`
+	// EnableThinking is DashScope's (Alibaba Bailian) on/off toggle — a plain
+	// boolean rather than DeepSeek/Kimi's {type: "enabled"|"disabled"} object.
+	// Set only for the bailian dialect (see Client.applyReasoning). DashScope
+	// has no reasoning_effort field at all.
+	EnableThinking *bool `json:"enable_thinking,omitempty"`
 }
 
 // apiReasoning is OpenRouter's nested reasoning-tuning object. Effort accepts


### PR DESCRIPTION
## Summary
Verified the OpenRouter vendor implementation against official docs at the user's request; found a real bug, then checked every other `openai`-protocol vendor for the same class of issue and found two more with high-confidence documentation.

**openrouter** — OpenRouter's Chat Completions API accepts reasoning effort only via a nested `reasoning: {effort: "..."}` object ([docs](https://openrouter.ai/docs/use-cases/reasoning-tokens)) — there is no `reasoning_effort` field in its schema. The `openrouter` vendor's `Dialect` fell through `applyReasoning`'s generic `default` branch, which sends the flat `reasoning_effort` field; OpenRouter silently ignores the unrecognized field, so `--reasoning-effort` had no effect for any model routed through it.

**bailian** (Alibaba DashScope/Qwen) — no `reasoning_effort` field at all, flat or nested. The real control is a top-level `enable_thinking` boolean ([docs](https://www.alibabacloud.com/help/en/model-studio/deep-thinking)). Same silent no-op as OpenRouter.

**kimi** (Moonshot) — shape is split by model generation, confirmed against the [official Kimi API docs](https://platform.kimi.ai/docs/api/chat):
- `kimi-k2.6` / `k2.5`: nested `{type: "enabled"|"disabled"}` toggle, same as DeepSeek — no `reasoning_effort`.
- `kimi-k2.7-code`: thinking is permanently on; sending `"disabled"` errors, so the toggle must always be `"enabled"`.
- `k3`: top-level `reasoning_effort`, but currently accepts only `"max"` — the generic dialect's clamp-to-`"high"` would send an unsupported value.

Adds `DialectOpenRouter`, `DialectBailian`, `DialectKimi` and the corresponding `applyReasoning` branches, plus the new wire types (`apiReasoning` for OpenRouter, `EnableThinking *bool` for Bailian). Kimi's dialect branches on `body.Model` since its shape isn't uniform across the vendor.

**Also checked, not fixed here:** minimax (M3's `thinking` field is a 3-way `enabled`/`adaptive`/`disabled` enum, no effort scale), glm (non-5.2 models need a separate `enable_thinking` toggle; GLM-5.2 itself looks compatible with a flat `reasoning_effort` clamped to `max` rather than `high`), longcat (looks like it also wants a nested `thinking` object). These came from lower-confidence/aggregated sources rather than a direct official-docs fetch, so left alone pending clearer verification.

Everything else about the OpenRouter implementation checked out fine: endpoint (`https://openrouter.ai/api` + `/v1/chat/completions` matches the documented URL exactly), `Authorization: Bearer` auth, SSE streaming with `stream_options.include_usage`. The optional `HTTP-Referer`/`X-Title` headers (only affect openrouter.ai's public leaderboard attribution) are not sent, which isn't a correctness issue.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/provider/openai/... -race` — new `TestOpenRouterDialect_UsesNestedReasoningObject`, `TestBailianDialect_UsesEnableThinkingBoolean`, `TestKimiDialect_ModelDependentShape` (subtests per Kimi model generation)
- [x] `go test ./internal/provider/... ./internal/app/... -race`
- [x] `gofmt -l` clean on touched files