### PR TITLE
fix(test): keep permission-gate tests out of the real audit log

### DIFF
--- a/cmd/octo/permission_gate.go
+++ b/cmd/octo/permission_gate.go
@@ -7,15 +7,17 @@ import (
 
 	"github.com/open-octo/octo-agent/internal/agent"
 	"github.com/open-octo/octo-agent/internal/app"
+	"github.com/open-octo/octo-agent/internal/audit"
 	"github.com/open-octo/octo-agent/internal/permission"
 )
 
 // newCLIGate builds the shared app permission gate wired to an interactive
 // prompter: ask-class verdicts raise a KindPermission prompt through the view
 // (stdin line today, modal in the TUI) and map the structured answer. A nil
-// prompter yields a non-interactive gate (ask → deny).
-func newCLIGate(engine *permission.Engine, ask userPrompter) agent.PermissionGate {
-	return app.NewPermissionGate(engine, permissionAskFrom(ask))
+// prompter yields a non-interactive gate (ask → deny). The optional auditLog
+// is for tests — see app.NewPermissionGate.
+func newCLIGate(engine *permission.Engine, ask userPrompter, auditLog ...*audit.Logger) agent.PermissionGate {
+	return app.NewPermissionGate(engine, permissionAskFrom(ask), auditLog...)
 }
 
 // permissionAskFrom adapts a userPrompter (the view) into an app.PermissionAsk.

--- a/cmd/octo/permission_gate_test.go
+++ b/cmd/octo/permission_gate_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/agent"
+	"github.com/open-octo/octo-agent/internal/audit"
 	"github.com/open-octo/octo-agent/internal/permission"
 )
 
@@ -21,7 +22,8 @@ func newGate(t *testing.T, mode permission.Mode, stdin string) (agent.Permission
 	}
 	var out bytes.Buffer
 	view := newPlainView(newScannerLineReader(strings.NewReader(stdin), &out), &out, &out, verbosityNormal, false)
