### PR TITLE
fix(windows): stop console windows flashing behind the desktop app

### DIFF
--- a/cmd/octo/serve_supervisor.go
+++ b/cmd/octo/serve_supervisor.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"runtime"
 
+	"github.com/open-octo/octo-agent/internal/executil"
 	"github.com/open-octo/octo-agent/internal/server"
 )
 
@@ -88,6 +89,9 @@ func spawnServeWorkerWithResolver(args []string, stdout, stderr io.Writer, resol
 			return nil, nil, err
 		}
 		cmd := exec.Command(exe, append([]string{"serve"}, args...)...)
+		// Windowless on Windows: the daemonized supervisor has no console, so
+		// an unflagged console-subsystem worker would pop a visible window.
+		executil.SetNoWindow(cmd)
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr
 		cmd.Env = append(os.Environ(), serveWorkerEnv+"=1")

--- a/internal/app/worktree.go
+++ b/internal/app/worktree.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/open-octo/octo-agent/internal/executil"
 )
 
 // worktree is a transient git worktree backing a sub-agent's isolation. The
@@ -25,6 +27,7 @@ type worktree struct {
 // folding stderr into the error so failures are legible.
 func gitRun(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
+	executil.SetNoWindow(cmd)
 	if dir != "" {
 		cmd.Dir = dir
 	}

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -23,6 +23,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/open-octo/octo-agent/internal/executil"
 )
 
 // IndexFile is the per-repo memory index, loaded into the system prompt.
@@ -33,6 +35,16 @@ const (
 	maxInjectLines = 200
 	maxInjectBytes = 25 * 1024
 )
+
+// gitOutput runs git -C dir with stdout captured. SetNoWindow keeps the
+// console-subsystem git.exe from flashing a console window when the parent is
+// the windowless Windows desktop app.
+func gitOutput(dir string, args ...string) ([]byte, error) {
+	args = append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", args...)
+	executil.SetNoWindow(cmd)
+	return cmd.Output()
+}
 
 // ProjectRoot returns the repo root that memory is scoped to for dir, or dir
 // itself when it's not in a git repo (or git is unavailable).
@@ -50,7 +62,7 @@ func ProjectRoot(dir string) string {
 	if dir == "" {
 		return ""
 	}
-	if out, err := exec.Command("git", "-C", dir, "rev-parse", "--git-common-dir").Output(); err == nil {
+	if out, err := gitOutput(dir, "rev-parse", "--git-common-dir"); err == nil {
 		common := strings.TrimSpace(string(out))
 		if common != "" {
 			if !filepath.IsAbs(common) {
@@ -63,7 +75,7 @@ func ProjectRoot(dir string) string {
 			// Bare repo or unusual layout — fall through to the top-level.
 		}
 	}
-	if out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output(); err == nil {
+	if out, err := gitOutput(dir, "rev-parse", "--show-toplevel"); err == nil {
 		if root := strings.TrimSpace(string(out)); root != "" {
 			return resolveSymlinks(root)
 		}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/config"
+	"github.com/open-octo/octo-agent/internal/executil"
 	"github.com/open-octo/octo-agent/internal/permission"
 	"github.com/open-octo/octo-agent/internal/tools"
 )
@@ -1044,16 +1045,20 @@ func (s *Server) handleFileAction(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusForbidden, "open action only allowed on localhost")
 			return
 		}
-		var cmd string
+		var cmd *exec.Cmd
 		switch runtime.GOOS {
 		case "darwin":
-			cmd = "open"
+			cmd = exec.Command("open", abs)
 		case "windows":
-			cmd = "start"
+			// start is a cmd.exe builtin, not an executable — route through
+			// cmd /c. The empty "" is start's window-title argument so a
+			// quoted path containing spaces isn't mistaken for the title.
+			cmd = exec.Command("cmd", "/c", "start", "", abs)
+			executil.SetNoWindow(cmd)
 		default:
-			cmd = "xdg-open"
+			cmd = exec.Command("xdg-open", abs)
 		}
-		if err := exec.Command(cmd, abs).Start(); err != nil {
+		if err := cmd.Start(); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}

--- a/internal/tools/overwrite_backup.go
+++ b/internal/tools/overwrite_backup.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/open-octo/octo-agent/internal/config"
+	"github.com/open-octo/octo-agent/internal/executil"
 	"github.com/open-octo/octo-agent/internal/trash"
 )
 
@@ -81,6 +82,7 @@ func gitTrackedClean(abs string) bool {
 // (which carries the non-zero exit status git uses to signal its answer).
 func runGitQuiet(dir string, args ...string) error {
 	cmd := exec.Command("git", args...)
+	executil.SetNoWindow(cmd)
 	cmd.Dir = dir
 	return cmd.Run()
 }


### PR DESCRIPTION
## 问题

#1589 — Windows 桌面端使用中 cmd 窗口频繁闪烁（新建对话、问问题、编辑文件时）。

## 根因

`octo-desktop.exe` 以 `-H windowsgui` 构建（GUI 子系统、无控制台）。Windows 下，无控制台的父进程 spawn 控制台子系统程序（git.exe、powershell.exe 等）时，系统会为子进程新建一个**可见控制台窗口**；子进程秒退，看起来就是窗口"闪一下"。

仓库里已有 `executil.SetNoWindow`（`CREATE_NO_WINDOW`）并覆盖了高频路径（ripgrep、终端工具的 PowerShell、MCP stdio、hooks、taskkill），但几处 `git.exe` spawn 漏了，正好对应 issue 里的三个场景：

| 用户操作 | 漏保护位置 | 每次闪几下 |
|---|---|---|
| 编辑文件 | `overwrite_backup.go` `runGitQuiet`（覆盖前跑 3 个 git 检查） | ≤3 |
| 新建对话/启动 | `memory.go` `ProjectRoot`（`git rev-parse` ×2，server 启动及 agents/workflows 扫描时触发） | 1~2 |
| 问问题（走 sub-agent/workflow） | 同上（`agents.go`、`workflow_registry.go` 调到 `ProjectRoot`） | 1~2 |
| worktree 工具 | `app/worktree.go` `gitRun` | 1 |

已确认 v1.12.21 到当前 main 这些文件无任何改动，bug 在最新代码仍存在。

## 改动

给剩余 spawn 点补上 `executil.SetNoWindow`：

- `internal/tools/overwrite_backup.go` — `runGitQuiet`
- `internal/memory/memory.go` — 收敛出 `gitOutput` helper，统一加 flag
- `internal/app/worktree.go` — `gitRun`
- `cmd/octo/serve_supervisor.go` — daemon 路径 supervisor 拉 worker（这个的症状是**常驻**控制台窗口而非闪烁）
- `internal/server/handlers.go` — 顺带修一个潜在 bug："open" 文件操作在 Windows 上 `exec.Command("start", ...)`，`start` 是 cmd 内建命令不是可执行文件，之前直接报错；改为 `cmd /c start "" <path>`（空 title 参数保证带空格路径正常）并加 windowless flag

## 验证

- `go build ./...` 及 `GOOS=windows go build ./...` 通过
- `go test ./internal/memory/ ./internal/tools/ ./internal/app/ ./internal/server/ ./cmd/octo/` 全绿
- `GOOS=windows go vet` 通过
- 闪烁修复本身需在 Windows 桌面端实测验证（本机为 macOS，无法复现原现象）；改动为纯增量 flag，不改变任何命令行为

Fixes #1589
