### PR TITLE
fix: strip internal agent: loop[N]: prefixes from user-facing error messages

### DIFF
--- a/cmd/octo/turncore.go
+++ b/cmd/octo/turncore.go
@@ -154,7 +154,7 @@ func (v *plainView) TurnEnded(reply agent.Reply, stats TurnStats, err error) {
 		// Ctrl-C / Esc: silently terminate. The agent already finalized
 		// history into a well-formed state.
 	case err != nil:
-		fmt.Fprintf(v.errOut, "\nerror: %v\n", err)
+		fmt.Fprintf(v.errOut, "\nerror: %s\n", agent.UserFacingError(err))
 	default:
 		fmt.Fprintln(v.out) // newline after the streamed reply
 		if !v.verbosity.quiet() {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -504,6 +504,23 @@ const (
 	StopReasonStuck = "stuck"
 )
 
+// UserFacingError strips internal agent-loop and dispatch prefixes from an
+// error for display to end users. For example:
+//
+//	"agent: loop[0]: anthropic: HTTP 403 ..." → "anthropic: HTTP 403 ..."
+//	"agent: dispatch tools[1]: openai: HTTP 429 ..." → "openai: HTTP 429 ..."
+func UserFacingError(err error) string {
+	msg := err.Error()
+	prefix := "agent: "
+	if strings.HasPrefix(msg, prefix) {
+		rest := msg[len(prefix):]
+		if idx := strings.Index(rest, ": "); idx >= 0 {
+			msg = rest[idx+2:]
+		}
+	}
+	return msg
+}
+
 // interruptNote caps an interrupted turn as an assistant message so history
 // keeps the user/assistant alternation the next turn depends on.
 const interruptNote = "[Interrupted by user.]"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2986,7 +2986,7 @@ func (s *Server) runChannelTurns(ctx context.Context, sess *channel.Session, ad 
 	// context length, auth) failed. A user interrupt (context.Canceled) is
 	// expected and stays quiet.
 	if runErr != nil && !errors.Is(runErr, context.Canceled) {
-		ad.SendText(ev.ChatID, "⚠️ "+runErr.Error(), ev.MessageID)
+		ad.SendText(ev.ChatID, "⚠️ "+agent.UserFacingError(runErr), ev.MessageID)
 	}
 
 	// Terminal-transition notice: the model finished, blocked, or exhausted

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -1203,7 +1203,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 	sw := s.newWSStreamWriter(sess.ID)
 
 	if err := s.ensureSender(); err != nil {
-		sw.error(err.Error())
+		sw.userError(err)
 		return
 	}
 
@@ -1323,7 +1323,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 		// (live-panel events + completion notes to the model).
 		runCtx, executor, _, cleanup, perr = s.prepareToolTurn(runCtx, a, sess)
 		if perr != nil {
-			sw.error(perr.Error())
+			sw.userError(perr)
 			return
 		}
 		toolDefs = tools.DefaultToolsForCtx(runCtx, a.Model)
@@ -1460,7 +1460,7 @@ func (s *Server) doAgentTurn(sess *agent.Session, content string, blocks []agent
 			// session_update tail. Returning here would skip `complete`, leaving
 			// the web UI's streaming flag (and its caret) stuck on forever; the
 			// tail's session_update is a superset of what we'd emit here.
-			sw.error(err.Error())
+			sw.userError(err)
 		}
 		// A first-round failure makes runLoop roll history back past the user
 		// message (appendUserInput's error-path contract), and the SyncFrom+
@@ -1703,6 +1703,13 @@ func (w *wsStreamWriter) error(msg string) {
 		"session_id": w.sessionID,
 		"error":      msg,
 	})
+}
+
+// userError is like error but strips internal agent-loop prefixes so the
+// message shown in the browser is user-friendly instead of displaying
+// "agent: loop[0]: anthropic: HTTP 403 ...".
+func (w *wsStreamWriter) userError(err error) {
+	w.error(agent.UserFacingError(err))
 }
 
 // bufferTurnEvent records an already-broadcast turn event in the session's


### PR DESCRIPTION
## Problem

LLM error messages displayed to users include internal prefixes like `agent: loop[0]: ` that are meaningless to end users:

> agent: loop[0]: anthropic: HTTP 403 (permission_error): You've reached your usage limit...

## Fix

Added `agent.UserFacingError()` that strips the `agent: ...: ` prefix, producing:

> anthropic: HTTP 403 (permission_error): You've reached your usage limit...

Applied at all three display points:

| Endpoint | File | Change |
|----------|------|--------|
| TUI | `cmd/octo/turncore.go` | `UserFacingError(err)` |
| IM | `internal/server/server.go` | `UserFacingError(runErr)` |
| Web | `internal/server/ws_handlers.go` | new `wsStreamWriter.userError()` method strips prefix before WS broadcast |

Fixes #1550