### PR TITLE
fix(web): isolate pendingSteers by session id to fix ghost bubble cross-session leak

### DIFF
--- a/web/src/views/ChatView.svelte
+++ b/web/src/views/ChatView.svelte
@@ -119,7 +119,7 @@
   // Pending steer messages typed while a turn is running. They are shown above
   // the composer as ghost user bubbles until the server drains the inbox and
   // confirms them in the scrollback.
-  let pendingSteers = $state<{ pendingId: string; text: string; files?: any[]; retracting?: boolean }[]>([])
+  let pendingSteers = $state<Record<string, { pendingId: string; text: string; files?: any[]; retracting?: boolean }[]>>({})
 
   // Set when the server reports a recoverable binding conflict. The UI shows a
   // banner with a "Force bind" button; clicking it retries the pending send
@@ -131,6 +131,8 @@
   let branchModal = $state<{ open: boolean; index: number; draft: string; busy: boolean }>({
     open: false, index: 0, draft: '', busy: false,
   })
+
+  let pendingSteerList = $derived(pendingSteers[$activeSessionId ?? ''] ?? [])
 
   // Sub-agents card elapsed time + reconnect countdown both tick off `now`.
   let now = $state(Date.now())
@@ -422,7 +424,7 @@
       if (queue && queue.length === 0) pendingSends.delete(sid)
       if (meta) {
         if (meta.wasStreaming) {
-          pendingSteers = pendingSteers.filter(s => s.pendingId !== meta.pendingId)
+          pendingSteers = { ...pendingSteers, [sid]: pendingSteers[sid]?.filter(s => s.pendingId !== meta.pendingId) ?? [] }
         } else {
           chatMessages.update(m => ({
             ...m,
@@ -453,8 +455,8 @@
     cleanups.push(ws.on('steer_retracted', (ev) => {
       if ((ev as any).session_id && (ev as any).session_id !== sid) return
       const pendingId = (ev as any).pending_id
-      const s = pendingSteers.find(x => x.pendingId === pendingId)
-      pendingSteers = pendingSteers.filter(x => x.pendingId !== pendingId)
+      const s = pendingSteers[sid]?.find(x => x.pendingId === pendingId)
+      pendingSteers = { ...pendingSteers, [sid]: pendingSteers[sid]?.filter(x => x.pendingId !== pendingId) ?? [] }
       const queue = pendingSends.get(sid)
       if (queue) {
         const next = queue.filter(m => m.pendingId !== pendingId)
@@ -470,7 +472,7 @@
     cleanups.push(ws.on('steer_retract_failed', (ev) => {
       if ((ev as any).session_id && (ev as any).session_id !== sid) return
       const pendingId = (ev as any).pending_id
-      pendingSteers = pendingSteers.map(x => x.pendingId === pendingId ? { ...x, retracting: false } : x)
+      pendingSteers = { ...pendingSteers, [sid]: pendingSteers[sid]?.map(x => x.pendingId === pendingId ? { ...x, retracting: false } : x) ?? [] }
       showToast(tr('chat.steer_retract_failed'), 'info')
     }))
 
@@ -713,7 +715,7 @@
       })
       if (isSteer && meta) {
         // The server drained this steer from the inbox; drop the ghost bubble.
-        pendingSteers = pendingSteers.filter(s => s.pendingId !== meta.pendingId)
+        pendingSteers = { ...pendingSteers, [sid]: pendingSteers[sid]?.filter(s => s.pendingId !== meta.pendingId) ?? [] }
       } else if (meta && meta.pendingId === confirmedPendingId) {
         // The server confirmed this optimistic send; stop tracking it for rollback.
         // (queue already shifted above)
@@ -1090,9 +1092,9 @@
   function retractSteer(pendingId: string) {
     const sid = get(activeSessionId)
     if (!sid) return
-    const s = pendingSteers.find(x => x.pendingId === pendingId)
+    const s = pendingSteers[sid]?.find(x => x.pendingId === pendingId)
     if (!s || s.retracting) return
-    pendingSteers = pendingSteers.map(x => x.pendingId === pendingId ? { ...x, retracting: true } : x)
+    pendingSteers = { ...pendingSteers, [sid]: pendingSteers[sid]?.map(x => x.pendingId === pendingId ? { ...x, retracting: true } : x) ?? [] }
     ws.retractSteer(sid, pendingId, s.text)
   }
 
@@ -1223,7 +1225,7 @@
     if (steering) {
       // Mid-turn input: show above the composer, not in the scrollback, until
       // the server drains it into the running turn (mirrors TUI pendingSteer).
-      pendingSteers = [...pendingSteers, { pendingId, text, files }]
+      pendingSteers = { ...pendingSteers, [sid]: [...(pendingSteers[sid] ?? []), { pendingId, text, files }] }
     } else {
       // Optimistically show the user bubble, marked pending. The server echoes
       // it back as a history_user_message — that handler replaces this pending
@@ -1733,9 +1735,9 @@
       <!-- Pending steer messages (mid-turn input) — shown above the composer
            as ghost user bubbles so they don't break the chronological order
            of the scrollback while waiting to be drained. -->
-      {#if pendingSteers.length > 0}
+      {#if pendingSteerList.length > 0}
         <div class="pending-steer-bar fadein">
-          {#each pendingSteers as s}
+          {#each pendingSteerList as s}
             <div class="pending-steer-bubble">
               <div class="user-avatar" aria-hidden="true">
                 <iconify-icon icon="ant-design:user-outlined" width="16"></iconify-icon>


### PR DESCRIPTION
## 问题

`pendingSteers`（composer 上方的幽灵气泡）是 ChatView 组件级 `$state` 数组，按 sid 隔离。切换会话后，旧会话的 steer ghost 气泡仍然渲染在 composer 上方，且因 WS 事件处理器按 `ev.session_id !== sid` 过滤永远无法被清除。

## 修复

将 `pendingSteers` 改为 `$state<Record<string, Steer[]>>`，所有 7 处读写操作加 `[sid]` 键控，模板层通过 `$derived` 取当前会话列表。

### 改点（全在 `ChatView.svelte`）

| 位置 | 原代码 | 新代码 |
|------|--------|--------|
| L122 声明 | `$state<Steer[]>([])` | `$state<Record<string, Steer[]>>({})` |
| L135 `$derived` | — | `pendingSteerList = $derived(pendingSteers[$activeSessionId ?? ""] ?? [])` |
| L427 send_rejected | `.filter()` | `[sid]?.filter()` |
| L458-459 steer_retracted | `.find()` + `.filter()` | `[sid]?.find()` + `[sid]?.filter()` |
| L475 steer_retract_failed | `.map()` | `[sid]?.map()` |
| L718 drain | `.filter()` | `[sid]?.filter()` |
| L1095-1097 retractSteer | `.find()` + `.map()` | `[sid]?.find()` + `[sid]?.map()` |
| L1228 send | `[...xs, x]` | `{...rec, [sid]: [...(rec[sid]??[]), x]}` |
| L1738-1740 render | `pendingSteers.length` / `pendingSteers as s` | `pendingSteerList.length` / `pendingSteerList as s` |

## 风险

- 无后端变动
- 模式与项目内其他所有会话态一致（`chatMessages`、`pendingSends`、`chatStreaming` 等）
- 已知边角 case（不在本次修复内）：发 steer 后切走、期间被服务端消化，切回时 ghost 可能短暂共存——pendingSends 队列本身的失同步问题

## 验证

- `svelte-check` 零错误
- 改动前前后后 10 处引用全部确认键控