### PR TITLE
fix(landing): prevent nav-cta squeeze and right-align on mobile

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -191,6 +191,9 @@
     .reveal.visible{opacity:1;transform:none;}
 
     @media(max-width:820px){
+      .nav{gap:12px;padding:0 16px;}
+      .nav-cta{white-space:nowrap;margin-left:auto;}
+      .lang{display:none;}
       .hero h1{font-size:42px;} .grid3,.grid4,.feat-grid,.grid2,.foot-grid{grid-template-columns:1fr;}
       .feat.hero-feat{grid-column:auto;} section{padding:56px 20px;} .hero{padding:100px 20px 0;}
     }


### PR DESCRIPTION
On narrow viewports the Download CTA could get squeezed between the GitHub ghost button and the language toggle. Fixes:
- Reduce nav gap (24->12px) and padding (32->16px) on mobile
- Keep CTA label on one line (nowrap) and push it right (margin-left:auto)
- Hide the language toggle entirely on mobile to free space

<!-- Write this PR description in English. -->

## What

<!-- One or two sentences: what does this PR change? -->

## Why

<!-- The need this addresses, and who benefits. -->

## User-visible impact

<!-- Default behavior changes? New config? Breaking changes? "None" is a valid answer. -->

---

## Self-review

Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### 1. Architecture

- [ ] Smallest possible diff for the need
- [ ] No new configuration knobs (or justified below)
- [ ] No new dependencies (or justified below)
- [ ] Fits the existing design / naming / layering

### 2. Need

- [ ] Common need that benefits most users, **or** scope and side effects are explained below
- [ ] No unintended impact on other users' workflows or defaults

### 3. Code

- [ ] All tests pass
- [ ] Coverage does not drop; new code has new tests
- [ ] Commit messages and this PR are written in English
- [ ] This branch was created from the latest `main` and is currently up to date with it

### Bonus

- [ ] This PR was authored using Octo itself

---

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs you considered, or follow-ups planned. -->
