### PR TITLE
blog: replace deep-dive post with the v2 rewrite (zh+en)

### DIFF
--- a/blog/src/content/posts/en/architecture-deep-dive.md
+++ b/blog/src/content/posts/en/architecture-deep-dive.md
@@ -1,37 +1,47 @@
-
 ---
-title: "octo-agent Deep Dive: The Genuinely Hard Parts of an Agent System"
-description: "This post dissects ten core mechanisms of octo-agent across the full stack — foundation, built-in tool design, context compaction, prompt caching, memory (history/context/long-term recall), /loop, workflow, browser, permissions, the trash can, and the batteries-included onboarding — and the trade-offs behind each."
+title: "octo-agent Deep Dive: The Genuinely Hard Parts of an AI Agent System"
+description: "Starting from an agent loop of only a few hundred lines, this post dissects the ten mechanisms that keep octo-agent stable, fast, and cheap — the built-in tool contract, context compaction, prompt caching, three lifetimes of memory, the robustness design of octo serve, workflow orchestration, a self-healing browser, the permission system, the trash can, and batteries included — plus the one line running through them all: whatever a mechanism can guarantee, never leave to the model's self-discipline."
 pubDate: 2026-07-08
-updatedDate: 2026-07-18
+updatedDate: 2026-07-19
 author: "octo-agent team"
 tags: ["architecture", "deep-dive", "engineering", "ai-agent"]
 locale: en
 originalSlug: architecture-deep-dive
 ---
 
-# octo-agent Deep Dive: The Genuinely Hard Parts of an Agent System
+# octo-agent Deep Dive: The Genuinely Hard Parts of an AI Agent System
 
+## Opening: What Happens Behind a Casual "Go Check That For Me"
 
-## The Foundation: The Agent Loop Must Stay Ignorant
+Between typing `octo "check the error rate in prod"` into your terminal and getting an answer back — what actually happens?
 
-Start with the big picture. The core of octo-agent is literally a while loop: send the history to the model; the model either answers (loop ends) or asks for a tool; execute the tool, append the result to history, go back to the top.
+The message enters through any one of the TUI, headless mode, an IM bridge, or the web UI, gets packed into an event structure, and is routed to the agent loop. The loop sends the full history to the LLM; the LLM either answers or asks to call a tool. If it calls a tool, the result is appended to the history and the loop continues.
+
+That loop itself is only a few hundred lines of code. But the ten mechanisms that make it actually work each answer a real design problem — without them, the agent runs unstable, slow, and expensive.
+
+This post walks through those mechanisms: what they solve, how they solve it, and why it's done that way. By the end you'll see one line running through all of them: **in an agent system, whatever a mechanism can guarantee, never leave to the model's self-discipline.**
+
+## The Foundation: Why the Agent Loop Gets to Be Only a Few Hundred Lines
+
+**The agent loop is small not because it does little, but because it knows only two interfaces (`Sender` + `ToolExecutor`) — it is the leaf package of the whole dependency tree.** It doesn't assemble JSON, doesn't speak HTTP, and has no idea how Anthropic's protocol differs from OpenAI's — all of that is quarantined in the adapter layer.
+
+First, the panorama. The core of octo-agent is a single while loop:
 
 ```mermaid
 flowchart TB
-    subgraph Entries["Entry layer — five faces, one loop"]
+    subgraph Entry["Entry layer — five faces, one loop"]
         TUI["TUI<br/>(Bubble Tea)"]
         Web["Web<br/>(Svelte 5 SPA)"]
         Headless["Headless<br/>(octo -p ...)"]
-        IM["IM bridges<br/>(Feishu / Telegram / Discord ...)"]
+        IM["IM bridge<br/>(Feishu / Telegram / Discord ...)"]
     end
 
     subgraph Assembly["Assembly layer — internal/app"]
-        App["The only package that knows everyone:<br/>provider + permission + subagent<br/>+ mcp + memory get wired here"]
+        App["The only package that knows every component:<br/>provider + permission + subagent<br/>+ mcp + memory, assembled here"]
     end
 
     subgraph Core["Agent core — internal/agent (leaf of the dependency tree)"]
-        Agent["RunStream: send → tool → append → send<br/>reads no HTTP, builds no JSON,<br/>knows no wire protocol"]
+        Agent["RunStream: send → tool → append → send<br/>no HTTP, no JSON, knows no protocol"]
     end
 
     subgraph Downstream["Downstream, behind abstract interfaces"]
@@ -51,430 +61,282 @@ flowchart TB
     style Core fill:#1a202c,color:#fff
 ```
 
-The loop itself is a few hundred lines. Everything complicated is kept out of it by a single discipline: **`internal/agent` is the leaf package of the entire dependency tree.** It imports neither `provider` nor `tools` nor any UI. It knows exactly two interfaces — `Sender` (send messages, get an abstract reply back) and `ToolExecutor` (run a tool by name, get text back).
+One rule of discipline: **`internal/agent` is the leaf package of the dependency tree** — it doesn't import `provider`, doesn't import `tools`, doesn't import any UI. To the outside it knows exactly two interfaces: `Sender` (send messages out, get an abstract reply back) and `ToolExecutor` (execute a tool by name, get a chunk of text back).
 
-The value of that discipline only shows in the details. When the model wants a tool, Anthropic's API says `stop_reason: "tool_use"` while OpenAI says `finish_reason: "tool_calls"`. In OpenAI streaming, tool arguments arrive as JSON fragments scattered across chunks that must be reassembled by index before parsing. Some third-party OpenAI-compatible servers don't even send the `[DONE]` sentinel. Each of these quirks is one temptation to bury an `if provider == "openai"` inside the core loop — and once that starts, the loop is unreadable by the time the third provider lands. octo-agent instead locks all of it inside two adapter packages, `internal/provider/anthropic` and `internal/provider/openai`; the agent loop only ever sees normalized, unified semantics.
+The value of this rule only shows in the details. Anthropic's API signals "the model wants to call a tool" with `stop_reason: "tool_use"`; OpenAI uses `finish_reason: "tool_calls"`. In OpenAI's streaming responses, tool-call arguments arrive as JSON fragments spread across multiple chunks and must be reassembled by index before parsing. Some third-party OpenAI-compatible services don't even send the `[DONE]` sentinel. Each of these quirks is enough to plant an `if provider == "openai"` in the core loop — and once that starts, the loop is unreadable by the time a third provider lands. octo-agent locks all of them inside the two adapter packages `internal/provider/anthropic` and `internal/provider/openai`; the agent loop only ever sees normalized, unified semantics.
 
-The payoff: five kinds of entry points (TUI, Web, Headless, IM, plus sub-agents) all run the same `RunStream`. Plugging in a new LLM backend changes zero lines of agent code; adding a tool means implementing an interface and registering one line. A full turn looks like this:
+So all five entries (TUI, Web, headless, IM, plus sub-agents) run the same `RunStream`; adding a new LLM backend doesn't touch a single line of agent code, and adding a tool means implementing an interface plus one line of registration. The full lifecycle of one turn:
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant U as User (any entry point)
+    participant U as User (any entry)
     participant Ag as Agent.RunStream
     participant Perm as Permission gate
     participant Prov as Provider adapter
     participant Tool as Tool
 
-    U->>Ag: one message (app layer has injected permission / browser / memory env)
+    U->>Ag: one message (app layer already injected permission/browser/memory context)
     loop until the model gives a final answer
-        Ag->>Prov: SendMessagesToTools(entire history)
+        Ag->>Prov: SendMessagesToTools(full history)
         Prov-->>Ag: normalized text / tool_use
         Ag->>Perm: is this call allowed? (deny/ask/allow)