-	return newCLIGate(eng, view), &out
+	// No-op audit logger: test checks must not land in the real ~/.octo/audit.log.
+	return newCLIGate(eng, view, audit.NewAt("")), &out
 }
 
 func TestCLIGate_AllowPassesThrough(t *testing.T) {

--- a/internal/app/gate.go
+++ b/internal/app/gate.go
@@ -21,8 +21,16 @@ type PermissionAsk func(ctx context.Context, toolName string, toolInput map[stri
 // interactive transport (the CLI prompts the user on ask-class verdicts); pass
 // nil for a non-interactive one (HTTP server, IM bridge), where ask resolves to
 // deny — the same posture the old per-transport gates had.
-func NewPermissionGate(engine *permission.Engine, ask PermissionAsk) agent.PermissionGate {
-	return &permissionGate{engine: engine, ask: ask, audit: audit.New()}
+//
+// The optional auditLog exists for tests: pass audit.NewAt("") (a no-op
+// logger) or a temp-path logger so test checks never land in the real
+// ~/.octo/audit.log. Production callers omit it and audit to the default path.
+func NewPermissionGate(engine *permission.Engine, ask PermissionAsk, auditLog ...*audit.Logger) agent.PermissionGate {
+	l := audit.New()
+	if len(auditLog) > 0 {
+		l = auditLog[0]
+	}
+	return &permissionGate{engine: engine, ask: ask, audit: l}
 }
 
 type permissionGate struct {

--- a/internal/app/gate_test.go
+++ b/internal/app/gate_test.go
@@ -30,6 +30,14 @@ func recordingAsk(allow, remember bool, err error, calls *int) PermissionAsk {
 	}
 }
 
+// quietGate builds a gate with a no-op audit logger, so test checks never
+// append to the real ~/.octo/audit.log (NewPermissionGate writes there by
+// default).
+func quietGate(t *testing.T, ask PermissionAsk) *permissionGate {
+	t.Helper()
+	return &permissionGate{engine: newEngine(t, permission.ModeInteractive), ask: ask, audit: audit.NewAt("")}
+}
+
 func TestGate_AuditLogsDenyAndAsk(t *testing.T) {
 	// Inject an audit logger at a temp path instead of the default
 	// ~/.octo/audit.log. (Redirecting $HOME would not work on Windows, where
@@ -67,7 +75,7 @@ func TestGate_AuditLogsDenyAndAsk(t *testing.T) {
 
 func TestGate_AllowPassesThrough(t *testing.T) {
 	calls := 0
-	g := NewPermissionGate(newEngine(t, permission.ModeInteractive), recordingAsk(true, false, nil, &calls))
+	g := quietGate(t, recordingAsk(true, false, nil, &calls))
 	ok, _ := g.Check(context.Background(), "terminal", map[string]any{"command": "ls"})
 	if !ok {
 		t.Error("ls should be allowed")
@@ -79,7 +87,7 @@ func TestGate_AllowPassesThrough(t *testing.T) {
 
 func TestGate_DenyReturnsReason(t *testing.T) {
 	calls := 0
-	g := NewPermissionGate(newEngine(t, permission.ModeInteractive), recordingAsk(true, false, nil, &calls))
+	g := quietGate(t, recordingAsk(true, false, nil, &calls))
 	ok, reason := g.Check(context.Background(), "terminal", map[string]any{"command": "rm -rf /"})
 	if ok {
 		t.Error("rm -rf / must be denied")
@@ -94,7 +102,7 @@ func TestGate_DenyReturnsReason(t *testing.T) {
 
 func TestGate_AskInteractive_Allow(t *testing.T) {
 	calls := 0
-	g := NewPermissionGate(newEngine(t, permission.ModeInteractive), recordingAsk(true, false, nil, &calls))
+	g := quietGate(t, recordingAsk(true, false, nil, &calls))
 	ok, _ := g.Check(context.Background(), "terminal", map[string]any{"command": "sudo apt update"})
 	if !ok || calls != 1 {
 		t.Errorf("ask-class should prompt once and allow; ok=%v calls=%d", ok, calls)
@@ -112,7 +120,7 @@ func TestGate_AskInteractive_DeclineOrError(t *testing.T) {
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			calls := 0
-			g := NewPermissionGate(newEngine(t, permission.ModeInteractive), recordingAsk(c.allow, false, c.err, &calls))
+			g := quietGate(t, recordingAsk(c.allow, false, c.err, &calls))
 			ok, reason := g.Check(context.Background(), "terminal", map[string]any{"command": "sudo apt update"})
 			if ok {
 				t.Error("decline/error must deny")
@@ -126,7 +134,7 @@ func TestGate_AskInteractive_DeclineOrError(t *testing.T) {
 
 func TestGate_AskRemembers(t *testing.T) {
 	calls := 0
-	g := NewPermissionGate(newEngine(t, permission.ModeInteractive), recordingAsk(true, true, nil, &calls))
+	g := quietGate(t, recordingAsk(true, true, nil, &calls))
 	input := map[string]any{"command": "sudo apt update"}
 	if ok, _ := g.Check(context.Background(), "terminal", input); !ok {
 		t.Fatal("first ask should allow")
@@ -142,7 +150,7 @@ func TestGate_AskRemembers(t *testing.T) {
 func TestGate_NonInteractive_DeniesAsk(t *testing.T) {
 	// A nil PermissionAsk is the server/IM posture: ask-class verdicts deny
 	// without prompting, carrying the policy's reason.
-	g := NewPermissionGate(newEngine(t, permission.ModeInteractive), nil)
+	g := quietGate(t, nil)
 	ok, reason := g.Check(context.Background(), "terminal", map[string]any{"command": "sudo apt update"})
 	if ok {
 		t.Error("non-interactive gate must deny ask-class commands")
@@ -154,7 +162,7 @@ func TestGate_NonInteractive_DeniesAsk(t *testing.T) {
 
 func TestGate_UnwrapsToolCall(t *testing.T) {
 	// A Tool Search mcp_call must be evaluated against the wrapped tool name.
-	g := NewPermissionGate(newEngine(t, permission.ModeInteractive), nil)
+	g := quietGate(t, nil)
 	ok, reason := g.Check(context.Background(), "mcp_call", map[string]any{
 		"name":      "terminal",
 		"arguments": map[string]any{"command": "rm -rf /"},

--- a/internal/server/channel_gate_test.go
+++ b/internal/server/channel_gate_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/open-octo/octo-agent/internal/app"
+	"github.com/open-octo/octo-agent/internal/audit"
 	"github.com/open-octo/octo-agent/internal/channel"
 	"github.com/open-octo/octo-agent/internal/permission"
 )
@@ -26,7 +27,8 @@ func TestChannelPerTurnGate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("permission engine: %v", err)
 	}
-	gate := app.NewPermissionGate(engine, srv.channelPermissionAsk(sess, ad, ev))
+	// No-op audit logger: test checks must not land in the real ~/.octo/audit.log.
+	gate := app.NewPermissionGate(engine, srv.channelPermissionAsk(sess, ad, ev), audit.NewAt(""))
 
 	ctx := context.Background()
 


### PR DESCRIPTION
## Problem

`NewPermissionGate` always audited to the real `~/.octo/audit.log`. Every test that built a gate through the production constructor appended deny/ask entries to the developer's live audit log. On one machine the log held **519 lines that were 100% test traffic** (`rm -rf /`, `sudo apt update` — deny / user-allowed / user-declined / ask-denied, in identical 7-entry bursts matching `go test` runs) and **zero real events**.

The audit log exists to answer "what was denied and why" — test noise buries the rare real denial.

## Root cause

- `internal/app/gate.go`: `NewPermissionGate` hardcoded `audit.New()` (default path).
- Tests all used the production constructor: `internal/app/gate_test.go` (7 call sites), `internal/server/channel_gate_test.go` (1), and `cmd/octo` tests via `newCLIGate`.
- `TestGate_AuditLogsDenyAndAsk` already injected a temp-path logger, but only for itself.

## Fix

- `NewPermissionGate` and `newCLIGate` take an optional `*audit.Logger` (variadic — production call sites unchanged).
- All gate tests now pass a no-op (`audit.NewAt("")`) or temp-path logger.

## Verification

- `go build ./...` ✅
- `go test ./internal/app/... ./cmd/octo/...` ✅
- `go test ./internal/server/ -run TestChannelPerTurnGate` ✅
- Before: the same three test runs appended ~21 lines to `~/.octo/audit.log`. After: line count unchanged (519 → 519), zero new writes.
