### PR TITLE
fix(loop): wrap IM/TUI wakeup ticks as system-reminders, not fake user bubbles

### DIFF
--- a/cmd/octo/loop_test.go
+++ b/cmd/octo/loop_test.go
@@ -1,11 +1,30 @@
 package main
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
+
+// wakeupCaptureSender records the message list of the first turn it serves,
+// so a test can inspect the exact user message a fired tick ran with.
+type wakeupCaptureSender struct {
+	msgs chan []agent.Message
+}
+
+func (s *wakeupCaptureSender) SendMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int) (agent.Reply, error) {
+	s.msgs <- msgs
+	return agent.Reply{Content: "ok"}, nil
+}
+
+func (s *wakeupCaptureSender) StreamMessages(_ context.Context, _, _ string, msgs []agent.Message, _ int, _ func(string), _ func(string)) (agent.Reply, error) {
+	s.msgs <- msgs
+	return agent.Reply{Content: "ok"}, nil
+}
 
 // armWakeupMsg (posted by the schedule_wakeup tool) arms the loop timer.
 func TestTUI_ArmWakeup(t *testing.T) {
@@ -54,6 +73,41 @@ func TestTUI_UserMessageKeepsLoop(t *testing.T) {
 		t.Fatal("a user message must not cancel the armed loop (they coexist)")
 	}
 	m.cancelWakeup()
+}
+
+// A fired tick runs the prompt wrapped as a <system-reminder>
+// (tools.FormatLoopTick) — parity with the web and IM paths. The TUI itself
+// only prints "● Loop tick", and the wrapped user message is what persists, so
+// a web/desktop UI replaying this transcript derives empty visible text and
+// can't render the tick as a fake user bubble. The model still receives the
+// task verbatim.
+func TestTUI_WakeupTickWrapsPrompt(t *testing.T) {
+	isolateTestInputHistory()
+	cs := &wakeupCaptureSender{msgs: make(chan []agent.Message, 1)}
+	a := agent.New(cs, "m")
+	m := newTUIModel(replConfig{a: a, noSave: true})
+	m.sink = &tuiSink{prog: &fakeProg{}}
+	m.armWakeup(time.Hour, "check the PR", false)
+	m.Update(wakeupMsg{prompt: "check the PR", repeat: false, delay: time.Hour})
+
+	select {
+	case msgs := <-cs.msgs:
+		last := msgs[len(msgs)-1]
+		if last.Role != "user" {
+			t.Fatalf("last message role = %q, want user", last.Role)
+		}
+		if !strings.Contains(last.Content, "check the PR") {
+			t.Fatalf("tick prompt must reach the model verbatim, got %q", last.Content)
+		}
+		if !strings.Contains(last.Content, "[LOOP TICK]") {
+			t.Fatalf("tick prompt must be wrapped as a loop tick, got %q", last.Content)
+		}
+		if visible := strings.TrimSpace(agent.StripSystemReminders(last.Content)); visible != "" {
+			t.Fatalf("wrapped tick must leave no visible user-bubble text, got %q", visible)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the wakeup turn never reached the model")
+	}
 }
 
 // schedule_wakeup(cancel=true) → cancelWakeupMsg stops the loop.

--- a/cmd/octo/tuirepl.go
+++ b/cmd/octo/tuirepl.go
@@ -1140,7 +1140,13 @@ func (m *tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.wakeupFired() // dynamic: keep the clock; the model re-arms in the turn
 		}
 		m.printlnBlock(noticeStyle.Render("● Loop tick"))
-		return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(msg.prompt, ""))
+		// Wrap the tick prompt as a <system-reminder> (tools.FormatLoopTick)
+		// — parity with the web and IM paths. The TUI itself shows only the
+		// "● Loop tick" line (the echo stays ""), but the wrapped user message
+		// is what persists, so a web/desktop UI replaying this transcript
+		// derives empty visible text and can't render the tick as a fake user
+		// bubble. The model still receives the prompt verbatim.
+		return m, tea.Sequence(m.flushPrints(), m.startTurnEcho(tools.FormatLoopTick(msg.prompt), ""))
 
 	case cancelWakeupMsg:
 		// schedule_wakeup(cancel=true): the model stopped the loop on request.

