### PR TITLE
fix(landing): stop cropping demo video's left/right edges

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -95,7 +95,7 @@
     .shot-bar{display:flex;align-items:center;gap:6px;padding:12px 16px;border-bottom:1px solid var(--line);background:var(--canvas);}
     .dot{width:10px;height:10px;border-radius:50%;}
     .shot-title{margin-left:10px;font-size:12px;color:var(--t45);font-family:var(--mono);}
-    .shot-media{height:520px;background:var(--canvas);display:flex;align-items:center;justify-content:center;position:relative;}
+    .shot-media{aspect-ratio:2/1;background:var(--canvas);display:flex;align-items:center;justify-content:center;position:relative;}
     .shot-media img,.shot-media video{width:100%;height:100%;object-fit:cover;display:block;}
     .shot-ph{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px;color:var(--t45);font-size:14px;}
 


### PR DESCRIPTION
## Summary
- Follow-up to #1538 — the demo video was getting its left/right edges clipped (sidebar and right panel cut off), reported after merge.
- Root cause: `.shot-media` used a fixed 960x520 box (~1.85:1) but the demo video is 2:1, so `object-fit:cover` cropped both sides to fill the shorter box.
- Fix: use `aspect-ratio:2/1` on `.shot-media` instead of a fixed height, so the box always matches the video and nothing gets cropped.

## Test plan
- [x] Served the page locally, re-screenshotted headlessly — sidebar and right panel are now fully visible edge to edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)