### PR TITLE
fix: route cron task errors through UserFacingError, add coverage

### DIFF
--- a/internal/agent/userfacingerror_test.go
+++ b/internal/agent/userfacingerror_test.go
@@ -1,0 +1,105 @@
+package agent
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUserFacingError(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"loop wrap + provider prefix",
+			"agent: loop[0]: anthropic: HTTP 403 (permission_error): invalid api key",
+			"HTTP 403 (permission_error): invalid api key",
+		},
+		{
+			"dispatch wrap + provider prefix",
+			"agent: dispatch tools[1]: openai: HTTP 429 rate limit",
+			"HTTP 429 rate limit",
+		},
+		{
+			"bare anthropic prefix",
+			"anthropic: HTTP 403 forbidden",
+			"HTTP 403 forbidden",
+		},
+		{
+			"bare openai prefix",
+			"openai: HTTP 500 internal error",
+			"HTTP 500 internal error",
+		},
+		{
+			// No ": " after the "agent: " segment — nothing to strip, the
+			// message must survive intact.
+			"agent prefix without inner separator preserved",
+			"agent: no Sender configured",
+			"agent: no Sender configured",
+		},
+		{
+			"non-provider prefix preserved",
+			"workflow: step failed",
+			"workflow: step failed",
+		},
+		{
+			"loop wrap around non-provider keeps tool prefix",
+			"agent: loop[0]: workflow: boom",
+			"workflow: boom",
+		},
+		{
+			"plain error unchanged",
+			"something broke",
+			"something broke",
+		},
+		{
+			"provider prefix match is case sensitive",
+			"Anthropic: HTTP 403",
+			"Anthropic: HTTP 403",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := UserFacingError(errors.New(tc.in)); got != tc.want {
+				t.Errorf("UserFacingError(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestKnownProviderPrefixesInSync guards against silent drift: every protocol
+// implementation under internal/provider/ must have its error-prefix name in
+// knownProviderPrefixes (and vice versa), or user-facing errors leak a raw
+// "provider: " prefix again.
+func TestKnownProviderPrefixesInSync(t *testing.T) {
+	// retry is a shared retry helper, not a protocol implementation.
+	nonProtocol := map[string]bool{"retry": true}
+
+	entries, err := os.ReadDir(filepath.Join("..", "provider"))
+	if err != nil {
+		t.Fatalf("read provider dir: %v", err)
+	}
+	impls := map[string]bool{}
+	for _, e := range entries {
+		if e.IsDir() && !nonProtocol[e.Name()] {
+			impls[e.Name()] = true
+		}
+	}
+	known := map[string]bool{}
+	for _, p := range knownProviderPrefixes {
+		known[p] = true
+	}
+	for name := range impls {
+		if !known[name] {
+			t.Errorf("internal/provider/%s/ exists but %q is not in knownProviderPrefixes — its errors will leak a raw prefix", name, name)
+		}
+	}
+	for name := range known {
+		if !impls[name] {
+			t.Errorf("knownProviderPrefixes entry %q has no matching internal/provider/%s/ directory", name, name)
+		}
+	}
+}

--- a/internal/server/tasks_handlers.go
+++ b/internal/server/tasks_handlers.go
@@ -252,7 +252,7 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (sessionID st
 	}()
 
 	if err := s.ensureSender(); err != nil {
-		sw.error(err.Error())
+		sw.userError(err)
 		return sessionID, fmt.Errorf("sender: %w", err)
 	}
 
@@ -293,7 +293,7 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (sessionID st
 		var perr error
 		runCtx, executor, _, cleanup, perr = s.prepareToolTurn(runCtx, a, sess)
 		if perr != nil {
-			sw.error(perr.Error())
+			sw.userError(perr)
 			return sessionID, fmt.Errorf("prepare tools: %w", perr)
 		}
 		toolDefs = tools.DefaultToolsForCtx(runCtx, a.Model)
@@ -331,7 +331,7 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (sessionID st
 
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {
-			sw.error(err.Error())
+			sw.userError(err)
 		}
 		// A first-round failure rolls the task prompt back out of history
 		// (an interrupt no longer does — finishInterrupted keeps the prompt)
@@ -341,7 +341,7 @@ func (s *Server) RunTask(ctx context.Context, task scheduler.Task) (sessionID st
 		if len(sess.Messages) < historyWatermark {
 			s.broadcastHistoryReload(sessionID)
 		}
-		s.notifyTaskResult(task, fmt.Sprintf("⏰ %s failed: %v", task.Name, err))
+		s.notifyTaskResult(task, fmt.Sprintf("⏰ %s failed: %s", task.Name, agent.UserFacingError(err)))
 	} else {
 		rCopy := reply
 		s.wsHub.broadcast(sessionID, map[string]any{


### PR DESCRIPTION
## Summary

Follow-up to #1554 (code review findings). The scheduled-task (cron) turn path bypassed `agent.UserFacingError`:

- `internal/server/tasks_handlers.go` had three `sw.error(err.Error())` calls plus a `notifyTaskResult` failure message that forwarded raw errors — so cron failures still surfaced `agent: loop[0]: anthropic: HTTP 403 ...` verbatim to the web `turn_error` banner and to IM notifications, while interactive turns already went through `sw.userError`.
- `UserFacingError` — now the single error-display funnel for Web / IM / TUI — had zero test coverage.

## Changes

- `tasks_handlers.go`: route all three turn-failure broadcasts through `sw.userError`, and the IM failure notification through `agent.UserFacingError`.
- `internal/agent/userfacingerror_test.go` (new):
  - Table-driven tests for `UserFacingError`: loop/dispatch wraps + provider prefix, bare provider prefixes, non-provider prefixes preserved, plain errors unchanged, the non-obvious `"agent: "` without inner `": "` separator case, and case sensitivity of the provider-prefix match.
  - `TestKnownProviderPrefixesInSync`: drift guard asserting every protocol directory under `internal/provider/` has an entry in `knownProviderPrefixes` (and vice versa), so adding a third provider without updating the list fails loudly instead of leaking raw prefixes.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./... -count=1` — all green
- [x] `go vet ./...`, `gofmt -l .` clean

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
