### PR TITLE
chore: bump version to 1.12.22

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.21"
+var Version = "1.12.22"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Version bump for the v1.12.22 release. Tag `v1.12.22` will be pushed on the merge commit, triggering goreleaser + installer builds (release.yml).

Co-authored-by: octo-agent <no-reply@octo-agent.dev>