### PR TITLE
feat(browser): add record_cancel to discard an abandoned recording

### DIFF
--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -360,8 +360,8 @@ func (BrowserTool) Definition() agent.ToolDefinition {
 			"properties": map[string]any{
 				"action": map[string]any{
 					"type":        "string",
-					"enum":        []string{"navigate", "back", "click", "hover", "type", "select", "key", "scroll", "wait", "screenshot", "observe", "ax", "cookies", "upload", "download", "pages", "select_page", "close", "eval", "record_start", "record_stop", "replay", "run_skill"},
-					"description": "The browser action to perform. observe lists the page's URL/title and interactable elements with selectors (text only) — the cheap way to look at an unfamiliar page before acting; works on any model. screenshot returns an image of the page for a vision-capable model to actually see (use when content is visual). ax returns an accessibility-tree digest (roles and names) — a semantic text view of the page, an alternative to observe when document structure matters more than selectors. pages lists open tabs; select_page switches between them. cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture the USER's own demonstration into an editable recording — record_start only installs listeners, so after it you MUST hand control to the user: tell them to perform the actions themselves in their browser and to say when they're done, then call record_stop. Do NOT drive the page yourself (navigate/click/type) while recording — your tool actions are not the demonstration and a click that navigates is easily lost; only the user's real gestures are captured. replay replays a recording (deterministic, self-healing; run_skill is a deprecated alias of replay).",
+					"enum":        []string{"navigate", "back", "click", "hover", "type", "select", "key", "scroll", "wait", "screenshot", "observe", "ax", "cookies", "upload", "download", "pages", "select_page", "close", "eval", "record_start", "record_stop", "record_cancel", "replay", "run_skill"},
+					"description": "The browser action to perform. observe lists the page's URL/title and interactable elements with selectors (text only) — the cheap way to look at an unfamiliar page before acting; works on any model. screenshot returns an image of the page for a vision-capable model to actually see (use when content is visual). ax returns an accessibility-tree digest (roles and names) — a semantic text view of the page, an alternative to observe when document structure matters more than selectors. pages lists open tabs; select_page switches between them. cookies returns the current page's cookies (HttpOnly included) for session reuse / token extraction. record_start/record_stop capture the USER's own demonstration into an editable recording — record_start only installs listeners, so after it you MUST hand control to the user: tell them to perform the actions themselves in their browser and to say when they're done, then call record_stop (or record_cancel to discard the demo without saving). Do NOT drive the page yourself (navigate/click/type) while recording — your tool actions are not the demonstration and a click that navigates is easily lost; only the user's real gestures are captured. replay replays a recording (deterministic, self-healing; run_skill is a deprecated alias of replay).",
 				},
 				"name":         map[string]any{"type": "string", "description": "Recording name (record_stop / replay)."},
 				"params":       map[string]any{"type": "object", "description": "Param values for {{...}} placeholders (replay). Omit a value the recording requires (no recorded default, e.g. a secret) and, in interactive modes, the user is prompted for it instead of the call failing."},
@@ -658,7 +658,7 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		recorderMu.Lock()
 		defer recorderMu.Unlock()
 		if activeRecorder != nil {
-			return agent.ToolResult{}, fmt.Errorf("browser: a recording is already in progress")
+			return agent.ToolResult{}, fmt.Errorf("browser: a recording is already in progress (record_stop to save it, record_cancel to discard it)")
 		}
 		rec := browser.NewRecorder(page)
 		if err := rec.Start(ctx); err != nil {
@@ -668,6 +668,20 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		_ = page.Eval(ctx, "location.href", &u)
 		activeRecorder, recorderStartURL = rec, u
 		return agent.ToolResult{Text: "recording started on " + u}, nil
+
+	case "record_cancel":
+		// Discard an abandoned demonstration without saving it — previously the
+		// only way out was a throwaway record_stop (which wrote a junk YAML), and
+		// record_start stayed wedged until then.
+		recorderMu.Lock()
+		rec := activeRecorder
+		activeRecorder = nil
+		recorderMu.Unlock()
+		if rec == nil {
+			return agent.ToolResult{}, fmt.Errorf("browser: no recording in progress")
+		}
+		rec.Stop()
+		return agent.ToolResult{Text: "recording discarded (nothing saved)"}, nil
 
 	case "record_stop":
 		name := getStr(input, "name")

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -198,6 +198,48 @@ func TestBrowserTool_RecordRunRoundTrip(t *testing.T) {
 	}
 }
 
+// TestBrowserTool_RecordCancel: an abandoned recording can be discarded without
+// saving, freeing record_start — previously wedged until a throwaway
+// record_stop wrote a junk YAML.
+func TestBrowserTool_RecordCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30_000_000_000)
+	defer cancel()
+	if !browser.ChromeAvailable("") {
+		t.Skip("chrome not available")
+	}
+	b, err := browser.Launch(ctx, browser.LaunchOptions{Headless: true})
+	skipOnBrowserFlake(t, "launch", err)
+	page, err := b.NewPage(ctx, "about:blank")
+	skipOnBrowserFlake(t, "new page", err)
+	SetBrowserSession(b, page)
+	defer ResetBrowserSession()
+
+	tool := BrowserTool{}
+	run := func(in map[string]any) (string, error) { r, e := tool.Execute(ctx, "browser", in); return r.Text, e }
+
+	if _, err := run(map[string]any{"action": "record_start"}); err != nil {
+		skipOnBrowserFlake(t, "record_start", err)
+	}
+	// A second start must fail — and the error must name the escape hatch.
+	if _, err := run(map[string]any{"action": "record_start"}); err == nil || !strings.Contains(err.Error(), "record_cancel") {
+		t.Fatalf("double record_start err = %v, want a record_cancel hint", err)
+	}
+	if _, err := run(map[string]any{"action": "record_cancel"}); err != nil {
+		t.Fatalf("record_cancel: %v", err)
+	}
+	// Freed: a fresh recording can start (and be discarded too).
+	if _, err := run(map[string]any{"action": "record_start"}); err != nil {
+		t.Fatalf("record_start after cancel: %v", err)
+	}
+	if _, err := run(map[string]any{"action": "record_cancel"}); err != nil {
+		t.Fatalf("second record_cancel: %v", err)
+	}
+	// Nothing left to cancel now.
+	if _, err := run(map[string]any{"action": "record_cancel"}); err == nil {
+		t.Fatal("record_cancel with no active recording should error")
+	}
+}
+
 // TestResolveMissingRecordingParams_ErrorsOnMissingRequired verifies a param
 // with no default and no caller-supplied value returns a clear error naming
 // the missing param(s), rather than auto-prompting the user. The model then


### PR DESCRIPTION
## Summary

Closes #1563. Adds a `record_cancel` action to the browser tool: stop capture, discard the events, clear `activeRecorder` — nothing is written to disk.

Previously `activeRecorder` was only cleared by `record_stop`, so abandoning a demonstration wedged every later `record_start` with "a recording is already in progress" until a throwaway `record_stop` (which compiled and saved a junk YAML) or a process restart. The already-in-progress error now also names the escape hatch: `(record_stop to save it, record_cancel to discard it)`.

Per the issue, the optional idle auto-expire is deliberately left out — with an explicit cancel path and an error that points at it, the wedge is gone.

## Testing

- New `TestBrowserTool_RecordCancel` (browser-gated): double `record_start` fails with a `record_cancel` hint; cancel frees a fresh start; cancel-with-no-recording errors.
- `go test ./internal/tools ./internal/browser ./internal/server ./internal/app` — all pass; build/vet/gofmt clean.
