### PR TITLE
feat(browser): record demonstrations that continue in a new tab

### DIFF
--- a/internal/browser/recorder.go
+++ b/internal/browser/recorder.go
@@ -218,13 +218,26 @@ func (r *Recorder) Start(ctx context.Context) error {
 						Type string `json:"type"`
 					} `json:"targetInfo"`
 				}
-				if json.Unmarshal(ev.Params, &a) == nil && a.TargetInfo.Type == "iframe" && a.SessionID != "" {
+				if json.Unmarshal(ev.Params, &a) != nil || a.SessionID == "" {
+					continue
+				}
+				ictx, icancel := context.WithTimeout(context.Background(), 10*time.Second)
+				switch a.TargetInfo.Type {
+				case "iframe":
 					// The browser watcher enables the child's domains; give it a
 					// moment, then instrument for recording.
-					ictx, icancel := context.WithTimeout(context.Background(), 10*time.Second)
 					r.instrumentOOPIF(ictx, a.SessionID)
-					icancel()
+				case "page":
+					// A tab the demonstration itself opened (target=_blank /
+					// window.open): instrument it like the top document so the rest
+					// of the demo is captured — replay follows the click that opened
+					// the tab, so the steps stay consistent. Tabs already open when
+					// recording started are deliberately NOT instrumented: switching
+					// to one leaves no replayable step, so its events would compile
+					// into a skill that replays on the wrong page.
+					r.instrumentPageSession(ictx, a.SessionID)
 				}
+				icancel()
 			}
 		}()
 	}
@@ -233,7 +246,31 @@ func (r *Recorder) Start(ctx context.Context) error {
 	// multi-page demonstration replays from the right pages — otherwise the only
 	// navigate step is the synthesized start URL, and the recording loses every
 	// page the user moved to.
-	navEvents, navUnsub := p.cli.subscribe("Page.frameNavigated", p.sessionID)
+	r.watchNavigations(p.sessionID)
+	return nil
+}
+
+// instrumentPageSession instruments a newly attached tab (a page target) the
+// same way the top document is instrumented, plus navigation capture — the demo
+// may navigate the new tab (or drive an SPA in it) before touching anything.
+func (r *Recorder) instrumentPageSession(ctx context.Context, session string) {
+	// Enable the domains ourselves rather than depend on the browser watcher's
+	// async registration having run first — same reasoning as instrumentOOPIF.
+	for _, d := range []string{"Page.enable", "Runtime.enable", "DOM.enable"} {
+		if _, err := r.page.cli.call(ctx, session, d, nil); err != nil {
+			return
+		}
+	}
+	if err := r.instrumentSession(ctx, session, ""); err != nil {
+		return
+	}
+	r.watchNavigations(session)
+}
+
+// watchNavigations records top-level navigations on one page session (subframe
+// navigations ignored; consecutive repeats collapsed).
+func (r *Recorder) watchNavigations(session string) {
+	navEvents, navUnsub := r.page.cli.subscribe("Page.frameNavigated", session)
 	r.mu.Lock()
 	r.unsubs = append(r.unsubs, navUnsub)
 	r.mu.Unlock()
@@ -263,7 +300,6 @@ func (r *Recorder) Start(ctx context.Context) error {
 			r.mu.Unlock()
 		}
 	}()
-	return nil
 }
 
 // Events returns the captured actions so far.

--- a/internal/browser/recorder_test.go
+++ b/internal/browser/recorder_test.go
@@ -141,3 +141,67 @@ func TestRecorderCapturesActions(t *testing.T) {
 		t.Errorf("replay did not set the select (value=%q)", selVal)
 	}
 }
+
+// TestRecorderCapturesNewTab: a demonstration that opens a new tab (target=_blank)
+// and keeps going there is captured end to end — previously everything after the
+// tab switch was silently lost (the attach watcher only instrumented iframes).
+func TestRecorderCapturesNewTab(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/b", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<!doctype html><title>b</title><button id="bb">B</button>`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<!doctype html><title>a</title><a id="open" href="/b" target="_blank">Open</a>`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#open", testWaitTimeout); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	rec := NewRecorder(page)
+	if err := rec.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer rec.Stop()
+
+	np, err := b.ClickFollow(ctx, page, "#open")
+	if err != nil {
+		t.Fatalf("open new tab: %v", err)
+	}
+	if np == page {
+		t.Fatal("click did not open a new tab")
+	}
+	if err := np.WaitFor(ctx, "#bb", testWaitTimeout); err != nil {
+		t.Fatalf("wait #bb: %v", err)
+	}
+	// The recorder instruments the new tab off the attach event — give it a beat
+	// before driving the click it must capture.
+	time.Sleep(500 * time.Millisecond)
+	if err := np.Click(ctx, "#bb"); err != nil {
+		t.Fatalf("click #bb: %v", err)
+	}
+	found := false
+	for i := 0; i < 30; i++ {
+		time.Sleep(100 * time.Millisecond)
+		for _, e := range rec.Events() {
+			if e.Type == "click" && e.Selector == "#bb" {
+				found = true
+			}
+		}
+		if found {
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("click in the new tab was not captured: %+v", rec.Events())
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1559. During recording, the attach watcher only instrumented `type == "iframe"` targets — so when the demonstration opened a **new tab** (`target=_blank` / `window.open`) and continued there, every subsequent action was silently lost and the compiled skill looked valid while missing a chunk of the flow.

The watcher now also instruments `type == "page"` targets: domain enablement (not relying on the browser watcher's async registration), the capture binding + listeners, and navigation recording (factored into `watchNavigations`, shared with the main session). Replay already handles the tab switch naturally — the recorded click that opened the tab replays via `ClickFollow`, and the steps captured in the new tab run on it.

Deliberately NOT instrumented: tabs that were already open when recording started. Switching to one leaves no replayable step in the stream, so its events would compile into a skill that replays on the wrong page — capturing them would be silent corruption, worse than losing them (noted in a code comment).

## Testing

- New `TestRecorderCapturesNewTab` (browser-gated): click a `target=_blank` link, keep acting in the new tab — the click there is captured.
- `go test ./internal/browser ./internal/tools ./internal/server ./internal/app` — all pass; build/vet/gofmt clean.
