### PR TITLE
feat(browser): record SPA same-document navigations

### DIFF
--- a/internal/browser/recorder.go
+++ b/internal/browser/recorder.go
@@ -261,7 +261,7 @@ func (r *Recorder) Start(ctx context.Context) error {
 	// multi-page demonstration replays from the right pages — otherwise the only
 	// navigate step is the synthesized start URL, and the recording loses every
 	// page the user moved to.
-	r.watchNavigations(p.sessionID)
+	r.watchNavigations(ctx, p.sessionID)
 	return nil
 }
 
@@ -279,16 +279,49 @@ func (r *Recorder) instrumentPageSession(ctx context.Context, session string) {
 	if err := r.instrumentSession(ctx, session, ""); err != nil {
 		return
 	}
-	r.watchNavigations(session)
+	r.watchNavigations(ctx, session)
 }
 
-// watchNavigations records top-level navigations on one page session (subframe
-// navigations ignored; consecutive repeats collapsed).
-func (r *Recorder) watchNavigations(session string) {
+// watchNavigations records top-level navigations on one page session: both
+// cross-document (Page.frameNavigated) and same-document SPA route changes
+// (Page.navigatedWithinDocument — pushState/replaceState never fire
+// frameNavigated). Subframe navigations are ignored: the cross-document event
+// carries the frame's parentId, and the same-document one is filtered against
+// the session's top frame (resolved once here). Consecutive repeats collapse.
+func (r *Recorder) watchNavigations(ctx context.Context, session string) {
+	topFrameID := ""
+	if res, err := r.page.cli.call(ctx, session, "Page.getFrameTree", nil); err == nil {
+		var ft struct {
+			FrameTree struct {
+				Frame struct {
+					ID string `json:"id"`
+				} `json:"frame"`
+			} `json:"frameTree"`
+		}
+		if json.Unmarshal(res, &ft) == nil {
+			topFrameID = ft.FrameTree.Frame.ID
+		}
+	}
+
 	navEvents, navUnsub := r.page.cli.subscribe("Page.frameNavigated", session)
+	spaEvents, spaUnsub := r.page.cli.subscribe("Page.navigatedWithinDocument", session)
 	r.mu.Lock()
-	r.unsubs = append(r.unsubs, navUnsub)
+	r.unsubs = append(r.unsubs, navUnsub, spaUnsub)
 	r.mu.Unlock()
+
+	recordNav := func(u string) {
+		if u == "" || u == "about:blank" {
+			return
+		}
+		r.mu.Lock()
+		n := len(r.events)
+		if n > 0 && r.events[n-1].Type == "navigate" && r.events[n-1].URL == u {
+			r.mu.Unlock()
+			return // collapse the initial-load echo / repeat
+		}
+		r.events = append(r.events, RecordedEvent{Type: "navigate", URL: u})
+		r.mu.Unlock()
+	}
 
 	go func() {
 		for ev := range navEvents {
@@ -301,18 +334,22 @@ func (r *Recorder) watchNavigations(session string) {
 			if json.Unmarshal(ev.Params, &b) != nil || b.Frame.ParentID != "" {
 				continue // ignore subframe navigations
 			}
-			u := b.Frame.URL
-			if u == "" || u == "about:blank" {
+			recordNav(b.Frame.URL)
+		}
+	}()
+	go func() {
+		for ev := range spaEvents {
+			var b struct {
+				FrameID string `json:"frameId"`
+				URL     string `json:"url"`
+			}
+			if json.Unmarshal(ev.Params, &b) != nil {
 				continue
 			}
-			r.mu.Lock()
-			n := len(r.events)
-			if n > 0 && r.events[n-1].Type == "navigate" && r.events[n-1].URL == u {
-				r.mu.Unlock()
-				continue // collapse the initial-load echo / repeat
+			if topFrameID != "" && b.FrameID != topFrameID {
+				continue // SPA routing inside a subframe — not a page move
 			}
-			r.events = append(r.events, RecordedEvent{Type: "navigate", URL: u})
-			r.mu.Unlock()
+			recordNav(b.URL)
 		}
 	}()
 }

--- a/internal/browser/recorder_test.go
+++ b/internal/browser/recorder_test.go
@@ -266,3 +266,64 @@ func TestRecorderCapturesEnter(t *testing.T) {
 		t.Fatalf("enter event = %+v, want selector #q with the typed snapshot", enters[0])
 	}
 }
+
+// TestRecorderCapturesSPANavigation: history.pushState route changes are recorded
+// as navigate events (they never fire Page.frameNavigated), while SPA routing
+// inside a subframe is ignored — it isn't the page moving.
+func TestRecorderCapturesSPANavigation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/frame", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<!doctype html><title>f</title><button id="fb" onclick="history.pushState({},'','/frame2')">F</button>`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<!doctype html><title>spa</title>
+<button id="go" onclick="history.pushState({},'','/route2')">Go</button><iframe src="/frame"></iframe>`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	b := newBrowser(t, ctx)
+	defer b.Close()
+	page, err := b.NewPage(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("new page: %v", err)
+	}
+	if err := page.WaitFor(ctx, "#go", testWaitTimeout); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	rec := NewRecorder(page)
+	if err := rec.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer rec.Stop()
+	if err := page.Click(ctx, "#go"); err != nil {
+		t.Fatalf("click #go: %v", err)
+	}
+	hasNav := func(sub string) bool {
+		for _, e := range rec.Events() {
+			if e.Type == "navigate" && strings.Contains(e.URL, sub) {
+				return true
+			}
+		}
+		return false
+	}
+	found := false
+	for i := 0; i < 30; i++ {
+		time.Sleep(100 * time.Millisecond)
+		if found = hasNav("/route2"); found {
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("pushState navigation was not captured: %+v", rec.Events())
+	}
+	// SPA routing inside the iframe must NOT produce a navigate event.
+	if err := page.Eval(ctx, `document.querySelector('iframe').contentDocument.getElementById('fb').click()`, nil); err != nil {
+		t.Fatalf("drive iframe pushState: %v", err)
+	}
+	time.Sleep(700 * time.Millisecond)
+	if hasNav("/frame2") {
+		t.Fatalf("subframe SPA routing should be ignored: %+v", rec.Events())
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1561. The recorder subscribed only to `Page.frameNavigated`, so History-API route changes (`pushState`/`replaceState` — which fire `Page.navigatedWithinDocument` instead) were never recorded; a demonstration whose state is expressed by an SPA route lost its navigate steps.

`watchNavigations` now subscribes to both events. Subframe navigations stay ignored: the cross-document event filters by `parentId` as before, and the same-document event is filtered against the session's top frame, resolved once via `Page.getFrameTree` (a pushState inside an iframe isn't the page moving). Echo-collapsing is shared via a single `recordNav` helper.

## Testing

- New `TestRecorderCapturesSPANavigation` (browser-gated): a pushState to `/route2` is captured as a navigate event; a pushState inside a same-origin iframe produces none.
- `go test ./internal/browser ./internal/tools ./internal/server ./internal/app` — all pass; build/vet/gofmt clean.
