### PR TITLE
fix(subagent): stop ghost 'running' panel + status wording for idle sub-agents

### DIFF
--- a/internal/server/live_replay_test.go
+++ b/internal/server/live_replay_test.go
@@ -580,3 +580,84 @@ func TestReplayLiveState_ReplaysSubAgentToolHistory(t *testing.T) {
 		t.Error("replay did not include the sub-agent's tool event")
 	}
 }
+
+// gatedSpawner blocks the "busy" spawn until released; every other spawn
+// completes immediately. It lets a test hold one sub-agent genuinely running
+// while another finishes and goes idle.
+type gatedSpawner struct{ release chan struct{} }
+
+func (g *gatedSpawner) Spawn(ctx context.Context, req tools.SpawnRequest) (tools.SpawnResult, error) {
+	if req.Description == "busy-one" {
+		select {
+		case <-g.release:
+			return tools.SpawnResult{Reply: "busy done"}, nil
+		case <-ctx.Done():
+			return tools.SpawnResult{}, ctx.Err()
+		}
+	}
+	return tools.SpawnResult{Reply: "idle done"}, nil
+}
+
+func (g *gatedSpawner) Continue(context.Context, string, string) (tools.SpawnResult, error) {
+	return tools.SpawnResult{}, nil
+}
+
+// TestReplayLiveState_SkipsIdleSubAgents: a completed-but-retained async
+// sub-agent (idle, kept so sub_agent_send can resume it) must NOT be replayed
+// to a subscribing tab — the retained events rebuild it as "running" on the
+// live panel, a ghost that only the next turn start clears. Only genuinely
+// busy agents have a live state worth replaying.
+func TestReplayLiveState_SkipsIdleSubAgents(t *testing.T) {
+	srv := mustServer(t, Config{Addr: "127.0.0.1:0"})
+	srv.initWS()
+
+	const sid = "replay-subagent-ghost"
+	spawner := &gatedSpawner{release: make(chan struct{})}
+	defer close(spawner.release)
+	mgr := tools.SessionSubAgentManager(sid, func() tools.Spawner { return spawner })
+	t.Cleanup(func() { tools.CloseSessionSubAgentManager(sid) })
+
+	idleID, err := mgr.Start(tools.SpawnRequest{Description: "idle-one"})
+	if err != nil {
+		t.Fatalf("start idle: %v", err)
+	}
+	busyID, err := mgr.Start(tools.SpawnRequest{Description: "busy-one"})
+	if err != nil {
+		t.Fatalf("start busy: %v", err)
+	}
+
+	// Wait for the idle agent to finish its round (busy=false, retained).
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		_, status, found := mgr.Read(idleID)
+		if found && status == "idle" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("idle agent never settled (status %q)", status)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	conn := &wsConn{hub: srv.wsHub, send: make(chan []byte, 256), subscribed: map[string]struct{}{}}
+	srv.replayLiveState(sid, conn)
+
+	var idleReplayed, busyReplayed bool
+	for _, ev := range drainConn(t, conn) {
+		if ev["type"] != "sub_agent_event" {
+			continue
+		}
+		switch ev["agent_id"] {
+		case idleID:
+			idleReplayed = true
+		case busyID:
+			busyReplayed = true
+		}
+	}
+	if idleReplayed {
+		t.Error("idle (completed) sub-agent must not be replayed — it rebuilds a ghost 'running' panel entry")
+	}
+	if !busyReplayed {
+		t.Error("a genuinely running sub-agent must still be replayed")
+	}
+}