--- a/internal/server/loop.go
+++ b/internal/server/loop.go
@@ -49,8 +49,8 @@ func (s *Server) armWakeup(sessionID string, delay time.Duration, prompt string,
 // timer has already re-armed, so the next tick delivers once the session is
 // idle — mirroring the TUI, which only re-arms (never queues) while a turn runs.
 //
-// The prompt is wrapped as a <system-reminder> (formatLoopTick) so the web
-// transcript renders the tick as an environment re-entry rather than a
+// The prompt is wrapped as a <system-reminder> (tools.FormatLoopTick) so the
+// web transcript renders the tick as an environment re-entry rather than a
 // duplicated user-message bubble every tick — matching the TUI, which prints a
 // "● Loop tick" line and never echoes the prompt as user speech. The scrollback
 // notice is broadcast only when kickIdleSteerTurn actually starts a turn, so a
@@ -62,29 +62,10 @@ func (s *Server) deliverLoopTick(sessionID, prompt string, repeat bool) {
 	if s.shouldSkipTick(sessionID, repeat) {
 		return
 	}
-	s.enqueueSteer(sessionID, agent.InboxItem{Text: formatLoopTick(prompt)})
+	s.enqueueSteer(sessionID, agent.InboxItem{Text: tools.FormatLoopTick(prompt)})
 	if s.kickIdleSteerTurn(sessionID) {
 		s.broadcastLoopTick(sessionID)
 	}
-}
-
-// formatLoopTick wraps a loop prompt as a <system-reminder> block — octo's
-// convention for injected, non-user context that UIs strip from user-visible
-// text (see FormatBgNote). This is what keeps the web transcript from rendering
-// the prompt as a fresh user bubble on every tick: doAgentTurn computes the
-// visible bubble text from StripSystemReminders(content), which is empty here,
-// so no history_user_message is broadcast (live) or reconstructed (on reload).
-// The model still reads and acts on it — doAgentTurn runs the turn on the full
-// wrapped content, and an idle turn whose entire user message is a
-// system-reminder still produces a reply (the same path background- and
-// sub-agent-completion notes use). The preamble tells the model to treat the
-// task as if the user just sent it, so a directive prompt isn't mistaken for
-// passive context.
-func formatLoopTick(prompt string) string {
-	return "<system-reminder>\n" +
-		"[LOOP TICK] Your scheduled loop fired. Continue the task below as if the user just sent it:\n\n" +
-		prompt +
-		"\n</system-reminder>"
 }
 
 // broadcastLoopTick emits the "Loop tick" scrollback notice to a web session,
@@ -198,10 +179,21 @@ func imWakeupKey(sess *channel.Session) string { return "im:" + string(sess.Key)
 func (w imWaker) ScheduleWakeup(delay time.Duration, prompt, reason string, repeat bool) error {
 	sess, ad, ev := w.sess, w.ad, w.ev
 	w.s.armWakeupFn(imWakeupKey(sess), delay, repeat, func() {
-		sess.Agent.Inbox.Enqueue(prompt)
+		w.enqueueTick(prompt)
 		go w.s.runChannelIdleTurn(context.Background(), sess, ad, ev)
 	})
 	return nil
+}
+
+// enqueueTick queues the loop prompt into the session's Inbox, wrapped as a
+// <system-reminder> (tools.FormatLoopTick) — parity with the web path
+// (deliverLoopTick). The injected prompt is model-facing context, never user
+// speech: an IM user only ever receives the model's reply, and a web/desktop
+// UI that renders or replays this session's transcript derives an empty
+// visible text via agent.StripSystemReminders, so the tick can't surface as a
+// fake user bubble there either.
+func (w imWaker) enqueueTick(prompt string) {
+	w.sess.Agent.Inbox.Enqueue(tools.FormatLoopTick(prompt))
 }
 
 func (w imWaker) CancelWakeup() error {

--- a/internal/server/loop_test.go
+++ b/internal/server/loop_test.go
@@ -132,19 +132,45 @@ func TestShouldSkipTick(t *testing.T) {
 	}
 }
 
-// A loop tick is wrapped as a <system-reminder> so the web transcript stops
-// duplicating the prompt as a user-message bubble on every tick. The model must
-// still receive the prompt verbatim, and the visible bubble text (what
-// doAgentTurn derives via StripSystemReminders) must be empty — the same
-// suppression that keeps completion notes from rendering as user speech.
-func TestFormatLoopTick_SuppressesUserBubble(t *testing.T) {
-	prompt := "check whether the PR is merged and report"
-	wrapped := formatLoopTick(prompt)
+// A web loop tick reaches the steer queue wrapped as a <system-reminder>
+// (tools.FormatLoopTick), so doAgentTurn derives an empty visible bubble and
+// no history_user_message is ever broadcast for it. The wrapped text still
+// carries the task verbatim for the model. (The kick fails here because the
+// bare test server has no loadable session — the steer just stays queued,
+// which is exactly what we inspect.)
+func TestDeliverLoopTick_EnqueuesWrappedTick(t *testing.T) {
+	s := newLoopTestServer()
+	s.deliverLoopTick("loop-test-nonexistent", "check whether the PR is merged", false)
 
-	if !strings.Contains(wrapped, prompt) {
-		t.Fatalf("wrapped tick must carry the original task verbatim, got %q", wrapped)
+	q := s.steerQueues["loop-test-nonexistent"]
+	if len(q) != 1 {
+		t.Fatalf("expected exactly one enqueued steer, got %d", len(q))
 	}
-	if visible := strings.TrimSpace(agent.StripSystemReminders(wrapped)); visible != "" {
+	if !strings.Contains(q[0].Text, "check whether the PR is merged") {
+		t.Fatalf("tick steer must carry the task verbatim, got %q", q[0].Text)
+	}
+	if visible := strings.TrimSpace(agent.StripSystemReminders(q[0].Text)); visible != "" {
+		t.Fatalf("a loop tick must leave no visible user-bubble text, got %q", visible)
+	}
+}
+
+// The IM path must wrap the same way: an imWaker tick lands in the session
+// Inbox as a <system-reminder>, so a web/desktop UI rendering this session's
+// transcript never shows the tick as a fake user bubble — an IM user only
+// ever sees the model's reply.
+func TestIMWaker_EnqueueTickWrapsPrompt(t *testing.T) {
+	sess := &channel.Session{Agent: agent.New(&stubSender{}, "stub-model")}
+	w := imWaker{s: newLoopTestServer(), sess: sess}
+	w.enqueueTick("check the PR and merge when green")
+
+	items := sess.Agent.Inbox.Drain()
+	if len(items) != 1 {
+		t.Fatalf("expected one enqueued tick, got %d", len(items))
+	}
+	if !strings.Contains(items[0].Text, "check the PR and merge when green") {
+		t.Fatalf("tick must carry the task verbatim, got %q", items[0].Text)
+	}
+	if visible := strings.TrimSpace(agent.StripSystemReminders(items[0].Text)); visible != "" {
 		t.Fatalf("a loop tick must leave no visible user-bubble text, got %q", visible)
 	}
 }
@@ -162,11 +188,12 @@ func TestServer_TurnActive(t *testing.T) {
 
 func newLoopTestServer() *Server {
 	return &Server{
-		wakeupTimers: map[string]*time.Timer{},
-		wakeupStart:  map[string]time.Time{},
-		turnRunning:  map[string]bool{},
-		turnLocks:    map[string]*sync.Mutex{},
-		steerQueues:  map[string][]agent.InboxItem{},
+		wakeupTimers:        map[string]*time.Timer{},
+		wakeupStart:         map[string]time.Time{},
+		turnRunning:         map[string]bool{},
+		turnLocks:           map[string]*sync.Mutex{},
+		steerQueues:         map[string][]agent.InboxItem{},
+		sessionBindingLocks: map[string]*sync.Mutex{},
 	}
 }
 

--- a/internal/tools/schedule_wakeup.go
+++ b/internal/tools/schedule_wakeup.go
@@ -87,6 +87,24 @@ func LoopExpired(start time.Time) bool {
 	return !start.IsZero() && time.Since(start) >= MaxLoopLifetime
 }
 
+// FormatLoopTick wraps a fired wakeup's prompt as a <system-reminder> block —
+// octo's convention for injected, non-user context that UIs strip from
+// user-visible text (see FormatBgNote, agent.StripSystemReminders). Every
+// surface that delivers a wakeup must wrap the prompt this way: the web path
+// (Server.deliverLoopTick), the IM path (imWaker), and the TUI tick. The
+// wrapped user message persists in the transcript, and any surface that later
+// renders or replays it derives an empty visible text, so the tick never
+// surfaces as a fake user bubble — each UI shows its own "Loop tick" marker
+// instead. The model still receives the prompt verbatim and acts on it; the
+// preamble tells it to treat the task as if the user just sent it, so a
+// directive prompt isn't mistaken for passive context.
+func FormatLoopTick(prompt string) string {
+	return "<system-reminder>\n" +
+		"[LOOP TICK] Your scheduled loop fired. Continue the task below as if the user just sent it:\n\n" +
+		prompt +
+		"\n</system-reminder>"
+}
+
 // ScheduleWakeupTool lets the model schedule its own next turn — the mechanism
 // behind an in-session loop (the /loop command). The model calls it at the end
 // of a turn to come back later (dynamic, self-paced mode) or to keep a fixed

--- a/internal/tools/schedule_wakeup_test.go
+++ b/internal/tools/schedule_wakeup_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,6 +27,22 @@ func (w *fakeWaker) ScheduleWakeup(delay time.Duration, prompt, reason string, r
 func (w *fakeWaker) CancelWakeup() error {
 	w.cancelled++
 	return nil
+}
+
+// A loop tick is wrapped as a <system-reminder> so every UI strips it from
+// user-visible text (agent.StripSystemReminders) — the fired prompt never
+// renders as a fake user bubble, whichever surface delivered it. The model
+// must still receive the original task verbatim.
+func TestFormatLoopTick_SuppressesUserBubble(t *testing.T) {
+	prompt := "check whether the PR is merged and report"
+	wrapped := FormatLoopTick(prompt)
+
+	if !strings.Contains(wrapped, prompt) {
+		t.Fatalf("wrapped tick must carry the original task verbatim, got %q", wrapped)
+	}
+	if visible := strings.TrimSpace(agent.StripSystemReminders(wrapped)); visible != "" {
+		t.Fatalf("a loop tick must leave no visible user-bubble text, got %q", visible)
+	}
 }
 
 func TestScheduleWakeup_ClampsDelay(t *testing.T) {


### PR DESCRIPTION
## 问题

一次性 / 循环 `schedule_wakeup` 触发时，注入的 prompt 在 Web/Desktop UI 里渲染成一条**用户消息气泡**，看起来像用户自己发的，很困惑。

#1433 修过这个问题，但只覆盖了 **Web 入口**（`serverWaker → deliverLoopTick → formatLoopTick` 包装）。wakeup 有三个入口，另外两个仍然裸注入：

| 入口 | 触发行为 | #1433 后状态 |
|---|---|---|
| Web (`serverWaker`) | steer + idle turn | ✅ 已包装 |
| IM (`imWaker`) | `Inbox.Enqueue(原始 prompt)` + channel idle turn | ❌ 裸注入 |
| TUI (`tuiWaker`) | `startTurnEcho(原始 prompt, "")` | ❌ 裸持久化 |

裸 prompt 持久化为普通 user 消息后，任何渲染/回放该 transcript 的 Web/Desktop UI 都会把它显示成用户气泡。

### 线上复现证据

会话 `20260718-090732-9a661529`：10:10 的 tick 是包装过的（Web 入口武装）；10:34 用户改从微信发消息（serve.log `channel message received platform=weixin` 时间戳与会话记录精确对上），之后所有 wakeup 都走 `imWaker`——10:48、10:57、11:14、11:29、11:50 五条裸 prompt 气泡。

## 修复

把 `formatLoopTick` 挪到 `tools.FormatLoopTick`（与 `Waker` 接口、`LoopExpired` 等循环设施同处），三个入口统一包装：

- **Web** `deliverLoopTick`：行为不变，改用共享函数
- **IM** `imWaker.enqueueTick`：入 Inbox 前包装。IM 用户本来就只看到模型回复，包装对其不可见
- **TUI** `wakeupMsg` handler：`startTurnEcho(tools.FormatLoopTick(msg.prompt), "")`。TUI 仍只打印 `● Loop tick`（echo 保持空），持久化的包装形态在 Web 回放时被 `StripSystemReminders` 剥掉

## 测试

- 格式不变量（prompt 原样保留 + `StripSystemReminders` 后为空）随函数移到 `internal/tools`
- server 新增：`TestDeliverLoopTick_EnqueuesWrappedTick`（web steer 已包装）、`TestIMWaker_EnqueueTickWrapsPrompt`（IM Inbox 已包装）
- TUI 新增：`TestTUI_WakeupTickWrapsPrompt`（捕获 tick turn 实际发出的 user 消息，断言已包装）
- `internal/tools`、`internal/server`、`cmd/octo` 三个包全量测试通过
