### PR TITLE
docs: drop outdated session zip section from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,16 +14,3 @@ Please also include:
 
 - **Octo version** (required, e.g. `0.x.y`)
 - Environment if relevant: OS (macOS / Linux / Windows / WSL / Docker), browser & version, model in use, whether you're behind a proxy/VPN.
-
-## Session zip (strongly recommended)
-
-The session zip contains the full context of the conversation and is the most useful artifact for us to reproduce and fix the issue.
-
-How to download:
-
-1. Open the Octo Web UI and go to the session (chat page) where the bug happened.
-2. Look at the status bar right above the input box — it shows the run status, the current **session ID** (a short hash like `7fd88060`), working directory, model, task count, and cost.
-3. Click the session ID. Your browser will download `octo-session-7fd88060.zip`.
-4. Drag the zip into this issue as an attachment.
-
-> Privacy note: the zip contains your full conversation with the AI, related file paths, and some file contents. Please review it before uploading and remove anything sensitive). If you'd rather not share it publicly, feel free to send it to the maintainers privately instead.


### PR DESCRIPTION
## What
Removes the "Session zip (strongly recommended)" section from the bug report issue template.

## Why
The session zip download feature no longer exists in the product, so the template's instructions telling users to download and attach it are obsolete and confusing.

## Change
- `.github/ISSUE_TEMPLATE/bug_report.md`: delete the session zip section (13 lines); keep the "What happened" section (version + environment info) untouched.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