--- a/internal/server/ws_handlers.go
+++ b/internal/server/ws_handlers.go
@@ -281,6 +281,15 @@ func (s *Server) replayLiveState(sessionID string, conn *wsConn) {
 	// a slow consumer.
 	if sam := tools.SessionSubAgentManager(sessionID, nil); sam != nil {
 		for _, sa := range sam.ListRunning() {
+			// ListRunning also returns COMPLETED agents (idle, kept so
+			// sub_agent_send can resume them). Replaying their retained events
+			// rebuilds them as "running" on the live panel — a ghost only the
+			// next turn start clears. Only a genuinely busy agent has a live
+			// state worth replaying; an idle one's outcome already lives in
+			// the chat record (sub_agent_notice).
+			if !sa.Busy {
+				continue
+			}
 			for _, ev := range sa.Events {
 				if ev.Kind == "done" {
 					continue

--- a/internal/tools/agent_followup.go
+++ b/internal/tools/agent_followup.go
@@ -98,8 +98,8 @@ func (AgentStatusTool) Definition() agent.ToolDefinition {
 		Name: "sub_agent_status",
 		Description: "Check on async sub-agents, but do not use this as a polling loop while waiting for a " +
 			"background sub-agent to finish — wait for the completion notification instead. With agent_id, report " +
-			"that sub-agent's state (running/done/exited) and its latest result; without agent_id, list all currently " +
-			"running sub-agents. Use this tool only when you suspect a sub-agent is stuck or when you need to know " +
+			"that sub-agent's state (running/done/exited) and its latest result; without agent_id, list all tracked " +
+			"sub-agents (working ones plus idle-but-resumable ones). Use this tool only when you suspect a sub-agent is stuck or when you need to know " +
 			"which agents are still running. Synchronous sub-agents return their result inline at spawn and are not " +
 			"tracked here unless the user promotes them to background while running.",
 		Parameters: map[string]any{
@@ -107,7 +107,7 @@ func (AgentStatusTool) Definition() agent.ToolDefinition {
 			"properties": map[string]any{
 				"agent_id": map[string]any{
 					"type":        "string",
-					"description": "Optional async sub-agent id (agent_N). Omit to list everything still running.",
+					"description": "Optional async sub-agent id (agent_N). Omit to list everything tracked (working or idle-but-resumable).",
 				},
 			},
 		},
@@ -126,8 +126,18 @@ func (AgentStatusTool) Execute(ctx context.Context, _ string, input map[string]a
 		if len(infos) == 0 {
 			return agent.ToolResult{Text: "No sub-agents are currently running."}, nil
 		}
+		// ListRunning includes COMPLETED agents (idle — retained so
+		// sub_agent_send can still resume them), so don't call the whole list
+		// "running": that misreads "resumable" as "still working".
+		working := 0
+		for _, in := range infos {
+			if in.Busy {
+				working++
+			}
+		}
 		var b strings.Builder
-		fmt.Fprintf(&b, "%d sub-agent(s) running:\n", len(infos))
+		fmt.Fprintf(&b, "%d sub-agent(s) tracked (%d working, %d idle — done, still reachable via sub_agent_send):\n",
+			len(infos), working, len(infos)-working)
 		for _, in := range infos {
 			state := "idle"
 			if in.Busy {

--- a/internal/tools/agent_followup.go
+++ b/internal/tools/agent_followup.go
@@ -98,7 +98,7 @@ func (AgentStatusTool) Definition() agent.ToolDefinition {
 		Name: "sub_agent_status",
 		Description: "Check on async sub-agents, but do not use this as a polling loop while waiting for a " +
 			"background sub-agent to finish — wait for the completion notification instead. With agent_id, report " +
-			"that sub-agent's state (running/done/exited) and its latest result; without agent_id, list all tracked " +
+			"that sub-agent's state (working/idle/exited) and its latest result; without agent_id, list all tracked " +
 			"sub-agents (working ones plus idle-but-resumable ones). Use this tool only when you suspect a sub-agent is stuck or when you need to know " +
 			"which agents are still running. Synchronous sub-agents return their result inline at spawn and are not " +
 			"tracked here unless the user promotes them to background while running.",
@@ -124,7 +124,7 @@ func (AgentStatusTool) Execute(ctx context.Context, _ string, input map[string]a
 	if id == "" {
 		infos := mgr.ListRunning()
 		if len(infos) == 0 {
-			return agent.ToolResult{Text: "No sub-agents are currently running."}, nil
+			return agent.ToolResult{Text: "No sub-agents are currently tracked."}, nil
 		}
 		// ListRunning includes COMPLETED agents (idle — retained so
 		// sub_agent_send can still resume them), so don't call the whole list
@@ -141,7 +141,7 @@ func (AgentStatusTool) Execute(ctx context.Context, _ string, input map[string]a
 		for _, in := range infos {
 			state := "idle"
 			if in.Busy {
-				state = "busy"
+				state = "working"
 			}
 			fmt.Fprintf(&b, "- %s — %s (%s, started %s ago)\n",
 				in.ID, in.Description, state, time.Since(in.Start).Round(time.Second))

--- a/internal/tools/agent_followup_test.go
+++ b/internal/tools/agent_followup_test.go
@@ -161,9 +161,16 @@ func TestStatus_ByIDAndList(t *testing.T) {
 		t.Fatalf("status list: %v", err)
 	}
 	// A completed-but-alive async agent stays listed (idle) — it can still
-	// receive sub_agent_send follow-ups.
+	// receive sub_agent_send follow-ups. The header must not call that
+	// "running": tracked ≠ working.
 	if !strings.Contains(res.Text, id) || !strings.Contains(res.Text, "idle") {
 		t.Errorf("list %q should show the resumable agent as idle", res.Text)
+	}
+	if strings.Contains(res.Text, "running") {
+		t.Errorf("header must not say 'running' when every agent is idle: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "tracked") {
+		t.Errorf("header should frame the list as tracked (resumable) agents: %q", res.Text)
 	}
 
 	// After a kill it leaves the list.


### PR DESCRIPTION
## 问题

完成的异步 sub-agent 会在 Web 面板上"借尸还魂"成 `N running`，刷新/重连都在，只有下一个 turn 开始才消失（用户实测：完成 4 小时后面板仍显示 "3 running"，elapsed 定格在重放时刻）。

## 根因

`SubAgentManager` **故意**保留已完成的异步 agent（`exited=false, busy=false → idle`）——`sub_agent_send` 还能凭 `backingID` 唤醒它继续干活。`ListRunning()` 只过滤 `exited`，于是两个消费方把"可唤醒"误读成"还在跑"：

1. **`replayLiveState`（主因）**：对 `ListRunning()` 里所有 agent 向(重)订阅的 tab 重放留存事件（只剔除 `done`），前端把它们重建成 `status: 'running'`，而 `done` 永远不重放 → 幽灵面板。
2. **`sub_agent_status` 列表**：抬头写死 `"N sub-agent(s) running"`，哪怕全部 idle——模型面同样被误导。

## 修复（保留语义不变，只修消费方）

- `replayLiveState`：跳过 `Busy=false` 的 agent。运行中 agent 刷新后照常重放（`Busy` 从 `Start` 到 `setDone` 全程为 true）；idle agent 的结果本来就在聊天记录（`sub_agent_notice`）里，不依赖 live replay。
- status 列表抬头改为 `N sub-agent(s) tracked (M working, K idle — done, still reachable via sub_agent_send)`，per-agent 状态、空列表文案、工具 Description 统一成 tracked/working/idle。

明确不做：idle agent 的 TTL/LRU 回收——会杀掉 `sub_agent_send` 的追问能力，那是它们被保留的初衷（评审确认 2 个 pre-existing minor 另案记录：首轮 pending 移交延迟、描述措辞，均不属本 PR）。

## 测试

- 新增 `TestReplayLiveState_SkipsIdleSubAgents`：gated spawner 同时持有一个 idle（已完成）+ 一个 busy（阻塞中）agent，断言回放只含 busy 的（评审以 `-race -count=3` 复跑通过）。
- `agent_followup_test.go` 增补断言：列表含 idle 条目但抬头不再出现 "running"。
- `go test ./internal/tools ./internal/server` 全绿，vet/gofmt 干净。
