### PR TITLE
chore: bump version to 1.12.23

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the SemVer string for this build. Overridden via -ldflags.
-var Version = "1.12.22"
+var Version = "1.12.23"
 
 // Commit is the short git SHA for this build. Overridden via -ldflags.
 // Empty in local `go build` invocations.


### PR DESCRIPTION
Bump version from 1.12.22 to 1.12.23.

## Changes
- Update `internal/version/version.go` to 1.12.23

## After merge
Tag `v1.12.23` on the merged commit to trigger the release workflow.