### PR TITLE
feat(browser): record and replay Enter-key submissions

### DIFF
--- a/internal/browser/actions.go
+++ b/internal/browser/actions.go
@@ -408,24 +408,41 @@ func (p *Page) Key(ctx context.Context, combo string) error {
 	if nk, ok := namedKeys[strings.TrimSpace(keyName)]; ok {
 		key, code, vk = nk.key, nk.code, nk.vk
 	} else if len(keyName) == 1 {
-		c := keyName[0]
 		key = keyName
 		code = "Key" + strings.ToUpper(keyName)
 		vk = int(strings.ToUpper(keyName)[0])
-		_ = c
 	} else {
 		return fmt.Errorf("key: unsupported key %q", keyName)
 	}
 
+	// Text carried on the keyDown so the press also runs its default action —
+	// without it Chrome fires the DOM events but skips the action (Enter would
+	// neither submit a form nor newline a textarea; a printable char would not
+	// insert). Only with no modifiers held: a combo like ctrl+a must not type a.
+	text := ""
+	if mods == 0 {
+		switch {
+		case key == "Enter":
+			text = "\r"
+		case len(keyName) == 1:
+			text = keyName
+		case keyName == "space":
+			text = " "
+		}
+	}
+
 	for _, typ := range []string{"keyDown", "keyUp"} {
-		_, err := p.cli.call(ctx, p.sessionID, "Input.dispatchKeyEvent", map[string]any{
+		params := map[string]any{
 			"type":                  typ,
 			"modifiers":             mods,
 			"key":                   key,
 			"code":                  code,
 			"windowsVirtualKeyCode": vk,
-		})
-		if err != nil {
+		}
+		if text != "" && typ == "keyDown" {
+			params["text"] = text
+		}
+		if _, err := p.cli.call(ctx, p.sessionID, "Input.dispatchKeyEvent", params); err != nil {
 			return err
 		}
 	}

--- a/internal/browser/recorder.go
+++ b/internal/browser/recorder.go
@@ -154,8 +154,8 @@ func (r *Recorder) instrumentOOPIF(ctx context.Context, session string) {
 	_ = r.instrumentSession(ctx, session, frameSel)
 }
 
-// captureScript installs capture-phase click/change listeners that report each
-// action (with a stable-ish selector) through the __octoRecord binding.
+// captureScript installs capture-phase click/change/keydown listeners that report
+// each action (with a stable-ish selector) through the __octoRecord binding.
 const captureScript = `(function(){
   if (window.__octoRec) return; window.__octoRec = true;
   function sel(el){
@@ -182,6 +182,21 @@ const captureScript = `(function(){
   }
   document.addEventListener('click', function(e){report('click',e);}, true);
   document.addEventListener('change', function(e){var t=e.target; report((t&&t.type==='file')?'upload':'change', e);}, true);
+  // Enter in a text input = the submit gesture (change never fires without a
+  // blur, so the typed value only reaches us as this event's snapshot). Not
+  // captured: textarea (Enter is a newline, already in the change value),
+  // select/buttons/links (Enter fires a click, caught above), non-text inputs
+  // (checkbox/radio have no typed value), and IME composition (Enter confirms
+  // the candidate — it is not a submit, CJK users hit it constantly).
+  var TEXTY={text:1,search:1,email:1,url:1,tel:1,number:1,password:1};
+  document.addEventListener('keydown', function(e){
+    if(e.key!=='Enter'&&e.keyCode!==13) return;
+    if(e.isComposing||e.keyCode===229) return;
+    var t=e.target;
+    if(!t||t.nodeType!==1||t.tagName!=='INPUT') return;
+    if(!TEXTY[t.type||'text']) return;
+    report('enter', e);
+  }, true);
 })();`
 
 // Start begins capturing. The binding and listeners are installed on the live

--- a/internal/browser/recorder_test.go
+++ b/internal/browser/recorder_test.go
@@ -205,3 +205,64 @@ func TestRecorderCapturesNewTab(t *testing.T) {
 		t.Fatalf("click in the new tab was not captured: %+v", rec.Events())
 	}
 }
+
+// TestRecorderCapturesEnter: Enter in a text input is captured with the field's
+// current value (change never fires without a blur); Enter in a textarea is a
+// newline, not a submit, and must not be captured.
+func TestRecorderCapturesEnter(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<!doctype html><title>enter</title>
+<form onsubmit="event.preventDefault()"><input id="q"></form><textarea id="t"></textarea>`))
+	}))
+	defer srv.Close()
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#q", testWaitTimeout); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	rec := NewRecorder(page)
+	if err := rec.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer rec.Stop()
+	if err := page.TypeText(ctx, "#q", "hello"); err != nil {
+		t.Fatalf("type: %v", err)
+	}
+	if err := page.Click(ctx, "#q"); err != nil {
+		t.Fatalf("focus #q: %v", err)
+	}
+	if err := page.Key(ctx, "enter"); err != nil {
+		t.Fatalf("enter #q: %v", err)
+	}
+	if err := page.Click(ctx, "#t"); err != nil {
+		t.Fatalf("focus #t: %v", err)
+	}
+	if err := page.Key(ctx, "enter"); err != nil {
+		t.Fatalf("enter #t: %v", err)
+	}
+	var enters []RecordedEvent
+	for i := 0; i < 30; i++ {
+		time.Sleep(100 * time.Millisecond)
+		enters = enters[:0]
+		for _, e := range rec.Events() {
+			if e.Type == "enter" {
+				enters = append(enters, e)
+			}
+		}
+		if len(enters) >= 1 {
+			break
+		}
+	}
+	if len(enters) != 1 {
+		t.Fatalf("want exactly 1 enter event (the textarea one excluded), got %d: %+v", len(enters), rec.Events())
+	}
+	if enters[0].Selector != "#q" || enters[0].Value != "hello" {
+		t.Fatalf("enter event = %+v, want selector #q with the typed snapshot", enters[0])
+	}
+}

