### PR TITLE
fix: broadcast sub_agent_event on kill so the frontend updates immediately

### DIFF
--- a/internal/tools/subagent_manager.go
+++ b/internal/tools/subagent_manager.go
@@ -800,6 +800,29 @@ func (m *SubAgentManager) Kill(id string) bool {
 	}
 	agent.setKilled()
 	agent.cancel()
+
+	// Emit a "done" event so the frontend receives the update immediately,
+	// even if the agent's goroutine has already exited (its deferred sink
+	// already fired, e.g. the agent completed before the kill call).
+	agent.mu.Lock()
+	desc := agent.description
+	at := agent.agentType
+	agent.mu.Unlock()
+	ev := SubAgentEvent{
+		AgentID:     id,
+		Description: desc,
+		AgentType:   at,
+		Kind:        "done",
+		StopReason:  "killed",
+	}
+	agent.recordEvent(ev)
+	m.mu.Lock()
+	onEvent := m.onEvent
+	m.mu.Unlock()
+	if onEvent != nil {
+		onEvent(ev)
+	}
+
 	return true
 }
 

--- a/internal/tools/subagent_manager_test.go
+++ b/internal/tools/subagent_manager_test.go
@@ -503,3 +503,82 @@ func TestEventSinkDoneErrorExit(t *testing.T) {
 		t.Errorf("done StopReason = %q, want error", events[1].StopReason)
 	}
 }
+
+// TestKillAfterAgentExited verifies that Kill() emits a "done" event even when
+// the sub-agent's goroutine has already completed, so the frontend always
+// receives the update immediately.
+func TestKillAfterAgentExited(t *testing.T) {
+	m := NewSubAgentManager(&fixedSpawner{result: SpawnResult{Reply: "ok", AgentID: "child-1", StopReason: "end_turn"}})
+
+	var mu sync.Mutex
+	var events []SubAgentEvent
+	m.SetOnEvent(func(ev SubAgentEvent) { mu.Lock(); events = append(events, ev); mu.Unlock() })
+
+	id, err := m.Start(SpawnRequest{Description: "d", Prompt: "p"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for the agent to complete (onExit fires).
+	exited := make(chan struct{})
+	m.SetOnExit(func(SubAgentNotification) { close(exited) })
+	select {
+	case <-exited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("onExit never fired")
+	}
+
+	// Verify the first "done" event arrived with the original stop reason.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		done := len(events) >= 2 && events[len(events)-1].Kind == "done"
+		mu.Unlock()
+		if done {
+			break
+		}
+		if time.Now().After(deadline) {
+			mu.Lock()
+			evs := events
+			mu.Unlock()
+			t.Fatalf("events = %v, want trailing done", evs)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	mu.Lock()
+	firstDone := events[len(events)-1]
+	mu.Unlock()
+	if firstDone.StopReason != "end_turn" {
+		t.Errorf("first done StopReason = %q, want end_turn", firstDone.StopReason)
+	}
+
+	// Now kill the already-completed agent. The fix should emit a second "done"
+	// event with StopReason = "killed".
+	eventsBefore := len(events)
+	m.Kill(id)
+
+	deadline = time.Now().Add(2 * time.Second)
+	var killEvent SubAgentEvent
+	for {
+		mu.Lock()
+		for _, ev := range events[eventsBefore:] {
+			if ev.AgentID == id && ev.Kind == "done" {
+				killEvent = ev
+			}
+		}
+		mu.Unlock()
+		if killEvent.Kind == "done" {
+			break
+		}
+		if time.Now().After(deadline) {
+			mu.Lock()
+			evs := events[eventsBefore:]
+			mu.Unlock()
+			t.Fatalf("no kill done event for %q; events after kill = %v", id, evs)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if killEvent.StopReason != "killed" {
+		t.Errorf("kill done StopReason = %q, want killed", killEvent.StopReason)
+	}
+}


### PR DESCRIPTION
### Problem

`sub_agent_kill` calls `Kill()` which only cancelled the context and set the `"killed"` stop reason. If the sub-agent's goroutine had already exited (e.g. the agent completed before the kill), the deferred `sink(SubAgentEvent{Kind: "done"})` would never fire again. The frontend received no WS update and kept showing the sub-agent entry until a manual page refresh.

### Fix

`Kill()` now emits a `SubAgentEvent{Kind: "done"}` with `StopReason: "killed"` directly after cancellation, via the manager's `onEvent` hook. This broadcasts a `sub_agent_event` WS event to the frontend immediately, regardless of whether the goroutine has already exited.

### Before

`sub_agent_kill agent_1` → tool returns text `"Killed sub-agent agent_1."` → no WS event → frontend stays unchanged → user must refresh

### After

`sub_agent_kill agent_1` → tool returns text → WS `sub_agent_event {kind: "done", stop_reason: "killed"}` → frontend updates the sub-agent card to `cancelled` status immediately