### PR TITLE
fix(browser): scale the replay timeout with recording length

### DIFF
--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -392,12 +392,16 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 
 	// Bound every action so a CDP call a janky/loading page never acks (e.g. a
 	// mouseWheel scroll on a heavy SPA) fails with a timeout instead of hanging
-	// the whole turn. replay runs many steps and download waits for a file
-	// to finish, so they get a much longer ceiling.
+	// the whole turn. download waits for a file to finish, so it gets a longer
+	// ceiling. replay gets the hard cap here as a parent bound; the replay case
+	// refines it per recording via replayTimeout (a long skill must not be
+	// killed mid-run by the old fixed 5 minutes, and a short one keeps it).
 	timeout := 45 * time.Second
 	switch action {
-	case "replay", "run_skill", "download":
+	case "download":
 		timeout = 5 * time.Minute
+	case "replay", "run_skill":
+		timeout = 30 * time.Minute
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -736,7 +740,11 @@ func (BrowserTool) Execute(ctx context.Context, _ string, input map[string]any) 
 		recorderMu.Lock()
 		healer := browserHealer
 		recorderMu.Unlock()
-		modified, finalPage, outputs, err := browser.ReplayRecording(ctx, page, &recording, params, browser.ReplayOptions{Healer: healer, Browser: b, DownloadDir: downloadDir()})
+		// Refine the call's parent bound (30 min) by the recording's length, so a
+		// long but healthy replay isn't killed by a one-size-fits-all ceiling.
+		rctx, rcancel := context.WithTimeout(ctx, replayTimeout(len(recording.Steps)))
+		defer rcancel()
+		modified, finalPage, outputs, err := browser.ReplayRecording(rctx, page, &recording, params, browser.ReplayOptions{Healer: healer, Browser: b, DownloadDir: downloadDir()})
 		if err != nil {
 			return agent.ToolResult{}, fmt.Errorf("browser: replay %q: %w", name, err)
 		}
@@ -785,6 +793,23 @@ func resolveMissingRecordingParams(rec *browser.Recording, recName string, param
 	}
 	return fmt.Errorf("browser: replay %q is missing required param(s): %s — pass them in `params`",
 		recName, strings.Join(missing, ", "))
+}
+
+// replayTimeout bounds one replay by the recording's length: a base for the
+// browser attach and page loads, plus a per-step budget (a step waits up to
+// StepTimeout for its target, and a failing step may consult the healer for
+// several rounds). Floored at the old fixed 5 minutes so short recordings
+// behave exactly as before; capped so a pathological recording can't hold a
+// turn indefinitely.
+func replayTimeout(steps int) time.Duration {
+	t := 2*time.Minute + time.Duration(steps)*20*time.Second
+	if t < 5*time.Minute {
+		return 5 * time.Minute
+	}
+	if t > 30*time.Minute {
+		return 30 * time.Minute
+	}
+	return t
 }
 
 func getStr(input map[string]any, key string) string {

--- a/internal/tools/browser_test.go
+++ b/internal/tools/browser_test.go
@@ -543,3 +543,24 @@ func TestBrowserPage_NoLaunchFallback(t *testing.T) {
 		t.Fatalf("error should be the actionable connect guide, got: %v", err)
 	}
 }
+
+// TestReplayTimeoutScalesWithSteps: the replay ceiling is floored at the old
+// fixed 5 minutes for short recordings, grows linearly for long ones, and is
+// hard-capped so a pathological recording can't hold a turn forever.
+func TestReplayTimeoutScalesWithSteps(t *testing.T) {
+	for _, tc := range []struct {
+		steps int
+		want  time.Duration
+	}{
+		{0, 5 * time.Minute},
+		{9, 5 * time.Minute},
+		{10, 5*time.Minute + 20*time.Second},
+		{30, 12 * time.Minute},
+		{84, 30 * time.Minute},
+		{1000, 30 * time.Minute},
+	} {
+		if got := replayTimeout(tc.steps); got != tc.want {
+			t.Errorf("replayTimeout(%d) = %v, want %v", tc.steps, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1565. The browser tool capped every `replay` at a fixed 5 minutes, so a long recording — N steps × up-to-15s per-step waits, plus up to 3 LLM heal rounds on a failing step — could be killed mid-run while every step was progressing normally.

The ceiling now scales with the recording:

- `2 min base + 20s × steps` (a step waits up to `StepTimeout` for its target; a failing one may consult the healer for several rounds),
- **floored at the old fixed 5 minutes** so short recordings behave exactly as before,
- **capped at 30 minutes** so a pathological recording can't hold a turn forever.

Implementation: the tool call's parent bound for `replay`/`run_skill` is now the 30-minute hard cap, and the replay case derives the effective timeout from `len(recording.Steps)` once the recording is loaded (the cap must bound a replay *making progress*, not guess at how long any skill might take). `download` keeps its fixed 5 minutes; the workflow `skill()` path never had the tool cap.

## Testing

- New `TestReplayTimeoutScalesWithSteps`: floor / linear growth / cap boundaries.
- `go test ./internal/tools ./internal/browser ./internal/server ./internal/app` — all pass; build/vet/gofmt clean.