-        Perm-->>Ag: allow / ask the user / deny
-        Ag->>Tool: execute, append result as tool_result
+        Perm-->>Ag: pass / ask the user / refuse
+        Ag->>Tool: execute; result appended to history as tool_result
     end
     Ag-->>U: event stream (text_delta / tool_started / turn_done)
     Note over Ag: history persisted to ~/.octo/sessions/*.jsonl
 ```
 
-That's the foundation. Now for the main course: the problems that only start once this loop is actually running.
+That's the foundation. Now the main event: the genuinely hard problems that show up once this loop starts running.
 
+## Built-in Tools: A Converged Interface with Sharp Edges
 
+Terminal, browser, workflow, MCP — these tools differ completely in how they're invoked, their parameter shapes, and their lifecycles. If the agent loop had to perceive those differences, every new tool species would mean changing the core loop. That's not architecture; that's piling.
 
+**octo's answer: lock down one pipe.** Every built-in tool implements the same two-method contract (`Definition() ToolDefinition` + `Execute(ctx, name, input) (ToolResult, error)`), discovered and dispatched by name through `tools.DefaultRegistry`, executed through the agent loop. The shared surface is itself the point: the agent core never branches on tool species, meta-skills freely recombine them, and browser / workflow / MCP all travel the same narrow pipe. The structure is simple; the design tension lives at the edges.
 
-## Built-In Tool Design: Small Interfaces, Sharp Edges
+### Streaming Fragments Across a Protocol Boundary
 
-Every built-in tool implements the same two-method contract (`Definition() ToolDefinition` + `Execute(ctx, name, input) (ToolResult, error)`), discovered by `tools.DefaultRegistry` and dispatched by name through the agent loop. That shared surface is the point: the agent core never branches on tool species, meta-skills are free to reshuffle them, and the browser / workflow / MCP layers all speak the same narrow pipe. The structure is simple. The design tensions live at the edges.
-
-### Streaming Fragments across Provider Borders
-
-A subtler design rule lives in the provider adapters, not the tools: **OpenAI-protocol tool-call arguments stream as JSON fragments across multiple chunks, keyed by `tool_calls[i].index`** — concatenate every fragment for the same index before parsing. Anthropic-style endpoints don't. The principle the codebase enforces is: the agent loop (`internal/agent/agent.go`) never branches on which spelling it got; normalization happens at the provider adapter. The same contract ("fragments in, complete tool call out") is the only way to keep the browser / workflow / MCP layers portable across Anthropic and OpenAI protocols without every layer growing `if provider == …` forks.
+OpenAI-protocol tool-call arguments stream as JSON fragments across multiple chunks, keyed by `tool_calls[i].index` — concatenate every fragment of the same index before parsing. Anthropic-style endpoints don't do this. The rule the codebase enforces: the agent loop (`internal/agent/agent.go`) never branches on which spelling it received; normalization happens in the provider adapter. The same "fragments in, complete tool call out" contract is the only way the browser / workflow / MCP layers stay portable between the Anthropic and OpenAI protocols, without every layer growing its own `if provider == …` forks.
 
 ### One Registry, Many Species
 
-`tools.DefaultRegistry` (`internal/tools/registry.go`) is a single dispatcher that routes any tool call by name to one entry of the `allTools` slice — `Terminal`, `ReadFile`, `WriteFile`, `EditFile`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `Skill`, `Agent*`, `Workflow*`, `ScheduleWakeup`, `Browser`, `MemoryRecall`, and the rest. There is "browser: internal/browser", "workflow: Ruby/mruby", and "MCP: a JSON-RPC bridge" — but the agent loop sees only `ToolExecutor`. The late addition of `mcp_describe` / `mcp_call` didn't require touching the agent core either; they entered through a registry entry like every other tool.
+`tools.DefaultRegistry` (`internal/tools/registry.go`) is a single dispatcher that routes any tool call by name to one slot of the `allTools` slice — `Terminal`, `ReadFile`, `WriteFile`, `EditFile`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `Skill`, `Agent*`, `Workflow*`, `ScheduleWakeup`, `Browser`, `MemoryRecall`, and so on. (We left out `TerminalOutput`/`TerminalInput` here — they're companion sub-tools for background processes, not invoked directly by the user.) Behind the browser lives a CDP long connection in `internal/browser`; behind workflow, a Ruby/mruby sandbox; behind MCP, a JSON-RPC bridge — but the agent loop sees only `ToolExecutor`. This choice is exactly what makes meta-skills possible: a guided "set up your IM channel" flow isn't a bespoke tool; it's `channel-manager` stringing `read_file` / `write_file` / `terminal` together in the order the user's situation demands. Tool composition is the reusable primitive; a new capability usually means a new skill, not a new tool.
 
-That choice is what makes the meta-skills from the previous section possible: a guided "set up your IM channel" flow isn't a bespoke tool, it's `channel-manager` stringing `read_file` / `write_file` / `terminal` together in the order the user's situation demands. Tool composition is the reusable primitive; a new capability usually means a new skill, not a new tool.
+### Read-Before-Write + the mtime Guard
 
-### The Read-Before-Write MTime Guard
+`internal/tools/ReadTracker` enforces a rule that sounds fussy but blocks a real class of bugs: the LLM may only write/edit files it has **already read**, and only while the on-disk mtime still matches what it was at read time. A file read on turn 3 that gets modified by an external editor by turn 7 → refuse, and tell the agent to re-read. The error wording is lifted from Claude Code — models trained on that corpus react correctly on retry.
 
-`internal/tools/ReadTracker` enforces what looks like a nitpick but stops a real class of mistake: the LLM may only write to (or edit) a file it has *already read*, and only while its on-disk mtime still matches what was seen at read time. A file read in turn 3 that an external editor touched by turn 7 is refused, and the agent is told to re-read — which mirrors Claude Code's error wording so the LLM, already trained on that prompt, reacts correctly on the retry.
+Guarding on an external file's mtime is inherently strict — what if a command the agent itself ran changed the file? A compile, a formatter rewrite — all of those touch mtime. The answer is `RefreshTarget`: paths the terminal tool has written get a fresh mtime stamp, so subsequent edits don't false-alarm. `RefreshTarget` re-stamps only the **exact** paths already registered in the tracker — never spreading to sibling files, and never promoting an unread file to writable. Files never read stay unwritable; files genuinely changed by an external editor (which never flow through the terminal tool and are never the exact write target of that command) keep their stale stamps and still raise the alarm. The guard catches real mistakes; the escape hatch is too narrow to be abused out of the sandbox.
 
-That last qualifier — "only while mtime matches" — introduces a bootstrapping problem the codebase handles with `RefreshTarget`: a formatter or shell redirect that the session *itself* wrote through the terminal tool stamps a fresh mtime so the next edit doesn't trip the guard on its own output. `RefreshTarget` only ever re-stamps an exact path the tracker already recorded; it never cascades to siblings, never promotes an un-readable path to writable. A file the session never read stays unwritable; a file truly touched by an out-of-band editor (which never flows through the terminal tool) keeps its stale stamp and still trips the guard. The guard catches the real mistakes; the loop-hole is narrow enough that it can't be abused to escape the sandbox.
+### Pulling the Floor Out from Under SSRF
 
-### Pulling the Floor Out from under SSRF
+`web_fetch` can't just `http.Get(userURL)` — that's textbook SSRF (Server-Side Request Forgery). Its answer (`internal/tools/web_fetch.go`) splits requests into **two hardened paths** sharing one `secureFetchTransport`:
 
-`web_fetch` can't just `http.Get(userURL)` — that's the textbook SSRF vector. Its answer (`internal/tools/web_fetch.go`) splits the fetch into **two hardened paths** sharing one `secureFetchTransport`:
+- **The Jina proxy path** — rendering is handed to `r.jina.ai` (Jina AI's page-parsing service), but **cross-host** redirects are refused (a redirect off `r.jina.ai` means being bounced somewhere unexpected), and the connection is cut if the resolved IP is link-local or cloud metadata. When the caller passes custom headers, the request is forced onto the direct path (Jina's outbound headers aren't controllable, so the overrides can't be enforced).
+- **The direct path** — required for arbitrary URLs, so it **must** follow cross-host redirects (URL shorteners and `www` canonicalization are normal). It shares the link-local ban and caps the redirect chain at 10 hops so a loop can't hang the agent.
 
-- **Jina proxy path** — delegates rendering to `r.jina.ai`, but refuses *cross-host* redirects (a redirect off `r.jina.ai` means something unexpected is bouncing the request) and drops the connection if the resolved IP is link-local / cloud-metadata. It forces a direct fetch when the caller passes custom headers (Jina's outbound headers aren't controllable, so it can't honor an override).
-- **Direct fetch path** — needed for arbitrary URLs, so it *must* follow cross-host redirects (URL shorteners, `www`-canonical hops). It shares the link-local block and caps the chain at 10 hops so a redirect loop can't hang the agent.
-
-The `net.Dialer.Control` hook fires *after* DNS resolution with the concrete IP, so a hostname that resolves to `169.254.x.x` or `127.0.0.1` via DNS rebinding is refused — even when it public-IP'd at resolve time one moment earlier. Bodied too: `WebFetchInlineBytes` (64 KB) is the inline threshold; `WebFetchMaxBytes` (5 MB) is the hard ceiling; past it the body is truncated and spilled to a temp file. Big page = summary + head/tail preview + a `read_file` path to the rest, never a wall of text dumped into the model's context.
+The `net.Dialer.Control` hook fires **after** DNS resolution with the concrete IP, so DNS rebinding (a hostname that resolves to a public IP now and `169.254.x.x` / `127.0.0.1` a moment later) is blocked too. Bodies have bounds as well: `WebFetchInlineBytes` (64 KB) is the inline threshold; `WebFetchMaxBytes` (5 MB) is the hard cap; beyond that the body is truncated to a temp file. A big page = summary + head/tail preview + a `read_file` pointer to the rest — never a wall of text shoved into the model's context.
 
 ### Five Search Surfaces, One Contract
 
-`web_search` looks simple on the wire (returns title/url/snippet), but the back is a tiered fallback over five backends (`internal/tools/web_search.go`): **Brave → Tavily → Serper → DuckDuckGo HTML → Bing HTML**. The first three activate when their env keys are set (`BRAVE_SEARCH_API_KEY` / `TAVILY_API_KEY` / `SERPER_API_KEY`); the last two need no key and are the default. Every failure gets swallowed into the response's `Error` field and the next tier is tried — the tool never panics, and the tier that actually produced the results is reported back in the `Provider` field so the model knows whether it's looking at an index lookup (Brave) or an HTML scrape (DDG/Bing).
+`web_search` looks simple on the wire (returns title/url/snippet), but behind it is a tiered fallback over five backends (`internal/tools/web_search.go`): **Brave → Tavily → Serper → DuckDuckGo HTML → Bing HTML**. The first three activate when their env keys (`BRAVE_SEARCH_API_KEY` / `TAVILY_API_KEY` / `SERPER_API_KEY`) are present; the last two need no key and are the default path. Every failure is swallowed into the response's `Error` field and the next tier is tried — the tool never panics, and the tier that actually produced results is reported back in the `Provider` field so the model knows whether it's looking at an index lookup (Brave) or an HTML scrape (DDG/Bing).
 
-Two details actually matter: **a DuckDuckGo cooldown** (`markDDGUnavailable`, 10 minutes) that keeps a token goroutine from hammering a DDG that just returned nothing — guarded by a `sync.RWMutex` because the web server made concurrent searches routine. And **a landmine on Bing's HTML endpoint**: if you send `Accept-Encoding: gzip`, Bing answers with a ~39 KB JavaScript skeleton instead of the ~120 KB real results page. The fix is the weird rule "never let Go auto-negotiate encoding against `cn.bing.com`" — `browserGet` deliberately omits that header.
+Two details are worth real money: first, the **DuckDuckGo cooldown** (`markDDGUnavailable`, 10 minutes), which stops a stampede of goroutines from hammering DDG right after it returned nothing — guarded by a `sync.RWMutex` because the web server made concurrent searches routine. Second, **a landmine on Bing's HTML endpoint**: if you send `Accept-Encoding: gzip`, Bing answers with a ~39 KB JavaScript skeleton page instead of the ~120 KB real results page. The fix is the odd rule "never let Go auto-negotiate encoding against `cn.bing.com`" — `browserGet` deliberately omits that header.
 
-### terminal: Time, Anti-Polling, and Backtick Survival
+### terminal: Timeouts, Anti-Polling, Backtick Survival
 
-The `terminal` tool runs everything you hand it on the system shell, so its description is the longest entry in the schema — most of it is rules that cost a debugging session each to learn:
+The `terminal` tool runs everything you hand it on the system shell, so its schema description is the longest in the codebase — most rules cost a debugging session each to learn:
 
-- **Three launch modes** — synchronous (default; blocked until the command returns), `run_in_background: "async"` (detached one-shot task, e.g. a build or `npm install`), and `"interactive"` (a long-running service / REPL you'll keep feeding via `terminal_input`). A `detached: true` mode deliberately outlives the session for things like `ngrok` / `cloudflared`.
-- **120-second default timeout** with a hard ceiling at `MaxTerminalTimeout` (600 s); anything above that must go background rather than monopolize a turn.
-- **Anti-polling window**: `BackgroundManager` tracks concurrent reads — three empty reads inside 30 seconds on a running process get blocked and the LLM is told to wait for the push notification instead of spinning in a `terminal_output` loop.
-- **A 1 MiB circular buffer** per background process — older drops are reported as such; only the most recent tail is retained.
-- **The backtick problem**: a shell will mangle backticks inside a quoted string (POSIX turns them into command substitution; PowerShell treats backtick as escape). The fix is the dedicated `stdin` parameter, which pipes text verbatim into the child's stdin and closes it — used whenever a command body contains quotes, backticks, or `$`.
+- **Three launch modes** — synchronous (default; blocks until the command returns), `run_in_background: "async"` (a detached one-shot like a build or `npm install`), and `"interactive"` (a long-running service / REPL you keep feeding via `terminal_input`). A `detached: true` mode is reserved for things that outlive the session (`ngrok` / `cloudflared`).
+- **120-second default timeout**, hard ceiling at `MaxTerminalTimeout` (600 s); anything longer must go background instead of hogging a turn.
+- **Anti-polling window**: `BackgroundManager` watches concurrent reads — three empty reads of a running process inside 30 seconds get blocked, and the LLM is told to wait for the push notification instead of spinning in `terminal_output`.
+- **A 1 MiB circular buffer per background process** — older drops are honestly reported; only the recent tail is kept.
+- **The backtick problem**: shells mangle backticks inside quotes (POSIX turns them into command substitution; PowerShell treats backtick as an escape). The fix is the dedicated `stdin` parameter, which pipes text verbatim into the child's stdin and closes it — mandatory whenever the command body contains quotes, backticks, or `$`.
 
-Together these turn "the shell can do anything" from a footgun into a bounded surface that the model can reason about without burning tokens polling dead output.
+Together these turn "a shell can do anything" from a blunderbuss into a bounded surface the model can reason about — without burning tokens polling dead output.
 
-### sub_agent: Forking Without Recursion
+### sub_agent: Can Fork, Can't Recurse
 
-The `sub_agent` tool looks like a simple delegate-and-wait, but the design tensions live in what it *doesn't* allow. The most visible rule is in `AgentTool.Execute` (`internal/tools/agent.go`): if the caller is already a sub-agent, the call fails outright — "a sub-agent cannot spawn another sub-agent." No recursion, period. Combined with the `tools` allowlist omitting `sub_agent` itself, that's a shallow hard ceiling rather than the workflow's Turing-complete unconstrained spawn — the design intent is a single level of delegation, not an agent tree.
+The `sub_agent` tool looks like delegate-and-wait, but the design tension lives in what it *refuses* to do. The most visible rule sits in `AgentTool.Execute` (`internal/tools/agent.go`): if the caller is already a sub-agent, fail outright — "a sub-agent cannot spawn another sub-agent." No recursion, period. Combined with the `tools` allowlist deliberately omitting `sub_agent` itself, that's a hard ceiling — not the workflow's Turing-complete arbitrary spawn. The design intent is "one layer of delegation only"; no agent trees.
 
-**Fork vs. fresh** (`subagent_type`): omitting `subagent_type` seeds the child with the *parent's full conversation* (system prompt + messages so far) — a true fork that shares context and has the same conclusion-shaped reply contract. Setting a type (`explore`, `plan`, `general`, `code-review`) starts a zero-context child with a specialized persona, read-only / lean-context defaults, and its own `model` frontmatter. The same tool covers both; a preset fills in what the call leaves unset.
+**Fork vs. fresh** (`subagent_type`): omitting `subagent_type` seeds the child with the **parent's full conversation** (system prompt + messages so far) — a true fork that shares context and follows the same conclusion-shaped reply contract. Setting a type (`explore`, `plan`, `general`, `code-review`) starts a zero-context child with a specialized persona, read-only / lean-context defaults, and its own `model` frontmatter. One tool covers both; presets fill in whatever the caller left unset.
 
-**Sync vs. async**: `run_in_background: true` calls `SubAgentManager.Start`, which returns an `agent_N` ID immediately and pushes a completion notification; `false` (default) calls `RunSync` and blocks the turn. A semaphore (`syncSem`) bounds how many synchronous sub-agents run at once so a wave of fan-outs can't starve the parent. Transport-aware too: synchronous channels (server / IM) have no follow-up-turn path, so `mgr.Synchronous()` silently forces the blocking path and tells the model — rather than silently failing.
+**Sync vs. async**: `run_in_background: true` calls `SubAgentManager.Start`, returning an `agent_N` ID immediately and pushing a notification on completion; `false` (default) calls `RunSync`, blocking the turn until the result is back. A semaphore (`syncSem`) bounds concurrent synchronous sub-agents so a fan-out wave can't starve the parent. Transport-aware too: synchronous channels (server / IM) have no follow-up-turn path, so `mgr.Synchronous()` silently forces the blocking path and tells the model — instead of failing quietly.
 
-When a sub-agent hits its turn limit, the result returns with an explicit `[INCOMPLETE: … partial]` marker rather than passing partial work off as done. The parent is meant to either re-launch narrower or treat it as unfinished. And every `StopReason` (`end_turn`, `tool_use`, `max_turns`, `error`, `killed`) reaches the WS broadcast so the frontend status panel updates without polling.
-
-
-
+When a sub-agent hits its turn limit, the result comes back with an explicit `[INCOMPLETE: … partial]` marker rather than passing half-done work off as finished. The parent either relaunches with a narrower task or treats it as unfinished. Every `StopReason` (`end_turn`, `tool_use`, `max_turns`, `error`, `killed`) is pushed to the WS broadcast, so the frontend status panel updates without polling.
 
 ## Context Compaction: You Can't Delete Messages, Only Fold Time
 
-The first wall you hit is physical: the context window has a fixed size, and agent conversations balloon fast — a single compiler-error tool_result can be thousands of tokens, and an afternoon session piles up to six figures without trying.
+The first wall is physics: the context window is only so big, and agent conversations inflate fast — a single compile-error tool_result can be thousands of tokens, and an afternoon session easily piles up into six figures.
 
-The intuitive fix is "when the window fills up, drop the oldest messages." In an agent setting this breaks the API outright: `tool_use` and `tool_result` blocks in history are strictly paired, and deleting messages that sever a pair gets you a 400 from both Anthropic and OpenAI. Worse, the oldest messages usually contain the original task statement — drop them and the agent forgets what it's doing halfway through.
+The intuitive fix — "drop the oldest messages when the window fills up" — outright breaks API requests in an agent setting: `tool_use` and `tool_result` in the history are strictly paired, and cutting a pair makes both Anthropic and OpenAI return 400. Worse, "the oldest messages" usually contain the original task statement; delete it and the agent spends the second half not knowing what it's doing.
 
-octo-agent's answer is **summary folding**: compress the early history into one summary, keep the recent history verbatim. Three details carry the design.
+octo-agent's answer is **summary folding**: compress the early history into a summary, keep the recent history verbatim. The devil is in three details.
 
 ```mermaid
 flowchart LR
-    A["usage ≥ 75% of window"] --> B["Free win first: reclaim stale<br/>bulky tool_results (zero cost)"]
+    A["usage ≥ 75% of window"] --> B["free win first: reclaim expired<br/>large tool_results (zero cost)"]
     B --> C{"still over?"}
     C -->|no| Z["done"]
-    C -->|yes| D["Find a split point: only at a<br/>'pure user message' boundary"]
-    D --> E["before the split → LLM summary<br/>after (≤30% of window) → kept verbatim"]
-    E --> F["History rebuilt as:<br/>one summary message + recent originals"]
+    C -->|yes| D["find split point: cut only at<br/>'pure user message' boundaries"]
+    D --> E["before split → LLM summary<br/>after (≤30% of window) → verbatim"]
+    E --> F["history rebuilt as:<br/>one summary message + recent verbatim"]
 ```
 
-**First, the split point is always safe.** `safeSplitIndexByBudget` (`internal/agent/compaction.go`) only ever cuts at a "pure user message containing no tool_result," which structurally guarantees no tool_use/tool_result pair is ever severed. That same guarantee is what allows compaction to happen *mid-turn*: a long turn checks usage after every batch of tool calls, and if it's over the line, earlier completed rounds get folded immediately while the in-flight calls stay untouched. For agent tasks that routinely make dozens of tool calls in one turn, mid-turn compaction isn't a nicety — it's table stakes.
+**First, the split point is always safe.** `safeSplitIndexByBudget` (`internal/agent/compaction.go`) only cuts at "pure user messages containing no tool_result" — structurally guaranteeing a tool_use/tool_result pair can never be split. This also lets compaction happen mid-turn: a long turn checks usage after every batch of tool calls, and if it's over, folds earlier complete rounds immediately while the in-flight calls proceed untouched. For agent tasks with dozens of tool calls, "can compact mid-turn" isn't a nice-to-have; it's a necessity.
 
-**Second, the usage math is counter-intuitive.** Context usage is not whatever `input_tokens` reports — when the prompt cache hits, Anthropic's `input_tokens` is only the uncached remainder, and the real footprint requires adding `cache_read + cache_write` back in (`accrueUsage` in `agent.go`). Get this wrong and the better your cache hit rate, the less compaction triggers — until one cache miss blows straight through the window.
+**Second, the usage math is counterintuitive.** Context usage is not whatever `input_tokens` reports — on a prompt-cache hit, Anthropic's `input_tokens` is only the uncached delta; the real usage adds `cache_read` back (`accrueUsage` in `agent.go`). Example: a 100K window, all early turns cache-hit, Anthropic reports `input_tokens: 20K` (the delta); real usage is 20K + 80K cache_read = 100K. A naive compactor sees 20K → 20% → doesn't trigger. Next turn the cache misses and 80K of original text + 20K of new content slams into the 100K threshold at once. **Without adding cache_read back, compaction never fires when hit rates are high — and the miss turn is exactly the turn that needs it most.**
 
-**Third, compaction has damping.** The trigger threshold defaults to 75% (configurable via `compact_auto_pct`), the keep budget is 30% of the window, and there's an anti-thrashing rule: if a fold would reclaim less than 15%, skip it entirely — otherwise a session hovering at the threshold pays for an expensive summarization call every single round.
+**Third, compaction has damping.** The trigger threshold defaults to 75% (configurable via `compact_auto_pct`), the retention budget is 30% of the window, and there's an anti-flap rule: if this fold would save less than 15%, skip it — otherwise a borderline session pays for an expensive summary call every single turn.
 
-One pitfall worth knowing: **the persisted `session.jsonl` stores the post-compaction history.** Compaction rebuilds the history wholesale, which triggers a full rewrite of the session file; the verbatim originals survive only if `ArchiveDir` is configured, in which case they're archived as `chunk-*.md` (the summary ends with the file path, so the model can read them back on demand) — otherwise they're gone for good. And since the history just got shorter, every `message_index` held by the Web frontend (edit and branch features depend on it) is silently invalidated; the server watches a length watermark and forces the frontend to re-fetch the whole transcript when the history shrinks below it. These compaction ripple effects have caused more rework than any other part of the mechanism.
-
-
-
+A pit worth knowing: **the on-disk `session.jsonl` stores the compacted history**. Compaction rebuilds the history wholesale, triggering a full rewrite of the session file; the original text only survives if `ArchiveDir` is configured, archived as `chunk-*.md` (the summary ends with the file path so the model can read it back itself with the read tool) — otherwise it's gone for good. A shorter history also invalidates every `message_index` the web frontend holds (edit/branch depend on it); the server detects the shrink via a watermark and forces the frontend to re-pull the whole transcript. These "compaction ripples" are the most reworked part of the whole mechanism.
 
 ## Prompt Caching: An Agent's Bill Is Quadratic
 
-The second problem is money. Every round of the loop re-sends the entire history, which means in an N-round session, message #1 gets billed N times — without caching, cost grows quadratically with conversation length.
+**The problem**: every iteration of the agent loop resends the full history. In an N-turn session, the first message gets billed N times. Without caching, cost grows **quadratically** with conversation length.
 
-Prompt caching fits in one sentence: if this request shares a prefix with the previous one, the matched part is billed at roughly a tenth of the price. The trouble is twofold: different protocols report "how much was cached" in completely different ways, and the Anthropic protocol requires you to **explicitly declare** where the cache boundary sits.
+The principle of prompt caching is simple: if this request shares a prefix with the last one, the hit portion is billed at about a tenth of the price. The trouble is that protocols report hits completely differently.
 
-The first point is where self-hosted gateway integrations crash most often:
+| Protocol | cache-hit field | semantics of input_tokens |
+|------|-------------|---------------------|
+| Anthropic | `cache_read_input_tokens` | reports only the uncached delta; hits counted separately |
+| OpenAI | `prompt_tokens_details.cached_tokens` | reports all input; hits are a subset |
+| DeepSeek | `prompt_cache_hit/miss_tokens` | two explicit buckets |
 
-| Protocol | Cache-hit field | Meaning of `input`/`prompt` tokens |
-|---|---|---|
-| Anthropic | `cache_read_input_tokens` | **only the uncached remainder**; hits counted separately |
-| OpenAI | `prompt_tokens_details.cached_tokens` | **the entire input**; hits are a subset of it |
-| DeepSeek | `prompt_cache_hit/miss_tokens` | explicitly split into two buckets |
+octo's answer: do one subtraction in the OpenAI adapter (`nonCachedInput`), turning OpenAI-style reporting into "two non-overlapping buckets" as well. From then on, the agent layer's `InputTokens` and `CacheReadTokens` mean the same thing under every protocol — and the usage math the compaction mechanism depends on is built on exactly that unification.
 
-Same semantics, three encodings. octo-agent performs one subtraction in the openai adapter (`nonCachedInput()`, `internal/provider/openai/types.go`) so the OpenAI-style numbers also become "two non-overlapping buckets" — from that point on, `InputTokens` and `CacheReadTokens` mean the same thing at the agent layer regardless of protocol. The usage arithmetic that compaction depends on (previous section) is built exactly on this unification. Protocol normalization isn't tidiness; it's the precondition for the layers above to be *correct*.
+**Breakpoint strategy**: declare cache scope with `cache_control` breakpoints in the request. There's one at the end of the system prompt — because the HTTP body order is tools → system → messages, the tools array sits before the system block and is implicitly included in the cached prefix, needing no breakpoint of its own. On the message side, one breakpoint each goes on the last two messages (two consecutive marks keep the cache anchor straddling the "old tail / new head" boundary). The newest message is never cached — it changes every time.
 
-The second point is more interesting: where to place the breakpoints. octo-agent plants exactly three `cache_control` breakpoints in every Anthropic request:
+## Memory: Three Lifetimes of "Remembering"
 
-```mermaid
-flowchart TB
-    subgraph Req["Request body (fixed order: tools → system → messages)"]
-        T["tool definitions"]
-        S["system prompt"]
-        M1["... earlier history ..."]
-        M2["second-to-last message"]
-        M3["last message"]
-    end
-    S ---|"breakpoint ① static prefix<br/>1h TTL on official endpoint, 5min on gateways"| S
-    M2 ---|"breakpoint ② 5min"| M2
-    M3 ---|"breakpoint ③ 5min"| M3
-```
+What an agent needs to remember spans three different lifecycle scales — the chat context within a session, user preferences across sessions, and retrievable knowledge fragments. Put it all in the system prompt and the window blows up fast; route it all through semantic search and high-frequency preferences get too slow to fetch. Three lifetimes naturally map to three storage and retrieval strategies:
 
-The static prefix (tool definitions + system prompt) needs only one breakpoint — since tools precede system in the request body, a breakpoint on the system block caches the tool definitions along with it. History gets a breakpoint on each of the **last two** messages. Why two? Because the next request appends new messages, so last round's "last message" becomes "N-th from the end"; with a single breakpoint, a retry that drops the trailing message would leave *no* breakpoint anywhere in the common prefix. Two breakpoints guarantee that however the sliding window moves, at least one lands inside the prefix shared with the previous request. Three total, against Anthropic's limit of four — margin left on purpose.
+| memory type | lifetime | storage | retrieval |
+|----------|------|----------|------|
+| session history | session lifetime | `~/.octo/sessions/*.jsonl` | loaded per session |
+| user preferences | cross-session | Markdown files under `~/.octo/memories/` | system-prompt injection (`Reminder`) |
+| semantic recall | cross-session | external memory backends (hindsight / mem0 / agentmemory, optionally self-hosted) | the `memory_recall` tool |
 
+The "user preference" memory deserves a closer look. It does no automatic extraction — the user or the agent triggers saves explicitly via `SaveNudge`. The `Reminder` injection runs on two tracks: entries written in `MEMORY.md` land directly in the system prompt as must-follow rules; topic files show up as only a filename and tags, and the agent reads them itself with `read_file` when needed. Textbook progressive disclosure — not every memory gets crammed into context.
 
+The "semantic recall" layer is likewise a product of restraint: octo ships no built-in vector database, instead handing conversation indexing wholesale to pluggable external backends (hindsight, mem0, or agentmemory — pick one, run the container yourself or use their managed clouds). Extraction and indexing are the backend's own business; octo only asks questions and collects answers. With no backend configured, `memory_recall` simply isn't registered into the tool list — not advertising a tool doomed to fail is more honest than failing after advertising it.
 
+## The Unkillable Host: octo serve's Robustness Design
 
-## Memory: History, Context, and Long-Term Recall
+A war story of my own first. I used to run an agent of OpenClaw's gateway-style architecture through IM: it ran on my machine at home while I was at the office. One day it executed a command that took the gateway process down — and from that moment, the chat window went dead silent. Later, on the subway, all I had was a conversation that would never reply again; there was nothing I could do until I got home and reached a terminal. For an agent that "lives in IM", a dead host process is brain death — and the killer was the agent itself.
 
-The previous three sections each touched a different layer of "what the model sees": tool calls arrive through the dispatcher, old turns get folded by compaction, and prompt-cached prefixes stop re-billing the unchanged parts. But none of them answer the question that holds the rest together: **what survives a session?**
+octo serve doesn't count on the model learning from other people's accidents; it stacks four layers of mechanism.
 
-octo keeps three distinct layers, and the distinction matters.
+**Layer one: the terminal refuses to hand over the knife.** When a serve process starts, it turns on the guard (`internal/tools/server_guard.go`); from then on the terminal tool refuses to execute any kill aimed at the host: `pkill / killall octo` (kill by name), `kill <PID>` (arguments scanned one by one, protecting its own PID and the supervisor's parent PID), `kill $(pgrep octo)` (resolve-then-kill) — all get bounced back with an error that names the correct move: use `restart_server`. Two details worth recording: a parent PID of 1 is not protected (being reparented to init/launchd means there is no supervisor, and a bare "1" would false-positive every command containing the digit); RE2 has no lookbehind, so PID extraction uses `(?:^|[^-\w])(\d+)` to explicitly sidestep — otherwise `kill -9 -1`, a phrase common in commit messages, would be misjudged. The package comment is honest as usual: this is a best-effort textual guard, not a sandbox — it stops the model from **reflexively** killing its host, not from a deliberate jailbreak.
 
-**会话历史 / session history** is the ordered list of user messages and assistant replies for *this* session. It's the single source of truth for "what just happened" and the payload the LLM receives on every turn. It's also the only layer that grows without a built-in ceiling — and the layer compaction fights for headroom.
-
-**上下文 / context** is the finite window actually handed to the model on a turn: the system prompt (env, skills manifest, injected memory) followed by the recent tail of conversation. Context is what compaction *shrinks* (by summarizing the older half of history into a single block), and what prompt *caching* makes cheaper to resend (by byte-stabilizing the prefix). It is per-session, rebuilt every turn, and strictly bounded by the model's context window.
-
-**长期记忆 / long-term memory** is anything that must outlive a single session — durable preferences, project decisions, corrections, the "why" behind a change. Memory is not part of context by default; it is *projected into* context at turn-build time by being injected into the system prompt or prepended to user messages, so it rides along with every turn without being part of the history that compaction can fold away.
-
-The pipeline flows one way: memory feeds context, context frames history, and when history grows too long compaction refolds it into context. Crucially, memory sits *outside* compaction's reach — a fact the agent can recall next session even if every turn from this one has been summarized into a single line.
-
-octo implements that last layer in two layers of its own, and they don't replace each other.
-
-### The Markdown Layer (internal/memory)
-
-Everything the agent remembers for the long term lives in plain markdown files it manages with the same file tools it uses on source code — there is no dedicated remember/forget/memory tool, and no code that reads the agent's intent. The agent itself decides what to keep, what to prune, and when to load a topic file on demand — the same way Claude Code works.
-
-**Layout and scoping.** Memories live in `~/.octo/memories/<repo-slug>/`, where the slug is `Slugify(basename)` plus a 32-bit FNV-1a hash of the full path — two checkouts of a repo named `my-app` don't collide. The repo root is derived from git's *common dir* (not the worktree top-level), so every linked worktree shares one memory scope. Alongside the project scope sits an **inherited home scope** (`~/.../octo-agent-<homehash>/`), for cross-project or personal preferences. On every turn, `memory.RenderInjection` loads both: inherited first (project-agnostic defaults), then project-specific.
-
-**MEMORY.md is the index; topic files hold the detail.** `MEMORY.md` is the small file loaded into the system prompt every session, acting as a pointer index. Anything longer lands in `<topic>.md` files linked from it (e.g. `octo-agent-subagent-lifecycle.md`). The budget is hard-capped: `truncateForInjection` clamps MEMORY.md to 200 lines or 25 UTF-8 kilobytes (whichever is hit first), matching Claude Code's ceiling. When the file overflows, a `⚠ exceeds the injection budget` warning is appended inside the system prompt so the model knows entries are being dropped — not silently surfacing 200 lines and forgetting the rest.
-
-**Rule tiers for action proximity.** Plain index entries are fine for "recall if you think to look," but load-bearing rules need to reach the agent *at the point of action*, not one read_file away. MEMORY.md may carry two optional structured sections parsed by `parseRules`:
-
-- `## 必须遵守` — always-apply rules, restated in full near every turn.
-- `## 触发提醒` — rules that fire only when user input matches a keyword prefix like `(触发: keyword1, keyword2)`.
-
-Rules in both tiers are written *verbatim*, not as pointers. A MEMORY.md with neither section parses to zero rules and the per-turn reminder is silent — the old plain-index style keeps working untouched. `Lint` flags the most common silent failure: a `触发提醒` rule missing its `(触发: …)` clause, which means it can never be recalled.
-
-**Per-turn reminders ride the message stream.** This is the piece most easily misunderstood. `Injector.Reminder(userInput)` runs on `EventUserPromptSubmit` and prepends activated rules as `<system-reminder>` to that turn's outgoing message — injected into history, not into the system prompt. The reason is prompt caching: keeping memory *out* of the system prompt keeps the prompt prefix byte-stable so Go's `markMessagesCacheable` breakpoints survive the protocol-adapter layer. Every turn re-announces the always-apply tier; the triggered tier is latched per text (`recalled map`) so each rule surfaces at most once per session and never spam-returns on every subsequent turn, re-armed on the next user input.
-
-Trigger matching is deliberately conservative: ASCII keywords must match on word boundaries (`deploy` does not fire on `deployment`, "用deploy部署" still matches because CJK bytes count as boundaries), while CJK keywords use substring matching because there are no spaces to anchor on and curated multi-rune phrases rarely collide. The fire direction is also one-way — input contains trigger never reverses — which is what stopped the earlier substring-explosion matcher from lighting up on nearly every message.
-
-**The save-nudge: memory as a follow-up incentive, not a pre-turn gate.** Memory survives best when the agent writes durable context while the moment is still fresh. `SaveNudge` fires on `EventPostToolUse` when the terminal runs `^gh pr (create|merge)` — a milestone that almost certainly means a decision was made. It appends a one-shot `<system-reminder>` telling the agent to record durable decisions, alternatives ruled out, and don't-repeat-this constraints in its memory directory *this turn*, while the diff and git log already hold WHAT changed — memory is for the why. The nudge is rate-limited (`nudged` flag) and re-armed per user turn, so a long session can still catch several milestones without nagging.
-
-### The Semantic Backend (internal/memorybackend, memory_recall)
-
-Plain markdown scales with the agent's own discipline and with how much prose it can hold. The optional semantic backend handles the case markdown can't: large corpora, approximate recall, and server-side extraction the agent would otherwise have to do itself.
-
-`internal/memorybackend` normalizes a swarm of external services (Hindsight, mem0, AgentMemory) behind a single `Backend { Name(); Store(ctx, content); Recall(ctx, query) }` interface. The `memory_recall` tool is advertised only when a backend is configured, and its `Execute` round-trips through `activeMemoryBackend.Recall` to return scored snippets. When the auto-recall flag is on, that same tool also runs as a `EventUserPromptSubmit` hook and folds results into the incoming message — matching the same channel `Injector` uses for MEMORY.md reminders, no new agent-core plumbing needed.
-
-Storing is a background side effect fired on `EventStop`: after each turn it detaches a goroutine (the turn's own context may already be cancelled), joins `User: … / Assistant: …` from the turn payload, strips `<system-reminder>` spans so already-injected context does not land in long-term storage (preventing round-trip recall pollution), and `Store`s with a 10-second decoupled timeout. Errors are swallowed: persistence is best-effort by design.
-
-Storing is fire-and-forget by necessity, not by choice. By the time `EventStop` fires, the turn's context may already be cancelled; the agent gets no tool_result channel to report store failures back through; and a flaky memory service should never break a turn. This is the same "memory must never block the agent" rule that keeps `RenderInjection` truncating instead of erroring when MEMORY.md is bloated.
-
-### How Memory Coexists with Compaction
-
-Because memory is injected into the system prompt / the message stream while compaction only folds the message stream's older turns, the two never trample each other. Compaction reduces history to a summary block; memory re-injected next turn still arrives in full. The index budget (200 lines / 25 KB) is deliberately compact: it is meant to stay under the cacheable prefix's own headroom so that recalling memory doesn't itself force a compaction. And because the summary produced by compaction includes the *effect* of any recalled memory (decisions the agent already acted on), memory can be pared back aggressively — the summary carries the *what*, MEMORY.md carries the *why*.
-
-## /loop: A Command That Doesn't Exist
-
-Users keep asking for things like "check every five minutes whether CI passed." octo-agent's answer is `/loop 5m check CI` — but grep the codebase for the implementation of `/loop` and you'll find the server's command router handles it with `return false`: don't intercept, pass it to the model as an ordinary message.
-
-**`/loop` isn't a command. It's a behavior taught by a tool description.** The thing that actually exists is a tool called `schedule_wakeup`, whose description spells out the convention: if the user's message starts with `/loop` plus a duration, parse the duration and call me with `repeat=true`; if it's `/loop` with no duration, enter dynamic mode and decide the next interval yourself each time you wake. Everything else is left to the model's reading comprehension.
+**Layer two: one front door for restarts, and it always asks you first.** Only two things genuinely need a restart: a replaced binary, or a change to config read only at startup. `restart_server` (`internal/tools/restart.go`) is that one front door, and it is pinned to the ask class, never allow-listable (`internal/permission/defaults.yml`) — every restart needs your personal confirmation: a modal on the web, a reply in IM; one tap on the subway is enough. The tool is only registered in the serve process (CLI/TUI never even see it), and sub-agents inherit the same gate. More importantly, calling it does **not** exit immediately: the server first drains all in-flight turns (30-second hard cap), *including the turn that made the call* — the "I'm about to restart" message is guaranteed to reach you before the process exits.
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant M as Model
-    participant W as schedule_wakeup
-    participant T as time.AfterFunc (in-process timer)
-    participant S as same session
-
-    M->>W: repeat=true, delay=300s (clamped to [60, 3600])
-    W->>T: arm the timer (12-hour hard cap)
-    T-->>S: fires: drop a [LOOP TICK] system reminder into the inbox
-    S->>M: kick one idle turn, the model carries on
-    T->>T: repeat=true → re-arm inside the callback
+    participant M as Model (mid-turn)
+    participant U as User (IM / on the subway)
+    participant W as serve worker
+    participant S as supervisor
+    M->>U: ask confirmation: restart the server?
+    U-->>M: replies "yes"
+    M->>W: restart_server(reason)
+    W->>W: drain in-flight turns (≤30s, incl. this turn)
+    W-->>M: "restart scheduled" + farewell reply delivered
+    W->>S: exits with code 42
+    S->>S: re-resolve binary path, spawn new worker
+    S-->>U: clients reconnect automatically
 ```
 
-What makes this design good is how cleanly it splits three responsibilities: **parsing belongs to the model** (no parser needed for "5m" or "every half hour"), **triggering belongs to Go** (`time.AfterFunc`; on wake, the prompt is wrapped as a system reminder and dropped into the session inbox, reusing the existing pathway for background-task notifications), and **cadence belongs to convention** (in dynamic mode, if the model doesn't re-arm, the loop simply ends — the termination condition is the model's *inaction*, not a state machine).
+**Layer three: the supervisor contract makes "restart" mean "back at full health".** `octo serve` runs as a supervisor/worker pair by default (`cmd/octo/serve_supervisor.go`). After draining, the worker exits with code **42** (`ExitRestart`); the supervisor sees 42 and respawns — re-resolving the binary path on every spawn, so replacing the binary on disk and restarting amounts to an upgrade. The contract is open to the outside: set `OCTO_SERVE_WORKER=1` and an external supervisor takes over respawn (systemd joins the same protocol via `RestartForceExitStatus=42`). Two honest boundaries: when the user hits Ctrl-C, the signal is forwarded and the worker is **not** respawned (the user asked the whole thing to quit — this isn't whack-a-mole); when the worker genuinely crashes, its exit code propagates as-is and it isn't respawned either — the built-in supervisor only handles graceful restarts; crash recovery belongs to systemd, the thing that actually does that for a living. No fake high availability.
 
-The cost is that loops live entirely in process memory: the timers are a map on the `Server` struct, gone on restart, with no state file. That's a deliberate division of labor — periodic tasks that must survive restarts belong to a different subsystem, `internal/scheduler` (real cron, JSON-persisted under `~/.octo/tasks/`); `/loop` serves the session-scoped "keep an eye on this for the next few hours" need, which is why it carries a 12-hour hard cap after which it stops re-arming. As for "won't a long-running loop blow up the history" — every tick is just a normal turn, and the compaction machinery above applies unchanged. Loop needs, and gets, no special treatment.
+**Layer four: most things that "need a restart" need no restart at all.** Hot reload is the preferred path for config changes. After editing channels.yml, `POST /api/channels/{platform}/reload` rebuilds only that one platform's adapter — the channel-manager skill calls it right after writing the config, and you won't feel so much as a tremor in IM. The desktop build has no supervisor, so hot reload is the only path there. The per-turn rebuild of permissions.yml was covered in the permissions chapter — same philosophy: whatever can be hot-swapped is never restarted; whatever must be restarted is never hard-cut.
 
+The four layers add up to the same old line: you can't teach a model "never kill your host", but you can make it unable to; you can't guarantee it remembers the front door every time, but you can make the front door the only way through.
 
+## Workflow: Turing-Complete Orchestration That Can't Touch the System
 
+**The problem**: "Review this diff from correctness, security, and performance angles simultaneously." Having the main model call sub-agents one by one is too slow; making users write Go is too heavy.
 
-## Workflow: Make Orchestration Turing-Complete, but Keep It Away from the System
-
-Concurrent sub-agents are another recurring need: "review this diff from correctness, security, and performance angles simultaneously, then synthesize." Having the main model call sub-agents one by one is slow and expensive; making users write Go is too heavy. octo-agent's answer is a Ruby DSL:
+**The answer**: a Ruby DSL running on the chain mruby (a lightweight embeddable Ruby interpreter) → wasm32-wasi → wazero (a pure-Go wasm runtime):
 
 ```ruby
-findings = parallel(["correctness", "security", "performance"].map { |view|
-  -> { agent("Review this diff from the #{view} angle") }
-})
+findings = parallel(["correctness", "security", "performance"]) { |view|
+  agent("Review this diff from the #{view} angle")
+}
 agent("Synthesize these findings: #{findings.join("\n")}")
 ```
 
-Where does this script run? The answer takes a detour: **an mruby interpreter, compiled to wasm32-wasi, executed by wazero (a pure-Go wasm runtime).** Every layer of the detour has a reason. Turing-complete orchestration (loops, conditionals, retries) demands a real language. Embedding an interpreter without cgo is non-negotiable — cgo destroys Go's "one command, binaries for every platform" cross-compilation, fatal for a project whose selling point is single-file distribution. And the wasm sandbox solves a third problem for free: user scripts physically cannot touch the filesystem or network; their entire capability surface is the handful of functions the host explicitly exports. Even the regex support is a child of this constraint — mruby's official C regex engine won't compile for the wasi target, so `Regexp` is bridged to Go's RE2, with an accidental bonus: RE2 guarantees linear time, so script authors can't write a ReDoS.
+Every layer has its reason:
+- **mruby**: Turing completeness demands a real language
+- **wasm32-wasi**: embed an interpreter without cgo (cgo kills Go's cross-compilation)
+- **wazero**: a pure-Go wasm runtime; one command builds binaries for every platform
 
-The most delicate part is the concurrency model. mruby inside wasm is single-threaded — how does `parallel` actually parallelize? By **two kinds of coroutines shaking hands at the function boundary**: Fibers (cooperative) on the mruby side, goroutines (truly concurrent) on the Go side.
+**Concurrency model**: mruby inside wasm is single-threaded. mruby-side Fibers (cooperative) and Go-side goroutines (true concurrency) shake hands at the function boundary — an `agent()` call is non-blocking: Go starts a goroutine for the LLM call while mruby suspends. `parallel`'s concurrency is fixed at 8 (`defaultWorkflowConcurrency`), so a `parallel` over a large list can't fan out an unbounded number of concurrent LLM calls.
 
-```mermaid
-flowchart TB
-    subgraph mruby["mruby VM (inside wasm, single-threaded)"]
-        F1["Fiber ①: agent('correctness…')"]
-        F2["Fiber ②: agent('security…')"]
-        L["scheduler loop __run_fibers"]
-    end
-    subgraph go["Go host (real concurrency)"]
-        S["agent_start: register token,<br/>immediately go func() the sub-agent"]
-        G1["goroutine ①: LLM call"]
-        G2["goroutine ②: LLM call"]
-        W["agent_wait_any:<br/>select on first completion"]
-    end
-    F1 -->|"non-blocking start"| S
-    F2 -->|"non-blocking start"| S
-    S --> G1
-    S --> G2
-    F1 -.->|"Fiber.yield suspends"| L
-    F2 -.->|"Fiber.yield suspends"| L
-    L -->|wait| W
-    G1 --> W
-    G2 --> W
-    W -->|"first finished token"| L
-    L -->|"resume that Fiber"| F1
-```
+**The journal mechanism**: every `agent()` call's result is recorded under `~/.octo/workflow-journals/`. On a re-run, once the hashes check out, completed calls replay their cached results — if step 8 of a long workflow died, fix one line and re-run without re-paying the LLM bill for the first 7 steps.
 
-An `agent()` call into the host's `agent_start` is non-blocking: the Go side immediately spawns a goroutine for the real LLM call and hands back a token, while the mruby side suspends itself with `Fiber.yield`. The scheduler loop first advances every branch to its first `agent()` call — launching all the goroutines — then repeatedly calls `agent_wait_any` (a Go `select` parked on a completion channel) and resumes whichever Fiber's work finished first. Concurrency is capped at a hardcoded 8; calls beyond the cap queue on a semaphore, so a `parallel` over a large list can't fan out an unbounded number of concurrent LLM turns.
+## The Browser: Never Launch, Only Attach
 
-There's a journal to go with it: every `agent()` result is appended to `~/.octo/workflow-journals/`, and on re-run — after verifying the script+args hash matches — completed calls replay their cached results instead of hitting the LLM again. For a long workflow that died at step 8, fixing one line and re-running doesn't re-pay for the first 7 steps.
+**The counterintuitive design**: octo never launches a browser; it only attaches to the Chrome the user already has open. A self-launched headless instance has no login state, and on macOS it triggers the keychain prompt — for a daily tool, the moment that prompt appears, user trust is gone.
 
+**Record & replay**: what's recorded is not a coordinate sequence (coordinates die the moment the window resizes) but a **semantic event stream** — structured fields like `action / selector / value / verify`. The recording pipeline: inject a listener script into the page to capture click/change/navigation events → generate a selector for each target element (prefer id → data-testid / aria-label → fall back to nth-of-type) → compile and dedupe → parameterize the repeatable inputs → emit structured YAML.
 
+Selectors rot: one frontend redesign turns `.btn-submit` into `.button-primary` and the script breaks. The replay engine's answer has two tiers:
 
+1. **The free tier**: the most common failure is actually a cookie popup covering the target element — auto-dismiss the overlay and retry first
+2. **The LLM tier**: feed the intent, the dead selector, and a digest of every interactable element on the current page to the model, have it answer with only a new selector, swap it in and retry, up to three rounds. Once the fix works and the whole skill run passes, the new selector is **written back to the YAML on disk** — the same redesign never costs you another LLM repair fee
 
-## Browser: Never Launch, Only Attach
+## The Permission System: Admitting It's Just String Matching
 
-The industry-standard move in browser automation is to launch a headless Chrome. octo-agent goes the opposite way: **it never launches a browser; it only attaches to the Chrome the user already has open.** The launch capability exists in the code but the production path never calls it, and the comment is blunt about why: a self-launched headless instance carries no login sessions, and on macOS it trips the "Chrome Safe Storage" keychain prompt — for a daily-driver tool, the moment that dialog appears, the user's trust is gone. When no attachable Chrome is found, the tool returns instructions for enabling the remote-debugging port rather than silently falling back to headless.
+An agent that can execute arbitrary shell commands needs a carefully thought-out security model.
 
-Underneath is a hand-rolled CDP (Chrome DevTools Protocol) client over `gorilla/websocket` — no chromedp. The needed domains (Target/Page/DOM/Runtime/Input/Network and a few more) are a short list; writing them directly turns out thinner than the dependency.
+**First, precedence is independent of declaration order** — it's not "the first matching rule from the top wins", which would make file line order part of the security semantics. The actual implementation buckets matches: hit rules go into deny/ask/allow buckets, and the result is taken by fixed priority. Hardcoded backstop rules (`rm -rf /usr`, `dd if=`, etc.) can't be overridden even by a user-written allow.
 
-The part worth unpacking is **record & replay**. What gets recorded is neither a screen capture nor a coordinate sequence — coordinates die with the next window resize — but a **semantic event stream**:
+**Second, `^` anchoring solves real accidents**: `deny: "format"` was meant to stop disk formatting, but it also stopped `docker ps --format json`; `deny: "shutdown"` stopped `git commit -m "fix shutdown handling"` — the sensitive word appearing inside a commit message. `^` anchors matching to command position (start of line, after a pipe, after `sudo`), leaving arguments and string contents alone.
 
-```mermaid
-flowchart LR
-    A["Inject listener script<br/>(Runtime.addBinding)"] --> B["Capture click / change / navigation"]
-    B --> C["Generate a selector per target<br/>#id → data-testid / aria-label<br/>→ fallback nth-of-type path"]
-    C --> D["Password fields flagged secret,<br/>value never stored"]
-    D --> E["Compile: dedupe + parameterize<br/>into {{param}} placeholders"]
-    E --> F["Artifact: structured YAML<br/>~/.octo/browser-recordings/*.yaml"]
-```
+**Third, hot reload + graceful degradation**: the permission engine is rebuilt every turn, so an edit to `permissions.yml` takes effect on the very next command. A YAML syntax error falls back to the last successfully parsed rules — a briefly broken config file must neither crash the session nor leave it "temporarily undefended" in that window.
 
-Each recorded step compiles into structured fields — `action / selector / value / verify` — with the repeatable inputs (search terms, dates) lifted into parameters: record once, replay many times with arguments.
+**Honesty**: by default there's no OS-level isolation; the shell tool is a bare `exec.Command` and the only line of defense is string rules. Real OS-level isolation is optional depth (macOS Seatbelt, Linux Landlock + seccomp). The package comment says it plainly — string matching can certainly be bypassed; stating the boundary clearly is worth far more than advertising a security model that doesn't exist.
 
-But selectors rot: the frontend ships a redesign, `.btn-submit` becomes `.button-primary`, and the script breaks. The replay engine responds in two tiers. Tier one costs nothing: the most common failure is actually a cookie banner covering the target, so first dismiss the overlay and retry. Tier two is **self-healing**: hand the LLM the step's intent description, the dead selector, and a digest of every interactive element on the current page, and ask for exactly one new selector; swap it in and retry, up to three rounds. If the fix works and the whole skill runs green, the new selector is **written back to the YAML on disk** — the healing is durable, so one redesign doesn't cost you an LLM repair fee on every subsequent replay.
+## The Trash Can: Designed for the Premise "The Model Will Delete the Wrong File"
 
-One axed feature deserves a footnote: early versions tried auto-triggering recorded skills when the user mentioned certain keywords. Too many false triggers in practice; it was removed. Recorded skills now fire in exactly two ways — an explicit Replay button in the Web UI, or the model explicitly invoking `replay` in conversation. The design doc keeps the record of that failure — knowing what was tried and abandoned is sometimes worth more than knowing what exists.
+**The premise**: the model **will** delete the wrong file. Not "might" — sooner or later. The right question isn't "how do we prevent bad deletes" but "what happens after one".
 
-
-
-
-## Permissions: Admitting It's Just String Matching
-
-An agent that can run arbitrary shell commands needs its security model thought all the way through. octo-agent's permission system has three designs worth telling, and one piece of honesty worth respecting.
-
-**First, precedence is independent of declaration order.** The verdict is not "first matching rule from the top wins" — that would make the line order of a config file part of the security semantics, where reshuffling lines can open a hole. The actual implementation buckets: walk every rule, drop the hits into deny/ask/allow buckets, then read out in fixed precedence — a non-empty deny bucket means denied, regardless of whether an allow was written above or below it. The hardcoded backstop rules (catastrophes like `^rm -rf /usr`, `^dd if=`) ride the same mechanism, so no user-written allow can override them.
-
-**Second, the `^` anchor exists because of real incidents.** Matching is substring-based at its core, and bare substrings over-block: `deny: "format"` was meant to stop disk formatting but also blocked `docker ps --format json`; `deny: "shutdown"` blocked `git commit -m "fix shutdown handling"` — the sensitive word merely appeared inside a commit message. The `^` prefix anchors the match to **command position**: start of line, after `&&`/`;`/`|`, after `sudo` or environment-variable prefixes. `^format` matches format being *executed as a command*, never as an argument or string content. This feature wasn't designed in the abstract; it was forced into existence by those two false positives.
-
-**Third, hot reload plus graceful degradation.** The permission engine is rebuilt every turn, so an edit to `permissions.yml` takes effect on the very next command, no restart. What if the YAML is mid-edit and syntactically broken? Fall back to the last successfully parsed rules (`lastGoodRules`) and log a warning — a briefly broken config file must neither crash the session nor leave it *temporarily unguarded* during that window.
-
-Then the honesty. **By default, octo-agent has no OS-level isolation whatsoever**: without `--sandbox`, the shell tool is a bare `exec.Command("sh", "-c", ...)`, and the only line of defense is the string rules above. Real OS-level isolation is opt-in depth: Seatbelt on macOS, Landlock + seccomp on Linux (inet sockets banned outright), unsupported elsewhere — and if `--sandbox` is requested on an unsupported platform, it refuses to run (fail closed) rather than silently degrading. The package comment in `internal/sandbox` characterizes the relationship precisely: the sandbox is "defense-in-depth *beneath* the permission engine, which only gates command strings." String matching can of course be bypassed — stating the boundary plainly is worth far more than advertising a security model that doesn't exist.
-
-The companion audit log records every deny and every user verdict (one JSON per line, 10 MiB rotation). One detail inside: every field is truncated at 1 KiB. Not to save disk — to prevent a single rejected `write_file` from copying an entire file's contents, or a command containing a secret, verbatim into the audit log. The audit log must not become a new leak surface.
-
-
-
-
-## Trash Can: Designed for the Premise "the Model Will Delete the Wrong File"
-
-The last mechanism is the humblest, and the clearest window into the project's worldview. The premise is simple: the model **will** delete the wrong file. Not might — eventually will. So the right question isn't "how do we prevent wrong deletions" but "what happens after one."
-
-octo-agent's answer is to turn every destructive operation from irreversible into reversible — with broader coverage than you'd guess:
+Coverage is wider than you'd think:
 
 ```mermaid
 flowchart TD
-    A["rm in the shell<br/>(injected __octo_safe_rm backs up first)"] --> T
-    B["Remove-Item on Windows<br/>(cmdlet shadowed by a wrapper)"] --> T
-    C["write_file / edit_file overwriting an existing file<br/>(old version backed up first)"] --> T
-    D["programmatic deletion<br/>session / skill / workflow / memory"] --> T
-    T["~/.octo/trash/&lt;project hash&gt;/<br/>&lt;timestamp&gt;_&lt;random&gt;_&lt;filename&gt; + .meta.json"]
-    T --> R["octo trash restore<br/>(by ID or fuzzy path match)"]
-    T --> E["background cleanup: 14-day expiry<br/>+ size cap, oldest evicted first"]
+    A["rm in shell (injected __octo_safe_rm cp -al's to trash first)"] --> T
+    B["write_file / edit_file overwriting an existing file<br/>old version backed up first"] --> T
+    C["programmatic deletes of session / skill / workflow / memory"] --> T
+    T["~/.octo/trash/<project hash>/<br/><timestamp>_<random>_<filename> + .meta.json"]
+    T --> R["octo trash restore<br/>fuzzy match by ID or path"]
+    T --> E["background sweep: 14-day expiry + size cap"]
 ```
 
-The `rm` interception works by injecting a same-named function into the shell environment; before the real delete, the target is moved into the trash via `cp -al` (hard links, nearly zero cost). On Windows the `Remove-Item` cmdlet is shadowed to run the same flow. Even the model *editing* files is covered — `write_file` overwriting an existing file sends the old version to the trash first.
+One small judgment call that shows craft: **if the target file is tracked by git and the working tree is clean, skip the backup**. git already has the content; storing another copy in the trash is pure waste. A good safety net doesn't just catch — it stays quiet.
 
-One judgment call in the overwrite backup shows real craft: **if the target file is git-tracked and the working tree is clean, skip the backup.** Git already has that content; a second copy in the trash is pure waste. One `git ls-files` plus two `git diff --quiet` calls cut the trash noise dramatically — a good safety net must not only catch, it must stay quiet, or users will switch the whole thing off.
+## Batteries Included: Keeping Users Through the First Five Minutes
 
-Recovery goes through `octo trash restore`, matching by ID or fuzzy path. If the destination is now occupied, three policies apply: abort with an error (default), move the occupant into the trash too and then restore, or restore under a timestamped new name. Each project's trash is isolated by a hash of the project path; it's purely local, with 14-day expiry and a size cap enforced by background cleanup, so it never grows without bound.
+The previous nine are "hard problems", but the genuinely hard part of building an agent is **the first five minutes**. If a user has to install ripgrep or dig through MCP repos before their first question, they're likely gone for good.
 
+- **MCP tool search**: don't cram full JSON schemas into the prompt; expose only a name and a one-line description. When the model actually wants to use one, it pulls the schema via `mcp_describe`. `auto` mode only kicks in when lazy-loading saves ≥ 10% of the context over uploading everything.
+- **Two bundled binaries**: ripgrep is compiled into the binary (`go:embed`) so users don't install anything; the Python openpyxl dependency is solved by bundling uv.
+- **Five meta-skills** (`skill-creator`, `mcp-creator`, `channel-manager`, `cron-task-creator`, `workflow-creator`) that handle octo's own configuration — walking users through flows that would otherwise be handwritten YAML. They rely on the file tools (`write_file`, `edit_file`, `terminal`) plus octo-specific knowledge, rather than a bespoke tool per YAML file — the "tools are composable" principle applies to user workflows and to octo's own onboarding alike.
 
+## Closing
 
+Ten mechanisms, each minding its own business — and together, one judgment: **whatever a mechanism can guarantee, never leave to the model's self-discipline.**
 
-## Batteries Included: Discoverability, Meta-Skills, and a Gentler Default
+Compaction rests on token thresholds and safe split points, not prayers that the summary loses nothing; cache breakpoints are inserted explicitly, not left to luck; serve makes sure the model can't kill its own host, and even a restart asks you first and delivers its reply before going down; workflow's concurrency cap is a constant, not the script author's self-restraint; the permission system's deny-first and command anchoring each correspond to a real accident; and the trash can simply assumes bad deletes are inevitable and spends its effort on "after".
 
-The seven sections above were the "hard parts" — places where a wrong design bleeds context tokens or loses a file. But the genuinely hardest part of shipping an agent isn't the hard parts; it's the first five minutes. If the user has to `apt install` ripgrep before the first search, or hunt down an MCP registry before asking a single question, they leave. octo answers that with three layers of "it just works" — all of which happen to be the same principles (defer what you can, surface what matters, degrade gracefully) applied to the onboarding path.
-
-### MCP Tool Search: The Lazy Registry
-
-Standard MCP wiring has a hidden tax: every tool's full JSON schema gets pushed into the system prompt on every turn. Connect three MCP servers with forty tools between them and you've spent a thousand tokens on the user just to learn *what exists before asking anything*. octo's answer (`internal/tools/tool_search.go`) is to defer the heavy half.
-
-Two bridge tools, `mcp_describe` and `mcp_call`, replace the full upload. Each MCP tool's **name and one-line description** ride along in the system prompt the same way `skills.RenderManifest` surfaces `# Available skills` — so the model can answer "is there a tool for X?" in zero round trips. `mcp_describe` pulls one schema on demand (when the model actually wants to use the tool), and `mcp_call` invokes it — routing straight into the existing `executeMCP` path, so all the `mcp__`-prefix dispatch, permission, and hook machinery runs against the real tool name unchanged.
-
-The mode selector (`auto` / `on` / `off`) is the same instinct as elsewhere: `auto` activates the bridge only when deferred schemas would occupy at least 10% of the context window. Below that, the simpler full-upload path wins; above it, the search mechanism keeps the prompt from drowning in schemas it won't use this turn.
-
-### Two Binaries You Don't Have to Install
-
-**ripgrep.** `internal/tools/rgembed` ships a platform-matched ripgrep binary *inside* the octo binary: the Makefile downloads the BurntSushi/ripgrep release for the build platform, and `go:embed` bakes it in when the `embedrg` tag is set. At runtime, if `rg` is already on `PATH`, that one's used; otherwise the embedded copy is extracted to `~/.octo/bin/rg-<version>`. The `grep` tool gets a fast, consistent search backend with zero user action.
-
-**uv.** `office-xlsx` depends on Python's openpyxl, and openpyxl needs a Python runner. Rather than ask the user to manage that, the macOS and Windows installer packages bundle uv directly. The tradeoff is straightforward: macOS grows ~100MB so the user never sees "install Python" on their first spreadsheet task. It bundles *uv* and not *bun* — uv is a single static binary that resolves dependencies; bun is a full JavaScript runtime for a power-user skill that most people don't need.
-
-### Windows Knows When to Suggest an Upgrade
-
-There's a playful bit of craft in the Windows installer (`packaging/windows/octo.iss`): it runs an `EnsurePowerShell7` check at the end. If `pwsh` isn't on PATH but `winget` is, it asks the user — once, bilingual — whether to install PowerShell 7. Why? octo runs hook scripts and the terminal tool through `pwsh` (7+) when it's present and falls back to the always-there Windows PowerShell 5.1 when it isn't. The 7 path is a better default (faster, predictable `~/.bashrc`-style profile, real `&&` semantics). Every skip-failure path is a silent no-op: if anything goes wrong, octo just keeps using 5.1. The user is prompted, never blocked.
-
-### Five Meta-Skills: octo Learns to Extend Itself
-
-A skill is usually a snippet the model can invoke — but a handful of shipped skills are *about* octo's own setup. They talk the user through configuration that would otherwise require hand-editing YAML, and they lean on agent memory so the conversation carries across sessions.
-
-| Skill | Job |
-|---|---|
-| `skill-creator` | Scaffold a new skill, edit an existing one, or capture a workflow as a skill. |
-| `mcp-creator` | Discover an MCP server package, build the `~/.octo/mcp.json` entry, verify the connection — guided, no manual JSON. |
-| `channel-manager` | Walk the user through each IM platform's console, collect credentials, write `~/.octo/channels.yml`, diagnose connection failures. |
-| `cron-task-creator` | Create, inspect, enable, and delete scheduled agent prompts stored in `~/.octo/tasks/`. |
-| `workflow-creator` | Capture a repeatable multi-step task and turn it into a saved, resumable Ruby (mruby) workflow. |
-
-One thing worth noting: `channel-manager`, `mcp-creator`, `cron-task-creator`, and `workflow-creator` all lean on the file tools (`write_file`, `edit_file`, `terminal`) as much as they do on octo-specific knowledge. That's a deliberate choice — it means a meta-skill doesn't need a bespoke tool for every piece of YAML it writes. The same "tools are composable" principle that powers user workflows powers octo's own onboarding.
-
-
-
-
-## Coda: One Worldview Throughout
-
-Each of the ten mechanisms minds its own patch; together they express a single judgment: **in an agent system, whatever a mechanism can guarantee, never leave to the model's good behavior.**
-
-Compaction relies on token thresholds and safe split points, not on praying the summary loses nothing. Cache breakpoints are placed explicitly, not left to luck. Loop has a 12-hour hard cap to catch a model that forgets to stop. Workflow's concurrency cap is a constant, not a hope that script authors show restraint. Every rule in the permission system — deny precedence, command anchoring — maps to an incident that actually happened. And the trash can simply assumes wrong deletions are inevitable and spends its effort on the *after*.
-
-The model supplies the intelligence; the mechanisms supply the floor. If one sentence is worth taking away from this codebase, it's that.
+The model does the clever; the mechanism does the floor. That's probably the one line most worth taking away from this codebase.
 
 ---
 
-### Appendix: Where to Start Reading the Code
+### Appendix: Code Entry Points
 
-| Mechanism | Entry file |
-|---|---|
+| mechanism | entry files |
+|------|----------|
 | Agent loop | `internal/agent/agent.go` |
-| Built-in tool contract | `internal/tools/registry.go` (allTools), `internal/agent/tool.go` |
-| Memory (markdown) | `internal/memory/memory.go` (RenderInjection), `internal/memory/injector.go` (Injector.Reminder / SaveNudge), `internal/memory/rules.go` (parseRules) |
-| Memory (semantic) | `internal/memorybackend/backend.go`, `internal/tools/memory_backend.go` (memory_recall) |
 | Context compaction | `internal/agent/compaction.go` |
-| Prompt cache breakpoints | `internal/provider/anthropic/client.go` (`markMessagesCacheable`) |
-| Protocol token normalization | `internal/provider/openai/types.go` (`nonCachedInput`) |
-| /loop | `internal/tools/schedule_wakeup.go`, `internal/server/loop.go` |
-| Workflow runtime | `internal/workflow/runtime.go`, `internal/workflow/prelude.rb` |
-| Browser record / self-heal | `internal/browser/recorder.go`, `internal/app/browser_heal.go` |
-| Permission verdicts | `internal/permission/permission.go` (`classify` / `Check`) |
+| Prompt-cache breakpoints | `internal/provider/anthropic/client.go` |
+| Protocol token normalization | `internal/provider/openai/types.go` |
+| Memory (Markdown) | `internal/memory/memory.go` |
+| Memory (semantic) | `internal/memorybackend/backend.go` |
+| serve self-kill guard | `internal/tools/server_guard.go` |
+| Graceful restart / supervisor | `internal/tools/restart.go`, `internal/server/restart.go`, `cmd/octo/serve_supervisor.go` |
+| Workflow runtime | `internal/workflow/runtime.go` |
+| Browser record/self-heal | `internal/browser/recorder.go` |
+| Permission decisions | `internal/permission/permission.go` |
 | OS-level sandbox | `internal/sandbox/` |
 | Trash can | `internal/trash/trash.go` |
 | MCP tool search | `internal/tools/tool_search.go` |
-| Meta-skills | `internal/skills/defaults/{skill-creator,mcp-creator,channel-manager,cron-task-creator,workflow-creator}/SKILL.md` |
+| Meta-skills | `internal/skills/defaults/` |
 | Read-before-write guard | `internal/tools/read_tracker.go` |
-| web_fetch SSRF defenses | `internal/tools/web_fetch.go` (`secureFetchTransport` / `directFetchHTTPClient`) |
-| web_search backends | `internal/tools/web_search.go` |
-| terminal background manager | `internal/tools/background.go` |
-| Sub-agent lifecycle | `internal/tools/agent.go`, `internal/tools/subagent_manager.go` |
+| web_fetch SSRF defense | `internal/tools/web_fetch.go` |
+| web_search tiered backends | `internal/tools/web_search.go` |
+| sub_agent lifecycle | `internal/tools/agent.go` |

--- a/blog/src/content/posts/zh/architecture-deep-dive.md
+++ b/blog/src/content/posts/zh/architecture-deep-dive.md
@@ -1,18 +1,31 @@
 ---
-title: "octo-agent 深度解析：一个 Agent 系统里真正难的部分"
-description: "从五层单向依赖讲起，拆解 octo-agent 跨全栈的十个核心机制——地基、内置 tool 契约、上下文压缩、prompt 缓存、记忆（历史/上下文/长期召回）、loop、workflow 编排、浏览器、权限管控、回收站、自带电池式入门引导——以及每一项背后的取舍。"
+title: "octo-agent 深度解析：一个 AI Agent 系统里真正难的事情"
+description: "从只有几百行的 agent 循环讲起，拆解 octo-agent 的十个机制——内置 tool 契约、上下文压缩、prompt 缓存、三种寿命的记忆、serve 的坚固性设计、workflow 编排、浏览器自愈、权限管控、回收站、自带电池——以及贯穿始终的一条线：凡是能用机制保证的，就不要指望模型的自觉。"
 pubDate: 2026-07-08
-updatedDate: 2026-07-18
+updatedDate: 2026-07-19
 author: "octo-agent team"
 tags: ["architecture", "deep-dive", "engineering", "ai-agent"]
 locale: zh
 originalSlug: architecture-deep-dive
 ---
 
-# octo-agent 深度解析：一个 Agent 系统里真正难的部分
-## 一切的地基：agent 循环必须保持无知
+# octo-agent 深度解析：一个 AI Agent 系统里真正难的事情
 
-先看整体。octo-agent 的核心其实就是一个 while 循环：把历史发给模型，模型要么给出回答（循环结束），要么要求调用工具；执行工具，把结果追加进历史，回到开头。
+## 开篇：一句"帮我查一下"背后发生了什么
+
+当你在终端输入 `octo "查一下生产环境的错误率"`，到它返回答案之间，发生了什么？
+
+消息穿过 TUI、Headless、IM 桥接或 Web 界面中的任意一个入口，被装进一个事件结构，路由到 Agent 循环。循环把全部历史发给 LLM，LLM 要么回答要么要求调工具。如果是调工具，执行结果追加到历史，循环继续。
+
+这个循环本身只有几百行代码。但围绕它运转起来的十个机制，每一个都对应一个真实的设计难题——不解决它们，Agent 就跑不稳、跑不快、跑不省。
+
+本文梳理这些机制：它们解决什么、怎么解决的、以及为什么那么做。读完你会看到一条贯穿始终的线：**在 Agent 系统里，凡是能用机制保证的，就不要指望模型的自觉。**
+
+## 地基：Agent 循环为什么可以只有几百行
+
+**Agent 循环只有几百行，不是因为它功能少，而是因为它只认识两个接口（`Sender` + `ToolExecutor`），是整棵依赖树的叶子包。** 它不拼 JSON、不懂 HTTP、不知道 Anthropic 和 OpenAI 的协议差异——这些全部隔离在 adapter 层。
+
+先把全景画出来。octo-agent 的核心就是一个 while 循环：
 
 ```mermaid
 flowchart TB
@@ -48,7 +61,7 @@ flowchart TB
     style 核心 fill:#1a202c,color:#fff
 ```
 
-这个循环本身只有几百行，围绕它的一切复杂性都被一条纪律挡在外面：**`internal/agent` 是整棵依赖树的叶子包**，它不 import `provider`、不 import `tools`、不 import 任何 UI。它对外只认识两个接口——`Sender`（把消息发出去，拿回一个抽象回复）和 `ToolExecutor`（按名字执行一个工具，拿回一段文本）。
+核心纪律一条：**`internal/agent` 是整棵依赖树的叶子包**，它不 import `provider`、不 import `tools`、不 import 任何 UI。它对外只认识两个接口——`Sender`（把消息发出去，拿回一个抽象回复）和 `ToolExecutor`（按名字执行一个工具，拿回一段文本）。
 
 这条纪律的价值在细节里才看得出来。Anthropic 的 API 说"模型想调工具"时用的字段是 `stop_reason: "tool_use"`，OpenAI 用的是 `finish_reason: "tool_calls"`；OpenAI 流式响应里工具参数是拆成 JSON 碎片跨多个 chunk 传的，得按 index 拼好才能解析；有些第三方 OpenAI 兼容服务连 `[DONE]` 哨兵都不发。这些怪癖每一个都足以在核心循环里埋一个 `if provider == "openai"`——而一旦开了这个头，第三个 provider 接入时循环就没法看了。octo-agent 的做法是把它们全部锁死在 `internal/provider/anthropic` 和 `internal/provider/openai` 两个适配器包里，agent 循环永远只见到归一化之后的统一语义。
 
@@ -77,42 +90,40 @@ sequenceDiagram
 
 地基讲完了。接下来是重头戏：这个循环运转起来之后，那些真正难的问题。
 
+## 内置工具：接口收拢，边缘锋利
 
+Terminal、browser、workflow、MCP——这些工具的调用方式、参数格式、生命周期完全不同。如果让 Agent 循环感知这些差异，每加一种工具就要改核心循环代码。这不是架构，是堆砌。
 
-## 内置工具设计：接口收拢，边缘锋利
-
-每个内置 tool 实现的都是同一个两方法契约（`Definition() ToolDefinition` + `Execute(ctx, name, input) (ToolResult, error)`），由 `tools.DefaultRegistry` 发现和按名派发，穿过 agent 循环执行。共享表面本身就是目的：agent core 永远不按 tool 物种分支，meta-skill 自由重组它们，browser / workflow / MCP 都走同一根窄管道。结构是简单的，设计张力全在边缘。
+**octo 的解法：锁死一根管道。** 每个内置 tool 实现同一个两方法契约（`Definition() ToolDefinition` + `Execute(ctx, name, input) (ToolResult, error)`），由 `tools.DefaultRegistry` 发现和按名派发，穿过 agent 循环执行。共享表面本身就是目的：agent core 永远不按 tool 物种分支，meta-skill 自由重组它们，browser / workflow / MCP 都走同一根窄管道。结构是简单的，设计张力全在边缘。
 
 ### 跨协议边界的流式 fragment
 
-一条更隐蔽的设计守则住在 provider adapter 里，不在 tool 里：**OpenAI 协议的 tool-call 参数会按 `tool_calls[i].index` 分散在多个 chunk 里流式下发**——把同一个 index 的所有 fragment 拼接后再解析。Anthropic 风格端点不会。代码库强制执行的准则是：agent 循环（`internal/agent/agent.go`）绝不按收到的是哪种断面来分支，归一化发生在 provider adapter。同一个"fragment 进、完整 tool call 出"契约，是 browser / workflow / MCP 层在 Anthropic 和 OpenAI 协议间可移植的唯一办法，不会让每一层都长出 `if provider == …` 分叉。
+OpenAI 协议的 tool-call 参数会按 `tool_calls[i].index` 分散在多个 chunk 里流式下发——把同一个 index 的所有 fragment 拼接后再解析。Anthropic 风格端点不会。代码库强制执行的准则是：agent 循环（`internal/agent/agent.go`）绝不按收到的是哪种断面来分支，归一化发生在 provider adapter。同一个"fragment 进、完整 tool call 出"契约，是 browser / workflow / MCP 层在 Anthropic 和 OpenAI 协议间可移植的唯一办法，不会让每一层都长出 `if provider == …` 分叉。
 
 ### 一个注册表，多种物种
 
-`tools.DefaultRegistry`（`internal/tools/registry.go`）是一个单一派发器，按名把任意 tool call 路由到 `allTools` slice 的某一格 —— `Terminal`、`ReadFile`、`WriteFile`、`EditFile`、`Glob`、`Grep`、`WebFetch`、`WebSearch`、`Skill`、`Agent*`、`Workflow*`、`ScheduleWakeup`、`Browser`、`MemoryRecall` 等等。（这里没有把 `TerminalOutput`/`TerminalInput` 列进去，因为它们是 background 配套的子工具，不直接由用户发起。）"浏览器: internal/browser""workflow: Ruby/mruby""MCP: 一个 JSON-RPC 桥"——但 agent 循环只看到 `ToolExecutor`。`mcp_describe` / `mcp_call` 后来加入时也没动 agent core；它们和每个其它 tool 一样通过注册表那一条缝进来。
-
-正是这个选择让上一节的 meta-skill 成为可能：一段引导你"配好 IM 通道"的流程不是一个定制 tool，是 `channel-manager` 把 `read_file` / `write_file` / `terminal` 按用户当下的情况串起来。tool 组合是那个可复用原语；新能力通常意味着新 skill，不是新 tool。
+`tools.DefaultRegistry`（`internal/tools/registry.go`）是一个单一派发器，按名把任意 tool call 路由到 `allTools` slice 的某一格——`Terminal`、`ReadFile`、`WriteFile`、`EditFile`、`Glob`、`Grep`、`WebFetch`、`WebSearch`、`Skill`、`Agent*`、`Workflow*`、`ScheduleWakeup`、`Browser`、`MemoryRecall` 等等。（这里没有把 `TerminalOutput`/`TerminalInput` 列进去，因为它们是 background 配套的子工具，不直接由用户发起。）浏览器背后是 `internal/browser` 的 CDP 长连接，workflow 背后是 Ruby/mruby 沙箱，MCP 背后是一个 JSON-RPC 桥——但 agent 循环只看到 `ToolExecutor`。正是这个选择让 meta-skill 成为可能：一段引导你"配好 IM 通道"的流程不是一个定制 tool，是 `channel-manager` 把 `read_file` / `write_file` / `terminal` 按用户当下的情况串起来。tool 组合是那个可复用原语；新能力通常意味着新 skill，不是新 tool。
 
 ### 读取先行 + mTime 守卫
 
-`internal/tools/ReadTracker` 管的是一个听起来像挑剔、却能拦住一类真问题的规矩：LLM 只能在*已经读取过的*文件上写入 / 编辑，且只在磁盘 mtime 仍与读取时一致时才放行。第 3 轮读的文件在第 7 轮被外部编辑器改过 -> 拒绝，并告知 agent 重读——这个错误语料照搬 Claude Code 的措辞，已经被那样训练过的 LLM 在重试时会做出正确反应。
+`internal/tools/ReadTracker` 管的是一个听起来像挑剔、却能拦住一类真问题的规矩：LLM 只能在**已经读取过的**文件上写入 / 编辑，且只在磁盘 mtime（修改时间戳）仍与读取时一致才放行。第 3 轮读的文件在第 7 轮被外部编辑器改过 -> 拒绝，并告知 agent 重读——这个错误语料照搬 Claude Code 的措辞，已经被那样训练过的 LLM 在重试时会做出正确反应。
 
-最后那句"只在 mtime 一致时"引出了引导问题：会话*自己的*输出（通过 terminal 跑的 formatter、重定向）mtime 也会变，难道下次编辑就该被挡？答案是 `RefreshTarget`：terminal 工具写过的路径补盖一个新 mtime 戳，这之后编辑不再误发告警。`RefreshTarget` 只重新戳记 tracker 已经登记过的*精确*路径，绝不扩散到兄弟文件，也绝不把一个没读过的文件提拔成可写。从未读过的文件依旧不可写；真被外部编辑器改过的文件（永远不流经 terminal tool，永远不作为这次命令的精确写目标）保持其陈旧戳记，照发告警。守卫接住真正的错误，逃生口窄到没法滥用出沙箱。
+靠一个外部文件的 mtime 做守卫本质上是很苛刻的——但如果是 agent 自己执行的命令改了这个文件怎么办？一轮编译输出、代码格式重写、等等都会改 mtime。答案是 `RefreshTarget`：terminal 工具写过的路径补盖一个新 mtime 戳，这之后编辑不再误发告警。`RefreshTarget` 只重新戳记 tracker 已经登记过的**精确**路径，绝不扩散到兄弟文件，也绝不把一个没读过的文件提拔成可写。从未读过的文件依旧不可写；真被外部编辑器改过的文件（永远不流经 terminal tool，永远不作为这次命令的精确写目标）保持其陈旧戳记，照发告警。守卫接住真正的错误，逃生口窄到没法滥用出沙箱。
 
 ### 抽掉 SSRF 的地板
 
-`web_fetch` 不能直接 `http.Get(userURL)`——那是教科书级的 SSRF。它的回应（`internal/tools/web_fetch.go`）把请求拆成*两条加固路径*，共享同一个 `secureFetchTransport`：
+`web_fetch` 不能直接 `http.Get(userURL)`——那是教科书级的 SSRF（Server-Side Request Forgery，服务端请求伪造）。它的回应（`internal/tools/web_fetch.go`）把请求拆成**两条加固路径**，共享同一个 `secureFetchTransport`：
 
-- **Jina 代理路径**——把渲染交给 `r.jina.ai`，但拒绝*跨主机*重定向（离开 `r.jina.ai` 的重定向意味着被弹到意外的地方），在解析后 IP 是链路本地地址/云元数据时直接断连接。调用方传入自定义 header 时强制走直接请求（Jina 的出站 header 不可控，无法执行覆盖）。
-- **直接请求路径**——处理任意 URL 所必须，因此*必须*跟随跨主机重定向（URL 短链、`www` 规范化跳转都正常）。共享链路本地封禁，并把重定向链上限设为 10 跳，避免环让 agent 挂起。
+- **Jina 代理路径**——把渲染交给 `r.jina.ai`（Jina AI 的网页内容解析服务），但拒绝**跨主机**重定向（离开 `r.jina.ai` 的重定向意味着被弹到意外的地方），在解析后 IP 是链路本地地址/云元数据时直接断连接。调用方传入自定义 header 时强制走直接请求（Jina 的出站 header 不可控，无法执行覆盖）。
+- **直接请求路径**——处理任意 URL 所必须，因此**必须**跟随跨主机重定向（URL 短链、`www` 规范化跳转都正常）。共享链路本地封禁，并把重定向链上限设为 10 跳，避免环让 agent 挂起。
 
-`net.Dialer.Control` 钩子在 DNS 解析*之后*拿到真实 IP 时触发，所以 DNS 重绑定（一个主机名此刻解析成公网 IP，下一刻就解析成 `169.254.x.x` / `127.0.0.1`）也被拦下。身体也有边界：`WebFetchInlineBytes`（64 KB）是内联阈值；`WebFetchMaxBytes`（5 MB）是硬上限；超出就截断落盘到临时文件。大页面 = 摘要 + 头尾预览 + 指一条 `read_file` 路径给剩余部分，绝不一墙文字糊进模型的 context。
+`net.Dialer.Control` 钩子在 DNS 解析**之后**拿到真实 IP 时触发，所以 DNS 重绑定（一个主机名此刻解析成公网 IP，下一刻就解析成 `169.254.x.x` / `127.0.0.1`）也被拦下。身体也有边界：`WebFetchInlineBytes`（64 KB）是内联阈值；`WebFetchMaxBytes`（5 MB）是硬上限；超出就截断落盘到临时文件。大页面 = 摘要 + 头尾预览 + 指一条 `read_file` 路径给剩余部分，绝不一墙文字糊进模型的 context。
 
 ### 五个搜索面，一份契约
 
 `web_search` 在线上看起来简单（返回 title/url/snippet），背后是五条后端的瀑布回退（`internal/tools/web_search.go`）：**Brave → Tavily → Serper → DuckDuckGo HTML → Bing HTML**。前三个在对应 env key（`BRAVE_SEARCH_API_KEY` / `TAVILY_API_KEY` / `SERPER_API_KEY`）出现时启用；后两个不需要 key，是默认路径。每个失败都吞进响应的 `Error` 字段、继续试下一条——tool 从不 panic，真正产出结果的层级会回到 `Provider` 字段里，让模型知道它看的是查索引（Brave）还是抓 HTML（DDG/Bing）。
 
-有两个细节真值钱：其一是 **DuckDuckGo 冷却**（`markDDGUnavailable`，10 分钟），挡住一串 token goroutine 在 DDG 刚返回空的时候继续锤——用 `sync.RWMutex` 守着，因为 Web 服务器让并发搜索成了日常。其二是 **Bing HTML 端点上的地雷**：如果你发 `Accept-Encoding: gzip`，Bing 会回一个 ~39 KB 的 JavaScript 骨架页，而不是 ~120 KB 的真正结果页。修复是这一条古怪规则"永远不要让 Go 对 `cn.bing.com` 自动协商编码"——`browserGet` 故意省略那个 header。
+有两个细节真值钱：其一是 **DuckDuckGo 冷却**（`markDDGUnavailable`，10 分钟），挡住一串 goroutine 在 DDG 刚返回空的时候继续锤它——用 `sync.RWMutex` 守着，因为 Web 服务器让并发搜索成了日常。其二是 **Bing HTML 端点上的地雷**：如果你发 `Accept-Encoding: gzip`，Bing 会回一个 ~39 KB 的 JavaScript 骨架页，而不是 ~120 KB 的真正结果页。修复是这一条古怪规则"永远不要让 Go 对 `cn.bing.com` 自动协商编码"——`browserGet` 故意省略那个 header。
 
 ### terminal：时效、反轮询、反引号求生
 
@@ -128,15 +139,13 @@ sequenceDiagram
 
 ### sub_agent：能 fork，不能递归
 
-`sub_agent` 工具表面看就是派活 + 等结果，设计张力藏在它*不许*做的事里。最醒目的规则在 `AgentTool.Execute`（`internal/tools/agent.go`）：如果调用方已经是 sub-agent，直接失败——"a sub-agent cannot spawn another sub-agent"。绝对禁止递归。配合 `tools` allowlist 里故意不列入 `sub_agent` 自身，这是一道硬的天花板，不是 workflow 那种图灵完备的任意派生——设计意图就是"只有一层委派"，不搞 agent 树。
+`sub_agent` 工具表面看就是派活 + 等结果，设计张力藏在它**不许**做的事里。最醒目的规则在 `AgentTool.Execute`（`internal/tools/agent.go`）：如果调用方已经是 sub-agent，直接失败——"a sub-agent cannot spawn another sub-agent"。绝对禁止递归。配合 `tools` allowlist 里故意不列入 `sub_agent` 自身，这是一道硬的天花板，不是 workflow 那种图灵完备的任意派生——设计意图就是"只有一层委派"，不搞 agent 树。
 
-**fork vs. fresh**（`subagent_type`）：省略 `subagent_type` 时，用*父的完整对话*（system prompt + 截至目前的消息）作为子 agent 的种子——真正的 fork，共享上下文、走同样的 conclusion-shaped 回复契约。设定 subagent_type（`explore`、`plan`、`general`、`code-review`）则从零上下文起一个带专用 persona 的子 agent，走 read-only / lean-context 默认值、带自己的 `model` frontmatter。同一把 tool 覆盖两种；preset 填充调用方没覆盖的字段。
+**fork vs. fresh**（`subagent_type`）：省略 `subagent_type` 时，用**父的完整对话**（system prompt + 截至目前的消息）作为子 agent 的种子——真正的 fork，共享上下文、走同样的 conclusion-shaped 回复契约。设定 subagent_type（`explore`、`plan`、`general`、`code-review`）则从零上下文起一个带专用 persona 的子 agent，走 read-only / lean-context 默认值、带自己的 `model` frontmatter。同一把 tool 覆盖两种；preset 填充调用方没覆盖的字段。
 
-**同步 vs. 异步**：`run_in_background: true` 调 `SubAgentManager.Start`，立刻返回 `agent_N` ID 并在完成后推通知；`false`（默认）调 `RunSync`，阻塞这个 turn 等结果。信号量（`syncSem`）Concurrent 同步 sub-agent 的上限，避免一波 fan-out 把父 agent 饿死。按 transport 自适应：同步通道（server / IM）没有 follow-up-turn 路径，`mgr.Synchronous()` 静默强制走阻塞路径并告知模型——而不是悄悄失败。
+**同步 vs. 异步**：`run_in_background: true` 调 `SubAgentManager.Start`，立刻返回 `agent_N` ID 并在完成后推通知；`false`（默认）调 `RunSync`，阻塞这个 turn 等结果。信号量（`syncSem`）控制同步 sub-agent 的上限，避免一波 fan-out 把父 agent 饿死。按 transport 自适应：同步通道（server / IM）没有 follow-up-turn 路径，`mgr.Synchronous()` 静默强制走阻塞路径并告知模型——而不是悄悄失败。
 
 子 agent 撞到 turn 上限时，结果会带上显式的 `[INCOMPLETE: … partial]` 标记返回，而不是把半成品当成品交差。父 agent 要么用更细的任务重启，要么把它当未完成处理。每种 `StopReason`（`end_turn`、`tool_use`、`max_turns`、`error`、`killed`）都会上送到 WS broadcast，前端状态面板无需轮询就能更新。
-
-
 
 ## 上下文压缩：不能删消息，只能折叠时间
 
@@ -158,310 +167,176 @@ flowchart LR
 
 **第一，切分点永远安全。** `safeSplitIndexByBudget`（`internal/agent/compaction.go`）只会在"不含任何 tool_result 的纯 user 消息"处下刀，从结构上保证 tool_use/tool_result 配对永远不会被劈开。这也让压缩可以发生在 turn 进行中——一个长 turn 每跑完一批工具调用就检查一次占用，超了立刻折叠更早的完整轮次，正在进行的调用毫发无伤。对于动辄几十次工具调用的 agent 长任务，"turn 中途能压缩"不是锦上添花，是必需品。
 
-**第二，占用的算法反直觉。** 上下文占用不是 `input_tokens` 报多少算多少——命中 prompt 缓存时 Anthropic 的 `input_tokens` 只是未命中的差量，真实占用得把 `cache_read + cache_write` 加回来（`agent.go` 的 `accrueUsage`）。不这么算的话，缓存命中率越高，压缩越不触发，最后一次缓存 miss 直接把窗口打爆。
+**第二，占用的算法反直觉。** 上下文占用不是 `input_tokens` 报多少算多少——命中 prompt 缓存时 Anthropic 的 `input_tokens` 只是未命中的差量，真实占用得把 `cache_read` 加回来（`agent.go` 的 `accrueUsage`）。举个例子：窗口 100K，会话前几轮都命中缓存，Anthropic 报 `input_tokens: 20K`（差量），真实占用是 20K + 80K cache_read = 100K。压缩器看到 20K → 只占 20% → 不触发压缩。下一轮缓存 miss 时 80K 原文 + 20K 新内容直接撞到 100K 阈值。**不加回 cache_read，压缩永远不会在命中率高的时候正确触发——而 miss 的那一轮恰恰最需要压缩。**
 
 **第三，压缩有阻尼。** 触发阈值默认 75%（可配 `compact_auto_pct`），保留预算是窗口的 30%，另有一条反抖动规则：这次折叠能省下的比例不足 15% 就干脆不折——否则临界状态下每一轮都要付一次昂贵的摘要调用。
 
 一个值得知道的坑：**落盘的 `session.jsonl` 存的是压缩后的历史**。compaction 走的是整体重建历史，会触发 session 文件全量重写，原文只有在配置了 `ArchiveDir` 时才会归档成 `chunk-*.md`（摘要末尾会附上文件路径，模型需要时可以自己用 read 工具翻回去），否则永久丢失。另外历史变短会导致 Web 前端持有的 `message_index`（编辑/分支功能依赖它）集体失效，服务端用水位线检测到长度回缩后会强制前端重拉整个 transcript——这类"压缩的涟漪效应"是这套机制里返工最多的部分。
 
+## Prompt 缓存：Agent 的账单是二次方的
 
+**问题**：Agent 循环每一轮都要重发全部历史。一个 N 轮的会话，第一条消息要被计费 N 次。不做缓存，成本随对话长度**平方增长**。
 
-## Prompt 缓存：agent 的账单是二次方的
+Prompt 缓存的原理很简单：如果这次请求和上次请求有相同的前缀，命中部分按一折计费。麻烦在于不同协议对命中的报法完全不同。
 
-第二个问题是钱。Agent 循环的每一轮都要重发全部历史，也就是说一个 N 轮的会话，第 1 条消息要被计费 N 次——不做缓存，成本随对话长度平方增长。
+| 协议 | 缓存命中字段 | input_tokens 的语义 |
+|------|-------------|---------------------|
+| Anthropic | `cache_read_input_tokens` | 只报未命中差量，命中单独计 |
+| OpenAI | `prompt_tokens_details.cached_tokens` | 报全部输入，命中是其子集 |
+| DeepSeek | `prompt_cache_hit/miss_tokens` | 显式拆两个桶 |
 
-Prompt 缓存的原理一句话就能说完：如果这次请求和上次请求有相同的前缀，命中部分按一折左右计费。麻烦在于两点：不同协议对"命中了多少"的报法完全不同；以及 Anthropic 协议需要你**主动声明**缓存到哪里。
+octo 的解法：在 OpenAI 适配器里做一次减法（`nonCachedInput`），把 OpenAI 系的报数也转成"互不重叠的两个桶"。从此 agent 层的 `InputTokens` 和 `CacheReadTokens` 在所有协议下含义一致——上一节压缩机制依赖的占用计算，正是建立在这个统一之上。
 
-先看第一点。这是自建网关接入时最容易翻车的地方：
+**断点策略**：在请求里打 `cache_control` 断点来声明缓存范围。system prompt 末尾有一个断点——因为 HTTP 请求体顺序是 tools → system → messages，tools 数组在 system block 之前被隐式包含在缓存前缀中，不需要独立断点。消息部分则在最后两条消息上各打一个断点（两个连续标记确保缓存锚跨过"旧尾/新头"边界）。最晚的消息不缓存——它每次都在变。
 
-| 协议 | 缓存命中字段 | `input`/`prompt` tokens 的语义 |
-|---|---|---|
-| Anthropic | `cache_read_input_tokens` | **只是未命中的差量**，命中部分单独计 |
-| OpenAI | `prompt_tokens_details.cached_tokens` | **全部输入**，命中部分是其子集 |
-| DeepSeek | `prompt_cache_hit/miss_tokens` | 显式拆开两个桶 |
+## 记忆：三种不同寿命的"记住"
 
-同一个语义，三种报法。octo-agent 在 openai 适配器里做一次减法（`nonCachedInput()`，`internal/provider/openai/types.go`），把 OpenAI 系的报数也转成"互不重叠的两个桶"，从此 agent 层的 `InputTokens` 和 `CacheReadTokens` 在所有协议下含义一致——上一节压缩机制依赖的占用计算，正是建立在这个统一之上。协议归一化不是洁癖，是让上层逻辑能写对的前提。
+Agent 需要记住的信息横跨三个不同的生命周期尺度——会话内的聊天上下文、跨会话的用户偏好、可检索的知识片段。如果全放 system prompt，上下文窗口很快撑爆；如果全走语义搜索，高频的偏好每次拉取又太慢。三种寿命自然对应三种存储和检索策略：
 
-第二点更有意思：断点打在哪。octo-agent 在每个 Anthropic 请求里固定打三个 `cache_control` 断点：
+| 记忆类型 | 寿命 | 存储方式 | 检索 |
+|----------|------|----------|------|
+| 会话历史 | 会话生命周期 | `~/.octo/sessions/*.jsonl` | 按 session 加载 |
+| 用户偏好 | 跨会话 | `~/.octo/memories/` Markdown 文件 | system prompt 注入（`Reminder`） |
+| 语义召回 | 跨会话 | 外部记忆后端（hindsight / mem0 / agentmemory，自托管可选） | `memory_recall` 工具 |
 
-```mermaid
-flowchart TB
-    subgraph Req["请求体（顺序固定：tools → system → messages）"]
-        T["工具定义"]
-        S["system prompt"]
-        M1["……更早的历史……"]
-        M2["倒数第二条消息"]
-        M3["最后一条消息"]
-    end
-    S ---|"断点① 静态前缀<br/>官方端点 1h TTL，第三方网关 5min"| S
-    M2 ---|"断点② 5min"| M2
-    M3 ---|"断点③ 5min"| M3
-```
+其中「用户偏好记忆」值得展开。它不作自动提取——用户或 agent 通过 `SaveNudge` 显式触发保存。`Reminder` 注入的内容分两条线：写在 `MEMORY.md` 里的条目作为"必须遵守"的规则直接写入 system prompt；写在话题文件里的内容只展示文件名和标签，agent 需要时自己用 `read_file` 去读。这是典型的渐进式披露——不让所有记忆都塞进上下文。
 
-静态前缀（工具定义 + system prompt）只需要一个断点——因为请求体顺序是 tools 在 system 之前，打在 system 上的断点会连带把工具定义一起缓存住。历史消息则在**最后两条**上各打一个。为什么是两个？因为下一轮请求会追加新消息，上一轮的"最后一条"就变成了"倒数第 N 条"；如果只打一个断点，遇到重试丢弃末条消息的情况，公共前缀上就没有任何断点可命中了。双断点保证滑动窗口无论怎么移动，总有一个断点落在两次请求的公共前缀内。三个断点，Anthropic 的限额是四个，留了余量。
+「语义召回」一层同样是克制的产物：octo 不内置向量数据库，而是把对话索引整体交给可插拔的外部记忆后端（hindsight、mem0、agentmemory 三选一，自己跑容器或用它们的托管云服务），提取和索引都是后端自己的事，octo 只负责发问和收答案。没配置后端时 `memory_recall` 干脆不注册进工具列表——不暴露一个必然失败的工具，比暴露之后再报错诚实。
 
+## 杀不死的宿主：octo serve 的坚固性设计
 
+先讲一个我自己的事故。早先通过 IM 用 OpenClaw 那类 gateway 架构的 agent：它在家里的机器上跑，我在公司。一次它执行命令时把 gateway 进程搞挂了——从那一刻起，聊天窗口那头就是一片死寂。我人后来在地铁上，手里只有一个再也收不到回复的对话，什么都做不了，直到回家摸到终端才把它拉起来。对一个"活在 IM 里"的 agent 来说，宿主进程死掉就是脑死亡，而杀死它的恰恰是它自己。
 
-## 记忆：历史、上下文与长期记忆
+octo serve 没有指望模型吸取别人的教训，而是叠了四层机制。
 
-前面三节各自讲了「模型看到什么」的一面：工具怎么经统一调度器抵达、旧对话怎么被压缩、怎么缓存一段不变的 prompt 前缀避免反复计费。但始终没有回答撑起其余一切的那个问题：**会话关掉之后，还留下什么？**
+**第一层：terminal 拒绝递刀。** serve 进程启动时打开守卫（`internal/tools/server_guard.go`），此后 terminal 工具拒绝执行一切指向宿主的 kill：`pkill / killall octo`（按名杀）、`kill <PID>`（逐个扫描参数，保护自身 PID 和 supervisor 的父 PID）、`kill $(pgrep octo)`（先解析再杀）都会被一个错误顶回来，错误信息里写着正确姿势——用 `restart_server`。两个细节值得记：父 PID 为 1 时不保护（被 init/launchd 收养意味着没有 supervisor，而裸数字 "1" 会误伤一切含 1 的命令）；RE2 没有后行断言，PID 提取用 `(?:^|[^-\w])(\d+)` 显式绕开，否则 `kill -9 -1` 这种常出现在 commit message 里的文本也会被误判。包注释同样诚实：这是 best-effort 的文本守卫，不是沙箱——防的是模型**反射性地**杀掉宿主，不是防蓄意越狱。
 
-octo 把记忆拆成三层，这三层不能混。
-
-**会话历史 / session history** 是本次会话里用户消息和助手回答的有序列表。它是「刚刚发生什么」的唯一真相，也是每轮都发给模型的负载。它还是唯一一层没有天然天花板的——压缩机制（compaction）正是替它抢空间。
-
-**上下文 / context** 是每轮实际递给模型的那扇有限窗口：系统 prompt（环境、技能清单、注入的记忆）在前，对话尾巴在后。上下文是压缩机制「折叠」的那一层（把对话靠后的一半总结成一段），也是 prompt 缓存「省 TOKEN」的那一层（把前缀字节稳定住，避免重算）。上下文是每轮重建、严格受模型窗口限制的。
-
-**长期记忆 / long-term记忆** 是任何必须活得比单次会话更久的东西——持久偏好、项目决策、被纠正的错、某次改动背后的「为什么」。记忆默认不是上下文的一部分；它在每轮构造时被「投射进」上下文：或注入系统 prompt，或挂在用户消息头部跟随发送，这样每轮记忆都到场，却不在压缩机制能折叠的那段历史里。
-
-数据流向是单向的：记忆灌进上下文，上下文框住历史，历史太长时压缩机制把旧的一半折回上下文。最关键的一点——记忆位于压缩机制的触及范围之外：即便本会话每一轮都被压缩成一行摘要，下一次会话记忆依然能原样召回。
-
-记忆层 octo 自己又拆成两层，二者不替代。
-
-### 用 Markdown 承载的长时记忆（internal/memory）
-
-代理为长期记忆写的每一条东西，都以纯 Markdown 文件和它操作源码时完全一样的文件工具维护——没有专用的 `remember` / `forget` / `memory` 工具，也没有任何代码「读」代理意图后再决定写什么。代理自己决定保留什么、删节什么、按需加载哪个话题文件。这是 Claude Code 同款记忆模型。
-
-**目录与命名空间。** 记忆存在 `~/.octo/memories/<repo-slug>/`，其中 slug = `Slugify(目录 basename)` + 路径的 32 位 FNV-1a 哈希——两个同名仓库 `my-app` 的记忆不会碰撞。仓库根目录取 git 的 *common dir*（而不是 worktree 自己的顶层），于是同一仓库所有链接 worktree 共享一处记忆。项目记忆旁边还有一处**继承自 home 的全局记忆**（`~/.../octo-agent-<homehash>/`），放跨项目或个人偏好。`memory.RenderInjection` 每一轮都注入两堆：先注入继承的（项目无关的默认值），再注入项目专属的。
-
-**MEMORY.md 是指针索引，话题文件承担细节。** `MEMORY.md` 是每轮载入系统 prompt 的小文件，作用是指针索引；更长的内容落在 `<话题>.md` 文件里（例如 `octo-agent-subagent-lifecycle.md`）。注入有硬上限：`truncateForInjection` 将 MEMORY.md 截到「200 行或 25 UTF-8 KB」两者中的先撞到者——上限照搬 Claude Code。文件溢出时，`⚠ exceeds the injection budget` 警告会直接贴在系统 prompt 里，模型就能读到「条目被截掉了，不是没写」而不是错把前 200 行当完整记忆。
-
-**让规则在动作发生的地点就位。** 指针索引够「想起来再翻」的场景用，但「不可跳过的规则」需要在动作发生地就进入模型视野，而不是多走一步 read_file。MEMORY.md 可以带两个可选的结构化小节，由 `parseRules` 解析：
-
-- `## 必须遵守` —— 每轮都在场、完整复述的规则。
-- `## 触发提醒` —— 只有当用户输入命中 `(触发: keyword1, keyword2)` 这类前缀时才召回的规则。
-
-两个小节里的规则必须**完整写出**，不允许写指针。没有这两个小节的 MEMORY.md 解析出零条规则，每轮提醒静默退出——旧式的纯索引风格照样能用。`Lint` 会标记最常见的「静默失败」：`触发提醒` 下的规则漏写了 `(触发: …)` 子句，等于永远无法被召回。
-
-**每轮提醒走的是消息流。** 这是最容易被误解的点。`Injector.Reminder(userInput)` 挂在 `EventUserPromptSubmit` 上，把命中的规则以 `<system-reminder>` 形式拼到当轮 outgoing 消息的头部——注入的是历史，而不是系统 prompt。原因在于 prompt 缓存：把记忆保持在系统 prompt 之外，前缀字节才能稳定，Go 侧的 `markMessagesCacheable` 断点才能跨协议适配器存活。每轮复述 `必须遵守` 层；`触发提醒` 层按 `recalled map` 锁文本，每条规则每会话至多召回一次，后续轮次不会反复出现，被下个用户输入重新激活。
-
-触发匹配是故意保守的：ASCII 关键字必须按词边界命中（`deploy` 不会触发 `deployment`，「用deploy部署」里的「deploy」仍算命中，因为 CJK 字节被当作边界），CJK 关键字走纯子串匹配（没有空格可锚，且精心挑选的多字词组不易撞）。匹配方向也是单向的——只检查 input 包含 trigger，不反过来——这正是早期那个爆炸式匹配器的解法。
-
-**保存诱导：记忆作为「趁热写」激励，而不是预检查门槛。** 记忆最容易留下来的是：趁事件还没凉，就诱导代理把「决定性的东西」写进记忆目录。`SaveNudge` 挂在 `EventPostToolUse`，当终端跑 `^gh pr (create|merge)` 这类里程碑命令时触发——此刻几乎一定有决策被做出。它附带一次性 `<system-reminder>` 告诉代理：趁现在把「持久决策、被排除的方案、以后不许再犯的坑」写进记忆目录；diff 和 git log 已经记住了 WHAT（改了啥），记忆应该记 WHY。诱导频率受 `nudged` 标志限制，并在每个用户输入重新激活，于是长会话可以抓住好几个里程碑，又不至于喋喋不休。
-
-### 语义后端（internal/memorybackend, memory_recall）
-
-纯 Markdown 随代理自身纪律和它能容纳的篇幅一起伸缩。可选的语义后端负责 Markdown 处理不了的场景：大体量语料、近似召回、以及代理自己不该做的服务端抽取。
-
-`internal/memorybackend` 用同一个 `Backend { Name(); Store(ctx, content); Recall(ctx, query) }` 接口归拢外部服务（Hindsight、mem0、AgentMemory）。`memory_recall` 工具只在后端被配置时才出现在 schema 里，经 `activeMemoryBackend.Recall` 返回带分的片段。自动召回模式开启时，同一个工具也作为 `EventUserPromptSubmit` 用户输入挂载，把搜索结果折进进来的消息——复用 `Injector` 给 MEMORY.md 提醒用的同一通道，不用改 agent 核心。
-
-存储是挂在 `EventStop` 上的一个后台副作用：每轮结束，分出一个 goroutine（此时 turn 自己的 context 可能已取消），把 turn 里的 `User: … / Assistant: …` 拼成一段、剥掉 `<system-reminder>` span（避免已注入的内容又被存进长期记忆——防止反复召回污染）、带着 10 秒独立超时 `Store`。错误全部吞掉：持久化是 best-effort。
-
-存储是「触发后不管」出于无奈而非偏好。`EventStop` 触发时 turn context 可能已失效，代理再没有 tool_result 通道把存失败传回来；不稳定的记忆服务绝不应该打断当轮。这和 `RenderInjection` 按上限截断而不是在 MEMORY.md 膨胀时崩溃，遵循的是同一条原则：记忆绝不阻塞代理。
-
-### 记忆与压缩如何共存
-
-记忆注入系统 prompt / 消息流，压缩机制只折叠消息流里的旧回合——于是二者互不踩脚。压缩机制把历史压成一段摘要；下一轮注入的记忆依然完整到场。索引预算（200 行 / 25 KB）是刻意做小的：目标就是趴在缓存前缀自己的头部空间之下，让“召回记忆”这件事本身不至于触发新一轮压缩。又因为压缩产出的摘要已经包含任何召回记忆所产生的“影响”（代理已执行的决策），记忆可以被大胆裁节——摘要负责「做了什么」，MEMORY.md 负责「为什么」。
-
-## /loop：一个不存在的命令
-
-用户经常提这样的需求："每五分钟看一眼 CI 过没过。" octo-agent 的答案是 `/loop 5m 看一眼CI`——但如果你去代码里 grep `/loop` 的实现，会发现服务端命令路由对它的处理是 `return false`：不拦截，当成普通消息发给模型。
-
-**`/loop` 不是命令，是一个工具描述"教"出来的行为。** 真正存在的是一个叫 `schedule_wakeup` 的工具，它的 description 里写明了约定：用户消息以 `/loop + 时长` 开头，就解析时长、带 `repeat=true` 调用我；只有 `/loop` 没有时长，就进入动态模式，每次醒来自己决定下一次隔多久。剩下的交给模型的理解能力。
+**第二层：重启只有一扇正门，而且永远先问过你。** 真正需要重启的只有两种事：换了二进制、改了只在启动时读的配置。`restart_server`（`internal/tools/restart.go`）就是那扇正门，它被钉死在 ask 档、不可加白名单（`internal/permission/defaults.yml`）——每次重启都要你亲口确认：Web 上弹一个模态框，IM 里就是回一条消息，地铁上点一下"同意"即可。工具只在 serve 进程里注册（CLI/TUI 根本看不见它），sub-agent 继承同一道闸门。更关键的是调用之后**不立即退**：server 先 drain 所有在途 turn（30 秒硬顶），包括发起调用的这个 turn 自己——"我要重启了"这句话一定先送到你手上，进程才退出。
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant M as 模型
-    participant W as schedule_wakeup
-    participant T as time.AfterFunc（进程内定时器）
-    participant S as 同一个 session
-
-    M->>W: repeat=true, delay=300s（clamp 到 [60, 3600]）
-    W->>T: 武装定时器（12 小时硬顶）
-    T-->>S: 到点：投一条 [LOOP TICK] 系统提醒进收件箱
-    S->>M: 踢一次 idle turn，模型继续干活
-    T->>T: repeat=true → 回调里自动重新武装
+    participant M as 模型（turn 进行中）
+    participant U as 用户（IM / 地铁上）
+    participant W as serve worker
+    participant S as supervisor
+    M->>U: ask 确认：请求重启 server
+    U-->>M: 回复"同意"
+    M->>W: restart_server(reason)
+    W->>W: drain 在途 turn（≤30s，含当前 turn）
+    W-->>M: "重启已排期" + 告别回复送达
+    W->>S: 以退出码 42 退出
+    S->>S: 重新解析二进制路径，spawn 新 worker
+    S-->>U: 客户端自动重连
 ```
 
-这个设计好在把三层职责切干净了：**解析归模型**（"5m"还是"每半小时"都不用写 parser），**触发归 Go**（`time.AfterFunc`，唤醒时把 prompt 包成一条系统提醒投进 session 收件箱，复用后台任务通知的现成通路），**节奏归约定**（动态模式下模型不续期，循环自然结束——终止条件是模型的一个"不作为"，而非一段状态机代码）。
+**第三层：supervisor 契约，让重启等于满血复活。** `octo serve` 默认跑 supervisor/worker 双进程（`cmd/octo/serve_supervisor.go`）。worker 排水完毕以退出码 **42**（`ExitRestart`）退出，supervisor 看到 42 就重新 spawn——每次 spawn 重新解析一次二进制路径，所以先在磁盘上换新二进制再重启，顺手就完成了升级。契约对外开放：设 `OCTO_SERVE_WORKER=1` 就把 respawn 交给外部 supervisor（systemd 用 `RestartForceExitStatus=42` 接同一个协议）。两个诚实的边界：用户按 Ctrl-C 时信号被转发且**不再** respawn（要的是整体退出，不是打地鼠）；worker 真正崩溃时退出码原样上抛、同样不复活——内建 supervisor 只管优雅重启，崩溃恢复交给 systemd 那种真干这行的，不假装高可用。
 
-代价是 loop 完全活在进程内存里：定时器就是 `Server` 结构体里的一个 map，进程重启即消失，也没有状态文件。这是刻意的分工——需要跨重启存活的定期任务归另一个子系统 `internal/scheduler`（真 cron，JSON 持久化在 `~/.octo/tasks/`）；`/loop` 只服务"接下来几个小时盯着点"这种会话级需求，所以它有 12 小时硬顶，到点就不再续。至于"长跑会不会把历史撑爆"——每个 tick 就是一次普通 turn，上文的压缩机制照常生效，loop 不需要也没有任何特殊处理。
+**第四层：多数"要重启"的事，根本不用重启。** 配置变更的首选路径是热加载。channels.yml 改完，`POST /api/channels/{platform}/reload` 只重建那一个平台的 adapter，channel-manager skill 写完配置顺手就调它——你在 IM 里连抖动都感觉不到。桌面版没有 supervisor，热加载就是唯一路径。permissions.yml 的每-turn 重建在权限一章讲过——同一个哲学：能热换的绝不重启，非重启不可的绝不硬切。
 
+四层合起来还是那句老话：你教不会模型"永远别 kill 宿主"，但可以让它 kill 不动；你保证不了它次次记得走正门，但可以让正门成为唯一通路。
 
+## Workflow：图灵完备的编排，但别让它碰系统
 
-## Workflow：让编排图灵完备，但别让它碰系统
+**问题**："对这个 diff 同时跑正确性、安全、性能三个视角的审查。"让主模型逐个调子 Agent 太慢，让用户写 Go 又太重。
 
-子 agent 并发是另一类需求："对这个 diff 同时跑正确性、安全、性能三个视角的审查，最后汇总。"让主模型挨个调用子 agent 太慢也太贵，让用户写 Go 又太重。octo-agent 给的答案是一个 Ruby DSL：
+**答案**：一个 Ruby DSL，跑在 mruby（轻量级嵌入式 Ruby 解释器）→ wasm32-wasi → wazero（纯 Go wasm runtime）的链路上：
 
 ```ruby
-findings = parallel(["正确性", "安全", "性能"].map { |view|
-  -> { agent("从#{view}视角审查这个 diff") }
-})
+findings = parallel(["正确性", "安全", "性能"]) { |view|
+  agent("从#{view}视角审查这个 diff")
+}
 agent("汇总以下发现：#{findings.join("\n")}")
 ```
 
-这个脚本跑在哪？答案有点绕：**mruby 解释器，编译成 wasm32-wasi，跑在 wazero（纯 Go 的 wasm runtime）里**。绕出来的每一层都有理由。要图灵完备的编排（循环、条件、重试）就需要真语言；要嵌入解释器又不想引入 cgo——cgo 会毁掉 Go 交叉编译"一条命令出全平台二进制"的能力，对一个以单文件分发为卖点的项目是致命的；而 wasm 沙箱顺手解决了第三个问题：用户脚本天然碰不到文件系统和网络，能力只有宿主显式导出的那几个函数。连正则都是这个约束的产物——mruby 官方 C 正则引擎编译不了 wasi target，于是 Regexp 被桥接到 Go 侧的 RE2 实现，意外的红利是 RE2 保证线性时间，脚本作者写不出 ReDoS。
+每一层都有理由：
+- **mruby**：要图灵完备就需要真语言
+- **wasm32-wasi**：嵌入解释器但不引入 cgo（cgo 毁掉 Go 交叉编译能力）
+- **wazero**：纯 Go wasm runtime，一条命令出全平台二进制
 
-最精巧的是并发模型。wasm 里的 mruby 是单线程的，`parallel` 怎么真正并行？答案是**两种协程在函数边界上握手**：mruby 侧用 Fiber（协作式），Go 侧用 goroutine（真并发）。
+**并发模型**：wasm 里的 mruby 是单线程的。mruby 侧的 Fiber（协作式）和 Go 侧的 goroutine（真并发）在函数边界上握手——`agent()` 调用是非阻塞的，Go 侧起 goroutine 跑 LLM，mruby 侧挂起等待。`parallel` 的并发上限固定为 8（`defaultWorkflowConcurrency`），防止一个 `parallel` 遍历大列表时扇出无界数量的并发 LLM 调用。
 
-```mermaid
-flowchart TB
-    subgraph mruby["mruby VM（wasm 内，单线程）"]
-        F1["Fiber①: agent('正确性…')"]
-        F2["Fiber②: agent('安全…')"]
-        L["调度循环 __run_fibers"]
-    end
-    subgraph go["Go 宿主（真并发）"]
-        S["agent_start：登记 token<br/>立刻 go func() 发起子 agent"]
-        G1["goroutine①: LLM 调用"]
-        G2["goroutine②: LLM 调用"]
-        W["agent_wait_any：<br/>select 等最先完成的"]
-    end
-    F1 -->|"非阻塞启动"| S
-    F2 -->|"非阻塞启动"| S
-    S --> G1
-    S --> G2
-    F1 -.->|"Fiber.yield 挂起"| L
-    F2 -.->|"Fiber.yield 挂起"| L
-    L -->|等待| W
-    G1 --> W
-    G2 --> W
-    W -->|"最先完成的 token"| L
-    L -->|"resume 对应 Fiber"| F1
-```
-
-`agent()` 调用宿主的 `agent_start` 是非阻塞的：Go 侧立刻起 goroutine 去跑真正的 LLM 调用并返回一个 token，mruby 侧则 `Fiber.yield` 把自己挂起。调度循环先把所有分支都推进到各自第一次 `agent()` 调用——即先把所有 goroutine 都发射出去——然后循环调 `agent_wait_any`（Go 侧一个 `select` 挡在完成 channel 上），谁先完成就 resume 谁的 Fiber。并发上限硬编码为 8，超出的调用在信号量上排队，防止一个 `parallel` 遍历大列表时扇出无界数量的并发 LLM 调用。
-
-配套还有一套 journal 机制：每个 `agent()` 调用的结果都追加记录到 `~/.octo/workflow-journals/`，重跑时校验"脚本+参数"哈希一致后，已完成的调用直接回放缓存结果。对于"跑到第 8 步挂了"的长工作流，改一行重跑不用重付前 7 步的 LLM 账单。
-
-
+**Journal 机制**：每个 `agent()` 调用的结果记录到 `~/.octo/workflow-journals/`。重跑时校验哈希一致后，已完成的调用直接回放缓存结果——跑到第 8 步挂了，改一行重跑不用重付前 7 步的 LLM 账单。
 
 ## 浏览器：不启动，只连接
 
-浏览器自动化领域的标准做法是启动一个 headless Chrome。octo-agent 反其道而行：**它永远不启动浏览器，只连接（attach）用户已经开着的那个 Chrome**。代码里留了 launch 能力，但生产路径一次都没调用过，注释写得很直白：自己启动的 headless 实例没有任何登录态，在 macOS 上还会触发"Chrome Safe Storage"的钥匙串弹窗——对一个日常工具来说，这个弹窗一出现，用户的信任就没了。找不到可连的 Chrome 时，工具返回的是一份开启远程调试端口的操作指引，而不是悄悄退回 headless。
+**反常的设计**：octo 永远不启动浏览器，只连接用户已经开着的 Chrome。自己启动的 headless 实例没有登录态，在 macOS 上还会触发钥匙串弹窗——对一个日常工具来说，这个弹窗一出现用户的信任就没了。
 
-底层是基于 `gorilla/websocket` 自研的 CDP（Chrome DevTools Protocol）客户端，没有引 chromedp——需要的 domain（Target/Page/DOM/Runtime/Input/Network 等）就那么几个，自己写反而薄。
+**录制回放**：录下来的不是坐标序列（坐标换窗口尺寸就废），而是**语义化的事件流**——`action / selector / value / verify` 这样的结构化字段。录制流程：页面注入监听脚本捕获 click/change/导航事件 → 为目标元素生成选择器（优先 id → data-testid / aria-label → 兜底 nth-of-type）→ 编译去重 → 参数化可重复输入的部分 → 输出结构化 YAML。
 
-真正值得展开的是**录制回放**。录下来的既不是录屏也不是坐标序列——坐标换个窗口尺寸就废——而是**语义化的事件流**：
+选择器会腐烂：前端一改版，`.btn-submit` 变成 `.button-primary`，脚本就断了。回放引擎的应对分两层：
 
-```mermaid
-flowchart LR
-    A["页面注入监听脚本<br/>（Runtime.addBinding）"] --> B["捕获 click / change / 导航"]
-    B --> C["为目标元素生成选择器<br/>#id → data-testid / aria-label<br/>→ 兜底 nth-of-type 路径"]
-    C --> D["密码字段标记 secret<br/>不落原值"]
-    D --> E["编译：去重 + 参数化为<br/>{{param}} 占位符"]
-    E --> F["产物：结构化 YAML<br/>~/.octo/browser-recordings/*.yaml"]
-```
-
-每一步录制都被编译成 `action / selector / value / verify` 这样的结构化字段，可重复输入的部分（搜索词、日期）被抽成参数——一次录制，多次带参重放。
-
-但选择器会腐烂：前端一改版，`.btn-submit` 变成 `.button-primary`，脚本就断了。回放引擎的应对分两层。第一层不花钱：最常见的失败原因其实是 cookie 弹窗挡住了目标元素，先自动关掉遮罩重试。第二层才是**自愈**：把这一步的意图描述、失效的旧选择器、当前页面全部可交互元素的摘要一起交给 LLM，让它只回答一个新选择器，换上重试，最多三轮。修复成功且整个技能跑通后，新选择器**写回磁盘上的 YAML**——自愈的成果是持久的，同一个改版不会让你每次重放都付一次 LLM 修复费。
-
-一个被砍掉的特性也值得记一笔：早期版本尝试过"用户说到某个关键词就自动触发录制好的技能"，实践中误触发太多，已经移除。现在录制好的技能只有两种触发方式：Web UI 里显式点重放，或模型在对话中显式调用 `replay`。设计文档里保留了这次失败的记录——知道什么被试过并放弃，有时比知道什么存在更有价值。
-
-
+1. **免费层**：最常见的失败原因其实是 cookie 弹窗挡住了目标元素，先自动关掉遮罩重试
+2. **LLM 层**：把意图、失效选择器、当前页面全部可交互元素的摘要一起喂给模型，让它只回答一个新选择器，换上重试，最多三轮。修复成功且整个技能跑通后，新选择器**写回磁盘上的 YAML**——同一个改版不会每次重放都付一次 LLM 修复费
 
 ## 权限系统：承认自己只是字符串匹配
 
-一个能执行任意 shell 命令的 agent，安全模型必须想清楚。octo-agent 的权限系统有三个值得讲的设计，和一条值得尊敬的诚实。
+Agent 能执行任意 shell 命令，安全模型必须想清楚。
 
-**第一，优先级与声明顺序无关。** 判定不是"从上往下第一条命中的规则说了算"——那会让规则文件的行序变成安全语义的一部分，改个顺序就可能打开一个洞。实际实现是分桶：遍历所有规则，命中的按 deny/ask/allow 分别入桶，然后按固定优先级取结果——deny 桶非空即拒绝，无视 allow 写在它前面还是后面。硬编码的兜底规则（`^rm -rf /usr`、`^dd if=` 这类灾难命令）也走同一套机制，用户在配置里写 allow 也压不过。
+**第一，优先级与声明顺序无关**——不是"从上往下第一条命中的规则说了算"，那会让文件行序变成安全语义的一部分。实际是分桶：命中规则按 deny/ask/allow 分别入桶，按固定优先级取结果。硬编码的兜底规则（`rm -rf /usr`、`dd if=` 等）用户写 allow 也压不过。
 
-**第二，`^` 锚定解决的是真实事故。** 匹配的基础是子串匹配，但纯子串会误伤：`deny: "format"` 本意是拦磁盘格式化，结果 `docker ps --format json` 也被拦了；`deny: "shutdown"` 会拦下 `git commit -m "fix shutdown handling"`——敏感词出现在 commit message 里而已。`^` 前缀把匹配锚定到**命令位置**：行首、`&&`/`;`/`|` 之后、`sudo`/环境变量前缀之后。`^format` 只匹配作为命令执行的 format，不碰参数和字符串内容。这个特性不是设计出来的，是被上面两个真实误伤逼出来的。
+**第二，`^` 锚定解决的是真实事故**：`deny: "format"` 本意拦磁盘格式化，结果 `docker ps --format json` 也被拦了；`deny: "shutdown"` 拦下 `git commit -m "fix shutdown handling"`——敏感词出现在 commit message 里。`^` 把匹配锚定到命令位置（行首、管道符后、`sudo` 之后），不碰参数和字符串内容。
 
-**第三，配置热加载 + 优雅降级。** 权限引擎每个 turn 重建一次，改完 `permissions.yml` 下一条命令就生效，不用重启。改到一半 YAML 语法错误怎么办？回退到上一次成功解析的规则（`lastGoodRules`）并打警告——既不能因为配置文件短暂坏掉就让 session 崩溃，更不能在这个窗口期"暂时不设防"。
+**第三，配置热加载 + 优雅降级**：权限引擎每个 turn 重建一次，改完 `permissions.yml` 下一条命令就生效。YAML 语法错误时回退到上次成功解析的规则——既不能让配置文件短暂损坏就让 session 崩溃，更不能在这个窗口期"暂时不设防"。
 
-然后是那条诚实。**默认情况下，octo-agent 没有任何 OS 级隔离**：不开 `--sandbox` 时，shell 工具就是裸的 `exec.Command("sh", "-c", ...)`，唯一防线是上面的字符串规则。真正的 OS 级隔离是可选纵深：macOS 用 Seatbelt，Linux 用 Landlock + seccomp（直接禁掉 inet socket），其他平台不支持——且请求了 `--sandbox` 但平台不支持时会拒绝启动（fail closed），而不是静默退化。`internal/sandbox` 的包注释把两层的关系定性得很清楚：sandbox 是"permission 引擎之下的纵深防御，而 permission 引擎只 gate 命令字符串"。字符串匹配当然绕得过——把边界说清楚，比宣传一个不存在的安全模型有价值得多。
-
-配套的审计日志记录每一次 deny 和每一次用户裁决（一行一条 JSON，10MiB 轮转）。里面有个细节：每个字段截断到 1KiB。不是省磁盘——是防止一次被拒绝的 `write_file` 把整份文件内容、或一条含密钥的命令，原样抄进审计日志。审计日志本身不该成为新的泄露面。
-
-
+**诚实**：默认无 OS 级隔离，shell 工具就是裸的 `exec.Command`，唯一防线是字符串规则。真正的 OS 级隔离是可选纵深（macOS Seatbelt、Linux Landlock + seccomp）。包注释写得很清楚——字符串匹配当然绕得过，把边界说清楚比宣传一个不存在的安全模型有价值得多。
 
 ## 回收站：为"模型会删错文件"这个前提设计
 
-最后一个机制最朴素，也最能体现这个项目的世界观。前提很简单：模型**会**删错文件。不是可能，是迟早。那么正确的问题就不是"怎么防止删错"，而是"删错之后怎么办"。
+**前提**：模型**会**删错文件。不是可能，是迟早。正确的问题不是"怎么防止删错"，而是"删错之后怎么办"。
 
-octo-agent 的答案是把所有破坏性操作从"不可逆"改成"可逆"——而且覆盖面比你以为的宽：
+覆盖范围比你以为的宽：
 
 ```mermaid
 flowchart TD
-    A["shell 里的 rm<br/>（注入的 __octo_safe_rm 先备份再删）"] --> T
-    B["Windows 的 Remove-Item<br/>（cmdlet 被包装函数遮蔽）"] --> T
-    C["write_file / edit_file 覆盖已有文件<br/>（旧版本先备份）"] --> T
-    D["程序化删除<br/>session / skill / workflow / memory"] --> T
+    A["shell rm（注入 __octo_safe_rm 先 cp -al 到回收站）"] --> T
+    B["write_file / edit_file 覆盖已有文件<br/>旧版本先备份"] --> T
+    C["程序化删除 session / skill / workflow / memory"] --> T
     T["~/.octo/trash/<项目哈希>/<br/><时间戳>_<随机>_<文件名> + .meta.json"]
-    T --> R["octo trash restore<br/>（按 ID 或路径模糊匹配）"]
-    T --> E["后台清理：14 天过期<br/>+ 容量上限，最旧先走"]
+    T --> R["octo trash restore<br/>支持 ID 或路径模糊匹配"]
+    T --> E["后台清理：14 天过期 + 容量上限"]
 ```
 
-`rm` 的拦截方式是往 shell 环境里注入一个同名函数，真删之前先 `cp -al`（硬链接，几乎零成本）把目标搬进回收站；Windows 上则遮蔽 `Remove-Item` cmdlet 走同样的流程。连模型改文件这种操作也在保护范围内——`write_file` 覆盖已有文件前旧版本先进回收站。
+一个见功力的小判断：**如果目标文件被 git 跟踪且工作区是干净的，跳过备份**。因为内容 git 里已经有了，回收站再存一份是纯浪费。好的安全网不光要接得住，还要足够安静。
 
-覆盖备份里有一个判断特别见功力：**如果目标文件被 git 跟踪且工作区是干净的，跳过备份**。因为这份内容 git 里已经有了，回收站再存一份是纯浪费。一个 `git ls-files` 加两次 `git diff --quiet`，把回收站噪音降了一大截——好的安全网不光要接得住，还要足够安静，不然很快会被用户整个关掉。
+## 自带电池：让用户在头五分钟留下来
 
-恢复走 `octo trash restore`，支持 ID 或路径模糊匹配；目标路径已被占用时可选三种策略：报错中止（默认）、把占用者也挪进回收站再恢复、或恢复为带时间戳的新名字。每个项目的回收站按项目路径哈希隔离，纯本地，14 天过期加容量上限的后台清理，不会无限膨胀。
+前面九个是"硬伤"，但做一个 Agent 真正的难题是**头五分钟**。如果用户第一次提问前还得自己去装 ripgrep、去翻 MCP 仓库，他很可能就此离开。
 
+- **MCP 工具搜索**：不把全套 JSON schema 塞进 prompt，只暴露名字+一句话描述。模型真想用的时候才用 `mcp_describe` 拉 schema。`auto` 模式只在延迟加载比全量上传节省 ≥10% 上下文时才启用。
+- **两个内置二进制**：ripgrep 编译进二进制（`go:embed`），用户不需要装；Python 的 openpyxl 依赖通过捆绑 uv 解决。
+- **五个元技能**（`skill-creator`、`mcp-creator`、`channel-manager`、`cron-task-creator`、`workflow-creator`）专门处理 octo 自己的配置——引导用户走完本需要手写 YAML 的流程。它们依赖文件工具（`write_file`、`edit_file`、`terminal`）加上 octo 专属知识，而不是为每段 YAML 都造专用工具——"工具可组合"这个原则既用在用户的 workflow 里，也用在 octo 自己的入门引导上。
 
+## 尾声
 
-## 自带电池：可发现性、元技能与更友好的默认
+十个机制分开看各管一摊，合起来是同一个判断：**凡是能用机制保证的，就不要指望模型的自觉。**
 
-前面七个是"硬伤"——设计错的地方会持续漏 token 或者丢文件。但做一个 agent 真正的难题不是这些硬伤，是头五分钟。如果用户第一次搜索之前还得自己去装 ripgrep，第一次提问之前还得先去翻 MCP 仓库，他很可能就此离开。octo 用三层"开箱即用"来回应——恰好也是同一套原则（能推迟的就推迟、露出该露的、优雅降级）在入门路径上的应用。
-
-### MCP 工具搜索：懒惰注册
-
-标准 MCP 接法有个隐形成本：每个 tool 的完整 JSON schema 在每一轮都推进 system prompt。接三个 MCP 服务器、中间有四十个工具,用户在还没问任何问题之前就已经烧了一千个 token 来"知道有什么可用"。octo 的回应放在 `internal/tools/tool_search.go`——把重的部分推迟。
-
-两个桥接工具 `mcp_describe` 和 `mcp_call` 替代了完整上传。每个 MCP 工具的**名字 + 一句话描述**走 `skills.RenderManifest` 那条路露在 system prompt 里（和 `# Available skills` 同一机制），于是模型在零往返里就能回答"有没有做 X 的工具"。`mcp_describe` 按需拉一个 schema（模型真想用那个工具时才拉），`mcp_call` 执行它——直接进入既有的 `executeMCP` 路径，所有 `mcp__` 前缀的派发、权限、hook 机制都照常在真实工具名上跑。
-
-模式选择器（`auto` / `on` / `off`）和前面各处是同一个直觉：`auto` 模式只在推迟的 schema 预计占 **context window ≥ 10%** 时才启用桥接机制。在那之下，更简单的全量上传占优；超过它，搜索机制才上场，避免 prompt 被本季不会用的 schema 淹没。
-
-### 两个不用你装的二进制
-
-**ripgrep。**`internal/tools/rgembed` 在 octo 二进制里打包了一份平台匹配的 ripgrep：构建时 Makefile 下载对应平台的 BurntSushi/ripgrep release，`go:embed` 在 `embedrg` 构建标签下把它烤进去。运行时如果 `rg` 已经在 `PATH` 里就用系统的；否则释放嵌入那份到 `~/.octo/bin/rg-<version>`。`grep` 工具由此得到一个又快又稳的搜索后端，用户不需要做任何事。
-
-**uv。**`office-xlsx` 依赖 Python 的 openpyxl，openpyxl 需要一个 Python 运行时。octo 选择不让用户操心这件事——macOS / Windows 安装包直接捆绑 uv。取舍很直接：macOS 包大约多出 100MB，换来用户在第一次做表格任务时永远看不到"请装 Python"。选捆绑 *uv* 而不是 *bun*——uv 是单一静态二进制，解析依赖就够了；bun 是完整的 JavaScript 运行时,给一个多数人用不到的 power-user skill 拖着太重。
-
-### Windows 知道何时该提示升级
-
-Windows 安装器（`packaging/windows/octo.iss`）末尾有段俏皮的工程：它跑一次 `EnsurePowerShell7` 检查。如果 `pwsh` 不在 PATH 但 `winget` 在,就问用户一次（双语）要不要装 PowerShell 7。原因：octo 跑 hook 脚本和 terminal tool 时，有 `pwsh` (7+) 就用它，没有就退回永远在那里的 Windows PowerShell 5.1。7 那条路径是更好的默认（更快、可预测的 `~/.bashrc` 式 profile、真正的 `&&` 语义）。所有跳过 / 失败路径都是静默 noop：随便哪条出错，octo 就照常用 5.1。用户被提示，从未被阻塞。
-
-### 五个元技能：octo 学会扩展自己
-
-skill 通常是一段模型能调用的流程——但有几个预装 skill 专门*处理 octo 自己的配置*。它们引导用户走过本需要手写 YAML 的流程,并依赖 agent 记忆让上下文跨 session 延续。
-
-| Skill | 职责 |
-|---|---|
-| `skill-creator` | 从零起稿新 skill、改写既有 skill、把一段 workflow 固化成 skill。 |
-| `mcp-creator` | 搜索合适的 MCP 服务器包、拼出 `~/.octo/mcp.json` 条目、验证连通——全程引导,不用手敲 JSON。 |
-| `channel-manager` | 领用户走完每家 IM 管理后台的步骤、收凭据、写 `~/.octo/channels.yml`、排查连接问题。 |
-| `cron-task-creator` | 创建 / 查看 / 启用 / 删除存在 `~/.octo/tasks/` 里的定时 agent 提示。 |
-| `workflow-creator` | 把重复的多步任务捕获成可保存、可续跑的 Ruby (mruby) workflow。 |
-
-有一点值得专门指出：`channel-manager`、`mcp-creator`、`cron-task-creator`、`workflow-creator` 都同时依赖文件工具（`write_file`、`edit_file`、`terminal`）和 octo 专属知识。这是刻意选择——一个元 skill 不需要为它写的每段 YAML 都造一个专用工具。"工具可组合"这个原则既用在用户的 workflow 里，也用在 octo 自己的入门引导上。
-
-
-
-## 尾声：一以贯之的世界观
-
-十个机制分开看各管一摊，合起来是同一个判断：**在 agent 系统里，凡是能用机制保证的，就不要指望模型的自觉。**
-
-压缩靠 token 阈值和安全切分点，而不是祈祷摘要别丢东西；缓存断点是显式插的，不是等运气命中；loop 有 12 小时硬顶兜住模型忘记停止；workflow 的并发上限是常量，不指望脚本作者自律；权限系统的 deny 优先和命令锚定，每一条都对应一个真出过的事故；回收站则干脆假设删错必然发生，把功夫花在"删错之后"。
+压缩靠 token 阈值和安全切分点，而不是祈祷摘要别丢东西；缓存断点是显式插的，不是等运气命中；serve 让模型杀不死自己的宿主，连重启都要先问过你、先把答复送到；workflow 并发上限是常量，不指望脚本作者自律；权限系统的 deny 优先和命令锚定，每一条都对应一个真实出过的事故；回收站干脆假设删错必然发生，把功夫花在"删错之后"。
 
 模型负责聪明，机制负责兜底。这大概就是读完这份代码库之后，最值得带走的一句话。
 
 ---
 
-### 附：想读代码，从这里进
+### 附：代码入口
 
 | 机制 | 入口文件 |
-|---|---|
+|------|----------|
 | Agent 循环 | `internal/agent/agent.go` |
-| 内置 tool 契约 | `internal/tools/registry.go` (allTools)、`internal/agent/tool.go` |
-| Memory (markdown) | `internal/memory/memory.go` (RenderInjection)、`internal/memory/injector.go` (Injector.Reminder / SaveNudge)、`internal/memory/rules.go` (parseRules) |
-| Memory (semantic) | `internal/memorybackend/backend.go`、`internal/tools/memory_backend.go` (memory_recall) |
 | 上下文压缩 | `internal/agent/compaction.go` |
-| Prompt 缓存断点 | `internal/provider/anthropic/client.go`（`markMessagesCacheable`） |
-| 协议 token 归一化 | `internal/provider/openai/types.go`（`nonCachedInput`） |
-| /loop | `internal/tools/schedule_wakeup.go`、`internal/server/loop.go` |
-| Workflow 运行时 | `internal/workflow/runtime.go`、`internal/workflow/prelude.rb` |
-| 浏览器录制/自愈 | `internal/browser/recorder.go`、`internal/app/browser_heal.go` |
-| 权限判定 | `internal/permission/permission.go`（`classify` / `Check`） |
+| Prompt 缓存断点 | `internal/provider/anthropic/client.go` |
+| 协议 token 归一化 | `internal/provider/openai/types.go` |
+| 记忆（Markdown） | `internal/memory/memory.go` |
+| 记忆（语义） | `internal/memorybackend/backend.go` |
+| serve 自杀拦截 | `internal/tools/server_guard.go` |
+| 优雅重启 / supervisor | `internal/tools/restart.go`、`internal/server/restart.go`、`cmd/octo/serve_supervisor.go` |
+| Workflow 运行时 | `internal/workflow/runtime.go` |
+| 浏览器录制/自愈 | `internal/browser/recorder.go` |
+| 权限判定 | `internal/permission/permission.go` |
 | OS 级沙箱 | `internal/sandbox/` |
 | 回收站 | `internal/trash/trash.go` |
 | MCP 工具搜索 | `internal/tools/tool_search.go` |
-| 元技能 | `internal/skills/defaults/{skill-creator,mcp-creator,channel-manager,cron-task-creator,workflow-creator}/SKILL.md` |
+| 元技能 | `internal/skills/defaults/` |
 | 读取先行守卫 | `internal/tools/read_tracker.go` |
-| web_fetch SSRF 防线 | `internal/tools/web_fetch.go`（`secureFetchTransport` / `directFetchHTTPClient`） |
+| web_fetch SSRF 防线 | `internal/tools/web_fetch.go` |
 | web_search 多层后端 | `internal/tools/web_search.go` |
-| terminal 后台管理器 | `internal/tools/background.go` |
-| Sub-agent 生命周期 | `internal/tools/agent.go`、`internal/tools/subagent_manager.go` |
+| sub_agent 生命周期 | `internal/tools/agent.go` |


### PR DESCRIPTION
## What

Full-content replacement of the architecture deep-dive post, both locales (zh + en). The v2 rewrite keeps the same slug (`architecture-deep-dive`), `pubDate`, and frontmatter schema; `updatedDate` bumped to 2026-07-19.

**Structure changes**

- New thesis-forward spine: ten mechanisms under one line — "in an agent system, whatever a mechanism can guarantee, never leave to the model's self-discipline"
- The `/loop` chapter is replaced by a new **octo serve robustness** chapter: terminal self-kill guard (`server_guard.go`), `restart_server` as the ask-pinned front door with drain semantics, the supervisor exit-code-42 contract, and config hot-reload as the no-restart path. Anchored on a real incident (an agent killing its own gateway while the user was away from the machine)
- Memory chapter rewritten around the truth: semantic recall is pluggable external backends (hindsight / mem0 / agentmemory), not a built-in sqlite; `memory_recall` isn't even registered when unconfigured

**Corrections vs the v1 text**

- Workflow concurrency: fixed at 8 (`defaultWorkflowConcurrency`), not "unlimited by default"
- `parallel()` example: real DSL is `parallel(items) { |it| ... }`, not an array of lambdas
- mermaid labels localized in both versions

Supersedes #1606 (its fixes targeted v1 paragraphs that this rewrite removes).

## Verification

`npm run build` in `blog/` passes: 30 pages, both `/posts/architecture-deep-dive/` and `/posts/en/architecture-deep-dive/` generated. Markdown-only change.

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
