### PR TITLE
fix(tools): detect terminal write targets the current parser missed

### DIFF
--- a/internal/tools/read_tracker_test.go
+++ b/internal/tools/read_tracker_test.go
@@ -125,6 +125,11 @@ func TestRegistry_WriteThenEdit_NoRedundantRead(t *testing.T) {
 // sed -i, a redirect) must still be editable afterwards — the terminal write
 // is the session's own change, not an out-of-band edit, so it should refresh
 // the tracker rather than trip the "modified since read" guard.
+//
+// The sed/semicolon, sed/pipe, and bash-c cases here are regression tests for
+// bugs where the tokenizer glued a trailing shell metacharacter to the filename
+// (`file.go;`) or the command was wrapped in `bash -c "..."`, both of which
+// made the write target unparseable and left the tracker unrefreshed.
 func TestRegistry_TerminalWriteThenEdit_Allowed(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -133,6 +138,10 @@ func TestRegistry_TerminalWriteThenEdit_Allowed(t *testing.T) {
 		{"redirect", func(p string) string { return "printf 'package x\\nconst c = 3\\n' > " + p }},
 		{"redirect-fused", func(p string) string { return "printf 'package x\\nconst c = 3\\n' >" + p }},
 		{"sed-inplace", func(p string) string { return "sed -i '' 's/const a = 1/const a = 2/' " + p }},
+		{"sed-inplace-semicolon", func(p string) string { return "sed -i 's/const a = 1/const a = 2/' " + p + "; echo done" }},
+		{"sed-inplace-pipe", func(p string) string { return "sed -i 's/const a = 1/const a = 2/' " + p + " | cat" }},
+		{"bash-c-sed", func(p string) string { return "bash -c \"sed -i 's/const a = 1/const a = 2/' " + p + "\"" }},
+		{"sh-c-sed", func(p string) string { return "sh -c \"sed -i 's/const a = 1/const a = 2/' " + p + "\"" }},
 		{"gofmt-w-file", func(p string) string { return "gofmt -w " + p }},
 	}
 	for _, tc := range cases {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -282,10 +282,40 @@ func writeTargets(tokens []string) []string {
 
 	// Pass 2: in-place editors (`sed -i`, `gofmt -w`, `… --write`) — their
 	// non-flag args are the files rewritten, keyed on the head of the command.
-	if hasInPlaceFlag(filepath.Base(tokens[0]), tokens[1:]) {
+	head := filepath.Base(tokens[0])
+	if hasInPlaceFlag(head, tokens[1:]) {
 		targets = append(targets, positionals(tokens[1:])...)
 	}
+
+	// Pass 3: shell-wrapped commands (`bash -c "sed -i ... f"`, `sh -c "…"`).
+	// The wrapped payload is a single quoted token the parser can't see into,
+	// so re-parse it as its own command and collect its write targets. Without
+	// this, `bash -c "sed -i 's/x/y/' file.go"` bumps the file's mtime without
+	// refreshing the tracker and trips the guard on the next edit_file.
+	if payload := wrappedCommand(head, tokens[1:]); payload != "" {
+		targets = append(targets, writeTargets(tokenizeCommand(payload))...)
+	}
+
 	return targets
+}
+
+// wrappedCommand returns the inner payload of a shell-wrapped invocation, or
+// "" if the command isn't one. Recognizes `bash|sh|zsh -c "..."` (and
+// `--posix -c`). The payload is the single string argument to `-c`, verbatim —
+// it's re-parsed by tokenizeCommand in the caller as its own command line.
+func wrappedCommand(head string, args []string) string {
+	switch head {
+	case "bash", "sh", "zsh":
+	default:
+		return ""
+	}
+	for i, a := range args {
+		if a == "-c" {
+			// The payload is the next positional token (the quoted script).
+			return nextPositional(args, i+1)
+		}
+	}
+	return ""
 }
 
 // redirectTarget classifies a single token as an output redirection:
@@ -342,11 +372,17 @@ func hasInPlaceFlag(cmd string, args []string) bool {
 // positionals returns the non-flag tokens (a flag is any token starting with
 // "-"). A stray positional that isn't a real path — a sed script, say — is
 // harmless: RefreshTarget ignores paths the tracker never recorded.
+//
+// Trailing shell metacharacters that tokenizeCommand can't split off (it only
+// splits on whitespace and honors quotes) are stripped here so that a filename
+// written as `file.go;` (`sed -i '...' file.go; echo done`) or `file.go|`
+// resolves to the real path. Without this, the glued `;` makes the path
+// unresolvable and the tracker is never refreshed for that file.
 func positionals(args []string) []string {
 	var out []string
 	for _, a := range args {
 		if !strings.HasPrefix(a, "-") {
-			out = append(out, a)
+			out = append(out, strings.TrimRight(a, ";|&"))
 		}
 	}
 	return out


### PR DESCRIPTION
## 问题

read-before-write tracker 在 #1500 已经覆盖了 `sed -i 's/x/y/' file` 这种常见写法，但还有两类场景会让 parser 漏判，导致紧接着的 `edit_file` 误报 "File has been modified since it was last read"：

1. **文件名后紧跟 shell 元字符**：`sed -i '...' file.go; echo done` / `sed -i '...' file.go | cat` —— tokenizer 只按 whitespace 和引号切分，导致 `file.go;` / `file.go|` 当一个 token，resolvePath 解除不出来，tracker 不刷新。
2. **shell 包装命令**：`bash -c "sed -i '...' file.go"` —— 真实命令被包在引号里成了一个 token，parser 看不到内层 sed。

验证：把这两类命令分别跑 `terminal` → `edit_file`，前一轮 test 失败率 100%。

## 改动

文件：`internal/tools/registry.go`

- `positionals()`: 对每个 positional token 去掉尾部 `;` `|` `&`，这样 tokenizer 切不掉的元字符不再阻碍路径解析。
- `writeTargets()`: 新增 Pass 3，识别 `bash|sh|zsh -c "..."`，把内层 payload 重新 tokenize 后递归解析出 write targets。

## 测试

`internal/tools/read_tracker_test.go` 新增 4 个回归 case 全部通过：`sed-inplace-semicolon`、`sed-inplace-pipe`、`bash-c-sed`、`sh-c-sed`。原有 `redirect`/`sed-inplace`/`gofmt-w-file` 等 case 不受影响。
