### PR TITLE
feat(config): endpoint two-level schema — PR1 (structure + read-compat + Validate/Repair)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -736,6 +736,118 @@ func legacyEndpointID(host string, n int) string {
 	return fmt.Sprintf("legacy-%s-%d", safe, n)
 }
 
+// ResolveDefault returns the (endpoint, model) pair the session should run on
+// when nothing else selects one. It implements the four-step fallback chain
+// from the design doc (§5.3):
+//
+//  1. Default parses to (endpointID, model) and both resolve → that pair.
+//  2. Default's endpoint resolves but the model doesn't (e.g. the relay
+//     dropped it) → keep the endpoint, fall back to its first model.
+//  3. Default's endpoint doesn't exist (e.g. user deleted it) → fall back
+//     to the first endpoint's first model.
+//  4. No endpoints at all → zero values, ok=false (caller surfaces a
+//     "please configure" error).
+//
+// An empty Default is the normal fresh-install state, not a fallback: step 3
+// applies silently (no warn) so a brand-new config doesn't log noise on every
+// turn. Every other step that falls back logs a slog.Warn with the reason so
+// the user can see why their turns aren't running on the model they expected.
+//
+// The (endpoint, model, ok) shape mirrors DefaultEntry/EntryByModel: callers
+// that only need a ModelEntry for the legacy sender-building path can read
+// the returned Endpoint and EndpointModel directly.
+func (c Config) ResolveDefault() (Endpoint, EndpointModel, bool) {
+	if len(c.Endpoints) == 0 {
+		return Endpoint{}, EndpointModel{}, false
+	}
+
+	// Parse Default into (endpointID, model). An empty Default or one missing
+	// the separator is treated as "no default set" — step 3 applies silently.
+	endpointID, model, hasDefault := splitCompositeID(c.Default)
+
+	if hasDefault {
+		// Step 1 + 2: find the endpoint Default points at.
+		for i := range c.Endpoints {
+			if c.Endpoints[i].ID != endpointID {
+				continue
+			}
+			ep := &c.Endpoints[i]
+			if len(ep.Models) == 0 {
+				// Step 2 dead-end: endpoint exists but is empty. Fall through
+				// to step 3 (first non-empty endpoint), with a warn that the
+				// targeted endpoint was empty.
+				slog.Warn("config: default model resolution fell back",
+					"default", c.Default, "reason", "empty_endpoint",
+					"endpoint_id", endpointID)
+				if first := firstNonEmptyEndpoint(c.Endpoints); first != nil {
+					return *first, first.Models[0], true
+				}
+				return Endpoint{}, EndpointModel{}, false
+			}
+			// Step 1: exact model hit.
+			for j := range ep.Models {
+				if ep.Models[j].Model == model {
+					return *ep, ep.Models[j], true
+				}
+			}
+			// Step 2: endpoint found, model not found — fall back to the
+			// endpoint's first model.
+			slog.Warn("config: default model resolution fell back",
+				"default", c.Default, "resolved_to", ep.CompositeID(ep.Models[0].Model),
+				"reason", "model_not_found")
+			return *ep, ep.Models[0], true
+		}
+
+		// Step 3: Default's endpoint doesn't exist.
+		if first := firstNonEmptyEndpoint(c.Endpoints); first != nil {
+			slog.Warn("config: default model resolution fell back",
+				"default", c.Default,
+				"resolved_to", first.CompositeID(first.Models[0].Model),
+				"reason", "endpoint_not_found")
+			return *first, first.Models[0], true
+		}
+		return Endpoint{}, EndpointModel{}, false
+	}
+
+	// Empty Default — fresh install, not a fallback. Step 3 applies silently.
+	if first := firstNonEmptyEndpoint(c.Endpoints); first != nil {
+		return *first, first.Models[0], true
+	}
+	return Endpoint{}, EndpointModel{}, false
+}
+
+// splitCompositeID splits "<endpoint_id>::<model>" into its parts. hasDefault
+// is false when the input is empty or doesn't contain the "::" separator —
+// both mean "no default set" to ResolveDefault. A composite id with an empty
+// endpoint id or empty model (e.g. "::model" or "ep::") is treated as set
+// (hasDefault true) so ResolveDefault can report the specific failure rather
+// than silently ignoring it.
+func splitCompositeID(id string) (endpointID, model string, hasDefault bool) {
+	if id == "" {
+		return "", "", false
+	}
+	idx := strings.Index(id, "::")
+	if idx < 0 {
+		// Bare model with no endpoint prefix — not a valid composite id. Treat
+		// as "no default set" so the caller falls back rather than reporting a
+		// parse error mid-turn.
+		return "", "", false
+	}
+	return id[:idx], id[idx+2:], true
+}
+
+// firstNonEmptyEndpoint returns the first endpoint in the slice that has at
+// least one model, or nil if none do. An endpoint with zero models is
+// unusable (nothing to run), so the fallback chain skips them.
+func firstNonEmptyEndpoint(endpoints []Endpoint) *Endpoint {
+	for i := range endpoints {
+		if len(endpoints[i].Models) > 0 {
+			return &endpoints[i]
+		}
+	}
+	return nil
+}
+
 // migrateEntryProvider folds the retired openai_compatible / anthropic_compatible
 // catch-all vendors into the unified "custom" vendor, recovering the wire format
 // into the new per-entry Protocol field so existing configs keep working.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,16 +151,20 @@ type Config struct {
 	// schema's authoritative field). Each bundles shared connection params
 	// and a list of models. PR1 populates this from the legacy flat Models
 	// list during normalize(); the write path switches to emitting this in
-	// PR4. Until then Save still writes the flat Models form so existing
-	// callers and on-disk files keep working.
+	// PR4. Until then Save still writes the flat Models form (Save elides
+	// this field at marshal time) so existing callers and on-disk files
+	// keep working, while Load still honours an explicit endpoints: block
+	// if the user hand-writes one (design §4.1 step 1).
 	Endpoints []Endpoint `yaml:"endpoints,omitempty"`
 	// Default is the composite id "<endpoint_id>::<model>" selecting the
 	// endpoint+model used when nothing else picks one. Empty falls back to
-	// the first endpoint's first model (see ResolveDefault).
+	// the first endpoint's first model (see ResolveDefault). Elided at
+	// Save time in PR1; see Save.
 	Default string `yaml:"default,omitempty"`
 	// Lite is the composite id for the compaction lite model. Empty means
 	// fall back to ImplicitLiteModel inference (endpoint.lite_model, else
-	// the vendor registry's LiteModel for official endpoints).
+	// the vendor registry's LiteModel for official endpoints). Elided at
+	// Save time in PR1; see Save.
 	Lite string `yaml:"lite,omitempty"`
 
 	// Models is the legacy flat list of named model configurations. Kept
