### PR TITLE
fix(browser): give the healer field hints and fixed-position elements

### DIFF
--- a/internal/app/browser_heal.go
+++ b/internal/app/browser_heal.go
@@ -28,16 +28,8 @@ func MakeBrowserHealer(sender agent.Sender, model string) browser.Healer {
 		if len(digest) == 0 {
 			return fmt.Errorf("heal: no interactive elements to match against")
 		}
-		var elems strings.Builder
-		for _, d := range digest {
-			fmt.Fprintf(&elems, "%s\t%s\n", d.Selector, d.Text)
-		}
-		const system = "You repair a failed browser-automation step. Given the intended action and the page's current interactive elements (each line: CSS_SELECTOR<TAB>visible text), reply with ONLY the single best CSS selector for the intended element. Reply NONE if nothing matches. No prose, no backticks."
-		user := fmt.Sprintf("Intended action: %s\nIntended element label: %q\nOld selector (no longer matches): %s\n\nCurrent elements:\n%s",
-			step.Action, step.Label, step.Selector, elems.String())
-
-		reply, err := sender.SendMessages(ctx, model, system, []agent.Message{
-			{Role: agent.RoleUser, Content: user},
+		reply, err := sender.SendMessages(ctx, model, healSystemPrompt, []agent.Message{
+			{Role: agent.RoleUser, Content: healPrompt(step, digest)},
 		}, 256)
 		if err != nil {
 			return fmt.Errorf("heal: model: %w", err)
@@ -53,6 +45,23 @@ func MakeBrowserHealer(sender agent.Sender, model string) browser.Healer {
 		step.Selector = sel
 		return nil
 	}
+}
+
+// healSystemPrompt / healPrompt ask the model for the single best replacement
+// selector, given the step's intent and the page's current interactive
+// elements. The prompt carries the step's visible label AND its field hint:
+// for a type/select step the label is empty (an input has no textContent), so
+// the hint — the placeholder/name/aria-label captured at record time — is the
+// only semantic clue to which field the step meant.
+const healSystemPrompt = "You repair a failed browser-automation step. Given the intended action and the page's current interactive elements (each line: CSS_SELECTOR<TAB>visible text), reply with ONLY the single best CSS selector for the intended element. Reply NONE if nothing matches. No prose, no backticks."
+
+func healPrompt(step *browser.Step, digest []browser.DigestElement) string {
+	var elems strings.Builder
+	for _, d := range digest {
+		fmt.Fprintf(&elems, "%s\t%s\n", d.Selector, d.Text)
+	}
+	return fmt.Sprintf("Intended action: %s\nIntended element label: %q\nField hint: %q\nOld selector (no longer matches): %s\n\nCurrent elements:\n%s",
+		step.Action, step.Label, step.Hint, step.Selector, elems.String())
 }
 
 // MakeRecordingGenerator builds the LLM-backed skill distiller for record_stop. It

--- a/internal/app/browser_heal_test.go
+++ b/internal/app/browser_heal_test.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/open-octo/octo-agent/internal/browser"
+)
+
+// TestHealPromptIncludesFieldHint: a type step's Label is empty (an input has
+// no textContent), so the recorded field hint is the healer's only semantic
+// clue to which field was intended — it must reach the prompt alongside the
+// old selector and the element list.
+func TestHealPromptIncludesFieldHint(t *testing.T) {
+	step := &browser.Step{Action: "type", Selector: "form > input:nth-of-type(2)", Hint: "Search keywords"}
+	digest := []browser.DigestElement{{Selector: "#q", Text: "Search keywords"}}
+	p := healPrompt(step, digest)
+	for _, want := range []string{"type", `"Search keywords"`, "form > input:nth-of-type(2)", "Field hint", "#q\tSearch keywords"} {
+		if !strings.Contains(p, want) {
+			t.Fatalf("heal prompt missing %q:\n%s", want, p)
+		}
+	}
+}

--- a/internal/browser/digest_test.go
+++ b/internal/browser/digest_test.go
@@ -34,6 +34,11 @@ func TestInteractiveDigestVisibility(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new page: %v", err)
 	}
+	// Wait for the document to parse before digesting: NewPage can resolve ahead
+	// of the renderer on slow runners (Windows CI returned an empty digest).
+	if err := page.WaitFor(ctx, "#fixed", 10*time.Second); err != nil {
+		t.Fatalf("wait for fixture: %v", err)
+	}
 	digest, err := InteractiveDigest(ctx, page, "", 0)
 	if err != nil {
 		t.Fatalf("digest: %v", err)

--- a/internal/browser/digest_test.go
+++ b/internal/browser/digest_test.go
@@ -1,0 +1,55 @@
+package browser
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestInteractiveDigestVisibility: the digest must include position:fixed
+// controls (offsetParent is null for them in Chrome, but they're visible and
+// clickable) while still excluding display:none / visibility:hidden ones. The
+// digest is the healer's candidate list, so a wrong filter both hides healable
+// targets and could offer unclickable ones.
+func TestInteractiveDigestVisibility(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `<!doctype html><title>digest</title>
+<button id="normal">Normal</button>
+<button id="fixed" style="position:fixed;top:0;left:0">Fixed</button>
+<button id="gone" style="display:none">Gone</button>
+<button id="invis" style="visibility:hidden">Invis</button>`)
+	}))
+	defer srv.Close()
+	b, err := Launch(ctx, LaunchOptions{Headless: true})
+	if err != nil {
+		t.Skipf("chrome unavailable: %v", err)
+	}
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	digest, err := InteractiveDigest(ctx, page, "", 0)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	has := func(id string) bool {
+		for _, d := range digest {
+			if d.Selector == "#"+id {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("normal") || !has("fixed") {
+		t.Fatalf("digest should include normal + fixed buttons: %+v", digest)
+	}
+	if has("gone") || has("invis") {
+		t.Fatalf("digest must exclude display:none / visibility:hidden: %+v", digest)
+	}
+}

--- a/internal/browser/recording.go
+++ b/internal/browser/recording.go
@@ -525,7 +525,11 @@ func InteractiveDigest(ctx context.Context, page *Page, frame string, max int) (
 	  }
 	  var out=[];
 	  var els=d.querySelectorAll('a,button,input,select,textarea,[role=button],[role=menuitem],[role=tab],label');
-	  for(var i=0;i<els.length && out.length<%d;i++){var el=els[i]; if(el.offsetParent===null) continue; var t=(el.textContent||el.value||el.getAttribute('aria-label')||el.getAttribute('placeholder')||'').trim().slice(0,50); out.push({text:t, selector:sel(el)});}
+	  // Visible = has layout boxes and not visibility:hidden. (The old
+	  // offsetParent===null check also dropped position:fixed controls, which are
+	  // null-offsetParent in Chrome but very much clickable — fixed nav bars and
+	  // floating buttons were invisible to the healer.)
+	  for(var i=0;i<els.length && out.length<%d;i++){var el=els[i]; if(el.getClientRects().length===0 || getComputedStyle(el).visibility==='hidden') continue; var t=(el.textContent||el.value||el.getAttribute('aria-label')||el.getAttribute('placeholder')||'').trim().slice(0,50); out.push({text:t, selector:sel(el)});}
 	  return out;
 	})()`, doc, max)
 	var digest []DigestElement


### PR DESCRIPTION
## Summary

Closes #1562. Two small gaps that together made the LLM healer much less effective than it should be:

1. **No field hint for `type` steps.** The healer prompt carried only `step.Label`, which is an input's `textContent` — always empty for `type` steps — so the model got an element list with zero semantic clue which field was intended. The prompt now includes `step.Hint` (the placeholder/name/aria-label recorded at capture time), and the prompt builder is extracted into a pure, unit-testable `healPrompt`.
2. **Fixed-position elements invisible to the digest.** `InteractiveDigest` filtered elements with `offsetParent === null`, which is true for `position: fixed` in Chrome — fixed nav bars, sticky headers, and floating buttons never reached the healer's candidate list. The visibility check is now `getClientRects().length === 0 || getComputedStyle(el).visibility === 'hidden'`: `display:none` and `visibility:hidden` stay excluded, fixed controls are back in.

## Testing

- New `TestHealPromptIncludesFieldHint` (unit): hint, old selector, and element list all reach the prompt.
- New `TestInteractiveDigestVisibility` (browser-gated): `position:fixed` buttons included; `display:none` / `visibility:hidden` excluded.
- `go test ./internal/browser ./internal/app ./internal/tools ./internal/server` — all pass; build/vet/gofmt clean.
