### PR TITLE
fix(desktop): tidy nested go.mod broken by root x/net bump + CI guard

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -17,6 +17,10 @@ on:
     paths:
       - 'cmd/octo-desktop/**'
       - 'internal/server/**'
+      # Root-module dep bumps flow into the nested desktop module via its
+      # replace directive, so they must build-verify the desktop app too.
+      - 'go.mod'
+      - 'go.sum'
       - 'scripts/package-desktop-macos.sh'
       - 'scripts/package-desktop-linux.sh'
       - 'scripts/embed-rg-windows.ps1'
@@ -25,6 +29,8 @@ on:
     paths:
       - 'cmd/octo-desktop/**'
       - 'internal/server/**'
+      - 'go.mod'
+      - 'go.sum'
       - 'scripts/package-desktop-macos.sh'
       - 'scripts/package-desktop-linux.sh'
       - 'scripts/embed-rg-windows.ps1'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -69,6 +69,15 @@ jobs:
       - name: go build
         run: go build ./...
 
+      # cmd/octo-desktop is a nested module replaced onto the root module, so a
+      # root dependency bump can leave its go.mod untidy without any file under
+      # cmd/octo-desktop changing (broke the 1.12.20 installers). tidy -diff is
+      # module-graph-only — no CGO/GTK needed — so it runs here on every PR.
+      - name: go mod tidy check (cmd/octo-desktop)
+        if: matrix.os == 'ubuntu-latest'
+        working-directory: cmd/octo-desktop
+        run: go mod tidy -diff
+
       # Data races are OS-independent, so the detector only runs on ubuntu (where
       # it's cheapest). Windows/macOS run a plain `go test` — fast, and still
       # catches platform-specific failures (path handling, process spawning, the

--- a/cmd/octo-desktop/go.mod
+++ b/cmd/octo-desktop/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/tetratelabs/wazero v1.12.0 // indirect
 	github.com/yuin/goldmark v1.7.16 // indirect
 	golang.org/x/image v0.41.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/cmd/octo-desktop/go.sum
+++ b/cmd/octo-desktop/go.sum
@@ -45,8 +45,8 @@ golang.org/x/image v0.41.0/go.mod h1:uIc348UZMSvS5Z65CVZ7iDPaNobNFEPeJ4kbqTOszmA
 golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Why

All five installer jobs of the [1.12.20 release run](https://github.com/open-octo/octo-agent/actions/runs/29572151905) failed with `go: updates to go.mod needed`.

Root cause: #1533 bumped `golang.org/x/net` 0.38.0 → 0.55.0 in the root module, which transitively requires `golang.org/x/sys` v0.45.0. The nested `cmd/octo-desktop` module (replaced onto the root) still pinned x/sys v0.44.0. Dependabot only tidies the module it bumps, and no PR-time CI builds or tidy-checks the desktop module, so this landed on main silently and only surfaced in the release pipeline.

## What

- **Fix**: `go mod tidy` in `cmd/octo-desktop` (x/sys 0.44.0 → 0.45.0; go.mod one line, go.sum two).
- **CI guard 1**: the Go workflow now runs `go mod tidy -diff` for `cmd/octo-desktop` on every PR (ubuntu job only — module-graph resolution needs no CGO/GTK, so it is cheap and would have caught exactly this).
- **CI guard 2**: the Desktop workflow's path filters now include root `go.mod`/`go.sum`, so root dependency bumps build-verify the desktop app for real.

## Verification

- Reproduced the failure on main (`go build ./...` in `cmd/octo-desktop` fails), passes after the tidy.
- `go mod tidy -diff` exits clean on the fixed branch.

After merge: delete the broken v1.12.20 release, re-tag from main to re-run the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)