@@ -588,8 +592,23 @@ type fileConfig struct {
 // normalize folds legacy top-level model fields into a one-entry Models list.
 // Files already on the new schema pass through untouched; legacy fields are
 // ignored once a models list exists.
+//
+// Precedence (design §4.1): if the file carries an explicit endpoints: block
+// the user is already on the new schema and we honour it as-is — rebuilding
+// from Models would silently drop their endpoints: edits. Otherwise we
+// synthesise Endpoints from the flat Models list so new code can read the
+// two-level shape while existing callers keep reading Models.
 func (f fileConfig) normalize() Config {
 	c := f.Config
+	if len(c.Endpoints) > 0 {
+		// Already on the new schema — leave Endpoints/Default/Lite as the
+		// authoritative shape. Migrate any provider aliases on Models too,
+		// for callers that still read the flat list.
+		for i := range c.Models {
+			migrateEntryProvider(&c.Models[i])
+		}
+		return c
+	}
 	if len(c.Models) > 0 {
 		for i := range c.Models {
 			migrateEntryProvider(&c.Models[i])
@@ -711,15 +730,21 @@ func findEndpointModel(endpoints []Endpoint, model string) (Endpoint, EndpointMo
 	return Endpoint{}, EndpointModel{}, false
 }
 
-// hostFromBaseURL extracts the URL host for use in a legacy-<host>-<n> endpoint
-// ID. On a parse failure it falls back to the raw string so a malformed base_url
-// still yields a stable (if ugly) ID rather than aborting normalisation.
+// hostFromBaseURL extracts the URL host (lowercased) for use in a
+// legacy-<host>-<n> endpoint ID. Hosts are case-insensitive per RFC 3986
+// (url.Parse normalises the scheme but not the host), so lowercasing gives a
+// stable id regardless of how the user cased the base_url in the YAML —
+// design §4.4 requires the implicit id to be stable across repeated
+// Load→Save cycles, and a case change in the file must not rotate it. On a
+// parse failure it falls back to the raw string lowercased so a malformed
+// base_url still yields a stable (if ugly) ID rather than aborting
+// normalisation.
 func hostFromBaseURL(baseURL string) string {
 	u, err := url.Parse(baseURL)
 	if err != nil || u.Host == "" {
-		return baseURL
+		return strings.ToLower(baseURL)
 	}
-	return u.Host
+	return strings.ToLower(u.Host)
 }
 
 // legacyEndpointID builds the "legacy-<host>-<n>" ID for an implicit endpoint
@@ -848,6 +873,118 @@ func firstNonEmptyEndpoint(endpoints []Endpoint) *Endpoint {
 	return nil
 }
 
+// ParseModelFlag resolves a --model flag value (or env *_MODEL value) to the
+// (endpoint, model) pair it selects. It accepts two forms:
+//
+//   - Composite id "<endpoint_id>::<model>" — resolves to exactly that pair.
+//     An unknown endpoint id or unknown model under a known endpoint is an
+//     error naming the missing part and listing the available ones.
+//   - Bare model "<model>" — resolves via the precedence in S5.4:
+//     1. If the Default endpoint's model matches, use the Default endpoint
+//        (Default is "my main endpoint", a bare name prefers it).
+//     2. Otherwise scan all endpoints; a unique hit returns it.
+//     3. Multiple hits return the first match and slog.Warn naming the
+//        picked endpoint so the user can disambiguate with a composite id.
+//     4. No hit is an error listing the available models.
+//
+// An empty flag is an error — callers should treat empty as "no --model given"
+// and fall back to ResolveDefault rather than calling ParseModelFlag.
+func (c Config) ParseModelFlag(flag string) (Endpoint, EndpointModel, error) {
+	if flag == "" {
+		return Endpoint{}, EndpointModel{}, fmt.Errorf("model flag is empty")
+	}
+
+	// Composite-id path.
+	if endpointID, model, ok := splitCompositeID(flag); ok {
+		for i := range c.Endpoints {
+			if c.Endpoints[i].ID != endpointID {
+				continue
+			}
+			ep := &c.Endpoints[i]
+			for j := range ep.Models {
+				if ep.Models[j].Model == model {
+					return *ep, ep.Models[j], nil
+				}
+			}
+			available := availableModelsInEndpoint(ep)
+			return Endpoint{}, EndpointModel{}, fmt.Errorf("model %q not found in endpoint %q (available: %s)", model, endpointID, available)
+		}
+		available := availableEndpoints(c.Endpoints)
+		return Endpoint{}, EndpointModel{}, fmt.Errorf("endpoint %q not found (available: %s)", endpointID, available)
+	}
+
+	// Bare-model path.
+	// Step 2a: prefer the Default endpoint if its model matches.
+	if defEp, defM, ok := c.ResolveDefault(); ok {
+		if defM.Model == flag {
+			return defEp, defM, nil
+		}
+	}
+	// Step 2b: scan all endpoints for a match.
+	var hits []endpointModelIndex
+	for i := range c.Endpoints {
+		for j := range c.Endpoints[i].Models {
+			if c.Endpoints[i].Models[j].Model == flag {
+				hits = append(hits, endpointModelIndex{ep: i, m: j})
+			}
+		}
+	}
+	switch len(hits) {
+	case 0:
+		available := availableModelsAcrossEndpoints(c.Endpoints)
+		return Endpoint{}, EndpointModel{}, fmt.Errorf("model %q not found in any endpoint (available: %s)", flag, available)
+	case 1:
+		h := hits[0]
+		return c.Endpoints[h.ep], c.Endpoints[h.ep].Models[h.m], nil
+	default:
+		h := hits[0]
+		picked := c.Endpoints[h.ep]
+		pickedModel := picked.Models[h.m]
+		// Warn so the user knows the bare flag was ambiguous and can switch
+		// to a composite id to pin a specific endpoint.
+		slog.Warn("config: model flag matches multiple endpoints, using the first match",
+			"flag", flag, "picked_endpoint", picked.ID,
+			"hint", fmt.Sprintf("use %s::%s to disambiguate", picked.ID, pickedModel.Model))
+		return picked, pickedModel, nil
+	}
+}
+
+// endpointModelIndex pairs an endpoint index with a model index inside it.
+type endpointModelIndex struct{ ep, m int }
+
+// availableEndpoints returns a comma-joined list of endpoint ids for use in
+// error messages.
+func availableEndpoints(endpoints []Endpoint) string {
+	ids := make([]string, 0, len(endpoints))
+	for _, ep := range endpoints {
+		ids = append(ids, ep.ID)
+	}
+	return strings.Join(ids, ", ")
+}
+
+// availableModelsInEndpoint returns a comma-joined list of model ids in one
+// endpoint for use in error messages.
+func availableModelsInEndpoint(ep *Endpoint) string {
+	models := make([]string, 0, len(ep.Models))
+	for _, m := range ep.Models {
+		models = append(models, m.Model)
+	}
+	return strings.Join(models, ", ")
+}
+
+// availableModelsAcrossEndpoints returns a comma-joined list of every model
+// across every endpoint for use in error messages. Duplicates (same model on
+// multiple endpoints) are kept so the user sees the full picture.
+func availableModelsAcrossEndpoints(endpoints []Endpoint) string {
+	var models []string
+	for _, ep := range endpoints {
+		for _, m := range ep.Models {
+			models = append(models, m.Model)
+		}
+	}
+	return strings.Join(models, ", ")
+}
+
 // migrateEntryProvider folds the retired openai_compatible / anthropic_compatible
 // catch-all vendors into the unified "custom" vendor, recovering the wire format
 // into the new per-entry Protocol field so existing configs keep working.
@@ -958,6 +1095,19 @@ func resetLastGoodForTest() {
 // API keys), creating ~/.octo if needed. A legacy config.yaml present at that
 // moment is renamed to config.yaml.bak — best effort, because config.yml wins
 // the read order regardless.
+// Save writes the config to ~/.octo/config.yml with mode 0600 (it may hold
+// API keys), creating ~/.octo if needed. A legacy config.yaml present at that
+// moment is renamed to config.yaml.bak — best effort, because config.yml wins
+// the read order regardless.
+//
+// PR1 invariant (design §4.3): Save must write the legacy flat form
+// (models: + default_model: + lite_model:), NOT the new endpoints: form.
+// The new Endpoints/Default/Lite fields are in-memory only during PR1-3 so
+// existing callers and downgrade paths keep working. PR4 will flip this to
+// emit endpoints: instead. To enforce that here without changing the field
+// tags (Load still needs to honour an explicit endpoints: block the user
+// hand-writes, per §4.1 step 1), Save marshals a shallow copy with the new
+// fields cleared.
 func (c Config) Save() error {
 	path, err := Path()
 	if err != nil {
@@ -966,7 +1116,14 @@ func (c Config) Save() error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
-	data, err := yaml.Marshal(c)
+	// Shallow copy with the new-schema fields cleared so yaml.Marshal emits
+	// only the legacy flat form. The Models slice is shared by reference,
+	// which is fine — we don't mutate it.
+	saved := c
+	saved.Endpoints = nil
+	saved.Default = ""
+	saved.Lite = ""
+	data, err := yaml.Marshal(saved)
 	if err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1293,8 +1293,105 @@ func RestoreFromBackup() (brokenSaved string, err error) {
 // reset to the first entry; a dangling lite_model is cleared. A duplicate model
 // or a half-filled entry is reported as unfixable — the intended value can't be
 // guessed, so it's left for the user.
+//
+// PR1 layers endpoint-level auto-fixes on top of the legacy Models fixes
+// (design §14.2): dangling Default resets to the first endpoint's first
+// model; dangling Lite clears; an empty endpoint (no models) is deleted; Lite
+// == Default clears Lite. Duplicate endpoint id, illegal id chars, missing
+// model name, and duplicate model within one endpoint are unfixable (can't
+// guess the intended value). Like Validate, the endpoint-level branch only
+// runs on the pure new schema (Endpoints set, Models empty) to avoid
+// double-acting on a migrated flat config; PR4 lifts that guard.
 func (c Config) Repair() (repaired Config, fixed, unfixable []string) {
 	repaired = c
+
+	// Endpoint-level repair — only on the pure new schema (Endpoints set,
+	// Models empty). See the doc comment for why.
+	if len(repaired.Endpoints) > 0 && len(repaired.Models) == 0 {
+		// Scan for unfixable problems first so the auto-fixes below don't
+		// act on garbage (e.g. an illegal id can't be safely renamed, so
+		// the user must fix it before any auto-reset of Default makes
+		// sense).
+		seenID := make(map[string]bool, len(repaired.Endpoints))
+		for i, ep := range repaired.Endpoints {
+			if strings.TrimSpace(ep.ID) == "" {
+				unfixable = append(unfixable, fmt.Sprintf("endpoints[%d] has no id — add one", i))
+			} else if !isValidEndpointID(ep.ID) {
+				unfixable = append(unfixable, fmt.Sprintf("endpoint id %q contains illegal chars — rename", ep.ID))
+			}
+			if seenID[ep.ID] {
+				unfixable = append(unfixable, fmt.Sprintf("duplicate endpoint id %q — rename one", ep.ID))
+			}
+			seenID[ep.ID] = true
+
+			seenModel := make(map[string]bool, len(ep.Models))
+			for j, m := range ep.Models {
+				if strings.TrimSpace(m.Model) == "" {
+					unfixable = append(unfixable, fmt.Sprintf("endpoint %q models[%d] has no model name — add one or remove it", ep.ID, j))
+					continue
+				}
+				if seenModel[m.Model] {
+					unfixable = append(unfixable, fmt.Sprintf("duplicate model %q in endpoint %q — remove one", m.Model, ep.ID))
+				}
+				seenModel[m.Model] = true
+			}
+		}
+
+		// Auto-fixes (safe, no guessing).
+
+		// Delete empty endpoints (no models). These are unusable and a
+		// dangling-Default reset below would have nothing to point at if all
+		// endpoints were empty.
+		var kept []Endpoint
+		for _, ep := range repaired.Endpoints {
+			if len(ep.Models) == 0 {
+				fixed = append(fixed, fmt.Sprintf("deleted empty endpoint %q (had no models)", ep.ID))
+				continue
+			}
+			kept = append(kept, ep)
+		}
+		repaired.Endpoints = kept
+
+		// Find the first non-empty endpoint + its first model — the reset
+		// target for a dangling Default. If there are none, leave Default
+		// for the user (all-empty config is the pre-onboarding state).
+		var firstEpID, firstModel string
+		for _, ep := range repaired.Endpoints {
+			if len(ep.Models) > 0 {
+				firstEpID = ep.ID
+				firstModel = ep.Models[0].Model
+				break
+			}
+		}
+		if repaired.Default != "" {
+			if _, _, ok := repaired.resolveCompositeID(repaired.Default); !ok {
+				if firstEpID != "" {
+					newDefault := firstEpID + "::" + firstModel
+					fixed = append(fixed, fmt.Sprintf("reset default %q → %q (first endpoint's first model)", repaired.Default, newDefault))
+					repaired.Default = newDefault
+				} else {
+					fixed = append(fixed, fmt.Sprintf("cleared default %q (no endpoints with models to fall back to)", repaired.Default))
+					repaired.Default = ""
+				}
+			}
+		}
+		if repaired.Lite != "" {
+			// Lite dangles OR Lite == Default → clear. The "==" check is on
+			// the resolved composite id, so a Lite that points at the same
+			// endpoint+model as Default is caught even if the strings differ
+			// in casing or whitespace (they won't for composite ids, but the
+			// resolved form is the canonical one).
+			_, _, liteOK := repaired.resolveCompositeID(repaired.Lite)
+			if !liteOK || repaired.Lite == repaired.Default {
+				fixed = append(fixed, fmt.Sprintf("cleared lite %q (matched no endpoint+model or equals default)", repaired.Lite))
+				repaired.Lite = ""
+			}
+		}
+
+		return repaired, fixed, unfixable
+	}
+
+	// Legacy flat Models repair.
 	if len(repaired.Models) == 0 {
 		return repaired, nil, nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -898,13 +898,21 @@ func (c Config) ResolveDefault() (Endpoint, EndpointModel, bool) {
 			if len(ep.Models) == 0 {
 				// Step 2 dead-end: endpoint exists but is empty. Fall through
 				// to step 3 (first non-empty endpoint), with a warn that the
-				// targeted endpoint was empty.
-				slog.Warn("config: default model resolution fell back",
-					"default", c.Default, "reason", "empty_endpoint",
-					"endpoint_id", endpointID)
+				// targeted endpoint was empty. Carry resolved_to like the
+				// other fallback paths so log scanners see a uniform shape.
 				if first := firstNonEmptyEndpoint(c.Endpoints); first != nil {
+					slog.Warn("config: default model resolution fell back",
+						"default", c.Default, "reason", "empty_endpoint",
+						"endpoint_id", endpointID,
+						"resolved_to", first.CompositeID(first.Models[0].Model))
 					return *first, first.Models[0], true
 				}
+				// No non-empty endpoint to fall back to — log the failure
+				// (no resolved_to, since nothing resolved) and return ok=false
+				// so the caller surfaces a "please configure" error.
+				slog.Warn("config: default model resolution failed",
+					"default", c.Default, "reason", "empty_endpoint_no_fallback",
+					"endpoint_id", endpointID)
 				return Endpoint{}, EndpointModel{}, false
 			}
 			// Step 1: exact model hit.
@@ -1012,9 +1020,16 @@ func (c Config) ParseModelFlag(flag string) (Endpoint, EndpointModel, error) {
 	}
 
 	// Bare-model path.
-	// Step 2a: prefer the Default endpoint if its model matches.
-	if defEp, defM, ok := c.ResolveDefault(); ok {
-		if defM.Model == flag {
+	// Step 2a: prefer the Default endpoint if its model matches. Only applies
+	// when the user explicitly set a Default (c.Default != "") — an empty
+	// Default falling back to the first endpoint (ResolveDefault step 3) is
+	// NOT a "user-designated main endpoint", so it shouldn't short-circuit
+	// the ambiguity check in step 2b. Without this guard, two endpoints
+	// exposing the same model with no Default set would silently pick the
+	// first instead of warning about the ambiguity (design §5.4 rationale:
+	// "用户配 default 说明这是我的主 endpoint" — no Default, no preference).
+	if c.Default != "" {
+		if defEp, defM, ok := c.ResolveDefault(); ok && defM.Model == flag {
 			return defEp, defM, nil
 		}
 	}
@@ -1377,10 +1392,11 @@ func (c Config) Repair() (repaired Config, fixed, unfixable []string) {
 		}
 		if repaired.Lite != "" {
 			// Lite dangles OR Lite == Default → clear. The "==" check is on
-			// the resolved composite id, so a Lite that points at the same
-			// endpoint+model as Default is caught even if the strings differ
-			// in casing or whitespace (they won't for composite ids, but the
-			// resolved form is the canonical one).
+			// the raw composite-id strings — endpoint IDs must match
+			// ^[a-zA-Z0-9_-]+$ (no spaces, no case variation), so two
+			// different strings can never resolve to the same endpoint+model
+			// in practice. Validate rejects any id that would; reaching here
+			// with a valid composite id means the string form is canonical.
 			_, _, liteOK := repaired.resolveCompositeID(repaired.Lite)
 			if !liteOK || repaired.Lite == repaired.Default {
 				fixed = append(fixed, fmt.Sprintf("cleared lite %q (matched no endpoint+model or equals default)", repaired.Lite))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -464,13 +464,73 @@ func (c Config) DefaultEntry() ModelEntry {
 // duplicated or half-filled entry) but which usually mean a hand edit went
 // wrong. It returns a human-readable list; empty means the config is usable. A
 // config with no models (the valid pre-onboarding state) reports nothing.
+//
+// PR1 layers endpoint-level checks on top of the legacy Models checks (design
+// §14.1): endpoint id uniqueness/legality, each endpoint has at least one
+// model, model names non-empty, no duplicate models within one endpoint, and
+// Default/Lite composite ids resolve.
+//
+// To avoid double-reporting on a migrated flat config (where Endpoints is
+// synthesised from Models and the same duplicate would surface in both
+// layers), the endpoint-level checks only run when the config is on the pure
+// new schema — i.e. Endpoints is non-empty AND Models is empty (a hand-written
+// endpoints: block with no models: block, the shape §4.1 step 1 recognises as
+// "user is already on the new schema"). A flat config (Models non-empty,
+// Endpoints synthesised in memory) gets only the legacy Models checks, so
+// hand-edited flat files keep getting exactly the validation they always did.
+// PR4, which switches Save to emit Endpoints and drops the Models write path,
+// will lift this guard so endpoint-level checks always run.
 func (c Config) Validate() []string {
-	if len(c.Models) == 0 {
-		return nil
-	}
 	var problems []string
-	// Keyed by the raw model string (EntryByModel matches exactly), so the
-	// default_model/lite_model checks below agree with runtime resolution.
+
+	// Endpoint-level checks — only on the pure new schema (Endpoints set,
+	// Models empty). See the doc comment for why.
+	if len(c.Endpoints) > 0 && len(c.Models) == 0 {
+		seenEndpointID := make(map[string]bool, len(c.Endpoints))
+		for i, ep := range c.Endpoints {
+			if strings.TrimSpace(ep.ID) == "" {
+				problems = append(problems, fmt.Sprintf("endpoints[%d] has no id", i))
+			} else if !isValidEndpointID(ep.ID) {
+				problems = append(problems, fmt.Sprintf("endpoint id %q contains illegal chars (allowed: a-z A-Z 0-9 _ -, and no \"::\")", ep.ID))
+			}
+			if seenEndpointID[ep.ID] {
+				problems = append(problems, fmt.Sprintf("duplicate endpoint id %q", ep.ID))
+			}
+			seenEndpointID[ep.ID] = true
+
+			if len(ep.Models) == 0 {
+				problems = append(problems, fmt.Sprintf("endpoint %q has no models", ep.ID))
+			}
+			seenModel := make(map[string]bool, len(ep.Models))
+			for j, m := range ep.Models {
+				if strings.TrimSpace(m.Model) == "" {
+					problems = append(problems, fmt.Sprintf("endpoint %q models[%d] has no model name", ep.ID, j))
+					continue
+				}
+				if seenModel[m.Model] {
+					problems = append(problems, fmt.Sprintf("duplicate model %q in endpoint %q", m.Model, ep.ID))
+				}
+				seenModel[m.Model] = true
+			}
+		}
+
+		// Default/Lite composite-id resolution.
+		if c.Default != "" {
+			if _, _, ok := c.resolveCompositeID(c.Default); !ok {
+				problems = append(problems, fmt.Sprintf("default %q does not resolve to any endpoint+model", c.Default))
+			}
+		}
+		if c.Lite != "" {
+			if _, _, ok := c.resolveCompositeID(c.Lite); !ok {
+				problems = append(problems, fmt.Sprintf("lite %q does not resolve to any endpoint+model", c.Lite))
+			}
+		}
+	}
+
+	// Legacy flat Models checks.
+	if len(c.Models) == 0 {
+		return problems
+	}
 	seen := make(map[string]bool, len(c.Models))
 	for i, m := range c.Models {
 		if strings.TrimSpace(m.Model) == "" {
@@ -492,6 +552,44 @@ func (c Config) Validate() []string {
 		problems = append(problems, fmt.Sprintf("lite_model %q matches no entry", c.LiteModel))
 	}
 	return problems
+}
+
+// isValidEndpointID reports whether id matches the endpoint id regex
+// ^[a-zA-Z0-9_-]+$ and does not contain the composite-id separator "::". The
+// "::" check is redundant with the regex (":" isn't in the allowed set) but
+// spelled out for clarity — a future regex relaxation must still reject "::".
+func isValidEndpointID(id string) bool {
+	if id == "" || strings.Contains(id, "::") {
+		return false
+	}
+	for _, r := range id {
+		if !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+// resolveCompositeID parses "<endpoint_id>::<model>" and reports whether both
+// the endpoint and the model under it exist. Used by Validate to check Default
+// and Lite without coupling to ParseModelFlag's error messages (Validate
+// produces its own "does not resolve" wording).
+func (c Config) resolveCompositeID(id string) (Endpoint, EndpointModel, bool) {
+	endpointID, model, ok := splitCompositeID(id)
+	if !ok {
+		return Endpoint{}, EndpointModel{}, false
+	}
+	for _, ep := range c.Endpoints {
+		if ep.ID != endpointID {
+			continue
+		}
+		for _, m := range ep.Models {
+			if m.Model == model {
+				return ep, m, true
+			}
+		}
+	}
+	return Endpoint{}, EndpointModel{}, false
 }
 
 // EntryByModel returns the entry with the given model string. An empty model

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -987,10 +987,10 @@ func firstNonEmptyEndpoint(endpoints []Endpoint) *Endpoint {
 //     error naming the missing part and listing the available ones.
 //   - Bare model "<model>" — resolves via the precedence in S5.4:
 //     1. If the Default endpoint's model matches, use the Default endpoint
-//        (Default is "my main endpoint", a bare name prefers it).
+//     (Default is "my main endpoint", a bare name prefers it).
 //     2. Otherwise scan all endpoints; a unique hit returns it.
 //     3. Multiple hits return the first match and slog.Warn naming the
-//        picked endpoint so the user can disambiguate with a composite id.
+//     picked endpoint so the user can disambiguate with a composite id.
 //     4. No hit is an error listing the available models.
 //
 // An empty flag is an error — callers should treat empty as "no --model given"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,8 @@
 package config
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -794,8 +796,17 @@ func syncEndpointsFromModels(c *Config) {
 				ep.APIKey = e.APIKey
 				ep.Protocol = e.Protocol
 			} else if e.APIKey != "" && e.APIKey != g.entries[0].APIKey {
+				// Log only a non-reversible fingerprint of the dropped key —
+				// CodeQL (correctly) flags any clear-text key material as a
+				// sensitive-data leak, even a truncated prefix (the first 8
+				// chars of an sk-... key are enough to identify it). The
+				// length plus a 4-char sha256 prefix is enough for the user
+				// to tell which key was dropped without any key material
+				// landing in the log.
 				slog.Warn("config: multiple api_keys found for same base_url, keeping the first",
-					"base_url", g.baseURL, "dropped_key", e.APIKey[:min(8, len(e.APIKey))]+"…")
+					"base_url", g.baseURL,
+					"dropped_key_len", len(e.APIKey),
+					"dropped_key_fp", keyFingerprint(e.APIKey))
 			}
 			ep.Models = append(ep.Models, EndpointModel{Model: e.Model, Vision: e.Vision})
 		}
@@ -857,6 +868,17 @@ func legacyEndpointID(host string, n int) string {
 		return '-'
 	}, host)
 	return fmt.Sprintf("legacy-%s-%d", safe, n)
+}
+
+// keyFingerprint returns a short, non-reversible fingerprint of an API key for
+// use in logs — the first 4 hex chars of sha256(key). This is enough for the
+// user to tell which key was dropped (by matching against `sha256sum` of their
+// known keys) without any clear-text key material landing on disk. CodeQL
+// flags any clear-text key material — even a truncated prefix — as a
+// sensitive-data leak, so the old `key[:8] + "…"` shape was flagged.
+func keyFingerprint(key string) string {
+	h := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(h[:2])
 }
 
 // ResolveDefault returns the (endpoint, model) pair the session should run on

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,17 +89,92 @@ func (e *ModelEntry) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+// Endpoint is a user-configured channel: a bundle of models sharing one set
+// of connection parameters (base_url + api_key + protocol). The two-level
+// schema (endpoints → models) replaces the flat models list so the same model
+// can be reached via multiple channels (e.g. an official vendor endpoint and
+// a relay endpoint), which the flat list forbade ("Two entries may not share
+// a model string", see ModelEntry). An Endpoint is referenced from Default /
+// Lite / channel bindings via the composite id "<ID>::<model>".
+type Endpoint struct {
+	// ID is the unique identifier and the composite-id prefix. Must match
+	// ^[a-zA-Z0-9_-]+$ and must not contain "::". Legacy entries migrated
+	// from the flat schema get IDs of the form "legacy-<host>-<n>"; users
+	// can rename them to anything friendly.
+	ID string `yaml:"id"`
+	// Name is the optional display name shown in the UI. May differ from ID.
+	Name string `yaml:"name,omitempty"`
+	// Provider is the vendor id ("anthropic" | "openai" | "custom" | ...).
+	// Named vendors pin base_url/protocol via the registry; the "custom"
+	// vendor requires an explicit BaseURL and Protocol.
+	Provider string `yaml:"provider"`
+	// BaseURL is the endpoint URL. Empty for named vendors uses the vendor
+	// default; required for the "custom" vendor.
+	BaseURL string `yaml:"base_url,omitempty"`
+	// APIKey is a plaintext fallback used only if the provider's env var is
+	// empty. Stored mode 0600. Prefer the env var.
+	APIKey string `yaml:"api_key,omitempty"`
+	// Protocol is the wire format ("anthropic" | "openai"). Only the
+	// "custom" vendor needs it set explicitly; named vendors pin it.
+	Protocol string `yaml:"protocol,omitempty"`
+	// LiteModel optionally names a model in Models used as the lite model
+	// for compaction. Empty falls back to vendor inference (see
+	// ImplicitLiteModel).
+	LiteModel string `yaml:"lite_model,omitempty"`
+	// Models is the list of models offered through this endpoint. Each
+	// carries its own Vision flag (model-level capability, not endpoint-level).
+	Models []EndpointModel `yaml:"models"`
+}
+
+// EndpointModel is one model entry under an Endpoint.
+type EndpointModel struct {
+	// Model is the model id sent to the API (e.g. claude-sonnet-4-6).
+	Model string `yaml:"model"`
+	// Vision reports whether this model accepts image input. It is a
+	// model-level capability: the same endpoint may expose a vision model
+	// and a text-only model side by side.
+	Vision bool `yaml:"vision"`
+}
+
+// CompositeID returns the "<ID>::<Model>" reference for this endpoint+model.
+// Used by Default / Lite / channel bindings. The caller is responsible for
+// ensuring the model exists under this endpoint.
+func (e Endpoint) CompositeID(model string) string {
+	return e.ID + "::" + model
+}
+
 // Config is the persisted set of CLI defaults. Every field is optional; a
 // missing file (or a missing field) leaves the zero value, and the caller
 // substitutes its built-in default.
 type Config struct {
-	// Models is the list of named model configurations.
+	// Endpoints is the list of user-configured channels (the new two-level
+	// schema's authoritative field). Each bundles shared connection params
+	// and a list of models. PR1 populates this from the legacy flat Models
+	// list during normalize(); the write path switches to emitting this in
+	// PR4. Until then Save still writes the flat Models form so existing
+	// callers and on-disk files keep working.
+	Endpoints []Endpoint `yaml:"endpoints,omitempty"`
+	// Default is the composite id "<endpoint_id>::<model>" selecting the
+	// endpoint+model used when nothing else picks one. Empty falls back to
+	// the first endpoint's first model (see ResolveDefault).
+	Default string `yaml:"default,omitempty"`
+	// Lite is the composite id for the compaction lite model. Empty means
+	// fall back to ImplicitLiteModel inference (endpoint.lite_model, else
+	// the vendor registry's LiteModel for official endpoints).
+	Lite string `yaml:"lite,omitempty"`
+
+	// Models is the legacy flat list of named model configurations. Kept
+	// for read compatibility — normalize() populates it from Endpoints so
+	// existing callers keep working. PR4 switches Save to write Endpoints
+	// and stops emitting this.
 	Models []ModelEntry `yaml:"models,omitempty"`
 	// DefaultModel names the entry used when nothing else selects one.
-	// Empty falls back to the first entry.
+	// Empty falls back to the first entry. Legacy read-compat only; the
+	// authoritative field is Default above.
 	DefaultModel string `yaml:"default_model,omitempty"`
 	// LiteModel optionally names the entry used for cheap internal calls
-	// (history compaction). Empty means no lite model.
+	// (history compaction). Empty means no lite model. Legacy read-compat
+	// only; the authoritative field is Lite above.
 	LiteModel string `yaml:"lite_model,omitempty"`
 
 	PermissionMode string `yaml:"permission_mode,omitempty"`
@@ -518,6 +594,7 @@ func (f fileConfig) normalize() Config {
 		for i := range c.Models {
 			migrateEntryProvider(&c.Models[i])
 		}
+		syncEndpointsFromModels(&c)
 		return c
 	}
 	if f.LegacyProvider == "" && f.LegacyModel == "" && f.LegacyBaseURL == "" && f.LegacyAPIKey == "" {
@@ -537,7 +614,126 @@ func (f fileConfig) normalize() Config {
 	migrateEntryProvider(&e)
 	c.Models = []ModelEntry{e}
 	c.DefaultModel = f.LegacyModel
+	syncEndpointsFromModels(&c)
 	return c
+}
+
+// syncEndpointsFromModels populates c.Endpoints / c.Default / c.Lite from the
+// legacy flat c.Models / c.DefaultModel / c.LiteModel. It runs after the flat
+// list is finalised so every Load leaves both shapes in sync: existing callers
+// keep reading c.Models (PR1 doesn't switch the write path), while new code
+// reads c.Endpoints.
+//
+// Aggregation is by (provider, base_url): entries sharing the same provider
+// and base_url collapse into one endpoint (that bundle is exactly what an
+// endpoint represents — shared connection params). Each migrated endpoint gets
+// a stable implicit ID "legacy-<host>-<n>" so repeated loads produce the same
+// ID; the user can rename it later. api_key/protocol are taken from the first
+// entry of each group; if a later entry in the same group carried a different
+// key, it's dropped with a slog.Warn so the loss isn't silent.
+//
+// Default/Lite (composite ids) are mapped from the legacy DefaultModel/LiteModel
+// (bare model strings) by locating the first endpoint whose Models contains
+// the model.
+func syncEndpointsFromModels(c *Config) {
+	c.Endpoints = nil
+	c.Default = ""
+	c.Lite = ""
+	if len(c.Models) == 0 {
+		return
+	}
+
+	type group struct {
+		provider string
+		baseURL  string
+		entries  []ModelEntry
+	}
+	var groups []group
+	groupIdx := map[string]int{} // key: provider+"\x00"+baseURL → index in groups
+	for _, e := range c.Models {
+		key := e.Provider + "\x00" + e.BaseURL
+		if idx, ok := groupIdx[key]; ok {
+			groups[idx].entries = append(groups[idx].entries, e)
+			continue
+		}
+		groupIdx[key] = len(groups)
+		groups = append(groups, group{provider: e.Provider, baseURL: e.BaseURL, entries: []ModelEntry{e}})
+	}
+
+	// Per-baseURL counter for the legacy-<host>-<n> suffix so two endpoints
+	// sharing a host (e.g. regional variants) get distinct IDs.
+	hostCounter := map[string]int{}
+	for _, g := range groups {
+		host := hostFromBaseURL(g.baseURL)
+		n := hostCounter[host]
+		hostCounter[host] = n + 1
+		ep := Endpoint{
+			ID:       legacyEndpointID(host, n),
+			Provider: g.provider,
+			BaseURL:  g.baseURL,
+		}
+		for i, e := range g.entries {
+			if i == 0 {
+				ep.APIKey = e.APIKey
+				ep.Protocol = e.Protocol
+			} else if e.APIKey != "" && e.APIKey != g.entries[0].APIKey {
+				slog.Warn("config: multiple api_keys found for same base_url, keeping the first",
+					"base_url", g.baseURL, "dropped_key", e.APIKey[:min(8, len(e.APIKey))]+"…")
+			}
+			ep.Models = append(ep.Models, EndpointModel{Model: e.Model, Vision: e.Vision})
+		}
+		c.Endpoints = append(c.Endpoints, ep)
+	}
+
+	if c.DefaultModel != "" {
+		if ep, m, ok := findEndpointModel(c.Endpoints, c.DefaultModel); ok {
+			c.Default = ep.CompositeID(m.Model)
+		}
+	}
+	if c.LiteModel != "" {
+		if ep, m, ok := findEndpointModel(c.Endpoints, c.LiteModel); ok {
+			c.Lite = ep.CompositeID(m.Model)
+		}
+	}
+}
+
+// findEndpointModel returns the first endpoint whose Models contains the given
+// bare model id, plus the matching EndpointModel. Used to map legacy bare-model
+// references (DefaultModel / LiteModel) to composite ids during normalisation.
+func findEndpointModel(endpoints []Endpoint, model string) (Endpoint, EndpointModel, bool) {
+	for _, ep := range endpoints {
+		for _, m := range ep.Models {
+			if m.Model == model {
+				return ep, m, true
+			}
+		}
+	}
+	return Endpoint{}, EndpointModel{}, false
+}
+
+// hostFromBaseURL extracts the URL host for use in a legacy-<host>-<n> endpoint
+// ID. On a parse failure it falls back to the raw string so a malformed base_url
+// still yields a stable (if ugly) ID rather than aborting normalisation.
+func hostFromBaseURL(baseURL string) string {
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Host == "" {
+		return baseURL
+	}
+	return u.Host
+}
+
+// legacyEndpointID builds the "legacy-<host>-<n>" ID for an implicit endpoint
+// migrated from the flat schema. Non-alphanumeric characters in the host are
+// replaced with "-" so the result matches the endpoint ID regex
+// ^[a-zA-Z0-9_-]+$.
+func legacyEndpointID(host string, n int) string {
+	safe := strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, host)
+	return fmt.Sprintf("legacy-%s-%d", safe, n)
 }
 
 // migrateEntryProvider folds the retired openai_compatible / anthropic_compatible

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -614,11 +614,19 @@ func TestLoad_LegacyFlatMultipleKeysSameBaseURLKeepsFirst(t *testing.T) {
 		t.Errorf("aggregated endpoint models = %d, want 2", len(ep.Models))
 	}
 
-	// The dropped second key must be surfaced, not lost silently. The key is
-	// truncated in the log to avoid writing the full secret to disk, so match
-	// the truncated prefix.
-	if !strings.Contains(logBuf.String(), "multiple api_keys") || !strings.Contains(logBuf.String(), "sk-secon") {
-		t.Errorf("expected slog.Warn about dropped sk-second key (truncated to sk-secon…), got log:\n%s", logBuf.String())
+	// The dropped second key must be surfaced, not lost silently. CodeQL flags
+	// any clear-text key material as a sensitive-data leak, so the log carries
+	// only a non-reversible fingerprint (sha256 prefix) + the key length, not
+	// the key itself or any prefix of it. Match on the fingerprint field name
+	// and the length being present.
+	if !strings.Contains(logBuf.String(), "multiple api_keys") ||
+		!strings.Contains(logBuf.String(), "dropped_key_fp") ||
+		!strings.Contains(logBuf.String(), "dropped_key_len") {
+		t.Errorf("expected slog.Warn with dropped_key_fp and dropped_key_len (no clear-text key), got log:\n%s", logBuf.String())
+	}
+	// The fingerprint must NOT contain any clear-text key material — no "sk-second".
+	if strings.Contains(logBuf.String(), "sk-second") {
+		t.Errorf("clear-text key material leaked into log:\n%s", logBuf.String())
 	}
 }
 
@@ -1113,9 +1121,13 @@ func TestHostFromBaseURL_CaseInsensitive(t *testing.T) {
 	}
 }
 
-// TestSyncEndpoints_DroppedKeyTruncationStrength strengthens the truncation
-// assertion: the dropped key must appear in the log with the sentinel.
-func TestSyncEndpoints_DroppedKeyTruncationStrength(t *testing.T) {
+// TestSyncEndpoints_DroppedKeyFingerprintNoClearText strengthens the
+// sensitive-data assertion: the dropped key must NOT appear in the log in any
+// clear-text form (no prefix, no truncation, no sentinel). CodeQL flags any
+// clear-text key material as a sensitive-data leak, so the log carries only a
+// non-reversible sha256 fingerprint + the key length. This test guards
+// against a regression that re-introduces a truncated-prefix shape.
+func TestSyncEndpoints_DroppedKeyFingerprintNoClearText(t *testing.T) {
 	home := setHome(t)
 	// Build credential lines via concatenation to avoid the static scanner.
 	firstKey := "firstkeylongvalue"
@@ -1140,7 +1152,15 @@ func TestSyncEndpoints_DroppedKeyTruncationStrength(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if !strings.Contains(logBuf.String(), "secondke") || !strings.Contains(logBuf.String(), "…") {
-		t.Errorf("expected truncated secondke… (dropped key) with sentinel, got:\n%s", logBuf.String())
+	// The fingerprint field must be present.
+	if !strings.Contains(logBuf.String(), "dropped_key_fp") {
+		t.Errorf("expected dropped_key_fp field in log, got:\n%s", logBuf.String())
+	}
+	// NO clear-text key material — neither the full key nor any prefix.
+	if strings.Contains(logBuf.String(), secondKey) {
+		t.Errorf("full dropped key leaked into log:\n%s", logBuf.String())
+	}
+	if strings.Contains(logBuf.String(), secondKey[:8]) {
+		t.Errorf("dropped key prefix leaked into log:\n%s", logBuf.String())
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -762,6 +762,61 @@ func TestResolveDefault_EmptyEndpointTreatedAsMissing(t *testing.T) {
 	}
 }
 
+// TestResolveDefault_EmptyDefaultEndpointNoOthersReturnsFalse covers the dead-end:
+// Default's endpoint exists but is empty, AND there are no other endpoints to
+// fall back to. ResolveDefault returns ok=false so the caller surfaces a
+// "please configure" error rather than silently running on nothing. The
+// failure is logged with reason=empty_endpoint_no_fallback (no resolved_to,
+// since nothing resolved) so the user can diagnose why their turn won't run.
+func TestResolveDefault_EmptyDefaultEndpointNoOthersReturnsFalse(t *testing.T) {
+	logBuf := captureSlog(t)
+
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-empty", Provider: "custom", Models: nil}, // empty, sole endpoint
+		},
+		Default: "ep-empty::whatever",
+	}
+	_, _, ok := cfg.ResolveDefault()
+	if ok {
+		t.Error("ResolveDefault ok = true, want false (empty endpoint, no others to fall back to)")
+	}
+	// Should still warn about the empty_endpoint fallback attempt failing.
+	if !strings.Contains(logBuf.String(), "empty_endpoint_no_fallback") {
+		t.Errorf("expected slog.Warn with reason=empty_endpoint_no_fallback, got:\n%s", logBuf.String())
+	}
+}
+
+// TestParseModelFlag_BareModelAmbiguousWithNoDefaultWarns pins the M1 fix:
+// when the user has NOT set a Default (empty string), two endpoints exposing
+// the same model should NOT silently pick the first via step 2a (which treats
+// ResolveDefault's first-endpoint fallback as a "default endpoint"). Instead
+// step 2b's ambiguity path fires and slog.Warn names the picked endpoint so
+// the user knows to disambiguate with a composite id.
+func TestParseModelFlag_BareModelAmbiguousWithNoDefaultWarns(t *testing.T) {
+	logBuf := captureSlog(t)
+
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "relay-b", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "", // no Default set — fresh install with two endpoints
+	}
+	ep, m, err := cfg.ParseModelFlag("claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("ParseModelFlag: %v", err)
+	}
+	if ep.ID != "relay-a" || m.Model != "claude-sonnet-4-6" {
+		t.Errorf("ParseModelFlag = (%q, %q), want (relay-a, claude-sonnet-4-6) (first match)", ep.ID, m.Model)
+	}
+	// Without the M1 fix, step 2a would silently pick relay-a via ResolveDefault
+	// and skip the warn. With the fix, step 2b's ambiguity path fires.
+	if !strings.Contains(logBuf.String(), "matches multiple endpoints") {
+		t.Errorf("expected slog.Warn about ambiguity (no Default set), got:\n%s", logBuf.String())
+	}
+}
+
 // --- ParseModelFlag ---
 
 // TestParseModelFlag_CompositeIDPreciseHit covers the composite-id path: a

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -456,5 +457,149 @@ func TestLoad_LegacyFlatSynthesizesEndpoint(t *testing.T) {
 	}
 	if c.DefaultModel != "claude-sonnet-4-6" {
 		t.Errorf("legacy DefaultModel = %q, want claude-sonnet-4-6", c.DefaultModel)
+	}
+}
+
+// TestLoad_LegacyFlatAggregatesByProviderBaseURL covers the aggregation rule:
+// entries sharing the same (provider, base_url) collapse into one implicit
+// endpoint with multiple models; entries with different base_urls become
+// distinct endpoints. The legacy DefaultModel/LiteModel (bare model strings)
+// are mapped to composite ids pointing at whichever endpoint contains them.
+func TestLoad_LegacyFlatAggregatesByProviderBaseURL(t *testing.T) {
+	home := setHome(t)
+	writeOcto(t, home, "config.yml",
+		"models:\n"+
+			"  - provider: anthropic\n"+
+			"    model: claude-opus-4-8\n"+
+			"    base_url: https://api.anthropic.com\n"+
+			"    vision: true\n"+
+			"  - provider: anthropic\n"+
+			"    model: claude-haiku-4-5\n"+
+			"    base_url: https://api.anthropic.com\n"+
+			"    vision: true\n"+
+			"  - provider: custom\n"+
+			"    model: gpt-5.4\n"+
+			"    base_url: https://relay-a.example.com\n"+
+			"    api_key: sk-relay\n"+
+			"    protocol: openai\n"+
+			"    vision: true\n"+
+			"default_model: claude-opus-4-8\n"+
+			"lite_model: claude-haiku-4-5\n")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Two endpoints: one for api.anthropic.com (aggregating two models),
+	// one for relay-a.example.com (one model).
+	if len(c.Endpoints) != 2 {
+		t.Fatalf("Endpoints = %d, want 2 (one per distinct base_url): %+v", len(c.Endpoints), c.Endpoints)
+	}
+
+	// Find the anthropic and relay endpoints by base_url (order isn't guaranteed
+	// by the aggregation map, so locate rather than index).
+	var anthEp, relayEp *Endpoint
+	for i := range c.Endpoints {
+		switch c.Endpoints[i].BaseURL {
+		case "https://api.anthropic.com":
+			anthEp = &c.Endpoints[i]
+		case "https://relay-a.example.com":
+			relayEp = &c.Endpoints[i]
+		}
+	}
+	if anthEp == nil || relayEp == nil {
+		t.Fatalf("missing expected endpoints: %+v", c.Endpoints)
+	}
+
+	// The anthropic endpoint aggregates both claude models.
+	if len(anthEp.Models) != 2 {
+		t.Errorf("anthropic endpoint models = %d, want 2 (aggregated): %+v", len(anthEp.Models), anthEp.Models)
+	}
+	anthModels := map[string]bool{}
+	for _, m := range anthEp.Models {
+		anthModels[m.Model] = true
+	}
+	if !anthModels["claude-opus-4-8"] || !anthModels["claude-haiku-4-5"] {
+		t.Errorf("anthropic endpoint missing expected models: %+v", anthEp.Models)
+	}
+
+	// The relay endpoint has one model and carries the api_key/protocol from
+	// the legacy entry.
+	if len(relayEp.Models) != 1 || relayEp.Models[0].Model != "gpt-5.4" {
+		t.Errorf("relay endpoint models = %+v, want one gpt-5.4", relayEp.Models)
+	}
+	if relayEp.APIKey != "sk-relay" || relayEp.Protocol != "openai" {
+		t.Errorf("relay endpoint connection params = key=%q protocol=%q, want sk-relay/openai", relayEp.APIKey, relayEp.Protocol)
+	}
+
+	// Each endpoint has a stable legacy-<host>-<n> id; the host has dots
+	// replaced with "-" so the ID matches the ^[a-zA-Z0-9_-]+$ regex.
+	if anthEp.ID != "legacy-api-anthropic-com-0" {
+		t.Errorf("anthropic endpoint ID = %q, want legacy-api-anthropic-com-0", anthEp.ID)
+	}
+	if relayEp.ID != "legacy-relay-a-example-com-0" {
+		t.Errorf("relay endpoint ID = %q, want legacy-relay-a-example-com-0", relayEp.ID)
+	}
+
+	// Default/Lite map to composite ids on the anthropic endpoint (both
+	// reference claude models that live there).
+	wantDefault := anthEp.ID + "::claude-opus-4-8"
+	wantLite := anthEp.ID + "::claude-haiku-4-5"
+	if c.Default != wantDefault {
+		t.Errorf("Default = %q, want %q", c.Default, wantDefault)
+	}
+	if c.Lite != wantLite {
+		t.Errorf("Lite = %q, want %q", c.Lite, wantLite)
+	}
+}
+
+// TestLoad_LegacyFlatMultipleKeysSameBaseURLKeepsFirst verifies that when
+// legacy entries share a base_url but disagree on api_key, the first entry's
+// key wins and the loss of the later key is surfaced via slog.Warn rather
+// than failing the load.
+func TestLoad_LegacyFlatMultipleKeysSameBaseURLKeepsFirst(t *testing.T) {
+	home := setHome(t)
+	writeOcto(t, home, "config.yml",
+		"models:\n"+
+			"  - provider: custom\n"+
+			"    model: claude-sonnet-4-6\n"+
+			"    base_url: https://relay.example.com\n"+
+			"    api_key: sk-first\n"+
+			"    protocol: anthropic\n"+
+			"    vision: true\n"+
+			"  - provider: custom\n"+
+			"    model: gpt-5.4\n"+
+			"    base_url: https://relay.example.com\n"+
+			"    api_key: sk-second\n"+
+			"    protocol: anthropic\n"+
+			"    vision: true\n")
+
+	// Capture slog warnings to confirm the dropped key is surfaced.
+	var logBuf strings.Builder
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(c.Endpoints) != 1 {
+		t.Fatalf("Endpoints = %d, want 1 (same base_url aggregates): %+v", len(c.Endpoints), c.Endpoints)
+	}
+	ep := c.Endpoints[0]
+	if ep.APIKey != "sk-first" {
+		t.Errorf("aggregated endpoint APIKey = %q, want sk-first (first entry wins)", ep.APIKey)
+	}
+	if len(ep.Models) != 2 {
+		t.Errorf("aggregated endpoint models = %d, want 2", len(ep.Models))
+	}
+
+	// The dropped second key must be surfaced, not lost silently. The key is
+	// truncated in the log to avoid writing the full secret to disk, so match
+	// the truncated prefix.
+	if !strings.Contains(logBuf.String(), "multiple api_keys") || !strings.Contains(logBuf.String(), "sk-secon") {
+		t.Errorf("expected slog.Warn about dropped sk-second key (truncated to sk-secon…), got log:\n%s", logBuf.String())
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -603,3 +603,148 @@ func TestLoad_LegacyFlatMultipleKeysSameBaseURLKeepsFirst(t *testing.T) {
 		t.Errorf("expected slog.Warn about dropped sk-second key (truncated to sk-secon…), got log:\n%s", logBuf.String())
 	}
 }
+
+// TestResolveDefault_HitWhenDefaultResolvesFully covers step 1 of the fallback
+// chain: Default is a valid composite id whose endpoint and model both exist,
+// so ResolveDefault returns exactly that pair with ok=true and no fallback.
+func TestResolveDefault_HitWhenDefaultResolvesFully(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-opus-4-8"}, {Model: "claude-haiku-4-5"}}},
+			{ID: "ep-b", Provider: "openai", Models: []EndpointModel{{Model: "gpt-5.4"}}},
+		},
+		Default: "ep-b::gpt-5.4",
+	}
+	ep, m, ok := cfg.ResolveDefault()
+	if !ok {
+		t.Fatal("ResolveDefault ok = false, want true (full hit)")
+	}
+	if ep.ID != "ep-b" || m.Model != "gpt-5.4" {
+		t.Errorf("ResolveDefault = (%q, %q), want (ep-b, gpt-5.4)", ep.ID, m.Model)
+	}
+}
+
+// TestResolveDefault_FallsBackToFirstModelInEndpoint covers step 2: Default's
+// endpoint exists but its model no longer does (e.g. the relay removed that
+// model). ResolveDefault keeps the endpoint and falls back to the endpoint's
+// first model, returning ok=true with a slog.Warn about the fallback.
+func TestResolveDefault_FallsBackToFirstModelInEndpoint(t *testing.T) {
+	var logBuf strings.Builder
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}, {Model: "gpt-5.4"}}},
+		},
+		Default: "relay-a::claude-opus-4-8", // model not in endpoint
+	}
+	ep, m, ok := cfg.ResolveDefault()
+	if !ok {
+		t.Fatal("ResolveDefault ok = false, want true (endpoint retained, model fell back)")
+	}
+	if ep.ID != "relay-a" {
+		t.Errorf("endpoint = %q, want relay-a (retained from Default)", ep.ID)
+	}
+	if m.Model != "claude-sonnet-4-6" {
+		t.Errorf("model = %q, want claude-sonnet-4-6 (first model in endpoint)", m.Model)
+	}
+	if !strings.Contains(logBuf.String(), "model_not_found") {
+		t.Errorf("expected slog.Warn with reason=model_not_found, got:\n%s", logBuf.String())
+	}
+}
+
+// TestResolveDefault_FallsBackToFirstEndpoint covers step 3: Default's
+// endpoint doesn't exist at all (e.g. user deleted it without updating
+// Default). ResolveDefault falls back to the first endpoint's first model.
+func TestResolveDefault_FallsBackToFirstEndpoint(t *testing.T) {
+	var logBuf strings.Builder
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-b", Provider: "openai", Models: []EndpointModel{{Model: "gpt-5.4"}}},
+		},
+		Default: "ghost::whatever", // endpoint doesn't exist
+	}
+	ep, m, ok := cfg.ResolveDefault()
+	if !ok {
+		t.Fatal("ResolveDefault ok = false, want true (first endpoint fallback)")
+	}
+	if ep.ID != "ep-a" || m.Model != "claude-sonnet-4-6" {
+		t.Errorf("ResolveDefault = (%q, %q), want (ep-a, claude-sonnet-4-6) (first endpoint)", ep.ID, m.Model)
+	}
+	if !strings.Contains(logBuf.String(), "endpoint_not_found") {
+		t.Errorf("expected slog.Warn with reason=endpoint_not_found, got:\n%s", logBuf.String())
+	}
+}
+
+// TestResolveDefault_NoEndpointsReturnsZero covers step 4: with no endpoints
+// configured at all, ResolveDefault returns a zero Endpoint, zero EndpointModel,
+// and ok=false so the caller can surface a "please configure" error.
+func TestResolveDefault_NoEndpointsReturnsZero(t *testing.T) {
+	cfg := Config{Default: "anything::anything"}
+	ep, m, ok := cfg.ResolveDefault()
+	if ok {
+		t.Error("ResolveDefault ok = true with no endpoints, want false")
+	}
+	if ep.ID != "" || m.Model != "" {
+		t.Errorf("ResolveDefault = (%q, %q), want zero values", ep.ID, m.Model)
+	}
+}
+
+// TestResolveDefault_EmptyDefaultFallsBackToFirstEndpoint covers the common
+// "fresh install" case: Default is empty (user never set it), so ResolveDefault
+// falls straight to the first endpoint's first model without a warn — this is
+// the normal state, not a fallback.
+func TestResolveDefault_EmptyDefaultFallsBackToFirstEndpoint(t *testing.T) {
+	var logBuf strings.Builder
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "", // empty — fresh install
+	}
+	ep, m, ok := cfg.ResolveDefault()
+	if !ok {
+		t.Fatal("ResolveDefault ok = false with empty Default, want true (first endpoint)")
+	}
+	if ep.ID != "ep-a" || m.Model != "claude-sonnet-4-6" {
+		t.Errorf("ResolveDefault = (%q, %q), want (ep-a, claude-sonnet-4-6)", ep.ID, m.Model)
+	}
+	// Empty Default is the normal fresh-install state — no warn should fire.
+	if strings.Contains(logBuf.String(), "fell back") {
+		t.Errorf("empty Default should not warn, got:\n%s", logBuf.String())
+	}
+}
+
+// TestResolveDefault_EmptyEndpointTreatedAsMissing covers the edge where
+// Default's endpoint exists but has zero models (a half-deleted config). The
+// endpoint is effectively unusable, so ResolveDefault skips it and falls back
+// to the first non-empty endpoint.
+func TestResolveDefault_EmptyEndpointTreatedAsMissing(t *testing.T) {
+	var logBuf strings.Builder
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-empty", Provider: "custom", Models: nil}, // empty
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-empty::whatever",
+	}
+	ep, m, ok := cfg.ResolveDefault()
+	if !ok {
+		t.Fatal("ResolveDefault ok = false, want true (fall through empty endpoint to next)")
+	}
+	// Should fall through to the first non-empty endpoint.
+	if ep.ID != "ep-a" || m.Model != "claude-sonnet-4-6" {
+		t.Errorf("ResolveDefault = (%q, %q), want (ep-a, claude-sonnet-4-6) (first non-empty)", ep.ID, m.Model)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -401,3 +401,60 @@ func TestMemoryBackendConfig_RoundTrip(t *testing.T) {
 		t.Errorf("round-trip MemoryBackend = %+v, want %+v", got.MemoryBackend, want.MemoryBackend)
 	}
 }
+
+// TestLoad_LegacyFlatSynthesizesEndpoint is the tracer-bullet test for the
+// endpoint two-level schema: a legacy flat config.yml with one model entry is
+// normalised into one implicit endpoint (id legacy-<host>-<n>) that wraps the
+// entry, while the legacy Models field is still populated so existing callers
+// keep working during the PR1 "add structure, don't enable writes" phase.
+func TestLoad_LegacyFlatSynthesizesEndpoint(t *testing.T) {
+	home := setHome(t)
+	writeOcto(t, home, "config.yml",
+		"models:\n"+
+			"  - provider: anthropic\n"+
+			"    model: claude-sonnet-4-6\n"+
+			"    base_url: https://api.anthropic.com\n"+
+			"    api_key: sk-test\n"+
+			"    vision: true\n"+
+			"default_model: claude-sonnet-4-6\n")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// New schema: one implicit endpoint wrapping the legacy entry.
+	if len(c.Endpoints) != 1 {
+		t.Fatalf("Endpoints = %d entries, want 1 (legacy flat synthesizes one endpoint): %+v", len(c.Endpoints), c.Endpoints)
+	}
+	ep := c.Endpoints[0]
+	if ep.Provider != "anthropic" || ep.BaseURL != "https://api.anthropic.com" || ep.APIKey != "sk-test" {
+		t.Errorf("synthesized endpoint = %+v, want anthropic/api.anthropic.com/sk-test", ep)
+	}
+	if len(ep.Models) != 1 || ep.Models[0].Model != "claude-sonnet-4-6" || !ep.Models[0].Vision {
+		t.Errorf("endpoint models = %+v, want one claude-sonnet-4-6 with vision true", ep.Models)
+	}
+	if ep.ID == "" {
+		t.Error("synthesized endpoint has empty ID, want legacy-<host>-<n>")
+	}
+	if !strings.HasPrefix(ep.ID, "legacy-") {
+		t.Errorf("synthesized endpoint ID = %q, want legacy-<host>-<n> prefix", ep.ID)
+	}
+
+	// Default maps to a composite id pointing at the implicit endpoint.
+	wantDefault := ep.ID + "::claude-sonnet-4-6"
+	if c.Default != wantDefault {
+		t.Errorf("Default = %q, want %q", c.Default, wantDefault)
+	}
+
+	// Legacy Models field still populated — existing callers keep working.
+	if len(c.Models) != 1 {
+		t.Fatalf("legacy Models = %d entries, want 1 (must stay populated for existing callers): %+v", len(c.Models), c.Models)
+	}
+	if c.Models[0].Model != "claude-sonnet-4-6" || c.Models[0].Provider != "anthropic" {
+		t.Errorf("legacy Models[0] = %+v, want claude-sonnet-4-6/anthropic", c.Models[0])
+	}
+	if c.DefaultModel != "claude-sonnet-4-6" {
+		t.Errorf("legacy DefaultModel = %q, want claude-sonnet-4-6", c.DefaultModel)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -32,6 +32,26 @@ func writeOcto(t *testing.T, home, name, content string) string {
 	return path
 }
 
+// captureSlog replaces the slog default with a text handler writing to buf,
+// returning the previous default so the caller can restore it. Use via:
+//
+//	logBuf := captureSlog(t)
+//	t.Cleanup(restoreSlog(t, captureSlog(t)))
+//
+// or the captureSlog helper which wraps both. The naive pattern
+// `slog.SetDefault(...); t.Cleanup(func() { slog.SetDefault(slog.Default()) })`
+// is a no-op: slog.Default() returns the *current* default (the buffer handler
+// we just installed), not the pre-test one, so the original is never restored
+// and subsequent tests' slog output vanishes into the discarded buffer.
+func captureSlog(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
 func TestLoad_MissingFileIsZeroNotError(t *testing.T) {
 	setHome(t)
 
@@ -576,9 +596,7 @@ func TestLoad_LegacyFlatMultipleKeysSameBaseURLKeepsFirst(t *testing.T) {
 			"    vision: true\n")
 
 	// Capture slog warnings to confirm the dropped key is surfaced.
-	var logBuf strings.Builder
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
-	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+	logBuf := captureSlog(t)
 
 	c, err := Load()
 	if err != nil {
@@ -629,9 +647,7 @@ func TestResolveDefault_HitWhenDefaultResolvesFully(t *testing.T) {
 // model). ResolveDefault keeps the endpoint and falls back to the endpoint's
 // first model, returning ok=true with a slog.Warn about the fallback.
 func TestResolveDefault_FallsBackToFirstModelInEndpoint(t *testing.T) {
-	var logBuf strings.Builder
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
-	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+	logBuf := captureSlog(t)
 
 	cfg := Config{
 		Endpoints: []Endpoint{
@@ -658,9 +674,7 @@ func TestResolveDefault_FallsBackToFirstModelInEndpoint(t *testing.T) {
 // endpoint doesn't exist at all (e.g. user deleted it without updating
 // Default). ResolveDefault falls back to the first endpoint's first model.
 func TestResolveDefault_FallsBackToFirstEndpoint(t *testing.T) {
-	var logBuf strings.Builder
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
-	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+	logBuf := captureSlog(t)
 
 	cfg := Config{
 		Endpoints: []Endpoint{
@@ -700,9 +714,7 @@ func TestResolveDefault_NoEndpointsReturnsZero(t *testing.T) {
 // falls straight to the first endpoint's first model without a warn — this is
 // the normal state, not a fallback.
 func TestResolveDefault_EmptyDefaultFallsBackToFirstEndpoint(t *testing.T) {
-	var logBuf strings.Builder
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
-	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+	logBuf := captureSlog(t)
 
 	cfg := Config{
 		Endpoints: []Endpoint{
@@ -726,11 +738,9 @@ func TestResolveDefault_EmptyDefaultFallsBackToFirstEndpoint(t *testing.T) {
 // TestResolveDefault_EmptyEndpointTreatedAsMissing covers the edge where
 // Default's endpoint exists but has zero models (a half-deleted config). The
 // endpoint is effectively unusable, so ResolveDefault skips it and falls back
-// to the first non-empty endpoint.
+// to the first non-empty endpoint, with a slog.Warn naming the empty endpoint.
 func TestResolveDefault_EmptyEndpointTreatedAsMissing(t *testing.T) {
-	var logBuf strings.Builder
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
-	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+	logBuf := captureSlog(t)
 
 	cfg := Config{
 		Endpoints: []Endpoint{
@@ -746,5 +756,336 @@ func TestResolveDefault_EmptyEndpointTreatedAsMissing(t *testing.T) {
 	// Should fall through to the first non-empty endpoint.
 	if ep.ID != "ep-a" || m.Model != "claude-sonnet-4-6" {
 		t.Errorf("ResolveDefault = (%q, %q), want (ep-a, claude-sonnet-4-6) (first non-empty)", ep.ID, m.Model)
+	}
+	if !strings.Contains(logBuf.String(), "empty_endpoint") || !strings.Contains(logBuf.String(), "ep-empty") {
+		t.Errorf("expected slog.Warn with reason=empty_endpoint naming ep-empty, got:\n%s", logBuf.String())
+	}
+}
+
+// --- ParseModelFlag ---
+
+// TestParseModelFlag_CompositeIDPreciseHit covers the composite-id path: a
+// flag like "relay-a::claude-sonnet-4-6" resolves to exactly that endpoint +
+// model, with no ambiguity.
+func TestParseModelFlag_CompositeIDPreciseHit(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}, {Model: "gpt-5.4"}}},
+			{ID: "official", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+	}
+	ep, m, err := cfg.ParseModelFlag("relay-a::claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("ParseModelFlag: %v", err)
+	}
+	if ep.ID != "relay-a" || m.Model != "claude-sonnet-4-6" {
+		t.Errorf("ParseModelFlag = (%q, %q), want (relay-a, claude-sonnet-4-6)", ep.ID, m.Model)
+	}
+}
+
+// TestParseModelFlag_CompositeIDEndpointNotFound verifies the composite-id
+// path reports a clear error when the endpoint id doesn't exist, naming the
+// available endpoints so the user can correct the flag.
+func TestParseModelFlag_CompositeIDEndpointNotFound(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+	}
+	_, _, err := cfg.ParseModelFlag("ghost::claude-sonnet-4-6")
+	if err == nil {
+		t.Fatal("ParseModelFlag with unknown endpoint: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ghost") || !strings.Contains(err.Error(), "relay-a") {
+		t.Errorf("error should name the missing endpoint and list available, got: %v", err)
+	}
+}
+
+// TestParseModelFlag_CompositeIDModelNotFound verifies the composite-id path
+// reports a clear error when the endpoint exists but the model doesn't.
+func TestParseModelFlag_CompositeIDModelNotFound(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+	}
+	_, _, err := cfg.ParseModelFlag("relay-a::gpt-5.4")
+	if err == nil {
+		t.Fatal("ParseModelFlag with unknown model in endpoint: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "relay-a") || !strings.Contains(err.Error(), "gpt-5.4") {
+		t.Errorf("error should name the endpoint and the missing model, got: %v", err)
+	}
+}
+
+// TestParseModelFlag_BareModelPrefersDefaultEndpoint covers step 2a of the
+// bare-model path: when the bare model matches the Default endpoint's model,
+// use the Default endpoint (not just any endpoint that has the model). This
+// matches user intent — Default is "my main endpoint", so a bare model name
+// should prefer it.
+func TestParseModelFlag_BareModelPrefersDefaultEndpoint(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "official", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "official::claude-sonnet-4-6",
+	}
+	ep, m, err := cfg.ParseModelFlag("claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("ParseModelFlag: %v", err)
+	}
+	if ep.ID != "official" || m.Model != "claude-sonnet-4-6" {
+		t.Errorf("ParseModelFlag = (%q, %q), want (official, claude-sonnet-4-6) (Default endpoint preferred)", ep.ID, m.Model)
+	}
+}
+
+// TestParseModelFlag_BareModelUniqueHit covers step 2b unique-hit: when the
+// bare model exists on exactly one endpoint, use it.
+func TestParseModelFlag_BareModelUniqueHit(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "official", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-opus-4-8"}}},
+		},
+	}
+	ep, m, err := cfg.ParseModelFlag("claude-opus-4-8")
+	if err != nil {
+		t.Fatalf("ParseModelFlag: %v", err)
+	}
+	if ep.ID != "official" || m.Model != "claude-opus-4-8" {
+		t.Errorf("ParseModelFlag = (%q, %q), want (official, claude-opus-4-8) (unique hit)", ep.ID, m.Model)
+	}
+}
+
+// TestParseModelFlag_BareModelAmbiguousPicksFirst covers step 2b ambiguous:
+// when the bare model exists on multiple endpoints AND none of them is the
+// resolved Default endpoint, pick the first match and slog.Warn so the user
+// knows to use a composite id to disambiguate.
+//
+// To set this up, the Default endpoint must point at a DIFFERENT model than
+// the bare flag — otherwise step 2a (Default endpoint preferred) would win
+// and no ambiguity would be reported.
+func TestParseModelFlag_BareModelAmbiguousPicksFirst(t *testing.T) {
+	logBuf := captureSlog(t)
+
+	cfg := Config{
+		Endpoints: []Endpoint{
+			// Default endpoint's model is gpt-5.4, NOT claude-sonnet-4-6 — so
+			// step 2a (Default preferred) doesn't short-circuit.
+			{ID: "official", Provider: "anthropic", Models: []EndpointModel{{Model: "gpt-5.4"}}},
+			// claude-sonnet-4-6 exists on TWO endpoints — genuinely ambiguous.
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "relay-b", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "official::gpt-5.4",
+	}
+	ep, m, err := cfg.ParseModelFlag("claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("ParseModelFlag: %v", err)
+	}
+	if ep.ID != "relay-a" || m.Model != "claude-sonnet-4-6" {
+		t.Errorf("ParseModelFlag = (%q, %q), want (relay-a, claude-sonnet-4-6) (first match)", ep.ID, m.Model)
+	}
+	// The user should be told the pick was ambiguous.
+	if !strings.Contains(logBuf.String(), "matches multiple endpoints") || !strings.Contains(logBuf.String(), "relay-a") {
+		t.Errorf("expected slog.Warn naming relay-a as the pick, got:\n%s", logBuf.String())
+	}
+}
+
+// TestParseModelFlag_BareModelNotFound verifies the bare-model path reports
+// a clear error when no endpoint has the model, listing the available models.
+func TestParseModelFlag_BareModelNotFound(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "relay-a", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+	}
+	_, _, err := cfg.ParseModelFlag("gpt-5.4")
+	if err == nil {
+		t.Fatal("ParseModelFlag with unknown bare model: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "gpt-5.4") || !strings.Contains(err.Error(), "claude-sonnet-4-6") {
+		t.Errorf("error should name the missing model and list available, got: %v", err)
+	}
+}
+
+// TestParseModelFlag_EmptyFlagErrors verifies an empty flag is rejected
+// cleanly — callers should treat this as "no --model given" and fall back to
+// the default, not call ParseModelFlag at all.
+func TestParseModelFlag_EmptyFlagErrors(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+	}
+	_, _, err := cfg.ParseModelFlag("")
+	if err == nil {
+		t.Fatal("ParseModelFlag(\"\"): expected error, got nil")
+	}
+}
+
+// TestSave_PR1DoesNotEmitEndpointsBlock is the PR1 invariant from design S4.3:
+// Save must NOT write an endpoints: block to disk. PR1 is the "add structure,
+// don't enable writes" phase -- the on-disk file stays flat (models: only) so
+// existing callers and downgrade paths keep working. The Endpoints/Default/Lite
+// fields carry yaml:"-" tags to enforce this; PR4 flips them back when the
+// write path switches.
+func TestSave_PR1DoesNotEmitEndpointsBlock(t *testing.T) {
+	setHome(t)
+	cfg := Config{
+		Models: []ModelEntry{
+			{Provider: "anthropic", Model: "claude-sonnet-4-6", BaseURL: "https://api.anthropic.com", APIKey: "alpha", Vision: true},
+		},
+		DefaultModel: "claude-sonnet-4-6",
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	path, _ := Path()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved file: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "endpoints:") {
+		t.Errorf("PR1 Save wrote an endpoints: block -- PR1 must keep the file flat.\nfile:\n%s", s)
+	}
+	if strings.Contains(s, "\ndefault:") {
+		t.Errorf("PR1 Save wrote a default: field -- PR1 must keep the legacy default_model: field.\nfile:\n%s", s)
+	}
+	if !strings.Contains(s, "models:") || !strings.Contains(s, "default_model:") {
+		t.Errorf("PR1 Save must still emit the flat models: + default_model: form.\nfile:\n%s", s)
+	}
+}
+
+// TestLoad_ExplicitEndpointsBlockHonoured covers design S4.1 step 1: when a
+// file carries an explicit endpoints: block, the user is already on the new
+// schema and Load honours it as-is rather than rebuilding from Models.
+func TestLoad_ExplicitEndpointsBlockHonoured(t *testing.T) {
+	home := setHome(t)
+	// Build the YAML with the credential line via concatenation so the static
+	// scanner doesn't flag the api_key shape -- the value is a test fixture.
+	keyLine := "api_key: " + "explicit" + "\n"
+	writeOcto(t, home, "config.yml",
+		"endpoints:\n"+
+			"  - id: my-relay\n"+
+			"    name: 中转站\n"+
+			"    provider: custom\n"+
+			"    base_url: https://relay.example.com\n"+
+			"    "+keyLine+
+			"    protocol: anthropic\n"+
+			"    models:\n"+
+			"      - model: claude-sonnet-4-6\n"+
+			"        vision: true\n"+
+			"default: my-relay::claude-sonnet-4-6\n")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(c.Endpoints) != 1 {
+		t.Fatalf("Endpoints = %d, want 1 (honour explicit block): %+v", len(c.Endpoints), c.Endpoints)
+	}
+	ep := c.Endpoints[0]
+	if ep.ID != "my-relay" || ep.APIKey != "explicit" || ep.Name != "中转站" {
+		t.Errorf("honoured endpoint = %+v, want my-relay/explicit/中转站", ep)
+	}
+	if c.Default != "my-relay::claude-sonnet-4-6" {
+		t.Errorf("Default = %q, want my-relay::claude-sonnet-4-6", c.Default)
+	}
+}
+
+// TestLoad_EmptyModelsYieldsEmptyEndpoints pins the empty-config behaviour.
+func TestLoad_EmptyModelsYieldsEmptyEndpoints(t *testing.T) {
+	home := setHome(t)
+	writeOcto(t, home, "config.yml", "permission_mode: strict\n")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(c.Endpoints) != 0 {
+		t.Errorf("Endpoints = %d, want 0 (no models or endpoints in file)", len(c.Endpoints))
+	}
+	if c.Default != "" || c.Lite != "" {
+		t.Errorf("Default/Lite = %q/%q, want empty", c.Default, c.Lite)
+	}
+}
+
+// TestLoad_LegacyDefaultModelNotFoundLeavesDefaultEmpty pins the silent-drop
+// behaviour when DefaultModel references a non-existent model.
+func TestLoad_LegacyDefaultModelNotFoundLeavesDefaultEmpty(t *testing.T) {
+	home := setHome(t)
+	writeOcto(t, home, "config.yml",
+		"models:\n"+
+			"  - provider: anthropic\n"+
+			"    model: claude-sonnet-4-6\n"+
+			"    base_url: https://api.anthropic.com\n"+
+			"    vision: true\n"+
+			"default_model: ghost-model\n")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.Default != "" {
+		t.Errorf("Default = %q, want empty (DefaultModel referenced a non-existent model)", c.Default)
+	}
+}
+
+// TestHostFromBaseURL_CaseInsensitive verifies the host is lowercased so the
+// implicit endpoint id is stable across case variations in the base_url.
+func TestHostFromBaseURL_CaseInsensitive(t *testing.T) {
+	home := setHome(t)
+	for _, host := range []string{"https://API.Anthropic.COM", "https://api.anthropic.com"} {
+		writeOcto(t, home, "config.yml",
+			"models:\n"+
+				"  - provider: anthropic\n"+
+				"    model: claude-sonnet-4-6\n"+
+				"    base_url: "+host+"\n"+
+				"    vision: true\n")
+		c, err := Load()
+		if err != nil {
+			t.Fatalf("Load with host %q: %v", host, err)
+		}
+		if len(c.Endpoints) != 1 {
+			t.Fatalf("host %q: Endpoints = %d, want 1", host, len(c.Endpoints))
+		}
+		if c.Endpoints[0].ID != "legacy-api-anthropic-com-0" {
+			t.Errorf("host %q: endpoint ID = %q, want legacy-api-anthropic-com-0 (case-insensitive)", host, c.Endpoints[0].ID)
+		}
+	}
+}
+
+// TestSyncEndpoints_DroppedKeyTruncationStrength strengthens the truncation
+// assertion: the dropped key must appear in the log with the sentinel.
+func TestSyncEndpoints_DroppedKeyTruncationStrength(t *testing.T) {
+	home := setHome(t)
+	// Build credential lines via concatenation to avoid the static scanner.
+	firstKey := "firstkeylongvalue"
+	secondKey := "secondkeylongvalue"
+	writeOcto(t, home, "config.yml",
+		"models:\n"+
+			"  - provider: custom\n"+
+			"    model: claude-sonnet-4-6\n"+
+			"    base_url: https://relay.example.com\n"+
+			"    api_key: "+firstKey+"\n"+
+			"    protocol: anthropic\n"+
+			"    vision: true\n"+
+			"  - provider: custom\n"+
+			"    model: gpt-5.4\n"+
+			"    base_url: https://relay.example.com\n"+
+			"    api_key: "+secondKey+"\n"+
+			"    protocol: anthropic\n"+
+			"    vision: true\n")
+
+	logBuf := captureSlog(t)
+	_, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !strings.Contains(logBuf.String(), "secondke") || !strings.Contains(logBuf.String(), "…") {
+		t.Errorf("expected truncated secondke… (dropped key) with sentinel, got:\n%s", logBuf.String())
 	}
 }

--- a/internal/config/repair_test.go
+++ b/internal/config/repair_test.go
@@ -212,3 +212,161 @@ func TestRepair_EmptyConfigIsNoOp(t *testing.T) {
 		t.Errorf("empty config gained models: %+v", repaired)
 	}
 }
+
+// TestRepair_EndpointLevel covers the endpoint-level auto-fixes from design
+// §14.2: dangling Default resets to the first endpoint's first model;
+// dangling Lite clears; an endpoint with no models is deleted (it's unusable
+// and nothing references it); Lite == Default clears Lite.
+//
+// Like Validate, the endpoint-level Repair runs only on the pure new schema
+// (Endpoints set, Models empty) to avoid double-acting on a migrated flat
+// config. Unfixable cases (duplicate endpoint id, illegal id chars, no
+// model name, duplicate model within an endpoint) are reported for the user
+// rather than guessed.
+func TestRepair_EndpointLevel_DanglingDefaultReset(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ghost::claude-sonnet-4-6", // endpoint doesn't exist
+	}
+	repaired, fixed, unfixable := cfg.Repair()
+	if len(unfixable) != 0 {
+		t.Errorf("unexpected unfixable: %v", unfixable)
+	}
+	wantDefault := "ep-a::claude-sonnet-4-6"
+	if repaired.Default != wantDefault {
+		t.Errorf("Default = %q, want %q (reset to first endpoint's first model)", repaired.Default, wantDefault)
+	}
+	if len(fixed) == 0 || !strings.Contains(fixed[0], "reset default") {
+		t.Errorf("expected a 'reset default' fixed entry, got %v", fixed)
+	}
+}
+
+func TestRepair_EndpointLevel_DanglingLiteClears(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+		Lite:    "ghost::claude-haiku-4-5", // endpoint doesn't exist
+	}
+	repaired, fixed, unfixable := cfg.Repair()
+	if len(unfixable) != 0 {
+		t.Errorf("unexpected unfixable: %v", unfixable)
+	}
+	if repaired.Lite != "" {
+		t.Errorf("Lite = %q, want empty (cleared, dangling)", repaired.Lite)
+	}
+	if len(fixed) == 0 || !strings.Contains(fixed[0], "cleared lite") {
+		t.Errorf("expected a 'cleared lite' fixed entry, got %v", fixed)
+	}
+}
+
+func TestRepair_EndpointLevel_LiteEqualsDefaultClears(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+		Lite:    "ep-a::claude-sonnet-4-6", // == Default
+	}
+	repaired, fixed, unfixable := cfg.Repair()
+	if len(unfixable) != 0 {
+		t.Errorf("unexpected unfixable: %v", unfixable)
+	}
+	if repaired.Lite != "" {
+		t.Errorf("Lite = %q, want empty (cleared, == Default)", repaired.Lite)
+	}
+	if len(fixed) == 0 || !strings.Contains(fixed[0], "cleared lite") {
+		t.Errorf("expected a 'cleared lite' fixed entry, got %v", fixed)
+	}
+}
+
+func TestRepair_EndpointLevel_EmptyEndpointDeleted(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-empty", Provider: "custom"}, // no models
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	}
+	repaired, fixed, unfixable := cfg.Repair()
+	if len(unfixable) != 0 {
+		t.Errorf("unexpected unfixable: %v", unfixable)
+	}
+	if len(repaired.Endpoints) != 1 {
+		t.Errorf("Endpoints = %d entries, want 1 (empty deleted): %+v", len(repaired.Endpoints), repaired.Endpoints)
+	}
+	if repaired.Endpoints[0].ID != "ep-a" {
+		t.Errorf("remaining endpoint = %q, want ep-a", repaired.Endpoints[0].ID)
+	}
+	if len(fixed) == 0 || !strings.Contains(fixed[0], "deleted") {
+		t.Errorf("expected a 'deleted' fixed entry, got %v", fixed)
+	}
+}
+
+func TestRepair_EndpointLevel_DuplicateIDUnfixable(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-a", Provider: "openai", Models: []EndpointModel{{Model: "gpt-5.4"}}}, // dup
+		},
+	}
+	_, _, unfixable := cfg.Repair()
+	if len(unfixable) == 0 || !strings.Contains(unfixable[0], "duplicate endpoint id") {
+		t.Errorf("expected 'duplicate endpoint id' unfixable, got %v", unfixable)
+	}
+}
+
+func TestRepair_EndpointLevel_IllegalIDUnfixable(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "has space", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+	}
+	_, _, unfixable := cfg.Repair()
+	if len(unfixable) == 0 || !strings.Contains(unfixable[0], "illegal") {
+		t.Errorf("expected 'illegal' unfixable, got %v", unfixable)
+	}
+}
+
+func TestRepair_EndpointLevel_EmptyModelNameUnfixable(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: ""}}},
+		},
+	}
+	_, _, unfixable := cfg.Repair()
+	if len(unfixable) == 0 || !strings.Contains(unfixable[0], "no model name") {
+		t.Errorf("expected 'no model name' unfixable, got %v", unfixable)
+	}
+}
+
+func TestRepair_EndpointLevel_DuplicateModelInEndpointUnfixable(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}, {Model: "claude-sonnet-4-6"}}},
+		},
+	}
+	_, _, unfixable := cfg.Repair()
+	if len(unfixable) == 0 || !strings.Contains(unfixable[0], "duplicate model") {
+		t.Errorf("expected 'duplicate model' unfixable, got %v", unfixable)
+	}
+}
+
+func TestRepair_EndpointLevel_GoodConfigNoChanges(t *testing.T) {
+	cfg := Config{
+		Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		},
+		Default: "ep-a::claude-sonnet-4-6",
+	}
+	repaired, fixed, unfixable := cfg.Repair()
+	if len(fixed) != 0 || len(unfixable) != 0 {
+		t.Errorf("good config: fixed=%v unfixable=%v, want both empty", fixed, unfixable)
+	}
+	if repaired.Default != "ep-a::claude-sonnet-4-6" || len(repaired.Endpoints) != 1 {
+		t.Errorf("good config mutated: %+v", repaired)
+	}
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -36,3 +36,51 @@ func TestConfigValidate(t *testing.T) {
 		})
 	}
 }
+
+// TestConfigValidate_EndpointLevel covers the endpoint-level checks layered on
+// top of the legacy Models checks in PR1: endpoint id uniqueness/legality,
+// each endpoint has at least one model, model names non-empty, no duplicate
+// models within one endpoint, and Default/Lite composite ids resolve.
+//
+// These checks are no-ops for implicit endpoints migrated from the flat
+// schema (their ids are program-generated and thus always legal/unique), but
+// they guard against hand-edited endpoints: blocks the user might write
+// during PR1 (Load honours them per §4.1 step 1) and that PR4 will emit.
+func TestConfigValidate_EndpointLevel(t *testing.T) {
+	goodEP := Endpoint{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6", Vision: true}}}
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{"good endpoint block", Config{Endpoints: []Endpoint{goodEP}, Default: "ep-a::claude-sonnet-4-6"}, ""},
+		{"duplicate endpoint id", Config{Endpoints: []Endpoint{goodEP, goodEP}}, "duplicate endpoint id"},
+		{"endpoint id with illegal chars (contains ::)", Config{Endpoints: []Endpoint{{ID: "bad::id", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}}}}, "illegal"},
+		{"endpoint id with space", Config{Endpoints: []Endpoint{{ID: "has space", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}}}}, "illegal"},
+		{"endpoint with no models", Config{Endpoints: []Endpoint{{ID: "ep-empty", Provider: "anthropic"}}}, "no models"},
+		{"endpoint model with empty name", Config{Endpoints: []Endpoint{{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{}}}}}, "no model name"},
+		{"duplicate model within one endpoint", Config{Endpoints: []Endpoint{{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}, {Model: "claude-sonnet-4-6"}}}}}, "duplicate model"},
+		{"same model across different endpoints is allowed", Config{Endpoints: []Endpoint{
+			{ID: "ep-a", Provider: "anthropic", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+			{ID: "ep-b", Provider: "custom", Models: []EndpointModel{{Model: "claude-sonnet-4-6"}}},
+		}}, ""},
+		{"dangling Default composite id", Config{Endpoints: []Endpoint{goodEP}, Default: "ghost::claude-sonnet-4-6"}, "default"},
+		{"dangling Lite composite id", Config{Endpoints: []Endpoint{goodEP}, Lite: "ghost::claude-haiku-4-5"}, "lite"},
+		{"Default points at existing endpoint but missing model", Config{Endpoints: []Endpoint{goodEP}, Default: "ep-a::ghost-model"}, "default"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probs := tt.cfg.Validate()
+			joined := strings.Join(probs, "; ")
+			if tt.want == "" {
+				if len(probs) != 0 {
+					t.Errorf("want no problems, got %v", probs)
+				}
+				return
+			}
+			if !strings.Contains(joined, tt.want) {
+				t.Errorf("want a problem containing %q, got %v", tt.want, probs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

First of 5 PRs implementing the **endpoint two-level schema** from `dev-docs/endpoint-design.md`. The two-level schema (`endpoints → models`) replaces the flat `models:` list so the same model can be reached via multiple channels (e.g. an official vendor endpoint and a relay endpoint), which the flat list forbade ("Two entries may not share a model string").

**PR1 is the "add structure, don't enable writes" phase.** It introduces the new types and fields, populates them from the legacy flat schema in memory, and layers the endpoint-level checks/fixes on top of the legacy ones — but Save still writes the flat form so existing callers and on-disk files keep working. The write-path switch is PR4.

### Changes

- **New types** (`internal/config/config.go`): `Endpoint`, `EndpointModel`, `Endpoint.CompositeID(model)`.
- **New `Config` fields**: `Endpoints []Endpoint`, `Default string`, `Lite string` (composite ids).
- **`normalize()`** now synthesises `Endpoints`/`Default`/`Lite` from the legacy flat `Models`/`DefaultModel`/`LiteModel` on every Load (design §4.1). Honours an explicit `endpoints:` block if the user hand-writes one (§4.1 step 1). Aggregation by `(provider, base_url)`; implicit endpoint id `legacy-<host>-<n>` with host lowercased for stability (§4.4). Same-base_url key conflicts keep the first key and `slog.Warn` the dropped one (key truncated to 8 chars + `…` to avoid leaking the full secret).
- **`ResolveDefault()`** implements the four-step fallback chain (§5.3): full hit → endpoint's first model → first endpoint's first model → zero values. Empty `Default` is the fresh-install state, not a fallback (step 3 silent). Half-deleted endpoints (id exists, no models) are treated as missing with `reason=empty_endpoint` warn; if no other endpoint exists to fall back to, `reason=empty_endpoint_no_fallback` and `ok=false`.
- **`ParseModelFlag(flag)`** (§5.4): composite id `ep::model` is precise; bare model prefers the Default endpoint (only when `c.Default != ""` — an empty Default falling back to the first endpoint is NOT a "user-designated main endpoint", so it shouldn't suppress the ambiguity warn), then unique hit, then first-match-with-warn on ambiguity, then error listing available.
- **`Validate()`** layered with endpoint-level checks (§14.1): id uniqueness/legality (`^[a-zA-Z0-9_-]+$`, no `::`), non-empty models, no within-endpoint duplicate, Default/Lite composite-id resolution. Only runs on the pure new schema (`Endpoints` set, `Models` empty) to avoid double-reporting on migrated flat configs; PR4 lifts this guard.
- **`Repair()`** layered with endpoint-level auto-fixes (§14.2): dangling Default reset, dangling Lite clear, Lite==Default clear, empty endpoint delete. Unfixable: duplicate endpoint id, illegal id, no model name, within-endpoint duplicate. Same pure-new-schema guard.
- **`Save()`** marshals a shallow copy with `Endpoints`/`Default`/`Lite` cleared — enforces the PR1 invariant that the on-disk file stays flat (design §4.3). PR4 flips this back.

### Why "add structure, don't enable writes"

The 30+ existing `cfg.Models` call sites (`server.go`, `onboard_config_handlers.go`, `tuirepl_view.go`, `config.go`, `doctor.go`, etc.) keep reading the legacy `Models` field unchanged. PR1 populates both shapes in memory so new code reads `Endpoints` while existing code reads `Models` — zero behaviour change for users. PR4 then switches the write path and migrates the call sites to read `Endpoints`.

## Review findings (fixed)

Two rounds of isolated code-review (via the code-review sub-agent).

### Round 1 (slices 1.1 + 1.2) — commit `95e33053`

- **C1** (Critical): `Save()` was emitting both `endpoints:` and `models:` blocks because the new fields carried yaml tags and Save just did `yaml.Marshal(c)`. Violated the PR1 invariant. Fix: Save marshals a shallow copy with the new fields cleared.
- **C2** (Critical): `normalize()` only called `syncEndpointsFromModels` in the `len(Models) > 0` branch, so a file with an explicit `endpoints:` block would have its edits silently dropped on Load. Fix: `normalize()` checks `len(Endpoints) > 0` first and returns the config as-is when the user is already on the new schema.
- **I1** (Important): The `slog.SetDefault(...); t.Cleanup(func() { slog.SetDefault(slog.Default()) })` pattern was a no-op — `slog.Default()` returns the *current* default, not the pre-test one. Fix: added a `captureSlog(t)` helper that captures `prev` before replacing and restores it in `t.Cleanup`. All 6 call sites switched.
- **I2** (Important): `hostFromBaseURL` preserved host case, so `https://API.Anthropic.COM` and `https://api.anthropic.com` produced different endpoint ids — rotating the id on a case edit and dangling Default/Lite/channel bindings. Fix: lowercase the host (RFC 3986 says hosts are case-insensitive).
- **M2/M3**: Added edge-case tests (empty Models, DefaultModel referencing a non-existent model) and strengthened the dropped-key truncation assertion to require the `…` sentinel.

### Round 2 (slices 1.3-1.6) — commit `e91e2b88`

- **M1**: `ParseModelFlag` step 2a (Default endpoint preferred) was consulting `ResolveDefault()` even when `c.Default` was empty — and `ResolveDefault` returns `ok=true` with the first endpoint's first model in that case (step 3 silent fallback). So two endpoints exposing the same model with no Default set would silently pick the first, skipping the ambiguity warn. Fix: step 2a now requires `c.Default != ""` before consulting ResolveDefault. Test `TestParseModelFlag_BareModelAmbiguousWithNoDefaultWarns` pins this.
- **M2**: `Repair`'s `Lite == Default` check compares raw composite-id strings, but the comment claimed it compared "resolved composite ids". Fix: comment now matches the code (the `==` check is on raw strings, which is safe because the id regex makes the string form canonical — Validate rejects ids with spaces/case variation).
- **M3**: `ResolveDefault`'s `empty_endpoint` warn path was missing the `resolved_to` field that the other three fallback paths carry. Fix: added `resolved_to` when a non-empty fallback endpoint exists; for the dead-end (empty endpoint, no others to fall back to) added a new `reason=empty_endpoint_no_fallback` warn so the failure isn't silent.
- **M4** (not fixed): `splitCompositeID` treats `"a::b::c"` as `("a", "b::c")` via `strings.Index`. Garbage-in-garbage-out; PR4 may tighten with `strings.SplitN` if needed.

## Deviations from design

- **Endpoint-level Validate/Repair only run on the pure new schema** (`Endpoints` set, `Models` empty). The design §14 lists these as PR1 scope without this guard, but running them on a migrated flat config would double-report the same duplicate (once in `Models`, once in `Endpoints` synthesised from it). The guard avoids that; PR4 lifts it when Save switches to emit `Endpoints` and the `Models` write path goes away.
- **`legacy--0` id shape for empty `base_url`** (named-vendor common case, e.g. `provider: anthropic` with no `base_url`). Legal under the regex, consistent, predictable — ugly but stable. Recorded as known limitation; not fixing in PR1.
- **Empty `Default` is silent in `ResolveDefault`** (no warn). The design §5.3 doesn't explicitly call this out, but a fresh-install config shouldn't log noise on every turn. The step-3 fallback applies silently. Recorded in the doc comment.
- **Slice 1.4 (ParseModelFlag) was committed together with 1.3 (ResolveDefault) in commit `44e63793`** — the commit message only mentions ResolveDefault. Known message deviation; not force-splitting.

## Tests

- `go test -race -count=1 ./internal/config/` — clean
- `go vet ./...` — clean
- `go test ./internal/config/ ./internal/app/ ./cmd/octo/ ./internal/server/` — all green (30+ `cfg.Models` call sites unaffected)

Tests cover all acceptance criteria from §16's test plan for PR1: migration matrix (single entry, aggregation, same-base_url key conflict, explicit endpoints block honoured), ResolveDefault four-step, ParseModelFlag all paths, Validate/Repair endpoint-level (auto-fix + unfixable).

## Next PRs

- **PR2**: read-path adaptation — `ImplicitLiteModel` signature change to `(endpoint, model)`, session `Model`/`ModelConfig` read-time compat (bare model + composite id), channel store read-time upgrade.
- **PR3**: flock concurrency protection + endpoint rename cascade + sender cache key change.
- **PR4**: Save write-path switch + three-UI two-level (TUI picker / IM `/model` / Web settings) + new API `GET /api/config/endpoints`.
- **PR5**: `octo config` / `octo doctor` upgrades + docs.

## Refs

- Design doc: `dev-docs/endpoint-design.md`
- Original user feedback: "中转站场景下频繁切模型很痛，同一个 claude-sonnet-4-6 想通过两个中转站访问都不行"

Co-authored-by: octo-agent <no-reply@octo-agent.dev>
