### PR TITLE
chore(deps): bump golang.org/x/image to v0.41.0 (GHSA-44p7-9xx4-hf2g)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/tetratelabs/wazero v1.12.0
 	github.com/yuin/goldmark v1.7.13
-	golang.org/x/image v0.32.0
+	golang.org/x/image v0.41.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
-golang.org/x/image v0.32.0 h1:6lZQWq75h7L5IWNk0r+SCpUJ6tUVd3v4ZHnbRKLkUDQ=
-golang.org/x/image v0.32.0/go.mod h1:/R37rrQmKXtO6tYXAjtDLwQgFLHmhW+V6ayXlxzP2Pc=
+golang.org/x/image v0.41.0 h1:8wS72eGJMJaBxK6okTzd4WaXumUlTVlb753MlsSvTCo=
+golang.org/x/image v0.41.0/go.mod h1:uIc348UZMSvS5Z65CVZ7iDPaNobNFEPeJ4kbqTOszmA=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
## Why

Dependabot alert #2: `golang.org/x/image` < 0.38.0 is vulnerable to an out-of-memory error via a crafted TIFF file (GHSA-44p7-9xx4-hf2g, medium). The root module was on v0.32.0.

The path is reachable: `internal/agent/image_compress.go` registers the TIFF decoder for read_file/TUI image attachments, so an attacker-supplied TIFF (e.g. in an untrusted repo the agent reads) reaches the vulnerable decode and can OOM a long-running `octo serve`.

## What

`go get golang.org/x/image@v0.41.0` + tidy in the root module — aligns with `cmd/octo-desktop`, which is already on v0.41.0 (#1532). go.mod one line, go.sum two.

## Verification

- `go build ./...` and `go test ./internal/agent/` pass locally.
- x/image v0.41.0 pulls no new transitive requirements beyond what #1535 already fixed, so the nested desktop module stays tidy (checked with `go mod tidy -diff` on top of #1535).

🤖 Generated with [Claude Code](https://claude.com/claude-code)