### PR TITLE
chore(release): bump version to 1.12.20

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.19"
+var Version = "1.12.20"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Version bump 1.12.19 → 1.12.20 for the next release. After merge, tag v1.12.20 on main.