### PR TITLE
fix(title): IM 会话接入标题生成机制，列表占位符回退 snippet

### DIFF
--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1430,24 +1430,26 @@ func (m *tuiModel) suggestCmd() tea.Cmd {
 // whole first turn. pending is the message starting the turn — the turn
 // goroutine appends it to History later, so the snapshot is taken here,
 // synchronously, and pending is added on top. It returns nil (no-op) when the
-// session is already titled (non-empty and not the "*Octo Agent"
-// placeholder), a generation is already in flight, saving is off, or there's
-// nothing to summarize. The shared mechanism (agent.GenerateTitleOrSnippet)
-// guarantees a title within TitleGenerationTimeout: the model's when the
-// throwaway call works, a snippet of pending otherwise. The result is
-// persisted by the titleMsg handler.
+// session is already titled (agent.IsAutoNamePlaceholder — the same predicate
+// the server gates on), a generation is already in flight, saving is off, or
+// there's no user text to summarize (blank pending and an empty history — no
+// throwaway call is spent on a title nothing can name). The shared mechanism
+// (agent.GenerateTitleOrSnippet) guarantees a title within
+// TitleGenerationTimeout: the model's when the throwaway call works, a
+// snippet of pending otherwise. The result is persisted by the titleMsg
+// handler.
 func (m *tuiModel) titleCmd(pending string) tea.Cmd {
 	if m.cfg.noSave || m.titlePending {
 		return nil
 	}
-	if t := m.cfg.session.Title; t != "" && t != "*Octo Agent" {
+	if !agent.IsAutoNamePlaceholder(m.cfg.session.Title) {
 		return nil
 	}
 	msgs := m.a.History.Snapshot()
 	if strings.TrimSpace(pending) != "" {
 		msgs = append(msgs, agent.NewUserMessage(pending))
 	}
-	if len(msgs) == 0 {
+	if agent.FirstUserSnippet(msgs) == "" {
 		return nil
 	}
 	m.titlePending = true

--- a/cmd/octo/tuirepl_test.go
+++ b/cmd/octo/tuirepl_test.go
@@ -289,6 +289,22 @@ func TestTUI_TitleCmdFallsBackToSnippet(t *testing.T) {
 	}
 }
 
+// Blank pending on an empty history carries no user text to summarize —
+// titleCmd must skip the throwaway call entirely (the same gate the web and
+// IM turns apply to attachments-only first messages).
+func TestTUI_TitleCmdSkipsBlankPending(t *testing.T) {
+	m := newTestModel()
+	m.cfg.noSave = false // newTestModel defaults to noSave, which gates titling
+	m.cfg.session = agent.NewSession("m", "")
+
+	if c := m.titleCmd("   "); c != nil {
+		t.Error("titleCmd with blank pending and empty history = command, want nil (no throwaway spend)")
+	}
+	if m.titlePending {
+		t.Error("titlePending set despite the skipped generation")
+	}
+}
+
 // An Esc take-back must leave no trace in the agent's history either: the
 // interrupt keeps the input capped with a note (finishInterrupted), so
 // handleTurnFinished has to strip that pair — otherwise the recalled text

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -909,6 +909,22 @@ func firstUserText(msgs []Message) string {
 	return ""
 }
 
+// sessionPlaceholderRe matches the web frontend's auto-assigned "Session N"
+// default name on freshly created web sessions.
+var sessionPlaceholderRe = regexp.MustCompile(`^Session \d+$`)
+
+// IsAutoNamePlaceholder reports whether a session title is absent or still an
+// auto-assigned placeholder — "*Octo Agent" (agent.NewSession's default) or
+// the frontend's "Session N" — both get replaced by a generated title after
+// the first completed turn. A name the user typed themselves is kept. This is
+// THE placeholder predicate: the generation gate, the turn-end adoption, and
+// every list overlay must agree on it or a title is generated but never
+// adopted (or vice versa).
+func IsAutoNamePlaceholder(title string) bool {
+	t := strings.TrimSpace(title)
+	return t == "" || t == "*Octo Agent" || sessionPlaceholderRe.MatchString(t)
+}
+
 // snippetBudget caps a one-line preview in half-width columns: wide (CJK)
 // runes count 2, others 1. 50 columns is 25 full-width characters or roughly
 // eight English words — display width is the one ruler that makes Chinese,

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -953,3 +953,27 @@ func TestSetWorkingDir_BeforeSave(t *testing.T) {
 		t.Errorf("loaded WorkingDir = %q, want /tmp/repo-a", got.WorkingDir)
 	}
 }
+
+// TestIsAutoNamePlaceholder pins THE placeholder predicate: the title
+// generation gate, turn-end adoption (server and channel), and list overlays
+// all share it — if they disagree a title is generated but never adopted.
+func TestIsAutoNamePlaceholder(t *testing.T) {
+	cases := []struct {
+		title string
+		want  bool
+	}{
+		{"", true},
+		{"  ", true},
+		{"Session 1", true},
+		{"Session 42", true},
+		{"*Octo Agent", true},
+		{"Session", false},
+		{"修复登录问题", false},
+		{"My Session 2", false},
+	}
+	for _, c := range cases {
+		if got := IsAutoNamePlaceholder(c.title); got != c.want {
+			t.Errorf("IsAutoNamePlaceholder(%q) = %v, want %v", c.title, got, c.want)
+		}
+	}
+}

--- a/internal/channel/persist.go
+++ b/internal/channel/persist.go
@@ -144,27 +144,36 @@ func (s *Session) Persist() error {
 	return nil
 }
 
-// AdoptGeneratedTitle records an async-generated session title, replacing the
-// "*Octo Agent" placeholder (or an empty title). A title the user set
-// themselves — anything else — always wins and the adoption is refused.
+// AdoptGeneratedTitle records an async-generated session title, replacing an
+// auto-name placeholder ("*Octo Agent", "Session N", or empty — the shared
+// agent.IsAutoNamePlaceholder predicate, so adoption can never disagree with
+// the server's generation gate). A non-placeholder in-memory title (e.g. one
+// the user set via this session) is kept and the adoption is refused — with
+// the same caveat the web path has: a rename that landed on disk mid-turn via
+// a separate load (REST rename) is only visible after the next reload.
 // storeMu serializes the write with Persist/UnbindStore/deleteStore, the same
 // discipline Persist follows; a tombstoned store (concurrent /unbind) just
-// reports false. Returns true when the placeholder was replaced.
+// reports false. The error is SetTitle's (a failed append surfaces to the
+// caller's log instead of vanishing). Returns true when the placeholder was
+// replaced.
 //
 // Durability: on a transcript that already carries messages SetTitle appends
 // a title record itself; on a meta-only store (no turn persisted yet) the
 // title rides the caller's next Persist, which folds it into the meta header
 // — the server's channel persist closure always adopts right before Persist.
-func (s *Session) AdoptGeneratedTitle(title string) bool {
+func (s *Session) AdoptGeneratedTitle(title string) (bool, error) {
 	s.storeMu.Lock()
 	defer s.storeMu.Unlock()
 	if s.Store == nil {
-		return false
+		return false, nil
 	}
-	if t := strings.TrimSpace(s.Store.Title); t != "" && t != "*Octo Agent" {
-		return false
+	if !agent.IsAutoNamePlaceholder(s.Store.Title) {
+		return false, nil
 	}
-	return s.Store.SetTitle(title) == nil
+	if err := s.Store.SetTitle(title); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // UnbindStore releases the store's entry binding and persists the change.

--- a/internal/channel/persist.go
+++ b/internal/channel/persist.go
@@ -41,13 +41,15 @@ func sessionStoreID(key SessionKey) string {
 }
 
 // newChannelStore builds a fresh, persisted-shape store for a channel
-// session: source "channel", bound to EntryChannel, Title left empty so
-// DisplayTitle() falls back to the first user message snippet (truncated to
-// 60 chars) instead of showing the raw SessionKey (e.g.
-// "weixin:o9cq…@im.wechat:o9cq…@im.wechat"). Shared by restoreOrInitStore
-// (first-ever store for a session) and EnsureStoreExists (#1079 — recovering
-// after the file was deleted out from under an already-running session), so
-// both give a fresh channel session the exact same shape.
+// session: source "channel", bound to EntryChannel. Title stays at
+// agent.NewSession's "*Octo Agent" placeholder — never the raw SessionKey
+// (e.g. "weixin:o9cq…@im.wechat:o9cq…@im.wechat") — until the first turn's
+// async title generation replaces it; meanwhile DisplayTitle() surfaces the
+// first user message snippet instead of the placeholder. Shared by
+// restoreOrInitStore (first-ever store for a session) and EnsureStoreExists
+// (#1079 — recovering after the file was deleted out from under an
+// already-running session), so both give a fresh channel session the exact
+// same shape.
 func newChannelStore(id, model string) *agent.Session {
 	st := agent.NewSession(model, "")
 	st.ID = id
@@ -140,6 +142,29 @@ func (s *Session) Persist() error {
 	// Best-effort and idempotent (a no-op when the count is unchanged).
 	_ = s.Agent.PersistContextUsage(s.Store)
 	return nil
+}
+
+// AdoptGeneratedTitle records an async-generated session title, replacing the
+// "*Octo Agent" placeholder (or an empty title). A title the user set
+// themselves — anything else — always wins and the adoption is refused.
+// storeMu serializes the write with Persist/UnbindStore/deleteStore, the same
+// discipline Persist follows; a tombstoned store (concurrent /unbind) just
+// reports false. Returns true when the placeholder was replaced.
+//
+// Durability: on a transcript that already carries messages SetTitle appends
+// a title record itself; on a meta-only store (no turn persisted yet) the
+// title rides the caller's next Persist, which folds it into the meta header
+// — the server's channel persist closure always adopts right before Persist.
+func (s *Session) AdoptGeneratedTitle(title string) bool {
+	s.storeMu.Lock()
+	defer s.storeMu.Unlock()
+	if s.Store == nil {
+		return false
+	}
+	if t := strings.TrimSpace(s.Store.Title); t != "" && t != "*Octo Agent" {
+		return false
+	}
+	return s.Store.SetTitle(title) == nil
 }
 
 // UnbindStore releases the store's entry binding and persists the change.

--- a/internal/channel/persist_test.go
+++ b/internal/channel/persist_test.go
@@ -519,3 +519,72 @@ func TestEnsureStoreExists_NoOpWhenStoreIsNil(t *testing.T) {
 		t.Error("EnsureStoreExists should not resurrect a tombstoned store")
 	}
 }
+
+// TestAdoptGeneratedTitle_ReplacesPlaceholder pins the contract the server's
+// channel turn relies on: an async-generated title replaces the "*Octo Agent"
+// placeholder and persists.
+func TestAdoptGeneratedTitle_ReplacesPlaceholder(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+	m := testManager()
+	sess := m.GetOrCreateSession(ev)
+	if sess.Store.Title != "*Octo Agent" {
+		t.Fatalf("fresh channel store title = %q, want the placeholder", sess.Store.Title)
+	}
+
+	if !sess.AdoptGeneratedTitle("deploy staging build") {
+		t.Fatal("AdoptGeneratedTitle refused to replace the placeholder")
+	}
+	if sess.Store.Title != "deploy staging build" {
+		t.Errorf("in-memory title = %q, want %q", sess.Store.Title, "deploy staging build")
+	}
+	// The store is meta-only (no messages persisted yet), so the title folds
+	// into the meta header on the next Persist — the order the server's
+	// channel persist closure always uses.
+	if err := sess.Persist(); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	reloaded, err := agent.LoadSession(sess.Store.ID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if reloaded.Title != "deploy staging build" {
+		t.Errorf("persisted title = %q, want %q", reloaded.Title, "deploy staging build")
+	}
+}
+
+// TestAdoptGeneratedTitle_KeepsUserTitle: a title the user set themselves
+// (anything but the placeholder) always wins over a late-arriving generated
+// one.
+func TestAdoptGeneratedTitle_KeepsUserTitle(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+	m := testManager()
+	sess := m.GetOrCreateSession(ev)
+	if err := sess.Store.SetTitle("my rename"); err != nil {
+		t.Fatal(err)
+	}
+
+	if sess.AdoptGeneratedTitle("generated") {
+		t.Error("AdoptGeneratedTitle overwrote a user-set title")
+	}
+	if sess.Store.Title != "my rename" {
+		t.Errorf("title = %q, want %q", sess.Store.Title, "my rename")
+	}
+}
+
+// TestAdoptGeneratedTitle_TombstonedStore: a concurrent /unbind tombstones the
+// store mid-turn; adoption must report false, not panic.
+func TestAdoptGeneratedTitle_TombstonedStore(t *testing.T) {
+	tempHome(t)
+	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
+	m := testManager()
+	sess := m.GetOrCreateSession(ev)
+	if err := sess.deleteStore(); err != nil {
+		t.Fatal(err)
+	}
+
+	if sess.AdoptGeneratedTitle("generated") {
+		t.Error("AdoptGeneratedTitle succeeded on a tombstoned store")
+	}
+}

--- a/internal/channel/persist_test.go
+++ b/internal/channel/persist_test.go
@@ -521,26 +521,44 @@ func TestEnsureStoreExists_NoOpWhenStoreIsNil(t *testing.T) {
 }
 
 // TestAdoptGeneratedTitle_ReplacesPlaceholder pins the contract the server's
-// channel turn relies on: an async-generated title replaces the "*Octo Agent"
-// placeholder and persists.
+// channel turn relies on: an async-generated title replaces an auto-name
+// placeholder and persists. "Session N" counts as a placeholder too — a chat
+// can /bind a web-created session that never completed title generation, and
+// the adoption predicate must agree with the server's generation gate
+// (agent.IsAutoNamePlaceholder) or the title would be regenerated every turn
+// yet never adopted.
 func TestAdoptGeneratedTitle_ReplacesPlaceholder(t *testing.T) {
 	tempHome(t)
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
 	m := testManager()
-	sess := m.GetOrCreateSession(ev)
-	if sess.Store.Title != "*Octo Agent" {
-		t.Fatalf("fresh channel store title = %q, want the placeholder", sess.Store.Title)
+
+	for _, placeholder := range []string{"*Octo Agent", "Session 3", ""} {
+		sess := m.GetOrCreateSession(ev)
+		sess.Store.Title = placeholder // direct assignment: SetTitle("") is a no-op
+		adopted, err := sess.AdoptGeneratedTitle("deploy staging build")
+		if err != nil {
+			t.Fatalf("AdoptGeneratedTitle over %q: %v", placeholder, err)
+		}
+		if !adopted {
+			t.Fatalf("AdoptGeneratedTitle refused to replace placeholder %q", placeholder)
+		}
+		if sess.Store.Title != "deploy staging build" {
+			t.Errorf("in-memory title = %q, want %q", sess.Store.Title, "deploy staging build")
+		}
+		if err := sess.deleteStore(); err != nil { // reset for the next case
+			t.Fatal(err)
+		}
+		m.sessions.Delete(sessionKeyFor(m.mode, ev))
 	}
 
-	if !sess.AdoptGeneratedTitle("deploy staging build") {
-		t.Fatal("AdoptGeneratedTitle refused to replace the placeholder")
-	}
-	if sess.Store.Title != "deploy staging build" {
-		t.Errorf("in-memory title = %q, want %q", sess.Store.Title, "deploy staging build")
-	}
 	// The store is meta-only (no messages persisted yet), so the title folds
 	// into the meta header on the next Persist — the order the server's
 	// channel persist closure always uses.
+	sess := m.GetOrCreateSession(ev)
+	adopted, err := sess.AdoptGeneratedTitle("deploy staging build")
+	if err != nil || !adopted {
+		t.Fatalf("AdoptGeneratedTitle: adopted=%v err=%v", adopted, err)
+	}
 	if err := sess.Persist(); err != nil {
 		t.Fatalf("Persist: %v", err)
 	}
@@ -553,9 +571,9 @@ func TestAdoptGeneratedTitle_ReplacesPlaceholder(t *testing.T) {
 	}
 }
 
-// TestAdoptGeneratedTitle_KeepsUserTitle: a title the user set themselves
-// (anything but the placeholder) always wins over a late-arriving generated
-// one.
+// TestAdoptGeneratedTitle_KeepsUserTitle: a non-placeholder in-memory title
+// (e.g. one the user set through this session) is kept over a late-arriving
+// generated one.
 func TestAdoptGeneratedTitle_KeepsUserTitle(t *testing.T) {
 	tempHome(t)
 	ev := InboundEvent{Platform: "feishu", ChatID: "c1", UserID: "u1"}
@@ -565,7 +583,11 @@ func TestAdoptGeneratedTitle_KeepsUserTitle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if sess.AdoptGeneratedTitle("generated") {
+	adopted, err := sess.AdoptGeneratedTitle("generated")
+	if err != nil {
+		t.Fatalf("AdoptGeneratedTitle: %v", err)
+	}
+	if adopted {
 		t.Error("AdoptGeneratedTitle overwrote a user-set title")
 	}
 	if sess.Store.Title != "my rename" {
@@ -584,7 +606,11 @@ func TestAdoptGeneratedTitle_TombstonedStore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if sess.AdoptGeneratedTitle("generated") {
+	adopted, err := sess.AdoptGeneratedTitle("generated")
+	if err != nil {
+		t.Fatalf("AdoptGeneratedTitle: %v", err)
+	}
+	if adopted {
 		t.Error("AdoptGeneratedTitle succeeded on a tombstoned store")
 	}
 }

--- a/internal/server/channel_title_test.go
+++ b/internal/server/channel_title_test.go
@@ -112,6 +112,35 @@ func TestHandleChannelMessage_TitleFallsBackToSnippet(t *testing.T) {
 	}
 }
 
+// TestHandleChannelMessage_SkipsTitleForEmptyFirstMessage: an attachments-only
+// first message (vision model — the image rides content blocks and the text
+// resolves to "") must not spend the throwaway title call. Web parity:
+// TestDoAgentTurn_SkipsTitleForEmptyFirstMessage.
+func TestHandleChannelMessage_SkipsTitleForEmptyFirstMessage(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	spy := &titleSpySender{}
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+		return agent.New(spy, "stub-model")
+	}, channel.BindByChat)
+
+	ad := &fullFakeAdapter{}
+	ev := evFor("") // text-free content, the attachments-only shape
+	sess := srv.channelMgr.GetOrCreateSession(ev)
+
+	srv.handleChannelMessage(context.Background(), ad, ev)
+
+	if got := spy.titleCalls.Load(); got != 0 {
+		t.Errorf("title calls = %d, want 0 for a text-free first message", got)
+	}
+	if sess.Store.Title != "*Octo Agent" {
+		t.Errorf("title = %q, want the placeholder (untouched)", sess.Store.Title)
+	}
+}
+
 // TestToSessionItem_PlaceholderFallsBackToSnippet: the REST session list must
 // collapse the "*Octo Agent" placeholder onto the first-message snippet
 // (DisplayTitle), matching the WS brief list — an IM session whose title

--- a/internal/server/channel_title_test.go
+++ b/internal/server/channel_title_test.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/channel"
+)
+
+// TestHandleChannelMessage_GeneratesSessionTitle is the regression guard for
+// IM sessions never getting an auto-generated title: the channel turn path
+// (handleChannelMessage → runChannelTurns) never called the shared title
+// mechanism, so an IM session kept agent.NewSession's "*Octo Agent"
+// placeholder forever while web/TUI sessions were titled after their first
+// turn (web parity: TestDoAgentTurn_GeneratesSessionTitle).
+func TestHandleChannelMessage_GeneratesSessionTitle(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	sender := &blockingTurnSender{entered: make(chan struct{}), release: make(chan struct{})}
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+		return agent.New(sender, "stub-model")
+	}, channel.BindByChat)
+
+	// Observe the global rename broadcast like a browser tab would.
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+
+	ad := &fullFakeAdapter{}
+	ev := evFor("hello there")
+	sess := srv.channelMgr.GetOrCreateSession(ev) // pre-create to learn the store ID
+	storeID := sess.Store.ID
+	if sess.Store.Title != "*Octo Agent" {
+		t.Fatalf("fresh IM session title = %q, want the placeholder", sess.Store.Title)
+	}
+
+	turnDone := make(chan struct{})
+	go func() { defer close(turnDone); srv.handleChannelMessage(context.Background(), ad, ev) }()
+	<-sender.entered // main turn call is blocked; title generation runs concurrently
+
+	// Mid-turn the generated title is broadcast live...
+	if name := waitForRename(t, conn, storeID); name != "early title" {
+		t.Fatalf("rename broadcast = %q, want %q", name, "early title")
+	}
+	close(sender.release)
+	<-turnDone
+
+	// ...and adopted + persisted by the turn's serialized write path.
+	if sess.Store.Title != "early title" {
+		t.Errorf("adopted title = %q, want %q", sess.Store.Title, "early title")
+	}
+	reloaded, err := agent.LoadSession(storeID)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if reloaded.Title != "early title" {
+		t.Errorf("persisted title = %q, want %q", reloaded.Title, "early title")
+	}
+}
+
+// TestHandleChannelMessage_TitleFallsBackToSnippet: when the title-generation
+// provider call fails, the shared GenerateTitleOrSnippet mechanism still
+// titles the IM session with the first user message — the same guarantee web
+// turns have (TestDoAgentTurn_TitleGenerationFailureIsLogged).
+func TestHandleChannelMessage_TitleFallsBackToSnippet(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	sender := &blockingTitleFailSender{entered: make(chan struct{}), release: make(chan struct{})}
+	srv.channelMgr = channel.NewManager(&channel.Config{}, func() *agent.Agent {
+		return agent.New(sender, "stub-model")
+	}, channel.BindByChat)
+
+	conn := &wsConn{
+		hub:        srv.wsHub,
+		send:       make(chan []byte, 256),
+		subscribed: map[string]struct{}{},
+	}
+	srv.wsHub.register <- conn
+
+	ad := &fullFakeAdapter{}
+	ev := evFor("hello there")
+	sess := srv.channelMgr.GetOrCreateSession(ev)
+	storeID := sess.Store.ID
+
+	turnDone := make(chan struct{})
+	go func() { defer close(turnDone); srv.handleChannelMessage(context.Background(), ad, ev) }()
+	<-sender.entered // main turn call is blocked; the snippet fallback lands mid-turn
+
+	if name := waitForRename(t, conn, storeID); name != "hello there" {
+		t.Fatalf("rename broadcast = %q, want the first-message snippet %q", name, "hello there")
+	}
+	close(sender.release)
+	<-turnDone
+
+	if sess.Store.Title != "hello there" {
+		t.Errorf("adopted title = %q, want the snippet %q", sess.Store.Title, "hello there")
+	}
+}
+
+// TestToSessionItem_PlaceholderFallsBackToSnippet: the REST session list must
+// collapse the "*Octo Agent" placeholder onto the first-message snippet
+// (DisplayTitle), matching the WS brief list — an IM session whose title
+// generation hasn't landed yet must not surface the raw placeholder.
+func TestToSessionItem_PlaceholderFallsBackToSnippet(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+
+	sess := agent.NewSession("stub-model", "") // Title: "*Octo Agent"
+	sess.Messages = []agent.Message{{Role: agent.RoleUser, Content: "hello there"}}
+
+	item := srv.toSessionItem(sess, "channel", "")
+	if item.Name == "*Octo Agent" {
+		t.Error("toSessionItem surfaced the raw placeholder; want the first-message snippet")
+	}
+	if item.Name != "hello there" {
+		t.Errorf("name = %q, want the snippet %q", item.Name, "hello there")
+	}
+
+	// A real title (generated or user-set) still wins over the snippet.
+	sess.Title = "deploy staging build"
+	item = srv.toSessionItem(sess, "channel", "")
+	if item.Name != "deploy staging build" {
+		t.Errorf("name = %q, want the session's own title %q", item.Name, "deploy staging build")
+	}
+}

--- a/internal/server/channel_title_test.go
+++ b/internal/server/channel_title_test.go
@@ -56,6 +56,11 @@ func TestHandleChannelMessage_GeneratesSessionTitle(t *testing.T) {
 	if sess.Store.Title != "early title" {
 		t.Errorf("adopted title = %q, want %q", sess.Store.Title, "early title")
 	}
+	// The adoption re-broadcast converges any client whose list refetch saw the
+	// placeholder since the mid-turn broadcast (web ws_handlers.go:1548 parity).
+	if name := waitForRename(t, conn, storeID); name != "early title" {
+		t.Fatalf("post-adoption re-broadcast = %q, want %q", name, "early title")
+	}
 	reloaded, err := agent.LoadSession(storeID)
 	if err != nil {
 		t.Fatalf("LoadSession: %v", err)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -92,10 +92,11 @@ func (srv *Server) toSessionItem(s *agent.Session, source, agentProfile string) 
 			updated = st.ModTime()
 		}
 	}
-	name := s.Title
-	if name == "" {
-		name = s.DisplayTitle()
-	}
+	// DisplayTitle collapses the "*Octo Agent" placeholder onto the first
+	// message snippet; Title alone would surface the raw placeholder for an
+	// IM session whose async title generation hasn't landed yet (the WS brief
+	// list already uses DisplayTitle — ws_handlers.go).
+	name := s.DisplayTitle()
 	title := s.Title
 	// A title generated mid-turn is broadcast immediately but adopted (and
 	// persisted) only at turn end; surface it in list responses meanwhile so

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -103,7 +103,7 @@ func (srv *Server) toSessionItem(s *agent.Session, source, agentProfile string) 
 	// a client refetch in between doesn't regress the sidebar to the
 	// placeholder. One storage: this overlays the same pendingTitles record
 	// the turn adopts from — it never writes anything itself.
-	if pt := srv.peekPendingTitle(s.ID); pt != "" && isAutoNamePlaceholder(s.Title) {
+	if pt := srv.peekPendingTitle(s.ID); pt != "" && agent.IsAutoNamePlaceholder(s.Title) {
 		name, title = pt, pt
 	}
 	_, pm, re, sr, ctxUsage := srv.sessionStatusFields(s)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2871,28 +2871,32 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// file itself. A generation still in flight at turn end rides the next
 	// turn's adoption; a failure leaves the placeholder and the next turn
 	// retries (the claim is released either way).
-	if st := sess.Store; st != nil && agent.IsAutoNamePlaceholder(st.Title) && s.claimTitleGeneration(st.ID) {
+	if st := sess.Store; st != nil && agent.IsAutoNamePlaceholder(st.Title) {
 		sid := st.ID
 		// Pre-turn snapshot plus the incoming user message — the turn loop
 		// owns History and hasn't appended it yet (web titleMsgs parity).
 		titleMsgs := append(append([]agent.Message{}, st.Messages...), agent.NewUserMessage(content))
-		go func() {
-			defer s.recoverBg("channel title generation")
-			defer s.releaseTitleGeneration(sid)
-			ctx, cancel := context.WithTimeout(context.Background(), agent.TitleGenerationTimeout)
-			defer cancel()
-			t, terr := sess.Agent.GenerateTitleOrSnippet(ctx, titleMsgs, toolDefs)
-			if terr != nil {
-				slog.Warn("channel session title generation failed, falling back to message snippet", "session_id", sid, "err", terr)
-			}
-			if strings.TrimSpace(t) == "" {
-				// No user text to title from at all (e.g. an attachments-only
-				// first message); nothing to fall back to — next turn retries.
-				return
-			}
-			s.storePendingTitle(sid, t)
-			s.broadcastSessionRenamed(sid, t)
-		}()
+		// No user text to title from at all (e.g. an attachments-only first
+		// message): skip the throwaway call rather than pay for a hallucinated
+		// title — the snippet fallback would come up empty anyway. The next
+		// text-bearing user message retries.
+		if agent.FirstUserSnippet(titleMsgs) != "" && s.claimTitleGeneration(sid) {
+			go func() {
+				defer s.recoverBg("channel title generation")
+				defer s.releaseTitleGeneration(sid)
+				ctx, cancel := context.WithTimeout(context.Background(), agent.TitleGenerationTimeout)
+				defer cancel()
+				t, terr := sess.Agent.GenerateTitleOrSnippet(ctx, titleMsgs)
+				if terr != nil {
+					slog.Warn("channel session title generation failed, falling back to message snippet", "session_id", sid, "err", terr)
+				}
+				if strings.TrimSpace(t) == "" {
+					return
+				}
+				s.storePendingTitle(sid, t)
+				s.broadcastSessionRenamed(sid, t)
+			}()
+		}
 	}
 
 	persist := func() {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2871,7 +2871,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// file itself. A generation still in flight at turn end rides the next
 	// turn's adoption; a failure leaves the placeholder and the next turn
 	// retries (the claim is released either way).
-	if st := sess.Store; st != nil && isAutoNamePlaceholder(st.Title) && s.claimTitleGeneration(st.ID) {
+	if st := sess.Store; st != nil && agent.IsAutoNamePlaceholder(st.Title) && s.claimTitleGeneration(st.ID) {
 		sid := st.ID
 		// Pre-turn snapshot plus the incoming user message — the turn loop
 		// owns History and hasn't appended it yet (web titleMsgs parity).
@@ -2899,12 +2899,17 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		// Adopt a title generated while the turn ran (web doAgentTurn parity):
 		// the generation goroutine only broadcast + stored it — this persist
 		// path is the only writer of the session file. AdoptGeneratedTitle
-		// refuses when the user renamed the session themselves meanwhile.
+		// refuses when the session's in-memory title is no longer a placeholder.
 		if st := sess.Store; st != nil {
-			if t := s.takePendingTitle(st.ID); t != "" && sess.AdoptGeneratedTitle(t) {
-				// Converge any client whose list refetch saw the placeholder
-				// since the mid-turn broadcast: disk is authoritative now.
-				s.broadcastSessionRenamed(st.ID, t)
+			if t := s.takePendingTitle(st.ID); t != "" {
+				adopted, aerr := sess.AdoptGeneratedTitle(t)
+				if aerr != nil {
+					slog.Warn("channel session title adoption: save failed", "session_id", st.ID, "err", aerr)
+				} else if adopted {
+					// Converge any client whose list refetch saw the placeholder
+					// since the mid-turn broadcast: disk is authoritative now.
+					s.broadcastSessionRenamed(st.ID, t)
+				}
 			}
 		}
 		// Persist the conversation so it survives server restarts. Failure

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2861,7 +2861,52 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 		ctx = tools.WithWaker(ctx, imWaker{s: s, sess: sess, ad: ad, ev: ev})
 	}
 
+	// Session title, web doAgentTurn parity: an IM session starts life with
+	// agent.NewSession's "*Octo Agent" placeholder and — unlike a web turn —
+	// nothing ever replaced it, so the session list showed the placeholder
+	// forever. Same one mechanism: an async GenerateTitleOrSnippet within
+	// TitleGenerationTimeout (an LLM title, else the first-message snippet),
+	// broadcast live and handed to this turn's serialized persist path via
+	// storePendingTitle — the generation goroutine never writes the session
+	// file itself. A generation still in flight at turn end rides the next
+	// turn's adoption; a failure leaves the placeholder and the next turn
+	// retries (the claim is released either way).
+	if st := sess.Store; st != nil && isAutoNamePlaceholder(st.Title) && s.claimTitleGeneration(st.ID) {
+		sid := st.ID
+		// Pre-turn snapshot plus the incoming user message — the turn loop
+		// owns History and hasn't appended it yet (web titleMsgs parity).
+		titleMsgs := append(append([]agent.Message{}, st.Messages...), agent.NewUserMessage(content))
+		go func() {
+			defer s.recoverBg("channel title generation")
+			defer s.releaseTitleGeneration(sid)
+			ctx, cancel := context.WithTimeout(context.Background(), agent.TitleGenerationTimeout)
+			defer cancel()
+			t, terr := sess.Agent.GenerateTitleOrSnippet(ctx, titleMsgs, toolDefs)
+			if terr != nil {
+				slog.Warn("channel session title generation failed, falling back to message snippet", "session_id", sid, "err", terr)
+			}
+			if strings.TrimSpace(t) == "" {
+				// No user text to title from at all (e.g. an attachments-only
+				// first message); nothing to fall back to — next turn retries.
+				return
+			}
+			s.storePendingTitle(sid, t)
+			s.broadcastSessionRenamed(sid, t)
+		}()
+	}
+
 	persist := func() {
+		// Adopt a title generated while the turn ran (web doAgentTurn parity):
+		// the generation goroutine only broadcast + stored it — this persist
+		// path is the only writer of the session file. AdoptGeneratedTitle
+		// refuses when the user renamed the session themselves meanwhile.
+		if st := sess.Store; st != nil {
+			if t := s.takePendingTitle(st.ID); t != "" && sess.AdoptGeneratedTitle(t) {
+				// Converge any client whose list refetch saw the placeholder
+				// since the mid-turn broadcast: disk is authoritative now.
+				s.broadcastSessionRenamed(st.ID, t)
+			}
+		}
 		// Persist the conversation so it survives server restarts. Failure
 		// must not eat the reply the user already got — log and move on.
 		// Persist() also records the context-token count (under storeMu) so this

--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -187,6 +188,57 @@ func isTitlePrompt(msgs []agent.Message) bool {
 		return false
 	}
 	return strings.Contains(msgs[len(msgs)-1].Content, "Generate a very short title")
+}
+
+// titleSpySender counts title-generation calls while letting the main turn
+// run freely — used to prove a gate SKIPPED the throwaway call rather than
+// the call merely failing.
+type titleSpySender struct {
+	stubSender
+	titleCalls atomic.Int32
+}
+
+func (s *titleSpySender) SendMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int) (agent.Reply, error) {
+	if isTitlePrompt(msgs) {
+		s.titleCalls.Add(1)
+	}
+	return agent.Reply{Content: "stub reply"}, nil
+}
+
+// TestDoAgentTurn_SkipsTitleForEmptyFirstMessage: a text-free first message
+// (attachments-only) must not spend the throwaway provider call — there is
+// nothing to summarize and the snippet fallback would come up empty, so a
+// compliant model's guessed title would be pure noise. The placeholder stays
+// and the next text-bearing message retries.
+func TestDoAgentTurn_SkipsTitleForEmptyFirstMessage(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0", Tools: false})
+	spy := &titleSpySender{}
+	srv.sender = spy
+	srv.initWS()
+	srv.turnRunning = make(map[string]bool)
+	srv.steerQueues = make(map[string][]agent.InboxItem)
+	srv.sessionAgents = make(map[string]*agent.Agent)
+
+	sess := agent.NewSession("stub-model", "")
+	if err := sess.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	srv.doAgentTurn(sess, "", nil, nil)
+
+	if got := spy.titleCalls.Load(); got != 0 {
+		t.Errorf("title calls = %d, want 0 for a text-free first message", got)
+	}
+	if sess.Title != "*Octo Agent" {
+		t.Errorf("title = %q, want the placeholder (untouched)", sess.Title)
+	}
+	if pt := srv.peekPendingTitle(sess.ID); pt != "" {
+		t.Errorf("pendingTitle = %q, want none stored", pt)
+	}
 }
 
 // blockingTurnSender lets the title-generation call (plain SendMessages, no

--- a/internal/server/session_title_test.go
+++ b/internal/server/session_title_test.go
@@ -34,27 +34,6 @@ func (b *syncBuffer) String() string {
 	return b.buf.String()
 }
 
-func TestIsAutoNamePlaceholder(t *testing.T) {
-	cases := []struct {
-		title string
-		want  bool
-	}{
-		{"", true},
-		{"  ", true},
-		{"Session 1", true},
-		{"Session 42", true},
-		{"*Octo Agent", true},
-		{"Session", false},
-		{"修复登录问题", false},
-		{"My Session 2", false},
-	}
-	for _, c := range cases {
-		if got := isAutoNamePlaceholder(c.title); got != c.want {
-			t.Errorf("isAutoNamePlaceholder(%q) = %v, want %v", c.title, got, c.want)
-		}
-	}
-}
-
 // waitForRename blocks until a global session_renamed for sid is observed on
 // conn (or fails on timeout), returning the broadcast name. Shared by the
 // title tests, which all drive a turn whose main call blocks so the rename is

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1354,32 +1354,36 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// only persistence path. A provider failure is logged and the snippet
 	// still applies; the claim releases either way and the next user message
 	// retries.
-	if agent.IsAutoNamePlaceholder(sess.Title) && s.claimTitleGeneration(sess.ID) {
+	if agent.IsAutoNamePlaceholder(sess.Title) {
 		sid := sess.ID
 		titleMsgs := append(append([]agent.Message{}, sess.Messages...), userMsg)
-		go func() {
-			defer s.recoverBg("title generation")
-			defer s.releaseTitleGeneration(sid)
-			ctx, cancel := context.WithTimeout(context.Background(), agent.TitleGenerationTimeout)
-			defer cancel()
-			t, terr := a.GenerateTitleOrSnippet(ctx, titleMsgs)
-			if terr != nil {
-				slog.Warn("session title generation failed, falling back to message snippet", "session_id", sid, "err", terr)
-			}
-			if strings.TrimSpace(t) == "" {
-				// No user text to title from at all (e.g. an attachments-only
-				// first message); nothing to fall back to — next turn retries.
-				return
-			}
-			// Hand the title to the turn goroutine (it persists it) and
-			// broadcast the rename so every tab's sidebar updates live.
-			s.storePendingTitle(sid, t)
-			s.wsHub.broadcast("", map[string]any{
-				"type":       "session_renamed",
-				"session_id": sid,
-				"name":       t,
-			})
-		}()
+		// No user text to title from at all (e.g. an attachments-only first
+		// message): skip the throwaway call rather than pay for a hallucinated
+		// title — the snippet fallback would come up empty anyway. The next
+		// text-bearing user message retries.
+		if agent.FirstUserSnippet(titleMsgs) != "" && s.claimTitleGeneration(sid) {
+			go func() {
+				defer s.recoverBg("title generation")
+				defer s.releaseTitleGeneration(sid)
+				ctx, cancel := context.WithTimeout(context.Background(), agent.TitleGenerationTimeout)
+				defer cancel()
+				t, terr := a.GenerateTitleOrSnippet(ctx, titleMsgs)
+				if terr != nil {
+					slog.Warn("session title generation failed, falling back to message snippet", "session_id", sid, "err", terr)
+				}
+				if strings.TrimSpace(t) == "" {
+					return
+				}
+				// Hand the title to the turn goroutine (it persists it) and
+				// broadcast the rename so every tab's sidebar updates live.
+				s.storePendingTitle(sid, t)
+				s.wsHub.broadcast("", map[string]any{
+					"type":       "session_renamed",
+					"session_id": sid,
+					"name":       t,
+				})
+			}()
+		}
 	}
 
 	// Persist the turn's progress incrementally: after any event that grew or

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1666,6 +1666,21 @@ func (s *Server) peekPendingTitle(sessionID string) string {
 	return s.pendingTitles[sessionID]
 }
 
+// broadcastSessionRenamed announces a session's new title globally so every
+// tab's sidebar updates live. Nil-hub safe (broadcastGoalUpdated precedent):
+// channel turns run in processes/tests where initWS never ran, and a rename
+// is cosmetic — never worth crashing the turn that carries it.
+func (s *Server) broadcastSessionRenamed(sessionID, name string) {
+	if s.wsHub == nil {
+		return
+	}
+	s.wsHub.broadcast("", map[string]any{
+		"type":       "session_renamed",
+		"session_id": sessionID,
+		"name":       name,
+	})
+}
+
 // ─── wsStreamWriter ────────────────────────────────────────────────────────
 
 type wsStreamWriter struct {

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"regexp"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -111,7 +110,7 @@ func (s *Server) listSessionsBrief() []wsSessionInfo {
 		name := sess.DisplayTitle()
 		// Same pending-title overlay as toSessionItem: a title broadcast
 		// mid-turn isn't on disk yet, and this list feeds the sidebar.
-		if pt := s.peekPendingTitle(sess.ID); pt != "" && isAutoNamePlaceholder(sess.Title) {
+		if pt := s.peekPendingTitle(sess.ID); pt != "" && agent.IsAutoNamePlaceholder(sess.Title) {
 			name = pt
 		}
 		_, pm, re, sr, ctxUsage := s.sessionStatusFields(sess)
@@ -1355,7 +1354,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// only persistence path. A provider failure is logged and the snippet
 	// still applies; the claim releases either way and the next user message
 	// retries.
-	if isAutoNamePlaceholder(sess.Title) && s.claimTitleGeneration(sess.ID) {
+	if agent.IsAutoNamePlaceholder(sess.Title) && s.claimTitleGeneration(sess.ID) {
 		sid := sess.ID
 		titleMsgs := append(append([]agent.Message{}, sess.Messages...), userMsg)
 		go func() {
@@ -1538,7 +1537,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	// disk keeps the placeholder and a reload falls back to the message
 	// snippet. Acceptable for a best-effort throwaway title; the common
 	// long-turn case always finishes generation well before this point.
-	if t := s.takePendingTitle(sess.ID); t != "" && isAutoNamePlaceholder(sess.Title) {
+	if t := s.takePendingTitle(sess.ID); t != "" && agent.IsAutoNamePlaceholder(sess.Title) {
 		if terr := sess.SetTitle(t); terr != nil {
 			slog.Warn("session title adoption: save failed", "session_id", sess.ID, "err", terr)
 		} else {
@@ -1596,18 +1595,6 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 // modest rather than papering over a slow call with a long wait. (Session
 // titles use agent.TitleGenerationTimeout, the shared title mechanism.)
 const throwawayGenerationTimeout = 5 * time.Second
-
-// sessionPlaceholderRe matches the frontend's auto-assigned "Session N"
-// default name on freshly created web sessions.
-var sessionPlaceholderRe = regexp.MustCompile(`^Session \d+$`)
-
-// isAutoNamePlaceholder reports whether a session title is absent or still the
-// frontend's "Session N" placeholder — both get replaced by a generated title
-// after the first completed turn. A name the user typed themselves is kept.
-func isAutoNamePlaceholder(title string) bool {
-	t := strings.TrimSpace(title)
-	return t == "" || t == "*Octo Agent" || sessionPlaceholderRe.MatchString(t)
-}
 
 // claimTitleGeneration marks a title generation in flight for the session;
 // it returns false when one is already running so concurrent turn ends don't


### PR DESCRIPTION
## 问题

通过 IM（微信/Telegram/飞书等）发起的会话，标题永远停在 `*Octo Agent` 占位符。

**根因**：web/TUI 的 turn 都会异步调 `GenerateTitleOrSnippet`（LLM 生成标题，5s 超时失败则兜底首条消息 snippet），而 channel 路径（`handleChannelMessage` → `runChannelTurns`）从未接入该机制——通读整个 turn 链路没有任何标题生成调用。会话经 `agent.NewSession` 创建后 Title 即占位符，此后再无人触碰。

**加重因素**：REST 会话列表 `toSessionItem` 的 `name := s.Title; if name == ""` 判断对非空的 `*Octo Agent` 占位符无效，连 `DisplayTitle()` 的 snippet 显示兜底都被跳过（WS brief 列表走 `DisplayTitle()` 是对的，两处行为不一致）。

## 修复

完全对齐 web `doAgentTurn` 的标题机制：

- **`runChannelTurns`**：turn 前检查 `isAutoNamePlaceholder` + `claimTitleGeneration`（复用 server 现有的去重机制），异步 `GenerateTitleOrSnippet`（LLM 标题，失败兜底 snippet），`storePendingTitle` + 广播 `session_renamed`；persist 闭包在序列化写路径上 adopt 并持久化（生成 goroutine 不写文件，与 web 同一纪律）。生成失败/超时留下占位符，下个 turn 重试；idle turn 走同一函数，自然获得重试路径。
- **`channel.Session.AdoptGeneratedTitle`**：`storeMu` 下替换占位符标题；用户自定义标题永远优先；tombstoned store（并发 `/unbind`）安全拒绝。
- **`toSessionItem`**：`name` 改走 `DisplayTitle()`，REST 列表对占位符回退首条消息 snippet，与 WS brief 列表一致。
- 修正 `newChannelStore` 过时注释（Title 并非"留空"，是 `NewSession` 的占位符）。

## 测试

- `TestHandleChannelMessage_GeneratesSessionTitle`：端到端回归——turn 阻塞期间标题并发生成并广播，turn 结束 adopt + 落盘（`LoadSession` 验证）
- `TestHandleChannelMessage_TitleFallsBackToSnippet`：provider 失败时 snippet 兜底（web 同款保证）
- `TestToSessionItem_PlaceholderFallsBackToSnippet`：REST 列表占位符回退 + 真实标题优先
- `TestAdoptGeneratedTitle_*`（channel 包）：占位符替换并持久化、用户标题拒绝覆盖、tombstone 安全
- `go test ./internal/server/ ./internal/channel/... ./internal/agent/...` 全绿

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
