### PR TITLE
fix(title): 兜底标题截断到 15 字符，LLM 生成标题保持 60

### DIFF
--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -284,8 +284,8 @@ func TestTUI_TitleCmdFallsBackToSnippet(t *testing.T) {
 	if !ok {
 		t.Fatalf("cmd returned %T, want titleMsg", c())
 	}
-	if msg.text != "fix the flaky title test" {
-		t.Errorf("title = %q, want the pending-message snippet %q", msg.text, "fix the flaky title test")
+	if msg.text != "fix the flaky…" {
+		t.Errorf("title = %q, want the pending-message snippet %q", msg.text, "fix the flaky…")
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1926,7 +1926,7 @@ func TestAgent_GenerateTitleOrSnippet(t *testing.T) {
 		if err == nil {
 			t.Error("expected the provider error to surface for logging")
 		}
-		if got != "please fix the login bug" {
+		if got != "please fix the…" {
 			t.Errorf("title = %q, want the user-message snippet", got)
 		}
 	})
@@ -1937,7 +1937,7 @@ func TestAgent_GenerateTitleOrSnippet(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GenerateTitleOrSnippet: %v", err)
 		}
-		if got != "please fix the login bug" {
+		if got != "please fix the…" {
 			t.Errorf("title = %q, want the user-message snippet", got)
 		}
 	})

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -888,7 +888,7 @@ func (s *Session) FallbackTitleIfPlaceholder() string {
 // skipping injected <system-reminder> blocks and tool-result turns, and
 // truncating to a list-friendly width.
 func FirstUserSnippet(msgs []Message) string {
-	const maxLen = 60
+	const maxLen = 15
 	for _, m := range msgs {
 		if m.Role != RoleUser {
 			continue

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -368,13 +368,13 @@ func TestDisplayTitle(t *testing.T) {
 		{
 			name: "falls back to first user message",
 			s:    &Session{Messages: []Message{NewUserMessage("help me refactor the parser")}},
-			want: "help me refactor the parser",
+			want: "help me refact…",
 		},
 		{
 			name: "strips system-reminder and takes first real line",
 			s: &Session{Messages: []Message{NewUserMessage(
 				"<system-reminder>injected context</system-reminder>\n\nreal question here")}},
-			want: "real question here",
+			want: "real question…",
 		},
 		{
 			name: "skips a leading tool-result user turn",
@@ -382,7 +382,7 @@ func TestDisplayTitle(t *testing.T) {
 				NewToolResultMessage([]ContentBlock{NewToolResultBlock("id", "out", false)}),
 				NewUserMessage("the actual prompt"),
 			}},
-			want: "the actual prompt",
+			want: "the actual pro…",
 		},
 		{
 			name: "untitled when empty",


### PR DESCRIPTION
## 改动
- `FirstUserSnippet`（LLM 失败兜底）maxLen 60 → **15**，session list 里的兜底标题不再撑行
- `cleanTitle`（LLM 生成标题）保持 **60** 不变

## 背景
LLM 生成失败时，兜底取第一条用户消息，60 字符在 session list 里太长。LLM 成功时标题本身较短（指令要求 ≤6 词），无需调整。

## 测试
- 更新 `TestAgent_GenerateTitleOrSnippet`、`TestTUI_TitleCmdFallsBackToSnippet`、`TestDisplayTitle` 预期值
- `TestCleanTitle_RuneSafeTruncation` 保持 60 不变
