### PR TITLE
docs: declare octo as an opinionated product shaped by Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
   <a href="README.md">English</a> · <a href="README_CN.md">简体中文</a>
 </p>
 
+> octo is an **opinionated** product — it bakes in the agent working patterns its author discovered through real-world use, heavily shaped by Ruby on Rails. Expect convention over configuration, **omakase** defaults over infinite choice, and metaprogramming to make the idiomatic path the effortless path.
+
 > An **MIT-licensed, single Go binary, zero-runtime** AI agent that combines the two things people usually
 > reach for two separate tools to get: a **coding agent on par with Claude Code**, and a **personal
 > assistant that's lighter and more stable than OpenClaw** — skills, CLI / Web / desktop / phone-IM / VS Code / Obsidian / a Go SDK (mobile app landing next), browser control,


### PR DESCRIPTION
Adds a one-line philosophy statement to the top of README.md: octo bakes in agent patterns discovered through real-world use, under strong Ruby on Rails influence — convention over configuration, omakase defaults over infinite choice, and metaprogramming to make the idiomatic path the effortless path.

<!-- Write this PR description in English. -->

## What

<!-- One or two sentences: what does this PR change? -->

## Why

<!-- The need this addresses, and who benefits. -->

## User-visible impact

<!-- Default behavior changes? New config? Breaking changes? "None" is a valid answer. -->

---

## Self-review

Please confirm before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

### 1. Architecture

- [ ] Smallest possible diff for the need
- [ ] No new configuration knobs (or justified below)
- [ ] No new dependencies (or justified below)
- [ ] Fits the existing design / naming / layering

### 2. Need

- [ ] Common need that benefits most users, **or** scope and side effects are explained below
- [ ] No unintended impact on other users' workflows or defaults

### 3. Code

- [ ] All tests pass
- [ ] Coverage does not drop; new code has new tests
- [ ] Commit messages and this PR are written in English
- [ ] This branch was created from the latest `main` and is currently up to date with it

### Bonus

- [ ] This PR was authored using Octo itself

---

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs you considered, or follow-ups planned. -->
