### PR TITLE
feat(title): 截断宽度预算放宽到 25 个全宽字符

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1350,10 +1350,10 @@ const titleContextMaxRunes = 500
 
 // titleInstruction demands brevity twice — in words for spacey languages, in
 // characters for CJK — because a sidebar title wraps or truncates past a
-// handful of words. 5 words / 15 characters mirrors FirstUserSnippet's
+// handful of words. 8 words / 25 characters mirrors FirstUserSnippet's
 // truncation budget, so a model title and the snippet fallback land at the
 // same length.
-const titleInstruction = "Generate a very short title for this conversation — at most 5 words, or 15 characters for Chinese or Japanese. " +
+const titleInstruction = "Generate a very short title for this conversation — at most 8 words, or 25 characters for Chinese or Japanese. " +
 	"Reply with the title text only — no preamble, no quotes, no trailing punctuation, no markdown."
 
 // GenerateTitle produces a short title for the conversation so far, for

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -2103,24 +2103,24 @@ func TestCleanTitle(t *testing.T) {
 
 func TestCleanTitle_RuneSafeTruncation(t *testing.T) {
 	// A long CJK title must be truncated on a rune boundary, never mid-byte,
-	// at the shared display-width budget: 15 full-width chars fill 30
-	// half-width columns, the 16th triggers the cut.
+	// at the shared display-width budget: 25 full-width chars fill 50
+	// half-width columns, the 26th triggers the cut.
 	in := strings.Repeat("订", 80)
 	got := cleanTitle(in)
 	if !strings.HasSuffix(got, "…") {
 		t.Errorf("cleanTitle(long) = %q, want a trailing ellipsis", got)
 	}
-	if r := []rune(got); len(r) != 16 { // 15 kept + the ellipsis
-		t.Errorf("cleanTitle(long) rune len = %d, want 16 (15 kept + ellipsis)", len(r))
+	if r := []rune(got); len(r) != 26 { // 25 kept + the ellipsis
+		t.Errorf("cleanTitle(long) rune len = %d, want 26 (25 kept + ellipsis)", len(r))
 	}
 }
 
 func TestCleanTitle_LongEnglishSnapsToWordBoundary(t *testing.T) {
-	// Same budget, Latin text: the cut must not break a word — "around"
-	// would straddle column 30, so it is dropped whole.
+	// Same budget, Latin text: the cut must not break a word — "pooling"
+	// would straddle column 50, so it is dropped whole.
 	got := cleanTitle("improve concurrency handling around connection pooling internals")
-	if got != "improve concurrency handling…" {
-		t.Errorf("cleanTitle(long English) = %q, want %q", got, "improve concurrency handling…")
+	if got != "improve concurrency handling around connection…" {
+		t.Errorf("cleanTitle(long English) = %q, want %q", got, "improve concurrency handling around connection…")
 	}
 }
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -910,10 +910,10 @@ func firstUserText(msgs []Message) string {
 }
 
 // snippetBudget caps a one-line preview in half-width columns: wide (CJK)
-// runes count 2, others 1. 30 columns is 15 full-width characters or roughly
-// five English words — display width is the one ruler that makes Chinese,
+// runes count 2, others 1. 50 columns is 25 full-width characters or roughly
+// eight English words — display width is the one ruler that makes Chinese,
 // English, and mixed text land at the same visual length in the sidebar.
-const snippetBudget = 30
+const snippetBudget = 50
 
 // FirstUserSnippet extracts a one-line preview from the first user message,
 // skipping injected <system-reminder> blocks and tool-result turns, and

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -399,32 +399,33 @@ func TestDisplayTitle(t *testing.T) {
 	}
 }
 
-// TestTruncateSnippet pins the display-width truncation strategy: a 30
-// half-width-column budget (15 full-width CJK chars ≈ five English words),
+// TestTruncateSnippet pins the display-width truncation strategy: a 50
+// half-width-column budget (25 full-width CJK chars ≈ eight English words),
 // wide runes counting double, cuts snapped back to Latin word boundaries,
 // and an ellipsis only when content was actually dropped.
 func TestTruncateSnippet(t *testing.T) {
 	cases := map[string]string{
 		// Fits within the budget — returned unchanged, no ellipsis.
-		"hello there":              "hello there",
-		"please fix the login bug": "please fix the login bug", // 24 cols
-		"帮我 review 一下这个 PR 的改动":    "帮我 review 一下这个 PR 的改动",    // mixed, exactly 30 cols
+		"hello there":                "hello there",
+		"please fix the login bug":   "please fix the login bug",   // 24 cols
+		"帮我 review 一下这个 PR 的改动":      "帮我 review 一下这个 PR 的改动",      // mixed, 30 cols
+		"Ask user question 组件遮挡屏幕内容": "Ask user question 组件遮挡屏幕内容", // mixed, 34 cols
 
 		// English over budget: cut snaps back to the last word boundary —
-		// "around" is dropped whole rather than left as "ar…".
-		"improve concurrency handling around connection pooling internals": "improve concurrency handling…",
+		// "pooling" is dropped whole rather than left as "pool…".
+		"improve concurrency handling around connection pooling internals": "improve concurrency handling around connection…",
 
 		// CJK over budget: characters are semantic units, cut anywhere —
-		// 15 full-width chars fill the budget exactly.
-		"修复登录页面的无限重定向问题并补充测试": "修复登录页面的无限重定向问题并…",
+		// 25 full-width chars fill the budget exactly.
+		"修复登录页面的无限重定向问题并补充测试用例覆盖所有分支": "修复登录页面的无限重定向问题并补充测试用例覆盖所有…",
 
 		// Mixed over budget: the English prefix spends budget too, so fewer
 		// CJK chars fit.
-		"fix: 修复登录页面的无限重定向问题": "fix: 修复登录页面的无限重定向…",
+		"fix: 修复登录页面的无限重定向问题并补充测试用例覆盖所有分支": "fix: 修复登录页面的无限重定向问题并补充测试用例覆…",
 
 		// One unbroken overlong token (URL/hash): no word boundary to snap
 		// to, so it hard-cuts at the budget.
-		"abcdefghijklmnopqrstuvwxyz0123456789abcdef": "abcdefghijklmnopqrstuvwxyz0123…",
+		"abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx": "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmn…",
 	}
 	for in, want := range cases {
 		if got := truncateSnippet(in); got != want {


### PR DESCRIPTION
## 改动

宽度预算从 30 半宽列（15 中文字 / ~5 英文单词）放宽到 **50 半宽列（25 中文字 / ~8 英文单词）**：

- `snippetBudget` 30 → 50，`truncateSnippet`/`cleanTitle` 随之统一生效（本来就共用这一个常量）
- 标题指令同步：`at most 8 words, or 25 characters for Chinese or Japanese`
- 三处长度策略（模型指令、LLM 标题硬上限、snippet 兜底）继续保持同一把尺子

动机：30 列对中英文混合标题太紧——`Ask user question 组件遮挡屏幕内容`（34 列）会被切掉最后两个字；放宽后完整保留。

## 测试

- `TestTruncateSnippet` 用例按 50 列预算重写（含上面这条混合文本作为 fits 用例）
- `TestCleanTitle_RuneSafeTruncation` 更新为 25 字 + `…`；`TestCleanTitle_LongEnglishSnapsToWordBoundary` 词边界用例同步更新
- `gofmt -l` 干净，`go vet ./...` 干净，`go test ./internal/agent/ ./internal/server/ ./cmd/octo/` 全绿
