### PR TITLE
fix(browser): escape replay param substitution by context (URL / JS)

### DIFF
--- a/internal/browser/recording.go
+++ b/internal/browser/recording.go
@@ -546,12 +546,70 @@ func (s Step) target() string {
 	return s.Selector
 }
 
+// subst replaces {{name}} placeholders with param values, verbatim. Used where
+// the surrounding context is plain text (typed values, select options, file
+// paths, verify comparisons). URL and JS contexts need the escaping variants
+// below — a raw value can silently reshape the URL or the expression.
 func subst(s string, params map[string]string) string {
 	for k, v := range params {
 		s = strings.ReplaceAll(s, "{{"+k+"}}", v)
 	}
 	return s
 }
+
+// substURL is subst for navigate targets: each param value is percent-encoded
+// as pure data (everything outside RFC 3986 unreserved), so a value containing
+// spaces, '&', '#', '%' or '/' can't silently reshape the URL. The template's
+// own structure (its query '&'/'=', path slashes) is untouched.
+func substURL(s string, params map[string]string) string {
+	enc := make(map[string]string, len(params))
+	for k, v := range params {
+		enc[k] = escapeURLValue(v)
+	}
+	return subst(s, enc)
+}
+
+// escapeURLValue percent-encodes every byte outside RFC 3986 unreserved
+// (A-Z a-z 0-9 - _ . ~). Byte-wise, so UTF-8 multibyte becomes the standard
+// %XX%XX form — correct for a data value in either path or query position.
+func escapeURLValue(v string) string {
+	const unreserved = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
+	var b strings.Builder
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		if strings.IndexByte(unreserved, c) >= 0 {
+			b.WriteByte(c)
+		} else {
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
+}
+
+// substJS is subst for extract expressions: values typically land inside a JS
+// string literal in the template, so escape the characters that could end the
+// literal or alter the value. \' and \" both evaluate to the bare quote in
+// either quote style in JS, so escaping both quote types is safe regardless of
+// how the template quotes the placeholder.
+func substJS(s string, params map[string]string) string {
+	enc := make(map[string]string, len(params))
+	for k, v := range params {
+		enc[k] = escapeJSStringValue(v)
+	}
+	return subst(s, enc)
+}
+
+func escapeJSStringValue(v string) string {
+	return jsStringEscaper.Replace(v)
+}
+
+var jsStringEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`'`, `\'`,
+	`"`, `\"`,
+	"\n", `\n`,
+	"\r", `\r`,
+)
 
 // ReplayOptions tunes a replay. StepTimeout bounds the per-step wait for a
 // target to appear (default 15s — generous for slow back-ends). Healer, when
