### PR TITLE
chore(blog): pin why-octo as the first listed post

### DIFF
--- a/blog/src/content/posts/en/why-octo.md
+++ b/blog/src/content/posts/en/why-octo.md
@@ -1,7 +1,7 @@
 ---
 title: "Why I Built Another Open-Source Agent"
 description: "The origin story of Octo, a self-hosted AI agent in a single Go binary — why I built it, the design decisions behind it, and what it deliberately won't do."
-pubDate: 2026-07-17
+pubDate: 2026-07-19
 author: "Roy Lei"
 tags: ["announcement", "octo-agent", "story"]
 locale: en

--- a/blog/src/content/posts/zh/why-octo.md
+++ b/blog/src/content/posts/zh/why-octo.md
@@ -1,7 +1,7 @@
 ---
 title: "为什么到今天我又做了一个开源 Agent"
 description: "Octo 是一个单 Go 二进制、自托管的个人 AI Agent。这是它的起源故事：为什么做、关键设计取舍，以及它刻意不做什么。"
-pubDate: 2026-07-17
+pubDate: 2026-07-19
 author: "Roy Lei"
 tags: ["announcement", "octo-agent", "story"]
 locale: zh


### PR DESCRIPTION
## Summary
- The blog index sorts posts purely by `pubDate` descending (`src/pages/index.astro`).
- "为什么到今天我又做了一个开源 Agent" / "Why I Built Another Open-Source Agent" was tied on 2026-07-17 with the Browser setup post, and sat behind the newer 2026-07-18 Record & Replay post.
- Bumped `pubDate` to 2026-07-19 in both `zh` and `en` versions so it now sorts first in both locale listings.

## Test plan
- [x] Confirmed the sort is date-only (`b.data.pubDate.valueOf() - a.data.pubDate.valueOf()`), no separate pin/order field exists.
- [x] Verified no other post has a later pubDate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)