### PR TITLE
chore: bump version to 1.12.21

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.20"
+var Version = "1.12.21"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump `internal/version.Version` from 1.12.20 to 1.12.21 in preparation for the v1.12.21 release.