@@ -770,7 +828,7 @@ func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map
 	target := step.target()
 	switch step.Action {
 	case "navigate":
-		if err := page.Navigate(ctx, subst(step.URL, params)); err != nil {
+		if err := page.Navigate(ctx, substURL(step.URL, params)); err != nil {
 			return page, err
 		}
 	case "wait":
@@ -907,7 +965,7 @@ func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map
 			return page, fmt.Errorf("extract: js is required")
 		}
 		var raw json.RawMessage
-		if err := page.Eval(ctx, subst(step.JS, params), &raw); err != nil {
+		if err := page.Eval(ctx, substJS(step.JS, params), &raw); err != nil {
 			return page, err
 		}
 		val := string(raw)

--- a/internal/browser/recording_test.go
+++ b/internal/browser/recording_test.go
@@ -1073,3 +1073,97 @@ func TestReplayRecordingDownloadNoDoubleBindOnHeal(t *testing.T) {
 		t.Fatalf("download must bind exactly once across a heal retry, got %#v", outputs["files"])
 	}
 }
+
+// TestSubstURLEscapesValues: navigate params are substituted as data, not URL
+// structure — a value holding spaces, query metacharacters or a slash must not
+// reshape the URL, while the template's own structure stays intact.
+func TestSubstURLEscapesValues(t *testing.T) {
+	got := substURL("https://x/s?q={{q}}&page={{p}}&tag={{tag}}", map[string]string{
+		"q": "foo bar&baz=1", "p": "2", "tag": "热榜",
+	})
+	want := "https://x/s?q=foo%20bar%26baz%3D1&page=2&tag=%E7%83%AD%E6%A6%9C"
+	if got != want {
+		t.Fatalf("substURL = %q, want %q", got, want)
+	}
+	if p := substURL("https://x/item/{{id}}", map[string]string{"id": "a/b c"}); p != "https://x/item/a%2Fb%20c" {
+		t.Fatalf("path-position value not encoded as data: %q", p)
+	}
+}
+
+// TestSubstJSEscapesValues: extract params land inside JS string literals, so
+// quotes, backslashes and newlines are escaped — \' and \" both evaluate to the
+// bare quote in either quote style, so this is safe however the template quotes.
+func TestSubstJSEscapesValues(t *testing.T) {
+	got := substJS("f('{{v}}', \"{{v}}\")", map[string]string{"v": "it's a \"q\" \\ test\nline"})
+	want := `f('it\'s a \"q\" \\ test\nline', "it\'s a \"q\" \\ test\nline")`
+	if got != want {
+		t.Fatalf("substJS = %q, want %q", got, want)
+	}
+}
+
+// TestReplayNavigateEncodesParams end to end: the server must receive the exact
+// original value (properly encoded on the wire), proving replay navigates to the
+// intended URL rather than a value-corrupted one.
+func TestReplayNavigateEncodesParams(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	var gotQ, gotURI string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQ, gotURI = r.URL.Query().Get("q"), r.RequestURI
+		w.Write([]byte(`<!doctype html><title>echo</title>ok`))
+	}))
+	defer srv.Close()
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, "about:blank")
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	recording := &Recording{
+		Name:   "x",
+		Params: []Param{{Name: "id"}, {Name: "q"}},
+		Steps:  []Step{{Action: "navigate", URL: srv.URL + "/item/{{id}}?q={{q}}"}},
+	}
+	params := map[string]string{"id": "a/b c", "q": "foo bar&baz=1"}
+	if _, _, _, err := ReplayRecording(ctx, page, recording, params, ReplayOptions{StepTimeout: 5 * time.Second}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if gotQ != "foo bar&baz=1" {
+		t.Fatalf("server received q = %q, want the exact original value", gotQ)
+	}
+	if gotURI != "/item/a%2Fb%20c?q=foo%20bar%26baz%3D1" {
+		t.Fatalf("wire RequestURI = %q, value was not encoded as data", gotURI)
+	}
+}
+
+// TestReplayExtractEscapesParams: a param holding quotes and a backslash used
+// inside a JS string literal evaluates to the exact original value, not a
+// broken (or altered) expression.
+func TestReplayExtractEscapesParams(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<!doctype html><title>x</title>ok`))
+	}))
+	defer srv.Close()
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	recording := &Recording{
+		Name:    "x",
+		Params:  []Param{{Name: "v"}},
+		Outputs: []Output{{Name: "v", Type: "string"}},
+		Steps:   []Step{{Action: "extract", JS: `'{{v}}'`, Bind: "v"}},
+	}
+	original := `it's a "q" \ test`
+	_, _, outputs, err := ReplayRecording(ctx, page, recording, map[string]string{"v": original}, ReplayOptions{StepTimeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if outputs["v"] != original {
+		t.Fatalf("extract = %#v, want the exact original %#v", outputs["v"], original)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1564. `subst` expanded `{{param}}` placeholders by plain string replacement regardless of context, so a param value could silently reshape a URL or a JS expression:

- **navigate `url:`** — a value with spaces, `&`, `#`, `%` or `/` produced a malformed or wrong URL.
- **extract `js:`** — a value with quotes or backslashes broke the expression (or worse, altered it).

Substitution is now context-aware:

- `substURL` — param values are percent-encoded as pure data (everything outside RFC 3986 unreserved, byte-wise so UTF-8 becomes standard `%XX` form). The template's own structure is untouched.
- `substJS` — values are escaped for JS string literals (`\`, `'`, `"`, newline, CR); `\'` and `\"` both evaluate to the bare quote in either quote style, so it's safe however the template quotes the placeholder.
- Plain `subst` stays for plain-text contexts (typed values, select options, file paths, verify comparisons).

## Testing

- New unit tests: `TestSubstURLEscapesValues`, `TestSubstJSEscapesValues`.
- New browser-gated end-to-end tests: `TestReplayNavigateEncodesParams` (server receives the exact original value; wire `RequestURI` is correctly encoded), `TestReplayExtractEscapesParams` (quotes + backslash survive intact).
- `go test ./internal/browser ./internal/tools ./internal/server ./internal/app` — all pass; build/vet/gofmt clean.