--- a/internal/browser/recording.go
+++ b/internal/browser/recording.go
@@ -49,7 +49,7 @@ type Output struct {
 // iframe selector) scopes it via the " >>> " convention. Label is a human note;
 // replay ignores it.
 type Step struct {
-	Action   string `yaml:"action"` // navigate | click | type | select | upload | wait | download | extract
+	Action   string `yaml:"action"` // navigate | click | type | select | upload | wait | download | extract | key
 	URL      string `yaml:"url,omitempty"`
 	Frame    string `yaml:"frame,omitempty"`
 	Selector string `yaml:"selector,omitempty"`
@@ -170,6 +170,30 @@ func CompileRecording(name, description, startURL string, events []RecordedEvent
 			}
 			pn := addParam(hint, e.Value, desc, e.Secret)
 			st.Value = "{{" + pn + "}}"
+		case e.Type == "enter":
+			// Enter in a text input — the submit gesture. Without a blur no change
+			// event fired, so the typed value only exists as this event's snapshot:
+			// emit the type step for it first (parameterized like a change), unless
+			// the field was already typed moments ago (blur → change → Enter).
+			st.Action = "key"
+			st.Value = "enter"
+			alreadyTyped := false
+			if n := len(s.Steps); n > 0 {
+				last := s.Steps[n-1]
+				alreadyTyped = last.Action == "type" && last.Selector == e.Selector && last.Frame == e.Frame
+			}
+			if (e.Value != "" || e.Secret) && !alreadyTyped {
+				hint := e.Field
+				if hint == "" {
+					hint = hintFromSelector(e.Selector)
+				}
+				desc := ""
+				if e.Secret {
+					desc = "secret value (not stored; provide at replay)"
+				}
+				pn := addParam(hint, e.Value, desc, e.Secret)
+				s.Steps = append(s.Steps, Step{Action: "type", Frame: e.Frame, Selector: e.Selector, Label: e.Text, Hint: hint, Value: "{{" + pn + "}}"})
+			}
 		default:
 			continue
 		}
@@ -902,6 +926,25 @@ func runStep(ctx context.Context, b *Browser, page *Page, step *Step, params map
 			if !page.fieldNonEmpty(ctx, target) {
 				return page, fmt.Errorf("type: %q did not accept input", target)
 			}
+		}
+	case "key":
+		// A recorded Enter in a text input (form submit / autocomplete confirm) —
+		// the only key recorded today. Page.Key dispatches to the focused element,
+		// so focus the field with a real (trusted) click first.
+		if h := strings.TrimSpace(step.Hint); h != "" {
+			target = page.resolveFieldTarget(ctx, step.Frame, step.Selector, h, waitTimeout)
+		} else if err := page.WaitFor(ctx, target, waitTimeout); err != nil {
+			return page, err
+		}
+		key := strings.ToLower(strings.TrimSpace(subst(step.Value, params)))
+		if key != "enter" {
+			return page, fmt.Errorf("key: unsupported key %q (only enter is recorded)", step.Value)
+		}
+		if err := page.Click(ctx, target); err != nil {
+			return page, err
+		}
+		if err := page.Key(ctx, key); err != nil {
+			return page, err
 		}
 	case "select":
 		if h := strings.TrimSpace(step.Hint); h != "" {

--- a/internal/browser/recording_test.go
+++ b/internal/browser/recording_test.go
@@ -1167,3 +1167,81 @@ func TestReplayExtractEscapesParams(t *testing.T) {
 		t.Fatalf("extract = %#v, want the exact original %#v", outputs["v"], original)
 	}
 }
+
+// TestCompileEnterFlow: an Enter event compiles to a key step, preceded by a
+// type step when the value only exists as the event's snapshot (no blur → no
+// change). A field typed just before (blur → change → Enter) must not be
+// typed twice; a password's snapshot is empty, so its type step takes a
+// defaultless secret param.
+func TestCompileEnterFlow(t *testing.T) {
+	// Plain: value only from the enter snapshot.
+	s := CompileRecording("x", "", "", []RecordedEvent{
+		{Type: "enter", Selector: "#q", Tag: "INPUT", Field: "query", Value: "hello"},
+	})
+	if len(s.Steps) != 2 || s.Steps[0].Action != "type" || s.Steps[1].Action != "key" {
+		t.Fatalf("want [type, key], got %+v", s.Steps)
+	}
+	if s.Steps[1].Value != "enter" || len(s.Params) != 1 || s.Params[0].Default != "hello" {
+		t.Fatalf("key step / param wrong: %+v %+v", s.Steps[1], s.Params)
+	}
+	// Blur-then-Enter on the same field: the change already typed it.
+	s = CompileRecording("x", "", "", []RecordedEvent{
+		{Type: "change", Selector: "#q", Tag: "INPUT", Field: "query", Value: "hello"},
+		{Type: "enter", Selector: "#q", Tag: "INPUT", Field: "query", Value: "hello"},
+	})
+	nTypes := 0
+	for _, st := range s.Steps {
+		if st.Action == "type" {
+			nTypes++
+		}
+	}
+	if len(s.Steps) != 2 || nTypes != 1 || s.Steps[1].Action != "key" {
+		t.Fatalf("want [type, key] without a duplicate type, got %+v", s.Steps)
+	}
+	// Secret: snapshot is empty, so the type step needs a replay-time param.
+	s = CompileRecording("x", "", "", []RecordedEvent{
+		{Type: "enter", Selector: "#pw", Tag: "INPUT", Field: "password", Secret: true},
+	})
+	if len(s.Steps) != 2 || len(s.Params) != 1 || s.Params[0].Default != "" {
+		t.Fatalf("secret enter should declare a defaultless param: %+v %+v", s.Steps, s.Params)
+	}
+}
+
+// TestReplayKeyEnter: replay types the value, focuses the field with a real
+// click, and presses Enter — the form actually submits.
+func TestReplayKeyEnter(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<!doctype html><title>k</title>
+<form onsubmit="event.preventDefault();window.submits=(window.submits||0)+1"><input id="q"></form>`))
+	}))
+	defer srv.Close()
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#q", testWaitTimeout); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	recording := &Recording{
+		Name:   "x",
+		Params: []Param{{Name: "q"}},
+		Steps: []Step{
+			{Action: "type", Selector: "#q", Value: "{{q}}"},
+			{Action: "key", Selector: "#q", Value: "enter"},
+		},
+	}
+	if _, _, _, err := ReplayRecording(ctx, page, recording, map[string]string{"q": "hello"}, ReplayOptions{StepTimeout: 5 * time.Second}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	var submits int
+	if err := page.Eval(ctx, "window.submits||0", &submits); err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if submits != 1 {
+		t.Fatalf("form should have submitted exactly once, got %d", submits)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1560. "Type into a search box and press Enter" used to record only the `type` step — the submission was lost, and replay stopped with a typed-but-unsubmitted form. Enter is now captured, compiled, and replayable end to end:

- **Capture** (`recorder.go`): a `keydown` listener reports Enter — but only for text-like inputs, and never during IME composition (`isComposing`, CJK candidate confirm is not a submit). Textareas are excluded (Enter is a newline, already in the `change` value), as are buttons/links (Enter fires a `click`, already captured). The report snapshots the field's current value, since no `change` event fires without a blur.
- **Compile** (`recording.go`): an Enter event becomes a new `key` step (`value: enter`), preceded by a parameterized `type` step when the value only exists as the snapshot — skipped when the field was just typed (blur → change → Enter), and declared as a defaultless secret param for password fields.
- **Replay** (`recording.go`): the `key` step re-locates the field (hint fallback like `type`), focuses it with a trusted click, and presses Enter.
- **`Page.Key` fix** (`actions.go`): the keyDown now carries `text` (`\r` for Enter, the char for printable keys, no modifiers held). Without it Chrome fires the DOM keydown but skips the default action — Enter would neither submit a form nor newline a textarea, and printable keys wouldn't insert. This was the root cause making replayed Enter a no-op.

## Testing

- `TestRecorderCapturesEnter`: Enter on a text input captured with its value snapshot; textarea Enter excluded.
- `TestCompileEnterFlow`: snapshot-only value → [type, key]; blur-then-Enter → no duplicate type; secret → defaultless param.
- `TestReplayKeyEnter`: replay actually submits the form (once).
- `go test ./internal/browser ./internal/tools ./internal/server ./internal/app` — all pass; build/vet/gofmt clean.
