### PR TITLE
fix(weixin): 加宽限流退避，减少 errcode=-2 丢消息

### DIFF
--- a/internal/channel/adapters/weixin/weixin.go
+++ b/internal/channel/adapters/weixin/weixin.go
@@ -43,7 +43,7 @@ const (
 	// Send queue tuning.
 	flushCharThreshold = 400
 	flushInterval      = 2 * time.Second
-	minSendInterval    = time.Second
+	minSendInterval    = 2 * time.Second
 
 	// typingTicketTTL bounds how long a cached typing ticket is reused before
 	// SendTyping re-fetches one via GetConfig.
@@ -202,7 +202,7 @@ func (q *sendQueue) throttle() {
 }
 
 func (q *sendQueue) sendWithRetry(chatID, text, contextToken string) {
-	retryDelays := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second}
+	retryDelays := []time.Duration{2 * time.Second, 4 * time.Second, 8 * time.Second}
 	for i, delay := range retryDelays {
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		err := q.client.SendMessage(ctx, q.baseURL, q.token,


### PR DESCRIPTION
## 问题

iLink 在服务端持续返回 errcode=-2（限流）。当前参数：
- `minSendInterval = 1s`
- `retryDelays = [1s, 2s, 4s]`

实际日志显示，连续 3 次重试全部失败后消息被丢弃（34 条最终丢弃 / 102 次失败，覆盖 2026-07-16 ~ 2026-07-18）。iLink 的限流不是偶发尖峰，而是持续性的，原参数根本绕不过。

## 改动

文件：`internal/channel/adapters/weixin/weixin.go`

| 参数 | 改前 | 改后 |
|---|---|---|
| `minSendInterval` | 1s | 2s |
| `retryDelays` | [1s, 2s, 4s] | [2s, 4s, 8s] |

三次重试总等待从 7s 提升至 14s，给 iLink 更大窗口，减少丢弃。

## 日志佐证

```
[weixin] send failed for o9cq807MOxPwBofFldcjF4nh4dJI@im.wechat: ilink api: prepare failed (http=200, errcode=-2)
[weixin] send failed for o9cq807MOxPwBofFldcjF4nh4dJI@im.wechat, retry in 1s (1/3): ilink api: prepare failed (http=200, errcode=-2)
[weixin] send failed for o9cq807MOxPwBofFldcjF4nh4dJI@im.wechat, retry in 2s (2/3): ilink api: prepare failed (http=200, errcode=-2)
[weixin] send failed for o9cq807MOxPwBofFldcjF4nh4dJI@im.wechat: ilink api: prepare failed (http=200, errcode=-2)
```
