### PR TITLE
fix(web): keep .gitkeep during vite build so goreleaser sees a clean tree

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,7 +5,12 @@ export default defineConfig({
   plugins: [svelte()],
   build: {
     outDir: '../internal/server/webdist',
-    emptyOutDir: true,
+    // Must stay false: webdist is gitignored except a tracked .gitkeep (which
+    // keeps go:embed satisfied on fresh clones). Emptying the dir deletes that
+    // .gitkeep and leaves the git tree dirty — goreleaser refuses to release
+    // from a dirty tree (broke the v1.12.22 tag build). Stale hashed assets
+    // left behind are inert: index.html only references the fresh ones.
+    emptyOutDir: false,
     // The UI ships as one embedded bundle served from localhost; code-splitting buys nothing here.
     chunkSizeWarningLimit: 600,
   },


### PR DESCRIPTION
## What broke

The v1.12.22 tag build ([failed run](https://github.com/open-octo/octo-agent/actions/runs/29649199484)) aborted in goreleaser:

```
error= git is in a dirty state
Please check in your pipeline what can be changing the following files:
 D internal/server/webdist/.gitkeep
```

Chain: #1595 added a "Build web UI" step before goreleaser → `vite build` with `emptyOutDir: true` wipes `internal/server/webdist/` → the **tracked** `.gitkeep` (committed so `go:embed all:webdist` has a file on fresh clones) is deleted → git tree dirty → goreleaser refuses to release. The desktop CI passed because plain `go build` doesn't check tree dirtiness — only goreleaser does.

## Fix

`emptyOutDir: false` in `web/vite.config.ts`, fixing at the source so no current or future workflow needs a restore step. Now that webdist is gitignored, emptying buys nothing anyway: stale hashed assets are inert (`index.html` only references the fresh build), and CI always starts from a clean checkout.

## Verification

Simulated the exact CI sequence locally on a webdist containing only `.gitkeep`:

```
$ npm run build   # ✓ built in 1.41s
$ git status --porcelain
(nothing under internal/server/webdist — .gitkeep intact, assets gitignored)
```

## Release note

Nothing was published for v1.12.22 (goreleaser failed before creating the release; installer jobs were skipped). After this merges I'll move the `v1.12.22` tag to the new main HEAD and re-push to re-trigger release.yml.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
